### PR TITLE
feat(lean,#6724): arm G3 bridge with offset machinery for crux (a) [sorry FLAT 8->8]

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -2876,6 +2876,30 @@ private theorem isAlive_true_iff_mem_local (g : Grid) (p : Int × Int) :
     isAlive g p = true ↔ p ∈ g := by
   rw [isAlive]; exact List.elem_iff
 
+/-- **crux (a) offset building block (sorry-free, #6724 c.749).** The
+    `2^level`-pinned quadrant decomposition of a `node`'s `toGrid` membership.
+    `mem_toGrid_node` (L1478) already decomposes `(node nw ne sw se).toGrid
+    (r0,c0)` but leaves the quadrant offset as the OPAQUE `2 ^ nw.level`; this
+    specialization pins it to the concrete `2 ^ k` once `nw.level = k` is known.
+
+    This is the "lemme intermédiaire nommé sur les offsets seuls" prescribed for
+    crux (a) (DM `msg-20260729T010408-cromnx`): the quadrant-offset arithmetic
+    (NW `(0,0)`, NE `(0, 2^k)`, SW `(2^k, 0)`, SE `(2^k, 2^k)`) isolated from the
+    game-of-life theory. Proven by `mem_toGrid_node` + the level rewrite — no
+    `sorry`, no game semantics. It is the available offset machinery the bridge
+    `(a)` half assembles over (see `p4_nw_g3_bridge` docstring); the bridge is
+    armed below with `hR1_l … hR5_l : R_j.level = k` precisely so it can apply
+    this lemma to pin every `(node R1 R2 R4 R5)` offset. -/
+private theorem p4_nw_offset_decomp (k : Nat)
+    (R1 R2 R4 R5 : MacroCell) (hR1_l : R1.level = k) (p : Int × Int) :
+    p ∈ (node R1 R2 R4 R5).toGrid (0, 0) ↔
+      p ∈ R1.toGrid (0, 0) ∨
+      p ∈ R2.toGrid (0, (2 ^ k : Int)) ∨
+      p ∈ R4.toGrid ((2 ^ k : Int), 0) ∨
+      p ∈ R5.toGrid ((2 ^ k : Int), (2 ^ k : Int)) := by
+  rw [mem_toGrid_node, hR1_l]
+  simp only [Int.zero_add, Int.add_zero]
+
 /-- **G3 wave-assembly bridge (named extraction, #6724 c.745).** The research
     heart of `p4_nw_supercell_agree`, extracted as a NAMED lemma carrying ALL
     the call-site hypotheses — per the ai-01 extraction protocol (DM
@@ -2895,8 +2919,14 @@ private theorem isAlive_true_iff_mem_local (g : Grid) (p : Int × Int) :
         facts (hcc1/2/4/5 → R_j centre = evolve (2^(k-1)) n_j on the central
         window) via `mem_toGrid_node` (node→4-quadrant decomposition, sorry-free
         L1478). The quadrant-offset arithmetic (NW at (0,0), NE at (0, 2^level),
-        etc.) and the `2^level` half-size shifts are the assembly glue NOT yet
-        bridged.
+        etc.) and the `2^level` half-size shifts are the assembly glue. **The
+        offset half is now armed (c.749):** the signature carries
+        `hR1_l … hR5_l : R_j.level = k` (transported from the call site, which
+        derives them via the proven `hashlifeResultAux_level_cellWf`), and the
+        named sorry-free lemma `p4_nw_offset_decomp` (just below `isAlive_true_iff_mem_local`)
+        pins `(node R1 R2 R4 R5).toGrid`'s quadrant offsets to concrete `2^k`.
+        What remains unbridged is the *evolve-agreement* — relating the evolved
+        parent grid to the per-quadrant `R_j` results on the central cone.
     (b) **Second-half-step locality** (SORRY-FREE once (a) holds):
         `evolve_cone_agree` / `quadrant_cone_agree` (both sorry-free) transport
         the agreement through the outer `evolve (2^(k-1))`, closing the goal
@@ -2915,6 +2945,8 @@ private theorem p4_nw_g3_bridge
     (hR2 : R2 = hashlifeResultAux (k + 1) (node nw_ne ne_nw nw_se ne_sw))
     (hR4 : R4 = hashlifeResultAux (k + 1) (node nw_sw nw_se sw_nw sw_ne))
     (hR5 : R5 = hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
+    (hR1_l : R1.level = k) (hR2_l : R2.level = k)
+    (hR4_l : R4.level = k) (hR5_l : R5.level = k)
     (hcc1 : centralCorrect (node nw_nw nw_ne nw_sw nw_se) (k - 1))
     (hcc2 : centralCorrect (node nw_ne ne_nw nw_se ne_sw) (k - 1))
     (hcc4 : centralCorrect (node nw_sw nw_se sw_nw sw_ne) (k - 1))
@@ -2980,6 +3012,8 @@ private theorem p4_nw_supercell_agree
     (hR2 : R2 = hashlifeResultAux (k + 1) (node nw_ne ne_nw nw_se ne_sw))
     (hR4 : R4 = hashlifeResultAux (k + 1) (node nw_sw nw_se sw_nw sw_ne))
     (hR5 : R5 = hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
+    (hR1_l : R1.level = k) (hR2_l : R2.level = k)
+    (hR4_l : R4.level = k) (hR5_l : R5.level = k)
     (hcc1 : centralCorrect (node nw_nw nw_ne nw_sw nw_se) (k - 1))
     (hcc2 : centralCorrect (node nw_ne ne_nw nw_se ne_sw) (k - 1))
     (hcc4 : centralCorrect (node nw_sw nw_se sw_nw sw_ne) (k - 1))
@@ -3004,7 +3038,8 @@ private theorem p4_nw_supercell_agree
   exact p4_nw_g3_bridge k hk1
     nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
     sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se
-    R1 R2 R4 R5 hR1 hR2 hR4 hR5 hcc1 hcc2 hcc4 hcc5 p
+    R1 R2 R4 R5 hR1 hR2 hR4 hR5
+    hR1_l hR2_l hR4_l hR5_l hcc1 hcc2 hcc4 hcc5 p
 
 /-- **nw membership arm (opaque-binder, sorry-free wiring — ai-01 option-a).**
     Discharges the nw quadrant of `p4_succ_membership` over OPAQUE wave-1
@@ -3078,7 +3113,8 @@ private theorem p4_nw_membership_arm
     rw [p4_nw_supercell_agree k hk1
           nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
           sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se
-          R1 R2 R4 R5 hR1 hR2 hR4 hR5 hcc1 hcc2 hcc4 hcc5 p]
+          R1 R2 R4 R5 hR1 hR2 hR4 hR5
+          hR1_l hR2_l hR4_l hR5_l hcc1 hcc2 hcc4 hcc5 p]
     exact hsup.1
   · -- 2^k ≤ p.1
     exact hsup.2.1


### PR DESCRIPTION
Grain: DEEP/lean-proof-progress — lane myia-po-2026:CoursIA — prev: #8763 (G3 bridge extraction, MERGED), #8766 (trefoil reduction)

## Summary

Third concrete structural step on the #6724 research root `p4_nw_g3_bridge` (HashlifeCorrectness.lean): **arms crux (a) with the named, sorry-free offset machinery ai-01 prescribed**, and resolves the under-hypothesization identified last cycle (the bridge carried no level hypotheses, so the `mem_toGrid_node` quadrant offsets `2^R_j.level` were opaque — a c.19-class trap).

This is the grain ai-01 dispatched (DM `msg-20260729T010408-cromnx`): *« (a) est de l'arithmétique d'offsets... attaquable par lemmes intermédiaires nommés sur les offsets seuls, indépendamment de la vie du jeu — même protocole d'extraction, même test `exact` au site d'appel. »* Two sorry-free building blocks delivered.

### 1. New sorry-free lemma `p4_nw_offset_decomp`

```lean
private theorem p4_nw_offset_decomp (k : Nat)
    (R1 R2 R4 R5 : MacroCell) (hR1_l : R1.level = k) (p : Int × Int) :
    p ∈ (node R1 R2 R4 R5).toGrid (0, 0) ↔
      p ∈ R1.toGrid (0, 0) ∨
      p ∈ R2.toGrid (0, (2 ^ k : Int)) ∨
      p ∈ R4.toGrid ((2 ^ k : Int), 0) ∨
      p ∈ R5.toGrid ((2 ^ k : Int), (2 ^ k : Int)) := by
  rw [mem_toGrid_node, hR1_l]
  simp only [Int.zero_add, Int.add_zero]
```

`mem_toGrid_node` (L1478) already decomposes a `node`'s `toGrid` membership, but leaves the quadrant offset as the OPAQUE `2 ^ nw.level`. This specialization pins it to the concrete `2^k` once `nw.level = k` is known — the quadrant-offset arithmetic (NW `(0,0)`, NE `(0,2^k)`, SW `(2^k,0)`, SE `(2^k,2^k)`) isolated from the game-of-life theory. **Sorry-free, no game semantics, no new axioms.**

### 2. Arm the bridge (signature carry the level hypotheses)

The bridge `p4_nw_g3_bridge` and root `p4_nw_supercell_agree` now carry:
```lean
(hR1_l : R1.level = k) (hR2_l : R2.level = k) (hR4_l : R4.level = k) (hR5_l : R5.level = k)
```
transported from the call site, which derives them via the proven `hashlifeResultAux_level_cellWf` (L2346, gives `(hashlifeResultAux L c).level = L - 1` under `cellWf`). The consumer's `rw [p4_nw_supercell_agree ...]` now passes `hR1_l hR2_l hR4_l hR5_l`.

**The `exact`-test is the correctness proof** (ai-01's extraction protocol, the #8763 pattern): the root's `exact p4_nw_g3_bridge ... hR1_l hR2_l hR4_l hR5_l ...` type-checks only if the level hypotheses propagate faithfully through consumer → root → bridge. `Lean CI SUCCESS` = the arming is faithful, re-verified each build.

## Why this is progress, not cosmetic

1. **The offset half of crux (a) is now a named, proven fact.** Previously the next attacker had to re-derive the quadrant-offset decomposition with concrete `2^k` from `mem_toGrid_node` + a level fact; now `p4_nw_offset_decomp` states it directly and the bridge carries the levels to apply it.
2. **The under-hypothesization is resolved.** Last cycle's finding (the bridge needed `R_j.level` to pin offsets but carried none) is now addressed: the levels are transported, exactly as `centralCorrect` was added to fix the c.19 trap.
3. **What remains is named precisely.** The docstring now distinguishes the offset half (armed/proven) from the *evolve-agreement* half (the unbridged glue: relating the evolved parent grid to the per-quadrant `R_j` results on the central cone).

## Honest scope

- **This is NOT a sorry reduction.** Standalone-tactic sorry count is **FLAT (8 → 8)**: one new sorry-free lemma is added, and the bridge/root signatures are strengthened; the bridge's `sorry` is unchanged.
- **The evolve-agreement wall stands.** crux (a)'s hard part (relating `evolve (2^(k-1)) parent.toGrid` to the `R_j` results) remains. This PR arms the offset machinery and names precisely what's left.
- **No signature/statement changed externally** beyond adding the 4 level hypotheses (which the consumer already had and derived). One new `private` declaration (`p4_nw_offset_decomp`).

## Proof gates (lean-merge-discipline §1 / pr-review-discipline §B)

1. **`grep -c sorry` (anchored)**: standalone-tactic **8 → 8** (FLAT — arming + proven lemma, not reduction).
2. **`lake build Conway.Life.HashlifeCorrectness`**: SUCCESS — warm-cache incremental build in isolated worktree. The `exact p4_nw_g3_bridge ... hR1_l hR2_l hR4_l hR5_l ...` elaborates and `p4_nw_offset_decomp` compiles — the arming's faithfulness test passes.
3. **No new axioms**: the new lemma is `rw` + `simp` (axiom-clean); the arming introduces none.
4. **Not a prover refactor**.

See #6724 (research root — cycle-4 partial progress: #8754 isolated the residual goal, #8763 extracted it as a named bridge, this PR arms it with the offset machinery for crux (a)).

Co-Authored-By: Claude <noreply@anthropic.com>
