### PR TITLE
feat(qc-infra,#8734): detect forward-fill flat tails in check_data_freshness

### DIFF
--- a/scripts/quantconnect/check_data_freshness.py
+++ b/scripts/quantconnect/check_data_freshness.py
@@ -26,13 +26,20 @@ signale tout ticker dont les donnees se terminent **avant un seuil de
 fraicheur** (defaut : 6 mois avant aujourd'hui, configurable via
 ``--months-back`` ou ``--min-year``).
 
-  - **FRESH**  -- dernier bar dans la fenetre de fraicheur.
-  - **STALE**  -- dernier bar avant la fenetre -> forward-fill probable si
-                  ``fillDataForward=True`` (defaut Lean). A NE PAS faire
-                  confiance pour une re-exec quantbook post-seuil.
+  - **FRESH**     -- dernier bar dans la fenetre de fraicheur.
+  - **STALE**     -- dernier bar avant la fenetre -> forward-fill probable si
+                     ``fillDataForward=True`` (defaut Lean). A NE PAS faire
+                     confiance pour une re-exec quantbook post-seuil.
+  - **DEGENERATE**-- la fin de la serie est une **ligne plate** (les N
+                     derniers closes identiques) meme si la derniere date a
+                     l'air courante. Signature d'un forward-fill ecrit sur
+                     disque ou d'une serie padded par le vendor -> metriques
+                     invalidees (B&H ~0%, direction ~100%) sans erreur. Seuil
+                     N configurable via ``--flat-tail-bars`` (defaut 60,
+                     analogue data-layer du garde flat-tail C951-L).
 
-Exit code 1 si au moins un ticker STALE (gatable en CI / pre-exec). Exit 0
-si tout est FRESH ou si ``--no-fail`` est passe.
+Exit code 1 si au moins un ticker STALE ou DEGENERATE (gatable en CI /
+pre-exec). Exit 0 si tout est FRESH ou si ``--no-fail`` est passe.
 
 Usage
 -----
@@ -41,10 +48,12 @@ Usage
     python check_data_freshness.py --asset-class equity --min-year 2025
     python check_data_freshness.py --ticker SPY,QQQ,TLT
     python check_data_freshness.py --months-back 12 --quiet
+    python check_data_freshness.py --flat-tail-bars 60  # detect forward-fill tails
 
-Operationalise les lecons C941-L (ticker present ?) et C942-L (ticker
-CURRENT post-seuil ?) : presence != fraicheur. Verifier AVANT toute re-exec
-equity/forex quantbook. See #8734, #8724.
+Operationalise les lecons C941-L (ticker present ?), C942-L (ticker CURRENT
+post-seuil ?) et C951-L (flat-tail = forward-fill) : presence != fraicheur !=
+non-degenerescence. Verifier AVANT toute re-exec equity/forex quantbook.
+See #8734, #8724.
 """
 from __future__ import annotations
 
@@ -81,29 +90,52 @@ def parse_qc_date(token: str) -> date | None:
     return None
 
 
-def scan_zip(path: Path) -> tuple[date | None, date | None, int]:
-    """Return (first_date, last_date, row_count) for a QC daily zip.
+def scan_zip(path: Path, flat_tail_bars: int = 0) -> tuple[date | None, date | None, int, bool]:
+    """Return (first_date, last_date, row_count, flat_tail) for a QC daily zip.
 
     QC daily zips hold one CSV (named like the ticker) with no header row :
-    each line is 'YYYYMMDD HH:MM,o,h,l,c,v'. We read first + last line only
-    (cheap, avoids loading multi-GB minute files -- we only scan daily).
+    each line is 'YYYYMMDD HH:MM,o,h,l,c,v'. We read the full CSV (daily zips
+    are small) so we can also inspect the trailing closes.
+
+    ``flat_tail_bars`` (>0) enables degenerate-tail detection : if the last
+    ``flat_tail_bars`` close prices are ALL identical, the zip carries a flat
+    tail -- the signature of Lean ``fillDataForward`` output saved back to disk,
+    or a vendor-padded series. A flat tail produces invalid metrics (B&H ~0%,
+    direction ~100%) *even when the last date looks current*, so it must be
+    flagged independently of the date-range staleness check (#8734 litmus,
+    data-layer complement of the C951-L runtime flat-tail guard).
     """
     try:
         with zipfile.ZipFile(path) as z:
             names = [n for n in z.namelist() if n.lower().endswith(".csv")]
             if not names:
-                return None, None, 0
+                return None, None, 0, False
             raw = z.read(names[0]).decode("utf-8", errors="replace")
     except (zipfile.BadZipFile, OSError):
-        return None, None, 0
+        return None, None, 0, False
 
     lines = [ln for ln in raw.split("\n") if ln.strip()]
     if not lines:
-        return None, None, 0
+        return None, None, 0, False
 
     first = parse_qc_date(lines[0].split(",")[0])
     last = parse_qc_date(lines[-1].split(",")[0])
-    return first, last, len(lines)
+
+    flat_tail = False
+    if flat_tail_bars > 0 and len(lines) >= flat_tail_bars:
+        # Close is column 4 of 'YYYYMMDD HH:MM,o,h,l,c,v'. Forward-fill writes
+        # the exact last known close (byte-identical), so set-equality is the
+        # robust signal; no float-tolerance heuristic needed.
+        closes = []
+        for ln in lines[-flat_tail_bars:]:
+            cols = ln.split(",")
+            if len(cols) > 4:
+                closes.append(cols[4].strip())
+        # Guard: only conclude if we captured the full tail (no malformed row).
+        if len(closes) == flat_tail_bars:
+            flat_tail = len(set(closes)) == 1
+
+    return first, last, len(lines), flat_tail
 
 
 def find_workspace(start: Path) -> Path | None:
@@ -126,6 +158,12 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--min-year", type=int, help="Flag tickers whose data ends before Jan 1 of this year.")
     p.add_argument("--months-back", type=int, default=6, help="Freshness window in months (default 6). Ignored if --min-year set.")
     p.add_argument("--ticker", help="Comma-separated tickers to filter (case-insensitive).")
+    p.add_argument(
+        "--flat-tail-bars",
+        type=int,
+        default=60,
+        help="Flag tickers whose last N closes are all identical (forward-fill tail). Default 60; 0 disables.",
+    )
     p.add_argument("--quiet", action="store_true", help="Summary line only.")
     p.add_argument("--no-fail", action="store_true", help="Always exit 0 (report only, do not gate).")
     args = p.parse_args(argv)
@@ -155,7 +193,7 @@ def main(argv: list[str] | None = None) -> int:
     classes = list(ASSET_CLASS_GLOBS) if args.asset_class == "all" else [args.asset_class]
     ticker_filter = {t.strip().lower() for t in args.ticker.split(",")} if args.ticker else None
 
-    rows = []  # (asset_class, ticker, first, last, count, stale)
+    rows = []  # (asset_class, ticker, first, last, count, stale, degenerate)
     for cls in classes:
         for pattern in ASSET_CLASS_GLOBS[cls]:
             for zpath in sorted(data_dir.glob(pattern)):
@@ -165,11 +203,10 @@ def main(argv: list[str] | None = None) -> int:
                     ticker = ticker.split("_")[0]
                 if ticker_filter and ticker not in ticker_filter:
                     continue
-                first, last, count = scan_zip(zpath)
+                first, last, count, flat_tail = scan_zip(zpath, flat_tail_bars=args.flat_tail_bars)
                 if last is None:
                     continue
-                stale = last < threshold
-                rows.append((cls, ticker, first, last, count, stale))
+                rows.append((cls, ticker, first, last, count, last < threshold, flat_tail))
 
     if not rows:
         print(f"No daily zips found under {data_dir} for asset-class={args.asset_class}.")
@@ -177,39 +214,49 @@ def main(argv: list[str] | None = None) -> int:
 
     # Dedupe crypto (quote/trade variants of same pair -> keep the newest last-date).
     dedup = {}
-    for cls, ticker, first, last, count, stale in rows:
+    for cls, ticker, first, last, count, stale, degenerate in rows:
         key = (cls, ticker)
         if key not in dedup or last > dedup[key][3]:
-            dedup[key] = (cls, ticker, first, last, count, stale)
+            dedup[key] = (cls, ticker, first, last, count, stale, degenerate)
     rows = sorted(dedup.values(), key=lambda r: (r[0], r[1]))
 
-    n_stale = sum(1 for r in rows if r[5])
-    n_fresh = len(rows) - n_stale
+    n_degenerate = sum(1 for r in rows if r[6])
+    n_stale = sum(1 for r in rows if r[5] and not r[6])
+    n_fresh = len(rows) - n_degenerate - n_stale
 
     if not args.quiet:
         print(f"Lean workspace : {ws}")
         print(f"Data folder    : {data_dir}")
         print(f"Freshness rule : flag tickers ending {threshold_lbl}")
+        if args.flat_tail_bars > 0:
+            print(f"Flat-tail rule : flag tickers whose last {args.flat_tail_bars} closes are identical")
         print()
         print(f"{'Asset':<7} {'Ticker':<12} {'First':<12} {'Last':<12} {'Rows':>7}  Status")
         print("-" * 62)
-        for cls, ticker, first, last, count, stale in rows:
-            status = "STALE" if stale else "FRESH"
+        for cls, ticker, first, last, count, stale, degenerate in rows:
+            status = "DEGENERATE" if degenerate else ("STALE" if stale else "FRESH")
             print(f"{cls:<7} {ticker:<12} {first.isoformat():<12} {last.isoformat():<12} {count:>7}  {status}")
         print("-" * 62)
 
-    by_cls_stale = {}
-    for cls, _, _, _, _, stale in rows:
-        by_cls_stale[cls] = by_cls_stale.get(cls, 0) + (1 if stale else 0)
-    stale_breakdown = ", ".join(f"{c}={n}" for c, n in sorted(by_cls_stale.items()) if n) or "none"
+    n_flagged = n_stale + n_degenerate
+    by_cls_flagged = {}
+    for cls, _, _, _, _, stale, degenerate in rows:
+        if stale or degenerate:
+            by_cls_flagged[cls] = by_cls_flagged.get(cls, 0) + 1
+    flagged_breakdown = ", ".join(f"{c}={n}" for c, n in sorted(by_cls_flagged.items()) if n) or "none"
 
-    print(f"Total {len(rows)} ticker(s) : {n_fresh} FRESH, {n_stale} STALE (breakdown: {stale_breakdown}).")
+    degenerate_part = f", {n_degenerate} DEGENERATE" if n_degenerate else ""
+    print(f"Total {len(rows)} ticker(s) : {n_fresh} FRESH, {n_stale} STALE{degenerate_part} (breakdown: {flagged_breakdown}).")
     if n_stale:
         print(f"WARNING: {n_stale} ticker(s) have data ending before the freshness window.")
         print("Lean fillDataForward=True (default) will silently forward-fill these as a")
         print("CONSTANT -> invalidates post-threshold metrics. See #8734.")
+    if n_degenerate:
+        print(f"WARNING: {n_degenerate} ticker(s) have a FLAT TAIL (last {args.flat_tail_bars} closes identical).")
+        print("This is the signature of forward-fill written to disk or a vendor-padded series:")
+        print("the date may look current but the tail is a constant -> invalid metrics. See #8734.")
 
-    if n_stale and not args.no_fail:
+    if n_flagged and not args.no_fail:
         return 1
     return 0
 

--- a/scripts/quantconnect/tests/test_check_data_freshness.py
+++ b/scripts/quantconnect/tests/test_check_data_freshness.py
@@ -52,15 +52,16 @@ class TestScanZip:
             "20150102 00:00,200.0,201.0,199.0,200.5,1000",
             "20251231 00:00,400.0,401.0,399.0,400.5,2000",
         ])
