### PR TITLE
feat(knot,#8644): mirror_wf_preserves polymorphic closure via List.Perm.flatMap

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic.lean
@@ -517,12 +517,12 @@ plus the edge multiset — is invariant under mirror. No `sorry`, no `decide`
 on free variables.
 -/
 
+open List in
 /-- The mirrored diagram's edge list is a permutation of the original's.
     Lifts the per-crossing permutation `mirrorCrossing_perm` through the
     flat-map: `(cs.map mirrorCrossing).flatMap F ~ cs.flatMap F` because each
     `F (mirrorCrossing c) ~ F c` (the 4-element lists `[e1,e4,e3,e2]` and
     `[e1,e2,e3,e4]` are permutations, `mirrorCrossing_perm`). -/
-open List in
 theorem mirror_edges_perm (d : KnotDiagram) :
     mirror_diag_edges d ~ d.edges := by
   show (d.crossings.map mirrorCrossing).flatMap (fun c => [c.e1, c.e2, c.e3, c.e4]) ~
@@ -530,8 +530,9 @@ theorem mirror_edges_perm (d : KnotDiagram) :
   rw [List.flatMap_map]
   -- After `(map f).flatMap g = flatMap (g ∘ f)`, the per-crossing function is
   -- defeq `fun c => [c.e1, c.e4, c.e3, c.e2]` (mirrorCrossing swaps e2 ↔ e4).
-  exact List.Perm.flatMap_right d.crossings (fun c => mirrorCrossing_perm c)
+  exact List.Perm.flatMap_left d.crossings (fun c _ => mirrorCrossing_perm c)
 
+open List in
 /-- `mirror` preserves `KnotDiagram.wf` (Issue #8644 closure).
 
 `mirrorCrossing` swaps `e2 ↔ e4`, so `mirror_diag_edges d` is a permutation of
@@ -540,7 +541,6 @@ multiset (range check on the support via `all`, parity check on per-label
 `count`) plus `numEdges`, and mirror preserves `numEdges` by field identity.
 This is the full polymorphic generalisation that `decide` could not discharge
 on free variables (cf. C918-L1 ★) — here closed by hand. -/
-open List in
 theorem mirror_wf_preserves (k : Knot) (h : k.diagram.wf = true) :
     k.mirror.diagram.wf = true := by
   -- Mirror diagram field identities (defeq).
@@ -571,8 +571,8 @@ theorem mirror_wf_preserves (k : Knot) (h : k.diagram.wf = true) :
     rw [Bool.and_eq_true] at h ⊢
     obtain ⟨h_all, h_par⟩ := h
     refine ⟨?_, ?_⟩
-    · -- Range check: `all` is invariant under permutation.
-      rw [← hmedges, hp.all_eq]; exact h_all
+    · -- Range check: `all` is invariant under permutation (`Perm.all_eq`).
+      rw [hmedges, hp.all_eq]; exact h_all
     · -- Parity check: per-label `count` is invariant under permutation.
       have heq : (fun i => decide (k.mirror.diagram.edges.count (i + 1) = 2)) =
                  (fun i => decide (k.diagram.edges.count (i + 1) = 2)) := by

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic.lean
@@ -499,3 +499,84 @@ theorem mirror_wf_preserves_partial (d : KnotDiagram) :
               (fun c => [c.e1, c.e2, c.e3, c.e4])).count l) := by
   intro l
   exact mirror_diag_preserves_count d l
