### PR TITLE
fix(genai,#8750): extend artefact to 5/5 keys - measure tool_calling + reasoning (cells 34/41)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
@@ -1384,9 +1384,41 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": "=== c.939 resultats cell[34] (tool_calling) - 3 endpoints ===\n{\n  \"status\": \"ok\",\n  \"elapsed_s\": 2.023,\n  \"content\": \"\",\n  \"tool_calls\": [\n    {\n      \"id\": \"call_7q52tMP6w9HZLQmEJmPO5jc6\",\n      \"type\": \"function\",\n      \"function\": {\n        \"name\": \"get_weather\",\n        \"arguments\": \"{\\\"location\\\":\\\"Marseille\\\",\\\"unit\\\":\\\"celsius\\\"}\"\n      }\n    }\n  ],\n  \"finish_reason\": \"tool_calls\",\n  \"usage\": {\n    \"prompt_tokens\": 156,\n    \"completion_tokens\": 23,\n    \"total_tokens\": 179,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\": 0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\": {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\": 0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"model\": \"gpt-5.2-2025-12-11\",\n  \"endpoint\": \"cloud-gpt5.2\",\n  \"prompt\": \"Bonjour, est-ce que tu peux me donner la météo pour Marseille en celsius ?\"\n}\n{\n  \"status\": \"ok\",\n  \"elapsed_s\": 6.541,\n  \"content\": \"Je suis désolé, mais je ne peux pas fournir de météo en temps réel. Cela nécessiterait une connexion à Internet qui n'est pas disponible dans les limites du monde moderne. Pour obtenir une information précise sur la météo, vous pouvez utiliser un service de météo ou un site web spécialiste de l'information météorologique. Si vous avez besoin d'aide avec la manière de vérifier votre appareil pour obtenir des informations météorologiques, il est recommandé de consulter un professionnel compétent.\",\n  \"tool_calls\": null,\n  \"finish_reason\": \"stop\",\n  \"usage\": {\n    \"prompt_tokens\": 47,\n    \"completion_tokens\": 119,\n    \"total_tokens\": 166\n  },\n  \"model\": \"Qwen/Qwen2.5-0.5B-Instruct\",\n  \"endpoint\": \"local-mini-v2\",\n  \"prompt\": \"Bonjour, est-ce que tu peux me donner la météo pour Marseille en celsius ?\"\n}\n{\n  \"status\": \"ok\",\n  \"elapsed_s\": 1.577,\n  \"content\": \"\",\n  \"tool_calls\": [\n    {\n      \"id\": \"chatcmpl-tool-b318c440f030e267\",\n      \"type\": \"function\",\n      \"function\": {\n        \"name\": \"get_weather\",\n        \"arguments\": \"{\\\"location\\\": \\\"Marseille\\\", \\\"unit\\\": \\\"celsius\\\"}\"\n      }\n    }\n  ],\n  \"finish_reason\": \"tool_calls\",\n  \"usage\": {\n    \"prompt_tokens\": 310,\n    \"total_tokens\": 436,\n    \"completion_tokens\": 126,\n    \"prompt_tokens_details\": null\n  },\n  \"model\": \"qwen3.6-35b-a3b\",\n  \"endpoint\": \"vllm-qwen3.6\",\n  \"prompt\": \"Bonjour, est-ce que tu peux me donner la météo pour Marseille en celsius ?\"\n}\n"
+     "name": "stdout",
+     "text": [
+      "=== c.939 resultats cell[34] (tool_calling) — 3 endpoints ===\n",
+      "{\n",
+      "  \"endpoint\": \"cloud-gpt5.2\",\n",
+      "  \"status\": \"tool_call OK\",\n",
+      "  \"finish_reason\": \"tool_calls\",\n",
+      "  \"tool_calls\": 1,\n",
+      "  \"tool_name\": \"get_weather\",\n",
+      "  \"tool_args\": \"{\\\"location\\\":\\\"Marseille\\\",\\\"unit\\\":\\\"celsius\\\"}\",\n",
+      "  \"content\": \"\",\n",
+      "  \"elapsed_s\": 4.016\n",
+      "}\n",
+      "{\n",
+      "  \"endpoint\": \"local-mini-v2\",\n",
+      "  \"status\": \"no tool_call\",\n",
+      "  \"finish_reason\": \"stop\",\n",
+      "  \"tool_calls\": 0,\n",
+      "  \"tool_name\": null,\n",
+      "  \"tool_args\": null,\n",
+      "  \"content\": \"En tant que modèle de langage naturel et intelligent créé par Alibaba Cloud, je ne peux pas avoir accès à l'information actuelle sur les conditions météorologiq\",\n",
+      "  \"elapsed_s\": 6.823\n",
+      "}\n",
+      "{\n",
+      "  \"endpoint\": \"vllm-qwen3.6\",\n",
+      "  \"status\": \"tool_call OK\",\n",
+      "  \"finish_reason\": \"tool_calls\",\n",
+      "  \"tool_calls\": 1,\n",
+      "  \"tool_name\": \"get_weather\",\n",
+      "  \"tool_args\": \"{\\\"location\\\": \\\"Marseille\\\"}\",\n",
+      "  \"content\": \"\",\n",
+      "  \"elapsed_s\": 2.409\n",
+      "}\n"
+     ]
     }
    ],
    "source": "# c.939 — re-execute stub for cell[34] (tool_calling)\nimport json\nimport os\nfrom pathlib import Path\n\n_CANDIDATES = [Path(os.getcwd()) / 'c939_run_results.json',\n               Path(os.getcwd()).parent / 'c939_run_results.json']\n_RESULTS_PATH = next((c for c in _CANDIDATES if c.exists()), None)\n\nif _RESULTS_PATH is None:\n    print(\"Artefact c939_run_results.json absent (gitignore) -- sorties du run 3-endpoints\")\n    print(\"conservees dans les cellules ci-dessous. Voir la section Reproductibilite.\")\nelse:\n    results = json.loads(_RESULTS_PATH.read_text(encoding='utf-8'))\n    print(f\"=== c.939 resultats cell[34] (tool_calling) — 3 endpoints ===\")\n    for entry in results.get('cell34_tool_calling', []):\n        print(json.dumps(entry, indent=2, ensure_ascii=False))\n"
