### PR TITLE
fix(cjk,#8858): SKIP_DIRS --stdin filters repo-relative parts, not absolute

### DIFF
--- a/scripts/notebook_tools/detect_cjk_residue.py
+++ b/scripts/notebook_tools/detect_cjk_residue.py
@@ -491,7 +491,21 @@ def main(argv=None) -> int:
             # fleet scan skips, so a PR that merely touched docs/archive/**
             # inherited a cjk-residue label for pre-existing residue it never
             # introduced (#8829 review follow-up).
-            if any(part in SKIP_DIRS for part in p.parts):
+            #
+            # #8858: SKIP_DIRS must filter REPO-RELATIVE parts, not the absolute
+            # path (p was absolutised above as `root / p`). The fleet mode
+            # (L374) gets relative parts from `git ls-files`; --stdin must do the
+            # same via p.relative_to(root), else a repo cloned under a dir whose
+            # name is a SKIP_DIRS member (archive/_output/worktrees/...) matches
+            # EVERY file and silences the whole scan -- the inverse defect of
+            # #8846, worse for an advisory organ (total silence ~= clean repo).
+            try:
+                rel_parts = p.relative_to(root).parts
+            except ValueError:
+                # Path outside the repo root (named-absolute on --stdin): fall
+                # back to absolute parts rather than raise.
+                rel_parts = p.parts
+            if any(part in SKIP_DIRS for part in rel_parts):
                 continue
             results.append(_scan_one(p, root))
     elif args.target:

--- a/scripts/notebook_tools/tests/test_detect_cjk_residue.py
+++ b/scripts/notebook_tools/tests/test_detect_cjk_residue.py
@@ -287,6 +287,30 @@ class TestStdinMode:
         assert out["total_hits"] == 0
         assert out["scanned"] == 0
 
+    def test_stdin_skipdirs_uses_repo_relative_not_absolute(self, tmp_path, monkeypatch, capsys):
+        # #8858: the --stdin SKIP_DIRS filter must test REPO-RELATIVE parts,
+        # not the absolute path. If the repo is cloned under a directory whose
+        # name is a SKIP_DIRS member (archive/_output/worktrees/...), testing the
+        # absolute path matches EVERY file and silences the whole scan (0 hit on
+        # a leaking diff) -- the inverse defect of #8846, and worse for an
+        # advisory organ (total silence is indistinguishable from a clean repo).
+        # Build a repo whose OWN root sits under a dir named `archive`.
+        repo_root = tmp_path / "archive" / "repo"
+        repo_root.mkdir(parents=True)
+        leaking = repo_root / "doc.md"
+        leaking.write_text("# a real均匀ément leak inside the repo\n", encoding="utf-8")
+        # The leak lives at the repo root (no archive/ component relative to it).
+        monkeypatch.setattr(
+            sys, "stdin",
+            io.StringIO(f"{leaking.relative_to(repo_root).as_posix()}\n"),
+        )
+        rc = mod.main(["--root", str(repo_root), "--stdin", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert out["total_hits"] == 1, (
+            "#8858: a leak under a repo cloned in an `archive`/ dir must STILL be "
+            "detected -- SKIP_DIRS must filter repo-relative, not absolute, parts")
+        assert out["scanned"] == 1
+
 
 # ===========================================================================
 # #8826 -- discriminating guard: CJK soldered into/dropped into Latin = leak;


### PR DESCRIPTION
## What

Defect in my own #8849 fix (reported by @jsboige in #8858). The `--stdin` SKIP_DIRS filter tested the **absolute** path: `p` had been absolutised as `root / p` two lines above, so `p.parts` carried the full absolute path. A repo cloned under a directory whose name is a `SKIP_DIRS` member (`archive`/`_output`/`worktrees`/…) makes **every** file match → scan returns **0 hit on a leaking diff** — total silence.

> This is the inverse defect of #8846, and the worse of the two for an advisory organ: #8846 produced a *visible, contestable* false accusation; this produces *invisible, incontestable* silence. A guard that accuses wrongly gets disabled; a guard that falls silent isn't even noticed.

Non-hypothetical: `worktrees` is a `SKIP_DIRS` member and the repo keeps worktrees under `.claude/worktrees/` — a CI run or agent launching the detector from such a worktree falls in the hole.

## Fix

Filter on **repo-relative** parts via `p.relative_to(root).parts` — matching the fleet mode at L374 (which gets relative parts from `git ls-files`). `except ValueError` falls back to absolute parts for a named-absolute path outside `root`:

```python
try:
    rel_parts = p.relative_to(root).parts
except ValueError:
    rel_parts = p.parts
if any(part in SKIP_DIRS for part in rel_parts):
    continue
```

## Acceptance (#8858, all 3 criteria)

1. **`test_stdin_skipdirs_uses_repo_relative_not_absolute`** builds a repo whose own root sits under a dir named `archive` and asserts a leak at the repo root is **still detected (1 hit)** — the parent dir name no longer silences the scan.
2. **See-it-fail-first** (same method as #8846 / #8826 point-4): that test is **RED on `main`** (`0 == 1`) before this fix, **GREEN** after.
3. **No regression**: **47/47 PASS** (was 46; +1 new test), including the `#8829` controls (`--stdin` clean list = 0, leak outside archive = 1) and the two `#8849` SKIP_DIRS tests.

CRLF = 0.

## Scope notes

- **Calibre: LIGHT/guard, filler** — per #8858 routing this is a second grain, not a plat principal, and a lane that just chained guard work should pair it with substance. My #8858 defect; owning it.
- 2 files: the 1-line predicate fix (+ comment) and the 1 new test.

See #8858

Grain: LIGHT/guard — myia-po-2026:CoursIA

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
