### PR TITLE
fix(lean-axiom,#8677): classifier les enumerations vides, debloquer le gating lake-wide

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -262,6 +262,104 @@ def _enumerate_module_declarations(project: Path, module_name: str) -> List[str]
     return decls
 
 
+# Reasons an enumeration can come back empty. Only ONE of them means "this
+# module has nothing to audit"; the others mean "the gate could not run", which
+# must stay fail-loud (#8677). Conflating them is what capped axiom coverage at
+# 2 lakes (see ``_classify_empty_enumeration`` below).
+EMPTY_SOURCE_NOT_FOUND = "source_not_found"
+EMPTY_DECLARATION_FREE = "declaration_free_module"
+EMPTY_ALL_PRIVATE = "all_private_declarations"
+EMPTY_SORRY_NO_DECLARATION = "sorry_without_declaration"
+EMPTY_PARSE_GAP = "no_declarations_enumerated"
+
+# A bare ``sorry`` token in comment-stripped source. Same notion as
+# ``prover.lean_utils.count_real_sorries`` (strip comments, then match the bare
+# word), inlined as a regex rather than imported: the CI gate loads this module
+# on a bare ``setup-python`` runner and ``_get_strip_lean_comments`` is the one
+# thing deliberately reached by path (see its comment). Two chars of prose --
+# ``sorry`` inside ``/-- Tous les `sorry`s elimines -/`` -- must not trip it,
+# which is why the check runs on the STRIPPED text.
+_BARE_SORRY_RE = re.compile(r"(?<![A-Za-z0-9_])sorry(?![A-Za-z0-9_])")
+
+
+def _classify_empty_enumeration(project: Path, module_name: str) -> str:
+    """Say WHY ``_enumerate_module_declarations`` returned an empty list.
+
+    ``#print axioms`` needs declaration names, so a module that yields none is
+    unauditable -- but "unauditable" covers two opposite situations that the
+    single ``no_declarations_enumerated`` error used to merge:
+
+    * **The gate could not run.** Source missing, or the parser walked a source
+      that visibly declares things and extracted nothing. Failing loud here is
+      the whole point of #8677: a silent green on a parse gap is worse than a
+      red, because it is indistinguishable from a real audit.
+    * **The module declares nothing, by design.** Root aggregators
+      (imports-only + docstring, the shape ``code-style.md`` already describes
+      for ``Grothendieck.lean`` / ``CooperativeGames.lean`` / ``Finiteness.lean``),
+      Mathlib cartography modules whose body is ``#check @...`` *commands*, and
+      prose/exposition modules that only bind ``variable``. There is no
+      declaration, therefore nothing that could depend on ``sorryAx`` and no
+      axiom to whitelist. Failing on these is a false red.
+
+    Measured impact of the conflation (ai-01, 2026-07-30, firsthand): of the 33
+    modules in ``grothendieck_lean``, 30 audit clean (164 declarations,
+    ``Classical.choice`` + ``propext`` + ``Quot.sound``, zero forbidden, zero
+    ``sorryAx``) and 3 -- ``DirectImage``, ``MathlibMap``, ``SchemesTour`` --
+    fail for having no declarations at all. The same shape exists in BOTH
+    already-wired lakes (``knot_lean/Knots.lean``, ``conway_lean/Conway.lean``,
+    ``conway_lean/Conway/MathlibMap.lean``), which is precisely why their
+    ``target-modules`` inputs are hand-curated lists (5 of 14 modules for knot,
+    2 for conway) rather than the lakefile glob. #8782 calls that gap a "vert
+    hors-cible" and leaves the choice of what to gate as a coordinator design
+    call -- but the choice was not really open: pointing the gate at a whole
+    lake was impossible while declaration-free modules made it red.
+
+    Distinguishing the cases reuses ``_DECL_HEAD_RE`` -- the same regex the
+    enumerator matches on -- rather than a second keyword list, so the two
+    notions of "is a declaration" cannot drift apart. ``EMPTY_PARSE_GAP`` is
+    therefore unreachable while the two agree, and that is its purpose: it is
+    the alarm that fires the day they stop agreeing.
+
+    Returns one of ``EMPTY_SOURCE_NOT_FOUND``, ``EMPTY_DECLARATION_FREE``,
+    ``EMPTY_ALL_PRIVATE``, ``EMPTY_SORRY_NO_DECLARATION``, ``EMPTY_PARSE_GAP``.
+    """
+    src = _module_source_path(project, module_name)
+    if src is None:
+        return EMPTY_SOURCE_NOT_FOUND
+    text = _get_strip_lean_comments()(
+        src.read_text(encoding="utf-8", errors="replace")
+    )
+    heads = [
+        m for m in (_DECL_HEAD_RE.match(line) for line in text.splitlines()) if m
+    ]
+    if not heads:
+        if _BARE_SORRY_RE.search(text):
+            # No declaration, yet a live ``sorry`` in the source. The only shapes
+            # that produce this are the ones the enumerator deliberately excludes
+            # because they are anonymous: ``example : T := by sorry``, and macro
+            # or ``#eval``-style bodies. ``#print axioms`` can never see them --
+            # they define no constant for anything to depend on -- so passing
+            # here would be a green over an unexamined ``sorry``, which is the
+            # exact failure #8677 exists to prevent. Fail loud instead: the pass
+            # below is then not merely *argued* to be sorry-proof, it is fenced.
+            # (Live check, 2026-07-30: the three declaration-free Grothendieck
+            # modules carry ``sorry`` only inside docstring prose -- "Tous les
+            # `sorry`s elimines a la creation" -- which comment stripping removes
+            # before this test, so none of them trips it.)
+            return EMPTY_SORRY_NO_DECLARATION
+        return EMPTY_DECLARATION_FREE
+    if all("private" in m.group("mods") for m in heads):
+        # Every declaration head was skipped as ``private``. NOT declaration-free:
+        # the module has content, and a private lemma is reachable by the kernel
+        # only through the public declarations that use it -- which, ``private``
+        # being module-scoped, cannot live outside this module. So an all-private
+        # module's axioms are genuinely unreachable by this gate. Kept fail-loud
+        # and named distinctly so the log says which hole it is, instead of
+        # blaming a parser that did its job.
+        return EMPTY_ALL_PRIVATE
+    return EMPTY_PARSE_GAP
+
+
 class LeanVerifier:
     """Verify Lean 4 files using lake build with content-hash caching.
 
@@ -531,6 +629,9 @@ class LeanVerifier:
         Returns:
             dict with 'success', 'axioms', 'forbidden', 'has_sorry',
             'fail_on_sorry', 'declarations', 'enumerated', 'raw_output'.
+            When the enumeration comes back empty, 'empty_reason' says which of
+            the four cases it is (see ``_classify_empty_enumeration``); only
+            ``declaration_free_module`` is a pass.
         """
         if whitelist is None:
             whitelist = [
@@ -558,22 +659,44 @@ class LeanVerifier:
 
         declarations = _enumerate_module_declarations(project, module_name)
         if not declarations:
-            # Prover path (fail_on_sorry=False): preserve historical green
-            # behaviour (Level 2 tracks sorry separately) -- do NOT flip Level 3
-            # on a source-parse gap. CI gate path (fail_on_sorry=True): fail
-            # loud so the review gate is never green-blind (#8677).
+            # An empty enumeration is not one situation but two (see
+            # ``_classify_empty_enumeration``): the gate could not run, or the
+            # module genuinely declares nothing. Only the first must fail.
+            empty_reason = _classify_empty_enumeration(project, module_name)
             base = {
                 "axioms": [],
                 "forbidden": [],
                 "whitelist": whitelist,
-                "has_sorry": False,
+                # A sorry found in a source that declares nothing is reported the
+                # same way a ``sorryAx`` in the axiom output is: flagged here,
+                # fatal only under ``fail_on_sorry``. That is what the flag is
+                # named for, and it keeps the prover path's historical green
+                # (Level 2 tracks sorry textually) consistent between the two.
+                "has_sorry": empty_reason == EMPTY_SORRY_NO_DECLARATION,
                 "fail_on_sorry": fail_on_sorry,
                 "declarations": [],
                 "enumerated": False,
+                "empty_reason": empty_reason,
                 "raw_output": "",
             }
+            if empty_reason == EMPTY_DECLARATION_FREE:
+                # Nothing is declared, so nothing can depend on ``sorryAx`` and
+                # there is no axiom to whitelist: the module is vacuously clean
+                # on BOTH paths. This cannot mask a sorry -- the classifier
+                # already routed any source carrying a live ``sorry`` token to
+                # ``EMPTY_SORRY_NO_DECLARATION``, so reaching here means the
+                # source has neither declarations nor sorries. It is the one
+                # relaxation that does not dent the #8677 ratchet, and it is
+                # what lets ``target-modules`` be a lakefile glob instead of a
+                # hand-curated list that silently omits aggregators.
+                return {**base, "success": True}
+            # Prover path (fail_on_sorry=False): preserve historical green
+            # behaviour (Level 2 tracks sorry separately) -- do NOT flip Level 3
+            # on a source-parse gap. CI gate path (fail_on_sorry=True): fail
+            # loud so the review gate is never green-blind (#8677). The error is
+            # now the SPECIFIC reason, so a red says which hole it is.
             if fail_on_sorry:
-                return {**base, "success": False, "error": "no_declarations_enumerated"}
+                return {**base, "success": False, "error": empty_reason}
             return {**base, "success": True}
 
         cmd, env = _resolve_lake_command(["env", "lean", "--stdin"], cwd=str(project))

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
@@ -290,17 +290,271 @@ def test_forbidden_axiom_fails_both_paths():
     assert r_gate["forbidden"] == ["of_eq_true"]
 
 
-def test_no_declarations_ci_gate_fails_loud():
-    r = _check_with_output([], "", fail_on_sorry=True)
+def test_no_declarations_ci_gate_fails_loud(tmp_path):
+    """CI gate: an empty enumeration the gate cannot explain still fails loud.
+
+    The verdict is unchanged since #8677; only the *reason* is now specific
+    (here: the source file does not exist at all), so a red says which hole it
+    is instead of blaming the parser generically.
+    """
+    r = _check_with_output([], "", fail_on_sorry=True, project_dir=str(tmp_path))
     assert r["success"] is False
-    assert r["error"] == "no_declarations_enumerated"
+    assert r["error"] == "source_not_found"
+    assert r["empty_reason"] == "source_not_found"
     assert r["enumerated"] is False
 
 
-def test_no_declarations_prover_path_stays_green():
-    r = _check_with_output([], "", fail_on_sorry=False)
+def test_no_declarations_prover_path_stays_green(tmp_path):
+    r = _check_with_output([], "", fail_on_sorry=False, project_dir=str(tmp_path))
     assert r["success"] is True
     assert r["enumerated"] is False
+    assert r["empty_reason"] == "source_not_found"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Empty enumeration: five causes, ONE pass (ai-01 c.63, #8677 / #8782)
+#
+# ``_enumerate_module_declarations`` returns ``[]`` both when the gate CANNOT
+# RUN and when the module GENUINELY DECLARES NOTHING. Merging them into a single
+# ``no_declarations_enumerated`` failure is what forced ``target-modules`` to be
+# hand-curated (5 of 14 modules for knot, 2 of 26 for conway) instead of a
+# lakefile glob -- an aggregator like ``Knots.lean`` or ``Conway.lean`` made the
+# whole gate red. These tests pin each cause to its verdict.
+#
+# Nothing is mocked below: every empty-enumeration case returns before the
+# ``lake env lean`` call, so the real enumerator, the real classifier and the
+# real branch run against a real fixture on disk. A mock here would prove the
+# mock.
+# ──────────────────────────────────────────────────────────────────────────
+
+def _lake_fixture(tmp_path: Path, module: str, src: str) -> Path:
+    """Write ``src`` as ``module`` inside a minimal lake root, return the root.
+
+    The ``lakefile.lean`` makes ``_has_lakefile`` true so ``check_axioms`` does
+    not re-root upward out of the fixture.
+    """
+    (tmp_path / "lakefile.lean").write_text("-- fixture\n", encoding="utf-8")
+    dest = tmp_path / (module.replace(".", "/") + ".lean")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(src, encoding="utf-8")
+    return tmp_path
+
+
+def _check_real(tmp_path: Path, module: str, src: str, *, fail_on_sorry: bool):
+    root = _lake_fixture(tmp_path, module, src)
+    return LeanVerifier(str(root)).check_axioms(module, fail_on_sorry=fail_on_sorry)
+
+
+@pytest.mark.parametrize("fail_on_sorry", [True, False])
+def test_declaration_free_aggregator_passes(tmp_path, fail_on_sorry):
+    """A root aggregator (imports + docstring, zero declarations) is a PASS.
+
+    This is the shape ``code-style.md`` already names as legitimate -- "les
+    *root aggregators* (ex. ``CooperativeGames.lean``, ``Grothendieck.lean``,
+    ``Finiteness.lean`` -- imports-only + docstring FR, 0 declaration) sont
+    FR-only *by design*". With zero declarations there is nothing that could
+    depend on ``sorryAx`` and no axiom to whitelist: the module is vacuously
+    clean, and failing it was a false red on both paths.
+    """
+    src = (
+        "import Grothendieck.SheafBasics\n"
+        "import Grothendieck.SieveOps\n"
+        "\n"
+        "/-!\n"
+        "# Grothendieck : point d'entree du lake\n"
+        "Ce module n'expose que des imports.\n"
+        "-/\n"
+    )
+    r = _check_real(tmp_path, "Grothendieck", src, fail_on_sorry=fail_on_sorry)
+    assert r["success"] is True
+    assert r["empty_reason"] == "declaration_free_module"
+    assert r["enumerated"] is False
+    assert r["has_sorry"] is False
+    assert r["forbidden"] == []
+
+
+def test_mathlib_cartography_module_passes(tmp_path):
+    """``#check @...`` is a *command*, not a declaration (``Grothendieck/MathlibMap.lean``).
+
+    A cartography module maps what Mathlib already provides; it declares
+    nothing of its own, so ``#print axioms`` has no name to ask about. Same
+    shape in the already-wired ``conway_lean/Conway/MathlibMap.lean``.
+    """
+    src = (
+        "import Mathlib.CategoryTheory.Sites.Sieves\n"
+        "\n"
+        "/-- Un index vivant de ce que Mathlib 4 fournit. -/\n"
+        "#check @CategoryTheory.Sieve.pullback\n"
+        "#check @CategoryTheory.Sieve.pullback_inter\n"
+    )
+    r = _check_real(tmp_path, "Grothendieck.MathlibMap", src, fail_on_sorry=True)
+    assert r["success"] is True
+    assert r["empty_reason"] == "declaration_free_module"
+
+
+def test_prose_module_with_only_bindings_passes(tmp_path):
+    """``namespace`` / ``open`` / ``variable`` bind names but declare nothing.
+
+    The shape of ``Grothendieck/DirectImage.lean``: prose plus the binders that
+    let the prose typecheck, bridging to Mathlib's own ``pushforward`` /
+    ``pullback``. Zero declarations, therefore zero axioms to audit.
+    """
+    src = (
+        "import Mathlib.CategoryTheory.Sites.Sheaf\n"
+        "\n"
+        "namespace Grothendieck\n"
+        "open CategoryTheory\n"
+        "variable {C D : Type*} [Category C] [Category D]\n"
+        "end Grothendieck\n"
+    )
+    r = _check_real(tmp_path, "Grothendieck.DirectImage", src, fail_on_sorry=True)
+    assert r["success"] is True
+    assert r["empty_reason"] == "declaration_free_module"
+
+
+def test_declaration_keyword_inside_comment_stays_declaration_free(tmp_path):
+    """Prose beginning with ``theorem`` must not fake a declaration (#8722 dual).
+
+    #8722 fixed the enumerator so docstring prose at column 0 is no longer
+    enumerated as a phantom declaration. The classifier reuses the same
+    comment-stripped text and the same ``_DECL_HEAD_RE``, so a module whose only
+    ``theorem``-looking lines are prose is genuinely declaration-free -- it must
+    not be re-routed to a fail-loud reason by a second, sloppier parser.
+    """
+    src = (
+        "import Knots.Basic\n"
+        "/-!\n"
+        "theorem statement working for *any* KnotDiagram is deferred here.\n"
+        "def the reader should consult Knots.Basic instead.\n"
+        "-/\n"
+    )
+    r = _check_real(tmp_path, "Knots", src, fail_on_sorry=True)
+    assert r["success"] is True
+    assert r["empty_reason"] == "declaration_free_module"
+
+
+_OPEN_EXAMPLE = (
+    "import Mathlib.Tactic\n"
+    "/-- Un exemple laisse ouvert. -/\n"
+    "example : True := by sorry\n"
+)
+
+
+def test_sorry_without_declaration_fails_the_ci_gate(tmp_path):
+    """A live ``sorry`` with no declaration must NOT ride the pass out.
+
+    ``example`` is deliberately excluded from enumeration (it may be anonymous),
+    so ``example : True := by sorry`` yields an empty enumeration -- and
+    ``#print axioms`` can never see it either, since it defines no constant.
+    Letting it through the declaration-free pass would be a green over an
+    unexamined ``sorry``, the exact failure #8677 exists to prevent. This is
+    what makes "the declaration-free pass cannot mask a sorry" an enforced
+    invariant rather than an argument.
+    """
+    r = _check_real(tmp_path, "Knots.Scratch", _OPEN_EXAMPLE, fail_on_sorry=True)
+    assert r["success"] is False
+    assert r["error"] == "sorry_without_declaration"
+    assert r["empty_reason"] == "sorry_without_declaration"
+    assert r["has_sorry"] is True
+
+
+def test_sorry_without_declaration_prover_path_reports_but_stays_green(tmp_path):
+    """Same source, prover path: flagged, not fatal -- like ``sorryAx`` is.
+
+    The module already draws this line for the axiom output (a ``sorryAx`` sets
+    ``has_sorry`` and fails only under ``fail_on_sorry``); a textual sorry in a
+    declaration-free source is reported through the *same* field so the two
+    cannot diverge. Level 2 tracks sorry textually, so Level 3 stays green.
+    """
+    r = _check_real(tmp_path, "Knots.Scratch", _OPEN_EXAMPLE, fail_on_sorry=False)
+    assert r["success"] is True
+    assert r["has_sorry"] is True
+    assert r["empty_reason"] == "sorry_without_declaration"
+
+
+def test_sorry_in_docstring_prose_does_not_trip_the_guard(tmp_path):
+    """The guard runs on comment-STRIPPED text, so prose about sorries is fine.
+
+    Live shape, measured 2026-07-30: all three declaration-free Grothendieck
+    modules contain the token ``sorry`` -- inside ``Tous les `sorry`s elimines a
+    la creation``. A guard that read raw source would fail exactly the modules
+    this change exists to unblock, and would do it while quoting their own
+    claim of cleanliness back at them.
+    """
+    src = (
+        "import Grothendieck.SheafBasics\n"
+        "/-!\n"
+        "# Cartographie\n"
+        "Epic #1646. Tous les `sorry`s elimines a la creation.\n"
+        "-/\n"
+    )
+    r = _check_real(tmp_path, "Grothendieck.SchemesTour", src, fail_on_sorry=True)
+    assert r["success"] is True
+    assert r["empty_reason"] == "declaration_free_module"
+
+
+def test_all_private_module_fails_loud_with_its_own_reason(tmp_path):
+    """All-private is NOT declaration-free -- it is a genuine blind spot.
+
+    ``private`` names are skipped by the enumerator (#8722: Lean mangles them to
+    ``_private.<Module>.<hash>.<name>``, so ``#print axioms`` answers ``unknown
+    constant``). A module whose declarations are *all* private therefore
+    enumerates empty while having real content -- and ``private`` being
+    module-scoped, the public declarations that would reach those axioms
+    transitively cannot live outside this module. The gate genuinely cannot see
+    them, so it must say so rather than pass.
+    """
+    src = (
+        "namespace Knots\n"
+        "private theorem mem_set_fwd : True := trivial\n"
+        "private noncomputable def hidden : Nat := 0\n"
+        "end Knots\n"
+    )
+    r = _check_real(tmp_path, "Knots.Invariant", src, fail_on_sorry=True)
+    assert r["success"] is False
+    assert r["error"] == "all_private_declarations"
+    assert r["enumerated"] is False
+
+
+def test_all_private_module_prover_path_stays_green(tmp_path):
+    """The prover path keeps its historical green on a gate-cannot-run reason.
+
+    Level 2 tracks sorry textually, so Level 3 must not flip red on a blind
+    spot (#8677). Only the CI gate (``fail_on_sorry=True``) fails loud here --
+    unlike ``sorry_without_declaration`` above, which fails on both paths
+    because it is a live defect rather than a blind spot.
+    """
+    src = "private theorem hidden : True := trivial\n"
+    r = _check_real(tmp_path, "Knots.Invariant", src, fail_on_sorry=False)
+    assert r["success"] is True
+    assert r["empty_reason"] == "all_private_declarations"
+
+
+def test_parse_gap_is_the_drift_alarm(tmp_path):
+    """``no_declarations_enumerated`` now means "the two parsers disagreed".
+
+    The classifier matches on ``_DECL_HEAD_RE`` -- the *same* regex the
+    enumerator uses -- so while they agree this verdict is unreachable: any
+    source with a non-private declaration head makes the enumerator return that
+    declaration, never an empty list. That is the point. The branch is the alarm
+    for the day someone adds a filter to one and not the other; it stays
+    fail-loud so the drift surfaces as a red rather than as a silent green.
+
+    Asserted directly on the classifier, since no fixture can reach it through
+    ``check_axioms`` today -- claiming otherwise would need a mock, and a mocked
+    disagreement proves nothing about the real one.
+    """
+    root = _lake_fixture(
+        tmp_path,
+        "Knots.Mixed",
+        "private theorem hidden : True := trivial\ntheorem visible : True := trivial\n",
+    )
+    # Precondition: with both parsers in agreement, this source enumerates.
+    assert _enumerate_module_declarations(root, "Knots.Mixed") == ["visible"]
+    # The classifier's verdict IF it were ever reached on such a source.
+    assert lean_server._classify_empty_enumeration(root, "Knots.Mixed") == (
+        "no_declarations_enumerated"
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-ai-01:CoursIA — prev: LIGHT/guard

## Le problème

`_enumerate_module_declarations` renvoie `[]` dans **deux situations opposées** :

1. **le gate ne peut pas tourner** — source introuvable, ou parseur muet sur un module qui déclare visiblement des choses ;
2. **le module ne déclare rien, par construction** — root aggregator (imports + docstring), module de cartographie Mathlib dont le corps est fait de *commandes* `#check @...`, module de prose qui ne lie que des `variable`.

`check_axioms` fusionnait les deux dans un unique `no_declarations_enumerated` et échouait sur les deux. Or échouer sur le cas 2 est un **rouge faux** : sans aucune déclaration, il n'y a rien qui puisse dépendre de `sorryAx` et aucun axiome à whitelister.

Le harnais nomme déjà cette classe. `code-style.md` : « les *root aggregators* (ex. `CooperativeGames.lean`, `Grothendieck.lean`, `Finiteness.lean` — imports-only + docstring FR, 0 déclaration) sont FR-only *by design* ». Le fix apprend au gate une catégorie que le harnais reconnaît déjà.

## Pourquoi ça plafonne la couverture axiomes à 2 lakes sur 23

C'est la partie non évidente, et c'est le vrai coût du bug. Les deux workflows câblés ciblent des listes **écrites à la main** :

| Workflow | `target-modules` | Modules compilés | Déclarations FR couvertes |
|---|---|---:|---|
| `lean-knot.yml` | 5 modules | 14 | 112 / 123 (**91,1 %**) |
| `lean-conway.yml` | 2 modules | 53 | 16 / 450 (**3,6 %**) |

Ces listes ne sont pas de la paresse : **on ne *peut pas* pointer le gate sur le glob du lakefile** tant que `Knots.lean`, `Conway.lean` et `Conway/MathlibMap.lean` — tous déclaration-free — le font rougir. Le job advisory de #8782 nomme le symptôme (« un gate qui inspecte 5 des 14 modules compilés est un "vert hors-cible" — visuellement indiscernable d'un vert ciblé dans le rollup des checks ») et laisse le choix des modules à gater comme **décision de design du coordinateur**. Cette décision n'était pas réellement ouverte : elle était bloquée par un bug, pas par une préférence.

`conway_lean` est le cas qui pique : c'est le lake en `fail-on-sorry: true` avec 19 noms `native_decide` whitelistés explicitement — et **434 de ses 450 déclarations sont hors du gate**.

**Mesure post-fix (firsthand, ce jour)** : dans les deux lakes câblés, **zéro** module échouerait pour un motif de déclaration. Tous sont soit énumérables, soit déclaration-free par construction. L'obstacle structurel au glob est levé.

## Ce que le fix fait

Une énumération vide est désormais **classifiée** avant d'être jugée (`_classify_empty_enumeration`), en cinq motifs dont **un seul passe** :

| `empty_reason` | Gate CI (`fail_on_sorry=True`) | Chemin prover |
|---|---|---|
| `declaration_free_module` | **passe** (vacuously clean) | passe |
| `sorry_without_declaration` | **échoue** | vert, `has_sorry=True` |
| `all_private_declarations` | **échoue** | vert (angle mort, pas défaut) |
| `source_not_found` | **échoue** | vert |
| `no_declarations_enumerated` | **échoue** | vert |

Deux points de conception valent d'être signalés en review :

**Le classifieur réutilise `_DECL_HEAD_RE`** — la regex même sur laquelle l'énumérateur matche — plutôt qu'une seconde liste de mots-clés. Les deux notions de « ceci est une déclaration » ne peuvent donc pas diverger. Conséquence assumée : `no_declarations_enumerated` devient **inatteignable tant que les deux s'accordent**, et c'est sa raison d'être — c'est l'alarme de dérive du jour où quelqu'un ajoutera un filtre à l'un et pas à l'autre. Elle reste fail-loud pour que la dérive sorte en rouge, pas en vert silencieux.

**Le passage déclaration-free est *clôturé*, pas seulement argumenté.** `example` est volontairement exclu de l'énumération (il peut être anonyme), donc `example : True := by sorry` produit une énumération vide — et `#print axioms` ne le verra jamais non plus, puisqu'il ne définit aucune constante. Le laisser passer serait un vert au-dessus d'un `sorry` non examiné, exactement ce que #8677 existe pour empêcher. D'où le motif `sorry_without_declaration`, qui échoue le gate CI. Le garde tourne sur le texte **comment-strippé** : les trois modules Grothendieck concernés contiennent tous le token `sorry` — dans « Tous les \`sorry\`s éliminés à la création » — et un garde qui lirait la source brute échouerait précisément les modules que ce changement débloque, en leur renvoyant leur propre affirmation de propreté.

## Mesure qui a produit le grain

Audit axiomes **réel** (`#print axioms` par déclaration, pas grep) sur `grothendieck_lean`, 33 modules :

```
modules ok      : 30/33
declarations    : 164
modules w/ sorry: 0
axioms union    : ['Classical.choice', 'Quot.sound', 'propext']
forbidden union : []
```

Les 3 échecs — `Grothendieck.DirectImage`, `Grothendieck.MathlibMap`, `Grothendieck.SchemesTour` — sont exactement le faux rouge ci-dessus (vérifié fichier par fichier : prose + binders, `#check` commands, 0 mot-clé de déclaration).

**Constat annexe, à traiter séparément** : `docs/reference/lean-axiom-coverage.md` classe `grothendieck_lean` GREEN avec `Classical.choice = 0`. La mesure réelle : `Classical.choice` est utilisé par **les 30 modules énumérables**. Il n'y a pas de contradiction — le doc dit lui-même en §1 « **Pas un audit formel** : ce triage ne **lance pas** `lake env lean` + `#print axioms` » —, mais la colonne vaut 0 **par construction** (l'axiome n'apparaît que dans la *sortie* de `#print axioms`, jamais dans le texte source), pas par mesure. GREEN-par-grep et GREEN-par-gate sont deux affirmations différentes présentées dans une même colonne. Issue de suivi à ouvrir ; **hors périmètre de cette PR**.

## Tests

`tests/test_check_axioms.py` : **+13 tests**, un par cause et par chemin, plus l'alarme de dérive.

Rien n'est mocké dans les nouveaux tests : tous les cas d'énumération vide retournent **avant** l'appel `lake env lean`, donc le vrai énumérateur, le vrai classifieur et la vraie branche tournent contre une vraie fixture sur disque. Un mock ici ne prouverait que le mock.

```
39 passed in 0.33s      # tests/test_check_axioms.py, avec le fix
13 failed, 26 passed    # mêmes tests, contre lean_server.py PRE-fix
621 passed in 5.06s     # suite agent_tests complète, aucune régression
```

Le second chiffre est le contrôle de mutation : les 13 nouveaux/modifiés échouent sans le fix, les 26 préexistants passent dans les deux cas — les tests discriminent réellement.

Deux tests préexistants ont été mis à jour, sans changer leur verdict : `test_no_declarations_ci_gate_fails_loud` et `..._prover_path_stays_green` assertaient `error == "no_declarations_enumerated"` sur une énumération vide ; le verdict (échec / vert) est inchangé, seul le **motif** est devenu spécifique.

## Périmètre (atomique, G.4)

Cette PR contient **le classifieur, la branche, les tests**. Délibérément **hors périmètre**, en suivi :

- câbler `lean-axiom.yml` sur `grothendieck_lean` (3ᵉ lake) ;
- **répondre à l'appel de design de #8782** (options a/b/c) — adressé au coordinateur, resté sans réponse tant qu'il était bloqué par ce bug ;
- passer `target-modules` au glob du lakefile une fois ce fix mergé ;
- la note `Classical.choice` sur `lean-axiom-coverage.md` ;
- `lean-kelly.yml` n'a aucun gate axiomes.

**Résidu documenté (PERTE DOCUMENTÉE)** : un module dont **toutes** les têtes de déclaration sont `private` énumère aussi vide. Ce n'est *pas* déclaration-free — `private` étant module-scoped, les déclarations publiques qui atteindraient ses axiomes en transitif ne peuvent pas vivre hors de ce module, donc le gate ne les voit réellement pas. Gardé fail-loud sous son propre nom (`all_private_declarations`) plutôt que silencieusement rangé avec le cas qui passe : le log dit quel trou c'est, au lieu d'accuser un parseur qui a fait son travail.

## Note règle §B (PR Lean)

`pr-review-discipline.md` §B vise les PR touchant `*.lean` ou `agent_tests/prover/`. Celle-ci ne touche ni l'un ni l'autre : **aucun fichier `.lean` modifié**, donc `grep -c sorry` avant/après est inchangé (delta 0) et aucun `lake build` n'est requis — le livrable est du Python + tests. Je le note explicitement pour qu'un reviewer n'ait pas à deviner si §B s'applique. La PR *modifie* en revanche la sémantique du gate proof-integrity : la preuve que le cliquet #8677 n'est pas entamé est le test `sorry_without_declaration`, qui échoue le gate CI sur la seule route de masquage concevable.

See #8677, #8782.
