### PR TITLE
fix(ci,#8765): give the variation tag guard a repo context so its labels actually land

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Inspect PR body for Grain tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Ce job n'a pas d'`actions/checkout` (il n'a rien a lire dans l'arbre).
+          # Sans depot git courant, `gh` ne peut pas deduire le repo cible et
+          # TOUTES les commandes `gh pr edit` / `gh label create` ci-dessous
+          # echouent — silencieusement, puisqu'elles sont suffixees `|| true`.
+          # Constat firsthand : depuis le merge de #8765, zero PR labellisee et
+          # les deux labels n'existaient meme pas dans le depot, alors que les
+          # `::warning::` etaient bien emis. GH_REPO restaure ce contexte sans
+          # payer un checkout.
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -62,10 +71,13 @@ jobs:
 
           if [ -z "$GRAIN_LINE" ]; then
             echo "::warning::Aucune ligne 'Grain:' dans le body. variation-protocol.md exige 'Grain: <TIER>/<GENRE>' (TIER = DEEP|MED|LIGHT)."
+            # stderr LAISSE PASSER : `|| true` garde le job non bloquant, mais
+            # masquer la sortie d'erreur est ce qui a rendu la panne invisible.
+            # Un garde dont l'echec est muet n'est pas un garde.
             gh label create "variation-tag-missing" \
               --description "PR sans tag Grain: <TIER>/<GENRE> (variation-protocol)" \
-              --color "FBCA04" --force 2>/dev/null || true
-            gh pr edit "$PR_NUMBER" --add-label "variation-tag-missing" 2>/dev/null || true
+              --color "FBCA04" --force || true
+            gh pr edit "$PR_NUMBER" --add-label "variation-tag-missing" || true
             exit 0
           fi
 
@@ -76,6 +88,9 @@ jobs:
             DEEP|MED|LIGHT)
               echo "Tag conforme : TIER=$TIER GENRE=${GENRE:-?}"
               # Le label eventuel d'un push anterieur ne doit pas rester colle.
+              # Ici `2>/dev/null` reste justifie : retirer un label absent est
+              # une erreur ATTENDUE au cas nominal (la PR conforme du premier
+              # coup), pas le symptome d'une panne.
               gh pr edit "$PR_NUMBER" --remove-label "variation-tag-missing" 2>/dev/null || true
               gh pr edit "$PR_NUMBER" --remove-label "variation-tag-malformed" 2>/dev/null || true
               exit 0
@@ -86,6 +101,6 @@ jobs:
           echo "Ligne lue : $GRAIN_LINE"
           gh label create "variation-tag-malformed" \
             --description "Tag Grain present mais TIER != DEEP|MED|LIGHT" \
-            --color "FEF2C0" --force 2>/dev/null || true
-          gh pr edit "$PR_NUMBER" --add-label "variation-tag-malformed" 2>/dev/null || true
+            --color "FEF2C0" --force || true
+          gh pr edit "$PR_NUMBER" --add-label "variation-tag-malformed" || true
           exit 0


### PR DESCRIPTION
`Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/docs (#8778)`

## Le probleme

Le garde de #8765 **detecte correctement** un tag `Grain:` absent ou malforme : l'annotation `::warning::` part comme prevu. Mais **aucun** de ses `gh label create` / `gh pr edit --add-label` n'a jamais abouti depuis le merge.

Cause : le job n'a **pas d'`actions/checkout`** — il n'a rien a lire dans l'arbre, ce qui etait un bon choix. Sans depot git courant, `gh` ne peut pas deduire le repo cible : toutes les commandes de label echouent, et `2>/dev/null || true` avale l'erreur.

## Evidence firsthand (mesuree sur `main`, pas deduite)

| Verification | Resultat |
|---|---|
| `gh label list --search variation-tag` | **vide** — les deux labels que le garde cree n'existent meme pas dans le depot |
| `gh pr list --label variation-tag-missing --state all` | **0** |
| `gh pr list --label variation-tag-malformed --state all` | **0** |
| PR #8784 (aucune ligne `Grain:`) | run `30423245810` : `##[warning]Aucune ligne 'Grain:' dans le body.` emis, puis `labels: []` |
| `stale-base-warning.yml`, seul autre workflow utilisant `gh` | **a un checkout** — et ses appels `gh` fonctionnent |

La derniere ligne est le comparateur qui tranche : dans ce depot, le workflow `gh` qui marche est celui qui a un checkout ; celui dont les labels n'atterrissent jamais n'a ni checkout ni `GH_REPO`.

## Le correctif

1. **`GH_REPO: ${{ github.repository }}`** sur le step. Restaure le contexte sans payer un checkout (le job reste a une seule etape, sans I/O disque).
2. **Arreter de masquer stderr** sur `create` et `--add-label`. Le `|| true` suffit a garder le job non bloquant — il est advisory par construction, `exit 0` sur tous les chemins, et le commentaire de tete de #8765 dit explicitement que le passage en bloquant sera une decision separee. Ce n'est donc pas `|| true` le probleme, c'est `2>/dev/null` : **un garde dont l'echec est muet n'est pas un garde**, et c'est precisement ce qui a permis a la panne de survivre toute la duree de vie du garde.
3. `2>/dev/null` **conserve** sur les deux `--remove-label` : y retirer un label absent est le cas **nominal** (PR conforme du premier coup), donc une erreur attendue, pas un symptome.

## Ce que ca change concretement pour le merge-gate

Le protocole de variation confie la lecture du tag au coordinateur. Aujourd'hui, une PR sans tag produit un check **SUCCESS** et une liste de labels **vide** : les deux endroits ou le coordinateur regarde (`gh pr checks`, `gh pr view --json labels`) sont muets, et le seul signal existant est enterre dans le log du run. Apres ce correctif le label apparait la ou la decision se prend.

## Provenance — et une correction a ma propre affirmation

J'ai ecrit dans ma revue de #8784, puis repete dans un DM a po-2026, que « le garde ne mord pas sur l'absence, seulement sur le mauvais format ». **C'est faux.** Je l'avais infere du couple `SUCCESS` + tag absent, sans lire le workflow. La lecture montre que la branche `if [ -z "$GRAIN_LINE" ]` existe et fonctionne ; le log du run le confirme.

Le defaut reel est plus etroit — et plus interessant : la **detection** marche, c'est l'**emission du signal** qui est cassee, et depuis toujours. Correction publiee ici et sur les deux dashboards.

## Verification

- YAML re-parse : OK (`yaml.safe_load`), 0 step `uses` (toujours aucun checkout), `exit 0` sur les 5 chemins de sortie inchange.
- `2>/dev/null` : 2 occurrences restantes dans les commandes, toutes deux sur `--remove-label` (la 3e occurrence grep est dans le commentaire qui l'explique).
- Diff : 1 fichier, +19/−4, aucune modification de la logique de detection ni des regex.

See #8765, #8738.
