### PR TITLE
fix(rl,#8052): rl_1_intro_cartpole cell[21] eval 'sur 10 episodes' but n_eval_episodes=100 (10x off)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb
@@ -666,7 +666,7 @@
     "tags": []
    },
    "source": [
-    "Evaluation de l'agent entraine sur 10 episodes."
+    "Evaluation de l'agent entraine sur 100 episodes."
    ]
   },
   {


### PR DESCRIPTION
fix(rl,#8052): rl_1_intro_cartpole cell[21] says eval "sur 10 episodes" but evaluate_policy runs n_eval_episodes=100 (10x off)

## The defect (count, contradicts the cell's own code)

- Claim (cell[21], the entire markdown cell): "Evaluation de l'agent entraine sur 10 episodes."
- Ground truth (cell[22] executed code): `mean_reward, std_reward = evaluate_policy(model, eval_env, n_eval_episodes=100)` -> output `mean_reward:428.87 +/- 100.38`

The evaluation runs 100 episodes, not 10. The markdown understates the sample
size by 10x. Fix: "sur 100 episodes".

## Verification

Firsthand (#8052 claims<->code lens): confirmed cell[22] passes
`n_eval_episodes=100` and that "10 episodes" appears exactly once in the
notebook (the cell[21] claim) -- no second "10 episodes" elsewhere to reconcile.
Markdown-only, no code/output/re-exec. Same #8052 class as rl_6b gradient-clip
norm (#9031), rl_4 UCB ranking (#8991): hand-written prose drifted from the
executed config.

## Twin

rl_1_intro_cartpole has no registered twin pair (RL family is not twinned), so
there is no yaml to rebaseline and zero drift surface. check_twin_parity --check
-> [OK] 149/149 at HEAD post-commit (no pair touched).

See #8052 (semantic-sampling audit, RL slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
