### PR TITLE
fix(tweety,#8052): Tweety-1 Setup recap — 22 data files, not 29

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-1-Setup.ipynb
@@ -2014,7 +2014,7 @@
     "| **JVM (JPype)** | OK | Java 17 (Zulu) avec JARs Tweety |\n",
     "| **Packages Python** | OK | jpype1, requests, tqdm, clingo, z3-solver, python-sat |\n",
     "| **JARs Tweety** | OK | Core + 39 modules + 2 dependances externes (version 1.30) |\n",
-    "| **Fichiers de données** | OK | 29 exemples (DeLP, ABA, ASPIC+, logiques) |\n",
+    "| **Fichiers de données** | OK | 22 exemples (DeLP, ABA, ASPIC+, logiques) |\n",
     "| **Clingo** | OK | Solveur ASP (Answer Set Programming) |\n",
     "| **SPASS** | OK | Prouveur logique modale |\n",
     "| **EProver** | OK | Prouveur FOL haute performance |\n",


### PR DESCRIPTION
Grain: MED/symbolicai -- lane myia-po-2023:CoursIA -- prev: MED/iit #9008

## Summary

EPIC #8052 whole-notebook sweep of the **Tweety** family (read-only sub-agent scan of 12 deterministic notebooks + firsthand re-verification). One of five defects surfaced; this PR fixes the resource-file overcount in **Tweety-1-Setup**.

## The defect

`Tweety-1-Setup.ipynb` cell #36 ("Resume" recap table) restates the resource-file count with an overcount:

```
markdown (cell #36 recap table):
  "| **Fichiers de donnees** | OK | 29 exemples (DeLP, ABA, ASPIC+, logiques) |"

committed output (cell #9 resource download):
  "Files to download: 22"
  "Successfully downloaded: 22/22 files"
  "Fichiers de donnees: 22"
```

So there are **22** resource files, not 29. The recap table overcounts the very files the cell above it enumerated and downloaded as 22. Deterministic environment count (the shipped resource set is stable), same class as the JAR-count fixes.

## The fix (markdown-only, cell #36)

`29` -> `22` on the single recap-table cell. Re-execution not required (markdown-only, rule C.3 exception; previous outputs stay valid).

## Verification (firsthand -- re-verified, not from sub-agent verdict alone)

- **Defect confirmed firsthand on a fresh origin/main worktree** (HEAD `7abb21f8d`): cell #9 output = `Files to download: 22` / `Successfully downloaded: 22/22 files` / `Fichiers de donnees: 22`; cell #36 recap = `29`. A read-only sub-agent flagged this (Tweety #8052 whole-notebook sweep); I re-read the download output directly before editing -- c.1003 discipline, never on a verdict alone.
- **Raw-bytes replace**: anchor exactly-1 (asserted), replacement exactly-0 before (asserted). No BOM, LF preserved. Post-edit: stale `29` = 0; corrected `22` = 1.
- **Post-edit**: JSON valid; code-cell outputs unchanged; edited recap line reads `22 exemples`.
- **H.3 validator**: 0 bad code cells.
- **git diff**: 1 file, +1/-1, the single recap-table line only.
- **No twin-parity registry for Tweety-1** (no twin) -> no #8057 gate, no rebaseline.

## Scope

One subject (correct the resource-file overcount in the Recap table to match the committed 22-file download output), 1 file, +1/-1. Catalogue byte-identical to main.

See #8052
