### PR TITLE
fix(prover,#8677): whitelist Quot.sound + timeout parametre

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -390,6 +390,7 @@ class LeanVerifier:
         module_name: str,
         whitelist: list = None,
         fail_on_sorry: bool = False,
+        timeout: int = 300,
     ) -> dict:
         """Check axioms used by a module via ``#print axioms``.
 
@@ -419,6 +420,12 @@ class LeanVerifier:
                 transitively depends on ``sorryAx``. Default False (prover
                 behaviour -- sorry is tracked at Level 2, so Level 3 stays green
                 on a parse gap to avoid flipping historical results).
+            timeout: Seconds before elaborating the enumerated declarations
+                against prebuilt oleans times out (passed to ``subprocess.run``).
+                Default 300: ``#print axioms`` elaborates each declaration, which
+                on a cold Mathlib cache can exceed the previous hard-coded 60 s
+                (issue #8677). Callers -- e.g. the CI review gate -- can raise it
+                without re-editing this module.
 
         Returns:
             dict with 'success', 'axioms', 'forbidden', 'has_sorry',
@@ -431,6 +438,13 @@ class LeanVerifier:
                 "funext",
                 "Quot.lift",
                 "Quot.mk",
+                # Quot.sound: the soundness axiom for quotients. Together with
+                # Quot.lift / Quot.mk it is one of Lean's three quotient axioms,
+                # and propext + funext both follow from it -- so any proof touching
+                # quotient soundness (most of Mathlib) needs it. Listing two of
+                # the three quotient axioms but omitting Quot.sound made the gate
+                # forbid it and fail falsely (issue #8677).
+                "Quot.sound",
             ]
 
         project = Path(self.project_dir)
@@ -473,7 +487,7 @@ class LeanVerifier:
                 cwd=str(project),
                 capture_output=True,
                 text=True,
-                timeout=60,
+                timeout=timeout,
                 env=env,
                 input=stdin_input,
             )


### PR DESCRIPTION
## Scope

Two surgical fixes to `LeanVerifier.check_axioms` (`agent_tests/lean_server.py`), per coordinator arbitration (msg-20260728T155204). **Strict scope: these two fixes only** — no CI cablage, no enumeration re-touch (that is #8681's contested zone).

## Fix 1 — `Quot.sound` in the default whitelist

The default axiom whitelist listed two of Lean's three quotient axioms (`Quot.lift`, `Quot.mk`) but omitted **`Quot.sound`**. Since `propext` and `funext` both *follow* from `Quot.sound`, any proof touching quotient soundness — i.e. most of Mathlib — resurfaced in `forbidden` and the gate **failed falsely**. Confirmed via `#print axioms mirror_wf_preserves` (it depends on `Quot.sound`).

This is the same defect family ai-01 flagged this cycle: a too-narrow predicate does not fail loudly, it returns a wrong answer with confidence.

## Fix 2 — `timeout` as a parameter (default 300 s)

`timeout` was hard-coded to `60` s. `#print axioms` elaborates each enumerated declaration against prebuilt oleans, which on a **cold Mathlib cache exceeds 60 s**. The neighbouring subprocess calls in the same file already use `120` (l.556) and `600` (l.287), so `60` was a visible inconsistency. Now `timeout: int = 300` — callers (the CI review gate) can tune it without re-editing the module. **Default chosen: 300 s** — comfortably above the observed cold-closure threshold, below the `600` of the heaviest call.

## Verification

- `python -m py_compile lean_server.py` → **SUCCESS**
- `git diff --stat` → `1 file changed, 15 insertions(+), 1 deletion(-)`
- The `forbidden` / `sorryAx` filter is **byte-identical to origin/main** (no re-touch of the enumeration logic).

## Notes

- `See #8677` (not `Closes`): the CI cablage (criterion 4) is #8681's track and remains open.
- Collision: this PR touches the whitelist; #8681's rebase may conflict here. Coordinator explicitly greenlit separate delivery — these two true-green fixes should not wait on #8681's contested rebase and let `main` carry a falsely-failing gate in the meantime.

See #8677