### PR TITLE
Fix: scan_md_hierarchy ne rapporte plus `0/0 flagged` sur un scan vide (cible obligatoire, exit codes)

### DIFF
--- a/docs/reference/notebook-formatting.md
+++ b/docs/reference/notebook-formatting.md
@@ -34,7 +34,15 @@ Un **indice / objectif / étape / conseil / note / remarque / attention / TODO**
 python scripts/notebook_tools/scan_md_hierarchy.py MyIA.AI.Notebooks/Sudoku
 # Tout l'arbre
 python scripts/notebook_tools/scan_md_hierarchy.py MyIA.AI.Notebooks
+# En porte (exit 1 des qu'un notebook est flague) — sinon recensement, exit 0
+python scripts/notebook_tools/scan_md_hierarchy.py MyIA.AI.Notebooks --fail-on-findings
 ```
+
+**La cible est obligatoire.** Sans argument, ou sur un chemin mal orthographie, ou
+sur un repertoire sans notebook, le scanner sort en **erreur (exit 2)** au lieu
+d'afficher `0/0 notebooks flagges` — un scan vide n'est pas un scan propre. Meme
+classe de defaut que le critere d'acceptation « le scanner rapporte 0 » de #3968,
+satisfait a vide pendant que ~194 hint-headings au pluriel survivaient.
 
 Etat initial (2026-06-23) : **261/676 notebooks flagges** (GenAI 71, QuantConnect 47, SymbolicAI 43, Sudoku 28, ML 23, Probas 17, GameTheory 14, Search 11, RL 5, CaseStudies 2).
 

--- a/scripts/notebook_tools/README.md
+++ b/scripts/notebook_tools/README.md
@@ -431,6 +431,13 @@ markdown interpretation -> code exercice -> ...) selon la convention
 Audit hierarchie markdown : pas de saut H1->H3, titres uniques, structure
 progressive pedagogique.
 
+- Cible **obligatoire** : sans argument / chemin errone / repertoire sans
+  notebook -> **exit 2**, jamais `0/0 notebooks flagged` (un scan vide n'est
+  pas un scan propre).
+- `--fail-on-findings` : exit 1 des qu'un notebook est flague. Par defaut mode
+  recensement (exit 0), ce qu'attend le job informationnel de
+  `.github/workflows/markdown-rendering-guard.yml`.
+
 ---
 
 ## Anti-banner / hygiene (Stop & Repair, secrets-hygiene §6)

--- a/scripts/notebook_tools/scan_md_hierarchy.py
+++ b/scripts/notebook_tools/scan_md_hierarchy.py
@@ -17,10 +17,16 @@ Detects (source-level, render-agnostic):
     (multiple competing H1s / H1 used mid-notebook -> title hierarchy muddled).
   - MULTI-H1: more than one H1 across the whole notebook.
 
-Usage: python scan_md_hierarchy.py <notebook-or-dir> [more...]
+Usage: python scan_md_hierarchy.py <notebook-or-dir> [more...] [--fail-on-findings]
 Outputs a per-notebook report + a machine-readable summary line per finding.
+
+An EMPTY scan is never reported as a clean scan: no argument, a mistyped path,
+or a directory holding no notebook exits 2 with a message on stderr instead of
+printing `0/0 notebooks flagged`. This scanner has already been fooled once by
+a vacuous zero (the #3968 acceptance criterion, see HINT_RE below); `0/0` was
+the second mouth of the same trap.
 """
-import json, re, sys, pathlib
+import argparse, json, re, sys, pathlib
 
 HEADING_RE = re.compile(r'^(#{1,6})\s+(.*\S)\s*$')
 # Fenced code block delimiter (```... or ~~~...), possibly indented. Lines inside
@@ -188,18 +194,42 @@ def scan_notebook(path):
     return findings
 
 def iter_notebooks(args):
+    """Yield the notebooks designated by `args` (dirs are walked recursively).
+
+    Raises ValueError if a target designates nothing, so that a typo can never
+    be mistaken for a clean scan (see `main`).
+    """
+    unresolved = []
     for a in args:
         p = pathlib.Path(a)
         if p.is_dir():
             yield from sorted(p.rglob('*.ipynb'))
-        elif p.suffix == '.ipynb':
+        elif p.suffix == '.ipynb' and p.is_file():
             yield p
+        else:
+            unresolved.append(a)
+    if unresolved:
+        raise ValueError('not a notebook nor a directory: ' + ', '.join(unresolved))
 
-def main():
-    targets = sys.argv[1:]
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('paths', nargs='+', metavar='NOTEBOOK-OR-DIR',
+                        help='notebooks and/or directories to scan (recursive)')
+    parser.add_argument('--fail-on-findings', action='store_true',
+                        help='exit 1 when at least one notebook is flagged '
+                             '(default: always exit 0, census mode)')
+    args = parser.parse_args(argv)
+
+    try:
+        notebooks = list(iter_notebooks(args.paths))
+    except ValueError as exc:
+        parser.error(str(exc))
+
     total = 0
     flagged = 0
