### PR TITLE
feat(curriculum,#8607): paired cross-rung comparison — 3 paradigms indistinguishable (Kronos↔M15 n=45 p=0.91)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/paired_rung_comparison.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/paired_rung_comparison.py
@@ -1,0 +1,339 @@
+"""Paired cross-rung comparison on per-seed edges (#8607, parent #1409).
+
+Purpose
+-------
+``seed_significance.py`` (c.902, PR #8626) answers, per rung: "is this model
+significantly below majority?" (one-sample t-test on the per-seed edge
+``edge_s = DirAcc_s - majority``, n=5 seeds). The 3 foundation rungs are all
+NO BEATS (Chronos degenerate, Kronos 6/9 SIG-negative, M15 9/9 SIG-negative).
+
+This module answers the **next** question: **are two rungs significantly
+different FROM EACH OTHER?** A zero-shot model (Kronos, AR sampling) and a
+fine-tuned model (M15 LSTM) both fail to beat majority -- but does fine-tuning
+change the directional edge relative to zero-shot, or do they land on the same
+edge? This is a **paired** comparison on the aligned ``(symbol, horizon, seed)``
+edges: for each of the 45 aligned observations (3 ETF x 3 horizons x 5 seeds)
+we have ``edge_kronos`` and ``edge_m15``, and we test the per-pair difference
+``d = edge_B - edge_A`` against 0 (paired t-test + Wilcoxon + sign + CI95%).
+
+This is NOT the full Diebold-Mariano test. DM is paired **by observation**
+(per-window / per-step forecast errors with a HAC variance correction) and
+requires the per-window DirAcc series, which is NOT committed (Kronos only
+dumps the fold-aggregated ``avg_direction_accuracy`` per seed). The true DM
+therefore remains a multi-cycle residual (re-run dumping per-window DirAcc).
+This paired-by-(config, seed) test is the strongest cross-rung comparison
+available from the committed per-seed edges -- no re-run needed.
+
+Honest scope
+------------
+- **Kronos <-> M15**: clean 45-pair alignment (both SPY/TLT/GLD x h={24,66,132}
+  x seeds {0,1,7,42,99}). This is the primary result.
+- **Chronos**: deterministic (std_edge=0, 1 edge per config, 7 configs) so it
+  has no per-seed variance -> paired comparison vs Chronos is done against the
+  Kronos/M15 **per-seed** edges with Chronos as a constant, reported separately
+  and interpreted cautiously (C893-L: deterministic rung).
+
+Usage
+-----
+    python paired_rung_comparison.py <rungA.json> <rungB.json> [--alpha 0.05]
+
+Outputs ``paired_comparison.json`` + ``paired_comparison.md`` next to rungB's
+results (convention: the comparison artefacts live under the rung being
+compared-against). With ``--out`` the artefacts go to an explicit folder.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from scipy import stats
+
+ALPHA = 0.05  # two-sided significance level
+
+
+# ---------------------------------------------------------------------------
+# Per-seed extraction (preserves seed identity, unlike seed_significance.auto_extract)
+# ---------------------------------------------------------------------------
+
+def _kronos_per_seed(sweep: list) -> dict[tuple, float]:
+    """Kronos: sweep[i].seed_results[j] -> {(symbol, pred_len, seed): edge}."""
+    out: dict[tuple, float] = {}
+    for cfg in sweep:
+        sym = cfg.get("symbol")
+        h = cfg.get("pred_len")
+        cfg_maj = cfg.get("majority_baseline", {}).get("majority_class_accuracy")
+        for s in cfg.get("seed_results", []):
+            seed = s.get("seed")
+            edge = s.get("edge_vs_majority")
+            if edge is None:
+                # Fallback: DirAcc - majority (some schemas omit edge_vs_majority).
+                da = s.get("avg_direction_accuracy")
+                maj = s.get("majority_baseline")
+                if maj is None:
+                    maj = cfg_maj  # fall back to config-level majority
+                if da is not None and maj is not None:
+                    edge = float(da) - float(maj)
+            if seed is not None and edge is not None:
+                out[(sym, h, int(seed))] = float(edge)
+    return out
+
+
+def _m15_per_seed(combos: list) -> dict[tuple, float]:
+    """M15: combos[i] -> {(symbol, horizon, seed): edge}."""
+    out: dict[tuple, float] = {}
+    for c in combos:
+        sym = c.get("symbol")
+        h = c.get("horizon")
+        seed = c.get("seed")
+        edge = c.get("edge_vs_majority")
+        if edge is None:
+            da = c.get("direction_accuracy")
+            maj = c.get("majority_baseline", {}).get("majority_class_accuracy")
+            if da is not None and maj is not None:
+                edge = float(da) - float(maj)
+        if seed is not None and edge is not None:
+            out[(sym, h, int(seed))] = float(edge)
+    return out
+
+
+def _chronos_per_config(sweep: list) -> dict[tuple, float]:
+    """Chronos: deterministic -> {(symbol, pred_len, None): edge}."""
+    out: dict[tuple, float] = {}
+    for cfg in sweep:
+        sym = cfg.get("symbol")
+        h = cfg.get("pred_len")
+        edge = cfg.get("edge")
+        if edge is None:
+            edge = cfg.get("mean_edge")
+        if edge is not None:
+            out[(sym, h, None)] = float(edge)
+    return out
+
+
+def extract_per_seed(doc: dict) -> tuple[dict[tuple, float], str, bool]:
+    """Auto-detect rung format -> (edges_by_key, model_name, is_deterministic)."""
+    model = doc.get("model", "")
+    sweep = doc.get("sweep")
+    if sweep and isinstance(sweep, list) and sweep and "seed_results" in sweep[0]:
+        return _kronos_per_seed(sweep), "Kronos", False
+    if sweep and isinstance(sweep, list) and sweep and "diracc" in sweep[0]:
+        return _chronos_per_config(sweep), "Chronos-Bolt", True
+    if "combos" in doc:
+        return _m15_per_seed(doc["combos"]), "M15", False
+    raise ValueError("Unrecognized results.json format (expected Kronos/Chronos/M15)")
+
+
+# ---------------------------------------------------------------------------
+# Paired battery
+# ---------------------------------------------------------------------------
+
+def paired_battery(diffs: np.ndarray, alpha: float = ALPHA) -> dict:
+    """Paired tests on the per-pair difference series d = edge_B - edge_A."""
+    diffs = diffs[np.isfinite(diffs)]
+    n = len(diffs)
+    mean_d = float(np.mean(diffs)) if n else float("nan")
+    # ddof=1 sample std of the differences
+    std_d = float(np.std(diffs, ddof=1)) if n >= 2 else 0.0
+    out = {
+        "n_pairs": n,
+        "mean_diff": mean_d,
+        "std_diff": std_d,
+        "median_diff": float(np.median(diffs)) if n else float("nan"),
+    }
+    if n < 2:
+        out.update({"verdict": "n<2: paired test undefined",
+                    "significant_at_alpha": False})
+        return out
+    se = std_d / math.sqrt(n)
+    if se > 1e-12:
+        t_stat = mean_d / se
+    elif abs(mean_d) > 1e-15:
+        # Zero variance but nonzero effect -> infinitely significant.
+        t_stat = float("inf") * math.copysign(1, mean_d)
+    else:
+        # Zero variance AND zero effect (e.g. all diffs exactly 0) -> no effect.
+        t_stat = 0.0
+    t_p = 2.0 * stats.t.sf(abs(t_stat), df=n - 1)
+    tcrit = stats.t.ppf(1 - alpha / 2, df=n - 1)
+    ci_low = mean_d - tcrit * se
+    ci_high = mean_d + tcrit * se
+    # Wilcoxon signed-rank (on |d| > 0). scipy warns if zeros; guard.
+    nz = diffs[diffs != 0]
+    if len(nz) == 0:
+        # All differences exactly zero -> cannot reject, perfectly balanced.
+        wilcoxon_stat = float("nan")
+        wilcoxon_p = 1.0
+    elif np.all(nz[0] == nz):  # all identical non-zero
+        wilcoxon_p = 0.0 if abs(nz[0]) > 0 else 1.0
+        wilcoxon_stat = float("nan")
+    else:
+        try:
+            w_stat, wilcoxon_p = stats.wilcoxon(diffs, zero_method="wilcox",
+                                                correction=False,
+                                                alternative="two-sided")
+            wilcoxon_stat = float(w_stat)
+        except ValueError:
+            wilcoxon_stat = float("nan")
+            wilcoxon_p = float("nan")
+    # Sign (binomial) test on the differences vs 0
+    n_pos = int(np.sum(diffs > 0))
+    n_neg = int(np.sum(diffs < 0))
+    n_nonzero = n_pos + n_neg
+    if n_nonzero == 0:
+        sign_p = 1.0
+    else:
+        k = min(n_pos, n_neg)
+        sign_p = min(1.0, 2.0 * stats.binom.cdf(k, n_nonzero, 0.5))
+    # Effect size: mean diff in DirAcc percentage points
+    out.update({
+        "t_stat": float(t_stat),
+        "t_p_value": float(t_p),
+        "df": n - 1,
+        "ci95_low": float(ci_low),
+        "ci95_high": float(ci_high),
+        "wilcoxon_stat": wilcoxon_stat,
+        "wilcoxon_p_value": float(wilcoxon_p),
+        "sign_n_pos": n_pos,
+        "sign_n_neg": n_neg,
+        "sign_p_value": float(sign_p),
+    })
+    sig = bool(t_p < alpha)
+    if not math.isfinite(t_p):
+        sig = abs(mean_d) > 0
+    direction = "B worse than A (more negative edge)" if mean_d < 0 else \
+                ("B better than A (less negative edge)" if mean_d > 0 else "no difference")
+    verdict = (
+        f"{'SIGNIFICANT' if sig else 'not significant'}: mean paired diff "
+        f"{mean_d:+.5f} (CI95 [{ci_low:+.5f}, {ci_high:+.5f}]), t={t_stat:+.3f} "
+        f"(p={t_p:.4g}), {direction}"
+    )
+    out["significant_at_alpha"] = sig
+    out["direction"] = direction
+    out["verdict"] = verdict
+    return out
+
+
+def compare(rung_a: dict, rung_b: dict, alpha: float = ALPHA) -> dict:
+    """Compare two rung docs. Returns the full structured verdict."""
+    edges_a, name_a, det_a = extract_per_seed(rung_a)
+    edges_b, name_b, det_b = extract_per_seed(rung_b)
+
+    # Align on (symbol, horizon) first, then on seed.
+    # Case 1: both per-seed (Kronos/M15) -> align (symbol, horizon, seed).
+    # Case 2: one deterministic (Chronos, seed=None) -> align (symbol, horizon)
+    #         and pair the deterministic constant against each per-seed edge.
+    if not det_a and not det_b:
+        common = sorted(set(edges_a) & set(edges_b))
+        pairs = [(k, edges_a[k], edges_b[k]) for k in common]
+    else:
+        # Collapse the deterministic side to (symbol, horizon) and the other
+        # side keeps per-seed; pair each seed against the constant.
+        det_edges, det_name = (edges_a, name_a) if det_a else (edges_b, name_b)
+        seed_edges, seed_name = (edges_b, name_b) if det_a else (edges_a, name_a)
+        det_by_sh = {(k[0], k[1]): v for k, v in det_edges.items()}
+        pairs = []
+        for (sym, h, seed), sev in seed_edges.items():
+            if (sym, h) in det_by_sh:
+                a_val = det_by_sh[(sym, h)] if det_a else sev
+                b_val = sev if det_a else det_by_sh[(sym, h)]
+                pairs.append(((sym, h, seed), a_val, b_val))
+        common = [p[0] for p in pairs]
+
+    diffs = np.array([b - a for (_, a, b) in pairs], dtype=float) if pairs else \
+        np.array([], dtype=float)
+    battery = paired_battery(diffs, alpha=alpha)
+
+    return {
+        "rung_a": name_a,
+        "rung_b": name_b,
+        "rung_a_deterministic": det_a,
+        "rung_b_deterministic": det_b,
+        "alpha": alpha,
+        "n_common_keys": len(common),
+        "common_keys": [
+            {"symbol": k[0], "horizon": k[1], "seed": k[2]} for k in common
+        ],
+        "pairs": [
+            {"symbol": k[0], "horizon": k[1], "seed": k[2],
+             "edge_a": a, "edge_b": b, "diff": b - a}
+            for (k, a, b) in pairs
+        ],
+        "mean_edge_a": float(np.mean([a for (_, a, _) in pairs])) if pairs else float("nan"),
+        "mean_edge_b": float(np.mean([b for (_, _, b) in pairs])) if pairs else float("nan"),
+        "battery": battery,
+    }
+
+
+def render_md(out: dict) -> str:
+    b = out["battery"]
+    lines = []
+    lines.append(f"# Paired cross-rung comparison -- {out['rung_a']} vs {out['rung_b']} (#8607)\n")
+    det = ""
+    if out["rung_a_deterministic"] or out["rung_b_deterministic"]:
+        det = (f" ({'A' if out['rung_a_deterministic'] else 'B'}="
+               f"{'Chronos' if out['rung_a_deterministic'] else 'Chronos'} "
+               f"deterministic, paired vs per-seed)")
+    lines.append(f"**Question**: is {out['rung_b']} significantly different from "
+                 f"{out['rung_a']} on the directional edge?{det}\n")
+    lines.append(f"**Alignment**: {out['n_common_keys']} paired (symbol, horizon, seed) "
+                 f"observations. mean edge A={out['mean_edge_a']:+.5f}, "
+                 f"mean edge B={out['mean_edge_b']:+.5f}.\n")
+    lines.append("| metric | value |")
+    lines.append("|--------|-------|")
+    lines.append(f"| n pairs | {b['n_pairs']} |")
+    lines.append(f"| mean diff (B-A) | {b['mean_diff']:+.5f} |")
+    lines.append(f"| std diff | {b['std_diff']:.5f} |")
+    lines.append(f"| paired t-stat (df={b.get('df','-')}) | {b.get('t_stat', float('nan')):+.3f} |")
+    lines.append(f"| t p-value | {b.get('t_p_value', float('nan')):.4g} |")
+    lines.append(f"| CI95 (mean diff) | [{b.get('ci95_low', float('nan')):+.5f}, {b.get('ci95_high', float('nan')):+.5f}] |")
+    lines.append(f"| Wilcoxon p | {b.get('wilcoxon_p_value', float('nan')):.4g} |")
+    lines.append(f"| sign p (n+={b.get('sign_n_pos','-')}, n-={b.get('sign_n_neg','-')}) | {b.get('sign_p_value', float('nan')):.4g} |")
+    lines.append(f"| direction | {b.get('direction','-')} |")
+    lines.append(f"| **verdict (alpha={out['alpha']})** | {b.get('verdict','-')} |")
+    lines.append("")
+    lines.append("## Interpretation\n")
+    lines.append("Both rungs are individually NO BEATS vs majority (cf "
+                 "`seed_significance_verdict.md`). This paired test asks whether they "
+                 "differ **from each other**. A non-significant paired difference means "
+                 "fine-tuning (B) did not change the directional edge relative to zero-shot "
+                 "(A) -- reinforcing the #1409 conclusion that directional forecasting "
+                 "edge is absent regardless of the forecasting paradigm; alpha comes from "
+                 "**action policies** (L4-DT), not price-direction prediction.")
+    lines.append("\n## Scope / residual\n")
+    lines.append("- This is a paired-by-(config, seed) test on committed per-seed edges, "
+                 "**not** a full Diebold-Mariano by-observation test. The true DM needs the "
+                 "per-window DirAcc series (Kronos dumps only the fold aggregate) -> "
+                 "multi-cycle residual (re-run dumping per-window forecasts).")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Paired cross-rung comparison on per-seed edges (#8607).")
+    p.add_argument("rung_a", type=Path, help="Path to rung A results.json.")
+    p.add_argument("rung_b", type=Path, help="Path to rung B results.json.")
+    p.add_argument("--alpha", type=float, default=ALPHA)
+    p.add_argument("--out", type=Path, default=None,
+                   help="Output folder (default: rung_b's folder).")
+    args = p.parse_args(argv)
+
+    doc_a = json.loads(args.rung_a.read_text(encoding="utf-8"))
+    doc_b = json.loads(args.rung_b.read_text(encoding="utf-8"))
+    out = compare(doc_a, doc_b, alpha=args.alpha)
+    out_folder = args.out if args.out is not None else args.rung_b.parent
+    out_folder.mkdir(parents=True, exist_ok=True)
+    (out_folder / "paired_comparison.json").write_text(
+        json.dumps(out, indent=2), encoding="utf-8")
+    (out_folder / "paired_comparison.md").write_text(
+        render_md(out), encoding="utf-8")
+    print(render_md(out))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/cross_rung_paired/chronos_vs_kronos.json
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/cross_rung_paired/chronos_vs_kronos.json
@@ -1,0 +1,488 @@
+{
+  "rung_a": "Chronos-Bolt",
+  "rung_b": "Kronos",
+  "rung_a_deterministic": true,
+  "rung_b_deterministic": false,
+  "alpha": 0.05,
+  "n_common_keys": 35,
+  "common_keys": [
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 0
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 1
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 7
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 42
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 99
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 0
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 1
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 7
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 42
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 99
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 0
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 1
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 7
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 42
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 99
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 0
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 1
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 7
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 42
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 99
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 0
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 1
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 7
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 42
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 99
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 0
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 1
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 7
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 42
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 99
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 0
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 1
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 7
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 42
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 99
+    }
+  ],
+  "pairs": [
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 0,
+      "edge_a": -0.050489433087751945,
+      "edge_b": -0.12875030265296944,
+      "diff": -0.0782608695652175
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 1,
+      "edge_a": -0.050489433087751945,
+      "edge_b": 0.0016844799557262924,
+      "diff": 0.05217391304347824
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 7,
+      "edge_a": -0.050489433087751945,
+      "edge_b": -0.015706824392099805,
+      "diff": 0.03478260869565214
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 42,
+      "edge_a": -0.050489433087751945,
+      "edge_b": 0.010380132129639286,
+      "diff": 0.06086956521739123
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 99,
+      "edge_a": -0.050489433087751945,
+      "edge_b": -0.04179378091383901,
+      "diff": 0.008695652173912938
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 0,
+      "edge_a": 0.004627623768435285,
+      "edge_b": -0.016910837770026332,
+      "diff": -0.021538461538461617
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 1,
+      "edge_a": 0.004627623768435285,
+      "edge_b": -0.04768006853925705,
+      "diff": -0.05230769230769233
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 7,
+      "edge_a": 0.004627623768435285,
+      "edge_b": -0.07844929930848776,
+      "diff": -0.08307692307692305
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 42,
+      "edge_a": 0.004627623768435285,
+      "edge_b": -0.01691083777002622,
+      "diff": -0.021538461538461506
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 99,
+      "edge_a": 0.004627623768435285,
+      "edge_b": -0.04152622238541093,
+      "diff": -0.04615384615384621
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 0,
+      "edge_a": -0.053011836008429125,
+      "edge_b": -0.07591259936720773,
+      "diff": -0.02290076335877861
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 1,
+      "edge_a": -0.053011836008429125,
+      "edge_b": -0.0667522940236962,
+      "diff": -0.013740458015267076
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 7,
+      "edge_a": -0.053011836008429125,
+      "edge_b": -0.036217942878658094,
+      "diff": 0.01679389312977103
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 42,
+      "edge_a": -0.053011836008429125,
+      "edge_b": -0.030111072649650517,
+      "diff": 0.02290076335877861
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 99,
+      "edge_a": -0.053011836008429125,
+      "edge_b": -0.014843897077131407,
+      "diff": 0.03816793893129772
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 0,
+      "edge_a": 0.008714528408733435,
+      "edge_b": -0.008676775939092662,
+      "diff": -0.017391304347826098
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 1,
+      "edge_a": 0.008714528408733435,
+      "edge_b": -0.017372428113005767,
+      "diff": -0.026086956521739202
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 7,
+      "edge_a": 0.008714528408733435,
+      "edge_b": -0.06954634115648395,
+      "diff": -0.07826086956521738
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 42,
+      "edge_a": 0.008714528408733435,
+      "edge_b": 0.01741018058264654,
+      "diff": 0.008695652173913104
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 99,
+      "edge_a": 0.008714528408733435,
+      "edge_b": -0.008676775939092662,
+      "diff": -0.017391304347826098
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 0,
+      "edge_a": -0.036101525102972265,
+      "edge_b": -0.026870755872202945,
+      "diff": 0.00923076923076932
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 1,
+      "edge_a": -0.036101525102972265,
+      "edge_b": -0.020716909718356824,
+      "diff": 0.015384615384615441
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 7,
+      "edge_a": -0.036101525102972265,
+      "edge_b": -0.017639986641433736,
+      "diff": 0.01846153846153853
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 42,
+      "edge_a": -0.036101525102972265,
+      "edge_b": -0.02994767894912609,
+      "diff": 0.006153846153846176
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 99,
+      "edge_a": -0.036101525102972265,
+      "edge_b": -0.005332294333741383,
+      "diff": 0.030769230769230882
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 0,
+      "edge_a": -0.013787960804675148,
+      "edge_b": -0.030581853934446124,
+      "diff": -0.016793893129770976
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 1,
+      "edge_a": -0.013787960804675148,
+      "edge_b": -0.027528418819942335,
+      "diff": -0.013740458015267187
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 7,
+      "edge_a": -0.013787960804675148,
+      "edge_b": -0.006154373018415482,
+      "diff": 0.007633587786259666
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 42,
+      "edge_a": -0.013787960804675148,
+      "edge_b": -0.021421548590934703,
+      "diff": -0.007633587786259555
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 99,
+      "edge_a": -0.013787960804675148,
+      "edge_b": -0.036688724163453756,
+      "diff": -0.02290076335877861
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 0,
+      "edge_a": -0.0706065563455609,
+      "edge_b": -0.079302208519474,
+      "diff": -0.008695652173913104
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 1,
+      "edge_a": -0.0706065563455609,
+      "edge_b": -0.0706065563455609,
+      "diff": 0.0
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 7,
+      "edge_a": -0.0706065563455609,
+      "edge_b": -0.01843264330208272,
+      "diff": 0.05217391304347818
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 42,
+      "edge_a": -0.0706065563455609,
+      "edge_b": -0.01843264330208272,
+      "diff": 0.05217391304347818
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 99,
+      "edge_a": -0.0706065563455609,
+      "edge_b": -0.027128295475995712,
+      "diff": 0.04347826086956519
+    }
+  ],
+  "mean_edge_a": -0.0300935941674601,
+  "mean_edge_b": -0.032089954262724936,
+  "battery": {
+    "n_pairs": 35,
+    "mean_diff": -0.0019963600952648437,
+    "std_diff": 0.03719009339423167,
+    "median_diff": 0.0,
+    "t_stat": -0.31757450765679013,
+    "t_p_value": 0.7527499043989224,
+    "df": 34,
+    "ci95_low": -0.014771604154235616,
+    "ci95_high": 0.010778883963705929,
+    "wilcoxon_stat": 285.5,
+    "wilcoxon_p_value": 0.8374280402895187,
+    "sign_n_pos": 17,
+    "sign_n_neg": 17,
+    "sign_p_value": 1.0,
+    "significant_at_alpha": false,
+    "direction": "B worse than A (more negative edge)",
+    "verdict": "not significant: mean paired diff -0.00200 (CI95 [-0.01477, +0.01078]), t=-0.318 (p=0.7527), B worse than A (more negative edge)"
+  }
+}

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/cross_rung_paired/chronos_vs_kronos.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/cross_rung_paired/chronos_vs_kronos.md
@@ -1,0 +1,26 @@
+# Paired cross-rung comparison -- Chronos-Bolt vs Kronos (#8607)
+
+**Question**: is Kronos significantly different from Chronos-Bolt on the directional edge? (A=Chronos deterministic, paired vs per-seed)
+
+**Alignment**: 35 paired (symbol, horizon, seed) observations. mean edge A=-0.03009, mean edge B=-0.03209.
+
+| metric | value |
+|--------|-------|
+| n pairs | 35 |
+| mean diff (B-A) | -0.00200 |
+| std diff | 0.03719 |
+| paired t-stat (df=34) | -0.318 |
+| t p-value | 0.7527 |
+| CI95 (mean diff) | [-0.01477, +0.01078] |
+| Wilcoxon p | 0.8374 |
+| sign p (n+=17, n-=17) | 1 |
+| direction | B worse than A (more negative edge) |
+| **verdict (alpha=0.05)** | not significant: mean paired diff -0.00200 (CI95 [-0.01477, +0.01078]), t=-0.318 (p=0.7527), B worse than A (more negative edge) |
+
+## Interpretation
+
+Both rungs are individually NO BEATS vs majority (cf `seed_significance_verdict.md`). This paired test asks whether they differ **from each other**. A non-significant paired difference means fine-tuning (B) did not change the directional edge relative to zero-shot (A) -- reinforcing the #1409 conclusion that directional forecasting edge is absent regardless of the forecasting paradigm; alpha comes from **action policies** (L4-DT), not price-direction prediction.
+
+## Scope / residual
+
+- This is a paired-by-(config, seed) test on committed per-seed edges, **not** a full Diebold-Mariano by-observation test. The true DM needs the per-window DirAcc series (Kronos dumps only the fold aggregate) -> multi-cycle residual (re-run dumping per-window forecasts).

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/cross_rung_paired/chronos_vs_m15.json
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/cross_rung_paired/chronos_vs_m15.json
@@ -1,0 +1,488 @@
+{
+  "rung_a": "Chronos-Bolt",
+  "rung_b": "M15",
+  "rung_a_deterministic": true,
+  "rung_b_deterministic": false,
+  "alpha": 0.05,
+  "n_common_keys": 35,
+  "common_keys": [
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 0
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 1
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 7
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 42
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 99
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 0
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 1
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 7
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 42
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 99
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 0
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 1
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 7
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 42
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 99
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 0
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 1
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 7
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 42
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 99
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 0
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 1
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 7
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 42
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 99
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 0
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 1
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 7
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 42
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 99
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 0
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 1
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 7
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 42
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 99
+    }
+  ],
+  "pairs": [
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 0,
+      "edge_a": -0.050489433087751945,
+      "edge_b": -0.04239388350446771,
+      "diff": 0.008095549583284234
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 1,
+      "edge_a": -0.050489433087751945,
+      "edge_b": -0.04498932583410731,
+      "diff": 0.005500107253644637
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 7,
+      "edge_a": -0.050489433087751945,
+      "edge_b": -0.04250432785892044,
+      "diff": 0.007985105228831502
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 42,
+      "edge_a": -0.050489433087751945,
+      "edge_b": -0.0477872494802436,
+      "diff": 0.002702183607508346
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 99,
+      "edge_a": -0.050489433087751945,
+      "edge_b": -0.04655395418885455,
+      "diff": 0.003935478898897393
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 0,
+      "edge_a": 0.004627623768435285,
+      "edge_b": -0.04735678430834833,
+      "diff": -0.05198440807678362
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 1,
+      "edge_a": 0.004627623768435285,
+      "edge_b": -0.04430638643036422,
+      "diff": -0.048934010198799505
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 7,
+      "edge_a": 0.004627623768435285,
+      "edge_b": -0.0458050601704173,
+      "diff": -0.050432683938852585
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 42,
+      "edge_a": 0.004627623768435285,
+      "edge_b": -0.046839542929037914,
+      "diff": -0.0514671666974732
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 99,
+      "edge_a": 0.004627623768435285,
+      "edge_b": -0.044856784308348274,
+      "diff": -0.04948440807678356
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 0,
+      "edge_a": -0.053011836008429125,
+      "edge_b": -0.04552717211826607,
+      "diff": 0.007484663890163057
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 1,
+      "edge_a": -0.053011836008429125,
+      "edge_b": -0.045760853377029176,
+      "diff": 0.007250982631399949
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 7,
+      "edge_a": -0.053011836008429125,
+      "edge_b": -0.04576762674684842,
+      "diff": 0.007244209261580703
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 42,
+      "edge_a": -0.053011836008429125,
+      "edge_b": -0.04519189031221482,
+      "diff": 0.007819945696214303
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 99,
+      "edge_a": -0.053011836008429125,
+      "edge_b": -0.045218983791491696,
+      "diff": 0.007792852216937429
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 0,
+      "edge_a": 0.008714528408733435,
+      "edge_b": -0.01453438189075723,
+      "diff": -0.023248910299490666
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 1,
+      "edge_a": 0.008714528408733435,
+      "edge_b": -0.015730862397328682,
+      "diff": -0.024445390806062117
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 7,
+      "edge_a": 0.008714528408733435,
+      "edge_b": -0.015749269789737452,
+      "diff": -0.024463798198470887
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 42,
+      "edge_a": 0.008714528408733435,
+      "edge_b": -0.015583603258058354,
+      "diff": -0.02429813166679179
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 99,
+      "edge_a": 0.008714528408733435,
+      "edge_b": -0.018234267764924317,
+      "diff": -0.026948796173657752
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 0,
+      "edge_a": -0.036101525102972265,
+      "edge_b": -0.013597671193152194,
+      "diff": 0.02250385390982007
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 1,
+      "edge_a": -0.036101525102972265,
+      "edge_b": -0.011847008063178732,
+      "diff": 0.024254517039793533
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 7,
+      "edge_a": -0.036101525102972265,
+      "edge_b": -0.012616238832409477,
+      "diff": 0.02348528627056279
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 42,
+      "edge_a": -0.036101525102972265,
+      "edge_b": -0.012954435118881669,
+      "diff": 0.023147089984090596
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 99,
+      "edge_a": -0.036101525102972265,
+      "edge_b": -0.014293957665300727,
+      "diff": 0.021807567437671538
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 0,
+      "edge_a": -0.013787960804675148,
+      "edge_b": -0.01257275721180473,
+      "diff": 0.0012152035928704175
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 1,
+      "edge_a": -0.013787960804675148,
+      "edge_b": -0.013466842027941628,
+      "diff": 0.00032111877673351996
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 7,
+      "edge_a": -0.013787960804675148,
+      "edge_b": -0.011983474037532749,
+      "diff": 0.0018044867671423992
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 42,
+      "edge_a": -0.013787960804675148,
+      "edge_b": -0.015028103771271561,
+      "diff": -0.0012401429665964137
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 99,
+      "edge_a": -0.013787960804675148,
+      "edge_b": -0.012901265648036897,
+      "diff": 0.0008866951566382508
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 0,
+      "edge_a": -0.0706065563455609,
+      "edge_b": -0.03459356612578929,
+      "diff": 0.03601299021977161
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 1,
+      "edge_a": -0.0706065563455609,
+      "edge_b": -0.03321301169512997,
+      "diff": 0.03739354465043093
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 7,
+      "edge_a": -0.0706065563455609,
+      "edge_b": -0.03503534354360033,
+      "diff": 0.03557121280196057
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 42,
+      "edge_a": -0.0706065563455609,
+      "edge_b": -0.03085686546680466,
+      "diff": 0.03974969087875624
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 99,
+      "edge_a": -0.0706065563455609,
+      "edge_b": -0.03393089999907284,
+      "diff": 0.03667565634648806
+    }
+  ],
+  "mean_edge_a": -0.0300935941674601,
+  "mean_edge_b": -0.03027381859599067,
+  "battery": {
+    "n_pairs": 35,
+    "mean_diff": -0.0001802244285305716,
+    "std_diff": 0.027549825187963905,
+    "median_diff": 0.005500107253644637,
+    "t_stat": -0.03870159214353971,
+    "t_p_value": 0.9693546616726241,
+    "df": 34,
+    "ci95_low": -0.009643920494774088,
+    "ci95_high": 0.009283471637712945,
+    "wilcoxon_stat": 282.0,
+    "wilcoxon_p_value": 0.5987840640591457,
+    "sign_n_pos": 24,
+    "sign_n_neg": 11,
+    "sign_p_value": 0.040959591511636986,
+    "significant_at_alpha": false,
+    "direction": "B worse than A (more negative edge)",
+    "verdict": "not significant: mean paired diff -0.00018 (CI95 [-0.00964, +0.00928]), t=-0.039 (p=0.9694), B worse than A (more negative edge)"
+  }
+}

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/cross_rung_paired/chronos_vs_m15.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/cross_rung_paired/chronos_vs_m15.md
@@ -1,0 +1,26 @@
+# Paired cross-rung comparison -- Chronos-Bolt vs M15 (#8607)
+
+**Question**: is M15 significantly different from Chronos-Bolt on the directional edge? (A=Chronos deterministic, paired vs per-seed)
+
+**Alignment**: 35 paired (symbol, horizon, seed) observations. mean edge A=-0.03009, mean edge B=-0.03027.
+
+| metric | value |
+|--------|-------|
+| n pairs | 35 |
+| mean diff (B-A) | -0.00018 |
+| std diff | 0.02755 |
+| paired t-stat (df=34) | -0.039 |
+| t p-value | 0.9694 |
+| CI95 (mean diff) | [-0.00964, +0.00928] |
+| Wilcoxon p | 0.5988 |
+| sign p (n+=24, n-=11) | 0.04096 |
+| direction | B worse than A (more negative edge) |
+| **verdict (alpha=0.05)** | not significant: mean paired diff -0.00018 (CI95 [-0.00964, +0.00928]), t=-0.039 (p=0.9694), B worse than A (more negative edge) |
+
+## Interpretation
+
+Both rungs are individually NO BEATS vs majority (cf `seed_significance_verdict.md`). This paired test asks whether they differ **from each other**. A non-significant paired difference means fine-tuning (B) did not change the directional edge relative to zero-shot (A) -- reinforcing the #1409 conclusion that directional forecasting edge is absent regardless of the forecasting paradigm; alpha comes from **action policies** (L4-DT), not price-direction prediction.
+
+## Scope / residual
+
+- This is a paired-by-(config, seed) test on committed per-seed edges, **not** a full Diebold-Mariano by-observation test. The true DM needs the per-window DirAcc series (Kronos dumps only the fold aggregate) -> multi-cycle residual (re-run dumping per-window forecasts).

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/cross_rung_paired/kronos_vs_m15.json
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/cross_rung_paired/kronos_vs_m15.json
@@ -1,0 +1,618 @@
+{
+  "rung_a": "Kronos",
+  "rung_b": "M15",
+  "rung_a_deterministic": false,
+  "rung_b_deterministic": false,
+  "alpha": 0.05,
+  "n_common_keys": 45,
+  "common_keys": [
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 0
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 1
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 7
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 42
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 99
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 66,
+      "seed": 0
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 66,
+      "seed": 1
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 66,
+      "seed": 7
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 66,
+      "seed": 42
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 66,
+      "seed": 99
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 132,
+      "seed": 0
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 132,
+      "seed": 1
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 132,
+      "seed": 7
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 132,
+      "seed": 42
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 132,
+      "seed": 99
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 0
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 1
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 7
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 42
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 99
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 0
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 1
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 7
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 42
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 99
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 0
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 1
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 7
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 42
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 99
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 0
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 1
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 7
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 42
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 99
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 0
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 1
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 7
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 42
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 99
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 0
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 1
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 7
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 42
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 99
+    }
+  ],
+  "pairs": [
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 0,
+      "edge_a": -0.079302208519474,
+      "edge_b": -0.03459356612578929,
+      "diff": 0.04470864239368472
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 1,
+      "edge_a": -0.0706065563455609,
+      "edge_b": -0.03321301169512997,
+      "diff": 0.03739354465043093
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 7,
+      "edge_a": -0.01843264330208272,
+      "edge_b": -0.03503534354360033,
+      "diff": -0.01660270024151761
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 42,
+      "edge_a": -0.01843264330208272,
+      "edge_b": -0.03085686546680466,
+      "diff": -0.012424222164721943
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "seed": 99,
+      "edge_a": -0.027128295475995712,
+      "edge_b": -0.03393089999907284,
+      "diff": -0.006802604523077127
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 66,
+      "seed": 0,
+      "edge_a": -0.03916842925525987,
+      "edge_b": -0.03255173710868842,
+      "diff": 0.006616692146571457
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 66,
+      "seed": 1,
+      "edge_a": 0.03467772459089402,
+      "edge_b": -0.03264457530497489,
+      "diff": -0.06732229989586891
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 66,
+      "seed": 7,
+      "edge_a": -0.02686073694756763,
+      "edge_b": -0.03093369997340989,
+      "diff": -0.004072963025842258
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 66,
+      "seed": 42,
+      "edge_a": -0.051476121562952115,
+      "edge_b": -0.030728129681632688,
+      "diff": 0.020747991881319428
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 66,
+      "seed": 99,
+      "edge_a": -0.02686073694756763,
+      "edge_b": -0.03162998644555842,
+      "diff": -0.004769249497990791
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 132,
+      "seed": 0,
+      "edge_a": -0.023079174998066776,
+      "edge_b": -0.03220488936942456,
+      "diff": -0.009125714371357785
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 132,
+      "seed": 1,
+      "edge_a": -0.029186045227074353,
+      "edge_b": -0.03172736679716964,
+      "diff": -0.0025413215700952896
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 132,
+      "seed": 7,
+      "edge_a": -0.016972304769059088,
+      "edge_b": -0.03208974208249782,
+      "diff": -0.01511743731343873
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 132,
+      "seed": 42,
+      "edge_a": -0.052086808585852906,
+      "edge_b": -0.0327636923795101,
+      "diff": 0.019323116206342805
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 132,
+      "seed": 99,
+      "edge_a": -0.003231846753791845,
+      "edge_b": -0.03188992767283089,
+      "diff": -0.028658080919039042
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 0,
+      "edge_a": -0.12875030265296944,
+      "edge_b": -0.04239388350446771,
+      "diff": 0.08635641914850173
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 1,
+      "edge_a": 0.0016844799557262924,
+      "edge_b": -0.04498932583410731,
+      "diff": -0.0466738057898336
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 7,
+      "edge_a": -0.015706824392099805,
+      "edge_b": -0.04250432785892044,
+      "diff": -0.026797503466820638
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 42,
+      "edge_a": 0.010380132129639286,
+      "edge_b": -0.0477872494802436,
+      "diff": -0.058167381609882884
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "seed": 99,
+      "edge_a": -0.04179378091383901,
+      "edge_b": -0.04655395418885455,
+      "diff": -0.0047601732750155445
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 0,
+      "edge_a": -0.016910837770026332,
+      "edge_b": -0.04735678430834833,
+      "diff": -0.030445946538322
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 1,
+      "edge_a": -0.04768006853925705,
+      "edge_b": -0.04430638643036422,
+      "diff": 0.003373682108892828
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 7,
+      "edge_a": -0.07844929930848776,
+      "edge_b": -0.0458050601704173,
+      "diff": 0.03264423913807046
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 42,
+      "edge_a": -0.01691083777002622,
+      "edge_b": -0.046839542929037914,
+      "diff": -0.029928705159011693
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "seed": 99,
+      "edge_a": -0.04152622238541093,
+      "edge_b": -0.044856784308348274,
+      "diff": -0.0033305619229373473
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 0,
+      "edge_a": -0.07591259936720773,
+      "edge_b": -0.04552717211826607,
+      "diff": 0.030385427248941665
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 1,
+      "edge_a": -0.0667522940236962,
+      "edge_b": -0.045760853377029176,
+      "diff": 0.020991440646667026
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 7,
+      "edge_a": -0.036217942878658094,
+      "edge_b": -0.04576762674684842,
+      "diff": -0.009549683868190328
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 42,
+      "edge_a": -0.030111072649650517,
+      "edge_b": -0.04519189031221482,
+      "diff": -0.015080817662564305
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "seed": 99,
+      "edge_a": -0.014843897077131407,
+      "edge_b": -0.045218983791491696,
+      "diff": -0.03037508671436029
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 0,
+      "edge_a": -0.008676775939092662,
+      "edge_b": -0.01453438189075723,
+      "diff": -0.005857605951664568
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 1,
+      "edge_a": -0.017372428113005767,
+      "edge_b": -0.015730862397328682,
+      "diff": 0.0016415657156770846
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 7,
+      "edge_a": -0.06954634115648395,
+      "edge_b": -0.015749269789737452,
+      "diff": 0.053797071366746496
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 42,
+      "edge_a": 0.01741018058264654,
+      "edge_b": -0.015583603258058354,
+      "diff": -0.03299378384070489
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "seed": 99,
+      "edge_a": -0.008676775939092662,
+      "edge_b": -0.018234267764924317,
+      "diff": -0.009557491825831654
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 0,
+      "edge_a": -0.026870755872202945,
+      "edge_b": -0.013597671193152194,
+      "diff": 0.01327308467905075
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 1,
+      "edge_a": -0.020716909718356824,
+      "edge_b": -0.011847008063178732,
+      "diff": 0.008869901655178092
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 7,
+      "edge_a": -0.017639986641433736,
+      "edge_b": -0.012616238832409477,
+      "diff": 0.005023747809024259
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 42,
+      "edge_a": -0.02994767894912609,
+      "edge_b": -0.012954435118881669,
+      "diff": 0.01699324383024442
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "seed": 99,
+      "edge_a": -0.005332294333741383,
+      "edge_b": -0.014293957665300727,
+      "diff": -0.008961663331559344
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 0,
+      "edge_a": -0.030581853934446124,
+      "edge_b": -0.01257275721180473,
+      "diff": 0.018009096722641393
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 1,
+      "edge_a": -0.027528418819942335,
+      "edge_b": -0.013466842027941628,
+      "diff": 0.014061576792000707
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 7,
+      "edge_a": -0.006154373018415482,
+      "edge_b": -0.011983474037532749,
+      "diff": -0.0058291010191172665
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 42,
+      "edge_a": -0.021421548590934703,
+      "edge_b": -0.015028103771271561,
+      "diff": 0.006393444819663141
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "seed": 99,
+      "edge_a": -0.036688724163453756,
+      "edge_b": -0.012901265648036897,
+      "diff": 0.02378745851541686
+    }
+  ],
+  "mean_edge_a": -0.030164286214481573,
+  "mean_edge_b": -0.030638831059452684,
+  "battery": {
+    "n_pairs": 45,
+    "mean_diff": -0.0004745448449711019,
+    "std_diff": 0.028452986756428652,
+    "median_diff": -0.004072963025842258,
+    "t_stat": -0.11188082370520228,
+    "t_p_value": 0.9114267479275604,
+    "df": 44,
+    "ci95_low": -0.009022768405553728,
+    "ci95_high": 0.008073678715611524,
+    "wilcoxon_stat": 494.0,
+    "wilcoxon_p_value": 0.7971090296958891,
+    "sign_n_pos": 20,
+    "sign_n_neg": 25,
+    "sign_p_value": 0.5514843298025198,
+    "significant_at_alpha": false,
+    "direction": "B worse than A (more negative edge)",
+    "verdict": "not significant: mean paired diff -0.00047 (CI95 [-0.00902, +0.00807]), t=-0.112 (p=0.9114), B worse than A (more negative edge)"
+  }
+}

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/cross_rung_paired/kronos_vs_m15.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/cross_rung_paired/kronos_vs_m15.md
@@ -1,0 +1,26 @@
+# Paired cross-rung comparison -- Kronos vs M15 (#8607)
+
+**Question**: is M15 significantly different from Kronos on the directional edge?
+
+**Alignment**: 45 paired (symbol, horizon, seed) observations. mean edge A=-0.03016, mean edge B=-0.03064.
+
+| metric | value |
+|--------|-------|
+| n pairs | 45 |
+| mean diff (B-A) | -0.00047 |
+| std diff | 0.02845 |
+| paired t-stat (df=44) | -0.112 |
+| t p-value | 0.9114 |
+| CI95 (mean diff) | [-0.00902, +0.00807] |
+| Wilcoxon p | 0.7971 |
+| sign p (n+=20, n-=25) | 0.5515 |
+| direction | B worse than A (more negative edge) |
+| **verdict (alpha=0.05)** | not significant: mean paired diff -0.00047 (CI95 [-0.00902, +0.00807]), t=-0.112 (p=0.9114), B worse than A (more negative edge) |
+
+## Interpretation
+
+Both rungs are individually NO BEATS vs majority (cf `seed_significance_verdict.md`). This paired test asks whether they differ **from each other**. A non-significant paired difference means fine-tuning (B) did not change the directional edge relative to zero-shot (A) -- reinforcing the #1409 conclusion that directional forecasting edge is absent regardless of the forecasting paradigm; alpha comes from **action policies** (L4-DT), not price-direction prediction.
+
+## Scope / residual
+
+- This is a paired-by-(config, seed) test on committed per-seed edges, **not** a full Diebold-Mariano by-observation test. The true DM needs the per-window DirAcc series (Kronos dumps only the fold aggregate) -> multi-cycle residual (re-run dumping per-window forecasts).

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/cross_rung_paired/verdict.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/cross_rung_paired/verdict.md
@@ -1,0 +1,45 @@
+# Cross-rung paired comparison — 3 foundation paradigms are statistically indistinguishable (#8607)
+
+> Script : [`paired_rung_comparison.py`](../../paired_rung_comparison.py).
+> Artefacts : [`kronos_vs_m15.json`](kronos_vs_m15.json) · [`chronos_vs_kronos.json`](chronos_vs_kronos.json) · [`chronos_vs_m15.json`](chronos_vs_m15.json) (+ `.md`).
+
+## Question (la suite naturelle de #8607)
+
+`seed_significance.py` (c.902, PR #8626) a répondu **par rung** : « ce modèle est-il significativement sous majority ? » (one-sample t-test sur l'edge par seed). Verdict : Chronos dégénéré (std_edge=0, C893-L), Kronos 6/9 SIG-négatif, M15 9/9 SIG-négatif. Les 3 rungs foundation sont **individuellement** NO BEATS.
+
+Ce module répond à la question **suivante** : **deux rungs sont-ils significativement différents l'un de l'autre ?** Un modèle zero-shot (Kronos, échantillonnage AR) et un modèle fine-tuned (M15 LSTM) échouent tous deux à battre majority — mais le fine-tuning change-t-il l'edge directionnel relativement au zero-shot, ou atterrissent-ils sur le même edge ?
+
+## Verdict — 3 comparaisons par paires, TOUTES non significatives
+
+| Comparaison (A vs B) | n paires appariées | mean diff (B−A) | CI95% | paired t (df) | t p | Wilcoxon p | verdict |
+|----------------------|-------------------|-----------------|-------|---------------|-----|-----------|---------|
+| **Kronos vs M15** | 45 | −0.00047 | [−0.009, +0.008] | −0.112 (44) | **0.91** | 0.80 | **non sig.** |
+| Chronos vs Kronos | 35 | −0.00200 | [−0.015, +0.011] | −0.318 (34) | 0.75 | 0.84 | non sig. |
+| Chronos vs M15 | 35 | −0.00018 | [−0.010, +0.009] | −0.039 (34) | 0.97 | 0.60 | non sig. |
+
+Aucune paire n'est significativement différente (alpha=0.05). Les 3 paradigmes foundation — **zero-shot langage-TS** (Chronos-Bolt), **zero-shot OHLCV AR** (Kronos), **fine-tuned LSTM direction** (M15) — produisent des edges directionnels **statistiquement indiscernables** sur le panier ETF (SPY/TLT/GLD), tous autour de −0.02 à −0.03 (sous majority).
+
+## Finding clé — aucun paradigme de prévision n'en surpasse un autre
+
+- **Kronos ↔ M15 (n=45, propre)** : la comparaison centrale. La difference moyenne appariée est −0.00047 (M15 0.05 points de % plus négatif), CI95 chevauche 0 largement, t=−0.112 (p=0.91). Le fine-tuning LSTM **ne change pas** l'edge directionnel relativement au zero-shot Kronos.
+- **Picture 3-voies cohérente** : Chronos↔Kronos et Chronos↔M15 tout aussi non significatifs. Quelle que soit la méthode de prévision (langage-TS pré-entraîné, AR OHLCV, ou LSTM fine-tuned sur le log-return), l'edge directionnel atterrit au même endroit (~−0.03, reliably sous majority).
+- **Reinforce #1409** : la conclusion capability-core (l'alpha vient de **politiques d'action** L4-DT, pas de prévision de direction prix) est désormais étayée à **deux niveaux statistiques** — (1) chaque rung est SIG-nég vs majority (seed-level, c.902/c.904), (2) aucun rung n'en bat un autre (paired cross-rung, ce cycle). L'absence d'edge directionnel n'est pas un artefact d'un paradigme particulier ; elle est **robuste à travers les paradigmes**.
+
+## Méthode
+
+Test **apparié par (symbole, horizon, seed)** sur les edges par seed **déjà committés** dans les `results.json` de chaque rung (Kronos `seed_results[j].edge_vs_majority`, M15 `combos[i].edge_vs_majority`, Chronos déterministe `edge` par config). Pour chaque observation appariée, `d = edge_B − edge_A`, puis : paired t-test (df=n−1) + Wilcoxon signed-rank + sign (binomial) + IC95% sur la différence moyenne.
+
+- **Kronos ↔ M15** : alignement complet (3 ETF × 3 horizons × 5 seeds = 45). C'est le résultat primaire.
+- **Chronos (déterministe, C893-L)** : std_edge=0, 1 edge par config (7 configs, donc 35 paires appariées par seed contre la constante Chronos). Interprété avec prudence (rung déterministe), rapporté pour complétude.
+
+## Scope / résiduel (honnête)
+
+- **Ce n'est PAS le test Diebold-Mariano complet.** DM est apparié **par observation** (erreurs de prévision par fenêtre/par pas de temps, avec correction de variance HAC — Harvey-Leybourne-Newbold). Il nécessite la série DirAcc **par fenêtre**, qui n'est PAS committée (Kronos ne dump que l'agrégat par fold `avg_direction_accuracy` par seed ; M15 dump `fold_results` mais Kronos non). Le vrai DM reste un résiduel **multi-cycle** (re-run dumper les prévisions par fenêtre walk-forward, fenêtres alignées).
+- Ce test apparié par (config, seed) est la comparaison cross-rung la plus forte **disponible depuis les edges par seed committés — sans re-run**.
+
+## Références
+
+- Seed-level one-sample (par rung vs majority) : [`kronos_zeroshot/seed_significance_verdict.md`](../kronos_zeroshot/seed_significance_verdict.md) (c.902) · [`m15_lstm_etf/seed_significance_verdict.md`](../m15_lstm_etf/seed_significance_verdict.md) (c.904).
+- C893-L : gate cross-seed inopérant pour zero-shot déterministes (Chronos std_edge=0).
+- C897-L : Kronos/M15 stochastiques → std_edge>0 → VRAI test (et vraie variance appariée ici).
+- Spin-out : #8607. Epic parent : #1409 (capability-core, alpha = politiques d'action L4-DT).

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_paired_rung_comparison.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_paired_rung_comparison.py
@@ -1,0 +1,186 @@
+"""Tests for paired_rung_comparison.py -- paired cross-rung edge comparison.
+
+CPU-only unit tests on the per-seed extractors, the paired statistical battery
+(analytically known t-stats), and the deterministic-vs-perseed alignment. The
+real Kronos<->M15 verdict is proven by the committed paired_comparison.json,
+not by these tests.
+"""
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from paired_rung_comparison import (  # noqa: E402
+    _chronos_per_config,
+    _kronos_per_seed,
+    _m15_per_seed,
+    compare,
+    extract_per_seed,
+    paired_battery,
+    render_md,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic minimal docs (same shapes as the real results.json)
+# ---------------------------------------------------------------------------
+
+def _kronos_doc(edges_by_seed):
+    """edges_by_seed: {(sym, h, seed): edge}. majority fixed at 0.55."""
+    sweep = []
+    for (sym, h), seed_edges in edges_by_seed.items():
+        sr = [{"seed": sd, "edge_vs_majority": e, "avg_direction_accuracy": 0.55 + e,
+               "majority_baseline": 0.55} for sd, e in seed_edges.items()]
+        sweep.append({"symbol": sym, "pred_len": h, "majority_baseline":
+                      {"majority_class_accuracy": 0.55}, "seed_results": sr})
+    return {"model": "NeoQuasar/Kronos-base", "sweep": sweep}
+
+
+def _m15_doc(edges_by_combo):
+    """edges_by_combo: {(sym, h, seed): edge}."""
+    combos = []
+    for (sym, h, seed), e in edges_by_combo.items():
+        combos.append({"symbol": sym, "horizon": h, "seed": seed,
+                       "direction_accuracy": 0.55 + e,
+                       "majority_baseline": {"majority_class_accuracy": 0.55},
+                       "edge_vs_majority": e})
+    return {"model": "Log-LSTM ETF-direction (M15)", "combos": combos,
+            "summary": []}
+
+
+def _chronos_doc(edges_by_cfg):
+    """edges_by_cfg: {(sym, h): edge}."""
+    sweep = [{"symbol": sym, "pred_len": h, "diracc": 0.55 + e,
+              "majority": 0.55, "edge": e, "mean_edge": e, "std_edge": 0.0}
+             for (sym, h), e in edges_by_cfg.items()]
+    return {"model": "amazon/chronos-bolt-base", "sweep": sweep}
+
+
+class TestExtractPerSeed:
+    def test_kronos_extracts_all_seeds(self):
+        doc = _kronos_doc({("SPY", 24): {0: -0.01, 1: -0.02, 99: -0.03}})
+        edges, name, det = extract_per_seed(doc)
+        assert name == "Kronos" and det is False
+        assert edges[("SPY", 24, 0)] == pytest.approx(-0.01)
+        assert edges[("SPY", 24, 99)] == pytest.approx(-0.03)
+        assert len(edges) == 3
+
+    def test_m15_extracts_per_combo(self):
+        doc = _m15_doc({("GLD", 66, 7): -0.03, ("TLT", 132, 0): -0.01})
+        edges, name, det = extract_per_seed(doc)
+        assert name == "M15" and det is False
+        assert edges[("GLD", 66, 7)] == pytest.approx(-0.03)
+        assert len(edges) == 2
+
+    def test_chronos_deterministic_flag(self):
+        doc = _chronos_doc({("SPY", 24): -0.05})
+        edges, name, det = extract_per_seed(doc)
+        assert name == "Chronos-Bolt" and det is True
+        # Chronos key has seed=None (deterministic, single value per config)
+        assert edges[("SPY", 24, None)] == pytest.approx(-0.05)
+
+    def test_m15_fallback_diracc_minus_majority(self):
+        # If edge_vs_majority is missing, fall back to direction_accuracy - majority.
+        combos = [{"symbol": "SPY", "horizon": 24, "seed": 0,
+                   "direction_accuracy": 0.50,
+                   "majority_baseline": {"majority_class_accuracy": 0.55}}]
+        edges = _m15_per_seed(combos)
+        assert edges[("SPY", 24, 0)] == pytest.approx(0.50 - 0.55)
+
+    def test_kronos_fallback_diracc_minus_majority(self):
+        sweep = [{"symbol": "SPY", "pred_len": 24,
+                  "majority_baseline": {"majority_class_accuracy": 0.55},
+                  "seed_results": [{"seed": 0, "avg_direction_accuracy": 0.50}]}]
+        edges = _kronos_per_seed(sweep)
+        assert edges[("SPY", 24, 0)] == pytest.approx(0.50 - 0.55)
+
+
+class TestPairedBattery:
+    def test_known_t_stat(self):
+        # diffs with known mean/std -> analytic t-stat.
+        # mean=0.02, and chosen so std gives a round t. Use a simple series.
+        diffs = np.array([0.02, 0.02, 0.02, 0.02, 0.02])  # std=0 -> t=inf
+        out = paired_battery(diffs)
+        assert out["n_pairs"] == 5
+        assert math.isinf(out["t_stat"]) or abs(out["t_stat"]) > 1e6
+        assert out["t_p_value"] == pytest.approx(0.0)
+
+    def test_zero_diff_not_significant(self):
+        diffs = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        out = paired_battery(diffs)
+        assert out["significant_at_alpha"] is False
+        assert out["mean_diff"] == 0.0
+
+    def test_symmetric_diff_zero_mean(self):
+        # +x and -x balanced -> mean 0 -> not significant.
+        diffs = np.array([0.05, -0.05, 0.03, -0.03, 0.04, -0.04, 0.02, -0.02])
+        out = paired_battery(diffs)
+        assert abs(out["mean_diff"]) < 1e-9
+        assert out["significant_at_alpha"] is False
+        assert out["sign_n_pos"] == 4 and out["sign_n_neg"] == 4
+
+    def test_clearly_different_is_significant(self):
+        # All diffs positive, large vs std -> significant, B better than A.
+        diffs = np.array([0.1, 0.12, 0.09, 0.11, 0.13, 0.10, 0.08, 0.12])
+        out = paired_battery(diffs)
+        assert out["significant_at_alpha"] is True
+        assert "B better" in out["direction"]
+        assert out["ci95_low"] > 0  # CI excludes 0
+
+    def test_ci_straddles_zero(self):
+        diffs = np.array([0.05, -0.05, 0.04, -0.04, 0.06, -0.06])
+        out = paired_battery(diffs)
+        assert out["ci95_low"] < 0 < out["ci95_high"]
+
+    def test_n_below_2(self):
+        out = paired_battery(np.array([0.1]))
+        assert "n<2" in out["verdict"]
+        assert out["significant_at_alpha"] is False
+
+
+class TestCompare:
+    def test_kronos_vs_m15_full_alignment(self):
+        seeds = {0: -0.03, 1: -0.035, 7: -0.04}
+        kronos = _kronos_doc({("SPY", 24): seeds, ("GLD", 66): seeds})
+        m15 = _m15_doc({("SPY", 24, s): e for s, e in seeds.items()})
+        # Add GLD to M15 too for full alignment (2 configs x 3 seeds = 6 pairs)
+        m15["combos"].extend([{"symbol": "GLD", "horizon": 66, "seed": s,
+                               "direction_accuracy": 0.55 + e + 0.001,
+                               "majority_baseline": {"majority_class_accuracy": 0.55},
+                               "edge_vs_majority": e + 0.001} for s, e in seeds.items()])
+        out = compare(kronos, m15)
+        assert out["rung_a"] == "Kronos" and out["rung_b"] == "M15"
+        assert out["n_common_keys"] == 6  # 2 configs x 3 seeds
+        # Only GLD has the +0.001 offset (3 pairs); SPY diffs are 0 (3 pairs).
+        # mean diff = (0*3 + 0.001*3) / 6 = 0.0005
+        assert out["battery"]["mean_diff"] == pytest.approx(0.0005, abs=1e-9)
+
+    def test_deterministic_vs_perseed_pairs_each_seed(self):
+        chronos = _chronos_doc({("SPY", 24): -0.05})
+        kronos = _kronos_doc({("SPY", 24): {0: -0.02, 1: -0.03, 7: -0.01}})
+        out = compare(chronos, kronos)  # A=deterministic, B=per-seed
+        assert out["rung_a_deterministic"] is True
+        # 3 pairs: each Kronos seed paired against the Chronos constant -0.05.
+        assert out["n_common_keys"] == 3
+        assert out["battery"]["mean_diff"] == pytest.approx(np.mean([-0.02, -0.03, -0.01]) - (-0.05))
+
+    def test_no_common_keys(self):
+        kronos = _kronos_doc({("SPY", 24): {0: -0.01}})
+        m15 = _m15_doc({("TLT", 66, 0): -0.02})  # disjoint
+        out = compare(kronos, m15)
+        assert out["n_common_keys"] == 0
+        assert out["battery"]["n_pairs"] == 0
+
+    def test_render_md_contains_verdict(self):
+        kronos = _kronos_doc({("SPY", 24): {0: -0.01, 1: -0.02}})
+        m15 = _m15_doc({("SPY", 24, 0): -0.01, ("SPY", 24, 1): -0.02})
+        out = compare(kronos, m15)
+        md = render_md(out)
+        assert "Paired cross-rung comparison" in md
+        assert "verdict" in md
+        assert "Kronos" in md and "M15" in md


### PR DESCRIPTION
Grain: DEEP/training-foundation — lane myia-po-2024:CoursIA-2 — prev: DEEP/training-foundation (c.904 M15 seed-sig #8629).

## Summary

Answers the **#8607 follow-up** to `seed_significance.py` (c.902, PR #8626): that module asked *per rung* "is this model significantly below majority?" (one-sample t-test on per-seed edge, n=5). All 3 rungs are individually NO BEATS (Chronos degenerate, Kronos 6/9 SIG-negative, M15 9/9 SIG-negative).

This PR asks the **next** question: **are two rungs significantly different FROM EACH OTHER?** A zero-shot model (Kronos) and a fine-tuned model (M15) both fail to beat majority — but does fine-tuning change the directional edge relative to zero-shot?

**New module** `scripts/paired_rung_comparison.py`: paired t-test + Wilcoxon signed-rank + sign (binomial) + CI95% on the per-`(symbol, horizon, seed)` edges aligned across two rungs, auto-detecting the Kronos/Chronos/M15 `results.json` formats (distinct from `seed_significance.auto_extract`, which aggregates by config and loses seed identity).

## Result — 3 pairwise comparisons, ALL non-significant

| Comparison (A vs B) | n pairs | mean diff (B−A) | CI95% | paired t (df) | t p | verdict |
|---------------------|--------|-----------------|-------|---------------|-----|---------|
| **Kronos vs M15** | 45 | −0.00047 | [−0.009, +0.008] | −0.112 (44) | **0.91** | **not sig.** |
| Chronos vs Kronos | 35 | −0.00200 | [−0.015, +0.011] | −0.318 (34) | 0.75 | not sig. |
| Chronos vs M15 | 35 | −0.00018 | [−0.010, +0.009] | −0.039 (34) | 0.97 | not sig. |

The 3 foundation paradigms — **zero-shot language-TS** (Chronos-Bolt), **zero-shot OHLCV AR** (Kronos), **fine-tuned LSTM direction** (M15) — produce **statistically indistinguishable** directional edges on the ETF basket (SPY/TLT/GLD), all around −0.03 (reliably below majority).

## Finding clé — aucun paradigme de prévision n'en surpasse un autre

- **Kronos ↔ M15 (n=45, the clean one)**: the central comparison. Mean paired diff −0.00047 (M15 a hair more negative), CI95 straddles 0 broadly, t=−0.112 (p=0.91). Fine-tuning the LSTM **did not change** the directional edge relative to zero-shot Kronos.
- **Reinforce #1409** at a **second statistical level**: (1) each rung is SIG-negative vs majority (seed-level, c.902/c.904), AND (2) no rung beats another (paired cross-rung, this PR). The absence of directional edge is not an artefact of one paradigm — it is **robust across paradigms**. Alpha comes from **action policies** (L4-DT), not price-direction forecasting.

## Scope / residual (honest)

This is a paired-**by-(config, seed)** test on committed per-seed edges — **not** the full Diebold-Mariano test. DM is paired **by observation** (per-window forecast errors with HAC variance correction) and needs the per-window DirAcc series, which is NOT committed (Kronos dumps only the fold-aggregated `avg_direction_accuracy` per seed; M15 has `fold_results` but Kronos does not). The true DM remains a **multi-cycle residual** (re-run dumping per-window forecasts on aligned walk-forward windows). This paired test is the strongest cross-rung comparison available **from committed data, no re-run**.

## Validation

- `paired_rung_comparison.py` (339 lines) + `test_paired_rung_comparison.py` (186 lines).
- **30/30 tests pass** (`test_paired_rung_comparison.py` 15 + `test_seed_significance.py` 15, CPU 1.40s): per-seed extractors (Kronos/M15/Chronos + DirAcc-minus-majority fallback), paired battery (analytic t-stats, CI-straddles-0, clear-significance, n<2 guard, all-zero guard), deterministic-vs-per-seed alignment, full compare + render.
- py_compile OK. Env `coursia-ml-training` (numpy, scipy).
- catalog-pr-hygiene R1: catalogue byte-identical (0 catalog file touched). Atomic (1 subject: paired cross-rung comparison; 9 files +2242 = script + tests + 7 force-added rung artefacts under `scripts/results/cross_rung_paired/`).
- L898 collision guard: 0 PR in-flight on the paired/cross-rung/DM front (`gh pr list --search` → 0).
- Rebase frais sur `origin/main` (17ed036d3).

See #8607 (foundation spin-out, NOT Closes — DM by-observation multi-cycle residual). See #1409 (epic capability-core). See #8626 (seed_significance one-sample, c.902). See #8629 (M15 seed-sig, c.904).
