### PR TITLE
docs(twin-parity,#8957): name strip-ordering constraint in --update help + success reminder

### DIFF
--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -592,7 +592,11 @@ def main(argv=None) -> int:
                    help="Exit 1 si DRIFT/MISSING detecte (CI-ready)")
     p.add_argument("--update", action="store_true",
                    help="Rebaseline : ecrit les SHAs courants comme nouveau last_audit "
-                        "(a lancer APRES une audit firsthand d'une paire)")
+                        "(a lancer APRES une audit firsthand d'une paire, ET EN DERNIER : "
+                        "toute normalisation outillee ulterieure -- strip_probe_banner.py, "
+                        "strip_machine_paths.py, scrub_papermill_paths.py -- deplace le "
+                        "blob SHA sans toucher le contenu calcule et invaliderait cette "
+                        "attestation, cf #8957)")
     p.add_argument("--json", action="store_true", help="Sortie machine JSON")
     p.add_argument("--coverage", action="store_true",
                    help="Recense les notebooks C# versionnes NON couverts par le "
@@ -835,6 +839,17 @@ def main(argv=None) -> int:
             )
         msg = f"Registre rebaseline : {updated} paire(s) mise(s) a jour -> {reg_path}"
         print(msg)
+        # Rappel d'ordre (#8957) : ce rebaseline est l'attestation des SHAs courants.
+        # Il va EN DERNIER -- si un strip outille (strip_probe_banner.py --apply,
+        # strip_machine_paths.py, scrub_papermill_paths.py) edite le notebook APRES
+        # ce point, le blob SHA deplace et le gate --per-pair sortira DRIFT-INTRO
+        # sur la prochaine PR (la parite est vraie, c'est son empreinte qui a bouge).
+        print(
+            "Rappel : cette attestation est celle du notebook TEL QU'IL EST MAINTENANT. "
+            "Tout strip outille ulterieur deplace le blob SHA -- si vous devez "
+            "normaliser (strip_probe_banner / strip_machine_paths / scrub_papermill), "
+            "refaites --update en dernier, apres (cf #8957)."
+        )
         return 0
 
     results = [check_pair(repo_root, pp) for pp in pairs]


### PR DESCRIPTION
## Scope — #8957 critere 2 (le message outil nomme la contrainte d ordre)

#8957 documente le piege : rebaseline check_twin_parity --update ecrit le git blob SHA du notebook ; tout strip outille ulterieur (strip_probe_banner --apply, strip_machine_paths, scrub_papermill_paths) deplace ce blob SANS toucher le contenu calcule -> la parite est vraie mais son empreinte a bouge -> le gate --per-pair sort DRIFT-INTRO. Ordre canonique : re-exec -> normalisations outillees -> rebaseline EN DERNIER.

### Etat des 3 criteres de l issue

| Critere | Etat |
|---|---|
| #1 sequence dans les DEUX sections README | DEJA FAIT (check_twin_parity section l.396-411 + strip_probe_banner section l.475-480, les deux se referencent et citent #8957) |
| **#2 le message imprime (gate OU aide --update) nomme la contrainte** | **CORRIGE PAR CETTE PR** (ci-dessous) |
| #3 garde refus-de-strip-pending | OPTIONNEL — l issue dit explicitement "sinon la doc suffit", skipped |

### Ce que fait cette PR (critere 2, 2 sous-lacunes)

1. **Aide --update (argparse)** : disait seulement "a lancer APRES une audit firsthand" sans nommer le piege strip. Complete pour nommer strip_probe_banner / strip_machine_paths / scrub_papermill_paths comme normalisations qui deplacent le blob SHA et doivent PRECEDER le rebaseline.
2. **Rappel sur le chemin SUCCES de --update** : le rappel d ordre existait DEJA mais seulement sur le chemin ECHEC de --check --per-pair (l.758-764). Un worker qui lance --update (le geste d attestation) n avait AUCUN rappel au moment ou il attestait. Ajout d un one-liner symetrique au moment du succes.

### Preuves

- Aide --update avant : "a lancer APRES une audit firsthand d une paire"
- Aide --update apres : + "ET EN DERNIER : toute normalisation outillee ulterieure -- strip_probe_banner.py, strip_machine_paths.py, scrub_papermill_paths.py -- deplace le blob SHA sans toucher le contenu calcule et invaliderait cette attestation, cf #8957"
- Tool runs : --help affiche le texte enrichi ; read-only check --family SMT/Z3-API -> OK=6 DRIFT=0 MISSING=0 (exit 0)
- Tests : 35/35 check_twin_parity tests pass (pytest, 5.09s)
- Diff : 16 ins / 1 del, 2 hunks, help text + 1 print. Pas de changement de comportement.

### Correction d une erreur G.1 de mon cycle precedent

Mon cycle c.812 a poste un comment sur #8957 affirmant "MOOT — check_twin_parity.py supprime de main". C etait FAUX : l outil EXISTE sur origin/main (scripts/notebook_tools/check_twin_parity.py, ajoute en #8079, jamais supprime). Cause racine : j ai lu contre HEAD (l arbre partage stale 25369a46a, 8 commits derriere origin/main) au lieu de origin/main — exactement la lecon polluted-cwd-worktree-false-positive-g1 / check-twin-parity-phantom-drift-wrong-head de ma propre memoire, que je n ai pas appliquee. Desole pour le bruit. Cette PR corrige le diagnostic : l issue est actionable, le tool existe, le critere 2 etait le vrai lacune restant.

See #8957.

🤖 Generated with [Claude Code](https://claude.com/claude-code)