### PR TITLE
docs(scripts-ref,#7422): document scripts/audit/ family (cost-matrix + claims-vs-outputs)

### DIFF
--- a/docs/reference/scripts-reference.md
+++ b/docs/reference/scripts-reference.md
@@ -142,6 +142,35 @@ La migration Plotly-CDN → SVG inline `text/html` (canon ai-01 `svg-6927-canon.
 | `fix_audio_dependencies.py`, `optimize_dvs.py` | Dépendances audio / optimisation |
 | `_alpha_diag.py`, `generate_16e.py` | Diagnostics ponctuels |
 
+## Audit, coûts & fidélité — `scripts/audit/`
+
+Pipeline d'audit qualité et de **matrice de coût** (EPIC #8056) + audit sémantique claims↔outputs (#8052). Complémentaire de `scripts/notebook_tools/` (qui cible exécution / lint / catalogue) : cette famille cible les **axes transverses** (coût, fidélité prose↔sortie, sorry Lean, registre datasets). Deux familles : **checkers** read-only gatables en CI (exit-code gatable), **populateurs** qui écrivent `nb.metadata['cost']`.
+
+### Checkers (read-only, gatables CI)
+
+| Script | Usage |
+|--------|-------|
+| `check_cost_metadata.py` | Cohérence matrice de coût (#8056) : lit `nb.metadata['cost']` (canonique) avec fallback legacy YAML `---cost---` ; flague `gpu_required:false` mais imports CUDA / `torch.cuda` |
+| `check_dataset_registry.py` | Cohérence registre datasets (#8055 tr.2) : verdicts `DRIFT` / `MISSING` / `CARD_REQUIRED` / `OK` (litmus : EXTRACT, pas DECIDE), sortie YAML |
+| `check_denominators.py` | Détecteur léger de divergence entre 3 sources (disque / forensic / catalogue), #8050 ; `--strict` → exit 1 sur drift |
+| `check_editorial_review.py` | Cohérence registre editorial-review (YAML ↔ catalogue) : 6 validations dont `reviewer != owner_logique`, `evidence_pr` en état `MERGED` |
+| `check_lean_notebook_sorry.py` | Tally `sorry` par notebook Lean (#8051, kernel `lean4-wsl`) : strip commentaires puis compte `sorry` word-bounded — alimente l'axe scientific_review |
+| `extract_claims_vs_outputs.py` | Audit sémantique cellule-par-cellule (#8052 P0) : compare prose markdown (claims) vs sorties code (outputs) ; 5 classes de mismatch |
+
+### Populateurs (écrivent `nb.metadata['cost']`)
+
+| Script | Usage |
+|--------|-------|
+| `populate_cost_metadata.py` | Populate `metadata['cost']` pour ~69 notebooks QC QuantBook sans coût (#8056) ; `qcc_tokens_est = max(400, n_code_cells×70)` |
+| `populate_gametheory_cost.py` | Populate coût GameTheory (48 NBs, CPU-pure : nashpy + numpy + matplotlib) |
+| `populate_semantickernel_cost.py` | Populate coût GenAI / SemanticKernel (26 NBs, API-heavy : gpt-4o / Azure) |
+
+### Réparation d'assets (Stop & Repair)
+
+| Script | Usage |
+|--------|-------|
+| `regen_img1_dalle3.py` | Réparation asset DALL-E legacy via **vraie regen** DALL-E 3 (#8624, Stop & Repair L948) — jamais hand-edit d'output |
+
 ## Maintenance & environnement — `scripts/`
 
 | Chemin | Usage |


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2024:CoursIA-2 — prev: DEEP/qc-tooling (#8742)

Genre rotation after the QC chain closed (ai-01 c.37 steer: pick a non-QC grain). This documents the `scripts/audit/` family — 10 active tools servicing EPICs #8056 (cost matrix), #8052 (claims-vs-outputs), #8055 (dataset registry), #8051 (sorry tally), #8050 (denominators), #8624 (asset repair) — which were previously a single one-line summary ("Outils par domaine") in `scripts-reference.md`.

## The gap (verified firsthand)

`docs/reference/scripts-reference.md` documented ~26 scripts in dedicated tables but lumped `scripts/audit/` (10 .py + tests) into a bare one-liner at the bottom. The family is coherent and actively used (it backs the cost-matrix EPIC + the semantic claims↔outputs audit), yet a reader could not discover what each tool does without opening its source.

## The fix

A dedicated `## Audit, coûts & fidélité — scripts/audit/` section matching the existing doc format (intro paragraph + per-tool tables), split into the family's two real roles:

- **Checkers** (read-only, CI-gatable via exit code): `check_cost_metadata`, `check_dataset_registry`, `check_denominators`, `check_editorial_review`, `check_lean_notebook_sorry`, `extract_claims_vs_outputs`.
- **Populateurs** (write `nb.metadata['cost']`): `populate_cost_metadata`, `populate_gametheory_cost`, `populate_semantickernel_cost`.
- **Réparation d'assets** (Stop & Repair): `regen_img1_dalle3`.

Each entry's interface/usage is derived from the tool's **actual docstring** (read verbatim, not paraphrased from memory), so the acceptance is falsifiable: the documented behavior must match the code.

## Validation

```
python scripts/check_docs_links.py
→ Scanned 549 files, 4204 links — No broken links found.

grep -c $'\r' docs/reference/scripts-reference.md → 0   (LF-clean)
git diff --stat origin/main -- COURSE_CATALOG.*          (empty = byte-identical)
```

+29 / −0, single file, single subject (atomic). French prose per readme-french-first.

## Scope / non-goals

Kept strictly to `scripts/audit/`. `scripts/translation/` (Epic #4957), `scripts/datasets/`, `scripts/secrets/` are also under-documented here but are separate subjects → separate PRs (anti-scope-creep, G.4/G-VAR-3).

See #7422
