### PR TITLE
docs(probas,#8081): add canonical citations to PyMC-3 Factor-Graphs (MBML/Pearl/Kschischang-Bishop)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-3-Factor-Graphs.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-3-Factor-Graphs.ipynb
@@ -124,7 +124,9 @@
     "- Colonel Mustard avait un motif (P = 0.3)\n",
     "- Mrs. Peacock avait un motif (P = 0.1)\n",
     "\n",
-    "On decouvre que le **revolver appartient a Colonel Mustard**. Qui est le coupable ?"
+    "On decouvre que le **revolver appartient a Colonel Mustard**. Qui est le coupable ?\n",
+    "\n",
+    "> *Source.* Le « Murder Mystery » (M. Boddy, Miss Scarlet, Colonel Mustard, Mrs. Peacock) est l'exemple introductif phare du **chapitre 1** de Winn & Bishop, *Model-Based Machine Learning* (2019, [mbmlbook.com](https://www.mbmlbook.com)) — conçu pour faire émerger l'inférence bayésienne *via* un récit, sans équation, en révisant itérativement les *a priori* à chaque indice. Le notebook en reprend l'énoncé et le résout en PyMC (`pm.Categorical` + vraisemblance conditionnelle) ; le twin Infer.NET utilise `Variable.Discrete` + `Variable.If/Case` (voir [Infer-3](../Infer/Infer-3-Factor-Graphs.ipynb))."
    ]
   },
   {
@@ -394,7 +396,9 @@
    "source": [
     "## 2. Explaining Away\n",
     "\n",
-    "Le phenomene d'**explaining away** : quand on observe l'arme de Mustard, la probabilite que Scarlet soit coupable diminue, car l'observation \"explique\" le crime par Mustard."
+    "Le phenomene d'**explaining away** : quand on observe l'arme de Mustard, la probabilite que Scarlet soit coupable diminue, car l'observation \"explique\" le crime par Mustard.\n",
+    "\n",
+    "> *Référence.* Le mécanisme d'« explaining away » est propre aux structures en V (colliders) : deux causes partagent un effet commun, et observer l'effet les rend *compétitives*. Formalisé par Pearl (1988), *Probabilistic Reasoning in Intelligent Systems* (Morgan Kaufmann), §3.3 — c'est l'une des structures élémentaires de la propagation d'information dans un réseau bayésien (chaîne, fourche, collider)."
    ]
   },
   {
@@ -468,6 +472,9 @@
     "1. Le joueur choisit une porte (disons la porte 0)\n",
     "2. Monty ouvre une autre porte qui contient une chevre\n",
     "3. Le joueur doit-il garder son choix ou changer ?\n",
+    "\n",
+    "\n",
+    "> *Source.* Le paradoxe de Monty Hall a été popularisé par Marilyn vos Savant (*Parade Magazine*, 1990). Sa résolution bayésienne et la controverse qu'elle suscita sont analysées dans Gill (2011), *The Monty Hall Problem is not a Probability Puzzle* (Comptes Rendus Mathématique **349**(23-24):1325-1330) — il illustre comment le conditionnement sur l'information *que Monty a révélé une chèvre* (et non sur la porte ouverte elle-même) renverse l'intuition (P(gagner en changeant) = 2/3).\n",
     "\n",
     "### Infer.NET : `Variable.Case`\n",
     "```csharp\n",
@@ -792,6 +799,9 @@
     "- Chaque facteur encode une dépendance locale (prior, vraisemblance, transition)\n",
     "- Sur ces modèles discrets, PyMC resout l'inference par **echantillonnage MCMC** (CategoricalGibbsMetropolis) : une approximation Monte-Carlo du calcul exact qu'un **passage de messages** (sum-product) realiserait directement sur le graphe de facteurs quand celui-ci est un arbre\n",
     "- Les graphes de facteurs generalisent les reseaux bayesiens et les chaînes de Markov\n",
+    "\n",
+    "\n",
+    "> *Références.* Les graphes de facteurs et le passage de messages *sum-product* sont formalisés dans Kschischang, Frey & Loeliger (2001), *Factor Graphs and the Sum-Product Algorithm* (IEEE Transactions on Information Theory **47**(2):498-519), et exposés de référence dans Bishop (2006), *Pattern Recognition and Machine Learning* [PRML], §8.4. L'algorithme calcule les marginales *exactement* en temps fini sur un arbre de facteurs ; PyMC l'approche ici par échantillonnage MCMC (CategoricalGibbsMetropolis) — une approximation Monte-Carlo du même calcul, là où Infer.NET propage les messages analytiquement via Expectation Propagation (EP).\n",
     "\n",
     "---\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/probas-3-factor-graphs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-3-factor-graphs.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-25'
-    by: po-2024
-    python_sha: 9f0c7a44ffd98bfc97b6ef091ae28fe7d6802541
+    date: "2026-07-28"
+    by: myia-po-2024:CoursIA-2
+    python_sha: 3e358b91d925700d4ab743b74c7799a5f654d02c
     csharp_sha: f5158092a1488ec4a9a397bffe0f1ae02835f7c0
   known_differences:
   - 'Socle pedagogique commun : graphes de facteurs et variables aleatoires modelise dans les deux stacks.'


### PR DESCRIPTION
Grain: MED/notebook-fidelity — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-dotnet (c.913 #8648 OPEN).

## Summary

Adds **canonical citations** to `PyMC-3-Factor-Graphs.ipynb` (Murder Mystery / factor graphs). This is the **residual of the #8081 Probas citation-distillation rollout**: PyMC-15/16/17/18/19 were all anchored in prior cycles (PRs #8302/#8314/#8334/#8339 + Infer twins), but **PyMC-3 was the only early PyMC notebook still without canonical anchoring** — verified firsthand (Winn=0, Bishop=0, Kschischang=0, Pearl=0, no years, no DOIs; the `doi` keyword count was `pt.switch` code, not citations).

The notebook is built on three pillars of the probabilistic-inference literature but cited none of them formally. This PR anchors each at its conceptually-relevant section, matching the **inline `> *Source.*` / `> *Référence.*` blockquote format** of the precedent (PyMC-18 #8314, PyMC-15 #8334).

## Changes (4 inline citation blockquotes, markdown-only)

| Cell | Concept | Canonical source anchored |
|---|---|---|
| **§1 (cell 2)** Murder Mystery | The flagship example (M. Boddy, Scarlet, Mustard, Peacock) | **Winn & Bishop (2019), *Model-Based Machine Learning* [MBML], Ch.1** — designed to introduce Bayesian inference via narrative, no equations. |
| **§2 (cell 8)** Explaining Away | Mustard "explains away" the crime → Scarlet less likely | **Pearl (1988), *Probabilistic Reasoning in Intelligent Systems*, §3.3** — the V-structure (collider): observing a common effect makes causes *competitive*. |
| **§3 (cell 10)** Monty Hall | The conditioning paradox | **vos Savant (1990, *Parade*) / Gill (2011, *Comptes Rendus Mathématique*)** — conditioning on *that Monty revealed a goat* (not the opened door) reverses intuition (P=2/3). |
| **Conclusion (cell 17)** Factor graphs + sum-product | Message passing vs MCMC | **Kschischang, Frey & Loeliger (2001), IEEE TIT 47(2):498-519** + **Bishop (2006) PRML §8.4** — exact sum-product on a factor tree vs PyMC's MCMC approximation (and Infer.NET's analytical EP). |

Each blockquote also documents the **Infer.NET ↔ PyMC algorithmic divergence** (EP deterministic message-passing vs MCMC sampling) at the relevant point — the central pedagogical axis of the twin.

## Why this is a genuine residual (C909-L)

`gh pr list --search "PyMC citation"` returns 5 MERGED precedents (#8302 PyMC-19, #8314 PyMC-18, #8334 PyMC-15, #8339 PyMC-17, #8348 PyMC-16) + their Infer twins. **PyMC-3 is absent** — confirmed firsthand it carries zero canonical citations despite being built on MBML's flagship example. Not a duplicate, not saturated; it is the next notebook in an active, validated rollout.

## Validation

- **Markdown-only (C.3 exception)**: no re-exec. Code cells **byte-identical** (source + outputs + execution_count 1-8, verified via canonical-JSON deep comparison — 0 code cells changed). Exactly **4 markdown cells** changed [2, 8, 10, 17].
- **nbformat VALID**; **LF-only (0 CR bytes)**.
- **Format matches precedent**: inline `> *Source.*` / `> *Référence.*` blockquotes (PyMC-18 #8314 style), French-accented (PyMC-18 is accented; PyMC-3's ASCII-stripping is legacy — accents move it toward the series standard).
- **No source-content loss**: the `+13/−3` diff is entirely benign nbformat line-wrap normalization (adding `\n` separators so the new blockquotes start cleanly); existing prose is byte-preserved.
- **Catalogue** byte-identical to main (markdown edit inside an existing notebook — no new/deleted notebook, no title change).
- L898 collision guard: 0 open PR on PyMC-3 / Probas citations. Rebase frais sur `origin/main` (`08a84bebc`, 0 behind).

## Genre / scope

MED/notebook-fidelity (distillation-citation axis, per-notebook domain reasoning — not scan-generable). Clean genre pivot from c.913 (DEEP/notebook-dotnet): Python + citations vs C# solver. Advances #8081 (Probas Infer.NET + PyMC distillation audit — PyMC side; c.907 did the Infer-14 side).

`See #8081` (Probas distillation audit — partial; this closes the PyMC-3 residual, other notebooks may remain). See #4956 (twin marathon — Infer-3 ↔ PyMC-3 is a registered semantic twin).
