### PR TITLE
fix(qc,#8772): disclose dead-fallback branch on Alpha-Correlation-Analysis (mechanism 2)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Alpha-Correlation-Analysis/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Alpha-Correlation-Analysis/quantbook.ipynb
@@ -108,6 +108,22 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Note sur l'environnement d'exécution (#8772)\n",
+    "\n",
+    "Ce notebook déclare en cell[1] une période `2020-01-01 → 2024-12-31` via `qb.SetStartDate` / `qb.SetEndDate`. **Ces appels n'ont jamais pris effet** dans l'environnement qui a produit les sorties committées : `QuantBook()` a levé `NameError` (environnement QC Cloud / Lean indisponible), et la branche de repli `yfinance` a pris le relais (mécanisme 2 de #8772).\n",
+    "\n",
+    "Conséquences :\n",
+    "- Les sorties ci-dessous proviennent du **chemin local `yfinance`**, pas d'un `QuantBook`.\n",
+    "- La fenêtre réellement calculée est **ancrée à l'heure d'exécution** : `2021-06-01 → 2026-05-29` (vérifié sur la cellule de chargement), elle **dépasse** la période déclarée au lieu de la précéder.\n",
+    "- Le repli `yfinance` est une source de données externe légitime (#7066), mais il est **annoncé ici explicitement** plutôt que silencieux. Pour une exécution `QuantBook` authentique (et la fenêtre déclarée), ré-exécuter via QC Cloud une fois l'environnement restauré.\n",
+    "\n",
+    "À noter : la fenêtre reculée actuelle repose néanmoins sur de vraies barres — ne pas la corriger en demandant explicitement 2020-2024 tant que les données equity locales s'arrêtent au 2021-03-31 (#8734), car Lean les prolongerait en constante (`fillDataForward=True`), produisant l'artefact de ligne plate de #8719.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6933c691",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## What

Closes **acceptance criterion 3 of #8772** for `Alpha-Correlation-Analysis`. Adds a markdown disclosure cell after cell[1] (env detection) announcing that the committed outputs were produced via the **local `yfinance` fallback**, not a `QuantBook`.

This is the **mechanism-2** case (distinct from po-2024's mechanism-1 work on ML-RandomForest/SVM in #8776, where `QuantBook()` *worked* and the issue was lookback anchoring). Here `QuantBook()` **raised `NameError`** in the commit environment, so the `try:` block containing `qb.SetStartDate(2020,1,1)` / `qb.SetEndDate(2024,12,31)` **never executed** — the declared period was never applied, and the fallback anchored to execution time.

## The defect (verified firsthand)

| | Declared | Actually computed |
|---|---|---|
| Period | `2020-01-01 → 2024-12-31` (dead `try` block) | **`2021-06-01 → 2026-05-29`** (yfinance, exec-anchored) |
| Source | `qb.SetStartDate/SetEndDate` (never ran) | local `yfinance` fallback |
| Cell | cell[1] `try:` (NameError) | cell[5] output: `Data shape: (1255, 18) \| Date range: 2021-06-01 to 2026-05-29` |

The window **exceeds** the declared period (into 2026) rather than preceding it. Walk-forward metrics (cell[35], starting `2021-06-01`) rest on this fallback window — real bars, not the `fillDataForward` flat-line artifact of #8719.

## The fix

A single markdown cell inserted at the top (right after the env-detection cell), per criterion 3's explicit option: *"soit sa branche de repli l'annonce en tête"* — announces the fallback + the effective window + the deviation from the "quantbook = QC Cloud execution" principle (#7066). References #8734 (data ends 2021-03-31 → don't re-window yet) and #8719 (flat-line artifact risk).

## §D — notebook execution proof

- **Markdown-only change** → **C.2 exception** (\"modifs uniquement markdown -> outputs précédents valides\"). No re-execution required.
- **All 18 code cells byte-identical** (verified programmatically vs `origin/main`): sources + outputs + `execution_count` (1–18) **unchanged**.
- **19 → 20 markdown cells** (+1), all original markdown preserved unchanged.
- **0 `NotImplementedError`** in the notebook (unchanged code).
- Diff: `+17 / -1` (the new cell + closing brace), purely additive — **no code cell touched, no output scrubbed** (Stop & Repair: the committed outputs are honest yfinance output, untouched).

## Why not re-window / re-exec via QC Cloud now

Per #8772's decision: re-fenetrering to 2020-2024 today would hit #8734 (local equity data ends 2021-03-31) → Lean `fillDataForward=True` would produce ~3 years of constant flat-line — exactly the #8719 artifact. The disclosed fallback window is, by accident, the reason this notebook has real bars. Re-execution via QC Cloud (for an authentic QuantBook run) is deferred until the env is restored; the silence is what this PR removes.

## Scope

1 file, `+17/-1`, markdown-only. See #8772 (criterion 3), #8776 (mechanism-1 precedent), #7066, #8734, #8719.