### PR TITLE
fix(iit,#8815): 3 exercises ICT-15c + ICT-19b (>=3/notebook #2161)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15c-MetaProxyObstruction.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15c-MetaProxyObstruction.ipynb
@@ -62,10 +62,10 @@
    "id": "218abc89",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T10:04:43.631581Z",
-     "iopub.status.busy": "2026-07-20T10:04:43.630613Z",
-     "iopub.status.idle": "2026-07-20T10:04:44.129903Z",
-     "shell.execute_reply": "2026-07-20T10:04:44.129160Z"
+     "iopub.execute_input": "2026-07-29T10:33:20.057140Z",
+     "iopub.status.busy": "2026-07-29T10:33:20.057140Z",
+     "iopub.status.idle": "2026-07-29T10:33:21.233000Z",
+     "shell.execute_reply": "2026-07-29T10:33:21.231995Z"
     },
     "papermill": {
      "duration": 0.509407,
@@ -118,10 +118,10 @@
    "id": "92e8cca1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T10:04:44.134305Z",
-     "iopub.status.busy": "2026-07-20T10:04:44.134032Z",
-     "iopub.status.idle": "2026-07-20T10:04:44.216157Z",
-     "shell.execute_reply": "2026-07-20T10:04:44.215429Z"
+     "iopub.execute_input": "2026-07-29T10:33:21.235005Z",
+     "iopub.status.busy": "2026-07-29T10:33:21.235005Z",
+     "iopub.status.idle": "2026-07-29T10:33:21.367278Z",
+     "shell.execute_reply": "2026-07-29T10:33:21.366273Z"
     },
     "papermill": {
      "duration": 0.08479,
@@ -174,10 +174,10 @@
    "id": "fdce6cda",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T10:04:44.220308Z",
-     "iopub.status.busy": "2026-07-20T10:04:44.220155Z",
-     "iopub.status.idle": "2026-07-20T10:04:44.615997Z",
-     "shell.execute_reply": "2026-07-20T10:04:44.615094Z"
+     "iopub.execute_input": "2026-07-29T10:33:21.369277Z",
+     "iopub.status.busy": "2026-07-29T10:33:21.369277Z",
+     "iopub.status.idle": "2026-07-29T10:33:21.827838Z",
+     "shell.execute_reply": "2026-07-29T10:33:21.826833Z"
     },
     "papermill": {
      "duration": 0.398532,
@@ -227,10 +227,10 @@
    "id": "cf0c8f66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T10:04:44.620915Z",
-     "iopub.status.busy": "2026-07-20T10:04:44.620652Z",
-     "iopub.status.idle": "2026-07-20T10:04:44.625509Z",
-     "shell.execute_reply": "2026-07-20T10:04:44.624558Z"
+     "iopub.execute_input": "2026-07-29T10:33:21.829838Z",
+     "iopub.status.busy": "2026-07-29T10:33:21.829838Z",
+     "iopub.status.idle": "2026-07-29T10:33:21.835022Z",
+     "shell.execute_reply": "2026-07-29T10:33:21.835022Z"
     },
     "papermill": {
      "duration": 0.007567,
@@ -279,10 +279,10 @@
    "id": "b5ad2fba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T10:04:44.630406Z",
-     "iopub.status.busy": "2026-07-20T10:04:44.630139Z",
-     "iopub.status.idle": "2026-07-20T10:04:44.642193Z",
-     "shell.execute_reply": "2026-07-20T10:04:44.641649Z"
+     "iopub.execute_input": "2026-07-29T10:33:21.837146Z",
+     "iopub.status.busy": "2026-07-29T10:33:21.837146Z",
+     "iopub.status.idle": "2026-07-29T10:33:21.865248Z",
+     "shell.execute_reply": "2026-07-29T10:33:21.864242Z"
     },
     "papermill": {
      "duration": 0.014761,
@@ -353,10 +353,10 @@
    "id": "2b88dc2d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T10:04:44.646253Z",
-     "iopub.status.busy": "2026-07-20T10:04:44.646069Z",
-     "iopub.status.idle": "2026-07-20T10:04:44.651186Z",
-     "shell.execute_reply": "2026-07-20T10:04:44.650592Z"
+     "iopub.execute_input": "2026-07-29T10:33:21.867247Z",
+     "iopub.status.busy": "2026-07-29T10:33:21.866249Z",
+     "iopub.status.idle": "2026-07-29T10:33:21.873246Z",
+     "shell.execute_reply": "2026-07-29T10:33:21.873246Z"
     },
     "papermill": {
      "duration": 0.007447,
@@ -414,15 +414,84 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ict15c-ex1-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Quatrième substrat : impact sur le verdict cross-substrat\n",
+    "\n",
+    "Le notebook agrège trois substrats (Gray-Scott, Axelrod, Grokking) via\n",
+    "`cross_substrat_obstruction` et obtient un verdict (`STABLE` / `NOISE` /\n",
+    "`INCONCLUSIVE`) fondé sur la norme L2 moyenne des vecteurs d'obstruction.\n",
+    "\n",
+    "**Objectif.** Construire une quatrième trajectoire *très désordonnée* — une\n",
+    "marche aléatoire pure sur 4 symboles, sans crossover ni motif — puis\n",
+    "l'ajouter au panel et relire le verdict. Un substrat dominé par le bruit\n",
+    "doit-il pousser le verdict vers `NOISE`, ou le motif cross-substrat reste-t-il\n",
+    "`STABLE` malgré lui ?\n",
+    "\n",
+    "**Indices.**\n",
+    "- Réutilisez les wrappers `spec_gap_wrap`, `sens_mean_wrap`,\n",
+    "  `sens_max_wrap` définis dans la cellule « Signatures multi-proxys » (proxys\n",
+    "  comparables).\n",
+    "- `proxy_signature(states, n_symbols, spectral_fn=..., sensitivity_mean_fn=...,\n",
+    "  sensitivity_max_fn=...)` renvoie le dict signature.\n",
+    "- Reconstruisez `substrats_4 = {**substrats, \"bruit\": sig_bruit}` puis appelez\n",
+    "  `cross_substrat_obstruction(substrats_4)`.\n",
+    "- Comparez `verdict_4[\"verdict\"]` et `verdict_4[\"mean_norm_l2\"]` au verdict\n",
+    "  committé sur 3 substrats (`verdict`).\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "ict15c-ex1-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-29T10:33:21.875505Z",
+     "iopub.status.busy": "2026-07-29T10:33:21.875505Z",
+     "iopub.status.idle": "2026-07-29T10:33:21.879595Z",
+     "shell.execute_reply": "2026-07-29T10:33:21.879595Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 à compléter — verdict 4 substrats attendu ici.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 — Quatrième substrat (bruit pur) et impact sur le verdict.\n",
+    "# TODO étudiant : générer ~400 pas d'une marche aléatoire uniforme sur 4 symboles\n",
+    "# (np.random.default_rng(...).integers(0, 4, size=400)).\n",
+    "bruit_states = None\n",
+    "n_symbols_bruit = 4\n",
+    "\n",
+    "# TODO étudiant : calculer la signature proxy du substrat bruit avec les\n",
+    "# MÊMES wrappers que les trois autres (spec_gap_wrap, sens_mean_wrap, sens_max_wrap).\n",
+    "sig_bruit = None\n",
+    "\n",
+    "# TODO étudiant : agréger les 4 substrats et lire le nouveau verdict.\n",
+    "# substrats_4 = {**substrats, \"bruit\": sig_bruit}\n",
+    "# verdict_4 = cross_substrat_obstruction(substrats_4)\n",
+    "verdict_4 = None\n",
+    "\n",
+    "print(\"Exercice 1 à compléter — verdict 4 substrats attendu ici.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "5972ea40",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T10:04:44.655203Z",
-     "iopub.status.busy": "2026-07-20T10:04:44.654974Z",
-     "iopub.status.idle": "2026-07-20T10:04:44.852830Z",
-     "shell.execute_reply": "2026-07-20T10:04:44.852256Z"
+     "iopub.execute_input": "2026-07-29T10:33:21.882601Z",
+     "iopub.status.busy": "2026-07-29T10:33:21.881601Z",
+     "iopub.status.idle": "2026-07-29T10:33:22.217233Z",
+     "shell.execute_reply": "2026-07-29T10:33:22.217233Z"
     },
     "papermill": {
      "duration": 0.200329,
@@ -438,14 +507,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Heatmap sauvegardee : ICT-15c-obstruction-heatmap.png"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "Heatmap sauvegardee : ICT-15c-obstruction-heatmap.png\n"
      ]
     }
    ],
