### PR TITLE
feat(iit,#7741): inhibited-action animat module (Laborit) + I(R) bridge + tests

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
@@ -86,6 +86,7 @@ from . import sensitivity
 from . import meta_proxy
 from . import reversibility_budget
 from . import argumentation
+from . import inhibited_action
 
 __all__ = [
     "Cell", "Probe", "SelfSortingArray", "KinSortingArray", "ALGOTYPES",
@@ -99,4 +100,5 @@ __all__ = [
     "spectral", "sensitivity", "meta_proxy",
     "reversibility_budget",
     "argumentation",
+    "inhibited_action",
 ]

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/inhibited_action.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/inhibited_action.py
@@ -1,0 +1,418 @@
+"""Animat inhibé (Laborit) — contrôlabilité de l'environnement, inhibition de l'action (#7741).
+
+Contexte
+--------
+Henri Laborit (*L'Éloge de la fuite*) : des rats soumis à des chocs développent
+une hypertension durable surtout quand **ni fuite ni action défensive** ne sont
+possibles. C'est l'**inhibition de l'action** : « le système apprend que ses
+actions ne contrôlent plus son environnement ». L'analogue formel est un animat
+dont les actions, à mesure que la contrôlabilité s'effondre, deviennent
+**sans effet** sur la transition d'état — et qui, le détectant, **rigidifie** sa
+politique (répétition stérile, effondrement exploratoire).
+
+Ce module instancie ce maillon (absent de la série : grep « Laborit » = 0 dans
+``ict/`` avant ce fichier) comme un substrat expérimental falsifiable, et le
+relie quantitativement à la **dette d'irréversibilité I(R)** via
+:func:`ict.reversibility_budget.work_budget` (la quantité de dynamique
+irréversible que l'animat subit sans pouvoir la « défaire »).
+
+Mécanisme
+---------
+- Un anneau d'états (la 1-torus, minimal). L'action ``a ∈ {−1, 0, +1}`` déplace
+  l'animat.
+- **Contrôlabilité** ``α ∈ [0, 1]`` : avec probabilité ``α`` l'action est
+  appliquée (l'animat contrôle), sinon l'état dérive (action ignorée = inhibition).
+  ``α = 0`` = inhibition totale (Laborit) ; ``α = 1`` = contrôle complet.
+- L'animat **estime** ``α`` depuis les transitions observées
+  (:func:`estimate_controllability`) — c'est la formalisation de « apprend que
+  ses actions ne contrôlent plus ».
+- Un animat **adaptatif** (:func:`adaptive_animat`) qui, détectant ``ĉ`` faible,
+  **inhibe** son action (se repli sur une action par défaut) : sa diversité
+  d'action s'effondre = rigidification.
+
+Références
+----------
+Laborit 1976 (*L'Éloge de la fuite*) ; spec #7741 (jambe C2, conversation de
+conception tours 756-761, 2026-07-20) ; pont I(R) via
+:mod:`ict.reversibility_budget` (work_budget / ICT-18).
+"""
+
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Substrat : anneau contrôlable / inhibé.
+# ---------------------------------------------------------------------------
+
+
+class InhibitedEnvironment:
+    """Anneau d'états avec un bouton de contrôlabilité ``α`` (inhibition Laborit).
+
+    L'action ``a`` (entier, typiquement −1/0/+1) est appliquée avec probabilité
+    ``α`` ; avec probabilité ``1 − α`` l'état dérive d'un pas aléatoire (action
+    ignorée). ``α = 0`` = inhibition totale ; ``α = 1`` = contrôle total.
+
+    Parametres
+    ----------
+    n_states : int
+        Nombre d'états sur l'anneau (≥ 3 pour que l'action ait un sens).
+    alpha : float
+        Contrôlabilité dans ``[0, 1]``.
+    drift : str
+        Régime de dérive quand l'action est inhibée : ``"uniform"`` (pas aléatoire
+        isotrope) ou ``"biased"`` (dérive orientée — environnement hostile).
+    rng : Optional[np.random.Generator]
+        Générateur pour la stochasticité de la dérive.
+    """
+
+    def __init__(
+        self,
+        n_states: int,
+        alpha: float,
+        drift: str = "uniform",
+        rng: Optional[np.random.Generator] = None,
+    ) -> None:
+        if n_states < 3:
+            raise ValueError(f"n_states >= 3 requis (recu {n_states}).")
+        if not 0.0 <= alpha <= 1.0:
+            raise ValueError(f"alpha dans [0, 1] requis (recu {alpha}).")
+        if drift not in ("uniform", "biased"):
+            raise ValueError(f"drift in {{'uniform','biased'}} requis (recu {drift}).")
+        self.n_states = n_states
+        self.alpha = alpha
+        self.drift = drift
+        self.rng = rng if rng is not None else np.random.default_rng()
+
+    def intended(self, state: int, action: int) -> int:
+        """Effectif attendu de l'action sur l'anneau (modulo n)."""
+        return int((state + action) % self.n_states)
+
+    def transition(self, state: int, action: int) -> int:
+        """Transition d'un pas. Avec proba ``α`` on applique l'action, sinon dérive."""
+        if not 0 <= state < self.n_states:
+            raise IndexError(f"state {state} hors borne [0, {self.n_states}).")
+        if self.rng.random() < self.alpha:
+            return self.intended(state, action)
+        # Inhibition : l'action est ignorée, l'état dérive.
+        if self.drift == "uniform":
+            step = int(self.rng.choice([-1, 0, 1]))
+        else:  # biased : environnement qui pousse dans un sens
+            step = int(self.rng.choice([0, 1, 1]))
+        return int((state + step) % self.n_states)
+
+    def transition_kernel(self, action: int) -> np.ndarray:
+        """Matrice de transition ``P[s', s]`` pour une ``action`` fixée.
+
+        Ligne ``s`` sommant à 1. Utile pour brancher ``work_budget`` (I(R)).
+        """
+        P = np.zeros((self.n_states, self.n_states), dtype=float)
+        for s in range(self.n_states):
+            target = self.intended(s, action)
+            P[target, s] += self.alpha
+            if self.drift == "uniform":
+                for step in (-1, 0, 1):
+                    P[(s + step) % self.n_states, s] += (1.0 - self.alpha) / 3.0
+            else:
+                for step in (0, 1, 1):
+                    P[(s + step) % self.n_states, s] += (1.0 - self.alpha) / 3.0
+        return P
+
+
+# ---------------------------------------------------------------------------
+# L'animat : estimation de contrôlabilité + inhibition adaptative.
+# ---------------------------------------------------------------------------
+
+
+def estimate_controllability(
+    states: np.ndarray,
+    actions: np.ndarray,
+    next_states: np.ndarray,
+    n_states: int,
+) -> float:
+    """Estime ``α`` depuis les transitions observées (l'animat détecte l'inhibition).
+
+    On mesure le **déplacement signé** ``d = s' − s`` (ramené dans {−1,0,1} sur
+    l'anneau) et on compare sa concordance avec l'action. Sous contrôle total
+    (α=1), ``d == action`` toujours ; sous inhibition (α=0, dérive uniforme),
+    ``d`` est indépendant de l'action.
+
+    La **ligne de chance** n'est PAS ``1/n`` (la dérive n'est pas uniforme sur
+    les états mais sur les pas {−1,0,1}) : on l'estime empiriquement comme la
+    concordance moyenne qu'on obtiendrait si le déplacement était indépendant de
+    l'action, soit ``chance = mean_{a∈{−1,0,1}} P_d(a)`` où ``P_d`` est la
+    marginale observée du déplacement. Alors
+    ``α̂ = (concordance − chance) / (1 − chance)``, clippé à ``[0, 1]``.
+
+    C'est la formalisation quantitative de « apprend que ses actions ne
+    contrôlent plus l'environnement » : un animat sous α=0 voit α̂ → 0.
+    """
+    if len(states) == 0:
+        return 0.0
+    # Déplacement signé sur l'anneau (les pas sont petits, n_states >= 3).
+    d = (next_states - states) % n_states
+    d = np.where(d > n_states // 2, d - n_states, d)
+    observed = float(np.mean(d == actions))
+    # Ligne de chance : concordance moyenne si d et action sont indépendants,
+    # actions supposées uniformes sur {−1,0,1}.
+    chance = float(np.mean([np.mean(d == a) for a in (-1, 0, 1)]))
+    if chance >= 1.0:
+        return 0.0
+    alpha_hat = (observed - chance) / (1.0 - chance)
+    return float(np.clip(alpha_hat, 0.0, 1.0))
+
+
+def adaptive_animat(
+    env: InhibitedEnvironment,
+    n_steps: int,
+    inhibit_threshold: float = 0.3,
+    window: int = 30,
+    rng: Optional[np.random.Generator] = None,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Animat qui **inhibe** son action quand il détecte une faible contrôlabilité.
+
+    Modèle Laborit : l'animat explore d'abord (actions −1/0/+1 uniformes), estime
+    en ligne la contrôlabilité ``ĉ`` sur une fenêtre glissante, et quand ``ĉ``
+    passe sous ``inhibit_threshold``, il **se replie sur l'action 0** (no-op) —
+    l'inhibition de l'action. Renvoie les trajectoires (états, actions) et la
+    trace de ``ĉ`` au cours du temps.
+
+    Under α=1, ``ĉ`` reste élevé → l'animat continue d'explorer (diversité haute).
+    Under α=0, ``ĉ`` s'effondre → l'animat inhibe (diversité d'action effondrée).
+    """
+    rng = rng if rng is not None else np.random.default_rng()
+    states = np.empty(n_steps, dtype=int)
+    actions = np.empty(n_steps, dtype=int)
+    chat = np.empty(n_steps, dtype=float)
+    s = int(rng.integers(0, env.n_states))
+    recent_s, recent_a, recent_s2 = [], [], []
+    for t in range(n_steps):
+        # Estimation en ligne de la contrôlabilité sur la fenêtre glissante.
+        if len(recent_s) >= window:
+            c = estimate_controllability(
+                np.array(recent_s), np.array(recent_a), np.array(recent_s2),
+                n_states=env.n_states,
+            )
+        else:
+            c = 1.0  # optimisme initial (explore) jusqu'à preuve du contraire.
+        chat[t] = c
+        if c < inhibit_threshold:
+            a = 0  # inhibition : repli sur le no-op.
+        else:
+            a = int(rng.choice([-1, 0, 1]))
+        s2 = env.transition(s, a)
+        states[t], actions[t] = s, a
+        recent_s.append(s); recent_a.append(a); recent_s2.append(s2)
+        if len(recent_s) > window:
+            recent_s.pop(0); recent_a.pop(0); recent_s2.pop(0)
+        s = s2
+    return states, actions, chat
+
+
+# ---------------------------------------------------------------------------
+# Mesures de pathologie (rigidification / effondrement exploratoire).
+# ---------------------------------------------------------------------------
+
+
+def action_entropy(actions: np.ndarray, n_actions: int = 3) -> float:
+    """Entropie de Shannon (naturelle) de la distribution d'actions.
+
+    Mesure de **rigidification** : une politique qui se replie sur une seule
+    action (inhibition) a une entropie ≈ 0 ; une politique qui explore (−1/0/+1
+    uniformes) a ``ln(3) ≈ 1.099``.
+    """
+    if len(actions) == 0:
+        return 0.0
+    counts = np.bincount((actions + 1) % n_actions, minlength=n_actions).astype(float)
+    p = counts / counts.sum()
+    p = p[p > 0]
+    return float(-(p * np.log(p)).sum())
+
+
+def state_coverage(states: np.ndarray, n_states: int) -> int:
+    """Nombre d'états distincts visités — mesure d'**effondrement exploratoire**."""
+    return int(np.unique(states % n_states).size)
+
+
+# ---------------------------------------------------------------------------
+# Bancs d'essai (protocole #7741) — chacun renvoie un verdict falsifiable.
+# ---------------------------------------------------------------------------
+
+
+def rigidification_test(
+    n_states: int = 9,
+    n_steps: int = 600,
+    inhibit_threshold: float = 0.3,
+    seed: int = 0,
+) -> Dict[str, float]:
+    """Test de RIGIDIFICATION (#7741).
+
+    Sous α=0 (inhibition totale), l'animat détecte ĉ→0 et se replie sur le
+    no-op : son entropie d'action s'effondre. Sous α=1 (contrôle), il explore.
+
+    Verdict falsifiable
+    -------------------
+    ``rigidified`` est True ssi l'entropie d'action sous α=0 est nettement
+    inférieure à celle sous α=1 (marge 0.3 nat). Un animat qui n'inhiberait pas
+    garderait la même diversité dans les deux régimes — le test le détecterait.
+    """
+    rng0 = np.random.default_rng(seed)
+    rng1 = np.random.default_rng(seed + 1)
+    env0 = InhibitedEnvironment(n_states, alpha=0.0, drift="uniform", rng=rng0)
+    env1 = InhibitedEnvironment(n_states, alpha=1.0, drift="uniform", rng=rng1)
+    _, a0, c0 = adaptive_animat(env0, n_steps, inhibit_threshold, rng=rng0)
+    _, a1, c1 = adaptive_animat(env1, n_steps, inhibit_threshold, rng=rng1)
+    H0 = action_entropy(a0)
+    H1 = action_entropy(a1)
+    rigidified = (H1 - H0) > 0.3
+    return {
+        "action_entropy_controlled": H1,
+        "action_entropy_inhibited": H0,
+        "entropy_drop": H1 - H0,
+        "chat_mean_controlled": float(np.mean(c1)),
+        "chat_mean_inhibited": float(np.mean(c0)),
+        "rigidified": 1.0 if rigidified else 0.0,
+    }
+
+
+def goal_seeking_efficacy_test(
+    n_states: int = 9,
+    n_steps: int = 800,
+    seed: int = 0,
+) -> Dict[str, float]:
+    """Test d'EFFICACITÉ D'ACTION ORIENTÉE BUT (#7741).
+
+    La couverture d'états ne s'effondre pas sous inhibition (la dérive porte
+    l'animat partout sur un petit anneau) — ce n'est donc pas la bonne
+    pathologie. Celle de Laborit est la **perte d'efficacité de l'action** :
+    l'animat ne peut plus *atteindre ni maintenir* un but. On mesure le temps
+    passé dans une région-cible (état 0 et ses voisins) par un animat qui
+    cherche activement à s'y rendre (policy greedy vers 0).
+
+    Verdict falsifiable
+    -------------------
+    ``lost_control`` est True ssi la fraction de pas dans la cible est
+    strictement supérieure sous contrôle (α=1) que sous inhibition (α=0).
+    """
+    target = {0, 1, n_states - 1}  # état 0 + ses deux voisins sur l'anneau.
+
+    def greedy_toward(state: int) -> int:
+        # Pas signé qui rapproche de 0 (mod n).
+        fwd = (0 - state) % n_states
+        if fwd == 0:
+            return 0
+        return 1 if fwd <= n_states // 2 else -1
+
+    def target_fraction(alpha: float, rng_seed: int) -> float:
+        rng = np.random.default_rng(rng_seed)
+        env = InhibitedEnvironment(n_states, alpha=alpha, drift="uniform", rng=rng)
+        s = int(rng.integers(0, n_states))
+        hits = 0
+        for _ in range(n_steps):
+            a = greedy_toward(s)
+            s = env.transition(s, a)
+            if s in target:
+                hits += 1
+        return hits / n_steps
+
+    frac_controlled = target_fraction(1.0, seed)
+    frac_inhibited = target_fraction(0.0, seed + 1)
+    lost_control = frac_controlled > frac_inhibited
+    return {
+        "target_fraction_controlled": frac_controlled,
+        "target_fraction_inhibited": frac_inhibited,
+        "efficacy_drop": frac_controlled - frac_inhibited,
+        "lost_control": 1.0 if lost_control else 0.0,
+    }
+
+
+def controllability_estimation_test(
+    n_states: int = 9,
+    n_steps: int = 2000,
+    seed: int = 0,
+) -> Dict[str, float]:
+    """Test d'ESTIMATION de contrôlabilité (#7741 — le coeur « apprend »).
+
+    L'animat doit pouvoir **détecter** α depuis les transitions observées (c'est
+    le prérequis de l'inhibition : sans détection, pas de « savoir que mes
+    actions ne contrôlent plus »). On vérifie que :func:`estimate_controllability`
+    récupère α_true à ``±0.1`` près sur plusieurs régimes.
+
+    Verdict falsifiable
+    -------------------
+    ``detected`` est True ssi |α̂ − α_true| < 0.1 pour α_true ∈ {0.0, 0.5, 1.0}.
+    Un estimateur aveugle (constant 0.5) raterait α=0 et α=1.
+    """
+    detected = True
+    errors = {}
+    for alpha_true in (0.0, 0.5, 1.0):
+        rng = np.random.default_rng(seed)
+        env = InhibitedEnvironment(n_states, alpha=alpha_true, drift="uniform", rng=rng)
+        s = int(rng.integers(0, n_states))
+        S, A, S2 = [], [], []
+        for _ in range(n_steps):
+            a = int(rng.choice([-1, 0, 1]))
+            s2 = env.transition(s, a)
+            S.append(s); A.append(a); S2.append(s2)
+            s = s2
+        a_hat = estimate_controllability(
+            np.array(S), np.array(A), np.array(S2), n_states=n_states,
+        )
+        err = abs(a_hat - alpha_true)
+        errors[alpha_true] = err
+        if err >= 0.1:
+            detected = False
+    return {
+        **{f"abs_err_alpha_{alpha:.1f}": err for alpha, err in errors.items()},
+        "max_abs_err": float(max(errors.values())),
+        "detected": 1.0 if detected else 0.0,
+    }
+
+
+def irreversibility_debt_bridge(
+    n_states: int = 9,
+) -> Dict[str, float]:
+    """Pont quantitatif vers la dette d'irréversibilité I(R) (#7741 spec).
+
+    On mesure :func:`ict.reversibility_budget.work_budget` (distance L1/2 entre
+    ``P`` et sa projection réversible ``P_rev``) sur le noyau vécu par l'animat.
+    Le finding empirique n'est pas « la dette monte sous inhibition » (une
+    permutation déterministe porte AUSSY une forte flèche du temps — ``P_rev``
+    diffère de ``P``) ; il est plus fin : sous inhibition (α=0), **changer
+    d'action ne change plus la dette subie** — l'animat a perdu toute prise sur
+    l'irréversibilité qu'il subit, qui devient dictée par la dérive seule. À
+    contrôlabilité partielle (α=0.5), l'action modulait encore cette dette.
+
+    Verdict falsifiable
+    -------------------
+    ``trapped`` est True ssi (a) l'effet de l'action sur la dette sous inhibition
+    est nul (|Δ| < 1e-9), ET (b) cet effet était non-négligeable à contrôle
+    partiel (|Δ(α=0.5)| > 0.5) — preuve que l'action était opérante puis a cessé
+    de l'être.
+    """
+    from .reversibility_budget import work_budget
+
+    def debt(alpha: float, act: int) -> float:
+        env = InhibitedEnvironment(n_states, alpha=alpha, drift="biased")
+        P = env.transition_kernel(act)
+        pi = np.full(n_states, 1.0 / n_states)
+        return work_budget(P, pi)
+
+    def action_effect(alpha: float) -> float:
+        return abs(debt(alpha, +1) - debt(alpha, -1))
+
+    eff_inhibited = action_effect(0.0)
+    eff_partial = action_effect(0.5)
+    trapped = (eff_inhibited < 1e-9) and (eff_partial > 0.5)
+    return {
+        "debt_inhibited_action_plus1": debt(0.0, +1),
+        "debt_inhibited_action_minus1": debt(0.0, -1),
+        "debt_partial_action_plus1": debt(0.5, +1),
+        "debt_partial_action_minus1": debt(0.5, -1),
+        "debt_controlled_action_plus1": debt(1.0, +1),
+        "debt_controlled_action_minus1": debt(1.0, -1),
+        "action_effect_inhibited": eff_inhibited,
+        "action_effect_partial_control": eff_partial,
+        "trapped": 1.0 if trapped else 0.0,
+    }

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_inhibited_action.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_inhibited_action.py
@@ -1,0 +1,174 @@
+"""Tests du module #7741 : animat inhibé (Laborit), contrôlabilité, inhibition.
+
+Couvrent les quatres verdicts falsifiables du banc d'essai :
+
+1. **Rigidification** — sous α=0 (inhibition totale), l'entropie d'action
+   s'effondre (l'animat se replie sur le no-op) vs α=1 (exploration).
+2. **Efficacité d'action orientée but** — l'animat ne peut plus atteindre/maintenir
+   un but sous inhibition (la couverture d'états, elle, ne s'effondre pas : la
+   dérive porte le corps partout).
+3. **Estimation de contrôlabilité** — l'animat récupère α_true à ±0.1 près
+   (prérequis : « savoir que ses actions ne contrôlent plus »).
+4. **Pont dette d'irréversibilité I(R)** — sous inhibition, l'effet de l'action
+   sur la dette s'annule (l'animat perd toute prise sur l'irréversibilité subie).
+
+Plus les propriétés mécaniques (kernel stochastique, bouton α, gardes).
+numpy + pytest, CPU uniquement.
+"""
+
+import numpy as np
+import pytest
+
+from ict.inhibited_action import (
+    InhibitedEnvironment,
+    action_entropy,
+    adaptive_animat,
+    controllability_estimation_test,
+    estimate_controllability,
+    goal_seeking_efficacy_test,
+    irreversibility_debt_bridge,
+    rigidification_test,
+    state_coverage,
+)
+
+
+# --- Proprietes mecaniques de InhibitedEnvironment ---
+
+
+def test_transition_kernel_rows_sum_to_one():
+    """Chaque ligne du noyau de transition somme à 1 (stochastique)."""
+    for alpha in (0.0, 0.3, 0.7, 1.0):
+        env = InhibitedEnvironment(n_states=7, alpha=alpha, drift="uniform")
+        for act in (-1, 0, 1):
+            P = env.transition_kernel(act)
+            np.testing.assert_allclose(P.sum(axis=0), np.ones(7), atol=1e-12)
+
+
+def test_full_control_applies_action():
+    """α=1 : la transition applique systematiquement l'action (controle total)."""
+    env = InhibitedEnvironment(n_states=5, alpha=1.0, drift="uniform",
+                               rng=np.random.default_rng(0))
+    n = env.n_states
+    for s in range(n):
+        for a in (-1, 0, 1):
+            assert env.transition(s, a) == env.intended(s, a)
+
+
+def test_full_inhibition_ignores_action():
+    """α=0 : l'action est ignoree (inhibition) — la transition ne vaut pas intended partout."""
+    env = InhibitedEnvironment(n_states=5, alpha=0.0, drift="uniform",
+                               rng=np.random.default_rng(0))
+    # Sur assez de pas, la transition sous α=0 s'ecarte de l'effet attendu
+    # (sinon l'action ne serait pas inhibee).
+    mismatches = sum(env.transition(2, 1) != env.intended(2, 1) for _ in range(200))
+    assert mismatches > 100  # la majorite des pas ignorent l'action.
+
+
+def test_intended_is_modulo():
+    """L'effet attendu est modulo n (anneau circulaire)."""
+    env = InhibitedEnvironment(n_states=4, alpha=1.0)
+    assert env.intended(3, 1) == 0   # (3 + 1) % 4
+    assert env.intended(0, -1) == 3  # (0 - 1) % 4
+
+
+# --- Gardes de validation ---
+
+
+@pytest.mark.parametrize("bad_n", [0, 1, 2])
+def test_invalid_n_states_raises(bad_n):
+    with pytest.raises(ValueError):
+        InhibitedEnvironment(n_states=bad_n, alpha=0.5)
+
+
+@pytest.mark.parametrize("bad_alpha", [-0.1, 1.1, 2.0])
+def test_invalid_alpha_raises(bad_alpha):
+    with pytest.raises(ValueError):
+        InhibitedEnvironment(n_states=5, alpha=bad_alpha)
+
+
+def test_invalid_drift_raises():
+    with pytest.raises(ValueError):
+        InhibitedEnvironment(n_states=5, alpha=0.5, drift="sideways")
+
+
+def test_transition_state_out_of_bounds_raises():
+    env = InhibitedEnvironment(n_states=5, alpha=0.5)
+    with pytest.raises(IndexError):
+        env.transition(99, 1)
+
+
+# --- estimate_controllability : propietes mecaniques ---
+
+
+def test_estimate_controllability_endpoints():
+    """Sous des transitions purement controlled / inhibées, l'estimateur recupere 1 / ~0."""
+    n = 6
+    rng = np.random.default_rng(0)
+    states = rng.integers(0, n, size=2000)
+    actions = rng.choice([-1, 0, 1], size=2000)
+    # α=1 : next = intended partout.
+    next_full = (states + actions) % n
+    assert abs(estimate_controllability(states, actions, next_full, n) - 1.0) < 1e-9
+    # α=0 : next aleatoire uniforme (independant de l'action).
+    next_inhib = rng.integers(0, n, size=2000)
+    assert estimate_controllability(states, actions, next_inhib, n) < 0.1
+
+
+def test_estimate_controllability_empty():
+    """Trajectoire vide -> estimateur 0 (pas de preuve de controle)."""
+    assert estimate_controllability(np.array([]), np.array([]), np.array([]), 5) == 0.0
+
+
+# --- Mesures de pathologie ---
+
+
+def test_action_entropy_uniform_is_log3():
+    """Actions −1/0/+1 uniformes -> entropie ln(3)."""
+    a = np.tile([-1, 0, 1], 100)
+    assert abs(action_entropy(a) - np.log(3)) < 1e-9
+
+
+def test_action_entropy_collapsed_is_zero():
+    """Une seule action repetee -> entropie 0 (rigidification)."""
+    assert action_entropy(np.zeros(100, dtype=int)) == 0.0
+
+
+def test_state_coverage_counts_distinct():
+    assert state_coverage(np.array([0, 0, 1, 1, 2, 7]) % 10, 10) == 4
+
+
+# --- Les quatre verdicts falsifiables #7741 ---
+
+
+def test_rigidification_inhibited_drops_action_entropy():
+    """Verdict RIGIDIFICATION : entropie sous α=0 nettement inférieure à α=1."""
+    report = rigidification_test(n_states=9, n_steps=800, seed=0)
+    assert report["action_entropy_controlled"] > 0.8  # ~ln(3) exploration
+    assert report["chat_mean_inhibited"] < report["chat_mean_controlled"]
+    assert report["entropy_drop"] > 0.3               # rigidification réelle
+    assert report["rigidified"] == 1.0
+
+
+def test_goal_seeking_efficacy_lost_under_inhibition():
+    """Verdict EFFICACITÉ BUT : l'animat maintient moins bien la cible sous α=0."""
+    report = goal_seeking_efficacy_test(n_states=9, n_steps=800, seed=0)
+    assert report["target_fraction_controlled"] > report["target_fraction_inhibited"]
+    assert report["efficacy_drop"] > 0.1
+    assert report["lost_control"] == 1.0
+
+
+def test_controllability_estimation_recovers_alpha():
+    """Verdict ESTIMATION : alpha_hat recupere alpha_true a ±0.1 sur 3 régimes."""
+    report = controllability_estimation_test(n_states=9, n_steps=2000, seed=0)
+    assert report["max_abs_err"] < 0.1
+    assert report["detected"] == 1.0
+
+
+def test_irreversibility_debt_bridge_trapped():
+    """Verdict PONT I(R) : sous inhibition, l'effet de l'action sur la dette s'annule."""
+    report = irreversibility_debt_bridge(n_states=9)
+    # Sous inhibition, changer d'action ne change plus la dette subie.
+    assert report["action_effect_inhibited"] < 1e-9
+    # À contrôle partiel, l'action modulait encore la dette.
+    assert report["action_effect_partial_control"] > 0.5
+    assert report["trapped"] == 1.0


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python (#8823 learned-valence)

See #7741. Not `Closes` — module-first (cycle-1 of jambe C2); the notebook
branching this banc is the follow-up.

## Summary

Adds `ict/inhibited_action.py`: the **Laborit "inhibition de l'action"**
experimental substrate (jambe C2). Verified absent beforehand: `grep "Laborit"
ict/` = 0 hits (`reaction_diffusion.py`'s "l'inhibiteur diffuse" is Gray-Scott
chemistry, a false positive — the spec's "0 Laborit" claim holds).

An animat whose actions, as **controllability collapses**, become **ineffective**
on state transitions — and which, **detecting** it, rigidifies its policy. This
formalizes Laborit (*L'Éloge de la fuite*): rats develop durable hypertension
when **neither flight nor defensive action** is possible — "the system learns
that its actions no longer control its environment."

### Mechanism

A ring MDP with a **controllability knob α**: with prob α the action is applied
(animat controls); with prob 1−α the state drifts (action **ignored** =
inhibition). α=0 = total inhibition; α=1 = full control. An **adaptive animat**
estimates α online (`estimate_controllability`) and, detecting low ĉ, **inhibits**
(collapses to no-op).

### Four falsifiable verdicts (the test banc)

Each is a function returning a verdict dict — a falsifiable property, not a vibe:

| Bench | Verdict is `True` iff … | The non-trivial part |
|-------|-------------------------|----------------------|
| `rigidification_test` | action entropy drops > 0.3 nat under α=0 vs α=1 | the animat gives up exploration when it detects its actions don't matter |
| `goal_seeking_efficacy_test` | target-maintenance fraction strictly lower under α=0 | **state coverage does NOT collapse** (the drift carries the body everywhere) — the pathology is action stereotypy + loss of efficacy, which this captures |
| `controllability_estimation_test` | `α̂` recovers `α_true` to ±0.1 over {0, 0.5, 1} | prerequisite for inhibition: no detection → no "knowing my actions don't control" |
| `irreversibility_debt_bridge` | action's effect on debt vanishes under inhibition AND was > 0.5 at partial control | bridges to `work_budget` (I(R)); the honest finding is **not** "debt rises" (a permutation also carries a time-arrow) but that **action leverage on irreversibility vanishes** |

### What I got wrong first, then fixed from data

I instrumented before asserting. Three claims did not survive contact with real
output and I corrected them rather than shipping a plausible-but-wrong bench:

1. **Estimator baseline.** My first `estimate_controllability` used chance = 1/n.
   Empirically `α̂` at α=0 was 0.25 (error 0.25, not < 0.1). Root cause: the drift
   is uniform over **steps** {−1,0,1}, not over states — the chance match-rate is
   1/3, not 1/n. Fixed with a signed-displacement + empirical chance-baseline
   (`mean_{a} P_d(a)`). Now max_err = **0.028**.
2. **Coverage collapse.** `exploration_collapse_test` returned 9.0 == 9.0
   (`collapsed=0`). On a small ring with uniform drift the body covers all states
   regardless. Replaced with `goal_seeking_efficacy_test` (reach/maintain a
   target) — the pathology that actually manifests.
3. **I(R) bridge.** I assumed a controlled permutation is reversible (debt ≈ 0);
   `work_budget` actually returns 4.5 for a deterministic shift (detailed-balance
   distance, not "ease to reverse"). Rewrote the verdict around the finding that
   **does** hold: action-effect on debt vanishes under inhibition.

## Validation (real, not claimed)

- **Full `ict` suite**: `543 passed in 52.99s` (was 522 on origin/main; **+21 new,
  0 regression**). `coursia-ml-training` env (numpy).
- **All 4 verdicts** return their falsifiable flags (1.0); estimation max_err =
  0.028.
- **Anti-regression**: purely additive — `ict/__init__.py` +2 (registration);
  `ict/valence.py` / `learned_valence.py` untouched (independent of #8823, which
  branches from the same origin/main).

## Scope

- `ict/inhibited_action.py` (new): `InhibitedEnvironment` + `adaptive_animat` +
  `estimate_controllability` + 4 test benches.
- `tests/test_inhibited_action.py` (new): 21 tests — 4 verdicts + mechanical
  properties (stochastic kernel, α knob, intended-modulo, entropy/coverage) +
  validation guards.
- `ict/__init__.py`: +2 (registration).

numpy only, CPU, no GPU, no notebook re-exec.

## Variation note (honest)

Same family/genre as #8823 (ICT, notebook-python module). G-VAR-3 permits
same-genre DEEP only if **genuinely distinct substance**: #7740 operationalizes
valence **acquisition/transfer** (Rescorla-Wagner); #7741 operationalizes action
**inhibition/controllability** (Laborit) — different mechanism, different
falsifiable properties, different I(R) bridge. Neither is scan-generable (both
require domain reasoning to design the substrate). The non-ICT pool was verified
exhausted firsthand this cycle (Lean/QC owner-locked or Cloud-gated; #8822/#8819
guards G-VAR-3-blocked; #6949 multi-hour + po-2023 territory; #6724 Lean).

See #7741, #4588, #7740, #2161.
