### PR TITLE
fix(search,#8052): CSP-3 identity -- "Search-6/7" CSP attribution stale (real CSP = CSP-1/CSP-2)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
@@ -56,11 +56,11 @@
     "\n",
     "## 1. Introduction (~3 min)\n",
     "\n",
-    "Dans les notebooks précédents (Search-6 et Search-7), nous avons construit nos propres solveurs CSP a la main : backtracking, heuristiques MRV/LCV, propagation AC-3, Forward Checking, MAC. Ces techniques sont fondamentales pour comprendre le fonctionnement interne des solveurs.\n",
+    "Dans les notebooks précédents (CSP-1 et CSP-2), nous avons construit nos propres solveurs CSP a la main : backtracking, heuristiques MRV/LCV, propagation AC-3, Forward Checking, MAC. Ces techniques sont fondamentales pour comprendre le fonctionnement interne des solveurs.\n",
     "\n",
     "Cependant, les **solveurs industriels** modernes vont beaucoup plus loin :\n",
     "\n",
-    "| Aspect | CSP academique (Search-6/7) | Solveur industriel (OR-Tools) |\n",
+    "| Aspect | CSP academique (CSP-1/CSP-2) | Solveur industriel (OR-Tools) |\n",
     "|--------|---------------------------|-------------------------------|\n",
     "| Contraintes | Binaires uniquement | Contraintes **globales** specialisees |\n",
     "| Propagation | AC-3 generique | Propagateurs **dedies** par contrainte |\n",
@@ -1212,7 +1212,7 @@
      "text": [
       "   100       862.97        Oui\n",
       "\n",
-      "Comparaison avec notre backtracking (Search-6) :\n",
+      "Comparaison avec notre backtracking (CSP-1) :\n",
       "  - Backtracking + MRV : N=12 peut prendre des secondes\n",
       "  - CP-SAT : N=100 en quelques millisecondes\n"
      ]
@@ -1233,7 +1233,7 @@
     "    print(f\"{n:>6} {t:>12.2f} {found:>10}\")\n",
     "\n",
     "print()\n",
-    "print(\"Comparaison avec notre backtracking (Search-6) :\")\n",
+    "print(\"Comparaison avec notre backtracking (CSP-1) :\")\n",
     "print(\"  - Backtracking + MRV : N=12 peut prendre des secondes\")\n",
     "print(\"  - CP-SAT : N=100 en quelques millisecondes\")"
    ]
@@ -3011,9 +3011,9 @@
     "\n",
     "| Concept | Notebook | Points cles |\n",
     "|---------|----------|-------------|\n",
-    "| Fondements CSP | Search-6 | Variables, domaines, contraintes, backtracking |\n",
-    "| Heuristiques | Search-6 | MRV, LCV, Forward Checking |\n",
-    "| Consistance | Search-7 | AC-3, MAC, forward checking |\n",
+    "| Fondements CSP | CSP-1 | Variables, domaines, contraintes, backtracking |\n",
+    "| Heuristiques | CSP-1 | MRV, LCV, Forward Checking |\n",
+    "| Consistance | CSP-2 | AC-3, MAC, forward checking |\n",
     "| Contraintes globales | **Ce notebook** | AllDifferent, Cumulative, Circuit, Table |\n",
     "| Solveur industriel | **Ce notebook** | CP-SAT, LNS, symetries |\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/csp-3-advanced.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-3-advanced.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: 43d03b3249e2f0c886a2a1e2df0c533510ff666e
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2
+    python_sha: ea4369680e7b982cb3a6efc2d73b060e4218a4df
     csharp_sha: c6865e44c00885bccd47a4ee26cc0a3b45ff8099
   known_differences:
     - "Socle pedagogique commun : global constraints (all_different, sum, element) + backtracking avec propagation globale + symetrie breaking (lexicographique)."


