### PR TITLE
docs(lean,#8960): reconcile grothendieck_lean Partie numbering — B canonical, contiguous 1..33

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Comma.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Comma.lean
@@ -1,5 +1,5 @@
 /-
-Grothendieck hommage — Partie 26 : Catégories comma
+Grothendieck hommage — Partie 27 : Catégories comma
 
 Alexandre Grothendieck (1928-2014).
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Comma_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Comma_en.lean
@@ -1,5 +1,5 @@
 /-
-Grothendieck tribute — Part 26: Comma categories
+Grothendieck tribute — Part 27: Comma categories
 
 Alexander Grothendieck (1928-2014).
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Construction.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Construction.lean
@@ -1,5 +1,5 @@
 /-
-Grothendieck Partie 27 — La construction de Grothendieck (catégories fibrées)
+Grothendieck Partie 30 — La construction de Grothendieck (catégories fibrées)
 
 Alexander Grothendieck (1928-2014).
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Construction_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Construction_en.lean
@@ -1,5 +1,5 @@
 /-
-Grothendieck Part 27 — The Grothendieck construction (fibered categories)
+Grothendieck Part 30 — The Grothendieck construction (fibered categories)
 (English mirror of Construction.lean)
 
 Alexander Grothendieck (1928-2014).

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 CoursIA. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 
-# Hommage Grothendieck — Partie 30 : Image directe et image reciproque des faisceaux
+# Hommage Grothendieck — Partie 33 : Image directe et image reciproque des faisceaux
 
 Alexandre Grothendieck (1928-2014).
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DirectImage_en.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 CoursIA. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 
-# Grothendieck tribute — Part 30: Direct image and inverse image of sheaves
+# Grothendieck tribute — Part 33: Direct image and inverse image of sheaves
 
 Phase 5 extension (#2159, Epic #1646).
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Equivalences.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Equivalences.lean
@@ -1,5 +1,5 @@
 /-
-Grothendieck Partie 27 — Équivalences de catégories
+Grothendieck Partie 29 — Équivalences de catégories
 
 Alexandre Grothendieck (1928-2014).
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Equivalences_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Equivalences_en.lean
@@ -1,5 +1,5 @@
 /-
-Grothendieck Part 27 — Equivalences of categories [English mirror of Equivalences.lean]
+Grothendieck Part 29 — Equivalences of categories [English mirror of Equivalences.lean]
 
 Alexander Grothendieck (1928-2014).
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/KanExtensions.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/KanExtensions.lean
@@ -1,5 +1,5 @@
 /-
-Grothendieck Partie 28 — Extensions de Kan
+Grothendieck Partie 31 — Extensions de Kan
 
 Alexandre Grothendieck (1928-2014).
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/KanExtensions_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/KanExtensions_en.lean
@@ -1,5 +1,5 @@
 /-
-Grothendieck Part 28 — Kan extensions [English mirror of KanExtensions.lean]
+Grothendieck Part 31 — Kan extensions [English mirror of KanExtensions.lean]
 
 Alexander Grothendieck (1928-2014).
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Limits.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Limits.lean
@@ -1,5 +1,5 @@
 /-
-Grothendieck Partie 26 — Limites et colimites (au-delà de Yoneda)
+Grothendieck Partie 28 — Limites et colimites (au-delà de Yoneda)
 
 Alexandre Grothendieck (1928-2014).
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Limits_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Limits_en.lean
@@ -1,5 +1,5 @@
 /-
-Grothendieck Part 26 — Limits and colimits (beyond Yoneda) [English mirror of Limits.lean]
+Grothendieck Part 28 — Limits and colimits (beyond Yoneda) [English mirror of Limits.lean]
 
 Alexander Grothendieck (1928-2014).
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 CoursIA. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 
-## `Grothendieck.MathlibMap` — Cartographie Mathlib
+## Partie 4 — `Grothendieck.MathlibMap` : Cartographie Mathlib
 
 Un index vivant de ce que Mathlib 4 fournit depuis le langage mathématique
 de Grothendieck. Chaque `#check` vérifie que la définition existe et est

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap_en.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 CoursIA. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 
-## `Grothendieck.MathlibMap` — Mathlib Map
+## Part 4 — `Grothendieck.MathlibMap` : Mathlib Map
 
 A living index of what Mathlib 4 provides from Grothendieck's mathematical
 language. Each `#check` verifies that the definition exists and is accessible

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MonoidalCategories.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MonoidalCategories.lean
@@ -1,5 +1,5 @@
 /-
-Grothendieck Partie 29 — Catégories monoïdales
+Grothendieck Partie 32 — Catégories monoïdales
 
 Alexander Grothendieck (1928-2014).
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MonoidalCategories_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MonoidalCategories_en.lean
@@ -1,5 +1,5 @@
 /-
-Grothendieck Part 29 — Monoidal categories [English mirror of Monoidal.lean]
+Grothendieck Part 32 — Monoidal categories [English mirror of Monoidal.lean]
 
 Alexander Grothendieck (1928-2014).
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
@@ -29,13 +29,6 @@ The goal is to give learners a curated entry point into:
 The formalization spans **33 leaf modules (11,206 FR+EN lines, 0 sorry)**, imported
 in order by the umbrella `Grothendieck.lean` (which is itself bilingual inline FR/EN; no `_en` sibling for the umbrella).
 
-> **Two numberings coexist, and they do not agree.** The `Part` column below is the **import
-> order** in the umbrella; each file's header carries a *separate* `Part` number, inherited from
-> its authoring phase, which diverges from the import order on **26 of the 33 modules** and
-> contains duplicates (`Part 26` ×3, `Part 27` ×2). The `## References` section and the
-> `### The arc` section below refer to the **header** numbering, not to this table's.
-> Reconciliation tracked by #8960.
-
 | Part | File | `_en` | Content | Lines |
 |------|------|-------|---------|-------|
 | root | `Grothendieck.lean` | (bilingual inline) | **Umbrella root** (imports-only of the 33 leaves + bilingual FR/EN doctring); no `_en` sibling (the EN content lives in the same file as a mirror) | 208 |
@@ -44,32 +37,32 @@ in order by the umbrella `Grothendieck.lean` (which is itself bilingual inline F
 | 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Zariski pretopology, `zariskiTopology_eq` bridge theorem, subcanonical | 93 |
 | 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | `#check` index of Grothendieck-related Mathlib definitions | 107 |
 | 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 micro-proof targets for the prover harness (Epic #1453) | 95 |
-| 6 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjunction of functors, unit/counit, turtle lemma, left/right adjoints | 168 |
-| 7 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Sieve pullback identities (7): `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 164 |
-| 8 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 148 |
-| 9 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Topology ordering, covering closure, sieve composition | 141 |
-| 10 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-to-topology, sheaf characterization, sup of coverages | 177 |
-| 11 | `Grothendieck/CanonicalProps.lean` | `CanonicalProps_en.lean` | Canonical topology, subcanonicity, representable sheaves | 154 |
-| 12 | `Grothendieck/SieveGenerate.lean` | `SieveGenerate_en.lean` | Sieve generation identities | 172 |
-| 13 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | The dense topology | 155 |
-| 14 | `Grothendieck/Sheafification.lean` | `Sheafification_en.lean` | Sheafification (the associated sheaf functor) | 189 |
-| 15 | `Grothendieck/LeftExact.lean` | `LeftExact_en.lean` | Left exactness of sheafification | 219 |
-| 16 | `Grothendieck/Equivalences.lean` | `Equivalences_en.lean` | Equivalences of categories, fully-faithful functors, essentially surjective | 189 |
-| 17 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points of a site (fiber functors) | 226 |
-| 18 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Subcanonical Grothendieck topologies | 105 |
-| 19 | `Grothendieck/Monads.lean` | `Monads_en.lean` | Monads in category theory, unit, multiplication, associativity law | 172 |
-| 20 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Internal hom of sheaves | 173 |
-| 21 | `Grothendieck/ConstantSheaf.lean` | `ConstantSheaf_en.lean` | The constant sheaf functor (bridges Mathlib `CategoryTheory.Sites.ConstantSheaf`) | 185 |
-| 22 | `Grothendieck/Conservative.lean` | `Conservative_en.lean` | Conservative families of points | 226 |
-| 23 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Sheaf cohomology (Ext-based) | 254 |
-| 24 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Mayer-Vietoris squares | 195 |
-| 25 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | `SheafCohomology/MayerVietoris_en.lean` | Mayer-Vietoris long exact sequence | 167 |
-| 26 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Čech cohomology | 130 |
-| 27 | `Grothendieck/YonedaLemma.lean` | `YonedaLemma_en.lean` | The Yoneda lemma (embedding, equivalence, naturality, fully-faithful, coyoneda) | 274 |
-| 28 | `Grothendieck/Comma.lean` | `Comma_en.lean` | Comma category, projections, functoriality | 129 |
-| 29 | `Grothendieck/Construction.lean` | `Construction_en.lean` | Basic categorical constructions | 152 |
-| 30 | `Grothendieck/KanExtensions.lean` | `KanExtensions_en.lean` | Kan extensions (generalized limits/colimits) | 270 |
-| 31 | `Grothendieck/Limits.lean` | `Limits_en.lean` | Limits and colimits | 242 |
+| 6 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Sieve pullback identities (7): `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 164 |
+| 7 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 148 |
+| 8 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Topology ordering, covering closure, sieve composition | 141 |
+| 9 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-to-topology, sheaf characterization, sup of coverages | 177 |
+| 10 | `Grothendieck/CanonicalProps.lean` | `CanonicalProps_en.lean` | Canonical topology, subcanonicity, representable sheaves | 154 |
+| 11 | `Grothendieck/SieveGenerate.lean` | `SieveGenerate_en.lean` | Sieve generation identities | 172 |
+| 12 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | The dense topology | 155 |
+| 13 | `Grothendieck/Sheafification.lean` | `Sheafification_en.lean` | Sheafification (the associated sheaf functor) | 189 |
+| 14 | `Grothendieck/LeftExact.lean` | `LeftExact_en.lean` | Left exactness of sheafification | 219 |
+| 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points of a site (fiber functors) | 226 |
+| 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Subcanonical Grothendieck topologies | 105 |
+| 17 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Internal hom of sheaves | 173 |
+| 18 | `Grothendieck/ConstantSheaf.lean` | `ConstantSheaf_en.lean` | The constant sheaf functor (bridges Mathlib `CategoryTheory.Sites.ConstantSheaf`) | 185 |
+| 19 | `Grothendieck/Conservative.lean` | `Conservative_en.lean` | Conservative families of points | 226 |
+| 20 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Sheaf cohomology (Ext-based) | 254 |
+| 21 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Mayer-Vietoris squares | 195 |
+| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | `SheafCohomology/MayerVietoris_en.lean` | Mayer-Vietoris long exact sequence | 167 |
+| 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Čech cohomology | 130 |
+| 24 | `Grothendieck/YonedaLemma.lean` | `YonedaLemma_en.lean` | The Yoneda lemma (embedding, equivalence, naturality, fully-faithful, coyoneda) | 274 |
+| 25 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjunction of functors, unit/counit, turtle lemma, left/right adjoints | 168 |
+| 26 | `Grothendieck/Monads.lean` | `Monads_en.lean` | Monads in category theory, unit, multiplication, associativity law | 172 |
+| 27 | `Grothendieck/Comma.lean` | `Comma_en.lean` | Comma category, projections, functoriality | 129 |
+| 28 | `Grothendieck/Limits.lean` | `Limits_en.lean` | Limits and colimits | 242 |
+| 29 | `Grothendieck/Equivalences.lean` | `Equivalences_en.lean` | Equivalences of categories, fully-faithful functors, essentially surjective | 189 |
+| 30 | `Grothendieck/Construction.lean` | `Construction_en.lean` | Basic categorical constructions | 152 |
+| 31 | `Grothendieck/KanExtensions.lean` | `KanExtensions_en.lean` | Kan extensions (generalized limits/colimits) | 270 |
 | 32 | `Grothendieck/MonoidalCategories.lean` | `MonoidalCategories_en.lean` | Monoidal categories, tensor, unit, associator | 244 |
 | 33 | `Grothendieck/DirectImage.lean` | `DirectImage_en.lean` | `#check` index (8) of the `f^* ⊣ f_*` adjunction — direct/inverse image of module sheaves (#8882) | 152 |
 
@@ -134,8 +127,10 @@ The modules trace a coherent path: **sites and sieves** (Parts 1, 6, 8, 11, 12,
 16) → **sheaves, separation, and transfer** (7, 9, 10, 17) → **sheafification and
 its left exactness** (13, 14) → **points and conservative families** (15, 19) →
 **sheaf cohomology, Mayer-Vietoris, and Čech** (20-23), with **schemes and the
-Zariski site** (2, 3) and a **Mathlib map** (4) anchoring the tour to the library
-it indexes. Finally, `DirectImage.lean` indexes the `f^* ⊣ f_*` adjunction — the
+Zariski site** (2, 3), a **Mathlib map** (4), and the **Yoneda lemma** (24)
+anchoring the tour to the library it indexes. The categorical foundations
+(Adjunction, Equivalences, Monads) at Parts 25, 29, 26 underpin the whole
+formalization. Finally, `DirectImage.lean` indexes the `f^* ⊣ f_*` adjunction — the
 simplest instance of the "six operations", transporting sheaves along morphisms
 of schemes.
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -30,13 +30,6 @@ Le but est d'offrir aux apprenants un point d'entrée curaté vers :
 La formalisation couvre **33 modules leaf (11 206 lignes FR+EN, 0 sorry)**,
 importés dans l'ordre par le parapluie `Grothendieck.lean` (qui est lui-même bilingue inline FR/EN, pas de sibling `_en` pour l'umbrella).
 
-> **Deux numérotations coexistent, et elles ne coïncident pas.** La colonne `Partie` du tableau
-> ci-dessous est l'**ordre d'import** dans l'umbrella ; l'en-tête de chaque fichier porte un
-> numéro de `Partie` distinct, hérité de sa phase de rédaction, qui diverge de l'ordre d'import
-> sur **26 des 33 modules** et comporte des doublons (`Partie 26` ×3, `Partie 27` ×2). Les
-> diagrammes et la section `## References` réfèrent à la numérotation des **en-têtes** ; la
-> section `### La trajectoire` réfère à celle du **tableau**. Réconciliation suivie par #8960.
-
 *La trajectoire pédagogique des 33 modules leaf — des sites et cribles jusqu'à la cohomologie, avec schémas/Zariski et carte Mathlib en ancrage :*
 
 ```mermaid
@@ -59,32 +52,32 @@ flowchart LR
 | 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Prétopologie de Zariski, théorème-pont `zariskiTopology_eq`, sous-canonique | 93 |
 | 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | Index `#check` des définitions Mathlib liées à Grothendieck | 107 |
 | 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 cibles de micro-preuve pour le harnais du prouveur (Epic #1453) | 95 |
-| 6 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjonction de foncteurs, unité/co-unit, lemme de la tortue (turtle), adjoints à droite/gauche | 168 |
-| 7 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Identités de pullback de cribles (7) : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 164 |
-| 8 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Bases faisceau/préfaisceau séparé, transfert de faisceau le long de J₁ ≤ J₂ | 148 |
-| 9 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Ordre sur les topologies, clôture de recouvrement, composition de cribles | 141 |
-| 10 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-vers-topologie, caractérisation des faisceaux, sup de coverages | 177 |
-| 11 | `Grothendieck/CanonicalProps.lean` | `CanonicalProps_en.lean` | Topologie canonique, sous-canoïcité, faisceaux représentables | 154 |
-| 12 | `Grothendieck/SieveGenerate.lean` | `SieveGenerate_en.lean` | Identités de génération de cribles | 172 |
-| 13 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | La topologie dense | 155 |
-| 14 | `Grothendieck/Sheafification.lean` | `Sheafification_en.lean` | Faisceautisation (le foncteur faisceau associé) | 189 |
-| 15 | `Grothendieck/LeftExact.lean` | `LeftExact_en.lean` | Exactitude à gauche de la faisceautisation | 219 |
-| 16 | `Grothendieck/Equivalences.lean` | `Equivalences_en.lean` | Équivalences de catégories, foncteurs pleinement fidèles, essentiellement surjectifs | 189 |
-| 17 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points d'un site (foncteurs fibres) | 226 |
-| 18 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Topologies de Grothendieck sous-canoniques | 105 |
-| 19 | `Grothendieck/Monads.lean` | `Monads_en.lean` | Monades en théorie des catégories, unité, multiplication, loi d'association | 172 |
-| 20 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Hom interne des faisceaux | 173 |
-| 21 | `Grothendieck/ConstantSheaf.lean` | `ConstantSheaf_en.lean` | Le foncteur faisceau constant (ponte vers `CategoryTheory.Sites.ConstantSheaf` de Mathlib) | 185 |
-| 22 | `Grothendieck/Conservative.lean` | `Conservative_en.lean` | Familles conservatrices de points | 226 |
-| 23 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Cohomologie des faisceaux (basée sur Ext) | 254 |
-| 24 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Carrés de Mayer-Vietoris | 195 |
-| 25 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | `SheafCohomology/MayerVietoris_en.lean` | Suite exacte longue de Mayer-Vietoris | 167 |
-| 26 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Cohomologie de Čech | 130 |
-| 27 | `Grothendieck/YonedaLemma.lean` | `YonedaLemma_en.lean` | Le lemme de Yoneda (plongement, équivalence, naturalité, pleinement fidèle, coyoneda) | 274 |
-| 28 | `Grothendieck/Comma.lean` | `Comma_en.lean` | Catégorie comma, projections, fonctorialité | 129 |
-| 29 | `Grothendieck/Construction.lean` | `Construction_en.lean` | Constructions catégorielles de base | 152 |
-| 30 | `Grothendieck/KanExtensions.lean` | `KanExtensions_en.lean` | Extensions de Kan (limites/colimites généralisées) | 270 |
-| 31 | `Grothendieck/Limits.lean` | `Limits_en.lean` | Limites et colimites | 242 |
+| 6 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Identités de pullback de cribles (7) : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 164 |
+| 7 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Bases faisceau/préfaisceau séparé, transfert de faisceau le long de J₁ ≤ J₂ | 148 |
+| 8 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Ordre sur les topologies, clôture de recouvrement, composition de cribles | 141 |
+| 9 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-vers-topologie, caractérisation des faisceaux, sup de coverages | 177 |
+| 10 | `Grothendieck/CanonicalProps.lean` | `CanonicalProps_en.lean` | Topologie canonique, sous-canoïcité, faisceaux représentables | 154 |
+| 11 | `Grothendieck/SieveGenerate.lean` | `SieveGenerate_en.lean` | Identités de génération de cribles | 172 |
+| 12 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | La topologie dense | 155 |
+| 13 | `Grothendieck/Sheafification.lean` | `Sheafification_en.lean` | Faisceautisation (le foncteur faisceau associé) | 189 |
+| 14 | `Grothendieck/LeftExact.lean` | `LeftExact_en.lean` | Exactitude à gauche de la faisceautisation | 219 |
+| 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points d'un site (foncteurs fibres) | 226 |
+| 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Topologies de Grothendieck sous-canoniques | 105 |
+| 17 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Hom interne des faisceaux | 173 |
+| 18 | `Grothendieck/ConstantSheaf.lean` | `ConstantSheaf_en.lean` | Le foncteur faisceau constant (ponte vers `CategoryTheory.Sites.ConstantSheaf` de Mathlib) | 185 |
+| 19 | `Grothendieck/Conservative.lean` | `Conservative_en.lean` | Familles conservatrices de points | 226 |
+| 20 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Cohomologie des faisceaux (basée sur Ext) | 254 |
+| 21 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Carrés de Mayer-Vietoris | 195 |
+| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | `SheafCohomology/MayerVietoris_en.lean` | Suite exacte longue de Mayer-Vietoris | 167 |
+| 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Cohomologie de Čech | 130 |
+| 24 | `Grothendieck/YonedaLemma.lean` | `YonedaLemma_en.lean` | Le lemme de Yoneda (plongement, équivalence, naturalité, pleinement fidèle, coyoneda) | 274 |
+| 25 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjonction de foncteurs, unité/co-unit, lemme de la tortue (turtle), adjoints à droite/gauche | 168 |
+| 26 | `Grothendieck/Monads.lean` | `Monads_en.lean` | Monades en théorie des catégories, unité, multiplication, loi d'association | 172 |
+| 27 | `Grothendieck/Comma.lean` | `Comma_en.lean` | Catégorie comma, projections, fonctorialité | 129 |
+| 28 | `Grothendieck/Limits.lean` | `Limits_en.lean` | Limites et colimites | 242 |
+| 29 | `Grothendieck/Equivalences.lean` | `Equivalences_en.lean` | Équivalences de catégories, foncteurs pleinement fidèles, essentiellement surjectifs | 189 |
+| 30 | `Grothendieck/Construction.lean` | `Construction_en.lean` | Constructions catégorielles de base | 152 |
+| 31 | `Grothendieck/KanExtensions.lean` | `KanExtensions_en.lean` | Extensions de Kan (limites/colimites généralisées) | 270 |
 | 32 | `Grothendieck/MonoidalCategories.lean` | `MonoidalCategories_en.lean` | Catégories monoïdales, tenseur, unité, associateur | 244 |
 | 33 | `Grothendieck/DirectImage.lean` | `DirectImage_en.lean` | Index `#check` (8) de l'adjonction `f^* ⊣ f_*` — image directe / réciproque des faisceaux de modules (#8882) | 152 |
 
@@ -145,12 +138,12 @@ qui laisse les apprenants voir la bibliothèque à travers des yeux grothendieck
 
 ### La trajectoire
 
-Les modules tracent un chemin cohérent : **sites et cribles** (Parties 1, 7, 9,
-12, 13, 18) → **faisceaux, séparation et transfert** (8, 10, 11, 20) →
-**faisceautisation et son exactitude à gauche** (14, 15) → **points et familles
-conservatrices** (17, 22) → **cohomologie des faisceaux, Mayer-Vietoris et Čech**
-(23-26), avec **schémas et site de Zariski** (2, 3), une **carte Mathlib** (4)
-et le **lemme de Yoneda** (27) ancrant la visite à la bibliothèque qu'elle indexe. Les bases catégorielles (Adjonction, Équivalences, Monades) aux Parties 6, 16, 19 soutiennent toute la formalisation. Enfin, `DirectImage.lean` indexe l'adjonction `f^* ⊣ f_*` — l'instance la plus simple des « six opérations », qui transporte les faisceaux le long des morphismes de schémas.
+Les modules tracent un chemin cohérent : **sites et cribles** (Parties 1, 6, 8,
+11, 12, 16) → **faisceaux, séparation et transfert** (7, 9, 10, 17) →
+**faisceautisation et son exactitude à gauche** (13, 14) → **points et familles
+conservatrices** (15, 19) → **cohomologie des faisceaux, Mayer-Vietoris et Čech**
+(20-23), avec **schémas et site de Zariski** (2, 3), une **carte Mathlib** (4)
+et le **lemme de Yoneda** (24) ancrant la visite à la bibliothèque qu'elle indexe. Les bases catégorielles (Adjonction, Équivalences, Monades) aux Parties 25, 29, 26 soutiennent toute la formalisation. Enfin, `DirectImage.lean` indexe l'adjonction `f^* ⊣ f_*` — l'instance la plus simple des « six opérations », qui transporte les faisceaux le long des morphismes de schémas.
 
 *La construction verticale « faisceau » — chaque couche bâtie sur la précédente, de la donnée du site jusqu'à la cohomologie :*
 


### PR DESCRIPTION
Grain: DEEP/Lean-docs — lane myia-po-2023:CoursIA — prev: MED/tooling #8975 (CI green, CLEAN/MERGEABLE)

Resolves **#8960**: the two incompatible `Partie N` numberings in `grothendieck_lean` (README table = import order "A"; file header docstrings = authoring phase "B"; diverging on 26/33 modules, B non-injective with `Partie 26`×3, `Partie 27`×2, no `Partie 4`). Per the issue's decision, **B becomes canonical** and is repaired to a contiguous injective `1..33`; the table and narrative align to it.

## Numbering resolution

25 modules at B 1..25 are **unchanged**. The messy tail (collisions + the missing 4) is rationalized:

| group | modules | resolution |
|---|---|---|
| missing 4 | MathlibMap | (none) → **4** |
| collision "26" | {Comma, Limits, Monads} | Monads stays **26**, Comma → **27**, Limits → **28** (intra-group A-import order) |
| collision "27" | {Construction, Equivalences} | Equivalences → **29**, Construction → **30** |
| tail | KanExtensions, MonoidalCategories, DirectImage | **31, 32, 33** |

Result: contiguous `1..33`, injective. Final order: …24 YonedaLemma, 25 Adjunction, 26 Monads, 27 Comma, 28 Limits, 29 Equivalences, 30 Construction, 31 KanExtensions, 32 MonoidalCategories, 33 DirectImage.

## Changes (16 `.lean` + 2 README)

- **8 module headers** renumbered (FR), and the **8 `_en` siblings** carry the matching number.
- **README.md + README.en.md** tables reordered + renumbered to B (now sorted `1..33`).
- **`### La trajectoire`** (FR) converted A→B; **`### The arc`** (EN) completed with the Yoneda-lemma + categorical-foundations sentence it was missing.
- The **#8962 "two numberings coexist" warning** removed from both READMEs.
- The **mermaid diagrams + `## References`** needed **no change** — every module they reference sits in the unchanged B 1..25 range (plus MathlibMap=4), verified by mapping each cited number to its module.

## Verification (firsthand)

- **File headers**: 33 FR + 33 EN, contiguous 1..33, **0 duplicate, 0 missing, FR↔EN 0 mismatch** (mechanical re-extraction, `re.search(r'(Partie|Part) (\d+)')`).
- **`check_i18n_siblings.py`**: **0 drift / 0 orphan** ✓ (the 2 HALF-DONE pairs `Conservative_en`/`SitePoints_en` are pre-existing + advisory + explicitly out-of-scope per #8960).
- **Comment-block integrity**: every edited `.lean` has balanced `/- … -/` counts (no broken block comment).
- **Diff scope**: all 16 `.lean` changes are block-comment **header text only** — no declaration/proof/tactic touched. Block comments are lexer-stripped, so elaboration is unaffected.

## `lake build Grothendieck` (criterion 7)

The `.lean` diff is provably comment-only (every changed line is inside a `/- -/` header), so the build result is identical to `main` — **green, 2821 jobs, confirmed by the issue author firsthand 2026-07-30**. A full local rebuild was **not** run on this disposable worktree: comment-text edits cannot reach the elaborator, and a ~20 GB mathlib clone for comment-only changes is disproportionate. Coordinator/CI to confirm the green build.

## Scope notes (faithful to #8960)

- The 2 HALF-DONE i18n pairs (`Conservative_en`, `SitePoints_en`) and the `MayerVietorisSquare_en.lean:40` French line the checker misses are left untouched — #8960 flags them as a separate angle-blindness issue.
- `README.en.md` lacks the two mermaid diagrams (pre-existing); adding them is out of scope here.

`See #8960` (substantive fix complete; closeable once a green lake build is confirmed).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
