### PR TITLE
fix(probas,#8052): Infer-101 mixture recap — strict threshold counts don't add up

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer-101.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer-101.ipynb
@@ -4463,7 +4463,7 @@
     "| Composante 1 | ~15 min | Trajet normal (circulation fluide) |\n",
     "| Composante 2 | ~27 min | Événement extraordinaire (accident, pluie...) |\n",
     "\n",
-    "Les coefficients du melange `Dirichlet(8, 4)` indiquent que **~67% des trajets** sont normaux et ~33% sont extraordinaires, ce qui correspond aux données observees (7 valeurs < 20 min, 3 valeurs >= 20 min dans les 10 observations)."
+    "Les coefficients du melange `Dirichlet(8, 4)` indiquent que **~67% des trajets** sont normaux et ~33% sont extraordinaires, ce qui correspond aux données observees (7 valeurs <= 20 min, 3 valeurs >= 25 min dans les 10 observations)."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/probas -- lane myia-po-2023:CoursIA -- prev: MED/probas #9023

## Summary

EPIC #8052 micro-lot: firsthand (no sub-agent) sweep of 3 Probas isolated notebooks (Do-Calculus-Bridge, Pyro_RSA_Hyperbole, Infer-101). Do-Calculus-Bridge and Pyro_RSA are CLEAN. This PR fixes one arithmetic defect in **Infer-101** (mixture-of-Gaussians recap), surfaced and re-verified firsthand -- not from a sub-agent verdict.

## The defect

`Infer-101.ipynb` cell #55 (interpretation of the 2-component Gaussian mixture) states the data split as:

```
markdown (cell #55):
  "Les coefficients du melange `Dirichlet(8, 4)` indiquent que **~67% des trajets** sont normaux
   et ~33% sont extraordinaires, ce qui correspond aux donnees observees (7 valeurs < 20 min,
   3 valeurs >= 20 min dans les 10 observations)."

committed training data (cell #54):
  trajets = {13, 17, 20, 25, 16, 11, 16, 25, 12.5, 30}
```

Counted **strictly**, `< 20` gives **6** values (13, 17, 16, 11, 16, 12.5 -- the value `20` is NOT `< 20`) and `>= 20` gives **4** (20, 25, 25, 30). So the stated 7/3 split is **arithmetically wrong as a strict threshold**: it sums to 10 but mis-buckets the boundary value 20.

The 7/3 split IS correct as a **model assignment** -- composante 1 (posterior mean ~15 min) attracts 7 normal trips (13,17,20,16,11,16,12.5) and composante 2 (~27 min) attracts 3 extraordinary trips (25,25,30) -- which is exactly what the posterior mix `Dirichlet(7.995, 4.005) ~= 67/33` encodes. The defect is purely the **threshold notation**: "< 20" excludes the boundary value 20 that is in fact a normal-regime trip. Deterministic arithmetic (fixed literals in source), same class as the count/identity fixes.

## The fix (markdown-only, cell #55)

`7 valeurs < 20 min, 3 valeurs >= 20 min` -> `7 valeurs <= 20 min, 3 valeurs >= 25 min`.

Both counts are now arithmetically exact: `<= 20` = **7** values (13,17,20,16,11,16,12.5) and `>= 25` = **3** (25,25,30), summing to 10. The 7:3 split still matches the `Dirichlet(8,4)` ~67/33 pedagogical point. Re-execution not required (markdown-only, rule C.3 exception; previous outputs stay valid).

## Verification (firsthand -- re-verified, NOT from a sub-agent verdict)

- **Defect confirmed firsthand on a fresh origin/main worktree** (HEAD `7abb21f8d`): cell #54 data array = `{13, 17, 20, 25, 16, 11, 16, 25, 12.5, 30}`; cell #55 states `7 valeurs < 20 min, 3 valeurs >= 20 min`. Recomputed: strict `< 20` = 6, strict `>= 20` = 4; inclusive `<= 20` = 7, `>= 25` = 3. This micro-lot was swept **without** a sub-agent (the c.1020 whole-notebook sweep had a 50% FP rate on DEFECTs -- Entry 5 -- so isolated micro-lots are re-verified cell-by-cell by hand). c.1003 discipline: never on a verdict alone.
- **Raw-bytes text replace (UTF-8-safe)**: anchor exactly-1 (asserted), replacement exactly-0 before (asserted). No BOM, LF preserved. Post-edit: stale `valeurs < 20` = 0; corrected `valeurs <= 20` = 1; `>= 25` = 1.
- **Post-edit**: JSON valid; code-cell outputs unchanged (the two posterior Gaussians + `Dirichlet(7,995 4,005)` mix untouched).
- **H.3 validator**: 0 bad code cells.
- **git diff**: 1 file, +1/-1, the single threshold line only.
- **No twin-parity registry for Infer-101** (no twin) -> no #8057 gate, no rebaseline.

## Scope

One subject (correct the strict-threshold counts in the mixture recap so they are arithmetically exact while preserving the 7:3 / Dirichlet(8,4) point), 1 file, +1/-1. Catalogue byte-identical to main.

See #8052
