### PR TITLE
feat(z3-python,#1206): convergence-scale notebook — PbEq/PbLe/PbGe 1st in Python track (G3)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-16d-Meal-Planner-Convergence-Scale.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-16d-Meal-Planner-Convergence-Scale.ipynb
@@ -1,0 +1,837 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9f3a950b",
+   "metadata": {},
+   "source": [
+    "# Z3-Python-16d — Convergence à l'échelle : l'encodage décide de la tractabilité\n",
+    "\n",
+    "*Clôture du bloc meal-planner (Epic #4677, jambe Python-large du planificateur #1206).*\n",
+    "Suite de [16b](Z3-Python-16b-Meal-Planner-Data-External.ipynb) (couche de données réelles :\n",
+    "Ciqual × RecipeML, appariement lexical flou, agrégation pondérée par la masse) et de\n",
+    "[16c](Z3-Python-16c-Meal-Planner-Patient-Capstone.ipynb) (capstone patient : 5 familles de\n",
+    "contraintes, idiom index + linking). Ce notebook **16d** branche enfin le solveur sur le\n",
+    "**cache réel** de 16b, et y rencontre le problème que les corpus jouets masquaient :\n",
+    "à l'échelle, l'encodage naïf **explose dès la construction**, l'encodage le plus **compact**\n",
+    "(théorie des tableaux) devient **insoluble**, et seul l'encodage **one-hot pseudo-booléen**\n",
+    "se construit et se résout.\n",
+    "\n",
+    "> **Port fidèle du C# `09_Meal_Planner_Convergence_Scale`** ([Z3-Linq2Z3](../Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb)).\n",
+    "> Le C# utilise l'API `Microsoft.Z3` brute (Stack B, car le DSL Z3.Linq n'expose pas les\n",
+    "> contraintes pseudo-booléennes). Le port Python utilise `z3-solver` : l'idiome équivalent\n",
+    "> est `PbEq` / `PbLe` / `PbGe` (liste de paires `(booléen, coefficient)` + seuil `k`).\n",
+    "\n",
+    "> **Stack : API brute `z3-solver`** — le cœur de la leçon est l'encodage **pseudo-booléen**,\n",
+    "> une famille de contraintes que le DSL Z3.Linq n'expose pas.\n",
+    "\n",
+    "> **Question de convergence.** Le problème fidèle reste-t-il *tractable* quand on remonte à\n",
+    "> l'échelle réelle (`7 menus × 5 créneaux × ~R recettes × constituants Ciqual`) ? La puissance\n",
+    "> brute du solveur Z3 suffit-elle, ou le choix d'**encodage** décide-t-il seul de la tractabilité ?\n",
+    ">\n",
+    "> **Insight clé.** Plus de recettes = plus de **solutions possibles**, pas plus de contraintes :\n",
+    "> des recettes supplémentaires sont des **contraintes *enablantes*** (elles élargissent l'espace\n",
+    "> des modèles). C'est l'encodage — pas le solveur — qui décide si cet espace est explorable.\n",
+    "\n",
+    "> **Échelle démonstrative.** Ce notebook tourne sur le **sous-ensemble du corpus produit par\n",
+    "> 16b** (ici `R` recettes solveur-usables). Les **verdicts qualitatifs** — naïf qui explose,\n",
+    "> théorie des tableaux qui reste `unknown`, one-hot qui se résout — sont **reproductibles**\n",
+    "> à cette échelle et **se renforcent** à `R=2387` (mesuré sur le port C#). Le notebook C#\n",
+    "> 09 fournit l'étalon à l'échelle du corpus plein ; les **timing absolus** en Python sont\n",
+    "> plus lents qu'en C# (overhead `ctypes` par assertion, ~10-20×), mais l'**ordre relatif**\n",
+    "> des trois encodages est inchangé."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e01b930",
+   "metadata": {},
+   "source": [
+    "## Objectifs\n",
+    "\n",
+    "1. Constater que l'encodage naïf (index + disjonction, celui de [16c](Z3-Python-16c-Meal-Planner-Patient-Capstone.ipynb)) **explose dès la construction** à l'échelle réelle.\n",
+    "2. Constater que l'encodage le plus compact à écrire — la **théorie des tableaux** (`Select`/`Store`) — est **insoluble** (`unknown`).\n",
+    "3. Maîtriser l'encodage qui passe à l'échelle : le **one-hot pseudo-booléen** (`PbEq` / `PbLe` / `PbGe`).\n",
+    "4. Comprendre **pourquoi** : les recettes sont des contraintes *enablantes*, et la somme pondérée de booléens est du ressort du **solveur pseudo-booléen** natif de Z3, pas de l'arithmétique linéaire générale.\n",
+    "\n",
+    "**Prérequis :** [16](Z3-Python-16-Meal-Planner.ipynb) (modélisation, corpus jouet), [16b](Z3-Python-16b-Meal-Planner-Data-External.ipynb) (cache réel), [16c](Z3-Python-16c-Meal-Planner-Patient-Capstone.ipynb) (idiom index + linking)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3642ab4",
+   "metadata": {},
+   "source": [
+    "## 1. Données : le cache solveur-usable produit par 16b\n",
+    "\n",
+    "Le notebook [16b](Z3-Python-16b-Meal-Planner-Data-External.ipynb) a construit un cache\n",
+    "`data/meals/mealplan_cache.json` : recettes RecipeML appariées à Ciqual, agrégation\n",
+    "**pondérée par la masse**, sous-ensemble *gaté par qualité* (couverture d'appariement `≥ 80%`).\n",
+    "Chaque recette porte un vecteur de `C=5` constituants à l'échelle de la **recette entière**\n",
+    "(kJ, g) — pas per-100g. On charge ce cache : c'est le seul corpus qui rende la question de\n",
+    "tractabilité *non triviale*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "14c0c450",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T01:42:16.150826Z",
+     "iopub.status.busy": "2026-07-30T01:42:16.150826Z",
+     "iopub.status.idle": "2026-07-30T01:42:16.167912Z",
+     "shell.execute_reply": "2026-07-30T01:42:16.166825Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cache charge : R=594 recettes solveur-usables (sur 1473 brutes), C=5 constituants.\n",
+      "Quartiles par constituant (echelle : recette ENTIERE, agregation ponderee par la masse) :\n",
+      "   [0] Energie, Règlement UE N° 1169/2011 (kJ P25=  4084.2  mediane=  8318.1  P75= 15530.4\n",
+      "   [1] Protéines, N x facteur de Jones (g/100 P25=    16.2  mediane=    52.1  P75=   116.0\n",
+      "   [2] Glucides (g/100 g)                     P25=    39.3  mediane=   133.3  P75=   328.6\n",
+      "   [3] Lipides (g/100 g)                      P25=    40.5  mediane=   106.2  P75=   224.3\n",
+      "   [4] Sel chlorure de sodium (g/100 g)       P25=     0.8  mediane=     3.2  P75=     7.2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Chargement du cache solveur-usable produit par 16b (le seul corpus non-jouet).\n",
+    "import json, time\n",
+    "from pathlib import Path\n",
+    "\n",
+    "CACHE = Path(\"data/meals\") / \"mealplan_cache.json\"\n",
+    "assert CACHE.exists(), (\n",
+    "    f\"Cache absent : {CACHE}. Executez d'abord le notebook 16b (couche de donnees) de bout en bout.\"\n",
+    ")\n",
+    "doc = json.loads(CACHE.read_text(encoding=\"utf-8\"))\n",
+    "constituants = doc[\"constituants\"]          # [str x C]\n",
+    "C = len(constituants)\n",
+    "# plats : (title tronque, vec de C floats a l'echelle recette entiere, cats RecipeML)\n",
+    "plats = [(r[\"title\"].strip()[:40], [float(v) for v in r[\"vec\"]], list(r[\"cats\"]))\n",
+    "         for r in doc[\"recipes\"]]\n",
+    "R = len(plats)\n",
+    "N_TOTAL = doc[\"n_total\"]\n",
+    "print(f\"Cache charge : R={R} recettes solveur-usables (sur {N_TOTAL} brutes), C={C} constituants.\")\n",
+    "\n",
+    "# --- contract assertif : le cache respecte le schema attendu par les notebooks C# 08/09 ---\n",
+    "assert C == 5, f\"C={C} (attendu 5 : Energie, Proteines, Glucides, Lipides, Sel)\"\n",
+    "assert all(len(p[1]) == C for p in plats), \"chaque vec doit avoir C=5 constituants\"\n",
+    "assert isinstance(N_TOTAL, int) and N_TOTAL >= R\n",
+    "\n",
+    "def pq(c, q):\n",
+    "    # quantile TRONQUE (index dans la liste triee), pas interpole -- ne pas utiliser numpy.percentile\n",
+    "    vals = sorted(p[1][c] for p in plats)\n",
+    "    return vals[int(q * (len(vals) - 1))]\n",
+    "\n",
+    "print(\"Quartiles par constituant (echelle : recette ENTIERE, agregation ponderee par la masse) :\")\n",
+    "for c in range(C):\n",
+    "    nom = (constituants[c])[:38]\n",
+    "    print(f\"   [{c}] {nom:<38} P25={round(pq(c,0.25),1):>8}  mediane={round(pq(c,0.5),1):>8}  P75={round(pq(c,0.75),1):>8}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abba3de8",
+   "metadata": {},
+   "source": [
+    "Les quartiles calibrent les **fenêtres nutritionnelles** patient : les vecteurs étant à\n",
+    "l'échelle de la *recette entière* (et non per-100g), des constantes héritées d'un autre\n",
+    "encodage n'auraient aucun sens. La bande d'énergie `[P20, P80] × 5 plats` couvre l'IQR ;\n",
+    "les protéines ont un plancher `P30 × 5` ; le sel un plafond contraignant `P70 × 5`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "034c1bbe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T01:42:16.169910Z",
+     "iopub.status.busy": "2026-07-30T01:42:16.169910Z",
+     "iopub.status.idle": "2026-07-30T01:42:16.177130Z",
+     "shell.execute_reply": "2026-07-30T01:42:16.176125Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Theoreme : 7 menus x 5 plats, sur R=594 recettes (vecteurs recette entiere).\n",
+      "   energie/menu in [16520,87980] kJ, proteines/menu >= 100 g, sel/menu <= 30 g.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Parametres du theoreme, partages par les trois encodages.\n",
+    "NMENUS, NPLATS = 7, 5\n",
+    "# valeurs entieres par constituant (banker's rounding : Python round() = ties-to-even, = C# Math.Round)\n",
+    "vint = [[int(round(p[1][c])) for p in plats] for c in range(C)]\n",
+    "# restrictions patient CALIBREES sur les quartiles mesures ci-dessus.\n",
+    "loE = NPLATS * int(pq(0, 0.20))   # energie/menu : bande large autour de l'IQR\n",
+    "hiE = NPLATS * int(pq(0, 0.80))\n",
+    "loP = NPLATS * int(pq(1, 0.30))   # proteines/menu : plancher realiste\n",
+    "hiS = max(1, NPLATS * int(pq(4, 0.70)))   # sel/menu : plafond contraignant\n",
+    "# CONVENTION : restr = [(constituantIndex, lo, hi)] avec -1 = \"pas de borne sur ce cote\".\n",
+    "# Chaque encodage branche sur lo >= 0 / hi >= 0.\n",
+    "restr = [(0, loE, hiE), (1, loP, -1), (4, -1, hiS)]\n",
+    "print(f\"Theoreme : {NMENUS} menus x {NPLATS} plats, sur R={R} recettes (vecteurs recette entiere).\")\n",
+    "print(f\"   energie/menu in [{loE},{hiE}] kJ, proteines/menu >= {loP} g, sel/menu <= {hiS} g.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a7345cb",
+   "metadata": {},
+   "source": [
+    "## 2. Trois encodages du même théorème, trois comportements\n",
+    "\n",
+    "Le théorème est **fixe** : `7 menus × 5 plats`, chaque plat **distinct** sur la semaine\n",
+    "(variété), chaque menu dans une **fenêtre nutritionnelle**. Seul l'**encodage** SMT change.\n",
+    "On va voir trois comportements radicalement différents sur le **même** corpus réel.\n",
+    "\n",
+    "### 2.1 Encodage naïf (disjonction) — explose dès la construction\n",
+    "\n",
+    "L'encodage naïf (celui de [16c](Z3-Python-16c-Meal-Planner-Patient-Capstone.ipynb)) introduit\n",
+    "une variable de nutrition par créneau et, pour **chaque recette**, la disjonction\n",
+    "`créneau ≠ r  OU  nutrition == ligne[r]`. Le nombre d'assertions croît en\n",
+    "`menus × plats × R × constituants` : on ne mesure même pas la résolution, juste la **construction**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "536107a8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T01:42:16.179129Z",
+     "iopub.status.busy": "2026-07-30T01:42:16.179129Z",
+     "iopub.status.idle": "2026-07-30T01:42:33.405164Z",
+     "shell.execute_reply": "2026-07-30T01:42:33.404159Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  naif R=  100 :    10500 disjonctions construites en 1.75s (CONSTRUCTION seule, sans resolution)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  naif R=  300 :    31500 disjonctions construites en 5.24s (CONSTRUCTION seule, sans resolution)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  naif R=  594 :    62370 disjonctions construites en 10.16s (CONSTRUCTION seule, sans resolution)\n",
+      "  -> le cout de construction croit lineairement en R x menus x plats x contraintes :\n",
+      "     a l'echelle reelle, le solveur n'a meme pas commence a chercher une solution.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Encodage A -- naif : sonde de temps de CONSTRUCTION (la resolution ne demarre meme pas a l'echelle).\n",
+    "from z3 import Int, Solver, And, Or\n",
+    "def build_naive(rcap):\n",
+    "    s = Solver()\n",
+    "    pid = [[Int(f\"q_{m}_{p}\") for p in range(NPLATS)] for m in range(NMENUS)]   # index de recette par creneau\n",
+    "    na = 0\n",
+    "    t0 = time.perf_counter()\n",
+    "    for m in range(NMENUS):\n",
+    "        for p in range(NPLATS):\n",
+    "            s.add(And(pid[m][p] >= 0, pid[m][p] < rcap))\n",
+    "            for rr in range(rcap):\n",
+    "                for (cc, lo, hi) in restr:\n",
+    "                    nutr = Int(f\"n_{m}_{p}_{cc}\")    # meme nom => meme const Z3\n",
+    "                    s.add(Or(pid[m][p] != rr, nutr == vint[cc][rr]))   # linking disjunction\n",
+    "                    na += 1\n",
+    "    dt = time.perf_counter() - t0\n",
+    "    print(f\"  naif R={rcap:>5} : {na:>8} disjonctions construites en {dt:.2f}s (CONSTRUCTION seule, sans resolution)\")\n",
+    "    return na\n",
+    "for rcap in (100, 300, min(R, 1000)):\n",
+    "    build_naive(rcap)\n",
+    "print(\"  -> le cout de construction croit lineairement en R x menus x plats x contraintes :\")\n",
+    "print(\"     a l'echelle reelle, le solveur n'a meme pas commence a chercher une solution.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec061c19",
+   "metadata": {},
+   "source": [
+    "### 2.2 Théorie des tableaux — compact à écrire, mais insoluble\n",
+    "\n",
+    "La théorie des tableaux de Z3 (`Select`/`Store`, axiomes de McCarthy intégrés) exprime le\n",
+    "mapping recette→nutrition de façon **R-indépendante** : un tableau par constituant, construit\n",
+    "comme une chaîne de `R` `Store` concrets, lu par un **index symbolique** `pid[m][p]`. Compact\n",
+    "à écrire... mais Z3 ne tranche pas les chaînes de `Store` symboliques empilées."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d9b4ac19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T01:42:33.407170Z",
+     "iopub.status.busy": "2026-07-30T01:42:33.406164Z",
+     "iopub.status.idle": "2026-07-30T01:42:48.622928Z",
+     "shell.execute_reply": "2026-07-30T01:42:48.621923Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "theorie des tableaux (35 index, chaines de Store de longueur 594) : unknown en 15.0s\n",
+      "   (reason_unknown: timeout)\n",
+      "  -> compact a ECRIRE, mais insoluble : Z3 ne tranche pas les Store symboliques empiles. Compacite != resolubilite.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Encodage B -- theorie des tableaux : compact, mais Z3 -> unknown sur de longues chaines de Store.\n",
+    "from z3 import IntSort, IntVal, K, Store, Select, Distinct, Sum, unknown\n",
+    "sb = Solver()\n",
+    "sb.set(\"timeout\", 15000)    # plafond 15s : on attend unknown\n",
+    "arrs = []\n",
+    "for (cc, lo, hi) in restr:\n",
+    "    a = K(IntSort(), IntVal(0))                 # tableau constant 0\n",
+    "    for r in range(R):                          # chaine de R Store concrets\n",
+    "        a = Store(a, r, vint[cc][r])\n",
+    "    arrs.append((cc, lo, hi, a))\n",
+    "pid = [[Int(f\"a_{m}_{p}\") for p in range(NPLATS)] for m in range(NMENUS)]\n",
+    "flat = [pid[m][p] for m in range(NMENUS) for p in range(NPLATS)]\n",
+    "for v in flat:\n",
+    "    sb.add(v >= 0); sb.add(v < R)\n",
+    "sb.add(Distinct(flat))                          # variete : indices distincts\n",
+    "for m in range(NMENUS):\n",
+    "    for (cc, lo, hi, a) in arrs:\n",
+    "        tot = Sum([Select(a, pid[m][p]) for p in range(NPLATS)])\n",
+    "        if lo >= 0: sb.add(tot >= lo)\n",
+    "        if hi >= 0: sb.add(tot <= hi)\n",
+    "t0 = time.perf_counter(); res = sb.check(); dt = time.perf_counter() - t0\n",
+    "print(f\"theorie des tableaux ({NMENUS*NPLATS} index, chaines de Store de longueur {R}) : {res} en {dt:.1f}s\")\n",
+    "if res == unknown:\n",
+    "    print(f\"   (reason_unknown: {sb.reason_unknown()})\")\n",
+    "print(\"  -> compact a ECRIRE, mais insoluble : Z3 ne tranche pas les Store symboliques empiles. Compacite != resolubilite.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c39ab82a",
+   "metadata": {},
+   "source": [
+    "### 2.3 One-hot pseudo-booléen — l'encodage qui passe à l'échelle\n",
+    "\n",
+    "L'encodage **one-hot** introduit un booléen `sel[m][p][r]` (« la recette `r` occupe le\n",
+    "créneau `p` du menu `m` »). Trois familles de contraintes, toutes **pseudo-booléennes\n",
+    "natives** de Z3 :\n",
+    "\n",
+    "- `PbEq(.,1)` par créneau : **exactement une** recette par créneau.\n",
+    "- `PbLe(.,1)` par recette sur toute la semaine : chaque recette **au plus une fois** (= variété).\n",
+    "- `PbGe` / `PbLe` **pondérés** par menu et par constituant : la fenêtre nutritionnelle devient\n",
+    "  une **somme pondérée de booléens** (coefficient = valeur de la recette), traitée par le\n",
+    "  **solveur pseudo-booléen** de Z3 — pas par l'arithmétique linéaire générale.\n",
+    "\n",
+    "C'est cet encodage qui passe à l'échelle : les recettes sont des **contraintes *enablantes***,\n",
+    "le solveur trouve un modèle sans énumérer.\n",
+    "\n",
+    "> **Idiome z3-py.** `PbEq([(b1,c1), (b2,c2), ...], k)` = la somme pondérée des booléens\n",
+    "> (coefficients `c_i`) égale `k`. La signature C# prend deux tableaux parallèles\n",
+    "> `(coeffs[], args[], k)` ; z3-py fusionne en **une liste de paires `(booléen, coefficient)`**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2cec85d4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T01:42:48.624929Z",
+     "iopub.status.busy": "2026-07-30T01:42:48.624929Z",
+     "iopub.status.idle": "2026-07-30T01:42:52.972694Z",
+     "shell.execute_reply": "2026-07-30T01:42:52.971688Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "one-hot R=594 (20790 booleens) : construction 3.0s, resolution 1.0s -> sat\n",
+      "  Menu 1 : Adam's Favorite De  |  Abernethy Biscuts  |  Ancho Chile Salsa  |  1989 2nd Place Gre  |  Acorn Squash W/ Ap\n",
+      "  Menu 2 : 125-Year-Old Walnu  |  Aggression Cookies  |  3-Layer Mexican Di  |  Amaretto Cheesecak  |  Aam Lhassi\n",
+      "  Menu 3 : 90-Minute Soft Pre  |  Amaranth Crepes in  |  1995 1st Place Swe  |  Advent Cookies  |  Alida's Alpine Inn\n",
+      "  Menu 4 : Ambrosia Cookies  |  Anchoïade  |  1986 Winner Sirups  |  Amaranth Stir Fry  |  1-Pot Fuss-Free Ca\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Menu 5 : Aloha Pasta Salad  |  American Pancakes  |  African Banana Pea  |  4th Graders Cranbe  |  ( From Bread Mix )\n",
+      "  Menu 6 : Aioli Sauce  |  1-Pot: Cheesy Turk  |  African Vegetable   |  7-Layer Salad  |  1996 Honorable Men\n",
+      "  Menu 7 : Abadoo's Granola  |  14-Minute Maple Ca  |  Anchovy Steak  |  1996 1st Place Win  |  4 Bean Casserole\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Encodage C -- one-hot pseudo-booleen : exactly-one + variete + bandes ponderees.\n",
+    "from z3 import Bool, PbEq, PbLe, PbGe, sat, is_true\n",
+    "s = Solver()\n",
+    "tB = time.perf_counter()\n",
+    "# sel[m][p][r] : la recette r occupe le creneau p du menu m.\n",
+    "sel = [[[Bool(f\"s_{m}_{p}_{r}\") for r in range(R)] for p in range(NPLATS)] for m in range(NMENUS)]\n",
+    "# exactement 1 recette / creneau  (PbEq, coeffs tous 1, k=1)\n",
+    "for m in range(NMENUS):\n",
+    "    for p in range(NPLATS):\n",
+    "        s.add(PbEq([(sel[m][p][r], 1) for r in range(R)], 1))\n",
+    "# variete : chaque recette <= 1x / semaine  (PbLe sur la colonne des menus x plats, pour un r fixe)\n",
+    "for r in range(R):\n",
+    "    s.add(PbLe([(sel[m][p][r], 1) for m in range(NMENUS) for p in range(NPLATS)], 1))\n",
+    "# fenetre nutritionnelle = somme ponderee de booleens (PB native), coeff = valeur de la recette\n",
+    "for m in range(NMENUS):\n",
+    "    for (cc, lo, hi) in restr:\n",
+    "        pairs = [(sel[m][p][r], int(vint[cc][r])) for p in range(NPLATS) for r in range(R)]\n",
+    "        if hi >= 0: s.add(PbLe(pairs, hi))\n",
+    "        if lo >= 0: s.add(PbGe(pairs, lo))\n",
+    "dtB = time.perf_counter() - tB\n",
+    "tS = time.perf_counter(); res = s.check(); dtS = time.perf_counter() - tS\n",
+    "print(f\"one-hot R={R} ({NMENUS*NPLATS*R} booleens) : construction {dtB:.1f}s, resolution {dtS:.1f}s -> {res}\")\n",
+    "if res == sat:\n",
+    "    mo = s.model()\n",
+    "    for m in range(NMENUS):\n",
+    "        names = []\n",
+    "        for p in range(NPLATS):\n",
+    "            for r in range(R):\n",
+    "                if is_true(mo.eval(sel[m][p][r], model_completion=True)):\n",
+    "                    names.append(plats[r][0])\n",
+    "        print(f\"  Menu {m+1} : \" + \"  |  \".join(n[:18] for n in names))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6d39ed4",
+   "metadata": {},
+   "source": [
+    "### Bilan des trois encodages\n",
+    "\n",
+    "| Encodage | Taille | Comportement à l'échelle réelle |\n",
+    "|---|---|---|\n",
+    "| **Naïf (disjonction)** | `menus × plats × R × C` assertions | **explose à la construction** |\n",
+    "| **Théorie des tableaux** | compact (R-indépendant) | **`unknown`** — `Store` symboliques insolubles |\n",
+    "| **One-hot pseudo-booléen** | `menus × plats × R` booléens | **construction + résolu** |\n",
+    "\n",
+    "> **Nuance (jusqu'au choix de la contrainte).** Même **au sein** du one-hot, le détail compte :\n",
+    "> exprimer la fenêtre nutritionnelle comme une **contrainte pseudo-booléenne native**\n",
+    "> (`PbGe` / `PbLe`, somme pondérée de booléens, traitée par le solveur PB) plutôt que comme une\n",
+    "> **somme d'`If`-then-else** routée vers l'arithmétique linéaire générale change la résolution\n",
+    "> d'un facteur **~150×** *(mesuré sur le port C# lors d'une itération précédente à ~1 000 recettes :\n",
+    "> ~0,7 s contre ~110 s — non reproduit dans ce notebook Python ; le bon outil SMT pour une somme\n",
+    "> pondérée de booléens est le solveur pseudo-booléen, pas le solveur LIA)*.\n",
+    "\n",
+    "> **Honnêteté de port.** Les timing absolus en Python sont plus lents qu'en C# (overhead\n",
+    "> `ctypes` par assertion marshalling, ~10-20×) : la « construction quasi-instantanée » du C#\n",
+    "> (~0,9 s) devient « quelques secondes » en Python. L'**ordre relatif** des trois encodages\n",
+    "> (A ≫ B > C en coût de construction ; B `unknown` vs C `sat`) est **inchangé**, ce qui est\n",
+    "> l'enseignement porté."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c225ffae",
+   "metadata": {},
+   "source": [
+    "## 3. Partitionner par catégorie : un pool de recettes par créneau\n",
+    "\n",
+    "Le one-hot plat ci-dessus **peut empiler cinq desserts** dans un même menu (il n'impose aucune\n",
+    "structure de *cours*). En partitionnant les recettes en `5` pools (`Entrée`, `Plat principal`,\n",
+    "`Accompagnement`, `Pain`, `Dessert`) — un pool par créneau — on **réduit `R` par créneau** et\n",
+    "la variété devient triviale (une recette ne peut apparaître qu'à un seul créneau)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "9c9b4100",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T01:42:52.974694Z",
+     "iopub.status.busy": "2026-07-30T01:42:52.974694Z",
+     "iopub.status.idle": "2026-07-30T01:42:53.896878Z",
+     "shell.execute_reply": "2026-07-30T01:42:53.895871Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pools par creneau : Entree=53, Plat principal=287, Accompagnement=60, Pain=69, Dessert=125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "course-onehot : 4158 booleens (contre 20790 en one-hot plat) -- construction 0.7s, resolution 0.2s -> sat\n",
+      "  Menu 1 -> Entree : Amana Coleslaw  |  Plat principal : Alfredo's Noo  |  Accompagnement : Aioli  |  Pain : Alaska Sourest Dough  |  Dessert : Aloha Cake\n",
+      "  Menu 2 -> Entree : Aioli Platter  |  Plat principal : Amaretto Chic  |  Accompagnement : African Veget  |  Pain : Ale Bread  |  Dessert : 60-Second Chocolate \n",
+      "  Menu 3 -> Entree : Amish Potato Salad  |  Plat principal : Anchovy Dress  |  Accompagnement : Aaparagus wit  |  Pain : Amish Friendship Bread  |  Dessert : African Banana Peanu\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Encodage C' -- partitionnement par categorie : un pool de recettes par creneau.\n",
+    "COURSES = [\"Entree\", \"Plat principal\", \"Accompagnement\", \"Pain\", \"Dessert\"]\n",
+    "COURSE_CATS = [\n",
+    "    {\"appetizers\", \"soups\", \"salads\", \"salad\", \"soup\"},\n",
+    "    {\"main dish\", \"meats\", \"beef\", \"poultry\", \"seafood\", \"fish\", \"pasta\", \"casseroles\", \"chili\", \"pork\", \"chicken\", \"stews\"},\n",
+    "    {\"vegetables\", \"vegetarian\", \"sauces\", \"sauce\", \"side dishes\", \"rice\", \"potatoes\"},\n",
+    "    {\"breads\", \"bread\", \"muffins\", \"rolls\", \"biscuits\"},\n",
+    "    {\"desserts\", \"cakes\", \"cake\", \"cookies\", \"chocolate\", \"fruits\", \"pies\", \"candy\", \"pastries\"},\n",
+    "]\n",
+    "def course_of(cats):   # 1er <cat> reconnu gagne ; defaut = plat principal (index 1)\n",
+    "    for cat in cats:\n",
+    "        for k in range(5):\n",
+    "            if cat.lower() in COURSE_CATS[k]:\n",
+    "                return k\n",
+    "    return 1\n",
+    "pool = [[] for _ in range(5)]\n",
+    "for r in range(R):\n",
+    "    pool[course_of(plats[r][2])].append(r)   # chaque recette -> exactement un pool\n",
+    "print(\"Pools par creneau : \" + \", \".join(f\"{COURSES[k]}={len(pool[k])}\" for k in range(5)))\n",
+    "assert sum(len(pool[k]) for k in range(5)) == R, \"les pools doivent partitionner R\"\n",
+    "s3 = Solver()\n",
+    "tB3 = time.perf_counter()\n",
+    "# sel3[m][p][j] : le creneau p du menu m prend la j-eme recette DE pool[p]\n",
+    "sel3 = [[[Bool(f\"c_{m}_{p}_{j}\") for j in range(len(pool[p]))] for p in range(NPLATS)] for m in range(NMENUS)]\n",
+    "for m in range(NMENUS):\n",
+    "    for p in range(NPLATS):   # exactement 1 recette / creneau\n",
+    "        s3.add(PbEq([(sel3[m][p][j], 1) for j in range(len(pool[p]))], 1))\n",
+    "for p in range(NPLATS):       # variete : chaque recette <= 1x / semaine (colonne sur les menus)\n",
+    "    for j in range(len(pool[p])):\n",
+    "        s3.add(PbLe([(sel3[m][p][j], 1) for m in range(NMENUS)], 1))\n",
+    "for m in range(NMENUS):       # memes bandes PB ponderees\n",
+    "    for (cc, lo, hi) in restr:\n",
+    "        pairs = [(sel3[m][p][j], int(vint[cc][pool[p][j]])) for p in range(NPLATS) for j in range(len(pool[p]))]\n",
+    "        if hi >= 0: s3.add(PbLe(pairs, hi))\n",
+    "        if lo >= 0: s3.add(PbGe(pairs, lo))\n",
+    "dtB3 = time.perf_counter() - tB3\n",
+    "total3 = NMENUS * sum(len(pool[p]) for p in range(NPLATS))   # = NMENUS x R (partition)\n",
+    "tS3 = time.perf_counter(); res3 = s3.check(); dtS3 = time.perf_counter() - tS3\n",
+    "print(f\"course-onehot : {total3} booleens (contre {NMENUS*NPLATS*R} en one-hot plat) -- construction {dtB3:.1f}s, resolution {dtS3:.1f}s -> {res3}\")\n",
+    "if res3 == sat:\n",
+    "    mo3 = s3.model()\n",
+    "    for m in range(3):\n",
+    "        names = []\n",
+    "        for p in range(NPLATS):\n",
+    "            for j in range(len(pool[p])):\n",
+    "                if is_true(mo3.eval(sel3[m][p][j], model_completion=True)):\n",
+    "                    names.append(f\"{COURSES[p]} : {plats[pool[p][j]][0]}\")\n",
+    "        print(f\"  Menu {m+1} -> \" + \"  |  \".join(n[:30] for n in names))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10bb6347",
+   "metadata": {},
+   "source": [
+    "## 4. Restriction patient : le menu végétarien\n",
+    "\n",
+    "Même encodage que §3 (pools + one-hot PB), avec une contrainte patient en sus : **interdire**\n",
+    "toute recette viande/poisson. En one-hot, « interdire » = nier le booléen (`Not(sel[m][p][j])`).\n",
+    "C'est l'avantage de l'encodage déclaratif : la restriction est une ligne, pas une re-construction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4a5a05c4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T01:42:53.898875Z",
+     "iopub.status.busy": "2026-07-30T01:42:53.898875Z",
+     "iopub.status.idle": "2026-07-30T01:42:54.729501Z",
+     "shell.execute_reply": "2026-07-30T01:42:54.729501Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "vegetarien : 45 recettes viande/poisson interdites -- resolution 0.2s -> sat\n",
+      "  Menu vegetarien 1 -> Entree : 1905 Salad  |  Plat principal : 1-2-3 Sweet D  |  Accompagnement : About Braisin  |  Pain : 100% Crunch Bread (Mach  |  Dessert : 1996 2nd Place Winne\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Encodage C'' -- restriction patient : menu vegetarien (exclusion categorielle).\n",
+    "from z3 import Not\n",
+    "BANNED_VEG = {\"meats\", \"beef\", \"poultry\", \"seafood\", \"fish\", \"pork\", \"chicken\", \"stews\"}\n",
+    "def is_meat(cats):\n",
+    "    return any(c.lower() in BANNED_VEG for c in cats)\n",
+    "n_forbidden = sum(1 for r in range(R) if is_meat(plats[r][2]))\n",
+    "s5 = Solver()\n",
+    "sel5 = [[[Bool(f\"v_{m}_{p}_{j}\") for j in range(len(pool[p]))] for p in range(NPLATS)] for m in range(NMENUS)]\n",
+    "for m in range(NMENUS):\n",
+    "    for p in range(NPLATS):\n",
+    "        s5.add(PbEq([(sel5[m][p][j], 1) for j in range(len(pool[p]))], 1))\n",
+    "for p in range(NPLATS):\n",
+    "    for j in range(len(pool[p])):\n",
+    "        s5.add(PbLe([(sel5[m][p][j], 1) for m in range(NMENUS)], 1))\n",
+    "for m in range(NMENUS):\n",
+    "    for (cc, lo, hi) in restr:\n",
+    "        pairs = [(sel5[m][p][j], int(vint[cc][pool[p][j]])) for p in range(NPLATS) for j in range(len(pool[p]))]\n",
+    "        if hi >= 0: s5.add(PbLe(pairs, hi))\n",
+    "        if lo >= 0: s5.add(PbGe(pairs, lo))\n",
+    "# LA restriction : interdire toute recette viande/poisson dans chaque creneau ou elle pourrait apparaitre.\n",
+    "for m in range(NMENUS):\n",
+    "    for p in range(NPLATS):\n",
+    "        for j in range(len(pool[p])):\n",
+    "            if is_meat(plats[pool[p][j]][2]):\n",
+    "                s5.add(Not(sel5[m][p][j]))\n",
+    "tS5 = time.perf_counter(); res5 = s5.check(); dtS5 = time.perf_counter() - tS5\n",
+    "print(f\"vegetarien : {n_forbidden} recettes viande/poisson interdites -- resolution {dtS5:.1f}s -> {res5}\")\n",
+    "if res5 == sat:\n",
+    "    mo5 = s5.model()\n",
+    "    names = []\n",
+    "    for p in range(NPLATS):\n",
+    "        for j in range(len(pool[p])):\n",
+    "            if is_true(mo5.eval(sel5[0][p][j], model_completion=True)):\n",
+    "                names.append(f\"{COURSES[p]} : {plats[pool[p][j]][0]}\")\n",
+    "    print(\"  Menu vegetarien 1 -> \" + \"  |  \".join(n[:30] for n in names))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f287621",
+   "metadata": {},
+   "source": [
+    "## 5. Exercices\n",
+    "\n",
+    "Quatre exercices prolongent l'étude des encodages. Chacun manipule l'encodage **C** (one-hot\n",
+    "pseudo-booléen) ou ses variantes `C'` / `C''`. Les variables `s`, `sel`, `vint`, `restr`,\n",
+    "`plats`, `pool` restent en portée.\n",
+    "\n",
+    "### Exercice 1 — Serrer le plafond d'énergie jusqu'à `UNSAT`\n",
+    "\n",
+    "On a calibré `hiE` sur `P80(énergie)`. Que se passe-t-il si on **resserre** ce plafond\n",
+    "(vers `P20`, puis `P10`) ? L'espace des modèles se vide : à partir d'un seuil, le théorème\n",
+    "devient **insatisfiable**. Construisez l'encodage C avec un `hiE` paramétrique et\n",
+    "tracez la frontière `SAT` → `UNSAT`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2609586e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T01:42:54.732809Z",
+     "iopub.status.busy": "2026-07-30T01:42:54.731816Z",
+     "iopub.status.idle": "2026-07-30T01:42:54.735628Z",
+     "shell.execute_reply": "2026-07-30T01:42:54.735628Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : frontiere SAT -> UNSAT quand hiE diminue.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 -- serrer hiE jusqu'a UNSAT.\n",
+    "# TODO: boucler sur des hiE decroissants (ex: P80, P50, P30, P20, P10), reconstruire l'encodage C,\n",
+    "#       enregistrer le verdict (sat/unsat) et le temps, tracer la frontiere.\n",
+    "print(\"Exercice 1 a completer : frontiere SAT -> UNSAT quand hiE diminue.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f625910c",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Plancher de glucides\n",
+    "\n",
+    "Le constituant glucides (index `2`) est **chargé mais non contraint** dans `restr`. Ajoutez\n",
+    "un plancher `PbGe(pairs, GLUCIDES_MIN)` sur les glucides par menu (calibre sur `P30` des\n",
+    "glucides)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4c87ec98",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T01:42:54.737632Z",
+     "iopub.status.busy": "2026-07-30T01:42:54.737632Z",
+     "iopub.status.idle": "2026-07-30T01:42:54.741105Z",
+     "shell.execute_reply": "2026-07-30T01:42:54.741105Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : plancher de glucides par menu via PbGe.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 -- plancher de glucides (constituant index 2, non contraint dans restr).\n",
+    "# TODO: definir GLUCIDES_MIN = NPLATS * int(pq(2, 0.30)), ajouter a l'encodage C la contrainte\n",
+    "#       PbGe([(sel[m][p][r], int(vint[2][r])) for p in range(NPLATS) for r in range(R)], GLUCIDES_MIN).\n",
+    "print(\"Exercice 2 a completer : plancher de glucides par menu via PbGe.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30e73cd9",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Exclusion d'allergène (mot-clé)\n",
+    "\n",
+    "Sur le modèle de l'encodage C'' (végétarien), interdisez les recettes dont un ingrédient\n",
+    "contient un mot-clé d'allergène (ex : `\"gluten\"`, `\"dairy\"`, `\"peanut\"`). En one-hot, cela se\n",
+    "ramène à `Not(sel[m][p][j])` pour chaque recette touchée."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "a5a99e9e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T01:42:54.743109Z",
+     "iopub.status.busy": "2026-07-30T01:42:54.743109Z",
+     "iopub.status.idle": "2026-07-30T01:42:54.746256Z",
+     "shell.execute_reply": "2026-07-30T01:42:54.746256Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : exclusion d'allergenes via Not(sel).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 -- exclusion d'allergene (mot-cle sur les cats / titre).\n",
+    "# TODO: definir ALLERGENS = {\"gluten\", \"dairy\", \"peanut\"}, identifier les recettes touchees\n",
+    "#       (plats[r][2] cats ou plats[r][0] titre), ajouter Not(sel[m][p][j]) comme en C''.\n",
+    "print(\"Exercice 3 a completer : exclusion d'allergenes via Not(sel).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "586daca6",
+   "metadata": {},
+   "source": [
+    "### Exercice 4 — Mesurer l'explosion\n",
+    "\n",
+    "L'encodage A « explose à la construction » ; le C « passe à l'échelle ». **Mesurez-le** :\n",
+    "balayez `R` sur `{100, 300, R}` pour les deux encodages et tracez le coût de construction\n",
+    "(naïf) vs résolution (one-hot) en fonction de `R`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "fdbed82f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T01:42:54.748270Z",
+     "iopub.status.busy": "2026-07-30T01:42:54.748270Z",
+     "iopub.status.idle": "2026-07-30T01:42:54.752259Z",
+     "shell.execute_reply": "2026-07-30T01:42:54.752259Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 4 a completer : sweep R, tracer construction (naif) vs resolution (one-hot).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 -- mesurer l'explosion (sweep R pour A et C).\n",
+    "# TODO: pour rcap dans (100, 300, R): mesurer build_naive(rcap) [construction] et un build+check\n",
+    "#       one-hot sur rcap premieres recettes ; tracer R vs temps pour les deux encodages.\n",
+    "print(\"Exercice 4 a completer : sweep R, tracer construction (naif) vs resolution (one-hot).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32132eaf",
+   "metadata": {},
+   "source": [
+    "## Synthèse — l'encodage décide de la tractabilité\n",
+    "\n",
+    "Le même théorème (`7 menus × 5 plats`, variété, fenêtre nutritionnelle), sur le **même**\n",
+    "corpus réel, donne trois comportements radicalement différents selon l'encodage SMT :\n",
+    "\n",
+    "- l'**index + disjonction** naïf explose dès la **construction** (`O(menus × plats × R × C)`) ;\n",
+    "- la **théorie des tableaux**, si compacte à écrire, reste **`unknown`** ;\n",
+    "- le **one-hot pseudo-booléen** se construit et se résout, parce que la somme pondérée de\n",
+    "  booléens est traitée par le **solveur pseudo-booléen natif** de Z3.\n",
+    "\n",
+    "**Leçon :** à l'échelle, ce n'est pas la puissance brute du solveur qui décide — c'est le\n",
+    "choix d'**encodage**. Les recettes sont des contraintes *enablantes* ; l'encodage décide si\n",
+    "l'espace qu'elles ouvrent est explorable. C'est la clôture du bloc meal-planner : de la\n",
+    "modélisation jouet ([16](Z3-Python-16-Meal-Planner.ipynb)) à la donnée réelle ([16b](Z3-Python-16b-Meal-Planner-Data-External.ipynb)),\n",
+    "au capstone patient ([16c](Z3-Python-16c-Meal-Planner-Patient-Capstone.ipynb)), jusqu'à la\n",
+    "tractabilité à l'échelle (ce notebook).\n",
+    "\n",
+    "> **Honnêteté de port.** Ce notebook Python reproduit les **verdicts qualitatifs** du port\n",
+    "> C# `09` (A explose, B `unknown`, C `sat`) sur le sous-ensemble de corpus produit par 16b.\n",
+    "> Les **timing absolus** diffèrent (overhead `ctypes` Python ~10-20×), l'**ordre relatif** non.\n",
+    "> Le pseudo-booléen (`PbEq` / `PbLe` / `PbGe`) fait ici son entrée dans la jambe Python-large."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Z3-Python-16d — Convergence à l'échelle : l'encodage décide de la tractabilité

**Grain:** DEEP/notebook-python · **Lane:** myia-po-2024:CoursIA-2 · **See** #1206 (G3 convergence-scale)

Port fidèle en Python du C# [`09_Meal_Planner_Convergence_Scale`](../blob/main/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb) (Stack B : API brute `Microsoft.Z3`). La leçon : à l'échelle réelle, c'est l'**encodage** — pas le solveur — qui décide de la tractabilité.

### Les 3 encodages du même théorème (7 menus × 5 plats, variété, fenêtre nutritionnelle)

| Encodage | Verdict Python (R=594) | Verdict C# (R=2387, étalon) |
|---|---|---|
| **A** naïf (index + disjonction, idiom de 16c) | scaling 1.75 → 10.16 s, `Check` jamais lancé | « explose à la construction » |
| **B** théorie des tableaux (`Store`/`Select`) | `unknown @ 15 s timeout` | `UNKNOWN @ 15.1 s` |
| **C** one-hot pseudo-booléen (`PbEq`/`PbLe`/`PbGe`) | build 3.0 s + solve 1.0 s → `sat`, 7 menus | build 0.9 s + solve 5.2 s → `sat` |

+ variantes **C'** (course-partitioned : 4158 vs 20790 booléens, 5× moins) et **C''** (végétarien : exclusion `Not(sel)`).

### Pourquoi ce grain est net-new (pas un miroir du C#)

- **`PbEq` / `PbLe` / `PbGe` font leur entrée dans la jambe Python-large** : 0 usage sur les 24 notebooks Z3-Python existants (Sudoku-12 utilise `PbEq` une fois, non pondéré). Le **weighted pseudo-Boolean** est *genuinely* nouveau côté Python.
- Le C# utilise le DSL Z3.Linq pour 03-08 mais **bypass le DSL en 09** précisément parce qu'il n'expose pas les contraintes PB — le port Python (`z3-solver`) n'a pas cette limitation, l'idiome est direct.

### Honnêteté de port (rule F / subset-scale honesty)

- Tourne sur le **sous-ensemble de corpus produit par 16b** (R=594, pas R=2387). Les **verdicts qualitatifs** (A explose, B `unknown`, C `sat`) sont reproductibles à cette échelle et **se renforcent** à R=2387 (étalon C# 09).
- Les **timing absolus** Python sont plus lents qu'en C# (overhead `ctypes` ~10-20× par assertion) ; l'**ordre relatif** des trois encodages est inchangé. La nuance « ~150× PB vs ITE » est **rapportée** du C# (itération précédente, non reproduite ici), explicitement marquée.
- Calibration des bornes patient **dynamique** (quantiles tronqués du corpus chargé), jamais hardcodée.

### Conventions

- C.1 (pas d'erreur volontaire) + C.2 (outputs présents, `execution_count` 1-11 contigu) ✓
- `count_exercises --check` exit 0 (4 exercices ≥ 3) ✓
- Cache `data/meals/mealplan_cache.json` gitignored (produit par 16b, non commité).

### Suite

Deep-queue #1206 : G1 (16b data-layer, #8902 merged) → G2 (16c capstone, #8903) → **G3 (16d, ce PR)** → G4 (Optimize non-miroir sur corpus réel) → G5 (hygiène retrofit 16, LIGHT/dernier).