### PR DESCRIPTION
Grain: MED/identity — lane myia-po-2024:CoursIA-2 — prev: MED/identity (#9074 Planners-7 VRP capacity premise) ; distinct notebook/substance: CSP-3 Search-6/7 CSP-attribution identity drift vs Planners-7 fleet-heterogeneity reframe.

## What

Fixes an **IDENTITY** defect in `CSP-3-Advanced.ipynb` where the intro, the comparison print, and the Bilan CSP table all frame **"Search-6 / Search-7"** as the notebooks where CSP solvers (backtracking, MRV/LCV, AC-3, MAC, Forward Checking) were built "a la main". Those references are stale leftovers from old notebook numbering: **Search-6 = AdversarialSearch** and **Search-7 = MCTS-And-Beyond** (Part1-Foundations). The real CSP foundations live in **CSP-1** (backtracking/MRV/LCV) and **CSP-2** (AC-3/MAC/FC). Markdown + print-literal output, no re-execution. Found via the #8052 claims↔outputs audit (Search/Part2-CSP slice).

## Ground truth (firsthand verified, L786-2)

- `git ls-tree` Part1-Foundations: Search-6 = AdversarialSearch, Search-7 = MCTS-And-Beyond.
- CSP-1 has backtracking/MRV/LCV; CSP-2 has AC-3/MAC/FC/ArcConsistency.
- **CSP-3's OWN c[0] nav** confirms the correct attribution: `prev = CSP-2-Consistency.ipynb`, prereq `"[CSP-2-Consistance] : AC-3, Forward Checking, MAC"` — i.e. AC-3/MAC/FC map to CSP-2, not Search-7. So the "Search-6/7" prose contradicts the notebook's own navigation.

## Defect (IDENTITY c.1062-L — strongest class)

- **cell[1] prose**: « notebooks précédents (Search-6 et Search-7) » → (CSP-1 et CSP-2)
- **cell[1] table header**: « CSP académique (Search-6/7) » → (CSP-1/CSP-2)
- **cell[23] print literal + committed output** (atomic, c.1077-L — print-literal source and its stream output are the same string): « Comparaison avec notre backtracking (Search-6) » → (CSP-1)
- **cell[56] Bilan CSP table**: `Fondements CSP | Search-6` → CSP-1 ; `Heuristiques | Search-6` → CSP-1 ; `Consistance | Search-7` → CSP-2

## Fix

7 targeted edits across 4 cells. Markdown-only except cell[23], which is a print-literal whose committed stream output carries the identical string — edited atomically (source + output byte-equivalent), **no re-execution** (c.1077-L). 0 residual "Search-6"/"Search-7" as CSP attribution anywhere in the notebook (assertion-locked).

## Verification (firsthand, #8052 lens)

- Ground-truth cross-check in the edit script: c[0] nav links CSP-2-Consistency.ipynb as prev and the prereq line maps AC-3/MAC/FC to CSP-2.
- Canonical JSON round-trip byte-identical pre/post. **Trailing-adaptive** (c.1086): CSP-3 is committed **without** a trailing newline, so the canonical assert uses `trailing = '\n' if raw.endswith('\n') else ''` in both the pre-check and post-serialization — a generic `+'\n'` would falsely fail.
- diff = 14 lines across 4 cells (7 edit pairs), no code/output change beyond the cell[23] print-literal atomic pair. `assert len(diff) < 40` corruption guard passed.

**CSP-3 is TWINNED** (semantic). C# twin **UNCHANGED** (`c6865e44`, Choco-solver from-scratch) → `python_sha` rebaselined `43d03b32 → ea4369680` (parity axis = global-constraints CSP concept, untouched); `csharp_sha` unchanged. `check_twin_parity --check` → CSP-3 **[OK]** (resolves at commit; pre-existing DRIFTs App-2 / CSP-5 / Tweety-4/5/7b/8 are unrelated, on origin/main).

## Scope

1 file content + 1 registry file. No source changes beyond the identity corrections and the attested-SHA refresh.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
