### PR TITLE
fix(planners,#8052): Planners-1 Introduction calls successor notebook "PDDL-Syntax" but it is titled "PDDL-Basics" (3 cross-refs)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Planners-1-Introduction a la Planification Automatique\n",
     "\n",
-    "**Navigation** : [Index](../../README.md) | [<< Setup](../00-Environment/Planners-0-Setup.ipynb) | [PDDL Syntax >>](Planners-2-PDDL-Basics.ipynb)\n",
+    "**Navigation** : [Index](../../README.md) | [<< Setup](../00-Environment/Planners-0-Setup.ipynb) | [PDDL Basics >>](Planners-2-PDDL-Basics.ipynb)\n",
     "\n",
     "---\n",
     "\n",
@@ -1521,14 +1521,14 @@
     "\n",
     "Dans les notebooks suivants, nous approfondirons :\n",
     "\n",
-    "1. **PDDL Syntax** : Le langage standard pour la planification\n",
+    "1. **PDDL Basics** : Le langage standard pour la planification\n",
     "2. **State-Space Search** : Algorithmes de recherche et heuristiques\n",
     "3. **Fast Downward** : Planificateur optimal avec A* et LM-cut\n",
     "4. **OR-Tools CP-SAT** : Approche par contraintes\n",
     "\n",
     "---\n",
     "\n",
-    "**Notebook suivant** : [Planners-2-PDDL-Syntax](Planners-2-PDDL-Basics.ipynb)"
+    "**Notebook suivant** : [Planners-2-PDDL-Basics](Planners-2-PDDL-Basics.ipynb)"
    ]
   }
  ],

--- a/scripts/notebook_tools/twin_pairs.d/planners-1-introduction.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-1-introduction.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-23"
-    by: po-2023
-    python_sha: d6f0f8fff2a6331cb4c979b90eda1ce526aa97fd
+    date: "2026-07-31"
+    by: po-2024
+    python_sha: 15b48a88234daf564512b163ffce816ca1b5a0d7
     csharp_sha: 684de6ba81caa8202262c6f7f1b3830bc4af8291
   known_differences:
     - "Concept : introduction a la planification classique (domaine, probleme, plan = sequence d'actions)."
     - "Python : unified-planning (API moderne, modelisation Fluent/Action). C# : from-scratch BCL .NET (dataclasses d'Action/Etat, 0 NuGet)."
+    - "Re-baseline 2026-07-31 (po-2024, #8052) : markdown-only correction cote Python (cell[0] nav label + cell[35] list item + link text : 'PDDL-Syntax' -> 'PDDL-Basics', conforme au titre reel du notebook suivant Planners-2-PDDL-Basics). Paraphite-preservant : aucun output/code modifie, axe de parite semantic (concept planification) intact."


### PR DESCRIPTION
Grain: MED/identity — lane myia-po-2024:CoursIA-2 — prev: MED/structural (#9071 Planners-10 forward-reference) ; distinct notebook/substance: Planners-1 PDDL-Syntax cross-ref vs Planners-10 identifier orientation.

## What

Fixes a static **identity defect** in `Planners-1-Introduction.ipynb`, found via the #8052 claims↔outputs audit (SymbolicAI/Planners slice). The next-notebook references name the successor « PDDL-Syntax » while the linked notebook's actual title is « PDDL-Basics ».

## Defect (cells 0/35 markdown — IDENTITY / cross-ref)

- **Claim** (3 occurrences):
  - cell[0] nav label: `[PDDL Syntax >>](Planners-2-PDDL-Basics.ipynb)`
  - cell[35] conclusion list: `1. **PDDL Syntax** : Le langage standard pour la planification`
  - cell[35] link: `**Notebook suivant** : [Planners-2-PDDL-Syntax](Planners-2-PDDL-Basics.ipynb)`
- **Ground truth**: the linked file `Planners-2-PDDL-Basics.ipynb` opens with the title cell `# Planners-2-PDDL-Basics` (its cell[0]). The **href is correct** in all three cases; only the label/link-text is wrong.
- **Fix**: « PDDL Syntax » → « PDDL Basics » in the nav label, the conclusion list item, and the next-notebook link text. href unchanged.

## Verification (firsthand, #8052 lens)

Confirmed 3 total occurrences of « PDDL-Syntax »/« PDDL Syntax » in Planners-1 (cells 0 and 35), and that `Planners-2-PDDL-Basics.ipynb` cell[0] title is `# Planners-2-PDDL-Basics`. Canonical JSON round-trip byte-identical pre/post; diff = 6 lines (3 source lines, no output/code change, no re-exec); 0 residual « PDDL Syntax » anywhere. `check_twin_parity --check` → **OK 149/149**.

Planners-1 is **twinned** (semantic). `python_sha` rebaselined `d6f0f8ff → 15b48a88`; paraphite-PRESERVING (parity axis = planning concept intro, untouched). C# twin unchanged.

## Scope

1 file content + 1 registry file. No source changes beyond the markdown corrections and the attested-SHA refresh.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
