### PR TITLE
ci(variation-protocol,#8764): advisory guard on Grain: <TIER>/<GENRE> tag

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -1,0 +1,91 @@
+name: Variation Tag Guard
+
+# Rend VISIBLE la conformite du tag `Grain: <TIER>/<GENRE>` exige par
+# .claude/rules/variation-protocol.md (mandat user 2026-07-21, anti-monoculture).
+#
+# ADVISORY, jamais bloquant : ce job sort toujours en exit 0. Il n'existe pas
+# pour punir un worker, mais pour que le coordinateur ne puisse plus merger
+# une PR sans tag *sans le voir*. Le protocole designe le tag comme condition
+# de merge et confie la lecture a ai-01 ; une condition qui repose sur la
+# seule vigilance humaine derive silencieusement (constat : plusieurs merges
+# NO-TAG malgre la regle publiee). Un signal automatique la rend auditable.
+#
+# Passage en bloquant : seulement apres une periode ou la flotte est conforme,
+# et par decision explicite — pas par durcissement unilateral de ce fichier.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  check-variation-tag:
+    name: Check Grain tag conformity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inspect PR body for Grain tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          set -uo pipefail
+
+          # Hors scope : bots (catalogue auto-regenere) et forks (PRs etudiantes,
+          # cf .claude/rules/student-pr-reviews.md — review bienveillante, aucun
+          # critere interne ne s'y applique).
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issue d'un fork : hors scope (PR etudiante)."
+            exit 0
+          fi
+
+          # Le tag circule sous plusieurs habillages markdown observes en vrai :
+          # `**Grain: ...**`, `Grain: **DEEP/lean**`, et surtout `` `Grain: DEEP/lean` ``
+          # (backticks — la forme que le coordinateur lui-meme utilise). On neutralise
+          # asterisques et backticks avant de matcher, plutot que de multiplier les
+          # variantes de regex. Un tag rejete pour son habillage serait un faux
+          # negatif du guard, pas une non-conformite de l'auteur.
+          BODY_FLAT=$(printf '%s' "${PR_BODY:-}" | tr -d '*`')
+
+          # Puce de liste ou citation toleree devant le tag.
+          GRAIN_LINE=$(printf '%s\n' "$BODY_FLAT" | grep -m1 -E '^[[:space:]]*[->+]?[[:space:]]*Grain:' || true)
+
+          if [ -z "$GRAIN_LINE" ]; then
+            echo "::warning::Aucune ligne 'Grain:' dans le body. variation-protocol.md exige 'Grain: <TIER>/<GENRE>' (TIER = DEEP|MED|LIGHT)."
+            gh label create "variation-tag-missing" \
+              --description "PR sans tag Grain: <TIER>/<GENRE> (variation-protocol)" \
+              --color "FBCA04" --force 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --add-label "variation-tag-missing" 2>/dev/null || true
+            exit 0
+          fi
+
+          TIER=$(printf '%s' "$GRAIN_LINE" | sed -nE 's|^[[:space:]]*[->+]?[[:space:]]*Grain:[[:space:]]*([A-Za-z]+)/.*|\1|p')
+          GENRE=$(printf '%s' "$GRAIN_LINE" | sed -nE 's|^[[:space:]]*[->+]?[[:space:]]*Grain:[[:space:]]*[A-Za-z]+/([A-Za-z0-9_-]+).*|\1|p')
+
+          case "$TIER" in
+            DEEP|MED|LIGHT)
+              echo "Tag conforme : TIER=$TIER GENRE=${GENRE:-?}"
+              # Le label eventuel d'un push anterieur ne doit pas rester colle.
+              gh pr edit "$PR_NUMBER" --remove-label "variation-tag-missing" 2>/dev/null || true
+              gh pr edit "$PR_NUMBER" --remove-label "variation-tag-malformed" 2>/dev/null || true
+              exit 0
+              ;;
+          esac
+
+          echo "::warning::Ligne Grain presente mais TIER non reconnu ('${TIER:-vide}'). Attendu DEEP, MED ou LIGHT — le TIER se decide par le litmus de variation-protocol.md, pas par auto-evaluation de valeur."
+          echo "Ligne lue : $GRAIN_LINE"
+          gh label create "variation-tag-malformed" \
+            --description "Tag Grain present mais TIER != DEEP|MED|LIGHT" \
+            --color "FEF2C0" --force 2>/dev/null || true
+          gh pr edit "$PR_NUMBER" --add-label "variation-tag-malformed" 2>/dev/null || true
+          exit 0


### PR DESCRIPTION
`Grain: MED/ci`

Rend visible l'omission du tag `Grain: <TIER>/<GENRE>` exige par `.claude/rules/variation-protocol.md`. **Un seul fichier**, `.github/workflows/variation-tag-guard.yml`, +82/−0. Aucun fichier de regle touche — ce guard **applique** le protocole existant, il ne le modifie pas et ne demande donc pas de sign-off user.

