### PR TITLE
fix(ml,#8052): 2.8-Theorie-PAC interpretation (au plus tard + train plateau)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8-Theorie-PAC.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8-Theorie-PAC.ipynb
@@ -298,7 +298,7 @@
     "4. On trace `P_succès` vs `m`, avec la ligne horizontale `1 - δ` et la ligne verticale au `m_min` théorique.\n",
     "5. On superpose **aussi** la prédiction théorique : la borne de Valiant équivaut à `P_succès ≥ 1 - |H|·(1-ε)^m`. Ce minorant doit rester **sous** la courbe empirique — c'est elle qui « prédit » le comportement.\n",
     "\n",
-    "**Prédiction de la théorie** : la courbe empirique doit franchir `1 - δ` **au plus tôt** au `m_min` prédit (la borne est *suffisante*) ; le minorant théorique, lui, franchit `1 - δ` exactement en `m_min`. Si la courbe empirique reste au-dessus du minorant en tout point, la borne est validée.\n"
+    "**Prédiction de la théorie** : la courbe empirique doit franchir `1 - δ` **au plus tard** au `m_min` prédit (la borne est *suffisante*, donc conservatrice) ; le minorant théorique, lui, franchit `1 - δ` exactement en `m_min`. Si la courbe empirique reste au-dessus du minorant en tout point, la borne est validée.\n"
    ]
   },
   {
@@ -635,7 +635,7 @@
    "source": [
     "### Interprétation : la richesse se paie en exemples\n",
     "\n",
-    "**Constat** : à mesure que le degré augmente, l'accuracy d'entraînement grimpe sans ambiguïté (0,775 → 0,825 → 0,925) — une classe plus riche épouse toujours mieux les données vues. Mais l'écart `train - test` ne se contente pas de « s'élargir » : il **change de signe**. Négatif aux bas degrés (le test *dépasse* le train — un artefact du petit `m = 40`), il devient positif et croît aux hauts degrés (le train mémorise, le test lâche). C'est la signature empirique de la dimension VC :\n",
+    "**Constat** : à mesure que le degré augmente, l'accuracy d'entraînement grimpe (0,775 → 0,825 → 0,925) puis plafonne au degré 7 (0,925, inchangé) — une classe plus riche épouse toujours au moins aussi bien les données vues. Mais l'écart `train - test` ne se contente pas de « s'élargir » : il **change de signe**. Négatif aux bas degrés (le test *dépasse* le train — un artefact du petit `m = 40`), il devient positif et croît aux hauts degrés (le train mémorise, le test lâche). C'est la signature empirique de la dimension VC :\n",
     "\n",
     "| Degré | train | test | écart (train - test) | Lecture |\n",
     "|-------|-------|------|----------------------|---------|\n",


### PR DESCRIPTION
fix(ml,#8052): 2.8-Theorie-PAC interpretation -- "au plus tot" is the wrong direction for a sufficient bound, and train accuracy plateaus (not "grimpe sans ambiguite")

Two independent markdown interpretation defects in 2.8-Theorie-PAC, both contradicting
the notebook's OWN committed output/code. Markdown-only, no code/output/re-exec.

## D9 -- cell[6] "Prediction de la theorie": "au plus tot" should be "au plus tard"

- Claim (cell[6]): "la courbe empirique doit franchir `1 - delta` **au plus tot** au
  `m_min` prédit (la borne est *suffisante*)".
- Ground truth:
  - cell[7] committed output: "Borne PAC : m_min = 70" and "Premier m ou P_succes
    empirique >= 0.95 : 15" -- the empirical curve crosses 1-delta at m=15.
  - cell[9] states the correct reading: "La courbe bleue (empirique) franchit
    `1 - delta = 0.95` vers `m ~ 15-20` -- **avant** le `m_min = 70` prédit."
- Why contradiction: a *sufficient* (conservative) bound guarantees success by m_min,
  so the true empirical crossing m* satisfies m* <= m_min -- i.e. the curve crosses
  1-delta **no later than** m_min ("au plus tard"), not "at the earliest" ("au plus tot").
  The empirical m*=15 << 70 confirms this. "au plus tot" is the wrong direction; it also
  contradicts cell[9]'s explicit "avant le m_min".
- Fix: "au plus tot" -> "au plus tard ... (la borne est suffisante, donc conservatrice)".

## D10 -- cell[14] "Constat": train accuracy plateaus, does not "grimpe sans ambiguite"

- Claim (cell[14]): "l'accuracy d'entraînement grimpe sans ambiguïté (0,775 -> 0,825 -> 0,925)".
- Ground truth (cell[13] committed output):
    degre 1 : train = 0.775 | test = 0.831
    degre 3 : train = 0.825 | test = 0.872
    degre 5 : train = 0.925 | test = 0.914
    degre 7 : train = 0.925 | test = 0.897
- Why contradiction: train accuracy is FLAT from degree 5 to degree 7 (0.925 -> 0.925),
  so it does not "grimpe sans ambiguite"; the quoted chain (0,775 -> 0,825 -> 0,925)
  silently drops the degree-7 value. (The same cell's table correctly reports degree 7
  train = 0,925, making this an internal inconsistency.) "une classe plus riche épouse
  toujours mieux" is also softened to "au moins aussi bien" since deg7 does not improve.
- Fix: "grimpe (0,775 -> 0,825 -> 0,925) puis plafonne au degré 7 (0,925, inchangé)".

## Verification

Firsthand (#8052 claims<->computed lens): extracted cell[7] output (m_min=70, empirical
cross m=15), cell[9]'s "avant le m_min", and cell[13]'s 4-row train/test output. Confirmed
both defects are the notebook's own interpretation drifting from its own computation.
Canonical JSON round-trip byte-identical pre/post; diff exactly 2/2. Markdown-only.
Same #8052 class as rl_6b gradient-clip 0.5-vs-1.0 (#9031), 2.9 Fourier-peak (#9037-companion):
hand-written interpretation drifted from the executed/computed result.

## Twin

The DataScienceWithAgents/02-ML-Cours series has no registered twin pair (the ml-1..ml-9
yaml twins cover the separate ML/ML.Net series), so there is no yaml to rebaseline and
zero drift surface. check_twin_parity --check -> [OK] 149/149 at HEAD post-commit.

See #8052 (semantic-sampling audit, ML-Cours slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
