### PR TITLE
ci(secu,#8949): harden GITHUB_TOKEN scope on Lean CI workflows — contents:read on 22 callers + drop dead pull-requests:write

### DIFF
--- a/.github/workflows/lean-argumentation.yml
+++ b/.github/workflows/lean-argumentation.yml
@@ -28,6 +28,9 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -65,7 +65,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   ci:

--- a/.github/workflows/lean-calibration.yml
+++ b/.github/workflows/lean-calibration.yml
@@ -36,6 +36,9 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-conway-cgt.yml
+++ b/.github/workflows/lean-conway-cgt.yml
@@ -21,6 +21,9 @@ on:
       - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -63,6 +63,9 @@ on:
       - 'scripts/lean/check_target_coverage.py'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-decision-theory.yml
+++ b/.github/workflows/lean-decision-theory.yml
@@ -40,6 +40,9 @@ on:
       - 'MyIA.AI.Notebooks/Probas/decision_theory_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-erc20.yml
+++ b/.github/workflows/lean-erc20.yml
@@ -37,6 +37,9 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-finiteness.yml
+++ b/.github/workflows/lean-finiteness.yml
@@ -32,6 +32,9 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-game-defs-ext.yml
+++ b/.github/workflows/lean-game-defs-ext.yml
@@ -23,6 +23,9 @@ on:
       - 'MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-game-defs.yml
+++ b/.github/workflows/lean-game-defs.yml
@@ -27,6 +27,9 @@ on:
       - 'MyIA.AI.Notebooks/GameTheory/lean_game_defs/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-game-theory.yml
+++ b/.github/workflows/lean-game-theory.yml
@@ -78,6 +78,9 @@ on:
       - '.github/workflows/lean-game-theory.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-grothendieck.yml
+++ b/.github/workflows/lean-grothendieck.yml
@@ -40,6 +40,9 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-kelly.yml
+++ b/.github/workflows/lean-kelly.yml
@@ -30,6 +30,9 @@ on:
       - 'MyIA.AI.Notebooks/QuantConnect/kelly_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -83,6 +83,9 @@ on:
       - 'scripts/lean/check_target_coverage.py'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-learning-theory.yml
+++ b/.github/workflows/lean-learning-theory.yml
@@ -34,6 +34,9 @@ on:
       - 'MyIA.AI.Notebooks/ML/learning_theory_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-mathlib-examples.yml
+++ b/.github/workflows/lean-mathlib-examples.yml
@@ -21,6 +21,9 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-minimax.yml
+++ b/.github/workflows/lean-minimax.yml
@@ -33,6 +33,9 @@ on:
       - 'MyIA.AI.Notebooks/GameTheory/minimax_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-planning.yml
+++ b/.github/workflows/lean-planning.yml
@@ -30,6 +30,9 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-search.yml
+++ b/.github/workflows/lean-search.yml
@@ -32,6 +32,9 @@ on:
       - 'MyIA.AI.Notebooks/Search/search_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-sensitivity.yml
+++ b/.github/workflows/lean-sensitivity.yml
@@ -21,6 +21,9 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-social-choice-peters.yml
+++ b/.github/workflows/lean-social-choice-peters.yml
@@ -21,6 +21,9 @@ on:
       - 'MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-social-choice.yml
+++ b/.github/workflows/lean-social-choice.yml
@@ -23,6 +23,9 @@ on:
       - 'MyIA.AI.Notebooks/GameTheory/game_theory_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   fail-on-sorry:
     name: "Proof integrity (no sorry)"

--- a/.github/workflows/lean-sudoku.yml
+++ b/.github/workflows/lean-sudoku.yml
@@ -26,6 +26,9 @@ on:
       - 'MyIA.AI.Notebooks/Sudoku/sudoku_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2023:CoursIA — prev: MED/Lean (#8946 MERGED)

See #8949

## Summary

Tranche 1 of #8949 (Lean callers + the shared reusable). The repo default
workflow permission is `write`, so every workflow without an explicit
`permissions:` block inherits a GITHUB_TOKEN that can push to the repo. **22
Lean caller workflows + the `lean-build.yml` reusable use no token at all**
yet carried that scope — a real attack-surface reduction, not cosmetics
(flagged by CodeQL on #8948 as `actions/missing-workflow-permissions`).

Tagged LIGHT/guard at the #8949 litmus (scan-generable mechanics) but the
substance is security hardening: each file was audited for real token use
before restricting it, per the ai-01 trap in #8949 ("before restricting a
caller, grep the reusable for its real token use").

## Changes (+66/−1, 23 files)

1. **`lean-build.yml`** — drop dead `pull-requests: write` → `contents: read`
   only. The reusable posts no comment, runs no `gh`, no `actions/github-script`
   (grep-verified firsthand). The grant was copied from a workflow that did
   comment; dead over-grant.
2. **22 `lean-*.yml` callers** — add `permissions: { contents: read }`. All
   token-less (verified line by line). Full list in the commit message.

## G.1 firsthand (the trap, audited not assumed)

- Repo workflow count: **60** (30 with a permissions block, 30 without)
  *(re-measured firsthand on origin/main; my earlier `42/14/28` did not reproduce —
  corrected per ai-01 review, same defect-class as #8943).*
- Token-use audit of the 30 without a block: only `secret-scan.yml` (gitleaks) and, on a first
  grep, `lean-social-choice.yml`. **Re-checked lean-social-choice.yml line by
  line**: the sole match is a COMMENT (L100 `# propagate lake's exit code…
  see lean-build.yml fix`) — it is token-less, so `contents: read` is safe. The
  first grep was a false positive on "lean-build.yml" in the comment. Assuming
  a token and skipping it, or over-granting it, were both wrong; verified
  token-less → `contents: read`.
- `lean-build.yml`: 0 token use (all other hits are sorry-mode docstring
  prose) → `pull-requests: write` is dead.
- **`lean-axiom.yml` left UNTOUCHED** — it already carries `{contents: read,
  pull-requests: write}` and is a proof-integrity gate (legitimate use, out of
  this tranche).

## Validation

`python yaml.safe_load` on all 24 `lean-*.yml` → **0 bad**; every modified file
parses with `permissions == {contents: read}`; formatting verified (blank line
separates the block from `on:` above and `jobs:` below, matching `lean-build`
style — no `contents: read\njobs:` adjacency).

## Scope vs #8949

| #8949 point | This PR |
|---|---|
| 1. `contents: read` on token-less workflows | ✅ Lean family (22 callers) |
| 2. `secret-scan.yml` gitleaks scope | ⏳ tranche 2 — to **measure**, not assume |
| 3. `lean-build.yml` dead grant | ✅ done |
| 4. CodeQL no longer raises | will confirm on this PR's CodeQL run |

**Left for tranche 2**: the **8** non-Lean workflows still without a `permissions:`
block — `docs-link-check`, `ml-tests`, `notebook-navlink-check`,
`notebook-validation`, `owui-playwright-check`, `scripts-tests`, `secret-scan`,
`validation-matrix` (30 without − 22 Lean callers = 8, re-counted firsthand).
**`secret-scan.yml` is the only token-consumer** of those 8 (`GITHUB_TOKEN` →
gitleaks) — point 2 of #8949: it needs a scope **derived from real usage, to
measure**, not `contents: read` by copy-paste. **Out of scope**: the repo setting
`can_approve_pull_request_reviews` (owner-only, #8949).

See #8949, #8948.

Co-Authored-By: Claude-Code <noreply@anthropic.com>

