### PR TITLE
fix(cjk,#8858): --stdin SKIP_DIRS on the RELATIVE path, not absolute parts

### DIFF
--- a/scripts/notebook_tools/detect_cjk_residue.py
+++ b/scripts/notebook_tools/detect_cjk_residue.py
@@ -484,14 +484,23 @@ def main(argv=None) -> int:
                 p = root / p
             if p.suffix not in _SCANNABLE_EXT or not p.exists():
                 continue
-            # #8846: SKIP_DIRS parity with the fleet mode (applied at L374/L140).
-            # A path under a pedagogical archive (docs/archive/**, .lake/,
-            # _output/, ...) is not ours to fix, so a leak there is never
-            # attributed to a PR diff. Without this, --stdin scanned what the
-            # fleet scan skips, so a PR that merely touched docs/archive/**
-            # inherited a cjk-residue label for pre-existing residue it never
-            # introduced (#8829 review follow-up).
-            if any(part in SKIP_DIRS for part in p.parts):
+            # #8846/#8858: SKIP_DIRS parity with the fleet mode (applied at
+            # L374/L140 on the RELATIVE path). The check must operate on the
+            # components RELATIVE TO the repo root, not on `p.parts` -- `p` was
+            # absolutised two lines above (`p = root / p`), so the absolute parts
+            # include the repo's parent directories. If the repo is cloned under a
+            # name that belongs to SKIP_DIRS (`worktrees`, `archive`, ...), every
+            # path matched and the scan returned 0 hit on the ENTIRE diff -- a
+            # total silence worse than #8846's false accusation (#8858). A leak
+            # under a pedagogical archive (docs/archive/**, .lake/, _output/, ...)
+            # is never attributed to a PR diff; the fleet scan skips the same.
+            try:
+                rel_parts = p.relative_to(root).parts
+            except ValueError:
+                # An explicit absolute path outside the repo: fall back to the
+                # current behaviour rather than raise.
+                rel_parts = p.parts
+            if any(part in SKIP_DIRS for part in rel_parts):
                 continue
             results.append(_scan_one(p, root))
     elif args.target:

--- a/scripts/notebook_tools/tests/test_detect_cjk_residue.py
+++ b/scripts/notebook_tools/tests/test_detect_cjk_residue.py
@@ -287,6 +287,32 @@ class TestStdinMode:
         assert out["total_hits"] == 0
         assert out["scanned"] == 0
 
+    # #8858 -- the SKIP_DIRS check must operate on the path RELATIVE to the repo
+    # root, not on the absolute parts. `p` is absolutised (`p = root / p`), so if
+    # the repo itself is cloned UNDER a SKIP_DIRS member (`archive`, `worktrees`,
+    # ...), the absolute parts matched and the --stdin scan returned 0 hit on the
+    # ENTIRE diff -- a total silence worse than #8846's false accusation. Here the
+    # repo root sits under an `archive/` parent; a leaking .md INSIDE the repo
+    # (not under an archive subdir) must still be detected. RED on the unfixed
+    # code (0 hit), GREEN after the fix.
+    def test_stdin_detects_leak_when_repo_under_skipdir_parent(self, tmp_path, monkeypatch, capsys):
+        # The repo root lives UNDER a directory named `archive` (a canonical
+        # SKIP_DIRS member): the parent's name must NOT silence leaks inside.
+        repo = tmp_path / "archive" / "repo"
+        dirty = repo / "leak.md"
+        dirty.parent.mkdir(parents=True)
+        dirty.write_text("# volume plus均匀ément distribue\n", encoding="utf-8")
+        # git diff --name-only emits repo-relative forward-slash paths.
+        monkeypatch.setattr(
+            sys, "stdin",
+            io.StringIO(f"{dirty.relative_to(repo).as_posix()}\n"),
+        )
+        rc = mod.main(["--root", str(repo), "--stdin", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert out["total_hits"] == 1   # the leak INSIDE the repo IS detected
+        assert out["scanned"] == 1
+
 
 # ===========================================================================
 # #8826 -- discriminating guard: CJK soldered into/dropped into Latin = leak;


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python (#8857). Filler (plat principal #8857 DEEP déjà livré ce cycle).

fix(cjk,#8858): --stdin SKIP_DIRS check on the RELATIVE path, not the absolute parts

In `detect_cjk_residue.py` `--stdin` mode, `p` is absolutised two lines above
the filter (`p = root / p`), so the parity check `if any(part in SKIP_DIRS for
part in p.parts)` (#8846) operated on the ABSOLUTE path components. If the repo
is cloned under a directory whose name belongs to `SKIP_DIRS` (`archive`,
`worktrees`, `.lake`, ...) — which the fleet actually does: `worktrees` is a
member and the repo keeps its worktrees under `.claude/worktrees/` — then EVERY
path passed to `--stdin` matched, and the scan returned 0 hit on the ENTIRE diff.

That is the inverse defect of #8846 and the worse of the two for an advisory
organ: #8846 produced a VISIBLE, contestable false accusation; this produced a
total, invisible, incontestable silence — indistinguishable from a clean repo.

Fix: make the SKIP_DIRS check operate on the components RELATIVE to the repo
root (the canonical behaviour the fleet mode uses at L374/L140), falling back to
`p.parts` for an explicit absolute path outside the repo (`ValueError`).

  try:
      rel_parts = p.relative_to(root).parts
  except ValueError:
      rel_parts = p.parts
  if any(part in SKIP_DIRS for part in rel_parts):
      continue

Acceptance criteria (#8858):
1. Added `test_stdin_detects_leak_when_repo_under_skipdir_parent`: the repo root
   lives UNDER an `archive/` parent; a leaking `.md` INSIDE the repo must still
   be detected (1 hit, scanned 1). The parent dir's name no longer silences.
2. Seen RED before the fix: on the unfixed code (`p.parts`) the test fails with
   `assert 0 == 1` (the leak was silenced by the `archive` parent).
3. No regression: 47 passed (was 46), including the #8829 controls (`--stdin`
   clean list = 0, leaking `.md` = 1) and the two `#8849` SKIP_DIRS tests.

Closes #8858.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
