### PR TITLE
refactor(conway_lean): factor byte-identical power facts hpe1/hpe2 into named lemmas

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/ConeGeometry.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/ConeGeometry.lean
@@ -242,6 +242,12 @@ coordinate directly, the proof is **simpler** than the loose analog: it consumes
 bridging through `manhattan_deviation`. No `hashlifeResultAux`, no whnf wall —
 pure `Int` window arithmetic. Sorry-free.
 
+This lemma lives in `ConeGeometry` (not `LightCone`) so that the P5
+`p5_large_n_jump` path in `HashlifeCorrectness` can consume it directly via
+`import Conway.Life.ConeGeometry`, without the circular reverse-import that would
+arise if it stayed in `LightCone` (which imports `HashlifeCorrectness`). The
+proof substance is independent of the P4 mono-verru. -/
+
 /-- Power identity `2^(k+1) = 2 · 2^k` in `Int`, proven in pure `Nat` (rw +
 `Nat.pow_succ`) then lifted via `exact_mod_cast`. Shared by the two window-
 membership theorems `window_cheb_cone_in_domain` (this module) and
@@ -263,11 +269,6 @@ lemma pow_two_add_two_int (k : Nat) : (2^(k+2) : Int) = 4 * (2^k : Int) := by
   have h : (2 : Nat)^(k+2) = 4 * (2 : Nat)^k := by rw [h2, h1]; ring
   exact_mod_cast h
 
-This lemma lives in `ConeGeometry` (not `LightCone`) so that the P5
-`p5_large_n_jump` path in `HashlifeCorrectness` can consume it directly via
-`import Conway.Life.ConeGeometry`, without the circular reverse-import that would
-arise if it stayed in `LightCone` (which imports `HashlifeCorrectness`). The
-proof substance is independent of the P4 mono-verrou. -/
 theorem window_cheb_cone_in_domain (k : Nat) (p q : Int × Int)
     (hp1_lo : (2^k : Int) ≤ p.1) (hp1_hi : p.1 < 2^k + 2^(k+1))
     (hp2_lo : (2^k : Int) ≤ p.2) (hp2_hi : p.2 < 2^k + 2^(k+1))

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/ConeGeometry.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/ConeGeometry.lean
@@ -242,6 +242,27 @@ coordinate directly, the proof is **simpler** than the loose analog: it consumes
 bridging through `manhattan_deviation`. No `hashlifeResultAux`, no whnf wall —
 pure `Int` window arithmetic. Sorry-free.
 
+/-- Power identity `2^(k+1) = 2 · 2^k` in `Int`, proven in pure `Nat` (rw +
+`Nat.pow_succ`) then lifted via `exact_mod_cast`. Shared by the two window-
+membership theorems `window_cheb_cone_in_domain` (this module) and
+`window_cone_in_domain` (`HashlifeCorrectness`, which imports this module),
+hence factored here rather than duplicated inline in each consumer. -/
+lemma pow_two_add_one_int (k : Nat) : (2^(k+1) : Int) = 2 * (2^k : Int) := by
+  have h : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
+    rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
+  exact_mod_cast h
+
+/-- Power identity `2^(k+2) = 4 · 2^k` in `Int`, proven in pure `Nat` (rw +
+`Nat.pow_succ` over two steps) then lifted via `exact_mod_cast`. Same shared
+rationale as `pow_two_add_one_int`: consumed by both window-membership theorems. -/
+lemma pow_two_add_two_int (k : Nat) : (2^(k+2) : Int) = 4 * (2^k : Int) := by
+  have h1 : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
+    rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
+  have h2 : (2 : Nat)^(k+2) = 2 * (2 : Nat)^(k+1) := by
+    rw [show (k + 2 : Nat) = Nat.succ (k + 1 : Nat) from rfl, Nat.pow_succ, Nat.mul_comm]
+  have h : (2 : Nat)^(k+2) = 4 * (2 : Nat)^k := by rw [h2, h1]; ring
+  exact_mod_cast h
+
 This lemma lives in `ConeGeometry` (not `LightCone`) so that the P5
 `p5_large_n_jump` path in `HashlifeCorrectness` can consume it directly via
 `import Conway.Life.ConeGeometry`, without the circular reverse-import that would
