### PR TITLE
fix(planners,#8052): Planners-9 HTN expresso method names a non-existent action (`!grinder` -> `!grind_beans`)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN.ipynb
@@ -2086,7 +2086,7 @@
     "\n",
     "Pour illustrer concretement la decomposition HTN sur un exemple compact et autonome, modelisons la preparation d'un cafe avec deux méthodes alternatives :\n",
     "\n",
-    "- **Méthode expresso** : `!grinder`, `!brew_expresso` (rapide, pour 1 personne)\n",
+    "- **Méthode expresso** : `!grind_beans`, `!brew_expresso` (rapide, pour 1 personne)\n",
     "- **Méthode filtre** : `!setup_filter`, `!pour_water`, `!brew_filter` (plus lent, pour plusieurs)\n",
     "\n",
     "Ce domaine montre comment les méthodes HTN guident le solveur vers des plans différents selon l'etat du monde (nombre de tasses, disponibilite du moulin)."

--- a/scripts/notebook_tools/twin_pairs.d/planners-9-htn.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-9-htn.yaml
@@ -4,12 +4,13 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-25"
+    date: "2026-07-31"
     by: po-2024
-    python_sha: 68182974b7bcf566966d8031212cf0eabf9ff9f8
+    python_sha: 96c663d1b5cadf6ecacd8981ae0c9f603b9d7e6d
     csharp_sha: 8d70f1020b83b60706f94aabb2e425b083b35a7d
   known_differences:
     - "Concept : Hierarchical Task Network (decomposition de taches, methodes, backtracking)."
     - "Python : unified-planning HTN. C# : from-scratch BCL .NET (Predicat grounde, Etat, decomposition de methodes)."
     - "po-2025 a enrichi firsthand (c.678, PR #8173) le cote Python (instance discriminante m_deliver_direct vs m_deliver_via_intermediate)."
     - "Re-baseline 2026-07-25 (po-2024, consolidation #8264) : SHA Python avance depuis l'audit 2026-07-23 via #8173 (enrichissement method-selection demonstration (backtracking) cote Python) ; drift verifie paraphite-preservant (ne touche pas l'axe de parite semantic)."
+    - "Re-baseline 2026-07-31 (po-2024, #8052) : markdown-only claim correction cote Python (cell[41] methode expresso : `!grinder` -> `!grind_beans`, l'action commise etant grind_beans(grinder1) per cell[42] output, grinder etant l'objet). Paraphite-preservant : aucun output/code modifie, axe de parite semantic intact."


### PR DESCRIPTION
Grain: LIGHT/identity — lane myia-po-2024:CoursIA-2 — prev: MED/CaseStudies (#9064 Diagnostic, #9065 Oncology) ; distinct family/substance: Planners HTN primitive-naming vs medical/case-studies claims.

## What

Fixes one static **identity defect** in `Planners-9-HTN.ipynb`, found via the #8052 claims↔outputs audit (SymbolicAI/Planners slice). The §"Exemple guide : Preparation de cafe" markdown names a primitive action that does not exist in the domain; the notebook's own committed plan prints the correct name.

## Defect (cell[41] markdown — IDENTITY)

- **Claim** (cell[41]): « Méthode expresso : `!grinder`, `!brew_expresso` (rapide, pour 1 personne) ».
- **Ground truth** (cell[42] committed output): `Plan (m_expresso) : grind_beans(arabica, grinder1) -> brew_expresso(grinder1, mug_A)`. The action is **`grind_beans`**; `grinder` is the **object parameter** (`grinder1`), not an action.
- **Isolated**: the « Méthode filtre » names (`!setup_filter`, `!pour_water`, `!brew_filter`) all match cell[42]'s output exactly — only the expresso method's first primitive is wrong. `brew_expresso` is correct.
- **Fix** (markdown-only, 1 line): `!grinder` → `!grind_beans`. No re-exec, outputs intact.

## Verification (firsthand, #8052 lens)

Read cell[41] source + cell[42] output. Confirmed the committed plan is `grind_beans(arabica, grinder1) -> brew_expresso(...)`; `grinder` is the object (`grinder1`). Filtr method names verified correct vs the same output. Canonical JSON round-trip byte-identical pre/post; diff = 2 lines (1 source line). `check_twin_parity --check` → **OK 149/149**.

Planners-9 is a **twinned** notebook (semantic parity). `python_sha` rebaselined `68182974 → 96c663d1`; paraphite-PRESERVING (the parity axis — HTN task decomposition / method selection — is untouched; only an isolated prose action-name is corrected). C# twin unchanged.

## Deferred (transparency, not in this PR)

- **Planners-9 §5 heading order** (cell[25]=`5.3`, cell[28]=`5.1`, cell[30]=`5.2`; cell[27] back-refs « cellule 5.1 » which follows it): real structural defect, but **no clean markdown-only renumber exists** without cell moves (the domain code at cell[21] has its « 5.1 Definition » header misplaced at cell[28]). Deferred for a design decision.
- **Planners-5 h^FF 2→3** (cell[17]): **duplicates PR #8987** (jsboige, OPEN/MERGEABLE) — not pursued (c.1037-L, no duplicate push). A separate Planners-5 defect (cell[39] « toutes deux admissibles » self-contradiction + `orthogogonale` typo) is also deferred to avoid a `python_sha` yaml conflict with #8987 until it merges.

## Scope

1 file content + 1 registry file. No source changes beyond the markdown correction and the attested-SHA refresh.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
