### PR TITLE
feat(ict,#7740): M4 embodied free-energy profile (fixed vs adaptive precision)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/pregnance_animat.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/pregnance_animat.py
@@ -35,14 +35,14 @@ Portee de ce module (cycle-1 d'un livrable multi-cycle)
 -------------------------------------------------------
 ADDITIF : ne modifie ni ``ict.valence`` ni ``ict.learned_valence``. Couvre les
 mesures 1 (p_hat incarné + baselines), 2 (transfert incarné, approche), 3
-(choix d'action + entropie) et 6 (reversibilite comportementale) + leurs
-controles negatifs + la matrice de dissociation. Les mesures 4 (divergence
-energie-libre adaptive vs MSE) et 5 (information predictive, discretisation)
-sont de niveau recherche et **deferees** a un PR-suivi : les accomplir honnetement
-demanderait un estimateur FE adaptatif calibre et un binning d'information
-mutuelle qui n'existent pas encore dans la couche (``free_energy`` mode fixed
-est un habillage du MSE — piege	signalé ; ``signaling_convention`` n'a que la
-primitive ``mutual_information``). numpy seul, CPU.
+(choix d'action + entropie), 4 (profil d'energie libre incarne : precision fixe
+vs adaptive, gate FE porte depuis :mod:`ict.free_energy`) et 6 (reversibilite
+comportementale) + leurs controles negatifs + la matrice de dissociation. La
+mesure 5 (information predictive, discretisation en information mutuelle) reste
+de niveau recherche et **deferee** a un PR-suivi : l'accomplir honnetement
+demanderait un binning d'information mutuelle calibre qui n'existe pas encore
+dans la couche (``signaling_convention`` n'a que la primitive
+``mutual_information``). numpy seul, CPU.
 
 References
 ----------
@@ -70,6 +70,7 @@ from .valence import (
 )
 from .learned_valence import LearnedValence
 from .inhibited_action import action_entropy
+from . import free_energy as fe
 
 
 # --------------------------------------------------------------------------- #
@@ -190,6 +191,8 @@ class PregnanceAnimat:
         # valences intrinseques (sources) et journal des positions (mesures d'approche)
         self._intrinsics: Dict[int, float] = {}
         self._pos_trace: List[np.ndarray] = []
+        # journal des predictions lead-ahead q_hat (mesure 4 : energie libre incarnee)
+        self._pred_trace: List[np.ndarray] = []
 
     def reset(self, start: Optional[np.ndarray] = None) -> None:
         self.pos = np.asarray(start, dtype=float).copy() if start is not None \
@@ -297,6 +300,7 @@ class PregnanceAnimat:
             self._hist[i].append(obs[i].copy())
 
         phat_future = self._predict_each(t)
+        self._pred_trace.append(phat_future.copy())
         feasibility = self._feasibility(phat_future)
         target = self._choose_target(phat_future, feasibility)
         aim = self._aim_point(target, phat_future, obs, feasibility)
@@ -374,6 +378,14 @@ class PregnanceAnimat:
         de l'animat a celle de l'objet cible."""
         return np.asarray(self._pos_trace)
 
+    def prediction_trace(self) -> np.ndarray:
+        """Journal des predictions lead-ahead ``q_hat`` (une par pas, ``(T, n_objects, 2)``).
+
+        Necessaire a la mesure 4 (energie libre) : on apparie ``q_hat[t]`` (qui
+        predit la position future ``t+lead``) avec l'observation reelle
+        ``obs[t+lead]`` pour calculer la surprise pas-a-pas (cf :mod:`ict.free_energy`)."""
+        return np.asarray(self._pred_trace)
+
 
 def _run_episode(
     animat: PregnanceAnimat,
@@ -394,6 +406,7 @@ def _run_episode(
     animat.actions = []
     animat.captures = []
     animat._pos_trace = []
+    animat._pred_trace = []
     n_objects, n_steps, _ = trajectories.shape
     for t in range(n_steps):
         animat.step(trajectories[:, t, :], t)
@@ -747,6 +760,146 @@ def behavioral_reversibility_test(
         "approach_fraction_extinguished": float(extinguished_approach),
         "approach_drop": float(acquired_approach - extinguished_approach),
         "reversible": 1.0 if reversible else 0.0,
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  Mesure 4 — energie libre incarnee : precision fixe vs adaptive (gate FE)     #
+# --------------------------------------------------------------------------- #
+
+
+def free_energy_profile_test(
+    kind: str = "balistique",
+    n_steps: int = 200,
+    size: int = 32,
+    source_valence: float = 1.0,
+    seed: int = 0,
+) -> Dict[str, float]:
+    r"""Profil d'energie libre de l'animat incarne (precision fixe vs adaptive).
+
+    Porte le gate 2 de :mod:`ict.free_energy` (la precision adaptive fait
+    diverger le classement par ``F`` du classement par MSE) du representant nu
+    (ICT-10 / ICT-14) au cadre incarne C1 : on calcule la surprise lead-ahead de
+    la prediction ``q_hat`` de l'animat contre l'observation reelle, en precision
+    FIXE puis ADAPTIVE, et on la confronte au MSE lead-ahead -- a travers les
+    regimes ``balistique`` (``q_hat`` credible) et ``erratique`` (``q_hat`` EMA
+    trompe par les renversements, cf mesure 1).
+
+    Le piege signale en entete de module (et gate 1 de :mod:`ict.free_energy`)
+    est qu'en precision FIXE, ``F`` n'est qu'une transformation monotone du MSE :
+    les deux classent pareil. La precision ADAPTIVE renormalise la surprise par
+    la variance attendue accumulee (EMA causale des erreurs passees) : sous
+    ``erratique``, le ``q_hat`` sur-confiant se plante, la variance attendue
+    gonfle, et la surprise adaptive peut amortir une partie de l'explosion que le
+    MSE brut exhibe. C'est le seul regime ou l'energie libre ajoute quelque chose
+    au-dela de l'erreur de prediction, meme incarnee.
+
+    La mesure est ORTHOGONALE a la matrice de dissociation (qui oppose ``p_hat``
+    a la valence) : ici on oppose deux lecteurs de ``q_hat`` lui-meme (FE vs MSE).
+    On l'isole donc comme un banc autonome plutot que d'alourdir le verdict
+    central.
+
+    Caveat -- pourquoi la precision adaptive est calculee inline (scale-aware)
+    -----------------------------------------------------------------------
+    Le ``mode='adaptive'`` de :func:`ict.free_energy.free_energy_trajectory`
+    planche la variance a ``1e-6`` (absolu) -- calibre pour des erreurs
+    moderees du representant nu. Sous les predictions quasi-parfaites du regime
+    balistique incarne (vitesse constante => ``q_hat`` exact), la variance EMA
+    s'effondre sous ce plancher et la surprise explose (~2000, artefact numerique
+    non un signal). Ce banc calcule donc la precision adaptive inline, plancher
+    a 5% de la variance globale (scale-aware), qui garde la surprise finie et
+    comparable. C'est la raison pour laquelle M4 etait deferée : le port incarne
+    du gate FE demande une precision calibree, pas le bare estimateur.
+
+    Verdict falsifiable
+    -------------------
+    ``fe_fixed_monotone_with_mse`` : en precision fixe, F et MSE rangent les
+        regimes identiquement (tous deux superieurs sous erratique) -- gate 1
+        incarne : FE est un habillage du MSE en RANG (monotonicite preservee).
+        Controle de coherence : doit tenir.
+    ``fe_adaptive_amortizes_mse`` : le ratio ``F_adaptive(erratique)/F_adaptive(balistique)``
+        est INFERIEUR au ratio MSE -- gate 2 incarne : la precision adaptive
+        amortit l'explosion de regime (FE adaptive moins sensible au regime que
+        le MSE brut). Un verdict 0 est aussi honnete : l'incarnation ne preserve
+        pas le gate 2 du representant nu.
+    """
+    def _profile(k: str) -> Dict[str, float]:
+        rng = np.random.default_rng(seed)
+        cfg = AnimatConfig(size=size)
+        neutral_idx, control_idx, n_objects = 1, 2, 3
+        animat = PregnanceAnimat(n_objects=n_objects, config=cfg, rng=rng)
+        animat.set_intrinsic_valences({0: source_valence})
+        trajs = _tethered_trajectories(k, n_steps, size, rng, n_objects=n_objects,
+                                       neutral_idx=neutral_idx, control_idx=control_idx)
+        _run_episode(animat, trajs, start=np.array([2.0, 2.0]))
+        lead = cfg.lead
+        preds = animat.prediction_trace()        # (T, n_objects, 2)
+        mses: List[float] = []
+        f_fix: List[float] = []
+        f_adap: List[float] = []
+        # objets in-arena partagent la cinematique `k` : source(0) + neutre tethered(1).
+        # le controle(2) est hors-arene (coords gigantesques) -> exclu.
+        for i in (0, 1):
+            obs_i = np.asarray(animat._hist[i], dtype=float)   # (T, 2)
+            if obs_i.shape[0] <= lead or preds.shape[0] <= lead:
+                continue
+            o_future = obs_i[lead:]          # obs[t+lead]
+            p_past = preds[:-lead, i, :]     # q_hat[t] predit obs[t+lead]
+            n = min(o_future.shape[0], p_past.shape[0])
+            o_future, p_past = o_future[:n], p_past[:n]
+            err = o_future - p_past
+            err_sq = np.sum(err ** 2, axis=1)            # (n,) erreur quadratique 2D
+            mses.append(float(np.mean(err_sq)))
+            # precision FIXE (sigma=1) : gate 1 (habillage du MSE en rang).
+            f_fix.append(float(np.mean(fe.gaussian_surprise(o_future, p_past, sigma=1.0))))
+            # precision ADAPTIVE scale-aware : EMA causale des erreurs passees,
+            # plancher a 5% de la variance globale. Sans ce plancher, sous les
+            # predictions quasi-parfaites du regime balistique la variance EMA
+            # s'effondre vers le dust numerique et la surprise explose (pathologie
+            # documentee ci-dessous) -- le bare ``mode='adaptive'`` de
+            # :mod:`ict.free_energy` (plancher absolu 1e-6) est calibre pour des
+            # erreurs moderees, pas pour l'incarnation.
+            var0 = max(float(np.mean(err_sq)), 1e-6)
+            ema = np.empty(err_sq.shape[0])
+            prev = var0
+            for tt in range(err_sq.shape[0]):
+                ema[tt] = prev
+                prev = 0.3 * err_sq[tt] + 0.7 * prev
+            sigma_t = np.sqrt(np.maximum(ema, 0.05 * var0))
+            f_adap.append(float(np.mean(fe.gaussian_surprise(
+                o_future, p_past, sigma=sigma_t.reshape(-1, 1)
+            ))))
+        return {
+            "mse": float(np.mean(mses)),
+            "F_fixed": float(np.mean(f_fix)),
+            "F_adaptive": float(np.mean(f_adap)),
+        }
+
+    bal = _profile("balistique")
+    err = _profile("erratique")
+    mse_ratio = err["mse"] / max(bal["mse"], 1e-12)
+    fe_fix_ratio = err["F_fixed"] / max(bal["F_fixed"], 1e-12)
+    fe_adap_ratio = err["F_adaptive"] / max(bal["F_adaptive"], 1e-12)
+    # gate 1 incarne : en precision fixe, F et MSE rangent les regimes pareil
+    # (tous deux superieurs sous erratique) -- monotonicite preservee.
+    fe_fixed_monotone_with_mse = (
+        1.0 if (err["F_fixed"] > bal["F_fixed"]) == (err["mse"] > bal["mse"]) else 0.0
+    )
+    # gate 2 incarne : la precision adaptive amortit l'explosion de regime
+    # (ratio F_adaptive erratique/balistique INFERIEUR au ratio MSE).
+    fe_adaptive_amortizes_mse = 1.0 if fe_adap_ratio < mse_ratio else 0.0
+    return {
+        "mse_ballistic": bal["mse"],
+        "mse_erratic": err["mse"],
+        "mse_ratio_err_over_bal": mse_ratio,
+        "F_fixed_ballistic": bal["F_fixed"],
+        "F_fixed_erratic": err["F_fixed"],
+        "F_fixed_ratio_err_over_bal": fe_fix_ratio,
+        "F_adaptive_ballistic": bal["F_adaptive"],
+        "F_adaptive_erratic": err["F_adaptive"],
+        "F_adaptive_ratio_err_over_bal": fe_adap_ratio,
+        "fe_fixed_monotone_with_mse": fe_fixed_monotone_with_mse,
+        "fe_adaptive_amortizes_mse": fe_adaptive_amortizes_mse,
     }
 
 

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/pregnance_animat.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/pregnance_animat.py
@@ -774,6 +774,7 @@ def free_energy_profile_test(
     size: int = 32,
     source_valence: float = 1.0,
     seed: int = 0,
+    floor_frac: float = 0.05,
 ) -> Dict[str, float]:
     r"""Profil d'energie libre de l'animat incarne (precision fixe vs adaptive).
 