@@ -1404,7 +1436,34 @@
     },
     "tags": []
    },
-   "source": "### Interpretation du test de function calling\n\nCe test vérifie le **support natif du function/tool calling** sur les\n3 endpoints câblés par c.939. Le code source cell[34] itère sur\n`endpoints[]` qui contient maintenant 3 entrées (cloud-gpt5.2, local-mini-v2, vllm-qwen3.6).\n\n**Résultat observé sur le run c.939** (3 endpoints, 2026-07-28) :\n\n| Endpoint | Statut | finish_reason | tool_calls | Latence |\n|----------|--------|--------------|------------|---------|\n| **cloud-gpt5.2** (gpt-5.2, OpenAI) | **tool_call OK** | `tool_calls` | 1 (get_weather args=`{location:\"Marseille\",unit:\"celsius\"}`) | 2.02s |\n| **local-mini-v2** (Qwen2.5-0.5B-Instruct, FastAPI local) | **Pas de tool_call** | `stop` | 0 (réponse texte libre : \"Je suis désolé, mais je ne peux pas fournir de météo en temps réel...\") | 6.54s |\n| **vllm-qwen3.6** (qwen3.6-35b-a3b) | **tool_call OK** | `tool_calls` | 1 (get_weather args=`{location:\"Marseille\",unit:\"celsius\"}`) | 1.58s |\n\n**Points pédagogiques** :\n\n1. **Tool calling natif = gros modèles (cloud + vLLM distant)** : gpt-5.2 et qwen3.6-35b\n   déclenchent `tool_calls` avec `finish_reason=\"tool_calls\"` dès le premier tour.\n   Les deux comprennent que la question météo appelle la fonction `get_weather()`.\n2. **0.5B-Instruct = pas de tool calling** : le petit modèle n'a pas été fine-tuné\n   sur le format `tool_calls` OpenAI ; il génère du texte libre à la place.\n   Sur un modèle 7B+ ou fine-tuné pour les tools, `tool_choice='auto'` déclenche\n   un `tool_calls` natif.\n3. **Verdict** : SOTA-OK (règle F) — les 3 endpoints sont installés/invoqués\n   proprement, pas de workaround dégradé. La sortie commitée EST la vraie\n   sortie de chaque endpoint (pas d'ASCII art, pas de stub, pas de fabrication).\n"
+   "source": [
+    "### Interpretation du test de function calling\n",
+    "\n",
+    "Ce test vérifie le **support natif du function/tool calling** sur les\n",
+    "3 endpoints câblés par c.939. Le code source cell[34] itère sur\n",
+    "`endpoints[]` qui contient maintenant 3 entrées (cloud-gpt5.2, local-mini-v2, vllm-qwen3.6).\n",
+    "\n",
+    "**Résultat observé sur le run c.945** (3 endpoints, 2026-07-29) :\n",
+    "\n",
+    "| Endpoint | Statut | finish_reason | tool_calls | Latence |\n",
+    "|----------|--------|--------------|------------|---------|\n",
+    "| **cloud-gpt5.2** (gpt-5.2, OpenAI) | **tool_call OK** | `tool_calls` | 1 (get_weather args=`{location:\"Marseille\",unit:\"celsius\"}`) | 4.0s |\n",
+    "| **local-mini-v2** (Qwen2.5-0.5B-Instruct, FastAPI local) | **Pas de tool_call** | `stop` | 0 (réponse texte libre, pas de `tool_calls`) | 6.8s |\n",
+    "| **vllm-qwen3.6** (qwen3.6-35b-a3b) | **tool_call OK** | `tool_calls` | 1 (get_weather args=`{location:\"Marseille\"}`) | 2.4s |\n",
+    "\n",
+    "**Points pédagogiques** :\n",
+    "\n",
+    "1. **Tool calling natif = gros modèles (cloud + vLLM distant)** : gpt-5.2 et qwen3.6-35b\n",
+    "   déclenchent `tool_calls` avec `finish_reason=\"tool_calls\"` dès le premier tour.\n",
+    "   Les deux comprennent que la question météo appelle la fonction `get_weather()`.\n",
+    "2. **0.5B-Instruct = pas de tool calling** : le petit modèle n'a pas été fine-tuné\n",
+    "   sur le format `tool_calls` OpenAI ; il génère du texte libre à la place.\n",
+    "   Sur un modèle 7B+ ou fine-tuné pour les tools, `tool_choice='auto'` déclenche\n",
+    "   un `tool_calls` natif.\n",
+    "3. **Verdict** : SOTA-OK (règle F) — les 3 endpoints sont installés/invoqués\n",
+    "   proprement, pas de workaround dégradé. La sortie commitée EST la vraie\n",
+    "   sortie de chaque endpoint (pas d'ASCII art, pas de stub, pas de fabrication).\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2213,9 +2272,35 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": "=== c.939 resultats cell[41] (reasoning) - 3 endpoints ===\n{\n  \"status\": \"ok\",\n  \"elapsed_s\": 1.441,\n  \"content\": \"18182\",\n  \"tool_calls\": null,\n  \"finish_reason\": \"stop\",\n  \"usage\": {\n    \"prompt_tokens\": 26,\n    \"completion_tokens\": 5,\n    \"total_tokens\": 31,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\": 0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\": {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\": 0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"model\": \"gpt-5.2-2025-12-11\",\n  \"endpoint\": \"cloud-gpt5.2\",\n  \"prompt\": \"Calcule 253 * 73 - 287. Réponds uniquement avec le résultat numérique.\",\n  \"answer_extracted\": \"18182\",\n  \"answer_correct\": true\n}\n{\n  \"status\": \"ok\",\n  \"elapsed_s\": 0.927,\n  \"content\": \"1692\",\n  \"tool_calls\": null,\n  \"finish_reason\": \"stop\",\n  \"usage\": {\n    \"prompt_tokens\": 55,\n    \"completion_tokens\": 5,\n    \"total_tokens\": 60\n  },\n  \"model\": \"Qwen/Qwen2.5-0.5B-Instruct\",\n  \"endpoint\": \"local-mini-v2\",\n  \"prompt\": \"Calcule 253 * 73 - 287. Réponds uniquement avec le résultat numérique.\",\n  \"answer_extracted\": \"1692\",\n  \"answer_correct\": false\n}\n{\n  \"status\": \"ok\",\n  \"elapsed_s\": 8.287,\n  \"content\": \"\\n\\n18182\",\n  \"tool_calls\": [],\n  \"finish_reason\": \"stop\",\n  \"usage\": {\n    \"prompt_tokens\": 35,\n    \"total_tokens\": 873,\n    \"completion_tokens\": 838,\n    \"prompt_tokens_details\": null\n  },\n  \"model\": \"qwen3.6-35b-a3b\",\n  \"endpoint\": \"vllm-qwen3.6\",\n  \"prompt\": \"Calcule 253 * 73 - 287. Réponds uniquement avec le résultat numérique.\",\n  \"answer_extracted\": \"18182\",\n  \"answer_correct\": true\n}\n"
+     "name": "stdout",
+     "text": [
+      "=== c.939 resultats cell[41] (reasoning) — 3 endpoints ===\n",
+      "{\n",
+      "  \"endpoint\": \"cloud-gpt5.2\",\n",
+      "  \"answer\": 18182,\n",
+      "  \"answer_raw\": \"18182\",\n",
+      "  \"correct\": true,\n",
+      "  \"completion_tokens\": 5,\n",
+      "  \"elapsed_s\": 3.732\n",
+      "}\n",
+      "{\n",
+      "  \"endpoint\": \"local-mini-v2\",\n",
+      "  \"answer\": 19460,\n",
+      "  \"answer_raw\": \"19460\",\n",
+      "  \"correct\": false,\n",
+      "  \"completion_tokens\": 6,\n",
+      "  \"elapsed_s\": 0.949\n",
+      "}\n",
+      "{\n",
+      "  \"endpoint\": \"vllm-qwen3.6\",\n",
+      "  \"answer\": 18182,\n",
+      "  \"answer_raw\": \"\\n\\n18182\",\n",
+      "  \"correct\": true,\n",
+      "  \"completion_tokens\": 1020,\n",
+      "  \"elapsed_s\": 11.323\n",
+      "}\n"
+     ]
     }
    ],
    "source": "# c.939 — re-execute stub for cell[41] (reasoning)\nimport json\nimport os\nfrom pathlib import Path\n\n_CANDIDATES = [Path(os.getcwd()) / 'c939_run_results.json',\n               Path(os.getcwd()).parent / 'c939_run_results.json']\n_RESULTS_PATH = next((c for c in _CANDIDATES if c.exists()), None)\n\nif _RESULTS_PATH is None:\n    print(\"Artefact c939_run_results.json absent (gitignore) -- sorties du run 3-endpoints\")\n    print(\"conservees dans les cellules ci-dessous. Voir la section Reproductibilite.\")\nelse:\n    results = json.loads(_RESULTS_PATH.read_text(encoding='utf-8'))\n    print(f\"=== c.939 resultats cell[41] (reasoning) — 3 endpoints ===\")\n    for entry in results.get('cell41_reasoning', []):\n        print(json.dumps(entry, indent=2, ensure_ascii=False))\n"
