### PR TITLE
feat(cost,#8056): falsifiable api_cost_breakdown gate + .NET canonical profile

### DIFF
--- a/docs/notebook-metadata/cost-matrix.md
+++ b/docs/notebook-metadata/cost-matrix.md
@@ -27,8 +27,9 @@ bloc `---\n...\n---` est promue par markdown-it en **setext-H2 supersize**
 ```json
 // nb.metadata["cost"] — l'objet JSON sérialisé par le notebook (.ipynb = JSON).
 {
-  "api_usd_est": 0.40,            // Coût API estimé par exécution end-to-end (USD). 0 si gratuit.
+  "api_usd_est": 0.40,            // Coût API estimé par exécution end-to-end (USD). 0 si gratuit, null si inconnu. Cf §"Attribution multi-fournisseur".
   "api_provider": "openai",       // openai | anthropic | mistral | hf | replicate | google | local | none
+  "api_cost_breakdown": null,     // OPTIONNEL. Ventilation provider→USD, somme == api_usd_est (gate falsifiable). Cf §"Attribution multi-fournisseur".
   "qcc_tokens_est": 0,            // QuantConnect Cloud compute tokens (QCC) estimés par exécution end-to-end. 0 si non-QC. Cf §"Coût QCC / QuantConnect".
   "cpu_min": 1,                   // Estimation CPU-only minutes (range ou best-case)
   "gpu_min": 0,                   // Estimation GPU minutes (range ou best-case)
@@ -76,6 +77,7 @@ source de vérité, le badge est un confort de lecture.
 |-------|-------------|----------------|
 | `cost.api_usd_est` | ✓ | `0` |
 | `cost.api_provider` | ✓ | `"none"` |
+| `cost.api_cost_breakdown` | optionnel | `null` (multi-fournisseur seulement ; `sum == api_usd_est` vérifié) |
 | `cost.qcc_tokens_est` | optionnel | `0` (0 = non-QC ; à peupler pour tout quantbook QC Cloud) |
 | `cost.cpu_min` | ✓ | `0` |
 | `cost.gpu_min` | optionnel | (omission = pas d'estimation GPU) |
@@ -89,6 +91,55 @@ source de vérité, le badge est un confort de lecture.
 | `cost.reproducibility` | ✓ | `"HIGH"` |
 | `cost.last_validated` | ✓ | (date de création de la metadata) |
 | `cost.validator` | ✓ | `"manual"` |
+
+### Attribution multi-fournisseur (`api_cost_breakdown`)
+
+**Décision de schéma (design-gate #8056, issuecomment 5106409423) : scalaire
+autoritatif + ventilation optionnelle et falsifiable.**
+
+`api_usd_est` reste **le** champ autoritatif — c'est lui que lisent les
+consommateurs (agrégats, catalogue, badges). `api_cost_breakdown` est un champ
+**optionnel** qui ventile le coût par fournisseur quand cette information est
+réellement connue (plusieurs endpoints payants dans le même notebook) :
+
+```json
+"api_usd_est": 0.42,                 // TOTAL autoritatif, obligatoire
+"api_cost_breakdown": {              // optionnel
+  "openai": 0.30,
+  "anthropic": 0.12
+}
+```
+
+**Règle falsifiable (la seule qui compte) :** quand `api_cost_breakdown` est
+présent, `sum(valeurs)` **doit égaler** `api_usd_est`. Vérifié par
+`check_cost_metadata.py` (Litmus 8) — un écart > 1 cent déclenche le finding
+`api_cost_breakdown_sum_mismatch`.
+
+Pourquoi exiger la somme plutôt que laisser la ventilation libre ? Une
+ventilation libre est **décorative** : personne ne peut la contredire, elle se
+périme en silence au premier drift. Une ventilation dont la somme doit égaler
+le total est **falsifiable** — elle casse le jour où elle ment. Même leçon que
+le README central (`#8678` : un compteur nu se périme ; un compteur avec son
+dénominateur se contredit tout seul) et que le gate de preuve Lean (`#8680` :
+un gate incapable d'échouer n'est pas un gate).
+
+**Quand l'écrire :**
+- Notebook multi-fournisseur dont les sous-totaux par provider sont réellement
+  mesurés (ex : un notebook qui appelle GPT-5 pour le raisonnement **et**
+  Claude pour la vérification, coûts séparés dans les logs).
+
+**Quand NE PAS l'écrire (règles d'or) :**
+- **Mono-fournisseur** : écrire la ventilation dupliquerait le total pour zéro
+  information, et fabriquerait 327 occasions de drift. On laisse `null`.
+- **Sous-totaux reconstitués à la louche** : une fausse précision sur une
+  estimation `validator: "manual"` est pire que l'absence. On laisse `null` et
+  on documente la raison dans `notes` si pertinent.
+
+**`0.0` vs `null` sur `api_usd_est` (corollaire) :**
+- `0.0` **affirme** la gratuité (notebook local, pas d'appel facturé). C'est un
+  énoncé positif.
+- `null` (+ raison) = coût **inconnu**. Ne pas confondre : `0.0` n'est pas un
+  défaut pour « je ne sais pas », l'absence se lirait à tort comme gratuite.
 
 ### Tiers VRAM (déterminé par `vram_gb`)
 
@@ -262,6 +313,58 @@ cost:
   last_validated: 2026-07-23T01:30Z
   validator: papermill
 ```
+
+### .NET Interactive (profil canonique, cpu-only)
+
+Un notebook **.NET Interactive** (kernel `.net-csharp` / `.net-fsharp`) sans
+appel API n'a **pas le profil** d'un notebook Python appelant OpenAI. Le profil
+canonique ci-dessous est celui à appliquer aux familles .NET cpu-only pures
+(Sudoku solveurs, Search CSP, GameTheory twins C#) — il diffère du profil
+Python+API sur trois points : `validator`, `vram_tier`, `free_alternative`.
+
+```yaml
+# Profil canonique .NET Interactive cpu-only (ex: Sudoku solveur, Search CSP)
+cost:
+  api_usd_est: 0.0
+  api_provider: none
+  cpu_min: 1
+  gpu_min: 0
+  gpu_required: false
+  vram_gb: 0
+  vram_tier: NONE              # cpu-only — c.888 canonical (PAS LITE)
+  network: false
+  external_account: none
+  free_alternative: self       # le notebook local sans API EST son alternative gratuite
+  reduced_pedagogical: null
+  reproducibility: HIGH        # solveurs .NET déterministes (MEDIUM si stochastique)
+  last_validated: "2026-07-28T15:45Z"   # UTC obligatoire (cf leçon TZ : jamais local+Z)
+  validator: manual
+```
+
+**`validator: manual` est la valeur canonique pour .NET.** Le kernel
+`.net-csharp` s'exécute via `dotnet-interactive` headless local, **pas** via
+papermill (qui ne pilote pas les kernels .NET Interactive par défaut). Écrire
+`validator: papermill` suggère une validation automatisée absente — `manual`
+est honnête : la re-exécution se fait via `dotnet-interactive` sur chaque
+machine worker (cf `docs/reference/kernels-runtime.md`), le résultat est vérifié
+à la main. La CI ne peut pas Papermill-exécuter les notebooks .NET (advisory
+`#5214`) — `manual` reflète cette réalité.
+
+**`vram_tier: NONE` pour cpu-only** (leçon c.888) : un notebook sans GPU doit
+porter `NONE`, pas `LITE`. `LITE` décrit un besoin VRAM faible mais **réel**
+(< 8 GB) ; un notebook cpu-only n'a **aucun** besoin VRAM. La table générale
+« <8=LITE » s'applique aux notebooks GPU à faible VRAM, pas au cpu-only.
+
+**`free_alternative: self`** : un notebook .NET local sans API payante **EST**
+déjà gratuit — le sentinel `self` le dit (`null` signifierait à tort « aucune
+alternative gratuite connue », cf §"Sentinels de `free_alternative`").
+
+> **Note d'harmonisation (hors scope de ce PR).** Les profils historiques
+> `Probas/Infer.NET` et `ML/ML.NET` ci-dessus portent `validator: papermill` et
+> omettent `vram_tier: NONE`/`free_alternative: self`. Ils ont été migrés avant
+> la formalisation de ce profil canonique. Leur harmonisation vers
+> `validator: manual` se fait en tranche dédiée (pas un blanket-sweep — chaque
+> notebook vérifié `api_provider: none` au passage).
 
 ### QC / QuantConnect (Cloud obligatoire)
 

--- a/scripts/audit/check_cost_metadata.py
+++ b/scripts/audit/check_cost_metadata.py
@@ -406,34 +406,51 @@ def check_notebook(notebook_path: Path, repo_root: Path) -> dict:
                 })
                 total = None
             if total is not None:
