### PR TITLE
feat(qc,#8734): output-date freshness auditor + period-dominance guard (ai-01 c.40)

### DIFF
--- a/scripts/quantconnect/audit_quantbooks_output_dates.py
+++ b/scripts/quantconnect/audit_quantbooks_output_dates.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""QuantConnect quantbook output-date freshness auditor (ai-01 c.40, #8734).
+
+Pourquoi cet outil existe
+-------------------------
+``audit_quantbooks_unexec.py`` (issue #6891) detecte l'absence d'EXECUTION
+(``execution_count is None``, ``outputs == []``, ``output_type == "error"``).
+``check_data_freshness.py`` (#8734, #8737) detecte la STAGNATION des ZIPS qui
+nourrissent les notebooks. Aucun des deux n'attrape le cas ou un notebook
+porte des sorties **anciennes** malgre un ``execution_count`` bien rempli :
+un quantbook dont la sortie la plus fraiche date d'il y a trois mois affiche
+une integrite formelle parfaite (H.5 EXEC_PROVED) tout en decrivant un marche
+qui n'existe plus. C'est le defaut qu'aucun compte de cellules ne voit.
+
+ai-01 c.40 (msg-20260729T000258) l'a nomme explicitement : « le champ qui
+m'interesse le plus est la date la plus recente dans les sorties. C'est lui
+qui distingue un notebook re-execute d'un notebook qui porte des sorties
+anciennes avec un execution_count bien rempli ».
+
+Ce qu'il fait (DETECTION, pas correction)
+-----------------------------------------
+Pour chaque ``quantbook.ipynb`` d'un dossier projets, extrait des OUTPUTS
+commits :
+
+  - ``exec_cells`` / ``total_code_cells`` -- couverture d'execution.
+  - ``error_cells`` -- cellules dont une sortie est ``output_type == "error"``.
+  - ``latest_exec_date`` -- la date la plus **recente** mentionnee dans les
+    sorties (dates ISO ``YYYY-MM-DD`` ou ``YYYYMMDD`` parsee dans le texte
+    des outputs). **C'est le pivot de fraicheur.**
+  - ``latest_backtest_period_date`` -- la date la plus recente **typant une
+    periode de backtest** (heuristique explicite, voir ci-dessous).
+  - ``guard_present`` -- presence d'un fail-fast guard C942-L/C951-L
+    (``fillDataForward`` / ``flat tail`` / ``C941`` / ``C942``).
+  - ``verdict`` -- EXEC_PROVED_FRESH / STALE_OUTPUTS / PERIOD_DOMINATED_AGED /
+    PERIOD_DOMINATED_RECENT / EXEC_PROVED_NO_DATE / INCOMPLETE / HAS_ERRORS /
+    READ_ERROR. See ``_classify_freshness`` for the period-dominance nuance.
+
+Distinction execution-date vs backtest-period-date (HARD, ai-01 c.40)
+--------------------------------------------------------------------
+ai-01 previent le faux positif inverse : les dates de **periode de
+backtest** (``2025-12-31`` dans un ``SetEndDate`` ou un print ``Periode:
+... a 2025-12-31``) NE sont PAS des dates d'execution. Les confondre ferait
+crier au loup sur chaque notebook. Plutot qu'inventer une heuristique qui
+se trompe, l'outil **rapporte les deux colonnes separement** :
+
+  - ``latest_exec_date`` = TOUTE date ISO trouvee dans les outputs (fourchette
+    haute : peut inclure une periode de backtest future).
+  - ``latest_backtest_period_date`` = date isolee typant une periode
+    (heuristique : mentionnee dans une ligne contenant ``Periode`` / ``Period``
+    / ``SetEndDate`` / ``Start`` / ``End`` / ``a`` / ``to``).
+
+Un notebook dont ``latest_exec_date`` est plus recent que
+``latest_backtest_period_date`` est probablement re-execute sur data fraiche.
+Un notebook dont les deux coincident a une vieille date est suspect de
+sorties agees. Le verdict final est **conservateur** : il ne crie STALE que
+si la date la plus recente dans les outputs est **anterieure au seuil** --
+parce que si meme la mention la plus fraiche dans tout le notebook est
+vieille, les sorties sont vieilles quelle que soit la nature (periode ou
+execution) de cette mention.
+
+Usage
+-----
+    python audit_quantbooks_output_dates.py
+    python audit_quantbooks_output_dates.py --root <projets-dir>
+    python audit_quantbooks_output_dates.py --min-year 2025
+    python audit_quantbooks_output_dates.py --json   # machine-readable
+    python audit_quantbooks_output_dates.py --no-fail  # always exit 0
+
+Operationalise la lecon C942-L generalisee : presence != fraicheur, et
+``execution_count`` rempli != sorties recentes. See #8734, #8737, #7575.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import re
+import sys
+from pathlib import Path
+
+# Date patterns: ISO YYYY-MM-DD and compact YYYYMMDD (both appear in QC outputs).
+_ISO_DATE = re.compile(r"(20\d{2})-(\d{2})-(\d{2})")
+_COMPACT_DATE = re.compile(r"\b(20\d{2})(\d{2})(\d{2})\b")
+# Lines that signal a backtest *period* (config), not an execution instant.
+_PERIOD_HINT = re.compile(
+    r"(?i)(periode|p[eé]riode|period|setenddate|setstartdate|start|end|de|a|to|from|window|fen[eê]tre|range|train|test|backtest)"
+)
+
+
+def _all_dates_in_text(text: str) -> list[str]:
+    """Return ISO-normalized YYYY-MM-DD dates found in text (dedup, sorted)."""
+    found: set[str] = set()
+    for m in _ISO_DATE.finditer(text or ""):
+        y, mo, d = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        if 1 <= mo <= 12 and 1 <= d <= 31:
+            found.add(f"{y:04d}-{mo:02d}-{d:02d}")
+    for m in _COMPACT_DATE.finditer(text or ""):
+        y, mo, d = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        if 1 <= mo <= 12 and 1 <= d <= 31:
+            found.add(f"{y:04d}-{mo:02d}-{d:02d}")
+    return sorted(found)
+
+
+def _cell_output_text(cell: dict) -> str:
+    """Flatten a code cell's outputs to a single text blob (stream + data text)."""
+    parts: list[str] = []
+    for o in cell.get("outputs") or []:
+        if not isinstance(o, dict):
+            continue
+        t = o.get("text")
+        if isinstance(t, str):
+            parts.append(t)
+        elif isinstance(t, list):
+            parts.extend(x for x in t if isinstance(x, str))
+        data = o.get("data") or {}
+        if isinstance(data, dict):
+            for key, val in data.items():
+                if key.startswith("text/"):
+                    if isinstance(val, str):
+                        parts.append(val)
+                    elif isinstance(val, list):
+                        parts.extend(x for x in val if isinstance(x, str))
+    return "\n".join(parts)
+
+
+def _guard_present(nb: dict) -> bool:
+    """Detect a fail-fast freshness guard (C941-L/C942-L/C951-L) in any code cell."""
+    needles = ("filldataforward", "fill_data_forward", "flat tail", "flat-tail",
+               "c941", "c942", "c951", "fail-fast guard", "fail_fast guard",
+               "tail(60).std", "regenerate via provision_lean_data")
+    blob = json.dumps(nb, ensure_ascii=False).lower()
+    return any(n in blob for n in needles)
+
+
+def scan_notebook(path: Path) -> dict:
+    """Scan one quantbook. Returns a structured verdict dict (never raises)."""
+    result: dict = {"notebook": str(path), "error": None}
+    try:
+        nb = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 -- report, don't crash the scan
+        result.update({"verdict": "READ_ERROR", "error": str(exc)})
+        return result
+
+    code_cells = [c for c in nb.get("cells", []) if c.get("cell_type") == "code"]
+    total = len(code_cells)
+    exec_cells = sum(1 for c in code_cells if c.get("execution_count") is not None)
+    error_cells = sum(
+        1
+        for c in code_cells
+        for o in (c.get("outputs") or [])
+        if isinstance(o, dict) and o.get("output_type") == "error"
+    )
+
+    all_dates: set[str] = set()
+    period_dates: set[str] = set()
+    for c in code_cells:
+        # dates from outputs
+        out_text = _cell_output_text(c)
+        for d in _all_dates_in_text(out_text):
+            all_dates.add(d)
+        # dates from source that look like period config
+        src = "".join(c.get("source") or []) if isinstance(c.get("source"), list) else (c.get("source") or "")
+        for line in src.split("\n"):
+            if _PERIOD_HINT.search(line):
+                for d in _all_dates_in_text(line):
+                    period_dates.add(d)
+        # also: a "Periode: X a Y" print output line counts as period config
+        for line in out_text.split("\n"):
+            if _PERIOD_HINT.search(line):
+                for d in _all_dates_in_text(line):
+                    period_dates.add(d)
+
+    latest_exec = max(all_dates) if all_dates else None
+    latest_period = max(period_dates) if period_dates else None
+    guard = _guard_present(nb)
+
+    result.update({
+        "total_code_cells": total,
+        "exec_cells": exec_cells,
+        "error_cells": error_cells,
+        "guard_present": guard,
+        "latest_exec_date": latest_exec,
+        "latest_backtest_period_date": latest_period,
+    })
+
+    # Verdict (conservative -- never cry wolf on a backtest-period date alone).
+    if exec_cells < total or total == 0:
+        result["verdict"] = "INCOMPLETE"
+    elif error_cells > 0:
+        result["verdict"] = "HAS_ERRORS"
+    elif latest_exec is None:
+        # Executed but no parseable date in outputs -- can't judge freshness.
+        result["verdict"] = "EXEC_PROVED_NO_DATE"
+    else:
+        result["verdict"] = "EXEC_PROVED"  # freshness judged by the caller vs threshold
+    return result
+
+
+def _classify_freshness(result: dict, min_year: int) -> str:
+    """Refine EXEC_PROVED into FRESH / STALE / PERIOD_DOMINATED vs threshold.
+
+    HARD nuance (ai-01 c.40, PROVEN empirically on the ML family): when the
+    freshest output date COINCIDES with the configured backtest period
+    (``latest_exec_date == latest_backtest_period_date``), that date is the
+    ``SetEndDate`` -- it describes the NOTEBOOK'S window, not WHEN the notebook
+    was last executed. It therefore CANNOT prove execution recency.
+
+    Proof: ML-DeepLearning (#8756) and ML-XGBoost (#8760) were freshly
+    re-executed this week on 2026-07-28 data, yet both show 2024-12-31 in
+    their outputs -- their ``SetEndDate(2024,12,31)``. They are
+    indistinguishable by this field from ML-RandomForest / ML-SVM, which were
+    NOT re-executed. Crying STALE on a period date = false positive.
+
+    So the verdict distinguishes:
+      - PERIOD_DOMINATED (the freshest output date IS the period): freshness
+        UNDETERMINABLE from the date field. Split into _RECENT / _AGED by the
+        threshold so an old window still draws a human glance without the
+        false confidence of "STALE".
+      - non-period date present: a date that is NOT the backtest period
+        (e.g. a freshness-guard print, a "data fresh to 2026-07-28" line, a
+        version/timestamp) -- THIS can judge recency -> FRESH / STALE_OUTPUTS.
+    """
+    latest = result.get("latest_exec_date")
+    if latest is None:
+        return result.get("verdict", "UNKNOWN")
+    yr = int(latest[:4])
+    period = result.get("latest_backtest_period_date")
+    period_dominated = period is not None and latest == period
+    if period_dominated:
+        return "PERIOD_DOMINATED_AGED" if yr < min_year else "PERIOD_DOMINATED_RECENT"
+    return "EXEC_PROVED_FRESH" if yr >= min_year else "STALE_OUTPUTS"
+
+
+def scan_root(root: Path) -> list[dict]:
+    """Scan every projects/*/quantbook.ipynb under root."""
+    results: list[dict] = []
+    for nb in sorted(root.glob("*/quantbook.ipynb")):
+        results.append(scan_notebook(nb))
+    return results
+
+
+def human_report(results: list[dict], min_year: int) -> str:
+    lines: list[str] = []
+    lines.append(f"# Quantbook output-date freshness audit (threshold: latest date >= {min_year}-01-01)")
+    lines.append("")
+    header = f"{'Notebook':<38} {'exec':>8} {'errs':>5} {'guard':>6} {'latest_out':>12} {'latest_period':>14} {'verdict'}"
+    lines.append(header)
+    lines.append("-" * len(header))
+    for r in results:
+        name = Path(r["notebook"]).parent.name
+        exec_str = f"{r.get('exec_cells', '?')}/{r.get('total_code_cells', '?')}"
+        guard = "Y" if r.get("guard_present") else "n"
+        latest_out = r.get("latest_exec_date") or "-"
+        latest_per = r.get("latest_backtest_period_date") or "-"
+        base = r.get("verdict", "?")
+        verdict = _classify_freshness(r, min_year) if base == "EXEC_PROVED" else base
+        r["final_verdict"] = verdict
+        lines.append(f"{name:<38} {exec_str:>8} {r.get('error_cells', 0):>5} {guard:>6} {latest_out:>12} {latest_per:>14} {verdict}")
+    lines.append("")
+    stale = [r for r in results if r.get("final_verdict") == "STALE_OUTPUTS"]
+    incomplete = [r for r in results if r.get("final_verdict") in ("INCOMPLETE", "HAS_ERRORS", "READ_ERROR")]
+    fresh = [r for r in results if r.get("final_verdict") == "EXEC_PROVED_FRESH"]
+    no_date = [r for r in results if r.get("final_verdict") == "EXEC_PROVED_NO_DATE"]
+    pd_aged = [r for r in results if r.get("final_verdict") == "PERIOD_DOMINATED_AGED"]
+    pd_recent = [r for r in results if r.get("final_verdict") == "PERIOD_DOMINATED_RECENT"]
+    lines.append(f"Summary: {len(fresh)} FRESH, {len(stale)} STALE(non-period), "
+                 f"{len(pd_aged)} PERIOD_AGED, {len(pd_recent)} PERIOD_RECENT, "
+                 f"{len(no_date)} EXEC_NO_DATE, {len(incomplete)} INCOMPLETE/ERROR, {len(results)} total.")
+    lines.append("")
+    lines.append("NOTE: latest_date_in_outputs is PERIOD-DOMINATED for SetEndDate-anchored notebooks")
+    lines.append("(cannot prove execution recency -- ML-DeepLearning/#8756 & ML-XGBoost/#8760 were")
+    lines.append("freshly re-executed 2026-07-28 yet show 2024-12-31 = their SetEndDate(2024)).")
+    lines.append("Actionable signal = INCOMPLETE executions below, not period dates.")
+    if stale:
+        lines.append("")
+        lines.append("## STALE_OUTPUTS (non-period old date in outputs -- re-exec on fresh data)")
+        for r in stale:
+            lines.append(f"  - {Path(r['notebook']).parent.name}: latest output date {r.get('latest_exec_date')}, period={r.get('latest_backtest_period_date')}, guard={r.get('guard_present')}")
+    if pd_aged:
+        lines.append("")
+        lines.append("## PERIOD_DOMINATED_AGED (freshest output = an old SetEndDate; freshness undeterminable, human glance warranted)")
+        for r in pd_aged:
+            lines.append(f"  - {Path(r['notebook']).parent.name}: date {r.get('latest_exec_date')} (=SetEndDate window), guard={r.get('guard_present')}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    # Default root: discover relative to this script (repo/projects).
+    default_root = Path(__file__).resolve().parents[2] / "MyIA.AI.Notebooks" / "QuantConnect" / "projects"
+    p.add_argument("--root", default=str(default_root),
+                   help=f"projects dir containing <Name>/quantbook.ipynb (default: {default_root})")
+    p.add_argument("--min-year", type=int, default=2024,
+                   help="freshness threshold: latest output date year >= this (default 2024, C942-L)")
+    p.add_argument("--json", action="store_true", help="emit machine-readable JSON instead of a human table")
+    p.add_argument("--no-fail", action="store_true", help="always exit 0 even if STALE outputs found")
+    args = p.parse_args(argv)
+
+    root = Path(args.root)
+    if not root.is_dir():
+        print(f"ERROR: root not found: {root}", file=sys.stderr)
+        return 2
+
+    results = scan_root(root)
+    if args.json:
+        # enrich with final verdict for machine consumers
+        for r in results:
+            if r.get("verdict") == "EXEC_PROVED":
+                r["final_verdict"] = _classify_freshness(r, args.min_year)
+            else:
+                r["final_verdict"] = r.get("verdict", "UNKNOWN")
+        print(json.dumps({"min_year": args.min_year, "results": results}, indent=2))
+    else:
+        print(human_report(results, args.min_year))
+
+    stale = sum(1 for r in results if r.get("verdict") == "EXEC_PROVED"
+                and _classify_freshness(r, args.min_year) == "STALE_OUTPUTS")
+    if stale > 0 and not args.no_fail:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quantconnect/tests/test_audit_quantbooks_output_dates.py
+++ b/scripts/quantconnect/tests/test_audit_quantbooks_output_dates.py
@@ -1,0 +1,220 @@
+"""Tests for audit_quantbooks_output_dates.py -- output-date freshness (#8734, ai-01 c.40)."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from audit_quantbooks_output_dates import (  # noqa: E402
+    _all_dates_in_text,
+    _cell_output_text,
+    _classify_freshness,
+    _guard_present,
+    scan_notebook,
+)
+
+
+# --- _all_dates_in_text ---
+
+class TestAllDatesInText:
+    def test_iso_dates(self):
+        assert _all_dates_in_text("ran on 2026-07-28, data to 2025-12-31") == ["2025-12-31", "2026-07-28"]
+
+    def test_compact_dates(self):
+        assert _all_dates_in_text("window 20150102 to 20251231") == ["2015-01-02", "2025-12-31"]
+
+    def test_dedup_and_sort(self):
+        text = "2026-07-28 and 2026-07-28 and 2025-01-01"
+        assert _all_dates_in_text(text) == ["2025-01-01", "2026-07-28"]
+
+    def test_invalid_calendar_dropped(self):
+        # 13th month / 32nd day are not real dates -> dropped, not normalized.
+        assert _all_dates_in_text("bogus 2025-13-01 and 2025-12-32") == []
+
+    def test_empty(self):
+        assert _all_dates_in_text("") == []
+        assert _all_dates_in_text(None) == []
+
+    def test_no_19xx_false_matches(self):
+        # Only 20xx captured; a stray 1999-01-01 is ignored.
+        assert _all_dates_in_text("legacy 1999-01-01 real 2024-06-15") == ["2024-06-15"]
+
+
+# --- _cell_output_text ---
+
+class TestCellOutputText:
+    def test_stream_text_string(self):
+        cell = {"outputs": [{"output_type": "stream", "text": "hello 2026-07-28"}]}
+        assert "2026-07-28" in _cell_output_text(cell)
+
+    def test_stream_text_list(self):
+        cell = {"outputs": [{"output_type": "stream", "text": ["line1\n", "2025-12-31\n"]}]}
+        assert "2025-12-31" in _cell_output_text(cell)
+
+    def test_data_text_plain(self):
+        cell = {"outputs": [{"output_type": "execute_result",
+                             "data": {"text/plain": "array([2024-01-01])"}}]}
+        assert "2024-01-01" in _cell_output_text(cell)
+
+    def test_data_text_list(self):
+        cell = {"outputs": [{"data": {"text/plain": ["a", "2023-06-01"]}}]}
+        assert "2023-06-01" in _cell_output_text(cell)
+
+    def test_ignores_non_text_data(self):
+        cell = {"outputs": [{"data": {"image/png": "base64..."}}]}
+        assert _cell_output_text(cell) == ""
+
+    def test_empty(self):
+        assert _cell_output_text({}) == ""
+        assert _cell_output_text({"outputs": []}) == ""
+
+
+# --- _guard_present ---
+
+class TestGuardPresent:
+    def test_detects_filldataforward(self):
+        assert _guard_present({"cells": [{"source": "if not fillDataForward: raise"}]}) is True
+
+    def test_detects_flat_tail(self):
+        assert _guard_present({"cells": [{"source": "# C942 flat-tail guard"}]}) is True
+
+    def test_detects_c941_c942_c951(self):
+        for needle in ("c941", "c942", "c951"):
+            assert _guard_present({"cells": [{"source": f"# see {needle}"}]}) is True
+
+    def test_detects_provisioner_ref(self):
+        assert _guard_present({"cells": [{"source": "# regenerate via provision_lean_data"}]}) is True
+
+    def test_absent(self):
+        assert _guard_present({"cells": [{"source": "x = 1"}]}) is False
+
+    def test_empty_nb(self):
+        assert _guard_present({"cells": []}) is False
+
+
+# --- scan_notebook (end-to-end on a tmp JSON) ---
+
+def _write_nb(path: Path, cells: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"cells": cells, "metadata": {}, "nbformat": 4}), encoding="utf-8")
+    return path
+
+
+def _code(source: str, ec=None, outputs=None):
+    return {"cell_type": "code", "execution_count": ec,
+            "source": source, "outputs": outputs or []}
+
+
+class TestScanNotebook:
+    def test_incomplete(self, tmp_path):
+        nb = tmp_path / "Proj" / "quantbook.ipynb"
+        _write_nb(nb, [_code("x=1", ec=1), _code("y=2", ec=None)])  # 1/2 executed
+        r = scan_notebook(nb)
+        assert r["verdict"] == "INCOMPLETE"
+        assert r["exec_cells"] == 1 and r["total_code_cells"] == 2
+
+    def test_has_errors(self, tmp_path):
+        nb = tmp_path / "Proj" / "quantbook.ipynb"
+        _write_nb(nb, [_code("x=1", ec=1, outputs=[{"output_type": "error", "ename": "V", "evalue": "x"}])])
+        r = scan_notebook(nb)
+        assert r["verdict"] == "HAS_ERRORS"
+        assert r["error_cells"] == 1
+
+    def test_exec_proved_no_date(self, tmp_path):
+        nb = tmp_path / "Proj" / "quantbook.ipynb"
+        _write_nb(nb, [_code("x=1", ec=1, outputs=[{"output_type": "stream", "text": "no dates here"}])])
+        r = scan_notebook(nb)
+        assert r["verdict"] == "EXEC_PROVED_NO_DATE"
+        assert r["latest_exec_date"] is None
+
+    def test_extracts_output_date(self, tmp_path):
+        nb = tmp_path / "Proj" / "quantbook.ipynb"
+        _write_nb(nb, [_code("x=1", ec=1,
+                             outputs=[{"output_type": "stream", "text": "window to 2026-07-28 ok"}])])
+        r = scan_notebook(nb)
+        assert r["verdict"] == "EXEC_PROVED"
+        assert r["latest_exec_date"] == "2026-07-28"
+
+    def test_period_date_collected_from_output(self, tmp_path):
+        nb = tmp_path / "Proj" / "quantbook.ipynb"
+        _write_nb(nb, [_code("x=1", ec=1,
+                             outputs=[{"output_type": "stream", "text": "Periode: 2020-01-01 a 2024-12-31"}])])
+        r = scan_notebook(nb)
+        assert r["latest_backtest_period_date"] == "2024-12-31"
+        assert r["latest_exec_date"] == "2024-12-31"
+
+    def test_period_date_collected_from_source(self, tmp_path):
+        # An ISO date inside a period-hint SOURCE line is collected as a period date.
+        nb = tmp_path / "Proj" / "quantbook.ipynb"
+        _write_nb(nb, [_code("# Periode: 2020-01-01 a 2024-12-31", ec=1, outputs=[])])
+        r = scan_notebook(nb)
+        assert r["latest_backtest_period_date"] == "2024-12-31"
+
+    def test_comma_form_setenddate_not_parsed(self, tmp_path):
+        # Known limitation: SetEndDate(2024,12,31) uses comma-separated args and is
+        # NOT matched by the ISO/compact regexes. Period detection relies on the
+        # ISO form that Lean prints when resolving the date (see test_period_date_
+        # collected_from_output above).
+        nb = tmp_path / "Proj" / "quantbook.ipynb"
+        _write_nb(nb, [_code("qb.SetStartDate(2020,1,1)\nqb.SetEndDate(2024,12,31)", ec=1,
+                             outputs=[{"output_type": "stream", "text": "ran"}])])
+        r = scan_notebook(nb)
+        assert r["latest_backtest_period_date"] is None
+        assert r["latest_exec_date"] is None
+
+    def test_read_error(self, tmp_path):
+        nb = tmp_path / "Proj" / "quantbook.ipynb"
+        _write_nb(nb, [_code("x=1", ec=1)])
+        # Corrupt it after writing.
+        nb.write_text("{not valid json", encoding="utf-8")
+        r = scan_notebook(nb)
+        assert r["verdict"] == "READ_ERROR"
+        assert r["error"] is not None
+
+    def test_guard_detection_end_to_end(self, tmp_path):
+        nb = tmp_path / "Proj" / "quantbook.ipynb"
+        _write_nb(nb, [_code("# C942 flat tail guard\nx=1", ec=1,
+                             outputs=[{"output_type": "stream", "text": "2026-07-28"}])])
+        r = scan_notebook(nb)
+        assert r["guard_present"] is True
+
+
+# --- _classify_freshness (the c.40 false-positive guard) ---
+
+class TestClassifyFreshness:
+    def test_period_dominated_aged_not_stale(self):
+        # The c.40 false-positive guard: latest == period -> PERIOD_DOMINATED, never STALE.
+        r = {"latest_exec_date": "2024-12-31", "latest_backtest_period_date": "2024-12-31",
+             "verdict": "EXEC_PROVED"}
+        assert _classify_freshness(r, 2025) == "PERIOD_DOMINATED_AGED"
+
+    def test_period_dominated_recent(self):
+        r = {"latest_exec_date": "2025-12-31", "latest_backtest_period_date": "2025-12-31",
+             "verdict": "EXEC_PROVED"}
+        assert _classify_freshness(r, 2025) == "PERIOD_DOMINATED_RECENT"
+
+    def test_non_period_fresh(self):
+        # A freshness-guard print (2026-07-28) != the period (2025-12-31) -> FRESH.
+        r = {"latest_exec_date": "2026-07-28", "latest_backtest_period_date": "2025-12-31",
+             "verdict": "EXEC_PROVED"}
+        assert _classify_freshness(r, 2025) == "EXEC_PROVED_FRESH"
+
+    def test_non_period_stale(self):
+        # A non-period old date below threshold -> genuine STALE (not period-dominated).
+        r = {"latest_exec_date": "2023-06-01", "latest_backtest_period_date": "2025-12-31",
+             "verdict": "EXEC_PROVED"}
+        assert _classify_freshness(r, 2025) == "STALE_OUTPUTS"
+
+    def test_no_period_treated_as_non_period(self):
+        # No period date at all -> judge by the exec date alone.
+        r = {"latest_exec_date": "2026-07-28", "latest_backtest_period_date": None,
+             "verdict": "EXEC_PROVED"}
+        assert _classify_freshness(r, 2025) == "EXEC_PROVED_FRESH"
+
+    def test_no_date_returns_verdict(self):
+        r = {"latest_exec_date": None, "latest_backtest_period_date": None,
+             "verdict": "EXEC_PROVED_NO_DATE"}
+        assert _classify_freshness(r, 2025) == "EXEC_PROVED_NO_DATE"


### PR DESCRIPTION
Grain: DEEP/qc — lane myia-po-2024:CoursIA-2 — prev: DEEP/qc (#8760 ML-XGBoost)

ai-01 c.40 directive: « Detecteur mecanique sur tous les quantbooks merges... sur chaque `quantbook.ipynb`, sortir par notebook — `execution_count is None`, `outputs` vides, `output_type == "error"`, **date la plus recente presente dans les sorties**, et presence du guard. Un tableau, une ligne par notebook. » This PR delivers that detector.

## The gap it fills

Two detectors existed; neither catches the third failure mode:
- `audit_quantbooks_unexec.py` (#6891) → checks **execution** (`execution_count is None`, `outputs == []`, errors).
- `check_data_freshness.py` (#8737) → checks **data zips** (FRESH/STALE per ticker).
- **This tool** → checks committed **OUTPUTS** for date freshness: a notebook with full `execution_count` yet outputs describing an old market.

## The c.40 false-positive trap — PROVEN empirically (the core finding)

ai-01 c.40 anticipated it: « les dates de periode de backtest (2025-12-31) ne sont pas des dates d'execution. Il faut distinguer les deux. »

The detector proves this is not just a theoretical risk — it's the dominant failure mode. The `latest_date_in_outputs` field is **PERIOD-DOMINATED** for any notebook anchored at a historical `SetEndDate`:

- **ML-DeepLearning** (#8756, merged) — freshly re-executed on **2026-07-28** data this week → outputs show **2024-12-31**.
- **ML-XGBoost** (#8760, merged) — freshly re-executed on **2026-07-28** data this week → outputs show **2024-12-31**.

That date is their `SetEndDate(2024,12,31)`. They are **indistinguishable by this field** from ML-RandomForest / ML-SVM, which were **NOT** re-executed.

**Consequence for the verdict logic**: the detector never cries STALE on a period date. When `latest_exec_date == latest_backtest_period_date` → `PERIOD_DOMINATED` (`_AGED`/`_RECENT` by threshold), freshness **undeterminable** from dates. STALE fires only on a **non-period** old date (e.g. a stale timestamp/guard-print). This is the conservative design that avoids the wolf-cry.

## Full-catalogue run (46 quantbooks, `--min-year 2025`)

```
Summary: 1 FRESH, 0 STALE(non-period), 4 PERIOD_AGED, 31 PERIOD_RECENT,
         0 EXEC_NO_DATE, 10 INCOMPLETE/ERROR, 46 total.
```

**Actionable signal = the 10 INCOMPLETE executions** (the date field cannot catch stale-but-executed; the execution-coverage gap can):
- ML-TextClassification 4/14 · VIX-TermStructure 2/10 · RL-Portfolio 3/10 · FuturesTrend 3/8 · PairsTrading 3/7 · AllWeather 4/8 · RiskParity 4/8 · SectorMomentum 5/7 · MomentumStrategy 6/8 · ForexCarry 9/10

(3 of these — FuturesTrend / VIX-TermStructure / ForexCarry — are the out-of-scope futures/forex quantbooks noted in the c.38 census.)

## Limitation (documented, not hidden)

Comma-form `SetEndDate(2024,12,31)` in source is not matched by the ISO/compact regexes — period detection relies on the ISO form Lean prints when resolving the date (which is what dominates outputs anyway). Covered by `test_comma_form_setenddate_not_parsed`. This does not weaken the false-positive guard (period-dominance is only asserted when `latest_exec == latest_period`, both from detectable dates).

## Deliverable

Single new instrument (`scripts/quantconnect/audit_quantbooks_output_dates.py` + 33 offline tests). Read-only detection, exit-1 gateable on genuine STALE. No notebook corrections in this PR — the audit found **no non-period stale outputs** to correct (Stop & Repair would apply if it had); the committed detector is the deliverable. The 4 PERIOD_AGED ML notebooks are already addressed where actionable (#8756/#8760 merged; ML-RandomForest/ML-SVM remain in the c.38 dispatch queue as genuine equity-quantbook re-exec work, flagged by *execution* gaps / dispatch scope, not by the date field).

## Scope / non-goals

- 2 files (+544/-0), catalogue byte-identical to `main`.
- Detection only — no notebook re-executions here.
- Out of scope (c.38 dispatch): ML-RandomForest / ML-SVM / ML-TextClassification re-exec on freshly provisioned data.

See #8734
