### PR TITLE
fix(ml,#8052): ML-6-ONNX-Python narrative falsely claims .NET twin consumes this notebook's .onnx (loads separate canonical iris_model.onnx)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX-Python.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "**Navigation** : [Index](README.md) | [<< ML-5-TimeSeries](ML-5-TimeSeries-Python.ipynb) | [Jumeau .NET (ML.NET)](ML-6-ONNX.ipynb) | [Suivant >> ML-7-Recommendation](ML-7-Recommendation-Python.ipynb)\n",
     "\n",
-    "> Ce notebook est le **jumeau Python** de [ML-6-ONNX.ipynb](ML-6-ONNX.ipynb) (ML.NET `OnnxTransformer`). Il couvre l'autre bout du pont d'interopérabilité : **produire** un modèle ONNX en Python (entraînement scikit-learn → export `skl2onnx`) puis le **consommer** en Python via `onnxruntime`. Le jumeau .NET, lui, charge le fichier `.onnx` que nous générons ici — c'est le workflow canonical Python → ONNX → .NET.\n",
+    "> Ce notebook est le **jumeau Python** de [ML-6-ONNX.ipynb](ML-6-ONNX.ipynb) (ML.NET `OnnxTransformer`). Il couvre l'autre bout du pont d'interopérabilité : **produire** un modèle ONNX en Python (entraînement scikit-learn → export `skl2onnx`) puis le **consommer** en Python via `onnxruntime`. Le jumeau .NET, lui, charge un modèle ONNX dérivé du même RandomForest Iris, mais sérialisé à part dans `iris_model.onnx` (produit par `scripts/ml/generate_iris_onnx.py`) ; ce notebook exporte le sien sous `iris_model_python.onnx` pour ne pas l'écraser.\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -43,7 +43,7 @@
     "4. Exécuter l'inférence avec `onnxruntime`\n",
     "5. Vérifier que sklearn et onnxruntime donnent **exactement** les mêmes prédictions\n",
     "\n",
-    "C'est précisément le `.onnx` produit à l'étape 2 que le jumeau .NET (ML-6-ONNX.ipynb) recharge côté ML.NET.\n"
+    "Le jumeau .NET (ML-6-ONNX.ipynb) recharge, lui, un modèle ONNX équivalent (même RandomForest Iris) produit séparément par `scripts/ml/generate_iris_onnx.py` dans le fichier `iris_model.onnx` — distinct de l'export `iris_model_python.onnx` réalisé à l'étape 2.\n"
    ]
   },
   {
@@ -700,7 +700,7 @@
     "| Équivalence sklearn ⇄ ONNX | Prédictions identiques, écarts de proba `< 1e-6` (float32 vs float64) |\n",
     "| `GraphOptimizationLevel` | Optimisations de graph (fusion d'opérateurs) → speedup en production |\n",
     "\n",
-    "**Ce qu'il faut retenir** : ONNX est le **pont** entre l'entraînement (Python/scikit-learn) et la production (.NET/ML.NET, C++, edge). On entraîne où c'est expressif (Python), on déploie où c'est rapide et portable (ONNX Runtime). Le jumeau .NET [ML-6-ONNX.ipynb](ML-6-ONNX.ipynb) consomme le **même** fichier `iris_model.onnx` que celui produit dans la Partie 2."
+    "**Ce qu'il faut retenir** : ONNX est le **pont** entre l'entraînement (Python/scikit-learn) et la production (.NET/ML.NET, C++, edge). On entraîne où c'est expressif (Python), on déploie où c'est rapide et portable (ONNX Runtime). Le jumeau .NET [ML-6-ONNX.ipynb](ML-6-ONNX.ipynb) consomme un modèle ONNX équivalent (même RandomForest Iris), mais dans un fichier distinct — `iris_model.onnx` produit par `scripts/ml/generate_iris_onnx.py`, indépendamment de l'export `iris_model_python.onnx` réalisé dans la Partie 2."
    ]
   },
   {
@@ -713,7 +713,7 @@
     "- **ONNX** — specification et opérateurs : https://onnx.ai/\n",
     "- **skl2onnx** — export scikit-learn vers ONNX : https://onnx.ai/sklearn-onnx/\n",
     "- **ONNX Runtime** — runtime d'inférence optimisé : https://onnxruntime.ai/\n",
-    "- **ML-6-ONNX.ipynb** (jumeau .NET) — consommation du même `.onnx` côté ML.NET\n",
+    "- **ML-6-ONNX.ipynb** (jumeau .NET) — consommation d'un modèle ONNX équivalent (`iris_model.onnx`) côté ML.NET\n",
     "- Série *Hands-On AI Trading*, Jared Broad — chapitre interopérabilité modèles ML\n"
    ]
   }

--- a/scripts/notebook_tools/twin_pairs.d/ml-6-onnx-integration.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-6-onnx-integration.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: bf5811ada77206db3e65d62f60696662b1e8cd56
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2
+    python_sha: 40517222f60d7acaacb6beeefdc225798309315e
     csharp_sha: cdfe398768e01d553c71bc82ee82227e708a3472
