### PR TITLE
fix(semanticweb,#8052): SW-6b-RDFS cell[34] 'seul rex ... Dog' contradicts cell[16] output (two Dogs: rex AND buddy)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb
@@ -1257,7 +1257,7 @@
     "- Chargez `data/animals.ttl` dans un graphe frais avec `g.parse(...)`.\n",
     "- Appliquez owlrl : `owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(g)`.\n",
     "- Ecrivez une requête SPARQL qui retourne **tous les animaux dont le cri contient la lettre \"o\"** (indice : `FILTER(CONTAINS(LCASE(?sound), \"o\"))`).\n",
-    "- Verifiez que le résultat inclut aussi bien `rex` (Dog) que `buddy` (Dog) et `coco` (Parrot) -- tous trois typés `Animal` par inference, même si seul `rex` est declare explicitement comme Dog dans le fichier source."
+    "- Verifiez que le résultat inclut aussi bien `rex` (Dog) que `buddy` (Dog) et `coco` (Parrot) -- tous trois typés `Animal` par inference, même si `rex` et `buddy` sont declares explicitement comme Dog dans le fichier source."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/sw-6-rdfs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-6-rdfs.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-23"
-    by: po-2024
-    python_sha: fd60c05c49ed10bc4532cc8ba89a9830673da6ff
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2
+    python_sha: 4ac2c822a4fb2729d4f5517968623a495af28480
     csharp_sha: f7a8a4f6cd60d8ce6484a1eac41072fe304e60f5
   known_differences:
     - "Socle commun : raisonnement RDFS (subClassOf, subPropertyOf, inference de hierarchies)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Ontology` OntologyGraph + `VDS.RDF.Query`). Python = `rdflib` + `owlrl` (moteur de closure RDFS/OWL-RL, derive les triplets inferes). Approche legerement differente : C# expose le modele ontologique oriente-objet ; Python deroule la closure de raisonnement explicitement."
+    - "Re-baseline 2026-07-31 (myia-po-2024:CoursIA-2, cycle c.1066) : SHA Python avance fd60c05c -> 4ac2c822 (Exercice 2 cell[34] : 'meme si seul rex est declare ... comme Dog' -> 'meme si rex et buddy sont declares ... comme Dog' ; cell[16] output liste Dog : ['buddy','rex'] + cell[17] table 'buddy (Dog)', le 'seul' etait contredit par la propre cellule). Drift verifie parite-preserving : prose markdown seule, aucune cellule de code touchee (n'affecte pas l'axe de parite semantic)."


### PR DESCRIPTION
fix(semanticweb,#8052): SW-6b-Python-RDFS cell[34] "seul rex ... Dog" contradicts own cell + cell[16] output (two Dogs: rex AND buddy)

Cell [34] (Exercice 2 indices) tells students to verify the SPARQL+RDFS
result "inclut aussi bien `rex` (Dog) que `buddy` (Dog) et `coco` (Parrot)
-- tous trois typés `Animal` par inference, même si **seul `rex` est declare
explicitement comme Dog** dans le fichier source."

The "seul rex" claim is doubly wrong:

## The defect (count/identity, contradicts own cell + computed output)

1. INTRA-CELL contradiction: the same sentence first names BOTH "rex (Dog)"
   AND "buddy (Dog)", then says "seul rex ... declare ... Dog". Both clauses
   cannot be true.
2. Cell [16] output (computed, ground truth) prints:
     "Instances par classe (avant inference) :
        Dog : ['buddy', 'rex']"
   -> TWO explicit Dogs (buddy AND rex).
3. Cell [17] table (same notebook) lists "Instances | 4 | rex (Dog), minou
   (Cat), coco (Parrot), buddy (Dog)" -- buddy is explicitly a Dog.

So "seul rex" understates the explicit declarations by one (buddy is also a
declared Dog); the computation and the cell's own first clause both show two.

## Fix

"même si seul `rex` est declare explicitement comme Dog" ->
"même si `rex` et `buddy` sont declares explicitement comme Dog"
(drop "seul", add "et `buddy`", plural agreement est->sont / declare->declares).

## Verification

Firsthand (#8052 claims<->outputs lens): cell [34] now agrees with cell [16]
(output `Dog : ['buddy','rex']`) and cell [17] (table "buddy (Dog)") and its
own first clause. Markdown-only, no code/output change, no re-exec. Same #8052
class as GT-9 player-flip (#9021), SC-04 SAT-flip (#9017): hand-written prose
drifted from the notebook's own computation.

## Twin rebaseline

SW-6 is a semantic twin (sw-6-rdfs.yaml). The C# twin SW-6-CSharp-RDFS does
NOT share this sentence (0 occurrences of "declare explicitement" in the C#
notebook -- it has its own OntologyGraph-centric presentation), so the defect
is Python-only. Drift is paraphite-PRESERVING; registry python_sha rebaselined
(fd60c05c -> 4ac2c822); csharp_sha unchanged (f7a8a4f6). check_twin_parity
--check -> [OK] at HEAD post-commit.

See #8052 (semantic-sampling audit, SemanticWeb slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
