### PR TITLE
fix(symbolicai,#8052): Planners-3 h* admissibility demo — optimal cost is 4, not 6

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb
@@ -1177,8 +1177,8 @@
       "\n",
       "--- Grille avec obstacle en (1,1) ---\n",
       "h((0,0), (2,2)) = 4\n",
-      "h*((0,0), (2,2)) = 6 (chemin reel avec obstacle)\n",
-      "h <= h* ? Oui, l'heuristique est admissible\n"
+      "h*((0,0), (2,2)) = 4 (chemin reel optimal, via BFS)\n",
+      "h <= h* ? True, l'heuristique est admissible (ici h = h* : l'obstacle (1,1) est hors des plus courts chemins, il n'allonge pas le trajet)\n"
      ]
     }
    ],
@@ -1192,10 +1192,15 @@
     "\n",
     "# Exemple avec obstacle\n",
     "grid_with_obstacle = GridWorld(3, 3, obstacles={(1, 1)})\n",
+    "_h_val = manhattan_distance(GridState(0,0), goal_state)\n",
+    "# h* via BFS sur la grille a obstacle. NB: l'obstacle (1,1) est hors de tous les\n",
+    "# plus courts chemins (0,0)->(2,2) (ex. (0,0)->(0,1)->(0,2)->(1,2)->(2,2)), donc le\n",
+    "# chemin optimal reste de cout 4 : ici h = h* (Manhattan exacte, donc admissible).\n",
+    "_h_star = bfs(GridState(0,0), goal_state, grid_with_obstacle.get_successors)[1]\n",
     "print(\"\\n--- Grille avec obstacle en (1,1) ---\")\n",
-    "print(f\"h((0,0), (2,2)) = {manhattan_distance(GridState(0,0), goal_state)}\")\n",
-    "print(f\"h*((0,0), (2,2)) = 6 (chemin reel avec obstacle)\")\n",
-    "print(f\"h <= h* ? Oui, l'heuristique est admissible\")"
+    "print(f\"h((0,0), (2,2)) = {_h_val}\")\n",
+    "print(f\"h*((0,0), (2,2)) = {_h_star} (chemin reel optimal, via BFS)\")\n",
+    "print(f\"h <= h* ? {_h_val <= _h_star}, l'heuristique est admissible (ici h = h* : l'obstacle (1,1) est hors des plus courts chemins, il n'allonge pas le trajet)\")"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/planners-3-state-space.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-3-state-space.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-25"
-    by: po-2023
-    python_sha: 8d03359d12709b134f644e187d04249b6e1fcadf
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2 2026-07-31
+    python_sha: e8cbb855b1d3b44b93c091d28990202477441e96
     csharp_sha: a9306fbf5a3c02555bf3f63b03a35db099da423f
   known_differences:
     - "Concept : recherche dans l'espace d'etats (BFS/DFS/A* sur le graphe des etats reachables)."


### PR DESCRIPTION
Grain: MED/notebook-content — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-content (#8987 Planners-5 h^FF ; distinct notebook & concept: Planners-3 BFS optimal-cost / admissibility vs Planners-5 FF heuristic value)

## What

Fixes a real **interpretation defect** in `Planners-3-State-Space.ipynb`, found via the #8052 static claims↔outputs audit (SymbolicAI/Planners family slice, ≥5%/fam bar).

The **§5.1 admissibility demonstration** (cell `cell-24`) hardcoded

```python
print(f"h*((0,0), (2,2)) = 6 (chemin reel avec obstacle)")
```

for a 3×3 grid with obstacle at (1,1), start (0,0), goal (2,2). The value **6 is WRONG**. The correct optimal cost is **4**.

## Why h* = 4, not 6 (verified firsthand, running the notebook's OWN bfs)

The obstacle at (1,1) lies **off every shortest path** from (0,0) to (2,2). For example:

```
(0,0) -> (0,1) -> (0,2) -> (1,2) -> (2,2)   = 4 steps, avoids (1,1)
```

So the obstacle does not lengthen the optimal path: **h\* = 4**. Manhattan h = 4 = h\* = 4 (the heuristic is **exact** here, hence admissible), not h < h\* = 6.

Running the notebook's own `bfs()` on `grid_with_obstacle` confirms cost 4. This also contradicts the notebook's **own cell 12**, which already reports BFS cost 4 for (0,0)→(2,2) on this same 3×3 grid (without obstacle — and the obstacle changes nothing).

## Why this is MED (not LIGHT) — falsifiability

The claim "h\* = 6" needed a **computed** refutation (run BFS), not a pattern-scan, to prove it answered a *wrong mental model* ("obstacle ⇒ longer path"). The defect survives structural validation (notebook parses, runs clean, has 3 exercises) — a textbook #8052 interpretation defect in a number-claim, same class as Planners-5's h^FF (c.1046) and App-1's "256 = max-14" (c.1039).

## Fix

Make h\* **computed** via `bfs()` (it was a hardcoded literal that could silently drift), and reframe the prose honestly — the obstacle (1,1) is off the shortest paths, so h = h\* here (Manhattan exact, admissible):

```python
_h_val   = manhattan_distance(GridState(0,0), goal_state)
_h_star  = bfs(GridState(0,0), goal_state, grid_with_obstacle.get_successors)[1]
print(f"h((0,0), (2,2)) = {_h_val}")
print(f"h*((0,0), (2,2)) = {_h_star} (chemin reel optimal, via BFS)")
print(f"h <= h* ? {_h_val <= _h_star}, l'heuristique est admissible (ici h = h* : l'obstacle (1,1) est hors des plus courts chemins, ...)")
```

**Re-executed** cell 27 via nbclient (kernel `coursia-ml-training`) to regenerate outputs (C.2). Output: `h=4, h*=4, admissible=True`. No .NET cells touched (no probe-banner concern). Minimal diff: 1 file, +10/−5.

## Twin rebaseline (commit 2)

Planners-3 is a semantic twin. The §5 admissibility demo is **not** the parity axis (parity = BFS/A\* terrain costs: BFS=55, A\*=16). The C# twin has no obstacle-admissibility section (Python-only). Drift is **paraphite-PRESERVING**; registry `python_sha` updated; `csharp_sha` unchanged. `check_twin_parity --check` → **[OK]** at HEAD.

## Scope

1 file content + 1 registry file. No source changes beyond the cell-27 correction and the attested-SHA refresh.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
