### PR TITLE
fix(rl,#8056): restore lost #8666 merge — RL cost-metadata + rl-cpu profile (+ signature fix)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb
@@ -676,6 +676,23 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.12"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb
@@ -999,6 +999,23 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.12"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb
@@ -1095,6 +1095,23 @@
    "parameters": {},
    "start_time": "2026-06-29T18:05:36.300389+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb
@@ -915,6 +915,23 @@
    "parameters": {},
    "start_time": "2026-06-29T18:57:51.212485+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb
@@ -1401,6 +1401,23 @@
    "parameters": {},
    "start_time": "2026-06-03T15:00:39.104609",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 4,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb
@@ -982,6 +982,23 @@
    "parameters": {},
    "start_time": "2026-06-03T15:02:40.038028",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb
@@ -1531,6 +1531,23 @@
    "parameters": {},
    "start_time": "2026-05-14T19:54:34.724165+00:00",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 3,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb
@@ -1882,6 +1882,23 @@
    "parameters": {},
    "start_time": "2026-06-04T03:05:55.289101+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 4,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb
@@ -1532,6 +1532,23 @@
    "parameters": {},
    "start_time": "2026-06-04T15:00:17.336762+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 3,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb
@@ -1291,6 +1291,23 @@
    "parameters": {},
    "start_time": "2026-06-03T14:50:26.001524",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb
@@ -1313,6 +1313,23 @@
    "parameters": {},
    "start_time": "2026-06-04T11:57:30.425935+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb
@@ -1105,6 +1105,23 @@
    "parameters": {},
    "start_time": "2026-06-04T14:09:39.867493+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb
@@ -1325,6 +1325,23 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.7"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb
@@ -1243,6 +1243,23 @@
    "parameters": {},
    "start_time": "2026-06-03T15:04:53.320487",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb
@@ -1204,6 +1204,23 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.12"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb
@@ -910,6 +910,23 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.12"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-28",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/scripts/audit/populate_cost_metadata.py
+++ b/scripts/audit/populate_cost_metadata.py
@@ -343,6 +343,101 @@ def build_search_cpu_cost(nb: dict, by: str, today: str) -> dict:
     }
 
 
