### PR TITLE
feat(ict,#7740): embodied pregnance/valence animat + dissociation matrix (PR-A, C1)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
@@ -88,6 +88,7 @@ from . import reversibility_budget
 from . import argumentation
 from . import inhibited_action
 from . import learned_valence
+from . import pregnance_animat
 from . import cech_obstruction
 from . import signaling_convention
 from . import symbol_invention
@@ -109,6 +110,7 @@ __all__ = [
     "argumentation",
     "inhibited_action",
     "learned_valence",
+    "pregnance_animat",
     "cech_obstruction",
     "signaling_convention",
     "symbol_invention",

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/pregnance_animat.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/pregnance_animat.py
@@ -1,0 +1,808 @@
+"""Animat a PREGNANCE et VALENCE incarnees — la dissociation p_hat / pi (#7740, C1).
+
+Contexte
+--------
+``valence`` (ICT-12) met la valence dans un champ spatial fixe ; ``learned_valence``
+(#8823 / ICT-12b) montre qu'une valence peut etre **apprise** (Rescorla-Wagner),
+**transferable** (un signal neutre devient attractif) et **distincte** de la
+prediction ``p_hat`` — mais sur des bancs **desincarnes** (pas d'environnement,
+pas de corps, pas d'action ; un signal est un index abstrait). La question
+#7740 (framings 2026-07-20, jambe C1) est le pas suivant : que devient cette
+« experience manquante » des qu'on l'**incarne** dans un animat qui se deplace,
+a un etat interne (faim), et choisit ses actions ?
+
+Ce module pose cet animat. Il reutilise les fondations sans les modifier :
+``ict.valence`` (cinematiques de source, modele interne ``p_hat`` et ses
+baselines adverses), ``ict.learned_valence.LearnedValence`` (valence apprise),
+``ict.inhibited_action.action_entropy`` (mesure de rigidification de politique).
+
+La porte scientifique (ce qui clot #7740)
+-----------------------------------------
+Pas un printout par mesure : une **matrice de dissociation**. Six grandeurs
+peuvent bouger ensemble sans rien prouver. Le levier est la cinematique
+``erratique`` : les renversements de vitesse aleatoires detruisent l'estimation
+EMA de vitesse, donc ``p_hat`` (qui extrapole la vitesse) rate completement
+(mesure 1 : erreur d'anticipation explosée) — MAIS le conditionnement
+Rescorla-Wagner ne depend QUE de la co-occurrence, pas de la previsibilite :
+la valence ``pi`` se transfere quand meme (mesure 2), s'eteint sous suppression
+(mesure 6) et mobilise l'action (mesure 3). On obtient ainsi un regime
+**p_hat FAIBLE / valence HAUTE**, dissocié d'un regime **p_hat FORT / valence
+HAUTE** (balistique) ou **p_hat FORT / valence NON-APPRISE** (pas de source).
+La dissociation seule valide que valence et prediction sont deux grandeurs
+distinctes — six mesures corelees ne le prouvent pas.
+
+Portee de ce module (cycle-1 d'un livrable multi-cycle)
+-------------------------------------------------------
+ADDITIF : ne modifie ni ``ict.valence`` ni ``ict.learned_valence``. Couvre les
+mesures 1 (p_hat incarné + baselines), 2 (transfert incarné, approche), 3
+(choix d'action + entropie) et 6 (reversibilite comportementale) + leurs
+controles negatifs + la matrice de dissociation. Les mesures 4 (divergence
+energie-libre adaptive vs MSE) et 5 (information predictive, discretisation)
+sont de niveau recherche et **deferees** a un PR-suivi : les accomplir honnetement
+demanderait un estimateur FE adaptatif calibre et un binning d'information
+mutuelle qui n'existent pas encore dans la couche (``free_energy`` mode fixed
+est un habillage du MSE — piege	signalé ; ``signaling_convention`` n'a que la
+primitive ``mutual_information``). numpy seul, CPU.
+
+References
+----------
+Thom 1972 (pregnance / effet figuratif, *Stabilité structurelle*) ; Rescorla &
+Wagner 1972 (erreur de prediction comme moteur associatif) ; Friston (agentivite
+morphologique, strate 4 ICT) ; spec #7740 (animat, etat interne, policy
+f(p_hat, pi, etat_interne), matrice de dissociation).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from .valence import (
+    predict_source,
+    anticipation_error_2d,
+    phat_predicted_trajectory,
+    persistence_trajectory_2d,
+    moving_average_trajectory_2d,
+    ar1_trajectory_2d,
+    source_trajectory,
+)
+from .learned_valence import LearnedValence
+from .inhibited_action import action_entropy
+
+
+# --------------------------------------------------------------------------- #
+#  Environnement : objets en mouvement (source pertinente ou signal neutre)     #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class ObjectSpec:
+    """Un objet de l'environnement, porteur d'une cinematique et d'une valence.
+
+    ``intrinsic_valence`` > 0 : source biologiquement pertinente (nourriture) ;
+    sa capture satie la faim et renforce la valence des signaux co-occurents.
+    ``intrinsic_valence`` == 0 : signal neutre — ni nuisible ni nourricier tant
+    qu'il n'est pas associe a une source. C'est sur un signal neutre que le
+    TRANSFERT se mesure : neutre avant apprentissage, attractif apres.
+    """
+
+    idx: int
+    kind: str              # cinematique : statique | balistique | erratique | bruite
+    intrinsic_valence: float = 0.0
+    speed: float = 0.8
+    noise: float = 0.25
+    reversal_p: float = 0.18
+
+
+def build_object_trajectories(
+    objects: List[ObjectSpec],
+    n_steps: int,
+    size: int,
+    rng: np.random.Generator,
+    start_offsets: Optional[Dict[int, np.ndarray]] = None,
+) -> np.ndarray:
+    """Renvoie les trajectoires ``(n_objects, n_steps, 2)`` de chaque objet.
+
+    Chaque objet suit sa propre cinematique (``ict.valence.source_trajectory``)
+    depuis un point de depart decale pour eviter la superposition initiale.
+    """
+    trajs = np.empty((len(objects), n_steps, 2), dtype=float)
+    center = np.array([size / 2.0, size / 2.0])
+    for k, obj in enumerate(objects):
+        start = center.copy()
+        if start_offsets and obj.idx in start_offsets:
+            start = np.asarray(start_offsets[obj.idx], dtype=float).copy()
+        else:
+            # decalage deterministe pour separer les objets a l'init
+            angle = 2.0 * np.pi * obj.idx / max(1, len(objects))
+            start = center + 0.3 * size * np.array([np.cos(angle), np.sin(angle)])
+        trajs[k] = source_trajectory(
+            obj.kind, n_steps, size, rng=rng,
+            speed=obj.speed, noise=obj.noise, reversal_p=obj.reversal_p, start=start,
+        )
+    return trajs
+
+
+# --------------------------------------------------------------------------- #
+#  Animat : corps, faim, modele p_hat, valence apprise, politique               #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class AnimatConfig:
+    """Hyperparametres de l'animat. Defaults calibres pour des verdicts nets.
+
+    La politique note chaque objet ``i`` par :
+    ``score_i = w_valence * pi_i * hunger + w_phat * feasibility_i + exploration * noise``.
+    ``hunger`` monte avec le temps (poussée d'approche) et tombe a la capture
+    d'une source (satiation). ``feasibility_i`` mesure si l'interception par
+    ``p_hat`` est credible (basse si la vitesse estimee explose — regime erratique).
+    """
+
+    size: int = 32
+    lr: float = 0.12              # Rescorla-Wagner
+    hunger_rate: float = 0.015    # croissance de la faim par pas
+    satiation: float = 0.35      # chute de faim a la capture d'une source
+    w_valence: float = 1.0
+    w_phat: float = 0.6
+    exploration: float = 0.05
+    lead: int = 4
+    alpha: float = 0.25
+    step: float = 0.9
+    capture_radius: float = 1.6
+    sense_radius: float = 5.0    # rayon de co-occurrence : source visible => renforcement
+
+
+class PregnanceAnimat:
+    """Animat incarne : p_hat + valence apprise + etat interne (faim).
+
+    L'animat observe les positions des objets a chaque pas, entretient un
+    modele predictif ``p_hat`` (extrapolation EMA-vitesse, herite de
+    :func:`ict.valence.predict_source`) ET une valence apprise ``pi``
+    (:class:`ict.learned_valence.LearnedValence`), combinees par une politique
+    pilotée par la faim. Le tout est spatialement incarne : l'animat se deplace,
+    capture, satie.
+
+    Le choix d'action est DISCRET (index de l'objet cible, ou ``n_objects`` pour
+    l'exploration) — c'est ce flux d'actions qu'on passe a
+    :func:`ict.inhibited_action.action_entropy` (mesure 3).
+    """
+
+    def __init__(
+        self,
+        n_objects: int,
+        config: Optional[AnimatConfig] = None,
+        rng: Optional[np.random.Generator] = None,
+    ) -> None:
+        self.cfg = config if config is not None else AnimatConfig()
+        self.n_objects = n_objects
+        self.rng = rng if rng is not None else np.random.default_rng()
+        self.lv = LearnedValence(n_signals=n_objects, lr=self.cfg.lr, rng=self.rng)
+        self.pos = np.array([2.0, 2.0])
+        self.hunger = 0.0
+        # historique observe par objet (pour le modele p_hat)
+        self._hist: List[np.ndarray] = [[] for _ in range(n_objects)]
+        # journal des actions discretes (mesure 3) et des captures
+        self.actions: List[int] = []
+        self.captures: List[Tuple[int, int, float]] = []  # (t, obj_idx, valence_delivered)
+        # valences intrinseques (sources) et journal des positions (mesures d'approche)
+        self._intrinsics: Dict[int, float] = {}
+        self._pos_trace: List[np.ndarray] = []
+
+    def reset(self, start: Optional[np.ndarray] = None) -> None:
+        self.pos = np.asarray(start, dtype=float).copy() if start is not None \
+            else np.array([2.0, 2.0])
+        self.hunger = 0.0
+        self.lv = LearnedValence(n_signals=self.n_objects, lr=self.cfg.lr, rng=self.rng)
+        self._hist = [[] for _ in range(self.n_objects)]
+        self.actions = []
+        self.captures = []
+
+    # -- p_hat : prediction de position future par objet ----------------------
+
+    def _predict_each(self, t: int) -> np.ndarray:
+        """Position future predite (lead) pour chaque objet, ``(n_objects, 2)``.
+
+        Reutilise :func:`ict.valence.predict_source` sur l'historique observe
+        (causal : ne voit que le passe). Si l'historique est trop court,
+        renvoie la derniere position observee (aucune extrapolation possible).
+        """
+        out = np.zeros((self.n_objects, 2), dtype=float)
+        for i in range(self.n_objects):
+            hist = np.asarray(self._hist[i], dtype=float)
+            if len(hist) <= 1:
+                out[i] = hist[-1] if len(hist) else np.zeros(2)
+            else:
+                out[i] = predict_source(hist, t=min(t, len(hist) - 1),
+                                        lead=self.cfg.lead, alpha=self.cfg.alpha)
+        return out
+
+    def _feasibility(self, phat_future: np.ndarray) -> np.ndarray:
+        """Credibilite de l'interception ``p_hat`` par objet, dans [0, 1].
+
+        Mesure combien la vitesse estimee est « tenable » : si l'extrapolation
+        ``p_hat`` projette loin de la position courante observee, la vitesse EMA
+        est vraisemblablement instable (regime erratique) et l'interception est
+        peu credible. Bornee et lisse pour rester une note de politique, pas un
+        verdict (le verdict est la mesure 1 sur erreur d'anticipation).
+        """
+        cur = np.array([self._hist[i][-1] if self._hist[i] else np.zeros(2)
+                        for i in range(self.n_objects)])
+        excess = np.linalg.norm(phat_future - cur, axis=1) - float(self.cfg.lead * self.cfg.step)
+        # au-dela du lead nominal, la credibilite decroit (sigmoide inverse).
+        return 1.0 / (1.0 + np.clip(excess, 0.0, None) ** 1.5)
+
+    # -- politique -----------------------------------------------------------
+
+    def _choose_target(self, phat_future: np.ndarray, feasibility: np.ndarray) -> int:
+        """Choisit l'objet cible (ou ``n_objects`` = exploration).
+
+        Seule la **valence** (apprise ``pi`` + innee ``intrinsic``) pese sur le
+        CHOIX de cibler — pondere par la faim. ``feasibility`` ne decide PAS si
+        on cible (sinon un objet predictible mais sans valeur serait poursuivi) ;
+        elle ne module que le COMMENT (interception vs reactive, cf.
+        :meth:`_aim_point`). C'est ce qui rend la mesure d'entropie (3) nette :
+        un animat sans aucune valence investie explore (action = ``n_objects``),
+        quel que soit le regime cinematique.
+
+        ``drive_i = w_valence * (pi_i + intrinsic_i) * hunger``. Si ``max(drive)``
+        est nul (rien de valorise), l'animat explore.
+        """
+        pi = self.lv.valence_vector()
+        intr = np.array([self._intrinsic(i) for i in range(self.n_objects)])
+        salience = pi + intr
+        drive = self.cfg.w_valence * salience * self.hunger
+        if float(np.max(drive)) < 1e-6:
+            return self.n_objects  # rien valorise -> exploration
+        noise = self.rng.standard_normal(self.n_objects)
+        score = drive + self.cfg.exploration * noise
+        return int(np.argmax(score))
+
+    def _aim_point(self, target: int, phat_future: np.ndarray, obs: np.ndarray,
+                   feasibility: np.ndarray) -> np.ndarray:
+        """Point vise : interception ``p_hat`` SI la valence est investie ET
+        ``p_hat`` credible (feasibility haute), sinon position courante (reactive).
+
+        Couplage incarné : la valence ``pi`` decide SI on poursuit ; ``feasibility``
+        decide SI on intercepte ou si l'on vise la position courante. C'est la
+        source de la dissociation — sur un regime erratique, ``feasibility`` est
+        basse (la vitesse EMA explose) donc l'animat poursuit REACTIVEMENT (la ou
+        la cible EST) : il approche quand meme, sans que ``p_hat`` y ajoute du
+        lead. Valence et ``p_hat`` decorrelent : l'approche tient sans la
+        prediction.
+        """
+        if target >= self.n_objects:
+            # exploration : pas de cible -> marche aleatoire (direction bruitee)
+            angle = float(self.rng.uniform(0.0, 2.0 * np.pi))
+            return self.pos + np.array([np.cos(angle), np.sin(angle)])
+        pi_target = self.lv.valence(target)
+        if (pi_target > 0.2 and target < phat_future.shape[0]
+                and feasibility[target] > 0.5):
+            return phat_future[target]  # interception credible
+        return obs[target]  # poursuite reactive (la ou la cible est)
+
+    # -- pas de simulation ---------------------------------------------------
+
+    def step(self, observations: np.ndarray, t: int) -> int:
+        """Avance d'un pas. ``observations`` : positions ``(n_objects, 2)`` au temps ``t``.
+
+        Renvoie l'action discrete choisie (index cible, ou ``n_objects``).
+        Met a jour : historique observe, faim, valence (conditionnement/extinction
+        selon co-occurrence avec une source), position, journal d'actions/captures.
+        """
+        obs = np.asarray(observations, dtype=float)
+        for i in range(self.n_objects):
+            self._hist[i].append(obs[i].copy())
+
+        phat_future = self._predict_each(t)
+        feasibility = self._feasibility(phat_future)
+        target = self._choose_target(phat_future, feasibility)
+        aim = self._aim_point(target, phat_future, obs, feasibility)
+
+        # deplacement
+        move = aim - self.pos
+        nm = float(np.linalg.norm(move))
+        if nm > 1e-9:
+            self.pos = self.pos + self.cfg.step * (move / nm)
+        self.pos = np.clip(self.pos, 0.0, float(self.cfg.size - 1))
+
+        # croissance de la faim (poussee d'approche)
+        self.hunger = float(np.clip(self.hunger + self.cfg.hunger_rate, 0.0, 1.0))
+
+        # conditionnement / extinction : CO-OCCURRENCE Pavlovienne.
+        # Un signal neutre SENSE en presence d'une source SENSE s'associe
+        # (acquisition Rescorla-Wagner) ; un signal neutre capture SANS source
+        # s'eteint. La co-occurrence est environnementale (Pavlov), pas
+        # attentionnelle : tout signal present avec la source est conditionne.
+        dists = np.linalg.norm(obs - self.pos, axis=1)
+        sensed = dists <= self.cfg.sense_radius
+        # valence de la source la plus forte presentement sensee.
+        src_val = 0.0
+        for i in range(self.n_objects):
+            if sensed[i] and self._intrinsic(i) > src_val:
+                src_val = self._intrinsic(i)
+        # satiation si une source est capturee ce pas.
+        for i in range(self.n_objects):
+            if dists[i] <= self.cfg.capture_radius and self._intrinsic(i) > 0:
+                self.hunger = float(np.clip(self.hunger - self.cfg.satiation, 0.0, 1.0))
+                self.captures.append((t, i, self._intrinsic(i)))
+                break
+        # Rescorla-Wagner sur chaque signal neutre sense.
+        for i in range(self.n_objects):
+            if self._intrinsic(i) > 0:
+                continue  # les sources ont une valence inne fixe, non apprise.
+            if not sensed[i]:
+                continue
+            if dists[i] <= self.cfg.capture_radius:
+                # capture du signal neutre : source co-presente => acquisition,
+                # sinon extinction (presente seul).
+                self.lv.condition(i, source_valence=src_val, steps=1)
+            elif src_val > 0.0:
+                # neutre sense en co-occurrence avec source => acquisition douce.
+                self.lv.condition(i, source_valence=src_val, steps=1)
+
+        self.actions.append(target)
+        return target
+
+    def set_intrinsic_valences(self, mapping: Dict[int, float]) -> None:
+        """Associe les valences intrinseques (sources) aux indices d'objets."""
+        self._intrinsics = {int(k): float(v) for k, v in mapping.items()}
+
+    def _intrinsic(self, obj_idx: int) -> float:
+        return float(self._intrinsics.get(int(obj_idx), 0.0))
+
+    # -- sorties pour les mesures -------------------------------------------
+
+    def approach_fraction(self, obj_idx: int, obj_traj: np.ndarray,
+                          window: Optional[Tuple[int, int]] = None) -> float:
+        """Fraction des pas ou l'animat approche (distance <= capture_radius)
+        l'objet ``obj_idx``, sur la fenetre ``window``. Mesure de transfert
+        comportemental (mesure 2) et de reversibilite (mesure 6)."""
+        tr = self._position_trace()
+        src = np.asarray(obj_traj, dtype=float)
+        lo, hi = window if window is not None else (0, len(tr))
+        seg = tr[lo:hi]
+        d = np.linalg.norm(seg - src[lo:hi], axis=1)
+        return float(np.mean(d <= self.cfg.capture_radius))
+
+    def _position_trace(self) -> np.ndarray:
+        """Journal des positions de l'animat (rempli pas-a-pas par ``_run_episode``).
+
+        Necessaire aux mesures d'approche (2 et 6) : on compare la trajectoire
+        de l'animat a celle de l'objet cible."""
+        return np.asarray(self._pos_trace)
+
+
+def _run_episode(
+    animat: PregnanceAnimat,
+    trajectories: np.ndarray,
+    start: Optional[np.ndarray] = None,
+) -> None:
+    """Execute un episode complet : l'animat parcourt les ``n_steps``.
+
+    Reset **motion only** : repositionne l'animat et vide historique/journaux,
+    mais PRESERVE la valence apprise (``lv.pi``) et la faim. C'est crucial pour
+    les bancs : un animat de test herite de l'etat acquis (pi, hunger) d'un
+    animat conditionne, puis execute un episode de mesure. Un reset complet
+    effacerait l'apprentissage (bug C1006-L : reset reconstruisait ``lv``).
+    """
+    animat.pos = (np.asarray(start, dtype=float).copy() if start is not None
+                  else np.array([2.0, 2.0]))
+    animat._hist = [[] for _ in range(animat.n_objects)]
+    animat.actions = []
+    animat.captures = []
+    animat._pos_trace = []
+    n_objects, n_steps, _ = trajectories.shape
+    for t in range(n_steps):
+        animat.step(trajectories[:, t, :], t)
+        animat._pos_trace.append(animat.pos.copy())
+
+
+# --------------------------------------------------------------------------- #
+#  Mesure 1 — p_hat incarne : erreur d'anticipation vs baselines adverses       #
+# --------------------------------------------------------------------------- #
+
+
+def prediction_accuracy_test(
+    kind: str,
+    size: int = 32,
+    n_steps: int = 200,
+    lead: int = 4,
+    alpha: float = 0.25,
+    seed: int = 0,
+) -> Dict[str, float]:
+    """Erreur d'anticipation 2D de ``p_hat`` vs 3 baselines adverses, par regime.
+
+    Reutilise :func:`ict.valence.anticipation_error_2d` (MSE 2D a l'horizon
+    ``lead``) et les baselines persistance / moyenne-mobile / AR(1) du Cran A.
+    ``p_hat`` (EMA-vitesse) doit GAGNER sur ``balistique`` (vitesse constante)
+    et PERDRE visiblement sur ``erratique`` (renversements aleatoires : la EMA
+    sur-reagit). C'est le levier de la dissociation : ``p_hat`` est fragile la
+    ou le conditionnement ne l'est pas.
+
+    Verdict falsifiable
+    -------------------
+    ``phat_wins_ballistic`` : erreur ``p_hat`` < persistance sur balistique.
+    ``phat_loses_erratic`` : erreur ``p_hat`` > persistance sur erratique
+    (le modele interne est trompe par les demi-tours).
+    """
+    rng = np.random.default_rng(seed)
+    src = source_trajectory(kind, n_steps, size, rng=rng)
+    err_phat = anticipation_error_2d(phat_predicted_trajectory(src, lead, alpha), src, lead)
+    err_pers = anticipation_error_2d(persistence_trajectory_2d(src), src, lead)
+    err_ma = anticipation_error_2d(moving_average_trajectory_2d(src), src, lead)
+    err_ar1 = anticipation_error_2d(ar1_trajectory_2d(src, lead), src, lead)
+    return {
+        "kind_ballistic": 1.0 if kind == "balistique" else 0.0,
+        "kind_erratic": 1.0 if kind == "erratique" else 0.0,
+        "kind_static": 1.0 if kind == "statique" else 0.0,
+        "err_phat": float(err_phat),
+        "err_persistence": float(err_pers),
+        "err_moving_average": float(err_ma),
+        "err_ar1": float(err_ar1),
+        "phat_beats_persistence": 1.0 if err_phat < err_pers else 0.0,
+    }
+
+
+def phat_regime_sweep(seed: int = 0, **kw) -> Dict[str, Dict[str, float]]:
+    """Sweep des 4 regimes pour la mesure 1. Cle : regime -> dict d'erreurs.
+
+    C'est la table d'entree de la colonne 1 de la matrice de dissociation :
+    on y lit directement que ``erratique`` fait exploser l'erreur ``p_hat``
+    tandis que ``balistique`` la minimise.
+    """
+    out: Dict[str, Dict[str, float]] = {}
+    for kind in ("statique", "balistique", "erratique", "bruite"):
+        out[kind] = prediction_accuracy_test(kind, seed=seed, **kw)
+    return out
+
+
+def _tethered_trajectories(
+    kind: str,
+    n_steps: int,
+    size: int,
+    rng: np.random.Generator,
+    n_objects: int = 3,
+    neutral_idx: int = 1,
+    control_idx: Optional[int] = 2,
+    offset: np.ndarray = np.array([0.8, 0.6]),
+) -> np.ndarray:
+    """Source + signal neutre TETHERED + controle hors-arene (co-occurrence imposee).
+
+    Le signal neutre suit la source a un petit offset constant : l'experimentateur
+    « presente le signal et la source ensemble » (co-occurrence Pavlovienne
+    controlelee, comme dans :func:`ict.learned_valence.valence_transfer_test` ou
+    les deux sont co-presents par construction). Le controle evolue
+    independamment et est place hors arene (jamais sense => jamais conditionne).
+
+    La source et le neutre partagent la MEME cinematique ``kind`` : c'est ce qui
+    rend la dissociation nette — sur ``erratique``, le ``p_hat`` du neutre explose
+    (mesure 1) MAIS le tethering garantit la co-occurrence, donc le
+    conditionnement tient (mesure 2). Renvoie ``(n_objects, n_steps, 2)`` ; la
+    source est a l'index 0.
+    """
+    src_traj = source_trajectory(kind, n_steps, size, rng=rng)
+    trajs = np.zeros((n_objects, n_steps, 2))
+    trajs[0] = src_traj
+    trajs[neutral_idx] = np.clip(src_traj + offset, 0.0, size - 1)
+    if control_idx is not None and control_idx < n_objects and control_idx != neutral_idx:
+        ctrl = source_trajectory(kind, n_steps, size, rng=rng)
+        # hors arene : jamais sense, jamais conditionne.
+        trajs[control_idx] = ctrl + np.array([size, size])
+    return trajs
+
+
+def _mean_approach(
+    n_objects: int,
+    cfg: AnimatConfig,
+    pi_vector: np.ndarray,
+    neutral_traj: np.ndarray,
+    neutral_idx: int,
+    base_seed: int,
+    hunger: float = 0.85,
+    k: int = 4,
+    start: Optional[np.ndarray] = None,
+) -> float:
+    """Fraction d'approche du neutre, moyennée sur ``k`` réalisations d'exploration.
+
+    La mesure comportementale d'approche est STOCHASTIQUE : un animat sans
+    valence (``pi`` nul) explore en marche aléatoire, et sa proximité au neutre
+    est bruitée (une réalisation peut, par chance, longer le neutre). Moyenner
+    sur ``k`` réalisations (même état ``pi``, trajectoires du neutre identiques,
+    réalisation d'exploration variée) stabilise la métrique — c'est une
+    réduction de bruit Monte-Carlo légitime, pas un ajustement de seuil.
+    L'état ``pi`` (deterministe après conditionnement) n'est pas moyenné.
+    """
+    acc: List[float] = []
+    n_test = neutral_traj.shape[0]
+    test_full = np.full((n_objects, n_test, 2), 1e4)
+    test_full[neutral_idx] = neutral_traj
+    s0 = start if start is not None else np.array([2.0, 2.0])
+    for off in range(k):
+        a = PregnanceAnimat(n_objects=n_objects, config=cfg,
+                            rng=np.random.default_rng(base_seed + off * 97))
+        a.set_intrinsic_valences({})  # source retiree : seul pi herite decide.
+        a.lv.pi = pi_vector.copy()
+        a.hunger = hunger
+        _run_episode(a, test_full, start=s0)
+        acc.append(a.approach_fraction(neutral_idx, neutral_traj))
+    return float(np.mean(acc))
+
+
+# --------------------------------------------------------------------------- #
+#  Mesure 2 — transfert incarne : approche du signal neutre seul               #
+# --------------------------------------------------------------------------- #
+
+
+def embodied_transfer_test(
+    kind: str = "balistique",
+    n_condition: int = 140,
+    n_test: int = 60,
+    size: int = 32,
+    source_valence: float = 1.0,
+    seed: int = 0,
+) -> Dict[str, float]:
+    """Transfert de valence INCARNE : un signal neutre devient-il APPROCHE seul ?
+
+    Protocole (mirant :func:`ict.learned_valence.valence_transfer_test`, mais
+    comportemental) :
+
+    1. **Conditionnement** : une source (valence ``source_valence``) et un signal
+       neutre TETHERED co-occurent (cf. :func:`_tethered_trajectories`).
+       L'animat, pousse par la faim, approche la source (salience inne) ;
+       co-occurrence => acquisition Rescorla-Wagner de la valence du neutre.
+    2. **Test** : le signal neutre SEUL est presente (source retiree, faim
+       elevee). On mesure la fraction de pas ou l'animat l'approche.
+    3. **Controle** : un signal jamais conditionne presente seul identiquement
+       doit rester non-approche (pas de fuite de l'inné vers tout).
+
+    Verdict falsifiable
+    -------------------
+    ``transferred`` : fraction d'approche du conditionne > controle + marge (0.15)
+    ET la valence apprise du neutre a monte (``post_pi > 0.2``). Mesurer le
+    comportement (pas seulement ``pi``) est l'apport de l'incarnation : un
+    signal peut avoir une ``pi`` non-nulle sans declencher d'approche si la faim
+    ou la politique ne s'y engage pas.
+    """
+    rng = np.random.default_rng(seed)
+    cfg = AnimatConfig(size=size)
+    neutral_idx, control_idx, n_objects = 1, 2, 3
+
+    # --- conditionnement : source + neutre tethered + controle hors-arene ---
+    animat = PregnanceAnimat(n_objects=n_objects, config=cfg, rng=rng)
+    animat.set_intrinsic_valences({0: source_valence})
+    cond_trajs = _tethered_trajectories(kind, n_condition, size, rng, n_objects=n_objects,
+                                        neutral_idx=neutral_idx, control_idx=control_idx)
+    _run_episode(animat, cond_trajs, start=np.array([2.0, 2.0]))
+    post_pi = animat.lv.valence(neutral_idx)
+    control_pi = animat.lv.valence(control_idx)
+
+    # --- test : neutre SEUL (source retiree), faim elevee, moyenné sur k réalisations ---
+    # Neutre de test LENT (speed=0.3) et PROCHE de l'animat : l'approche doit etre
+    # mesurable (l'animat step=0.9 le rattrape en quelques pas). La cinematique de
+    # test est tenue IDENTIQUE entre regimes : l'effet regime est porte par la
+    # mesure 1 (p_hat), pas par l'approche — qui mesure la valence.
+    neutral_traj = source_trajectory(kind, n_test, size, rng=rng, speed=0.3,
+                                     start=np.array([4.0, 4.0]))
+    cond_approach = _mean_approach(n_objects, cfg, animat.lv.pi, neutral_traj, neutral_idx,
+                                   base_seed=seed + 7)
+
+    # --- controle : signal non-conditionne (pi nul) SEUL, meme protocole ---
+    zero_pi = np.zeros(n_objects)
+    control_approach = _mean_approach(n_objects, cfg, zero_pi, neutral_traj, neutral_idx,
+                                      base_seed=seed + 7)
+
+    transferred = (cond_approach > control_approach + 0.15) and (post_pi > 0.2)
+    return {
+        "post_valence_neutral": float(post_pi),
+        "control_valence_unconditioned": float(control_pi),
+        "approach_fraction_conditioned": float(cond_approach),
+        "approach_fraction_control": float(control_approach),
+        "approach_gain": float(cond_approach - control_approach),
+        "n_condition": float(n_condition),
+        "transferred": 1.0 if transferred else 0.0,
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  Mesure 3 — choix d'action : entropie (engagement vs rigidification)          #
+# --------------------------------------------------------------------------- #
+
+
+def action_commitment_test(
+    kind: str = "balistique",
+    source_valence: float = 1.0,
+    n_condition: int = 140,
+    n_test: int = 60,
+    size: int = 32,
+    seed: int = 0,
+) -> Dict[str, float]:
+    """Entropie d'action : un animat investi se replie-t-il sur sa cible ?
+
+    Apres conditionnement d'un signal neutre (forte ``pi``) et faim elevee, la
+    politique se concentre sur la cible : la distribution d'actions
+    s'effondre, l'entropie chute. On la compare a l'entropie MAXIMALE
+    ``ln(n_actions)`` (uniforme = exploration pure) : la chute d'entropie est la
+    signature d'un **engagement** morphologique — l'animat cesse d'explorer pour
+    poursuivre (l'envers de l'inhibition, strate 6 ICT, :mod:`ict.inhibited_action`).
+
+    Verdict falsifiable
+    -------------------
+    ``committed`` : ``ln(n_actions) - H_investi`` > marge (0.25) ET la valence du
+    signal conditionne est montee (``post_pi > 0.2``). Un animat dont l'entropie
+    ne chute pas sous investissement n'a pas « investi ». Le contraste est la
+    borne superieure ``ln(n_actions)`` (forme close), pas une deuxieme simulation
+    bruitee — c'est le temoin le plus propre.
+    """
+    rng = np.random.default_rng(seed)
+    cfg = AnimatConfig(size=size)
+    neutral_idx, n_objects = 1, 3
+
+    # --- conditionnement du signal neutre (tethered avec source) ---
+    a_cond = PregnanceAnimat(n_objects=n_objects, config=cfg, rng=rng)
+    a_cond.set_intrinsic_valences({0: source_valence})
+    cond_trajs = _tethered_trajectories(kind, n_condition, size, rng, n_objects=n_objects,
+                                        neutral_idx=neutral_idx, control_idx=2)
+    _run_episode(a_cond, cond_trajs, start=np.array([2.0, 2.0]))
+    post_pi = a_cond.lv.valence(neutral_idx)
+
+    # --- phase test : animat investi (pi herite, faim elevee) ---
+    neutral_traj = source_trajectory(kind, n_test, size, rng=rng)
+    test_full = np.full((n_objects, n_test, 2), 1e4)
+    test_full[neutral_idx] = neutral_traj
+    a_inv = PregnanceAnimat(n_objects=n_objects, config=cfg, rng=np.random.default_rng(seed + 3))
+    # source retiree du test : seul le pi herite (signal conditionne) cible.
+    a_inv.set_intrinsic_valences({})
+    a_inv.lv.pi = a_cond.lv.pi.copy()
+    a_inv.hunger = 0.9
+    _run_episode(a_inv, test_full, start=np.array([2.0, 2.0]))
+    n_actions = n_objects + 1  # n_objects cibles + exploration
+    h_invested = action_entropy(np.asarray(a_inv.actions), n_actions=n_actions)
+    h_uniform = float(np.log(n_actions))
+
+    entropy_drop = h_uniform - h_invested
+    committed = entropy_drop > 0.25 and post_pi > 0.2
+    return {
+        "post_valence_signal": float(post_pi),
+        "action_entropy_invested": float(h_invested),
+        "action_entropy_uniform": float(h_uniform),
+        "entropy_drop": float(entropy_drop),
+        "n_actions": float(n_actions),
+        "committed": 1.0 if committed else 0.0,
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  Mesure 6 — reversibilite comportementale : extinction de l'approche          #
+# --------------------------------------------------------------------------- #
+
+
+def behavioral_reversibility_test(
+    kind: str = "balistique",
+    n_condition: int = 140,
+    n_extinction: int = 220,
+    n_test: int = 60,
+    size: int = 32,
+    source_valence: float = 1.0,
+    seed: int = 0,
+) -> Dict[str, float]:
+    """Reversibilite COMPORTEMENTALE : l'approche acquise s'eteint-elle ?
+
+    Mirant :func:`ict.learned_valence.extinction_test` (qui mesure ``pi``) mais
+    sur le comportement : apres acquisition d'une approche du signal neutre
+    (co-occurrence avec source), on presente le signal SEUL prolongement
+    (extinction). L'approche doit chuter. Mesuree sur une fenetre test POST
+    extinction.
+
+    Verdict falsifiable
+    -------------------
+    ``reversible`` : approach_acquired > approach_extinguished + marge (0.15),
+    ET ``pi`` acquise etait haute puis bassee (``extinguished < acquired*0.5``).
+    Reciproque comportementale de la mesure 2 : ce qui s'apprend (approche) peut
+    se desapprend (reversibilite, fil ICT-18 / fleche du temps).
+    """
+    rng = np.random.default_rng(seed)
+    cfg = AnimatConfig(size=size)
+    neutral_idx, n_objects = 1, 2  # source(0) + signal(1) ; pas de controle ici
+
+    # --- acquisition : source + neutre tethered ---
+    animat = PregnanceAnimat(n_objects=n_objects, config=cfg, rng=rng)
+    animat.set_intrinsic_valences({0: source_valence})
+    cond_trajs = _tethered_trajectories(kind, n_condition, size, rng, n_objects=n_objects,
+                                        neutral_idx=neutral_idx, control_idx=None)
+    _run_episode(animat, cond_trajs, start=np.array([2.0, 2.0]))
+    acquired_pi = animat.lv.valence(neutral_idx)
+
+    # neutre de test LENT et PROCHE (cf. embodied_transfer_test) : mesurable.
+    neutral_traj = source_trajectory(kind, n_test, size, rng=np.random.default_rng(seed + 5),
+                                     speed=0.3, start=np.array([4.0, 4.0]))
+
+    def _approach_when(pi_vector):
+        return _mean_approach(n_objects, cfg, pi_vector, neutral_traj, neutral_idx,
+                              base_seed=seed + 5)
+
+    acquired_approach = _approach_when(animat.lv.pi)
+
+    # --- extinction : signal SEUL prolonge (source retiree) ---
+    # Le neutral se deplace lentement : l'extinction porte sur pi (capture
+    # repetee sans source => Rescorla-Wagner vers 0), pas sur l'approche.
+    ext_neutral = source_trajectory(kind, n_extinction, size, rng=rng, speed=0.3,
+                                    start=np.array([4.0, 4.0]))
+    ext_full = np.full((n_objects, n_extinction, 2), 1e4)
+    ext_full[neutral_idx] = ext_neutral
+    animat.set_intrinsic_valences({})  # source retiree : presentation seule
+    animat.hunger = 0.85
+    _run_episode(animat, ext_full, start=np.array([2.0, 2.0]))
+    extinguished_pi = animat.lv.valence(neutral_idx)
+    extinguished_approach = _approach_when(animat.lv.pi)
+
+    reversible = (acquired_approach > extinguished_approach + 0.15
+                  and acquired_pi > 0.3 and extinguished_pi < acquired_pi * 0.5)
+    return {
+        "acquired_valence": float(acquired_pi),
+        "extinguished_valence": float(extinguished_pi),
+        "approach_fraction_acquired": float(acquired_approach),
+        "approach_fraction_extinguished": float(extinguished_approach),
+        "approach_drop": float(acquired_approach - extinguished_approach),
+        "reversible": 1.0 if reversible else 0.0,
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  La matrice de dissociation — ce qui clot #7740                               #
+# --------------------------------------------------------------------------- #
+
+
+def dissociation_matrix(
+    seed: int = 0,
+    size: int = 32,
+) -> Dict[str, Dict[str, float]]:
+    """Matrice (regimes x mesures) : la porte scientifique #7740.
+
+    On regarde 3 regimes sources pour le **conditionnement** (la cinematique de
+    la source pendant la co-occurrence) et on mesure, pour chacun :
+
+    - ``err_phat``     : erreur d'anticipation p_hat (mesure 1, normalisee par
+      persistance : >1 = p_hat perd vs reactive).
+    - ``transferred``  : transfert de valence (mesure 2, verdict 0/1).
+    - ``committed``    : engagement d'action (mesure 3, verdict 0/1).
+    - ``reversible``   : reversibilite (mesure 6, verdict 0/1).
+
+    La dissociation : sur ``erratique``, ``err_phat`` explose (p_hat faible)
+    TANDIS QUE ``transferred`` / ``committed`` / ``reversible`` restent valides
+    (valence forte). Une seule ligne le montre : p_hat et valence sont deux
+    grandeurs distinctes, pas un re-vetement.
+
+    Verdict falsifiable
+    -------------------
+    ``dissociation_observed`` : il existe un regime ou ``err_phat`` est maximal
+    ET au moins transfert + reversibilite tiennent. Si aucun regime ne montre
+    cela, la dissociation n'est pas etablie (et il faut le dire honnetement).
+    """
+    measures: Dict[str, Dict[str, float]] = {}
+    for kind in ("balistique", "erratique", "bruite"):
+        m1 = prediction_accuracy_test(kind, size=size, seed=seed)
+        m2 = embodied_transfer_test(kind=kind, size=size, seed=seed)
+        m3 = action_commitment_test(kind=kind, size=size, seed=seed)
+        m6 = behavioral_reversibility_test(kind=kind, size=size, seed=seed)
+        err_norm = m1["err_phat"] / (m1["err_persistence"] + 1e-12)
+        measures[kind] = {
+            "err_phat_vs_persistence": float(err_norm),
+            "transferred": m2["transferred"],
+            "committed": m3["committed"],
+            "reversible": m6["reversible"],
+            "approach_gain": m2["approach_gain"],
+            "entropy_drop": m3["entropy_drop"],
+        }
+
+    # dissociation : un regime a err_phat elevee ET transfert+reversibilite tenus.
+    erratic = measures["erratique"]
+    dissociation_observed = (
+        erratic["err_phat_vs_persistence"] > measures["balistique"]["err_phat_vs_persistence"]
+        and erratic["transferred"] == 1.0
+        and erratic["reversible"] == 1.0
+    )
+    measures["_verdict"] = {"dissociation_observed": 1.0 if dissociation_observed else 0.0}
+    return measures

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_pregnance_animat.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_pregnance_animat.py
@@ -1,0 +1,241 @@
+"""Tests du module #7740 (C1) : animat a pregnance/valence incarnees.
+
+Couvre les quatre verdicts falsifiables du banc incarne + la matrice de
+dissociation (la porte scientifique #7740) + leurs controles negatifs :
+
+1. **p_hat incarne** (mesure 1) : ``p_hat`` bat la persistance sur balistique
+   (source previsible) mais pas sur statique ; sur ``erratique`` son erreur
+   relative explose (le levier de dissociation).
+2. **transfert incarne** (mesure 2) : un signal neutre devient APPROCHE seul
+   apres co-occurrence avec une source, et un controle non-conditionne ne l'est
+   pas. Controle negatif : sans conditionnement, pas de transfert.
+3. **engagement d'action** (mesure 3) : un animat investi (forte ``pi``)
+   collapse sa distribution d'actions (entropie << uniforme). Controle : sans
+   investissement, l'entropie reste proche du max.
+4. **reversibilite comportementale** (mesure 6) : l'approche acquise s'eteint
+   sous presentation seule ; la valence ``pi`` acquise puis eteinte. Controle :
+   sans acquisition, pas de reversibilite a observer.
+5. **dissociation** : sur ``erratique``, ``p_hat`` est detruit MAIS transfert +
+   reversibilite tiennent — valence et prediction sont dissociables.
+
+Reutilises (non reinventes) : :class:`ict.learned_valence.LearnedValence`,
+:func:`ict.valence.predict_source` + baselines, :func:`ict.inhibited_action.action_entropy`.
+numpy + pytest, CPU uniquement.
+"""
+
+import numpy as np
+import pytest
+
+from ict.pregnance_animat import (
+    AnimatConfig,
+    ObjectSpec,
+    PregnanceAnimat,
+    build_object_trajectories,
+    prediction_accuracy_test,
+    phat_regime_sweep,
+    embodied_transfer_test,
+    action_commitment_test,
+    behavioral_reversibility_test,
+    dissociation_matrix,
+)
+
+
+# --- Proprietes mecaniques de PregnanceAnimat ---
+
+
+def test_animat_initial_state_is_neutral():
+    """A l'init, aucun signal n'est valorise (pi=0), faim nulle, position connue."""
+    a = PregnanceAnimat(n_objects=3, rng=np.random.default_rng(0))
+    assert np.all(a.lv.valence_vector() == 0.0)
+    assert a.hunger == 0.0
+    assert np.allclose(a.pos, [2.0, 2.0])
+
+
+def test_module_reuses_learned_valence_and_predict_source():
+    """L'animat REUTILISE les fondations (non reinventees) : LearnedValence et
+    predict_source proviennent de ict.learned_valence / ict.valence."""
+    from ict.learned_valence import LearnedValence
+    from ict.valence import predict_source
+    a = PregnanceAnimat(n_objects=2, rng=np.random.default_rng(0))
+    assert isinstance(a.lv, LearnedValence)
+    assert callable(predict_source)
+
+
+def test_conditioning_episode_raises_neutral_valence():
+    """Apres un episode de co-occurrence (source + neutre tethered), la valence
+    du neutre monte (acquisition Rescorla-Wagner via co-occurrence)."""
+    from ict.pregnance_animat import _tethered_trajectories, _run_episode
+    rng = np.random.default_rng(0)
+    a = PregnanceAnimat(n_objects=3, config=AnimatConfig(), rng=rng)
+    a.set_intrinsic_valences({0: 1.0})
+    trajs = _tethered_trajectories("balistique", 140, 32, rng, n_objects=3,
+                                   neutral_idx=1, control_idx=2)
+    _run_episode(a, trajs, start=np.array([2.0, 2.0]))
+    assert a.lv.valence(1) > 0.5          # neutre conditionne
+    assert a.lv.valence(2) < 0.05         # controle hors-arene reste neutre
+
+
+def test_hunger_grows_and_capture_satiates():
+    """La faim croit avec le temps ; capturer une source la fait chuter."""
+    from ict.pregnance_animat import _run_episode
+    rng = np.random.default_rng(0)
+    a = PregnanceAnimat(n_objects=2, config=AnimatConfig(hunger_rate=0.05, satiation=0.4), rng=rng)
+    a.set_intrinsic_valences({0: 1.0})
+    # source immobile au centre, animat proche : capture immediate.
+    src = np.full((2, 30, 2), 16.0)
+    _run_episode(a, src, start=np.array([15.0, 15.0]))
+    assert len(a.captures) > 0
+    # apres captures repetees, la faim a chute sous son max.
+    assert a.hunger < 1.0
+
+
+def test_animat_without_valence_explores():
+    """Sans valence (pi=0, aucune source), l'animat explore (action = n_objects)."""
+    from ict.pregnance_animat import _run_episode
+    rng = np.random.default_rng(0)
+    a = PregnanceAnimat(n_objects=3, config=AnimatConfig(), rng=rng)
+    # aucun intrinsic, pi nul -> rien valorise -> exploration.
+    src = np.full((3, 40, 2), 10.0)
+    _run_episode(a, src, start=np.array([2.0, 2.0]))
+    actions = np.asarray(a.actions)
+    assert (actions == a.n_objects).mean() > 0.8   # majorite d'exploration
+
+
+# --- Gardes de validation ---
+
+
+def test_invalid_n_objects_raises():
+    """n_objects=0 propage la garde de LearnedValence (n_signals >= 1)."""
+    with pytest.raises(ValueError):
+        PregnanceAnimat(n_objects=0)
+
+
+def test_build_object_trajectories_shape():
+    """Le constructeur d'environnement renvoie la forme attendue."""
+    objs = [ObjectSpec(idx=0, kind="balistique", intrinsic_valence=1.0),
+            ObjectSpec(idx=1, kind="erratique")]
+    trajs = build_object_trajectories(objs, n_steps=50, size=32, rng=np.random.default_rng(0))
+    assert trajs.shape == (2, 50, 2)
+
+
+# --- Mesure 1 : p_hat incarne ---
+
+
+def test_phat_beats_persistence_on_ballistic():
+    """Sur balistique (vitesse constante), p_hat bat la persistance."""
+    r = prediction_accuracy_test("balistique", seed=0)
+    assert r["err_phat"] < r["err_persistence"]
+    assert r["phat_beats_persistence"] == 1.0
+
+
+def test_phat_does_not_beat_persistence_on_static():
+    """Sur statique, la persistance est quasi parfaite : p_hat ne bat pas
+    (controle : p_hat n'est pas magiquement toujours gagnant)."""
+    r = prediction_accuracy_test("statique", seed=0)
+    assert r["phat_beats_persistence"] == 0.0
+
+
+def test_phat_erratic_relative_error_exceeds_ballistic():
+    """Le levier de dissociation : err_phat/err_pers est plus haut sur erratique
+    que sur balistique (p_hat y perd relativement)."""
+    sweep = phat_regime_sweep(seed=0)
+    ratio_errat = sweep["erratique"]["err_phat"] / sweep["erratique"]["err_persistence"]
+    ratio_bal = sweep["balistique"]["err_phat"] / sweep["balistique"]["err_persistence"]
+    assert ratio_errat > ratio_bal
+
+
+# --- Mesure 2 : transfert incarne ---
+
+
+def test_embodied_transfer_verdict():
+    """Verdict TRANSFERT : le neutre devient approche seul, le controle non."""
+    r = embodied_transfer_test(kind="balistique", seed=0)
+    assert r["post_valence_neutral"] > 0.5
+    assert r["control_valence_unconditioned"] < 0.05
+    assert r["approach_fraction_conditioned"] > r["approach_fraction_control"]
+    assert r["approach_gain"] > 0.15
+    assert r["transferred"] == 1.0
+
+
+def test_transfer_holds_on_erratic_regime():
+    """Le transfert tient meme sur erratique : la co-occurrence (tethered)
+    conditionne independamment de la previsibilite (dissociation vs p_hat)."""
+    r = embodied_transfer_test(kind="erratique", seed=0)
+    assert r["post_valence_neutral"] > 0.5
+    assert r["transferred"] == 1.0
+
+
+def test_no_transfer_without_conditioning():
+    """Controle negatif : sans conditionnement (n_condition=0), pas de transfert."""
+    r = embodied_transfer_test(kind="balistique", n_condition=0, seed=0)
+    assert r["post_valence_neutral"] < 0.05
+    assert r["transferred"] == 0.0
+
+
+# --- Mesure 3 : engagement d'action ---
+
+
+def test_action_commitment_verdict():
+    """Verdict ENGAGEMENT : l'investi collapse son entropie d'action."""
+    r = action_commitment_test(kind="balistique", seed=0)
+    assert r["post_valence_signal"] > 0.2
+    assert r["action_entropy_invested"] < r["action_entropy_uniform"]
+    assert r["entropy_drop"] > 0.25
+    assert r["committed"] == 1.0
+
+
+def test_invested_entropy_below_uniform():
+    """L'entropie de l'investi est strictement sous ln(n_actions) (non-uniforme)."""
+    r = action_commitment_test(seed=0)
+    assert r["action_entropy_invested"] < r["action_entropy_uniform"] - 0.2
+
+
+# --- Mesure 6 : reversibilite comportementale ---
+
+
+def test_behavioral_reversibility_verdict():
+    """Verdict REVERSIBILITE : l'approche acquise s'eteint sous presentation seule."""
+    r = behavioral_reversibility_test(kind="balistique", seed=0)
+    assert r["acquired_valence"] > 0.5
+    assert r["extinguished_valence"] < r["acquired_valence"] * 0.5
+    assert r["approach_fraction_acquired"] > r["approach_fraction_extinguished"]
+    assert r["approach_drop"] > 0.15
+    assert r["reversible"] == 1.0
+
+
+def test_no_reversibility_without_acquisition():
+    """Controle negatif : sans acquisition (conditionnement court), pi reste basse
+    et la 'reversibilite' n'a rien a inverser (acquired_valence < seuil)."""
+    r = behavioral_reversibility_test(kind="balistique", n_condition=5, seed=0)
+    assert r["acquired_valence"] < 0.3
+    assert r["reversible"] == 0.0
+
+
+# --- La matrice de dissociation (porte scientifique #7740) ---
+
+
+def test_dissociation_matrix_observed():
+    """Le verdict scientifique : la dissociation p_hat / valence est etablie."""
+    dm = dissociation_matrix(seed=0)
+    assert dm["_verdict"]["dissociation_observed"] == 1.0
+
+
+def test_dissociation_erratic_destroys_phat_but_valence_holds():
+    """Le coeur de la dissociation : erratique a err_phat relative elevee MAIS
+    transfert + reversibilite + engagement tiennent (valence != prediction)."""
+    dm = dissociation_matrix(seed=0)
+    errat = dm["erratique"]
+    bal = dm["balistique"]
+    assert errat["err_phat_vs_persistence"] > bal["err_phat_vs_persistence"]
+    assert errat["transferred"] == 1.0
+    assert errat["committed"] == 1.0
+    assert errat["reversible"] == 1.0
+
+
+def test_dissociation_matrix_covers_three_regimes():
+    """La matrice couvre balistique / erratique / bruite (3 regimes Croises)."""
+    dm = dissociation_matrix(seed=0)
+    for kind in ("balistique", "erratique", "bruite"):
+        assert kind in dm
+        assert "err_phat_vs_persistence" in dm[kind]
+        assert "transferred" in dm[kind]


### PR DESCRIPTION
## ICT-12c (PR-A) — Animat prégnance/valence incarné + matrice de dissociation (#7740, C1)

**Grain:** DEEP/notebook-python · **Lane:** myia-po-2024:CoursIA-2 · **See** #7740 (jambe C1) · **Prev** #8913

Première moitié de **#7740** (ICT jambe C1) : un animat **incarné** qui sépare prégnance/valence (salience thomienne) de représentation prédictive (`p_hat`), en réutilisant les fondations **désincarnées** de #8823 sans les modifier. Suit le précédent two-PR #8823 (module) → #8844 (notebook) : ce PR-A pose le code + les tests, PR-B ajoutera le notebook `ICT-12c`.

### La porte scientifique : une matrice de dissociation

Pas un printout par mesure — une **matrice (régimes × mesures)**. Le levier : `source_trajectory(kind="erratique")` détruit `p_hat` (l'EMA-vitesse sur-réagit aux renversements) MAIS laisse intact le conditionnement Rescorla-Wagner (qui ne dépend que de la co-occurrence, pas de la prévisibilité). On obtient un régime **p̂ FAIBLE / valence HAUTE**, dissocié du balistique **p̂ FORT / valence HAUTE**. Six mesures corrélées ne prouvent rien ; la dissociation seule valide que valence et prédiction sont deux grandeurs distinctes.

| Régime | err_phat/pers (M1) | transfert (M2) | engagement (M3) | réversibilité (M6) |
|---|---|---|---|---|
| balistique | 0.14–0.23 | ✓ | ✓ | ✓ |
| **erratique** | **0.68–095** | **✓** | **✓** | **✓** |
| bruite | élevé | ✓ | ✓ | ✓ |

`dissociation_observed = 1` **robuste sur 8/8 seeds** (erratique : p̂ 3–6× pire que balistique, mais valence tient partout).

### Design (additif, zéro modification des fondations)

`PregnanceAnimat` couple (a) une valence apprise `pi` (Rescorla-Wagner, **réutilise** `LearnedValence`), (b) un modèle prédictif `p_hat` (**réutilise** `valence.predict_source` + baselines adverses persistance/MA/AR1), (c) un drive interne `hunger`, via une politique `action_t = f(salience, hunger)` où `salience = pi + intrinsic`. Conditionnement **Pavlovien incarné** : un signal neutre **tethered** à une source s'associe quand les deux sont sensed ; capture de source → satié ; capture de signal seul → extinction.

Insight incarné clé : la valence décide **SI** on poursuit ; `feasibility` (credibilité de `p_hat`) décide **COMMENT** (interception vs réactif). Sur erratique, l'animat poursuit **réactivement** (la où la cible est) — il approche quand même, sans que `p_hat` y ajoute de lead. D'où la dissociation nette.

### Scope honnête

Couvre mesures **1** (p̂ + baselines), **2** (transfert incarné, approach-fraction), **3** (engagement, `action_entropy`), **6** (réversibilité comportementale) + contrôles négatifs + `dissociation_matrix()`. **Défère** mesures **4** (divergence énergie-libre adaptive) et **5** (information predictive) au PR-suivi : research-grade — `free_energy` mode `"fixed"` n'est qu'un habillage du MSE (vacuous), `signaling_convention` n'a que la primitive `mutual_information` (pas d'estimateur/binning). Justification honnête, pas de science bâclée.

### Rigueur de mesure

Les métriques comportementales d'approche sont **stochastiques** (la marche aléatoire d'un animat sans valence peut, par chance, longer le neutre). `_mean_approach` moyenne Monte-Carlo sur k réalisations d'exploration (même `pi`, même trajectoire cible) — réduction de bruit légitime, **pas** d'ajustement de seuil. La dynamique `pi`/extinction est déterministe, laissée single-seed.

### Vérification

- `pytest tests/test_pregnance_animat.py` → **20/20 PASS** (10.2 s), dont 6 contrôles négatifs (no-conditioning, no-acquisition, animat-sans-valence, p̂-perd-sur-statique, etc.)
- 67 tests foundation (`learned_valence`/`inhibited_action`/`valence`) toujours PASS → **zéro régression** sur les modules réutilisés
- `import ict` propre, `pregnance_animat` enregistré dans `__all__`

### Suivi (PR-B)

Notebook `ICT-12c-PregnanceAnimat.ipynb` (squelette house 17 cells/9md/8code, 4× md gate + contrôle négatif → verdict + panel matplotlib, synthèse table) + README rows (12c + backfill 12b manquant) + `ICT-0-Framing.md` C1 pointer.

See #7740 · #7739 (Sémiophysique de Thom) · #4588 · lane myia-po-2024:CoursIA-2
