### PR TITLE
feat(ci,#8964): G-VAR-2 light-cap organ — cross-PR counter for the per-lane/day cap

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -209,3 +209,100 @@ jobs:
             echo "Defauts signales (advisory, non bloquant) :$DEFECTS"
           fi
           exit 0
+
+  # G-VAR-2 est le seul gate du protocole qui ne se decide pas DANS la PR : il
+  # demande de savoir ce que la lane a DEJA merge aujourd'hui (au plus une LIGHT
+  # par lane et par jour, toutes categories LIGHT confondues). Compte a la main
+  # par le coordinateur jusqu'ici, qui a merge une 2e LIGHT deux fois en un
+  # cycle (#8964). Ce job rend le fait VISIBLE (advisory, exit 0).
+  #
+  # La logique de parsing + comptage vit dans scripts/variation_light_cap.py
+  # (testable, agnostique separateur/casse #8938, bodies lus en TEXTE ENTIER --
+  # le bug ligne-a-ligne avait rendu "18/38 sans tag" au lieu de "2/38"). Le job
+  # n'est que la plomberie CI : dataset des mergees du jour + label + commentaire.
+  check-light-cap:
+    name: G-VAR-2 light cap (cross-PR)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the cap detector (sparse)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/variation_light_cap.py
+      - name: Cross-PR LIGHT cap (G-VAR-2)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          set -uo pipefail
+
+          # Meme garde-fou anti-spam que le job de tag : bots et forks hors
+          # scope (PRs etudiantes, .claude/rules/student-pr-reviews.md).
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issue d'un fork : hors scope (PR etudiante)."
+            exit 0
+          fi
+
+          # Jour courant en UTC : G-VAR-2 se compte par jour UTC (reset 00:00Z).
+          TODAY=$(date -u +%Y-%m-%d)
+
+          # Les PR deja mergees aujourd'hui = le jeu de comptage. La PR courante
+          # est OUVERTE (le job tourne sur opened/edited/synchronize/reopened,
+          # pas sur le merge) donc elle n'est PAS dans ce set -- c'est ce qui
+          # rend la 2e LIGHT detectable.
+          gh pr list --state merged --search "merged:$TODAY" \
+            --json number,body,mergedAt > /tmp/merged.json 2>/dev/null || true
+
+          # Le body circule par fichier : printf '%s' ne reinterprete rien
+          # (newlines, quotes, $), contrairement a un passage en arg CLI.
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          # ADVISORY : le script sort toujours en 0. Si le TIER n'est pas LIGHT
+          # ou la lane absente, il renvoie cap_reached=false et le label est
+          # retire (un label colle par un push anterieur ne survit pas).
+          python3 scripts/variation_light_cap.py \
+            --replay /tmp/merged.json \
+            --check-pr "$PR_NUMBER" \
+            --body-file /tmp/pr_body.txt > /tmp/status.json 2>/tmp/cap.err || true
+
+          echo "--- detector output ---"
+          cat /tmp/status.json 2>/dev/null || true
+          [ -s /tmp/cap.err ] && { echo "--- detector stderr ---"; cat /tmp/cap.err; } || true
+
+          CAP=$(python3 -c "import json; print(json.load(open('/tmp/status.json')).get('cap_reached'))" 2>/dev/null || echo "False")
+
+          # Label distinct (lisible dans gh pr list --json labels). advisory,
+          # donc create/add/remove tolerent l'echec sans tuer le job (|| true).
+          gh label create variation-light-cap-reached \
+            --description "Lane ayant deja merge une LIGHT aujourd'hui (cap G-VAR-2 atteint)" \
+            --color B60205 --force 2>/dev/null || true
+
+          if [ "$CAP" = "True" ]; then
+            gh pr edit "$PR_NUMBER" --add-label variation-light-cap-reached 2>/dev/null || true
+            LANE=$(python3 -c "import json; print(json.load(open('/tmp/status.json')).get('lane','?'))" 2>/dev/null || echo "?")
+            CB=$(python3 -c "import json; c=(json.load(open('/tmp/status.json')).get('consumed_by') or {}); print(f\"#{c.get('number','?')} (merge a {c.get('mergedAt','?')})\")" 2>/dev/null || echo "une LIGHT anterieure de cette lane")
+            # Commentaire idempotent : un marqueur HTML invisible evite le spam
+            # a chaque synchronize. On ne poste que si aucun commentaire ne le
+            # porte deja.
+            MARK="<!-- gvar2-light-cap -->"
+            if ! gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' 2>/dev/null | grep -qF "$MARK"; then
+              BODY="${MARK}
+          **G-VAR-2 light cap reached** (advisory, non bloquant).
+          La lane \`${LANE}\` a deja merge une LIGHT aujourd'hui (${CB}).
+          G-VAR-2 plafonne a **une LIGHT par lane et par jour, toutes categories LIGHT confondees**
+          (guard, doc, refs, ... partagent un seul budget). La decision de merge reste au coordinateur."
+              gh pr comment "$PR_NUMBER" --body "$BODY" 2>/dev/null || true
+            fi
+            echo "::notice::G-VAR-2 cap reached pour la lane ${LANE} (consomme par ${CB})."
+          else
+            # Cas nominal : on retire un label obsolete colle par un push anterieur.
+            gh pr edit "$PR_NUMBER" --remove-label variation-light-cap-reached 2>/dev/null || true
+          fi
+          exit 0

--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Unit tests for variation_light_cap.py (G-VAR-2 cap detection, #8964).
+
+Acceptance replay over a live `gh pr list` wave is pasted in the PR body; these
+tests pin the PARSING and CAP LOGIC with synthetic cases so the organ does not
+silently rot. Run: `python -m pytest scripts/tests/test_variation_light_cap.py`.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import variation_light_cap as vlc  # noqa: E402
+
+# The three body shapes observed in the wild (separator/case-agnostic, #8938).
+BODY_EMDASH = "Grain: LIGHT/guard -- lane myia-po-2023:CoursIA\n\nbody"
+BODY_HYPHEN_BOLD = "**Grain:** LIGHT/guard - lane myia-ai-01:CoursIA"
+BODY_MIDDOT_BOLD_LANE = (
+    "**Grain:** LIGHT/refs . **Lane:** myia-po-2024:CoursIA-2 . **See** #1206"
+)
+
+
+def test_parse_emdash_lowercase_lane():
+    g = vlc.parse_grain(BODY_EMDASH)
+    assert g == {"tier": "LIGHT", "lane": "myia-po-2023:CoursIA"}
+
+
+def test_parse_hyphen_bold():
+    g = vlc.parse_grain(BODY_HYPHEN_BOLD)
+    assert g == {"tier": "LIGHT", "lane": "myia-ai-01:CoursIA"}
+
+
+def test_parse_middot_bold_capital_lane():
+    # bold + middot + capital **Lane:** + workspace with a hyphen (CoursIA-2)
+    g = vlc.parse_grain(BODY_MIDDOT_BOLD_LANE)
+    assert g == {"tier": "LIGHT", "lane": "myia-po-2024:CoursIA-2"}
+
+
+def test_parse_no_grain_returns_none():
+    assert vlc.parse_grain("no tag here") is None
+
+
+def test_parse_empty_body():
+    assert vlc.parse_grain("") is None
+    assert vlc.parse_grain(None) is None  # type: ignore[arg-type]
+
+
+def test_parse_non_light_tier():
+    g = vlc.parse_grain("Grain: DEEP/lean -- lane myia-po-2023:CoursIA")
+    assert g["tier"] == "DEEP"
+
+
+def test_parse_grain_without_lane():
+    # Tag present but lane missing -> tier read, lane None.
+    g = vlc.parse_grain("Grain: LIGHT/guard -- no lane here")
+    assert g == {"tier": "LIGHT", "lane": None}
+
+
+def test_second_light_same_lane_is_cap_reached():
+    # CI semantics: the current PR is NOT in the merged set. If the lane
+    # already has one merged LIGHT, the current (2nd) is cap-reached.
+    prs = [
+        {"number": 1, "body": BODY_EMDASH, "mergedAt": "2026-07-30T03:00:00Z"},
+    ]
+    status = vlc.light_cap_status(prs, "myia-po-2023:CoursIA")
+    assert status["cap_reached"] is True
+    assert status["consumed_by"]["number"] == 1
+
+
+def test_no_merged_light_not_cap_reached():
+    # No prior merged LIGHT of this lane -> the current PR is the 1st -> OK.
+    status = vlc.light_cap_status([], "myia-po-2023:CoursIA")
+    assert status["cap_reached"] is False
+    assert status["consumed_by"] is None
+
+
+def test_other_lane_merged_does_not_reach_this_lane():
+    # A LIGHT of a DIFFERENT lane already merged does not spend THIS lane's
+    # budget (G-VAR-2 is per-lane).
+    prs = [
+        {"number": 1, "body": BODY_HYPHEN_BOLD, "mergedAt": "2026-07-30T03:00:00Z"},
+    ]
+    status_ai = vlc.light_cap_status(prs, "myia-ai-01:CoursIA")
+    assert status_ai["cap_reached"] is True  # #1 ai-01 merged -> 2nd ai-01 reached
+    status_po = vlc.light_cap_status(prs, "myia-po-2023:CoursIA")
+    assert status_po["cap_reached"] is False  # 0 po-2023 merged -> 1st OK
+
+
+def test_non_light_does_not_spend_budget():
+    # A DEEP PR of the same lane must not consume the LIGHT budget.
+    prs = [
+        {"number": 1, "body": "Grain: DEEP/lean -- lane myia-po-2023:CoursIA",
+         "mergedAt": "2026-07-30T03:00:00Z"},
+    ]
+    status = vlc.light_cap_status(prs, "myia-po-2023:CoursIA")
+    assert status["cap_reached"] is False
+
+
+def test_replay_flags_only_second_light_per_lane():
+    prs = [
+        {"number": 10, "body": BODY_HYPHEN_BOLD, "mergedAt": "2026-07-30T02:54:00Z"},
+        {"number": 9, "body": BODY_EMDASH, "mergedAt": "2026-07-30T03:28:00Z"},
+        {"number": 13, "body": BODY_MIDDOT_BOLD_LANE, "mergedAt": "2026-07-30T03:47:00Z"},
+        {"number": 51, "body": BODY_EMDASH, "mergedAt": "2026-07-30T13:32:00Z"},
+    ]
+    rows = vlc.replay(prs)
+    # #51 is the 2nd po-2023 LIGHT -> the only cap-reached entry.
+    flagged = [r for r in rows if r["cap_reached"]]
+    assert [r["number"] for r in flagged] == [51]
+    assert flagged[0]["consumed_by"] == 9
+    ok = {r["number"] for r in rows if not r["cap_reached"]}
+    assert ok == {10, 9, 13}
+
+
+def test_replay_empty():
+    assert vlc.replay([]) == []

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Detect G-VAR-2 cap-reached: a 2nd+ LIGHT PR merged the same day for a lane.
+
+G-VAR-2 (variation-protocol.md) caps the protocol at **one LIGHT PR per lane
+per day, all LIGHT sub-categories confounded** (guard, doc, refs, ... share a
+single budget). It is the only gate of the protocol that is **cross-PR** -- it
+needs to know what the lane has ALREADY merged today -- so until now it was
+counted by hand by the coordinator, who merged a 2nd LIGHT twice in one cycle
+(issue #8964: measured firsthand on the 2026-07-30 wave). This tool makes the
+fact VISIBLE (advisory, exit 0), it does not block.
+
+Input: a JSON array of the day's merged PRs, each `{number, body, mergedAt}`,
+produced by:
+
+    gh pr list --state merged --search 'merged:<YYYY-MM-DD>' \
+        --json number,body,mergedAt
+
+Modes
+-----
+  --replay <file>      Acceptance-test mode (#8964): for every LIGHT PR in the
+                       dataset, report whether it is cap-reached (a LIGHT of the
+                       same lane merged EARLIER today). Prints a table + a JSON
+                       summary on stdout. The replay over the 2026-07-30 wave
+                       must flag #8951 (2nd LIGHT of myia-po-2023:CoursIA) and
+                       NOT flag #8909 / #8910 / #8913 (each the 1st LIGHT of its
+                       lane).
+
+  --check-pr <N>       CI mode (the current PR): report whether PR <N> would be
+                       cap-reached given the already-merged PRs in <file>.
+                       Emits machine-readable fields for the workflow to label
+                       and comment: `cap_reached`, `lane`, `consumed_by` (the
+                       earlier LIGHT that spent the budget, with its merge time).
+
+Parsing
+-------
+Bodies are read as FULL TEXT, never line-by-line. The line-by-line bug measured
+hand counted "18/38 untagged" when the true figure was "2/38": the tag is often
+on the 2nd+ line of a multi-line body, and a per-line scan misses it (#8964).
+
+Agnostic to separator and case (#8938): the three shapes observed in the wild
+all parse identically after markdown noise is stripped --
+
+    Grain: LIGHT/guard -- lane myia-po-2023:CoursIA      (em-dash)
+    **Grain:** LIGHT/guard - lane myia-ai-01:CoursIA     (bold, hyphen)
+    `Grain: LIGHT/refs` . **Lane:** myia-po-2024:CoursIA-2  (backticks, middot)
+
+Exit 0 always (advisory).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# --- parsing ---------------------------------------------------------------
+
+# Markdown noise to strip before matching: asterisks (bold) and backticks.
+# Mirrors the workflow's `tr -d '*\`'` so the two stay in lockstep.
+_NOISE = str.maketrans({"*": "", "`": ""})
+
+# `Grain:` (case-insensitive) then TIER / GENRE. TIER is the word before `/`.
+_GRAIN_TIER_RE = re.compile(r"Grain:\s*([A-Za-z]+)\s*/", re.IGNORECASE)
+
+# `lane` (case-insensitive), optional colon, whitespace, then machine:workspace.
+# machine = myia-po-2024 (letters, digits, dot, underscore, hyphen); workspace
+# likewise (CoursIA-2). Captured as the single token "<machine>:<workspace>".
+_LANE_RE = re.compile(
+    r"lane:?\s+([A-Za-z0-9._-]+:[A-Za-z0-9._-]+)", re.IGNORECASE
+)
+
+
+def parse_grain(body: str) -> dict | None:
+    """Extract {tier, lane} from a PR body, full-text + separator-agnostic.
+
+    Returns None when no `Grain:` line is found. `tier` is upper-cased
+    (LIGHT/MED/DEEP) or None if the TIER could not be read. `lane` is the
+    "<machine>:<workspace>" string or None.
+    """
+    if not body:
+        return None
+    flat = body.translate(_NOISE)
+    tier_m = _GRAIN_TIER_RE.search(flat)
+    if not tier_m:
+        return None
+    lane_m = _LANE_RE.search(flat)
+    return {
+        "tier": tier_m.group(1).upper(),
+        "lane": lane_m.group(1) if lane_m else None,
+    }
+
+
+# --- cap logic -------------------------------------------------------------
+
+def light_cap_status(merged_prs: list[dict], target_lane: str) -> dict:
+    """Given the day's ALREADY-MERGED PRs, is a NEW LIGHT of `target_lane`
+    cap-reached?
+
+    CI semantics: the current PR is OPEN (not yet merged), so it is NOT in
+    `merged_prs`. If the lane already has >= 1 LIGHT merged today, the current
+    PR would be the 2nd -> cap-reached. Returns {cap_reached, consumed_by}
+    where consumed_by is the earliest merged LIGHT of that lane (the one that
+    spent the budget), or None.
+    """
+    earlier_lights = []
+    for pr in merged_prs:
+        g = parse_grain(pr.get("body", ""))
+        if not g or g["tier"] != "LIGHT" or g["lane"] != target_lane:
+            continue
+        earlier_lights.append(pr)
+    if not earlier_lights:
+        return {"cap_reached": False, "consumed_by": None}
+    # earliest merged LIGHT of the lane = the one that consumed the budget
+    earlier_lights.sort(key=lambda p: p.get("mergedAt", ""))
+    first = earlier_lights[0]
+    return {
+        "cap_reached": True,
+        "consumed_by": {
+            "number": first.get("number"),
+            "mergedAt": first.get("mergedAt"),
+        },
+    }
+
+
+def replay(merged_prs: list[dict]) -> list[dict]:
+    """For every LIGHT PR in the set, decide cap_reached against the FULL set.
+
+    A LIGHT is cap-reached iff a LIGHT of its OWN lane merged strictly EARLIER
+    (earlier mergedAt). The first LIGHT of each lane is never cap-reached.
+    Returns the list sorted by mergedAt (chronological replay).
+    """
+    lights = []
+    for pr in merged_prs:
+        g = parse_grain(pr.get("body", ""))
+        if not g or g["tier"] != "LIGHT" or not g["lane"]:
+            continue
+        lights.append({**pr, "_tier": g["tier"], "_lane": g["lane"]})
+    lights.sort(key=lambda p: p.get("mergedAt", ""))
+    # one pass: per lane, the first seen (chronologically) is the budget owner
+    seen_lane: dict[str, int] = {}
+    out = []
+    for pr in lights:
+        lane = pr["_lane"]
+        owner = seen_lane.get(lane)
+        cap = owner is not None
+        out.append({
+            "number": pr.get("number"),
+            "lane": lane,
+            "mergedAt": pr.get("mergedAt"),
+            "cap_reached": cap,
+            "consumed_by": owner,
+        })
+        if owner is None:
+            seen_lane[lane] = pr.get("number")
+    return out
+
+
+# --- CLI -------------------------------------------------------------------
+
+def _load(path: str) -> list[dict]:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        sys.exit(f"--replay/--check-pr expects a JSON array, got {type(data).__name__}")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--replay", metavar="FILE",
+                   help="JSON array of the day's merged PRs (the counting set)")
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--replay-mode", action="store_true",
+                   help="acceptance-test mode: report cap_reached for every "
+                        "LIGHT in the --replay set")
+    g.add_argument("--check-pr", metavar="N", type=int,
+                   help="CI mode: assess PR <N> (the current open PR) against "
+                        "the --replay merged set")
+    p.add_argument("--body", metavar="TEXT",
+                   help="--check-pr only: body of the current PR (the open PR "
+                        "is not in the merged set, so its tag is read here)")
+    p.add_argument("--body-file", metavar="FILE",
+                   help="--check-pr only: path to a file holding the current "
+                        "PR body (alternative to --body)")
+    args = p.parse_args(argv)
+
+    if not args.replay:
+        p.error("--replay FILE (the merged-PR set) is required")
+
+    merged = _load(args.replay)
+
+    if args.check_pr is not None:
+        # CI mode: the current PR is OPEN, so its body is NOT in the merged set.
+        body = None
+        if args.body is not None:
+            body = args.body
+        elif args.body_file:
+            body = Path(args.body_file).read_text(encoding="utf-8")
+        if body is None:
+            p.error("--check-pr requires --body or --body-file")
+        g = parse_grain(body)
+        if not g or g["tier"] != "LIGHT":
+            print(json.dumps({"cap_reached": False, "reason": "not LIGHT"}))
+            return 0
+        if not g["lane"]:
+            print(json.dumps({"cap_reached": False, "reason": "no lane in tag"}))
+            return 0
+        status = light_cap_status(merged, g["lane"])
+        print(json.dumps({
+            "pr": args.check_pr,
+            "lane": g["lane"],
+            **status,
+        }))
+        return 0
+
+    # replay mode: the acceptance test
+    rows = replay(merged)
+    flagged = [r for r in rows if r["cap_reached"]]
+    print(f"LIGHT PRs replayed: {len(rows)} | cap-reached: {len(flagged)}")
+    print(f"{'PR':>7}  {'lane':<28} {'mergedAt':<21} cap")
+    for r in rows:
+        mark = "CAP-REACHED" if r["cap_reached"] else "ok"
+        print(f"  #{r['number']:<5} {r['lane']:<28} {r['mergedAt']:<21} {mark}"
+              + (f"  (consumed by #{r['consumed_by']})" if r["cap_reached"] else ""))
+    print(json.dumps({"rows": rows}, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA-2 — prev: MED/guard (#8921 MERGED)

# #8964 — G-VAR-2 light-cap organ (the cross-PR counter the protocol lacked)

## Why

G-VAR-2 caps the variation protocol at **one LIGHT PR per lane per day, all LIGHT sub-categories confounded** (guard, doc, refs, ... share a single budget). It is the **only gate that is cross-PR** — it needs to know what the lane has *already merged* today — so until now it was counted **by hand** by the coordinator, who merged a 2nd LIGHT twice in one cycle (#8964, measured firsthand on the 2026-07-30 wave). This PR gives the cap an **organ** that renders the fact **visible** (advisory, exit 0).

## Livrable (3 files)

1. **`scripts/variation_light_cap.py`** — the detector, testable + offline:
   - `--replay FILE --replay-mode` : acceptance test — for every LIGHT in the set, report `cap_reached` (a LIGHT of the same lane merged strictly earlier today).
   - `--replay FILE --check-pr N --body FILE` : CI mode — assess the current OPEN PR against the already-merged set.
   - Bodies parsed as **full text** (not line-by-line — that bug measured "18/38 untagged" instead of "2/38"), **agnostic to separator/case** (#8938): `Grain: LIGHT/x — lane a:b`, `**Grain:** LIGHT/x - lane a:b`, `**Grain:** LIGHT/x · **Lane:** a:b` all parse identically.

2. **`scripts/tests/test_variation_light_cap.py`** — 13 unit tests pinning the parsing + cap logic on synthetic cases (3 body shapes, lane isolation, non-LIGHT doesn't spend budget, replay flags only the 2nd LIGHT/lane).

3. **`.github/workflows/variation-tag-guard.yml`** — a 2nd job `check-light-cap` (sibling to the existing tag-conformity job): sparse-checkout the script, build the day's merged set via `gh pr list --state merged --search merged:<today>`, assess the current PR, label `variation-light-cap-reached` + post **one** idempotent comment (HTML marker) naming the PR that consumed the budget. **ADVISORY exit 0** — same discipline as the rest of the guard; the merge decision stays with the coordinator.

## Acceptance (#8964 criterion) — replayed firsthand on the 2026-07-30 wave

The issue's criterion: *replayed over the day's PRs, the job must flag **#8951** (2nd LIGHT of `myia-po-2023:CoursIA`) and NOT flag #8913 / #8909 / #8910 (each the 1st LIGHT of its lane).*

```
LIGHT PRs replayed: 5 | cap-reached: 2
     PR  lane                         mergedAt              cap
  #8910  myia-ai-01:CoursIA           2026-07-30T02:54:22Z  ok
  #8909  myia-po-2023:CoursIA         2026-07-30T03:28:11Z  ok
  #8913  myia-po-2024:CoursIA-2       2026-07-30T03:47:18Z  ok
  #8951  myia-po-2023:CoursIA         2026-07-30T13:32:41Z  CAP-REACHED  (consumed by #8909)
  #8930  myia-po-2024:CoursIA-2       2026-07-30T16:03:58Z  CAP-REACHED  (consumed by #8913)
```

**Flags #8951 and does NOT flag #8913/#8909/#8910** — exactly the criterion. It also flags **#8930**, which the coordinator had **held manually** on G-VAR-2 grounds (the slides symmetric-trap, 2nd LIGHT of `myia-po-2024:CoursIA-2`): the organ reproduces the human decision.

## Verified

- `ast.parse` OK on the script; **13 unit tests pass**.
- PyYAML parses the workflow (2 jobs, both well-formed).
- `bash -n` on **both** run blocks (new `check-light-cap` + original `check-variation-tag`, no regression).
- `--check-pr` mode (simulated: #8951 body vs. the set without #8951) returns `cap_reached=true, consumed_by={number:8909, ...}`.

## Scope notes

- Grain **MED/tooling** (new CI job + testable script + measurable acceptance criterion) — not a LIGHT, so G-VAR-2 does not gate it.
- No `.claude/rules/` touched (the organ APPLIES the protocol as written) — no sign-off required.
- Bots and forks excluded (same anti-spam guard as the tag job).
- ADVISORY exit 0: this renders the cap breach *auditable*; it does not block. Hardening to blocking, if ever, is an explicit later decision (the guard's own header says so).

Closes #8964. See #8938 (separator/case agnosticism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
