### PR TITLE
fix(search,#8052): Search-4 Tabu success rate 100% vs claimed ~60-90%

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch.ipynb
@@ -1961,7 +1961,7 @@
     "\n",
     "| Mesure | Hill Climbing | Tabu Search |\n",
     "|--------|--------------|------------|\n",
-    "| Taux de succes | ~10-15% | ~60-90% |\n",
+    "| Taux de succes | ~10-15% | 100% (20/20) |\n",
     "| itérations (succes) | ~4-6 | ~10-30 |\n",
     "| mécanisme d'echappement | Aucun | Liste tabou |\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/search-4-localsearch.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-4-localsearch.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: 7603bd23f94542ef31234f5dd68985d2ae246783
+    date: "2026-08-01"
+    by: myia-po-2023:CoursIA
+    python_sha: 952bcfdc76d9081394fc63e46f999c1d826c54a4
     csharp_sha: d82c3b21f1f515ae25ec06eb1dc733ace1d39b05
   known_differences:
     - "Socle pedagogique commun : metaheuristiques de recherche locale — Hill Climbing (variations steepest/first-improvement + diagnosis plateau/ridge), Simulated Annealing (schema de refroidissement, critere de Metropolis), Tabu Search (liste tabou, memoire a court terme). Comparaison empirique sur N-Reines. Les deux twins implementent les 3 algorithmes from-scratch (parite algorithmique, pas seulement narratif)."


### PR DESCRIPTION
Grain: MED/search -- lane myia-po-2023:CoursIA -- prev: MED/search #9097

See #8052 (partial contribution — claims↔outputs EPIC §D.5 set).

## Summary

The Hill-Climbing-vs-Tabu comparison table (g35) in Search-4 listed the Tabu Search success rate on 8-Queens as "~60-90%", but the committed Tabu output is **100%** (20/20). The notebook contradicted itself (the benchmark cell g41 also shows 30/30 = 100%). Confirmed reproducible by a fresh re-exec and aligned the markdown.

## The defect

**Claim** (comparison table, g35):
| Mesure | Hill Climbing | Tabu Search |
|--------|--------------|------------|
| Taux de succes | ~10-15% | **~60-90%** |

**Outputs** (fresh re-exec, kernel python3, seed 42, 0 errors):
- Tabu Search g34: `Taux de succes : 20/20 (100%)`, `Iterations moyennes : 15.8`
- Benchmark g41: `Tabu Search 30/30 100%`

The "~60-90%" understates the actual 100%.

## Diagnostic dérive (§D.5)

- **Cause** : a success-rate count (20/20) under a **fixed seed** (random.seed(42) + np.random.seed(42), re-seeded per stochastic cell). This is a **deterministic count**, not a wall-clock perf number — it reproduces at 100% on every run. Markdown-align to the re-executed output is the correct §D.5 remedy (cf `claims-vs-outputs-d5-perf-number-reexec-not-markdown`: "Compte / rang / logique (déterministe) → markdown-fix OK"; the wall-clock-re-exec rule does not apply to a deterministic seed-fixed count).
- **Verdict** : CAUSE_FIXED. Markdown aligned to the fresh re-executed rate.

## The fix

Aligned the table cell: `~60-90%` → `100% (20/20)`. The Hill Climbing column "~10-15%" is **left unchanged** — the fresh HC rate is 10% (2/20), within the claimed range.

## Acceptance criteria (verified firsthand)

- **Re-exec** : kernel python3, 0 errors, 62/62 cells — Tabu 20/20 (100%), HC 2/20 (10%).
- **Markdown-only fix** : outputs byte-identical to origin/main.
- **Code sha identical** to origin/main (23 code cells untouched).
- **Diff strictly minimal** : 1 insertion / 1 deletion (the table cell only).
- **H.3** : 0 null execution_count, 0 errors.
- **content-loss guard** : findings=0 (39→39 md cells stable).
- Catalogue byte-identical to main (untouched).

See #8052.
