### PR TITLE
fix(sl,#8052): SL-12 narrative restates stale 600-iter run, output is 2000

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12-DifferentiableLogicGateNetworks.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12-DifferentiableLogicGateNetworks.ipynb
@@ -68,7 +68,7 @@
     "\n",
     "1. **Prerequis** : import difflogic + sanity check GPU\n",
     "2. **Modèle difflogic** : `LogicLayer` + `GroupSum`, choix device/implementation\n",
-    "3. **Entrainement MNIST 20x20** : Adam, lr=0.01, 600 itérations (run CPU-safe ; voir cellule 9 — execution partielle, N_ITERS=2000 en code mais run commit arreté a 600)\n",
+    "3. **Entrainement MNIST 20x20** : Adam, lr=0.01, 2000 itérations (run CPU-safe ; voir cellule 9 — cycle(train_loader) honore N_ITERS=2000)\n",
     "4. **Inspection** : distribution des predictions sur le test set\n",
     "5. **`CompiledLogicNet`** (RECOVERABLE-MACHINE) : export en C compile\n",
     "6. **Note historique** : EML/NAND, l'intuition que difflogic realise en mature\n",
@@ -313,7 +313,7 @@
    "source": [
     "## 2. Apprentissage sur MNIST 20x20\n",
     "\n",
-    "Le dataset **MNIST 20x20** (propose par difflogic) contient 60 000 images d'entrainement et 10 000 de test, redimensionnees a 20x20 et binarisees par seuillage a 0.5. C'est *volontairement* modeste pour rester pedague : 400 pixels par image suffisent pour la classification des 10 chiffres avec une accuracy >80% sur un modèle difflogic de 3 couches (run commit = 600 iters ; N_ITERS=2000 en code, voir cellule 9)."
+    "Le dataset **MNIST 20x20** (propose par difflogic) contient 60 000 images d'entrainement et 10 000 de test, redimensionnees a 20x20 et binarisees par seuillage a 0.5. C'est *volontairement* modeste pour rester pedague : 400 pixels par image suffisent pour la classification des 10 chiffres avec une accuracy >80% sur un modèle difflogic de 3 couches (run commit = 2000 iters, voir cellule 9)."
    ]
   },
   {
@@ -1045,7 +1045,7 @@
     "\n",
     "- **Lib SOTA** : [Felix-Petersen/difflogic](https://github.com/Felix-Petersen/difflogic) (MIT, NeurIPS 2022, arXiv 2210.08277).\n",
     "- **API cle** : `LogicLayer(in, out)`, `GroupSum(k, tau)`, `CompiledLogicNet(model)`.\n",
-    "- **MNIST 20x20** : accuracy ~0.81 (8098/10000 ; fourchette attendue 80-88%) avec GroupSum k=10 et 3 couches intermediaires (LogicLayer dim 2000). Execution commitee : DEVICE=cuda, implementation python (nvcc absent), 600 iters (1 epoque -- le dataloader s'épuise avant la cible N_ITERS=2000)\n",
+    "- **MNIST 20x20** : accuracy ~0.83 (8301/10000 ; fourchette attendue 80-88%) avec GroupSum k=10 et 3 couches intermediaires (LogicLayer dim 2000). Execution commitee : DEVICE=cuda, implementation python (nvcc absent), 2000 iters (cycle(train_loader) re-demarre le loader pour honorer N_ITERS=2000)\n",
     "- **Universalite booleenne** : 16 portes logiques, dont NAND seul est Turing-complet.\n",
     "- **Inference ultra-rapide** : 1M images/s sur 1 core CPU via `CompiledLogicNet` (RECOVERABLE-MACHINE, gcc requis).\n",
     "\n",


### PR DESCRIPTION
Grain: MED/symbolicai -- lane myia-po-2023:CoursIA -- prev: MED/argument-analysis #9007

## Summary

EPIC #8052 whole-notebook sweep of the **SymbolicLearning** Python family (read-only sub-agent scan of 10 notebooks + firsthand re-verification). This PR fixes the stale 600-iteration narrative in **SL-12**: the code was fixed with `cycle(train_loader)` and re-run to 2000, but three markdown cells still describe the old partial 600-iter run.

## The defect

`SL-12-DifferentiableLogicGateNetworks.ipynb` cells #2 (Plan), #7 (section 2), and #24 (Resume) all describe the MNIST training as a partial "600 iters" run:

```
markdown (cell #2):
  "600 iterations (run CPU-safe ; ... execution partielle, N_ITERS=2000 en code mais run commit arrete a 600)"
markdown (cell #7):
  "...(run commit = 600 iters ; N_ITERS=2000 en code, voir cellule 9)."
markdown (cell #24):
  "accuracy ~0.81 (8098/10000 ...) ... 600 iters (1 epoque -- le dataloader s'epuise avant la cible N_ITERS=2000)"

committed training output (cell #9):
  iter  600/2000 | loss 1.235 | train_acc 0.750 | elapsed 24s
  iter 1200/2000 | ...
  iter 2000/2000 | loss 1.134 | train_acc 0.780 | elapsed 58s
  Entrainement termine en 57.6s
code source (cell #9):
  from itertools import cycle
  N_ITERS = 2_000
  for it, (x, y) in enumerate(cycle(train_loader)): ... if (it+1) >= N_ITERS: break
```

The code was fixed (added `cycle(train_loader)` so the DataLoader re-loops instead of exhausting at 600) and re-run: the committed output now reaches **2000/2000**. The code source itself documents the history ("bug firsthand : la sortie commitee affichait iter 200/400/600 ... cycle() re-demarre le loader"). The three markdown cells were not updated and still describe the OLD pre-`cycle()` state. Cell #24 also pairs the stale 600-iter count with the old run's accuracy `8098/10000`; the committed 2000-iter run gives `8301/10000` (cell #10: "Accuracy test : 0.830 (8301/10000)").

Deterministic iteration COUNT (the run always reaches 2000 via `cycle()`); same class as the JAR/resource-count fixes.

## The fix (markdown-only, cells #2/#7/#24)

- Cells #2, #7, #24: `600 iters` -> `2000 iters`; remove the false "execution partielle / dataloader s'epuise" framing; note `cycle(train_loader) honore N_ITERS=2000`.
- Cell #24: align the accuracy to the committed output `0.81 (8098/10000)` -> `0.83 (8301/10000)` -- same root cause (the stale pre-cycle() narrative bundled the old run's accuracy).

Note on accuracy: the notebook trains **without a fixed seed** (no `torch.manual_seed`; `DataLoader(shuffle=True)`), so the exact accuracy is a committed-run snapshot that varies within the stated 80-88% fourchette on re-run. It is aligned to the committed output here, not enshrined as reproducible.

Re-execution not required (markdown-only, rule C.3 exception; previous outputs stay valid).

## Verification (firsthand -- re-verified, not from sub-agent verdict alone)

- **Defect confirmed firsthand on a fresh origin/main worktree** (HEAD `7abb21f8d`): cell #9 source = `for it,(x,y) in enumerate(cycle(train_loader))` + `N_ITERS = 2_000`; cell #9 output ends at `iter 2000/2000 ... Entrainement termine en 57.6s`; cells #2/#7/#24 all state "600 iters". Cell #10 output = `Accuracy test : 0.830 (8301/10000)`. A read-only sub-agent flagged this (SymbolicLearning #8052 whole-notebook sweep); I re-read the training output + source + test output directly before editing -- c.1003 discipline, never on a verdict alone.
- **No-seed claim verified firsthand** (G.1): grep across all SL-12 code cells returned 0 `seed` hits; cell #8 = `DataLoader(train_ds, batch_size=100, shuffle=True)`.
- **Raw-bytes text replace (UTF-8-safe)**: all 4 anchors exactly-1 (asserted), replacements exactly-0 before (asserted). No BOM, LF preserved. Post-edit: stale `600` in MD cells #2/#7/#24 = 0; `2000` present (2/1/3 resp.); `8098` = 0, `8301` = 1 (cell #24).
- **Post-edit**: JSON valid; code-cell outputs unchanged (the 2000/2000 training log + 8301/10000 test accuracy untouched).
- **H.3 validator**: 0 bad code cells.
- **git diff**: 1 file, +3/-3, three markdown lines only.
- **No twin-parity registry for SL-12** (no twin) -> no #8057 gate, no rebaseline.

## Scope

One subject (correct the stale 600-iteration narrative across cells #2/#7/#24 to match the committed 2000-iteration run; align cell #24 accuracy to the committed output), 1 file, +3/-3. Catalogue byte-identical to main.

See #8052
