### PR TITLE
refactor(#8650): shared notebook_walk walker + migrate 11 scanners (SKIP_DIRS drift)

### DIFF
--- a/scripts/notebook_tools/check_notebook_navlinks.py
+++ b/scripts/notebook_tools/check_notebook_navlinks.py
@@ -70,12 +70,11 @@ from urllib.parse import unquote
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 NOTEBOOKS_ROOT = REPO_ROOT / "MyIA.AI.Notebooks"
 
-# Dossiers a ignorer (archives, vendores, caches)
-SKIP_DIRS = {
-    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
-    ".ipynb_checkpoints", "_output", ".pytest_cache", "worktrees",
-    "foundry-lib",  # lib vendored tierce, pas a nous a fixer
-}
+# Dossiers a ignorer (archives, vendores, caches) -- source unique notebook_walk (#8650).
+# navlinks est l'impl de reference du filtre git tracked_only que notebook_walk
+# generalise aux 10 autres scanners ; seul son SKIP_DIRS avait derive (manquait
+# .claude, node_modules) -- il adopte maintenant le set canonique.
+from notebook_walk import SKIP_DIRS  # noqa: E402
 
 BASELINE_PATH = REPO_ROOT / "scripts" / "tests" / "baseline_nb_navlinks.json"
 

--- a/scripts/notebook_tools/check_plotly_static_risk.py
+++ b/scripts/notebook_tools/check_plotly_static_risk.py
@@ -49,29 +49,21 @@ from pathlib import Path
 CDN_PATTERN = re.compile(r"cdn\.plot\.?ly", re.IGNORECASE)
 IMAGE_MIMES = ("image/png", "image/jpeg", "image/svg+xml", "image/webp", "image/gif")
 
-# Skips
-SKIP_DIRS = {
-    ".git",
-    "_output",
-    "_archives",
-    ".ipynb_checkpoints",
-    ".lake",  # Lean vendored
-    ".claude",
-    "node_modules",
-}
+# Skips -- source unique notebook_walk (#8650). Plotly etait le cas net du
+# constat : son SKIP_DIRS (7 entrees) manquait `archive`/`_archive`/`__pycache__`/
+# `.pytest_cache`/`worktrees`/`foundry-lib` et balayait donc 4 notebooks archives
+# que les 10 autres scanners excluaient. Le set canonique (13 entrees) harmonise.
+from notebook_walk import SKIP_DIRS, iter_notebooks as _shared_iter_notebooks  # noqa: E402
 
 
 def iter_notebooks(root: Path):
-    """Yield all .ipynb paths under root, skipping vendored/archived dirs."""
-    for p in root.rglob("*.ipynb"):
-        # Skip vendored, archives, outputs
-        rel_parts = p.parts
-        if any(part in SKIP_DIRS for part in rel_parts):
-            continue
-        # Skip _output.ipynb duplicates (always have same outputs as primary)
-        if p.stem.endswith("_output"):
-            continue
-        yield p
+    """Yield all .ipynb paths under root, skipping vendored/archived dirs.
+
+    Delegue au marcheur partage (#8650) : SKIP_DIRS canonique + filtre git
+    tracked_only (exclut deterministement les arbres gitignores) + skip des
+    artefacts papermill ``*_output.ipynb``.
+    """
+    yield from _shared_iter_notebooks(root)
 
 
 def cell_is_risky(cell: dict) -> bool:

--- a/scripts/notebook_tools/detect_ascii_workaround.py
+++ b/scripts/notebook_tools/detect_ascii_workaround.py
@@ -364,20 +364,14 @@ def _kernel(nb: dict) -> str:
     return nb.get("metadata", {}).get("kernelspec", {}).get("name", "?")
 
 
-# Dossiers a ignorer (alignes sur la convention check_notebook_navlinks.py:SKIP_DIRS).
-SKIP_DIRS = {
-    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
-    ".ipynb_checkpoints", ".pytest_cache", "worktrees",
-    "foundry-lib",  # lib vendored tierce, pas a nous a fixer
-}
-
-# Artefacts papermill (gitignored mais presents en local apres exec). Sans ce
-# filtre, le detecteur flag des _output STALE : la source canonique est editee
-# (defect corrige) sans regen du _output, qui porte encore l'ancienne bar ASCII.
-# Cas firsthand : SC-17 _output cell10 `bar="#"*votes` alors que la source
-# canonique n'a plus la bar (c.597 forensic #6843). Dans ce repo les _output
-# sont des SUFFIXES de nom de fichier (*_output.ipynb), pas des dossiers.
-_OUTPUT_SUFFIX = "_output.ipynb"
+# Marcheur + SKIP_DIRS canonique centralises dans notebook_walk (#8650) :
+# source unique pour le perimetre des scanners (ferme la derive detectee).
+# Artefacts papermill (gitignored mais presents en local apres exec) : sans ce
+# filtre, le detecteur flag des _output STALE. Cas firsthand : SC-17 _output
+# cell10 `bar="#"*votes` alors que la source canonique n'a plus la bar
+# (c.597 forensic #6843). Dans ce repo les _output sont des SUFFIXES de nom de
+# fichier (*_output.ipynb), pas des dossiers.
+from notebook_walk import SKIP_DIRS, _OUTPUT_SUFFIX, iter_notebooks  # noqa: E402
 
 
 def _should_skip(rel: Path) -> bool:
@@ -387,15 +381,8 @@ def _should_skip(rel: Path) -> bool:
 
 
 def _iter_notebooks(root: Path, family: str | None):
-    base = root / "MyIA.AI.Notebooks"
-    if family:
-        base = base / family
-    if not base.exists():
-        return
-    for nb in sorted(base.rglob("*.ipynb")):
-        if _should_skip(nb.relative_to(base)):
-            continue
-        yield nb
+    # Delegue au marcheur partage : SKIP_DIRS canonique + filtre git tracked_only.
+    yield from iter_notebooks(root / "MyIA.AI.Notebooks", family=family)
 
 
 def _human_report(results: list[dict]) -> str:

--- a/scripts/notebook_tools/detect_bare_cross_dir_load.py
+++ b/scripts/notebook_tools/detect_bare_cross_dir_load.py
@@ -160,13 +160,8 @@ def detect_cell(cell: dict, nb_dir: Path) -> list[dict]:
     return hits
 
 
-# Dossiers a ignorer (alignes sur detect_svg_empty_display.py / detect_blank_figures.py).
-SKIP_DIRS = {
-    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
-    ".ipynb_checkpoints", ".pytest_cache", "worktrees",
-    "foundry-lib",  # lib vendored tierce, pas a nous a fixer
-}
-_OUTPUT_SUFFIX = "_output.ipynb"
+# Marcheur + SKIP_DIRS canonique centralises dans notebook_walk (#8650).
+from notebook_walk import SKIP_DIRS, _OUTPUT_SUFFIX, iter_notebooks  # noqa: E402
 
 
 def _should_skip(rel: Path) -> bool:
@@ -192,15 +187,8 @@ def scan_notebook(path: Path) -> dict:
 
 
 def _iter_notebooks(root: Path, family: str | None):
-    base = root / "MyIA.AI.Notebooks"
-    if family:
-        base = base / family
-    if not base.exists():
-        return
-    for nb in sorted(base.rglob("*.ipynb")):
-        if _should_skip(nb.relative_to(base)):
-            continue
-        yield nb
+    # Delegue au marcheur partage : SKIP_DIRS canonique + filtre git tracked_only.
+    yield from iter_notebooks(root / "MyIA.AI.Notebooks", family=family)
 
 
 def _human_report(results: list[dict]) -> str:

--- a/scripts/notebook_tools/detect_blank_figures.py
+++ b/scripts/notebook_tools/detect_blank_figures.py
@@ -241,16 +241,11 @@ def _kernel(nb: dict) -> str:
     return nb.get("metadata", {}).get("kernelspec", {}).get("name", "?")
 
 
-# Dossiers a ignorer (alignes sur detect_ascii_workaround.py:SKIP_DIRS).
-SKIP_DIRS = {
-    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
-    ".ipynb_checkpoints", ".pytest_cache", "worktrees",
-    "foundry-lib",  # lib vendored tierce, pas a nous a fixer
-}
-
+# Marcheur + SKIP_DIRS canonique centralises dans notebook_walk (#8650) :
+# source unique pour le perimetre des scanners (ferme la derive detectee).
 # Artefacts papermill (*_output.ipynb) : la source canonique est le livrable, le
 # _output re-genere peut porter une figure stale -- on scanne la source.
-_OUTPUT_SUFFIX = "_output.ipynb"
+from notebook_walk import SKIP_DIRS, _OUTPUT_SUFFIX, iter_notebooks  # noqa: E402
 
 
 def _should_skip(rel: Path) -> bool:
@@ -260,15 +255,9 @@ def _should_skip(rel: Path) -> bool:
 
 
 def _iter_notebooks(root: Path, family: str | None):
-    base = root / "MyIA.AI.Notebooks"
-    if family:
-        base = base / family
-    if not base.exists():
-        return
-    for nb in sorted(base.rglob("*.ipynb")):
-        if _should_skip(nb.relative_to(base)):
-            continue
-        yield nb
+    # Delegue au marcheur partage : SKIP_DIRS canonique + filtre git tracked_only
+    # (exclut deterministement les arbres gitignores - lean-workspace, _output).
+    yield from iter_notebooks(root / "MyIA.AI.Notebooks", family=family)
 
 
 def _human_report(results: list[dict]) -> str:

--- a/scripts/notebook_tools/detect_cjk_residue.py
+++ b/scripts/notebook_tools/detect_cjk_residue.py
@@ -159,13 +159,8 @@ def scan_notebook(path: Path, root: Path) -> dict:
     return {"path": rel, "allowed": None, "hits": hits, "error": None}
 
 
-# Dossiers a ignorer (alignes sur detect_ascii_workaround.py:SKIP_DIRS).
-SKIP_DIRS = {
-    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
-    ".ipynb_checkpoints", ".pytest_cache", "worktrees",
-    "foundry-lib",  # lib vendored tierce
-}
-_OUTPUT_SUFFIX = "_output.ipynb"
+# Marcheur + SKIP_DIRS canonique centralises dans notebook_walk (#8650).
+from notebook_walk import SKIP_DIRS, _OUTPUT_SUFFIX, iter_notebooks  # noqa: E402
 
 
 def _should_skip(rel: Path) -> bool:
@@ -175,19 +170,8 @@ def _should_skip(rel: Path) -> bool:
 
 
 def _iter_notebooks(root: Path, family: str | None):
-    base = root / "MyIA.AI.Notebooks"
-    if family:
-        base = base / family
-    if not base.exists():
-        return
-    for nb in sorted(base.rglob("*.ipynb")):
-        try:
-            rel = nb.relative_to(base)
-        except ValueError:
-            continue
-        if _should_skip(rel):
-            continue
-        yield nb
+    # Delegue au marcheur partage : SKIP_DIRS canonique + filtre git tracked_only.
+    yield from iter_notebooks(root / "MyIA.AI.Notebooks", family=family)
 
 
 def _human_report(results: list[dict]) -> str:

--- a/scripts/notebook_tools/detect_fabricated_outputs.py
+++ b/scripts/notebook_tools/detect_fabricated_outputs.py
@@ -247,15 +247,9 @@ def _kernel(nb: dict) -> str:
     return nb.get("metadata", {}).get("kernelspec", {}).get("name", "?")
 
 
-# Dossiers a ignorer (alignes sur detect_blank_figures.py).
-SKIP_DIRS = {
-    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
-    ".ipynb_checkpoints", ".pytest_cache", "worktrees",
-    "foundry-lib",  # lib vendored tierce, pas a nous a fixer
-}
-
+# Marcheur + SKIP_DIRS canonique centralises dans notebook_walk (#8650).
 # Artefacts papermill (*_output.ipynb) : la source canonique est le livrable.
-_OUTPUT_SUFFIX = "_output.ipynb"
+from notebook_walk import SKIP_DIRS, _OUTPUT_SUFFIX, iter_notebooks  # noqa: E402
 
 
 def _should_skip(rel: Path) -> bool:
@@ -265,15 +259,8 @@ def _should_skip(rel: Path) -> bool:
 
 
 def _iter_notebooks(root: Path, family: str | None):
-    base = root / "MyIA.AI.Notebooks"
-    if family:
-        base = base / family
-    if not base.exists():
-        return
-    for nb in sorted(base.rglob("*.ipynb")):
-        if _should_skip(nb.relative_to(base)):
-            continue
-        yield nb
+    # Delegue au marcheur partage : SKIP_DIRS canonique + filtre git tracked_only.
+    yield from iter_notebooks(root / "MyIA.AI.Notebooks", family=family)
 
 
 def _human_report(results: list[dict]) -> str:

--- a/scripts/notebook_tools/detect_svg_broken_geometry.py
+++ b/scripts/notebook_tools/detect_svg_broken_geometry.py
@@ -168,13 +168,8 @@ def scan_notebook(path: Path) -> dict:
     return {"path": str(path), "kernel": _kernel(nb), "hits": hits, "error": None}
 
 
-# Dossiers a ignorer (alignes sur detect_svg_decimal_commas.py:SKIP_DIRS).
-SKIP_DIRS = {
-    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
-    ".ipynb_checkpoints", ".pytest_cache", "worktrees",
-    "foundry-lib",
-}
-_OUTPUT_SUFFIX = "_output.ipynb"
+# Marcheur + SKIP_DIRS canonique centralises dans notebook_walk (#8650).
+from notebook_walk import SKIP_DIRS, _OUTPUT_SUFFIX, iter_notebooks  # noqa: E402
 
 
 def _should_skip(rel: Path) -> bool:
@@ -184,15 +179,8 @@ def _should_skip(rel: Path) -> bool:
 
 
 def _iter_notebooks(root: Path, family: str | None):
-    base = root / "MyIA.AI.Notebooks"
-    if family:
-        base = base / family
-    if not base.exists():
-        return
-    for nb in sorted(base.rglob("*.ipynb")):
-        if _should_skip(nb.relative_to(base)):
-            continue
-        yield nb
+    # Delegue au marcheur partage : SKIP_DIRS canonique + filtre git tracked_only.
+    yield from iter_notebooks(root / "MyIA.AI.Notebooks", family=family)
 
 
 def _human_report(results: list[dict]) -> str:

--- a/scripts/notebook_tools/detect_svg_decimal_commas.py
+++ b/scripts/notebook_tools/detect_svg_decimal_commas.py
@@ -215,13 +215,8 @@ def scan_notebook(path: Path) -> dict:
     return {"path": str(path), "kernel": _kernel(nb), "hits": hits, "error": None}
 
 
-# Dossiers a ignorer (alignes sur detect_blank_figures.py:SKIP_DIRS).
-SKIP_DIRS = {
-    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
-    ".ipynb_checkpoints", ".pytest_cache", "worktrees",
-    "foundry-lib",  # lib vendored tierce, pas a nous a fixer
-}
-_OUTPUT_SUFFIX = "_output.ipynb"
+# Marcheur + SKIP_DIRS canonique centralises dans notebook_walk (#8650).
+from notebook_walk import SKIP_DIRS, _OUTPUT_SUFFIX, iter_notebooks  # noqa: E402
 
 
 def _should_skip(rel: Path) -> bool:
@@ -231,15 +226,8 @@ def _should_skip(rel: Path) -> bool:
 
 
 def _iter_notebooks(root: Path, family: str | None):
-    base = root / "MyIA.AI.Notebooks"
-    if family:
-        base = base / family
-    if not base.exists():
-        return
-    for nb in sorted(base.rglob("*.ipynb")):
-        if _should_skip(nb.relative_to(base)):
-            continue
-        yield nb
+    # Delegue au marcheur partage : SKIP_DIRS canonique + filtre git tracked_only.
+    yield from iter_notebooks(root / "MyIA.AI.Notebooks", family=family)
 
 
 def _human_report(results: list[dict]) -> str:

--- a/scripts/notebook_tools/detect_svg_empty_display.py
+++ b/scripts/notebook_tools/detect_svg_empty_display.py
@@ -230,13 +230,8 @@ def scan_notebook(path: Path) -> dict:
     return {"path": str(path), "kernel": kernel, "hits": hits, "error": None}
 
 
-# Dossiers a ignorer (alignes sur detect_svg_decimal_commas.py / detect_blank_figures.py).
-SKIP_DIRS = {
-    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
-    ".ipynb_checkpoints", ".pytest_cache", "worktrees",
-    "foundry-lib",  # lib vendored tierce, pas a nous a fixer
-}
-_OUTPUT_SUFFIX = "_output.ipynb"
+# Marcheur + SKIP_DIRS canonique centralises dans notebook_walk (#8650).
+from notebook_walk import SKIP_DIRS, _OUTPUT_SUFFIX, iter_notebooks  # noqa: E402
 
 
 def _should_skip(rel: Path) -> bool:
@@ -246,15 +241,8 @@ def _should_skip(rel: Path) -> bool:
 
 
 def _iter_notebooks(root: Path, family: str | None):
-    base = root / "MyIA.AI.Notebooks"
-    if family:
-        base = base / family
-    if not base.exists():
-        return
-    for nb in sorted(base.rglob("*.ipynb")):
-        if _should_skip(nb.relative_to(base)):
-            continue
-        yield nb
+    # Delegue au marcheur partage : SKIP_DIRS canonique + filtre git tracked_only.
+    yield from iter_notebooks(root / "MyIA.AI.Notebooks", family=family)
 
 
 def _human_report(results: list[dict]) -> str:

--- a/scripts/notebook_tools/detect_svg_offscreen_flat.py
+++ b/scripts/notebook_tools/detect_svg_offscreen_flat.py
@@ -224,13 +224,8 @@ def scan_notebook(path: Path) -> dict:
     return {"path": str(path), "kernel": _kernel(nb), "hits": hits, "error": None}
 
 
-# Dossiers a ignorer (alignes sur detect_svg_broken_geometry.py:SKIP_DIRS).
-SKIP_DIRS = {
-    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
-    ".ipynb_checkpoints", ".pytest_cache", "worktrees",
-    "foundry-lib",
-}
-_OUTPUT_SUFFIX = "_output.ipynb"
+# Marcheur + SKIP_DIRS canonique centralises dans notebook_walk (#8650).
+from notebook_walk import SKIP_DIRS, _OUTPUT_SUFFIX, iter_notebooks  # noqa: E402
 
 
 def _should_skip(rel: Path) -> bool:
@@ -240,15 +235,8 @@ def _should_skip(rel: Path) -> bool:
 
 
 def _iter_notebooks(root: Path, family: str | None):
-    base = root / "MyIA.AI.Notebooks"
-    if family:
-        base = base / family
-    if not base.exists():
-        return
-    for nb in sorted(base.rglob("*.ipynb")):
-        if _should_skip(nb.relative_to(base)):
-            continue
-        yield nb
+    # Delegue au marcheur partage : SKIP_DIRS canonique + filtre git tracked_only.
+    yield from iter_notebooks(root / "MyIA.AI.Notebooks", family=family)
 
 
 def _human_report(results: list[dict]) -> str:

--- a/scripts/notebook_tools/notebook_walk.py
+++ b/scripts/notebook_tools/notebook_walk.py
@@ -1,0 +1,155 @@
+"""Shared directory walker for the notebook scanners (#8650).
+
+Eleven scanners under ``scripts/notebook_tools/`` each carried their own
+``SKIP_DIRS`` set (which had drifted into three variants) and their own
+``rglob`` loop. This module is the single source of truth for (a) which
+directory names are out-of-scope and (b) the file-set walked by an audit.
+
+Design notes
+------------
+* ``SKIP_DIRS`` is the canonical union of the 13 directory names seen across
+  the eleven scanners. ``_output`` is kept as a member (belt-and-suspenders):
+  it is primarily a Papermill *file* suffix (``*_output.ipynb``) handled by
+  ``skip_papermill_output``, but keeping it as a directory name too is harmless
+  (no tracked directory is literally named ``_output``, verified #8650) and
+  preserves the two scanners (check_notebook_navlinks, check_plotly_static_risk)
+  whose tests assert a ``_output/`` directory is out-of-scope.
+* ``tracked_only=True`` (default) restricts the walk to git-tracked files via
+  ``git ls-files``. This deterministically excludes gitignored trees that may
+  nonetheless exist on disk (local ``lean-workspace/`` clones, Papermill
+  ``*_output.ipynb`` artefacts) so an audit never emits a finding that no PR
+  can fix. When ``git`` is unavailable (a fresh export without ``.git``, a
+  tarball), the walk gracefully degrades to the plain ``SKIP_DIRS`` scan and
+  warns on stderr -- modelled on ``check_notebook_navlinks._iter_notebooks``,
+  the reference implementation this module generalises.
+* ``tracked_only=False`` keeps the historical "everything on disk" behaviour
+  for ad-hoc local-artefact audits; it must stay explicit.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+NOTEBOOKS_ROOT = REPO_ROOT / "MyIA.AI.Notebooks"
+
+# Out-of-scope directory names (matched as any path segment). Canonical union
+# of the entries that were duplicated -- and had drifted -- across the eleven
+# scanners (#8650). A plain ``set`` so callers/tests can rebind/inspect it.
+SKIP_DIRS = {
+    ".lake",             # Lean vendored (Mathlib)
+    ".git",
+    "__pycache__",
+    "_archives", "archive", "_archive",   # pedagogical archives (not ours to fix)
+    ".ipynb_checkpoints",
+    "_output",           # Papermill output dir (file suffix handled separately)
+    ".pytest_cache",
+    "worktrees",         # git worktrees of other sessions
+    "foundry-lib",       # vendored third-party library
+    ".claude",
+    "node_modules",
+}
+
+# Papermill execution artefact (gitignored). Not a directory name -> filtered
+# on the file suffix via ``skip_papermill_output``.
+_OUTPUT_SUFFIX = "_output.ipynb"
+
+
+def _git_repo_root(start: Path) -> Path | None:
+    """Return the git repository root containing ``start``, or None if ``start``
+    is not inside a git repo / git is unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(start.resolve()), capture_output=True, text=True, timeout=15,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    top = result.stdout.strip()
+    return Path(top) if top else None
+
+
+def _git_tracked_notebooks(repo_root: Path, notebooks_root: Path) -> set[str] | None:
+    """Return the set of git-tracked ``*.ipynb`` paths (repo-root posix) under
+    ``notebooks_root``, or None if ``git ls-files`` fails. ``notebooks_root`` is
+    resolved to absolute so the pathspec is well-formed against ``repo_root``
+    (which is always absolute from ``git rev-parse``) even when the caller passed
+    a relative ``--root``."""
+    try:
+        rel = notebooks_root.resolve().relative_to(repo_root).as_posix()
+    except (ValueError, OSError):
+        rel = "."
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-z", "--", rel],
+            cwd=str(repo_root), capture_output=True, text=False, timeout=120,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    entries = result.stdout.decode("utf-8", "replace").strip("\x00").split("\x00")
+    return {e.replace("\\", "/") for e in entries if e.endswith(".ipynb")}
+
+
+def iter_notebooks(
+    notebooks_root: Path,
+    *,
+    family: str | None = None,
+    tracked_only: bool = True,
+    skip_papermill_output: bool = True,
+):
+    """Yield ``*.ipynb`` paths under ``notebooks_root[/<family>]``.
+
+    Parameters
+    ----------
+    notebooks_root : the directory containing the family sub-tree to scan (for
+        the repo, ``REPO_ROOT/MyIA.AI.Notebooks``; scanners that take a CLI
+        ``--root`` pointing there pass it directly).
+    family : optional top-level family under ``notebooks_root`` (e.g. "Search").
+    tracked_only : if True (default), restrict to git-tracked notebooks via
+        ``git ls-files`` (drops gitignored trees present on disk). Degrades to
+        a plain ``SKIP_DIRS`` scan with a stderr warning when git is unavailable.
+    skip_papermill_output : if True (default), drop ``*_output.ipynb`` artefacts.
+    """
+    base = notebooks_root / family if family else notebooks_root
+    if not base.is_dir():
+        return
+
+    tracked: set[str] | None = None
+    repo_root: Path | None = None
+    if tracked_only:
+        repo_root = _git_repo_root(notebooks_root)
+        if repo_root is not None:
+            tracked = _git_tracked_notebooks(repo_root, notebooks_root)
+    if tracked_only and tracked is None:
+        # Not in a git repo (or git missing): degrade to "all files on disk"
+        # to avoid a silent false "0 finding", but warn explicitly.
+        print(
+            "warn: tracked_only requested but git is unavailable; "
+            "falling back to full on-disk discovery (possible gitignored noise).",
+            file=sys.stderr,
+        )
+
+    for nb in sorted(base.rglob("*.ipynb")):
+        rel_base = nb.relative_to(base)
+        if any(part in SKIP_DIRS for part in rel_base.parts):
+            continue
+        if skip_papermill_output and nb.name.endswith(_OUTPUT_SUFFIX):
+            continue
+        if tracked is not None and repo_root is not None:
+            # Resolve nb to absolute for the membership check only (repo_root is
+            # absolute); yield the original rglob'd path so callers that do
+            # ``nb.relative_to(their_root)`` (e.g. check_plotly_static_risk with a
+            # relative --root) still work.
+            try:
+                rel_repo = nb.resolve().relative_to(repo_root).as_posix()
+            except (ValueError, OSError):
+                continue
+            if rel_repo not in tracked:
+                continue
+        yield nb

--- a/scripts/notebook_tools/tests/test_notebook_walk.py
+++ b/scripts/notebook_tools/tests/test_notebook_walk.py
@@ -1,0 +1,154 @@
+"""Tests for the shared notebook walker (#8650).
+
+Covers: canonical SKIP_DIRS content, SKIP_DIRS / _output filtering, and the
+``tracked_only`` git filter (the deterministic exclusion of gitignored trees
+that the eleven scanners previously relied on SKIP_DIRS only matching by
+accident). The git filter is exercised with a real throwaway ``git init`` so
+the regression is caught if the mechanism ever breaks.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import notebook_walk as nw  # noqa: E402
+
+
+def _nb(name="nb.ipynb"):
+    return {"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+
+
+def _write(tree_root: Path, rel: str):
+    p = tree_root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(_nb()), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# 1. SKIP_DIRS canonical content
+# ---------------------------------------------------------------------------
+class TestSkipDirs:
+    def test_is_a_set(self):
+        assert isinstance(nw.SKIP_DIRS, set)
+
+    def test_contains_canonical_entries(self):
+        for key in (
+            ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
+            ".ipynb_checkpoints", "_output", ".pytest_cache", "worktrees",
+            "foundry-lib", ".claude", "node_modules",
+        ):
+            assert key in nw.SKIP_DIRS, key
+
+    def test_output_kept_as_dir_entry(self):
+        # `_output` is primarily a Papermill *file suffix* (skip_papermill_output),
+        # but it is also kept as a directory name -- harmless (no tracked `_output/`
+        # dir exists) and preserves the scanners whose tests assert a `_output/`
+        # directory is out-of-scope (#8650 discussion).
+        assert "_output" in nw.SKIP_DIRS
+
+
+# ---------------------------------------------------------------------------
+# 2. iter_notebooks -- SKIP_DIRS + papermill suffix filtering (no git)
+# ---------------------------------------------------------------------------
+class TestIterNotebooksFiltering:
+    def test_yields_plain_notebook(self, tmp_path):
+        _write(tmp_path, "family/nb.ipynb")
+        paths = list(nw.iter_notebooks(tmp_path, tracked_only=False))
+        assert [p.name for p in paths] == ["nb.ipynb"]
+
+    def test_skips_vendored_dirs(self, tmp_path):
+        _write(tmp_path, ".lake/packages/x.ipynb")
+        _write(tmp_path, "foundry-lib/lib/y.ipynb")
+        _write(tmp_path, "nb.ipynb")
+        names = {p.name for p in nw.iter_notebooks(tmp_path, tracked_only=False)}
+        assert names == {"nb.ipynb"}
+
+    def test_skips_archive_dirs(self, tmp_path):
+        # `archive` (singular) is the entry plotly historically lacked (#8650).
+        _write(tmp_path, "Search/archive/old.ipynb")
+        _write(tmp_path, "_archives/older.ipynb")
+        _write(tmp_path, "nb.ipynb")
+        names = {p.name for p in nw.iter_notebooks(tmp_path, tracked_only=False)}
+        assert names == {"nb.ipynb"}
+
+    def test_skips_papermill_output_artifact(self, tmp_path):
+        _write(tmp_path, "primary.ipynb")
+        _write(tmp_path, "primary_output.ipynb")
+        names = {p.name for p in nw.iter_notebooks(tmp_path, tracked_only=False)}
+        assert names == {"primary.ipynb"}
+
+    def test_skip_papermill_output_false_keeps_artifact(self, tmp_path):
+        _write(tmp_path, "primary.ipynb")
+        _write(tmp_path, "primary_output.ipynb")
+        names = {p.name for p in nw.iter_notebooks(tmp_path, tracked_only=False, skip_papermill_output=False)}
+        assert names == {"primary.ipynb", "primary_output.ipynb"}
+
+    def test_family_subset(self, tmp_path):
+        _write(tmp_path, "Search/a.ipynb")
+        _write(tmp_path, "ML/b.ipynb")
+        names = {p.name for p in nw.iter_notebooks(tmp_path, family="Search", tracked_only=False)}
+        assert names == {"a.ipynb"}
+
+
+# ---------------------------------------------------------------------------
+# 3. tracked_only -- the git filter (deterministic exclusion of gitignored)
+# ---------------------------------------------------------------------------
+def _git(path: Path, *args):
+    return subprocess.run(["git", *args], cwd=str(path), capture_output=True, text=True)
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    """A throwaway git repo with one tracked + one gitignored notebook."""
+    root = tmp_path / "repo"
+    (root / "MyIA.AI.Notebooks").mkdir(parents=True)
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "t@t")
+    _git(root, "config", "user.name", "t")
+    root.joinpath(".gitignore").write_text("ignored.ipynb\n", encoding="utf-8")
+    nb_root = root / "MyIA.AI.Notebooks"
+    _write(nb_root, "tracked.ipynb")
+    _write(nb_root, "ignored.ipynb")  # gitignored -> never added
+    _git(root, "add", ".")
+    _git(root, "commit", "-q", "-m", "init")
+    return nb_root
+
+
+class TestTrackedOnly:
+    def test_default_excludes_gitignored(self, git_repo):
+        names = {p.name for p in nw.iter_notebooks(git_repo)}
+        assert names == {"tracked.ipynb"}
+
+    def test_tracked_only_false_includes_gitignored(self, git_repo):
+        names = {p.name for p in nw.iter_notebooks(git_repo, tracked_only=False)}
+        assert names == {"tracked.ipynb", "ignored.ipynb"}
+
+    def test_relative_root_with_git(self, git_repo, monkeypatch):
+        # Regression: a caller passing a RELATIVE --root (e.g. plotly's default
+        # "MyIA.AI.Notebooks") must still resolve against the absolute repo root
+        # returned by `git rev-parse` -- otherwise nb.relative_to(repo_root)
+        # raises ValueError and EVERY notebook is silently skipped (#8650).
+        # git_repo is <repo>/MyIA.AI.Notebooks, so the repo root is its parent.
+        monkeypatch.chdir(git_repo.parent)
+        names = {p.name for p in nw.iter_notebooks(Path("MyIA.AI.Notebooks"))}
+        assert names == {"tracked.ipynb"}
+
+    def test_fallback_when_not_a_repo(self, tmp_path, capsys, monkeypatch):
+        # Outside any git repo: degrade to on-disk scan + warn (no false "0").
+        monkeypatch.setattr(nw, "_git_repo_root", lambda _p: None)
+        _write(tmp_path, "a.ipynb")
+        _write(tmp_path, "b.ipynb")
+        names = {p.name for p in nw.iter_notebooks(tmp_path)}
+        assert names == {"a.ipynb", "b.ipynb"}
+        assert "git is unavailable" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# 4. missing base -- graceful no-op
+# ---------------------------------------------------------------------------
+def test_missing_base_yields_nothing(tmp_path):
+    assert list(nw.iter_notebooks(tmp_path / "does_not_exist")) == []


### PR DESCRIPTION
Grain: MED/refactor — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-fidelity (c.914 #8651 OPEN).

## Summary

Closes #8650. Eleven scanners under `scripts/notebook_tools/` each carried their own `SKIP_DIRS` set (drifted into **three variants**) and their own `rglob` loop. This PR introduces **`notebook_walk.py`** — a single shared walker (canonical `SKIP_DIRS` + `tracked_only` git filter + papermill-suffix skip) — and migrates the 11 scanners to delegate to it.

The drift the issue documents is real and **measured firsthand**: `check_plotly_static_risk` (7-entry set, missing `archive`) scanned **4 archived notebooks** the 10 others correctly excluded (`Search/archive/*`, `SymbolicAI/Planners/archive/*`, `SymbolicAI/archive/*`). After migration all 11 scanners walk the **same 940-notebook perimeter**.

## The module — `scripts/notebook_tools/notebook_walk.py` (155 lines)

- **`SKIP_DIRS`** — canonical union of the 13 directory names seen across the 11 scanners (`.lake .git __pycache__ _archives archive _archive .ipynb_checkpoints _output .pytest_cache worktrees foundry-lib .claude node_modules`). A plain `set` so callers/tests rebind it.
- **`iter_notebooks(notebooks_root, *, family, tracked_only=True, skip_papermill_output=True)`** — single `rglob` + filters.
- **`tracked_only` git filter** — restricts to `git ls-files` (drops gitignored trees present on disk: local `lean-workspace/` clones, `*_output.ipynb` artefacts) so an audit never emits a finding no PR can fix. **Graceful fallback**: when git is unavailable (fresh export, tarball) it degrades to the plain `SKIP_DIRS` scan + a stderr warning — modelled on `check_notebook_navlinks._iter_notebooks`, the reference implementation this module generalises.
- **`_output` discussion (resolved)**: kept in `SKIP_DIRS` (belt-and-suspenders) — it is primarily a Papermill *file suffix* (handled by `skip_papermill_output`), but keeping it as a dir-name too is harmless (no tracked `_output/` dir exists) and preserves the two scanners (`navlinks`, `plotly`) whose tests assert a `_output/` directory is out-of-scope.

## Migration (11 scanners)

- **9 group-A detectors** (`detect_ascii_workaround`, `detect_bare_cross_dir_load`, `detect_blank_figures`, `detect_cjk_residue`, `detect_fabricated_outputs`, `detect_svg_{broken_geometry,decimal_commas,empty_display,offscreen_flat}`): rebind `SKIP_DIRS`/`_OUTPUT_SUFFIX` from the module; keep `_should_skip` (now uses the shared constants); `_iter_notebooks` body becomes a one-line delegate. `main()` and CLI unchanged.
- **`check_notebook_navlinks`** (the reference impl, already had git-filter): adopts the canonical `SKIP_DIRS` (closes its drift — it lacked `.claude`/`node_modules`). Its own `_iter_notebooks`/`_git_tracked_notebooks` are kept as-is (tests mock them; `notebook_walk` is modelled on them).
- **`check_plotly_static_risk`** (the "cas net"): rebinds `SKIP_DIRS` + delegates `iter_notebooks`. Its `--root` (notebooks-root convention) keeps working — the module resolves paths internally for the git check and **yields the original rglob'd path**, so `main()`'s `nb_path.relative_to(args.root)` is preserved.

## Per-scanner before/after delta (acceptance criterion #8650)

Captured by importing each scanner's walk on pristine `origin/main` (BEFORE) and after migration (AFTER), on the clean checkout (worktree `c:/dev/CoursIA-c915`, HEAD `5d21c4207`):

| Scanner | BEFORE | AFTER | Delta |
|---|---|---|---|
| 9 group-A detectors | 940 | 940 | **0** |
| check_notebook_navlinks | 940 | 940 | **0** |
| check_plotly_static_risk | 944 | 940 | **−4** |

The only delta: plotly drops **4 archived notebooks** — `Search/archive/CSPs_Intro.ipynb`, `Search/archive/Exploration_non_informée_et_informée_intro.ipynb`, `SymbolicAI/Planners/archive/Fast-Downward-Legacy.ipynb`, `SymbolicAI/archive/Tweety.ipynb`. **Cause: harmonized `archive` SKIP_DIRS entry** (plotly's 7-entry set lacked it; canonical has it). This is exactly the divergence the issue names ("check_plotly_static_risk est le cas net"). **No unexplained delta.**

The git-filter (`tracked_only`) is a behavioural addition for the 10 scanners that lacked it; on a clean checkout it produces **0 file delta** (no gitignored trees present). Its value (deterministic exclusion of gitignored trees) is proven by the new `test_notebook_walk.py::TestTrackedOnly` (real `git init` fixture: tracked + gitignored notebook → `tracked_only=True` yields only tracked).

## Validation

- **`3415/3415` notebook_tools tests pass** (was 3401; +14 from `test_notebook_walk.py`). Includes all 11 scanners' existing suites **unchanged** (no test modified — the canonical `SKIP_DIRS` satisfies every existing assertion; the `_output`-kept decision preserves the navlinks + plotly dir-skip tests).
- **End-to-end** (not just unit): `detect_blank_figures --check` → 940 scanned, 0 degenerate, exit 0. `check_plotly_static_risk` → 940 scanned, 1 risky (no longer the crashed "0 scanned").
- **Bug caught in-session by e2e (H.1)**: plotly's CLI passes a **relative** `--root`; a first version resolved paths globally → `main()`'s `nb_path.relative_to(args.root)` crashed → "0 scanned". Fixed by resolving paths **internally** for the git check only and yielding the original rglob'd path. Regression test `test_relative_root_with_git` added.
- **`py_compile` OK** on all 12 files. **LF-only (0 CRLF)**. **Catalogue byte-identical** (no notebook/catalogue touched — diff is 13 `.py` files only).
- **Atomic** (G.4): 13 files, one coherent feature (shared walker), mechanical delegate diff (+61/−183 on the 11 scanners + new module/test).
- L898 collision guard: 0 open PR on #8650 / `notebook_walk`. Rebase frais sur `origin/main` (`5d21c4207`, 0 behind).

## Genre / scope

MED/refactor (deterministic single-source walker with verifiable per-scanner delta — not scan-generable). Clean R6 pivot from c.914 (MED/notebook-fidelity, Python citations) to tooling/refactor. CPU-only, no GPU/vision/user-action — "assignable à n'importe quelle lane" per issue.

`See #8650` (the shared-walker debt — fully resolved). See #8634 / #8649 (the `detect_blank_figures` content-gate work that surfaced this). See #3801 (SOTA audit axis).
