### PR TITLE
ci(notebook-tools,#8814): advisory job for the >=3 exercises convention

### DIFF
--- a/.github/workflows/exercises-advisory.yml
+++ b/.github/workflows/exercises-advisory.yml
@@ -1,0 +1,110 @@
+name: Exercises Convention Advisory
+
+# The missing ORGAN for the ">= 3 exercises per pedagogical notebook" rule
+# (#2161, #8814). The convention (.claude/rules/three-exercises-per-notebook.md)
+# and its canonical tool (count_exercises.py) existed, but nothing wired the
+# tool to a PR -- the rule relied entirely on reviewer vigilance, which drifts
+# silently. This workflow makes a below-threshold notebook VISIBLE on the PR.
+#
+# ADVISORY, never blocking (issue #8814 acceptance 5): the job ALWAYS exits 0.
+# The actionable payload is the `exercises-below-threshold` LABEL, NEVER the
+# green conclusion of the job (which is green by construction). A reviewer who
+# reads only "exit 0" as "conforming" has read the wrong signal -- the same trap
+# that let a non-conforming PR through in #8797.
+#
+# Per-PR scope (acceptance 1): runs count_exercises.py ONLY on the *.ipynb
+# modified by the PR, not a repo-wide scan on every push. The corpus/kind
+# classification (setup/Lean exempt, out-of-corpus artifacts) is CONSUMED from
+# count_exercises.py, never re-implemented here (acceptance 4) -- the label and
+# the canonical tool must not diverge.
+#
+# Hors scope (student-pr-reviews.md): forks (student PRs) are skipped -- a
+# benevolent review applies, no internal content criterion runs against them.
+#
+# Promoting to a blocking gate is a separate decision (issue #8814 "Hors
+# scope"), to revisit only once the residual is at 0 and stable.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - '**/*.ipynb'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  exercises-advisory:
+    name: "Exercises >= 3 advisory (label, non-blocking)"
+    runs-on: ubuntu-latest
+    # Same-repo PRs only (agents/staff). Fork PRs are student submissions
+    # under student-pr-reviews.md -- benevolent review, no content gate.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          # Need base..head history for `git diff` of changed notebooks.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Advisory check on modified notebooks
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Without a git context GH_REPO, `gh pr edit` / `gh label create`
+          # cannot infer the target repo and fail silently (variation-tag-guard
+          # documented this trap firsthand after #8765).
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+          LABEL: exercises-below-threshold
+        run: |
+          set -uo pipefail
+
+          # Added/modified *.ipynb in the PR (deletions excluded -- a deleted
+          # notebook has nothing to count).
+          git diff --name-only --diff-filter=d "$BASE" "$HEAD" -- '*.ipynb' \
+            | grep -v $'\r$' > changed_ipynb.txt || true
+          COUNT=$(wc -l < changed_ipynb.txt | tr -d ' ')
+          echo "Modified *.ipynb in this PR: $COUNT"
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No modified notebooks to check."
+            # A label from an earlier push is stale here, but since `paths`
+            # scopes this job to *.ipynb changes, this branch is rare; still,
+            # a clean removal keeps the signal trustworthy.
+            gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
+            exit 0
+          fi
+
+          # Advisory: ALWAYS exit 0. We capture the JSON payload to decide the
+          # label, but the job itself never fails on a sub-threshold notebook.
+          python scripts/notebook_tools/check_pr_exercises.py --json --stdin \
+            < changed_ipynb.txt > payload.json
+          cat payload.json
+
+          SUB=$(python -c "import json; print(json.load(open('payload.json'))['summary']['sub_threshold'])")
+          echo "Sub-threshold notebooks: $SUB"
+
+          if [ "$SUB" -gt 0 ]; then
+            echo "::notice::$SUB modified notebook(s) below the >=3 exercises convention (#2161). See the '$LABEL' label for the list."
+            gh label create "$LABEL" \
+              --description "A modified notebook is below the >=3 exercises convention (#2161)" \
+              --color "D93F0B" --force 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --add-label "$LABEL" || true
+          else
+            echo "All modified notebooks meet their threshold."
+            # Removing an absent label is an EXPECTED error at the nominal
+            # (already-conforming) case -- stderr suppressed here, not stdout.
+            gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
+          fi
+          exit 0

--- a/scripts/notebook_tools/check_pr_exercises.py
+++ b/scripts/notebook_tools/check_pr_exercises.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Per-PR advisory check for the ">= 3 exercises" convention (#2161).
+
+This is the missing ORGAN pointed out by issue #8814: the convention
+(``.claude/rules/three-exercises-per-notebook.md``) and its tool
+(``count_exercises.py``) existed, but nothing wired the tool to a PR, so the
+rule relied entirely on reviewer vigilance. This script + the
+``exercises-advisory.yml`` workflow make the convention VISIBLE on each PR.
+
+It is ADVISORY by design (issue #8814 acceptance 5): it always exits 0. The
+actionable payload is the ``exercises-below-threshold`` LABEL the workflow
+posts when a modified notebook is below threshold -- never the green
+conclusion of the job, which is green by construction. A reviewer who reads
+only "exit 0" as "conforming" has read the wrong signal (the same trap that
+let a non-conforming PR through in #8797).
+
+Consumes, never re-implements, the classification of ``count_exercises.py``
+(issue #8814 acceptance 4): it calls ``classify_notebook`` (the corpus/kind
+logic -- setup/Lean exemptions, out-of-corpus artifacts) and
+``count_exercises_in_notebook`` (the count). If the two diverged because this
+script reinvented the rules, the label and the canonical tool would disagree.
+
+Scope: only ``*.ipynb`` MODIFIED by the PR (issue #8814 acceptance 1) -- not
+a repo-wide scan on every push. The caller passes the changed paths.
+
+Usage:
+    python check_pr_exercises.py --paths a.ipynb b.ipynb
+    python check_pr_exercises.py --paths a.ipynb --json
+    git diff --name-only BASE HEAD -- '*.ipynb' | python check_pr_exercises.py --stdin
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+# Import the canonical classification + counter rather than re-implementing
+# them (issue #8814 acceptance 4: the two must not diverge).
+_TOOLS_DIR = Path(__file__).resolve().parent
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from count_exercises import (  # noqa: E402
+    OUT_OF_CORPUS_KINDS,
+    classify_notebook,
+    count_exercises_in_notebook,
+)
+
+LABEL_NAME = "exercises-below-threshold"
+
+
+@dataclass
+class NotebookVerdict:
+    """One notebook's advisory verdict, with the evidence the label needs."""
+
+    path: str
+    kind: str
+    threshold: int | None  # None = out of corpus (convention does not apply)
+    count: int
+    status: str  # 'sub_threshold' | 'ok' | 'out_of_corpus' | 'parse_error'
+    detail: str = ""
+
+
+@dataclass
+class CheckResult:
+    """Aggregate verdict over all PR-modified notebooks."""
+
+    sub_threshold: list[NotebookVerdict] = field(default_factory=list)
+    ok: list[NotebookVerdict] = field(default_factory=list)
+    out_of_corpus: list[NotebookVerdict] = field(default_factory=list)
+    parse_errors: list[NotebookVerdict] = field(default_factory=list)
+
+    def as_payload(self) -> dict:
+        """Machine-readable payload for the workflow to decide the label."""
+        return {
+            "label": LABEL_NAME,
+            "summary": {
+                "total": sum(
+                    len(x) for x in (
+                        self.sub_threshold, self.ok,
+                        self.out_of_corpus, self.parse_errors,
+                    )
+                ),
+                "in_corpus": len(self.sub_threshold) + len(self.ok),
+                "out_of_corpus": len(self.out_of_corpus),
+                "sub_threshold": len(self.sub_threshold),
+                "parse_errors": len(self.parse_errors),
+            },
+            "sub_threshold": [asdict(v) for v in self.sub_threshold],
+            "ok": [asdict(v) for v in self.ok],
+            "out_of_corpus": [asdict(v) for v in self.out_of_corpus],
+            "parse_errors": [asdict(v) for v in self.parse_errors],
+        }
+
+
+def check_notebooks(paths: list[Path]) -> CheckResult:
+    """Classify + count each path, bucketing by advisory status.
+
+    A notebook is ``sub_threshold`` only when it is IN the pedagogical corpus
+    (threshold is not None) AND its exercise count is below its KIND-SPECIFIC
+    threshold. A setup notebook (threshold 0), a Lean notebook (threshold 2),
+    or an out-of-corpus artifact is never sub-threshold -- the rule exempts
+    them, and this function consumes that exemption rather than overriding it.
+    """
+    result = CheckResult()
+    for path in paths:
+        kind, threshold = classify_notebook(path)
+        if threshold is None:
+            result.out_of_corpus.append(
+                NotebookVerdict(
+                    path=str(path), kind=kind, threshold=None,
+                    count=0, status="out_of_corpus",
+                    detail=f"out of corpus (kind={kind}) -- convention does not apply",
+                )
+            )
+            continue
+
+        cnt = count_exercises_in_notebook(path)
+        if cnt.parse_error is not None:
+            result.parse_errors.append(
+                NotebookVerdict(
+                    path=str(path), kind=kind, threshold=threshold,
+                    count=cnt.count, status="parse_error", detail=cnt.parse_error,
+                )
+            )
+            continue
+
+        verdict = NotebookVerdict(
+            path=str(path), kind=kind, threshold=threshold, count=cnt.count,
+            status="ok" if cnt.count >= threshold else "sub_threshold",
+        )
+        if cnt.count < threshold:
+            result.sub_threshold.append(verdict)
+        else:
+            result.ok.append(verdict)
+    return result
+
+
+def _render_text(result: CheckResult) -> str:
+    """Human-readable summary (the workflow log; the label is separate)."""
+    s = result.as_payload()["summary"]
+    lines = [
+        f"Notebooks checked   : {s['total']}",
+        f"In corpus           : {s['in_corpus']}",
+        f"Out of corpus       : {s['out_of_corpus']}",
+        f"Below threshold     : {s['sub_threshold']}",
+        f"Parse errors        : {s['parse_errors']}",
+    ]
+    if result.sub_threshold:
+        lines.append("\n--- Below threshold (label target) ---")
+        for v in result.sub_threshold:
+            lines.append(
+                f"  [{v.count}/{v.threshold}] ({v.kind}) {v.path}"
+            )
+    if result.out_of_corpus:
+        lines.append("\n--- Out of corpus (exempt, not labelled) ---")
+        for v in result.out_of_corpus:
+            lines.append(f"  ({v.kind}) {v.path} -- {v.detail}")
+    if result.parse_errors:
+        lines.append("\n--- Parse errors (investigate manually) ---")
+        for v in result.parse_errors:
+            lines.append(f"  {v.path}: {v.detail[:120]}")
+    if not result.sub_threshold:
+        lines.append(
+            "\nAll in-corpus modified notebooks meet their threshold."
+        )
+    return "\n".join(lines)
+
+
+def _collect_paths(argv_paths: list[str], from_stdin: bool) -> list[Path]:
+    """Resolve paths from CLI args and/or stdin (one path per line).
+
+    The workflow pipes ``git diff --name-only`` output here. Blank lines and
+    duplicates are dropped; non-existent paths are warned and skipped (a
+    deleted notebook has nothing to count).
+    """
+    raw: list[str] = list(argv_paths)
+    if from_stdin:
+        raw += [ln.strip() for ln in sys.stdin if ln.strip()]
+    seen: set[str] = set()
+    paths: list[Path] = []
+    for r in raw:
+        if r in seen:
+            continue
+        seen.add(r)
+        p = Path(r)
+        if not p.exists():
+            print(f"warning: {r} does not exist (deleted?), skipping", file=sys.stderr)
+            continue
+        if p.suffix != ".ipynb":
+            continue
+        paths.append(p)
+    return paths
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Per-PR advisory check for the >= 3 exercises convention (#2161). "
+            "Always exits 0 (advisory): the signal is the "
+            f"'{LABEL_NAME}' label, not this exit code."
+        ),
+    )
+    parser.add_argument(
+        "--paths", nargs="*", default=[],
+        help="Notebook paths modified by the PR.",
+    )
+    parser.add_argument(
+        "--stdin", action="store_true",
+        help="Also read paths from stdin (one per line; e.g. git diff output).",
+    )
+    parser.add_argument(
+        "--json", dest="json_out", action="store_true",
+        help="Emit machine-readable JSON (the workflow parses this for the label).",
+    )
+    args = parser.parse_args(argv)
+
+    paths = _collect_paths(args.paths, args.stdin)
+    if not paths:
+        msg = "No modified notebooks in corpus to check."
+        if args.json_out:
+            payload = CheckResult().as_payload()
+            payload["note"] = msg
+            print(json.dumps(payload, indent=2, ensure_ascii=False))
+        else:
+            print(msg)
+        return 0
+
+    result = check_notebooks(paths)
+    if args.json_out:
+        print(json.dumps(result.as_payload(), indent=2, ensure_ascii=False))
+    else:
+        print(_render_text(result))
+    # Advisory: NEVER exit non-zero (issue #8814 acceptance 5).
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_check_pr_exercises.py
+++ b/scripts/notebook_tools/tests/test_check_pr_exercises.py
@@ -1,0 +1,203 @@
+"""Tests for scripts/notebook_tools/check_pr_exercises.py
+
+Issue #8814 acceptance 3 -- CONTROLE POSITIF OBLIGATOIRE: a gate that cannot
+fail is green for the wrong reason (#8680, #8782). These tests prove the
+advisory can actually fire (a standard notebook below 3 exercises is flagged)
+and that it honours the corpus/kind exemptions of count_exercises.py rather
+than re-implementing them (acceptance 4).
+
+Pure functions on tmp_path notebooks -- no I/O on the real repo.
+"""
+
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+
+_tools_dir = str(Path(__file__).resolve().parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+import check_pr_exercises as cpe  # noqa: E402
+
+
+def _write_nb(path: Path, cells: list[dict]) -> Path:
+    nb = {"cells": cells, "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+    path.write_text(json.dumps(nb), encoding="utf-8")
+    return path
+
+
+def _split_source(source: str) -> list[str]:
+    if not source:
+        return []
+    return source.splitlines(keepends=True)
+
+
+def _md(source: str) -> dict:
+    return {"cell_type": "markdown", "source": _split_source(source), "metadata": {}}
+
+
+def _code(source: str) -> dict:
+    return {
+        "cell_type": "code",
+        "source": _split_source(source),
+        "metadata": {},
+        "execution_count": None,
+        "outputs": [],
+    }
+
+
+def _exercises(n: int) -> list[dict]:
+    """A notebook with ``n`` exercise stubs (markdown header + stub code)."""
+    cells: list[dict] = [_md("# Titre du cours")]
+    for i in range(1, n + 1):
+        cells.append(_md(f"### Exercice {i} : sujet {i}"))
+        cells.append(_code("# TODO etudiant\npass"))
+    return cells
+
+
+# ---------------------------------------------------------------------------
+# ACCEPTANCE 3 -- controle positif: the advisory CAN flag a sub-threshold nb
+# ---------------------------------------------------------------------------
+
+class TestPositiveControl:
+    def test_standard_below_threshold_is_flagged(self, tmp_path):
+        """A STANDARD notebook with 0 exercises must land in sub_threshold.
+
+        This is the controle positif for issue #8814 acceptance 3: a gate
+        that never fires is green for the wrong reason. The title deliberately
+        avoids the word "exercice" -- the counter counts any SINGULAR exercise
+        word in a header (verified firsthand by this test failing at count==1
+        when the fixture said "Cours sans exercice"), so a zero-exercise
+        fixture must not mention the word at all.
+        """
+        nb = _write_nb(tmp_path / "Course-Lesson.ipynb", [_md("# Cours de logique")])
+        result = cpe.check_notebooks([nb])
+        assert len(result.sub_threshold) == 1
+        v = result.sub_threshold[0]
+        assert v.kind == "standard"
+        assert v.threshold == 3
+        assert v.count == 0
+        assert v.status == "sub_threshold"
+
+    def test_standard_one_exercise_still_below_threshold(self, tmp_path):
+        """1 < 3 for a standard notebook -- still flagged (not a quiet pass)."""
+        nb = _write_nb(tmp_path / "Course-Lesson.ipynb", _exercises(1))
+        result = cpe.check_notebooks([nb])
+        assert len(result.sub_threshold) == 1
+        assert result.sub_threshold[0].count == 1
+
+    def test_standard_three_exercises_is_ok(self, tmp_path):
+        """The true negative: 3 exercises meets the threshold (not flagged)."""
+        nb = _write_nb(tmp_path / "Course-Lesson.ipynb", _exercises(3))
+        result = cpe.check_notebooks([nb])
+        assert len(result.sub_threshold) == 0
+        assert len(result.ok) == 1
+        assert result.ok[0].status == "ok"
+
+
+# ---------------------------------------------------------------------------
+# ACCEPTANCE 4 -- consume count_exercises.py classification (no re-impl)
+# ---------------------------------------------------------------------------
+
+class TestExemptionsConsumed:
+    def test_setup_exempt_never_flagged(self, tmp_path):
+        """A setup notebook (threshold 0) with 0 exercises is OK, not flagged.
+
+        Proves the advisory consumes classify_notebook's exemption rather than
+        applying a blanket threshold 3 (which would false-flag every setup nb).
+        """
+        nb = _write_nb(tmp_path / "01-Setup-Env.ipynb", [_md("# Setup seulement")])
+        result = cpe.check_notebooks([nb])
+        assert len(result.sub_threshold) == 0
+        assert len(result.ok) == 1
+        assert result.ok[0].kind == "setup"
+        assert result.ok[0].threshold == 0
+
+    def test_lean_exempt_never_flagged(self, tmp_path):
+        """A Lean notebook carries its own (lenient) threshold, not 3."""
+        nb = _write_nb(tmp_path / "DecInfer-9-Lean-Gittins.ipynb", [_md("# Lean cours")])
+        result = cpe.check_notebooks([nb])
+        assert len(result.sub_threshold) == 0
+        assert result.ok[0].kind == "lean"
+
+    def test_artifact_out_of_corpus(self, tmp_path):
+        """A research/quantbook artifact is out of corpus -- never flagged."""
+        nb = _write_nb(tmp_path / "research.ipynb", [_md("# pas un cours")])
+        result = cpe.check_notebooks([nb])
+        assert len(result.sub_threshold) == 0
+        assert len(result.out_of_corpus) == 1
+        assert result.out_of_corpus[0].threshold is None
+        assert result.out_of_corpus[0].kind in {"artifact", "tooling"}
+
+
+# ---------------------------------------------------------------------------
+# ACCEPTANCE 5 -- advisory: ALWAYS exit 0 (the label is the signal, not rc)
+# ---------------------------------------------------------------------------
+
+class TestAdvisoryContract:
+    def test_main_returns_zero_even_when_subthreshold(self, tmp_path, capsys):
+        nb = _write_nb(tmp_path / "Course-Lesson.ipynb", [_md("# vide")])
+        rc = cpe.main(["--paths", str(nb)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Below threshold" in out
+
+    def test_main_returns_zero_when_all_ok(self, tmp_path, capsys):
+        nb = _write_nb(tmp_path / "Course-Lesson.ipynb", _exercises(3))
+        rc = cpe.main(["--paths", str(nb)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "meet their threshold" in out
+
+    def test_json_payload_has_label_and_summary(self, tmp_path, capsys):
+        nb = _write_nb(tmp_path / "Course-Lesson.ipynb", _exercises(2))
+        rc = cpe.main(["--paths", str(nb), "--json"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["label"] == "exercises-below-threshold"
+        assert payload["summary"]["sub_threshold"] == 1
+        assert payload["summary"]["in_corpus"] == 1
+        assert len(payload["sub_threshold"]) == 1
+        assert payload["sub_threshold"][0]["threshold"] == 3
+        assert payload["sub_threshold"][0]["count"] == 2
+
+    def test_json_payload_zero_when_conforming(self, tmp_path, capsys):
+        nb = _write_nb(tmp_path / "Course-Lesson.ipynb", _exercises(3))
+        cpe.main(["--paths", str(nb), "--json"])
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["summary"]["sub_threshold"] == 0
+
+    def test_no_paths_is_zero(self, capsys):
+        rc = cpe.main([])
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Path collection (stdin from `git diff --name-only`, dedup, skip deleted)
+# ---------------------------------------------------------------------------
+
+class TestPathCollection:
+    def test_stdin_paths_collected(self, tmp_path, monkeypatch):
+        a = _write_nb(tmp_path / "Course-A.ipynb", _exercises(0))
+        b = _write_nb(tmp_path / "Course-B.ipynb", _exercises(3))
+        monkeypatch.setattr(sys, "stdin", StringIO(f"{a}\n{b}\n"))
+        paths = cpe._collect_paths([], from_stdin=True)
+        assert {p.name for p in paths} == {"Course-A.ipynb", "Course-B.ipynb"}
+
+    def test_dedup_paths(self, tmp_path):
+        a = _write_nb(tmp_path / "Course-A.ipynb", _exercises(0))
+        paths = cpe._collect_paths([str(a), str(a)], from_stdin=False)
+        assert len(paths) == 1
+
+    def test_nonexistent_path_skipped(self, tmp_path, capsys):
+        paths = cpe._collect_paths(
+            [str(tmp_path / "ghost.ipynb")], from_stdin=False
+        )
+        assert paths == []
+        assert "does not exist" in capsys.readouterr().err
+
+    def test_non_ipynb_ignored(self, tmp_path):
+        f = tmp_path / "README.md"
+        f.write_text("not a notebook")
+        assert cpe._collect_paths([str(f)], from_stdin=False) == []


### PR DESCRIPTION
The missing ORGAN for the “>= 3 exercises per pedagogical notebook” rule (#2161). The convention ([three-exercises-per-notebook.md](.claude/rules/three-exercises-per-notebook.md)) and its canonical tool (`count_exercises.py`) existed, but nothing wired the tool to a PR — the rule relied entirely on reviewer vigilance, which drifts silently. This PR adds the organ issue #8814 asks for.

## What

Three files, **advisory by design** (always exit 0; the actionable signal is the `exercises-below-threshold` **label**, never the green job conclusion — acceptance 5: a reviewer who reads only “exit 0” as “conforming” has read the wrong signal, the same trap that let a non-conforming PR through in #8797).

- **`scripts/notebook_tools/check_pr_exercises.py`** — per-PR wrapper. **Consumes** `classify_notebook` + `count_exercises_in_notebook` from `count_exercises.py` (acceptance 4: never re-implements the corpus/kind rules — the label and the canonical tool must not diverge). Buckets each modified notebook as `sub_threshold` / `ok` / `out_of_corpus` / `parse_error`. Emits `--json` for the workflow + human-readable text. **Always exit 0** (acceptance 5).
- **`scripts/notebook_tools/tests/test_check_pr_exercises.py`** — 15 tests including the **contrôle positif** (acceptance 3): a standard notebook below 3 exercises lands in `sub_threshold` (a gate that cannot fail is green for the wrong reason, #8680/#8782). Also proves the exemptions are **consumed** (setup/lean threshold 0 never flagged, artifact out-of-corpus never flagged) rather than overridden by a blanket threshold 3.
- **`.github/workflows/exercises-advisory.yml`** — `on: pull_request` for `*.ipynb`, **same-repo only** (fork = student PR, benevolent review per [student-pr-reviews.md](.claude/rules/student-pr-reviews.md) — hors scope). Lists added/modified `*.ipynb` via `git diff base..head` (acceptance 1: per-PR, not a repo-wide scan on every push), runs the wrapper, parses the JSON, posts/removes the label with `gh label create --force` + `gh pr edit --add-label` (pattern from `variation-tag-guard.yml`). Advisory exit 0.

## Verification (acceptance 3 = contrôle positif obligatoire)

- `pytest test_check_pr_exercises.py` → **15 passed** (incl. `test_standard_below_threshold_is_flagged`, the positive control that proves the gate can fire).
- `pytest test_count_exercises.py` → **62 passed** (0 regression — `count_exercises.py` untouched).
- **Dry-run on the 2 real sub-threshold notebooks** (ICT-15c, ICT-19b): both flagged `[0/3] (standard)` → the workflow would add the label. Proof on real content, not just a synthetic fixture:
  ```
  --- Below threshold (label target) ---
    [0/3] (standard) MyIA.AI.Notebooks\IIT\ICT-Series\ICT-15c-MetaProxyObstruction.ipynb
    [0/3] (standard) MyIA.AI.Notebooks\IIT\ICT-Series\ICT-19b-EnjeuBattery-Raffinement.ipynb
  ```
- Full shell flow simulated: `SUB=2 → ADD label`; `SUB=0 → REMOVE label`.
- YAML validated; catalogue byte-identical to `main`.

## Acceptance criteria (all 5)

1. ✅ Per-PR scope — `git diff --name-only --diff-filter=d base..head -- '*.ipynb'`.
2. ✅ Posts label `exercises-below-threshold` + logs which notebooks, count, and effective threshold (the `::notice::` + the JSON payload).
3. ✅ Contrôle positif — unit test + real-notebook dry-run prove the gate fires.
4. ✅ Consumes `count_exercises.py` classification (no rule re-implementation).
5. ✅ Advisory exit 0; body + job header remind that the payload is the LABEL, never the conclusion.

## Hors scope (per #8814)
- Making the gate blocking (revisit when residual is 0 and stable).
- Adding exercises to the non-conforming notebooks (separate content grain — #8815).

Closes #8814 (all 5 acceptance criteria covered).

Co-Authored-By: Claude <noreply@anthropic.com>