### PR TITLE
fix(notebook-tools,#8634): keep the content gate alive past Pillow 14

### DIFF
--- a/scripts/notebook_tools/detect_blank_figures.py
+++ b/scripts/notebook_tools/detect_blank_figures.py
@@ -133,6 +133,19 @@ def _png_dimensions(raw: bytes) -> tuple[int, int] | None:
     return (width, height)
 
 
+def _flattened_pixels(im):
+    """Return the flat pixel sequence of a PIL image, across Pillow versions.
+
+    `Image.getdata()` is deprecated since Pillow 12 and REMOVED in Pillow 14
+    (2027-10-15) in favour of `get_flattened_data()`. Both return the same
+    sequence for an RGB image (verified). Calling the deprecated name is not a
+    cosmetic warning here: see `_has_real_content` below for why it would
+    silently disable the content gate.
+    """
+    getter = getattr(im, "get_flattened_data", None) or im.getdata
+    return getter()
+
+
 def _has_real_content(raw: bytes, min_colors: int = MIN_DISTINCT_COLORS) -> bool | None:
     """Return True if the image carries enough distinct colors to be a real figure.
 
@@ -141,13 +154,22 @@ def _has_real_content(raw: bytes, min_colors: int = MIN_DISTINCT_COLORS) -> bool
     decoded -- in which case the caller keeps the size-based behaviour (no
     coverage regression, #6891). PIL is a repo dependency (Image notebooks) but
     the detector must remain functional without it.
+
+    The `None` fallback is deliberate but load-bearing, and that makes the Pillow
+    API surface a correctness concern rather than a lint one: anything raising in
+    here degrades to `None`, i.e. back to the size-only rule that #8634 was filed
+    to fix. Under `python -W error::DeprecationWarning` -- how a CI run pins
+    warnings -- a deprecated call raises, is swallowed, and the pixel-art of
+    #8634 is flagged again with no error and no failing test. Hence
+    `_flattened_pixels`: the supported API is called on the nominal path, so the
+    gate cannot revert by warning.
     """
     try:
         from PIL import Image
         import io
 
         im = Image.open(io.BytesIO(raw)).convert("RGB")
-        return len(set(im.getdata())) >= min_colors
+        return len(set(_flattened_pixels(im))) >= min_colors
     except Exception:
         return None
 

--- a/scripts/notebook_tools/tests/test_detect_blank_figures.py
+++ b/scripts/notebook_tools/tests/test_detect_blank_figures.py
@@ -48,6 +48,7 @@ from detect_blank_figures import (  # noqa: E402
     _PNG_SIGNATURE,
     _classify_image,
     _decode_image,
+    _flattened_pixels,
     _has_real_content,
     detect_cell,
     _human_report,
@@ -769,3 +770,50 @@ class TestContentGate:
         nb_path = _write_nb(tmp_path / "mono.ipynb", [_code_cell_with_png(mono_b64)])
         result = scan_notebook(nb_path)
         assert len(result["hits"]) == 1
+
+
+class TestContentGateSurvivesDeprecation:
+    """The content gate must not revert to size-only because of a Pillow warning.
+
+    `_has_real_content` swallows every exception into `None`, and `None` means
+    "fall back to the size rule" -- the very rule #8634 was filed against. So any
+    call that can *raise* on the nominal path silently undoes #8637. Pillow 12
+    deprecated `Image.getdata()` and removes it in Pillow 14 (2027-10-15): under
+    a warnings-as-errors run the deprecation raises, is swallowed, and the
+    pixel-art of #8634 is flagged again -- with no error and no failing test.
+
+    These tests pin the nominal path as warning-free, so the regression surfaces
+    here rather than in a scan verdict two years from now.
+    """
+
+    def test_content_gate_is_warning_free(self):
+        # The happy path must not emit ANY warning: one turned into an error by
+        # `-W error` would be swallowed into None and silently disable the gate.
+        import warnings
+
+        raw = base64.b64decode(PNG_PIXELART_B64)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert _has_real_content(raw) is True
+
+    def test_pixelart_stays_free_under_warnings_as_errors(self):
+        # End-to-end guard: this is what regresses on Pillow 14 if the deprecated
+        # API is called -- the pixel-art gets flagged tiny_payload again.
+        import warnings
+
+        raw = base64.b64decode(PNG_PIXELART_B64)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert _classify_image("image/png", raw, MIN_DIM, MIN_BYTES) is None
+
+    def test_uses_supported_pillow_api_when_available(self):
+        # Prefer get_flattened_data(); fall back to getdata() on older Pillow.
+        pytest.importorskip("PIL")
+        from PIL import Image
+
+        im = Image.new("RGB", (2, 2))
+        im.putdata([(0, 0, 0), (1, 1, 1), (2, 2, 2), (3, 3, 3)])
+        if hasattr(im, "get_flattened_data"):
+            assert list(_flattened_pixels(im)) == list(im.get_flattened_data())
+        else:  # Pillow < 12: the legacy name is the only one available
+            assert len(list(_flattened_pixels(im))) == 4


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/twin-parity (c.26 #8639).

## Résumé

`_has_real_content()` — la porte de sortie par contenu ajoutée par #8637 pour corriger le faux positif pixel-art de #8634 — appelle `Image.getdata()`, **déprécié depuis Pillow 12 et supprimé dans Pillow 14 (2027-10-15)**.

Ce n'est pas un avertissement cosmétique, parce que la fonction avale toute exception dans `return None` et que `None` signifie « retomber sur la règle de taille » — c'est-à-dire exactement la règle contre laquelle #8634 a été ouverte. Le jour où l'API disparaît, la porte de sortie se désarme **silencieusement** : pas d'erreur, pas de test rouge, et le pixel-art de #8634 redevient `tiny_payload`.

Le fusible a une date. Cette PR le désamorce et pose le test qui l'aurait vu.

## Démonstration firsthand (sur `main`, avant cette PR)

Les avertissements-en-erreurs sont la façon dont une CI épingle ce genre de dérive. Sur `main` :

```
$ python -m pytest scripts/notebook_tools/tests/test_detect_blank_figures.py -q -W error::DeprecationWarning
FAILED ...::TestContentGate::test_has_real_content_true_for_multicolor
FAILED ...::TestContentGate::test_has_real_content_false_for_monochrome
FAILED ...::TestContentGate::test_has_real_content_respects_custom_threshold
FAILED ...::TestContentGate::test_pixelart_not_flagged_on_tiny_payload
FAILED ...::TestContentGate::test_scan_notebook_frees_pixelart
5 failed, 66 passed
```

Les 5 échecs sont précisément les tests qui traversent le chemin nominal de `_has_real_content`. Le mode de défaillance est celui annoncé : la dépréciation lève, `except Exception` l'avale, la fonction renvoie `None`, la porte se referme et le pixel-art est de nouveau flaggé (`test_pixelart_not_flagged_on_tiny_payload`, `test_scan_notebook_frees_pixelart`). La suite normale, elle, passait à 71/71 — c'est ce qui rend la régression invisible.

Le message de Pillow est explicite sur l'échéance :

```
DeprecationWarning: Image.Image.getdata is deprecated and will be removed in
Pillow 14 (2027-10-15). Use get_flattened_data instead.
```

## Changement

`detect_blank_figures.py` (+24/−2) :

- Nouvel helper `_flattened_pixels(im)` : appelle `get_flattened_data()` quand il existe, retombe sur `getdata()` pour Pillow < 12. Équivalence vérifiée firsthand sur une image RGB décodée — même séquence, `list(get_flattened_data()) == list(getdata())` → `True`.
- `_has_real_content()` passe par cet helper. Sa docstring explique désormais **pourquoi** le choix d'API est une question de correction et non de lint : le repli `None` est délibéré mais porteur, donc tout ce qui peut lever sur le chemin nominal désarme la porte.

Aucun autre comportement ne bouge : `MIN_DIM`, `MIN_BYTES`, `MIN_DISTINCT_COLORS`, le repli taille sur image indécodable et la couverture #6891 sont inchangés.

## Tests (+50)

Nouvelle classe `TestContentGateSurvivesDeprecation`, 3 cas :

- `test_content_gate_is_warning_free` — sous `warnings.simplefilter("error")`, le chemin nominal ne doit émettre **aucun** avertissement (un seul, transformé en erreur, suffit à désarmer la porte).
- `test_pixelart_stays_free_under_warnings_as_errors` — garde bout-en-bout : c'est ce cas précis qui régresse sur Pillow 14 si l'API dépréciée est appelée.
- `test_uses_supported_pillow_api_when_available` — l'helper préfère `get_flattened_data()` quand il existe, et reste fonctionnel sinon.

```
$ python -m pytest scripts/notebook_tools/tests/test_detect_blank_figures.py -q
74 passed in 0.59s

$ python -m pytest scripts/notebook_tools/tests/test_detect_blank_figures.py -q -W error::DeprecationWarning
74 passed in 0.57s          # <- 5 failed avant cette PR
```

Suite complète du répertoire : **3401 passed** (2 min 14, CPU).

## Non-régression du scan

Balayage repo-wide identique avant/après — `955 notebooks scannés, 0 figure dégénérée, 0 notebook affecté, rc=0`. Aucune figure libérée ni nouvellement flaggée : cette PR change la façon dont la porte survit, pas ce qu'elle laisse passer.

## Hygiène

`py_compile` OK · blobs LF-only (`CR=0` sur les deux fichiers, vérifié sur l'index, pas sur le working tree Windows) · catalogue intouché · aucun notebook touché (H.4 sans objet) · 2 fichiers, +74/−4, atomique · garde L898 : `gh pr list` — aucune PR en vol sur `detect_blank_figures` (#8637 mergée à 20:04Z, HEAD à jour).

## Ce que ça referme au passage

**#8634 est terminée.** #8637 a livré les 6 critères d'acceptation et je les ai revérifiés firsthand ce cycle (scan repo-wide `rc=0`, tests, delta des 4 figures libérées = les grilles de broderie 24×16). Elle est restée ouverte parce que la PR portait `See #8634` et non `Closes` : le `Closes` ci-dessous la ferme au merge, et le relevé de vérification est posté en commentaire sur l'issue.

Closes #8634

## Constat de côté, à ne pas absorber ici

En instrumentant le scan j'ai mesuré deux choses qui appellent leur propre grain, pas celui-ci :

1. **11 scanners de `notebook_tools/` redéclarent chacun leur `SKIP_DIRS`**, sans module partagé — et les jeux ont dérivé (union de 13 entrées ; `check_plotly_static_risk.py` n'en porte que 7 et ignore `archive`, `_archive`, `foundry-lib`, `worktrees`). Conséquence aujourd'hui latente (0 finding constaté dans ces arbres), mais deux scanners « verts » ne parlent pas du même périmètre.
2. **Les scanners marchent dans les arbres gitignorés** : 16 des 955 notebooks balayés ne sont pas suivis par git (dont `lean-workspace/` qui a produit le « 1 notebook illisible » de mon run — un JSON invalide dans un artefact local, non commité, donc pas un défaut du dépôt).

J'ouvre une issue dédiée pour le marcheur partagé plutôt que de l'empiler ici.

See #8637 (la porte de sortie que cette PR rend durable) · See #6891 (incident fondateur, couverture préservée) · See #3801 (EPIC SOTA axe-2).
