### PR TITLE
docs(readme,#7422): bump SymbolicAI notebook count 220 -> 224

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ MyIA.AI.Notebooks/
   GameTheory/      -> Théorie des jeux, équilibres de Nash, mechanism design, social choice
   IIT/             -> Information intégrée (Tononi, PyPhi) + banc ICT : trajectoires causales, du tri au LLM
   CaseStudies/     -> Études de cas interdisciplinaires
-  SymbolicAI/      -> Raisonnement formel (Lean 4, Tweety, Semantic Web, Smart Contracts, Planners, SMT, Argument Analysis, Symbolic Learning) -- la plus vaste série du dépôt (220 notebooks)
+  SymbolicAI/      -> Raisonnement formel (Lean 4, Tweety, Semantic Web, Smart Contracts, Planners, SMT, Argument Analysis, Symbolic Learning) -- la plus vaste série du dépôt (224 notebooks)
   GenAI/           -> IA générative (Image, Audio, Video, Texte, Semantic Kernel, Vibe Coding) -- l'une des plus vastes séries (141 notebooks)
   QuantConnect/    -> Trading algorithmique (notebooks pédagogiques + stratégies backtestées + pipeline ML)
   cross-series/    -> Applications transverses (matching-cv : data science multi-domaines)


### PR DESCRIPTION
# c.964 — root README SymbolicAI count drift (See #7422)

Grain: MED/docs — lane myia-po-2023:CoursIA-2 — prev: MED/docs

## What

The SymbolicAI notebook count in root `README.md` drifted from the catalog since
the 2026-07-20 refresh (`#7550` documented "220/141/105 notebook counts"). The
catalog's `### SymbolicAI` row now reads **224 notebooks**, but README line 35
still says **220**.

This is a 1-line atomic fix: `220 notebooks` → `224 notebooks`. The prose
surrounding the number (`-- la plus vaste série du dépôt`) is still accurate:
224 > 141 (GenAI, the next-largest family).

Part of **`#7422`** (Hygiène docs/ + index.md racine — triage archive/MAJ,
préalable de fraîcheur avant traduction `#1650`), specifically **item 3**:
*Refresh root index.md/README.md*. Item 1 (inventory) was delivered by
**`#8885`** (c.957, MERGED `04652a15d`); item 4 (triple-grounding reconciliation)
remains outstanding for future wakeups.

## Drift evidence (catalog = source of truth, per `catalog-pr-hygiene.md`)

| Subdir | Count |
|---|---|
| SMT | 46 |
| Tweety | 32 |
| Lean | 28 |
| SmartContracts | 27 |
| SemanticWeb | 25 |
| Planners | 23 |
| Argument_Analysis | 22 |
| SymbolicLearning | 20 |
| root | 1 |
| **Total** | **224** |

(Extracted from `COURSE_CATALOG.generated.md`, sub-bullet of
`### SymbolicAI (224 notebooks) — DEMO:9, READY:215 | ALPHA:6, BETA:215, DRAFT:3`.)

## Other counts checked (no drift)

| Family | README claims | Catalog | Drift |
|---|---|---|---|
| SymbolicAI | 220 | **224** | **+4 (fixed)** |
| GenAI | 141 | 141 | 0 |
| QuantConnect | 105 | 105 | 0 |

Catalog-pr-hygiene rule respected: the catalog itself is **byte-identical to main**
on this branch (no regeneration in this PR — that's the catalog-cron's job).

## Why this scope

`#7422` is a multi-criterion epic (inventory + archive + refresh + reconciliation).
This PR is a **sub-bullet** delivering **item 3 partially** (the root README
count-drift piece). Per `catalog-pr-hygiene.md` rule 4 + `proactive-coordination.md`
R1-R7, partial delivery = `See #7422` not `Closes #7422`. The epic stays open.

Scope is intentionally narrow: 1 file, 1 line. The catalog regeneration is the
cron's job (per `catalog-pr-hygiene.md`); the broader reconciliation (item 4) is
for a future wakeup with deeper root README refresh (cf. `#7550` as reference for
the last big README pass).

## Files changed

- `README.md`: +1/-1 (line 35: `220 notebooks` → `224 notebooks`)

No catalog regeneration, no other files modified.

## Cross-ref

- Issue **`#7422`** — the parent epic, of which this PR is a sub-delivery.
- PR **`#7550`** — the previous root README refresh, dated 2026-07-20, that
  documented the "220/141/105" triple. Counts have drifted since.
- PR **`#8885`** (c.957) — `docs/README.md` +2/-0 delivery of item 1 of `#7422`
  (inventory, two-line link additions).
- **c.963** (`#9075`) — the PR immediately preceding this on the same lane
  (MED/docs, on `scripts/README.md`, not root README → distinct scope).

`See #7422`
