### PR TITLE
fix(genai,#8750): untrack c939_run_results.json so nb10 benchmark cells replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -834,9 +834,6 @@ analyze_ratio.py
 # Whisper comparison results (regenerable)
 scripts/whisper_comparison_results.json
 
-# Multi-endpoint run results (c.939 — kept as gitignored data artifact)
-MyIA.AI.Notebooks/GenAI/Texte/c939_run_results.json
-
 # Final model files referenced by executed notebooks (tracked via git LFS)
 # These must be at the END of .gitignore (last matching pattern wins)
 !MyIA.AI.Notebooks/QuantConnect/Python/transformer_checkpoint.pt

--- a/MyIA.AI.Notebooks/GenAI/Texte/c939_run_results.json
+++ b/MyIA.AI.Notebooks/GenAI/Texte/c939_run_results.json
@@ -1,0 +1,77 @@
+{
+  "cell44_benchmark": [
+    {
+      "endpoint": "cloud-gpt5.2",
+      "status": "ok",
+      "elapsed_s": 2.404,
+      "completion_tokens": 90,
+      "content": "L’inférence bayésienne est une méthode statistique qui met à jour la probabilité d’une hypothèse à partir de nouvelles données, en combinant une croyance initiale (le *prior*) et la vraisemblance des "
+    },
+    {
+      "endpoint": "local-mini-v2",
+      "status": "ok",
+      "elapsed_s": 19.993,
+      "completion_tokens": 358,
+      "content": "L' inference bayesian est un processus statistique utilisé pour déterminer des estimations et des prédictions sur une variété de données qui ne sont pas directement observées. Cela se fait par le biai"
+    },
+    {
+      "endpoint": "vllm-qwen3.6",
+      "status": "ok",
+      "elapsed_s": 5.168,
+      "completion_tokens": 492,
+      "content": "\n\nL'inférence bayésienne est une méthode statistique qui met à jour la probabilité d'une hypothèse au fur et à mesure que de nouvelles données sont observées, en combinant une connaissance initiale (a"
+    }
+  ],
+  "cell51_batching": [
+    {
+      "endpoint": "cloud-gpt5.2",
+      "n_req": 25,
+      "n_ok": 25,
+      "total_time_s": 2.862,
+      "sum_tokens": 2160,
+      "throughput_tok_per_s": 754.59
+    },
+    {
+      "endpoint": "local-mini-v2",
+      "n_req": 25,
+      "n_ok": 12,
+      "total_time_s": 150.047,
+      "sum_tokens": 2619,
+      "throughput_tok_per_s": 17.45
+    },
+    {
+      "endpoint": "vllm-qwen3.6",
+      "n_req": 25,
+      "n_ok": 25,
+      "total_time_s": 16.677,
+      "sum_tokens": 12800,
+      "throughput_tok_per_s": 767.51
+    }
+  ],
+  "cell54_global_parallel": [
+    {
+      "endpoint": "cloud-gpt5.2",
+      "ok": true,
+      "elapsed_s": 2.434,
+      "completion_tokens": 84,
+      "finish_order": 1,
+      "total_time_s": 150.017
+    },
+    {
+      "endpoint": "vllm-qwen3.6",
+      "ok": true,
+      "elapsed_s": 5.36,
+      "completion_tokens": 512,
+      "finish_order": 2,
+      "total_time_s": 150.017
+    },
+    {
+      "endpoint": "local-mini-v2",
+      "ok": false,
+      "elapsed_s": 150.015,
+      "completion_tokens": 0,
+      "finish_order": 3,
+      "total_time_s": 150.017
+    }
+  ]
+}


### PR DESCRIPTION
## Context

See #8750 (option 1, user-recommended). Cells 34/41/44/51/54 of `10_LocalLlama.ipynb` load the gitignored `c939_run_results.json` to replay the multi-endpoint benchmark. Without the file on disk, every reader hits the dead `else`-branch ("Artefact absent"), so the notebook's benchmark cells cannot replay for anyone but the author.

## Change

- Remove `.gitignore` lines 837-839 (comment + path + blank) → the artefact is now tracked.
- Commit `MyIA.AI.Notebooks/GenAI/Texte/c939_run_results.json` (c.944 gpt-5.2 run: cloud-gpt5.2 / local-mini-v2 / vllm-qwen3.6).

## Coverage — honest (3/5 cells fully replay)

The committed artefact carries **3 of the 5 keys** the stubs expect:

| Stub cell | Key expected | Present? | After merge |
|---|---|---|---|
| cell[44] benchmark | `cell44_benchmark` | ✅ | replays (3 endpoints, mono-query) |
| cell[51] batching | `cell51_batching` | ✅ | replays (25-concurrent throughput) |
| cell[54] global_parallel | `cell54_global_parallel` | ✅ | replays (parallel finish order) |
| cell[34] tool_calling | `cell34_tool_calling` | ❌ | `.get(key, [])` → header only, 0 entries |
| cell[41] reasoning | `cell41_reasoning` | ❌ | `.get(key, [])` → header only, 0 entries |

The c.944 re-run (PR #8743) measured only benchmark/batching/global_parallel — tool_calling (function-calling setup) and reasoning (reasoning_content capture) were not re-measured. The stubs use `.get(key, [])`, so cell34/41 print their header with no entries rather than crashing. Measuring the 2 remaining scenarios on the 3 endpoints is a **separate DEEP grain** (GenAI real measurement) — I did not fabricate the missing keys to fake full coverage (rule: real output over bug evidence). Tracking as residual; `See #8750` (partial resolution, not `Closes`).

## Verification (firsthand)

- **Scan-leak CLEAN** — ran twice (file on disk + staged blob via `git show :path`): only matches are `completion_tokens` / `sum_tokens` JSON metric keys. No API key, token, secret, IP, URL, hash, or machine path.
- Artefact content = the exact c.944 gpt-5.2 run that PR #8743 updates the stubs (44/51/54) and markdowns (47/52/55/61) to describe. The two PRs compose cleanly for those 3 cells.
- Diff scope: `.gitignore` (-3 lines) + artefact (+77 lines). No code changes.
- Base = `dced647b3` (fresh origin/main) — no catalogue churn (HARD 1 catalog-pr-hygiene).

## Why commit a data artefact (not regenerate)

The benchmark measures 3 live endpoints (OpenAI cloud, local CPU FastAPI, remote vLLM GPU) that are not reproducible by a CI runner or a reader's machine. The measured numbers (latency, throughput, token counts) are the pedagogical payload — they are the point of the cells. Committing the JSON artefact is the honest way to make the notebook replayable, per the #8750 issue analysis. Verdict SOTA-OK: the committed artefact IS the real measured output of the 3 real endpoints.

See #8750, #8743, #8052, #3801.