### PR TITLE
fix(sl,#8052): SL-8 self-contradicts its own ILP-vs-KG cross-ref + mislabels Jean/Claire generation (2 cells)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-KnowledgeGraphs-ILP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-KnowledgeGraphs-ILP.ipynb
@@ -337,7 +337,7 @@
     "| `marriedTo` | 2 | Lien mariage (symetrique) |\n",
     "\n",
     "**Points cles** :\n",
-    "1. `grandparentOf` est **incomplet** : seuls 5 triples sur les 14 possibles sont presents (les grands-parents des generations 1 et 2 -- Jean, Claire -- n'ont aucun triple)\n",
+    "1. `grandparentOf` est **incomplet** : seuls 5 triples sur les 14 possibles sont presents (les grands-parents de la generation 1 -- Jean, Claire -- n'ont aucun triple)\n",
     "2. C'est exactement la situation ou le rule mining est utile : **completer les données manquantes**\n",
     "3. Si on peut decouvrir la règle `parentOf(X,Y) ^ parentOf(Y,Z) => grandparentOf(X,Z)`, on pourra inferer les 9 triples manquants\n",
     "\n",
@@ -1552,7 +1552,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ILP Classique (SL-4) vs Rule Mining sur KG (SL-6)"
+      "ILP Classique (SL-4) vs Rule Mining sur KG (SL-8)"
      ]
     },
     {
@@ -1584,7 +1584,7 @@
    ],
    "source": [
     "# Comparative analysis table\n",
-    "print(\"ILP Classique (SL-4) vs Rule Mining sur KG (SL-6)\")\n",
+    "print(\"ILP Classique (SL-4) vs Rule Mining sur KG (SL-8)\")\n",
     "print(\"=\" * 65)\n",
     "print()\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/sl-8-knowledgegraphs-ilp.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-8-knowledgegraphs-ilp.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-KnowledgeGraphs-ILP-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-27"
+    date: "2026-07-31"
     by: po-2024
-    python_sha: 4ecd9674b07192aedfa58e35dda8bb327cc17ab9
+    python_sha: 9676659f00897939293e7bb0b36c5073ad89eb93
     csharp_sha: 376249822ecee95d86a8d1f806a99b7595486bc7
   known_differences:
     - "Socle commun : ILP moderne sur Knowledge Graphs -- construction du KG familial, extraction des relations, rule mining (decouverte de regles de Horn), enumeration des candidats, passage des regles d'association aux regles logiques, completion du KG."


### PR DESCRIPTION
fix(sl,#8052): SL-8 self-contradicts its own ILP-vs-KG cross-ref + mislabels Jean/Claire generation (2 cells)

Two static defects where hand-written text contradicts the notebook's own committed
output/tables. Markdown + one print-literal, no re-execution.

## Defect 1 (cell[29], print-literal + output -- wrong notebook in flagship cross-ref)

- Claim: `print("ILP Classique (SL-4) vs Rule Mining sur KG (SL-6)")` -> committed output
  "ILP Classique (SL-4) vs Rule Mining sur KG (SL-6)".
- Ground truth: the notebook IS SL-8 (cell[0] H1 "# SL-8 - Knowledge Graphs et ILP");
  cell[58]'s comparison table is titled "...(SL-8)". SL-6 is a DIFFERENT notebook
  (SL-6-ModernILP). This is the ONLY "SL-6" string anywhere in SL-8.
- Fix: "SL-6" -> "SL-8" in the print string AND its committed output line (atomic
  source+output edit, byte-identical string, no re-exec).

## Defect 2 (cell[6], markdown -- generation mislabel)

- Claim: "...les grands-parents des generations 1 et 2 -- Jean, Claire -- n'ont aucun
  triple" (5 grandparentOf triples out of 14 possible are missing).
- Ground truth (cell[24] family-generation table): Gen0 = Marie/Pierre, Gen1 = Jean/Claire,
  Gen2 = Luc/Sophie/Paul/Anne, Gen3 = Marc/Lea/... Jean and Claire are generation 1 ONLY,
  not "1 et 2". Their parents (gen0) exist, so it is their grandparents (pre-gen0) who are
  absent -- i.e. the grandparents of generation 1.
- Fix: "des generations 1 et 2" -> "de la generation 1" (element-bounded markdown edit,
  matches the cell's ASCII orthography).

## Verification

Firsthand (#8052 claims<->executed-output lens): read cell[0]/[6]/[24]/[29]/[58] source +
outputs, confirmed SL-8 identity (cell[0] H1, cell[58] table title), the only "SL-6"
occurrence is the cell[29] print-literal, and the cell[24] generation table (Jean/Claire =
gen1). Canonical JSON round-trip byte-identical pre/post; diff = 3 source + 3 output lines
across 2 cells (print-literal edited atomically source+output). Markdown + print-literal +
yaml only, no re-exec. Twin sl-8 (semantic): python-only fix -> rebaselined python_sha
4ecd9674 -> 9676659f (csharp unchanged 37624982); check_twin_parity OK 149/149.

See #8052 (semantic-sampling audit, SymbolicLearning slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
