### PR TITLE
feat(g-var-2,#8970): light-cap counter reads coordinator re-qualification label

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -257,8 +257,13 @@ jobs:
           # est OUVERTE (le job tourne sur opened/edited/synchronize/reopened,
           # pas sur le merge) donc elle n'est PAS dans ce set -- c'est ce qui
           # rend la 2e LIGHT detectable.
+          # `labels` inclus (#8970) : un PR re-qualifie MED au merge porte le label
+          # `grain-requalified:MED` -- le compteur le lit comme tier EFFECTIF et
+          # ne le compte plus comme LIGHT depensier (symetrique pour la
+          # down-qualification LIGHT). Sans cout d'API supplementaire (un seul
+          # champ dans le meme appel `gh pr list`).
           gh pr list --state merged --search "merged:$TODAY" \
-            --json number,body,mergedAt > /tmp/merged.json 2>/dev/null || true
+            --json number,body,mergedAt,labels > /tmp/merged.json 2>/dev/null || true
 
           # Le body circule par fichier : printf '%s' ne reinterprete rien
           # (newlines, quotes, $), contrairement a un passage en arg CLI.

--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -114,3 +114,110 @@ def test_replay_flags_only_second_light_per_lane():
 
 def test_replay_empty():
     assert vlc.replay([]) == []
+
+
+# --- re-qualification (#8970) ----------------------------------------------
+# Declared LIGHT, coordinator re-qualified MED at merge. The label is the final
+# word on the tier; the declared tag stays in the body (author intent preserved).
+LABEL_REQUAL_MED = [{"name": "grain-requalified:MED"}]
+LABEL_REQUAL_LIGHT = [{"name": "grain-requalified:LIGHT"}]
+
+
+def test_effective_grain_label_overrides_tier():
+    g = vlc.effective_grain({"body": BODY_EMDASH, "labels": LABEL_REQUAL_MED})
+    assert g["tier"] == "MED"
+    assert g["declared_tier"] == "LIGHT"
+    assert g["lane"] == "myia-po-2023:CoursIA"
+
+
+def test_effective_grain_no_label_keeps_declared():
+    g = vlc.effective_grain({"body": BODY_EMDASH})
+    assert g["tier"] == "LIGHT"
+    assert g["declared_tier"] == "LIGHT"
+
+
+def test_label_names_accepts_strings_and_dicts():
+    # gh yields [{"name": ...}]; synthetic data may carry bare strings.
+    assert vlc._label_names({"labels": [{"name": "a"}, {"name": "b"}]}) == ["a", "b"]
+    assert vlc._label_names({"labels": ["a", "b"]}) == ["a", "b"]
+    assert vlc._label_names({}) == []
+
+
+def test_requalified_tier_case_insensitive():
+    assert vlc._requalified_tier(["grain-requalified:med"]) == "MED"
+    assert vlc._requalified_tier(["other", "grain-requalified:LIGHT"]) == "LIGHT"
+    assert vlc._requalified_tier([]) is None
+    # An unrelated label must not be misread as a re-qualification.
+    assert vlc._requalified_tier(["variation-light-cap-reached"]) is None
+
+
+def test_requalified_med_does_not_spend_budget():
+    # #8970: a prior merged declared-LIGHT re-qualified MED is NOT a LIGHT, so it
+    # did not spend the budget -> a new LIGHT of the lane is NOT cap-reached.
+    prs = [
+        {"number": 8930, "body": BODY_EMDASH, "mergedAt": "2026-07-30T10:00:00Z",
+         "labels": LABEL_REQUAL_MED},
+    ]
+    status = vlc.light_cap_status(prs, "myia-po-2023:CoursIA")
+    assert status["cap_reached"] is False
+    assert status["consumed_by"] is None
+
+
+def test_requalified_med_spared_in_replay():
+    # #8970 acceptance: #8930 (declared LIGHT, re-qualified MED) is effective MED
+    # -> it is NOT in the LIGHT replay set, so it is neither flagged nor the
+    # budget owner. #8951 is the real 1st (and only) effective LIGHT -> OK.
+    prs = [
+        {"number": 8930, "body": BODY_EMDASH, "mergedAt": "2026-07-30T10:00:00Z",
+         "labels": LABEL_REQUAL_MED},
+        {"number": 8951, "body": BODY_EMDASH, "mergedAt": "2026-07-30T13:32:00Z"},
+    ]
+    rows = vlc.replay(prs)
+    assert [r["number"] for r in rows] == [8951]
+    assert rows[0]["cap_reached"] is False
+
+
+def test_no_regression_first_light_per_lane():
+    # #8970 acceptance: #8913/#8909/#8910 (1st LIGHT of each lane) stay unflagged
+    # beside a re-qualified PR; only #8951 (real 2nd po-2023 LIGHT) is flagged.
+    prs = [
+        {"number": 8910, "body": BODY_HYPHEN_BOLD, "mergedAt": "2026-07-30T02:54:00Z"},
+        {"number": 8909, "body": BODY_EMDASH, "mergedAt": "2026-07-30T03:28:00Z"},
+        {"number": 8913, "body": BODY_MIDDOT_BOLD_LANE, "mergedAt": "2026-07-30T03:47:00Z"},
+        {"number": 8930, "body": BODY_EMDASH, "mergedAt": "2026-07-30T10:00:00Z",
+         "labels": LABEL_REQUAL_MED},
+        {"number": 8951, "body": BODY_EMDASH, "mergedAt": "2026-07-30T13:32:00Z"},
+    ]
+    rows = vlc.replay(prs)
+    flagged = [r["number"] for r in rows if r["cap_reached"]]
+    assert flagged == [8951]
+    assert {r["number"] for r in rows if not r["cap_reached"]} == {8910, 8909, 8913}
+    assert 8930 not in {r["number"] for r in rows}  # spared: effective MED
+
+
+def test_downqualification_light_spends_budget():
+    # Symmetric case (#8970): a declared DEEP down-qualified to LIGHT IS an
+    # effective LIGHT -> it spends the budget. A later LIGHT is cap-reached.
+    prs = [
+        {"number": 700, "body": "Grain: DEEP/lean -- lane myia-po-2023:CoursIA",
+         "mergedAt": "2026-07-30T08:00:00Z", "labels": LABEL_REQUAL_LIGHT},
+    ]
+    status = vlc.light_cap_status(prs, "myia-po-2023:CoursIA")
+    assert status["cap_reached"] is True
+    assert status["consumed_by"]["number"] == 700
+
+
+def test_downqualification_light_replayed_and_flaggable():
+    # A down-qualified LIGHT enters the replay set and can itself be flagged if
+    # a same-lane effective LIGHT merged earlier. declared_tier is carried.
+    prs = [
+        {"number": 9, "body": BODY_EMDASH, "mergedAt": "2026-07-30T03:28:00Z"},
+        {"number": 700, "body": "Grain: DEEP/lean -- lane myia-po-2023:CoursIA",
+         "mergedAt": "2026-07-30T11:00:00Z", "labels": LABEL_REQUAL_LIGHT},
+    ]
+    rows = vlc.replay(prs)
+    assert [r["number"] for r in rows] == [9, 700]
+    flagged = [r for r in rows if r["cap_reached"]]
+    assert [r["number"] for r in flagged] == [700]
+    assert flagged[0]["consumed_by"] == 9
+    assert rows[1]["declared_tier"] == "DEEP"

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -91,6 +91,72 @@ def parse_grain(body: str) -> dict | None:
     }
 
 
