### PR TITLE
docs(harness): ecrire le detail L576 que git-workflow.md promet a un 404

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Cadre de travail (adapté de Karpathy + ajout user) : ces principes gouvernent *
 - [docs/reference/kernels-runtime.md](docs/reference/kernels-runtime.md) - .NET / Python / WSL kernels, conda envs (`coursia-ml-training`, `mcp-jupyter`, `epita_symbolic_ai`), dotnet-interactive PIN
 - [docs/reference/procedures-recurrentes.md](docs/reference/procedures-recurrentes.md) - Workflow PR, dispatch agents, validation notebook, audit anti-regression, productivite operations longues, pre-commit H.3
 - [docs/reference/stale-tree-drift-scan.md](docs/reference/stale-tree-drift-scan.md) - Scan de drift/traduction sur worktree frais (anti-phantom 88% FP sur arbre partagé dirty)
+- [docs/reference/orphan-branch-scan-l576.md](docs/reference/orphan-branch-scan-l576.md) - Scan de branche orpheline (L576) : les 3 ancres `pulls` mentent dans les deux sens, ancre 4 = identite de contenu
 - [docs/reference/subagents-reference.md](docs/reference/subagents-reference.md) - Catalogue 21 sous-agents + 17 skills, mapping side-tracks, usage async
 - [docs/reference/scripts-reference.md](docs/reference/scripts-reference.md) - Catalogue scripts dépôt (notebook CLI, exécution, catalogue anti-drift, qualité, maintenance/env)
 - [docs/reference/env-python-reparation.md](docs/reference/env-python-reparation.md) - Reparation env Python (regle F)

