### PR TITLE
fix(genai,#8052): correct local-mini-v2 reasoning answer in LocalLlama recap (1692->19460)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
@@ -2901,7 +2901,7 @@
     "| Test | cloud-gpt5.2 | local-mini-v2 | vllm-qwen3.6 |\n",
     "|------|--------------|----------------|---------------|\n",
     "| Tool calling (cell 34) | ✅ tool_calls | ❌ texte libre | ✅ tool_calls |\n",
-    "| Raisonnement (cell 41) | ✅ 18182 | ❌ 1692 | ✅ 18182 |\n",
+    "| Raisonnement (cell 41) | ✅ 18182 | ❌ 19460 | ✅ 18182 |\n",
     "| Benchmark séquentiel (cell 44) | 37.4 tok/s | 17.9 tok/s | **95.2 tok/s** |\n",
     "| Batching 25 req (cell 51) | 754.6 tok/s (25/25) | 17.45 tok/s (12/25) | 767.5 tok/s (25/25) |\n",
     "| Parallélisme global (cell 54) | ok (2.4s) | timeout (150s) | ok (5.4s) |\n",


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2023:CoursIA — prev: MED/docs #8992

## Summary

EPIC **#8052** semantic-sampling audit, **GenAI/Texte** family. A claims-vs-outputs
lens (static, no re-exec) found a recap-table cell that **mis-described its own committed
output** — the classic #8052 defect pattern.

#8052 GenAI coverage was sparse until now: #8263 (merged) covered the **RAG** notebook.
`10_LocalLlama` cell 61 was a remaining gap.

## The defect

`10_LocalLlama.ipynb` cell 61 is the consolidated "Verdict SOTA-OK" recap table for the
3-endpoint reasoning run (Section 11, resolution of #8369/#8664). Its Raisonnement row
cites **"(cell 41)"** as the source and asserted the local-mini-v2 (Qwen2.5-0.5B) answer:

```
| Raisonnement (cell 41) | ✅ 18182 | ❌ 1692 | ✅ 18182 |
```

But the actual committed output (cell 41, reasoning over 3 endpoints) shows **19460**:

```json
{"endpoint": "local-mini-v2", "answer": 19460, "answer_raw": "19460",
 "correct": false, "completion_tokens": 6, "elapsed_s": 0.949}
```

The notebook's OWN dedicated interpretation cell (cell 42) also states **19460**
("*hallucination arithmétique*"). The literal `1692` appeared exactly **once** in the
whole notebook (an isolated transcription typo in the recap); every other row of the
cell-61 table matches its referenced output. The recap cites "(cell 41)" by name, so a
student cross-checking sees the contradiction directly.

Arithmetic check: the prompt is `253*73-287 = 18469-287 = 18182` (correct → gpt5.2 and
qwen3.6). The 0.5B hallucinates **19460**, not 1692.

This is the #8052 pattern (cf #8974 variance/precision, #8988 optimal-cost-4-not-6,
#8989 minimax-3-3-is-a-tie, #8991 UCB-2e-is-last): prose mis-describes a number in its
own committed output.

## The fix

Markdown-only, **1 literal** corrected in cell 61: `1692` → `19460`. Code cell 41 and
interpretation cell 42 untouched. Re-execution not required (markdown-only edit, rule
C.3 exception; previous outputs stay valid).

## Verification (firsthand, on fresh origin/main worktree)

- **Defect confirmed before editing** (not from subagent verdict alone): cell 41 output =
  19460, cell 42 = 19460, cell 61 = 1692 (read via fresh worktree, not the dirty shared tree).
- **Text-replace asserted exactly 1 substitution** (count check); byte delta +1 (4-char
  `1692` → 5-char `19460`); UTF-8 no-BOM, LF line endings preserved.
- **Post-edit**: JSON valid (67 cells); `1692` now 0 occurrences anywhere; cell 41 + cell 42
  outputs/sources unchanged.
- **H.3 validator**: 1/1 PASS (23 code cells checked).
- **git diff**: 1 file, +1/−1, the single Raisonnement row only.

## Scope

One subject (correct a mis-reported answer in the recap table), 1 file, +1/−1. Catalogue
byte-identical to main (no CATALOG regeneration). Distinct from sibling PRs #8974/#8988/
#8989/#8991 (other families) and #8263 (RAG notebook, merged).

See #8052
