### PR TITLE
fix(ml,#8052): ML-7-Recommendation-Python claims rating matrix is 'clairsemee' (sparse) but own output shows 23/25 (92% filled) -- 3 of 5 users rated every film

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation-Python.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "Ce notebook se concentre sur le **filtrage collaboratif par factorisation de matrice**, l'approche canonique (Koren, Bell & Volinsky, 2009 — prix Netflix).\n",
     "\n",
-    "Le cas d'usage : une plateforme de films dispose des notes (1 à 5) attribuées par des utilisateurs à des films. La matrice est **clairsemée** (chaque utilisateur ne note que quelques films). On veut **prédire** les notes manquantes pour recommander les films que l'utilisateur noterait haut."
+    "Le cas d'usage : une plateforme de films dispose des notes (1 à 5) attribuées par des utilisateurs à des films. Dans les **vrais** systèmes, la matrice utilisateur-item est **clairsemée** (chaque utilisateur ne note qu'une petite fraction des films). Notre exemple jouet ci-dessous est volontairement **presque complet** (23 notes sur 25, 92 % — cf. cellule 4) pour rester lisible ; il contient malgré tout deux notes manquantes à prédire. On veut **prédire** les notes manquantes pour recommander les films que l'utilisateur noterait haut."
    ]
   },
   {
@@ -568,7 +568,7 @@
     "| Concept | Description |\n",
     "|---------|-------------|\n",
     "| Système de recommandation | Suggère des items pertinents (CF, content-based, hybride) |\n",
-    "| Matrice utilisateur-item | Notes $R$ ($U \\times I$), creuse (cellules manquantes = non vues) |\n",
+    "| Matrice utilisateur-item | Notes $R$ ($U \\times I$) ; creuse dans les vrais systèmes (notre jouet est presque complet : 23/25) |\n",
     "| `sklearn.decomposition.NMF` | Factorisation non-négative : $R \\approx W \\cdot H$ (facteurs latents) |\n",
     "| Facteurs latents | Axes de goût appris automatiquement (interprétables en NMF) |\n",
     "| Top-N | Films non vus classés par note prédite décroissante |\n",

--- a/scripts/notebook_tools/twin_pairs.d/ml-7-recommendation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-7-recommendation.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: cbaec2f4986df15a3463b4ab4b88bcb5aa3e9204
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2
+    python_sha: a3279c176b3266566d06cd2eebb8274aba150d0e
     csharp_sha: 033dbe7f8ffda8fd0258a6f1a702436de69234df
+    reason: "rebaseline python apres fix claim sparsite (cellules 1 et 22, #8052) : la prose disait 'La matrice est clairsemee (chaque utilisateur ne note que quelques films)' + table resume 'creuse' mais l'output cellule 4 affiche 'Notes observees : 23/25 (92% rempli)' (3 users sur 5 ont note TOUS les films) = matrice presque complete, l'oppose de clairsemee. Fix distingue systems reels (clairsemes, point pedago conserve) vs jouet (presque complet pour lisibilite). Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:
     - "Socle pedagogique commun : filtrage collaboratif par factorisation de matrices (recommandation user-item, K facteurs latents)."
     - "Idiomes framework : C# = `mlContext.Recommendation().Trainers.MatrixFactorization` (trainer dedie + MapValueToKey pour UserId/MovieId). Python = `sklearn.decomposition.NMF` (Non-negative Matrix Factorization generique, init='nndsvda', solver='mu') avec erreur de reconstruction explicite."


### PR DESCRIPTION
## Defect (structural / claim-vs-own-code, #8052)

`ML-7-Recommendation-Python.ipynb` asserts the rating matrix is sparse ("clairsemée" / "creuse"), but the notebook's own executed output shows it is 92% filled — the opposite of sparse.

| | |
|---|---|
| **Claim cell[1]** | "La matrice est **clairsemée** (chaque utilisateur ne note que quelques films)." |
| **Claim cell[22]** | "Matrice utilisateur-item \| Notes R (U×I), creuse (cellules manquantes = non vues)" |
| **Ground truth cell[4]** | `R` is 5×5 with only **TWO zeros** (U1 missed "Le Notebook", U2 missed "Interstellar"). Output: **`Notes observées : 23 / 25 (92% rempli)`**. Three of five users (U3, U4, U5) rated **all five** films. |

The sparsity claim (the canonical motivation for matrix factorization / collaborative filtering) is applied to a toy matrix that is 92% filled — an intra-notebook contradiction surfacing one cell after the claim. "chaque utilisateur ne note que quelques films" is false for all five users.

## Fix (markdown-only, byte-identical output, no re-exec)

- **cell[1]**: distinguish real systems (sparse — pedagogical point preserved) from this toy (near-complete for readability): "Dans les **vrais** systèmes, la matrice ... est **clairsemée** ... Notre exemple jouet ci-dessous est volontairement **presque complet** (23 notes sur 25, 92 % — cf. cellule 4) pour rester lisible ; il contient malgré tout deux notes manquantes à prédire."
- **cell[22]**: "creuse (cellules manquantes = non vues)" → "creuse dans les vrais systèmes (notre jouet est presque complet : 23/25)".

Genuine true statements left untouched (cell[5] note "Les vrais systèmes gèrent le caractère creux différemment" is about real systems — general truth, consistent with the fix).

## Out of scope (deliberately not fixed here)

cell[12] "Top-3" recommendations yield at most 1 item per user (3 users get "(a tout vu)") — a direct **consequence** of the density this fix now acknowledges. The `top_n=3` code works as designed (returns up to N unseen films); it becomes self-consistent once the prose no longer claims sparsity. Fixing it would require a code/output change (changing `top_n` or the matrix), which is out of the markdown-only #8052 lens.

## Verification

Firsthand (#8052 claims↔executed-code lens): read cell[1]/[4]/[22] source + committed output, confirmed `R` has 2 zeros and "23/25 (92% rempli)". Canonical JSON round-trip byte-identical pre/post; diff **2/2** markdown elements. Markdown-only, no re-exec.

## Twin rebaseline

`ml-7-recommendation.yaml` (parity_level **semantic**). Python-only — the C# twin is unaffected. Registry `python_sha` rebaselined (`cbaec2f4` → `a3279c17`), `csharp_sha` unchanged (`033dbe7f`). `check_twin_parity --check` → **OK 149/149** at HEAD post-commit.

See #8052 (semantic-sampling audit, ML.Net Python slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
