### PR TITLE
docs(lean,#2159): resync navmap grothendieck_lean sur l'etat mesure (32->33 modules, 26 modules de derive de numerotation documentes)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap.lean
@@ -90,12 +90,15 @@ open AlgebraicGeometry CategoryTheory
 #check Scheme.forgetToLocallyRingedSpace  -- Scheme ⥤ LocallyRingedSpace
 
 /-!
-## Ce que Mathlib n'a PAS ENCORE (état 2026-05)
+## Ce que Mathlib n'a PAS ENCORE (état 2026-07)
 
 Les concepts fondamentaux de Grothendieck qui ne sont PAS encore dans Mathlib :
   - Cohomologie étale (site étale, cohomologie l-adique)
   - Motifs (motifs purs, catégorie DM de Voevodsky)
-  - Six opérations (formalisme de Grothendieck)
+  - Six opérations (formalisme complet de Grothendieck) — Mathlib fournit
+    l'instance de base `f^* ⊣ f_*` sur les faisceaux de modules
+    (`AlgebraicGeometry.Modules.Sheaf`, indexée par `DirectImage.lean`) ;
+    `f_!` / `f^!` et le formalisme complet restent absents
   - Grothendieck-Riemann-Roch
   - Dualité de Grothendieck
   - Cohomologie cristalline

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap_en.lean
@@ -84,12 +84,15 @@ Mathlib 4 has a rich category theory library built on these ideas.
 #check Scheme.forgetToLocallyRingedSpace  -- Scheme ⥤ LocallyRingedSpace
 
 /-!
-## What Mathlib does NOT have yet (as of 2026-05)
+## What Mathlib does NOT have yet (as of 2026-07)
 
 The following are foundational Grothendieck concepts NOT yet in Mathlib:
   - Etale cohomology (site etale, l-adic cohomology)
   - Motives (pure motives, Voevodsky's DM category)
-  - Six operations (Grothendieck's formalism)
+  - Six operations (Grothendieck's full formalism) — Mathlib provides the base
+    instance `f^* ⊣ f_*` on module sheaves (`AlgebraicGeometry.Modules.Sheaf`,
+    indexed by `DirectImage_en.lean`); `f_!` / `f^!` and the full formalism
+    remain absent
   - Grothendieck-Riemann-Roch
   - Grothendieck duality
   - Crystalline cohomology

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
@@ -5,10 +5,10 @@ Alexandre Grothendieck (1928-2014).
 ## Status
 
 - **Toolchain**: `leanprover/lean4:v4.31.0-rc1`
-- **Sorry**: **0 sorry, 0 axiom** — all 32 leaf modules are complete at creation (Parts 1-32 merged)
-- **Build**: `lake build Grothendieck` — compiles the 32 leaf modules (~10783 FR+EN lines, verified post-c.745 #7856)
+- **Sorry**: **0 sorry, 0 axiom** — all 33 leaf modules are complete at creation
+- **Build**: `lake build Grothendieck` — compiles the 33 leaf modules (11,206 FR+EN lines, + 208 for the umbrella = **11,414 total**, measured 2026-07-30)
 - **Dependencies**: Mathlib 4 (via `lakefile.lean`)
-- **i18n coverage (EPIC #4980, ratified 2026-07-04)**: complete bilingual FR/EN coverage — **33 FR files** (1 umbrella `Grothendieck.lean` bilingual inline FR+EN + **32 leaf modules** FR canonical) + **32 `_en.lean` siblings** on `main` (leaf modules only; the umbrella is bilingual inline). Per the ratified convention (Option A: `Foo.lean` FR canonical + `Foo_en.lean` EN mirror for leaves), **all 32 leaf modules** are bilingual in Pattern A (`_en` namespaces anti-collision, non-docstring content byte-identical CI-detectable). The umbrella `Grothendieck.lean` is bilingual inline (FR canonical first, EN mirror, see final doctring in the file) — *by design*, not an i18n gap. **`README.md`** present (FR canonical sibling of this file). Out-of-scope: `.lake/packages/`, vendored libs.
+- **i18n coverage (EPIC #4980, ratified 2026-07-04)**: complete bilingual FR/EN coverage — **34 FR files** (1 umbrella `Grothendieck.lean` bilingual inline FR+EN + **33 leaf modules** FR canonical) + **33 `_en.lean` siblings** on `main` (leaf modules only; the umbrella is bilingual inline). Per the ratified convention (Option A: `Foo.lean` FR canonical + `Foo_en.lean` EN mirror for leaves), **all 33 leaf modules** are bilingual in Pattern A (`_en` namespaces anti-collision, non-docstring content byte-identical CI-detectable). The umbrella `Grothendieck.lean` is bilingual inline (FR canonical first, EN mirror, see final doctring in the file) — *by design*, not an i18n gap. **`README.md`** present (FR canonical sibling of this file). Out-of-scope: `.lake/packages/`, vendored libs.
 
 ## Purpose
 
@@ -26,20 +26,26 @@ The goal is to give learners a curated entry point into:
 
 ## Structure
 
-The formalization spans **32 leaf modules (Parts 1-32, ~10783 FR+EN lines, 0 sorry)**, imported
-in order by the umbrella `Grothendieck.lean` (which is itself bilingual inline FR/EN; no `_en` sibling for the umbrella). Each leaf module self-numbers via its header
-(`Grothendieck tribute — Part N`).
+The formalization spans **33 leaf modules (11,206 FR+EN lines, 0 sorry)**, imported
+in order by the umbrella `Grothendieck.lean` (which is itself bilingual inline FR/EN; no `_en` sibling for the umbrella).
+
+> **Two numberings coexist, and they do not agree.** The `Part` column below is the **import
+> order** in the umbrella; each file's header carries a *separate* `Part` number, inherited from
+> its authoring phase, which diverges from the import order on **26 of the 33 modules** and
+> contains duplicates (`Part 26` ×3, `Part 27` ×2). The `## References` section and the
+> `### The arc` section below refer to the **header** numbering, not to this table's.
+> Reconciliation tracked by #8960.
 
 | Part | File | `_en` | Content | Lines |
 |------|------|-------|---------|-------|
-| root | `Grothendieck.lean` | (bilingual inline) | **Umbrella root** (imports-only of the 32 leaves + bilingual FR/EN doctring lines 32-205); no `_en` sibling (the EN content lives in the same file as a mirror) | 207 |
+| root | `Grothendieck.lean` | (bilingual inline) | **Umbrella root** (imports-only of the 33 leaves + bilingual FR/EN doctring); no `_en` sibling (the EN content lives in the same file as a mirror) | 208 |
 | 1 | `Grothendieck/CategoryAndSites.lean` | `CategoryAndSites_en.lean` | Sieves, Grothendieck topologies (trivial/discrete/dense), three axioms | 243 |
 | 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Scheme type, Spec functor, Γ, `homeoOfIso`, fully-faithful | 109 |
 | 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Zariski pretopology, `zariskiTopology_eq` bridge theorem, subcanonical | 93 |
 | 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | `#check` index of Grothendieck-related Mathlib definitions | 107 |
 | 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 micro-proof targets for the prover harness (Epic #1453) | 95 |
 | 6 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjunction of functors, unit/counit, turtle lemma, left/right adjoints | 168 |
-| 7 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Sieve pullback identities: `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone` | 103 |
+| 7 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Sieve pullback identities: `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895) | 164 |
 | 8 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 148 |
 | 9 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Topology ordering, covering closure, sieve composition | 141 |
 | 10 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-to-topology, sheaf characterization, sup of coverages | 177 |
@@ -65,22 +71,26 @@ in order by the umbrella `Grothendieck.lean` (which is itself bilingual inline F
 | 30 | `Grothendieck/KanExtensions.lean` | `KanExtensions_en.lean` | Kan extensions (generalized limits/colimits) | 270 |
 | 31 | `Grothendieck/Limits.lean` | `Limits_en.lean` | Limits and colimits | 242 |
 | 32 | `Grothendieck/MonoidalCategories.lean` | `MonoidalCategories_en.lean` | Monoidal categories, tensor, unit, associator | 244 |
+| 33 | `Grothendieck/DirectImage.lean` | `DirectImage_en.lean` | `#check` index (8) of the `f^* ⊣ f_*` adjunction — direct/inverse image of module sheaves (#8882) | 152 |
 
-The extension (Parts 1-32) was developed under Issue #2159 / Epic #1646 and is
-**complete**: all 32 leaf modules merged + 1 bilingual umbrella, 0 `sorry`, 0 axiom added.
+*The `Lines` column counts the **FR file alone**; the FR+EN total is roughly double.*
+
+The extension was developed under Issue #2159 / Epic #1646: the 33 leaf modules
+are merged + 1 bilingual umbrella, 0 `sorry`, 0 axiom added.
 
 ## Build
 
 ```bash
 # From this directory (WSL required)
 lake build Grothendieck
-# Builds the 32 leaf modules + 1 bilingual umbrella (~10783 FR+EN lines)
+# Builds the 33 leaf modules + 1 bilingual umbrella (11,414 FR+EN lines total)
+# Last verified build: 2026-07-30, "Build completed successfully (2821 jobs)"
 ```
 
 ## Sorry count
 
-**0 sorry, 0 axiom** — all 32 leaf modules are complete at creation
-(Parts 1-32 merged; umbrella `Grothendieck.lean` is imports-only without declarations).
+**0 sorry, 0 axiom** — all 33 leaf modules are complete at creation
+(the umbrella `Grothendieck.lean` is imports-only without declarations).
 
 ## Toolchain
 
@@ -106,14 +116,15 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 - Epic #1453 (prover harness calibration)
 - Conway tribute workspace (`../conway_lean/`)
 - Lean notebook series (`../README.md`)
-- **EPIC #4980** — Lean i18n convention (Option A sibling pair post-2026-07-04; 32 `_en.lean` siblings on `main` in this lake + 1 bilingual inline umbrella)
+- **EPIC #4980** — Lean i18n convention (Option A sibling pair post-2026-07-04; 33 `_en.lean` siblings on `main` in this lake + 1 bilingual inline umbrella)
+- Issue #8960 (reconciling the two `Part` numberings)
 - **[`README.md`](./README.md)** — FR canonical sibling of this file
 
 ## Conclusion
 
-This tribute is a **complete pedagogical tour** (32 leaf modules + 1 bilingual umbrella, ~10783 FR+EN lines, 0 `sorry`,
+This tribute is a **complete pedagogical tour** (33 leaf modules + 1 bilingual umbrella, 11,414 FR+EN lines, 0 `sorry`,
 0 axiom added) showing how Grothendieck's language — sites, sheaves,
-sheafification, points, cohomology, Yoneda — already lives in Mathlib 4. It is
+sheafification, points, cohomology, Yoneda, direct images — already lives in Mathlib 4. It is
 deliberately **not** a formalization of EGA/SGA; it is a curated index that lets
 learners see the library through Grothendieckian eyes.
 
@@ -124,7 +135,9 @@ The modules trace a coherent path: **sites and sieves** (Parts 1, 6, 8, 11, 12,
 its left exactness** (13, 14) → **points and conservative families** (15, 19) →
 **sheaf cohomology, Mayer-Vietoris, and Čech** (20-23), with **schemes and the
 Zariski site** (2, 3) and a **Mathlib map** (4) anchoring the tour to the library
-it indexes.
+it indexes. Finally, `DirectImage.lean` indexes the `f^* ⊣ f_*` adjunction — the
+simplest instance of the "six operations", transporting sheaves along morphisms
+of schemes.
 
 ### Scope, honestly
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
@@ -45,7 +45,7 @@ in order by the umbrella `Grothendieck.lean` (which is itself bilingual inline F
 | 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | `#check` index of Grothendieck-related Mathlib definitions | 107 |
 | 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 micro-proof targets for the prover harness (Epic #1453) | 95 |
 | 6 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjunction of functors, unit/counit, turtle lemma, left/right adjoints | 168 |
-| 7 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Sieve pullback identities: `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895) | 164 |
+| 7 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Sieve pullback identities (7): `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 164 |
 | 8 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 148 |
 | 9 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Topology ordering, covering closure, sieve composition | 141 |
 | 10 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-to-topology, sheaf characterization, sup of coverages | 177 |

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -60,7 +60,7 @@ flowchart LR
 | 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | Index `#check` des définitions Mathlib liées à Grothendieck | 107 |
 | 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 cibles de micro-preuve pour le harnais du prouveur (Epic #1453) | 95 |
 | 6 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjonction de foncteurs, unité/co-unit, lemme de la tortue (turtle), adjoints à droite/gauche | 168 |
-| 7 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Identités de pullback de cribles : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895) | 164 |
+| 7 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Identités de pullback de cribles (7) : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 164 |
 | 8 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Bases faisceau/préfaisceau séparé, transfert de faisceau le long de J₁ ≤ J₂ | 148 |
 | 9 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Ordre sur les topologies, clôture de recouvrement, composition de cribles | 141 |
 | 10 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-vers-topologie, caractérisation des faisceaux, sup de coverages | 177 |

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -5,10 +5,10 @@ Alexandre Grothendieck (1928-2014).
 ## État
 
 - **Toolchain** : `leanprover/lean4:v4.31.0-rc1`
-- **Sorry** : **0 sorry, 0 axiome** — les 32 modules leaf sont complets à la création (Parties 1-32 mergées)
-- **Build** : `lake build Grothendieck` — compile 32 modules leaf (~10783 lignes FR+EN, vérifié post-c.745 #7856)
+- **Sorry** : **0 sorry, 0 axiome** — les 33 modules leaf sont complets à la création
+- **Build** : `lake build Grothendieck` — compile 33 modules leaf (11 206 lignes FR+EN, + 208 pour l'umbrella = **11 414 au total**, mesuré 2026-07-30)
 - **Dépendances** : Mathlib 4 (via `lakefile.lean`)
-- **Couverture i18n (EPIC #4980 ratifiée 2026-07-04)** : couverture bilingue FR/EN complète — **33 fichiers FR** (1 umbrella `Grothendieck.lean` bilingue inline FR+EN + **32 modules leaf** FR canonique) + **32 siblings `_en.lean`** sur `main` (les 32 modules leaf uniquement ; l'umbrella est bilingue inline). Conformément à la convention ratifiée (Option A : `Foo.lean` FR canonique + `Foo_en.lean` miroir EN pour les leafs), **tous les 32 modules leaf** sont déjà bilingues au pattern A (namespaces `_en` anti-collision, contenu non-docstring byte-identique détectable par CI). L'umbrella `Grothendieck.lean` est bilingue inline (FR canonique d'abord, EN en miroir, cf doctring final du fichier) — c'est *by design*, pas un gap i18n. **`README.en.md`** présent (miroir EN du présent fichier). Hors-scope : `.lake/packages/`, libs vendored.
+- **Couverture i18n (EPIC #4980 ratifiée 2026-07-04)** : couverture bilingue FR/EN complète — **34 fichiers FR** (1 umbrella `Grothendieck.lean` bilingue inline FR+EN + **33 modules leaf** FR canonique) + **33 siblings `_en.lean`** sur `main` (les 33 modules leaf uniquement ; l'umbrella est bilingue inline). Conformément à la convention ratifiée (Option A : `Foo.lean` FR canonique + `Foo_en.lean` miroir EN pour les leafs), **tous les 33 modules leaf** sont déjà bilingues au pattern A (namespaces `_en` anti-collision, contenu non-docstring byte-identique détectable par CI). L'umbrella `Grothendieck.lean` est bilingue inline (FR canonique d'abord, EN en miroir, cf doctring final du fichier) — c'est *by design*, pas un gap i18n. **`README.en.md`** présent (miroir EN du présent fichier). Hors-scope : `.lake/packages/`, libs vendored.
 
 ## Objectif
 
@@ -27,11 +27,17 @@ Le but est d'offrir aux apprenants un point d'entrée curaté vers :
 
 ## Structure
 
-La formalisation couvre **32 modules leaf (Parties 1-32, ~10783 lignes FR+EN, 0 sorry)**,
-importés dans l'ordre par le parapluie `Grothendieck.lean` (qui est lui-même bilingue inline FR/EN, pas de sibling `_en` pour l'umbrella). Chaque module leaf se
-numérote lui-même via son en-tête (`Grothendieck tribute — Part N`).
+La formalisation couvre **33 modules leaf (11 206 lignes FR+EN, 0 sorry)**,
+importés dans l'ordre par le parapluie `Grothendieck.lean` (qui est lui-même bilingue inline FR/EN, pas de sibling `_en` pour l'umbrella).
 
-*La trajectoire pédagogique des 32 modules leaf — des sites et cribles jusqu'à la cohomologie, avec schémas/Zariski et carte Mathlib en ancrage :*
+> **Deux numérotations coexistent, et elles ne coïncident pas.** La colonne `Partie` du tableau
+> ci-dessous est l'**ordre d'import** dans l'umbrella ; l'en-tête de chaque fichier porte un
+> numéro de `Partie` distinct, hérité de sa phase de rédaction, qui diverge de l'ordre d'import
+> sur **26 des 33 modules** et comporte des doublons (`Partie 26` ×3, `Partie 27` ×2). Les
+> diagrammes et la section `## References` réfèrent à la numérotation des **en-têtes** ; la
+> section `### La trajectoire` réfère à celle du **tableau**. Réconciliation suivie par #8960.
+
+*La trajectoire pédagogique des 33 modules leaf — des sites et cribles jusqu'à la cohomologie, avec schémas/Zariski et carte Mathlib en ancrage :*
 
 ```mermaid
 flowchart LR
@@ -47,14 +53,14 @@ flowchart LR
 
 | Partie | Fichier | `_en` | Contenu | Lignes |
 |--------|---------|-------|---------|--------|
-| racine | `Grothendieck.lean` | (bilingue inline) | **Racine umbrella** (imports-only des 32 leaf + doctring bilingue FR/EN lignes 32-205) ; pas de sibling `_en` (le contenu EN vit dans le même fichier en miroir) | 207 |
+| racine | `Grothendieck.lean` | (bilingue inline) | **Racine umbrella** (imports-only des 33 leaf + doctring bilingue FR/EN) ; pas de sibling `_en` (le contenu EN vit dans le même fichier en miroir) | 208 |
 | 1 | `Grothendieck/CategoryAndSites.lean` | `CategoryAndSites_en.lean` | Cribles, topologies de Grothendieck (triviale/discrète/dense), trois axiomes | 243 |
 | 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Type des schémas, foncteur Spec, Γ, `homeoOfIso`, pleinement fidèle | 109 |
 | 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Prétopologie de Zariski, théorème-pont `zariskiTopology_eq`, sous-canonique | 93 |
 | 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | Index `#check` des définitions Mathlib liées à Grothendieck | 107 |
 | 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 cibles de micro-preuve pour le harnais du prouveur (Epic #1453) | 95 |
 | 6 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjonction de foncteurs, unité/co-unit, lemme de la tortue (turtle), adjoints à droite/gauche | 168 |
-| 7 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Identités de pullback de cribles : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone` | 103 |
+| 7 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Identités de pullback de cribles : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895) | 164 |
 | 8 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Bases faisceau/préfaisceau séparé, transfert de faisceau le long de J₁ ≤ J₂ | 148 |
 | 9 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Ordre sur les topologies, clôture de recouvrement, composition de cribles | 141 |
 | 10 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-vers-topologie, caractérisation des faisceaux, sup de coverages | 177 |
@@ -80,22 +86,26 @@ flowchart LR
 | 30 | `Grothendieck/KanExtensions.lean` | `KanExtensions_en.lean` | Extensions de Kan (limites/colimites généralisées) | 270 |
 | 31 | `Grothendieck/Limits.lean` | `Limits_en.lean` | Limites et colimites | 242 |
 | 32 | `Grothendieck/MonoidalCategories.lean` | `MonoidalCategories_en.lean` | Catégories monoïdales, tenseur, unité, associateur | 244 |
+| 33 | `Grothendieck/DirectImage.lean` | `DirectImage_en.lean` | Index `#check` (8) de l'adjonction `f^* ⊣ f_*` — image directe / réciproque des faisceaux de modules (#8882) | 152 |
 
-L'extension (Parties 1-32) a été développée sous l'Issue #2159 / Epic #1646 et
-est **complète** : tous les 32 modules leaf mergés + 1 umbrella bilingue, 0 `sorry`, 0 axiome ajouté.
+*La colonne `Lignes` compte le **fichier FR seul** ; le total FR+EN est le double approximatif.*
+
+L'extension a été développée sous l'Issue #2159 / Epic #1646 : les 33 modules leaf
+sont mergés + 1 umbrella bilingue, 0 `sorry`, 0 axiome ajouté.
 
 ## Build
 
 ```bash
 # Depuis ce répertoire (WSL requis)
 lake build Grothendieck
-# Compile les 32 modules leaf + 1 umbrella bilingue (~10783 lignes FR+EN)
+# Compile les 33 modules leaf + 1 umbrella bilingue (11 414 lignes FR+EN au total)
+# Dernier build vérifié : 2026-07-30, « Build completed successfully (2821 jobs) »
 ```
 
 ## Compte de sorry
 
-**0 sorry, 0 axiome** — tous les 32 modules leaf sont complets à la création
-(Parties 1-32 mergées ; umbrella `Grothendieck.lean` est imports-only sans déclaration).
+**0 sorry, 0 axiome** — tous les 33 modules leaf sont complets à la création
+(l'umbrella `Grothendieck.lean` est imports-only sans déclaration).
 
 ## Toolchain
 
@@ -120,15 +130,16 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 - PR #2675 (Phases 4-6 : SieveOps + CoverageGen + CanonicalProps)
 - Epic #1453 (calibration du harnais prouveur)
 - Workspace hommage Conway (`../conway_lean/`)
-- **EPIC #4980** — convention i18n Lean (Option A sibling pair post-2026-07-04 ; 32 siblings `_en.lean` sur `main` dans cette lake + 1 umbrella bilingue inline)
+- **EPIC #4980** — convention i18n Lean (Option A sibling pair post-2026-07-04 ; 33 siblings `_en.lean` sur `main` dans cette lake + 1 umbrella bilingue inline)
+- Issue #8960 (réconciliation des deux numérotations `Partie`)
 - **[`README.en.md`](./README.en.md)** — miroir EN du présent fichier
 - Série de notebooks Lean (`../README.md`)
 
 ## Conclusion
 
-Cet hommage est une **visite pédagogique complète** (32 modules leaf + 1 umbrella bilingue, ~10783 lignes FR+EN,
+Cet hommage est une **visite pédagogique complète** (33 modules leaf + 1 umbrella bilingue, 11 414 lignes FR+EN,
 0 `sorry`, 0 axiome ajouté) montrant comment le langage de Grothendieck — sites,
-faisceaux, faisceautisation, points, cohomologie, Yoneda — vit déjà dans Mathlib 4. Ce
+faisceaux, faisceautisation, points, cohomologie, Yoneda, images directes — vit déjà dans Mathlib 4. Ce
 n'est délibérément **pas** une formalisation d'EGA/SGA ; c'est un index curaté
 qui laisse les apprenants voir la bibliothèque à travers des yeux grothendieckiens.
 
@@ -139,7 +150,7 @@ Les modules tracent un chemin cohérent : **sites et cribles** (Parties 1, 7, 9,
 **faisceautisation et son exactitude à gauche** (14, 15) → **points et familles
 conservatrices** (17, 22) → **cohomologie des faisceaux, Mayer-Vietoris et Čech**
 (23-26), avec **schémas et site de Zariski** (2, 3), une **carte Mathlib** (4)
-et le **lemme de Yoneda** (27) ancrant la visite à la bibliothèque qu'elle indexe. Les bases catégorielles (Adjonction, Équivalences, Monades) aux Parties 6, 16, 19 soutiennent toute la formalisation.
+et le **lemme de Yoneda** (27) ancrant la visite à la bibliothèque qu'elle indexe. Les bases catégorielles (Adjonction, Équivalences, Monades) aux Parties 6, 16, 19 soutiennent toute la formalisation. Enfin, `DirectImage.lean` indexe l'adjonction `f^* ⊣ f_*` — l'instance la plus simple des « six opérations », qui transporte les faisceaux le long des morphismes de schémas.
 
 *La construction verticale « faisceau » — chaque couche bâtie sur la précédente, de la donnée du site jusqu'à la cohomologie :*
 


### PR DESCRIPTION
`Grain: MED/lean — lane myia-ai-01:CoursIA — prev: MED/guard`

Les deux README de `grothendieck_lean` decrivaient un lake a **32 modules leaf / ~10783 lignes**.
Mesure firsthand sur `main` le 2026-07-30 : **33 modules leaf / 11 414 lignes**.

```
leaf FR : 33   |  _en : 33   |  aucun FR sans sibling
leaf FR = 5819 · leaf EN = 5387 · leaf FR+EN = 11206 · umbrella = 208 · TOTAL = 11414
umbrella imports : 33   (DirectImage importe ligne 11)
```

## Ce que la mesure a trouve

| Constat | Etat avant | Etat apres |
|---|---|---|
| Nombre de leaf | 32 | **33** |
| Lignes | `~10783` (unite ambigue) | `11 414` FR+EN, decompose |
| `DirectImage.lean` (#8882, merge 2026-07-29) | **absent des deux tableaux** | ligne 33 |
| `SieveLattice.lean` | `103` lignes, `pullback_union` absent de la colonne Contenu | `164`, `pullback_union (#7895)` |
| umbrella | `207` lignes, « doctring lignes 32-205 » | `208`, reference de lignes retiree |
| colonne `Lignes` | FR seul, mais les totaux en prose disaient FR+EN | note d'unite explicite |
| `MathlibMap{,_en}.lean` | « etat 2026-05 : six operations absentes » | qualifie (voir plus bas) |

`SieveLattice` est la **seule** ligne du tableau qui avait derive : j'ai verifie les 32 autres
une par une contre `wc -l`, elles sont exactes.

`DirectImage.lean` est un **index `#check`** (8 checks, 0 theoreme), meme genre que `MathlibMap.lean` —
la ligne du tableau le dit ainsi, pour ne pas laisser croire a du contenu de preuve.

## Le releve Mathlib etait contredit par le depot lui-meme

`MathlibMap.lean` listait « Six operations (formalisme de Grothendieck) » parmi ce que Mathlib
**n'a pas**, alors que `DirectImage.lean` — merge dans ce meme lake le 2026-07-29 — indexe
precisement `pullbackPushforwardAdjunction` **depuis** Mathlib. Redater `2026-05` -> `2026-07`
aurait laisse l'affirmation fausse. Elle est donc **qualifiee** :

> Six operations (formalisme complet de Grothendieck) — Mathlib fournit l'instance de base
> `f^* ⊣ f_*` sur les faisceaux de modules (`AlgebraicGeometry.Modules.Sheaf`, indexee par
> `DirectImage.lean`) ; `f_!` / `f^!` et le formalisme complet restent absents

## Une affirmation fausse supprimee, et pourquoi elle ne devient pas un fix

Le README affirmait : *« Chaque module leaf se numerote lui-meme via son en-tete »*.
C'est faux, et d'une facon qui casse la navigation : **deux numerotations coexistent**.

| | source | totale ? | injective ? |
|---|---|---|---|
| **A — ordre d'import** | colonne `Partie` du tableau | oui, 1→33 | oui |
| **B — en-tete de fichier** | `Partie N` du docstring d'en-tete | non (pas de `4`, max `30`) | **non** |

Elles divergent sur **26 des 33 modules**, et **B** comporte des doublons :
`Partie 26` → `Comma` / `Limits` / `Monads` (×3), `Partie 27` → `Construction` / `Equivalences` (×2).

Les sections ne s'accordent pas non plus entre elles : le tableau et `### La trajectoire` (FR)
utilisent **A** ; les deux mermaids, les deux `## References` et `### The arc` (EN) utilisent **B**.
Consequence : **la prose FR et la prose EN se contredisent pour le meme paragraphe.**

Verification que **B** est bien la numerotation des diagrammes — le mermaid T1 dit
*« Sites & cribles — Parties 1·6·8·11·12·16 »*. Sous **B** cet ensemble vaut exactement
`{CategoryAndSites, SieveLattice, SieveOps, SieveGenerate, DenseTopology, Subcanonical}` : que des cribles.
Sous **A** il contiendrait `Adjunction` et `Equivalences`, qui n'en sont pas.

**Cette PR ne repare pas la numerotation** — ce serait 68 fichiers et un autre sujet (G.4).
Elle **supprime l'affirmation fausse** et pose un encart qui dit au lecteur quelle section
parle quelle langue, en attendant #8960 qui tranche (les en-tetes font foi, et on repare
leur non-injectivite) et qui **retirera cet encart**.

Corriger les comptes en laissant intacte une phrase fausse que je venais de relire aurait
consacre l'erreur ; la regle globale est « supprime-la d'abord ».

## Preuves

```
$ lake build Grothendieck
✔ [2820/2821] Built Grothendieck (39s)
Build completed successfully (2821 jobs).            EXIT=0
```

```
$ python scripts/lean/check_i18n_siblings.py MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean
32/33 byte-identical | 1 consumer | 0 drift | 0 orphan | 2 half-done (advisory)
```

Les edits sont **docstring-only** : la byte-identity hors-docstring est preservee, le checker
reste vert. Les 2 `HALF-DONE` (`Conservative_en.lean`, `SitePoints_en.lean`) sont **pre-existants** —
verifie contre `main`, pas introduits ici ; ils sont consignes dans #8960.

`grep -c sorry` : toutes les occurrences sont en prose (docstrings). **sorry reel = 0**, inchange.

## Note de diff

`README.md` etait committe en CRLF alors que `core.autocrlf=true` normalise en LF au staging.
Il est **stage en preservant le blob CRLF d'origine** (`-c core.autocrlf=false`) : sans cela le
diff affichait 363 lignes de churn de fins de ligne pour 29 lignes de contenu. Une migration de
fins de ligne est un autre sujet, et se ferait via `.gitattributes` au niveau du depot.

## Tier

**MED**, pas LIGHT : ce n'est pas un `±1` scan-generable. Le grain a demande une mesure
per-fichier (33 leaf × FR/EN), un audit ligne-a-ligne du tableau, la resolution semantique de
laquelle des deux numerotations chaque section utilise, et une verification par `lake build`.
Il corrige une derive de 26 modules, un module absent, une ligne a `+61`, et un releve Mathlib
contredit par le depot. Genre `lean`, distinct du `guard` precedent (G-VAR-3).

See #2159, #4980, #8960.
