### PR TITLE
fix(gametheory,#8052): GT-14 Conclusion §D.5 recap drift (Riccati K1 0.4277→0.5450, deterrence K* 61.72/1716)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
@@ -2391,9 +2391,9 @@
     "\n",
     "1. **L'avantage du premier joueur** : le leader Stackelberg gagne +12.5% par rapport a Cournot, mais le follower perd -43.75%. L'industrie dans son ensemble est **moins efficace** (1519 vs 1800).\n",
     "\n",
-    "2. **Jeux LQ et equation de Riccati** : les stratégies feedback sont lineaires (u_i = -K_i * x), avec K_1(0)=0.4277 et K_2(0)=-0.4277 dans la course publicitaire. La dynamique est stable.\n",
+    "2. **Jeux LQ et equation de Riccati** : les stratégies feedback sont lineaires (u_i = -K_i * x), avec K_1(0)≈0.5450 et K_2(0)≈-0.5450 dans la course publicitaire. La dynamique est stable.\n",
     "\n",
-    "3. **Dissuasion d'entree** : en augmentant sa capacite a K=100, le monopole peut dissuader l'entree, mais le profit revient au niveau du monopole (1525).\n",
+    "3. **Dissuasion d'entree** : en s'engageant sur la capacite de dissuasion K*≈61.72 (qui annule le profit espere de l'entrant), l'incumbent bloque l'entree et preserve son monopole (profit 1716, vs 1525 au monopole sans investissement).\n",
     "\n",
     "**Suite** : [GT-15 - Jeux cooperatifs](GameTheory-15b-Lean-CooperativeGames.ipynb) | [Retour au sommaire](README.md)"
    ]

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-14-differentialgames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-14-differentialgames.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-25"
-    by: po-2023
-    python_sha: 1fadd569c0e0fd7da3d20263db1734e008f8c325
+    date: "2026-08-01"
+    by: myia-po-2026:CoursIA
+    python_sha: d50fc758aedbec023d1b732fe5d577f46509d97e
     csharp_sha: 17c7e9394da43390c00791aa53912181dc497a2e
   known_differences:
     - "Socle pedagogique commun : jeux differentiels et jeux dynamiques, equilibres de Stackelberg (von Stackelberg 1934) leader-follower, duopole a demande lineaire, comparaison avec Cournot, decisions dynamiques et leadership strategique."


### PR DESCRIPTION
## What

§D.5 markdown-recap drift in GameTheory-14-DifferentialGames.ipynb Conclusion (cell #39). The Conclusion restated pre-fix values that contradict the notebook's OWN already-correct code outputs and interpretation cells. Two independent stale numbers in the same recap cell, both missed when the c.767 Riccati fix was applied to the code + the dedicated interpretation cells.

See #8052 (semantic-audit epic — partial contribution, does not close the epic).

## Defects (both firsthand-verified against origin/main HEAD 73aa7168e)

**Defect 1 — LQ/Riccati gain (Lesson 2):**
- Conclusion #39 said: K_1(0)=0.4277 et K_2(0)=-0.4277
- code cell #14 output (the ground truth): K1(0) = 0.5450, K2(0) = -0.5450
- markdown cell #15 documents 0.4277 as the OLD buggy coupled-Riccati value and 0.5450 as correct (c.767 fix). The Conclusion was simply missed during that fix.
- Fix: 0.4277 -> 0.5450 (both K_1, K_2).

**Defect 2 — entry deterrence (Lesson 3):**
- Conclusion #39 said: capacity K=100, and "le profit revient au niveau du monopole (1525)".
- code cell #30 output: Capacite de deterrence: K* = 61.72. Scenario table: Deterrence par capacite 61.72 / 1716.42 (which is HIGHER than the 1525 monopoly-without-investment benchmark — not equal to it).
- markdown cell #31 documents K* = 90 - 2*sqrt(F) ~= 61.7, deterrence profit 1716, and explicitly identifies K=100 as the OLD degenerate solver-boundary behavior (pi_entrant constant at 700 for K>=30, solver returns the edge K=100).
- Fix: K=100 -> K*~=61.72; profit claim corrected (deterrence 1716 > monopoly 1525; the overcapacity is profitable, not "back to monopoly level").

## Verdict §D.5: markdown-recap drift (NOT CAUSE_FIXED re-exec)

The code outputs (#14, #30) are ALREADY correct and self-corroborated by the interpretation cells (#15, #31). The defect is purely the Conclusion recap retaining stale pre-fix values. Per the §D.5 paradigm this is a recap/interpretation drift from already-correct deterministic outputs -> markdown fix is correct (NOT a re-exec case: there is nothing to regenerate, the deterministic outputs are already the ground truth). Markdown-only change per C.2 exception.

## Notebook review-discipline §D evidence

- Re-exec: N/A (markdown-only, C.2 exception). No code cell source changed.
- 0 NotImplementedError / assert False / 1/0 in the notebook (verified).
- execution_count: 0 code cells with null execution_count; 0 executed code cells lacking outputs (C.2 OK — all outputs intact).
- No # Solution / # Exemple resolu cell deleted (anti-regression OK — only the Conclusion recap text changed).
- Cell-by-cell diff proof: ONLY cell #39 (markdown) changed; ALL code cells + outputs + execution_counts are byte-identical to origin/main (verified programmatically: diffs == [(39, markdown)]).
- notebook_tools validate: 0 errors.
- Diff: +2/-2 on the notebook (2 markdown lines), +3/-3 on the twin yaml (rebaseline).

## Twin parity (GT-14 is a Python/C# twin)

Markdown edit shifted the python blob SHA, so the twin registry was rebaselined:
- gametheory-14-differentialgames.yaml: python_sha 1fadd569c -> d50fc758a (== committed blob). csharp_sha unchanged.
- check_twin_parity.py --per-pair --base origin/main: [OK] GameTheory-14 ... base=OK head=OK (0 drift introduced). Rebaseline run AFTER the notebook commit (working-tree == committed blob), per #8957 ordering protocol.

## Follow-up flagged (out of scope here)

The C# twin Conclusion (GameTheory-14-DifferentialGames-Csharp.ipynb cell #25) also states K1(0)=0.4277 but cites a DIFFERENT Riccati equation (5P^2+0.2P-1=0, whose positive root IS 0.4277). Whether the C# formulation is correct-for-C# (a legitimate scalar/uncoupled Riccati) or the same coupled-Riccati bug as Python's pre-fix is a separate semantic-divergence investigation requiring C# code analysis. NOT addressed in this markdown-only §D.5 PR.

## Repo

Read from a fresh worktree on origin/main (HEAD 73aa7168e, 0 behind) — the shared tree was stale/dirty. Catalogue byte-identical to main (no catalogue file touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
