### PR TITLE
feat(qc,#8734): reproducible LEAN data provisioning wrapper + committed manifest

### DIFF
--- a/docs/qc/quantconnect.md
+++ b/docs/qc/quantconnect.md
@@ -150,6 +150,25 @@ MyIA.AI.Notebooks/QuantConnect/
   docs/              # Documentation technique (pas de coordination)
 ```
 
+## Provisionnement reproductible des data LEAN locales
+
+Les data equity/forex locales (`<lean-workspace>/data/`) sont **gitignorées** (binaires volumineuses, régénérables — `.gitignore` ligne 581). L'incident **#8734** (leçon C942-L ★★★, découvert c.942) a montré que des zips tronqués (fin **2021-03-31**) forward-fillés silencieusement par `fillDataForward=True` (défaut Lean) invalident les métriques **sans aucun signal d'erreur** : le notebook affiche une période « 2015 → 2025 » normale mais les ~4-5 dernières années sont une **ligne plate**. Trois outils forment la chaîne reproductible qui ferme ce défaut :
+
+| Outil | Rôle | Issue |
+|-------|------|-------|
+| `scripts/quantconnect/yfinance_to_lean_daily.py` | **Convertisseur** yfinance → zips LEAN daily (OHLC x10000, `00:00`, lowercase) | #8627 |
+| `scripts/quantconnect/check_data_freshness.py` | **Détecteur** STALE, exit 1 gatable pre-exec | #8737 |
+| `scripts/quantconnect/provision_lean_data.py` | **Provisionneur** : regen idempotente one-command d'un univers + **gate fraîcheur cablée** | #8742 |
+
+Le **manifeste versionné** [`lean_universes.manifest.json`](../../scripts/quantconnect/lean_universes.manifest.json) (committé, texte) pin la spec de chaque univers (tickers + plage + `regen_date` + issue) — c'est le **« quelle data a produit ce Sharpe »** vérifiable au merge-gate. Les zips restent gitignorés (machine-local), mais reproductibles en une commande :
+
+```bash
+python scripts/quantconnect/provision_lean_data.py --universe turn_of_month
+# → download yfinance + convert + gate fraîcheur (exit 1 si STALE)
+```
+
+**Avant toute re-exec equity/forex quantbook** : provisionner l'univers (ou lancer `check_data_freshness.py`) pour ne pas reposer sur une ligne plate forward-fillée. Le provisionneur est idempotent (un ticker déjà FRESH est skipé sauf `--force`) et la gate est **cablée** post-provision (pas un outil optionnel à penser à lancer). Voir #8734, #8737, #8627.
+
 ## QC Cloud Assistants — méthode privilégiée Quantbook execution
 
 QuantConnect expose 8 assistants intégrés (Conductor, Ideas, Research, Research Validation, Backtest, Paper Testing, Live Monitoring, Mia) accessibles via :

--- a/scripts/quantconnect/lean_universes.manifest.json
+++ b/scripts/quantconnect/lean_universes.manifest.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "description": "Provenance spec for local LEAN daily equity data. The zips themselves are gitignored (regenerable binaries, machine-local under <lean-workspace>/data/equity/usa/daily/); this manifest is the COMMITTED text record that pins 'what data produced a shipped quantbook metric', so the regen is reproducible from the repo. Regenerate via scripts/quantconnect/provision_lean_data.py.",
+  "source": "yfinance",
+  "converter": "scripts/quantconnect/yfinance_to_lean_daily.py",
+  "freshness_min_year": 2024,
+  "note": "Closes the reproducibility gap surfaced by #8734 (forward-fill defect) + ai-01 c.37 (msg-20260728T220240): a shipped Sharpe must rest on data anyone can regenerate, not on machine-local zips only the author has. The regen_date pins when a shipped metric's data was last provisioned; re-running the provisioner yields FRESH data (current to today) and the freshness_min_year gate enforces it before any re-exec. See #8734, #8737 (detector), #8627 (converter).",
+  "universes": {
+    "turn_of_month": {
+      "purpose": "TurnOfMonth quantbook (#8730 correctif) -- SPY/QQQ/IWM/DIA daily bars from 2005 (preserves GFC + Recovery sub-periods).",
+      "issue": "#8730",
+      "tickers": ["SPY", "QQQ", "IWM", "DIA"],
+      "start": "2005-01-01",
+      "end": null,
+      "regen_date": "2026-07-28"
+    },
+    "ema_cross_alpha": {
+      "purpose": "EMA-Cross-Alpha quantbook (#8714 correctif) -- 5 large-cap tech stocks from 2015.",
+      "issue": "#8714",
+      "tickers": ["AAPL", "MSFT", "GOOGL", "AMZN", "NVDA"],
+      "start": "2015-01-01",
+      "end": null,
+      "regen_date": "2026-07-28"
+    }
+  }
+}

--- a/scripts/quantconnect/provision_lean_data.py
+++ b/scripts/quantconnect/provision_lean_data.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Reproducible Lean daily equity data provisioning (Issue #8734 follow-up).
+
+WHY
+---
+``check_data_freshness.py`` (#8737) DETECTS stale local equity data. The
+converter ``yfinance_to_lean_daily.py`` (#8627) WRITES fresh zips from yfinance.
+What was missing -- surfaced by ai-01 c.37 (msg-20260728T220240) -- was the
+REPRODUCIBLE PROVISIONING STEP that ties them together: a one-command,
+idempotent regen pinned by a COMMITTED manifest, with the freshness gate cabled
+in as a post-provision guardrail rather than a tool one has to remember to run.
+
+Without this, a shipped quantbook metric (e.g. #8730 TurnOfMonth Sharpe) rests on
+data that is gitignored + machine-local -- unreproducible at the merge gate (the
+H.4 trap: the coordinator would merge a Sharpe on the faith of the PR body). The
+local equity zips live under ``<lean-workspace>/data/equity/usa/daily/`` which is
+``.gitignore``-d (line 581), so zero zips are tracked and only the author's
+machine holds the fresh bars. This wrapper makes the regen replayable:
+``python provision_lean_data.py --universe turn_of_month`` regenerates exactly
+the data behind that metric, then PROVES it FRESH via the same gate that would
+catch #8734 -- so the PR body can say "provision by <command>, freshness gate
+PASS", verifiable by anyone.
+
+WHAT IT DOES
+------------
+1. Reads a universe spec from ``lean_universes.manifest.json`` (committed
+   provenance: tickers + start + regen_date + issue ref -- the "what data
+   produced this Sharpe" record).
+2. For each ticker: if ``<dest>/<ticker>.zip`` is already FRESH (last bar year
+   >= freshness_min_year) and not ``--force``, SKIP (idempotent -- cheap re-run).
+   Otherwise download + convert via ``yfinance_to_lean_daily.convert_one``.
+3. After writing, runs the freshness GATE on the provisioned tickers -> exit 1 if
+   any STALE. The gate is CABLED (not optional), and the canonical manual
+   equivalent (``check_data_freshness.py --workspace ... --min-year ...``) is
+   printed so the operator sees the exact pre-exec command.
+
+USAGE
+-----
+    # Provision one universe into the auto-detected lean-workspace
+    python scripts/quantconnect/provision_lean_data.py --universe turn_of_month
+
+    # Provision all universes, force re-download even if already fresh
+    python scripts/quantconnect/provision_lean_data.py --all --force
+
+    # Custom dest (e.g. a CI sandbox with no lean-workspace)
+    python scripts/quantconnect/provision_lean_data.py \\
+        --universe ema_cross_alpha --dest /tmp/prov
+
+Env: any Python with ``yfinance`` (coursia-ml-training has 1.5.2). The converter
+imports yfinance lazily, so this module + its offline tests import without
+network. See #8734, #8737, #8627.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Callable, Optional
+
+# Sibling imports (same dir). check_data_freshness for the gate primitives,
+# yfinance_to_lean_daily for the actual download+convert.
+from check_data_freshness import find_workspace, scan_zip
+from yfinance_to_lean_daily import convert_one
+
+DEFAULT_MANIFEST = Path(__file__).resolve().parent / "lean_universes.manifest.json"
+DEFAULT_MIN_YEAR = 2024  # post-2021 forward-fill cutoff (C942-L)
+
+
+def load_manifest(path: Path) -> dict:
+    """Load + structurally validate the universe manifest."""
+    path = Path(path)
+    if not path.is_file():
+        raise FileNotFoundError(f"Manifest not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("version") != 1:
+        raise ValueError(f"Unsupported manifest version: {data.get('version')!r} (expected 1)")
+    if "universes" not in data or not isinstance(data["universes"], dict):
+        raise ValueError("Manifest missing 'universes' object")
+    for name, spec in data["universes"].items():
+        if not spec.get("tickers"):
+            raise ValueError(f"Universe {name!r} has no 'tickers'")
+    return data
+
+
+def resolve_dest(dest_arg: Optional[Path], workspace_arg: Optional[Path]) -> Path:
+    """Resolve the LEAN daily output folder.
+
+    Precedence: explicit --dest > --workspace (<ws>/data/equity/usa/daily) >
+    auto-detected lean-workspace (walk up for lean.json + data/).
+    """
+    if dest_arg is not None:
+        return Path(dest_arg)
+    if workspace_arg is not None:
+        return Path(workspace_arg) / "data" / "equity" / "usa" / "daily"
+    ws = find_workspace(Path.cwd())
+    if ws is None:
+        raise SystemExit(
+            "ERROR: no lean-workspace (lean.json + data/) found from cwd; "
+            "pass --dest <folder> or --workspace <lean-workspace>."
+        )
+    return ws / "data" / "equity" / "usa" / "daily"
+
+
+def is_fresh(zip_path: Path, min_year: int) -> bool:
+    """True iff the zip's last bar year >= min_year (presence != freshness, C942-L)."""
+    _first, last, _count = scan_zip(Path(zip_path))
+    if last is None:
+        return False
+    return last.year >= min_year
+
+
+def provision_universe(
+    spec: dict,
+    dest: Path,
+    force: bool,
+    min_year: int,
+    converter: Callable[..., int] = convert_one,
+) -> list[tuple[str, str, int, Optional[date]]]:
+    """Provision one universe's tickers into ``dest``.
+
+    Idempotent: a ticker whose zip is already FRESH is skipped unless ``force``.
+    ``converter`` is injected so offline tests avoid the network (default = the
+    real yfinance converter). Returns [(ticker, action, bars, last_date)].
+    """
+    dest = Path(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+    start = spec.get("start")
+    end = spec.get("end")
+    results: list[tuple[str, str, int, Optional[date]]] = []
+    for ticker in spec["tickers"]:
+        zip_path = dest / f"{ticker.lower()}.zip"
+        if zip_path.exists() and not force:
+            _first, last, count = scan_zip(zip_path)
+            if last is not None and last.year >= min_year:
+                print(f"[skip] {ticker}: FRESH (last {last}, {count} bars) -- --force to re-download")
+                results.append((ticker, "skip (fresh)", count, last))
+                continue
+        bars = converter(ticker, dest, start, end, dry_run=False)
+        _first, last, _count = scan_zip(zip_path)
+        print(f"[ok]   {ticker}: provisioned {bars} bars (last {last})")
+        results.append((ticker, "provisioned", bars, last))
+    return results
+
+
+def run_gate(dest: Path, tickers: list[str], min_year: int) -> list[tuple[str, Optional[date], int, bool]]:
+    """Cabled freshness gate over the universe's tickers.
+
+    Returns [(ticker, last_date, rows, stale)]. Missing zip => stale (True).
+    Mirrors check_data_freshness.scan_zip semantics scoped to the provisioned set.
+    """
+    dest = Path(dest)
+    rows: list[tuple[str, Optional[date], int, bool]] = []
+    for ticker in tickers:
+        zip_path = dest / f"{ticker.lower()}.zip"
+        if zip_path.exists():
+            _first, last, count = scan_zip(zip_path)
+            stale = True if last is None else last.year < min_year
+        else:
+            last, count = None, 0
+            stale = True
+        rows.append((ticker, last, count, stale))
+    return rows
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Reproducibly provision LEAN daily equity data for a quantbook universe, with a cabled freshness gate.")
+    p.add_argument("--universe", help="Universe name from the manifest (e.g. turn_of_month).")
+    p.add_argument("--all", action="store_true", help="Provision every universe in the manifest.")
+    p.add_argument("--dest", type=Path, help="LEAN daily output folder (default: <lean-workspace>/data/equity/usa/daily).")
+    p.add_argument("--workspace", type=Path, help="Lean workspace dir (resolved to <ws>/data/equity/usa/daily).")
+    p.add_argument("--force", action="store_true", help="Re-download even if a ticker is already FRESH.")
+    p.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST, help="Path to the universe manifest.")
+    p.add_argument("--no-fail", action="store_true", help="Exit 0 even if the freshness gate finds STALE tickers.")
+    args = p.parse_args(argv)
+
+    if not args.universe and not args.all:
+        p.error("provide --universe <name> or --all")
+
+    manifest = load_manifest(args.manifest)
+    min_year = manifest.get("freshness_min_year", DEFAULT_MIN_YEAR)
+
+    if args.all:
+        unis = manifest["universes"]
+    else:
+        assert args.universe is not None
+        if args.universe not in manifest["universes"]:
+            print(f"ERROR: unknown universe {args.universe!r}; known: {list(manifest['universes'])}", file=sys.stderr)
+            return 2
+        unis = {args.universe: manifest["universes"][args.universe]}
+
+    dest = resolve_dest(args.dest, args.workspace)
+
+    print(f"Manifest : {args.manifest}")
+    print(f"Source   : {manifest.get('source')} via {manifest.get('converter')}")
+    print(f"Dest     : {dest}")
+    print(f"Gate     : freshness_min_year = {min_year} (post-{min_year - 1} forward-fill cutoff, C942-L)")
+    print()
+
+    all_tickers: list[str] = []
+    for name, spec in unis.items():
+        print(f"=== Universe: {name} ({spec.get('issue', '?')}) -- {len(spec['tickers'])} tickers, "
+              f"start={spec.get('start')}, regen_date={spec.get('regen_date')} ===")
+        provision_universe(spec, dest, args.force, min_year)
+        all_tickers.extend(spec["tickers"])
+        print()
+
+    # Cabled gate: verify every provisioned ticker is FRESH before trusting a re-exec.
+    print("=== Freshness gate (cabled) ===")
+    gate_rows = run_gate(dest, sorted(set(t.lower() for t in all_tickers)), min_year)
+    print(f"{'Ticker':<10} {'Last':<12} {'Rows':>7}  Status")
+    print("-" * 44)
+    n_stale = 0
+    for ticker, last, count, stale in gate_rows:
+        if stale:
+            n_stale += 1
+        print(f"{ticker:<10} {last.isoformat() if last else 'MISSING':<12} {count:>7}  {'STALE' if stale else 'FRESH'}")
+    print()
+
+    ws_for_cmd = args.workspace or (find_workspace(Path.cwd()) or Path("<lean-workspace>"))
+    print(f"Manual equivalent: python scripts/quantconnect/check_data_freshness.py "
+          f"--workspace {ws_for_cmd} --min-year {min_year} "
+          f"--ticker {','.join(sorted(set(t.lower() for t in all_tickers)))}")
+
+    if n_stale and not args.no_fail:
+        print(f"\nFAIL: {n_stale}/{len(gate_rows)} ticker(s) STALE post-provision -- data NOT trustworthy for re-exec. See #8734.",
+              file=sys.stderr)
+        return 1
+    print(f"\nOK: all {len(gate_rows)} ticker(s) FRESH -- re-exec ready.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quantconnect/tests/test_provision_lean_data.py
+++ b/scripts/quantconnect/tests/test_provision_lean_data.py
@@ -1,0 +1,153 @@
+"""Offline unit tests for provision_lean_data.py (no network, no yfinance).
+
+Validates manifest parsing, dest resolution, the idempotent skip-when-fresh, and
+the cabled freshness gate -- without touching the network. A fake converter
+writes small in-memory LEAN daily zips so ``provision_universe`` + ``run_gate``
+are exercised end-to-end. The real yfinance path is documented in the module
+docstring (and exercised at dev time); it is not invoked here.
+"""
+
+import json
+import sys
+import zipfile
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from provision_lean_data import (  # noqa: E402
+    is_fresh,
+    load_manifest,
+    provision_universe,
+    resolve_dest,
+    run_gate,
+)
+
+MANIFEST = Path(__file__).resolve().parent.parent / "lean_universes.manifest.json"
+
+
+def _write_zip(dest: Path, ticker: str, last_iso: str, n_bars: int = 3) -> None:
+    """Write a tiny valid LEAN daily zip for ``ticker`` ending at ``last_iso`` (YYYYMMDD)."""
+    dest = Path(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+    y, m, d = int(last_iso[:4]), int(last_iso[4:6]), int(last_iso[6:8])
+    lines = []
+    for i in range(n_bars):
+        dt = date(y, m, d) - timedelta(days=n_bars - 1 - i)
+        lines.append(f"{dt:%Y%m%d} 00:00,100000,101000,99000,100500,1000")
+    low = ticker.lower()
+    with zipfile.ZipFile(dest / f"{low}.zip", "w") as zf:
+        zf.writestr(f"{low}.csv", "\n".join(lines) + "\n")
+
+
+class TestLoadManifest:
+    def test_loads_real_manifest(self):
+        m = load_manifest(MANIFEST)
+        assert m["version"] == 1
+        assert "turn_of_month" in m["universes"]
+        assert "ema_cross_alpha" in m["universes"]
+        assert m["freshness_min_year"] >= 2024
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_manifest(tmp_path / "does_not_exist.json")
+
+    def test_universes_have_required_fields(self):
+        m = load_manifest(MANIFEST)
+        for name, spec in m["universes"].items():
+            assert spec["tickers"], f"{name} has no tickers"
+            assert "start" in spec, f"{name} missing start"
+            assert "regen_date" in spec, f"{name} missing regen_date"
+
+    def test_rejects_bad_version(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text(json.dumps({"version": 99, "universes": {}}))
+        with pytest.raises(ValueError):
+            load_manifest(bad)
+
+
+class TestResolveDest:
+    def test_explicit_dest_wins(self, tmp_path):
+        assert resolve_dest(tmp_path, None) == tmp_path
+
+    def test_workspace_resolves_daily_subdir(self, tmp_path):
+        ws = tmp_path / "ws"
+        assert resolve_dest(None, ws) == ws / "data" / "equity" / "usa" / "daily"
+
+
+class TestIsFresh:
+    def test_fresh_zip(self, tmp_path):
+        _write_zip(tmp_path, "SPY", "20260101")
+        assert is_fresh(tmp_path / "spy.zip", 2024) is True
+
+    def test_stale_zip(self, tmp_path):
+        _write_zip(tmp_path, "SPY", "20210101")
+        assert is_fresh(tmp_path / "spy.zip", 2024) is False
+
+    def test_missing_zip_not_fresh(self, tmp_path):
+        assert is_fresh(tmp_path / "nope.zip", 2024) is False
+
+
+class TestProvisionUniverse:
+    @staticmethod
+    def _fake_converter(calls):
+        def _conv(ticker, dest, start, end, dry_run=False):
+            _write_zip(dest, ticker, "20260101")
+            calls.append(ticker)
+            return 3
+        return _conv
+
+    def test_provisions_missing_tickers(self, tmp_path):
+        calls = []
+        spec = {"tickers": ["SPY", "QQQ"], "start": "2005-01-01", "end": None}
+        results = provision_universe(spec, tmp_path, force=False, min_year=2024,
+                                     converter=self._fake_converter(calls))
+        assert calls == ["SPY", "QQQ"]
+        assert all(r[1] == "provisioned" for r in results)
+
+    def test_skips_when_fresh(self, tmp_path):
+        _write_zip(tmp_path, "SPY", "20260101")  # already fresh
+        calls = []
+        spec = {"tickers": ["SPY"], "start": "2005-01-01", "end": None}
+        results = provision_universe(spec, tmp_path, force=False, min_year=2024,
+                                     converter=self._fake_converter(calls))
+        assert calls == []  # converter never called -- skipped
+        assert results[0][1].startswith("skip")
+
+    def test_force_redownloads_even_if_fresh(self, tmp_path):
+        _write_zip(tmp_path, "SPY", "20260101")
+        calls = []
+        spec = {"tickers": ["SPY"], "start": "2005-01-01", "end": None}
+        provision_universe(spec, tmp_path, force=True, min_year=2024,
+                           converter=self._fake_converter(calls))
+        assert calls == ["SPY"]
+
+    def test_stale_zip_triggers_redownload(self, tmp_path):
+        _write_zip(tmp_path, "SPY", "20210101")  # present but STALE
+        calls = []
+        spec = {"tickers": ["SPY"], "start": "2005-01-01", "end": None}
+        results = provision_universe(spec, tmp_path, force=False, min_year=2024,
+                                     converter=self._fake_converter(calls))
+        assert calls == ["SPY"]  # stale -> re-provisioned
+        assert results[0][1] == "provisioned"
+
+
+class TestRunGate:
+    def test_all_fresh(self, tmp_path):
+        _write_zip(tmp_path, "SPY", "20260101")
+        _write_zip(tmp_path, "QQQ", "20260101")
+        rows = run_gate(tmp_path, ["spy", "qqq"], 2024)
+        assert all(not stale for _, _, _, stale in rows)
+
+    def test_detects_stale(self, tmp_path):
+        _write_zip(tmp_path, "SPY", "20260101")
+        _write_zip(tmp_path, "QQQ", "20210101")  # stale
+        rows = run_gate(tmp_path, ["spy", "qqq"], 2024)
+        stale = {t: s for t, _, _, s in rows}
+        assert stale["spy"] is False
+        assert stale["qqq"] is True
+
+    def test_missing_ticker_is_stale(self, tmp_path):
+        rows = run_gate(tmp_path, ["nope"], 2024)
+        assert rows[0][3] is True  # missing -> stale


### PR DESCRIPTION
Grain: DEEP/qc-tooling — lane myia-po-2024:CoursIA-2 — prev: MED/qc-tooling (#8737)

ai-01 c.37 (msg-20260728T220240) caught a real reproducibility gap in what I shipped this cycle: **a shipped quantbook metric rests on equity data that is gitignored + machine-local**, so it is unreproducible at the merge gate (the H.4 trap — the coordinator would merge a Sharpe on the faith of the PR body alone). This PR ships the **reproducible provisioning step** that closes it.

## The gap (verified firsthand)

```
$ git check-ignore -v .../lean-workspace/data/equity/usa/daily/spy.zip
.gitignore:581:lean-workspace/
$ git ls-files ".../lean-workspace/data/equity/usa/daily/*.zip" | wc -l
0
```

`lean-workspace/` is gitignored and **zero zips are tracked**. My c.943 regen (the 2907/5424 FRESH bars behind #8730 TurnOfMonth + #8714 EMA-Cross) lives only on my machine; ai-01's is still 2021-03-31, and every other lane too. So the metrics I pushed in #8730/#8739 cannot be reproduced by anyone but me. The binaires are correctly gitignored (regenerable) — the missing piece was the **committed, one-command step that regenerates them**.

## The fix (4 parts, one subject)

1. **Wrapper** `scripts/quantconnect/provision_lean_data.py` — idempotent regen of a universe (skip-when-fresh, `--force` to re-download), ties together the converter `yfinance_to_lean_daily.py` (#8627) + the detector `check_data_freshness.py` (#8737).
2. **Committed manifest** `lean_universes.manifest.json` — the provenance record per universe (tickers + start + `regen_date` + issue). Text, not binary. This is the **"what data produced this Sharpe"** record ai-01 asked for.
3. **Cabled gate** — the wrapper runs `check_data_freshness` post-provision (exit 1 STALE), and prints the canonical manual equivalent. The gate is invoked **by the procedure**, not merely available.
4. **Doc** — `docs/qc/quantconnect.md` FR section (3-tool table + usage).

G-VAR-3 note: `prev` is MED/qc-tooling (#8737, the detector). This is DEEP/qc-tooling — a **different instrument** (provisioner, not detector), substance genuinely distinct, so the same-genre back-to-back passes the distinctness test.

## Result (real exec, not just tests)

E2E via real yfinance (`coursia-ml-training`, yfinance 1.5.2), writing to a scratchpad dest:

```
=== Universe: turn_of_month (#8730) -- 4 tickers, start=2005-01-01 ===
[ok] SPY/QQQ/IWM/DIA: 5425 bars each (last 2026-07-28)
=== Universe: ema_cross_alpha (#8714) -- 5 tickers, start=2015-01-01 ===
[ok] AAPL/MSFT/GOOGL/AMZN/NVDA: 2908 bars each (last 2026-07-28)
=== Freshness gate (cabled) ===
9/9 FRESH -- re-exec ready. (exit 0)
```

Bar counts are ±1 vs the c.943 regen (5424→5425, 2907→2908): expected, because today is 2026-07-29 and yfinance now carries the 07-28 bar — this is the provisioner being **current**, and the manifest's `regen_date` 2026-07-28 + "re-run yields FRESH data" note frames the ±1 honestly.

## Tests

`tests/test_provision_lean_data.py` — **16 offline tests** (manifest parsing/validation, dest resolution, `is_fresh`, idempotent skip-when-fresh, `--force`, stale-triggers-redownload, gate all-fresh/detects-stale/missing). No network (a fake converter writes in-memory zips). Full QC suite: **132 passed, 1 skipped** (pre-existing). No regression — existing files untouched.

## Scope

4 files (+434): 3 new (wrapper + manifest + tests), 1 doc section. Catalogue byte-identical to `origin/main`. LF-clean. Atomic (one subject: reproducible provisioning).

## What this unblocks

Once merged, the metrics behind **#8730** (TurnOfMonth) and **#8739** (EMA-Cross-Alpha) become reproducible: anyone runs `python scripts/quantconnect/provision_lean_data.py --universe <name>`, gets the same FRESH data, and re-execs. The PR bodies for those can then cite "provision by `<command>`, freshness gate PASS" — verifiable at the merge gate, which is exactly what H.4 demands.

See #8734