@@ -2233,7 +2318,32 @@
     },
     "tags": []
    },
-   "source": "### Interpretation du test de reasoning\n\nCe test demande un **calcul mathématique** (`253 * 73 - 287 = ?`) et observe\nle raisonnement sur les 3 endpoints c.939.\n\n**Résultat observé sur le run c.939** (3 endpoints, 2026-07-28) :\n\n| Endpoint | Réponse | Correct? | Latence | Tokens |\n|----------|---------|----------|---------|--------|\n| **cloud-gpt5.2** (gpt-5.2) | `18182` | **Oui** (`253*73-287=18182`) | 1.44s | 5 |\n| **local-mini-v2** (Qwen2.5-0.5B-Instruct) | `1692` | **Non** (hallucination arithmétique) | 0.93s | 5 |\n| **vllm-qwen3.6** (qwen3.6-35b-a3b) | `\\n\\n18182` | **Oui** | 8.29s | 838 (réflexion visible) |\n\n**Points pédagogiques** :\n\n1. **Vérification du calcul exact** : `253 * 73 - 287 = 18469 - 287 = 18182`.\n   Le 0.5B répond `1692` (artefact classique des petits LLM : hallucination\n   plausible mais fausse sur l'arithmétique multi-chiffres).\n2. **Raisonnement visible sur qwen3.6** : le qwen3.6-35b produit 838 tokens\n   pour arriver à la réponse, contre 5 tokens pour gpt-5.2 (réponse directe).\n   Cela illustre que les modèles **pensent à voix haute** quand on leur laisse\n   la place — sans pour autant être plus rapides.\n3. **Verdict** : SOTA-OK — calcul correct sur 2/3 endpoints, fail bien\n   caractérisé sur le 3ème (taille du modèle).\n"
+   "source": [
+    "### Interpretation du test de reasoning\n",
+    "\n",
+    "Ce test demande un **calcul mathématique** (`253 * 73 - 287 = ?`) et observe\n",
+    "le raisonnement sur les 3 endpoints c.939.\n",
+    "\n",
+    "**Résultat observé sur le run c.945** (3 endpoints, 2026-07-29) :\n",
+    "\n",
+    "| Endpoint | Réponse | Correct? | Latence | Tokens |\n",
+    "|----------|---------|----------|---------|--------|\n",
+    "| **cloud-gpt5.2** (gpt-5.2) | `18182` | **Oui** (`253*73-287=18182`) | 3.7s | 5 |\n",
+    "| **local-mini-v2** (Qwen2.5-0.5B-Instruct) | `19460` | **Non** (hallucination arithmétique) | 0.9s | 6 |\n",
+    "| **vllm-qwen3.6** (qwen3.6-35b-a3b) | `18182` | **Oui** | 11.3s | 1020 (réflexion visible) |\n",
+    "\n",
+    "**Points pédagogiques** :\n",
+    "\n",
+    "1. **Vérification du calcul exact** : `253 * 73 - 287 = 18469 - 287 = 18182`.\n",
+    "   Le 0.5B répond `19460` (artefact classique des petits LLM : hallucination\n",
+    "   plausible mais fausse sur l'arithmétique multi-chiffres).\n",
+    "2. **Raisonnement visible sur qwen3.6** : le qwen3.6-35b produit 1020 tokens\n",
+    "   pour arriver à la réponse, contre 5 tokens pour gpt-5.2 (réponse directe).\n",
+    "   Cela illustre que les modèles **pensent à voix haute** quand on leur laisse\n",
+    "   la place — sans pour autant être plus rapides.\n",
+    "3. **Verdict** : SOTA-OK — calcul correct sur 2/3 endpoints, fail bien\n",
+    "   caractérisé sur le 3ème (taille du modèle).\n"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/c939_run_results.json
+++ b/MyIA.AI.Notebooks/GenAI/Texte/c939_run_results.json
@@ -73,5 +73,63 @@
       "finish_order": 3,
       "total_time_s": 150.017
     }
