### PR TITLE
fix(ci,#8884): render-suite gates — errexit-safe rc under bash -e

### DIFF
--- a/.github/workflows/svg-broken-geometry-gate.yml
+++ b/.github/workflows/svg-broken-geometry-gate.yml
@@ -98,8 +98,11 @@ jobs:
             # Skip notebooks deleted by the PR.
             [ -f "$nb" ] || continue
             checked=$((checked + 1))
-            out=$(python scripts/notebook_tools/detect_svg_broken_geometry.py "$nb" --check 2>&1)
-            rc=$?
+            # `&& rc=0 || rc=$?` is load-bearing under `bash -e`: a bare `out=$(cmd)`
+            # that exits non-zero aborts the step before `rc=$?` is read, making the
+            # rc=1/rc=2 branches below dead code and the failure anonymous (#8884 motif).
+            # NOT `|| true` (that makes $? read 0 from `true` and permanently disarms the gate).
+            out=$(python scripts/notebook_tools/detect_svg_broken_geometry.py "$nb" --check 2>&1) && rc=0 || rc=$?
             if [ "$rc" -eq 1 ]; then
               echo "::error title=SVG broken-geometry defect::$nb commits an inline SVG with a negative-dimension element (renders invisible; broken logY/log-scale layout)."
               echo "<details><summary><code>$nb</code></summary>" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/svg-decimal-comma-gate.yml
+++ b/.github/workflows/svg-decimal-comma-gate.yml
@@ -93,8 +93,11 @@ jobs:
             # Skip notebooks deleted by the PR.
             [ -f "$nb" ] || continue
             checked=$((checked + 1))
-            out=$(python scripts/notebook_tools/detect_svg_decimal_commas.py "$nb" --check 2>&1)
-            rc=$?
+            # `&& rc=0 || rc=$?` is load-bearing under `bash -e`: a bare `out=$(cmd)`
+            # that exits non-zero aborts the step before `rc=$?` is read, making the
+            # rc=1/rc=2 branches below dead code and the failure anonymous (#8884 motif).
+            # NOT `|| true` (that makes $? read 0 from `true` and permanently disarms the gate).
+            out=$(python scripts/notebook_tools/detect_svg_decimal_commas.py "$nb" --check 2>&1) && rc=0 || rc=$?
             if [ "$rc" -eq 1 ]; then
               echo "::error title=SVG decimal-comma defect::$nb commits an inline SVG with French decimal commas (renders broken on GitHub/nbviewer)."
               echo "<details><summary><code>$nb</code></summary>" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/svg-empty-display-gate.yml
+++ b/.github/workflows/svg-empty-display-gate.yml
@@ -148,8 +148,11 @@ jobs:
             # Skip notebooks deleted by the PR.
             [ -f "$nb" ] || continue
             checked=$((checked + 1))
-            out=$(python scripts/notebook_tools/detect_svg_empty_display.py "$nb" --check 2>&1)
-            rc=$?
+            # `&& rc=0 || rc=$?` is load-bearing under `bash -e`: a bare `out=$(cmd)`
+            # that exits non-zero aborts the step before `rc=$?` is read, making the
+            # rc=1/rc=2 branches below dead code and the failure anonymous (#8884 motif).
+            # NOT `|| true` (that makes $? read 0 from `true` and permanently disarms the gate).
+            out=$(python scripts/notebook_tools/detect_svg_empty_display.py "$nb" --check 2>&1) && rc=0 || rc=$?
             if [ "$rc" -eq 1 ]; then
               echo "::error title=SVG empty-display defect::$nb commits a code cell with a chart-display pattern but EMPTY output list (renders BLANK on GitHub/nbviewer)."
               echo "<details><summary><code>$nb</code></summary>" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/svg-offscreen-flat-gate.yml
+++ b/.github/workflows/svg-offscreen-flat-gate.yml
@@ -89,8 +89,11 @@ jobs:
             # Skip notebooks deleted by the PR.
             [ -f "$nb" ] || continue
             checked=$((checked + 1))
-            out=$(python scripts/notebook_tools/detect_svg_offscreen_flat.py --check "$nb" 2>&1)
-            rc=$?
+            # `&& rc=0 || rc=$?` is load-bearing under `bash -e`: a bare `out=$(cmd)`
+            # that exits non-zero aborts the step before `rc=$?` is read, making the
+            # rc=1/rc=2 branches below dead code and the failure anonymous (#8884 motif).
+            # NOT `|| true` (that makes $? read 0 from `true` and permanently disarms the gate).
+            out=$(python scripts/notebook_tools/detect_svg_offscreen_flat.py --check "$nb" 2>&1) && rc=0 || rc=$?
             if [ "$rc" -eq 1 ]; then
               echo "::error title=SVG offscreen-flat::$nb commits a flat SVG whose data geometry is projected off the viewBox (>15%) — figure renders amputated on GitHub/nbviewer."
               echo "<details><summary><code>$nb</code></summary>" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/notebook_tools/tests/test_render_suite_gates.py
+++ b/scripts/notebook_tools/tests/test_render_suite_gates.py
@@ -1,0 +1,103 @@
+"""Ratchet contract for the render-suite CI gates (#8884 motif).
+
+Every detector gate runs its ``python scripts/notebook_tools/detect_*.py`` call
+under ``bash -e`` (the GitHub Actions Ubuntu default: ``bash --noprofile --norc
+-eo pipefail {0}``). Under errexit, a bare ``out=$(cmd)`` that exits non-zero
+aborts the **whole step** before the following ``rc=$?`` is read -- which makes
+the ``rc=1`` / ``rc=2`` branches below it unreachable dead code. A real finding
+then surfaces as a bare anonymous ``exit 1``, indistinguishable from the
+detector crashing, and the gate can never *name* the notebook it caught.
+
+This is the defect #8884 filed against ``degenerate-figure-gate`` (fixed in
+#8886) and that the same issue's "Portée" carved out for the render-suite
+siblings. The fix is the ``&& rc=0 || rc=$?`` tail (membership in a ``&&``/``||``
+list is exempt from errexit, and ``$?`` reads the real detector exit code).
+
+A unit test cannot observe another job's interpreter -- that is the crack #8884
+fell through (the detector library tests stayed green while the workflow was
+broken in CI). So this ratchet asserts against the **workflow FILE**, not the
+detector. Reverting any gate to the errexit-unsafe form turns this file red
+instead of silently disarming the gate.
+
+Auto-discovers the render-suite via ``{svg,degenerate}*-gate.yml`` so a gate
+added later with the bug is caught here automatically.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+_WF_DIR = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / ".github"
+    / "workflows"
+)
+
+# The render-suite: figure/SVG-quality gates that all run a detect_*.py call
+# under bash -e. Discovered by glob so future render-suite gates are covered.
+_RENDER_SUITE = sorted(
+    list(_WF_DIR.glob("svg-*-gate.yml")) + list(_WF_DIR.glob("degenerate-*-gate.yml"))
+)
+
+
+def _detector_invocation(text: str) -> str | None:
+    """Return the ``out=$(python ... detect_*.py ...)`` line, or None.
+
+    ``cell_order_ci.py`` and other non-detect invocations are intentionally not
+    matched -- this ratchet scopes the #8884 detector motif.
+    """
+    for line in text.splitlines():
+        s = line.strip()
+        if "out=$(" in s and "detect_" in s and "scripts/notebook_tools" in s:
+            return s
+    return None
+
+
+@pytest.mark.parametrize("workflow", _RENDER_SUITE, ids=lambda p: p.stem)
+def test_render_suite_gate_invocation_is_errexit_safe(workflow: pathlib.Path):
+    """Each render-suite gate must read the detector exit code under ``bash -e``.
+
+    The ``out=$(...) && rc=0 || rc=$?`` form preserves the real exit code: a
+    bare ``out=$(cmd)`` aborts the step on non-zero before ``rc=$?`` is read.
+    """
+    assert workflow.is_file(), f"render-suite gate missing: {workflow}"
+    text = workflow.read_text(encoding="utf-8")
+    invocation = _detector_invocation(text)
+    assert invocation is not None, (
+        f"{workflow.name}: expected an `out=$(... detect_*.py ...)` invocation"
+    )
+    assert "&& rc=0 || rc=$?" in invocation, (
+        f"{workflow.name}: errexit-unsafe invocation {invocation!r} -- under "
+        "`bash -e` a bare `out=$(cmd)` aborts before `rc=$?` is read, making the "
+        "rc=1/rc=2 branches dead code. Use `out=$(...) && rc=0 || rc=$?`."
+    )
+    # `|| true` would make `$?` read 0 from `true` itself: rc always 0, so the
+    # gate could never fire at all -- strictly worse than the original bug.
+    assert "|| true" not in invocation, (
+        f"{workflow.name}: `|| true` makes rc always 0 and permanently disarms "
+        "the gate; use `&& rc=0 || rc=$?`."
+    )
+
+
+def test_render_suite_discovered_at_least_the_known_gates():
+    """Guard against the glob silently matching nothing (e.g. a rename).
+
+    If this fails, either the glob pattern drifted or every render-suite gate
+    was renamed -- the parametrize above would then run zero cases and look
+    green for the wrong reason.
+    """
+    stems = {p.stem for p in _RENDER_SUITE}
+    expected = {
+        "svg-decimal-comma-gate",
+        "svg-empty-display-gate",
+        "svg-broken-geometry-gate",
+        "svg-offscreen-flat-gate",
+        "degenerate-figure-gate",
+    }
+    missing = expected - stems
+    assert not missing, (
+        f"render-suite glob no longer matches known gates: {sorted(missing)}; "
+        "the parametrize would run zero cases and hide regressions"
+    )


### PR DESCRIPTION
## What

The #8884 "Portée" follow-up: the four render-suite sibling gates carry the **same errexit defect** #8884 filed against `degenerate-figure-gate` (fixed in #8886).

Under `bash -e` (the Ubuntu runner default: `bash --noprofile --norc -eo pipefail {0}`), a bare `out=$(python detect_*.py ...)` that exits non-zero **aborts the step** before the following `rc=$?` is read. The `rc=1` / `rc=2` branches are unreachable dead code — a real finding surfaces as a bare anonymous `exit 1`, indistinguishable from the detector crashing, and the gate can never **name** the notebook it caught.

| Gate | Buggy line |
|------|-----------|
| `svg-decimal-comma-gate.yml` | `out=$(python ...detect_svg_decimal_commas.py "$nb" --check 2>&1)` then `rc=$?` |
| `svg-empty-display-gate.yml` | same motif |
| `svg-broken-geometry-gate.yml` | same motif |
| `svg-offscreen-flat-gate.yml` | same motif (`--check "$nb"` arg order) |

## Fix

`out=$(...) && rc=0 || rc=$?` — membership in a `&&`/`||` list is errexit-exempt, and `$?` reads the real detector exit code. **NOT `|| true`**: that reads `0` from `true` itself and permanently disarms the gate (strictly worse). Same idiom as #8886.

## Verified firsthand before claiming (#8884: "si confirmé")

The defect only bites if (a) errexit is active, (b) the detector exits non-zero on findings, (c) the gate actually reaches the invocation. All three confirmed:

- **(a) errexit active**: each `run: |` step has **no `shell:` override** → default `bash -eo pipefail`. (The workflows already `|| true`-guard `git diff`, proving the authors knew errexit was on.)
- **(b) non-zero exits**: all 4 detectors `return 1` (finding) / `return 2` (read error) → `sys.exit(main())`. So the assignment aborts before `rc=$?` is read on a finding.
- **(c) stdlib-only**: all 4 import only `argparse`/`json`/`re`/`sys` → **no `pip install` needed** (unlike the degenerate detector's Pillow requirement — Defect 1 of #8884 does NOT apply here, only Defect 2).

## Ratchet — `test_render_suite_gates.py`

A unit test cannot observe another job's interpreter (the crack #8884 fell through — detector library tests stayed green while the CI workflow was broken). So this ratchet asserts against the **workflow FILE**: parametrized over the render-suite (auto-discovers `{svg,degenerate}*-gate.yml`, so a future render gate with the bug is caught automatically), asserting each detector invocation carries `&& rc=0 || rc=$?` and never `|| true`.

**RED→GREEN verified**: reverting `svg-decimal-comma-gate` to the bare form turns the test red with a diagnostic naming the gate + the exact fix; the fix turns it green. #8886's own contract on `degenerate-figure-gate` stays green too (defense in depth). Full bounded suite: **205 passed** (4 svg detector suites + `test_detect_blank_figures` #8886 contract + new render-suite ratchet).

## Scope (atomicity)

Respects #8884's explicit render-suite carve-out. The same `out=$(detector)` + `rc=$?` motif is **confirmed** in 3 non-render gates (`bare-cross-dir-load`, `manifest-description-visuelle`, `md-content-loss`) — that is a **separate grain**, flagged here, not folded in (one subject per PR).

See #8884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
