### PR TITLE
ci(slides,#8821-fixup): self-cover paths + symmetrize denominator (CHANGES_REQUESTED that lost the merge race)

### DIFF
--- a/.github/workflows/slides-build-advisory.yml
+++ b/.github/workflows/slides-build-advisory.yml
@@ -27,6 +27,10 @@ name: Slides Build Advisory
 #      `deck-*.md` as a fallback AND FAILS LOUDLY (exit 1, a META-FAILURE of the
 #      gate itself, NOT advisory) if any tracked deck dir yields zero targets.
 #      A gate that enumerates zero targets is green and mute (#8680, #8782, #8678).
+#      The denominator is falsifiable in BOTH directions: a dir that does NOT
+#      match the NN/SN convention but DOES carry a deck file is caught too
+#      (renaming 01-introduction to intro-01 would otherwise shrink M silently),
+#      and an EMPTY discovery (M=0, e.g. a mass rename) refuses to assert.
 #
 #   2. FAIL-FAST IS A SAMPLE, NOT AN INVENTORY (#8807 trap 2). On S3 and 06,
 #      Rollup stopped at the markup crash BEFORE reaching asset resolution, so
@@ -51,6 +55,13 @@ on:
     branches: [main]
     paths:
       - 'slides/**'
+      # The workflow's own file MUST be in the filter, else the gate can never
+      # run on the PR that wires it (this PR touches .github/, not slides/) AND
+      # a live-control revert would strand the label: after revert, base..head
+      # contains no slides/ change, paths blocks re-run, slides-build-failed
+      # sticks dead (the exact defect on exercises-unparseable / #8820). A gate
+      # filtered by paths that also poses a label must self-cover (#8822).
+      - '.github/workflows/slides-build-advisory.yml'
   workflow_dispatch:
 
 permissions:
@@ -125,6 +136,22 @@ jobs:
             [ -d "$d" ] || continue
             base="$(basename "$d")"
             if ! printf '%s' "$base" | grep -qE '^(S)?[0-9]'; then
+              # SYMMETRIC of trap 1 (ai-01 #8821 review blocage 2): a dir that
+              # does NOT match the convention but DOES carry a deck file is
+              # invisible to discovery. Renaming 01-introduction to intro-01
+              # would silently drop it from M -- 15 OK lines for 16 dirs, the
+              # literal shape of the #8807 incident moved from file-test to
+              # name-test. The denominator must be falsifiable in BOTH
+              # directions, not just the "convention dir with no target" one.
+              # Check existence per-pattern (ls over a non-matching glob passes
+              # the literal and errors on it, masking a real slides.md).
+              has_deck=0
+              [ -f "${d}slides.md" ] && has_deck=1
+              for deck in "${d}"deck-*.md; do [ -f "$deck" ] && has_deck=1; done
+              if [ "$has_deck" -eq 1 ]; then
+                echo "::error::'$d' carries a deck file (slides.md or deck-*.md) but does NOT match the NN/SN convention -- invisible to discovery (#8807 trap 1, symmetrized). Rename the directory to match the convention or move the deck into a convention dir."
+                ZERO_TARGET_DIRS=$((ZERO_TARGET_DIRS + 1))
+              fi
               continue   # infra dir -- not a deck
             fi
             N_DECK_DIRS=$((N_DECK_DIRS + 1))
@@ -149,6 +176,18 @@ jobs:
           echo "Deck dirs tracked (M): $N_DECK_DIRS"
           echo "Build targets discovered (N): ${#TARGETS[@]}"
           printf '  target: %s\n' "${TARGETS[@]}"
+
+          # META-FAILURE (empty discovery, ai-01 #8821 review blocage 2): if
+          # NOTHING matched the convention, the gate measures nothing and must
+          # NOT print "valid" from an empty measure. A mass rename or a
+          # convention change would empty N_DECK_DIRS silently -- the job would
+          # otherwise emit "Discovery sanity above still validates the gate" from
+          # a vacuous inventory (the #8807 defect one notch higher: there the
+          # unmeasured item was one notebook, here it is the whole inventory).
+          if [ "$N_DECK_DIRS" -eq 0 ] || [ "${#TARGETS[@]}" -eq 0 ]; then
+            echo "::error::Discovery empty (M=$N_DECK_DIRS decks, N=${#TARGETS[@]} targets) -- the gate measures nothing. Refusing to assert validity from an empty measure (#8807, #8680)."
+            exit 1
+          fi
 
           # META-FAILURE: the gate itself is broken (incomplete discovery), NOT a
           # build failure. This is the one non-advisory exit -- a gate that


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python (#8828 Čech, MERGED `50324520c`)

See #8817, #8822. **Follow-up to #8821 (merged): ships the CHANGES_REQUESTED fix that lost a 6-second race to the merge.**

## Why this exists (the race)

#8821 was merged by `jsboige` at the original head `bb84465a0` at **13:15:09Z**. My CHANGES_REQUESTED fix commit (`7a389ee76`) carries timestamp **13:15:15Z — 6 seconds later**. The fix pushed to an already-merged PR, so it never registered as a PR update and never landed on `main`. Verified firsthand:

- `git show origin/main:.github/workflows/slides-build-advisory.yml` → `has_deck` count **0** (the symmetric check is absent) — main has the pre-fix `bb84465a0`.
- `gh pr view 8821 --json mergedAt` → `13:15:09Z`; `git show 7a389ee76 --format=%aI` → `13:15:15Z`.

So ai-01's two blocages shipped live on `main`. This PR ships the fix (cherry-pick of `7a389ee76`, byte-identical; the no-op resync commit `25d55d545` from the race is dropped).

## The two blocages (ai-01's CHANGES_REQUESTED), both closed

**Blocage 1 — the gate can never run on the PR that wires it (paths self-cover, #8822).** The `paths: ['slides/**']` filter excludes `.github/`, so this very workflow merged without a single CI run of itself — AND a live-control revert would strand the `slides-build-failed` label (after revert, `base..head` has no `slides/` change, `paths` blocks re-run, the label sticks dead — the exact defect on `exercises-unparseable` / #8820). **Fix:** add the workflow's own file to its `paths:` filter. A gate filtered by `paths` that also poses a label must self-cover (#8822) — one line, semantically just.

**Blocage 2 — the denominator was printed but never opposed to anything.** The discovery printed `M` deck dirs and `N` targets but nothing checked the relationship either direction: a deck that *disappears* from the measure would be invisible (rename `01-introduction` → `intro-01` silently shrinks `M`, 15 OK lines for 16 dirs — the literal shape of #8807 moved from file-test to name-test), and an EMPTY discovery (`M=0`, mass rename) would print "Discovery sanity still validates the gate" from a vacuous inventory. **Fix:** (a) a **symmetric** check — a dir that does NOT match the `NN/SN` convention but DOES carry a deck file is flagged; (b) an **empty-discovery guard** that refuses to assert validity when `M=0` or `N=0`.

## Verification (instrument before assert, C976-L)

Simulated the discovery loop against a mock `slides/` tree before asserting:
- **Symmetric check fires**: a renamed deck dir (`intro-01/` carrying `slides.md`, not matching `^S?[0-9]`) → flagged, `ZERO_TARGET_DIRS` incremented → would `exit 1`.
- **Empty-discovery guard fires**: no dir matches the convention (`M=0`) → `exit 1`, refuses to assert validity from an empty measure.

NB: ai-01's suggested `ls "${d}slides.md" "${d}"deck-*.md` form has a latent bug — a non-matching `deck-*.md` glob passes the literal to `ls`, which errors and masks a real `slides.md`, so the check never fires. Used the existing per-pattern `[ -f ]` + glob-loop form instead, which the simulation confirms works. (Prior-cycle simulation evidence; this cherry-pick is byte-identical to `7a389ee76`.)

## Complementarity with #8824 (not a duplicate)

#8824 introduces the general `label-paths-guard.yml` (a blocking guard enforcing the #8822 self-cover principle for ALL paths-filtered label-posers) and fixes `exercises-advisory.yml` (+6) to comply. It does **not** touch `slides-build-advisory.yml`. Once #8824 merges, its guard would *flag* the slides gate as non-compliant — this PR is exactly what makes the slides gate pass it. The two are complementary: #8824 = the general rule; this = the slides gate following it.

See #8817, #8822, #8807, #8824.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
