### PR TITLE
feat(tooling,#9089): extend migrate_cost_frontmatter_to_metadata for GenAI shape

### DIFF
--- a/scripts/audit/migrate_cost_frontmatter_to_metadata.py
+++ b/scripts/audit/migrate_cost_frontmatter_to_metadata.py
@@ -45,6 +45,32 @@ Usage
   python scripts/audit/migrate_cost_frontmatter_to_metadata.py \\
       --project MyIA.AI.Notebooks/QuantConnect/projects/RiskParity --apply
 
+FORME GenAI (#9089, follow-up de #9088)
+---------------------------------------
+Le path GenAI (migrate_genai_notebook) est un SUPERSET du path QC. Il gere les
+3 axes ou la forme GenAI differe du quantbook QC :
+  - frontmatter en cell#0 OU cell#1 (Audio/Image le portent en cell#1, apres
+    la cell titre/navigation) ;
+  - metadata.cost ABSENT -> CREE depuis le frontmatter (pas de scanner QC) ;
+  - frontmatter MALFORME (closing `---` indente, avale par `notes: |`) ->
+    parse tolerant yaml.safe_load.
+De plus : un bloc top-level `notes:` migre vers `metadata.cost.notes` (guard
+#8921-4, « cas Claudish » — un colocataire substantiel ne doit pas etre
+silencieusement droppe avec le frontmatter), et les timestamps ISO auto-parses
+par yaml.safe_load sont re-serializes en chaines ISO (json.dumps ne serialise
+pas les datetime). Une cell frontmatter-only est SUPPRIMEE ; une cell
+frontmatter + trailing H1 est strippee en gardant le H1.
+
+`--shape` :
+  - `auto` (defaut) : GenAI-first (superset) ; fallback QC pour un diagnostic
+    plus fin sur les notebooks sans cell `--- cost:` (ex. deja migre ->
+    skip-already-migrated). Un quantbook QC est traite de facon identique par
+    les deux paths (union cost + strip).
+  - `qc` : path QC strict (cell#0, metadata.cost present, bien forme) — refuse
+    si metadata.cost absent (contrat quantbook : peupler via
+    populate_quantconnect_cost.py d'abord).
+  - `genai` : path GenAI uniquement.
+
 Exit codes : 0 = ok (dry-run ou apply) ; 1 = au moins une erreur/defaut de coherence.
 """
 
@@ -111,6 +137,94 @@ def strip_frontmatter_preserving_type(raw_source):
 
 def _lf_only(text: str) -> str:
     return text.replace("\r\n", "\n")
+
+
+# ---------------------------------------------------------------------------
+# GenAI shape (#9089, follow-up of #9088) — ADDITIVE, QC path unchanged.
+#
+# The GenAI shape differs from the QC quantbook shape on three axes:
+#   1. frontmatter in cell#0 OR cell#1 (Audio/Image carry it in cell#1, after a
+#      title/navigation cell);
+#   2. `metadata.cost` usually ABSENT (no QC scanner populates it first) — the
+#      frontmatter is the only source, so migration must CREATE it;
+#   3. MALFORMED frontmatter possible (3 Audio notebooks: the closing `---` is
+#      indented and swallowed by a `notes: |` block — no column-0 closer; a raw
+#      whole-body `yaml.safe_load` is tolerant of this).
+# Additionally: a top-level `notes:` colocataire migrates to
+# `metadata.cost.notes` (guard #8921-4, "cas Claudish" — a substantive prose
+# block must not be silently dropped with the frontmatter), and ISO timestamps
+# auto-parsed by yaml.safe_load (e.g. `metadata_written: 2026-07-23T09:30Z`)
+# are sanitized back to ISO strings (json.dumps cannot serialize datetimes).
+# ---------------------------------------------------------------------------
+
+
+def _sanitize(obj):
+    """yaml.safe_load auto-parses ISO timestamps into datetime objects, which
+    json.dumps cannot serialize. Convert them (and nested) back to ISO strings."""
+    import datetime
+    if isinstance(obj, dict):
+        return {k: _sanitize(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize(v) for v in obj]
+    if isinstance(obj, (datetime.datetime, datetime.date)):
+        return obj.isoformat()
+    return obj
+
+
+# Well-formed frontmatter WITH trailing capture: opening `---`, body, col-0
+# closing `---`, optional trailing content. The body is parsed BETWEEN the
+# delimiters (a raw whole-body parse sees the closing `---` as a YAML doc
+# separator -> error).
+_WF_RE_TRAILING = re.compile(r"\A---\s*\n(.*?)\n---\s*\n?(.*)\Z", re.DOTALL)
+
+
+def parse_frontmatter_genai(src: str):
+    """GenAI frontmatter parser. Returns (fm_dict, trailing_str) or (None, None).
+
+    Well-formed (col-0 closing `---`): parse the body BETWEEN delimiters; the
+    closing `---` is a YAML doc separator, so a raw whole-body parse fails.
+    trailing = content after the closer (may be '' for frontmatter-only cells).
+
+    Malformed (no col-0 closer, e.g. indented `---` swallowed by `notes: |`):
+    tolerant whole-body `yaml.safe_load` (the indented closer becomes literal
+    content); the whole cell is frontmatter -> trailing = ''.
+    """
+    m = _WF_RE_TRAILING.match(src)
+    if m:
+        try:
+            data = yaml.safe_load(m.group(1)) or {}
+            if isinstance(data, dict):
+                return data, m.group(2)
+        except yaml.YAMLError:
+            pass
+    # Malformed fallback: tolerant whole-body parse.
+    body = re.sub(r"\A---\s*\n", "", src, count=1)
+    try:
+        data = yaml.safe_load(body)
+    except yaml.YAMLError:
+        return None, None
+    if isinstance(data, dict):
+        return data, ""
+    return None, None
+
+
+def find_genai_frontmatter_cell(nb: dict):
+    """Return (idx, fm_dict, trailing_str, src_str) for the first markdown cell
+    among #0/#1 whose source starts with `---` and parses to a dict with a
+    `cost` key. None if no such cell."""
+    for i in (0, 1):
+        if i >= len(nb.get("cells", [])):
+            continue
+        c = nb["cells"][i]
+        if c.get("cell_type") != "markdown":
+            continue
+        src = _as_str(c.get("source", ""))
+        if not src.startswith("---"):
+            continue
+        fm, trailing = parse_frontmatter_genai(src)
+        if isinstance(fm, dict) and isinstance(fm.get("cost"), dict):
+            return i, fm, trailing, src
+    return None
 
 
 def migrate_notebook(path: Path, apply: bool, by: str):
@@ -246,8 +360,186 @@ def migrate_notebook(path: Path, apply: bool, by: str):
     return report
 
 
+def migrate_genai_notebook(path: Path, apply: bool, by: str):
+    """Migre un notebook de la forme GenAI (#9089, follow-up de #9088).
+
+    Differencie du path QC (migrate_notebook, inchange) sur :
+      - frontmatter en cell#0 OU cell#1 ;
+      - metadata.cost absent -> CREE depuis le frontmatter ;
+      - frontmatter malforme (closing `---` indente) -> parse tolerant ;
+      - notes: -> metadata.cost.notes (guard #8921-4) ;
+      - cell frontmatter-only -> SUPPRIME la cell ; frontmatter+trailing -> garde le H1.
+
+    Memes gates que le path QC : byte-stable round-trip, code-sha256 inchange,
+    output-count inchange, diff minimal.
+    """
+    import copy
+    import hashlib
+    rel = str(path)
+    try:
+        original = path.read_text(encoding="utf-8")
+        nb_o = json.loads(original)
+    except Exception as exc:
+        return {"path": rel, "status": "error", "detail": f"read/parse: {exc}"}
+
+    found = find_genai_frontmatter_cell(nb_o)
+    if found is None:
+        return {"path": rel, "status": "skip-no-genai-frontmatter",
+                "detail": "no `--- cost:` cell among #0/#1"}
+    fm_idx, fm, trailing, fm_full_src = found
+    fm_cost = _sanitize(fm.get("cost") or {})
+
+    meta = nb_o.get("metadata", {})
+    meta_cost = meta.get("cost")
+    existing = meta_cost if isinstance(meta_cost, dict) else {}
+    merged = {**existing, **fm_cost}
+    # Guard #8921-4 : un bloc notes: substantiel migre vers metadata.cost.notes.
+    notes = fm.get("notes")
+    if isinstance(notes, str) and notes.strip() and "notes" not in merged:
+        merged["notes"] = notes.strip()
+
+    overwritten = {k: {"from": existing.get(k), "to": fm_cost.get(k)}
+                   for k in fm_cost if existing.get(k) != fm_cost.get(k)}
+    meta_only = sorted(k for k in existing if k not in fm_cost)
+
+    nb_n = copy.deepcopy(nb_o)
+    if trailing.strip():
+        # frontmatter + trailing -> garder la cell, source = trailing (preserver list/str).
+        old_cell = nb_n["cells"][fm_idx]
+        if isinstance(old_cell.get("source"), list):
+            old_cell["source"] = trailing.splitlines(keepends=True)
+        else:
+            old_cell["source"] = trailing
+        removed = False
+    else:
+        # frontmatter-only -> supprimer la cell.
+        del nb_n["cells"][fm_idx]
+        removed = True
+    nb_n.setdefault("metadata", {})["cost"] = merged
+
+    # ---- GATES ----
+    gates = {}
+    # 1. byte-stable baseline (tolere un \n final manquant dans l'original).
+    rt_orig = _lf_only(json.dumps(json.loads(original), indent=1, ensure_ascii=False) + "\n")
+    norm_orig = _lf_only(original)
+    if not norm_orig.endswith("\n"):
+        norm_orig += "\n"
+    gates["byte_stable_baseline"] = (rt_orig == norm_orig)
+
+    # 2. code sha256 inchange (ensemble ; la cell supprimee est markdown).
+    def _code_sha_set(nb):
+        out = []
+        for c in nb.get("cells", []):
+            if c.get("cell_type") == "code":
+                out.append(hashlib.sha256(_as_str(c.get("source", "")).encode("utf-8")).hexdigest())
+        return out
+    gates["code_sha_unchanged"] = (_code_sha_set(nb_o) == _code_sha_set(nb_n))
+
+    # 3. output-count inchange (la cell frontmatter est markdown : pas d'outputs).
+    def _output_count(nb):
+        return sum(len(c.get("outputs") or []) for c in nb.get("cells", []))
+    oc_o, oc_n = _output_count(nb_o), _output_count(nb_n)
+    gates["output_count_unchanged"] = (oc_o == oc_n)
+    gates["output_count"] = f"{oc_o}->{oc_n}"
+
+    # 4. diff minimal : seuls la cell frontmatter (source) et metadata.cost changent.
+    cells_o, cells_n = nb_o["cells"], nb_n["cells"]
+    minimal, diff_detail = True, []
+    if removed:
+        keep_o = [c for j, c in enumerate(cells_o) if j != fm_idx]
+        if len(keep_o) != len(cells_n):
+            minimal = False
+            diff_detail.append(f"len mismatch after removal {len(keep_o)} vs {len(cells_n)}")
+        else:
+            for j, (co, cn) in enumerate(zip(keep_o, cells_n)):
+                if co != cn:
+                    minimal = False
+                    diff_detail.append(f"kept cell#{j} differs")
+    else:
+        if len(cells_o) != len(cells_n):
+            minimal = False
+            diff_detail.append("len changed without removal")
+        else:
+            for j, (co, cn) in enumerate(zip(cells_o, cells_n)):
+                if j == fm_idx:
+                    for k in co:
+                        if k == "source":
+                            continue
+                        if co.get(k) != cn.get(k):
+                            minimal = False
+                            diff_detail.append(f"fm cell#{j} field {k} changed")
+                elif co != cn:
+                    minimal = False
+                    diff_detail.append(f"cell#{j} changed")
+    meta_o, meta_n = nb_o.get("metadata", {}), nb_n.get("metadata", {})
+    for k in set(list(meta_o.keys()) + list(meta_n.keys())):
+        if k == "cost":
+            continue
+        if meta_o.get(k) != meta_n.get(k):
+            minimal = False
+            diff_detail.append(f"metadata field {k} changed")
+    gates["minimal_diff"] = minimal
+    gates["diff_detail"] = diff_detail
+
+    if removed:
+        gates["kept_cell_starts_with_h1"] = "n/a (cell removed)"
+    else:
+        new_src = _as_str(nb_n["cells"][fm_idx].get("source", ""))
+        gates["kept_cell_starts_with_h1"] = new_src.lstrip().startswith("#")
+
+    new_content = _lf_only(json.dumps(nb_n, indent=1, ensure_ascii=False) + "\n")
+    all_ok = (gates["byte_stable_baseline"] and gates["code_sha_unchanged"]
+              and gates["output_count_unchanged"] and gates["minimal_diff"]
+              and (removed or gates["kept_cell_starts_with_h1"]))
+
+    report = {
+        "path": rel,
+        "fm_cell": f"#{fm_idx}",
+        "action": "remove-cell" if removed else "strip-keep-trailing",
+        "trailing_chars": len(trailing),
+        "cost_keys": sorted(fm_cost.keys()),
+        "overwritten_fields": overwritten,
+        "metadata_only_fields_preserved": meta_only,
+        "merged_cost_keys": len(merged),
+        "notes_migrated": "notes" in merged and isinstance(fm.get("notes"), str),
+        **gates,
+    }
+    if not apply:
+        report["status"] = "dry-run-genai" if all_ok else "dry-run-genai-GATE-FAIL"
+        return report
+    if not all_ok:
+        report["status"] = "aborted-genai-gate-fail"
+        return report
+    path.write_bytes(new_content.encode("utf-8"))
+    report["status"] = "migrated-genai"
+    return report
+
+
 def _iter_project(project_dir: Path):
     yield from sorted(project_dir.glob("*.ipynb"))
+
+
+def _dispatch(path: Path, apply: bool, by: str, shape: str):
+    """Choisit le path QC (migrate_notebook) ou GenAI (migrate_genai_notebook)
+    selon --shape.
+
+    Le path GenAI est un SUPERSET du path QC : il gere cell#0 OU cell#1, le
+    frontmatter malforme, la creation de metadata.cost si absent, ET migre
+    `notes:` -> metadata.cost.notes (guard #8921-4). Un quantbook QC (cell#0
+    bien forme + metadata.cost present) est traite de facon identique par les
+    deux paths (union cost + strip). `auto` prefere donc GenAI (uniformise la
+    migration notes sur tous les notebooks a frontmatter cost) et ne retombe
+    sur QC que si GenAI ne reconnait pas de cell `--- cost:` (ex. notebook
+    deja migre -> QC donne un skip-already-migrated plus specifique)."""
+    if shape == "qc":
+        return migrate_notebook(path, apply=apply, by=by)
+    if shape == "genai":
+        return migrate_genai_notebook(path, apply=apply, by=by)
+    # auto : GenAI-first (superset), fallback QC pour un diagnostic plus fin.
+    genai_dry = migrate_genai_notebook(path, apply=False, by=by)
+    if genai_dry["status"] != "skip-no-genai-frontmatter":
+        return migrate_genai_notebook(path, apply=apply, by=by)
+    return migrate_notebook(path, apply=apply, by=by)
 
 
 def main(argv=None) -> int:
@@ -257,6 +549,10 @@ def main(argv=None) -> int:
                     help="Répertoire projet QC (migrer tous ses *.ipynb).")
     ap.add_argument("--apply", action="store_true", help="Écrire (défaut : dry-run).")
     ap.add_argument("--by", default="anonymous", help="machine:workspace (provenance).")
+    ap.add_argument("--shape", choices=("auto", "qc", "genai"), default="auto",
+                    help="Forme de frontmatter : qc (cell#0, metadata.cost present, "
+                         "bien forme), genai (cell#0/#1, malforme, metadata.cost absent), "
+                         "auto (defaut : qc si preconditions tiennent, sinon genai).")
     args = ap.parse_args(argv)
 
     paths = list(args.notebooks)
@@ -274,22 +570,33 @@ def main(argv=None) -> int:
             counts["error"] = counts.get("error", 0) + 1
             rc = 1
             continue
-        rep = migrate_notebook(p, apply=args.apply, by=args.by)
+        rep = _dispatch(p, apply=args.apply, by=args.by, shape=args.shape)
         st = rep["status"]
         counts[st] = counts.get(st, 0) + 1
-        marker = "WRITE" if (args.apply and st == "migrated") else "DRY" if st == "dry-run" else "SKIP"
+        is_genai = st.endswith("-genai") or "genai" in st
+        wrote = (args.apply and st in ("migrated", "migrated-genai"))
+        marker = "WRITE" if wrote else ("DRY" if st.startswith("dry-run") else "SKIP")
         if st in ("error", "refused-no-metadata-cost", "aborted-not-equivalent",
-                  "aborted-non-minimal-diff"):
+                  "aborted-non-minimal-diff", "aborted-genai-gate-fail",
+                  "dry-run-genai-GATE-FAIL"):
             rc = 1
         ow = rep.get("overwritten_fields", {})
         total_overwritten += len(ow)
         name = p.name
         fields = ",".join(sorted(ow)) if ow else "-"
-        print(f"  [{marker:4s}] {st:26s} {name:24} overwrite=[{fields}] meta_only={rep.get('metadata_only_fields_preserved', [])}")
-        print(f"          byte_stable_baseline={rep.get('byte_stable_baseline')} "
-              f"field_equivalent={rep.get('field_equivalent')} "
-              f"minimal_diff={rep.get('minimal_diff')} "
-              f"h1={rep.get('new_cell0_starts_with_h1')}")
+        print(f"  [{marker:4s}] {st:28s} {name:26} overwrite=[{fields}] meta_only={rep.get('metadata_only_fields_preserved', [])}")
+        if is_genai:
+            print(f"          fm={rep.get('fm_cell')} act={rep.get('action')} "
+                  f"byte_stable={rep.get('byte_stable_baseline')} "
+                  f"code_sha={rep.get('code_sha_unchanged')} "
+                  f"out_cnt={rep.get('output_count_unchanged')}({rep.get('output_count')}) "
+                  f"minimal={rep.get('minimal_diff')} h1={rep.get('kept_cell_starts_with_h1')} "
+                  f"notes_migrated={rep.get('notes_migrated')}")
+        else:
+            print(f"          byte_stable_baseline={rep.get('byte_stable_baseline')} "
+                  f"field_equivalent={rep.get('field_equivalent')} "
+                  f"minimal_diff={rep.get('minimal_diff')} "
+                  f"h1={rep.get('new_cell0_starts_with_h1')}")
 
     mode = "APPLY" if args.apply else "DRY-RUN"
     print(f"\n[{mode}] by={args.by}  notebooks={len(paths)}  fields_overwritten={total_overwritten}")

--- a/scripts/audit/tests/test_migrate_cost_frontmatter_to_metadata.py
+++ b/scripts/audit/tests/test_migrate_cost_frontmatter_to_metadata.py
@@ -1,0 +1,265 @@
+"""Tests for scripts/audit/migrate_cost_frontmatter_to_metadata.py.
+
+Covers two shapes via the --shape flag:
+  - QC path (migrate_notebook): cell#0 well-formed frontmatter, metadata.cost
+    PRESENT (union), strip keep H1. Regression guard for the original contract
+    (issues #8904 / #8056).
+  - GenAI path (migrate_genai_notebook, #9089 follow-up of #9088): cell#0 OR
+    cell#1, malformed YAML tolerated, metadata.cost ABSENT -> CREATE, top-level
+    `notes:` -> metadata.cost.notes (guard #8921-4), frontmatter-only cell ->
+    REMOVE, datetime sanitization.
+  - auto dispatch (GenAI-first superset, QC fallback).
+
+Fixtures are built as raw nb dicts dumped with the script's own byte-stable
+serializer (json.dumps(indent=1, ensure_ascii=False)+'\\n'), so the
+byte_stable_baseline gate holds without depending on nbformat.write formatting.
+"""
+import importlib.util
+import json
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_PATH = HERE.parent / "migrate_cost_frontmatter_to_metadata.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("migrate_cost_frontmatter", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _cell(ct, src, **kw):
+    c = {"cell_type": ct, "source": src, "metadata": {}}
+    if ct == "code":
+        c["execution_count"] = kw.get("execution_count", 1)
+        c["outputs"] = kw.get("outputs", [])
+    return c
+
+
+def _write_nb(path, cells, metadata=None):
+    nb = {"cells": cells, "metadata": metadata or {}, "nbformat": 4, "nbformat_minor": 5}
+    path.write_bytes((json.dumps(nb, indent=1, ensure_ascii=False) + "\n").encode("utf-8"))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# QC path (regression)
+# ---------------------------------------------------------------------------
+
+def test_qc_union_and_strip(tmp_path):
+    """cell#0 well-formed frontmatter + metadata.cost present -> union + strip keep H1."""
+    mod = _load()
+    fm = "---\ncost:\n  api_provider: openai\n  api_usd_est: 0.5\n---\n# Title\n"
+    cells = [_cell("markdown", fm), _cell("code", "x=1")]
+    p = _write_nb(tmp_path / "qc.ipynb", cells, metadata={"cost": {"qcc_tokens_est": 1200, "api_provider": "local"}})
+    rep = mod.migrate_notebook(p, apply=False, by="test")
+    assert rep["status"] == "dry-run"
+    assert rep["field_equivalent"] is True
+    assert rep["minimal_diff"] is True
+    assert rep["new_cell0_starts_with_h1"] is True
+    # frontmatter api_provider overwrites metadata local; qcc_tokens_est preserved.
+    assert "api_provider" in rep["overwritten_fields"]
+    assert "qcc_tokens_est" in rep["metadata_only_fields_preserved"]
+
+
+def test_qc_refuses_when_metadata_cost_absent(tmp_path):
+    mod = _load()
+    fm = "---\ncost:\n  api_provider: openai\n---\n# Title\n"
+    p = _write_nb(tmp_path / "q.ipynb", [_cell("markdown", fm), _cell("code", "x=1")])
+    rep = mod.migrate_notebook(p, apply=False, by="test")
+    assert rep["status"] == "refused-no-metadata-cost"
+
+
+def test_qc_skip_already_migrated(tmp_path):
+    mod = _load()
+    p = _write_nb(tmp_path / "q.ipynb", [_cell("markdown", "# Title\n"), _cell("code", "x=1")])
+    rep = mod.migrate_notebook(p, apply=False, by="test")
+    assert rep["status"] == "skip-already-migrated"
+
+
+def test_qc_apply_byte_stable(tmp_path):
+    mod = _load()
+    fm = "---\ncost:\n  api_usd_est: 0.5\n---\n# Title\n"
+    cells = [_cell("markdown", fm), _cell("code", "x=1")]
+    p = _write_nb(tmp_path / "q.ipynb", cells, metadata={"cost": {"cpu_min": 1}})
+    rep = mod.migrate_notebook(p, apply=True, by="test")
+    assert rep["status"] == "migrated"
+    out = json.loads(p.read_text(encoding="utf-8"))
+    assert out["metadata"]["cost"] == {"cpu_min": 1, "api_usd_est": 0.5}
+    assert out["cells"][0]["source"].startswith("# Title")
+
+
+# ---------------------------------------------------------------------------
+# GenAI path (new, #9089)
+# ---------------------------------------------------------------------------
+
+def test_genai_cell1_frontmatter_only_remove(tmp_path):
+    """Audio/Image shape: frontmatter in cell#1, no trailing -> REMOVE the cell,
+    CREATE metadata.cost (was absent)."""
+    mod = _load()
+    fm = "---\ntitle: Audio\ncost:\n  api_provider: openai\n  api_usd_est: 0.3\n---\n"
+    cells = [_cell("markdown", "# Title\n"), _cell("markdown", fm), _cell("code", "x=1")]
+    p = _write_nb(tmp_path / "g.ipynb", cells)
+    rep = mod.migrate_genai_notebook(p, apply=True, by="test")
+    assert rep["status"] == "migrated-genai"
+    assert rep["fm_cell"] == "#1"
+    assert rep["action"] == "remove-cell"
+    out = json.loads(p.read_text(encoding="utf-8"))
+    assert len(out["cells"]) == 2  # frontmatter cell removed
+    assert out["cells"][0]["source"] == "# Title\n"
+    assert out["metadata"]["cost"]["api_provider"] == "openai"
+    assert out["metadata"]["cost"]["api_usd_est"] == 0.3
+
+
+def test_genai_cell0_trailing_strip_keep_h1(tmp_path):
+    """Claudish/SK shape: frontmatter + trailing H1 in cell#0 -> strip, keep H1."""
+    mod = _load()
+    fm = "---\ntitle: X\ncost:\n  api_provider: anthropic\n---\n# Real Title\nintro.\n"
+    p = _write_nb(tmp_path / "g.ipynb", [_cell("markdown", fm), _cell("code", "x=1")])
+    rep = mod.migrate_genai_notebook(p, apply=True, by="test")
+    assert rep["status"] == "migrated-genai"
+    assert rep["action"] == "strip-keep-trailing"
+    assert rep["kept_cell_starts_with_h1"] is True
+    out = json.loads(p.read_text(encoding="utf-8"))
+    assert out["cells"][0]["source"].startswith("# Real Title")
+
+
+def test_genai_malformed_yaml_tolerant(tmp_path):
+    """Malformed frontmatter: closing `---` indented, swallowed by `notes: |`.
+    yaml.safe_load is tolerant; whole cell is frontmatter -> remove-cell."""
+    mod = _load()
+    # The closing --- is indented (2 spaces) -> no col-0 closer -> malformed.
+    fm = "---\ntitle: Audio\ncost:\n  api_provider: openai\nnotes: |\n  some note\n  ---\n"
+    p = _write_nb(tmp_path / "g.ipynb", [_cell("markdown", "# T\n"), _cell("markdown", fm), _cell("code", "x=1")])
+    rep = mod.migrate_genai_notebook(p, apply=False, by="test")
+    assert rep["status"] == "dry-run-genai"
+    assert rep["fm_cell"] == "#1"
+    assert rep["action"] == "remove-cell"
+    assert rep["notes_migrated"] is True
+
+
+def test_genai_notes_migrated_to_metadata_cost_notes(tmp_path):
+    """Guard #8921-4 ('cas Claudish'): a top-level notes: block migrates to
+    metadata.cost.notes, not dropped."""
+    mod = _load()
+    fm = "---\ncost:\n  api_provider: openai\nnotes: |\n  This is a substantive note.\n---\n# T\n"
+    p = _write_nb(tmp_path / "g.ipynb", [_cell("markdown", fm), _cell("code", "x=1")])
+    rep = mod.migrate_genai_notebook(p, apply=True, by="test")
+    assert rep["status"] == "migrated-genai"
+    out = json.loads(p.read_text(encoding="utf-8"))
+    assert "notes" in out["metadata"]["cost"]
+    assert "substantive note" in out["metadata"]["cost"]["notes"]
+
+
+def test_genai_notes_not_overwritten_when_metadata_has_it(tmp_path):
+    """If metadata.cost.notes already exists, frontmatter notes does NOT overwrite."""
+    mod = _load()
+    fm = "---\ncost:\n  api_provider: openai\nnotes: frontmatter note\n---\n# T\n"
+    p = _write_nb(tmp_path / "g.ipynb", [_cell("markdown", fm), _cell("code", "x=1")],
+                  metadata={"cost": {"api_provider": "openai", "notes": "existing note"}})
+    rep = mod.migrate_genai_notebook(p, apply=True, by="test")
+    assert rep["status"] == "migrated-genai"
+    out = json.loads(p.read_text(encoding="utf-8"))
+    assert out["metadata"]["cost"]["notes"] == "existing note"
+
+
+def test_genai_metadata_cost_present_union(tmp_path):
+    """metadata.cost present -> union (existing fields preserved, frontmatter wins on overlap)."""
+    mod = _load()
+    fm = "---\ncost:\n  api_provider: openai\n  api_usd_est: 0.5\n---\n# T\n"
+    p = _write_nb(tmp_path / "g.ipynb", [_cell("markdown", fm), _cell("code", "x=1")],
+                  metadata={"cost": {"api_provider": "local", "extra_field": 42}})
+    rep = mod.migrate_genai_notebook(p, apply=True, by="test")
+    out = json.loads(p.read_text(encoding="utf-8"))
+    assert out["metadata"]["cost"]["api_provider"] == "openai"  # frontmatter wins
+    assert out["metadata"]["cost"]["extra_field"] == 42  # existing preserved
+    assert out["metadata"]["cost"]["api_usd_est"] == 0.5
+
+
+def test_genai_datetime_sanitized(tmp_path):
+    """ISO timestamp metadata_written auto-parsed by yaml -> datetime -> sanitized to ISO string."""
+    mod = _load()
+    fm = "---\ncost:\n  api_provider: openai\n  metadata_written: 2026-07-23T09:30:00Z\n---\n# T\n"
+    p = _write_nb(tmp_path / "g.ipynb", [_cell("markdown", fm), _cell("code", "x=1")])
+    rep = mod.migrate_genai_notebook(p, apply=True, by="test")
+    assert rep["status"] == "migrated-genai"
+    out = json.loads(p.read_text(encoding="utf-8"))
+    # Must be a JSON string, not a datetime object.
+    assert isinstance(out["metadata"]["cost"]["metadata_written"], str)
+    assert "2026-07-23" in out["metadata"]["cost"]["metadata_written"]
+
+
+def test_genai_code_sha_and_output_count_unchanged(tmp_path):
+    """Removing the frontmatter cell must not touch code source or outputs."""
+    mod = _load()
+    fm = "---\ncost:\n  api_provider: openai\n---\n"
+    code_out = [{"output_type": "stream", "name": "stdout", "text": ["hello\n"]}]
+    cells = [_cell("markdown", "# T\n"), _cell("markdown", fm),
+             _cell("code", "print('hello')", execution_count=1, outputs=code_out)]
+    p = _write_nb(tmp_path / "g.ipynb", cells)
+    rep = mod.migrate_genai_notebook(p, apply=True, by="test")
+    assert rep["code_sha_unchanged"] is True
+    assert rep["output_count_unchanged"] is True
+    assert rep["minimal_diff"] is True
+    out = json.loads(p.read_text(encoding="utf-8"))
+    # The single code cell kept byte-identical with its output.
+    code_cells = [c for c in out["cells"] if c["cell_type"] == "code"]
+    assert len(code_cells) == 1
+    assert code_cells[0]["outputs"] == code_out
+    assert code_cells[0]["source"] == "print('hello')"
+
+
+def test_genai_idempotent_skip(tmp_path):
+    """Re-running on an already-migrated notebook -> skip."""
+    mod = _load()
+    p = _write_nb(tmp_path / "g.ipynb", [_cell("markdown", "# T\n"), _cell("code", "x=1")])
+    rep = mod.migrate_genai_notebook(p, apply=False, by="test")
+    assert rep["status"] == "skip-no-genai-frontmatter"
+
+
+def test_genai_source_list_type_preserved(tmp_path):
+    """When source is a list, the kept trailing content stays a list (no collapse churn)."""
+    mod = _load()
+    fm_list = ["---\n", "cost:\n", "  api_provider: openai\n", "---\n", "# Title\n", "body\n"]
+    p = _write_nb(tmp_path / "g.ipynb", [_cell("markdown", fm_list), _cell("code", "x=1")])
+    rep = mod.migrate_genai_notebook(p, apply=True, by="test")
+    assert rep["status"] == "migrated-genai"
+    out = json.loads(p.read_text(encoding="utf-8"))
+    assert isinstance(out["cells"][0]["source"], list)
+    assert out["cells"][0]["source"][0].startswith("# Title")
+
+
+# ---------------------------------------------------------------------------
+# auto dispatch
+# ---------------------------------------------------------------------------
+
+def test_auto_routes_genai_cell1(tmp_path):
+    """auto (GenAI-first) routes a cell#1 GenAI notebook to the GenAI path."""
+    mod = _load()
+    fm = "---\ncost:\n  api_provider: openai\n---\n"
+    p = _write_nb(tmp_path / "g.ipynb", [_cell("markdown", "# T\n"), _cell("markdown", fm), _cell("code", "x=1")])
+    rep = mod._dispatch(p, apply=False, by="test", shape="auto")
+    assert rep["status"] == "dry-run-genai"
+
+
+def test_auto_fallback_qc_for_already_migrated(tmp_path):
+    """auto falls back to QC (skip-already-migrated) when no GenAI frontmatter."""
+    mod = _load()
+    p = _write_nb(tmp_path / "g.ipynb", [_cell("markdown", "# T\n"), _cell("code", "x=1")])
+    rep = mod._dispatch(p, apply=False, by="test", shape="auto")
+    assert rep["status"] == "skip-already-migrated"
+
+
+def test_auto_handles_qc_quantbook_via_superset(tmp_path):
+    """auto handles a QC quantbook (cell#0 + metadata.cost present) via the GenAI
+    superset path -> same union result as QC."""
+    mod = _load()
+    fm = "---\ncost:\n  api_provider: openai\n  api_usd_est: 0.5\n---\n# Title\n"
+    p = _write_nb(tmp_path / "q.ipynb", [_cell("markdown", fm), _cell("code", "x=1")],
+                  metadata={"cost": {"qcc_tokens_est": 1200}})
+    rep = mod._dispatch(p, apply=True, by="test", shape="auto")
+    assert rep["status"] == "migrated-genai"
+    out = json.loads(p.read_text(encoding="utf-8"))
+    assert out["metadata"]["cost"]["qcc_tokens_est"] == 1200
+    assert out["metadata"]["cost"]["api_provider"] == "openai"


### PR DESCRIPTION
Grain: LIGHT/tooling -- lane myia-po-2023:CoursIA -- prev: MED/gametheory #9092

Closes #9089 (the tool fully resolves the issue: GenAI shape now handled durably). See #9082, #8056.

## Summary

Extends the canonical `scripts/audit/migrate_cost_frontmatter_to_metadata.py` to handle the **GenAI shape** durably, so future GenAI frontmatter is migrated by the canonical tool rather than via a one-shot. Follow-up of #9088 (where the 6 GenAI notebooks were migrated via a gated one-shot using the canonical script's validated primitives).

The canonical tool previously covered only the **QC quantbook shape** (cell#0, well-formed, `metadata.cost` present). The GenAI shape differs on 3 axes. This PR adds a **GenAI path as an additive superset** — the existing QC `migrate_notebook` path is **byte-unchanged**.

## What the GenAI path handles (`migrate_genai_notebook`)

| Axis | QC shape | GenAI shape (new) |
|------|----------|-------------------|
| Frontmatter location | cell#0 only | **cell#0 OR cell#1** (Audio/Image carry it in cell#1, after a title cell) |
| `metadata.cost` | must be present (union) | **absent → CREATE** from frontmatter (no QC scanner) |
| YAML well-formedness | well-formed only (col-0 closer) | **malformed tolerated** (indented closer swallowed by `notes: \|`) |

Plus:
- **`notes:` → `metadata.cost.notes`** (guard #8921-4, "cas Claudish" — a substantive prose block migrates, never silently dropped with the frontmatter).
- **ISO timestamps** auto-parsed by `yaml.safe_load` → sanitized to ISO strings (`json.dumps` cannot serialize datetimes).
- **frontmatter-only cell → REMOVE**; **frontmatter + trailing H1 → strip, keep H1**.

## `--shape {auto,qc,genai}` (default `auto`)

- `auto` (default) = **GenAI-first superset**; falls back to QC for a finer diagnostic on notebooks without a `--- cost:` cell (e.g. already-migrated → `skip-already-migrated`). A QC quantbook is handled identically by both paths (union cost + strip).
- `qc` = strict legacy contract (refuses if `metadata.cost` absent — the quantbook "populate-first" guard).
- `genai` = GenAI path only.

**No automated callers exist** (ad-hoc tool — grepped scripts/CI/docs), so changing the default to `auto` is safe; `--shape qc` preserves the exact refusal behavior for the quantbook contract.

## Correctness proof — byte-for-byte reproduction of the validated #9088 one-shot

The GenAI path reproduces the **validated #9088 one-shot output byte-for-byte on all 6 notebooks** (03-1/2/3 Audio, 04-4 Image, SK-Intro, Claudish), verified against PR #9088 head commit `34d02bb2`:

```
BYTE-IDENTICAL: 03-1-Multi-Model-Audio-Comparison.ipynb
BYTE-IDENTICAL: 03-2-Audio-Pipeline-Orchestration.ipynb
BYTE-IDENTICAL: 03-3-Realtime-Voice-API.ipynb
BYTE-IDENTICAL: 04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb
BYTE-IDENTICAL: 01-SemanticKernel-Intro.ipynb
BYTE-IDENTICAL: 01-claude-code-via-claudish.ipynb
```

Same gates as the QC path: byte-stable round-trip, code-sha256 unchanged, output-count unchanged, minimal diff, kept-cell-starts-with-H1.

## Acceptance criteria (verified firsthand)

- **QC path unchanged**: `migrate_notebook` byte-identical (4 regression tests pass).
- **17 new tests** (4 QC regression, 10 GenAI incl. malformed-YAML / notes-migration / datetime-sanitize / union / idempotency / list-type-preservation, 3 auto dispatch).
- **Full `scripts/audit/tests/` = 124 passed** (no sibling breakage).
- **AST OK**, `--shape` flag exposed in `--help`.
- **No notebook changes, no re-exec needed** (tooling PR). Catalogue byte-identical to main.

See #9089, #9082, #8056.
