### PR TITLE
fix(iit,#8052): IIT-2 mechanism {A,B} state — (0,0), not (0,1)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb
@@ -517,7 +517,7 @@
     "\n",
     "Les deux repertoires sont **uniformes** (`[0.5, 0.5]`) : le mécanisme {A, B} dans son etat actuel ne contraint **ni** le passe **ni** le futur du purview {A}.\n",
     "\n",
-    "- En **cause**, savoir que {A, B} = (0, 1) ne modifie pas la probabilite des etats anterieurs de A : les deux restent equiprobables.\n",
+    "- En **cause**, savoir que {A, B} = (0, 0) ne modifie pas la probabilite des etats anterieurs de A : les deux restent equiprobables.\n",
     "- En **effet**, ce même mécanisme ne biaise pas davantage l'etat futur de A.\n",
     "\n",
     "Autrement dit, ce couple (mécanisme, purview) **ne specifie aucune information** : son repertoire contraint est identique au repertoire non-perturbe (uniforme). C'est exactement ce que la section suivante va quantifier — la distance EMD entre le repertoire contraint et le repertoire non-perturbe sera **nulle**, confirmant l'absence d'information specifiee.\n",


### PR DESCRIPTION
Grain: MED/symbolicai -- lane myia-po-2023:CoursIA -- prev: MED/argument-analysis #9006

## Summary

EPIC #8052 audit extended to the **IIT/PyPhi** family (read-only sub-agent scan of 3 notebooks + firsthand re-verification). 2/3 CLEAN, 1 DEFECT in **IIT-2-AdvancedTopics** -- the §3.1 interpretation names the wrong state for mechanism {A,B}: it says (0,1) but the committed subsystem state (0,0,0) makes {A,B}=(0,0). Same deterministic identity-claim class as #9004 (GT-16 partner), #9005 (Planners-12 count), #8985 (Dung_AF labeling).

## The defect

`IIT-2-AdvancedTopics.ipynb` cell #11 ("Interpretation : un mécanisme qui ne spécifie aucune information") explains why the cause/effect repertoires for mechanism {A,B} over purview {A} are uniform, and cites the wrong state for {A,B}:

```
markdown (cell #11):
  "- En cause, savoir que {A, B} = (0, 1) ne modifie pas la probabilité
   des états antérieurs de A : les deux restent équiprobables."

committed code (cell #3):
  network = pyphi.examples.xor_network()
  state = (0, 0, 0)
  subsystem = pyphi.Subsystem(network, state)

committed output (cell #3):
  "Réseau XOR : 3 noeuds (A, B, C)"
  "Etat initial : (0, 0, 0)"

committed output (cell #10):
  "Répertoire effet pour mécanisme (0, 1) -> purview (0,):"
```

The subsystem state is (0,0,0), so node A=0 and node B=0. Mechanism {A,B} (node indices 0,1) is therefore in state **(0,0)**, not (0,1). The cell #10 output string `(0, 1)` denotes the mechanism's **node indices** {A,B} (PyPhi prints mechanisms as index tuples), NOT the state -- the markdown cell #11 misreads those indices as the mechanism's state value, yielding B=1 which contradicts the committed B=0. The conclusion (the repertoire is uniform, the mechanism specifies no information) is **correct**; only the state value cited in the supporting explanation is wrong.

## The fix (markdown-only, cell #11)

`{A, B} = (0, 1)` -> `{A, B} = (0, 0)`

One-character change (1->0). Re-execution not required (markdown-only, rule C.3 exception; previous outputs stay valid).

## Verification (firsthand -- re-verified, not from sub-agent verdict alone)

- **Defect confirmed firsthand on a fresh origin/main worktree** (HEAD `7abb21f8d`): cell #3 source `state = (0, 0, 0)` + output `Etat initial : (0, 0, 0)`; cell #10 output `mécanisme (0, 1) -> purview (0,)`; cell #11 prose `{A, B} = (0, 1)` (contradiction). A read-only sub-agent flagged this (IIT #8052 audit); I re-verified the state-vs-indices distinction directly (PyPhi mechanism tuples are node indices; the state at indices 0,1 of state (0,0,0) is (0,0)) before editing -- c.1003 discipline, never on a verdict alone.
- **Raw-bytes replace**: anchor `{A, B} = (0, 1)` exactly-1 (asserted), replacement exactly-0 before (asserted), pure ASCII, no BOM, LF preserved. Byte count unchanged (66965 -> 66965, `1` and `0` are both 1 char). Post-edit: anchor = 0; replacement = 1.
- **Post-edit**: JSON valid (40 cells); code cell #3 output unchanged (`Etat initial : (0, 0, 0)`); code cell #10 output unchanged (`mécanisme (0, 1)` -- indices, untouched); edited line reads `{A, B} = (0, 0)`.
- **H.3 validator**: 0 bad code cells (no execution_count null & no outputs).
- **git diff**: 1 file, +1/-1, the single cause-explanation line only.
- **No twin-parity registry for IIT-2** (no twin) -> no #8057 gate, no rebaseline.

## Scope

One subject (correct the mechanism {A,B} state value in the §3.1 interpretation to match the committed subsystem state), 1 file, +1/-1. Catalogue byte-identical to main. Distinct from #9004 (GT-16), #9005 (Planners-12), #9006 (CrossLinks).

(The IIT scan audited 3 notebooks; only IIT-2 had a claims<->outputs defect. IIT-1 (Phi=1.875 on the 3 XOR states, 10 causal links all alpha=1.0, forces 0.128..0.922) and IIT-3 (Phi micro=0, ecart nul, EI=1.0 copy-network reference) are CLEAN -- their interpretation cells faithfully match their committed PyPhi outputs.)

See #8052
