### PR TITLE
fix(notebook_tools,#8858): SKIP_DIRS filter relative-to-root in 3 papermill detectors

### DIFF
--- a/scripts/notebook_tools/detect_papermill_cell_level_state.py
+++ b/scripts/notebook_tools/detect_papermill_cell_level_state.py
@@ -208,7 +208,19 @@ def iter_notebooks(root: Path) -> list[Path]:
         return []
     out: list[Path] = []
     for p in root.rglob("*.ipynb"):
-        if any(part in _SKIP_DIR_NAMES for part in p.parts):
+        # #8858-class guard: ``root.rglob`` yields ABSOLUTE paths, so
+        # filtering on ``p.parts`` (absolute components) would match the
+        # repo's own parent if it sits under a SKIP_DIR-name dir (e.g. a
+        # checkout cloned at ``_archives/repo/``). That makes the filter
+        # match EVERY path and silences the whole scan — worse than a
+        # false positive. Filter on the path RELATIVE to ``root`` instead
+        # (the in-repo SKIP_DIRS semantics, same as the single-file mode),
+        # falling back to ``p.parts`` when ``p`` is not under ``root``.
+        try:
+            rel_parts = p.relative_to(root).parts
+        except ValueError:
+            rel_parts = p.parts
+        if any(part in _SKIP_DIR_NAMES for part in rel_parts):
             continue
         out.append(p)
     return sorted(out)

--- a/scripts/notebook_tools/detect_papermill_failed_state.py
+++ b/scripts/notebook_tools/detect_papermill_failed_state.py
@@ -151,7 +151,19 @@ def iter_notebooks(root: Path) -> list[Path]:
         return []
     out: list[Path] = []
     for p in root.rglob("*.ipynb"):
-        if any(part in _SKIP_DIR_NAMES for part in p.parts):
+        # #8858-class guard: ``root.rglob`` yields ABSOLUTE paths, so
+        # filtering on ``p.parts`` (absolute components) would match the
+        # repo's own parent if it sits under a SKIP_DIR-name dir (e.g. a
+        # checkout cloned at ``_archives/repo/``). That makes the filter
+        # match EVERY path and silences the whole scan — worse than a
+        # false positive. Filter on the path RELATIVE to ``root`` instead
+        # (the in-repo SKIP_DIRS semantics, same as the single-file mode),
+        # falling back to ``p.parts`` when ``p`` is not under ``root``.
+        try:
+            rel_parts = p.relative_to(root).parts
+        except ValueError:
+            rel_parts = p.parts
+        if any(part in _SKIP_DIR_NAMES for part in rel_parts):
             continue
         out.append(p)
     return sorted(out)

--- a/scripts/notebook_tools/detect_papermill_path_leak.py
+++ b/scripts/notebook_tools/detect_papermill_path_leak.py
@@ -264,7 +264,19 @@ def iter_notebooks(root: Path) -> list[Path]:
         return []
     out: list[Path] = []
     for p in root.rglob("*.ipynb"):
-        if any(part in _SKIP_DIR_NAMES for part in p.parts):
+        # #8858-class guard: ``root.rglob`` yields ABSOLUTE paths, so
+        # filtering on ``p.parts`` (absolute components) would match the
+        # repo's own parent if it sits under a SKIP_DIR-name dir (e.g. a
+        # checkout cloned at ``_archives/repo/``). That makes the filter
+        # match EVERY path and silences the whole scan — worse than a
+        # false positive. Filter on the path RELATIVE to ``root`` instead
+        # (the in-repo SKIP_DIRS semantics, same as the single-file mode),
+        # falling back to ``p.parts`` when ``p`` is not under ``root``.
+        try:
+            rel_parts = p.relative_to(root).parts
+        except ValueError:
+            rel_parts = p.parts
+        if any(part in _SKIP_DIR_NAMES for part in rel_parts):
             continue
         out.append(p)
     return sorted(out)

--- a/scripts/notebook_tools/tests/test_detect_papermill_cell_level_state.py
+++ b/scripts/notebook_tools/tests/test_detect_papermill_cell_level_state.py
@@ -352,6 +352,23 @@ class TestScanTree(unittest.TestCase):
             )
             self.assertEqual(detector.scan_tree(root), [])
 