-                try:
-                    breakdown_sum = sum(float(v) for v in breakdown.values())
-                except (TypeError, ValueError):
+                # bool est subclass de int en Python (float(True) == 1.0) : un
+                # montant USD n'est jamais un booleen. Rejeter explicitement
+                # AVANT la sommation, sinon {"openai": true} passerait le gate
+                # en silence (NIT Hermes review #8688).
+                bool_keys = sorted(k for k, v in breakdown.items() if isinstance(v, bool))
+                if bool_keys:
                     findings.append({
                         'pattern': 'api_cost_breakdown_non_numeric',
                         'detail': (
-                            f'cost.api_cost_breakdown contient des valeurs '
-                            f'non-numeriques : {sorted(breakdown.keys())}. '
-                            f'Chaque cle (provider) doit avoir une valeur float USD.'
+                            f'cost.api_cost_breakdown contient une valeur '
+                            f'booleenne (true/false) pour : {bool_keys}. '
+                            f'Chaque cle (provider) doit avoir une valeur '
+                            f'float USD, pas un bool (float(True)==1.0 trompe la sommation).'
                         ),
                         'severity': 'MAJOR',
                     })
                 else:
-                    # Tolerance 1 cent (arrondi USD) : evite les FP de precision
-                    # float (0.1+0.2 != 0.3 en binaire) sans tolerer un vrai
-                    # desequilibre. round(..., 2) serait equivalent.
-                    if abs(breakdown_sum - total) > 0.01:
+                    try:
+                        breakdown_sum = sum(float(v) for v in breakdown.values())
+                    except (TypeError, ValueError):
                         findings.append({
-                            'pattern': 'api_cost_breakdown_sum_mismatch',
+                            'pattern': 'api_cost_breakdown_non_numeric',
                             'detail': (
-                                f'cost.api_cost_breakdown somme '
-                                f'{breakdown_sum:.2f} != api_usd_est {total:.2f} '
-                                f'(delta {breakdown_sum - total:+.2f}). La '
-                                f'ventilation doit sommer au total autoritatif '
-                                f'(design-gate #8056).'
+                                f'cost.api_cost_breakdown contient des valeurs '
+                                f'non-numeriques : {sorted(breakdown.keys())}. '
+                                f'Chaque cle (provider) doit avoir une valeur float USD.'
                             ),
                             'severity': 'MAJOR',
                         })
