### PR TITLE
fix(sl,#8052): SL-3 "Point cle" says THE minimal determination is {metal} (there are three)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb
@@ -316,7 +316,7 @@
     "| `state` | **Non** | Cu et Na sont tous deux solid mais conductivites différentes |\n",
     "| `metal, density` | **Oui** | Surensemble de `metal` seul, donc toujours valide (monotonie) |\n",
     "\n",
-    "> **Point cle** : La détermination minimale est `{metal}`. Les autres attributs (density, color, state) sont des **epiphenomenes** --- ils correlent avec la conductivite mais ne la déterminent pas fonctionnellement. La monotonie garantit que tout surensemble d'une détermination valide est aussi valide."
+    "> **Point cle** : `{metal}` est la **plus petite** détermination (niveau 1), mais elle n'est **pas la seule minimale** --- la cellule suivante révèle **trois** déterminations minimales : `{metal}`, `{color, density}` et `{color, state}` (cf. propriété d'Unicité ci-dessus). La monotonie garantit que tout surensemble d'une détermination valide est aussi valide."
    ]
   },
   {
@@ -493,8 +493,8 @@
     "| Propriete | Observation |\n",
     "|-----------|-------------|\n",
     "| **Up-set** | Tout surensemble de `{metal}` est aussi valide (monotonie) |\n",
-    "| **détermination minimale** | `{metal}` est le plus petit ensemble valide |\n",
-    "| **Bruit** | Les ensembles sans `metal` sont généralement invalides |\n",
+    "| **déterminations minimales** | **trois** : `{metal}` (niveau 1), `{color, density}` et `{color, state}` (niveau 2) |\n",
+    "| **Attributs seuls** | `density`, `color`, `state` seuls (niveau 1) sont invalides ; mais certaines paires sans `metal` (`{color,density}`, `{color,state}`) sont valides |\n",
     "\n",
     "> **Analogie mathematique** : Le treillis des determinations est isomorphe a la relation d'inclusion sur $\\mathcal{P}(\\{x_1, \\ldots, x_n\\})$. La connaissance de pertinence identifie un **filtre** dans ce treillis : les ensembles d'attributs a partir desquels on peut prédire la cible."
    ]

--- a/scripts/notebook_tools/twin_pairs.d/sl-3-relevancelearning.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-3-relevancelearning.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-27"
+    date: "2026-07-31"
     by: po-2024
-    python_sha: 02f723faac11b46b492bb80542f6f67352dd69f3
+    python_sha: e85deb5d621775641b31cbacb96c70e55266cfe1
     csharp_sha: 7b065b84b9a88aa7f1986fda628aa70d2127e4ba
   known_differences:
     - "Socle commun : Relevance-Based Learning (RBL) approfondi -- determinations fonctionnelles, treillis des determinations, algorithme MINIMAL-CONSISTENT-DET, selection d'attributs guidee."


### PR DESCRIPTION
fix(sl,#8052): SL-3-RelevanceLearning "Point cle" says THE minimal determination is {metal} (there are three)

Two markdown defects in SL-3-RelevanceLearning contradict the notebook's own
computed output AND the Unicité principle stated earlier in the same notebook.

## Defect 1 (cell[5], "Point cle", structural / identity)

- Claim: "> **Point cle** : La détermination minimale est `{metal}`. Les autres
  attributs (density, color, state) sont des **epiphenomenes** --- ils correlent
  avec la conductivite mais ne la déterminent pas fonctionnellement."
- Ground truth (cell[7] output): "Determinations minimales : ['{metal}',
  '{color, density}', '{color, state}']" --- THREE minimal determinations.
  cell[9] ASCII lattice stars all three as minimal: `*V {metal}`,
  `*V {color,density}`, `*V {color,state}`.
- Self-contradiction (cell[3]): "**Unicite** : La détermination minimale n'est
  pas forcement unique --- il peut exister plusieurs ensembles minimaux
  différents." cell[5]'s definite-singular "La détermination minimale est
  `{metal}`" directly violates this.
- Also: calling density/color/state "epiphenomenes" is too strong --- {color,
  density} and {color, state} are metal-free VALID determinations.
- Fix: state `{metal}` is the **plus petite** (niveau 1) but **pas la seule
  minimale** --- three exist; remove the epiphenomene gloss.

## Defect 2 (cell[8], interpretation table, structural)

- Claim row: "| **détermination minimale** | `{metal}` est le plus petit
  ensemble valide |" --- {metal} IS the smallest, but row implies it is the
  ONLY minimal, contradicting the three above.
- Claim row: "| **Bruit** | Les ensembles sans `metal` sont généralement
  invalides |" --- FALSE at niveau 2: two of the three metal-free pairs
  ({color,density}, {color,state}) are VALID minimal determinations.
- Fix: row -> "trois : `{metal}` (niveau 1), `{color, density}` et
  `{color, state}` (niveau 2)"; "Bruit" row -> "Attributs seuls" noting level-1
  single attrs invalid but some metal-free pairs valid.

## Verification

Firsthand (#8052 claims<->executed-code lens): read cell[3]/[5]/[7]/[8]/[9]
source + outputs, confirmed three minimal determinations in computed output +
ASCII lattice, and the cell[3] Unicité principle the prose violated. Canonical
JSON round-trip byte-identical pre/post; diff 3 markdown elements (cell[5]
Point cle + cell[8] two rows). Markdown-only, no re-exec.

## Twin rebaseline

SL-3 is a semantic twin (sl-3-relevancelearning.yaml). The fix is Python-only;
drift is paraphrase-preserving; registry python_sha rebaselined
(02f723fa -> e85deb5d), csharp_sha unchanged (7b065b84). check_twin_parity
--check -> OK at HEAD post-commit.

See #8052 (semantic-sampling audit, SymbolicLearning slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
