### PR TITLE
fix(harness,#7423): redirect L576 links from gitignored .claude/memory to docs/reference

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -55,7 +55,7 @@ GitHub auto-closes issues on `Refs #N`, `Fixes #N`, `Closes #N`. Use safe syntax
 
 **S'applique quand** un worker voit une branche distante `jsboige/*` (via `git fetch`, listing `git branch -r`, ou topic-file date) et **envisage de la self-pick**. Risque : **REST `commits/<oid>/pulls` peut renvoyer un empty / faux negatif** pour une branche reellement attachee a une PR OPEN. Conclure « orpheline » sur REST seul = auto-pick dangereux d'un travail deja en cours.
 
-**Compound gate obligatoire** (3 ancres, voir [lecon-L576](https://github.com/jsboige/CoursIA/blob/main/.claude/memory/lecon-L576-rest-commits-pulls-fpos.md)) — TOUTES doivent etre passees avant de reclamer la branche :
+**Compound gate obligatoire** (3 ancres, detail : [orphan-branch-scan-l576.md](../../docs/reference/orphan-branch-scan-l576.md)) — TOUTES doivent etre passees avant de reclamer la branche :
 
 ```bash
 # 1. Integree upstream ?
@@ -80,7 +80,7 @@ gh pr list --state all --search "head:<branch>" --json number,state -q '.[].numb
 
 **Anti-pattern** : ne JAMAIS conclure « orpheline » sur `git fetch` + REST seul. Gate 3 est autoritatif ; l'investigation prend ~10 secondes et elimine le risque de double-pickup.
 
-**Voir aussi** : [lecon-L576](https://github.com/jsboige/CoursIA/blob/main/.claude/memory/lecon-L576-rest-commits-pulls-fpos.md) (detail fondateur + symtome 5 branches `jsboige/*` decouvertes c.576 / attachees a #7086-#7091). Sub-grain 5/5 de l'epic #7423 « revue globale du harnais » (boucle vertueuse close par cette PR — dernier orphelin L576 ancre dans git-workflow ; reste 5 orphelines pour futurs grains cross-famille : L574 / L751 / L770 / L771 / L772+L789+L790+L791).
+**Voir aussi** : [orphan-branch-scan-l576.md](../../docs/reference/orphan-branch-scan-l576.md) (detail fondateur + symtome 5 branches `jsboige/*` decouvertes c.576 / attachees a #7086-#7091). *Ce detail a longtemps ete cite a l'URL `.claude/memory/lecon-L576-...md` : ce chemin est ignore par `.gitignore` (ligne 651, etat local par machine), donc il ne peut jamais exister sur `main` et le lien etait mort par construction. Ne pas le retablir — la doc perenne vit dans `docs/`, cf [harness-hygiene.md](harness-hygiene.md).* Sub-grain 5/5 de l'epic #7423 « revue globale du harnais » (boucle vertueuse close par cette PR — dernier orphelin L576 ancre dans git-workflow ; reste 5 orphelines pour futurs grains cross-famille : L574 / L751 / L770 / L771 / L772+L789+L790+L791).
 ## PR Body Generation
 
 **Leçon ancrée** — L677-L4 ★★ (c.680, voir aussi c.683/c.684/c.685/c.686/c.687/c.688/c.689/c.690 réutilisations ; détail en mémoire locale per-machine) : le **body de PR se génère HORS worktree**, jamais dans un fichier du worktree (qui finirait stageé par `git add .` ou committe accidentellement).


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-ai-01:CoursIA — prev: MED/tooling #9076

## Deux liens morts par construction, pas par accident

La section « Orphan-branch scan (L576) » de `.claude/rules/git-workflow.md` cite son
détail fondateur à l'URL :

```
https://github.com/jsboige/CoursIA/blob/main/.claude/memory/lecon-L576-rest-commits-pulls-fpos.md
```

`.claude/memory/` est **ignoré par `.gitignore` (ligne 651)**, aux côtés de
`.claude/local/` — c'est de l'état local par machine. Ce fichier ne peut donc **jamais**
exister sur `main` : les deux liens ne sont pas « cassés depuis un déplacement », ils sont
morts **par construction**, et l'étaient dès leur écriture.

Vérifié :

```
$ git check-ignore -v .claude/memory/x.md
.gitignore:651:.claude/memory/	.claude/memory/x.md

$ ls .claude/memory/
ls: cannot access '.claude/memory/': No such file or directory
```

## Ce qui rend la correction évidente

Le détail durable **existe déjà** sur `main`, à `docs/reference/orphan-branch-scan-l576.md`,
et ce document constate lui-même le problème dans sa note de localisation :

> « Ce chemin est **ignoré par `.gitignore`** (ligne 651…) : il ne peut donc jamais exister
> sur `main`, et les deux liens de la règle sont morts par construction. »

Le diagnostic était donc posé — mais côté `docs/`, pas côté règle, si bien que la règle
auto-chargée à chaque session continuait d'envoyer ses lecteurs sur un 404. Cette PR ferme
la boucle en corrigeant l'endroit qui est réellement lu.

## Le changement

`+2/-2` sur un seul fichier :

1. Ligne 58 — le lien du *compound gate* pointe sur `docs/reference/orphan-branch-scan-l576.md`.
2. Ligne 83 — idem pour le « Voir aussi », **plus une note inline** disant pourquoi
   l'ancien chemin ne doit pas être rétabli. Sans cette note, la correction se fait
   ré-annuler par le prochain agent qui « restaure » un lien qu'il croit avoir été perdu —
   c'est le mode d'échec typique d'un fix de lien nu.

Après la PR, plus aucun fichier **suivi** ne référence `.claude/memory/`, hormis cette note
d'avertissement (`git grep '\.claude/memory' -- '*.md'`). Les occurrences restantes sur
disque sont dans `.claude/worktrees/`, non versionnées.

## Portée

Aucun changement de règle : la procédure L576 (3 ancres, gate 3 autoritatif) est
strictement inchangée. Seule la cible de deux liens bouge. C'est de l'hygiène de harnais au
sens de [`harness-hygiene.md`](../blob/main/.claude/rules/harness-hygiene.md) — tier « doc
pérenne → `docs/`, référencé succinctement par le harnais » — appliquée à un cas où le
pointeur ne pouvait pas résoudre.

See #7423
