### PR TITLE
fix(gitignore,#8901): scope mealplan_cache negation to canonical Z3-Linq2Z3 path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -891,5 +891,9 @@ _freeze/
 # EXCEPTION (#8901) : le cache derive data/meals/mealplan_cache.json (~205 Ko) est EPIINGLE
 # (derive stable consommee par 07/08/09 + port Python 16b/16c/16d) pour stopper la derive de
 # millesime. Le brut volumineux reste ignore ; seul le cache est tracke (cf Z3-Linq2Z3/.gitignore).
+# La negation est scopee au chemin CANONIQUE Z3-Linq2Z3/ (pas de glob **) : un ** ferait remonter
+# le vestige SMT/Z3/data/meals/ (ancien nom de serie, vintage 270 Ko 2026-07-02) en ?? sur les
+# machines qui le portent -> risque de committer le mauvais millesime que #8905 a deplace (#8901).
+# L'ignore (ligne du dessus) reste large pour couvrir les autres fichiers du vestige stale.
 MyIA.AI.Notebooks/SymbolicAI/SMT/**/data/meals/*
-!MyIA.AI.Notebooks/SymbolicAI/SMT/**/data/meals/mealplan_cache.json
+!MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/data/meals/mealplan_cache.json


### PR DESCRIPTION
Grain: MED/infra — lane myia-po-2023:CoursIA

## Problem (residual on #8901, scoped by @jsboige)

The `!.../SMT/**/data/meals/mealplan_cache.json` negation added in #8932 used a broad `**` glob. On machines carrying the stale `SMT/Z3/data/meals/` vestige (old series name, pre Z3-API/Z3-Linq2Z3 split), this de-ignored the **wrong vintage** cache (270 Ko, dated 2026-07-02) — surfacing it as untracked `??` and risking a `git add .` committing the millesime that #8905 just displaced.

@jsboige's latest comment on #8901 ("petit, dans la lane qui possède déjà le sujet") suggested narrowing the negation to the canonical path.

## Fix

Narrow the negation to `SMT/Z3-Linq2Z3/data/meals/mealplan_cache.json`. The ignore line above stays broad (`SMT/**/data/meals/*`) so other files in the stale location remain ignored; only the canonical cache is pinned. Asymmetric but correct — the broad ignore covers the stale vestige's other files, the scoped negation pins only the canonical good cache.

## Firsthand verification (G.1)

`git check-ignore -v` on a fresh worktree from `origin/main`:
- **canonical** `Z3-Linq2Z3/data/meals/mealplan_cache.json` → **NOT ignored** (correctly pinned, exit 1)
- **stale** `Z3/data/meals/mealplan_cache.json` → **now ignored** by the broad ignore line (exit 0, shows the `SMT/**/data/meals/*` rule) — bad vintage stays out, `??` noise resolved
- canonical cache still tracked (`git ls-files`)
- Only one series carries the cache (`git ls-files SMT/**/data/meals/*` returns the single canonical path) → no over-match risk

Diff: `+5/-1` (4 explanatory comment lines + 1 narrowed negation). No notebook/catalog/Lean touched.

## Scope

`See #8901` (partial — the negation over-breadth is fixed; "etape 2" re-exec of 09 from the pinned cache is a separate concern). 

R6 rotation: lean-docs (#8976) -> infra (distinct family). Non-Lean, non-QC.

Co-Authored-By: Claude-Code <noreply@anthropic.com>