### PR TITLE
fix(rl,#8052): rl_6b_actor_critic wrong gradient-clip norm (0.5 vs executed 1.0) + DQN/REINFORCE attributed to RL-5 (live in RL-6)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb
@@ -39,7 +39,7 @@
     "---\n",
     "\n",
     "**Pourquoi Actor-Critic ?**\n",
-    "Dans le notebook précédent (RL-5), nous avons vu deux paradigmes :\n",
+    "Dans le notebook précédent (RL-6), nous avons vu deux paradigmes :\n",
     "- **DQN** (value-based) : apprend $Q(s,a)$, stable mais limite aux actions discretes\n",
     "- **REINFORCE** (policy-based) : apprend directement $\\pi(a|s)$, flexible mais haute variance\n",
     "\n",
@@ -295,7 +295,7 @@
    "source": [
     "## 4. L'Actor -- Politique parametree\n",
     "\n",
-    "L'actor est un reseau de neurones qui produit une **distribution de probabilite** sur les actions $\\pi(a|s)$. Il est identique au `PolicyNetwork` de REINFORCE vu dans RL-5.\n",
+    "L'actor est un reseau de neurones qui produit une **distribution de probabilite** sur les actions $\\pi(a|s)$. Il est identique au `PolicyNetwork` de REINFORCE vu dans RL-6.\n",
     "\n",
     "La différence cle : dans REINFORCE, les gradients sont ponderes par $G_t$ (retour Monte Carlo). Dans Actor-Critic, ils seront ponderes par l'avantage $A_t = G_t - V(s_t)$."
    ]
@@ -1023,12 +1023,12 @@
     "Comparez les courbes d'apprentissage des deux algorithmes sur CartPole-v1.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : Reutilisez la classe PolicyNetwork et la boucle REINFORCE du notebook rl_5\n",
+    "- # Indice : Reutilisez la classe PolicyNetwork et la boucle REINFORCE du notebook rl_6\n",
     "- # Indice : Entrainenez les deux agents avec le même nombre d'episodes et le même random seed\n",
     "- # Indice : La perte REINFORCE est -(log_probs * returns).mean() sans avantage\n",
     "\n",
     "**Étapes** :\n",
-    "- # Étape 1 : Implementez une version simplifiee de REINFORCE (ou importez depuis rl_5)\n",
+    "- # Étape 1 : Implementez une version simplifiee de REINFORCE (ou importez depuis rl_6)\n",
     "- # Étape 2 : Lancez les deux entrainements avec les mêmes hyperparametres\n",
     "- # Étape 3 : Tracez les deux courbes sur le même graphe avec moyenne mobile"
    ]
@@ -1253,7 +1253,7 @@
     "| **Critic** | Valeur $V(s)$ qui estime la qualite des etats | Sortie : scalaire |\n",
     "| **Avantage** | Signal d'apprentissage a variance reduite | $A_t = G_t - V(s_t)$ |\n",
     "| **Entropy bonus** | Encourage l'exploration | $H(\\pi) = -\\sum_a \\pi(a|s) \\log \\pi(a|s)$ |\n",
-    "| **Gradient clipping** | Stabilise les mises a jour | `clip_grad_norm_(max_norm=0.5)` |\n",
+    "| **Gradient clipping** | Stabilise les mises a jour | `clip_grad_norm_(max_norm=1.0)` |\n",
     "\n",
     "### Comparaison des approches\n",
     "\n",


### PR DESCRIPTION
fix(rl,#8052): rl_6b_actor_critic conclusion states wrong gradient-clip norm (0.5 vs executed 1.0) + attributes DQN/REINFORCE/PolicyNetwork to RL-5 (they live in RL-6)

Two independent markdown defects, both contradicting the notebook's own code
/ prerequisites. Markdown-only, no code/output/re-exec.

## S2 — cell[29] conclusion table: wrong gradient-clip norm

- Claim (cell[29] "Resume" table): `| Gradient clipping | Stabilise les mises a jour | clip_grad_norm_(max_norm=0.5) |`
- Ground truth: cell[15] executed code `torch.nn.utils.clip_grad_norm_(... max_norm=1.0)`, and cell[16] markdown confirms "Le gradient clipping (max_norm=1.0)".
- The 0.5 in the conclusion is stale. Fix: 0.5 -> 1.0.

## S6 — cell[0]/[8]/[23]: DQN/REINFORCE/PolicyNetwork attributed to the wrong notebook (RL-5 instead of RL-6)

rl_6b's OWN prerequisites (cell[0]) correctly state:
  - [RL-5 MDP/Q-Learning tabulaire] (concepts Q-value, TD learning)
  - [RL-6 DQN et Policy Gradient] (DQN, REINFORCE)

i.e. DQN and REINFORCE are in RL-6, not RL-5. Verified firsthand: `PolicyNetwork`
and `REINFORCE` appear in rl_6_dqn_policy_gradient.ipynb and NOWHERE in
rl_5_mdp_dp_qlearning.ipynb (rl_5 is purely tabular Q-learning). But 4 prose
lines send the student to RL-5 for RL-6 material:

- cell[0]: "Dans le notebook precedent (RL-5), nous avons vu deux paradigmes : DQN... REINFORCE..." -> (RL-6)
- cell[8]: "Il est identique au PolicyNetwork de REINFORCE vu dans RL-5." -> vu dans RL-6
- cell[23]: "Reutilisez la classe PolicyNetwork et la boucle REINFORCE du notebook rl_5" -> rl_6
- cell[23]: "(ou importez depuis rl_5)" -> rl_6

The genuine RL-5 prerequisite line and nav link ("RL-5 Tabulaire" -> rl_5) are
CORRECT and left untouched.

## Verification

Firsthand (#8052 claims<->code lens): extracted the executed `clip_grad_norm_`
call (max_norm=1.0), confirmed cell[16] matches, and grepped both rl_5 and rl_6
for PolicyNetwork/REINFORCE (rl_5: 0 occurrences, rl_6: both present). The fixes
align the conclusion/prose with the notebook's own code and prerequisites.
Markdown-only, no re-exec. Same #8052 class as rl_4 UCB ranking (#8991),
rl_7 state-space (#8997): hand-written prose drifted from the executed config.

## Twin

rl_6b_actor_critic has no registered twin pair (RL family is not twinned), so
there is no yaml to rebaseline and zero drift surface. check_twin_parity --check
-> [OK] 149/149 at HEAD post-commit (no pair touched).

See #8052 (semantic-sampling audit, RL slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