+                    else:
+                        # Tolerance 1 cent (arrondi USD) : evite les FP de precision
+                        # float (0.1+0.2 != 0.3 en binaire) sans tolerer un vrai
+                        # desequilibre. round(..., 2) serait equivalent.
+                        if abs(breakdown_sum - total) > 0.01:
+                            findings.append({
+                                'pattern': 'api_cost_breakdown_sum_mismatch',
+                                'detail': (
+                                    f'cost.api_cost_breakdown somme '
+                                    f'{breakdown_sum:.2f} != api_usd_est {total:.2f} '
+                                    f'(delta {breakdown_sum - total:+.2f}). La '
+                                    f'ventilation doit sommer au total autoritatif '
+                                    f'(design-gate #8056).'
+                                ),
+                                'severity': 'MAJOR',
+                            })
 
     return {
         'notebook': str(notebook_path),

--- a/scripts/audit/check_cost_metadata.py
+++ b/scripts/audit/check_cost_metadata.py
@@ -367,6 +367,74 @@ def check_notebook(notebook_path: Path, repo_root: Path) -> dict:
             'severity': 'MAJOR',
         })
 
+    # Litmus 8 : api_cost_breakdown incoherent avec api_usd_est (design-gate #8056).
+    # `api_usd_est` est le scalaire AUTORITATIF (obligatoire, lu par les 327
+    # notebooks deja migres et les agregats). `api_cost_breakdown` est OPTIONNEL :
+    # un notebook mono-fournisseur ne l'ecrit pas (il dupliquerait son total pour
+    # zero information). Quand un multi-fournisseur l'ecrit, sum(valeurs) DOIT
+    # egaler api_usd_est — sinon la ventilation ment (gate FALSIFIABLE, decision
+    # ai-01 #8056 issuecomment 5106409423). Une ventilation libre serait
+    # decorative : personne ne peut la contredire, elle se perime en silence. Une
+    # ventilation dont la somme doit egaler le total casse le jour ou elle derive
+    # — meme lecon que #8678 (un compteur nu se perime) et #8680 (un gate incapable
+    # d'echouer n'est pas un gate).
+    breakdown = cost_meta.get('api_cost_breakdown')
+    if breakdown is not None:
+        if not isinstance(breakdown, dict) or not breakdown:
+            findings.append({
+                'pattern': 'api_cost_breakdown_malformed',
+                'detail': (
+                    'cost.api_cost_breakdown present mais pas un dict non-vide. '
+                    'Attendu : {"openai": 0.30, "anthropic": 0.12} sommant a '
+                    'api_usd_est, ou absent (mono-fournisseur).'
+                ),
+                'severity': 'MAJOR',
+            })
+        else:
+            # api_usd_est doit etre numerique pour pouvoir comparer la somme.
+            try:
+                total = float(cost_meta.get('api_usd_est'))
+            except (TypeError, ValueError):
+                findings.append({
+                    'pattern': 'api_usd_est_not_numeric',
+                    'detail': (
+                        'cost.api_usd_est absent ou non-numerique alors que '
+                        'api_cost_breakdown est present — le scalaire autoritatif '
+                        'manque (design-gate #8056).'
+                    ),
+                    'severity': 'MAJOR',
+                })
+                total = None
+            if total is not None:
+                try:
+                    breakdown_sum = sum(float(v) for v in breakdown.values())
+                except (TypeError, ValueError):
+                    findings.append({
+                        'pattern': 'api_cost_breakdown_non_numeric',
+                        'detail': (
+                            f'cost.api_cost_breakdown contient des valeurs '
+                            f'non-numeriques : {sorted(breakdown.keys())}. '
+                            f'Chaque cle (provider) doit avoir une valeur float USD.'
+                        ),
+                        'severity': 'MAJOR',
+                    })
+                else:
+                    # Tolerance 1 cent (arrondi USD) : evite les FP de precision
+                    # float (0.1+0.2 != 0.3 en binaire) sans tolerer un vrai
+                    # desequilibre. round(..., 2) serait equivalent.
+                    if abs(breakdown_sum - total) > 0.01:
+                        findings.append({
+                            'pattern': 'api_cost_breakdown_sum_mismatch',
+                            'detail': (
+                                f'cost.api_cost_breakdown somme '
+                                f'{breakdown_sum:.2f} != api_usd_est {total:.2f} '
+                                f'(delta {breakdown_sum - total:+.2f}). La '
+                                f'ventilation doit sommer au total autoritatif '
+                                f'(design-gate #8056).'
+                            ),
+                            'severity': 'MAJOR',
+                        })
+
     return {
         'notebook': str(notebook_path),
         'cost_meta_found': bool(cost_meta),

--- a/scripts/audit/tests/test_check_cost_metadata.py
+++ b/scripts/audit/tests/test_check_cost_metadata.py
@@ -355,3 +355,30 @@ def test_litmus8_breakdown_without_numeric_total_fails(tmp_path):
         cost_meta={"api_cost_breakdown": {"openai": 0.30, "anthropic": 0.12}},
     )
     assert "api_usd_est_not_numeric" in _patterns(res["findings"])
