### PR TITLE
ci(lean,#8848): distinguish advisory proof-integrity display-name + pin convention

### DIFF
--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -114,7 +114,13 @@ jobs:
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
-      display-name: conway_lean
+      # #8848: the advisory (fail-on-sorry: false) job carries the ' (audit)' suffix
+      # so it is distinguishable from the blocking proof-integrity job above in the
+      # CI check rollup ("Proof integrity (conway_lean (audit))" vs "(conway_lean)").
+      # Without it a reviewer saw two identical "Proof integrity (conway_lean)" checks
+      # and could not tell which tolerates the 8 acknowledged sorries from which
+      # refuses them. Pinned by scripts/lean/tests/test_proof_integrity_display_names.py.
+      display-name: conway_lean (audit)
       target-modules: "Conway.Life.HashlifeCorrectness"
       # allow-axioms: the 28 native_decide axioms that HashlifeCorrectness ACTUALLY
       # depends on (empirical footprint revealed by THIS audit job's first CI run).

--- a/scripts/lean/tests/test_proof_integrity_display_names.py
+++ b/scripts/lean/tests/test_proof_integrity_display_names.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Contract test: lean-axiom.yml jobs in a workflow must carry DISTINCT display-names (#8848).
+
+Dual-mode: runnable directly (``python scripts/lean/tests/test_proof_integrity_display_names.py``)
+or under pytest (auto-collected by scripts-tests.yml on any ``scripts/**`` change).
+
+The reusable ``lean-axiom.yml`` workflow exposes a ``display-name`` input that becomes
+the check's label in the CI rollup (``Proof integrity (<display-name>)``). When a lake
+wires TWO lean-axiom.yml jobs -- a BLOCKING one (``fail-on-sorry: true``, sorry-free
+modules) and an ADVISORY one (``fail-on-sorry: false``, sorry-bearing modules) -- giving
+both the SAME display-name renders them indistinguishable at a glance (#8848): a reviewer
+sees ``Proof integrity (conway_lean)`` twice and cannot tell which one tolerates 8
+acknowledged sorries from which one refuses them. That recreates, one layer up, the very
+"green whose scope is invisible" defect the audit job was built to close (#8782).
+
+This test pins the convention PROACTIVELY for every lake that has, or will have, more
+than one lean-axiom.yml job: the advisory one MUST carry a distinguishing suffix
+(``<lake> (audit)``), the blocking one keeps the bare lake name (so any branch-protection
+rule referencing the check name is unaffected). Discovery is glob-based over
+``.github/workflows/lean-*.yml`` so a future lake that adds a second lean-axiom.yml job
+is caught the moment it lands -- "corrected at two occurrences, not six" (#8848).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+WF_DIR = REPO / ".github" / "workflows"
+
+
+def _lean_workflows():
+    """Every ``lean-*.yml`` workflow in the repo (discover-based: a future lake that
+    wires lean-axiom.yml is covered without editing this test)."""
+    return sorted(WF_DIR.glob("lean-*.yml"))
+
+
+def _lean_axiom_jobs(doc):
+    """Map ``job-name -> display-name`` for jobs that reuse ``lean-axiom.yml``.
+
+    The blocking job conventionally carries the bare lake ``display-name``; any
+    ADDITIONAL lean-axiom.yml job (advisory) must distinguish itself."""
+    yaml = pytest.importorskip("yaml")
+    jobs = doc.get("jobs", {})
+    out = {}
+    for name, spec in jobs.items():
+        uses = (spec or {}).get("uses", "")
+        if "lean-axiom.yml" in uses:
+            display = (spec.get("with", {}) or {}).get("display-name", "")
+            out[name] = display
+    return out
+
+
+def test_there_is_at_least_one_lean_workflow():
+    wfs = _lean_workflows()
+    assert wfs, "no .github/workflows/lean-*.yml found -- test discovery is broken"
+
+
+def test_lean_axiom_jobs_carry_distinct_display_names():
+    """#8848: within ONE workflow, no two lean-axiom.yml jobs may share a
+    display-name. The advisory job must suffix `` (audit)``; the blocking job keeps
+    the bare lake name (branch-protection check-name stability)."""
+    yaml = pytest.importorskip("yaml")
+    failures = []
+    for wf in _lean_workflows():
+        with wf.open(encoding="utf-8") as fh:
+            doc = yaml.safe_load(fh)
+        jobs = _lean_axiom_jobs(doc)
+        if not jobs:
+            continue
+        # Group jobs by display-name; any group with >1 entry is a collision.
+        by_display = {}
+        for name, display in jobs.items():
+            by_display.setdefault(display, []).append(name)
+        for display, owners in by_display.items():
+            if len(owners) > 1:
+                failures.append(
+                    f"{wf.name}: jobs {sorted(owners)} share display-name "
+                    f"{display!r} -- the advisory job must suffix ' (audit)' (#8848)")
+    assert not failures, (
+        "#8848: indistinguishable proof-integrity checks in the CI rollup:\n  - "
+        + "\n  - ".join(failures))
+
+
+def test_advisory_audit_job_carries_audit_suffix():
+    """The advisory job (``fail-on-sorry: false``) must carry the `` (audit)``
+    suffix WHEN it coexists with a BLOCKING job (``fail-on-sorry: true``) in the
+    same workflow -- that is the only configuration where the two are
+    indistinguishable without the suffix (#8848). A lake whose sole lean-axiom.yml
+    job is already advisory (knot_lean: one ``proof-integrity`` job,
+    ``fail-on-sorry: false``) has nothing to distinguish FROM, so the bare lake
+    name is correct there. The convention is "distinguish the advisory FROM the
+    blocking", not "advisory jobs always suffix"."""
+    yaml = pytest.importorskip("yaml")
+    failures = []
+    for wf in _lean_workflows():
+        with wf.open(encoding="utf-8") as fh:
+            doc = yaml.safe_load(fh)
+        jobs = doc.get("jobs", {}) or {}
+        # Does THIS workflow have a blocking (fail-on-sorry: true) lean-axiom job?
+        has_blocking = any(
+            "lean-axiom.yml" in ((spec or {}).get("uses", ""))
+            and (spec.get("with", {}) or {}).get("fail-on-sorry") is True
+            for spec in jobs.values()
+        )
+        if not has_blocking:
+            continue  # no blocking job to distinguish from (e.g. knot_lean)
+        for name, spec in jobs.items():
+            uses = (spec or {}).get("uses", "")
+            if "lean-axiom.yml" not in uses:
+                continue
+            with_opts = spec.get("with", {}) or {}
+            if with_opts.get("fail-on-sorry") is False:
+                display = with_opts.get("display-name", "")
+                if "(audit)" not in display:
+                    failures.append(
+                        f"{wf.name}: job {name} is advisory (fail-on-sorry: false) "
+                        f"beside a blocking job but display-name {display!r} lacks "
+                        f"the ' (audit)' suffix (#8848)")
+    assert not failures, (
+        "#8848: advisory proof-integrity job(s) indistinguishable from blocking:\n  - "
+        + "\n  - ".join(failures))
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

Closes #8848 (criterion 1 + reframed criterion 2): the two `lean-axiom.yml` jobs of `conway_lean` carried the **same** `display-name` (`conway_lean`), so the CI check rollup showed **"Proof integrity (conway_lean)" twice** — a reviewer could not tell the **blocking** job (fail-on-sorry: true, sorry-free showcase) from the **advisory** one (fail-on-sorry: false, the 8-sorry `HashlifeCorrectness`). That recreates, one layer up at the reviewer's eye, the exact "green whose scope is invisible" defect #8845's audit was built to close (#8782).

Measured firsthand on #8845: `gh pr view 8845 --json statusCheckRollup` lists two identically-labelled entries.

## Fix (criterion 1)

The advisory job's `display-name` becomes **`conway_lean (audit)`** — the value the issue proposed. The check now reads `Proof integrity (conway_lean (audit))` vs `Proof integrity (conway_lean)`. The blocking job keeps the bare lake name, so any **branch-protection rule referencing the check name is unaffected** (criterion 3 of #8848).

## Convention pinned proactively (criterion 2, reframed)

A new contract test `scripts/lean/tests/test_proof_integrity_display_names.py` **discovers every `lean-*.yml` workflow** and asserts:
1. **No two `lean-axiom.yml` jobs in one workflow share a `display-name`** (the collision rule).
2. **An advisory job (`fail-on-sorry: false`) coexisting with a blocking job (`fail-on-sorry: true`) must suffix ` (audit)`** (the distinction rule).

This corrects the convention **"at two occurrences, not six"** (#8848): a future lake that wires a second `lean-axiom.yml` job is caught the moment it lands. Discovery is glob-based, so no test edit is needed when a new lake is added.

### Why `knot_lean` is NOT touched

The issue anticipated "le prochain câblage d'advisory knot_lean", but **knot does not have conway's structure**. knot has a **single** `lean-axiom.yml` job (`proof-integrity`, `fail-on-sorry: false`) that already targets the sorry-bearing modules — it has **no blocking counterpart to distinguish from**, so there is no collision and the bare name `knot_lean` is correct. knot lacks conway's showcase/sorry-bearing split (its one job covers all 5 modules in report-only mode), so it will not grow a second `lean-axiom.yml` job. The test encodes exactly this: the ` (audit)` suffix is required **only where a blocking job exists**. knot's advisory organ is `target-coverage` (#8794), a different, coverage-focused job that is not a `lean-axiom.yml` reuse.

This is the honest reading of criterion 2: the convention is **"distinguish the advisory FROM the blocking"**, not "every advisory job must suffix". Pinning it as a test is what delivers the "poser la convention pour les deux lakes" intent — for conway now, and for any future lake automatically.

## Validation

- **See-it-fail-first** (#8826 point-4 method): the test is **RED on main** before this PR —
  ```
  lean-conway.yml: jobs ['proof-integrity', 'proof-integrity-audit'] share display-name 'conway_lean'
  lean-conway.yml: job proof-integrity-audit is advisory ... but display-name 'conway_lean' lacks the ' (audit)' suffix
  ```
  GREEN after the rename.
- **3/3 PASS** (`test_proof_integrity_display_names.py`).
- **No-regression 20/20** (`test_proof_integrity_audit_wiring.py` 7 + `test_check_target_coverage.py` 13 — the #8845 audit wiring and the target-coverage contract are untouched).
- YAML valid, CRLF = 0 (0 CR bytes).

## Scope notes

- This is **not an isolated rename** — the test makes it a structural guard: the convention is enforced, not just applied once. It addresses the issue's "pas en grain isolé" by carrying the prevention forward, and documents why criterion 2 (knot) is N/A rather than silently skipping it.
- `.claude/rules/` untouched (no sign-off needed).

Grain: MED/lean-ci — myia-po-2026:CoursIA

See #8848

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
