### PR TITLE
fix(prover,#8722): proof-integrity enumerator strips comments + qualifies dotted names

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -23,6 +23,12 @@ import time
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+# Reuse the canonical Lean comment-stripper (handles nested ``/- -/`` blocks and
+# ``--`` line comments) rather than a second copy -- the sorry counter
+# (``count_real_sorries``) already proved this is the only honest way to exclude
+# docstring prose from a keyword scan (#6171, #8722 cause 2).
+from prover.lean_utils import strip_lean_comments
+
 
 def _to_wsl_path(win_path: str) -> str:
     """Convert ``C:\\foo\\bar`` to ``/mnt/c/foo/bar`` for use inside WSL bash."""
@@ -146,11 +152,25 @@ def _enumerate_module_declarations(project: Path, module_name: str) -> List[str]
     ``example`` (which may be anonymous) are intentionally excluded. Returns an
     empty list when the source file cannot be located -- callers MUST treat that
     as "gate cannot run" (fail-loud for the CI gate), never as "gate passed".
+
+    Two correctness fixes (#8722):
+
+    * **Comments are stripped first** via ``strip_lean_comments`` (the same
+      helper ``count_real_sorries`` uses). Docstring prose beginning at column 0
+      with ``theorem``/``lemma``/``def`` (e.g. ``/- lemma statement working for
+      *any* ... -/``) is no longer enumerated as a phantom declaration, which
+      produced ``#print axioms <unknown>`` errors that failed the whole module.
+
+    * **Names are always qualified by the namespace stack.** A dotted name
+      (``def Knot.crossingNumber``) declared inside ``namespace Knots`` is
+      ``Knots.Knot.crossingNumber`` in Lean 4 -- a dotted source name is NOT
+      already absolute. The only absolute prefix is ``_root_.``, which is
+      stripped so the emitted name is the true root-qualified identifier.
     """
     src = _module_source_path(project, module_name)
     if src is None:
         return []
-    text = src.read_text(encoding="utf-8", errors="replace")
+    text = strip_lean_comments(src.read_text(encoding="utf-8", errors="replace"))
     ns_stack: List[str] = []
     decls: List[str] = []
     for line in text.splitlines():
@@ -166,10 +186,17 @@ def _enumerate_module_declarations(project: Path, module_name: str) -> List[str]
         m = _DECL_HEAD_RE.match(line)
         if m:
             name = m.group("name")
-            if "." in name or not ns_stack:
-                decls.append(name)
-            else:
+            if name.startswith("_root_."):
+                # ``_root_.`` is the ONLY absolute prefix in Lean 4: it escapes
+                # the enclosing namespace. Strip it to emit the root identifier.
+                decls.append(name[len("_root_."):])
+            elif ns_stack:
+                # A dotted source name is still nested in the namespace stack --
+                # ``def Knot.crossingNumber`` in ``namespace Knots`` is
+                # ``Knots.Knot.crossingNumber`` (#8722 cause 1).
                 decls.append(".".join(ns_stack + [name]))
+            else:
+                decls.append(name)
     return decls
 
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
@@ -91,6 +91,73 @@ def test_enumeration_missing_source_returns_empty(tmp_path):
     assert _enumerate_module_declarations(tmp_path, "Does.Not.Exist") == []
 
 
+# ── #8722: the two defects that made the gate false-fail ──────────────────
+
+def test_enumeration_dotted_name_inside_namespace_is_qualified(tmp_path):
+    """#8722 cause 1: a dotted source name in a namespace is NOT absolute.
+
+    ``def Knot.crossingNumber`` written inside ``namespace Knots`` declares
+    ``Knots.Knot.crossingNumber`` -- the old ``if "." in name`` heuristic
+    emitted the bare ``Knot.crossingNumber`` (unknown to Lean), failing the
+    whole module's axiom check.
+    """
+    src = (
+        "namespace Knots\n"
+        "def Knot.crossingNumber (k : Nat) : Nat := 0\n"
+        "def KnotDiagram.edges (d : Nat) : List Nat := []\n"
+        "end Knots\n"
+    )
+    (tmp_path / "Knots").mkdir()
+    (tmp_path / "Knots" / "Basic.lean").write_text(src, encoding="utf-8")
+    decls = _enumerate_module_declarations(tmp_path, "Knots.Basic")
+    assert decls == ["Knots.Knot.crossingNumber", "Knots.KnotDiagram.edges"]
+
+
+def test_enumeration_ignores_docstring_prose_at_column_zero(tmp_path):
+    """#8722 cause 2: docstring prose starting with a decl keyword is a phantom.
+
+    A ``/- ... lemma statement working for *any* KnotDiagram ... -/`` block is
+    prose, not a declaration. Before comment-stripping it was enumerated as
+    ``Knots.statement`` (unknown), failing the module. The fix reuses
+    ``strip_lean_comments`` (same helper as ``count_real_sorries``, #6171).
+    """
+    src = (
+        "namespace Knots\n"
+        "/-! ## 13. Polymorphic section\n"
+        "\n"
+        "lemma statement working for *any* KnotDiagram whose well-formedness\n"
+        "theorem at the same time it proves it (the lemma + body are inseparable).\n"
+        "-/\n"
+        "theorem real_lemma : True := trivial\n"
+        "end Knots\n"
+    )
+    (tmp_path / "Knots").mkdir()
+    (tmp_path / "Knots" / "Basic.lean").write_text(src, encoding="utf-8")
+    decls = _enumerate_module_declarations(tmp_path, "Knots.Basic")
+    # The two prose lines ("lemma statement...", "theorem at the same time...")
+    # must NOT appear; only the real declaration survives, properly qualified.
+    assert decls == ["Knots.real_lemma"]
+
+
+def test_enumeration_root_prefix_strips_to_absolute(tmp_path):
+    """``_root_.`` is the ONLY absolute escape in Lean 4 (#8722 cause 1, edge).
+
+    ``def _root_.globalName`` inside any namespace still declares ``globalName``
+    at the root, unqualified.
+    """
+    src = (
+        "namespace Knots\n"
+        "def _root_.globalHelper : Nat := 0\n"
+        "def _root_.Outer.inner : Nat := 0\n"
+        "theorem local_thm : True := trivial\n"
+        "end Knots\n"
+    )
+    (tmp_path / "Knots").mkdir()
+    (tmp_path / "Knots" / "Basic.lean").write_text(src, encoding="utf-8")
+    decls = _enumerate_module_declarations(tmp_path, "Knots.Basic")
+    assert decls == ["globalHelper", "Outer.inner", "Knots.local_thm"]
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # _extract_axioms
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Grain: MED/lean-tooling — lane myia-po-2026:CoursIA — prev: MED/probas-dotnet (#8715)

## Summary

Fixe le gate `proof-integrity` (#8677) qui **false-failait** sur 3 modules de `knot_lean` (`Knots.Basic`, `Knots.Invariant`, `Knots.Reidemeister`) — non pas à cause d'une preuve, mais parce que `_enumerate_module_declarations` fabriquait des noms de déclaration inexistants. `#print axioms <nom-inconnu>` mettait le returncode à 1, et **un seul** nom fautif faisait échouer tout le module alors que toutes les déclarations réelles étaient propres.

Rendu visible par le `raw_output` tail ajouté en #8721 ; invisible avant.

Root cause (#8722) — **2 defects** dans `lean_server.py` :

1. **Heuristique de qualification fausse** (cause 1). L'ancien code `if "." in name or not ns_stack: decls.append(name)` supposait qu'un nom pointé (`def Knot.crossingNumber`) était « déjà qualifié ». Faux en Lean 4 : un nom pointé déclaré dans un namespace est **quand même** préfixé par ce namespace — `def Knot.crossingNumber` dans `namespace Knots` déclare `Knots.Knot.crossingNumber`. L'ancien émetteur produisait le bare `Knot.crossingNumber` (inconnu de Lean). Le seul préfixe absolu est `_root_.`.

2. **Commentaires non retirés avant le parse** (cause 2). `_DECL_HEAD_RE` était appliqué ligne à ligne sur la source **brute**. Toute prose de docstring commençant en colonne 0 par `theorem`/`lemma`/`def` était énumérée comme une déclaration fantôme (`Knots.statement`, `Knots.at`). C'est **exactement** le défaut déjà corrigé pour le comptage de sorries (`lean-knot.yml` est passé en `sorry-filter-mode: real` le 2026-07-11 pour la même raison, #6171).

## Fix (scope : `lean_server.py` uniquement, 0 `.lean`)

1. **Strip comments avant énumération** via `strip_lean_comments` (le helper canonique de `prover.lean_utils`, déjà utilisé par `count_real_sorries` — handles nested `/- -/` + `--`). On réutilise la logique existante plutôt que d'en écrire une seconde (leçon c.713).
2. **Toujours qualifier par la pile de namespaces** quand elle est non-vide ; `_root_.` est le seul préfixe absolu (strippé → identifiant root).

## Preuves

**Énumération réelle sur les 5 modules knot_lean** (source parsing, pas de build requis) :

| Module | Avant (bug) | Après (fix) | Phantoms |
|--------|-------------|-------------|----------|
| Knots.Basic | 37 (dont `Knot.crossingNumber`, `KnotDiagram.edges`, `Knots.statement`) | **36** | **0** |
| Knots.Invariant | 37 (dont `KnotDiagram.colorAtNat_comp`, `Knots.at`) | **34** | **0** |
| Knots.Reidemeister | 26 | **26** | **0** |
| Knots.Conway | 15 (déjà OK) | **15** | **0** |
| Knots.Lidman | 4 (déjà OK) | **4** | **0** |

Les noms jadis faux sont maintenant **correctement qualifiés** : `Knots.Knot.crossingNumber`, `Knots.KnotDiagram.colorAtNat_comp`, `Knots.Knot.mirror`, `Knots.Knot.isTricolorable` — correspondance exacte avec la colonne « réel » du tableau firsthand de #8722. Le compte est **stable-or-down** (les fantômes disparaissent, aucune sur-capture).

**Régression autres lakes** (acceptance #4) — énumération propre, 0 nom mal formé : `conway_lean` (Conway.Angel/CollatzLike), `calibration_lean` (Calibration.Doomsday/Nash), `sensitivity_lean` (Sensitivity.Hypercube). Le changement est correctness-monotone (le strip ne fait que retirer des fantômes ; la qualification ne fait que corriger des noms faux).

**Tests** : `python -m pytest tests/test_check_axioms.py tests/test_lean_utils.py -q` → **60 passed** (3 nouveaux tests épingleant les 3 formes + 19 existants inchangés + 38 lean_utils).

## Acceptance #8722

- [x] `check_axioms` ne produira plus d'`Unknown constant` — l'énumération émet les noms Lean réels (vérifié au niveau source vs la table firsthand de #8722 ; la résolution `#print axioms` canonique est confirmée par CI au prochain run du gate).
- [x] Test unitaire épingle les 3 formes : nom pointé dans un namespace, prose de docstring en colonne 0, `_root_.`.
- [x] Le compte de déclarations est stable-or-down (36≤37, 34≤37, autres =).
- [x] Les 4 autres modules cablés ne regressent pas (Conway/Lidman inchangés ; conway/calibration/sensitivity lakes propres).

## Note — hypothèse `_NS_CLOSE_RE` validée clean

#8722 soulevait l'hypothèse que `_NS_CLOSE_RE` dépilerait à tort sur `end <section>` (un `section Foo ... end Foo` n'ouvre pas de namespace). Validé firsthand sur knot_lean : **0** `section <Name>` dans les 5 modules ; le seul `end <Name>` est `end Knots` (correctement apparié à `namespace Knots`). Ce n'est pas un défaut établi — laissé inchangé pour éviter une régression sur un lake qui utiliserait `end` différemment.

## Débloque

#8723 (`figureEight_not_tricolorable` dépend de l'axiome `native_decide`). Tant que l'énumérateur produisait des constantes inconnues, `Knots.Invariant` échouait avant d'arriver au verdict d'axiome. Une fois ce fix mergé, le gate pourra confirmer en vert (ou révéler proprement le `native_decide` de #8723, traité séparément).

See #8722, #8677, #8712, #8723.

Co-Authored-By: Claude <noreply@anthropic.com>
