### PR TITLE
feat(audit,#8056): Litmus 10 - validator contredit par des sorties error commitees

### DIFF
--- a/docs/notebook-metadata/cost-matrix.md
+++ b/docs/notebook-metadata/cost-matrix.md
@@ -189,6 +189,36 @@ une sortie de cellule à la main (Stop & Repair, cf
 > (`Probas/Infer.NET`, `ML/ML.NET`) — ceux-là *ont* été exécutés, leur défaut est une
 > étiquette inexacte, pas une exécution fantôme.
 
+### Sorties `error` commitées — l'échec d'exécution (Litmus 10)
+
+Le Litmus 9 mesure l'**absence** d'exécution (`execution_count: null`). Il ne voit
+jamais son **échec** : une cellule qui a tourné et levé une exception porte un
+`execution_count` non nul et une sortie `error` — elle passe le Litmus 9 sans bruit.
+Avant le Litmus 10, **aucun** des neuf litmus ne lisait `outputs` : une trace
+d'exception commitée n'était contredite par rien.
+
+**Règle falsifiable :** quand `validator` affirme une validation, aucune cellule ne
+doit porter de sortie `output_type: error`. Vérifié par `check_cost_metadata.py`
+(Litmus 10) → finding `validator_asserts_validation_but_cells_errored` (MAJOR).
+
+**Le périmètre inclut `qc_cloud`, exclu du Litmus 9** — et c'est l'application
+littérale de la phrase ci-dessus : le carve-out H.3 excuse une cellule **qui n'a pas
+pu tourner**, il n'excuse pas une cellule qui a **démontrablement tourné et échoué**.
+L'indisponibilité du runtime QC n'explique pas un `KeyError`. Le carve-out reste donc
+entier côté Litmus 9 (cellules non exécutées) et ne couvre pas ce cas-ci. `manual`
+reste hors périmètre, lui : il déclare une inspection de source, « pas de
+ré-exécution machine claimée » — aucune affirmation qu'un traceback contredirait.
+
+> **Mesure à l'introduction (2026-07-29, 1019 notebooks scannés) :** 3 notebooks
+> portent au moins une sortie `error`, dont 2 **sans** metadata `cost` (hors périmètre
+> du checker). Reste **un** finding : `partner-course-quant-trading/examples/
+> Crypto-MultiCanal/research_archive.ipynb` — 33/33 cellules exécutées, **13 sorties
+> `error`** (6 `KeyError`, 7 `NameError` en cascade depuis `KeyError: 'close'`), sous
+> `validator: qc_cloud, last_validated: 2026-07-26`. Le corpus n'utilise pas
+> l'exception non rattrapée comme ressort pédagogique — une exception *démontrée* est
+> rattrapée et ne produit pas de sortie `error` —, donc le litmus est **contradictoire,
+> pas bruyant**. Correction : ré-exécution QC Cloud (gated #6891) ou `validator: manual`.
+
 ### Tiers VRAM (déterminé par `vram_gb`)
 
 | Tier | VRAM (GB) | Modèles typiques |
@@ -548,6 +578,7 @@ Le script `extract_claims_vs_outputs.py` (livré par [PR #8068 / cycle c.793](ht
 | Notebook QC sans `qc_cloud` validator | MAJOR |
 | Notebook GPU sans `sk_visual` validator (cf #5780 sweep) | MINOR |
 | `metadata.cost.validator` affirme une exécution mais des cellules code portent `execution_count: null` (Litmus 9) | MAJOR |
+| `metadata.cost.validator` affirme une validation mais des sorties `error` sont commitées (Litmus 10) | MAJOR |
 
 Ces extensions restent **hors scope c.794** (à dispatcher cycles c.795+) — la grille est volontairement extensible.
 

--- a/scripts/audit/check_cost_metadata.py
+++ b/scripts/audit/check_cost_metadata.py
@@ -25,6 +25,8 @@ But : extraire pour un notebook :
       (8) api_cost_breakdown dont la somme != api_usd_est (design-gate #8056)
       (9) validator affirmant une exécution alors que des cellules code
           non vides portent execution_count: null
+     (10) validator affirmant une validation alors que des sorties `error`
+          sont commitées (le litmus 9 voit l'absence d'exécution, pas son échec)
 
 Litmus anti-LIGHT : ce script EXTRACT, il ne DÉCIDE pas. Le verdict final
 = revue humaine/agent compétent. Cf docs/notebook-metadata/cost-matrix.md.
@@ -526,6 +528,68 @@ def check_notebook(notebook_path: Path, repo_root: Path) -> dict:
                     f"Corriger la DECLARATION (validator: manual si le notebook "
                     f"n'est pas executable localement) ou re-executer — jamais "
                     f"editer les sorties a la main."
+                ),
+                'severity': 'MAJOR',
+            })
+
+    # Litmus 10 : le validator affirme une validation que les SORTIES contredisent.
+    #
+    # Le litmus 9 mesure l'ABSENCE d'execution (`execution_count: null`). Il ne
+    # voit jamais son ECHEC : une cellule qui a tourne et leve une exception
+    # porte un `execution_count` non nul et un output `error`, donc elle passe
+    # le litmus 9 sans bruit. Aucun des 9 litmus precedents ne lit `outputs` —
+    # une trace d'exception commitee n'est, avant celui-ci, contredite par rien.
+    #
+    # Pourquoi le perimetre inclut `qc_cloud`, exclu du litmus 9. Le carve-out
+    # du litmus 9 est justifie par « le runtime research QC n'existe sur aucune
+    # machine worker » : il excuse une cellule QUI N'A PAS PU TOURNER. Cette
+    # justification ne s'etend pas a une cellule qui a DEMONTRABLEMENT tourne et
+    # echoue — l'indisponibilite du runtime n'explique pas un `KeyError`. Le
+    # carve-out reste donc entier cote litmus 9 (cellules non executees) et ne
+    # couvre pas ce cas-ci.
+    #
+    # `manual` reste exclu, et ce n'est pas un oubli : il declare une inspection
+    # de source, « pas de re-execution machine claimee » (populate_cost_metadata
+    # .py). Il n'affirme aucune validation d'execution qu'un traceback pourrait
+    # contredire.
+    #
+    # Faux positifs mesures avant ecriture : sur 1019 notebooks du depot, 3
+    # portent au moins une sortie `error`, dont 2 sans metadata `cost` (donc
+    # hors perimetre de ce checker) — le corpus n'utilise pas l'exception non
+    # rattrapee comme ressort pedagogique (une exception DEMONTREE est rattrapee
+    # et ne produit pas d'output `error`). Le litmus est donc contradictoire,
+    # pas bruyant : il tient sur des preuves, pas sur une heuristique.
+    VALIDATION_ASSERTING_VALIDATORS = EXECUTION_ASSERTING_VALIDATORS + ('qc_cloud',)
+    if validator in VALIDATION_ASSERTING_VALIDATORS:
+        failed = []
+        for idx, cell in enumerate(nb.cells):
+            if cell.get('cell_type') != 'code':
+                continue
+            enames = [
+                out.get('ename') or 'error'
+                for out in (cell.get('outputs') or [])
+                if out.get('output_type') == 'error'
+            ]
+            if enames:
+                failed.append((idx, enames))
+        if failed:
+            n_err = sum(len(e) for _, e in failed)
+            shown = ', '.join(
+                f"{idx} ({'/'.join(sorted(set(e)))})" for idx, e in failed[:3]
+            )
+            more = f', +{len(failed) - 3}' if len(failed) > 3 else ''
+            findings.append({
+                'pattern': 'validator_asserts_validation_but_cells_errored',
+                'detail': (
+                    f"cost.validator: '{validator}' affirme une validation, mais "
+                    f"{n_err} sortie(s) error sont commitees dans "
+                    f"{len(failed)} cellule(s) (index {shown}{more}). "
+                    f"cost.last_validated"
+                    f"{' = ' + str(cost_meta['last_validated']) if cost_meta.get('last_validated') else ''}"
+                    f" date une validation que les sorties du notebook "
+                    f"contredisent. Reparer la CAUSE et re-executer, ou corriger "
+                    f"la DECLARATION — jamais editer les sorties a la main "
+                    f"(Stop & Repair)."
                 ),
                 'severity': 'MAJOR',
             })

--- a/scripts/audit/tests/test_check_cost_metadata.py
+++ b/scripts/audit/tests/test_check_cost_metadata.py
@@ -13,7 +13,8 @@ import importlib.util
 from pathlib import Path
 
 import nbformat
-from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook
+from nbformat.v4 import (new_code_cell, new_markdown_cell, new_notebook,
+                         new_output)
 
 HERE = Path(__file__).resolve().parent
 CHECK_PATH = HERE.parent / "check_cost_metadata.py"
@@ -545,3 +546,102 @@ def test_litmus9_detail_names_the_cell_indices(tmp_path):
     detail = next(f["detail"] for f in findings if f["pattern"] == _LITMUS9_PATTERN)
     assert "1, 2" in detail
     assert "2026-07-23T01:30Z" in detail
+
+
+# ---------------------------------------------------------------------------
+# Litmus 10 — validator_asserts_validation_but_cells_errored
+#
+# Le litmus 9 mesure l'ABSENCE d'exécution ; il ne voit jamais son ÉCHEC. Une
+# cellule qui a tourné et levé une exception porte un `execution_count` non nul
+# — elle passe le litmus 9 sans bruit. Aucun des 9 litmus précédents ne lit
+# `outputs`. Cf docs/notebook-metadata/cost-matrix.md.
+# ---------------------------------------------------------------------------
+
+_LITMUS10_PATTERN = "validator_asserts_validation_but_cells_errored"
+
+
+def _notebook_error_cells(path: Path, specs, cost_meta=None) -> None:
+    """spec = (source, execution_count, ename|None) ; ename => output `error`."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    nb = new_notebook()
+    cells = []
+    for source, exec_count, ename in specs:
+        cell = new_code_cell(source)
+        cell["execution_count"] = exec_count
+        if ename:
+            # `new_output` rend un NotebookNode : `nbformat.write` valide les
+            # sorties par acces d'attribut (`output.output_type`) et rejette un
+            # dict nu.
+            cell["outputs"] = [
+                new_output("error", ename=ename, evalue="boom",
+                           traceback=["Traceback..."])
+            ]
+        cells.append(cell)
+    nb.cells = cells
+    if cost_meta:
+        nb.metadata["cost"] = cost_meta
+    with path.open("w", encoding="utf-8") as f:
+        nbformat.write(nb, f, version=4)
+
+
+def _litmus10_patterns(tmp_path, specs, cost_meta):
+    mod = _load_check()
+    nb_path = tmp_path / "nb.ipynb"
+    _notebook_error_cells(nb_path, specs, cost_meta=cost_meta)
+    return _patterns(mod.check_notebook(nb_path, tmp_path)["findings"])
+
+
+def test_litmus10_qc_cloud_errored_cell_flags(tmp_path):
+    """Le carve-out `qc_cloud` du litmus 9 excuse une cellule QUI N'A PAS PU
+    tourner. Il ne s'étend pas à une cellule qui a tourné et échoué :
+    l'indisponibilité du runtime n'explique pas un KeyError."""
+    pats = _litmus10_patterns(
+        tmp_path,
+        [("df['close']", 1, "KeyError")],
+        {"validator": "qc_cloud", "last_validated": "2026-07-26"},
+    )
+    assert _LITMUS10_PATTERN in pats
+
+
+def test_litmus10_qc_cloud_unexecuted_without_error_is_exempt(tmp_path):
+    """Régression : étendre le périmètre à `qc_cloud` ne doit PAS annuler le
+    carve-out du litmus 9 pour les cellules simplement non exécutées."""
+    pats = _litmus10_patterns(
+        tmp_path,
+        [("qb = QuantBook()", None, None)],
+        {"validator": "qc_cloud", "qcc_tokens_est": 400},
+    )
+    assert _LITMUS10_PATTERN not in pats
+    assert _LITMUS9_PATTERN not in pats
+
+
+def test_litmus10_papermill_errored_cell_flags(tmp_path):
+    """Un validator affirmant l'exécution est contredit par un traceback commité
+    tout autant que par une cellule jamais exécutée."""
+    pats = _litmus10_patterns(
+        tmp_path,
+        [("1/0", 1, "ZeroDivisionError")],
+        {"validator": "papermill", "last_validated": "2026-07-26"},
+    )
+    assert _LITMUS10_PATTERN in pats
+
+
+def test_litmus10_manual_validator_exempt(tmp_path):
+    """`manual` déclare une inspection de source, « pas de re-exécution machine
+    claimée » : aucune affirmation d'exécution qu'un traceback contredirait."""
+    pats = _litmus10_patterns(
+        tmp_path,
+        [("df['close']", 1, "KeyError")],
+        {"validator": "manual"},
+    )
+    assert _LITMUS10_PATTERN not in pats
+
+
+def test_litmus10_clean_outputs_no_finding(tmp_path):
+    """Contrôle négatif : un notebook exécuté sans erreur ne doit rien lever."""
+    pats = _litmus10_patterns(
+        tmp_path,
+        [("x = 1", 1, None), ("y = 2", 2, None)],
+        {"validator": "papermill", "last_validated": "2026-07-26"},
+    )
+    assert _LITMUS10_PATTERN not in pats


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: LIGHT/guard

Le Litmus 9 mesure l'**absence** d'exécution. Il ne voit jamais son **échec**.

## Le trou, et comment je suis tombé dessus

Je partais auditer la matrice `cost:` de #8056 sur un tout autre soupçon — `free_alternative: "self"`, 164 occurrences, que je prenais pour une non-déclaration déguisée en déclaration. **Hypothèse fausse** : lire le bloc la réfute (`gpu_required: false`, `api_usd_est: 0.0`, mode par défaut ComfyUI self-hosted). Le notebook *est* déjà le chemin gratuit ; `self` est une sentinelle légitime, et le Litmus 4 la traite déjà comme telle. Je ne livre donc rien là-dessus.

En revanche le croisement « claim de métadonnée ↔ preuve d'exécution » a sorti un cas que rien ne contredit :

```
QuantConnect/partner-course-quant-trading/examples/Crypto-MultiCanal/research_archive.ipynb
  validator: qc_cloud   last_validated: 2026-07-26   reproducibility: MED
  33/33 cellules exécutées   13 sorties error
  KeyError: 'close' (x6) -> NameError: 'pivotList' non défini (x7)   [cascade]
```

Une cascade qui part du premier accès aux données, sous un tampon de validation daté. Et **pré-patch, ce notebook passe la batterie des 9 litmus avec `findings:` vide.**

La raison est structurelle, pas accidentelle : le Litmus 9 teste `execution_count is None`. Une cellule qui a tourné et levé une exception porte un `execution_count` **non nul** — elle est donc, pour lui, exécutée. Et **aucun** des neuf litmus ne lit `outputs` (`grep -c "output_type"` sur le checker = 0). Une trace d'exception commitée n'était contredite par rien.

## Pourquoi le périmètre inclut `qc_cloud`, que le Litmus 9 exclut

Ce n'est pas un élargissement de confort : c'est l'application littérale d'une phrase que `cost-matrix.md` posait **déjà**, en note de mesure du Litmus 9 —

> le carve-out excuse l'**absence** d'exécution, il n'autorise pas à en **affirmer** une.

Le carve-out H.3 est justifié par « le runtime research QC n'existe sur aucune machine worker ». Cette justification couvre une cellule **qui n'a pas pu tourner**. Elle ne couvre pas une cellule qui a **démontrablement tourné et échoué** : l'indisponibilité du runtime QC n'explique pas un `KeyError`. Le carve-out reste donc **entier** côté Litmus 9, et un test de régression le verrouille (`test_litmus10_qc_cloud_unexecuted_without_error_is_exempt` asserte que ni le 9 ni le 10 ne se déclenchent sur une cellule qc_cloud simplement non exécutée).

`manual` reste hors périmètre, lui, et pour la raison écrite par le populator : « inspection source, pas de re-exécution machine claimée ». Aucune affirmation d'exécution qu'un traceback contredirait.

## Contrôle positif

C'est ce que je réclame aux autres (#8681), donc je le fournis. Le gate doit être **vu échouer sur le vrai défaut**, pas se prouver seul :

```
PRE-PATCH  (checker de main) sur research_archive.ipynb :   findings:        <- VIDE
POST-PATCH :  MAJOR validator_asserts_validation_but_cells_errored
              "13 sortie(s) error ... (index 4 (KeyError), 6 (KeyError), 10 (NameError), +10).
               cost.last_validated = 2026-07-26 date une validation que les sorties
               du notebook contredisent."
```

Les deux moitiés, car celle qu'on oublie est celle qui dit si le gate crie à tort :

```
qc_cloud partiellement exécuté, 0 erreur (FuturesTrend/quantbook.ipynb)  -> silencieux (carve-out intact)
papermill entièrement exécuté, 0 erreur (LTX-Video-Lightweight.ipynb)    -> silencieux
```

## Faux positifs mesurés AVANT d'écrire la règle

Un litmus sur `outputs` pourrait plausiblement pilonner les notebooks qui *démontrent* une exception. Mesuré, pas supposé :

```
1019 notebooks scannés -> 3 portent >=1 sortie error
   2 sans metadata cost  (research_robustness_output.ipynb ; archive/Tweety.ipynb)  -> hors périmètre
   1 avec validator      (research_archive.ipynb)                                   -> le finding
```

Le corpus n'utilise pas l'exception non rattrapée comme ressort pédagogique — une exception *démontrée* est rattrapée et ne produit pas de sortie `error`. Le litmus est donc **contradictoire, pas bruyant**. Fleet-wide après patch : **1 finding**, celui visé.

## Ce que je ne fais pas dans cette PR

Je ne corrige pas `research_archive.ipynb`. La réparation honnête est une ré-exécution QC Cloud, **gated #6891** — et éditer sa métadonnée pour éteindre le finding, ou pire ses sorties, serait exactement le maquillage que le message du finding interdit (Stop & Repair). Le cas part en issue séparée avec la mesure.

Je ne touche pas non plus aux 14 autres notebooks `qc_cloud` partiellement exécutés : j'avais commencé par les croire sur-tamponnés, la lecture du carve-out me donne tort, et je préfère le dire que livrer un correctif sur une prémisse réfutée.

## Vérifications

- `96 passed` (`scripts/audit/tests/`), dont **5 tests Litmus 10** + le test de régression du carve-out
- Catalogue **byte-identique à main** (`git diff --name-only origin/main -- COURSE_CATALOG.*` = 0)
- 3 fichiers, aucun notebook modifié, aucune sortie de cellule touchée
- Doc synchronisée : `cost-matrix.md` (section Litmus 10 + ligne du tableau des défauts) et le docstring `--help` du checker, qui énuméraient tous deux 9 litmus

See #8056, #6891, #8680.
