### PR TITLE
feat(qc-infra,#8734): wire data-quality pre-flight into quantbook exec recipe

### DIFF
--- a/scripts/notebook_tools/qc_quantbook_execute.py
+++ b/scripts/notebook_tools/qc_quantbook_execute.py
@@ -3,6 +3,10 @@
 Recipe validated 2026-05-10 (incident H.7 / forensic T17, ai-01).
 
 Workflow:
+  0. **#8734 data-quality pre-flight** -- extract the tickers the notebook requests
+     (AddEquity/add_equity/AddForex/AddCrypto) and scan their on-disk daily zips; ABORT
+     before Docker if any are STALE or DEGENERATE (forward-fill signature). Bypass:
+     `--no-freshness-check`. (yfinance-only notebooks skip this -- not Lean-driven.)
   1. `lean login` once with QC_API_USER_ID + QC_API_TOKEN (Lean CLI stores creds in ~/.lean)
   2. `lean research <project> --detach --no-open --port <port>` from a Lean workspace
      (workspace must contain lean.json + data/ folder, e.g. partner-course-quant-trading/lean-workspace/)
@@ -29,7 +33,9 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -77,7 +83,141 @@ def get_container_for_project(project_name: str) -> str | None:
     return candidates[0] if candidates else None
 
 
-def run(project_dir: Path, notebook_name: str, port: int, timeout: int) -> int:
+# --- #8734 data-quality pre-flight (presence != freshness != non-degeneracy) ---
+
+# A data-request call (Python QuantBook `add_equity` or C# Lean `AddEquity` and
+# forex/crypto/option/security variants) followed by its first quoted symbol.
+_SYMBOL_CALL_RE = re.compile(
+    r'(?:qb|self|QB)?\s*\.\s*'
+    r'(AddEquity|add_equity|AddForex|add_forex|AddCrypto|add_crypto|'
+    r'AddSecurity|add_security|AddOption|add_option)'
+    r'\s*\(\s*["\']([A-Za-z0-9.\-/]+)["\']'
+)
+# Asset class inferred from the request method, for daily-zip path resolution.
+_METHOD_CLASS: dict[str, str] = {
+    "AddEquity": "equity", "add_equity": "equity",
+    "AddForex": "forex", "add_forex": "forex",
+    "AddCrypto": "crypto", "add_crypto": "crypto",
+    "AddSecurity": "equity", "add_security": "equity",
+    "AddOption": "equity", "add_option": "equity",
+}
+# Daily-zip glob per asset class under <workspace>/data/.
+_ZIP_GLOBS: dict[str, str] = {
+    "equity": "equity/*/daily/{}.zip",
+    "forex": "forex/*/daily/{}.zip",
+    "crypto": "crypto/*/daily/{}.zip",
+}
+
+
+def extract_requested_symbols(notebook_path: Path) -> dict[str, set[str]]:
+    """Return ``{'equity': {...}, 'forex': {...}, 'crypto': {...}}`` of symbols
+    the notebook requests via AddEquity / add_equity / AddForex / AddCrypto /
+    AddSecurity / AddOption calls.
+
+    Used by the #8734 pre-flight so we only check tickers the quantbook actually
+    consumes (not every zip in the workspace). Symbol case is normalised upper.
+    """
+    out: dict[str, set[str]] = {"equity": set(), "forex": set(), "crypto": set()}
+    if not notebook_path.exists():
+        return out
+    try:
+        nb = json.loads(notebook_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return out
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        src = cell.get("source", "")
+        if isinstance(src, list):
+            src = "".join(src)
+        # Skip full-line comments (Python `#` / C# `//`) so commented-out calls
+        # (e.g. `# demo: self.AddEquity("DUMMY")`) are not mined as real requests.
+        for line in src.split("\n"):
+            if re.match(r"\s*(#|//)", line):
+                continue
+            for m in _SYMBOL_CALL_RE.finditer(line):
+                cls = _METHOD_CLASS.get(m.group(1), "equity")
+                out[cls].add(m.group(2).upper())
+    return out
+
+
+def preflight_data_quality(
+    ws: Path, symbols: dict[str, set[str]], flat_tail_bars: int = 60,
+) -> tuple[int, list[str]]:
+    """Scan the requested symbols' daily zips under ``ws/data`` and return
+    ``(n_flagged, messages)``.
+
+    A symbol is **flagged** when its on-disk zip is:
+
+    - **DEGENERATE** -- the last ``flat_tail_bars`` closes are identical (Lean
+      ``fillDataForward`` output saved to disk, or a vendor-padded series), OR
+    - **STALE** -- the last bar is older than a 6-month window (Lean
+      ``fillDataForward=True``, the default, will silently forward-fill the tail
+      as a constant at runtime).
+
+    Both produce invalid metrics (B&H ~0%, direction ~100%) without any error
+    -- the exact #8734 failure mode that invalidated #8714/#8730/#8719.
+
+    Detection reuses ``check_data_freshness.scan_zip`` (single source of truth);
+    if that module is not importable, the pre-flight degrades to a no-op (it is
+    a guard, not a hard dependency). Symbols with no on-disk zip are not flagged
+    here (absence/provisioning is a separate concern -- see #8724).
+    """
+    messages: list[str] = []
+    quantconnect_dir = Path(__file__).resolve().parent.parent / "quantconnect"
+    if str(quantconnect_dir) not in sys.path:
+        sys.path.insert(0, str(quantconnect_dir))
+    try:
+        from check_data_freshness import scan_zip  # type: ignore
+    except Exception as exc:  # pre-flight is a guard, never a hard failure
+        return 0, [f"[freshness] check_data_freshness not importable ({exc}); pre-flight skipped."]
+
+    from datetime import date, timedelta
+    threshold = date.today() - timedelta(days=int(6 * 30.4))
+
+    data_dir = ws / "data"
+    n_flagged = 0
+    seen: set[tuple[str, str]] = set()
+    for cls, symset in symbols.items():
+        glob_pat = _ZIP_GLOBS.get(cls)
+        if not glob_pat or not symset:
+            continue
+        for sym in sorted(symset):
+            if (cls, sym) in seen:
+                continue
+            seen.add((cls, sym))
+            # crypto stems: <sym>.zip plus <sym>_trade / <sym>_quote variants.
+            cands = list(data_dir.glob(glob_pat.format(sym)))
+            if cls == "crypto":
+                cands += list(data_dir.glob(glob_pat.format(sym + "_trade")))
+                cands += list(data_dir.glob(glob_pat.format(sym + "_quote")))
+            if not cands:
+                continue
+            zpath = sorted(cands)[-1]
+            _first, last, _count, flat_tail = scan_zip(zpath, flat_tail_bars=flat_tail_bars)
+            if last is None:
+                continue
+            if flat_tail:
+                n_flagged += 1
+                messages.append(
+                    f"[freshness] {cls}/{sym}: DEGENERATE -- last {flat_tail_bars} closes "
+                    f"identical in {zpath.name}. Forward-fill written to disk or vendor pad "
+                    f"-> invalid metrics. See #8734."
+                )
+            elif last < threshold:
+                n_flagged += 1
+                messages.append(
+                    f"[freshness] {cls}/{sym}: STALE -- last bar {last} predates {threshold}. "
+                    f"Lean fillDataForward=True (default) will silently forward-fill the tail "
+                    f"as a constant -> invalid metrics. See #8734."
+                )
+    return n_flagged, messages
+
+
+def run(
+    project_dir: Path, notebook_name: str, port: int, timeout: int,
+    freshness_check: bool = True, flat_tail_bars: int = 60,
+) -> int:
     lean = find_lean()
     ws = workspace_root(project_dir)
     project_rel = project_dir.resolve().relative_to(ws)
@@ -86,6 +226,29 @@ def run(project_dir: Path, notebook_name: str, port: int, timeout: int) -> int:
 
     env = os.environ.copy()
     env["PYTHONUTF8"] = "1"
+
+    # #8734 data-quality pre-flight: fail fast BEFORE the expensive Docker exec
+    # if the notebook's requested tickers have stale or degenerate local data.
+    # Producing metrics on degenerate data is the silent failure mode behind
+    # #8714/#8730/#8719. Bypass with --no-freshness-check when intentional.
+    if freshness_check:
+        symbols = extract_requested_symbols(project_dir / notebook_name)
+        total = sum(len(s) for s in symbols.values())
+        if total:
+            print(f"[freshness] pre-flight: {total} requested symbol(s) "
+                  f"({dict({k: len(v) for k, v in symbols.items() if v})}) "
+                  f"under {ws / 'data'}", file=sys.stderr)
+            n_flagged, msgs = preflight_data_quality(ws, symbols, flat_tail_bars=flat_tail_bars)
+            for msg in msgs:
+                print(msg, file=sys.stderr)
+            if n_flagged:
+                print(f"[freshness] ABORT: {n_flagged} requested symbol(s) STALE or DEGENERATE. "
+                      f"Not launching Docker exec (would produce invalid metrics, #8734). "
+                      f"Re-provision the data or bypass with --no-freshness-check.",
+                      file=sys.stderr)
+                return 3
+            print("[freshness] OK: all requested symbols fresh + non-degenerate.",
+                  file=sys.stderr)
 
     print(f"[recipe] launching lean research --detach on port {port}...", file=sys.stderr)
     res = subprocess.run(
@@ -129,8 +292,20 @@ def main() -> int:
     p.add_argument("--notebook", default="research.ipynb")
     p.add_argument("--port", type=int, default=8889)
     p.add_argument("--timeout", type=int, default=600, help="Per-cell timeout (seconds)")
+    p.add_argument(
+        "--no-freshness-check", action="store_true",
+        help="Skip #8734 data-quality pre-flight (stale/degenerate requested tickers).",
+    )
+    p.add_argument(
+        "--freshness-flat-tail-bars", type=int, default=60,
+        help="Flat-tail window for the pre-flight (default 60; 0 disables flat-tail).",
+    )
     args = p.parse_args()
-    return run(Path(args.project_dir), args.notebook, args.port, args.timeout)
+    return run(
+        Path(args.project_dir), args.notebook, args.port, args.timeout,
+        freshness_check=not args.no_freshness_check,
+        flat_tail_bars=args.freshness_flat_tail_bars,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/notebook_tools/tests/test_qc_quantbook_execute.py
+++ b/scripts/notebook_tools/tests/test_qc_quantbook_execute.py
@@ -1,13 +1,23 @@
-"""Tests for qc_quantbook_execute.py — workspace_root and find_lean."""
+"""Tests for qc_quantbook_execute.py — workspace_root, find_lean, and the
+#8734 data-quality pre-flight (extract_requested_symbols / preflight_data_quality)."""
 
+import json
 import os
 import sys
+import zipfile
+from datetime import date
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from qc_quantbook_execute import workspace_root, find_lean, LEAN_BIN_CANDIDATES
+from qc_quantbook_execute import (
+    workspace_root,
+    find_lean,
+    LEAN_BIN_CANDIDATES,
+    extract_requested_symbols,
+    preflight_data_quality,
+)
 
 
 # --- workspace_root ---
@@ -76,3 +86,130 @@ class TestFindLean:
             assert isinstance(result, str)
         except RuntimeError:
             pass  # Expected when lean is not installed
+
+
+# --- #8734 data-quality pre-flight ---
+
+
+def _nb(cells):
+    """Build a minimal notebook dict from (type, source) tuples."""
+    return {"cells": [{"cell_type": t, "source": s, "metadata": {}} for t, s in cells],
+            "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+
+
+def _write_daily_zip(path: Path, rows: list[str]) -> None:
+    """Write a QC-style daily zip (one CSV, no header, 'YYYYMMDD HH:MM,o,h,l,c,v')."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    csv = "\n".join(rows).encode("utf-8")
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr(path.stem + ".csv", csv)
+
+
+class TestExtractRequestedSymbols:
+    def test_equity_python_and_csharp(self, tmp_path):
+        nb = tmp_path / "research.ipynb"
+        nb.write_text(json.dumps(_nb([
+            ("code", 'qb.add_equity("SPY", Resolution.Daily)'),
+            ("code", 'self.AddEquity("qqq")'),
+        ])), encoding="utf-8")
+        syms = extract_requested_symbols(nb)
+        assert syms["equity"] == {"SPY", "QQQ"}
+
+    def test_asset_class_split(self, tmp_path):
+        nb = tmp_path / "research.ipynb"
+        nb.write_text(json.dumps(_nb([
+            ("code", 'qb.AddEquity("SPY")'),
+            ("code", 'qb.AddForex("EURUSD")'),
+            ("code", 'qb.AddCrypto("BTCUSD")'),
+        ])), encoding="utf-8")
+        syms = extract_requested_symbols(nb)
+        assert syms["equity"] == {"SPY"}
+        assert syms["forex"] == {"EURUSD"}
+        assert syms["crypto"] == {"BTCUSD"}
+
+    def test_ignores_markdown_and_comments(self, tmp_path):
+        """Markdown cells and plain strings must not be mined as data requests."""
+        nb = tmp_path / "research.ipynb"
+        nb.write_text(json.dumps(_nb([
+            ("markdown", 'We call qb.AddEquity("SPY") here.'),
+            ("code", '# demo: self.AddEquity("DUMMY")\nprice = "100"'),
+            ("code", 'qb.add_equity("REAL")'),
+        ])), encoding="utf-8")
+        syms = extract_requested_symbols(nb)
+        assert syms["equity"] == {"REAL"}  # markdown + comment excluded
+
+    def test_missing_notebook_returns_empty(self, tmp_path):
+        syms = extract_requested_symbols(tmp_path / "nope.ipynb")
+        assert all(len(v) == 0 for v in syms.values())
+
+    def test_malformed_json_returns_empty(self, tmp_path):
+        nb = tmp_path / "broken.ipynb"
+        nb.write_text("{not json", encoding="utf-8")
+        syms = extract_requested_symbols(nb)
+        assert all(len(v) == 0 for v in syms.values())
+
+
+class TestPreflightDataQuality:
+    def _ws(self, tmp_path: Path) -> Path:
+        ws = tmp_path / "ws"
+        (ws / "data").mkdir(parents=True)
+        (ws / "lean.json").write_text("{}", encoding="utf-8")
+        return ws
+
+    def test_degenerate_flagged(self, tmp_path):
+        ws = self._ws(tmp_path)
+        # 60 identical closes ending today -> DEGENERATE (#8734 signature).
+        today = date.today().year
+        rows = [f"{today}{m:02d}15 00:00,1,2,0,396.33,0" for m in range(1, 13)] * 5
+        _write_daily_zip(ws / "data" / "equity" / "usa" / "daily" / "SPY.zip", rows)
+        n, msgs = preflight_data_quality(
+            ws, {"equity": {"SPY"}, "forex": set(), "crypto": set()}, flat_tail_bars=60)
+        assert n == 1
+        assert any("DEGENERATE" in m for m in msgs)
+
+    def test_stale_flagged(self, tmp_path):
+        ws = self._ws(tmp_path)
+        _write_daily_zip(ws / "data" / "equity" / "usa" / "daily" / "SPY.zip", [
+            "20150102 00:00,1,2,0,100.5,1000",
+            "20210331 00:00,1,2,0,200.5,1000",
+        ])
+        n, msgs = preflight_data_quality(
+            ws, {"equity": {"SPY"}, "forex": set(), "crypto": set()}, flat_tail_bars=60)
+        assert n == 1
+        assert any("STALE" in m for m in msgs)
+
+    def test_fresh_not_flagged(self, tmp_path):
+        ws = self._ws(tmp_path)
+        today = date.today()
+        rows = [f"{today.year}{m:02d}15 00:00,1,2,0,{300 + m}.5,1000" for m in range(1, 13)]
+        _write_daily_zip(ws / "data" / "equity" / "usa" / "daily" / "SPY.zip", rows)
+        n, msgs = preflight_data_quality(
+            ws, {"equity": {"SPY"}, "forex": set(), "crypto": set()}, flat_tail_bars=60)
+        assert n == 0 and msgs == []
+
+    def test_missing_symbol_not_flagged(self, tmp_path):
+        """Absence is NOT flagged by the pre-flight (provisioning is separate, #8724)."""
+        ws = self._ws(tmp_path)
+        n, msgs = preflight_data_quality(
+            ws, {"equity": {"NOPE"}, "forex": set(), "crypto": set()}, flat_tail_bars=60)
+        assert n == 0 and msgs == []
+
+    def test_only_requested_symbols_scanned(self, tmp_path):
+        """A degenerate zip for a NON-requested ticker must not flag."""
+        ws = self._ws(tmp_path)
+        today = date.today().year
+        rows = [f"{today}{m:02d}15 00:00,1,2,0,396.33,0" for m in range(1, 13)] * 5
+        _write_daily_zip(ws / "data" / "equity" / "usa" / "daily" / "DEAD.zip", rows)
+        n, msgs = preflight_data_quality(
+            ws, {"equity": {"SPY"}, "forex": set(), "crypto": set()}, flat_tail_bars=60)
+        assert n == 0  # SPY absent, DEAD not requested -> nothing flagged
+
+    def test_flat_tail_disabled_when_zero(self, tmp_path):
+        """flat_tail_bars=0 disables the DEGENERATE check (STALE still applies if old)."""
+        ws = self._ws(tmp_path)
+        today = date.today().year
+        rows = [f"{today}{m:02d}15 00:00,1,2,0,396.33,0" for m in range(1, 13)] * 5
+        _write_daily_zip(ws / "data" / "equity" / "usa" / "daily" / "SPY.zip", rows)
+        n, _ = preflight_data_quality(
+            ws, {"equity": {"SPY"}, "forex": set(), "crypto": set()}, flat_tail_bars=0)
+        assert n == 0  # date is current, flat-tail check disabled -> OK


### PR DESCRIPTION
Grain: DEEP/qc-infra — lane myia-po-2024:CoursIA-2 — prev: DEEP/qc-infra (#8802 flat-tail detection, merged)

## Summary

Wires the **#8734 data-quality pre-flight** into the quantbook execution recipe (`qc_quantbook_execute.py`) — the operational complement of the merged #8802 flat-tail *detection* lib. Where #8802 added the ability to *detect* degenerate data, this PR makes that detection **bite at execution time**: a quantbook whose *requested* tickers have STALE or DEGENERATE local data now **fails fast before the Docker exec**, instead of running to completion and emitting invalid metrics (B&H ~0%, direction ~100%) — the exact silent failure mode that invalidated #8714 / #8730 / #8719.

This operationalises the **#8734 litmus** (*"presence != freshness != non-degeneracy"*) at the point where it matters most: right before Lean's `fillDataForward=True` (default) would silently forward-fill a stale tail into a constant.

### Changes
- **`extract_requested_symbols(notebook_path)`** — mines the notebook's code cells (parsed JSON source, so JSON-escaped quotes are handled correctly) for `AddEquity` / `add_equity` / `AddForex` / `add_crypto` / `AddSecurity` / `AddOption` calls and their first quoted-symbol argument, partitioned by asset class. Full-line comments (`#` / `//`) are skipped so commented-out demo calls aren't mined.
- **`preflight_data_quality(ws, symbols, flat_tail_bars=60)`** — maps each requested symbol to its daily zip under `ws/data` (equity/forex/crypto globs, incl. crypto `_trade`/`_quote` variants) and reuses **`check_data_freshness.scan_zip`** (single source of truth — no duplicated detection logic). Returns `(n_flagged, messages)`. A symbol is flagged when its on-disk zip is **DEGENERATE** (last N closes identical) or **STALE** (last bar older than a 6-month window). Symbols with no on-disk zip are *not* flagged (absence/provisioning is the separate gated concern #8724).
- **`run()` wiring** — after `workspace_root()` resolves the workspace and before `lean research --detach`, the pre-flight runs on the notebook's requested symbols. On any flag it prints an actionable message and **returns exit 3** (aborts before the expensive Docker pull/exec). Two CLI flags: `--no-freshness-check` (bypass), `--freshness-flat-tail-bars` (default 60, `0` disables flat-tail).
- The import of `check_data_freshness` is **lazy + defensive**: if the module is not importable, the pre-flight degrades to a no-op (it is a guard, never a hard dependency — the exec recipe keeps working in a minimal env).

### Why DEEP/qc-infra and not qc-exec monoculture
Per variation-protocol §5 / G-VAR-3: this is the **same domain-cœur (qc-infra)** as #8802 but a **genuinely distinct GENRE/mechanism** — *pipeline integration + ticker-aware symbol extraction* vs #8802's *detection algorithm over all zips*. The litmus passes: this is not scan-generable (it required reading the exec recipe, calibrating the regex against real quantbook patterns, and wiring a fail-fast gate). It is also the explicit default this lane named for c.967, and it makes #8802 actually do something at runtime instead of being a lib nobody calls.

### Calibration against real quantbooks (honest scope note)
The extractor was validated against the **actual** request patterns in `QuantConnect/projects/*/research.ipynb`, not assumed patterns:
- **Lean-data quantbooks** register via `qb.add_equity("SPY")` / `qb.AddEquity("GLD")` / `qb.add_crypto("BTCUSDT")` (quoted literals) → extracted correctly (verified on `Crypto-MultiCanal` → `{equity: [SPY], crypto: [BTCUSDT]}`).
- A minority use a loop variable (`qb.add_equity(ticker)`) → cannot be resolved statically → correctly skipped (conservative under-flagging; full coverage via standalone `check_data_freshness.py`).
- **yfinance-only quantbooks** (e.g. `AllWeather`, which fetches via `yf.download(tickers=[...])` with no Lean call) → extract `{}` → **pre-flight correctly skips them** (they are not subject to Lean `fillDataForward`, so the #8734 risk genuinely does not apply — no false block).

### Scope note — detection/prevention only
The 3 #8734 **fix** options (provision updated equity / `fillDataForward=False` / constrain to 2021) remain explicitly *"decision for ai-01 / user"* in the issue body. This PR delivers **prevention** (auto-abort on degenerate requested data), which is wanted regardless of which fix is chosen. `See #8734` (partial — prevention layer), not `Closes`.

## Validation
```
39/39 tests pass (was 21):
  qc_quantbook_execute.py:  18  (was 9 — +9 new: extract_requested_symbols x5,
                                  preflight_data_quality x6 incl. DEGENERATE/STALE/
                                  FRESH/missing/only-requested/flat-tail-disabled;
                                  run() wiring covered via preflight_data_quality)
  check_data_freshness.py:  21  (unchanged — no regression from shared scan_zip)
Real-world smoke:
  Crypto-MultiCanal/research.ipynb -> {equity:[SPY], crypto:[BTCUSDT]}  (Lean, extracted)
  AllWeather/research.ipynb        -> {}  (yfinance-only, correctly skipped)
py_compile OK; 0 .ipynb in diff (tooling-only, H.3/C.2 N/A).
```

## Files
- `scripts/notebook_tools/qc_quantbook_execute.py` (+179/−4: 2 functions + run() wiring + 2 CLI flags + docstring)
- `scripts/notebook_tools/tests/test_qc_quantbook_execute.py` (+141: 2 test classes, 11 tests)

No notebooks touched; no cell outputs; pure tooling + tests. `git add` by name (2 files).

See #8734 #8724 #6891 #7575.