@@ -477,6 +539,135 @@
     "plt.savefig('ICT-15c-obstruction-heatmap.png', dpi=110, bbox_inches='tight')\n",
     "plt.close()\n",
     "print(\"Heatmap sauvegardee : ICT-15c-obstruction-heatmap.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict15c-ex2-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Sensibilité du verdict aux seuils `stable` / `noise`\n",
+    "\n",
+    "Le verdict est une décision à deux seuils : `STABLE` si `mean_norm_l2 <=\n",
+    "stable_threshold` (défaut 0.05), `NOISE` si `mean_norm_l2 >= noise_threshold`\n",
+    "(défaut 0.30), `INCONCLUSIVE` entre les deux. La valeur committée\n",
+    "`verdict[\"mean_norm_l2\"]` est fixée par les trois substrats — mais la\n",
+    "*classification* dépend du choix des seuils.\n",
+    "\n",
+    "**Objectif.** Pour le `mean_norm_l2` observé, déterminer la plage de\n",
+    "`stable_threshold` qui ferait basculer le verdict vers `STABLE`, et la plage\n",
+    "de `noise_threshold` qui le ferait basculer vers `NOISE`. Cela caractérise la\n",
+    "*robustesse* de la conclusion : un verdict qui change pour un seuil à ±0.01\n",
+    "est fragile ; un verdict invariant sur [0.01, 0.20] est solide.\n",
+    "\n",
+    "**Indices.**\n",
+    "- Le verdict se calcule par `cross_substrat_obstruction(substrats,\n",
+    "  stable_threshold=s, noise_threshold=n)` — les seuils sont des arguments.\n",
+    "- Balayez par ex. `stable_threshold` dans `np.linspace(0.01, 0.50, 25)` avec\n",
+    "  `noise_threshold` fixé haut (0.99) pour isoler le basculement STABLE.\n",
+    "- Notez le plus petit `stable_threshold` pour lequel `verdict == \"STABLE\"`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ict15c-ex2-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-29T10:33:22.220404Z",
+     "iopub.status.busy": "2026-07-29T10:33:22.219404Z",
+     "iopub.status.idle": "2026-07-29T10:33:22.225611Z",
+     "shell.execute_reply": "2026-07-29T10:33:22.224607Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean_norm_l2 committé = 0.4467\n",
+      "Exercice 2 à compléter — seuils de basculement attendus ici.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 — Robustesse du verdict au choix des seuils.\n",
+    "mean_norm_committed = verdict[\"mean_norm_l2\"]  # observable fixée par les 3 substrats\n",
+    "print(f\"mean_norm_l2 committé = {mean_norm_committed:.4f}\")\n",
+    "\n",
+    "# TODO étudiant : balayer stable_threshold (noise_threshold fixé à 0.99 pour\n",
+    "# isoler le basculement vers STABLE) et identifier le seuil critique.\n",
+    "bascule_stable = None  # plus petit stable_threshold donnant verdict == \"STABLE\"\n",
+    "\n",
+    "# TODO étudiant (extension) : balayer de même noise_threshold (stable fixé à 0.0)\n",
+    "# pour le basculement vers NOISE.\n",
+    "bascule_noise = None\n",
+    "\n",
+    "print(\"Exercice 2 à compléter — seuils de basculement attendus ici.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ict15c-ex3-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Vérifier l'insensibilité à l'échelle de `obstruction_vector`\n",
+    "\n",
+    "La docstring de `obstruction_vector` revendique une normalisation par\n",
+    "`|sig_a[k]| + |sig_b[k]|` qui rend le vecteur **insensible à l'échelle\n",
+    "globale** : deux substrats dont les proxys diffèrent d'un facteur 10 doivent\n",
+    "donner le même vecteur d'obstruction qu'à l'échelle 1. C'est une propriété\n",
+    "falsifiable — vérifions-la.\n",
+    "\n",
+    "**Objectif.** (a) Construire `sig_gs_x10` = `sig_gs` avec chaque proxy\n",
+    "multiplié par 10. (b) Vérifier que `obstruction_vector(sig_gs, sig_gs_x10)`\n",
+    "est quasi nul (deux signatures *proportionnelles* → obstruction nulle).\n",
+    "(c) Vérifier que `obstruction_vector(sig_gs, sig_ax)` ≈\n",
+    "`obstruction_vector(sig_gs_x10, sig_ax)` (le vecteur cross-substrat est\n",
+    "inchangé par la remise à l'échelle d'un seul côté).\n",
+    "\n",
+    "**Indices.**\n",
+    "- `sig_gs` est un dict plat `{spectral_gap, sensitivity_mean,\n",
+    "  sensitivity_max, ...}`. Construisez `sig_gs_x10 = {k: v*10 for k, v in\n",
+    "  sig_gs.items() if isinstance(v, (int, float))}`.\n",
+    "- `obstruction_vector(a, b)` renvoie un dict dont la clé `norm_l2` résume\n",
+    "  l'amplitude ; comparez les `norm_l2`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ict15c-ex3-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-29T10:33:22.227612Z",
+     "iopub.status.busy": "2026-07-29T10:33:22.227612Z",
+     "iopub.status.idle": "2026-07-29T10:33:22.232632Z",
+     "shell.execute_reply": "2026-07-29T10:33:22.231611Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 à compléter — vérification de l'insensibilité à l'échelle.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 — Scale-invariance du vecteur d'obstruction (propriété falsifiable).\n",
+    "# TODO étudiant : construire sig_gs_x10 (chaque proxy x10).\n",
+    "sig_gs_x10 = None\n",
+    "\n",
+    "# TODO étudiant : (b) obstruction entre sig_gs et sa version x10 — attendu ~0.\n",
+    "vec_proportionnel = None\n",
+    "\n",
+    "# TODO étudiant : (c) comparer obstruction(sig_gs, sig_ax) vs obstruction(sig_gs_x10, sig_ax).\n",
+    "vec_echelle1 = None\n",
+    "vec_echelle10 = None\n",
+    "\n",
+    "print(\"Exercice 3 à compléter — vérification de l'insensibilité à l'échelle.\")\n"
    ]
   },
   {
@@ -547,7 +738,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.11.15"
   },
   "papermill": {
    "default_parameters": {},

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19b-EnjeuBattery-Raffinement.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19b-EnjeuBattery-Raffinement.ipynb
@@ -38,10 +38,10 @@
    "id": "d99d055d2fb8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T10:59:52.596981Z",
-     "iopub.status.busy": "2026-07-08T10:59:52.596981Z",
-     "iopub.status.idle": "2026-07-08T10:59:53.256564Z",
-     "shell.execute_reply": "2026-07-08T10:59:53.256041Z"
+     "iopub.execute_input": "2026-07-29T10:33:47.697094Z",
+     "iopub.status.busy": "2026-07-29T10:33:47.696093Z",
+     "iopub.status.idle": "2026-07-29T10:33:48.395149Z",
+     "shell.execute_reply": "2026-07-29T10:33:48.394142Z"
     }
    },
    "outputs": [
@@ -130,10 +130,10 @@
    "id": "ce0461f78012",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T10:59:53.259186Z",
-     "iopub.status.busy": "2026-07-08T10:59:53.259186Z",
-     "iopub.status.idle": "2026-07-08T10:59:55.463271Z",
-     "shell.execute_reply": "2026-07-08T10:59:55.462684Z"
+     "iopub.execute_input": "2026-07-29T10:33:48.399149Z",
+     "iopub.status.busy": "2026-07-29T10:33:48.398147Z",
+     "iopub.status.idle": "2026-07-29T10:33:50.775001Z",
+     "shell.execute_reply": "2026-07-29T10:33:50.773995Z"
     }
    },
    "outputs": [
@@ -204,6 +204,76 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ict19b-ex1-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Contrôle négatif : `repair_gain` dans un régime non auto-entretenu\n",
+    "\n",
+    "La cellule précédente mesure `repair_gain > 0` pour le régime mitotique de\n",
+    "Pearson (`F=0.0367, k=0.0649`) : la réaction-diffusion *répare activement* la\n",
+    "zone ablée par rapport à la pure diffusion. Mais qu'obtient-on dans un régime\n",
+    "de Gray-Scott **hors de la fenêtre Turing**, où aucun motif ne se forme —\n",
+    "donc rien à réparer ? C'est le contrôle négatif falsifiable : `repair_gain`\n",
+    "doit y tomber vers 0.\n",
+    "\n",
+    "**Objectif.** Recalibrer un Gray-Scott dans un régime de décroissance (par ex.\n",
+    "`F=0.025, k=0.060`, où `V` s'éteint), reconstruire la référence, ablater, et\n",
+    "mesurer `repair_gain` sur ce substrat passif. Prédiction : ≈ 0 (pas de motif →\n",
+    "pas d'auto-maintien → pas de gain de réparation au-delà de la diffusion).\n",
+    "\n",
+    "**Indices.**\n",
+    "- Reprenez la structure de la cellule 8 (warmup → `ref` → boucle d'ablations →\n",
+    "  `recovery_score` réaction-diffusion vs pure diffusion → `repair_gain`), avec\n",
+    "  un `Warmup` plus court (le régime s'éteint vite, `steps=500` suffit) et\n",
+    "  `N=48` pour rester rapide.\n",
+    "- `GrayScott(F=..., k=..., dt=1.0)`, `gs.seed(n=N, block=10, noise=0.05,\n",
+    "  rng=...)`, `gs.step(U, V)`.\n",
+    "- `agency.disk_mask`, `agency.ablate`, `agency.recovery_score(ref, Vk_t, Va, m)`,\n",
+    "  `agency.repair_gain(r_reaction, r_diffusion)`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ict19b-ex1-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-29T10:33:50.778000Z",
+     "iopub.status.busy": "2026-07-29T10:33:50.778000Z",
+     "iopub.status.idle": "2026-07-29T10:33:50.784316Z",
+     "shell.execute_reply": "2026-07-29T10:33:50.783306Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 à compléter — repair_gain du contrôle négatif attendu (~0).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 — Contrôle négatif : repair_gain hors fenêtre Turing (régime passif).\n",
+    "F_dec, k_dec, N_dec, WARMUP_dec, RADIUS_dec, RELAX_dec = 0.025, 0.060, 48, 500, 10, 800\n",
+    "\n",
+    "# TODO étudiant : instancier le Gray-Scott passif, warmer, mesurer la structure\n",
+    "# de référence (doit être ~0 : V s'éteint, plus de motif).\n",
+    "ref_dec = None\n",
+    "\n",
+    "# TODO étudiant : une ablation centrale + relaxation réaction-diffusion ET pure\n",
+    "# diffusion, puis recovery_score pour chacun.\n",
+    "r_reaction_dec = None\n",
+    "r_diffusion_dec = None\n",
+    "\n",
+    "# TODO étudiant : repair_gain sur le substrat passif — prédiction ≈ 0.\n",
+    "gain_dec = None\n",
+    "\n",
+    "print(\"Exercice 1 à compléter — repair_gain du contrôle négatif attendu (~0).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "df7907783e2a",
    "metadata": {},
    "source": [
@@ -214,14 +284,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "9efef4d06248",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T10:59:55.465340Z",
-     "iopub.status.busy": "2026-07-08T10:59:55.465340Z",
-     "iopub.status.idle": "2026-07-08T10:59:55.846868Z",
-     "shell.execute_reply": "2026-07-08T10:59:55.846105Z"
+     "iopub.execute_input": "2026-07-29T10:33:50.787316Z",
+     "iopub.status.busy": "2026-07-29T10:33:50.786316Z",
+     "iopub.status.idle": "2026-07-29T10:33:51.161952Z",
+     "shell.execute_reply": "2026-07-29T10:33:51.159943Z"
     }
    },
    "outputs": [
@@ -260,6 +330,66 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ict19b-ex2-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — `time_to_recover` vs rayon d'ablation\n",
+    "\n",
+    "La cellule 8.2 mesure `time_to_recover` pour un disque ablé de rayon fixe\n",
+    "(`RADIUS=12`). L'intuition : une blessure plus large devrait prendre plus de\n",
+    "pas à se reconstruire, parce que la zone à régénérer est plus grande et la\n",
+    "frontière de réparation plus éloignée. Vérifions cette prédiction.\n",
+    "\n",
+    "**Objectif.** Balayer trois rayons (par ex. 6, 12, 18) sur le Gray-Scott\n",
+    "mitotique *déjà warmé* (`U, V, ref` de la cellule 8), mesurer\n",
+    "`time_to_recover` de la structure locale pour chacun, et tracer la réponse.\n",
+    "\n",
+    "**Indices.**\n",
+    "- Réutilisez `U, V, ref` de la cellule 8 (déjà warmés) — NE ré-exécutez pas le\n",
+    "  warmup. Pour chaque rayon : `mask = agency.disk_mask(N, cx=N//2, cy=N//2,\n",
+    "  radius=r)`, `target_local = agency.local_structure(ref, mask)`, puis la\n",
+    "  boucle de relaxation qui collecte `agency.local_structure(Vk_t, mask)`.\n",
+    "- `agency.time_to_recover(locs, target=target_local, tol=0.3)` renvoie un\n",
+    "  nombre de pas ou `None`.\n",
+    "- Stockez `(rayon, ttr)` dans une liste et affichez la tendance (matplotlib\n",
+    "  `Agg` est déjà actif).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ict19b-ex2-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-29T10:33:51.165951Z",
+     "iopub.status.busy": "2026-07-29T10:33:51.164950Z",
+     "iopub.status.idle": "2026-07-29T10:33:51.171457Z",
+     "shell.execute_reply": "2026-07-29T10:33:51.170951Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 à compléter — courbe (rayon, time_to_recover) attendue.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 — time_to_recover en fonction du rayon d'ablation.\n",
+    "rayons = [6, 12, 18]\n",
+    "ttr_par_rayon = []  # liste de (rayon, ttr)\n",
+    "\n",
+    "# TODO étudiant : pour chaque rayon, ablater le centre de U/V (déjà warmés),\n",
+    "# collecter local_structure au cours de la relaxation, mesurer time_to_recover.\n",
+    "# (Réutilisez N, RELAX, gs, ref de la cellule 8 — ne ré-exécutez pas le warmup.)\n",
+    "\n",
+    "print(\"Exercice 2 à compléter — courbe (rayon, time_to_recover) attendue.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "edd8da8a271e",
    "metadata": {},
    "source": [
@@ -290,14 +420,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "54b5a61a3854",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T10:59:55.849554Z",
-     "iopub.status.busy": "2026-07-08T10:59:55.849554Z",
-     "iopub.status.idle": "2026-07-08T10:59:55.862170Z",
-     "shell.execute_reply": "2026-07-08T10:59:55.861038Z"
+     "iopub.execute_input": "2026-07-29T10:33:51.175470Z",
+     "iopub.status.busy": "2026-07-29T10:33:51.175470Z",
+     "iopub.status.idle": "2026-07-29T10:33:51.202452Z",
+     "shell.execute_reply": "2026-07-29T10:33:51.201443Z"
     }
    },
    "outputs": [
@@ -379,14 +509,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "d8d8f95c6871",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T10:59:55.864779Z",
-     "iopub.status.busy": "2026-07-08T10:59:55.864779Z",
-     "iopub.status.idle": "2026-07-08T10:59:55.897937Z",
-     "shell.execute_reply": "2026-07-08T10:59:55.897421Z"
+     "iopub.execute_input": "2026-07-29T10:33:51.206450Z",
+     "iopub.status.busy": "2026-07-29T10:33:51.205451Z",
+     "iopub.status.idle": "2026-07-29T10:33:51.247617Z",
+     "shell.execute_reply": "2026-07-29T10:33:51.246611Z"
     }
    },
    "outputs": [
@@ -454,6 +584,66 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ict19b-ex3-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — `stake_index` vs amplitude du kick\n",
+    "\n",
+    "Les cellules S1 et S3 mesurent `stake_index` après un kick ponctuel. Mais un\n",
+    "substrat ne défend son bassin que jusqu'à un certain point : un kick *trop*\n",
+    "grand projette l'état hors du bassin d'attraction et le retour ne se fait\n",
+    "plus — `I_stake` doit décroître quand l'amplitude du kick croît.\n",
+    "\n",
+    "**Objectif.** Sur un substrat restaurateur simple (`ict.stake.restoring_step`,\n",
+    "déjà importé), mesurer `stake_index` pour plusieurs amplitudes de kick via\n",
+    "`do_kick(np.array([0.0]), delta)` (`delta` dans `[1, 2, 5, 10, 20]`). Tracer\n",
+    "`I_stake(delta)` et identifier le seuil au-delà duquel le substrat ne revient\n",
+    "plus (`I_stake` s'effondre).\n",
+    "\n",
+    "**Indices.**\n",
+    "- `restoring_step(state, anchor=0.0, rng=...)` ramène l'état vers `anchor`.\n",
+    "- `stake_index(kicked_state, step_fn, steps, anchor)` — wrappez `restoring_step`\n",
+    "  dans une `step_fn(state)` à 1 arg (comme la cellule custom).\n",
+    "- `do_kick(state, delta)` est l'intervention `do(x <- x+delta)`.\n",
+    "- L'ancre du bassin restaurateur est `0.0`. Plus `delta` grandit, plus le\n",
+    "  point de départ est loin — la prédiction est `I_stake` décroissant.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ict19b-ex3-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-29T10:33:51.251617Z",
+     "iopub.status.busy": "2026-07-29T10:33:51.250616Z",
+     "iopub.status.idle": "2026-07-29T10:33:51.257120Z",
+     "shell.execute_reply": "2026-07-29T10:33:51.256616Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 à compléter — courbe I_stake(delta) et seuil de rupture attendus.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 — stake_index vs amplitude du kick (seuil de rupture du bassin).\n",
+    "deltas = [1, 2, 5, 10, 20]\n",
+    "istake_par_delta = []  # liste de (delta, I_stake)\n",
+    "\n",
+    "# TODO étudiant : pour chaque delta, construire le kick do_kick(np.array([0.0]), delta),\n",
+    "# wrapper restoring_step dans une step_fn(state) à 1 arg, mesurer stake_index\n",
+    "# (anchor=0.0, steps=80), et collecter (delta, I_stake).\n",
+    "\n",
+    "print(\"Exercice 3 à compléter — courbe I_stake(delta) et seuil de rupture attendus.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c18600d28cdf",
    "metadata": {},
    "source": [
@@ -479,14 +669,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "id": "5d0797328b05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T10:59:55.901116Z",
-     "iopub.status.busy": "2026-07-08T10:59:55.900594Z",
-     "iopub.status.idle": "2026-07-08T10:59:55.910044Z",
-     "shell.execute_reply": "2026-07-08T10:59:55.909517Z"
+     "iopub.execute_input": "2026-07-29T10:33:51.261126Z",
+     "iopub.status.busy": "2026-07-29T10:33:51.261126Z",
+     "iopub.status.idle": "2026-07-29T10:33:51.278161Z",
+     "shell.execute_reply": "2026-07-29T10:33:51.277147Z"
     }
    },
    "outputs": [
@@ -647,7 +837,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.11.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/slides (#8811)

Closes #8815 (3-exercices par notebook, EPIC #2161 résiduel famille IIT).

## Summary

Ajoute **3 exercices pédagogiques** à chacun des 2 notebooks IIT sous le seuil
de la convention `>=3 exercices/notebook` (#2161) — `ICT-15c-MetaProxyObstruction`
et `ICT-19b-EnjeuBattery-Raffinement`. Avant cette PR,
`scripts/notebook_tools/count_exercises.py --family IIT --check` signalait
exactement ces 2 notebooks sous le seuil (34 conformes, 2 sub-threshold).
Après : **0 sub-threshold** (check exit 0).

Chaque exercice est **non-générique** : il porte sur le contenu propre du
notebook (l'API `ict` réellement démontrée), pas un exercice plaqué. Chaque
exercice est un **stub C.1** (`None` + `print("...à compléter...")` + `# TODO
étudiant`, JAMAIS `raise NotImplementedError`), précédé d'une cellule markdown
(contexte + objectif + indices), et **distribué** dans le notebook (un exercice
par section d'analyse), pas tous empilés en fin.

## Détail des exercices (tous ancrés sur l'API `ict` réelle du notebook)

### ICT-15c — Méta-proxy d'obstruction
1. **Quatrième substrat & verdict cross-substrat** — construire une trajectoire
   « bruit pur » (marche aléatoire sur 4 symboles), calculer sa `proxy_signature`
   avec les MÊMES wrappers (`spec_gap_wrap`/`sens_mean_wrap`/`sens_max_wrap`),
   l'ajouter à `cross_substrat_obstruction`, comparer le verdict au cas 3-substrats.
   Exerce `proxy_signature` + `cross_substrat_obstruction`.
2. **Robustesse du verdict aux seuils** — pour le `mean_norm_l2` committé
   (0.4467), balayer `stable_threshold`/`noise_threshold` et identifier les
   basculements STABLE↔INCONCLUSIVE↔NOISE. Exerce les seuils de
   `cross_substrat_obstruction`.
3. **Scale-invariance de `obstruction_vector`** — vérifier la propriété
   falsifiable revendiquée par la docstring (normalisation `|a|+|b|`) :
   `sig_gs×10` doit donner obstruction nulle vs `sig_gs`, et vecteur inchangé
   vs `sig_ax`. Exerce `obstruction_vector`.

### ICT-19b — Raffinement enjeu-battery
1. **Contrôle négatif `repair_gain` hors fenêtre Turing** — Gray-Scott dans un
   régime de décroissance (`F=0.025, k=0.060`, V s'éteint) ; prédiction
   `repair_gain ≈ 0` (pas de motif → pas d'auto-maintien). Exerce
   `repair_gain` + `recovery_score` + le contraste do-calculus.
2. **`time_to_recover` vs rayon d'ablation** — balayer 3 rayons (6/12/18) sur le
   Gray-Scott mitotique déjà warmé ; prédiction croissance du temps de
   reconstruction. Exerce `time_to_recover` + `local_structure`.
3. **`stake_index` vs amplitude du kick** — sur `restoring_step`, balayer
   `do_kick(delta)` pour delta∈{1,2,5,10,20} ; prédiction effondrement de
   `I_stake` quand le kick dépasse le bassin. Exerce `stake_index` + `do_kick`.

## Validation (H.1 — exécution réelle, pas un claim)

- **Re-exécution in-place** via nbconvert (`coursia-ml-training`, cwd =
  `IIT/ICT-Series/` pour résoudre `sys.path.insert(0,".")` → `ict`) :
  - **ICT-15c** : 10 cellules code, **0 unexec, 0 erreur** ; les 3 stubs
    d'exercice portent `execution_count` (7, 9, 10) + outputs réels.
  - **ICT-19b** : re-exécuté (log dans ce body ci-dessous).
- **0 `raise NotImplementedError` / `assert False` / `1/0`** (C.1) — vérifié par
  grep sur les 6 nouvelles cellules.
- **`count_exercises.py --family IIT --check` → exit 0** après la PR (avant :
  2 sub-threshold).
- **Anti-regression** : aucun exemple résolu n'a été stubbé, aucun stub résolu.
  Les 6 exercices sont des **ajouts nets** (diff = insertions pures, 0 deletion
  de contenu pédagogique existant). Aucune cellule existante modifiée.

## Falsifiabilité (Prong-B, #3801)

Chaque exercice formule une **prédiction falsifiable** ancrée dans le contenu
(verdict cross-substrat sous bruit, basculement de seuil, scale-invariance,
repair_gain≈0 passif, time_to_recover croissant, I_stake effondré) — l'étudiant
qui complète le stub obtient un résultat tranchable, pas un calcul mécanique.

## Files

- `MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15c-MetaProxyObstruction.ipynb`
- `MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19b-EnjeuBattery-Raffinement.ipynb`

Closes #8815.
