### PR TITLE
docs(qc,#7575): remove stale QC-UNEXEC-TRIAGED markers from 4 executed quantbooks

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/quantbook.ipynb
@@ -39,27 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "qc-unexec-triaged-btc-ml",
-   "metadata": {},
-   "source": [
-    "<!-- QC-UNEXEC-TRIAGED issue=#7575 -->\n",
-    "\n",
-    "> **Cellules non executees -- bug-class #7575 (DISTINCT de #6891).**\n",
-    ">\n",
-    "> Ce notebook contient **8 cellule(s) code sur 11** qui n'ont\n",
-    "> **jamais ete executees** (`execution_count: null`, `outputs: []`). Ce ne sont\n",
-    "> **pas** des sorties fabriquees ni stripees (scope #6891) : l'execution n'a\n",
-    "> simplement jamais eu lieu -- un bug-class separé, tracked dans l'issue #7575.\n",
-    ">\n",
-    "> **Re-exec gated** sur QC Cloud (kernel research `QuantBook`). **Statut config : NO-CONFIG** (pas de `config.json` / cloud-id). Re-exec IMPOSSIBLE tant que le projet n'est pas deploye sur QC Cloud (RECOVERABLE-USER-HAND : creation du projet QC + cloud-id requise au prealable).\n",
-    ">\n",
-    "> En attendant, ce markdown signale honnetement l'etat (Stop & Repair,\n",
-    "> secrets-hygiene 6 + sota-not-workaround Prong-A) -- **ne jamais fabriquer**\n",
-    "> de sorties pour combler."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "cell-1",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-MultiCanal/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-MultiCanal/quantbook.ipynb
@@ -35,26 +35,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<!-- QC-UNEXEC-TRIAGED issue=#7575 -->\n",
-    "\n",
-    "> **Cellules non executees -- bug-class #7575 (DISTINCT de #6891).**\n",
-    ">\n",
-    "> Ce notebook contient **8 cellule(s) code sur 10** qui n'ont\n",
-    "> **jamais ete executees** (`execution_count: null`, `outputs: []`). Ce ne sont\n",
-    "> **pas** des sorties fabriquees ni stripees (scope #6891) : l'execution n'a\n",
-    "> simplement jamais eu lieu -- un bug-class separé, tracked dans l'issue #7575.\n",
-    ">\n",
-    "> **Re-exec gated** sur QC Cloud (kernel research `QuantBook`). **Statut config : ALIVE** (cloud-id 30750734). Re-exec *ready* des que l'acces QC Cloud est restaure (RECOVERABLE-MACHINE) -- le projet existe deja sur QC Cloud, il suffit de relancer le kernel research.\n",
-    ">\n",
-    "> En attendant, ce markdown signale honnetement l'etat (Stop & Repair,\n",
-    "> secrets-hygiene 6 + sota-not-workaround Prong-A) -- **ne jamais fabriquer**\n",
-    "> de sorties pour combler."
-   ]
-  },
-  {
    "cell_id": "cell-1",
    "cell_type": "code",
    "execution_count": 1,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/DL-LSTM/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DL-LSTM/quantbook.ipynb
@@ -30,26 +30,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<!-- QC-UNEXEC-TRIAGED issue=#7575 -->\n",
-    "\n",
-    "> **Cellules non executees -- bug-class #7575 (DISTINCT de #6891).**\n",
-    ">\n",
-    "> Ce notebook contient **2 cellule(s) code sur 12** qui n'ont\n",
-    "> **jamais ete executees** (`execution_count: null`, `outputs: []`). Ce ne sont\n",
-    "> **pas** des sorties fabriquees ni stripees (scope #6891) : l'execution n'a\n",
-    "> simplement jamais eu lieu -- un bug-class separé, tracked dans l'issue #7575.\n",
-    ">\n",
-    "> **Re-exec gated** sur QC Cloud (kernel research `QuantBook`). **Statut config : NO-CONFIG** (pas de `config.json` / cloud-id). Re-exec IMPOSSIBLE tant que le projet n'est pas deploye sur QC Cloud (RECOVERABLE-USER-HAND : creation du projet QC + cloud-id requise au prealable).\n",
-    ">\n",
-    "> En attendant, ce markdown signale honnetement l'etat (Stop & Repair,\n",
-    "> secrets-hygiene 6 + sota-not-workaround Prong-A) -- **ne jamais fabriquer**\n",
-    "> de sorties pour combler."
-   ]
-  },
-  {
    "cell_id": "cell-1",
    "cell_type": "code",
    "execution_count": 1,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-DeepLearning/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-DeepLearning/quantbook.ipynb
@@ -42,26 +42,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<!-- QC-UNEXEC-TRIAGED issue=#7575 -->\n",
-    "\n",
-    "> **Cellules non executees -- bug-class #7575 (DISTINCT de #6891).**\n",
-    ">\n",
-    "> Ce notebook contient **2 cellule(s) code sur 12** qui n'ont\n",
-    "> **jamais ete executees** (`execution_count: null`, `outputs: []`). Ce ne sont\n",
-    "> **pas** des sorties fabriquees ni stripees (scope #6891) : l'execution n'a\n",
-    "> simplement jamais eu lieu -- un bug-class separé, tracked dans l'issue #7575.\n",
-    ">\n",
-    "> **Re-exec gated** sur QC Cloud (kernel research `QuantBook`). **Statut config : NO-CONFIG** (pas de `config.json` / cloud-id). Re-exec IMPOSSIBLE tant que le projet n'est pas deploye sur QC Cloud (RECOVERABLE-USER-HAND : creation du projet QC + cloud-id requise au prealable).\n",
-    ">\n",
-    "> En attendant, ce markdown signale honnetement l'etat (Stop & Repair,\n",
-    "> secrets-hygiene 6 + sota-not-workaround Prong-A) -- **ne jamais fabriquer**\n",
-    "> de sorties pour combler."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {


### PR DESCRIPTION
Grain: MED/qc — lane myia-po-2024:CoursIA-2 — prev: DEEP/qc (#8777 ML-TextClassification)

Doc-honesty cleanup (partial #7575): remove the **stale `QC-UNEXEC-TRIAGED` marker** from 4 quantbooks that are now **fully executed**. The marker's claim "Re-exec IMPOSSIBLE / RECOVERABLE-USER-HAND (QC Cloud deploy required)" is FALSE — all 4 were re-executed locally via Docker lean-cli (no creds needed, RECOVERABLE-LOCAL).

## The defect

The `QC-UNEXEC-TRIAGED` marker block was added during #7575 triage to honestly flag unexecuted quantbooks. But 4 notebooks have since been **re-executed to full completion** (by prior PRs), and the marker was never removed — so each now carries a false "Re-exec IMPOSSIBLE" banner *above* fully-executed cells. A reader sees the banner and wrongly concludes the notebook can't run.

| Notebook | Cells | Re-executed by | Marker claim (now false) |
|---|---|---|---|
| BTC-ML | 11/11 exec | #8700 | "Re-exec IMPOSSIBLE / RECOVERABLE-USER-HAND" |
| Crypto-MultiCanal | 10/10 exec | (prior re-exec) | same |
| DL-LSTM | 12/12 exec | #8751 | same |
| ML-DeepLearning | 12/12 exec | #8756/#8770 | same |

This is **C958-L applied at scale**: a marker-block documenting a now-resolved blocker = misinformation → remove the block.

## Validation

- **Pure markdown removal**: 0 code-source changes, 0 output changes. Verified per-notebook: `code_source == origin/main` AND `output_count == origin/main` for all 4. Only the marker markdown cell is deleted.
- H.3 clean (no code cell touched). Diff = 4 files, 81 deletions, 0 insertions.
- Catalogue byte-identical to main.

## Context — how this PR came about

This is a **re-scope after a self-caught false claim**. My initial target this cycle was "re-execute BTC-ML 3/11→11/11" (PR #8780, now closed) — but that scan ran against the STALE shared checkout. The worktree baseline (origin/main, includes #8700) already had BTC-ML at 11/11. I closed #8780 rather than ship a mislabeled "re-exec", and the audit that caught it revealed these 4 stale markers as the genuine (if lighter) defect. Recorded as C959-L: verify the worktree's origin/main baseline firsthand before claiming a re-exec; never trust a scan from the stale shared checkout.

## Scope

Bounded doc-honesty cleanup (4 notebooks). The genuinely-unexec #7575 work remaining (separate DEEP re-exec PRs): **PairsTrading, RL-Portfolio, VIX-TermStructure** (ML-TextClassification is in flight via #8777).

See #7575.