+    def test_parent_in_skipdir_not_silenced(self):
+        """#8858-class: a repo cloned UNDER a SKIP_DIR-name parent (e.g.
+        ``_archives/repo/``) must NOT be totally silenced by ``scan_tree``.
+        The SKIP_DIRS check operates on parts RELATIVE to root, so the repo's
+        absolute parent dir is irrelevant. RED on unfixed code (0 notebooks
+        scanned -> silent clean), GREEN after the relative-to-root fix."""
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td) / "_archives" / "repo"  # repo under a SKIP_DIR parent
+            (repo / "good").mkdir(parents=True)
+            # One failing notebook to anchor: if silenced, scan_tree returns [].
+            (repo / "good" / "fail.ipynb").write_text(
+                json.dumps(_nb([_failed_meta()])), encoding="utf-8"
+            )
+            defects = detector.scan_tree(repo.resolve())  # absolute root, as CI passes
+            self.assertTrue(any("fail.ipynb" in d.get("file", "") for d in defects),
+                            f"expected fail.ipynb defect, got {defects}")
+
 
 # --- CLI tests ---
 

--- a/scripts/notebook_tools/tests/test_detect_papermill_failed_state.py
+++ b/scripts/notebook_tools/tests/test_detect_papermill_failed_state.py
@@ -193,6 +193,19 @@ class ScanTreeTests(unittest.TestCase):
             found = iter_notebooks(root)
             self.assertEqual([p.name for p in found], ["a.ipynb"])
 
