### PR TITLE
refactor(scanners,#8858): audit_solution_leaks + audit_pip_install_cells → notebook_walk (tranche 3)

### DIFF
--- a/scripts/notebook_tools/audit_pip_install_cells.py
+++ b/scripts/notebook_tools/audit_pip_install_cells.py
@@ -57,6 +57,15 @@ from collections import Counter
 from pathlib import Path
 from typing import Iterable
 
+# Marcheur canonique centralise dans notebook_walk (#8650) : SKIP_DIRS canonique
+# (sur-ensemble strict de l'ancien filtre local -- ajoute ``.lake``, ``archive``,
+# ``_archive``, ``foundry-lib``, ``.ipynb_checkpoints``, etc., donc les
+# arborescences vendored/archivees ne sont plus auditees), filtre git
+# tracked_only, et filtre sur le chemin RELATIF a la racine (immunise contre la
+# classe #8858 -- un filtre abs-parts reduit le scan au silence sous un parent
+# nomme ``_archives/`` / ``archive/``).
+from notebook_walk import iter_notebooks as _walk_notebooks  # noqa: E402
+
 # A line that runs pip in a cell. Captures:
 #   !pip install pandas
 #   !{sys.executable} -m pip install pandas
@@ -113,15 +122,16 @@ def _classify_cell(source: str) -> str:
 def _iter_notebooks(root: Path) -> Iterable[Path]:
     """Yield notebooks under ``root``, excluding papermill output artifacts.
 
-    The ``iter_notebooks`` convention (cf #6312) excludes
-    ``_output.ipynb`` and ``_executed.ipynb`` paths (papermill artifacts,
-    never source). This keeps the audit focused on what's actually
-    committed and reviewed.
+    Directory walk delegated to ``notebook_walk.iter_notebooks`` (#8650):
+    canonical SKIP_DIRS (excludes .lake/foundry-lib/archive/_archives/etc.),
+    git-tracked filter, RELATIVE-path filtering (#8858-immune). The
+    ``_output.ipynb`` papermill artifact is handled by the walker's
+    ``skip_papermill_output``; ``_executed.ipynb`` (a second papermill
+    artifact convention) is preserved here as a thin post-filter because the
+    canonical walker does not know that suffix.
     """
-    for path in sorted(root.rglob("*.ipynb")):
-        parts = path.parts
-        if any(part.endswith("_output.ipynb") or part.endswith("_executed.ipynb")
-               for part in parts):
+    for path in _walk_notebooks(root):
+        if path.name.endswith("_executed.ipynb"):
             continue
         yield path
 

--- a/scripts/notebook_tools/audit_solution_leaks.py
+++ b/scripts/notebook_tools/audit_solution_leaks.py
@@ -18,6 +18,15 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 NOTEBOOKS_DIR = REPO_ROOT / "MyIA.AI.Notebooks"
 
+# Marcheur canonique centralise dans notebook_walk (#8650) : SKIP_DIRS canonique
+# (sur-ensemble strict de l'ancienne exclusion locale -- ajoute ``.lake``,
+# ``archive``, ``_archive``, ``foundry-lib``, ``.ipynb_checkpoints``, etc., donc
+# les arborescences vendored/archivees ne sont plus auditees), filtre git
+# tracked_only, et filtre sur le chemin RELATIF a la racine (immunise contre la
+# classe #8858 -- un filtre abs-parts reduit le scan au silence sous un parent
+# nomme ``_archives/`` / ``archive/``).
+from notebook_walk import iter_notebooks as _walk_notebooks  # noqa: E402
+
 EXERCICE_MARKERS = re.compile(
     r'#\s*(Exercice|TODO\s+etudiant|Etape)\s*\d*', re.IGNORECASE
 )
@@ -352,9 +361,8 @@ def _run_audit():
     Shared by the human-readable report (default) and the ``--json`` machine
     output consumed by ``solution_leak_delta.py`` (CI WARN-mode gate, #8053).
     """
-    notebooks = list(NOTEBOOKS_DIR.rglob('*.ipynb'))
-    notebooks = [n for n in notebooks if '_output' not in n.name and '_executed' not in n.name
-                 and '.ipynb_checkpoints' not in str(n)]
+    notebooks = [n for n in _walk_notebooks(NOTEBOOKS_DIR)
+                 if '_executed' not in n.name]
 
     results = {}
     total_leaks = {


### PR DESCRIPTION
## Summary

Tranche 3 of the **#8858-structural** DEEP migration (audit_* family). Both CI-wired audit scanners had bespoke non-canonical walkers (`NOTEBOOKS_DIR.rglob` + suffix/abs-path filters). Migrated both to `notebook_walk.iter_notebooks` (#8650): canonical `SKIP_DIRS` + git-tracked filter + **RELATIVE-path filtering (#8858-immune)**.

- `audit_solution_leaks.py` — replaced `rglob` + name/`str()` filter with `_walk_notebooks(NOTEBOOKS_DIR)` + `_executed` post-filter.
- `audit_pip_install_cells.py` — replaced `rglob` + abs-`parts` suffix filter (a **#8858-class** bug: filter on `path.parts` from `rglob` reduces the scan to silence when the repo sits under an `archive/`-named parent) with `_walk_notebooks(root)` + `_executed` post-filter.

Pattern proven in **#8899** (detect_* family, +121/−97 across 5 scanners).

## Behavior measured OLD-vs-NEW

Both scanners: **952 → 946 notebooks. Exactly 6 dropped, ALL vendored/archive** — identical 6 files in both:

- `Search/archive/CSPs_Intro.ipynb`
- `Search/archive/Exploration_non_informée_et_informée_intro.ipynb`
- `SymbolicAI/Planners/archive/Fast-Downward-Legacy.ipynb`
- `SymbolicAI/SymbolicLearning/_archives/2026-07-04-…/EML-NAND-Compose.ipynb`
- `SymbolicAI/SymbolicLearning/_archives/2026-07-04-…/EML-NAND-Explore.ipynb`
- `SymbolicAI/archive/Tweety.ipynb`

**0 real notebooks dropped, 0 added.** This is a coverage FIX: both scanners were auditing 6 archived/vendored trees they should skip per canonical `SKIP_DIRS`. Not a silent-empty regression, not a real-notebook loss. Same 6 files both scanners = consistent behavior.

## Why `audit_c1_c3` is deliberately excluded

`audit_c1_c3.EXCLUDE_DIRS` carries scanner-specific exclusions (`obj`, `bin`, `research`, `partner-course`, `examples`) that **do not map to canonical `SKIP_DIRS`**. Migrating it would change behavior in *both* directions (drop `.lake`-skip but start auditing `obj`/`bin`; stop auditing `partner-course`). It is already #8858-point-fixed; its migration value is pure dedup with behavior-change risk, so it is deferred rather than forced.

## Tests

```
3721 passed in 75.05s   # full scripts/notebook_tools/tests/ suite
266 passed (audit + walk + solution-leak + delta suites targeted)
```

---

See #8858 #8650 #8899

`Grain: MED/refactor — lane myia-po-2023:CoursIA`
