### PR TITLE
fix(search,#8052): CSP-2 identity -- "Search-6" CSP-foundation attribution stale (real foundations = CSP-1)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
@@ -32,7 +32,7 @@
     "5. **Comparer** experimentalement Backtracking, FC et MAC\n",
     "\n",
     "### Prerequis\n",
-    "- Search-6 : formalisme CSP, backtracking, heuristiques MRV/LCV\n",
+    "- CSP-1 : formalisme CSP, backtracking, heuristiques MRV/LCV\n",
     "- Bases de Python : recursion, dictionnaires, files (deque)\n",
     "\n",
     "### Duree estimee : 45 minutes\n",
@@ -60,7 +60,7 @@
     "\n",
     "## 1. Pourquoi la propagation de contraintes ? (~5 min)\n",
     "\n",
-    "Dans le notebook précédent (Search-6), nous avons vu que le backtracking detecte les conflits au moment de l'assignation. Cependant, il ne tire pas pleinement parti de la structure des contraintes : il attend de tenter une assignation pour decouvrir un conflit.\n",
+    "Dans le notebook précédent (CSP-1), nous avons vu que le backtracking detecte les conflits au moment de l'assignation. Cependant, il ne tire pas pleinement parti de la structure des contraintes : il attend de tenter une assignation pour decouvrir un conflit.\n",
     "\n",
     "**Idee cle** : au lieu d'attendre passivement, on peut **propager les consequences** de chaque assignation pour eliminer des valeurs impossibles dans les domaines des autres variables. C'est la **propagation de contraintes**.\n",
     "\n",
@@ -144,7 +144,7 @@
     "tags": []
    },
    "source": [
-    "### Classe CSP (rappel de Search-6)\n",
+    "### Classe CSP (rappel de CSP-1)\n",
     "\n",
     "Nous reutilisons la classe CSP définie dans le notebook précédent, avec quelques méthodes supplementaires pour la propagation."
    ]
@@ -362,7 +362,7 @@
     "    plt.tight_layout()\n",
     "    return fig\n",
     "\n",
-    "# Heuristique MRV (rappel de Search-6)\n",
+    "# Heuristique MRV (rappel de CSP-1)\n",
     "def select_mrv(csp, assignment, domains):\n",
     "    \"\"\"Heuristique MRV : choisir la variable avec le moins de valeurs viables.\"\"\"\n",
     "    unassigned = [v for v in csp.variables if v not in assignment]\n",

--- a/scripts/notebook_tools/twin_pairs.d/csp-2-consistency.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-2-consistency.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: 49861cbc522cd0dd1aa91e50475bdfa1bc050722
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2
+    python_sha: e4bcb98f9b804b32f5116fdb79e253b7488cd030
     csharp_sha: e846c562a18f32cb4e643b607a1b6556aa0d3c85
   known_differences:
     - "Socle pedagogique commun : node consistency + AC-3 + Forward Checking + MAC, implementes from-scratch des deux cotes."


### PR DESCRIPTION
Grain: MED/identity — lane myia-po-2024:CoursIA-2 — prev: MED/identity (#9081 CSP-3 same family-wide drift) ; distinct notebook/substance: CSP-2 (foundations attribution, 4 cells) vs CSP-3 (intro+print+Bilan).

## What

Fixes an **IDENTITY** defect in `CSP-2-Consistency.ipynb`: the prereq list, intro prose, Classe CSP header, and MRV heuristique code comment all frame **"Search-6"** as the notebook where CSP foundations (formalisme CSP, backtracking, Classe CSP, heuristique MRV) were built. Stale leftover from old notebook numbering: **Search-6 = AdversarialSearch** (Part1-Foundations). The real foundations notebook is **CSP-1 (Fondamentaux)** — which CSP-2's OWN c[0] nav names as prev: `[<< CSP-1-Fondamentaux](CSP-1-Fundamentals.ipynb)`. Same family-wide drift as CSP-3 (merged #9081). Markdown + code comment, no re-execution. Found via the #8052 claims↔outputs audit (Search/Part2-CSP slice).

## Ground truth (firsthand verified, L786-2)

- `git ls-tree` Part1-Foundations: Search-6 = AdversarialSearch.
- CSP-1 has `class CSP` / `Classe CSP` / `MRV` / `backtracking` / `Minimum Remaining` / `LCV` — all present, so "rappel de CSP-1" is accurate.
- CSP-2 c[0] nav names CSP-1-Fundamentals.ipynb as prev — so "le notebook précédent (Search-6)" is self-contradicted by CSP-2's own navigation.

## Defect (IDENTITY c.1062-L — strongest class)

- **cell[0] prereq** (markdown): « - Search-6 : formalisme CSP, backtracking, heuristiques MRV/LCV » → CSP-1
- **cell[1] prose** (markdown): « Dans le notebook précédent (Search-6) » → (CSP-1)
- **cell[3] header** (markdown): « ### Classe CSP (rappel de Search-6) » → (rappel de CSP-1)
- **cell[6] comment** (code): « # Heuristique MRV (rappel de Search-6) » → (rappel de CSP-1)

All 4 hits = "Search-6" → "CSP-1". (CSP-2 references only "Search-6" — the foundations notebook — never "Search-7", because in the old numbering Search-7 = consistency = CSP-2 itself.)

## Fix

4 targeted edits across 4 cells. Source-only — no committed output carried "Search-6", so no print-literal atomic edit was needed. 0 residual "Search-6"/"Search-7" as CSP attribution anywhere (assertion-locked).

## Verification (firsthand, #8052 lens)

- Ground-truth cross-check in the edit script: c[0] nav names CSP-1-Fundamentals.ipynb as prev.
- Canonical JSON round-trip byte-identical pre/post. **Trailing-adaptive** (c.1086-L): CSP-2 ends WITH a trailing newline (unlike CSP-3), but the assert uses `trailing = '\n' if raw.endswith('\n') else ''` regardless.
- diff = 8 lines (4 edit pairs), no code/output change beyond the comment edit. `assert len(diff) < 40` corruption guard passed.

**CSP-2 is TWINNED** (semantic). C# twin **UNCHANGED** (`e846c562`, Choco-solver) → `python_sha` rebaselined `49861cbc → e4bcb98f` (parity axis = AC-3/FC/MAC consistency concept, untouched); `csharp_sha` unchanged. `check_twin_parity --check` → CSP-2 **[OK]** (resolves at commit).

## Coexistence note (coord sequencing)

PR **#9048** (po-2025, CSP-2 BT/FC/MAC **timing** re-exec, twin rebaseline) touches **different cells** (timing §D.5) — **distinct substance** (this PR = IDENTITY in c[0]/c[1]/c[3]/c[6], not timing; c.1062-L: timing is the weaker class, identity the stronger). Content edits are non-overlapping; only the twin yaml `python_sha` line is shared, which resolves at merge (whoever merges second rebaselines on the other's SHA). Flagged for sequencing — not a conflict.

## Scope

1 file content + 1 registry file. No source changes beyond the identity corrections and the attested-SHA refresh.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
