### PR TITLE
docs(scripts,#8924): recette periodique hygiene disque (worktree + gc + stash)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,7 +4,7 @@ Scripts de gestion, validation et execution pour l'ecosysteme CoursIA.
 
 ## Structure
 
-```
+```text
 scripts/
 ├── notebook_tools/              # Outils manipulation notebooks
 │   ├── notebook_tools.py        # CLI (skeleton, validate, analyze, execute)
@@ -127,3 +127,62 @@ python scripts/kernels/validate_lean11.py
 ```bash
 python -m pytest scripts/tests/
 ```
+
+## Hygiene disque — worktrees, stash, object-store
+
+Recette periodique (cf #8924). Une lane livre par l'API GitHub des que son
+disk-fill empeche `git fetch` ; ces preventifs gardent le depot exploitable.
+
+### Avant/apres publie (recette reproductible, etalon ai-01)
+
+| Mesure | Avant | Apres | Source |
+| --- | --- | --- | --- |
+| Worktrees enregistres | 192 | 188 | `git worktree list --porcelain` |
+| Worktrees disposable (HEAD∈main, dirty=0) | 9 | 5 | merge-base + status |
+| Object store | 2 389 MB | 1 234 MB | `du -sh .git/objects` |
+| Stash global (16 entrees) | preserve | preserve | inventaire ci-dessous |
+
+Cycle execute sur `myia-po-2023` (2026-07-30) : 4 worktrees retires (~3.6 GB),
+`git gc --prune=now --aggressive` (4min41), gain net ~1.15 GB sur l'object-store.
+
+### Recette, du moins risque au plus risque
+
+```bash
+# 1. Lister les worktrees + reperer ceux dont le HEAD est deja dans origin/main
+git worktree list --porcelain
+# Pour chaque candidat, verifier :
+git merge-base --is-ancestor <HEAD> origin/main
+git -C <path> status --porcelain    # doit etre vide (hors untracked)
+# Si les deux sont VRAI -> git worktree remove <path>
+
+# 2. Compacter l'object store (gain le plus gros, perte nulle)
+git gc --prune=now --aggressive     # plusieurs minutes sur gros depots
+
+# 3. Seulement si un fetch casse encore : nettoyer les packs temporaires
+ls .git/objects/pack/tmp_pack_*     # residus d'index-pack interrompu
+```
+
+**A NE PAS faire** :
+
+- `git stash clear` : les entrees sont du travail non-commite, sans proprietaire
+  automatiquement identifiable (29+ sur ai-01). Inventorier d'abord
+  (`git stash list --date=iso` + `git stash show --stat <n>` par entree) et
+  decider par entree (rejouer / abandonner / promouvoir en branche).
+- `git worktree remove -f` sur un arbre dirty : c'est precisement la ou du
+  travail non-pousse vit.
+- `git gc --aggressive` regulierement sur un workflow actif : chaque appel
+  recompacte tout. Une fois par cycle / une fois par semaine suffit.
+
+### Stash global vs stash-par-worktree (piege classique)
+
+`git stash list` est **global au depot**, pas par worktree : un stash pose dans
+un worktree survit a la suppression de ce worktree. Lire 29 entrees depuis 5
+worktrees **n'en fait pas 145** : c'est 29, point. La liste retournee depuis
+n'importe quel worktree est la meme.
+
+### Documentation source
+
+- Issue **#8924** (recette, mesure, cycle par machine)
+- Lane proprietaire : `myia-po-2023:CoursIA-2` pour le cycle de reference ; a
+  tour de role par cycle parmi `myia-ai-01`, `myia-po-2023`, `myia-po-2024`,
+  `myia-po-2025`, `myia-po-2026`.


### PR DESCRIPTION
# c963 — disk hygiene po-2023 cycle (See #8924)

Grain: MED/docs — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-dotnet (c.962 #8906)

## What

Recette periodique d'hygiene disque documentee dans `scripts/README.md` :
3 etapes (worktree remove -> git gc --prune=now --aggressive -> nettoyage
des packs temporaires) avec le piege `git stash list` = global au depot,
et trois INTERDITS (`stash clear`, `worktree remove -f` sur dirty,
`gc --aggressive` regulier).

## Cycle execute sur po-2023 (et published mesure)

| Mesure | Avant | Apres |
| --- | --- | --- |
| Worktrees enregistres | 192 | 188 |
| Worktrees disposable (HEAD∈main, dirty=0) | 9 | 5 |
| Object store `.git/objects` | 2 389 MB | 1 234 MB (-48 %) |
| Stash entries (global) | 16 | 16 (preserve) |

4 worktrees retires (`c937-knot-hwell-decide`, `c948-genai-localllama-vllm-35b`,
`c956-conway-closure-8782`, `c849-infer15-recommenders-citations-8081`),
3.6 GB sur working trees + 1.15 GB sur l'object-store apres gc.

## Stashes : ne PAS dropper

Les 16 entrees sont du travail lane-owned (`c935-rebase-stash`,
`image axe-2 cell-order + infra fix`, `lfs-dirty`,
`fix(search): execute 3 DRAFT notebooks`, ...) sur des branches
historiques. `git stash clear` detruirait sans proprietaire. Recette
de l'issue (#8924) : inventorier par entree, decider (rejouer /
abandonner / promouvoir en branche). Ce PR ne touche pas aux stashes.

## Why this scope

L'issue #8924 demande un **proprietaire par machine + avant/apres
public** ; la regle ecrite + le tableau de mesure repondent aux deux.
Le `git stash clear` est explicitement deconseille par l'issue
elle-meme. Pas de refonte des outils, pas de garde fragile - juste la
doc d'un piege mesure.

## Files changed

- `scripts/README.md` : +58/-0 (1 nouvelle section, 1 langage de bloc corrige,
  ajustement MD040/MD012 pour le linter markdown).

Toutes les autres actions sont des operations de maintenance cote
working tree, pas du contenu commite : `git worktree remove` (4x),
`git worktree prune`, `git gc --prune=now --aggressive` (4min41).

## Cross-ref

- Issue **#8924** : la definition de la recette + la demande d'inventaire
- `~/.claude/projects/d--Dev-CoursIA-2/memory/topic-c963-8924-disk-hygiene.md` :
  sortie ephemere (dashboard INFRO OUTAGE, fallback MEMORY topic)
- **#8906** (c.962) : la PR precedente sur la meme lane, pour le calcul
  G-VAR-3 (precedent = MED/notebook-dotnet, ce cycle = MED/docs, OK).

`See #8924`
