### PR TITLE
test(slides,#8929): lock build_advisory symmetric-trap probe with regression test

### DIFF
--- a/scripts/tests/test_build_advisory_symmetric_trap.py
+++ b/scripts/tests/test_build_advisory_symmetric_trap.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Regression tests for build_advisory.sh — denominator + symmetric-trap (#8929/#8930).
+
+PR #8930 added the symmetric-trap probe to `scripts/slides/build_advisory.sh`
+(a non-convention dir that DOES carry a deck is invisible to discovery -> the
+`check` command must FAIL, mirroring the gate in BOTH directions). That fix
+shipped without a test. These tests build synthetic `slides/` trees in
+`tmp_path` and assert the probe fires, so the behavior is locked against
+regression. The decisive case is `test_nonconvention_dir_with_deck_is_caught`
+(#8929). Verified firsthand before encoding (C976-L).
+
+Executable two ways:
+    py scripts/tests/test_build_advisory_symmetric_trap.py
+    npx pytest scripts/tests/test_build_advisory_symmetric_trap.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "slides" / "build_advisory.sh"
+
+# build_advisory.sh relies on `git check-ignore` (the authority on "ignored").
+# `is_deck_dir` falls through to the convention grep when check-ignore reports
+# "not ignored" (exit 1), which requires the cwd to be a git worktree. We init a
+# real (empty) repo in tmp_path so the tool behaves exactly as it does in CI.
+GIT = shutil.which("git")
+BASH = shutil.which("bash")
+
+pytestmark = pytest.mark.skipif(
+    BASH is None or GIT is None,
+    reason="build_advisory.sh needs bash and git on PATH",
+)
+
+
+def _make_tree(tmp_path: Path, entries: dict[str, str]) -> Path:
+    """Build a slides/ tree under tmp_path. entries maps rel-path -> file content.
+
+    A rel-path ending in '/' creates an empty dir; otherwise a file with content.
+    Returns the slides/ root. Also git-inits tmp_path (check-ignore authority).
+    """
+    root = tmp_path / "slides"
+    root.mkdir(exist_ok=True)
+    for rel, content in entries.items():
+        target = root / rel
+        if rel.endswith("/"):
+            target.mkdir(parents=True, exist_ok=True)
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+    subprocess.run(
+        [GIT, "init", "-q", str(tmp_path)],
+        check=True, capture_output=True,
+    )
+    return root
+
+
+def _run_check(slides_root: Path) -> subprocess.CompletedProcess:
+    """Run `build_advisory.sh check` against a slides tree, return the process."""
+    env = os.environ.copy()
+    env["SLIDES_DIR"] = str(slides_root)
+    return subprocess.run(
+        [BASH, str(SCRIPT), "check"],
+        capture_output=True, text=True, env=env, cwd=str(slides_root.parent),
+        encoding="utf-8", errors="replace",
+    )
+
+
+class TestDenominatorCheck:
+    """The trap-1 direction (#8817): convention dir + denominator mismatch."""
+
+    def test_convention_dir_with_deck_passes(self, tmp_path: Path):
+        slides = _make_tree(tmp_path, {"01-introduction/slides.md": "# Intro\n"})
+        proc = _run_check(slides)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "PASS" in proc.stdout
+
+    def test_convention_dir_without_deck_fails(self, tmp_path: Path):
+        # One healthy dir + one empty convention dir -> the empty one is a
+        # silent-skip risk (deck dir with ZERO discovered decks).
+        slides = _make_tree(
+            tmp_path,
+            {"01-real/slides.md": "# Real\n", "02-empty/": ""},
+        )
+        proc = _run_check(slides)
+        assert proc.returncode == 1
+        assert "02-empty" in proc.stdout
+
+
+class TestSymmetricTrap8929:
+    """The symmetric direction (#8929/#8930): the decisive regression.
+
+    A dir that does NOT match the NN/SN convention but DOES carry a deck file is
+    invisible to discovery. The `check` command must FAIL here (mirroring the
+    gate), otherwise an author renaming `07-xxx` to `slides-07-xxx` sees green
+    locally and discovers the red `::error::` only in CI.
+    """
+
+    def test_nonconvention_dir_with_deck_is_caught(self, tmp_path: Path):
+        # A healthy convention deck + a renamed (non-convention) dir carrying a deck.
+        slides = _make_tree(
+            tmp_path,
+            {
+                "01-introduction/slides.md": "# Intro\n",
+                "intro-renamed/slides.md": "# Renamed\n",  # non-convention, has deck
+            },
+        )
+        proc = _run_check(slides)
+        assert proc.returncode == 1, "symmetric-trap probe should FAIL #8929"
+        # The probe prints to stderr.
+        assert "intro-renamed" in proc.stderr
+        assert "convention" in proc.stderr.lower()
+
+    def test_nonconvention_dir_with_deck_dash_pattern_caught(self, tmp_path: Path):
+        # deck-*.md is the other recognized deck filename (not just slides.md).
+        slides = _make_tree(
+            tmp_path,
+            {
+                "01-introduction/slides.md": "# Intro\n",
+                "legacy-talk/deck-2024.md": "# Legacy\n",
+            },
+        )
+        proc = _run_check(slides)
+        assert proc.returncode == 1
+        assert "legacy-talk" in proc.stderr
+
+    def test_nonconvention_dir_without_deck_is_skipped(self, tmp_path: Path):
+        # A peer infra dir (no convention, no deck) must NOT trip a false error.
+        slides = _make_tree(
+            tmp_path,
+            {
+                "01-introduction/slides.md": "# Intro\n",
+                "_assets/style.css": "body {}\n",   # non-convention, no deck -> fine
+            },
+        )
+        proc = _run_check(slides)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "PASS" in proc.stdout
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Grain: MED/test-coverage — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python (#8978 App-1, distinct substance: bash-tool regression test vs CSP-combinatorics reframe)

## What

Adds the missing regression test for the **build_advisory.sh symmetric-trap probe** (#8929/#8930). PR **#8930** added the probe — a non-convention dir that DOES carry a deck is invisible to discovery, so `check` must FAIL (mirroring the gate in BOTH directions) — but shipped without a test. This locks the behavior against regression.

## Why this is a real guard, not a tautology (falsifiability, c.1022-L)

Verified firsthand before encoding:

| script version | `intro-renamed/slides.md` (non-convention + deck) |
|---|---|
| PRE-#8930 (`346b37079`) | `Denominator check: PASS`, **exit 0** (probe absent → missed) |
| current main (`85606cfb0`) | `Denominator check: FAIL … #8929`, **exit 1** (probe catches it) |

So this test passes on the fixed code and **would fail if the probe were removed** — a genuine regression guard, not a vacuous one.

## Coverage (5 cases, all pass — verified with conda-env pytest)

`TestDenominatorCheck` (trap-1 direction, #8817):
- convention dir **with** deck → `PASS`
- convention dir **without** deck → `FAIL` (silent-skip risk, dir named in output)

`TestSymmetricTrap8929` (the decisive direction):
- non-convention dir **with** `slides.md` → `FAIL` (exit 1, dir + "convention" in stderr) ← the regression
- non-convention dir **with** `deck-*.md` → `FAIL` (both recognized deck filenames)
- non-convention dir **without** deck (peer infra) → `PASS` (no false positive)

The test builds synthetic `slides/` trees in `tmp_path` (real files, not mocks), `git init`s the tmp (so `git check-ignore` is the authority, as in CI), and invokes `build_advisory.sh check` via subprocess — matching the repo's existing convention (`test_check_orphan_post_merge_commits.py`). Skips cleanly when `bash`/`git` aren't on PATH.

## Side note — #8929 is resolved-but-open

#8929's fix landed via **#8930 (MERGED `85606cfb0`, 2026-07-30T16:03Z)** but the issue is still OPEN with 0 comments. This PR adds the test; the issue itself is ready for the coordinator to close (fix verified firsthand, now test-covered). See #8929, #8817, #8926.

## Scope

1 file, +148 (new test). No source changes — `build_advisory.sh` untouched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