+# --- Profile rl-cpu : notebooks RL CPU-purs (gymnasium/torch/SB3, petits envs) ---
+# Issue #8056 (P1) — rollout family-partitionné. Le profile `rl-cpu` couvre les
+# notebooks d'apprentissage par renforcement pédagogiques : gymnasium / stable-
+# baselines3 / torch en local CPU, petits environnements (CartPole, etc.), timesteps
+# modestes (10-5000). Gratuit, pas d'API cloud / compte externe / GPU requis.
+#
+# Diffère de `search-cpu` sur deux axes honnêtes :
+#   1. `reproducibility: MED` (l'entraînement RL est STOCHASTIQUE, seeds) vs `HIGH`
+#      (algorithmes déterministes).
+#   2. `cpu_min` plus élevé (boucles d'entraînement itératives vs algo single-pass).
+
+# Gate RL-spécifique : PLUS PRÉCISE que le `is_cpu_pure` générique. Raisonnement
+# (C920-L ★★, FP prose) : le mot « openai » apparaît dans la PROSE des notebooks RL
+# (« gym.openai.com/envs/ », « jeux d'OpenAI », « spinningup.openai.com ») sans qu'aucun
+# appel API cloud ne soit fait — gymnasium/SB3 sont des libs LOCALES. Le `_API_RE`
+# générique (mot isolé « openai ») FP-skipperait rl_1 (intro CartPole), rl_6c (PPO),
+# rl_6d (SAC) — les notebooks les plus pédagogiques. On matche donc un VRAI appel API
+# (import/instance), pas le mot isolé. Le signal GPU réel (`torch.cuda`,
+# `.cuda(`) est conservé → rl_6e (GRPO, CUDA-hard) reste correctement skippé.
+_RL_API_RE = re.compile(
+    # Imports explicites des SDK cloud (jamais en prose) — couvre `import openai`,
+    # `from openai import …`, `import anthropic`, `from anthropic import Anthropic`.
+    r"\b(?:from|import)\s+(?:openai|anthropic|replicate)\b"
+    # Appels dotted sur les modules (openai.ChatCompletion / openai.OpenAI /
+    # anthropic.Anthropic) — code réel, jamais de la prose.
+    r"|openai\.(?:ChatCompletion|OpenAI|chat)\b"
+    r"|anthropic\.(?:Anthropic|messages)\b"
+    # replicate.run(…) — appel explicite.
+    r"|replicate\.run\s*\(",
+    re.I,
+)
+
+
+def is_rl_cpu_pure(nb: dict) -> bool:
+    """True si notebook RL CPU-pur : pas de QuantBook, pas de GPU réel, pas d'appel
+    API cloud explicite.
+
+    Plus précise que `is_cpu_pure` pour RL : ignore le FP prose « openai »
+    (gym.openai.com, « jeux d'OpenAI ») qui n'est PAS un appel API. Gymnasium et
+    stable-baselines3 sont des libs locales CPU. Le signal GPU réel (`torch.cuda`,
+    `.cuda(`) est conservé (rl_6e GRPO = CUDA-hard → skippé).
+    """
+    if _uses_quantbook(nb):
+        return False
+    src = _source_text(nb)
+    if _GPU_RE.search(src):  # torch.cuda.is_available() etc. → GPU réel
+        return False
+    if _ACCOUNT_RE.search(src):  # token / env-var secret
+        return False
+    if _RL_API_RE.search(src):  # vrai appel API cloud (import/instance)
+        return False
+    return True
+
+
+def _rl_cpu_min_estimate(n_code: int) -> int:
+    """Heuristic cpu_min RL (minutes) : boucles d'entraînement pédagogiques sur petits
+    environnements (CartPole, timesteps 10-5000 = secondes à ~1 min sur CPU). Plus
+    élevé que search-cpu (entraînement itératif vs algo single-pass) : ≤12 → 2,
+    13-18 → 3, >18 → 4."""
+    if n_code <= 12:
+        return 2
+    if n_code <= 18:
+        return 3
+    return 4
+
+
+def build_rl_cpu_cost(nb: dict, by: str, today: str) -> dict:
+    """Bloc `metadata['cost']` canonique pour un notebook RL CPU-pur pédagogique.
+
+    Diffère de `build_search_cpu_cost` : `reproducibility: MED` (stochastique, seeds)
+    vs `HIGH` (déterministe) ; `cpu_min` via `_rl_cpu_min_estimate` (boucles
+    d'entraînement). `network: False` (gymnasium/torch/SB3 sont pip-installés en
+    local, aucun appel réseau au runtime). Champs notebook-specific
+    (`reduced_pedagogical`) : null (honnête, pas fabriqué).
+    """
+    n_code = _count_code_cells(nb)
+    return {
+        "api_usd_est": 0.0,  # gratuit, CPU local
+        "api_provider": "none",
+        "qcc_tokens_est": 0,  # non-QC
+        "cpu_min": _rl_cpu_min_estimate(n_code),  # heuristic entraînement
+        "gpu_min": 0,
+        "gpu_required": False,  # CPU OK pour petits envs RL
+        "vram_gb": 0,
+        "vram_tier": "NONE",
+        "network": False,  # pip install local, pas d'appel runtime
+        "external_account": "none",
+        "free_alternative": "self",  # sentinelle canonique : déjà gratuit
+        "reduced_pedagogical": None,  # notebook-specific (jugement humain) ; null = honnête
+        "reproducibility": "MED",  # stochastique (seeds), pas déterministe
+        "last_validated": today,  # date d'établissement de la metadata (inspection source)
+        "validator": "manual",  # inspection source, pas re-exécution machine claimée
+    }
+
+
 # --- Dispatch par profile -------------------------------------------------------
 # Chaque profile : (gate d'éligibilité, builder de cost, raison de skip si inéligible).
 # Uniformisation c.929 : eligible(nb, path) et build(nb, path, by, today) — `path` requis
