### PR TITLE
feat(cost,#8056): forward-migrate metadata.cost on Search Part1-Foundations tranche (10 NB)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb
@@ -805,6 +805,23 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb
@@ -3659,6 +3659,23 @@
    "parameters": {},
    "start_time": "2026-05-23T01:53:53.589996",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch-Csharp.ipynb
@@ -1127,6 +1127,23 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb
@@ -2125,6 +2125,23 @@
    "parameters": {},
    "start_time": "2026-05-23T01:51:56.206661",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb
@@ -1331,6 +1331,23 @@
   },
   "language_info": {
    "name": "C#"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
@@ -2145,6 +2145,23 @@
    "parameters": {},
    "start_time": "2026-06-08T22:39:11.966415+00:00",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb
@@ -841,6 +841,23 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb
@@ -3345,6 +3345,23 @@
    "parameters": {},
    "start_time": "2026-06-02T23:26:35.394174+00:00",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb
@@ -1198,6 +1198,23 @@
    "parameters": {},
    "start_time": "2026-07-06T00:01:35.032719",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb
@@ -2661,6 +2661,23 @@
    "parameters": {},
    "start_time": "2026-07-12T14:13:11.610053+00:00",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/data (flotte cost-metadata #8056, famille Search — rotation depuis Sudoku c.930-931).

## Livrable

Forward-migration du profil cpu-only canonique (#8056 c.888, `vram_tier: NONE`) sur la série Search Part1-Foundations fondamentale — 10 notebooks (5 twin-pairs .NET C# / Python) : GeneticAlgorithms, AdversarialSearch, MCTS-And-Beyond, DancingLinks, LinearProgramming.

Tous cpu-only algorithme pur (pas d'API/GPU/réseau) : recherche génétique, minimax/alpha-beta, MCTS, Dancing Links/Algorithm X, programmation linéaire.

## Repro honnête (verified firsthand)

- **Reproducibility HIGH sur toute la tranche**. Les deux algorithmes stochastiques (Genetic, MCTS) sont **seeded** (`random.seed(42)`, grep verifié dans le source) → sorties déterministes. Les 3 autres (Adversarial minimax, DancingLinks, LP) déterministes par construction.
- `validator: manual` — convention fleet Search (harmonisation c.931 ; CI ne peut papermiller .NET Interactive, et les notebooks Python voisins de Part1-Foundations utilisent déjà manual).
- Profil identique au voisin migré Part1-Foundations (`api_usd_est: 0.0, vram_tier: NONE, free_alternative: self`).

## Vérification G.1 (post-fix)

- **byte-stable forward migration** : `json.dumps(indent=1)` round-trip byte-identique vérifié sur les 10 AVANT insertion, trailing-newline préservé par fichier → insertion JSON clean, pas de chirurgie raw-text.
- `git diff --stat` : 10 fichiers, **+170/-0**, 17 lignes/notebook (le bloc cost), **0 changement de cellule source** (grep `+"source"` = 0).
- `check_cost_metadata.py` **PASS 10/10** (0 findings).

## Contexte fleet

Scan fleet autoritatif : 613/946 notebooks unmigrés. Search 109/117 unmigrés avant cette tranche → 99 restants (CSP, Hybrid, MGS, et autres sous-séries Search). Cette PR pose le profil Search Part1-Foundations aux côtés de Sudoku (c.930-931, 17 NB) et ML.NET (déjà complet).

See #8056 (partial — une tranche de famille de la flotte).

Co-Authored-By: Claude-Code <noreply@anthropic.com>