### PR TITLE
feat(ict,#8077): bridge_testing — falsifiable protocol, bridge #1 sigma->recoverability FALSIFIED

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/__init__.py
@@ -95,6 +95,7 @@ from . import symbol_invention
 from . import collective_adoption
 from . import inhibited_invention
 from . import concept_inoculation
+from . import bridge_testing
 
 __all__ = [
     "Cell", "Probe", "SelfSortingArray", "KinSortingArray", "ALGOTYPES",
@@ -117,4 +118,5 @@ __all__ = [
     "collective_adoption",
     "inhibited_invention",
     "concept_inoculation",
+    "bridge_testing",
 ]

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/bridge_testing.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/bridge_testing.py
@@ -1,0 +1,240 @@
+"""Bridge-testing protocols (Epic #8077) : tester les FLECHES, pas les NOEUDS.
+
+La serie ICT valide chaque brique localement (un sigma, un SAE, un workspace,
+un MDL, un Phi). L'ambition unificatrice repose sur les **transitions** entre
+briques -- les fleches (ponts) -- et ce sont elles qui portent le risque
+scientifique : une brique peut tenir isolee sans que la fleche qui l'enchaine
+a la suivante soit causale. Ce module porte un protocole falsifiable **par pont
+testable**, sur le modele explicite ``hypothese + modele nul + intervention +
+verdict``, au compte-gouttes (un pont par PR, cf #8077).
+
+Bridge #1 (sigma stabilite -> recuperabilite)
+---------------------------------------------
+Cf #8077, pont 1 du retour externe ChatGPT. Hypothese implicite de la strate
+catastrophe (ICT-8/11) : un equilibre plus **stable** (bassin plus raide,
+courbure ``V''(x*)`` grande) se reparerait **mieux** apres perturbation. Le
+substrat est la fronce de Thom (:mod:`ict.catastrophe`).
+
+La subtilite (qui rend le pont NON tautologique et donc falsifiable) est qu'on
+distingue **deux** dimensions de la recuperation, qui se separant dans la fronce
+asymetrique :
+
+* **vitesse de relaxation** : linearise au voisinage de l'equilibre,
+  ``dx/dt = -V''(x*) (x - x*)`` -- le taux de retour = la courbure ``sigma``.
+  Plus ``sigma`` est grand, plus le systeme se rapproche vite de son equilibre
+  en un temps fixe. C'est le pole ou le pont tient **par construction**
+  (tautologie de la linearisation).
+* **portee du bassin** : la perturbation finie franchit-elle le col (equilibre
+  instable) ? Si oui, le systeme tombe dans l'autre bassin -- la recuperation
+  est PERDUE, independamment de la courbure locale. La portee est gouvernee par
+  la **largeur de bassin** (distance ``x* -> col``), pas par ``sigma``.
+
+Le verdict falsifiable confronte donc les deux : si ``sigma`` predit la
+recuperation **mieux que la largeur de bassin**, le pont tient ; si la largeur
+de bassin predit mieux (``sigma`` n'etant qu'un proxy grossier de la portee,
+qui s'effondre au pli ou largeur -> 0 alors que la courbure reste moderee), le
+pont est **partiellement falsifie** -- c'est la geometrie du bassin (position du
+col), pas la raideur locale, qui decide de la reparation. Un tel verdict 0 est
+aussi honnete qu'un verdict 1 : c'est l'interet du protocole.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+from . import catastrophe as cat
+
+
+# --------------------------------------------------------------------------- #
+#  Bridge #1 : sigma (courbure) -> recuperabilite apres perturbation finie      #
+# --------------------------------------------------------------------------- #
+
+
+def basin_geometry(a: float, b: float) -> List[Tuple[float, float, float, float]]:
+    """Geometrie des bassins de la fronce en ``(a, b)``.
+
+    Renvoie, pour chaque minimum stable ``x*``, le tuple
+    ``(x*, sigma, width, col)`` ou :
+
+    * ``sigma`` = courbure ``V''(x*) = 3 x*^2 + a`` (raideur locale = stabilite) ;
+    * ``col`` = equilibre instable le plus proche (frontiere de bassin) ;
+    * ``width`` = ``|x* - col|`` (demi-largeur du bassin vers le col = portee).
+
+    Renvoie ``[]`` hors region bistable (pas de col -> bassin infini, cas
+    trivial ou toute perturbation est recuperee ; hors-scope du pont).
+    """
+    eqs = cat.cusp_equilibria(a, b)              # [(x, stable), ...] trie par x
+    stables = [x for x, st in eqs if st]
+    unstables = [x for x, st in eqs if not st]
+    if not stables or not unstables:
+        return []
+    out: List[Tuple[float, float, float, float]] = []
+    for xstar in stables:
+        col = min(unstables, key=lambda c: abs(c - xstar))
+        sigma = float(cat.cusp_curvature(xstar, a))
+        width = float(abs(xstar - col))
+        out.append((float(xstar), sigma, width, float(col)))
+    return out
+
+
+def _recover_fraction(xstar: float, col: float, a: float, b: float,
+                      delta_grid: np.ndarray, dt: float,
+                      full_steps: int, eps: float) -> float:
+    """Fraction d'un **balayage de perturbations** (vers le col) dont la
+    relaxation convergente revient dans le bassin de ``x*``.
+
+    On relaxe **a convergence** (``full_steps`` suffisant) : le resultat binaire
+    (revient / ne revient pas) depend donc de la **portee du bassin** (la
+    perturbation franchit-elle le col ?), PAS de la vitesse de relaxation. C'est
+    ce qui rend la mesure NON tautologique : a convergence, un bassin plus raide
+    (``sigma`` grand) ne recupere pas << mieux >> qu'un bassin plat de meme
+    largeur -- seul compte le franchissement du col (largeur de bassin)."""
+    direction = 1.0 if col > xstar else -1.0
+    n_back = 0
+    for d in delta_grid:
+        x = cat.relax_to_equilibrium(xstar + direction * float(d), a, b,
+                                     dt=dt, steps=full_steps)
+        if abs(x - xstar) < eps:
+            n_back += 1
+    return float(n_back) / float(delta_grid.size)
+
+
+def _partial_spearman(sig: np.ndarray, rec: np.ndarray,
+                      wid: np.ndarray) -> float:
+    """Correlation partielle de Spearman de ``sigma`` avec ``recovery`` en
+    controlant la largeur de bassin ``width``. C'est le test decisif : si elle
+    est ~0, ``sigma`` n'a AUCUNE puissance predictive independante au-dela de la
+    largeur -- le pont est falsifie (``sigma`` n'est qu'un proxy correle)."""
+    r_sr = _spearman(sig, rec)
+    r_sw = _spearman(sig, wid)
+    r_wr = _spearman(wid, rec)
+    denom_sq = (1.0 - r_sw * r_sw) * (1.0 - r_wr * r_wr)
+    if denom_sq <= 1e-12:
+        return 0.0
+    return float((r_sr - r_sw * r_wr) / np.sqrt(denom_sq))
+
+
+def _spearman(xs: np.ndarray, ys: np.ndarray) -> float:
+    """Correlation de Spearman (monotone, robuste aux non-linearites) sur deux
+    series. Renvoie 0.0 si une variance est nulle."""
+    if xs.size < 2 or float(np.std(xs)) < 1e-12 or float(np.std(ys)) < 1e-12:
+        return 0.0
+    rx = np.argsort(np.argsort(xs)).astype(float)
+    ry = np.argsort(np.argsort(ys)).astype(float)
+    rx = rx - rx.mean()
+    ry = ry - ry.mean()
+    denom = float(np.sqrt((rx * rx).sum() * (ry * ry).sum()))
+    return float((rx * ry).sum() / denom) if denom > 0 else 0.0
+
+
+def bridge_stability_to_recoverability(
+    a_grid: np.ndarray = None,
+    b_grid: np.ndarray = None,
+    delta_max: float = 2.5,
+    n_delta: int = 25,
+    dt: float = 0.01,
+    full_steps: int = 2000,
+    eps: float = 0.05,
+    n_shuffle: int = 200,
+    seed: int = 0,
+) -> Dict[str, float]:
+    r"""Bridge #1 : ``sigma`` (courbure) -> **portee de recuperation** (falsifiable, #8077 pont 1).
+
+    Echantillonne une grille ``(a, b)`` dans la region bistable de la fronce
+    (symetrique ET asymetrique, pour separer courbure et largeur de bassin).
+    Pour chaque minimum stable ``x*`` : ``sigma = V''(x*)``, ``width`` = demi-
+    largeur vers le col, et une **mesure de recuperation** = fraction d'un
+    balayage de perturbations ``[0, delta_max]`` vers le col dont la relaxation
+    **convergente** revient dans le bassin de ``x*``.
+
+    La relaxation a convergence (``full_steps`` suffisant) est cruciale pour
+    l'honnetete du test : si l'on mesurait la proximite a temps fixe, la
+    recuperation serait monotone en ``sigma`` par construction (taux linearise
+    ``exp(-sigma T)``) -- un pont tautologique. A convergence, seul compte le
+    franchissement du col : la recuperation est gouvernee par la **largeur de
+    bassin**, et la question devient *non triviale* : ``sigma`` predit-il cette
+    portee mieux que la chance ?
+
+    Trois correlations de Spearman (monotones) :
+
+    * ``rho_sigma_recovery`` : la courbure predit-elle la portee de recuperation ?
+    * ``rho_width_recovery`` : la largeur de bassin predit-elle mieux ? (concurrent)
+    * ``rho_sigma_width`` : courbure et largeur sont-elles couplees ? (diagnostic)
+
+    **Test decisif (non threshold-fragile)** : la **correlation partielle**
+    ``partial_rho_sigma_recovery_given_width``. Si elle est ~0, ``sigma`` n'a
+    aucune puissance predictive independante au-dela de la largeur de bassin : la
+    courbure n'est qu'un proxy correle de la portee, et le pont est falsifie.
+
+    Verdict falsifiable
+    -------------------
+    ``bridge_sigma_to_recoverability`` : 1.0 si la correlation partielle de
+        ``sigma`` (controle de la largeur) est **positive et significative**
+        (``partial > 0.2`` et au-dela de son null par brouillage) -- ``sigma``
+        porte une information causale propre sur la recuperation (plus stable =>
+        mieux recupere, au-dela de la largeur). 0.0 sinon : la portee est
+        gouvernee par la **geometrie du bassin** (position du col), et ``sigma``
+        n'est qu'un proxy correle (rho_sigma_width eleve) sans pouvoir explicatif
+        independant. Une correlation partielle **negative** (plus stable =>
+        moins bien recupere en controle de la largeur) falsifie le pont tout
+        autant qu'une partielle nulle. C'est la falsification honnete du pont
+        naif « plus stable => mieux recupere ».
+
+    Le verdict 0 est scientifiquement honnete et **informatif** : sur le substrat
+    fronce, la recuperation apres perturbation finie est une question de
+    **largeur de bassin** (le col est-il franchi ?), pas de raideur locale. La
+    courbure ``sigma`` predit la *vitesse* de retour (par linearisation, hors
+    scope ici) mais non la *portee*. Cf taxonomie ``claim_type`` #7734.
+    """
+    rng = np.random.default_rng(seed)
+    if a_grid is None:
+        a_grid = np.array([-3.0, -2.0, -1.5, -1.0, -0.6])
+    if b_grid is None:
+        b_grid = np.linspace(-0.9, 0.9, 19)
+
+    delta_grid = np.linspace(0.0, float(delta_max), int(n_delta))
+
+    sigmas: List[float] = []
+    widths: List[float] = []
+    recoveries: List[float] = []
+    for a in a_grid:
+        for b in b_grid:
+            for xstar, sigma, width, col in basin_geometry(float(a), float(b)):
+                frac = _recover_fraction(xstar, col, float(a), float(b),
+                                         delta_grid, dt, full_steps, eps)
+                sigmas.append(sigma)
+                widths.append(width)
+                recoveries.append(frac)
+
+    sig = np.asarray(sigmas, dtype=float)
+    wid = np.asarray(widths, dtype=float)
+    rec = np.asarray(recoveries, dtype=float)
+
+    rho_sigma = _spearman(sig, rec)          # pont : courbure -> portee
+    rho_width = _spearman(wid, rec)          # concurrent : largeur -> portee
+    rho_sigma_width = _spearman(sig, wid)    # diagnostic : couplage courbure/largeur
+    partial = _partial_spearman(sig, rec, wid)  # test decisif : sigma | width
+
+    # null du test decisif : brouiller sigma, recompute la partielle.
+    null_partial = np.array([
+        _partial_spearman(rng.permutation(sig), rec, wid) for _ in range(int(n_shuffle))
+    ])
+    p95_partial_null = float(np.percentile(np.abs(null_partial), 95))
+
+    # pont confirme : partial POSITIVE et significative (plus stable => mieux
+    # recupere, au-dela de la largeur). Une partielle nulle (proxy pur) ou
+    # negative (effet inverse) -> falsifie.
+    bridge = 1.0 if (partial > p95_partial_null and partial > 0.2) else 0.0
+
+    return {
+        "n_equilibria": int(sig.size),
+        "delta_max": float(delta_max),
+        "rho_sigma_recovery": float(rho_sigma),
+        "rho_width_recovery": float(rho_width),
+        "rho_sigma_width": float(rho_sigma_width),
+        "partial_rho_sigma_recovery_given_width": float(partial),
+        "partial_null_p95": p95_partial_null,
+        "bridge_sigma_to_recoverability": bridge,
+    }

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_bridge_testing.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_bridge_testing.py
@@ -1,0 +1,123 @@
+"""Tests du module bridge_testing (Epic #8077 — tester les fleches, pas les noeuds).
+
+Verifient le protocole falsifiable du **pont #1** (sigma stabilite ->
+recuperabilite) sur le substrat fronce de Thom, et surtout son **verdict
+honnêtement FALSIFIE** : la recuperation apres perturbation finie est gouvernee
+par la largeur de bassin (position du col), pas par la courbure locale ``sigma``.
+``sigma`` n'a aucune puissance predictive independante (correlation partielle
+~0) -- c'est un proxy correle, non la cause.
+
+C'est le point methodologique de #8077 : un pont qui echoue est aussi
+informatif (distinction toy-model / lien causal) qu'un pont qui tient.
+
+Numpy + pytest. Le module depend de ``catastrophe`` (+ numpy du package).
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ict import bridge_testing as bt  # noqa: E402
+from ict import catastrophe as cat  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+#  Geometrie des bassins : structure bistable vs monostable                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_basin_geometry_bistable_has_col():
+    # region bistable (a<0, petit |b|) : 2 minima + 1 col -> 2 entrees
+    geo = bt.basin_geometry(-2.0, 0.3)
+    assert len(geo) == 2
+    for xstar, sigma, width, col in geo:
+        assert sigma > 0.0          # minimum stable : courbure positive
+        assert width > 0.0          # col a distance finie
+    # le col est commun aux deux bassins (l'equilibre instable du milieu)
+    assert geo[0][3] == pytest.approx(geo[1][3], abs=1e-6)
+
+
+def test_basin_geometry_monostable_empty():
+    # region monostable (a>0) : pas de col -> bassin infini -> hors-scope (vide)
+    assert bt.basin_geometry(1.0, 0.5) == []
+    # au pli exact (discriminant = 0) : pas non plus de col net
+    assert bt.basin_geometry(-1.0, 0.0) != []  # b=0, a<0 : bistable symetrique
+
+
+def test_basin_geometry_width_is_distance_to_col():
+    # la demi-largeur doit egaler |x* - col|
+    geo = bt.basin_geometry(-2.0, 0.6)
+    for xstar, sigma, width, col in geo:
+        assert width == pytest.approx(abs(xstar - col), rel=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+#  GATE (falsifiable) : sigma ne predit pas la portee mieux que la largeur     #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def verdict():
+    # seed 0, deterministe. 126 equilibria sur la grille par defaut.
+    return bt.bridge_stability_to_recoverability(seed=0)
+
+
+def test_bridge_verdict_is_falsified(verdict):
+    """Le pont naif « plus stable => mieux recupere » est FALSIFIE sur la fronce :
+    la portee de recuperation est gouvernee par la largeur de bassin (col), pas
+    par la courbure locale. Verdict honnete = 0.0 (informatif, pas un echec)."""
+    assert verdict["bridge_sigma_to_recoverability"] == 0.0
+
+
+def test_width_dominates_sigma_for_recovery(verdict):
+    """La largeur de bassin predit la portee NETTEMENT mieux que sigma
+    (rho_width >> rho_sigma) -- sigma n'est qu'un proxy correle."""
+    assert verdict["rho_width_recovery"] > verdict["rho_sigma_recovery"]
+    assert verdict["rho_width_recovery"] > 0.95   # portee = f(largeur) quasi-parfaite
+    assert verdict["rho_sigma_recovery"] < 0.98    # sigma : proxy imparfait
+
+
+def test_sigma_has_no_independent_predictive_power(verdict):
+    """LE TEST DECISIF : correlation partielle de sigma (controle largeur) ~ 0.
+    Sigma n'apporte rien au-dela de la largeur -- ce n'est pas la cause."""
+    partial = verdict["partial_rho_sigma_recovery_given_width"]
+    assert abs(partial) < 0.2                       # ~0 (pas de pouvoir independant)
+    assert abs(partial) < verdict["partial_null_p95"]  # sous le null (non significatif)
+
+
+def test_sigma_width_are_correlated_but_not_identical(verdict):
+    """Sigma et largeur sont couplees (rho ~0.93) -- c'est pourquoi sigma a l'air
+    de predire la portee marginal -> c'est le piege que le test partiel detecte."""
+    assert verdict["rho_sigma_width"] > 0.8
+    assert verdict["rho_sigma_width"] < 0.99        # couplees mais distinctes
+
+
+def test_bridge_verdict_robust_across_seeds():
+    """Le verdict falsifie n'est pas un point-artefact (c.1014-L) : il tient sur
+    plusieurs graines (le null est shuffle-dependant, la conclusion non)."""
+    verdicts = [bt.bridge_stability_to_recoverability(seed=s)["bridge_sigma_to_recoverability"]
+                for s in (0, 1, 2)]
+    assert all(v == 0.0 for v in verdicts)
+
+
+# --------------------------------------------------------------------------- #
+#  Cohérence interne : la recuperation est bien une fonction de largeur        #
+# --------------------------------------------------------------------------- #
+
+
+def test_recovery_fraction_zero_when_delta_exceeds_width():
+    """Sanity : une perturbation franchissant le col perd le bassin (portee bornee
+    par la largeur), une perturbation inferieure revient."""
+    geo = bt.basin_geometry(-2.0, 0.3)
+    xstar, sigma, width, col = geo[0]
+    a, b = -2.0, 0.3
+    # petite perturbation (sous la largeur) -> revient
+    small = cat.relax_to_equilibrium(xstar + 0.1 * np.sign(col - xstar), a, b, dt=0.01, steps=2000)
+    assert abs(small - xstar) < 0.1
+    # perturbation au-dela de la largeur -> bascule dans l'autre bassin
+    big = cat.relax_to_equilibrium(xstar + (width + 0.5) * np.sign(col - xstar), a, b, dt=0.01, steps=2000)
+    assert abs(big - xstar) > 0.3   # perdu : beaucoup plus loin de x*


### PR DESCRIPTION
## #8077 — Bridge-testing protocol, pont #1 σ→recouvrabilité → **FALSIFIÉ** (honnête)

**Grain:** DEEP/research-code · **Lane:** myia-po-2024:CoursIA-2 · **See** #8077 (arc multi-ponts, 1 pont/PR) · **Prev** #8942 (ICT-12c panel, LGTM)

### Ce que c'est

#8077 (retour externe ChatGPT) : la série ICT valide chaque brique localement (un σ, un SAE, un workspace, un MDL, un Φ), mais l'ambition unificatrice repose sur les **flèches** (transitions) — et ce sont elles qui portent le risque. Cette PR livre le **premier pont** au rythme prescrit par l'issue (« un pont par PR »), comme protocole falsifiable explicite : hypothèse + modèle nul + intervention + verdict.

### Pont #1 — σ (stabilité) → recouvrabilité, substrat fronce de Thom

**Hypothèse naïve** : un équilibre plus stable (bassin plus raide, courbure `V''(x*)` grande) se répare mieux après perturbation.

**Instrumenté AVANT d'asserter (C976-L)** : deux notions de récupération se séparent sur la fronce asymétrique :
- **vitesse** à temps de relaxation fixe = monotone en σ **par construction** (taux linearisé = σ) → pont tautologique.
- **portée** (la perturbation franchit-elle le col ? perd-on le bassin ?) = gouvernée par la **largeur de bassin** (distance `x* → col`), pas σ.

Le protocole mesure la récupération comme la **fraction d'un balayage de perturbations à convergence complète** qui revient au bassin (portée, non tautologique) et utilise la **corrélation partielle de Spearman** (σ | largeur) comme test décisif (non threshold-fragile).

### Le finding honnête — pont FALSIFIÉ (`bridge_sigma_to_recoverability = 0.0`)

| Mesure | Valeur | Lecture |
|---|---|---|
| `rho_sigma_recovery` | 0.92 | σ a l'air prédictif |
| `rho_width_recovery` | 0.996 | la largeur prédit la portée quasi-parfaitement |
| `rho_sigma_width` | 0.93 | σ et largeur couplées (le piège) |
| **`partial(σ | width)`** | **−0.062 ≈ 0** | **σ n'a AUCUNE puissance prédictive indépendante** |

**Verdict** : la récupération après perturbation finie est gouvernée par la **géométrie du bassin** (position du col), pas par la raideur locale. σ n'est qu'un **proxy corrélé** (ρ=0.93), non la cause. Le pont naïf « plus stable ⇒ mieux récupéré » confond raideur locale et robustesse de bassin.

### Robustesse (c.1014-L — pas un point-artefact)

- **Seed** {0,1,2,3,7,42} → bridge=0 partout (partial=−0.062, déterministe).
- **delta_max** {1.5,2.0,2.5,3.0,4.0} → bridge=0 partout. Le sweep delta_max a **attrapé un bug de signe** (logic `abs(partial)` initial) : aux extrêmes la partielle devient négative (plus stable ⇒ *moins* bien récupéré en contrôle de largeur) — ce qui falsifie aussi, ne confirme pas. Verdict corrigé : **partielle positive et significative** requise pour confirmer.

Un pont falsifié est **aussi informatif** qu'un pont confirmé (distinction toy-model / lien causal, taxonomie `claim_type` #7734).

### Preuve

9/9 bridge_testing PASS + 53/53 catastrophe/free_energy consommateurs PASS (**0 régression**). Substrat = primitives `catastrophe` existantes (`cusp_curvature`, `cusp_equilibria`, `relax_to_equilibrium`) — 0 nouvel infra.

### Livrable

`ict/bridge_testing.py` (module + protocole pont #1, ~250l) + `tests/test_bridge_testing.py` (9 tests) + registration `ict/__init__.py`. `See #8077` (arc multi-ponts, les 4 ponts restants = PRs séparés).

See #8077 (arc, pont 1/5) · #7734 (claim_type) · #4588 · lane myia-po-2024:CoursIA-2
