### PR TITLE
fix(rl,#8052): rl_4 bandits cell-35 title — UCB "finit 2e a T=2000" is wrong (UCB is last, not 2nd)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb
@@ -1558,7 +1558,7 @@
    "id": "f5ae47a4",
    "metadata": {},
    "source": [
-    "### Interprétation : robustesse de Greedy vs UCB (pourquoi UCB \"optimal\" finit 2e a T=2000)\n",
+    "### Interprétation : robustesse de Greedy vs UCB (pourquoi UCB \"optimal\" finit en mauvaise position a T=2000)\n",
     "\n",
     "Le benchmark principal (cellule précédente, T=2000) montre **Greedy gagnant** et UCB en mauvaise position. Le sweep ci-dessus explique pourquoi **sans contredire la théorie** : l'optimalite d'UCB est **asymptotique**, et sa vraie force est la **robustesse**, pas de battre un Greedy bien initialise a court terme.\n",
     "\n",


### PR DESCRIPTION
Grain: MED/notebook-content — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-content (#8989 App-14 ConnectFour tournament ; distinct notebook & concept: RL multi-armed-bandit regret ranking vs game-tree tournament interpretation)

## What

Fixes a real **interpretation defect** in `rl_4_multi_armed_bandits.ipynb`, found via the #8052 static claims↔outputs audit (Reinforcement Learning family slice, ≥5%/fam bar).

The **§7 interpretation cell 35** title claimed:

> ### Interprétation : robustesse de Greedy vs UCB (pourquoi UCB "optimal" **finit 2e a T=2000**)

"finit 2e" = finishes 2nd. But UCB does **not** finish 2nd at T=2000 — it finishes **last** (worst) among the smart strategies at short/medium horizons. The title is **internally contradicted** by the very next sentence in the same cell (the body):

> Le benchmark principal (cellule précédente, T=2000) montre Greedy gagnant et UCB en **mauvaise position**.

"finit 2e" (2nd) vs "mauvaise position" (bad position) — opposite characterizations of UCB at the same horizon. The "mauvaise position" reading is correct.

## Why "finit 2e a T=2000" is wrong (verified firsthand, the notebook's OWN regret tables)

The notebook's averaged benchmark (cell 32) ranks strategies by regret (lower = better):

```
| Strategie        | Regret final |
| Greedy           |      46.0    |   ← 1st
| e-greedy (0.1)   |      97.1    |   ← 2nd
| e-greedy (0.01)  |     199.8    |   ← 3rd
| UCB (c=2)        |     271.1    |   ← LAST (worst among smart strategies)
| Random           |     658.6    |
```

At T=2000, UCB has the **highest** regret among the four smart strategies → it finishes **last (4th)**, not 2nd.

The horizon sweep (cell 34) confirms UCB is **last at every short/medium horizon** and only moves up at very long horizons:

```
| Strategie          | T=1000 | T=3000 | T=10000 | T=30000 |
| Greedy (warmup=10) |   41.8 |   55.3 |   112.0 |   248.4 |  ← 1st (warmup artifact)
| Greedy (warmup=1)  |   42.4 |  121.2 |   406.4 |  1172.5 |
| e-greedy (0.1)     |   53.2 |  125.5 |   391.6 |  1088.2 |
| UCB (c=sqrt(2))    |  123.9 |  224.6 |   381.2 |   546.9 |  ← LAST at T≤3000, 2nd only at T=30000
```

So "2e" and "T=2000" **cannot both be correct**: UCB is *dernier* at T=2000 (and T=1000/3000), and only *2e* at T=30000. The title conflates the two. This is the same #8052 class as Dung_AF c=OUT→UNDEC (#8985) and App-14 "bat 3-3" (#8989): a hand-written characterization of a computed result that gets the semantics wrong, internally contradicted, surviving structural validation (notebook parses, runs clean, has 3 exercises).

## Fix

Markdown-only, the cell-35 title only:

- `finit 2e a T=2000` → `finit en mauvaise position a T=2000`

Now mirrors the body's own "UCB en mauvaise position" and is data-correct (UCS is last among smart strategies at T=2000). The cell's thesis — UCB is asymptotically optimal but performs poorly short-term, with robustness revealed only at long horizons (T=30000) — is preserved and now consistent across title, body, and data. No code change, no re-exec, outputs intact. Minimal diff: 1 file, +1/−1.

## Twin

rl_4 is **not twinned** (no `twin_pairs.d/` entry for rl_4 or bandits; the only RL twin is `gametheory-17-multiagent-rl`, a different notebook) → no rebaseline, 0 drift.

## Scope

1 file content only. No source changes beyond the cell-35 title correction.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
