### PR TITLE
fix(gametheory,#8052): GT-16 universal-quantifier "pour chaque profil" false -- (a',a') has no outcome > SW(o1) (empty list, o1 optimal)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
@@ -1572,7 +1572,7 @@
    "source": [
     "### 4.6.3 Interpretation : la Caracteristique 2 tient en charpie\n",
     "\n",
-    "**Resultat** : pour **chaque** profil de vrais types $(a, a), (a, a'), (a', a), (a', a')$, il existe au moins un outcome *differents de $o_1$* dont le bien-etre social depasse $SW(o_1)$. Concretement :\n",
+    "**Resultat** : des qu'un agent byzantin apparait (3 des 4 profils -- tous sauf $(a', a')$), il existe au moins un outcome *different de $o_1$* dont le bien-etre social depasse $SW(o_1)$. (Le profil sans byzantin $(a', a')$ fait exception : $o_1$ y est optimal.) Concretement :\n",
     "\n",
     "- Profil $(a, a)$ : $o_2$ donne $SW = 4 > 2 = SW(o_1)$.\n",
     "- Profil $(a, a')$ : $o_3$ donne $SW = 6 > 5 = SW(o_1)$.\n",

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-16-mechanismdesign.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-16-mechanismdesign.yaml
@@ -5,8 +5,8 @@
   parity_level: semantic
   last_audit:
     date: "2026-07-31"
-    by: myia-po-2023:CoursIA
-    python_sha: c24fac8331faf0b0a8fc0db138d11cece353e027
+    by: myia-po-2024:CoursIA-2
+    python_sha: 2fe1a205b80c23fe6c79128e6f93576a805bccb9
     csharp_sha: fd5fd04b331a2cbef35868a55e5e25436493b00f
   known_differences:
     - "Socle pedagogique commun : theorie des mecanismes et principe de revelation, encheres premier et second prix, Vickrey 1961 (sincerite de l'enchere au second prix), mecanisme VCG (Vickrey-Clarke-Groves) et regle de Clarke."


### PR DESCRIPTION
Grain: MED/value — lane myia-po-2024:CoursIA-2 — prev: MED/value #9086 GT-6 (same family, distinct notebook/substance: GT-16 universal-quantifier vs GT-6 robust-table).

## What

Fixes a **STRUCTURAL/VALUE** defect in `GameTheory-16-MechanismDesign.ipynb`: cell[29] s2 asserts a **universal quantifier** that is contradicted by cell[28]'s committed SW computation *and* by the cell's own s7/s9. Markdown-only, no re-execution. Found via the #8052 claims↔outputs audit (GameTheory slice).

## Ground truth (firsthand verified, L786-2)

cell[28] committed output (Caractéristique 2 / strict MOM, welfare SW):

```
Profil (a,a)   : SW(o1)=2,  outcomes > SW(o1) : ['o2','o3','o4']
Profil (a,a')  : SW(o1)=5,  outcomes > SW(o1) : ['o3']
Profil (a',a)  : SW(o1)=4,  outcomes > SW(o1) : ['o2']
Profil (a',a') : SW(o1)=7,  outcomes > SW(o1) : []            <- EMPTY: o1 is optimal
```

## Defect (STRUCTURAL/VALUE c.1062-L; intra-notebook self-contradiction c.1069-L)

- **cell[29] s2**: « pour **chaque** profil … il existe au moins un outcome … dont le SW dépasse SW(o₁) » — **FALSE for (a',a')**, whose `outcomes > SW(o1)` list is **EMPTY** (o₁ is optimal at SW=7). The cell **already contradicts itself**:
  - **s7**: « Profil (a',a') : o₁ reste optimal (SW=7), aucun outcome ne le surpasse »
  - **s9**: « dès qu'un agent byzantin … apparaît, le mécanisme bénéficie d'un outcome strictement meilleur »

## Fix (markdown-only, grounded in the cell's OWN s7/s9)

Rewrite s2 to the honest **scoped** claim — it holds for the **3 of 4** profiles *with* a byzantine agent, not for the all-truthful (a',a'):

> « **Résultat** : dès qu'un agent byzantin apparaît (3 des 4 profils — tous sauf (a',a')), il existe au moins un outcome *différent de o₁* dont le bien-être social dépasse SW(o₁). (Le profil sans byzantin (a',a') fait exception : o₁ y est optimal.) Concrètement : »

**Preserved untouched**: s4/s5/s6 (the 3 correct concrete examples) and s7/s9 (the grounding). The incidental "différents"→"différent" plural normalization happens inside the rewritten clause (not a separate edit).

## Verification (firsthand, #8052 lens)

Ground-truth cross-checks in the edit script lock cell[28] output: **(a',a')=[] EMPTY** (o₁ optimal), the 3 others non-empty with exact lists; and preserve cell[29] s4/s5/s6/s7/s9 verbatim. Canonical JSON round-trip byte-identical pre/post (**trailing-adaptive** c.1086-L — GT-16 ends **without** a trailing newline). diff = 2 lines (1 element rewrite), no code/output change. `assert len(diff) < 40` passed.

**GameTheory-16 is TWINNED** (semantic, .NET-Parity). C# twin **UNCHANGED** (`fd5fd04b`) → `python_sha` rebaselined `c24fac83 → 2fe1a205` (parity axis = mechanism-design / VCG / strict-MOM concept, untouched); `csharp_sha` unchanged. `check_twin_parity --check` → GameTheory-16 **[OK]** (pre-commit staged-state DRIFT resolved at commit, c.1086).

## Coexistence (coord sequencing)

po-2023 merged **#9004** (Gale-Shapley stability prose — **distinct section**) and **#8285** (citations docs #8081, merged 2026-07-24) — both unrelated to this cell-29 Caractéristique-2 fix. No content overlap; only the twin yaml `python_sha` line is shared and resolves at merge.

## Scope

1 file content + 1 registry file. No source changes beyond the claim correction and the attested-SHA refresh.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
