### PR TITLE
fix(planners,#8052): Planners-5-Csharp md#9 h^max value 3 -> 1 (confused with h^add)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics-Csharp.ipynb
@@ -419,7 +419,7 @@
     "\n",
     "But `{on_1, on_2, on_3}`, trois actions independantes `turn_on_i : {off_i} -> {on_i}` (cout 1 chacune).\n",
     "Cout optimal reel $h^* = 3$. Sur cette instance les **deux** heuristiques sont admissibles (3 interrupteurs\n",
-    "independants -> pas d'enabler partage) : $h^{max} = 3$, $h^{add} = 3$."
+    "independants -> pas d'enabler partage) : $h^{max} = 1$ (max des trois couts unitaires), $h^{add} = 3$."
    ]
   },
   {


### PR DESCRIPTION
Grain: HIGH/planners-heuristic -- lane myia-po-2023:CoursIA -- prev: LOW-MED/probas-timing #9053

## Defect (EPIC #8052 — claims↔outputs)

`Planners-5-Heuristics-Csharp.ipynb` cell **md#9** (§3.4 "Comparaison h^max vs h^add : trois interrupteurs") states for the 3-independent-switches instance:
> Cout optimal reel $h^* = 3$. ... les **deux** heuristiques sont admissibles ... : **$h^{max} = 3$**, $h^{add} = 3$.

The committed **CODE[10]** output reads:
```
h^max       : 1
h^add       : 3
h* (optimal): 3
h^max admissible ? True
h^add admissible ? True
```
- `h^add = 3` → **correct**
- `h^max = 3` → **WRONG** (code says **1**)

## Root cause (#8364)

The author confused **h^max** (MAX of subgoal costs) with **h^add** (SUM). For three independent subgoals each cost 1:
- `h^max = max(1,1,1) = 1` ← code is correct
- `h^add = 1+1+1 = 3`
- `h* = 3` (must execute all three)

The planner is deterministic (notebook labels it "deterministe, reproductible"), so the committed output is the ground truth; the markdown drifted (h^add value written into the h^max slot).

## Fix = report-the-truth markdown alignment

Code + output are correct; only the prose number is wrong. Corrected `$h^{max} = 3$` → `$h^{max} = 1$ (max des trois couts unitaires)`. The parenthetical makes the max-vs-sum distinction explicit — precisely the confusion that caused the drift and the notebook's central teaching point. `h^add = 3` unchanged.

## G.1 check

The conclusion **"les deux heuristiques sont admissibles (3 interrupteurs independants -> pas d'enabler partage)"** still holds with the true numbers: `h^max=1 ≤ h*=3` (admissible), `h^add=3 ≤ h*=3` (admissible — no shared enabler to double-count). Only the stated h^max value is corrected; no conclusion inverted.

## Twin parity + collision

- The **Python twin** `Planners-5-Heuristics.ipynb` correctly shows `h^max=1` here (no contradicting markdown) → this fix **restores C#-twin parity**.
- **Distinct from #8987** (OPEN, po-2024): that fixes the **Python twin**'s `h^FF=2` on the **shared-precondition instance** (§3.5). This PR fixes the **C# twin**'s `h^max=3` on the **3-independent-switches instance** (§3.4). Different notebook, section, heuristic, and instance.

## Forensic (C.2 markdown-only exemption)

| Metric | Value |
|--------|-------|
| code cells changed | **0** |
| markdown cells changed | 1 (md#9) |
| execution/output cells changed | **0** |
| diff | 1 insertion, 1 deletion |

See #8052