### PR TITLE
docs(probas,#8705): Infer-101 README — harmonize to the C#/.NET truth

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -155,7 +155,7 @@ Pour les étudiants en recherche opérationnelle ou finance :
 
 #### Parcours rapide Python (standalone, ~2h)
 
-Si vous préférez Python au C#, commencez par Infer-101.ipynb (introduction standalone avec modèles Two Coins et Cyclist) puis Pyro_RSA_Hyperbole.ipynb (application à la linguistique pragmatique avec le framework RSA).
+Si vous préférez Python au C#, commencez par **PyMC-1-Setup** (introduction standalone en Python, premier modèle Two Coins) puis Pyro_RSA_Hyperbole.ipynb (application à la linguistique pragmatique avec le framework RSA). Infer-101.ipynb est également une introduction standalone, mais en **C#/.NET** (voir la table « Notebooks racine » ci-dessous).
 
 #### Parcours PyMC complet (26 notebooks, ~17h)
 
@@ -214,7 +214,7 @@ Deux stacks, un même parcours de 20 modèles : **Infer.NET** (C#, message passi
 
 ```
 Probas/
-├── Infer-101.ipynb              # Introduction Python/C# (standalone)
+├── Infer-101.ipynb              # Introduction C#/.NET (standalone)
 ├── Pyro_RSA_Hyperbole.ipynb     # Pragmatique linguistique (Python)
 ├── GeneratedSource/             # Sources Infer.NET compilées (Model0_EP.cs ... Model10_VMP.cs)
 ├── PyMC/                # Port PyMC : bayésien + causal (1-13, dont PyMC-5 causal) + séquences/reco/GP (14-16) + frontières (17-19)
@@ -467,7 +467,7 @@ cd MyIA.AI.Notebooks/Probas/Infer/scripts
 .\setup_environment.ps1
 ```
 
-### Notebooks Python (Infer-101, Pyro_RSA)
+### Notebooks Python (Pyro_RSA)
 
 ```bash
 pip install pyro-ppl torch matplotlib numpy
@@ -549,9 +549,9 @@ La visualisation des factor graphs nécessite **Graphviz installé**. Si `dot` n
 - Vous pouvez les visualiser sur [viz-js.com](https://viz-js.com/) ou [edotor.net](https://edotor.net/).
 - Installation Graphviz Windows : télécharger depuis https://graphviz.org/download/, puis ajouter `C:\Program Files\Graphviz\bin` au PATH.
 
-### Switcher entre kernels C# et Python dans un même notebook
+### Kernels : un par sous-série, jamais mélangés
 
-Le notebook `Infer-101.ipynb` est le seul à mélanger les deux kernels. Il utilise le mode **polyglot** de .NET Interactive, où chaque cellule spécifie son kernel via le tag `#kernel name`. Pour la série standard, chaque sous-série (Infer/ ou PyMC/) utilise un seul kernel.
+Chaque notebook de la série Probas utilise un **unique kernel** : `.NET (C#)` pour `Infer/` et `Infer-101`, `Python 3` pour `PyMC/` et `Pyro_RSA`. Aucun notebook ne mélange les deux kernels. (Historiquement, `Infer-101` avait été rédigé en mode polyglot .NET Interactive avec des cellules `#kernel` par langage ; ce n'est plus le cas — il est aujourd'hui un notebook C#/.NET autonome.)
 
 ### PyMC : échantillonnage très lent ou divergence NUTS
 


### PR DESCRIPTION
**Grain: po-2023:CoursIA** · docs/markdown-honesty · See #8705 · See #8081

## Summary

Resolves the internal contradiction of the Probas README about Infer-101's nature. Firsthand verification of the notebook settles it: **Infer-101 is NOT polyglot today** — declared kernel `.NET (C#)`, 28 code cells, 0 Python cells, 0 `#!kernel` magic tags. It was polyglot in the past (commit `a7848f075` touched a `#!python` cell), but that is no longer the case.

## Premise inversion (transparency for ai-01)

The grain as received framed the contradiction as "the README is inconsistent *because* Infer-101 IS polyglot — the tables just don't say so." Firsthand, that premise is false. The two tables (L.297, L.407: `| Infer-101 | .NET (C#) |`) tell the truth; four prose claims were the false ones. The honest harmonization therefore points **toward** the tables' truth, not away from it.

If restoring the polyglot design (adding Python cells to Infer-101) is preferred, that is a code-scope change (re-execution, C.2) outside this markdown PR — flagging for the coordinator to decide.

## Changes (markdown-only, +5/-5, single file)

1. **L.158** — routed Python-preferring readers to Infer-101 (a C# notebook). Now routes them to **PyMC-1-Setup** (a real Python standalone, same Two-Coins first model), with a note that Infer-101 is the C# standalone.
2. **L.217** — tree comment `Introduction Python/C#` → `Introduction C#/.NET`.
3. **L.470** — section `Notebooks Python (Infer-101, Pyro_RSA)` → `Notebooks Python (Pyro_RSA)` (Infer-101 is not Python).
4. **L.554** — paragraph "le seul à mélanger les deux kernels / polyglot / #kernel tag" was false. Rewritten: one kernel per notebook, no mixing, with a historical note on the former polyglot design.

## Firsthand evidence

```
Infer-101.ipynb: cells=71 (md=43, code=28)
declared kernel: .net-csharp / display .NET (C#)
cells with #!python magic: 0
cells with #!csharp/#!fsharp/#!pwsh magic: 0
```

## Hygiene

- Markdown-only, +5/-5, single file. No links changed (navlinks intact).
- No CATALOG-STATUS touched (catalogue byte-identical to main).
- New routing target PyMC-1-Setup.ipynb verified to exist.

Co-Authored-By: Claude <noreply@anthropic.com>
