### PR TITLE
fix(slides,#8807): prefix bare image imports with ./ (class 1: 04-probabilites + S2)

### DIFF
--- a/slides/04-probabilites/slides.md
+++ b/slides/04-probabilites/slides.md
@@ -589,9 +589,9 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_019.png" width="380">
-<img src="images/img_020.png" width="380">
-<img src="images/img_021.png" width="380">
+<img src="./images/img_019.png" width="380">
+<img src="./images/img_020.png" width="380">
+<img src="./images/img_021.png" width="380">
 
 
 
@@ -638,9 +638,9 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_022.png" width="380">
-<img src="images/img_023.png" width="380">
-<img src="images/img_024.png" width="380">
+<img src="./images/img_022.png" width="380">
+<img src="./images/img_023.png" width="380">
+<img src="./images/img_024.png" width="380">
 
 
 
@@ -670,8 +670,8 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_025.png" width="380">
-<img src="images/img_026.png" width="380">
+<img src="./images/img_025.png" width="380">
+<img src="./images/img_026.png" width="380">
 
 
 
@@ -707,8 +707,8 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_028.png" width="420">
-<img src="images/img_029.png" width="420">
+<img src="./images/img_028.png" width="420">
+<img src="./images/img_029.png" width="420">
 
 
 
@@ -731,8 +731,8 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_030.png" width="420">
-<img src="images/img_031.png" width="420">
+<img src="./images/img_030.png" width="420">
+<img src="./images/img_031.png" width="420">
 
 
 
@@ -761,7 +761,7 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_032.png" width="380">
+<img src="./images/img_032.png" width="380">
 
 
 
@@ -1217,9 +1217,9 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_064.png" width="380">
-<img src="images/img_065.png" width="380">
-<img src="images/img_066.png" width="380">
+<img src="./images/img_064.png" width="380">
+<img src="./images/img_065.png" width="380">
+<img src="./images/img_066.png" width="380">
 
 
 
@@ -1242,9 +1242,9 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_067.png" width="380">
-<img src="images/img_068.png" width="380">
-<img src="images/img_069.png" width="380">
+<img src="./images/img_067.png" width="380">
+<img src="./images/img_068.png" width="380">
+<img src="./images/img_069.png" width="380">
 
 
 
@@ -1267,9 +1267,9 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_070.png" width="380">
-<img src="images/img_071.png" width="380">
-<img src="images/img_072.png" width="380">
+<img src="./images/img_070.png" width="380">
+<img src="./images/img_071.png" width="380">
+<img src="./images/img_072.png" width="380">
 
 
 
@@ -1297,8 +1297,8 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_073.png" width="380">
-<img src="images/img_074.png" width="380">
+<img src="./images/img_073.png" width="380">
+<img src="./images/img_074.png" width="380">
 
 
 
@@ -1328,7 +1328,7 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_075.png" width="380">
+<img src="./images/img_075.png" width="380">
 
 
 
@@ -1439,8 +1439,8 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_077.png" width="380">
-<img src="images/img_078.png" width="380">
+<img src="./images/img_077.png" width="380">
+<img src="./images/img_078.png" width="380">
 
 
 
@@ -1462,9 +1462,9 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_079.png" width="420">
-<img src="images/img_080.png" width="420">
-<img src="images/img_081.png" width="420">
+<img src="./images/img_079.png" width="420">
+<img src="./images/img_080.png" width="420">
+<img src="./images/img_081.png" width="420">
 
 
 
@@ -1486,9 +1486,9 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_082.png" width="420">
-<img src="images/img_083.png" width="420">
-<img src="images/img_084.png" width="420">
+<img src="./images/img_082.png" width="420">
+<img src="./images/img_083.png" width="420">
+<img src="./images/img_084.png" width="420">
 
 
 
@@ -1510,9 +1510,9 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_085.png" width="420">
-<img src="images/img_086.png" width="420">
-<img src="images/img_087.png" width="420">
+<img src="./images/img_085.png" width="420">
+<img src="./images/img_086.png" width="420">
+<img src="./images/img_087.png" width="420">
 
 
 
@@ -1534,8 +1534,8 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_088.png" width="420">
-<img src="images/img_089.png" width="420">
+<img src="./images/img_088.png" width="420">
+<img src="./images/img_089.png" width="420">
 
 
 
@@ -1558,8 +1558,8 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_090.png" width="420">
-<img src="images/img_091.png" width="420">
+<img src="./images/img_090.png" width="420">
+<img src="./images/img_091.png" width="420">
 
 
 
@@ -1581,8 +1581,8 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_092.png" width="420">
-<img src="images/img_093.png" width="420">
+<img src="./images/img_092.png" width="420">
+<img src="./images/img_093.png" width="420">
 
 
 
@@ -1642,8 +1642,8 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_094.png" width="420">
-<img src="images/img_095.png" width="420">
+<img src="./images/img_094.png" width="420">
+<img src="./images/img_095.png" width="420">
 
 
 
@@ -1668,8 +1668,8 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_096.png" width="420">
-<img src="images/img_097.png" width="420">
+<img src="./images/img_096.png" width="420">
+<img src="./images/img_097.png" width="420">
 
 
 
@@ -1690,8 +1690,8 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_098.png" width="420">
-<img src="images/img_099.png" width="420">
+<img src="./images/img_098.png" width="420">
+<img src="./images/img_099.png" width="420">
 
 
 
@@ -1712,9 +1712,9 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_100.png" width="420">
-<img src="images/img_101.png" width="420">
-<img src="images/img_102.png" width="420">
+<img src="./images/img_100.png" width="420">
+<img src="./images/img_101.png" width="420">
+<img src="./images/img_102.png" width="420">
 
 
 
@@ -1735,8 +1735,8 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_103.png" width="420">
-<img src="images/img_104.png" width="420">
+<img src="./images/img_103.png" width="420">
+<img src="./images/img_104.png" width="420">
 
 
 
@@ -1757,7 +1757,7 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_105.png" width="420">
+<img src="./images/img_105.png" width="420">
 
 
 
@@ -1785,7 +1785,7 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_106.png" width="380">
+<img src="./images/img_106.png" width="380">
 
 
 
@@ -1813,7 +1813,7 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_107.png" width="380">
+<img src="./images/img_107.png" width="380">
 
 
 
@@ -1835,8 +1835,8 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_108.png" width="420">
-<img src="images/img_109.png" width="420">
+<img src="./images/img_108.png" width="420">
+<img src="./images/img_109.png" width="420">
 
 
 
@@ -1858,7 +1858,7 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_110.png" width="420">
+<img src="./images/img_110.png" width="420">
 
 
 

--- a/slides/S2-ia-exploratoire-symbolique/slides.md
+++ b/slides/S2-ia-exploratoire-symbolique/slides.md
@@ -154,8 +154,8 @@ layout: cover
   - Bots conversationnels: Un nouveau paradigme UX
 
 <div class="image-row">
-<img src="images/img_004.jpg" height="100" alt="DARPA">
-<img src="images/img_005.jpg" height="100" alt="ImageNet">
+<img src="./images/img_004.jpg" height="100" alt="DARPA">
+<img src="./images/img_005.jpg" height="100" alt="ImageNet">
 </div>
 
 
@@ -206,9 +206,9 @@ layout: cover
   - Algorithmes
 
 <div class="image-row">
-<img src="images/img_007.jpg" height="150" alt="Intelligence procedurale">
-<img src="images/img_008.png" height="150" alt="Automates">
-<img src="images/img_009.jpg" height="150" alt="Algorithmes">
+<img src="./images/img_007.jpg" height="150" alt="Intelligence procedurale">
+<img src="./images/img_008.png" height="150" alt="Automates">
+<img src="./images/img_009.jpg" height="150" alt="Algorithmes">
 </div>
 
 
@@ -218,9 +218,9 @@ layout: cover
 # Intelligences (suite)
 
 <div class="image-row">
-<img src="images/img_010.jpg" height="180" alt="Intelligence exploratoire">
-<img src="images/img_011.png" height="180" alt="Intelligence symbolique">
-<img src="images/img_012.jpg" height="180" alt="Intelligence probabiliste">
+<img src="./images/img_010.jpg" height="180" alt="Intelligence exploratoire">
+<img src="./images/img_011.png" height="180" alt="Intelligence symbolique">
+<img src="./images/img_012.jpg" height="180" alt="Intelligence probabiliste">
 </div>
 
 
@@ -313,7 +313,7 @@ layout: cover
 - Règles
   - Conditions / Actions
 
-![w:500 center](images/img_014.png)
+![w:500 center](./images/img_014.png)
 
 
 
@@ -326,7 +326,7 @@ layout: cover
 - Historique des percepts
 - Mémoire du changement
 
-![w:500 center](images/img_015.png)
+![w:500 center](./images/img_015.png)
 
 
 
@@ -378,7 +378,7 @@ layout: section
 - Exploration du Futur, séquences d'actions
 - Recherche, planification
 
-![w:550 center](images/img_017.png)
+![w:550 center](./images/img_017.png)
 
 
 
@@ -422,7 +422,7 @@ layout: section
 
 # Exemple Abstraction: Assemblage robotique
 
-![w:500 center](images/img_019.png)
+![w:500 center](./images/img_019.png)
 
 - **Etats:** Coordonnées réelles des joints du robot et des objets
 - **Test de but:** Objet assemblé
@@ -436,7 +436,7 @@ layout: section
 
 # Problème jouet: Les 8 reines
 
-![w:350 center](images/img_020.png)
+![w:350 center](./images/img_020.png)
 
 - **Etats:** Disposition de 0-8 reines
 - **Test de but:** 8 reines sont présentes, et aucune n'est menacée
@@ -481,9 +481,9 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_021.png" width="380">
-<img src="images/img_022.png" width="380">
-<img src="images/img_023.png" width="380">
+<img src="./images/img_021.png" width="380">
+<img src="./images/img_022.png" width="380">
+<img src="./images/img_023.png" width="380">
 
 
 
@@ -497,7 +497,7 @@ layout: two-cols
 - Si + de cannibales que de missionnaires d'un côté ou l'autre
   - ils se font manger
 
-![w:500 center](images/img_024.png)
+![w:500 center](./images/img_024.png)
 
 
 ---
@@ -537,7 +537,7 @@ layout: two-cols
   - Peut fonctionner dans des espaces de grande taille ou infinis
 - **Exemple:** 8 reines
 
-![w:600 center](images/img_026.png)
+![w:600 center](./images/img_026.png)
 
 
 ---
@@ -549,7 +549,7 @@ layout: two-cols
   - Objectif = trouver le meilleur état selon une fonction objectif
 - Utilité du paysage de l'espace des états
 
-![w:700 center](images/img_027.png)
+![w:700 center](./images/img_027.png)
 
 
 ---
@@ -669,10 +669,10 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_032.png" width="380">
-<img src="images/img_033.png" width="380">
-<img src="images/img_034.png" width="380">
-<img src="images/img_035.png" width="380">
+<img src="./images/img_032.png" width="380">
+<img src="./images/img_033.png" width="380">
+<img src="./images/img_034.png" width="380">
+<img src="./images/img_035.png" width="380">
 
 
 
@@ -742,9 +742,9 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_038.png" width="380">
-<img src="images/img_039.png" width="380">
-<img src="images/img_040.png" width="380">
+<img src="./images/img_038.png" width="380">
+<img src="./images/img_039.png" width="380">
+<img src="./images/img_040.png" width="380">
 
 
 
@@ -777,9 +777,9 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_041.png" width="380">
-<img src="images/img_042.png" width="380">
-<img src="images/img_043.png" width="380">
+<img src="./images/img_041.png" width="380">
+<img src="./images/img_042.png" width="380">
+<img src="./images/img_043.png" width="380">
 
 
 
@@ -883,9 +883,9 @@ layout: two-cols
 ::right::
 
 
-<img src="images/img_044.png" width="380">
-<img src="images/img_045.png" width="380">
-<img src="images/img_046.png" width="380">
+<img src="./images/img_044.png" width="380">
+<img src="./images/img_045.png" width="380">
+<img src="./images/img_046.png" width="380">
 
 
 
@@ -987,7 +987,7 @@ layout: two-cols
 - Viole l'un des critères
 - Taxonomie
 
-<img src="images/img_047.jpg" width="300" alt="Taxonomie des fallacies">
+<img src="./images/img_047.jpg" width="300" alt="Taxonomie des fallacies">
 
 - Comment le dénoncer
   - Reconstruction standard
@@ -1011,8 +1011,8 @@ layout: two-cols
 - But à atteindre
 - Listes des opérations
 
-<img src="images/img_048.png" width="350" alt="Langage formel planification">
-<img src="images/img_049.png" width="350" alt="Operations planification">
+<img src="./images/img_048.png" width="350" alt="Langage formel planification">
+<img src="./images/img_049.png" width="350" alt="Operations planification">
 
 
 ::right::
@@ -1026,8 +1026,8 @@ layout: two-cols
 - Planification à Ordre partiel
 - Décomposition hiérarchique
 
-<img src="images/img_050.png" width="300" alt="Diagramme planification">
-<img src="images/img_051.png" width="300" alt="Schema hierarchique">
+<img src="./images/img_050.png" width="300" alt="Diagramme planification">
+<img src="./images/img_051.png" width="300" alt="Schema hierarchique">
 
 
 
@@ -1046,11 +1046,11 @@ layout: two-cols
 - Web sémantique
   - W3C
 
-<img src="images/img_052.png" width="280" alt="Ontologies web semantique">
+<img src="./images/img_052.png" width="280" alt="Ontologies web semantique">
 
 - Linked Data
 
-<img src="images/img_053.png" width="280" alt="Linked Data">
+<img src="./images/img_053.png" width="280" alt="Linked Data">
 
 
 ::right::
@@ -1070,7 +1070,7 @@ layout: two-cols
   - C(A+B) = C(A)+C(B)
   - Non-divulgation
 
-<img src="images/img_054.png" width="200" alt="Smart contracts">
+<img src="./images/img_054.png" width="200" alt="Smart contracts">
 
 
 


### PR DESCRIPTION
## Summary

Class 1 of #8807 — the two Slidev decks whose image files **are present** but fail to resolve because the import specifier is bare (`images/foo.png`) instead of relative (`./images/foo.png`). Vite/Rollup treats a bare specifier as a module lookup (node_modules-style), not a relative path, so the build fails despite the file existing on disk.

Per the #8807 acceptance criteria, this is **one PR for class 1** (the syntax fix), distinct from class 2 (absent asset, `07`) and class 3 (malformed markup, `06`/`S3`).

## Changes

| Deck | Pattern | Refs fixed |
|---|---|---|
| `04-probabilites` | `<img src="images/...">` → `<img src="./images/...">` | 59 |
| `S2-ia-exploratoire-symbolique` | `<img src="images/...">` → `<img src="./images/...">` | 32 |
| `S2-ia-exploratoire-symbolique` | `![alt](images/...)` → `![alt](./images/...)` | 8 |

**The markdown-image refs in S2 were a second pattern masked by Rollup's fail-fast** (it reports only the first unresolved import and stops): the #8807 diagnosis listed the S2 error as `img_004.jpg` (an `<img src>`). Fixing those surfaced the markdown `![](images/...)` refs as the next failures — same class-1 defect (bare specifier), second syntactic form.

HTML-comment annotations `<!-- Image: images/... -->` (51 in 04, 14 in S2) are **not** resolved by the bundler and are left untouched.

## Verification (rule F — install the env, don't work around it)

The fresh worktree had no `node_modules`, so `npx slidev` tried a fresh install (E404 — `slidev` ≠ `@slidev/cli`). Fixed by installing the real env rather than skipping the build:
- `npm ci` from `slides/package-lock.json` → 627 packages installed.
- `npx slidev build 04-probabilites/slides.md` → **built in 4.49s** (was: `Rollup failed to resolve import "images/img_019.png"`).
- `npx slidev build S2-ia-exploratoire-symbolique/slides.md` → **built in 3.95s** (was: `Rollup failed to resolve import "images/img_004.jpg"`).
- Both emit `dist/index.html` (artifacts written to `/tmp`, **not** committed — `slides/.gitignore` covers `dist/`).
- All referenced image files exist on disk (59/59 + 40/40, **0 missing**) — confirms class 1 (syntax), not class 2 (absent asset).

## Acceptance criteria

1. ✅ Both class-1 decks build (`npx slidev build` → success).
2. ✅ No image removed — only the path prefix changed (99 ins / 99 del, all `images/` → `./images/`).
3. ✅ One PR for class 1 (independent of classes 2 and 3).

`See #8807` (class 1 of 3). Classes 2 (`07-elargissements`, absent asset) and 3 (`06-apprentissage`/`S3-acculturation`, malformed markup) remain as separate PRs.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>