### PR TITLE
fix(cost,#8791): metadata validator papermill→manual + last_validated→null on 13 QC-Py notebooks

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb
@@ -1155,8 +1155,8 @@
    "free_alternative": null,
    "reduced_pedagogical": null,
    "reproducibility": "HIGH",
-   "last_validated": "2026-07-23T01:30Z",
-   "validator": "papermill"
+   "last_validated": null,
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-03-Data-Management.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-03-Data-Management.ipynb
@@ -1478,8 +1478,8 @@
    "free_alternative": null,
    "reduced_pedagogical": null,
    "reproducibility": "HIGH",
-   "last_validated": "2026-07-23T01:30Z",
-   "validator": "papermill"
+   "last_validated": null,
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb
@@ -1660,8 +1660,8 @@
    "free_alternative": null,
    "reduced_pedagogical": null,
    "reproducibility": "HIGH",
-   "last_validated": "2026-07-23T01:30Z",
-   "validator": "papermill"
+   "last_validated": null,
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
@@ -1946,8 +1946,8 @@
    "free_alternative": null,
    "reduced_pedagogical": null,
    "reproducibility": "HIGH",
-   "last_validated": "2026-07-23T01:30Z",
-   "validator": "papermill"
+   "last_validated": null,
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-10-Risk-Portfolio-Management.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-10-Risk-Portfolio-Management.ipynb
@@ -2935,8 +2935,8 @@
    "free_alternative": null,
    "reduced_pedagogical": null,
    "reproducibility": "HIGH",
-   "last_validated": "2026-07-23T01:30Z",
-   "validator": "papermill"
+   "last_validated": null,
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
@@ -4303,8 +4303,8 @@
    "free_alternative": null,
    "reduced_pedagogical": null,
    "reproducibility": "MEDIUM",
-   "last_validated": "2026-07-23T01:30Z",
-   "validator": "papermill"
+   "last_validated": null,
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
@@ -4140,8 +4140,8 @@
    "free_alternative": "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MEDIUM",
-   "last_validated": "2026-07-23T01:30Z",
-   "validator": "papermill"
+   "last_validated": null,
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
@@ -4074,8 +4074,8 @@
    "free_alternative": null,
    "reduced_pedagogical": null,
    "reproducibility": "HIGH",
-   "last_validated": "2026-07-23T01:30Z",
-   "validator": "papermill"
+   "last_validated": null,
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
@@ -3610,8 +3610,8 @@
    "free_alternative": null,
    "reduced_pedagogical": null,
    "reproducibility": "HIGH",
-   "last_validated": "2026-07-23T01:30Z",
-   "validator": "papermill"
+   "last_validated": null,
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb
@@ -4076,8 +4076,8 @@
    "free_alternative": null,
    "reduced_pedagogical": "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb",
    "reproducibility": "MEDIUM",
-   "last_validated": "2026-07-23T01:30Z",
-   "validator": "papermill"
+   "last_validated": null,
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
@@ -3192,8 +3192,8 @@
    "free_alternative": null,
    "reduced_pedagogical": "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb",
    "reproducibility": "MEDIUM",
-   "last_validated": "2026-07-23T01:30Z",
-   "validator": "papermill"
+   "last_validated": null,
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-25-Reinforcement-Learning.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-25-Reinforcement-Learning.ipynb
@@ -2988,8 +2988,8 @@
    "free_alternative": null,
    "reduced_pedagogical": null,
    "reproducibility": "LOW",
-   "last_validated": "2026-07-23T01:30Z",
-   "validator": "papermill"
+   "last_validated": null,
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
@@ -2260,8 +2260,8 @@
    "free_alternative": "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "LOW",
-   "last_validated": "2026-07-23T01:30Z",
-   "validator": "papermill"
+   "last_validated": null,
+   "validator": "manual"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Context — See #8791

13 `QuantConnect/Python/QC-Py-*.ipynb` notebooks declared `metadata.cost.validator: "papermill"` + an **identical** `last_validated: "2026-07-23T01:30Z"` while their code cells are **unexecuted** (`execution_count: null`). The unexecuted cells are either `[REFERENCE QC]` code (`from AlgorithmImports import *` — runnable only in the QuantConnect runtime) or C.1-compliant exercise stubs (`# Exercice N` / `# TODO etudiant`).

A `papermill` validator asserts an automated validation that **never happened** — the shared timestamp is a **populator mass-write signature** (identical across all 13), not a real validation event. This is the first finding of **litmus 9** (#8790: `validator_asserts_execution_but_cells_unexecuted`).

## Fix — metadata only (per #8791 criteria)

For each of the 13 notebooks:
- `metadata.cost.validator`: `"papermill"` → `"manual"` (honest: not papermill-run)
- `metadata.cost.last_validated`: `"2026-07-23T01:30Z"` → `null` (criterion 4: *retirer plutôt que de laisser mentir*; matches the `null` convention used by the 38 QC-Py notebooks carrying no validator — the canonical honest state per `docs/notebook-metadata/cost-matrix.md`)

The 13 targets (sweep-derived, matches the issue table exactly):
`QC-Py-{02,03,05,06,10,15,17,19,20,22,23,25,26}`.

## Verification

**Litmus 9 sweep** (`scripts/audit/check_cost_metadata.py` from #8790 — not yet on main, so run from that branch's tree):

| | `validator_asserts_execution_but_cells_unexecuted` hits |
|---|---|
| QuantConnect/Python (53 QC-Py notebooks) | **13 → 0** |

**Surgical / byte-stable** (criterion 3): `26 ins / 26 del` across 13 files; the unique changed-line patterns are exactly:
```
-   "last_validated": "2026-07-23T01:30Z",   ->   "last_validated": null,
-   "validator": "papermill"                  ->   "validator": "manual"
```
No cell source edited, **no cell output hand-edited** (Stop & Repair — secrets-hygiene rule 6; there were no outputs to touch anyway), **no notebook re-executed** (cells require the QC runtime; out of scope).

## Out of scope (explicitly, per issue)
- The `AlgorithmImports` fast-path tightening is a **separate byproduct** — not treated here ("ne PAS traiter ici").
- The detector itself (#8790 litmus 9) is a separate PR, CLEAN+MERGEABLE awaiting review.

See #8791