### PR TITLE
fix(symbolicai,#8052): Planners-5 h^FF shared-precondition instance — value is 3 (= h*), not 2

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics.ipynb
@@ -693,7 +693,7 @@
     "|-------------|--------|--------------------------|-------------|\n",
     "| h^max       | 2      | Oui                     | Compte le sous-but le plus cher (cout 2 = setup + make) |\n",
     "| h^add       | 4      | **Non**                 | Double-compte `setup` : 2 (pour g1) + 2 (pour g2) |\n",
-    "| h^FF        | 2      | **Non**                 | Extrait le plan relaxe partage, retombe sur h^max |\n",
+    "| h^FF        | 3      | **Non**                 | Plan relaxe partage `setup` : {setup, make_g1, make_g2} = 3 = h* |\n",
     "| h*          | 3      | -                       | Plan optimal : setup, make_g1, make_g2 |\n",
     "\n",
     "**Pourquoi h^add = 4 > h* = 3** :\n",
@@ -708,7 +708,7 @@
     "\n",
     "**h^max reste admissible** : `max(2, 2) = 2 <= h* = 3`. C'est la superiorite classique de h^max pour la recherche optimale : il sous-estime systematiquement, garantissant l'optimalite avec A*.\n",
     "\n",
-    "**h^FF = h^max = 2 sur cette instance** : le plan relaxe partage `setup` (il atteint `p` qui sert les deux sous-buts), donc FF le compte une seule fois. C'est une illustration que **FF peut etre meilleur que h^add sur des problemes avec actions partagees** — c'est d'ailleurs une des motivations historiques de FF (Hoffmann & Nebel 2001).\n",
+    "**h^FF = h* = 3 sur cette instance** : le plan relaxe partage `setup` (il atteint `p` qui sert les deux sous-buts), donc FF le compte une seule fois — le plan relaxe extrait est exactement {`setup`, `make_g1`, `make_g2`} (cout 3 = h*), et non 4 comme h^add (qui double-compte `setup`). C'est une illustration que **FF peut etre meilleur que h^add sur des problemes avec actions partagees** — c'est d'ailleurs une des motivations historiques de FF (Hoffmann & Nebel 2001).\n",
     "\n",
     "**Implication pratique** : pour la planification optimale, preferer h^max ou LM-cut (admissibles) ; pour la recherche satisfiable rapide, h^FF est souvent preferable a h^add (meilleure guidance, pas de surestimation catastrophique sur actions partagees)."
    ]

--- a/scripts/notebook_tools/twin_pairs.d/planners-5-heuristics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-5-heuristics.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-25"
-    by: po-2024
-    python_sha: 18790ce7c2eb67b9ae02ebdcc829842b62f38de4
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2 2026-07-31
+    python_sha: 53cfe0cd86022c2a7cd5136f71aa4ba867727abb
     csharp_sha: 64708cbd5657ac6c52dc7211f0cfa0833d46f732
   known_differences:
     - "Concept : heuristiques admissibles (relaxation, h_add, h_max, delete-relaxation)."


### PR DESCRIPTION
Grain: MED/notebook-content — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-content (#8985 Argument_Analysis Dung_AF grounded-labeling ; distinct family/substance: Planners heuristic-claim vs argumentation grounded-labeling)

## What

Fixes a real **interpretation defect** in `Planners-5-Heuristics.ipynb`, found via the #8052 static claims↔outputs audit (SymbolicAI/Planners family slice, ≥5%/fam bar — a fresh vein in my CPU/.NET partition, non-owner-locked, cross-lane eligible).

The **§3.5 interpretation table + prose** (cell `hadd-inadmissible-demo-interp`) claimed that on the shared-precondition instance

```
setup:{s}->{p}, make_g1:{p}->{g1}, make_g2:{p}->{g2}, goal={g1,g2}
```

the FF heuristic gives **h^FF = 2** and "**h^FF = h^max = 2 sur cette instance**".

The value **2 is WRONG**. The correct value is **h^FF = 3 (= h\*)**.

## Why h^FF = 3, not 2 (verified firsthand, running the notebook's OWN code)

The §3.5 code cell only computes `h_max` and `h_add` (it explicitly notes "*h^FF est défini plus loin dans le notebook*"). So the "h^FF = 2" was a **hand-claim never computed**. Running the notebook's own `h_ff` function (the same one whose output appears later for the multi-switch instance) on `shared_problem` returns **3**:

```
relaxed plan extracted = {setup, make_g1, make_g2} = 3 unique actions
=> h^FF = 3  (= h*)
```

The conceptual slip: the author conflated "**FF counts the shared enabler `setup` once**" (correct — that's why FF avoids the double-count) with "**therefore FF falls back to h^max = 2**" (false). Counting `setup` once does **not** collapse FF to the max: FF counts **all** unique relaxed-plan actions (`setup` + `make_g1` + `make_g2` = 3). The correct reading is h^FF = h\* = 3 — which is precisely what makes FF superior to h^add on shared-action instances (h^add = 4 double-counts `setup`; h^FF = 3 recovers the optimum).

Sanity: `h_ff` on the multi-switch instance returns 3 (matches the existing cell output), confirming the function behaves as documented and the §3.5 "2" is an isolated hand-computation error.

## The C# twin is ALREADY correct (strongest internal evidence)

This is a **twinned** notebook (semantic parity). The C# twin `Planners-5-Heuristics-Csharp.ipynb` handles the same §3.5 demonstration **correctly**:

- **C# cell 11**: "$h^{add} = 2+2 = 4 > h^* = 3$" ✓
- **C# cell 13**: h^FF "*evite le double-compte de h^add*", "*ne double-compte pas les enablers partagés*", "*très proche de h\*" ✓

So the Python "h^FF = 2" defect was **isolated to the Python notebook**, and this fix **RESTORES semantic parity** with the already-correct C# twin. The parity axis (h^add = 4 > h\* = 3) is untouched.

## Why this is MED (not LIGHT) — falsifiability

The claim "h^FF = 2" needed a **computed** refutation (run the notebook's own `h_ff` on `shared_problem`), not a pattern-scan, to prove it answered a *wrong mental model* of FF (conflating "count once" with "take the max"). The defect survives structural validation (notebook parses, runs clean end-to-end, has 3 exercises) exactly as the #8052 thesis predicts — a textbook interpretation defect in a number-claim, same class as App-1's "256 = max-14" (c.1039).

## Fix

Markdown-only, 2 lines in cell `hadd-inadmissible-demo-interp`:
- table row: `h^FF` value **2 → 3**, observation "*Extrait le plan relaxe partagé, retombe sur h^max*" → "*Plan relaxe partagé `setup` : {setup, make_g1, make_g2} = 3 = h\**"
- prose: "**h^FF = h^max = 2 sur cette instance** …" → "**h^FF = h\* = 3 sur cette instance** … le plan relaxé extrait est exactement {`setup`, `make_g1`, `make_g2`} (coût 3 = h\*), et non 4 comme h^add (qui double-compte `setup`)"

No code change, no re-exec, outputs intact. Minimal diff: 1 file, +2/−2.

## Twin rebaseline (commit 2)

Planners-5 is a semantic-level twin. The Python blob SHA advanced (`18790ce7c → 53cfe0cd8`); the drift is **paraphite-PRESERVING** (parity axis h^add>h\* unchanged, fix aligns Python with the already-correct C#). Registry `python_sha` updated in the follow-up commit; `csharp_sha` unchanged. `check_twin_parity --check` → **[OK]** at HEAD.

## Scope

1 file content + 1 registry file. No source changes beyond the markdown correction and the attested-SHA refresh.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
