### PR TITLE
feat(ci,#8970): G-VAR-2 requalification channel — label overrides the declared tier

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -220,6 +220,15 @@ jobs:
   # (testable, agnostique separateur/casse #8938, bodies lus en TEXTE ENTIER --
   # le bug ligne-a-ligne avait rendu "18/38 sans tag" au lieu de "2/38"). Le job
   # n'est que la plomberie CI : dataset des mergees du jour + label + commentaire.
+  #
+  # #8970 : le compteur lit le tier DECLARE, mais le protocole dit que le tag
+  # declare n'est pas auto-executable -- le coordinateur RE-qualifie au merge
+  # (up LIGHT->MED, down DEEP->LIGHT). Cette requalification est porte par un
+  # LABEL `grain-requalified:<TIER>` applique au merge (machine-readable, body
+  # intact, cheap : --json labels ajoute le champ a la MEME requete, pas de
+  # quota supplementaire). Le label OVERRIDE le tier declare pour le comptage,
+  # dans les deux sens. Sans lui, le compteur flaggait du travail legitiment
+  # re-qualifie (1 FP/2 flags sur la vague 2026-07-30 : #8930 LIGHT->MED).
   check-light-cap:
     name: G-VAR-2 light cap (cross-PR)
     runs-on: ubuntu-latest
@@ -256,21 +265,34 @@ jobs:
           # Les PR deja mergees aujourd'hui = le jeu de comptage. La PR courante
           # est OUVERTE (le job tourne sur opened/edited/synchronize/reopened,
           # pas sur le merge) donc elle n'est PAS dans ce set -- c'est ce qui
-          # rend la 2e LIGHT detectable.
+          # rend la 2e LIGHT detectable. On recupere aussi les LABELS pour
+          # honorer la requalification #8970 (grain-requalified:<TIER> qui
+          # override le tier declare) : ajouter le champ `labels` a la MEME
+          # requete ne consomme pas de quota supplementaire.
           gh pr list --state merged --search "merged:$TODAY" \
-            --json number,body,mergedAt > /tmp/merged.json 2>/dev/null || true
+            --json number,body,mergedAt,labels > /tmp/merged.json 2>/dev/null || true
 
           # Le body circule par fichier : printf '%s' ne reinterprete rien
           # (newlines, quotes, $), contrairement a un passage en arg CLI.
           printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
 
-          # ADVISORY : le script sort toujours en 0. Si le TIER n'est pas LIGHT
-          # ou la lane absente, il renvoie cap_reached=false et le label est
-          # retire (un label colle par un push anterieur ne survit pas).
+          # Labels de la PR courante : une requalification peut etre pre-appliquee
+          # sur la PR ouverte (cas down-qualification, ou up-qualification
+          # anticipee). On les passe au detecteur pour que son verdict soit
+          # symetrique a celui porte sur les mergees. `gh pr view --json labels`
+          # renvoie [{name,...}] -- le script l'aplatit.
+          gh pr view "$PR_NUMBER" --json labels > /tmp/pr_labels.json 2>/dev/null || \
+            printf '[]' > /tmp/pr_labels.json
+
+          # ADVISORY : le script sort toujours en 0. Si le TIER EFFECTIF n'est
+          # pas LIGHT (declare LIGHT re-qualifie up, ou declare non-LIGHT sans
+          # down-qualif) ou la lane absente, il renvoie cap_reached=false et le
+          # label est retire (un label colle par un push anterieur ne survit pas).
           python3 scripts/variation_light_cap.py \
             --replay /tmp/merged.json \
             --check-pr "$PR_NUMBER" \
-            --body-file /tmp/pr_body.txt > /tmp/status.json 2>/tmp/cap.err || true
+            --body-file /tmp/pr_body.txt \
+            --labels-file /tmp/pr_labels.json > /tmp/status.json 2>/tmp/cap.err || true
 
           echo "--- detector output ---"
           cat /tmp/status.json 2>/dev/null || true

--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -114,3 +114,98 @@ def test_replay_flags_only_second_light_per_lane():
 
 def test_replay_empty():
     assert vlc.replay([]) == []
+
+
+# --- requalification (#8970): coordinator override of the declared tag -----
+
+# GitHub `--json labels` returns objects {name,...}; label_names must flatten
+# BOTH that shape and a bare [str].
+def test_label_names_flattens_objects_and_strings():
+    assert vlc.label_names({"labels": [{"name": "a", "color": "fff"}, {"name": "b"}]}) == ["a", "b"]
+    assert vlc.label_names({"labels": ["a", "b"]}) == ["a", "b"]
+    assert vlc.label_names({}) == []
+    assert vlc.label_names({"labels": None}) == []
+
+
+def test_effective_tier_declared_when_no_requal_label():
+    # No requalification label -> the declared tier stands.
+    assert vlc.effective_tier(BODY_EMDASH, []) == "LIGHT"
+    assert vlc.effective_tier("Grain: DEEP/lean -- lane x:y", ["bug"]) == "DEEP"
+
+
+def test_effective_tier_requal_label_overrides_up():
+    # Declared LIGHT, re-qualified MED -> effective MED (spares the budget).
+    assert vlc.effective_tier(BODY_EMDASH, ["grain-requalified:MED"]) == "MED"
+
+
+def test_effective_tier_requal_label_overrides_down():
+    # Declared DEEP, re-qualified LIGHT -> effective LIGHT (consumes the budget).
+    # This is the symmetric case #8970 requires a test for.
+    assert vlc.effective_tier(
+        "Grain: DEEP/lean -- lane x:y", ["grain-requalified:LIGHT"]
+    ) == "LIGHT"
+
+
+def test_effective_tier_requal_label_case_insensitive():
+    assert vlc.effective_tier(BODY_EMDASH, ["Grain-Requalified:med"]) == "MED"
+
+
+def test_up_qualification_spare_light_budget():
+    # A declared LIGHT re-qualified up to MED does NOT spend the budget ->
+    # a NEW LIGHT of the same lane is the 1st -> not cap-reached. (#8930 case.)
+    prs_po2023 = [
+        {"number": 30, "body": BODY_EMDASH,  # po-2023, declared LIGHT
+         "labels": ["grain-requalified:MED"],
+         "mergedAt": "2026-07-30T03:00:00Z"},
+    ]
+    status = vlc.light_cap_status(prs_po2023, "myia-po-2023:CoursIA")
+    assert status["cap_reached"] is False  # the only LIGHT was re-qualified up
+
+
+def test_up_qualification_unflags_in_replay():
+    # #8930 acceptance case: declared LIGHT/tooling (po-2024), re-qualified MED,
+    # must NOT be flagged in the replay. #8951 (no requal) stays flagged.
+    prs = [
+        {"number": 9, "body": BODY_EMDASH, "mergedAt": "2026-07-30T03:28:00Z"},
+        {"number": 13, "body": BODY_MIDDOT_BOLD_LANE, "mergedAt": "2026-07-30T03:47:00Z"},
+        {"number": 51, "body": BODY_EMDASH, "mergedAt": "2026-07-30T13:32:00Z"},
+        {"number": 30, "body": BODY_MIDDOT_BOLD_LANE,  # po-2024, declared LIGHT
+         "labels": ["grain-requalified:MED"],
+         "mergedAt": "2026-07-30T16:03:00Z"},
+    ]
+    rows = vlc.replay(prs)
+    flagged = {r["number"] for r in rows if r["cap_reached"]}
+    assert 51 in flagged      # 2nd po-2023 LIGHT, no requal -> flagged
+    assert 30 not in flagged  # re-qualified up to MED -> NOT a LIGHT -> unflagged
+    assert 30 not in {r["number"] for r in rows}  # not even counted as a LIGHT
+
+
+def test_down_qualification_feeds_counter_in():
+    # Symmetric: a declared DEEP re-qualified DOWN to LIGHT DOES spend the
+    # budget -> a later declared LIGHT of the same lane becomes the 2nd.
+    prs = [
+        {"number": 1, "body": "Grain: DEEP/lean -- lane myia-po-2023:CoursIA",
+         "labels": ["grain-requalified:LIGHT"],
+         "mergedAt": "2026-07-30T02:00:00Z"},
+        {"number": 2, "body": BODY_EMDASH,  # declared LIGHT, same lane
+         "mergedAt": "2026-07-30T10:00:00Z"},
+    ]
+    # #1 is now an effective LIGHT -> a NEW po-2023 LIGHT is cap-reached.
+    status = vlc.light_cap_status(prs, "myia-po-2023:CoursIA")
+    assert status["cap_reached"] is True
+    assert status["consumed_by"]["number"] == 1  # the re-qualified-down PR
+
+
+def test_replay_down_qualification_makes_later_light_cap_reached():
+    prs = [
+        {"number": 1, "body": "Grain: DEEP/lean -- lane myia-po-2023:CoursIA",
+         "labels": ["grain-requalified:LIGHT"],
+         "mergedAt": "2026-07-30T02:00:00Z"},
+        {"number": 2, "body": BODY_EMDASH, "mergedAt": "2026-07-30T10:00:00Z"},
+    ]
+    rows = vlc.replay(prs)
+    # both are now effective LIGHT of the same lane -> #2 is the 2nd -> flagged
+    flagged = [r for r in rows if r["cap_reached"]]
+    assert [r["number"] for r in flagged] == [2]
+    assert flagged[0]["consumed_by"] == 1
+

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -91,6 +91,61 @@ def parse_grain(body: str) -> dict | None:
     }
 
 