+# --- re-qualification (#8970) ----------------------------------------------
+#
+# The DECLARED `Grain:` tag is not self-executing: the coordinator re-qualifies
+# it at merge (e.g. #8930 was declared LIGHT/tooling, then merged MED after the
+# diff revealed 43 lines of shell reasoning -- not scan-generable). That final
+# decision lives in a machine-readable GitHub label, `grain-requalified:<TIER>`,
+# applied at merge; the body is left intact (author intent preserved).
+#
+# This organ was flagging #8930 as CAP-REACHED on its declared LIGHT -- it
+# reproduced the WITHDRAWN decision (1 FP of 2 flags on the 2026-07-30 replay,
+# #8970). The label is the final word on the tier: a re-qualified-MED does not
+# spend the LIGHT budget; symmetrically, a re-qualified-LIGHT (down-qualification
+# of a declared DEEP) feeds the budget IN.
+
+# `grain-requalified:MED` / `grain-requalified:LIGHT` -- TIER captured, any case.
+_REQUALIFIED_RE = re.compile(r"^grain-requalified:([A-Za-z]+)$")
+
+
+def _label_names(pr: dict) -> list[str]:
+    """Normalize a PR's `labels` field.
+
+    `gh pr list --json ...,labels` yields a list of ``{"name": ...}`` objects;
+    synthetic replay data may carry bare strings. Both are accepted.
+    """
+    raw = pr.get("labels") or []
+    names: list[str] = []
+    for lb in raw:
+        if isinstance(lb, dict):
+            names.append(lb.get("name", ""))
+        else:
+            names.append(str(lb))
+    return names
+
+
+def _requalified_tier(labels: list[str]) -> str | None:
+    """Return the re-qualified TIER from a `grain-requalified:<TIER>` label.
+
+    None when no such label is present (the common case -- most PRs are not
+    re-qualified). Upper-cased to match `parse_grain`'s tier normalization.
+    """
+    for name in labels:
+        m = _REQUALIFIED_RE.match(name.strip())
+        if m:
+            return m.group(1).upper()
+    return None
+
+
+def effective_grain(pr: dict) -> dict | None:
+    """Declared `Grain:` tag, with the tier overridden by any re-qualification.
+
+    Returns ``{tier, declared_tier, lane}`` where ``tier`` is the EFFECTIVE tier
+    (re-qualified one wins, #8970) and ``declared_tier`` is what the body says.
+    None when the body carries no `Grain:` tag at all. Lane is never affected by
+    re-qualification (only the tier moves).
+    """
+    g = parse_grain(pr.get("body", ""))
+    if not g:
+        return None
+    rq = _requalified_tier(_label_names(pr))
+    return {
+        "tier": rq if rq else g["tier"],
+        "declared_tier": g["tier"],
+        "lane": g["lane"],
+    }
+
+
 # --- cap logic -------------------------------------------------------------
 
 def light_cap_status(merged_prs: list[dict], target_lane: str) -> dict:
