### PR TITLE
docs(search8-minizinc,#8081): add Nethercote 2007 + MiniZinc Handbook citations to C# twin (completes pair)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb
@@ -1338,6 +1338,24 @@
     "\n",
     "Les graphiques matplotlib du twin Python sont remplacés par des barres ASCII autonomes. Deux axes : concision (lignes de code) et evaluation multi-critères (score 1-5)."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "references-citations",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Références\n",
+    "\n",
+    "Ce notebook enseigne la **modélisation déclarative par contraintes** via le langage **MiniZinc**, résolu côté C# par le solveur **OR-Tools CP-SAT** (NuGet `Google.OrTools`). Les deux références canoniques ci-dessous ancrent cette démarche dans la littérature fondatrice et l'écosystème standard du domaine.\n",
+    "\n",
+    "- **Nethercote, N., Stuckey, P. J., Becket, R., Brand, S., Duck, G. J., & Tack, G. (2007).** « MiniZinc: Towards a Standard CP Modelling Language. » In *Principles and Practice of Constraint Programming (CP 2007)*, LNCS **4741**, p. 529-543. Springer. DOI : [10.1007/978-3-540-74970-7_38](https://doi.org/10.1007/978-3-540-74970-7_38). — l'article fondateur qui définit MiniZinc comme langage de modélisation standard pour la programmation par contraintes, indépendant des solveurs sous-jacents. Cartographie directe avec la philosophie déclarative, la syntaxe (variables, domaines, contraintes, objectifs) et les contraintes globales (`alldifferent`, `circuit`) du notebook.\n",
+    "\n",
+    "- **MiniZinc Team.** *The MiniZinc Handbook* (spécification du langage + interface vers les solveurs) et la **MiniZinc Challenge** (compétition annuelle de solveurs CP, depuis 2008). [www.minizinc.org](https://www.minizinc.org). — la spécification en évolution du langage et le banc d'essai canonique qui évalue les solveurs backend (dont OR-Tools CP-SAT, invoqué ici via le NuGet `Google.OrTools`).\n",
+    "\n",
+    "> **Fidélité à la source** : ce notebook (jumeau C# du `App-8-MiniZinc.ipynb` Python) explicite et met en pratique la modélisation déclarative que Nethercote et al. (2007) ont formalisée. Le socle théorique (variables / domaines / contraintes / objectifs) suit la spécification MiniZinc ; la résolution s'appuie sur OR-Tools CP-SAT, l'un des solveurs backend que la MiniZinc Challenge évalue chaque année.\n"
+   ]
   }
  ],
  "metadata": {

--- a/scripts/notebook_tools/twin_pairs.d/app-8-minizinc.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-8-minizinc.yaml
@@ -7,9 +7,8 @@
     date: "2026-07-28"
     by: po-2024:CoursIA-2
     python_sha: 8eaa1026bcc06cbaa624c808ce8458ff9646ae6c
-    csharp_sha: a23abb89caa43b005af88529f9f757810b5ec384
+    csharp_sha: 240e04733ad2b9e1bcc0c8ec42a56a342408d5e9
   known_differences:
     - "Socle pedagogique commun : MiniZinc (modeling language CSP, OR-Tools CP-SAT cross-solve) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = minizinc + OR-Tools CP-SAT ; C# = Google.OrTools.Sat NuGet (C# binding du meme solver OR-Tools)."
     - "Asymetrie pedagogique : Python met l'accent sur le solveur SOTA (OR-Tools CP-SAT / library specialisee) + visualisation matplotlib + experimentation comparative ; le C# demontre l'implementation from-scratch en BCL pure (ou binding NuGet du meme solver pour App-8/10/15), presentation compacte. Meme socle theorique, leviers de demonstration differents."
-    - "Asymetrie citations (c.932, 2026-07-28) : le twin Python porte une cellule finale ## References (Nethercote et al. 2007 + MiniZinc Handbook/Challenge, #8081 distillation-fidelity) ; le twin C# n'en a pas encore (left for a follow-up grain, atomicite 1-sujet/PR, pattern c.927 GT-4 Nash)."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python (c.932 #8682 — Python twin of this same pair).

## Summary

Completes the **App-8 MiniZinc twin pair** by adding the same `## Références` markdown cell to the **C# twin** (`App-8-MiniZinc-Csharp.ipynb`, 24→25 cells) that c.932 (#8682) added to the Python twin. This resolves the citation asymmetry I explicitly flagged in #8682's known_difference ("C# twin left for a follow-up grain"). Both twins of a registered pair now carry the canonical MiniZinc references → twin-parity restored on the citation axis.

The C# twin teaches the same **MiniZinc SOTA constraint-programming modeling language** socle (9 MiniZinc mentions, 15 CP-SAT) resolved via the **OR-Tools CP-SAT** NuGet binding (`Google.OrTools`), with **zero attribution** to the foundational literature — same #8081 distillation-fidelity gap as the Python twin.

## The two citations (same canonical refs as the Python twin, for twin-parity; both DBLP/web-verified in c.932)

- **Nethercote, N., Stuckey, P. J., Becket, R., Brand, S., Duck, G. J., & Tack, G. (2007).** « MiniZinc: Towards a Standard CP Modelling Language. » In *Principles and Practice of Constraint Programming (CP 2007)*, LNCS **4741**, p. 529-543. Springer. DOI: [10.1007/978-3-540-74970-7_38](https://doi.org/10.1007/978-3-540-74970-7_38). — the founding paper defining MiniZinc as a solver-independent standard CP modeling language. (Verified firsthand on DBLP in c.932.)
- **MiniZinc Team.** *The MiniZinc Handbook* + the **MiniZinc Challenge** (annual CP solver competition, since 2008). [www.minizinc.org](https://www.minizinc.org). — the language spec and the canonical solver benchmark (OR-Tools CP-SAT, invoked here via NuGet, is one of the Challenge solvers).

A `> **Fidélité à la source**` blockquote ties the citations to the notebook's pedagogical stance and notes the C# twin's OR-Tools.Sat NuGet idiom. References chosen to match the Python twin exactly (twin-parity on the citation axis); the OR-Tools-specific framing lives in the Fidélité note and the existing known_differences, not as a divergent citation set.

## Verification (firsthand)

- **Markdown-only** (C.2 exception — no re-execution needed): diff is **+18 / −0** on the notebook, one new markdown cell appended after the last cell (`### Visualisation ASCII`). **0 code/output/execution_count lines touched** (verified: `git diff | grep -cE '"execution_count"|"outputs"'` = 0).
- **Exact JSON serialization preserved**: `json.dumps(d, indent=1, ensure_ascii=False) + '\n'` (round-trip verified byte-identical pre-edit; same serializer as c.932). Proper French accents (é=31, matching the notebook body, C887-L).
- **Registered twin — rebaselined**: `scripts/notebook_tools/twin_pairs.d/app-8-minizinc.yaml` (pair "App-8 MiniZinc"). Markdown edit moves the C# blob → `check_twin_parity.py --check --per-pair --base origin/main` run **before push** (C928-L): `csharp_sha` rebaselined a23abb89 → new blob. **CRLF 14→0** post-`--update` (C934-L1). twin-parity guard: **136/0/0 (OK=136, DRIFT=0)**.
- `validate_pr_notebooks.py`: **1/1 passed** (14 code cells, .net-csharp, C.1/H.1/H.3 OK).
- `detect_md_content_loss.py` (#8656 gate): **findings=0** (md_cells 10→11, +1568 normalized chars).
- **C.1**: 0 `raise NotImplementedError`/`assert False`/`1/0`.
- `nbformat.validate`: OK. JSON valid, **0 CRLF**.

## Stacking note for ai-01 (merge order + trivial yaml conflict)

This PR and **#8682** (c.932, the Python twin of the same pair) **both touch `twin_pairs.d/app-8-minizinc.yaml`** — specifically the `last_audit` block (date / by / python_sha / csharp_sha). It is a **mono-file conflict on the SHA fields**, identical in shape to the c.929 rebases. This branch was created from `origin/main` (33dc9e5e8), so its yaml carries `python_sha` = the pre-#8682 value (the Python twin is unmodified here) — correct for this branch in isolation.

**Merge order: #8682 first, then this PR.** When #8682 merges (`python_sha` → the Python-with-citations blob), this branch rebases onto `main` and the yaml conflict resolves by: `python_sha` = #8682's value (Python twin now on main), `csharp_sha` = this PR's value, `date`/`by` updated, and the **asymmetry known_difference note added in #8682 is removed** (both twins now carry citations → parity). A `--update --pair "App-8 MiniZinc"` after rebase recomputes both SHAs cleanly. Trivial, mechanical — same as c.929.

## Scope

One notebook (C# twin), one markdown cell + one twin YAML rebaseline. Atomic. Completes the twin pair started by #8682. Search is my partition (CPU/.NET); no cross-lane collision (L898: `gh pr list --search "App-8-MiniZinc Csharp"` = no other open PR).

See #8081 (distillation-fidelity / attribution class — twin-pair completion).
