### PR TITLE
fix(rl,#8052): rl_7 Connect Four state space — 4^42 is wrong (3 states/cell => 3^42)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb
@@ -1023,7 +1023,7 @@
     "\n",
     "### Exercice 1 : Connect Four\n",
     "\n",
-    "PettingZoo inclut `connect_four_v3`. Adaptez le code IQL pour ce jeu. Observez comment la taille de l'espace d'etat (4^42 vs 3^9) affecte l'apprentissage.\n",
+    "PettingZoo inclut `connect_four_v3`. Adaptez le code IQL pour ce jeu. Observez comment la taille de l'espace d'etat (3^42 vs 3^9) affecte l'apprentissage.\n",
     "\n",
     "```python\n",
     "from pettingzoo.classic import connect_four_v3\n",


### PR DESCRIPTION
Grain: LIGHT/notebook-content — lane myia-po-2024:CoursIA-2 — prev: LIGHT/notebook-content (#8994 MED Search-7-MCTS Nim win/loss count swap ; distinct notebook & concept: RL exercise factual state-space error vs game-tournament interpretation)

## What

Fixes a **factual error** in `rl_7_multi_agent_rl.ipynb` §8 Exercice 1 (Connect Four), found via the #8052 audit **revue-domaine** axis (≥5%/fam bar, Reinforcement Learning family slice).

The exercise prompt claimed Connect Four's state space is **`4^42`**:

> PettingZoo inclut `connect_four_v3`. Adaptez le code IQL pour ce jeu. Observez comment la taille de l'espace d'etat **(4^42 vs 3^9)** affecte l'apprentissage.

**`4^42` is wrong.** The framing is clearly "states^cells": `3^9` = TicTacToe (9 cells × 3 states). For the parallel to hold **and** be correct, Connect Four (7×6 = **42 cells**) must be `3^42` (42 cells × **3 piece-states**: empty / player-1 / player-2). There is no 4th piece-state in Connect Four.

## Why "4^42" is wrong (verified firsthand)

`4^42 ≈ 1.93×10^25` matches **no** standard convention for Connect Four:
- **Naive upper bound** (cells × states): `3^42 ≈ 1.09×10^20`.
- **Allis (1988) legal-config count**: ≈ `4.53×10^12`.
- **Game-tree complexity**: ≈ `10^21`.

None is `4^42`. The "4" is simply an error — a student would internalize a wrong per-cell state count. Fixed to `3^42`, now consistent with the `3^9` TicTacToe baseline ("3 states^cells").

## What I did NOT change (verified clean, 1 false-positive avoided)

The fix is surgical — rl_7's **computed interpretation is all clean** and left untouched:
- **cell 15** training (X win-rate 57.1%→65.1%; draws 13.3%→20.4% rising) matches **MD18** « La proportion de matchs nuls augmente » + « X ne peut pas perdre » (correct game-theory: first player forces ≥ draw).
- **cell 20** eval (X 92.0% > O 71.0% vs random) matches **MD21** « Le joueur X (...) devrait avoir un taux de victoire plus eleve ».
- **MD29** conclusion table « RL-3 | HER, goal-conditioned RL (off-policy) » is **CORRECT** — rl_3's own title is « Notebook 3 – Hindsight Expérience Replay (HER) et Sauvegarde Avancée » (verified firsthand; the misleading filename `rl_3_experience_replay_dqn` does not change that the content IS HER). **Not flagged.**

Only the `4^42` factual error needed fixing. Same lens applied to **rl_8 (Dyna-Q), rl_9 (Offline RL), rl_11 (POMDP)** — all CLEAN firsthand (Dyna-Q 93/216=43% ✓; offline-RL « random dataset succeeds / expert fails » = correct extrapolation-error insight, 33/35=94% ✓; Tiger POMDP standard ✓).

## Fix

Markdown-only, one cell, one character (`4`→`3`):

- `(4^42 vs 3^9)` → `(3^42 vs 3^9)`

Raw-byte JSON replacement (round-trip identical, canonical form preserved). No code change, no outputs, no re-exec. Minimal diff: 1 file, +1/−1. Notebook structure intact (30 cells, 3 exercises).

## Twin

rl_7 is **not twinned** (no `twin_pairs.d/` entry; the only RL twin is `gametheory-17-multiagent-rl`, a different GameTheory notebook) → **0 drift, no rebaseline**.

## Scope

1 file content only. No source changes beyond the Exercice 1 state-space correction.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
