### PR TITLE
feat(twin-register,#8057): register Sudoku metaheuristics tranche (3 pairs, semantic)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/sudoku-2-dancinglinks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-2-dancinglinks.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-2 DancingLinks"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-29"
+    by: po-2023:CoursIA
+    python_sha: d6cb4eb7b359606355dc84c25d7128497fc8fd37
+    csharp_sha: 48c7793a2ccd58db031eabde72efde66dd3c410d
+  known_differences:
+    - "Socle pedagogique commun : algorithme Dancing Links (DLX) de Knuth / Algorithm X pour la couverture exacte (exact cover), applique a un mini-Sudoku 4x4. Meme concept mathematique (matrice binaire de couverture, selection de colonnes a cardinalite minimale, unlinking/relinking des noeuds), meme cas d'application (mini-Sudoku 4x4), meme exercice pedagogique (construire la matrice de couverture, stub TODO)."
+    - "Divergence d'implementation : le C# delegue a la lib DlxLib (NuGet `#r \"nuget: DlxLib\"`, classe `DancingLinkSolver : ISudokuSolver` qui wrappe le solveur de la lib, importe le socle `Sudoku-0-Environment-Csharp.ipynb`) ; le Python implemente Dancing Links ENTIEREMENT from scratch (`class DancingLinksNode` a 4 voisins gauche/droite/haut/bas + `class DancingLinks` construisant la matrice creuse et executant l'Algorithm X de Knuth manuellement). Meme algorithme, deux niveaux d'abstraction : lib industrielle cote C# vs reconstruction pedagogique a la main cote Python."
+    - "Asymetrie structurelle : Python 12 cellules code / 21 markdown (implementation complete from scratch + docstring algorithmique detaillee) ; C# 10 cellules code / 16 markdown (wrapper DlxLib + exercice BuildMiniSudokuMatrix). Idiomes framework : C# = DlxLib + System.*, Python = stdlib (typing, dataclasses), 0 dependance numerique."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-3-genetic.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-3-genetic.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-3 Genetic"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-29"
+    by: po-2023:CoursIA
+    python_sha: cab27307b9ae093ac7bce95762ede96eb5753c09
+    csharp_sha: 22deefde347abceb07963a9a897a43f28d6228a3
+  known_differences:
+    - "Socle pedagogique commun : algorithme genetique (GA) applique au Sudoku -- population d'individus, selection, crossover, mutation, fonction de fitness (nombre de conflits). Meme concept evolutionnaire, meme cas d'application (resolution/amelioration d'une grille de Sudoku). Les deux exposent les memes primitives : Population, Crossover, Mutation, GeneticAlgorithm."
+    - "Divergence d'implementation : le C# delegue a la lib GeneticSharp (NuGet, expose GeneticAlgorithm/Population/Crossover/Mutation au niveau framework) ; le Python implemente le GA from scratch sur numpy (Population/Crossover/Mutation codes a la main, fitness a base de conflits). Meme paradigme genetique, deux niveaux d'abstraction : framework SOTA cote C# vs reconstruction pedagogique a la main cote Python."
+    - "Idiomes framework : C# = GeneticSharp (Nuget) + System.*, 13 cellules code ; Python = numpy (stdlib), 12 cellules code. Asymetrie attendue (lib dediee vs implmentation didactique), meme enseignement algorithmique sous-jacent."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-4-simulatedannealing.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-4-simulatedannealing.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-4 SimulatedAnnealing"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-29"
+    by: po-2023:CoursIA
+    python_sha: ccc89ffe014c757290777cecad5870c3d0a83b04
+    csharp_sha: 880f25e068bfb9a01f0336b32f6a9969977cb216
+  known_differences:
+    - "Socle pedagogique commun : recuit simule (Simulated Annealing) applique au Sudoku -- schema de refroidissement (cooling schedule), temperature T decroissante, acceptation de Metropolis (accepter une solution pire avec probabilite exp(-delta/T)), voisinage par mutation locale. Meme algorithme, meme cas d'application (optimisation stochastique d'une grille)."
+    - "Implementation from scratch des deux cotes (ni lib dediee C# ni framework Python) : le C# est pur stdlib System.* (0 NuGet, 17 cellules code) ; le Python utilise numpy/math/random (19 cellules code). Les deux codent le schedule de temperature, la mutation et le critere d'acceptation de Metropolis manuellement -- c'est la paire la plus proche d'une traduction native, mais les 2 implementations restent independantes (idiomes langage, structures de donnees), d'ou parity_level semantic et non native-both."
+    - "Idiomes framework : C# = pur System.* (System / System.Collections.Generic / System.Linq), 0 NuGet, 17 cellules code ; Python = numpy + math + random, 19 cellules code. Meme enseignement (Metropolis + cooling), sorties attendues similaires (convergence de la fitness)."


### PR DESCRIPTION
Grain: MED/tooling — lane po-2023:CoursIA — twin registry tranche (3 pairs Sudoku metaheuristics)

## Scope

Enregistre 3 paires Python<->C# de la serie Sudoku dans le registre de parite formel (#8057), les rendant visibles au gate de derive (`check_twin_parity.py`). Ces paires etaient identifiees comme **UNREGISTERED** par le coverage scan de #8684 mais non encore declarees.

## Audit firsthand (parity_level = semantic pour les 3)

Chaque paire auditee firsthand (Read des deux notebooks) avant enregistrement, protocole `_schema.yaml` respecte (jamais en masse) :

| Paire | C# | Python | parity_level |
|---|---|---|---|
| **Sudoku-2 DancingLinks** | delegue a `DlxLib` (NuGet wrapper, `DancingLinkSolver : ISudokuSolver`) | Algorithm X de Knuth **from scratch** (`DancingLinksNode` a 4 voisins + `DancingLinks`) | semantic |
| **Sudoku-3 Genetic** | delegue a `GeneticSharp` (framework) | GA **from scratch** sur numpy (Population/Crossover/Mutation manuels) | semantic |
| **Sudoku-4 SimulatedAnnealing** | pur `System.*` (0 NuGet, from scratch) | numpy/math/random (from scratch) | semantic |

`semantic` = meme contenu mathematique/conceptuel, API idiomatique differente (def `_schema.yaml`). C#/Python couvrent le meme algorithme metaheuristique sur le meme cas (Sudoku), mais C# delegue aux libs framework (DlxLib/GeneticSharp) tandis que Python implemente from scratch — divergence pedagogique deliberate.

## Lecon : typo SHA manuelle -> DRIFT fantome

J'ai d'abord ecrit les SHAs a la main. Une **typo d'un seul caractere** sur Sudoku-4 csharp (`1f0376` au lieu de `1f0336`) a provoque un DRIFT fantome (`880f25e0 -> 880f25e0`, invisible dans l'affichage tronque). Corrige apres diagnostic `--json` (comparaison exacte recorded vs current). **Confirme la recommandation `_schema.yaml`** : preferer `--update` canonique a l'ecriture manuelle des SHAs. Retenu pour les prochaines tranches.

## Validation

- `check_twin_parity.py --check` : **140 paires, OK=140, DRIFT=0, MISSING=0** (avant : 137 paires).
- `check_twin_parity.py --coverage` : **19 -> 16** paires hors registre (les 3 declarees ne sont plus UNREGISTERED).
- `pytest test_twin_registry_integrity.py` : **11 passed**.

## Notes

- `See #8057` (epic reste ouvert — 16 paires encore hors registre sur d'autres familles).
- `See #8684` (coverage scan source), `See #8642` (precedent tranche Search T1).
- 3 nouveaux fichiers `twin_pairs.d/` (file-per-entry, convention du registre). 0 modification de notebooks — pure declaration de metadonnee.

See #8057.
