### PR TITLE
fix(lean-tooling,#8722): axiom gate imports on a bare runner, `end` pops only on a match, `private` skipped

### DIFF
--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -52,6 +52,14 @@ on:
       - '.github/workflows/lean-knot.yml'
       - '.github/workflows/lean-axiom.yml'
       - '.github/workflows/lean-build.yml'
+      # ...and the gate is not only its YAML. The axiom step is a Python
+      # program whose whole body is `from lean_server import LeanVerifier`,
+      # so lean_server.py (and the helper it loads) ARE gate inputs. Omitting
+      # them reopened #8712 one layer down: #8725 edited the enumerator, no
+      # path matched, the gate never ran on the PR, and an import that dies on
+      # a bare runner reached main unobserved (#8727).
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py'
   pull_request:
     branches: [main]
     paths:
@@ -62,6 +70,8 @@ on:
       - '.github/workflows/lean-knot.yml'
       - '.github/workflows/lean-axiom.yml'
       - '.github/workflows/lean-build.yml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -57,7 +57,7 @@ on:
       # so lean_server.py (and the helper it loads) ARE gate inputs. Omitting
       # them reopened #8712 one layer down: #8725 edited the enumerator, no
       # path matched, the gate never ran on the PR, and an import that dies on
-      # a bare runner reached main unobserved (#8727).
+      # a bare runner reached main unobserved (#8722).
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py'
   pull_request:

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -28,7 +28,7 @@ from typing import Dict, List, Optional, Tuple
 # (``count_real_sorries``) already proved this is the only honest way to exclude
 # docstring prose from a keyword scan (#6171, #8722 cause 2).
 #
-# Loaded LAZILY, by direct path, on purpose (#8727). ``from prover.lean_utils
+# Loaded LAZILY, by direct path, on purpose (#8722). ``from prover.lean_utils
 # import ...`` executes ``prover/__init__.py`` first, which imports the prover
 # agents -- ``agent_framework``, the OpenAI client, ~1250 modules. The
 # proof-integrity CI gate (.github/workflows/lean-axiom.yml) does nothing but
@@ -191,9 +191,13 @@ def _enumerate_module_declarations(project: Path, module_name: str) -> List[str]
       already absolute. The only absolute prefix is ``_root_.``, which is
       stripped so the emitted name is the true root-qualified identifier.
 
-    * **``end`` pops only on a name match** (#8727). ``namespace`` is the only
+    * **``end`` pops only on a name match** (#8722). ``namespace`` is the only
       construct pushed, but ``end`` closes others (``section``); an unmatched
       ``end`` used to pop anyway and under-qualify the whole rest of the file.
+      Live instance: ``game_theory_lean/SocialChoice/Voting.lean`` opens
+      ``namespace SocialChoice`` (l.36) then ``section SinglePeaked`` (l.177);
+      ``end SinglePeaked`` (l.513) emptied the stack, so ``section BanksSet``
+      (l.661+) and everything after it was emitted unqualified.
     """
     src = _module_source_path(project, module_name)
     if src is None:
@@ -211,7 +215,7 @@ def _enumerate_module_declarations(project: Path, module_name: str) -> List[str]
         m_close = _NS_CLOSE_RE.match(line)
         if m_close:
             # Pop only when the ``end`` names the namespace actually on top
-            # (#8727). ``namespace`` is the ONLY construct we push, but ``end``
+            # (#8722). ``namespace`` is the ONLY construct we push, but ``end``
             # closes several others -- ``section Foo``, and any ``end`` that
             # survives comment stripping. Popping unconditionally lets one such
             # line unbalance the stack, and every declaration after it is

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -133,7 +133,7 @@ def _find_lake_root(start: Path) -> Optional[Path]:
 # emitted fully qualified. See pr-review-discipline.md §B.3 / issue #8677.
 _DECL_HEAD_RE = re.compile(
     r"^(?:@\[[^\]]*\]\s*)*"                                     # attributes (zero or more)
-    r"(?:(?:private|protected|noncomputable|unsafe|partial|abstract)\s+)*"
+    r"(?P<mods>(?:(?:private|protected|noncomputable|unsafe|partial|abstract)\s+)*)"
     r"(?:theorem|lemma|def|opaque|axiom|abbrev|structure|inductive|class)\s+"
     r"(?P<name>[A-Za-z_][A-Za-z0-9_'.]*)",
     re.MULTILINE,
@@ -198,6 +198,13 @@ def _enumerate_module_declarations(project: Path, module_name: str) -> List[str]
       ``namespace SocialChoice`` (l.36) then ``section SinglePeaked`` (l.177);
       ``end SinglePeaked`` (l.513) emptied the stack, so ``section BanksSet``
       (l.661+) and everything after it was emitted unqualified.
+
+    * **``private`` declarations are skipped** (#8722). Lean 4 mangles a private
+      name to ``_private.<Module>.<hash>.<name>``, so its source name is not a
+      resolvable constant; emitting it fails the whole module. Their axioms are
+      still counted, transitively, via the public declarations that use them.
+      Live instance: ``Knots.Invariant`` (``mem_set_fwd``, ``mem_drop_out``,
+      ``mem_set_self``).
     """
     src = _module_source_path(project, module_name)
     if src is None:
@@ -228,6 +235,18 @@ def _enumerate_module_declarations(project: Path, module_name: str) -> List[str]
             continue
         m = _DECL_HEAD_RE.match(line)
         if m:
+            if "private" in m.group("mods"):
+                # A ``private`` declaration is NOT addressable by its source name
+                # (#8722). Lean 4 mangles it to ``_private.<Module>.<hash>.<name>``,
+                # so ``#print axioms Knots.mem_set_fwd`` answers ``unknown
+                # constant`` and takes the WHOLE module's verdict down with it --
+                # observed on Knots.Invariant (mem_set_fwd / mem_drop_out /
+                # mem_set_self), which reported ``build_failed_returncode_1``
+                # while every public theorem in it had checked out fine.
+                # Nothing is lost by skipping them: a private lemma reaches the
+                # kernel only through the public theorems that use it, and those
+                # are enumerated, so its axioms are still counted transitively.
+                continue
             name = m.group("name")
             if name.startswith("_root_."):
                 # ``_root_.`` is the ONLY absolute prefix in Lean 4: it escapes

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -27,7 +27,31 @@ from typing import Dict, List, Optional, Tuple
 # ``--`` line comments) rather than a second copy -- the sorry counter
 # (``count_real_sorries``) already proved this is the only honest way to exclude
 # docstring prose from a keyword scan (#6171, #8722 cause 2).
-from prover.lean_utils import strip_lean_comments
+#
+# Loaded LAZILY, by direct path, on purpose (#8727). ``from prover.lean_utils
+# import ...`` executes ``prover/__init__.py`` first, which imports the prover
+# agents -- ``agent_framework``, the OpenAI client, ~1250 modules. The
+# proof-integrity CI gate (.github/workflows/lean-axiom.yml) does nothing but
+# ``from lean_server import LeanVerifier`` on a bare ``setup-python`` runner
+# with no ``pip install`` step, so the eager form makes the gate die with
+# ``ModuleNotFoundError: No module named 'agent_framework'`` before it can check
+# a single axiom. Reaching the file directly keeps the one-copy guarantee
+# without dragging the agent stack into a gate that only parses text.
+_strip_lean_comments = None
+_LEAN_UTILS_PATH = Path(__file__).resolve().parent / "prover" / "lean_utils.py"
+
+
+def _get_strip_lean_comments():
+    """Return ``prover.lean_utils.strip_lean_comments``, loaded on first use."""
+    global _strip_lean_comments
+    if _strip_lean_comments is None:
+        import importlib.util as ilu
+
+        spec = ilu.spec_from_file_location("_lean_utils_strip_only", _LEAN_UTILS_PATH)
+        mod = ilu.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        _strip_lean_comments = mod.strip_lean_comments
+    return _strip_lean_comments
 
 
 def _to_wsl_path(win_path: str) -> str:
@@ -166,11 +190,17 @@ def _enumerate_module_declarations(project: Path, module_name: str) -> List[str]
       ``Knots.Knot.crossingNumber`` in Lean 4 -- a dotted source name is NOT
       already absolute. The only absolute prefix is ``_root_.``, which is
       stripped so the emitted name is the true root-qualified identifier.
+
+    * **``end`` pops only on a name match** (#8727). ``namespace`` is the only
+      construct pushed, but ``end`` closes others (``section``); an unmatched
+      ``end`` used to pop anyway and under-qualify the whole rest of the file.
     """
     src = _module_source_path(project, module_name)
     if src is None:
         return []
-    text = strip_lean_comments(src.read_text(encoding="utf-8", errors="replace"))
+    text = _get_strip_lean_comments()(
+        src.read_text(encoding="utf-8", errors="replace")
+    )
     ns_stack: List[str] = []
     decls: List[str] = []
     for line in text.splitlines():
@@ -180,7 +210,16 @@ def _enumerate_module_declarations(project: Path, module_name: str) -> List[str]
             continue
         m_close = _NS_CLOSE_RE.match(line)
         if m_close:
-            if ns_stack:
+            # Pop only when the ``end`` names the namespace actually on top
+            # (#8727). ``namespace`` is the ONLY construct we push, but ``end``
+            # closes several others -- ``section Foo``, and any ``end`` that
+            # survives comment stripping. Popping unconditionally lets one such
+            # line unbalance the stack, and every declaration after it is
+            # emitted under-qualified: on ``namespace Outer / namespace Inner``,
+            # a stray ``end Other`` turned ``Outer.Inner.still_inner`` into
+            # ``Outer.still_inner``, which ``#print axioms`` reports as an
+            # unknown constant -- failing the whole module for a typo.
+            if ns_stack and ns_stack[-1] == m_close.group("ns"):
                 ns_stack.pop()
             continue
         m = _DECL_HEAD_RE.match(line)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
@@ -158,6 +158,38 @@ def test_enumeration_root_prefix_strips_to_absolute(tmp_path):
     assert decls == ["globalHelper", "Outer.inner", "Knots.local_thm"]
 
 
+def test_enumeration_end_pops_only_on_a_name_match(tmp_path):
+    """An unmatched ``end`` must NOT pop the namespace stack (#8727).
+
+    ``namespace`` is the only construct the enumerator pushes, but ``end``
+    closes others too (``section Foo ... end Foo``), and one can survive
+    comment stripping. Popping unconditionally unbalances the stack and
+    under-qualifies every declaration that follows -- which ``#print axioms``
+    then reports as an unknown constant, failing the whole module.
+
+    Authored by po-2023:CoursIA-2 in #8726; carried here after #8725 shipped
+    the same repair without this case.
+    """
+    src = (
+        "namespace Outer\n"
+        "namespace Inner\n"
+        "theorem deep : True := trivial\n"
+        "end Other\n"  # closes nothing we opened -- must not pop Inner
+        "theorem still_inner : True := trivial\n"
+        "end Inner\n"
+        "theorem back_in_outer : True := trivial\n"
+        "end Outer\n"
+    )
+    (tmp_path / "Knots").mkdir()
+    (tmp_path / "Knots" / "Basic.lean").write_text(src, encoding="utf-8")
+    decls = _enumerate_module_declarations(tmp_path, "Knots.Basic")
+    assert decls == [
+        "Outer.Inner.deep",
+        "Outer.Inner.still_inner",
+        "Outer.back_in_outer",
+    ]
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # _extract_axioms
 # ──────────────────────────────────────────────────────────────────────────

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
@@ -159,7 +159,7 @@ def test_enumeration_root_prefix_strips_to_absolute(tmp_path):
 
 
 def test_enumeration_end_pops_only_on_a_name_match(tmp_path):
-    """An unmatched ``end`` must NOT pop the namespace stack (#8727).
+    """An unmatched ``end`` must NOT pop the namespace stack (#8722).
 
     ``namespace`` is the only construct the enumerator pushes, but ``end``
     closes others too (``section Foo ... end Foo``), and one can survive

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
@@ -190,6 +190,33 @@ def test_enumeration_end_pops_only_on_a_name_match(tmp_path):
     ]
 
 
+def test_enumeration_skips_private_declarations(tmp_path):
+    """``private`` names are not addressable, so they must not be emitted (#8722).
+
+    Lean 4 mangles a private declaration to ``_private.<Module>.<hash>.<name>``.
+    Emitting the source name makes ``#print axioms`` answer ``unknown constant``
+    and fails the ENTIRE module -- observed on ``Knots.Invariant``, whose three
+    private list helpers (``mem_set_fwd``, ``mem_drop_out``, ``mem_set_self``)
+    sank a module in which every public theorem had checked out fine.
+
+    The other modifiers must keep working: ``protected``/``noncomputable``/
+    ``partial`` names stay addressable and must still be enumerated.
+    """
+    src = (
+        "namespace Knots\n"
+        "private theorem mem_set_fwd : True := trivial\n"
+        "theorem public_thm : True := trivial\n"
+        "private noncomputable def hidden : Nat := 0\n"
+        "protected theorem prot_thm : True := trivial\n"
+        "noncomputable def slow : Nat := 0\n"
+        "end Knots\n"
+    )
+    (tmp_path / "Knots").mkdir()
+    (tmp_path / "Knots" / "Basic.lean").write_text(src, encoding="utf-8")
+    decls = _enumerate_module_declarations(tmp_path, "Knots.Basic")
+    assert decls == ["Knots.public_thm", "Knots.prot_thm", "Knots.slow"]
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # _extract_axioms
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
`Grain: DEEP/lean-ci-tooling — lane myia-ai-01:CoursIA — prev: MED/ci (#8721)`

I merged #8725 for #8722 and shipped two defects with it. #8726 — opened in parallel by `po-2023:CoursIA-2`, because my own dispatch error put two lanes on the same grain — had caught both. This completes #8725 rather than reverting it, and carries their work forward with credit.

## 1. The gate could not start on a clean runner

#8725 added a **top-level** `from prover.lean_utils import strip_lean_comments`. That executes `prover/__init__.py` first, which imports the prover agents:

```
import prover  ->  agent_framework, agent_framework._clients, ... (1255 modules)
```

`lean-axiom.yml` uses `setup-python@v5` with **no `pip install` step**, and the entire body of its check is `from lean_server import LeanVerifier`. Reproduced with `agent_framework`/`openai` blocked at the import hook, exactly as a fresh runner presents them:

```
ModuleNotFoundError: No module named 'agent_framework'
-> the proof-integrity gate FAILS on a runner without agent_framework
```

The gate would not have failed *a check* — it would have died before checking a single axiom. Fixed by loading the stripper lazily, by direct path: still one copy of the comment-stripping logic (the #6171 lesson holds), without dragging the agent stack into a gate that only parses text.

## 2. `end` popped the namespace stack even when it closed something else

`namespace` is the only construct the enumerator pushes, but `end` closes others. **This is live in `game_theory_lean`, not hypothetical** — `SocialChoice/Voting.lean`:

```
 36: namespace SocialChoice     <- pushed
177: section SinglePeaked       <- not pushed (correctly)
513: end SinglePeaked           <- popped SocialChoice anyway; stack now empty
661: section BanksSet
...  every declaration from 513 on emitted unqualified
```

so `banks_set` was emitted instead of `SocialChoice.banks_set` — which `#print axioms` reports as an unknown constant, failing the whole module. **6 modules** affected (`CooperativeGames.Basic`, `SocialChoice.Voting`, `StableMarriage.GSState` and their `_en` siblings). knot_lean, the current pilot, happens not to use `section` — which is why the gate's first wiring didn't reveal it.

I raised this in #8722 as *"a hypothesis to validate, not an established defect"*. It is now established, with the line numbers above.

## 3. `lean_server.py` was not a CI path filter

`lean-knot.yml` lists the three workflow files under a comment explaining that *"a change to the gate must run the gate"* (#8712). But the axiom step is a Python program whose whole body imports `lean_server` — so `lean_server.py` **is** a gate input. It wasn't listed, so #8725 edited the enumerator, no path matched, and the gate never ran on the PR that broke it. That is #8712 one layer down. Added `lean_server.py` and `prover/lean_utils.py` to both the `push` and `pull_request` filters.

## Verification

| Check | Result |
|---|---|
| Import with `agent_framework`/`openai` blocked | OK — and stripping + qualification still correct through the lazy loader |
| `pytest tests/test_check_axioms.py` | 23/23 |
| Enumeration sweep, 10 lakes | 219 modules, 3028 declarations, **0 malformed** |
| Enumeration diff vs `main` | exactly **6** modules changed, each from an unqualified name to the correctly qualified one — no other declaration moves |

The last row is the one that matters: the `end` fix is a strict improvement, not a behaviour change. Every name it alters was previously wrong.

## Credit

`test_enumeration_end_pops_only_on_a_name_match` is `po-2023:CoursIA-2`'s test from #8726, adapted to the `tmp_path` fixture used by its neighbours. Their diagnosis of the import problem was right and mine was wrong; #8726 was closed as a duplicate on my instruction, which it was not.

See #8722, #8677, #8712.


---

## 4. `private` declarations are not addressable — found by the gate this PR re-enabled

Adding `lean_server.py` to the path filters had an immediate payoff: `proof-integrity` ran on this branch for the first time and **failed**, on a defect neither #8725 nor #8726 had.

```
--- Module Knots.Invariant ---
  error: build_failed_returncode_1
  | error(lean.unknownIdentifier): Unknown constant `Knots.mem_set_fwd`
  | error(lean.unknownIdentifier): Unknown constant `Knots.mem_drop_out`
  | error(lean.unknownIdentifier): Unknown constant `Knots.mem_set_self`
```

The three are `private theorem`s (`Invariant.lean:746/770/798`). Lean 4 mangles a private name to `_private.<Module>.<hash>.<name>`, so the source name is not a resolvable constant. The enumerator consumed `private` as a modifier and emitted the bare name anyway — and **one** unknown constant takes the whole module's verdict down, while every public theorem in `Knots.Invariant` had checked out fine.

Nothing is lost by skipping them: a private lemma reaches the kernel only through the public declarations that use it, and those are enumerated, so its axioms are still counted transitively.

**Firsthand impact across all 10 lakes / 321 modules / 3673 declarations emitted:** 110 private declarations skipped, **0 leaks** — no private name still emitted, no non-private name dropped. This was never a knot_lean quirk; it hits 6 lakes (`conway_lean` 42, `game_theory_lean` 58, `decision_theory_lean` 4, `knot_lean` 6, counting `_en` siblings). Each would have failed identically as the gate rolls out lake by lake.

`protected` / `noncomputable` / `partial` / `unsafe` / `abstract` stay enumerated — those names remain addressable. Covered by a fifth test.

## Note on the in-code issue references

The first commit wrote `#8727` in five comments, on the assumption that this PR would take that number. It did not — #8727 is `po-2023:CoursIA-2`'s guard fix on `10_LocalLlama.ipynb`, since merged. Re-anchored on **#8722**: the issue outlives PR numbers, a guessed number does not.

## Verification

| Check | Result |
|---|---|
| `pytest tests/test_check_axioms.py` | **24/24 pass** |
| Bare-runner import (agent_framework/openai blocked) | **imports OK**, enumerates `['Knots.Knot.crossingNumber']` |
| Enumeration diff vs main, 10 lakes / 219 modules / 3028 decls (`end` fix) | exactly **6 modules** changed, every one wrong-unqualified -> correct-qualified |
| Private-skip impact, 10 lakes / 321 modules | **110 skipped, 0 leaks** |
| `proof-integrity` on this branch | ran (thanks to the path filter) and **caught defect 4** |
