### PR TITLE
fix(prover,#8677): B.3 proof-integrity gate — sorryAx policy + per-declaration #print axioms (crit 1,2,3,5; CI job split)

### DIFF
--- a/.claude/rules/pr-review-discipline.md
+++ b/.claude/rules/pr-review-discipline.md
@@ -26,7 +26,8 @@ Si dépassement : refuser le merge, exiger split en PRs cohérentes par feature.
 Toute PR touchant `*.lean` ou `agent_tests/prover/` **DOIT** inclure dans le body :
 1. `grep -c sorry` avant/après par fichier modifié
 2. Lien vers `Lake build SUCCESS` (CI ou commit local prouvable)
-3. Lien vers `Proof integrity SUCCESS` (axiom check)
+3. Lien vers `Proof integrity SUCCESS` (axiom check) — produit par le job CI `proof-integrity` (câblé lake par lake, pilote `knot_lean`) qui exécute `LeanVerifier.check_axioms(module, fail_on_sorry=True)` : détecte un `sorry` **transitif** (l'axiome `sorryAx` dans la chaîne de dépendances) qu'un `grep -c sorry` ne verra jamais. Reproduction locale : `python -c "from lean_server import LeanVerifier; print(LeanVerifier('<lake-root>').check_axioms('<Module>', fail_on_sorry=True))"` depuis `agent_tests/`. **Tant que le job n'est pas câblé sur le lake de la PR**, B.3 se lit **non applicable** (à écrire explicitement dans le body), jamais comme un gate silencieusement sauté — un reviewer ne doit pas avoir à choisir entre bloquer sur un artefact impossible et merger sur un gate mort (#8677).
+
 4. Si refactor du prover Python : justifier pourquoi le refactor est nécessaire pour le claim Lean (sinon split en 2 PRs)
 
 Sans ces 4 éléments → **CHANGES_REQUESTED** automatique.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -94,6 +94,73 @@ def _find_lake_root(start: Path) -> Optional[Path]:
         cur = cur.parent
 
 
+# --- Declaration enumeration for the axiom-integrity gate (#8677) ------------
+#
+# `#print axioms` expects a *declaration* name, not a module segment: emitting
+# `#print axioms Basic` for module `Knots.Basic` resolves nothing unless a
+# declaration is fortuitously named `Basic`. To feed real declaration names we
+# parse the module source, tracking `namespace`/`end` blocks so each name is
+# emitted fully qualified. See pr-review-discipline.md §B.3 / issue #8677.
+_DECL_HEAD_RE = re.compile(
+    r"^(?:@\[[^\]]*\]\s*)*"                                     # attributes (zero or more)
+    r"(?:(?:private|protected|noncomputable|unsafe|partial|abstract)\s+)*"
+    r"(?:theorem|lemma|def|opaque|axiom|abbrev|structure|inductive|class)\s+"
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_'.]*)",
+    re.MULTILINE,
+)
+_NS_OPEN_RE = re.compile(r"^\s*namespace\s+(?P<ns>[A-Za-z_][A-Za-z0-9_.]*)")
+_NS_CLOSE_RE = re.compile(r"^\s*end\s+(?P<ns>[A-Za-z_][A-Za-z0-9_.]*)")
+
+
+def _module_source_path(project: Path, module_name: str) -> Optional[Path]:
+    """Resolve the ``.lean`` file for a dotted ``module_name`` under ``project``."""
+    rel = Path(module_name.replace(".", "/") + ".lean")
+    direct = project / rel
+    if direct.exists():
+        return direct
+    # Nested lakes may root source trees one level below the lakefile; glob the
+    # basename as a fallback rather than walking every directory.
+    for hit in project.rglob(rel.name):
+        if hit.is_file():
+            return hit
+    return None
+
+
+def _enumerate_module_declarations(project: Path, module_name: str) -> List[str]:
+    """Return fully-qualified declaration names declared in ``module_name``.
+
+    Parses the module source, tracking ``namespace``/``end`` blocks so each
+    declaration is qualified by its enclosing namespace(s). ``instance`` and
+    ``example`` (which may be anonymous) are intentionally excluded. Returns an
+    empty list when the source file cannot be located -- callers MUST treat that
+    as "gate cannot run" (fail-loud for the CI gate), never as "gate passed".
+    """
+    src = _module_source_path(project, module_name)
+    if src is None:
+        return []
+    text = src.read_text(encoding="utf-8", errors="replace")
+    ns_stack: List[str] = []
+    decls: List[str] = []
+    for line in text.splitlines():
+        m_open = _NS_OPEN_RE.match(line)
+        if m_open:
+            ns_stack.append(m_open.group("ns"))
+            continue
+        m_close = _NS_CLOSE_RE.match(line)
+        if m_close:
+            if ns_stack:
+                ns_stack.pop()
+            continue
+        m = _DECL_HEAD_RE.match(line)
+        if m:
+            name = m.group("name")
+            if "." in name or not ns_stack:
+                decls.append(name)
+            else:
+                decls.append(".".join(ns_stack + [name]))
+    return decls
+
+
 class LeanVerifier:
     """Verify Lean 4 files using lake build with content-hash caching.
 
@@ -318,18 +385,44 @@ class LeanVerifier:
             except OSError:
                 pass
 
-    def check_axioms(self, module_name: str, whitelist: list = None) -> dict:
-        """Check axioms used by a module via #print axioms.
+    def check_axioms(
+        self,
+        module_name: str,
+        whitelist: list = None,
+        fail_on_sorry: bool = False,
+    ) -> dict:
+        """Check axioms used by a module via ``#print axioms``.
 
-        Level 3 verification: after build succeeds, check that no
-        unexpected axioms (beyond sorry/classical.choice) are used.
+        Level 3 verification: after build succeeds, check that no unexpected
+        axioms (beyond the whitelist) are used, and -- when ``fail_on_sorry`` is
+        set -- that no declaration transitively depends on ``sorryAx``.
+
+        Two correctness gates (issue #8677, pr-review-discipline §B.3):
+
+        * ``#print axioms`` is emitted per **declaration** (enumerated from the
+          module source, namespace-qualified), not per module segment. The
+          command expects a declaration name, so the previous
+          ``module_name.split('.')[-1]`` form resolved nothing and made the gate
+          green-blind.
+        * ``sorryAx`` is the axiom that reveals a (possibly transitive) ``sorry``
+          in the dependency chain -- the one piece of information a textual
+          ``grep -c sorry`` can never see. The prover tracks sorry at Level 2 and
+          intentionally tolerates ``sorryAx`` here, so ``fail_on_sorry=False``
+          (the default) preserves that behaviour. The CI review gate passes
+          ``fail_on_sorry=True`` so a transitive sorry fails integrity.
 
         Args:
-            module_name: Dotted module name (e.g. 'SocialChoice.Voting')
-            whitelist: List of allowed axiom names (default: classical + propext + funext)
+            module_name: Dotted module name (e.g. 'Knots.Basic').
+            whitelist: Allowed axiom names (default: classical + propext + funext
+                + Quot).
+            fail_on_sorry: When True, ``success`` is False if any declaration
+                transitively depends on ``sorryAx``. Default False (prover
+                behaviour -- sorry is tracked at Level 2, so Level 3 stays green
+                on a parse gap to avoid flipping historical results).
 
         Returns:
-            dict with 'success', 'axioms' (list), 'forbidden' (list), 'raw_output'
+            dict with 'success', 'axioms', 'forbidden', 'has_sorry',
+            'fail_on_sorry', 'declarations', 'enumerated', 'raw_output'.
         """
         if whitelist is None:
             whitelist = [
@@ -341,10 +434,40 @@ class LeanVerifier:
             ]
 
         project = Path(self.project_dir)
+        # Re-root to the Lake root the same way verify_project_file does, so the
+        # import resolves against prebuilt oleans regardless of project_dir depth.
+        if not _has_lakefile(project):
+            root = _find_lake_root(project)
+            if root is not None:
+                project = root
+
+        declarations = _enumerate_module_declarations(project, module_name)
+        if not declarations:
+            # Prover path (fail_on_sorry=False): preserve historical green
+            # behaviour (Level 2 tracks sorry separately) -- do NOT flip Level 3
+            # on a source-parse gap. CI gate path (fail_on_sorry=True): fail
+            # loud so the review gate is never green-blind (#8677).
+            base = {
+                "axioms": [],
+                "forbidden": [],
+                "whitelist": whitelist,
+                "has_sorry": False,
+                "fail_on_sorry": fail_on_sorry,
+                "declarations": [],
+                "enumerated": False,
+                "raw_output": "",
+            }
+            if fail_on_sorry:
+                return {**base, "success": False, "error": "no_declarations_enumerated"}
+            return {**base, "success": True}
+
         cmd, env = _resolve_lake_command(["env", "lean", "--stdin"], cwd=str(project))
+        stdin_lines = [f"import {module_name}"] + [
+            f"#print axioms {decl}" for decl in declarations
+        ]
+        stdin_input = "\n".join(stdin_lines) + "\n"
 
         try:
-            stdin_input = f"import {module_name}\n#print axioms {module_name.split('.')[-1]}\n"
             result = subprocess.run(
                 cmd,
                 cwd=str(project),
@@ -354,17 +477,21 @@ class LeanVerifier:
                 env=env,
                 input=stdin_input,
             )
-
             output = result.stdout + "\n" + result.stderr
             axioms = self._extract_axioms(output)
             forbidden = [a for a in axioms if a not in whitelist and a != "sorryAx"]
+            has_sorry = "sorryAx" in axioms
+            success = len(forbidden) == 0 and not (fail_on_sorry and has_sorry)
 
             return {
-                "success": len(forbidden) == 0,
+                "success": success,
                 "axioms": axioms,
                 "forbidden": forbidden,
                 "whitelist": whitelist,
-                "has_sorry": "sorryAx" in axioms,
+                "has_sorry": has_sorry,
+                "fail_on_sorry": fail_on_sorry,
+                "declarations": declarations,
+                "enumerated": True,
                 "raw_output": output,
             }
         except (subprocess.TimeoutExpired, FileNotFoundError) as e:
@@ -372,6 +499,11 @@ class LeanVerifier:
                 "success": False,
                 "axioms": [],
                 "forbidden": [],
+                "whitelist": whitelist,
+                "has_sorry": False,
+                "fail_on_sorry": fail_on_sorry,
+                "declarations": declarations,
+                "enumerated": True,
                 "error": str(e),
                 "raw_output": "",
             }
@@ -483,15 +615,28 @@ class LeanVerifier:
 
     @staticmethod
     def _extract_axioms(output: str) -> list:
-        """Extract axiom names from #print axioms output."""
+        """Extract axiom names from ``#print axioms`` output.
+
+        Lean emits one line per declaration in the form
+        ``'Foo.bar' depends on axioms [A, B, C]`` (or ``'Foo.bar' depends on
+        axioms []``). Parse the bracketed list of each such line and union the
+        names across declarations. The previous comma-split over the whole line
+        captured garbage such as ``'Foo.bar' depends on axioms [Classical.choice``
+        as an "axiom name", which silently poisoned the forbidden-axiom check
+        (#8677).
+        """
         axioms = []
         for line in output.split("\n"):
-            line = line.strip()
-            if line and not line.startswith("[") and not line.startswith("error"):
-                for name in line.split(","):
-                    name = name.strip().rstrip(".")
-                    if name and name not in ("", "axioms"):
-                        axioms.append(name)
+            m = re.search(r"depends on axioms \[([^\]]*)\]", line)
+            if not m:
+                continue
+            inner = m.group(1).strip()
+            if not inner:
+                continue
+            for name in inner.split(","):
+                name = name.strip().rstrip(".")
+                if name:
+                    axioms.append(name)
         return list(set(axioms))
 
     @staticmethod

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
@@ -1,0 +1,165 @@
+"""Unit tests for ``LeanVerifier.check_axioms`` and declaration enumeration (#8677).
+
+Covers the two correctness gates of ``pr-review-discipline.md`` §B.3:
+
+* ``#print axioms`` is emitted per **declaration** (namespace-qualified), not
+  per module segment -- the command expects a declaration name.
+* ``sorryAx`` reveals a (possibly transitive) ``sorry`` in the dependency chain
+  and fails integrity when ``fail_on_sorry=True`` (the CI review gate), while
+  the prover default ``fail_on_sorry=False`` preserves historical behaviour
+  (Level 2 tracks sorry textually, so Level 3 stays green).
+
+No real Lean build is required: ``subprocess.run``, the lake resolver and the
+declaration enumerator are mocked so the gate logic is exercised deterministically.
+
+Run from ``agent_tests/``::
+
+    python -m pytest tests/test_check_axioms.py -q
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Make the package importable regardless of how pytest is invoked.
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+import lean_server  # noqa: E402
+from lean_server import LeanVerifier, _enumerate_module_declarations  # noqa: E402
+
+# Lean single-quotes the declaration name in ``#print axioms`` output.
+Q = "'"
+
+
+def _axiom_line(name: str, axioms: list) -> str:
+    inner = ", ".join(axioms) if axioms else ""
+    return f"{Q}{name}{Q} depends on axioms [{inner}]"
+
+
+class _FakeCompletedProcess:
+    def __init__(self, stdout: str = "", stderr: str = ""):
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _enumerate_module_declarations
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_enumeration_namespace_tracking(tmp_path):
+    src = (
+        "namespace Foo\n"
+        "theorem bar : True := trivial\n"
+        "theorem baz : True := trivial\n"
+        "end Foo\n"
+        "def quux : Nat := 0\n"
+    )
+    mod = tmp_path / "Knots"
+    mod.mkdir()
+    (mod / "Basic.lean").write_text(src, encoding="utf-8")
+    decls = _enumerate_module_declarations(tmp_path, "Knots.Basic")
+    assert decls == ["Foo.bar", "Foo.baz", "quux"]
+
+
+def test_enumeration_attributes_and_dotted_name(tmp_path):
+    src = (
+        "@[simp] theorem Private.thing : True := trivial\n"
+        "theorem plain : True := trivial\n"
+    )
+    (tmp_path / "M.lean").write_text(src, encoding="utf-8")
+    decls = _enumerate_module_declarations(tmp_path, "M")
+    assert decls == ["Private.thing", "plain"]
+
+
+def test_enumeration_missing_source_returns_empty(tmp_path):
+    assert _enumerate_module_declarations(tmp_path, "Does.Not.Exist") == []
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _extract_axioms
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_extract_axioms_parses_depends_on_format():
+    out = "\n".join(
+        [
+            _axiom_line("A.foo", ["Classical.choice", "propext"]),
+            _axiom_line("A.bar", []),
+        ]
+    )
+    assert set(LeanVerifier._extract_axioms(out)) == {"Classical.choice", "propext"}
+
+
+def test_extract_axioms_detects_sorry_axiom():
+    out = _axiom_line("X.y", ["sorryAx"])
+    assert LeanVerifier._extract_axioms(out) == ["sorryAx"]
+
+
+def test_extract_axioms_ignores_non_axiom_lines():
+    out = "error: unknown identifier 'Nope'\nrandom diagnostics line\n"
+    assert LeanVerifier._extract_axioms(out) == []
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# check_axioms gate logic (subprocess mocked)
+# ──────────────────────────────────────────────────────────────────────────
+
+def _check_with_output(decls, fake_stdout, *, fail_on_sorry=False, project_dir="."):
+    verifier = LeanVerifier(project_dir)
+    with patch.object(lean_server, "_enumerate_module_declarations", return_value=decls), \
+            patch.object(lean_server, "_resolve_lake_command", return_value=(["lean"], {})), \
+            patch.object(lean_server.subprocess, "run",
+                         return_value=_FakeCompletedProcess(fake_stdout)):
+        return verifier.check_axioms("Knots.Basic", fail_on_sorry=fail_on_sorry)
+
+
+def test_clean_proof_passes_gate():
+    out = _axiom_line("Knots.Basic.t1", ["Classical.choice", "propext"])
+    r = _check_with_output(["Knots.Basic.t1"], out, fail_on_sorry=True)
+    assert r["success"] is True
+    assert r["has_sorry"] is False
+    assert r["enumerated"] is True
+    assert r["declarations"] == ["Knots.Basic.t1"]
+
+
+def test_transitive_sorry_fails_ci_gate():
+    out = _axiom_line("Knots.Basic.t1", ["sorryAx"])
+    r = _check_with_output(["Knots.Basic.t1"], out, fail_on_sorry=True)
+    assert r["success"] is False
+    assert r["has_sorry"] is True
+
+
+def test_transitive_sorry_prover_path_stays_green():
+    # fail_on_sorry=False (prover): Level 2 tracks sorry textually, so Level 3
+    # must NOT flip to red on a sorryAx -- historical behaviour preserved.
+    out = _axiom_line("Knots.Basic.t1", ["sorryAx"])
+    r = _check_with_output(["Knots.Basic.t1"], out, fail_on_sorry=False)
+    assert r["success"] is True
+    assert r["has_sorry"] is True
+
+
+def test_forbidden_axiom_fails_both_paths():
+    out = _axiom_line("Knots.Basic.t1", ["of_eq_true"])
+    r_prover = _check_with_output(["Knots.Basic.t1"], out, fail_on_sorry=False)
+    r_gate = _check_with_output(["Knots.Basic.t1"], out, fail_on_sorry=True)
+    assert r_prover["success"] is False
+    assert r_gate["success"] is False
+    assert r_gate["forbidden"] == ["of_eq_true"]
+
+
+def test_no_declarations_ci_gate_fails_loud():
+    r = _check_with_output([], "", fail_on_sorry=True)
+    assert r["success"] is False
+    assert r["error"] == "no_declarations_enumerated"
+    assert r["enumerated"] is False
+
+
+def test_no_declarations_prover_path_stays_green():
+    r = _check_with_output([], "", fail_on_sorry=False)
+    assert r["success"] is True
+    assert r["enumerated"] is False


### PR DESCRIPTION
fix(prover,#8677): wire the B.3 proof-integrity gate — sorryAx policy + per-declaration `#print axioms` + parsed output

Grain: MED/code (harness tooling). Lane: po-2023:CoursIA. Fixes the two defects in `LeanVerifier.check_axioms` that made `pr-review-discipline.md` §B.3 ("Proof integrity / axiom check") a dead gate, plus a latent parsing defect that would have kept it dead even after the fix. Criteria **1, 2, 3, 5** of #8677 delivered here; criterion **4 (CI job cabling)** deliberately split to a follow-up (rationale below). See #8677 (partial).

## Why §B.3 is currently unverifiable

`#8677` (opened firsthand at the merge of knot_lean #8673) documents that the axiom-integrity check exists in the prover harness (`lean_server.py:check_axioms`, consumed by `prover/tools.py:compile(check_axioms=True)` for the prover's Level-3 self-verification) but is **never cabled for a human PR review**. Worse, the tool itself was green-blind:

- **(b)** `#print axioms {module_name.split('.')[-1]}` emits a *module segment* (e.g. `Basic` for `Knots.Basic`), but `#print axioms` expects a *declaration name*. So Lean answered `unknown identifier`, `_extract_axioms` got nothing, and `success` was `True` by default — a gate that cannot fail.
- **(a)** `sorryAx` was excluded from `forbidden`, so even a correctly-named check would report `success=True` on a proof whose dependency chain hides a transitive `sorry` — exactly the `sorry` a textual `grep -c sorry` can never see, i.e. the whole reason to run an axiom check at all.

## What this PR changes — `agent_tests/lean_server.py`

| Defect | Before | After |
|--------|--------|-------|
| **(b)** `#print axioms` target | module segment `module.split('.')[-1]` (resolves nothing) | per **declaration**: new `_enumerate_module_declarations()` parses the module source, tracks `namespace`/`end` blocks, returns fully-qualified names (`Foo.bar`, `standalone`, `Private.thing` incl. `@[simp]` attributes) |
| **(a)** sorryAx policy | `a != "sorryAx"` silently excluded from `forbidden` → `success` always ignored sorry | explicit `fail_on_sorry: bool = False` param; `success = len(forbidden)==0 and not (fail_on_sorry and has_sorry)`. Default `False` **preserves prover behaviour** (Level 2 tracks sorry textually); CI gate passes `True` |
| **latent** `_extract_axioms` | comma-split over the whole line captured garbage like `'Foo.bar' depends on axioms [Classical.choice` as an "axiom name" | regex `depends on axioms \[([^\]]*)\]` parses the bracketed list of the canonical `'Name' depends on axioms [...]` output |

### Prover behaviour preservation (anti-regression)

The existing consumer `prover/tools.py:2062` calls `check_axioms(module_name)` with no `fail_on_sorry` → default `False`. Two safeguards avoid flipping historical Level-3 results:

1. `sorryAx` still excluded from `forbidden` on the default path → a proof with a transitive sorry stays `success=True` exactly as before (the prover counts sorry at Level 2).
2. When `_enumerate_module_declarations` returns `[]` (source not located / parse gap): prover path returns `success=True` (historical green), CI-gate path (`fail_on_sorry=True`) **fails loud** (`error: no_declarations_enumerated`) — so the review gate is never green-blind. The only behavioural change for the prover is that real *forbidden* axioms (beyond the whitelist) are now detected on modules whose source parses, which is the intended Level-3 job.

## Tests — `agent_tests/tests/test_check_axioms.py` (new, 12 cases, all mock-based)

No real Lean build needed (`subprocess.run`, `_resolve_lake_command`, `_enumerate_module_declarations` mocked):

- `_enumerate_module_declarations`: namespace tracking, `@[simp]` attributes + dotted names, missing-source → `[]`.
- `_extract_axioms`: `depends on axioms [...]` parsing, `sorryAx` detection, ignores error/non-axiom lines.
- `check_axioms` gate logic: **clean proof → PASS**; **transitive sorry → FAIL** (`fail_on_sorry=True`); transitive sorry on prover path → stays green; forbidden axiom → FAIL both paths; no-declarations gate → fail loud / prover → green.

```
12 passed in 0.20s   (python -m pytest tests/test_check_axioms.py -q, from agent_tests/)
```

## Rule — `.claude/rules/pr-review-discipline.md` §B point 3

Updated to cite the producing job (`proof-integrity`, pilot `knot_lean`), the local reproduction command (`check_axioms(module, fail_on_sorry=True)`), and the **N/A caveat**: until the job is cabled on a PR's lake, B.3 reads *non applicable* (written explicitly in the body), never as a silently-skipped gate.

## Scope: criterion 4 (CI job) deliberately deferred

#8677 acceptance criterion 4 asks for a reusable CI job producing a citable `Proof integrity` artefact. **This PR does not include it**, on purpose:

- `lean-knot.yml` (and the 13 sibling `lean-*.yml`) all consume the **shared reusable workflow** `lean-build.yml` via inputs (`sorry-baseline`, `sorry-filter-mode`). Cabling the gate "in the same form" means either adding a `proof-integrity` input to that shared workflow (touches all 14 lakes' CI) or a standalone job duplicating the elan/Lake/mathlib-clone setup — either way **non-trivial YAML that only runs on push** (no local verification possible).
- Per `pr-review-discipline.md` §A (G.4: one subject per PR) and the anti-regression rule, the safe split is: **(this PR)** make the tool correct + tested + documented; **(follow-up)** cable the CI job once the tool is verified. The tool fix is the foundation; a half-tested CI job modifying a shared workflow risks breaking 14 lakes' green builds.

A follow-up issue/PR will add the `proof-integrity` job (input on `lean-build.yml`, cabled first on `knot_lean` per the issue's pilot choice).

## Acceptance checklist (#8677)

- [x] `check_axioms` distinguishes `sorryAx` explicitly (policy written in code via `fail_on_sorry`)
- [x] `#print axioms` emitted on real declaration names (namespace-qualified enumeration)
- [x] Test: clean proof → PASS ; transitive sorry → FAIL (12 cases)
- [ ] CI job on `knot_lean` producing a citable artefact — **follow-up PR** (see Scope above)
- [x] `pr-review-discipline.md` B.3 updated with the exact command/link

See #8677 (partial), #1453 (prover harness epic). Not `Closes` — criterion 4 remains.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
