### PR TITLE
fix(ci,#8951): drop lean-axiom's dead pull-requests grant — Lean gate dead since 13:32Z

### DIFF
--- a/.github/workflows/lean-axiom.yml
+++ b/.github/workflows/lean-axiom.yml
@@ -61,9 +61,15 @@ on:
         type: boolean
         default: true
 
+# A reusable workflow cannot request more than its caller grants. #8951 gave the
+# callers (lean-conway.yml, lean-knot.yml) `permissions: {contents: read}`, which
+# implicitly sets pull-requests to none -- so this block's `pull-requests: write`
+# became unsatisfiable and both callers died at startup, gate included. The grant
+# was dead anyway (this file posts no comment, runs no `gh`, no github-script:
+# grep-verified), exactly like the one #8951 removed from lean-build.yml. Dropping
+# it completes that hardening instead of contradicting it. See #8949.
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   axiom-check:

--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -51,6 +51,9 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.toml'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain'
       - '.github/workflows/lean-conway.yml'
+      # The gate's own implementation: a change to it must re-run the gate.
+      # knot lists it already; conway did not (added with #8951's startup break).
+      - '.github/workflows/lean-axiom.yml'
       - 'scripts/lean/check_target_coverage.py'
   pull_request:
     branches: [main]
@@ -60,6 +63,9 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.toml'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain'
       - '.github/workflows/lean-conway.yml'
+      # The gate's own implementation: a change to it must re-run the gate.
+      # knot lists it already; conway did not (added with #8951's startup break).
+      - '.github/workflows/lean-axiom.yml'
       - 'scripts/lean/check_target_coverage.py'
   workflow_dispatch:
 


### PR DESCRIPTION
Grain: MED/ci — lane myia-ai-01:CoursIA — prev: MED/ci

## Le gate d'axiomes Lean ne tourne plus depuis 13:32Z aujourd'hui

`Lean Conway CI` et `Lean Knot CI` sont en **`startup_failure`** — pas en echec de
job, en echec de **demarrage du workflow** :

```
2026-07-30T16:36  startup_failure  fix/target-coverage-from-workflow
2026-07-30T13:32  startup_failure  main            <- depuis ce commit
2026-07-30T11:56  startup_failure  fix/ci-permissions-hardening-8949
2026-07-30T01:50  success          main
```

`13:32Z` = `d35a881b0`, le merge de **#8951** (`ci(secu,#8949): harden GITHUB_TOKEN
scope on Lean CI workflows`). Meme minute.

## Le mecanisme

Un workflow reutilisable **ne peut pas demander plus de permissions que son
appelant n'en accorde**. #8951 a donne aux appelants :

```yaml
# lean-conway.yml, lean-knot.yml
permissions:
  contents: read      # -> tout le reste passe implicitement a `none`
```

pendant que le reutilisable `lean-axiom.yml` continue de declarer :

```yaml
permissions:
  contents: read
  pull-requests: write   # <- devenu insatisfiable
```

GitHub refuse l'appel **au demarrage**. Le workflow appelant entier meurt : pas
seulement le job `proof-integrity`, mais aussi `ci` et `target-coverage`.

Le body de #8951 dit explicitement : « lean-axiom.yml left UNTOUCHED : it carries
{contents: read, pull-requests: write} already and is a proof-integrity gate
(legitimate use, out of this tranche's scope) ». C'est **cette exclusion** qui
casse : durcir les appelants sans durcir le reutilisable cree le desaccord. Le
reste de la tranche est juste — c'est la maille manquante qui a rendu l'ensemble
incoherent.

## Pourquoi personne ne l'a vu

**Un `startup_failure` n'apparait pas dans `gh pr checks`.** Sur ma PR #8965 :
13 checks listes, aucun ne s'appelle « Proof integrity ». Ni rouge, ni jaune —
**absent**. Le rollup d'une PR Lean ressemble exactement a celui d'une PR sans
gate Lean.

C'est le mode de defaillance que #8677 et #8782 traquent, dans sa forme extreme :
non pas « le gate est vert hors-cible », mais « le gate n'existe plus, et son
absence est indistinguable d'un depot ou il n'aurait jamais ete cable ». Un gate
qui ne peut plus rougir n'est pas un gate — celui-ci ne peut meme plus demarrer.

Ce meme angle mort explique que #8951 ait ete mergee : sa propre branche etait
deja en `startup_failure` a 11:56Z, invisible dans son rollup.

## Le correctif

**Retirer le `pull-requests: write` mort de `lean-axiom.yml`.** Le grep est net —
ce fichier ne poste aucun commentaire, n'appelle ni `gh` ni `github-script`, et
n'utilise aucun `secrets.` :

```
$ grep -nE "GITHUB_TOKEN|github-script|gh (pr|api|issue)|secrets\." .github/workflows/lean-axiom.yml
  (aucun resultat)
```

C'est exactement le grant mort que #8951 a lui-meme retire de `lean-build.yml`
(« The reusable posts no comment, runs no `gh`, no github-script (grep-verified
firsthand). The pull-requests grant was copied from a workflow that did comment;
it is a dead over-grant »). Le meme diagnostic s'applique mot pour mot ici.

Le correctif **acheve** donc le durcissement de #8949 au lieu de le contredire :
apres cette PR, appelants **et** reutilisable sont a `contents: read` seul.

## Second point — le gate ne se re-declenchait pas sur son propre code

`lean-knot.yml` liste `.github/workflows/lean-axiom.yml` dans ses `paths:`
(L57, L79) ; **`lean-conway.yml` ne le listait pas**. Modifier l'implementation du
gate ne relancait donc pas le gate cote conway. Ajoute, par parite.

## Preuve, et sa limite — dite honnetement

`lean-knot.yml` appelle `./.github/workflows/lean-axiom.yml` (resolution
**par-PR**) : le run Knot de cette PR utilise la version corrigee et **prouve** le
correctif ici meme.

`lean-conway.yml` epingle `...lean-axiom.yml@main` : son run resout la copie de
**`main`**, qui porte encore le grant mort. Conway restera donc en
`startup_failure` sur cette PR, et ne pourra etre verifie qu'**apres** merge. Je
l'ecris plutot que de laisser croire que les deux sont prouves.

Cette asymetrie est elle-meme une observation utile : un gate epingle `@main` ne
peut pas etre teste avant d'etre merge. Non traite ici (changer le pin est une
decision de design distincte, et le commentaire L104 de knot documente deja
pourquoi knot a choisi `./`).

## Rayon d'impact

Les PR Lean mergees depuis 13:32Z portent sur `learning_theory`, `minimax`,
`grothendieck` — **aucun lake gate par `lean-axiom.yml`**, qui n'est cable que sur
conway et knot (2 des 23, cf `docs/reference/lean-axiom-coverage.md`). Aucune
source conway/knot n'est donc passee sans gate. Le risque etait devant nous, pas
derriere.

Suivi separe : **#8958** (meme famille, meme auteur, meme tranche #8949) ajoute des
blocs `permissions:` a 8 workflows sans scope. A verifier avant merge qu'aucun
n'appelle un reutilisable declarant plus que `contents: read` — c'est le meme
piege, et il ne se verra pas davantage dans le rollup.

See #8949, #8951, #8677, #8782