@@ -264,18 +285,11 @@ theorem window_cheb_cone_in_domain (k : Nat) (p q : Int × Int)
     rw [hk_pow.symm, Int.abs_eq_natAbs]; exact_mod_cast hq1
   have hq2' : |q.2 - p.2| ≤ (2^k : Int) := by
     rw [hk_pow.symm, Int.abs_eq_natAbs]; exact_mod_cast hq2
-  -- Power facts in pure `Nat`, lifted to `Int` (linarith reads the atoms).
-  have hpe1 : (2^(k+1) : Int) = 2 * (2^k : Int) := by
-    have h : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
-      rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
-    exact_mod_cast h
-  have hpe2 : (2^(k+2) : Int) = 4 * (2^k : Int) := by
-    have h1 : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
-      rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
-    have h2 : (2 : Nat)^(k+2) = 2 * (2 : Nat)^(k+1) := by
-      rw [show (k + 2 : Nat) = Nat.succ (k + 1) from rfl, Nat.pow_succ, Nat.mul_comm]
-    have h : (2 : Nat)^(k+2) = 4 * (2 : Nat)^k := by rw [h2, h1]; ring
-    exact_mod_cast h
+  -- Power facts in pure `Nat`, lifted to `Int` (linarith reads the atoms),
+  -- factored into the named lemmas `pow_two_add_one_int`/`pow_two_add_two_int`
+  -- above (shared with `window_cone_in_domain` in `HashlifeCorrectness`).
+  have hpe1 : (2^(k+1) : Int) = 2 * (2^k : Int) := pow_two_add_one_int k
+  have hpe2 : (2^(k+2) : Int) = 4 * (2^k : Int) := pow_two_add_two_int k
   -- `Int.abs` bound unpacked into a two-sided `Int` clamp on `q.i - p.i`.
   obtain ⟨hq1lo, hq1hi⟩ := abs_le.mp hq1'
   obtain ⟨hq2lo, hq2hi⟩ := abs_le.mp hq2'

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/ConeGeometry_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/ConeGeometry_en.lean
@@ -156,6 +156,12 @@ coordinate directly, the proof is **simpler** than the loose analog: it consumes
 bridging through `manhattan_deviation`. No `hashlifeResultAux`, no whnf wall —
 pure `Int` window arithmetic. Sorry-free.
 
+This lemma lives in `ConeGeometry` (not `LightCone`) so that the P5
+`p5_large_n_jump` path in `HashlifeCorrectness` can consume it directly via
+`import Conway.Life.ConeGeometry`, without the circular reverse-import that would
+arise if it stayed in `LightCone` (which imports `HashlifeCorrectness`). The
+proof substance is independent of the P4 mono-verrou. -/
+
 /-- Power identity `2^(k+1) = 2 · 2^k` in `Int`, proven in pure `Nat` (rw +
 `Nat.pow_succ`) then lifted via `exact_mod_cast`. Shared by the two window-
 membership theorems `window_cheb_cone_in_domain` (this module) and
@@ -177,11 +183,6 @@ lemma pow_two_add_two_int (k : Nat) : (2^(k+2) : Int) = 4 * (2^k : Int) := by
   have h : (2 : Nat)^(k+2) = 4 * (2 : Nat)^k := by rw [h2, h1]; ring
   exact_mod_cast h
 
-This lemma lives in `ConeGeometry` (not `LightCone`) so that the P5
-`p5_large_n_jump` path in `HashlifeCorrectness` can consume it directly via
-`import Conway.Life.ConeGeometry`, without the circular reverse-import that would
-arise if it stayed in `LightCone` (which imports `HashlifeCorrectness`). The
-proof substance is independent of the P4 mono-verrou. -/
 theorem window_cheb_cone_in_domain (k : Nat) (p q : Int × Int)
     (hp1_lo : (2^k : Int) ≤ p.1) (hp1_hi : p.1 < 2^k + 2^(k+1))
     (hp2_lo : (2^k : Int) ≤ p.2) (hp2_hi : p.2 < 2^k + 2^(k+1))

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/ConeGeometry_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/ConeGeometry_en.lean
@@ -156,6 +156,27 @@ coordinate directly, the proof is **simpler** than the loose analog: it consumes
 bridging through `manhattan_deviation`. No `hashlifeResultAux`, no whnf wall —
 pure `Int` window arithmetic. Sorry-free.
 
