### PR TITLE
docs(lean,#6724): fix p4_nw_g3_bridge attack-docstring offset + cite evolve_shift

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -2999,9 +2999,15 @@ private theorem p4_nw_g3_bridge
   --   (b) **outer locality** — once (a) holds, `evolve_cone_agree (2^(k-1))
   --       (2^(k-1))` transports the agreement through the outer evolve. The
   --       subtlety (not a single apply): LHS evaluates at `p`, RHS at
-  --       `p' = p - 2^(k-1)` (NW correspondence), so the locality step needs the
-  --       point-shift alignment between the parent's central window and the
-  --       supercell `(node R1 R2 R4 R5)`'s shifted origin.
+  --       `p' = p - 2^k + 2^(k-1)` (NW correspondence — the goal's offset at the
+  --       theorem statement, not `p - 2^(k-1)`), so the locality step needs the
+  --       point-shift alignment between the parent's central window (origin
+  --       `(0,0)`) and the supercell `(node R1 R2 R4 R5)`'s shifted origin. That
+  --       alignment is now directly attackable: `evolve_shift` (translation-
+  --       invariance capstone, sorry-free, on `main` via #8797 —
+  --       `shift v (evolve n g) = evolve n (shift v g)`) lets the supercell's
+  --       shifted origin be rewritten to match the parent's before
+  --       `evolve_cone_agree` applies. The residual obstruction is (a), not (b).
   --
   -- **Extraction-test caveat** (ai-01 #8766 review): the `exact p4_nw_g3_bridge
   --   ...` at the call site (`p4_nw_supercell_agree`, below) proves the bridge is


### PR DESCRIPTION
## Summary

Accuracy fix to the **attack-documentation** of the `#6724` bridge `p4_nw_g3_bridge` (Conway/Life/HashlifeCorrectness.lean), enabled by the env unblock of c.763 (the Mathlib cache was intact at 8119 oleans all along; `find`/`os.path.islink` don't traverse Windows junctions — triaged by a real `lake build`, see ai-01 #8801).

The **(b) outer-locality** branch of the bridge's docstring stated the NW-correspondence point-shift offset as `p' = p - 2^(k-1)`. The goal's actual offset at the theorem statement is **`p' = p - 2^k + 2^(k-1)`**. Mis-documenting the target offset would send the next reduction attempt at the wrong point.

It also documents that the point-shift alignment is now **directly attackable**: `evolve_shift` (translation-invariance capstone, sorry-free, on `main` via #8797 — `shift v (evolve n g) = evolve n (shift v g)`) lets the supercell's shifted origin be rewritten to match the parent's before `evolve_cone_agree` applies. Residual obstruction is **(a)** the inner overlap-wall, not (b).

## Nature of change

**Comment-only.** No proof body touched. 9 insertions / 3 deletions, all `--` comment lines.

## Lean §B disclosure

- **sorry diff**: FLAT `8 -> 8` (comment-only; `grep -cE '^\s*sorry\b' HashlifeCorrectness.lean`).
- **Lake build**: `lake build Conway.Life.HashlifeCorrectness` = **Build completed successfully (8498 jobs)** (only the 2 expected `declaration uses sorry` warnings at L3895/L3923 — unchanged).
- **Proof integrity (axiom check)**: unchanged — no proof body modified.
- **i18n parity**: `HashlifeCorrectness.lean` is FR-only (no `_en` sibling — consistent with convention; it is a research/WIP proof file). No twin edit required.

## Scope

`See #6724` (partial — attack-documentation accuracy only). The bridge **reduction** itself (eliminating the inner overlap-wall (a)) remains the deep obstruction, meriting a dedicated cycle. This PR does **not** reduce the sorry count.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>