@@ -363,6 +458,11 @@ PROFILES = {
         "eligible": _is_pymc_notebook,  # (nb, path) — subpath + import pymc/arviz
         "build": build_probas_cpu_cost,  # (nb, path, by, today) — index depuis path.name
         "skip_reason": "skipped-not-pymc",
+    },
+    "rl-cpu": {
+        "eligible": lambda nb, path: is_rl_cpu_pure(nb),  # (nb) — RL API usage via _RL_API_RE
+        "build": lambda nb, path, by, today: build_rl_cpu_cost(nb, by=by, today=today),
+        "skip_reason": "skipped-not-rl-cpu-pure",
     },
 }
 

--- a/scripts/audit/tests/test_populate_cost_metadata.py
+++ b/scripts/audit/tests/test_populate_cost_metadata.py
@@ -334,3 +334,131 @@ def test_search_cpu_preserves_cells(tmp_path):
     after = json.loads(p.read_text(encoding="utf-8"))
     assert after["metadata"]["custom_field"] == "keep"
     assert len(after["cells"]) == len(nb["cells"])
+
+
+# =============================================================================
+# Profile rl-cpu (RL CPU-pur — Issue #8056, rollout RL family)
+# =============================================================================
+
+def _make_rl_cpu(n_code: int = 10, gpu: bool = False) -> dict:
+    """Un notebook RL CPU-pur minimal (gymnasium/stable-baselines3), n cellules code.
+    Si `gpu=True`, ajoute un vrai signal GPU (torch.cuda) pour tester le skip."""
+    nb = {
+        "cells": [
+            {"cell_type": "markdown", "metadata": {},
+             "source": ["# RL demo (cf gym.openai.com/envs/#classic_control)\n"]},
+        ],
+        "metadata": {"kernelspec": {"name": "python3"}},
+        "nbformat": 4, "nbformat_minor": 5,
+    }
+    first = ("import torch\n"
+             f"print(torch.cuda.is_available())  # info\n") if gpu else "import gymnasium as gym\n"
+    nb["cells"].append({"cell_type": "code", "execution_count": 1, "metadata": {},
+                        "outputs": [], "source": [first]})
+    for _ in range(n_code - 1):
+        nb["cells"].append({"cell_type": "code", "execution_count": 1, "metadata": {},
+                            "outputs": [],
+                            "source": ["obs, info = env.reset(seed=0)\naction = policy(obs)\n"]})
+    return nb
+
+
+# === Gate is_rl_cpu_pure ===
+
+def test_is_rl_cpu_pure_true_for_local_rl():
+    """gymnasium/stable-baselines3 local = CPU-pur RL → éligible."""
+    assert pcm.is_rl_cpu_pure(_make_rl_cpu(10))
+
+
+def test_is_rl_cpu_pure_ignores_openai_prose_fp():
+    """FP prose critique (C920-L) : « gym.openai.com », « jeux d'OpenAI » ne sont PAS
+    des appels API cloud (gymnasium/SB3 = libs locales). Le gate précis ne doit PAS
+    skipper ces notebooks — sinon rl_1 (intro CartPole), rl_6c (PPO), rl_6d (SAC)
+    resteraient non couverts."""
+    assert pcm.is_rl_cpu_pure(_nb_with("env = gymnasium.make('CartPole-v1')  # voir gym.openai.com\n"))
+    assert pcm.is_rl_cpu_pure(_nb_with("# Inspiré de spinningup.openai.com — algorithme PPO from scratch.\n"))
+    assert pcm.is_rl_cpu_pure(_nb_with("PPO et SAC sont des algorithmes popularisés par OpenAI (Spinning Up).\n"))
+
+
+def test_is_rl_cpu_pure_false_for_quantbook():
+    assert not pcm.is_rl_cpu_pure(_make_quantbook(10))
+
+
+def test_is_rl_cpu_pure_false_for_real_gpu():
+    """Vrai signal GPU (`torch.cuda`, `.cuda(`) → skippé. Couvre rl_6e (GRPO, CUDA-hard)."""
+    assert not pcm.is_rl_cpu_pure(_make_rl_cpu(10, gpu=True))
+    assert not pcm.is_rl_cpu_pure(_nb_with("device = torch.device('cuda')\nx = x.cuda()\n"))
+
+
+def test_is_rl_cpu_pure_false_for_real_api_call():
+    """Un VRAI appel API cloud (import/instance OpenAI/anthropic/replicate) → skippé.
+    Le gate précis distingue l'appel réel de la prose (cf test ci-dessus)."""
+    assert not pcm.is_rl_cpu_pure(_nb_with("from openai import OpenAI\nclient = OpenAI()\n"))
+    assert not pcm.is_rl_cpu_pure(_nb_with("import openai\nr = openai.ChatCompletion.create()\n"))
+    assert not pcm.is_rl_cpu_pure(_nb_with("from anthropic import Anthropic\nclient = Anthropic()\n"))
+
+
+# === build_rl_cpu_cost ===
+
+def test_rl_cpu_cost_has_mandatory_fields():
+    cost = pcm.build_rl_cpu_cost(_make_rl_cpu(10), by="m:w", today="2026-07-28")
+    mandatory = {"api_usd_est", "api_provider", "cpu_min", "gpu_required",
+                 "network", "external_account", "reproducibility",
+                 "last_validated", "validator"}
+    assert mandatory <= set(cost)
+
+
+def test_rl_cpu_cost_canonical_values():
+    """RL CPU-pur : gratuit, CPU, network False (pip local). Diffère de search-cpu :
+    reproducibility MED (stochastique, seeds) vs HIGH (déterministe)."""
+    cost = pcm.build_rl_cpu_cost(_make_rl_cpu(10), by="m:w", today="2026-07-28")
+    assert cost["api_usd_est"] == 0.0
+    assert cost["api_provider"] == "none"
+    assert cost["qcc_tokens_est"] == 0
+    assert cost["gpu_required"] is False
+    assert cost["network"] is False  # pip install local, pas d'appel runtime
+    assert cost["external_account"] == "none"
+    assert cost["free_alternative"] == "self"  # sentinelle canonique
+    assert cost["reduced_pedagogical"] is None  # honnête, pas fabriqué
+    assert cost["reproducibility"] == "MED"  # stochastique (seeds), pas déterministe
+    assert cost["validator"] == "manual"
+
+
+def test_rl_cpu_cpu_min_heuristic():
+    """cpu_min RL plus élevé que search-cpu (boucles d'entraînement vs algo single-pass)."""
+    assert pcm.build_rl_cpu_cost(_make_rl_cpu(5), "", "")["cpu_min"] == 2    # ≤12
+    assert pcm.build_rl_cpu_cost(_make_rl_cpu(15), "", "")["cpu_min"] == 3   # 13-18
+    assert pcm.build_rl_cpu_cost(_make_rl_cpu(25), "", "")["cpu_min"] == 4   # >18
+
+
+# === Dispatch populate_notebook profile=rl-cpu ===
+
+def test_rl_cpu_populates_local_rl(tmp_path):
+    nb = _make_rl_cpu(10)
+    p = tmp_path / "nb.ipynb"
+    p.write_text(json.dumps(nb, indent=1), encoding="utf-8")
+    status = pcm.populate_notebook(p, profile="rl-cpu", by="m:w",
+                                   today="2026-07-28", apply=True)
+    assert status == "populated"
+    after = json.loads(p.read_text(encoding="utf-8"))
+    assert "cost" in after["metadata"]
+    assert after["metadata"]["cost"]["reproducibility"] == "MED"
+
+
+def test_rl_cpu_skips_gpu_notebook(tmp_path):
+    """rl_6e-style (CUDA-hard) → skippé avec la raison rl-cpu."""
+    nb = _make_rl_cpu(10, gpu=True)
+    p = tmp_path / "nb.ipynb"
+    p.write_text(json.dumps(nb, indent=1), encoding="utf-8")
+    status = pcm.populate_notebook(p, profile="rl-cpu", by="m:w",
+                                   today="2026-07-28", apply=True)
+    assert status == "skipped-not-rl-cpu-pure"
+
+
+def test_rl_cpu_idempotent(tmp_path):
+    nb = _make_rl_cpu(10)
+    nb["metadata"]["cost"] = {"existing": True}
+    p = tmp_path / "nb.ipynb"
+    p.write_text(json.dumps(nb, indent=1), encoding="utf-8")
+    status = pcm.populate_notebook(p, profile="rl-cpu", by="m:w",
+                                   today="2026-07-28", apply=True)
+    assert status == "skipped-has-cost"


