### PR TITLE
fix(ml,#8052): ML-3-Entrainement-Python Exemple 2/AutoML prose says quadratique but executed code is sinus + 3 DecisionTree (not 2 GradientBoosting)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement-Python.ipynb
@@ -183,7 +183,7 @@
    "source": [
     "## Exemple 2 : Régression non-linéaire — compromis biais-variance\n",
     "\n",
-    "On bascule sur des données **quadratiques** : $y = 100 x^2 + \\text{bruit}$. On compare deux `GradientBoosting` : l'un avec peu de feuilles (sous-ajustement / underfitting), l'autre avec beaucoup de feuilles (risque de sur-ajustement / overfitting). Cela illustre le **compromis biais-variance** et l'équivalent du paramètre `numberOfLeaves` de LightGbm.\n"
+    "On bascule sur des données **sinusoïdales** : $y = 10 \\sin(x) + \\text{bruit}$. On compare trois `DecisionTreeRegressor` de profondeur croissante : peu profond (sous-ajustement / underfitting), compromis, très profond (risque de sur-ajustement / overfitting). Cela illustre le **compromis biais-variance** et l'équivalent du paramètre `numberOfLeaves` / `max_depth` de LightGbm.\n"
    ]
   },
   {
@@ -218,7 +218,7 @@
    "source": [
     "np.random.seed(0)\n",
     "# Données SINUS bruitées avec PEU de points : setup canonique d'overfitting.\n",
-    "# Avec peu d'échantillons + bruit, un arbre profond épouse le bruit -> le RMSE test explose.\n",
+    "# Avec peu d'échantillons + bruit, un arbre très profond (1 feuille/point) mémorise le bruit : train -> 0 et un grand écart train/test (variance élevée).\n",
     "n_pts = 60\n",
     "x_nl = np.linspace(0, 4 * np.pi, n_pts)\n",
     "y_nl = 10 * np.sin(x_nl) + np.random.normal(0, 2.0, size=n_pts)\n",
@@ -326,7 +326,7 @@
    "source": [
     "### Interprétation\n",
     "\n",
-    "Sur données quadratiques, la `LinearRegression` échoue (elle ne modélise que des droites) — son RMSE CV est énorme. Les modèles non-linéaires (`GradientBoosting`, `RandomForest`, `SVR` RBF) s'en sortent bien mieux. **C'est tout l'intérêt d'AutoML** : on ne parie pas sur un algorithme, on laisse la validation croisée désigner le meilleur pour ce dataset.\n"
+    "Sur données sinusoïdales, la `LinearRegression` échoue (elle ne modélise que des droites) — son RMSE CV est énorme (7.01, contre 3.06 pour RandomForest). Les modèles non-linéaires (`GradientBoosting`, `RandomForest`, `SVR` RBF) s'en sortent bien mieux. **C'est tout l'intérêt d'AutoML** : on ne parie pas sur un algorithme, on laisse la validation croisée désigner le meilleur pour ce dataset.\n"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: c85af15091facac0eb75d8b3e0f76e1a30ed4824
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2
+    python_sha: 3c86b640ab9512ee3e6c66679c12fac732c2ccb8
     csharp_sha: 23a665e9c31aa87889cbaf4630e4d87b3c32e8c2
+    reason: "rebaseline python apres fix prose Exemple 2/AutoML (cellules 7/8/11, #8052) : la prose disait 'donnees quadratiques y=100x^2' et 'compare deux GradientBoosting' mais le code cellule 8 genere des SINUS (y=10sin(x)) et compare trois DecisionTreeRegressor (underfit/good/overfit) ; l'AutoML cellule 10 tourne sur ces memes donnees sinus (LinearRegression RMSE CV=7.01, RandomForest=3.06). Le comment cellule 8 'le RMSE test explose' contredisait l'output (overfit test=2.78, le plus bas). Fix aligne prose sur le code execute. Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:
     - "Socle pedagogique commun : comparaison de trainers de regression (lineaire vs boosting) + evaluation RMSE train/test."
     - "Zoos de modeles distincts : C# = `Regression.Trainers.Sdca` (Stochastic Dual Coord Ascent) + `LightGbm` (binding ML.NET LightGBM natif). Python = `LinearRegression` + `GradientBoostingRegressor, RandomForestRegressor, DecisionTreeRegressor, SVR` (ensemble sklearn)."


### PR DESCRIPTION
## Defect (structural / claim-vs-own-code, intra-notebook self-contradiction)

`ML-3-Entrainement-Python.ipynb` Exemple 2 + AutoML: the prose describes a **quadratic** dataset and **two `GradientBoosting`** models, but the notebook's own executed code generates a **sinus** dataset and compares **three `DecisionTreeRegressor`** models. The AutoML cross-validation runs on that same sinus data.

## Evidence (firsthand, #8052 claims↔executed-code lens)

| Cell | Claim (prose/comment) | Ground truth (executed code + committed output) |
|------|----------------------|--------------------------------------------------|
| `[7]` Exemple 2 intro | "données **quadratiques** : `y = 100 x² + bruit`" / "compare **deux `GradientBoosting`** (peu / beaucoup de feuilles)" | `[8]` code: `y_nl = 10*np.sin(x_nl)` → **sinus**; `DecisionTreeRegressor(max_depth=2/4/None)` → **three DecisionTrees** |
| `[8]` header comment | "un arbre profond épouse le bruit → le RMSE test **explose**" | `[8]` output: overfit test RMSE = **2.78** (the **lowest** of the three; underfit 5.45, good 3.29). The executed print in the same cell already says it correctly: *"train=0 ... grand gap train/test → variance élevée"* |
| `[11]` AutoML interp | "Sur données **quadratiques**, la `LinearRegression` échoue ... RMSE CV énorme" | `[10]` AutoML `cross_val_score` runs on `X_tr/y_tr` = the **sinus** data; LinearRegression RMSE CV = **7.01**, RandomForest = **3.06** |

The sinus is smooth and densely sampled (60 pts over `[0, 4π]`), so a 1-leaf/point tree interpolates well — overfitting manifests as `train→0` + a large train/test gap, **not** a test-RMSE blow-up. The header comment's "explosion" is contradicted by the committed output.

## Fix (markdown/comment-only, byte-identical output, no re-exec)

- **`[7]`**: "quadratiques `y = 100 x²`" → "sinusoïdales `y = 10 sin(x)`"; "deux `GradientBoosting` (peu/beaucoup de feuilles)" → "trois `DecisionTreeRegressor` de profondeur croissante" (matches the executed code; keeps the `numberOfLeaves`/`max_depth` equivalence).
- **`[8]` comment**: "le RMSE test explose" → "train → 0 et un grand écart train/test (variance élevée)" (faithful to output; the executed print already states this).
- **`[11]`**: "Sur données quadratiques ... RMSE CV énorme" → "Sur données sinusoïdales ... RMSE CV énorme (7.01, contre 3.06 pour RandomForest)" (anchors to `[10]` output).

Left untouched: cell `[16]`/`[17]` Exercice 3 (already correctly sinusoidal), the algorithm-mapping table `[18]`, and general `GradientBoosting` mentions.

## Verification

Canonical JSON round-trip byte-identical pre/post; diff **3/3** source elements (one per cell). Comment is non-executed → no output change, no re-execution. Same #8052 class as ML-5 (#9040) and rl_6d print-literal (#9033): prose drifted from the notebook's own executed code.

## Twin rebaseline

`ml-3-entrainement-automl.yaml` (parity_level **semantic**). Python-only — the C# twin's AutoML genuinely uses quadratic data (`y = 100·x²`, C# cell[13]); that's a documented dataset difference acceptable at semantic parity, independent of this Python-side prose-vs-own-code fix. Registry `python_sha` rebaselined (`c85af150` → `3c86b640`), `csharp_sha` unchanged (`23a665e9`). `check_twin_parity --check` → **OK 149/149** at HEAD post-commit.

See #8052 (semantic-sampling audit, ML.Net Python slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
