### PR TITLE
fix(planners,#8052): Planners-11 markdown claims Fast Downward resolution but output is INTERNAL_ERROR (numeric fluents)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
@@ -1431,7 +1431,7 @@
    "source": [
     "### Exemple guide 1 : Resolution complete du problème robot_battery\n",
     "\n",
-    "Le problème `robot_battery` est maintenant défini avec un robot qui doit aller de A a C en passant par B, avec une contrainte de batterie (50 unites, 10 par mouvement). Verifions que le problème est coherent et resolvons-le avec Fast Downward."
+    "Le problème `robot_battery` est maintenant défini avec un robot qui doit aller de A a C en passant par B, avec une contrainte de batterie (50 unites, 10 par mouvement). Verifions que le problème est coherent et tentons de le résoudre avec Fast Downward (moteur classique qui ne supporte pas les fluents numériques — le plan affiché est le résultat attendu, calculé à la main)."
    ]
   },
   {
@@ -1571,13 +1571,13 @@
    "source": [
     "### Interpretation : Exemple guide 1\n",
     "\n",
-    "**Cycle complet** : definition du problème (fluents booléens + numériques) → resolution avec Fast Downward → extraction du plan.\n",
+    "**Cycle complet** : definition du problème (fluents booléens + numériques) → tentative avec Fast Downward (échoue : INTERNAL_ERROR, fluents numériques non supportés par le moteur classique) → plan attendu calculé à la main.\n",
     "\n",
     "**Points a retenir** :\n",
     "1. Les fluents numériques (`IntType`) permettent de modeliser des **ressources consommables** (batterie, carburant, budget)\n",
     "2. La precondition `GE(battery(), 10)` empeche toute action si la ressource est insuffisante\n",
-    "3. `add_decrease_effect` modifie le fluent numérique a chaque action — le solveur en tient compte dans sa recherche\n",
-    "4. Le plan optimal minimise les mouvements (2 actions pour A→B→C), consommant 20/50 unites"
+    "3. `add_decrease_effect` modifie le fluent numérique a chaque action — un solveur numérique (ex. ENHSP) en tiendrait compte dans sa recherche (Fast Downward, moteur classique, ne gère pas les fluents numériques)\n",
+    "4. Le plan attendu minimise les mouvements (2 actions pour A→B→C), consommant 20/50 unites"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/value — lane myia-po-2024:CoursIA-2 — prev: MED/value (#9069 Planners-6 Ferry O(n)) ; distinct notebook/substance: Planners-11 Unified-Planning solver-status contradiction vs Planners-6 complexity math.

## What

Fixes an **intra-notebook self-contradiction** in `Planners-11-Unified-Planning.ipynb`, found via the #8052 claims↔outputs audit (SymbolicAI/Planners slice). The Exemple-guide-1 interpretation markdown narrates a successful « resolution avec Fast Downward → extraction du plan », contradicting the committed code comment and output (`INTERNAL_ERROR`).

## Defect (cells 35/37 markdown — VALUE / intra-nb self-contradiction)

- **Claim** (cell[37]): « **Cycle complet** : … → resolution avec Fast Downward → extraction du plan », « 3. `add_decrease_effect` … — le solveur en tient compte dans sa recherche », « 4. Le plan optimal minimise les mouvements (2 actions pour A→B→C) »; plus cell[35] « resolvons-le avec Fast Downward ».
- **Ground truth** (cell[36] code + committed output):
  - **Code comment** (over the `else` branch): `# Solveur ne supporte pas les fluents numeriques ou erreur interne`.
  - **`else`-branch hard-coded fallback**: `print("Plan attendu (2 actions)")` with literal `move(A, B) # batterie: 50 -> 40` (a comment a real solver would never emit).
  - **Committed output**: `Statut : INTERNAL_ERROR` then `Plan attendu (2 actions)` (the fallback).

  Fast Downward (classical engine) never solved the numeric-fluents problem; the printed plan is the hand-computed fallback, **not** a solver extraction.

## Fix (markdown-only, cells 35/37)

- cell[35]: « resolvons-le » → « tentons de le résoudre … (moteur classique qui ne supporte pas les fluents numériques — le plan affiché est le résultat attendu, calculé à la main) ».
- cell[37] elem2: « resolution avec Fast Downward → extraction du plan » → « tentative avec Fast Downward (échoue : INTERNAL_ERROR, fluents numériques non supportés par le moteur classique) → plan attendu calculé à la main ».
- cell[37] elem7: « le solveur en tient compte dans sa recherche » → « un solveur numérique (ex. ENHSP) en tiendrait compte … (Fast Downward, moteur classique, ne gère pas les fluents numériques) ».
- cell[37] elem8: « Le plan optimal » → « Le plan attendu ».

Points 1-2 (resource modeling, `GE(battery(), 10)` precondition) and cell[36] code+output are **untouched** (they are the grounding).

## Verification (firsthand, #8052 lens)

Read cell[35]/[36]/[37] source + cell[36] full output. Confirmed `Statut : INTERNAL_ERROR` + hard-coded `else`-branch `Plan attendu` (literal `# batterie: 50 -> 40`), and the code comment « Solveur ne supporte pas les fluents numeriques ». Canonical JSON round-trip byte-identical pre/post; diff = 8 lines (4 source lines, no output/code change, no re-exec). **Planners-11 is UNPAIRED** (no twin yaml) → 0 drift surface, no registry change.

## Scope

1 file content. No source changes beyond the markdown corrections.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
