### PR TITLE
docs(lean): fix stale "prose-header baseline 25" docstring in knot_lean (real mode = 17)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -1140,12 +1140,12 @@ non-empty structural lemma about `Reidemeister1Connected` that is reusable in
 both directions.
 
 **No new sorries are introduced.** The backward theorem is intentionally not
-stated here as a tactic-stub placeholder because the Knots-CI prose-header
-sorries baseline is locked at 25 (see `lean-knot.yml`) and a research stub
-would push it to 26. The proof obligation is therefore documented as a
+stated here as a tactic-stub placeholder because the Knots-CI sorries
+baseline is locked at 17 (see `lean-knot.yml`, `real` mode) and a research stub
+would push it to 18. The proof obligation is therefore documented as a
 comment-only contract and the next BG-prover / dedicated cycle will state the
 theorem at the same time it proves it (the lemma + body land in one commit,
-keeping the sorries baseline at 25 throughout).
+keeping the sorries baseline at 17 throughout).
 
 ### 8.1. Proof obligation (informal contract)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
@@ -1103,12 +1103,12 @@ non-empty structural lemma about `Reidemeister1Connected` that is reusable in
 both directions.
 
 **No new sorries are introduced.** The backward theorem is intentionally not
-stated here as a tactic-stub placeholder because the Knots-CI prose-header
-sorries baseline is locked at 25 (see `lean-knot.yml`) and a research stub
-would push it to 26. The proof obligation is therefore documented as a
+stated here as a tactic-stub placeholder because the Knots-CI sorries
+baseline is locked at 17 (see `lean-knot.yml`, `real` mode) and a research stub
+would push it to 18. The proof obligation is therefore documented as a
 comment-only contract and the next BG-prover / dedicated cycle will state the
 theorem at the same time it proves it (the lemma + body land in one commit,
-keeping the sorries baseline at 25 throughout).
+keeping the sorries baseline at 17 throughout).
 
 ### 8.1. Proof obligation (informal contract)
 


### PR DESCRIPTION
Grain: LIGHT/lean-docstring — lane myia-po-2026:CoursIA — prev: DEEP/lean (#8731)

## Summary

Fixes a stale docstring in knot_lean that stated the wrong CI sorries baseline. Surfaced by ai-01 during the #8723 / proof-integrity gate review ("au registre, non traité").

The `Reidemeister1Connected.tricolorable_backward` proof-obligation docstring (FR `Invariant.lean` + EN sibling `Invariant_en.lean`) claimed:

> the Knots-CI **prose-header** sorries baseline is locked at **25** ... a research stub would push it to **26** ... keeping the sorries baseline at **25** throughout.

Both the **mode** and the **numbers** are stale. `lean-knot.yml` switched to `real` mode on 2026-07-11 (line 15: *"switched to `real` mode, baseline=17; was prose-header/28"*) with `sorry-baseline: "17"` (line 83). The `prose-header`/28 era is gone — `real` mode strips comments then counts word-bounded `sorry`, so docstring prose no longer counts toward the baseline.

## Fix

Corrected to the current `real`-mode baseline (verified firsthand against `lean-knot.yml:15/36/83`):

| was | now |
|---|---|
| prose-header sorries baseline is locked at **25** | sorries baseline is locked at **17** (`real` mode) |
| would push it to **26** | would push it to **18** (17 + 1) |
| keeping the sorries baseline at **25** throughout | keeping the sorries baseline at **17** throughout |

A wrong baseline number misleads the next contributor into thinking they have headroom they don't (or vice-versa) when adding a real tactic sorry.

## Scope & neutrality

- Comment-only, inside a `/- -/` docstring block. No tactic, signature, or proof touched.
- FR `Invariant.lean:1142-1148` + EN sibling `Invariant_en.lean:1105-1111` — byte-identical change (i18n convention preserved).
- **Build-neutral and gate-neutral**: the prose sits in a comment, stripped before Lean elaboration and before the `real`-mode sorry count. The `real`-mode baseline (17) and the proof-integrity verdict are unaffected.
- Diff: 2 files, 8 insertions, 8 deletions.

## Out of scope (noted, not bundled)

`Invariant.lean:1478` (+ EN `:1441`) narrates a historical *"raises the prose-header baseline from 25 to 28"*. This describes the old prose-header era and its numbers don't match `lean-knot.yml`'s recorded history (prose-header was 28; #6171 did 28→30). Left untouched: correcting a historical narrative needs the exact baseline at that date — separate archaeology, not bundled with this current-state honesty fix.

See #8723 (where it surfaced).

Co-Authored-By: Claude <noreply@anthropic.com>
