### PR TITLE
fix(cjk,#8846): SKIP_DIRS parity in detect_cjk_residue --stdin

### DIFF
--- a/scripts/notebook_tools/detect_cjk_residue.py
+++ b/scripts/notebook_tools/detect_cjk_residue.py
@@ -484,6 +484,15 @@ def main(argv=None) -> int:
                 p = root / p
             if p.suffix not in _SCANNABLE_EXT or not p.exists():
                 continue
+            # #8846: SKIP_DIRS parity with the fleet mode (applied at L374/L140).
+            # A path under a pedagogical archive (docs/archive/**, .lake/,
+            # _output/, ...) is not ours to fix, so a leak there is never
+            # attributed to a PR diff. Without this, --stdin scanned what the
+            # fleet scan skips, so a PR that merely touched docs/archive/**
+            # inherited a cjk-residue label for pre-existing residue it never
+            # introduced (#8829 review follow-up).
+            if any(part in SKIP_DIRS for part in p.parts):
+                continue
             results.append(_scan_one(p, root))
     elif args.target:
         p = Path(args.target)

--- a/scripts/notebook_tools/tests/test_detect_cjk_residue.py
+++ b/scripts/notebook_tools/tests/test_detect_cjk_residue.py
@@ -248,6 +248,45 @@ class TestStdinMode:
         rc = mod.main(["--root", str(tmp_path), "--stdin", "--check"])
         assert rc == 0
 
+    # #8846 -- --stdin must apply SKIP_DIRS (parity with the fleet mode that
+    # already skips them at L374/L140), else a PR that merely touches
+    # docs/archive/** inherits a cjk-residue label for pre-existing residue the
+    # PR never introduced. Acceptance criterion of #8846: a SKIP_DIRS path
+    # passed to --stdin must yield 0 hit. This test is RED on the unfixed code
+    # (the detector scanned it -- 1 hit), GREEN after the parity fix.
+    def test_stdin_skips_archive_paths(self, tmp_path, monkeypatch, capsys):
+        # `archive` is a canonical SKIP_DIRS member (#8650): pedagogical archives
+        # are not ours to fix, so a leak there is never attributed to a PR diff.
+        # git diff --name-only emits repo-relative forward-slash paths.
+        archived = tmp_path / "archive" / "leak.md"
+        archived.parent.mkdir(parents=True)
+        archived.write_text("# pre-existing均匀ément residue\n", encoding="utf-8")
+        monkeypatch.setattr(
+            sys, "stdin",
+            io.StringIO(f"{archived.relative_to(tmp_path).as_posix()}\n"),
+        )
+        rc = mod.main(["--root", str(tmp_path), "--stdin", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert out["total_hits"] == 0   # the archive leak is NOT attributed
+        assert out["scanned"] == 0      # ...and not even counted as scanned
+
+    def test_stdin_skips_other_skip_dirs_members(self, tmp_path, monkeypatch, capsys):
+        # Parity must hold for every SKIP_DIRS member, not just `archive`.
+        # `_archives` (plural) is a distinct canonical member (#8650).
+        archived = tmp_path / "_archives" / "leak.py"
+        archived.parent.mkdir(parents=True)
+        archived.write_text("# de重建 residue\n", encoding="utf-8")
+        monkeypatch.setattr(
+            sys, "stdin",
+            io.StringIO(f"{archived.relative_to(tmp_path).as_posix()}\n"),
+        )
+        rc = mod.main(["--root", str(tmp_path), "--stdin", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert out["total_hits"] == 0
+        assert out["scanned"] == 0
+
 
 # ===========================================================================
 # #8826 -- discriminating guard: CJK soldered into/dropped into Latin = leak;


### PR DESCRIPTION
## What

Closes the `--stdin` asymmetry of #8846 (my own #8829 review bug): `detect_cjk_residue --stdin` scanned paths the **fleet mode skips**. `SKIP_DIRS` (the canonical #8650 set — `archive`, `_archives`, `.lake`, `_output`, …) was applied in the fleet walker (`detect_cjk_residue` L374, `notebook_walk` L140) but **not** in the PR-diff `--stdin` loop, so a PR that merely touched `docs/archive/**` inherited a `cjk-residue` label for **pre-existing residue it never introduced**.

### The defect, measured (acceptance criterion 2 — see it fail first)

Two new tests, **RED on the unfixed code** before this PR:
```
TestStdinMode::test_stdin_skips_archive_paths            FAILED  assert 1 == 0
TestStdinMode::test_stdin_skips_other_skip_dirs_members  FAILED  assert 1 == 0
```
The detector counted 1 hit for a `docs/archive/leak.md` that the fleet scan would skip — the exact mis-attribution #8846 reports.

## Option B (filter in the detector) — why not Option A

The user's issue steers "penche A (le filtre appartient au cablage, pas au detecteur)" but **delegates the call** to the organ owner ("je ne trancherai pas a la place de qui tient l'organe") and, crucially, sets **acceptance criterion 1** as:

> un test passant a `detect_cjk_residue --stdin` un path dans SKIP_DIRS (ex: `docs/archive/foo.md`) et asserte 0 hit (apres le fix)

That test calls the **detector** `--stdin` directly and expects **0 hit** — only satisfiable if the filter lives **in the detector** (Option B). If the filter lived in the workflow (Option A), that test would still see a hit on the bare detector. The acceptance criterion dictates B.

Two further reasons B is the honest fit here:
- **No third copy of `SKIP_DIRS`.** Option A would re-encode the set in the workflow YAML — the exact drift `notebook_walk` (#8650) centralized away. B reuses the already-imported canonical set (one line, identical form to L374/L140).
- **`--stdin` already filters** by `_SCANNABLE_EXT` and `.exists()`; `SKIP_DIRS` is the third dimension of the same "is this in the fleet's scope" concept. Not applying it was the inconsistency, not the design.

The fix is one logical line:
```python
if any(part in SKIP_DIRS for part in p.parts):
    continue
```

## Validation (acceptance criteria 1 + 3)

- **Criterion 1** — the 2 new tests now **GREEN**: a `SKIP_DIRS` path (`archive/leak.md`, `_archives/leak.py`) passed to `--stdin` yields `total_hits == 0` and `scanned == 0`.
- **Criterion 3 (no #8829 regression)** — the 44 existing controls are unchanged: clean diff → 0 (`test_stdin_check_exits_0_on_clean_diff`), leaky `.md` **outside** archive → 1 (`test_stdin_scans_only_listed_files`).
- **46/46 PASS** (`scripts/notebook_tools/tests/test_detect_cjk_residue.py`).

## Scope notes

- **Second grain, not main dish** — per the user's #8846 routing ("c'est un bon second grain de cycle, pas un plat principal"), this accompanies a substance main dish in the same cycle.
- **No workflow change** — the detector-level fix is sufficient; `cjk-residue-advisory.yml` still pipes `git diff --name-only … | detect_cjk_residue --stdin`, now with parity.
- CRLF = LF (0 CR bytes), additif (+48, 0 deletions), no notebook touched.

Grain: MED/cjk-ci — myia-po-2026:CoursIA

See #8846

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
