### PR TITLE
docs(lean,#6724): extraction-test caveat (sufficiency vs satisfiability) at bridge [sorry FLAT 8→8]

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -3002,6 +3002,19 @@ private theorem p4_nw_g3_bridge
   --       `p' = p - 2^(k-1)` (NW correspondence), so the locality step needs the
   --       point-shift alignment between the parent's central window and the
   --       supercell `(node R1 R2 R4 R5)`'s shifted origin.
+  --
+  -- **Extraction-test caveat** (ai-01 #8766 review): the `exact p4_nw_g3_bridge
+  --   ...` at the call site (`p4_nw_supercell_agree`, below) proves the bridge is
+  --   SUFFICIENT to close the root goal — the compiler re-checks this each build,
+  --   so it IS the faithful-extraction test (#8763). It does NOT prove the bridge
+  --   is SATISFIABLE (provable): an over-general or under-hypothesized statement
+  --   passes `exact` and remains a dead-end. The `R_j.level = k` hypotheses
+  --   (added #8768) are load-bearing precisely here — drop them and the offsets
+  --   `2^R_j.level` in `mem_toGrid_node` stay opaque, leaving the bridge
+  --   under-hypothesized (the c.19 trap: a statement that type-checks at the call
+  --   site but cannot be proven). With them, the bridge is correctly-stated
+  --   (offsets pinned to `2^k`); it is still UNPROVEN — the (a) overlap wall
+  --   above is the obstruction, not a malformed statement.
   rw [evolve_half_step k hk1]
   sorry
 


### PR DESCRIPTION
## Summary

Documents the **extraction-test caveat** (sufficiency ≠ satisfiability) at the `p4_nw_g3_bridge` comment, per ai-01's review on #8766. This is a comment-only refinement of the mur-nommé bridge (#6724 crux (a)); no proof, tactic, or signature change.

### Why

ai-01's #8766 review corrected an over-reading of the mur-nommé pattern (#8763): the `exact p4_nw_g3_bridge …` at the call site proves the bridge is **sufficient** to close the root goal (the faithful-extraction test, compiler-rechecked each build), but **not** that the bridge is **satisfiable** (provable). An over-general or under-hypothesized statement passes `exact` and remains a dead-end.

The comment now records concretely why the `R_j.level = k` hypotheses (added #8768) are load-bearing: drop them and the offsets `2^R_j.level` in `mem_toGrid_node` stay opaque, leaving the bridge under-hypothesized (the c.19 trap — type-checks at the call site, unprovable). With them the bridge is correctly-stated (offsets pinned to `2^k`); it remains **unproven**, the (a) double-nine overlap wall being the obstruction — not a malformed statement.

This prevents two future mistakes: (1) "cleaning up" the `R_j.level = k` hypotheses as redundant, and (2) assuming the bridge is provable because `exact` type-checks.

## Scope

- `conway_lean/Conway/Life/HashlifeCorrectness.lean`: +13 comment lines, 0 deletions, at the `p4_nw_g3_bridge` sorry site.
- No proof/tactic/signature change (comment-only).

## Proof gates (§B)

| Check | Result |
|---|---|
| `grep -cE '^[[:space:]]*(exact sorry\|sorry[[:space:]]*$\|.*:= sorry)'` | **8 → 8** (FLAT) |
| `lake build Conway.Life.HashlifeCorrectness` | **SUCCESS** (8498 jobs, EXIT=0) |
| New axioms | **0** (comment-only, no proof change) |
| Not a prover refactor | ✓ (no change to `agent_tests/prover/`) |
| diff non-comment additions | **0** (all 13 added lines are `--` comments) |

See #6724. Branch fresh from `origin/main` (`d15c1d16c`).
