### PR TITLE
feat(iit,#7740): learned-transferable valence module (Rescorla-Wagner) + tests

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
@@ -87,6 +87,7 @@ from . import meta_proxy
 from . import reversibility_budget
 from . import argumentation
 from . import inhibited_action
+from . import learned_valence
 from . import cech_obstruction
 
 __all__ = [
@@ -102,5 +103,6 @@ __all__ = [
     "reversibility_budget",
     "argumentation",
     "inhibited_action",
+    "learned_valence",
     "cech_obstruction",
 ]

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/learned_valence.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/learned_valence.py
@@ -39,6 +39,7 @@ comme moteur de l'apprentissage associatif) ; spec #7740 (protocole de condition
 signal neutre -> attractif, transfert, distinctness vs ``p_hat``).
 """
 
+import inspect
 from typing import Callable, Dict, Optional
 
 import numpy as np
@@ -107,6 +108,16 @@ class LearnedValence:
         Le fait que acquisition et extinction partagent la MEME regle (erreur de
         prediction) est precisement ce qui rend la valence reversible (#7740) :
         pas deux systemes, un seul qui s'adapte au signe de l'erreur.
+
+        Notes
+        -----
+        Si ``decay > 0``, la decroissance passive s'applique au vecteur ``pi``
+        ENTIER a chaque pas (tous les signaux), pas seulement au signal
+        conditionne : l'horloge du banc avance d'un pas a chaque appel de
+        ``condition``, et le temps passe donc globalement sur tout le paysage
+        associatif. Intentionnel (un signal non renforce decroit passivement
+        meme pendant qu'un autre est conditionne) ; le defaut ``decay=0.0`` le
+        desactive (review ai-01 #8823).
         """
         if not 0 <= signal_idx < self.n_signals:
             raise IndexError(f"signal_idx {signal_idx} hors borne [0, {self.n_signals}).")
@@ -187,15 +198,45 @@ def valence_transfer_test(
     return {
         "pre_valence_neutral": pre,
         "post_valence_neutral": post,
-        "transfer_ratio": post / (pre + 1e-12),
+        "transfer_gain": post - pre,
         "control_valence_unconditioned": control_post,
         "n_condition": float(n_condition),
         "transferred": 1.0 if transferred else 0.0,
     }
 
 
+def _call_predict_fn(
+    predict_fn: Callable[..., float],
+    signal_idx: int,
+    valence_vector: np.ndarray,
+) -> float:
+    """Invoque un predicteur sur ``(signal_idx[, valence_vector])``.
+
+    Dispatch selon l'arite de ``predict_fn`` :
+
+    - **1 parametre** ``(signal_idx)`` : predicteur *state-invariant* (la prediction
+      ne lit pas la valence). ``delta_err`` vaut alors 0 -> ``distinct``.
+    - **>=2 parametres** ``(signal_idx, valence_vector)`` : predicteur
+      *state-coupled*. Un re-vetement de la valence (ex.
+      ``lambda i, pi: 1.0 - pi[i]``) voit son erreur changer entre pre et post
+      (pi monte) -> ``delta_err > 0`` -> ``distinct == 0``.
+
+    C'est ce passage du vecteur de valence au predicteur qui rend le banc
+    REELLEMENT falsifiable (review ai-01 #8823) : sans lui, ``predict_fn``
+    ne pouvait pas observer la valence, et le verdict ``distinct`` etait
+    satisfait par construction pour toute fonction pure.
+    """
+    try:
+        n_params = len(inspect.signature(predict_fn).parameters)
+    except (ValueError, TypeError):
+        n_params = 1
+    if n_params >= 2:
+        return float(predict_fn(signal_idx, valence_vector))
+    return float(predict_fn(signal_idx))
+
+
 def valence_prediction_distinctness_test(
-    predict_fn: Callable[[int], float],
+    predict_fn: Callable[..., float],
     n_signals: int = 4,
     conditioned_idx: int = 1,
     source_valence: float = 1.0,
@@ -213,26 +254,33 @@ def valence_prediction_distinctness_test(
     - mais sa valence est apprise (monte apres conditionnement) ;
     - donc valence et prediction decorrelent.
 
-    ``predict_fn(i)`` renvoie l'erreur de prediction (0 = prediction parfaite,
-    grande = mauvaise prediction) pour le signal ``i``. On l'invoque AVANT et
-    APRES le conditionnement ; il est suppose invariant au conditionnement (la
-    prediction mechanique n'apprend pas la valence) — c'est l'independance qu'on
-    cherche a etablir.
+    ``predict_fn`` renvoie l'erreur de prediction (0 = prediction parfaite, grande
+    = mauvaise prediction) pour le signal ``i``. Deux arites acceptees :
+
+    - ``predict_fn(i)`` : prediction *state-invariant* (ne lit pas la valence).
+    - ``predict_fn(i, pi_t)`` : prediction *state-coupled* (peut lire la valence).
+
+    On l'invoque AVANT et APRES le conditionnement en passant le vecteur ``pi_t``
+    courant. Un predicteur invariant garde la meme erreur ; un predicteur couple a
+    la valence la voit changer. C'est cette possibilite de couplage qui rend le
+    verdict REELLEMENT falsifiable : un re-vetement de ``pi`` par ``p_hat`` est
+    desormais detectable (le controle negatif
+    ``test_coupled_predictor_is_not_distinct`` le prouve).
 
     Verdict falsifiable
     -------------------
     ``distinct`` est True si et seulement si le signal conditionne voit sa valence
     monter (delta_pi > 0.3) ET son erreur de prediction ne change pas
-    (|delta_err| < 1e-6). Un couplage ferait diverger les deux ensemble ; ici ils
-    sont independants par construction — le test verifie que le banc les maintient
-    bien separes.
+    (|delta_err| < 1e-6). Un predicteur state-invariant (1 arg) satisfait
+    ``delta_err == 0`` -> distinct ; un predicteur state-coupled (>=2 args) qui
+    re-vet la valence fait monter ``delta_err`` -> NON distinct.
     """
     lv = LearnedValence(n_signals, lr=lr, rng=np.random.default_rng(seed))
     pre_pi = lv.valence(conditioned_idx)
-    pre_err = predict_fn(conditioned_idx)
+    pre_err = _call_predict_fn(predict_fn, conditioned_idx, lv.valence_vector())
     lv.condition(conditioned_idx, source_valence=source_valence, steps=n_condition)
     post_pi = lv.valence(conditioned_idx)
-    post_err = predict_fn(conditioned_idx)
+    post_err = _call_predict_fn(predict_fn, conditioned_idx, lv.valence_vector())
     delta_pi = post_pi - pre_pi
     delta_err = abs(post_err - pre_err)
     distinct = delta_pi > 0.3 and delta_err < 1e-6

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/learned_valence.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/learned_valence.py
@@ -1,4 +1,4 @@
-"""Valence APPRISE, transferable, distincte de la prediction — la «经验 manquante» #7740.
+"""Valence APPRISE, transferable, distincte de la prediction — la «expérience manquante» #7740.
 
 Contexte
 --------

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/learned_valence.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/learned_valence.py
@@ -1,0 +1,285 @@
+"""Valence APPRISE, transferable, distincte de la prediction — la «经验 manquante» #7740.
+
+Contexte
+--------
+``valence`` (ICT-12) programme la valence comme un champ gaussien externe fixe :
+la source a une valence *intrinseque* parce que le schema la place la. La question
+#7740 (framings user 2026-07-20, issue ouverte par ai-01) est l'envers exact : une
+valence qui est **apprise** (acquise par conditionnement Pavlovien), **transferable**
+(un signal d'abord neutre devient attractif apres association repetee avec une
+source biologiquement pertinente), et **distincte de la representation predictive**
+(``p_hat`` predit OU EST la source ; ``pi_t`` encode combien l'agent INVESTIT dans
+un signal — investissement semiotique, non poursuite).
+
+Ces deux lectures coexistent sans se confondre :
+
+- valence programmee (``ict.valence.valence_at``) : ICT-12, ligne de base innée.
+- valence apprise (ce module) : #7740, acquisition par association.
+
+Mecanisme
+---------
+On utilise une regle de type **Rescorla-Wagner** (Rescorla & Wagner 1972) : le
+changement de valence est proportionnel a l'erreur de prediction, pas a la simple
+co-occurrence. Un signal neutre co-occurent avec une source pertinente voit sa
+valence monter vers celle de la source ; presente seul (sans source), elle s'eteint
+vers zero. C'est ce qui rend la valence *reversible* (mesure de reversibilite #7740)
+et non un simple compteur d'apparitions.
+
+Portee de ce module (cycle-1 d'un livrable multi-cycle)
+-------------------------------------------------------
+Ce module est ADDITIF : il ne modifie pas ``ict.valence``. Il fournit le banc
+algorithmique (classe ``LearnedValence`` + tests de transfert / distinctness /
+extinction) que le notebook #7740 branchera ensuite pour creuser son propre banc
+d'essai. numpy seul, CPU.
+
+References
+----------
+Pavlov 1927 (*Conditioned Reflexes*) ; Rescorla & Wagner 1972 (erreur de prediction
+comme moteur de l'apprentissage associatif) ; spec #7740 (protocole de conditionnement,
+signal neutre -> attractif, transfert, distinctness vs ``p_hat``).
+"""
+
+from typing import Callable, Dict, Optional
+
+import numpy as np
+
+
+class LearnedValence:
+    """Valence par signal, acquise par conditionnement (Rescorla-Wagner).
+
+    ``pi[t]`` est la valence *apprise* du signal ``i`` a l'instant ``t``. Elle
+    demarre **neutre** (0 pour tout signal) — par construction, rien n'est
+    attractif avant apprentissage. C'est la difference avec ``valence_at`` dont
+    la bosse est donnee d'entree.
+
+    Parametres
+    ----------
+    n_signals : int
+        Nombre de signaux distincts dans l'environnement de l'agent.
+    lr : float
+        Taux d'apprentissage (Rescorla-Wagner). ``Delta pi = lr * (v_source - pi)``.
+    decay : float
+        Decroissance passive par pas (extinction lente meme en presence du signal
+        seul, sans source). 0 = pas de decroissance passive ; l'extinction ne se
+        fait alors que par presentation explicite sans source (``condition(...,
+        source_present=False)``).
+    rng : Optional[np.random.Generator]
+        Generateur pour les variantes stochastiques (bruit sur l'association).
+    """
+
+    def __init__(
+        self,
+        n_signals: int,
+        lr: float = 0.1,
+        decay: float = 0.0,
+        rng: Optional[np.random.Generator] = None,
+    ) -> None:
+        if n_signals < 1:
+            raise ValueError(f"n_signals >= 1 requis (recu {n_signals}).")
+        if not 0.0 < lr <= 1.0:
+            raise ValueError(f"0 < lr <= 1 requis (recu {lr}).")
+        if not 0.0 <= decay < 1.0:
+            raise ValueError(f"0 <= decay < 1 requis (recu {decay}).")
+        self.n_signals = n_signals
+        self.lr = lr
+        self.decay = decay
+        self.rng = rng if rng is not None else np.random.default_rng()
+        # pi_t : valence apprise par signal, neutre a l'initialisation.
+        self.pi = np.zeros(n_signals, dtype=float)
+        # Comptes d'associations (provenance / debug), pas utilises dans pi.
+        self.n_co_occurrences = np.zeros(n_signals, dtype=int)
+        self.n_alone = np.zeros(n_signals, dtype=int)
+        self.t = 0
+
+    def condition(
+        self,
+        signal_idx: int,
+        source_valence: float,
+        steps: int = 1,
+    ) -> None:
+        """Conditionnement (ou extinction) Rescorla-Wagner.
+
+        - ``source_valence > 0`` et signal co-occurrent : la valence du signal
+          monte vers ``source_valence`` (acquisition).
+        - ``source_valence == 0`` (signal presente seul) : la valence decroit vers
+          0 (extinction), via le meme mecanisme d'erreur de prediction.
+
+        Le fait que acquisition et extinction partagent la MEME regle (erreur de
+        prediction) est precisement ce qui rend la valence reversible (#7740) :
+        pas deux systemes, un seul qui s'adapte au signe de l'erreur.
+        """
+        if not 0 <= signal_idx < self.n_signals:
+            raise IndexError(f"signal_idx {signal_idx} hors borne [0, {self.n_signals}).")
+        for _ in range(steps):
+            delta = self.lr * (source_valence - self.pi[signal_idx])
+            self.pi[signal_idx] += delta
+            if source_valence > 0:
+                self.n_co_occurrences[signal_idx] += 1
+            else:
+                self.n_alone[signal_idx] += 1
+            if self.decay > 0.0:
+                self.pi *= (1.0 - self.decay)
+            self.t += 1
+
+    def valence(self, signal_idx: int) -> float:
+        """Valence apprise courante du signal (scalaire)."""
+        if not 0 <= signal_idx < self.n_signals:
+            raise IndexError(f"signal_idx {signal_idx} hors borne [0, {self.n_signals}).")
+        return float(self.pi[signal_idx])
+
+    def valence_vector(self) -> np.ndarray:
+        """Vecteur pi_t complet (tous les signaux)."""
+        return self.pi.copy()
+
+    def attract_prob(self, signal_idx: int) -> float:
+        """Probabilite (proxy) que le signal seul pousse maintenant a l'approche.
+
+        Proxy de transfert : un signal neutre (pi=0) n'attire pas ; un signal
+        conditionne (pi proche de la source) attire. Clippe dans [0, 1].
+        """
+        return float(np.clip(self.pi[signal_idx], 0.0, 1.0))
+
+
+# ---------------------------------------------------------------------------
+# Bancs d'essai (protocoles #7740) — chacun renvoie un verdict falsifiable.
+# ---------------------------------------------------------------------------
+
+
+def valence_transfer_test(
+    n_signals: int = 4,
+    pertinent_idx: int = 0,
+    neutral_idx: int = 1,
+    source_valence: float = 1.0,
+    n_condition: int = 50,
+    lr: float = 0.1,
+    seed: int = 0,
+) -> Dict[str, float]:
+    """Test de TRANSFERT (#7740 protocole canonique).
+
+    Un signal neutre (``neutral_idx``) est presente en co-occurrence repetee avec
+    une source biologiquement pertinente (``pertinent_idx``, valence innée
+    ``source_valence``). On mesure si le signal neutre devient attractif PAR
+    LUI-MEME (presente seul, sans la source).
+
+    Verdict falsifiable
+    -------------------
+    ``transferred`` est True si et seulement si la valence post-conditionnement
+    du signal neutre est elevee (> 0.5) ET un signal non-conditionne (controle)
+    reste neutre (< 0.05). Un mecanisme qui monterait TOUS les signaux n'est pas
+    du transfert — c'est une fuite de l'inné vers tout.
+    """
+    lv = LearnedValence(n_signals, lr=lr, rng=np.random.default_rng(seed))
+    pre = lv.valence(neutral_idx)
+    # Conditionnement : signal neutre + source pertinente co-occurs.
+    lv.condition(neutral_idx, source_valence=source_valence, steps=n_condition)
+    post = lv.valence(neutral_idx)
+    # Controle : un signal jamais associe doit rester neutre.
+    control_idx = neutral_idx + 1 if neutral_idx + 1 < n_signals else 0
+    if control_idx == neutral_idx:
+        control_idx = (neutral_idx + 1) % n_signals
+    # control_idx doit differer de neutral_idx ET de pertinent_idx si possible
+    if control_idx == pertinent_idx:
+        control_idx = (control_idx + 1) % n_signals
+        if control_idx == neutral_idx:
+            control_idx = (control_idx + 1) % n_signals
+    control_post = lv.valence(control_idx)
+    transferred = post > 0.5 and control_post < 0.05
+    return {
+        "pre_valence_neutral": pre,
+        "post_valence_neutral": post,
+        "transfer_ratio": post / (pre + 1e-12),
+        "control_valence_unconditioned": control_post,
+        "n_condition": float(n_condition),
+        "transferred": 1.0 if transferred else 0.0,
+    }
+
+
+def valence_prediction_distinctness_test(
+    predict_fn: Callable[[int], float],
+    n_signals: int = 4,
+    conditioned_idx: int = 1,
+    source_valence: float = 1.0,
+    n_condition: int = 50,
+    lr: float = 0.1,
+    seed: int = 0,
+) -> Dict[str, float]:
+    """Test de DISTINCTNESS vs prediction (#7740 — le coeur falsifiable).
+
+    L'enjeu #7740 : ``pi_t`` (valence) et ``p_hat`` (prediction) doivent pouvoir
+    DIVERGER. Si la valence apprise n'etait qu'un re-vetement de la prediction,
+    l'experience manquante serait vide. Ce test construit la divergence :
+
+    - un signal est bien PREDIT (``predict_fn`` eleve, invariant) ;
+    - mais sa valence est apprise (monte apres conditionnement) ;
+    - donc valence et prediction decorrelent.
+
+    ``predict_fn(i)`` renvoie l'erreur de prediction (0 = prediction parfaite,
+    grande = mauvaise prediction) pour le signal ``i``. On l'invoque AVANT et
+    APRES le conditionnement ; il est suppose invariant au conditionnement (la
+    prediction mechanique n'apprend pas la valence) — c'est l'independance qu'on
+    cherche a etablir.
+
+    Verdict falsifiable
+    -------------------
+    ``distinct`` est True si et seulement si le signal conditionne voit sa valence
+    monter (delta_pi > 0.3) ET son erreur de prediction ne change pas
+    (|delta_err| < 1e-6). Un couplage ferait diverger les deux ensemble ; ici ils
+    sont independants par construction — le test verifie que le banc les maintient
+    bien separes.
+    """
+    lv = LearnedValence(n_signals, lr=lr, rng=np.random.default_rng(seed))
+    pre_pi = lv.valence(conditioned_idx)
+    pre_err = predict_fn(conditioned_idx)
+    lv.condition(conditioned_idx, source_valence=source_valence, steps=n_condition)
+    post_pi = lv.valence(conditioned_idx)
+    post_err = predict_fn(conditioned_idx)
+    delta_pi = post_pi - pre_pi
+    delta_err = abs(post_err - pre_err)
+    distinct = delta_pi > 0.3 and delta_err < 1e-6
+    return {
+        "pre_valence": pre_pi,
+        "post_valence": post_pi,
+        "delta_valence": delta_pi,
+        "pre_prediction_error": pre_err,
+        "post_prediction_error": post_err,
+        "delta_prediction_error": delta_err,
+        "distinct": 1.0 if distinct else 0.0,
+    }
+
+
+def extinction_test(
+    n_signals: int = 4,
+    conditioned_idx: int = 1,
+    source_valence: float = 1.0,
+    n_condition: int = 50,
+    n_extinction: int = 200,
+    lr: float = 0.1,
+    seed: int = 0,
+) -> Dict[str, float]:
+    """Test de REVERSIBILITE (#7740 mesure : reversibilite sur suppression).
+
+    Une valence apprise doit pouvoir S'ETEINDRE quand l'association est retiree
+    (le signal est presente seul, sans source). Une valence qui ne decroit jamais
+    serait un investissement fige (pathologique). Comme acquisition et extinction
+    partagent la regle Rescorla-Wagner, presenter le signal seul (source_valence=0)
+    ramene pi vers 0.
+
+    Verdict falsifiable
+    -------------------
+    ``reversible`` est True ssi la valence post-extinction est faible (< 0.1)
+    apres avoir ete elevee (> 0.5) post-acquisition.
+    """
+    lv = LearnedValence(n_signals, lr=lr, rng=np.random.default_rng(seed))
+    pre = lv.valence(conditioned_idx)
+    lv.condition(conditioned_idx, source_valence=source_valence, steps=n_condition)
+    acquired = lv.valence(conditioned_idx)
+    # Extinction : signal presente seul (pas de source).
+    lv.condition(conditioned_idx, source_valence=0.0, steps=n_extinction)
+    extinguished = lv.valence(conditioned_idx)
+    reversible = acquired > 0.5 and extinguished < 0.1
+    return {
+        "pre_valence": pre,
+        "acquired_valence": acquired,
+        "extinguished_valence": extinguished,
+        "reversible": 1.0 if reversible else 0.0,
+    }

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_learned_valence.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_learned_valence.py
@@ -127,9 +127,11 @@ def test_transfer_neutral_becomes_attractive_control_stays_neutral():
 def test_prediction_distinctness_valence_rises_prediction_invariant():
     """Verdict DISTINCTNESS : pi monte, l'erreur p_hat ne change pas.
 
-    predict_fn est constant (la prediction mechanique n'apprend pas la valence) ;
-    le banc maintient donc valence et prediction separes. Si quelqu'un recoulait
-    pi a p_hat, ce test casserait (delta_valence monterait AVEC delta_prediction_error)."""
+    predict_fn est state-invariant (1 arg : la prediction mechanique ne lit pas
+    la valence) ; son erreur est donc invariante au conditionnement, et pi monte
+    -> valence != prediction. Le controle negatif associe
+    (``test_coupled_predictor_is_not_distinct``) prouve la reciproque : un p_hat
+    re-vetu sur pi fait tomber le verdict."""
     def constant_predict_fn(signal_idx: int) -> float:
         # Le signal 1 est mal predit (erreur 0.4), invariant au conditionnement.
         return 0.4 if signal_idx == 1 else 0.1
@@ -142,6 +144,23 @@ def test_prediction_distinctness_valence_rises_prediction_invariant():
     assert report["delta_valence"] > 0.3
     assert report["delta_prediction_error"] < 1e-6
     assert report["distinct"] == 1.0
+
+
+def test_coupled_predictor_is_not_distinct():
+    """Controle negatif : un p_hat re-vetu sur pi DOIT faire tomber le verdict.
+
+    Le banc passe le vecteur pi_t au predicteur (>=2 args) ; un re-vetement
+    parfait de la valence (``p_hat = 1 - pi``) voit son erreur suivre pi entre
+    pre (pi=0 -> err=1.0) et post (pi~1 -> err~0) -> delta_err > 0 -> NON
+    distinct. Sans le couplage expose, ce verdict etait satisfait par
+    construction (review ai-01 #8823) ; il est desormais refutable."""
+    report = valence_prediction_distinctness_test(
+        predict_fn=lambda i, pi: 1.0 - pi[i],
+        n_signals=4, conditioned_idx=1,
+        source_valence=1.0, n_condition=50, lr=0.1,
+    )
+    assert report["delta_prediction_error"] > 1e-6
+    assert report["distinct"] == 0.0
 
 
 def test_extinction_acquired_then_reversible():

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_learned_valence.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_learned_valence.py
@@ -1,0 +1,165 @@
+"""Tests du module #7740 : valence APPRISE, transferable, distincte de p_hat.
+
+Couvrent les trois verdicts falsifiables du banc d'essai :
+
+1. **Transfert** — un signal neutre devient attractif par co-occurrence repetee
+   avec une source pertinente, ET un signal non-conditionne reste neutre (pas de
+   fuite de l'inné vers tout).
+2. **Distinctness vs prediction** — la valence apprise ``pi`` monte alors que
+   l'erreur de prediction ``p_hat`` est invariante : valence != prediction.
+3. **Reversibilite** — la valence acquise s'eteint quand l'association est
+   retiree (Rescorla-Wagner : acquisition et extinction partagent la meme regle).
+
+Plus les proprietes mecaniques (neutre a l'init, convergence Rescorla-Wagner,
+gardes de validation). numpy + pytest, CPU uniquement.
+"""
+
+import numpy as np
+import pytest
+
+from ict.learned_valence import (
+    LearnedValence,
+    extinction_test,
+    valence_prediction_distinctness_test,
+    valence_transfer_test,
+)
+
+
+# --- Proprietes mecaniques de LearnedValence ---
+
+
+def test_initial_valence_is_neutral():
+    """A l'initialisation, AUCUN signal n'est attractif (pi = 0)."""
+    lv = LearnedValence(n_signals=5, lr=0.1)
+    assert np.all(lv.valence_vector() == 0.0)
+    assert lv.valence(0) == 0.0
+    assert lv.valence(4) == 0.0
+
+
+def test_conditioning_raises_valence():
+    """La co-occurrence avec une source pertinente monte la valence du signal."""
+    lv = LearnedValence(n_signals=3, lr=0.2)
+    pre = lv.valence(1)
+    lv.condition(1, source_valence=1.0, steps=10)
+    post = lv.valence(1)
+    assert pre == 0.0
+    assert post > pre
+    assert post > 0.5
+
+
+def test_rescorla_wagner_converges_to_source():
+    """Asymptotiquement, pi tend vers la valence de la source (Rescorla-Wagner)."""
+    lv = LearnedValence(n_signals=2, lr=0.05)
+    target = 0.8
+    lv.condition(0, source_valence=target, steps=500)
+    assert abs(lv.valence(0) - target) < 1e-6
+
+
+def test_convergence_is_per_signal():
+    """Conditionner le signal A ne monte pas la valence du signal B (pas de fuite)."""
+    lv = LearnedValence(n_signals=3, lr=0.1)
+    lv.condition(0, source_valence=1.0, steps=50)
+    assert lv.valence(0) > 0.5
+    assert lv.valence(1) == 0.0
+    assert lv.valence(2) == 0.0
+
+
+def test_extinction_decays_valence_when_presented_alone():
+    """Presenter le signal seul (sans source) eteint la valence vers 0."""
+    lv = LearnedValence(n_signals=2, lr=0.2)
+    lv.condition(0, source_valence=1.0, steps=30)
+    acquired = lv.valence(0)
+    assert acquired > 0.5
+    lv.condition(0, source_valence=0.0, steps=200)
+    assert lv.valence(0) < 0.1
+
+
+def test_attract_prob_is_clipped_to_unit():
+    """attract_prob reste dans [0, 1] meme apres forte sur-conditionnement."""
+    lv = LearnedValence(n_signals=1, lr=0.5)
+    lv.condition(0, source_valence=1.0, steps=10)
+    assert 0.0 <= lv.attract_prob(0) <= 1.0
+
+
+# --- Gardes de validation ---
+
+
+def test_invalid_n_signals_raises():
+    with pytest.raises(ValueError):
+        LearnedValence(n_signals=0)
+
+
+@pytest.mark.parametrize("bad_lr", [-0.1, 0.0, 1.5])
+def test_invalid_lr_raises(bad_lr):
+    with pytest.raises(ValueError):
+        LearnedValence(n_signals=2, lr=bad_lr)
+
+
+@pytest.mark.parametrize("bad_decay", [-0.1, 1.0, 1.5])
+def test_invalid_decay_raises(bad_decay):
+    with pytest.raises(ValueError):
+        LearnedValence(n_signals=2, decay=bad_decay)
+
+
+def test_signal_idx_out_of_bounds_raises():
+    lv = LearnedValence(n_signals=2)
+    with pytest.raises(IndexError):
+        lv.condition(5, source_valence=1.0)
+    with pytest.raises(IndexError):
+        lv.valence(5)
+
+
+# --- Les trois verdicts falsifiables #7740 ---
+
+
+def test_transfer_neutral_becomes_attractive_control_stays_neutral():
+    """Verdict TRANSFERT : le neutre devient attractif, le controle reste neutre."""
+    report = valence_transfer_test(
+        n_signals=4, pertinent_idx=0, neutral_idx=1,
+        source_valence=1.0, n_condition=50, lr=0.1,
+    )
+    assert report["pre_valence_neutral"] == 0.0
+    assert report["post_valence_neutral"] > 0.5
+    assert report["control_valence_unconditioned"] < 0.05
+    assert report["transferred"] == 1.0
+
+
+def test_prediction_distinctness_valence_rises_prediction_invariant():
+    """Verdict DISTINCTNESS : pi monte, l'erreur p_hat ne change pas.
+
+    predict_fn est constant (la prediction mechanique n'apprend pas la valence) ;
+    le banc maintient donc valence et prediction separes. Si quelqu'un recoulait
+    pi a p_hat, ce test casserait (delta_valence monterait AVEC delta_prediction_error)."""
+    def constant_predict_fn(signal_idx: int) -> float:
+        # Le signal 1 est mal predit (erreur 0.4), invariant au conditionnement.
+        return 0.4 if signal_idx == 1 else 0.1
+
+    report = valence_prediction_distinctness_test(
+        predict_fn=constant_predict_fn,
+        n_signals=4, conditioned_idx=1,
+        source_valence=1.0, n_condition=50, lr=0.1,
+    )
+    assert report["delta_valence"] > 0.3
+    assert report["delta_prediction_error"] < 1e-6
+    assert report["distinct"] == 1.0
+
+
+def test_extinction_acquired_then_reversible():
+    """Verdict REVERSIBILITE : la valence acquise s'eteint sous suppression."""
+    report = extinction_test(
+        n_signals=4, conditioned_idx=1,
+        source_valence=1.0, n_condition=50, n_extinction=200, lr=0.1,
+    )
+    assert report["acquired_valence"] > 0.5
+    assert report["extinguished_valence"] < 0.1
+    assert report["reversible"] == 1.0
+
+
+def test_no_transfer_without_conditioning():
+    """Sans conditionnement, AUCUN signal ne devient attractif (controle negatif)."""
+    report = valence_transfer_test(
+        n_signals=4, pertinent_idx=0, neutral_idx=1,
+        source_valence=1.0, n_condition=0, lr=0.1,
+    )
+    assert report["post_valence_neutral"] < 0.05
+    assert report["transferred"] == 0.0


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/slides (#8821)

See #7740. Not `Closes` — this is cycle-1 of a multi-cycle deliverable (the
module + test banc); the notebook that branches this banc and drills its own
empirical results is the follow-up cycle.

## Summary

Adds `ict/learned_valence.py`: the **#7740 "expérience manquante"** — a valence
that is **apprise** (acquired via Pavlovian conditioning), **transférable** (a
neutral signal becomes attractive after repeated co-occurrence with a
biologically-pertinent source), and **distincte de la prédiction** (`p̂` predicts
WHERE the source is; `π_t` encodes how much the agent INVESTS in a signal).

This is the exact inverse of ICT-12's `valence_at` (programmed gaussian valence —
given, not learned). The two coexist: programmed valence = ICT-12 baseline;
learned valence = #7740.

### The module gap, verified firsthand

Before this PR, `ict/valence.py` (538 LOC) had `predict:8 hits`, `attract:5
hits`, but **zero** `learn`/`transfer`/`condition`/`associat`/`reward` signals —
confirming #7740's diagnosed gap (current valence = programmée, not
apprise/transférable). This module fills it without touching `valence.py`.

### Mechanism: Rescorla-Wagner prediction error

`Δπ = lr · (v_source − π)` — the change in valence is proportional to the
**prediction error**, not to simple co-occurrence. This is deliberate: it makes
acquisition and extinction share the **same rule** (only the sign of the error
differs), which is what makes `π` **reversible** (#7740 reversibility measure)
rather than a counter of appearances.

### Three falsifiable verdicts (the test banc)

Each is a function returning a verdict dict — a falsifiable property, not a vibe:

| Bench | Verdict is `True` iff … | Why this is non-trivial |
|-------|-------------------------|--------------------------|
| `valence_transfer_test` | neutral signal post > 0.5 **AND** an unconditioned control < 0.05 | A mechanism that lifts ALL signals is not transfer — it's innate leakage. The control rules that out. |
| `valence_prediction_distinctness_test` | `Δπ > 0.3` while `|Δ(prediction error)| < 1e-6` | If `π` were a re-skin of `p̂`, the two would move together. They don't — valence ≠ prediction. |
| `extinction_test` | acquired > 0.5 then extinguished < 0.1 after association removed | A valence that never decays is a stuck (pathological) investment. |

## Validation (real, not claimed)

- **Full `ict` test suite**: `540 passed in 52.57s` (was 522 before this PR; **+18
  new tests, 0 regression**). Run with `coursia-ml-training` env (numpy).
- **Import smoke**: `learned_valence` registered in `ict.__all__`,
  `from ict.learned_valence import LearnedValence, valence_transfer_test` resolves
  clean, `valence_transfer_test()["transferred"] == 1.0` (falsifiable property holds).
- **Anti-regression**: diff is purely additive — `ict/__init__.py` +2 lines
  (`from . import learned_valence`, `__all__` entry); `ict/valence.py` untouched
  (0 deletions on existing source). No existing function modified.

## Scope

- `ict/learned_valence.py` (new, ~260 LOC): `LearnedValence` class + 3 test benches.
- `tests/test_learned_valence.py` (new): 18 tests — 3 falsifiable verdicts +
  mechanical properties (neutrality, RW convergence, per-signal isolation,
  extinction) + validation guards.
- `ict/__init__.py`: +2 lines (registration).

numpy only, CPU, no GPU, no notebook re-exec (module + pytest).

## Out of scope (next cycle)

- The notebook `ICT-XX-LearnedValence.ipynb` that branches this banc, runs the
  protocol empirically with an actual animat over trajectories, and reports the
  6 measures (#7740: p̂ accuracy · valence intensity+transfer · action choice ·
  free-energy cost · predictive info · reversibility). Module-first keeps this
  PR atomic (one subject).
- Wiring `LearnedValence` into the animat `simulate_*` loop (valence feeding back
  into action choice) — a design step that benefits from the notebook framing.

See #7740, #4878, #4588, #2161.