### PR DESCRIPTION
Grain: MED/tooling — lane po-2023:CoursIA — recovery of a LOST merge (#8666)

## Anomalie détectée (c.947, firsthand G.1)

**#8666** `feat(rl,#8056): metadata.cost on 16 CPU RL notebooks + rl-cpu profile` est **GitHub-MERGED** (mergeCommit `4b0ef95b06`, 2026-07-28T13:06Z) mais son commit est **ABSENT de origin/main** :
- `git merge-base --is-ancestor 4b0ef95b06 origin/main` → NOT ancestor (fresh fetch).
- `git branch -a --contains 4b0ef95b06` → vide (reachable from NO branch — dangling).
- `git log -S '"cost"' -- RL/rl_1_intro_cartpole.ipynb` → vide (la string `"cost"` n'a JAMAIS été dans l'historique main du fichier).
- Conséquence : **0/17 notebooks RL** portent `metadata.cost` sur origin/main HEAD.

**Contrôle (5 PRs #8056 sœurs, toutes IN main)** : #8660 (Search) ✓ · #8658 (GameTheory) ✓ · #8687 (Sudoku) ✓ · #8697 (Search P1) ✓ · #8432 (CaseStudies) ✓. **Seule #8666 manque.** Les 20 PRs merged aujourd'hui (2026-07-29) sont aussi toutes in-main → l'anomalie est **isolée et historique** (2026-07-28), pas un force-push broad.

→ Évoque un merge perdu ou force-push/reset ciblé autour du 2026-07-28 13:06Z. **L'investigation git-history (reflog/force-push) reste à faire côté coordinateur ai-01** (droits `jsboige`) — c'est **orthogonal** à cette PR, qui ne fait que restaurer le contenu.

## Recovery (cette PR)

Cherry-pick du commit dangling `4b0ef95b06` (le travail original de po-2024, déjà reviewed+merged).

- **16 notebooks RL** : cost-metadata block appliqué tel quel (byte-identique à #8666).
- **`populate_cost_metadata.py`** : conflit dans le dict `PROFILES` résolu — `probas-cpu` (ajouté sur main entre-temps) et `rl-cpu` (#8666) **coexistent**.
- **`test_populate_cost_metadata.py`** : 128 lignes de tests, applé sans conflit.

### Bonus — fix d'un bug latent de signature

#8666 enregistrait rl-cpu **unwrap** : `eligible: is_rl_cpu_pure(nb)` (1-arg) et `build: build_rl_cpu_cost(nb,by,today)` (3-arg). Mais le dispatcher `PROFILES` appelle `eligible(nb, path)` (L11) et `build(nb, path, by=by, today=today)` (L18) → **aurait levé TypeError** à l'exécution via le dispatcher. Wrappé en lambdas, pattern identique à `quantbook`/`search-cpu` (L448-449). Si l'original fonctionnait (appels directs hors-PROFILES), le wrapper aussi ; sinon, bug corrigé.

## Validation

- `python -m pytest scripts/audit/tests/test_populate_cost_metadata.py` → **40 passed**.
- Dry-run `--profile rl-cpu` sur `RL/` → **16 populated, 1 skipped-not-rl-cpu-pure** (rl_6e GRPO = CUDA-hard, correctement exclu comme dans #8666).
- `rl_1_intro_cartpole` : `cost.gpu_required=False`, `validator=manual` ✓.
- `git diff --cached --stat` : 18 fichiers, **+500 / -0** (pure addition, recovery — aucune régression de contenu).

## Note coordinateur

- **Ne pas `Closes`** #8056 (epic cost-matrix reste ouvert — d'autres familles pending). `See #8056`.
- L'investigation du **pourquoi** #8666 fut perdu (force-push ? merge perdu ?) reste à faire par ai-01 — le commit `4b0ef95b06` étant dangling, l'historique reflog/main autour du 2026-07-28 13:06Z est à auditer. Cette PR restaure le **contenu** ; elle n'obscurcit pas l'investigation git-history.
- RooSync (dashboard + messages) était DOWN ce cycle (GDrive shared-state ENOENT) — ai-01 n'a pas pu être notifié par DM ; ce PR body documente l'anomalie pour traçabilité.

See #8056, #8666.
