### PR TITLE
ci(knot,#8782): wire advisory target-coverage job to lean-knot.yml

### DIFF
--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -60,6 +60,10 @@ on:
       # a bare runner reached main unobserved (#8722).
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py'
+      # Advisory target-coverage check (See #8782): the target-modules list is
+      # hand-maintained while the lakefile glob grows; a change to the checker
+      # must run it.
+      - 'scripts/lean/check_target_coverage.py'
   pull_request:
     branches: [main]
     paths:
@@ -72,6 +76,7 @@ on:
       - '.github/workflows/lean-build.yml'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py'
+      - 'scripts/lean/check_target_coverage.py'
   workflow_dispatch:
 
 jobs:
@@ -109,3 +114,27 @@ jobs:
       # three lines up. `has_sorry` is still reported per module, and forbidden
       # axioms still hard-fail. Flip this to `true` when the baseline reaches 0.
       fail-on-sorry: false
+
+  # Advisory proof-integrity coverage (See #8782). Same pattern as conway_lean
+  # (#8787): the `target-modules` list above is hand-maintained while the
+  # lakefile glob (.submodules Knots, Knots_en) grows as modules are added; a
+  # gate that inspects 5 of 14 compiled modules is a "vert hors-cible" --
+  # visually indistinguishable from a targeted green in the check rollup. This
+  # job prints the delta (compiled vs target) and ALWAYS exits 0: it never
+  # fails CI, it makes the gap legible in the log. It does NOT decide which
+  # modules to gate (options a/b/c in #8782) -- that is a coordinator design call.
+  target-coverage:
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Advisory target-coverage delta
+        run: |
+          python3 scripts/lean/check_target_coverage.py \
+            --project-path MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean \
+            --target-modules "Knots.Basic,Knots.Conway,Knots.Invariant,Knots.Reidemeister,Knots.Lidman" \
+            --lib-root Knots \
+            --name knot_lean


### PR DESCRIPTION
## Context — See #8782

`knot_lean` has a Level-3 proof-integrity gate (`target-modules: 5 Knots.* modules`) but, unlike `conway_lean` (#8787), **no advisory coverage check**. The lakefile glob (`.submodules Knots`, `Knots_en`) compiles **14** modules while the gate inspects **5** — a 35.7 % "vert hors-cible", visually indistinguishable from a targeted green in the CI rollup. The 9 blind-spots are the umbrella (`Knots`, `Knots_en`) + all `_en` siblings + `MathlibPrerequisites` FR/EN.

This is the **second lake** hit by the #8782 anti-pattern (conway was the first, wired in #8787).

## Fix

Wire the same **exit-0 advisory** `target-coverage` job as `lean-conway.yml`:
- walks the lakefile glob vs the hand-maintained `target-modules` list,
- prints the delta (blind-spot + phantom),
- **always exits 0** — never fails CI, makes the gap legible in the log.

Also adds `scripts/lean/check_target_coverage.py` to the push/PR path triggers (a change to the checker re-runs it), mirroring conway.

**It does NOT decide** which modules to gate (options a/b/c in #8782) nor the blocking policy — that remains a coordinator design call. Advisory only.

## Verification (firsthand, this tree)

```
Compiled modules: 14 | Gate target-modules: 5 | Covered: 5 (35.7%)
BLIND SPOT (9): Knots, Knots_en, Knots.Basic_en, Knots.Conway_en,
                Knots.Invariant_en, Knots.Lidman_en, Knots.Reidemeister_en,
                Knots.MathlibPrerequisites, Knots.MathlibPrerequisites_en
exit 0 (advisory)
```

YAML validated (`yaml.safe_load` OK). Diff: 1 file, 29 insertions (job + 2 path-trigger lines).

Mirrors `lean-conway.yml` target-coverage job from #8787.

See #8782