### PR TITLE
docs(notebook_tools,#8957): document rebaseline-after-strip ordering trap in twin-parity gate

### DIFF
--- a/scripts/notebook_tools/README.md
+++ b/scripts/notebook_tools/README.md
@@ -393,6 +393,23 @@ python scripts/notebook_tools/check_twin_parity.py --update
 python scripts/notebook_tools/check_twin_parity.py --json
 ```
 
+> **Ordre des outils** (#8957) : `--update` ecrit le **git blob SHA** courant des
+> jumeaux. Toute edition du notebook deplace ce blob -- y compris une
+> normalisation outillee qui ne touche aucun contenu calcule
+> (`strip_probe_banner.py`, `strip_machine_paths.py`, `scrub_papermill_paths.py`).
+> Le rebaseline va donc **en dernier**, apres toute mutation du notebook, sinon
+> l'attestation est invalidee par le strip qui suit et le gate `--per-pair` sort
+> DRIFT-INTRO :
+>
+>     1. re-exec locale (.net-csharp / papermill)
+>     2. normalisations outillees (strip_probe_banner.py --apply, ...)
+>     3. check_twin_parity.py --update   <-- TOUJOURS en dernier
+>
+> Inverser les etapes 2 et 3 (attester la parite PUIS stripper le banner) est le
+> reflexe naturel et le piege exact : la parite est vraie, mais son empreinte a
+> bouge, et le worker comme le coordinateur ne peuvent le deviner sans relire
+> cette sequence.
+
 ### CI integration (`.github/workflows/twin-parity.yml`, c.818)
 
 Le workflow `.github/workflows/twin-parity.yml` **fail** toute PR qui
@@ -401,7 +418,7 @@ exemple un fix doc-honesty sur un seul cote), le worker doit :
 
 1. **Re-auditer la paire firsthand** (lecture cellule-par-cellule des deux
    jumeaux, verdict ecrit dans `known_differences` du registre).
-2. **Rebaseline les SHAs** : `python scripts/notebook_tools/check_twin_parity.py --update [--family ...]`.
+2. **Rebaseline les SHAs** : `python scripts/notebook_tools/check_twin_parity.py --update [--family ...]`. **En dernier** -- apres toute normalisation outillee du notebook (`strip_probe_banner.py --apply` deplace le blob SHA ; cf. *Ordre des outils* ci-dessus, #8957).
 3. Committer le registre rebaseline **dans la meme PR** que l'edit du cote
    modifie (le PR porte a la fois le diff du notebook et le diff du
    registre).
@@ -456,7 +473,11 @@ les outputs.
 - Hook CI : `.github/workflows/banner-guard.yml`
 
 **Hook executant** : la re-execution d'un notebook .NET re-injecte le
-banner. Toujours `--apply` apres chaque re-exec .NET avant commit.
+banner. Toujours `--apply` apres chaque re-exec .NET avant commit. Si le
+notebook a un jumeau (registre `twin_pairs.d/`), `--apply` deplace son git
+blob SHA : rebaselinez la parite (`check_twin_parity.py --update`) **apres**
+le strip, jamais avant -- sinon le strip invalide l'attestation et le gate
+sort DRIFT-INTRO (#8957).
 
 ### `strip_machine_paths.py`, `scrub_papermill_paths.py`
 

--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -78,6 +78,12 @@ Usage
     # les 116 paires, --by evite d'heriter de l'auteur de l'audit precedent.
     python check_twin_parity.py --update --pair "Probas-4 Bayesian-Networks" \
         --by "myia-po-2024:CoursIA-2"
+    # ORDRE (#8957) : --update ecrit le git blob SHA courant du notebook ; toute
+    # mutation POSTERIEURE (strip_probe_banner.py --apply, strip_machine_paths.py,
+    # scrub_papermill_paths.py) deplace ce blob et invalide l'attestation. Donc
+    # --update va EN DERNIER, apres toute normalisation outillee. Inverser
+    # l'ordre (attester PUIS stripper) laisse le gate --per-pair sortir DRIFT-INTRO
+    # sur une parite pourtant vraie.
     # sortie machine
     python check_twin_parity.py --json
     # recenser les paires reelles absentes du registre (angle mort)
@@ -742,6 +748,20 @@ def main(argv=None) -> int:
                   f"OK={n_ok} INTRO={n_introduced} FIXED={n_resolved} PRE={n_pre_existing}")
 
         if args.check and n_introduced > 0:
+            if args.per_pair:
+                # Le DRIFT d'une normalisation outillee (strip_probe_banner.py --apply,
+                # strip_machine_paths.py, scrub_papermill_paths.py) deplace le blob SHA
+                # SANS toucher le contenu calcule : la parite est vraie, c'est son
+                # empreinte qui a bouge. Dans ce cas le rebaseline --update va EN DERNIER,
+                # apres ces strips, sinon l'attestation est invalidee par le strip qui suit
+                # (piege naturel, #8957).
+                print(
+                    "\nRappel : si le DRIFT vient d'une normalisation outillee qui "
+                    "deplace le blob SHA (strip_probe_banner.py --apply, "
+                    "strip_machine_paths.py, scrub_papermill_paths.py), le rebaseline "
+                    "--update va EN DERNIER, apres ces strips -- attester PUIS "
+                    "stripper invalide l'attestation (#8957)."
+                )
             return 1
         return 0
 


### PR DESCRIPTION
Grain: LIGHT/doc — lane myia-po-2024:CoursIA-2 — prev: LIGHT/guard (#8958)

# #8957 — document the rebaseline-after-strip ordering trap in the twin-parity gate

## The trap (re-measured firsthand)

`check_twin_parity.py` stores the **git blob SHA** of each twin notebook and attests parity against that SHA. `--update` rebaselines by writing the **current** blob SHA. Any notebook mutation moves the blob SHA — **including a tooled normalization that touches no computed content** (`strip_probe_banner.py --apply`, `strip_machine_paths.py`, `scrub_papermill_paths.py`).

The natural reflex is: rebaseline **first** (attest parity), *then* strip the banner. That order is the exact trap the issue names: the strip that follows invalidates the attestation, and the per-pair gate then exits **DRIFT-INTRO**. #8957 traces this to a real incident on #8906 (Infer-4), where the `.net-csharp` re-exec mechanically re-injected the `probeAddresses` banner and the rebaseline was applied before the strip.

## The fix: docs + gate hint (no guard)

Acceptance points closed:

1. **Canonical sequence in BOTH README sections** (`scripts/notebook_tools/README.md`):
   - the parity section (next to the `--update` usage): a callout block with the ordered 3-step recipe (`re-exec → tooled normalizations → rebaseline`) and an explanation of why inverting steps 2-3 is the reflex *and* the trap.
   - the strip section (`strip_probe_banner.py` "Hook exécutant"): extended with "if the notebook has a twin, `--apply` moves its blob SHA → rebaseline **after** the strip, never before".
   - CI integration step 2 ("Rebaseline les SHAs") reinforced with "En dernier — après toute normalisation outillée".

2. **Ordering constraint in the gate output itself** (`check_twin_parity.py`):
   - `--update` docstring/help: an `# ORDRE (#8957)` note block.
   - **At the bottom of the per-pair gate output** (the `--check --per-pair` failure path, `return 1`): a "Rappel" line that prints exactly when the user reads the red DRIFT-INTRO verdict — "le rebaseline `--update` va EN DERNIER, après ces strips — attester PUIS stripper invalide l'attestation".

3. **Optional pre-commit guard deliberately NOT added.** The issue explicitly scopes this as "à ne faire que si c'est détectable sans faux positif — sinon la doc suffit, et un garde fragile est pire que pas de garde." A guard that fires on `strip_probe_banner.py --apply` would false-positive on every legitimate tooled normalization (the normal case), so it is worse than no guard. Docs + gate hint are the durable fix.

## No behaviour change

`check_twin_parity.py` logic is untouched. The only code addition is a **diagnostic `print()` before the existing `return 1`** (per-pair, DRIFT-INTRO branch) — same exit code, same verdicts, just a one-line nudge appended to the failure output. Plus docstring/README text.

## Verification

- `ast.parse` OK on `check_twin_parity.py`.
- Live gate test (run the branch's tool from the full repo): `check_twin_parity.py --check --per-pair --base origin/main` prints the Rappel at `exit 1` (82 DRIFT-INTRO pairs in the diverged full-repo working state — owner-locked Tweety/Z3 work, untouched by this PR).
- Acceptance #1 (sequence in both sections) confirmed via `grep` (2 hits: parity section + strip section).
- Diff: `README.md` +25/-2, `check_twin_parity.py` +20/-0. Two files, no existing logic removed.

See #8957.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

