### PR TITLE
fix(qc,#8799): add config.json with cloud-id (real or explicit null) to 7 quantbook projects

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/config.json
@@ -1,0 +1,7 @@
+{
+    "algorithm-language": "Python",
+    "name": "BTC-ML",
+    "cloud-id": 29318876,
+    "organization-id": "d600793ee4caecb03441a09fc2d00f7f",
+    "local-id": 831609908
+}

--- a/MyIA.AI.Notebooks/QuantConnect/projects/DL-LSTM/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DL-LSTM/config.json
@@ -1,0 +1,7 @@
+{
+    "algorithm-language": "Python",
+    "name": "DL-LSTM",
+    "cloud-id": null,
+    "organization-id": "d600793ee4caecb03441a09fc2d00f7f",
+    "local-id": 309272190
+}

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-DeepLearning/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-DeepLearning/config.json
@@ -1,0 +1,7 @@
+{
+    "algorithm-language": "Python",
+    "name": "ML-DeepLearning",
+    "cloud-id": null,
+    "organization-id": "d600793ee4caecb03441a09fc2d00f7f",
+    "local-id": 911884201
+}

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-TextClassification/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-TextClassification/config.json
@@ -1,0 +1,7 @@
+{
+    "algorithm-language": "Python",
+    "name": "ML-TextClassification",
+    "cloud-id": null,
+    "organization-id": "d600793ee4caecb03441a09fc2d00f7f",
+    "local-id": 400269086
+}

--- a/MyIA.AI.Notebooks/QuantConnect/projects/PairsTrading/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/PairsTrading/config.json
@@ -1,0 +1,7 @@
+{
+    "algorithm-language": "Python",
+    "name": "PairsTrading",
+    "cloud-id": 28693651,
+    "organization-id": "d600793ee4caecb03441a09fc2d00f7f",
+    "local-id": 666140425
+}

--- a/MyIA.AI.Notebooks/QuantConnect/projects/RL-Portfolio/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RL-Portfolio/config.json
@@ -1,0 +1,7 @@
+{
+    "algorithm-language": "Python",
+    "name": "RL-Portfolio",
+    "cloud-id": null,
+    "organization-id": "d600793ee4caecb03441a09fc2d00f7f",
+    "local-id": 654038285
+}

--- a/MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure/config.json
@@ -1,0 +1,7 @@
+{
+    "algorithm-language": "Python",
+    "name": "VIX-TermStructure",
+    "cloud-id": null,
+    "organization-id": "d600793ee4caecb03441a09fc2d00f7f",
+    "local-id": 410360635
+}


### PR DESCRIPTION
## What

Closes **#8799**. Adds `config.json` (with `cloud-id`) to the **7 of 9** `#7575` HEALTHY quantbook projects that lacked one — closing the traceability gap that became the weak link once the notebooks were sound.

Now that the 9 are `HEALTHY` (real committed outputs, post-#7575), the missing `config.json` meant an audit could see a clean notebook but **could not trace which QC Cloud project produced it, nor where to re-execute next**. The trace stopped at the file.

## cloud-id resolution (acceptance criterion 1 + 2)

Resolved via `qc-mcp-lite` `list_projects` (exact name match) + `read_project` (content check on ambiguous candidates). **No invented cloud-id** — a false id is worse than none.

| Project | cloud-id | Verdict | Evidence |
|---|---|---|---|
| **BTC-ML** | `29318876` | ✅ real | exact name match `BTC-ML` (created 2026-03-24) |
| **PairsTrading** | `28693651` | ✅ real | exact name match `PairsTrading` (created 2026-03-05) |
| **VIX-TermStructure** | `null` | mort | candidate `VIX-TermStructure-Researcher` (28657907) is an **EMPTY shell** (`files: []`) — verified via `read_project` |
| **RL-Portfolio** | `null` | mort | candidate `RL-Portfolio-Q-Learning-Research` (32057969) is an **EMPTY shell** (`files: []`) — verified |
| **ML-DeepLearning** | `null` | absent | 0 cloud projects found |
| **ML-TextClassification** | `null` | absent | 0 cloud projects found |
| **DL-LSTM** | `null` | absent | 0 exact match (3 unrelated `LSTM-*` projects exist, none named `DL-LSTM`) |

`null` is **explicit** (not an absent file) per criterion 1: it distinguishes *\"verified, no Cloud counterpart\"* from *\"never looked at\"*. For VIX-TermStructure / RL-Portfolio, the near-name cloud projects were checked and found empty (dead), so `null` is honest rather than a guessed link.

## §D — acceptance criterion 3

`py scripts/quantconnect/audit_quantbooks_unexec.py --json` classifies all **9/9 `#7575` projects `HEALTHY`** (70 HEALTHY total, `by_class`: HEALTHY 70, STOP_REPAIR_STRIPPED 6, PREEXISTING_UNEXEC 8). The `config.json` files touch **zero notebooks** — diff is exactly 7 new config files, `+49/-0`, no `.ipynb` in the diff. All 7 JSON valid.

## Format

Matches the existing tracked config.json convention (e.g. `Crypto-MultiCanal`, `ML-XGBoost`): `algorithm-language`, `name`, `cloud-id`, `organization-id` (shared `d600793…`), `local-id` (preserved from the stale May-2025 local scaffolds). 4-space indent.

## Hors scope (per #8799)

The 16 `PREEXISTING_UNEXEC` residuals (`research.ipynb` / `output.ipynb`, no `quantbook.ipynb`) form a distinct family, scoped separately — not touched here.

See #8799, #7575, #6891.