+    reason: "rebaseline python apres fix prose .onnx (cellules 0/1/26/27, #8052) : la prose disait faussement que le jumeau .NET charge 'le meme fichier iris_model.onnx produit ici' ; en realite le C# charge iris_model.onnx canonique (scripts/ml/generate_iris_onnx.py) et ce notebook exporte iris_model_python.onnx (distinct, pour ne pas l'ecraser). Aligne la prose sur le code (cell 7) et les known_differences ci-dessous. Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:
     - "Socle pedagogique commun : integration de modeles ONNX (chargement, inference, inspection du graph, exercices). C# = ML.NET OnnxTransformer + OnnxRuntime ; Python = skl2onnx (export sklearn->ONNX) + onnxruntime (inference) + onnx (inspection structurelle). Cree comme twin de parite explicite en #5607 (EPIC #4956 .NET<->Python)."
     - "Asymetrie export-vs-load (pont Python->.NET) : le C# charge un modele ONNX pre-exporte (iris_model.onnx genere par scripts/ml/generate_iris_onnx.py, RandomForest sklearn) car l'export ML.NET->ONNX est experimental (documente en commentaire, c13/c15) ; le Python effectue l'export sklearn->ONNX lui-meme via skl2onnx (opset 15, zipmap=False). Le twin Python est le cote 'producteur' du pont ONNX, le C# le cote 'consommateur'."


### PR DESCRIPTION
fix(ml,#8052): ML-6-ONNX-Python narrative falsely claims the .NET twin consumes this notebook's .onnx output -- it loads a separate canonical iris_model.onnx

The notebook's central narrative -- "le workflow canonical Python -> ONNX -> .NET"
where the .NET twin consumes "le meme fichier" produced here -- is false and
contradicts the notebook's OWN executed code. Four markdown cells (intro + intro
section + conclusion + references) make the claim; the export cell + the C# twin
deny it.

## The defect (claim-vs-own-code, structural)

- Ground truth (cell[7] executed code + comment):
    onnx_path = "iris_model_python.onnx"
    # Nom distinct du .onnx canonique (produit par scripts/ml/generate_iris_onnx.py,
    # consommé par le jumeau .NET ML-6-ONNX.ipynb) — on evite de l'ecraser.
  i.e. this notebook writes a DISTINCT file `iris_model_python.onnx`. The canonical
  `iris_model.onnx` is produced by `scripts/ml/generate_iris_onnx.py` and consumed by
  the .NET twin. Confirmed firsthand: generate_iris_onnx.py writes
  `MyIA.AI.Notebooks/ML/ML.Net/iris_model.onnx`; the C# twin ML-6-ONNX.ipynb loads
  "iris_model.onnx produit par scripts/ml/generate_iris_onnx.py" (cells 3 + 7).
  The registry yaml's own known_differences documents this asymmetry correctly.

- But the prose asserts the opposite in 4 places:
  - cell[0]: "Le jumeau .NET, lui, charge le fichier `.onnx` que nous générons ici
    — c'est le workflow canonical Python → ONNX → .NET."
  - cell[1]: "C'est précisément le `.onnx` produit à l'étape 2 que le jumeau .NET
    (ML-6-ONNX.ipynb) recharge côté ML.NET."
  - cell[26]: "Le jumeau .NET [ML-6-ONNX.ipynb] consomme le **même** fichier
    `iris_model.onnx` que celui produit dans la Partie 2." (also wrong filename:
    this notebook produces `iris_model_python.onnx`, not `iris_model.onnx`.)
  - cell[27]: "ML-6-ONNX.ipynb (jumeau .NET) — consommation du même `.onnx` côté ML.NET"

- Why contradiction: the .NET twin loads a SEPARATE canonical `iris_model.onnx`
  (from generate_iris_onnx.py); this notebook produces `iris_model_python.onnx`
  (deliberately distinct, to avoid clobbering the canonical one). Both are derived
  from the same Iris RandomForest (conceptually equivalent models), but they are
  different files. The "le même fichier / canonical Python→ONNX→.NET" narrative is
  the notebook's thesis and it is backwards.

## Fix

Rewrite the 4 false claims to state the truth (the .NET twin consumes an equivalent
model in a separate canonical file `iris_model.onnx` from generate_iris_onnx.py;
this notebook exports its own `iris_model_python.onnx`). Genuine true statements
left untouched (e.g. cell[8] "on peut le copier... et le charger en ML.NET" is a
general possibility; cell[16] "consommable identiquement cote .NET" is a general
ONNX-format statement).

## Verification

Firsthand (#8052 claims<->executed-code lens): read cell[7] code + comment,
confirmed generate_iris_onnx.py on origin/main writes iris_model.onnx, confirmed
the C# twin (cells 3+7) loads that canonical file, confirmed the registry yaml
known_differences documents the asymmetry. Canonical JSON round-trip byte-identical
pre/post; diff 4/4 (4 source elements, one per cell). Markdown-only, no re-exec.
Same #8052 class as rl_6d print-literal-vs-construction (#9033): prose drifted from
the notebook's own executed code.

## Twin rebaseline

ML-6 is a semantic twin (ml-6-onnx-integration.yaml). The fix is Python-only (the
C# twin is already correct, so this RESTORES prose alignment with the C# twin's own
behavior and the yaml's known_differences). Drift is paraphite-preserving; registry
python_sha rebaselined (bf5811ad -> 40517222), csharp_sha unchanged (cdfe398768).
check_twin_parity --check -> [OK] at HEAD post-commit.

See #8052 (semantic-sampling audit, ML.Net Python slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
