### PR TITLE
fix(prover,#8698): regenerate legacy workspace-root fallback test (machine-independent, post-#4365)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -2889,32 +2889,42 @@ def test_candidates_list_prefers_workspace_relative_entry():
         )
 
 
-def test_legacy_fallback_still_works_when_no_workspace_root(monkeypatch):
-    """If _WORKSPACE_ROOT is None, the legacy drive-letter list still resolves.
+def test_legacy_fallback_still_works_when_no_workspace_root(monkeypatch, tmp_path):
+    """If _WORKSPACE_ROOT is None, the candidate list still resolves to the
+    first existing entry — the safety-net a harness copy dropped outside the
+    CoursIA layout (no MyIA.AI.Notebooks/ ancestor) relies on.
 
-    Defends the safety-net path: a harness copy dropped outside the
-    CoursIA layout (e.g. into a standalone dir without MyIA.AI.Notebooks/
-    ancestor) must keep working via the original candidates.
+    Regenerated post-#4365 (#8698): the lake is now ``game_theory_lean``
+    (CooperativeGames was absorbed, cf ``config.py`` _COOPERATIVE_GAMES_CANDIDATES
+    which now points at GameTheory/game_theory_lean). The prior form asserted
+    against hardcoded ``C:\\dev\\CoursIA\\...cooperative_games_lean`` paths that
+    (a) named an absorbed lake and (b) only existed on hosts with a stale
+    sibling checkout — so the test passed or failed depending on the operator's
+    machine, not on the resolver code. It now stands up its own layout under
+    ``tmp_path`` and proves the resolver skips a non-existent decoy.
     """
     import prover.config as cfg
-    from pathlib import Path
 
-    # Pretend no workspace root was found.
+    # Real candidate the fallback can resolve to, plus a decoy that must be
+    # skipped — proves "first EXISTING entry wins", not just "first entry".
+    real = tmp_path / "game_theory_lean"
+    real.mkdir()
+    decoy = tmp_path / "absent_lean"
+
+    # Pretend no workspace root was found (harness outside CoursIA layout).
     monkeypatch.setattr(cfg, "_WORKSPACE_ROOT", None)
-    # Remove the workspace-relative first entry from the candidate list so
-    # resolution falls back to the drive-letter list (mirrors what
-    # _workspace_root()==None would produce).
-    monkeypatch.setattr(cfg, "_COOPERATIVE_GAMES_CANDIDATES", [
-        Path(r"C:\dev\CoursIA\MyIA.AI.Notebooks\GameTheory\cooperative_games_lean"),
-        Path(r"D:\dev\CoursIA\MyIA.AI.Notebooks\GameTheory\cooperative_games_lean"),
-    ])
+    monkeypatch.setattr(cfg, "_COOPERATIVE_GAMES_CANDIDATES", [decoy, real])
+
     cfg.COOPERATIVE_GAMES_DIR = next(
         (p for p in cfg._COOPERATIVE_GAMES_CANDIDATES if p.exists()),
         cfg._COOPERATIVE_GAMES_CANDIDATES[0],
     )
-    # On this Windows host, C:\dev\CoursIA exists — the legacy path resolves.
+    assert cfg.COOPERATIVE_GAMES_DIR == real, (
+        "legacy fallback must skip absent candidates and resolve to the first "
+        "existing one"
+    )
     assert cfg.COOPERATIVE_GAMES_DIR.exists(), (
-        "legacy drive-letter fallback must still resolve to a real path"
+        "legacy fallback must resolve to a real path"
     )
 
 


### PR DESCRIPTION
# fix(prover,#8698): regenerate legacy workspace-root fallback test (machine-independent, post-#4365)

Grain: MED/test — lane myia-po-2024:CoursIA-2 — prev: DEEP/qc (#8700)

`test_legacy_fallback_still_works_when_no_workspace_root` was machine-dependent: it asserted against hardcoded `C:\dev\CoursIA\...cooperative_games_lean` paths that (a) name a lake absorbed into `game_theory_lean/` by #4365, and (b) only exist on hosts carrying a stale sibling `C:\dev\CoursIA` checkout. It **passed on such hosts and failed on clean ones** (ai-01 reported the failure, #8698) — testing the operator's filesystem, not the resolver code. Regenerated to stand up its own layout under `tmp_path` so it tests the code on every machine.

## Why this is not a trivial delete (#8698 acceptance)

The acceptance explicitly forbids suppressing the failure: the fallback path ("no `workspace_root` → resolve via the drive-letter candidate list") is a real safety-net used by BG-iter runs, and the test is the only thing pinning it. Deleting it would trade a false-red for a real coverage hole — the same "porte qui ne peut plus rougir" class measured four times on 28/07 (#8693, #8681, #8607, #6790). The fix reconstitutes the coverage instead.

## The fix

- `tmp_path` fixture replaces the hardcoded `C:\dev\CoursIA\...` paths → no machine dependency.
- A **decoy** (`absent_lean`, non-existent) precedes the real candidate, so the assertion proves *"first **existing** entry wins"*, not just "first entry" — strictly stronger than the original.
- The real candidate is named `game_theory_lean` (the post-#4365 target, matching `config.py:111-125` where `_COOPERATIVE_GAMES_CANDIDATES` now points at `GameTheory/game_theory_lean`), documenting the absorbed-lake migration.
- Added an `== real` resolution-correctness assertion on top of the existing `.exists()` one.

## Verification (run from `agent_tests/`)

```
$ python -m pytest tests/test_prover_guards.py::test_legacy_fallback_still_works_when_no_workspace_root -q
1 passed in 1.14s

$ python -m pytest tests/test_prover_guards.py -q      # full guards file
191 passed in 1.98s

$ python -m pytest tests/ -q                            # full prover test suite
601 passed in 3.75s
```

No new failures. On this host the baseline was already green (it carries the stale `C:\dev\CoursIA\...cooperative_games_lean` checkout the old test hardcoded); on a clean host the test was red and is now green — the failure count drops by 1 there, 0 regressions either way.

## Scope

1 file, `MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py` (+27/−17, one test function rewritten). No production code touched (`config.py` is unchanged — the fix is entirely in the test).

See #8698
