### PR TITLE
fix(rl,#8052): rl_6c + rl_6d nav "Notebook suivant" skips immediate successor (jumps to RL-7)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "**Serie** : Reinforcement Learning | **Notebook** : 6c/13 | **Duree estimee** : 45-50 min\n",
     "\n",
-    "**Navigation** : [[Notebook précédent] Actor-Critic (A2C)](rl_6b_actor_critic.ipynb) | [Index](README.md) | [[Notebook suivant] Multi-Agent RL](rl_7_multi_agent_rl.ipynb)\n",
+    "**Navigation** : [[Notebook précédent] Actor-Critic (A2C)](rl_6b_actor_critic.ipynb) | [Index](README.md) | [[Notebook suivant] SAC depuis zéro](rl_6d_sac_from_scratch.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "**Serie** : Reinforcement Learning | **Notebook** : 6d/13 | **Duree estimee** : 45-50 min\n",
     "\n",
-    "**Navigation** : [[Notebook précédent] PPO](rl_6c_ppo_from_scratch.ipynb) | [Index](README.md) | [[Notebook suivant] Multi-Agent RL](rl_7_multi_agent_rl.ipynb)\n",
+    "**Navigation** : [[Notebook précédent] PPO](rl_6c_ppo_from_scratch.ipynb) | [Index](README.md) | [[Notebook suivant] GRPO depuis zéro](rl_6e_grpo_from_scratch.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",


### PR DESCRIPTION
Grain: MED/structural — lane myia-po-2024:CoursIA-2 — prev: MED/value #9099 rl_10 (same RL family, distinct substance: nav cross-ref skip vs reward-shaping formula sign).

## What

Fixes a **STRUCTURAL** cross-reference defect in the RL "from scratch" sub-series: both `rl_6c_ppo_from_scratch.ipynb` and `rl_6d_sac_from_scratch.ipynb` have a cell[0] "Navigation" line whose **"Notebook suivant"** forward-pointer jumps straight to **RL-7** (Multi-Agent RL), **skipping their immediate successor** in the series. Markdown-only, no re-execution. Found via the #8052 claims↔outputs audit (RL slice).

## Ground truth (firsthand verified, L786-2)

**README row order** (`MyIA.AI.Notebooks/RL/README.md`): `6c (PPO) → 6d (SAC) → 6e (GRPO) → 7 (Multi-Agent)`. So the sequential successor of 6c is 6d, and of 6d is 6e.

**rl_6d's own back-pointer confirms it:** `rl_6d` cell[0] declares `[[Notebook précédent] PPO](rl_6c_ppo_from_scratch.ipynb)` — so rl_6c's immediate successor is unambiguously rl_6d.

**rl_6e exists and self-declares the chain** (cell[0] breadcrumb): `> **Serie RL from scratch** | [RL-6c PPO] · [RL-6d SAC] · **RL-6e GRPO**` — placing 6e after 6d.

Yet both rl_6c and rl_6d point "suivant" to **rl_7**, jumping past 6d/6e. The defect is symmetric: the "suivant" link was presumably written before rl_6d/rl_6e were added and never updated.

## Defect (STRUCTURAL cross-ref c.1062-L — strong class)

| notebook | cell[0] | wrong → correct "suivant" |
|----------|---------|---------------------------|
| rl_6c_ppo_from_scratch | [4] | `[[Notebook suivant] Multi-Agent RL](rl_7_...)` → `[[Notebook suivant] SAC depuis zéro](rl_6d_sac_from_scratch.ipynb)` |
| rl_6d_sac_from_scratch | [4] | `[[Notebook suivant] Multi-Agent RL](rl_7_...)` → `[[Notebook suivant] GRPO depuis zéro](rl_6e_grpo_from_scratch.ipynb)` |

## Why both in one PR

Same defect class (cross-ref skip), same fix pattern, sibling notebooks sharing the **identical** "Notebook précédent/suivant" Navigation line format. Fixing only rl_6c would ship a **half-fix** — rl_6d's same wrong-jump would remain. The sweep sub-agent flagged only rl_6c; **firsthand review caught that rl_6d has the identical bug** (c.943-L2: bug-de-famille = même remède).

**Untouched (correct, no skip):** rl_6e uses a "Serie RL from scratch" breadcrumb (not the précédent/suivant format); rl_6b uses a horizontal navbar (`[RL-1 Intro] | [RL-2 Wrappers] | ...`). Neither has the skip defect.

## Fix

1 element per notebook (the forward-pointer only). The "précédent" links (rl_6c→rl_6b, rl_6d→rl_6c) and the `[Index](README.md)` link are CORRECT and preserved. Markdown-only, no code/output change.

## Verification (firsthand, #8052 lens)

Ground-truth locks in the edit script: README row order (6c→6d→6e→7), rl_6d's own "précédent = PPO (rl_6c)" (confirms 6c's successor = 6d), rl_6e exists and self-declares the from-scratch chain. Script asserts: precedent + index links preserved, new successor target files exist, **0 residual** stale rl_7 forward-pointer in each c0, forward-pointer uniqueness. Canonical JSON round-trip byte-identical pre/post (**trailing-adaptive** c.1086-L). diff = 2 lines per notebook (1 element each), no code/output change. `assert len(diff) < 40` passed.

**Neither notebook is twinned** (no entry in `scripts/notebook_tools/twin_pairs.d/`) → no SHA rebaseline required.

## Scope

2 file contents (1 nav element each). No source changes beyond the cross-ref correction.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
