### PR TITLE
refactor(slides,#8926): build_advisory discovery pattern-driven (gate-aligned)

### DIFF
--- a/scripts/slides/build_advisory.sh
+++ b/scripts/slides/build_advisory.sh
@@ -30,54 +30,54 @@ set -euo pipefail
 SLIDES_DIR="${SLIDES_DIR:-slides}"
 SLIDEV_BIN="${SLIDEV_BIN:-npx --no-install slidev}"
 
-# Top-level entries under slides/ that are NOT decks.
-# Kept as an explicit allowlist-inverted list so a new deck dir is covered by
-# default; a new non-deck dir must be added here (and the denominator check
-# will remind you, since it would otherwise count it as an empty deck dir).
-NON_DECK_DIRS="_assets _tools analysis node_modules node_modules.cache theme-ia101 themes"
-
-is_non_deck() {
-  local d="$1"
-  local x
-  for x in $NON_DECK_DIRS; do [ "$d" = "$x" ] && return 0; done
-  return 1
+# A deck dir is a top-level dir under SLIDES_DIR that is BOTH:
+#  (1) NOT gitignored (a build output / local workdir present on disk but
+#      ignored by git must not trip a false ERROR -- CASE 5 of #8926), and
+#  (2) matching the NN/SN naming convention the gate uses (`^(S)?[0-9]`).
+# This mirrors .github/workflows/slides-build-advisory.yml STRUCTURALLY: infra
+# dirs (_assets, _tools, analysis, theme-ia101, themes, node_modules) do not
+# match the convention and are excluded with no hand-maintained list to drift
+# against the gate (#8926: the former NON_DECK_DIRS allowlist-inverted
+# subtraction reproduced the pattern by hand and was guaranteed to diverge --
+# the day an infra dir was added under slides/, the gate would keep ignoring
+# it for free while this tool counted it as an empty deck dir -> false ERROR).
+is_deck_dir() {
+  local d="$1" name
+  git check-ignore -q -- "$d" 2>/dev/null && return 1   # (1) git = authority on "ignored"
+  name="$(basename "$d")"
+  printf '%s' "$name" | grep -qE '^(S)?[0-9]'           # (2) gate convention (workflow L138)
 }
 
-# Deck dirs = top-level dirs under SLIDES_DIR that are actual decks.
+# Deck dirs = top-level dirs under SLIDES_DIR matching the NN/SN convention
+# (and not gitignored). Mirrors the gate's `slides/*/` + `^(S)?[0-9]` filter.
 deck_dirs() {
-  local d name
+  local d
   for d in "$SLIDES_DIR"/*/; do
     [ -d "$d" ] || continue
     d="${d%/}"
-    name="$(basename "$d")"
-    is_non_deck "$name" && continue
-    echo "$name"
+    is_deck_dir "$d" || continue
+    echo "$(basename "$d")"
   done | sort
 }
 
 # Discover every deck file (repo-relative), one per line, sorted.
-# A deck is `slides.md` or `deck-*.md`, NOT under an `archive/`/`analysis/`/
-# `_assets/` subdir. The exclusion set mirrors the `case` in the canonical CI
-# gate `.github/workflows/slides-build-advisory.yml` so this local tool and the
-# gate agree on what is a deck — a deck author running `build_advisory.sh check`
-# before pushing sees the same inventory the PR gate will compute
-# (review nit #8868: the two had drifted — shell excluded only archive/).
+# A deck is `slides.md` or `deck-*.md` directly under a convention deck dir.
+# Like the gate (workflow L158-172), we glob the deck dir's direct children --
+# there is no sub-path exclusion list because a top-level NN/SN dir's direct
+# child cannot be under archive/analysis/_assets (those are peer infra dirs,
+# already excluded by is_deck_dir). A deck author running `build_advisory.sh
+# check` before pushing thus sees the same inventory the PR gate computes.
 discover_decks() {
-  local d name dk
+  local d dk
   for d in "$SLIDES_DIR"/*/; do
     [ -d "$d" ] || continue
     d="${d%/}"
-    name="$(basename "$d")"
-    is_non_deck "$name" && continue
+    is_deck_dir "$d" || continue
     if [ -f "$d/slides.md" ]; then
-      case "$d/slides.md" in */archive/*|*/analysis/*|*/_assets/*) continue ;; esac
       echo "$d/slides.md"
     fi
     for dk in "$d"/deck-*.md; do
       [ -f "$dk" ] || continue
-      case "$dk" in
-        */archive/*|*/analysis/*|*/_assets/*) continue ;;
-      esac
       echo "$dk"
     done
   done | sort
@@ -137,7 +137,8 @@ check_denominator() {
     printf '  - %s\n' "${empty[@]}"
     echo
     echo "Either add a slides.md / deck-*.md under the dir, or — if it is not a"
-    echo "deck — add it to NON_DECK_DIRS in scripts/slides/build_advisory.sh."
+    echo "deck — rename it so it does not match the NN/SN convention (the gate"
+    echo "excludes non-convention dirs structurally; see is_deck_dir)."
     return 1
   fi
   echo "Denominator check: PASS (every tracked deck dir has >=1 deck)."


### PR DESCRIPTION
## #8926 — `build_advisory.sh` discovery pattern-driven (aligné sur le gate)

**Grain:** MED/refactor · **Lane:** myia-po-2024:CoursIA-2 · **See** #8926 (residuel review #8868) · **Prev** #8925 (#7741 ICT-12d)

`scripts/slides/build_advisory.sh` promet, dans son propre en-tête, l'**équivalence avec le gate** `.github/workflows/slides-build-advisory.yml` (« a deck author running `build_advisory.sh check` before pushing sees the same inventory the PR gate will compute »). Or les deux calculaient l'inventaire par des mécanismes **différents** : le gate exclut les dirs infra **structurellement** (pattern `^(S)?[0-9]`), le tool soustrayait une **liste nommée en dur** (`NON_DECK_DIRS`) — garanti de dériver.

### Le changement de mécanisme (cœur de #8926)

Un deck dir est désormais **les deux** : (1) **non gitignoré**, et (2) **convention NN/SN** (`^(S)?[0-9]`, celle du gate, workflow L138). `is_deck_dir()` remplace `is_non_deck()` ; la liste `NON_DECK_DIRS` disparaît.

| | Avant | Après |
|---|---|---|
| Découverte | énumère `slides/*/` puis soustrait `NON_DECK_DIRS` | pattern `^(S)?[0-9]` (aligné gate) |
| Dirs infra | liste **en dur** à maintenir | exclus **structurellement** (ne matchent pas la convention) |
| Dir gitignoré sur disque | faux `ERROR` (non listé) | `git check-ignore` → skippé (**CASE 5**) |

### Preuve avant/après (CASE 5 — le défaut)

Sur un arbre jetable : `slides/99-local-build/` (gitignoré, présent sur disque, sans deck).

- **AVANT** : `ERROR: deck dir(s) with ZERO decks ... - 99-local-build`, **exit 1** (faux positif — le défaut #8926).
- **APRÈS** : skippé par `git check-ignore`, **exit 0**.

### Preuve 5-CASE (tous PASS)

| CASE | Scénario | Attendu | Observé |
|---|---|---|---|
| **B** | arbre sain (deck réel + dir infra) | mute, exit 0 | exit 0 ✓ |
| **A** | dir convention **sans deck** | ERROR, exit 1 | exit 1 ✓ (**non-régression** — trap #8807/#8817 reste rouge) |
| **5** | dir gitignoré, sans deck | exit 0, no ERROR | exit 0 ✓ (**NOUVEAU**) |
| **5b** | dir gitignoré **matchant la convention** | skippé | exit 0 ✓ (variante la plus dure) |
| **C** | M=0 (aucun dir convention) | REFUSE, exit 1 | exit 1 ✓ |

### Critère 3 — coincidence tool/gate sur l'arbre réel

Inchangé : **16 deck dirs / 18 decks / PASS** (référence #8868). La refactor ne modifie pas l'inventaire réel — elle change *comment* il est calculé (pattern vs soustraction), pour qu'il ne dérive plus.

### Pourquoi (b) pas (a)

L'issue proposait (a) `git check-ignore` seul (LIGHT) ou (b) pattern-driven (MED, durable). Cette PR livre **(b) qui subsume (a)** : le garde `git check-ignore` est inclus **et** la découverte est alignée sur la convention du gate. C'est le fix durable — aucun mécanisme parallèle à maintenir.

### Livrable

- `scripts/slides/build_advisory.sh` — +31/−30 (1 fichier). `NON_DECK_DIRS` + `is_non_deck` retirés, `is_deck_dir` ajouté, `deck_dirs()`/`discover_decks()` mis à jour, message d'erreur `check_denominator` réécrit (n'évoque plus `NON_DECK_DIRS`), `case` d'exclusion de sous-chemin vestigial retiré (les enfants directs d'un dir NN/SN ne peuvent pas être sous un dir infra pair).
- Preuve 5-CASE reproduite sur arbre jetable (harness en scratchpad, non committé).

See #8926 · #8817 (gate canonique) · residuel review #8868 · lane myia-po-2024:CoursIA-2
