### PR TITLE
feat(translation,#6949): expose fill-rate signal alongside drift count

### DIFF
--- a/scripts/tests/test_check_translation_sync.py
+++ b/scripts/tests/test_check_translation_sync.py
@@ -20,6 +20,13 @@ verdict WRONG_SCRIPT ni la fonction ``_has_expected_script``), les tests
 d import et de detection FAIL (ImportError sur ``_has_expected_script`` /
 aucune anomalie WRONG_SCRIPT remontee), donc la suite garde le fix.
 
+Extension #6949 point 1 (signal honnete de taux de remplissage) : un
+``SRC_DRIFT=0`` sur une table 0% traduite se lisait a tort comme « a jour ».
+``csv_fill_stats`` + ``_format_fill_line`` exposent le taux de remplissage par
+langue a cote du compte de drift, pour qu'un compteur nu cesse d'etre lu comme
+un achevement. Couverture : denominateur (rows bien formees seules), pivot fr
+toujours 100%, suffixe « AUCUNE traduction deposee » quand toutes cibles a 0%.
+
 Run: ``python -m pytest scripts/tests/test_check_translation_sync.py -q``
 """
 
@@ -162,3 +169,96 @@ def test_check_csv_empty_text_no_wrong_script(tmp_path):
     _write_csv(csv_path, nb_rel, "abc", {"zh": ""})
     anomalies = C.check_csv(csv_path, tmp_path)
     assert not any(a["verdict"] == "WRONG_SCRIPT" for a in anomalies)
+
+
+# ---------------------------------------------------------------------------
+# #6949 point 1 — taux de remplissage (signal honnete)
+# ---------------------------------------------------------------------------
+
+def _write_fill_csv(csv_path, rows):
+    """Ecrit un CSV multi-rows pour ``csv_fill_stats``.
+
+    ``rows`` = liste de dicts ``{lang: text}``. Le pivot ``fr`` est toujours
+    rempli (notebook source) ; les cibles ne le sont que si la row le dit.
+    Une row ``None`` produit une ligne malformee (``cell_id`` vide) pour tester
+    l'exclusion du denominateur.
+    """
+    fields = ["notebook", "cell_id", "cell_type", "src_lang", "src_hash"]
+    fields += [f"text_{l}" for l in C.ALL_LANGS]
+    fields += [f"hash_{l}" for l in C.ALL_LANGS]
+    with csv_path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        for i, row in enumerate(rows):
+            d = {k: "" for k in fields}
+            d["notebook"] = "nb.ipynb"
+            if row is None:  # row malformée (cell_id vide) -> doit etre exclue du denominateur
+                d["cell_id"] = ""
+                w.writerow(d)
+                continue
+            d["cell_id"] = f"cell{i}"
+            d["text_fr"] = "source fr"  # pivot toujours rempli
+            for lang, txt in row.items():
+                d[f"text_{lang}"] = txt
+            w.writerow(d)
+
+
+def test_csv_fill_stats_all_zero(tmp_path):
+    """Table sans aucune traduction : pivot 100%, toutes cibles 0%."""
+    csv_path = tmp_path / "fill.csv"
+    _write_fill_csv(csv_path, [{}, {}])  # 2 rows, fr seulement
+    stats = C.csv_fill_stats(csv_path)
+    assert stats["fr"] == {"filled": 2, "total": 2}
+    for lang in C.TARGET_LANGS:
+        assert stats[lang] == {"filled": 0, "total": 2}, f"{lang} should be 0/2"
+
+
+def test_csv_fill_stats_fully_translated(tmp_path):
+    """Table 100% traduite sur 2 cibles : 2/2 pour ces cibles."""
+    csv_path = tmp_path / "fill.csv"
+    _write_fill_csv(csv_path, [{"en": "x", "es": "y"}, {"en": "x", "es": "y"}])
+    stats = C.csv_fill_stats(csv_path)
+    assert stats["en"] == {"filled": 2, "total": 2}
+    assert stats["es"] == {"filled": 2, "total": 2}
+    # les autres cibles restent à 0
+    assert stats["zh"] == {"filled": 0, "total": 2}
+
+
+def test_csv_fill_stats_partial(tmp_path):
+    """1 traduction en sur 2 rows -> 1/2 (le denominateur se voit)."""
+    csv_path = tmp_path / "fill.csv"
+    _write_fill_csv(csv_path, [{"en": "x"}, {}])
+    stats = C.csv_fill_stats(csv_path)
+    assert stats["en"] == {"filled": 1, "total": 2}
+
+
+def test_csv_fill_stats_malformed_rows_excluded(tmp_path):
+    """Une row malformée (cell_id vide) n'entre pas dans le dénominateur.
+
+    Discipline #6949 : le dénominateur = cellules bien formées que le CSV
+    référence. Une row cassée ne gonfle pas artificiellement le total.
+    """
+    csv_path = tmp_path / "fill.csv"
+    _write_fill_csv(csv_path, [{}, None, {}])  # 2 valides + 1 malformée
+    stats = C.csv_fill_stats(csv_path)
+    assert stats["fr"]["total"] == 2  # pas 3
+
+
+def test_format_fill_line_zero_suffix(tmp_path):
+    """Toutes cibles à 0% -> suffixe 'AUCUNE traduction déposée'."""
+    stats = {lang: {"filled": 0, "total": 5} for lang in C.ALL_LANGS}
+    stats["fr"] = {"filled": 5, "total": 5}
+    line = C._format_fill_line(stats)
+    assert "AUCUNE traduction déposée" in line
+    assert "en=0.0%" in line
+    assert "5 cellules" in line
+
+
+def test_format_fill_line_no_suffix_when_translated():
+    """Au moins une cible > 0% -> pas de suffixe, pct réelle affichée."""
+    stats = {lang: {"filled": 0, "total": 2} for lang in C.ALL_LANGS}
+    stats["fr"] = {"filled": 2, "total": 2}
+    stats["en"] = {"filled": 1, "total": 2}
+    line = C._format_fill_line(stats)
+    assert "AUCUNE" not in line
+    assert "en=50.0%" in line

--- a/scripts/translation/check_translation_sync.py
+++ b/scripts/translation/check_translation_sync.py
@@ -269,6 +269,61 @@ def check_csv(csv_path: Path, repo_root: Path) -> list[dict]:
     return anomalies
 
 
+def csv_fill_stats(csv_path: Path) -> dict[str, dict[str, int]]:
+    """Taux de remplissage par langue cible d'un CSV de synchro (#6949 point 1).
+
+    Rend visible le signal honnête que le compte de drift seul masque : un
+    ``SRC_DRIFT=0`` sur une table où ``text_en..text_pt`` sont vides se lit à
+    tort comme « à jour », alors qu'aucune traduction n'a été déposée (discipline
+    #6949 : un compteur nu se périmé ; un compteur avec son dénominateur se
+    contredit tout seul).
+
+    Compte, pour chaque langue cible (``TARGET_LANGS`` + le pivot ``fr``), les
+    cellules où ``text_<lang>`` est non-vide, sur le dénominateur des lignes
+    bien formées (``notebook`` + ``cell_id`` renseignés). Lecture CSV seule,
+    aucun chargement de notebook (I/O minime) — les ``ORPHAN_ROW`` rares
+    restent dans le dénominateur (signal honnête : « sur les N cellules que ce
+    CSV référence, X% sont traduites »).
+
+    Retourne ``{lang: {"filled": int, "total": int}}`` (total = dénominateur
+    commun, identique pour toutes les langues).
+    """
+    stats: dict[str, dict[str, int]] = {}
+    total = 0
+    filled: dict[str, int] = {lang: 0 for lang in ALL_LANGS}
+    with csv_path.open(encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            if not row.get("notebook") or not row.get("cell_id"):
+                continue
+            total += 1
+            for lang in ALL_LANGS:
+                if row.get(f"text_{lang}", "").strip():
+                    filled[lang] += 1
+    for lang in ALL_LANGS:
+        stats[lang] = {"filled": filled[lang], "total": total}
+    return stats
+
+
+def _format_fill_line(stats: dict[str, dict[str, int]]) -> str:
+    """Ligne lisible stderr : 'en=0.0% es=0.0% ... — AUCUNE traduction déposée'.
+
+    N'inclut que les langues cibles (le pivot ``fr`` est à 100% par construction,
+    l'afficher n'apporte rien). Le suffixe ``AUCUNE traduction déposée`` est
+    ajouté quand toutes les cibles sont à 0% — il rend explicite que le compte de
+    drift est non-informatif sur une table vide.
+    """
+    total = next(iter(stats.values()))["total"] if stats else 0
+    parts = []
+    for lang in TARGET_LANGS:
+        s = stats.get(lang, {"filled": 0, "total": 0})
+        pct = (100.0 * s["filled"] / s["total"]) if s["total"] else 0.0
+        parts.append(f"{lang}={pct:.1f}%")
+    line = f"REMPLISSAGE TRADUCTION ({total} cellules, {len(TARGET_LANGS)} langues cibles) : " + " ".join(parts)
+    if total and all(stats[lang]["filled"] == 0 for lang in TARGET_LANGS):
+        line += " — AUCUNE traduction déposée (le compte de drift est non-informatif tant que 0%)"
+    return line
+
+
 def iter_csvs(target: Path) -> list[Path]:
     if target.is_file():
         return [target]
@@ -302,16 +357,51 @@ def main() -> int:
         return 0
 
     all_anomalies: list[dict] = []
+    fill_by_csv: dict[str, dict[str, dict[str, int]]] = {}
     for csv_path in csvs:
         all_anomalies.extend(check_csv(csv_path, repo_root))
+        fill_by_csv[str(csv_path)] = csv_fill_stats(csv_path)
+
+    # Agrégation du taux de remplissage (#6949 point 1) : somme des filled/total
+    # sur tous les CSV, pour un signal global honnête. Le pivot fr est à 100% par
+    # construction (c'est le notebook source) — on l'inclut dans le JSON pour
+    # auditabilité mais on ne l'affiche pas (cf ``_format_fill_line``).
+    global_fill: dict[str, dict[str, int]] = {
+        lang: {"filled": 0, "total": 0} for lang in ALL_LANGS
+    }
+    for stats in fill_by_csv.values():
+        for lang in ALL_LANGS:
+            global_fill[lang]["filled"] += stats[lang]["filled"]
+            global_fill[lang]["total"] += stats[lang]["total"]
+
+    def _with_pct(stats: dict[str, dict[str, int]]) -> dict[str, dict[str, object]]:
+        out: dict[str, dict[str, object]] = {}
+        for lang in ALL_LANGS:
+            s = stats.get(lang, {"filled": 0, "total": 0})
+            pct = (100.0 * s["filled"] / s["total"]) if s["total"] else 0.0
+            out[lang] = {"filled": s["filled"], "total": s["total"], "pct": round(pct, 1)}
+        return out
+
+    fill_report = {
+        "global": _with_pct(global_fill),
+        "by_csv": {path: _with_pct(stats) for path, stats in fill_by_csv.items()},
+    }
 
     # Rapport lisible (stderr) + JSON (stdout, consommable CI).
     report = {
         "csvs_checked": len(csvs),
         "anomalies": all_anomalies,
         "anomaly_count": len(all_anomalies),
+        "fill_rate": fill_report,
     }
     print(json.dumps(report, ensure_ascii=False, indent=2))
+
+    # Signal honnête stderr : le taux de remplissage à côté du compte de drift,
+    # pour qu'un SRC_DRIFT=0 sur une table 0% traduite ne se lise plus comme
+    # « à jour » (discipline #6949 : compteur nu se périmé ; avec dénominateur,
+    # se contredit tout seul).
+    if global_fill[PIVOT_LANG]["total"]:
+        print(_format_fill_line(global_fill), file=sys.stderr)
 
     if not all_anomalies:
         print(f"OK : {len(csvs)} CSV vérifié(s), 0 drift.", file=sys.stderr)


### PR DESCRIPTION
## Summary

Implante le **point 1** de #6949 : rendre le signal de drift honnete en exposant le **taux de remplissage par langue** a cote du compte de drift, pour qu'un \`SRC_DRIFT=0\` sur une table 0% traduite ne se lise plus comme « a jour ».

**Probleme** (discipline ai-01 c.31) : un compteur nu se perime ; un compteur avec son denominateur se contredit tout seul. Sur le fleet actuel, \`check_translation_sync.py\` remonte 5873 anomalies (5701 \`SRC_DRIFT\` + 172 \`ORPHAN_ROW\`) sur 33 CSV — mais aucune traduction n'a ete deposee (0% sur les 7 langues cibles). Sans le taux de remplissage, « 5873 drifts » se lit comme un probleme urgent ; avec, on voit que ces drifts portent sur une table vide : il n'y a rien a retraduire car rien n'a ete depose.

## Changes

- \`scripts/translation/check_translation_sync.py\` (+90) :
  - \`csv_fill_stats(csv_path)\` : compte, par langue (pivot fr + 7 cibles), les \`text_<lang>\` non-vides sur le denominateur des rows bien formees (\`notebook\` + \`cell_id\` renseignes).
  - \`_format_fill_line(stats)\` : ligne stderr lisible \`en=0.0% es=0.0% ... pt=0.0%\` + suffixe explicite « AUCUNE traduction deposee (le compte de drift est non-informatif tant que 0%) » quand toutes les cibles sont a 0%.
  - \`main()\` : agregation global (somme filled/total sur tous les CSV) + champ additif \`fill_rate\` (global + par CSV, avec \`pct\`) dans le report JSON. CI-safe : la CI \`translation-drift.yml\` ne lit que \`anomaly_count\`, inchange.

- \`scripts/tests/test_check_translation_sync.py\` (+100) : 6 nouveaux tests (denominateur rows bien formees, pivot 100%, table 0%, table 100%, partial 1/2, suffixe format-line). Suite **24/24 PASS**, 0 regression sur WRONG_SCRIPT (c.734).

## Validation

\`\`\`
$ python scripts/translation/check_translation_sync.py translations --check
REMPLISSAGE TRADUCTION (24470 cellules, 7 langues cibles) : en=0.0% es=0.0% ar=0.0% fa=0.0% zh=0.0% ru=0.0% pt=0.0% — AUCUNE traduction déposée (le compte de drift est non-informatif tant que 0%)
DRIFT DETECTE (5873 anomalie(s) sur 33 CSV) : SRC_DRIFT=5701, ORPHAN_ROW=172

$ python -m pytest scripts/tests/test_check_translation_sync.py -q
24 passed in 0.23s
\`\`\`

Report JSON (additif, CI-safe) :
\`\`\`json
"fill_rate": {
  "global": {"fr": {"filled":24469,"total":24470,"pct":100.0}, "en": {"filled":0,"total":24470,"pct":0.0}},
  "by_csv": {"translations/casestudies/casestudies.csv": {"fr": {...}, "en": {...}}}
}
\`\`\`

## Scope

- **Point 1 uniquement** : signal honnete (detection + affichage). Aucune modification des CSV, aucune traduction deposee, aucune activation de moteur.
- **Activation T3 hors scope** : le moteur (\`translate_csv.py\`) reste \`ENABLED=False\`. L'activation (~171k appels API, 24470 cellules x 7 langues) est irreversibile (argent depense avant relecture) et exige un GO user explicite — porte par ai-01, defaut = non. Je n'active rien (cf ai-01 STOP-net c.31).

See #6949

Co-Authored-By: Claude-Code <noreply@anthropic.com>