### PR TITLE
fix(semanticweb,#8052): SW-4-CSharp-SPARQL cell[7]/[9] 'Interpretation' presented QueryBuilder object as literal -- .Object(string) emits a VARIABLE (the gotcha)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb
@@ -279,7 +279,7 @@
     "```sparql\n",
     "SELECT ?x\n",
     "WHERE {\n",
-    "    ?x <http://www.w3.org/2001/vcard-rdf/3.0#FN> \"John Smith\" .\n",
+    "    ?x <http://www.w3.org/2001/vcard-rdf/3.0#FN> ?John Smith .\n",
     "}\n",
     "```\n",
     "\n",
@@ -288,7 +288,9 @@
     "| Variables retournees | `.Select(new[] { \"x\" })` | `SELECT ?x` |\n",
     "| Pattern sujet | `.Subject(x)` | `?x` (variable) |\n",
     "| Pattern predicat | `.PredicateUri(uri)` | `<uri>` (URI fixe) |\n",
-    "| Pattern objet | `.Object(\"John Smith\")` | `\"John Smith\"` (litteral) |"
+    "| Pattern objet | `.Object(\"John Smith\")` | `?John Smith` (variable) |\n",
+    "\n",
+    "> **Piege QueryBuilder** : `.Object(\"John Smith\")` (string simple) est lu comme un **nom de variable** (`?John Smith`), pas comme un litteral. Pour filtrer sur la valeur litterale `\"John Smith\"`, il faut un noeud typé (ex. `NodeFactory.CreateLiteralNode(\"John Smith\")`)."
    ]
   },
   {
@@ -390,7 +392,7 @@
     "PREFIX vcard: <http://www.w3.org/2001/vcard-rdf/3.0#>\n",
     "SELECT ?givenName\n",
     "WHERE {\n",
-    "    ?y vcard:Family \"Smith\" .\n",
+    "    ?y vcard:Family ?Smith .\n",
     "    ?y vcard:Given ?givenName .\n",
     "}\n",
     "```"

--- a/scripts/notebook_tools/twin_pairs.d/sw-4-sparql.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-4-sparql.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-23"
-    by: po-2024
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2
     python_sha: ca77e6a8869febafe182e51fbb41372489fd89ae
-    csharp_sha: 2665b2384dace718433e7b6cf6ae611b4386464f
+    csharp_sha: 8423823352423ed333872a3c24dc84d946992957
   known_differences:
     - "Socle commun : execution de requetes SPARQL 1.1 (SELECT/CONSTRUCT/ASK) sur un graphe RDF."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Query` moteur Leviathan + `VDS.RDF.Query.Builder` fluent). Python = `rdflib` (`graph.query()` natif). Moteurs SPARQL equivalents, syntaxe de binding idiomatique differente."
+    - "Re-baseline 2026-07-31 (myia-po-2024:CoursIA-2, cycle c.1067) : SHA C# avance 2665b238 -> 84238233 (cell[7] + cell[9] : le code-block d'interpretation presentait l'objet comme un litteral `\"John Smith\"` / `\"Smith\"`, mais la sortie cell[6]/[8] montre que `.Object(string)` a emis une VARIABLE `?John Smith` / `?Smith` (piege QueryBuilder) ; code-block et tableau alignes sur la variable, note piege ajoutee). Drift verifie parite-preserving : prose markdown seule, aucune cellule de code touchee (n'affecte pas l'axe de parite semantic ; le twin Python n'utilise pas QueryBuilder)."


### PR DESCRIPTION
fix(semanticweb,#8052): SW-4-CSharp-SPARQL cell[7]/[9] interpretation presented QueryBuilder object as literal, but .Object(string) emits a VARIABLE (the QueryBuilder gotcha)

The "Interpretation" markdown cells after the first two QueryBuilder examples
(cell [7] for the simple SELECT, cell [9] for the PREFIX multi-pattern SELECT)
each show a SPARQL code block and, in cell [7], a component table. Both
presented the object term as a **literal** string. The committed cell outputs
show it is actually a **variable** -- exactly the dotNetRDF QueryBuilder trap
students hit.

## The defect (literal-vs-variable, contradicts the cell's own output)

cell [6] source: `... .Object("John Smith")`  ->  cell [6] OUTPUT:
  SELECT ?x WHERE
  { ?x <http://www.w3.org/2001/vcard-rdf/3.0#FN> ?John Smith . }
                                            ^^^^^^^^^^^ variable, not literal

cell [8] source: `... .Object("Smith")`      ->  cell [8] OUTPUT:
  SELECT ?givenName WHERE
  { ?y vcard:Family ?Smith .   <-- variable ?Smith, not literal "Smith"
    ?y vcard:Given ?givenName . }

But cell [7] said:
  ```sparql
  ... ?x <...#FN> "John Smith" .   <-- claims literal
  ```
  | Pattern objet | `.Object("John Smith")` | `"John Smith"` (litteral) |   <-- claims literal

And cell [9] said:
  ```sparql
  ... ?y vcard:Family "Smith" .   <-- claims literal
  ```

Root cause: dotNetRDF's `TriplePatternBuilder.Object(string)` reads a plain
`string` argument as a **variable name** (it has `.ObjectLiteral(...)` / typed
`INode` overloads for actual literals). Passing `"John Smith"` therefore emits
the variable `?John Smith`, not the literal `"John Smith"`. The interpretation
cells described the opposite of what the QueryBuilder produced.

## Fix

- cell [7] code block: `?x <...#FN> "John Smith" .` -> `?x <...#FN> ?John Smith .`
- cell [7] table row: `"John Smith"` (litteral) -> `?John Smith` (variable)
- cell [7]: added a blockquote "Piege QueryBuilder" note explaining that
  `.Object(string)` is read as a variable name and how to emit a real literal
  (`NodeFactory.CreateLiteralNode(...)`).
- cell [9] code block: `?y vcard:Family "Smith" .` -> `?y vcard:Family ?Smith .`

## Verification

Firsthand (#8052 claims<->outputs lens): the code block and table now quote
the actual emitted query (cell [6]/[8] outputs). Checked that NO later cell in
the notebook already framed `.Object(string)` as a variable trap (the notebook
presented the literal as plain fact in an "Interpretation" cell). Markdown-only,
no code/output change, no re-exec. Same #8052 class as SW-13 "reflexivite des
proprietes" (#9026), SW-6b "seul rex" (#9024): hand-written interpretation
drifted from the notebook's own computation; here it is the pedagogically
central QueryBuilder gotcha.

## Twin rebaseline

SW-4 is a semantic twin (sw-4-sparql.yaml). The Python twin SW-4b-Python-SPARQL
does NOT use QueryBuilder at all (rdflib `graph.query()` with native SPARQL
strings; 0 occurrences of "QueryBuilder"/".Object("/"John Smith"/"?Smith"),
so the defect is C#-only. Drift is paraphite-PRESERVING; registry csharp_sha
rebaselined (2665b238 -> 84238233); python_sha unchanged (ca77e6a8).
check_twin_parity --check -> [OK] at HEAD post-commit.

See #8052 (semantic-sampling audit, SemanticWeb slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