+# --- requalification (coordinator override of the declared tag) ------------
+
+# variation-protocol says the DECLARED `Grain:` tag is not self-executing: the
+# coordinator re-qualifies it at merge (up: a declared LIGHT read as MED on the
+# strength of the diff; down: a declared DEEP read as LIGHT). Until #8970 that
+# decision lived only in a dashboard post -- invisible to this job, which then
+# flagged legitimately re-qualified work (1 FP / 2 flags on the 2026-07-30
+# wave: #8930, re-qualified LIGHT->MED, was still flagged CAP-REACHED).
+#
+# The channel is a GitHub LABEL applied at merge -- `grain-requalified:<TIER>`
+# -- machine-readable, leaves the worker's body intact, cheap to query
+# (`gh pr list --json ...,labels` adds the field to the SAME call, no extra
+# quota). A present label OVERRIDES the declared tier for counting, in BOTH
+# directions: up-qualification spares the LIGHT budget, down-qualification
+# consumes it (the symmetric case #8970 asks for). The LANE is structural
+# (the worker's workspace) and is never re-qualified -- it still comes from
+# the declared body.
+_REQUAL_LABEL_RE = re.compile(
+    r"grain-requalified:\s*(LIGHT|MED|DEEP)", re.IGNORECASE
+)
+
+
+def label_names(pr: dict) -> list[str]:
+    """Flatten a PR's `labels` field to a list of names.
+
+    Robust to the two shapes `gh ... --json labels` can return: a list of
+    strings (names) or a list of objects `{name, color, ...}` (the default).
+    """
+    out: list[str] = []
+    for lab in pr.get("labels") or []:
+        if isinstance(lab, str):
+            out.append(lab)
+        elif isinstance(lab, dict):
+            name = lab.get("name")
+            if name:
+                out.append(name)
+    return out
+
+
+def effective_tier(body: str | None, labels: list[str]) -> str | None:
+    """The TIER that counts for G-VAR-2.
+
+    A `grain-requalified:<TIER>` label (if present) OVERRIDES the declared
+    `Grain:` tag, in both directions -- up (LIGHT->MED spares the budget) and
+    down (DEEP->LIGHT consumes it). Returns the declared tier when no
+    requalification label is present, or None when neither is readable.
+    """
+    for lab in labels:
+        m = _REQUAL_LABEL_RE.search(lab)
+        if m:
+            return m.group(1).upper()
+    g = parse_grain(body or "")
+    return g["tier"] if g else None
+
+
 # --- cap logic -------------------------------------------------------------
 
 def light_cap_status(merged_prs: list[dict], target_lane: str) -> dict:
