### PR TITLE
feat(audit,#8056): litmus 9 rend cost.validator / last_validated falsifiables

### DIFF
--- a/docs/notebook-metadata/cost-matrix.md
+++ b/docs/notebook-metadata/cost-matrix.md
@@ -141,6 +141,54 @@ un gate incapable d'échouer n'est pas un gate).
 - `null` (+ raison) = coût **inconnu**. Ne pas confondre : `0.0` n'est pas un
   défaut pour « je ne sais pas », l'absence se lirait à tort comme gratuite.
 
+### `validator` / `last_validated` — la seconde règle falsifiable (Litmus 9)
+
+Ces deux champs affirment qu'une validation a eu lieu. Jusqu'au Litmus 9, **rien
+dans le dépôt ne pouvait les contredire** : les populators écrivent
+`last_validated: date.today()` au moment du *peuplement* — pas au moment d'une
+validation — et aucun consommateur ne le relit. Le tableau des défauts ci-dessus
+le dit d'ailleurs sans détour : le défaut de `cost.last_validated` est « date de
+création de la metadata ». Un champ que rien ne peut contredire est **décoratif** :
+il porterait la même valeur sur un notebook dont *aucune* cellule n'a jamais tourné.
+
+**Règle falsifiable :** quand `validator` affirme une **exécution de cellules**
+(`papermill`, `sk_visual`, `dotnet-interactive`), aucune cellule code non vide ne
+doit porter `execution_count: null`. Le fondement est mécanique : nbclient/papermill
+exécutent **toute** cellule code non vide — y compris celles qui échouent
+(`--allow-errors` ne change que le comportement d'arrêt, pas l'attribution du
+compteur). Donc `execution_count: null` **prouve** la non-exécution. Vérifié par
+`check_cost_metadata.py` (Litmus 9) → finding `validator_asserts_execution_but_cells_unexecuted`
+(MAJOR).
+
+**Validators hors périmètre, délibérément :**
+
+| Validator | Pourquoi il n'est pas contredit |
+|---|---|
+| `manual` | un humain a relu — aucune affirmation d'exécution. C'est aussi **la valeur de correction** pour un notebook non exécutable localement |
+| `qc_cloud` | carve-out H.3 documenté — le runtime research QC n'existe sur aucune machine worker |
+| `lean_build` | `lake build` SUCCESS porte sur le lake, pas sur les cellules |
+| `sk_agent` | périmètre ambigu, pas d'affirmation nette |
+
+**Échappatoire honnête (tag de skip).** Une cellule délibérément non exécutable —
+code de référence destiné à un autre runtime — se **déclare** par un tag de cellule
+(`skip-execution`, `skip`, `no-execute`). Le notebook cesse alors d'être contredit
+sans mentir, et l'exemption est **visible dans le fichier**, contrairement à une
+exception codée en dur dans l'outil. La contrepartie est la même que partout
+ailleurs : on corrige la **déclaration**, ou on ré-exécute — **jamais** on n'édite
+une sortie de cellule à la main (Stop & Repair, cf
+[secrets-hygiene.md](../../.claude/rules/secrets-hygiene.md) règle 6).
+
+> **Mesure à l'introduction (2026-07-29, 1020 notebooks scannés) :** 13 findings,
+> tous `validator: papermill`, tous dans `QuantConnect/Python` — série dont chaque
+> cellule code est du `[REFERENCE QC]` important `AlgorithmImports`, qui n'existe
+> que dans le runtime QC. Ces notebooks sont couverts par le carve-out H.3 **par
+> chemin** (`QC_CLOUD_PATHS`) alors qu'ils échappent au prédicat de contenu partagé
+> (`QuantBook()`) : le carve-out excuse l'**absence** d'exécution, il n'autorise pas
+> à en **affirmer** une. Correction attendue : `validator: manual`. Zéro finding sur
+> les autres validators, y compris sur la tranche .NET en attente d'harmonisation
+> (`Probas/Infer.NET`, `ML/ML.NET`) — ceux-là *ont* été exécutés, leur défaut est une
+> étiquette inexacte, pas une exécution fantôme.
+
 ### Tiers VRAM (déterminé par `vram_gb`)
 
 | Tier | VRAM (GB) | Modèles typiques |
