### PR TITLE
fix(guard,#8352): setext rule is now code-fence-aware — 11 FP eliminated

### DIFF
--- a/scripts/notebook_tools/detect_markdown_rendering.py
+++ b/scripts/notebook_tools/detect_markdown_rendering.py
@@ -87,6 +87,13 @@ RULE_SEVERITY = {
 
 # a line that is *only* dashes/equals of length >= 3 (setext underline / thematic break)
 _SETEXT_RE = re.compile(r"^\s{0,3}(-{3,}|={3,})\s*$")
+# a fenced-code marker: >=3 backticks OR tildes, optionally indented up to 3 spaces.
+# A ``` / ~~~ block renders its content VERBATIM, so a `---`/`===` line inside it is
+# literal text (ASCII art, a cryptarithme divider, a box-drawing rule) — NOT a setext
+# underline. Without fence-awareness the setext rules flagged ~11 such cells as
+# `setext_oversized` false positives (CSP cryptarithmes, Sudoku grids, Mermaid-ish
+# boxes). See PR follow-up to #8392 (same precision vein, different FP family).
+_FENCE_RE = re.compile(r"^\s{0,3}(`{3,}|~{3,})")
 _YAML_KV_RE = re.compile(r"^\s*[A-Za-z_][\w .\-]*:\s?(\S.*)?$")
 # exercise-hint keywords, word-boundary. Deliberately NOT "note"/"remarque"
 # (those are legitimate section headings, not the oversized-hint defect).
@@ -138,14 +145,52 @@ def _is_frontmatter_block(lines) -> bool:
     return True
 
 
-def _frontmatter_supersizes(lines) -> bool:
+def _inside_fence_lines(lines) -> set[int]:
+    """Indices of lines that fall INSIDE a fenced-code block (verbatim, non-rendered).
+
+    CommonMark fenced code: a marker line of >=3 backticks or tildes (indent <=3)
+    opens a block; a later marker line of the SAME fence char with length >= the
+    opening closes it. Lines strictly between the two markers (exclusive of both) are
+    "inside" and render verbatim — so any ``---``/``===`` there is literal text, never a
+    setext underline. Backtick and tilde fences are independent: a tilde line never
+    closes a backtick block (and vice-versa). An unclosed fence leaves every subsequent
+    line inside (defensive: prefer a false-negative on setext over a false-positive).
+    """
+    inside: set[int] = set()
+    in_fence = False
+    fence_char = None
+    fence_len = 0
+    for i, ln in enumerate(lines):
+        m = _FENCE_RE.match(ln)
+        if m:
+            marker = m.group(1)
+            ch, ln_len = marker[0], len(marker)
+            if not in_fence:
+                in_fence, fence_char, fence_len = True, ch, ln_len
+                continue  # opening marker line itself is NOT inside
+            elif ch == fence_char and ln_len >= fence_len:
+                in_fence, fence_char, fence_len = False, None, 0
+                continue  # closing marker line is NOT inside
+            # a fence marker of the *other* char inside an open block is literal text
+        if in_fence:
+            inside.add(i)
+    return inside
+
+
+def _frontmatter_supersizes(lines, fenced: set[int] | None = None) -> bool:
     """A setext underline whose IMMEDIATELY-preceding line is text -> oversized H2.
 
     CommonMark: a setext heading underline must be on the line directly after the
     paragraph. A blank line before ``---`` makes it a thematic break (``<hr>``), which
     renders fine — so we require ``lines[j-1]`` to be non-blank, no blank-skipping.
+    ``fenced`` carries the code-fence line indices (see ``_inside_fence_lines``): a
+    ``---``/``===`` line inside a verbatim code block is literal text, not a setext
+    underline, so it is skipped.
     """
+    fenced = fenced or set()
     for j in range(1, len(lines)):
+        if j in fenced:
+            continue
         if _SETEXT_RE.match(lines[j]):
             prev = lines[j - 1].strip()
             if prev and prev != "---" and not prev.startswith("#") and not _SETEXT_RE.match(lines[j - 1]):
@@ -172,6 +217,9 @@ def scan_cell(cell) -> list[dict]:
     if not text.strip():
         return []
     lines = text.split("\n")
+    # Lines inside a fenced-code block render verbatim: a `---`/`===` there is literal
+    # text, not a setext underline. Computed once, reused by both setext rules.
+    fenced = _inside_fence_lines(lines)
     findings: list[dict] = []
 
     # ---- frontmatter-in-markdown ------------------------------------------------
@@ -179,7 +227,7 @@ def scan_cell(cell) -> list[dict]:
         nz = _nonblank(lines)
         yamlish = sum(1 for ln in nz[1:] if ln.strip() != "---" and _YAML_KV_RE.match(ln))
         if yamlish >= 2:
-            if _frontmatter_supersizes(lines):
+            if _frontmatter_supersizes(lines, fenced):
                 rule = "frontmatter_supersize"
                 msg = "YAML frontmatter in a markdown cell renders as one oversized H2 block (setext)"
             else:
@@ -198,6 +246,8 @@ def scan_cell(cell) -> list[dict]:
     # A setext heading forms ONLY when the text line is IMMEDIATELY before the '---'
     # (no blank line between). `paragraph.\n\n---` is a thematic break and renders fine.
     for j in range(1, len(lines)):
+        if j in fenced:
+            continue  # `---`/`===` inside a verbatim code block is literal text
         if _SETEXT_RE.match(lines[j]):
             k = j - 1
             if k < 0:

--- a/scripts/tests/test_detect_markdown_rendering.py
+++ b/scripts/tests/test_detect_markdown_rendering.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Unit tests for detect_markdown_rendering.py (markdown-rendering guard, #8352).
+
+The corpus carries pre-existing violations baselined in
+``markdown_rendering_baseline.json``; this suite pins the DETECTION LOGIC so a
+precision/recall regression cannot ship silently. The focal regression here is
+the code-fence awareness added for the ``setext_oversized`` rule: a ``---``/``===``
+line INSIDE a fenced-code block is literal text (ASCII art, a cryptarithme divider,
+a box-drawing rule) and must NOT be flagged as a setext underline.
+
+Run: ``python -m pytest scripts/tests/test_detect_markdown_rendering.py``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "notebook_tools"))
+
+import detect_markdown_rendering as dmr  # noqa: E402
+
+
+def _cell(source: str) -> dict:
+    """A markdown cell whose source is a single string (the nbformat list form is
+    exercised implicitly via ``_as_text``; the detector handles both)."""
+    return {"cell_type": "markdown", "source": source}
+
+
+def _rules(findings: list[dict]) -> set[str]:
+    return {f["rule"] for f in findings}
+
+
+# ---------------------------------------------------------------- scan_cell core
+
+
+def test_non_markdown_cell_skipped():
+    assert dmr.scan_cell({"cell_type": "code", "source": "# x"}) == []
+
+
+def test_empty_cell_skipped():
+    assert dmr.scan_cell(_cell("   ")) == []
+
+
+# ----------------------------------------------- setext_oversized: fence awareness
+
+
+def test_setext_inside_code_fence_not_flagged():
+    """The canonical false positive: an ASCII-art divider inside a ``` block."""
+    src = (
+        "```\n"
+        "  S E N D\n"
+        "+ M O R E\n"
+        "---------\n"  # >=3 dashes -> _SETEXT_RE, but inside the fence
+        "M O N E Y\n"
+        "```\n"
+    )
+    assert "setext_oversized" not in _rules(dmr.scan_cell(_cell(src)))
+
+
+def test_setext_outside_code_fence_still_flagged():
+    """Regression guard: real prose underlined by --- (outside any fence) IS flagged."""
+    src = (
+        "Ceci est un long paragraphe de prose pedagogique qui se termine "
+        "sans point final avant la regle.\n"
+        "---\n"
+    )
+    assert "setext_oversized" in _rules(dmr.scan_cell(_cell(src)))
+
+
+def test_setext_after_closed_fence_flagged():
+    """--- outside a CLOSED fence underlining real prose is still flagged."""
+    src = (
+        "```\n"
+        "code block\n"
+        "```\n"
+        "\n"
+        "Un paragraphe de prose explicatif assez long pour depasser le seuil.\n"
+        "---\n"
+    )
+    assert "setext_oversized" in _rules(dmr.scan_cell(_cell(src)))
+
+
+def test_cryptarithmetic_ascii_art_not_flagged():
+    """The exact defect family that shipped as FP on the CSP/Sudoku notebooks:
+    a multi-line ASCII diagram inside a code fence containing a `---` divider."""
+    src = (
+        "Voici le cryptarithme SEND + MORE = MONEY :\n\n"
+        "```\n"
+        "    S E N D\n"
+        "  + M O R E\n"
+        "  ---------\n"
+        "  M O N E Y\n"
+        "```\n"
+    )
+    assert "setext_oversized" not in _rules(dmr.scan_cell(_cell(src)))
+
+
+def test_equals_rule_inside_fence_not_flagged():
+    """The `===` setext variant, inside a fence, is also literal."""
+    src = "texte\n```\npara ligne\n=====\n```\n"
+    assert "setext_oversized" not in _rules(dmr.scan_cell(_cell(src)))
+
+
+# ----------------------------------------------------------- _inside_fence_lines
+
+
+def test_inside_fence_lines_basic_backtick():
+    lines = ["```", "a", "---", "b", "```", "c"]
+    assert dmr._inside_fence_lines(lines) == {1, 2, 3}
+
+
+def test_inside_fence_lines_marker_lines_not_inside():
+    """The opening and closing marker lines themselves are NOT inside."""
+    lines = ["```", "a", "```"]
+    assert dmr._inside_fence_lines(lines) == {1}
+
+
+def test_inside_fence_lines_tilde_fence():
+    lines = ["~~~", "x", "y", "~~~"]
+    assert dmr._inside_fence_lines(lines) == {1, 2}
+
+
+def test_inside_fence_lines_unclosed_fence():
+    """An unclosed fence leaves every subsequent line inside (defensive)."""
+    lines = ["```", "a", "---", "b"]
+    assert dmr._inside_fence_lines(lines) == {1, 2, 3}
+
+
+def test_inside_fence_lines_mixed_chars_do_not_close():
+    """A tilde line inside a backtick block is literal text, not a closer."""
+    lines = ["```", "~~~", "a", "```"]
+    assert dmr._inside_fence_lines(lines) == {1, 2}
+
+
+def test_inside_fence_lines_indented_fence():
+    lines = ["   ```python", "a", "---", "   ```"]
+    assert dmr._inside_fence_lines(lines) == {1, 2}
+
+
+def test_inside_fence_lines_two_separate_blocks():
+    lines = ["```", "a", "```", "b", "```", "c", "```"]
+    assert dmr._inside_fence_lines(lines) == {1, 5}
+
+
+def test_no_fence_returns_empty():
+    assert dmr._inside_fence_lines(["a", "---", "b"]) == set()
+
+
+# ---------------------------------------------------- frontmatter still detected
+
+
+def test_frontmatter_supersize_still_detected():
+    """Regression guard: a real frontmatter-supersize block IS still flagged."""
+    src = (
+        "---\n"
+        "title: \"Un notebook\"\n"
+        "cost:\n"
+        "  api_usd_est: 0.01\n"
+        "  cpu_min: 5\n"
+        "---\n"  # directly after a text line -> setext H2 supersize
+    )
+    rules = _rules(dmr.scan_cell(_cell(src)))
+    assert "frontmatter_supersize" in rules
+
+
+def test_frontmatter_rawyaml_still_detected():
+    """Regression guard: raw frontmatter (blank line before closing ---) IS flagged."""
+    src = (
+        "---\n"
+        "title: \"Un notebook\"\n"
+        "cost:\n"
+        "  cpu_min: 5\n"
+        "\n"
+        "---\n"
+    )
+    rules = _rules(dmr.scan_cell(_cell(src)))
+    assert "frontmatter_rawyaml" in rules
+
+
+# -------------------------------------------------------------- oversized hint
+
+
+def test_oversized_hint_still_detected():
+    src = "# Indice : pensez a la recursion pour resoudre ce probleme specifique\n"
+    assert "oversized_hint" in _rules(dmr.scan_cell(_cell(src)))


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/data #8973 (CLEAN/MERGEABLE) · MED/tooling #8972 (CLEAN/MERGEABLE)

## Defect

The `setext_oversized` rule flagged a `---`/`===` line as a setext underline regardless of whether it sat INSIDE a fenced-code block. Inside a ``` / ~~~ block the line renders **verbatim** (ASCII art, a cryptarithme divider, a box-drawing rule) — it is literal text, not an oversized heading. This produced **11 false positives** across 5 families:

| family | notebook (cell) |
|---|---|
| CSP | CSP-1-Fundamentals (cell65, cell67, -Csharp cell40), CSP-3-Advanced (cell50, -Csharp cell19) |
| SMT | 13_Cryptarithmetic_SMT (cell0) |
| Sudoku | Sudoku-7-Norvig-Python (cell24) |
| Planners | Planners-11-Unified-Planning (cell24) |
| GameTheory/Tweety | GameTheory-3-Topology2x2-Csharp (cell2), Tweety-2-Basic-Logics (cell29), Tweety-10-MLN (cell12) |

These cells contain legitimate pedagogical ASCII diagrams (e.g. the SEND+MORE=MONEY cryptarithme grid) inside ``` fences; the `---`/`===` divider is part of the art, not a setext underline. Stripping or reformatting the art would corrupt the notebooks (anti-régression §D) — so the fix belongs in the **detector**, not the corpus.

## Root cause + fix

`detect_markdown_rendering.py` had no code-fence awareness: both setext sites (`_frontmatter_supersizes` + the `scan_cell` setext loop) iterated raw lines and matched `_SETEXT_RE` regardless of whether the line was inside a fenced block.

- Added `_inside_fence_lines(lines)` — CommonMark fence tracking: a marker line of >=3 backticks/tildes (indent <=3) opens; a later same-char marker of length >= opening closes; backtick and tilde fences are independent (a tilde line never closes a backtick block); an unclosed fence leaves all subsequent lines inside (defensive: prefer a false-negative on setext over a false-positive).
- Skip fenced indices in both setext sites.

## Verification (firsthand, all canonical tools post-apply)

- **setext_oversized: 19 -> 8** — the 11 fence FPs gone, the **8 REAL** prose-underline defects preserved (Diagnostic-Medical ×2, Oncology-Planning, Lab5-Viz-ML, Lab6-First-Agent, DecPyMC-7, rl_2_wrappers, rl_3_experience_replay).
- **Gate** `detect_markdown_rendering.py --check --baseline` → exit 0 ("OK: no new ERROR-level markdown-rendering violations").
- **18/18 new unit tests green** (`scripts/tests/test_detect_markdown_rendering.py` — the first dedicated suite for this detector; existing tests covered quarto only).
- frontmatter rules unchanged (1 rawyaml + 17 supersize remain, all baselined).
- Diff +52/-2 on the detector, no corpus change (catalogue byte-identical to main).

## Why the baseline is NOT updated in this PR

The baseline carries **35 orphaned hashes** (24 pre-existing — defects already burned down on main since the last `--update-baseline` regen; 11 mine). A surgical removal of exactly my 11 risks mis-classifying a pre-existing **REAL** defect as NEW (removing its hash from the baseline → next scan flags it as NEW → gate breaks). A dedicated baseline burn-down batch (regen via `--update-baseline`) is deferred to its own subject.

## Follow-up to #8392

Same precision vein, different FP family: #8392 fixed `_is_frontmatter_block` (prose-section-divider FPs); this fixes the setext code-fence FPs.

See #8352.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
