### PR TITLE
docs(twin-parity,#8957): document the strip->update rebaseline order

### DIFF
--- a/scripts/notebook_tools/README.md
+++ b/scripts/notebook_tools/README.md
@@ -393,6 +393,14 @@ python scripts/notebook_tools/check_twin_parity.py --update
 python scripts/notebook_tools/check_twin_parity.py --json
 ```
 
+> **Ordre canonique rebaseline** (#8957) : `--update` atteste le git blob SHA
+> *courant* du notebook. Toute normalisation outillee (`strip_probe_banner.py`,
+> `strip_machine_paths.py`, `scrub_papermill_paths.py`) re-edite le fichier et
+> deplace ce SHA. Sequence : re-exec -> **strip / normalisation** ->
+> `check_twin_parity.py --update` **en dernier**. Inverser l'ordre (update puis
+> strip) pose une attestation sur un notebook qui va changer -> fausse DRIFT,
+> gate rouge alors que la parite est reelle.
+
 ### CI integration (`.github/workflows/twin-parity.yml`, c.818)
 
 Le workflow `.github/workflows/twin-parity.yml` **fail** toute PR qui
@@ -457,6 +465,12 @@ les outputs.
 
 **Hook executant** : la re-execution d'un notebook .NET re-injecte le
 banner. Toujours `--apply` apres chaque re-exec .NET avant commit.
+
+> **Ordre vs parite** (#8957) : sur une PR a paire jumelle, `--apply` re-edite
+> le notebook et deplace son git blob SHA. Lance-le **avant**
+> `check_twin_parity.py --update` : la rebaseline doit se faire en dernier,
+> sur le notebook deja normalise, sinon le gate twin-parity signale une fausse
+> DRIFT (parite reelle, empreinte deplacee).
 
 ### `strip_machine_paths.py`, `scrub_papermill_paths.py`
 

--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -586,7 +586,11 @@ def main(argv=None) -> int:
                    help="Exit 1 si DRIFT/MISSING detecte (CI-ready)")
     p.add_argument("--update", action="store_true",
                    help="Rebaseline : ecrit les SHAs courants comme nouveau last_audit "
-                        "(a lancer APRES une audit firsthand d'une paire)")
+                        "(a lancer APRES une audit firsthand d'une paire). ORDRE : en "
+                        "DERNIER, apres toute normalisation outillee (strip_probe_banner / "
+                        "strip_machine_paths / scrub_papermill_paths) : ces outils re-"
+                        "edintent le notebook, donc un --update fait avant eux est invalide "
+                        "et declenche une fausse DRIFT (cf issue #8957).")
     p.add_argument("--json", action="store_true", help="Sortie machine JSON")
     p.add_argument("--coverage", action="store_true",
                    help="Recense les notebooks C# versionnes NON couverts par le "


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: MED/genai #8995

## Summary

Resolves the documentation gap behind a recurring **false-DRIFT** trap on twin-parity PRs.
The rebaseline order (`strip_probe_banner` → `check_twin_parity --update`) was written in
no document, so each worker re-discovers it via a gate red.

## The trap (issue #8957, hit firsthand by its author)

`check_twin_parity.py` attests the **git blob SHA** of each twin. Any tooled normalization
re-edits the notebook and moves that SHA. On a .NET twin PR the natural reflex fails:

```
1. re-exec local (.net-csharp)
2. check_twin_parity.py --update   <- attests the SHA NOW
3. strip_probe_banner.py --apply   <- required by secrets-hygiene rule 6, RE-EDITS the notebook
   => the step-2 attestation is stale -> gate red (false DRIFT)
```

The correct order is **1 → 3 → 2**: rebaseline **last**, after every notebook mutation. Neither
tool's README mentioned the other; the relative order existed in no document.

## The fix (issue-specified: items 1 + 2)

- **`check_twin_parity.py` `--update` help** now states the order: run it **last**, after any
  tooled normalization (`strip_probe_banner` / `strip_machine_paths` / `scrub_papermill_paths`),
  else a stale attestation triggers a false DRIFT. Catches the user at the moment they invoke
  `--update`.
- **`scripts/notebook_tools/README.md`**: a canonical-order callout in **both** sections (the
  parity section *and* the strip section), so a reader arriving via either tool sees the constraint.

Item 3 of the issue (auto-detection of false drift) is explicitly marked *"optionnel, à évaluer,
ne pas présumer"* → out of scope for this PR.

## Verification (firsthand)

- **Python syntax**: `ast.parse` OK; `--help` renders the order note under `--update`; smoke run (`--help`) exits 0.
- **Both README callouts** placed at the natural reading points (after the `--update` code block; after the strip "Hook executant" line).
- **git diff**: 2 files, +19/−1 (1 script + 1 README → not "uniquement docs", rule §E does not apply).

## Scope

One subject (document the rebaseline-vs-strip order), 2 files, +19/−1. Catalogue byte-identical to
main. Distinct from #8993/#8995 (GenAI audit, different family + genre). GenAI #8052 saturated this
window (Texte #8993 + Image #8995 delivered; Audio/Video CLEAN), so I re-picked from the global pool.

See #8957
