### PR TITLE
fix(security,#8830): declared pii_no_output exemption — stop the gate prescribing student-data commits

### DIFF
--- a/MyIA.AI.Notebooks/GradeBook.ipynb
+++ b/MyIA.AI.Notebooks/GradeBook.ipynb
@@ -1161,6 +1161,7 @@
   }
  ],
  "metadata": {
+  "pii_no_output": true,
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",

--- a/scripts/notebook_tools/README.md
+++ b/scripts/notebook_tools/README.md
@@ -308,12 +308,24 @@ notebook touche :
 - **C.3** : scope strict re-exec Papermill (verifie `git diff` cellule
   source modifiee)
 - **H.5 verdict** : `EXEC_PROVED` / `STRUCTURAL_ONLY` /
-  `SUSPECT_REGRESSION` par parsing JSON du diff
+  `ADVISORY_NON_EXEC`, et (#8830) `PII_EXEMPT_EMPTY` /
+  `PII_LEAKAGE_SUSPECTED` (voir ci-dessous)
 
 Advisory `.NET execution_count` ≠ outputs vides autorises (#5214) : la CI
 ne peut pas Papermill-exec les notebooks .NET, mais une cellule .NET
 **DOIT** porter `execution_count != null` (preuve d'execution locale sur
 chaque worker `dotnet-interactive`).
+
+Exemption PII declaree `metadata.pii_no_output=True` (#8830) : un notebook
+transportant des donnees personnelles (ex. `GradeBook.ipynb` : login/nom/email/
+notes etudiants) est prescrit VIDE (CLAUDE.md « clear outputs si sensibles ») —
+son `execution_count: null` est correct, pas une violation C.2. L'exiger
+preuve d'execution prescrirait de committer un trombinoscope nominatif dans un
+depot public. Symetrique et falsifiable : declare + vide partout = PASS propre
+(`PII_EXEMPT_EMPTY`) ; declare + ≥1 output commite = FAIL
+(`PII_LEAKAGE_SUSPECTED` — les donnees sont peut-etre deja dans l'historique).
+Declaree uniquement (jamais inferee), sur le modele `metadata.qc_reference`
+(#3776).
 
 ### `check_c2_compliance.py` (regle C.2)
 

--- a/scripts/notebook_tools/check_c2_compliance.py
+++ b/scripts/notebook_tools/check_c2_compliance.py
@@ -50,6 +50,15 @@ def check_notebook(nb_path: Path) -> dict:
     violations = []
     code_idx = 0
 
+    # #8830: a declared PII notebook (metadata.pii_no_output=True) is prescribed
+    # empty (CLAUDE.md: clear outputs when sensitive). Its empty state is correct,
+    # not a C.2 violation -- demanding execution proof here would prescribe
+    # committing student data. Symmetric: declared + any committed output = FAIL
+    # (data may be in history). Declared only (PII is not detectable from source),
+    # modelled on metadata.qc_reference. The broader kernel/QC exemption gap
+    # (~54 quantbooks) is a distinct concern governed by #6891 -- NOT added here.
+    pii_declared = notebook.get("metadata", {}).get("pii_no_output") is True
+
     for i, cell in enumerate(notebook.get("cells", [])):
         if cell.get("cell_type") != "code":
             continue
@@ -69,6 +78,18 @@ def check_notebook(nb_path: Path) -> dict:
         # and audit_c1_c3.py (cf #5261 C-family comment-awareness).
         lines = [l.strip() for l in source.split("\n") if l.strip()]
         if all(l.startswith(("#", "//")) for l in lines):
+            continue
+
+        if pii_declared:
+            # #8830 symmetric arm: empty is prescribed (skip exec_count checks);
+            # any committed output = student data may be in history = violation.
+            if cell.get("outputs"):
+                violations.append({
+                    "cell_index": i,
+                    "code_cell": code_idx,
+                    "reason": "PII notebook (pii_no_output) has committed output -- strip outputs & execution_count (See #8830)",
+                    "source_preview": source[:80].replace("\n", " "),
+                })
             continue
 
         # Check execution_count

--- a/scripts/notebook_tools/tests/test_check_c2_compliance.py
+++ b/scripts/notebook_tools/tests/test_check_c2_compliance.py
@@ -584,3 +584,40 @@ class TestConstants:
         assert isinstance(EXCLUDE_PEDAGOGICAL, set)
         assert "research" in EXCLUDE_PEDAGOGICAL
         assert "archive" in EXCLUDE_PEDAGOGICAL
+
+
+# ---------------------------------------------------------------------------
+# check_notebook — #8830 declared PII exemption (symmetric)
+# ---------------------------------------------------------------------------
+class TestPiiNoOutputExemption:
+    """#8830: a declared PII notebook (metadata.pii_no_output=True) is prescribed
+    empty. Declared + empty = compliant; declared + any committed output = FAIL
+    (student data may be in git history). Opt-in only -- the broader kernel/QC
+    exemption gap (~54 quantbooks, #6891) is distinct and NOT widened here."""
+
+    def test_pii_declared_empty_compliant(self, tmp_path):
+        nb = _write_nb(tmp_path / "pii.ipynb", [
+            _code("var records = Load();", exec_count=None),
+            _code("GenerateWorkbook(records);", exec_count=None),
+        ], metadata={"pii_no_output": True})
+        result = check_notebook(nb)
+        assert result["violations"] == []
+
+    def test_pii_declared_with_output_violation(self, tmp_path):
+        nb = _write_nb(tmp_path / "pii.ipynb", [
+            _code("DisplayTable(records);", exec_count=1,
+                  outputs=[{"output_type": "stream", "text": ["Jean Dupont j@x.fr"]}]),
+        ], metadata={"pii_no_output": True})
+        result = check_notebook(nb)
+        assert len(result["violations"]) == 1
+        assert "#8830" in result["violations"][0]["reason"]
+
+    def test_pii_not_declared_still_checked(self, tmp_path):
+        # Without the flag, missing execution_count is still flagged -- the pii
+        # exemption does not widen into a kernel/QC exemption (#6891 is separate).
+        nb = _write_nb(tmp_path / "not_pii.ipynb", [
+            _code("var x = Load();", exec_count=None),
+        ], metadata={})
+        result = check_notebook(nb)
+        assert len(result["violations"]) == 1
+        assert result["violations"][0]["reason"] == "missing execution_count"

--- a/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
+++ b/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
@@ -597,3 +597,72 @@ class TestBlankRenderVerdict:
         ], kernelspec={"name": "lean4", "language": "lean4"})
         result = validate_notebook(nb)
         assert result["forensic_verdict"] == "ADVISORY_NON_EXEC"
+
+
+# ---------------------------------------------------------------------------
+# validate_notebook — #8830 declared PII exemption (symmetric, falsifiable)
+# ---------------------------------------------------------------------------
+class TestPiiNoOutputExemption:
+    """#8830: a declared PII notebook (metadata.pii_no_output=True) is prescribed
+    empty (CLAUDE.md: clear outputs when sensitive). The gate must NOT demand
+    execution proof -- obeying that + Rule F would prescribe committing student
+    data into a public repo. Symmetric and falsifiable both ways: declared +
+    empty = clean PASS; declared + any committed output = FAIL."""
+
+    DOTNET = {"name": ".net-csharp", "language": "C#", "display_name": ".NET (C#)"}
+
+    def test_pii_declared_empty_passes_clean(self, tmp_path):
+        # Declared + empty everywhere = prescribed state. Clean PASS with a
+        # distinct verdict (NOT the advisory non-exec one).
+        nb = _write_nb(tmp_path / "pii.ipynb", [
+            _code('#r "nuget: CsvHelper"\nvar records = Load();', exec_count=None),
+            _code("GenerateWorkbook(records);", exec_count=None),
+        ], kernelspec=self.DOTNET, extra_metadata={"pii_no_output": True})
+        result = validate_notebook(nb)
+        assert result["passed"] is True
+        assert result["forensic_verdict"] == "PII_EXEMPT_EMPTY"
+        assert result["errors"] == []
+
+    def test_pii_declared_null_exec_count_not_flagged(self, tmp_path):
+        # The CORE fix: a null execution_count on a declared PII notebook is NOT
+        # an H.3/C.2 violation. Before #8830 the gate prescribed committing proof.
+        nb = _write_nb(tmp_path / "pii.ipynb", [
+            _code("var x = Load();", exec_count=None),
+        ], kernelspec=self.DOTNET, extra_metadata={"pii_no_output": True})
+        result = validate_notebook(nb)
+        assert result["passed"] is True
+        assert not any("execution_count is null" in e for e in result["errors"])
+
+    def test_pii_declared_with_output_fails(self, tmp_path):
+        # Symmetric FAIL arm: a declared PII notebook that committed output may
+        # have leaked student data into git history.
+        nb = _write_nb(tmp_path / "pii.ipynb", [
+            _code("studentRecords.DisplayTable();", exec_count=1,
+                  outputs=[{"output_type": "execute_result",
+                            "data": {"text/plain": ["Jean Dupont jdupont@x.fr"]}}]),
+        ], kernelspec=self.DOTNET, extra_metadata={"pii_no_output": True})
+        result = validate_notebook(nb)
+        assert result["passed"] is False
+        assert result["forensic_verdict"] == "PII_LEAKAGE_SUSPECTED"
+        assert any("#8830" in e and "student data" in e for e in result["errors"])
+
+    def test_pii_not_declared_null_exec_count_still_fails(self, tmp_path):
+        # Without the flag, a .net-csharp notebook with null exec_count STILL
+        # fails (#5214) -- the exemption is opt-in, never an escape hatch.
+        nb = _write_nb(tmp_path / "not_pii.ipynb", [
+            _code("var x = Load();", exec_count=None),
+        ], kernelspec=self.DOTNET)
+        result = validate_notebook(nb)
+        assert result["passed"] is False
+        assert any("execution_count is null" in e for e in result["errors"])
+        assert result["forensic_verdict"] == "STRUCTURAL_ONLY"
+
+    def test_pii_declared_c1_violation_still_fails(self, tmp_path):
+        # The exemption waives the empty-state requirement, NOT C.1: a PII
+        # notebook must still not ship raise NotImplementedError.
+        nb = _write_nb(tmp_path / "pii.ipynb", [
+            _code("raise NotImplementedError", exec_count=None),
+        ], kernelspec=self.DOTNET, extra_metadata={"pii_no_output": True})
+        result = validate_notebook(nb)
+        assert result["passed"] is False
+        assert any("C.1 violation" in e for e in result["errors"])

--- a/scripts/notebook_tools/validate_pr_notebooks.py
+++ b/scripts/notebook_tools/validate_pr_notebooks.py
@@ -176,6 +176,23 @@ def _is_qc_cloud(rel_path: str, data: dict) -> bool:
     return False
 
 
+def _is_pii_no_output(data: dict) -> bool:
+    """Whether a notebook is a DECLARED PII notebook whose empty state is
+    prescribed (so null execution_count / stripped outputs are correct, not a
+    C.2 violation). #8830: a PR gate demanding execution proof on such a notebook
+    would prescribe committing student data (login/nom/email/notes) into a public
+    repo — the gate would be the immediate cause of the incident.
+
+    Declared only (never inferred: the presence of personal data is NOT
+    detectable from the source), on the model of ``metadata.qc_reference``
+    (#3776). The exemption is SYMMETRIC and falsifiable both ways (see
+    ``validate_notebook``): declared + empty everywhere = clean PASS; declared +
+    any committed output = FAIL (PII may already be in git history). Without the
+    symmetry the flag would become a #5214 escape hatch for any half-run notebook.
+    """
+    return data.get("metadata", {}).get("pii_no_output") is True
+
+
 def validate_notebook(nb_path: Path) -> dict:
     """Validate a single notebook for H.1/H.3 compliance.
 
@@ -205,6 +222,11 @@ def validate_notebook(nb_path: Path) -> dict:
     # advisory, and H.1 error outputs are advisory (expected without the
     # kernel/runtime). Covers .NET, Lean, QC Cloud, qc_reference templates.
     qc_cloud = _is_qc_cloud(rel_path, data)
+    # #8830: a declared PII notebook (metadata.pii_no_output=True) is prescribed
+    # empty — its null execution_count is correct, not a C.2 violation. The gate
+    # must NOT demand execution proof (that would prescribe committing student
+    # data). The symmetric "any output = FAIL" check runs after the loop.
+    pii_declared = _is_pii_no_output(data)
     ci_reexec_skipped = any(k in kernel for k in SKIP_EXEC_KERNELS) or qc_cloud
     # Research archive snapshot: error outputs are a deliberate record, not a
     # bug (#6803). H.1 is advisory; H.3 + C.1 still enforced below.
@@ -218,6 +240,7 @@ def validate_notebook(nb_path: Path) -> dict:
     # (#5194/#5199/#5202) was merged at execution_count:null + outputs:[].
     allow_null_exec_count = (
         any(k in kernel for k in ALLOW_NULL_EXEC_COUNT_KERNELS) or qc_cloud
+        or pii_declared
     )
     saw_null_exec = False  # for the forensic verdict (H.5)
     saw_empty_display = False  # #6971 blank-render signature (see verdict below)
@@ -325,6 +348,31 @@ def validate_notebook(nb_path: Path) -> dict:
                     f"(severity:error — failed compile/import/proof)"
                 )
                 break  # one report per cell is enough
+
+    # #8830: declared PII exemption — SYMMETRIC and falsifiable both ways.
+    # Declared + 0 committed output everywhere = the prescribed empty state
+    # (CLAUDE.md: clear outputs when sensitive) = clean PASS, distinct from the
+    # advisory non-exec verdict. Declared + >=1 committed output = FAIL: the
+    # notebook was run and committed despite holding student data, so the data
+    # may already be in git history. The symmetry is what keeps the flag honest
+    # — without the FAIL arm it degrades into a #5214 escape hatch.
+    if pii_declared:
+        cells_with_output = sum(
+            1 for c in data.get("cells", [])
+            if c.get("cell_type") == "code" and c.get("outputs")
+        )
+        if cells_with_output > 0:
+            result["passed"] = False
+            result["errors"].append(
+                f"PII notebook (metadata.pii_no_output=True): {cells_with_output} "
+                f"code cell(s) carry committed output -- student data may be in "
+                f"git history. Strip outputs & execution_count and audit the "
+                f"history (or rotate the data). See #8830."
+            )
+            result["forensic_verdict"] = "PII_LEAKAGE_SUSPECTED"
+        else:
+            result["forensic_verdict"] = "PII_EXEMPT_EMPTY"
+        return result
 
     # Forensic verdict (H.5): EXEC_PROVED / STRUCTURAL_ONLY / ADVISORY_NON_EXEC.
     # Distinguishes "real outputs present" from "structural-only / advisory" so


### PR DESCRIPTION
## Summary

Fixes the **security defect #8830**: the two CI-wired notebook scanners demanded execution proof on `GradeBook.ipynb` — a `.NET` notebook that loads student records (`StudentRecord { Login, Prenom, Nom, Email }`) and is correctly committed **empty** per CLAUDE.md (*« Clear cell outputs avant commit UNIQUEMENT si les outputs contiennent des donnees sensibles »*). An agent obeying **both** the gate **and** Rule F (repair env, never workaround) would install `dotnet-interactive`, execute the notebook, and **commit a nominative student roster into a public repo**. The gate would be the **immediate cause** of the incident — same family as #8681/#8820 but **inverted**: the guard does not *miss* a defect, it *prescribes* one.

Reproduced firsthand on `origin/main` (`50324520c`):
- `check_c2_compliance.py --path GradeBook.ipynb` → **12 violations** (missing execution_count), 0/1 compliant
- `validate_pr_notebooks.py` → `forensic_verdict: STRUCTURAL_ONLY`, 12× *« .net-csharp executes locally; commit execution proof »*

## The fix — a DECLARED, SYMMETRIC exemption

`metadata.pii_no_output=True` (modelled on `metadata.qc_reference` #3776), **never inferred** (PII presence is not detectable from source). The symmetry is the point the issue author stressed — without the FAIL arm the flag degrades into a #5214 escape hatch for any half-run notebook:

| State | Verdict | Result |
|-------|---------|--------|
| declared + **0 output everywhere** | `PII_EXEMPT_EMPTY` | **PASS** (clean, not advisory) |
| declared + **≥1 committed output** | `PII_LEAKAGE_SUSPECTED` | **FAIL** — student data may be in git history |
| not declared + null exec_count | `STRUCTURAL_ONLY` | **FAIL** (#5214 unchanged — opt-in only) |

## Changes (6 files, +189/−1, purely additive)

- **`validate_pr_notebooks.py`**: `_is_pii_no_output()` helper; declared notebook joins `allow_null_exec_count` (null `execution_count` no longer flagged); symmetric verdict block before the H.5 forensic verdict. **C.1 still enforced** — the exemption waives the empty-state rule, not C.1 (`raise NotImplementedError` still fails).
- **`check_c2_compliance.py`**: per-cell symmetric arm (empty → skip exec checks; any output → violation).
- **`GradeBook.ipynb`**: declares `metadata.pii_no_output=true` (1-line surgical add). This is the ancestor notebook that got **neither** `PRIVACY.md` **nor** `.gitignore` protection when the safeguards migrated to `GradeBookApp/` (#8063).
- **tests**: 8 new (5 validator + 3 c2) — positive (declared+empty PASS), negative (declared+output FAIL), opt-in guard (un-declared still fails), C.1 still fires. **100 PASS** (92 existing + 8 new), 0 regression.
- **README**: document the PII verdicts + exemption next to the .NET/QC advisory; fix stale `SUSPECT_REGRESSION` in the verdict list (actual code = `EXEC_PROVED`/`STRUCTURAL_ONLY`/`ADVISORY_NON_EXEC`).

## Validation

- `GradeBook.ipynb` now **passes both scanners** (was 12 violations / `STRUCTURAL_ONLY`): `validate` → `passed=True, PII_EXEMPT_EMPTY`; `check_c2` → `1/1 compliant`.
- Symmetry proven both ways: a declared notebook with a committed output → `passed=False, PII_LEAKAGE_SUSPECTED` + 1 violation.
- **100 tests PASS** (92 existing + 8 new). AST OK. **0 CRLF** on all 6 files (LF-only, Python byte count).
- No CI workflow change — scanners keep their CLI; `forensic_verdict` new values are additive (no consumer branches on them: `svg-empty-display-gate.yml` is a comment; `audit_quantbooks_output_dates.py` has its own `verdict` field and GradeBook is not a quantbook).

## Out of scope (respected)

- `forensic_scan.py` classifies the notebook `C_NEVER_EXECUTED` — **exact**, not CI-wired, emits no instruction. Nothing to fix.
- `check_c2_compliance.py`'s broader kernel/QC exemption gap (~54 quantbooks at `execution_count: null`) — preexisting, distinct, governed by **#6891**. Not widened here.
- GradeBook's 3 minor residues (not in catalogue, no `metadata.cost`, generic transition cell) — off-topic.

`See #8830` (the exemption is delivered; the deeper GradeBook privacy migration to match `GradeBookApp/` is a separate concern the issue raises as context, not as acceptance).

Co-Authored-By: Claude <noreply@anthropic.com>