### PR TITLE
fix(ml,#8052): 02-ML-Cours series-end mislabel (2.6 is not the last notebook; 2.7/2.8/2.9 follow)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
@@ -1027,7 +1027,7 @@
     "\n",
     "Nous avons formalisé le **compromis biais-variance** entrevu empiriquement en 2.1 et 2.4, puis outillé son évaluation : la **validation croisée k-fold** pour une estimation fiable (moyenne ± écart-type plutôt qu'un seul découpage bruité), et la **courbe ROC** avec l'**AUC** pour juger un classifieur au-delà de l'accuracy et choisir un **seuil de décision** adapté au coût des erreurs.\n",
     "\n",
-    "Le dernier notebook de la série (`2.6-Clustering-KMeans-PCA`) quitte l'apprentissage supervisé pour l'apprentissage **non supervisé** : clustering (**KMeans**) et réduction de dimension (**PCA**), sans étiquettes."
+    "Le notebook suivant (`2.6-Clustering-KMeans-PCA`) quitte l'apprentissage supervisé pour l'apprentissage **non supervisé** : clustering (**KMeans**) et réduction de dimension (**PCA**), sans étiquettes."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.6-Clustering-KMeans-PCA.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.6-Clustering-KMeans-PCA.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "Tous les notebooks précédents (2.1 à 2.5) relevaient de l'apprentissage **supervisé** : on disposait d'étiquettes `y` à prédire. Ce dernier notebook de la série aborde l'apprentissage **non supervisé** : **aucune étiquette** n'est fournie à l'algorithme. Nous étudions deux techniques canoniques : le **clustering** (regrouper les observations similaires, ici avec KMeans) et la **réduction de dimension** (projeter des données à forte dimension dans un espace plus petit tout en préservant l'information, ici l'Analyse en Composantes Principales — ACP / PCA).\n",
+    "Tous les notebooks précédents (2.1 à 2.5) relevaient de l'apprentissage **supervisé** : on disposait d'étiquettes `y` à prédire. Ce notebook aborde l'apprentissage **non supervisé** : **aucune étiquette** n'est fournie à l'algorithme. Nous étudions deux techniques canoniques : le **clustering** (regrouper les observations similaires, ici avec KMeans) et la **réduction de dimension** (projeter des données à forte dimension dans un espace plus petit tout en préservant l'information, ici l'Analyse en Composantes Principales — ACP / PCA).\n",
     "\n",
     "Nous travaillons sur les chiffres manuscrits de `load_digits` : 64 pixels par image (une image 8×8 aplanie en un vecteur de dimension 64) et 10 classes de chiffres (0 à 9). Les algorithmes ne verront **jamais** les étiquettes — nous les utiliserons uniquement pour **vérifier** que la structure non supervisée retrouve les classes connues.\n",
     "\n",
@@ -773,7 +773,7 @@
    "source": [
     "## Conclusion : fin du socle ML\n",
     "\n",
-    "Vous avez parcouru toute la série `02-ML-Cours` : (2.1) le workflow ML, (2.2) la descente de gradient, (2.3) la régression linéaire et logistique, (2.4) les arbres / forêts / ensembles, (2.5) le compromis biais-variance / validation croisée / courbes ROC, et enfin (2.6) le clustering et la PCA. Un étudiant ayant travaillé les six notebooks dispose désormais du **socle ML canonique** qui manquait entre NumPy/Pandas et les ateliers agents. Ceci conclut la série `02-ML-Cours`."
+    "Vous avez parcouru les six premiers notebooks de la série `02-ML-Cours` : (2.1) le workflow ML, (2.2) la descente de gradient, (2.3) la régression linéaire et logistique, (2.4) les arbres / forêts / ensembles, (2.5) le compromis biais-variance / validation croisée / courbes ROC, et (2.6) le clustering et la PCA. Un étudiant ayant travaillé ces six notebooks dispose du **socle ML canonique** qui manquait entre NumPy/Pandas et les ateliers agents. La série se poursuit avec [2.7](2.7-Modeles-Non-Parametriques.ipynb) (modèles non paramétriques), [2.8](2.8-Theorie-PAC.ipynb) (théorie PAC) et [2.9](2.9-Grokking-Generalisation.ipynb) (grokking).\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.7-Modeles-Non-Parametriques.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.7-Modeles-Non-Parametriques.ipynb
@@ -943,7 +943,7 @@
     "\n",
     "> **Référence.** Vapnik, V. (1998), *Statistical Learning Theory*, Wiley. Cadre théorique des SVM : minimisation structurelle du risque, marge et bornes de généralisation.\n",
     "\n",
-    "Avec ce notebook, la série `02-ML-Cours` couvre désormais l'essentiel des grandes familles : modèles **linéaires** (2.3), **arbres et ensembles** (2.4), **modèles non paramétriques à noyaux et par distance** (2.7), sans oublier l'évaluation rigoureuse (2.5) et le non supervisé (2.6). La suite logique est l'utilisation de ce socle comme **référent jugeable** des labs agentic (`Track1-LangChain`, `Track2-GoogleADK`)."
+    "Avec ce notebook, la série `02-ML-Cours` couvre désormais l'essentiel des grandes familles : modèles **linéaires** (2.3), **arbres et ensembles** (2.4), **modèles non paramétriques à noyaux et par distance** (2.7), sans oublier l'évaluation rigoureuse (2.5) et le non supervisé (2.6). Deux notebooks théoriques prolongent ensuite la série : [2.8](2.8-Theorie-PAC.ipynb) (théorie PAC, dimension VC) et [2.9](2.9-Grokking-Generalisation.ipynb) (grokking). La suite logique est ensuite l'utilisation de ce socle comme **référent jugeable** des labs agentic (`Track1-LangChain`, `Track2-GoogleADK`)."
    ]
   },
   {


### PR DESCRIPTION
fix(ml,#8052): 02-ML-Cours series-end mislabel -- 2.6 is not the last notebook; 2.7/2.8/2.9 follow

The `02-ML-Cours` series (DataScienceWithAgents) was extended from 6 to 9 notebooks
(2.7 Modeles-Non-Parametriques, 2.8 Theorie-PAC, 2.9 Grokking-Generalisation were
appended), but the series-finale/inventory prose in 2.5/2.6/2.7 still claims 2.6
concludes the series. Four markdown cells send the student past the end of the series.

## The defects (structural/count, verified vs the directory inventory + nav chain)

The directory holds NINE notebooks; each of 2.6/2.7/2.8/2.9 cell[0] carries a
back-link to its predecessor, and 2.9 cell[0] itself says "les **huit chapitres
précédents**" (8 preceding = 2.1..2.8). Yet:

- **2.6 cell[0]**: "Ce **dernier** notebook **de la série** aborde l'apprentissage
  non supervisé" -- but 2.7/2.8/2.9 follow. Fix: "Ce notebook aborde ...".
- **2.6 cell[21]** (Conclusion): "Vous avez parcouru **toute la série** ... les
  **six notebooks** ... **Ceci conclut la série** `02-ML-Cours`." -- the series has
  9 notebooks and 2.6 does not conclude it. Fix: "les **six premiers** notebooks ...
  dispose du **socle ML canonique** ... **La série se poursuit avec** [2.7] [2.8] [2.9]".
- **2.5 cell[22]**: "Le **dernier notebook de la série** (`2.6-Clustering-KMeans-PCA`)
  quitte l'apprentissage supervisé ..." Fix: "Le notebook **suivant**".
- **2.7 cell[21]** (Synthese): the series inventory lists 2.3/2.4/2.7/2.5/2.6 then
  jumps straight to the agentic labs as the next step, omitting 2.8 (PAC/VC theory)
  and 2.9 (grokking). Fix: insert "Deux notebooks théoriques prolongent ensuite la
  série : [2.8] (theorie PAC, dimension VC) et [2.9] (grokking)" before the agentic-labs
  transition.

The genuine cross-references that ARE correct are left untouched (e.g. 2.6 cell[0]
"Notebooks precedents (2.1 a 2.5)", the back-link to 2.5, the MacQueen reference).

## Verification

Firsthand (#8052 structural/count lens): confirmed all four claims verbatim, then
confirmed the forward chain by reading each of 2.6/2.7/2.8/2.9 cell[0] (each
back-links its predecessor) and 2.9 cell[0] "huit chapitres precedents". Canonical
JSON round-trip byte-identical pre/post for all three files; diff exactly 4/4
(one source element per cell). Markdown-only, no code/output/re-exec. Same #8052
class as rl_11 cross-ref mislabel (#9034), SW-1 navigation numbering (#9028):
hand-written series/inventory prose drifted from the family inventory.

## Twin

The DataScienceWithAgents/02-ML-Cours series has no registered twin pair (the
ml-1..ml-9 yaml twins cover the separate ML/ML.Net series, not these notebooks),
so there is no yaml to rebaseline and zero drift surface.
check_twin_parity --check -> [OK] 149/149 at HEAD post-commit (no pair touched).

See #8052 (semantic-sampling audit, ML-Cours slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
