### PR TITLE
fix(casestudies,#8052): SmartGrid names wrong riskiest hour, false radar promise, stale cell-ref indices (4 cells)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/solution/SmartGrid-Energy.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/solution/SmartGrid-Energy.ipynb
@@ -39,7 +39,7 @@
    "cell_type": "markdown",
    "id": "c2",
    "metadata": {},
-   "source": "## Architecture en 4 couches\n\n| Couche | Rôle | Technique | Partie |\n|--------|------|-----------|--------|\n| **Contraintes dures** | Filtrer les dispatches impossibles | OR-Tools CP-SAT | Partie 1 |\n| **Incertitude** | Modeliser l'aleatoire renouvelable | Modèle bayesien | Partie 2 |\n| **Optimisation** | Choisir le meilleur compromis | Multi-objectif pondere | Partie 3 |\n| **Decision** | Synthese + comparaison | Workflow + scoring | Partie 4 |\n\nCe notebook est une **fondation** : le jumeau numérique (couche 0) est operationnel et les\n4 couches de solveurs (CP-SAT, bayésien, multi-objectif, analyse comparative) sont\nimplémentees et exécutées (cellules 6, 10, 14, 18). Les 3 exercices d'extension\n(cellules 8, 12, 16) sont volontairement laissés en stub pour les étudiants."
+   "source": "## Architecture en 4 couches\n\n| Couche | Rôle | Technique | Partie |\n|--------|------|-----------|--------|\n| **Contraintes dures** | Filtrer les dispatches impossibles | OR-Tools CP-SAT | Partie 1 |\n| **Incertitude** | Modeliser l'aleatoire renouvelable | Modèle bayesien | Partie 2 |\n| **Optimisation** | Choisir le meilleur compromis | Multi-objectif pondere | Partie 3 |\n| **Decision** | Synthese + comparaison | Workflow + scoring | Partie 4 |\n\nCe notebook est une **fondation** : le jumeau numérique (couche 0) est operationnel et les\n4 couches de solveurs (CP-SAT, bayésien, multi-objectif, analyse comparative) sont\nimplémentees et exécutées (Parties 1 à 4). Les 3 exercices d'extension\n(Exercices 1 à 3) sont volontairement laissés en stub pour les étudiants."
   },
   {
    "cell_type": "markdown",
@@ -383,9 +383,9 @@
    "source": [
     "### Interprétation : un risque de queue négligeable, piloté par l'incertitude\n",
     "\n",
-    "Les risques de défaillance sont **astronomiquement faibles** (de l'ordre de 10⁻³⁸ à 10⁻²⁸⁴) : avec 800 MW de capacité pilotable pour une demande nette de 420–490 MW, la marge est si large que la probabilité d'un dépassement (queue de distribution gaussienne via `erfc`) est numériquement négligeable.\n",
+    "Les risques de défaillance sont **astronomiquement faibles** (de l'ordre de 10⁻³⁵ à 10⁻²⁸⁴) : avec 800 MW de capacité pilotable pour une demande nette de 420–490 MW, la marge est si large que la probabilité d'un dépassement (queue de distribution gaussienne via `erfc`) est numériquement négligeable.\n",
     "\n",
-    "- Le risque **ne suit pas le niveau de demande** mais **l'incertitude de la prévision renouvelable** : H4 (demande 480 MW, incertitude ±25 MW) affiche le risque le plus élevé (≈ 8·10⁻³⁸), très au-dessus de H0 (demande 420 MW, ±15 MW, ≈ 7·10⁻¹⁴²) — alors que la demande de H0 est plus faible. C'est l'écart-type `renewable_forecast_std`, pas la demande, qui pilote la probabilité de queue.\n",
+    "- Le risque **ne suit pas le niveau de demande** mais **l'incertitude de la prévision renouvelable** : H5 (demande 430 MW, incertitude ±30 MW) affiche le risque le plus élevé (≈ 3·10⁻³⁵), très au-dessus de H0 (demande 420 MW, ±15 MW, ≈ 7·10⁻¹⁴²) — alors que la demande de H0 est plus faible. C'est l'écart-type `renewable_forecast_std`, pas la demande, qui pilote la probabilité de queue.\n",
     "- **Enseignement** : tant que la capacité pilotable surpasse largement la demande nette, la fiabilité est quasi gratuite. Le risque ne devient pertinent qu'en cas de marge tendue ou d'incertitude élevée — c'est ce que l'Exercice 2 explore en amplifiant l'incertitude renouvelable.\n"
    ]
   },
@@ -545,8 +545,8 @@
     "## Partie 4 : Decision finale et analyse comparative\n",
     "\n",
     "**Synthese** : on compare les stratégies (CP-SAT pur, multi-objectif weighted-sum, front de\n",
