### PR TITLE
fix(notebook_tools): C# //-comment-only cells skipped as non-executable

### DIFF
--- a/scripts/notebook_tools/notebook_lint.py
+++ b/scripts/notebook_tools/notebook_lint.py
@@ -134,9 +134,13 @@ def check_c2(notebook: dict) -> list[dict]:
         if not source.strip():
             continue
 
-        # Skip comment-only cells
+        # Skip comment-only cells. Recognise the three line-comment forms used
+        # across the fleet: Python '#', C-family '//' (.NET Interactive C#/F#,
+        # also handled by scan_c1_source #5261), and Lean '--'. A cell whose
+        # non-blank lines are ALL comments is a transition note, not executable
+        # code, so it must not be flagged for a missing execution_count.
         lines = [l.strip() for l in source.split("\n") if l.strip()]
-        if all(l.startswith("#") for l in lines):
+        if all(l.startswith(("#", "//", "--")) for l in lines):
             continue
 
         # Skip QC reference cells (not executable locally)

--- a/scripts/notebook_tools/tests/test_notebook_lint.py
+++ b/scripts/notebook_tools/tests/test_notebook_lint.py
@@ -329,6 +329,20 @@ class TestCheckC2:
         nb = _nb([_code("# line 1\n# line 2\n# line 3")])
         assert check_c2(nb) == []
 
+    def test_csharp_comment_only_skipped(self):
+        # .NET Interactive C# '//'-only cell is a transition note, not
+        # executable code — must not be flagged for a missing execution_count.
+        # Mirrors scan_c1_source '//' awareness (#5261).
+        nb = _nb([_code("// Exercice : implementez le solveur ci-dessous\n"
+                        "// (cellule de transition, aucun enonce executable)")])
+        assert check_c2(nb) == []
+
+    def test_lean_comment_only_skipped(self):
+        # Lean '--'-only cell is non-executable prose (consistent with the
+        # validate_pr_notebooks gate, which special-cases Lean '--' per #5151).
+        nb = _nb([_code("-- Exercice : completez la preuve\n-- (note de transition)")])
+        assert check_c2(nb) == []
+
 
 # ---------------------------------------------------------------------------
 # check_structure

--- a/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
+++ b/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
@@ -153,6 +153,25 @@ class TestValidateNotebookH3:
         assert result["passed"] is True
         assert result["forensic_verdict"] == "EXEC_PROVED"
 
+    def test_csharp_comment_only_cell_skipped(self, tmp_path):
+        """A .NET C# cell that is purely '//'-comments is a transition note,
+        not executable code — it is skipped (not counted in total_code, not
+        flagged for a null execution_count), consistent with Lean '--' (#5151)
+        and the '//' awareness of scan_c1_source (#5261). Previously the gate
+        used 'comment_prefix = # if not lean', so a '//'-only cell with
+        execution_count null was a false H.3/C.2 hit."""
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code("// Exercice : le solveur est introduit ci-dessous.\n"
+                  "// (cellule de transition, aucun enonce executable)",
+                  exec_count=None),
+            _code('Console.WriteLine("ok");', exec_count=1,
+                  outputs=[{"output_type": "stream", "name": "stdout",
+                            "text": ["ok"]}]),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"})
+        result = validate_notebook(nb)
+        assert result["total_code"] == 1  # comment-only cell skipped, real cell counted
+        assert result["passed"] is True
+
     def test_skip_exec_for_lean_kernel(self, tmp_path):
         """Lean notebooks tolerate a null execution_count (kept advisory — own
         rendering subtleties via lean4_jupyter/alectryon, out of #5214 scope)."""

--- a/scripts/notebook_tools/validate_pr_notebooks.py
+++ b/scripts/notebook_tools/validate_pr_notebooks.py
@@ -269,7 +269,16 @@ def validate_notebook(nb_path: Path) -> dict:
         # Lean command cells — and with them any error output they carry
         # (#5151: the failing '#print axioms' / '#check' cells were skipped;
         # the notebook was only caught by its failing 'import' cell).