@@ -105,7 +171,10 @@ def light_cap_status(merged_prs: list[dict], target_lane: str) -> dict:
     """
     earlier_lights = []
     for pr in merged_prs:
-        g = parse_grain(pr.get("body", ""))
+        # EFFECTIVE tier (#8970): a PR re-qualified MED at merge (label
+        # `grain-requalified:MED`) is not a LIGHT -- it did not spend the budget.
+        # Symmetrically, a down-qualified LIGHT (declared DEEP) DOES spend it.
+        g = effective_grain(pr)
         if not g or g["tier"] != "LIGHT" or g["lane"] != target_lane:
             continue
         earlier_lights.append(pr)
@@ -132,10 +201,14 @@ def replay(merged_prs: list[dict]) -> list[dict]:
     """
     lights = []
     for pr in merged_prs:
-        g = parse_grain(pr.get("body", ""))
+        # EFFECTIVE tier (#8970): re-qualification label overrides the declared
+        # one, so a re-qualified-MED is not replayed as a LIGHT (spared) and a
+        # down-qualified LIGHT (declared DEEP) enters the set.
+        g = effective_grain(pr)
         if not g or g["tier"] != "LIGHT" or not g["lane"]:
             continue
-        lights.append({**pr, "_tier": g["tier"], "_lane": g["lane"]})
+        lights.append({**pr, "_tier": g["tier"], "_declared": g["declared_tier"],
+                       "_lane": g["lane"]})
     lights.sort(key=lambda p: p.get("mergedAt", ""))
     # one pass: per lane, the first seen (chronologically) is the budget owner
     seen_lane: dict[str, int] = {}
@@ -148,6 +221,7 @@ def replay(merged_prs: list[dict]) -> list[dict]:
             "number": pr.get("number"),
             "lane": lane,
             "mergedAt": pr.get("mergedAt"),
