### PR TITLE
feat(cost,#8056): forward-migrate metadata.cost on Sudoku metaheuristic/CSP tranche (12 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
@@ -1715,6 +1715,23 @@
      }
     ]
    }
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:45Z",
+   "vram_tier": "NONE",
+   "validator": "manual",
+   "reproducibility": "HIGH",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Résolution Sudoku via Google OR-Tools (solveur CP-SAT). Solveur exact cpu-only déterministe, aucun appel réseau."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
@@ -1721,7 +1721,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:45Z",
+   "last_validated": "2026-07-28T15:45Z",
    "vram_tier": "NONE",
    "validator": "manual",
    "reproducibility": "HIGH",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
@@ -1469,7 +1469,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:45Z",
+   "last_validated": "2026-07-28T15:45Z",
    "vram_tier": "NONE",
    "validator": "papermill",
    "reproducibility": "HIGH",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
@@ -1463,6 +1463,23 @@
    "parameters": {},
    "start_time": "2026-06-02T21:28:41.925174+00:00",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:45Z",
+   "vram_tier": "NONE",
+   "validator": "papermill",
+   "reproducibility": "HIGH",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Résolution Sudoku via Google OR-Tools CP-SAT (jumeau Python). Solveur exact cpu-only déterministe."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
@@ -1116,7 +1116,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:45Z",
+   "last_validated": "2026-07-28T15:45Z",
    "vram_tier": "NONE",
    "validator": "manual",
    "reproducibility": "MEDIUM",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
@@ -1110,6 +1110,23 @@
      }
     ]
    }
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:45Z",
+   "vram_tier": "NONE",
+   "validator": "manual",
+   "reproducibility": "MEDIUM",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Algorithme génétique (population, sélection, croisement, mutation) pour la résolution Sudoku. Métaheuristique stochastique cpu-only, aucun API/GPU."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
@@ -1873,7 +1873,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:45Z",
+   "last_validated": "2026-07-28T15:45Z",
    "vram_tier": "NONE",
    "validator": "papermill",
    "reproducibility": "MEDIUM",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
@@ -1867,6 +1867,23 @@
    "parameters": {},
    "start_time": "2026-05-14T07:40:09.547119+00:00",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:45Z",
+   "vram_tier": "NONE",
+   "validator": "papermill",
+   "reproducibility": "MEDIUM",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Algorithme génétique pour Sudoku (jumeau Python). Métaheuristique stochastique cpu-only."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
@@ -3165,6 +3165,23 @@
      }
     ]
    }
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:45Z",
+   "vram_tier": "NONE",
+   "validator": "manual",
+   "reproducibility": "MEDIUM",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Recuit simulé (Simulated Annealing) pour la résolution Sudoku. Métaheuristique stochastique cpu-only, aucun API/GPU."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
@@ -3171,7 +3171,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:45Z",
+   "last_validated": "2026-07-28T15:45Z",
    "vram_tier": "NONE",
    "validator": "manual",
    "reproducibility": "MEDIUM",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
@@ -2780,6 +2780,23 @@
    "parameters": {},
    "start_time": "2026-05-13T07:58:03.197644",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:45Z",
+   "vram_tier": "NONE",
+   "validator": "papermill",
+   "reproducibility": "MEDIUM",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Recuit simulé pour Sudoku (jumeau Python). Métaheuristique stochastique cpu-only."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
@@ -2786,7 +2786,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:45Z",
+   "last_validated": "2026-07-28T15:45Z",
    "vram_tier": "NONE",
    "validator": "papermill",
    "reproducibility": "MEDIUM",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
@@ -2395,6 +2395,23 @@
    "parameters": {},
    "start_time": "2026-05-02T18:21:55.357600+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:45Z",
+   "vram_tier": "NONE",
+   "validator": "manual",
+   "reproducibility": "MEDIUM",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Optimisation par essaim particulaire (PSO) appliquée au Sudoku. Métaheuristique stochastique cpu-only, aucun API/GPU."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
@@ -2401,7 +2401,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:45Z",
+   "last_validated": "2026-07-28T15:45Z",
    "vram_tier": "NONE",
    "validator": "manual",
    "reproducibility": "MEDIUM",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
@@ -2166,6 +2166,23 @@
    "parameters": {},
    "start_time": "2026-06-05T11:07:19.385500",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:45Z",
+   "vram_tier": "NONE",
+   "validator": "papermill",
+   "reproducibility": "MEDIUM",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Optimisation par essaim particulaire (PSO) pour Sudoku (jumeau Python). Métaheuristique stochastique cpu-only."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
@@ -2172,7 +2172,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:45Z",
+   "last_validated": "2026-07-28T15:45Z",
    "vram_tier": "NONE",
    "validator": "papermill",
    "reproducibility": "MEDIUM",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
@@ -1812,7 +1812,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:45Z",
+   "last_validated": "2026-07-28T15:45Z",
    "vram_tier": "NONE",
    "validator": "manual",
    "reproducibility": "HIGH",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
@@ -1806,6 +1806,23 @@
    "parameters": {},
    "start_time": "2026-05-02T18:23:09.710901+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:45Z",
+   "vram_tier": "NONE",
+   "validator": "manual",
+   "reproducibility": "HIGH",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Solveur CSP style AIMA (backtracking + propagation de contraintes, heuristiques MRV/LCV) pour Sudoku. Solveur déterministe cpu-only, aucun API/GPU."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
@@ -2333,6 +2333,23 @@
    "parameters": {},
    "start_time": "2026-06-05T11:16:00.836465",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:45Z",
