### PR TITLE
fix(probas,#8052): DecInfer-10 timing re-exec §D.5 — add measurement cell (CAUSE_FIXED)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
@@ -377,7 +377,7 @@
    "cell_type": "markdown",
    "id": "cell-15063fa1",
    "metadata": {},
-   "source": "## 4. Reutiliser le moteur compile (problematique runtime)\n\nUn bandit reel rejoue des centaines de fois, et le posterior de chaque bras evolue a chaque recompense. Si l'on reconstruisait le modèle a chaque pas, Infer.NET **recompilerait** a chaque fois (~250 ms par appel). La solution : un modèle a **taille fixe** `MAX` ou un **masque** `mask[i]` dit quelles cases de `obs[i]` sont de vraies observations. On compile une fois, puis on met seulement a jour `ObservedValue` des tableaux : Infer.NET **reutilise** le code compile (mesure : ~0,2 ms par re-inference).\n\nOn encapsule ce pattern dans une classe `BayesArm` : un bras dont Infer.NET calcule le posterior."
+   "source": "## 4. Reutiliser le moteur compile (problematique runtime)\n\nUn bandit reel rejoue des centaines de fois, et le posterior de chaque bras evolue a chaque recompense. Si l'on reconstruisait le modèle a chaque pas, Infer.NET **recompilerait** a chaque fois (~250 ms par appel). La solution : un modèle a **taille fixe** `MAX` ou un **masque** `mask[i]` dit quelles cases de `obs[i]` sont de vraies observations. On compile une fois, puis on met seulement a jour `ObservedValue` des tableaux : Infer.NET **reutilise** le code compile (ordre de grandeur typique d'Infer.NET : ~0,2 ms par re-inference).\n\nOn encapsule ce pattern dans une classe `BayesArm` : un bras dont Infer.NET calcule le posterior."
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
@@ -3,38 +3,245 @@
   {
    "cell_type": "markdown",
    "id": "cell-065982ec",
-   "metadata": {},
-   "source": "# DecInfer-10-Thompson-Sampling : Bandits bayesiens par Infer.NET\n\n**Serie** : Programmation Probabiliste avec Infer.NET (10/10)\n**Duree estimee** : 60 minutes\n**Prerequis** : [Infer-7-Skills-IRT](../../Infer/Infer-7-Skills-IRT.ipynb) (posterior Beta), [DecInfer-8-Sequential](DecInfer-8-Sequential.ipynb) (bandits, epsilon-greedy, UCB1)\n\n---\n\n## Objectifs\n\n- Modeliser un **bandit multi-bras** comme un programme probabiliste Infer.NET\n- Faire calculer au **moteur d'inference** le posterior Beta-Bernoulli de chaque bras (inference variationnelle / EP), plutot que d'appliquer la formule conjuguee a la main\n- Implementer le **Thompson Sampling** : jouer le bras dont l'echantillon posterior est le plus eleve\n- Mesurer le **regret cumule** face a epsilon-greedy et UCB1 (Prong-B : Thompson exploite l'incertitude posterior)\n- Etendre au **best-arm identification** : estimer P(bras i est le meilleur) par echantillonnage posterior\n\n## Navigation\n\n| Précédent | Suivant |\n|-----------|---------|\n| [DecInfer-8-Sequential](DecInfer-8-Sequential.ipynb) | [Infer-5-Causal-Inference](../../Infer/Infer-5-Causal-Inference.ipynb) |\n\n> **Pont inter-series** : le traitement des bandits en [DecInfer-8](DecInfer-8-Sequential.ipynb) section 8 implemente epsilon-greedy, UCB1 et un exercice de Thompson **manuel** (comptage des succes/echecs, formule conjuguee codee a la main). Ce notebook en est le versant **moteur** : Infer.NET calcule le posterior Beta de chaque bras par inference variationnelle, et Thompson echantillonne depuis ce posterior."
+   "metadata": {
+    "papermill": {
+     "duration": 0.005603,
+     "end_time": "2026-07-31T19:52:05.422055",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:05.416452",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# DecInfer-10-Thompson-Sampling : Bandits bayesiens par Infer.NET\n",
+    "\n",
+    "**Serie** : Programmation Probabiliste avec Infer.NET (10/10)\n",
+    "**Duree estimee** : 60 minutes\n",
+    "**Prerequis** : [Infer-7-Skills-IRT](../../Infer/Infer-7-Skills-IRT.ipynb) (posterior Beta), [DecInfer-8-Sequential](DecInfer-8-Sequential.ipynb) (bandits, epsilon-greedy, UCB1)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Objectifs\n",
+    "\n",
+    "- Modeliser un **bandit multi-bras** comme un programme probabiliste Infer.NET\n",
+    "- Faire calculer au **moteur d'inference** le posterior Beta-Bernoulli de chaque bras (inference variationnelle / EP), plutot que d'appliquer la formule conjuguee a la main\n",
+    "- Implementer le **Thompson Sampling** : jouer le bras dont l'echantillon posterior est le plus eleve\n",
+    "- Mesurer le **regret cumule** face a epsilon-greedy et UCB1 (Prong-B : Thompson exploite l'incertitude posterior)\n",
+    "- Etendre au **best-arm identification** : estimer P(bras i est le meilleur) par echantillonnage posterior\n",
+    "\n",
+    "## Navigation\n",
+    "\n",
+    "| Précédent | Suivant |\n",
+    "|-----------|---------|\n",
+    "| [DecInfer-8-Sequential](DecInfer-8-Sequential.ipynb) | [Infer-5-Causal-Inference](../../Infer/Infer-5-Causal-Inference.ipynb) |\n",
+    "\n",
+    "> **Pont inter-series** : le traitement des bandits en [DecInfer-8](DecInfer-8-Sequential.ipynb) section 8 implemente epsilon-greedy, UCB1 et un exercice de Thompson **manuel** (comptage des succes/echecs, formule conjuguee codee a la main). Ce notebook en est le versant **moteur** : Infer.NET calcule le posterior Beta de chaque bras par inference variationnelle, et Thompson echantillonne depuis ce posterior."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-e1a1df7a",
-   "metadata": {},
-   "source": "## 1. Exploration vs exploitation — pourquoi Thompson ?\n\nUn **bandit multi-bras** (Robbins, 1952) : K bras, chacun d'une recompense Bernoulli de moyenne inconnue theta_k. A chaque pas de temps on choisit un bras, on percoit une recompense 0/1, et on cherche a **maximiser la recompense cumulee**. Le dilemme :\n\n- **Exploiter** : jouer le bras qui semble le meilleur jusqu'ici.\n- **Explorer** : tester un bras peu joue pour estimer sa moyenne.\n\nTrois familles de politiques :\n\n| Politique | Stratégie d'exploration |\n|-----------|------------------------|\n| **epsilon-greedy** | Avec proba epsilon, jouer un bras au hasard (exploration uniforme) |\n| **UCB1** (Auer et al., 2002) | Jouer le bras maximisant moyenne + bonus d'incertitude `sqrt(2 ln t / n_k)` |\n| **Thompson Sampling** (Thompson, 1933) | Maintenir un **posterior** sur chaque theta_k ; **echantillonner** theta_k dans son posterior ; jouer le max |\n\n**L'idee de Thompson** est subtilement bayesienne : au lieu d'explorer au hasard (epsilon-greedy) ou via un bonus frequentiste (UCB1), on quantifie l'incertitude sur chaque bras par une **distribution posterior**, et on joue proportionnellement a la probabilite que chaque bras soit le meilleur. Les bras peu explores ont un posterior **large** (incertain) : l'echantillonnage les fait parfois gagner, ce qui declenche une exploration **ciblee** la ou l'information manque.\n\n### La valeur ajoutee Infer.NET (non-doublon avec DecInfer-8)\n\nPour un bras Bernoulli de prior Beta(a, b), le posterior après s succes et f echecs est **conjugue** : Beta(a+s, b+f). On pourrait le coder a la main (c'est l'exercice DecInfer-8 section 8). **Ce notebook ne le fait pas** : on declare le modèle `theta ~ Beta ; reward ~ Bernoulli(theta)` et on laisse **Infer.NET inferer le posterior**. Pour ce cas conjugue le moteur recouvre exactement la forme analytique — mais la même approche se generalise a des modèles **non conjugues** ou la formule fermee n'existe pas, la ou seul un moteur d'inference (EP, VMP) sait faire."
+   "metadata": {
+    "papermill": {
+     "duration": 0.00355,
+     "end_time": "2026-07-31T19:52:05.431391",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:05.427841",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Exploration vs exploitation — pourquoi Thompson ?\n",
+    "\n",
+    "Un **bandit multi-bras** (Robbins, 1952) : K bras, chacun d'une recompense Bernoulli de moyenne inconnue theta_k. A chaque pas de temps on choisit un bras, on percoit une recompense 0/1, et on cherche a **maximiser la recompense cumulee**. Le dilemme :\n",
+    "\n",
+    "- **Exploiter** : jouer le bras qui semble le meilleur jusqu'ici.\n",
+    "- **Explorer** : tester un bras peu joue pour estimer sa moyenne.\n",
+    "\n",
+    "Trois familles de politiques :\n",
+    "\n",
+    "| Politique | Stratégie d'exploration |\n",
+    "|-----------|------------------------|\n",
+    "| **epsilon-greedy** | Avec proba epsilon, jouer un bras au hasard (exploration uniforme) |\n",
+    "| **UCB1** (Auer et al., 2002) | Jouer le bras maximisant moyenne + bonus d'incertitude `sqrt(2 ln t / n_k)` |\n",
+    "| **Thompson Sampling** (Thompson, 1933) | Maintenir un **posterior** sur chaque theta_k ; **echantillonner** theta_k dans son posterior ; jouer le max |\n",
+    "\n",
+    "**L'idee de Thompson** est subtilement bayesienne : au lieu d'explorer au hasard (epsilon-greedy) ou via un bonus frequentiste (UCB1), on quantifie l'incertitude sur chaque bras par une **distribution posterior**, et on joue proportionnellement a la probabilite que chaque bras soit le meilleur. Les bras peu explores ont un posterior **large** (incertain) : l'echantillonnage les fait parfois gagner, ce qui declenche une exploration **ciblee** la ou l'information manque.\n",
+    "\n",
+    "### La valeur ajoutee Infer.NET (non-doublon avec DecInfer-8)\n",
+    "\n",
+    "Pour un bras Bernoulli de prior Beta(a, b), le posterior après s succes et f echecs est **conjugue** : Beta(a+s, b+f). On pourrait le coder a la main (c'est l'exercice DecInfer-8 section 8). **Ce notebook ne le fait pas** : on declare le modèle `theta ~ Beta ; reward ~ Bernoulli(theta)` et on laisse **Infer.NET inferer le posterior**. Pour ce cas conjugue le moteur recouvre exactement la forme analytique — mais la même approche se generalise a des modèles **non conjugues** ou la formule fermee n'existe pas, la ou seul un moteur d'inference (EP, VMP) sait faire."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-cf83f140",
-   "metadata": {},
-   "source": "## 2. Configuration d'Infer.NET\n\nChargement du moteur d'inference probabiliste (même `#r \"nuget\"` que toute la serie)."
+   "metadata": {
+    "papermill": {
+     "duration": 0.002369,
+     "end_time": "2026-07-31T19:52:05.436386",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:05.434017",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Configuration d'Infer.NET\n",
+    "\n",
+    "Chargement du moteur d'inference probabiliste (même `#r \"nuget\"` que toute la serie)."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "id": "cell-eb337d48",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:52:05.450439Z",
+     "iopub.status.busy": "2026-07-31T19:52:05.444626Z",
+     "iopub.status.idle": "2026-07-31T19:52:08.585109Z",
+     "shell.execute_reply": "2026-07-31T19:52:08.580921Z"
+    },
+    "papermill": {
+     "duration": 3.146266,
+     "end_time": "2026-07-31T19:52:08.585214",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:05.438948",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/html": [
-       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Microsoft.ML.Probabilistic</span></li><li><span>Microsoft.ML.Probabilistic.Compiler</span></li></ul></div><div></div></div>"
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '49572.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.ML.Probabilistic, 0.4.2504.701</span></li><li><span>Microsoft.ML.Probabilistic.Compiler, 0.4.2504.701</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Infer.NET charge.\r\n"
      ]
@@ -49,32 +256,58 @@
     "using Microsoft.ML.Probabilistic.Algorithms;\n",
     "using Microsoft.ML.Probabilistic.Compiler;\n",
     "Console.WriteLine(\"Infer.NET charge.\");"
-   ],
-   "execution_count": 1
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-45c5e1c5",
-   "metadata": {},
-   "source": "Chargement du helper de visualisation des graphes de facteurs (Graphviz)."
+   "metadata": {
+    "papermill": {
+     "duration": 0.002833,
+     "end_time": "2026-07-31T19:52:08.590887",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:08.588054",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Chargement du helper de visualisation des graphes de facteurs (Graphviz)."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "id": "cell-b0f29d4f",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:52:08.597345Z",
+     "iopub.status.busy": "2026-07-31T19:52:08.597170Z",
+     "iopub.status.idle": "2026-07-31T19:52:09.260742Z",
+     "shell.execute_reply": "2026-07-31T19:52:09.260541Z"
+    },
+    "papermill": {
+     "duration": 0.667299,
+     "end_time": "2026-07-31T19:52:09.260812",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:08.593513",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "FactorGraphHelper charge.\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Graphviz disponible : True\r\n"
+      "Graphviz disponible : False\r\n"
      ]
     }
    ],
@@ -82,44 +315,77 @@
     "#load \"../../Infer/FactorGraphHelper.cs\"\n",
     "Console.WriteLine(\"FactorGraphHelper charge.\");\n",
     "Console.WriteLine($\"Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}\");"
-   ],
-   "execution_count": 2
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-8be332b6",
-   "metadata": {},
-   "source": "## 3. Le modèle Beta-Bernoulli d'un bras\n\nSoit un bras de probabilite de succes inconnue `theta`. Modèle :\n\n- **Prior** : `theta ~ Beta(1, 1)` (uniforme sur [0,1] — ignorance totale).\n- **Vraisemblance** : `reward_i ~ Bernoulli(theta)` pour chaque tirage observe.\n\nAprès avoir observe `s` succes et `f` echecs, on demande au moteur d'inference le posterior sur `theta`. Verifions qu'Infer.NET recouvre la forme conjuguee `Beta(1+s, 1+f)` (le moteur fait le calcul, nous declarons seulement le modèle)."
+   "metadata": {
+    "papermill": {
+     "duration": 0.003539,
+     "end_time": "2026-07-31T19:52:09.268872",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:09.265333",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Le modèle Beta-Bernoulli d'un bras\n",
+    "\n",
+    "Soit un bras de probabilite de succes inconnue `theta`. Modèle :\n",
+    "\n",
+    "- **Prior** : `theta ~ Beta(1, 1)` (uniforme sur [0,1] — ignorance totale).\n",
+    "- **Vraisemblance** : `reward_i ~ Bernoulli(theta)` pour chaque tirage observe.\n",
+    "\n",
+    "Après avoir observe `s` succes et `f` echecs, on demande au moteur d'inference le posterior sur `theta`. Verifions qu'Infer.NET recouvre la forme conjuguee `Beta(1+s, 1+f)` (le moteur fait le calcul, nous declarons seulement le modèle)."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "id": "cell-0629643f",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:52:09.278136Z",
+     "iopub.status.busy": "2026-07-31T19:52:09.277696Z",
+     "iopub.status.idle": "2026-07-31T19:52:10.745823Z",
+     "shell.execute_reply": "2026-07-31T19:52:10.745691Z"
+    },
+    "papermill": {
+     "duration": 1.473998,
+     "end_time": "2026-07-31T19:52:10.745887",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:09.271889",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Apres 7 succes / 3 echecs :\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  Posterior Infer.NET = Beta(8,0, 4,0) ; mean = 0,667\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  Formule conjuguee   = Beta(8, 4) ; mean = 0,667\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  => Le moteur recouvre la forme analytique (cas conjugue favorable).\r\n"
      ]
@@ -145,114 +411,102 @@
     "Console.WriteLine($\"  Posterior Infer.NET = Beta({post1.TrueCount:F1}, {post1.FalseCount:F1}) ; mean = {post1.GetMean():F3}\");\n",
     "Console.WriteLine($\"  Formule conjuguee   = Beta({1+succ}, {1+fail}) ; mean = {theoMean:F3}\");\n",
     "Console.WriteLine($\"  => Le moteur recouvre la forme analytique (cas conjugue favorable).\");"
-   ],
-   "execution_count": 3
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-2a769548",
-   "metadata": {},
-   "source": "### 3.1 Graphe de facteurs du bras (Prong-A)\n\nLe même modèle, rendu en graphe de facteurs par Graphviz via le `FactorGraphHelper` (pattern de la serie, cf [DecInfer-3](../../Infer/Infer-3-Factor-Graphs.ipynb), [DecInfer-4](DecInfer-4-Multi-Attribute.ipynb)). Le noeud `theta` (Beta) alimente les facteurs Bernoulli des observations."
+   "metadata": {
+    "papermill": {
+     "duration": 0.002571,
+     "end_time": "2026-07-31T19:52:10.751430",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:10.748859",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3.1 Graphe de facteurs du bras (Prong-A)\n",
+    "\n",
+    "Le même modèle, rendu en graphe de facteurs par Graphviz via le `FactorGraphHelper` (pattern de la serie, cf [DecInfer-3](../../Infer/Infer-3-Factor-Graphs.ipynb), [DecInfer-4](DecInfer-4-Multi-Attribute.ipynb)). Le noeud `theta` (Beta) alimente les facteurs Bernoulli des observations."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "id": "cell-702b3d96",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:52:10.758273Z",
+     "iopub.status.busy": "2026-07-31T19:52:10.757926Z",
+     "iopub.status.idle": "2026-07-31T19:52:11.076382Z",
+     "shell.execute_reply": "2026-07-31T19:52:11.076480Z"
+    },
+    "papermill": {
+     "duration": 0.322511,
+     "end_time": "2026-07-31T19:52:11.076546",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:10.754035",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Problem with converting DOT to SVG\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\CoursIA-9053\\MyIA.AI.Notebooks\\Probas\\DecisionTheory\\DecInfer'. Le fichier spécifié est introuvable.\"\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "If \"dot\" program is not installed, install Graphviz\n",
+      "and add a path to \"dot\" to the PATH\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DOT file is saved to \"D:\\Dev\\CoursIA-9053\\MyIA.AI.Notebooks\\Probas\\DecisionTheory\\DecInfer\\Model_07_31_26_21_52_10_83.gv\"\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Modele Beta-Bernoulli : theta (Beta) -> 6 facteurs Bernoulli (un par tirage observe).\r\n"
      ]
     },
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/html": [
-       "\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_28_26_16_44_51_89.svg</div>\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\n",
-       "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
-       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
-       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.2 (20260124.0452)\r\n",
-       " -->\r\n",
-       "<!-- Title: Model Pages: 1 -->\r\n",
-       "<svg width=\"109pt\" height=\"354pt\"\r\n",
-       " viewBox=\"0.00 0.00 109.00 354.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\r\n",
-       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 349.5)\">\r\n",
-       "<title>Model</title>\r\n",
-       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-349.5 104.75,-349.5 104.75,4 -4,4\"/>\r\n",
-       "<!-- node0 -->\r\n",
-       "<g id=\"node1\" class=\"node\">\r\n",
-       "<title>node0</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M83.5,-345.5C83.5,-345.5 17.25,-345.5 17.25,-345.5 11.25,-345.5 5.25,-339.5 5.25,-333.5 5.25,-333.5 5.25,-321.5 5.25,-321.5 5.25,-315.5 11.25,-309.5 17.25,-309.5 17.25,-309.5 83.5,-309.5 83.5,-309.5 89.5,-309.5 95.5,-315.5 95.5,-321.5 95.5,-321.5 95.5,-333.5 95.5,-333.5 95.5,-339.5 89.5,-345.5 83.5,-345.5\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"50.38\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">Beta(1,1)[mean=0,5]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node1 -->\r\n",
-       "<g id=\"node2\" class=\"node\">\r\n",
-       "<title>node1</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M65.38,-263.75C65.38,-263.75 35.38,-263.75 35.38,-263.75 29.38,-263.75 23.38,-257.75 23.38,-251.75 23.38,-251.75 23.38,-239.75 23.38,-239.75 23.38,-233.75 29.38,-227.75 35.38,-227.75 35.38,-227.75 65.38,-227.75 65.38,-227.75 71.38,-227.75 77.38,-233.75 77.38,-239.75 77.38,-239.75 77.38,-251.75 77.38,-251.75 77.38,-257.75 71.38,-263.75 65.38,-263.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"50.38\" y=\"-243.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
-       "</g>\r\n",
-       "<!-- node0&#45;&gt;node1 -->\r\n",
-       "<g id=\"edge1\" class=\"edge\">\r\n",
-       "<title>node0&#45;&gt;node1</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M50.38,-309.59C50.38,-299.68 50.38,-286.9 50.38,-275.46\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"53.88,-275.7 50.38,-265.7 46.88,-275.7 53.88,-275.7\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"56\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
-       "</g>\r\n",
-       "<!-- node2 -->\r\n",
-       "<g id=\"node3\" class=\"node\">\r\n",
-       "<title>node2</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M65.38,-190.75C65.38,-190.75 35.38,-190.75 35.38,-190.75 29.38,-190.75 23.38,-184.75 23.38,-178.75 23.38,-178.75 23.38,-166.75 23.38,-166.75 23.38,-160.75 29.38,-154.75 35.38,-154.75 35.38,-154.75 65.38,-154.75 65.38,-154.75 71.38,-154.75 77.38,-160.75 77.38,-166.75 77.38,-166.75 77.38,-178.75 77.38,-178.75 77.38,-184.75 71.38,-190.75 65.38,-190.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"50.38\" y=\"-168.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">theta</text>\r\n",
-       "</g>\r\n",
-       "<!-- node1&#45;&gt;node2 -->\r\n",
-       "<g id=\"edge2\" class=\"edge\">\r\n",
-       "<title>node1&#45;&gt;node2</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M50.38,-227.56C50.38,-219.98 50.38,-210.85 50.38,-202.29\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"53.88,-202.29 50.38,-192.29 46.88,-202.29 53.88,-202.29\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node3 -->\r\n",
-       "<g id=\"node4\" class=\"node\">\r\n",
-       "<title>node3</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M65.38,-109C65.38,-109 35.38,-109 35.38,-109 29.38,-109 23.38,-103 23.38,-97 23.38,-97 23.38,-85 23.38,-85 23.38,-79 29.38,-73 35.38,-73 35.38,-73 65.38,-73 65.38,-73 71.38,-73 77.38,-79 77.38,-85 77.38,-85 77.38,-97 77.38,-97 77.38,-103 71.38,-109 65.38,-109\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"50.38\" y=\"-88.28\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Bernoulli</text>\r\n",
-       "</g>\r\n",
-       "<!-- node2&#45;&gt;node3 -->\r\n",
-       "<g id=\"edge3\" class=\"edge\">\r\n",
-       "<title>node2&#45;&gt;node3</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M50.38,-154.45C50.38,-144.52 50.38,-131.81 50.38,-120.45\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"53.88,-120.78 50.38,-110.78 46.88,-120.78 53.88,-120.78\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"65\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probTrue</text>\r\n",
-       "</g>\r\n",
-       "<!-- node4 -->\r\n",
-       "<g id=\"node5\" class=\"node\">\r\n",
-       "<title>node4</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M88.75,-36C88.75,-36 12,-36 12,-36 6,-36 0,-30 0,-24 0,-24 0,-12 0,-12 0,-6 6,0 12,0 12,0 88.75,0 88.75,0 94.75,0 100.75,-6 100.75,-12 100.75,-12 100.75,-24 100.75,-24 100.75,-30 94.75,-36 88.75,-36\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"50.38\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">recompenses[tirages]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node3&#45;&gt;node4 -->\r\n",
-       "<g id=\"edge4\" class=\"edge\">\r\n",
-       "<title>node3&#45;&gt;node4</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M50.38,-72.81C50.38,-65.23 50.38,-56.1 50.38,-47.54\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"53.88,-47.54 50.38,-37.54 46.88,-47.54 53.88,-47.54\"/>\r\n",
-       "</g>\r\n",
-       "</g>\r\n",
-       "</svg>\r\n",
-       "\n",
-       "    </div>\n",
-       "</div>"
+       "<div style='padding: 10px; border: 1px solid #f0ad4e; background: #fcf8e3; border-radius: 5px;'>\n",
+       "                <strong>Graphviz non disponible.</strong><br/>\n",
+       "                Copiez le contenu de <code>Model_07_31_26_21_52_10_83.gv</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>\n",
+       "            </div>"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "\r\n",
       "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
@@ -273,72 +527,100 @@
     "var _fg = engFG.Infer<Beta>(thetaFG);\n",
     "Console.WriteLine(\"Modele Beta-Bernoulli : theta (Beta) -> 6 facteurs Bernoulli (un par tirage observe).\");\n",
     "display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));"
-   ],
-   "execution_count": 4
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-50c9bbca",
-   "metadata": {},
-   "source": "### 3.2 Convergence du posterior\n\nA mesure que les observations s'accumulent, le posterior se concentre autour de la vraie moyenne. Le moteur recalcule le posterior a chaque lot d'observations."
+   "metadata": {
+    "papermill": {
+     "duration": 0.004052,
+     "end_time": "2026-07-31T19:52:11.083920",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:11.079868",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3.2 Convergence du posterior\n",
+    "\n",
+    "A mesure que les observations s'accumulent, le posterior se concentre autour de la vraie moyenne. Le moteur recalcule le posterior a chaque lot d'observations."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "cell-5884b7f3",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:52:11.098178Z",
+     "iopub.status.busy": "2026-07-31T19:52:11.097780Z",
+     "iopub.status.idle": "2026-07-31T19:52:12.008598Z",
+     "shell.execute_reply": "2026-07-31T19:52:12.008402Z"
+    },
+    "papermill": {
+     "duration": 0.919002,
+     "end_time": "2026-07-31T19:52:12.008661",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:11.089659",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Vraie moyenne du bras = 0,70 (inconnue de l algorithme)\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  N tirages | posterior mean | ic 95% (approx)\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  ------------------------------------------\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "          5 | 0,857          | [0,615, 1,000]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "         20 | 0,727          | [0,545, 0,909]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "         50 | 0,769          | [0,656, 0,883]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "        200 | 0,663          | [0,598, 0,728]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  => Le posterior se resserre autour de la vraie moyenne quand N croit.\r\n"
      ]
@@ -370,23 +652,53 @@
     "    Console.WriteLine($\"  {N,9} | {mean:F3}          | [{lo:F3}, {hi:F3}]\");\n",
     "}\n",
     "Console.WriteLine(\"  => Le posterior se resserre autour de la vraie moyenne quand N croit.\");"
-   ],
-   "execution_count": 5
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-15063fa1",
-   "metadata": {},
-   "source": "## 4. Reutiliser le moteur compile (problematique runtime)\n\nUn bandit reel rejoue des centaines de fois, et le posterior de chaque bras evolue a chaque recompense. Si l'on reconstruisait le modèle a chaque pas, Infer.NET **recompilerait** a chaque fois (~250 ms par appel). La solution : un modèle a **taille fixe** `MAX` ou un **masque** `mask[i]` dit quelles cases de `obs[i]` sont de vraies observations. On compile une fois, puis on met seulement a jour `ObservedValue` des tableaux : Infer.NET **reutilise** le code compile (ordre de grandeur typique d'Infer.NET : ~0,2 ms par re-inference).\n\nOn encapsule ce pattern dans une classe `BayesArm` : un bras dont Infer.NET calcule le posterior."
+   "metadata": {
+    "papermill": {
+     "duration": 0.00292,
+     "end_time": "2026-07-31T19:52:12.014913",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:12.011993",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Reutiliser le moteur compile (problematique runtime)\n",
+    "\n",
+    "Un bandit reel rejoue des centaines de fois, et le posterior de chaque bras evolue a chaque recompense. Si l'on reconstruisait le modèle a chaque pas, Infer.NET **recompilerait** a chaque fois (~236 ms par compilation, mesure en section 4.1). La solution : un modèle a **taille fixe** `MAX` ou un **masque** `mask[i]` dit quelles cases de `obs[i]` sont de vraies observations. On compile une fois, puis on met seulement a jour `ObservedValue` des tableaux : Infer.NET **reutilise** le code compile (~0,05 ms par re-inference, mesure en section 4.1 -- soit ~5000x moins qu'une compilation).\n",
+    "\n",
+    "On encapsule ce pattern dans une classe `BayesArm` : un bras dont Infer.NET calcule le posterior."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
    "id": "cell-775a0d0a",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:52:12.021610Z",
+     "iopub.status.busy": "2026-07-31T19:52:12.021424Z",
+     "iopub.status.idle": "2026-07-31T19:52:12.080967Z",
+     "shell.execute_reply": "2026-07-31T19:52:12.080837Z"
+    },
+    "papermill": {
+     "duration": 0.063262,
+     "end_time": "2026-07-31T19:52:12.081029",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:12.017767",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Classe BayesArm definie (modele masque, moteur reutilise).\r\n"
      ]
@@ -439,121 +751,238 @@
     "    public double Mean()    => engine.Infer<Beta>(theta).GetMean();\n",
     "}\n",
     "Console.WriteLine(\"Classe BayesArm definie (modele masque, moteur reutilise).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3757d65",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002994,
+     "end_time": "2026-07-31T19:52:12.087561",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:12.084567",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 4.1 Mesure du gain de runtime : compilation vs re-inference\n",
+    "\n",
+    "La classe `BayesArm` est concue pour compiler le moteur **une fois** (warmup dans le constructeur), puis reutiliser ce code compile a chaque `Observe`/`Posterior`. Mesurons concretement les deux regimes pour confirmer l'ordre de grandeur annonce : la **compilation** est l'operation couteuse (~centaines de ms), la **re-inference** sur un modele pre-compile est sub-milliseconde."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "46507dc2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:52:12.094449Z",
+     "iopub.status.busy": "2026-07-31T19:52:12.094273Z",
+     "iopub.status.idle": "2026-07-31T19:52:12.378985Z",
+     "shell.execute_reply": "2026-07-31T19:52:12.378697Z"
+    },
+    "papermill": {
+     "duration": 0.288605,
+     "end_time": "2026-07-31T19:52:12.379084",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:12.090479",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compilation (1 fois, warmup BayesArm)        : 235,9 ms\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Re-inference (ObservedValue, compile reutilise) : 0,046 ms en moyenne sur 200 appels\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ratio compilation / re-inference              : 5100x\r\n"
+     ]
+    }
    ],
-   "execution_count": 6
+   "source": [
+    "// Mesure runtime : compilation (1 fois) vs re-inference (compile reutilise).\n",
+    "var swMes = System.Diagnostics.Stopwatch.StartNew();\n",
+    "var armMes = new BayesArm(maxN: 220);   // constructeur = warmup compilation du moteur\n",
+    "swMes.Stop();\n",
+    "double tCompile = swMes.Elapsed.TotalMilliseconds;\n",
+    "\n",
+    "var rngMes = new System.Random(42);\n",
+    "swMes.Restart();\n",
+    "int NMes = 200;\n",
+    "for (int i = 0; i < NMes; i++) {\n",
+    "    armMes.Observe(rngMes.NextDouble() < 0.5);   // ajoute une observation (masque + ObservedValue)\n",
+    "    var _post = armMes.Posterior();               // re-inference : compile reutilise\n",
+    "}\n",
+    "swMes.Stop();\n",
+    "double tReinfer = swMes.Elapsed.TotalMilliseconds / NMes;\n",
+    "\n",
+    "Console.WriteLine($\"Compilation (1 fois, warmup BayesArm)        : {tCompile:F1} ms\");\n",
+    "Console.WriteLine($\"Re-inference (ObservedValue, compile reutilise) : {tReinfer:F3} ms en moyenne sur {NMes} appels\");\n",
+    "Console.WriteLine($\"Ratio compilation / re-inference              : {tCompile/tReinfer:F0}x\");"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-5ce3ed6d",
-   "metadata": {},
-   "source": "## 5. Thompson Sampling multi-bras\n\nTrois bras de vraies moyennes `theta* = [0,2 ; 0,5 ; 0,8]` (inconnues de l'algorithme). A chaque pas de temps :\n\n1. Pour chaque bras, **Infer.NET infere** le posterior Beta.\n2. On **echantillonne** `theta_k ~ posterior_k` (Thompson : \"jouer selon la probabilite que chaque bras soit le meilleur\").\n3. On joue le bras d'echantillon maximum.\n4. On observe la recompense (Bernoulli(theta*)) et on met a jour le posterior du bras joue."
+   "metadata": {
+    "papermill": {
+     "duration": 0.004701,
+     "end_time": "2026-07-31T19:52:12.388439",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:12.383738",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Thompson Sampling multi-bras\n",
+    "\n",
+    "Trois bras de vraies moyennes `theta* = [0,2 ; 0,5 ; 0,8]` (inconnues de l'algorithme). A chaque pas de temps :\n",
+    "\n",
+    "1. Pour chaque bras, **Infer.NET infere** le posterior Beta.\n",
+    "2. On **echantillonne** `theta_k ~ posterior_k` (Thompson : \"jouer selon la probabilite que chaque bras soit le meilleur\").\n",
+    "3. On joue le bras d'echantillon maximum.\n",
+    "4. On observe la recompense (Bernoulli(theta*)) et on met a jour le posterior du bras joue."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
    "id": "cell-6acb9561",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:52:12.400566Z",
+     "iopub.status.busy": "2026-07-31T19:52:12.400374Z",
+     "iopub.status.idle": "2026-07-31T19:52:13.108116Z",
+     "shell.execute_reply": "2026-07-31T19:52:13.108001Z"
+    },
+    "papermill": {
+     "duration": 0.714273,
+     "end_time": "2026-07-31T19:52:13.108176",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:12.393903",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Bandit : K=3 bras, T=200 pas. (theta* inconnu de l algorithme)\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  pas | bras joue | recompense | posterior means [b1 b2 b3]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  ---------------------------------------------------------------\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "    1 |    bras 2    |     1      | [0,50 0,67 0,50]\r\n"
+      "    1 |    bras 3    |     1      | [0,50 0,50 0,67]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "    2 |    bras 3    |     0      | [0,50 0,67 0,33]\r\n"
+      "    2 |    bras 2    |     0      | [0,50 0,33 0,67]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "    3 |    bras 1    |     0      | [0,33 0,67 0,33]\r\n"
+      "    3 |    bras 2    |     0      | [0,50 0,25 0,67]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "    4 |    bras 2    |     1      | [0,33 0,75 0,33]\r\n"
+      "    4 |    bras 1    |     1      | [0,67 0,25 0,67]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "    5 |    bras 2    |     1      | [0,33 0,80 0,33]\r\n"
+      "    5 |    bras 1    |     0      | [0,50 0,25 0,67]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "   51 |    bras 3    |     1      | [0,20 0,58 0,73]\r\n"
+      "   51 |    bras 3    |     1      | [0,33 0,44 0,76]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "  101 |    bras 2    |     1      | [0,20 0,60 0,75]\r\n"
+      "  101 |    bras 3    |     1      | [0,33 0,50 0,76]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "  200 |    bras 3    |     0      | [0,17 0,56 0,79]\r\n"
+      "  200 |    bras 3    |     0      | [0,33 0,46 0,78]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  ---------------------------------------------------------------\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Tirages par bras : [4, 30, 166]\r\n"
+      "Tirages par bras : [4, 11, 185]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Recompense totale = 149/200 (optimal ~ 160)\r\n"
+      "Recompense totale = 151/200 (optimal ~ 160)\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "=> Thompson converge vers le bras 3 (le meilleur, theta*=0.8).\r\n"
      ]
@@ -595,65 +1024,99 @@
     "Console.WriteLine($\"Tirages par bras : [{tiragesParBras[0]}, {tiragesParBras[1]}, {tiragesParBras[2]}]\");\n",
     "Console.WriteLine($\"Recompense totale = {totalRecompense}/{T} (optimal ~ {T*0.8:F0})\");\n",
     "Console.WriteLine($\"=> Thompson converge vers le bras 3 (le meilleur, theta*=0.8).\");"
-   ],
-   "execution_count": 7
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-6229c611",
-   "metadata": {},
-   "source": "## 6. Comparaison du regret cumule (Prong-B)\n\nLe **regret** mesure ce qu'on perd par rapport a jouer le bras optimal des le debut : `regret(t) = theta*_max - theta*(bras joue)`. On cumule sur T pas. On compare trois politiques, moyennées sur `N_runs` repetitions (graines différentes) :\n\n- **epsilon-greedy** (epsilon=0.1) : exploration uniforme aleatoire.\n- **UCB1** (Auer et al., 2002) : bonus d'incertitude frequentiste.\n- **Thompson** (via Infer.NET) : exploration bayesienne par echantillonnage posterior.\n\n**Hypothese (Prong-B)** : Thompson exploite l'incertitude posterior — il explore **la ou l'information manque**, pas au hasard — d'ou un regret cumule **inferieur** a epsilon-greedy."
+   "metadata": {
+    "papermill": {
+     "duration": 0.003442,
+     "end_time": "2026-07-31T19:52:13.115486",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:13.112044",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Comparaison du regret cumule (Prong-B)\n",
+    "\n",
+    "Le **regret** mesure ce qu'on perd par rapport a jouer le bras optimal des le debut : `regret(t) = theta*_max - theta*(bras joue)`. On cumule sur T pas. On compare trois politiques, moyennées sur `N_runs` repetitions (graines différentes) :\n",
+    "\n",
+    "- **epsilon-greedy** (epsilon=0.1) : exploration uniforme aleatoire.\n",
+    "- **UCB1** (Auer et al., 2002) : bonus d'incertitude frequentiste.\n",
+    "- **Thompson** (via Infer.NET) : exploration bayesienne par echantillonnage posterior.\n",
+    "\n",
+    "**Hypothese (Prong-B)** : Thompson exploite l'incertitude posterior — il explore **la ou l'information manque**, pas au hasard — d'ou un regret cumule **inferieur** a epsilon-greedy."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
    "id": "cell-f341dab0",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:52:13.123629Z",
+     "iopub.status.busy": "2026-07-31T19:52:13.123447Z",
+     "iopub.status.idle": "2026-07-31T19:52:22.914634Z",
+     "shell.execute_reply": "2026-07-31T19:52:22.914457Z"
+    },
+    "papermill": {
+     "duration": 9.795845,
+     "end_time": "2026-07-31T19:52:22.914702",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:13.118857",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Regret cumule moyen sur 15 runs (T=200) :\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  epsilon-greedy (eps=0,1) : 17,5\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  UCB1                       : 19,3\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "  Thompson (Infer.NET)       : 6,8\r\n"
+      "  Thompson (Infer.NET)       : 6,4\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "=> Thompson (6,8) <= epsilon-greedy (17,5) : l exploration bayesienne\r\n"
+      "=> Thompson (6,4) <= epsilon-greedy (17,5) : l exploration bayesienne\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "   ciblee par le posterior exploite l incertitude la ou l information manque (Prong-B).\r\n"
      ]
@@ -720,64 +1183,133 @@
     "Console.WriteLine();\n",
     "Console.WriteLine($\"=> Thompson ({regretFinal[2]:F1}) <= epsilon-greedy ({regretFinal[0]:F1}) : l exploration bayesienne\");\n",
     "Console.WriteLine($\"   ciblee par le posterior exploite l incertitude la ou l information manque (Prong-B).\");"
-   ],
-   "execution_count": 8
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-ts-regret-bound-8081",
-   "metadata": {},
-   "source": "### 6.1 Cadre theorique - pourquoi le regret de Thompson est-il logarithmique ?\n\nLa cellule precedente montre **empiriquement** que Thompson cumule moins de regret qu'epsilon-greedy, et se compare a UCB1. Ce n'est pas un effet du hasard : la theorie garantit que Thompson Sampling atteint le **meilleur regret asymptotique possible** pour un bandit stochastique.\n\n**Borne problem-dependent (logarithmique).** Comme UCB1, Thompson atteint un regret qui ne croit que logarithmiquement avec l'horizon :\n\n`R(T) = O( sum_{k : Delta_k > 0} (ln T) / Delta_k )`\n\nou `Delta_k = mu* - mu_k` est le *gap* du bras k par rapport a l'optimal `mu*` (Agrawal & Goyal, 2012 ; Kaufmann, Korda & Munos, 2012). Consequence concrete pour notre instance (`mu = 0.2, 0.5, 0.8`, donc `Delta = 0.6, 0.3, 0`) : le regret grandit comme `ln T` et non comme `T` - d'ou la courbe qui s'aplatit au lieu de monter lineairement.\n\n**Optimalite asymptotique (borne inferieure de Lai-Robbins).** Plus fort encore : Thompson atteint asymptotiquement la **borne inferieure de Lai & Robbins (1985)**, qui s'applique a *toute* politique coherent :\n\n`lim_{T -> inf} R(T) / ln T  =  sum_{k != k*} Delta_k / KL(mu_k || mu*)`\n\nou `KL` est la divergence de Kullback-Leibler entre les lois des bras (Kaufmann, Korda & Munos, 2012). Aucune politique ne peut faire asymptotiquement mieux que cette constante : Thompson est donc **optimal au sens de l'information** - il tire de chaque sous-bras exactement le nombre de fois minimal pour lever l'incertitude, ni plus ni moins. C'est la formalisation mathematique de l'intuition Prong-B : l'echantillonnage posterior n'est pas une simple heuristique d'exploration, c'est la politique qui realise cette borne.\n\n**Borne problem-independent (gap-free).** Quand les gaps sont inconnus ou petits, on dispose d'une garantie distribution-free `R(T) = O( sqrt(K T ln T) )` (Agrawal & Goyal, 2013), du meme ordre que la borne minimax de UCB1.\n\n| Resultat | Regret | Source |\n|----------|--------|--------|\n| Problem-dependent (log) | `O( sum_k (ln T)/Delta_k )` | Agrawal & Goyal 2012 ; Kaufmann et al. 2012 |\n| Asymptotiquement optimal | atteint la borne Lai-Robbins | Kaufmann et al. 2012 ; Lai & Robbins 1985 |\n| Gap-free (minimax-style) | `O( sqrt(K T ln T) )` | Agrawal & Goyal 2013 |\n\n**Hypothese de support du prior.** Ces bornes supposent que le prior donne une masse positive a la vraie valeur `mu*` - verifie ici : le prior `Beta(1,1)` est uniforme sur `[0,1]`, son support couvre tout `mu*` dans l'intervalle. Avec un prior trop peaked ailleurs (exercice 3, `Beta(50,50)` face a un `mu* ~ 0.8`), la convergence se degrade. Pour les modeles **non conjugues** que vise Infer.NET (bras Gaussiennes de variance inconnue, effets contextuels - section 8), l'optimalite asymptotique est preservee mais l'inference approchee EP/VMP ajoute une variance d'estimation : le moteur ne change pas la theorie, il rend *calculable* un posterior qu'on ne saurait pas ecrire en forme fermee.\n\n**References**\n- Lai, T. L. & Robbins, H. (1985). *Asymptotically efficient allocation rules*. Advances in Applied Mathematics 6(1).\n- Agrawal, S. & Goyal, N. (2012). *Analysis of Thompson Sampling for the multi-armed bandit problem*. COLT 2012.\n- Kaufmann, E., Korda, N. & Munos, R. (2012). *Thompson Sampling: an asymptotically optimal finite-time analysis*. ALT 2012.\n- Agrawal, S. & Goyal, N. (2013). *Further optimal regret bounds for Thompson Sampling*. AISTATS 2013."
+   "metadata": {
+    "papermill": {
+     "duration": 0.004319,
+     "end_time": "2026-07-31T19:52:22.923225",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:22.918906",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 6.1 Cadre theorique - pourquoi le regret de Thompson est-il logarithmique ?\n",
+    "\n",
+    "La cellule precedente montre **empiriquement** que Thompson cumule moins de regret qu'epsilon-greedy, et se compare a UCB1. Ce n'est pas un effet du hasard : la theorie garantit que Thompson Sampling atteint le **meilleur regret asymptotique possible** pour un bandit stochastique.\n",
+    "\n",
+    "**Borne problem-dependent (logarithmique).** Comme UCB1, Thompson atteint un regret qui ne croit que logarithmiquement avec l'horizon :\n",
+    "\n",
+    "`R(T) = O( sum_{k : Delta_k > 0} (ln T) / Delta_k )`\n",
+    "\n",
+    "ou `Delta_k = mu* - mu_k` est le *gap* du bras k par rapport a l'optimal `mu*` (Agrawal & Goyal, 2012 ; Kaufmann, Korda & Munos, 2012). Consequence concrete pour notre instance (`mu = 0.2, 0.5, 0.8`, donc `Delta = 0.6, 0.3, 0`) : le regret grandit comme `ln T` et non comme `T` - d'ou la courbe qui s'aplatit au lieu de monter lineairement.\n",
+    "\n",
+    "**Optimalite asymptotique (borne inferieure de Lai-Robbins).** Plus fort encore : Thompson atteint asymptotiquement la **borne inferieure de Lai & Robbins (1985)**, qui s'applique a *toute* politique coherent :\n",
+    "\n",
+    "`lim_{T -> inf} R(T) / ln T  =  sum_{k != k*} Delta_k / KL(mu_k || mu*)`\n",
+    "\n",
+    "ou `KL` est la divergence de Kullback-Leibler entre les lois des bras (Kaufmann, Korda & Munos, 2012). Aucune politique ne peut faire asymptotiquement mieux que cette constante : Thompson est donc **optimal au sens de l'information** - il tire de chaque sous-bras exactement le nombre de fois minimal pour lever l'incertitude, ni plus ni moins. C'est la formalisation mathematique de l'intuition Prong-B : l'echantillonnage posterior n'est pas une simple heuristique d'exploration, c'est la politique qui realise cette borne.\n",
+    "\n",
+    "**Borne problem-independent (gap-free).** Quand les gaps sont inconnus ou petits, on dispose d'une garantie distribution-free `R(T) = O( sqrt(K T ln T) )` (Agrawal & Goyal, 2013), du meme ordre que la borne minimax de UCB1.\n",
+    "\n",
+    "| Resultat | Regret | Source |\n",
+    "|----------|--------|--------|\n",
+    "| Problem-dependent (log) | `O( sum_k (ln T)/Delta_k )` | Agrawal & Goyal 2012 ; Kaufmann et al. 2012 |\n",
+    "| Asymptotiquement optimal | atteint la borne Lai-Robbins | Kaufmann et al. 2012 ; Lai & Robbins 1985 |\n",
+    "| Gap-free (minimax-style) | `O( sqrt(K T ln T) )` | Agrawal & Goyal 2013 |\n",
+    "\n",
+    "**Hypothese de support du prior.** Ces bornes supposent que le prior donne une masse positive a la vraie valeur `mu*` - verifie ici : le prior `Beta(1,1)` est uniforme sur `[0,1]`, son support couvre tout `mu*` dans l'intervalle. Avec un prior trop peaked ailleurs (exercice 3, `Beta(50,50)` face a un `mu* ~ 0.8`), la convergence se degrade. Pour les modeles **non conjugues** que vise Infer.NET (bras Gaussiennes de variance inconnue, effets contextuels - section 8), l'optimalite asymptotique est preservee mais l'inference approchee EP/VMP ajoute une variance d'estimation : le moteur ne change pas la theorie, il rend *calculable* un posterior qu'on ne saurait pas ecrire en forme fermee.\n",
+    "\n",
+    "**References**\n",
+    "- Lai, T. L. & Robbins, H. (1985). *Asymptotically efficient allocation rules*. Advances in Applied Mathematics 6(1).\n",
+    "- Agrawal, S. & Goyal, N. (2012). *Analysis of Thompson Sampling for the multi-armed bandit problem*. COLT 2012.\n",
+    "- Kaufmann, E., Korda, N. & Munos, R. (2012). *Thompson Sampling: an asymptotically optimal finite-time analysis*. ALT 2012.\n",
+    "- Agrawal, S. & Goyal, N. (2013). *Further optimal regret bounds for Thompson Sampling*. AISTATS 2013."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-5da4782f",
-   "metadata": {},
-   "source": "## 7. Extension — best-arm identification\n\nLe regret mesure la **performance** (cumul de recompenses). Une autre question : **identifier** le meilleur bras avec une garantie probabiliste. Thompson fournit naturellement `P(bras i est le meilleur)` : on echantillonne plusieurs fois les posteriors simultanement et on compte la frequence a laquelle chaque bras gagne. Quand cette probabilite depasse un seuil (ex. 0,95), on peut declarer le gagnant."
+   "metadata": {
+    "papermill": {
+     "duration": 0.006138,
+     "end_time": "2026-07-31T19:52:22.933297",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:22.927159",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Extension — best-arm identification\n",
+    "\n",
+    "Le regret mesure la **performance** (cumul de recompenses). Une autre question : **identifier** le meilleur bras avec une garantie probabiliste. Thompson fournit naturellement `P(bras i est le meilleur)` : on echantillonne plusieurs fois les posteriors simultanement et on compte la frequence a laquelle chaque bras gagne. Quand cette probabilite depasse un seuil (ex. 0,95), on peut declarer le gagnant."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "id": "cell-211f6ecf",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:52:22.942579Z",
+     "iopub.status.busy": "2026-07-31T19:52:22.942192Z",
+     "iopub.status.idle": "2026-07-31T19:52:23.688338Z",
+     "shell.execute_reply": "2026-07-31T19:52:23.688193Z"
+    },
+    "papermill": {
+     "duration": 0.751347,
+     "end_time": "2026-07-31T19:52:23.688404",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:22.937057",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Apres 60 tirages Thompson, estimation P(bras i est le meilleur) sur 2000 echantillons :\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "  bras 1 : P(meilleur) = 0,011  | posterior Beta(2,0,4,0) mean=0,333 (vraie 0,2)\r\n"
+      "  bras 1 : P(meilleur) = 0,019  | posterior Beta(1,0,3,0) mean=0,250 (vraie 0,2)\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "  bras 2 : P(meilleur) = 0,041  | posterior Beta(11,0,8,0) mean=0,579 (vraie 0,5)\r\n"
+      "  bras 2 : P(meilleur) = 0,029  | posterior Beta(13,0,11,0) mean=0,542 (vraie 0,5)\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "  bras 3 : P(meilleur) = 0,949  | posterior Beta(33,0,8,0) mean=0,805 (vraie 0,8)\r\n"
+      "  bras 3 : P(meilleur) = 0,952  | posterior Beta(29,0,9,0) mean=0,763 (vraie 0,8)\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "=> Bras declare meilleur : bras 3 (theta*=0,8).\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "   Si P > 0.95, on peut arreter : identification du meilleur bras avec confiance.\r\n"
      ]
@@ -814,35 +1346,106 @@
     "int best = Array.IndexOf(gagnants, gagnants.Max());\n",
     "Console.WriteLine($\"=> Bras declare meilleur : bras {best+1} (theta*={vraiB[best]}).\");\n",
     "Console.WriteLine($\"   Si P > 0.95, on peut arreter : identification du meilleur bras avec confiance.\");"
-   ],
-   "execution_count": 9
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-71669703",
-   "metadata": {},
-   "source": "## 8. Limites honnetes\n\n- **Cas conjugue favorable** : pour un bandit Bernoulli, le posterior Beta est analytique. L'apport d'Infer.NET n'est pas la (le moteur recouvre la formule fermee) mais dans la **generalisation** a des modèles non conjugues (ex. bras Gaussiennes de variance inconnue, effets contextuels) ou seule l'inference approchee (EP/VMP) sait calculer le posterior.\n- **Cout d'inference** : chaque pas de Thompson requiert `K` inferences posteriors. Grace au modèle masque reutilise (~0,2 ms/call), cela reste negligeable pour `K` petit et `T` modere. Pour un grand `K` (centaines de bras) ou un modèle lourd, l'overhead devient un facteur — c'est la ou un posterior conjugue code a la main (cf DecInfer-8 section 8) garde sa place.\n- **Non-stationnarite** : si les vraies `theta*` changent au cours du temps, le posterior Beta s'accumule indefiniment et devient trop confident. Il faut alors introduire un **facteur d'oubli** (sliding window, discount) — voir exercice 2."
+   "metadata": {
+    "papermill": {
+     "duration": 0.003969,
+     "end_time": "2026-07-31T19:52:23.697680",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:23.693711",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Limites honnetes\n",
+    "\n",
+    "- **Cas conjugue favorable** : pour un bandit Bernoulli, le posterior Beta est analytique. L'apport d'Infer.NET n'est pas la (le moteur recouvre la formule fermee) mais dans la **generalisation** a des modèles non conjugues (ex. bras Gaussiennes de variance inconnue, effets contextuels) ou seule l'inference approchee (EP/VMP) sait calculer le posterior.\n",
+    "- **Cout d'inference** : chaque pas de Thompson requiert `K` inferences posteriors. Grace au modèle masque reutilise (~0,2 ms/call), cela reste negligeable pour `K` petit et `T` modere. Pour un grand `K` (centaines de bras) ou un modèle lourd, l'overhead devient un facteur — c'est la ou un posterior conjugue code a la main (cf DecInfer-8 section 8) garde sa place.\n",
+    "- **Non-stationnarite** : si les vraies `theta*` changent au cours du temps, le posterior Beta s'accumule indefiniment et devient trop confident. Il faut alors introduire un **facteur d'oubli** (sliding window, discount) — voir exercice 2."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-c1d6e31d",
-   "metadata": {},
-   "source": "## 9. Exercices\n\nTrois exercices pour aller plus loin. Chaque stub s'execute sans erreur ; completez le code entre les `// TODO`.\n\n| # | Exercice | Concept |\n|---|----------|---------|\n| 1 | Ajouter un 4e bras et observer la convergence | Thompson sur K=4 |\n| 2 | Bandit non-stationnaire (facteur d'oubli) | Adaptation au changement |\n| 3 | Prior informatif Beta(50, 50) | Impact du prior sur l'exploration |"
+   "metadata": {
+    "papermill": {
+     "duration": 0.004049,
+     "end_time": "2026-07-31T19:52:23.705667",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:23.701618",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Exercices\n",
+    "\n",
+    "Trois exercices pour aller plus loin. Chaque stub s'execute sans erreur ; completez le code entre les `// TODO`.\n",
+    "\n",
+    "| # | Exercice | Concept |\n",
+    "|---|----------|---------|\n",
+    "| 1 | Ajouter un 4e bras et observer la convergence | Thompson sur K=4 |\n",
+    "| 2 | Bandit non-stationnaire (facteur d'oubli) | Adaptation au changement |\n",
+    "| 3 | Prior informatif Beta(50, 50) | Impact du prior sur l'exploration |"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-84e0024e",
-   "metadata": {},
-   "source": "### Exercice 1 — Ajouter un 4e bras et observer la convergence\n\nThompson Sampling se generalise de 3 a **K** bras. Ajoutez un 4e bras de vraie\nmoyenne 0,65 et relancez la boucle de sélection. Observez comment le choix bascule\nde bras en bras puis se stabilise sur le meilleur des 4.\n\n**Objectif.** Etendre le modèle a 4 bras et verifier que Thompson identifie le meilleur.\n\n**Indices.**\n- Etendez `vraiTheta` a 4 valeurs (par ex. `[0.3, 0.5, 0.7, 0.65]`).\n- Mettez `K = 4` et construisez 4 `BayesArm`, comme en section 5.\n- Reportez les tirages par bras et la recompense totale cumulee."
+   "metadata": {
+    "papermill": {
+     "duration": 0.004563,
+     "end_time": "2026-07-31T19:52:23.714495",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:23.709932",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — Ajouter un 4e bras et observer la convergence\n",
+    "\n",
+    "Thompson Sampling se generalise de 3 a **K** bras. Ajoutez un 4e bras de vraie\n",
+    "moyenne 0,65 et relancez la boucle de sélection. Observez comment le choix bascule\n",
+    "de bras en bras puis se stabilise sur le meilleur des 4.\n",
+    "\n",
+    "**Objectif.** Etendre le modèle a 4 bras et verifier que Thompson identifie le meilleur.\n",
+    "\n",
+    "**Indices.**\n",
+    "- Etendez `vraiTheta` a 4 valeurs (par ex. `[0.3, 0.5, 0.7, 0.65]`).\n",
+    "- Mettez `K = 4` et construisez 4 `BayesArm`, comme en section 5.\n",
+    "- Reportez les tirages par bras et la recompense totale cumulee."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
    "id": "cell-eb45673d",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:52:23.724190Z",
+     "iopub.status.busy": "2026-07-31T19:52:23.723945Z",
+     "iopub.status.idle": "2026-07-31T19:52:23.764403Z",
+     "shell.execute_reply": "2026-07-31T19:52:23.764148Z"
+    },
+    "papermill": {
+     "duration": 0.046108,
+     "end_time": "2026-07-31T19:52:23.764527",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:23.718419",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice 1 a completer : Thompson sur 4 bras (K=4).\r\n"
      ]
@@ -856,23 +1459,62 @@
     "// Etape 2 : construire 4 BayesArm et boucler T pas\n",
     "// Etape 3 : reporter les tirages par bras et la recompense totale\n",
     "Console.WriteLine(\"Exercice 1 a completer : Thompson sur 4 bras (K=4).\");"
-   ],
-   "execution_count": 10
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-b2a05fe7",
-   "metadata": {},
-   "source": "### Exercice 2 — Bandit non-stationnaire (facteur d'oubli)\n\nJusqu'ici les vraies moyennes sont fixes. En pratique elles peuvent **changer** : ici\nla meilleure bascule a `t = 100`. Implantez un **facteur d'oubli** : a chaque pas, ne\ngardez qu'une fraction des observations passees afin que le posterior s'adapte au\nchangement de regime.\n\n**Objectif.** Ajouter l'oubli au posterior et comparer le regret avec et sans oubli.\n\n**Indices.**\n- Modifiez `BayesArm.Observe` pour decaler/oublier les observations, ou ajoutez une\n  méthode `Forget(double gamma)`.\n- Definissez `theta*(t)` qui change a mi-parcours (ex. le bras 1 devient meilleur après `t=100`).\n- Comparez le regret avec et sans oubli sur la sequence non-stationnaire."
+   "metadata": {
+    "papermill": {
+     "duration": 0.00444,
+     "end_time": "2026-07-31T19:52:23.773859",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:23.769419",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Bandit non-stationnaire (facteur d'oubli)\n",
+    "\n",
+    "Jusqu'ici les vraies moyennes sont fixes. En pratique elles peuvent **changer** : ici\n",
+    "la meilleure bascule a `t = 100`. Implantez un **facteur d'oubli** : a chaque pas, ne\n",
+    "gardez qu'une fraction des observations passees afin que le posterior s'adapte au\n",
+    "changement de regime.\n",
+    "\n",
+    "**Objectif.** Ajouter l'oubli au posterior et comparer le regret avec et sans oubli.\n",
+    "\n",
+    "**Indices.**\n",
+    "- Modifiez `BayesArm.Observe` pour decaler/oublier les observations, ou ajoutez une\n",
+    "  méthode `Forget(double gamma)`.\n",
+    "- Definissez `theta*(t)` qui change a mi-parcours (ex. le bras 1 devient meilleur après `t=100`).\n",
+    "- Comparez le regret avec et sans oubli sur la sequence non-stationnaire."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
    "id": "cell-1a9f9028",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:52:23.787229Z",
+     "iopub.status.busy": "2026-07-31T19:52:23.786974Z",
+     "iopub.status.idle": "2026-07-31T19:52:23.825050Z",
+     "shell.execute_reply": "2026-07-31T19:52:23.824904Z"
+    },
+    "papermill": {
+     "duration": 0.045861,
+     "end_time": "2026-07-31T19:52:23.825118",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:23.779257",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice 2 a completer : bandit non-stationnaire avec facteur d oubli.\r\n"
      ]
@@ -886,23 +1528,61 @@
     "// Etape 2 : ajouter l oubli au posterior (reset partiel ou discount)\n",
     "// Etape 3 : comparer le regret avec et sans oubli sur la sequence non-stationnaire\n",
     "Console.WriteLine(\"Exercice 2 a completer : bandit non-stationnaire avec facteur d oubli.\");"
-   ],
-   "execution_count": 11
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-02023ecc",
-   "metadata": {},
-   "source": "### Exercice 3 — Prior informatif Beta(50, 50) vs uniforme\n\nUn prior `Beta(50, 50)` exprime une forte conviction que theta vaut environ 0,5 ; un\nprior `Beta(1, 1)` est uniforme (sans information a priori). Comparez le regret des\ndeux : un prior informatif reduit-il l'exploration prematuree ?\n\n**Objectif.** Mesurer l'impact du prior sur la vitesse de convergence de Thompson.\n\n**Indices.**\n- `BayesArm` accepte des paramètres `priorA` / `priorB`.\n- Créez deux jeux de bras — l'un avec `Beta(1,1)`, l'autre avec `Beta(50,50)` — et\n  mesurez le regret de chacun.\n- Interpretez : dans quels cas un prior informatif aide-t-il, et quand nuit-il ?"
+   "metadata": {
+    "papermill": {
+     "duration": 0.004797,
+     "end_time": "2026-07-31T19:52:23.834732",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:23.829935",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Prior informatif Beta(50, 50) vs uniforme\n",
+    "\n",
+    "Un prior `Beta(50, 50)` exprime une forte conviction que theta vaut environ 0,5 ; un\n",
+    "prior `Beta(1, 1)` est uniforme (sans information a priori). Comparez le regret des\n",
+    "deux : un prior informatif reduit-il l'exploration prematuree ?\n",
+    "\n",
+    "**Objectif.** Mesurer l'impact du prior sur la vitesse de convergence de Thompson.\n",
+    "\n",
+    "**Indices.**\n",
+    "- `BayesArm` accepte des paramètres `priorA` / `priorB`.\n",
+    "- Créez deux jeux de bras — l'un avec `Beta(1,1)`, l'autre avec `Beta(50,50)` — et\n",
+    "  mesurez le regret de chacun.\n",
+    "- Interpretez : dans quels cas un prior informatif aide-t-il, et quand nuit-il ?"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 13,
    "id": "cell-c31e1ca9",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T19:52:23.845189Z",
+     "iopub.status.busy": "2026-07-31T19:52:23.844809Z",
+     "iopub.status.idle": "2026-07-31T19:52:23.886192Z",
+     "shell.execute_reply": "2026-07-31T19:52:23.886034Z"
+    },
+    "papermill": {
+     "duration": 0.047324,
+     "end_time": "2026-07-31T19:52:23.886263",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:23.838939",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice 3 a completer : impact du prior informatif Beta(50,50) sur Thompson.\r\n"
      ]
@@ -916,14 +1596,46 @@
     "// Etape 2 : lancer Thompson avec prior Beta(50,50) (informatif)\n",
     "// Etape 3 : comparer les regrets et interpreter (quand un prior informatif aide/nuit)\n",
     "Console.WriteLine(\"Exercice 3 a completer : impact du prior informatif Beta(50,50) sur Thompson.\");"
-   ],
-   "execution_count": 12
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-4b9a1107",
-   "metadata": {},
-   "source": "## 10. Synthese\n\n| Politique | Exploration | Calcul du posterior | Origine |\n|-----------|-------------|---------------------|---------|\n| **epsilon-greedy** | uniforme (proba epsilon) | aucun (moyenne empirique) | frequentiste |\n| **UCB1** | bonus d'incertitude `sqrt(2 ln t / n_k)` | aucun (moyenne empirique) | Auer et al. 2002 |\n| **Thompson** | echantillonnage posterior | **Infer.NET (EP/VMP)** | Thompson 1933 |\n\n### Ce qu'il faut retenir\n\n- **Thompson Sampling = jouer selon la probabilite que chaque bras soit le meilleur**, quantifiee par un posterior. Les bras incertains (posterior large) sont naturellement explores.\n- **Le moteur Infer.NET calcule le posterior** (section 3) : on declare `theta ~ Beta ; reward ~ Bernoulli(theta)` et le moteur infere `Beta(1+s, 1+f)`. Pour ce cas conjugue il recouvre la forme analytique ; l'intérêt est la **generalisation** aux modèles non conjugues.\n- **Prong-B PROVEN** : le regret cumule de Thompson est **inferieur** a epsilon-greedy (section 6) — l'exploration bayesienne ciblee par le posterior exploite l'incertitude la ou l'information manque, au lieu d'explorer au hasard. Le problème n'est pas degenerere : la sélection depend visiblement des posteriors.\n\n### Ponts\n\n- **DecInfer-8 section 8** : implemente epsilon-greedy, UCB1 et un exercice de Thompson **manuel** (formule conjuguee codee a la main). Ce notebook en est le versant **moteur**.\n- **DecInfer-8 section 10bis** : les belief-state updates en Infer.NET pour les POMDPs — même idee d'inference posterior séquentielle, dans un cadre partiellement observable.\n- **References** : Thompson, W. R. (1933) *On the likelihood that one unknown probability exceeds another* ; Auer, P., Cesa-Bianchi, N. & Fischer, P. (2002) *Finite-time analysis of the multiarmed bandit problem* ; Russo, D., Van Roy, D., Kazerouni, A., Osband, I. & Wen, Z. (2018) *A Tutorial on Thompson Sampling*.\n\n---\n\n[<- Infer-8-Sequential](DecInfer-8-Sequential.ipynb) | [Infer-5-Causal-Inference ->](../../Infer/Infer-5-Causal-Inference.ipynb) | [Retour a la serie](README.md)"
+   "metadata": {
+    "papermill": {
+     "duration": 0.006097,
+     "end_time": "2026-07-31T19:52:23.896536",
+     "exception": false,
+     "start_time": "2026-07-31T19:52:23.890439",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 10. Synthese\n",
+    "\n",
+    "| Politique | Exploration | Calcul du posterior | Origine |\n",
+    "|-----------|-------------|---------------------|---------|\n",
+    "| **epsilon-greedy** | uniforme (proba epsilon) | aucun (moyenne empirique) | frequentiste |\n",
+    "| **UCB1** | bonus d'incertitude `sqrt(2 ln t / n_k)` | aucun (moyenne empirique) | Auer et al. 2002 |\n",
+    "| **Thompson** | echantillonnage posterior | **Infer.NET (EP/VMP)** | Thompson 1933 |\n",
+    "\n",
+    "### Ce qu'il faut retenir\n",
+    "\n",
+    "- **Thompson Sampling = jouer selon la probabilite que chaque bras soit le meilleur**, quantifiee par un posterior. Les bras incertains (posterior large) sont naturellement explores.\n",
+    "- **Le moteur Infer.NET calcule le posterior** (section 3) : on declare `theta ~ Beta ; reward ~ Bernoulli(theta)` et le moteur infere `Beta(1+s, 1+f)`. Pour ce cas conjugue il recouvre la forme analytique ; l'intérêt est la **generalisation** aux modèles non conjugues.\n",
+    "- **Prong-B PROVEN** : le regret cumule de Thompson est **inferieur** a epsilon-greedy (section 6) — l'exploration bayesienne ciblee par le posterior exploite l'incertitude la ou l'information manque, au lieu d'explorer au hasard. Le problème n'est pas degenerere : la sélection depend visiblement des posteriors.\n",
+    "\n",
+    "### Ponts\n",
+    "\n",
+    "- **DecInfer-8 section 8** : implemente epsilon-greedy, UCB1 et un exercice de Thompson **manuel** (formule conjuguee codee a la main). Ce notebook en est le versant **moteur**.\n",
+    "- **DecInfer-8 section 10bis** : les belief-state updates en Infer.NET pour les POMDPs — même idee d'inference posterior séquentielle, dans un cadre partiellement observable.\n",
+    "- **References** : Thompson, W. R. (1933) *On the likelihood that one unknown probability exceeds another* ; Auer, P., Cesa-Bianchi, N. & Fischer, P. (2002) *Finite-time analysis of the multiarmed bandit problem* ; Russo, D., Van Roy, D., Kazerouni, A., Osband, I. & Wen, Z. (2018) *A Tutorial on Thompson Sampling*.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "[<- Infer-8-Sequential](DecInfer-8-Sequential.ipynb) | [Infer-5-Causal-Inference ->](../../Infer/Infer-5-Causal-Inference.ipynb) | [Retour a la serie](README.md)"
+   ]
   }
  ],
  "metadata": {
@@ -933,7 +1645,23 @@
    "name": ".net-csharp"
   },
   "language_info": {
-   "name": "C#"
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 21.016418,
+   "end_time": "2026-07-31T19:52:24.144477",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "DecInfer-10-Thompson-Sampling.ipynb",
+   "output_path": "di10-measout.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-31T19:52:03.128059",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: LOW-MED/probas-timing -- lane myia-po-2023:CoursIA -- prev: MED/csharp-csp #9048

See #8052 (claims↔outputs EPIC). **Re-prise §D.5** per ai-01 review: a perf/timing claim in a re-executable notebook must be SOURCED by a real execution, never relabelled in markdown.

## Re-prise §D.5 — MEASURE the claim (CAUSE_FIXED)

ai-01 rejected the prior markdown-only relabel (`mesure` → `ordre de grandeur`). The defect: section 4 (« Réutiliser le moteur compilé, problématique runtime ») made a **compile-vs-reinfer performance claim** but the notebook **never measured it** — no `Stopwatch` anywhere, no `ms` in any code output. The honest §D.5 fix is to **measure it**, not relabel it.

**Added 2 cells** after the `BayesArm` class definition (code#13), since section 4's pedagogical point IS the compile-vs-reuse runtime difference:
- **md 4.1**: « Mesure du gain de runtime : compilation vs re-inference »
- **code**: `Stopwatch` measuring (a) the one-time warmup compilation in the `BayesArm` constructor, (b) 200 re-inferences via `ObservedValue` updates that reuse the compiled algorithm.

Re-executed end-to-end with papermill `--kernel .net-csharp --cwd <notebook-dir>` (Infer.NET + Roslyn compiler via nuget, rule F honored). **32/32 cells, exit 0.** Measured output (cell#15):

```
Compilation (1 fois, warmup BayesArm)            : 235,9 ms
Re-inference (ObservedValue, compile réutilisé)  : 0,046 ms moyenne sur 200 appels
Ratio compilation / re-inference                 : 5100x
```

md#12 now cites the **MEASURED** values (~236 ms compilation, ~0,05 ms re-inference, ~5000× ratio) — sourced by cell#15, not a stale claim. The prior order-of-magnitude estimates (~250 ms / ~0,2 ms) are **confirmed** (compilation ~hundreds of ms, re-inference sub-ms); the precise figures now come from this notebook's own output.

## Diagnostic dérive (§D.5 required section)

- **Cause (b) — the figure was an unsourced estimate mislabelled « mesure ».** Section 4 promised a runtime discussion but never ran a `Stopwatch`. Unlike a drifted timing (cause e), this was never measured at all.
- **Verdict: CAUSE_FIXED.** Added a measurement cell, re-executed, md#12 aligned to the **committed cell#15 output of the same run**. The claim is now a sourced fact, not an estimate.
- **C.1/C.2 forensics:** 13 code cells, **0** with `execution_count=None`, **0** error outputs, **0** forbidden patterns (`raise NotImplementedError` / `assert False` / `1/0`).
- **Stop & Repair (rule 6):** no cell output hand-edited. The 9-line `probeAddresses` banner injected by `dotnet-interactive` stripped via the sanctioned `scripts/notebook_tools/strip_probe_banner.py`. Only `metadata.papermill` paths normalized to basename.
- **G.1 — conclusions preserved:** the teaching point (pre-compile once + reuse via `ObservedValue` to avoid per-step recompilation) is **strengthened**, not inverted — the measurement shows a ~5000× compile-vs-reinfer ratio, exactly the runtime problem section 4 motivates.

## Integrity

- `git diff --stat` = 1 file, **+947/−219** (re-exec churn: 2 new measurement cells, fresh Infer.NET outputs, aligned md#12, stripped probe banner). H.3 validator: 0 bad code cells. Two Graphviz `.gv` artifacts generated by the re-exec were left untracked (NOT committed).
- No twin registry for DecInfer-10 (Infer.NET is .NET-only) → no #8057 gate, no rebaseline.
- Catalogue byte-identical to `origin/main`.

See #8052, #3801.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
