### PR TITLE
feat(twin-register,#8057): register Sudoku CSP/PSO tranche (3 pairs, semantic)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/sudoku-5-pso.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-5-pso.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-5 PSO"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-29"
+    by: po-2023:CoursIA
+    python_sha: 5716acbae4da766db672ff195e19b68e4668066b
+    csharp_sha: b5353084166e7e045dbaf93ab9e79a0944e6b8bb
+  known_differences:
+    - "Socle pedagogique commun : optimisation par essaim de particules (Particle Swarm Optimization) appliquee au Sudoku -- population de particules, vecteurs position/vitesse, update via best personnel (pbest) et global (gbest), fonction de fitness (conflits Sudoku). Meme algorithme, meme cas d'application (optimisation stochastique d'une grille)."
+    - "Divergence d'implementation : le Python (numpy + matplotlib, 15 cellules code) implemente le PSO avec visualisation (convergence de la fitness, trajectoires de l'essaim) ; le C# (pur System.* stdlib, 0 NuGet, 13 cellules code) implemente le PSO from scratch sans visualisation (sorties texte). Meme algorithme, deux angles : numerique+visualisation cote Python vs implementation pedagogique cote C#."
+    - "Idiomes framework : Python = numpy + matplotlib, 15 cellules code ; C# = pur System.* (System / System.Collections.Generic / System.Linq), 0 NuGet, 13 cellules code. Asymetrie attendue (le C# evite les libs numeriques), meme enseignement algorithmique (pbest/gbest + update de vitesse)."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-6-aima-csp.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-6-aima-csp.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-6 AIMA-CSP"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-29"
+    by: po-2023:CoursIA
+    python_sha: 57feaad6b90cec840a4ac63971f44eb12ea0ade0
+    csharp_sha: d8696f90ac42c47b53ded32401117e89fad5098f
+  known_differences:
+    - "Socle pedagogique commun : resolution de Sudoku comme probleme de satisfaction de contraintes (CSP), suivant le formalisme AIMA (Artificial Intelligence: A Modern Approach) -- AC-3 (arc consistency / propagation de contraintes), backtracking avec heuristiques (MRV, LCV), assign/eliminate (Norvig-style propagation). Meme concept mathematique (variables, domaines, contraintes binaires, arc consistency), meme cas canonique (Sudoku). Les deux couvrent AC3, backtracking, Norvig, AIMA, csp."
+    - "Divergence d'implementation : le Python (numpy, 19 cellules code) implemente le framework CSP a la AIMA (classe CSP, AC-3, backtracking) ; le C# (pur System.* stdlib, 0 NuGet, 18 cellules code) implemente le meme framework CSP (AC-3, backtracking, assign/eliminate) sans dependance externe. Paire proche d'une traduction native (meme algorithmes, meme structure AIMA), mais les 2 implementations restent independantes (idiomes langage, structures de donnees), d'ou parity_level semantic et non native-both."
+    - "Idiomes framework : Python = numpy, 19 cellules code ; C# = pur System.* (System / System.Collections.Generic / System.Linq), 0 NuGet, 18 cellules code. Meme enseignement (CSP AIMA + AC-3 + backtracking), implementations independantes."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-7-norvig.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-7-norvig.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-7 Norvig"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-29"
+    by: po-2023:CoursIA
+    python_sha: ce921ebb2f887ed7e353cfc7765fdbf56d2a87bc
+    csharp_sha: 021b1e42569256cc6dd8b4ce51fc110be9328e4d
+  known_differences:
+    - "Socle pedagogique commun : solveur de Sudoku de Peter Norvig (combinaison de constraint propagation + search) -- fonctions assign (assigner une valeur en eliminant des candidats) et eliminate (propager les contraintes via les unites/peers), backtracking search quand la propagation seule ne suffit pas. Meme algorithme (Norvig's solver), meme cas canonique (Sudoku). Les deux couvrent backtracking, Norvig, eliminate, assign."
+    - "Implementation from scratch des deux cotes (NI lib dediee C# NI framework Python) : le C# est pur stdlib System.* (0 NuGet, 15 cellules code) ; le Python est aussi pur stdlib (0 numpy, 12 cellules code). C'est la paire la plus proche d'une traduction native : les deux codent assign/eliminate/search manuellement selon l'algorithme de Norvig. Mais les 2 implementations restent independantes (idiomes langage : dict/sets cote Python vs Dictionary/HashSet cote C#), d'ou parity_level semantic et non native-both."
+    - "Idiomes framework : C# = pur System.* (System / System.Collections.Generic / System.Linq), 0 NuGet, 15 cellules code ; Python = pur stdlib (0 dependance numerique), 12 cellules code. Meme algorithme de Norvig, implementations didactiques independantes des deux cotes."


### PR DESCRIPTION
Grain: MED/tooling — lane po-2023:CoursIA — twin registry Sudoku CSP/PSO tranche

## Scope

Enregistre 3 paires Python<->C# de Sudoku (CSP + metaheuristique PSO) dans le registre formel (#8057). Suite de #8870 (Sudoku metaheuristics) et parallèle à #8873 (GameTheory).

## Audit firsthand (parity_level = semantic pour les 3)

| Paire | C# | Python | Concept commun |
|---|---|---|---|
| **Sudoku-5 PSO** | pur `System.*` (PSO from scratch) | numpy+matplotlib (essaim + convergence visualisée) | Particle Swarm Optimization |
| **Sudoku-6 AIMA-CSP** | pur `System.*` (framework CSP AIMA : AC-3, backtracking, assign/eliminate) | numpy (idem) | CSP AIMA + AC-3 |
| **Sudoku-7 Norvig** | pur `System.*` (0 NuGet) | pur stdlib (0 numpy) | Solveur de Norvig (assign/eliminate/search) |

`semantic` = même algorithme, API idiomatique différente. **Sudoku-7 Norvig** est la paire la plus proche d'une traduction native (les deux from scratch, solveur de Norvig), mais idiomes langage différents → semantic non native-both. **Sudoku-6 AIMA-CSP** couvre le même framework CSP (AC-3, backtracking) des deux côtés.

## Validation

- `check_twin_parity.py --check` : **143 paires** (sur cette branche : 140 baseline + 3) , OK=143, DRIFT=0, MISSING=0.
- `check_twin_parity.py --coverage` : contribution à la réduction des paires hors registre.
- `pytest test_twin_registry_integrity.py` : **11 passed**.

## Note

- Branche séparée (`feature/cycle949-sudoku-csp`) — je n'ai pas poussé ce commit sur `feature/cycle949` (#8873 GameTheory reste atomique : 1 sujet = 1 PR, cf catalog-pr-hygiene HARD 3).
- 3 nouveaux fichiers `twin_pairs.d/`, 0 modification de notebooks.

See #8057, #8870, #8873.
