### PR TITLE
fix(knot,#8604): remove misleading hwell placeholder field, wf extrinsic sole notion

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic.lean
@@ -88,11 +88,12 @@ structure PDCrossing where
 structure KnotDiagram where
   crossings : List PDCrossing
   numEdges : Nat
-  -- TODO Phase 2: well-formedness predicate.
-  -- Each edge label 0..numEdges-1 appears exactly twice across all crossings.
-  -- Reference: Doll & Hoste (1991), A tabulation of oriented links.
-  -- Placeholder `True` until the predicate is formalised; do NOT read as "well-formed".
-  hwell : True
+  -- Well-formedness is the standalone predicate `KnotDiagram.wf` (§11),
+  -- threaded as a hypothesis `(hwf : d.wf = true)` on Reidemeister moves.
+  -- It is deliberately NOT a field: a Reidemeister move constructs an
+  -- intermediate diagram whose well-formedness holds only under the
+  -- relation's hypotheses, so an intrinsic invariant would make the move
+  -- unstatable (see design rationale on issue #8604).
   deriving Repr
 
 /-! ## 5. Knot
@@ -133,7 +134,6 @@ The simplest knot: the unknot (no crossings).
 def unknotDiagram : KnotDiagram where
   crossings := []
   numEdges := 1
-  hwell := by trivial
 
 def unknot : Knot where
   diagram := unknotDiagram
@@ -150,7 +150,6 @@ def trefoilDiagram : KnotDiagram where
     ⟨5, 2, 6, 3⟩   -- crossing 3
   ]
   numEdges := 6
-  hwell := by trivial  -- TODO: proper well-formedness check
 
 def trefoil : Knot where
   diagram := trefoilDiagram
@@ -167,7 +166,6 @@ def figureEightDiagram : KnotDiagram where
     ⟨7, 3, 8, 6⟩
   ]
   numEdges := 8
-  hwell := by trivial  -- TODO: proper well-formedness check
 
 def figureEight : Knot where
   diagram := figureEightDiagram
@@ -187,7 +185,6 @@ def Knot.mirror (k : Knot) : Knot where
   diagram := {
     crossings := k.diagram.crossings.map mirrorCrossing
     numEdges := k.diagram.numEdges
-    hwell := k.diagram.hwell  -- mirror preserves well-formedness
   }
 
 /-! ## 9. Crossing number (minimal crossings)
@@ -304,7 +301,7 @@ non-trivial hand-case-analysis on 4 labels with possible collisions,
 out of scope for a non-specialist worker (cf. CI failure post-mortem
 `Basic.lean:218` of the abandoned hwell-replace PR; the polymorphism
 on `PDCrossing` prevents `decide` from closing such goals directly,
-cf. C918-L1 ★ on `decide` ≠ prouveur universel).
+since `decide` is not a universal prover on free variables).
 -/
 
 /-- Mirror of the unknot is well-formed: trivially `[]`'s image is `[]`,
@@ -335,9 +332,9 @@ Permutation of itself — the count-per-label invariant is preserved
 *symbolically*, not just on instances.
 
 This is the polymorphic generalisation that CI failure post-mortem
-`Basic.lean:218` of the abandoned hwell-replace PR (c.918) could not
-discharge: `decide` does not close polymorphic goals on free variables
-(cf. C918-L1 ★). The proof here is **hand-written** using `Perm.swap`
+`Basic.lean:218` of the abandoned hwell-replace PR could not
+discharge: `decide` does not close polymorphic goals on free variables.
+The proof here is **hand-written** using `Perm.swap`
 + `Perm.cons` + `Subperm.count_le` + `Subperm.antisymm`:
 the 4-element list `[e1, e4, e3, e2]` is a permutation of
 `[e1, e2, e3, e4]` (transposition `e2 ↔ e4` at position 1..2). v4.31.0-rc1
@@ -459,8 +456,8 @@ For any `KnotDiagram d`, the `mirror`-produced label list is a
 count equality established by `mirror_diag_preserves_count`.
 
 This is the **polymorphic generalisation** that `decide` cannot
