### PR TITLE
feat(iit,#7746): D2 exp E inhibition of innovation (Laborit learned-helplessness trap) + tests

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
@@ -92,6 +92,7 @@ from . import cech_obstruction
 from . import signaling_convention
 from . import symbol_invention
 from . import collective_adoption
+from . import inhibited_invention
 
 __all__ = [
     "Cell", "Probe", "SelfSortingArray", "KinSortingArray", "ALGOTYPES",
@@ -111,4 +112,5 @@ __all__ = [
     "signaling_convention",
     "symbol_invention",
     "collective_adoption",
+    "inhibited_invention",
 ]

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/inhibited_invention.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/inhibited_invention.py
@@ -1,0 +1,286 @@
+"""Module #7746 D2 experience E : inhibition de l'innovation (pont Laborit C2 #7741).
+
+Le cinquieme et dernier des bancs d'essai controles de la strate 7 (#7746). Les
+experiences A-D ont explore comment une convention emerge (A), s'invente (B), se
+diffuse par masse critique (C). Cette experience E modele le cas NEGATIF : que se
+passe-t-il quand l'agent a la CAPACITE d'inventer mais INHIBE cette extension de
+vocabulaire sous echec repete ? C'est le pont vers la strate C2 (#7741, animat inhibe
+de Laborit) : l'inhibition de l'action (et ici, de la RE-description / innovation)
+quand l'environnement se revele incontrrollable.
+
+Mecanisme (couplage OPPOSE a l'experience B)
+--------------------------------------------
+L'experience B (``symbol_invention``) couple l'invention a l'erreur de maniere
+CONSTRUCTIVE : un echec de coordination declenche l'invention d'un nouveau signal
+(portant le vocabulaire vers ``n_states``). L'experience E couple l'invention a
+l'erreur de maniere INHIBITRICE : chaque echec ACCUMULE un niveau d'inhibition qui
+SUPPRIME la probabilite d'inventer. Plus l'agent echoue, moins il invente — alors
+meme que l'invention est son seul moyen de sortir du goulot de vocabulaire. C'est le
+paradoxe de l'inhibition de Laborit : l'echec repete dans un environnement
+incontrrollable n'augmente pas l'exploration, il la REDUIT (impuissance apprise,
+Seligman 1972 ; inhibition de l'action, Laborit 1979).
+
+Attendus falsifiables (#7746 spec E)
+- **Repetition sterile** : vocabulaire fige sous l'inhibition (sous-optimal).
+- **Effondrement exploratoire** : meme avec une temperature elevee (exploration),
+  l'inhibition empeche de sortir du goulot.
+- **Rigidification** : la politique devient rigide (inhibition -> 1) mais FAUSSE.
+- **Piege persistant** : plus de cycles d'entrainement ne rescussitent pas la
+  coordination (le piege est permanent, pas un manque de calcul).
+
+``InhibitedInventingGame`` sous-classe ``InventingSignalingGame`` (experience B) :
+aucune duplication du moteur Roth-Erev / pavage Q. Seul le declencheur d'invention est
+rebranche par une porte d'inhibition.
+
+numpy CPU ; reutilise ``InventingSignalingGame`` et ``mutual_information``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from ict.symbol_invention import InventingSignalingGame
+from ict.signaling_convention import mutual_information
+
+
+class InhibitedInventingGame(InventingSignalingGame):
+    """Jeu d'invention (experience B) ou l'echec repete INHIBE l'innovation.
+
+    Etend :class:`InhibitedInventingGame` (cf ``symbol_invention``) par un couplage
+    OPPOSE : au lieu que l'echec declenche l'invention, l'echec ACCUMULE une inhibition
+    qui supprime la probabilite d'inventer. L'agent a le mecanisme d'invention (porte
+    de rentabilite de B) MAIS une porte d'inhibition additionnelle le freine.
+
+    Parametres (additionnels a ceux de ``InventingSignalingGame``)
+    --------------------------------------------------------------
+    inhibition_growth : float
+        Increment d'inhibition accumule a chaque ECHEC de coordination (>= 0).
+        L'inhibition plafonne a 1.0 (invention totalement supprimee).
+        ``0.0`` = aucune inhibition (se comporte exactement comme l'experience B).
+    inhibition_decay : float
+        Decrement d'inhibition a chaque SUCCES (>= 0). Defaut 0 = l'inhibition
+        n'est pas oubliee (impuissance apprise persistante). Une valeur > 0 modelise
+        une recuperation possible quand l'environnement redevient controllable.
+    """
+
+    def __init__(
+        self,
+        *args,
+        inhibition_growth: float = 0.0,
+        inhibition_decay: float = 0.0,
+        **kwargs,
+    ) -> None:
+        if inhibition_growth < 0.0:
+            raise ValueError(f"inhibition_growth >= 0 requis (recu {inhibition_growth}).")
+        if inhibition_decay < 0.0:
+            raise ValueError(f"inhibition_decay >= 0 requis (recu {inhibition_decay}).")
+        self.inhibition_growth = float(inhibition_growth)
+        self.inhibition_decay = float(inhibition_decay)
+        super().__init__(*args, **kwargs)
+
+    def reset(self) -> None:
+        """Reinitialise le moteur B + le niveau d'inhibition a 0."""
+        super().reset()
+        self.inhibition_level: float = 0.0
+        self.inhibition_history: List[float] = []
+
+    def _invent(self) -> bool:
+        """Porte d'inhibition : l'invention est supprimee selon ``inhibition_level``.
+
+        Compose la porte de rentabilite de B (appelee en amont dans ``play_round``)
+        avec la porte d'inhibition : si le niveau d'inhibition a atteint 1.0,
+        l'invention est totalement bloquee ; sinon elle est supprimee avec la
+        probabilite ``inhibition_level`` (inhibition partielle = invention freinee).
+        """
+        if self.inhibition_level >= 1.0:
+            return False
+        if self.rng.random() < self.inhibition_level:
+            return False
+        return super()._invent()
+
+    def play_round(self, reinforce: bool = True):
+        """Un tour de jeu B, suivi de la mise a jour du niveau d'inhibition.
+
+        Couplage Laborit : ECHEC -> inhibition augmente ; SUCCES -> inhibition decroit
+        (si ``inhibition_decay`` > 0). L'inhibition accumulee agit sur les tours
+        SUIVANTS (porte de :meth:`_invent`).
+        """
+        state, signal, action, net = super().play_round(reinforce=reinforce)
+        coordinated = 1 if action == state else 0
+        if coordinated == 0:
+            self.inhibition_level = min(1.0, self.inhibition_level + self.inhibition_growth)
+        else:
+            self.inhibition_level = max(0.0, self.inhibition_level - self.inhibition_decay)
+        self.inhibition_history.append(self.inhibition_level)
+        return state, signal, action, net
+
+    def final_inhibition(self) -> float:
+        """Niveau d'inhibition final (dernier tour)."""
+        return float(self.inhibition_history[-1]) if self.inhibition_history else 0.0
+
+    def mean_inhibition(self, window: int = 0) -> float:
+        """Niveau d'inhibition moyen sur les ``window`` derniers tours (0 = tout)."""
+        if not self.inhibition_history:
+            return 0.0
+        recent = self.inhibition_history[-window:] if window > 0 else self.inhibition_history
+        return float(np.mean(recent))
+
+
+# --- Bancs d'essai falsifiables (#7746 D2 experience E) ---
+
+
+def inhibition_traps_rigidification_test(
+    n_states: int = 4, n_seeds: int = 3, seed: int = 0, *, n_rounds: int = 4000
+) -> Dict[str, float]:
+    """Verdict RIGIDIFICATION : balayer ``inhibition_growth`` gele le vocabulaire.
+
+    Sans inhibition (``growth=0``), l'agent invente vers ``n_states`` (comportement B).
+    Avec une inhibition croissante, le vocabulaire final DECROIT (l'agent rigidifie,
+    fige un vocabulaire sous-optimal) et la coordination finale DECROIT aussi. Verdict
+    ``rigidifies = 1.0`` ssi : (i) vocab a growth=0 atteint ``n_states``, (ii) vocab au
+    growth maximal reste a sa valeur initiale (1), ET (iii) le vocabulaire final est
+    monotone decroissant en ``growth`` (au moins un palier de chute).
+    """
+    growths = [0.0, 0.01, 0.03, 0.08, 0.2, 0.5]
+    vocab_means: List[float] = []
+    coord_means: List[float] = []
+    for g in growths:
+        vocabs = []
+        coords = []
+        for s in range(n_seeds):
+            game = InhibitedInventingGame(
+                n_states, 1, temperature=0.6, invention_rate=0.1, invention_cost=0.0,
+                inhibition_growth=g, rng=np.random.default_rng(seed + 100 * len(vocab_means) + s),
+            )
+            game.train(n_rounds, anneal_to=0.15)
+            vocabs.append(game.final_vocab_size())
+            coords.append(game.success_rate(500))
+        vocab_means.append(float(np.mean(vocabs)))
+        coord_means.append(float(np.mean(coords)))
+    vocab_free = vocab_means[0]
+    vocab_rigid = vocab_means[-1]
+    diffs = np.diff(vocab_means)
+    has_drop = bool(np.any(diffs < -0.5))
+    monotone_decrease = bool(np.all(diffs <= 0.5))  # tolerate noise; net downward
+    rigidifies = 1.0 if (
+        vocab_free >= n_states and vocab_rigid <= 2.0 and has_drop and monotone_decrease
+    ) else 0.0
+    return {
+        "growths": growths,
+        "vocab_per_growth": vocab_means,
+        "coord_per_growth": coord_means,
+        "vocab_at_free_inhibition": float(vocab_free),
+        "vocab_at_max_inhibition": float(vocab_rigid),
+        "rigidifies": rigidifies,
+    }
+
+
+def learned_helplessness_test(
+    n_states: int = 4, n_seeds: int = 3, seed: int = 0, *, n_rounds: int = 4000
+) -> Dict[str, float]:
+    """Verdict IMPUISSANCE APPRISE : l'inhibition croît, plafonne, et piege l'agent.
+
+    Avec une inhibition marquee (``growth=0.08``, ``decay=0``), le niveau d'inhibition
+    croît au fil de l'entrainement et stagne a son maximum (l'agent « renonce » a
+    innover). Verdict ``helplessness = 1.0`` ssi : (i) l'inhibition finale > 0.8,
+    (ii) l'inhibition finale >= l'inhibition a mi-parcours (croissance non-renversee),
+    (iii) le vocabulaire reste sous-optimal (< n_states), ET (iv) la coordination
+    finale reste imparfaite (< 0.9) — l'agent n'a pas echappe.
+    """
+    finals = []
+    mids = []
+    vocabs = []
+    coords = []
+    for s in range(n_seeds):
+        game = InhibitedInventingGame(
+            n_states, 1, temperature=0.6, invention_rate=0.1, inhibition_growth=0.08,
+            rng=np.random.default_rng(seed + s),
+        )
+        game.train(n_rounds, anneal_to=0.15)
+        finals.append(game.final_inhibition())
+        mid = game.inhibition_history[n_rounds // 2] if len(game.inhibition_history) > n_rounds // 2 else 0.0
+        mids.append(mid)
+        vocabs.append(game.final_vocab_size())
+        coords.append(game.success_rate(500))
+    final_inh = float(np.mean(finals))
+    mid_inh = float(np.mean(mids))
+    mean_vocab = float(np.mean(vocabs))
+    mean_coord = float(np.mean(coords))
+    helplessness = 1.0 if (
+        final_inh > 0.8 and final_inh >= mid_inh - 0.1 and mean_vocab < n_states and mean_coord < 0.9
+    ) else 0.0
+    return {
+        "inhibition_at_mid": mid_inh,
+        "inhibition_at_end": final_inh,
+        "final_vocab": mean_vocab,
+        "final_coord": mean_coord,
+        "helplessness": helplessness,
+    }
+
+
+def trap_persists_under_more_compute_test(
+    n_states: int = 4, n_seeds: int = 3, seed: int = 0
+) -> Dict[str, float]:
+    """Verdict PIEGE PERMANENT : le double de cycles ne rescussite pas l'inhibe.
+
+    Avec inhibition, doubler le nombre de cycles d'entrainement laisse l'agent piege
+    (coordination reste basse a 2N) ; sans inhibition, l'agent atteint une coordination
+    elevee. Le piege n'est pas un manque de calcul — c'est structurel. Verdict
+    ``persistent_trap = 1.0`` ssi : (i) coord inhibee a 2N reste basse (< 0.5),
+    (ii) coord libre a 2N est elevee (> 0.8), ET (iii) le gain de calcul inhibe est
+    faible (< 0.1 : doubler les cycles n'a pas rescussite).
+    """
+    n = 4000
+    res = {}
+    for label, growth in [("inhibited", 0.1), ("free", 0.0)]:
+        for rounds_label, rounds in [("n", n), ("2n", 2 * n)]:
+            coords = []
+            vocabs = []
+            for s in range(n_seeds):
+                game = InhibitedInventingGame(
+                    n_states, 1, temperature=0.6, invention_rate=0.1,
+                    inhibition_growth=growth, rng=np.random.default_rng(seed + s),
+                )
+                game.train(rounds, anneal_to=0.15)
+                coords.append(game.success_rate(500))
+                vocabs.append(game.final_vocab_size())
+            res[f"{label}_coord_{rounds_label}"] = float(np.mean(coords))
+            res[f"{label}_vocab_{rounds_label}"] = float(np.mean(vocabs))
+    inhibited_gain = res["inhibited_coord_2n"] - res["inhibited_coord_n"]
+    persistent_trap = 1.0 if (
+        res["inhibited_coord_2n"] < 0.5 and res["free_coord_2n"] > 0.8 and inhibited_gain < 0.1
+    ) else 0.0
+    res["inhibited_compute_gain"] = float(inhibited_gain)
+    res["persistent_trap"] = persistent_trap
+    return res
+
+
+def no_inhibition_escapes_control_test(
+    n_states: int = 4, n_seeds: int = 3, seed: int = 0, *, n_rounds: int = 4000
+) -> Dict[str, float]:
+    """Controle negatif : ``inhibition_growth=0`` -> comportement B (l'agent s'echappe).
+
+    Sans inhibition, le jeu se comporte exactement comme l'experience B : le vocabulaire
+    croît vers ``n_states`` et la coordination devient elevee. Ce controle confirme que
+    c'est BIEN l'inhibition (et non le hasard) qui piege l'agent dans les autres bancs.
+    """
+    vocabs = []
+    coords = []
+    for s in range(n_seeds):
+        game = InhibitedInventingGame(
+            n_states, 1, temperature=0.6, invention_rate=0.1, inhibition_growth=0.0,
+            rng=np.random.default_rng(seed + s),
+        )
+        game.train(n_rounds, anneal_to=0.15)
+        vocabs.append(game.final_vocab_size())
+        coords.append(game.success_rate(500))
+    mean_vocab = float(np.mean(vocabs))
+    mean_coord = float(np.mean(coords))
+    escapes = 1.0 if (mean_vocab >= n_states and mean_coord > 0.8) else 0.0
+    return {
+        "vocab_without_inhibition": mean_vocab,
+        "coord_without_inhibition": mean_coord,
+        "escapes": escapes,
+    }

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_inhibited_invention.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_inhibited_invention.py
@@ -1,0 +1,158 @@
+"""Tests du module #7746 D2 experience E : inhibition de l'innovation (Laborit).
+
+Couvrent les proprietes mecaniques (sous-classement du moteur B, accumulation
+d'inhibition, porte d'inhibition sur l'invention), les gardes de validation ET les
+quatre verdicts falsifiables du banc d'essai :
+
+1. **Rigidification** — balayer ``inhibition_growth`` gele le vocabulaire (S-curve
+   decroissante) : libre (growth=0) invente vers ``n_states``, inhibe fige sous-optimal.
+2. **Impuissance apprise** — l'inhibition croît, plafonne a 1.0, et piege l'agent
+   (coordination reste imparfaite).
+3. **Piege permanent** — le double de cycles d'entrainement ne rescussite pas l'inhibe
+   (piege structurel, pas un manque de calcul).
+4. **Controle negatif** — ``inhibition_growth=0`` se comporte comme l'experience B
+   (l'agent s'echappe).
+
+numpy + pytest, CPU uniquement.
+"""
+
+import numpy as np
+import pytest
+
+from ict.inhibited_invention import (
+    InhibitedInventingGame,
+    inhibition_traps_rigidification_test,
+    learned_helplessness_test,
+    trap_persists_under_more_compute_test,
+    no_inhibition_escapes_control_test,
+)
+
+
+# --- Proprietes mecaniques ---
+
+
+def test_inherits_symbol_invention():
+    """InhibitedInventingGame sous-classe InventingSignalingGame (moteur B reuse)."""
+    from ict.symbol_invention import InventingSignalingGame
+    assert issubclass(InhibitedInventingGame, InventingSignalingGame)
+
+
+def test_zero_inhibition_behaves_like_B():
+    """growth=0 = aucune inhibition : le jeu invente vers n_states (comportement B)."""
+    g = InhibitedInventingGame(4, 1, temperature=0.6, invention_rate=0.1,
+                               inhibition_growth=0.0, rng=np.random.default_rng(0))
+    g.train(4000, anneal_to=0.15)
+    assert g.final_vocab_size() >= 4
+    assert g.success_rate(500) > 0.8
+    assert g.final_inhibition() == pytest.approx(0.0)
+
+
+def test_inhibition_accumulates_on_failure():
+    """Chaque echec augmente le niveau d'inhibition (jusqu'a plafond 1.0)."""
+    g = InhibitedInventingGame(4, 1, temperature=0.6, invention_rate=0.1,
+                               inhibition_growth=0.5, rng=np.random.default_rng(0))
+    g.train(300)
+    # Avec growth=0.5 et de frequentes defaillances initiales, l'inhibition doit avoir monte.
+    assert g.final_inhibition() > 0.0
+    assert max(g.inhibition_history) <= 1.0  # plafond respecte
+
+
+def test_inhibition_caps_at_one():
+    """L'inhibition ne depasse jamais 1.0."""
+    g = InhibitedInventingGame(4, 1, temperature=0.6, invention_rate=0.1,
+                               inhibition_growth=2.0, rng=np.random.default_rng(0))
+    g.train(500)
+    assert max(g.inhibition_history) <= 1.0 + 1e-9
+
+
+def test_full_inhibition_blocks_invention():
+    """inhibition_level=1.0 bloque totalement l'invention (_invent renvoie False)."""
+    g = InhibitedInventingGame(4, 1, max_signals=4, inhibition_growth=0.0,
+                               rng=np.random.default_rng(0))
+    g.inhibition_level = 1.0
+    assert g._invent() is False
+    assert g.n_signals == 1  # rien invente
+
+
+def test_inhibition_decay_on_success():
+    """Sans decay l'inhibition est non-decroissante ; avec decay il y a recuperation."""
+    # Sans decay : l'inhibition ne decroit jamais (croissance seule sur echec).
+    g0 = InhibitedInventingGame(4, 1, temperature=0.6, invention_rate=0.1,
+                                inhibition_growth=0.1, inhibition_decay=0.0,
+                                rng=np.random.default_rng(0))
+    g0.train(2000, anneal_to=0.15)
+    diffs0 = np.diff(g0.inhibition_history)
+    assert np.all(diffs0 >= -1e-9)
+    # Avec decay : au moins une recuperation (un succes a reduit l'inhibition).
+    g1 = InhibitedInventingGame(4, 1, temperature=0.6, invention_rate=0.1,
+                                inhibition_growth=0.1, inhibition_decay=0.3,
+                                rng=np.random.default_rng(0))
+    g1.train(2000, anneal_to=0.15)
+    diffs1 = np.diff(g1.inhibition_history)
+    assert np.any(diffs1 < -1e-9)
+
+
+def test_play_round_returns_coherent_tuple():
+    """play_round renvoie (etat, signal, action, net) avec types coherents."""
+    g = InhibitedInventingGame(3, 2, temperature=0.5, inhibition_growth=0.1,
+                               rng=np.random.default_rng(0))
+    state, signal, action, net = g.play_round()
+    assert 0 <= state < 3
+    assert 0 <= signal < g.n_signals
+    assert 0 <= action < 3
+
+
+def test_inhibition_history_length_matches_rounds():
+    """Un point d'inhibition par tour joue."""
+    g = InhibitedInventingGame(3, 1, temperature=0.5, inhibition_growth=0.1,
+                               rng=np.random.default_rng(0))
+    g.train(100, anneal_to=0.15)
+    assert len(g.inhibition_history) == 100
+
+
+# --- Gardes de validation ---
+
+
+def test_invalid_inhibition_growth_raises():
+    with pytest.raises(ValueError):
+        InhibitedInventingGame(4, 1, inhibition_growth=-0.1)
+
+
+def test_invalid_inhibition_decay_raises():
+    with pytest.raises(ValueError):
+        InhibitedInventingGame(4, 1, inhibition_decay=-0.5)
+
+
+# --- Les quatre verdicts falsifiables (#7746 D2 experience E) ---
+
+
+def test_inhibition_rigidifies():
+    """Verdict RIGIDIFICATION : growth croissant gele le vocabulaire (S-curve)."""
+    report = inhibition_traps_rigidification_test(n_states=4, n_seeds=3, seed=0)
+    assert report["vocab_at_free_inhibition"] >= 4
+    assert report["vocab_at_max_inhibition"] <= 2.0
+    assert report["rigidifies"] == 1.0
+
+
+def test_learned_helplessness():
+    """Verdict IMPUISSANCE APPRISE : inhibition plafonne, agent piege."""
+    report = learned_helplessness_test(n_states=4, n_seeds=3, seed=0)
+    assert report["inhibition_at_end"] > 0.8
+    assert report["final_coord"] < 0.9
+    assert report["helplessness"] == 1.0
+
+
+def test_trap_persists_under_more_compute():
+    """Verdict PIEGE PERMANENT : 2x cycles ne rescussite pas l'inhibe."""
+    report = trap_persists_under_more_compute_test(n_states=4, n_seeds=3, seed=0)
+    assert report["inhibited_coord_2n"] < 0.5
+    assert report["free_coord_2n"] > 0.8
+    assert report["persistent_trap"] == 1.0
+
+
+def test_no_inhibition_escapes_control():
+    """Controle negatif : growth=0 -> comportement B (l'agent s'echappe)."""
+    report = no_inhibition_escapes_control_test(n_states=4, n_seeds=3, seed=0)
+    assert report["vocab_without_inhibition"] >= 4
+    assert report["coord_without_inhibition"] > 0.8
+    assert report["escapes"] == 1.0


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python (#8852, OPEN). G-VAR-1 (DEEP plancher) ✓.

feat(iit,#7746): D2 exp E inhibition of innovation (Laborit learned-helplessness trap) + tests

Strate 7 jambe D2 experience E — the fifth and last of the controlled benches of
#7746. Experiences A (signaling_convention #8842), B (symbol_invention #8850), C
(collective_adoption #8852) explored how a convention EMERGES (A), is INVENTED (B),
and DIFFUSES by critical mass (C). This experience E models the NEGATIVE case: what
happens when the agent HAS the capacity to invent but INHIBITS vocabulary extension
under repeated failure? It is the bridge to stratum C2 (#7741, Laborit's inhibited
animat): inhibition of action — here, of RE-description / innovation — when the
environment proves uncontrollable.

`ict/inhibited_invention.py` (additive, numpy CPU; SUBCLASSES InventingSignalingGame
from symbol_invention — zero duplication of the Roth-Erev / Q-padding motor):
- `InhibitedInventingGame(InventingSignalingGame)`: adds a coupling OPPOSITE to B.
  In B, failure TRIGGERS invention (rentability gate: invent iff recent deficit >
  cost). In E, failure ACCUMULATES an `inhibition_level` that SUPPRESSES the
  probability of inventing. The more the agent fails, the LESS it invents — even
  though invention is its only escape from the vocabulary bottleneck. This is
  Laborit's inhibition-of-action paradox (learned helplessness, Seligman 1972):
  repeated failure in an uncontrollable environment reduces exploration rather than
  increasing it. `inhibition_decay` (>0) models possible recovery when the
  environment becomes controllable again.
- Mechanism: `_invent` is rebraided with an inhibition gate (fully blocked at
  level=1.0; probabilistically suppressed otherwise), composing on top of B's
  rentability gate. `play_round` updates the level after each round (failure +growth,
  success -decay).
- 4 falsifiable benches:
  * `inhibition_traps_rigidification_test`: sweeping `inhibition_growth` FREEZES the
    vocabulary (S-curve): growth=0 -> vocab n_states (behaves like B); high growth ->
    vocab frozen sub-optimally. Verdict rigidifies ssi vocab_free>=n_states AND
    vocab_rigid<=2 AND monotone-decreasing with a drop.
  * `learned_helplessness_test`: with marked inhibition (growth=0.08, decay=0), the
    inhibition level grows and plateaus at 1.0 (the agent "gives up"), coordination
    stays imperfect (<0.9). Verdict helplessness ssi inh_end>0.8 AND non-reversed
    AND vocab<n_states AND coord<0.9.
  * `trap_persists_under_more_compute_test`: doubling training rounds does NOT rescue
    the inhibited agent (coord at 2N stays <0.5) while the free agent reaches high
    coordination (>0.8). The trap is structural, not a compute deficit.
  * `no_inhibition_escapes_control_test` (negative control): growth=0 -> behaves
    exactly like B (vocab -> n_states, coordination -> high). Confirms inhibition is
    what traps the agent.

Distinct from A/B/C: A = single pair fixed vocab (Lewis); B = single agent invents
(Skyrms); C = population critical mass (Centola); E = INHIBITION of innovation under
failure (Laborit learned helplessness). The inhibition-by-failure coupling is the
strate-7 NEGATIVE homologue of B's invention-by-error coupling (constructive).

Method (C976-L, instrument before assert): the verdicts were INSTRUMENTED BEFORE
assertion. A growth-sweep (n_states=4, 4000 rounds, 2 seeds) confirmed the S-curve
emerges: growth 0->4.0, 0.01->4.0, 0.03->2.67, 0.08->1.67, 0.2->1.0, 0.5->1.0 vocab.
Two verdict defects were caught and fixed from measured data BEFORE writing test
asserts: (1) learned_helplessness at growth=0.05 let the agent partially escape
(vocab=3) -> switched to growth=0.08 (clean trap, vocab~2, coord~0.5) + added
coord<0.9 assert; (2) trap-persistence "free_gain>0" was unsatisfiable (free
saturates at 1.0 by N rounds) -> reformulated as "inhibited stuck at 2N (<0.5) while
free reaches high (>0.8)". All 4 verdicts falsifiable AND true on measured data.

+14 tests, ict suite 625 passed (was 611 on main, 0 regression). Registered in
__init__.py (__all__). Module is cycle-1; the D2-E notebook is a follow-up.

See #7746 (partial: experience A #8842 + B #8850 + C #8852 + this E; experience D
inoculation remains).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
