### PR TITLE
fix(rl,#8052): rl_8 c17 corrupted LaTeX escape renders "5 imes 10^-3" (single-backslash \t -> literal TAB)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb
@@ -806,7 +806,7 @@
     "\n",
     "Le bonus a un cout : en regime stationnaire, Dyna-Q+ \"gaspille\" des pas a re-verifier des couloirs\n",
     "qui n'ont pas change. C'est le dilemme exploration/exploitation (notebook 4) transpose au\n",
-    "**non-stationnaire** — et l'exercice 3 vous fera mesurer ce que coute un $\\kappa$ mal règle. Un ordre de grandeur de trop suffit : a $\\kappa = 5\times 10^{-3}$, le bonus amplifie par le bootstrap ($\\gamma \\max_a Q$) depasse la valeur reelle du but et la recompense cumulee s'effondre.\n",
+    "**non-stationnaire** — et l'exercice 3 vous fera mesurer ce que coute un $\\kappa$ mal règle. Un ordre de grandeur de trop suffit : a $\\kappa = 5\\times 10^{-3}$, le bonus amplifie par le bootstrap ($\\gamma \\max_a Q$) depasse la valeur reelle du but et la recompense cumulee s'effondre.\n",
     "L'exercice 1 (Shortcut Maze) montre un cas plus frappant : quand le changement *ouvre un raccourci*\n",
     "au lieu de fermer un passage, Dyna-Q standard ne le decouvre **jamais**."
    ]


### PR DESCRIPTION
Grain: LIGHT/rendering — lane myia-po-2024:CoursIA-2 — prev: MED/structural #9103 rl_6c+rl_6d (same RL family, distinct substance: LaTeX-escape rendering vs nav cross-ref).

## What

Fixes a **rendering** defect in `rl_8_model_based_dyna_q.ipynb` cell[17] elem[9]: the LaTeX `$\kappa = 5\times 10^{-3}$` is stored in the JSON with a **single backslash** before `times` (`\t`), which is a valid JSON **TAB escape** → the markdown source parses to a **literal TAB**, so the cell renders `$\kappa = 5<TAB>imes 10^{-3}$` → MathJax shows **`5 imes 10^{-3}`** (multiply sign gone, "imes" as literal text). Markdown-only, no re-execution. Found via the #8052 claims↔outputs audit (RL slice).

## Ground truth (firsthand byte-confirmed, L786-2)

Raw JSON bytes of the two `\times` sites in rl_8:
- **`cell[17][9]` (BUG):** `[53, 92, 116, 105, 109, 101, 115, ...]` = `5` `\` `t`(=TAB) `i m e s` — single backslash
- **`cell[26][9]` (exercise 3, CORRECT):** `[53, 32, 92, 92, 116, ...]` = `5` ` ` `\` `\` `t i m e s` — double backslash

The notebook's **own exercise 3 already uses the correct double-backslash**; cell[17] is the single-backslash outlier (a JSON-escaping slip, the "JSON LaTeX" gotcha: `\t \n \r \b \f` are valid JSON escapes that silently break LaTeX).

## Defect (rendering, byte-confirmed)

| cell | element | wrong → correct |
|------|---------|-----------------|
| 17 | [9] | raw JSON `5\times 10^{-3}` (single-backslash → parses to `5`+TAB+`imes`) → `5\\times 10^{-3}` (double-backslash → parses to `5\times` = renders `5×10⁻³`) |

## Scope decision: rendering ONLY; κ-VALUE prose DEFERRED (L786-2)

The sweep sub-agent flagged the κ **value** in this same sentence (claims collapse at κ=5e-3) as also wrong, proposing κ=5e-3 → 10⁻¹. **That is DEFERRED as a judgment call, NOT shipped:**
- The prose is **foreshadowing** ("l'exercice 3 vous fera mesurer ce que coûte un κ mal réglé"): of course no κ=5e-3 result is shown yet — exercise 3 is where the student measures it.
- The notebook **runs only** κ=0 and κ=1e-3 (cell[16] output: "Dyna-Q: 73.4 \| Dyna-Q+: 109.8").
- Exercise 3 (cell[26]) sweeps κ ∈ {0, 1e-4, 1e-3, **5e-3**, 1e-2, 1e-1} and asks "que se passe-t-il pour κ=0.1" — but listing 5e-3 as a sweep value and focusing the question on 0.1 does **not** definitively prove 5e-3 doesn't collapse. Changing 5e-3 → 0.1 would **replace one un-run quantitative prediction with another unverified one**.

So only the **unambiguous** rendering escape is fixed; the κ value and the whole prose claim are **preserved**. This is the honest call per L786-2 (don't make unverified quantitative changes).

## Verification (firsthand, #8052 lens)

Ground-truth locks in the edit script: cell[17][9] no longer has a TAB char, the correct literal `\times` is present, **0 residual TAB** anywhere in rl_8 markdown, exercise 3 (cell[26]) uses the correct double-backslash (the canonical form matched), and the κ=5e-3 value + collapse prose + exercise-3 foreshadow are preserved. Post-edit raw bytes `[53, 92, 92, 116, ...]` re-confirmed directly. Canonical JSON round-trip byte-identical pre/post (**trailing-adaptive** c.1086-L). diff = 2 lines (1 element), no code/output change. `assert len(diff) < 40` passed.

**rl_8 is NOT twinned** (no entry in `scripts/notebook_tools/twin_pairs.d/`) → no SHA rebaseline required.

## Scope

1 file content. No source changes beyond the LaTeX escape.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
