### PR TITLE
fix(ml,#8052): ML-1-Introduction-Python resume says 'Trois familles' but enumerates two + pred '≈76 min' but output is 75.1

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb
@@ -422,7 +422,7 @@
    "source": [
     "Le modèle trouve une pente d'environ **3 minutes par kilomètre**, ce qui correspond à\n",
     "une vitesse moyenne de 20 km/h — cohérent pour un trajet urbain avec feux et stops. La\n",
-    "prédiction pour 25 km (≈ 76 min) est fiable car 25 km est **dans la plage** observée\n",
+    "prédiction pour 25 km (≈ 75 min) est fiable car 25 km est **dans la plage** observée\n",
     "(5 à 40 km)."
    ]
   },
@@ -715,7 +715,7 @@
     "| Évaluation | `r2_score`, `accuracy_score` | `mlContext.Regression.Evaluate` |\n",
     "| Prédiction | `model.predict(X_new)` | `predictionEngine.Predict(x)` |\n",
     "\n",
-    "**Trois familles** abordées : régression linéaire (maison, trajet), classification\n",
+    "**Deux familles** abordées à travers trois exemples guidés : régression linéaire (maison, trajet), classification\n",
     "binaire (transactions). Les concepts sont **identiques** entre .NET et Python — seules\n",
     "les API et les solveurs par défaut diffèrent.\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/ml-1-introduction.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-1-introduction.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: fe6031b3f3c917b5f77d613d1fdf4a3d2db02ddc
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2
+    python_sha: 736ca5bc84443703871b0889ec8fe8413b5246c3
     csharp_sha: 0e5a5f450b7d111d2ae1bb4507dde72790604527
+    reason: "rebaseline python apres 2 fixes (#8052) : (1) cellule 21 '(environ 76 min)' mais output cellule 20 = 75.1 minutes (arrondit a 75) ; (2) cellule 34 resume 'Trois familles abordees' mais n'enumere que 2 familles (regression + classification) -- 'familles' est une transposition de 'exemples' (cellule 0 dit 'trois exemples guides'). Fix value + count. Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:
     - "Socle pedagogique commun : regression lineaire (R2, MAE) + regression logistique (accuracy, ROC-AUC). Dataset : prediction de prix / classification binaire."
     - "Idiomes framework : C# = `Microsoft.ML` (API imperative MLContext -> PredictionEngine, schema via classes [ColumnName]). Python = `sklearn.linear_model` (LinearRegression, LogisticRegression) fonctionnel (estimator.fit/predict), metrics `r2_score, mean_absolute_error, accuracy_score, roc_auc_score`."


### PR DESCRIPTION
## Defects (count + value drift, #8052)

Two markdown cells in `ML-1-Introduction-Python.ipynb` contradict the notebook's own content.

### 1. cell[34] (summary) — count self-contradiction in one sentence

| | |
|---|---|
| **Claim** | "**Trois familles** abordées : régression linéaire (maison, trajet), classification binaire (transactions)." |
| **Ground truth** | The sentence enumerates only **TWO** families — régression linéaire and classification binaire. What there are three of is guided **examples** (cell[0]: "Il reprend exactement les **trois exemples guidés**"). "familles" is a transposition of "exemples". |

**Fix**: "**Deux familles** abordées à travers trois exemples guidés : régression linéaire (maison, trajet), classification binaire (transactions)."

### 2. cell[21] (interpretation) — value drift

| | |
|---|---|
| **Claim** | "La prédiction pour 25 km (≈ 76 min) est fiable car 25 km est dans la plage observée." |
| **Ground truth** | `[20]` committed output: **`Temps prévu pour 25 km : 75.1 minutes`**. 75.1 rounds to ≈75, not ≈76. |

Note: the same cell's other quantitative claim is **correct** — slope ≈3 min/km → 20 km/h (60/3.02 ≈ 19.9 ≈ 20). Only the 76 is wrong. **Fix**: "(≈ 75 min)".

## Verification

Firsthand (#8052 lens): read cell[0]/[20]/[21]/[34], confirmed 75.1 output and the two-vs-three enumeration. Canonical JSON round-trip byte-identical pre/post; diff **2/2** markdown elements. Markdown-only, no re-exec. (cell[21]/[34] source is split per-line; edits target element-bounded substrings.)

## Twin rebaseline

`ml-1-introduction.yaml` (parity_level **semantic**). Python-only — the C# twin is unaffected. Registry `python_sha` rebaselined (`fe6031b3` → `736ca5bc`), `csharp_sha` unchanged (`0e5a5f45`). `check_twin_parity --check` → **OK 149/149** at HEAD post-commit.

See #8052 (semantic-sampling audit, ML.Net Python slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
