### PR TITLE
fix(qc,#8052): QC-Py-07 position-sizing table 10x error (50x->5x leverage)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
@@ -1662,7 +1662,7 @@
     "- Stop plus large = Moins de contrats\n",
     "- **Toujours calculer AVANT d'entrer**\n",
     "\n",
-    "⚠️ **Attention** : Ce tableau montre que le leverage effectif peut monter à 50x avec un stop serré. C'est pourquoi il est recommandé de limiter le leverage effectif à 5-10x maximum."
+    "⚠️ **Attention** : Ce tableau montre que le leverage effectif peut monter à 5x avec un stop serré. C'est pourquoi il est recommandé de limiter le leverage effectif à 5-10x maximum."
    ],
    "metadata": {}
   },
@@ -1864,10 +1864,12 @@
     "\n",
     "| Stop Loss (ES) | Contrats | Exposure | Leverage Effectif |\n",
     "|----------------|----------|----------|-------------------|\n",
-    "| 10 points | 20 | $5M | 50x |\n",
-    "| 20 points | 10 | $2.5M | 25x |\n",
-    "| 50 points | 4 | $1M | 10x |\n",
-    "| 100 points | 2 | $500k | 5x |\n",
+    "| 10 points | 2 | $500k | 5.0x |\n",
+    "| 20 points | 1 | $250k | 2.5x |\n",
+    "| 50 points | 1 | $250k | 2.5x |\n",
+    "| 100 points | 1 | $250k | 2.5x |\n",
+    "\n",
+    "> **Note** : au-dela de 20 points, la formule donne moins d'un contrat ; la taille est **capee a 1 contrat minimum**, d'ou un leverage constant de 2.5x (cf. sortie code ci-dessus).\n",
     "\n",
     "> **Recommandation** : Viser un leverage effectif de 5x a 10x maximum."
    ]


### PR DESCRIPTION
Grain: G1/claims-outputs -- lane myia-po-2023:CoursIA -- prev: G1/claims-outputs #9055 (DecInfer-4)

## Défaut #8052 (claims vs outputs) — HIGH sévérité

Le tableau de position sizing (MD#66) sur-estime contrats/exposure/leverage d'un facteur **10×** pour les MÊMES paramètres ($100k, 1% risque) que la cellule code productrice (CODE#65).

| Stop | MD#66 (faux) | CODE#65 output (vérité, 1% risk) |
|------|-------------|----------------------------------|
| 10 pts | 20 contrats / $5M / **50x** | 2 contrats / $500k / **5.0x** |
| 20 pts | 10 / $2.5M / 25x | 1 / $250k / 2.5x |
| 50 pts | 4 / $1M / 10x | 1 / $250k / 2.5x (capé) |
| 100 pts | 2 / $500k / 5x | 1 / $250k / 2.5x (capé) |

## Diagnostic #8364 (cause racine, pas cosmétique)

Les lignes du tableau matchent exactement $(Capital×**10%**)/(stop×mult) — le tableau a été construit avec **risk=10%** mais étiqueté **1%**. CODE#65 est correct selon la formule (l'exemple travaillé MD#60 donne aussi 20pts → 1 contrat) : risk_amount=$1000, risk_per_contract(10pts)=$500 → 2 contrats. **Ground truth = output committé.**

## Correction (report-the-truth, markdown-only)

- **MD#66 tableau** → 2/1/1/1 contrats à 1% risk (+ note : au-delà de 20 pts la formule donne <1 contrat, taille capée à 1 contrat minimum, d'où leverage constant 2.5x).
- **MD#60 caveat** « leverage peut monter à 50x » → « 5x » (le vrai maximum corrigé).

## Intégrité

- Markdown-only : 7 ins / 5 del. CODE#65 + outputs **byte-identical** (0 churn). Pas de re-exec (ground truth = output committé).
- Catalogue byte-identical à main.
- **Recommandation « 5x-10x max » préservée** (le max corrigé 5x est à la borne inférieure). Un notebook de trading enseignant 50x de leverage au lieu de 5x était matériellement faux.

See #8052

Co-Authored-By: Claude-Code <noreply@anthropic.com>