### PR TITLE
docs(archive,#7422): materialize ARCHIVED header on 26 investigation-mcp-nuget + fix 3 dead _archives refs

### DIFF
--- a/docs/archive/03-plan-formation-datascience-agentique.md
+++ b/docs/archive/03-plan-formation-datascience-agentique.md
@@ -132,4 +132,4 @@ Emplacement : `MyIA.AI.Notebooks/GenAI/Playwright-OWUI/` (5 modules, 30+ tests)
 
 ---
 
-*Document mis a jour mai 2026. Pour l'historique de la version originale (ADK DeepMind 2023), voir `docs/_archives/02-etude-adk-deepmind.md`.*
+*Document mis a jour mai 2026. Pour l'historique de la version originale (ADK DeepMind 2023), voir `docs/archive/02-etude-adk-deepmind.md`.*

--- a/docs/archive/investigation-mcp-nuget/06-MCP-Jupyter-Setup.md
+++ b/docs/archive/investigation-mcp-nuget/06-MCP-Jupyter-Setup.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # Rapport d'échec : Tâche d'exécution de notebook via MCP Jupyter
 
 ## Objectif de la tâche

--- a/docs/archive/investigation-mcp-nuget/07-SDDD-Investigation-Bug-SDK-Solutions-Alternatives.md
+++ b/docs/archive/investigation-mcp-nuget/07-SDDD-Investigation-Bug-SDK-Solutions-Alternatives.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # Investigation Technique SDDD : Bug SDK et Solutions Alternatives
 
 **Date :** 12 septembre 2025  

--- a/docs/archive/investigation-mcp-nuget/08-SDDD-Checkpoint-Semantique-Papermill.md
+++ b/docs/archive/investigation-mcp-nuget/08-SDDD-Checkpoint-Semantique-Papermill.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # Checkpoint Sémantique SDDD : Architecture Papermill-CoursIA
 
 **Date :** 12 septembre 2025  

--- a/docs/archive/investigation-mcp-nuget/09-SDDD-Implementation-Success-Papermill-CoursIA.md
+++ b/docs/archive/investigation-mcp-nuget/09-SDDD-Implementation-Success-Papermill-CoursIA.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # SDDD Checkpoint Final : Implémentation Réussie Papermill-CoursIA
 
 **Date :** 12 septembre 2025  

--- a/docs/archive/investigation-mcp-nuget/10-SDDD-Comparaison-Outils-MCP-Servers.md
+++ b/docs/archive/investigation-mcp-nuget/10-SDDD-Comparaison-Outils-MCP-Servers.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # Rapport de Comparaison des Outils MCP
 
 ## Résumé Exécutif

--- a/docs/archive/investigation-mcp-nuget/11-SDDD-Rapport-Validation-Complete-MCP-Servers.md
+++ b/docs/archive/investigation-mcp-nuget/11-SDDD-Rapport-Validation-Complete-MCP-Servers.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # Rapport de Validation Complète - Serveurs MCP Jupyter
 
 ## 📋 Résumé Exécutif

--- a/docs/archive/investigation-mcp-nuget/12-MIGRATION-MCP-Jupyter-Python-Server.md
+++ b/docs/archive/investigation-mcp-nuget/12-MIGRATION-MCP-Jupyter-Python-Server.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # Documentation Migration MCP : Serveur Jupyter Node.js → Python
 
 **Date de migration :** 13 septembre 2025  

--- a/docs/archive/investigation-mcp-nuget/13-ROLLBACK-MCP-JUPYTER-SERVER.md
+++ b/docs/archive/investigation-mcp-nuget/13-ROLLBACK-MCP-JUPYTER-SERVER.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # Rollback de la Configuration du Serveur MCP Jupyter
 
 **Date du Rollback :** 2025-09-13T12:35:22.847Z (heure UTC)

--- a/docs/archive/investigation-mcp-nuget/14-DIAGNOSTIC-CRITIQUE-MCP-JUPYTER-RECOVERY.md
+++ b/docs/archive/investigation-mcp-nuget/14-DIAGNOSTIC-CRITIQUE-MCP-JUPYTER-RECOVERY.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # Diagnostic Critique et Stratégie de Récupération MCP Jupyter
 
 **Date du diagnostic :** 2025-09-13T13:01:49.292Z  

--- a/docs/archive/investigation-mcp-nuget/15-TEST-CRITIQUE-SOLUTION-A-SUCCESS-FINAL.md
+++ b/docs/archive/investigation-mcp-nuget/15-TEST-CRITIQUE-SOLUTION-A-SUCCESS-FINAL.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # TEST CRITIQUE FINAL - Solution A avec Architecture MCP Améliorée
 
 ## 🎯 RÉSULTAT : SUCCÈS COMPLET ✅

--- a/docs/archive/investigation-mcp-nuget/16-VALIDATION-NOTEBOOKS-PYTHON-COMPLEXES-SOLUTION-A.md
+++ b/docs/archive/investigation-mcp-nuget/16-VALIDATION-NOTEBOOKS-PYTHON-COMPLEXES-SOLUTION-A.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # 🧪 **VALIDATION NOTEBOOKS PYTHON COMPLEXES - Solution A Papermill Direct API**
 
 ## 🎯 **Objectif de la Validation**

--- a/docs/archive/investigation-mcp-nuget/17-SDDD-RESOLUTION-DEFINITIVE-NUGET-DOTNET-INTERACTIVE.md
+++ b/docs/archive/investigation-mcp-nuget/17-SDDD-RESOLUTION-DEFINITIVE-NUGET-DOTNET-INTERACTIVE.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # SDDD - Résolution Définitive du Problème NuGet .NET Interactive
 
 **Date :** 2025-09-15  

--- a/docs/archive/investigation-mcp-nuget/18-SDDD-ETAT-FINAL-MCP-JUPYTER-NUGET.md
+++ b/docs/archive/investigation-mcp-nuget/18-SDDD-ETAT-FINAL-MCP-JUPYTER-NUGET.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # SDDD - État Final MCP Jupyter-Papermill : Post-Investigation Complète
 
 **Date :** 15 septembre 2025  

--- a/docs/archive/investigation-mcp-nuget/19-RESOLUTION-DEFINITIVE-MICROSOFT-ML-MCP.md
+++ b/docs/archive/investigation-mcp-nuget/19-RESOLUTION-DEFINITIVE-MICROSOFT-ML-MCP.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # RÉSOLUTION DÉFINITIVE : Blocage Microsoft.ML dans MCP
 
 ## 🎯 **RÉSULTATS FINAUX**

--- a/docs/archive/investigation-mcp-nuget/20-SYNTHESE-DOCUMENTAIRE-COMPLETE-06-19.md
+++ b/docs/archive/investigation-mcp-nuget/20-SYNTHESE-DOCUMENTAIRE-COMPLETE-06-19.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # Synthèse Documentaire Complète (Documents 06-19) - Investigation MCP-NuGet
 
 Ce document est une synthèse exhaustive de l'investigation menée sur les problèmes d'exécution des notebooks .NET Interactive via le MCP Jupyter, basée sur l'analyse des documents de suivi numérotés de 06 à 19.

--- a/docs/archive/investigation-mcp-nuget/21-ANALYSE-ARCHITECTURE-MCP-EVOLUTION-GIT.md
+++ b/docs/archive/investigation-mcp-nuget/21-ANALYSE-ARCHITECTURE-MCP-EVOLUTION-GIT.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # Analyse d'Architecture MCP et Évolution Git
 
 Ce document détaille l'analyse comparative des architectures des serveurs MCP Jupyter (Node.js et Python/Papermill) pour identifier la cause racine du problème de restauration NuGet avec .NET Interactive.

--- a/docs/archive/investigation-mcp-nuget/22-RESOLUTION-DEFINITIVE-FINALE-MCP-NUGET.md
+++ b/docs/archive/investigation-mcp-nuget/22-RESOLUTION-DEFINITIVE-FINALE-MCP-NUGET.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # 22 - RÉSOLUTION DÉFINITIVE FINALE MCP-NUGET
 
 **Date :** 2025-09-17  

--- a/docs/archive/investigation-mcp-nuget/23-VALIDATION-EXHAUSTIVE-NOTEBOOKS-DOTNET-MCP.md
+++ b/docs/archive/investigation-mcp-nuget/23-VALIDATION-EXHAUSTIVE-NOTEBOOKS-DOTNET-MCP.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # VALIDATION EXHAUSTIVE NOTEBOOKS .NET RÉELS - ÉCHEC CRITIQUE
 
 **MISSION CRITIQUE :** Validation exhaustive de TOUS les notebooks .NET du dépôt CoursIA avec la solution implémentée

--- a/docs/archive/investigation-mcp-nuget/24-RESOLUTION-TECHNIQUE-NUGET-TARGETS-PATH1-NULL.md
+++ b/docs/archive/investigation-mcp-nuget/24-RESOLUTION-TECHNIQUE-NUGET-TARGETS-PATH1-NULL.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # RÉSOLUTION TECHNIQUE : Investigation Erreur NuGet.targets Path1 Null
 
 **Date :** 17 septembre 2025  

--- a/docs/archive/investigation-mcp-nuget/25-SYNTHESE-FINALE-ET-PLAN-ACTION-MCP-NUGET.md
+++ b/docs/archive/investigation-mcp-nuget/25-SYNTHESE-FINALE-ET-PLAN-ACTION-MCP-NUGET.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # Synthèse Finale et Plan d'Action pour la Résolution Définitive MCP-NuGet
 
 **Date :** 17 septembre 2025  

--- a/docs/archive/investigation-mcp-nuget/25-SYNTHESE-HISTORIQUE-INVESTIGATION-MCP-NUGET.md
+++ b/docs/archive/investigation-mcp-nuget/25-SYNTHESE-HISTORIQUE-INVESTIGATION-MCP-NUGET.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # Synthèse de l'Historique d'Investigation MCP-NuGet
 
 Ce document retrace l'historique des tâches liées à la résolution du problème d'exécution des notebooks .NET Interactive avec des paquets NuGet via le MCP Jupyter.

--- a/docs/archive/investigation-mcp-nuget/26-RESOLUTION-DEFINITIVE-MCP-NUGET-SOLUTION-RETROUVEE.md
+++ b/docs/archive/investigation-mcp-nuget/26-RESOLUTION-DEFINITIVE-MCP-NUGET-SOLUTION-RETROUVEE.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # Résolution Définitive MCP-NuGet : La Solution Retrouvée
 
 **Date :** 18 septembre 2025  

--- a/docs/archive/investigation-mcp-nuget/27-RESOLUTION-FINALE-NOTEBOOK-MAKER-SUJET-COMPLEXE.md
+++ b/docs/archive/investigation-mcp-nuget/27-RESOLUTION-FINALE-NOTEBOOK-MAKER-SUJET-COMPLEXE.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # 27 - RÉSOLUTION FINALE : Notebook Maker avec Sujets Complexes
 
 **Date :** 7 octobre 2025  

--- a/docs/archive/investigation-mcp-nuget/29-ARCHITECTURE-ASYNC-EXECUTIONMANAGER-RESOLUTION-TIMEOUTS.md
+++ b/docs/archive/investigation-mcp-nuget/29-ARCHITECTURE-ASYNC-EXECUTIONMANAGER-RESOLUTION-TIMEOUTS.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # 🚀 ARCHITECTURE ASYNC EXECUTIONMANAGER : RÉSOLUTION DÉFINITIVE DES TIMEOUTS MCP
 
 **Date :** 28 septembre 2025  

--- a/docs/archive/investigation-mcp-nuget/30-RESOLUTION-DEFINITIVE-SEMANTIC-KERNEL-CLR-NOTEBOOK.md
+++ b/docs/archive/investigation-mcp-nuget/30-RESOLUTION-DEFINITIVE-SEMANTIC-KERNEL-CLR-NOTEBOOK.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # RÉSOLUTION DÉFINITIVE : SemanticKernel CLR Notebook - Compatibilité MCP Async
 
 **Date :** 28 septembre 2025  

--- a/docs/archive/investigation-mcp-nuget/31-VALIDATION-SYMBOLIQUE-AI-ARGUMENT-ANALYSIS-SUITE.md
+++ b/docs/archive/investigation-mcp-nuget/31-VALIDATION-SYMBOLIQUE-AI-ARGUMENT-ANALYSIS-SUITE.md
@@ -1,3 +1,5 @@
+> **ARCHIVED 2026-07-30** — PM transiente (investigation MCP Jupyter / NuGet / .NET Interactive, Sept-Oct 2025). L'etat courant vit dans le serveur `mcp-jupyter` (roo-extensions) et `docs/reference/kernels-runtime.md`. INDEX-only (no external inbound refs on `origin/main`). See #7422 triage.
+
 # Document SDDD 31 - VALIDATION SYMBOLIQUE-AI ARGUMENT ANALYSIS SUITE
 
 **Mission :** Validation complète de la suite de notebooks SymbolicAI Argument_Analysis via l'architecture MCP async, avec identification et résolution des problèmes d'intégration.

--- a/scripts/mcp-maintenance/README_MCP_MAINTENANCE.md
+++ b/scripts/mcp-maintenance/README_MCP_MAINTENANCE.md
@@ -72,7 +72,7 @@ Emplacement pour développer des outils de :
 - **`26-RESOLUTION-DEFINITIVE-MCP-NUGET-SOLUTION-RETROUVEE.md`** : Solution complète retrouvée par analyse archéologique
 
 ### Complémentarité
-Cette documentation technique complète celle disponible dans `docs/_archives/investigation-mcp-nuget/` (21 documents séquentiels, archives).
+Cette documentation technique complète celle disponible dans `docs/archive/investigation-mcp-nuget/` (21 documents séquentiels, archives).
 
 ---
 
@@ -115,7 +115,7 @@ Utiliser les fichiers `config/` comme référence pour reproduire la configurati
 ## 📚 Documentation Complémentaire
 
 ### Investigation Complète
-Voir `docs/_archives/investigation-mcp-nuget/` pour la séquence complète de 21 documents d'investigation (docs 06-26, archives).
+Voir `docs/archive/investigation-mcp-nuget/` pour la séquence complète de 21 documents d'investigation (docs 06-26, archives).
 
 ### Architecture Générale
 Voir `architecture_mcp_roo.md` à la racine pour l'architecture globale des serveurs MCP.


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2023:CoursIA

## Summary

Canonical **ARCHIVED blockquote header** (pattern #8131/#8138/#7919) materialized on the 26 content files of `docs/archive/investigation-mcp-nuget/` (PM transiente — MCP Jupyter / NuGet / .NET Interactive investigation, Sept-Oct 2025). The header cites the live-state location (`mcp-jupyter` server + `docs/reference/kernels-runtime.md`), per the "Consolider != Archiver" convention (an archive header should cite supersession).

Also fixes **3 dead `docs/_archives/` refs** (post-rename #1925 — the underscore path is fully superseded by `docs/archive/`). Each redirect target verified to exist on `origin/main`:
- `docs/archive/03-plan-formation-datascience-agentique.md:135` → `docs/archive/02-etude-adk-deepmind.md` (exists)
- `scripts/mcp-maintenance/README_MCP_MAINTENANCE.md:75,118` → `docs/archive/investigation-mcp-nuget/` (27 files)

## Verification (firsthand on origin/main `3ea3dc7a5`)
- 26/26 content files lacked the header before (samples `06-`/`07-`/`08-` started with `# …`, not `> **ARCHIVED`).
- 3/3 dead refs confirmed: `docs/_archives/investigation-mcp-nuget/` does NOT exist on main; live path is `docs/archive/investigation-mcp-nuget/`.
- Header format consistent with canonical precedent (`docs/archive/genai/architecture.md`, #8131). ASCII accent convention matches `docs/archive/` (genai INDEX: "Archivee", "se referer a").
- Collision-clean: no open PR on these paths (#8131/#8138/#7919 merged on OTHER dirs).
- Catalogue byte-identical to main (not regenerated on the branch). +55/-3, 28 files.
- Markdown-only — no notebook cells, no re-exec, H.3 n/a.

## Scope discipline
Single subject: archive hygiene on one investigation dir + its inbound dead refs. `See #7422` (the broader docs-hygiene epic is not closed by this).

## Related finding (G.1 correction — NOT in this PR)
While re-verifying checkout staleness for this PR, I confirmed firsthand on `origin/main` that **#8904 is a REAL defect** (QC quantbooks carry YAML frontmatter in cell#0 → oversized setext-H2 rendering). A prior dismissal ("ML-Regression cell#0 carries no defect") was a stale-tree artifact — that checkout predated the #8866 merge. Reported separately on #8904; the fix itself (frontmatter detector-scoped) is reserved for a dedicated execution, not bundled here.