### PR TITLE
feat(notebook-tools,#8655): markdown content-loss detector + CI gate (catches #8654/#8630 cell-truncation)

### DIFF
--- a/.github/workflows/md-content-loss-gate.yml
+++ b/.github/workflows/md-content-loss-gate.yml
@@ -1,0 +1,109 @@
+name: Markdown content-loss gate
+
+# Purpose
+# -------
+# Per-PR gate that catches markdown CONTENT LOSS a cellule tronquee : une PR
+# du rollout #3966 (demotion de titres H1/H2 en callouts blockquote) peut,
+# quand le correcteur one-shot opere sur une cellule dont le `source` est une
+# chaine unique jointe, REMPLACER LA CELLULE ENTIERE par le seul callout. Une
+# cellule de 941 caracteres (enonce + contraintes + indices) se reduit a 16 ;
+# un bloc `**Navigation**` + 5 objectifs disparait. Aucun garde existant ne
+# mesure le volume de prose markdown -> la CI reste verte (issue #8655).
+#
+# Ce gate est le filet : il compare chaque notebook modifie entre sa base git
+# (origin/<base_ref>) et sa tete (working tree) et signale toute cellule
+# markdown dont le contenu normalise chute sous 75 % du volume d'origine, et
+# toute perte de motif structurant (Navigation / Objectifs / Prerequis / Enonce
+# / liens de navigation). La transformation LEGITIME titre->callout est
+# invisible apres normalisation (heading `#{1,6}` et callout `> **X :**` sont
+# retires) -> pas de faux positif sur une demotion honnete.
+#
+# Detector: scripts/notebook_tools/detect_md_content_loss.py (#8655), run in
+# --check mode (exit 0 clean, exit 1 on defect) on every notebook changed by
+# the PR. Diff-scoped (base git vs working tree) : les pertes pre-existantes
+# sur `main` ne sont pas relevees tant que le notebook n'est pas touche
+# (clavette, comme degenerate-figure-gate).
+#
+# Sortie exploitable en review : fichier / cellule / avant-apres / ratio /
+# motifs perdus. Le detecteur SIGNALE ; la PR justifie en review (une
+# reformulation legitime qui resserre le texte reste au-dessus de 75 %).
+#
+# See issue #8655 (cahier des charges + 3 cas reels), registre #3966 (le rollout
+# demotion-de-titres dont provient le defaut), degenerate-figure-gate.yml
+# (modele de gate diff-scoped), detect_link_target_regression.py (modele de
+# detecteur base-vs-head).
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'MyIA.AI.Notebooks/**/*.ipynb'
+      - 'scripts/notebook_tools/detect_md_content_loss.py'
+      - '.github/workflows/md-content-loss-gate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  md-content-loss:
+    name: "No markdown content loss in changed notebooks"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Gate changed notebooks
+        run: |
+          set -uo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "::notice title=Markdown content-loss gate::Manual dispatch — nothing to diff."
+            exit 0
+          fi
+
+          BASE="origin/${{ github.base_ref }}"
+          CHANGED=$(git diff --name-only "$BASE"...HEAD -- 'MyIA.AI.Notebooks/**/*.ipynb' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "::notice title=Markdown content-loss gate::No notebooks changed — clean."
+            exit 0
+          fi
+
+          echo "## Markdown content-loss gate" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          fail=0
+          checked=0
+          while IFS= read -r nb; do
+            [ -z "$nb" ] && continue
+            # Skip notebooks deleted by the PR.
+            [ -f "$nb" ] || continue
+            checked=$((checked + 1))
+            out=$(python scripts/notebook_tools/detect_md_content_loss.py --base "$BASE" --check "$nb" 2>&1)
+            rc=$?
+            if [ "$rc" -eq 1 ]; then
+              echo "::error title=Markdown content loss::$nb lost substantial markdown content (truncated cell or lost structuring motif). If this is a legit rephrase, justify in review."
+              echo "<details><summary><code>$nb</code></summary>" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "$out" >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+              fail=1
+            elif [ "$rc" -eq 2 ]; then
+              echo "::warning title=Markdown content-loss gate::$nb could not be read (rc=2); see detector log."
+            fi
+          done <<< "$CHANGED"
+
+          if [ "$fail" -ne 0 ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "FIX: the demotion one-shot replaced a whole cell instead of just its heading line (joined-string bug). Restore the original markdown content and re-apply the heading->callout demotion LINE BY LINE (see `demote_md_asides.py --dir`). See issue #8655." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "::notice title=Markdown content-loss gate::Checked $checked changed notebook(s); no content loss."

--- a/scripts/notebook_tools/detect_md_content_loss.py
+++ b/scripts/notebook_tools/detect_md_content_loss.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Detecte la perte de contenu markdown entre la base d'une PR et sa tete (#8655).
+
+Pourquoi cet outil existe
+-------------------------
+Le rollout #3966 (demotion des titres-H1/H2 en callouts blockquote `> **X :**`)
+a un defaut mecanique silencieux : quand le correcteur one-shot opere "a la
+granularite ligne" sur une cellule dont le `source` est une **chaine unique
+jointe** (et non une liste de lignes), remplacer la "ligne" du titre remplace
+la **cellule entiere**. Une cellule de 941 caracteres se reduit a 16 ; un
+bloc `**Navigation**` + 5 objectifs + contexte disparait au profit d'un simple
+titre H2. Et la CI reste verte : `scan_md_hierarchy`, le verificateur de liens,
+le catalogue, la parite des jumeaux -- aucun ne mesure le **volume de prose
+markdown**. Une cellule 941c -> 16c compte pour `1-/1+` au `git diff --stat`.
+
+Deux PR reelles ont passe tous les gardes en detruisant du contenu
+(issue #8655, verifie firsthand) :
+
+  | PR    | Notebook                              | Cell | Avant | Apres | Contenu perdu                    |
+  |-------|---------------------------------------|------|-------|-------|----------------------------------|
+  | #8654 | Sudoku/Sudoku-1-...Python.ipynb       | 9    | 941 c | 16 c  | enonce + 4 contraintes + 3 indices|
+  | #8630 | GenAI/Texte/11_Quantization.ipynb     | 3    | 998 c | 28 c  | Navigation + duree + prerequis   |
+  | #8630 | GenAI/Texte/12_Test_Time_Scaling.ipynb| 2    | 1655c | 61 c  | Navigation + ref Snell 2024      |
+
+Comment ca marche
+-----------------
+Pour chaque notebook compare entre sa base git (defaut origin/main) et sa tete
+(working tree ou ref explicite), cet outil :
+
+  1. NORMALISE le contenu markdown de chaque cellule : retire les marqueurs de
+     titre `#{1,6}` et les callouts `> **... :**` (la transformation LEGITIME
+     du rollout #3966), plus les espaces. La demotion d'un titre en callout
+     laisse alors une empreinte NORMALISEE IDENTIQUE -> invisible. Une perte
+     reelle de contenu se traduit par une chute du volume normalise.
+
+  2. COMPARAISON PAR FICHIER (total normalise) puis, **uniquement quand le
+     nombre de cellules est inchange**, descente au niveau cellule (design #1
+     de l'issue #8655). Une fusion/scission de cellule decale les index et
+     produirait des faux positifs position-par-position : on s'en garde en
+     restant au niveau fichier quand le compte bouge.
+
+  3. SEUIL DE CHUTE RELATIVE par cellule : signal si le volume normalise
+     devient < 75 % du volume d'origine, ET l'original etait substantiel
+     (>= MIN_ORIG_CHARS, pour ignorer les cellules triviales). Les 3 cas reels
+     chutent a 1-4 %, avec une marge enorme sous le seuil ; une reformulation
+     honnete qui resserre de 10-20 % reste au-dessus de 75 %.
+
+  4. MOTIFS STRUCTURANTS PERDUS : signale explicitement la disparition de
+     `**Navigation**`, `**Objectif(s)**`, `**Prerequis**`, `### Enonce`, et
+     des liens de navigation `[...](*.ipynb)` -- des elements dont la perte
+     est un signal fort independamment du seuil de caracteres.
+
+  5. NE BLOQUE PAS LA REFORMULATION LEGITIME : le detecteur SIGNALE, la PR
+     justifie en review (design #4). Sortie exploitable : fichier / cellule /
+     avant-apres / ratio / motifs perdus.
+
+Usage
+-----
+    # un notebook, diff vs origin/main (head = working tree)
+    python detect_md_content_loss.py NB.ipynb --check
+    python detect_md_content_loss.py NB.ipynb --base origin/main --head origin/fix/ma-branche --check
+    # sortie machine
+    python detect_md_content_loss.py NB.ipynb --json
+
+Exit codes
+----------
+    0 -- aucune perte de contenu detectee (ou mode non --check)
+    1 -- une ou plusieurs pertes detectees (--check)
+    2 -- erreur (notebook illisible, ref git introuvable)
+
+Voir aussi
+----------
+- detect_link_target_regression.py -- modele de detecteur base-vs-head
+- detect_caps_regression.py (#7198) -- autre regression markdown base-vs-head
+- scan_md_hierarchy / check_notebook_navlinks -- gardes existants (volume-aveugles)
+- Issue #8655 -- cahier des charges + 3 cas reels
+- Registre #3966 -- le rollout demotion-de-titres dont provient le defaut
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Seuil de chute relative : une cellule signale si son volume normalise devient
+# strictement inferieur a DROP_THRESHOLD x le volume d'origine (issue #8655 :
+# "p. ex. < 75 % du volume d'origine"). Les 3 cas reels chutent a 1-4 %.
+DROP_THRESHOLD = 0.75
+# Volume normalise minimal d'origine pour qu'une chute soit signalee : evite
+# le bruit sur les cellules triviales (un titre seul, un separateur).
+MIN_ORIG_CHARS = 100
+
+# Motifs structurants dont la disparition est un signal fort (design #3 #8655).
+# Notes : "Navigation" / "Objectif(s)" / "Prerequis" sont matches aussi bien en
+# titre (`## Navigation`) qu'en callout (`> **Navigation :**`) car la regex
+# cible le mot-cle hors-marqueurs. Les liens de navigation vers un notebook
+# sont comptes collectivement (perte = N liens disparus).
+MOTIF_PATTERNS = [
+    (re.compile(r"\bNavigation\b", re.I), "Navigation"),
+    (re.compile(r"\bObjectifs?\b", re.I), "Objectif(s)"),
+    (re.compile(r"\bPr[eé]requis\b", re.I), "Prerequis"),
+    (re.compile(r"^#{1,6}\s*Enonc[eé]", re.I | re.M), "Enonce"),
+]
+NAV_LINK_RE = re.compile(r"\[[^\]]+\]\([^)]+\.ipynb\)")
+
+
+def _normalize(md_text: str) -> str:
+    """Normalise le contenu markdown pour la comparaison de volume.
+
+    Retire les transformations LEGITIMES du rollout #3966 (titre H1-H6 ->
+    callout blockquote `> **X :**`) afin qu'une demotion honnete laisse une
+    empreinte identique (pas de signal), puis retire les espaces. Une perte
+    reelle de contenu (cellule tronquee) se traduit par une chute du volume.
+    """
+    # 1. Marqueurs de titre en debut de ligne : "## Foo" -> "Foo".
+    t = re.sub(r"^[ \t]*#{1,6}[ \t]+", "", md_text, flags=re.M)
+    # 2. Callouts blockquote de la forme "> **Mot :** ..." (leger data du
+    #    rollout #3966) : on retire la LIGNE-entiere de callout quand elle
+    #    n'est QU'un marqueur (pas de contenu supplaitre apres). Cela evite
+    #    qu'un titre legitiment demote en callout soit compte comme "nouveau"
+    #    contenu par rapport au titre original.
+    t = re.sub(r"^[ \t]*>\s*\*\*[^*\n]*:\*\*\s*$", "", t, flags=re.M)
+    # 3. Espaces : on compare le volume de PROSE, pas la mise en forme.
+    t = re.sub(r"\s+", "", t)
+    return t
+
+
+def _norm_len(md_text: str) -> int:
+    return len(_normalize(md_text))
+
+
+def extract_md_cells(nb: dict) -> list[tuple[int, str]]:
+    """Retourne [(cell_idx, source_str)] pour les cellules markdown seulement."""
+    out = []
+    for idx, c in enumerate(nb.get("cells", [])):
+        if c.get("cell_type") != "markdown":
+            continue
+        src = c.get("source", [])
+        src = "".join(src) if isinstance(src, list) else (src or "")
+        out.append((idx, src))
+    return out
+
+
+def _collect_motifs(nb: dict) -> dict:
+    """Compte les occurrences de chaque motif structurant dans le notebook.
+
+    Retourne {motif_label: count} + {'nav_links': count}. La comparaison
+    base/head revelera les motifs disparus (count tombe a 0).
+    """
+    counts: dict = {}
+    full_md = "\n".join(src for _, src in extract_md_cells(nb))
+    for pat, label in MOTIF_PATTERNS:
+        counts[label] = len(pat.findall(full_md))
+    counts["nav_links"] = len(NAV_LINK_RE.findall(full_md))
+    return counts
+
+
+def read_notebook_at_ref(nb_path: Path, ref: str) -> dict | None:
+    """Lit le contenu d'un notebook a un ref git donne via `git show ref:path`."""
+    rel = nb_path.as_posix()
+    try:
+        out = subprocess.run(
+            ["git", "show", f"{ref}:{rel}"],
+            capture_output=True, text=True, encoding="utf-8", check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if out.returncode != 0 or not out.stdout:
+        return None
+    try:
+        return json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def _compare_cells(base_md: list[tuple[int, str]],
+                   head_md: list[tuple[int, str]]) -> list[dict]:
+    """Compare cellule-par-cellule (INDEX STABLE requis, design #1 #8655).
+
+    Ne descend au niveau cellule QUE quand le nombre de cellules markdown est
+    inchange entre base et head ; sinon une fusion/scission decale les index et
+    produirait des faux positifs position-par-position (26 FP observes sur
+    10_LocalLlama.ipynb, cite dans l'issue). Retourne les cellules tronquees.
+    """
+    findings: list[dict] = []
+    if len(base_md) != len(head_md):
+        return findings  # compte modifie -> la comparaison fichier suffit
+    for (b_idx, b_src), (h_idx, h_src) in zip(base_md, head_md):
+        b_norm = _norm_len(b_src)
+        h_norm = _norm_len(h_src)
+        if b_norm < MIN_ORIG_CHARS:
+            continue  # cellule d'origine trop courte pour qu'une chute soit du bruit
+        if h_norm < DROP_THRESHOLD * b_norm:
+            ratio = (h_norm / b_norm) if b_norm else 0.0
+            findings.append({
+                "kind": "TRUNCATED_CELL",
+                "cell_idx": h_idx,
+                "before_chars": b_norm,
+                "after_chars": h_norm,
+                "ratio": round(ratio, 3),
+                "before_excerpt": b_src.strip().split("\n", 1)[0][:90],
+                "after_excerpt": h_src.strip().split("\n", 1)[0][:90],
+            })
+    return findings
+
+
+def _compare_motifs(base_counts: dict, head_counts: dict) -> list[dict]:
+    """Signale les motifs structurants disparus (present en base, absent en head)."""
+    findings: list[dict] = []
+    for key, b_count in base_counts.items():
+        h_count = head_counts.get(key, 0)
+        if b_count > 0 and h_count == 0:
+            findings.append({
+                "kind": "LOST_MOTIF",
+                "motif": key,
+                "before_count": b_count,
+            })
+        elif key == "nav_links" and h_count < b_count:
+            # Perte PARTIELLE de liens de navigation : signalee (secondary).
+            findings.append({
+                "kind": "LOST_NAV_LINKS",
+                "motif": "nav_links",
+                "before_count": b_count,
+                "after_count": h_count,
+                "delta": b_count - h_count,
+            })
+    return findings
+
+
+def scan_notebook(nb_path: Path, base_ref: str, head_ref: str | None = None) -> dict:
+    """Compare le contenu markdown d'un notebook entre base_ref et head_ref."""
+    if head_ref is None:
+        try:
+            nb_head = json.loads(nb_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            return {"notebook": str(nb_path), "error": f"head unreadable: {e}"}
+        head_label = "working_tree"
+    else:
+        nb_head = read_notebook_at_ref(nb_path, head_ref)
+        if nb_head is None:
+            return {"notebook": str(nb_path), "error": f"head_ref {head_ref} unreadable"}
+        head_label = head_ref
+
+    nb_base = read_notebook_at_ref(nb_path, base_ref)
+    if nb_base is None:
+        return {"notebook": str(nb_path), "error": f"base_ref {base_ref} unreadable"}
+
+    base_md = extract_md_cells(nb_base)
+    head_md = extract_md_cells(nb_head)
+
+    findings: list[dict] = []
+    findings.extend(_compare_cells(base_md, head_md))
+    findings.extend(_compare_motifs(_collect_motifs(nb_base), _collect_motifs(nb_head)))
+
+    base_total = sum(_norm_len(s) for _, s in base_md)
+    head_total = sum(_norm_len(s) for _, s in head_md)
+
+    return {
+        "notebook": str(nb_path),
+        "base_ref": base_ref,
+        "head_ref": head_label,
+        "findings": findings,
+        "stats": {
+            "base_md_cells": len(base_md),
+            "head_md_cells": len(head_md),
+            "cell_count_stable": len(base_md) == len(head_md),
+            "base_total_normalized_chars": base_total,
+            "head_total_normalized_chars": head_total,
+            "findings_count": len(findings),
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("notebook", type=Path, help="Chemin vers le .ipynb")
+    p.add_argument("--base", default="origin/main", help="Ref git de la base (defaut origin/main)")
+    p.add_argument("--head", default=None, help="Ref git du head (defaut working tree)")
+    p.add_argument("--check", action="store_true", help="Exit 1 si perte detectee (CI)")
+    p.add_argument("--json", action="store_true", help="Sortie JSON machine")
+    args = p.parse_args(argv)
+
+    if not args.notebook.exists():
+        print(f"ERROR: notebook introuvable: {args.notebook}", file=sys.stderr)
+        return 2
+
+    result = scan_notebook(args.notebook, args.base, args.head)
+
+    if "error" in result:
+        print(f"ERROR: {result['error']}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        nb = result["notebook"]
+        st = result["stats"]
+        fins = result["findings"]
+        print(f"[NOTEBOOK] {nb}")
+        print(f"[BASE]     {result['base_ref']}")
+        print(f"[HEAD]     {result['head_ref']}")
+        print(f"[STATS]    md_cells base={st['base_md_cells']} head={st['head_md_cells']} "
+              f"stable={st['cell_count_stable']} | "
+              f"normalized_chars base={st['base_total_normalized_chars']} "
+              f"head={st['head_total_normalized_chars']} | findings={st['findings_count']}")
+        if fins:
+            print("\n[FINDINGS]")
+            for f in fins:
+                if f["kind"] == "TRUNCATED_CELL":
+                    print(f"  - cell {f['cell_idx']} {f['kind']}: "
+                          f"{f['before_chars']}c -> {f['after_chars']}c "
+                          f"(ratio {f['ratio']}, seuil {DROP_THRESHOLD})")
+                    print(f"      before: {f['before_excerpt']!r}")
+                    print(f"      after:  {f['after_excerpt']!r}")
+                elif f["kind"] == "LOST_MOTIF":
+                    print(f"  - {f['kind']}: '{f['motif']}' disparu "
+                          f"(base={f['before_count']})")
+                elif f["kind"] == "LOST_NAV_LINKS":
+                    print(f"  - {f['kind']}: {f['delta']} lien(s) de navigation en moins "
+                          f"({f['before_count']} -> {f['after_count']})")
+
+    if args.check and result["findings"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_detect_md_content_loss.py
+++ b/scripts/notebook_tools/tests/test_detect_md_content_loss.py
@@ -1,0 +1,228 @@
+"""Tests for scripts/notebook_tools/detect_md_content_loss.py (issue #8655).
+
+Couvre les 4 scenarios d'acceptation + le comportement de normalisation :
+  - cellule tronquee (signal)
+  - cellules fusionnees (PAS de signal -- FP interdit, design #1)
+  - scission de cellule (PAS de signal -- FP interdit, design #1)
+  - reformulation neutre (PAS de signal -- design #4)
+  - demotion legitime titre -> callout (PAS de signal -- c'est la transformation
+    #3966 saine, doit etre invisible apres normalisation)
+  - perte de motif structurant (signal independant du seuil de caracteres)
+"""
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import detect_md_content_loss as dml  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _md(src):
+    """Cellule markdown avec source (str ou list)."""
+    return {"cell_type": "markdown", "source": src, "metadata": {}}
+
+
+def _nb(*cells):
+    return {"cells": list(cells), "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+
+
+# Une cellule pedagogique substantielle (~700c normalises, au-dessus de MIN_ORIG_CHARS).
+EXERCISE_BODY = (
+    "## Exercice : Verifier qu'une grille est valide\n\n"
+    "### Enonce\n\n"
+    "Apres avoir resolu un Sudoku avec le backtracking, il est essentiel de "
+    "verifier que la solution obtenue est bien valide. Implementez une fonction "
+    "qui verifie les contraintes suivantes :\n\n"
+    "1. Chaque ligne contient les chiffres 1 a 9 sans repetition.\n"
+    "2. Chaque colonne contient les chiffres 1 a 9 sans repetition.\n"
+    "3. Chaque bloc 3x3 contient les chiffres 1 a 9 sans repetition.\n\n"
+    "**Indices gradues** :\n\n"
+    "- Indice 1 : pensez a utiliser des ensembles pour detecter les doublons.\n"
+    "- Indice 2 : decoupez la verification en trois sous-fonctions.\n"
+    "- Indice 3 : la contrainte de bloc utilise des coordonnees en blocs de 3.\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Normalisation -- la demotion legitime (titre -> callout) est invisible
+# ---------------------------------------------------------------------------
+class TestNormalize:
+    def test_heading_stripped(self):
+        # "## Foo" et "Foo" normalisent identiquement.
+        assert dml._normalize("## Foo bar") == dml._normalize("Foo bar")
+
+    def test_callout_stripped(self):
+        # Une LIGNE entiere qui n'est qu'un callout #3966 `> **X :**` disparait
+        # a la normalisation (c'est la transformation legitime titre->callout).
+        # NB : une ligne avec du contenu APRES le callout n'est pas un callout
+        # pur et n'est pas retiree (le contenu reste).
+        pure_callout = "> **Navigation :**"
+        assert dml._normalize(pure_callout) == ""
+
+    def test_legit_demotion_is_invisible(self):
+        # La transformation SAINE du rollout #3966 : titre H1 -> callout blockquote.
+        # Apres normalisation, le VOLUME de contenu doit etre identique -> pas de
+        # signal de perte (c'est le coeur de l'anti-FP).
+        before = "# 11. Quantization des LLMs\n\n" + ("Objectif general. " * 20)
+        after = "## 11. Quantization des LLMs\n\n" + ("Objectif general. " * 20)
+        assert dml._norm_len(before) == dml._norm_len(after)
+
+    def test_whitespace_collapsed(self):
+        assert dml._normalize("a  b\n\n  c") == dml._normalize("abc")
+
+
+# ---------------------------------------------------------------------------
+# 2. Cellule tronquee (signal) -- le defaut reel de #8654/#8630
+# ---------------------------------------------------------------------------
+class TestTruncatedCell:
+    def test_massive_truncation_signals(self):
+        # Cas reel #8654 cell 9 : 941c -> 16c (seul le callout d'indices reste).
+        base = _nb(_md(EXERCISE_BODY))
+        head = _nb(_md("> **Indices :**"))
+        findings = dml._compare_cells(dml.extract_md_cells(base), dml.extract_md_cells(head))
+        assert len(findings) == 1
+        f = findings[0]
+        assert f["kind"] == "TRUNCATED_CELL"
+        assert f["ratio"] < dml.DROP_THRESHOLD
+        assert f["before_chars"] >= dml.MIN_ORIG_CHARS
+
+    def test_tiny_original_not_flagged(self):
+        # Une cellule d'origine trop courte (< MIN_ORIG_CHARS) n'est pas signalee
+        # meme si elle est tronquee -> evite le bruit sur les cellules triviales.
+        short = "## Titre court\n"  # ~10c normalises < 100
+        base = _nb(_md(short))
+        head = _nb(_md("> **Titre :**"))
+        findings = dml._compare_cells(dml.extract_md_cells(base), dml.extract_md_cells(head))
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Cellules fusionnees (FAUX POSITIF a NE PAS lever, design #1)
+# ---------------------------------------------------------------------------
+class TestMergedCellsNoFalsePositive:
+    def test_merge_preserves_content_no_signal(self):
+        # Deux cellules base fusionnees en une seule head : le compte change
+        # (2 -> 1), la comparaison cellule-par-cellule est court-circuitee, et le
+        # contenu total est preserve -> 0 signal.
+        part1 = "## Section A\n\n" + ("Contenu A. " * 20)
+        part2 = "## Section B\n\n" + ("Contenu B. " * 20)
+        merged = part1 + "\n\n" + part2  # tout est la, juste fusionne
+        base = _nb(_md(part1), _md(part2))
+        head = _nb(_md(merged))
+        findings = dml._compare_cells(dml.extract_md_cells(base), dml.extract_md_cells(head))
+        assert findings == [], "une fusion qui preserve le contenu ne doit PAS etre signalee"
+
+
+# ---------------------------------------------------------------------------
+# 4. Scission de cellule (FAUX POSITIF a NE PAS lever, design #1)
+# ---------------------------------------------------------------------------
+class TestSplitCellNoFalsePositive:
+    def test_split_preserves_content_no_signal(self):
+        # Une cellule base scindee en deux head : le compte change (1 -> 2),
+        # court-circuit, contenu total preserve -> 0 signal.
+        whole = "## Section\n\n" + ("Contenu. " * 40)
+        base = _nb(_md(whole))
+        head = _nb(_md("## Section\n"), _md(("Contenu. " * 40)))
+        findings = dml._compare_cells(dml.extract_md_cells(base), dml.extract_md_cells(head))
+        assert findings == [], "une scission qui preserve le contenu ne doit PAS etre signalee"
+
+
+# ---------------------------------------------------------------------------
+# 5. Reformulation neutre (PAS de signal, design #4)
+# ---------------------------------------------------------------------------
+class TestNeutralRephraseNoSignal:
+    def test_minor_tightening_below_threshold(self):
+        # Une reformulation qui resserre le texte de ~15 % reste au-dessus du
+        # seuil de 75 % -> pas de signal. (Seul un effondrement est signale.)
+        long_body = ("Phrase pedagogique assez longue pour rester substantielle. " * 12)
+        base = _nb(_md("## Titre\n\n" + long_body))
+        # On retire ~10 % du contenu (une phrase sur dix), reste > 75 %.
+        trimmed = "## Titre\n\n" + ("Phrase pedagogique assez longue pour rester substantielle. " * 11)
+        head = _nb(_md(trimmed))
+        findings = dml._compare_cells(dml.extract_md_cells(base), dml.extract_md_cells(head))
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Motifs structurants (signal independant du seuil de caracteres)
+# ---------------------------------------------------------------------------
+class TestLostMotifs:
+    def test_lost_navigation_motif_signals(self):
+        # La disparition du bloc **Navigation** est signalee meme si la chute de
+        # caracteres est borderline. NB : le mot-cle est matche case-insensitive,
+        # donc le head ne doit PAS contenir "navigation" pour que la perte soit vue.
+        base = _nb(_md("**Navigation** : [Index](README.md) | [Suivant](11.ipynb)"))
+        head = _nb(_md("Titre simple."))
+        findings = dml._compare_motifs(dml._collect_motifs(base), dml._collect_motifs(head))
+        labels = [f["motif"] for f in findings]
+        assert "Navigation" in labels
+
+    def test_partial_nav_link_loss_signals(self):
+        # Perte PARTIELLE de liens de navigation (4 -> 2) -> LOST_NAV_LINKS.
+        base = _nb(_md("[a](1.ipynb) [b](2.ipynb) [c](3.ipynb) [d](4.ipynb)"))
+        head = _nb(_md("[a](1.ipynb) [b](2.ipynb)"))
+        findings = dml._compare_motifs(dml._collect_motifs(base), dml._collect_motifs(head))
+        kinds = [(f["kind"], f["delta"]) for f in findings]
+        assert ("LOST_NAV_LINKS", 2) in kinds
+
+    def test_motif_preserved_no_signal(self):
+        # Le motif survit -> pas de signal.
+        base = _nb(_md("**Navigation** : [Index](README.md)"))
+        head = _nb(_md("**Navigation** : [Index](README.md) | [Suivant](2.ipynb)"))
+        findings = dml._compare_motifs(dml._collect_motifs(base), dml._collect_motifs(head))
+        assert all(f["kind"] != "LOST_MOTIF" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# 7. scan_notebook end-to-end (base via mock, head = working tree tmp file)
+# ---------------------------------------------------------------------------
+class TestScanNotebook:
+    def _scan(self, tmp_path, base_nb, head_nb, nb_name="x.ipynb"):
+        p = tmp_path / nb_name
+        p.write_text(json.dumps(head_nb), encoding="utf-8")
+        with mock.patch.object(dml, "read_notebook_at_ref", return_value=base_nb):
+            return dml.scan_notebook(p, base_ref="MOCK_BASE", head_ref=None)
+
+    def test_truncation_end_to_end(self, tmp_path):
+        r = self._scan(tmp_path, _nb(_md(EXERCISE_BODY)), _nb(_md("> **Indices :**")))
+        assert r["stats"]["findings_count"] >= 1
+        assert any(f["kind"] == "TRUNCATED_CELL" for f in r["findings"])
+
+    def test_clean_demotion_end_to_end(self, tmp_path):
+        # Demotion legitime (titre -> callout, contenu preserve) -> 0 finding.
+        before = "# Titre\n\n" + ("Contenu pedagogique substantiel. " * 15)
+        after = "## Titre\n\n" + ("Contenu pedagogique substantiel. " * 15)
+        r = self._scan(tmp_path, _nb(_md(before)), _nb(_md(after)))
+        assert r["stats"]["findings_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 8. main() exit codes
+# ---------------------------------------------------------------------------
+class TestMainExitCodes:
+    def _run(self, tmp_path, base_nb, head_nb):
+        p = tmp_path / "x.ipynb"
+        p.write_text(json.dumps(head_nb), encoding="utf-8")
+        with mock.patch.object(dml, "read_notebook_at_ref", return_value=base_nb):
+            return dml.main([str(p), "--base", "MOCK", "--check"])
+
+    def test_exit_1_on_truncation(self, tmp_path):
+        assert self._run(tmp_path, _nb(_md(EXERCISE_BODY)), _nb(_md("> **Indices :**"))) == 1
+
+    def test_exit_0_on_clean(self, tmp_path):
+        before = "# Titre\n\n" + ("Contenu. " * 20)
+        after = "## Titre\n\n" + ("Contenu. " * 20)
+        assert self._run(tmp_path, _nb(_md(before)), _nb(_md(after))) == 0
+
+    def test_exit_2_on_missing_base_ref(self, tmp_path):
+        # base_ref illisible -> erreur -> exit 2.
+        p = tmp_path / "x.ipynb"
+        p.write_text(json.dumps(_nb(_md("ok"))), encoding="utf-8")
+        with mock.patch.object(dml, "read_notebook_at_ref", return_value=None):
+            assert dml.main([str(p), "--base", "BAD_REF", "--check"]) == 2


### PR DESCRIPTION
Grain: DEEP/tooling — lane myia-po-2024:CoursIA-2 — prev: forensics (c.917).

## Summary

Closes #8655. Adds `detect_md_content_loss.py` — the missing per-PR gate for markdown content loss — + a CI workflow wiring it. Two PRs of the #3966 rollout (#8654 Sudoku, #8630 GenAI/Texte) destroyed substantial pedagogical content (a 941-char exercise cell → 16 chars; a 1655-char Navigation+reference block → 61) while passing 30/30 and 31/31 checks. No scanner measured markdown prose volume: this detector closes that gap.

## Why the existing guards miss it

A cell collapsing 941→16 chars counts as `1-/1+` at `git diff --stat`. `scan_md_hierarchy`, the navigation-link checker, the catalogue, twin parity — none compare markdown **content volume** base-vs-head. The defect slips through.

## The detector — `scripts/notebook_tools/detect_md_content_loss.py`

Compares each changed notebook between its git base (`origin/<base_ref>`) and head (working tree):

1. **Normalize** — strips heading markers `#{1,6}` and pure callout lines `> **X :**` (the LEGIT #3966 demotion) + whitespace. A honest heading→callout demotion leaves an **identical normalized footprint → invisible**. A real truncation shows as a normalized-volume collapse.
2. **File-level first, cell-level only when count is stable** (design #1) — when cell count changes (merge/split), position-by-position comparison would false-alarm (26 FP observed on `10_LocalLlama.ipynb`); the detector stays at file-level there.
3. **Relative-drop threshold** — flags a cell when its normalized volume falls below **75 %** of original AND original ≥ 100 chars (ignores trivial cells). The 3 real cases collapse to 1–4 %.
4. **Structuring-motif loss** — independently flags disappearance of `Navigation` / `Objectif(s)` / `Prérequis` / `### Enoncé` / navigation links, regardless of char threshold.
5. **Doesn't block legit rephrase** — a tightening of ~15 % stays above 75 %; the detector signals, the PR justifies (design #4).

Modeled on `detect_link_target_regression.py` (base-vs-head, exit 0/1/2, `--check`/`--json`).

## Acceptance criteria (#8655) — all verified firsthand

- **Detector + tests present** — 17 tests covering truncated cell, merged cells (no FP), cell split (no FP), neutral rephrase (no FP), legit demotion (no FP), lost motifs, exit codes. `3432/3432` notebook_tools tests pass (was 3415; +17), 0 regression.
- **Replays on #8654 + #8630 heads — signals the 3 cells**:
  - `Sudoku-1-...Python.ipynb` cell 9: `TRUNCATED_CELL 770c→0c` (ratio 0.0)
  - `11_Quantization.ipynb` cell 3: `TRUNCATED_CELL 836c→22c` + `LOST_MOTIF Navigation/Prerequis/nav_links`
  - `12_Test_Time_Scaling.ipynb` cell 2: `TRUNCATED_CELL 1421c→47c` + `LOST_NAV_LINKS`
- **Replays on #8647 merge (721385282, healthy Tweety tranche) — 0 signals** across all **11** Tweety notebooks (legit line-by-line demotion, content preserved).
- **FP stress** — the OTHER 4 Sudoku notebooks in #8654's rollout (legit demotions) → **0 findings** each; only the 1 real bug (cell 9) flags.
- **CI wired** — `.github/workflows/md-content-loss-gate.yml`, diff-scoped (`git diff base...HEAD`), passes `--base origin/<base_ref>`, exit 1 blocks. Modeled on `degenerate-figure-gate.yml`.

## Validation

- `py_compile` OK; **LF-only** (0 CR) on all 3 files; YAML lint OK.
- Atomic (G.4): 3 files, one coherent feature (content-loss gate).
- L898 collision guard: 0 open PR on #8655 / `detect_md_content_loss` (file absent on main). Rebase frais sur `origin/main` (`de59ec2bb`, 0 behind).

## Genre / scope

DEEP/tooling (new base-vs-head detector with verified precision on 3 real defects + 15 healthy-notebook FP-proving — not scan-generatable). CPU-only. Distinct genre from c.917 (forensics) and c.916 (P1 review-fix).

`Closes #8655`. See #3966 (the rollout whose defect this catches), #8654/#8630 (the 2 buggy PRs that proved the gap).
