### PR TITLE
fix(lean,#8869): mergeSort→insertionSort swap (decide-reducible sortDedup)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life.lean
@@ -103,10 +103,10 @@ def aliveNext (g : Grid) (p : Int × Int) : Bool :=
 def candidates (g : Grid) : List (Int × Int) :=
   g ++ g.flatMap mooreNeighbors
 
-/-- Reflexive closure of `lexLt`: a **total** comparator for `mergeSort`.
+/-- Reflexive closure of `lexLt`: a **total** comparator for `insertionSort`.
     On distinct pairs it decides exactly like `lexLt`; on equal pairs it is
-    `true`. Totality is what `List.pairwise_mergeSort` needs to certify that
-    the output is sorted (see `Conway.Life.GridCanonical`). -/
+    `true`. Totality is what `List.pairwise_insertionSort` needs to certify
+    that the output is sorted (see `Conway.Life.GridCanonical`). -/
 def lexLe (a b : Int × Int) : Bool :=
   lexLt a b || a == b
 
@@ -115,19 +115,30 @@ def lexLe (a b : Int × Int) : Bool :=
     The comparator is the total `lexLe` and deduplication uses Mathlib's
     `List.dedup`, so the canonical-form lemmas (`sortedness`, `Nodup`,
     membership, extensionality) are all derivable — see
-    `Conway.Life.GridCanonical`. The output is the same as with the strict
-    comparator + `eraseDups`: the comparators agree on all distinct pairs,
-    ties are *equal values* (so any tie-breaking yields the same list), and
-    on a sorted list both dedup flavours collapse each run of equal values
-    to a single copy. -/
+    `Conway.Life.GridCanonical`.
+
+    We use `insertionSort` (rather than `mergeSort`) because the kernel
+    reducer — used by `decide` on the `Computation` theorems — can fully
+    evaluate `List.insertionSort`, whereas `List.mergeSort` stays *stuck*
+    (its nested `merge` is opaque to `decide`). Measured po-2026 c.786
+    (per-target isolated `decide` probe): `mergeSort` stuck for BOTH `Nat`
+    and `Int` element types — the blocker is the sort algorithm, not the
+    coordinate type. `insertionSort` reduces under `decide` (verified POC
+    on the `eater1` 7-cell pattern, #8749 INTRINSIC case). This swap keeps
+    `Int × Int` coordinates (no glider/origin statement altered) and yields
+    a byte-identical canonical list — the comparators agree on all distinct
+    pairs and ties are *equal values*. -/
 def sortDedup (l : List (Int × Int)) : List (Int × Int) :=
-  (l.mergeSort lexLe).dedup
+  -- `insertionSort` (Mathlib) takes a Prop comparator; Lean core `mergeSort`
+  -- takes a Bool comparator. We lift `lexLe : → Bool` to `→ Prop` via
+  -- `= true` so the two comparators decide identically.
+  (List.insertionSort (fun a b => lexLe a b = true) l).dedup
 
 /-- `sortDedup` preserves membership. -/
 theorem mem_sortDedup {p : Int × Int} {l : List (Int × Int)} :
     p ∈ sortDedup l ↔ p ∈ l := by
   unfold sortDedup
-  rw [List.mem_dedup, List.mem_mergeSort]
+  rw [List.mem_dedup, List.mem_insertionSort]
 
 /-- One step of Conway's Game of Life (B3/S23 rule). -/
 def step (g : Grid) : Grid :=

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical.lean
@@ -73,7 +73,7 @@ fondamentales du moteur Life :
   précédent, pour la clôture réflexive.
 - `lexLe_total` : **lexLe total** — `(lexLe a b || lexLe b a) = true` (par
   `simp only [Bool.or_eq_true, lexLe_iff]` + `omega`). C'est l'hypothèse
-  que `List.pairwise_mergeSort` exige sur son argument comparateur.
+  que `List.pairwise_insertionSort` exige sur son argument comparateur.
 - `lexLe_trans` : **lexLe transitif** — `lexLe a c = true` depuis
   `lexLe a b = true` + `lexLe b c = true` (par `simp only [lexLe_iff] at *`
   + `omega`).
@@ -87,7 +87,8 @@ fondamentales du moteur Life :
 - `canonical_sortDedup` : **`sortDedup` produit une grid canonique** —
   `Canonical (sortDedup l)` pour toute liste `l` (par dépliage `sortDedup`
   + `List.Pairwise.sublist (List.dedup_sublist _)` (depuis
-  `pairwise_mergeSort` utilisant `lexLe_trans` + `lexLe_total`) +
+  `pairwise_insertionSort` via instances locales `lexLe_trans` +
+  `lexLe_total`) +
   `List.nodup_dedup _`). Le fait central : toute image `sortDedup` est
   canonique.
 - `Canonical.filter` : **filter préserve la canonicité** — `Canonical
@@ -180,7 +181,7 @@ theorem lexLe_iff {a b : Int × Int} :
   simp only [lexLe, Bool.or_eq_true, lexLt_iff, beq_iff_eq, Prod.ext_iff]
   omega
 
-/-- `lexLe` is total — the hypothesis `List.pairwise_mergeSort` needs. -/
+/-- `lexLe` is total — the hypothesis `List.pairwise_insertionSort` needs. -/
 theorem lexLe_total (a b : Int × Int) : (lexLe a b || lexLe b a) = true := by
   simp only [Bool.or_eq_true, lexLe_iff]
   omega
@@ -198,6 +199,17 @@ theorem lexLe_antisymm (a b : Int × Int)
   rw [Prod.ext_iff]
   omega
 
+/-- Instances de typeclass pour `lexLe`, pour que `List.pairwise_insertionSort`
+    (qui exige `[Std.Total r] [IsTrans α r]`) synthétise automatiquement. -/
+instance lexLe.isTrans : IsTrans (Int × Int) fun a b => lexLe a b = true :=
+  ⟨fun _ _ _ hab hbc => lexLe_trans _ _ _ hab hbc⟩
+
+instance lexLe.isTotal : Std.Total fun a b : Int × Int => lexLe a b = true :=
+  ⟨fun a b => by
+    have h : (lexLe a b || lexLe b a) = true := lexLe_total a b
+    rw [Bool.or_eq_true_eq_eq_true_or_eq_true] at h
+    exact h⟩
+
 /-! ## Canonical grids -/
 
 /-- A grid in canonical form: lexicographically sorted and duplicate-free.
@@ -206,14 +218,22 @@ def Canonical (g : Grid) : Prop :=
   g.Pairwise (fun a b => lexLe a b = true) ∧ g.Nodup
 
 /-- `sortDedup` always produces a canonical grid: sortedness comes from
-    `pairwise_mergeSort` (using totality and transitivity of `lexLe`) and
+    `pairwise_insertionSort` (using totality and transitivity of `lexLe`) and
     survives `dedup` because `dedup` yields a sublist; freedom from
-    duplicates is `nodup_dedup`. -/
+    duplicates is `nodup_dedup`.
+
+    `insertionSort` (not `mergeSort`) is used in `sortDedup` because the
+    kernel reducer can evaluate `List.insertionSort` under `decide` whereas
+    `List.mergeSort` stays stuck (measured po-2026 c.786). The Mathlib lemma
+    `List.pairwise_insertionSort` is typeclass-based (`[Std.Total r]`
+    `[IsTrans α r]`); we discharge those instances locally from
+    `lexLe_total` and `lexLe_trans`. -/
 theorem canonical_sortDedup (l : List (Int × Int)) : Canonical (sortDedup l) := by
   unfold sortDedup
-  exact ⟨List.Pairwise.sublist (List.dedup_sublist _)
-          (List.pairwise_mergeSort lexLe_trans lexLe_total l),
-        List.nodup_dedup _⟩
+  have hsort : List.Pairwise (fun a b => lexLe a b = true)
+      (List.insertionSort (fun a b => lexLe a b = true) l) :=
+    List.pairwise_insertionSort _ l
+  exact ⟨hsort.sublist (List.dedup_sublist _), List.nodup_dedup _⟩
 
 /-- Filtering preserves canonical form (`filter` yields a sublist). -/
 theorem Canonical.filter {g : Grid} (h : Canonical g) (q : (Int × Int) → Bool) :

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical_en.lean
@@ -41,7 +41,7 @@ theorem lexLe_iff {a b : Int × Int} :
   simp only [lexLe, Bool.or_eq_true, lexLt_iff, beq_iff_eq, Prod.ext_iff]
   omega
 
-/-- `lexLe` is total — the hypothesis `List.pairwise_mergeSort` needs. -/
+/-- `lexLe` is total — the hypothesis `List.pairwise_insertionSort` needs. -/
 theorem lexLe_total (a b : Int × Int) : (lexLe a b || lexLe b a) = true := by
   simp only [Bool.or_eq_true, lexLe_iff]
   omega
@@ -59,6 +59,17 @@ theorem lexLe_antisymm (a b : Int × Int)
   rw [Prod.ext_iff]
   omega
 
+/-- Typeclass instances for `lexLe`, so that `List.pairwise_insertionSort`
+    (which requires `[Std.Total r] [IsTrans α r]`) synthesizes automatically. -/
+instance lexLe.isTrans : IsTrans (Int × Int) fun a b => lexLe a b = true :=
+  ⟨fun _ _ _ hab hbc => lexLe_trans _ _ _ hab hbc⟩
+
+instance lexLe.isTotal : Std.Total fun a b : Int × Int => lexLe a b = true :=
+  ⟨fun a b => by
+    have h : (lexLe a b || lexLe b a) = true := lexLe_total a b
+    rw [Bool.or_eq_true_eq_eq_true_or_eq_true] at h
+    exact h⟩
+
 /-! ## Canonical grids -/
 
 /-- A grid in canonical form: lexicographically sorted and duplicate-free.
@@ -67,14 +78,22 @@ def Canonical (g : Grid) : Prop :=
   g.Pairwise (fun a b => lexLe a b = true) ∧ g.Nodup
 
 /-- `sortDedup` always produces a canonical grid: sortedness comes from
-    `pairwise_mergeSort` (using totality and transitivity of `lexLe`) and
+    `pairwise_insertionSort` (using totality and transitivity of `lexLe`) and
     survives `dedup` because `dedup` yields a sublist; freedom from
-    duplicates is `nodup_dedup`. -/
+    duplicates is `nodup_dedup`.
+
+    `insertionSort` (not `mergeSort`) is used in `sortDedup` because the
+    kernel reducer can evaluate `List.insertionSort` under `decide` whereas
+    `List.mergeSort` stays stuck (measured po-2026 c.786). The Mathlib lemma
+    `List.pairwise_insertionSort` is typeclass-based (`[Std.Total r]`
+    `[IsTrans α r]`); we discharge those instances locally from
+    `lexLe_total` and `lexLe_trans`. -/
 theorem canonical_sortDedup (l : List (Int × Int)) : Canonical (sortDedup l) := by
   unfold sortDedup
-  exact ⟨List.Pairwise.sublist (List.dedup_sublist _)
-          (List.pairwise_mergeSort lexLe_trans lexLe_total l),
-        List.nodup_dedup _⟩
+  have hsort : List.Pairwise (fun a b => lexLe a b = true)
+      (List.insertionSort (fun a b => lexLe a b = true) l) :=
+    List.pairwise_insertionSort _ l
+  exact ⟨hsort.sublist (List.dedup_sublist _), List.nodup_dedup _⟩
 
 /-- Filtering preserves canonical form (`filter` yields a sublist). -/
 theorem Canonical.filter {g : Grid} (h : Canonical g) (q : (Int × Int) → Bool) :

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1049,7 +1049,7 @@ live region by at most `2*jumpSize`, within the margin `n`). -/
 theorem isAlive_empty (p : Int × Int) : isAlive ([] : Grid) p = false := by
   simp [isAlive]
 
-/-- `sortDedup` of the empty list is empty (empty `mergeSort`, empty `dedup`). -/
+/-- `sortDedup` of the empty list is empty (empty `insertionSort`, empty `dedup`). -/
 theorem sortDedup_nil : sortDedup ([] : List (Int × Int)) = [] := by
   simp [sortDedup]
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life_en.lean
@@ -103,10 +103,10 @@ def aliveNext (g : Grid) (p : Int × Int) : Bool :=
 def candidates (g : Grid) : List (Int × Int) :=
   g ++ g.flatMap mooreNeighbors
 
-/-- Reflexive closure of `lexLt`: a **total** comparator for `mergeSort`.
+/-- Reflexive closure of `lexLt`: a **total** comparator for `insertionSort`.
     On distinct pairs it decides exactly like `lexLt`; on equal pairs it is
-    `true`. Totality is what `List.pairwise_mergeSort` needs to certify that
-    the output is sorted (see `Conway.Life.GridCanonical`). -/
+    `true`. Totality is what `List.pairwise_insertionSort` needs to certify
+    that the output is sorted (see `Conway.Life.GridCanonical`). -/
 def lexLe (a b : Int × Int) : Bool :=
   lexLt a b || a == b
 
@@ -115,19 +115,30 @@ def lexLe (a b : Int × Int) : Bool :=
     The comparator is the total `lexLe` and deduplication uses Mathlib's
     `List.dedup`, so the canonical-form lemmas (`sortedness`, `Nodup`,
     membership, extensionality) are all derivable — see
-    `Conway.Life.GridCanonical`. The output is the same as with the strict
-    comparator + `eraseDups`: the comparators agree on all distinct pairs,
-    ties are *equal values* (so any tie-breaking yields the same list), and
-    on a sorted list both dedup flavours collapse each run of equal values
-    to a single copy. -/
+    `Conway.Life.GridCanonical`.
+
+    We use `insertionSort` (rather than `mergeSort`) because the kernel
+    reducer — used by `decide` on the `Computation` theorems — can fully
+    evaluate `List.insertionSort`, whereas `List.mergeSort` stays *stuck*
+    (its nested `merge` is opaque to `decide`). Measured po-2026 c.786
+    (per-target isolated `decide` probe): `mergeSort` stuck for BOTH `Nat`
+    and `Int` element types — the blocker is the sort algorithm, not the
+    coordinate type. `insertionSort` reduces under `decide` (verified POC
+    on the `eater1` 7-cell pattern, #8749 INTRINSIC case). This swap keeps
+    `Int × Int` coordinates (no glider/origin statement altered) and yields
+    a byte-identical canonical list — the comparators agree on all distinct
+    pairs and ties are *equal values*. -/
 def sortDedup (l : List (Int × Int)) : List (Int × Int) :=
-  (l.mergeSort lexLe).dedup
+  -- `insertionSort` (Mathlib) takes a Prop comparator; Lean core `mergeSort`
+  -- takes a Bool comparator. We lift `lexLe : → Bool` to `→ Prop` via
+  -- `= true` so the two comparators decide identically.
+  (List.insertionSort (fun a b => lexLe a b = true) l).dedup
 
 /-- `sortDedup` preserves membership. -/
 theorem mem_sortDedup {p : Int × Int} {l : List (Int × Int)} :
     p ∈ sortDedup l ↔ p ∈ l := by
   unfold sortDedup
-  rw [List.mem_dedup, List.mem_mergeSort]
+  rw [List.mem_dedup, List.mem_insertionSort]
 
 /-- One step of Conway's Game of Life (B3/S23 rule). -/
 def step (g : Grid) : Grid :=

--- a/docs/reference/lean-axiom-coverage.md
+++ b/docs/reference/lean-axiom-coverage.md
@@ -106,6 +106,33 @@ La seconde localise l'obstruction : ce n'est pas la taille du calcul, c'est que 
 
 **Recommandation c.954 (livrée par commentaire #8869, 2026-07-29)** : Phase 1 = Option 2 (instance `DecidableEq` manuelle, blast radius minimal, énoncés préservés verbatim). Phase 2 = Option 4 si `lake build` échoue sur `sortDedup` non-réductible.
 
+> **MISE À JOUR c.786/c.795 — Option 2 mesurée INEFFICACE, Option 4 (insertionSort) retenue.**
+>
+> La sonde par-cible-isolée `decide` menée par po-2026 au c.786 a invalidé la
+> premise de la recommandation c.954 : le blocage n'est **ni** le type de
+> coordonnée (`Int` vs `Nat` — `mergeSort` reste stuck pour les DEUX), **ni**
+> l'absence d'instance `DecidableEq` manuelle (le prédicat `beq` sous-jacent
+> est `Bool.beq`, donc `DecidableEq` n'est jamais invoqué par le chemin de
+> réduction). La cause racine est **l'algorithme de tri lui-même** :
+> `List.mergeSort` ne se réduit pas sous le kernel `decide` (son `merge`
+> imbriqué est opaque), tandis que `List.insertionSort` se réduit (POC
+> vérifié sur le motif `eater1` 7-cellules, le cas classé INTRINSIC en #8749).
+>
+> En conséquence :
+> - **Option 2 (ligne RECOMMANDÉ ci-dessus) : SUPERSEDÉE** — mesurée sans
+>   effet. Noter que **#8872 est docs-only** (cette section 3.1.a) : aucune
+>   instance `DecidableEq` manuelle n'a jamais été committée en code. Il n'y
+>   a donc rien à retirer du code source ; cette annotation documente
+>   l'inopérance constatée, comme l'exige l'acceptance du dispatch c.58
+>   (« retire-la, ou annote en place pourquoi elle est inoperante »).
+> - **Option 4 (insertionSort swap) : GREENLIT ai-01 c.794/c.795** (DM
+>   `msg-20260729T220506-0zjzog`), implémentée dans la PR #8869 : swap
+>   `mergeSort lexLe` → `insertionSort lexLe` dans `Conway.Life.sortDedup`,
+>   recâblage de `Conway.Life.GridCanonical.canonical_sortDedup` via
+>   `List.pairwise_insertionSort` (instances `[Std.Total]`/`[IsTrans]`
+>   déchargées localement depuis `lexLe_total`/`lexLe_trans`). Coordonnées
+>   `Int × Int` conservées — aucun énoncé glider/origine/périodicité altéré.
+
 **Critère #5 (sortie INTRINSIC assumée)** : si `lake build` échoue après Option 2 + Option 4 combinées, la whitelist de 19 reste INTRINSIC (assumée, pas dette latente). Issue #8869 se ferme alors avec verdict mesuré, et la whitelist devient un plafond documenté plutôt qu'un objectif de réduction.
 
 **Statut whitelist après c.954** : inchangée. Les 19 noms explicites du commit `84eef8c76` (PR #8746 v2, c.951 MERGED) couvrent toujours les 19 occurrences actuelles. Une baisse éventuelle se fera par sous-grains successifs (1 nom retiré à la fois, après mesure `lake build` SUCCESS + `proof-integrity` vert sur le retrait), pas en une seule PR composite.


### PR DESCRIPTION
## Summary

Implements **Option 4** of #8869: swap `List.mergeSort lexLe` → `List.insertionSort (fun a b => lexLe a b = true)` in `Conway.Life.sortDedup`, so the kernel `decide` reducer can fully evaluate the sort on the `Computation` theorems (the 19 `native_decide` sites).

**Greenlit by ai-01** (c.794/c.795, DM `msg-20260729T220506-0zjzog`). Branch rebased clean on `origin/main` (`814b086fd`): single commit, +123/−35 across 6 files (the prior iterations + 2 unrelated commits were squashed/dropped — both unrelated commits #7746/#8884 are already merged to main via other PRs).

## Root cause (measured, not assumed)

Per-target isolated `decide` probe (po-2026 c.786): `List.mergeSort` stays **stuck** under the kernel `decide` reducer — its nested `merge` is opaque — for **BOTH** `Nat` **AND** `Int` element types. The blocker is the **sort algorithm**, not the coordinate type. This retracts the c.954 Option-2 recommendation (manual `DecidableEq` — measured **INEFFECTIVE**: the `beq`-based predicate means `DecidableEq` is never on the reduction path) and the "Int doesn't reduce, Nat does" framing (false; mergeSort stuck for both).

`List.insertionSort` (Mathlib `Data/List/Sort.lean:65`) **reduces** under `decide` (POC verified on `eater1` 7-cell — the case #8749 classified `INTRINSIC`-stuck).

## Changes (6 files, +123/−35)

| File | Change |
|------|--------|
| `Conway/Life.lean` | `sortDedup`: `mergeSort lexLe` → `insertionSort (· = true)` lift; `mem_sortDedup` via `List.mem_insertionSort` |
| `Conway/Life_en.lean` | byte-identical sibling (i18n #4980) |
| `Conway/Life/GridCanonical.lean` | `canonical_sortDedup` recabled via `List.pairwise_insertionSort`; new global instances `lexLe.isTrans`/`lexLe.isTotal` (Bool totality → Prop disjunction via `Bool.or_eq_true_eq_eq_true_or_eq_true`) |
| `Conway/Life/GridCanonical_en.lean` | byte-identical sibling |
| `Conway/Life/HashlifeCorrectness.lean` | 1-line docstring (`sortDedup_nil`: mergeSort→insertionSort) |
| `docs/reference/lean-axiom-coverage.md` §3.1.a | annotation: Option 2 superseded + #8872 docs-only (annotate-in-place per acceptance) |

**Comparator-type note**: Mathlib `insertionSort` takes `r : α → α → Prop`; Lean core `mergeSort` takes `le : α → α → Bool`. `lexLe : → Bool` lifted to `→ Prop` via `= true` → comparators decide **identically** → canonical list byte-identical. Coordinates `Int × Int` **conserved** (no glider/origin/periodicity statement altered).

## ✅ Build verification — LOCAL SUCCESS (c.798, Branche B unblocked)

Branche B was a **worktree-specific** Mathlib corruption, NOT machine-wide: the `#8895` worktree `.lake/packages/mathlib` was broken (git-clone fail, 0 oleans), but the **main checkout** `conway_lean/.lake` carries a working rc1 cache (**8119 oleans**). Built locally by overlaying the 5 Lean files onto the main-checkout hot cache:

- `Conway.Life.GridCanonical` (FR): **Build completed successfully** (2947 jobs)
- `Conway.Life.GridCanonical_en` (EN): **Build completed successfully**
- `Conway.Life.HashlifeCorrectness` (downstream consumer): **Build completed successfully** (8498 jobs)
- **0 real sorries** in all 5 touched Lean files (no regression; only docstring prose "aucun `sorry`").

`Life.lean` (the foundational sort-swap file) is byte-identical between the build-test base and `origin/main` (`814b086fd`); Mathlib pinned rc1 `d568c8c0` (same cache). The authoritative `lake build` at the PR base runs in **Lean CI (conway_lean)** below.

## Acceptance checklist (per dispatch c.58)

- [x] Option 4 swap in the REAL `Life.lean` pipeline (not just POC)
- [x] **lake build SUCCESS** — local (hot cache, FR + EN + HashlifeCorrectness); CI confirms at base
- [ ] native_decide count per-target before/after (the 7 `native_decide`→`decide` follow-through) — separate sub-grain

See #8869 (partial: enables sort-reducibility; native_decide conversion is the follow-through sub-grain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
