### PR TITLE
fix(tooling,#8858): count_exercises corpus_scope anchored to scan root

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -682,8 +682,14 @@ def corpus_scope(root: Path) -> tuple[list[Path], dict[str, int]]:
     if not root.exists():
         return out, removed
     for nb_path in sorted(root.rglob("*.ipynb")):
-        parts = nb_path.parts
-        if any(exc in parts for exc in EXCLUDE_DIRS):
+        # #8858-class guard: root.rglob yields ABSOLUTE paths, so filtering
+        # on nb_path.parts (absolute components) matches the repo's ABSOLUTE
+        # path whenever the clone lives under a skip-named ancestor (e.g.
+        # .../archive/CoursIA/... or .../research/...) and silently empties
+        # the entire corpus -- a false-empty corpus then passes --check
+        # trivially. Filter on the path RELATIVE to the scan root instead.
+        rel_parts = nb_path.relative_to(root).parts
+        if any(exc in rel_parts for exc in EXCLUDE_DIRS):
             continue
         if nb_path.stem.endswith("_output"):
             continue

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -773,6 +773,43 @@ class TestExclusions:
         result = iter_pedagogical_notebooks(tmp_path)
         assert [p.name for p in result] == ["ESGF-Real.ipynb"]
 
+    @pytest.mark.parametrize("skip_named_ancestor", [
+        "archive",   # the canonical #8858 case (clone under .../archive/CoursIA)
+        "research",  # the historical twin case
+        "bin",       # a common build-output / checkout-parent name
+    ])
+    def test_clone_under_skip_named_ancestor_is_not_silenced(
+        self, tmp_path, skip_named_ancestor
+    ):
+        """#8858-class guard: a checkout's ABSOLUTE path is not signal.
+
+        ``corpus_scope`` filters ``root.rglob`` results against ``EXCLUDE_DIRS``.
+        The bug: it tested ``nb_path.parts`` -- the ABSOLUTE components -- so a
+        clone living under a skip-named ancestor (e.g.
+        ``/home/u/archive/CoursIA/MyIA.AI.Notebooks``) matched ``archive`` in
+        its absolute path and was excluded wholesale. The corpus emptied, an
+        empty corpus counts zero below-threshold notebooks, and ``--check``
+        passes trivially -- a false-clean fleet scan with no signal that
+        anything was inspected.
+
+        The sibling ``test_excludes_research_archive`` does NOT catch this: it
+        makes ``research`` a SUBDIR of the scan root (a real relative
+        exclusion), not an ANCESTOR of the scan root (the false absolute one).
+        This test anchors the filter at ``relative_to(root)`` -- the same fix
+        as ``detect_papermill_path_leak.py``'s ``#8858-class guard``.
+        """
+        # The scan root lives UNDER a skip-named ancestor (real-world: a
+        # second clone, a CI checkout, a worktree under .../archive/...).
+        root = tmp_path / skip_named_ancestor / "clone" / "MyIA.AI.Notebooks"
+        nb_path = root / "ML" / "Lesson-1.ipynb"
+        _write_nb(nb_path, [_md("## Exercice 1"), _code("pass")])
+
+        corpus, removed = corpus_scope(root)
+        assert [p.name for p in corpus] == ["Lesson-1.ipynb"], (
+            f"clone under .../{skip_named_ancestor}/... was silenced: "
+            f"corpus={corpus!r} removed={removed!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Threshold / verdict integration


### PR DESCRIPTION
## What

`count_exercises.py::corpus_scope` filtered `root.rglob` results against `EXCLUDE_DIRS` using `nb_path.parts` — the **absolute** path components. When the clone lives under a skip-named ancestor (`.../archive/CoursIA`, `.../research/...`, `.../bin/...`), **every** notebook matched the absolute skip-name and was excluded wholesale: the corpus emptied, counted zero below-threshold notebooks, and `--check` passed trivially — a **false-clean fleet scan** with no signal anything was inspected.

## Fix

Same **#8858-class** as `detect_papermill_path_leak.py`'s guard: filter on `nb_path.relative_to(root).parts` (relative to the scan root) instead of `nb_path.parts`. Single site — `corpus_scope` is the only `EXCLUDE_DIRS` consumer; every other `relative_to` call in the file was already correct.

```python
# count_exercises.py, corpus_scope()
for nb_path in sorted(root.rglob("*.ipynb")):
    # #8858-class guard: root.rglob yields ABSOLUTE paths, so filtering
    # on nb_path.parts would match the clone's ABSOLUTE path under a
    # skip-named ancestor and silently empty the corpus.
    rel_parts = nb_path.relative_to(root).parts
    if any(exc in rel_parts for exc in EXCLUDE_DIRS):
        continue
```

## Verification — RED then GREEN

New regression test `test_clone_under_skip_named_ancestor_is_not_silenced`, parametrized over `archive` / `research` / `bin` (common checkout-parent names).

**On the buggy code** (fix stashed, test kept) — all 3 cases FAIL with `corpus=[]`, the exact false-silence symptom:
```
FAILED ...[archive]  AssertionError: clone under .../archive/... was silenced: corpus=[] removed={}
FAILED ...[research] AssertionError: clone under .../research/... was silenced: corpus=[]
FAILED ...[bin]      AssertionError: clone under .../bin/... was silenced: corpus=[]
```

**On the fix** — `test_count_exercises.py` → **69 passed** (66 prior + 3 new), and the bounded corpus-consumer suite (`-k "exercise or corpus or conform or c1 or c3 or cell_order or validate_pr"`) → **401 passed** on a fresh `origin/main` worktree. The existing relative-subdir exclusions (`research`/`archive` as real subdirs of the root, covered by `test_excludes_research_archive`) are unaffected: anchoring at the scan root **narrows** the filter, it does not weaken it.

## Why existing tests missed it

- `test_excludes_research_archive` makes `research` a **subdir** of the scan root (a genuine relative exclusion), not an **ancestor** of the scan root (the false absolute match).
- `test_root_prefix_carries_no_classification_signal` puts the hostile prefix **outside** the scan root — it tests `_classify`'s anchoring, not the `corpus_scope` EXCLUDE_DIRS filter on `rglob` results.
- pytest's `tmp_path` rarely lives under a skip-named ancestor, so the absolute-path match never fired in CI. The bug is latent on any worker/CI whose checkout absolute path contains `archive`/`research`/`bin`/`obj`/`examples`/`node_modules`/`partner-course` (all in `EXCLUDE_DIRS`).

## Scope

- `scripts/notebook_tools/count_exercises.py` — 1 filter anchored to scan root (`#8858-class guard`, mirrors `detect_papermill_path_leak.py`).
- `scripts/notebook_tools/tests/test_count_exercises.py` — +1 parametrized regression test (3 cases).

No catalogue / notebook changes. See #8858 (closed class bug — this is a sibling instance missed by the prior sweep #8859 / #8865 / #8871).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
