### PR TITLE
fix(notebook-tools,#8655): exempt NEW notebooks from md-content-loss gate (FP on creation)

### DIFF
--- a/scripts/notebook_tools/detect_md_content_loss.py
+++ b/scripts/notebook_tools/detect_md_content_loss.py
@@ -54,6 +54,14 @@ Pour chaque notebook compare entre sa base git (defaut origin/main) et sa tete
      justifie en review (design #4). Sortie exploitable : fichier / cellule /
      avant-apres / ratio / motifs perdus.
 
+  6. EXEMPT LES NOTEBOOKS NOUVEAUX : un fichier absent a la base (creation)
+     n'a rien a perdre (tout est ajout). On le distingue d'un notebook
+     existant illisible via ``path_exists_at_ref`` (``git cat-file -e``) pour
+     ne pas confondre "nouveau fichier" et "detecteur casse" -- sinon le garde
+     anti-auto-desarmement (#8655/#8662) fail-loud sur toute creation de
+     notebook. Un nouveau fichier renvoie rc=0 (exempt), un fichier existant
+     illisible renvoie toujours rc=2 (fail loud preserve).
+
 Usage
 -----
     # un notebook, diff vs origin/main (head = working tree)
@@ -64,9 +72,11 @@ Usage
 
 Exit codes
 ----------
-    0 -- aucune perte de contenu detectee (ou mode non --check)
+    0 -- aucune perte de contenu detectee (ou mode non --check), y compris un
+         notebook NOUVEAU (absent a la base : rien a comparer -> exempt)
     1 -- une ou plusieurs pertes detectees (--check)
-    2 -- erreur (notebook illisible, ref git introuvable)
+    2 -- erreur (notebook EXISTANT illisible, ref git introuvable). Un notebook
+         absent a la base (nouveau fichier) ne declenche PAS rc=2 : il est exempt.
 
 Voir aussi
 ----------
@@ -176,6 +186,52 @@ def read_notebook_at_ref(nb_path: Path, ref: str) -> dict | None:
         return None
 
 
+def path_exists_at_ref(nb_path: Path, ref: str) -> bool:
+    """True si le chemin existe a ce ref (``git cat-file -e``), False sinon.
+
+    Permet de distinguer un notebook **NOUVEAU** (absent a la base -> il n'y a
+    rien a comparer, on l'exempte) d'un notebook **existant mais illisible**
+    (``read_notebook_at_ref`` renvoie None -> detecteur casse ou ref git
+    manquant -> on le signale en rc=2 pour que le garde anti-auto-desarmement
+    (#8655/#8662) continue de fail loud). Sans cette distinction, toute creation
+    de notebook tripe le garde : un fichier absent a la base est lu comme
+    "unreadable" et fait echouer la CI sur une fausse perte de contenu.
+
+    NB: un ref git **invalide** fait aussi echouer ``cat-file -e`` (sur tous les
+    chemins) ; on valide donc le ref separement via ``ref_resolves`` AVANT
+    d'appeler cette fonction, sinon un BASE casse desarmerait silencieusement le
+    garde (tout semblerait "nouveau").
+    """
+    rel = nb_path.as_posix()
+    try:
+        out = subprocess.run(
+            ["git", "cat-file", "-e", f"{ref}:{rel}"],
+            capture_output=True, check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return False
+    return out.returncode == 0
+
+
+def ref_resolves(ref: str) -> bool:
+    """True si le ref git existe (``git cat-file -e <ref>``), False sinon.
+
+    Garde anti-regression : si le ref de base est invalide (ref manquant,
+    actions/checkout rate), ``path_exists_at_ref`` renverrait False pour tous
+    les chemins et toute la PR semblerait "nouveau fichier" -> rc=0 ->
+    desarmement silencieux du garde #8655/#8662. On valide le ref en amont pour
+    que ce cas reste un rc=2 (fail loud preserve).
+    """
+    try:
+        out = subprocess.run(
+            ["git", "cat-file", "-e", ref],
+            capture_output=True, check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return False
+    return out.returncode == 0
+
+
 def _compare_cells(base_md: list[tuple[int, str]],
                    head_md: list[tuple[int, str]]) -> list[dict]:
     """Compare cellule-par-cellule (INDEX STABLE requis, design #1 #8655).
@@ -244,6 +300,37 @@ def scan_notebook(nb_path: Path, base_ref: str, head_ref: str | None = None) -> 
             return {"notebook": str(nb_path), "error": f"head_ref {head_ref} unreadable"}
         head_label = head_ref
 
+    # Ref de base invalide (ref manquant, checkout rate) = detecteur/ref casse,
+    # PAS un nouveau fichier. On le signale en erreur (rc=2) pour que le garde
+    # anti-auto-desarmement (#8655/#8662) fail loud -- sinon un BASE casse
+    # ferait passer tous les chemins pour "nouveaux" et desarmerait le gate.
+    if not ref_resolves(base_ref):
+        return {"notebook": str(nb_path), "error": f"base_ref {base_ref} introuvable (ref git invalide)"}
+
+    # Notebook NOUVEAU (absent a la base) : rien a perdre (tout est ajout),
+    # donc exempt de content-loss. On retourne un resultat propre (pas
+    # d'erreur, pas de findings) plutot que de laisser read_notebook_at_ref
+    # renvoyer None -> "unreadable" -> declenchement intempestif du garde
+    # anti-auto-desarmement (#8655/#8662) sur toute creation de notebook.
+    if not path_exists_at_ref(nb_path, base_ref):
+        head_md_new = extract_md_cells(nb_head)
+        head_total_new = sum(_norm_len(s) for _, s in head_md_new)
+        return {
+            "notebook": str(nb_path),
+            "base_ref": base_ref,
+            "head_ref": head_label,
+            "new_file": True,
+            "findings": [],
+            "stats": {
+                "base_md_cells": 0,
+                "head_md_cells": len(head_md_new),
+                "cell_count_stable": False,
+                "base_total_normalized_chars": 0,
+                "head_total_normalized_chars": head_total_new,
+                "findings_count": 0,
+            },
+        }
+
     nb_base = read_notebook_at_ref(nb_path, base_ref)
     if nb_base is None:
         return {"notebook": str(nb_path), "error": f"base_ref {base_ref} unreadable"}
@@ -302,6 +389,9 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[NOTEBOOK] {nb}")
         print(f"[BASE]     {result['base_ref']}")
         print(f"[HEAD]     {result['head_ref']}")
+        if result.get("new_file"):
+            print("[NEW FILE] absent a la base -> exempt de content-loss "
+                  "(rien a perdre, tout est ajout ; #8655/#8662).")
         print(f"[STATS]    md_cells base={st['base_md_cells']} head={st['head_md_cells']} "
               f"stable={st['cell_count_stable']} | "
               f"normalized_chars base={st['base_total_normalized_chars']} "

--- a/scripts/notebook_tools/tests/test_detect_md_content_loss.py
+++ b/scripts/notebook_tools/tests/test_detect_md_content_loss.py
@@ -186,7 +186,11 @@ class TestScanNotebook:
     def _scan(self, tmp_path, base_nb, head_nb, nb_name="x.ipynb"):
         p = tmp_path / nb_name
         p.write_text(json.dumps(head_nb), encoding="utf-8")
-        with mock.patch.object(dml, "read_notebook_at_ref", return_value=base_nb):
+        # Mock aussi ref_resolves (True) et path_exists_at_ref (True) : un
+        # notebook EXISTANT a la base atteint la comparaison (follow-up #8662).
+        with mock.patch.object(dml, "read_notebook_at_ref", return_value=base_nb), \
+             mock.patch.object(dml, "ref_resolves", return_value=True), \
+             mock.patch.object(dml, "path_exists_at_ref", return_value=True):
             return dml.scan_notebook(p, base_ref="MOCK_BASE", head_ref=None)
 
     def test_truncation_end_to_end(self, tmp_path):
@@ -209,7 +213,11 @@ class TestMainExitCodes:
     def _run(self, tmp_path, base_nb, head_nb):
         p = tmp_path / "x.ipynb"
         p.write_text(json.dumps(head_nb), encoding="utf-8")
-        with mock.patch.object(dml, "read_notebook_at_ref", return_value=base_nb):
+        # Mock ref_resolves (True) et path_exists_at_ref (True) : notebook
+        # EXISTANT a la base -> la comparaison s'execute (follow-up #8662).
+        with mock.patch.object(dml, "read_notebook_at_ref", return_value=base_nb), \
+             mock.patch.object(dml, "ref_resolves", return_value=True), \
+             mock.patch.object(dml, "path_exists_at_ref", return_value=True):
             return dml.main([str(p), "--base", "MOCK", "--check"])
 
     def test_exit_1_on_truncation(self, tmp_path):
@@ -221,8 +229,49 @@ class TestMainExitCodes:
         assert self._run(tmp_path, _nb(_md(before)), _nb(_md(after))) == 0
 
     def test_exit_2_on_missing_base_ref(self, tmp_path):
-        # base_ref illisible -> erreur -> exit 2.
+        # Notebook EXISTANT mais illisible (ref valide, path presente, contenu
+        # illisible) -> erreur -> exit 2 (garde anti-auto-desarmement preserve).
         p = tmp_path / "x.ipynb"
         p.write_text(json.dumps(_nb(_md("ok"))), encoding="utf-8")
-        with mock.patch.object(dml, "read_notebook_at_ref", return_value=None):
+        with mock.patch.object(dml, "ref_resolves", return_value=True), \
+             mock.patch.object(dml, "path_exists_at_ref", return_value=True), \
+             mock.patch.object(dml, "read_notebook_at_ref", return_value=None):
+            assert dml.main([str(p), "--base", "BAD_REF", "--check"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# 9. New-file exemption + invalid-ref guard (follow-up #8655/#8662)
+# ---------------------------------------------------------------------------
+class TestNewFileExemptionAndRefGuard:
+    """Un notebook NOUVEAU (absent a la base) est exempt de content-loss ; un
+    ref de base invalide reste rc=2 (garde anti-auto-desarmement preserve)."""
+
+    def test_new_file_exempt_no_findings(self, tmp_path):
+        # Notebook absent a la base (nouveau) -> exempt, 0 findings, new_file=True.
+        p = tmp_path / "x.ipynb"
+        p.write_text(json.dumps(_nb(_md(EXERCISE_BODY))), encoding="utf-8")
+        with mock.patch.object(dml, "ref_resolves", return_value=True), \
+             mock.patch.object(dml, "path_exists_at_ref", return_value=False), \
+             mock.patch.object(dml, "read_notebook_at_ref", return_value=None):
+            r = dml.scan_notebook(p, base_ref="MOCK_BASE", head_ref=None)
+        assert r.get("new_file") is True
+        assert r["stats"]["findings_count"] == 0
+        assert "error" not in r
+
+    def test_new_file_main_exits_0(self, tmp_path):
+        # main() renvoie 0 pour un nouveau fichier (rien a perdre, tout est ajoute).
+        p = tmp_path / "x.ipynb"
+        p.write_text(json.dumps(_nb(_md(EXERCISE_BODY))), encoding="utf-8")
+        with mock.patch.object(dml, "ref_resolves", return_value=True), \
+             mock.patch.object(dml, "path_exists_at_ref", return_value=False), \
+             mock.patch.object(dml, "read_notebook_at_ref", return_value=None):
+            assert dml.main([str(p), "--base", "MOCK", "--check"]) == 0
+
+    def test_invalid_ref_exits_2_disarm_preserved(self, tmp_path):
+        # Ref de base invalide -> rc=2 : le garde anti-auto-desarmement (#8662)
+        # reste arme. Sans ref_resolves, un BASE casse ferait passer tous les
+        # chemins pour "nouveaux" (path_exists_at_ref False) -> desarmement silencieux.
+        p = tmp_path / "x.ipynb"
+        p.write_text(json.dumps(_nb(_md("ok"))), encoding="utf-8")
+        with mock.patch.object(dml, "ref_resolves", return_value=False):
             assert dml.main([str(p), "--base", "BAD_REF", "--check"]) == 2


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python

fix(notebook-tools,#8655): exempt NEW notebooks from md-content-loss gate (FP on creation)

The `No markdown content loss in changed notebooks` CI gate (#8656 + anti-self-
disarmament guard #8662) fails loud on every notebook CREATION PR. Root cause:
`detect_md_content_loss.py` reads the base version via `git show <base>:<path>`;
for a path absent at base (a new file) it returns None -> `scan_notebook` emits
`error: base_ref unreadable` -> exit rc=2 -> the wrapper counts it as "unreadable"
-> when ALL checked notebooks are unreadable the #8662 anti-disarmament guard
fails loud. A notebook whose base does not exist cannot "lose" content (the
comparison is never reached), so the red is the disarm guard firing on a
legitimate new file, not a content-loss verdict.

Tripped in the wild by #8844 (ICT-12b-LearnedValence.ipynb, +493/-0, creation):
`mergeStateStatus: UNSTABLE` on the only red check, with `git show origin/main:<path>`
confirmed ABSENT and the detector reproduced locally as `rc=2 base unreadable`.

Fix (surgical, in the detector — the gate YAML and the comparison logic are
unchanged):

1. `path_exists_at_ref(nb_path, ref)` — `git cat-file -e <ref>:<path>` distinguishes
   "path absent at a VALID ref" (new file -> exempt) from "exists but unreadable"
   (broken). A new file returns a clean result (no error, no findings, `new_file:
   True`) -> rc=0 -> not counted as unreadable -> disarm guard does NOT fire.

2. `ref_resolves(ref)` — `git cat-file -e <ref>` validates the base ref BEFORE the
   path check. Anti-regression on #8662: an INVALID base ref (missing ref, failed
   checkout) makes `path_exists_at_ref` return False for ALL paths -> without this
   guard everything would look "new" and the disarm would be SILENTLY bypassed.
   `ref_resolves` keeps the broken-ref case at rc=2 (fail loud preserved).

The comparison functions (`_compare_cells`, `_compare_motifs`) are byte-identical;
real content-loss detection is unchanged.

Verified firsthand (5 cases):
- NEW notebook (absent at base) -> rc=0 + `[NEW FILE]` notice, findings=0.
- EXISTING unchanged notebook -> rc=0 (normal compare, 13 md cells, no new-file msg).
- INVALID base ref -> rc=2 (disarm guard PRESERVED — anti-regression).
- Truncation 941c->16c -> TRUNCATED_CELL ratio 0.012 (detection unchanged).
- Motif loss full (LOST_MOTIF) + partial nav (LOST_NAV_LINKS) -> detected.

Tests: `test_detect_md_content_loss.py` + `test_md_content_loss_gate_guard.py`
26 passed (was 23; +3 new in `TestNewFileExemptionAndRefGuard`: new-file exempt,
new-file rc=0, invalid-ref rc=2 disarm-preserved). Existing helpers updated to
mock the two new guard functions alongside `read_notebook_at_ref`.

This unblocks #8844 (and all future notebook-creation PRs) from the FP without
weakening the guard for genuinely-unreadable existing notebooks or broken refs.

See #8655 (cahier des charges) · See #8662 (anti-disarmament guard) · refs #8844 (trigger)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
