### PR TITLE
docs(lean,#6724): fix stale centralCorrect_mem_shift docstring (wrong research wall)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -2435,9 +2435,11 @@ theorem centralCorrect_mem (c : MacroCell) (j : Nat) (p : Int × Int)
 
     Pure composition of `centralCorrect_mem` (G2 congruence, c.153) and
     `toGrid_shift_between` (#4797, the double-shift ingredient) — sorry-free gate
-    ingredient. The residual research heart (sorry 4→3) is `evolve_half_step`,
-    which consumes this gate to connect the induction hypothesis
-    `centralCorrect q_* (k-1)` to the four quadrant offsets at once. -/
+    ingredient. `evolve_half_step` (proven sorry-free) consumes this gate to fold
+    the half-step `2^k = 2^(k-1) ∘ 2^(k-1)`; the residual research heart is the
+    **G3 wave-assembly** — how `(hashlifeResultAux (k+2) parent)` decomposes into
+    the four `(hashlifeResultAux (k+1) q_j)` sub-results at the quadrant offsets —
+    carried by the `sorry` of `p4_nw_supercell_agree` (the NW supercell root). -/
 theorem centralCorrect_mem_shift (c : MacroCell) (j : Nat) (a b : Int) (p : Int × Int)
     (h : centralCorrect c j) :
     p ∈ (hashlifeResultAux (j + 2) c).toGrid (a, b) ↔


### PR DESCRIPTION
Grain: LIGHT/lean-docstring — lane myia-po-2026:CoursIA — prev: DEEP/lean (#8731) + verdict cycle (#6724 c.741/c.742)

## Summary

Fixes a stale docstring on `centralCorrect_mem_shift` that named the **wrong research wall**, directly contradicting the file's own correct statement two hundred lines below. Surfaced firsthand while attacking the #6724 research root `p4_nw_supercell_agree` — the docstring claimed `evolve_half_step` was the residual obstruction, which my reading refuted (it is proven sorry-free).

The `centralCorrect_mem_shift` docstring (HashlifeCorrectness.lean) claimed:

> sorry-free gate ingredient. The residual research heart (sorry 4→3) is `evolve_half_step`, which consumes this gate to connect the induction hypothesis `centralCorrect q_* (k-1)` to the four quadrant offsets at once.

Both the **mechanism** and the **number** are wrong:

1. **`evolve_half_step` is proven sorry-free** (L2738: `evolve (2^k) g = evolve (2^(k-1)) (evolve (2^(k-1)) g) := by set m := k-1 ...`). The file's own summary table at L2084 says so explicitly: *"The pure `evolve` half-step composition is `evolve_add` + `evolve_half_step`, both proven sorry-free."* So the docstring contradicts a sibling statement in the same file.
2. **"sorry 4→3" is a stale count** — the canonical `standalone-tactic` sorry count of this file is **8** (per #6792: 4→8 when `p4_succ_membership` was decomposed). The `4→3` narrative dates from the c.139 era.
3. The **actual** residual research heart is the **G3 wave-assembly** — how `(hashlifeResultAux (k+2) parent)` decomposes into the four `(hashlifeResultAux (k+1) q_j)` sub-results at the quadrant offsets — which `centralCorrect_mem` (L2392) itself documents as *"the residual wall... which remains to be bridged."* It is carried by the `sorry` of `p4_nw_supercell_agree`, the NW-supercell root (the #6724 grain).

This is the same defect class as #8733 (a docstring that gives a **false mechanism**, which misdirects the next contributor away from the real wall — *"une docstring qui ment sur la mécanique dissuade le prochain de retenter la bonne voie"*).

## Fix

Corrected to name the true residual (G3 wave-assembly / `p4_nw_supercell_agree`), and state `evolve_half_step` accurately as the proven half-step folder:

```diff
-    ingredient. The residual research heart (sorry 4→3) is `evolve_half_step`,
-    which consumes this gate to connect the induction hypothesis
-    `centralCorrect q_* (k-1)` to the four quadrant offsets at once. -/
+    ingredient. `evolve_half_step` (proven sorry-free) consumes this gate to fold
+    the half-step `2^k = 2^(k-1) ∘ 2^(k-1)`; the residual research heart is the
+    **G3 wave-assembly** — how `(hashlifeResultAux (k+2) parent)` decomposes into
+    the four `(hashlifeResultAux (k+1) q_j)` sub-results at the quadrant offsets —
+    carried by the `sorry` of `p4_nw_supercell_agree` (the NW supercell root). -/
```

## Scope & neutrality

- **Comment-only**, inside a `/- -/` docstring block. No tactic, signature, or proof touched.
- **Build-neutral and gate-neutral**: the prose sits in a comment, stripped before Lean elaboration and before the `standalone-tactic` sorry count.
- `standalone-tactic` sorry count: **8 → 8** (verified: `grep -cE '^\s*sorry\s*$'` unchanged — the diff is pure prose).
- Diff: 1 file, +5/−3.
- **Deliberately not bundled**: the `p4_nw_supercell_agree` root itself is untouched (its `sorry` is the research kernel — see #6724). Only the *mis-describing* docstring on its sibling gate lemma is corrected.

## Proof gates (lean-merge-discipline §1 / pr-review-discipline §B)

1. **`grep -c sorry`**: standalone-tactic sorries **8 → 8** (comment-only change).
2. **`lake build Conway.Life.HashlifeCorrectness`**: SUCCESS — `BUILD_EXIT=0` (warm-cache build in isolated worktree at `35e1258df`). A `/-- ... -/` block that fails to close breaks a build as surely as a false tactic, so the comment was build-verified, not assumed.
3. **No new axioms**: comment-only, no declarations.
4. **Not a prover refactor**.

See #6724 (the research root whose attack surfaced this defect).

Co-Authored-By: Claude <noreply@anthropic.com>
