### PR TITLE
fix(notebook_tools,#8858): SKIP_DIRS filter relative-to-root in 3 more detectors (audit_c1_c3, scan_cell_ordering, forensic_scan)

### DIFF
--- a/scripts/notebook_tools/audit_c1_c3.py
+++ b/scripts/notebook_tools/audit_c1_c3.py
@@ -68,7 +68,19 @@ def find_notebooks(family: str | None = None) -> list[Path]:
     if not root.exists():
         return []
     for p in root.rglob("*.ipynb"):
-        if any(part in EXCLUDE_DIRS for part in p.parts):
+        # #8858-class guard: ``root.rglob`` yields ABSOLUTE paths, so
+        # filtering on ``p.parts`` (absolute components) would match the
+        # repo's own parent if it sits under an EXCLUDE_DIRS-name dir (e.g.
+        # a checkout cloned at ``archive/repo/``). That matches EVERY path
+        # and silences the whole scan — worse than a false positive for a
+        # C.1 compliance gate. Filter on the path RELATIVE to ``root``
+        # (the in-repo SKIP_DIRS semantics), with a fallback to ``p.parts``
+        # when ``p`` is not under ``root``.
+        try:
+            rel_parts = p.relative_to(root).parts
+        except ValueError:
+            rel_parts = p.parts
+        if any(part in EXCLUDE_DIRS for part in rel_parts):
             continue
         notebooks.append(p)
     return sorted(notebooks)

--- a/scripts/notebook_tools/forensic_scan.py
+++ b/scripts/notebook_tools/forensic_scan.py
@@ -132,6 +132,24 @@ def get_series(path: Path, root: Path) -> str:
     return rel[0] if len(rel) > 1 else "TOP"
 
 
+def collect_notebooks(root: Path) -> list[Path]:
+    """All non-excluded ``*.ipynb`` under ``root``, sorted.
+
+    Extracted from ``main`` so the discovery logic (and its SKIP_DIRS
+    filtering) is unit-testable without invoking the full CLI.
+
+    #8858-class guard: ``is_excluded`` receives the path RELATIVE to
+    ``root`` (matching its relative-path semantics), not the absolute
+    rglob path — otherwise a skip-name component in the repo's ABSOLUTE
+    parent (e.g. a checkout cloned under ``_archives/``) would silence the
+    whole forensic scan.
+    """
+    return sorted(
+        p for p in root.rglob("*.ipynb")
+        if not is_excluded(p.relative_to(root))
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--root", default="MyIA.AI.Notebooks", help="Notebook root")
@@ -151,7 +169,7 @@ def main() -> int:
         print(f"ERROR: root {root} does not exist", file=sys.stderr)
         return 1
 
-    notebooks = sorted(p for p in root.rglob("*.ipynb") if not is_excluded(p))
+    notebooks = collect_notebooks(root)
     print(f"Scanning {len(notebooks)} notebooks under {root}", file=sys.stderr)
 
     results = []

--- a/scripts/notebook_tools/scan_cell_ordering.py
+++ b/scripts/notebook_tools/scan_cell_ordering.py
@@ -113,7 +113,19 @@ def find_notebooks(family: str | None = None) -> list[Path]:
         return []
     out = []
     for p in root.rglob("*.ipynb"):
-        if any(part in EXCLUDE_DIRS for part in p.parts):
+        # #8858-class guard: ``root.rglob`` yields ABSOLUTE paths, so
+        # filtering on ``p.parts`` (absolute components) would match the
+        # repo's own parent if it sits under an EXCLUDE_DIRS-name dir (e.g.
+        # a checkout cloned at ``archive/repo/``). That matches EVERY path
+        # and silences the whole scan — worse than a false positive for a
+        # cell-ordering CI guard. Filter on the path RELATIVE to ``root``
+        # (the in-repo SKIP_DIRS semantics), with a fallback to ``p.parts``
+        # when ``p`` is not under ``root``.
+        try:
+            rel_parts = p.relative_to(root).parts
+        except ValueError:
+            rel_parts = p.parts
+        if any(part in EXCLUDE_DIRS for part in rel_parts):
             continue
         out.append(p)
     return sorted(out)

--- a/scripts/notebook_tools/tests/test_audit_c1_c3.py
+++ b/scripts/notebook_tools/tests/test_audit_c1_c3.py
@@ -453,3 +453,27 @@ class TestMainCLI:
             output = capsys.readouterr().out
             assert "Family" in output
             assert "Total" in output
+
+
+# ---------------------------------------------------------------------------
+# find_notebooks SKIP_DIRS guard (#8858-class)
+# ---------------------------------------------------------------------------
+
+class TestFindNotebooksSkipdirParent:
+    """``find_notebooks`` must NOT be silenced when the repo is cloned under
+    a parent whose name is in ``EXCLUDE_DIRS``.
+
+    ``NOTEBOOKS_DIR`` is absolute and ``find_notebooks`` walks it with
+    ``root.rglob`` (absolute paths), then filters ``EXCLUDE_DIRS`` on
+    ``p.parts`` (absolute components). A checkout cloned under e.g.
+    ``archive/`` would match every path and silence the whole scan — worse
+    than a false positive for a C.1 compliance gate.
+    """
+
+    def test_find_notebooks_under_archive_parent_not_silenced(self, tmp_path):
+        nb_root = tmp_path / "archive" / "repo" / "MyIA.AI.Notebooks"
+        nb_root.mkdir(parents=True)
+        (nb_root / "nb.ipynb").write_text("{}", encoding="utf-8")
+        with patch("audit_c1_c3.NOTEBOOKS_DIR", nb_root):
+            found = find_notebooks()
+        assert [p.name for p in found] == ["nb.ipynb"]

--- a/scripts/notebook_tools/tests/test_forensic_scan.py
+++ b/scripts/notebook_tools/tests/test_forensic_scan.py
@@ -15,6 +15,7 @@ from forensic_scan import (
     EXCLUDE_DIRS,
     RULE_C2_DATE,
     categorize_notebook,
+    collect_notebooks,
     get_series,
     is_excluded,
 )
@@ -168,6 +169,43 @@ class TestIsExcluded:
 
     def test_old_dir(self):
         assert is_excluded(Path("_old/legacy.ipynb")) is True
+
+
+# ---------------------------------------------------------------------------
+# collect_notebooks SKIP_DIRS guard (#8858-class)
+# ---------------------------------------------------------------------------
+
+class TestCollectNotebooksSkipdirParent:
+    """``collect_notebooks`` must NOT be silenced when the scan root sits
+    under a parent whose name is in ``EXCLUDE_DIRS``.
+
+    ``main`` resolves an absolute ``root`` and used to pass absolute rglob
+    paths to ``is_excluded``, which checks ``path.parts`` (absolute
+    components). A checkout cloned under e.g. ``archive/`` would match
+    every path and silence the whole forensic scan. The fix passes the
+    path RELATIVE to ``root`` (matching ``is_excluded``'s relative-path
+    semantics exercised by ``TestIsExcluded`` above).
+    """
+
+    def test_collect_under_archives_parent_not_silenced(self, tmp_path):
+        nb_root = tmp_path / "_archives" / "repo" / "MyIA.AI.Notebooks"
+        nb_root.mkdir(parents=True)
+        (nb_root / "nb.ipynb").write_text("{}", encoding="utf-8")
+        found = collect_notebooks(nb_root)
+        assert [p.name for p in found] == ["nb.ipynb"]
+
+    def test_collect_still_skips_in_repo_archives_dir(self, tmp_path):
+        """A legit in-repo ``_archives/`` subdir IS still skipped (the fix
+        must not weaken real SKIP_DIRS filtering)."""
+        nb_root = tmp_path / "MyIA.AI.Notebooks"
+        (nb_root / "good").mkdir(parents=True)
+        (nb_root / "good" / "keep.ipynb").write_text("{}", encoding="utf-8")
+        (nb_root / "_archives").mkdir()
+        (nb_root / "_archives" / "hide.ipynb").write_text("{}", encoding="utf-8")
+        found = collect_notebooks(nb_root)
+        names = [p.name for p in found]
+        assert "keep.ipynb" in names
+        assert "hide.ipynb" not in names
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/notebook_tools/tests/test_scan_cell_ordering.py
+++ b/scripts/notebook_tools/tests/test_scan_cell_ordering.py
@@ -9,6 +9,7 @@ backwards jumps must be flagged HIGH.
 import json
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from scan_cell_ordering import (  # noqa: E402
@@ -19,6 +20,7 @@ from scan_cell_ordering import (  # noqa: E402
     scan_enchainement,
     scan_consecutive_code,
     scan_notebook,
+    find_notebooks,
 )
 
 
@@ -237,3 +239,28 @@ class TestScanNotebook:
         result = scan_notebook(p)
         assert "error" in result
         assert result["findings"] == []
+
+
+# ---------------------------------------------------------------------------
+# find_notebooks SKIP_DIRS guard (#8858-class)
+# ---------------------------------------------------------------------------
+
+class TestFindNotebooksSkipdirParent:
+    """``find_notebooks`` must NOT be silenced when the repo is cloned under
+    a parent whose name is in ``EXCLUDE_DIRS``.
+
+    ``NOTEBOOKS_DIR`` is absolute and ``find_notebooks`` walks it with
+    ``root.rglob`` (absolute paths), then filters ``EXCLUDE_DIRS`` on
+    ``p.parts`` (absolute components). A checkout cloned under e.g.
+    ``archive/`` would match every path and silence the whole scan — worse
+    than a false positive for a cell-ordering CI guard.
+    """
+
+    def test_find_notebooks_under_archive_parent_not_silenced(self, tmp_path):
+        import scan_cell_ordering as sco
+        nb_root = tmp_path / "archive" / "repo" / "MyIA.AI.Notebooks"
+        nb_root.mkdir(parents=True)
+        (nb_root / "nb.ipynb").write_text("{}", encoding="utf-8")
+        with patch.object(sco, "NOTEBOOKS_DIR", nb_root):
+            found = sco.find_notebooks()
+        assert [p.name for p in found] == ["nb.ipynb"]


### PR DESCRIPTION
## What

Three more notebook detectors had the same **`#8858`-class bug** already fixed for the papermill detectors (#8865) and `detect_cjk_residue` (#8859): they walk an absolute `root` with `root.rglob` and filter `SKIP_DIRS` on the **absolute** path components (`p.parts`). A repository cloned under a parent whose name is in the skip set (e.g. `archive/`, `_archives/`) then matches **every** path and the scan returns **zero notebooks** — a total silent silence, indistinguishable from a clean tree.

This is the **bug-family completion** for that class (cf C943-L2: "bug-de-famille = même remède"). After #8859 and #8865, a targeted sweep found three more live instances in CI-relevant guards.

Affected files:

- `scripts/notebook_tools/audit_c1_c3.py` — `find_notebooks`, the **C.1 compliance gate**. A silenced scan reports "0 C.1 violations" on a dirty tree — the gate fails open.
- `scripts/notebook_tools/scan_cell_ordering.py` — `find_notebooks` (same idiom, *"same convention as audit_c1_c3.py"*); the **cell-ordering CI guard**.
- `scripts/notebook_tools/forensic_scan.py` — the inline notebook collection in `main` passed absolute rglob paths to `is_excluded`, which checks `path.parts`. Extracted into a unit-testable `collect_notebooks(root)` helper that passes the path **relative to `root`** (matching `is_excluded`'s relative-path semantics already exercised by `TestIsExcluded`).

## Why it matters

A guard that wrongly *accuses* gets noticed and disabled (the #8846 failure mode). A guard that wrongly *stays silent* is never caught — it reads as "all compliant" while violations slip through. These three detectors are CI guards, so a silenced scan is the worse defect.

`archive` is a common clone-dir name for backups/CI; `_archives` is the repo's own convention. Cloning the repo under either (or running the detectors from such a location) triggers the silence.

## Fix

Filter on the path **relative to `root`** (the in-repo SKIP_DIRS semantics), with an `except ValueError` fallback to `p.parts` — same shape as #8859/#8865:

```python
for p in root.rglob("*.ipynb"):
    try:
        rel_parts = p.relative_to(root).parts
    except ValueError:
        rel_parts = p.parts
    if any(part in EXCLUDE_DIRS for part in rel_parts):
        continue
    ...
```

For `forensic_scan`, the collection was inline in `main()`; extracting `collect_notebooks(root)` makes the (now-correct) discovery logic unit-testable without invoking the full CLI. `is_excluded` itself is unchanged — its existing relative-path tests in `TestIsExcluded` remain valid.

## Acceptance (#8858-style: RED on buggy, GREEN on fixed)

One new regression test per detector — a repo under an `archive/` (audit_c1_c3, scan_cell_ordering) or `_archives/` (forensic_scan) parent with one notebook inside, asserting the scan still finds it:

| detector | new test | buggy→fixed |
|---|---|---|
| `audit_c1_c3` | `TestFindNotebooksSkipdirParent::test_find_notebooks_under_archive_parent_not_silenced` | RED→GREEN |
| `scan_cell_ordering` | `TestFindNotebooksSkipdirParent::test_find_notebooks_under_archive_parent_not_silenced` | RED→GREEN |
| `forensic_scan` | `TestCollectNotebooksSkipdirParent::test_collect_under_archives_parent_not_silenced` | RED→GREEN |
| `forensic_scan` | `TestCollectNotebooksSkipdirParent::test_collect_still_skips_in_repo_archives_dir` | GREEN (in-repo `_archives/` subdir still skipped — fix does not weaken real filtering) |

- **RED on buggy**: all three silence tests fail (scan returns `[]`).
- **GREEN on fixed**: all pass.
- **No regression**: full suites = **101 passed** (audit_c1_c3 + scan_cell_ordering + forensic_scan); `test_cell_order_ci.py` = 12 passed.

## Scope

- Calibre: `LIGHT/guard`. 3 detectors × (relative-to-root guard replacing the absolute `p.parts` line) + `forensic_scan` `collect_notebooks` extraction + 4 pure-add regression tests = **6 files, +134/−3**.
- The `−3` are the three old absolute-`p.parts` filter lines (and the old inline `notebooks = sorted(...)` in forensic_scan) being replaced by the relative-to-root guard. No content removed elsewhere.
- Pathspec commit (`git commit -- <6 paths>`) — verified `git show --stat HEAD` shows only the 6 intended files, 0 sparse-deletion leakage.

See #8858
See #8859
See #8865

lane: myia-po-2024:CoursIA-2
Grain: LIGHT/guard
