### PR TITLE
fix(sudoku,#8052): BDD example node counts in recap don't match count_nodes()

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Python.ipynb
@@ -404,9 +404,9 @@
     "#### Interprétation : Exemples de BDD\n",
     "\n",
     "- **Constante TRUE** : un seul nœud (la feuille `True`). Aucune variable à tester.\n",
-    "- **Variable x** : 2 nœuds (la racine `x?` + la feuille). Le chemin True mène à\n",
+    "- **Variable x** : 3 nœuds (la racine `x?` et les deux feuilles `True` et `False`). Le chemin True mène à\n",
     "  `True`, le chemin False mène à `False`.\n",
-    "- **x AND y** : 3 nœuds. On voit la *factorisation* : quand x est False, on retourne\n",
+    "- **x AND y** : 5 nœuds (comptage par référence : la feuille `False` est atteinte par deux chemins, donc comptée deux fois). On voit la *factorisation* : quand x est False, on retourne\n",
     "  directement False sans tester y (court-circuit). C'est l'avantage du BDD sur la\n",
     "  table de vérité (4 lignes) : représentation **compacte**."
    ]


### PR DESCRIPTION
Grain: MED/sudoku -- lane myia-po-2023:CoursIA -- prev: MED/search #9030

## Summary

EPIC #8052 micro-lot: firsthand (no sub-agent) sweep across 3 fresh families (GameTheory-Python, SocialChoice, SmartContracts, Sudoku-Python). This PR fixes one stale-count defect in **Sudoku-14-BDD-Python** (node counts in the BDD recap), surfaced and root-caused firsthand — not from a sub-agent verdict.

## The defect

`Sudoku-14-BDD-Python.ipynb` cell #8 ('Interprétation : Exemples de BDD') states:

```
markdown (cell #8):
  - **Variable x** : 2 nœuds (la racine `x?` + la feuille).
  - **x AND y** : 3 nœuds. On voit la *factorisation*...
```

But the committed `count_nodes()` (cell #3) measures **3** and **5** respectively, printed in CODE #7 output (`Noeuds : 3` for x, `Noeuds : 5` for x AND y).

## Root cause (firsthand, read the code)

`count_nodes()` recurses **by reference** — a shared terminal reached by two paths is counted once per occurrence:

```python
def count_nodes(self):
    if self.is_terminal: return 1
    return 1 + self.child_false.count_nodes() + self.child_true.count_nodes()
```

- `x = create('x', FALSE, TRUE)` → 1 + 1 + 1 = **3** (root + FALSE + TRUE). Prose said 2 ('la racine + la feuille' — drops that x points to TWO distinct leaves FALSE and TRUE).
- `x AND y = create('x', FALSE, bdd_y)` where `bdd_y = create('y', FALSE, TRUE)` → 1 + 1 + (1+1+1) = **5** (FALSE reached twice: directly under x? and under y?). Prose said 3.

The prose had been written with a naive node count and never resynchronised with the actual reference-counting method. The notebook is already aware of this counting semantics elsewhere — MD #18 states for the MDD line: *« le compte somme les références partagées ; le DAG unique est plus petit »*.

## The fix (markdown-only, cell #8)

Align the recap on the measured counts (3, 5) and add a short reference-counting caveat for x AND y (FALSE counted twice), making the prose consistent with the caveat already present at MD #18. No re-execution (C.3 exception, markdown-only; previous outputs stay valid — the code and its outputs were already correct, only the interpretation prose drifted).

## Verification (firsthand — re-verified, NOT from a sub-agent verdict)

- **Defect confirmed firsthand**: read `count_nodes()` source (cell #3), recomputed x=3 and x AND y=5 by hand, cross-checked against committed CODE #7 outputs before editing. Micro-lot swept **without** a sub-agent (c.1020 proved whole-notebook sub-agent sweeps have ~50% FP on DEFECTs → isolated micro-lots are re-verified cell-by-cell by hand).
- **Raw-bytes UTF-8 text replace**: both anchors exactly-1 before (asserted), exactly-0 after (asserted). LF preserved, no BOM.
- **git diff**: 1 file, +2/−2, only the two prose lines changed.
- **H.3 validator**: 0 errors.
- **No twin registry** for Sudoku-14-BDD → no #8057 gate, no rebaseline.

## Scope

One subject (correct the stale BDD node counts in the recap so they match `count_nodes()`'s reference-counting output, with an honest caveat), 1 file, +2/−2. Catalogue byte-identical to main.

See #8052