@@ -102,11 +157,19 @@ def light_cap_status(merged_prs: list[dict], target_lane: str) -> dict:
     PR would be the 2nd -> cap-reached. Returns {cap_reached, consumed_by}
     where consumed_by is the earliest merged LIGHT of that lane (the one that
     spent the budget), or None.
+
+    A PR counts as a LIGHT for the budget iff its EFFECTIVE tier (#8970
+    requalification) is LIGHT: a declared LIGHT re-qualified up to MED does
+    NOT spend it, a declared DEEP re-qualified down to LIGHT DOES.
     """
     earlier_lights = []
     for pr in merged_prs:
+        labels = label_names(pr)
+        if effective_tier(pr.get("body", ""), labels) != "LIGHT":
+            continue
+        # lane is structural -- never re-qualified; it still comes from the body.
         g = parse_grain(pr.get("body", ""))
-        if not g or g["tier"] != "LIGHT" or g["lane"] != target_lane:
+        if not g or g["lane"] != target_lane:
             continue
         earlier_lights.append(pr)
     if not earlier_lights:
@@ -132,10 +195,13 @@ def replay(merged_prs: list[dict]) -> list[dict]:
     """
     lights = []
     for pr in merged_prs:
-        g = parse_grain(pr.get("body", ""))
-        if not g or g["tier"] != "LIGHT" or not g["lane"]:
+        labels = label_names(pr)
+        if effective_tier(pr.get("body", ""), labels) != "LIGHT":
             continue