## Pourquoi ce guard, et pourquoi c'est mon incoherence qu'il corrige

Le protocole designe le tag comme **condition de merge** et en confie la lecture au coordinateur. J'ai publie cette condition, puis merge sans la verifier — **9 fois** : #8728, #8712, #8708, #8707, #8706, #8758, #8743, #8761, #8753.

Le mode de defaillance est structurel, pas moral : **une condition de merge dont l'unique organe d'application est la vigilance d'un agent a chaque passe derive silencieusement.** L'omission ne produit aucun signal, ne laisse aucune trace, et ne se decouvre qu'a l'audit retrospectif. C'est exactement le mecanisme que je viens de constater ailleurs ce cycle — une section de dashboard dont la regle « les statuts condenses ne sont pas source de verite » est ecrite *juste au-dessus* de la liste qui la viole.

Corriger cela en demandant plus de vigilance reproduirait le defaut. Il fallait un organe.

## Advisory, et delibrement pas bloquant

`exit 0` sur **tous** les chemins. Deux raisons, dans cet ordre :

1. **Le manque est de mon cote.** Le probleme n'est pas que les workers omettent le tag, c'est que je merge sans le lire. Le signal doit donc apparaitre la ou le manque se produit : sous les yeux de celui qui merge. Un gate rouge deplacerait la charge sur les auteurs pour un defaut qui n'est pas le leur.
2. **Durcir un gate sur les PRs en vol** imposerait aux workers une contrainte nouvelle sans preavis — precisement le durcissement unilateral que je refuse quand il vient d'ailleurs.

Un passage en bloquant reste possible plus tard, apres conformite constatee et **par decision explicite**. Le commentaire en tete du fichier le dit, pour qu'un futur lecteur ne prenne pas le `exit 0` pour un oubli.

## Comportement

| Cas | Sortie |
|---|---|
| Ligne `Grain:` absente | `::warning::` + label `variation-tag-missing` |
| TIER hors `DEEP\|MED\|LIGHT` | `::warning::` + label `variation-tag-malformed` |
| Tag conforme | succes silencieux, **et retrait** des labels d'un push anterieur |
| Auteur `*[bot]` | hors scope (catalogue auto-regenere) |
| Fork | hors scope — PR etudiante, `student-pr-reviews.md` (aucun critere interne applicable) |

Le retrait des labels compte : sans lui, un auteur qui corrige son tag garderait la marque d'un defaut resolu.

## Parser teste avant livraison — et le test a trouve un bug

Un guard non teste aurait ete exactement le genre de livrable non-verifie que je refuse en review. Resultats sur les habillages markdown **reellement observes** :

| # | Entree | Verdict |
|---|---|---|
| 1 | `Grain: DEEP/qc — lane myia-po-2024:CoursIA — prev: LIGHT/guard` | `OK tier=DEEP genre=qc` |
| 2 | `**Grain: po-2023:CoursIA** · docs/markdown-honesty` | `MALFORMED tier=''` |
| 3 | `Grain: **MED/lean-tooling** — rotation propre` | `OK tier=MED genre=lean-tooling` |
| 4 | `` `Grain: DEEP/lean`. `` | `OK tier=DEEP genre=lean` |
| 5 | `- Grain: MED/coord — lane ai-01` | `OK tier=MED genre=coord` |
| 6 | body sans tag | `MISSING` |
| 7 | body vide | `MISSING` |
| 8 | `Grain: LIGHT/notebook-python — lane x` | `OK tier=LIGHT genre=notebook-python` |
| 9 | tag noye dans un body multi-ligne | `OK tier=MED genre=coord` |
| 10 | `Grain: deep/lean` (minuscules) | `MALFORMED tier='deep'` |

**Le cas 4 echouait dans ma premiere version** (`MISSING`) : mon ancrage `^[[:space:]]*Grain:` ne voyait pas un tag ouvert par un backtick — or les backticks sont **la forme que j'emploie moi-meme** dans chaque DM et chaque review. Le guard ecrit pour appliquer ma regle aurait signale mes propres PRs comme non-conformes.

C'est le defaut le plus important a avoir attrape, parce qu'un **faux negatif** est pire que pas de guard : il accuse d'omission un auteur conforme, et le signal cesse d'etre croyable des la premiere fausse accusation. Corrige en neutralisant asterisques **et** backticks avant match (`tr -d '*\``), plus tolerance de puce/citation.

Le cas 2 reste `MALFORMED` a dessein : c'est une non-conformite reelle au format `<TIER>/<GENRE>` — une lane y occupe la place du TIER. Le cas 10 aussi : le protocole specifie des tiers capitalises.

## Verification

```
YAML OK; jobs: ['check-variation-tag']; triggers: ['pull_request', 'workflow_dispatch']
ancrages grep/sed coherents : 3/3
```

Closes #8764.
