### PR TITLE
ci(lean): bidirectional sorry-baseline gate (fail above AND below)

### DIFF
--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -15,6 +15,14 @@ name: Lean Build (reusable)
 #         sorry-baseline:    "0"
 #         sorry-filter-mode: prose-header   # raw | prose-header | standalone-tactic
 #
+# Bidirectional gate (anti-regression §D, See #8853/#8856): sorry-baseline must
+# EXACTLY equal the counter's real output. The gate FAILs on above-baseline
+# (regression: a sorry-as-tactic was introduced) AND on below-baseline (stale:
+# a sorry was discharged but the baseline was not decremented — a stale floor
+# hides the next regression). When you discharge a sorry, decrement
+# sorry-baseline in the same PR; when you introduce one intentionally, raise it
+# with justification.
+#
 # Sorry-filter modes (chosen per project's sorry "profile"):
 #   raw               : grep -c "sorry"                          (every mention)
 #   prose-header      : grep "sorry" | grep -viE "sorries|sorry.s"   (excludes prose plural/possessive)
@@ -47,7 +55,7 @@ on:
         type: string
         required: true
       sorry-baseline:
-        description: "Known-good standalone/real sorry count (regression floor)"
+        description: "Current real sorry count (must EXACTLY match the counter; bidirectional gate fails above AND below)"
         type: string
         required: true
       sorry-filter-mode:
@@ -140,8 +148,23 @@ jobs:
           echo "scaffolding target), raise sorry-baseline in the caller workflow WITH"
           echo "a documented justification in the PR body."
           exit 1
+        elif [ "$SORRY_TOTAL" -lt "$BASELINE" ]; then
+          # Bidirectional enforcement (anti-regression §D, See #8853/#8856).
+          # The gate previously only failed on above-baseline regressions; a
+          # discharged sorry (real count drops) left the baseline stale with no
+          # signal, so the NEXT regression above the stale floor passed silently.
+          # A baseline must track the real count exactly. Real < baseline means
+          # the caller workflow's sorry-baseline is stale — decrement it here.
+          echo ""
+          echo "FAIL: sorry count ($SORRY_TOTAL) is BELOW baseline ($BASELINE)."
+          echo "A sorry was discharged (or the counter scope changed) but the"
+          echo "sorry-baseline in the caller workflow was not decremented to match."
+          echo "A stale baseline hides the next regression — the gate only flags"
+          echo "above-baseline. Decrement sorry-baseline to $SORRY_TOTAL in the"
+          echo "caller workflow, in this same PR (anti-regression §D, #8853/#8856)."
+          exit 1
         fi
-        echo "OK: sorry count at or below baseline ($SORRY_TOTAL <= $BASELINE)."
+        echo "OK: sorry count matches baseline exactly ($SORRY_TOTAL == $BASELINE)."
 
     - name: Install elan
       run: |


### PR DESCRIPTION
## Summary

The sorry-baseline gate in `lean-build.yml` (the reusable CI for all Lean lakes) only failed **above-baseline** (`SORRY_TOTAL > BASELINE` = a sorry-as-tactic was introduced). A **discharged** sorry (real count drops **below** baseline) left the baseline stale with **no CI signal**, so the next regression above the stale floor passed silently. This blind spot was caught twice by manual audit — this PR closes it by making the comparison **bidirectional**.

## The defect (anti-regression §D)

- **#8853 (knot_lean):** #8766 discharged `trefoil_not_unknot` (real count 17→16) but the baseline stayed `17` for ~5 cycles until caught by manual audit; a subsequent 16→17 regression would have been **invisible** (the gate only flags `> baseline`).
- **#8856 (decision_theory):** the baseline `4` was computed as FR(2)+EN(2), but the CI counter is FR-only (it excludes `*_en.lean` siblings), so real was always `2` — a 2→4 regression would have been invisible.

In both cases the gate was **green** while the baseline was wrong. A baseline must track the real count **exactly**, not be an aspirational ceiling.

## The fix

Add an `elif SORRY_TOTAL -lt BASELINE` branch that FAILs on below-baseline with an actionable message:

```
FAIL: sorry count (N) is BELOW baseline (M).
A sorry was discharged ... but the sorry-baseline ... was not decremented to match.
A stale baseline hides the next regression ... Decrement sorry-baseline to N in the
caller workflow, in this same PR (anti-regression §D, #8853/#8856).
```

Same `SORRY_TOTAL` variable as the above-baseline check — **zero replication risk**. The OK message changes from `<=` to `==` to state the exact-match invariant.

## Verified safe (CI stays green on `main`)

All 3 non-zero baselines were verified to match the counter's real output **exactly** on `origin/main` (ran the identical CI awk/`tr`/`grep` logic):

| Lake | Mode | Baseline | Real (verified) | Files |
|------|------|----------|-----------------|-------|
| conway_lean | standalone-tactic | 8 | **8** | HashlifeCorrectness.lean |
| knot_lean | real | 16 | **16** | Conway 8 + Invariant 4 + Lidman 2 + Reidemeister 2 |
| decision_theory_lean | standalone-tactic | 2 | **2** | GittinsTheorem.lean |

Zero-baseline lakes (calibration, grothendieck, kelly, erc20, finiteness, game-defs, conway-cgt, argumentation) **cannot** trigger below-baseline (count ≥ 0 = baseline). YAML valid; bash `if/elif/fi` balanced; logic simulated (drift → FAIL-below, match → OK, regression → FAIL-above).

## Impact (disclosed)

Any in-flight Lean PR that **discharges** a sorry in conway/knot/decision-theory must now **decrement** `sorry-baseline` in the same PR (e.g. a `knot-sorry-reduction` PR). This is the **intended hygiene** — when you remove a sorry, you sync the floor down. This is a merge-gate behavior change; ai-01 to judge at merge.

See #8853, #8856 (the PRs that documented the defect + proposed this follow-up gate). No issue closed (preventive hardening; the specific drifts were already fixed in those PRs).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>