### PR TITLE
fix(rl,#8052): rl_6d_sac_from_scratch cell[11] print hardcodes capacity=10000 but buffer is constructed capacity=100 (100x off)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb
@@ -288,7 +288,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ReplayBuffer defini : capacity=10000, state_dim=3, action_dim=1\n",
+      "ReplayBuffer defini : capacity=100, state_dim=3, action_dim=1\n",
       "Test push OK : size=1, ptr=1\n"
      ]
     }
@@ -332,7 +332,7 @@
     "# Verification\n",
     "buf = ReplayBuffer(capacity=100, state_dim=3, action_dim=1)\n",
     "buf.push(np.array([1.0, 0.0, 0.5]), np.array([0.3]), 1.0, np.array([1.1, 0.1, 0.4]), 0.0)\n",
-    "print(f\"ReplayBuffer defini : capacity=10000, state_dim={state_dim}, action_dim={action_dim}\")\n",
+    "print(f\"ReplayBuffer defini : capacity={buf.capacity}, state_dim={state_dim}, action_dim={action_dim}\")\n",
     "print(f\"Test push OK : size={buf.size}, ptr={buf.ptr}\")"
    ]
   },


### PR DESCRIPTION
fix(rl,#8052): rl_6d_sac_from_scratch cell[11] print hardcodes capacity=10000 but the ReplayBuffer is constructed with capacity=100 (100x off)

## The defect (print-hardcoded claim vs executed config)

- Ground truth (cell[11] executed code):
    buf = ReplayBuffer(capacity=100, state_dim=3, action_dim=1)
- Claim (cell[11] print statement -> committed output):
    print(f"ReplayBuffer defini : capacity=10000, state_dim={state_dim}, action_dim={action_dim}")
    -> output: "ReplayBuffer defini : capacity=10000, state_dim=3, action_dim=1"

The f-string correctly interpolates `state_dim` and `action_dim` but HARD-CODES
`capacity=10000`, whereas the buffer is constructed with `capacity=100`. The
printed capacity is 100x too large and is presented as computed output.

## Fix

Make the print read the actual object: interpolate `{buf.capacity}` instead of
the hard-coded literal, so it can never drift from the construction again:

    print(f"ReplayBuffer defini : capacity={buf.capacity}, state_dim={state_dim}, action_dim={action_dim}")
    -> output: "ReplayBuffer defini : capacity=100, state_dim=3, action_dim=1"

## Verification

Firsthand (#8052 claims<->code lens): confirmed the construction line
`ReplayBuffer(capacity=100, ...)` and that the print interpolated state_dim/
action_dim but hard-coded capacity=10000 (no buf.capacity reference). Edited
source + rendered output atomically -- byte-equivalent re-exec (the print is
deterministic: buf.capacity=100 -> "capacity=100"). No kernel needed. Same #8052
class as SC-04 print-literal 2226->2216 (#9017): pure-print-literal code cell.

## Twin

rl_6d_sac_from_scratch has no registered twin pair (RL family is not twinned),
so there is no yaml to rebaseline and zero drift surface.
check_twin_parity --check -> [OK] 149/149 at HEAD post-commit (no pair touched).

See #8052 (semantic-sampling audit, RL slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