-        lights.append({**pr, "_tier": g["tier"], "_lane": g["lane"]})
+        g = parse_grain(pr.get("body", ""))
+        if not g or not g["lane"]:
+            continue
+        lights.append({**pr, "_tier": "LIGHT", "_lane": g["lane"]})
     lights.sort(key=lambda p: p.get("mergedAt", ""))
     # one pass: per lane, the first seen (chronologically) is the budget owner
     seen_lane: dict[str, int] = {}
@@ -182,6 +248,10 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--body-file", metavar="FILE",
                    help="--check-pr only: path to a file holding the current "
                         "PR body (alternative to --body)")
+    p.add_argument("--labels-file", metavar="FILE",
+                   help="--check-pr only: JSON array of the current PR's labels "
+                        "(so a requalification label on the open PR is honored; "
+                        "symmetric to the requalification read on merged PRs)")
     args = p.parse_args(argv)
 
     if not args.replay:
@@ -198,11 +268,29 @@ def main(argv: list[str] | None = None) -> int:
             body = Path(args.body_file).read_text(encoding="utf-8")
         if body is None:
             p.error("--check-pr requires --body or --body-file")
-        g = parse_grain(body)
-        if not g or g["tier"] != "LIGHT":
-            print(json.dumps({"cap_reached": False, "reason": "not LIGHT"}))
+        cur_labels: list[str] = []
+        if args.labels_file:
+            # Tolerate a missing/empty file (treat as no labels) rather than
+            # crash: the CI workflow always writes valid JSON (`gh pr view` or
+            # a `printf '[]'` fallback), but a manual invocation should not
+            # hard-fail on an absent file.
+            lpath = Path(args.labels_file)
+            raw = []
+            if lpath.exists() and lpath.read_text(encoding="utf-8").strip():
+                try:
+                    raw = json.loads(lpath.read_text(encoding="utf-8"))
+                except json.JSONDecodeError:
+                    raw = []
+            # accept [str] or [{name}] (label_names handles objects via a dict)
+            cur_labels = label_names({"labels": raw})
+        # Effective tier (#8970): a requalification label overrides the declared
+        # one. Only an EFFECTIVE LIGHT is assessed against the cap.
+        eff = effective_tier(body, cur_labels)
+        if eff != "LIGHT":
+            print(json.dumps({"cap_reached": False, "reason": f"not LIGHT (effective {eff})"}))
             return 0