--- a/docs/reference/orphan-branch-scan-l576.md
+++ b/docs/reference/orphan-branch-scan-l576.md
@@ -1,0 +1,105 @@
+# Scan de branche orpheline (L576) — les deux ancres `pulls` peuvent mentir
+
+Détail de référence de la section « Orphan-branch scan (L576) » de
+[`.claude/rules/git-workflow.md`](../../.claude/rules/git-workflow.md).
+
+> **Note de localisation.** La règle cite ce détail à l'URL
+> `.claude/memory/lecon-L576-rest-commits-pulls-fpos.md`. Ce chemin est **ignoré par
+> `.gitignore`** (ligne 651, aux côtés de `.claude/local/` — état local par machine) : il ne
+> peut donc jamais exister sur `main`, et les deux liens de la règle sont morts par
+> construction. Le détail durable vit ici, conformément à
+> [`harness-hygiene`](../../.claude/rules/harness-hygiene.md) (tier « doc pérenne →
+> `docs/` », référencé succinctement par le harnais).
+
+## Ce que la règle demande
+
+Avant de conclure qu'une branche distante est **orpheline** et de se l'auto-attribuer, trois
+ancres doivent être passées :
+
+1. `git merge-base --is-ancestor <sha> origin/main` — intégrée en amont ?
+2. `gh api repos/jsboige/CoursIA/commits/<sha>/pulls` — endpoint REST (peut être faux négatif)
+3. `gh pr list --state all --search "head:<branche>"` — **gate présenté comme autoritatif**
+
+## Incident fondateur (c.576) — RAPPORTÉ
+
+Symptôme d'origine : **l'ancre 2 (REST) peut renvoyer vide pour une branche réellement
+attachée à une PR ouverte.** Conclure « orpheline » sur `git fetch` + REST seul exposait donc
+à s'auto-attribuer un travail déjà en cours. D'où l'ancre 3, ajoutée comme filet.
+
+*Statut de vérification (2026-07-29)* : les PR citées par la règle — **#7086, #7087, #7088,
+#7089, #7091** (MERGED) et **#7090** (CLOSED) — existent bien. En revanche leurs branches de
+tête sont nommées `fix/…`, `feat/…`, `feature/…`, et **non** `jsboige/*` comme le résumé
+d'une ligne de la règle le laisse entendre. Ce point du résumé hérité n'a pas pu être
+reconfirmé ; le mécanisme (faux négatif REST) reste, lui, la raison d'être de l'ancre 3.
+
+## Nouvelle classe de faux positif — l'ancre 3 aussi peut mentir (VÉRIFIÉ 2026-07-29)
+
+**L'ancre 3 n'est autoritative que si la branche examinée est celle qui a servi de tête à la
+PR.** Elle ne l'est pas pour une **branche de travail locale nommée d'après un numéro de PR**,
+dont le contenu a été livré sous une *autre* tête. Ces branches tombent exactement dans la
+case « ORPHELINE CONFIRMÉE (ok self-pick) » de la matrice — et cette case est **fausse** : le
+travail est déjà sur `main`.
+
+Cinq branches mesurées firsthand, toutes VIVANTE (non-ancêtres de `main`), toutes `PRs=[none]`
+aux ancres 2 **et** 3, toutes en avance de 1 à 5 commits — et **toutes déjà livrées** :
+
+| Branche | Ancre 3 | Contenu réellement sur `main` |
+|---|---|---|
+| `uniontest` | `none` | paire twin GT-13 → `twin_pairs.d/gametheory-13-imperfectinfo-cfr.yaml` |
+| `m8526` | `none` | paire twin App-2-GraphColoring → `twin_pairs.d/app-2-graphcoloring.yaml` |
+| `c17-8525-reexec` | `none` | `bfda2bb1e` (PR #8525) |
+| `tmp8549` | `none` | `5bb5d0194` (PR #8549) |
+| `tmp8556` | `none` | `c826a9c48` (PR #8556) |
+
+Se fier à la matrice seule aurait conduit à **refaire cinq fois du travail mergé** — pas à
+perdre du travail. Le risque L576 est donc **bilatéral** : l'ancre 2 seule fait sur-attribuer
+(double-pickup d'un travail en cours) ; la matrice complète fait re-produire (duplication d'un
+travail livré).
+
+Deux tells suffisent à reconnaître la classe, **avant** toute enquête :
+
+- **Le nom encode un numéro de PR** (`tmp8549`, `m8526`, `c17-8525-reexec`) — c'est une
+  branche d'échafaudage local, pas une tête de PR. Le PR homonyme est le premier endroit à
+  regarder : `gh pr view <numéro-extrait-du-nom>`.
+- **Le chemin touché est *superseded* sur `main`** (ici `twin_pairs.yaml`, fichier, remplacé
+  par le répertoire `twin_pairs.d/` en #8586). Une branche qui modifie un support qui n'existe
+  plus ne peut pas être « du travail à récupérer ».
+
+## Ancre 4 — identité de **contenu**, pas de branche
+
+Quand les ancres 1-3 disent « orpheline », ne pas s'arrêter là : vérifier que le **contenu**
+n'est pas déjà sur `main`.
+
+```bash
+# 1. Le nom porte-t-il un numéro de PR ? Commencer par là.
+gh pr view <N> --json state,mergedAt,mergeCommit
+
+# 2. Sinon : le sujet de commit est-il déjà sur main ? (squash → sujet préservé)
+git log --oneline origin/main | grep -F "$(git log -1 --format=%s <branche>)"
+
+# 3. Ou : les fichiers touchés portent-ils déjà le changement sur main ?
+git diff --stat $(git merge-base origin/main <branche>) <branche>
+git log --oneline -3 -- <chemin-touché>
+```
+
+Une branche **squash-mergée n'est jamais ancêtre de `main`** : `merge-base --is-ancestor` est
+FAUX pour du travail pourtant livré. C'est ce qui rend l'ancre 1 muette ici et laisse toute la
+charge de preuve aux ancres 2-3, aveugles au nommage local.
+
+## Décision
+
+| Ancres 1-3 | Ancre 4 (contenu) | Verdict |
+|---|---|---|
+| INTÉGRÉE (ancre 1) | — | **ARRÊTER** — déjà sur `main` |
+| orpheline | contenu **présent** sur `main` | **NE PAS self-pick** — branche d'échafaudage, supprimable |
+| orpheline | contenu **absent** de `main` | orpheline confirmée — self-pick OK, poser `[CLAIMED]` |
+| PR(s) OPEN à l'ancre 2 ou 3 | — | **NE PAS self-pick** — travail en cours |
+
+Coût de l'ancre 4 : une commande. Coût de son omission : un cycle de travail dupliqué, ou
+l'écrasement d'un travail en cours.
+
+## Voir aussi
+
+- [`.claude/rules/git-workflow.md`](../../.claude/rules/git-workflow.md) — matrice à 3 ancres
+- [`.claude/rules/proactive-coordination.md`](../../.claude/rules/proactive-coordination.md) — L898, garde anti-collision cross-lane (vérifier **avant d'écrire**, pas avant de pousser)
+- [`.claude/rules/harness-hygiene.md`](../../.claude/rules/harness-hygiene.md) — 3 tiers : harnais succinct / doc pérenne / dashboard éphémère


### PR DESCRIPTION
`Grain: MED/docs — lane myia-ai-01:CoursIA — prev: MED/guard`

## Ce que ca corrige

`git-workflow.md` cite **deux fois** (lignes 58 et 83) son « detail fondateur » a l'URL
`.claude/memory/lecon-L576-rest-commits-pulls-fpos.md`.

Ce chemin est **ignore par `.gitignore:651`** — a cote de `.claude/local/` et `.claude/mcp.json`,
introduit par `8862d407b` comme etat local par machine. Il ne peut donc **jamais** exister sur
`main` : les deux liens sont morts par construction, et la regle a 3 ancres circule depuis c.576
sans le detail qu'elle promet. Verifie : aucun fichier `L576` nulle part dans l'arbre.

Cette PR ecrit ce detail la ou il peut vivre — `docs/reference/`, tier « doc perenne » de
[harness-hygiene](https://github.com/jsboige/CoursIA/blob/main/.claude/rules/harness-hygiene.md) —
et l'inscrit dans l'index de `CLAUDE.md`, a cote de `stale-tree-drift-scan.md` (meme genre : une
methodologie de scan etroite mais referencable).

## Ce que le detail porte

**1. L'incident fondateur, marque RAPPORTE.** Les PR citees par la regle (#7086, #7087, #7088,
#7089, #7091 MERGED ; #7090 CLOSED) existent bien. Mais leurs branches de tete sont nommees
`fix/…`, `feat/…`, `feature/…` — **pas** `jsboige/*` comme le resume d'une ligne de la regle le
laisse entendre. Point signale comme non-reconfirmable plutot que recopie tel quel. Le mecanisme
(faux negatif de l'endpoint REST) reste, lui, la raison d'etre de l'ancre 3.

**2. Une classe de faux positif VERIFIEE aujourd'hui, qui inverse une case de la matrice.**

L'ancre 3 (`gh pr list --search "head:<branche>"`) n'est autoritative que si la branche examinee
**a servi de tete a la PR**. Elle ne l'est pas pour une branche d'echafaudage local nommee d'apres
un numero de PR, dont le contenu a ete livre sous une *autre* tete. Cinq branches mesurees
firsthand pendant le menage de worktrees de ce cycle — toutes VIVANTE (non-ancetres de `main`),
toutes `PRs=[none]` aux ancres 2 **et** 3, toutes en avance de 1 a 5 commits :

| Branche | Verdict matrice a 3 ancres | Realite |
|---|---|---|
| `uniontest` | ORPHELINE CONFIRMEE (ok self-pick) | livree — `twin_pairs.d/gametheory-13-imperfectinfo-cfr.yaml` |
| `m8526` | ORPHELINE CONFIRMEE (ok self-pick) | livree — `twin_pairs.d/app-2-graphcoloring.yaml` |
| `c17-8525-reexec` | ORPHELINE CONFIRMEE (ok self-pick) | livree — `bfda2bb1e` (#8525) |
| `tmp8549` | ORPHELINE CONFIRMEE (ok self-pick) | livree — `5bb5d0194` (#8549) |
| `tmp8556` | ORPHELINE CONFIRMEE (ok self-pick) | livree — `c826a9c48` (#8556) |

Suivre la matrice aurait fait **refaire cinq fois du travail deja merge**. Le risque L576 est donc
**bilateral** : l'ancre 2 seule fait sur-attribuer (double-pickup d'un travail *en cours*) ; la
matrice complete fait re-produire (duplication d'un travail *livre*). Une branche squash-mergee
n'est jamais ancetre de `main`, donc l'ancre 1 est muette et toute la charge de preuve tombe sur
les ancres 2-3 — aveugles au nommage local.

D'ou une **ancre 4 — identite de CONTENU, pas de branche** (`gh pr view <N-extrait-du-nom>`, ou
grep du sujet de commit contre `git log --oneline origin/main`, ou `git log -3 -- <chemin>`), plus
deux tells de reconnaissance : le nom encode un numero de PR ; ou le chemin touche est *superseded*
sur `main` (ici `twin_pairs.yaml` remplace par le repertoire `twin_pairs.d/` en #8586).

## Deux constats signales, pas corriges ici

**(a) Les deux liens morts de `git-workflow.md` restent morts apres cette PR.** Les reparer est une
edition de `.claude/rules/`, donc sign-off user. Elle rejoint le lot en attente (#8744, #8769)
plutot que d'ouvrir une troisieme PR gelee. La substance atterrit maintenant ; le lien suivra.

**(b) Contradiction harnais.** Le `CLAUDE.md` global annonce
`.claude/memory/PROJECT_MEMORY.md — Cross-machine shared (via git)`, alors que `.gitignore:651`
ignore `.claude/memory/` en entier. Rien de « partage via git » ne peut vivre la. A trancher avec
(a) : soit `.gitignore` desigore un sous-chemin, soit le `CLAUDE.md` global cesse de promettre un
partage impossible.

## Verification

- `git-workflow.md:58` et `:83` citent bien l'URL morte — lu firsthand.
- `.gitignore:651` = `.claude/memory/`, introduit par `8862d407b` — lu firsthand.
- Les cinq branches : `merge-base --is-ancestor`, `gh api commits/<sha>/pulls`, `gh pr list --search head:`
  et l'identification du contenu sur `main` executes un par un ce cycle.
- Aucun fichier genere touche (catalogue byte-identique a `main`), aucune edition de `.claude/rules/`.

See #8769.
