### PR TITLE
feat(twin-register,#8641): register Search/Part1 7 pairs T1 — CI guard no longer blind (123 pairs, DRIFT=0)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/search-10-symbolicautomata.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-10-symbolicautomata.yaml
@@ -1,0 +1,15 @@
+- name: "Search-10 SymbolicAutomata"
+  family: Search/Part1-Foundations
+  python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata-Csharp.ipynb
+  parity_level: surface
+  last_audit:
+    date: "2026-07-27"
+    by: po-2024
+    python_sha: dfb97d3c84b778e5d00d30d897fb8dcaebf32353
+    csharp_sha: fd623c2d84b2a6c4b7008519abbca9f0bb6237a2
+  known_differences:
+    - "AVERTISSEMENT DE PERIMETRE : le jumeau C# est explicitement un twin PARTIEL -- son titre porte '(tranche 1)' et sa conclusion s'intitule 'Bilan (tranches 1 + 2)'. parity_level=surface (pas semantic) car la couverture C# est incomplete vs Python."
+    - "Asymetrie de couverture forte : Python (91 cellules, 24 code) couvre §1-9 (automates finis avec automata-lib, automates symboliques avec Z3, verification de proprietes, lien Sudoku, Automata.Net) ; C# (39 cellules, 14 code) couvre §1-4 uniquement (automates finis a la main, automates symboliques avec Microsoft.Z3). Les sections 'verification de proprietes', 'lien Sudoku', 'Automata.Net' sont absentes du C#."
+    - "Bibliotheque DFA/NFA : Python invoque `automata-lib` (librairie mature) ; C# implemente les classes DFA/NFA a la main (valeur pedagogique : montrer la structure). Les deux cotes utilisent un vrai solveur SOTA pour la partie symbolique (Z3 / Microsoft.Z3 NuGet 4.12.2)."
+    - "Parite réelle limitée au coeur conceptuel (automates finis + symboliques Z3) -- les domaines avances (verification, Sudoku, Automata.Net) restent a porter en tranche 2+."

--- a/scripts/notebook_tools/twin_pairs.d/search-11-metaheuristics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-11-metaheuristics.yaml
@@ -1,0 +1,15 @@
+- name: "Search-11 Metaheuristics"
+  family: Search/Part1-Foundations
+  python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-27"
+    by: po-2024
+    python_sha: 9b8a7c5a644278888f991ab10ac8e87bd7ec6238
+    csharp_sha: 9de0aa08582035e96886cbada255c5ce9a7ceb3c
+  known_differences:
+    - "Socle commun : metaheuristiques d'optimisation (PSO Particle Swarm, SA Simulated Annealing), fonctions de benchmark, benchmark comparatif, analyse de parametres, exemple guide."
+    - "Bibliotheque vs from-scratch : Python invoque MEALPy (librairie metaheuristique, 40+ algorithmes) pour PSO/ABC/SA/BRO ; C# implemente PSO/SA/GA from-scratch (System.Random, pas de NuGet metaheuristique)."
+    - "Asymetrie de couverture algorithmique : Python couvre PSO + ABC (Artificial Bee Colony) + SA + BRO (Brownian) via MEALPy ; C# couvre PSO + SA + GA (Genetic Algorithm) + un exemple TSP (recuit simule). GA et TSP sont propres au C# ; ABC et BRO sont propres au Python."
+    - "Stochasticite : les deux cotes sont sedeables mais non deterministes (optimisation stochastique) -- parite conceptuelle (meme famille d'algorithmes, memes fonctions de benchmark), pas bitwise."

--- a/scripts/notebook_tools/twin_pairs.d/search-15-networkx.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-15-networkx.yaml
@@ -1,0 +1,15 @@
+- name: "Search-15 NetworkX"
+  family: Search/Part1-Foundations
+  python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX-Csharp.ipynb
+  parity_level: surface
+  last_audit:
+    date: "2026-07-27"
+    by: po-2024
+    python_sha: 0b4c12b4d9133ea693d82775f7a8a06a5b1d511d
+    csharp_sha: 8bb63a9acc5195d1ec87cf70d8f80b27a411796c
+  known_differences:
+    - "Bibliotheque vs from-scratch : Python invoque NetworkX (librairie mature, algorithmes de graphes prets a l'emploi : plus courts chemins, centralites, flot max, Louvain, matching) ; C# implemente les algorithmes from-scratch sur une adjacency list maison (BFS, DFS, Dijkstra, Ford-Fulkerson). parity_level=surface (meme plan pedagogique, implementations independantes)."
+    - "Asymetrie de couverture : Python (42 cellules, 21 code) couvre §1-10 (construction, visualisation matplotlib, plus courts chemins, centralites, flot maximum, detection de communautes Louvain, matching pondere, Prong-B #3801) ; C# (20 cellules, 9 code) couvre §1-6 (graphe pondere, BFS/DFS, Dijkstra, centralites, flot maximum Ford-Fulkerson, visualisation ASCII). Louvain, matching pondere et Prong-B sont absents du C#."
+    - "Visualisation : Python = matplotlib (rendu graphique du reseau) ; C# = visualisation ASCII du graphe (sortie textuelle)."
+    - "Parite réelle : memes concepts fondamentaux (parcours, plus courts chemins, centralites, flot max) ; C# valorise la reimplementation pedagogique la ou Python valorise l'invocation de la lib SOTA."

--- a/scripts/notebook_tools/twin_pairs.d/search-6-adversarialsearch.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-6-adversarialsearch.yaml
@@ -1,0 +1,15 @@
+- name: "Search-6 AdversarialSearch"
+  family: Search/Part1-Foundations
+  python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-27"
+    by: po-2024
+    python_sha: 8608b6f46014d1b18984265609f1b1e3e741eb39
+    csharp_sha: 0d5371ae6b7236a387e89ed008909d0953212da4
+  known_differences:
+    - "Socle commun : jeux a somme nulle a information parfaite (Tic-Tac-Toe/Morpion), minimax, elagage alpha-beta, iterative deepening, tables de transposition."
+    - "Asymetrie de couverture : le jumeau Python (44 cellules, 16 code) inclut une section benchmark comparatif detaillee + visualisation matplotlib du Tic-Tac-Toe ; le jumeau C# (23 cellules, 10 code) est plus court, sortie textuelle des traces (pas de matplotlib)."
+    - "Idiomes framework : Python = numpy/matplotlib pour les benchmarks et la visualisation ; C# = implementation from-scratch (System.Collections.Generic, pas de NuGet graphique)."
+    - "Les deux cotes restent from-scratch sur le coeur algorithmique (minimax, alpha-beta, transposition) -- pas de solveur tiers invoque."

--- a/scripts/notebook_tools/twin_pairs.d/search-7-mcts-and-beyond.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-7-mcts-and-beyond.yaml
@@ -1,0 +1,15 @@
+- name: "Search-7 MCTS-And-Beyond"
+  family: Search/Part1-Foundations
+  python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-27"
+    by: po-2024
+    python_sha: 582680ddc89dc6fb61e49ee717868b30cb4b413f
+    csharp_sha: 01d1bdcd8d02769a4f7ad3d3fd1fe6f71bf698a3
+  known_differences:
+    - "Socle commun : limites de minimax, algorithme MCTS (selection/expansion/simulation/retropropagation), test sur Tic-Tac-Toe, comparaison MCTS vs minimax, framework OpenSpiel, AlphaGo/AlphaZero, extensions avancees. Structure des sections quasi-identique (le jumeau le plus proche cellule-a-cellule de la famille)."
+    - "Idiomes RNG : Python = module `random` (PRNG Mersenne Twister) ; C# = `new Random()` (PRNG .NET). Les deux sont sedees mais les suites different -- les statistiques MCTS (taux de victoire) fluctuent d'un run a l'autre, parite conceptuelle pas bitwise."
+    - "Visualisation : Python = matplotlib pour les comparatifs MCTS vs minimax ; C# = traces textuels (le terme 'matplotlib' n'apparait qu'en prose de comparaison, pas en import)."
+    - "Section OpenSpiel : les deux cotes presentent le framework OpenSpiel (Google DeepMind) en prose ; aucun des deux n'invoque la librairie OpenSpiel directement (concept pedagogique, pas appel de service)."

--- a/scripts/notebook_tools/twin_pairs.d/search-8-dancinglinks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-8-dancinglinks.yaml
@@ -1,0 +1,15 @@
+- name: "Search-8 DancingLinks"
+  family: Search/Part1-Foundations
+  python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-27"
+    by: po-2024
+    python_sha: 9fe64f2e2bccf773fc0293f1ae3f82fe09cfb544
+    csharp_sha: b1a44f1710ef8dd954dfbe5f4cd5405295bc8598
+  known_differences:
+    - "Socle commun : probleme de couverture exacte, algorithme X de Knuth, structure de donnees Dancing Links (DLX), implementation DLX, application polyominos, comparaison de performances DLX vs backtracking."
+    - "Asymetrie de couverture : le jumeau Python (60 cellules, 21 code) couvre 3 applications (Sudoku solver, Pavage de polyominos, Pentominoes) + visualisation matplotlib ; le jumeau C# (22 cellules, 10 code) couvre uniquement le pavage de polyominos (Sudoku et Pentominoes absents), pas de matplotlib."
+    - "Implementation DLX : les deux cotes codent la structure de listes doublement chainees a la main (noeud avec L/R/U/D/C) -- c'est le coeur pedagogique, identique conceptuellement. Aucun solveur tiers."
+    - "Le jumeau C# est explicitement plus compact (tranche pedagogique focalisee sur DLX + polyominos) ; le jumeau Python est la version de reference complete."

--- a/scripts/notebook_tools/twin_pairs.d/search-9-linearprogramming.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-9-linearprogramming.yaml
@@ -1,0 +1,15 @@
+- name: "Search-9 LinearProgramming"
+  family: Search/Part1-Foundations
+  python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-27"
+    by: po-2024
+    python_sha: 290e11ed4aae0abf7fad8e60a69f5275ac2d586c
+    csharp_sha: 651843696c9ea76ee910a22ed3d7e569fe6d9325
+  known_differences:
+    - "Solveur SOTA distinct : Python = PuLP (interface declarative, solveur CBC par defaut) ; C# = Google.OrTools (GLOP simplexe pour PL continue, CBC pour PLNE). Les deux invoquent un vrai solveur industriel -- parite SOTA, pas reimplementation."
+    - "Asymetrie de couverture : le jumeau Python (47 cellules, 18 code) couvre §1-8 (intro, PuLP, formulation, Transport §4, sensibilite/dualite §5, PLNE §6, exemple guide multi-depots §7, resume §8) ; le jumeau C# (23 cellules, 9 code) couvre §1-6 (intro, OrTools production, diet formulation, sensibilite/dualite §4, PLNE sac a dos §5, Transport §6 ajoute par #8640/c.909). Le multi-depots §7 Python n'a pas d'equivalent C#."
+    - "Probleme de Transport : present des deux cotes (Python §4, C# §6) avec les MEMES donnees (3 usines x 4 magasins, equilibre 450=450, cout optimal 760 EUR) -- verifie firsthand c.909. GLOP renvoie un optimum degenere 5 routes vs 6 routes PuLP/CBC (memes 760 EUR, optima alternatifs, documente dans le notebook C#)."
+    - "Analyse de sensibilite : les deux exposent les shadow prices / valeurs duales (Python `prob.constraints[i].pi` ; C# `Constraint.DualValue()`)."


### PR DESCRIPTION
Grain: MED/twin-parity — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-dotnet (c.909 #8640 MERGED).

## Summary

The twin-parity registry (`scripts/notebook_tools/twin_pairs.d/`, #8057) was blind to **20 real C#/Python twin pairs** — so the CI guard `Twin parity audit (#8057)` passed green even when only one side of a pair changed. **#8640 (c.909, my own Search-9 Transport tranche) demonstrated exactly this**: the check went SUCCESS because the pair wasn't registered; the Python side never saw the new §6.

This PR registers **T1 — Search/Part1-Foundations (7 pairs)**: Search-6, 7, 8, 9, 10, 11, 15. The CI guard now catches drift on these 7 pairs. Search-1..5 were already registered (verified firsthand — see `git ls-tree`).

## This is NOT mechanical registration (why it's MED, not LIGHT)

Per the #8641 body: an entry is not just a pair of paths. `last_audit` attests a **firsthand read of both sides**, and `known_differences` documents the real asymmetries. For each of the 7 pairs I read both notebooks (structure, cell counts, libraries, section headers) and determined:

- **parity_level** — `semantic` (same math/concept, idiomatic API) vs `surface` (same plan, independent implementations / partial coverage).
- **known_differences** — concrete, verified asymmetries (solver swap, coverage gaps, RNG idiom, viz medium), not assumed.

Two pairs are flagged `parity_level: surface` with an explicit coverage warning:
- **Search-10 SymbolicAutomata**: the C# twin is explicitly **partial** (title carries "(tranche 1)", conclusion "Bilan (tranches 1 + 2)") — covers §1-4 only, the verification/Sudoku/Automata.Net sections are absent.
- **Search-15 NetworkX**: Python invokes the NetworkX lib; C# reimplements BFS/DFS/Dijkstra/Ford-Fulkerson from-scratch on a hand-rolled adjacency list. Same plan, independent implementations.

## Firsthand audit highlights (per pair)

| Pair | Parity | Key difference (firsthand) |
|---|---|---|
| Search-6 AdversarialSearch | semantic | Py (44 cells) has benchmark section + matplotlib viz; C# (23) is thinner, text output. Both from-scratch minimax/alpha-beta. |
| Search-7 MCTS | semantic | Near-identical section structure (closest cell-to-cell twin). RNG: `random` vs `new Random()` — seeded but non-bitwise (MCTS stats fluctuate). |
| Search-8 DancingLinks | semantic | Py covers 3 apps (Sudoku + Polyominos + Pentominoes); C# covers only Polyominos. DLX hand-coded both sides. |
| Search-9 LinearProgramming | semantic | PuLP/CBC vs Google.OrTools GLOP/CBC. Transport present both sides (same 760€ — verified c.909). Multi-depots §7 Py-only. |
| Search-10 SymbolicAutomata | **surface** | C# is a **partial "tranche 1" twin** (§1-4 only). automata-lib vs hand-rolled DFA/NFA. |
| Search-11 Metaheuristics | semantic | Py = MEALPy lib (PSO/ABC/SA/BRO); C# = from-scratch (PSO/SA/GA + TSP). Different algo coverage. |
| Search-15 NetworkX | **surface** | Py = NetworkX lib (Louvain/matching/Prong-B); C# = from-scratch adjacency list (BFS/DFS/Dijkstra/Ford-Fulkerson, ASCII viz). |

## Validation

- **`check_twin_parity.py`**: Total **123 pairs | OK=123 | DRIFT=0 | MISSING=0** (was 116; +7). The guard now sees all 7 pairs.
- **git blob SHAs** via `git rev-parse HEAD:<path>` (not content hashes — per #8641 body), audited at `af997e09a` (origin/main). DRIFT=0 confirms SHA-audited == SHA-current.
- **LF-only (0 CR)** on all 7 files; format matches `search-1-statespace.yaml` (file-per-entry #8586).
- **Atomic**: 7 new YAML files, +0/-0 (pure additions, no notebook touched, no existing entry modified).
- **Catalogue** `COURSE_CATALOG.generated.{json,md}` **byte-identical to main**.
- L898 collision guard: 0 open PR on #8641 / twin-register tranches. Rebase frais sur `origin/main` (`af997e09a`, 0 behind).

## Scope / residual

This is **T1 of 4 tranches** in #8641. Remaining (independent, partitionable across lanes):
- **T2** SymbolicAI/SymbolicLearning (8 pairs — biggest asymmetry expected).
- **T3** Search/Part2-CSP (3 pairs).
- **T4** GameTheory (2 pairs).

`See #8641` (partial — T1 only; issue stays open for T2/T3/T4). See #8057 (registry infrastructure, delivered). See #4956 (twin .NET⇄Python marathon).
