### PR TITLE
fix(lean-decision-theory): correct sorry-baseline 4->2 — counter scope mismatch + #2911 discharge

### DIFF
--- a/.github/workflows/lean-decision-theory.yml
+++ b/.github/workflows/lean-decision-theory.yml
@@ -4,16 +4,24 @@ name: Lean CI (decision_theory_lean)
 # at the Probas series root, lifted from Probas/Infer/gittins_lean in PR #4058
 # (lake content unchanged by the lift). First module: Gittins index. Research scaffolding.
 #
-# sorry-filter-mode=standalone-tactic, baseline=4: a CONSERVATIVE regression floor
-# counting only standalone `sorry` tokens (never false-positives on prose; catches
-# any NEW standalone sorry; UNDERCOUNTS inline-commented ones). Authoritative sorry
-# profile: GittinsTheorem.lean = 2 (INTRINSIC gittins_optimality, #4039 MDP barrier),
-# mirrored 1:1 in the EN sibling GittinsTheorem_en.lean = 2 (i18n #4980 mandates
-# byte-identical proofs FR↔EN, including INTRINSIC sorries), lake total = 4.
-# Discount.lean / Discount_en.lean = 0 since PR #2911. Raised 3→4 in the i18n PR
-# adding the Gittins_en siblings (documented justification: faithful EN mirror of
-# an existing INTRINSIC sorry, NOT a regression). Consolidated per ai-01 DRY
-# decision (matrix). See lean-build.yml.
+# sorry-filter-mode=standalone-tactic, baseline=2: regression floor matching what
+# the CI counter actually reports. lean-build.yml counts FR files only
+# (`find ! -name '*_en.lean'`), so the EN siblings are OUT of the gate's scope.
+# GittinsTheorem.lean (FR) carries 2 standalone `sorry` (gittins_optimality, the
+# value V := sorry and the inequality proof sorry, both INTRINSIC #4039 MDP
+# barrier) — and 2 is ALSO the `real`-mode count (no inline `exact sorry` forms),
+# so standalone-tactic does not undercount here. The EN sibling
+# GittinsTheorem_en.lean mirrors them 1:1 (i18n #4980 byte-identical proofs) but,
+# being `_en`, is never scanned — its parity with FR is enforced by the i18n
+# convention, not by this gate.
+#
+# Was baseline=4: that value counted FR(2)+EN(2), but the counter excludes `_en`,
+# so the EN half was never seen — a scope mismatch that left the floor 2 above
+# the real count (Discount.lean, also 0 since #2911, compounded it). A floor 2
+# above real defeats the §D anti-regression gate: a 2-sorry regression (2->4)
+# would pass undetected (CI run 29857938621 already reports "Real sorry
+# (standalone-tactic): 2 / Known baseline: 4"). Corrected to 2 so the gate is
+# sensitive again. Consolidated per ai-01 DRY decision (matrix). See lean-build.yml.
 
 on:
   push:
@@ -38,5 +46,5 @@ jobs:
     with:
       project-path: MyIA.AI.Notebooks/Probas/decision_theory_lean
       display-name: decision_theory_lean
-      sorry-baseline: "4"
+      sorry-baseline: "2"
       sorry-filter-mode: standalone-tactic


### PR DESCRIPTION
## What

`lean-decision-theory.yml` declared `sorry-baseline: "4"` but the CI counter reports **real=2**. The baseline is **stale/inflated by 2**.

## Root cause (different from knot #8853)

The i18n PR raised the baseline **3→4 "adding the Gittins_en siblings"** — counting **FR(2)+EN(2)=4**. But `lean-build.yml`'s counter is **FR-only** (`find ! -name '*_en.lean'`), so the EN half was **never scanned**. The Discount.lean discharge (#2911, baseline never decremented) compounded it. Result: a floor **2 above the real count**.

| Lake | Baseline | Real (CI counter) | Status |
|------|----------|-------------------|--------|
| conway | 8 | 8 | ✅ MATCH |
| knot (#8853) | 17 | 16 | ⚠️ stale −1 (fix pending) |
| **decision-theory** | **4** | **2** | ⚠️ **stale −2 (this PR)** |

(baseline=0 lakes are self-enforcing: any `sorry` makes real>0>baseline → CI fails.)

## Why this is an anti-regression fix (§D), not cosmetics

The gate fails **only** when `SORRY_TOTAL > BASELINE`. A floor 2 above real means a **2-sorry regression (2→4) passes undetected** — the §D `grep -c sorry` before/after blind spot. Aligning `baseline=2` restores that a 2→3 regression now **hard-fails**.

## Triple-verified (canonical counter + CI + grep)

1. **Canonical standalone-tactic counter** (`tr -d '\302\267' | grep -cE "^\s*sorry\s*$"`, FR-only) = **2** (GittinsTheorem.lean L104, L108). The `real`-mode count is **also 2** (no inline `exact sorry` forms) → standalone-tactic does not undercount for this file.
2. **Actual CI run `29857938690`** verbatim: `./Gittins/GittinsTheorem.lean: 2` / `Real sorry (standalone-tactic): 2` / `Known baseline: 4`.
3. **grep** confirms GittinsTheorem.lean has exactly 2 sorry lines (both standalone).

## The EN sibling

`GittinsTheorem_en.lean` mirrors the 2 sorries 1:1 (i18n #4980 byte-identical proofs) but is excluded by the counter by design. Its parity with FR is enforced by the **i18n convention**, not by this gate — so `baseline=2` (FR-only) is correct.

## Changes (1 workflow file)

- `sorry-baseline: "4"` → `"2"`.
- Rewrote the sorry-profile comment block to document the scope mismatch (baseline counted EN siblings the counter excludes) + the #2911 Discount discharge + the §D rationale, and to note the FR-only counter scope.

## Validation

- **See-it-fail-first**: the stale baseline is currently GREEN on `main` (2 < 4) — i.e. the gate is asleep through the blind-spot. After this PR, a 3rd standalone sorry flips it RED.
- **No-regression 10/10 PASS** (`test_proof_integrity_display_names.py` 3 + `test_proof_integrity_audit_wiring.py` 7). No test pins the decision-theory baseline.
- CRLF = 0.

## Scope notes & follow-up

- Atomic: the baseline correction + the comment fix in the same file's profile block (same subject: "decision-theory sorry profile is 2, not 4").
- **This is the 2nd instance of the stale-baseline class** (knot #8853 was the 1st), found by systematically scanning all 20 `lean-*.yml` baselines. Two instances argue for a **drift-guard contract test** asserting each `sorry-baseline` == the canonical count — but that test must faithfully port both counting modes (`real` and `standalone-tactic`) and is blocked on #8853 (knot) landing first, so it's a separate future PR.

Grain: MED/lean-ci — myia-po-2026:CoursIA

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
