### PR TITLE
feat(notebook-tools,#2161): corpus scope for count_exercises (168 -> 2 actionable)

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -42,6 +42,13 @@ Excludes (same convention as count_notebooks_by_series.py): .ipynb_checkpoints,
 research, archive, _output, partner-course, examples, obj, bin, .git, plus
 `.QuantConnect`/`TrashBin` (QuantConnect CLI app-data + recycle bin of deleted
 project notebooks -- not pedagogical content).
+
+Beyond those directory exclusions, each remaining notebook is classified into
+the pedagogical corpus or out of it (see "Corpus scope" below), because the
+convention answers two questions and not one: which notebooks are course
+material, and what minimum applies to those that are. The count of what scope
+removed is reported as `Out of corpus`, so a narrowed run stays distinguishable
+from a clean one.
 """
 
 from __future__ import annotations
@@ -56,6 +63,9 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 NOTEBOOKS_DIR = REPO_ROOT / "MyIA.AI.Notebooks"
 
+#: Standard exercise budget for an ordinary course notebook (#2161).
+DEFAULT_THRESHOLD = 3
+
 EXCLUDE_DIRS = {
     ".ipynb_checkpoints", ".git", "__pycache__", "obj", "bin",
     "_output", "research", "archive", "partner-course", "examples",
@@ -66,6 +76,183 @@ EXCLUDE_DIRS = {
     # tally (false sub-3) -- same class of artifact gap as `_output.ipynb`.
     ".QuantConnect", "TrashBin",
 }
+
+# ---------------------------------------------------------------------------
+# Corpus scope and per-kind thresholds (#2161 exception table)
+#
+# `.claude/rules/three-exercises-per-notebook.md` states the convention in two
+# parts that this script historically collapsed into a single "count < 3 =
+# violation" test:
+#
+#   (a) WHICH notebooks belong to the pedagogical corpus at all. Research
+#       artifacts, quantbooks, templates, probes, vendored sub-repos and
+#       archives are not course material, so they have no exercise budget.
+#   (b) WHAT threshold applies to a notebook that IS course material. The rule
+#       publishes an exception table: Setup/Environment 0-1, purely-Lean 0-2,
+#       Archive/Legacy 0 ("pas maintenir"), everything else 3.
+#
+# Collapsing (a) into (b) makes the output unreadable rather than merely
+# imprecise: a run over the whole repo reported 168 "sub-threshold" notebooks,
+# of which 133 were QuantConnect research/quantbook artifacts and nearly all the
+# rest were setup, Lean or archive notebooks that the rule explicitly exempts.
+# A tally that mixes "should never have been counted" with "counted, and
+# legitimately below 3" cannot be acted on and cannot be gated -- the same
+# defect class as a bare counter published without its denominator (#8678).
+# Classifying first makes the denominator visible and leaves a residue that is
+# actually actionable.
+#
+# Every pattern below is derived from a path observed in this repo; none is
+# speculative. Filename rules are preferred over directory lists because the
+# historical directory list drifted into near-misses that silently matched
+# nothing: `archive` never matched `_archives/`, and `partner-course` never
+# matched `partner-course-quant-trading/`.
+# ---------------------------------------------------------------------------
+
+#: Directories whose notebooks are not course material.
+#: Underscore-prefixed directories are handled generically below: every one of
+#: them under MyIA.AI.Notebooks/ today is internal (`_archives/`, `_probes/`,
+#: `_docs/`, `_legacy/`, `__pycache__/`), and no taught series uses that form.
+NON_PEDAGOGICAL_DIRS = {
+    "semantic-fleet",  # vendored sub-repo under GenAI/SemanticKernel/
+    "ML-Training-Pipeline",  # QC model-training research, not a taught series
+    "Research-Executor",  # QC batch-run harness (`runner.ipynb`)
+}
+
+#: Minimum exercise count per notebook kind, transcribed from the rule's
+#: "Exceptions" table. Note the column is *Minimum exercices* and the exempt
+#: rows read "0-1" (setup) and "0-2" (Lean): the acceptable count INCLUDES zero,
+#: with the upper figure describing the expected ceiling, not a floor. So a
+#: setup or Lean notebook is never sub-threshold. Encoding 1 and 2 as floors
+#: here would invent a stricter policy than the rule states and would re-create,
+#: at small scale, exactly the noise this change removes -- eight GenAI
+#: `00-*-Environment` notebooks flagged for a requirement the rule exempts them
+#: from. Only `standard` carries the real budget.
+KIND_MINIMUM: dict[str, int | None] = {
+    "setup": 0,
+    "lean": 0,
+}
+
+#: Execution / research artifacts, matched on the notebook stem.
+#: Covers `research.ipynb`, `Research.ipynb`, `quantbook.ipynb`, `output_v2.ipynb`,
+#: `research_robustness.ipynb`, `m12_har_rv_j_research.ipynb`,
+#: `sector_momentum_research_v2.ipynb`, `CrossSubmissionCaptureRepro.ipynb`.
+ARTIFACT_STEM_RE = re.compile(
+    r"^(?:research|quantbook|output)(?:[_-]v?\d+)?$"
+    r"|^research[_-]"
+    r"|[_-]research(?:[_-]v?\d+)?$"
+    r"|[_-]output(?:[_-]v?\d+)?$"
+    r"|repro$",
+    re.IGNORECASE,
+)
+
+#: Setup / environment notebooks -- rule threshold 0-1.
+#: `Lean-1-Setup`, `Sudoku-0-Environment-Csharp`, `SC-1-Setup-Foundry`,
+#: `QC-Py-01-Setup`, `Argument_Analysis_Agentic-0-init`, `..-0-init_agent`.
+SETUP_STEM_RE = re.compile(
+    r"(?:^|[-_])(?:setup|environment|init)(?:$|[-_])", re.IGNORECASE
+)
+
+#: A directory that scopes a whole environment sub-series, e.g.
+#: `GenAI/00-GenAI-Environment/` (whose 00-2..00-6 stems carry no setup marker)
+#: and `Planners/00-Environment/`.
+SETUP_DIR_RE = re.compile(r"environment", re.IGNORECASE)
+
+#: Purely-Lean notebooks -- rule threshold 0-2.
+#: `Lean-3-Propositions-Proofs`, `GameTheory-11b-Lean-BayesianGamesExt`,
+#: `DecInfer-9-Lean-Gittins`.
+LEAN_STEM_RE = re.compile(r"(?:^|[-_])lean(?:$|[-_])", re.IGNORECASE)
+
+#: Legacy material -- rule "Archive / Legacy" row. Matched on DIRECTORY parts
+#: only (`SemanticWeb/RDF.Net-Legacy/`), never on the notebook stem: a filename
+#: match would drop `GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker
+#: -Legacy.ipynb`, where "Legacy" names the notebook's SUBJECT (a legacy
+#: pattern-maker) and not its status -- it is a maintained lesson in a numbered
+#: series (04-1..04-4) and it already carries 4 exercises. A scope rule that
+#: silently removes a conforming course notebook from the denominator is the
+#: same failure as one that leaves artifacts in it, just harder to notice.
+LEGACY_RE = re.compile(r"legacy", re.IGNORECASE)
+
+#: Kinds that carry no exercise budget: they are outside the corpus entirely.
+OUT_OF_CORPUS_KINDS = frozenset(
+    {"artifact", "template", "vendored", "archive", "legacy", "tooling", "student"}
+)
+
+
+def classify_notebook(path: Path) -> tuple[str, int | None]:
+    """Return ``(kind, threshold)`` for a notebook path.
+
+    ``threshold`` is ``None`` when the notebook is outside the pedagogical
+    corpus (kind in :data:`OUT_OF_CORPUS_KINDS`); such notebooks are never
+    sub-threshold because the convention does not apply to them.
+
+    ``standard_threshold`` applies to ordinary course notebooks. Setup and Lean
+    notebooks stay in the corpus -- they ARE course material -- but carry a
+    minimum of 0 per :data:`KIND_MINIMUM`, so raising ``--threshold`` never
+    invents an exercise budget for a notebook the rule exempts.
+    """
+    return _classify(path, standard_threshold=DEFAULT_THRESHOLD)
+
+
+def _scope_parts(path: Path, root: Path | None = None) -> tuple[str, ...]:
+    """Path components that may carry classification signal.
+
+    The directory rules below (underscore, legacy, `groupe-`) must only see the
+    part of the path INSIDE the scanned tree. The absolute prefix above it
+    belongs to whoever cloned the repo, and it is not signal: a checkout under
+    `.../_worktrees/` or `.../legacy-box/` would otherwise classify every
+    notebook in the repository as archive -- silently, and with a green
+    `--check`, since an empty corpus cannot fail. Caught by a unit test whose
+    own `tmp_path` happened to contain the substring `legacy`.
+    """
+    for anchor in (root, NOTEBOOKS_DIR, REPO_ROOT):
+        if anchor is None:
+            continue
+        try:
+            return path.resolve().relative_to(anchor.resolve()).parts
+        except (ValueError, OSError):
+            continue
+    return path.parts
+
+
+def _classify(
+    path: Path, standard_threshold: int, root: Path | None = None
+) -> tuple[str, int | None]:
+    parts = _scope_parts(path, root)
+    stem = path.stem
+
+    if any(part in NON_PEDAGOGICAL_DIRS for part in parts):
+        return ("archive", None)
+    if any(part.startswith("_") for part in parts[:-1]):
+        return ("archive", None)
+    if any(LEGACY_RE.search(part) for part in parts[:-1]):
+        return ("legacy", None)
+    if any(part.casefold().startswith("groupe-") for part in parts):
+        # Student group deliverables (`groupe-I2-contre-arguments-aspic/`) are
+        # submissions, not course material we author.
+        return ("student", None)
+    if "template" in stem.casefold():
+        return ("template", None)
+    if ARTIFACT_STEM_RE.search(stem):
+        return ("artifact", None)
+    if stem.startswith("_"):
+        # `_e2e_quant_validation.ipynb` -- internal harness notebook.
+        return ("tooling", None)
+
+    # A notebook sitting directly at the top of MyIA.AI.Notebooks/ belongs to no
+    # series; every taught series lives in a family directory. `GradeBook.ipynb`
+    # (the grading engine) is the only such file today.
+    if path.is_absolute():
+        try:
+            if len(path.relative_to(NOTEBOOKS_DIR).parts) == 1:
+                return ("tooling", None)
+        except ValueError:
+            pass
+
+    if SETUP_STEM_RE.search(stem) or any(SETUP_DIR_RE.search(p) for p in parts[:-1]):
+        return ("setup", KIND_MINIMUM["setup"])
+    if LEAN_STEM_RE.search(stem):
+        return ("lean", KIND_MINIMUM["lean"])
+    return ("standard", standard_threshold)
 
 # \bexercice\b anywhere in the line, case-insensitive, French or English form.
 # Matches `### Exercice 1`, `## 8. Exercice`, `### Exercice - ...`, `### Exercise`.
@@ -468,18 +655,42 @@ def iter_pedagogical_notebooks(root: Path) -> list[Path]:
     Excludes execution-artifact notebooks whose filename ends in `_output.ipynb`
     (the papermill convention used in this repo: each lab has both
     `LabN-Name.ipynb` and `LabN-Name_output.ipynb`; counting both double-counts).
+
+    Also excludes notebooks that :func:`classify_notebook` places outside the
+    pedagogical corpus (research artifacts, quantbooks, templates, probes,
+    vendored sub-repos, archives). Without that filter the default target list
+    is not the corpus, and every aggregate computed from it -- conforming count,
+    sub-threshold tally, ``--check`` exit code -- carries a denominator that
+    silently includes material the convention never applied to.
+    """
+    return corpus_scope(root)[0]
+
+
+def corpus_scope(root: Path) -> tuple[list[Path], dict[str, int]]:
+    """Return ``(corpus, removed_by_kind)`` for a tree.
+
+    The second element is the part a plain filter throws away. Reporting the
+    corpus size alone would leave the reader unable to tell a tool that
+    inspected everything from one that quietly narrowed its own scope -- the
+    failure this change exists to fix, so it must not be reintroduced by the
+    fix itself. `--check` prints it as `Out of corpus`.
     """
     out: list[Path] = []
+    removed: dict[str, int] = {}
     if not root.exists():
-        return out
+        return out, removed
     for nb_path in sorted(root.rglob("*.ipynb")):
         parts = nb_path.parts
         if any(exc in parts for exc in EXCLUDE_DIRS):
             continue
         if nb_path.stem.endswith("_output"):
             continue
+        kind, _ = _classify(nb_path, standard_threshold=DEFAULT_THRESHOLD, root=root)
+        if kind in OUT_OF_CORPUS_KINDS:
+            removed[kind] = removed.get(kind, 0) + 1
+            continue
         out.append(nb_path)
-    return out
+    return out, removed
 
 
 def _family_of(path: Path, notebooks_dir: Path) -> str:
@@ -490,47 +701,94 @@ def _family_of(path: Path, notebooks_dir: Path) -> str:
         return "_root"
 
 
+def _display_path(path: Path) -> Path:
+    """Repo-relative form for reporting, falling back to the path itself.
+
+    `relative_to` raises for an absolute path outside the repo, so reporting a
+    target collected from elsewhere would crash the run rather than print it.
+    """
+    if not path.is_absolute():
+        return path
+    try:
+        return path.relative_to(REPO_ROOT)
+    except ValueError:
+        return path
+
+
 def run(
     targets: list[Path],
     threshold: int,
     json_out: bool,
     check: bool,
+    root: Path | None = None,
+    removed_by_kind: dict[str, int] | None = None,
 ) -> int:
-    """Execute the count over the given targets. Returns exit code for --check."""
+    """Execute the count over the given targets. Returns exit code for --check.
+
+    ``root`` is the tree the targets were collected from; it anchors path-based
+    classification so the prefix above it never carries signal (:func:`_scope_parts`).
+    """
     if json_out:
-        return _run_json(targets, threshold)
-    return _run_text(targets, threshold, check)
+        return _run_json(targets, threshold, root, removed_by_kind)
+    return _run_text(targets, threshold, check, root, removed_by_kind)
 
 
-def _run_text(targets: list[Path], threshold: int, check: bool) -> int:
-    sub_threshold: list[tuple[Path, NotebookCount]] = []
+def _run_text(
+    targets: list[Path],
+    threshold: int,
+    check: bool,
+    root: Path | None = None,
+    removed_by_kind: dict[str, int] | None = None,
+) -> int:
+    sub_threshold: list[tuple[Path, NotebookCount, str, int]] = []
     parse_errors: list[tuple[Path, str]] = []
+    exempt: list[tuple[Path, str]] = []
+    by_kind: dict[str, int] = {}
     total_notebooks = 0
     total_exercises = 0
 
     for nb_path in targets:
+        kind, effective = _classify(nb_path, standard_threshold=threshold, root=root)
+        by_kind[kind] = by_kind.get(kind, 0) + 1
+        if effective is None:
+            exempt.append((nb_path, kind))
+            continue
         total_notebooks += 1
         cnt = count_exercises_in_notebook(nb_path)
         if cnt.parse_error:
             parse_errors.append((nb_path, cnt.parse_error))
             continue
         total_exercises += cnt.count
-        if cnt.count < threshold:
-            sub_threshold.append((nb_path, cnt))
+        if cnt.count < effective:
+            sub_threshold.append((nb_path, cnt, kind, effective))
 
-    print(f"Notebooks scanned : {total_notebooks}")
-    print(f"Total exercises   : {total_exercises}")
-    print(f"Threshold         : >= {threshold} per notebook")
-    print(f"Conforming        : {total_notebooks - len(sub_threshold) - len(parse_errors)}")
-    print(f"Sub-threshold     : {len(sub_threshold)}")
+    print(f"Notebooks in corpus : {total_notebooks}")
+    print(f"Total exercises     : {total_exercises}")
+    print(
+        f"Threshold           : >= {threshold} for course notebooks "
+        f"(setup / Lean exempt -- #2161 table)"
+    )
+    print(
+        f"Conforming          : "
+        f"{total_notebooks - len(sub_threshold) - len(parse_errors)}"
+    )
+    print(f"Sub-threshold       : {len(sub_threshold)}")
     if parse_errors:
-        print(f"Parse errors      : {len(parse_errors)}")
+        print(f"Parse errors        : {len(parse_errors)}")
+    # The denominator, spelled out: without it, "N sub-threshold" is not
+    # actionable because it silently mixes exempt material into the tally.
+    removed = dict(removed_by_kind or {})
+    for _, kind in exempt:  # explicitly-passed paths the scan never saw
+        removed[kind] = removed.get(kind, 0) + 1
+    if removed:
+        detail = ", ".join(f"{k}={v}" for k, v in sorted(removed.items()))
+        print(f"Out of corpus       : {sum(removed.values())} ({detail})")
 
     if sub_threshold:
         print("\n--- Sub-threshold notebooks (with evidence) ---")
-        for nb_path, cnt in sub_threshold:
-            rel = nb_path.relative_to(REPO_ROOT) if nb_path.is_absolute() else nb_path
-            print(f"\n[{cnt.count}/{threshold}] {rel}")
+        for nb_path, cnt, kind, effective in sub_threshold:
+            rel = _display_path(nb_path)
+            print(f"\n[{cnt.count}/{effective}] ({kind}) {rel}")
             for hit in cnt.exercises:
                 print(f"    cell {hit.cell_index:>3} ({hit.cell_type:<8} {hit.detected_by}): {hit.preview}")
     else:
@@ -546,16 +804,29 @@ def _run_text(targets: list[Path], threshold: int, check: bool) -> int:
     return 0
 
 
-def _run_json(targets: list[Path], threshold: int) -> int:
-    payload = {"threshold": threshold, "notebooks": []}
+def _run_json(
+    targets: list[Path],
+    threshold: int,
+    root: Path | None = None,
+    removed_by_kind: dict[str, int] | None = None,
+) -> int:
+    payload = {
+        "threshold": threshold,
+        "out_of_corpus": dict(sorted((removed_by_kind or {}).items())),
+        "notebooks": [],
+    }
     for nb_path in targets:
+        kind, effective = _classify(nb_path, standard_threshold=threshold, root=root)
         cnt = count_exercises_in_notebook(nb_path)
         entry = {
-            "path": str(nb_path.relative_to(REPO_ROOT))
-            if nb_path.is_absolute()
-            else str(nb_path),
+            "path": str(_display_path(nb_path)),
             "count": cnt.count,
-            "conforming": cnt.count >= threshold and cnt.parse_error is None,
+            "kind": kind,
+            # None => outside the pedagogical corpus, so never sub-threshold.
+            "effective_threshold": effective,
+            "in_corpus": effective is not None,
+            "conforming": effective is None
+            or (cnt.count >= effective and cnt.parse_error is None),
             "parse_error": cnt.parse_error,
             "evidence": [
                 {
@@ -588,8 +859,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--threshold",
         type=int,
-        default=3,
-        help="Minimum exercises per notebook (default: 3, per #2161).",
+        default=DEFAULT_THRESHOLD,
+        help=(
+            f"Minimum exercises for an ordinary course notebook "
+            f"(default: {DEFAULT_THRESHOLD}, per #2161). Setup and Lean "
+            f"notebooks are exempt by the rule's exception table and are never "
+            f"flagged, whatever value is passed here."
+        ),
     )
     parser.add_argument(
         "--json",
@@ -606,6 +882,15 @@ def main(argv: list[str] | None = None) -> int:
 
     # Resolve targets.
     targets: list[Path] = []
+    removed_by_kind: dict[str, int] = {}
+    scan_root: Path | None = None
+
+    def _absorb(root: Path) -> None:
+        found, removed = corpus_scope(root)
+        targets.extend(found)
+        for kind, n in removed.items():
+            removed_by_kind[kind] = removed_by_kind.get(kind, 0) + n
+
     if args.paths:
         for raw in args.paths:
             p = Path(raw)
@@ -613,13 +898,15 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"warning: {raw} does not exist, skipping", file=sys.stderr)
                 continue
             if p.is_dir():
-                targets.extend(iter_pedagogical_notebooks(p))
+                _absorb(p)
             elif p.suffix == ".ipynb":
                 targets.append(p)
     elif args.family:
-        targets = iter_pedagogical_notebooks(NOTEBOOKS_DIR / args.family)
+        scan_root = NOTEBOOKS_DIR / args.family
+        _absorb(scan_root)
     else:
-        targets = iter_pedagogical_notebooks(NOTEBOOKS_DIR)
+        scan_root = NOTEBOOKS_DIR
+        _absorb(scan_root)
 
     if not targets:
         print("No notebooks matched the given targets.", file=sys.stderr)
@@ -630,6 +917,8 @@ def main(argv: list[str] | None = None) -> int:
         threshold=args.threshold,
         json_out=args.json_out,
         check=args.check,
+        root=scan_root,
+        removed_by_kind=removed_by_kind,
     )
 
 

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -18,9 +18,13 @@ if _tools_dir not in sys.path:
     sys.path.insert(0, _tools_dir)
 
 from count_exercises import (
+    OUT_OF_CORPUS_KINDS,
+    _classify,
+    corpus_scope,
     _is_stub_code,
     count_exercises_in_notebook,
     iter_pedagogical_notebooks,
+    run,
 )
 
 
@@ -910,3 +914,169 @@ class TestGroupedAndPluralHeaders:
         result = count_exercises_in_notebook(nb)
         assert result.count == 2
 
+
+
+class TestCorpusScope:
+    """Corpus scope and the #2161 exception table (`classify_notebook`).
+
+    The convention has two parts the counter historically collapsed into one
+    `count < 3` test: WHICH notebooks are course material, and WHAT minimum
+    applies to those that are. Collapsing them reported 168 sub-threshold
+    notebooks repo-wide, of which 133 were QuantConnect research artifacts and
+    nearly all the rest were rule-exempt setup/Lean/archive notebooks.
+    """
+
+    @pytest.mark.parametrize(
+        "stem",
+        [
+            "research",            # QC projects/*/research.ipynb
+            "Research",            # CSharp-BTC-MACD-ADX/Research.ipynb (capital)
+            "quantbook",           # QC projects/*/quantbook.ipynb
+            "output_v2",           # Sector-Momentum-Researcher/output_v2.ipynb
+            "research_robustness",
+            "m12_har_rv_j_research",
+            "sector_momentum_research_v2",
+            "CrossSubmissionCaptureRepro",
+        ],
+    )
+    def test_execution_artifacts_are_out_of_corpus(self, tmp_path, stem):
+        kind, threshold = _classify(tmp_path / f"{stem}.ipynb", standard_threshold=3, root=tmp_path)
+        assert threshold is None, f"{stem} should carry no exercise budget"
+        assert kind in OUT_OF_CORPUS_KINDS
+
+    def test_templates_and_internal_notebooks_are_out_of_corpus(self, tmp_path):
+        for stem, expect in [
+            ("Workbook-Template", "template"),
+            ("Notebook-Template", "template"),
+            ("_e2e_quant_validation", "tooling"),
+        ]:
+            kind, threshold = _classify(tmp_path / f"{stem}.ipynb", standard_threshold=3, root=tmp_path)
+            assert (kind, threshold) == (expect, None), stem
+
+    def test_underscore_directory_is_out_of_corpus(self, tmp_path):
+        for parent in ("_archives", "_probes", "_docs"):
+            nb = tmp_path / parent / "Serie-2-Concepts.ipynb"
+            kind, threshold = _classify(nb, standard_threshold=3, root=tmp_path)
+            assert (kind, threshold) == ("archive", None), parent
+
+    def test_legacy_directory_excluded_but_legacy_filename_kept(self, tmp_path):
+        """The precision case that a naive `legacy` match gets wrong.
+
+        `SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb` sits in a legacy FOLDER and
+        is not maintained. `GenAI/Image/04-Applications/04-4-Cross-Stitch-
+        Pattern-Maker-Legacy.ipynb` is a maintained lesson in a numbered series
+        whose SUBJECT happens to be a legacy pattern-maker -- it carries 4
+        exercises. Dropping it would remove a conforming course notebook from
+        the denominator, which is the same defect as leaving artifacts in it and
+        considerably harder to notice.
+        """
+        in_legacy_dir = tmp_path / "RDF.Net-Legacy" / "RDF.Net.ipynb"
+        assert _classify(in_legacy_dir, standard_threshold=3, root=tmp_path) == ("legacy", None)
+
+        legacy_named = tmp_path / "04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb"
+        kind, threshold = _classify(legacy_named, standard_threshold=3, root=tmp_path)
+        assert kind == "standard"
+        assert threshold == 3
+
+    def test_setup_and_lean_are_in_corpus_but_exempt(self, tmp_path):
+        """Rule table: Setup/Environment `0-1`, purely-Lean `0-2`.
+
+        The column is *Minimum exercices* and both rows include zero, so these
+        kinds are never sub-threshold. Encoding 1 and 2 as FLOORS would invent a
+        stricter policy than the rule states.
+        """
+        for stem, expect in [
+            ("Lean-1-Setup", "setup"),
+            ("Sudoku-0-Environment-Csharp", "setup"),
+            ("SC-1-Setup-Foundry", "setup"),
+            ("Argument_Analysis_Agentic-0-init_agent", "setup"),
+            ("Lean-3-Propositions-Proofs", "lean"),
+            ("GameTheory-11b-Lean-BayesianGamesExt", "lean"),
+            ("DecInfer-9-Lean-Gittins", "lean"),
+        ]:
+            kind, threshold = _classify(tmp_path / f"{stem}.ipynb", standard_threshold=3, root=tmp_path)
+            assert kind == expect, stem
+            assert threshold == 0, f"{stem}: rule exempts this kind, floor must be 0"
+
+    def test_environment_directory_scopes_its_notebooks_as_setup(self, tmp_path):
+        """`GenAI/00-GenAI-Environment/00-2-Docker-Services-Management.ipynb`
+        carries no setup marker in its own stem -- the directory supplies it."""
+        nb = tmp_path / "00-GenAI-Environment" / "00-2-Docker-Services-Management.ipynb"
+        assert _classify(nb, standard_threshold=3, root=tmp_path) == ("setup", 0)
+
+    def test_ordinary_course_notebook_keeps_the_full_budget(self, tmp_path):
+        nb = tmp_path / "Serie" / "SW-4-Ontologies.ipynb"
+        assert _classify(nb, standard_threshold=3, root=tmp_path) == ("standard", 3)
+
+    def test_raising_threshold_does_not_raise_exempt_kinds(self, tmp_path):
+        """`--threshold 5` must not invent an exercise budget for setup/Lean."""
+        assert _classify(tmp_path / "Lean-1-Setup.ipynb", standard_threshold=5, root=tmp_path)[1] == 0
+        assert _classify(tmp_path / "X-Lean-Y.ipynb", standard_threshold=5, root=tmp_path)[1] == 0
+        assert _classify(tmp_path / "X-Concepts.ipynb", standard_threshold=5, root=tmp_path)[1] == 5
+
+    def test_iter_pedagogical_notebooks_drops_out_of_corpus(self, tmp_path):
+        cells = [_md("## Exercice 1"), _code("pass")]
+        _write_nb(tmp_path / "SW-4-Ontologies.ipynb", cells)
+        _write_nb(tmp_path / "research.ipynb", cells)
+        _write_nb(tmp_path / "quantbook.ipynb", cells)
+        _write_nb(tmp_path / "Workbook-Template.ipynb", cells)
+        found = {p.name for p in iter_pedagogical_notebooks(tmp_path)}
+        assert found == {"SW-4-Ontologies.ipynb"}
+
+    def test_gate_can_still_fail_positive_control(self, tmp_path):
+        """The control that matters for any scope-NARROWING change.
+
+        Restricting what a checker looks at can quietly produce a checker that
+        cannot fail at all -- green because it inspects nothing, indistinguish-
+        able from green because everything is clean. A standard course notebook
+        below the floor must still be reported, and `--check` must still exit 1.
+        """
+        _write_nb(
+            tmp_path / "SW-4-Ontologies.ipynb",
+            [_md("## Exercice 1 : une seule"), _code("# TODO etudiant\npass")],
+        )
+        targets = iter_pedagogical_notebooks(tmp_path)
+        assert len(targets) == 1
+        assert count_exercises_in_notebook(targets[0]).count == 1
+        assert run(targets, threshold=3, json_out=False, check=True) == 1
+        # ... and conversely stays silent once the notebook conforms.
+        assert run(targets, threshold=1, json_out=False, check=True) == 0
+
+    def test_corpus_scope_reports_what_it_removed(self, tmp_path):
+        """The denominator must be reported, not merely applied.
+
+        A scope filter that silently drops material leaves the reader unable to
+        distinguish a tool that inspected everything from one that narrowed its
+        own scope -- which is the defect this change fixes, so the fix must not
+        reintroduce it one level up.
+        """
+        cells = [_md("## Exercice 1"), _code("pass")]
+        _write_nb(tmp_path / "SW-4-Ontologies.ipynb", cells)
+        _write_nb(tmp_path / "research.ipynb", cells)
+        _write_nb(tmp_path / "quantbook.ipynb", cells)
+        _write_nb(tmp_path / "Workbook-Template.ipynb", cells)
+        (tmp_path / "_archives").mkdir()
+        _write_nb(tmp_path / "_archives" / "Old-Serie-1.ipynb", cells)
+
+        corpus, removed = corpus_scope(tmp_path)
+        assert [p.name for p in corpus] == ["SW-4-Ontologies.ipynb"]
+        assert removed == {"artifact": 2, "template": 1, "archive": 1}
+        assert sum(removed.values()) + len(corpus) == 5, "every notebook accounted for"
+
+    def test_root_prefix_carries_no_classification_signal(self, tmp_path):
+        """A checkout path is not signal.
+
+        `_classify` scans path components for `_`-prefixed and legacy folders.
+        Anchoring at the scan root keeps a clone living under e.g.
+        `.../_worktrees/` or `.../legacy-box/` from classifying the entire
+        repository as archive -- which would empty the corpus, and an empty
+        corpus passes `--check` silently.
+        """
+        hostile = tmp_path / "_worktrees" / "RDF-Legacy-box"
+        hostile.mkdir(parents=True)
+        nb = _write_nb(hostile / "SW-4-Ontologies.ipynb", [_md("## Exercice 1"), _code("pass")])
+
+        assert _classify(nb, standard_threshold=3, root=hostile) == ("standard", 3)
+        corpus, removed = corpus_scope(hostile)
+        assert corpus == [nb]
+        assert removed == {}


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/security (#8808)

## Le probleme : un compteur sans notion de perimetre

`count_exercises.py --check` rapportait **168 notebooks sous le seuil** sur 931 scannes. En les ouvrant un par un : **133** sont des artefacts QuantConnect (`research.ipynb`, `quantbook.ipynb`, `output_v2.ipynb`), et la quasi-totalite du reste sont des notebooks **setup**, **Lean** ou **archive** que la regle exempte explicitement. Le residu reellement actionnable etait de **2**.

Un decompte qui melange « n'aurait jamais du etre compte » et « compte, et legitimement sous 3 » n'est pas seulement imprecis — il est **inexploitable**, donc la convention #2161 n'avait en pratique **aucun organe**. C'est la meme classe de defaut qu'un compteur nu publie sans son denominateur (#8678), qu'un gate incapable d'echouer (#8680) ou qu'un gate qui pointe a cote (#8782).

**Cause racine.** L'historique du fichier (8 commits) ne touche qu'un seul axe : la **detection** (quelles cellules comptent comme exercice — raffinee 8 fois, `## 8. Exercice`, cellules code sans header, dedup arriere #5179…). L'axe **perimetre** — quels notebooks sont au denominateur — n'a jamais ete ecrit. La regle, elle, en enonce deux :

- **(a)** quels notebooks sont du materiel de cours ;
- **(b)** quel minimum s'applique a ceux qui le sont (table d'exceptions : Setup/Environment `0-1`, Lean pur `0-2`, Archive/Legacy `0`, le reste `3`).

## Ce que fait la PR

`classify_notebook(path) -> (kind, threshold)` separe les deux. `threshold is None` = hors corpus, donc jamais sous-seuil.

| kind | traitement |
|---|---|
| `artifact` / `template` / `vendored` / `archive` / `legacy` / `tooling` / `student` | hors corpus (pas de budget d'exercices) |
| `setup` / `lean` | **dans** le corpus — c'est du materiel de cours — mais minimum **0** |
| `standard` | seuil `--threshold` (defaut 3) |

**Sur `setup`/`lean` a 0 et non 1/2.** La colonne de la table est *Minimum exercices* et les lignes exemptees lisent `0-1` et `0-2` : zero est acceptable, le chiffre haut decrit le plafond attendu, pas un plancher. Encoder 1 et 2 comme planchers inventait une politique plus stricte que la regle — et recreait le bruit a petite echelle (8 notebooks GenAI `00-*-Environment` flaggees pour une exigence dont la regle les dispense). Ces deux kinds restent **dans** le denominateur : ce sont des notebooks de cours, ils comptent comme corpus, ils ne sont juste jamais en infraction.

Le rapport imprime desormais son propre denominateur :

```
Notebooks in corpus : 778
Total exercises     : 2760
Threshold           : >= 3 for course notebooks (setup / Lean exempt -- #2161 table)
Conforming          : 776
Sub-threshold       : 2
Out of corpus       : 138 (archive=29, artifact=102, legacy=1, student=1, template=3, tooling=2)
```

**168 -> 2.** `--check` sort toujours 1. Le JSON gagne `kind`, `effective_threshold`, `in_corpus`, un `conforming` corrige, et un `out_of_corpus` de tete.

## Controle positif — le gate mord toujours

C'est le controle qui compte pour tout **retrecissement** de perimetre : restreindre ce qu'un checker regarde produit facilement un checker qui ne peut plus echouer — vert parce qu'il n'inspecte rien, indiscernable d'un vert propre. `--threshold 99` :

```
Notebooks in corpus : 778
Conforming          :  58     <- 19 setup + 39 lean (exemptes par la table)
Sub-threshold       : 720     <- 100 % des notebooks standard
```

`720 + 58 = 778`. **Chaque** notebook standard du corpus est evalue et flaggable.

## Deux corrections trouvees en mesurant, pas en supposant

**1. Un `-Legacy` dans un nom de fichier n'est pas un statut.** Ma premiere version excluait tout chemin contenant `legacy` et retirait `GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb` — une lecon **vivante** d'une serie numerotee (04-1..04-4), qui porte **4 exercices**, et dont « Legacy » nomme le *sujet* (un pattern-maker legacy). La regle ne s'applique donc plus qu'aux **repertoires** (`RDF.Net-Legacy/`). Retirer silencieusement un notebook **conforme** du denominateur est le meme defaut que d'y laisser des artefacts, en nettement plus difficile a voir. Corpus 777 -> 778.

**2. Le prefixe du checkout n'est pas du signal.** Les regles repertoire (`_`-prefixe, legacy, `groupe-`) scannaient `path.parts` **en entier**, prefixe absolu compris. Un clone vivant sous `.../_worktrees/` ou `.../legacy-box/` aurait classe **tout le depot** en archive — corpus vide, et un corpus vide passe `--check` en silence. La classification est desormais ancree a la racine scannee (`_scope_parts`). Trouve par un test dont le `tmp_path` pytest contenait par hasard la sous-chaine `legacy` : le test a echoue pour la bonne raison.

Au passage, `_display_path()` : `relative_to(REPO_ROOT)` levait sur un chemin absolu hors depot, faisant **planter** le run au lieu de l'imprimer.

## Verification

- **62 tests** dans `test_count_exercises.py` (43 existants **inchanges et verts** + 19 nouveaux) ; suite complete `scripts/notebook_tools/tests/` : **3591 passed**.
- Les nouveaux tests couvrent : stems d'artefacts (`research`, `Research`, `quantbook`, `output_v2`, `*_research_v2`, `*Repro`), templates, repertoires `_`, la **regression Cross-Stitch** (nom de fichier `-Legacy` conserve / repertoire `-Legacy/` exclu), `setup`/`lean` a 0 y compris sous `--threshold 5`, detection setup par repertoire parent (`00-GenAI-Environment/`), le filtrage de `iter_pedagogical_notebooks`, le **denominateur rapporte** (`corpus_scope`), l'**ancrage a la racine**, et le **controle positif** (un notebook standard a 1 exercice reste sous-seuil, `--check` sort 1).
- Aucun notebook touche, aucun output modifie : **0 deletion** sur `MyIA.AI.Notebooks/`. Catalogue byte-identique a `main`.

## Residu actionnable — 2 notebooks, front ICT

Les deux seuls notebooks de cours reellement sous le seuil, tous deux a **0/3** :

- `MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15c-MetaProxyObstruction.ipynb`
- `MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19b-EnjeuBattery-Raffinement.ipynb`

Ils relevent de la lane ICT (po-2025) ; je les signale plutot que de les corriger ici — cette PR est l'outil, pas le contenu. C'est desormais un residu qu'on peut traiter, ce qui n'etait pas le cas avec 168 lignes.

See #2161, #8678, #8680, #8782.
