### PR TITLE
fix(sl,#8052): SL-7 interpretation cell restates stale 60 epochs, code runs 150

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-NeuroSymbolic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-NeuroSymbolic.ipynb
@@ -489,7 +489,7 @@
     "  explicites, on echantillonne des paires absentes des faits positifs. C'est\n",
     "  exactement la stratégie d'entrainement des embeddings de Knowledge Graphs (SL-8).\n",
     "\n",
-    "| Avant entrainement | Après entrainement (60 epoques) |\n",
+    "| Avant entrainement | Après entrainement (150 epoques) |\n",
     "|-------------------|--------------------------------|\n",
     "| Valeurs ~0.5 (aleatoire) | Positifs ~0.9, negatifs < 0.1 |\n",
     ""


### PR DESCRIPTION
Grain: MED/symbolicai -- lane myia-po-2023:CoursIA -- prev: MED/argument-analysis #9007

## Summary

EPIC #8052 whole-notebook sweep of the **SymbolicLearning** Python family (read-only sub-agent scan of 10 notebooks + firsthand re-verification). This PR fixes the epoch-count label in **SL-7** only. (Two other notebooks surfaced in the same sweep: SL-12 stale iter-count is a sibling PR; SL-2 is a documented defer -- see the cycle [DONE] note.)

## The defect

`SL-7-NeuroSymbolic.ipynb` cell #12 ("Interpretation : Entrainement LTN") labels the post-training column of its summary table:

```
markdown (cell #12 table header):
  "| Avant entrainement | Apres entrainement (60 epoques) |"

committed training output (cell #11):
  Epoch  30 : perte = 2.3809
  Epoch  60 : perte = 1.3391
  Epoch  90 : perte = 0.9147
  Epoch 120 : perte = 0.6909
  Epoch 150 : perte = 0.5539   <- last milestone
code source (cell #11):
  for epoch in range(150):
```

The code trains **150** epochs (`range(150)`), and the milestones end at Epoch 150. The values the table cites (positifs ~0.9, negatifs <0.1) are the FINAL post-training values printed after the 150-epoch loop. So "Apres entrainement (60 epoques)" mislabels the committed run as 60 epochs. Deterministic count (epoch count fixed by `range(150)`), same class as the JAR/iter-count fixes.

## The fix (markdown-only, cell #12)

`60 epoques` -> `150 epoques` on the single table-header line. Re-execution not required (markdown-only, rule C.3 exception; previous outputs stay valid).

## Verification (firsthand -- re-verified, not from sub-agent verdict alone)

- **Defect confirmed firsthand on a fresh origin/main worktree** (HEAD `7abb21f8d`): cell #11 source = `for epoch in range(150):`; cell #11 output prints milestones through `Epoch 150 : perte = 0.5539`; cell #12 table header = `Apres entrainement (60 epoques)`. A read-only sub-agent flagged this (SymbolicLearning #8052 whole-notebook sweep); I re-read the training source + output directly before editing -- c.1003 discipline, never on a verdict alone.
- **Raw-bytes text replace (UTF-8-safe)**: anchor exactly-1 (asserted), replacement exactly-0 before (asserted). No BOM, LF preserved. Post-edit: stale `60 epoques` = 0; corrected `150 epoques` = 1.
- **Post-edit**: JSON valid; code-cell outputs unchanged (the 150-epoch milestones + post-training values untouched); edited header reads `150 epoques`.
- **H.3 validator**: 0 bad code cells.
- **git diff**: 1 file, +1/-1, the single table-header line only.
- **No twin-parity registry for SL-7** (no twin) -> no #8057 gate, no rebaseline.

## Scope

One subject (correct the epoch-count label in the LTN interpretation cell to match the committed 150-epoch run), 1 file, +1/-1. Catalogue byte-identical to main.

See #8052
