### PR TITLE
fix(twin-parity,#8057): rebaseline 5 paires Search/Part1-Foundations post-#8697

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/search-5-geneticalgorithms.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-5-geneticalgorithms.yaml
@@ -4,11 +4,12 @@
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-25"
-    by: po-2026
-    python_sha: 8b6074cc1daf3b00c21f2456b489215b4129a254
-    csharp_sha: 7084e6b3164abadce004bd0937451a134a7b9294
+    date: "2026-07-28"
+    by: myia-ai-01:CoursIA
+    python_sha: beac5a59dd303901482179a02235e71c3f029b44
+    csharp_sha: d89e8b4376a85293402065fb2c121477f41b5632
   known_differences:
+    - "Rebaseline c.34 (ai-01) : #8697 a insere le bloc `metadata.cost` (#8056) a l'identique sur les DEUX jumeaux — les deux blob SHA ont bouge, la parite semantique est inchangee. Attestation de parite, pas reparation."
     - "Socle pedagogique commun : algorithmes genetiques (AG) — composants d'un AG (population, fonction de fitness, selection (roulette/tournoi), crossover, mutation), schemas d'evolution, probleme OneMax. Les deux twins implementent le cycle evolutionnaire from-scratch (population initiale → evaluation fitness → selection → croisement → mutation → nouvelle generation)."
     - "Idiomes framework : Python = demos riches multi-frameworks (76 cellules) : AG from-scratch (OneMax) + framework **DEAP** + framework **PyGAD** (optimisation continue) + concepts avances + comparaison quantitative GA-vs-solveurs-exacts. C# = pur System.* (System / System.Collections.Generic / System.Linq), 0 NuGet, 5 using, 25 cellules (AG from-scratch compact, presentation tabulaire)."
     - "Asymetrie pedagogique : Python couvre 3 frameworks (from-scratch + DEAP + PyGAD) + comparaison vs solveurs exacts (large spectre d'outils) ; le C# demontre le cycle AG canonique en BCL pure sans dependance externe. Meme socle theorique (algorithmes evolutionnaires, Holland 1975 / Goldberg 1989), leviers de demonstration differents."

--- a/scripts/notebook_tools/twin_pairs.d/search-6-adversarialsearch.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-6-adversarialsearch.yaml
@@ -4,11 +4,12 @@
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-27"
-    by: po-2024
-    python_sha: 8608b6f46014d1b18984265609f1b1e3e741eb39
-    csharp_sha: 0d5371ae6b7236a387e89ed008909d0953212da4
+    date: "2026-07-28"
+    by: myia-ai-01:CoursIA
+    python_sha: d26a0b6e8fcee510aea28342d2ac3ac5b81a7f54
+    csharp_sha: 3975fb9fe6db1730e666e05c423721a466dac9c3
   known_differences:
+    - "Rebaseline c.34 (ai-01) : #8697 a insere le bloc `metadata.cost` (#8056) a l'identique sur les DEUX jumeaux — les deux blob SHA ont bouge, la parite semantique est inchangee. Attestation de parite, pas reparation."
     - "Socle commun : jeux a somme nulle a information parfaite (Tic-Tac-Toe/Morpion), minimax, elagage alpha-beta, iterative deepening, tables de transposition."
     - "Asymetrie de couverture : le jumeau Python (44 cellules, 16 code) inclut une section benchmark comparatif detaillee + visualisation matplotlib du Tic-Tac-Toe ; le jumeau C# (23 cellules, 10 code) est plus court, sortie textuelle des traces (pas de matplotlib)."
     - "Idiomes framework : Python = numpy/matplotlib pour les benchmarks et la visualisation ; C# = implementation from-scratch (System.Collections.Generic, pas de NuGet graphique)."

--- a/scripts/notebook_tools/twin_pairs.d/search-7-mcts-and-beyond.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-7-mcts-and-beyond.yaml
@@ -4,11 +4,12 @@
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-27"
-    by: po-2024
-    python_sha: 582680ddc89dc6fb61e49ee717868b30cb4b413f
-    csharp_sha: 01d1bdcd8d02769a4f7ad3d3fd1fe6f71bf698a3
+    date: "2026-07-28"
+    by: myia-ai-01:CoursIA
+    python_sha: e1ee9f5381d43f942f9fd20b6c83c59d49701c39
+    csharp_sha: dc96b031f94dbaddbe83fe54e522ebf5887769b1
   known_differences:
+    - "Rebaseline c.34 (ai-01) : #8697 a insere le bloc `metadata.cost` (#8056) a l'identique sur les DEUX jumeaux — les deux blob SHA ont bouge, la parite semantique est inchangee. Attestation de parite, pas reparation."
     - "Socle commun : limites de minimax, algorithme MCTS (selection/expansion/simulation/retropropagation), test sur Tic-Tac-Toe, comparaison MCTS vs minimax, framework OpenSpiel, AlphaGo/AlphaZero, extensions avancees. Structure des sections quasi-identique (le jumeau le plus proche cellule-a-cellule de la famille)."
     - "Idiomes RNG : Python = module `random` (PRNG Mersenne Twister) ; C# = `new Random()` (PRNG .NET). Les deux sont sedees mais les suites different -- les statistiques MCTS (taux de victoire) fluctuent d'un run a l'autre, parite conceptuelle pas bitwise."
     - "Visualisation : Python = matplotlib pour les comparatifs MCTS vs minimax ; C# = traces textuels (le terme 'matplotlib' n'apparait qu'en prose de comparaison, pas en import)."

--- a/scripts/notebook_tools/twin_pairs.d/search-8-dancinglinks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-8-dancinglinks.yaml
@@ -4,11 +4,12 @@
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-27"
-    by: po-2024
-    python_sha: 9fe64f2e2bccf773fc0293f1ae3f82fe09cfb544
-    csharp_sha: b1a44f1710ef8dd954dfbe5f4cd5405295bc8598
+    date: "2026-07-28"
+    by: myia-ai-01:CoursIA
+    python_sha: 944805c717b29cfbd29c543418b14cf1ad81d5e3
+    csharp_sha: 29f89557a6fb3164dc2a341ed8e6a24e4051a5e4
   known_differences:
+    - "Rebaseline c.34 (ai-01) : #8697 a insere le bloc `metadata.cost` (#8056) a l'identique sur les DEUX jumeaux — les deux blob SHA ont bouge, la parite semantique est inchangee. Attestation de parite, pas reparation."
     - "Socle commun : probleme de couverture exacte, algorithme X de Knuth, structure de donnees Dancing Links (DLX), implementation DLX, application polyominos, comparaison de performances DLX vs backtracking."
     - "Asymetrie de couverture : le jumeau Python (60 cellules, 21 code) couvre 3 applications (Sudoku solver, Pavage de polyominos, Pentominoes) + visualisation matplotlib ; le jumeau C# (22 cellules, 10 code) couvre uniquement le pavage de polyominos (Sudoku et Pentominoes absents), pas de matplotlib."
     - "Implementation DLX : les deux cotes codent la structure de listes doublement chainees a la main (noeud avec L/R/U/D/C) -- c'est le coeur pedagogique, identique conceptuellement. Aucun solveur tiers."

--- a/scripts/notebook_tools/twin_pairs.d/search-9-linearprogramming.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-9-linearprogramming.yaml
@@ -5,10 +5,11 @@
   parity_level: semantic
   last_audit:
     date: "2026-07-28"
-    by: po-2024:CoursIA-2
-    python_sha: 290e11ed4aae0abf7fad8e60a69f5275ac2d586c
-    csharp_sha: 7b07dc878a4ab996e0e318ee93140aca3942ba6f
+    by: myia-ai-01:CoursIA
+    python_sha: 8f12ab7133fbc93d321fef24ac340f97fe647402
+    csharp_sha: 3fcc002679a6df8a3b5babe1b611a7846e15efa2
   known_differences:
+    - "Rebaseline c.34 (ai-01) : #8697 a insere le bloc `metadata.cost` (#8056) a l'identique sur les DEUX jumeaux — les deux blob SHA ont bouge, la parite semantique est inchangee. Attestation de parite, pas reparation."
     - "Solveur SOTA distinct : Python = PuLP (interface declarative, solveur CBC par defaut) ; C# = Google.OrTools (GLOP simplexe pour PL continue, CBC pour PLNE). Les deux invoquent un vrai solveur industriel -- parite SOTA, pas reimplementation."
     - "Asymetrie de couverture : le jumeau Python (47 cellules, 18 code) couvre §1-8 (intro, PuLP, formulation, Transport §4, sensibilite/dualite §5, PLNE §6, exemple guide multi-depots §7, resume §8) ; le jumeau C# (28 cellules, 11 code) couvre §1-7 (intro, OrTools production, diet formulation, sensibilite/dualite §4, PLNE sac a dos §5, Transport §6 ajoute par #8640/c.909, multi-depots §7 + variante desequilibree ajoutes par c.913 ; enonces complets des exercices melange-industriel et set-cover ajoutes par c.930 (#8676), alignant la parite pedagogique des exercices avec le jumeau Python). Divergence positive : le Python laisse le multi-depots en exercice (stub PuLP) ; le C# en donne une solution OrTools travaillee (290 EUR equilibre + 240 EUR cas desequilibre avec depot fictif)."
     - "Probleme de Transport : present des deux cotes (Python §4, C# §6) avec les MEMES donnees (3 usines x 4 magasins, equilibre 450=450, cout optimal 760 EUR) -- verifie firsthand c.909. GLOP renvoie un optimum degenere 5 routes vs 6 routes PuLP/CBC (memes 760 EUR, optima alternatifs, documente dans le notebook C#)."


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-ai-01:CoursIA — prev: (coord, pas de grain PR ce cycle)

Repare une regression que **j'ai introduite moi-meme** en mergeant #8697 par-dessus un gate rouge.

## Ce qui s'est passe

#8697 (forward-migration `metadata.cost`, #8056) a insere un bloc de 17 lignes a l'identique sur les **deux** jumeaux de 5 paires `Search/Part1-Foundations`. Le registre twin-parity stocke le **git blob SHA de chaque jumeau** : toute edition le deplace, **y compris metadata-only**. Les 10 SHA ont bouge, les 5 paires sont tombees en DRIFT.

Le gate `Twin parity audit (#8057)` **etait rouge sur #8697** et l'a dit correctement. Je l'ai rate : j'ai liste le rollup de checks tronque a 12 lignes, et le `FAILURE` triait alphabetiquement **sous** les 30 `SUCCESS`. J'ai lu « 30 SUCCESS » et merge.

C'est la meme classe de defaut que je poursuis dans quatre autres lanes ce cycle — une verification qui ne peut pas rendre le verdict « mauvais ». Sauf qu'ici le gate CI etait sain : **c'est ma lecture du gate qui etait la porte aveugle.** Un `head -12` sur une sortie triee ne peut pas montrer un echec qui trie en fin de liste. Verification corrigee : je liste desormais les checks **non-SUCCESS explicitement** (`select(...) | test("FAIL|ERROR")`) au lieu de me fier a une tete de liste.

## Ce que fait cette PR

Rebaseline des 5 paires. C'est une **attestation** de parite, pas une reparation — la distinction est celle que le log CI enonce lui-meme : *« Tu rebaselines pour ATTESTER la parite, pas pour la reparer. »*

Re-audit firsthand avant d'attester : le bloc `cost` est identique des deux cotes (10 occurrences de chacune des 17 cles dans le diff de #8697), donc la parite **semantique** n'a jamais bouge — seuls les SHA l'ont fait. Attester est ici legitime ; ca ne l'aurait pas ete si un seul cote avait ete migre.

| Paire | Python SHA | C# SHA |
|---|---|---|
| Search-5 GeneticAlgorithms | `8b6074cc` -> `beac5a59` | `7084e6b3` -> `d89e8b43` |
| Search-6 AdversarialSearch | `8608b6f4` -> `d26a0b6e` | `0d5371ae` -> `3975fb9f` |
| Search-7 MCTS-And-Beyond | `582680dd` -> `e1ee9f53` | `01d1bdcd` -> `dc96b031` |
| Search-8 DancingLinks | rebaseline | rebaseline |
| Search-9 LinearProgramming | rebaseline | rebaseline |

**Ecriture chirurgicale (#8570)** : seules les lignes `last_audit` (date / by / python_sha / csharp_sha) changent. `known_differences` est preserve integralement, avec **une entree ajoutee en tete** expliquant l'edition, comme le demande le log CI.

## Verification

```
avant : Total : 136 paire(s) | OK=131 DRIFT=5 MISSING=0
apres : Total : 136 paire(s) | OK=136 DRIFT=0 MISSING=0
```

`git diff --stat` : 5 fichiers, registre uniquement, **aucun notebook touche**. `.vscode/settings.json` (sale avant ce cycle) volontairement **non stage**.

## Portee

Ne corrige **pas** #8699 (tranche Search/Part2-CSP, 17 NB / 9 paires), qui est ouverte et porte le meme gate rouge pour la meme raison. Cette PR-la se rebaseline elle-meme cote auteur — c'est du travail de la lane, pas du mien, et le splitter ici melangerait deux perimetres.

See #8057, See #8056
