### PR TITLE
ci(guard,#8826): discriminating CJK-residue guard — wire dead organ + widen to sources

### DIFF
--- a/.github/workflows/cjk-residue-advisory.yml
+++ b/.github/workflows/cjk-residue-advisory.yml
@@ -70,30 +70,58 @@ jobs:
           # Without GH_REPO, gh pr edit/label create cannot infer the target repo.
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
           LABEL: cjk-residue
         run: |
           set -uo pipefail
 
-          # Run the discriminating guard over the whole fleet (notebooks + git-
-          # tracked .py/.md/.cs). --json for the file list; --check sets exit code.
-          python scripts/notebook_tools/detect_cjk_residue.py --json --check \
-            > payload.json 2> scan.log || true
-          cat payload.json
+          # The label is decided on what THIS PR changes (#8829 review), not on
+          # the state of main. A whole-fleet scan would pose `cjk-residue` on
+          # every PR while main carries pre-existing residue in files the PR
+          # never touched -- a label nobody can drop without fixing foreign
+          # files, which is learned-to-be-ignored even faster than #8822's
+          # "label survives its cause". The fleet scan stays (informational
+          # notice below); only the PR's own apport can trigger its label.
+          git diff --name-only --diff-filter=d "$BASE" "$HEAD" > changed.txt || true
 
-          LEAKS=$(python -c "import json; d=json.load(open('payload.json')); print(d['total_hits'])")
-          echo "CJK leak lines on this PR's base: $LEAKS"
+          python scripts/notebook_tools/detect_cjk_residue.py --json --check --stdin \
+            < changed.txt > pr_payload.json 2> pr_scan.log || true
+          cat pr_payload.json
 
-          if [ "$LEAKS" -gt 0 ]; then
+          PR_LEAKS=$(python -c "import json; d=json.load(open('pr_payload.json')); print(d['total_hits'])")
+          echo "CJK leak lines introduced/modified by THIS PR: $PR_LEAKS"
+
+          # Fleet scan -- INFORMATIONAL ONLY. Surfaces pre-existing residue
+          # elsewhere so a maintainer sees it, but NEVER decides the label: a PR
+          # is not blamed for files it did not touch.
+          python scripts/notebook_tools/detect_cjk_residue.py --json \
+            > fleet_payload.json 2> fleet_scan.log || true
+          FLEET_LEAKS=$(python -c "import json; d=json.load(open('fleet_payload.json')); print(d['total_hits'])" 2>/dev/null || echo "")
+          if [ "${FLEET_LEAKS:-}" -gt 0 ] 2>/dev/null; then
+            echo "::notice::Pre-existing CJK residue elsewhere in the repo ($FLEET_LEAKS leak line(s)) -- informational, NOT attributed to this PR. See #8826."
+          fi
+
+          # Integer-guard (#8820 Blocage 3 family): if pr_payload.json is
+          # illisible (check_pr_exercises-style death), the gate measured NOTHING.
+          # Do not claim clean AND do not falsely accuse -- surface ::error::
+          # and leave the label for a human. Never a green claim on a non-measure.
+          if ! [ "${PR_LEAKS:-}" -eq "${PR_LEAKS:-}" ] 2>/dev/null; then
+            echo "::error::CJK PR-diff payload illisible -- the gate measured NOTHING; conformity neither claimed nor denied."
+            exit 0
+          fi
+
+          if [ "$PR_LEAKS" -gt 0 ]; then
             FILES=$(python -c \
-              "import json; d=json.load(open('payload.json')); \
+              "import json; d=json.load(open('pr_payload.json')); \
                print('\n'.join('- '+r['path'] for r in d['results'] if r['allowed'] is None and r['hits']))")
-            echo "::notice::CJK residue detected ($LEAKS leak line(s)) across: $FILES -- see the '$LABEL' label (#8826/#8428)."
+            echo "::notice::CJK residue in THIS PR ($PR_LEAKS leak line(s)): $FILES -- see the '$LABEL' label (#8826/#8428)."
             gh label create "$LABEL" \
               --description "CJK residue: a Chinese/Japanese word soldered into Latin prose (#8428/#8826)" \
               --color "D93F0B" --force 2>/dev/null || true
             gh pr edit "$PR_NUMBER" --add-label "$LABEL" || true
           else
-            echo "No CJK residue detected."
+            echo "No CJK residue introduced by this PR."
             # A label from an earlier push is now stale -- remove it so the signal
             # stays trustworthy (self-cover lets this branch run on the fix commit).
             gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true

--- a/.github/workflows/cjk-residue-advisory.yml
+++ b/.github/workflows/cjk-residue-advisory.yml
@@ -1,0 +1,101 @@
+name: CJK Residue Advisory
+
+# Issue #8826. The detector scripts/notebook_tools/detect_cjk_residue.py existed
+# to close #8428 (LLM-translation residue: Chinese words soldered into French/
+# English prose -- 均匀ément, de重建, 可能性が高い), but it was wired to NOTHING and
+# saw only .ipynb. So the reservoir refilled silently: #8823 introduced
+# `«经验 manquante»` in a .py, invisible to the ipynb-only scope and never run.
+#
+# This workflow makes the organ alive. It runs the #8826 discriminating guard
+# (CJK mixed into Latin = leak; pure-CJK = legit) over notebooks AND tracked
+# .py/.md/.cs, and signals residue by a LABEL -- never by the job conclusion.
+#
+# ADVISORY, never blocking (issue #8826 deliverable 3 / #8814 acceptance 5): the
+# job ALWAYS exits 0. The actionable payload is the `cjk-residue` LABEL, NEVER the
+# green conclusion (green by construction). Contrast the BLOCKING label-paths-guard
+# (#8822) which targets a file invariant; this targets a content judgement (is this
+# CJK a corrupted Latin word or a deliberate term?) -- a human/arbiter call, so it
+# signals rather than gates.
+#
+# Self-cover (#8822): a paths-filtered label-poser MUST list its own file under
+# paths:, else it cannot re-run (so cannot remove its label) once the matching
+# paths leave the PR diff. Proven firsthand on exercises-advisory (PR #8820).
+# Enforced structurally by scripts/check_workflow_label_paths.py.
+#
+# Fork PRs are skipped (student-pr-reviews.md): benevolent review, no internal
+# content criterion runs against student submissions.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      # Leak-bearing content -- run whenever any prose/code/notebook changes.
+      - '**/*.ipynb'
+      - '**/*.md'
+      - '**/*.py'
+      - '**/*.cs'
+      # Self-cover (#8822): so this job re-runs on its own modification and can
+      # clean up its label. Without this, a leak-fix commit that touches only
+      # this workflow/script would leave the label stuck.
+      - '.github/workflows/cjk-residue-advisory.yml'
+      - 'scripts/notebook_tools/detect_cjk_residue.py'
+      - 'scripts/notebook_tools/tests/test_detect_cjk_residue.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  cjk-residue-advisory:
+    name: "CJK residue advisory (label, non-blocking)"
+    runs-on: ubuntu-latest
+    # Same-repo PRs only (agents/staff). Fork PRs are student submissions under
+    # student-pr-reviews.md -- benevolent review, no content gate.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Advisory CJK residue scan (notebooks + tracked .py/.md/.cs)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Without GH_REPO, gh pr edit/label create cannot infer the target repo.
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LABEL: cjk-residue
+        run: |
+          set -uo pipefail
+
+          # Run the discriminating guard over the whole fleet (notebooks + git-
+          # tracked .py/.md/.cs). --json for the file list; --check sets exit code.
+          python scripts/notebook_tools/detect_cjk_residue.py --json --check \
+            > payload.json 2> scan.log || true
+          cat payload.json
+
+          LEAKS=$(python -c "import json; d=json.load(open('payload.json')); print(d['total_hits'])")
+          echo "CJK leak lines on this PR's base: $LEAKS"
+
+          if [ "$LEAKS" -gt 0 ]; then
+            FILES=$(python -c \
+              "import json; d=json.load(open('payload.json')); \
+               print('\n'.join('- '+r['path'] for r in d['results'] if r['allowed'] is None and r['hits']))")
+            echo "::notice::CJK residue detected ($LEAKS leak line(s)) across: $FILES -- see the '$LABEL' label (#8826/#8428)."
+            gh label create "$LABEL" \
+              --description "CJK residue: a Chinese/Japanese word soldered into Latin prose (#8428/#8826)" \
+              --color "D93F0B" --force 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --add-label "$LABEL" || true
+          else
+            echo "No CJK residue detected."
+            # A label from an earlier push is now stale -- remove it so the signal
+            # stays trustworthy (self-cover lets this branch run on the fix commit).
+            gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
+          fi
+          exit 0

--- a/scripts/notebook_tools/detect_cjk_residue.py
+++ b/scripts/notebook_tools/detect_cjk_residue.py
@@ -438,6 +438,12 @@ def _scan_one(path: Path, root: Path) -> dict:
     return scan_source_file(path, root)
 
 
+# Extensions the PR-diff (--stdin) mode scans. Mirrors the fleet scope
+# (notebooks + tracked .py/.md/.cs): a .yml/.json/.lock in the diff is NOT read
+# as Latin prose, so it is skipped rather than risk a content-judgement false hit.
+_SCANNABLE_EXT = {".ipynb", ".py", ".md", ".cs"}
+
+
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
         description=__doc__.split("\n\n")[0],
@@ -451,10 +457,35 @@ def main(argv=None) -> int:
     parser.add_argument("--root", default=".", help="Repo root (default: cwd)")
     parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
     parser.add_argument("--check", action="store_true", help="Exit 1 if any CJK leak (CI-ready)")
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read paths to scan from stdin (one per line, as `git diff "
+             "--name-only` emits). Decides the leak verdict on exactly the PR's "
+             "changed files, not the whole fleet -- so a label can be attributed "
+             "to the PR that introduced the leak rather than to every PR while "
+             "main carries pre-existing residue (#8829 review).",
+    )
     args = parser.parse_args(argv)
 
     root = Path(args.root).resolve()
-    if args.target:
+    if args.stdin:
+        # PR-diff mode (#8829 review): scan only the leak-bearing files the PR
+        # touches. The fleet scan (below, in the workflow) stays informational.
+        # Filter to scannable extensions so a .yml/.json in the diff is not read
+        # as prose (would match the fleet scope: notebooks + .py/.md/.cs only).
+        results = []
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            p = Path(line)
+            if not p.is_absolute():
+                p = root / p
+            if p.suffix not in _SCANNABLE_EXT or not p.exists():
+                continue
+            results.append(_scan_one(p, root))
+    elif args.target:
         p = Path(args.target)
         if not p.is_absolute():
             p = root / p

--- a/scripts/notebook_tools/detect_cjk_residue.py
+++ b/scripts/notebook_tools/detect_cjk_residue.py
@@ -1,104 +1,227 @@
 #!/usr/bin/env python3
-"""Detecte les residus de glyphes CJK (corruption LLM-translation) dans les notebooks.
+"""Detecte les residus CJK (corruption LLM-translation) dans les notebooks ET les sources trackees.
 
 Pourquoi cet outil existe
 -------------------------
-Le defect fleet-wide #8428 : des mots chinois inseres mid-prose francaise/anglaise
-pendant la generation/enrichissement des notebooks par un LLM (ex `风险管理` risk
-management, `胜利=1` victoire, `分布式约束优化` distributed constraint optimization,
-`dataset支撑`, `arbre de分支`). 8 PRs sur 2026-07-25 (#8430/#8433/#8434/#8437/#8455/
-#8461/#8465/#8523) ont elimine ces residus a la main, un notebook a la fois. Chaque
-defaut est decouvert tardivement, ad-hoc, par le worker qui tombe dessus.
+Le defect fleet-wide #8428 : des mots chinois/japonais inseres mid-prose
+francaise/anglaise pendant la generation/enrichissement par un LLM (ex `dataset支撑`,
+`arbre de分支`, `均匀ément`, `de重建`). 8 PRs sur 2026-07-25 ont elimine ces residus
+a la main. Ce tool formalise la moitie DETECTION pour empecher la recidive.
 
-Ce tool formalise la moitie DETECTION : il liste toute cellule (markdown OU code) qui
-contient un glyphe CJK inattendu, pour empecher la classe de defect de RECIDIVER
-(regression-guard). C'est la fermeture naturelle de #8428 : apres le sweep manuel,
-le guard veille que le reservoir ne se re-remplit pas silencieusement.
+#8826 : le guard existait mais etait cable sur RIEN (aucun workflow ne l appelait)
+et ne voyait que les .ipynb. Le reservoir s est donc re-rempli silencieusement :
+#8823 a introduit `«经验 manquante»` dans un .py -- invisible au detecteur (scope
+ipynb) et de toute facon jamais execute (pas de cablage). Ce tool desormais
+(a) est cable par .github/workflows/cjk-residue-advisory.yml, (b) couvre les .ipynb
+ET les .py/.md/.cs trackees. Il DETECTE, il ne CORRIGE PAS -- la correction est un
+grain de substance separe (byte-surgical replacement, cf #8428).
 
-Il DETECTE, il ne CORRIGE PAS. La correction (remplacer la phrase CJK par le terme
-francais/anglais correct en contexte) est un travail de substance par notebook
-(byte-surgical raw-text replacement, cf #8428 fix pattern). Cet outil guide la
-vigilance en listant les candidats au commit/CI.
+Discriminateur #8826 (inverser le ratio signal/bruit)
+-----------------------------------------------------
+Le defect a une signature mecanisable : un mot chinois/japonais SOUDE ou depose en
+pleine prose latine. La regle : un run CJK est une FUITE si son scope englobant
+(un span protege backtick/double-quote/guillemet, ou la ligne hors span) contient a
+la FOIS du CJK et une lettre latine [A-Za-z+A-y]. Le CJK legitime vit dans un scope
+PUR-CJK (terme backticke `风险管理`, fixture `"你好"`, ligne de demo entierement CJK)
+-- sans lettre latine -- et est laisse tranquille.
 
-Discriminateur (G.1, lecons des faux positifs)
-----------------------------------------------
-Un genuine CJK residue = un glyphe des plages CJK (`　-鿿` unified ideographs
-+ symbols, `＀-￯` halfwidth/fullwidth forms) dans un notebook pedagogique
-FR/EN, SANS justification multilingue. Le_detecteur est CONSERVATEUR : il signale
-tout glyphe CJK non explicitement allowlisté.
+Un backtick span qui MIXE CJK+Latin (ex `dataset支撑`) reste une fuite : le CJK y est
+un mot latin corrompu, meme s il est backticke. Les fichiers qui DOCUMENTENT les
+patterns de fuite (ce detecteur, son README, ses tests, les ledgers) sont allowlistes
+par chemin -- ALLOWED est l echappatoire pour le legit irreductible (prompt
+fonctionnel comfyui, kanji visible dans une image, demo multilingue, verbatim preserve
+par l extracteur de traduction), PAS le mecanisme principal.
 
-Filtres faux-positifs (EXCLUS — CJK legitime)
----------------------------------------------
-- Notebooks multilingues legiTIME : la demo TTS japonaise
-  `GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb` contient volontairement du
-  japonais (`こんにちは！多言語音声合成のデモンストレーションです。`) pour demontrer
-  la synthese multilingue. Allowliste avec raison documentee.
-- Notebooks multilingues legiTIME (suite) : `GenAI/Texte/9_Production_Patterns.ipynb`
-  cell[20] demontre une salutation multilingue (`你好，世界！` = « Hello World » mandarin,
-  aux cotes de l'italien). Allowliste avec raison documentee.
-- Residu gated connu : a titre exceptionnel, un notebook dont le residu CJK exige une
-  re-exec gated (ex QuantBook via QC Cloud) peut etre allowliste de façon temporaire,
-  documente comme « known gated residual — fix needs <env> re-exec », pour ne pas bloquer
-  le CI sur un defect connu et tracé. Retirer de l'allowlist des que re-executed.
-  ATTENTION G.1 : verifier que le special-exec est REELLEMENT requis (kernel type, usage
-  QuantBook) — le filename/famille ne suffit pas. « Allowlisted/needs-special-exec » n'est
-  pas un bouton defer : un residu en commentaire ou un notebook Python local n'a pas besoin
-  de QC Cloud. (Incident c.889 : QC-Py-Cloud-03 etait faussement allowliste « needs
-  QC-Cloud » alors qu'il est Python local — defect fixe par re-exec locale en #8553.)
+Les Halfwidth/Fullwidth forms (U+FF00-FFEF : ￢ not logique, ：deux-points pleine-
+chasse) sont EXCLUES : variantes typographiques d ASCII, pas des mots chinois. Aucune
+des 7 fuites mesurees n utilise la pleine-chasse ; l inclure ferait hurler les slides
+de logique (￢) et les regex (：) pour du bruit. Les blocs de code fences sont ignores
+(leur CJK est du config/output, pas de la prose).
 
-ALLOWED = dictionnaire {substring de chemin: raison}. Un notebook dont le chemin
-contient une cle de ALLOWED est skip entierement (toutes ses cellules CJK sont
-legitimes/connues). La liste est volontairement courte et documentee : ajouter une
-entree exige de justifier la legitimite du CJK (vraie demo multilingue) ou de
-tracer un gated residual.
+Mesure sur origin/main : 5 fuites reelles (MANIFEST/README .md) detectees, 0 faux
+positif, 12 fichiers legit allowlistes -- ratio signal/bruit redresse.
+
+ALLOWED = dictionnaire {substring de chemin: raison}. Un fichier dont le chemin
+contient une cle est skip entierement. Liste courte et documentee : chaque entree
+justifie le caractere irreductible du CJK (fonctionnel, docs, fixture).
 
 Usage
 -----
-    python detect_cjk_residue.py NB.ipynb                 # un notebook
-    python detect_cjk_residue.py --family Probas          # une famille
-    python detect_cjk_residue.py                           # toute la flotte
-    python detect_cjk_residue.py NB.ipynb --json          # sortie machine
-    python detect_cjk_residue.py --check                  # exit 1 si hits (CI-ready)
+    python detect_cjk_residue.py                        # toute la flotte (notebooks + sources)
+    python detect_cjk_residue.py NB.ipynb               # un notebook
+    python detect_cjk_residue.py path/leak.md           # un fichier source
+    python detect_cjk_residue.py --family Probas        # une famille
+    python detect_cjk_residue.py --json                 # sortie machine
+    python detect_cjk_residue.py --check                # exit 1 si fuite (CI-ready)
 
 Exit codes
 ----------
-    0 -- aucun residu inattendu detecte (ou mode non --check)
-    1 -- un ou plusieurs residus detectes (--check seulement)
-    2 -- erreur (notebook illisible, famille introuvable)
+    0 -- aucune fuite CJK detectee (ou mode non --check)
+    1 -- une ou plusieurs fuites detectees (--check seulement)
+    2 -- erreur (fichier illisible, famille introuvable)
 
 Voir aussi
 ----------
-- `detect_ascii_workaround.py` (#3801) -- pattern de detecteur read-only + filtres FP
-- `detect_accent_stripping.py` (#6806) -- baseline honnete + convention detect_*
-- #8428 -- le defect fleet-wide que ce guard cloture (anti-recidive)
+- `.github/workflows/cjk-residue-advisory.yml` (#8826) -- cablage advisory (label)
+- `detect_ascii_workaround.py` (#3801), `detect_accent_stripping.py` (#6806) -- pattern detect_*
+- #8428 (defect fondateur), #8826 (discriminateur + scope sources + cablage)
 
-See #8428.
+See #8428, #8826.
 """
 from __future__ import annotations
 
 import argparse
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
-# --- Plages CJK (alignees sur la def #8428) ---
+# --- Plages CJK (alignees sur la classe de residu #8428/#8826) ---
 # 　-〿 : CJK symbols and punctuation
 # ぀-ゟ : Hiragana  (JP TTS demo legitime -> allowlist)
 # ゠-ヿ : Katakana
-# 一-鿿 : CJK unified ideographs (le reservoir principal des residus chinois)
-# ＀-￯ : Halfwidth and Fullwidth forms
-CJK_RE = re.compile(r"[　-〿぀-ゟ゠-ヿ一-鿿＀-￯]")
+# 一-鿿 : CJK unified ideographs (le reservoir principal des residus)
+# Les Halfwidth/Fullwidth forms (＀-￯, ex. ￢ not logique U+FFE2,
+# ： deux-points pleine-chasse U+FF1A) sont EXCLUES : variantes typographiques
+# d ASCII, pas des mots chinois. Le defect #8428/#8826 est des MOTS chinois/
+# japonais (ideographes + kana) soudes a la prose (均匀ément, de重建,
+# 可能性が高い) -- aucune des 7 fuites mesurees n utilise la pleine-chasse.
+# Inclure ＀-￯ ferait hurler les slides de logique (￢) et les regex
+# (：) pour du bruit, inversant le ratio signal/bruit que #8826 veut redresser.
+CJK_RE = re.compile(r"[　-〿぀-ゟ゠-ヿ一-鿿]")
 
 # --- Allowlist CJK legitime / residu gated connu ---
 # Un notebook dont le chemin (relatif au root) contient une cle est skip.
 # Chaque entree DOIT documenter la raison (demo multilingue legiTIME OU gated residual).
 ALLOWED: dict[str, str] = {
+    # --- Notebooks: deliberate multilingual demos (CJK is the subject) ---
     "GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb":
         "demo TTS multilingue legiTIME (japonais volontaire pour la synthese)",
     "GenAI/Texte/9_Production_Patterns.ipynb":
         "demo multilingue legiTIME (cell[20]: 你好，世界！ = 'Hello World' mandarin, aux cotes de Ciao mondo! italien)",
+    # --- Source files: irreducible legit CJK that mixes with Latin (#8826) ---
+    # The detector itself DOCUMENTS the leak class in its docstring (cites
+    # `dataset支撑`, `arbre de分支` as examples) -- those mixed spans are the
+    # spec, not residue. A guard must not flag its own rule book.
+    "scripts/notebook_tools/detect_cjk_residue.py":
+        "self -- docstring cite les patterns de fuite en exemple (spec, pas residu)",
+    # The detector's own test suite carries the leak phrases as POSITIVE
+    # fixtures (it must, to prove detection) -- mixed CJK+Latin by design.
+    "scripts/notebook_tools/tests/test_detect_cjk_residue.py":
+        "fixtures de test positif (patterns de fuite volontaires pour piner le contrat)",
+    # Functional model prompt: the Wan/Qwen negative prompt is canonically
+    # Chinese and mixes CJK with Latin tokens like `JPEG` (e.g. JPEG压缩残留).
+    # Not prose -- a model input. Replacing it would break generation.
+    "GenAI/shared/helpers/comfyui_client.py":
+        "negative prompt canonique du modele Wan/Qwen (CJK fonctionnel, pas prose)",
+    # GenAI Image MANIFEST: the CJK is a kanji VISIBLE IN the described image
+    # (e.g. 北小路 on a sign) -- the prose names what the image shows. Functional.
+    "GenAI/Image/02-Advanced/assets/readme/MANIFEST.md":
+        "kanji visible dans l image decrite (le prose nomme le contenu de l image)",
+    # SOTA-axe2 ledger: DISCUSSES the CJK-residue defect class as its subject
+    # (cites 绑定, 完整 to document findings). Quoting leaks to analyse them != leaking.
+    "docs/ledgers/3801-sota-axe2.md":
+        "ledger qui cite le defect CJK comme sujet d analyse (pas de la prose leak)",
+    # notebooks_tools README: documents the leak examples (`dataset支撑`, etc.)
+    # in backticks -- the spec of what the detector hunts, not residue.
+    "scripts/notebook_tools/README.md":
+        "documente les patterns de fuite en exemple (spec du detecteur)",
+    # Translation-sync test: a deliberate `"你好 world 123"` fixture proving the
+    # script detector sees CJK in a mixed Latin string. Mixed by design.
+    "scripts/tests/test_check_translation_sync.py":
+        "fixture de test volontaire (string CJK+Latin pour piner le detecteur de script)",
+    # Translations READMEs: the CJK (完整, etc.) is preserved VERBATIM by the
+    # deterministic extractor (a sha256-16 anchor would drift otherwise). The
+    # whole point is to keep the original glyph exact -- not residue.
+    "translations/sudoku/README.md":
+        "CJK preserve verbatim par l extracteur deterministe (ancrage sha256)",
+    "translations/search-part1/README.md":
+        "CJK preserve verbatim par l extracteur deterministe (ancrage sha256)",
+    "translations/search-part2/README.md":
+        "CJK preserve verbatim par l extracteur deterministe (ancrage sha256)",
 }
+
+# --- Discriminateur #8826 : CJK mixe a du Latin = fuite ; CJK pur = legitime ---
+# Un residu #8428/#8826 a une signature mecanisable : un mot chinois/japonais
+# SOUDE ou depose en pleine prose latine -- `均匀ément`, `de重建`, `la 拥挤 city`,
+# `«经验 manquante»`, `—可能性が高い c'est`. Le CJK et le Latin cohabitent dans
+# le meme SCOPE (un span protege backtick/guillemet, ou la ligne hors span).
+# A l'inverse, le CJK legitime vit dans un scope PUR-CJK (terme backticke
+# `风险管理`, fixture de test `"你好"`, ligne de demo multilingue entierement CJK)
+# -- sans aucune lettre latine. Cette regle separe les 7 vraies fuites des ~59
+# cas legitimes SANS allowlist par defaut (mesure #8826).
+LATIN_RE = re.compile(r"[A-Za-zÀ-ÿ]")
+
+# Spans proteges : backtick (inline code markdown), doubles quotes droites/
+# courbes, guillemets francais. Le CONTENU d'un span est legitime s'il est
+# pur-CJK ; s'il MIXE CJK+Latin (ex `«经验 manquante»`), le CJK est une fuite
+# (un mot latin corrompu). Les simples quotes sont EXCLUES : les apostrophes
+# francaises (l', d', c'est) rendent l'appariement non fiable (masquerait de
+# vraies fuites ou inventerait des spans fantomes).
+_SPAN_RE = re.compile(
+    r"(`[^`\n]*`)"        # backtick
+    r"|(\"[^\"\n]*\")"    # double quote droite
+    r"|(«[^»\n]*»)"       # guillemets francais
+    r"|(“[^”\n]*”)"       # double quote courbe
+)
+
+# Ouverture de bloc de code fence (``` ou ~~~). Les lignes DANS un fence sont
+# du config/output colle, pas de la prose : on les ignore.
+_FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+
+
+def _context(line: str) -> str:
+    """A ~60-char window around the first CJK glyph in ``line`` (single-line)."""
+    m = CJK_RE.search(line)
+    start = m.start() if m else 0
+    return line[max(0, start - 30): start + 30].replace("\n", " ")
+
+
+def _judge_segment(seg: str, lineno: int, line: str, leaks: list, *, protected: bool) -> None:
+    """Append a leak if ``seg`` carries CJK AND a Latin letter (the defect
+    signature). Pure-CJK segments (no Latin) are legitimate -- do nothing."""
+    glyphs = CJK_RE.findall(seg)
+    if not glyphs:
+        return
+    if LATIN_RE.search(seg):
+        leaks.append({
+            "lineno": lineno,
+            "glyphs": glyphs,
+            "protected": protected,
+            "context": _context(line),
+            "reason": ("CJK mixe a du Latin dans un span protege (mot latin corrompu)"
+                       if protected else
+                       "CJK en pleine prose latine (hors backticks/guillemets)"),
+        })
+    # else: scope pur-CJK (terme backticke, fixture, ligne de demo) -> legitime.
+
+
+def classify_cjk_leaks(text: str) -> list[dict]:
+    """Return the CJK *leaks* in ``text`` (a notebook cell source OR a source
+    file body). See the discriminator block above for the rule.
+
+    Each leak dict: ``{lineno, glyphs, protected, context, reason}``. A text
+    with only legitimate CJK (backticked terms, pure-CJK quoted strings, CJK-only
+    lines, fenced code blocks) yields an empty list.
+    """
+    leaks: list[dict] = []
+    in_fence = False
+    for lineno, line in enumerate(text.split("\n"), start=1):
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        # Decoupe la ligne en spans proteges + fragments libres; juge chaque
+        # segment porteur de CJK sur la presence concurrente de Latin.
+        pos = 0
+        for m in _SPAN_RE.finditer(line):
+            _judge_segment(line[pos:m.start()], lineno, line, leaks, protected=False)
+            _judge_segment(m.group(0), lineno, line, leaks, protected=True)
+            pos = m.end()
+        _judge_segment(line[pos:], lineno, line, leaks, protected=False)
+    return leaks
 
 
 def _cell_source(cell: dict) -> str:
@@ -109,22 +232,25 @@ def _cell_source(cell: dict) -> str:
 
 
 def detect_cell(src: str) -> dict | None:
-    """Return a finding dict if `src` (any cell type) carries unexpected CJK glyphs, else None.
+    """Return a finding dict if `src` (any cell type) carries a CJK *leak*
+    (CJK mixed into Latin prose), else None.
 
-    Returns the count + the distinct glyphs + the first context window, so a human
-    can judge whether it is genuine residue or a new legitimate multilingual case
-    (which should then be added to ALLOWED with a reason).
+    Uses the #8826 discriminator (``classify_cjk_leaks``): pure-CJK content
+    (backticked terms, quoted fixtures, multilingual demo lines) is legitimate
+    and returns None. The count/glyphs/context describe the LEAK glyphs only,
+    so a human can judge whether it is genuine residue or a new legitimate
+    multilingual case (which should then be added to ALLOWED with a reason).
     """
-    glyphs = CJK_RE.findall(src)
-    if not glyphs:
+    leaks = classify_cjk_leaks(src)
+    if not leaks:
         return None
-    first = CJK_RE.search(src)
-    start = first.start() if first else 0
-    context = src[max(0, start - 30): start + 30].replace("\n", " ")
+    all_glyphs: list[str] = []
+    for lk in leaks:
+        all_glyphs.extend(lk["glyphs"])
     return {
-        "count": len(glyphs),
-        "glyphs": sorted(set(glyphs)),
-        "context": context,
+        "count": len(all_glyphs),
+        "glyphs": sorted(set(all_glyphs)),
+        "context": leaks[0]["context"],
     }
 
 
@@ -159,6 +285,34 @@ def scan_notebook(path: Path, root: Path) -> dict:
     return {"path": rel, "allowed": None, "hits": hits, "error": None}
 
 
+# Extensions de source que le guard couvre desormais (#8826) en plus des .ipynb.
+SOURCE_EXTS = (".py", ".md", ".cs")
+
+
+def scan_source_file(path: Path, root: Path) -> dict:
+    """Return a result dict for one tracked source file (.py/.md/.cs): path,
+    allowed, hits[], error. Uses the same #8826 discriminator as notebook cells
+    -- a CJK leak is CJK mixed into Latin prose, not any CJK glyph."""
+    try:
+        rel = str(path.relative_to(root)).replace("\\", "/")
+    except ValueError:
+        rel = str(path).replace("\\", "/")
+    allowed_reason = _is_allowed(rel)
+    if allowed_reason:
+        return {"path": rel, "allowed": allowed_reason, "hits": [], "error": None}
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return {"path": rel, "allowed": None, "hits": [], "error": str(exc)}
+    leaks = classify_cjk_leaks(text)
+    hits = [
+        {"lineno": lk["lineno"], "glyphs": lk["glyphs"],
+         "context": lk["context"], "reason": lk["reason"]}
+        for lk in leaks
+    ]
+    return {"path": rel, "allowed": None, "hits": hits, "error": None}
+
+
 # Marcheur + SKIP_DIRS canonique centralises dans notebook_walk (#8650).
 from notebook_walk import SKIP_DIRS, _OUTPUT_SUFFIX, iter_notebooks  # noqa: E402
 
@@ -174,6 +328,58 @@ def _iter_notebooks(root: Path, family: str | None):
     yield from iter_notebooks(root / "MyIA.AI.Notebooks", family=family)
 
 
+def _submodule_paths(root: Path) -> set[str]:
+    """Submodule mount paths (posix, repo-root-relative), to exclude source
+    scanning defensively. ``git ls-files`` already omits submodule *contents*
+    (they are gitlinks, not files), but a checked-out submodule working tree can
+    leave files on disk -- belt-and-suspenders for #8826's 'submodules exclus'."""
+    try:
+        result = subprocess.run(
+            ["git", "submodule", "status"],
+            cwd=str(root), capture_output=True, text=True, timeout=30,
+        )
+    except (FileNotFoundError, OSError):
+        return set()
+    if result.returncode != 0:
+        return set()
+    paths: set[str] = set()
+    for line in result.stdout.splitlines():
+        parts = line.strip().split()
+        if len(parts) >= 2:
+            paths.add(parts[1].replace("\\", "/"))
+    return paths
+
+
+def _iter_tracked_sources(root: Path, family: str | None):
+    """Yield git-tracked .py/.md/.cs paths under ``root``, excluding SKIP_DIRS
+    and submodule mounts. Enumerates via ``git ls-files`` (source of truth for
+    'tracked' -- naturally drops gitignored trees and submodule contents)."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-z", "--", "*.py", "*.md", "*.cs"],
+            cwd=str(root), capture_output=True, text=False, timeout=180,
+        )
+    except (FileNotFoundError, OSError):
+        return
+    if result.returncode != 0:
+        return
+    sub_paths = _submodule_paths(root)
+    prefix = f"MyIA.AI.Notebooks/{family}/" if family else None
+    entries = result.stdout.decode("utf-8", "replace").strip("\x00").split("\x00")
+    for e in entries:
+        if not e:
+            continue
+        rel = e.replace("\\", "/")
+        parts = rel.split("/")
+        if any(part in SKIP_DIRS for part in parts):
+            continue
+        if any(rel == sp or rel.startswith(sp + "/") for sp in sub_paths):
+            continue
+        if prefix and not rel.startswith(prefix):
+            continue
+        yield root / rel
+
+
 def _human_report(results: list[dict]) -> str:
     scanned = [r for r in results if r["allowed"] is None and r["error"] is None]
     allowed = [r for r in results if r["allowed"]]
@@ -181,9 +387,9 @@ def _human_report(results: list[dict]) -> str:
     total_hits = sum(len(r["hits"]) for r in scanned)
     affected = [r for r in scanned if r["hits"]]
     lines = [
-        f"Notebooks scanned : {len(scanned)}",
-        f"Cells with CJK residue : {total_hits}",
-        f"Affected notebooks : {len(affected)}",
+        f"Files scanned (notebooks + sources) : {len(scanned)}",
+        f"CJK leak lines : {total_hits}",
+        f"Affected files : {len(affected)}",
         f"Allowed (skipped) : {len(allowed)}",
         "",
     ]
@@ -206,18 +412,30 @@ def _human_report(results: list[dict]) -> str:
         for h in r["hits"]:
             glyphs = "".join(h["glyphs"])
             ctx = f"  | ...{h['context']}..." if h["context"] else ""
-            lines.append(
-                f"  - cell [{h['cell_index']}] ({h['cell_type']}): "
-                f"{h['count']} glyph(s) [{glyphs}]{ctx}"
-            )
+            if "cell_index" in h:
+                loc = f"cell [{h['cell_index']}] ({h['cell_type']})"
+                n = h.get("count", len(h["glyphs"]))
+            else:
+                loc = f"line {h['lineno']}"
+                n = len(h["glyphs"])
+            reason = f"  -- {h['reason']}" if h.get("reason") else ""
+            lines.append(f"  - {loc}: {n} glyph(s) [{glyphs}]{ctx}{reason}")
         lines.append("")
     lines.append(
-        "NOTE: conservative detector. Verify each hit firsthand -- if a notebook "
-        "carries LEGITIMATE multilingual CJK (demo TTS, language course), add it to "
-        "ALLOWED in detect_cjk_residue.py with a documented reason rather than "
-        "stripping the glyphs."
+        "NOTE: discriminating detector (#8826). A hit is CJK mixed into Latin "
+        "prose -- verify each firsthand. If a file carries LEGITIMATE mixed CJK "
+        "(functional prompt, docstring citing examples, multilingual demo), add it "
+        "to ALLOWED with a documented reason rather than stripping the glyphs."
     )
     return "\n".join(lines)
+
+
+def _scan_one(path: Path, root: Path) -> dict:
+    """Dispatch a single target: notebook (.ipynb) -> scan_notebook, source
+    (.py/.md/.cs) -> scan_source_file. Other extensions are read as text."""
+    if path.suffix == ".ipynb":
+        return scan_notebook(path, root)
+    return scan_source_file(path, root)
 
 
 def main(argv=None) -> int:
@@ -225,33 +443,44 @@ def main(argv=None) -> int:
         description=__doc__.split("\n\n")[0],
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("notebook", nargs="?", help="Notebook to scan (default: all pedagogical)")
+    parser.add_argument(
+        "target", nargs="?",
+        help="Notebook OR source file (.py/.md/.cs) to scan (default: whole fleet)",
+    )
     parser.add_argument("--family", help="Top-level family under MyIA.AI.Notebooks/ (e.g. Probas, ML)")
     parser.add_argument("--root", default=".", help="Repo root (default: cwd)")
     parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
-    parser.add_argument("--check", action="store_true", help="Exit 1 if any unexpected CJK hit (CI-ready)")
+    parser.add_argument("--check", action="store_true", help="Exit 1 if any CJK leak (CI-ready)")
     args = parser.parse_args(argv)
 
     root = Path(args.root).resolve()
-    if args.notebook:
-        paths = [Path(args.notebook)]
-        if not paths[0].is_absolute():
-            paths[0] = root / paths[0]
-        if not paths[0].exists():
-            print(f"error: notebook not found: {paths[0]}", file=sys.stderr)
+    if args.target:
+        p = Path(args.target)
+        if not p.is_absolute():
+            p = root / p
+        if not p.exists():
+            print(f"error: target not found: {p}", file=sys.stderr)
             return 2
+        results = [_scan_one(p, root)]
     else:
-        paths = list(_iter_notebooks(root, args.family))
-        if args.family and not paths:
+        # Fleet scan (#8826): pedagogical notebooks + tracked source files
+        # (.py/.md/.cs) so the reservoir cannot refill in prose OR code.
+        nb_paths = list(_iter_notebooks(root, args.family))
+        src_paths = list(_iter_tracked_sources(root, args.family))
+        results = (
+            [scan_notebook(p, root) for p in nb_paths]
+            + [scan_source_file(p, root) for p in src_paths]
+        )
+        if args.family and not nb_paths and not src_paths:
             print(f"error: family not found: {args.family}", file=sys.stderr)
             return 2
 
-    results = [scan_notebook(p, root) for p in paths]
     total_hits = sum(len(r["hits"]) for r in results if r["allowed"] is None)
+    scanned = sum(1 for r in results if r["allowed"] is None and r["error"] is None)
 
     if args.json:
         payload = {
-            "notebooks_scanned": sum(1 for r in results if r["allowed"] is None),
+            "scanned": scanned,
             "total_hits": total_hits,
             "results": results,
         }

--- a/scripts/notebook_tools/tests/test_detect_cjk_residue.py
+++ b/scripts/notebook_tools/tests/test_detect_cjk_residue.py
@@ -30,6 +30,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 # Make the sibling detector importable regardless of invocation cwd.
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE.parent))
@@ -75,9 +77,17 @@ class TestDetectCell:
         # sorted by codepoint: 利 (U+5229) < 胜 (U+80DC)
         assert finding["glyphs"] == ["利", "胜"]
 
-    def test_fullwidth_form_detected(self):
-        finding = mod.detect_cell("largeur：50")  # fullwidth colon ＀-￯ range
-        assert finding is not None
+    def test_fullwidth_form_not_in_leak_class(self):
+        # #8826: Halfwidth/Fullwidth forms (＀-￯) are EXCLUDED from the leak
+        # detector -- typographic ASCII variants (fullwidth colon ：U+FF1A,
+        # logical-not ￢ U+FFE2), not Chinese WORDS. The #8428 residue class is
+        # unified ideographs + kana. `largeur：50` (fullwidth colon) is therefore
+        # NOT flagged: including ＀-￯ inverted signal/noise (logic slides ￢,
+        # regex ：) -- none of the 7 measured leaks uses fullwidth.
+        assert mod.detect_cell("largeur：50") is None
+        # Sanity: a fullwidth char adjacent to a REAL ideograph leak still flags
+        # (the ideograph is the residue, the fullwidth is incidental).
+        assert mod.detect_cell("largeur 风：50") is not None
 
     def test_clean_french_prose_no_hit(self):
         assert mod.detect_cell("L'optimisation de contraintes distribuées.") is None
@@ -180,5 +190,142 @@ class TestMainExitCodes:
         rc = mod.main(["--root", str(tmp_path), str(p), "--json"])
         out = json.loads(capsys.readouterr().out)
         assert out["total_hits"] == 1
-        assert out["notebooks_scanned"] == 1
+        assert out["scanned"] == 1
         assert rc == 0  # --json without --check does not fail
+
+
+# ===========================================================================
+# #8826 -- discriminating guard: CJK soldered into/dropped into Latin = leak;
+# pure-CJK (backticked term, quoted fixture, CJK-only line) = legit. The guard
+# must invert the signal/noise ratio: the 7 measured leaks are the POSITIVE
+# control; the legit multilingual/functional CJK is the NEGATIVE control.
+# ===========================================================================
+
+
+class TestDiscriminator:
+    """Unit tests for classify_cjk_leaks -- the #8826 scope-mixed rule."""
+
+    def test_soldered_cjk_latin_is_leak(self):
+        # CJK directly adjacent to a Latin letter, no separator (均匀ément).
+        leaks = mod.classify_cjk_leaks("volume plus均匀ément distribue")
+        assert leaks, "soldered CJK+Latin must be a leak"
+        assert "均" in leaks[0]["glyphs"]
+
+    def test_latin_cjk_soldered_other_direction(self):
+        # Latin immediately before CJK (de重建).
+        leaks = mod.classify_cjk_leaks("Necessite de重建 l'environnement")
+        assert leaks
+        assert "重" in leaks[0]["glyphs"]
+
+    def test_mid_latin_phrase_is_leak(self):
+        # A CJK run dropped into an otherwise-Latin line, spaces around it
+        # (可能性が高い = "fort probablement" in JP, in a French sentence).
+        leaks = mod.classify_cjk_leaks("G.1 n'a pas detecte —可能性が高い c'est (1)")
+        assert leaks
+        assert any("可" in lk["glyphs"] for lk in leaks)
+
+    def test_pure_cjk_backtick_span_is_legit(self):
+        # A backticked CJK term in a Latin line is NOT a leak (`` `风险管理` ``).
+        leaks = mod.classify_cjk_leaks("See `风险管理` (risk management) for details.")
+        assert leaks == [], "pure-CJK backtick span in a Latin line is legit"
+
+    def test_mixed_backtick_span_is_leak(self):
+        # A backtick span that MIXES CJK+Latin (`` `dataset支撑` ``) is a leak:
+        # the CJK is a corrupted Latin word, even though backticked. This is why
+        # files that DOCUMENT leak examples (detector, README, tests) need ALLOWED.
+        leaks = mod.classify_cjk_leaks("exemple typique: `dataset支撑` et `arbre de分支`")
+        assert leaks, "mixed CJK+Latin span is a leak even inside backticks"
+
+
+class TestLegitPureCjk:
+    def test_pure_cjk_string_value_no_leak(self):
+        leaks = mod.classify_cjk_leaks('prompt = "负面提示词"  # the negative prompt')
+        assert leaks == [], "a pure-CJK quoted value (no Latin inside) is legit"
+
+    def test_cjk_only_line_no_leak(self):
+        # An integrally-CJK line (multilingual demo) -- no Latin letters at all.
+        leaks = mod.classify_cjk_leaks("こんにちは！多言語音声合成のデモンストレーションです。")
+        assert leaks == [], "a CJK-only line is legit (no Latin to intrude into)"
+
+    def test_fenced_code_block_cjk_skipped(self):
+        # CJK inside a ``` fence is config/output, not prose -- skipped.
+        text = (
+            "Intro line in French.\n"
+            "```yaml\n"
+            "prompt: 风险管理 is not residue here\n"
+            "```\n"
+            "Outro in French.\n"
+        )
+        leaks = mod.classify_cjk_leaks(text)
+        assert leaks == [], "CJK inside a fenced code block is skipped"
+
+    def test_fullwidth_logic_not_not_flagged(self):
+        # ￢ (U+FFE2 fullwidth not) in a logic formula is NOT in the leak class.
+        leaks = mod.classify_cjk_leaks("Ex: ￢B1,1 ∨ P1,2 (propositional logic)")
+        assert leaks == [], "fullwidth logical-not is not CJK-word residue (#8826 narrowing)"
+
+
+class TestLeakPatterns:
+    """POSITIVE CONTROL (#8826 acceptance 4): the 7 measured leak patterns MUST
+    be detected. These are the exact residues from the #8826 census (5 non-archive;
+    the 2 docs/archive ones are the same class). A guard never seen to fire is not
+    a guard (#8681)."""
+
+    @pytest.mark.parametrize("phrase,glyph", [
+        ("volume plus均匀ément distribue", "均"),      # ML-XGBoost README:70
+        ("volume均等ément distribue", "均"),           # ML-XGBoost MANIFEST:139
+        ("la zone supérieure est拥挤", "拥"),          # ML.Net MANIFEST:59
+        ("Le rédacteur原始 ne pouvait pas", "原"),     # EMA-Cross MANIFEST:87
+        ("Le rédacteur原始 ne pouvait pas", "原"),     # LongShortHarvest MANIFEST:119
+        ("Necessite de重建 l'environnement", "重"),    # docs/archive RAPPORT (same class)
+        ("—可能性が高い c'est (1)", "可"),              # docs/archive ledger (same class)
+    ])
+    def test_measured_leak_detected(self, phrase, glyph):
+        leaks = mod.classify_cjk_leaks(phrase)
+        assert leaks, f"expected leak in {phrase!r}"
+        assert any(glyph in lk["glyphs"] for lk in leaks), (
+            f"{glyph!r} not in leak glyphs for {phrase!r}")
+
+
+class TestSourceFileScan:
+    """#8826: the guard now covers .py/.md/.cs, not just .ipynb -- that is where
+    #8823's `«经验 manquante»` lived (a .py), invisible to the ipynb-only scope."""
+
+    def test_md_file_leak_detected(self, tmp_path):
+        p = tmp_path / "README.md"
+        p.write_text("# Titre\n\nLe volume plus均匀ément distribue.\n", encoding="utf-8")
+        r = mod.scan_source_file(p, tmp_path)
+        assert r["allowed"] is None
+        assert len(r["hits"]) == 1
+        assert r["hits"][0]["lineno"] == 3
+
+    def test_py_file_pure_cjk_string_no_hit(self, tmp_path):
+        # A pure-CJK string literal in a .py is legit (no Latin in the span).
+        p = tmp_path / "x.py"
+        p.write_text('prompt = "负面提示词"\n', encoding="utf-8")
+        r = mod.scan_source_file(p, tmp_path)
+        assert r["hits"] == []
+
+    def test_py_file_soldered_leak_detected(self, tmp_path):
+        # #8823 class: a corrupted French word in a .py comment/string.
+        p = tmp_path / "learned_valence.py"
+        p.write_text("# 经验 manquante -- should be 'expérience'\n", encoding="utf-8")
+        r = mod.scan_source_file(p, tmp_path)
+        assert len(r["hits"]) == 1
+        assert r["hits"][0]["lineno"] == 1
+
+    def test_allowed_source_file_skipped(self, tmp_path):
+        # The detector's own ALLOWED path is skipped (irreducible legit).
+        nbtools = tmp_path / "scripts" / "notebook_tools"
+        nbtools.mkdir(parents=True)
+        p = nbtools / "detect_cjk_residue.py"
+        p.write_text("# docstring cites `dataset支撑` as the leak example\n", encoding="utf-8")
+        r = mod.scan_source_file(p, tmp_path)
+        assert r["allowed"] is not None
+        assert r["hits"] == []
+
+    def test_main_check_source_file_exits_1(self, tmp_path, capsys):
+        p = tmp_path / "dirty.md"
+        p.write_text("prose with 原始 leak\n", encoding="utf-8")
+        rc = mod.main(["--root", str(tmp_path), str(p), "--check"])
+        assert rc == 1

--- a/scripts/notebook_tools/tests/test_detect_cjk_residue.py
+++ b/scripts/notebook_tools/tests/test_detect_cjk_residue.py
@@ -26,6 +26,7 @@ The baseline validated c.884 on 937 pedagogical notebooks is **0 unexpected hits
 """
 from __future__ import annotations
 
+import io
 import json
 import sys
 from pathlib import Path
@@ -192,6 +193,60 @@ class TestMainExitCodes:
         assert out["total_hits"] == 1
         assert out["scanned"] == 1
         assert rc == 0  # --json without --check does not fail
+
+
+# ===========================================================================
+# #8829 review -- --stdin: decide the leak verdict on the PR's changed files
+# only (``git diff --name-only`` input), so the label attributes to the PR that
+# introduced the leak -- not to every PR while main carries pre-existing residue
+# in files the PR never touched.
+# ===========================================================================
+
+
+class TestStdinMode:
+    """--stdin reads paths from stdin and scans only those (the PR diff), not
+    the whole fleet. Non-scannable extensions (.yml/.json) are skipped."""
+
+    def test_stdin_scans_only_listed_files(self, tmp_path, monkeypatch, capsys):
+        dirty = tmp_path / "leak.md"
+        dirty.write_text("# volume plus均匀ément distribue\n", encoding="utf-8")
+        clean = tmp_path / "ok.py"
+        clean.write_text("x = 1\n", encoding="utf-8")
+        monkeypatch.setattr(sys, "stdin", io.StringIO(f"{dirty}\n{clean}\n"))
+        rc = mod.main(["--root", str(tmp_path), "--stdin", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0  # --json without --check never fails
+        assert out["total_hits"] == 1  # only the dirty .md leaks
+        assert out["scanned"] == 2  # both files scanned (dirty + clean)
+
+    def test_stdin_skips_non_scannable_extensions(self, tmp_path, monkeypatch, capsys):
+        # A .yml in the diff (e.g. this workflow editing itself) is NOT Latin
+        # prose -- scanning it could false-positive on a legit CJK entry. It is
+        # filtered out before scanning, so its CJK never reaches the results.
+        yml = tmp_path / "workflow.yml"
+        yml.write_text("name: 风险管理 demo\n", encoding="utf-8")
+        dirty = tmp_path / "leak.md"
+        dirty.write_text("# est拥挤 ici\n", encoding="utf-8")
+        monkeypatch.setattr(sys, "stdin", io.StringIO(f"{yml}\n{dirty}\n"))
+        rc = mod.main(["--root", str(tmp_path), "--stdin", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert out["total_hits"] == 1  # the .md only; .yml skipped entirely
+        assert out["scanned"] == 1
+
+    def test_stdin_check_exits_1_when_diff_carries_leak(self, tmp_path, monkeypatch):
+        dirty = tmp_path / "leak.md"
+        dirty.write_text("# de重建 needed\n", encoding="utf-8")
+        monkeypatch.setattr(sys, "stdin", io.StringIO(f"{dirty}\n"))
+        rc = mod.main(["--root", str(tmp_path), "--stdin", "--check"])
+        assert rc == 1
+
+    def test_stdin_check_exits_0_on_clean_diff(self, tmp_path, monkeypatch):
+        clean = tmp_path / "ok.py"
+        clean.write_text("print('bonjour')\n", encoding="utf-8")
+        monkeypatch.setattr(sys, "stdin", io.StringIO(f"{clean}\n"))
+        rc = mod.main(["--root", str(tmp_path), "--stdin", "--check"])
+        assert rc == 0
 
 
 # ===========================================================================


### PR DESCRIPTION
## What

`detect_cjk_residue.py` existed to close #8428 but was **wired to nothing** (`grep cjk .github/workflows/*.yml` = vide) and **saw only `.ipynb`**. So the reservoir refilled silently — #8823 introduced `«经验 manquante»` in a `.py`, invisible to the ipynb-only scope and never run anyway. This PR makes the organ **alive** and **discriminating**.

## The 5 #8826 deliverables

**1. Portée** — scope widened from `.ipynb` to git-tracked `.py`/`.md`/`.cs` (submodules excluded: `git ls-files` naturally omits their contents + a defensive mount filter). This is exactly where #8823's leak lived.

**2. Discrimination** — the #8826 rule, implemented as `classify_cjk_leaks`:
> A CJK run is a **leak** iff its enclosing scope (a protected backtick/double-quote/guillemet span, or the line outside one) carries **both** CJK **and** a Latin letter `[A-Za-zÀ-ÿ]`. Pure-CJK scopes (backticked term `` `风险管理` ``, quoted fixture `"你好"`, CJK-only demo line) are **legit**.

This inverts the signal/noise ratio the body demanded. **Measured on origin/main:**

| | conservative (any-CJK) | #8826 discriminator |
|---|---|---|
| signal | 7 | **5** |
| noise (false positives) | 59 | **0** |
| irreducible-legit ALLOWED | (would be ~59) | **12** |

The 12 ALLOWED entries are the genuinely irreducible cases (functional comfyui prompt `JPEG压缩残留`, the detector's own docstring citing examples, its test fixtures, ledgers that analyse the defect, GenAI Image MANIFEST kanji-in-image, translation verbatim preserves, multilingual demos) — ALLOWED is the escape hatch, **not** the primary mechanism.

**3. Câblage** — `.github/workflows/cjk-residue-advisory.yml`: an **advisory** workflow that poses/removes a `cjk-residue` **label**, **always exit 0** (the signal is the label, never the green conclusion — this guards a *content judgement*, unlike the blocking file-invariant label-paths-guard #8822). **Self-cover paths** (#8822 lesson, proven on exercises-advisory #8820): lists its own file + script + tests so it can re-run and remove its label on the fix commit.

**4. Le voir échouer** (#8681 — a guard never seen to fail is not a guard):
- **Positive control**: `TestLeakPatterns` parametrizes the **7 measured leak patterns** (均匀ément, 均等ément, 拥挤, 原始×2, de重建, 可能性が高い) — all detected.
- **Negative control**: `TestLegitPureCjk` / `TestDiscriminator` — pure-CJK spans, CJK-only lines, fenced code blocks, fullwidth logic-not → all legit (not flagged).
- **Fleet run**: `--check` exits **1** on the 5 non-archive leaks (proven red), exits 0 after a fix (proven green by the test fixtures).

**5. Sweep is separate** — the 7-leak content sweep is a **separate LIGHT grain** (G-VAR-1/2, per the body). This PR is the **organ only** — it does NOT touch the 5 leaked MANIFEST/README files.

## Design notes

- **CJK_RE narrowed**: dropped `U+FF00-FFEF` (halfwidth/fullwidth forms — ￢ logic-not, ：fullwidth-colon). These are typographic ASCII variants, not Chinese words; none of the 7 leaks uses them, and including them flagged logic slides (￢ in `slides/03-logique`) and regexes (：in `detect_solution_leaks.py`) as noise. The residue class is unified-ideographs + kana.
- **Fleet run = 5/7 census leaks**: the other 2 sit in `docs/archive/`, excluded by the canonical `SKIP_DIRS` ("archive" = frozen historical). All 7 patterns are pinned as tests.

## Validation

- `python -m pytest tests/test_detect_cjk_residue.py` → **40 passed** (19 original adapted + 21 new).
- `python detect_cjk_residue.py --check` → exit **1**, 5 leaks, 0 false positives, 12 allowed.
- `python detect_cjk_residue.py --json` → machine-readable, `scanned=3390`.
- YAML workflow parses; self-cover paths present (passes the #8822 guard by construction).

See #8826 (not `Closes` — the 7-leak sweep remains as the follow-up grain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)