### PR TITLE
fix(argument-analysis,#8052): CrossLinks recap — 1081 cells, not 22

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb
@@ -1033,7 +1033,7 @@
     "tags": []
    },
    "source": [
-    "**Exercice 2 — CrossLink discovery** : sur les 22 relations crossLink non-vides, identifier les paires de sophismes les plus liées (par exemple : `Pensée binaire` ↔ `Pensée binaire` est une relation `Mirrors` circulaire). Y a-t-il un pattern ? Les crossLinks sont-ils concentrés sur certaines familles (par exemple `abusDeLangage` qui se prête à l'équivoque) ?"
+    "**Exercice 2 — CrossLink discovery** : sur les 1 081 cellules crossLink non-vides (couvrant 844 sophismes), identifier les paires de sophismes les plus liées (par exemple : `Pensée binaire` ↔ `Pensée binaire` est une relation `Mirrors` circulaire). Y a-t-il un pattern ? Les crossLinks sont-ils concentrés sur certaines familles (par exemple `abusDeLangage` qui se prête à l'équivoque) ?"
    ]
   },
   {
@@ -1159,7 +1159,7 @@
    "source": [
     "## 12. Conclusion + Ponts\n",
     "\n",
-    "**Substance PR-B** : 1 408 sophismes canoniques, 8 langues (100% coverage), 8 familles, 9 niveaux, 70 AIF mappings vers 60 schemes Walton uniques, 22 relations crossLink (sparsité 1,5% = 22/1 408 sophismes ; 0,2% si mesuré sur la matrice 8 × 1 408 = 11 264). Le CSV canonique Argumentum est la **source curée à la main** d'où l'OWL est probablement généré par script.\n",
+    "**Substance PR-B** : 1 408 sophismes canoniques, 8 langues (100% coverage), 8 familles, 9 niveaux, 70 AIF mappings vers 60 schemes Walton uniques, 1 081 cellules crossLink (couverture 59,9 % = 844/1 408 sophismes ; densité 9,6 % sur la matrice 8 × 1 408 = 11 264). Le CSV canonique Argumentum est la **source curée à la main** d'où l'OWL est probablement généré par script.\n",
     "\n",
     "**Complémentarité avec PR-A** :\n",
     "- PR-A expose la **substance OWL** (10 976 `NamedIndividual`, 4 183 `ObjectPropertyAssertion`, multilingue sparse).\n",


### PR DESCRIPTION
Grain: MED/symbolicai -- lane myia-po-2023:CoursIA -- prev: MED/planners #9005

## Summary

EPIC #8052 audit extended to the **Argument_Analysis** family (read-only sub-agent scan of 11 deterministic notebooks + firsthand re-verification). 10/11 CLEAN, 1 DEFECT in **Argument_Analysis_Ontology_CrossLinks** — the summary cells (Exercice #2 premise + Conclusion) cite the pre-#763 crossLink count (22), contradicting the notebook's own refreshed body (1081 cells / 59.9%). Same claims-vs-outputs class as #9005 (Planners-12 6 vs 16), #9004 (GT-16 partner), #8985 (Dung_AF labeling).

## The defect

`Argument_Analysis_Ontology_CrossLinks.ipynb` cells #21 + #25 carry the stale pre-#763 crossLink count, while the body (cell #11 table + cells #12/#14 outputs) was refreshed after #763 to the corrected numbers:

```
markdown cell #21 (Exercice 2 premise):
  "sur les 22 relations crossLink non-vides, identifier les paires..."

markdown cell #25 (Conclusion, Substance PR-B):
  "...70 AIF mappings vers 60 schemes Walton uniques, 22 relations crossLink
   (sparsité 1,5% = 22/1 408 sophismes ; 0,2% si mesuré sur la matrice 8 × 1 408 = 11 264)."

committed output (cell #12):
  TOTAL cellules: 1081 / 11264 = 9.60% de densité
  Couverture par sophisme: 844 / 1408 = 59.9%

committed output (cell #14):
  CrossLink cellules (CSV): 1 081  (844 sophismes = 59,9 %)

corroborating markdown (cell #11 §7 header + interpretation):
  "## 7. CrossLink coverage — 1081 cellules / 844 sophismes (59,9 %)"
  "...la version historique de ce notebook mesurait 22 relations (1,5 %) — la taxonomie
   était alors un arbre quasi-pur. La curation #141 ... a ajouté 1059 cellules, portant
   la couverture à 59,9 %."
```

So the notebook measures **1081** non-empty crossLink cells (844 sophismes, 59.9%, density 9.6%), not 22. The "22" is the pre-#763 historical count; cell #11 §7 even EXPLAINS this history ("la version historique mesurait 22"), making the conclusion's "22" a stale summary that was never synced with the refreshed body. (22 + 1059 added by #141 = 1081.)

## The fix (markdown-only, cells #21 + #25)

- Cell #21: `sur les 22 relations crossLink non-vides` -> `sur les 1 081 cellules crossLink non-vides (couvrant 844 sophismes)`
- Cell #25: `22 relations crossLink (sparsité 1,5% = 22/1 408 sophismes ; 0,2% si mesuré sur la matrice 8 × 1 408 = 11 264)` -> `1 081 cellules crossLink (couverture 59,9 % = 844/1 408 sophismes ; densité 9,6 % sur la matrice 8 × 1 408 = 11 264)`

Re-execution not required (markdown-only, rule C.3 exception; previous outputs stay valid).

## Verification (firsthand -- re-verified, not from sub-agent verdict alone)

- **Defect confirmed firsthand on a fresh origin/main worktree** (HEAD `7abb21f8d`): cell #12 output = `TOTAL cellules: 1081 / 11264 = 9.60%` + `Couverture par sophisme: 844 / 1408 = 59.9%`; cell #14 output = `CrossLink cellules (CSV): 1 081  (844 sophismes = 59,9 %)`; cells #21 + #25 prose = `22` (stale). A read-only sub-agent flagged this (Argument_Analysis #8052 audit, 11 notebooks); I re-verified the outputs directly AND confirmed the §7 history narrative (22 + 1059 = 1081) before editing -- c.1003 discipline, never on a verdict alone.
- **Raw-bytes replace (UTF-8-safe text replace)**: both anchors exactly-1 (asserted), replacements exactly-0 before (asserted). No BOM, LF preserved. Post-edit: `22 relations crossLink` = 0; `1 081 cellules crossLink non-vides` = 1; `1 081 cellules crossLink (couverture 59,9 %` = 1.
- **Post-edit**: JSON valid (26 cells); code cells #12 + #14 outputs unchanged (exec_counts intact); edited lines read `sur les 1 081 cellules crossLink non-vides` + `1 081 cellules crossLink (couverture 59,9 %...`.
- **H.3 validator**: 0 bad code cells (no execution_count null & no outputs).
- **git diff**: 1 file, +2/-2, the two summary-cell lines only.
- **No twin-parity registry for Argument_Analysis_Ontology_CrossLinks** (no twin) -> no #8057 gate, no rebaseline.

## Honesty note (not fixed, documented)

Cell #25 ALSO carries PR-A OWL numbers -- `PR-A expose la substance OWL (10 976 NamedIndividual, 4 183 ObjectPropertyAssertion, multilingue sparse)` -- which appear stale vs the §8 table (cell #13: post-#763 OWL uses `1509 owl:Class`, not `NamedIndividual`). However, **no committed output in this notebook computes the current PR-A OWL NamedIndividual count** (cell #14 lists CSV↔OWL crossLink/AIF substance but not a NamedIndividual tally). Changing `10 976 NamedIndividual` to a value I cannot verify against a computed output would be COSMETIC re-alignment (#8364 anti-complaisance: understand WHY before editing). The drift cause for the crossLink count is clear (body refreshed, summary not synced); the PR-A OWL NamedIndividual verification requires the actual OWL file substance and is left to a separate pass. This PR stays scoped to the verifiable crossLink count. The derived ratio insight ("× 7,8 = 1 NamedIndividual ≈ 7,8 labels") also depends on that unverifiable count and is left intact.

## Scope

One subject (correct the stale pre-#763 crossLink count in the Exercice #2 premise + Conclusion to match the notebook's own 1081/844/59.9% body), 1 file, +2/-2. Catalogue byte-identical to main. Distinct from #9005 (Planners-12), #9004 (GT-16), #8985 (Dung_AF).

(The Argument_Analysis scan audited 11 deterministic notebooks; only CrossLinks had a claims<->outputs defect. The 10 others are CLEAN -- the Dung_AF grounded/preferred/stable labelings, the Ontology AIF/Virtues counts (223 concepts / 446 definitions, 14 Walton schemes summing to 222), the h-Categoriser values (a=0.5, b=0.25, cycle 0.618034), the Formal Richness Matrix tallies (24 = 8x3), and the Multi-Backend Tweety verdicts all faithfully match their committed outputs. Non-defect items correctly excluded as FP: the LLM/Agentic notebooks are non-deterministic and out of scope; Dung_AF Exercise-3 was already fixed by #8985.)

See #8052
