### PR TITLE
feat(iit,#7746): finalize D2-B as ICT-27 + fix incoming refs (EPIC closure)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-26-SignalingConvention.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-26-SignalingConvention.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "Cette expérience est la **ligne de base « sans coup ontologique »** de la strate 7 :\n",
     "le vocabulaire est **FIXE** — aucun symbole n'est inventé (c'est l'expérience B,\n",
-    "*ICT-XX-SymbolInvention*). On demande alors une chose précise et falsifiable :\n",
+    "*ICT-27-SymbolInvention*). On demande alors une chose précise et falsifiable :\n",
     "\n",
     "> Partant de propensités **uniformes** (aucune signification pré-inscrite), un\n",
     "> **code conventionnel** émerge-t-il spontanément par apprentissage par\n",
@@ -377,7 +377,7 @@
     "\n",
     "**Leçon de l'expérience A** : avec un vocabulaire **fixe**, la signification\n",
     "émerge bien — mais elle est **bornée** par $\\log_2(n_{\\text{signaux}})$. C'est\n",
-    "exactement la borne que l'expérience B (*ICT-XX-SymbolInvention*) lève en\n",
+    "exactement la borne que l'expérience B (*ICT-27-SymbolInvention*) lève en\n",
     "laissant les agents **inventer** de nouveaux signaux à la mesure du problème.\n",
     "Lewis (le *donné*) ouvre sur Skyrms (l'*inventé*)."
    ]

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-27-SymbolInvention.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-27-SymbolInvention.ipynb
@@ -5,7 +5,7 @@
    "id": "f5b39108",
    "metadata": {},
    "source": [
-    "# ICT-XX — Invention de symboles (expérience B, strate 7)\n",
+    "# ICT-27 — Invention de symboles (expérience B, strate 7)\n",
     "\n",
     "*Compagnon pédagogique du module `ict.symbol_invention` (#7746, expérience B).*\n",
     "\n",

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-28-CollectiveAdoption.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-28-CollectiveAdoption.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "*Compagnon pédagogique du module `ict.collective_adoption` (#7746, jambe D2 expérience C).*\n",
     "\n",
-    "Les expériences A (*ICT-26-SignalingConvention*) et B (*ICT-XX-SymbolInvention*)\n",
+    "Les expériences A (*ICT-26-SignalingConvention*) et B (*ICT-27-SymbolInvention*)\n",
     "modélisent **un** couple émetteur/récepteur qui apprend à coordonner. Cette\n",
     "expérience C passe à l'échelle **multi-agent** et pose une question nouvelle :\n",
     "> Une fraction `ρ` d'agents « instigateurs » pré-engagés vers une convention\n",


### PR DESCRIPTION
## What

**EPIC closure for #7746** (strate-7 D2 arc). The five companion notebooks — one per experience — are now all present and stably numbered: **A ICT-26** (signaling_convention) · **B ICT-27** (symbol_invention) · **C ICT-28** (collective_adoption) · **D ICT-29** (concept_inoculation) · **E ICT-30** (inhibited_invention).

B was merged in #8864 as a placeholder `ICT-XX-SymbolInvention` before its final number was decided. This closure assigns B its definitive number **27** and repairs the incoming references that cited the placeholder, so the series reads 26/27/28/29/30 with no gap.

## The change (3 files, 4 line edits + 1 rename)

- **Rename** `ICT-XX-SymbolInvention.ipynb` → `ICT-27-SymbolInvention.ipynb` (`git mv`, 99% similarity, history preserved).
- The placeholder token `ICT-XX` → `ICT-27` is a **same-length (6 chars), pure-ASCII, byte-level swap** with no JSON-special characters — so formatting, indentation, key order, and committed cell outputs are untouched. Only the four narrative mentions change.

## Incoming-reference audit (ai-01 vigilance c.60 #2)

Per the rule *« grep the old name BEFORE the rename, fix incoming references in the SAME PR »*, `git grep ICT-XX` repo-wide returned **exactly four hits**, all fixed here:

| File | Line | Was | Now |
|---|---|---|---|
| ICT-27 (self-title) | 8 | `# ICT-XX — Invention de symboles` | `# ICT-27 — Invention de symboles` |
| ICT-26 (A cites B) | 14 | `*ICT-XX-SymbolInvention*` | `*ICT-27-SymbolInvention*` |
| ICT-26 (A cites B) | 380 | `(*ICT-XX-SymbolInvention*)` | `(*ICT-27-SymbolInvention*)` |
| ICT-28 (C cites A+B) | 12 | `(*ICT-XX-SymbolInvention*)` | `(*ICT-27-SymbolInvention*)` |

**No other references**: zero in READMEs, the catalogue, or `.py` modules (the `symbol_invention` module name is unchanged). ICT-29 and ICT-30 contain no `ICT-XX` token, so they are untouched. Post-rename `git grep ICT-XX` is **empty**.

## Verification

- The three touched notebooks re-pass `count_exercises` (`All meet threshold`, #2161).
- All three remain valid JSON with `execution_count [1..8]` and zero errors; B's committed outputs are intact (no re-execution — markdown-only change).
- Minimal diff: `3 files changed, 4 insertions(+), 4 deletions(-)` + rename — no reformatting noise.

## EPIC status

All five strate-7 modules (signaling_convention, symbol_invention, collective_adoption, concept_inoculation, inhibited_invention) are merged, all five companion notebooks are present and stably numbered, and B carries its final number. **This closes #7746.**

Closes #7746
See #8864 (B module + notebook) · See #8881 (A, ICT-26) · See #8883 (C, ICT-28) · See #8887 (D, ICT-29) · See #8891 (E, ICT-30)

lane: myia-po-2024:CoursIA-2
Grain: MED/refs