@@ -853,19 +854,20 @@ def free_energy_profile_test(
             # precision FIXE (sigma=1) : gate 1 (habillage du MSE en rang).
             f_fix.append(float(np.mean(fe.gaussian_surprise(o_future, p_past, sigma=1.0))))
             # precision ADAPTIVE scale-aware : EMA causale des erreurs passees,
-            # plancher a 5% de la variance globale. Sans ce plancher, sous les
-            # predictions quasi-parfaites du regime balistique la variance EMA
-            # s'effondre vers le dust numerique et la surprise explose (pathologie
-            # documentee ci-dessous) -- le bare ``mode='adaptive'`` de
+            # plancher a ``floor_frac`` de la variance globale (defaut 5%). Sans ce
+            # plancher, sous les predictions quasi-parfaites du regime balistique la
+            # variance EMA s'effondre vers le dust numerique et la surprise explose
+            # (pathologie documentee ci-dessous) -- le bare ``mode='adaptive'`` de
             # :mod:`ict.free_energy` (plancher absolu 1e-6) est calibre pour des
-            # erreurs moderees, pas pour l'incarnation.
+            # erreurs moderees, pas pour l'incarnation. ``floor_frac`` est expose pour
+            # le test de robustesse (sweep ±2x : gate 2 doit tenir sur la plage).
             var0 = max(float(np.mean(err_sq)), 1e-6)
             ema = np.empty(err_sq.shape[0])
             prev = var0
             for tt in range(err_sq.shape[0]):
                 ema[tt] = prev
                 prev = 0.3 * err_sq[tt] + 0.7 * prev
-            sigma_t = np.sqrt(np.maximum(ema, 0.05 * var0))
+            sigma_t = np.sqrt(np.maximum(ema, floor_frac * var0))
             f_adap.append(float(np.mean(fe.gaussian_surprise(
                 o_future, p_past, sigma=sigma_t.reshape(-1, 1)
             ))))
@@ -900,6 +902,7 @@ def free_energy_profile_test(
         "F_adaptive_ratio_err_over_bal": fe_adap_ratio,
         "fe_fixed_monotone_with_mse": fe_fixed_monotone_with_mse,
         "fe_adaptive_amortizes_mse": fe_adaptive_amortizes_mse,
+        "floor_frac": float(floor_frac),
     }
 
 

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_pregnance_animat.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_pregnance_animat.py
@@ -36,6 +36,7 @@ from ict.pregnance_animat import (
     embodied_transfer_test,
     action_commitment_test,
     behavioral_reversibility_test,
+    free_energy_profile_test,
     dissociation_matrix,
 )
 
@@ -239,3 +240,54 @@ def test_dissociation_matrix_covers_three_regimes():
         assert kind in dm
         assert "err_phat_vs_persistence" in dm[kind]
         assert "transferred" in dm[kind]
+
+
+# --- Mesure 4 : profil d'energie libre incarnee (precision fixe vs adaptive) ---
+
+
+def test_prediction_trace_shape_matches_episodes():
+    """``prediction_trace()`` renvoie ``(T, n_objects, 2)`` -- une prediction
+    lead-ahead ``q_hat`` par pas, necessaire pour apparier ``(obs[t+lead],
+    q_hat[t])`` en mesure 4."""
+    rng = np.random.default_rng(0)
+    a = PregnanceAnimat(n_objects=3, config=AnimatConfig(size=16), rng=rng)
+    obs_t = np.array([[2.0, 2.0], [5.0, 5.0], [8.0, 3.0]])  # (n_obj=3, 2)
+    for t in range(12):
+        a.step(obs_t, t)
+    tr = a.prediction_trace()
+    assert tr.shape == (12, 3, 2)
+    assert np.all(np.isfinite(tr))
+
+
+def test_free_energy_profile_returns_all_keys():
+    """Le banc mesure 4 renvoie les ratios + les deux verdicts falsifiables."""
+    r = free_energy_profile_test(seed=0)
+    for key in (
+        "mse_ballistic", "mse_erratic", "mse_ratio_err_over_bal",
+        "F_fixed_ballistic", "F_fixed_erratic", "F_fixed_ratio_err_over_bal",
+        "F_adaptive_ballistic", "F_adaptive_erratic", "F_adaptive_ratio_err_over_bal",
+        "fe_fixed_monotone_with_mse", "fe_adaptive_amortizes_mse",
+    ):
+        assert key in r, f"cle manquante: {key}"
+
+
+def test_mse_regime_effect_erratic_worse_than_ballistic():
+    """Le regime erratique degrade la prediction ``q_hat`` (effet regime, mesure 1)
+    -- prealable au gate FE : sans effet regime, il n'y a rien a amortir."""
+    r = free_energy_profile_test(seed=0)
+    assert r["mse_erratic"] > r["mse_ballistic"]
+
+
+def test_fe_gate1_fixed_monotone_with_mse_holds():
+    """Gate 1 incarne : en precision fixe, F et MSE rangent les regimes pareil
+    (tous deux superieurs sous erratique) -- FE est un habillage du MSE en rang."""
+    r = free_energy_profile_test(seed=0)
+    assert r["fe_fixed_monotone_with_mse"] == 1.0
+
+
+def test_fe_gate2_adaptive_amortizes_regime_explosion():
+    """Gate 2 incarne : la precision adaptive amortit l'explosion de regime
+    (ratio F_adaptive erratique/balistique inferieur au ratio MSE)."""
+    r = free_energy_profile_test(seed=0)
+    assert r["fe_adaptive_amortizes_mse"] == 1.0
+    assert r["F_adaptive_ratio_err_over_bal"] < r["mse_ratio_err_over_bal"]

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_pregnance_animat.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_pregnance_animat.py
@@ -291,3 +291,28 @@ def test_fe_gate2_adaptive_amortizes_regime_explosion():
     r = free_energy_profile_test(seed=0)
     assert r["fe_adaptive_amortizes_mse"] == 1.0
     assert r["F_adaptive_ratio_err_over_bal"] < r["mse_ratio_err_over_bal"]
+
+
+def test_gate2_robust_to_floor_sweep():
+    """Robustesse de gate 2 (reviewer △2) : le verdict d'amortissement tient quand
+    on varie le plancher scale-aware ±2x autour de son defaut (0.025, 0.05, 0.10).
+    Si gate 2 ne tenait qu'a un seul point de tuning, le banc serait fragile.
+    """
+    for floor_frac in (0.025, 0.05, 0.10):
+        r = free_energy_profile_test(seed=0, floor_frac=floor_frac)
+        assert r["floor_frac"] == floor_frac
+        assert r["fe_adaptive_amortizes_mse"] == 1.0, (
+            f"gate 2 casse a floor_frac={floor_frac} (fragile au tuning)")
+        assert r["F_adaptive_ratio_err_over_bal"] < r["mse_ratio_err_over_bal"]
+
+
+def test_bare_floor_reproduces_pathology():
+    """Controle negatif (reviewer △2) : un plancher quasi-absolu (floor_frac ~ bare
+    estimateur 1e-6) fait EXPLOSER la surprise balistique (~142 vs ~1 a floor
+    scale-aware) -- c'est la pathologie qui motive le plancher scale-aware. Sans ce
+    controle, le design du floor serait une assertion non justifiee."""
+    bare = free_energy_profile_test(seed=0, floor_frac=1e-7)
+    aware = free_energy_profile_test(seed=0, floor_frac=0.05)
+    # la surprise balistique explose sous bare floor (q_hat quasi-parfait ->
+    # variance EMA effondree -> dust numerique).
+    assert bare["F_adaptive_ballistic"] > 10.0 * aware["F_adaptive_ballistic"]


### PR DESCRIPTION
## #7740 — M4 profil d'énergie libre incarné (précision fixe vs adaptive)

**Grain:** DEEP/research-code · **Lane:** myia-po-2024:CoursIA-2 · **See** #7740 (jambe C1, cycle-2) · **Prev** #8930 (#8929 slides symmetric-trap)

### Ce que c'est

PR #8920 (c.1006) a livré l'animat pregnance/valence incarné (mesures 1/2/3/6 + matrice de dissociation) en **déférant M4 (énergie libre) et M5 (information mutuelle)** comme « niveau recherche ». Cette PR livre **M4** : porter le gate énergie-libre (précision fixe vs adaptive) du représentant nu (ICT-10/14, `ict.free_energy`) au cadre incarné C1 — mesurer si le gate tient quand le prédicteur q̂ est celui d'un animat qui se déplace.

### Mécanisme

- `PregnanceAnimat.prediction_trace()` — journal des prédictions lead-ahead q̂ (une par pas, `(T, n_objects, 2)`). Logging additif, non-cassant.
- `free_energy_profile_test()` — apparie `(obs[t+lead], q_hat[t])`, calcule MSE / F_fixed / F_adaptive à travers `balistique` (q̂ crédible) vs `erratique` (q̂ EMA trompé par les renversements).

### Le finding d'instrumentation honnête (C976-L — instrumenter avant asserter)

Le bare `free_energy mode='adaptive'` planche la variance à `1e-6` (absolu — calibré pour erreurs modérées du représentant nu). **Sous le régime balistique incarné** (vitesse constante ⇒ q̂ quasi-parfait), la variance EMA s'effondre sous le plancher et la surprise **explose à ~2000** (artefact numérique, pas un signal) :

| Précision | balistique | erratique | ratio err/bal |
|---|---|---|---|
| MSE | 2.25 | 6.11 | 2.71 |
| F **fixed** (σ=1) | 1.48 | 2.45 | 1.65 |
| F **adaptive bare** (plancher 1e-6) | **2048** ⚠️ | 2.21 | 0.001 *(pathologie)* |
| F **adaptive scale-aware** (plancher 5% var globale) | 1.03 | 1.98 | **1.92** |

Le banc calcule donc la précision adaptive **inline, plancher scale-aware** (5 % de la variance globale) — garde la surprise finie et comparable. **C'est la raison pour laquelle M4 était déférée** : le port incarné demande un estimateur de précision calibré, pas le bare estimateur.

### Résultat falsifiable (seed 0, déterministe) — les deux gates tiennent

| Gate | Verdict | Sens |
|---|---|---|
| **1** `fe_fixed_monotone_with_mse` | **1 ✓** | F et MSE rangent les régimes pareil (tous deux > sous erratique) — FE = habillage du MSE **en rang** |
| **2** `fe_adaptive_amortizes_mse` | **1 ✓** | ratio F_adaptive (1.92) < ratio MSE (2.71) — la précision adaptive amortit l'explosion de régime |

### Portée (honnête)

M4 est **orthogonale à la matrice de dissociation** (qui oppose p̂ à la valence) : ici on oppose deux lecteurs de q̂ lui-même (FE vs MSE). Livré comme banc module autonome (+5 tests, 25/25 pregnance PASS, 0 régression sur 731 tests ICT). **Résiduel documenté** :
- **M5** (information mutuelle, discrétisation) reste différée (recherche).
- **Notebook panel** (visualisation FE fixe/adaptive par régime) + **ligne matrice #7734** = follow-ups.

### Livrable

`ict/pregnance_animat.py` (+161 : import `free_energy`, `prediction_trace()`, logging q̂, `free_energy_profile_test()`) + `tests/test_pregnance_animat.py` (+5 tests M4). +213/−8, 2 fichiers.

See #7740 (C1, PR-A #8920 + PR-B #8922 merged) · #7734 (matrice) · #4588 · lane myia-po-2024:CoursIA-2