+            "declared_tier": pr.get("_declared"),
             "cap_reached": cap,
             "consumed_by": owner,
         })


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/lean #8969 (closed, reverted) · MED/qc #8966 (MERGED)

Residual of #8968 (the G-VAR-2 light-cap organ, merged today). Pattern: a
**precision defect in the coordinator's chain**, measured firsthand by the user
on an independently gathered 46-PR dataset.

## The defect (#8970)

The organ counts the **declared** `Grain:` tier from the PR body. But the
declared tag is **not self-executing** — the coordinator re-qualifies it at
merge. Concrete case on the 2026-07-30 replay: **#8930** is flagged
`CAP-REACHED` on its declared `LIGHT/tooling`, but the coordinator's *final*
decision was the opposite — the PR was merged **re-qualified MED** (43 lines of
shell reasoning: a probe inside a process substitution runs in a subshell; a
trailing `[ ] &&` aborts the loop under `set -e` — not scan-generable). The
organ reproduces the *withdrawn* decision: **1 FP of 2 flags**.

## Why it is advisory (not urgent)

The organ is `exit 0` by construction — its signal is the **label**, never a
conclusion. A spurious label is read and dismissed; it blocks nothing. But it
erodes the organ exactly where it is most useful: a counter that flags
legitimately re-qualified work trains its readers to ignore it.

## The fix

A new `effective_grain(pr)` helper returns the body's **declared** tier
**overridden by any `grain-requalified:<TIER>` label** (already created, desc
refs #8970). `light_cap_status` and `replay` use the **effective** tier on the
merged set:

- A re-qualified-**MED** no longer spends the LIGHT budget (the FP case).
- Symmetric: a down-qualified **LIGHT** (declared DEEP) **feeds** the budget in.
- The current **OPEN** PR (`--check-pr`) keeps its **declared** tier — the label
  is applied at merge, so only the already-merged set is overridden.

The workflow gains one field: `gh pr list --json number,body,mergedAt,labels`
(labels ride in the same call — **no extra API quota**, resolving the body's
open worry).

## Proof (end-to-end on the 2026-07-30 wave)

| | replayed LIGHTs | cap-reached |
|---|---|---|
| **baseline** (no label) | 5 | 2 → **#8930 + #8951** (reproduces the #8968 FP) |
| **with fix** | 4 | 1 → **#8951 only; #8930 spared** (effective MED) |

No regression: `#8910` (ai-01), `#8909` (po-2023), `#8913` (po-2024) — each the
1st LIGHT of its lane — stay unflagged in both runs. This is exactly #8970's
acceptance: *replay flags #8951 and NOT #8930*.

## Acceptance (#8970)

- [x] Replay over 2026-07-30 flags #8951 and **not** #8930.
- [x] #8913 / #8909 / #8910 still unflagged (no regression on #8964's criterion).
- [x] Down-qualification path covered by a test
      (`test_downqualification_light_spends_budget` +
      `test_downqualification_light_replayed_and_flaggable`).

## Verification (firsthand, worktree @ 852b38812 = origin/main + this PR)

- **22/22 pytest pass** (`python -m pytest scripts/tests/test_variation_light_cap.py`):
  13 existing (unchanged behaviour — PRs without a label keep their declared
  tier) + 9 new (up/down-qualification, label parsing, no-regression replay).
- **CLI baseline-vs-fix** replay on the synthetic 2026-07-30 wave (output above).
- **Diff +190/-4** across 3 files; catalogue byte-identical to `main`; no Lean,
  no notebook, no i18n touched.
- **No anti-régression §D concern** (pure tooling: a Python detector + its
  tests + a one-field workflow change; advisory exit 0).

## Design-gate disclosure (#8970 "direction not decided")

Implemented the **proposed label channel**: the `grain-requalified:MED` label
already exists with a description referencing #8970, so the direction is
de-facto settled. The body's worry about "burning API quota" is a non-issue —
labels ride in the same `gh pr list --json` call, no per-PR query. If a
different signal channel is later preferred, the `effective_grain` helper is
the single seam to change (label parsing is isolated in `_requalified_tier`).

See #8970, #8964, #8968, #8930.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
