### PR TITLE
fix(notebook-tools,#8057): registry rebaseline writes LF, not os.linesep

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -32,3 +32,11 @@ lake-manifest.json text eol=lf
 # plus d'objet (et de toute facon n'etait jamais honore par le merge cote serveur
 # GitHub). Ne PAS le re-ajouter : le filet de securite structural est desormais
 # scripts/notebook_tools/tests/test_twin_registry_integrity.py (file-per-entry).
+#
+# EOL (meme motif "L268" que ci-dessus) : le registre est reecrit par
+# `check_twin_parity.py --update`, donc par des agents dont la moitie tourne
+# sous Windows. Sans regle explicite, un rebaseline d'UNE paire y basculait le
+# fichier entier en CRLF et le diff passait de 2 lignes a tout le fichier
+# (#8709, #8713). L'ecrivain est corrige cote outil (`write_registry_text`) ;
+# cette regle est le second filet, qui vaut pour n'importe quel ecrivain.
+scripts/notebook_tools/twin_pairs.d/*.yaml text eol=lf

--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -473,6 +473,28 @@ def _fmt_audit_value(key: str, value) -> str:
     return f'"{value}"' if key == "date" else str(value)
 
 
+def write_registry_text(path: Path, text: str) -> None:
+    """Ecrit un fichier de registre en preservant ses fins de ligne LF.
+
+    `Path.write_text(..., encoding="utf-8")` ouvre le fichier avec
+    `newline=None`, ce qui traduit chaque `\\n` en `os.linesep` -- donc en
+    `\\r\\n` sous Windows. La moitie de la flotte tourne sous Windows : un
+    rebaseline y reecrivait silencieusement **toutes** les lignes du fichier en
+    CRLF, y compris celles que `surgical_rebaseline` venait de laisser
+    intactes. Le diff annonce (« exactement les lignes changees ») devenait un
+    diff de fichier entier, et la ligne qu'un relecteur doit examiner -- le SHA
+    -- se retrouvait noyee dans le bruit.
+
+    `newline=""` desactive toute traduction : le texte est ecrit tel quel.
+
+    Incident : PR #8709 et #8713, deux rebaselines d'une seule paire chacun,
+    affichant `+23/-16` et `+24/-16` la ou le changement reel valait deux
+    lignes.
+    """
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        fh.write(text)
+
+
 def surgical_rebaseline(raw: str, updates: dict[str, dict]) -> tuple[str, int]:
     """Reecrit UNIQUEMENT les lignes `last_audit` des paires ciblees.
 
@@ -778,14 +800,14 @@ def main(argv=None) -> int:
                 raw = pfile.read_text(encoding="utf-8")
                 new_raw, _ = surgical_rebaseline(raw, {name: audit})
                 if new_raw != raw:
-                    pfile.write_text(new_raw, encoding="utf-8")
+                    write_registry_text(pfile, new_raw)
                     written += 1
             updated = written
         else:
             # mono-fichier legacy (--registry <file.yaml>)
             raw = reg_path.read_text(encoding="utf-8")
             new_raw, updated = surgical_rebaseline(raw, updates)
-            reg_path.write_text(new_raw, encoding="utf-8")
+            write_registry_text(reg_path, new_raw)
         if skipped:
             print(
                 f"Ignorees (notebook absent de git) : {', '.join(skipped)}",

--- a/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
@@ -245,3 +245,56 @@ def test_schema_file_is_never_a_rebaseline_target(registry_backup):
 
     loaded_names = {p["name"] for p in ctp.load_registry(REGISTRY_DIR)}
     assert loaded_names == {_pair_name(f) for f in registry_backup}
+
+
+def test_write_preserves_lf_on_every_platform(tmp_path):
+    """La garantie chirurgicale doit survivre a l'ECRITURE, pas seulement au calcul.
+
+    Les tests ci-dessus verifient `surgical_rebaseline` au niveau de la chaine :
+    ils passent sur toutes les plateformes, y compris quand le fichier ecrit sur
+    disque est integralement reecrit. `Path.write_text` ouvre avec
+    `newline=None`, qui traduit `\\n` en `os.linesep` -- donc en CRLF sous
+    Windows. Le calcul restait chirurgical, l'ecriture ne l'etait pas, et le
+    diff affichait le fichier entier (#8709, #8713 : `-16` lignes pour un
+    changement de deux).
+    """
+    target = tmp_path / "pair.yaml"
+    original = "- name: X\n  last_audit:\n    date: \"2020-01-01\"\n"
+    target.write_bytes(original.encode("utf-8"))
+
+    new_raw, _ = ctp.surgical_rebaseline(original, {"X": {"date": "2026-01-01"}})
+    ctp.write_registry_text(target, new_raw)
+
+    written = target.read_bytes()
+    assert b"\r\n" not in written, (
+        "le registre doit rester en LF : un CRLF fait apparaitre chaque ligne "
+        "inchangee comme modifiee et noie la ligne reellement auditee"
+    )
+    assert written.decode("utf-8").count("\n") == original.count("\n")
+
+
+def test_registry_blobs_are_lf_only():
+    """Aucun blob de registre versionne ne doit etre en CRLF.
+
+    Backstop du test precedent : meme si un ecrivain contourne
+    `write_registry_text`, le registre **dans git** reste homogene.
+
+    On interroge l'index (`git ls-files --eol`, colonne `i/`) et non le working
+    tree : avec `core.autocrlf=true` -- la configuration par defaut de la moitie
+    de la flotte -- le working tree est legitimement en CRLF alors que le blob
+    est en LF. Tester les octets sur disque ferait echouer ce test sur toutes
+    les machines Windows correctement configurees, pour un registre sain. C'est
+    aussi ce qui explique que le defaut ait pu voyager : la ou `autocrlf` est
+    actif il est invisible, la ou il ne l'est pas il committe du CRLF.
+    """
+    import subprocess
+
+    out = subprocess.run(
+        ["git", "ls-files", "--eol", str(REGISTRY_DIR)],
+        capture_output=True, text=True, cwd=SCRIPT_DIR,
+    )
+    if out.returncode != 0:
+        pytest.skip("hors depot git")
+    crlf = [line.split("\t")[-1] for line in out.stdout.splitlines()
+            if line.startswith("i/crlf")]
+    assert not crlf, f"blobs de registre en CRLF : {', '.join(crlf)}"


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/docs (#8710)

`check_twin_parity.py --update` promet un diff chirurgical. Il tient cette promesse **pendant le calcul** et la perd **a l'ecriture**, sur toutes les machines Windows.

## Le defaut

```python
pfile.write_text(new_raw, encoding="utf-8")
```

`Path.write_text` ouvre avec `newline=None`, ce qui traduit chaque `\n` en `os.linesep` — donc en `\r\n` sous Windows. Le fichier entier est reecrit en CRLF, y compris les lignes que `surgical_rebaseline` venait deliberement de laisser intactes.

La docstring de cette fonction dit, mesure a l'appui, pourquoi elle existe :

> Mesure firsthand sur le registre a 116 paires — un rebaseline d'UNE paire produisait `1108 insertions(+), 658 deletions(-)` […] Le vrai changement (4 lignes) devenait irreviewable.

C'est exactement ce qui se reproduisait, a une echelle plus petite et par un autre chemin. Constate aujourd'hui sur deux PRs, toutes deux des rebaselines d'**une seule** paire :

| PR | Diff affiche | Changement reel |
|---|---|---|
| #8709 | `+23/-16` | 1 SHA + 1 entree `known_differences` |
| #8713 | `+24/-16` sur deux fichiers | idem, par fichier |

Les `-16` sont les lignes inchangees, supprimees puis reajoutees en CRLF. La ligne qu'un relecteur doit reellement examiner — le SHA rebaseline — se retrouve noyee au milieu.

## Pourquoi ca n'avait jamais ete vu

Le defaut est invisible la ou `core.autocrlf=true` (ma machine, entre autres) : git renormalise en LF a l'ajout, le blob reste propre. Il n'apparait que la ou `autocrlf` est inactif, ou le CRLF part directement dans le blob. Un defaut qui ne se manifeste que sur une partie de la flotte voyage longtemps.

Et la suite de tests ne pouvait pas l'attraper : `test_diff_limited_to_target_block` et `test_noop_is_byte_identical` testent `surgical_rebaseline`, la fonction **pure**, sur des chaines. Elles passent sur toutes les plateformes meme quand le fichier ecrit sur disque est integralement reecrit. La garantie etait testee la ou elle tient et non appliquee la ou elle casse.

## Le correctif, en deux couches

**1. L'ecrivain.** `write_registry_text(path, text)` ouvre avec `newline=""` — aucune traduction, le texte part tel quel. Utilise aux deux sites d'ecriture (file-per-entry et mono-fichier legacy).

**2. `.gitattributes`.** `scripts/notebook_tools/twin_pairs.d/*.yaml text eol=lf`. La premiere couche corrige *cet* outil ; la seconde tient l'invariant pour **n'importe quel** ecrivain — un `Edit` sous Windows, un script ad-hoc, un futur outil. Le fichier documente deja ce motif sous le nom « L268 » (« the Edit tool on Windows flips LF->CRLF intermittently when no explicit eol rule is set »), avec cinq occurrences constatees ; le registre en est la sixieme, et le bloc de commentaire du registre existait deja pour l'accueillir.

## Tests

```
9 passed in 1.23s   (7 existants + 2 nouveaux)
```

- `test_write_preserves_lf_on_every_platform` — ecrit via `write_registry_text`, relit en **octets**, exige l'absence de `\r\n`.
- `test_registry_blobs_are_lf_only` — backstop : aucun blob du registre n'est en CRLF.

Ce second test interroge l'**index** (`git ls-files --eol`, colonne `i/`), pas le working tree. C'est le detail qui compte : ma premiere version testait les octets sur disque et echouait sur 130 fichiers parfaitement sains — avec `core.autocrlf=true`, un working tree en CRLF est *correct*, seul le blob doit etre en LF. Un test sur le disque aurait echoue sur toute machine Windows normalement configuree, pour un registre irreprochable. C'est la meme confusion de surface qui rend ce defaut difficile a voir.

## Effet sur les deux PRs en cours

Une fois cette PR sur `main`, #8709 et #8713 rebasees verront leurs YAML renormalises en LF au prochain `git add` — leur diff retombera aux deux lignes reelles sans effort de leur auteur. Je l'ai signale sur les deux.

## Perimetre

3 fichiers, +85/-2. Aucun notebook, aucun fichier de registre, catalogue byte-identique a `main`. Le comportement de `surgical_rebaseline` est inchange : cette PR corrige ce qu'on fait de son resultat.

See #8057