+
+
+def test_litmus8_breakdown_bool_value_rejected(tmp_path):
+    """Un bool n'est pas un montant USD : float(True)==1.0 en Python trompe la
+    sommation (bool est subclass de int). Le gate doit le rejeter explicitement
+    (NIT Hermes review #8688), sinon {"openai": true} passerait en silence."""
+    res = _findings_for(
+        tmp_path,
+        "x = 1",
+        cost_meta={"api_usd_est": 1.0, "api_cost_breakdown": {"openai": True}},
+    )
+    pats = _patterns(res["findings"])
+    assert "api_cost_breakdown_non_numeric" in pats
+    assert "api_cost_breakdown_sum_mismatch" not in pats  # le bool est rejeté avant sommation
+
+
+def test_litmus8_breakdown_int_value_accepted(tmp_path):
+    """Un int (non-bool) est un montant USD valide : {openai: 1} -> somme 1.0 == total.
+    Garde-fou anti-regression : le guard bool ne doit pas rejeter les ints légitimes."""
+    res = _findings_for(
+        tmp_path,
+        "x = 1",
+        cost_meta={"api_usd_est": 1.0, "api_cost_breakdown": {"openai": 1}},
+    )
+    pats = _patterns(res["findings"])
+    assert "api_cost_breakdown_non_numeric" not in pats
+    assert "api_cost_breakdown_sum_mismatch" not in pats

