### PR TITLE
fix(search,#8052): App-14 ConnectFour tournament — Minimax "bat MCTS 3-3" is wrong (3-3 is a tie)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb
@@ -2200,7 +2200,7 @@
     "\n",
     "**Points cles** :\n",
     "1. **Alpha-Beta domine largement** : 94% de victoires, 6-0 contre Minimax et Random\n",
-    "2. **Minimax équilibre** : 50% de win rate (bat MCTS 3-3, perd contre Alpha-Beta)\n",
+    "2. **Minimax équilibre** : 50% de win rate (fait égalité avec MCTS 3-3, perd contre Alpha-Beta)\n",
     "3. **MCTS en difficulté** : Perd contre Alpha-Beta (1-5) et contre Random (2-4), égalité contre Minimax (3-3)\n",
     "4. **échantillon insuffisant** : 6 parties par match = résultats variables\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/app-14-connectfour-adversarial.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-14-connectfour-adversarial.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial-CSharp.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-25'
-    by: po-2026
-    python_sha: 5098122cf762afaf6ea657f3715aee00257e65b8
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2
+    python_sha: 63f23b87a3e1bc62f89faf34745d206caf1befdb
     csharp_sha: 2ec088ff8d391f7e8bc39e967730ca6c7c821b01
   known_differences:
     - "Socle pedagogique commun : Puissance 4 adversarial (variant Connect-4, IA jeux combinatoires) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."


### PR DESCRIPTION
Grain: MED/notebook-content — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-content (#8988 Planners-3 h* admissibility ; distinct notebook & concept: App-14 ConnectFour tournament head-to-head interpretation vs Planners BFS optimal-cost)

## What

Fixes a real **interpretation defect** in `App-14-ConnectFour-Adversarial.ipynb`, found via the #8052 static claims↔outputs audit (Search family slice, ≥5%/fam bar).

The **§7 tournament interpretation** (cell 34, "Points cles") claimed:

> 2. **Minimax équilibre** : 50% de win rate (**bat MCTS 3-3**, perd contre Alpha-Beta)

"bat" = beat/defeated. But the head-to-head score **3-3 is a tie (draw)**, not a win. The claim is **factually wrong**, and it is **internally contradicted** by the very next point in the same cell:

> 3. **MCTS en difficulté** : ... **égalité contre Minimax (3-3)**

Point 2 says Minimax BEAT MCTS; Point 3 says MCTS TIED Minimax — same matchup, opposite characterizations. The tie reading (Point 3) is correct.

## Why "bat 3-3" is wrong (verified firsthand, running the notebook's OWN tournament)

The notebook's `run_tournament` (cell 33) prints the round-robin head-to-head:

```
Match: Minimax(d=4) vs MCTS(1000)... 3-3-0
```

A 3-3 result is a **draw**. Minimax's higher *standing* (50% win rate vs MCTS's 33.3%, per the cell-34 table) does **not** come from beating MCTS head-to-head — it comes from Minimax crushing Random 6-0 while MCTS *lost* to Random 2-4 (`Match: Random vs MCTS(1000)... 4-2-0`). So Minimax finishes ahead *despite* tying MCTS, not by beating MCTS.

This is the same #8052 class as Dung_AF c=OUT→UNDEC (#8985): a hand-written characterization of a computed result that gets the semantics wrong (a tie misread as a win). The defect survives structural validation (notebook parses, runs clean, has 5 exercises) — textbook interpretation defect in a result-claim.

## Fix

Markdown-only, one phrase in cell 34 Point 2:

- `bat MCTS 3-3` → `fait égalité avec MCTS 3-3`

Now parallel to Point 3's "égalité contre Minimax (3-3)" and factually correct. No code change, no re-exec, outputs intact. Minimal diff: 1 file, +1/−1.

## Twin rebaseline (commit 2)

App-14 is a semantic twin (`app-14-connectfour-adversarial.yaml`, parity_level: semantic). The §7 tournament interpretation is **Python-only** — the C# twin (22 cells, compact from-scratch) has no "Points cles" interpretation cell; the registry's `known_differences` already documents this asymmetry ("Python met l'accent sur l'expérimentation comparative ; le C# démontre l'implementation from-scratch en BCL pure, présentation compacte"). The parity axis (theoretical socle: adversarial search, Minimax/Alpha-Beta/MCTS node-counts) is untouched. Drift is **paraphite-PRESERVING**; registry `python_sha` rebaselined; `csharp_sha` unchanged. `check_twin_parity --check` → **[OK]** at HEAD.

## Scope

1 file content + 1 registry file. No source changes beyond the cell-34 prose correction and the attested-SHA refresh.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
