### PR TITLE
chore(twin-parity,#8057): rebaseline Probas-14 Sequences after #8635

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/probas-14-sequences.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-14-sequences.yaml
@@ -4,10 +4,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-24'
-    by: po-2023
+    date: "2026-07-27"
+    by: myia-ai-01:CoursIA
     python_sha: 765544fe8ac71c15305c2cb91f9b16909e86e1df
-    csharp_sha: 0615f621145fb72de2e690c6bb7ef79838b06b53
+    csharp_sha: 379aa78acb0ab84810670bf9b1b741b6a9c5ed95
   known_differences:
   - 'Socle pedagogique commun : modeles de sequences (chaines de Markov cachees / HMM) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
`Grain: LIGHT/ledger` — lane `myia-ai-01:CoursIA` — prev: `MED/tooling` (review #8637/#8635, c.26)

Consequence directe du merge de #8635 : rebaseline du `last_audit` de la paire jumelle `Probas-14 Sequences`, dont le cote C# vient de changer.

## Pourquoi cette PR existe

#8635 ajoute une cellule d'ancrage markdown a `Infer-14-Sequences.ipynb` (jumeau C#). Le registre de parite epingle un `csharp_sha` d'audit, qui ne correspond donc plus :

```
[DRIFT] Probas-14 Sequences (Probas/Infer.NET-PyMC, semantic)
       - C# a drift : 0615f621 -> 379aa78a
```

Le garde `--per-pair` a correctement fait echouer #8635 en `UNSTABLE` (check non requis). J'ai merge en connaissance de cause, ce qui a laisse `main` en `OK=115 DRIFT=1` — cette PR ferme ce trou.

## Pourquoi c'est moi qui l'atteste, pas l'auteur de #8635

Rebaseliner `last_audit`, c'est attester avoir **re-audite la paire firsthand**. Le body de #8635 n'affirme pas avoir lu le jumeau Python ; je l'ai lu pour trancher le check, et j'ai constate que `PyMC-14-Sequences.ipynb` porte deja son appareil de citations — cellule [4] (bloc d'ancrage) et cellule [38] (bibliographie), avec Baum & Petrie 1966, Baum 1970, Dempster 1977, Viterbi 1967, Rabiner 1989.

Le cote C# etait donc le seul des deux sans ancrage : **#8635 supprime une asymetrie, il n'en cree pas.** La parite semantique tient, et le `by:` porte mon nom parce que c'est mon audit — pas celui de po-2024 signe de son nom.

## Verification

```
avant : 116 paire(s) | OK=115 DRIFT=1 MISSING=0
apres : 116 paire(s) | OK=116 DRIFT=0 MISSING=0
```

Ecriture chirurgicale par l'outil (`--update --pair 'Probas-14 Sequences' --by 'myia-ai-01:CoursIA'`) : 4 lignes, la seule paire ciblee, `known_differences` et commentaires preserves. Pas de `--yes-all-pairs`, donc aucun risque de masquer un drift legitime ailleurs (#8508, L963/L974).

Atomique : 1 fichier. Catalogue non touche.

See #8057 (registre de parite des jumeaux). See #8081 (rollout d'ancrage canonique Infer).