+  ],
+  "cell34_tool_calling": [
+    {
+      "endpoint": "cloud-gpt5.2",
+      "status": "tool_call OK",
+      "finish_reason": "tool_calls",
+      "tool_calls": 1,
+      "tool_name": "get_weather",
+      "tool_args": "{\"location\":\"Marseille\",\"unit\":\"celsius\"}",
+      "content": "",
+      "elapsed_s": 4.016
+    },
+    {
+      "endpoint": "local-mini-v2",
+      "status": "no tool_call",
+      "finish_reason": "stop",
+      "tool_calls": 0,
+      "tool_name": null,
+      "tool_args": null,
+      "content": "En tant que modèle de langage naturel et intelligent créé par Alibaba Cloud, je ne peux pas avoir accès à l'information actuelle sur les conditions météorologiq",
+      "elapsed_s": 6.823
+    },
+    {
+      "endpoint": "vllm-qwen3.6",
+      "status": "tool_call OK",
+      "finish_reason": "tool_calls",
+      "tool_calls": 1,
+      "tool_name": "get_weather",
+      "tool_args": "{\"location\": \"Marseille\"}",
+      "content": "",
+      "elapsed_s": 2.409
+    }
+  ],
+  "cell41_reasoning": [
+    {
+      "endpoint": "cloud-gpt5.2",
+      "answer": 18182,
+      "answer_raw": "18182",
+      "correct": true,
+      "completion_tokens": 5,
+      "elapsed_s": 3.732
+    },
+    {
+      "endpoint": "local-mini-v2",
+      "answer": 19460,
+      "answer_raw": "19460",
+      "correct": false,
+      "completion_tokens": 6,
+      "elapsed_s": 0.949
+    },
+    {
+      "endpoint": "vllm-qwen3.6",
+      "answer": 18182,
+      "answer_raw": "\n\n18182",
+      "correct": true,
+      "completion_tokens": 1020,
+      "elapsed_s": 11.323
+    }
   ]
 }


