### PR TITLE
fix(ml,#8052): ML-5-TimeSeries-Python intro horizon (7 jours vs 366 days actual forecast)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries-Python.ipynb
@@ -39,7 +39,7 @@
     "| **Saisonnalité** (seasonality) | Motif périodique (hebdo, mensuel, annuel) | ACF, décomposition STL |\n",
     "| **Bruit** (residual) | Variations aléatoires non prévisibles | ce qui reste après décomposition |\n",
     "\n",
-    "L'horizon de prévision est le nombre de pas de temps à prédire (ici : 7 jours = 1 semaine).\n",
+    "L'horizon de prévision est le nombre de pas de temps à prédire (ici : 366 jours, toute l'année 2024 — cf. Partie 4).\n",
     "\n",
     "## Deux familles d'approches\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/ml-5-timeseries.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-5-timeseries.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
   parity_level: surface
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: 1e5dfe1cf4d57382161653bcbd8bf705e5a3ce09
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2
+    python_sha: 349824e5b0b13acdee29273dfac9e58656459e50
     csharp_sha: 581fcb6c880b55928062698a37560736ff250681
+    reason: "rebaseline python apres fix intro horizon (cellule 1, #8052) : la prose disait 'horizon = 7 jours (1 semaine)' mais le SARIMA prevoit 366 jours (2024 entiere, cellules 13/14/16). 7 = periode saisonniere hebdo, pas l'horizon. Python-only, csharp_sha unchanged, parite (surface) preservee."
   known_differences:
     - "FAMILLES ALGORITHMIQUES DIFFERENTES (pas un simple idiome swap) : C# = `Microsoft.ML.Transforms.TimeSeries` -> `ForecastBySsa` (Singular Spectrum Analysis, decomposition spectrale ML.NET-native). Python = `statsmodels` -> `STL` (seasonal-trend LOESS decomposition) + `SARIMAX` (seasonal ARIMA classique)."
     - "Aucune lib Python n'expose SSA de facon pedagogique equivalente ; le pendant Python choisit donc l'approche statistique classique (STL+SARIMAX) pour couvrir le meme besoin (forecast saisonnier) avec un OUTIL different."


### PR DESCRIPTION
fix(ml,#8052): ML-5-TimeSeries-Python intro says forecast horizon is "7 jours (1 semaine)" but the notebook forecasts 366 days (all of 2024)

Intra-notebook self-contradiction in ML-5-TimeSeries-Python. The introduction defines
the forecast horizon as 7 days, but the notebook's own SARIMA forecast runs over 366
days and three later cells state 366.

## The defect (structural/count, intra-notebook self-contradiction)

- Claim (cell[1], introduction):
    "L'horizon de prévision est le nombre de pas de temps à prédire (ici : 7 jours
    = 1 semaine)."
- Ground truth:
  - cell[13]: "On prévoit les ventes de **2024** (366 jours) à partir du modèle SARIMA"
  - cell[14] code: `horizon = len(test)` ; committed output:
    "Prévision 2024 : 175.2 (jour 1) -> 230.6 (jour 366)"
  - cell[16] output: "=== Évaluation sur 2024 (366 jours) ==="
- Why contradiction: the actual forecast horizon is 366 days (all of 2024), not 7
  days. The "7" in the notebook is the weekly seasonality period s=7 (cell[13]
  "s = 7 (hebdomadaire)") and the first-week preview (cell[14] prints "Première
  semaine 2024 prévue"), NOT the forecast horizon. "(ici : 7 jours)" is wrong.
- Fix: "(ici : 366 jours, toute l'année 2024 — cf. Partie 4)".

## Verification

Firsthand (#8052 structural lens): extracted cell[1] horizon sentence, cell[13]
"366 jours", cell[14] code `horizon = len(test)` + output "jour 366", cell[16]
"366 jours". Confirmed the self-contradiction. Canonical JSON round-trip byte-
identical pre/post; diff 1/1. Markdown-only, no re-exec. Same #8052 class as
rl_1 "10 episodes" vs n_eval=100 (#9032): a count in the intro drifted from the
executed config.

## Twin rebaseline

ML-5 is a twin (ml-5-timeseries.yaml, parity_level surface). The fix is Python-only;
drift is paraphite-preserving; registry python_sha rebaselined (1e5dfe1c -> 349824e5),
csharp_sha unchanged (581fcb6c88). check_twin_parity --check -> [OK] at HEAD post-commit.

See #8052 (semantic-sampling audit, ML.Net Python slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
