### PR TITLE
fix(ci,#8819): exercises advisory -- an unread notebook is NOT conforming

### DIFF
--- a/.github/workflows/exercises-advisory.yml
+++ b/.github/workflows/exercises-advisory.yml
@@ -111,6 +111,25 @@ jobs:
           ensure_label "$LABEL_UNPARSEABLE" \
             "A modified notebook could not be parsed -- NOT verified (#8819)" "BFD4F2"
 
+          # Review #8820 (Blocage 3): if check_pr_exercises.py died (truncated
+          # JSON, ImportError, OOM), payload.json is unreadable, the two
+          # python -c above fail, and SUB/PARSE are not integers. With only
+          # `set -uo pipefail` (no -e), each `[ "" -gt 0 ]` below exits rc=2 --
+          # which falls into the else branch, UNSETS both labels, and asserts
+          # verified conformity on a measurement that never happened. That is
+          # this PR's own defect (#8819) one layer down: #8816 said "all meet
+          # threshold" when ONE notebook was unreadable; this branch would say
+          # "all meet threshold (verified)" when NOTHING was read. `[ "$x" -eq
+          # "$x" ]` succeeds only for an integer, so its negation is true when
+          # the payload is illisible. NOT measured => NOT verified: pose the
+          # unparseable label and a loud ::error::, never a green claim.
+          if ! [ "${SUB:-}" -eq "${SUB:-}" ] 2>/dev/null \
+             || ! [ "${PARSE:-}" -eq "${PARSE:-}" ] 2>/dev/null; then
+            echo "::error::exercises payload illisible (check_pr_exercises.py produced no usable JSON) -- the gate measured NOTHING; conformity neither claimed nor denied."
+            set_label "$LABEL_UNPARSEABLE"
+            exit 0
+          fi
+
           if [ "$SUB" -gt 0 ]; then
             echo "::notice::$SUB modified notebook(s) below the >=3 exercises convention (#2161). See the '$LABEL_BELOW' label."
             set_label "$LABEL_BELOW"

--- a/.github/workflows/exercises-advisory.yml
+++ b/.github/workflows/exercises-advisory.yml
@@ -66,7 +66,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
-          LABEL: exercises-below-threshold
+          LABEL_BELOW: exercises-below-threshold
+          LABEL_UNPARSEABLE: exercises-unparseable
         run: |
           set -uo pipefail
 
@@ -77,34 +78,61 @@ jobs:
           COUNT=$(wc -l < changed_ipynb.txt | tr -d ' ')
           echo "Modified *.ipynb in this PR: $COUNT"
 
+          # Helper: ensure a label exists (idempotent), then add/remove it.
+          ensure_label() {
+            gh label create "$1" --description "$2" --color "$3" --force 2>/dev/null || true
+          }
+          set_label() { gh pr edit "$PR_NUMBER" --add-label "$1" || true; }
+          unset_label() { gh pr edit "$PR_NUMBER" --remove-label "$1" 2>/dev/null || true; }
+
           if [ "$COUNT" -eq 0 ]; then
             echo "No modified notebooks to check."
-            # A label from an earlier push is stale here, but since `paths`
-            # scopes this job to *.ipynb changes, this branch is rare; still,
-            # a clean removal keeps the signal trustworthy.
-            gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
+            unset_label "$LABEL_BELOW"; unset_label "$LABEL_UNPARSEABLE"
             exit 0
           fi
 
-          # Advisory: ALWAYS exit 0. We capture the JSON payload to decide the
-          # label, but the job itself never fails on a sub-threshold notebook.
+          # Advisory: ALWAYS exit 0. The job never fails; the actionable signal
+          # is the pair of LABELS decided from the JSON payload below.
           python scripts/notebook_tools/check_pr_exercises.py --json --stdin \
             < changed_ipynb.txt > payload.json
           cat payload.json
 
-          SUB=$(python -c "import json; print(json.load(open('payload.json'))['summary']['sub_threshold'])")
-          echo "Sub-threshold notebooks: $SUB"
+          SUB=$(python -c "import json; print(json.load(open('payload.json'))['summary']['below_threshold'])")
+          PARSE=$(python -c "import json; print(json.load(open('payload.json'))['summary']['unverified'])")
+          echo "Below-threshold notebooks: $SUB"
+          echo "Unverified (parse errors): $PARSE"
+
+          # Issue #8819: TWO distinct labels. "Could not measure" (unparseable)
+          # and "measured, below threshold" call for different reactions, so they
+          # never collapse into one. Each label is raised when its count > 0 and
+          # cleared otherwise (a stale label from an earlier push must not stick).
+          ensure_label "$LABEL_BELOW" \
+            "A modified notebook is below the >=3 exercises convention (#2161)" "D93F0B"
+          ensure_label "$LABEL_UNPARSEABLE" \
+            "A modified notebook could not be parsed -- NOT verified (#8819)" "BFD4F2"
 
           if [ "$SUB" -gt 0 ]; then
-            echo "::notice::$SUB modified notebook(s) below the >=3 exercises convention (#2161). See the '$LABEL' label for the list."
-            gh label create "$LABEL" \
-              --description "A modified notebook is below the >=3 exercises convention (#2161)" \
-              --color "D93F0B" --force 2>/dev/null || true
-            gh pr edit "$PR_NUMBER" --add-label "$LABEL" || true
+            echo "::notice::$SUB modified notebook(s) below the >=3 exercises convention (#2161). See the '$LABEL_BELOW' label."
+            set_label "$LABEL_BELOW"
           else
-            echo "All modified notebooks meet their threshold."
-            # Removing an absent label is an EXPECTED error at the nominal
-            # (already-conforming) case -- stderr suppressed here, not stdout.
-            gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
+            unset_label "$LABEL_BELOW"
+          fi
+
+          if [ "$PARSE" -gt 0 ]; then
+            echo "::warning::$PARSE modified notebook(s) could not be parsed -- NOT verified by the exercises gate (#8819). See the '$LABEL_UNPARSEABLE' label."
+            set_label "$LABEL_UNPARSEABLE"
+          else
+            unset_label "$LABEL_UNPARSEABLE"
+          fi
+
+          # The closing line asserts ONLY what was measured (issue #8819). The
+          # job never claims "all conform" while unverified > 0 -- that was the
+          # original defect (a gate that reassures while the true state sleeps).
+          if [ "$PARSE" -gt 0 ]; then
+            echo "RESULT: $PARSE notebook(s) NOT verified (parse error) -- conformity neither claimed nor denied."
+          elif [ "$SUB" -gt 0 ]; then
+            echo "RESULT: $SUB notebook(s) below threshold -- labelled."
+          else
+            echo "RESULT: all in-corpus modified notebooks meet their threshold (verified)."
           fi
           exit 0

--- a/scripts/notebook_tools/check_pr_exercises.py
+++ b/scripts/notebook_tools/check_pr_exercises.py
@@ -50,6 +50,12 @@ from count_exercises import (  # noqa: E402
 )
 
 LABEL_NAME = "exercises-below-threshold"
+# A SECOND, distinct label for notebooks the checker could NOT READ (issue #8819).
+# "I could not measure" and "I measured, it is below threshold" are two different
+# states calling for two different reactions, so they get two different labels --
+# collapsing them into one would re-create the very defect #8819 fixes (a gate
+# whose official signal reassures while the true state sleeps in the log).
+LABEL_UNPARSEABLE = "exercises-unparseable"
 
 
 @dataclass
@@ -74,20 +80,38 @@ class CheckResult:
     parse_errors: list[NotebookVerdict] = field(default_factory=list)
 
     def as_payload(self) -> dict:
-        """Machine-readable payload for the workflow to decide the label."""
+        """Machine-readable payload for the workflow to decide the labels.
+
+        Issue #8819: a notebook the checker could not read is NOT conforming --
+        it is UNVERIFIED. The summary therefore exposes ``unverified`` (parse
+        errors) at the top, and the payload carries TWO labels: one for
+        "measured, below threshold" (below_threshold) and one for "could not
+        measure" (unparseable). The workflow raises each when its count is > 0,
+        and crucially never claims "all conform" while ``unverified > 0``.
+        """
+        n_sub = len(self.sub_threshold)
+        n_parse = len(self.parse_errors)
+        n_ok = len(self.ok)
+        n_out = len(self.out_of_corpus)
         return {
-            "label": LABEL_NAME,
+            "labels": {
+                "below_threshold": {"name": LABEL_NAME, "count": n_sub},
+                "unparseable": {"name": LABEL_UNPARSEABLE, "count": n_parse},
+            },
             "summary": {
-                "total": sum(
-                    len(x) for x in (
-                        self.sub_threshold, self.ok,
-                        self.out_of_corpus, self.parse_errors,
-                    )
-                ),
-                "in_corpus": len(self.sub_threshold) + len(self.ok),
-                "out_of_corpus": len(self.out_of_corpus),
-                "sub_threshold": len(self.sub_threshold),
-                "parse_errors": len(self.parse_errors),
+                # unverified FIRST (issue #8819 criterion 4): a glance at the
+                # payload makes the gap obvious without arithmetic. A gate that
+                # claims more than it measured is the defect class #8819 fixes.
+                "unverified": n_parse,
+                "total": n_sub + n_ok + n_out + n_parse,
+                # in_corpus counts everything the convention COULD apply to,
+                # including unparseable ones -- an unread notebook is still in
+                # the corpus, just not measured.
+                "in_corpus": n_sub + n_ok + n_parse,
+                "out_of_corpus": n_out,
+                "below_threshold": n_sub,
+                "sub_threshold": n_sub,  # kept alias for readability
+                "parse_errors": n_parse,
             },
             "sub_threshold": [asdict(v) for v in self.sub_threshold],
             "ok": [asdict(v) for v in self.ok],
@@ -140,17 +164,25 @@ def check_notebooks(paths: list[Path]) -> CheckResult:
 
 
 def _render_text(result: CheckResult) -> str:
-    """Human-readable summary (the workflow log; the label is separate)."""
+    """Human-readable summary (the workflow log; the labels are separate).
+
+    Issue #8819 criterion 2: the closing line asserts ONLY what was measured.
+    ``All ... meet their threshold`` is conditional on ``parse_errors == 0`` --
+    otherwise the honest statement is "N could not be parsed -- NOT verified",
+    never a blanket claim of conformity over notebooks the checker never read.
+    """
     s = result.as_payload()["summary"]
     lines = [
         f"Notebooks checked   : {s['total']}",
         f"In corpus           : {s['in_corpus']}",
         f"Out of corpus       : {s['out_of_corpus']}",
-        f"Below threshold     : {s['sub_threshold']}",
-        f"Parse errors        : {s['parse_errors']}",
+        f"Below threshold     : {s['below_threshold']}",
+        f"Unverified (parse)  : {s['unverified']}",
     ]
     if result.sub_threshold:
-        lines.append("\n--- Below threshold (label target) ---")
+        lines.append(
+            f"\n--- Below threshold (label: {LABEL_NAME}) ---"
+        )
         for v in result.sub_threshold:
             lines.append(
                 f"  [{v.count}/{v.threshold}] ({v.kind}) {v.path}"
@@ -160,10 +192,18 @@ def _render_text(result: CheckResult) -> str:
         for v in result.out_of_corpus:
             lines.append(f"  ({v.kind}) {v.path} -- {v.detail}")
     if result.parse_errors:
-        lines.append("\n--- Parse errors (investigate manually) ---")
+        lines.append(
+            f"\n--- Unverified: could not parse (label: {LABEL_UNPARSEABLE}) ---"
+        )
         for v in result.parse_errors:
             lines.append(f"  {v.path}: {v.detail[:120]}")
-    if not result.sub_threshold:
+    # Criterion 2: assert only what was measured. A parse error means we did
+    # NOT measure that notebook, so "all meet threshold" would be a false claim.
+    if s["unverified"] > 0:
+        lines.append(
+            f"\n{s['unverified']} notebook(s) could not be parsed -- NOT verified."
+        )
+    elif not result.sub_threshold:
         lines.append(
             "\nAll in-corpus modified notebooks meet their threshold."
         )

--- a/scripts/notebook_tools/tests/fixtures/corrupt-control-positive.ipynb
+++ b/scripts/notebook_tools/tests/fixtures/corrupt-control-positive.ipynb
@@ -1,1 +1,0 @@
-{ this is deliberately invalid JSON : control-positive for #8819 }

--- a/scripts/notebook_tools/tests/fixtures/corrupt-control-positive.ipynb
+++ b/scripts/notebook_tools/tests/fixtures/corrupt-control-positive.ipynb
@@ -1,0 +1,1 @@
+{ this is deliberately invalid JSON : control-positive for #8819 }

--- a/scripts/notebook_tools/tests/test_check_pr_exercises.py
+++ b/scripts/notebook_tools/tests/test_check_pr_exercises.py
@@ -155,8 +155,11 @@ class TestAdvisoryContract:
         rc = cpe.main(["--paths", str(nb), "--json"])
         assert rc == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["label"] == "exercises-below-threshold"
-        assert payload["summary"]["sub_threshold"] == 1
+        # Two distinct labels (#8819): below_threshold + unparseable.
+        assert payload["labels"]["below_threshold"]["name"] == "exercises-below-threshold"
+        assert payload["labels"]["unparseable"]["name"] == "exercises-unparseable"
+        assert payload["summary"]["below_threshold"] == 1
+        assert payload["summary"]["unverified"] == 0
         assert payload["summary"]["in_corpus"] == 1
         assert len(payload["sub_threshold"]) == 1
         assert payload["sub_threshold"][0]["threshold"] == 3
@@ -166,11 +169,92 @@ class TestAdvisoryContract:
         nb = _write_nb(tmp_path / "Course-Lesson.ipynb", _exercises(3))
         cpe.main(["--paths", str(nb), "--json"])
         payload = json.loads(capsys.readouterr().out)
-        assert payload["summary"]["sub_threshold"] == 0
+        assert payload["summary"]["below_threshold"] == 0
+        assert payload["summary"]["unverified"] == 0
 
     def test_no_paths_is_zero(self, capsys):
         rc = cpe.main([])
         assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# ACCEPTANCE 3 (#8819) -- controle positif: an UNREAD notebook is NOT conforming
+# ---------------------------------------------------------------------------
+
+class TestParseErrorNotConforming:
+    """Issue #8819: a notebook the checker could not read must NOT pass silently.
+
+    This is the defect the follow-up fixes: a corrupt notebook landed in
+    parse_errors, summary.sub_threshold stayed 0, and the workflow claimed
+    conformity over a notebook it never measured. The controle positif proves
+    the gate now raises a SEPARATE label for the unverified case and refuses
+    to assert "all conform".
+    """
+
+    def test_corrupt_notebook_lands_in_parse_errors_not_subthreshold(self, tmp_path):
+        """A corrupt .ipynb is unverified, not conforming."""
+        (tmp_path / "Course-Lesson.ipynb").write_text(
+            "{ this is not valid json ", encoding="utf-8"
+        )
+        nb = tmp_path / "Course-Lesson.ipynb"
+        result = cpe.check_notebooks([nb])
+        assert len(result.parse_errors) == 1
+        assert len(result.sub_threshold) == 0
+        assert result.parse_errors[0].status == "parse_error"
+
+    def test_corrupt_notebook_raises_unverified_label_count(self, tmp_path, capsys):
+        """The JSON payload exposes unverified > 0 so the workflow raises a label.
+
+        Before #8819: unverified notebooks were invisible to the label decision
+        (sub_threshold=0 -> "all conform"). Now unverified is the FIRST summary
+        key and its count drives the `exercises-unparseable` label.
+        """
+        (tmp_path / "Course-Lesson.ipynb").write_text(
+            "not json at all", encoding="utf-8"
+        )
+        cpe.main(["--paths", str(tmp_path / "Course-Lesson.ipynb"), "--json"])
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["summary"]["unverified"] == 1
+        assert payload["summary"]["below_threshold"] == 0
+        assert payload["labels"]["unparseable"]["count"] == 1
+
+    def test_text_output_does_not_claim_conformity_when_unverified(self, tmp_path, capsys):
+        """Critère 2: the closing line must NOT say 'all meet threshold' when a
+        notebook is unverified -- that was the original false-claim defect."""
+        (tmp_path / "Course-Lesson.ipynb").write_text(
+            "broken {", encoding="utf-8"
+        )
+        cpe.main(["--paths", str(tmp_path / "Course-Lesson.ipynb")])
+        out = capsys.readouterr().out
+        assert "NOT verified" in out
+        assert "meet their threshold" not in out
+
+    def test_corrupt_notebook_still_exits_zero(self, tmp_path, capsys):
+        """Advisory contract preserved: unverified raises a label, never a red job."""
+        (tmp_path / "Course-Lesson.ipynb").write_text(
+            "broken", encoding="utf-8"
+        )
+        rc = cpe.main(["--paths", str(tmp_path / "Course-Lesson.ipynb")])
+        assert rc == 0
+
+    def test_in_corpus_counts_unverified(self, tmp_path, capsys):
+        """An unparseable notebook IS in the corpus (just unread), so in_corpus
+        must count it -- not silently drop it from the denominator."""
+        (tmp_path / "Course-Lesson.ipynb").write_text(
+            "broken", encoding="utf-8"
+        )
+        cpe.main(["--paths", str(tmp_path / "Course-Lesson.ipynb"), "--json"])
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["summary"]["in_corpus"] == 1
+
+    def test_subthreshold_and_parse_error_coexist_distinctly(self, tmp_path):
+        """A PR with one below-threshold notebook AND one corrupt one raises BOTH
+        labels -- they are independent states, never collapsed."""
+        good_below = _write_nb(tmp_path / "Course-Below.ipynb", _exercises(1))
+        (tmp_path / "Course-Broken.ipynb").write_text("broken", encoding="utf-8")
+        result = cpe.check_notebooks([good_below, tmp_path / "Course-Broken.ipynb"])
+        assert len(result.sub_threshold) == 1
+        assert len(result.parse_errors) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Defect found by the user **while merging #8816** (the exercises advisory organ of #2161). The gate decided the label on `summary.sub_threshold` ALONE. A notebook the checker could NOT read lands in `parse_errors` (not `sub_threshold`), so `sub_threshold` stayed 0 and the workflow:
- **removed** the label, and
- printed **“All modified notebooks meet their threshold”**

…over a notebook it never measured. A gate whose official signal reassures while the true state sleeps in the log is the defect class #8816 set out to fight, returned one notch lower — in the gate’s own output sentence.

## Reproduced firsthand on origin/main
```
Course-Lesson.ipynb (corrupt) -> {sub_threshold:0, parse_errors:1} -> "All meet threshold"  (FALSE)
```

## The four #8819 criteria — all covered

**1. A second, distinct label `exercises-unparseable`.** “Could not measure” and “measured, below threshold” are different states calling for different reactions — collapsing them into one would re-create the defect. The workflow now raises each label on its own count and clears the other.

**2. The closing line asserts ONLY what was measured.** “All … meet threshold” is now conditional on `unverified == 0`; otherwise “N could not be parsed — NOT verified”. Never a blanket conformity claim over unread notebooks.

**3. Contrôle positif — CI proof (captured).** A deliberately corrupt `.ipynb` was committed on this branch to drive the live advisory job. The CI **posted `exercises-unparseable`** on the PR (run [30445544911](https://github.com/jsboige/CoursIA/actions/runs/30445544911)), with the decision log:
```
Modified *.ipynb in this PR: 3
Below-threshold notebooks: 0
Unverified (parse errors): 1
RESULT: 1 notebook(s) NOT verified (parse error) -- conformity neither claimed nor denied.
```
The file was then removed (final diff below = clean, 3 files, code only). Plus 6 new unit tests, incl. `test_corrupt_notebook_raises_unverified_label_count` and `test_text_output_does_not_claim_conformity_when_unverified`.

**4. JSON payload exposes `unverified` (= parse errors) as the FIRST summary key**, so a glance at the payload makes the gap obvious without arithmetic. Also fixes a counting bug: `in_corpus` now counts unparseable notebooks (they ARE in the corpus, just unread) instead of silently dropping them from the denominator.

## Verification
- `pytest test_check_pr_exercises.py`: **21 passed** (15 prior + 6 new #8819).
- `pytest test_count_exercises.py`: **62 passed** (0 regression — `count_exercises.py` untouched).
- Dry-run on a real corrupt notebook: `unverified=1` → “NOT verified” + `exercises-unparseable` label + `in_corpus=1`.
- **CI live**: advisory job posted `exercises-unparseable` on the corrupt-file push (captured above), `Scripts Tests (CPU)` = SUCCESS on the clean final diff.
- YAML validated; catalogue byte-identical to `main`.

## Scope
Fixes the defect in the #8816 advisory. Final diff = 3 files (module + workflow + tests), `+191/−39`.

Closes #8819 (all 4 criteria covered).

See #8816, #8814, #2161, #8678, #8680, #8782, #8807.

Co-Authored-By: Claude <noreply@anthropic.com>