### PR TITLE
docs(rules,#8738): §B.3 — 3 classes d'axiomes, cliquet whitelist, état du câblage (critère 4 non livré)

### DIFF
--- a/.claude/rules/pr-review-discipline.md
+++ b/.claude/rules/pr-review-discipline.md
@@ -26,7 +26,21 @@ Si dépassement : refuser le merge, exiger split en PRs cohérentes par feature.
 Toute PR touchant `*.lean` ou `agent_tests/prover/` **DOIT** inclure dans le body :
 1. `grep -c sorry` avant/après par fichier modifié
 2. Lien vers `Lake build SUCCESS` (CI ou commit local prouvable)
-3. Lien vers `Proof integrity SUCCESS` (axiom check) — produit par le job CI `proof-integrity` (câblé lake par lake, pilote `knot_lean`) qui exécute `LeanVerifier.check_axioms(module, fail_on_sorry=True)` : détecte un `sorry` **transitif** (l'axiome `sorryAx` dans la chaîne de dépendances) qu'un `grep -c sorry` ne verra jamais. Reproduction locale : `python -c "from lean_server import LeanVerifier; print(LeanVerifier('<lake-root>').check_axioms('<Module>', fail_on_sorry=True))"` depuis `agent_tests/`. **Tant que le job n'est pas câblé sur le lake de la PR**, B.3 se lit **non applicable** (à écrire explicitement dans le body), jamais comme un gate silencieusement sauté — un reviewer ne doit pas avoir à choisir entre bloquer sur un artefact impossible et merger sur un gate mort (#8677).
+3. Lien vers `Proof integrity SUCCESS` (axiom check) — produit par le job CI `proof-integrity` (câblé lake par lake) qui exécute `LeanVerifier.check_axioms(module, fail_on_sorry=True)`. Reproduction locale : `python -c "from lean_server import LeanVerifier; print(LeanVerifier('<lake-root>').check_axioms('<Module>', fail_on_sorry=True))"` depuis `agent_tests/`.
+
+   **Trois classes d'axiomes sont `forbidden`**, pas seulement le `sorry` :
+
+   | Classe | Ce qu'elle signale |
+   |---|---|
+   | `native_decide.*` | réduction par le noyau natif **sans preuve** — vide le théorème de son contenu |
+   | `sorryAx` | `sorry` **transitif** dans la chaîne de dépendances, qu'un `grep -c sorry` ne verra jamais |
+   | `Classical.choice` | base non-constructive (souvent légitime — se whiteliste au câblage, avec justification écrite) |
+
+   **Un `proof-integrity SUCCESS` antérieur au 2026-07-28 ne prouve PAS l'absence de `native_decide`.** Le parser lisait la sortie de `#print axioms` **ligne par ligne** ; or les noms natifs (`<theoreme>._native.native_decide.ax_1_1`, ~58 caractères) débordent la largeur de pretty-print de Lean et forcent un retour à la ligne — la déclaration entière était alors **silencieusement ignorée**. Le gate était donc structurellement aveugle à la classe exactement la plus dangereuse. Corrigé par #8740 (#8738) ; ne pas ré-invoquer un vert plus ancien comme preuve.
+
+   **Whitelist = noms explicites, jamais de wildcard.** `allow-axioms` liste les axiomes tolérés **un par un** (mécanisme à cliquet : tout nouveau `native_decide` produit un nom absent de la liste → le gate rougit). Un motif générique type `*native_decide*` détruirait la propriété « nouveau `native_decide` = nouveau rouge » et rendrait le gate incapable de rougir — un gate qui ne peut plus rougir n'est pas un gate.
+
+   **Tant que le job n'est pas câblé sur le lake de la PR**, B.3 se lit **non applicable** (à écrire explicitement dans le body), jamais comme un gate silencieusement sauté — un reviewer ne doit pas avoir à choisir entre bloquer sur un artefact impossible et merger sur un gate mort (#8677). État du câblage : **2 lakes sur 23** (`lean-knot.yml`, `lean-conway.yml`) ; statut par lake et axiomes constatés → [docs/reference/lean-axiom-coverage.md](../../docs/reference/lean-axiom-coverage.md).
 
 4. Si refactor du prover Python : justifier pourquoi le refactor est nécessaire pour le claim Lean (sinon split en 2 PRs)
 


### PR DESCRIPTION
`Grain: MED/docs — lane myia-ai-01:CoursIA — prev: MED/guard`

## Ce que ça corrige

Le critère d'acceptance 4 de #8738 — « `pr-review-discipline.md` §B.3 : préciser que le gate couvre `native_decide` » — est **coché `[x]`** dans le ticket avec **#8752** cité comme preuve. #8752 n'a pas livré ce point.

Mesuré à l'instant sur `main` (`dc789ec26`) :

```
$ gh pr view 8752 --json files
  docs/reference/lean-axiom-coverage.md (+141/-0)     <- un seul fichier

$ git log --oneline -1 -- .claude/rules/pr-review-discipline.md
  0a3460342 fix(prover,#8677): wire the B.3 proof-integrity gate ...   <- #8680, pas #8752
```

§B.3 sur `main` ne mentionne aujourd'hui que `sorryAx`. Un reviewer qui l'applique littéralement ne sait pas que le gate couvre `native_decide` — c'est-à-dire, d'après #8738 lui-même, **la classe d'axiomes la plus dangereuse**.

Le reste de #8738 est **réellement livré** et je l'ai vérifié firsthand plutôt que sur les cases cochées :

| Critère | Vérification |
|---|---|
| 1. parser multi-lignes | `_extract_axioms` sur `main` utilise `re.finditer` sur la sortie entière — **OK** |
| 2. test E2E `native_decide` → `forbidden` | `test_real_lean_output_fails_when_native_decide_not_whitelisted` + fixture Lean multi-lignes verbatim ; `pytest tests/test_check_axioms.py` = **28 passed** |
| 3. triage des lakes | `docs/reference/lean-axiom-coverage.md`, 22 lakes, 1 RED (`conway_lean`) — **OK** |
| 4. §B.3 | **NON livré** — objet de cette PR |

## Le contenu ajouté

1. **Les trois classes `forbidden`** en tableau : `native_decide.*`, `sorryAx`, `Classical.choice`. §B.3 n'en nommait qu'une.
2. **Un vert antérieur au 2026-07-28 ne prouve rien sur `native_decide`.** Le parser lisait `#print axioms` ligne par ligne ; les noms natifs (~58 caractères) débordent la largeur de pretty-print de Lean, la déclaration wrappée était donc entièrement ignorée. C'est le point opérationnel : un reviewer qui ré-invoque un `proof-integrity SUCCESS` daté d'avant #8740 invoque un gate aveugle.
3. **Whitelist = noms explicites, jamais de wildcard.** Un motif `*native_decide*` détruirait la propriété « nouveau `native_decide` = nouveau rouge ». La formulation reprend l'argument de po-2023 sur #8746, qui est le bon et mérite d'être dans la règle plutôt que dans un commentaire de workflow.
4. **État du câblage chiffré : 2 lakes sur 23** (`lean-knot.yml`, `lean-conway.yml`), + pointeur vers le doc de couverture. §B.3 dit « non applicable tant que le job n'est pas câblé » sans dire que c'est le cas de 21 lakes sur 23 — un reviewer pouvait croire le gate largement actif.

Aucune obligation nouvelle pour les auteurs de PR : les 4 éléments requis par §B restent les mêmes. Le changement décrit plus exactement un gate **déjà livré**.

## Note de méthode — pourquoi cette PR existe

J'ai cité §B.3 il y a une heure pour merger #8768 (`proof-integrity (conway_lean)` SUCCESS). En allant fermer #8738 sur ses 4 cases cochées, j'ai trouvé qu'une case était fausse. Si je l'avais fermée sur les cases, je fermais un ticket dont le dernier critère n'était pas livré — et je continuais à m'appuyer sur une §B.3 qui décrit un gate plus faible que celui qui tourne.

C'est la leçon du ticket lui-même, retournée contre son propre suivi : *« le gate a toujours été validé contre des fixtures, jamais contre la sortie d'un vrai build »*. Ici : l'acceptance a été validée contre un numéro de PR, jamais contre le fichier.

**#8738 reste OUVERTE** jusqu'au merge de cette PR.

## Sign-off requis

Modification de `.claude/rules/` → **je ne merge pas unilatéralement**, conformément à la même contrainte qui gèle #8744.

Je signale que le contenu est de l'**alignement factuel** (décrire un gate déjà en production) et non un changement de politique : si tu la lis comme telle, elle peut passer sans discussion de fond. Si tu préfères traiter toute édition de `rules/` comme un changement de politique, elle attend derrière #8744.

See #8738, #8740, #8746.
