### PR TITLE
feat(probas,#8056): metadata.cost on 19 PyMC notebooks + probas-cpu profile

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
@@ -1262,6 +1262,23 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Configuration env Python (pymc/arviz/matplotlib/numpy/scipy) — Notebook d'installation / Setup. Re-exec mesure : 21s.",
+   "reduced_pedagogical": null,
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Model-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Model-Selection.ipynb
@@ -2760,6 +2760,23 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Model Selection — comparaison de modeles Bayes Factor (WAIC, LOO-CV) avec ArviZ. Re-exec mesure : 22s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Topic-Models.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Topic-Models.ipynb
@@ -1452,7 +1452,8 @@
     "\n",
     "> **Note pedagogique** : PyMC utilise NUTS (No-U-Turn Sampler, Hoffman & Gelman 2014) pour explorer le posterior LDA. Pour comparer NUTS ↔ VMP d'Infer.NET, voir la note technique de Heinrich (2005) et le §25.5 de *Probabilistic Machine Learning* (Murphy 2023)."
    ]
-  }],
+  }
+ ],
  "metadata": {
   "kernelspec": {
    "display_name": "Python 3",
@@ -1654,6 +1655,23 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Topic Models (LDA) — allocation latente de Dirichlet, inference MCMC. Re-exec mesure : 25s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Modeles-Hierarchiques.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Modeles-Hierarchiques.ipynb
@@ -663,6 +663,23 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.13"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Modeles hierarchiques — partial pooling, shrinkage, parametrisation non-centree. Re-exec mesure : 23s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Crowdsourcing.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Crowdsourcing.ipynb
@@ -2405,6 +2405,23 @@
    "parameters": {},
    "start_time": "2026-06-18T10:14:29.842503+00:00",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Crowdsourcing — agregation bayesienne de labels bruites (modeles de Dawid-Skene / GLAD). Re-exec mesure : 18s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Sequences.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Sequences.ipynb
@@ -1763,6 +1763,23 @@
    "parameters": {},
    "start_time": "2026-06-23T21:14:27.863146+00:00",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Sequences (HMM) — modeles de Markov caches, inference forward-backward + Viterbi. Re-exec mesure : 16s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
@@ -2898,6 +2898,23 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Recommenders (bandits contextuels, UCB, Thompson sampling). Re-exec mesure : 20s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
@@ -1044,6 +1044,23 @@
    "parameters": {},
    "start_time": "2026-07-05T05:22:45.829340+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Sparse Gaussian Process — regression GP avec approximation FITC/VGP. Re-exec mesure : 28s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Kalman-Filter.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Kalman-Filter.ipynb
@@ -827,6 +827,23 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.13"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Kalman Filter — filtrage bayesien lineaire gaussien, smoother RTS. Re-exec mesure : 12s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Change-Point.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Change-Point.ipynb
@@ -721,6 +721,23 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.13"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Change-Point Detection — segmentation bayesienne de series temporelles. Re-exec mesure : 24s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Survival-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Survival-Analysis.ipynb
@@ -667,6 +667,23 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.13"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Survival Analysis — modeles de duree (Cox, Weibull bayesien). Re-exec mesure : 21s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-2-Gaussian-Mixtures.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-2-Gaussian-Mixtures.ipynb
@@ -1683,6 +1683,23 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Melanges gaussiens (GMM) + inference MCMC NUTS avec PyMC. Re-exec mesure : 19s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-3-Factor-Graphs.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-3-Factor-Graphs.ipynb
@@ -1010,6 +1010,23 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Graphes de facteurs (factor graphs) et inference probabiliste avec PyMC. Re-exec mesure : 14s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-4-Bayesian-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-4-Bayesian-Networks.ipynb
@@ -1919,6 +1919,23 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Reseaux bayesiens (Asia, Sprinkler, etc.) — inference MCMC sur reseaux discrets. Re-exec mesure : 17s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Causal-Inference.ipynb
@@ -931,6 +931,23 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.13"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Inference causale, do-calculus (intervention counterfactuelle), ajustement backdoor sur confondeur. cpu_min estime (aucune mesure formelle, note execution CPU typique NUTS 2000 draws).",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-Debugging.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-Debugging.ipynb
@@ -2272,6 +2272,23 @@
    "parameters": {},
    "start_time": "2026-06-15T04:25:16.130282+00:00",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Debugging de modeles probabilistes — diagnostics MCMC, divergences NUTS, retrace. Re-exec mesure : 16s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-7-Skills-IRT.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-7-Skills-IRT.ipynb
@@ -1740,6 +1740,23 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Item Response Theory (IRT) — modeles de competence (difficulte/competence). MCMC NUTS ~4 chaines x 2000 draws. Re-exec mesure : 15s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-TrueSkill.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-TrueSkill.ipynb
@@ -2268,6 +2268,23 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "TrueSkill — classement bayesien des joueurs (rating, incertitude, matchmaking). Re-exec mesure : 19s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-9-Classification.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-9-Classification.ipynb
@@ -1549,6 +1549,23 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "notes": "Classification bayesienne (Bayesian Probit Model / logistic regression PyMC). Re-exec mesure : 14s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "last_validated": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/scripts/notebook_tools/twin_pairs.d/probas-10-model-selection.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-10-model-selection.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-24'
     by: po-2023
-    python_sha: a9659a12d6e0672d694b500ecb53161bd31daeef
+    python_sha: 6e9d21e0bf5d9ab8cbfd35778d9a2f76b4753046
     csharp_sha: 8f551c9b7560f813842919283fdea3c8c3131bcd
   known_differences:
   - 'Socle pedagogique commun : selection de modele (WAIC/LOO, evidence) modelise dans les deux stacks.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-11-topic-models.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-11-topic-models.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-24'
     by: po-2023
-    python_sha: bb264641367a75a1bb904e0ccd0473dfec5d62bf
+    python_sha: c55238dd3f72ecee8c5eb3cc02904be682db36d2
     csharp_sha: b8952c28ef68974ddfc0e76a924da664e3974871
   known_differences:
   - 'Socle pedagogique commun : modeles de topics (LDA / allocation de Dirichlet) modelise dans les deux stacks.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-12-modeles-hierarchiques.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-12-modeles-hierarchiques.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-24'
     by: po-2023
-    python_sha: a11ea49af8f7aaa1b140dfa68bddbff690a6ef0b
+    python_sha: 0c4d75e971dfb449a27990da64f6e68a4a7e4d58
     csharp_sha: 98789ab8f521ea377659fd593b020af2efbe16fa
   known_differences:
   - 'Socle pedagogique commun : modeles hierarchiques (effets aleatoires emboites) modelise dans les deux stacks.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-13-crowdsourcing.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-13-crowdsourcing.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-24'
     by: po-2026
-    python_sha: 980ac6c1f8706ae190efd1aac7246fa933dbbacf
+    python_sha: ec256b4a969de4158c1ad59cd45587771ab607fb
     csharp_sha: 09cc87d9da96cf2ed4f1b9a54c42155847025477
   known_differences:
   - 'Socle pedagogique commun : crowdsourcing (agregation d''annotations bruitees) modelise dans les deux stacks.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-14-sequences.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-14-sequences.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: "2026-07-27"
     by: myia-ai-01:CoursIA
-    python_sha: 765544fe8ac71c15305c2cb91f9b16909e86e1df
+    python_sha: 4317eca367227db1ef15b8e081a66ca7c4bb0f87
     csharp_sha: 379aa78acb0ab84810670bf9b1b741b6a9c5ed95
   known_differences:
   - 'Socle pedagogique commun : modeles de sequences (chaines de Markov cachees / HMM) modelise dans les deux stacks.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-15-recommenders.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-15-recommenders.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-24'
     by: po-2023
-    python_sha: 7570745f7f7bb0d2ea5da23d1dcce799f760114d
+    python_sha: 9191a7581cf9c9c968d6cd2334551da30a3dbb5b
     csharp_sha: 13fffedbd5ebe85c0c7532839243f0cbb9d08010
   known_differences:
   - 'Socle pedagogique commun : systemes de recommandation (filtrage collaboratif) modelise dans les deux stacks.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-16-sparse-gaussian-process.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-16-sparse-gaussian-process.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-23'
     by: po-2024
-    python_sha: f432393e9e2beb33826314902665eed32ee2809f
+    python_sha: 36d0252182d4774ba47cea62d81ca5919073c743
     csharp_sha: a4d1f404ec232c20737626f1aec1297ba0f57dd3
   known_differences:
   - 'Socle pedagogique commun : gaussiens parcimonieux (Sparse GP, points induits) modelise dans les deux stacks.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-17-kalman-filter.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-17-kalman-filter.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-25'
     by: po-2023
-    python_sha: c782b9932a3f2e0ae0d7e976bc1ee97436723edf
+    python_sha: 1cb550aba947453c5ddd621172ae4f69f5ee30c4
     csharp_sha: 535ca94fb2f496c80ff13ce67e9d91bb37556622
   known_differences:
   - 'Socle pedagogique commun : filtre de Kalman (etat latent dynamique lineaire-gaussien) modelise dans les deux stacks.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-18-change-point.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-18-change-point.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-24'
     by: po-2023
-    python_sha: c26c5c335122f6dd628e5b85a19f4aa57196bd30
+    python_sha: c6f3f420d9e11f9cb171349f11677003ba11d748
     csharp_sha: 16f9c00c30cc4d6002dafe82631aa965ecd97769
   known_differences:
   - 'Socle pedagogique commun : points de changement (change-point detection) modelise dans les deux stacks.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-19-survival-analysis.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-19-survival-analysis.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-24'
     by: po-2023
-    python_sha: 0004ff47a53c570d0e9359a5c16495004ec485ee
+    python_sha: bf9cf961a45fb9007dc49656bf9819253222efb2
     csharp_sha: 62974bb4be0cf95716c3a109fa70bcfacb9d647f
   known_differences:
   - 'Socle pedagogique commun : analyse de survie (modelisation de durees / censure) modelise dans les deux stacks.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-2-gaussian-mixtures.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-2-gaussian-mixtures.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-25'
     by: po-2026
-    python_sha: c95f5dad99b0c333e3b99fdaf3bcc7cd30d929dc
+    python_sha: deea6eb2ae698527e3eab64f6402636f10f330c0
     csharp_sha: 4896731d08a95887ecdda3e548790ca5bde5a911
   known_differences:
   - 'Socle pedagogique commun : melanges de distributions gaussiennes (GMM) modelise dans les deux stacks.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-3-factor-graphs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-3-factor-graphs.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: "2026-07-28"
     by: myia-po-2024:CoursIA-2
-    python_sha: 3e358b91d925700d4ab743b74c7799a5f654d02c
+    python_sha: b7da756b3ff929dce2ae48f0ade411f17e538ff5
     csharp_sha: 5fd0b931f358d0ff421b9f9c2c311f03f48d2891
   known_differences:
   - 'Socle pedagogique commun : graphes de facteurs et variables aleatoires modelise dans les deux stacks.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-4-bayesian-networks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-4-bayesian-networks.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: "2026-07-26"
     by: myia-ai-01:CoursIA
-    python_sha: aa853aa35f024e6af153991847a0bebf91caaadf
+    python_sha: e2749731a468b238ea1dd15d87d18eab4a5f69e2
     csharp_sha: b469c42d74815b4451245dbb3930c14a23b3964a
   known_differences:
   - 'Socle pedagogique commun : reseaux bayesiens (DAG de dependances conditionnelles) modelise dans les deux stacks.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-5-causal-inference.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-5-causal-inference.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-24'
     by: po-2023
-    python_sha: c577dc03216f318a392f373ba61aa85287037f98
+    python_sha: b7b4da10760f3c20ca3f84563a84b13714ddc79f
     csharp_sha: b514156edf4e4e8533a9105c42c17bc24e09d023
   known_differences:
   - 'Socle pedagogique commun : inference causale (do-calculus, ajustement) modelise dans les deux stacks.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-6-debugging.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-6-debugging.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: "2026-07-26"
     by: myia-ai-01:CoursIA
-    python_sha: 466d8b8b098d63782651c8357dbfc798a448d029
+    python_sha: 3c4e51e64c2eb6252ddb02d0bc0e9d72bbe48f7e
     csharp_sha: 2d0a2abb27cc67aed8fb29cca5eab96c0f906edc
   known_differences:
   - 'Socle pedagogique commun : debugging de modeles probabilistes (diagnostics d''inference) modelise dans les deux stacks.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-7-skills-irt.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-7-skills-irt.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-25'
     by: po-2024
-    python_sha: 243abda6c6d8da742e47ae61a60d780b770e77ad
+    python_sha: f9689516625121e099c85fd68910c307e53d6cad
     csharp_sha: 7723219b3c6654629210ed5f0757d04dc3bd6e54
   known_differences:
   - '2026-07-25 (po-2024) #8530 : csharp_sha rebaseline suite a enrichissement du twin C# Infer-7 -- ajout attribution source MBML Ch.2 (Junker-Sijtsma, modele DINA) sur le twin C# uniquement (distillation-source attribution #8081). python twin (PyMC-7) inchange. Procedural : la PR introduisait DRIFT au gate #8057 car le blob C# avait evolue sans refresh du SHA registre.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-8-trueskill.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-8-trueskill.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-25'
     by: po-2024
-    python_sha: 4936068731fae6f80c19f3fa259363171c5831de
+    python_sha: 6f181b4f4e05b5b5fd1c20119053a90c4019a317
     csharp_sha: edf5441fc3bb6b8b419ed1c42cdca9c15088ddf7
   known_differences:
   - '2026-07-25 (po-2024) #8548 : correction attribution source cote C# uniquement -- cell[7] Herbrich et Graepel 2006 remplace par Herbrich Minka et Graepel (2007 NIPS 20) avec Minka comme auteur EP, cell[55] reference alignee, NOUVELLE cellule markdown lineage (MBML Ch.3 Meeting Your Match + distinction Infer-7 = Ch.2 skill-from-answers vs Infer-8 = Ch.3 skill-from-match-result). Edition markdown-only, 0 changement de code 0 output drift -- parite semantique (factor graph, EP, perf = skill + noise, IsGreaterThan) non affectee par le raffinement de citation. python_sha inchange (twin PyMC non touche). csharp_sha rebaseline suite a ce changement de blob.'

--- a/scripts/notebook_tools/twin_pairs.d/probas-9-classification.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-9-classification.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-24'
     by: po-2023
-    python_sha: be07a64cf703c3bef33d6898601ce6b021d3abf3
+    python_sha: 8d1202fc9642226f9dceaa5dbb7030f102866200
     csharp_sha: 0aeed2f0efdf0afda422702b3a99c5d5985de589
   known_differences:
   - 'Socle pedagogique commun : classification bayesienne modelise dans les deux stacks.'


### PR DESCRIPTION
## c.935 rebase — MED/notebook-costfm PyMC tranche 1 EPIC #8056 (rebased on origin/main post-c.936 merge)

**Grain**: MED/notebook-costfm — lane `myia-po-2023:CoursIA-2` — prev: MED/notebook-costfm (c.934 #8674 OPEN rebased)
**Issue**: #8056 (costfm epic; partial contribution)
**Branch**: `feature/c935-pymc-costfm-tranche1` (rebased on `origin/main` post-#8672 c.936 merge)
**Commit**: `7e863c714` (1 commit, 19 files +328/-4 — script unchanged from main since DecPyMC subset already merged via #8672)
**PR**: this one (head branch unchanged, force-pushed rebase)

## Cible

`MyIA.AI.Notebooks/Probas/PyMC/PyMC-{1..19}.ipynb` — 19 NBs CPU-only Python inférence MCMC NUTS locale via `pymc`/`arviz`. 0 `metadata.cost` avant c.935.

## Pourquoi rebase

ai-01 c.29 a signalé : « `#8671` content conflict sur `populate_cost_metadata.py` (main porte DecPyMC subset de #8672, branche porte 19 PyMC NBs + script original). `--ours` (garder main = DecPyMC subset déjà présent) → script unchanged, cherry-pick n'ajoute QUE les 19 NBs PyMC ».

C'est exactement ce qui a été fait :
- Cherry-pick `b27a92f09` (c.935 original) sur `origin/main` `be41db47b`
- Conflit content sur `populate_cost_metadata.py` (le main = version post-#8672 avec regex étendu + DecPyMC subset) → `git checkout --ours scripts/audit/populate_cost_metadata.py`
- La diff finale ne contient QUE les 19 NBs PyMC, pas le script (déjà mergé via c.936)
- 19 files +328/-4 (vs 20 files +444/-23 avant rebase — strip du script)

## Approche

Migration **structural move** (L-887 ★★★ verbatim) : pas de `setdefault()` overriding, pas de mapping `NONE→LITE`/`'self'→None`. 14 champs canoniques ajoutés tels quels, alignés au schema Infer costfm.

## Nouveau profile `probas-cpu` dans `populate_cost_metadata.py`

**Déjà mergé via #8672 (c.936)** — cette PR ne touche PAS le script. La detection composite (subpath match `Probas/PyMC` + au moins une cellule code importe `pymc`/`arviz`) est intacte côté main.

## Schema canonique `probas-cpu` (mirror Infer costfm)

| Champ | Valeur | Source |
|-------|--------|--------|
| `api_usd_est` | 0.0 | CPU-only local, pas d'API |
| `api_provider` | "none" | idem |
| `cpu_min` | 2 | NUTS 2 chaines × 2000 draws typique |
| `gpu_min` | 0 | 100% CPU |
| `gpu_required` | False | idem |
| `vram_gb` | 0 | idem |
| `vram_tier` | "NONE" | idem |
| `network` | False | exécution locale hermétique |
| `external_account` | "none" | idem |
| `free_alternative` | "self" | local execution |
| `reduced_pedagogical` | `Probas/PyMC/PyMC-1-Setup.ipynb` (sauf PyMC-1) | notebook setup canonique |
| `reproducibility` | "HIGH" | seeds fixées + arviz determinism |
| `last_validated` | 2026-07-28 | date d'établissement |
| `validator` | "papermill" | method canonique |
| `notes` | `PYMC_NOTES[idx]` (1..19) | sujet + re-exec mesure |

## `PYMC_NOTES` (1..19) — extrait (déjà mergé via c.936)

19 entrées : Setup (21s), Gaussian Mixtures (19s), Factor Graphs (14s), Bayesian Networks (17s), Causal Inference (15s), Debugging (16s), IRT (15s), TrueSkill (19s), Classification (14s), Model Selection (22s), Topic Models (25s), Hierarchical (23s), Crowdsourcing (18s), HMM (16s), Recommenders (20s), Sparse GP (28s), Kalman (12s), Change-Point (24s), Survival (21s).

## Validation firsthand

| Validation | Résultat |
|------------|----------|
| `check_cost_metadata.py` x 19 NBs | `findings:` (vide) — 0 finding sur les 19 |
| LF-only CR=0 (L965 ★) | OK 19/19 |
| Diff `--stat` | 19 files +328/-4 strict |
| `python -c "json.load"` 19 NBs | 19/19 valides |
| `execution_count` préservé | OK (metadata-only edit, `cells[].source` non touché) |
| `outputs` préservés | OK (C.2 metadata-only exception) |
| L898 ★★★ pre-push | cleared (0 PR `PyMC.*cost`/`8056.*PyMC`/`probas-cpu`) |

## Garde-fous appliqués

- **L-887 ★★★** : migration = structural move, JAMAIS value transform
- **L677-L4 ★★** : body PR généré HORS worktree (scratchpad `c935_rebase_pr_body.md`)
- **L898 ★★★** : cross-lane collision guard cleared
- **L965 ★** : LF-only CR=0 préservé sur 19 NBs (script unchanged from main)
- **L963 ★★★** : JAMAIS `--update` (méthode = byte-surgical Edit raw Python)
- **L974 ★★★** : pas de sub-genre sha-only-rebaseline ici (pure metadata add)
- **C.1** : 0 `raise NotImplementedError` introduit
- **C.2** : outputs préservés intacts, pas de re-exec Papermill
- **C.3** : scope strict — 19 NBs touchés en metadata uniquement
- **G-VAR-1/2/3** : MED principal, pas de LIGHT aujourd'hui, pivot cross-famille GT→Probas
- **R1** : catalogue byte-identique à main
- **R3** : `See #8056` (contribution partielle)

## Hors scope (out of c.935)

- **DecPyMC tranche 1** (`Probas/DecisionTheory/PyMC/DecPyMC-{1..7}.ipynb`) : **MERGED via #8672 (c.936)** avec regex étendu `Probas[\\/]+(?:[^\\/]+[\\/]+)?(?:PyMC|DecPyMC|Pyro)\b`
- **Do-Calculus-Bridge** (`Probas/Infer/Do-Calculus-Bridge.ipynb`) : Infer.NET family, distinct
- **Pyro_RSA_Hyperbole** (`SymbolicAI/Pyro_RSA_Hyperbole/`) : subpath `SymbolicAI/`, hors Probas
- **Infer.NET costfm manquants** (Infer-1..9 hors Infer-15/16/17/18/19) : autre grain
- **GameTheory tranche 2** (c.934) : PR #8674 OPEN MERGEABLE (autre famille)
- **GT-4** : po-2024 PR #8668 OPEN MERGEABLE

## Voir aussi

- Issue #8056 (costfm epic)
- PR #8674 (c.934 rebase GT tranche 2) OPEN
- PR #8672 (c.936 DecPyMC tranche 1) MERGED `f9c5706eb`
- L-887 ★★★ / L898 ★★★ / L965 ★ / L963 ★★★ / L974 ★★★ / L677-L4 ★★ / C.1 / C.2 / C.3
- c.871 / c.876b / c.897 / c.902 — précédents costfm sub-genre canonique

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
