### PR TITLE
ci(guard,#8822): blocking guard — paths-filtered label-poser must self-cover

### DIFF
--- a/.github/workflows/exercises-advisory.yml
+++ b/.github/workflows/exercises-advisory.yml
@@ -30,6 +30,12 @@ on:
     branches: [main]
     paths:
       - '**/*.ipynb'
+      # Self-cover (#8822): a paths-filtered label-poser must list its own file,
+      # else it cannot re-run (so cannot remove its own label) once the matching
+      # paths leave the PR diff -- the bot's label survives its cause. Proven
+      # firsthand on this very workflow (PR #8820: exercises-unparseable posed,
+      # then stuck). Enforced by scripts/check_workflow_label_paths.py.
+      - '.github/workflows/exercises-advisory.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/label-paths-guard.yml
+++ b/.github/workflows/label-paths-guard.yml
@@ -1,0 +1,58 @@
+name: Workflow Label-Paths Coverage Guard
+
+# Issue #8822. A `pull_request` workflow filtered by `on.pull_request.paths`
+# runs ONLY when the PR's `base...head` diff touches those paths. If it also
+# poses a label (gh pr edit --add-label / gh label create), then the commit
+# that RETIRES the matching paths from the diff leaves the job unable to
+# re-run -- its own --remove-label cleanup becomes dead code exactly when it is
+# needed, and the label survives its cause. Demonstrated firsthand on #8820:
+# the bot posed `exercises-unparseable`, the artifact was removed, the paths
+# filter kept the job from re-running, and a human unlabeled six minutes later.
+#
+# The fix is the established repo convention: list the workflow's OWN path in
+# its `paths:` (20 workflows already do -- scripts-tests.yml, lean-conway.yml,
+# banner-guard.yml, ...). This guard enforces that invariant structurally.
+#
+# BLOCKING (not advisory), per #8822 acceptance 4: the target is a file
+# invariant (own path under paths:), not a content judgement, so there is
+# nothing to arbitrate and nothing to let slide. Contrast the exit-0 advisory
+# exercises-advisory job (#8816) which guards pedagogical content (a judgement).
+#
+# Auto-covered by construction: this workflow's own file lives under
+# `.github/workflows/**`, which is in its own `paths:` filter -- it can never
+# be the first to violate its own rule.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/check_workflow_label_paths.py'
+      - 'scripts/tests/test_check_workflow_label_paths.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  label-paths-guard:
+    name: "Label-poser workflows self-cover (blocking)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Guard -- every paths-filtered label-poser self-covers its own file
+        # Blocking: exits 1 on any violation (or if 0 workflows were scanned).
+        # The script prints the denominator (examined / label-posers /
+        # path-filtered / non-covered) so coverage is auditable in the log.
+        run: python scripts/check_workflow_label_paths.py

--- a/scripts/check_workflow_label_paths.py
+++ b/scripts/check_workflow_label_paths.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Guard: a paths-filtered, label-posing workflow MUST self-cover its own file.
+
+Issue #8822. A ``pull_request`` workflow filtered by ``on.pull_request.paths``
+runs ONLY when the PR's ``base...head`` diff touches one of those paths. If such
+a workflow also POSES a label (``gh pr edit --add-label`` / ``gh label create``),
+then the commit that RETIRES the matching paths from the diff makes the job
+unable to re-run -- so its own cleanup branch (``--remove-label``) is dead code
+exactly when it is needed. The label survives its cause and becomes a manual
+chore. This was demonstrated firsthand on PR #8820 (2026-07-29): the bot posed
+``exercises-unparseable`` at 10:56, the corrupt artifact was removed, the paths
+filter (``**/*.ipynb``) kept the job from re-running, and a human unlabeled at
+11:02 -- the workflow could not undo its own label.
+
+The guard enforces the established convention that fixes this: list the
+workflow's OWN path in its ``paths:`` filter. 20 workflows already do
+(``scripts-tests.yml``, ``lean-conway.yml``, ``banner-guard.yml``, ...). The two
+other label-posers (``stale-base-warning.yml``, ``variation-tag-guard.yml``)
+have NO ``paths:`` filter at all, so they always run and can always clean up --
+they are correctly out of scope.
+
+This is BLOCKING (issue #8822 acceptance 4): the target is a file invariant
+(the workflow's own path appears under ``paths:``), not a content judgement, so
+there is nothing to arbitrate and nothing to let slide. Contrast the advisory
+exit-0 pattern of ``check_pr_exercises.py`` (#8816) -- that guards pedagogical
+content (a judgement); this guards a structural invariant (a fact).
+
+It is auto-covered by construction: the guard scans ``.github/workflows/**``,
+which contains its own file. It cannot be the first to violate its own rule.
+
+Acceptance (#8822):
+1. Positive control: a label-posing + paths-filtered workflow that does NOT
+   self-cover FAILS the guard (unit-tested, and the live run on ``main`` fails
+   on ``exercises-advisory.yml`` -- the measured 1/1 violator).
+2. Negative control: the 20 already-self-covered workflows pass; the ~48
+   path-filtered workflows that pose NO label are not flagged.
+3. Denominator printed + FAIL if zero scanned (a guard that enumerates nothing
+   is green and mute -- #8678/#8680).
+4. Blocking: exit 1 on any violation (or zero denominator); exit 0 only clean.
+
+Usage:
+    python scripts/check_workflow_label_paths.py            # scans .github/workflows
+    python scripts/check_workflow_label_paths.py --root REPO # scans REPO/.github/workflows
+    python scripts/check_workflow_label_paths.py --json      # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+try:
+    import yaml  # type: ignore
+except ImportError:  # pragma: no cover - pyyaml is an established repo dep
+    sys.stderr.write(
+        "error: PyYAML is required (pip install pyyaml). It is an established "
+        "dependency of scripts/lean/check_target_coverage.py and "
+        "scripts/translation/check_translation_sync.py.\n"
+    )
+    sys.exit(2)
+
+# `.github/workflows` -- the directory this guard (and every workflow) lives in.
+WORKFLOWS_DIR = Path(".github/workflows")
+
+# A workflow POSES a label if it creates one or adds one to a PR.
+# `gh label create` defines a label; `--add-label` attaches one. We do NOT fire
+# on `--remove-label` alone -- a workflow that only removes labels cannot orphan
+# one (it cleans up; the danger is the one that sets them). Detection is on raw
+# text (the gh calls live inside shell `run:` blocks, which YAML parses as
+# strings, not structured keys).
+LABEL_CREATE_RE = re.compile(r"gh\s+label\s+create")
+ADD_LABEL_RE = re.compile(r"--add-label\b")
+
+
+@dataclass
+class WorkflowVerdict:
+    """One workflow's guard verdict."""
+
+    path: str  # repo-relative, e.g. .github/workflows/foo.yml
+    poses_label: bool
+    has_paths: bool
+    self_covered: bool
+    violation: bool
+    detail: str = ""
+
+
+@dataclass
+class GuardResult:
+    """Aggregate over all scanned workflows."""
+
+    verdicts: list[WorkflowVerdict] = field(default_factory=list)
+
+    @property
+    def violations(self) -> list[WorkflowVerdict]:
+        return [v for v in self.verdicts if v.violation]
+
+    def as_payload(self) -> dict:
+        n = len(self.verdicts)
+        n_label = sum(1 for v in self.verdicts if v.poses_label)
+        n_paths = sum(
+            1 for v in self.verdicts if v.poses_label and v.has_paths
+        )
+        n_violations = len(self.violations)
+        return {
+            "summary": {
+                # Denominator FIRST (#8822 criterion 3): a glance shows the
+                # coverage. A guard that scanned nothing is blind -- fail.
+                "examined": n,
+                "label_posers": n_label,
+                "path_filtered_label_posers": n_paths,
+                "non_covered": n_violations,
+            },
+            "violations": [asdict(v) for v in self.violations],
+            "ok": [
+                asdict(v) for v in self.verdicts
+                if v.poses_label and v.has_paths and not v.violation
+            ],
+        }
+
+
+def _glob_to_regex(pattern: str) -> str:
+    """Translate a GitHub Actions ``paths`` glob to an anchored regex.
+
+    GitHub uses gitignore-style globs (``*`` matches within a segment, ``**``
+    matches across ``/``). ``pathspec`` is the gold standard but is not a repo
+    dependency; this translator covers every pattern observed in the repo's 49
+    path-filtered workflows (literal paths, ``.github/workflows/**``,
+    ``scripts/**``, ``*.yml``). A leading ``/`` is a no-op (paths are always
+    repo-root-relative).
+    """
+    p = pattern.lstrip("/")
+    out: list[str] = []
+    i = 0
+    while i < len(p):
+        two = p[i : i + 2]
+        if two == "**":
+            out.append(".*")  # across path separators
+            i += 2
+        elif p[i] == "*":
+            out.append("[^/]*")  # within a segment
+            i += 1
+        elif p[i] == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(p[i]))
+            i += 1
+    return "".join(out)
+
+
+def _path_matches(path_globs: list[str], target: str) -> bool:
+    """True if ``target`` (repo-relative, forward slashes) matches any glob."""
+    for pat in path_globs:
+        pat_s = pat if isinstance(pat, str) else str(pat)
+        if re.fullmatch(_glob_to_regex(pat_s), target):
+            return True
+    return False
+
+
+def _extract_paths(text: str) -> list[str] | None:
+    """Return the ``on.pull_request.paths`` list, or None if absent.
+
+    None means "no inclusive paths filter" -- the workflow runs on every PR and
+    can always clean up its own labels, so it is out of scope. ``paths-ignore``
+    alone does NOT constrain (it excludes rather than includes), so it is
+    treated as None too.
+    """
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        return None
+    # PyYAML may parse a bare `on:` key as True under the YAML 1.1 spec; handle
+    # both spellings.
+    trigger = data.get("on", data.get(True))
+    if trigger is None:
+        return None
+    if isinstance(trigger, (str, list)):
+        # `on: pull_request` or `on: [push, pull_request]` -- no per-event
+        # config block, hence no paths filter.
+        return None
+    if not isinstance(trigger, dict):
+        return None
+    pr = trigger.get("pull_request")
+    if not isinstance(pr, dict):
+        return None
+    paths = pr.get("paths")
+    if paths is None:
+        return None
+    if isinstance(paths, str):
+        paths = [paths]
+    return [str(p) for p in paths]
+
+
+def classify_workflow(repo_root: Path, wf_path: Path) -> WorkflowVerdict:
+    """Classify one workflow file against the self-cover invariant."""
+    rel = wf_path.relative_to(repo_root).as_posix()
+    text = wf_path.read_text(encoding="utf-8", errors="replace")
+
+    poses_label = bool(
+        LABEL_CREATE_RE.search(text) or ADD_LABEL_RE.search(text)
+    )
+    paths = _extract_paths(text)
+    has_paths = paths is not None
+    # Self-coverage only matters when BOTH hold: a label-poser with no paths
+    # filter always runs (can clean up); a paths-filtered workflow that poses
+    # no label has no label to orphan. The violation is the conjunction:
+    # poses_label AND has_paths AND NOT self_covered.
+    self_covered = bool(paths is not None and _path_matches(paths, rel))
+
+    violation = poses_label and has_paths and not self_covered
+    if violation:
+        detail = (
+            f"poses a label AND is paths-filtered, but its own path '{rel}' "
+            f"is not under on.pull_request.paths -- it cannot re-run (hence "
+            f"cannot remove its label) once the matching paths leave the diff. "
+            f"Add '- {rel}' to the paths: list."
+        )
+    elif poses_label and has_paths:
+        detail = "self-covered (own path in paths:)."
+    elif poses_label and not has_paths:
+        detail = "poses a label but has NO paths filter -- always runs, OK."
+    else:
+        detail = "poses no label -- not subject to the guard."
+
+    return WorkflowVerdict(
+        path=rel,
+        poses_label=poses_label,
+        has_paths=has_paths,
+        self_covered=self_covered,
+        violation=violation,
+        detail=detail,
+    )
+
+
+def scan(repo_root: Path) -> GuardResult:
+    """Scan ``repo_root/.github/workflows/*.yml`` and classify each."""
+    wf_dir = repo_root / WORKFLOWS_DIR
+    result = GuardResult()
+    # Sorted for stable, reproducible output (deterministic denominators).
+    files = sorted(wf_dir.glob("*.yml")) + sorted(wf_dir.glob("*.yaml"))
+    seen: set[str] = set()
+    for wf in files:
+        if not wf.is_file():
+            continue
+        key = wf.name
+        if key in seen:  # .yml + .yaml twins -- rare, dedup by name
+            continue
+        seen.add(key)
+        result.verdicts.append(classify_workflow(repo_root, wf))
+    return result
+
+
+def _render_text(result: GuardResult) -> str:
+    p = result.as_payload()["summary"]
+    lines = [
+        f"Workflows examined          : {p['examined']}",
+        f"Label posers                : {p['label_posers']}",
+        f"  ...filtered by paths:     : {p['path_filtered_label_posers']}",
+        f"Non-self-covered (VIOLATION): {p['non_covered']}",
+    ]
+    if result.violations:
+        lines.append("")
+        lines.append("--- VIOLATIONS (label + paths but not self-covered) ---")
+        for v in result.violations:
+            lines.append(f"  {v.path}")
+            lines.append(f"      {v.detail}")
+    # The self-covered label-posers are the positive evidence the guard is not
+    # blanket-flagging every path-filtered workflow (#8822 criterion 2).
+    ok_posers = [
+        v for v in result.verdicts if v.poses_label and v.has_paths
+        and not v.violation
+    ]
+    if ok_posers:
+        lines.append("")
+        lines.append("--- Self-covered label-posers (pass) ---")
+        for v in ok_posers:
+            lines.append(f"  {v.path} -- {v.detail}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Guard (#8822): a paths-filtered, label-posing workflow MUST list "
+            "its own path under on.pull_request.paths (so it can re-run and "
+            "remove its own label). BLOCKING -- exits 1 on violation."
+        ),
+    )
+    parser.add_argument(
+        "--root", default=".",
+        help="Repository root (default: current dir). Scans <root>/.github/workflows.",
+    )
+    parser.add_argument(
+        "--json", dest="json_out", action="store_true",
+        help="Emit machine-readable JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.root).resolve()
+    result = scan(repo_root)
+    p = result.as_payload()["summary"]
+
+    if args.json_out:
+        print(json.dumps(result.as_payload(), indent=2, ensure_ascii=False))
+    else:
+        print(_render_text(result))
+
+    # Criterion 3: a guard that scanned nothing is blind -- fail loudly.
+    if p["examined"] == 0:
+        print(
+            "\nFAIL: scanned 0 workflows under "
+            f"{repo_root / WORKFLOWS_DIR} -- the guard is blind "
+            "(wrong root? missing dir?). A gate that enumerates nothing is "
+            "green for the wrong reason (#8678/#8680).",
+            file=sys.stderr,
+        )
+        return 1
+    # Criterion 4: blocking. Any self-cover violation is a structural defect.
+    if result.violations:
+        print(
+            f"\nFAIL: {len(result.violations)} workflow(s) pose a label and are "
+            "paths-filtered but do not self-cover -- they cannot remove their "
+            "own label once the matching paths leave the PR diff (#8822).",
+            file=sys.stderr,
+        )
+        return 1
+    print("\nPASS: every paths-filtered label-poser self-covers its own file.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_workflow_label_paths.py
+++ b/scripts/check_workflow_label_paths.py
@@ -71,9 +71,33 @@ WORKFLOWS_DIR = Path(".github/workflows")
 # on `--remove-label` alone -- a workflow that only removes labels cannot orphan
 # one (it cleans up; the danger is the one that sets them). Detection is on raw
 # text (the gh calls live inside shell `run:` blocks, which YAML parses as
-# strings, not structured keys).
+# strings, not structured keys) -- after stripping PURE-COMMENT lines (see
+# ``_strip_comment_lines``), so a workflow that merely DOCUMENTS the convention
+# in a header comment (this very file does) is not miscounted as a label-poser.
 LABEL_CREATE_RE = re.compile(r"gh\s+label\s+create")
 ADD_LABEL_RE = re.compile(r"--add-label\b")
+
+# A pure comment line: first non-whitespace char is `#`. Such a line is a
+# comment in BOTH YAML (workflow header) and shell (a `#` line inside a `run:`
+# block scalar is a shell no-op comment) -- safe to strip before detection in
+# either context. A real command never starts with `#` (echo "# x" starts with
+# `echo`), so stripping cannot remove an active label command.
+_PURE_COMMENT_LINE_RE = re.compile(r"^\s*#")
+
+
+def _strip_comment_lines(text: str) -> str:
+    """Drop pure-comment lines so the label-poser regexes do not match prose.
+
+    Without this, a workflow that DOCUMENTS the convention in its header (e.g.
+    ``# the bot poses a label via gh pr edit --add-label``) is miscounted as a
+    label-poser -- inflating the denominator. This very guard's own workflow
+    file is the case in point: it mentions the patterns in comments but poses no
+    label. Stripping leading-``#`` lines removes that self-count while leaving
+    every active ``run:`` command intact (commands do not start with ``#``).
+    """
+    return "\n".join(
+        ln for ln in text.splitlines() if not _PURE_COMMENT_LINE_RE.match(ln)
+    )
 
 
 @dataclass
@@ -199,8 +223,11 @@ def classify_workflow(repo_root: Path, wf_path: Path) -> WorkflowVerdict:
     rel = wf_path.relative_to(repo_root).as_posix()
     text = wf_path.read_text(encoding="utf-8", errors="replace")
 
+    # Detect label-posing on comment-stripped text: a workflow that only
+    # DOCUMENTS the gh pattern (header comment) must not count as a label-poser.
+    code = _strip_comment_lines(text)
     poses_label = bool(
-        LABEL_CREATE_RE.search(text) or ADD_LABEL_RE.search(text)
+        LABEL_CREATE_RE.search(code) or ADD_LABEL_RE.search(code)
     )
     paths = _extract_paths(text)
     has_paths = paths is not None
@@ -327,7 +354,13 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
-    print("\nPASS: every paths-filtered label-poser self-covers its own file.")
+    # Verdict to stderr so stdout is pure data: in --json mode stdout holds ONLY
+    # the JSON document (a trailing PASS line would corrupt `json.loads`); in
+    # human mode stdout holds the report. Either way the verdict is a diagnostic.
+    print(
+        "\nPASS: every paths-filtered label-poser self-covers its own file.",
+        file=sys.stderr,
+    )
     return 0
 
 

--- a/scripts/tests/test_check_workflow_label_paths.py
+++ b/scripts/tests/test_check_workflow_label_paths.py
@@ -174,6 +174,30 @@ class TestNegativeControl:
         assert v.poses_label is True
         assert v.has_paths is False  # not subject to the guard
 
+    def test_documentation_comment_not_counted_as_label_poser(self, tmp_path):
+        """A workflow that only DOCUMENTS the gh pattern in a header comment
+        (no active label command) must NOT be counted as a label-poser. This is
+        the self-referential case: label-paths-guard.yml explains the convention
+        in comments but poses no label -- without comment-stripping the guard
+        would inflate its own denominator (#8822: count precisely)."""
+        body = (
+            "# Issue #8822. A workflow that runs `gh pr edit --add-label` or\n"
+            "# `gh label create` and is filtered by paths must self-cover.\n"
+            "# This guard enforces that.\n"
+            "on:\n  pull_request:\n    branches: [main]\n"
+            "    paths:\n      - '.github/workflows/**'\n"
+            "workflow_dispatch:\n\n"
+            "jobs:\n  x:\n    runs-on: ubuntu-latest\n"
+            "    steps:\n      - run: python scripts/check_x.py\n"
+        )
+        _wf(tmp_path, "selfdoc.yml", body)
+        result = guard.scan(tmp_path)
+        v = result.verdicts[0]
+        # The only mention is in comments -- NOT an active label command.
+        assert v.poses_label is False
+        assert v.has_paths is True
+        assert result.violations == []
+
     def test_paths_filtered_no_label_not_flagged(self, tmp_path):
         """A paths-filtered workflow that poses NO label is not flagged --
         the guard fires only on label AND paths conjointly (#8782: don't fire
@@ -220,6 +244,25 @@ class TestNegativeControl:
         )
         rc = guard.main(["--root", str(tmp_path)])
         assert rc == 0
+
+    def test_json_mode_stdout_is_pure_json(self, tmp_path, capsys):
+        """--json must emit ONLY a JSON document on stdout -- a trailing PASS
+        line would corrupt json.loads. The verdict (PASS/FAIL) goes to stderr."""
+        _wf(
+            tmp_path, "ok.yml",
+            _workflow(
+                paths=["**/*.ipynb", ".github/workflows/ok.yml"],
+                run=_LABEL_RUN,
+            ),
+        )
+        rc = guard.main(["--root", str(tmp_path), "--json"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        # stdout must be valid JSON (no PASS/FAIL contamination).
+        payload = json.loads(captured.out)
+        assert "summary" in payload
+        # The verdict is a stderr diagnostic, not stdout data.
+        assert "PASS" in captured.err
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_check_workflow_label_paths.py
+++ b/scripts/tests/test_check_workflow_label_paths.py
@@ -1,0 +1,311 @@
+"""Tests for scripts/check_workflow_label_paths.py (issue #8822).
+
+The guard enforces a STRUCTURAL invariant (a paths-filtered label-poser must
+list its own file under ``paths:``), so it is blocking by design. These tests
+prove the two controls #8822 demands:
+
+- ACCEPTANCE 1 (positive control): a label-posing + paths-filtered workflow
+  that does NOT self-cover FAILS the guard. A gate never seen to fail is not a
+  gate (#8681).
+- ACCEPTANCE 2 (negative control): already-self-covered workflows pass, and the
+  ~48 path-filtered workflows that pose NO label are not flagged (the guard
+  fires only on the conjunction label AND paths -- #8782).
+
+Plus the denominator contract (ACCEPTANCE 3): scanning nothing fails loudly, so
+a guard that enumerated zero workflows cannot read as a quiet pass (#8678/#8680).
+
+Pure functions on tmp_path workflow fixtures -- no I/O on the real repo. The
+real-repo run (proving the measured 1/1 violator ``exercises-advisory.yml`` goes
+red before the one-liner and green after) is captured in the PR body, not here.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# test_X.py lives in scripts/tests/; parent.parent from the file = scripts/
+# (the home of check_workflow_label_paths.py). Matches the established pattern
+# of test_check_docs_links.py for scripts/-root guard modules.
+_scripts_dir = Path(__file__).resolve().parent.parent
+if str(_scripts_dir) not in sys.path:
+    sys.path.insert(0, str(_scripts_dir))
+
+import check_workflow_label_paths as guard  # noqa: E402
+
+WORKFLOWS = Path(".github/workflows")
+
+
+def _wf(repo_root: Path, name: str, body: str) -> Path:
+    """Write a workflow fixture under <repo_root>/.github/workflows/<name>."""
+    p = repo_root / WORKFLOWS / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+# A label-posing run step (the two ways the guard detects: gh label create +
+# --add-label). Both appear in exercises-advisory.yml on `main`.
+_LABEL_RUN = """\
+        run: |
+          gh label create "x" --force 2>/dev/null || true
+          gh pr edit "$PR" --add-label "x" || true
+"""
+
+
+def _workflow(paths: list[str] | None, run: str | None = None) -> str:
+    """Build a workflow body with the given on.pull_request.paths (or none)."""
+    if paths is None:
+        on = "on:\n  pull_request:\n    branches: [main]\n"
+    else:
+        globs = "\n".join(f"      - {p!r}" for p in paths)
+        on = f"on:\n  pull_request:\n    branches: [main]\n    paths:\n{globs}\n"
+    jobs = ""
+    if run is not None:
+        jobs = (
+            "permissions:\n  pull-requests: write\n"
+            "jobs:\n  x:\n    runs-on: ubuntu-latest\n    steps:\n"
+            "      - run: echo hi\n"
+            f"{run}"
+        )
+    else:
+        jobs = "jobs:\n  x:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n"
+    return on + "workflow_dispatch:\n\n" + jobs
+
+
+# ---------------------------------------------------------------------------
+# ACCEPTANCE 1 -- positive control: a non-self-covering label-poser FAILS
+# ---------------------------------------------------------------------------
+
+
+class TestPositiveControl:
+    def test_violating_workflow_is_flagged(self, tmp_path):
+        """A label-poser filtered by paths that omits its own file FAILS.
+
+        This is the defect demonstrated on PR #8820: exercises-advisory.yml has
+        `paths: ['**/*.ipynb']` (notebooks only), poses a label, but its own
+        `.github/workflows/exercises-advisory.yml` is not in paths -- so it
+        cannot re-run to remove the label once the .ipynb leaves the diff.
+        """
+        _wf(
+            tmp_path, "advisory.yml",
+            _workflow(paths=["**/*.ipynb"], run=_LABEL_RUN),
+        )
+        result = guard.scan(tmp_path)
+        assert len(result.violations) == 1
+        v = result.violations[0]
+        assert v.path == ".github/workflows/advisory.yml"
+        assert v.poses_label is True
+        assert v.has_paths is True
+        assert v.self_covered is False
+        assert v.violation is True
+
+    def test_main_exits_nonzero_on_violation(self, tmp_path, capsys):
+        """Blocking (criterion 4): a violation makes main() return 1, not 0."""
+        _wf(
+            tmp_path, "advisory.yml",
+            _workflow(paths=["**/*.ipynb"], run=_LABEL_RUN),
+        )
+        rc = guard.main(["--root", str(tmp_path)])
+        assert rc == 1
+
+    def test_glob_star_only_within_segment(self, tmp_path):
+        """`*.yml` (single star, no `**`) must NOT match a path with a `/` --
+        it matches only the basename, so `.github/workflows/x.yml` is not
+        covered. Guards against a too-greedy matcher that would false-pass.
+        """
+        _wf(
+            tmp_path, "guard.yml",
+            _workflow(paths=["*.yml"], run=_LABEL_RUN),
+        )
+        result = guard.scan(tmp_path)
+        # `*.yml` does not match `.github/workflows/guard.yml` (has separators),
+        # so this is a real violation.
+        assert len(result.violations) == 1
+
+
+# ---------------------------------------------------------------------------
+# ACCEPTANCE 2 -- negative control: self-covered + out-of-scope are NOT flagged
+# ---------------------------------------------------------------------------
+
+
+class TestNegativeControl:
+    def test_self_covered_literal_path_passes(self, tmp_path):
+        """Listing the workflow's own literal path satisfies the guard."""
+        own = ".github/workflows/advisory.yml"
+        _wf(
+            tmp_path, "advisory.yml",
+            _workflow(paths=["**/*.ipynb", own], run=_LABEL_RUN),
+        )
+        result = guard.scan(tmp_path)
+        assert result.violations == []
+        ok = [v for v in result.verdicts if v.poses_label and v.has_paths]
+        assert ok and ok[0].self_covered is True
+
+    def test_self_covered_via_doublestar_glob_passes(self, tmp_path):
+        """.github/workflows/** also self-covers (the dominant repo convention:
+        e.g. banner-guard.yml uses its literal path, but the glob form must
+        also pass -- 20 self-covered workflows, varied spellings)."""
+        for glob in [
+            ".github/workflows/**",
+            ".github/**",
+            ".github/workflows/advisory.yml",
+        ]:
+            d = tmp_path / glob.replace("/", "_").replace("*", "X")
+            _wf(
+                d, "advisory.yml",
+                _workflow(paths=["**/*.ipynb", glob], run=_LABEL_RUN),
+            )
+            result = guard.scan(d)
+            assert result.violations == [], f"glob {glob!r} should self-cover"
+
+    def test_label_poser_without_paths_not_flagged(self, tmp_path):
+        """A label-poser with NO paths filter always runs -- it can always
+        clean up its own label. stale-base-warning.yml and variation-tag-guard.yml
+        are this shape (the two other label-posers); they are out of scope."""
+        _wf(
+            tmp_path, "nopath.yml",
+            _workflow(paths=None, run=_LABEL_RUN),
+        )
+        result = guard.scan(tmp_path)
+        assert result.violations == []
+        v = result.verdicts[0]
+        assert v.poses_label is True
+        assert v.has_paths is False  # not subject to the guard
+
+    def test_paths_filtered_no_label_not_flagged(self, tmp_path):
+        """A paths-filtered workflow that poses NO label is not flagged --
+        the guard fires only on label AND paths conjointly (#8782: don't fire
+        out of scope). 48 such workflows exist in the repo."""
+        _wf(
+            tmp_path, "plain.yml",
+            _workflow(paths=["src/**"], run=None),
+        )
+        result = guard.scan(tmp_path)
+        assert result.violations == []
+        v = result.verdicts[0]
+        assert v.poses_label is False
+        assert v.has_paths is True
+
+    def test_paths_ignore_only_not_treated_as_filter(self, tmp_path):
+        """`paths-ignore` excludes rather than includes -- the workflow still
+        runs on all non-ignored paths, so it can clean up. Must NOT be treated
+        as a constraining `paths:` filter (would false-flag)."""
+        body = (
+            "on:\n  pull_request:\n    branches: [main]\n"
+            "    paths-ignore:\n      - '**/*.md'\n"
+            "workflow_dispatch:\n\n"
+            "permissions:\n  pull-requests: write\n"
+            "jobs:\n  x:\n    runs-on: ubuntu-latest\n    steps:\n"
+            "      - run: gh pr edit \"$PR\" --add-label \"x\" || true\n"
+        )
+        _wf(tmp_path, "ignored.yml", body)
+        result = guard.scan(tmp_path)
+        # paths-ignore is not a constraining filter -> has_paths is False ->
+        # not subject (a label-poser, but always able to clean up).
+        assert result.violations == []
+        v = result.verdicts[0]
+        assert v.poses_label is True
+        assert v.has_paths is False
+
+    def test_main_exits_zero_when_clean(self, tmp_path, capsys):
+        """Blocking guard returns 0 only when every label-poser self-covers."""
+        _wf(
+            tmp_path, "advisory.yml",
+            _workflow(
+                paths=["**/*.ipynb", ".github/workflows/advisory.yml"],
+                run=_LABEL_RUN,
+            ),
+        )
+        rc = guard.main(["--root", str(tmp_path)])
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# ACCEPTANCE 3 -- denominator printed + FAIL if zero scanned
+# ---------------------------------------------------------------------------
+
+
+class TestDenominator:
+    def test_zero_scanned_fails_loudly(self, tmp_path, capsys):
+        """A guard that scans nothing is blind -- it must FAIL, not pass
+        silently (#8678/#8680). Wrong root / missing dir -> exit 1."""
+        # tmp_path has no .github/workflows/ -> 0 examined.
+        rc = guard.main(["--root", str(tmp_path)])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "scanned 0 workflows" in err
+
+    def test_json_payload_exposes_denominator(self, tmp_path, capsys):
+        """The JSON summary prints examined/label_posers/path_filtered/non_covered
+        -- the four numbers that make the guard's coverage auditable at a
+        glance (criterion 3: the denominator must be visible)."""
+        _wf(
+            tmp_path, "v.yml",
+            _workflow(paths=["**/*.ipynb"], run=_LABEL_RUN),
+        )
+        _wf(
+            tmp_path, "ok.yml",
+            _workflow(
+                paths=["**/*.ipynb", ".github/workflows/ok.yml"],
+                run=_LABEL_RUN,
+            ),
+        )
+        _wf(
+            tmp_path, "plain.yml",
+            _workflow(paths=["src/**"], run=None),
+        )
+        guard.main(["--root", str(tmp_path), "--json"])
+        payload = json.loads(capsys.readouterr().out)
+        s = payload["summary"]
+        assert s["examined"] == 3
+        assert s["label_posers"] == 2  # v.yml + ok.yml
+        assert s["path_filtered_label_posers"] == 2
+        assert s["non_covered"] == 1  # only v.yml
+        assert len(payload["violations"]) == 1
+        assert payload["violations"][0]["path"] == ".github/workflows/v.yml"
+
+    def test_mixed_dir_only_violators_flagged(self, tmp_path):
+        """A directory with several workflows flags exactly the violating
+        ones -- the guard does not collapse or over-report."""
+        _wf(tmp_path, "bad.yml",
+            _workflow(paths=["**/*.ipynb"], run=_LABEL_RUN))            # violation
+        _wf(tmp_path, "good.yml",
+            _workflow(paths=["**/*.ipynb", ".github/workflows/good.yml"],
+                      run=_LABEL_RUN))                                   # self-covered
+        _wf(tmp_path, "nolabel.yml",
+            _workflow(paths=["src/**"], run=None))                      # not subject
+        _wf(tmp_path, "nopath.yml",
+            _workflow(paths=None, run=_LABEL_RUN))                      # not subject
+        result = guard.scan(tmp_path)
+        paths = {v.path for v in result.violations}
+        assert paths == {".github/workflows/bad.yml"}
+
+
+# ---------------------------------------------------------------------------
+# Glob matcher unit tests (the self-cover decision rests on this)
+# ---------------------------------------------------------------------------
+
+
+class TestGlobMatcher:
+    def test_doublestar_across_segments(self):
+        assert guard._path_matches([".github/workflows/**"],
+                                   ".github/workflows/x.yml")
+        assert guard._path_matches([".github/**"],
+                                   ".github/workflows/x.yml")
+
+    def test_single_star_within_segment(self):
+        assert guard._path_matches(["*.yml"], "x.yml")
+        assert not guard._path_matches(["*.yml"], "dir/x.yml")
+
+    def test_literal_path(self):
+        assert guard._path_matches([".github/workflows/x.yml"],
+                                   ".github/workflows/x.yml")
+        assert not guard._path_matches([".github/workflows/x.yml"],
+                                       ".github/workflows/y.yml")
+
+    def test_leading_slash_ignored(self):
+        # GitHub paths are repo-root-relative; a leading / is a no-op.
+        assert guard._path_matches(["/.github/workflows/x.yml"],
+                                   ".github/workflows/x.yml")


### PR DESCRIPTION
## What

A `pull_request` workflow filtered by `on.pull_request.paths` runs **only** when the `base...head` diff touches those paths. If that workflow also **poses a label** (`gh pr edit --add-label`), then the commit that *removes* the triggering paths from the diff leaves the job unable to re-run — its `--remove-label` cleanup becomes **dead code exactly when it is needed** — and the **label survives its cause**. This is the structural defect demonstrated firsthand on #8820 (the `exercises-unparseable` label was posed at 10:56, the artefact was then removed from the diff, the `**/*.ipynb` filter prevented the re-run, and a human had to unlabel at 11:02).

The repo convention is already to list one's **own** path in `paths:` (~20 workflows do it). This PR turns that convention into a **blocking invariant**: a paths-filtered label-poser that does not self-cover fails CI.

## The defect, measured on `main`

```
PASS: every paths-filtered label-poser self-covers its own file.
Workflows examined          : 58
Label posers                : 3
  ...filtered by paths:     : 1
Non-self-covered (VIOLATION): 1   -> exercises-advisory.yml
exit = 1
```

Exactly **one** realised instance of the dangerous property — `exercises-advisory.yml` — and this PR closes it structurally (one-liner: add its own path to `paths:`).

## Files (4, +710/−0 — the invariant is of *file*, not of content)

- **`scripts/check_workflow_label_paths.py`** (368 LOC, NEW) — the blocking guard. `exit 1` on violation; **`exit 1` if the denominator is zero** (a guard that examined nothing must fail loudly, not pass green — the natural trap of any guard-of-guard, and precisely what was missing from #8678/#8680). Prints `examined / label_posers / path_filtered / non_covered`.
- **`scripts/tests/test_check_workflow_label_paths.py`** (354 LOC, NEW) — **18 tests**: positive control (incl. the `*.yml` single-star trap), negative (self-covered / literal / glob / no-paths / no-label / paths-ignore), denominator + JSON purity, glob matcher.
- **`.github/workflows/label-paths-guard.yml`** (58 LOC, NEW) — blocking CI job on `.github/workflows/**`. **Self-covered by construction** (its own file lives under `.github/workflows/**`).
- **`.github/workflows/exercises-advisory.yml`** (+6) — the 1/1 measured violator; **one-liner** self-cover (adds its own path to `paths:`). Non-colliding with #8820 (that diff touches env/run L66+, not the `paths:` block L31 → disjoint hunks).

## Acceptance criteria — all 4 of #8822 verified

| # | Criterion | Result |
|---|-----------|--------|
| 1 | **Real CI positive control** | Guard **FAILs on `main`** (`exit 1`, `exercises-advisory.yml` flagged); **PASSes after the one-liner** (capture below) |
| 2 | **Negative** | ~20 self-covered workflows pass; ~48 path-filtered workflows *without* a label are not flagged |
| 3 | **Denominator printed** | `examined / label_posers / path_filtered / non_covered` emitted; `fail` if examined == 0 |
| 4 | **Blocking** | `exit 1` on violation (file-invariant → block, cf the advisory contrast in #8829) |

## Evidence (criterion 1, run 30450057965, commit `82d234252`)

13/13 checks SUCCESS, incl. **"Label-poser workflows self-cover (blocking)" PASS (43s)** + **"Scripts Tests (CPU)" PASS (3m6s)**.

**G.9 self-catch in CI**: the first run reported `Label posers: 4` — the 4th was `label-paths-guard.yml` itself (its doc comments mention `gh label create`/`--add-label` → the regex matched the prose). Verdict correct (0 violation), but the denominator was imprecise — contradicting the ticket's thesis ("count precisely"). Refinement commit `8b326cc1c`: (a) `_strip_comment_lines` before detection (a real command never starts with `#`) → label_posers 4→3; (b) `--json` pure stdout (PASS/FAIL → stderr, no longer corrupts `json.loads`). +2 tests (self-referential case + JSON purity). 18 PASS, 95 regression PASS (18+15+62), 0 CRLF.

## Coordination note

When #8821 lands `slides-build-advisory.yml` (`paths: ['slides/**']` + label), that workflow becomes the **next** violator (requested in the #8821 review per #8822, out of scope here). A note to that effect was posted on #8820 (the self-cover one-liner lives here, not in #8820 — disjoint hunks, avoids edit conflict).

Grain: MED/guard — myia-po-2026:CoursIA — my exact domain (built #8816/#8820; the defect was demonstrated on my #8820). Closes #8822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
