### PR TITLE
fix(prover,#8738): _extract_axioms multiline-bracket — capture native_decide axioms (gate was blind to the dangerous class)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -756,10 +756,9 @@ class LeanVerifier:
     def _extract_axioms(output: str) -> list:
         """Extract axiom names from ``#print axioms`` output.
 
-        Lean emits one line per declaration in the form
-        ``'Foo.bar' depends on axioms: [A, B, C]`` (or ``'Foo.bar' does not
-        depend on any axioms`` when none). Parse the bracketed list of each
-        such line and union the names across declarations.
+        Lean emits one declaration per ``'Foo.bar' depends on axioms: [A, B, C]``
+        (or ``'Foo.bar' does not depend on any axioms``). Parse each bracketed
+        list and union the names across declarations.
 
         The match is anchored on the literal colon (``axioms:``) -- the
         previous regex ``r"depends on axioms \\[([^\\]]*)\\]"`` (no colon)
@@ -768,12 +767,26 @@ class LeanVerifier:
         and the criterion-4 forbidden-axiom check (#8677) was a no-op.
         Verified by ai-01's rebuild of ``knot_lean`` and reproduction in
         PR #8681 review (``.reason about regex #8677``, msg-20260728T165702).
+
+        Multi-line bracket handling (#8738, c.944): Lean wraps the axiom list to
+        ~100 columns whenever it is long or a name is long -- the exact case for
+        ``native_decide`` axioms (``Foo._native.native_decide.ax_1_1``). The
+        PREVIOUS implementation iterated line-by-line, so on the wrapped form
+        ``depends on axioms: [propext,`` the first line has no closing ``]`` and
+        the regex did not match; the continuation lines carry no
+        ``depends on axioms:`` prefix so they were skipped. The whole
+        declaration was silently dropped -> ``forbidden: []`` / ``OK`` on a
+        module that really uses ``native_decide``. Fix: search the FULL output
+        (``[^\]]*`` already accepts ``\n``), so a bracket that spans lines is
+        captured. ``re.DOTALL`` is not needed because the bracket class already
+        spans newlines, but it is harmless and makes the intent explicit.
         """
         axioms = []
-        for line in output.split("\n"):
-            m = re.search(r"depends on axioms:\s*\[([^\]]*)\]", line)
-            if not m:
-                continue
+        # Search the WHOLE output (not per-line) so a bracket that Lean wraps
+        # across multiple lines is captured. The inner ``[^\]]*`` accepts ``\n``.
+        for m in re.finditer(
+            r"depends on axioms:\s*\[([^\]]*)\]", output, re.DOTALL
+        ):
             inner = m.group(1).strip()
             if not inner:
                 continue

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
@@ -241,6 +241,27 @@ def test_extract_axioms_ignores_non_axiom_lines():
     assert LeanVerifier._extract_axioms(out) == []
 
 
+def test_extract_axioms_multiline_bracket_native_decide():
+    # #8738: Lean wraps the axiom list to ~100 cols when it is long or a name is
+    # long (native_decide axioms). The first line carries no closing ']', so a
+    # per-line regex silently dropped the WHOLE declaration -- the gate rendered
+    # forbidden=[] / OK on a module that really uses native_decide. Reproduced
+    # firsthand by ai-01 c.37 on Knots/Invariant.lean:1054 (figureEight_not_
+    # tricolorable depends on a native_decide.ax_1_1 axiom).
+    out = (
+        "'Knots.figureEight_not_tricolorable' depends on axioms: [propext,\n"
+        " Classical.choice,\n"
+        " Quot.sound,\n"
+        " Knots.figureEight_not_tricolorable._native.native_decide.ax_1_1]\n"
+    )
+    assert set(LeanVerifier._extract_axioms(out)) == {
+        "propext",
+        "Classical.choice",
+        "Quot.sound",
+        "Knots.figureEight_not_tricolorable._native.native_decide.ax_1_1",
+    }
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # check_axioms gate logic (subprocess mocked)
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Grain: MED/lean-tooling — lane myia-po-2024:CoursIA-2 — prev: DEEP/qc × 2 (#8730/#8739 correctifs, same cycle c.944)

Fixes #8738 — the proof-integrity `_extract_axioms` parser was structurally blind to the most dangerous class of axioms (`native_decide`), because those are exactly the longest names (so they trigger Lean's line-wrap).

## The defect

`LeanVerifier._extract_axioms` parsed `#print axioms` output **line by line**. When Lean wraps the axiom list to ~100 columns (long list or long name), the first line is:

```
'Knots.figureEight_not_tricolorable' depends on axioms: [propext,
```

— no closing `]`. The regex `depends on axioms:\s*\[([^\]]*)\]` requires `]`, which isn't on this line, so it did not match. The continuation lines (`Classical.choice,` …) carry no `depends on axioms:` prefix and were skipped by `continue`. The **whole declaration** contributed nothing.

Firsthand-reproduced by ai-01 c.37: on `Knots/Invariant.lean:1054` (which uses `native_decide`), `#print axioms` emits `... depends on axioms: [propext, Classical.choice, Quot.sound, Knots.figureEight_not_tricolorable._native.native_decide.ax_1_1]`, yet the proof-integrity gate on the same commit rendered `forbidden: []` / `OK`. This is the exact class that should be caught — `native_decide` is the dangerous one (decision procedures axioms).

Note the character class `[^\]]*` **already accepts `\n`** — the bug was the line-by-line iteration, not the regex itself.

## The fix

Search the **whole output** (not per-line) with `re.finditer` + `re.DOTALL`. `[^\]]*` then spans the bracket across lines, capturing the wrapped form. One declaration's bracket is still captured as one match (the `]` closes it before the next `depends on axioms:`).

```python
for m in re.finditer(
    r"depends on axioms:\s*\[([^\]]*)\]", output, re.DOTALL
):
    ...
```

## Result

Direct verification (the exact #8738 fixture):
```python
out = "'Foo.bar' depends on axioms: [propext,\n Classical.choice,\n Foo.bar._native.native_decide.ax_1_1]\n"
LeanVerifier._extract_axioms(out)
# -> ['Classical.choice', 'Foo.bar._native.native_decide.ax_1_1', 'propext']  # was: ['propext'] only
```

Now `native_decide.ax_1_1` enters `axioms` → `forbidden = [a for a in axioms if a not in whitelist and a != "sorryAx"]` → it appears in `forbidden` (not whitelisted) → `success=False` → gate **fails loudly**, as it should.

## Tests

`tests/test_check_axioms.py` — new `test_extract_axioms_multiline_bracket_native_decide` covers the exact wrapped form from #8738. Full file: **25 passed** (was 24; +1 new). The existing single-line tests (`parses_depends_on_format`, `detects_sorry_axiom`, `ignores_non_axiom_lines`, `handles_real_lean_format`, `does_not_match_no_colon_format`) all still pass — the single-line path is unchanged, only the multiline gap is closed.

## Scope

2 files (`lean_server.py` `_extract_axioms` body + test), pure Python (no Lean build needed to validate the parser logic — it's regex/string parsing, unit-tested). The 15 collection errors in the broader `agent_tests/` suite are a pre-existing `ModuleNotFoundError: agent_framework` (env/import-path, unrelated to this fix) — the regression surface is `test_check_axioms.py` (25/25).

Closes #8738
