### PR TITLE
fix(translation,#6949): floor fill pct — no false 100.0% at 24469/24470

### DIFF
--- a/scripts/tests/test_check_translation_sync.py
+++ b/scripts/tests/test_check_translation_sync.py
@@ -262,3 +262,46 @@ def test_format_fill_line_no_suffix_when_translated():
     line = C._format_fill_line(stats)
     assert "AUCUNE" not in line
     assert "en=50.0%" in line
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _fill_pct — floor anti-arrondi (ride ai-01 c.33 : fr=100.0% pour 24469/24470)
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_fill_pct_floors_below_100_when_not_complete():
+    """24469/24470 ne doit PAS s'afficher 100.0% (ride #6949, ai-01 c.33).
+
+    ``round(99.9959, 1)`` -> ``100.0`` : dans un outil dont la raison d'être
+    est qu'un compteur n'affirme plus faussement la complétude, l'arrondi
+    refait le défaut un ordre plus bas. Le floor garde le pct sous le seuil.
+    """
+    assert C._fill_pct(24469, 24470) == 99.9
+    assert C._fill_pct(24469, 24470) != 100.0
+
+
+def test_fill_pct_100_only_when_complete():
+    """100.0 uniquement si filled == total exactement."""
+    assert C._fill_pct(24470, 24470) == 100.0
+    assert C._fill_pct(2, 2) == 100.0
+    # un de moins -> déjà sous le seuil
+    assert C._fill_pct(1, 2) == 50.0
+
+
+def test_fill_pct_zero_when_no_total():
+    """total=0 (table vide) -> 0.0, pas de ZeroDivisionError."""
+    assert C._fill_pct(0, 0) == 0.0
+
+
+def test_format_fill_line_floors_incomplete_target_below_100():
+    """Une cible à 24469/24470 s'affiche ``99.9%``, jamais ``100.0%``.
+
+    Exerce le path stderr ``_format_fill_line`` (qui n'affiche que les cibles,
+    pas le pivot fr) avec le floor anti-arrondi. Reproduit la ride #6949
+    signalée par ai-01 c.33 au niveau de la ligne lisible.
+    """
+    stats = {lang: {"filled": 0, "total": 24470} for lang in C.ALL_LANGS}
+    stats["fr"] = {"filled": 24470, "total": 24470}
+    stats["en"] = {"filled": 24469, "total": 24470}
+    line = C._format_fill_line(stats)
+    assert "en=99.9%" in line
+    assert "en=100.0%" not in line

--- a/scripts/translation/check_translation_sync.py
+++ b/scripts/translation/check_translation_sync.py
@@ -47,6 +47,7 @@ import argparse
 import csv
 import hashlib
 import json
+import math
 import sys
 from pathlib import Path
 
@@ -304,6 +305,22 @@ def csv_fill_stats(csv_path: Path) -> dict[str, dict[str, int]]:
     return stats
 
 
+def _fill_pct(filled: int, total: int) -> float:
+    """Pourcentage floored à 1 décimale — jamais arrondi vers le haut.
+
+    Discipline #6949 (ai-01 c.33) : un compteur ne doit pas affirmer faussement
+    la complétude. ``round(99.996, 1)`` vaut ``100.0`` pour ``24469/24470``, ce
+    qui réintroduit, un ordre de grandeur plus bas, le défaut que cet outil
+    dénonce (un ``SRC_DRIFT=0`` lu comme « à jour »). On floor donc : ``100.0``
+    n'apparaît que si ``filled == total`` exactement ; sinon le pct reste sous
+    le seuil de complétude. ``filled``/``total`` bruts restent disponibles à
+    côté du pct pour la précision exacte.
+    """
+    if not total:
+        return 0.0
+    return math.floor((100.0 * filled / total) * 10) / 10
+
+
 def _format_fill_line(stats: dict[str, dict[str, int]]) -> str:
     """Ligne lisible stderr : 'en=0.0% es=0.0% ... — AUCUNE traduction déposée'.
 
@@ -316,7 +333,7 @@ def _format_fill_line(stats: dict[str, dict[str, int]]) -> str:
     parts = []
     for lang in TARGET_LANGS:
         s = stats.get(lang, {"filled": 0, "total": 0})
-        pct = (100.0 * s["filled"] / s["total"]) if s["total"] else 0.0
+        pct = _fill_pct(s["filled"], s["total"])
         parts.append(f"{lang}={pct:.1f}%")
     line = f"REMPLISSAGE TRADUCTION ({total} cellules, {len(TARGET_LANGS)} langues cibles) : " + " ".join(parts)
     if total and all(stats[lang]["filled"] == 0 for lang in TARGET_LANGS):
@@ -378,8 +395,11 @@ def main() -> int:
         out: dict[str, dict[str, object]] = {}
         for lang in ALL_LANGS:
             s = stats.get(lang, {"filled": 0, "total": 0})
-            pct = (100.0 * s["filled"] / s["total"]) if s["total"] else 0.0
-            out[lang] = {"filled": s["filled"], "total": s["total"], "pct": round(pct, 1)}
+            out[lang] = {
+                "filled": s["filled"],
+                "total": s["total"],
+                "pct": _fill_pct(s["filled"], s["total"]),
+            }
         return out
 
     fill_report = {


### PR DESCRIPTION
Grain: LIGHT/tooling (follow-up #8690, sous plafond G-VAR-2 — aucun LIGHT ce lane-jour sur CoursIA).

## Contexte — ride signalée par ai-01 c.33 sur #8690

> `fr` s'affiche `100.0%` pour 24469/24470 — dans un outil dont la raison d'être est qu'un compteur n'affirme plus fausement la complétude, l'arrondi refait le défaut un ordre plus bas.

#8690 a ajouté le signal de taux de remplissage (`pct = round(filled/total*100, 1)`). Pour `fr` pivot : `round(24469/24470*100, 1) = round(99.996, 1) = 100.0`. Le champ JSON `fill_rate.global.fr.pct` valait donc `100.0` alors qu'une cellule source manquait — exactement l'assertion fausse de complétude que l'outil dénonce.

## Fix — floor, jamais arrondi vers le haut

Nouveau helper `_fill_pct(filled, total)` : `math.floor(pct * 10) / 10`. Propriété : `100.0` n'apparaît que si `filled == total` exactement ; sinon le pct reste sous le seuil (99.996 → 99.9). Les bruts `filled`/`total` restent disponibles à côté du pct pour la précision exacte.

Utilisé aux 2 sites : `_format_fill_line` (stderr) et `_with_pct` (champ JSON `fill_rate`).

## Vérification G.1 (post-fix, firsthand sur `translations/`)

```
fr: filled=24469 total=24470 pct=99.9   (était 100.0 avant le fix)
REMPLISSAGE TRADUCTION (24470 cellules, 7 langues cibles) : en=0.0% ... pt=0.0% — AUCUNE traduction déposée...
```
- 7 cibles toujours 0.0% + suffixe AUCUNE (inchangé)
- `anomaly_count` inchangé → CI-safe (`translation-drift.yml` ne lit que `anomaly_count`)
- `fr=100.0` désormais réservé au cas réellement complet

## Tests — 28/28 PASS (24 existants + 4 nouveaux)

- `test_fill_pct_floors_below_100_when_not_complete` — 24469/24470 → 99.9 ≠ 100.0 (reproduction exacte de la ride)
- `test_fill_pct_100_only_when_complete` — 100.0 uniquement si filled==total
- `test_fill_pct_zero_when_no_total` — total=0 → 0.0, pas de ZeroDivisionError
- `test_format_fill_line_floors_incomplete_target_below_100` — path stderr, cible incomplète → `en=99.9%` pas `en=100.0%`

Aucune regression des 24 tests existants (`en=50.0%`, `en=0.0%`, suffixes AUCUNE inchangés).

See #6949 (point 1 follow-up — l'activation T3 reste gated GO user, je n'active rien).