### PR TITLE
fix(ict,#8936): free_energy relative precision floor (defuses small-scale cliff)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/free_energy.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/free_energy.py
@@ -65,12 +65,22 @@ from . import catastrophe as cat
 # Plancher numerique pour la precision : eviter log(0) et division par zero.
 # Un estimateur trop confiant (sigma -> 0) ferait exploser la surprise ; on
 # borne la precision par en bas pour garder les quantites finies et comparables.
+#
+# ATTENTION (condition d'emploi) : ce plancher est ABSOLU et calibre pour une
+# erreur d'echelle O(1) (cas du representant nu ICT-10/14, erreurs moderees).
+# Tout appelant dont l'echelle d'erreur est petite devant ``1e-6`` (par ex. un
+# predicteur quasi-parfait : variance EMA s'effondre sous le plancher absolu)
+# verra la surprise DIVERGER pour la mauvaise raison. Passer alors un plancher
+# RELATIF ``floor_frac`` (fraction de la variance d'echelle ``var0``) aux
+# primitives ci-dessous -- defaut ``None`` = plancher absolu ``_SIGMA2_FLOOR``
+# (inchange, les resultats existants ne bougent pas). Cf #8936, decouvert par
+# mesure dans #8931 (M4 embodied free-energy profile).
 _SIGMA2_FLOOR = 1e-6
 _TWO_PI = 2.0 * np.pi
 
 
 def gaussian_surprise(
-    obs: np.ndarray, pred: np.ndarray, sigma
+    obs: np.ndarray, pred: np.ndarray, sigma, floor_frac=None, scale=None
 ) -> np.ndarray:
     """Surprise (negative log-vraisemblance gaussienne) pas-a-pas.
 
@@ -89,7 +99,18 @@ def gaussian_surprise(
     sigma : float ou array
         Ecart-type du modele generatif. Scalaire (precision fixe) ou tableau
         (precision adaptive, aligne sur ``obs``). La **variance** ``sigma^2``
-        est bornee par ``_SIGMA2_FLOOR``.
+        est bornee par le plancher (voir ci-dessous).
+    floor_frac : float ou None
+        Si ``None`` (defaut) : plancher absolu ``_SIGMA2_FLOOR`` (= ``1e-6``) --
+        calibre pour une erreur d'echelle O(1) (ICT-10/14). Aucun resultat
+        existant ne change. Si un ``float`` est donne : plancher **relatif**
+        ``floor_frac * scale`` -- pour les appelants dont l'echelle d'erreur est
+        petite (predictor quasi-parfait) ou le plancher absolu fait diverger la
+        surprise (#8936). ``scale`` doit alors etre fourni (l'echelle de
+        reference, typiquement la variance globale des erreurs).
+    scale : float ou None
+        Echelle de reference (variance) utilisee par le plancher relatif. Obligatoire
+        si ``floor_frac`` est non-``None`` ; ignore sinon.
 
     Renvoie
     -------
@@ -99,12 +120,22 @@ def gaussian_surprise(
     o = np.asarray(obs, dtype=float)
     p = np.asarray(pred, dtype=float)
     s = np.asarray(sigma, dtype=float)
-    var = np.maximum(s * s, _SIGMA2_FLOOR)
+    if floor_frac is None:
+        floor = _SIGMA2_FLOOR
+    else:
+        if scale is None:
+            raise ValueError(
+                "floor_frac relatif requiert scale (la variance d'echelle de "
+                "reference) ; cf #8936. Laisser floor_frac=None pour le plancher absolu."
+            )
+        floor = max(float(floor_frac) * float(scale), _SIGMA2_FLOOR)
+    var = np.maximum(s * s, floor)
     return 0.5 * ((o - p) ** 2 / var + np.log(_TWO_PI * var))
 
 
 def adaptive_precision(
-    errors: np.ndarray, alpha: float = 0.3, var0: Optional[float] = None
+    errors: np.ndarray, alpha: float = 0.3, var0: Optional[float] = None,
+    floor_frac: Optional[float] = None,
 ) -> np.ndarray:
     """Variance adaptive ``sigma^2_t`` par EMA **causale** des erreurs passees.
 
@@ -128,11 +159,19 @@ def adaptive_precision(
         Facteur de lissage EMA dans ``]0, 1]``.
     var0 : float ou None
         Variance initiale. Si None, ``var(errors)`` (amorce non causale).
