### PR TITLE
docs(infer,#8081): Infer-14 HMM canonical anchoring — Rabiner 3-problem framework + 7 citations

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb
@@ -350,6 +350,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c907rabiner",
+   "metadata": {},
+   "source": [
+    "> **Ancres savantes -- les trois problemes canoniques des HMM.** Rabiner (1989) structure toute la theorie des Hidden Markov Models autour de **trois problemes distincts**, que ce notebook aborde en pratique avec Infer.NET :\n",
+    ">\n",
+    "> | Probleme | Question | Algorithme canonique | Mise en oeuvre dans ce notebook |\n",
+    "> |----------|----------|----------------------|---------------------------------|\n",
+    "> | **1. Evaluation** | Quelle est la vraisemblance $P(x_{1:T} \\mid \\lambda)$ d'une sequence sous le modele ? | **Forward** (recursion avant, Baum & Petrie 1966) | Calculee par Infer.NET via le passage de messages sur le graphe factoriel |\n",
+    "> | **2. Decodage** | Quelle sequence d'etats caches $z_{1:T}$ explique le mieux les observations ? | **Viterbi** (programmation dynamique, Viterbi 1967) | Section 3.3 -- decode la sequence d'etats par Viterbi |\n",
+    "> | **3. Apprentissage** | Comment estimer les parametres $\\lambda = (\\pi, A, \\mu)$ depuis les donnees ? | **Baum-Welch** (EM sur les HMM, Baum & Petrie 1966 ; Dempster-Laird-Rubin 1977) | Infer.NET (EP, 50 iter.) + init K-means pour briser la symetrie (section 3.3) |\n",
+    ">\n",
+    "> **Pourquoi Infer.NET plutot que Forward-Backward / Baum-Welch \"a la main\" ?** Les algorithmes canoniques (Forward, Backward, Baum-Welch) sont des instances de **passage de messages** sur le graphe factoriel du HMM. Infer.NET construit ce graphe de facon declarative (`Variable.Array`, `ForEach`, `Switch`) et instancie automatiquement ce passage de messages -- **exact (Forward-Backward) pour les emissions conjuguees** (gaussiennes, section 3), **approche via Expectation Propagation (EP)** pour les modeles non conjugues. L'apport du *model-based machine learning* (Winn & Bishop, MBML) : on specifie le modele, la librairie produit l'inference, sans re-ecrire Baum-Welch pour chaque nouvelle structure (FHMM section 3.4, motif finding section 5).\n",
+    ">\n",
+    "> **References fondatrices** : Rabiner, L.R. (1989), *A Tutorial on Hidden Markov Models and Selected Applications in Speech Recognition*, Proceedings of the IEEE 77(2):257-286 (les trois problemes canoniques, Baum-Welch, tutorial de reference) ; Baum, L.E. & Petrie, T. (1966), *Statistical Inference for Probabilistic Functions of Finite State Markov Chains*, Annals of Mathematical Statistics 37(6):1554-1563 (Forward-Backward, base de Baum-Welch) ; Viterbi, A.J. (1967), *Error Bounds for Convolutional Codes and an Asymptotically Optimum Decoding Algorithm*, IEEE Transactions on Information Theory 13(2):260-269 (algorithme de Viterbi) ; Ghahramani, Z. (2001), *An Introduction to Hidden Markov Models and Bayesian Networks*, International Journal of Pattern Recognition and Artificial Intelligence 15(1):9-42 (cadre bayesien unifie, lien HMM / reseaux bayesiens) ; Ghahramani, Z. & Jordan, M.I. (1997), *Factorial Hidden Markov Models*, Machine Learning 29(2-3):245-273 (le FHMM de la section 3.4) ; Bailey, T.L. & Elkan, C. (1994), *Fitting a Mixture Model by Expectation Maximization to Discover Motifs in Biopolymers*, Proceedings ISMB 1994 (algorithme MEME, derriere le motif finding de la section 5) ; Winn, J. & Bishop, C.M. (2024), *Model-Based Machine Learning*, Chapman & Hall/CRC (l'approche modele-declaratif + EP d'Infer.NET).*\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "592f5eb5",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
Grain: MED/notebook-fidelity — lane myia-po-2024:CoursIA-2 — prev: DEEP/training-baseline (c.906 #8633 MERGED).

> **G-VAR-3 pivot honored.** c.904/905/906 were 3 training cycles on #8607. This cycle pivots to a DISTINCT family (Probas/Infer.NET notebook-fidelity, genre notebook-dotnet, NOT training). 5 non-training families verified clean firsthand this cycle before picking (DecInfer = 4 audit findings already fixed; Infer-11 saturated 10+ PRs; Infer-12 saturated; rl_4 excellent + Prong-B already done; all 21 GameTheory non-lean = N/N executed 0 gap). Infer-14 was the genuine residual: last Infer notebook without canonical anchoring.

## Summary

`Infer-14-Sequences.ipynb` taught HMM / FHMM / Viterbi / motif-finding but with **0 canonical citations** and **without naming Rabiner (1989)'s three canonical HMM problems** (evaluation/Forward, decoding/Viterbi, learning/Baum-Welch) — the organizing framework for all HMM literature.

**Firsthand verification (G.1, read source on origin/main)**:
- `trois problemes` = 0, `baum-welch` = 0, cite_markers = 0 in the notebook markdown.
- No citations PR in the notebook's history (PRs were accents / exercise-headers / renum / audit-#3164). Infer-2/4/6/8/11/12/13/15/16/17/18/19 each got a dedicated citations PR (#8230/#8307/#8331/etc.); **Infer-14 was the gap** — this completes the Infer-series citation/anchoring rollout.

## Change — one substantive "Ancres savantes" markdown cell after the introduction

- **Rabiner 3-problem framework table** mapping each notebook section to its canonical problem (1=Evaluation/Forward, 2=Decoding/Viterbi, 3=Apprentissage/Baum-Welch) — a missing canonical concept, now added.
- **Baum-Welch vs Infer.NET EP explanation**: Forward-Backward is exact for conjugate Gaussian emissions, EP approximates otherwise; the model-based ML point (Winn/Bishop) is that one specifies the model and the library produces the inference — no hand-rolled Baum-Welch per structure (FHMM, motif finding).
- **7 canonical citations**: Rabiner 1989 (tutorial + 3 problems), Baum & Petrie 1966 (Forward-Backward), Viterbi 1967 (decoding), Ghahramani 2001 (HMM/Bayesian nets intro), Ghahramani & Jordan 1997 (Factorial HMM §3.4), Bailey & Elkan 1994 (MEME, behind motif finding §5), Winn & Bishop MBML (Infer.NET declarative-model + EP).

## Validation

- **Markdown-only insertion** (C.3 exception: no re-exec needed for markdown-only).
- **Raw-JSON surgical** to preserve all 21 code cells' outputs/execution_counts (L772/L744: NotebookEdit can erase outputs; raw-JSON avoids it). Verified post-insert: 21/21 executed, 0 no_output.
- **nbformat VALID**, LF-only (CR count = 0), catalogue byte-identical (untouched).
- Atomic: 1 file, +18/-0 (pure insertion).
- L898 collision guard: 0 PR in-flight on Infer-14 HMM/citations.
- Rebase frais sur `origin/main` (`4d2d03c2e`, 0 behind — base post-#8633-merge).

## Doc-honesty of the added content

Each claim verified against the canonical source firsthand:
- Rabiner 1989 three problems (evaluation/decoding/learning) = canonical, correct.
- "EP exact for conjugate Gaussian emissions" = correct (EP reduces to Forward-Backward with conjugate Gaussian/Dirichlet updates, which is what Infer.NET runs on this notebook's Gaussian HMM).
- All citation venues/volumes/years checked (Rabiner Proc. IEEE 77(2); Ghahramani-Jordan ML 29(2-3); Viterbi IEEE TIT 13(2); etc.).

See #8081 (Infer.NET+PyMC distillation audit authority). See #3801 (SOTA + non-trivial).
