### PR TITLE
fix(cost-metadata,#8056): resolve 2 Audio free_alternative bare basenames (Kokoro/Whisper no ext)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb
@@ -2327,7 +2327,7 @@
    },
    "start_time": "2026-06-23T22:41:41.170863",
    "version": "2.6.0"
-  }, "cost": {"api_usd_est": 0.02, "api_provider": "openai", "cpu_min": 0, "gpu_min": 0, "gpu_required": false, "vram_gb": 0, "vram_tier": "NONE", "network": true, "external_account": "openai", "free_alternative": "01-5-Kokoro-TTS-Local", "reduced_pedagogical": null, "reproducibility": "HIGH", "last_validated": "2026-07-24T00:00Z", "validator": "manual", "notes": "OpenAI TTS API (modeles tts-1 $0.015/1K chars et tts-1-hd $0.030/1K chars, 6 voix). Le notebook\ncompare les voix et les modeles. Cout estime depuis les tarifs officiels et le decompte d'appels\n(lecture G.1 firsthand), execution GPU non relancee (API cloud). Alternative locale : 01-5 Kokoro."}},
+  }, "cost": {"api_usd_est": 0.02, "api_provider": "openai", "cpu_min": 0, "gpu_min": 0, "gpu_required": false, "vram_gb": 0, "vram_tier": "NONE", "network": true, "external_account": "openai", "free_alternative": "MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb", "reduced_pedagogical": null, "reproducibility": "HIGH", "last_validated": "2026-07-24T00:00Z", "validator": "manual", "notes": "OpenAI TTS API (modeles tts-1 $0.015/1K chars et tts-1-hd $0.030/1K chars, 6 voix). Le notebook\ncompare les voix et les modeles. Cout estime depuis les tarifs officiels et le decompte d'appels\n(lecture G.1 firsthand), execution GPU non relancee (API cloud). Alternative locale : 01-5 Kokoro."}},
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb
@@ -2119,7 +2119,7 @@
    },
    "start_time": "2026-06-24T16:38:29.311949",
    "version": "2.6.0"
-  }, "cost": {"api_usd_est": 0.02, "api_provider": "openai", "cpu_min": 0, "gpu_min": 0, "gpu_required": false, "vram_gb": 0, "vram_tier": "NONE", "network": true, "external_account": "openai", "free_alternative": "01-4-Whisper-Local", "reduced_pedagogical": null, "reproducibility": "HIGH", "last_validated": "2026-07-24T00:00Z", "validator": "manual", "notes": "OpenAI Whisper API (whisper-1, gpt-4o-transcribe). Genere l'audio de test via TTS puis transcrit\ndans plusieurs formats (json, srt, vtt) et compare les modeles. Cout estime depuis les tarifs et le\ndecompte d'appels (lecture G.1 firsthand), execution non relancee (API cloud). Alternative locale : 01-4."}},
+  }, "cost": {"api_usd_est": 0.02, "api_provider": "openai", "cpu_min": 0, "gpu_min": 0, "gpu_required": false, "vram_gb": 0, "vram_tier": "NONE", "network": true, "external_account": "openai", "free_alternative": "MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb", "reduced_pedagogical": null, "reproducibility": "HIGH", "last_validated": "2026-07-24T00:00Z", "validator": "manual", "notes": "OpenAI Whisper API (whisper-1, gpt-4o-transcribe). Genere l'audio de test via TTS puis transcrit\ndans plusieurs formats (json, srt, vtt) et compare les modeles. Cout estime depuis les tarifs et le\ndecompte d'appels (lecture G.1 firsthand), execution non relancee (API cloud). Alternative locale : 01-4."}},
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
Grain: LIGHT/cost-metadata (fleet-tail completion of c.923 MED/notebook #8602). Resolves the 2 Audio `cost.free_alternative` bare-basenames flagged MAJOR by litmus-4 (`free_alternative_missing`), completing the fleet fix that #8602 started (GenAI/Texte 18 + GenAI/Video 2). Lane: po-2023:CoursIA.

## The defect

2 GenAI/Audio notebooks had `cost.free_alternative` set to a **bare basename WITHOUT extension** that the litmus-4 dual-base check (`repo_root/X` OU `repo_root/MyIA.AI.Notebooks/X`) cannot resolve — the targets live at `MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-X-....ipynb`, two levels deeper than either base, and the value lacks the `.ipynb` suffix. Parser reported `free_alternative pointe vers X mais fichier absent` (MAJOR). The targets all exist; only the path was ambiguous.

| file | bare basename (no ext) | real location |
|------|------------------------|---------------|
| `GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb` | `01-5-Kokoro-TTS-Local` | `…/GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb` |
| `GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb` | `01-4-Whisper-Local` | `…/GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb` |

## Why these 2 were not in #8602

#8602 used `json.dumps(indent=1, ensure_ascii=False)` round-trip byte-identity and **conservatively skipped** the 17 GenAI notebooks that were not byte-stable in that canonical form. These 2 Audio files belong to that non-canonical family (their `cost` object is serialized inline-compact on one line, not indent=1), so #8602 skipped them. This PR handles them via **raw-text regex surgery** on the single field instead of a full JSON round-trip.

## The fix

Bare basename → **full repo-relative path** (canonical convention per `docs/notebook-metadata/cost-matrix.md` line 113 example: `"MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb"`).

**Sémantique inchangée** — the free-alternative target stays the same notebook (local Kokoro TTS / local Whisper STT, already documented in each `notes` field: *"Alternative locale : 01-5 Kokoro"* / *"01-4"*). This is a **data-quality path fix**, not a design decision.

## Validation (H.3 — metadata-only, no re-exec required)

- **raw-text surgery with count==1 assertion**: the literal `"free_alternative": "01-5-Kokoro-TTS-Local"` appears exactly once per file; replacement is the ONLY byte change.
- **2/2 nbformat VALID** post-fix (full `nbformat.validate`).
- **0 CRLF** (LF-only asserted).
- **byte-identity of everything outside the field** preserved (length delta == value-length delta; single occurrence).
- **leak-scan NONE** (no token/path/IP in the 2 added lines — only the repo-relative path).
- 2 files, +2/−2 (1 line/file, surgical). No cell source changed.

## Scope discipline

- Single subject: the 2 residual Audio `free_alternative` basenames from the c.903 dispatch (#8056 epic). Homogeneous, mechanical, deterministic — the G.4 threshold is lifted for scripted/deterministic metadata transforms (cf #8056), and this is smaller still (2 files, no schema change, no re-exec).
- Did **not** re-judge the semantic target (Kokoro/Whisper as the local alternative for the OpenAI-API Audio notebooks is the populator's decision, already recorded in `notes`).
- Account hygiene: pushed from the cluster account `jsboige` (NOT the fork `jsboigeEpita`), per c.17 steer — keeps `student-pr-reviews.md` regime off and `catalog-drift.yml` backstop available.

See #8056 (cost-matrix epic), #8602 (fleet predecessor). Not `Closes` — partial fleet contribution.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