-discharge on free variables (cf. C918-L1 ★, "decide ≠ prouveur
-universel"). The proof uses `mirror_diag_preserves_count` to give the
+discharge on free variables (`decide` is not a universal prover).
+The proof uses `mirror_diag_preserves_count` to give the
 bound in each direction. -/
 theorem mirror_edges_subperm (d : KnotDiagram) (l : Nat) :
     (mirror_diag_edges d).count l ≤ d.edges.count l ∧
@@ -469,7 +466,7 @@ theorem mirror_edges_subperm (d : KnotDiagram) (l : Nat) :
          le_of_eq (mirror_diag_preserves_count d l).symm⟩
 
 /-- **Top-level polymorphic theorem** — `mirror` preserves `KnotDiagram.wf`
-    (Issue #8644 sub-track, deferred-scope per C918-L2 ★★).
+    (Issue #8644 sub-track, deferred-scope, no `sorry` introduced).
 
 This is the *headline polymorphic lemma* called out by `#8644`. The proof
 is hand-written and threads through:
@@ -481,7 +478,7 @@ is hand-written and threads through:
     to the parity check + range check, each closed by the corresponding
     `Subperm`-derived equality.
 
-**Honest scope-reduction (C918-L2 ★★)**: closing the full polymorphic
+**Honest scope-reduction**: closing the full polymorphic
 goal requires a `Subperm.antisymm`-then-`Perm`-then-range-check chain
 that is multi-cycle work for a Lean-CPU-only lane. This PR ships the
 **per-diagram count preservation** (`mirror_diag_preserves_count`,
@@ -540,7 +537,7 @@ open List in
 multiset (range check on the support via `all`, parity check on per-label
 `count`) plus `numEdges`, and mirror preserves `numEdges` by field identity.
 This is the full polymorphic generalisation that `decide` could not discharge
-on free variables (cf. C918-L1 ★) — here closed by hand. -/
+on free variables — here closed by hand. -/
 theorem mirror_wf_preserves (k : Knot) (h : k.diagram.wf = true) :
     k.mirror.diagram.wf = true := by
   -- Mirror diagram field identities (defeq).
@@ -584,16 +581,16 @@ theorem mirror_wf_preserves (k : Knot) (h : k.diagram.wf = true) :
         funext i; rw [hc]
       rw [heq]; exact h_par
 
-/-! ## 15. Retrospective on the c.918 → c.934 chain (rationale, post-closure)
+/-! ## 15. Retrospective on the `mirror_wf_preserves` proof chain (rationale, post-closure)
 
-The §14 closure above was the **terminal lemma** of a 4-cycle chain
-that began with c.918's honest failure post-mortem. The retrospective
+The §14 closure above was the **terminal lemma** of a 4-PR chain
+that began with the #8643 failure post-mortem. The retrospective
 below documents the chain so future contributors can navigate it
 without re-walking the same dead ends.
 
 **The four-stop chain:**
 
-1. **c.918 (PR #8643, CLOSED)** — first attempt at `mirror_wf_preserves`
+1. **PR #8643 (CLOSED)** — first attempt at `mirror_wf_preserves`
    using `decide` on the polymorphic `KnotDiagram` goal. The `decide`
    tactic requires a `Decidable` instance and the goal type included
    free variables (`crossings : List PDCrossing`, `numEdges : Nat`);
@@ -602,17 +599,17 @@ without re-walking the same dead ends.
    to `Knot.mirror` (a `Knot` field) but was stated at `KnotDiagram`
    level. PR closed, sub-issue #8644 opened.
 
-2. **c.923 (PR #8652)** — reduced scope to named-knot concrete instances
+2. **PR #8652** — reduced scope to named-knot concrete instances
    (`unknot`, `trefoil`, `figureEight`). `decide` discharges each
    because the type is closed at the diagram level. 3 lemmas
    (`mirror_unknot_wf`, `mirror_trefoil_wf`, `mirror_figureEight_wf`).
 
-3. **c.933 (PR #8667)** — restored polymorphism by hand-writing the
+3. **PR #8667** — restored polymorphism by hand-writing the
    per-label count preservation `mirror_diag_preserves_count` via
    `Perm.subperm` + `le_antisymm`, repairing the v4.31.0-rc1 missing
    `List.perm_iff_count`. 5 lemmas + 1 helper.
 
-4. **c.934 (PR #8673, the closure shipped in `0323b2daa`)** — lifted
+4. **PR #8673 (the closure shipped in `0323b2daa`)** — lifted
    the goal to `Knot.mirror.diagram.wf`, where field-equality of
    `Knot.mirror` yields `rfl` for `numEdges` and `crossings`, and the
    per-diagram permutation `mirror_edges_perm` lifts the per-crossing
@@ -633,10 +630,16 @@ without re-walking the same dead ends.
   reconstruct the per-label count argument by hand.
 
 **EPIC #8604 status:** the polymorphic `mirror_wf_preserves` closure
-shipped in c.934. The original EPIC #8604 acceptance criterion #1
-(`hwell : True` → decidable `IsWellFormed` in `KnotDiagram`) was NOT
-addressed by this chain — the `hwell` field is still `True` in the
-structure definition. That separate piece of work is tracked under
-#8644. No `sorry` introduced (C918-L2 ★★ respected). -/
+shipped in PR #8673. The original EPIC #8604 acceptance criterion #1
+(replace the `hwell : True` placeholder with a decidable well-formedness
+field) was re-scoped: the placeholder `hwell` field has been **removed**,
+leaving `KnotDiagram.wf` (§11) as the sole well-formedness notion — a
+standalone predicate threaded *extrinsically* as a hypothesis
+`(hwf : d.wf = true)` on Reidemeister moves. An intrinsic field is
+incompatible with that architecture, since a Reidemeister move
+constructs an intermediate diagram whose well-formedness holds only
+under the relation's hypotheses. The kernel-verification value (`decide`
+on `unknot_wf`/`trefoil_wf`/`figureEight_wf`) is unchanged. See issue
+#8604 for the design rationale. No `sorry` introduced. -/
 
 end Knots

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Basic_en.lean
@@ -87,11 +87,12 @@ structure PDCrossing where
 structure KnotDiagram where
   crossings : List PDCrossing
   numEdges : Nat
-  -- TODO Phase 2: well-formedness predicate.
-  -- Each edge label 0..numEdges-1 appears exactly twice across all crossings.
-  -- Reference: Doll & Hoste (1991), A tabulation of oriented links.
-  -- Placeholder `True` until the predicate is formalised; do NOT read as "well-formed".
-  hwell : True
+  -- Well-formedness is the standalone predicate `KnotDiagram.wf` (§11),
+  -- threaded as a hypothesis `(hwf : d.wf = true)` on Reidemeister moves.
+  -- It is deliberately NOT a field: a Reidemeister move constructs an
+  -- intermediate diagram whose well-formedness holds only under the
+  -- relation's hypotheses, so an intrinsic invariant would make the move
+  -- unstatable (see design rationale on issue #8604).
   deriving Repr
 
 /-! ## 5. Knot
@@ -132,7 +133,6 @@ The simplest knot: the unknot (no crossings).
 def unknotDiagram : KnotDiagram where
   crossings := []
   numEdges := 1
-  hwell := by trivial
 
 def unknot : Knot where
   diagram := unknotDiagram
@@ -149,7 +149,6 @@ def trefoilDiagram : KnotDiagram where
     ⟨5, 2, 6, 3⟩   -- crossing 3
   ]
   numEdges := 6
-  hwell := by trivial  -- TODO: proper well-formedness check
 
 def trefoil : Knot where
   diagram := trefoilDiagram
@@ -166,7 +165,6 @@ def figureEightDiagram : KnotDiagram where
     ⟨7, 3, 8, 6⟩
   ]
   numEdges := 8
-  hwell := by trivial  -- TODO: proper well-formedness check
 
 def figureEight : Knot where
   diagram := figureEightDiagram
@@ -186,7 +184,6 @@ def Knot.mirror (k : Knot) : Knot where
   diagram := {
     crossings := k.diagram.crossings.map mirrorCrossing
     numEdges := k.diagram.numEdges
-    hwell := k.diagram.hwell  -- mirror preserves well-formedness
   }
 
 /-! ## 9. Crossing number (minimal crossings)
@@ -303,7 +300,7 @@ non-trivial hand-case-analysis on 4 labels with possible collisions,
 out of scope for a non-specialist worker (cf. CI failure post-mortem
 `Basic.lean:218` of the abandoned hwell-replace PR; the polymorphism
 on `PDCrossing` prevents `decide` from closing such goals directly,
-cf. C918-L1 ★ on `decide` ≠ prouveur universel).
+since `decide` is not a universal prover on free variables).
 -/
 
 /-- Mirror of the unknot is well-formed: trivially `[]`'s image is `[]`,
@@ -334,9 +331,9 @@ Permutation of itself — the count-per-label invariant is preserved
 *symbolically*, not just on instances.
 
 This is the polymorphic generalisation that CI failure post-mortem
-`Basic.lean:218` of the abandoned hwell-replace PR (c.918) could not
-discharge: `decide` does not close polymorphic goals on free variables
-(cf. C918-L1 ★). The proof here is **hand-written** using `Perm.swap`
+`Basic.lean:218` of the abandoned hwell-replace PR could not
+discharge: `decide` does not close polymorphic goals on free variables.
+The proof here is **hand-written** using `Perm.swap`
 + `Perm.cons` + `Subperm.count_le` + `Subperm.antisymm`:
 the 4-element list `[e1, e4, e3, e2]` is a permutation of
 `[e1, e2, e3, e4]` (transposition `e2 ↔ e4` at position 1..2). v4.31.0-rc1
@@ -458,8 +455,8 @@ For any `KnotDiagram d`, the `mirror`-produced label list is a
 count equality established by `mirror_diag_preserves_count`.
 
 This is the **polymorphic generalisation** that `decide` cannot
-discharge on free variables (cf. C918-L1 ★, "decide ≠ prouveur
-universel"). The proof uses `mirror_diag_preserves_count` to give the
+discharge on free variables (`decide` is not a universal prover).
+The proof uses `mirror_diag_preserves_count` to give the
 bound in each direction. -/
 theorem mirror_edges_subperm (d : KnotDiagram) (l : Nat) :
     (mirror_diag_edges d).count l ≤ d.edges.count l ∧
@@ -468,7 +465,7 @@ theorem mirror_edges_subperm (d : KnotDiagram) (l : Nat) :
          le_of_eq (mirror_diag_preserves_count d l).symm⟩
 
 /-- **Top-level polymorphic theorem** — `mirror` preserves `KnotDiagram.wf`
-    (Issue #8644 sub-track, deferred-scope per C918-L2 ★★).
+    (Issue #8644 sub-track, deferred-scope, no `sorry` introduced).
 
 This is the *headline polymorphic lemma* called out by `#8644`. The proof
 is hand-written and threads through:
@@ -480,7 +477,7 @@ is hand-written and threads through:
     to the parity check + range check, each closed by the corresponding
     `Subperm`-derived equality.
 
-**Honest scope-reduction (C918-L2 ★★)**: closing the full polymorphic
+**Honest scope-reduction**: closing the full polymorphic
 goal requires a `Subperm.antisymm`-then-`Perm`-then-range-check chain
 that is multi-cycle work for a Lean-CPU-only lane. This PR ships the
 **per-diagram count preservation** (`mirror_diag_preserves_count`,
@@ -539,7 +536,7 @@ open List in
 multiset (range check on the support via `all`, parity check on per-label
 `count`) plus `numEdges`, and mirror preserves `numEdges` by field identity.
 This is the full polymorphic generalisation that `decide` could not discharge
-on free variables (cf. C918-L1 ★) — here closed by hand. -/
+on free variables — here closed by hand. -/
 theorem mirror_wf_preserves (k : Knot) (h : k.diagram.wf = true) :
     k.mirror.diagram.wf = true := by
   -- Mirror diagram field identities (defeq).
@@ -583,16 +580,16 @@ theorem mirror_wf_preserves (k : Knot) (h : k.diagram.wf = true) :
         funext i; rw [hc]
       rw [heq]; exact h_par
 
-/-! ## 15. Retrospective on the c.918 → c.934 chain (rationale, post-closure)
+/-! ## 15. Retrospective on the `mirror_wf_preserves` proof chain (rationale, post-closure)
 
-The §14 closure above was the **terminal lemma** of a 4-cycle chain
-that began with c.918's honest failure post-mortem. The retrospective
+The §14 closure above was the **terminal lemma** of a 4-PR chain
+that began with the #8643 failure post-mortem. The retrospective
 below documents the chain so future contributors can navigate it
 without re-walking the same dead ends.
 
 **The four-stop chain:**
 
-1. **c.918 (PR #8643, CLOSED)** — first attempt at `mirror_wf_preserves`
+1. **PR #8643 (CLOSED)** — first attempt at `mirror_wf_preserves`
    using `decide` on the polymorphic `KnotDiagram` goal. The `decide`
    tactic requires a `Decidable` instance and the goal type included
    free variables (`crossings : List PDCrossing`, `numEdges : Nat`);
@@ -601,17 +598,17 @@ without re-walking the same dead ends.
    to `Knot.mirror` (a `Knot` field) but was stated at `KnotDiagram`
    level. PR closed, sub-issue #8644 opened.
 
-2. **c.923 (PR #8652)** — reduced scope to named-knot concrete instances
+2. **PR #8652** — reduced scope to named-knot concrete instances
    (`unknot`, `trefoil`, `figureEight`). `decide` discharges each
    because the type is closed at the diagram level. 3 lemmas
    (`mirror_unknot_wf`, `mirror_trefoil_wf`, `mirror_figureEight_wf`).
 
-3. **c.933 (PR #8667)** — restored polymorphism by hand-writing the
+3. **PR #8667** — restored polymorphism by hand-writing the
    per-label count preservation `mirror_diag_preserves_count` via
    `Perm.subperm` + `le_antisymm`, repairing the v4.31.0-rc1 missing
    `List.perm_iff_count`. 5 lemmas + 1 helper.
 
-4. **c.934 (PR #8673, the closure shipped in `0323b2daa`)** — lifted
+4. **PR #8673 (the closure shipped in `0323b2daa`)** — lifted
    the goal to `Knot.mirror.diagram.wf`, where field-equality of
    `Knot.mirror` yields `rfl` for `numEdges` and `crossings`, and the
    per-diagram permutation `mirror_edges_perm` lifts the per-crossing
@@ -632,10 +629,16 @@ without re-walking the same dead ends.
   reconstruct the per-label count argument by hand.
 
 **EPIC #8604 status:** the polymorphic `mirror_wf_preserves` closure
-shipped in c.934. The original EPIC #8604 acceptance criterion #1
-(`hwell : True` → decidable `IsWellFormed` in `KnotDiagram`) was NOT
-addressed by this chain — the `hwell` field is still `True` in the
-structure definition. That separate piece of work is tracked under
-#8644. No `sorry` introduced (C918-L2 ★★ respected). -/
+shipped in PR #8673. The original EPIC #8604 acceptance criterion #1
+(replace the `hwell : True` placeholder with a decidable well-formedness
+field) was re-scoped: the placeholder `hwell` field has been **removed**,
+leaving `KnotDiagram.wf` (§11) as the sole well-formedness notion — a
+standalone predicate threaded *extrinsically* as a hypothesis
+`(hwf : d.wf = true)` on Reidemeister moves. An intrinsic field is
+incompatible with that architecture, since a Reidemeister move
+constructs an intermediate diagram whose well-formedness holds only
+under the relation's hypotheses. The kernel-verification value (`decide`
+on `unknot_wf`/`trefoil_wf`/`figureEight_wf`) is unchanged. See issue
+#8604 for the design rationale. No `sorry` introduced. -/
 
 end Knots_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway.lean
@@ -77,7 +77,6 @@ def conwayKnotDiagram : KnotDiagram where
     ⟨21, 22, 22, 21⟩
   ]
   numEdges := 22
-  hwell := by trivial  -- TODO: proper well-formedness check
 
 def conwayKnot : Knot where
   diagram := conwayKnotDiagram
@@ -104,7 +103,6 @@ def kinoshitaTerasakaDiagram : KnotDiagram where
     ⟨21, 12, 22, 21⟩
   ]
   numEdges := 22
-  hwell := by trivial  -- TODO: proper well-formedness check
 
 def kinoshitaTerasakaKnot : Knot where
   diagram := kinoshitaTerasakaDiagram

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean
@@ -87,7 +87,6 @@ def conwayKnotDiagram : KnotDiagram where
     ⟨21, 22, 22, 21⟩
   ]
   numEdges := 22
-  hwell := by trivial  -- TODO: proper well-formedness check
 
 def conwayKnot : Knot where
   diagram := conwayKnotDiagram
@@ -114,7 +113,6 @@ def kinoshitaTerasakaDiagram : KnotDiagram where
     ⟨21, 12, 22, 21⟩
   ]
   numEdges := 22
-  hwell := by trivial  -- TODO: proper well-formedness check
 
 def kinoshitaTerasakaKnot : Knot where
   diagram := kinoshitaTerasakaDiagram

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -441,8 +441,8 @@ theorem tricolorable_invariant_fails_under_pr1_model :
       ¬ IsTricolorable d₁ ∧
       IsTricolorable d₂ := by
   -- Witness pair.
-  refine' ⟨{ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial },
-           { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4, hwell := by trivial },
+  refine' ⟨{ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 },
+           { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 },
            ?_, ?_, ?_⟩
   -- (a) Reidemeister1 d₁ d₂: a single free-ρ R1 twist, witness c = ⟨3,4,3,4⟩.
   --     d₁ = {[⟨1,2,1,2⟩], numEdges = 2}; d₂ = {[⟨1,2,1,2⟩, ⟨3,4,3,4⟩], numEdges = 4}.
@@ -467,7 +467,7 @@ theorem tricolorable_invariant_fails_under_pr1_model :
       rfl
   -- (b) d₁ is NOT tricolorable: Fox at the sole crossing ⟨1,2,1,2⟩ forces the two
   --     edges to the same colour, contradicting the ≥2-colours requirement.
-  · show ¬ IsTricolorable { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial }
+  · show ¬ IsTricolorable { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
     rintro ⟨coloring, hcond, hedges, htwo⟩
     -- The sole crossing ⟨1,2,1,2⟩ is in d₁.crossings; apply the Fox condition to it.
     have hfox := hcond (⟨1, 2, 1, 2⟩ : PDCrossing)
@@ -494,7 +494,7 @@ theorem tricolorable_invariant_fails_under_pr1_model :
     exact hne (by rw [hAll i, hAll j])
   -- (c) d₂ IS tricolorable: edges 1,2 (Fin index 0,1) = red, edges 3,4 (index 2,3) = blue;
   --     Fox is all-equal within each crossing, ≥2 colours used.
-  · show IsTricolorable { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4, hwell := by trivial }
+  · show IsTricolorable { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 }
     refine' ⟨fun i : Fin 4 => if i.val ≤ 1 then TriColor.red else TriColor.blue, ?_, ?_, ?_⟩
     · -- Fox at every crossing of d₂.
       intro c hc
@@ -543,8 +543,8 @@ Why `Reidemeister1' d₁ d₂` fails:
 the counter-example by construction. -/
 theorem pr1_counterexample_excluded_under_rho_determined :
     ¬ Reidemeister1'
-        { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial }
-        { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4, hwell := by trivial } := by
+        { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
+        { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 } := by
   -- Unfold Reidemeister1': wf₁ ∧ wf₂ ∧ (∃ a, range ∧ (∃ ρ, surgery ∨ surgery)).
   rintro ⟨_hwf₁, _hwf₂, a, _hrange₁, _hrange₂, _ρ, hsurg⟩
   rcases hsurg with ht | ht
@@ -553,9 +553,9 @@ theorem pr1_counterexample_excluded_under_rho_determined :
     -- Project .crossings off the record equality ht by congruence, then the RHS
     -- ({ d₁ with crossings := X }).crossings reduces to X = d₁.crossings ++ [⟨a,a,3,4⟩].
     have hfield :
-        ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4, hwell := by trivial }
+        ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 }
           : KnotDiagram).crossings =
-        ({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial }
+        ({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
           : KnotDiagram).crossings ++ [⟨a, a, 3, 4⟩] :=
       congrArg (·.crossings) ht
     -- The RHS reduces to [⟨1,2,1,2⟩] ++ [⟨a,a,3,4⟩]; second elements: ⟨3,4,3,4⟩ = ⟨a,a,3,4⟩.
@@ -569,9 +569,9 @@ theorem pr1_counterexample_excluded_under_rho_determined :
     -- Project .crossings off the record equality by congruence (term-mode, robust
     -- against literal-form mismatch that blocks `subst`/`rw`).
     have hfield :
-        ({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial }
+        ({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
           : KnotDiagram).crossings =
-        ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4, hwell := by trivial }
+        ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 }
           : KnotDiagram).crossings ++ [⟨a, a, 5, 6⟩] :=
       congrArg (·.crossings) ht
     -- Length contradiction: LHS has length 1, RHS has length 3.
@@ -603,8 +603,8 @@ is currently twist-only and needs an untwist arm + `.symm` before the equivalenc
 `reidemeister_equiv_symm` can carry it. See #2874.) -/
 theorem pr1_counterexample_excluded_under_connected :
     ¬ Reidemeister1Connected
-        { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial }
-        { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4, hwell := by trivial } := by
+        { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
+        { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 } := by
   -- Reidemeister1Connected unfolds as wf₁ ∧ wf₂ ∧ (∃ i a Y' ρ, bounds ∧ edges ∧
   -- proper-arc ∧ isRenameOf ∧ surgery). The surgery is single-arm (twist only):
   -- d₂ = { d₁ with crossings := d₁.crossings.set i.val Y' ++ [⟨a,3,4,4⟩], numEdges := 4 }.
@@ -615,14 +615,14 @@ theorem pr1_counterexample_excluded_under_connected :
   -- let omega combine `hbnd : i.val < e` with `hlen : e = 1` directly.
   have hi : i.val = 0 := by
     have hlen :
-        (({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial }
+        (({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
           : KnotDiagram).crossings).length = 1 := by rfl
     have hbnd := i.isLt
     omega
   have hfield :
-      ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4, hwell := by trivial }
+      ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 }
         : KnotDiagram).crossings =
-      (({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial }
+      (({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
         : KnotDiagram).crossings.set i.val Y') ++ [⟨a, 3, 4, 4⟩] :=
     congrArg (·.crossings) hsurg
   rw [hi] at hfield
@@ -666,11 +666,11 @@ supplied by hand, with each crossing's Fox condition discharged by `decide`.
 
 /-- The witness `d₁` of `reidemeister1Connected_satisfiable` (Reidemeister.lean). -/
 def witnessD1Connected : KnotDiagram :=
-  { crossings := [⟨1,2,3,4⟩, ⟨1,2,3,4⟩], numEdges := 4, hwell := by trivial }
+  { crossings := [⟨1,2,3,4⟩, ⟨1,2,3,4⟩], numEdges := 4 }
 
 /-- The witness `d₂` of `reidemeister1Connected_satisfiable` (Reidemeister.lean). -/
 def witnessD2Connected : KnotDiagram :=
-  { crossings := [⟨1,2,3,4⟩, ⟨5,2,3,4⟩, ⟨1,5,6,6⟩], numEdges := 6, hwell := by trivial }
+  { crossings := [⟨1,2,3,4⟩, ⟨5,2,3,4⟩, ⟨1,5,6,6⟩], numEdges := 6 }
 
 /-- `witnessD1Connected` is tricolorable (Path B): both crossings are
     `⟨1,2,3,4⟩`, each reading `(red, blue, green)` on the Fox strands

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
@@ -404,8 +404,8 @@ theorem tricolorable_invariant_fails_under_pr1_model :
       ¬ IsTricolorable d₁ ∧
       IsTricolorable d₂ := by
   -- Witness pair.
-  refine' ⟨{ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial },
-           { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4, hwell := by trivial },
+  refine' ⟨{ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 },
+           { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 },
            ?_, ?_, ?_⟩
   -- (a) Reidemeister1 d₁ d₂: a single free-ρ R1 twist, witness c = ⟨3,4,3,4⟩.
   --     d₁ = {[⟨1,2,1,2⟩], numEdges = 2}; d₂ = {[⟨1,2,1,2⟩, ⟨3,4,3,4⟩], numEdges = 4}.
@@ -430,7 +430,7 @@ theorem tricolorable_invariant_fails_under_pr1_model :
       rfl
   -- (b) d₁ is NOT tricolorable: Fox at the sole crossing ⟨1,2,1,2⟩ forces the two
   --     edges to the same colour, contradicting the ≥2-colours requirement.
-  · show ¬ IsTricolorable { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial }
+  · show ¬ IsTricolorable { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
     rintro ⟨coloring, hcond, hedges, htwo⟩
     -- The sole crossing ⟨1,2,1,2⟩ is in d₁.crossings; apply the Fox condition to it.
     have hfox := hcond (⟨1, 2, 1, 2⟩ : PDCrossing)
@@ -457,7 +457,7 @@ theorem tricolorable_invariant_fails_under_pr1_model :
     exact hne (by rw [hAll i, hAll j])
   -- (c) d₂ IS tricolorable: edges 1,2 (Fin index 0,1) = red, edges 3,4 (index 2,3) = blue;
   --     Fox is all-equal within each crossing, ≥2 colours used.
-  · show IsTricolorable { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4, hwell := by trivial }
+  · show IsTricolorable { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 }
     refine' ⟨fun i : Fin 4 => if i.val ≤ 1 then TriColor.red else TriColor.blue, ?_, ?_, ?_⟩
     · -- Fox at every crossing of d₂.
       intro c hc
@@ -506,8 +506,8 @@ Why `Reidemeister1' d₁ d₂` fails:
 the counter-example by construction. -/
 theorem pr1_counterexample_excluded_under_rho_determined :
     ¬ Reidemeister1'
-        { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial }
-        { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4, hwell := by trivial } := by
+        { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
+        { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 } := by
   -- Unfold Reidemeister1': wf₁ ∧ wf₂ ∧ (∃ a, range ∧ (∃ ρ, surgery ∨ surgery)).
   rintro ⟨_hwf₁, _hwf₂, a, _hrange₁, _hrange₂, _ρ, hsurg⟩
   rcases hsurg with ht | ht
@@ -516,9 +516,9 @@ theorem pr1_counterexample_excluded_under_rho_determined :
     -- Project .crossings off the record equality ht by congruence, then the RHS
     -- ({ d₁ with crossings := X }).crossings reduces to X = d₁.crossings ++ [⟨a,a,3,4⟩].
     have hfield :
-        ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4, hwell := by trivial }
+        ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 }
           : KnotDiagram).crossings =
-        ({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial }
+        ({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
           : KnotDiagram).crossings ++ [⟨a, a, 3, 4⟩] :=
       congrArg (·.crossings) ht
     -- The RHS reduces to [⟨1,2,1,2⟩] ++ [⟨a,a,3,4⟩]; second elements: ⟨3,4,3,4⟩ = ⟨a,a,3,4⟩.
@@ -532,9 +532,9 @@ theorem pr1_counterexample_excluded_under_rho_determined :
     -- Project .crossings off the record equality by congruence (term-mode, robust
     -- against literal-form mismatch that blocks `subst`/`rw`).
     have hfield :
-        ({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial }
+        ({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
           : KnotDiagram).crossings =
-        ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4, hwell := by trivial }
+        ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 }
           : KnotDiagram).crossings ++ [⟨a, a, 5, 6⟩] :=
       congrArg (·.crossings) ht
     -- Length contradiction: LHS has length 1, RHS has length 3.
@@ -566,8 +566,8 @@ is currently twist-only and needs an untwist arm + `.symm` before the equivalenc
 `reidemeister_equiv_symm` can carry it. See #2874.) -/
 theorem pr1_counterexample_excluded_under_connected :
     ¬ Reidemeister1Connected
-        { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial }
-        { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4, hwell := by trivial } := by
+        { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
+        { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 } := by
   -- Reidemeister1Connected unfolds as wf₁ ∧ wf₂ ∧ (∃ i a Y' ρ, bounds ∧ edges ∧
   -- proper-arc ∧ isRenameOf ∧ surgery). The surgery is single-arm (twist only):
   -- d₂ = { d₁ with crossings := d₁.crossings.set i.val Y' ++ [⟨a,3,4,4⟩], numEdges := 4 }.
@@ -578,14 +578,14 @@ theorem pr1_counterexample_excluded_under_connected :
   -- let omega combine `hbnd : i.val < e` with `hlen : e = 1` directly.
   have hi : i.val = 0 := by
     have hlen :
-        (({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial }
+        (({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
           : KnotDiagram).crossings).length = 1 := by rfl
     have hbnd := i.isLt
     omega
   have hfield :
-      ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4, hwell := by trivial }
+      ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 }
         : KnotDiagram).crossings =
-      (({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2, hwell := by trivial }
+      (({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
         : KnotDiagram).crossings.set i.val Y') ++ [⟨a, 3, 4, 4⟩] :=
     congrArg (·.crossings) hsurg
   rw [hi] at hfield
@@ -629,11 +629,11 @@ supplied by hand, with each crossing's Fox condition discharged by `decide`.
 
 /-- The witness `d₁` of `reidemeister1Connected_satisfiable` (Reidemeister.lean). -/
 def witnessD1Connected : KnotDiagram :=
-  { crossings := [⟨1,2,3,4⟩, ⟨1,2,3,4⟩], numEdges := 4, hwell := by trivial }
+  { crossings := [⟨1,2,3,4⟩, ⟨1,2,3,4⟩], numEdges := 4 }
 
 /-- The witness `d₂` of `reidemeister1Connected_satisfiable` (Reidemeister.lean). -/
 def witnessD2Connected : KnotDiagram :=
-  { crossings := [⟨1,2,3,4⟩, ⟨5,2,3,4⟩, ⟨1,5,6,6⟩], numEdges := 6, hwell := by trivial }
+  { crossings := [⟨1,2,3,4⟩, ⟨5,2,3,4⟩, ⟨1,5,6,6⟩], numEdges := 6 }
 
 /-- `witnessD1Connected` is tricolorable (Path B): both crossings are
     `⟨1,2,3,4⟩`, each reading `(red, blue, green)` on the Fox strands

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Lidman.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Lidman.lean
@@ -64,7 +64,6 @@ def knot_11n102_diagram : KnotDiagram where
     ⟨21, 16, 22, 17⟩   -- crossing 11
   ]
   numEdges := 22
-  hwell := by trivial  -- TODO Phase 2: proper well-formedness check
 
 def knot_11n102 : Knot where
   diagram := knot_11n102_diagram

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Lidman_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Lidman_en.lean
@@ -65,7 +65,6 @@ def knot_11n102_diagram : KnotDiagram where
     ⟨21, 16, 22, 17⟩   -- crossing 11
   ]
   numEdges := 22
-  hwell := by trivial  -- TODO Phase 2: proper well-formedness check
 
 def knot_11n102 : Knot where
   diagram := knot_11n102_diagram

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
@@ -272,8 +272,8 @@ def Reidemeister1Connected (d₁ d₂ : KnotDiagram) : Prop :=
     l'option C du modèle vide PR1.5. -/
 theorem reidemeister1Connected_satisfiable :
     Reidemeister1Connected
-      { crossings := [⟨1,2,3,4⟩, ⟨1,2,3,4⟩], numEdges := 4, hwell := by trivial }
-      { crossings := [⟨1,2,3,4⟩, ⟨5,2,3,4⟩, ⟨1,5,6,6⟩], numEdges := 6, hwell := by trivial } := by
+      { crossings := [⟨1,2,3,4⟩, ⟨1,2,3,4⟩], numEdges := 4 }
+      { crossings := [⟨1,2,3,4⟩, ⟨5,2,3,4⟩, ⟨1,5,6,6⟩], numEdges := 6 } := by
   refine ⟨by decide, by decide, ⟨1, by decide⟩, 1, ⟨5,2,3,4⟩, ?_, ?_⟩
   · -- ρ : Fin 4 ↪ Fin 6 (trivial embedding, first 4 → first 4 of 6).
     exact { toFun := fun j => ⟨j.val, by omega⟩,
@@ -491,8 +491,8 @@ theorem Reidemeister3Determined.implies_reidemeister3 {d₁ d₂ : KnotDiagram}
     donc `wf` vaut des deux côtés. -/
 theorem reidemeister3Determined_satisfiable :
     Reidemeister3Determined
-      { crossings := [⟨1,2,3,4⟩, ⟨1,2,3,4⟩], numEdges := 4, hwell := by trivial }
-      { crossings := [⟨1,3,2,4⟩, ⟨1,2,3,4⟩], numEdges := 4, hwell := by trivial } := by
+      { crossings := [⟨1,2,3,4⟩, ⟨1,2,3,4⟩], numEdges := 4 }
+      { crossings := [⟨1,3,2,4⟩, ⟨1,2,3,4⟩], numEdges := 4 } := by
   refine ⟨by decide, by decide, ?_⟩
   refine ⟨⟨0, by decide⟩, ⟨1,3,2,4⟩, ?_, ?_, ?_, ?_, ?_⟩
   · -- ρ : Fin 4 ↪ Fin 4 (identity; numEdges equal on both sides)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister_en.lean
@@ -253,8 +253,8 @@ def Reidemeister1Connected (d₁ d₂ : KnotDiagram) : Prop :=
     vacuous PR1.5 model. -/
 theorem reidemeister1Connected_satisfiable :
     Reidemeister1Connected
-      { crossings := [⟨1,2,3,4⟩, ⟨1,2,3,4⟩], numEdges := 4, hwell := by trivial }
-      { crossings := [⟨1,2,3,4⟩, ⟨5,2,3,4⟩, ⟨1,5,6,6⟩], numEdges := 6, hwell := by trivial } := by
+      { crossings := [⟨1,2,3,4⟩, ⟨1,2,3,4⟩], numEdges := 4 }
+      { crossings := [⟨1,2,3,4⟩, ⟨5,2,3,4⟩, ⟨1,5,6,6⟩], numEdges := 6 } := by
   refine ⟨by decide, by decide, ⟨1, by decide⟩, 1, ⟨5,2,3,4⟩, ?_, ?_⟩
   · -- ρ : Fin 4 ↪ Fin 6 (trivial embedding, first 4 → first 4 of 6).
     exact { toFun := fun j => ⟨j.val, by omega⟩,
@@ -461,8 +461,8 @@ theorem Reidemeister3Determined.implies_reidemeister3 {d₁ d₂ : KnotDiagram}
     `{1,2,3,4}` is unchanged, so `wf` holds on both sides. -/
 theorem reidemeister3Determined_satisfiable :
     Reidemeister3Determined
-      { crossings := [⟨1,2,3,4⟩, ⟨1,2,3,4⟩], numEdges := 4, hwell := by trivial }
-      { crossings := [⟨1,3,2,4⟩, ⟨1,2,3,4⟩], numEdges := 4, hwell := by trivial } := by
+      { crossings := [⟨1,2,3,4⟩, ⟨1,2,3,4⟩], numEdges := 4 }
+      { crossings := [⟨1,3,2,4⟩, ⟨1,2,3,4⟩], numEdges := 4 } := by
   refine ⟨by decide, by decide, ?_⟩
   refine ⟨⟨0, by decide⟩, ⟨1,3,2,4⟩, ?_, ?_, ?_, ?_, ?_⟩
   · -- ρ : Fin 4 ↪ Fin 4 (identity; numEdges equal on both sides)


### PR DESCRIPTION
## Summary

Removes the placeholder `hwell : True` field from `KnotDiagram`, making `KnotDiagram.wf` (§11) the **sole** well-formedness notion — a standalone Bool predicate threaded *extrinsically* as a hypothesis `(hwf : d.wf = true)` on the re-modelled Reidemeister moves.

This is the coordinator's option **(C)** arbitration on #8604 (public rationale: https://github.com/jsboige/CoursIA/issues/8604#issuecomment-5107649516).

## Why remove the field rather than make it real

The original EPIC #8604 criterion #1 asked to replace the `hwell : True` placeholder with a decidable well-formedness *field*. Escalation (verified firsthand against `main`) showed this breaks **9 polymorphic sites** in the Reidemeister relation *definitions* (`d₂ = { d₁ with crossings := d₁.crossings ++ [c] }`, `c` a free existential): an intrinsic well-formedness field makes a Reidemeister move **unstatable**, because the move *constructs* an intermediate diagram whose well-formedness holds only under the relation's hypotheses. The domain does not permit an intrinsic invariant on `KnotDiagram`.

This is not a limitation of the tool — it is a fact about the domain, already documented in the file's own design comments (lines 248-249, 266): `wf` is deliberately *extrinsic* (predicate + hypothesis on the relation), modelled on `MacroCell.wf` in `conway_lean`.

## The targeted value is already achieved

The kernel-verification value criterion #1 sought — PD-codes verified by the kernel — already exists via `KnotDiagram.wf` + the `*_wf` theorems:
- `unknot_wf`, `trefoil_wf`, `figureEight_wf` (and the mirror variants) discharge by `decide` — **real kernel verification**, not `native_decide`/`ofReduceBool`.
- `mirror_wf_preserves` is **already fully proven** polymorphically, sorry-free (`Basic.lean:544`).

So the placeholder field was a redundant second layer whose removal is pure simplification — nothing is weakened.

## Scope (mechanical, 66 occurrences / 10 files / 5 FR-EN pairs)

| File (×2 FR/EN) | `hwell` refs |
|---|---|
| Basic | 9 + 9 (structure field, 3 diagram literals, `Knot.mirror` propagation, comments) |
| Invariant | 17 + 17 (inline record literals in tricolorability witnesses) |
| Reidemeister | 4 + 4 (inline record literals in satisfiability witnesses) |
| Conway | 2 + 2 (diagram literals) |
| Lidman | 1 + 1 (diagram literal) |

Nothing consumes the field (it is `True`, nothing derives from it), so removal stops cleanly at the references. Folds the #8679 review feedback (strip ephemeral `c.918-c.934` cycle markers + `C918-L★` memory slugs from docstrings; §15 retrospective title/wording per coordinator).

## Verification (G.1, post-edit)

- `grep -c sorry` on `Knots/` (code-only): **17 → 17 unchanged** (no anti-regression violation)
- `lake build knot_lean` (full package): **SUCCESS** — all Knots modules (`Basic`, `Reidemeister`, `Invariant`, `Conway`, `Lidman` + `_en` twins) build green
- `check_i18n_siblings.py`: **6/6 FR-EN pairs byte-identical** on code (comments-only divergence, as the i18n convention allows)
- Branch fresh from `origin/main` (base `7980dcc13`), no catalogue/generated drift

## Note on the literal acceptance criterion

The literal criterion of #8604 ("replace placeholder with a decidable field") is **not** met — and this PR does not pretend otherwise. The placeholder is *removed*; what remains is the extrinsic `wf` that was always there. It is the **value** the criterion aimed at (kernel-verified PD-codes) that is delivered, and the field was only ever a means to that end. Closing the issue on that honest basis.

Closes #8604

Co-Authored-By: Claude <noreply@anthropic.com>