### PR DESCRIPTION
## Context

Closes #8750. After #8758 committed the artefact (3/5 keys: cell44/51/54), cells 34 (tool_calling) and 41 (reasoning) still hit `.get(key, [])` → empty output. This PR measures the 2 remaining scenarios on the 3 endpoints (c.945 gpt-5.2 run), extending the artefact to all 5 keys → **every benchmark cell replays for every reader**.

## Change

- `c939_run_results.json`: +2 keys `cell34_tool_calling` + `cell41_reasoning` (3 endpoints each, c.945 measurements).
- `10_LocalLlama.ipynb`: stubs cell34/41 re-executed in-process with the 5-key artefact → authentic outputs spliced (`exec_count=1`, normalized format matching cell44/51/54). Markdowns 35/42 updated with c.945 numbers + header date.

## Results (c.945, real measured)

**tool_calling** (`get_weather(location, unit)` tool, prompt "Quel temps à Marseille ?"):

| Endpoint | Statut | finish_reason | tool_calls | Latence |
|---|---|---|---|---|
| cloud-gpt5.2 | tool_call OK | tool_calls | 1 (location=Marseille, unit=celsius) | 4.0s |
| local-mini-v2 (0.5B) | no tool_call | stop | 0 (free text) | 6.8s |
| vllm-qwen3.6 | tool_call OK | tool_calls | 1 (location=Marseille) | 2.4s |

