### PR TITLE
fix(rl,#8052): rl_13 misattributes DQN to notebook 3 (DQN = notebook 6)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb
@@ -17,7 +17,7 @@
     "# RL 13 - Exploration par curiosité : Random Network Distillation (RND)\n",
     "\n",
     "Dans la plupart des notebooks précédents, l'exploration reposait sur l'aléa : tirage\n",
-    "**epsilon-greedy** (notebooks 1, 3, 6), bandits (notebook 4) ou bonus de comptage **Dyna-Q+**\n",
+    "**epsilon-greedy** (notebooks 1, 5, 6), bandits (notebook 4) ou bonus de comptage **Dyna-Q+**\n",
     "(notebook 8). Ces stratégies suffisent quand les récompenses sont fréquentes, mais elles\n",
     "**échouent dès que la récompense est rare** : l'agent peut errer des milliers de pas sans\n",
     "jamais rencontrer le moindre signal qui oriente son apprentissage.\n",
@@ -35,7 +35,7 @@
     "- Visualiser le mécanisme comme un **détecteur de nouveauté** (Partie A) puis observer son effet\n",
     "  sur un **piège d'exploitation** (Partie B), où epsilon-greedy reste bloqué et RND s'en échappe.\n",
     "\n",
-    "> Prérequis : notebooks 3 (DQN / expérience replay), 4 (bandits) et 8 (Dyna-Q+, bonus d'exploration)."
+    "> Prérequis : notebooks 6 (DQN / expérience replay), 4 (bandits) et 8 (Dyna-Q+, bonus d'exploration)."
    ]
   },
   {
@@ -610,7 +610,7 @@
     "\n",
     "| Approche | Mesure de nouveauté | Passage à l'échelle | Notebook |\n",
     "|----------|---------------------|---------------------|----------|\n",
-    "| Epsilon-greedy | aucune (aléa uniforme) | trivial mais myope | 1, 3, 6 |\n",
+    "| Epsilon-greedy | aucune (aléa uniforme) | trivial mais myope | 1, 5, 6 |\n",
     "| Comptage tabulaire / Dyna-Q+ | $1/\\sqrt{N(s)}$ | limité aux petits espaces | 8 |\n",
     "| Pseudo-comptage (modèles de densité) | densité estimée | moyen, coûteux | - |\n",
     "| **RND** | **erreur de prédiction d'une cible figée** | **excellent** (réseau) | **13 (ici)** |\n",
@@ -875,7 +875,7 @@
     "\n",
     "- **ICM** (Pathak et al., 2017) : curiosité fondée sur un modèle de dynamique avant/inverse.\n",
     "- **Go-Explore** (Ecoffet et al., 2019) : mémoriser et revisiter les états prometteurs.\n",
-    "- Combiner RND avec un agent **DQN** (notebook 3) ou **PPO** (notebook 6c) sur un environnement\n",
+    "- Combiner RND avec un agent **DQN** (notebook 6) ou **PPO** (notebook 6c) sur un environnement\n",
     "  continu à récompense parcimonieuse (ex. *MountainCar*, *Montezuma's Revenge*).\n",
     "\n",
     "### Références\n",


### PR DESCRIPTION
Grain: MED/identity — lane myia-po-2024:CoursIA-2 — R6 family pivot (GameTheory → RL), prev: MED/identity #9091 GT-9 (distinct family & substance: RL forward-reference DQN attribution vs GT-9 reputation-notebook identity).

## What

Fixes an **IDENTITY** defect in `rl_13_curiosity_exploration.ipynb`: 4 places (cells 0, 14, 22) systematically attribute **DQN** to **notebook 3**. But `rl_3` is **HER / goal-conditioned RL**, not DQN; the DQN notebook is `rl_6`. Markdown-only, no re-execution. Found via the #8052 claims↔outputs audit (RL slice).

## Ground truth (firsthand verified, L786-2)

Confirmed three independent ways:
- **README** (`MyIA.AI.Notebooks/RL/README.md`): row 3 = `rl_3 ... HER, goal-conditioned RL`; row 6 = `rl_6 ... DQN depuis zéro, REINFORCE`.
- **rl_3 source**: `Hindsight` / `HerReplayBuffer` / `SAC` / `DDPG` / `parking-v0`; **0 hit** on `epsilon`, `greedy`, `Q-learning` (and "DQN" only as filename artifact). It is off-policy actor-critic + hindsight, not a value-based DQN agent.
- **rl_6 source**: title `# RL-6 : Deep Q-Network (DQN) et Policy Gradient`; `QNetwork(...)`, `Nombre de parametres`, `epsilon-greedy`, `ReplayBuffer`.

The filename `rl_3_experience_replay_dqn.ipynb` literally contains "dqn" — that is the source of the misattribution. rl_13's **own numbering convention is the actual notebook index**: in the very same intro cell, "bandits (notebook 4)" = rl_4 ✓, "Dyna-Q+ (notebook 8)" = rl_8 ✓, "PPO (notebook 6c)" = rl_6c ✓. So "DQN (notebook 3)" is a stale/wrong attribution → the correct notebook is **6**.

## Defect (IDENTITY c.1062-L — strongest class)

| cell | element | wrong → correct |
|------|---------|-----------------|
| 0 | [3] | `**epsilon-greedy** (notebooks 1, 3, 6)` → `(notebooks 1, 5, 6)` |
| 0 | [21] | prereq `notebooks 3 (DQN / expérience replay)` → `notebooks 6 (DQN / expérience replay)` |
| 14 | [4] | table `| ... \| 1, 3, 6 \|` → `| ... \| 1, 5, 6 \|` |
| 22 | [15] | `agent **DQN** (notebook 3)` → `agent **DQN** (notebook 6)` |

**Why "1, 5, 6" for epsilon-greedy** (firsthand, correcting the sweep sub-agent which proposed "4, 5, 6"): `rl_3` has **no** epsilon-greedy (grep 0 hit) → must be removed; `rl_5` (Q-learning, `epsilon`/`greedy` in cells 10–35) implements it and was **missing** → added; `rl_1` (intro, `eps=` cells 20/38/42) and `rl_6` (DQN) confirmed. `rl_4` is intentionally categorized separately as "bandits (notebook 4)" in the same sentence, so it stays out of the epsilon-greedy list (the sub-agent's "4" would double-list it).

## Fix

4 elements in 3 cells. The lesson prose, the exploration-strategy comparison table structure, and the **correct** references — "PPO (notebook 6c)", "bandits (notebook 4)", "Dyna-Q+ (notebook 8)" — are preserved untouched. rl_13's own numbering convention (notebook 4 = bandits, notebook 8 = Dyna-Q+) confirms the fix direction.

## Verification (firsthand, #8052 lens)

Ground-truth locks in the edit script: README rows (rl_3 = HER, rl_6 = DQN), rl_3 source grep (0 hit on `epsilon`/`greedy`/`Q-learning`), rl_6 source (`QNetwork` + `epsilon-greedy` + replay buffer), c0 "notebook 4 = bandits" + "notebook 8 = Dyna-Q+" (convention = actual index), and **0 residual** `notebook 3 (DQN` / `DQN (notebook 3)` / `1, 3, 6`. Canonical JSON round-trip byte-identical pre/post (**trailing-adaptive** c.1086-L). diff = 8 lines (4 elements), no code/output change. `assert len(diff) < 40` passed.

**rl_13 is NOT twinned** (no entry in `scripts/notebook_tools/twin_pairs.d/`) → no SHA rebaseline required.

## Scope

1 file content. No source changes beyond the identity correction.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
