### PR TITLE
fix(ml,#8052): 2.9-Grokking exercise hint (pic unique vs 4 comparable Fourier peaks)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.9-Grokking-Generalisation.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.9-Grokking-Generalisation.ipynb
@@ -643,7 +643,7 @@
    "source": [
     "### Exercice 3 — Quantifier l'horloge\n",
     "\n",
-    "L'horloge se lit à l'œil ; mesurez-la. Après le grok, calculez pour chaque nombre `n` son **angle** `θ_n` sur le cercle ACP (`atan2(y_n, x_n)`), puis vérifiez que `θ_n` est (à une rotation près) une fonction **affine** de `(k*·n) mod P` — et *non* de la valeur brute `n`. *Indice* : `np.fft.fft` sur les embeddings (variable `spectre` déjà calculée) révèle la ou les fréquences dominantes ; un pic unique = une horloge propre.\n"
+    "L'horloge se lit à l'œil ; mesurez-la. Après le grok, calculez pour chaque nombre `n` son **angle** `θ_n` sur le cercle ACP (`atan2(y_n, x_n)`), puis vérifiez que `θ_n` est (à une rotation près) une fonction **affine** de `(k*·n) mod P` — et *non* de la valeur brute `n`. *Indice* : `np.fft.fft` sur les embeddings (variable `spectre` déjà calculée) révèle la ou les fréquences dominantes ; ici, un petit nombre de pics de poids comparable (cf. la liste imprimée plus haut) organise une horloge quasi propre.\n"
    ]
   },
   {
@@ -682,7 +682,7 @@
     "# Etape 1 : calculer l'angle theta_n = atan2(y_n, x_n) sur l'anneau ACP (coords)\n",
     "# Etape 2 : tracer theta_n contre n (disperse) puis contre (k*.n mod P) (aligne)\n",
     "# Indice : np.fft.fft sur les embeddings (deja calcule : variable 'spectre')\n",
-    "#   revele la ou les frequences dominantes. Un pic unique = une horloge propre.\n",
+    "#   revele la ou les frequences dominantes. Ici un petit nombre de pics de poids comparable.\n",
     "angles = None  # TODO etudiant : remplacer par np.arctan2(coords[:, 1], coords[:, 0])\n",
     "print(\"Exercice 3 a completer\")"
    ]


### PR DESCRIPTION
fix(ml,#8052): 2.9-Grokking exercise hint says "un pic unique" but the notebook's own Fourier spectrum shows 4 comparable peaks

Intra-notebook self-contradiction in 2.9-Grokking-Generalisation. The Exercise 3 hint
(cell[18]) and the matching code comment (cell[19]) tell the student that "un pic unique
= une horloge propre" (a single dominant Fourier peak = a clean clock), but the notebook's
own committed spectrum shows FOUR peaks of comparable weight.

## The defect (structural/identity, contradicts the cell's own output)

- Ground truth (cell[10] committed output):
    Frequence dominante k* = 33 (part de variance 25%)
    Frequences principales (k : part de variance) :
      [(33, '25%'), (41, '24%'), (30, '20%'), (6, '19%')]
  -- four near-equal peaks (25/24/20/19 %).
- cell[11] states the correct reading: the embeddings are organised by "un petit nombre
  de fréquences de Fourier ... la liste imprimée montre qu'elles sont quelques-unes,
  de poids comparables".
- But cell[18] (Exercise 3 hint): "*Indice* : np.fft.fft sur les embeddings ... révèle
  la ou les fréquences dominantes ; un pic unique = une horloge propre."
  and cell[19] code comment: "#   revele la ou les frequences dominantes. Un pic unique =
  une horloge propre."
- Why contradiction: the spectrum has 4 comparable peaks, not a single one. The exercise
  hint contradicts both cell[10]'s output and cell[11]'s own (correct) interpretation.
  (The hint's "la ou les" already hedges singular/plural, then immediately asserts the
  single-peak ideal that does not hold here.)

## Fix

Align the hint with the actual spectrum (and cell[11]):
- cell[18]: "un pic unique = une horloge propre" -> "ici, un petit nombre de pics de
  poids comparable (cf. la liste imprimée plus haut) organise une horloge quasi propre".
- cell[19] code comment: "Un pic unique = une horloge propre." -> "Ici un petit nombre
  de pics de poids comparable." (this is a `#` comment, not executed -> no output change,
  no re-exec).

## Verification

Firsthand (#8052 structural/identity lens): extracted cell[10]'s 4-peak output and
cell[11]'s "quelques-unes, de poids comparables", confirmed the hint says "un pic unique"
in both cell[18] and cell[19]. Canonical JSON round-trip byte-identical pre/post; diff
exactly 2/2. Markdown + non-executed comment only, no re-exec. Same #8052 class as
rl_11 PPO/notebook-8 self-contradiction (#9034): the notebook contradicts itself.

## Twin

The DataScienceWithAgents/02-ML-Cours series has no registered twin pair (the ml-1..ml-9
yaml twins cover the separate ML/ML.Net series), so there is no yaml to rebaseline and
zero drift surface. check_twin_parity --check -> [OK] 149/149 at HEAD post-commit.

See #8052 (semantic-sampling audit, ML-Cours slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
