### PR TITLE
fix(harness): coordinate skill must check reviews[].state, not mergeStateStatus alone

### DIFF
--- a/.claude/skills/coordinate/SKILL.md
+++ b/.claude/skills/coordinate/SKILL.md
@@ -36,7 +36,8 @@ Cycle de coordination du cluster CoursIA. **Reserve au coordinateur ai-01** : un
 Pour chaque PR ouverte, dans l'ordre d'anciennete :
 
 1. Lire body + comments + reviews + diff (regle HARD "Read Body Before Any Action", `~/.claude/CLAUDE.md` global).
-2. Verifier l'etat A L'INSTANT-T : `gh pr view N --json state,mergedAt,mergeStateStatus` (jamais depuis le dashboard ou le cycle N-1 — lecon phantom-steer #5563).
+2. Verifier l'etat A L'INSTANT-T : `gh pr view N --json state,mergedAt,mergeStateStatus,reviews` (jamais depuis le dashboard ou le cycle N-1 — lecon phantom-steer #5563).
+   **`mergeStateStatus` ne dit RIEN de l'etat des reviews** : `reviews[].state` est un champ **separe**, et `CLEAN` coexiste parfaitement avec un `CHANGES_REQUESTED` non leve (le global `~/.claude/CLAUDE.md` l'exige deja : « le `mergeStateStatus` seul n'est pas une review »). Un `CHANGES_REQUESTED` non suivi d'un commit **ou** d'un commentaire de levee = **ne pas merger** — y compris quand la review est la sienne, qui ne s'auto-leve pas par ecoulement du temps (incident #8821).
 3. Gates : H.4 (notebooks : checkout + Papermill local OU log dans le body), catalogue byte-identique a main (`gh pr view N --json files` — lecon stale-catalog), scope reel = titre, criteres [pr-review-discipline](../../rules/pr-review-discipline.md).
 4. Merge : compte `jsboige` (defaut, seul compte avec MergePullRequest), `--squash` par defaut, `--merge` (preserve-SHA) pour la base d'un stack, **JAMAIS `--delete-branch`**.
 


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-ai-01:CoursIA — prev: MED/tooling

## Le harnais prescrivait la commande qui a cause l'incident

Phase 3.2 du skill `coordinate` disait :

```
gh pr view N --json state,mergedAt,mergeStateStatus
```

Cette liste de champs **omet le seul qui decide si une review bloque**. `mergeStateStatus: CLEAN` coexiste parfaitement avec un `CHANGES_REQUESTED` non leve — GitHub ne traite une review comme bloquante que sous branch-protection ; sans elle, `CLEAN` veut dire « pas de conflit, checks verts », rien de plus.

**Ce n'est pas une nouvelle politique.** Le global `~/.claude/CLAUDE.md` (« Read Body Before Any Action ») l'exige deja, noir sur blanc :

> Le titre seul n'est pas la PR. Le `mergeStateStatus` seul n'est pas une review.

et, dans son tableau : `gh pr merge N` → lire `reviews[].state == "CHANGES_REQUESTED"` → **NE PAS merger si demandes non-adressees**. La commande operationnelle du skill contredisait donc silencieusement la regle qu'elle etait censee servir. C'est cet ecart que la PR ferme.

## L'incident

#8821, aujourd'hui, sur cette machine :

```
11:15:20Z  myia-ai-01  CHANGES_REQUESTED   (2 blocages, ecrits par moi)
13:15:09Z  merge --squash par jsboige      <- 2h apres
```

Aucun commit entre les deux, aucun commentaire levant le blocage. Le gate « verifier l'etat a l'instant-T » **a bien ete execute** — sur le mauvais champ. Le defaut decrit dans le blocage 1 est parti sur `main` (verifie : `grep -c "slides-build-advisory.yml"` dans le workflow lui-meme rendait `0`), repare 14 minutes plus tard par #8834.

Aggravant, et c'est pour ca que je le corrige dans le harnais plutot que dans ma tete : c'etait le cycle meme ou j'opposais ce critere a #8820, #8829 et #8824.

## Organe, pas vigilance

La reponse a une regle non appliquee est de **construire l'organe**, jamais de se promettre plus d'attention — un correctif qui repose sur « je ferai attention » a une demi-vie d'un cycle. Ici l'organe est minimal : la commande prescrite lit desormais le champ, et le texte dit pourquoi.

Ajout explicite du cas qui m'a eu : **une review a soi ne s'auto-leve pas par ecoulement du temps**. Si on change d'avis apres mesure, on **ecrit la levee** avant de merger — la trace est ce qui distingue « revue revisee » de « merge qui n'a pas regarde ».

## Portee

`+2/−1` sur un seul fichier, `.claude/skills/coordinate/SKILL.md`. Aucun `.claude/rules/` touche (ceux-la demandent un sign-off user, et de toute facon la regle existe deja en amont — il n'y a rien a y ajouter).

Je ne merge pas cette PR moi-meme : c'est du harnais, et elle sort du cycle ou j'ai justement merge quelque chose que je n'aurais pas du. Elle attend une relecture.

See #8821, #8834.
