### PR TITLE
fix(ml,#8052): ML-2-Data&Features-Python parity table says remainder='passthrough' (code='drop', passthrough would leak label) + cites df.info() (code uses df.dtypes)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features-Python.ipynb
@@ -28,7 +28,7 @@
     "| `LoadColumn` / `ColumnName` attributes | Nommage de colonnes `DataFrame` |\n",
     "| `OneHotEncodingEstimator` | `sklearn.preprocessing.OneHotEncoder` |\n",
     "| `ReplaceMissingValues` | `sklearn.impute.SimpleImputer` |\n",
-    "| `Concatenate(\"Features\", ...)` | `ColumnTransformer` avec `remainder='passthrough'` |\n",
+    "| `Concatenate(\"Features\", ...)` | `ColumnTransformer` avec `remainder='drop' (exclut le label)` |\n",
     "| `mlContext.Transforms.*` chain | `sklearn.pipeline.Pipeline` |\n",
     "\n",
     "### Prérequis\n",
@@ -250,7 +250,7 @@
    "source": [
     "### Exploration du DataFrame\n",
     "\n",
-    "Contrairement à ML.NET où les types sont déclarés via attributs (`LoadColumn`, `ColumnName`), pandas **infère** automatiquement les types. On peut inspecter le résultat via `df.info()` et `df.describe()`."
+    "Contrairement à ML.NET où les types sont déclarés via attributs (`LoadColumn`, `ColumnName`), pandas **infère** automatiquement les types. On peut inspecter le résultat via `df.dtypes` et `df.describe()`."
    ]
   },
   {
@@ -876,7 +876,7 @@
     "Dans ce notebook vous avez maîtrisé le **feature engineering** avec l'écosystème Python (pandas + scikit-learn), en miroir du notebook ML.NET :\n",
     "\n",
     "1. **Chargement** : `pd.DataFrame` in-memory (équivalent `IDataView`) avec schéma inféré automatiquement\n",
-    "2. **Exploration** : `df.info()`, `df.describe()`, `df.isna().sum()` (gestion native des `NaN`)\n",
+    "2. **Exploration** : `df.dtypes`, `df.describe()`, `df.isna().sum()` (gestion native des `NaN`)\n",
     "3. **Transformations** :\n",
     "   - `OneHotEncoder` pour les catégorielles (équivalent `OneHotEncodingEstimator` ML.NET)\n",
     "   - `SimpleImputer` pour les valeurs manquantes (équivalent `ReplaceMissingValues`)\n",

--- a/scripts/notebook_tools/twin_pairs.d/ml-2-data-features.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-2-data-features.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: af21e99f91c1f21b8aeacd2de14e5c4b2bfddc44
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2
+    python_sha: 101ab5a0f5a70557bcddc84c4ebfebadbb8ecc64
     csharp_sha: f08215df5b5be9b9a64577a165a13fc386719c70
+    reason: "rebaseline python apres 2 fixes (#8052) : (1) table parite cellule 0 disait ColumnTransformer remainder='passthrough' mais code cellule 7 = remainder='drop' (passthrough ferait fuiter fare_amount le label dans les features) ; (2) cellules 4 et 18 citaient df.info() mais le code cellule 5 utilise df.dtypes (output=Series dtypes, pas rendering info()) -- df.describe()/isna() etait reels, seul df.info() fantome. Fix API-config identity. Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:
     - "Socle pedagogique commun : featurization (encodage categoriel one-hot, normalisation, imputation) sur donnees tabulaires."
     - "Idiomes framework : C# = `mlContext.Transforms.Categorical.OneHotEncoding` (OutputKind.Binary) sur IDataView (LoadFromEnumerable). Python = `sklearn.preprocessing` (OneHotEncoder, StandardScaler, SimpleImputer) composes via `ColumnTransformer` + `Pipeline`."


### PR DESCRIPTION
## Defects (structural / API-config identity, #8052)

Two markdown cells in `ML-2-Data&Features-Python.ipynb` contradict the notebook's own executed code.

### 1. cell[0] (parity table) — `remainder='passthrough'` vs code `'drop'`

| | |
|---|---|
| **Claim** | `\| Concatenate("Features", ...) \| ColumnTransformer avec remainder='passthrough' \|` |
| **Ground truth** | `[7]` code: `ColumnTransformer(..., remainder="drop")  # on ignore fare_amount (label) pour la matrice de features`. `[9]` output: `X : (8, 9)` — 9 feature names, **no** `fare_amount`/`remainder__` column. |

`remainder='passthrough'` would carry `fare_amount` (the **label**) into the feature matrix — label leakage. The code deliberately uses `remainder='drop'` (comment says so). ML.NET `Concatenate("Features", col1, col2, ...)` outputs ONLY the named columns into "Features", so `remainder='drop'` (output = only transformed columns) is the correct equivalent. **Fix**: table cell → `remainder='drop' (exclut le label)`.

### 2. cell[4] + cell[18] (intro + summary) — `df.info()` never executed

| | |
|---|---|
| **Claim** | `[4]`: "On peut inspecter le résultat via `df.info()` et `df.describe()`." / `[18]` Résumé: "**Exploration** : `df.info()`, `df.describe()`, `df.isna().sum()`" |
| **Ground truth** | `[5]` (the only exploration cell): `print(df.dtypes) ; df.describe() ; df.isna().sum()`. Output = a **dtypes Series** (`vendor_id str / rate_code float64 / ...`), NOT the `df.info()` rendering (no `RangeIndex`, no `Non-Null Count`, no `memory usage`). |

`df.info()` is cited twice (intro + "what you did") but **never executed** anywhere in the notebook (grep of every source line: `info()` appears only in those two markdown cells). `df.describe()` and `df.isna().sum()` ARE present; only `df.info()` is a phantom. **Fix**: `df.info()` → `df.dtypes` in both cells.

## Verification

Firsthand (#8052 claims↔executed-code lens): read `[0]`/`[4]`/`[5]`/`[7]`/`[18]` source + outputs, confirmed `remainder='drop'` code + comment, and the dtypes Series output (not `info()`). Canonical JSON round-trip byte-identical pre/post; diff **3/3** markdown elements. Markdown-only, no re-exec. Post-edit assertion: `df.info()` absent from the whole notebook.

## Twin rebaseline

`ml-2-data-features.yaml` (parity_level **semantic**). Python-only — the C# twin is unaffected. Registry `python_sha` rebaselined (`af21e99f` → `101ab5a0`), `csharp_sha` unchanged (`f08215df`). `check_twin_parity --check` → **OK 149/149** at HEAD post-commit.

See #8052 (semantic-sampling audit, ML.Net Python slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
