### PR TITLE
feat(gametheory_lean): punishment_gt_sucker — complete PD inequality sibling family (2/3→3/3)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Stage.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Stage.lean
@@ -68,4 +68,8 @@ lemma mutual_coop_better_than_mutual_defect (g : PrisonersDilemma) :
 /-- Le paiement de déviation `T` est strictement supérieur à `R`. -/
 lemma temptation_gt_reward (g : PrisonersDilemma) : g.T > g.R := g.hTR
 
+/-- Le paiement de punition `P` est strictement supérieur à `S`
+(Punishment > Sucker). -/
+lemma punishment_gt_sucker (g : PrisonersDilemma) : g.P > g.S := g.hPS
+
 end RepeatedGames

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Stage_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Stage_en.lean
@@ -94,4 +94,8 @@ lemma mutual_coop_better_than_mutual_defect (g : PrisonersDilemma) :
 /-- The deviation payoff `T` is strictly greater than `R`. -/
 lemma temptation_gt_reward (g : PrisonersDilemma) : g.T > g.R := g.hTR
 
+/-- The punishment payoff `P` is strictly greater than `S`
+(Punishment > Sucker). -/
+lemma punishment_gt_sucker (g : PrisonersDilemma) : g.P > g.S := g.hPS
+
 end RepeatedGames_en


### PR DESCRIPTION
Grain: MED/Lean — lane myia-po-2023:CoursIA — prev: MED/docs (#8941/PR #8943)

See #4365

## Summary

`game_theory_lean/RepeatedGames/Stage.lean` exposes 3 of the 4 `PrisonersDilemma` structure fields as named consumer lemmas, but only **2 of the 3 ordinal-inequality siblings** are named. The `defect_strictly_dominates` docstring (L54-57) cites **both** `T > R` and `P > S` symmetrically, yet the author named only the `T > R` half (`temptation_gt_reward`) and left `P > S` as an inline `exact g.hPS` (L62). This PR closes the obvious gap: the missing third sibling.

| Sibling | Statement | Status before | After |
|---------|-----------|---------------|-------|
| `temptation_gt_reward` | `T > R` | named (`:= g.hTR`, L69) | unchanged |
| `mutual_coop_better_than_mutual_defect` | `R > P` | named (`:= g.hRP`, L66) | unchanged |
| **`punishment_gt_sucker`** | **`P > S`** | **inline only** (`exact g.hPS`, L62) | **named (`:= g.hPS`)** |

Byte-identical one-liner shape to the existing two siblings.

## G.1 firsthand (claim verified against source, not propagated by trust)

- `g.hPS : P > S` is the `PrisonersDilemma` structure field — confirmed at `Stage.lean:37` (FR) and `Stage_en.lean:63` (EN).
- `g.hPS` **already compiles inline**: `defect_strictly_dominates` uses `exact g.hPS` (FR L62, EN L88) to discharge the `defect/defect` branch, which reduces by `simp only [stagePayoff]` to exactly `g.P > g.S`. The expression type-checks today.
- `punishment_gt_sucker` is **not already named**: `git grep punishment_gt_sucker` over `game_theory_lean/**/*.lean` returns empty.
- The 2 existing siblings confirmed at FR L66/L69 and EN L92/L95 — same module, same author intent, same one-liner shape.

## i18n sibling pair (EPIC #4980 Pattern A)

`scripts/lean/check_i18n_siblings.py` on the `Stage`/`Stage_en` pair:
```
OK      .../RepeatedGames/Stage_en.lean
1/1 pairs byte-identical | 0 drift
```
The FR (namespace `RepeatedGames`) and EN (namespace `RepeatedGames_en`) differ only on docstrings FR↔EN + the namespace suffix — the new lemma is byte-identical on signature/proof across both.

## Honesty note on the build

No warm `.lake/mathlib` cache for `game_theory_lean` on po-203 this cycle (mathlib clone ~20 Go would be disproportionate for a one-liner). **`g.hPS` already type-checks inline** at L62/L88, so the named declaration `:= g.hPS` mechanically cannot fail. Per `lean-merge-discipline`, the mergeur (ai-01) runs `lake build RepeatedGames.Stage` locally pre-merge — I am not claiming a build I did not run.

## Scope / orthogonality

Additive only: **+8 / −0**, 2 files, 0 existing proof/signature/tactic modified (anti-régression §D clean). Sorry count unchanged (0 real tactic `sorry` in this module). Collision guard `gh pr list --search RepeatedGames`: 30 historical PRs, all MERGED, **0 OPEN**. Completes a family established by the lake owner (#6146); module stable & sorry-free since absorption.

## Turf / ack request

`game_theory_lean` is EPIC #4365 (jsboige consolidation turf). This is **additive** (completes an obvious 2/3→3/3 sibling family, not new content) and the module is stable, but — as with #8928 (`kelly_growth_nonneg`) — **ack requested from jsboige/ai-01 for the merge**. Not merge-forced.

See #4365, #4980.
