### PR TITLE
fix(tweety,#8052): Tweety-5 Abstract-Argumentation init restates 35 JARs, output is 42

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
@@ -226,7 +226,7 @@
     "\n",
     "La cellule précédente a configure l'infrastructure complete pour l'argumentation avec Tweety :\n",
     "\n",
-    "1. **JVM Java** : Demarree avec 35 JARs Tweety charges en memoire\n",
+    "1. **JVM Java** : Demarree avec 42 JARs Tweety charges en memoire\n",
     "2. **JDK portable** : Zulu OpenJDK 17 auto-detecte\n",
     "3. **Outils externes** (5/5) :\n",
     "   - **Clingo** : Solveur ASP (Answer Set Programming)\n",


### PR DESCRIPTION
Grain: MED/symbolicai -- lane myia-po-2023:CoursIA -- prev: MED/argument-analysis #9007

## Summary

EPIC #8052 whole-notebook sweep of the **Tweety** family (read-only sub-agent scan of 12 deterministic notebooks + firsthand re-verification). This is one of five structural/identity defects surfaced in that sweep (the same stale pre-1.30 boilerplate appears across several Tweety notebooks); this PR fixes the copy in **this notebook only** (one subject, one file, per G.4).

## The defect

The environment/init interpretation cell restates the committed JVM output with the stale JAR count:

```
markdown (init interpretation cell):
  ... "35" ... JARs ... (the exact line is the boilerplate count)

committed init output (the setup cell directly above):
  "JVM demarree avec 42 JARs."   (and Tweety-1 prints "Successfully downloaded: 39/39 JARs")
```

So the JVM loads **42** JAR modules (Tweety 1.30), not 35. The "35" is the pre-1.30 stale count; the interpretation cell directly restates the init output, so a reader following the intro reads a contradiction with the output two cells below it. The class is the same stale-boilerplate environment-count drift as #8998 (Tweety-2), #8999 (Tweety-3) — deterministic (the shipped JARs are stable), not a machine-dependent timing/tool-detection value (those `Outils: 3/5` mismatches, where the committing machine lacked CLINGO/SPASS, are correctly excluded as non-deterministic).

## The fix (markdown-only)

`35` -> `42` on the single boilerplate JAR-count line. Re-execution not required (markdown-only, rule C.3 exception; previous outputs stay valid).

## Verification (firsthand -- re-verified, not from sub-agent verdict alone)

- **Defect confirmed firsthand on a fresh origin/main worktree** (HEAD `7abb21f8d`): the setup cell output prints `JVM demarree avec 42 JARs.`; the interpretation cell restates `35`. A read-only sub-agent flagged this (Tweety #8052 whole-notebook sweep); I re-read the init output directly before editing -- c.1003 discipline, never on a verdict alone.
- **Raw-bytes replace (UTF-8-safe text replace)**: anchor exactly-1 (asserted), replacement exactly-0 before (asserted). No BOM, LF preserved. Post-edit: the stale count = 0; the corrected count = 1.
- **Post-edit**: JSON valid; code-cell outputs unchanged (the init `42 JARs` output is untouched); the edited interpretation line now restates the correct count.
- **H.3 validator**: 0 bad code cells (no execution_count null & no outputs).
- **git diff**: 1 file, +1/-1, the single boilerplate line only.
- **No twin-parity registry for this notebook** (no twin) -> no #8057 gate, no rebaseline.

## Scope

One subject (correct the stale pre-1.30 JAR count in the init interpretation cell to match the committed 42-JAR output), 1 file, +1/-1. Catalogue byte-identical to main. Distinct from #8998 (Tweety-2), #8999 (Tweety-3) -- this notebook's own copy of the same boilerplate.

(The Tweety sweep audited 12 deterministic notebooks; the logic computations were all CLEAN -- SAT models, Dung/CF2/SetAF/EAF extensions, ASPIC+/DeLP/ABA verdicts, deductive scores, ranking values, MLN exact-reasoner probabilities, Borda/Condorcet/Copeland tallies, causal observe/do/counterfactual verdicts all match their markdown. The 5 defects found were all stale environment-count boilerplate [JAR count / resource-file count], fixed one-PR-per-notebook.)

See #8052
