### PR TITLE
refactor(notebook_tools,#8858): migrate all 5 detect_* scanners to canonical notebook_walk walker

### DIFF
--- a/scripts/notebook_tools/detect_accent_stripping.py
+++ b/scripts/notebook_tools/detect_accent_stripping.py
@@ -64,6 +64,9 @@ import sys
 import unicodedata
 from pathlib import Path
 
+# Marcheur + SKIP_DIRS canonique centralises dans notebook_walk (#8650).
+from notebook_walk import iter_notebooks  # noqa: E402
+
 # --- Dictionnaire cure : forme stripped (sans accent) -> forme accentuee correcte ---
 # CONSERVATEUR : la forme stripped ne doit PAS etre un mot francais valide seul,
 # sinon on genere des faux positifs massifs (le scan #2876 historique etait ~96% FP).
@@ -329,19 +332,18 @@ def scan_notebook(path):
 
 
 def _iter_notebooks(family_filter=None):
-    """Genere les chemins des notebooks pedagogiques (MyIA.AI.Notebooks/**/*.ipynb)."""
+    """Genere les chemins des notebooks pedagogiques (MyIA.AI.Notebooks/**/*.ipynb).
+
+    Delegue au marcheur canonique ``notebook_walk.iter_notebooks`` (#8650) :
+    SKIP_DIRS canonique, filtre git tracked_only, et filtre sur le chemin
+    RELATIF a la racine de scan. Cela immunise contre la classe #8858 (un filtre
+    sur les composants ABSOLUS fait matcher le parent du depot quand celui-ci vit
+    sous un dossier nomme ``_archive/`` / ``archive/`` et reduit le scan au
+    silence -- pire qu'un faux positif). Remplace aussi l'ancienne logique de
+    famille fragile (``nb.parts[1]`` assumait un chemin relatif a 2 composants).
+    """
     root = Path("MyIA.AI.Notebooks")
-    if not root.is_dir():
-        return
-    for nb in sorted(root.rglob("*.ipynb")):
-        # skip checkpoints et archives
-        if ".ipynb_checkpoints" in nb.parts or "_archive" in nb.parts:
-            continue
-        if family_filter is not None:
-            # family = sous-dossier de niveau 1 (ex. Sudoku, ML, Probas)
-            if len(nb.parts) < 2 or nb.parts[1] != family_filter:
-                continue
-        yield nb
+    yield from iter_notebooks(root, family=family_filter)
 
 
 def main(argv=None):

--- a/scripts/notebook_tools/detect_markdown_rendering.py
+++ b/scripts/notebook_tools/detect_markdown_rendering.py
@@ -71,6 +71,9 @@ import re
 import sys
 from pathlib import Path
 
+# Marcheur + SKIP_DIRS canonique centralises dans notebook_walk (#8650).
+from notebook_walk import iter_notebooks  # noqa: E402
+
 # ------------------------------------------------------------------ severities
 ERROR = "error"
 WARN = "warn"
@@ -262,9 +265,14 @@ def gather(root: Path) -> list[dict]:
     if root.is_file() and root.suffix == ".ipynb":
         return scan_notebook(root)
     findings: list[dict] = []
-    for p in sorted(root.rglob("*.ipynb")):
-        if ".ipynb_checkpoints" in p.parts:
-            continue
+    # Delegue au marcheur canonique ``notebook_walk.iter_notebooks`` (#8650) :
+    # SKIP_DIRS canonique + filtre git tracked_only + filtre sur le chemin
+    # RELATIF a la racine. Immunise contre la classe #8858 (l'ancien filtre
+    # ``".ipynb_checkpoints" in p.parts`` sur les composants ABSOLUS faisait
+    # matcher le parent du depot sous un dossier nomme ``_archive/`` /
+    # ``archive/`` et reduisait le scan au silence). Single-file pass-through
+    # preserved above.
+    for p in iter_notebooks(root):
         findings.extend(scan_notebook(p))
     return findings
 

--- a/scripts/notebook_tools/detect_papermill_cell_level_state.py
+++ b/scripts/notebook_tools/detect_papermill_cell_level_state.py
@@ -190,40 +190,27 @@ def _read_notebook(nb_path: Path) -> dict | None:
 # Directories skipped during recursive scans. Mirrors the conventions in
 # ``scrub_papermill_paths.py``, ``detect_papermill_path_leak.py`` and
 # ``detect_papermill_failed_state.py``.
-_SKIP_DIR_NAMES = frozenset({
-    ".git",
-    "_archives",
-    "__pycache__",
-    "node_modules",
-    ".venv",
-    "venv",
-})
+# Marcheur canonique centralise dans notebook_walk (#8650) : SKIP_DIRS canonique
+# (sur-ensemble strict de l'ancien ``_SKIP_DIR_NAMES`` local -- ajoute ``.lake``,
+# ``archive``, ``_archive``, ``foundry-lib``, ``.ipynb_checkpoints``, etc., donc
+# les arborescences vendored/archivees ne sont plus auditees), filtre git
+# tracked_only, et filtre sur le chemin RELATIF a la racine (immunise contre la
+# classe #8858 -- un filtre abs-parts reduit le scan au silence sous un parent
+# nomme ``_archives/`` / ``archive/``).
+from notebook_walk import iter_notebooks as _walk_notebooks  # noqa: E402
 
 
 def iter_notebooks(root: Path) -> list[Path]:
-    """Yield every ``*.ipynb`` under ``root`` recursively, skipping noise dirs."""
+    """Yield every ``*.ipynb`` under ``root`` recursively (single-file passthrough).
+
+    Directory walk delegated to ``notebook_walk.iter_notebooks`` (#8650): canonical
+    SKIP_DIRS + git-tracked filter + RELATIVE-path filtering (#8858-immune).
+    """
     if root.is_file():
         return [root] if root.suffix == ".ipynb" else []
     if not root.is_dir():
         return []
-    out: list[Path] = []
-    for p in root.rglob("*.ipynb"):
-        # #8858-class guard: ``root.rglob`` yields ABSOLUTE paths, so
-        # filtering on ``p.parts`` (absolute components) would match the
-        # repo's own parent if it sits under a SKIP_DIR-name dir (e.g. a
-        # checkout cloned at ``_archives/repo/``). That makes the filter
-        # match EVERY path and silences the whole scan — worse than a
-        # false positive. Filter on the path RELATIVE to ``root`` instead
-        # (the in-repo SKIP_DIRS semantics, same as the single-file mode),
-        # falling back to ``p.parts`` when ``p`` is not under ``root``.
-        try:
-            rel_parts = p.relative_to(root).parts
-        except ValueError:
-            rel_parts = p.parts
-        if any(part in _SKIP_DIR_NAMES for part in rel_parts):
-            continue
-        out.append(p)
-    return sorted(out)
+    return list(_walk_notebooks(root))
 
 
 def scan_notebook(nb_path: Path) -> list[dict]:

--- a/scripts/notebook_tools/detect_papermill_failed_state.py
+++ b/scripts/notebook_tools/detect_papermill_failed_state.py
@@ -133,40 +133,27 @@ def _read_notebook(nb_path: Path) -> dict | None:
 
 # Directories skipped during recursive scans. Mirrors the conventions in
 # ``scrub_papermill_paths.py`` and ``detect_papermill_path_leak.py``.
-_SKIP_DIR_NAMES = frozenset({
-    ".git",
-    "_archives",
-    "__pycache__",
-    "node_modules",
-    ".venv",
-    "venv",
-})
+# Marcheur canonique centralise dans notebook_walk (#8650) : SKIP_DIRS canonique
+# (sur-ensemble strict de l'ancien ``_SKIP_DIR_NAMES`` local -- ajoute ``.lake``,
+# ``archive``, ``_archive``, ``foundry-lib``, ``.ipynb_checkpoints``, etc., donc
+# les arborescences vendored/archivees ne sont plus auditees), filtre git
+# tracked_only, et filtre sur le chemin RELATIF a la racine (immunise contre la
+# classe #8858 -- un filtre abs-parts reduit le scan au silence sous un parent
+# nomme ``_archives/`` / ``archive/``).
+from notebook_walk import iter_notebooks as _walk_notebooks  # noqa: E402
 
 
 def iter_notebooks(root: Path) -> list[Path]:
-    """Yield every ``*.ipynb`` under ``root`` recursively, skipping noise dirs."""
+    """Yield every ``*.ipynb`` under ``root`` recursively (single-file passthrough).
+
+    Directory walk delegated to ``notebook_walk.iter_notebooks`` (#8650): canonical
+    SKIP_DIRS + git-tracked filter + RELATIVE-path filtering (#8858-immune).
+    """
     if root.is_file():
         return [root] if root.suffix == ".ipynb" else []
     if not root.is_dir():
         return []
-    out: list[Path] = []
-    for p in root.rglob("*.ipynb"):
-        # #8858-class guard: ``root.rglob`` yields ABSOLUTE paths, so
-        # filtering on ``p.parts`` (absolute components) would match the
-        # repo's own parent if it sits under a SKIP_DIR-name dir (e.g. a
-        # checkout cloned at ``_archives/repo/``). That makes the filter
-        # match EVERY path and silences the whole scan — worse than a
-        # false positive. Filter on the path RELATIVE to ``root`` instead
-        # (the in-repo SKIP_DIRS semantics, same as the single-file mode),
-        # falling back to ``p.parts`` when ``p`` is not under ``root``.
-        try:
-            rel_parts = p.relative_to(root).parts
-        except ValueError:
-            rel_parts = p.parts
-        if any(part in _SKIP_DIR_NAMES for part in rel_parts):
-            continue
-        out.append(p)
-    return sorted(out)
+    return list(_walk_notebooks(root))
 
 
 def scan_notebook(nb_path: Path) -> list[dict]:

--- a/scripts/notebook_tools/detect_papermill_path_leak.py
+++ b/scripts/notebook_tools/detect_papermill_path_leak.py
@@ -246,40 +246,27 @@ def _collect_leaks(
 
 # Directories skipped during recursive scans. Mirrors the conventions in
 # ``scrub_papermill_paths.py`` and the other detectors.
-_SKIP_DIR_NAMES = frozenset({
-    ".git",
-    "_archives",
-    "__pycache__",
-    "node_modules",
-    ".venv",
-    "venv",
-})
+# Marcheur canonique centralise dans notebook_walk (#8650) : SKIP_DIRS canonique
+# (sur-ensemble strict de l'ancien ``_SKIP_DIR_NAMES`` local -- ajoute ``.lake``,
+# ``archive``, ``_archive``, ``foundry-lib``, ``.ipynb_checkpoints``, etc., donc
+# les arborescences vendored/archivees ne sont plus auditees), filtre git
+# tracked_only, et filtre sur le chemin RELATIF a la racine (immunise contre la
+# classe #8858 -- un filtre abs-parts reduit le scan au silence sous un parent
+# nomme ``_archives/`` / ``archive/``).
+from notebook_walk import iter_notebooks as _walk_notebooks  # noqa: E402
 
 
 def iter_notebooks(root: Path) -> list[Path]:
-    """Yield every ``*.ipynb`` under ``root`` recursively, skipping noise dirs."""
+    """Yield every ``*.ipynb`` under ``root`` recursively (single-file passthrough).
+
+    Directory walk delegated to ``notebook_walk.iter_notebooks`` (#8650): canonical
+    SKIP_DIRS + git-tracked filter + RELATIVE-path filtering (#8858-immune).
+    """
     if root.is_file():
         return [root] if root.suffix == ".ipynb" else []
     if not root.is_dir():
         return []
-    out: list[Path] = []
-    for p in root.rglob("*.ipynb"):
-        # #8858-class guard: ``root.rglob`` yields ABSOLUTE paths, so
-        # filtering on ``p.parts`` (absolute components) would match the
-        # repo's own parent if it sits under a SKIP_DIR-name dir (e.g. a
-        # checkout cloned at ``_archives/repo/``). That makes the filter
-        # match EVERY path and silences the whole scan — worse than a
-        # false positive. Filter on the path RELATIVE to ``root`` instead
-        # (the in-repo SKIP_DIRS semantics, same as the single-file mode),
-        # falling back to ``p.parts`` when ``p`` is not under ``root``.
-        try:
-            rel_parts = p.relative_to(root).parts
-        except ValueError:
-            rel_parts = p.parts
-        if any(part in _SKIP_DIR_NAMES for part in rel_parts):
-            continue
-        out.append(p)
-    return sorted(out)
+    return list(_walk_notebooks(root))
 
 
 def scan_notebook(nb_path: Path, *, include_outputs: bool = False) -> list[dict]:

--- a/scripts/notebook_tools/tests/test_detect_accent_stripping.py
+++ b/scripts/notebook_tools/tests/test_detect_accent_stripping.py
@@ -33,6 +33,7 @@ from detect_accent_stripping import (  # noqa: E402
     ACCENT_PAIRS,
     _STRIP_RE,
     _build_regex,
+    _iter_notebooks,
     _src_lines,
     main,
     scan_notebook,
@@ -382,3 +383,55 @@ class TestMainExitCodes:
         # The detector uses ensure_ascii=False (per source line 302).
         assert "problème" in out
         assert rc == 0  # no --check => exit 0
+
+
+# ---------------------------------------------------------------------------
+# Walker delegation (#8858-structural migration, c.959)
+# ---------------------------------------------------------------------------
+# _iter_notebooks delegates to notebook_walk.iter_notebooks (#8650): canonical
+# SKIP_DIRS + git-tracked filter + RELATIVE-path filtering. The old local walker
+# only knew ``_archive`` (singular) -- it missed ``archive/`` and ``_archives/``
+# and audited archived legacy notebooks (6 false hit-bearers on main, all under
+# Search/archive, SymbolicAI/archive, SymbolicAI/SymbolicLearning/_archives).
+# This locks the canonical coverage so the gap cannot regress.
+
+class TestWalkerDelegatesToNotebookWalk:
+    def test_archived_notebooks_excluded(self, tmp_path, monkeypatch):
+        root = tmp_path / "MyIA.AI.Notebooks"
+        live = root / "ML" / "live.ipynb"
+        archived = root / "SymbolicAI" / "archive" / "old.ipynb"
+        archived2 = root / "SL" / "_archives" / "legacy.ipynb"
+        for p in (live, archived, archived2):
+            p.parent.mkdir(parents=True, exist_ok=True)
+            _write_nb(p, [_md("# ecole\n")])  # stripped (would be a hit if scanned)
+        monkeypatch.chdir(tmp_path)
+        names = {Path(p).name for p in _iter_notebooks()}
+        assert "live.ipynb" in names
+        assert "old.ipynb" not in names, (
+            "archived notebook (archive/) must be excluded by canonical SKIP_DIRS"
+        )
+        assert "legacy.ipynb" not in names, (
+            "archived notebook (_archives/) must be excluded by canonical SKIP_DIRS"
+        )
+
+    def test_relative_and_absolute_root_give_same_count(self, tmp_path, monkeypatch):
+        """#8858 immunity: nesting the tree under an archive-named parent, or
+        passing an absolute root, must NOT silence the scan (the old abs-parts
+        filter class). Build the same tree at two roots and compare counts."""
+        def build(base):
+            root = base / "MyIA.AI.Notebooks" / "ML"
+            root.mkdir(parents=True, exist_ok=True)
+            _write_nb(root / "a.ipynb", [_md("# ecole\n")])
+            _write_nb(root / "b.ipynb", [_md("# ouvert\n")])
+            return base
+
+        normal = build(tmp_path / "normal")
+        nested = build(tmp_path / "_archive" / "clone")  # parent named _archive
+        monkeypatch.chdir(normal)
+        n_normal = len(list(_iter_notebooks()))
+        monkeypatch.chdir(nested)
+        n_nested = len(list(_iter_notebooks()))
+        assert n_normal == n_nested == 2, (
+            f"#8858 parity failed: normal={n_normal} nested-under-_archive={n_nested} "
+            "(expected equal, non-zero)"
+        )


### PR DESCRIPTION
## Summary

**#8858-structural migration** (steer ai-01 c.59, deconflicted from po-2024): retire every per-scanner `rglob` + local `SKIP_DIRS` in the 5 `notebook_tools/detect_*` scanners in favor of the canonical `notebook_walk.iter_notebooks` walker (#8650). Until each scanner carries its own walk, the #8858-class defect (filtering on ABSOLUTE path components → silent empty scan when the repo sits under a SKIP_DIR-named parent — *worse* than a false positive) is guaranteed to recur — 3 PRs (#8859/#8865/#8871) already point-fixed it by copying the same six lines.

> Originally scoped as 2 tranches; unified into one PR (the two commits are `ab064490e` accent+markdown_rendering and `0348f9965` papermill trio). Force-pushing to split is forbidden (git-workflow HARD rule), and the unified migration is a single coherent subject — 1 feature, 1 domain, +121/−97 across 6 files — well under the G.4 composite thresholds.

### Scanners migrated (5)

| Scanner | Old walker | Behavior change |
|---------|-----------|-----------------|
| `detect_accent_stripping.py` | `.rglob` + `.parts` filter (`_archive` singular) + fragile `nb.parts[1]` family | **860→854** notebooks-with-hits (6 TRACKED-but-ARCHIVED excluded — coverage FIX) |
| `detect_markdown_rendering.py` | `.rglob` + `.parts` filter (checkpoints only) | 225→225 findings (no change) |
| `detect_papermill_cell_level_state.py` | local `_SKIP_DIR_NAMES` (6) + duplicated `iter_notebooks` | 1→1 finding (no change) |
| `detect_papermill_failed_state.py` | identical | 0→0 (no change) |
| `detect_papermill_path_leak.py` | identical | 6→6 files (no change) |

All delegate to `notebook_walk.iter_notebooks` (#8650): canonical `SKIP_DIRS` (strict superset of every local set — adds `.lake`, `archive`, `_archive`, `foundry-lib`, `.ipynb_checkpoints`, etc.), git-tracked filter, RELATIVE-path filtering. Single-file passthrough (`--scan PATH` / positional notebook) preserved everywhere.

## Why accent_stripping's 860→854 is a FIX not a regression

The 6 dropped notebooks are **all TRACKED-but-ARCHIVED**:
- `Search/archive/{CSPs_Intro,Exploration_*}.ipynb`
- `SymbolicAI/archive/Tweety.ipynb`, `SymbolicAI/Planners/archive/Fast-Downward-Legacy.ipynb`
- `SymbolicAI/SymbolicLearning/_archives/2026-07-04-*/EML-NAND-{Compose,Explore}.ipynb`

The OLD skip-set only had `_archive` (singular); canonical `SKIP_DIRS` adds `archive`/`_archives` → archived legacy notebooks are now correctly excluded. They were spurious accent-stripping hit-bearers no PR will fix.

## #8858 two-root parity (c.59 acceptance)

NEW scanners, relative-root vs absolute-root give **identical** counts (immune to the abs-parts silencing):
- `detect_markdown_rendering`: 225 = 225
- `detect_papermill_path_leak`: 12 = 12

A regression test (`TestWalkerDelegatesToNotebookWalk`, 2 cases in `test_detect_accent_stripping.py`) locks the archived-notebook exclusion and the relative/absolute-root parity.

## Tests

`notebook_tools` full suite: **3723 passed**.

## Diffstat

```
6 files changed, 121 insertions(+), 97 deletions(-)
detect_accent_stripping.py            | walker delegation (+regression-test doc)
detect_markdown_rendering.py          | walker delegation
detect_papermill_cell_level_state.py  | -local SKIP_DIRS -dup walker, +delegate (net -39 across trio)
detect_papermill_failed_state.py      | same
detect_papermill_path_leak.py         | same
tests/test_detect_accent_stripping.py | +TestWalkerDelegatesToNotebookWalk (2 tests)
```

## Scope / next

The 5 `notebook_tools/detect_*` scanners that carried their own walker are now retired. Remaining `rglob("*.ipynb")` users are non-detector tools (`count_exercises` already point-fixed #8880; `audit_*`/`check_*`/`scan_*`/`forensic_*`; the `genai-stack` ecosystem) — separate tranches by theme.

`Grain: MED/refactor — lane myia-po-2023:CoursIA — prev: LIGHT/ledger (#8870)`

See #8858 (bug-class origin), #8650 (canonical walker), #8880 (count_exercises point-fix same class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)