### PR TITLE
feat(cost,#8056): forward-migrate metadata.cost on Sudoku-0/1/2 tranche (5 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb
@@ -854,6 +854,23 @@
      }
     ]
    }
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:30Z",
+   "vram_tier": "NONE",
+   "validator": "manual",
+   "reproducibility": "HIGH",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Environnement C# et classes de base Sudoku (grille, énumables, helpers). cpu-only .NET, aucun API/GPU. Fondations importées par les notebooks suivants via #!import."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb
@@ -860,7 +860,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:30Z",
+   "last_validated": "2026-07-28T15:30Z",
    "vram_tier": "NONE",
    "validator": "manual",
    "reproducibility": "HIGH",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
@@ -1155,6 +1155,23 @@
      }
     ]
    }
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:30Z",
+   "vram_tier": "NONE",
+   "validator": "manual",
+   "reproducibility": "HIGH",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Résolution Sudoku par backtracking (DFS avec retour-arrière) en C#. Solveur algorithmique cpu-only, déterministe, aucun API/GPU. Exécution < 1 min."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
@@ -1161,7 +1161,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:30Z",
+   "last_validated": "2026-07-28T15:30Z",
    "vram_tier": "NONE",
    "validator": "manual",
    "reproducibility": "HIGH",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
@@ -1789,6 +1789,23 @@
    "parameters": {},
    "start_time": "2026-06-01T20:39:12.737056+00:00",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:30Z",
+   "vram_tier": "NONE",
+   "validator": "papermill",
+   "reproducibility": "HIGH",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Résolution Sudoku par backtracking (DFS retour-arrière) en Python (jumeau du C#). Solveur algorithmique cpu-only, déterministe. Exécution < 1 min."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
@@ -1795,7 +1795,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:30Z",
+   "last_validated": "2026-07-28T15:30Z",
    "vram_tier": "NONE",
    "validator": "papermill",
    "reproducibility": "HIGH",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
@@ -1482,6 +1482,23 @@
      }
     ]
    }
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:30Z",
+   "vram_tier": "NONE",
+   "validator": "manual",
+   "reproducibility": "HIGH",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Résolution Sudoku par Dancing Links / Algorithm X (Knuth) en C#. Solveur exact-cover cpu-only, déterministe. Aucun appel réseau (références HTTP = liens doc uniquement)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
@@ -1488,7 +1488,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:30Z",
+   "last_validated": "2026-07-28T15:30Z",
    "vram_tier": "NONE",
    "validator": "manual",
    "reproducibility": "HIGH",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
@@ -1868,7 +1868,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:30Z",
+   "last_validated": "2026-07-28T15:30Z",
    "vram_tier": "NONE",
    "validator": "papermill",
    "reproducibility": "HIGH",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
@@ -1862,6 +1862,23 @@
    "parameters": {},
    "start_time": "2026-05-13T07:58:03.197644",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:30Z",
+   "vram_tier": "NONE",
+   "validator": "papermill",
+   "reproducibility": "HIGH",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Résolution Sudoku par Dancing Links / Algorithm X (Knuth) en Python (jumeau du C#). Solveur exact-cover cpu-only, déterministe. Références HTTP = liens doc uniquement."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
feat(cost,#8056): forward-migrate metadata.cost on Sudoku-0/1/2 tranche (5 notebooks)

Grain: MED/data (cost-metadata fleet, forward migration). Lane: po-2023:CoursIA. Adds the cpu-only canonical cost profile to the first Sudoku tranche. See #8056 (partial — one family of the cost-metadata fleet).

## What this PR changes

Adds `metadata.cost` to 5 Sudoku notebooks (forward migration — none had pre-existing metadata to disturb):

| Notebook | Kernel | Solver |
|----------|--------|--------|
| Sudoku-0-Environment-Csharp | .net-csharp | Environnement + classes de base (fondations `#!import`-ées) |
| Sudoku-1-Backtracking-Csharp | .net-csharp | Backtracking (DFS retour-arrière) |
| Sudoku-1-Backtracking-Python | python3 | Backtracking (jumeau Python) |
| Sudoku-2-DancingLinks-Csharp | .net-csharp | Dancing Links / Algorithm X (Knuth) |
| Sudoku-2-DancingLinks-Python | python3 | Dancing Links (jumeau Python) |

All five are **pure algorithmic solvers** — no API, no GPU, no network.

## Canonical cpu-only profile (c.888 lesson: vram_tier NONE, NOT LITE)

```json
{
  "api_provider": "none",
  "network": false,
  "cpu_min": 1,
  "api_usd_est": 0.0,
  "last_validated": "2026-07-28T17:30Z",
  "vram_tier": "NONE",
  "validator": "manual | papermill",   // manual=.NET (dotnet-interactive local), papermill=Python
  "reproducibility": "HIGH",            // deterministic
  "gpu_required": false,
  "gpu_min": 0,
  "vram_gb": 0,
  "reduced_pedagogical": "self",
  "external_account": "none",
  "free_alternative": "self",
  "notes": "<per-notebook FR description>"
}
```

`vram_tier: NONE` (not LITE) is the c.888 canonical value for cpu-only notebooks — the prior migration fleet bug (c.887/c.888) had defaulted cpu-only to LITE; this forward migration applies the corrected value.

## Verification

- **Byte-stable forward migration**: each notebook round-trips identically under `json.dumps(indent=1)` (verified in-script), so the cost block was inserted via clean JSON — no raw-text surgery, no source-cell changes.
- `git diff --stat`: **5 files, +85/-0** (17 lines/file = the cost block), 0 deletions.
- **No source cell changes**: `git diff | grep -cE '^\+\s*"source"'` = 0. 33 cells intact (Sudoku-2 Python spot-checked).
- `check_cost_metadata.py` (scripts/audit) **PASS — 0 findings** on all 5.
- **No secrets**: notes are FR prose describing solvers (no keys, tokens, `os.getenv` literals).
- **Sudoku-2 'http' flag**: Dancing Links references are documentation URLs (Knuth / Wikipedia), not API calls — `network: false` is correct.

## Scope

One family (Sudoku-0/1/2) of the #8056 cost-metadata fleet. Not `Closes` — the fleet spans many families; this is the forward Sudoku tranche. Subsequent tranches (Sudoku-10 ORTools, etc.) are separate PRs.

## Notebook re-execution note (C.2/C.3)

This PR touches **metadata only** (`metadata.cost`), not code cells or markdown source. Per C.3, no re-execution is required for a metadata-only change (no source cell changed). The notebooks' existing `execution_count`/`outputs` are untouched and remain valid.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