+    def test_iter_notebooks_parent_in_skipdir_not_silenced(self):
+        """#8858-class: a repo cloned UNDER a SKIP_DIR-name parent (e.g.
+        ``_archives/repo/``) must NOT be totally silenced. ``iter_notebooks``
+        checks parts RELATIVE to root, so the repo's absolute parent dir is
+        irrelevant. RED on the unfixed code (absolute ``p.parts`` matched the
+        ``_archives`` parent -> 0 found), GREEN after the relative-to-root fix."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "_archives" / "repo"  # repo under a SKIP_DIR parent
+            (repo / "good").mkdir(parents=True)
+            (repo / "good" / "leak.ipynb").write_text("{}", encoding="utf-8")
+            found = iter_notebooks(repo.resolve())  # absolute root, as CI passes
+            self.assertEqual([p.name for p in found], ["leak.ipynb"])
+
     def test_iter_notebooks_sorted(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/scripts/notebook_tools/tests/test_detect_papermill_path_leak.py
+++ b/scripts/notebook_tools/tests/test_detect_papermill_path_leak.py
@@ -393,6 +393,17 @@ class ScanTreeTests(unittest.TestCase):
             found = iter_notebooks(root)
             self.assertEqual([p.name for p in found], ["a.ipynb"])
 
+    def test_iter_notebooks_parent_in_skipdir_not_silenced(self):
+        """#8858-class: a repo cloned UNDER a SKIP_DIR-name parent (e.g.
+        ``_archives/repo/``) must NOT be totally silenced. Checks parts RELATIVE
+        to root, not absolute ``p.parts``. RED on unfixed code, GREEN after fix."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "_archives" / "repo"  # repo under a SKIP_DIR parent
+            (repo / "good").mkdir(parents=True)
+            (repo / "good" / "leak.ipynb").write_text("{}", encoding="utf-8")
+            found = iter_notebooks(repo.resolve())  # absolute root, as CI passes
+            self.assertEqual([p.name for p in found], ["leak.ipynb"])
+
     def test_iter_notebooks_sorted(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## What

Three papermill notebook detectors filter `SKIP_DIRS` on the **absolute** path components inside `iter_notebooks(root)`, which **silences the entire scan** when the repository is cloned under a parent whose name is a `SKIP_DIR` member (e.g. `_archives/repo/`, `worktrees/repo/`).

Affected files:

- `scripts/notebook_tools/detect_papermill_failed_state.py`
- `scripts/notebook_tools/detect_papermill_cell_level_state.py`
- `scripts/notebook_tools/detect_papermill_path_leak.py`

This is the **papermill-detector instance of the `#8858`-class bug** already fixed for `detect_cjk_residue` in #8859. Same root cause, same fix shape, different detector family. See #8858 for the canonical write-up of the class; see #8859 for the cjk_residue fix.

## Root cause

```python
for p in root.rglob("*.ipynb"):
    if any(part in _SKIP_DIR_NAMES for part in p.parts):   # p.parts is ABSOLUTE
        continue
```

`root.rglob(...)` yields **absolute** paths, so `p.parts` includes the repo's own absolute parent segments. When the repo sits under, say, `_archives/repo/`, the `_archives` component matches **every** yielded path → the filter rejects the whole scan → the detector returns **zero notebooks**.

A guard that wrongly *accuses* gets noticed and disabled (the #8846 failure mode); a guard that wrongly *stays silent* is indistinguishable from a clean repo and never gets caught. Silence is the worse defect for an advisory organ.

Non-hypothetical on the fleet: `worktrees` is a SKIP_DIR and the repo keeps its worktrees under `.claude/worktrees/`. A CI step or agent launching these detectors from such a worktree would land in the hole and report "all clean" on a dirty tree.

## Fix

Filter on the path **relative to `root`** (the in-repo SKIP_DIRS semantics, matching the single-file mode), with an `except ValueError` fallback to `p.parts` for paths not under `root`:

```python
for p in root.rglob("*.ipynb"):
    try:
        rel_parts = p.relative_to(root).parts
    except ValueError:
        rel_parts = p.parts
    if any(part in _SKIP_DIR_NAMES for part in rel_parts):
        continue
    out.append(p)
```

Applied verbatim to all three detectors. Patch identical in shape to #8859.

## Acceptance (#8858-style: RED on buggy, GREEN on fixed)

One new regression test per detector — `_archives/repo/good/<nb>.ipynb` fixture, asserts the scan still finds the notebook:

| detector | new test | result |
|---|---|---|
| `detect_papermill_failed_state` | `test_iter_notebooks_parent_in_skipdir_not_silenced` | RED→GREEN |
| `detect_papermill_cell_level_state` | `test_parent_in_skipdir_not_silenced` | RED→GREEN |
| `detect_papermill_path_leak` | `test_iter_notebooks_parent_in_skipdir_not_silenced` | RED→GREEN |

- **RED on buggy code**: with the three sources reverted to `origin/main`, all three new tests fail (scan returns `[]`).
- **GREEN on fixed code**: re-applying the fix → all three pass.
- **No regression**: full papermill suites = **99 passed** (was 96, +3 new tests). Legit in-repo `_archives/` / `__pycache__` / `node_modules` / `.venv` skips still pass (`test_skips_noise_directories` and siblings).

## Scope

- Calibre: `LIGHT/guard`. 3 detectors × (~13-line guard block replacing 1 line) + 3 pure-add regression tests = **6 files, +80/−3**.
- The `−3` are exactly the three old `if any(part in _SKIP_DIR_NAMES for part in p.parts):` lines being replaced by the relative-to-root guard. No content removed elsewhere.
- Pathspec commit (`git commit -- <6 paths>`) — verified `git show --stat HEAD` shows only the 6 intended files.

See #8858
See #8859

lane: myia-po-2024:CoursIA-2
Grain: LIGHT/guard
