### PR TITLE
fix(notebook-tools,#8835): classify_notebook path-form invariant (top-of-tree rule)

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -240,13 +240,19 @@ def _classify(
 
     # A notebook sitting directly at the top of MyIA.AI.Notebooks/ belongs to no
     # series; every taught series lives in a family directory. `GradeBook.ipynb`
-    # (the grading engine) is the only such file today.
-    if path.is_absolute():
-        try:
-            if len(path.relative_to(NOTEBOOKS_DIR).parts) == 1:
-                return ("tooling", None)
-        except ValueError:
-            pass
+    # (the grading engine) is the only such file today. Computed on the RESOLVED
+    # path relative to NOTEBOOKS_DIR -- `resolve()` is lexical, so a relative
+    # path and its absolute form agree (the fleet `--check` resolves to absolute,
+    # the PR gate feeds `git diff --name-only` relative; both must agree, #8835).
+    # The original `if path.is_absolute()` gate skipped this entirely on a
+    # relative path, silently dropping the file to `standard`. NB: this is the
+    # resolved path, NOT the raw `path.relative_to()` of the bug -- form-invariant
+    # by construction, like `_scope_parts` above.
+    try:
+        if len(path.resolve().relative_to(NOTEBOOKS_DIR.resolve()).parts) == 1:
+            return ("tooling", None)
+    except (ValueError, OSError):
+        pass
 
     if SETUP_STEM_RE.search(stem) or any(SETUP_DIR_RE.search(p) for p in parts[:-1]):
         return ("setup", KIND_MINIMUM["setup"])

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -20,6 +20,7 @@ if _tools_dir not in sys.path:
 from count_exercises import (
     OUT_OF_CORPUS_KINDS,
     _classify,
+    classify_notebook,
     corpus_scope,
     _is_stub_code,
     count_exercises_in_notebook,
@@ -1080,3 +1081,42 @@ class TestCorpusScope:
         corpus, removed = corpus_scope(hostile)
         assert corpus == [nb]
         assert removed == {}
+
+    @pytest.mark.parametrize(
+        "rel_path, expected_kind",
+        [
+            ("GradeBook.ipynb", "tooling"),                # root of NOTEBOOKS_DIR -> the #8835 bug
+            ("Search/SW-4-Ontologies.ipynb", "standard"),  # subdir, taught series
+            ("SymbolicAI/Lean-1-Setup.ipynb", "setup"),    # subdir, rule-exempt kind
+        ],
+    )
+    def test_classify_is_invariant_to_path_form(self, monkeypatch, rel_path, expected_kind):
+        """The same file must classify identically as a relative or absolute path.
+
+        The two #2161 organs disagree otherwise: the fleet `count_exercises.py
+        --check` resolves paths to absolute, while the PR gate
+        `check_pr_exercises.py --stdin` feeds `git diff --name-only` (relative).
+        A classification that flips with path form makes the two contradict, and
+        the liar is the one that writes the label (#8835). Paths are NOTEBOOKS_DIR
+        subpaths (the public `classify_notebook` API, root=None, exactly as the
+        two organs call it) run from the repo root so the relative form resolves
+        under NOTEBOOKS_DIR; the notebooks need not exist on disk because
+        classification is path-only. On the pre-fix code the `tooling` case fails
+        (relative -> `standard`); `setup`/`standard` already held the invariant.
+        """
+        from count_exercises import REPO_ROOT
+
+        monkeypatch.chdir(REPO_ROOT)
+        rel = Path("MyIA.AI.Notebooks") / rel_path
+        abso = rel.resolve()
+        assert not rel.is_absolute() and abso.is_absolute()  # the two forms under test
+        classified_rel = classify_notebook(rel)
+        classified_abs = classify_notebook(abso)
+        assert classified_rel == classified_abs, (
+            f"{rel_path}: relative {classified_rel} != absolute {classified_abs} "
+            f"(path form must not be signal, #8835)"
+        )
+        assert classified_rel[0] == expected_kind, (
+            f"{rel_path}: expected kind {expected_kind!r}, got {classified_rel[0]!r}"
+        )
+


### PR DESCRIPTION
Grain: MED/refactor — lane myia-po-2024:CoursIA-2 — prev: MED/guard

## Résumé

`classify_notebook` rendait un verdict différent pour un **même** fichier selon la **forme** du chemin (`GradeBook.ipynb` → `('tooling', None)` en absolu mais `('standard', 3)` en relatif). La flotte (`count_exercises --check`, chemins résolus absolus) était correcte ; le **gate PR** (`check_pr_exercises --stdin`, chemins `git diff --name-only` **relatifs**) étiquetait donc `GradeBook.ipynb` `exercises-below-threshold` alors que la flotte était à 0 sub-threshold — l'organe qui pose les labels était celui qui se trompait (#8831 portait le faux label).

**Cause racine** : la règle « haut de l'arbre » de `_classify` (count_exercises.py:241-255) se gorait sur `if path.is_absolute():` — silencieusement sautée sur un chemin relatif, le fichier retombait en `standard`. Une seule règle n'utilisait pas la normalisation `_scope_parts` que toutes les autres consomment déjà (#8812).

**Fix** : exprimer la règle sur le chemin **résolu** relatif à `NOTEBOOKS_DIR` — invariant par forme par construction, comme `_scope_parts`. Correctif d'**une** règle, pas un re-skin.

## Preuves — les 5 critères d'acceptation de #8835

### 1. Le voir échouer d'abord

`test_classify_is_invariant_to_path_form` (paramétré) **échoue sur le code bogué** :

```
$ git stash (fix retiré) ; pytest test_classify_is_invariant_to_path_form
FAILED tests/test_count_exercises.py::TestCorpusScope::test_classify_is_invariant_to_path_form[GradeBook.ipynb-tooling]
1 failed, 2 passed
```

### 2. Étendre au-delà du cas connu

Le test paramètre 3 classifications via l'API publique `classify_notebook` (+ `monkeypatch.chdir(REPO_ROOT)`, sous-chemins `NOTEBOOKS_DIR` réels) :

| chemin relatif | `kind` attendu |
|---|---|
| `GradeBook.ipynb` (racine `NOTEBOOKS_DIR`) | `tooling` — le bug #8835 |
| `Search/SW-4-Ontologies.ipynb` (sous-dossier) | `standard` |
| `SymbolicAI/Lean-1-Setup.ipynb` (sous-dossier) | `setup` |

Réécrit pour utiliser l'API publique (pas `root=tmp_path`) : la règle tooling est spécifique à `NOTEBOOKS_DIR`, donc les fichiers `tmp_path` ne seraient jamais tooling — le test doit utiliser le vrai ancrage.

### 3. Les deux organes d'accord, mesurés (fixed code)

```
$ echo "MyIA.AI.Notebooks/GradeBook.ipynb" | python check_pr_exercises.py --stdin   # RELATIF (gate PR)
Out of corpus       : 1
Below threshold     : 0
  (tooling) MyIA.AI.Notebooks\GradeBook.ipynb -- out of corpus (kind=tooling) -- convention does not apply
# AUCUN label. Idem en chemin ABSOLU.

$ python count_exercises.py --check                                                   # flotte
Conforming          : 778
Sub-threshold       : 0
Out of corpus       : 138 (archive=29, artifact=102, legacy=1, student=1, template=3, tooling=2)
```

`tooling=2` (GradeBook.ipynb toujours hors corpus), `out_of_corpus: 1, sub_threshold: 0`, **aucun label**. ✅

### 4. Dénominateur non régressé — before/after BYTE-IDENTIQUE

La flotte résout en absolu → la règle était **déjà** correcte pour elle (le bug ne touchait que le relatif). Mesuré sur le **même corpus** complet (946 `.ipynb`) avant (code bogué, fix stashé) puis après (code fixé) :

| | Conforming | Sub-threshold | Out-of-corpus |
|---|---|---|---|
| **before** (buggy) | 778 | 0 | 138 (… tooling=2) |
| **after** (fixed) | 778 | 0 | 138 (… tooling=2) |

Byte-identique → le fix ne rétrécit pas le corpus pour « acheter le vert » (contrôle `--threshold 99` de #8812 satisfait par construction). ✅

### 5. Aucune autre règle laissée sur le chemin brut

`grep` dans `_classify` : la seule normalisation de chemin est désormais `path.resolve().relative_to(NOTEBOOKS_DIR.resolve())` (l.252) + `_scope_parts` (l.211). Les `path.is_absolute()`/`relative_to` restants (l.704, l.716) sont dans les helpers de reporting `_family_of` / `_display_path` — **pas** des règles de classification. ✅

## Suite de tests

`pytest tests/test_count_exercises.py tests/test_check_pr_exercises.py` → **80 passed**, 0 régression (was 79 + mon nouveau test paramétré = 3 cas).

Closes #8835
