### PR TITLE
fix(ml,#8052): ML-9-Anomaly-Python says anomalies 'faciles a detecter' + FPR<=5% 'rater la plupart' -- but AUC=0.87/DR@10FP=0.60 and sweep TPR=0.60@FPR=0.04 contradict both

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection-Python.ipynb
@@ -502,7 +502,7 @@
    "source": [
     "### Interprétation : un compromis détection / fausse alarme\n",
     "\n",
-    "Le sweep dessine la courbe ROC de façon lisible : à seuil bas on rattrape presque toutes les anomalies mais au prix de nombreuses fausses alarmes ; à seuil haut on devient précis mais on rate la plupart des anomalies. Un point de fonctionnement raisonnable détecte la grande majorité des anomalies pour une fraction de fausses alarmes acceptable. Si le métier exige `FPR <= 5 %`, il faut monter le seuil — mais on accepte alors de rater la plupart des anomalies. Ce compromis n'a pas de réponse universelle : il dépend du **coût relatif** d'une casse ratée (très élevé en maintenance prédictive) face au coût d'une intervention inutile. L'[Exercice 2](#exercice-2-seuil-cout) formalise cet accord sur une contrainte `TPR >= 0,95`."
+    "Le sweep dessine la courbe ROC de façon lisible : à seuil bas on rattrape presque toutes les anomalies mais au prix de nombreuses fausses alarmes ; à seuil haut on devient précis mais on rate la plupart des anomalies. Un point de fonctionnement raisonnable détecte la grande majorité des anomalies pour une fraction de fausses alarmes acceptable. Si le métier exige `FPR <= 5 %`, il faut monter le seuil — on y détecte encore environ 60 % des anomalies (seuil ≈ 0,04, précision 0,83), un compromis serré mais pas un ratage majoritaire. Ce compromis n'a pas de réponse universelle : il dépend du **coût relatif** d'une casse ratée (très élevé en maintenance prédictive) face au coût d'une intervention inutile. L'[Exercice 2](#exercice-2-seuil-cout) formalise cet accord sur une contrainte `TPR >= 0,95`."
    ]
   },
   {
@@ -615,7 +615,7 @@
    "source": [
     "## Exercice 3 : Anomalies subtiles (limite de l'approche PCA)\n",
     "\n",
-    "Les anomalies actuelles sont décalées de ~3 écarts-types : faciles à détecter. Que se passe-t-il avec des anomalies **subtiles** (~1.5 sigma), qui se rapprochent du régime normal ?\n",
+    "Les anomalies actuelles sont décalées de ~2 à 3 écarts-types par capteur : détectables (AUC ≈ 0,87) mais non-triviales — on n'en rattrape que 60 % pour un budget de 10 fausses alarmes (cellule 13). Que se passe-t-il avec des anomalies **subtiles** (~1.5 sigma), qui se rapprochent du régime normal ?\n",
     "\n",
     "**Objectifs** :\n",
     "1. Régénérer `X_test_anom` avec un décalage réduit (ex. Température ~ N(2, 2), Pression ~ N(0.10, 0.1), Vibration ~ N(1.0, 0.8))\n",

--- a/scripts/notebook_tools/twin_pairs.d/ml-9-anomaly-detection.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-9-anomaly-detection.yaml
@@ -4,11 +4,11 @@
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: 6b572381934b41f131a0e134913e6b109c9d2ec2
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2
+    python_sha: b58ed094f029113ec2976957d45593f5a52465a6
     csharp_sha: bf2ddbc3863d9cecf4045ddb73e80399149a2584
-    reason: "rebaseline apres add metadata.cost (#8445) aux DEUX jumeaux (vrais CPU-only identiques) ; parite semantique preservee (metadata-only, 0 code churn)"
+    reason: "rebaseline python apres fix prose difficulte detection (cellules 20 et 25, #8052) : (1) cellule 25 disait anomalies '~3 ecarts-types : faciles a detecter' mais le code cellule 6 genere ~2-3 sigma et l'AUC=0.87 / DR@10FP=0.60 (cellule 13) montrant une detection non-triviale (cellule 5 dit explicitement 'non-triviale') ; (2) cellule 20 disait qu'a FPR<=5% 'on raterait la plupart' mais le sweep cellule 19 donne TPR=0.60 a FPR=0.04 (60% detectees, contredisait aussi la phrase precedente de la meme cellule). Fix aligne prose sur les outputs executes. Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:
     - "metadata.cost ajoute symetriquement aux deux jumeaux (#8445, po-2023) : valeurs identiques (api_usd_est=0.0, gpu_required=false, vram_tier=NONE, free_alternative=self) — addition metadata-only, n'affecte pas la parite comportementale."
     - "Socle pedagogique commun : detection d'anomalies par PCA (Analyse en Composantes Principales) sur donnees capteurs."


### PR DESCRIPTION
## Defects (structural / claim-vs-own-code, #8052)

Two markdown cells in `ML-9-Anomaly-Detection-Python.ipynb` contradict the notebook's own committed outputs.

### 1. cell[25] (Exercice 3 intro) — task-difficulty inversion

| | |
|---|---|
| **Claim** | "Les anomalies actuelles sont décalées de ~3 écarts-types : **faciles à détecter**." |
| **Ground truth** | `[6]` code generates ~2–3σ shifts (Temp 2.5σ, Press 2.0σ, Vib 3.1σ — not ~3σ). `[5]` states design intent: "anomalies volontairement **modérées** (~2 à 3 écarts-types) afin que la détection reste **non-triviale**". `[13]` output: **AUC 0.8683, DR@10FP 0.6000** (not "easy"). `[14]`: "Ce n'est pas 1.0 car le chevauchement subsiste." |

"faciles à détecter" inverts the notebook's own non-trivial framing and undercuts Exercice 3's pedagogical point (contrast current moderate anomalies AUC~0.87 vs subtle ~1.5σ AUC→0.5).

**Fix**: "~2 à 3 écarts-types par capteur : détectables (AUC ≈ 0,87) mais non-triviales — on n'en rattrape que 60 % pour un budget de 10 fausses alarmes (cellule 13)."

### 2. cell[20] (ROC sweep interp) — detected↔missed transposition

| | |
|---|---|
| **Claim** | "Si le métier exige `FPR <= 5 %`, il faut monter le seuil — mais on accepte alors de **rater la plupart** des anomalies." |
| **Ground truth** | `[19]` committed sweep: threshold 0.04 → **FPR 0.04, TPR 0.60, precision 0.83**. At FPR ≤ 5% you **detect 60%** (miss 40%), not "la plupart". This 0.60 is precisely the DR@10FP=0.60 already printed in `[13]`. |

The claim also negates the sentence immediately preceding it in the same cell ("Un point de fonctionnement raisonnable détecte la **grande majorité** des anomalies..."). Classic complementary-count transposition (detected↔missed).

**Fix**: "on y détecte encore environ 60 % des anomalies (seuil ≈ 0,04, précision 0,83), un compromis serré mais pas un ratage majoritaire."

## Verification

Firsthand (#8052 claims↔executed-code lens): read `[5]`/`[6]`/`[13]`/`[14]`/`[19]`/`[20]`/`[25]` source + committed outputs, confirmed sigma shifts, AUC 0.8683 / DR@10FP 0.60, sweep TPR 0.60 @ FPR 0.04. Canonical JSON round-trip byte-identical pre/post; diff **2/2** markdown elements. Markdown-only, no re-exec. Same #8052 class as ML-3 (#9041) and the c.1068 rl_1 count defects.

## Twin rebaseline

`ml-9-anomaly-detection.yaml` (parity_level **semantic**). Python-only — the C# twin is unaffected. Registry `python_sha` rebaselined (`6b572381` → `b58ed094`), `csharp_sha` unchanged (`bf2ddbc3`). `check_twin_parity --check` → **OK 149/149** at HEAD post-commit.

See #8052 (semantic-sampling audit, ML.Net Python slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