@@ -499,6 +547,7 @@ Le script `extract_claims_vs_outputs.py` (livré par [PR #8068 / cycle c.793](ht
 | `metadata.cost.free_alternative` : valeur ni sentinel canonique ni chemin | MINOR |
 | Notebook QC sans `qc_cloud` validator | MAJOR |
 | Notebook GPU sans `sk_visual` validator (cf #5780 sweep) | MINOR |
+| `metadata.cost.validator` affirme une exécution mais des cellules code portent `execution_count: null` (Litmus 9) | MAJOR |
 
 Ces extensions restent **hors scope c.794** (à dispatcher cycles c.795+) — la grille est volontairement extensible.
 

--- a/scripts/audit/check_cost_metadata.py
+++ b/scripts/audit/check_cost_metadata.py
@@ -21,6 +21,10 @@ But : extraire pour un notebook :
       (4) free_alternative pointe vers un notebook inexistant
       (5) Notebook QC sans qc_cloud validator
       (6) Notebook GPU sans sk_visual validator
+      (7) QuantBook détecté sans estimation qcc_tokens_est (#8376)
+      (8) api_cost_breakdown dont la somme != api_usd_est (design-gate #8056)
+      (9) validator affirmant une exécution alors que des cellules code
+          non vides portent execution_count: null
 
 Litmus anti-LIGHT : ce script EXTRACT, il ne DÉCIDE pas. Le verdict final
 = revue humaine/agent compétent. Cf docs/notebook-metadata/cost-matrix.md.
@@ -451,6 +455,80 @@ def check_notebook(notebook_path: Path, repo_root: Path) -> dict:
                                 ),
                                 'severity': 'MAJOR',
                             })
+
+    # Litmus 9 : le validator AFFIRME une execution que le notebook contredit.
+    #
+    # `validator` et `last_validated` sont, avant ce litmus, les deux seuls
+    # champs de la matrice que RIEN ne peut contredire. Les populators ecrivent
+    # `last_validated: _dt.date.today()` au moment du peuplement — pas au moment
+    # d'une validation — et aucun consommateur ne le relit. Un champ que rien
+    # ne peut contredire est decoratif : il aurait la meme valeur sur un
+    # notebook dont AUCUNE cellule n'a jamais tourne. Meme raisonnement que le
+    # litmus 8 (une ventilation dont la somme doit egaler le total casse le jour
+    # ou elle ment) et que #8680 (un gate incapable d'echouer n'est pas un gate).
+    #
+    # Ce que le litmus rend falsifiable : nbclient/papermill executent CHAQUE
+    # cellule code non vide, y compris celles qui echouent (`--allow-errors` ne
+    # change que le comportement d'arret, pas l'attribution du compteur). Donc
+    # `execution_count: null` sur une cellule code non vide PROUVE que la
+    # cellule n'a pas ete executee — et contredit un validator qui affirme
+    # l'avoir ete.
+    #
+    # Perimetre : seuls les validators qui affirment une EXECUTION DE CELLULES.
+    # Sont exclus, et ce n'est pas un oubli :
+    #   - `manual`   : un humain a relu — aucune affirmation d'execution ;
+    #   - `qc_cloud` : carve-out documente (H.3) — le runtime research QC
+    #                  n'existe sur aucune machine worker ;
+    #   - `lean_build`: `lake build` SUCCESS, qui porte sur le lake, pas sur
+    #                  les cellules du notebook ;
+    #   - `sk_agent` : perimetre ambigu, pas d'affirmation nette.
+    # `dotnet-interactive` est retenu bien qu'absent de la liste canonique de
+    # cost-matrix.md (4 notebooks l'emploient) : il affirme une execution du
+    # kernel .NET local, exigee par l'advisory #5214.
+    #
+    # Echappatoire honnete : une cellule deliberement non executable (code de
+    # reference destine a un autre runtime) se declare par un tag de skip. Le
+    # notebook cesse alors d'etre contredit — sans mentir, et de facon visible
+    # dans le fichier. Fleet-wide au moment de l'ecriture : 0 cellule taguee.
+    EXECUTION_ASSERTING_VALIDATORS = ('papermill', 'sk_visual', 'dotnet-interactive')
+    SKIP_EXECUTION_TAGS = {'skip-execution', 'skip', 'no-execute'}
+    if validator in EXECUTION_ASSERTING_VALIDATORS:
+        unexecuted = []
+        for idx, cell in enumerate(nb.cells):
+            if cell.get('cell_type') != 'code':
+                continue
+            source = cell.get('source', '')
+            if isinstance(source, list):
+                source = ''.join(source)
+            # Une cellule code VIDE n'est pas executee par nbclient (skip
+            # explicite sur `not cell.source.strip()`) : son `execution_count`
+            # reste null apres un run complet. La flagger serait un faux
+            # positif qui pousse a modifier un notebook sain.
+            if not source.strip():
+                continue
+            tags = set((cell.get('metadata') or {}).get('tags') or [])
+            if tags & SKIP_EXECUTION_TAGS:
+                continue
+            if cell.get('execution_count') is None:
+                unexecuted.append(idx)
+        if unexecuted:
+            shown = ', '.join(str(i) for i in unexecuted[:5])
+            more = f', +{len(unexecuted) - 5}' if len(unexecuted) > 5 else ''
+            findings.append({
+                'pattern': 'validator_asserts_execution_but_cells_unexecuted',
+                'detail': (
+                    f"cost.validator: '{validator}' affirme une execution, mais "
+                    f"{len(unexecuted)} cellule(s) code non vides ont "
+                    f"execution_count: null (index {shown}{more}). "
+                    f"cost.last_validated"
+                    f"{' = ' + str(cost_meta['last_validated']) if cost_meta.get('last_validated') else ''}"
+                    f" date donc une validation que le notebook contredit. "
+                    f"Corriger la DECLARATION (validator: manual si le notebook "
+                    f"n'est pas executable localement) ou re-executer — jamais "
+                    f"editer les sorties a la main."
+                ),
+                'severity': 'MAJOR',
+            })
 
     return {
         'notebook': str(notebook_path),

--- a/scripts/audit/tests/test_check_cost_metadata.py
+++ b/scripts/audit/tests/test_check_cost_metadata.py
@@ -382,3 +382,166 @@ def test_litmus8_breakdown_int_value_accepted(tmp_path):
     pats = _patterns(res["findings"])
     assert "api_cost_breakdown_non_numeric" not in pats
     assert "api_cost_breakdown_sum_mismatch" not in pats
+
+
+# ---------------------------------------------------------------------------
+# Litmus 9 — validator_asserts_execution_but_cells_unexecuted
+#
+# Rend `validator` / `last_validated` falsifiables : avant ce litmus, rien dans
+# le dépôt ne pouvait les contredire. Cf docs/notebook-metadata/cost-matrix.md.
+# ---------------------------------------------------------------------------
+
+_LITMUS9_PATTERN = "validator_asserts_execution_but_cells_unexecuted"
+
+
+def _notebook_cells(path: Path, specs, cost_meta=None) -> None:
+    """Écrit un notebook dont chaque cellule code est décrite par un spec.
+
+    spec = (source, execution_count, tags). `execution_count=None` = cellule
+    jamais exécutée ; `tags` = liste de tags de cellule (ou None).
+    Nécessaire pour le litmus 9 : les autres helpers laissent
+    `execution_count: None` partout (défaut de `new_code_cell`), ce qui ne
+    permet pas de distinguer exécuté / non exécuté.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    nb = new_notebook()
+    cells = []
+    for source, exec_count, tags in specs:
+        cell = new_code_cell(source)
+        cell["execution_count"] = exec_count
+        if tags:
+            cell["metadata"]["tags"] = list(tags)
+        cells.append(cell)
+    nb.cells = cells
+    if cost_meta:
+        nb.metadata["cost"] = cost_meta
+    with path.open("w", encoding="utf-8") as f:
+        nbformat.write(nb, f, version=4)
+
+
+def _litmus9_patterns(tmp_path, specs, cost_meta):
+    mod = _load_check()
+    nb_path = tmp_path / "nb.ipynb"
+    _notebook_cells(nb_path, specs, cost_meta=cost_meta)
+    return _patterns(mod.check_notebook(nb_path, tmp_path)["findings"])
+
+
+def test_litmus9_papermill_with_unexecuted_cell_flags(tmp_path):
+    """`validator: papermill` affirme une exécution end-to-end. nbclient exécute
+    toute cellule code non vide (même celles qui échouent) : un
+    execution_count null PROUVE que la cellule n'a pas tourné."""
+    pats = _litmus9_patterns(
+        tmp_path,
+        [("x = 1", 1, None), ("from AlgorithmImports import *", None, None)],
+        {"validator": "papermill", "last_validated": "2026-07-23T01:30Z"},
+    )
+    assert _LITMUS9_PATTERN in pats
+
+
+def test_litmus9_papermill_all_executed_ok(tmp_path):
+    """Toutes les cellules exécutées : la déclaration n'est contredite par rien."""
+    pats = _litmus9_patterns(
+        tmp_path,
+        [("x = 1", 1, None), ("y = 2", 2, None)],
+        {"validator": "papermill", "last_validated": "2026-07-23T01:30Z"},
+    )
+    assert _LITMUS9_PATTERN not in pats
+
+
+def test_litmus9_empty_cell_is_not_a_finding(tmp_path):
+    """FP guard : nbclient SKIPPE les cellules code vides (`not source.strip()`),
+    leur execution_count reste null après un run complet. Les flagger pousserait
+    à modifier un notebook sain — même garde-fou que
+    audit_quantbooks_unexec._is_unexecuted_code."""
+    pats = _litmus9_patterns(
+        tmp_path,
+        [("x = 1", 1, None), ("   \n", None, None)],
+        {"validator": "papermill"},
+    )
+    assert _LITMUS9_PATTERN not in pats
+
+
+def test_litmus9_skip_tagged_cell_is_exempt(tmp_path):
+    """Échappatoire honnête : une cellule délibérément non exécutable (code de
+    référence destiné à un autre runtime) se DÉCLARE par un tag de skip. Le
+    notebook cesse d'être contredit sans mentir, et le tag est visible dans le
+    fichier — contrairement à une exception codée en dur dans l'outil."""
+    for tag in ("skip-execution", "skip", "no-execute"):
+        pats = _litmus9_patterns(
+            tmp_path,
+            [("x = 1", 1, None), ("reference_only()", None, [tag])],
+            {"validator": "papermill"},
+        )
+        assert _LITMUS9_PATTERN not in pats, f"tag {tag} devrait exempter la cellule"
+
+
+def test_litmus9_qc_cloud_validator_exempt(tmp_path):
+    """`qc_cloud` = carve-out H.3 documenté : le runtime research QC n'existe sur
+    aucune machine worker. Le validator n'affirme pas une exécution locale."""
+    pats = _litmus9_patterns(
+        tmp_path,
+        [("qb = QuantBook()", None, None)],
+        {"validator": "qc_cloud", "qcc_tokens_est": 400},
+    )
+    assert _LITMUS9_PATTERN not in pats
+
+
+def test_litmus9_manual_validator_exempt(tmp_path):
+    """`manual` = un humain a relu. Aucune affirmation d'exécution, donc rien à
+    contredire — c'est aussi la valeur canonique vers laquelle un notebook non
+    exécutable localement doit être corrigé."""
+    pats = _litmus9_patterns(
+        tmp_path,
+        [("x = 1", None, None)],
+        {"validator": "manual"},
+    )
+    assert _LITMUS9_PATTERN not in pats
+
+
+def test_litmus9_absent_validator_exempt(tmp_path):
+    """Pas de `validator` déclaré = pas de claim. Le défaut `manual` ne doit pas
+    fabriquer un finding sur un notebook qui n'affirme rien."""
+    pats = _litmus9_patterns(
+        tmp_path,
+        [("x = 1", None, None)],
+        {"api_usd_est": 0.0},
+    )
+    assert _LITMUS9_PATTERN not in pats
+
+
+def test_litmus9_dotnet_interactive_validator_flags(tmp_path):
+    """`dotnet-interactive` affirme l'exécution du kernel .NET local, exigée par
+    l'advisory #5214 (`execution_count != null` = preuve d'exécution locale)."""
+    pats = _litmus9_patterns(
+        tmp_path,
+        [("Console.WriteLine(1);", None, None)],
+        {"validator": "dotnet-interactive"},
+    )
+    assert _LITMUS9_PATTERN in pats
+
+
+def test_litmus9_sk_visual_validator_flags(tmp_path):
+    """`sk_visual` = vision check sur figures RENDUES : les figures viennent des
+    sorties du notebook, donc l'exécution est entraînée par la déclaration."""
+    pats = _litmus9_patterns(
+        tmp_path,
+        [("plt.show()", None, None)],
+        {"validator": "sk_visual", "gpu_required": True},
+    )
+    assert _LITMUS9_PATTERN in pats
+
+
+def test_litmus9_detail_names_the_cell_indices(tmp_path):
+    """Le finding doit être actionnable : nommer les index de cellules, pas
+    seulement leur nombre — sinon la remédiation demande de re-scanner."""
+    mod = _load_check()
+    nb_path = tmp_path / "nb.ipynb"
+    _notebook_cells(
+        nb_path,
+        [("a = 1", 1, None), ("b = 2", None, None), ("c = 3", None, None)],
+        cost_meta={"validator": "papermill", "last_validated": "2026-07-23T01:30Z"},
+    )
+    findings = mod.check_notebook(nb_path, tmp_path)["findings"]
+    detail = next(f["detail"] for f in findings if f["pattern"] == _LITMUS9_PATTERN)
+    assert "1, 2" in detail
+    assert "2026-07-23T01:30Z" in detail


### PR DESCRIPTION
Grain: MED/test — lane myia-ai-01:CoursIA — prev: MED/guard (#8786)

## Le champ que rien ne pouvait contredire

`cost.validator` et `cost.last_validated` affirment qu'une validation a eu lieu. Avant cette PR, **rien dans le dépôt ne pouvait les contredire** : les quatre populators écrivent `last_validated: _dt.date.today()` au moment du **peuplement** — pas d'une validation — et aucun consommateur ne relit le champ. Le schéma le dit d'ailleurs lui-même sans détour : le défaut documenté de `cost.last_validated` est « date de création de la metadata ».

C'est exactement le critère posé pour le Litmus 8 dans `cost-matrix.md` :

> Une ventilation libre est **décorative** : personne ne peut la contredire, elle se périme en silence au premier drift. Une ventilation dont la somme doit égaler le total est **falsifiable** — elle casse le jour où elle ment.

`last_validated` était l'inverse du Litmus 8 : il aurait porté la **même valeur** sur un notebook dont aucune cellule n'a jamais tourné. Cette PR le rend contredisable.

## Le litmus

Quand `validator` affirme une **exécution de cellules** — `papermill`, `sk_visual`, `dotnet-interactive` — aucune cellule code non vide ne doit porter `execution_count: null`.

Le fondement est mécanique, pas heuristique : **nbclient/papermill exécutent toute cellule code non vide**, y compris celles qui échouent (`--allow-errors` ne change que le comportement d'arrêt, pas l'attribution du compteur). Donc `execution_count: null` **prouve** la non-exécution, et contredit un validator qui affirme le contraire. Finding `validator_asserts_execution_but_cells_unexecuted`, MAJOR.

**Hors périmètre, délibérément** (chaque exclusion est motivée dans le code) :

| Validator | Pourquoi il n'est pas contredit |
|---|---|
| `manual` | un humain a relu — aucune affirmation d'exécution. C'est aussi **la valeur de correction** |
| `qc_cloud` | carve-out H.3 documenté — le runtime research QC n'existe sur aucune machine worker |
| `lean_build` | `lake build` SUCCESS porte sur le lake, pas sur les cellules |
| `sk_agent` | périmètre ambigu, pas d'affirmation nette |

`dotnet-interactive` est retenu bien qu'**absent de la liste canonique** de `cost-matrix.md` (4 notebooks l'emploient) : il affirme l'exécution du kernel .NET local, exigée par l'advisory #5214. Cette divergence liste-canonique ↔ usage réel est signalée, pas corrigée ici.

## Deux garde-fous FP, mesurés avant d'être écrits

1. **Cellule code vide exemptée.** nbclient skippe explicitement `not cell.source.strip()` : son `execution_count` reste `null` **après un run complet**. La flagger pousserait à modifier un notebook sain — même garde-fou, et même raison, que `audit_quantbooks_unexec._is_unexecuted_code` (« mesure sur le dépôt : 1 notebook, 2 cellules »).
2. **Tag de skip comme échappatoire honnête.** Une cellule délibérément non exécutable (code de référence destiné à un autre runtime) se **déclare** par `skip-execution` / `skip` / `no-execute`. Le notebook cesse d'être contredit **sans mentir**, et l'exemption est **visible dans le fichier** — contrairement à une exception codée en dur dans l'outil, que personne ne relit. Fleet-wide à l'écriture : **0 cellule taguée**, donc l'échappatoire n'excuse rien rétroactivement.

## Mesure fleet-wide — 13 findings, et ce qu'ils disent

Sweep avec le checker **réel** (pas un script ad-hoc), 1020 notebooks scannés :

```
scannes=1020  erreurs_parse=1  findings_litmus9=13
  papermill  QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb
  papermill  QuantConnect/Python/QC-Py-03-Data-Management.ipynb
  papermill  QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb
  ... (13 au total, tous QuantConnect/Python, tous papermill)
```

Les 13 portent le **même** `last_validated: 2026-07-23T01:30Z` — signature d'une écriture en masse par le populator. Cinq d'entre eux sont **intégralement** non exécutés (14/14, 13/13, 12/13, 8/8, 13/20 cellules).

Lecture firsthand de deux d'entre eux : **chaque** cellule code est du `# [REFERENCE QC] Code a copier dans main.py QC Lab (non executable ici)` important `from AlgorithmImports import *` — module qui n'existe **que** dans le runtime QC. Ces notebooks ne peuvent pas être papermill-exécutés, et ne le prétendent pas dans leur prose : seule leur metadata le prétend.

**Le point qui rend le finding non-trivial** : ils sont couverts par le carve-out H.3 **par chemin** (`QC_CLOUD_PATHS = ("QuantConnect/Python", ...)`) alors qu'ils échappent au prédicat de **contenu** partagé par les trois outils (`QuantBook()` — vérifié : aucun des deux lus ne l'instancie). Ils vivent exactement dans l'écart que `validate_pr_notebooks.py` documente lui-même :

> NOTE: this list is a FAST PATH, not the definition. The definition is "the notebook instantiates QuantBook".

Le carve-out excuse l'**absence** d'exécution ; il n'autorise pas à en **affirmer** une. Correction attendue : `validator: manual` (valeur canonique pour le non-exécutable-localement, cf `cost-matrix.md`). Elle n'est **pas** dans cette PR — voir ci-dessous.

Zéro finding sur les autres validators, y compris sur la tranche .NET en attente d'harmonisation (`Probas/Infer.NET`, `ML/ML.NET`, qui portent `validator: papermill` à tort) : ceux-là **ont** été exécutés, leur défaut est une étiquette inexacte, pas une exécution fantôme. L'extension à `sk_visual`/`dotnet-interactive` ajoute **0 finding aujourd'hui** et ferme le trou prospectivement.

## Ce que cette PR ne fait PAS, et pourquoi

- **Elle ne corrige pas les 13 notebooks.** Sujet distinct (outil vs données), famille distincte (QC), et surtout : les corriger dans la même PR rendrait le litmus **invisible** — on ne saurait plus s'il a des dents. Même séquencement que #8787, dont j'ai loué l'ordre : rendre l'angle mort **visible** d'abord. Issue de suivi à ouvrir sur la lane QC.
- **Elle ne touche à aucun notebook** : `git diff --stat` = 3 fichiers, `+290/-0`, aucun `.ipynb`, catalogue byte-identique à `main`.
- **Elle ne durcit rien en CI.** Vérifié : `check_cost_metadata.py` n'est appelé par **aucun** workflow (`grep` sur `.github/` = 0 match). C'est un outil d'audit manuel ; les 13 findings ne rendent aucune CI rouge.
- **Elle ne resserre pas `QC_CLOUD_PATHS` vers le prédicat de contenu.** L'écart identifié ci-dessus est réel et vaut un suivi, mais toucher au carve-out H.3 change le comportement du gate PR — risque et sujet distincts.

## Validation

```
python -m pytest scripts/audit/tests/test_check_cost_metadata.py -q
37 passed in 0.95s          (27 existants + 10 nouveaux, aucun existant modifié)
```

Les 10 cas : fire sur `papermill` / `dotnet-interactive` / `sk_visual` ; silence sur all-executed, cellule vide, les **trois** tags de skip, `qc_cloud`, `manual`, `validator` absent ; et un cas qui vérifie que le detail est **actionnable** (index de cellules nommés + `last_validated` cité, pas seulement un compte).

Vérification firsthand sur un notebook réel, pas seulement sur des fixtures :

```
$ python scripts/audit/check_cost_metadata.py MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb --repo-root .
findings:
  - pattern: validator_asserts_execution_but_cells_unexecuted
    severity: MAJOR
    detail: "cost.validator: 'papermill' affirme une execution, mais 14 cellule(s)
             code non vides ont execution_count: null (index 5, 8, 11, 13, 17, +9).
             cost.last_validated = 2026-07-23T01:30Z date donc une validation que le
             notebook contredit. Corriger la DECLARATION (validator: manual si le
             notebook n'est pas executable localement) ou re-executer — jamais editer
             les sorties a la main."
```

Le message de remédiation cite explicitement **Stop & Repair** : corriger la déclaration ou ré-exécuter, jamais éditer une sortie à la main (`secrets-hygiene.md` règle 6).

## Note annexe

L'inventaire des litmus dans la docstring du module s'était périmé de deux entrées (7 et 8 livrés sans y être ajoutés). Complété plutôt qu'incrémenté d'un seul — un inventaire faux se lit comme un inventaire.

## Variation

`Grain: MED/test`. **MED et pas DEEP** : `main` gagne un gate, pas un résultat de domaine — aucune preuve ne tombe, aucune capacité n'apparaît. **MED et pas LIGHT** malgré la taille : le litmus n'est pas scan-générable — il a fallu établir la sémantique d'exécution de nbclient (cellule vide skippée, `--allow-errors` sans effet sur le compteur), mesurer le fleet **avant** d'écrire pour dimensionner les garde-fous, et lire deux notebooks flaggés en entier pour distinguer « jamais exécuté » de « non exécutable par construction ». Genre `test` après `guard` (#8786) : rotation acquise, G-VAR-3 satisfaite ; MED, donc G-VAR-2 hors sujet.

See #8056, #5214, #8598, #8787.
