### PR TITLE
fix(smt,#8052): Z3-09 Einstein benchmark search space is ~25 billion, not 2.5

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb
@@ -385,9 +385,9 @@
      "text": [
       "Espace de recherche brut       : (5!)^5 = 24,883,200,000 combinaisons\n",
       "Brute force estime (~1e8/s)    : 248.8 s (hors test des 15 indices)\n",
-      "Z3 solve temps                 : 11.9 ms\n",
+      "Z3 solve temps                 : 11.8 ms\n",
       "Solution unique (UNSAT si nie) : True\n",
-      " -> Z3 resout en millisecondes un espace de 2,5 milliards, et prouve l'unicite sans enumeration.\n"
+      " -> Z3 resout en millisecondes un espace de ~25 milliards, et prouve l'unicite sans enumeration.\n"
      ]
     }
    ],
@@ -436,7 +436,7 @@
     "\n",
     "print(f\"Solution unique (UNSAT si nie) : {unique}\")\n",
     "\n",
-    "print(f\" -> Z3 resout en millisecondes un espace de 2,5 milliards, et prouve l'unicite sans enumeration.\")"
+    "print(f\" -> Z3 resout en millisecondes un espace de ~{space/1e9:.0f} milliards, et prouve l'unicite sans enumeration.\")"
    ]
   },
   {
@@ -451,7 +451,7 @@
     "\n",
     "\n",
     "\n",
-    "Sur cette enigme, l'ecart est **frappant** : Z3 resout les 25 variables entrelacees en quelques millisecondes, alors que la brute force doit affronter **2,5 milliards** de combinaisons (soit plusieurs minutes même a cadence elevee, et bien plus avec le test des 15 indices a chaque candidat).\n",
+    "Sur cette enigme, l'ecart est **frappant** : Z3 resout les 25 variables entrelacees en quelques millisecondes, alors que la brute force doit affronter **~25 milliards** de combinaisons (soit plusieurs minutes même a cadence elevee, et bien plus avec le test des 15 indices a chaque candidat).\n",
     "\n",
     "\n",
     "\n",
@@ -691,7 +691,7 @@
     "\n",
     "- L'**encodage par position** (une variable entiere = position de chaque valeur) transforme un puzzle apparemment qualitatif en un système de contraintes arithmetiques : egalites (`Brit == Red`), adjacences (`|Blend - Cat| == 1`), permutations (`Distinct`).\n",
     "\n",
-    "- La **propagation de contraintes** resout les 25 variables entrelacees en millisecondes la ou la brute force affronte 2,5 milliards de combinaisons ; le solveur **prouve l'unicite** en niant le temoin et en observant `unsat`.\n",
+    "- La **propagation de contraintes** resout les 25 variables entrelacees en millisecondes la ou la brute force affronte ~25 milliards de combinaisons ; le solveur **prouve l'unicite** en niant le temoin et en observant `unsat`.\n",
     "\n",
     "- Le modèle est **paramètre par les données** : ajouter un indice, un attribut ou une maison se fait en modifiant l'instance, sans re-ecrire l'algorithme de resolution.\n",
     "\n",


### PR DESCRIPTION
Grain: MED/smt -- lane myia-po-2023:CoursIA -- prev: MED/probas #9025

## Summary

EPIC #8052 micro-lot: firsthand (no sub-agent) sweep of the unswept, collision-free SMT/Z3 family. Among Z3-01 / Z3-08 / Z3-09 (and a targeted scan of the whole `02-ML-Cours` series), one deterministic 10x factual error in **Z3-Python-09 (Énigme d'Einstein)** benchmark — fixed at the code root + re-executed.

## The defect

`Z3-Python-09-Enigme-Einstein.ipynb` cell #8 (the "Approche naive vs solveur" benchmark) computes the brute-force search space correctly but summarizes it **10x too small**:

```
code (cell #8):
  space = math.factorial(5) ** 5     # (5!)^5 = 24_883_200_000
  brute_seconds = space / 1e8        # -> 248.8 s
  ...
  print(f"Espace de recherche brut : (5!)^5 = {space:,} combinaisons")   # 24,883,200,000
  print(f"Brute force estime (~1e8/s) : {brute_seconds:.1f} s ...")       # 248.8 s
  print(f" -> Z3 resout en millisecondes un espace de 2,5 milliards, ...")  # <-- WRONG (hardcoded)
```

The hardcoded summary string says **2,5 milliards** while the value computed two lines above is **24,883,200,000 = 24,88 milliards** (off by 10x — a missing digit, 2,5 instead of ~25).

**Three independent confirmations the true value is ~25 milliards:**
1. `(5!)^5 = 120^5 = 24,883,200,000 = 24,88 milliards` — printed by the very same cell.
2. `brute_seconds = space/1e8 = 248,8 s` — only holds if space ≈ 25B (2,5B / 1e8 = 25 s, not 248,8 s).
3. Markdown cell #9 prose says the brute force takes « plusieurs minutes » — which fits 248,8 s (~4 min), not 25 s. (So the surrounding prose was already consistent with 25 milliards; only the figure was the typo.)

The wrong figure propagated to two markdown cells (#9 « Lecture du benchmark » and #17 « Conclusion »).

## The fix (code root-cause + re-exec, then align markdown — Stop & Repair)

1. **Cell #8 code**: the print line now **derives** the rounded milliards from the computed `space` (`~{space/1e9:.0f} milliards` → prints `~25 milliards`) instead of hardcoding a wrong literal — fixes the root cause (never hardcode what you can compute).
2. **Cell #8 re-executed** via papermill (python3, z3 4.15.4) so the output is honestly regenerated, not hand-edited. The deterministic outputs (`space=24,883,200,000`, `brute=248.8 s`, `unique=True`) are unchanged; the `z3_ms` timing moved 11.9 → 11.8 ms as an incidental honest re-exec side-effect.
3. **Markdown #9 + #17**: aligned `2,5 milliards` → `~25 milliards` to match the corrected output.

## Verification (firsthand — re-verified, NOT from a sub-agent verdict)

- **Defect confirmed firsthand** on a fresh origin/main worktree (HEAD `7abb21f8d`): recomputed `(5!)^5 = 24,883,200,000` and `space/1e8 = 248.8 s` before editing. This micro-lot was swept **without** a sub-agent (the c.1020 whole-notebook sweep had a 50% FP rate on DEFECTs — Entry 5 — so isolated micro-lots are re-verified cell-by-cell by hand).
- **Papermill re-exec**: 18/18 cells, exit 0; cell #8 output now reads `un espace de ~25 milliards`.
- **Surgical scope (C.3)**: `git diff` = 1 file, **+5/−5**, only cells #8 (code, re-executed) and #9/#17 (markdown) changed. Cell #1 (z3 version `4.16.0`) and all other cells kept byte-identical — only the modified cell was re-executed.
- **H.3 validator**: 0 bad code cells.
- **No twin-parity registry for Z3-09** (no twin) -> no #8057 gate, no rebaseline.

## Scope

One subject (correct the 10x-off brute-force search-space figure in the Einstein benchmark to ~25 milliards, matching the cell's own computed `(5!)^5`), 1 file, +5/−5. Catalogue byte-identical to main.

See #8052