-    for nb in iter_notebooks(targets):
+    for nb in notebooks:
         if '_output' in nb.name or '.ipynb_checkpoints' in str(nb):
             continue
         total += 1
@@ -209,7 +239,15 @@ def main():
             print(f'\n## {nb.as_posix()}')
             for f in fs:
                 print(f"  [{f['kind']}] cell {f['cell']}  L{f.get('level','?')}  {f['text']}")
+    if total == 0:
+        # An empty scan is NOT a clean scan: say so, and fail. `0/0 flagged`
+        # otherwise reads as an all-clear while nothing has been looked at.
+        print('ERROR: no notebook found under the given paths -- nothing was '
+              'scanned, this is NOT an all-clear.', file=sys.stderr)
+        return 2
+    # Keep this the LAST stdout line: the CI census reads it with `tail -1`.
     print(f'\n=== {flagged}/{total} notebooks flagged ===')
+    return 1 if (flagged and args.fail_on_findings) else 0
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_scan_md_hierarchy.py
+++ b/scripts/notebook_tools/tests/test_scan_md_hierarchy.py
@@ -13,7 +13,7 @@ import tempfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from scan_md_hierarchy import scan_notebook, _has_collapsed_markdown  # noqa: E402
+from scan_md_hierarchy import scan_notebook, _has_collapsed_markdown, main  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -292,3 +292,64 @@ def test_titled_step_no_colon_with_glued_colon_not_hint():
     """`### Step 1:Import...` (glued colon, no space) also matches — GFM-style."""
     cells = [_md("# Titre\n"), _md("### Step 1:Import configuration\n")]
     assert "HINT-AS-HEADING" not in _kinds(_write_nb(cells))
+
+
+# ---------------------------------------------------------------------------
+# CLI contract — an EMPTY scan is never reported as a CLEAN scan
+#
+# The scanner used to print `=== 0/0 notebooks flagged ===` and exit 0 whenever
+# it had been handed nothing to look at: no argument at all, a mistyped path, a
+# flag swallowed as a positional. That output reads as an all-clear while
+# nothing was scanned. Same defect class as the vacuous `scanner reports 0`
+# acceptance criterion of #3968 (see HINT_RE in the scanner).
+# ---------------------------------------------------------------------------
+
+def _run(argv: list[str]) -> int:
+    """Run main(argv), returning its exit code (argparse errors -> SystemExit)."""
+    try:
+        return main(argv)
+    except SystemExit as exc:  # argparse.error() / --help
+        return exc.code
+
+
+def test_no_argument_is_an_error_not_an_all_clear():
+    assert _run([]) == 2
+
+
+def test_mistyped_path_is_an_error_not_an_all_clear():
+    """A path that designates nothing must fail, not scan zero notebooks."""
+    assert _run(["MyIA.AI.Notebook"]) == 2  # missing final 's'
+
+
+def test_directory_without_notebooks_is_an_error():
+    with tempfile.TemporaryDirectory() as empty:
+        assert _run([empty]) == 2
+
+
+def test_clean_notebook_exits_zero():
+    nb = _write_nb([_md("# Titre\n"), _md("Du texte ordinaire.\n")])
+    assert _run([nb]) == 0
+
+
+def test_findings_stay_non_fatal_by_default():
+    """Census mode: the CI reads the summary line and must not be broken."""
+    nb = _write_nb([_md("# Titre\n"), _md("### Indices\n")])
+    assert _run([nb]) == 0
+
+
+def test_fail_on_findings_exits_one():
+    nb = _write_nb([_md("# Titre\n"), _md("### Indices\n")])
+    assert _run([nb, "--fail-on-findings"]) == 1
+
+
+def test_fail_on_findings_still_zero_when_clean():
+    nb = _write_nb([_md("# Titre\n"), _md("Du texte ordinaire.\n")])
+    assert _run([nb, "--fail-on-findings"]) == 0
+
+
+def test_summary_is_the_last_stdout_line(capsys):
+    """The CI census does `... | tail -1`: the summary must stay last."""
+    nb = _write_nb([_md("# Titre\n"), _md("### Indices\n")])
+    _run([nb])
+    assert capsys.readouterr().out.rstrip().splitlines()[-1] == (
+        "=== 1/1 notebooks flagged ===")


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: DEEP/lean (merge #8652)

## Le defaut

`scan_md_hierarchy.py` affichait `=== 0/0 notebooks flagged ===` et sortait **0** des qu'on ne lui donnait rien a regarder. Trois chemins y menaient :

```
$ python scripts/notebook_tools/scan_md_hierarchy.py
=== 0/0 notebooks flagged ===                      # exit 0

$ python scripts/notebook_tools/scan_md_hierarchy.py MyIA.AI.Notebook   # 's' oublie
=== 0/0 notebooks flagged ===                      # exit 0

$ python scripts/notebook_tools/scan_md_hierarchy.py --help
=== 0/0 notebooks flagged ===                      # exit 0, le flag avale comme chemin
```

Cette sortie se lit comme un feu vert. Elle signifie « je n'ai rien scanne ».

Je suis tombe dessus en l'invoquant a vide pendant l'audit de #8654 ce cycle, et j'ai failli en conclure que la famille etait propre.

## Ce n'est pas la premiere fois sur ce fichier

La docstring de `HINT_RE`, dans ce meme fichier, documente deja la version precedente du meme piege :

> `indice\b` ne matche pas `Indices` [...] ce qui explique qu'il rapportait 0 hint-headings alors que ~194 hint-headings au pluriel survivaient a la remediation #3968 (**le critere d'acceptation « le scanner rapporte 0 » de #3968 etait satisfait a vide**).

Un zero non qualifie avait deja valide une remediation qui n'avait pas eu lieu. Le `0/0` sur cible vide en etait la seconde bouche : meme mensonge, autre entree.

C'est aussi la classe de defaut de #8649 (une garde qui reste verte parce qu'elle ne regarde pas) et de ce que j'ai constate ailleurs ce cycle — #8654 et #8630 detruisent du contenu pedagogique avec 31/31 et 30/30 checks verts (issue #8655 ouverte pour le detecteur manquant).

