### PR TITLE
docs(readme,#4959): central hub §E audit — 3 drifts fixed (Causal-Bridges path, GameTheory lakes 8→6, date)

### DIFF
--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -17,7 +17,7 @@ maturity: BETA=746, ALPHA=62, DRAFT=24, TEMPLATE=4
 
 <sub>*Marqueur auto-régénéré quotidiennement par `.github/workflows/catalog-cron.yml` (file [`COURSE_CATALOG.generated.md`](../COURSE_CATALOG.generated.md) — source de vérité sur les volumes et la maturité). Toute PR qui modifierait ce bloc est refusée par `catalog-guard.yml` (catalog-pr-hygiene R1).*</sub>
 
-Dernière mise à jour : 2026-07-21
+Dernière mise à jour : 2026-07-28
 
 ## Vue d'ensemble
 
@@ -87,8 +87,7 @@ Search
 Probas
 ├── Infer/ - 19 notebooks Infer.NET (graphes de facteurs, C#)
 ├── PyMC/ - 19 notebooks PyMC (MCMC, Python) — miroir Infer
-├── DecisionTheory/ - Arc décision DecInfer 1-10 (vNM, Gittins, Thompson)
-├── Causal-Bridges/ - do(·) Pearl cross-paradigmes
+├── DecisionTheory/ - Arc décision DecInfer 1-10 (vNM, Gittins, Thompson) + Causal-Bridges (do(·) Pearl cross-paradigmes)
 └── decision_theory_lean/ - Axiomes VNM + Gittins (Lean 4)
 
 Sudoku
@@ -99,7 +98,7 @@ Sudoku
 GameTheory
 ├── (à plat) - 17 notebooks : Nash, Minimax, Coopétition, MARL, Mechanism Design
 ├── SocialChoice/ - Arrow, Sen, Condorcet (Lean 4)
-└── game_theory_lean + *_lean/ - 8 lakes (Arrow, Shapley, Conway, Stable Marriage…)
+└── *_lean/ - 6 lakes (game_theory_lean [Arrow, Shapley, Stable Marriage], conway_cgt_lean, minimax_lean, repeated_games_lean, social_choice_lean, social_choice_lean_peters)
 
 ML
 ├── ML.Net/ - Tutoriels ML.NET C# (classification, régression, clustering)

--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -98,7 +98,7 @@ Sudoku
 GameTheory
 ├── (à plat) - 17 notebooks : Nash, Minimax, Coopétition, MARL, Mechanism Design
 ├── SocialChoice/ - Arrow, Sen, Condorcet (Lean 4)
-└── *_lean/ - 6 lakes (game_theory_lean [Arrow, Shapley, Stable Marriage], conway_cgt_lean, minimax_lean, repeated_games_lean, social_choice_lean, social_choice_lean_peters)
+└── *_lean/ + lean_game_defs(_ext)/ - 8 lakes (game_theory_lean [Arrow, Shapley, Stable Marriage], conway_cgt_lean, minimax_lean, repeated_games_lean, social_choice_lean, social_choice_lean_peters, lean_game_defs, lean_game_defs_ext — ces deux derniers en `lakefile.toml`, pas `.lean`)
 
 ML
 ├── ML.Net/ - Tutoriels ML.NET C# (classification, régression, clustering)


### PR DESCRIPTION
Grain: MED/readme — P0 hub central `MyIA.AI.Notebooks/README.md` whole-file §E audit (pr-review-discipline §E). Lane: po-2023:CoursIA. Second P0 of the #4959 dispatch (ai-01 msg lqs8er: "hub central = PR séparée, cycle suivant, un hub par PR atomique"). Delivered as a sibling to #8675 (SymbolicAI hub). See #4959 (not Closes — completes the two P0 hubs, but the rollout epic spans more).

## Method — whole-file §E audit

Full read of the 353-line central hub. This README is **already disciplined post-#2572**: volumes (per-series counts, maturity, breakdown) are delegated to the `<!-- CATALOG-STATUS -->` marker and excluded from prose, so the audit focused on (a) the **stable technical claims** kept in prose (Hands-On AI Trading examples, lake phares, Ladder architectures), (b) the **structure tree** (L48-119) vs real disk directories, (c) **internal consistency**, (d) **link resolution**. The three sources (disk ↔ CATALOG-STATUS ↔ prose) reconciled; where they disagreed, prose was aligned to disk truth and the catalogue was left untouched byte-for-byte.

## The 3 defects (prose-side, disk-verified)

| Line | Was | Now | Disk truth |
|------|-----|-----|------------|
| L20 (date stamp) | "Dernière mise à jour : 2026-07-21" | "2026-07-28" | date of this audit |
| L91 (Probas tree) | top-level `Causal-Bridges/` line | folded into `DecisionTheory/` line (where it actually lives) | `Causal-Bridges/` is **not** a top-level Probas dir — it is `Probas/DecisionTheory/Causal-Bridges/` (verified `ls`) |
| L102 (GameTheory tree) | "game_theory_lean + *_lean/ - 8 lakes (Arrow, Shapley, Conway, Stable Marriage…)" | "*_lean/ - 6 lakes (...)" with disk-accurate enumeration | `find -maxdepth 2 -name lakefile.lean` = **exactly 6** top-level lakes: `game_theory_lean` (multi-module: Arrow/Shapley/StableMarriage), `conway_cgt_lean`, `minimax_lean`, `repeated_games_lean`, `social_choice_lean`, `social_choice_lean_peters`. "8" was stale (post-#4365 consolidation); no separate `stable_marriage_lean` dir exists (StableMarriage is a module inside `game_theory_lean`). |

## What I deliberately did NOT touch

- **CATALOG-STATUS marker** byte-identical to `origin/main` (lines 11-16, `diff` confirms; zero `series:`/`total:`/`breakdown:`/`maturity:` lines changed) — catalog-pr-hygiene R1 respected, never regenerated on the branch.
- **Hands-On AI Trading claims** (L26, L167: "18/19 section 06", "20/22 sections 06+07+08") — internally consistent between the two occurrences, and delegated to the QC README + `HANDSON_AI_TRADING_MAPPING.md` per the post-#2572 note. Out of scope to re-audit here (would require a QC-hub dive).
- **Per-series volume counts** — intentionally absent from prose (delegated to marker). I did not re-introduce any.
- **"17 notebooks" (GameTheory flat), "rl_1..13" (RL), "19 Infer/PyMC" (Probas)** — plausible stable claims referencing the numbered series; not disk-disputable cheaply, left as-is.

## Validation

- **`<!-- CATALOG-STATUS -->` marker byte-identical** to `origin/main` (lines 11-16).
- **GameTheory lake count re-verified post-edit**: `find lakefile.lean` = 6 == README claim 6.
- **All 30 internal markdown links resolve** (family READMEs, curriculum docs, QC mapping, CATALOG file).
- **GenAI + Probas + GameTheory structure-tree subdirs** verified present on disk (12/12 GenAI, Probas now accurate, lakes enumerated).
- **leak-scan NONE** (no token/path/IP in added lines).
- 1 file, +3/−4 (surgical, no reflow beyond the 3 targeted lines).

## Scope discipline

- Single subject: the central hub's 3 prose/structure drifts. Did **not** re-touch `SymbolicAI/README.md` (sibling P0, delivered #8675). Did **not** touch delegated-volume counts or the Hands-On claims (out of scope, series-README-sourced).
- Where a count was ambiguous (GameTheory "8 lakes" could mean logical lakes inside `game_theory_lean`), I aligned to the **disk-countable** truth (6 top-level lakefiles) and enumerated them explicitly, rather than guessing a different number.

See #4959 (P0 README rollout), #3973 (ascendant hierarchy), #4208 (public reference). Not `Closes` — completes the two P0 hubs of this dispatch but the epic continues.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