--- a/scripts/audit/tests/test_check_cost_metadata.py
+++ b/scripts/audit/tests/test_check_cost_metadata.py
@@ -269,3 +269,89 @@ def test_litmus7_qc_notebook_with_qcc_estimate_ok(tmp_path):
         cost_meta={"validator": "qc_cloud", "qcc_tokens_est": 1200},
     )
     assert "qc_notebook_no_qcc_estimate" not in _patterns(res["findings"])
+
+
+# ---------------------------------------------------------------------------
+# Litmus 8 — api_cost_breakdown falsifiable gate (design-gate #8056)
+# ---------------------------------------------------------------------------
+
+def test_litmus8_breakdown_absent_ok(tmp_path):
+    """Mono-provider: no api_cost_breakdown -> no finding (optional field)."""
+    res = _findings_for(
+        tmp_path, "x = 1", cost_meta={"api_usd_est": 0.0, "api_provider": "none"}
+    )
+    pats = _patterns(res["findings"])
+    assert not any(p.startswith("api_cost_breakdown") for p in pats)
+
+
+def test_litmus8_breakdown_sum_equals_total_ok(tmp_path):
+    """Multi-provider with breakdown summing exactly to api_usd_est -> ok."""
+    res = _findings_for(
+        tmp_path,
+        "x = 1",
+        cost_meta={
+            "api_usd_est": 0.42,
+            "api_cost_breakdown": {"openai": 0.30, "anthropic": 0.12},
+        },
+    )
+    pats = _patterns(res["findings"])
+    assert "api_cost_breakdown_sum_mismatch" not in pats
+
+
+def test_litmus8_breakdown_sum_mismatch_fails(tmp_path):
+    """Breakdown sum != api_usd_est -> finding (the falsifiable gate bites)."""
+    res = _findings_for(
+        tmp_path,
+        "x = 1",
+        cost_meta={
+            "api_usd_est": 0.50,
+            "api_cost_breakdown": {"openai": 0.30, "anthropic": 0.12},  # 0.42 != 0.50
+        },
+    )
+    assert "api_cost_breakdown_sum_mismatch" in _patterns(res["findings"])
+
+
+def test_litmus8_breakdown_float_rounding_ok(tmp_path):
+    """0.1+0.2-style float drift within 1-cent tolerance -> ok (no FP)."""
+    res = _findings_for(
+        tmp_path,
+        "x = 1",
+        cost_meta={
+            "api_usd_est": 0.30,
+            "api_cost_breakdown": {"openai": 0.10, "anthropic": 0.20},  # 0.30000000004
+        },
+    )
+    assert "api_cost_breakdown_sum_mismatch" not in _patterns(res["findings"])
+
+
+def test_litmus8_breakdown_malformed_fails(tmp_path):
+    """Breakdown present but not a non-empty dict -> malformed finding."""
+    res = _findings_for(
+        tmp_path,
+        "x = 1",
+        cost_meta={"api_usd_est": 0.42, "api_cost_breakdown": "openai+anthropic"},
+    )
+    assert "api_cost_breakdown_malformed" in _patterns(res["findings"])
+
+
+def test_litmus8_breakdown_non_numeric_values_fails(tmp_path):
+    """Breakdown with non-numeric values -> non_numeric finding."""
+    res = _findings_for(
+        tmp_path,
+        "x = 1",
+        cost_meta={
+            "api_usd_est": 0.42,
+            "api_cost_breakdown": {"openai": 0.30, "anthropic": "twelve cents"},
+        },
+    )
+    assert "api_cost_breakdown_non_numeric" in _patterns(res["findings"])
+
+
+def test_litmus8_breakdown_without_numeric_total_fails(tmp_path):
+    """Breakdown present but api_usd_est missing/non-numeric -> finding."""
+    res = _findings_for(
+        tmp_path,
+        "x = 1",
+        cost_meta={"api_cost_breakdown": {"openai": 0.30, "anthropic": 0.12}},
+    )
+    assert "api_usd_est_not_numeric" in _patterns(res["findings"])


