### PR TITLE
fix(ci,#8915): make lake + navlink gates self-diagnosing (tee+grep on failure, drop --quiet)

### DIFF
--- a/.github/workflows/lean-axiom.yml
+++ b/.github/workflows/lean-axiom.yml
@@ -88,9 +88,20 @@ jobs:
     - name: Lake build
       working-directory: ${{ inputs.project-path }}
       run: |
+        # Same self-diagnosing pipeline as lean-build.yml (defect #8915): tee the
+        # full log and surface error lines on failure so the gate says *what* broke.
+        # 2026-06-14 invariant preserved via pipefail + `if; then :; else exit $rc`.
         set -o pipefail
         lake exe cache get || true
-        lake -R build 2>&1 | tail -10
+        if lake -R build 2>&1 | tee "$RUNNER_TEMP/lake.log" | tail -10; then
+          :
+        else
+          rc=$?
+          echo "::group::Lake error lines (from full log)"
+          grep -nE "^error:|\.lean:[0-9]+:[0-9]+: (error|warning)" "$RUNNER_TEMP/lake.log" | head -100 || true
+          echo "::endgroup::"
+          exit "$rc"
+        fi
 
     - name: Setup Python
       uses: actions/setup-python@v5

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -182,9 +182,27 @@ jobs:
     - name: Lake build
       working-directory: ${{ inputs.project-path }}
       run: |
-        set -o pipefail   # propagate lake's exit code through `| tail` — without this a
-                          # FAILED lake build reports exit 0 (tail always succeeds), and the
-                          # CI step passes regardless. See incident conway_lean HashlifeCorrectness
-                          # L1058 (rfl fail masked as CI PASS, 2026-06-14).
+        # Keep the short `tail` summary on the nominal path, but tee the FULL log
+        # and surface its error lines on failure. Without this, lake's parallel
+        # build continues after a module failure, burying the `File.lean:L:C: error:`
+        # line under thousands of progress lines so `tail -20` shows only
+        # "Some required targets logged failures: / error: build failed" — a gate
+        # that fails silently, forcing local reproduction to learn *what* broke
+        # (cf conway_lean run 30502964271, 8545 targets, defect #8915).
+        #
+        # The 2026-06-14 invariant (a FAILED build MUST fail the step) is preserved:
+        # `set -o pipefail` makes the pipeline return lake's non-zero exit, and
+        # `if pipeline; then :; else exit $rc; fi` re-emits it (the `$?` in the else
+        # branch is the condition's exit — no intervening command). Proven locally
+        # against a mock burying scenario + real lake: see #8915 verification.
+        set -o pipefail
         lake exe cache get || true
-        lake -R build 2>&1 | tail -20
+        if lake -R build 2>&1 | tee "$RUNNER_TEMP/lake.log" | tail -20; then
+          :
+        else
+          rc=$?
+          echo "::group::Lake error lines (from full log)"
+          grep -nE "^error:|\.lean:[0-9]+:[0-9]+: (error|warning)" "$RUNNER_TEMP/lake.log" | head -100 || true
+          echo "::endgroup::"
+          exit "$rc"
+        fi

--- a/.github/workflows/notebook-navlink-check.yml
+++ b/.github/workflows/notebook-navlink-check.yml
@@ -1,10 +1,13 @@
 name: Notebook Navlink Check
 
 # CI gate for broken relative navlinks INSIDE .ipynb markdown cells.
-# Mirrors docs-link-check.yml (same --check --quiet convention), but for the
-# notebook navlink checker (check_notebook_navlinks.py, PR #6813). Enforces the
-# EPIC #5081 renumbering hygiene: any NEW broken navlink 404 introduced by a PR
-# fails the gate (exit 1). Pre-existing broken are tracked in the baseline
+# Runs WITHOUT --quiet (mirrors docs-link-check.yml:20-22): on failure, the
+# checker prints each new broken navlink (source:line -> target) so the CI log
+# is self-diagnosing. On success the output is a single summary line, so
+# verbosity costs nothing. --quiet stays available for local/pre-commit use.
+# (check_notebook_navlinks.py, PR #6813). Enforces the EPIC #5081 renumbering
+# hygiene: any NEW broken navlink 404 introduced by a PR fails the gate (exit 1).
+# Pre-existing broken are tracked in the baseline
 # (scripts/tests/baseline_nb_navlinks.json) and do not block.
 #
 # The checker is stdlib-only (no deps) and handles un-checked-out submodules
@@ -25,4 +28,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check notebook navlinks
-        run: python scripts/notebook_tools/check_notebook_navlinks.py --check --quiet
+        # No --quiet: on failure, print each new broken navlink (source:line -> target)
+        # so the CI log is self-diagnosing. See header comment + docs-link-check.yml.
+        run: python scripts/notebook_tools/check_notebook_navlinks.py --check


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA — prev: MED/qc (#8916)

## Summary

**One principle, three sites: a gate that fails must say *why*.** Today three CI gates fail with `exit 1` and no diagnostic — the first reader must reproduce locally to learn what broke. This is the defect I paid on #8895 (I had to DM ai-01 to run `lake build Conway.Life.GridCanonical` on a hot machine to get *one line* the CI had produced then thrown away). #8915 formalized it + found the mechanism (truncation, not stderr).

| Site | Before | After |
|---|---|---|
| `lean-build.yml:190` | `lake -R build 2>&1 \| tail -20` | tee full log → `tail -20` nominal; on failure, `grep` error lines + `exit $rc` |
| `lean-axiom.yml:93` | `lake -R build 2>&1 \| tail -10` | same self-diagnosing pipeline |
| `notebook-navlink-check.yml:28` | `... --check --quiet` (no output) | `--check` only (mirrors `docs-link-check.yml:20-22`); header fixed |

Lake builds in parallel and **continues after a module failure**, so an early `File.lean:L:C: error:` gets pushed ~8000 lines up, out of any `tail` window — the gate names the **target** (`Some required targets logged failures: - Conway.Life.GridCanonical`) but never the **error**. The fix tees the full log and greps the error lines into a `::group::` block **only on failure**; the nominal path keeps the short `tail` summary (no added noise).

## The 2026-06-14 invariant is preserved (proven, not assumed)

The `| tail` exists for a reason: `set -o pipefail` was added because without it `tail` returns 0 and a FAILED build masked as CI PASS (incident HashlifeCorrectness L1058). The new pipeline keeps that guarantee:

```bash
set -o pipefail
if lake -R build 2>&1 | tee "$RUNNER_TEMP/lake.log" | tail -20; then :
else
  rc=$?                                      # $? = the condition's exit (no intervening cmd)
  grep -nE "^error:|\.lean:[0-9]+:[0-9]+: (error|warning)" "$RUNNER_TEMP/lake.log" | head -100 || true
  exit "$rc"                                 # re-emit lake's non-zero -> step still FAILS
fi
```

`pipefail` makes the pipeline return lake's non-zero exit; the `else`-branch `$?` captures it (the `:` is in the untaken `then`-branch). **Proven by execution, two ways** (acceptance criterion: "ne pas se contenter du raisonnement sur pipefail"):

1. **Mock burying scenario** (`pipefail_proof.sh`): a mock lake emits an error on line 1, then 8000 progress lines, then `error: build failed`, exit 1.
   - *Current pipeline*: exit=1 (pipefail propagates ✓) — but the `error:` line is ~8000 lines above the `tail -20` window → **diagnostic LOST** (the defect reproduced).
   - *Proposed pipeline*: `grep` recovers `1:...GridCanonical.lean:42:11: error: unknown identifier 'foo'` + `8004:error: build failed`, exit=1 → **error recovered + step fails ✓**.
   - *Nominal path*: success → output stays `tail -20` only, no added noise ✓.
2. **Real lake** (minimal throwaway project, broken module): lake emits `error: ...lakefile.lean:L:C: ...` — the `grep` regex `\.lean:[0-9]+:[0-9]+: (error|warning)` **matches lake's actual format** (recovered at log line 1), exit=1 propagates. (The local rc1 toolchain is incomplete per `MEMORY.md` c.449, so the throwaway hit a lakefile-parse error rather than reaching my intended module — but that still validates the regex against real lake output + the exit propagation; the burying scenario is what the mock covers.)

## Acceptance criteria

- [x] A failed Lean build surfaces the `File.lean:L:C: error:` line in the CI log (grep recovery, proven on mock + real lake).
- [x] **Non-regression of the 2026-06-14 invariant**: a FAILED build still fails the step (exit != 0) — proven by execution (mock exit=1, real lake exit=1).
- [x] A failed navlink lists `source:line -> target` per broken link (drops `--quiet`; checker already prints these without `--quiet`, per `docs-link-check.yml` rationale).
- [x] Nominal (success) path gains no noise — proven (mock nominal path = `tail` summary only).
- [x] `notebook-navlink-check.yml` header describes what the file actually does (fixed L4-7 + L31 — no longer claims the reversed `--quiet` convention).

## Verification

- **YAML valid** for all 3 files (`yaml.safe_load` → `jobs` parsed).
- **navlink `run:` line** confirmed `--check` only (the 3 remaining "quiet" strings are explanatory comments).
- **Both lakes** carry the `tee "$RUNNER_TEMP/lake.log"` + `grep` + `exit $rc` pipeline.

## Base / method

Fresh base `87da50c76f`. Local `git fetch` broken (`invalid index-pack`, C: 99% full) → delivered via GitHub contents/git-refs API relay (byte-content PUT; cf #8908/#8916).

Closes #8915.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
