### PR TITLE
fix(lean,#8723): eliminate native_decide axiom (kernel decide + maxRecDepth)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -86,7 +86,7 @@ inductive TriColor where
   deriving BEq, DecidableEq, Repr
 
 /-- `TriColor` est un type à trois éléments, donc un `Fintype` : nécessaire pour
-décider par énumération finie (`native_decide`) l'existentiel
+décider par énumération finie (`decide`) l'existentiel
 `∃ coloring : Fin n → TriColor, …` dans `figureEight_not_tricolorable`. Sans cette
 instance, `Fintype (Fin n → TriColor)` (via `Pi.fintype`) ne se synthétise pas et
 `decide`/`native_decide` échouent en amont de toute réduction. -/
@@ -236,7 +236,7 @@ def Knot.isTricolorable (k : Knot) : Prop :=
 
 La tricolorabilité d'un diagramme fini est décidable : chaque couche prédicative
 reçoit une instance `Decidable` nommée, de sorte que la synthèse au point d'usage
-(`native_decide` dans `figureEight_not_tricolorable`) reste peu profonde. Sans cette
+(`decide` dans `figureEight_not_tricolorable`) reste peu profonde. Sans cette
 décomposition, une seule synthèse monolithique doit enchaîner `List.decidableBAll`,
 plusieurs `And.decidable`, les `DecidableEq TriColor` des `dite` de coloriage, et
 l'énumération `Fintype (Fin n → TriColor)` — ce qui épuise le budget de synthèse
@@ -1039,19 +1039,24 @@ d'arc-égalité `c₂ = c₄`), c'est le témoin de distinction canonique : le m
 permissif antérieur laissait passer une tricoloration parasite `(0,0,0,1,0,0,1,2)`
 (README §Path B), que la contrainte d'arc exclut désormais.
 
-Preuve par énumération finie (`native_decide`) : l'espace des coloriages
+Preuve par énumération finie (`decide` noyau) : l'espace des coloriages
 `Fin 8 → TriColor` (3⁸ = 6561) est parcouru, et pour chacun la conjonction
 d'arc-égalité + Fox aux 4 croisements est réfutée — soit l'arc-continuité casse,
-soit Fox force le monochrome (contredisant « ≥ 2 couleurs »). On emploie
-`native_decide` (et non `decide`) : l'existentiel porte sur le type-fonction
-`Fin 8 → TriColor`, dont l'instance `Decidable` repose sur `Fintype.piFinset` ; le
-noyau ne réduit pas cette énumération (`decide` échoue avec « did not reduce to
-'isTrue' or 'isFalse' »), là où l'évaluateur natif la traite en quelques ms —
-même outil que les lemmes de calibration finie de `conway_lean/Angel.lean`.
-Témoin de non-régression Path B (#2874). -/
+soit Fox force le monochrome (contredisant « ≥ 2 couleurs »). On emploie `decide`
+(et non `native_decide`) : l'existentiel porte sur le type-fonction
+`Fin 8 → TriColor`, dont l'instance `Decidable` repose sur `Fintype.piFinset`. La
+réduction noyau de cette énumération dépasse la profondeur de récursion par
+défaut (échec `maximum recursion depth has been reached`), on lève donc la
+limite via `set_option maxRecDepth 100000` — le `decide` termine alors en ~33s.
+C'est strictement préférable à `native_decide` : le **noyau vérifie** le
+résultat plutôt que de déléguer au compilateur C / runtime (le TCB reste Lean,
+pas `native_decide.ax`), et `#print axioms` ne relève plus que
+`[propext, Classical.choice, Quot.sound]`. Voir #8723. Témoin de
+non-régression Path B (#2874). -/
 theorem figureEight_not_tricolorable : ¬ Knot.isTricolorable figureEight := by
   unfold Knot.isTricolorable
-  native_decide
+  set_option maxRecDepth 100000 in
+  decide
 
 /-! ## 5. Corollary: the trefoil is not the unknot
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
@@ -49,7 +49,7 @@ inductive TriColor where
   deriving BEq, DecidableEq, Repr
 
 /-- `TriColor` is a three-element type, hence a `Fintype`: needed to decide, by
-finite enumeration (`native_decide`), the existential
+finite enumeration (`decide`), the existential
 `∃ coloring : Fin n → TriColor, …` in `figureEight_not_tricolorable`. Without this
 instance, `Fintype (Fin n → TriColor)` (via `Pi.fintype`) fails to synthesize and
 `decide`/`native_decide` fail before any reduction. -/
@@ -198,7 +198,7 @@ def Knot.isTricolorable (k : Knot) : Prop :=
 /-! ### Decidability of tricolorability (finite enumeration)
 
 Tricolorability of a finite diagram is decidable: each predicate layer receives a
-named `Decidable` instance, so that synthesis at the use site (`native_decide` in
+named `Decidable` instance, so that synthesis at the use site (`decide` in
 `figureEight_not_tricolorable`) stays shallow. Without this decomposition, a single
 monolithic synthesis must chain `List.decidableBAll`, several `And.decidable`, the
 `DecidableEq TriColor` of the coloring `dite`s, and the `Fintype (Fin n →
@@ -1002,19 +1002,24 @@ continuity conjunct), this is the canonical distinguishing witness: the earlier
 permissive model admitted a spurious tricoloring `(0,0,0,1,0,0,1,2)` (README
 §Path B), which the arc constraint now excludes.
 
-Proof by finite enumeration (`native_decide`): the coloring space
+Proof by finite enumeration (kernel `decide`): the coloring space
 `Fin 8 → TriColor` (3⁸ = 6561) is exhausted, and for each the arc-continuity +
 Fox conjunction at all 4 crossings is refuted — either arc-continuity breaks, or
-Fox forces monochrome (contradicting "≥ 2 colors"). We use `native_decide` (not
-`decide`): the existential ranges over the function type `Fin 8 → TriColor`, whose
-`Decidable` instance rests on `Fintype.piFinset`; the kernel does not reduce that
-enumeration (`decide` fails with "did not reduce to 'isTrue' or 'isFalse'"),
-whereas the native evaluator handles it in a few ms — the same tool used by the
-finite-calibration lemmas in `conway_lean/Angel.lean`. Path-B non-regression
+Fox forces monochrome (contradicting "≥ 2 colors"). We use `decide` (not
+`native_decide`): the existential ranges over the function type `Fin 8 → TriColor`,
+whose `Decidable` instance rests on `Fintype.piFinset`. The kernel reduction of
+this enumeration exceeds the default recursion depth (failure
+`maximum recursion depth has been reached`), so the limit is raised via
+`set_option maxRecDepth 100000` — `decide` then terminates in ~33s. This is
+strictly preferable to `native_decide`: the **kernel verifies** the result rather
+than delegating to the C compiler / runtime (the TCB stays Lean, not
+`native_decide.ax`), and `#print axioms` now reports only
+`[propext, Classical.choice, Quot.sound]`. See #8723. Path-B non-regression
 witness (#2874). -/
 theorem figureEight_not_tricolorable : ¬ Knot.isTricolorable figureEight := by
   unfold Knot.isTricolorable
-  native_decide
+  set_option maxRecDepth 100000 in
+  decide
 
 /-! ## 5. Corollary: the trefoil is not the unknot
 


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA — prev: MED/lean-tooling (#8725)

## Summary

Élimine l'axiome `native_decide` de `Knots.figureEight_not_tricolorable` (**#8723, option 1**). La preuve déléguait la vérification au compilateur C-backend via `native_decide` (TCB = runtime, pas noyau Lean) ; elle est désormais vérifiée **à l'intérieur du noyau** par `decide`.

Débloquée par #8725 (l'énumérateur d'axiomes déréférencé, merged `2127f8c36`) — sans ce fix, le gate `proof-integrity` échouait avant d'arriver au verdict d'axiome.

## Chemin pris — option 1 (`decide` noyau), mesurée avant conclusion

Le point d'entrée de #8723 est explicite : « Si le `decide` noyau termine dans un temps acceptable, c'est strictement mieux. **A mesurer avant de conclure.** » Mesuré firsthand :

| Variante | Résultat |
|----------|----------|
| `native_decide` (avant) | OK, mais axiome `_native.native_decide.ax_1_1` ajouté (TCB = compilateur) |
| `decide` nu | **ÉCHEC** : `maximum recursion depth has been reached` |
| `set_option maxRecDepth 100000 in decide` (retenu) | **OK en ~33s**, zéro axiome ajouté |

**Correctif de docstring** : l'ancienne docstring affirmait que le `decide` noyau échouait avec « did not reduce to 'isTrue' or 'isFalse' » — c'était **inexact**. L'échec réel est un **débordement de profondeur de récursion** lors de la réduction de l'énumération `Fintype.piFinset` sur `Fin 8 → TriColor` (3⁸ = 6561 coloriages). Lever `maxRecDepth` à 100000 laisse la réduction terminer. La docstring (FR + EN) reflète désormais la cause réelle mesurée.

## Preuve — `#print axioms` (avant → après)

```
-- AVANT
'Knots.figureEight_not_tricolorable' depends on axioms:
  [propext, Classical.choice, Quot.sound,
   Knots.figureEight_not_tricolorable._native.native_decide.ax_1_1]

-- APRÈS
'Knots.figureEight_not_tricolorable' depends on axioms:
  [propext, Classical.choice, Quot.sound]
```

L'axiome `native_decide.ax_1_1` est **éliminé**. La voisine propre reste intacte :

```
'Knots.unknot_not_tricolorable' depends on axioms: [propext, Quot.sound]   -- inchangée
```

Le sibling EN (`Knots_en.figureEight_not_tricolorable`) est lui aussi clean : `[propext, Classical.choice, Quot.sound]`.

## Acceptance #8723

- [x] **Chemin 1 pris, avec la mesure qui le justifie** : bare `decide` mesuré → échec recursion-depth ; `maxRecDepth 100000` → succès ~33s ; axiome éliminé. (Options 2 et 3 écartées : 2 inutile car 1 termine en temps acceptable ; 3 inutile car 1 résout sans assumer d'axiome.)
- [x] **`lake build` SUCCESS** : 2959/2959 jobs, knot_lean complet, aucune régression.
- [x] **`grep -c sorry` inchangé** : `Invariant.lean` 7 (avant=après), `Invariant_en.lean` 6 (avant=après). Le changement est `native_decide → decide`, **orthogonal au compte de sorry** (figureEight n'a jamais utilisé `sorry`).
- [x] **Aucune preuve voisine touchée** : seul le théorème `figureEight_not_tricolorable` (FR + EN sibling) et ses docstrings/références incidentes. `unknot_not_tricolorable` et toutes les autres preuves inchangées (vérifié par `git diff` hunk-headers).

## Vérification anti-régression (§D / pr-review-discipline §B)

- `grep -c sorry` before == after (Invariant.lean 7=7, Invariant_en.lean 6=6).
- Insertions (31) > deletions (21) — entièrement des **docstrings** (prose FR/EN), pas de code métier supprimé ; la preuve elle-même gagne en rigueur (noyau vs compilateur).
- Code byte-identity FR/EN respectée (convention i18n #4980) : seule la ligne de tactique `set_option maxRecDepth 100000 in` / `decide` et les docstrings diffèrent.
- Build SUCCESS post-modif (2959/2959), `#print axioms` reverifié firsthand (FR + EN + voisin unknot).

## Scope

2 fichiers `.lean` :
- `Knots/Invariant.lean` (FR) — théorème + docstring + 2 références incidentes.
- `Knots/Invariant_en.lean` (EN sibling) — miroir, byte-identity sur le code.

Aucun autre module touché. Pas de changement de configuration (`lean-knot.yml` inchangé — l'option 3 n'a pas été retenue).

Closes #8723

See #8725, #8677, #8712.

Co-Authored-By: Claude <noreply@anthropic.com>
