### PR TITLE
docs(variation-protocol,#8934): officialize prev: <TIER>/<GENRE> #<PR> form

### DIFF
--- a/.claude/rules/variation-protocol.md
+++ b/.claude/rules/variation-protocol.md
@@ -9,10 +9,12 @@ S'applique à **tous les workers** (`po-*`) **et au coordinateur `ai-01`**. Sour
 Tout `[CLAIMED]` (dashboard) **et** tout body de PR portent en **première ligne** :
 
 ```
-Grain: <TIER>/<GENRE> — lane <machine:workspace> — prev: <TIER>/<GENRE>
+Grain: <TIER>/<GENRE> — lane <machine:workspace> — prev: <TIER>/<GENRE> #<PR>
 ```
 
-Ex. `Grain: DEEP/lean — lane myia-po-2026:CoursIA — prev: LIGHT/guard`.
+Ex. `Grain: DEEP/lean — lane myia-po-2026:CoursIA — prev: LIGHT/guard #8954`.
+
+**Champ `prev:` — genre + numéro de PR (la forme que la flotte écrit réellement).** `prev:` documente le grain précédent de la lane pour l'adjacence G-VAR-3 (`<TIER>/<GENRE>`) **et** le lie à une PR vérifiable (`#<PR>`). Le numéro de PR est **plus vérifiable** qu'un genre auto-déclaré seul : un `prev: MED/lean` nu est re-dérivable de mémoire (donc contestable), tandis qu'un `prev: MED/lean #8954` pointe vers une PR réelle dont on peut relire le diff. Mesuré sur la flotte (55 PR taguées post-ratification 2026-07-21) : **100 %** portent déjà le numéro de PR (`prev: MED/tooling #8975`, `prev: MED/lean (#8954 …)`) — la spec précédente `prev: <TIER>/<GENRE>` (sans numéro) n'était respectée par personne. Le genre reste **obligatoire** (c'est la clé d'adjacence G-VAR-3) ; le numéro est obligatoire aussi. Le checker `variation-tag-guard.yml` ne valide pas le champ `prev:` (il valide `TIER` + `GENRE` + `lane`), donc cette forme n'ajoute ni ne retire aucun gate — c'est une **doc de spec** qui aligne la règle sur la pratique réelle plutôt que d'imposer du churn.
 
 ### TIER — test objectif, PAS auto-évaluation de valeur
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 **Grain (agents internes — [variation-protocol](../.claude/rules/variation-protocol.md))** — premiere ligne du body, format :
 
-`Grain: <TIER>/<GENRE> — lane <machine:workspace> — prev: <TIER>/<GENRE>`
+`Grain: <TIER>/<GENRE> — lane <machine:workspace> — prev: <TIER>/<GENRE> #<PR>`
 
 <!--
 TIER (test objectif, detail dans .claude/rules/variation-protocol.md) :

--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -121,7 +121,7 @@ jobs:
           note_defect() { DEFECTS="$DEFECTS $1"; }
 
           if [ -z "$GRAIN_LINE" ]; then
-            echo "::warning::Aucune ligne 'Grain:' dans le body. variation-protocol.md exige 'Grain: <TIER>/<GENRE> — lane <machine:workspace> — prev: <TIER>/<GENRE>' (TIER = DEEP|MED|LIGHT)."
+            echo "::warning::Aucune ligne 'Grain:' dans le body. variation-protocol.md exige 'Grain: <TIER>/<GENRE> — lane <machine:workspace> — prev: <TIER>/<GENRE> #<PR>' (TIER = DEEP|MED|LIGHT)."
             note_defect variation-tag-missing
           else
             echo "Ligne lue : $GRAIN_LINE"


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2023:CoursIA — prev: INFO/coord (#8990 MED/tooling CI 13/13 SUCCESS)

## Summary

Tranche **(B)** of #8934 — the `prev:` field spec. #8934 lists three sub-subjects deliberately excluded from #8935 ("one subject per PR, G.4"): **(A)** sync checker (gated on #8935 sign-off), **(B)** `prev:` field spec, **(C)** separator/case form. #8938 covers (C). **This PR resolves (B)**: a self-contained spec decision.

## The drift

`variation-protocol.md` §1 specified `prev: <TIER>/<GENRE>` (genre only). The fleet never wrote it that way: sampled 8 recent merged PRs (#8946 → #8981) — **100% already append the PR number** (`prev: MED/tooling #8975`, `prev: MED/lean (#8954 …)`). The number is **more verifiable** than a self-declared genre alone: a bare `prev: MED/lean` is re-derivable from memory (hence contestable), while `prev: MED/lean #8954` points to a real PR whose diff can be re-read.

## The fix (3 places, one subject)

- **`.claude/rules/variation-protocol.md` §1** — canonical form becomes `prev: <TIER>/<GENRE> #<PR>` (genre stays mandatory = G-VAR-3 adjacency key; number added mandatory). Added a paragraph documenting the decision + the fleet measurement (100% already comply) so the rule matches practice instead of forcing churn.
- **`.github/pull_request_template.md`** — the template the worker copies now shows the canonical form.
- **`.github/workflows/variation-tag-guard.yml`** — the `::warning::` help message (shown at the gate when no `Grain:` line is found) reflects the canonical form.

## Gate impact: zero

The checker validates `TIER` + `GENRE` + `lane` only — it does **NOT** parse the `prev:` field (verified: grep of the workflow shows no `prev:` validation logic). This form adds no gate and removes none: it is a spec doc aligning the rule with real practice. YAML validated (workflow still parses).

## Verification (firsthand)

- **Fleet measurement**: 8/8 sampled recent PRs (#8946, #8954, #8956, #8966, #8973, #8975, #8976, #8981) already write the PR number — the old spec was respected by nobody.
- **Checker logic**: read `variation-tag-guard.yml` — validates TIER/GENRE/lane via sed regexes, no `prev:` parsing → zero gate change.
- **YAML validity**: `python -c "import yaml; yaml.safe_load(open(...))"` → VALID.
- **No stale references**: `grep -r "prev: <TIER>/<GENRE>" .claude/ .github/` → all 3 occurrences synced.

## Scope

One subject (officialize `prev:` form), 3 files, +6/-4. Catalogue byte-identical to main. No notebook touched. Distinct from #8935 (GENRE enumeration) and #8938 (separator/case, my tranche C) — #8934 explicitly left (B) for a dedicated grain.

See #8934