+
+/-! ## 14. Closure: `mirror` preserves `KnotDiagram.wf` (Issue #8644)
+
+Section §13 proved the per-crossing permutation `mirrorCrossing_perm` and the
+per-diagram count preservation `mirror_diag_preserves_count`. This section
+closes the polymorphic theorem deferred to the Lean-capable lane by PR #8667:
+`mirror` preserves `KnotDiagram.wf` for **any** knot.
+
+The cleanest route lifts `mirrorCrossing_perm` to a full-diagram permutation
+`mirror_edges_perm` via `List.Perm.flatMap` — `mirror` only swaps `e2 ↔ e4`
+inside each crossing, so the flat-mapped edge list is a permutation of the
+original. From a permutation, both the per-label `count` (parity check) and
+`all` (range check) are preserved directly, and `mirror` preserves `numEdges`
+by field identity. Hence `KnotDiagram.wf` — which depends only on `numEdges`
+plus the edge multiset — is invariant under mirror. No `sorry`, no `decide`
+on free variables.
+-/
+
+/-- The mirrored diagram's edge list is a permutation of the original's.
+    Lifts the per-crossing permutation `mirrorCrossing_perm` through the
+    flat-map: `(cs.map mirrorCrossing).flatMap F ~ cs.flatMap F` because each
+    `F (mirrorCrossing c) ~ F c` (the 4-element lists `[e1,e4,e3,e2]` and
+    `[e1,e2,e3,e4]` are permutations, `mirrorCrossing_perm`). -/
+open List in
+theorem mirror_edges_perm (d : KnotDiagram) :
+    mirror_diag_edges d ~ d.edges := by
+  show (d.crossings.map mirrorCrossing).flatMap (fun c => [c.e1, c.e2, c.e3, c.e4]) ~
+       d.crossings.flatMap (fun c => [c.e1, c.e2, c.e3, c.e4])
+  rw [List.flatMap_map]
+  -- After `(map f).flatMap g = flatMap (g ∘ f)`, the per-crossing function is
+  -- defeq `fun c => [c.e1, c.e4, c.e3, c.e2]` (mirrorCrossing swaps e2 ↔ e4).
+  exact List.Perm.flatMap_right d.crossings (fun c => mirrorCrossing_perm c)
+
+/-- `mirror` preserves `KnotDiagram.wf` (Issue #8644 closure).
+
+`mirrorCrossing` swaps `e2 ↔ e4`, so `mirror_diag_edges d` is a permutation of
+`d.edges` (`mirror_edges_perm`); `KnotDiagram.wf` depends only on the edge
+multiset (range check on the support via `all`, parity check on per-label
+`count`) plus `numEdges`, and mirror preserves `numEdges` by field identity.
+This is the full polymorphic generalisation that `decide` could not discharge
+on free variables (cf. C918-L1 ★) — here closed by hand. -/
+open List in
+theorem mirror_wf_preserves (k : Knot) (h : k.diagram.wf = true) :
+    k.mirror.diagram.wf = true := by
+  -- Mirror diagram field identities (defeq).
+  have hmcross : k.mirror.diagram.crossings = k.diagram.crossings.map mirrorCrossing := rfl
+  have hmnum   : k.mirror.diagram.numEdges = k.diagram.numEdges := rfl
+  have hmedges : k.mirror.diagram.edges = mirror_diag_edges k.diagram := rfl
+  -- Full-diagram permutation of the edge list.
+  have hp : mirror_diag_edges k.diagram ~ k.diagram.edges := mirror_edges_perm k.diagram
+  -- Per-label count equality between mirrored and original edges
+  -- (uses `mirror_diag_preserves_count` from §13, which already reconstructs
+  -- the count-preservation that v4.31.0-rc1's missing `List.perm_iff_count`
+  -- would give directly).
+  have hc (l : Nat) : k.mirror.diagram.edges.count l = k.diagram.edges.count l := by
+    rw [hmedges]; exact mirror_diag_preserves_count k.diagram l
+  -- Mirror preserves emptiness of the crossings list.
+  have hem : k.mirror.diagram.crossings = [] ↔ k.diagram.crossings = [] := by
+    rw [hmcross]; exact List.map_eq_nil_iff
+  -- Unfold `wf` on both sides.
+  simp only [KnotDiagram.wf] at h ⊢
+  by_cases he : k.diagram.crossings = []
+  · -- Degenerate branch: mirror is empty too; both ifs reduce to `numEdges ≤ 1`.
+    have hme := hem.mpr he
+    simp only [hme, he, if_true, hmnum] at h ⊢
+    exact h
+  · -- Non-degenerate branch: mirror is non-empty too.
+    have hme : k.mirror.diagram.crossings ≠ [] := fun H => he (hem.mp H)
+    simp only [hme, he, if_false, hmnum] at h ⊢
+    rw [Bool.and_eq_true] at h ⊢
+    obtain ⟨h_all, h_par⟩ := h
+    refine ⟨?_, ?_⟩
+    · -- Range check: `all` is invariant under permutation.
+      rw [← hmedges, hp.all_eq]; exact h_all
+    · -- Parity check: per-label `count` is invariant under permutation.
+      have heq : (fun i => decide (k.mirror.diagram.edges.count (i + 1) = 2)) =
+                 (fun i => decide (k.diagram.edges.count (i + 1) = 2)) := by
+        funext i; rw [hc]
+      rw [heq]; exact h_par
+
+end Knots

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic.lean
@@ -571,8 +571,13 @@ theorem mirror_wf_preserves (k : Knot) (h : k.diagram.wf = true) :
     rw [Bool.and_eq_true] at h ⊢
     obtain ⟨h_all, h_par⟩ := h
     refine ⟨?_, ?_⟩
-    · -- Range check: `all` is invariant under permutation (`Perm.all_eq`).
-      rw [hmedges, hp.all_eq]; exact h_all
+    · -- Range check: the predicate does not depend on position, only on
+      -- membership, so transport it pointwise via `Perm.mem_iff` (the oldest
+      -- perm lemma — survives version bumps; does not lean on `Perm.all_eq`).
+      rw [hmedges]
+      rw [List.all_eq_true] at h_all ⊢
+      intro x hx
+      exact h_all x (hp.mem_iff.mp hx)
     · -- Parity check: per-label `count` is invariant under permutation.
       have heq : (fun i => decide (k.mirror.diagram.edges.count (i + 1) = 2)) =
                  (fun i => decide (k.diagram.edges.count (i + 1) = 2)) := by

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic_en.lean
@@ -570,8 +570,13 @@ theorem mirror_wf_preserves (k : Knot) (h : k.diagram.wf = true) :
     rw [Bool.and_eq_true] at h ⊢
     obtain ⟨h_all, h_par⟩ := h
     refine ⟨?_, ?_⟩
-    · -- Range check: `all` is invariant under permutation (`Perm.all_eq`).
-      rw [hmedges, hp.all_eq]; exact h_all
+    · -- Range check: the predicate does not depend on position, only on
+      -- membership, so transport it pointwise via `Perm.mem_iff` (the oldest
+      -- perm lemma — survives version bumps; does not lean on `Perm.all_eq`).
+      rw [hmedges]
+      rw [List.all_eq_true] at h_all ⊢
+      intro x hx
+      exact h_all x (hp.mem_iff.mp hx)
     · -- Parity check: per-label `count` is invariant under permutation.
       have heq : (fun i => decide (k.mirror.diagram.edges.count (i + 1) = 2)) =
                  (fun i => decide (k.diagram.edges.count (i + 1) = 2)) := by

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic_en.lean
@@ -499,4 +499,83 @@ theorem mirror_wf_preserves_partial (d : KnotDiagram) :
   intro l
   exact mirror_diag_preserves_count d l
 
+/-! ## 14. Closure: `mirror` preserves `KnotDiagram.wf` (Issue #8644)
+
+Section §13 proved the per-crossing permutation `mirrorCrossing_perm` and the
+per-diagram count preservation `mirror_diag_preserves_count`. This section
+closes the polymorphic theorem deferred to the Lean-capable lane by PR #8667:
+`mirror` preserves `KnotDiagram.wf` for **any** knot.
+
+The cleanest route lifts `mirrorCrossing_perm` to a full-diagram permutation
+`mirror_edges_perm` via `List.Perm.flatMap` — `mirror` only swaps `e2 ↔ e4`
+inside each crossing, so the flat-mapped edge list is a permutation of the
+original. From a permutation, both the per-label `count` (parity check) and
+`all` (range check) are preserved directly, and `mirror` preserves `numEdges`
+by field identity. Hence `KnotDiagram.wf` — which depends only on `numEdges`
+plus the edge multiset — is invariant under mirror. No `sorry`, no `decide`
+on free variables.
+-/
+
+/-- The mirrored diagram's edge list is a permutation of the original's.
+    Lifts the per-crossing permutation `mirrorCrossing_perm` through the
+    flat-map: `(cs.map mirrorCrossing).flatMap F ~ cs.flatMap F` because each
+    `F (mirrorCrossing c) ~ F c` (the 4-element lists `[e1,e4,e3,e2]` and
+    `[e1,e2,e3,e4]` are permutations, `mirrorCrossing_perm`). -/
+open List in
+theorem mirror_edges_perm (d : KnotDiagram) :
+    mirror_diag_edges d ~ d.edges := by
+  show (d.crossings.map mirrorCrossing).flatMap (fun c => [c.e1, c.e2, c.e3, c.e4]) ~
+       d.crossings.flatMap (fun c => [c.e1, c.e2, c.e3, c.e4])
+  rw [List.flatMap_map]
+  -- After `(map f).flatMap g = flatMap (g ∘ f)`, the per-crossing function is
+  -- defeq `fun c => [c.e1, c.e4, c.e3, c.e2]` (mirrorCrossing swaps e2 ↔ e4).
+  exact List.Perm.flatMap_right d.crossings (fun c => mirrorCrossing_perm c)
+
+/-- `mirror` preserves `KnotDiagram.wf` (Issue #8644 closure).
+
+`mirrorCrossing` swaps `e2 ↔ e4`, so `mirror_diag_edges d` is a permutation of
+`d.edges` (`mirror_edges_perm`); `KnotDiagram.wf` depends only on the edge
+multiset (range check on the support via `all`, parity check on per-label
+`count`) plus `numEdges`, and mirror preserves `numEdges` by field identity.
+This is the full polymorphic generalisation that `decide` could not discharge
+on free variables (cf. C918-L1 ★) — here closed by hand. -/
+open List in
+theorem mirror_wf_preserves (k : Knot) (h : k.diagram.wf = true) :
+    k.mirror.diagram.wf = true := by
+  -- Mirror diagram field identities (defeq).
+  have hmcross : k.mirror.diagram.crossings = k.diagram.crossings.map mirrorCrossing := rfl
+  have hmnum   : k.mirror.diagram.numEdges = k.diagram.numEdges := rfl
+  have hmedges : k.mirror.diagram.edges = mirror_diag_edges k.diagram := rfl
+  -- Full-diagram permutation of the edge list.
+  have hp : mirror_diag_edges k.diagram ~ k.diagram.edges := mirror_edges_perm k.diagram
+  -- Per-label count equality between mirrored and original edges
+  -- (uses `mirror_diag_preserves_count` from §13, which already reconstructs
+  -- the count-preservation that v4.31.0-rc1's missing `List.perm_iff_count`
+  -- would give directly).
+  have hc (l : Nat) : k.mirror.diagram.edges.count l = k.diagram.edges.count l := by
+    rw [hmedges]; exact mirror_diag_preserves_count k.diagram l
+  -- Mirror preserves emptiness of the crossings list.
+  have hem : k.mirror.diagram.crossings = [] ↔ k.diagram.crossings = [] := by
+    rw [hmcross]; exact List.map_eq_nil_iff
+  -- Unfold `wf` on both sides.
+  simp only [KnotDiagram.wf] at h ⊢
+  by_cases he : k.diagram.crossings = []
+  · -- Degenerate branch: mirror is empty too; both ifs reduce to `numEdges ≤ 1`.
+    have hme := hem.mpr he
+    simp only [hme, he, if_true, hmnum] at h ⊢
+    exact h
+  · -- Non-degenerate branch: mirror is non-empty too.
+    have hme : k.mirror.diagram.crossings ≠ [] := fun H => he (hem.mp H)
+    simp only [hme, he, if_false, hmnum] at h ⊢
+    rw [Bool.and_eq_true] at h ⊢
+    obtain ⟨h_all, h_par⟩ := h
+    refine ⟨?_, ?_⟩
+    · -- Range check: `all` is invariant under permutation.
+      rw [← hmedges, hp.all_eq]; exact h_all
+    · -- Parity check: per-label `count` is invariant under permutation.
+      have heq : (fun i => decide (k.mirror.diagram.edges.count (i + 1) = 2)) =
+                 (fun i => decide (k.diagram.edges.count (i + 1) = 2)) := by
+        funext i; rw [hc]
+      rw [heq]; exact h_par
+
 end Knots_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic_en.lean
@@ -516,12 +516,12 @@ plus the edge multiset — is invariant under mirror. No `sorry`, no `decide`
 on free variables.
 -/
 
+open List in
 /-- The mirrored diagram's edge list is a permutation of the original's.
     Lifts the per-crossing permutation `mirrorCrossing_perm` through the
     flat-map: `(cs.map mirrorCrossing).flatMap F ~ cs.flatMap F` because each
     `F (mirrorCrossing c) ~ F c` (the 4-element lists `[e1,e4,e3,e2]` and
     `[e1,e2,e3,e4]` are permutations, `mirrorCrossing_perm`). -/
-open List in
 theorem mirror_edges_perm (d : KnotDiagram) :
     mirror_diag_edges d ~ d.edges := by
   show (d.crossings.map mirrorCrossing).flatMap (fun c => [c.e1, c.e2, c.e3, c.e4]) ~
@@ -529,8 +529,9 @@ theorem mirror_edges_perm (d : KnotDiagram) :
   rw [List.flatMap_map]
   -- After `(map f).flatMap g = flatMap (g ∘ f)`, the per-crossing function is
   -- defeq `fun c => [c.e1, c.e4, c.e3, c.e2]` (mirrorCrossing swaps e2 ↔ e4).
-  exact List.Perm.flatMap_right d.crossings (fun c => mirrorCrossing_perm c)
+  exact List.Perm.flatMap_left d.crossings (fun c _ => mirrorCrossing_perm c)
 
+open List in
 /-- `mirror` preserves `KnotDiagram.wf` (Issue #8644 closure).
 
 `mirrorCrossing` swaps `e2 ↔ e4`, so `mirror_diag_edges d` is a permutation of
@@ -539,7 +540,6 @@ multiset (range check on the support via `all`, parity check on per-label
 `count`) plus `numEdges`, and mirror preserves `numEdges` by field identity.
 This is the full polymorphic generalisation that `decide` could not discharge
 on free variables (cf. C918-L1 ★) — here closed by hand. -/
-open List in
 theorem mirror_wf_preserves (k : Knot) (h : k.diagram.wf = true) :
     k.mirror.diagram.wf = true := by
   -- Mirror diagram field identities (defeq).
@@ -570,8 +570,8 @@ theorem mirror_wf_preserves (k : Knot) (h : k.diagram.wf = true) :
     rw [Bool.and_eq_true] at h ⊢
     obtain ⟨h_all, h_par⟩ := h
     refine ⟨?_, ?_⟩
-    · -- Range check: `all` is invariant under permutation.
-      rw [← hmedges, hp.all_eq]; exact h_all
+    · -- Range check: `all` is invariant under permutation (`Perm.all_eq`).
+      rw [hmedges, hp.all_eq]; exact h_all
     · -- Parity check: per-label `count` is invariant under permutation.
       have heq : (fun i => decide (k.mirror.diagram.edges.count (i + 1) = 2)) =
                  (fun i => decide (k.diagram.edges.count (i + 1) = 2)) := by


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA — prev: REVIEW/lean #8667 (c.727)

# feat(knot,#8644): `mirror_wf_preserves` — polymorphic closure via `List.Perm.flatMap`

**EPIC**: #8604 (knot theory formalisation)
**Sub-track**: #8644 (polymorphic `mirror_wf_preserves` lemma)
**See**: #8604, #8644

## Scope

This PR closes the polymorphic lemma that #8667 (merged c.933) **explicitly deferred** to a Lean-capable lane. #8667 shipped the per-diagram count preservation (`mirror_diag_preserves_count`) and a partial wrapper (`mirror_wf_preserves_partial`); the full closure `∀ k, k.diagram.wf = true → k.mirror.diagram.wf = true` was left to po-2026 (this lane). This is that closure.

## Approach

The cleanest route (cleaner than the count→membership argument I sketched in my #8667 review) lifts the **per-crossing permutation** `mirrorCrossing_perm` (S13, #8667) to a **full-diagram permutation**:

```
mirror_edges_perm : ∀ d, mirror_diag_edges d ~ d.edges
```

via `List.flatMap_map` + `List.Perm.flatMap_right` — `mirror` only swaps `e2 ↔ e4` inside each crossing, so `(cs.map mirrorCrossing).flatMap F ~ cs.flatMap F`. From a permutation:

- **range check** (`d.edges.all (1 ≤ l ∧ l ≤ numEdges)`): `List.all` is invariant under permutation (`hp.all_eq`).
- **parity check** (`(range numEdges).all (count (i+1) = 2)`): per-label count preserved via `mirror_diag_preserves_count` (S13, already proved — not re-derived, so this branch does not depend on the missing `List.perm_iff_count`).
- `numEdges` is a field identity under `Knot.mirror`.

Both branches of `KnotDiagram.wf` (degenerate `crossings = []` / non-degenerate) close. No `sorry`, no `decide` on free variables.

## Critère B (`pr-review-discipline`) — `grep -c sorry` before/after

| File | before (code-only) | after (code-only) | Δ |
|------|--------------------|-------------------|---|
| `Basic.lean` | 0 | 0 | 0 |
| `Basic_en.lean` | 0 | 0 | 0 |

Code-only = docstrings (`/- ... -/`) and comments (`-- ...`) stripped. (Raw `grep -c sorry Basic.lean` = 1, but that hit is the prose "No `sorry`" inside the S14 docstring, not a tactic — same prose-only pattern S13 already uses.) **No proof-sorry introduced.**

## Sibling-pair `_en` byte-identity (EPIC #4980)

S14 is mirrored in `Basic_en.lean`. Code-identity verified (strip docstrings/comments → diff modulo `Knots` ↔ `Knots_en` namespace + `end`): only the expected `namespace`/`end` lines differ; the S14 code (signatures, proofs, tactics) is byte-identical FR ↔ EN. Also **restores the missing `end Knots`** that #8667 dropped (FR file had an unclosed `namespace Knots` — compiled via Lean's end-of-file tolerance, but a latent defect; this PR closes it cleanly).

## `lake build` — honest verification status

The job `ci / Lean CI (knot_lean)` (`lean-knot.yml`) is the canonical build oracle (lesson c.28, relayed by ai-01). I have triggered it by opening this PR; the verdict will appear on the checks. 

I could **not** pre-verify locally before push: `knot_lean`'s `.lake/packages` Mathlib was not junctioned on this lane and a from-scratch build is ~40 min. I launched a local `lake exe cache get && lake build Knots` in parallel (background); if it finishes before the CI it gives an independent local confirmation, but the CI check is the merge gate.

**Risk flagged honestly**: the proof leans on three Mathlib/Batteries lemma names that I could not verify offline — `List.flatMap_map`, `List.Perm.flatMap_right`, and `List.Perm.all_eq` (used as `hp.all_eq`). These are standard perm lemmas; if any has a different name in v4.31.0-rc1, the CI will name it in the error log and I iterate. The parity-check branch does **not** depend on perm lemmas (it uses `mirror_diag_preserves_count`), so a perm-naming failure would only affect the range-check branch.

## Acceptance of #8644 (honest mapping)

| #8644 acceptance | this PR | note |
|---|---|---|
| `mirror_wf_preserves` lemma, no sorry | ✅ | delivered |
| `lake build knot_lean` SUCCESS | ⏳ | CI gate (this PR) |
| Sibling-pair in `Basic_en.lean` | ✅ | byte-identical S14 |
| PR opened targeting #8604 | ✅ | this PR |
| `Knot.mirror.hwell` restored to `mirror_wf_preserves …` | ❌ (gated) | **gated by #8604** (not caduc — it becomes exigible the moment #8604 re-lands the structural field change). `hwell` is still `True` on `main` (the `#8604` field change was reverted in #8643). This PR delivers the *lemma* #8644 calls for; the `hwell` rewiring is the separate, larger `#8604` follow-up. |

`See #8644` (not `Closes`): the lemma is delivered, but the `hwell`-restoration acceptance item is gated by #8604 and out of scope here. Coordinator to judge whether the lemma alone warrants `Closes #8644`.

## Links

- EPIC #8604, Sub-track #8644, PR #8667 (merged, deferred this closure), PR #8643 (closed, hwell-replace attempt), my #8667 review (comment-5104524855).
- Convention sibling-pair EPIC #4980, `lean-merge-discipline.md` (CI = build oracle).

— po-2026
