### PR TITLE
fix(security,#8830): exemption declaree `pii_no_output` — les gates cessent de prescrire le commit de donnees etudiantes

### DIFF
--- a/MyIA.AI.Notebooks/GradeBook.ipynb
+++ b/MyIA.AI.Notebooks/GradeBook.ipynb
@@ -4,6 +4,51 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Notebook a donnees personnelles — les sorties restent vides, volontairement\n",
+    "\n",
+    "Ce notebook traite des **donnees personnelles d'etudiants** : login, prenom, nom,\n",
+    "adresse e-mail (`StudentRecord`, section 3), puis les notes individuelles par\n",
+    "projet (sections 4 a 6) et le classeur `Resultats_Evaluations.xlsx` produit en\n",
+    "section 7. Plusieurs cellules les affichent telles quelles — `studentRecords\n",
+    ".DisplayTable()`, les tableaux d'evaluations, les graphiques de distribution.\n",
+    "\n",
+    "**Aucune de ces cellules ne doit etre committee avec ses sorties.** Le depot est\n",
+    "public : une sortie conservee y ferait entrer un trombinoscope nominatif, de\n",
+    "maniere permanente (l'historique git garde ce qu'on y a pousse, meme apres\n",
+    "suppression du fichier). C'est le cas d'exception prevu par le CLAUDE.md du\n",
+    "depot : *« Clear cell outputs avant commit UNIQUEMENT si les outputs contiennent\n",
+    "des donnees sensibles »*. Ici l'etat conforme, c'est **vide**.\n",
+    "\n",
+    "Le notebook porte donc `\"pii_no_output\": true` dans ses metadonnees. Cette\n",
+    "declaration est lue par `scripts/notebook_tools/validate_pr_notebooks.py` et\n",
+    "joue **dans les deux sens** :\n",
+    "\n",
+    "| Situation | Verdict du validateur |\n",
+    "|---|---|\n",
+    "| Toutes les cellules code sans sortie | **PASS** — `PII_NO_OUTPUT`. L'absence de preuve d'execution (H.3/#5214) est ici la conformite, pas un defaut. |\n",
+    "| Une seule cellule avec une sortie committee | **FAIL** — signale que des donnees personnelles sont peut-etre deja dans l'historique. |\n",
+    "\n",
+    "Autrement dit la declaration excuse le vide et **interdit** le non-vide : elle ne\n",
+    "peut pas servir a faire passer un notebook a moitie execute. Si le validateur\n",
+    "declenche ce second cas, la reponse n'est pas de retoucher la sortie a la main\n",
+    "(ce serait falsifier une preuve d'execution) mais de la supprimer et de traiter\n",
+    "la fuite en amont.\n",
+    "\n",
+    "**Executer ce notebook en local reste normal et souhaitable** — c'est son usage.\n",
+    "Ce qui est proscrit, c'est de committer le resultat. Les fichiers d'entree sont\n",
+    "choisis interactivement (`Kernel.GetInputAsync`) et le classeur de sortie est\n",
+    "ecrit **a cote du fichier d'entree**, hors du depot : rien n'atterrit dans\n",
+    "l'arbre git tant qu'on ne l'y copie pas.\n",
+    "\n",
+    "**Voir aussi** : [`GradeBookApp/PRIVACY.md`](../GradeBookApp/PRIVACY.md) — la\n",
+    "notice RGPD (responsable du traitement, base legale, finalite, donnees traitees)\n",
+    "de l'application Python qui a succede a ce notebook et qui remplit le meme role.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### 1. Déclaration des packages NuGet"
    ]
   },
@@ -1180,7 +1225,8 @@
      }
     ]
    }
-  }
+  },
+  "pii_no_output": true
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/scripts/notebook_tools/check_c2_compliance.py
+++ b/scripts/notebook_tools/check_c2_compliance.py
@@ -24,6 +24,14 @@ import json
 import sys
 from pathlib import Path
 
+# Same declared PII carve-out as the PR gate — imported, never re-spelled, so
+# the two scanners cannot drift apart on the key name. A notebook whose outputs
+# would embed student rosters/e-mails/marks is COMPLIANT while empty; honouring
+# the flag in only one of the two scanners would leave the other still telling
+# an agent to go and execute it. See validate_pr_notebooks.PII_NO_OUTPUT_KEY.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from validate_pr_notebooks import PII_NO_OUTPUT_KEY
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 CATALOG_PATH = REPO_ROOT / "COURSE_CATALOG.generated.json"
 NOTEBOOKS_DIR = REPO_ROOT / "MyIA.AI.Notebooks"
