### PR TITLE
fix(gametheory,#8052): GT-6 robust table marks AlwaysCooperate "Robuste: Oui" but it collapses to dead last (#8) under noise

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust.ipynb
@@ -2099,7 +2099,7 @@
     "| **TitForTat** | Oui | Oui | Oui | Non |\n",
     "| **TitForTwoTats** | Oui | Oui | Très | Oui |\n",
     "| **Grudger** | Oui | Oui | Non | Non |\n",
-    "| **AlwaysCooperate** | Oui | Non | N/A | Oui |\n",
+    "| **AlwaysCooperate** | Oui | Non | N/A | Non |\n",
     "| **AlwaysDefect** | Non | N/A | N/A | Oui |\n",
     "| **Pavlov** | Oui | Variable | Variable | Moyen |\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-6-evolutiontrust.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-6-evolutiontrust.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: e45fb36548d082806991c54c8d332f61347c894a
+    date: "2026-07-31"
+    by: myia-po-2024:CoursIA-2
+    python_sha: db8f5ea35f0f891863bcf212bc112b031cafa494
     csharp_sha: ebd556fc1bbd7743aa60567b2fafab1853f384e7
   known_differences:
     - "Socle pedagogique commun : Dilemme du Prisonnier Itere (IPD), tournoi d'Axelrod, strategies classiques (TitForTat, Pavlov, Generous TitForTat), dynamique evolutive (processus de Moran), emergence de la cooperation."


### PR DESCRIPTION
Grain: MED/value — lane myia-po-2024:CoursIA-2 — prev: MED/value #9085 GT-14 (same family, distinct notebook/substance: GT-6 robust-table vs GT-14 recap-values).

## What

Fixes a **VALUE** defect in `GameTheory-6-EvolutionTrust.ipynb`: cell[42]'s strategy-properties table marks **AlwaysCooperate** as « Robuste au bruit: **Oui** », but AlwaysCooperate is the **least** robust strategy under noise. Markdown-only, no re-execution. Found via the #8052 claims↔outputs audit (GameTheory slice).

## Ground truth (firsthand verified, L786-2)

The « Robuste au bruit » column uses an **outcome-based** definition — does the strategy keep its ranking/performance under noise? — consistent across every other row:

| Strategy | Clean rank | Noise rank (5%) | Table says | Correct? |
|----------|-----------|-----------------|------------|----------|
| TitForTat | #2 (518.69) | #3 (432.24) | Non | ✓ |
| TitForTwoTats | #1 (520.06) | #1 (440.83) | Oui | ✓ |
| Grudger | #3 (498.25) | #5 (428.87) | Non | ✓ |
| **AlwaysCooperate** | #5 (484.12) | **#8 DEAD LAST (383.77)** | **Oui** | **✗** |
| AlwaysDefect | #7 (401.25) | #7 (424.02) | Oui | ✓ (stable) |

AlwaysCooperate suffers the **largest score collapse** of any strategy (−100.35), and the notebook's own cell[16] states it outright:
> « 4. **AlwaysCooperate chute** : Sans reciprocite, les erreurs s'accumulent contre lui »

## Defect (VALUE c.1062-L — strongest class)

- **cell[42] s9**: `| **AlwaysCooperate** | Oui | Non | N/A | Oui |` → last cell `Oui` → **`Non`** (rank #5 → dead last #8 under noise; the biggest collapse of any strategy).

**AlwaysDefect "Oui" is left UNTOUCHED** — it is defensible: AlwaysDefect is stable #7→#7 under noise, its ranking holds. Only the AlwaysCooperate entry contradicts the column's own outcome-based definition.

## ORIGIN (partial-fix residue)

Merged **#7921** (2026-07-22, doc-honesty) fixed cell[16]'s noise-evolution comparison table but **missed the cell[42] robust-properties table**. Same "partial fix" residue pattern as GT-14 (#9085), where merged PRs fixed the computation but missed the recap.

## Fix

1 element in cell[42] (a table row). Source-only (hand-written table, not a committed output) — no print-literal atomic edit. The other 5 table rows + headers are preserved (assertion-locked, untouched).

## Verification (firsthand, #8052 lens)

Ground-truth cross-checks in the edit script lock: cell[13] output « 5 AlwaysCooperate 484.12 » (clean rank 5), cell[15] output « 8 AlwaysCooperate 383.77 » (noise rank 8, dead last), cell[16] « AlwaysCooperate chute ». Canonical JSON round-trip byte-identical pre/post (**trailing-adaptive** c.1086-L). diff = 2 lines (1 row edit), no code/output change. `assert len(diff) < 40` passed.

**GameTheory-6 is TWINNED** (semantic, .NET-Parity). C# twin **UNCHANGED** (`ebd556fc`) → `python_sha` rebaselined `e45fb365 → db8f5ea3` (parity axis = Axelrod iterated-prisoner's-dilemma / trust concept, untouched); `csharp_sha` unchanged. `check_twin_parity --check` → GameTheory-6 **[OK]** (pre-commit staged-state DRIFT resolved at commit, c.1086).

## Scope

1 file content + 1 registry file. No source changes beyond the value correction and the attested-SHA refresh.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
