### PR TITLE
docs(probas,#8081): Pearl/Kschischang/Gill citations Infer-3 C# twin (parity #8651)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
@@ -875,7 +875,8 @@
     "\n",
     "Quand le produit des rapports de vraisemblance vaut 1, les indices sont **parfaitement compensatoires** et on revient au prior.\n",
     "\n",
-    "> **Leçon** : L'inférence bayésienne combine **tous** les indices de manière cohérente, même quand ils pointent dans des directions opposées. C'est une propriété fondamentale : aucun indice n'est ignoré, mais leur impact relatif dépend de leur force discriminante."
+    "> **Leçon** : L'inférence bayésienne combine **tous** les indices de manière cohérente, même quand ils pointent dans des directions opposées. C'est une propriété fondamentale : aucun indice n'est ignoré, mais leur impact relatif dépend de leur force discriminante.",
+    "\n\n> **Référence** : La compensation exacte des indices (produit des LR ≈ 1) illustre la structure en V (collider) du Murder Mystery : l'arme et le cheveu sont deux effets d'une cause commune (le meurtrier), conditionnellement indépendants sachant cette cause. Pearl (1988), *Probabilistic Reasoning in Intelligent Systems* (Morgan Kaufmann), §3.3, formalise cette propagation de l'information dans les réseaux bayésiens (structures en chaîne, fourche et collider).\n"
    ]
   },
   {
@@ -1204,7 +1205,8 @@
     "\n",
     "Ce graphe illustre la structure de dépendance : le meurtrier influence a la fois l'arme et le cheveu, mais ces deux indices sont conditionnellement independants etant donne le meurtrier.\n",
     "\n",
-    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (executable `dot` sur le PATH) et de `FactorGraphHelper.GetLatestFactorGraphHtml()`, qui selectionne le fichier `Model_*.svg` le plus recent dans le repertoire de travail. Si Graphviz n'est pas disponible a l'exécution, l'image affichée peut etre un SVG mis en cache correspondant a un autre modèle. La structure reelle du modèle Murder Mystery (construite dans la cellule de code ci-dessus via `Variable.Bernoulli` + `Variable.If`) est celle decrite textuellement : `meurtrier -> {arme, cheveu}` avec les tables conditionnelles 0.9/0.8 (coupable) et 0.2/0.1 (innocent)."
+    "> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (executable `dot` sur le PATH) et de `FactorGraphHelper.GetLatestFactorGraphHtml()`, qui selectionne le fichier `Model_*.svg` le plus recent dans le repertoire de travail. Si Graphviz n'est pas disponible a l'exécution, l'image affichée peut etre un SVG mis en cache correspondant a un autre modèle. La structure reelle du modèle Murder Mystery (construite dans la cellule de code ci-dessus via `Variable.Bernoulli` + `Variable.If`) est celle decrite textuellement : `meurtrier -> {arme, cheveu}` avec les tables conditionnelles 0.9/0.8 (coupable) et 0.2/0.1 (innocent).",
+    "\n\n> **Référence** : Le graphe de facteurs comme représentation du produit de facteurs d'une distribution jointe, et l'algorithme sum-product (passage de messages) qui réalise l'inférence exacte sur un arbre de facteurs, sont formalisés dans Kschischang, Frey & Loeliger (2001), « Factor graphs and the sum-product algorithm », *IEEE Transactions on Information Theory* **47**(2):498-519. Infer.NET propage analytiquement ces messages par Expectation Propagation (EP), là où PyMC approxime par échantillonnage MCMC.\n"
    ]
   },
   {
@@ -1665,7 +1667,8 @@
     "\n",
     "C'est cette **asymétrie d'information** qui crée le paradoxe. L'action de Monty révèle indirectement où est la voiture.\n",
     "\n",
-    "> **Intuition correcte** : En changeant, vous captez les 2/3 de chance initiale que la voiture soit derrière l'une des portes non choisies. Avant l'ouverture, cette probabilité était répartie sur 2 portes. Après, elle se concentre sur une seule."
+    "> **Intuition correcte** : En changeant, vous captez les 2/3 de chance initiale que la voiture soit derrière l'une des portes non choisies. Avant l'ouverture, cette probabilité était répartie sur 2 portes. Après, elle se concentre sur une seule.",
+    "\n\n> **Source** : Le paradoxe de Monty Hall, popularisé par Marilyn vos Savant (*Parade Magazine*, 1990), et sa résolution bayésienne sont analysés dans Gill (2011), *The Monty Hall Problem is not a Probability Puzzle* (Comptes Rendus Mathématique **349**(23-24):1325-1330) : le renversement d'intuition vient du conditionnement sur l'information *que Monty a révélé une chèvre* (et non sur la porte ouverte elle-même), d'où P(gagner en changeant) = 2/3.\n"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/probas-3-factor-graphs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-3-factor-graphs.yaml
@@ -7,7 +7,7 @@
     date: "2026-07-28"
     by: myia-po-2024:CoursIA-2
     python_sha: 3e358b91d925700d4ab743b74c7799a5f654d02c
-    csharp_sha: f5158092a1488ec4a9a397bffe0f1ae02835f7c0
+    csharp_sha: 5fd0b931f358d0ff421b9f9c2c311f03f48d2891
   known_differences:
   - 'Socle pedagogique commun : graphes de facteurs et variables aleatoires modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
Grain: MED/notebook-fidelity — lane myia-po-2024:CoursIA-2 — prev: DEEP/tooling (c.918 #8656 md-content-loss).

## Summary

See #8081 (partial to the epic — canonical-citation rollout for Probas). Mirrors into the **C# Infer-3 twin** the 3 academic citations I added to the **Python PyMC-3 twin** in #8651, restoring the twin-parity that #8651 alone would have broken (Python cited Pearl/Kschischang/Gill, C# did not).

This grain was explicitly identified by ai-01's review of #8651:

> **Non bloquant : l'asymetrie se deplace vers le jumeau C#.** Le Python passe maintenant **devant** : Pearl et Kschischang manquent cote C#. Ce n'est pas a corriger dans cette PR. C'est un grain de suite naturel, et il est **deja dans le perimetre de #8081** qui scope explicitement `Probas/Infer/` **et** `Probas/PyMC/`. A prendre en tranche suivante sur la meme issue.

## Changes (markdown-only, C.3 — no re-exec)

3 citation blockquotes added in Infer-3's house style (`> **Label** :`), anchored to the existing pedagogy of each cell:

| Cell | Citation | Anchor in Infer-3 |
|---|---|---|
| 16 | **Pearl (1988)**, *Probabilistic Reasoning in Intelligent Systems*, §3.3 | "evidences contradictoires" / produit des LR ≈ 1 → collider (V-structure) explaining-away |
| 19 | **Kschischang, Frey & Loeliger (2001)**, *IEEE Trans. Inf. Theory* 47(2):498-519 | "Lecture du Factor Graph" → formalisation des factor graphs + sum-product message passing |
| 28 | **Gill (2011)**, *Comptes Rendus Mathématique* 349(23-24):1325-1330 | résultat Monty Hall → renversement d'intuition par conditionnement sur "Monty a révélé une chèvre" |

Same 3 references as PyMC-3 (#8651), adapted to Infer-3's C#/EP framing (Infer.NET propage les messages analytiquement par Expectation Propagation, là où PyMC approxime par MCMC — souligne la divergence de paradigme déjà documentée dans le `known_differences` du registre twin).

## Verification (firsthand)

- **nbformat VALID** — 53 cells, `nbformat.validate()` OK.
- **Diff surgical (+6/−3)** — exactement les 3 ajouts, **0 churn** ligne-par-ligne. `sort_keys=False` préserve l'ordre des clés original (Infer-3 ne fut pas sérialisé avec `sort_keys` — l'utiliser réordonne `id` dans chaque cellule = churn massif, C913-L). Trailing-newline + LF-only préservés (CR=0).
- **Twin parity DRIFT=0** — `check_twin_parity.py` : OK=136 DRIFT=0 MISSING=0 post-rebaseline. `csharp_sha` rebaselined `f5158092 → 5fd0b931` dans la même PR (C868-L : twin édité = rebaseline même PR).
- **Markdown-only (C.3)** — aucune cellule code touchée, `execution_count`/`outputs` inchangés → re-exec non requise.
- **LF-only yaml** — rebaseline fait par remplacement Python direct (pas `--update` qui écrit CRLF, C918-L), CR=0 vérifié.

## Atomic (G.4) + collision (L898)

- 2 fichiers, un sujet cohérent (3 citations twin-parity sur Infer-3).
- L898 : 0 PR ouverte sur Infer-3 / `feature/c919-infer3-citations`. Rebase frais sur `origin/main`.
- **Note fusion yaml** : cette PR et #8651 éditent toutes deux `probas-3-factor-graphs.yaml` mais sur des **lignes différentes** (`csharp_sha` ici vs `python_sha` dans #8651) avec **date/by identiques** (2026-07-28 / myia-po-2024:CoursIA-2) → merge 3-way propre quel que soit l'ordre de fusion.

## Genre / scope

MED/notebook-fidelity (citations académiques canoniques twin-parity, firsthand-anchored — pas scan-générable). Suite directe de c.918 (DEEP/tooling #8656) — pivot de genre R6/R7. Coordinator-delegated grain (ai-01 #8651 review), natural sequel maintenant la twin-parity chez le même auteur.

`See #8081` (partial to the citation-anchoring epic). See #8651 (PyMC-3 twin, Python side). See #8641 (twin-registry 136/0/0).
