### PR TITLE
fix(symbolicai,#8052): Dung_AF_Semantics Exercise-3 grounded labeling — c is UNDEC, not OUT

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Dung_AF_Semantics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Dung_AF_Semantics.ipynb
@@ -820,7 +820,7 @@
     "Les sémantiques admettent une formulation équivalente en **étiquetages** : chaque\n",
     "argument reçoit l'étiquette IN (accepté), OUT (rejeté) ou UNDEC (indécidable), avec les\n",
     "règles : (i) $x$ est OUT si un IN l'attaque ; (ii) $x$ est IN si tous ses attaquants sont\n",
-    "OUT. Le labeling grounded de `af1` devrait donner $d$=IN, $c$=OUT (auto-attaqué), et\n",
+    "OUT. Le labeling grounded de `af1` devrait donner $d$=IN, $c$=UNDEC (auto-attaqué, mais rejeté par aucun IN), et\n",
     "$a, b$=UNDEC (le flottement non tranché).\n",
     "\n",
     "**Objectif** : implémenter `grounded_labeling(af)` renvoyant un dict `{arg: \"IN\"/\"OUT\"/\"UNDEC\"}`,\n",


### PR DESCRIPTION
Grain: MED/notebook-content — lane myia-po-2024:CoursIA-2 — prev: MED/test-coverage (#8980 slides symtrap regression test, distinct genre: argumentation-semantics interpretation defect vs slides-tooling regression test)

## What

Fixes a real **interpretation defect** in `Argument_Analysis_Dung_AF_Semantics.ipynb`, found via the #8052 static claims↔outputs audit (Argument_Analysis family slice, ≥5%/fam bar — a family beyond my CPU/.NET partition but cross-lane eligible).

The **Exercise 3 statement** declared the expected grounded labeling of the canonical AF `F=⟨{a,b,c,d},{(a,b),(b,a),(c,c)}⟩` as:

> d=IN, **c=OUT (auto-attacked)**, a,b=UNDEC

The **c=OUT** verdict is **WRONG**. The correct grounded labeling is c=**UNDEC**.

## Why c is UNDEC, not OUT (verified firsthand, c.1022-L)

The Exercise-3 cell states the labeling rule one line above the wrong claim:

> (i) $x$ is OUT **if an IN attacks it**

On `af1`: `c` is attacked only by itself (`c→c`), and `c` is not IN. So **no IN attacks c** → by the statement's own rule, c is **NOT OUT** — it's neither IN nor OUT, i.e. **UNDEC**.

Running the notebook's own `grounded()` + standard grounded labeling confirms:

```
grounded(af1)            = {d}                    # only IN is d
grounded labeling(af1)   = {a:UNDEC, b:UNDEC, c:UNDEC, d:IN}
```

The conceptual slip is "**self-attack ⇒ OUT**", which is intuitively tempting but false: self-attack excludes c from IN and lands it in UNDEC (OUT requires an IN attacker), not OUT.

## The notebook already contradicts itself here

This is the strongest internal evidence the claim is a defect, not an author's intent: the notebook's **trajectory section** (cell b1e59d36, two cells later) **explicitly corrects the same misconception**:

> « **c est UNDEC, pas OUT.** L'argument auto-attaqué n'est rejeté par personne — il s'exclut lui-même sans qu'un IN ne l'attaque. La règle « OUT = attaqué par un IN » ne s'applique donc pas à lui »

So the Exercise-3 "c=OUT" contradicts (a) the rule stated in its own cell, (b) the computed output, **and** (c) the trajectory section's explicit correction. The fix makes the Exercise-3 expected result consistent with all three.

## Why this is MED (not LIGHT) — falsifiability

The claim "c=OUT" needed a **computed** refutation (run the grounded labeling), not a pattern-scan, to prove it answered a *wrong mental model* of self-attack. The defect survives structural validation (notebook parses, runs clean end-to-end, has ≥3 exercises) exactly as the #8052 thesis predicts. c.1039-L reinforced: interpretation defects in number/label claims need computed grounding, MED not LIGHT.

## Fix

Markdown-only, single line:
`"$c$=OUT (auto-attaqué)"` → `"$c$=UNDEC (auto-attaqué, mais rejeté par aucun IN)"`

- No code change, no re-exec, outputs/code intact.
- Not twinned (verified `scripts/notebook_tools/twin_pairs.d/` has no Argument_Analysis pair — only app-*/tweety yaml files exist) → **no twin-parity drift trap** (contrast Infer-2/App-1 which forced rebaseline).
- 1 file, +1/−1, LF clean, UTF-8 no-BOM, trailing newline preserved.

## Scope

1 file, 1 line changed. No source changes beyond the markdown correction.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
