### PR TITLE
fix(lean-ci,#8782): read target-modules from the workflow, stop keeping a copy

### DIFF
--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -147,14 +147,20 @@ jobs:
       allow-axioms: "Conway.Life.hashlife_correct_implies_block_2._native.native_decide.ax_1_1,Conway.Life.hashlife_correct_implies_toad_2._native.native_decide.ax_1_1,Conway.Life.hashlife_correct_implies_glider_2._native.native_decide.ax_1_1,Conway.Life.hashlife_correct_implies_blinker_h_2._native.native_decide.ax_1_1,Conway.Life.hashlife_correct_implies_beacon_2._native.native_decide.ax_1_1,Conway.Life.box_assez_grandN_single_cell._native.native_decide.ax_1_4,Conway.Life.box_assez_grandN_single_cell._native.native_decide.ax_1_2,Conway.Life.box_assez_grandN_single_cell._native.native_decide.ax_1_3,Conway.Life.box_assez_grandN_single_cell._native.native_decide.ax_1_1,Conway.Life.box_assez_grandN_single_cell_8._native.native_decide.ax_1_1,Conway.Life.box_assez_grandN_single_cell_3._native.native_decide.ax_1_1,Conway.Life.box_assez_grandN_block_8._native.native_decide.ax_1_1,Conway.Life.box_assez_grandN_glider_8._native.native_decide.ax_1_1,Conway.Life.boxAssezGrandN_block_8._native.native_decide.ax_1_1,Conway.Life.boxAssezGrandN_glider_8._native.native_decide.ax_1_1,Conway.Life.box_assez_grand_single_cell_3_false._native.native_decide.ax_1_1,Conway.Life.box_assez_grand_single_cell_8_false._native.native_decide.ax_1_1,Conway.Life.box_assez_grand_single_cell_2._native.native_decide.ax_1_1,Conway.Life.box_assez_grand_not_vacuous._native.native_decide.ax_1_1,Conway.Life.p4_wf_witness_k2._native.native_decide.ax_1_1,Conway.Life.p4_wf_witness_k1._native.native_decide.ax_1_1,Conway.Life.p4_base_exhaustive._native.native_decide.ax_1_1✝,Conway.Life.p4_base_blinker._native.native_decide.ax_1_1,Conway.Life.p4_base_block._native.native_decide.ax_1_1,Conway.Life.p4_base_glider._native.native_decide.ax_1_1,Conway.Life.p4_base_dead._native.native_decide.ax_1_1,Conway.Life.p4_unrestricted_counterexample._native.native_decide.ax_1_1,Conway.Life.padCenter2_correct_block_level1._native.native_decide.ax_1_1"
       fail-on-sorry: false
 
-  # Advisory proof-integrity coverage (See #8782). The `target-modules` list
-  # above is hand-maintained while the lakefile glob (.submodules Conway,
-  # Conway_en) grows as modules are added; a gate that inspects 2 of N compiled
+  # Advisory proof-integrity coverage (See #8782). The `target-modules` lists
+  # above are hand-maintained while the lakefile glob (.submodules Conway,
+  # Conway_en) grows as modules are added; a gate that inspects 3 of N compiled
   # modules is a "vert hors-cible" -- visually indistinguishable from a targeted
   # green in the check rollup. This job prints the delta (compiled vs target)
   # and ALWAYS exits 0: it never fails CI, it makes the gap legible in the log.
-  # It intentionally does NOT decide which modules to gate or the blocking
-  # policy (options a/b/c in #8782) -- that is a coordinator design call.
+  #
+  # `--from-workflow` reads THIS file and unions target-modules over every job
+  # whose `uses:` resolves to lean-axiom.yml. It replaces a literal
+  # `--target-modules` flag that had been given the blocking job's list only:
+  # when option (b) of #8782 added the audit job above, the advisory kept the
+  # old list and reported Conway.Life.HashlifeCorrectness as a blind spot --
+  # false about precisely the module the audit job inspects. A drift-detector
+  # that keeps its own copy of the list detects everyone's drift but its own.
   target-coverage:
     runs-on: ubuntu-latest
     if: always()
@@ -163,10 +169,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+      - name: Install PyYAML
+        run: pip install pyyaml
       - name: Advisory target-coverage delta
         run: |
           python3 scripts/lean/check_target_coverage.py \
             --project-path MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean \
-            --target-modules "Conway.KochenSpecker,Conway.FreeWillTheorem" \
+            --from-workflow .github/workflows/lean-conway.yml \
             --lib-root Conway \
             --name conway_lean

--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -128,8 +128,14 @@ jobs:
   # gate that inspects 5 of 14 compiled modules is a "vert hors-cible" --
   # visually indistinguishable from a targeted green in the check rollup. This
   # job prints the delta (compiled vs target) and ALWAYS exits 0: it never
-  # fails CI, it makes the gap legible in the log. It does NOT decide which
-  # modules to gate (options a/b/c in #8782) -- that is a coordinator design call.
+  # fails CI, it makes the gap legible in the log.
+  #
+  # `--from-workflow` reads THIS file and unions target-modules over every job
+  # whose `uses:` resolves to lean-axiom.yml, instead of restating the list a
+  # second time here. knot_lean has a single gate job today, so the union is
+  # the same set -- the point is that it stays the same set if a second gate
+  # job is ever added, which is exactly where the conway copy went stale
+  # (it reported the audit job's module as a blind spot). See #8782.
   target-coverage:
     runs-on: ubuntu-latest
     if: always()
@@ -138,10 +144,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+      - name: Install PyYAML
+        run: pip install pyyaml
       - name: Advisory target-coverage delta
         run: |
           python3 scripts/lean/check_target_coverage.py \
             --project-path MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean \
-            --target-modules "Knots.Basic,Knots.Conway,Knots.Invariant,Knots.Reidemeister,Knots.Lidman" \
+            --from-workflow .github/workflows/lean-knot.yml \
             --lib-root Knots \
             --name knot_lean

--- a/scripts/lean/check_target_coverage.py
+++ b/scripts/lean/check_target_coverage.py
@@ -18,12 +18,38 @@ Usage (local)::
 
     python scripts/lean/check_target_coverage.py \
         --project-path MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean \
-        --target-modules "Conway.KochenSpecker,Conway.FreeWillTheorem" \
+        --from-workflow .github/workflows/lean-conway.yml \
+        --lib-root Conway \
         --name conway_lean
 
 Wired as a non-blocking final step in ``lean-axiom.yml`` (``if: always()``) so
 the coverage report lands in every Lean PR's CI log regardless of the blocking
 axiom verdict.
+
+``--from-workflow`` vs ``--target-modules`` (#8782)
+---------------------------------------------------
+``--target-modules`` takes the list literally, which means the caller keeps a
+copy. That is how this tool acquired the very defect it was built to detect: a
+tool that flags the drift of a hand-maintained list introduced a *second*
+hand-maintained copy of it, and the copies diverged the moment option (b) of
+#8782 landed. ``lean-conway.yml`` ended up with three copies -- the blocking
+gate (``Conway.KochenSpecker,Conway.FreeWillTheorem``), the advisory audit job
+(``Conway.Life.HashlifeCorrectness``), and this script's own ``--target-modules``
+flag, which had only ever been given the *blocking* job's list. The report then
+printed ``Conway.Life.HashlifeCorrectness`` under "the gate never inspects their
+axioms" -- a statement that was false about precisely the module the design
+decision had been taken to cover.
+
+``--from-workflow`` removes the copy by construction: it reads the workflow YAML
+and unions ``with.target-modules`` across **every** job whose ``uses:`` resolves
+to ``lean-axiom.yml`` (both the ``owner/repo/.github/...@ref`` and the local
+``./.github/...`` forms). Adding, retargeting or deleting a gate job moves the
+coverage report with it, and no third list exists to fall out of date.
+
+GitHub Actions forbids the ``env`` context inside ``jobs.<id>.with``, so sharing
+the list through a workflow-level variable is closed; reading the YAML is what
+remains. ``--target-modules`` is kept for ad-hoc local runs and for lakes whose
+gate is not (yet) expressed as a workflow job.
 
 Module discovery is filesystem-based (no ``lake build`` required): every
 ``.lean`` file under ``--project-path`` (excluding ``.lake/``, ``lakefile*``,
@@ -99,15 +125,63 @@ def parse_target_modules(raw: str) -> set[str]:
     return {m.strip() for m in raw.split(",") if m.strip()}
 
 
+def _uses_lean_axiom(uses: str) -> bool:
+    """True if a job's ``uses:`` resolves to the reusable ``lean-axiom.yml``.
+
+    Both call forms occur in the repo and must match:
+    ``jsboige/CoursIA/.github/workflows/lean-axiom.yml@main`` (lean-conway.yml)
+    and ``./.github/workflows/lean-axiom.yml`` (lean-knot.yml, per-PR resolution).
+    """
+    if not isinstance(uses, str):
+        return False
+    ref = uses.split("@", 1)[0].strip()  # drop @main / @sha
+    return ref.rsplit("/", 1)[-1] == "lean-axiom.yml"
+
+
+def targets_from_workflow(workflow_path: Path) -> tuple[set[str], dict[str, set[str]]]:
+    """Union ``with.target-modules`` over every lean-axiom job in a workflow.
+
+    Returns ``(union, per_job)``. An **empty** ``per_job`` means no job in the
+    file calls ``lean-axiom.yml`` -- reported by the caller as an explicit
+    "no gate wired" line, never folded into a 0%-coverage figure: those two
+    states have opposite meanings and a number that conflates them would be a
+    computed value measuring the wrong thing.
+    """
+    import yaml  # local import: only --from-workflow needs the dependency
+
+    doc = yaml.safe_load(workflow_path.read_text(encoding="utf-8")) or {}
+    jobs = doc.get("jobs") or {}
+
+    per_job: dict[str, set[str]] = {}
+    for job_id, job in jobs.items():
+        if not isinstance(job, dict) or not _uses_lean_axiom(job.get("uses", "")):
+            continue
+        raw = (job.get("with") or {}).get("target-modules", "")
+        # A gate job with an empty target list is still a gate job: record it so
+        # the report shows it contributed nothing, rather than hiding it.
+        per_job[str(job_id)] = parse_target_modules(str(raw))
+
+    union: set[str] = set()
+    for mods in per_job.values():
+        union |= mods
+    return union, per_job
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Advisory: lake compiled modules vs proof-integrity target-modules."
     )
     parser.add_argument("--project-path", required=True, help="Repo-relative lake root.")
-    parser.add_argument(
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
         "--target-modules",
-        required=True,
-        help="Comma-separated dotted modules the gate inspects (lean-axiom.yml input).",
+        help="Comma-separated dotted modules the gate inspects (lean-axiom.yml input). "
+        "Literal list -- keeps a copy; prefer --from-workflow in CI.",
+    )
+    source.add_argument(
+        "--from-workflow",
+        help="Path to a workflow YAML; union target-modules over every job whose "
+        "`uses:` resolves to lean-axiom.yml. No second copy of the list to drift.",
     )
     parser.add_argument("--name", default="lake", help="Display name for the report header.")
     parser.add_argument(
@@ -124,7 +198,16 @@ def main(argv: list[str] | None = None) -> int:
         return 0  # advisory: never fail CI on a missing path
 
     compiled = discover_modules(project_path, args.lib_root)
-    targeted = parse_target_modules(args.target_modules)
+
+    per_job: dict[str, set[str]] = {}
+    if args.from_workflow:
+        wf = Path(args.from_workflow)
+        if not wf.is_file():
+            print(f"ADVISORY target-coverage ({args.name}): workflow not found: {wf}")
+            return 0  # advisory: never fail CI on a missing path
+        targeted, per_job = targets_from_workflow(wf)
+    else:
+        targeted = parse_target_modules(args.target_modules)
 
     covered = compiled & targeted
     blind_spot = sorted(compiled - targeted)  # compiled but gate never inspects
@@ -135,6 +218,29 @@ def main(argv: list[str] | None = None) -> int:
     print(f"=== ADVISORY: proof-integrity target coverage ({args.name}) ===")
     print(f"Project: {project_path}")
     print(f"lib-root scope: {args.lib_root or '(maximal walk of every .lean)'}")
+
+    if args.from_workflow:
+        print(f"Target source: {args.from_workflow} (union over lean-axiom jobs)")
+        if not per_job:
+            # NOT the same thing as 0% coverage, and must not be printed as such:
+            # "no gate job in this file" means the report has nothing to measure,
+            # whereas "0% covered" would assert the gate inspects nothing. Emitting
+            # the latter for the former is the failure this tool exists to catch.
+            print()
+            print(
+                "NO GATE WIRED -- no job in this workflow has `uses:` resolving to\n"
+                "      lean-axiom.yml, so there is no target list to compare against.\n"
+                "      This is not a coverage figure: nothing was measured. Check the\n"
+                "      workflow path, or whether the gate job was renamed/removed."
+            )
+            return 0
+        for job_id in sorted(per_job):
+            mods = per_job[job_id]
+            shown = ", ".join(sorted(mods)) if mods else "(none)"
+            print(f"  job {job_id}: {len(mods)} -> {shown}")
+    else:
+        print("Target source: --target-modules (literal list passed by the caller)")
+
     print(f"Compiled modules (filesystem walk): {len(compiled)}")
     print(f"Gate target-modules:                {len(targeted)}")
     print(f"Covered (in both):                  {len(covered)}  ({coverage_pct:.1f}% of compiled)")

--- a/scripts/lean/tests/test_check_target_coverage.py
+++ b/scripts/lean/tests/test_check_target_coverage.py
@@ -9,21 +9,29 @@ Locks the advisory contract of the conway proof-integrity gate coverage check:
   - blind-spot detection (compiled-but-ungated modules);
   - phantom detection (gated-but-no-source modules);
   - lib-root scoping (``<lib>/`` subdir + ``<lib>.lean`` umbrella + ``<lib>_en.lean`` sibling);
-  - maximal walk excludes build cache / lakefile / toolchain.
+  - maximal walk excludes build cache / lakefile / toolchain;
+  - ``--from-workflow`` unions the target list over every gate job, so the report
+    cannot hold a stale copy of it (#8782).
 """
 from __future__ import annotations
 
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from check_target_coverage import (  # noqa: E402
     _EXCLUDE_TOP_DIRS,
+    _uses_lean_axiom,
     discover_modules,
     main,
     parse_target_modules,
+    targets_from_workflow,
 )
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +188,202 @@ class TestAdvisoryExitZero:
         assert "25.0%" in out
 
 
+# ---------------------------------------------------------------------------
+# --from-workflow — the target list is read, never copied (#8782)
+# ---------------------------------------------------------------------------
+
+def _write_workflow(tmp_path: Path, body: str) -> Path:
+    wf = tmp_path / "wf.yml"
+    wf.write_text(body, encoding="utf-8")
+    return wf
+
+
+class TestUsesLeanAxiom:
+    """Both call forms occur in the repo; matching only one silently halves coverage."""
+
+    def test_pinned_remote_form(self):
+        # lean-conway.yml
+        assert _uses_lean_axiom("jsboige/CoursIA/.github/workflows/lean-axiom.yml@main")
+
+    def test_local_relative_form(self):
+        # lean-knot.yml (resolves per-PR)
+        assert _uses_lean_axiom("./.github/workflows/lean-axiom.yml")
+
+    def test_sha_pin_form(self):
+        assert _uses_lean_axiom("jsboige/CoursIA/.github/workflows/lean-axiom.yml@abc1234")
+
+    def test_other_reusable_workflow_rejected(self):
+        assert not _uses_lean_axiom("./.github/workflows/lean-build.yml")
+        assert not _uses_lean_axiom("actions/checkout@v4")
+
+    def test_non_string_rejected(self):
+        # a job with `steps:` and no `uses:` yields None, not a string
+        assert not _uses_lean_axiom(None)  # type: ignore[arg-type]
+
+
+class TestTargetsFromWorkflow:
+    def test_unions_across_jobs(self, tmp_path):
+        """The blocking gate and the audit gate are *both* the gate."""
+        wf = _write_workflow(tmp_path, """
+name: fake
+jobs:
+  proof-integrity:
+    uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
+    with:
+      target-modules: "Conway.KochenSpecker,Conway.FreeWillTheorem"
+      fail-on-sorry: true
+  proof-integrity-audit:
+    uses: ./.github/workflows/lean-axiom.yml
+    with:
+      target-modules: "Conway.Life.HashlifeCorrectness"
+      fail-on-sorry: false
+""")
+        union, per_job = targets_from_workflow(wf)
+        assert union == {
+            "Conway.KochenSpecker",
+            "Conway.FreeWillTheorem",
+            "Conway.Life.HashlifeCorrectness",
+        }
+        assert set(per_job) == {"proof-integrity", "proof-integrity-audit"}
+        assert per_job["proof-integrity-audit"] == {"Conway.Life.HashlifeCorrectness"}
+
+    def test_ignores_non_gate_jobs(self, tmp_path):
+        wf = _write_workflow(tmp_path, """
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: lake build
+  proof-integrity:
+    uses: ./.github/workflows/lean-axiom.yml
+    with:
+      target-modules: "Knots.Basic"
+""")
+        union, per_job = targets_from_workflow(wf)
+        assert union == {"Knots.Basic"}
+        assert set(per_job) == {"proof-integrity"}  # `build` contributes nothing
+
+    def test_gate_job_with_empty_list_is_still_recorded(self, tmp_path):
+        """A gate that targets nothing is a finding, not an absence -- keep it visible."""
+        wf = _write_workflow(tmp_path, """
+jobs:
+  proof-integrity:
+    uses: ./.github/workflows/lean-axiom.yml
+    with:
+      fail-on-sorry: true
+""")
+        union, per_job = targets_from_workflow(wf)
+        assert union == set()
+        assert per_job == {"proof-integrity": set()}  # recorded, not dropped
+
+    def test_no_gate_job_yields_empty_per_job(self, tmp_path):
+        wf = _write_workflow(tmp_path, """
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+""")
+        union, per_job = targets_from_workflow(wf)
+        assert union == set()
+        assert per_job == {}
+
+
+class TestFromWorkflowCli:
+    def test_reports_per_job_breakdown(self, tmp_path, capsys):
+        lake = _make_lake(tmp_path)
+        wf = _write_workflow(tmp_path, """
+jobs:
+  blocking:
+    uses: ./.github/workflows/lean-axiom.yml
+    with:
+      target-modules: "Conway.KochenSpecker"
+  audit:
+    uses: ./.github/workflows/lean-axiom.yml
+    with:
+      target-modules: "Conway.Life.GridCanonical"
+""")
+        rc = main(["--project-path", str(lake), "--from-workflow", str(wf),
+                   "--lib-root", "Conway", "--name", "fake"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "job blocking: 1" in out
+        assert "job audit: 1" in out
+        # union of the two -> 2 of the 4 compiled modules, neither in the blind spot
+        assert "Gate target-modules:                2" in out
+        assert "Conway.Life.GridCanonical" not in out.split("BLIND SPOT")[-1]
+
+    def test_no_gate_wired_is_not_a_zero_percent_figure(self, tmp_path, capsys):
+        """`no gate job` and `0% covered` are opposite claims; never print the latter for the former."""
+        lake = _make_lake(tmp_path)
+        wf = _write_workflow(tmp_path, """
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+""")
+        rc = main(["--project-path", str(lake), "--from-workflow", str(wf),
+                   "--lib-root", "Conway"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "NO GATE WIRED" in out
+        assert "nothing was measured" in out
+        # the sentinel returns before any coverage arithmetic is printed
+        assert "Covered" not in out
+        assert "0.0%" not in out
+        assert "BLIND SPOT" not in out
+
+    def test_missing_workflow_exits_zero(self, tmp_path, capsys):
+        lake = _make_lake(tmp_path)
+        rc = main(["--project-path", str(lake),
+                   "--from-workflow", str(tmp_path / "absent.yml"),
+                   "--lib-root", "Conway"])
+        assert rc == 0
+        assert "workflow not found" in capsys.readouterr().out
+
+    def test_source_flags_are_mutually_exclusive(self, tmp_path):
+        lake = _make_lake(tmp_path)
+        wf = _write_workflow(tmp_path, "jobs: {}\n")
+        with pytest.raises(SystemExit):
+            main(["--project-path", str(lake),
+                  "--target-modules", "A", "--from-workflow", str(wf)])
+
+    def test_a_source_is_required(self, tmp_path):
+        lake = _make_lake(tmp_path)
+        with pytest.raises(SystemExit):
+            main(["--project-path", str(lake)])
+
+
+class TestRealWorkflowRegression:
+    """The report this mode exists to stop having emitted.
+
+    Before ``--from-workflow``, the advisory step in ``lean-conway.yml`` was given
+    the *blocking* job's list literally, so it printed
+    ``Conway.Life.HashlifeCorrectness`` under "the gate never inspects their
+    axioms" -- false about precisely the module option (b) of #8782 had been
+    wired to cover. These assertions fail if any gate job's list is ever again
+    dropped from the coverage report.
+    """
+
+    def test_conway_union_covers_the_audit_job_target(self):
+        wf = _REPO_ROOT / ".github" / "workflows" / "lean-conway.yml"
+        if not wf.is_file():
+            pytest.skip(f"workflow not present: {wf}")
+        union, per_job = targets_from_workflow(wf)
+        assert len(per_job) >= 2, f"expected blocking + audit gate jobs, got {sorted(per_job)}"
+        assert "Conway.Life.HashlifeCorrectness" in union
+        assert "Conway.KochenSpecker" in union
+        assert "Conway.FreeWillTheorem" in union
+
+    def test_knot_union_is_non_empty(self):
+        wf = _REPO_ROOT / ".github" / "workflows" / "lean-knot.yml"
+        if not wf.is_file():
+            pytest.skip(f"workflow not present: {wf}")
+        union, per_job = targets_from_workflow(wf)
+        assert per_job, "lean-knot.yml has a proof-integrity job; it must be found"
+        assert "Knots.Basic" in union
+
+
 if __name__ == "__main__":
-    import pytest
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Grain: MED/ci — lane myia-ai-01:CoursIA — prev: MED/lean

## Le defaut, mesure sur `main` avant d'ecrire une ligne

`check_target_coverage.py` a ete cree par #8787 pour signaler la derive d'une liste
tenue a la main (`target-modules` fige pendant que le glob du lakefile grossit). Son
invocation CI lui passait cette liste **en dur** — donc `lean-conway.yml` en portait
**trois copies** : le gate bloquant, le job d'audit, et le flag de l'advisory.

Les copies ont diverge a l'instant ou l'option (b) de #8782 a atterri. Voici ce
qu'imprime l'outil sur `main`, tel que la CI l'invoque aujourd'hui :

```
Gate target-modules:                2
Covered (in both):                  2  (3.8% of compiled)

BLIND SPOT (51) -- compiled by the lake but the gate never inspects their axioms:
  ...
  - Conway.Life.HashlifeCorrectness      <- ligne 32
```

Cette ligne est **fausse**. Le job `proof-integrity-audit` (`lean-conway.yml:127`,
ajoute precisement par l'option (b)) inspecte ce module et rien d'autre. L'advisory
n'avait jamais recu que la liste du job **bloquant**.

Le detecteur de derive avait acquis le defaut qu'il avait ete construit pour detecter :
il detectait la derive de tout le monde sauf la sienne. Et il ne s'est pas contente de
se taire — il a **affirme un angle mort sur le module meme** que la decision de design
avait ete prise pour couvrir.

## Le correctif — supprimer la copie, pas la resynchroniser

`--from-workflow <chemin>` lit le YAML et **unionne** `with.target-modules` sur **chaque**
job dont le `uses:` resout vers `lean-axiom.yml`. Ajouter, recibler ou supprimer un job
de gate deplace le rapport avec lui ; aucune troisieme liste ne peut vieillir.

Les deux formes d'appel du depot doivent matcher, sinon on divise silencieusement la
couverture par deux :

| Forme | Fichier |
|---|---|
| `jsboige/CoursIA/.github/workflows/lean-axiom.yml@main` | `lean-conway.yml` |
| `./.github/workflows/lean-axiom.yml` | `lean-knot.yml` (resolution par-PR) |

Le contexte `env` est **interdit** par GitHub Actions dans `jobs.<id>.with` — partager la
liste via une variable de workflow est donc ferme. Lire le YAML est ce qui reste.
`--target-modules` est conserve pour les runs locaux ad-hoc et les lakes dont le gate
n'est pas (encore) exprime comme job de workflow ; les deux flags sont mutuellement
exclusifs et l'un des deux est requis.

## `NO GATE WIRED` n'est pas `0%`

Un workflow sans job de gate retourne **tot**, sur une ligne explicite, au lieu d'un
chiffre de couverture :

```
NO GATE WIRED -- no job in this workflow has `uses:` resolving to
      lean-axiom.yml, so there is no target list to compare against.
      This is not a coverage figure: nothing was measured.
```

« Aucun gate ici » et « le gate n'inspecte rien » sont deux affirmations **opposees**.
Un nombre qui les confond serait une valeur calculee qui mesure la mauvaise chose —
exactement la classe de defaut pour laquelle cet outil existe. Le test correspondant
verifie que la sortie ne contient ni `Covered`, ni `0.0%`, ni `BLIND SPOT`.

## Mesure apres correctif

```
Target source: .github/workflows/lean-conway.yml (union over lean-axiom jobs)
  job proof-integrity:       2 -> Conway.FreeWillTheorem, Conway.KochenSpecker
  job proof-integrity-audit: 1 -> Conway.Life.HashlifeCorrectness
Compiled modules (filesystem walk): 53
Gate target-modules:                3
Covered (in both):                  3  (5.7% of compiled)
BLIND SPOT (50)
EXIT=0
```

La fausse entree a disparu du bloc `BLIND SPOT` (verifie par `awk` sur la seule section
concernee : il reste `Hashlife`, `HashlifeMarginDemo`, `HashlifeMemo` et leurs `_en`,
qui eux sont bel et bien hors-cible). L'attribution par job rend desormais lisible
**quel** gate couvre **quoi** — ce que la liste unique masquait.

`knot_lean` : 5 cibles, 14 modules compiles, blind spot 9 — **ensemble inchange**. Le
lake n'a qu'un job de gate aujourd'hui ; l'interet est qu'il reste juste le jour ou un
second job apparait, ce qui est exactement la ou la copie conway a lache.

Les deux workflows se listent deja eux-memes dans leur propre `paths:` trigger
(`lean-conway.yml:53,62` / `lean-knot.yml:56,78`) : editer une liste de cibles relance
le rapport qui la mesure. La boucle est fermee.

## Tests — 12 ajoutes, mutation-checked

`TestUsesLeanAxiom` (5), `TestTargetsFromWorkflow` (4), `TestFromWorkflowCli` (5),
`TestRealWorkflowRegression` (2) :

- union sur plusieurs jobs, les deux formes de `uses:` (`@main`, `@sha`, `./`) ;
- jobs non-gate ignores (`build:` avec `steps:` et pas de `uses:`) ;
- **un job de gate avec une liste vide reste enregistre** — c'est un finding, pas une
  absence : le rapport doit montrer qu'il n'a rien contribue, pas le cacher ;
- la sentinelle `NO GATE WIRED` n'imprime aucun chiffre de couverture ;
- flags de source mutuellement exclusifs, et l'un requis ;
- **regression** : l'union derivee du vrai `lean-conway.yml` doit contenir
  `Conway.Life.HashlifeCorrectness` et compter >= 2 jobs de gate.

Le test de regression n'est pas decoratif — verifie par mutation. En restreignant
`_uses_lean_axiom` a la seule forme `./`, **4 tests tombent**, dont la regression, sur
`assert 0 >= 2` : les jobs conway epingles en `@main` disparaissent de l'union. Restaure,
`100 passed` sur l'ensemble de `scripts/lean/tests/`.

## Ce que cette PR ne fait pas

Elle ne change **aucune politique de gating** : quels modules sont bloquants, lesquels
sont en audit, et le contenu des `allow-axioms` restent tels quels. Elle corrige un
**rapport qui mentait**, elle ne redecide rien.

Le commentaire « It intentionally does NOT decide which modules to gate or the blocking
policy (options a/b/c in #8782) -- that is a coordinator design call » est retire des deux
workflows : il etait doublement perime, l'option (b) ayant atterri.

Le second etage de l'angle mort — `_enumerate_module_declarations` saute les decls
`private`, si bien qu'un module correctement cible peut rapporter propre en portant des
`sorry` qu'aucune decl **publique** ne referme — reste ouvert sous #8782 et n'est pas
touche ici.

See #8782, #8787, #8749
