### PR TITLE
feat(twin-register,#8057): register Sudoku CP/SMT tranche (3 pairs, semantic, #8866-immune)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/sudoku-11-choco.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-11-choco.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-11 Choco"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-29"
+    by: po-2023:CoursIA
+    python_sha: eb91329e04c6173dbaa8904e2b7e9574bb4817fb
+    csharp_sha: b1cedb474514fc7a8afdf87594c5fc229b6f4c0c
+  known_differences:
+    - "Socle pedagogique commun : resolution de Sudoku par programmation par contraintes (CP) avec le solveur Choco -- modelisation (variables, domaines, contraintes), propagation, recherche. Meme solveur (Choco), meme cas d'application (Sudoku). Les deux couvrent Choco, choco, Solver."
+    - "Divergence d'implementation : le C# accede a Choco via IKVM (bridge Java->.NET, NuGet IKVM 8.15.0 + IKVM.Image) -- Choco etant une lib Java, le C# la consomme a travers le runtime IKVM ; le Python (pur stdlib, 0 dependance Choco) implemente un solveur CP a la Choco from scratch (propagation, recherche). Meme paradigme CP, deux niveaux : le C# wrappe le vrai Choco via IKVM (RECOVERABLE-MACHINE per SOTA ledger Entry #008 : IKVM instable dans dotnet-interactive), le Python reconstruit la logique CP didactiquement."
+    - "Idiomes framework : C# = IKVM + Choco (Java lib via bridge) + System.*, 12 cellules code ; Python = pur stdlib (0 dependance), 13 cellules code. Asymetrie pedagogique (vrai Choco cote C# vs reconstruction cote Python), meme enseignement CP sous-jacent."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-12-z3.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-12-z3.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-12 Z3"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-29"
+    by: po-2023:CoursIA
+    python_sha: 2e25dae8e9b743238c2aeb1bf8ad45ef9d916e24
+    csharp_sha: 8d3b07ab2b79096fca427c6c3781091c9de88ce8
+  known_differences:
+    - "Socle pedagogique commun : resolution de Sudoku par SMT (Satisfiability Modulo Theories) avec le vrai solveur Z3 (Microsoft Research) -- modelisation des contraintes Sudoku comme formules logiques (BitVec, contraintes all-different sur lignes/colonnes/carres), resolution par le solveur SMT. Les deux cotes utilisent le VRAI Z3 SOTA (meme moteur sous-jacent), meme cas d'application (Sudoku). Les deux couvrent Z3, z3, BitVec, Solver."
+    - "Divergence de binding : le C# accede a Z3 via Microsoft.Z3 (NuGet, bindings .NET natifs, 19 cellules code) ; le Python accede a Z3 via pyz3 (import z3, bindings Python, 11 cellules). C'est le meme solveur Z3 avec deux bindings idiomatiques -- c'est la definition meme de parity_level semantic (meme moteur, API idiomatique differente). Note : le Python reference aussi ortools (OR-Tools, alternative CP-SAT) en complement."
+    - "Idiomes framework : C# = Microsoft.Z3 (NuGet) + System.*, 19 cellules code ; Python = pyz3 + ortools, 11 cellules code. Vrai Z3 SMT solver des deux cotes (SOTA veritable, pas de workaround), bindings langage differents."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-13-symbolicautomata.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-13-symbolicautomata.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-13 SymbolicAutomata"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-29"
+    by: po-2023:CoursIA
+    python_sha: 5610e16db6926dc92a182150450844a218f29554
+    csharp_sha: cafe505628e7739a4587c56271c0304f14910581
+  known_differences:
+    - "Socle pedagogique commun : automates symboliques et resolution de Sudoku via Z3 (automates finis symboliques, representation symbolique des contraintes, liens avec SMT). Meme concept (automates symboliques + Z3 comme backend de decision), meme cas d'application (Sudoku). Les deux couvrent Z3, z3, symbolic, Solver."
+    - "Divergence d'implementation : le C# (pur System.* stdlib, 0 NuGet, 18 cellules code) construit la logique d'automate symbolique from scratch avec references a Z3 ; le Python (pyz3, 10 cellules code) utilise les bindings Z3 directement pour la partie symbolique. Meme enseignement (automates symboliques + Z3), deux niveaux : construction from scratch cote C# vs bindings Z3 cote Python."
+    - "Idiomes framework : C# = pur System.* (System / System.Linq), 0 NuGet, 18 cellules code ; Python = pyz3, 10 cellules code. Meme concept (automates symboliques), implementations independantes. Note per SOTA ledger Entry #008 : limite academique SFAz3+Z3 'monstre regex tronque' = INTRINSIC disclosed (limite prouvee, pas un workaround)."


### PR DESCRIPTION
Grain: MED/tooling — lane po-2023:CoursIA — twin registry Sudoku CP/SMT tranche (3 pairs)

## Scope

Enregistre 3 paires Python<->C# de Sudoku dédiées à la **résolution formelle CP/SMT** (constraint programming + SMT solving). Suite de #8870/#8875 (Sudoku) et #8873 (GameTheory).

## Audit firsthand (parity_level = semantic pour les 3)

| Paire | C# | Python | Solveur |
|---|---|---|---|
| **Sudoku-11 Choco** | IKVM bridge (Java→.NET pour Choco) | from scratch (stdlib) | Choco CP |
| **Sudoku-12 Z3** | Microsoft.Z3 (NuGet) | pyz3 | **VRAI Z3 SMT SOTA des deux côtés** |
| **Sudoku-13 SymbolicAutomata** | pur System.* (from scratch + réf Z3) | pyz3 | Z3 + automates symboliques |

`semantic` = même solveur/concept, API idiomatique différente. **Sudoku-12 Z3** est l'archétype du `semantic` : le même moteur Z3 sous-jacent via deux bindings (Microsoft.Z3 .NET vs pyz3 Python). Aucun workaround — vrai Z3 SOTA.

## Spécifique à cette tranche — sélection #8866-immune

Les **6 notebooks de cette tranche sont SANS `metadata.cost`** (vérifié firsthand). Critère de sélection délibéré : PR #8866 (renomme `cost.last_validated` → `cost.metadata_written` sur 391 notebooks) faille actuellement la CI **"Twin parity audit (#8057)"** parce que le rename modifie le SHA des notebooks pairés → DRIFT. En sélectionnant des paires cost-FREE, les SHAs enregistrés ici **ne dériveront pas** au merge de #8866.

## Validation

- `check_twin_parity.py --check` : OK=143 (140 baseline + 3), DRIFT=0, MISSING=0.
- `pytest test_twin_registry_integrity.py` : **11 passed**.

See #8057, #8873, #8875, #8866 (raison de la sélection cost-FREE).