-        if not g["lane"]:
+        g = parse_grain(body)
+        if not g or not g["lane"]:
             print(json.dumps({"cap_reached": False, "reason": "no lane in tag"}))
             return 0
         status = light_cap_status(merged, g["lane"])


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA-2 — prev: MED/tooling (#8968 MERGED)

*Same-genre carve-out: this is the direct follow-up tranche of the #8964/#8968 rollout (the requalification precision gap jsboige discovered while verifying #8968), like the #7740 M4/M5 multi-tranche precedent.*

# #8970 — G-VAR-2 requalification channel (the declared tag is not self-executing)

## Why

The G-VAR-2 counter (#8968) reads the **declared** `Grain:` tag. But variation-protocol says the declared tag is *not self-executing*: the coordinator **re-qualifies** it at merge (up: a declared LIGHT read as MED on the strength of the diff; down: a declared DEEP read as LIGHT). Until now that decision lived only in a dashboard post — **invisible to the job**, which then flagged legitimately re-qualified work. jsboige measured it firsthand while verifying #8968's acceptance: **1 false positive out of 2 flags** on the 2026-07-30 wave — #8930, re-qualified LIGHT→MED (the HOLD was withdrawn after reading the diff; 43 lines of shell reasoning), was still flagged `CAP-REACHED`.

## The channel

A **GitHub label `grain-requalified:<TIER>`** applied at merge — machine-readable, leaves the worker's body intact, cheap to query (`gh pr list --json ...,labels` adds the field to the **same** call, no extra quota). A present label **overrides** the declared tier for counting, in **both** directions:
- **up-qualification** (LIGHT→MED): spares the LIGHT budget.
- **down-qualification** (DEEP→LIGHT): consumes it (the symmetric case #8970 asks for).

The **lane** is structural (the worker's workspace) — never re-qualified; it still comes from the declared body.

## Livrable (3 files)

1. **`scripts/variation_light_cap.py`**:
   - `label_names()` — flatten `labels` to names (robust to `[str]` and `[{name}]`).
   - `effective_tier(body, labels)` — a requal label overrides the declared tier; falls back to the declared tag otherwise.
   - `light_cap_status()` + `replay()` now count by **effective** tier. `--check-pr` gains `--labels-file` (symmetric requal read on the open PR), tolerant of a missing/empty file.
2. **`scripts/tests/test_variation_light_cap.py`** — **9 new tests** (label_names, effective_tier up/down/case-insensitive, up spares budget, down feeds in, replay unflags the re-qualified, replay down-qualif makes a later LIGHT cap-reached). **22 total, 0 regression.**
3. **`.github/workflows/variation-tag-guard.yml`** — `check-light-cap` fetches `... --json number,body,mergedAt,labels`, passes `--labels-file` from `gh pr view $PR --json labels`.

## Acceptance (#8970) — replayed firsthand on the REAL 2026-07-30 dataset

```
BEFORE backfill: 5 LIGHTs, 2 cap-reached  -> #8951 + #8930 both CAP-REACHED  (the bug; #8930 was re-qual MED)
AFTER  backfill: 4 LIGHTs, 1 cap-reached
     #8951  myia-po-2023:CoursIA   CAP-REACHED  (consumed by #8909)
     #8930  NOT flagged            (effective MED — dropped from the count)
     #8913 / #8909 / #8910         unflagged    (no regression on #8964)
```
- **Down-qualification path** covered by tests (`test_down_qualification_feeds_counter_in`, `test_replay_down_qualification_makes_later_light_cap_reached`).
- `bash -n` on both run blocks (tag job + light-cap job, no regression); ast.parse OK; PyYAML parses.

## Backfill note (transparency)

The real-replay pass depends on the `grain-requalified:MED` label I applied to **#8930** — a **one-time recording** of the coordinator's known merge-time decision (the requalification predates this channel and lived only in a dashboard post). Going forward the coordinator applies the label at merge. **Reversible** (remove the label); does not re-trigger the guard (the job runs on `opened/edited/synchronize/reopened`, not on `labeled`).

Closes #8970. See #8964, #8968, #8930.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