-        first, last, count = scan_zip(z)
+        first, last, count, flat_tail = scan_zip(z)
         assert first == date(2015, 1, 2)
         assert last == date(2025, 12, 31)
         assert count == 2
+        assert flat_tail is False  # 2 rows < default 60-bar window; varied closes anyway
 
     def test_single_row(self, tmp_path):
         z = tmp_path / "foo.zip"
         _write_daily_zip(z, ["20200615 00:00,1,2,0,1,10"])
-        first, last, count = scan_zip(z)
+        first, last, count, flat_tail = scan_zip(z)
         assert first == date(2020, 6, 15)
         assert last == date(2020, 6, 15)
         assert count == 1
@@ -68,21 +69,66 @@ class TestScanZip:
     def test_empty_zip(self, tmp_path):
         z = tmp_path / "empty.zip"
         _write_daily_zip(z, [])
-        first, last, count = scan_zip(z)
+        first, last, count, flat_tail = scan_zip(z)
         assert first is None and last is None and count == 0
 
     def test_bad_zip(self, tmp_path):
         z = tmp_path / "broken.zip"
         z.write_bytes(b"not a zip")
-        first, last, count = scan_zip(z)
+        first, last, count, flat_tail = scan_zip(z)
         assert first is None and last is None and count == 0
 
     def test_no_csv_member(self, tmp_path):
         z = tmp_path / "notes.zip"
         with zipfile.ZipFile(z, "w") as zf:
             zf.writestr("readme.txt", "hello")