@@ -49,6 +57,11 @@ def check_notebook(nb_path: Path) -> dict:
 
     violations = []
     code_idx = 0
+    # Declared PII notebook: emptiness IS the compliant state, and conversely a
+    # committed output is the violation to report (symmetric, like the PR gate).
+    pii_no_output = (
+        notebook.get("metadata", {}).get(PII_NO_OUTPUT_KEY) is True
+    )
 
     for i, cell in enumerate(notebook.get("cells", [])):
         if cell.get("cell_type") != "code":
@@ -74,6 +87,19 @@ def check_notebook(nb_path: Path) -> dict:
         # Check execution_count
         exec_count = cell.get("execution_count")
         outputs = cell.get("outputs", [])
+
+        if pii_no_output:
+            if outputs:
+                violations.append({
+                    "cell_index": i,
+                    "code_cell": code_idx,
+                    "reason": (
+                        f"metadata.{PII_NO_OUTPUT_KEY} declared but output "
+                        f"committed — personal data may be in git history"
+                    ),
+                    "source_preview": source[:80].replace("\n", " "),
+                })
+            continue
 
         if exec_count is None:
             violations.append({

--- a/scripts/notebook_tools/tests/test_check_c2_compliance.py
+++ b/scripts/notebook_tools/tests/test_check_c2_compliance.py
@@ -569,6 +569,44 @@ class TestGetTargetNotebooksCatalog:
 
 
 # ---------------------------------------------------------------------------
+# check_notebook — declared PII carve-out (metadata.pii_no_output)
+# ---------------------------------------------------------------------------
+
+class TestPiiNoOutput:
+    """Second half of the carve-out introduced in validate_pr_notebooks.py.
+    Honouring the declaration in only one of the two scanners would leave this
+    one still reporting "missing execution_count" on a grading notebook — i.e.
+    still telling an agent to execute it and commit student PII."""
+
+    def test_declared_pii_notebook_is_compliant_while_empty(self, tmp_path):
+        nb = _write_nb(tmp_path / "GradeBook.ipynb", [
+            _code("studentRecords.DisplayTable();"),
+            _code("evaluations.DisplayTable();"),
+        ], metadata={"pii_no_output": True})
+        assert check_notebook(nb)["violations"] == []
+
+    def test_declared_pii_notebook_with_output_is_a_violation(self, tmp_path):
+        """Symmetric: the flag excuses emptiness and criminalises non-emptiness."""
+        nb = _write_nb(tmp_path / "GradeBook.ipynb", [
+            _code("studentRecords.DisplayTable();", outputs=[
+                {"output_type": "stream", "name": "stdout",
+                 "text": ["login prenom nom email\n"]}]),
+        ], metadata={"pii_no_output": True})
+        violations = check_notebook(nb)["violations"]
+        assert len(violations) == 1
+        assert "git history" in violations[0]["reason"]
+
+    def test_without_the_flag_missing_exec_count_still_flagged(self, tmp_path):
+        """Control: opt-in, never inferred."""
+        nb = _write_nb(tmp_path / "GradeBook.ipynb", [
+            _code("studentRecords.DisplayTable();"),
+        ])
+        violations = check_notebook(nb)["violations"]
+        assert len(violations) == 1
+        assert violations[0]["reason"] == "missing execution_count"
+
+
+# ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 

--- a/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
+++ b/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
@@ -245,6 +245,92 @@ class TestValidateNotebookH3:
 
 
 # ---------------------------------------------------------------------------
+# validate_notebook — PII carve-out (metadata.pii_no_output)
+# ---------------------------------------------------------------------------
+
+class TestValidateNotebookPiiNoOutput:
+    """A grading notebook renders student logins, e-mails and marks. For it an
+    EMPTY output is the compliant state (CLAUDE.md §E), yet the gate used to
+    answer `.net-csharp executes locally; commit execution proof, See #5214` —
+    an instruction that, obeyed together with rule F, commits student PII to a
+    public repo. The carve-out is DECLARED (PII is undetectable from source)
+    and, crucially, symmetric: it excuses emptiness and forbids non-emptiness.
+
+    Both directions are exercised here on purpose. A guard nobody has seen fail
+    is not yet a guard (#8681/#8820)."""
+
+    def test_declared_pii_notebook_with_empty_outputs_passes(self, tmp_path):
+        """The trap that was armed on MyIA.AI.Notebooks/GradeBook.ipynb:
+        12/12 code cells null, 0 outputs, .net-csharp — FAIL before, PASS once
+        the notebook declares why it is empty."""
+        nb = _write_nb(tmp_path / "GradeBook.ipynb", [
+            _code("studentRecords.DisplayTable()", exec_count=None),
+            _code("evaluations.DisplayTable()", exec_count=None),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"},
+            extra_metadata={"pii_no_output": True})
+        result = validate_notebook(nb)
+        assert result["passed"] is True
+        assert result["errors"] == []
+
+    def test_declared_pii_notebook_gets_its_own_verdict(self, tmp_path):
+        """Not ADVISORY_NON_EXEC: 'we could not execute here' and 'empty ON
+        PURPOSE, any output is a data-protection incident' must not read alike
+        to a reviewer."""
+        nb = _write_nb(tmp_path / "GradeBook.ipynb", [
+            _code("studentRecords.DisplayTable()", exec_count=None),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"},
+            extra_metadata={"pii_no_output": True})
+        assert validate_notebook(nb)["forensic_verdict"] == "PII_NO_OUTPUT"
+
+    def test_declared_pii_notebook_with_committed_output_fails(self, tmp_path):
+        """The self-tripping half. An output on a notebook that renders student
+        rosters is the signature of personal data already in git history — so
+        the declaration makes it a HARD failure instead of hiding it."""
+        roster = {"output_type": "stream", "name": "stdout",
+                  "text": ["login  prenom  nom  email\n"]}
+        nb = _write_nb(tmp_path / "GradeBook.ipynb", [
+            _code("studentRecords.DisplayTable()", exec_count=None,
+                  outputs=[roster]),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"},
+            extra_metadata={"pii_no_output": True})
+        result = validate_notebook(nb)
+        assert result["passed"] is False
+        assert any("pii_no_output" in e and "git history" in e
+                   for e in result["errors"])
+
+    def test_flag_cannot_smuggle_a_half_executed_notebook(self, tmp_path):
+        """The abuse the carve-out must not enable: bolting the flag onto an
+        ordinary notebook to buy silence on #5214. Execution_count present, so
+        H.3 alone would pass — the committed output still fails it."""
+        nb = _write_nb(tmp_path / "ordinary.ipynb", [
+            _code("print('hello')", exec_count=1,
+                  outputs=[{"output_type": "stream", "name": "stdout",
+                            "text": ["hello\n"]}]),
+        ], extra_metadata={"pii_no_output": True})
+        assert validate_notebook(nb)["passed"] is False
+
+    def test_without_the_flag_the_same_notebook_still_fails_h3(self, tmp_path):
+        """Control: the exemption is opt-in, never inferred. Same cells, no
+        declaration — the #5214 instruction fires exactly as before."""
+        nb = _write_nb(tmp_path / "GradeBook.ipynb", [
+            _code("studentRecords.DisplayTable()", exec_count=None),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"})
+        result = validate_notebook(nb)
+        assert result["passed"] is False
+        assert any("execution_count is null" in e for e in result["errors"])
+
+    def test_flag_must_be_true_not_merely_present(self, tmp_path):
+        """`is True`, not truthiness: a stray "false"/"" string must not open
+        the carve-out by accident."""
+        for value in (False, "true", 1, None):
+            nb = _write_nb(tmp_path / f"g{value}.ipynb", [
+                _code("studentRecords.DisplayTable()", exec_count=None),
+            ], kernelspec={"name": ".net-csharp", "language": "C#"},
+                extra_metadata={"pii_no_output": value})
+            assert validate_notebook(nb)["passed"] is False, value
+
+
+# ---------------------------------------------------------------------------
 # validate_notebook — C.1 checks (forbidden patterns)
 # ---------------------------------------------------------------------------
 

--- a/scripts/notebook_tools/validate_pr_notebooks.py
+++ b/scripts/notebook_tools/validate_pr_notebooks.py
@@ -84,6 +84,33 @@ QUANTBOOK_PATTERN = re.compile(r"QuantBook\(\)|self\.QuantBook")
 # #6803.
 ARCHIVE_NOTEBOOK_SUFFIX = "_archive.ipynb"
 
+# Notebooks whose OUTPUTS would embed personal data (student rosters, e-mails,
+# individual grades). Here an EMPTY output is the compliant state, not a defect
+# — CLAUDE.md §E: "Clear cell outputs avant commit UNIQUEMENT si les outputs
+# contiennent des donnees sensibles".
+#
+# Without this carve-out the gate is not merely wrong, it is DANGEROUS: it told
+# `MyIA.AI.Notebooks/GradeBook.ipynb` (.net-csharp, 12/12 cells null) twelve
+# times over ".net-csharp executes locally; commit execution proof, See #5214".
+# An agent obeying that instruction plus rule F ("install the kernel, never
+# bypass") would execute a notebook whose cells render `studentRecords
+# .DisplayTable()` — login, first name, last name, e-mail — and commit student
+# PII to a public repo. The gate would have been the proximate cause.
+#
+# DECLARED, never inferred: PII cannot be detected from source, so the notebook
+# must opt in via `metadata.pii_no_output: true` (same declarative shape as
+# `metadata.qc_reference`, #3776).
+#
+# The declaration is NOT a free pass on #5214 — it is load-bearing in the other
+# direction too. A notebook that declares it MUST carry zero outputs on every
+# code cell; a single committed output makes the gate FAIL loudly, because that
+# is the signature of personal data already sitting in git history. So the flag
+# excuses emptiness and forbids non-emptiness: it cannot be used to smuggle a
+# half-executed notebook past the execution proof. Both verdicts are exercised
+# in tests/test_validate_pr_notebooks.py (a guard nobody has seen fail is not
+# yet a guard — #8681/#8820).
+PII_NO_OUTPUT_KEY = "pii_no_output"
+
 # Kernels that render errors as TEXT, not as output_type=="error" (#5151).
 # Lean via lean4_jupyter/alectryon embeds the compiler's own message severity
 # in the cell output (text/plain + text/html). A `severity: error` message is
@@ -216,8 +243,14 @@ def validate_notebook(nb_path: Path) -> dict:
     # committed .NET cell MUST carry execution_count != null = EXEC_PROVED
     # (#5214: "CI skip .NET" != "outputs may be empty"). The Tweety-3 cluster
     # (#5194/#5199/#5202) was merged at execution_count:null + outputs:[].
+    # Declared PII notebook: empty outputs are the compliant state (see the
+    # PII_NO_OUTPUT_KEY comment above). Read once, used twice — it relaxes H.3
+    # and, symmetrically, makes any committed output a hard failure.
+    pii_no_output = data.get("metadata", {}).get(PII_NO_OUTPUT_KEY) is True
     allow_null_exec_count = (
-        any(k in kernel for k in ALLOW_NULL_EXEC_COUNT_KERNELS) or qc_cloud
+        any(k in kernel for k in ALLOW_NULL_EXEC_COUNT_KERNELS)
+        or qc_cloud
+        or pii_no_output
     )
     saw_null_exec = False  # for the forensic verdict (H.5)
     saw_empty_display = False  # #6971 blank-render signature (see verdict below)
@@ -242,6 +275,22 @@ def validate_notebook(nb_path: Path) -> dict:
             continue
 
         result["total_code"] += 1
+
+        # The other half of the PII carve-out. Declaring `pii_no_output` buys
+        # tolerance for a null execution_count and, in exchange, forbids ANY
+        # committed output: an output on a notebook that renders student
+        # rosters is the signature of personal data already in git history.
+        # Failing here is what stops the flag from becoming an escape hatch
+        # from #5214 for ordinary half-executed notebooks.
+        if pii_no_output and cell.get("outputs"):
+            result["passed"] = False
+            result["errors"].append(
+                f"cell {i}: notebook declares metadata.{PII_NO_OUTPUT_KEY} but "
+                f"this cell carries {len(cell['outputs'])} committed output(s) — "
+                f"personal data may already be in git history. Clear the outputs "
+                f"and rotate/scrub upstream if they were pushed; do NOT hand-edit "
+                f"them into something plausible (Stop&Repair)."
+            )
 
         # C.1 check: forbidden patterns via the shared digit-bounded,
         # comment/docstring-aware scanner (#1505 — no more date false positives)
@@ -329,7 +378,12 @@ def validate_notebook(nb_path: Path) -> dict:
     # Forensic verdict (H.5): EXEC_PROVED / STRUCTURAL_ONLY / ADVISORY_NON_EXEC.
     # Distinguishes "real outputs present" from "structural-only / advisory" so
     # reviewers and bots apply CHANGES_REQUESTED on the second (#5214).
-    if allow_null_exec_count:
+    if pii_no_output:
+        # Its own verdict, ahead of ADVISORY_NON_EXEC: a reviewer must not read
+        # "advisory" (= we could not execute here) where the truth is "empty ON
+        # PURPOSE, and any output would be a data-protection incident".
+        result["forensic_verdict"] = "PII_NO_OUTPUT"
+    elif allow_null_exec_count:
         result["forensic_verdict"] = "ADVISORY_NON_EXEC"
     elif saw_null_exec:
         result["forensic_verdict"] = "STRUCTURAL_ONLY"


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: LIGHT/qc (#8827)

## Le gate prescrivait l'incident

`MyIA.AI.Notebooks/GradeBook.ipynb` affiche des logins, prenoms, noms, e-mails et notes individuelles d'etudiants. Ses 12 cellules code portent **0 sortie** — exactement ce que le CLAUDE.md du depot demande pour un notebook dont les sorties contiennent des donnees sensibles. Les deux scanners cables en CI repondaient le contraire :

```
validate_pr_notebooks -> passed:false | STRUCTURAL_ONLY | 12 erreurs
   "cell N: execution_count is null (H.3/C.2 violation — .net-csharp
    executes locally; commit execution proof, See #5214)"

check_c2_compliance   -> 0/1 compliant | 11 violations
   "cell #N: missing execution_count"
```

Un agent qui obeit a cette instruction **et** a la regle F (« installer le kernel, jamais contourner ») installe `.NET Interactive`, execute le notebook, et committe un trombinoscope nominatif dans un depot public — de facon permanente, l'historique git conservant les donnees apres toute suppression du fichier.

Ce n'est pas seulement un faux positif. C'est un garde qui **prescrit** l'incident au lieu de le detecter — le motif de #8681 / #8820, inverse.

Le gate n'a pourtant pas tort dans sa logique propre : #5214 dit bien qu'un `.net-csharp` s'execute localement, donc qu'un `execution_count: null` est une preuve d'execution manquante. Ce qui manquait, c'est un moyen de **declarer** qu'un notebook est vide *exprès*.

Diagnostic complet, mesures et contexte : **#8830**.

## Le correctif : une exemption declaree, et symetrique

`metadata.pii_no_output: true` — **opt-in, jamais infere** (la presence de donnees personnelles n'est pas detectable depuis le source), sur la forme declarative deja en place avec `metadata.qc_reference` (#3776), et dont le fichier dit lui-meme que les listes de chemins sont *« a FAST PATH, not the definition »*.

Le point qui compte est la **symetrie** :

| Situation | Verdict |
|---|---|
| Declare + 0 sortie partout | **PASS**, verdict forensique `PII_NO_OUTPUT` |
| Declare + >=1 sortie committee | **FAIL** — des donnees personnelles sont peut-etre deja dans l'historique |

Le drapeau **excuse le vide et interdit le non-vide**. Sans cette seconde moitie, il ne serait qu'une porte de sortie de #5214 : n'importe quel notebook a moitie execute pourrait l'apposer pour acheter le silence. Avec elle, il est falsifiable dans les deux sens — et il **peut** echouer.

Verdict distinct de `ADVISORY_NON_EXEC` a dessein : « on n'a pas pu executer ici » et « vide **exprès**, toute sortie serait un incident de donnees personnelles » ne doivent pas se lire pareil pour un reviewer.

## Ce que la mesure a change dans le livrable

**Un garde qu'on n'a pas vu echouer n'est pas encore un garde.** J'ai donc mute mon propre correctif — quatre variantes, chacune supprimant une moitie du mecanisme — et verifie que chacune est tuee par exactement un des nouveaux tests :

```
variante         empty_passes   output_fails   own_verdict   flag_must_be_true
REEL                 PASS           PASS          PASS            PASS
sans self-trip       PASS           FAIL          PASS            PASS
sans relaxation      FAIL           PASS          PASS            PASS
truthiness           PASS           PASS          PASS            FAIL
sans verdict         PASS           PASS          FAIL            PASS
```

Diagonale propre : aucun test n'est decoratif, et aucune moitie du mecanisme n'est protegee par un autre test que le sien.

**Le second scanner a fallu le mesurer aussi.** Apres avoir corrige `validate_pr_notebooks.py`, j'ai relance `check_c2_compliance.py` par acquit de conscience : il disait toujours la meme chose (11 violations). Une exemption honoree par un seul des deux scanners laisse l'autre continuer a emettre l'instruction dangereuse — la correction n'aurait rien valu. La cle est **importee**, jamais re-epelee, pour que les deux ne puissent pas deriver.

**J'ai retire une hypothese que je n'avais pas verifiee.** J'avais suppose que les CSV de notes ingerees atterrissaient dans l'arbre du depot — un `git add -A` du commit de PII. Mesure : les entrees sont choisies interactivement (`Kernel.GetInputAsync(..., typeHint: "file")`) et le classeur de sortie est ecrit **a cote du fichier d'entree** (`Path.Combine(new FileInfo(studentFileInput).DirectoryName, ...)`), hors depot. Le risque reel est celui des **sorties de cellules**, pas des fichiers de donnees. L'hypothese n'a pas survecu et n'est pas dans le livrable.

## Contexte : la protection avait migre sans l'ancetre

`GradeBookApp/` — l'application Python qui a succede a ce notebook et remplit le meme role — a recu `PRIVACY.md` (notice RGPD complete, #8063 pour #8054) **et** une protection `.gitignore` (lignes 630-645). Le notebook ancetre n'a recu ni l'une ni l'autre. La cellule de declaration ajoutee ici pointe explicitement vers `GradeBookApp/PRIVACY.md` pour recoudre les deux.

## Conformite

| Regle | Preuve |
|---|---|
| **Stop & Repair** (secrets-hygiene §6) | Empreinte sha256 des 12 cellules code (`source` + `execution_count` + `outputs`) : `445d4498a0bd9e81` **avant et apres**. Aucune sortie touchee — il n'y en avait aucune, et il ne doit y en avoir aucune. |
| **Diff notebook** | 47 insertions, 1 deletion — la deletion est le `}` du bloc `metadata` qui devient `},`. Round-trip JSON verifie byte-identique avant edition, donc zero reserialisation parasite. |
| **C.1** | Aucune cellule code touchee. |
| **Tests** | 9 cas nouveaux (les deux sens sur les deux scanners) ; `3598 passed` sur `scripts/notebook_tools/tests/`. |
| **regression-guard** | `regression_scan.py --guard --base origin/main` : *no notebook went healthy->degraded*. |
| **Catalogue** | `git diff --name-only origin/main...HEAD | grep -c catalog` = **0**. Byte-identique a main. |
| **PR body hors worktree** | Redige en scratchpad (L677-L4). |

## Laisse en place, et signale plutot qu'elargi

- **`forensic_scan.py`** classe toujours le notebook `C_NEVER_EXECUTED`. C'est **exact**, ce n'est pas cable en CI, et cela n'emet aucune instruction. Rien a corriger : etendre le drapeau a un troisieme scanner aurait ete du sprawl.
- **`check_c2_compliance.py` n'a aucune exemption kernel/QC/Lean** : il signale aussi les ~54 quantbooks QuantConnect a `execution_count: null`. Lacune preexistante, distincte, gouvernee par **#6891**. Hors scope ici.
- Le notebook n'est pas au catalogue, n'a pas de `metadata.cost`, et sa cellule 6 porte une transition generique (« Suite du traitement des notes. »). Trois residus mineurs, notes, non traites.

## Tier, et un point de donnee pour la question gelee

**MED** au test du protocole : « pourrais-je en generer une douzaine en scannant l'instance suivante ? » — non. Il a fallu lire un gate, mesurer son verdict reel, voir l'implication PII, puis concevoir une exemption qui se declenche contre elle-meme. Ce n'est pas scan-generable. Je ne le declare pas DEEP : il n'y a ici ni resultat scientifique ni capacite pedagogique nouvelle, c'est un organe de garde.

G-VAR-1 : MED, donc le plancher de substance du cycle est tenu (celui de c.54 ne l'etait pas — #8827 etait LIGHT et je l'avais dit). G-VAR-2 : non-LIGHT, pas de cap. G-VAR-3 : `qc` -> `guard`, genres differents.

**Un point de donnee pour la question gelee** (« `guard` est-il un genre LIGHT par nature, ou le tier prime-t-il sur le nom du genre ? ») : cette PR est un `guard` qui n'est pas scan-generable. Si `guard` etait LIGHT **par nature**, elle serait plafonnee a 1/jour et ne pourrait jamais tenir un plancher — alors que c'est precisement le genre de travail qui empeche un incident de donnees personnelles. Cela plaide pour que **le tier prime sur le nom du genre**, le litmus restant l'arbitre. A trancher par le user ; je ne modifie pas la regle.

Closes #8830
See #8054, #8063, #5214, #3776, #8681, #8820, #6891