+   "vram_tier": "NONE",
+   "validator": "papermill",
+   "reproducibility": "HIGH",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Solveur CSP style AIMA pour Sudoku (jumeau Python). Solveur déterministe cpu-only."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
@@ -2339,7 +2339,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:45Z",
+   "last_validated": "2026-07-28T15:45Z",
    "vram_tier": "NONE",
    "validator": "papermill",
    "reproducibility": "HIGH",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
@@ -1890,7 +1890,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:45Z",
+   "last_validated": "2026-07-28T15:45Z",
    "vram_tier": "NONE",
    "validator": "manual",
    "reproducibility": "HIGH",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
@@ -1884,6 +1884,23 @@
     "defaultKernelName": "csharp",
     "languageName": "csharp"
    }
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:45Z",
+   "vram_tier": "NONE",
+   "validator": "manual",
+   "reproducibility": "HIGH",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Modélisation Sudoku comme coloration de graphe (DSATUR / Welsh-Powell). Algorithme cpu-only déterministe, aucun API/GPU."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
@@ -1446,7 +1446,7 @@
    "network": false,
    "cpu_min": 1,
    "api_usd_est": 0.0,
-   "last_validated": "2026-07-28T17:45Z",
+   "last_validated": "2026-07-28T15:45Z",
    "vram_tier": "NONE",
    "validator": "papermill",
    "reproducibility": "HIGH",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
@@ -1440,6 +1440,23 @@
    "parameters": {},
    "start_time": "2026-07-17T05:24:53.102317",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_provider": "none",
+   "network": false,
+   "cpu_min": 1,
+   "api_usd_est": 0.0,
+   "last_validated": "2026-07-28T17:45Z",
+   "vram_tier": "NONE",
+   "validator": "papermill",
+   "reproducibility": "HIGH",
+   "gpu_required": false,
+   "gpu_min": 0,
+   "vram_gb": 0,
+   "reduced_pedagogical": "self",
+   "external_account": "none",
+   "free_alternative": "self",
+   "notes": "Coloration de graphe pour Sudoku (jumeau Python). Algorithme cpu-only déterministe."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/data (cost-metadata fleet #8056, forward migration tranche 2). Lane: po-2023:CoursIA. Adds the cpu-only canonical cost profile to 6 twin-pairs (C#+Python) of Sudoku algorithmic solvers. See #8056 (partial — one family of the cost-metadata fleet).

## What this PR changes

Adds `metadata.cost` to 12 Sudoku notebooks (forward migration — none had pre-existing metadata). All 12 were selected for **flags=none** (no http/api/gpu patterns in source) — zero network-judgment risk:

| Solver | Kernel | Type | Reproducibility |
|--------|--------|------|-----------------|
| Sudoku-3-Genetic (C#/Py) | .net-csharp / python3 | stochastic metaheuristic | MEDIUM (seed-dependent) |
| Sudoku-4-SimulatedAnnealing (C#/Py) | .net-csharp / python3 | stochastic metaheuristic | MEDIUM |
| Sudoku-5-PSO (C#/Py) | .net-csharp / python3 | stochastic metaheuristic | MEDIUM |
| Sudoku-6-AIMA-CSP (C#/Py) | .net-csharp / python3 | deterministic CSP solver | HIGH |
| Sudoku-9-GraphColoring (C#/Py) | .net-csharp / python3 | deterministic graph coloring | HIGH |
| Sudoku-10-ORTools (C#/Py) | .net-csharp / python3 | deterministic CP-SAT solver | HIGH |

## Canonical cpu-only profile (c.888: vram_tier NONE, NOT LITE)

```
api_provider: none, network: false, gpu_required: false, gpu_min: 0
vram_tier: NONE, vram_gb: 0, cpu_min: 1, api_usd_est: 0.0
validator: manual (.NET, dotnet-interactive local) | papermill (Python)
reproducibility: HIGH (deterministic) | MEDIUM (stochastic, honest)
reduced_pedagogical: self, external_account: none, free_alternative: self
notes: <per-notebook FR description of the solver>
```

Honest reproducibility is the key judgment here: stochastic metaheuristics (genetic, simulated annealing, PSO) are seed-dependent → MEDIUM; exact/deterministic solvers (OR-Tools CP-SAT, AIMA CSP, graph coloring) → HIGH.

## Verification

- **Byte-stable forward migration**: each notebook round-trips identically under `json.dumps(indent=1)` (verified in-script) → clean JSON insertion, no raw-text surgery.
- `git diff --stat`: **12 files, +204/-0** (17 lines/file = the cost block), 0 deletions.
- **No source cell changes**: `git diff | grep -cE '"source"'` = 0.
- `check_cost_metadata.py` (scripts/audit) **PASS — 0 findings** on all 12.
- **No secrets**: notes are FR prose describing solvers.

## Scope & siblings

One family (Sudoku cpu-only metaheuristics/CSP) of the #8056 fleet. Sibling PR #8685 (tranche 1: Sudoku-0/1/2 backtracking + Dancing Links, 5 notebooks) is independent — different notebooks, no conflict. The remaining flagged Sudoku notebooks (Norvig, Z3, BDD, SymbolicAutomata, Infer, NeuralNetwork, LLM, Comparison — http/api/gpu patterns) are **excluded** here: their patterns need per-notebook verification (doc URL vs API call, cf the Sudoku-2 DancingLinks precedent where http = doc link, network:false correct) and go in a dedicated tranche. Tranche 2 sticks to the clean flags=none batch.

## Notebook re-execution note (C.2/C.3)

Metadata-only change (`metadata.cost`) — no code/markdown source cells touched. Per C.3, no re-execution required. Existing `execution_count`/`outputs` untouched and remain valid.

Co-Authored-By: Claude-Code <noreply@anthropic.com>