-        first, last, count = scan_zip(z)
+        first, last, count, flat_tail = scan_zip(z)
         assert first is None and last is None and count == 0
+
+
+# --- flat-tail / forward-fill detection (#8734 litmus, data layer) ---
+
+class TestFlatTail:
+    def _row(self, d: str, close: str) -> str:
+        return f"{d} 00:00,1,2,0,{close},100"
+
+    def test_forward_filled_tail_detected(self, tmp_path):
+        """A zip whose last 60 closes are identical -> flat_tail True (forward-fill)."""
+        z = tmp_path / "spy.zip"
+        rows = [self._row(f"2015010{n}", f"{200 + n}.0") for n in range(1, 6)]  # 5 varied
+        rows += [self._row(f"2021{m:02d}15", "396.33") for m in range(1, 13)]  # 12 constant
+        rows += [self._row(f"2022{m:02d}15", "396.33") for m in range(1, 13)]  # 12 constant
+        rows += [self._row(f"2023{m:02d}15", "396.33") for m in range(1, 13)]  # 12 constant
+        rows += [self._row(f"2024{m:02d}15", "396.33") for m in range(1, 13)]  # 12 constant
+        rows += [self._row(f"2025{m:02d}15", "396.33") for m in range(1, 13)]  # 12 constant = 60 const total
+        _write_daily_zip(z, rows)
+        first, last, count, flat_tail = scan_zip(z, flat_tail_bars=60)
+        assert count == 5 + 60
+        assert last == date(2025, 12, 15)  # date looks current...
+        assert flat_tail is True  # ...but the tail is a forward-filled constant
+
+    def test_varied_tail_not_flagged(self, tmp_path):
+        """Realistic varied closes in the tail -> flat_tail False."""
+        z = tmp_path / "spy.zip"
+        rows = [self._row(f"2025{m:02d}15", f"{300 + m}.5") for m in range(1, 13)] * 5  # 60 varied-ish
+        _write_daily_zip(z, rows)
+        _, _, _, flat_tail = scan_zip(z, flat_tail_bars=60)
+        assert flat_tail is False
+
+    def test_short_zip_not_flagged(self, tmp_path):
+        """Fewer rows than the window -> cannot conclude, no false positive."""
+        z = tmp_path / "thin.zip"
+        _write_daily_zip(z, [self._row("20250101", "1.0"), self._row("20250102", "1.0")])
+        _, _, count, flat_tail = scan_zip(z, flat_tail_bars=60)
+        assert count == 2
+        assert flat_tail is False
+
+    def test_disabled_when_zero(self, tmp_path):
+        """flat_tail_bars=0 disables the check."""
+        z = tmp_path / "spy.zip"
+        _write_daily_zip(z, [self._row(f"2025010{n}", "396.33") for n in range(1, 10)])
+        _, _, _, flat_tail = scan_zip(z, flat_tail_bars=0)
+        assert flat_tail is False
 
 
 # --- end-to-end main() classification (STALE vs FRESH) ---
