### PR TITLE
docs(conway,#8749): batch 2 — justify Sections 2+3 native_decide (per-theorem)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Computation.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Computation.lean
@@ -88,6 +88,15 @@ X.X.
 ..X.
 ..XX
 ```
+
+### Pourquoi `native_decide` — #8749
+
+`isStillLife eater1` ne se reduit pas sous `decide` (`maxRecDepth 100000` :
+`reduction got stuck at the Decidable instance`, EXIT≠0, secondes). La cause
+est structurelle — `Grid = List (Int × Int)` (voir Section 1 pour le
+detail) ; meme le cas le plus simple (vie stable, aucune evolution) coince.
+L'enonce est VRAI (`#eval` natif ci-dessus), c'est le role de
+`native_decide`. Verifie par-theoreme (sondage #8749, 2026-07-29).
 -/
 
 /-- L'**eater 1** (fishhook), une vie stable de 7 cellules. -/
@@ -101,7 +110,8 @@ def eater1 : Grid :=
 #eval s!"step(eater1) = {step eater1}"
 #eval s!"isStillLife eater1 = {isStillLife eater1}"
 
-/-- L'eater 1 est une vie stable. -/
+/-- L'eater 1 est une vie stable. `native_decide` requis : non-reductible sous
+    `decide` (voir Section 2, #8749). -/
 theorem eater1_still_life : isStillLife eater1 = true := by native_decide
 
 /-! ## Section 3 : composition de gliders par evolution multi-periode
@@ -113,15 +123,26 @@ des fils de gliders.
 
 On verifie pour k = 1 (deja dans Life.lean), k = 2 et k = 3.
 Le cas k = 2 (8 generations) se verifie aussi via `evolveHashlife`.
+
+### Pourquoi `native_decide` — #8749
+
+Ces trois theoremes (periodicite du glider + coherence hashlife sur 8
+generations) ne se reduisent pas sous `decide` (`maxRecDepth 100000` :
+chacun stuck a l'instance `Decidable`, EXIT≠0, verifie par-theoreme). Cause
+structurelle `Grid = List (Int × Int)` (voir Section 1). Enonces VRAIS
+(`#eval` section 5) ; `native_decide` requis.
 -/
 
-/-- Apres 8 generations (2 periodes), le glider s'est deplace de (2, -2). -/
+/-- Apres 8 generations (2 periodes), le glider s'est deplace de (2, -2).
+    `native_decide` requis : non-reductible sous `decide` (voir Section 3, #8749). -/
 theorem glider_2periods : evolve 8 glider = shift (2, -2) glider := by native_decide
 
-/-- Apres 12 generations (3 periodes), le glider s'est deplace de (3, -3). -/
+/-- Apres 12 generations (3 periodes), le glider s'est deplace de (3, -3).
+    `native_decide` requis : non-reductible sous `decide` (voir Section 3, #8749). -/
 theorem glider_3periods : evolve 12 glider = shift (3, -3) glider := by native_decide
 
-/-- Hashlife et reference sont d'accord sur le glider apres 8 generations (2 periodes). -/
+/-- Hashlife et reference sont d'accord sur le glider apres 8 generations (2 periodes).
+    `native_decide` requis : non-reductible sous `decide` (voir Section 3, #8749). -/
 theorem hashlife_glider_8 : evolveHashlife 8 glider = evolve 8 glider := by native_decide
 
 /-! ## Section 4 : verification de l'aller-retour MacroCell

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Computation_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Computation_en.lean
@@ -86,6 +86,15 @@ X.X.
 ..X.
 ..XX
 ```
+
+### Why `native_decide` — #8749
+
+`isStillLife eater1` does not reduce under `decide` (`maxRecDepth 100000`:
+`reduction got stuck at the Decidable instance`, EXIT≠0, seconds). The cause
+is structural — `Grid = List (Int × Int)` (see Section 1 for detail); even
+the simplest case (still life, no evolution) gets stuck. The statement is
+TRUE (native `#eval` above); this is the role of `native_decide`. Verified
+per-theorem (#8749 probe, 2026-07-29).
 -/
 
 /-- The **eater 1** (fishhook), a 7-cell still life. -/
@@ -99,7 +108,8 @@ def eater1 : Grid :=
 #eval s!"step(eater1) = {step eater1}"
 #eval s!"isStillLife eater1 = {isStillLife eater1}"
 
-/-- The eater 1 is a still life. -/
+/-- The eater 1 is a still life. `native_decide` required: not reducible by
+    `decide` (see Section 2, #8749). -/
 theorem eater1_still_life : isStillLife eater1 = true := by native_decide
 
 /-! ## Section 3: Glider composition via multi-period evolution
@@ -111,15 +121,26 @@ glider wires.
 
 We verify for k = 1 (already in Life.lean), k = 2, and k = 3.
 The k = 2 case (8 generations) also verifies via `evolveHashlife`.
+
+### Why `native_decide` — #8749
+
+These three theorems (glider periodicity + hashlife coherence over 8
+generations) do not reduce under `decide` (`maxRecDepth 100000`: each stuck
+at the `Decidable` instance, EXIT≠0, verified per-theorem). Structural cause:
+`Grid = List (Int × Int)` (see Section 1). Statements TRUE (`#eval` section
+5); `native_decide` required.
 -/
 
-/-- After 8 generations (2 periods), the glider has shifted by (2, -2). -/
+/-- After 8 generations (2 periods), the glider has shifted by (2, -2).
+    `native_decide` required: not reducible by `decide` (see Section 3, #8749). -/
 theorem glider_2periods : evolve 8 glider = shift (2, -2) glider := by native_decide
 
-/-- After 12 generations (3 periods), the glider has shifted by (3, -3). -/
+/-- After 12 generations (3 periods), the glider has shifted by (3, -3).
+    `native_decide` required: not reducible by `decide` (see Section 3, #8749). -/
 theorem glider_3periods : evolve 12 glider = shift (3, -3) glider := by native_decide
 
-/-- Hashlife and reference agree on glider after 8 generations (2 periods). -/
+/-- Hashlife and reference agree on glider after 8 generations (2 periods).
+    `native_decide` required: not reducible by `decide` (see Section 3, #8749). -/
 theorem hashlife_glider_8 : evolveHashlife 8 glider = evolve 8 glider := by native_decide
 
 /-! ## Section 4: MacroCell round-trip verification


### PR DESCRIPTION
Batch 2 of **#8749**. `See #8749` — not `Closes` (multi-batch; Sections 4+6 = 9 remaining). Non-overlapping with batch 1 (#8861, Section 1) → clean merge.

## What

Documents why `native_decide` is structurally required for the 4 theorems in Sections 2 + 3:
- **Section 2**: `eater1_still_life` (`isStillLife eater1 = true`)
- **Section 3**: `glider_2periods`, `glider_3periods`, `hashlife_glider_8`

Concise section-notes (FR canonical + EN sibling) + one-line pointer per theorem. Full mechanism is in Section 1 (#8861).

## Per-theorem measured evidence

| theorem | `decide` + `maxRecDepth 100000` | verdict |
|---|---|---|
| `eater1_still_life` | stuck (Decidable instance), EXIT≠0 | INTRINSIC |
| `glider_2periods` | stuck (instDecidableEqList) | INTRINSIC |
| `glider_3periods` | stuck (instDecidableEqList) | INTRINSIC |
| `hashlife_glider_8` | stuck (instDecidableEqBool/List/Nat) | INTRINSIC |

All fail **definitively** (stuck, not timeout). Key finding: `isStillLife eater1` — the simplest case (no evolve/hashlife machinery) — is ALSO stuck, confirming the obstruction is the `Grid = List (Int × Int)` representation itself, uniform across all shape-classes (not specific to evolveHashlife). Statements TRUE (`#eval` witnesses).

## §B.3 proof-of-progress (Lean PR)
- **sorry av/après**: 0→0 (both files).
- **Lake build SUCCESS**: `lake build Conway.Life.Computation Conway.Life.Computation_en` → 2950 jobs, EXIT=0 (~15s). Pre-existing warnings only.
- **Proof integrity**: `native_decide` 19→19 — no theorem/axiom change. Docstring-only.
- **No prover refactor**: N/A.

## i18n parity (#4980)
FR + EN siblings both enriched. Theorem/def declaration lines byte-identical FR==EN.

## Diff
2 files, +X/−Y, all docstring/comment enrichment. No proof/tactic/signature touched.