### PR TITLE
fix(rl,#8052): rl_10 Q'=Q*+Phi sign wrong (Ng-Harada-Russell = Q* - Phi), contradicts own output

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb
@@ -395,7 +395,7 @@
     "\n",
     "### Demonstration intuitive\n",
     "\n",
-    "La valeur modifiée $Q'(s, a) = Q^*(s, a) + \\Phi(s)$ : le potentiel s'ajoute comme un biais constant\n",
+    "La valeur modifiée $Q'(s, a) = Q^*(s, a) - \\Phi(s)$ : le potentiel agit comme un biais constant\n",
     "par etat, qui ne change pas l'ordre relatif des actions. L'argmax est preserve.\n",
     "\n",
     "**Attention au shaping naif :** Le shaping heuristique $F(s, s') = 2 \\cdot (d(s) - d(s'))$ n'est PAS potential-based\n",
@@ -452,11 +452,11 @@
     "\n",
     "**1. Un near-tie rend `argmax` instable.** En baseline, les actions `haut` (Q = -12.24583) et `droite` (Q = -12.24582) sont egales a **5 decimales pres** (ecart ~4e-6). Sur un tel quasi-egalite, le moindre bruit numerique fait basculer `argmax` d'une action a l'autre — c'est exactement ce qui se passe ici (`droite` en baseline, `haut` en shaped).\n",
     "\n",
-    "**2. Q-learning en temps fini n'est pas converge.** Le theoreme suppose Q* **exactement** converge : alors `Q'(s,a) = Q*(s,a) + Phi(s)`, et comme `Phi(s)` est le meme pour toutes les actions d'un meme etat, l'ordre relatif des actions est preserve. Mais avec un nombre fini d'episodes, Q reste bruite : la difference `Q_pot - Q_base` n'est pas parfaitement constante d'une action a l'autre (ecart-type ~0.03), donc le decalage exact `+ Phi(s)` ne tient pas au niveau des valeurs.\n",
+    "**2. Q-learning en temps fini n'est pas converge.** Le theoreme suppose Q* **exactement** converge : alors `Q'(s,a) = Q*(s,a) - Phi(s)`, et comme `Phi(s)` est le meme pour toutes les actions d'un meme etat, l'ordre relatif des actions est preserve. Mais avec un nombre fini d'episodes, Q reste bruite : la difference `Q_pot - Q_base` n'est pas parfaitement constante d'une action a l'autre (ecart-type ~0.03), donc le decalage exact `- Phi(s)` ne tient pas au niveau des valeurs.\n",
     "\n",
-    "**3. La politique, elle, est bien preservee.** Ce qui compte dans le theoreme n'est pas la valeur exacte de `argmax` sur un near-tie, mais la **politique globale** : ici, dans les deux cas les actions `haut` et `droite` dominent largement `bas` et `gauche` (ecart ~0.8), et le decalage moyen `Q_pot - Q_base ~= 14` est coherent avec un unique potentiel `Phi(start)`. Le retour cumule d'une politique greedy suit donc la meme trajectoire.\n",
+    "**3. La politique, elle, est bien preservee.** Ce qui compte dans le theoreme n'est pas la valeur exacte de `argmax` sur un near-tie, mais la **politique globale** : ici, dans les deux cas les actions `haut` et `droite` dominent largement `bas` et `gauche` (ecart ~0.8), et le decalage moyen `Q_pot - Q_base ~= 14` est coherent avec `-Phi(start) = +manhattan(start, but) = +14`. Le retour cumule d'une politique greedy suit donc la meme trajectoire.\n",
     "\n",
-    "> **Le bon diagnostic** n'est donc pas `argmax == argmax` (trop strict sur un near-tie bruite), mais soit une comparaison au niveau des valeurs `np.allclose(Q_base + Phi, Q_pot, atol=1e-1)`, soit - plus robuste - **l'egalite du retour cumule** des politiques greedy derivées des deux Q. Le theoreme est une propriete asymptotique (Q* converge) ; la verification a `N_EP` fini en est une estimation bruitee.\n",
+    "> **Le bon diagnostic** n'est donc pas `argmax == argmax` (trop strict sur un near-tie bruite), mais soit une comparaison au niveau des valeurs `np.allclose(Q_base - Phi, Q_pot, atol=1e-1)`, soit - plus robuste - **l'egalite du retour cumule** des politiques greedy derivées des deux Q. Le theoreme est une propriete asymptotique (Q* converge) ; la verification a `N_EP` fini en est une estimation bruitee.\n",
     "\n",
     "**Lecon** : potential-based shaping est **sans risque pour la politique optimale** (c'est tout l'interet du theoreme), mais la verification empirique exige de tester la bonne grandeur (politique / retour), pas un argmax ponctuel sur des valeurs non convergees."
    ]


