### PR TITLE
fix(ci,#8949): add explicit permissions to the 8 token-scope-less workflows

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -10,6 +10,9 @@ on:
       - '**/README.md'
       - 'scripts/check_docs_links.py'
 
+permissions:
+  contents: read
+
 jobs:
   check-links:
     runs-on: ubuntu-latest

--- a/.github/workflows/ml-tests.yml
+++ b/.github/workflows/ml-tests.yml
@@ -17,6 +17,9 @@ on:
       - '.github/workflows/ml-tests.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ml-tests:
     name: ML Pipeline Tests (CPU)

--- a/.github/workflows/notebook-navlink-check.yml
+++ b/.github/workflows/notebook-navlink-check.yml
@@ -20,6 +20,9 @@ on:
       - 'scripts/tests/baseline_nb_navlinks.json'
       - '.github/workflows/notebook-navlink-check.yml'
 
+permissions:
+  contents: read
+
 jobs:
   check-navlinks:
     runs-on: ubuntu-latest

--- a/.github/workflows/notebook-validation.yml
+++ b/.github/workflows/notebook-validation.yml
@@ -11,6 +11,9 @@ on:
       - '**.ipynb'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate-notebooks:
     runs-on: ubuntu-latest

--- a/.github/workflows/owui-playwright-check.yml
+++ b/.github/workflows/owui-playwright-check.yml
@@ -30,6 +30,9 @@ defaults:
   run:
     working-directory: MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI
 
+permissions:
+  contents: read
+
 jobs:
   compile-collect:
     name: Compile & Collect (no live server)

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -51,6 +51,9 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_forensic_guards.py'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   scripts-tests:
     name: Scripts Tests (CPU)

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   gitleaks:
     name: Gitleaks secret scanner

--- a/.github/workflows/validation-matrix.yml
+++ b/.github/workflows/validation-matrix.yml
@@ -23,6 +23,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-dotnet (#8906)

# #8949 — close the 8 remaining workflows missing a `permissions:` block

## Re-measured firsthand (the issue's 30 is stale)

#8949 reported **30/60** workflows without a top-level `permissions:` block, running on the repo default of `write` (`gh api .../permissions/workflow` -> `{"default_workflow_permissions":"write"}`). Re-measured on `origin/main` after **#8948** (merged today, the lean-game-theory migration) already added `permissions:` to the 22 Lean callers and stripped the dead `pull-requests: write` grant from `lean-build.yml`:

```
workflows WITH top-level permissions:  52 / 60
workflows WITHOUT                      :  8 / 60   <- this PR
```

So the remaining surface is 8, not 30. This PR closes all 8.

## The 8 + the scope decision

Token usage of each was measured exhaustively (grep for `GITHUB_TOKEN`, `secrets.`, `gh `, `github-script`, comment-posting actions):

| workflow | token usage | granted scope | rationale |
|---|---|---|---|
| docs-link-check | none | `contents: read` | runs `python scripts/check_docs_links.py` |
| ml-tests | none | `contents: read` | pytest only |
| notebook-navlink-check | none | `contents: read` | stdlib checker |
| notebook-validation | none | `contents: read` | nbformat validation |
| owui-playwright-check | none | `contents: read` | `tsc --noEmit` + `playwright test --list` |
| scripts-tests | none | `contents: read` | pytest only |
| validation-matrix | none | `contents: read` | checker only |
| **secret-scan** | **`GITHUB_TOKEN` -> gitleaks-action@v2** | `contents: read` + **`pull-requests: write`** | gitleaks posts PR review comments with the token it's handed |

The 7 token-less workflows get the least-privilege `contents: read`. **`secret-scan.yml` keeps `pull-requests: write`** deliberately: `gitleaks-action@v2` uses the `GITHUB_TOKEN` to post inline review comments on PRs, and dropping that grant would silently break the comment (the exact runtime-only failure the issue's "piege" section warns against — permissions don't propagate back up the call chain, and an over-restriction breaks quietly).

## Not touched here

- The 52 workflows that already have a `permissions:` block (including `lean-build.yml`, fixed in #8948, and all Lean callers).
- No caller of `lean-build.yml` is modified — a caller's `permissions:` only *caps* what the reusable receives, and since `lean-build.yml` uses no token, the existing callers are unaffected.
- The repo setting `can_approve_pull_request_reviews: true` is out of scope (owner-only) and flagged in #8949 for a separate decision.

## Verification

- All **60/60** workflows now carry a top-level `permissions:` block (script verified).
- Each new block sits between `on:` and `jobs:` (the `banner-guard.yml` / `lean-build.yml` convention).
- **PyYAML parses** every modified file (YAML validity).
- **Additive only**: 8 files, +25/-0 (no existing line removed or reordered).
- CodeQL `actions/missing-workflow-permissions` should no longer fire on these files (the gate that surfaced the issue on #8948).

See #8949, #8948.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
