### PR TITLE
fix(ci,#8884): degenerate-figure gate — installer Pillow, rendre rc lisible sous bash -e

### DIFF
--- a/.github/workflows/degenerate-figure-gate.yml
+++ b/.github/workflows/degenerate-figure-gate.yml
@@ -76,6 +76,16 @@ jobs:
         with:
           python-version: '3.11'
 
+      # Pillow is REQUIRED, not optional. `_has_min_colors` in the detector
+      # opens the raster to count distinct colours; without PIL it swallows the
+      # ImportError and returns None, which silently disables the content
+      # escape hatch of #8634 and falls back to the size-only rule. The gate
+      # then flags legitimate small-but-colour-rich figures (pixel-art, the
+      # 24x16 cross-stitch grid #8634 was filed for) as degenerate. Absent this
+      # install the #8634 fix is inoperative in the one place it matters.
+      - name: Install detector dependencies
+        run: python -m pip install --quiet Pillow
+
       - name: Gate changed notebooks
         run: |
           set -uo pipefail
@@ -100,8 +110,17 @@ jobs:
             # Skip notebooks deleted by the PR.
             [ -f "$nb" ] || continue
             checked=$((checked + 1))
-            out=$(python scripts/notebook_tools/detect_blank_figures.py --check "$nb" 2>&1)
-            rc=$?
+            # The `&& rc=0 || rc=$?` tail is load-bearing. The step runs under
+            # `bash -e`, where a bare `out=$(cmd)` that exits non-zero aborts
+            # the whole step IMMEDIATELY -- before `rc=$?` is read -- making the
+            # rc=1 / rc=2 branches below unreachable dead code. A real finding
+            # then surfaces as a bare `exit 1` naming no notebook, which is
+            # indistinguishable from the detector crashing. Membership in an
+            # `&&`/`||` list exempts the assignment from errexit; the explicit
+            # `fail` flag decides the step's outcome instead.
+            # NOT `|| true`: that would make `$?` read 0 from `true` itself, so
+            # rc would always be 0 and the gate could never fire at all.
+            out=$(python scripts/notebook_tools/detect_blank_figures.py --check "$nb" 2>&1) && rc=0 || rc=$?
             if [ "$rc" -eq 1 ]; then
               echo "::error title=Degenerate figure::$nb commits a degenerate placeholder figure (1x1 / tiny-payload PNG) that renders blank on GitHub/nbviewer."
               echo "<details><summary><code>$nb</code></summary>" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/notebook_tools/tests/test_detect_blank_figures.py
+++ b/scripts/notebook_tools/tests/test_detect_blank_figures.py
@@ -817,3 +817,62 @@ class TestContentGateSurvivesDeprecation:
             assert list(_flattened_pixels(im)) == list(im.get_flattened_data())
         else:  # Pillow < 12: the legacy name is the only one available
             assert len(list(_flattened_pixels(im))) == 4
+
+
+# ---------------------------------------------------------------------------
+# 11. Gate workflow contract (#8884) -- the environment the detector RUNS in
+# ---------------------------------------------------------------------------
+# Every test above exercises the detector as a library, in THIS job's
+# environment -- where Pillow is present transitively (scripts-tests.yml installs
+# matplotlib, which depends on Pillow). The GATE runs in a different job with its
+# own environment, and that is the gap #8884 fell through: the unit tests stayed
+# green while `degenerate-figure-gate.yml` had no `pip install` at all, so PIL was
+# missing, `_has_real_content` returned None, the #8634 content escape hatch was
+# inoperative, and the 24x16 cross-stitch grid was flagged again -- in CI only,
+# invisible from here.
+#
+# These two assertions are the ratchet. They are deliberately assertions about
+# the WORKFLOW FILE, not about the detector: a unit test cannot observe another
+# job's interpreter. Dropping the Pillow install, or reverting the loop to the
+# errexit-unsafe form, turns this file red instead of silently disarming the gate.
+
+_GATE_WORKFLOW = (
+    Path(__file__).resolve().parents[3] / ".github" / "workflows" / "degenerate-figure-gate.yml"
+)
+
+
+class TestGateWorkflowContract:
+    def test_gate_workflow_exists(self):
+        assert _GATE_WORKFLOW.is_file(), f"gate workflow missing: {_GATE_WORKFLOW}"
+
+    def test_gate_installs_pillow_explicitly(self):
+        # PIL is REQUIRED for the #8634 content gate, not optional. Relying on a
+        # transitive matplotlib dependency (as scripts-tests.yml does) is exactly
+        # the asymmetry that hid #8884.
+        text = _GATE_WORKFLOW.read_text(encoding="utf-8")
+        assert "pip install" in text and "Pillow" in text, (
+            "degenerate-figure-gate.yml must install Pillow explicitly; without it "
+            "_has_real_content() degrades to None and the #8634 escape hatch is dead"
+        )
+
+    def test_detector_invocation_is_errexit_safe(self):
+        # The step runs under `bash -e`: a bare `out=$(cmd)` that exits non-zero
+        # aborts before `rc=$?` is read, making the rc=1/rc=2 branches dead code
+        # and the failure anonymous. `&& rc=0 || rc=$?` preserves the real code.
+        text = _GATE_WORKFLOW.read_text(encoding="utf-8")
+        invocation = [
+            ln for ln in text.splitlines()
+            if "detect_blank_figures.py" in ln and "out=$(" in ln
+        ]
+        assert invocation, "expected an `out=$(... detect_blank_figures.py ...)` invocation"
+        line = invocation[0]
+        assert "&& rc=0 || rc=$?" in line, (
+            f"errexit-unsafe detector invocation: {line.strip()!r} -- use "
+            "`out=$(...) && rc=0 || rc=$?` so rc survives `bash -e`"
+        )
+        # `|| true` would make $? read 0 from `true` itself: rc always 0, so the
+        # gate could never fire at all -- strictly worse than the original bug.
+        assert "|| true" not in line, (
+            "`|| true` makes rc always 0 and permanently disarms the gate; "
+            "use `&& rc=0 || rc=$?`"
+        )


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: LIGHT/ledger

Le gate `degenerate-figure-gate.yml` (#6918) portait **deux defauts independants** qui se combinaient en un faux positif muet. Decouvert en revoyant #8866, dont il bloquait le merge sans nommer quoi que ce soit.

## Defaut 1 — Pillow n'etait jamais installe

Le workflow n'avait **aucune** etape `pip install` : seulement `actions/setup-python@v5`. Or `detect_blank_figures.py` a besoin de PIL pour compter les couleurs distinctes d'un raster, et son `except Exception` avale l'`ImportError` en renvoyant `None` — ce qui **desarme silencieusement l'echappatoire par contenu de #8634** et retombe sur la regle taille-seule. Les figures petites mais riches en couleurs sont alors flaggees a nouveau.

C'est exactement la degradation que la docstring de `_has_min_colors` decrit :

> *"here degrades to `None`, i.e. back to the size-only rule that #8634 was filed to fix"* — en nommant *"pixel-art, grille de broderie 24x16 a 17 couleurs"*.

Mesure sur le contenu de #8866 (`c9f6090b0`, worktree detache, chemins reels) :

```
avec PIL (local)        : 412 notebooks, 412 rc=0
sans PIL (emulation CI) : 411 rc=0  +  1 rc=1
   -> GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb
```

Le notebook qui saute est **litteralement** le cas nomme dans la docstring. #8866 ne le touche que par une ligne de renommage de cle (`1 insertion(+), 1 deletion(-)`) ; la figure est pre-existante sur `main`.

**Pourquoi aucun test ne l'a vu** : `scripts-tests.yml` installe `matplotlib`, qui tire Pillow **transitivement**. Les tests unitaires sont donc verts (PIL present dans *leur* job) pendant que le job du gate n'a rien. L'asymetrie est entre **jobs** — aucun test au niveau de la librairie ne peut l'observer.

## Defaut 2 — sous `bash -e`, la branche de classification etait du code mort

Le step tourne sous `shell: /usr/bin/bash -e {0}` et faisait `out=$(... --check "$nb" 2>&1)` puis `rc=$?`. Sous `errexit`, une affectation par substitution de commande qui sort non-zero **avorte le step immediatement**, avant que `rc=$?` soit lu : tout le `if rc -eq 1 / elif rc -eq 2` etait **inatteignable**. Le gate ne pouvait structurellement **jamais nommer** ce qu'il trouve — il mourait muet, avec un `exit 1` indiscernable d'un crash du detecteur.

C'est ce que montre le log du run 30492125704 sur #8866 : **rien** entre `##[endgroup]` et `##[error]Process completed with exit code 1` — ni l'annotation `::error title=Degenerate figure::<nb>`, ni la `::notice ... Checked N`.

## Le correctif

1. Une etape `python -m pip install --quiet Pillow` — PIL est **requis**, pas optionnel.
2. `out=$(...) && rc=0 || rc=$?` — l'appartenance a une liste `&&`/`||` exempte l'affectation d'`errexit` et **preserve** le vrai code de sortie.

**Pas `|| true`** : `$?` lirait alors le `0` de `true` lui-meme, `rc` serait toujours 0, et le gate ne pourrait **plus jamais** rougir — strictement pire que le bug. Verifie empiriquement avant de choisir :

```
IDIOME (|| true)            -> rc=0            (le gate ne peut plus se declencher)
IDIOME (&& rc=0 || rc=$?)   -> 1 / 0 / 2 preserves
```

Les deux points portent un commentaire en place expliquant *pourquoi* l'idiome est charge de sens, pour qu'un futur nettoyage cosmetique ne le defasse pas.

## Verification

Cote a cote sur la meme entree (un notebook a PNG 1x1 synthetique + le notebook cross-stitch) :

```
ANCIEN idiome  : exit=1, AUCUNE sortie          <- reproduit le log de #8866
IDIOME CORRIGE : ::error ... degenerate.ipynb   <- nomme, puis echoue deliberement
                 checked=2  fail=1              <- le pixel-art reste propre
```

## Cliquet permanent

`TestGateWorkflowContract` (section 11 de `test_detect_blank_figures.py`) asserte que le workflow installe Pillow et utilise l'idiome errexit-safe — et que `|| true` n'y est pas.

Ces assertions portent sur le **fichier de workflow**, par conception : un test unitaire ne peut pas observer l'interpreteur d'un *autre* job, et c'est precisement la faille par laquelle #8884 est passe. Un correctif workflow-only pourrirait en silence ; ce cliquet le tient.

Les deux assertions ont ete verifiees rouges en revertant chaque correctif separement (`1 failed, 2 passed` a chaque fois), puis vertes une fois restaurees. Suite complete : **77 passed**.

## Portee

Les trois autres detecteurs de la suite render (`svg-decimal-comma`, `svg-empty-display`, `svg-broken-geometry`) sont a auditer pour le meme motif `out=$(...)` + `rc=$?` sous `bash -e` — grain separe, note dans #8884.

Catalogue byte-identique a `main` (0 fichier touche).

Closes #8884
See #8866, #8634, #6918
