### PR TITLE
docs(lean,#6724): expose locality-ready half-step form at the crux (a) sorry site

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -2985,7 +2985,24 @@ private theorem p4_nw_g3_bridge
       = isAlive (evolve (2^(k - 1)) ((node R1 R2 R4 R5).toGrid (0, 0)))
           (p.1 - (2^k : Int) + (2^(k - 1) : Int),
            p.2 - (2^k : Int) + (2^(k - 1) : Int)) := by
-  -- G3 wave-assembly (the research heart — see docstring for the (a)/(b) plan).
+  -- Expose the **symmetric half-step form** (c.750→c.751 structural step): both
+  -- sides now carry an outer `evolve (2^(k-1))`, which is the locality-ready shape
+  -- for `evolve_cone_agree` (proven sorry-free, L963). The goal at the `sorry` is
+  -- the (a)/(b) decomposition site:
+  --
+  --   (a) **inner agreement** — `evolve (2^(k-1)) parent.toGrid` agrees (pointwise,
+  --       on the central light cone) with `(node R1 R2 R4 R5).toGrid`, assembled
+  --       from the 4 `hcc_j` (`centralCorrect_mem_shift`, L2443) + the armed
+  --       offset decomp `p4_nw_offset_decomp` (#8768). This is the **double-nine
+  --       overlap wall** (see docstring + L2104-2108): non-overlapping parent
+  --       quadrants vs overlapping wave-1 recombinations R2/R4/R5.
+  --   (b) **outer locality** — once (a) holds, `evolve_cone_agree (2^(k-1))
+  --       (2^(k-1))` transports the agreement through the outer evolve. The
+  --       subtlety (not a single apply): LHS evaluates at `p`, RHS at
+  --       `p' = p - 2^(k-1)` (NW correspondence), so the locality step needs the
+  --       point-shift alignment between the parent's central window and the
+  --       supercell `(node R1 R2 R4 R5)`'s shifted origin.
+  rw [evolve_half_step k hk1]
   sorry
 
 /-- **S4 nw supercell agreement (the residual `sorry`, ai-01's proof target).**


### PR DESCRIPTION
Grain: DEEP/lean-proof-progress — lane myia-po-2026:CoursIA — prev: #8771 (crux-a overlap-wall pinpoint, MERGED)

## Summary

Code-level structural refinement of the `p4_nw_g3_bridge` body (c.751, follow-on to the c.750 docstring pinpoint #8771). The bridge body was a bare \`sorry\` with goal \`evolve (2^k) parent p = evolve (2^(k-1)) Rgrid p'\`; it now opens with \`rw [evolve_half_step k hk1]\`, exposing the **symmetric half-step form** at the sorry site:

\`\`\`
evolve (2^(k-1)) (evolve (2^(k-1)) parent) p = evolve (2^(k-1)) Rgrid p'
\`\`\`

Both sides now carry an outer \`evolve (2^(k-1))\` — the **locality-ready shape** for \`evolve_cone_agree\` (proven sorry-free, L963). A structured comment names exactly where the (a)/(b) decomposition plugs in:

- **(a) inner agreement** (the double-nine overlap wall, L2104-2108 OPEN): \`evolve (2^(k-1)) parent.toGrid\` agrees with \`(node R1 R2 R4 R5).toGrid\` on the central cone, assembled from the 4 \`hcc_j\` (\`centralCorrect_mem_shift\` L2443) + the armed offset decomp \`p4_nw_offset_decomp\` (#8768).
- **(b) outer locality**: \`evolve_cone_agree\` transports the agreement through the outer evolve — subtlety flagged: LHS evaluates at \`p\`, RHS at \`p' = p - 2^(k-1)\` (NW correspondence), so the locality step needs the point-shift alignment, not a single \`apply\`.

## Why this is progress, not cosmetic

1. **The goal at the \`sorry\` is now the locality-ready symmetric form.** Previously the next attacker opened a bridge whose goal was the asymmetric \`evolve (2^k)\` vs \`evolve (2^(k-1))\`; now both sides carry the same outer evolve, which is exactly the shape \`evolve_cone_agree\` consumes.
2. **The (a)/(b) decomposition is now visible at the PROOF level**, not only in the docstring (c.750). The structured comment names the exact plug-in points + the point-shift subtlety that defeats a naive single \`apply evolve_cone_agree\` — saving the next attacker the firsthand re-derivation I did this cycle (reading \`evolve_cone_agree\` L963 to confirm it reduces agreement at a single point \`q\`, hence the p/p' shift needs handling).

## Honest scope

- **NOT a sorry reduction.** Standalone-tactic sorry count is **FLAT (8 -> 8)** — structural refinement. The \`rw\` is a proven lemma (sorry-free); the residual \`sorry\` is unchanged.
- **The evolve-agreement wall stands.** The (a) overlap lemma + the (b) point-shift locality remain open. This PR exposes the goal shape + plug-in points.
- **No external signature/statement change.** Pure bridge-body refinement (18 insertions / 1 deletion: bare \`sorry\` -> \`rw\` + structured comment + \`sorry\`).

## Proof gates (lean-merge-discipline §B)

1. **\`grep -cE '^[[:space:]]*sorry[[:space:]]*$'\` (anchored)**: standalone-tactic **8 -> 8** (FLAT).
2. **\`lake build Conway.Life.HashlifeCorrectness\`**: SUCCESS — exit 0, 8498 jobs, warm-cache incremental build in isolated worktree.
3. **No new axioms**: \`rw\` of a proven lemma, axiom-clean.
4. **Not a prover refactor.**

## Pool / variety note

Surveyed variety firsthand this cycle before returning to the deep track: #8757 already resolved (PR #8767/#8770 merged — G.1 open-issue-already-fixed); #8738 resolved (#8740/#8752 merged); Infer-17 already fully audited (15-ref canonical citation set incl. Kalman 1960, RTS 1965, Minka EP, Bishop PRML). The bounded non-Lean grains checked were drained/resolved; crux (a) is the highest-value free work (ai-01's (A)/(B) arbitration pending). This refinement is the code-level step toward the (A) deeper extraction (writing the (b) locality sorry-free to isolate a named \`p4_nw_overlap_wall\`).

See #6724 (research root — cycle-6 partial progress: #8754 isolated, #8763 extracted as named bridge, #8768 armed offset machinery, #8771 pinpointed the overlap wall, this PR exposes the locality-ready goal shape at the sorry site).

Co-Authored-By: Claude <noreply@anthropic.com>