## Le correctif

- **argparse** : la cible devient obligatoire ; `--help` fonctionne au lieu d'etre pris pour un chemin.
- **Cible non resolue** (typo, fichier non-`.ipynb`) -> `exit 2` en nommant le coupable :
  ```
  scan_md_hierarchy.py: error: not a notebook nor a directory: MyIA.AI.Notebook
  ```
- **Zero notebook trouve** -> message sur **stderr** + `exit 2` :
  ```
  ERROR: no notebook found under the given paths -- nothing was scanned, this is NOT an all-clear.
  ```
- **`--fail-on-findings`** (opt-in) -> `exit 1` quand au moins un notebook est flague, alignant ce scanner sur ses deux freres `detect_blank_figures.py` et `check_plotly_static_risk.py`, qui ont tous deux argparse + `sys.exit(1)`. Il etait le seul sans.

Le message d'erreur va sur stderr, jamais sur stdout : la ligne de resume reste la **derniere ligne stdout**.

## Compatibilite CI — verifiee, pas supposee

`.github/workflows/markdown-rendering-guard.yml` l. 89/92 appelle le scanner **avec** un chemin explicite, en mode informationnel :

```yaml
python scripts/notebook_tools/scan_md_hierarchy.py MyIA.AI.Notebooks | tail -1
python scripts/notebook_tools/scan_md_hierarchy.py MyIA.AI.Notebooks | grep -c 'HINT-AS-HEADING' || true
```

Les deux invocations sont inchangees. Mesure avant/apres sur l'arbre complet :

| | avant | apres |
|---|---|---|
| `\| tail -1` | `=== 99/961 notebooks flagged ===` | `=== 99/961 notebooks flagged ===` |
| `\| grep -c 'HINT-AS-HEADING'` | 179 | 179 |
| exit code | 0 | 0 |

Le defaut reste le mode recensement (exit 0) : `--fail-on-findings` est opt-in, la CI ne le passe pas, le job informationnel reste informationnel. Aucun autre appelant dans le depot (grep sur `*.yml`/`*.md`/`*.py`/`*.sh`/`*.ps1`).

## Tests

**31 verts** : les 23 preexistants, plus 8 sur le nouveau contrat CLI —

- pas d'argument -> 2
- chemin mal orthographie -> 2
- repertoire sans notebook -> 2
- notebook propre -> 0
- notebook flague sans le flag -> 0 (recensement, la CI ne casse pas)
- notebook flague avec `--fail-on-findings` -> 1
- notebook propre avec `--fail-on-findings` -> 0
- la ligne de resume est bien la derniere ligne stdout (garde du `tail -1`)

Les 23 tests preexistants importent `scan_notebook` et `_has_collapsed_markdown` directement : la logique de detection n'est pas touchee, seul le point d'entree CLI change.

## Perimetre

4 fichiers, +131/-10 dont 63 lignes de tests. Catalogue intouche. Rien dans `MyIA.AI.Notebooks/`. La logique de detection n'est pas modifiee — ce n'est pas une passe #3966, c'est la reparation de l'outil qui la mesure.

Recensement au passage, non traite ici : **99/961 notebooks flagges, 179 lignes HINT-AS-HEADING** restantes sur l'arbre. Le rollout #3966 est loin d'etre fini ; c'est le sujet des tranches, pas de cette PR.

See #3966
