### PR TITLE
docs(qc,#8772): disclose effective data window in ML-RandomForest + ML-SVM quantbooks

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-RandomForest/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-RandomForest/quantbook.ipynb
@@ -149,6 +149,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Fenetre effective vs annoncee - honnetete documentaire (#8772).**\n",
+    "\n",
+    "La cellule d'initialisation annonce `Periode: 2020-01-01 a 2024-12-31`, mais le DataFrame charge commence au **2012-09-28** et compte **1825 barres** (verifiable en tete de la sortie de la cellule precedente, et via `Features shape: (1825, 80)` plus bas) - soit une fenetre reelle **2012-09-28 -> fin 2019** (debut verifie sur l'index committe ; fin deduite du nombre de barres, identique au pattern imprime par ML-DeepLearning en #8770).\n",
+    "\n",
+    "**Pourquoi** : `qb.History(N, Resolution.Daily)` recule depuis `qb.Time`, qui dans un `QuantBook` frais vaut `StartDate` (2020-01-01). Un lookback de `365*5` barres demande donc les 5 ans **qui precedent** 2020, et non les 5 ans declares apres 2020. Les metriques de ce notebook (precision de direction, etc.) sont calculees sur 2012-2019 - une fenetre qui **n'inclut ni le COVID ni le drawdown 2022**, les deux regimes qu'on s'attendrait precisement a voir.\n",
+    "\n",
+    "**A ne pas faire** : re-fenetrer explicitement sur 2020-2024 tant que l'issue #8734 n'est pas resolue - les donnees equity locales s'arretent au 2021-03-31 et Lean les prolonge en constante via `fillDataForward=True`, ce qui produirait ~3 ans de plat (l'artefact a l'origine des 100 % de direction accuracy en #8719). La fenetre reculee est, par accident, la raison pour laquelle ce notebook a des donnees reelles.\n",
+    "\n",
+    "**Reste a faire** (garde par #6891, creds QC Cloud requises) : une re-execution via QC Cloud ajoutera la ligne `Fenetre effective:` imprimee par le code, sur le modele de ML-DeepLearning (#8770). En attendant, cette divulgation documentaire assure l'honnetete interimaire.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 2. Feature Engineering"
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-SVM/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-SVM/quantbook.ipynb
@@ -149,6 +149,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Fenetre effective vs annoncee - honnetete documentaire (#8772).**\n",
+    "\n",
+    "La cellule d'initialisation annonce `Periode: 2020-01-01 a 2024-12-31`, mais le DataFrame charge commence au **2012-09-28** et compte **1825 barres** (verifiable en tete de la sortie de la cellule precedente, et via `Features shape: (1825, 65)` plus bas) - soit une fenetre reelle **2012-09-28 -> fin 2019** (debut verifie sur l'index committe ; fin deduite du nombre de barres, identique au pattern imprime par ML-DeepLearning en #8770).\n",
+    "\n",
+    "**Pourquoi** : `qb.History(N, Resolution.Daily)` recule depuis `qb.Time`, qui dans un `QuantBook` frais vaut `StartDate` (2020-01-01). Un lookback de `365*5` barres demande donc les 5 ans **qui precedent** 2020, et non les 5 ans declares apres 2020. Les metriques de ce notebook (precision de direction, etc.) sont calculees sur 2012-2019 - une fenetre qui **n'inclut ni le COVID ni le drawdown 2022**, les deux regimes qu'on s'attendrait precisement a voir.\n",
+    "\n",
+    "**A ne pas faire** : re-fenetrer explicitement sur 2020-2024 tant que l'issue #8734 n'est pas resolue - les donnees equity locales s'arretent au 2021-03-31 et Lean les prolonge en constante via `fillDataForward=True`, ce qui produirait ~3 ans de plat (l'artefact a l'origine des 100 % de direction accuracy en #8719). La fenetre reculee est, par accident, la raison pour laquelle ce notebook a des donnees reelles.\n",
+    "\n",
+    "**Reste a faire** (garde par #6891, creds QC Cloud requises) : une re-execution via QC Cloud ajoutera la ligne `Fenetre effective:` imprimee par le code, sur le modele de ML-DeepLearning (#8770). En attendant, cette divulgation documentaire assure l'honnetete interimaire.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 2. Feature Engineering pour SVM"
    ]
   },


### PR DESCRIPTION
## Summary

Doc-honesty disclosure for 2 of the sklearn quantbooks in the #8772 inventory (the two "non divulgué" entries with the identical anchored-lookback defect). Both announce `Periode: 2020-01-01 a 2024-12-31` but compute on **2012-2019**.

**Root cause** (mechanism 1 of #8772): `qb.History(N, Resolution.Daily)` looks back from `qb.Time`, which in a fresh `QuantBook` equals `StartDate` (2020-01-01). So `365*5` bars request the 5 years **preceding** 2020, not the 5 declared years after it. Metrics (direction accuracy, etc.) are therefore on 2012-2019 — a window excluding both COVID and the 2022 drawdown.

## Effective window — VERIFIED from committed outputs (not deduced)

Measured on `origin/main` (`d9cb26dce`), from the committed cell outputs:

| Notebook | cell[3] DataFrame head start | cell[5] Features shape | Effective window |
|---|---|---|---|
| ML-RandomForest | **2012-09-28** | **(1825, 80)** — 16 features/asset | 2012-09-28 → ~fin 2019 |
| ML-SVM | **2012-09-28** | **(1825, 65)** — 13 features/asset | 2012-09-28 → ~fin 2019 |

Start date **verified** from the committed DataFrame head index; end **deduced** from the 1825-bar count (identical to the pattern ML-DeepLearning prints, #8770).

## Change

Markdown disclosure cell inserted after the History load (cell[4] of each), documenting:
1. The mismatch (announced 2020-2024 vs effective 2012-2019).
2. The anchoring mechanism (`qb.History` recedes from `qb.Time` = `StartDate`).
3. The **#8734 guard**: do NOT re-window to 2020-2024 until local equity data covers it — data ends 2021-03-31 and Lean forward-fills constant via `fillDataForward=True` (the #8719 100%-direction artifact). The receded window is, by accident, why these notebooks have real data.
4. The **remaining work**: a QC Cloud re-exec will add the code-printed `Fenetre effective:` line on the ML-DeepLearning model (#8770); gated by creds (#6891).

## C.2 markdown exception (no re-exec)

- Code cells **byte-identical** (0 source changes). All 10 code cells retain `execution_count` + `outputs`. 0 deletions, 30 insertions (markdown only).
- Quantbooks require QC Cloud re-exec (QuantBook NameError locally); the markdown disclosure is the interim-honesty path per #6891 RECOVERABLE-USER-HAND. No committed output is hand-edited (Stop & Repair respected — the disclosure is additive prose, not an output scrub).
- JSON integrity validated post-edit (nbformat 4, 22 cells each).

## Scope / non-goals

`See #8772` (partial). Disclosed 2 of the remaining inventory (ML-RandomForest, ML-SVM). Still open under #8772: ML-EnhancedPairs (libellé fix — 2 contradicting `Periode:` lines), ML-XGBoost (comment-alone case), and the full code-print `Fenetre effective:` re-exec for all (gated by #6891 creds). Those are separate atomic PRs.

1 catalogue check: byte-identical to main (no churn).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>