### PR TITLE
feat(twin-parity,#8057): register Probas-1 Setup pair (Infer-1-Setup <-> PyMC-1-Setup) — Two Coins shared

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/probas-1-setup.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-1-setup.yaml
@@ -1,0 +1,13 @@
+- name: Probas-1 Setup
+  family: Probas/Infer.NET-PyMC
+  python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
+  csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-28"
+    by: "myia-po-2023"
+    python_sha: b24306bbc6d25fd654c31d6276d99b81dcb001cf
+    csharp_sha: 432984a9e0116db3bb01b14e29ff222cf45a3baa
+  known_differences:
+  - "Premier modele partage : les deux notebooks demarrent par le modele classique des deux pieces (Two Coins) -- prior Beta, vraisemblance Bernoulli, inference du biais de la piece. Socle pedagogique commun au-dela de la dimension setup (installation Infer.NET cote C# vs PyMC cote Python). Note : #8183 avait initialement exclu cette paire comme 'env-config mecanique, pas de demonstration de concept' (analogue ML-6 ONNX) ; relecture firsthand (ai-01 c.36, po-2023 c.941) confirme la presence substantive du modele Two Coins dans les DEUX notebooks (Infer-1-Setup : piece x15 / Bernoulli x10 / Beta x8 ; PyMC-1-Setup : coin x6 / piece x13 / Beta x12) -> la rationale d'exclusion initiale etait incomplete, paire re-enregistree."
+  - "Moteurs d'inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation, modele compile en code d'inference) ; Python PyMC = echantillonnage MCMC (NUTS/HMC) + ADVI sur backend PyTensor. Memes concepts (Beta-Bernoulli two-coins), paradigmes d'inference differents -- les ecarts numeriques attendus (point estimate EP vs posterior samples NUTS) ne sont pas des defauts."


### PR DESCRIPTION
## Summary

Registre de parité des jumeaux (#8057) — **famille Probas/Infer.NET-PyMC : 18 → 19 paires**. Enregistrement de la paire `probas-1` manquante : `Infer-1-Setup.ipynb` (C#) ↔ `PyMC-1-Setup.ipynb` (Python).

Cette paire avait été **délibérément exclue** par #8183 (« *Probas-1 Setup exclu : notebook d'env-config mécanique, pas une démonstration de concept, analogue ML-6 ONNX* »). La relecture firsthand montre que cette rationale était **incomplète** : les deux notebooks partagent bien un **modèle conceptuel substantiel** (Two Coins / Beta-Bernoulli), pas seulement une étape d'installation.

## Grounding firsthand (G.9 falsifieur)

Le test falsifieur (compter les marqueurs du modèle Two Coins dans le code source des deux notebooks, sur `origin/main` `360115acb`) :

| Notebook | Côté | Marqueurs Two Coins (code source) |
|---|---|---|
| `Infer-1-Setup.ipynb` | C# Infer.NET | `piece`×15, `deux`×9, `Bernoulli`×10, `Beta`×8 |
| `PyMC-1-Setup.ipynb` | Python PyMC | `coin`×6, `piece`×13, `Bernoulli`×2, `Beta`×12 |

Les deux notebooks démarrent par le modèle classique des **deux pièces** (prior Beta, vraisemblance Bernoulli, inférence du biais). La dimension « setup » (installer Infer.NET vs installer PyMC) coexiste avec ce premier modèle — ce n'est pas un pur env-config.

## Correction de naming (vs le dispatch coordinateur)

Le grain ai-01 (c.36, `msg-…m3a1im`) nommait `Infer-101.ipynb` comme côté C#. **Correction appliquée firsthand** : le vrai twin C# de PyMC-1-Setup est **`Infer-1-Setup.ipynb`** (dans `Probas/Infer/`), qui suit la convention 1:1 `Infer-N ↔ PyMC-N` des 18 autres paires. `Infer-101.ipynb` est un notebook **standalone top-level** séparé (legacy polyglot, hors-série Infer-N, sans PyMC-101 correspondant) — l'enregistrer casserait la convention. ACK documenté au coordinateur (`msg-…663npy`).

## SHAs (audités = `origin/main` `360115acb`)

```
python_sha  b24306bbc6d25fd654c31d6276d99b81dcb001cf  (PyMC-1-Setup.ipynb)
csharp_sha  432984a9e0116db3bb01b14e29ff222cf45a3baa  (Infer-1-Setup.ipynb)
```

Récupérés firsthand via `git ls-tree origin/main` (pas de valeur inventée). `known_differences` documentent EP/VMP Infer.NET vs NUTS/ADVI PyMC sur le modèle Two Coins + la dimension setup partagée + la note de ré-ouverture du cas #8183.

## Validation

```
$ python scripts/notebook_tools/check_twin_parity.py --check
... (19 paires Probas, Probas-1 Setup & Two-Coins [OK] en tête)
Total : 137 paire(s) | OK=137 DRIFT=0 MISSING=0
$ echo $?
0
```

- `check_twin_parity --check` : **exit 0** (CI-ready, DRIFT=0 MISSING=0, zero régression sur les autres familles).
- `--family Probas/Infer.NET-PyMC` : **19 paires [OK]** (18 → 19).
- `--coverage` : `Infer-1-Setup.ipynb` n'apparaît plus dans les notebooks non couverts.
- **C.3 compliant** : 0 notebook source modifié (`git diff --stat` = `probas-1-setup.yaml` +13 lignes uniquement) → pas de re-exécution requise (registre YAML seul).
- YAML valide (parse, 1 entrée, LF, ASCII-only `known_differences`, convention registre).

## Coordination

- Grain nommé par ai-01 (c.36, `Grain: MED/test`), ACK + correction de naming documentés (`msg-…663npy`).
- Aucune collision : `gh pr list --search` ne retourne aucune PR ouverte sur probas-1 / twin-register Probas.

See #8057 (famille Probas complète 19/19 ; l'epic reste ouvert pour les autres familles).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
