### PR TITLE
fix(sl,#8052): SL-4-ILP plan table says 3 exercices (4 exist) + comment says 10+ triples (KG has 9)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
@@ -136,7 +136,7 @@
     "| 4. Resolution inverse | Opérateurs V et W | 10 min |\n",
     "| 5. Ancetres | Application complete | 10 min |\n",
     "| 6. Knowledge Graphs | Connexion SemanticWeb | 8 min |\n",
-    "| 7. Exercices | 3 exercices pratiques | 7 min |"
+    "| 7. Exercices | 4 exercices pratiques | 7 min |"
    ]
   },
   {
@@ -2256,7 +2256,7 @@
     "# a la maniere d'AMIE. Representation : un KG est un ensemble de triples\n",
     "# (sujet, predicat, objet).\n",
     "\n",
-    "# Etape 1 : un mini-KG familial (10+ triples). On reintroduit la famille Arthur,\n",
+    "# Etape 1 : un mini-KG familial (9 triples). On reintroduit la famille Arthur,\n",
     "# avec un fait grandparent MANQUANT (Bob -> George) pour illustrer la confiance.\n",
     "KG = {\n",
     "    (\"Arthur\", \"parent\", \"Bob\"),\n",

--- a/scripts/notebook_tools/twin_pairs.d/sl-4-inductivelogicprogramming.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-4-inductivelogicprogramming.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming-Csharp.ipynb
   parity_level: surface
   last_audit:
-    date: "2026-07-27"
+    date: "2026-07-31"
     by: po-2024
-    python_sha: 0ed758211c39538ea201d12fce5563b1473bd107
+    python_sha: 795040c265ec073893f2ec2a3597a78285cdf11c
     csharp_sha: ea011ad638e69c982deb3f508e45841b3d71a75a
   known_differences:
     - "AVERTISSEMENT D'INGENIERIE : parity_level=surface car le jumeau Python INVOQUE un vrai moteur ILP SOTA (SWI-Prolog via pyswip + reference a Popper 'Learning From Failures') tandis que le C# reimplémente FOIL from-scratch (pas de moteur Prolog). Meme concept pedagogique, machineries differentes."


### PR DESCRIPTION
fix(sl,#8052): SL-4-ILP plan table says "3 exercices" (4 exist) + comment says "10+ triples" (KG has 9)

Two count defects in SL-4-InductiveLogicProgramming, both contradicting the notebook's
own committed output/structure. Markdown + comment only (no re-exec).

## Defect 1 (cell[2], plan table, count)

- Claim: "| 7. Exercices | **3 exercices** pratiques | 7 min |"
- Ground truth: four student exercise code cells --- cell[32] "# Exercice : offspring
  avec FOIL", cell[36] "# Exercice : Operateur W sur un tournoi", cell[40] "# Exercice :
  TRANSITIVITE sur un KG", cell[44] "# Exercice : great-grandparent" --- each with its own
  "### A votre tour" header (cells 31, 35, 39, 43). There are 4 exercises, not 3.
- Fix: "3 exercices pratiques" -> "4 exercices pratiques".

## Defect 2 (cell[38], comment, count)

- Claim: "# Etape 1 : un mini-KG familial (**10+ triples**)."
- Ground truth (cell[38] own output, first line): "KG : **9** triples, predicats =
  ['grandparent', 'parent']" --- the KG set has 6 parent + 3 grandparent = 9 triples.
- Fix: "10+ triples" -> "9 triples" (comment only; output unaffected).

## Verification

Firsthand (#8052 claims<->executed-output lens): read cell[2] plan table + counted the 4
exercise code cells + 4 "A votre tour" headers (32/36/40/44, 31/35/39/43); read cell[38]
source comment + output "KG : 9 triples". Canonical JSON round-trip byte-identical
pre/post; diff 2 elements (1 markdown table cell + 1 comment). Markdown/comment only, no
re-exec. cell[38] output sanity: still prints "KG : 9 triples".

## DEFER (judgment-call, c.1052-L)

SL-4 cell[41] heading "### Exercice 4 : grandparent avec Popper" is actually a SOLVED
guided example (cell[42] "# Exemple guide ... grandparent" with passing assert). Renaming
it to "### Exemple guide" would cascade into the cell[46] Defi table "Ex. 4" numbering ---
multi-cell relabel beyond a clean claim-vs-output fix. DEFER.

## Twin rebaseline

SL-4 is a surface-parity twin (sl-4-inductivelogicprogramming.yaml). The fix is Python-only;
registry python_sha rebaselined (0ed75821 -> 795040c2), csharp_sha unchanged (ea011ad6).
check_twin_parity --check -> OK at HEAD post-commit.

See #8052 (semantic-sampling audit, SymbolicLearning slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