-    "Pareto) sur les 3 axes cout/CO2/fiabilite + l'equite territoriale. Le tableau comparatif et\n",
-    "le graphique radar seront produits une fois les Parties 1-3 executees.\n"
+    "Pareto) sur les 3 axes cout/CO2/fiabilite + l'equite territoriale. Le tableau comparatif\n",
+    "ci-dessous est produit a partir des Parties 1-3 deja executees.\n"
    ]
   },
   {
@@ -639,7 +639,7 @@
    "cell_type": "markdown",
    "id": "c19",
    "metadata": {},
-   "source": "## Conclusion\n\nCette étude de cas illustre la **composition ordonnee** des paradigmes IA sur un problème\nmetier reel (transition energetique) : on filtre les dispatches impossibles (CP-SAT) avant\nde modeliser l'incertitude (bayesien) avant d'optimiser (multi-objectif). Inverser l'ordre\nproduit un système soit trop rigide (contraintes ignorent l'aleatoire), soit trop flou\n(decision sans contraintes physiques).\n\n**Etat de la fondation** : jumeau numérique operationnel (couche 0) **+ 4 couches de solveurs\nimplémentees** (CP-SAT dans la cellule 6, bayésien dans la cellule 10, multi-objectif dans\nla cellule 14, analyse comparative dans la cellule 18 — toutes avec sorties réelles).\nLes 3 exercices d'extension (cellules 8, 12, 16) restent en stub pour les étudiants."
+   "source": "## Conclusion\n\nCette étude de cas illustre la **composition ordonnee** des paradigmes IA sur un problème\nmetier reel (transition energetique) : on filtre les dispatches impossibles (CP-SAT) avant\nde modeliser l'incertitude (bayesien) avant d'optimiser (multi-objectif). Inverser l'ordre\nproduit un système soit trop rigide (contraintes ignorent l'aleatoire), soit trop flou\n(decision sans contraintes physiques).\n\n**Etat de la fondation** : jumeau numérique operationnel (couche 0) **+ 4 couches de solveurs\nimplémentees** (CP-SAT en Partie 1, bayésien en Partie 2, multi-objectif en Partie 3, analyse comparative en Partie 4 — toutes avec sorties réelles).\nLes 3 exercices d'extension (Exercices 1 à 3) restent en stub pour les étudiants."
   }
  ],
  "metadata": {


### PR DESCRIPTION
fix(casestudies,#8052): SmartGrid names wrong riskiest hour, false radar promise, stale cell-ref indices (4 cells)

Three static defects in CC3 SmartGrid-Energy solution where hand-written markdown
contradicts the notebook's own committed outputs. Markdown-only, no re-execution.

## Defect 1 (cell[12], VALUE -- wrong hour named as riskiest + wrong range floor)

- Claim: "(de l'ordre de 10⁻³⁸ à 10⁻²⁸⁴)" and "H4 (demande 480 MW, incertitude ±25 MW)
  affiche le risque le plus élevé (≈ 8·10⁻³⁸)".
- Ground truth (cell[11] committed output): the risks are H0 6.86e-142, H1 6.72e-177,
  H2 4.18e-284, H3 1.87e-147, H4 8.20e-38, **H5 3.00e-35**. The LARGEST risk is **H5**
  (3.00e-35 > 8.20e-38, ~3 orders of magnitude), not H4; and the range floor is 10⁻³⁵
  (H5), not 10⁻³⁸ (H4).
- The fix *strengthens* the paragraph's own thesis ("c'est l'écart-type, pas la demande,
  qui pilote la queue"): H5 has the largest std (±30 MW) AND near-lowest net demand
  (430 MW) -- exactly the case the prose argues for.
- Fix: range 10⁻³⁸ -> 10⁻³⁵; H4 (480 MW, ±25 MW, ≈ 8·10⁻³⁸) -> H5 (430 MW, ±30 MW, ≈ 3·10⁻³⁵).

## Defect 2 (cell[20], VALUE -- false "graphique radar" deliverable)

- Claim: "Le tableau comparatif et le graphique radar seront produits une fois les
  Parties 1-3 executees."
- Ground truth: cell[21] produces the comparison TABLE only; there is no matplotlib
  import, no `plt.` call, and no `<Figure>` output anywhere in the notebook (grep:
  matplotlib=0, plt.=0, Figure=0). Parties 1-3 are all executed (committed outputs).
  The radar is promised but never exists.
- Fix: drop the radar promise; "Le tableau comparatif ci-dessous est produit a partir
  des Parties 1-3 deja executees."

## Defect 3 (cell[2] + cell[23], STRUCTURAL -- stale cell-number cross-references)

- Claim (cell[2]): solver layers at "cellules 6, 10, 14, 18"; stubs at "cellules 8, 12, 16".
  Repeated in cell[23]: "CP-SAT dans la cellule 6, bayésien dans la cellule 10,
  multi-objectif dans la cellule 14, analyse comparative dans la cellule 18"; stubs at
  "cellules 8, 12, 16".
- Ground truth (committed cell list): the executed solver code is at indices 6, 11, 16,
  21 (not 6/10/14/18); the stubs are at 9, 14, 19 (not 8/12/16). The interpretation
  cells inserted later shifted the layout. 6 of the 7 indices are stale; "cellule 14"
  even points at the Exercice 2 stub (no output), contradicting "toutes avec sorties
  réelles".
- Fix: replace the brittle absolute indices with robust section references ("Parties 1
  à 4" / "Partie 1..4" / "Exercices 1 à 3") so the pointers survive future edits.

## Verification

Firsthand (#8052 claims<->executed-output lens): read cell[0]/[2]/[11]/[12]/[20]/[21]/[23]
source + outputs, confirmed H5=3.00e-35 > H4=8.20e-38 (riskiest = H5), range floor 10⁻³⁵,
zero plotting in the notebook (grep), and the actual cell indices (6/11/16/21 executed,
9/14/19 stubs). Canonical JSON round-trip byte-identical pre/post; diff = 14 lines across
4 cells (markdown-only, no output changes, no re-exec). SmartGrid-Energy is UNPAIRED
(no twin yaml) -> 0 drift surface, no registry change.

See #8052 (semantic-sampling audit, CaseStudies slice).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
