### PR TITLE
feat(z3-python,#1206): Python data-layer notebook (Meal-Planner G1)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-16b-Meal-Planner-Data-External.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-16b-Meal-Planner-Data-External.ipynb
@@ -1,0 +1,837 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3b618ed6",
+   "metadata": {},
+   "source": [
+    "# Z3-Python-16b — Meal-Planner : couche de données réelles (Ciqual × RecipeML)\n",
+    "\n",
+    "*Compagnon « data layer » du module [Z3-Python-16 — Meal-Planner](Z3-Python-16-Meal-Planner.ipynb) (strate SMT, jambe Python-large du planificateur #1206).*\n",
+    "\n",
+    "Le notebook [16](Z3-Python-16-Meal-Planner.ipynb) posait la **modélisation** (3 encodages,\n",
+    "`Optimize`, matrice `jours × plats`) sur un **corpus jouet** (24 plats saisis à la main, la\n",
+    "nutrition = un scalaire par plat). Ce notebook **16b** est la **couche de données** qui\n",
+    "manquait : il charge un corpus **réel** (Ciqual ANSES 2025 × archive RecipeML), le fusionne\n",
+    "par **appariement lexical flou**, normalise les quantités en **grammes**, et agrège la\n",
+    "nutrition **pondérée par la masse** — puis sérialise un cache propre que les notebooks de\n",
+    "capstone consommeront. **0 solveur** : pur *data-engineering*.\n",
+    "\n",
+    "> **Port fidèle du C# `07_Meal_Planner_Data_External`** ([Z3-Linq2Z3](../Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb)).\n",
+    "> La logique (normalisation étagée, garde tête-de-nom, densités, gating) est transposée\n",
+    "> *byte-pour-byte* ; seule la plomberie change : `XmlReader` → `xml.etree.ElementTree.iterparse`,\n",
+    "> LINQ → Python natif. Les valeurs committées sont **recomputées** à l'exécution (anti-drift).\n",
+    "\n",
+    "## Deux sources, une jointure de *data fusion*\n",
+    "\n",
+    "| Source | Rôle | Format | Ce qu'elle apporte |\n",
+    "|--------|------|--------|--------------------|\n",
+    "| **Ciqual (ANSES 2025)** | référentiel nutrition | XML | composition de ~3484 aliments **par 100 g** ; noms **anglais** (`alim_nom_eng`) |\n",
+    "| **RecipeML** (archive culinaire) | corpus recettes | XML auto-décrit | `<ing>` = `<amt><qty>` + `<unit>` + `<item>` — **avec les quantités** |\n",
+    "\n",
+    "RecipeML porte **quoi** (les ingrédients), Ciqual porte **combien** (la nutrition). Aucune clé\n",
+    "commune ne les relie : seul un **appariement lexical approximatif** (item anglais ↔\n",
+    "`alim_nom_eng`) fait le pont. C'est de la **fusion de données réelle** — pas un `join` jouet.\n",
+    "\n",
+    "> **Échelle démonstrative.** Ce notebook charge un **sous-ensemble** du corpus (Ciqual\n",
+    "> complet + 5 lots RecipeML ≈ 500 recettes) pour valider le pipeline bout-en-bout en quelques\n",
+    "> secondes. Le **taux** de couverture d'appariement (~72 %) est reproductible et constitue la\n",
+    "> métrique *cross-stack* (il matche le port C# à 73,1 %) ; le **compte absolu** d'utilisables\n",
+    "> (~215) dépend de la taille du sous-ensemble. Le passage à l'échelle sur le corpus plein\n",
+    "> (~11 000 recettes, ~2 400 utilisables) est l'objet du grain **convergence-scale** (G3) :\n",
+    "> augmenter `--recipeml-limit` dans la cellule de *setup*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1a256fc7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:15:20.988503Z",
+     "iopub.status.busy": "2026-07-30T00:15:20.987503Z",
+     "iopub.status.idle": "2026-07-30T00:15:21.095736Z",
+     "shell.execute_reply": "2026-07-30T00:15:21.094731Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Donnees presentes : Ciqual, RecipeML\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Setup : imports + données (téléchargées si absentes, via le downloader partagé).\n",
+    "import sys, json, re, unicodedata\n",
+    "from pathlib import Path\n",
+    "from xml.etree import ElementTree as ET\n",
+    "\n",
+    "BASE = Path(\"data/meals\")\n",
+    "# --- truststore : cert store OS natif (proxy SSL corporate SOTA, on ne DESACTIVE pas la vérif) ---\n",
+    "try:\n",
+    "    import truststore; truststore.inject_into_ssl()\n",
+    "except Exception:\n",
+    "    pass  # env sans MITM : urllib utilise déjà le default context\n",
+    "\n",
+    "if not (BASE / \"Ciqual\").exists() or not (BASE / \"RecipeML\").exists():\n",
+    "    print(\"Donnees absentes : appel du downloader partage (subset limit 5 batches RecipeML)...\")\n",
+    "    # reuse the shared downloader in-process (avoids touching po-2025's file)\n",
+    "    import importlib.util\n",
+    "    _p = Path(\"../Z3-Linq2Z3/download_meal_data.py\").resolve()\n",
+    "    _spec = importlib.util.spec_from_file_location(\"dl\", _p)\n",
+    "    _dl = importlib.util.module_from_spec(_spec); _spec.loader.exec_module(_dl)\n",
+    "    _dl.main([\"--dest\", str(BASE), \"--areas\", \"Ciqual\", \"RecipeML\", \"--recipeml-limit\", \"5\"])\n",
+    "\n",
+    "dirs = sorted(p.name for p in BASE.iterdir() if p.is_dir())\n",
+    "print(\"Donnees presentes :\", \", \".join(dirs) if dirs else \"(aucune)\")\n",
+    "assert (BASE / \"Ciqual\").exists() and (BASE / \"RecipeML\").exists(), \"Corpus toujours absent.\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ed80d6f",
+   "metadata": {},
+   "source": [
+    "## 1. Ciqual : le référentiel nutritionnel (per-100g), lu en flux\n",
+    "\n",
+    "On lit `const` (5 constituants contraints : énergie, protéines, glucides, lipides, sel), `alim`\n",
+    "(nom anglais) et `compo` (teneurs) — le gros fichier `compo` (~66 Mo) est lu **en flux**\n",
+    "(`iterparse` + `clear`) pour ne pas tout charger en mémoire. Les teneurs Ciqual sont **toutes\n",
+    "par 100 g** — c'est ce qui rendra la normalisation en grammes (§4) indispensable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "39cc27d6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:15:21.097736Z",
+     "iopub.status.busy": "2026-07-30T00:15:21.097736Z",
+     "iopub.status.idle": "2026-07-30T00:15:27.250123Z",
+     "shell.execute_reply": "2026-07-30T00:15:27.249118Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ciqual charge en 6.1s : 74 constituants, 3484 aliments, 3484 avec composition.\n",
+      "Constituants contraints (C=5) :\n",
+      "   [327] Energie, Règlement UE N° 1169/2011 (kJ/100 g)\n",
+      "   [25000] Protéines, N x facteur de Jones (g/100 g)\n",
+      "   [31000] Glucides (g/100 g)\n",
+      "   [40000] Lipides (g/100 g)\n",
+      "   [10004] Sel chlorure de sodium (g/100 g)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Ciqual : lecture en flux du sous-ensemble des constituants contraints.\n",
+    "import time\n",
+    "WANTED = [\"Energie, Règlement\", \"Protéines, N x\", \"Glucides (g\", \"Lipides (g\", \"Sel chlorure\"]\n",
+    "\n",
+    "def _text_stream(path, record_tag, fields):\n",
+    "    \"\"\"Stream an XML file yielding dicts for each <record_tag> with wanted text fields.\"\"\"\n",
+    "    fields = set(fields)\n",
+    "    for ev, el in ET.iterparse(path, events=(\"start\", \"end\")):\n",
+    "        if ev == \"start\" and el.tag == record_tag:\n",
+    "            cur = {f: None for f in fields}\n",
+    "        elif ev == \"end\":\n",
+    "            if el.tag in fields:\n",
+    "                cur[el.tag] = (el.text or \"\").strip()\n",
+    "            elif el.tag == record_tag:\n",
+    "                yield cur\n",
+    "            el.clear()  # free memory\n",
+    "\n",
+    "# const_code -> nom FR\n",
+    "consts = {}\n",
+    "for r in _text_stream(BASE / \"Ciqual/const_2025_11_03.xml\", \"CONST\", [\"const_code\", \"const_nom_fr\"]):\n",
+    "    if r[\"const_code\"]:\n",
+    "        consts[r[\"const_code\"]] = r[\"const_nom_fr\"] or \"\"\n",
+    "chosen = []\n",
+    "for w in WANTED:\n",
+    "    pref = w[:18]\n",
+    "    code = next(c for c, n in consts.items() if n.startswith(pref))\n",
+    "    chosen.append(code)\n",
+    "codeIdx = {c: i for i, c in enumerate(chosen)}\n",
+    "C = len(chosen)\n",
+    "\n",
+    "# alim_code -> nom anglais\n",
+    "alimEng = {}\n",
+    "for r in _text_stream(BASE / \"Ciqual/alim_2025_11_03.xml\", \"ALIM\", [\"alim_code\", \"alim_nom_eng\"]):\n",
+    "    if r[\"alim_code\"]:\n",
+    "        alimEng[r[\"alim_code\"]] = r[\"alim_nom_eng\"] or \"\"\n",
+    "\n",
+    "def parse_teneur(s):\n",
+    "    if not s:\n",
+    "        return 0.0\n",
+    "    s = s.replace(\"traces\", \"0\").replace(\"<\", \" \").replace(\"-\", \"0\").replace(\",\", \".\").strip()\n",
+    "    try:\n",
+    "        return float(s)\n",
+    "    except ValueError:\n",
+    "        return 0.0\n",
+    "\n",
+    "t0 = time.time()\n",
+    "alimCompo = {}  # alim_code -> [teneurs sur C constituants]\n",
+    "for r in _text_stream(BASE / \"Ciqual/compo_2025_11_03.xml\", \"COMPO\", [\"alim_code\", \"const_code\", \"teneur\"]):\n",
+    "    cc, ac = r[\"const_code\"], r[\"alim_code\"]\n",
+    "    if cc in codeIdx and ac:\n",
+    "        alimCompo.setdefault(ac, [0.0] * C)[codeIdx[cc]] = parse_teneur(r[\"teneur\"])\n",
+    "print(f\"Ciqual charge en {time.time()-t0:.1f}s : {len(consts)} constituants, \"\n",
+    "      f\"{len(alimEng)} aliments, {len(alimCompo)} avec composition.\")\n",
+    "print(f\"Constituants contraints (C={C}) :\")\n",
+    "for cc in chosen:\n",
+    "    print(f\"   [{cc}] {consts[cc][:48]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38e6dbb9",
+   "metadata": {},
+   "source": [
+    "## 2. La jointure de data fusion : ingrédient anglais → aliment Ciqual\n",
+    "\n",
+    "RecipeML est en **anglais** ; on matche contre `alim_nom_eng`. Un **index inversé** mot →\n",
+    "aliments accélère la recherche : chaque ingrédient n'est comparé qu'aux aliments partageant au\n",
+    "moins un mot. La **normalisation étagée** est la leçon — et la curation tue les faux positifs :\n",
+    "\n",
+    "1. **déaccentuation** + singularisation grossière + suppression des mots de préparation/qualificatifs ;\n",
+    "2. **aliment primaire** = avant la 1re virgule côté Ciqual (`Sugar, white` → tête = `sugar`) ;\n",
+    "3. **garde sur la tête-de-nom** : l'aliment candidat doit partager le **dernier mot** de l'ingrédient\n",
+    "   (le nom, pas l'adjectif) — c'est ce qui écarte « White pudding » pour « white **sugar** » ;\n",
+    "4. **similarité de Jaccard** (seuil 0,5), départage par nom Ciqual **le plus court** ;\n",
+    "5. petites tables de **synonymes** / **composés** / **modificateurs de forme**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8725053f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:15:27.252122Z",
+     "iopub.status.busy": "2026-07-30T00:15:27.252122Z",
+     "iopub.status.idle": "2026-07-30T00:15:27.299179Z",
+     "shell.execute_reply": "2026-07-30T00:15:27.298126Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Démonstration du matcheur curé sur quelques items RecipeML :\n",
+      "   'White sugar'            -> Sugar, white\n",
+      "   'All-purpose flour'      -> Soya flour, wholegrain\n",
+      "   'Baking soda'            -> Sodium bicarbonate\n",
+      "   'Eggs'                   -> Egg, raw\n",
+      "   'Butter'                 -> Butter, 80% fat minimum, unsalted\n",
+      "   'Olive oil'              -> Olive oil, extra virgin\n",
+      "   'Salt pepper'            -> Salt, pure sea salt, no fortification\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Rapprochement lexical CURÉ : normalisation étagée + index inversé + garde tête-de-nom.\n",
+    "# (port verbatim du C# 07 : DROP / SYN / COMPOUND + Deaccent / Singular / Norm / Jacc / MatchKey)\n",
+    "DROP = set((\"chopped ground grated minced sliced diced melted softened packed sifted beaten cooked raw \"\n",
+    "    \"peeled seeded finely coarsely halved quartered cubed shredded crushed crumbled drained rinsed \"\n",
+    "    \"lightly thinly thickly cut divided fresh dried frozen canned chilled warmed uncooked prepared \"\n",
+    "    \"unbaked mashed toasted roasted boiled steamed blanched julienned trimmed cored pitted stemmed deveined \"\n",
+    "    \"large small medium extra whole ripe boneless skinless unsalted salted lean heavy light dark \"\n",
+    "    \"granulated powdered confectioners all purpose self rising active instant fine coarse \"\n",
+    "    \"of to for the with and or into pieces piece plus taste needed garnish optional about each more \"\n",
+    "    \"as in at room temperature degrees inch thick thin long your favorite good quality such other any some few several\").split())\n",
+    "\n",
+    "SYN = {\"catsup\": \"ketchup\", \"scallion\": \"green onion\", \"cilantro\": \"coriander\",\n",
+    "    \"cornstarch\": \"corn starch\", \"shortening\": \"vegetable fat\", \"baking soda\": \"sodium bicarbonate\",\n",
+    "    \"confectioner sugar\": \"icing sugar\", \"powdered sugar\": \"icing sugar\", \"bell pepper\": \"sweet pepper\",\n",
+    "    \"heavy cream\": \"cream\", \"whipping cream\": \"cream\", \"vanilla extract\": \"vanilla\",\n",
+    "    \"lemon rind\": \"lemon zest\", \"lemon peel\": \"lemon zest\"}\n",
+    "COMPOUND = {\"salt pepper\": [\"salt\", \"pepper\"], \"butter margarine\": [\"butter\", \"margarine\"],\n",
+    "    \"salt black pepper\": [\"salt\", \"black pepper\"], \"oil butter\": [\"oil\", \"butter\"]}\n",
+    "\n",
+    "def deaccent(s):\n",
+    "    return \"\".join(ch for ch in unicodedata.normalize(\"NFKD\", s) if not unicodedata.combining(ch))\n",
+    "\n",
+    "def singular(t):\n",
+    "    if t.endswith(\"ies\") and len(t) > 4: return t[:-3] + \"y\"\n",
+    "    if t.endswith(\"oes\") and len(t) > 4: return t[:-2]\n",
+    "    if t.endswith(\"s\") and not t.endswith(\"ss\") and len(t) > 3: return t[:-1]\n",
+    "    return t\n",
+    "\n",
+    "def norm(s):\n",
+    "    s = deaccent((s or \"\").lower())\n",
+    "    s = re.sub(r\"\\([^)]*\\)\", \" \", s)            # retire les parenthèses\n",
+    "    s = s.split(\",\")[0]                            # aliment primaire = avant la 1re virgule\n",
+    "    s = re.sub(r\"[^a-z\\s-]\", \" \", s).replace(\"-\", \" \")\n",
+    "    out = []\n",
+    "    for w in s.split():\n",
+    "        if len(w) <= 1 or w in DROP: continue\n",
+    "        t = singular(w)\n",
+    "        if t: out.append(t)\n",
+    "    return out\n",
+    "\n",
+    "# index Ciqual : (code, toks set, head, first)\n",
+    "ents = []\n",
+    "for k in alimCompo:\n",
+    "    if k in alimEng and alimEng[k]:\n",
+    "        t = norm(alimEng[k])\n",
+    "        if t:\n",
+    "            ents.append((k, set(t), t[-1], t[0]))\n",
+    "byTok = {}\n",
+    "for e, (code, toks, head, first) in enumerate(ents):\n",
+    "    for tok in toks:\n",
+    "        byTok.setdefault(tok, []).append(e)\n",
+    "\n",
+    "def jacc(a, b):\n",
+    "    if not a or not b: return 0.0\n",
+    "    inter = len(a & b)\n",
+    "    return inter / (len(a) + len(b) - inter)\n",
+    "\n",
+    "def match_key(key):\n",
+    "    if key in SYN: key = \" \".join(norm(SYN[key]))\n",
+    "    toks = key.split()\n",
+    "    if len(toks) > 1 and toks[-1] in (\"powder\", \"extract\", \"root\") and key != \"baking powder\":\n",
+    "        toks = toks[:-1]                           # retire un modificateur de forme final\n",
+    "    if not toks: return None\n",
+    "    it = set(toks); head = toks[-1]\n",
+    "    cand = set()\n",
+    "    for tok in it:\n",
+    "        for e in byTok.get(tok, ()): cand.add(e)\n",
+    "    best = None; bj = 0.0; bfb = 0; bnl = 0; has = False\n",
+    "    for e in cand:\n",
+    "        code, etoks, ehead, efirst = ents[e]\n",
+    "        if head not in etoks: continue             # garde : partage la tête-de-nom\n",
+    "        j = jacc(it, etoks)\n",
+    "        if j < 0.5: continue\n",
+    "        fb = 1 if efirst == head else 0            # bonus : Ciqual COMMENCE par la tête\n",
+    "        nl = -len(etoks)                           # préférer le nom le plus court\n",
+    "        if not has or j > bj + 1e-9 or (abs(j - bj) < 1e-9 and (fb > bfb or (fb == bfb and nl > bnl))):\n",
+    "            bj, bfb, bnl, best, has = j, fb, nl, code, True\n",
+    "    return best\n",
+    "\n",
+    "_matchCache = {}\n",
+    "def match(item):\n",
+    "    key = \" \".join(norm(item.split(\";\")[0]))\n",
+    "    if not key: return None\n",
+    "    if key in _matchCache: return _matchCache[key]\n",
+    "    if key in COMPOUND: code = match_key(\" \".join(norm(COMPOUND[key][0])))\n",
+    "    else: code = match_key(key)\n",
+    "    _matchCache[key] = code\n",
+    "    return code\n",
+    "\n",
+    "print(\"Démonstration du matcheur curé sur quelques items RecipeML :\")\n",
+    "for t in [\"White sugar\", \"All-purpose flour\", \"Baking soda\", \"Eggs\", \"Butter\", \"Olive oil\", \"Salt pepper\"]:\n",
+    "    mcode = match(t)\n",
+    "    print(f\"   {t!r:24} -> {alimEng.get(mcode) if mcode else '(aucun)'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a26438ed",
+   "metadata": {},
+   "source": [
+    "## 3. RecipeML : parsing structuré **avec quantités**\n",
+    "\n",
+    "Chaque `<recipe>` porte des `<ing>` de forme `<amt><qty>…</qty><unit>…</unit></amt><item>…</item>`.\n",
+    "On extrait le **triplet (item, quantité, unité)**. `ParseQty` gère entiers, **fractions** (`1/2`),\n",
+    "**quantités mixtes** (`1 1/2`), fractions Unicode (`½`) et prend la borne basse d'une fourchette\n",
+    "(`2-3` → `2`). Le parsing XML est tolérant (`&` nus → `&amp;`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "beceb300",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:15:27.301179Z",
+     "iopub.status.busy": "2026-07-30T00:15:27.301179Z",
+     "iopub.status.idle": "2026-07-30T00:15:27.468436Z",
+     "shell.execute_reply": "2026-07-30T00:15:27.467431Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RecipeML : 483 recettes, 4710 ingrédients (91% avec quantité, 78% avec unité), 2 fichiers XML irrécupérables ignorés.\n",
+      "Exemple de recette (item | qty | unité) :\n",
+      "   (19-oz) crushed pineapple with juice   |   1.0 | can\n",
+      "   White sugar                            |   2.0 | cups\n",
+      "   Eggs                                   |   2.0 | \n",
+      "   Flour                                  |   2.0 | cups\n",
+      "   Baking soda                            |   2.0 | teaspoons\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ParseQty + parsing de l'archive RecipeML -> (item, qty, unit) par recette.\n",
+    "FRAC = {\"½\": \"1/2\", \"¼\": \"1/4\", \"¾\": \"3/4\", \"⅓\": \"1/3\", \"⅔\": \"2/3\"}\n",
+    "\n",
+    "def parse_qty(s):\n",
+    "    if not s or not s.strip(): return 0.0\n",
+    "    s = s.strip()\n",
+    "    for u, v in FRAC.items(): s = s.replace(u, v)\n",
+    "    dash = s.find(\"-\")\n",
+    "    if dash > 0: s = s[:dash]                     # fourchette -> borne basse\n",
+    "    total = 0.0; any_ = False\n",
+    "    for tok in s.split():\n",
+    "        if \"/\" in tok:\n",
+    "            pr = tok.split(\"/\")\n",
+    "            if len(pr) == 2:\n",
+    "                try:\n",
+    "                    a, b = float(pr[0]), float(pr[1])\n",
+    "                    if b != 0: total += a / b; any_ = True\n",
+    "                except ValueError: pass\n",
+    "        else:\n",
+    "            try: total += float(tok); any_ = True\n",
+    "            except ValueError: pass\n",
+    "    return total if any_ else 0.0\n",
+    "\n",
+    "recipes = []\n",
+    "skipped = nIng = nQty = nUnit = 0\n",
+    "for f in sorted((BASE / \"RecipeML\").rglob(\"*.xml\")):\n",
+    "    try:\n",
+    "        doc = ET.parse(f)\n",
+    "    except ET.ParseError:\n",
+    "        try:\n",
+    "            txt = f.read_text(encoding=\"utf-8\", errors=\"replace\").replace(\"&\", \"&amp;\")\n",
+    "            doc = ET.fromstring(txt)\n",
+    "        except Exception:\n",
+    "            skipped += 1; continue\n",
+    "    root = doc.getroot() if not isinstance(doc, ET.Element) else doc\n",
+    "    title_el = next((e for e in root.iter(\"title\") if (e.text or \"\").strip()), None)\n",
+    "    title = (title_el.text.strip()[:44] if title_el is not None else f.stem)\n",
+    "    cats = [e.text.strip() for e in root.iter(\"cat\") if (e.text or \"\").strip()]\n",
+    "    ings = []\n",
+    "    for ing in root.iter(\"ing\"):\n",
+    "        item_el = ing.find(\"item\")\n",
+    "        item = (item_el.text or \"\").strip() if item_el is not None else \"\"\n",
+    "        if not item: continue\n",
+    "        nIng += 1\n",
+    "        qty = 0.0; unit = \"\"\n",
+    "        amt = ing.find(\"amt\")\n",
+    "        if amt is not None:\n",
+    "            qty_el = amt.find(\"qty\")\n",
+    "            qty = parse_qty(qty_el.text) if qty_el is not None else 0.0\n",
+    "            unit_el = amt.find(\"unit\")\n",
+    "            unit = (unit_el.text or \"\").strip().lower() if unit_el is not None else \"\"\n",
+    "        if qty > 0: nQty += 1\n",
+    "        if unit: nUnit += 1\n",
+    "        ings.append((item, qty, unit))\n",
+    "    if ings: recipes.append((title, cats, ings))\n",
+    "print(f\"RecipeML : {len(recipes)} recettes, {nIng} ingrédients \"\n",
+    "      f\"({100.0*nQty/max(1,nIng):.0f}% avec quantité, {100.0*nUnit/max(1,nIng):.0f}% avec unité), \"\n",
+    "      f\"{skipped} fichiers XML irrécupérables ignorés.\")\n",
+    "print(\"Exemple de recette (item | qty | unité) :\")\n",
+    "for it, q, u in recipes[0][2][:5]:\n",
+    "    print(f\"   {it[:38]:38} | {q:5} | {u}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d00cb117",
+   "metadata": {},
+   "source": [
+    "## 4. Normalisation quantité → grammes (le show-stopper résolu)\n",
+    "\n",
+    "Ciqual ne fournit pas de densité. Le passage `(qté, unité, ingrédient) → grammes` se fait en\n",
+    "**deux couches honnêtes** : (1) unité → mL (volumes) ou g (masses) via une table fixe ;\n",
+    "(2) mL → g via une **table de densités** curée par mot-clé ; (3) items **comptés** (unité vide :\n",
+    "`2 Eggs`) → poids moyen par pièce. Les unités de conditionnement (`can`, `package`…) restent\n",
+    "**non convertibles** → masse `0` (honnête et visible dans les métriques)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "07b66ccd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:15:27.470436Z",
+     "iopub.status.busy": "2026-07-30T00:15:27.469436Z",
+     "iopub.status.idle": "2026-07-30T00:15:27.482562Z",
+     "shell.execute_reply": "2026-07-30T00:15:27.482562Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   2.0 cups       white sugar        -> 402.2 g\n",
+      "   2.0 cups       flour              -> 250.8 g\n",
+      "   1.0 teaspoon   vanilla            -> 4.9 g\n",
+      "   4.0 ounces     butter             -> 113.4 g\n",
+      "   2.0 (compte)   eggs               -> 100.0 g\n",
+      "   1.0 can        crushed pineapple  -> 0.0 g   (non convertible)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# unite -> mL/g ; densites ; items comptes -> grammes.\n",
+    "UNIT = {\"cup\": (236.588, False), \"cups\": (236.588, False),\n",
+    "    \"tablespoon\": (14.7868, False), \"tablespoons\": (14.7868, False), \"tbsp\": (14.7868, False), \"tbs\": (14.7868, False),\n",
+    "    \"teaspoon\": (4.92892, False), \"teaspoons\": (4.92892, False), \"tsp\": (4.92892, False),\n",
+    "    \"ounce\": (28.3495, True), \"ounces\": (28.3495, True), \"oz\": (28.3495, True),\n",
+    "    \"pound\": (453.592, True), \"pounds\": (453.592, True), \"lb\": (453.592, True), \"lbs\": (453.592, True),\n",
+    "    \"gram\": (1, True), \"grams\": (1, True), \"g\": (1, True), \"kg\": (1000, True), \"kilogram\": (1000, True),\n",
+    "    \"ml\": (1, False), \"milliliter\": (1, False), \"millilitre\": (1, False),\n",
+    "    \"l\": (1000, False), \"liter\": (1000, False), \"litre\": (1000, False),\n",
+    "    \"pint\": (473.176, False), \"pt\": (473.176, False), \"quart\": (946.353, False), \"qt\": (946.353, False),\n",
+    "    \"gallon\": (3785.41, False), \"gal\": (3785.41, False),\n",
+    "    \"pinch\": (0.36, True), \"dash\": (0.6, False), \"stick\": (113.0, True), \"sticks\": (113.0, True)}\n",
+    "DENS = [(\"flour\", 0.53), (\"sugar\", 0.85), (\"oil\", 0.92), (\"butter\", 0.911), (\"honey\", 1.42),\n",
+    "    (\"syrup\", 1.33), (\"milk\", 1.03), (\"cream\", 1.01), (\"water\", 1.0), (\"salt\", 1.22),\n",
+    "    (\"rice\", 0.85), (\"cocoa\", 0.52), (\"cornstarch\", 0.54), (\"oats\", 0.41)]\n",
+    "COUNT = [(\"egg\", 50), (\"banana\", 120), (\"apple\", 180), (\"onion\", 110), (\"clove\", 5),\n",
+    "    (\"carrot\", 60), (\"potato\", 150), (\"tomato\", 120), (\"lemon\", 60), (\"lime\", 45),\n",
+    "    (\"orange\", 130), (\"garlic\", 5), (\"shallot\", 30), (\"scallion\", 15), (\"pepper\", 120)]\n",
+    "\n",
+    "def density(item_lower):\n",
+    "    for kw, d in DENS:\n",
+    "        if kw in item_lower: return d\n",
+    "    return 1.0\n",
+    "def count_weight(item_lower):\n",
+    "    for kw, g in COUNT:\n",
+    "        if kw in item_lower: return g\n",
+    "    return 0.0\n",
+    "def to_grams(qty, unit, item_lower):\n",
+    "    if qty <= 0: return 0.0\n",
+    "    if not unit:\n",
+    "        cw = count_weight(item_lower)\n",
+    "        return qty * cw if cw > 0 else 0.0\n",
+    "    u = UNIT.get(unit)\n",
+    "    if u is None: return 0.0\n",
+    "    factor, is_mass = u\n",
+    "    return qty * factor if is_mass else qty * factor * density(item_lower)\n",
+    "\n",
+    "for q, u, it in [(2.0, \"cups\", \"white sugar\"), (2.0, \"cups\", \"flour\"), (1.0, \"teaspoon\", \"vanilla\"),\n",
+    "                 (4.0, \"ounces\", \"butter\"), (2.0, \"\", \"eggs\"), (1.0, \"can\", \"crushed pineapple\")]:\n",
+    "    g = to_grams(q, u, it)\n",
+    "    print(f\"   {q} {(u or '(compte)'):10} {it:18} -> {g:.1f} g\" + (\"   (non convertible)\" if g == 0 else \"\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "451ccc82",
+   "metadata": {},
+   "source": [
+    "## 5. Agrégation nutritionnelle **pondérée par la masse** + couverture\n",
+    "\n",
+    "Pour chaque recette : on apparie chaque `item` à Ciqual, on convertit sa quantité en grammes, et\n",
+    "on ajoute sa contribution `teneur_per_100g × grammes / 100`. C'est la correction du biais\n",
+    "*quantity-blind* : un gâteau avec 2 tasses de farine (~250 g) ne compte plus comme 100 g. On\n",
+    "mesure aussi la **couverture d'appariement** (fraction des ingrédients appariés) — le critère de\n",
+    "gating."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "61d4605c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:15:27.485566Z",
+     "iopub.status.busy": "2026-07-30T00:15:27.484568Z",
+     "iopub.status.idle": "2026-07-30T00:15:27.536610Z",
+     "shell.execute_reply": "2026-07-30T00:15:27.536610Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Agrégation : 483 recettes, couverture moyenne d'appariement = 72.6%\n",
+      "   couverture 100%           :    58 recettes\n",
+      "   couverture >=80% (solveur):   215 recettes\n",
+      "   couverture >=50%          :   437 recettes\n",
+      "   couverture  <50%          :    46 recettes\n",
+      "Échantillon 100% apparié (énergie kJ, prot g, gluc g, lip g, sel g — PONDÉRÉ par la masse) :\n",
+      "   #10 Cake                                       [27040.6, 131.5, 749.9, 310.4, 0.8]\n",
+      "   #1 Lemon Bars                                  [12393.9, 92.4, 490.4, 58.7, 0.6]\n",
+      "   1,2,3,4 Cake                                   [15889.9, 163.4, 511.8, 106.5, 1.1]\n",
+      "   1-1-1 Cookies                                  [9464.4, 54.2, 237.8, 115.7, 2.5]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Agrégation pondérée par la masse + couverture par recette.\n",
+    "built = []\n",
+    "mc = {}  # item -> code Ciqual (cache d'appariement)\n",
+    "for title, cats, ings in recipes:\n",
+    "    vec = [0.0] * C\n",
+    "    nMatch = 0\n",
+    "    for item, qty, unit in ings:\n",
+    "        acode = mc.get(item)\n",
+    "        if acode is None:\n",
+    "            acode = match(item); mc[item] = acode\n",
+    "        if acode is None: continue\n",
+    "        nMatch += 1\n",
+    "        cv = alimCompo.get(acode)\n",
+    "        if cv is None: continue\n",
+    "        grams = to_grams(qty, unit, item.lower())\n",
+    "        if grams <= 0: continue\n",
+    "        for k in range(C):\n",
+    "            vec[k] += cv[k] * (grams / 100.0)\n",
+    "    cover = nMatch / len(ings) if ings else 0.0\n",
+    "    built.append((title, cats, vec, cover, nMatch, len(ings)))\n",
+    "\n",
+    "N = len(built)\n",
+    "b100 = b90 = b80 = b50 = blo = 0; covSum = 0.0\n",
+    "for r in built:\n",
+    "    c = r[3]; covSum += c\n",
+    "    if c >= 1.0: b100 += 1\n",
+    "    elif c >= 0.9: b90 += 1\n",
+    "    elif c >= 0.8: b80 += 1\n",
+    "    elif c >= 0.5: b50 += 1\n",
+    "    else: blo += 1\n",
+    "print(f\"Agrégation : {N} recettes, couverture moyenne d'appariement = {100.0*covSum/max(1,N):.1f}%\")\n",
+    "print(f\"   couverture 100%           : {b100:5} recettes\")\n",
+    "print(f\"   couverture >=80% (solveur): {b100+b90+b80:5} recettes\")\n",
+    "print(f\"   couverture >=50%          : {b100+b90+b80+b50:5} recettes\")\n",
+    "print(f\"   couverture  <50%          : {blo:5} recettes\")\n",
+    "print(\"Échantillon 100% apparié (énergie kJ, prot g, gluc g, lip g, sel g — PONDÉRÉ par la masse) :\")\n",
+    "for r in [x for x in built if x[3] >= 1.0 and any(v > 0 for v in x[2])][:4]:\n",
+    "    vec = \", \".join(f\"{v:.1f}\" for v in r[2])\n",
+    "    print(f\"   {r[0][:46]:46} [{vec}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e63307b9",
+   "metadata": {},
+   "source": [
+    "## 6. Sous-ensembles gatés par qualité + cache JSON (contract assertif)\n",
+    "\n",
+    "Le sous-ensemble **solveur-usable** (≥ 80 % des ingrédients appariés) est sérialisé en cache\n",
+    "`mealplan_cache.json` — la matière première propre que les notebooks de capstone consommeront.\n",
+    "Le **cache contract** (`constituants`, `n_total`, `n_usable`, `recipes[].{title,cats,cover,vec}`)\n",
+    "est **asserté** : c'est un test différentiel qui garantit que le port Python respecte le même\n",
+    "schéma que le cache C# consommé par [08](../Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb).\n",
+    "\n",
+    "> Le cache vit sous `data/meals/` (gitignore) : régénéré à l'exécution, jamais committé."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "254ac27c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:15:27.539613Z",
+     "iopub.status.busy": "2026-07-30T00:15:27.538618Z",
+     "iopub.status.idle": "2026-07-30T00:15:27.549727Z",
+     "shell.execute_reply": "2026-07-30T00:15:27.549727Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cache écrit : mealplan_cache.json -- 215 recettes solveur-usables, 27 Ko.\n",
+      "Contract assertif PASS : constituants(C), n_total, n_usable, recipes[].{title,cats,cover,vec} OK.\n",
+      "Palier de montée en charge (piloté par la qualité, non par un plafond arbitraire) :\n",
+      "   subset propre 100%   :    58 recettes\n",
+      "   subset >=80% (cache) :   215 recettes  <- livré au solveur\n",
+      "   subset >=50%         :   433 recettes\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cache JSON du sous-ensemble solveur-usable (>=80% apparié) + contract assertif.\n",
+    "usable = [{\"title\": r[0], \"cats\": r[1], \"cover\": round(r[3], 3),\n",
+    "           \"vec\": [round(v, 2) for v in r[2]]}\n",
+    "          for r in built if r[3] >= 0.8 and any(v > 0 for v in r[2])]\n",
+    "payload = {\"constituants\": [consts[c] for c in chosen],\n",
+    "           \"n_total\": N, \"n_usable\": len(usable), \"recipes\": usable}\n",
+    "cache_path = BASE / \"mealplan_cache.json\"\n",
+    "cache_path.write_text(json.dumps(payload, ensure_ascii=False), encoding=\"utf-8\")\n",
+    "size_kb = cache_path.stat().st_size / 1024\n",
+    "\n",
+    "# --- contract assertif : le cache respecte le schema attendu par les notebooks C# 08/09 ---\n",
+    "assert isinstance(payload[\"constituants\"], list) and len(payload[\"constituants\"]) == C\n",
+    "assert isinstance(payload[\"n_total\"], int) and payload[\"n_total\"] == N\n",
+    "assert isinstance(payload[\"n_usable\"], int) and payload[\"n_usable\"] == len(usable)\n",
+    "for rec in payload[\"recipes\"][:50]:\n",
+    "    assert set(rec.keys()) == {\"title\", \"cats\", \"cover\", \"vec\"}\n",
+    "    assert isinstance(rec[\"cats\"], list) and isinstance(rec[\"vec\"], list) and len(rec[\"vec\"]) == C\n",
+    "print(f\"Cache écrit : {cache_path.name} -- {len(usable)} recettes solveur-usables, {size_kb:.0f} Ko.\")\n",
+    "print(\"Contract assertif PASS : constituants(C), n_total, n_usable, recipes[].{title,cats,cover,vec} OK.\")\n",
+    "print(\"Palier de montée en charge (piloté par la qualité, non par un plafond arbitraire) :\")\n",
+    "print(f\"   subset propre 100%   : {sum(1 for r in built if r[3] >= 1.0 and any(v>0 for v in r[2])):5} recettes\")\n",
+    "print(f\"   subset >=80% (cache) : {len(usable):5} recettes  <- livré au solveur\")\n",
+    "print(f\"   subset >=50%         : {sum(1 for r in built if r[3] >= 0.5 and any(v>0 for v in r[2])):5} recettes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72134c54",
+   "metadata": {},
+   "source": [
+    "## Synthèse — la couche de données du planificateur, en Python\n",
+    "\n",
+    "| Verdict | Ce qu'il montre | Contrôle falsifiant |\n",
+    "|---|---|---|\n",
+    "| **appariement curé** | White sugar → Sugar white (pas White pudding) | garde tête-de-nom écarte le faux positif positionnel |\n",
+    "| **agrégation massique** | 2 cups flour (~250 g) ≠ 100 g | sans `ToGrams`, chaque ingrédient = 100 g fictif |\n",
+    "| **gating par qualité** | seules les recettes ≥80% appariées entrent au cache | `cover < 0.8` → exclu du cache |\n",
+    "\n",
+    "Ce notebook **16b** comble le **gap de la couche données** du planificateur Python : là où\n",
+    "[16](Z3-Python-16-Meal-Planner.ipynb) modélisait sur un corpus jouet, ici le corpus est **réel**\n",
+    "(Ciqual × RecipeML), **fusionné** (appariement lexical flou), **normalisé** (unités → grammes),\n",
+    "et **agrégé** (pondéré par la masse). C'est le socle que les prochains grains Python consommeront :\n",
+    "**capstone patient** (restrictions Min/Max) et **convergence à l'échelle** (comparaison d'encodages\n",
+    "`Optimize` / `PbEq` / Array theory)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3ad5249",
+   "metadata": {},
+   "source": [
+    "## 7. Exercices\n",
+    "\n",
+    "Trois exercices de data-engineering (0 solveur), prolongeant les limites mesurées."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d1629f6c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:15:27.552731Z",
+     "iopub.status.busy": "2026-07-30T00:15:27.551731Z",
+     "iopub.status.idle": "2026-07-30T00:15:27.557613Z",
+     "shell.execute_reply": "2026-07-30T00:15:27.557613Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top 15 items non appariés (à couvrir dans SYN) :\n",
+      "     14x  Gluten\n",
+      "     10x  Bread flour\n",
+      "      9x  Dry bread crumbs\n",
+      "      8x  Shortening\n",
+      "      8x  Celery seed\n",
+      "      7x  Buttermilk\n",
+      "      7x  Margarine\n",
+      "      7x  Bay leaf\n",
+      "      7x  Salad oil\n",
+      "      6x  Cornmeal\n",
+      "      6x  Chicken stock\n",
+      "      6x  Graham cracker crumbs\n",
+      "      6x  Cream of tartar\n",
+      "      6x  Gebhardt chili powder\n",
+      "      5x  Chocolate chips\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 — pousser le matcheur (synonymes non couverts).\n",
+    "# TODO: lister les items non appariés fréquents, étendre SYN, re-mesurer la couverture.\n",
+    "from collections import Counter\n",
+    "miss = Counter(it for _, _, ings in recipes for it, _, _ in ings if mc.get(it) is None)\n",
+    "print(\"Top 15 items non appariés (à couvrir dans SYN) :\")\n",
+    "for it, n in miss.most_common(15):\n",
+    "    print(f\"   {n:4}x  {it}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ef66fe8f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:15:27.559617Z",
+     "iopub.status.busy": "2026-07-30T00:15:27.559617Z",
+     "iopub.status.idle": "2026-07-30T00:15:27.566575Z",
+     "shell.execute_reply": "2026-07-30T00:15:27.566575Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ingrédients pesables (table UNIT courante) : à compléter après extension.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 — étendre la couverture des unités (rendre pesables plus d'ingrédients).\n",
+    "# TODO: ajouter à une copie de UNIT (clove ~5g, slice ~30g, bunch...) et recompter ToGrams > 0.\n",
+    "unites_sup = {}  # ex: {\"clove\": (5, True), \"slice\": (30, True)}\n",
+    "n_pesable = sum(1 for _, _, ings in recipes for _, q, u in ings if to_grams(q, u, \"x\") > 0 or not u)\n",
+    "print(f\"Ingrédients pesables (table UNIT courante) : à compléter après extension.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "316d4d8c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:15:27.569579Z",
+     "iopub.status.busy": "2026-07-30T00:15:27.568580Z",
+     "iopub.status.idle": "2026-07-30T00:15:27.573872Z",
+     "shell.execute_reply": "2026-07-30T00:15:27.573872Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Profil par catégorie : à compléter (moyenne de vec par catégorie).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 — profil nutritionnel moyen par catégorie RecipeML.\n",
+    "# TODO: built filtré cover>=0.8, grouper par cats, moyenne composant par composant.\n",
+    "from collections import defaultdict\n",
+    "prof = defaultdict(list)\n",
+    "for title, cats, vec, cover, _, _ in built:\n",
+    "    if cover >= 0.8:\n",
+    "        for c in cats: prof[c].append(vec)\n",
+    "print(\"Profil par catégorie : à compléter (moyenne de vec par catégorie).\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/refs

## G1 — Python data-layer port (#1206 Python-large, grain 1/5)

Faithful port of the C# `07_Meal_Planner_Data_External` data-layer notebook to Python: new `Z3-Python-16b-Meal-Planner-Data-External.ipynb`. **Pure data-engineering (0 solver)** — the missing data layer under the existing toy `Z3-Python-16` strate notebook.

### What it does (the 3-notebook Python gap, measured firsthand)
- **Loads real corpus**: Ciqual ANSES 2025 (XML streaming via `iterparse`) × RecipeML archive
- **Fuses by curated fuzzy-lexical matching**: deaccent/singular + DROP/SYN/COMPOUND tables + head-of-name guard + Jaccard (≥0.5)
- **Normalizes quantities to grams**: UNIT/DENS/COUNT tables (mass-weighted aggregation, not quantity-blind)
- **Quality-gated cache** (≥80% matched) serialized with an **assertive schema contract**

### Cross-stack differential verdict (the acceptance that exceeds a bare port)
| metric | C# 07 (full) | Python 16b (subset) |
|---|---|---|
| coverage rate | 73.1% | **72.6% ✓ matches** |
| usable (≥80%) | 2387 / 5424 recipes | 215 / 500 recipes |

The coverage **rate** matches cross-stack (the matcher port is faithful); the absolute count differs because this runs a **demonstrative subset** (Ciqual full + 5 RecipeML batches ≈ 500 recipes). Scale-up to the full ~11k corpus is **G3** (convergence-scale).

### Honesty notes
- Subset scale documented in the intro (`Échelle démonstrative`); values recomputed at exec (anti-drift).
- The matcher inherits the C# `DROP` list verbatim — `"all-purpose flour"` loses its qualifier (drops to `flour`) → minor false positive (`Soya flour`), **same behavior as C#**.
- 3 exercises (count_exercises conforming, #2161), 0 execution errors, relative links verified.

### Not in this PR (deferred, signaled)
- **README Z3-API entry/count** — Z3-API is po-2025 turf + `CATALOG-STATUS` is auto-regenerated (`pedagogical_count: 0`); left for the catalog pipeline / po-2025 sign-off.
- Builder `build_z3python16b.py` not committed (dev tool — no `build_*.py` tracked anywhere in the repo).
- Corpus `data/` is gitignored.

### Scope question for ai-01 (pending your tranche)
I tagged this `DEEP/notebook-python`; my scope comment on #1206 recommended treating the whole Python-large track as `refactor`. Content is identical — relabel if you prefer. Per your directive ("prends la tranche livrable et signale"), shipping G1 now rather than blocking on the label.

**Next grains** (per the 5-grain plan on #1206): G2 patient-capstone · G3 convergence-scale (introduces `PbEq`/`PbLe`/`PbGe` for the 1st time in the Python track) · G4 Optimize-non-mirror · G5 hygiene retrofit.

See #1206
