### PR TITLE
feat(twin-register,#8057): register GameTheory tranche (3 pairs, semantic)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/gametheory-15c-cooperativegames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-15c-cooperativegames.yaml
@@ -1,0 +1,14 @@
+- name: "GameTheory-15c CooperativeGames"
+  family: GameTheory
+  python: MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
+  csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-29"
+    by: po-2023:CoursIA
+    python_sha: 1573791a1d0795c8480cffbd0660c6a0df9bf9cf
+    csharp_sha: 2b5ecf27a189d00765e6f80edf7c48eb10372cfe
+  known_differences:
+    - "Socle pedagogique commun : jeux cooperatifs a utilite transferable (TU) -- valeur de Shapley (formule axiomatique, calcul sur permutations), le core (stabilite, imputations), coalitions. Meme concept mathematique (Shapley value phi_i = somme sur permutations, core comme polytope des imputations stables), meme cas d'application (repartition de gains cooperatifs). Les deux couvrent Shapley, core, Coalition."
+    - "Divergence d'implementation : le Python (numpy + scipy + matplotlib, 18 cellules code) calcule les valeurs de Shapley et visualise le core (polytope, extremites) ; le C# (pur System.* stdlib, 0 NuGet, 15 cellules code) implemente le calcul de Shapley (iteration sur permutations) et la verification d'appartenance au core sans libs numeriques. Meme theoreme, deux angles : numerique+visualisation cote Python vs implementation constructive cote C#."
+    - "Idiomes framework : Python = numpy + scipy + matplotlib, 18 cellules code ; C# = pur System.* (System / System.Linq), 0 NuGet, 15 cellules code. Asymetrie attendue (le C# evite les libs numeriques/scientifiques), meme enseignement sous-jacent (Shapley axiomatique + core)."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-4c-nashexistence.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-4c-nashexistence.yaml
@@ -1,0 +1,14 @@
+- name: "GameTheory-4c NashExistence"
+  family: GameTheory
+  python: MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
+  csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-29"
+    by: po-2023:CoursIA
+    python_sha: 66a89d9abf5e268c7abca2b8b141c556258b9146
+    csharp_sha: ca1c73ac33c1ffbec1f99ba3a60da33bce3cfea1
+  known_differences:
+    - "Socle pedagogique commun : existence d'un equilibre de Nash (theoreme de point fixe de Brouwer / Kakutani), structure de jeu et conditions d'existence. Meme concept mathematique (equilibre, point fixe, convexite), meme cas d'application (jeux strategiques, illustration de l'existence). Les deux couvrent le theoreme de Nash."
+    - "Divergence d'implementation : le Python (numpy + matplotlib, 15 cellules code) calcule et visualise numeriquement les equilibres (support enumeration / approche numerique + tracé du best-response correspondence) ; le C# (pur System.* stdlib, 0 NuGet, 10 cellules code) demontre l'existence de maniere constructive/algebrique (sans solveur numerique externe). Meme theoreme, deux angles : numerique+visualisation cote Python vs construction algebrique cote C#."
+    - "Idiomes framework : Python = numpy + matplotlib, 15 cellules code ; C# = pur System.* (System / System.Linq), 0 NuGet, 10 cellules code. Asymetrie attendue (le C# evite les libs numeriques pour rester constructif), meme enseignement (point fixe de Brouwer -> existence)."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-8c-combinatorialgames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-8c-combinatorialgames.yaml
@@ -1,0 +1,14 @@
+- name: "GameTheory-8c CombinatorialGames"
+  family: GameTheory
+  python: MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Python.ipynb
+  csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-29"
+    by: po-2023:CoursIA
+    python_sha: cddabe42e47d1258f444f3019bd5876407d59bee
+    csharp_sha: b0ecb44cd66eceae27918eb02ab60f1f02a7661a
+  known_differences:
+    - "Socle pedagogique commun : theorie des jeux combinatoires (Sprague-Grundy, nombres de Grundy, theoreme de Sprague-Grundy sur la somme de jeux, Nim et sa strategie gagnante XOR des tas). Meme concept mathematique (fonction de Grundy/g(x), XOR nim-sum, jeux impartiaux a information complete), meme cas canonique (Nim). Les deux couvrent Nim, Sprague, Grundy."
+    - "Divergence d'implementation : le Python (numpy + matplotlib, 14 cellules code) implemente les nombres de Grundy et le XOR nim-sum avec visualisation (graphe de jeu, table de Grundy) ; le C# (pur System.* stdlib, 0 NuGet, 14 cellules code) implemente la meme logique combinatoire (Sprague-Grundy, nim-sum) sans dependance numerique. Meme theoreme, meme contenu algorithmique, sorties differentes (visualisation Python vs sorties texte/table C#)."
+    - "Idiomes framework : Python = numpy + matplotlib, 14 cellules code ; C# = pur System.* (System / System.Linq), 0 NuGet, 14 cellules code. Paire proche d'une traduction native (meme contenu algorithmique), mais les 2 implementations restent independantes (idiomes langage, structures de donnees, visualisation), d'ou parity_level semantic et non native-both."


### PR DESCRIPTION
Grain: MED/tooling — lane po-2023:CoursIA — twin registry GameTheory tranche (suite #8870, rotation famille)

## Scope

Suite de #8870 (Sudoku metaheuristics). Enregistre 3 paires Python<->C# de **GameTheory** dans le registre formel (#8057), les retirant du coverage UNREGISTERED. Pivot de famille (rotation R6) : Sudoku -> GameTheory.

## Audit firsthand (parity_level = semantic pour les 3)

| Paire | C# | Python | Concept commun |
|---|---|---|---|
| **GT-4c NashExistence** | pur `System.*` (point fixe de Brouwer constructif) | numpy+matplotlib (équilibre numérique + best-response visualisé) | théorème de Nash |
| **GT-8c CombinatorialGames** | pur `System.*` (Grundy + nim-sum XOR) | numpy+matplotlib (idem + visualisation graphe/table) | Sprague-Grundy, Nim |
| **GT-15c CooperativeGames** | pur `System.*` (Shapley sur permutations + core constructif) | numpy+scipy+matplotlib (Shapley + core polytope visualisé) | Shapley value, core |

`semantic` = même contenu mathématique, API idiomatique différente. Pattern cohérent des familles précédentes : le C# évite systématiquement les libs numériques pour rester constructif (0 NuGet), le Python numérise + visualise.

## Validation

- `check_twin_parity.py --check` : **143 paires, OK=143, DRIFT=0, MISSING=0** (avant : 140).
- `check_twin_parity.py --coverage` : **16 -> 13** paires hors registre.
- `pytest test_twin_registry_integrity.py` : **11 passed**.

## Note leçon

La typo SHA du cycle c.948 (DRIFT fantôme `880f25e0 -> 880f25e0`) ne s'est pas reproduite — la validation `--check` systématique post-écriture la détecterait. 3 nouveaux fichiers `twin_pairs.d/` (file-per-entry), 0 modification de notebooks.

See #8057, #8870 (Sudoku precedent), #8506 (GT-14..17 precedent).
