### PR TITLE
docs(conway,#8749): batch 1 — justify Section 1 native_decide (non-reducible by decide)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Computation.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Computation.lean
@@ -47,24 +47,50 @@ canoniques.
 Pour les entrees de niveau 2, `evolveHashlife` passe par `step4x4` (le cas
 de base du quadtree). Pour les entrees plus grandes, il retombe sur `step`.
 Dans les deux cas, le resultat doit coincider avec `evolve n g`.
+
+### Pourquoi `native_decide` (et non `decide`) — #8749
+
+Ces six theoremes d'equivalence utilisent `native_decide` par **necessite
+structurelle**, non par commodite. Le noyau Lean ne peut pas les prouver par
+`decide` : avec `set_option maxRecDepth 100000`, chacun echoue par
+`reduction got stuck at the Decidable instance` (compilation en erreur,
+en quelques secondes) — un echec *definitif*, pas un depassement de temps
+que davantage de profondeur de reduction leverait. La cause est que
+`Grid = List (Int × Int)` : le calcul de `evolveHashlife`/`evolve` (tri
+`sortDedup` sur des `Int × Int`, puis comparaison par les instances
+`instDecidableEqList` / `instDecidableEqNat` / `Bool.decEq`) ne se reduit
+pas en forme normale, le noyau reste bloque avant d'atteindre
+`isTrue`/`isFalse`. Les enonces sont VRAIS (temoins `#eval` natifs en
+section 5) : c'est exactement le role de `native_decide` — evaluer le calcul
+en code natif et ajouter le resultat a la base de confiance plutot que de
+le reverifier dans le noyau. Verifie par-theoreme pour les six declarations
+de cette section (sondage #8749, 2026-07-29). L'echappatoire serait un
+refactor `Grid = List (Nat × Nat)` (Nat est reductible, Int ne l'est pas) ;
+refonte profonde, hors scope de ce triage (voir #8749 caveat).
 -/
 
-/-- Hashlife et reference sont d'accord sur `block` apres 1 generation. -/
+/-- Hashlife et reference sont d'accord sur `block` apres 1 generation.
+    `native_decide` requis : non-reductible sous `decide` (voir Section 1, #8749). -/
 theorem hashlife_block_1 : evolveHashlife 1 block = evolve 1 block := by native_decide
 
-/-- Hashlife et reference sont d'accord sur `block` apres 4 generations. -/
+/-- Hashlife et reference sont d'accord sur `block` apres 4 generations.
+    `native_decide` requis : non-reductible sous `decide` (voir Section 1, #8749). -/
 theorem hashlife_block_4 : evolveHashlife 4 block = evolve 4 block := by native_decide
 
-/-- Hashlife et reference sont d'accord sur `blinker_h` apres 2 generations. -/
+/-- Hashlife et reference sont d'accord sur `blinker_h` apres 2 generations.
+    `native_decide` requis : non-reductible sous `decide` (voir Section 1, #8749). -/
 theorem hashlife_blinker_2 : evolveHashlife 2 blinker_h = evolve 2 blinker_h := by native_decide
 
-/-- Hashlife et reference sont d'accord sur `glider` apres 4 generations. -/
+/-- Hashlife et reference sont d'accord sur `glider` apres 4 generations.
+    `native_decide` requis : non-reductible sous `decide` (voir Section 1, #8749). -/
 theorem hashlife_glider_4 : evolveHashlife 4 glider = evolve 4 glider := by native_decide
 
-/-- Hashlife et reference sont d'accord sur `beacon` apres 2 generations. -/
+/-- Hashlife et reference sont d'accord sur `beacon` apres 2 generations.
+    `native_decide` requis : non-reductible sous `decide` (voir Section 1, #8749). -/
 theorem hashlife_beacon_2 : evolveHashlife 2 beacon = evolve 2 beacon := by native_decide
 
-/-- Hashlife et reference sont d'accord sur `toad` apres 2 generations. -/
+/-- Hashlife et reference sont d'accord sur `toad` apres 2 generations.
+    `native_decide` requis : non-reductible sous `decide` (voir Section 1, #8749). -/
 theorem hashlife_toad_2 : evolveHashlife 2 toad = evolve 2 toad := by native_decide
 
 /-! ## Section 2 : Eater 1 (Fishhook) — le puits de calcul le plus simple

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Computation_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Computation_en.lean
@@ -46,24 +46,50 @@ both algorithms agree on canonical small patterns.
 For level-2 inputs, `evolveHashlife` routes through `step4x4` (the
 quadtree base case). For larger inputs, it falls back to `step`. In both
 cases, the result should match `evolve n g`.
+
+### Why `native_decide` (not `decide`) — #8749
+
+These six consistency theorems use `native_decide` out of **structural
+necessity**, not convenience. The Lean kernel cannot prove them with
+`decide`: under `set_option maxRecDepth 100000`, each one fails with
+`reduction got stuck at the Decidable instance` (a compile error, within a
+few seconds) — a *definitive* failure, not a timeout that more reduction
+depth would lift. The reason is that `Grid = List (Int × Int)`: the
+`evolveHashlife`/`evolve` computation (`sortDedup` over `Int × Int`, then
+comparison via the `instDecidableEqList` / `instDecidableEqNat` /
+`Bool.decEq` instances) does not reduce to normal form; the kernel gets
+stuck before reaching `isTrue`/`isFalse`. The statements are TRUE (native
+`#eval` witnesses in section 5): this is precisely the role of
+`native_decide` — evaluate the computation as native code and add the
+result to the trust base rather than re-checking it in the kernel. Verified
+per-theorem for all six declarations in this section (#8749 probe,
+2026-07-29). The escape hatch would be a `Grid = List (Nat × Nat)` refactor
+(`Nat` reduces, `Int` does not); a deep rewrite, out of scope for this
+triage (see #8749 caveat).
 -/
 
-/-- Hashlife and reference agree on `block` after 1 generation. -/
+/-- Hashlife and reference agree on `block` after 1 generation.
+    `native_decide` required: not reducible by `decide` (see Section 1, #8749). -/
 theorem hashlife_block_1 : evolveHashlife 1 block = evolve 1 block := by native_decide
 
-/-- Hashlife and reference agree on `block` after 4 generations. -/
+/-- Hashlife and reference agree on `block` after 4 generations.
+    `native_decide` required: not reducible by `decide` (see Section 1, #8749). -/
 theorem hashlife_block_4 : evolveHashlife 4 block = evolve 4 block := by native_decide
 
-/-- Hashlife and reference agree on `blinker_h` after 2 generations. -/
+/-- Hashlife and reference agree on `blinker_h` after 2 generations.
+    `native_decide` required: not reducible by `decide` (see Section 1, #8749). -/
 theorem hashlife_blinker_2 : evolveHashlife 2 blinker_h = evolve 2 blinker_h := by native_decide
 
-/-- Hashlife and reference agree on `glider` after 4 generations. -/
+/-- Hashlife and reference agree on `glider` after 4 generations.
+    `native_decide` required: not reducible by `decide` (see Section 1, #8749). -/
 theorem hashlife_glider_4 : evolveHashlife 4 glider = evolve 4 glider := by native_decide
 
-/-- Hashlife and reference agree on `beacon` after 2 generations. -/
+/-- Hashlife and reference agree on `beacon` after 2 generations.
+    `native_decide` required: not reducible by `decide` (see Section 1, #8749). -/
 theorem hashlife_beacon_2 : evolveHashlife 2 beacon = evolve 2 beacon := by native_decide
 
-/-- Hashlife and reference agree on `toad` after 2 generations. -/
+/-- Hashlife and reference agree on `toad` after 2 generations.
+    `native_decide` required: not reducible by `decide` (see Section 1, #8749). -/
 theorem hashlife_toad_2 : evolveHashlife 2 toad = evolve 2 toad := by native_decide
 
 /-! ## Section 2: Eater 1 (Fishhook) — the simplest computational sink


### PR DESCRIPTION
Batch 1 of **#8749** (conway_lean native_decide triage). `See #8749` — not `Closes` (multi-batch campaign; Sections 2-6 = 13 remaining theorems).

## What

The 6 Hashlife/reference consistency theorems in `Conway.Life.Computation` use `native_decide`. This PR documents **why** (the issue's HARD requirement: "justification à côté de la déclaration, temps mesuré à l'appui") — a full justification block in the Section 1 header (FR canonical + EN sibling) + a one-line self-contained pointer on each theorem docstring.

## Why native_decide is structurally required (per-theorem measured)

The prior #8749 comment delivered a *global* INTRINSIC verdict from measuring ONE theorem + inferring the rest. The issue body explicitly warns against that ("arbitrage par théorème, pas un verdict global"). This batch closes that gap with **per-theorem** `decide` probes across Section 1:

| theorem | `decide` + `maxRecDepth 100000` | verdict |
|---|---|---|
| `hashlife_block_1` | "reduction got stuck at the Decidable instance", EXIT≠0 (~s) | INTRINSIC |
| `hashlife_block_4` | stuck (unfolded instDecidableEqBool/List/Nat) | INTRINSIC |
| `hashlife_blinker_2` | stuck | INTRINSIC |
| `hashlife_glider_4` | stuck | INTRINSIC |
| `hashlife_beacon_2` | stuck | INTRINSIC |
| `hashlife_toad_2` | stuck | INTRINSIC |

All 6 fail **definitively** (stuck, EXIT≠0, seconds) — not a timeout that more reduction depth would lift. Root cause: `Grid = List (Int × Int)`; the `evolveHashlife`/`evolve` computation (`sortDedup` + the `instDecidableEqList`/`instDecidableEqNat`/`Bool.decEq` instances) does not reduce to normal form, so `decide` never reaches `isTrue`/`isFalse`. The statements are TRUE (native `#eval` witnesses in section 5) — exactly `native_decide`'s role. Cross-shape probes (eater1_still_life, block_macrocell_roundtrip, glider_2periods — the other 4 shape-classes) all stuck too, confirming the obstruction is structural.

The escape hatch would be a `Grid = List (Nat × Nat)` refactor (`Nat` reduces, `Int` does not); deep rewrite, out of scope for this triage (see #8749 caveat).

## §B.3 proof-of-progress (Lean PR)

- **sorry av/après**: `Computation.lean` 0→0, `Computation_en.lean` 0→0 (no sorries here).
- **Lake build SUCCESS**: `lake build Conway.Life.Computation Conway.Life.Computation_en` → `Build completed successfully (2950 jobs)`, EXIT=0 (~14s, warm cache, only changed modules recompiled). Pre-existing warnings only (manifest, unused simp args in MacroCell.lean — not these files).
- **Proof integrity / axioms**: `native_decide` count 19→19 in both files — **no theorem added/removed/changed**, so the 19-name `allow-axioms` ratchet in `lean-conway.yml` is unchanged. Docstring-only edit.
- **No prover refactor**: N/A (not `agent_tests/prover/`).

## i18n parity (#4980)

`Computation.lean` (FR canonical) + `Computation_en.lean` (EN sibling) both enriched. Verified: every `theorem`/`def` declaration line byte-identical FR==EN (only docstrings/comments + namespace suffixes differ, per convention).

## Diff

2 files, +64/−12, all docstring/comment enrichment. No proof/tactic/signature touched.