### PR TITLE
ci(#8915): make failing gates emit their diagnostic (lean tail truncation + navlink --quiet)

### DIFF
--- a/.github/workflows/lean-axiom.yml
+++ b/.github/workflows/lean-axiom.yml
@@ -88,9 +88,19 @@ jobs:
     - name: Lake build
       working-directory: ${{ inputs.project-path }}
       run: |
-        set -o pipefail
+        set -o pipefail   # propagate lake's exit code through the pipeline (FAILED must
+                          # exit != 0; See incident conway_lean HashlifeCorrectness L1058, 2026-06-14).
         lake exe cache get || true
-        lake -R build 2>&1 | tail -10
+        # On failure, surface the error lines the `tail` window loses (See #8915).
+        if lake -R build 2>&1 | tee "$RUNNER_TEMP/lake.log" | tail -10; then
+          :
+        else
+          rc=$?
+          echo "::group::Error lines from the full lake log (See #8915)"
+          grep -nE "^error:|\.lean:[0-9]+:[0-9]+: (error|warning)" "$RUNNER_TEMP/lake.log" | head -100 || true
+          echo "::endgroup::"
+          exit "$rc"
+        fi
 
     - name: Setup Python
       uses: actions/setup-python@v5

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -182,9 +182,23 @@ jobs:
     - name: Lake build
       working-directory: ${{ inputs.project-path }}
       run: |
-        set -o pipefail   # propagate lake's exit code through `| tail` — without this a
+        set -o pipefail   # propagate lake's exit code through the pipeline — without this a
                           # FAILED lake build reports exit 0 (tail always succeeds), and the
                           # CI step passes regardless. See incident conway_lean HashlifeCorrectness
                           # L1058 (rfl fail masked as CI PASS, 2026-06-14).
         lake exe cache get || true
-        lake -R build 2>&1 | tail -20
+        # `tail` keeps the SUCCESS path terse, but on FAILURE it also truncates the
+        # `File.lean:L:C: error:` line — lake builds in parallel and pushes an early
+        # failure ~8000 lines out of the tail window (See #8915). Tee the full log so
+        # the error lines can be surfaced in a ::group:: on failure. `if cmd;` exempts
+        # the pipeline from errexit, but pipefail still feeds `$?` here — this is what
+        # preserves the 2026-06-14 invariant (FAILED build still exits != 0).
+        if lake -R build 2>&1 | tee "$RUNNER_TEMP/lake.log" | tail -20; then
+          :
+        else
+          rc=$?
+          echo "::group::Error lines from the full lake log (See #8915)"
+          grep -nE "^error:|\.lean:[0-9]+:[0-9]+: (error|warning)" "$RUNNER_TEMP/lake.log" | head -100 || true
+          echo "::endgroup::"
+          exit "$rc"
+        fi

--- a/.github/workflows/notebook-navlink-check.yml
+++ b/.github/workflows/notebook-navlink-check.yml
@@ -1,8 +1,10 @@
 name: Notebook Navlink Check
 
 # CI gate for broken relative navlinks INSIDE .ipynb markdown cells.
-# Mirrors docs-link-check.yml (same --check --quiet convention), but for the
-# notebook navlink checker (check_notebook_navlinks.py, PR #6813). Enforces the
+# Like docs-link-check.yml: deliberately NO --quiet, so on failure each broken
+# navlink is printed (source:line -> target) and the CI log is self-diagnosing;
+# on success the output is a single summary line, so verbosity costs nothing.
+# --quiet stays available for local/pre-commit use. Checker: check_notebook_navlinks.py (PR #6813). Enforces the
 # EPIC #5081 renumbering hygiene: any NEW broken navlink 404 introduced by a PR
 # fails the gate (exit 1). Pre-existing broken are tracked in the baseline
 # (scripts/tests/baseline_nb_navlinks.json) and do not block.
@@ -25,4 +27,4 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check notebook navlinks
-        run: python scripts/notebook_tools/check_notebook_navlinks.py --check --quiet
+        run: python scripts/notebook_tools/check_notebook_navlinks.py --check


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA

> Note: #8915 suggested lane `myia-po-2026:CoursIA` (they paid the defect on the Lean case). po-2026 had not claimed it (mid-flight on the #8904 quantbook burn-down + #8868). po-203 is build-proven (conway_lean 460-job build) and available, so I took it — transparent ack of the lane suggestion.

## Summary

Three CI gates failed with `exit 1` but emitted **no diagnostic**, forcing local reproduction to learn *what* broke. One subject: *a gate that fails should say why*. Three sites, one invariant to preserve.

### Site 1 — navlinks (cheapest, most documented)
`notebook-navlink-check.yml` passed `--quiet`, but the checker only prints each broken navlink (`source:line -> target`) when **not** quiet — confirmed at source `check_notebook_navlinks.py:408-414` (`if new_broken: if not args.quiet: print(...)`). The header also *wrongly claimed* it mirrored `docs-link-check.yml`'s `--quiet` convention; that sibling deliberately omits `--quiet` (its own header L20-22 documents why). Fix: drop `--quiet` + correct the header.

### Sites 2 & 3 — lean-build / lean-axiom (the `tail` truncation)
Lake builds in parallel and continues after a module failure, pushing an early `File.lean:L:C: error:` ~8000 lines out of the `tail -20`/`tail -10` window (proven on run 30502964271, conway_lean: the log named the failing *target* but never the *error line*). Fix: tee the full log to `$RUNNER_TEMP`, keep `tail` for nominal terseness, and on failure surface the error lines in a `::group::`.

## The 2026-06-14 invariant — proven, not assumed

The original `set -o pipefail` + `| tail` exists because without it a FAILED build reports exit 0 (tail always succeeds) — incident conway_lean HashlifeCorrectness L1058. The new `if pipeline; then :; else rc=$?; ...; exit "$rc"; fi` form must preserve this.

`if cmd;` exempts the pipeline from errexit, but pipefail still feeds `$?` — **proven empirically** with the exact pattern (a failing lake-shaped pipeline returning 1):

```
CASE A2 (FAILED): STEP-EXIT=1 ✓ (invariant preserved)
  ::group::Error lines from the full lake log (See #8915)
  1:error: Conway/Life/Broken.lean:42:18: unknown identifier 'nonexistent'   ← buried at line 2/8004, invisible to tail -20
  102:error: build failed
  ::endgroup::
CASE B (SUCCESS): exit 0, terse tail output, no ::group:: ✓
```

## Acceptance criteria (all met)
- [x] Lean build failure shows `File.lean:L:C: error:` in the CI log (no local intervention) — CASE A2.
- [x] **Invariant 2026-06-14**: FAILED build still exits != 0 — CASE A2, STEP-EXIT=1.
- [x] Navlink failure lists `source:line -> target` per broken link — source L408-414 (`not args.quiet`).
- [x] Nominal path (success) stays terse — CASE B.
- [x] Header of `notebook-navlink-check.yml` describes what the file actually does.

## Verification
- YAML syntax validated (3/3 parse OK).
- pipefail/if/exit semantics proven by real execution (not reasoning) — the exact pattern with a failing pipeline.
- Catalogue byte-identical; markdown/yaml only, no notebook cells, H.3 n/a.

See #8915