### PR TITLE
feat(audit,#8056): mode flotte pour check_cost_metadata (--all / --family / --json)

### DIFF
--- a/docs/notebook-metadata/cost-matrix.md
+++ b/docs/notebook-metadata/cost-matrix.md
@@ -189,6 +189,46 @@ une sortie de cellule à la main (Stop & Repair, cf
 > (`Probas/Infer.NET`, `ML/ML.NET`) — ceux-là *ont* été exécutés, leur défaut est une
 > étiquette inexacte, pas une exécution fantôme.
 
+#### Mode flotte — agréger avant de résorber
+
+Les neuf litmus n'avaient jusqu'ici qu'un mode **un notebook à la fois** : chacun
+était donc appliqué à la main, par quiconque y pensait, et **personne n'avait
+jamais agrégé le résultat**. Conséquence directe : un litmus vert ne pouvait pas
+être distingué d'un litmus *jamais exécuté* — c'est le même angle mort que
+« vert hors-cible ». `--all` / `--family` ferment cet écart (même prédicat,
+marcheur canonique [`notebook_walk`](../../scripts/notebook_tools/notebook_walk.py), #8650) :
+
+```bash
+python scripts/audit/check_cost_metadata.py --all                 # flotte entière
+python scripts/audit/check_cost_metadata.py --family QuantConnect # une famille
+python scripts/audit/check_cost_metadata.py --all --json          # sortie machine
+```
+
+**Mesure d'introduction du mode (2026-07-29) : 941 notebooks scannés, 71 porteurs
+d'au moins un finding, 86 findings sur 6 patterns** — `gpu_used_but_not_declared`
+31, `gpu_no_visual_validator` 18, `token_required_but_no_account` 17,
+`api_used_but_cost_zero` 13, `qc_notebook_no_qcc_estimate` 4,
+`qc_notebook_no_validator` 3. Le **litmus 9 est à zéro** : les 13 findings mesurés
+ci-dessus ont bien été corrigés en `validator: manual`, ils n'ont pas été
+escamotés par le marcheur (contrôle indépendant sur `--family QuantConnect` :
+`manual: 13`).
+
+**Écart de population assumé, 1020 vs 941 :** la mesure du litmus 9 ci-dessus
+parcourait le disque brut ; le mode flotte passe par `notebook_walk`, qui restreint
+aux fichiers **suivis par git** (`tracked_only=True`) et écarte `_output.ipynb`,
+`_archives/`, `.ipynb_checkpoints/`, `.lake/`. Les ~79 de différence sont des
+sorties d'exécution, des archives et des notebooks non suivis — hors périmètre
+d'un audit de métadonnées déclarées.
+
+**Pas de `--check`, pas de câblage CI, délibérément.** Les 86 findings sont
+**pré-existants** : un gate posé dessus naîtrait rouge et serait ignoré dès le
+premier jour. L'ordre est *agréger → résorber → gater*, jamais l'inverse. C'est
+d'ailleurs ce que dit déjà « [Ce que ce schéma n'est PAS](#ce-que-ce-schéma-nest-pas) » :
+le validateur **signale**, il ne décide pas si l'incohérence est bloquante.
+Résorber un pattern est un grain de substance séparé — et la correction se fait
+**à la source** (ré-exécuter, ou corriger la déclaration), jamais en éditant une
+sortie de cellule à la main.
+
 ### Tiers VRAM (déterminé par `vram_gb`)
 
 | Tier | VRAM (GB) | Modèles typiques |

--- a/scripts/audit/check_cost_metadata.py
+++ b/scripts/audit/check_cost_metadata.py
@@ -29,13 +29,42 @@ But : extraire pour un notebook :
 Litmus anti-LIGHT : ce script EXTRACT, il ne DÉCIDE pas. Le verdict final
 = revue humaine/agent compétent. Cf docs/notebook-metadata/cost-matrix.md.
 
+Mode flotte (c.58)
+------------------
+Jusqu'ici le vérificateur ne prenait QU'UN notebook positionnel : les neuf
+litmus étaient donc appliqués un notebook à la fois, à la main, par quiconque y
+pensait. Personne n'avait jamais agrégé le résultat sur la flotte — de sorte
+que le compte réel de findings (86 au moment de l'écriture, sur 6 patterns)
+n'était connu de personne, et qu'un litmus vert (le 9, #8790) ne pouvait pas
+être distingué d'un litmus jamais exécuté. `--all` / `--family` ferment cet
+écart : même prédicat, marcheur canonique `notebook_walk` (#8650), sortie
+agrégée par pattern ET recensement par validator.
+
+Ce que ce mode ne fait PAS, délibérément :
+  - pas de `--check` / exit non nul sur findings, et aucun câblage CI. Les 86
+    findings sont PRÉ-EXISTANTS : un gate posé dessus serait rouge à l'arrivée,
+    donc ignoré dès le premier jour (décision « ne se câble pas sur rouge
+    pré-existant », cf organe Slides #8817). L'ordre est : agréger, résorber,
+    PUIS gater — pas l'inverse.
+  - pas de correction automatique : ce script EXTRACT (litmus anti-LIGHT
+    ci-dessus). Résorber un pattern est un grain de substance séparé.
+
 Usage :
   python scripts/audit/check_cost_metadata.py <notebook>.ipynb [--out <fichier.yml>]
+  python scripts/audit/check_cost_metadata.py --all                # toute la flotte
+  python scripts/audit/check_cost_metadata.py --family QuantConnect # une famille
+  python scripts/audit/check_cost_metadata.py --all --json         # sortie machine
+
+Exit codes :
+  0 — audit produit (findings ou non : la sortie est advisory)
+  1 — erreur (notebook introuvable, famille inexistante, lecture impossible)
 """
 
 import argparse
+import json
 import re
 import sys
+from collections import Counter
 from pathlib import Path
 
 import nbformat
@@ -543,13 +572,151 @@ def check_notebook(notebook_path: Path, repo_root: Path) -> dict:
     }
 
 
+# === Mode flotte (c.58) ===
+
+NOTEBOOKS_DIRNAME = 'MyIA.AI.Notebooks'
+
+
+def _iter_fleet(repo_root: Path, family=None):
+    """Énumère les notebooks pédagogiques via le marcheur canonique (#8650).
+
+    Import différé : le mode notebook-unique n'a aucune raison de dépendre de
+    `scripts/notebook_tools/`, et les tests chargent ce module par
+    `spec_from_file_location` (un import de package cassé au niveau module
+    ferait tomber toute la suite, pas seulement le mode flotte).
+    """
+    walk_dir = Path(__file__).resolve().parent.parent / 'notebook_tools'
+    if str(walk_dir) not in sys.path:
+        sys.path.insert(0, str(walk_dir))
+    from notebook_walk import iter_notebooks  # noqa: PLC0415 (import différé, cf docstring)
+
+    yield from iter_notebooks(repo_root / NOTEBOOKS_DIRNAME, family=family)
+
+
+def aggregate_fleet(notebook_paths, repo_root: Path) -> dict:
+    """Applique `check_notebook` à chaque chemin et agrège le résultat.
+
+    Retourne : scanned, errors, `validators` (recensement — combien de notebooks
+    déclarent chaque validator), `patterns` (combien de findings par pattern),
+    et `notebooks` (le détail, notebooks sans finding exclus).
+
+    Un notebook illisible est compté dans `errors` et n'interrompt pas la
+    marche : un audit de flotte qui s'arrête au premier .ipynb corrompu ne
+    mesure rien (cf `ESGF-2026/.../research.ipynb`, gitignored et non
+    parsable). L'erreur reste VISIBLE dans le rapport — elle n'est pas avalée.
+    """
+    validators: Counter = Counter()
+    patterns: Counter = Counter()
+    errors: list = []
+    notebooks: list = []
+    scanned = 0
+
+    for nb_path in notebook_paths:
+        try:
+            rel = nb_path.resolve().relative_to(repo_root.resolve()).as_posix()
+        except (ValueError, OSError):
+            rel = str(nb_path).replace('\\', '/')
+        try:
+            result = check_notebook(nb_path, repo_root)
+        except Exception as exc:  # noqa: BLE001 — un notebook cassé ne stoppe pas l'audit
+            errors.append({'notebook': rel, 'error': f'{type(exc).__name__}: {exc}'})
+            continue
+        scanned += 1
+        cost_meta = result.get('cost_meta') or {}
+        if cost_meta.get('validator'):
+            validators[str(cost_meta['validator'])] += 1
+        findings = result.get('findings') or []
+        for finding in findings:
+            patterns[finding['pattern']] += 1
+        if findings:
+            notebooks.append({'notebook': rel, 'findings': findings})
+
+    return {
+        'scanned': scanned,
+        'errors': errors,
+        'validators': dict(validators.most_common()),
+        'patterns': dict(patterns.most_common()),
+        'notebooks': notebooks,
+    }
+
+
+def format_fleet_report(agg: dict) -> str:
+    """Rapport humain agrégé. Le DÉTAIL complet de chaque finding est en
+    `--json` : ici on donne pattern + sévérité par notebook, pour que la vue
+    reste scannable (86 details de 3 lignes noieraient les comptes, qui sont
+    précisément ce que le mode flotte apporte)."""
+    total_findings = sum(agg['patterns'].values())
+    lines = [
+        f"Notebooks scannes        : {agg['scanned']}",
+        f"Notebooks avec finding   : {len(agg['notebooks'])}",
+        f"Findings                 : {total_findings}",
+        f"Erreurs de lecture       : {len(agg['errors'])}",
+        "",
+    ]
+    if agg['errors']:
+        lines.append("--- erreurs de lecture ---")
+        for err in agg['errors']:
+            lines.append(f"  {err['notebook']}: {err['error']}")
+        lines.append("")
+
+    lines.append("--- validators declares (recensement) ---")
+    if agg['validators']:
+        for name, count in agg['validators'].items():
+            lines.append(f"  {name:24s} {count}")
+    else:
+        lines.append("  (aucun)")
+    lines.append("")
+
+    lines.append("--- findings par pattern ---")
+    if agg['patterns']:
+        for pattern, count in agg['patterns'].items():
+            lines.append(f"  {pattern:52s} {count}")
+    else:
+        lines.append("  (aucun)")
+    lines.append("")
+
+    if agg['notebooks']:
+        lines.append("--- notebooks concernes ---")
+        for entry in agg['notebooks']:
+            lines.append(f"## {entry['notebook']}")
+            for finding in entry['findings']:
+                lines.append(f"  - [{finding['severity']}] {finding['pattern']}")
+        lines.append("")
+
+    lines.append(
+        "NOTE: ce script EXTRACT, il ne DECIDE pas. Chaque finding se verifie "
+        "firsthand avant correction — et la correction se fait a la SOURCE "
+        "(re-executer, corriger la declaration), jamais en editant une sortie "
+        "de cellule a la main. Detail complet des findings : --json."
+    )
+    return '\n'.join(lines)
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('notebook', type=Path, help='Chemin du .ipynb à auditer')
-    parser.add_argument('--out', type=Path, help='Fichier YAML de sortie (default: stdout)')
+    parser.add_argument('notebook', type=Path, nargs='?',
+                        help='Chemin du .ipynb à auditer (défaut si ni --all ni --family)')
+    parser.add_argument('--all', action='store_true',
+                        help='Auditer toute la flotte pédagogique (MyIA.AI.Notebooks/)')
+    parser.add_argument('--family',
+                        help='Auditer une famille (ex: QuantConnect, Probas) — implique le mode flotte')
+    parser.add_argument('--json', action='store_true',
+                        help='Sortie JSON machine-readable (détail complet des findings)')
+    parser.add_argument('--out', type=Path, help='Fichier de sortie (default: stdout)')
     parser.add_argument('--repo-root', type=Path, default=Path('.'),
                         help='Racine du repo (pour résoudre free_alternative)')
     args = parser.parse_args()
+
+    fleet = args.all or bool(args.family)
+    if fleet and args.notebook:
+        print("ERROR: <notebook> et --all/--family sont exclusifs", file=sys.stderr)
+        return 1
+    if not fleet and not args.notebook:
+        print("ERROR: fournir un notebook, ou --all / --family <nom>", file=sys.stderr)
+        return 1
+
+    if fleet:
+        return _run_fleet(args)
 
     if not args.notebook.exists():
         print(f"ERROR: notebook {args.notebook} introuvable", file=sys.stderr)
@@ -560,6 +727,9 @@ def main():
     except Exception as e:
         print(f"ERROR: {e}", file=sys.stderr)
         return 1
+
+    if args.json:
+        return _emit(json.dumps(result, ensure_ascii=False, indent=2, default=str), args.out)
 
     # Sortie YAML
     lines = [
@@ -580,13 +750,30 @@ def main():
         lines.append(f"    severity: {f['severity']}")
         lines.append(f"    detail: {f['detail']!r}")
 
-    output = '\n'.join(lines)
-    if args.out:
-        args.out.write_text(output, encoding='utf-8')
-        print(f"Audit écrit: {args.out}")
+    return _emit('\n'.join(lines), args.out)
+
+
+def _emit(output: str, out_path) -> int:
+    if out_path:
+        out_path.write_text(output, encoding='utf-8')
+        print(f"Audit écrit: {out_path}")
     else:
         print(output)
     return 0
+
+
+def _run_fleet(args) -> int:
+    repo_root = args.repo_root
+    if args.family:
+        family_dir = repo_root / NOTEBOOKS_DIRNAME / args.family
+        if not family_dir.is_dir():
+            print(f"ERROR: famille introuvable: {family_dir}", file=sys.stderr)
+            return 1
+
+    agg = aggregate_fleet(_iter_fleet(repo_root, family=args.family), repo_root)
+    if args.json:
+        return _emit(json.dumps(agg, ensure_ascii=False, indent=2, default=str), args.out)
+    return _emit(format_fleet_report(agg), args.out)
 
 
 if __name__ == '__main__':

--- a/scripts/audit/tests/test_check_cost_metadata.py
+++ b/scripts/audit/tests/test_check_cost_metadata.py
@@ -545,3 +545,85 @@ def test_litmus9_detail_names_the_cell_indices(tmp_path):
     detail = next(f["detail"] for f in findings if f["pattern"] == _LITMUS9_PATTERN)
     assert "1, 2" in detail
     assert "2026-07-23T01:30Z" in detail
+
+
+# ---------------------------------------------------------------------------
+# Mode flotte (c.58) — agregation par pattern + recensement par validator
+# ---------------------------------------------------------------------------
+
+
+def _fleet_notebooks(tmp_path):
+    """Trois notebooks : deux porteurs de findings distincts, un sain."""
+    a = tmp_path / "a.ipynb"
+    _notebook(a, ["import torch; torch.cuda.is_available()"],
+              cost_meta={"validator": "papermill", "gpu_required": False})
+    b = tmp_path / "sub" / "b.ipynb"
+    _notebook(b, ["import torch; torch.cuda.is_available()"],
+              cost_meta={"validator": "manual", "gpu_required": False})
+    clean = tmp_path / "clean.ipynb"
+    _notebook(clean, ["x = 1"], cost_meta={"validator": "manual", "gpu_required": False})
+    return [a, b, clean]
+
+
+def test_aggregate_fleet_counts_patterns_and_validators(tmp_path):
+    """Le mode flotte apporte deux comptes qu'aucun appel notebook-unique ne
+    donne : findings PAR PATTERN, et recensement des validators declares."""
+    mod = _load_check()
+    agg = mod.aggregate_fleet(_fleet_notebooks(tmp_path), tmp_path)
+
+    assert agg["scanned"] == 3
+    assert agg["errors"] == []
+    assert agg["patterns"]["gpu_used_but_not_declared"] == 2
+    assert agg["validators"] == {"manual": 2, "papermill": 1}
+
+
+def test_aggregate_fleet_excludes_clean_notebooks_from_detail(tmp_path):
+    """`notebooks` porte le detail des SEULS notebooks a finding : un rapport
+    ou 941 lignes saines noient 71 lignes utiles ne se lit pas."""
+    mod = _load_check()
+    agg = mod.aggregate_fleet(_fleet_notebooks(tmp_path), tmp_path)
+
+    listed = {entry["notebook"] for entry in agg["notebooks"]}
+    assert listed == {"a.ipynb", "sub/b.ipynb"}
+
+
+def test_aggregate_fleet_unreadable_notebook_is_recorded_not_fatal(tmp_path):
+    """Un .ipynb corrompu est compte dans `errors` et laisse la marche
+    continuer : un audit qui s'arrete au premier fichier casse ne mesure rien.
+    L'erreur reste VISIBLE — elle n'est pas avalee."""
+    mod = _load_check()
+    broken = tmp_path / "broken.ipynb"
+    broken.write_text("{ pas du json", encoding="utf-8")
+    good = tmp_path / "good.ipynb"
+    _notebook(good, ["x = 1"], cost_meta={"validator": "manual"})
+
+    agg = mod.aggregate_fleet([broken, good], tmp_path)
+
+    assert agg["scanned"] == 1
+    assert len(agg["errors"]) == 1
+    assert agg["errors"][0]["notebook"] == "broken.ipynb"
+    assert agg["errors"][0]["error"]
+
+
+def test_format_fleet_report_shows_counts_and_offenders(tmp_path):
+    """Le rapport humain doit porter les comptes agreges ET nommer les
+    notebooks concernes (sinon il faut re-scanner pour agir)."""
+    mod = _load_check()
+    agg = mod.aggregate_fleet(_fleet_notebooks(tmp_path), tmp_path)
+    report = mod.format_fleet_report(agg)
+
+    assert "Notebooks scannes        : 3" in report
+    assert "gpu_used_but_not_declared" in report
+    assert "papermill" in report
+    assert "a.ipynb" in report
+    assert "clean.ipynb" not in report
+
+
+def test_format_fleet_report_handles_empty_fleet(tmp_path):
+    """Zero notebook scanne ne doit pas produire un rapport trompeur (ni
+    planter) : les sections vides s'annoncent explicitement."""
+    mod = _load_check()
+    report = mod.format_fleet_report(mod.aggregate_fleet([], tmp_path))
+
+    assert "Notebooks scannes        : 0" in report
+    assert "(aucun)" in report


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: LIGHT/docs

> *Tag corrigé avant merge.* La première version portait `MED/tooling — prev: LIGHT/harness` :
> ni `tooling` ni `harness` n'appartiennent à la liste canonique de genres du
> [variation-protocol](.claude/rules/variation-protocol.md) (`lean · qc · training · genai ·
> notebook-python · notebook-dotnet · docs · guard · refactor · ledger · readme · test`). Un genre
> hors-liste rend le tag **inauditable** : deux grains du même genre réel prennent deux étiquettes
> différentes et passent G-VAR-2/G-VAR-3 sans être vus. Je corrige le mien avant de le reprocher à
> quiconque. TIER inchangé — litmus LIGHT (« générable en série en scannant l'instance suivante »)
> **négatif** : il n'y a qu'un `check_cost_metadata.py`, et le mode flotte a demandé la conception de
> l'agrégation, la réutilisation de `notebook_walk` et la réconciliation d'un écart de population
> 1020 vs 941.

## Résumé

`check_cost_metadata.py` n'avait qu'un mode **un notebook à la fois**. Les neuf litmus du
schéma de coût étaient donc appliqués à la main, par quiconque y pensait, et **personne
n'avait jamais agrégé le résultat sur la flotte**. Conséquence : un litmus vert ne pouvait
pas être distingué d'un litmus *jamais exécuté* — le même angle mort que « vert hors-cible »
(#8845), en pire, puisqu'ici la sous-détection est totale et silencieuse.

Cette PR ajoute le **mode flotte** : `--all`, `--family <nom>`, `--json`, `--out`. Même
prédicat que le mode mono-notebook (aucun litmus dupliqué ni réécrit) ; le parcours passe
par le marcheur canonique `notebook_walk.iter_notebooks` (#8650), pas par un `glob` local
de plus.

## Mesure d'introduction (firsthand, `--all` sur `main` @ `915e5b28c`)

```
941 notebooks scannes | 71 avec au moins un finding | 86 findings | 0 erreur de lecture

--- validators declares (recensement) ---
  papermill           153
  manual              138
  qc_cloud             81
  sk_visual            18
  dotnet-interactive    4

--- findings par pattern ---
  gpu_used_but_not_declared      31
  gpu_no_visual_validator        18
  token_required_but_no_account  17
  api_used_but_cost_zero         13
  qc_notebook_no_qcc_estimate     4
  qc_notebook_no_validator        3
```

**Le litmus 9 (`validator_asserts_execution_but_cells_unexecuted`, #8790) est à zéro** — et
c'est un vrai zéro, pas un escamotage du marcheur : les 13 findings mesurés lors de son
introduction ont bien été corrigés en `validator: manual`. Contrôle indépendant :
`--family QuantConnect` → 205 scannés, 22 findings, `qc_cloud 81 / papermill 16 / manual 13`.
Le `manual: 13` recoupe exactement le compte attendu.

**Écart de population assumé, 1020 vs 941** : la mesure du litmus 9 documentée dans
`cost-matrix.md` parcourait le disque brut ; le mode flotte passe par `notebook_walk`, qui
restreint aux fichiers **suivis par git** (`tracked_only=True`) et écarte `_output.ipynb`,
`_archives/`, `.ipynb_checkpoints/`, `.lake/`. Les ~79 de différence sont des sorties
d'exécution, des archives et des notebooks non suivis — hors périmètre d'un audit de
**métadonnées déclarées**. L'écart est écrit dans la doc plutôt que laissé en contradiction
silencieuse.

## Deux frontières délibérées

**1. Pas de `--check`, pas de câblage CI.** Les 86 findings sont **pré-existants** : un gate
posé dessus naîtrait rouge et serait ignoré dès le premier jour. L'ordre est *agréger →
résorber → gater*, jamais l'inverse (décision « ne se câble pas sur rouge pré-existant »,
cf organe Slides #8817). C'est d'ailleurs déjà la doctrine du fichier : « Ce que ce schéma
n'est PAS » dit que le validateur **signale** et ne décide pas si l'incohérence est
bloquante. Résorber un pattern est un grain de substance séparé, dispatchable par lane.

**2. Pas de renommage de `last_validated`.** Le champ se contredit entre le commentaire de
schéma, la table et la prose — c'est le design-gate **#8843**, tranché séparément. Cette PR
n'y touche pas : elle mesure, elle ne redéfinit pas.

Aucune auto-correction non plus : ce script **extrait**, il ne réécrit pas les notebooks. La
correction d'un finding se fait **à la source** (ré-exécuter, ou corriger la déclaration),
jamais en éditant une sortie de cellule à la main (Stop & Repair).

## Vérifications

- `pytest scripts/audit/tests/test_check_cost_metadata.py` → **42 passed** (37 avant ; 5 tests
  ajoutés : agrégation par pattern, recensement par validator, exclusion des notebooks sains
  du détail, notebook illisible **enregistré et visible** — pas avalé —, rapport vide qui
  affiche `(aucun)`).
- Mode mono-notebook inchangé : régression YAML vérifiée sur un notebook réel.
- Les trois chemins d'erreur CLI (`--all` + positionnel, `--all` + `--family`, aucun des deux)
  vérifiés.
- `--json` vérifié dans les deux modes.
- Catalogue non touché (`git status` : 3 fichiers, aucun `COURSE_CATALOG.*`, aucun marqueur
  `CATALOG-STATUS`).

See #8056
Part of #4208