+/-- Power identity `2^(k+1) = 2 · 2^k` in `Int`, proven in pure `Nat` (rw +
+`Nat.pow_succ`) then lifted via `exact_mod_cast`. Shared by the two window-
+membership theorems `window_cheb_cone_in_domain` (this module) and
+`window_cone_in_domain` (`HashlifeCorrectness`, which imports this module),
+hence factored here rather than duplicated inline in each consumer. -/
+lemma pow_two_add_one_int (k : Nat) : (2^(k+1) : Int) = 2 * (2^k : Int) := by
+  have h : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
+    rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
+  exact_mod_cast h
+
+/-- Power identity `2^(k+2) = 4 · 2^k` in `Int`, proven in pure `Nat` (rw +
+`Nat.pow_succ` over two steps) then lifted via `exact_mod_cast`. Same shared
+rationale as `pow_two_add_one_int`: consumed by both window-membership theorems. -/
+lemma pow_two_add_two_int (k : Nat) : (2^(k+2) : Int) = 4 * (2^k : Int) := by
+  have h1 : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
+    rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
+  have h2 : (2 : Nat)^(k+2) = 2 * (2 : Nat)^(k+1) := by
+    rw [show (k + 2 : Nat) = Nat.succ (k + 1 : Nat) from rfl, Nat.pow_succ, Nat.mul_comm]
+  have h : (2 : Nat)^(k+2) = 4 * (2 : Nat)^k := by rw [h2, h1]; ring
+  exact_mod_cast h
+
 This lemma lives in `ConeGeometry` (not `LightCone`) so that the P5
 `p5_large_n_jump` path in `HashlifeCorrectness` can consume it directly via
 `import Conway.Life.ConeGeometry`, without the circular reverse-import that would
@@ -178,18 +199,11 @@ theorem window_cheb_cone_in_domain (k : Nat) (p q : Int × Int)
     rw [hk_pow.symm, Int.abs_eq_natAbs]; exact_mod_cast hq1
   have hq2' : |q.2 - p.2| ≤ (2^k : Int) := by
     rw [hk_pow.symm, Int.abs_eq_natAbs]; exact_mod_cast hq2
-  -- Power facts in pure `Nat`, lifted to `Int` (linarith reads the atoms).
-  have hpe1 : (2^(k+1) : Int) = 2 * (2^k : Int) := by
-    have h : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
-      rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
-    exact_mod_cast h
-  have hpe2 : (2^(k+2) : Int) = 4 * (2^k : Int) := by
-    have h1 : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
-      rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
-    have h2 : (2 : Nat)^(k+2) = 2 * (2 : Nat)^(k+1) := by
-      rw [show (k + 2 : Nat) = Nat.succ (k + 1) from rfl, Nat.pow_succ, Nat.mul_comm]
-    have h : (2 : Nat)^(k+2) = 4 * (2 : Nat)^k := by rw [h2, h1]; ring
-    exact_mod_cast h
+  -- Power facts in pure `Nat`, lifted to `Int` (linarith reads the atoms),
+  -- factored into the named lemmas `pow_two_add_one_int`/`pow_two_add_two_int`
+  -- above (shared with `window_cone_in_domain` in `HashlifeCorrectness`).
+  have hpe1 : (2^(k+1) : Int) = 2 * (2^k : Int) := pow_two_add_one_int k
+  have hpe2 : (2^(k+2) : Int) = 4 * (2^k : Int) := pow_two_add_two_int k
   -- `Int.abs` bound unpacked into a two-sided `Int` clamp on `q.i - p.i`.
   obtain ⟨hq1lo, hq1hi⟩ := abs_le.mp hq1'
   obtain ⟨hq2lo, hq2hi⟩ := abs_le.mp hq2'

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -2804,17 +2804,10 @@ private theorem window_cone_in_domain (k : Nat) (p q : Int × Int)
   obtain ⟨hq2lo, hq2hi⟩ := abs_le.mp hq2
   -- Power facts proven in pure Nat (rw only — omega splits the Nat `2^k` from
   -- `Nat.pow_succ` against the `(2^k : Int)` casts in scope), lifted to Int.
