### PR TITLE
docs(#8081): corrige 4 verdicts d'attribution perimes dans mbml-source-attribution

### DIFF
--- a/docs/reference/mbml-source-attribution.md
+++ b/docs/reference/mbml-source-attribution.md
@@ -16,6 +16,8 @@ Les **verdicts de cycle** d'audit et les **décisions de suivi** ne vivent plus 
 
 > **Note** : comptages cellules au format `total (md + code)`. La sous-traitance initiale avait inversé l'ordre (md/code) ; corrigé par vérification G.1 firsthand.
 
+> **Ce qui est pérenne et ce qui ne l'est pas.** La colonne de droite mélange deux natures. La **correspondance notebook ↔ source canonique** (quel chapitre MBML, quel papier fondateur) est durable : c'est l'objet de cette référence. En revanche, toute formulation d'**état d'attribution** — « cite », « sans citation inline », « hors-cité », « non attribué » — est un **instantané daté du c.803 (2026-07-23)** et se périme dès qu'un backfill ajoute la citation. Ne jamais lire ces mentions comme l'état courant : l'état frais se mesure sur le notebook, et le suivi vit dans [#8081](https://github.com/jsboige/CoursIA/issues/8081). Trois lignes ont déjà été corrigées à ce titre (voir ci-dessous, Infer-7 / Infer-13 / PyMC-7).
+
 | Notebook | Cells | Source / attribution (snippet + cell) |
 |----------|------:|---------------------------------------|
 | Infer/Infer-1-Setup.ipynb | 41 (29+12) | « [Model-Based Machine Learning Book](https://mbmlbook.com/) » @ cell 37 (footer Pour aller plus loin) |
@@ -24,13 +26,13 @@ Les **verdicts de cycle** d'audit et les **décisions de suivi** ne vivent plus 
 | Infer/Infer-4-Bayesian-Networks.ipynb | 66 (46+20) | WetGrass/Sprinkler (144 hits) ; source canonique citée = « Lauritzen & Spiegelhalter (1988) et Jensen, Lauritzen & Olesen (1990) » (Springer) — couvre le MBML WetGrass Chap.5 avec pedigree académique différent |
 | Infer/Infer-5-Causal-Inference.ipynb | 38 (23+15) | do-calculus = MBML Chap.7 ; notebook cite « Pearl, J. (2000) » sans mention MBML — sous-portée, à clarifier |
 | Infer/Infer-6-Debugging.ipynb | 50 (33+17) | Debugging pur EP/VMP/Gibbs — pas de concept MBML à attribuer |
-| **Infer/Infer-7-Skills-IRT.ipynb** | 74 (51+23) | IRT exécuté sans mention Rasch/Birnbaum/Lord/Junker-Sijtsma ; README L251 « StudentSkills/IRT (Ch2) » promet MBML Ch.2 mais notebook muet. **PIRE CAS** |
+| **Infer/Infer-7-Skills-IRT.ipynb** | 74 (51+23) | IRT / DINA — source canonique = MBML Ch.2 (StudentSkills) + Rasch (1960), Birnbaum (1968), Lord (1980), Junker & Sijtsma (2001). Attribution **présente** aux cellules 8-9 (backfill [#8530](https://github.com/jsboige/CoursIA/pull/8530), `16376a901`) — le verdict « notebook muet / PIRE CAS » du c.803 est périmé |
 | **Infer/Infer-8-TrueSkill.ipynb** | 59 (40+19) | Pilote vérifié end-to-end : structure MBML Ch.3 fidèle (model 2 joueurs, draw via ConstrainBetween, online learning, teams, free-for-all, Elo bayésien, 3 exercices) MAIS **pas de formules V(t)/W(t)/τ² reproduites** (délégué à la machinerie EP Infer.NET). Cell 51 « Pour aller plus loin : Herbrich et al., 2006 » (référence 2006, pas 2007 NeurIPS — léger typo) |
 | Infer/Infer-9-Classification.ipynb | 55 (37+18) | BPM (Herbrich, MBML Chap.4) exécuté sans citation explicite — source = Herbrich 2001 thesis mais MBML non nommé |
 | Infer/Infer-10-Model-Selection.ipynb | 58 (40+18) | Bayes Factors / ARD — MBML Chap.11 (Model Comparison) hors-cité |
 | Infer/Infer-11-Topic-Models.ipynb | 55 (38+17) | LDA — « Source primaire : Blei, Ng & Jordan (2003) » — couvre MBML Chap.10 mais en citant la source primaire canonique |
 | Infer/Infer-12-Modeles-Hierarchiques.ipynb | 18 (10+8) | Pooling partiel / shrinkage — modèle générique, pas de MBML spécifique |
-| **Infer/Infer-13-Crowdsourcing.ipynb** | 50 (36+14) | Worker models Honest/Biased/Community ; aucun cite Raykar/Karger/Zhou/MBML Chap.9c ; README L257 « Crowdsourcing (Ch7) » silencieux côté notebook |
+| **Infer/Infer-13-Crowdsourcing.ipynb** | 50 (36+14) | Worker models Honest/Biased/Community — sources canoniques = Dawid & Skene (1979), Raykar (2010), Karger (2011) + MBML Ch.7. Citations **présentes** (backfill [#8247](https://github.com/jsboige/CoursIA/pull/8247), `0ff926ded`) — le verdict « aucun cite / silencieux » du c.803 est périmé |
 | Infer/Infer-14-Sequences.ipynb | 62 (41+21) | HMM forward-backward ; MBML Chap.12 absent mais pattern canonique (Rabiner 1989) |
 | Infer/Infer-15-Recommenders.ipynb | 81 (55+26) | « [Livre MBML](https://mbmlbook.com/) » @ cell 76 (footer Pour aller plus loin) ; couvre PMF/Matchbox/ClickModel |
 | Infer/Infer-16-Sparse-Gaussian-Process.ipynb | 31 (19+12) | GP sparse / EP — Titsias 2009 / MBML Chap.16 absent |
@@ -43,13 +45,13 @@ Les **verdicts de cycle** d'audit et les **décisions de suivi** ne vivent plus 
 | PyMC/PyMC-4-Bayesian-Networks.ipynb | 26 (15+11) | WetGrass/Sprinkler (111 hits) ; « Lauritzen & Spiegelhalter (1988) » — Springer canonique |
 | PyMC/PyMC-5-Causal-Inference.ipynb | 30 (16+14) | Pearl + `pm.do` — do-calculus (MBML Chap.7) non attribué |
 | PyMC/PyMC-6-Debugging.ipynb | 43 (30+13) | Debugging pur MCMC |
-| PyMC/PyMC-7-Skills-IRT.ipynb | 33 (19+14) | IRT (33 hits) ; « Origine de la méthode : Rasch (1960) + Birnbaum (1968) + Lord (1980) + Junker-Sijtsma DINA » — attribution académique explicite **complète** mais ne cite pas MBML Ch.2. **Asymétrie** marquée vs Infer-7 (muet) |
+| PyMC/PyMC-7-Skills-IRT.ipynb | 33 (19+14) | IRT (33 hits) ; « Origine de la méthode : Rasch (1960) + Birnbaum (1968) + Lord (1980) + Junker-Sijtsma DINA » — pedigree académique explicite **complet**, mais **0 mention MBML** (mesuré). L'asymétrie notée au c.803 s'est **inversée** depuis #8530 : c'est désormais le jumeau PyMC qui ne relie pas au chapitre MBML Ch.2, pendant qu'Infer-7 le cite |
 | **PyMC/PyMC-8-TrueSkill.ipynb** | 30 (17+13) | **Section 7 bis reproduit explicitement les formules fermées V(t)/W(t)/τ²** + cell 2 cite « Herbrich, Minka & Graepel (2007), TrueSkill(TM): A Bayesian Skill Rating System (NeurIPS / Microsoft Research Cambridge) ». **Substance MBML Ch.3 complète + bonus algorithmique** |
 | PyMC/PyMC-9-Classification.ipynb | 22 (12+10) | « Herbrich » 2 hits (MBML Chap.4 BPM) sans mention explicite |
 | PyMC/PyMC-10-Model-Selection.ipynb | 35 (19+16) | WAIC/LOO (Vehtari) ; ARD générique |
 | PyMC/PyMC-11-Topic-Models.ipynb | 34 (19+15) | LDA — « Source primaire : Blei, Ng & Jordan (2003) » — source canonique |
 | PyMC/PyMC-12-Modeles-Hierarchiques.ipynb | 23 (14+9) | Pooling partiel — attribution au jumeau Infer-12 uniquement |
-| **PyMC/PyMC-13-Crowdsourcing.ipynb** | 43 (27+16) | Worker models Honest/Biased/Community ; README L280 silencieux côté notebook (jumeau PyMC du Infer-13) |
+| **PyMC/PyMC-13-Crowdsourcing.ipynb** | 43 (27+16) | Worker models Honest/Biased/Community (jumeau PyMC d'Infer-13) — source canonique = Dawid & Skene (1979), **citée** (53 mentions mesurées) ; Raykar / Karger / MBML Ch.7 non mentionnés, contrairement au jumeau Infer-13 |
 | PyMC/PyMC-14-Sequences.ipynb | 39 (22+17) | HMM forward-backward échantillonné — pas d'attribution |
 | PyMC/PyMC-15-Recommenders.ipynb | 58 (34+24) | « Adapté de : Infer-15-Recommenders » + « Origine : PMF Salakhutdinov & Mnih (2008) » — attribution double explicite (jumeau interne + source primaire) |
 | PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb | 27 (16+11) | GP sparse — attribution au jumeau Infer-16 uniquement |


### PR DESCRIPTION
Grain: MED/docs — lane myia-ai-01:CoursIA — prev: LIGHT/tooling (#8701)

Repare une seconde fois du travail que **j'ai merge moi-meme**. #8706 a requalifie `docs/audit/c803-mapping.md` en **reference perenne** `docs/reference/mbml-source-attribution.md`. J'avais verifie ce merge contre ma propre specification — « colonne Verdict retiree, table conservee verbatim » — et la specification etait tenue. Mais les verdicts n'etaient pas seulement dans la colonne Verdict : certains vivaient en prose dans la colonne de droite. **Retirer une colonne ne retire pas les jugements formules ailleurs.**

Trouvaille remontee par po-2023 (`msg-...e7lvmu`, FORENSIC) apres extraction des issues filles ; verifiee ici firsthand avant d'agir.

## Ce qui etait faux

Mesure sur `main` @ `092818f91`, comptage de motifs sur les cellules source :

| Ligne | Verdict c.803 (2026-07-23) | Mesure aujourd'hui | Resolu par |
|---|---|---|---|
| Infer-7-Skills-IRT | « notebook **muet** … **PIRE CAS** » | Rasch 6 · Birnbaum 3 · Lord 4 · Junker 1 · MBML 3 | #8530 `16376a901` |
| Infer-13-Crowdsourcing | « **aucun cite** Raykar/Karger/Zhou/MBML … silencieux » | Raykar 10 · Karger 6 · Dawid 24 · MBML 7 | #8247 `0ff926ded` |
| PyMC-7-Skills-IRT | « **Asymetrie** marquee vs Infer-7 (muet) » | Rasch 3 · **MBML 0** — l'asymetrie s'est **inversee** | consequence de #8530 |
| PyMC-13-Crowdsourcing | « **silencieux** cote notebook » | Dawid **53** · Raykar/Karger/MBML 0 | #8247 (volet PyMC) |

Les deux commits invoques existent et sont sur main (`git log --oneline -1` sur chacun). Les quatre lignes sont corrigees vers l'etat mesure, chacune citant le backfill qui l'a resolue.

Note sur PyMC-7 : la moitie du verdict tenait toujours — « ne cite pas MBML Ch.2 » est **vrai** (0 mention mesuree). Je ne l'ai pas efface : j'ai efface la comparaison qui, elle, etait devenue fausse. Corriger une ligne perimee n'autorise pas a en effacer la part exacte.

## La cause, qui est structurelle et vaut plus que les 4 lignes

La colonne de droite melange **deux natures** qui n'ont pas la meme duree de vie :

- la **correspondance notebook ↔ source canonique** (quel chapitre MBML, quel papier fondateur) — durable, c'est l'objet meme d'une reference ;
- l'**etat d'attribution** (« cite », « sans citation inline », « hors-cite », « non attribue ») — un **instantane**, qui se perime a chaque backfill.

Tant que les deux cohabitent sans etre distingues, ce fichier re-perimera : une quinzaine d'autres lignes portent la meme tournure d'etat, et deviendront fausses au fil des backfills. J'ajoute donc une note en tete de table qui dit lequel des deux se lit comme courant et lequel ne le fait pas — et ou l'etat frais se mesure (#8081, ou le notebook lui-meme).

Je **ne** repasse **pas** les ~15 autres lignes : ce serait re-executer l'audit #8081 dans un fichier de reference, exactement ce que #7422 vient de sortir d'ici. Les quatre corrigees le sont parce qu'elles etaient **mesurees fausses**, pas parce qu'elles etaient suspectes.

## Pourquoi pas un simple disclaimer

po-2023 proposait trois cadrages et recommandait le plus leger : un bandeau « snapshot c.803 ». Je prends le cadrage intermediaire, pour une raison de nature du document : **une reference n'a pas le droit d'enoncer une faussete, meme datee.** Un bandeau rend le lecteur responsable de deviner quelles lignes ont pourri ; il transforme le document en piege poli. Les quatre lignes mesurees fausses se corrigent — c'est peu de travail et ca rend le fichier utilisable. Le bandeau, lui, sert a ce qu'on ne peut pas mesurer a bon compte : la quinzaine de lignes non re-verifiees.

## Verification

- `git diff --stat` : **1 fichier, +6/−4**. Aucun notebook touche, catalogue non concerne.
- Aucun residuel des quatre formules perimees hors des citations de provenance que j'introduis volontairement (« le verdict … est perime »).
- L898 : `gh pr list --search mbml-source-attribution` → aucune PR ouverte sur ce chemin, uniquement des mergees (#8706, #8530, #8091, #8150, #8088).

## Suite tracee ailleurs, pas ici

La mesure fait apparaitre un **gap reel et courant** : PyMC-7 et PyMC-13 ne relient pas au chapitre MBML alors que leurs jumeaux Infer le font depuis #8530/#8247. C'est un ecart de parite entre jumeaux, donc un livrable — j'ouvre une issue plutot que d'en faire un paragraphe dans un fichier de reference. C'est la meme discipline qui a produit #8702-#8705 depuis ce document.

See #8081, See #7422