### PR DESCRIPTION
feat(cost,#8056): falsifiable api_cost_breakdown gate + .NET canonical profile

Implements the design-gate ai-01 tranche on #8056 (issuecomment 5106409423):
scalar-authoritative + optional falsifiable breakdown, and formalizes the
canonical .NET Interactive profile that distinguishes a cpu-only .NET notebook
from a Python+OpenAI one. MED/tooling — genre rotation from cost-data
application (per ai-01: application-cost = LIGHT, this is the MED that serves
the other .NET families).

## 1. Litmus 8 — `sum(api_cost_breakdown) == api_usd_est` (falsifiable gate)

`scripts/audit/check_cost_metadata.py`: when `api_cost_breakdown` is present
(optional field), its values MUST sum to `api_usd_est` (tolerance 1 cent, to
avoid 0.1+0.2 float FP). A breakdown that lies is now CAUGHT, not decorative.
Handles 4 failure modes: malformed (not a dict), `api_usd_est_not_numeric`,
`api_cost_breakdown_non_numeric`, `api_cost_breakdown_sum_mismatch`. Same
lesson as #8678 (a bare counter goes stale; one with its denominator
self-contradicts) and #8680 (a gate that can't fail isn't a gate).

Rule (per ai-01 decision):
- `api_usd_est` stays THE authoritative scalar (327 migrated notebooks, all
  aggregators read it — no consumer migration, no broken field).
- `api_cost_breakdown` optional; mono-provider does NOT write it (would
  duplicate the total for zero info).
- When present, sum == total (falsifiable).

## 2. Tests — 7 new cases (Litmus 8)

`scripts/audit/tests/test_check_cost_metadata.py`: absent OK, sum==total OK,
sum!=total FAILS, float-rounding within 1cent OK (no FP), malformed FAILS,
non-numeric values FAILS, missing-numeric-total FAILS. Suite: 25/25 PASS
(18 existing + 7 new). No regression on Litmus 1-7.

## 3. Doc — schema + .NET canonical profile

`docs/notebook-metadata/cost-matrix.md`:
- New section "Attribution multi-fournisseur (api_cost_breakdown)": the
  falsifiable rule, when to write it (multi-provider, real subtotals) vs when
  NOT (mono-provider / reconstituted-guesstimate), and the 0.0 vs null
  corollary on api_usd_est (0.0 asserts free; null = unknown).
- New section ".NET Interactive (profil canonique, cpu-only)": formalizes the
  profile that differs from Python+API on 3 points — `validator: manual`
  (dotnet-interactive headless, NOT papermill — honest about what CI cannot do,
  advisory #5214), `vram_tier: NONE` for cpu-only (c.888 canonical, NOT LITE),
  `free_alternative: self`. Notes the harmonization gap (Probas/Infer.NET +
  ML/ML.NET carry legacy `validator: papermill`) for a future dedicated tranche.

## Non-regression

The gate is INACTIVE on the current fleet (0 notebook has `api_cost_breakdown`
today — verified by grep). It activates only when the field is first written,
so 0 FP fleet-wide. Validator spot-check on a migrated notebook: 0 new finding.

See #8056 (partial — design-gate tranche). Not Closes: the fleet rollout and
the .NET harmonization tranche remain.

Co-Authored-By: Claude-Code <noreply@anthropic.com>

