### PR TITLE
fix(socialchoice,#8052): SC-04 2-alternatives SAT/UNSAT flip + 2226 clause-count typo

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
@@ -840,7 +840,7 @@
     "\n",
     "**Observation critique** : Le nombre de profils croit comme $(m!)^n$ ou $m$ est le nombre d'alternatives et $n$ le nombre d'electeurs. Pour 4 alternatives et 3 electeurs, on atteint plus de 13,000 profils, rendant l'encodage SAT prohibitif.\n",
     "\n",
-    "Le cas 2 alternatives est particulier : l'encodage trouve UNSAT alors que le theoreme d'Arrow classique suppose $|A| \\geq 3$. Cela s'explique par la combinaison Pareto + non-dictature qui est déjà trop restrictive dans ce cadre formel, même sans IIA."
+    "Le cas 2 alternatives est particulier : l'encodage trouve **SAT** alors que le theoreme d'Arrow classique suppose $|A| \\geq 3$. Cela s'explique car avec seulement 2 alternatives, l'espace des profils est assez restreint pour qu'une fonction non dictatoriale existe (la regle majoritaire satisfait Pareto + IIA + non-dictature)."
    ]
   },
   {
@@ -2534,7 +2534,7 @@
       "Type de variables              Booleennes           Entieres            \n",
       "Encodage ordre total           Clauses CNF          Comparaisons <      \n",
       "Variables (3 alt, 2 voters)    216                  108                 \n",
-      "Contraintes (3 alt, 2 voters)  2226 clauses         ~800 assert.        \n",
+      "Contraintes (3 alt, 2 voters)  2216 clauses         ~800 assert.        \n",
       "Resultat 3 alt                 UNSAT                UNSAT               \n",
       "Lisibilite encodage            Bas niveau           Declaratif          \n",
       "Extensibilite                  Moderee              Bonne               \n",
@@ -2557,7 +2557,7 @@
     "print(f\"{'Type de variables':<30} {'Booleennes':<20} {'Entieres':<20}\")\n",
     "print(f\"{'Encodage ordre total':<30} {'Clauses CNF':<20} {'Comparaisons <':<20}\")\n",
     "print(f\"{'Variables (3 alt, 2 voters)':<30} {'216':<20} {'108':<20}\")\n",
-    "print(f\"{'Contraintes (3 alt, 2 voters)':<30} {'2226 clauses':<20} {'~800 assert.':<20}\")\n",
+    "print(f\"{'Contraintes (3 alt, 2 voters)':<30} {'2216 clauses':<20} {'~800 assert.':<20}\")\n",
     "print(f\"{'Resultat 3 alt':<30} {'UNSAT':<20} {'UNSAT':<20}\")\n",
     "print(f\"{'Lisibilite encodage':<30} {'Bas niveau':<20} {'Declaratif':<20}\")\n",
     "print(f\"{'Extensibilite':<30} {'Moderee':<20} {'Bonne':<20}\")\n",

--- a/scripts/notebook_tools/twin_pairs.d/socialchoice-4-computational-aggregation-sat-z3.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/socialchoice-4-computational-aggregation-sat-z3.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3-Csharp.ipynb
   parity_level: surface
   last_audit:
-    date: "2026-07-27"
-    by: po-2024
-    python_sha: c0d45f4de1281b82707fa32f4e0ad020c5aad0b0
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2
+    python_sha: 871a25d65e0f12c7347a3cb6322931d84ce2c6b9
     csharp_sha: 64e14757bdf161f3bf84fbe8096cf0217d58c8fd
   known_differences:
     - "AVERTISSEMENT D'INGENIERIE : parity_level=surface. Asymetrie de solveur SAT : le jumeau Python INVOQUE 3 vrais solveurs SAT industriels via PySAT (Glucose3, Minisat22, Cadical103) et les benchmark en §6 ; le C# reimplémente DPLL from-scratch (§1.1) sans NuGet de solveur SAT. Meme concept (agregation computationnelle d'Arrow/Sen), machineries SAT differentes."


### PR DESCRIPTION
fix(socialchoice,#8052): SC-04 2-alternatives SAT/UNSAT verdict flip + 2226 clause-count typo

Two markdown/literal defects in SC-04-Computational-Aggregation-SAT-Z3
contradict the notebook's own committed output (cell [19] 2-alt SAT verdict +
cell [56] benchmark + cells [10]/[24] 2216 clause count). The C# twin already
states the correct SAT verdict, so this restores parity.

## Defect 1 -- cell [18] (structural): 2-alternatives verdict flipped to UNSAT

Cell [18] (complexity interpretation) last paragraph:
  "Le cas 2 alternatives est particulier : l'encodage trouve UNSAT alors que le
  theoreme d'Arrow classique suppose |A| >= 3. Cela s'explique par la
  combinaison Pareto + non-dictature qui est deja trop restrictive dans ce cadre
  formel, meme sans IIA."

But the notebook's own computation says SAT:
  - cell [19] output: "Resultat : SAT (fonction non-dictatoriale existe!) ...
    Une fonction non-dictatoriale existe : la regle majoritaire."
  - cell [56] benchmark: "2 2 4 8 SAT 22.7" and "2 3 8 16 SAT 24.8" (2-alt = SAT
    in BOTH benchmark rows).
  - cell [20] markdown (immediately after): "Le resultat est maintenant SAT pour
    2 alternatives : une fonction de bien-etre social non dictatoriale existe,
    et la regle majoritaire en est un exemple".
  - cell [21] table: "2 | 2+ | SAT | Une SWF non dictatoriale existe".
So the whole explanatory paragraph is backwards: SAT means a non-dictatorial
function EXISTS (majority rule), so the encoding is NOT "too restrictive" --
rather, |A|<3 is below the Arrow impossibility frontier where majority rule
satisfies Pareto + IIA + non-dictature.

Fix: "trouve UNSAT" -> "trouve SAT"; rewrite the explanation to match the
notebook's own cells [19]/[20] (a non-dictatorial function exists for |A|<3).

## Defect 2 -- cell [58] (count): 2226 clause count typo

Cell [58] (SAT-vs-SMT comparison, hardcoded print literal):
  print(f"{'Contraintes (3 alt, 2 voters)':<30} {'2226 clauses':<20} ...")

But the Arrow encoding produces 2216 clauses (3 alt, 2 voters), printed 3x
elsewhere in the SAME notebook:
  - cell [10] markdown: "216 variables et 2216 clauses pour 3 alternatives et 2
    electeurs"
  - cell [24] markdown: "celui d'Arrow (2216)"
  - cell [17] output (complexity table): "3 2 36 216 2,216"
"2226" appears ONLY in cell [58] (source literal + its rendered output) -- a
digit transposition. Fix: 2226 -> 2216 (both source literal and its rendered
output, which is a deterministic print render so they must move together).

## Verification

Firsthand (#8052 claims<->outputs lens): cell [18] now matches cells [19]/[20]
and the [56] benchmark; cell [58] now matches cells [10]/[24]/[17]. Markdown +
one print-literal fix (output regenerated as the literal's deterministic render,
no computation, no kernel re-exec). Same #8052 class as GT-3 PD-diagonal (#9010),
GT-11 hybride (#9011): hand-written interpretation/typo drifted from computed
output.

## Twin rebaseline

SC-4 is a surface twin (socialchoice-4-computational-aggregation-sat-z3.yaml).
The C# twin already states the CORRECT verdict -- C# cell [17] "l'encodage
retourne SAT ... la regle majoritaire" + C# cell [18] output "Resultat : SAT"
-- and has "2216" (no "2226"). So both defects are Python-only and fixing them
RESTORES parity with the correct C# twin. Drift is paraphite-PRESERVING;
registry python_sha rebaselined (c0d45f4d -> 871a25d6); csharp_sha unchanged
(64e14757). check_twin_parity --check -> [OK] at HEAD post-commit.

See #8052 (semantic-sampling audit, GameTheory/SocialChoice slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
