### PR TITLE
feat(audit,#8795): detecteur de commits orphelins pousses apres le merge de leur PR

### DIFF
--- a/scripts/audit/check_orphan_post_merge_commits.py
+++ b/scripts/audit/check_orphan_post_merge_commits.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""check_orphan_post_merge_commits.py — detecte le travail pousse APRES le merge de sa PR.
+
+Classe de defaut visee : une PR est mergee, puis des commits sont pousses sur sa
+branche de tete. Le contenu de ces commits n'atteint jamais `main` et **rien ne le
+signale** : la PR affiche `MERGED`, son titre peut avoir ete edite pour annoncer le
+travail complet, et le rapport de l'auteur herite du titre plutot que de l'historique.
+
+Incident fondateur (#6724, 2026-07-29) : le capstone `evolve_shift` a ete pousse
+**11 minutes apres** le merge de sa PR. Cinq theoremes sont restes absents de `main`
+pendant deux cycles alors que le titre de la PR annoncait « chain COMPLETE ». Le
+travail n'a survecu que parce que la branche n'avait pas ete supprimee au merge
+(`--delete-branch` est interdit dans ce depot, cf .claude/rules/git-workflow.md).
+
+Deux filtres anti-faux-positifs, sans lesquels l'outil serait inutilisable :
+
+1. **Les originaux d'un squash-merge ne sont PAS orphelins.** Apres un squash, les
+   commits d'origine restent inaccessibles depuis `main` par construction — leur
+   contenu, lui, y est. Seuls les commits **dates apres** `mergedAt` sont candidats.
+2. **Le contenu re-atterri par une autre route n'est PAS orphelin.** Un cherry-pick
+   ulterieur peut avoir apporte les memes lignes. On ne signale que si les fichiers
+   touches **different encore** entre `main` et la branche.
+
+Un finding est donc : *au moins un commit poste-merge dont le contenu manque toujours
+a `main`*. C'est verifiable en une commande, et c'est ce que la sortie affiche.
+
+Usage :
+    py scripts/audit/check_orphan_post_merge_commits.py --days 14
+    py scripts/audit/check_orphan_post_merge_commits.py --from-json prs.json
+    py scripts/audit/check_orphan_post_merge_commits.py --days 30 --strict
+    py scripts/audit/check_orphan_post_merge_commits.py --days 7 --json-out out.json
+
+Exit codes :
+    0 — advisory par defaut : n'echoue jamais, meme avec des findings
+    1 — findings ET `--strict` (a n'activer qu'une fois la classe de FP mesuree a zero)
+    2 — erreur d'execution (git absent, depot invalide, JSON illisible)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+class GitError(RuntimeError):
+    """Echec d'une commande git — remonte en exit 2, jamais en finding."""
+
+
+def run_git(repo: Path, *args: str, check: bool = True) -> str:
+    """Execute git dans `repo` et rend stdout strippe."""
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if check and proc.returncode != 0:
+        raise GitError(f"git {' '.join(args)} -> {proc.returncode}: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def parse_ts(value: str) -> datetime:
+    """Parse un horodatage ISO 8601 (git %cI ou gh mergedAt) en datetime aware."""
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def branch_exists(repo: Path, ref: str) -> bool:
+    """Vrai si la ref existe (branche locale, distante, ou tag)."""
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "--verify", "--quiet", ref],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode == 0
+
+
+def commits_not_in_base(repo: Path, base_ref: str, branch_ref: str) -> list[dict]:
+    """Commits presents sur `branch_ref` et inaccessibles depuis `base_ref`.
+
+    Rend une liste de dicts {sha, committed_at, subject}, du plus recent au plus ancien.
+    """
+    out = run_git(
+        repo,
+        "log",
+        "--format=%H%x1f%cI%x1f%s",
+        f"{base_ref}..{branch_ref}",
+    )
+    commits: list[dict] = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\x1f")
+        if len(parts) != 3:
+            continue
+        sha, committed_at, subject = parts
+        commits.append({"sha": sha, "committed_at": committed_at, "subject": subject})
+    return commits
+
+
+def files_touched(repo: Path, shas: Iterable[str]) -> list[str]:
+    """Union des chemins touches par les commits donnes."""
+    paths: set[str] = set()
+    for sha in shas:
+        out = run_git(repo, "show", "--pretty=", "--name-only", sha)
+        paths.update(p for p in out.splitlines() if p.strip())
+    return sorted(paths)
+
+
+def content_missing_from_base(
+    repo: Path, base_ref: str, branch_ref: str, paths: list[str]
+) -> bool:
+    """Vrai si les chemins donnes different encore entre base et branche.
+
+    Diff **deux-points** volontairement : on compare les arbres tels qu'ils sont
+    aujourd'hui, pas depuis la base de fusion. Un diff trois-points reintroduirait
+    le contenu deja squashe et rendrait tout squash-merge suspect.
+    """
+    if not paths:
+        return False
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "diff", "--quiet", base_ref, branch_ref, "--", *paths],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode == 0:
+        return False  # identique -> le contenu est deja dans la base
+    if proc.returncode == 1:
+        return True  # differe -> contenu absent de la base
+    raise GitError(f"git diff --quiet -> {proc.returncode}: {proc.stderr.strip()}")
+
+
+def analyse_pr(repo: Path, pr: dict, base_ref: str, remote: str) -> dict:
+    """Analyse une PR mergee. Rend un dict de resultat, avec `status` explicite.
+
+    Statuts possibles :
+      ``orphan``       — commits poste-merge dont le contenu manque a la base (finding)
+      ``clean``        — rien de poste-merge, ou contenu deja re-atterri
+      ``branch_gone``  — branche supprimee : indetectable, signale sans etre un finding
+      ``skipped``      — PR sans `mergedAt` ou sans branche de tete exploitable
+    """
+    number = pr.get("number")
+    head = (pr.get("headRefName") or "").strip()
+    merged_at_raw = pr.get("mergedAt")
+
+    base = {"number": number, "head": head, "merged_at": merged_at_raw,
+            "title": pr.get("title", "")}
+
+    if not head or not merged_at_raw:
+        return {**base, "status": "skipped", "reason": "missing headRefName or mergedAt"}
+
+    branch_ref = f"{remote}/{head}" if remote else head
+    if not branch_exists(repo, branch_ref):
+        return {**base, "status": "branch_gone", "branch_ref": branch_ref}
+
+    merged_at = parse_ts(merged_at_raw)
+    unreachable = commits_not_in_base(repo, base_ref, branch_ref)
+
+    # Filtre 1 : seuls les commits DATES APRES le merge sont candidats.
+    # Les originaux d'un squash sont inaccessibles par construction, pas orphelins.
+    post_merge = [c for c in unreachable if parse_ts(c["committed_at"]) > merged_at]
+    if not post_merge:
+        return {**base, "status": "clean", "branch_ref": branch_ref,
+                "unreachable_total": len(unreachable), "post_merge": 0}
+
+    # Filtre 2 : le contenu a-t-il re-atterri par une autre route (cherry-pick) ?
+    paths = files_touched(repo, [c["sha"] for c in post_merge])
+    missing = content_missing_from_base(repo, base_ref, branch_ref, paths)
+    if not missing:
+        return {**base, "status": "clean", "branch_ref": branch_ref,
+                "unreachable_total": len(unreachable), "post_merge": len(post_merge),
+                "reason": "content already present in base (re-landed elsewhere)"}
+
+    return {
+        **base,
+        "status": "orphan",
+        "branch_ref": branch_ref,
+        "base_ref": base_ref,
+        "unreachable_total": len(unreachable),
+        "post_merge": len(post_merge),
+        "commits": post_merge,
+        "paths": paths,
+    }
+
+
+def load_prs(args: argparse.Namespace) -> list[dict]:
+    """Charge les PR mergees depuis un JSON local (`--from-json`) ou via `gh`."""
+    if args.from_json:
+        path = Path(args.from_json)
+        if not path.is_file():
+            raise GitError(f"--from-json: fichier introuvable: {path}")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else data.get("prs", [])
+
+    cmd = [
+        "gh", "pr", "list", "--state", "merged", "--limit", str(args.limit),
+        "--json", "number,title,headRefName,mergedAt",
+    ]
+    if args.repo:
+        cmd += ["--repo", args.repo]
+    proc = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8",
+                          errors="replace")
+    if proc.returncode != 0:
+        raise GitError(f"gh pr list -> {proc.returncode}: {proc.stderr.strip()}")
+    return json.loads(proc.stdout or "[]")
+
+
+def filter_by_age(prs: list[dict], days: int, now: datetime | None = None) -> list[dict]:
+    """Ne garde que les PR mergees dans la fenetre demandee (0 = sans limite)."""
+    if days <= 0:
+        return prs
+    reference = now or datetime.now(timezone.utc)
+    kept = []
+    for pr in prs:
+        raw = pr.get("mergedAt")
+        if not raw:
+            continue
+        if (reference - parse_ts(raw)).days <= days:
+            kept.append(pr)
+    return kept
+
+
+def format_report(results: list[dict]) -> str:
+    """Rapport texte : les findings d'abord, puis un recapitulatif compte."""
+    orphans = [r for r in results if r["status"] == "orphan"]
+    gone = [r for r in results if r["status"] == "branch_gone"]
+    lines: list[str] = []
+
+    for r in orphans:
+        lines.append(f"ORPHAN  PR #{r['number']}  {r['head']}")
+        lines.append(f"        merge: {r['merged_at']}   |  {r['title'][:70]}")
+        for c in r["commits"]:
+            lines.append(f"        + {c['sha'][:9]}  {c['committed_at']}  {c['subject'][:60]}")
+        for p in r["paths"]:
+            lines.append(f"          ~ {p}")
+        lines.append(
+            "        verifier : git diff {base} {branch} -- {paths}".format(
+                base=r.get("base_ref", "origin/main"),
+                branch=r["branch_ref"],
+                paths=" ".join(r["paths"][:3]),
+            )
+        )
+        lines.append("")
+
+    lines.append(
+        "Analysees: {total} | orphelines: {o} | propres: {c} | branche supprimee: {g} | ignorees: {s}".format(
+            total=len(results),
+            o=len(orphans),
+            c=sum(1 for r in results if r["status"] == "clean"),
+            g=len(gone),
+            s=sum(1 for r in results if r["status"] == "skipped"),
+        )
+    )
+    if gone:
+        lines.append(
+            "Note: {n} PR ont une branche supprimee — le travail poste-merge y serait "
+            "indetectable (raison du 'JAMAIS --delete-branch').".format(n=len(gone))
+        )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo-path", default=".", help="racine du depot git (defaut: .)")
+    parser.add_argument("--base-ref", default="origin/main", help="ref de base (defaut: origin/main)")
+    parser.add_argument("--remote", default="origin",
+                        help="remote portant les branches de tete ('' pour des refs locales)")
+    parser.add_argument("--days", type=int, default=14,
+                        help="fenetre d'anciennete des merges, en jours (0 = sans limite)")
+    parser.add_argument("--limit", type=int, default=100, help="nombre de PR demandees a gh")
+    parser.add_argument("--repo", default=None, help="slug owner/name passe a gh")
+    parser.add_argument("--from-json", default=None,
+                        help="lire les PR depuis un JSON local au lieu d'appeler gh")
+    parser.add_argument("--json-out", default=None, help="ecrire le resultat complet en JSON")
+    parser.add_argument("--strict", action="store_true",
+                        help="exit 1 si au moins un orphelin (defaut: advisory, exit 0)")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo = Path(args.repo_path).resolve()
+
+    try:
+        if not (repo / ".git").exists() and not (repo / ".git").is_file():
+            run_git(repo, "rev-parse", "--git-dir")
+        prs = filter_by_age(load_prs(args), args.days)
+        results = [analyse_pr(repo, pr, args.base_ref, args.remote) for pr in prs]
+    except GitError as exc:
+        print(f"ERREUR: {exc}", file=sys.stderr)
+        return 2
+    except json.JSONDecodeError as exc:
+        print(f"ERREUR: JSON illisible: {exc}", file=sys.stderr)
+        return 2
+
+    print(format_report(results))
+
+    if args.json_out:
+        try:
+            Path(args.json_out).write_text(
+                json.dumps({"results": results}, indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            print(f"ERREUR: --json-out non ecrivable: {exc}", file=sys.stderr)
+            return 2
+
+    orphans = [r for r in results if r["status"] == "orphan"]
+    return 1 if (orphans and args.strict) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_orphan_post_merge_commits.py
+++ b/scripts/tests/test_check_orphan_post_merge_commits.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Tests de check_orphan_post_merge_commits.py — depots git synthetiques reels.
+
+Les fixtures construisent de vrais depots git dans `tmp_path` plutot que de simuler
+la sortie de git : la classe de faux-positif que l'outil doit eviter (les commits
+d'origine d'un squash-merge) n'apparait que dans une vraie topologie.
+
+Executable des deux facons :
+    py scripts/tests/test_check_orphan_post_merge_commits.py
+    npx pytest scripts/tests/test_check_orphan_post_merge_commits.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "audit"))
+
+import check_orphan_post_merge_commits as mod  # noqa: E402
+
+
+BASE_TS = datetime(2026, 7, 20, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+
+def git(repo: Path, *args: str, at: datetime | None = None) -> str:
+    env = None
+    if at is not None:
+        import os
+
+        env = os.environ.copy()
+        env["GIT_AUTHOR_DATE"] = iso(at)
+        env["GIT_COMMITTER_DATE"] = iso(at)
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, env=env, encoding="utf-8", errors="replace",
+    )
+    if proc.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} -> {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def write(repo: Path, name: str, content: str) -> None:
+    (repo / name).write_text(content, encoding="utf-8")
+
+
+def init_repo(root: Path) -> Path:
+    repo = root / "repo"
+    repo.mkdir(parents=True, exist_ok=True)
+    git(repo, "init", "-q", "-b", "main")
+    git(repo, "config", "user.email", "test@example.invalid")
+    git(repo, "config", "user.name", "Test")
+    write(repo, "README.md", "base\n")
+    git(repo, "add", "README.md")
+    git(repo, "commit", "-q", "-m", "base", at=BASE_TS)
+    return repo
+
+
+def make_squash_merged_branch(repo: Path) -> datetime:
+    """Branche 'feat' avec 2 commits, squashee dans main. Rend l'instant du merge."""
+    git(repo, "checkout", "-q", "-b", "feat")
+    write(repo, "feature.txt", "first\n")
+    git(repo, "add", "feature.txt")
+    git(repo, "commit", "-q", "-m", "wip 1", at=BASE_TS + timedelta(hours=1))
+    write(repo, "feature.txt", "first\nsecond\n")
+    git(repo, "add", "feature.txt")
+    git(repo, "commit", "-q", "-m", "wip 2", at=BASE_TS + timedelta(hours=2))
+
+    merged_at = BASE_TS + timedelta(hours=3)
+    git(repo, "checkout", "-q", "main")
+    git(repo, "merge", "-q", "--squash", "feat")
+    git(repo, "commit", "-q", "-m", "squashed feat (#1)", at=merged_at)
+    git(repo, "checkout", "-q", "feat")
+    return merged_at
+
+
+def pr(merged_at: datetime, head: str = "feat", number: int = 1) -> dict:
+    return {"number": number, "title": "feat", "headRefName": head,
+            "mergedAt": iso(merged_at)}
+
+
+# --------------------------------------------------------------------------- tests
+
+def test_squash_originals_are_not_orphans(root: Path) -> None:
+    """Les commits d'origine d'un squash sont inaccessibles mais PAS orphelins."""
+    repo = init_repo(root)
+    merged_at = make_squash_merged_branch(repo)
+
+    result = mod.analyse_pr(repo, pr(merged_at), base_ref="main", remote="")
+
+    assert result["unreachable_total"] == 2, result
+    assert result["post_merge"] == 0, result
+    assert result["status"] == "clean", result
+
+
+def test_post_merge_commit_is_flagged(root: Path) -> None:
+    """Un commit pousse APRES le merge, absent de main, est un finding."""
+    repo = init_repo(root)
+    merged_at = make_squash_merged_branch(repo)
+
+    write(repo, "capstone.txt", "theorem evolve_shift\n")
+    git(repo, "add", "capstone.txt")
+    git(repo, "commit", "-q", "-m", "capstone", at=merged_at + timedelta(minutes=11))
+
+    result = mod.analyse_pr(repo, pr(merged_at), base_ref="main", remote="")
+
+    assert result["status"] == "orphan", result
+    assert result["post_merge"] == 1, result
+    assert result["paths"] == ["capstone.txt"], result
+    assert result["commits"][0]["subject"] == "capstone", result
+
+
+def test_relanded_content_is_not_an_orphan(root: Path) -> None:
+    """Un contenu poste-merge re-atterri par une autre route n'est pas orphelin."""
+    repo = init_repo(root)
+    merged_at = make_squash_merged_branch(repo)
+
+    write(repo, "capstone.txt", "theorem evolve_shift\n")
+    git(repo, "add", "capstone.txt")
+    git(repo, "commit", "-q", "-m", "capstone", at=merged_at + timedelta(minutes=11))
+    sha = git(repo, "rev-parse", "HEAD")
+
+    git(repo, "checkout", "-q", "main")
+    git(repo, "cherry-pick", sha)
+    git(repo, "checkout", "-q", "feat")
+
+    result = mod.analyse_pr(repo, pr(merged_at), base_ref="main", remote="")
+
+    assert result["post_merge"] == 1, result
+    assert result["status"] == "clean", result
+    assert "re-landed" in result["reason"], result
+
+
+def test_deleted_branch_is_reported_not_flagged(root: Path) -> None:
+    """Branche supprimee : indetectable, signale sans compter comme finding."""
+    repo = init_repo(root)
+    merged_at = make_squash_merged_branch(repo)
+    git(repo, "checkout", "-q", "main")
+    git(repo, "branch", "-q", "-D", "feat")
+
+    result = mod.analyse_pr(repo, pr(merged_at), base_ref="main", remote="")
+
+    assert result["status"] == "branch_gone", result
+
+
+def test_missing_merged_at_is_skipped(root: Path) -> None:
+    repo = init_repo(root)
+    result = mod.analyse_pr(repo, {"number": 9, "headRefName": "feat"},
+                            base_ref="main", remote="")
+    assert result["status"] == "skipped", result
+
+
+def test_parse_ts_accepts_z_and_offset(root: Path) -> None:
+    z = mod.parse_ts("2026-07-29T04:10:39Z")
+    off = mod.parse_ts("2026-07-29T06:10:39+02:00")
+    assert z == off, (z, off)
+    assert mod.parse_ts("2026-07-29T04:10:39").tzinfo is not None
+
+
+def test_filter_by_age(root: Path) -> None:
+    now = datetime(2026, 7, 29, tzinfo=timezone.utc)
+    prs = [
+        {"number": 1, "mergedAt": iso(now - timedelta(days=3))},
+        {"number": 2, "mergedAt": iso(now - timedelta(days=40))},
+        {"number": 3},
+    ]
+    kept = [p["number"] for p in mod.filter_by_age(prs, days=14, now=now)]
+    assert kept == [1], kept
+    assert len(mod.filter_by_age(prs, days=0, now=now)) == 3
+
+
+def test_main_end_to_end_advisory_then_strict(root: Path) -> None:
+    """L'outil sort 0 par defaut (advisory) et 1 avec --strict sur un orphelin."""
+    repo = init_repo(root)
+    merged_at = make_squash_merged_branch(repo)
+    write(repo, "capstone.txt", "theorem evolve_shift\n")
+    git(repo, "add", "capstone.txt")
+    git(repo, "commit", "-q", "-m", "capstone", at=merged_at + timedelta(minutes=11))
+
+    prs_json = root / "prs.json"
+    prs_json.write_text(json.dumps([pr(merged_at)]), encoding="utf-8")
+    out_json = root / "out.json"
+
+    argv = ["--repo-path", str(repo), "--base-ref", "main", "--remote", "",
+            "--days", "0", "--from-json", str(prs_json), "--json-out", str(out_json)]
+
+    assert mod.main(argv) == 0
+    assert mod.main(argv + ["--strict"]) == 1
+
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert [r["status"] for r in payload["results"]] == ["orphan"], payload
+
+
+def test_bad_repo_path_exits_2(root: Path) -> None:
+    prs_json = root / "empty.json"
+    prs_json.write_text("[]", encoding="utf-8")
+    code = mod.main(["--repo-path", str(root / "nope"), "--from-json", str(prs_json)])
+    assert code == 2, code
+
+
+# --------------------------------------------------------------------- harnais
+
+try:  # pytest fournit tmp_path ; on mappe root dessus.
+    import pytest
+
+    @pytest.fixture()
+    def root(tmp_path: Path) -> Path:  # noqa: D103
+        return tmp_path
+except ImportError:  # pragma: no cover - execution directe sans pytest
+    pass
+
+
+def run_direct() -> int:
+    tests = [(n, f) for n, f in sorted(globals().items())
+             if n.startswith("test_") and callable(f)]
+    failures = 0
+    for name, fn in tests:
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                fn(Path(tmp))
+                print(f"PASS  {name}")
+            except Exception as exc:  # noqa: BLE001
+                failures += 1
+                print(f"FAIL  {name}: {exc}")
+    print(f"\n{len(tests) - failures}/{len(tests)} tests passes")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_direct())


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/test (#8790)

## La classe de defaut, et pourquoi elle etait invisible

Une PR est mergee ; des commits sont ensuite pousses sur sa branche de tete. Leur contenu n'atteint jamais `main`. La PR affiche `MERGED`, son titre annonce le travail complet, la CI ne repasse pas — il n'y a plus de PR ouverte a verifier. **Le rapport de l'auteur herite du titre plutot que de l'historique**, et il est de bonne foi.

Cas de reproduction, mesure au c.49 : **#8784**, titre « translation-invariance chain COMPLETE ». Le commit `82e2240d2` est date de **11 minutes apres** son `mergedAt`. Cinq theoremes — `mem_shift`, `mooreNeighbors_shift_mem`, `candidates_shift`, `step_shift`, `evolve_shift` — restent absents de `main` deux cycles plus tard. Quatre autres du meme fichier y sont : c'est une chaine **partiellement** arrivee, ce qui la rend discrete.

Le defaut n'a ete trouve qu'en mesurant a la main le DM de son auteur. Rien dans le depot ne le voyait.

## Ce qui rend la detection non triviale

`git rev-list origin/main..origin/<branche>` non vide est le **cas normal** apres un squash-merge : les commits d'origine deviennent inaccessibles depuis `main` par construction, alors meme que leur contenu y est. Un detecteur naif signale **chaque PR squashee du depot** — c'est-a-dire toutes.

Deux filtres, et le second a un piege :

1. **Date** — seuls les commits dont la date de commit est posterieure a `mergedAt` sont candidats.
2. **Contenu** — ne signaler que si les fichiers touches different **encore** entre `main` et la branche. Diff **deux-points** obligatoire : un trois-points partirait de la base de fusion et reintroduirait le contenu deja squashe, annulant le filtre 1.

## Mesure sur les donnees reelles du depot

```
$ py scripts/audit/check_orphan_post_merge_commits.py --days 90 --limit 200
Analysees: 200 | orphelines: 1 | propres: 197 | branche supprimee: 2 | ignorees: 0
```

**200 merges reels, 1 finding — le cas connu — et zero faux positif.** C'est le chiffre qui decide si l'organe est utilisable : un detecteur qui signale les 200 serait ignore des la premiere semaine.

Une honnetete a inscrire, parce qu'elle nuance ce resultat : **le filtre 2 n'a ete declenche par aucune donnee reelle** (`post_merge > 0 && status == clean` est vide sur les 200). C'est le filtre 1 seul qui porte toute la suppression de faux positifs en production. Le filtre 2 n'est prouve que par son test unitaire — il couvre un cas qui ne s'est pas encore produit ici, pas un cas mesure.

Et les **2 branches supprimees** ne sont pas un detail : sur celles-la, du travail poste-merge serait **indetectable**. Elles sont rapportees comme angle mort, jamais comme finding. C'est le premier benefice visible de l'interdiction de `--delete-branch` — sans elle, #8784 n'aurait laisse aucune trace.

## Tests — depots git reels, pas simules

9 tests, `PASS 9/9`. Ils construisent de vrais depots dans `tmp_path` avec `GIT_COMMITTER_DATE` controle, parce que la topologie squash-merge qu'il faut ne pas signaler n'apparait pas dans une sortie de git simulee.

| Test | Ce qu'il verrouille |
|---|---|
| `test_squash_originals_are_not_orphans` | 2 commits inaccessibles, 0 poste-merge, verdict `clean` — le faux positif de masse |
| `test_post_merge_commit_is_flagged` | le cas #8784, reproduit a la minute pres |
| `test_relanded_content_is_not_an_orphan` | cherry-pick ulterieur vers `main` -> `clean`, filtre 2 |
| `test_deleted_branch_is_reported_not_flagged` | `branch_gone` distinct d'un finding |
| `test_main_end_to_end_advisory_then_strict` | exit 0 par defaut, exit 1 avec `--strict`, JSON conforme |

Plus `parse_ts` (Z vs offset), `filter_by_age`, `mergedAt` absent, chemin de depot invalide -> exit 2.

## Advisory d'abord

Exit 0 par defaut **meme avec des findings** ; `--strict` pour exit 1. Un organe se cable en advisory, se mesure, et ne bloque qu'ensuite — c'est la sequence que j'ai demandee a po-2023 sur #8787/#8794, elle vaut pour moi. Aucun workflow n'est modifie par cette PR : le cablage CI est une decision distincte, a prendre quand le taux de faux positifs aura tenu plusieurs semaines.

## Ce que cette PR ne fait pas

Elle ne **recupere pas** #8784. Les cinq theoremes restent dus par la lane qui les a ecrits (#6724) ; l'outil dit ou ils sont, il ne les cherry-picke pas.

## Tag de variation

`MED/tooling`. **`tooling` est une extension de la liste de genres** de [variation-protocol.md](.claude/rules/variation-protocol.md) — je l'ecris plutot que de forcer ce travail dans `test` (il ne teste rien d'existant) ou `ci` (rien n'est cable en CI). Ni LIGHT — le litmus est franchi net : je ne peux pas en generer une douzaine en scannant l'instance voisine, il a fallu deriver la topologie squash pour trouver le filtre date. Ni DEEP — `main` gagne un organe de detection, pas une capacite de domaine.

Closes #8795
See #8784, #6724
