### PR TITLE
fix(symbolicai,#8052): Planners-12 LOOP intro -- 16 valid configs, not 6 (confused with 6 put-actions)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-12-LOOP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-12-LOOP.ipynb
@@ -2127,7 +2127,7 @@
     "\n",
     "### Exemple guide : Heuristique aprendie pour Blocks World 3-blocs\n",
     "\n",
-    "L'exemple ci-dessous montre un cycle complet d'apprentissage d'heuristique sur un mini-domaine **Blocks World** a 3 blocs (A, B, C). On genere les 6 configurations valides, on resout chaque configuration par recherche exhaustive (BFS) pour obtenir les plans optimaux, puis on entraine un petit `PlannerNetwork` a predire la bonne action depuis chaque etat. L'objectif est de verifier que le modèle aprend converge et predit correctement les actions optimales sur les etats d'entrainement."
+    "L'exemple ci-dessous montre un cycle complet d'apprentissage d'heuristique sur un mini-domaine **Blocks World** a 3 blocs (A, B, C). On genere les 16 configurations valides, on resout chaque configuration par recherche exhaustive (BFS) pour obtenir les plans optimaux, puis on entraine un petit `PlannerNetwork` a predire la bonne action depuis chaque etat. L'objectif est de verifier que le modèle aprend converge et predit correctement les actions optimales sur les etats d'entrainement."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/symbolicai -- lane myia-po-2023:CoursIA -- prev: MED/gametheory #9004

## Summary

EPIC #8052 audit extended to the **Planners** family (read-only sub-agent scan of 11 notebooks + firsthand re-verification). **10/11 CLEAN, 1 DEFECT** in **Planners-12-LOOP** — the example-guide intro names the wrong count of valid configurations (6, confused with the 6 `put X on Y` actions), contradicting its own committed output (16 states enumerated) and its own interpretation cell #52 ("16 etats", fixed by #3770). Same claims-vs-outputs class as #9003 (Sudoku Hard row), #3770 (same notebook cell #52).

## The defect

`Planners-12-LOOP.ipynb` cell #50 (example-guide intro, Blocks World) explains the learning-to-plan cycle and cites the wrong count:

```
markdown (cell #50, intro):
  "On genere les 6 configurations valides, on resout chaque configuration par BFS..."

committed output (cell #51):
  Nombre d'etats valides enumeres: 16
  Etat 0: ... Etat 15: ...   (16 states listed)

corroborating markdown (cell #52 interpretation, fixed to 16 by #3770):
  | **Enumeration** | Generation exhaustive des configurations valides (16 etats) |
```

So the notebook enumerates **16** valid states, not 6. The "6" conflates the **6 put-actions** (`ON_ACTIONS = [(x,y) for x in BLOCKS for y in BLOCKS if x!=y]` = 6) with the **16 valid states** those actions generate. The conclusion of the prose (BFS solves each config to get optimal plans) is unaffected; only the count is wrong.

## The fix (markdown-only, cell #50)

`les 6 configurations valides` -> `les 16 configurations valides`

One-token edit (6->16). Cell #52 (already "16 etats"), code cell #51 + its output (16 states), and "6 predicats" (cell #52 encoding dim 12 = 6 on + 3 ontable + 3 clear, CORRECT) are all untouched. Re-execution not required (markdown-only, rule C.3 exception; previous outputs stay valid).

**Distinct from #3770**: that PR fixed **cell #52** ("13 etats"->"16 etats"); this PR fixes **cell #50** ("6 configurations"->"16 configurations") -- a different cell, same notebook, same drift class, missed by #3770.

## Verification (firsthand -- re-verified, not from sub-agent verdict alone)

- **Defect confirmed firsthand on a fresh origin/main worktree** (HEAD `2d0858f1d`): cell #51 output = `Nombre d'etats valides enumeres: 16` + Etat 0..15; cell #50 prose = `les 6 configurations valides`; cell #52 = `16 etats` (correct). A read-only sub-agent flagged this (Planners #8052 audit, 11 notebooks); I re-verified the cells directly **and** confirmed the root cause (6 put-actions vs 16 states) before editing -- c.1003 discipline, never on a verdict alone.
- **Raw-bytes replace**: anchor `les 6 configurations valides` exactly-1 (asserted), replacement exactly-0 before (asserted), pure ASCII, no BOM, LF preserved. Byte count 164330 -> 164331 (+1, "6"->"16"). Post-edit: `les 6 configurations`=0; `16 configurations`=1; `6 predicats` untouched=1; `16 etats` untouched=1.
- **Post-edit**: JSON valid (60 cells); code cell #51 output unchanged (exec_count 11, 16 states still present); edited line reads `On genere les 16 configurations valides`.
- **H.3 validator**: 0 bad code cells (no execution_count null & no outputs).
- **git diff**: 1 file, +1/-1, the single intro-prose line only.
- **No twin-parity registry for Planners-12** (no -Csharp twin) -> no #8057 gate, no rebaseline needed.

## Honesty note (not fixed, documented)

Cell #51 code **comment** `# --- Domaine Blocks World 3-blocs : 6 etats valides ---` also carries the same wrong value (6, vs the 16 its own output prints). Left intact here: editing a code-cell comment engages rule C.2 (code-cell modification -> re-exec), and the #8052 lens targets markdown interpretation claims (cell #50). A separate code-comment pass can address it; this PR stays markdown-only per the C.3 exception.

## Scope

One subject (correct the example-guide intro config count to match the committed 16-state enumeration + cell #52), 1 file, +1/-1. Catalogue byte-identical to main. Distinct from #3770 (cell #52), #9003 (Sudoku).

(The Planners scan audited all 11 notebooks not already covered by #8987/#8988; only Planners-12 had a claims<->outputs defect. The 10 others are CLEAN -- their markdown interpretation cells faithfully match their committed plan-lengths, makespans, CP-SAT objective values, and Lean axiom lists. Non-defect items correctly excluded as FP: Planners-12 cell #16 "~"-hedged param counts; Planners-11 cell #36 Fast Downward INTERNAL_ERROR (transparent "Plan attendu" fallback, EPIC #3801 not #8052); Planners-12 LOOP-vs-FD benchmark.)

See #8052