**reasoning** (`253 * 73 - 287 = ?`, expected 18182):

| Endpoint | Réponse | Correct | Latence | Tokens |
|---|---|---|---|---|
| cloud-gpt5.2 | 18182 | Oui | 3.7s | 5 (direct) |
| local-mini-v2 (0.5B) | 19460 | Non (hallucination) | 0.9s | 6 |
| vllm-qwen3.6 | 18182 | Oui | 11.3s | 1020 (CoT visible) |

## Diagnostic (G.9 — doubt self before blaming the tool)

First run had qwen3.6 answer `4` (wrong) at 512 tokens: the reasoning CoT was **truncated** before emitting the final answer. Markdown c.939 documented qwen3.6 needed 838 tokens. Fix: `max_tokens=2000` for the reasoning scenario → qwen3.6 now finishes its CoT (1020 tok) and answers 18182 correctly. gpt-5.2/local-mini consume only a few tokens regardless. Not a model defect — a token-budget defect in the driver, caught and fixed before commit.

## Verification (firsthand)

- **Stubs executed in-process** with cwd = notebook dir (artefact found via `Path(os.getcwd())`); stdout captured authentically (not hand-edited).
- **Scan-leak CLEAN** on artefact (5 keys, 3013 bytes) + notebook outputs cell34/41 (1393 chars): no secret/IP/hex/call-id. Normalized format avoids the OpenAI `call_id` noise of the legacy c.939 brute format.
- **Byte-stable surgery**: `json.dumps(indent=1, ensure_ascii=False)`, LF, round-trip byte-identical on all 3 edits (splice 34/41, markdown 35, markdown 42).
- **Outputs ↔ markdowns ↔ artefact coherent**: all describe the same c.945 gpt-5.2 run.
- Verdict **SOTA-OK**: real measured output of 3 real endpoints (cloud OpenAI / local CPU FastAPI / remote vLLM GPU).
- Base = `17f5ee923` (fresh origin/main, post-#8758) — no catalogue churn.

See #8750, #8758, #8743, #8052, #3801.