+    floor_frac : float ou None
+        Si ``None`` (defaut) : plancher absolu ``_SIGMA2_FLOOR`` (= ``1e-6``) --
+        calibre pour une erreur d'echelle O(1). Aucun resultat existant ne
+        change. Si un ``float`` est donne : plancher **relatif**
+        ``floor_frac * var0`` (``var0`` = echelle de reference) -- pour les
+        appelants dont l'echelle d'erreur est petite devant ``1e-6`` (predictor
+        quasi-parfait) ou le plancher absolu fait diverger la surprise (#8936).
 
     Renvoie
     -------
     array
-        ``sigma^2_t`` aligne sur ``errors``, borde par ``_SIGMA2_FLOOR``.
+        ``sigma^2_t`` aligne sur ``errors``, borde par le plancher (absolu par
+        defaut, relatif si ``floor_frac`` est donne ; jamais sous ``_SIGMA2_FLOOR``).
     """
     e = np.asarray(errors, dtype=float)
     a = float(alpha)
@@ -141,6 +180,7 @@ def adaptive_precision(
     if var0 is None:
         var0 = float(np.var(e)) if e.size else 1.0
     var0 = max(float(var0), _SIGMA2_FLOOR)
+    floor = _SIGMA2_FLOOR if floor_frac is None else max(floor_frac * var0, _SIGMA2_FLOOR)
     var = np.empty_like(e)
     prev = var0
     sq = e * e
@@ -148,7 +188,7 @@ def adaptive_precision(
     for t in range(e.shape[0]):
         var[t] = prev
         prev = a * sq[t] + (1.0 - a) * prev
-    return np.maximum(var, _SIGMA2_FLOOR)
+    return np.maximum(var, floor)
 
 
 def free_energy_trajectory(
@@ -158,6 +198,7 @@ def free_energy_trajectory(
     mode: str = "fixed",
     alpha: float = 0.3,
     var0: Optional[float] = None,
+    floor_frac: Optional[float] = None,
 ) -> Dict[str, np.ndarray]:
     """Trajectoire d'energie libre ``F_t`` + decomposition accuracy/complexity.
 
@@ -165,6 +206,14 @@ def free_energy_trajectory(
     alors une transformation monotone du MSE (gate 1 : habillage du MSE).
     Si ``mode="adaptive"`` : ``sigma^2_t`` calcule par ``adaptive_precision`` sur
     les erreurs (gate 2 : la ponderation varie, F peut diverger du MSE).
+
+    Parametres
+    ----------
+    floor_frac : float ou None
+        Passe a ``adaptive_precision`` en mode ``adaptive`` (plancher relatif
+        ``floor_frac * var0`` pour les appelants a petite echelle d'erreur,
+        #8936). Defaut ``None`` = plancher absolu ``_SIGMA2_FLOOR`` (inchange).
+        Ignore en mode ``fixed`` (sigma constant).
 
     Renvoie un dict ``{"F", "accuracy", "complexity", "sigma2"}`` aligne sur
     ``obs``. ``F_t = accuracy_t + complexity_t``.
@@ -175,7 +224,7 @@ def free_energy_trajectory(
         s = 1.0 if sigma is None else float(sigma)
         var = np.full(o.shape, max(s * s, _SIGMA2_FLOOR))
     elif mode == "adaptive":
-        var = adaptive_precision(o - p, alpha=alpha, var0=var0)
+        var = adaptive_precision(o - p, alpha=alpha, var0=var0, floor_frac=floor_frac)
     else:
         raise ValueError(f"mode inconnu : {mode!r} ('fixed' ou 'adaptive')")
     accuracy = 0.5 * (o - p) ** 2 / var

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_free_energy.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_free_energy.py
@@ -277,3 +277,51 @@ def test_surprise_gain_iid_near_zero():
     g = fe.surprise_gain(noise, rng, n_shuffles=10)
     assert abs(g["fe_gain"]) < 0.2
 
+
+# --------------------------------------------------------------------------- #
+#  #8936 : plancher absolu (1e-6) = mine pour appelants a petite echelle         #
+# --------------------------------------------------------------------------- #
+
+
+def test_relative_floor_default_is_absolute_unchanged():
+    """Non-regression : ``floor_frac=None`` (defaut) = plancher absolu ``1e-6``.
+    Aucun resultat ICT-10/14 ne bouge (acceptance #8936)."""
+    rng = np.random.default_rng(0)
+    obs = rng.standard_normal(100)
+    pred = obs + rng.standard_normal(100) * 0.5  # O(1) errors (ICT-10/14 scale)
+    bare = fe.free_energy_trajectory(obs, pred, mode="adaptive")
+    none_floor = fe.free_energy_trajectory(obs, pred, mode="adaptive", floor_frac=None)
+    assert np.allclose(bare["F"], none_floor["F"])
+    # le plancher absolu 1e-6 borne la variance (pas de divergence a cette echelle)
+    assert np.all(np.isfinite(bare["F"]))
+
+
+def test_relative_floor_defuses_cliff_for_small_error_scale():
+    """La falaise #8936 : un predictor confiant (sigma^2 << 1e-6) trompe le
+    plancher absolu. Le plancher relatif ``floor_frac * scale`` s'adapte a
+    l'echelle reelle et borne la surprise, l'absolu l'influe (scale-insensible).
+
+    Cas isole controle : err^2 = 1e-4, predictor reclame sigma^2 = 1e-9 (<< floor).
+    - abs floor (1e-6) : accuracy = 1e-4 / 1e-6 = 100 -> surprise ~ 44.
+    - rel floor (0.05 * scale=1e-4 = 5e-6) : accuracy = 1e-4 / 5e-6 = 20 -> surprise ~ 5.
+    Le relatif est nettement inferieur (la surprise reflète l'erreur réelle,
+    pas le plancher numerique)."""
+    scale = 1e-4  # echelle d'erreur reelle (petite devant 1e-6)
+    err = np.full(5, np.sqrt(scale))   # err^2 = 1e-4
+    sigma = np.full(5, np.sqrt(1e-9))  # predictor sur-confiant (var << 1e-6)
+    f_abs = fe.gaussian_surprise(err, np.zeros(5), sigma=sigma)
+    f_rel = fe.gaussian_surprise(err, np.zeros(5), sigma=sigma,
+                                 floor_frac=0.05, scale=scale)
+    # le plancher absolu influe la surprise (clipped a 1e-6)
+    # le plancher relatif la borne (clipped a 0.05*scale)
+    assert float(np.mean(f_rel)) < float(np.mean(f_abs))
+    # et le facteur est substantiel (pas une marge bruit)
+    assert float(np.mean(f_abs) / np.mean(f_rel)) > 2.0
+
+
+def test_gaussian_surprise_relative_floor_requires_scale():
+    """Le plancher relatif sans ``scale`` echoue explicitement (pas de chute
+    silencieuse sur l'absolu -- l'appelant doit nommer l'echelle de reference)."""
+    with pytest.raises(ValueError):
+        fe.gaussian_surprise(np.ones(3), np.zeros(3), sigma=0.5, floor_frac=0.05)
+


### PR DESCRIPTION
## #8936 — `ict.free_energy` plancher de variance relatif (désamorce la falaise)

**Grain:** MED/research-code · **Lane:** myia-po-2024:CoursIA-2 · **See** #8936 (découvert par mesure dans #8931/M4) · **Prev** #8937 (M5, merged `2aa7b5607`)

### Ce que c'est

#8931 (M4) a mesuré et contourné (inline, banc scopé) une pathologie du **plancher de variance absolu** `_SIGMA2_FLOOR = 1e-6` de `ict.free_energy` : calibré pour les erreurs O(1) du représentant nu (ICT-10/14), il fait **diverger** la surprise dès qu'un appelant a une échelle d'erreur petite devant `1e-6` (predictor quasi-parfait → variance EMA s'effondre sous le plancher). jsboige l'a tracé en **#8936** comme mine pour tout futur appelant. Cette PR porte le fix dans la **primitive** (pas juste le banc).

### Le scope respecté (acceptance #8936)

**Le défaut ne change pas.** #8931 a scopé sa correction au banc précisément pour ne pas déplacer les résultats d'ICT-10/14 — ce scope est maintenu : la primitive gagne un plancher relatif **optionnel**, `floor_frac=None` par défaut = plancher absolu `1e-6` **byte-identique**.

| Primitive | Changement | Défaut |
|---|---|---|
| `gaussian_surprise` | +`floor_frac`, +`scale` | `None` = absolu (inchange) |
| `adaptive_precision` | +`floor_frac` (relatif = `floor_frac*var0`) | `None` = absolu (inchange) |
| `free_energy_trajectory` | +`floor_frac` (passe à adaptive) | `None` = absolu (inchange) |

`gaussian_surprise(floor_frac=0.05)` **requiert `scale`** (ValueError sinon) — pas de repli silencieux sur l'absolu : l'appelant doit nommer son échelle d'erreur de référence.

### La falaise, isolée et contrôlée (modèle du contrôle négatif #8931)

| err² réelle | predictor reclame σ² | floor | accuracy | F |
|---|---|---|---|---|
| 1e-4 | 1e-9 (<< floor) | **absolu 1e-6** (clipped) | 1e-4/1e-6 = 100 | **~44** ⚠️ |
| 1e-4 | 1e-9 | **relatif 0.05·1e-4 = 5e-6** | 1e-4/5e-6 = 20 | **~4.8** ✓ |

Le relatif borne la surprise (reflète l'erreur réelle) ; l'absolu l'**influe** (scale-insensible, clip à 1e-6). Facteur ~9× ici.

### Honnêteté de test (C976-L)

Les modèles gaussiens synthétiques **n'ont pas reproduit** le ~2048 de l'issue (spécifique à la dynamique d'erreur lead-ahead de l'animat). Le test utilise donc la **falaise isolée** via `gaussian_surprise` avec un sigma confiant explicite — le signal propre, indépendant du régime, qui prouve la falaise sans dépendre de la dynamique de l'animat. Documenté dans le commit.

### Preuve

27/27 free_energy PASS (+3 tests), 30/30 pregnance PASS (module consommateur, **0 régression** — le défaut None est byte-identique).

### Livrable

`ict/free_energy.py` (+`floor_frac`/`scale` sur 3 fonctions + docstring constante §condition d'emploi) + `tests/test_free_energy.py` (+3 tests). +104/−7, 2 fichiers. `Closes #8936` (les 3 acceptance items satisfaits : plancher relatif optionnel défaut inchangé, test reproduit la falaise, docstring amendée).

See #8936 · discovered #8931 (M4) · #7740 · #4588 · lane myia-po-2024:CoursIA-2
