### PR TITLE
feat(grothendieck): Part 30 DirectImage — sheaf direct/inverse image (f_*, f^*) + functoriality identities

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -8,6 +8,7 @@ import Grothendieck.ConstantSheaf
 import Grothendieck.Construction
 import Grothendieck.CoverageGen
 import Grothendieck.DenseTopology
+import Grothendieck.DirectImage
 import Grothendieck.Equivalences
 import Grothendieck.KanExtensions
 import Grothendieck.LeftExact

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Hommage Grothendieck — Partie 18 : Image directe et image reciproque des faisceaux
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 5 (#2159, EPIC #1646).
+
+Les parties 1-17 ont etabli les fondamentaux : categories, cribles, topologies,
+lois de treillis, identites de pullback, bases de faisceaux, cloture couvrante,
+calibration, sous-canonicalite, topologies denses, faisceaux, hom interne,
+cohomologie de Cech, limite de Mayer-Vietoris.
+
+Ce module introduit le couple **image directe / image reciproque** des faisceaux
+de modules sur les schemas : pour un morphisme de schemas `f : X ⟶ Y`, le foncteur
+**image directe** `f_* : X.Modules ⥤ Y.Modules` (pushforward) et le foncteur
+**image reciproque** `f^* : Y.Modules ⥤ X.Modules` (pullback), relies par
+l'**adjonction fondamentale `f^* ⊣ f_*`**.
+
+Cette adjonction est la pierre angulaire du transport des faisceaux le long des
+morphismes en geometrie algebrique : c'est l'instance la plus simple du
+formalisme des « six operations » de Grothendieck (SGA 4, SGA 5). Elle dit que
+les morphismes de faisceaux de modules `f^* G ⟶ M` (sur X) sont en bijection
+naturelle avec les morphismes `G ⟶ f_* M` (sur Y).
+
+Constructions clefs pontees depuis Mathlib (`AlgebraicGeometry.Modules.Sheaf`) :
+
+  - `Scheme.Modules X`        : la categorie abelienne des `𝒪ₓ`-modules sur un schema X
+  - `pushforward f`           : le foncteur image directe `f_* : X.Modules ⥤ Y.Modules`
+  - `pullback f`              : le foncteur image reciproque `f^* : Y.Modules ⥤ X.Modules`
+  - `pullbackPushforwardAdjunction f` : l'adjonction `f^* ⊣ f_*`
+  - `pushforwardId X`         : `f_*` le long de l'identite s'identifie au foncteur identite
+  - `pushforwardComp f g`     : `f_*` puis `g_*` s'identifie a `(g ∘ f)_*`
+  - `pullbackId X`, `pullbackComp f g` : analogues pour `f^*`
+
+EPIC #1646, Phase 5 (#2159). Tous les `sorry`s elimines a la creation.
+
+### Note d'accessibilite (Epics #1452/#1453)
+
+Ce module expose **6 verifications `#check`** sur le couple image directe /
+image reciproque, organisees par 5 sections thematiques : (1) la categorie des
+`𝒪ₓ`-modules sur un schema, (2) l'image directe `f_*`, (3) l'image reciproque
+`f^*`, (4) l'adjonction fondamentale `f^* ⊣ f_*`, (5) les identites de
+fonctorialite (identite, composition).
+
+### Convention i18n (EPIC #4980 ratifiee par user 2026-07-04)
+
+Ce module substantiel est apparie avec son jumeau anglais dans le fichier sibling
+`DirectImage_en.lean` (modele sibling pair, voir PR #6154 pour le pilote sur
+`Utility.lean` et #6275/#6277/#6280/#6284 pour la continuite du rollout).
+Namespace suffix `_en` applique au fichier EN (anti-collision, conforme
+code-style.md #4980). Les verifications `#check`, les signatures, les variables
+et les univers sont **byte-identical** entre les deux fichiers ; seules les
+docstrings `/-- ... -/` et les commentaires `-- ...` different.
+-/
+
+import Mathlib.AlgebraicGeometry.Modules.Sheaf
+
+universe u
+
+namespace Grothendieck.DirectImage
+
+open CategoryTheory AlgebraicGeometry Limits
+open AlgebraicGeometry.Scheme (Modules)
+open AlgebraicGeometry.Scheme.Modules
+
+variable {X Y Z : Scheme.{u}} (f : X ⟶ Y) (g : Y ⟶ Z)
+
+/-!
+## Section 1 : La categorie des faisceaux de modules sur un schema
+
+Pour un schema `X`, le type `X.Modules` est la categorie abelienne des faisceaux
+de modules sur le faisceau structural `𝒪ₓ`. C'est le cadre naturel ou vivent
+l'image directe et l'image reciproque : ce sont des foncteurs entre de telles
+categories, parametres par un morphisme de schemas `f : X ⟶ Y`.
+-/
+
+-- La categorie des 𝒪ₓ-modules sur un schema X (categorie abelienne).
+#check (Scheme.Modules X : Type _)
+
+/-!
+## Section 2 : L'image directe (pushforward, `f_*`)
+
+Pour un morphisme de schemas `f : X ⟶ Y`, l'**image directe** `f_*` envoie un
+`𝒪ₓ`-module `M` sur le `𝒪_Y`-module `f_* M` dont les sections sur un ouvert
+`U` de `Y` sont les sections de `M` sur l'image reciproque `f ⁻¹ᵁ U`.
+
+C'est la facon naturelle de *pousser en avant* un faisceau le long de `f`.
+-/
+
+-- Le foncteur image directe f_* : des 𝒪ₓ-modules vers les 𝒪_Y-modules.
+#check (pushforward f : X.Modules ⥤ Y.Modules)
+
+/-!
+## Section 3 : L'image reciproque (pullback, `f^*`)
+
+L'**image reciproque** `f^*` est le foncteur adjoint a gauche de `f_*` : il
+*tire en arriere* un `𝒪_Y`-module sur `X`. Geometriquement, `f^* G` represente
+le faisceau `G` vu sur l'espace source `X` via le morphisme `f`.
+-/
+
+-- Le foncteur image reciproque f^* : des 𝒪_Y-modules vers les 𝒪ₓ-modules.
+#check (pullback f : Y.Modules ⥤ X.Modules)
+
+/-!
+## Section 4 : L'adjonction fondamentale `f^* ⊣ f_*`
+
+Le resultat central : l'image reciproque est adjointe a gauche de l'image
+directe. Les morphismes de `𝒪ₓ`-modules `f^* G ⟶ M` sont en correspondance
+naturelle avec les morphismes de `𝒪_Y`-modules `G ⟶ f_* M`. Cette adjonction
+est le coeur du transport des faisceaux en geometrie algebrique et l'ancetre
+le plus simple du formalisme des six operations de Grothendieck.
+-/
+
+-- L'adjonction fondamentale : f^* est adjoint a gauche de f_*.
+#check (pullbackPushforwardAdjunction f : pullback f ⊣ pushforward f)
+
+/-!
+## Section 5 : Identites de fonctorialite
+
+L'image directe (et reciproquement l'image reciproque) se comporte bien vis-a-vis
+de l'identite et de la composition des morphismes de schemas : pousser en avant
+le long de l'identite est l'identite, et pousser en avant le long de `f` puis `g`
+s'identifie au pushforward le long de la composee `f ≫ g`.
+-/
+
+-- f_* le long de l'identite s'identifie au foncteur identite.
+#check (pushforwardId X : pushforward (𝟙 X) ≅ 𝟭 _)
+
+-- f_* puis g_* s'identifie au pushforward de la composee (f ≫ g)_*.
+#check (pushforwardComp f g : pushforward f ⋙ pushforward g ≅ pushforward (f ≫ g))
+
+end Grothendieck.DirectImage

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage.lean
@@ -2,13 +2,13 @@
 Copyright (c) 2026 CoursIA. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 
-# Hommage Grothendieck — Partie 18 : Image directe et image reciproque des faisceaux
+# Hommage Grothendieck — Partie 30 : Image directe et image reciproque des faisceaux
 
 Alexandre Grothendieck (1928-2014).
 
 Extension Phase 5 (#2159, EPIC #1646).
 
-Les parties 1-17 ont etabli les fondamentaux : categories, cribles, topologies,
+Les parties 1-29 ont etabli les fondamentaux : categories, cribles, topologies,
 lois de treillis, identites de pullback, bases de faisceaux, cloture couvrante,
 calibration, sous-canonicalite, topologies denses, faisceaux, hom interne,
 cohomologie de Cech, limite de Mayer-Vietoris.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage.lean
@@ -39,11 +39,12 @@ EPIC #1646, Phase 5 (#2159). Tous les `sorry`s elimines a la creation.
 
 ### Note d'accessibilite (Epics #1452/#1453)
 
-Ce module expose **6 verifications `#check`** sur le couple image directe /
-image reciproque, organisees par 5 sections thematiques : (1) la categorie des
+Ce module expose **8 verifications `#check`** sur le couple image directe /
+image reciproque, organisees par 6 sections thematiques : (1) la categorie des
 `𝒪ₓ`-modules sur un schema, (2) l'image directe `f_*`, (3) l'image reciproque
 `f^*`, (4) l'adjonction fondamentale `f^* ⊣ f_*`, (5) les identites de
-fonctorialite (identite, composition).
+fonctorialite de l'image directe `f_*` (identite, composition), (6) les
+identites de fonctorialite de l'image reciproque `f^*` (analogue dual).
 
 ### Convention i18n (EPIC #4980 ratifiee par user 2026-07-04)
 
@@ -65,6 +66,7 @@ namespace Grothendieck.DirectImage
 open CategoryTheory AlgebraicGeometry Limits
 open AlgebraicGeometry.Scheme (Modules)
 open AlgebraicGeometry.Scheme.Modules
+open AlgebraicGeometry.Scheme.Modules (pullbackId pullbackComp)
 
 variable {X Y Z : Scheme.{u}} (f : X ⟶ Y) (g : Y ⟶ Z)
 
@@ -118,12 +120,12 @@ le plus simple du formalisme des six operations de Grothendieck.
 #check (pullbackPushforwardAdjunction f : pullback f ⊣ pushforward f)
 
 /-!
-## Section 5 : Identites de fonctorialite
+## Section 5 : Identites de fonctorialite de l'image directe `f_*`
 
-L'image directe (et reciproquement l'image reciproque) se comporte bien vis-a-vis
-de l'identite et de la composition des morphismes de schemas : pousser en avant
-le long de l'identite est l'identite, et pousser en avant le long de `f` puis `g`
-s'identifie au pushforward le long de la composee `f ≫ g`.
+L'image directe `f_*` se comporte bien vis-a-vis de l'identite et de la
+composition des morphismes de schemas : pousser en avant le long de l'identite
+est l'identite, et pousser en avant le long de `f` puis `g` s'identifie au
+pushforward le long de la composee `f ≫ g`.
 -/
 
 -- f_* le long de l'identite s'identifie au foncteur identite.
@@ -131,5 +133,20 @@ s'identifie au pushforward le long de la composee `f ≫ g`.
 
 -- f_* puis g_* s'identifie au pushforward de la composee (f ≫ g)_*.
 #check (pushforwardComp f g : pushforward f ⋙ pushforward g ≅ pushforward (f ≫ g))
+
+/-!
+## Section 6 : Identites de fonctorialite de l'image reciproque `f^*`
+
+L'image reciproque `f^*` satisfait les identites duales : tirer en arriere le
+long de l'identite est l'identite, et tirer en arriere le long de `f ≫ g`
+s'identifie a tirer en arriere selon `g` puis `f` (notez l'ordre renverse :
+`pullback g ⋙ pullback f`, car `f^*` est contravariante en `f`).
+-/
+
+-- f^* le long de l'identite s'identifie au foncteur identite.
+#check pullbackId X
+
+-- f^* de la composee : pullback g puis pullback f = pullback (f ≫ g) (ordre renverse, contravariance).
+#check pullbackComp f g
 
 end Grothendieck.DirectImage

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage_en.lean
@@ -37,11 +37,12 @@ Epic #1646, Phase 5 (#2159). All `sorry`s eliminated at creation.
 
 ### Accessibility note (Epics #1452/#1453)
 
-This module exposes **6 `#check` verifications** on the direct image / inverse
-image pair, organised into 5 thematic sections: (1) the category of `𝒪ₓ`-modules
+This module exposes **8 `#check` verifications** on the direct image / inverse
+image pair, organised into 6 thematic sections: (1) the category of `𝒪ₓ`-modules
 on a scheme, (2) the direct image `f_*`, (3) the inverse image `f^*`, (4) the
-fundamental adjunction `f^* ⊣ f_*`, (5) the functoriality identities (identity,
-composition).
+fundamental adjunction `f^* ⊣ f_*`, (5) the functoriality identities of the
+direct image `f_*` (identity, composition), (6) the functoriality identities of
+the inverse image `f^*` (dual analogue).
 
 ### i18n — convention #4980 ratified 2026-07-04
 
@@ -63,6 +64,7 @@ namespace Grothendieck.DirectImage_en
 open CategoryTheory AlgebraicGeometry Limits
 open AlgebraicGeometry.Scheme (Modules)
 open AlgebraicGeometry.Scheme.Modules
+open AlgebraicGeometry.Scheme.Modules (pullbackId pullbackComp)
 
 variable {X Y Z : Scheme.{u}} (f : X ⟶ Y) (g : Y ⟶ Z)
 
@@ -116,12 +118,12 @@ operations formalism.
 #check (pullbackPushforwardAdjunction f : pullback f ⊣ pushforward f)
 
 /-!
-## Section 5: Functoriality identities
+## Section 5: Functoriality identities of the direct image `f_*`
 
-The direct image (and dually the inverse image) behaves well with respect to
-identity and composition of scheme morphisms: pushing forward along the
-identity is the identity, and pushing forward along `f` then `g` identifies to
-the pushforward along the composite `f ≫ g`.
+The direct image `f_*` behaves well with respect to identity and composition of
+scheme morphisms: pushing forward along the identity is the identity, and
+pushing forward along `f` then `g` identifies to the pushforward along the
+composite `f ≫ g`.
 -/
 
 -- f_* along the identity identifies to the identity functor.
@@ -129,5 +131,20 @@ the pushforward along the composite `f ≫ g`.
 
 -- f_* then g_* identifies to the pushforward of the composite (f ≫ g)_*.
 #check (pushforwardComp f g : pushforward f ⋙ pushforward g ≅ pushforward (f ≫ g))
+
+/-!
+## Section 6: Functoriality identities of the inverse image `f^*`
+
+The inverse image `f^*` satisfies the dual identities: pulling back along the
+identity is the identity, and pulling back along `f ≫ g` identifies to pulling
+back along `g` then `f` (note the reversed order: `pullback g ⋙ pullback f`,
+since `f^*` is contravariant in `f`).
+-/
+
+-- f^* along the identity identifies to the identity functor.
+#check pullbackId X
+
+-- f^* of the composite: pullback g then pullback f = pullback (f ≫ g) (reversed order, contravariance).
+#check pullbackComp f g
 
 end Grothendieck.DirectImage_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage_en.lean
@@ -2,11 +2,11 @@
 Copyright (c) 2026 CoursIA. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 
-# Grothendieck tribute — Part 18: Direct image and inverse image of sheaves
+# Grothendieck tribute — Part 30: Direct image and inverse image of sheaves
 
 Phase 5 extension (#2159, Epic #1646).
 
-Parts 1-17 established the foundations: categories, sieves, topologies, lattice
+Parts 1-29 established the foundations: categories, sieves, topologies, lattice
 laws, pullback identities, sheaf bases, covering closure, calibration,
 subcanonicality, dense topologies, sheaves, internal hom, Cech cohomology,
 Mayer-Vietoris limit.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage_en.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Grothendieck tribute — Part 18: Direct image and inverse image of sheaves
+
+Phase 5 extension (#2159, Epic #1646).
+
+Parts 1-17 established the foundations: categories, sieves, topologies, lattice
+laws, pullback identities, sheaf bases, covering closure, calibration,
+subcanonicality, dense topologies, sheaves, internal hom, Cech cohomology,
+Mayer-Vietoris limit.
+
+This module introduces the **direct image / inverse image** pair of sheaves of
+modules on schemes: for a scheme morphism `f : X ⟶ Y`, the **direct image**
+functor `f_* : X.Modules ⥤ Y.Modules` (pushforward) and the **inverse image**
+functor `f^* : Y.Modules ⥤ X.Modules` (pullback), tied by the **fundamental
+adjunction `f^* ⊣ f_*`**.
+
+This adjunction is the cornerstone of sheaf transport along morphisms in
+algebraic geometry: it is the simplest instance of Grothendieck's "six
+operations" formalism (SGA 4, SGA 5). It states that morphisms of sheaves of
+modules `f^* G ⟶ M` (on X) are in natural bijection with morphisms `G ⟶ f_* M`
+(on Y).
+
+Key constructions bridged from Mathlib (`AlgebraicGeometry.Modules.Sheaf`):
+
+  - `Scheme.Modules X`        : the abelian category of `𝒪ₓ`-modules on a scheme X
+  - `pushforward f`           : the direct image functor `f_* : X.Modules ⥤ Y.Modules`
+  - `pullback f`              : the inverse image functor `f^* : Y.Modules ⥤ X.Modules`
+  - `pullbackPushforwardAdjunction f` : the adjunction `f^* ⊣ f_*`
+  - `pushforwardId X`         : `f_*` along the identity identifies to the identity functor
+  - `pushforwardComp f g`     : `f_*` then `g_*` identifies to `(g ∘ f)_*`
+  - `pullbackId X`, `pullbackComp f g` : the analogues for `f^*`
+
+Epic #1646, Phase 5 (#2159). All `sorry`s eliminated at creation.
+
+### Accessibility note (Epics #1452/#1453)
+
+This module exposes **6 `#check` verifications** on the direct image / inverse
+image pair, organised into 5 thematic sections: (1) the category of `𝒪ₓ`-modules
+on a scheme, (2) the direct image `f_*`, (3) the inverse image `f^*`, (4) the
+fundamental adjunction `f^* ⊣ f_*`, (5) the functoriality identities (identity,
+composition).
+
+### i18n — convention #4980 ratified 2026-07-04
+
+This substantial module is paired with its French canonical counterpart in the
+sibling file `DirectImage.lean` (sibling pair model, see PR #6154 for the pilot
+on `Utility.lean` and #6275/#6277/#6280/#6284 for the rollout continuation).
+Namespace suffix `_en` applied to the EN file (anti-collision, per code-style.md
+#4980). The `#check`s, signatures, variables and universes are **byte-identical**
+between the two files; only the docstrings `/-- ... -/` and comments `-- ...`
+differ.
+-/
+
+import Mathlib.AlgebraicGeometry.Modules.Sheaf
+
+universe u
+
+namespace Grothendieck.DirectImage_en
+
+open CategoryTheory AlgebraicGeometry Limits
+open AlgebraicGeometry.Scheme (Modules)
+open AlgebraicGeometry.Scheme.Modules
+
+variable {X Y Z : Scheme.{u}} (f : X ⟶ Y) (g : Y ⟶ Z)
+
+/-!
+## Section 1: The category of sheaves of modules on a scheme
+
+For a scheme `X`, the type `X.Modules` is the abelian category of sheaves of
+modules over the structure sheaf `𝒪ₓ`. This is the natural setting where the
+direct and inverse image live: they are functors between such categories,
+parametrised by a scheme morphism `f : X ⟶ Y`.
+-/
+
+-- The category of 𝒪ₓ-modules on a scheme X (abelian category).
+#check (Scheme.Modules X : Type _)
+
+/-!
+## Section 2: The direct image (pushforward, `f_*`)
+
+For a scheme morphism `f : X ⟶ Y`, the **direct image** `f_*` sends an
+`𝒪ₓ`-module `M` to the `𝒪_Y`-module `f_* M` whose sections over an open set
+`U` of `Y` are the sections of `M` over the preimage `f ⁻¹ᵁ U`.
+
+This is the natural way to *push forward* a sheaf along `f`.
+-/
+
+-- The direct image functor f_* : from 𝒪ₓ-modules to 𝒪_Y-modules.
+#check (pushforward f : X.Modules ⥤ Y.Modules)
+
+/-!
+## Section 3: The inverse image (pullback, `f^*`)
+
+The **inverse image** `f^*` is the left adjoint of `f_*`: it *pulls back* a
+`𝒪_Y`-module to `X`. Geometrically, `f^* G` represents the sheaf `G` seen on
+the source space `X` via the morphism `f`.
+-/
+
+-- The inverse image functor f^* : from 𝒪_Y-modules to 𝒪ₓ-modules.
+#check (pullback f : Y.Modules ⥤ X.Modules)
+
+/-!
+## Section 4: The fundamental adjunction `f^* ⊣ f_*`
+
+The central result: the inverse image is left adjoint to the direct image.
+Morphisms of `𝒪ₓ`-modules `f^* G ⟶ M` are in natural correspondence with
+morphisms of `𝒪_Y`-modules `G ⟶ f_* M`. This adjunction is the heart of sheaf
+transport in algebraic geometry and the simplest ancestor of Grothendieck's six
+operations formalism.
+-/
+
+-- The fundamental adjunction: f^* is left adjoint to f_*.
+#check (pullbackPushforwardAdjunction f : pullback f ⊣ pushforward f)
+
+/-!
+## Section 5: Functoriality identities
+
+The direct image (and dually the inverse image) behaves well with respect to
+identity and composition of scheme morphisms: pushing forward along the
+identity is the identity, and pushing forward along `f` then `g` identifies to
+the pushforward along the composite `f ≫ g`.
+-/
+
+-- f_* along the identity identifies to the identity functor.
+#check (pushforwardId X : pushforward (𝟙 X) ≅ 𝟭 _)
+
+-- f_* then g_* identifies to the pushforward of the composite (f ≫ g)_*.
+#check (pushforwardComp f g : pushforward f ⋙ pushforward g ≅ pushforward (f ≫ g))
+
+end Grothendieck.DirectImage_en


### PR DESCRIPTION
## Summary

Extends `grothendieck_lean` beyond Phase 1 (Epic #1646, Phase 5) with **Part 30: Direct image and inverse image of sheaves** — a module exposing the sheaf **direct image** (pushforward `f_*`) / **inverse image** (pullback `f^*`) pair, the **fundamental adjunction `f^* ⊣ f_*`**, and the **functoriality identities of both** — the simplest ancestor of Grothendieck's six-operations formalism (SGA 4/5).

This fills a tractable gap in the Grothendieck tribute: pushforward/stalk transport along scheme morphisms was not yet covered, while the lake already spans 32 modules (categories, sieves, topologies, sheaves, cohomology, internal hom).

### Mathlib bridge (`AlgebraicGeometry.Modules.Sheaf`, Joël Riou 2024)

| Mathlib constant | Meaning |
|---|---|
| `Scheme.Modules X` | abelian category of `𝒪_X`-modules on a scheme |
| `pushforward f` | direct image `f_* : X.Modules ⥤ Y.Modules` |
| `pullback f` | inverse image `f^* : Y.Modules ⥤ X.Modules` |
| `pullbackPushforwardAdjunction f` | the adjunction `f^* ⊣ f_*` |
| `pushforwardId X` | `f_*` along `𝟙 ≅ 𝟭` |
| `pushforwardComp f g` | `f_* ⋙ g_* ≅ (f ≫ g)_*` |
| `pullbackId X` | `f^*` along `𝟙 ≅ 𝟭` (dual) |
| `pullbackComp f g` | `pullback g ⋙ pullback f ≅ (f ≫ g)^*` (dual, **contravariant order**) |

**8 `#check` verifications across 6 thematic sections** (the category, `f_*`, `f^*`, the adjunction, `f_*` functoriality, `f^*` functoriality). Follows the established Grothendieck exposition-module idiom (`#check` of existing Mathlib constants, zero tactic `sorry`).

## Commits

1. `ae7b72287` — initial module (6 #checks, 5 sections; Partie 18).
2. `f817367fd` — **self-correction**: Partie 18 → **30** (18 collided with `ConstantSheaf.lean` on `main`; built from a stale shared tree). Narrative range 1-17 → 1-29. Docstring-only.
3. `032858c3f` — **enrichment**: added Section 6 (`pullbackId`, `pullbackComp`) so the delivered #checks match the docstring's constructions list — symmetric `f_*` Id+Comp AND `f^*` Id+Comp (8 #checks, 6 sections).

## i18n (#4980 sibling pair)

- `DirectImage.lean` (FR canonical) + `DirectImage_en.lean` (EN mirror).
- Code **byte-identical** FR↔EN (same `import` / `universe` / `open` / `variable` / `#check` lines — verified by diff); only docstrings `/-- ... -/`, comments `-- ...`, and the namespace suffix (`_en`) differ.
- The `_en` sibling is **not** wired into the FR aggregator `Grothendieck.lean` (consistent with the existing lake convention — `_en` files compile independently, verified).

## Acceptance §B (Lean PR)

- **`sorry` (real mode): 0 → 0** per file (verified via comment-stripping `awk`; prose header stripped; no tactic `sorry`). Baseline `0` maintained.
- **`lake build`**: SUCCESS — FR + `_en` both compile (2429 jobs).
- **Proof integrity**: N/A — exposition module (`#check` of existing axiom-clean Mathlib constants); no theorem proved, no axiom introduced.

See #2159

🤖 Generated with [Claude Code](https://claude.com/claude-code)