### PR TITLE
fix(search,#8052): App-2 GraphColoring recap says 15 departements, the graph has 18

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb
@@ -239,7 +239,7 @@
     "\n",
     "Nous utilisons un sous-ensemble de departements francais metropolitains pour illustrer le problème. Chaque departement est un sommet, et deux departements sont relies par une arete s'ils partagent une frontiere commune.\n",
     "\n",
-    "Nous construisons un graphe de **15 departements** autour de l'Ile-de-France et de ses voisins, ce qui donne un graphe planaire suffisamment riche pour etre interessant."
+    "Nous construisons un graphe de **18 departements** autour de l'Ile-de-France et de ses voisins, ce qui donne un graphe planaire suffisamment riche pour etre interessant."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/search -- lane myia-po-2023:CoursIA -- prev: MED/smt #9029

## Summary

EPIC #8052 micro-lot: firsthand (no sub-agent) sweep of the Search family. Part3-Advanced (Search-12/13/14) is CLEAN (Prong-B-aware, consistent claims↔outputs, deterministic). This PR fixes one stale-count defect in **App-2 GraphColoring** (Applications/CSP), surfaced and re-verified firsthand — not from a sub-agent verdict.

## The defect

`App-2-GraphColoring.ipynb` cell #6 (graph construction intro) states:

```
markdown (cell #6):
  "Nous construisons un graphe de **15 departements** autour de l'Ile-de-France..."
```

But the committed `DEPARTMENTS_ADJACENCY` dict (cell #7 source) defines **18** entries (Paris, Hauts-de-Seine, Seine-Saint-Denis, Val-de-Marne, Essonne, Yvelines, Val-d'Oise, Seine-et-Marne, Oise, Aisne, Loiret, Eure-et-Loir, Eure, Marne, Aube, Yonne, Somme, Nord), and the graph prints `Sommets : 18`. Cell #8 (same notebook) already correctly states "18 departements". The graph was extended 15→18 (Somme/Nord/... added) and this prose line was not updated → stale count, contradicted by both the code output and a sibling markdown cell.

Deterministic factual error (fixed source literals), same class as the Infer-8 / SL-7 count fixes.

## The fix (markdown-only, cell #6)

`**15 departements**` → `**18 departements` (1 token). Now consistent with the 18 adjacency keys, CODE #7 output, and MD #8. Re-execution not required (markdown-only, C.3 exception; previous outputs stay valid).

## Verification (firsthand — re-verified, NOT from a sub-agent verdict)

- **Defect confirmed firsthand**: counted the 18 `DEPARTMENTS_ADJACENCY` keys in cell #7 source; cross-checked CODE #7 output (`Sommets : 18`, `Aretes : 37`) and MD #8 ("18 departements"). Micro-lot swept **without** a sub-agent (c.1020 proved whole-notebook sub-agent sweeps have ~50% FP on DEFECTs → isolated micro-lots are re-verified cell-by-cell by hand).
- **Raw-bytes text replace (UTF-8-safe, ASCII literal)**: anchor `**15 departements**` exactly-1 (asserted), replaced → exactly-0 after (asserted). LF preserved, no BOM. Post-edit: `15 departements` = 0, `18 departements` present in cell #6.
- **JSON valid**; code-cell outputs unchanged (all 26 code cells untouched).
- **git diff**: 1 file, +1/−1, the single count token only.
- **Twin-parity #8057**: App-2 is a registered Python/C# semantic pair (`app-2-graphcoloring.yaml`). The department graph is a **Python-only** case study (C# twin uses Petersen/dodecahedron/Mycielski per `known_differences`), so no C# change needed. `check_twin_parity.py` after edit: **149/149 OK, DRIFT=0** (semantic parity is prose-insensitive; a single count token does not change the semantic hash). No rebaseline required.

## Scope

One subject (correct the stale 15→18 department count in the App-2 intro prose so it matches the actual 18-vertex graph), 1 file, +1/−1. Catalogue byte-identical to main.

See #8052
