### PR TITLE
fix(ci,#8896): variation-tag guard — detection de la lane insensible a la casse

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -165,9 +165,9 @@ jobs:
             # humain, donc simple note et pas de label. Un tag rejete pour son
             # placement serait un faux negatif du guard.
             LANE_RE='lane:?[[:space:]]+[A-Za-z0-9._-]+:[A-Za-z0-9._-]+'
-            if printf '%s' "$GRAIN_LINE" | grep -qE "$LANE_RE"; then
+            if printf '%s' "$GRAIN_LINE" | grep -qiE "$LANE_RE"; then
               echo "lane declaree sur la ligne du tag."
-            elif printf '%s\n' "$BODY_FLAT" | grep -qE "$LANE_RE"; then
+            elif printf '%s\n' "$BODY_FLAT" | grep -qiE "$LANE_RE"; then
               echo "::notice::lane declaree, mais hors de la ligne 'Grain:'. §1 la place sur la ligne du tag."
             else
               echo "::warning::Aucune 'lane <machine:workspace>' declaree. G-VAR-2 est un cap PAR LANE et PAR JOUR : un grain sans lane est structurellement incomptable, et le cap devient inapplicable sans que personne ne l'ait contourne (§3)."


### PR DESCRIPTION
`Grain: LIGHT/guard - lane myia-ai-01:CoursIA - prev: LIGHT/guard (#8897)`

## Le defaut

Le garde pose `variation-tag-lane-missing` sur une PR qui **declare pourtant sa lane**, des lors que l'auteur capitalise le mot. `LANE_RE` etait matche avec `grep -qE` — sensible a la casse — alors que le reste du garde neutralise deja l'habillage markdown (`tr -d '*` '`, L111) precisement pour ne pas rejeter un tag sur sa presentation.

Constate en vrai sur **#8907**, dont le body porte `**Lane:** myia-po-2024:CoursIA-2`. Le tag est complet et non ambigu ; le garde crie au loup sur un **L majuscule**. Le motif ecrit en L105-110 pour les asterisques et les backticks — « un tag rejete pour son habillage serait un faux negatif du guard, pas une non-conformite de l'auteur » — couvre la casse exactement de la meme facon. C'etait la troisieme variante d'habillage, et elle avait ete manquee.

Le cout n'est pas cosmetique : un label pose a tort sur une PR conforme apprend aux workers que le garde se trompe, et c'est ainsi qu'un garde cesse d'etre lu. C'est le defaut symetrique de celui que je viens de bloquer sur #8868 (un outil qui part en ERROR sur un arbre propre).

## Le correctif, et la preuve qu'il n'emousse rien

Deux caracteres, `-qE` -> `-qiE`, dans **les deux** branches (ligne du tag, puis reste du body) — sinon les deux chemins divergent.

Matrice mesuree sur la ligne **aplatie** (post-`tr`, comme le garde la voit reellement — mon premier test portait sur la ligne brute, ou les deux formes echouent, et m'aurait fait accuser les `**` au lieu de la casse) :

| Ligne testee | `grep -qE` | `grep -qiE` |
|---|---|---|
| `Grain: DEEP/notebook-python · Lane: myia-po-2024:CoursIA-2 …` (#8907) | no-match | **MATCH** |
| `Grain: DEEP/notebook-python - lane myia-po-2024:CoursIA-2 - prev: …` (forme canonique) | MATCH | MATCH |
| `Grain: LIGHT/ledger - LANE MYIA-PO-2023:CoursIA` (tout capitales) | no-match | **MATCH** |
| `Grain: MED/docs - prev: LIGHT/guard` (**controle negatif** : pas de lane) | no-match | no-match |

La derniere ligne est ce qui compte : **une PR sans lane reste signalee**. Le filtre ne se relache pas, il cesse de mordre sur la casse. La forme canonique lowercase continue de passer par la premiere branche — aucune regression.

## Ce que je n'etends pas, et pourquoi

La detection de la ligne `Grain:` (L114) et les extractions `sed` de TIER/GENRE (L129-130) **restent sensibles a la casse**. Les rendre insensibles a moitie serait *pire* : une ligne `grain:` bas-de-casse serait alors trouvee, mais TIER parserait vide, et le garde produirait un faux `variation-tag-malformed` a la place du faux `variation-tag-lane-missing` — un defaut deplace, pas corrige. Il faudrait les quatre d'un coup (dont un `s///I` GNU-sed). Aucune occurrence de `grain:` bas-de-casse observee a ce jour ; a traiter en bloc le jour ou il y en a une, pas par anticipation.

## Note G-VAR-3 — l'adjacence est reelle et je l'ecris

`prev: LIGHT/guard (#8897)` : c'est un **deuxieme `guard` consecutif** sur ma lane, et [variation-protocol §2](../blob/main/.claude/rules/variation-protocol.md) bloque l'adjacence des genres LIGHT **des 2**, sans carve-out. Je ne me l'accorde pas en silence.

Le protocole n'a pas de vocabulaire pour ce cas : **un correctif a ma propre regression, dans le livrable que j'ai merge il y a quatre heures, decouvert en l'utilisant.** Ce n'est pas un grain qu'on *choisit* dans le pool — G-VAR-3 gouverne le choix de ce qu'on ramasse, et vise les vagues scan-generables (« j'en genere une douzaine en scannant l'instance suivante » : non, ce correctif nait d'un faux positif nomme sur une PR nommee). Un organe d'enforcement casse qui continue de tourner mal-etiquette les PR des workers a chaque passe : le laisser en place jusqu'a demain coute plus que la repetition de genre.

Test que j'applique a moi-meme ce que j'appliquerais a un worker : si po-2026 m'apportait un 2-caracteres sur son propre garde merge 4 h plus tot, qui vient de mal-etiqueter la PR d'un tiers — est-ce que je bloquerais sur G-VAR-3 et lui dirais « change de genre, livre demain » ? Non. Je le mergerais, et je dirais que reparer sa propre casse ne consomme pas le budget de variete. La lecture n'est donc pas de complaisance envers moi.

**Deuxieme manque de regle enregistre ce cycle**, apres celui de #8903 (un port sequence de N grains ou le grain N produit l'artefact que le grain N+1 consomme genere N same-genre *par construction*). Les deux partent dans une seule PR harnais — `.claude/rules/` demande une PR + sign-off user, je ne le modifie pas unilateralement.

G-VAR-1 : ce n'est pas le plat principal du cycle (les merges G1/G2/G3 du port #1206 et l'elargissement de #8901 le sont). G-VAR-2 : premiere LIGHT de la journee sur cette lane — #8897 datait du 29.

See #8896
