### PR TITLE
fix(conway,#6724): recover 5 stranded translation-invariance theorems from post-merge orphan #8784

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical.lean
@@ -308,5 +308,72 @@ theorem mem_step_iff {g : Grid} {p : Int × Int} :
   unfold step
   rw [mem_sortDedup, List.mem_filter]
 
+/-! ## Commutation de `step` / `evolve` avec la translation
+
+Suite et fin de la chaîne d'invariance par translation : la couche locale
+(`isAlive_shift`, `liveNeighborCount_shift`, `aliveNext_shift` ci-dessus) établit
+que la **règle** B3/S23 est invariante ; cette couche établit que le **pas global**
+`step` puis l'**itération** `evolve` **commutent** avec la translation de grille :
+`shift v (evolve n g) = evolve n (shift v g)`. C'est la machinerie d'alignement
+des points `p ↔ p'` requise par le chemin (A) de #6724 avant d'appliquer
+`evolve_cone_agree` (qui ne conclut qu'en un même point). -/
+
+/-- Appartenance à une grille translatée : `p ∈ shift v g ↔ (p.1-v.1, p.2-v.2) ∈ g`. -/
+theorem mem_shift (v : Int × Int) (g : Grid) (p : Int × Int) :
+    p ∈ shift v g ↔ (p.1 - v.1, p.2 - v.2) ∈ g := by
+  simp [shift, List.mem_map, mem_sortDedup]
+  constructor
+  · rintro ⟨a, b, hg, hp⟩
+    have hp' : a + v.1 = p.1 ∧ b + v.2 = p.2 := Prod.ext_iff.mp hp
+    have heq : (a, b) = (p.1 - v.1, p.2 - v.2) := by rw [Prod.ext_iff]; omega
+    rw [← heq]; exact hg
+  · intro h
+    refine ⟨p.1 - v.1, p.2 - v.2, h, ?_⟩
+    rw [Prod.ext_iff]; omega
+
+/-- Les voisins de Moore sont relatifs : `p ∈ mooreNeighbors a` équivaut à
+    `(p - v) ∈ mooreNeighbors (a - v)` (le voisinage translated coïncide). -/
+theorem mooreNeighbors_shift_mem (v a p : Int × Int) :
+    p ∈ mooreNeighbors a ↔ (p.1 - v.1, p.2 - v.2) ∈ mooreNeighbors (a.1 - v.1, a.2 - v.2) := by
+  simp [mooreNeighbors, Prod.ext_iff, Prod.eta]
+  omega
+
+/-- L'ensemble candidat est invariant par translation de la grille. -/
+theorem candidates_shift (v : Int × Int) (g : Grid) (p : Int × Int) :
+    p ∈ candidates (shift v g) ↔ (p.1 - v.1, p.2 - v.2) ∈ candidates g := by
+  simp [candidates, mem_shift, mooreNeighbors_shift_mem, Prod.ext_iff]
+  constructor
+  · rintro (h | ⟨a, b, hg, hm⟩)
+    · exact Or.inl h
+    · refine Or.inr ⟨a - v.1, b - v.2, hg, (mooreNeighbors_shift_mem v (a, b) p).mp hm⟩
+  · rintro (h | ⟨a, b, hg, hm⟩)
+    · exact Or.inl h
+    · refine Or.inr ⟨a + v.1, b + v.2, ?_, ?_⟩
+      · have heq : (a + v.1 - v.1, b + v.2 - v.2) = (a, b) := by rw [Prod.ext_iff]; omega
+        rw [heq]; exact hg
+      · have heq : ((a + v.1) - v.1, (b + v.2) - v.2) = (a, b) := by rw [Prod.ext_iff]; omega
+        have hm' : (p.1 - v.1, p.2 - v.2) ∈ mooreNeighbors ((a + v.1) - v.1, (b + v.2) - v.2) := by
+          rw [heq]; exact hm
+        exact (mooreNeighbors_shift_mem v (a + v.1, b + v.2) p).mpr hm'
+
+/-- `step` commute avec la translation : `shift v (step g) = step (shift v g)`. -/
+theorem step_shift (v : Int × Int) (g : Grid) : shift v (step g) = step (shift v g) := by
+  apply Canonical.ext
+  · exact canonical_shift v (step g)
+  · exact canonical_step (shift v g)
+  · intro p
+    rw [mem_shift, mem_step_iff, mem_step_iff, aliveNext_shift]
+    constructor
+    · rintro ⟨hc, ha⟩; exact ⟨(candidates_shift v g p).mpr hc, ha⟩
+    · rintro ⟨hc, ha⟩; exact ⟨(candidates_shift v g p).mp hc, ha⟩
+
+/-- `evolve` commute avec la translation :
+    `shift v (evolve n g) = evolve n (shift v g)` (par induction sur `n`). -/
+theorem evolve_shift (v : Int × Int) (n : Nat) (g : Grid) :
+    shift v (evolve n g) = evolve n (shift v g) := by
+  induction n with
+  | zero => simp [evolve]
+  | succ k ih => rw [evolve_succ, step_shift, ih, ← evolve_succ]
+
 end Life
 end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical_en.lean
@@ -168,5 +168,72 @@ theorem mem_step_iff {g : Grid} {p : Int × Int} :
   unfold step
   rw [mem_sortDedup, List.mem_filter]
 
+/-! ## Commutation of `step` / `evolve` with translation
+
+Conclusion of the translation-invariance chain: the local layer
+(`isAlive_shift`, `liveNeighborCount_shift`, `aliveNext_shift` above) establishes
+that the B3/S23 **rule** is invariant; this layer establishes that the global
+**step** and its iteration **evolve** **commute** with grid translation:
+`shift v (evolve n g) = evolve n (shift v g)`. This is the point-alignment
+machinery `p ↔ p'` required by path (A) of #6724 before applying
+`evolve_cone_agree` (which concludes only at a common point). -/
+
+/-- Membership in a shifted grid: `p ∈ shift v g ↔ (p.1-v.1, p.2-v.2) ∈ g`. -/
+theorem mem_shift (v : Int × Int) (g : Grid) (p : Int × Int) :
+    p ∈ shift v g ↔ (p.1 - v.1, p.2 - v.2) ∈ g := by
+  simp [shift, List.mem_map, mem_sortDedup]
+  constructor
+  · rintro ⟨a, b, hg, hp⟩
+    have hp' : a + v.1 = p.1 ∧ b + v.2 = p.2 := Prod.ext_iff.mp hp
+    have heq : (a, b) = (p.1 - v.1, p.2 - v.2) := by rw [Prod.ext_iff]; omega
+    rw [← heq]; exact hg
+  · intro h
+    refine ⟨p.1 - v.1, p.2 - v.2, h, ?_⟩
+    rw [Prod.ext_iff]; omega
+
+/-- Moore neighbours are relative: `p ∈ mooreNeighbors a` is equivalent to
+    `(p - v) ∈ mooreNeighbors (a - v)` (the translated neighbourhood coincides). -/
+theorem mooreNeighbors_shift_mem (v a p : Int × Int) :
+    p ∈ mooreNeighbors a ↔ (p.1 - v.1, p.2 - v.2) ∈ mooreNeighbors (a.1 - v.1, a.2 - v.2) := by
+  simp [mooreNeighbors, Prod.ext_iff, Prod.eta]
+  omega
+
+/-- The candidate set is translation-invariant. -/
+theorem candidates_shift (v : Int × Int) (g : Grid) (p : Int × Int) :
+    p ∈ candidates (shift v g) ↔ (p.1 - v.1, p.2 - v.2) ∈ candidates g := by
+  simp [candidates, mem_shift, mooreNeighbors_shift_mem, Prod.ext_iff]
+  constructor
+  · rintro (h | ⟨a, b, hg, hm⟩)
+    · exact Or.inl h
+    · refine Or.inr ⟨a - v.1, b - v.2, hg, (mooreNeighbors_shift_mem v (a, b) p).mp hm⟩
+  · rintro (h | ⟨a, b, hg, hm⟩)
+    · exact Or.inl h
+    · refine Or.inr ⟨a + v.1, b + v.2, ?_, ?_⟩
+      · have heq : (a + v.1 - v.1, b + v.2 - v.2) = (a, b) := by rw [Prod.ext_iff]; omega
+        rw [heq]; exact hg
+      · have heq : ((a + v.1) - v.1, (b + v.2) - v.2) = (a, b) := by rw [Prod.ext_iff]; omega
+        have hm' : (p.1 - v.1, p.2 - v.2) ∈ mooreNeighbors ((a + v.1) - v.1, (b + v.2) - v.2) := by
+          rw [heq]; exact hm
+        exact (mooreNeighbors_shift_mem v (a + v.1, b + v.2) p).mpr hm'
+
+/-- `step` commutes with translation: `shift v (step g) = step (shift v g)`. -/
+theorem step_shift (v : Int × Int) (g : Grid) : shift v (step g) = step (shift v g) := by
+  apply Canonical.ext
+  · exact canonical_shift v (step g)
+  · exact canonical_step (shift v g)
+  · intro p
+    rw [mem_shift, mem_step_iff, mem_step_iff, aliveNext_shift]
+    constructor
+    · rintro ⟨hc, ha⟩; exact ⟨(candidates_shift v g p).mpr hc, ha⟩
+    · rintro ⟨hc, ha⟩; exact ⟨(candidates_shift v g p).mp hc, ha⟩
+
+/-- `evolve` commutes with translation:
+    `shift v (evolve n g) = evolve n (shift v g)` (by induction on `n`). -/
+theorem evolve_shift (v : Int × Int) (n : Nat) (g : Grid) :
+    shift v (evolve n g) = evolve n (shift v g) := by
+  induction n with
+  | zero => simp [evolve]
+  | succ k ih => rw [evolve_succ, step_shift, ih, ← evolve_succ]
+
 end Life_en
 end Conway_en


### PR DESCRIPTION
## What

Recovers **5 translation-invariance theorems** in `Conway/Life/GridCanonical.lean` (+ `_en` mirror) that were written and verified in #8784 but **never reached `main`** — they were pushed to the branch 11 min *after* the squash-merge (`82e2240d2`), so the merge content reflected the pre-push state and the post-merge push stranded them.

This is the recovery explicitly scoped to this lane by **#8795** ("Hors scope: la récupération de #8784 elle-même reste due par la lane qui les a écrits — voir #6724"). The detector (#8796) landed; this PR closes the one defect it flagged.

## The 5 recovered theorems (sorry-free)

| Theorem | Statement |
|---------|-----------|
| `mem_shift` | membership invariance under cell shift |
| `mooreNeighbors_shift_mem` | Moore-neighbor set invariant under shift |
| `candidates_shift` | candidate-cell set invariant under shift |
| `step_shift` | one Conway step commutes with shift |
| `evolve_shift` | n-step evolution commutes with shift |

These are the translation-invariance layer feeding the #6724 bridge-reduction front (`p4_nw_g3_bridge` → `p4_nw_overlap_wall`).

## §B — proof integrity (verified-green content, byte-identical recovery)

This is **not a new proof** — it is a **byte-identical recovery** of content that was already lake-built green in #8784 (verified firsthand in c.756):

- **`grep -c sorry` GridCanonical FR/EN: 0 / 0** (FLAT vs main — main was already 0/0; the 5 theorems add zero sorries). HashlifeCorrectness baseline **8 → 8** (untouched).
- **Cherry-pick CLEAN, no conflict**: `main` has not touched `GridCanonical.lean` since #8784's squash (`eea0c55d2`), so the additive recovery applies without merge friction.
- **Byte-identity proven** (blob SHA, both files):
  - FR `GridCanonical.lean` → `2ea9c50986385a57dde572d98d86a30243f97b51` (== the `82e2240d2` blob)
  - EN `GridCanonical_en.lean` → matches the `82e2240d2` EN blob
- **`#print axioms`** (c.756, sorry-free theorems): `step_shift`, `evolve_shift` → `[propext, Classical.choice, Quot.sound]` (standard Mathlib core, no `sorryAx`).
- **i18n byte-identity** (`check_i18n_siblings.py`): `OK` — no DRIFT between FR and EN declarations. The 5 theorems are byte-identical across both siblings.
- **Lean CI** (`lean-conway.yml`) runs on this PR → fresh `Lake build SUCCESS` + proof-integrity gate, re-confirming what c.756 already proved.

### Lake build local — env blocker (disclosed, not bypassed)

Local `lake build` is **not currently runnable** on this lane: ai-01's 140+ worktree cleanup (#8783) purged all junctioned `.lake` Mathlib caches; broad `C:/dev` search returned **0 Mathlib oleans** anywhere; cold-build is 30+ min (not cron-feasible); disk C: at 97% (ENOSPC risk). DM-HIGH `msg-20260729T055956-n3f4ap` sent c.758, **unanswered 5 cycles**.

This recovery carries **zero regression risk** precisely because it is byte-identical to the #8784 content that *did* have lake SUCCESS (CI-green, 8498 jobs) — there is no new tactic, no edited proof, no modified signature. Lean CI re-proves it on this PR. The env blocker is the reason local lake is absent, not a workaround.

## Scope

- **Recovery only** — 2 files (`GridCanonical.lean`, `GridCanonical_en.lean`), `+134 / -0`, purely additive.
- **No** new tactics, **no** sorry changes, **no** signature edits.
- **Does NOT** deliver the #6724 bridge reduction (`p4_nw_g3_bridge` → `p4_nw_overlap_wall`) — that deep track remains **env-blocked** (needs restored Mathlib junction to lake-build the bridge). This PR restores the 5 theorems the bridge depends on.

## Diff

```
 MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical.lean    | +67
 MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical_en.lean | +67
 2 files changed, +134 insertions(+)
```

See #6724 (partial — recovery only, bridge reduction still env-blocked). See #8795 (the defect class), #8796 (the detector).