### PR TITLE
fix(genai,#8052): correct quantization sizes in Bonsai-Image Avantages (4/32 GB->0.74/7.45, ~8->~10)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-5-Bonsai-Image-Ternary.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-5-Bonsai-Image-Ternary.ipynb
@@ -55,7 +55,7 @@
     "\n",
     "### Avantages\n",
     "\n",
-    "- **Taille modèle divisee par ~8** vs FP16 (4 GB vs 32 GB pour 4B paramètres bruts), avec overhead reel proche du minimum théorique.\n",
+    "- **Taille modèle divisee par ~10** vs FP16 (0.74 GB vs 7.45 GB pour 4B paramètres bruts), avec overhead reel proche du minimum théorique.\n",
     "- **Inference plus rapide** sur GPU avec kernels INT2 dedies (Gemlite optimise pour Ampere/Ada/Hopper).\n",
     "- **Qualite preservee** : la perte de qualite vs FP16 est de ~5-10 % sur les benchmarks d'image, vs ~30-50 % pour INT2 naif sans schema ternaire (voir section 5).\n",
     "\n",


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2023:CoursIA — prev: MED/genai #8993

## Summary

EPIC **#8052** semantic-sampling audit, **GenAI/Image** family (sibling grain of #8993
which covered GenAI/Texte). A claims-vs-outputs lens (static, no re-exec) found an
"Avantages" bullet that **mis-described its own committed comparison table**.

## The defect

`02-Advanced/02-5-Bonsai-Image-Ternary.ipynb` cell 1 (markdown, "Avantages") asserted,
explicitly scoped "pour 4B paramètres bruts":

```
- **Taille modèle divisée par ~8** vs FP16 (4 GB vs 32 GB pour 4B paramètres bruts), ...
```

But cell 4 (the quantitative comparison table — header cell 3 = "pour un transformer de
4 milliards de paramètres", `N_PARAMS = 4_000_000_000`) commits:

```
           regime  bits_per_weight  taille_GB  ratio_vs_FP16
             FP16           16.000       7.45          1.000
  Ternaire 1.58-bit            1.585       0.74          0.099
```

So for the **same "4B paramètres bruts"** the bullet names: FP16 = **7.45 GB** (not 32 GB),
ternaire = **0.74 GB** (not 4 GB), ratio = 0.099 = **~10×** (not ~8×). Both the absolute
figures AND the reduction ratio are wrong.

**Arithmetic:** 4B params × 16 bits / 8 = 8 GB raw = 7.45 GiB. There is no reading of
"4B paramètres bruts" in FP16 that yields 32 GB (that needs ~16B params). The "4 GB" was
likely a conflation with the deployed total payload (architecture table: ~4.55 GB), but
the bullet explicitly scopes itself to "4B paramètres bruts", where cell 4 is authoritative.

This is the #8052 pattern (cf #8993 GenAI/Texte, #8974 Infer-2, #8988 Planners-3): prose
mis-describes a number in its own committed output. A student cross-checking the Avantages
bullet against section 2's table sees the contradiction directly.

## The fix

Markdown-only, **1 bullet** in cell 1: `~8` → `~10`, `4 GB vs 32 GB` → `0.74 GB vs 7.45 GB`.
Code cell 4 and its output untouched. Re-execution not required (markdown-only, rule C.3
exception; previous outputs valid).

## Verification (firsthand, on fresh origin/main worktree)

- **Defect confirmed before editing** (not from subagent verdict alone): cell 1 bullet =
  4/32 GB, cell 4 output = 0.74/7.45 GB (read via fresh worktree, not the dirty shared tree).
- **Text-replace asserted exactly-1** on each anchor (`4 GB vs 32 GB` unique, `divisee par ~8`
  unique); UTF-8 no-BOM, LF preserved.
- **Post-edit**: JSON valid (16 cells); `32 GB` now 0 occurrences; cell 4 output unchanged
  (7.45 FP16 / 0.74 ternaire).
- **H.3 validator**: 1/1 PASS (8 code cells checked).
- **git diff**: 1 file, +1/−1, the single Avantages bullet only.

## Scope

One subject (correct the quantization-size figures to match the section-2 table), 1 file,
+1/−1. Catalogue byte-identical to main. Distinct from #8993 (GenAI/Texte, sibling grain of
the same #8052 GenAI audit vein).


## Diagnostic dérive (§D.5 required section)

- **Cause (b) — claim antérieure erronée (wrong static size figures).** The Avantages bullet cited "4 GB vs 32 GB" / "~8×" for the quantized-vs-FP16 model size, contradicting the section-2 table in the SAME notebook (committed output: 0.74 GB INT4 vs 7.45 GB FP16, ~10×). Model size = n_params × bytes/param is a **static architectural property** — it does NOT rebouger au prochain passage kernel (unlike a Stopwatch timing / WER / AUC); it is either right or wrong. This is a factual claim-vs-output, not a re-measurable perf figure.
- **Verdict: CAUSE_FIXED.** Single bullet aligned to the section-2 committed table (+1/−1, 1 file). The figures are sourced from the notebook's own deterministic param-count × dtype-size table, stable across machines.

See #8052