@@ -128,6 +174,36 @@ class TestEndToEnd:
         out = capsys.readouterr().out
         assert "2 STALE" in out
         assert rc == 1
+
+    def test_degenerate_flat_tail_flagged(self, tmp_path, capsys):
+        """A ticker with a current date but a constant tail -> DEGENERATE, exit 1.
+
+        This is the #8734 failure mode the date-check misses: the last date
+        looks fresh, but Lean forward-fill (or a vendor pad) left a flat tail
+        that produces invalid metrics.
+        """
+        import check_data_freshness as cdf
+        ws = tmp_path / "lean-workspace"
+        ws.mkdir(parents=True)
+        (ws / "lean.json").write_text("{}")
+        # 60 constant-close bars, ending this year (date-fresh) -- the flat tail.
+        rows = [
+            f"2021{m:02d}15 00:00,1,2,0,396.33,0" for m in range(1, 13)
+        ] + [
+            f"2022{m:02d}15 00:00,1,2,0,396.33,0" for m in range(1, 13)
+        ] + [
+            f"2023{m:02d}15 00:00,1,2,0,396.33,0" for m in range(1, 13)
+        ] + [
+            f"2024{m:02d}15 00:00,1,2,0,396.33,0" for m in range(1, 13)
+        ] + [
+            f"2026{m:02d}15 00:00,1,2,0,396.33,0" for m in range(1, 13)
+        ]  # 60 bars, last = 2026-12-15 (fresh), all close 396.33
+        _write_daily_zip(ws / "data" / "equity" / "usa" / "daily" / "padded.zip", rows)
+        rc = cdf.main([str(ws), "--flat-tail-bars", "60"])
+        out = capsys.readouterr().out
+        assert "padded" in out and "DEGENERATE" in out
+        assert "FLAT TAIL" in out
+        assert rc == 1  # degenerate -> gate fails
 
 
 # --- find_workspace ---


