### PR TITLE
docs(variation-protocol,#8934): document guard agnosticism to separator/case (tranche C)

### DIFF
--- a/.claude/rules/variation-protocol.md
+++ b/.claude/rules/variation-protocol.md
@@ -14,6 +14,8 @@ Grain: <TIER>/<GENRE> — lane <machine:workspace> — prev: <TIER>/<GENRE>
 
 Ex. `Grain: DEEP/lean — lane myia-po-2026:CoursIA — prev: LIGHT/guard`.
 
+**Forme canonique vs substance (le guard est agnostique à la ponctuation).** La ligne ci-dessus est la **forme canonique** (`—` em-dash, libellés minuscules). Le guard d'enforcement ([`variation-tag-guard.yml`](../../.github/workflows/variation-tag-guard.yml)) matche par **mot-clé** (`Grain:`, `lane`) en casse insensible, après neutralisation de la décoration markdown (`tr -d '*\`'`) — il ne voit **ni** le séparateur (`—` / `·` / virgule) **ni** la casse des libellés (`Lane:` / backticks passent). Ce que G-VAR-2/G-VAR-3 et le coordinateur vérifient est la **substance** (TIER par le litmus, GENRE dans l'énumération §1, `lane` présente) — pas la ponctuation. Un tag existant en variante de présentation n'est **pas** une non-conformité à reformatter : ne pas forcer du churn cosmétique sur un tag valide. (See #8934 tranche (C).)
+
 ### TIER — test objectif, PAS auto-évaluation de valeur
 
 Le TIER se décide par un **test mécanique**, pour couper le gaming (« mon tranche-de-guards est de la *substance* ») :


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2023:CoursIA — prev: MED/notebook-dotnet (#8901/PR#8932 merged c.975)

## Summary

Tranche **(C)** de #8934 — séparateurs/forme. #8934 liste trois sous-sujets délibérément exclus de #8935 (« un sujet par PR, G.4 ») ; (A) sync checker est gaté sur le sign-off de #8935, (B) champ `prev:` est une décision de spec laissée à un grain dédié. Cette PR traite **(C)** : documenter dans §1 que le guard est agnostique au séparateur et à la casse des libellés.

## Le drift corrigé

§1 spécifiait la forme canonique `Grain: <TIER>/<GENRE> — lane …` (em-dash, minuscules). La flotte écrit aussi `·` (middle dot) avec libellés capitalisés (`**Lane:**`). **Le guard tolère déjà les deux** — mais la règle ne le disait pas, créant une tension spéculative (un worker pourrait croire devoir reformatter un tag valide).

## Fix (aligner la règle sur le guard, pas l'inverse)

Ajout d'un paragraphe « Forme canonique vs substance » après l'exemple §1 :
- La forme canonique (em-dash, minuscules) **reste la référence**.
- Le guard ([`variation-tag-guard.yml`](../../.github/workflows/variation-tag-guard.yml)) matche par **mot-clé** (`Grain:`, `lane`) en casse insensible après `tr -d '*\`'` → agnostique au séparateur (`—`/`·`/virgule) **et** à la casse des libellés.
- Ce qui compte pour G-VAR-2/G-VAR-3 est la **substance** (TIER litmus, GENRE dans la liste §1, `lane` présente), pas la ponctuation.
- Un tag en variante de présentation n'est **pas** une non-conformité à reformatter → **pas de churn cosmétique** sur des tags valides.

## G.1 — vérification firsthand du claim du body

Le body #8934 dit « Le guard tolère déjà les deux (`grep -i`, `tr -d '*'`) ». Vérifié contre la source `variation-tag-guard.yml` :
- `BODY_FLAT=$(printf '%s' "${PR_BODY:-}" | tr -d '*\`')` → neutralise `**` et backticks (`**Lane:**` → `Lane:`). ✓
- `LANE_RE='lane:?[[:space:]]+[A-Za-z0-9._-]+:[A-Za-z0-9._-]+'` + `grep -qiE "$LANE_RE"` → `-i` casse insensible, **matche le mot-clé `lane` où qu'il soit**, pas le séparateur. ✓
- TIER/GENRE extraits par `sed` après `Grain:[[:space:]]*[A-Za-z]+/` → agnostique au séparateur autour. ✓

Le claim est **vrai** (pas propagé par confiance).

## Orthogonalité à #8935 (zéro conflit de merge)

#8935 (jsboige, OUVERTE) touche `.claude/rules/variation-protocol.md` mais avec **2 hunks seulement** : `@@-28,12` (énumération GENRE + composés) et `@@-49,7` (litmus tag-mal-dérivé). Cette PR édite la **zone format** (lignes 11-15) que #8935 ne touche pas → pas de chevauchement de contexte.

See #8934, #8935.