-        comment_prefix = "--" if "lean" in kernel else "#"
+        # C# / F# (.NET Interactive) line comments use '//' — a '//'-only cell is
+        # a transition note, not executable code, so it must not be counted as
+        # total_code nor flagged for a missing execution_count. Mirrors the '//'
+        # awareness of scan_c1_source (#5261) in the same ecosystem.
+        if "lean" in kernel:
+            comment_prefix = "--"
+        elif "csharp" in kernel or "fsharp" in kernel:
+            comment_prefix = "//"
+        else:
+            comment_prefix = "#"
         lines = [l.strip() for l in source.split("\n") if l.strip()]
         if all(l.startswith(comment_prefix) for l in lines):
             continue


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA

## Summary

The PR-notebook gate and the structural linter skip "comment-only cells" (a cell whose non-blank lines are all comments) so a transition note is not counted as executable code nor flagged for a missing `execution_count`. Both handled only Python `#` and (in the gate) Lean `--`, but **not** the C-family `//` line comment used by .NET Interactive C#/F# cells. A `//`-only C# cell with `execution_count: null` would have been a **false H.3/C.2 hit**.

This PR extends the comment-prefix mapping to `//` for C#/F# kernels, mirroring the `//` awareness of `scan_c1_source` (#5261) and the Lean `--` special-case (#5151) — same blind-spot-prevention culture as the C# `//` (#5760) and Lean `--` (#5774) C.1 detector fixes.

## Changes (4 files, +49/-3)

- **`validate_pr_notebooks.py:272`** — kernel-aware `comment_prefix`: `"--"` Lean / `"//"` C#-F# / `"#"` otherwise. The Lean special-case (#5151: `#check`/`#print`/`#reduce` are commands, not comments) is **unchanged**; only a new `csharp`/`fsharp` branch is added.
- **`notebook_lint.py:139`** (`check_c2`) — recognise all three line-comment forms (`#`, `//`, `--`), kernel-agnostic. Also closes a latent Lean `--` gap in the linter (it previously only matched `#`).

## Tests (3, G.9 non-vacuous — each FAILS on the old code)

- `test_csharp_comment_only_cell_skipped` — a `.net-csharp` notebook with a `//`-only cell (`exec_count=None`) + a real executed cell → `total_code==1` (comment-only skipped), `passed==True`. Old code: `total_code==2`, `passed==False` (false H.3 hit).
- `test_csharp_comment_only_skipped` + `test_lean_comment_only_skipped` — `check_c2` skips `//`-only C# and `--`-only Lean cells.

## Verification (firsthand)

- **Local**: `python -m pytest scripts/notebook_tools/tests/test_validate_pr_notebooks.py scripts/notebook_tools/tests/test_notebook_lint.py -q` → **57 passed, 73 passed, 0 regressions** (was 56 + 71; +3 new tests).
- **Latent today** (honest): no `//`-only C# code cell exists in the committed fleet — verified via `git grep` across `origin/main` `*-Csharp.ipynb`. **Zero behavior change on the current corpus.** The fix prevents a future false gate failure the moment such a cell is added, and brings the two comment-only skips in line with the documented comment-awareness culture.
- **Lean special-case preserved**: the `"lean" in kernel` branch is byte-identical to before; only a new branch is added, so #5151 behavior is untouched.
- **No over-skip risk**: the `all(l.startswith(prefix))` guard means a `//`-comment line mixed with real code (e.g. `// intro\nvar x = 1;`) is NOT skipped — only a cell where EVERY non-blank line is a comment.

## Scope

One subject (recognize `//`/`--` comment-only cells), 4 files, +49/-3. Catalogue byte-identical to main. No notebook touched.

See #5261, #5151, #5760, #5774