### PR DESCRIPTION
Grain: DEEP/qc-infra — lane myia-po-2024:CoursIA-2 — prev: (investigation/coordination c.965, no code PR)

## Summary

Extends `scripts/quantconnect/check_data_freshness.py` with **flat-tail / forward-fill detection** — the data-layer complement of the C951-L runtime flat-tail guard, operationalising the **#8734 detection litmus** (*"presence != freshness != non-degeneracy"*).

`scan_zip` now also inspects the trailing closes and flags a zip whose **last N closes (default 60) are all identical** — the signature of Lean `fillDataForward` output saved to disk, or a vendor-padded series. A flat tail produces invalid metrics (B&H ~0%, direction ~100%) **even when the last date looks current**, so it is missed by the existing date-range staleness check (the exact #8734 failure mode that invalidated #8714/#8730/#8719).

### Changes
- `scan_zip(path, flat_tail_bars=0)` → returns `(first, last, count, flat_tail)`. When `flat_tail_bars > 0` and the zip has ≥ N rows, it checks set-equality of the last N closes (forward-fill writes the byte-identical last known close → exact set-equality, no float heuristic).
- New **DEGENERATE** status (priority over STALE); `--flat-tail-bars` CLI flag (default 60, `0` disables).
- Exit 1 if any STALE **or** DEGENERATE (gatable in CI / pre-exec).

### Why DEEP/qc-infra and not the qc-exec monoculture
Per variation-protocol §5 / G-VAR-3: this is a **different GENRE** (`qc-infra` tooling) from my c.955–c.964 `qc-exec` quantbook re-execs, it is DEEP (root-cause detection capability requiring Lean-forward-fill domain reasoning), and QC is po-2024's domain-cœur → same-domain DEEP/MED with genuinely-distinct substance is allowed. The c.965 [ASK] provisioning fork (non-QC pool verified empty) is **not dodged** — it is escalated separately to ai-01; this grain is the strongest available root-cause infra that does **not** require the coord decision.

### Scope note — detection only
The #8734 **fix** (3 options: provision updated equity / `fillDataForward=False` / constrain to 2021) remains explicitly *"decision for ai-01 / user"* in the issue body. This PR delivers only the **detection** litmus, which is wanted regardless of which fix is chosen. `See #8734` (partial — detection layer), not `Closes`.

## Validation
```
21/21 tests pass (was 16) — incl. +5 new:
  TestFlatTail::test_forward_filled_tail_detected   (60 identical closes → flat_tail True, date current)
  TestFlatTail::test_varied_tail_not_flagged        (realistic varied closes → False)
  TestFlatTail::test_short_zip_not_flagged          (< N rows → no false positive)
  TestFlatTail::test_disabled_when_zero             (flat_tail_bars=0 → off)
  TestEndToEnd::test_degenerate_flat_tail_flagged   (current date + flat tail → DEGENERATE, exit 1)
```
Real-world run on the refreshed local lean-workspace equity zips: **17 FRESH, 0 STALE, 0 DEGENERATE** — confirms the flat-tail check does not false-fire on real varied data (the #8734 STALE case itself was already resolved in that workspace by c.958–c.964 data provisioning).

## Files
- `scripts/quantconnect/check_data_freshness.py` (+115/−39 region)
- `scripts/quantconnect/tests/test_check_data_freshness.py` (+86)

No notebooks touched; no cell outputs; pure tooling + tests. `git add` by name (2 files).

See #8734 #8724 #6891 #7575.
