### PR TITLE
fix(gametheory,#8052): GT-2 Chicken le pire misidentifies (Devier,Devier) not (Continuer,Continuer)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb
@@ -1177,7 +1177,7 @@
     "|-----|-----------------|---------|\n",
     "| Stag Hunt | `(Cerf,Cerf)` (4,4) vs `(Lièvre,Lièvre)` (3,3) | **Payoff-dominant** (4,4) vs **risk-dominant** (3,3 garanti même en cas de déviation de l'autre) |\n",
     "| Bataille des Sexes | `(Opera,Opera)` (3,2) vs `(Football,Football)` (2,3) | Les deux eq sont Pareto-comparables, mais **chaque joueur préfère un eq différent** → conflit de sélection |\n",
-    "| Poulet (Chicken) | `(Dévier,Continuer)` (-1,1) vs `(Continuer,Devier)` (1,-1) | Eq **asymétriques** : chacun veut que l'autre cède ; le pire `(Dévier,Dévier)` n'est PAS un eq → incitation à la *brinkmanship* |\n",
+    "| Poulet (Chicken) | `(Dévier,Continuer)` (-1,1) vs `(Continuer,Devier)` (1,-1) | Eq **asymétriques** : chacun veut que l'autre cède ; le pire `(Continuer,Continuer)` n'est PAS un eq → incitation à la *brinkmanship* |\n",
     "\n",
     "→ Pour ces jeux, le problème n'est plus de *trouver* un équilibre (ils existent), mais de le **choisir** : c'est le problème de la *sélection d'équilibre*, qui exigera des concepts complémentaires (focal points, évolution, communication).\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: 8322e5764ed51ce22cca66780a4bb2367032f261
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2
+    python_sha: 183d8f84edcf34e6018de795ebc2540dfa3f74d0
     csharp_sha: 4af2b2213ed29adf3390baee09d29c9d9429818d
   known_differences:
     - "Socle pedagogique commun : jeux sous forme normale (matrices de gains 2 joueurs), strategies pures, dominance, equilibres de Nash purs sur 5 jeux canoniques (Prisonnier, Stag Hunt, BoS, Poulet, Matching Pennies)."


### PR DESCRIPTION
fix(gametheory,#8052): GT-2-NormalForm Chicken "le pire" misidentifies (Devier,Devier) instead of (Continuer,Continuer)

Cell [25] (taxonomie des equilibres), Chicken row:
  "... Eq asymetriques : chacun veut que l autre cede ; le pire `(Devier,Devier)` n est PAS un eq -> brinkmanship"

But the committed Chicken matrix (cell [6] output) is:
              Devier   Continuer
  Devier  (  0,   0)  ( -1,   1)
Continuer  (  1,  -1)  (-10, -10)

(Devier,Devier)=(0,0) is the BEST symmetric outcome (mutual yield), not the
worst. The worst is (Continuer,Continuer)=(-10,-10) (mutual dare = crash), and
THAT is the outcome that is not an equilibrium (at -10,-10 either player
deviates to Devier, improving to -1), which is precisely the brinkmanship
incentive (each dares hoping the other yields). The prose attached "le pire" to
the wrong profile.

Fix: "le pire (Devier,Devier)" -> "le pire (Continuer,Continuer)".

Verified firsthand (#8052 claims<->outputs lens): matches cell [6] matrix.
Markdown-only, no re-exec. Same class as GT-3 PD-diagonal (#9010), GT-11
hybride (#9011), SC-04 SAT/UNSAT flip (#9017).

Twin: C# twin has none of this prose (0 brinkmanship/le pire/Poulet) ->
paraphite-preserving. python_sha 8322e576->183d8f84 ; csharp 4af2b221
unchanged. check_twin_parity --check -> [OK] at HEAD.

See #8052 (GameTheory slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
