### PR TITLE
feat(z3-python,#1206): Python patient-capstone notebook (Meal-Planner G2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-16c-Meal-Planner-Patient-Capstone.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-16c-Meal-Planner-Patient-Capstone.ipynb
@@ -1,0 +1,779 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f088ace5",
+   "metadata": {},
+   "source": [
+    "# Z3-Python-16c — Meal-Planner : capstone patient (restrictions nutritionnelles)\n",
+    "\n",
+    "*Compagnon « capstone » de la jambe Python-large #1206 : [16](Z3-Python-16-Meal-Planner.ipynb) (modélisation jouet) → [16b](Z3-Python-16b-Meal-Planner-Data-External.ipynb) (couche de données réelles) → **16c (ce notebook) : le patient**.*\n",
+    "\n",
+    "Le capstone : un **patient** impose des **restrictions nutritionnelles** (énergie bornée, protéines\n",
+    "minimum, lipides maximum) et le solveur doit composer un menu multi-jours qui les satisfait.\n",
+    "**Port fidèle du C# `08_Meal_Planner_Patient_Capstone`** ([Z3-Linq2Z3](../Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb)).\n",
+    "\n",
+    "```\n",
+    "Patient ──> Menu (1 jour) ──> Plat (1 créneau) ──> Denrées (nutrition Ciqual)\n",
+    "            [energie?]       [entrée | plat | accomp.]\n",
+    "```\n",
+    "\n",
+    "**Deux mouvements** : (1) un **squelette structural** à grande échelle (semaine 7×5, sans\n",
+    "nutrition) ; (2) le **capstone patient** curé (nutrition contrainte)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8af082a2",
+   "metadata": {},
+   "source": [
+    "## 0. Dépendances : le cache produit par 16b\n",
+    "\n",
+    "Ce notebook **consomme** le cache solveur-usable régénéré par\n",
+    "[16b](Z3-Python-16b-Meal-Planner-Data-External.ipynb) (`data/meals/mealplan_cache.json`). Pas de\n",
+    "solveur ici tant que le cache est absent — échec **bruyant** (règle SOTA : pas de corpus de\n",
+    "substitution)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3dfcf6ff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:39:01.507009Z",
+     "iopub.status.busy": "2026-07-30T00:39:01.506010Z",
+     "iopub.status.idle": "2026-07-30T00:39:01.638960Z",
+     "shell.execute_reply": "2026-07-30T00:39:01.637951Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cache present : data\\meals\\mealplan_cache.json (27 Ko)\n",
+      "Cache charge en 0.00s : 150 recettes exploitables (sur 483 brutes), 5 constituants.\n",
+      "Constituants : [0] Energie | [1] Protéines | [2] Glucides (g/100 g) | [3] Lipides (g/100 g) | [4] Sel chlorure de sodium (g/100 g)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Chargement du cache 16b + derivation du creneau (Ordre 1..5) depuis les cats RecipeML.\n",
+    "import json, time\n",
+    "from z3 import Solver, Int, Or, Distinct, sat, Implies\n",
+    "from pathlib import Path\n",
+    "\n",
+    "CACHE = Path(\"data/meals/mealplan_cache.json\")\n",
+    "if not CACHE.exists():\n",
+    "    print(f\"[CACHE ABSENT] {CACHE}\")\n",
+    "    print(\"Executez d'abord Z3-Python-16b-Meal-Planner-Data-External (couche de donnees).\")\n",
+    "    raise FileNotFoundError(CACHE)\n",
+    "print(f\"Cache present : {CACHE} ({CACHE.stat().st_size/1024:.0f} Ko)\")\n",
+    "\n",
+    "root = json.loads(CACHE.read_text(encoding=\"utf-8\"))\n",
+    "constituants = root[\"constituants\"]; C = len(constituants)\n",
+    "\n",
+    "class Plat:\n",
+    "    __slots__ = (\"nom\", \"ordre\", \"comp\")\n",
+    "    def __init__(self, nom, ordre, comp): self.nom, self.ordre, self.comp = nom, ordre, comp\n",
+    "\n",
+    "def ordre_from_cats(cats):\n",
+    "    j = \" \".join(cats).lower()\n",
+    "    if any(k in j for k in (\"appetizer\",\"starter\",\"soup\")): return 1\n",
+    "    if any(k in j for k in (\"main dish\",\"beef\",\"pork\",\"chicken\",\"meat\",\"fish\")): return 2\n",
+    "    if any(k in j for k in (\"vegetable\",\"salad\",\"rice\",\"pasta\",\"potato\",\"bread\",\"side\")): return 3\n",
+    "    if any(k in j for k in (\"cheese\",\"dairy\",\"yogurt\",\"cream\")): return 4\n",
+    "    if any(k in j for k in (\"dessert\",\"cake\",\"cookie\",\"pie\",\"fruit\",\"sweet\",\"tart\")): return 5\n",
+    "    return 0\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
+    "all_plats = []\n",
+    "for r in root[\"recipes\"]:\n",
+    "    t = r[\"title\"].strip()[:44]                 # tronque a 44 (miroir C#)\n",
+    "    o = ordre_from_cats(r[\"cats\"])\n",
+    "    if o < 1: continue                          # orphelin ecarte\n",
+    "    all_plats.append(Plat(t, o, [float(x) for x in r[\"vec\"]]))\n",
+    "print(f\"Cache charge en {time.perf_counter()-t0:.2f}s : {len(all_plats)} recettes exploitables \"\n",
+    "      f\"(sur {root['n_total']} brutes), {C} constituants.\")\n",
+    "print(\"Constituants : \" + \" | \".join(f\"[{i}] {n.split(',')[0].strip()}\" for i,n in enumerate(constituants)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c03386aa",
+   "metadata": {},
+   "source": [
+    "## Mouvement 1 — squelette structural à grande échelle (7 jours × 5 créneaux)\n",
+    "\n",
+    "Avant la nutrition, le **squelette** : une semaine de 7 jours × 5 créneaux, où chaque créneau\n",
+    "choisit un plat dans sa catégorie. C'est l'occasion d'examiner l'idiome « tableau imbriqué »\n",
+    "(`int[][]`) en SMT — et pourquoi le binding C# `Z3.Linq` le réifie via `CollectionHandling.Array`\n",
+    "tandis qu'en z3-py on déclare simplement une **grille plate de `Int`**.\n",
+    "\n",
+    "> **Divergence de port (honnête)** : le C# pose `DefaultCollectionHandling = CollectionHandling.Array`\n",
+    "> pour traduire `int[][]` en un *SMT Array* (théorie des tableaux de McCarthy, `Select`/`Store`).\n",
+    "> z3-py n'impose pas cette couche : on déclare une `list[list[Int]]` — chaque cellule est une\n",
+    "> variable `Int` indépendante. Fonctionnellement équivalent pour ce squelette ; la vraie théorie\n",
+    "> des Array est l'objet du notebook [15](Z3-Python-15-Nested-Arrays-2D.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2e3423d",
+   "metadata": {},
+   "source": [
+    "### 1.1 Corpus + créneaux : pourquoi trier par Ordre"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6767b1a8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:39:01.639964Z",
+     "iopub.status.busy": "2026-07-30T00:39:01.639964Z",
+     "iopub.status.idle": "2026-07-30T00:39:01.647591Z",
+     "shell.execute_reply": "2026-07-30T00:39:01.647084Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "150 plats ranges en 5 creneaux :\n",
+      "  creneau 1 (ordre 1) : [0..9] (10 candidats)\n",
+      "  creneau 2 (ordre 2) : [10..29] (20 candidats)\n",
+      "  creneau 3 (ordre 3) : [30..82] (53 candidats)\n",
+      "  creneau 4 (ordre 4) : [83..83] (1 candidats)\n",
+      "  creneau 5 (ordre 5) : [84..149] (66 candidats)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Semaine 7x5 : on groupe les plats par creneau, ranges contigus [lo,hi] par categorie.\n",
+    "JOURS, CRENEAUX = 7, 5\n",
+    "# tri par (ordre, nom) pour des ranges contigus par creneau (le tri n'affecte que lo/hi, pas le modele M2).\n",
+    "plats = sorted([p for p in all_plats], key=lambda p: (p.ordre, p.nom))\n",
+    "lo, hi = [], []\n",
+    "for o in range(1, CRENEAUX + 1):\n",
+    "    idxs = [i for i, p in enumerate(plats) if p.ordre == o]\n",
+    "    lo.append(idxs[0] if idxs else 0)\n",
+    "    hi.append(idxs[-1] if idxs else -1)\n",
+    "print(f\"{len(plats)} plats ranges en 5 creneaux :\")\n",
+    "for o in range(CRENEAUX):\n",
+    "    n = 0 if hi[o] < lo[o] else hi[o] - lo[o] + 1\n",
+    "    print(f\"  creneau {o+1} (ordre {o+1}) : [{lo[o]}..{hi[o]}] ({n} candidats)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d3bcb03",
+   "metadata": {},
+   "source": [
+    "### 1.2 Le théorème hiérarchique + deux variantes\n",
+    "\n",
+    "`with_bounds` encadre chaque créneau dans sa range contigue. **Variante A** : montée en gamme\n",
+    "(chaque jour fait *mieux* que le précédent, même créneau). **Variante B** : variété totale\n",
+    "(`Distinct` croisé sur la colonne d'un même créneau, tous jours confondus)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "49de70d6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:39:01.649600Z",
+     "iopub.status.busy": "2026-07-30T00:39:01.649600Z",
+     "iopub.status.idle": "2026-07-30T00:39:01.752093Z",
+     "shell.execute_reply": "2026-07-30T00:39:01.751025Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[A] Montee en gamme : UNSAT en 58 ms\n",
+      "[B] Permutation totale (Distinct cross-row) : resolue en 33 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "# M1 : squelette 7x5 + Variante A (montee en gamme) + Variante B (Distinct cross-row).\n",
+    "def with_bounds(plan):\n",
+    "    cs = []\n",
+    "    for jj in range(JOURS):\n",
+    "        for cc in range(CRENEAUX):\n",
+    "            cs.append(plan[jj][cc] >= lo[cc]); cs.append(plan[jj][cc] <= hi[cc])\n",
+    "    return cs\n",
+    "def print_plan(plan, mdl, titre):\n",
+    "    print(titre)\n",
+    "    for jj in range(JOURS):\n",
+    "        row = []\n",
+    "        for cc in range(CRENEAUX):\n",
+    "            v = mdl.eval(plan[jj][cc]).as_long()\n",
+    "            row.append(f\"{plats[v].nom[:14]:14}\")\n",
+    "        print(f\"  J{jj+1}: \" + \" | \".join(row))\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
+    "# Variante A : montee en gamme, chaque jour > precedent (meme creneau)\n",
+    "sA = Solver()\n",
+    "planA = [[Int(f\"a_j{jj}_c{cc}\") for cc in range(CRENEAUX)] for jj in range(JOURS)]\n",
+    "for c in with_bounds(planA): sA.add(c)\n",
+    "for jj in range(JOURS - 1):\n",
+    "    for cc in range(CRENEAUX):\n",
+    "        sA.add(planA[jj][cc] < planA[jj+1][cc])\n",
+    "satA = (sA.check() == sat); mA = sA.model() if satA else None\n",
+    "print(f\"[A] Montee en gamme : {'resolue' if satA else 'UNSAT'} en {(time.perf_counter()-t0)*1000:.0f} ms\")\n",
+    "\n",
+    "# Variante B : Distinct cross-row par creneau (tous jours differents dans la meme categorie)\n",
+    "t1 = time.perf_counter()\n",
+    "sB = Solver()\n",
+    "planB = [[Int(f\"b_j{jj}_c{cc}\") for cc in range(CRENEAUX)] for jj in range(JOURS)]\n",
+    "for c in with_bounds(planB): sB.add(c)\n",
+    "for cc in range(CRENEAUX):\n",
+    "    if hi[cc] >= lo[cc] and (hi[cc] - lo[cc] + 1) >= JOURS:\n",
+    "        sB.add(Distinct(*[planB[jj][cc] for jj in range(JOURS)]))\n",
+    "satB = (sB.check() == sat); mB = sB.model() if satB else None\n",
+    "print(f\"[B] Permutation totale (Distinct cross-row) : {'resolue' if satB else 'UNSAT'} en {(time.perf_counter()-t1)*1000:.0f} ms\")\n",
+    "if satA: print_plan(planA, mA, \"\\n== Variante A (montee en gamme) ==\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b743f07f",
+   "metadata": {},
+   "source": [
+    "## Mouvement 2 — le capstone patient : la nutrition force la curation\n",
+    "\n",
+    "Le squelette M1 ignore la nutrition. Lui ajouter des restrictions patient à l'échelle pleine\n",
+    "(`7×5×R×C`) ferait exploser le modèle. D'où la **curation** : on réduit à **2 menus × 3 créneaux ×\n",
+    "5 candidats × 3 constituants** — un sous-ensemble à taille humaine où le capstone reste lisible.\n",
+    "\n",
+    "> **Note de fidélité** : le C# 08 référence dans sa prose une classe upstream `Patient {\n",
+    "> Restriction[] Restrictions }` (chaque restriction porte un `Min`/`Max` par constituant, `-1` =\n",
+    "> pas de borne), qui **n'existe pas dans ce dépôt** (fork externe `Z3.LinqBinding`). Le notebook\n",
+    "> 08 lui-même **inline** le patient comme quatre entiers et n'a **aucune** classe `Patient`/\n",
+    "> `Restriction`. Ce port Python reste **fidèle à 08** (patient inline) plutôt que de reconstruire\n",
+    "> la classe upstream absente — ne pas lui attribuer une structure que 08 n'a pas."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d9d06d6",
+   "metadata": {},
+   "source": [
+    "### 2.1 Curation : 2 menus × 3 créneaux × 5 candidats × 3 constituants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1cf364f2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:39:01.754189Z",
+     "iopub.status.busy": "2026-07-30T00:39:01.753663Z",
+     "iopub.status.idle": "2026-07-30T00:39:01.762138Z",
+     "shell.execute_reply": "2026-07-30T00:39:01.761091Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Constituants suivis :\n",
+      "  k=0 -> cache[0] Energie\n",
+      "  k=1 -> cache[1] Protéines\n",
+      "  k=2 -> cache[3] Lipides (g/100 g)\n",
+      "\n",
+      "Pool curee : 15 plats (3 creneaux x 5 candidats)\n",
+      "Apercu (creneau : candidats -> energie kJ) :\n",
+      "  creneau 1 : 'ncapriata Di Fave(5922), 4 B's Restaurant T(3433), 5-Minute Broccoli (6560), 7 Layer Dip(11374), 90-Minute Soft Pre(9445)\n",
+      "  creneau 2 : (Sort-Of) Sweet an(958), 1-Pot: Pastitsio G(15530), 1-Pot Pastitsio Go(15530), 10 Minute Szechuan(1188), 16th-Street Stew(11118)\n",
+      "  creneau 3 : 'sense and Sensibi(6483), ( From Bread Mix )(4421), ( From Bread Mix )(13568), 1-2-3 Meurbeteig D(15612), 1-Pot: Creamy Chic(3557)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Curation : pool de 5 candidats par creneau 1..3 (cache order, PAS le tri M1), 3 constituants.\n",
+    "NB_MENUS, NB_PLATS, CAND = 2, 3, 5\n",
+    "# 3 constituants cles : [0] Energie kJ, [1] Proteines, [3] Lipides (le 2 = Glucides est SKIPPE).\n",
+    "cEnergie, cProt, cLip = 0, 1, 3\n",
+    "CONST = [cEnergie, cProt, cLip]\n",
+    "NOMK = [\"energie(kJ)\", \"proteines(g)\", \"lipides(g)\"]\n",
+    "K = len(CONST)\n",
+    "print(\"Constituants suivis :\")\n",
+    "for k, ci in enumerate(CONST): print(f\"  k={k} -> cache[{ci}] {constituants[ci].split(',')[0].strip()}\")\n",
+    "\n",
+    "pool = []\n",
+    "for o in range(1, NB_PLATS + 1):\n",
+    "    pool.extend([p for p in all_plats if p.ordre == o][:CAND])   # cache order, fidèle a 08\n",
+    "def teneur(i, constIdx): return int(round(pool[i].comp[constIdx]))   # round half-to-even (caveat float)\n",
+    "def slot(m, p): return m * NB_PLATS + p\n",
+    "print(f\"\\nPool curee : {len(pool)} plats ({NB_PLATS} creneaux x {CAND} candidats)\")\n",
+    "print(\"Apercu (creneau : candidats -> energie kJ) :\")\n",
+    "for p in range(NB_PLATS):\n",
+    "    noms = [f\"{pool[i].nom.strip()[:18]}({teneur(i,cEnergie)})\" for i in range(p*CAND, p*CAND+CAND)]\n",
+    "    print(f\"  creneau {p+1} : \" + \", \".join(noms))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a46990a4",
+   "metadata": {},
+   "source": [
+    "### 2.2 Trois matrices d'entiers : `PlatId`, `Comp`, `MenuNut`\n",
+    "\n",
+    "| Matrice | Forme | Rôle |\n",
+    "|---|---|---|\n",
+    "| `PlatId[m][p]` | 2×3 | index pool du plat choisi par (menu, créneau) |\n",
+    "| `Comp[slot][k]` | 6×3 | **composition liée** du slot aplati (variable auxiliaire) |\n",
+    "| `MenuNut[m][k]` | 2×3 | somme nutritionnelle par menu |\n",
+    "\n",
+    "`Comp` est la **variable auxiliaire** qui résout l'impossibilité d'indexer un tableau hôte par une\n",
+    "variable Z3 (`pool[PlatId[m][p]]` est interdit). Total : **30 variables `Int`**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "272cfbe8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:39:01.764230Z",
+     "iopub.status.busy": "2026-07-30T00:39:01.763709Z",
+     "iopub.status.idle": "2026-07-30T00:39:01.769616Z",
+     "shell.execute_reply": "2026-07-30T00:39:01.769080Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6 PlatId + 18 Comp + 6 MenuNut = 30 variables Int.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Variables de decision : 30 Int (PlatId 6 + Comp 18 + MenuNut 6).\n",
+    "platid = [[Int(f\"pid_{m}_{p}\") for p in range(NB_PLATS)] for m in range(NB_MENUS)]\n",
+    "comp = [[Int(f\"comp_{slot(m,p)}_{k}\") for k in range(K)] for m in range(NB_MENUS) for p in range(NB_PLATS)]\n",
+    "menunut = [[Int(f\"nut_{m}_{k}\") for k in range(K)] for m in range(NB_MENUS)]\n",
+    "print(f\"{NB_MENUS*NB_PLATS} PlatId + {NB_MENUS*NB_PLATS*K} Comp + {NB_MENUS*K} MenuNut = \"\n",
+    "      f\"{NB_MENUS*NB_PLATS + NB_MENUS*NB_PLATS*K + NB_MENUS*K} variables Int.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "605d03bf",
+   "metadata": {},
+   "source": [
+    "### 2.3 Le patient et ses restrictions (bornes par MENU)\n",
+    "\n",
+    "Fidèle au C# 08 : un seul patient, **inline** comme quatre bornes entières, **par menu** (la somme\n",
+    "des 3 plats du menu doit respecter chaque borne). Bornes rescalées kcal→kJ (×4,184) au moment du\n",
+    "rewiring sur le cache Ciqual (kJ/100 g).\n",
+    "\n",
+    "> **ATTENTION millésime (#8901)** : ces bornes ont été *réglées* contre un cache C# aujourd'hui\n",
+    "> désuet (08 tourne sur 121 Ko / 736 recettes ; 07+09 s'accordent sur 270 Ko / 2387). Ici on\n",
+    "> consomme le **cache Python 16b régénéré frais** — les valeurs du menu résolu **différeront** des\n",
+    "> sorties C# (qu'on ne reproduit pas). On vérifie que le patient reste **SAT** sur ce pool (sinon\n",
+    "> = finding à reporter, pas de retouche silencieuse des bornes)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4a30e44d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:39:01.771807Z",
+     "iopub.status.busy": "2026-07-30T00:39:01.771807Z",
+     "iopub.status.idle": "2026-07-30T00:39:01.776533Z",
+     "shell.execute_reply": "2026-07-30T00:39:01.775483Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Patient : energie in [3347, 10878] kJ, proteines >= 30 g, lipides <= 600 g (par menu)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Restrictions patient (fidele a Restriction{Min,Max}, -1 = pas de borne), par MENU.\n",
+    "energieMin = 3347    # ~800 kcal cumules minimum par menu\n",
+    "energieMax = 10878   # ~2600 kcal cumules maximum par menu\n",
+    "protMin    = 30      # proteines minimum par menu (g)\n",
+    "lipMax     = 600     # lipides maximum par menu (g)\n",
+    "print(f\"Patient : energie in [{energieMin}, {energieMax}] kJ, proteines >= {protMin} g, \"\n",
+    "      f\"lipides <= {lipMax} g (par menu)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5a75359",
+   "metadata": {},
+   "source": [
+    "### 2.4 Les cinq familles de contraintes\n",
+    "\n",
+    "1. **Bornes d'ordre** : `PlatId[m][p]` dans la fenêtre des 5 candidats de son créneau.\n",
+    "2. **Variété** : `Distinct` global sur les 6 slots (pas deux fois le même plat).\n",
+    "3. **Linking composition** : `Or(PlatId[m][p] ≠ cand, Comp[slot][k] == teneur(cand, k))` — l'idiome\n",
+    "   **index + disjonction** (90 assertions) qui relie l'index choisi à sa composition. C'est l'idiom\n",
+    "   que la jambe Python n'avait **aucun** exemple avant ce notebook.\n",
+    "4. **Somme par menu** : `MenuNut[m][k] == Σ Comp[slot][k]` sur les 3 créneaux.\n",
+    "5. **Restrictions patient** : `MenuNut[m][·]` dans les bornes (énergie, protéines, lipides)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b2b1d3c9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:39:01.778654Z",
+     "iopub.status.busy": "2026-07-30T00:39:01.778129Z",
+     "iopub.status.idle": "2026-07-30T00:39:01.815537Z",
+     "shell.execute_reply": "2026-07-30T00:39:01.814532Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele resolu en 25 ms\n",
+      "== Menu 1 ==  energie=8812 kJ | proteines=46 g | lipides=168 g\n",
+      "   creneau 1 : 4 B's Restaurant Tomato Soup   (kJ=3433, prot=17, lip=63)\n",
+      "   creneau 2 : (Sort-Of) Sweet and Sour Chicken (Also Good (kJ=958, prot=3, lip=0)\n",
+      "   creneau 3 : ( From Bread Mix ) Big Soft Pretzels (kJ=4421, prot=26, lip=105)\n",
+      "== Menu 2 ==  energie=10667 kJ | proteines=112 g | lipides=123 g\n",
+      "   creneau 1 : 'ncapriata Di Fave (Fava Bean Puree with Gre (kJ=5922, prot=58, lip=73)\n",
+      "   creneau 2 : 10 Minute Szechuan Chicken     (kJ=1188, prot=11, lip=15)\n",
+      "   creneau 3 : 1-Pot: Creamy Chicken Noodle Casserole (kJ=3557, prot=43, lip=35)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# THE MODEL : 5 familles de contraintes + Solve (pure satisfiabilite, pas d'objectif).\n",
+    "t0 = time.perf_counter()\n",
+    "s = Solver()\n",
+    "# (1) bornes d'ordre\n",
+    "for m in range(NB_MENUS):\n",
+    "    for p in range(NB_PLATS):\n",
+    "        s.add(platid[m][p] >= p*CAND, platid[m][p] <= p*CAND + CAND - 1)\n",
+    "# (2) variete : Distinct global sur les 6 slots\n",
+    "s.add(Distinct(*[platid[m][p] for m in range(NB_MENUS) for p in range(NB_PLATS)]))\n",
+    "# (3) linking composition : PlatId != cand || Comp[slot][k] == teneur(cand, k)\n",
+    "for m in range(NB_MENUS):\n",
+    "    for p in range(NB_PLATS):\n",
+    "        sl = slot(m, p)\n",
+    "        for cand in range(p*CAND, p*CAND + CAND):\n",
+    "            for k in range(K):\n",
+    "                s.add(Or(platid[m][p] != cand, comp[sl][k] == teneur(cand, CONST[k])))\n",
+    "# (4) somme par menu\n",
+    "for m in range(NB_MENUS):\n",
+    "    for k in range(K):\n",
+    "        s.add(menunut[m][k] == comp[slot(m,0)][k] + comp[slot(m,1)][k] + comp[slot(m,2)][k])\n",
+    "# (5) restrictions patient (par menu)\n",
+    "for m in range(NB_MENUS):\n",
+    "    s.add(menunut[m][0] >= energieMin, menunut[m][0] <= energieMax)\n",
+    "    s.add(menunut[m][1] >= protMin)\n",
+    "    s.add(menunut[m][2] <= lipMax)\n",
+    "\n",
+    "sat_cap = (s.check() == sat)\n",
+    "mdl = s.model() if sat_cap else None\n",
+    "print(f\"Modele resolu en {(time.perf_counter()-t0)*1000:.0f} ms\")\n",
+    "if not sat_cap:\n",
+    "    print(\"UNSAT : aucun plan ne satisfait les restrictions du patient sur cette pool (finding #8901).\")\n",
+    "else:\n",
+    "    for m in range(NB_MENUS):\n",
+    "        e = mdl.eval(menunut[m][0]).as_long(); pr = mdl.eval(menunut[m][1]).as_long(); li = mdl.eval(menunut[m][2]).as_long()\n",
+    "        print(f\"== Menu {m+1} ==  energie={e} kJ | proteines={pr} g | lipides={li} g\")\n",
+    "        for p in range(NB_PLATS):\n",
+    "            v = mdl.eval(platid[m][p]).as_long()\n",
+    "            print(f\"   creneau {p+1} : {pool[v].nom.strip():<30} \"\n",
+    "                  f\"(kJ={teneur(v,cEnergie)}, prot={teneur(v,cProt)}, lip={teneur(v,cLip)})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0adf3a59",
+   "metadata": {},
+   "source": [
+    "### 2.5 Vérification hors-Z3 (croire vs prouver)\n",
+    "\n",
+    "Un solveur **garantit** les contraintes par construction — mais on **vérifie** indépendamment\n",
+    "(re-calcul hors Z3). Deux prongs : (a) les sommes recomputées depuis la pool satisfont les bornes\n",
+    "patient ; (b) ces sommes **égalent** les `MenuNut` du solveur — ce qui valide la **couche de\n",
+    "linking** elle-même, pas seulement les bornes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "6ca44228",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:39:01.817539Z",
+     "iopub.status.busy": "2026-07-30T00:39:01.817539Z",
+     "iopub.status.idle": "2026-07-30T00:39:01.825591Z",
+     "shell.execute_reply": "2026-07-30T00:39:01.825082Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Menu 1 : recalc energie=8812(OK), prot=46(OK), lip=168(OK) ; coherent avec MenuNut=oui\n",
+      "Menu 2 : recalc energie=10667(OK), prot=112(OK), lip=123(OK) ; coherent avec MenuNut=oui\n",
+      "\n",
+      "VERIFIE : toutes les restrictions patient sont respectees.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Re-verification hors Z3 : re-somme depuis la pool, compare aux MenuNut du solveur.\n",
+    "if not sat_cap:\n",
+    "    print(\"Pas de solution a verifier (UNSAT).\")\n",
+    "else:\n",
+    "    ok = True\n",
+    "    for m in range(NB_MENUS):\n",
+    "        e = pr = li = 0\n",
+    "        for p in range(NB_PLATS):\n",
+    "            v = mdl.eval(platid[m][p]).as_long()\n",
+    "            e  += teneur(v, cEnergie); pr += teneur(v, cProt); li += teneur(v, cLip)\n",
+    "        eOk = energieMin <= e <= energieMax; pOk = pr >= protMin; lOk = li <= lipMax\n",
+    "        Me = mdl.eval(menunut[m][0]).as_long(); Mpr = mdl.eval(menunut[m][1]).as_long(); Mli = mdl.eval(menunut[m][2]).as_long()\n",
+    "        match = (e == Me and pr == Mpr and li == Mli)\n",
+    "        ok = ok and eOk and pOk and lOk and match\n",
+    "        print(f\"Menu {m+1} : recalc energie={e}({'OK' if eOk else 'HORS'}), prot={pr}({'OK' if pOk else 'HORS'}), \"\n",
+    "              f\"lip={li}({'OK' if lOk else 'HORS'}) ; coherent avec MenuNut={'oui' if match else 'NON'}\")\n",
+    "    print(\"\\nVERIFIE : toutes les restrictions patient sont respectees.\" if ok\n",
+    "          else \"\\nINCOHERENCE detectee (a investiguer).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c32230f3",
+   "metadata": {},
+   "source": [
+    "## 3. Exercices\n",
+    "\n",
+    "Quatre prolongements (stubs : ils s'exécutent tels quels, n'échouent pas, à compléter)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61cbf070",
+   "metadata": {},
+   "source": [
+    "**Exercice 1** — Diversité d'entrée sur jours consécutifs : forcer que le créneau 1 diffère\n",
+    "entre `Menu 1` et `Menu 2` (déjà couvert par le `Distinct` global, mais l'exprimer comme une\n",
+    "contrainte dédiée `Or(PlatId[0][0] != PlatId[1][0], ...)` et mesurer l'impact)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "7f58a745",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:39:01.827606Z",
+     "iopub.status.busy": "2026-07-30T00:39:01.827606Z",
+     "iopub.status.idle": "2026-07-30T00:39:01.831615Z",
+     "shell.execute_reply": "2026-07-30T00:39:01.831615Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Ex.1] Stub : a completer (diversite entree jours consecutifs).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 (stub) : diversite entree jours consecutifs.\n",
+    "# TODO: ajouter s.add(Or(...)) forçant créneau 1 different entre menus, re-solve, comparer.\n",
+    "print(\"[Ex.1] Stub : a completer (diversite entree jours consecutifs).\")\n",
+    "def exercice_diversite_entree():\n",
+    "    # ... ajouter la contrainte, re-solve, retourner le nb de plans ...\n",
+    "    return -1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32408a7e",
+   "metadata": {},
+   "source": [
+    "**Exercice 2** — Seuil d'énergie strict → UNSAT : resserrer `energieMax` par dichotomie\n",
+    "jusqu'à rendre le modèle insatisfiable. Quel créneau porte l'essentiel de l'énergie kJ ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2d870898",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:39:01.834063Z",
+     "iopub.status.busy": "2026-07-30T00:39:01.834063Z",
+     "iopub.status.idle": "2026-07-30T00:39:01.838060Z",
+     "shell.execute_reply": "2026-07-30T00:39:01.838060Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Ex.2] Stub : a completer (seuil UNSAT energie).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 (stub) : seuil UNSAT par dichotomie sur energieMax.\n",
+    "# TODO: boucle resserrant energieMax, re-solve, retourner le seuil ou ca casse.\n",
+    "print(\"[Ex.2] Stub : a completer (seuil UNSAT energie).\")\n",
+    "def exercice_unsat_threshold():\n",
+    "    # ... dichotomie sur energieMax ...\n",
+    "    return -1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "780da97c",
+   "metadata": {},
+   "source": [
+    "**Exercice 3** — Passage à 3 menus : adapter les dimensions des matrices (`PlatId` 3×3,\n",
+    "`Comp` 9×3, `MenuNut` 3×3) et re-solve. Note : les formes sont hardcoded à `NB_MENUS=2` dans la\n",
+    "déclaration des variables — les paramétrer est le cœur de l'exercice."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "53456006",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:39:01.840234Z",
+     "iopub.status.busy": "2026-07-30T00:39:01.840234Z",
+     "iopub.status.idle": "2026-07-30T00:39:01.844743Z",
+     "shell.execute_reply": "2026-07-30T00:39:01.844743Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Ex.3] Stub : a completer (3 menus).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 (stub) : passer a 3 menus (adapter les formes de matrices).\n",
+    "# TODO: parametriser NB_MENUS=3, redeclarer les matrices, re-solve, retourner le temps.\n",
+    "print(\"[Ex.3] Stub : a completer (3 menus).\")\n",
+    "def exercice_trois_menus():\n",
+    "    # ... NB_MENUS=3, redeclarer vars, re-solve ...\n",
+    "    return -1.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b956624",
+   "metadata": {},
+   "source": [
+    "**Exercice 4** — Ajouter le sel (`Sel chlorure de sodium`, cache idx 4) comme 4e constituant\n",
+    "contraint (borne max `selMax`), et re-solve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "8192b51c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T00:39:01.847170Z",
+     "iopub.status.busy": "2026-07-30T00:39:01.847170Z",
+     "iopub.status.idle": "2026-07-30T00:39:01.851751Z",
+     "shell.execute_reply": "2026-07-30T00:39:01.851751Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Ex.4] Stub : a completer (constituant sel).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 (stub) : ajouter le constituant Sel (cache idx 4).\n",
+    "# TODO: CONST.append(4), ajouter selMax, re-declarer Comp/MenuNut sur K=4, re-solve.\n",
+    "print(\"[Ex.4] Stub : a completer (constituant sel).\")\n",
+    "def exercice_constituant_sel():\n",
+    "    cSel = next(i for i, n in enumerate(constituants) if \"sel chlorure\" in n.lower())\n",
+    "    # ... CONST.append(cSel) ...\n",
+    "    return cSel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bafa1e9",
+   "metadata": {},
+   "source": [
+    "## Synthèse — le capstone patient, en Python\n",
+    "\n",
+    "| Mouvement | Ce qu'il montre | Idiome Z3 |\n",
+    "|---|---|---|\n",
+    "| **M1 squelette** | semaine 7×5 sans nutrition | `int[][]` plate de `Int` (vs `CollectionHandling.Array` C#) |\n",
+    "| **M2 capstone** | patient SAT avec restrictions nutritionnelles | **index + linking disjonction** (`Or(pid≠cand, comp==val)`) |\n",
+    "\n",
+    "Le capstone patient est **le point où la nutrition rencontre la combinatoire** : on ne peut pas\n",
+    "forcer « 30 g de protéines minimum » sur un jouet de 24 plats — il faut un corpus réel (le cache\n",
+    "16b) pour que la contrainte *morde*. La **re-vérification hors-Z3** clôt l'arc : on ne *croit* pas\n",
+    "le solveur, on le *prouve*. C'est ce qui distingue ce capstone d'une simple démonstration.\n",
+    "\n",
+    "**Prochain grain (G3)** : la convergence à l'échelle — comparer les encodages (index naïf vs\n",
+    "one-hot pseudo-Boolean `PbEq`/`PbLe`) quand `R` et `C` augmentent, là où le naïf explose."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python (#8902)

## G2 — Python patient-capstone port (#1206 Python-large, grain 2/5)

Faithful port of the C# `08_Meal_Planner_Patient_Capstone` notebook to Python: new `Z3-Python-16c-Meal-Planner-Patient-Capstone.ipynb`. Consumes the cache produced by **G1** (`Z3-Python-16b`, #8902). Two movements:

### M1 — structural skeleton (7×5)
- Weekly plan as flat `list[list[Int]]` — the Python equivalent of the C# `int[][]` reified via `CollectionHandling.Array`. (The true SMT Array theory is notebook 15's subject; here a flat grid is functionally equivalent and idiomatic.)
- **Variant A** (ascending-gamme) + **Variant B** (cross-row `Distinct` per créneau).

### M2 — patient capstone (the core)
- **5 constraint families**: order bounds → global `Distinct` → **index+linking disjunction** `Or(pid≠cand, comp==val)` → per-menu sum → patient bounds.
- **Pure `Solver`** (no `Optimize`) — satisfiability, not optimization (that's G4).
- **Two-prong re-verification outside Z3**: (a) recomputed sums satisfy patient bounds, (b) recomputed sums == solver's `MenuNut` (validates the linking layer itself, not just the bounds).

### The idiom this introduces
The **index + linking disjunction** (`Or(PlatId[m][p] != cand, Comp[slot][k] == val)`) — 90 assertions — is how you bind an integer *index* variable to a *value* from a host array when you can't write `pool[PlatId[m][p]]` in Z3. The Python track had **zero** examples of this idiom before this notebook.

### Verified
12 code cells, 0 execution errors, 4 exercises (count_exercises conforming, #2161). Patient SAT on fresh cache, VERIFIE prong passes.

### Honesty notes (stale-vintage #8901, handled — no numeric parity claimed)
- Patient bounds (3347/10878/30/600) port as-is, but the **resolved menu values differ** from C# 08 (different corpus subset + fresh cache 16b). Cross-stack claim = **structural** (same 5 families, same 90 linking assertions, SAT, VERIFIE), not numeric.
- **M1 Variant A is UNSAT on this subset** (creneau 4 has only 1 candidate → 7 strictly-ascending days impossible). Honest solver verdict; resolved on the full corpus (G3).
- Patient bounds were tuned against the stale C# corpus — **verified SAT** on the fresh pool (no silent retune; if it had gone UNSAT I'd report that as a finding).

### Port fidelity correction (honest)
My scope plan (#1206, c.998 comment) described a `Patient`/`Restriction` dataclass. A firsthand read of 08 shows it has **no such class** — the upstream `Patient{Restriction[]}` is absent from this repo; 08 inlines the patient as four `int` locals. This port stays **faithful to 08** (inline) rather than reconstructing the absent upstream class. Flagged so the scope comment and the port don't disagree silently.

### Not in this PR
- README Z3-API entry/count — po-2025 turf + auto-regenerated `CATALOG-STATUS`.
- Builder + cache gitignored (data-layer notebook 16b produces the cache; run it first).

**Next grains** (per #1206 plan): G3 convergence-scale (introduces `PbEq`/`PbLe`/`PbGe`, 1st in Python track) · G4 Optimize-non-mirror · G5 hygiene retrofit.

See #1206 · Depends on #8902 (G1 cache)