### PR DESCRIPTION
Grain: MED/value — lane myia-po-2024:CoursIA-2 — prev: MED/identity #9094 rl_13 (same RL family, distinct notebook & substance: rl_10 reward-shaping formula sign vs rl_13 DQN attribution).

## What

Fixes a **VALUE** defect in `rl_10_reward_shaping.ipynb`: 4 places state the shaped Q-value as **$Q'(s,a) = Q^*(s,a) + \Phi(s)$** (PLUS sign). The Ng–Harada–Russell (1999) result is **$Q^*_{M'}(s,a) = Q^*_M(s,a) - \Phi(s)$** (MINUS). The notebook's **own committed output confirms the minus sign** numerically. Markdown-only, no re-execution. Found via the #8052 claims↔outputs audit (RL slice).

## Ground truth (firsthand verified, L786-2)

**The theorem (minus sign).** With shaping $F(s,s') = \gamma\Phi(s') - \Phi(s)$, the telescoping sum $\sum_k \gamma^k F(s_k,a_k,s_{k+1}) = -\Phi(s_0)$ (terminal $\Phi=0$), so $Q^*_{M'}(s,a) = Q^*_M(s,a) - \Phi(s)$.

**The notebook's own output confirms it numerically:**
- `cell[4]` code: `phi_s = -env.manhattan(s)` → $\Phi(s) = -\text{manhattan}(s)$
- `cell[2]` output: "Distance Manhattan optimale : 14 pas" → $\Phi(\text{start}) = -14$
- `cell[10]` output: $Q_{\text{base}}[\text{start}] \approx [-12.24, -13.07, -13.07, -12.24]$ vs $Q_{\text{pot}}[\text{start}] \approx [+1.75, +0.86, +0.87, +1.73]$
- shift $Q_{\text{pot}} - Q_{\text{base}} = [13.998, 13.929, 13.939, 13.977]$, **mean ≈ 13.96 ≈ +14 = $-\Phi(\text{start})$**

So the observed shift is $-\Phi(s)$, not $+\Phi(s)$. The "+Phi" formula predicts $Q^* + (-14) = Q^* - 14 \approx -26$ — the opposite of the committed $+14$ shift.

## Defect (VALUE c.1062-L — strong class)

| cell | element | wrong → correct |
|------|---------|-----------------|
| 9 | [9] | `$Q'(s,a) = Q^*(s,a) + \Phi(s)$` → `$Q^*(s,a) - \Phi(s)$` (and "le potentiel s'ajoute" → "agit", sign-neutral) |
| 11 | [6] | formula `Q*(s,a) + Phi(s)` → `Q*(s,a) - Phi(s)`; and text "`+ Phi(s)`" → "`- Phi(s)`" |
| 11 | [8] | "coherent avec un unique potentiel `Phi(start)`" → "coherent avec `-Phi(start) = +manhattan(start, but) = +14`" (sign explicit) |
| 11 | [10] | code snippet `np.allclose(Q_base + Phi, Q_pot, atol=1e-1)` → `np.allclose(Q_base - Phi, Q_pot, atol=1e-1)` |

## Why all 4 (not just the 2 the sweep sub-agent flagged)

Firsthand review caught **2 extra wrong-sign sites** the sweep sub-agent missed. Leaving any `+ Phi` would make the notebook **self-contradictory** once the formulas are corrected: the corrected $Q'=Q^*-\Phi$ must be matched by the verification snippet (`Q_base - Phi`) and the empirical-shift reading (+14 = $-\Phi(\text{start})$).

## Fix

4 elements. The **shaping definition** $F(s,s') = \gamma\Phi(s') - \Phi(s)$ (cell[9][5]) is **CORRECT** — its minus sign is standard and untouched. The "bias constant preserves argmax" policy argument holds regardless of sign → preserved. The near-tie / non-converged-Q discussion and the empirical +14 shift are preserved.

## Verification (firsthand, #8052 lens)

Ground-truth locks in the edit script: `cell[4]` code `phi_s = -env.manhattan(s)` (the sign anchor $\Phi(\text{start})=-14$), `cell[2]` "Distance Manhattan optimale : 14 pas", my own computation of the cell[10] shift (mean 13.961 ≈ +14 = $-\Phi(\text{start})$), c9[5] shaping definition preserved, c11[8] empirical "+14" quote + c11[4] near-tie argument preserved, and **0 residual** `+ \Phi` / `Q* + Phi` / `Q_base + Phi` across **all** markdown cells. Canonical JSON round-trip byte-identical pre/post (**trailing-adaptive** c.1086-L). diff = 12 lines (4 content elements), no code/output change. `assert len(diff) < 40` passed.

**rl_10 is NOT twinned** (no entry in `scripts/notebook_tools/twin_pairs.d/`) → no SHA rebaseline required.

## Scope

1 file content. No source changes beyond the sign correction.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