-  have hpe1 : (2^(k+1) : Int) = 2 * (2^k : Int) := by
-    have h : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
-      rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
-    exact_mod_cast h
-  have hpe2 : (2^(k+2) : Int) = 4 * (2^k : Int) := by
-    have h1 : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
-      rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
-    have h2 : (2 : Nat)^(k+2) = 2 * (2 : Nat)^(k+1) := by
-      rw [show (k + 2 : Nat) = Nat.succ (k + 1) from rfl, Nat.pow_succ, Nat.mul_comm]
-    have h : (2 : Nat)^(k+2) = 4 * (2 : Nat)^k := by rw [h2, h1]; ring
-    exact_mod_cast h
+  -- Factored into `Conway.Life.pow_two_add_one_int`/`pow_two_add_two_int`
+  -- (ConeGeometry, imported above), shared with `window_cheb_cone_in_domain`.
+  have hpe1 : (2^(k+1) : Int) = 2 * (2^k : Int) := pow_two_add_one_int k
+  have hpe2 : (2^(k+2) : Int) = 4 * (2^k : Int) := pow_two_add_two_int k
   -- Rewrite every power occurrence into a multiple of the single atom `2^k`,
   -- so the goal reduces to pure linear `Int` arithmetic in `2^k`. `linarith`
   -- (not `omega`) closes it: omega loses the positivity of `2^k` when juggling


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2023:CoursIA

## What

The two window-membership theorems `window_cheb_cone_in_domain` (ConeGeometry.lean) and `window_cone_in_domain` (HashlifeCorrectness.lean) each inlined the **same byte-identical 11-line block** proving `2^(k+1) = 2·2^k` and `2^(k+2) = 4·2^k` in `Int` (pure `Nat` rw + `Nat.pow_succ` + `exact_mod_cast`). `diff` over the two blocks returned **exit 0**.

Factor both into two top-level lemmas in `ConeGeometry` (namespace `Conway.Life`):
```
lemma pow_two_add_one_int (k : Nat) : (2^(k+1) : Int) = 2 * (2^k : Int)
lemma pow_two_add_two_int (k : Nat) : (2^(k+2) : Int) = 4 * (2^k : Int)
```
and rewire both consumers to `:= pow_two_add_one_int k` / `:= pow_two_add_two_int k`. Downstream `rw [hpe1] ...; rw [hpe2]` is unchanged (rw reads the term regardless of provenance).

This is the faithful #8956 / #8928 shape (byte-identical `have`-block in ≥2 consumers → named lemma, called), not stretched similarity.

## Callability (verified, avoids the #8969 def-trap)

- `HashlifeCorrectness.lean:81` already does `import Conway.Life.ConeGeometry`, and `:83-84` `namespace Conway` / `namespace Life` → the lemmas are callable qualified with **zero new import**.
- Callability class **(c)**: top-level `lemma` (callable via `Conway.Life.pow_two_add_one_int`). This is NOT the #8969 trap (that lemma was on a standalone `def`, non-callable via dot-notation or qualified).

## Firsthand verification (G.1)

- **sorry count unchanged**: ConeGeometry = 2, HashlifeCorrectness = 78 (the block is in a 0-sorry proven region — no regression)
- **4 inline `:= by` blocks removed**, 6 call sites across 3 files
- **i18n checker (conway_lean)**: 26/26 byte-identical, 0 drift, 0 orphan (Pattern A parity — the EN twin `ConeGeometry_en.lean` carried the same block and is mirrored: named lemmas in namespace `Conway_en.Life_en` + rewire)
- collision-guard clean (no PR targets `ConeGeometry`/`HashlifeCorrectness`)

## Scope / risk

- **#8869 / #8782 design-owner turf = OUT OF SCOPE**: #8869 is about `native_decide` (Kochen-Specker/Free-Will-Theorem, not Life/Hashlife); #8782's proof-integrity whitelist is explicitly inert on `Conway.Life.*`. This PR touches only the P4 window-membership power facts, pure consumer-rewiring.
- HashlifeCorrectness is prover-harness scaffolding (78 sorries, Epic #1453), but the edit is localized to a proven region (0 sorry touched) — exactly the consumer-rewiring the brief permits for non-`native_decide` conway modules.

## Compile gating (lean-merge-discipline, honesty)

No local mathlib cache on this worktree (~20GB clone is disproportionate for a consumer-rewiring grain). The named lemmas' bodies are **byte-identical** to the eliminated inline blocks, and call sites preserve the `hpe1`/`hpe2` term types, so compile risk is low — but **gated on Lean CI** (`conway_lean` via `lean-build.yml`). I am not claiming "compiles by construction" — that was the #8969 failure. The Lean CI run is the firsthand verification.

See #8928 (consumer-rewiring pattern).

Co-Authored-By: Claude-Code <noreply@anthropic.com>