### PR TITLE
fix(smartcontracts,#8052): SC-11 Anthropic-vs-OpenAI output caveat (CAUSE_DOCUMENTED_ONLY, config fallback)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
@@ -1317,7 +1317,7 @@
    "source": [
     "## 6. Integration avec l'API Anthropic Claude\n",
     "\n",
-    "Exemple d'integration complete avec Claude Sonnet 4.6 pour un workflow de développement."
+    "Exemple d'integration complete avec Claude Sonnet 4.6 pour un workflow de développement.\n\n> **Note (depend de la config)** : `SolidityLLMAssistant` privilegie Anthropic Claude par defaut (`client_type=\"anthropic\"`) et bascule sur le fallback OpenAI quand la cle `ANTHROPIC_API_KEY` est absente. La sortie d'execution ci-dessous affiche donc `openai (gpt-4o)` (fallback faute de cle configuree) ; avec une cle Anthropic, elle afficherait `anthropic (claude-sonnet-4-6)`. Le reste du workflow s'execute en mode mock (generation de templates sans appel API reel)."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/smartcontracts -- lane myia-po-2023:CoursIA -- prev: LIGHT/genai-rendering #9104

See #8052 (partial contribution -- SmartContracts §D.5 scan).

## Summary

SC-11-LLM-Assisted section 6 markdown (g28) presented the demo as "Integration avec l'API Anthropic Claude / Claude Sonnet 4.6", but the executed output (g29) prints "Assistant initialise avec openai (gpt-4o)". A student reading the section sees a provider mismatch. Root cause confirmed firsthand: the instantiation `SolidityLLMAssistant(client_type="anthropic" if anthropic_client else "openai")` falls back to OpenAI when `ANTHROPIC_API_KEY` is absent -- which was the case at the committed run. The code INTENDS Anthropic (default `client_type="anthropic"`, prefers it when configured); the output is a config-dependent fallback artifact, not a stale claim.

## The defect

Claim (g28 markdown):
> ## 6. Integration avec l'API Anthropic Claude
> Exemple d'integration complete avec Claude Sonnet 4.6 pour un workflow de developpement.

Output (g29 committed stdout):
> Assistant initialise avec openai (gpt-4o)

## Diagnostic derive (§D.5)

- **Cause**: config-dependent provider fallback. `SolidityLLMAssistant(client_type="anthropic" if anthropic_client else "openai")` -- at the committed run, `anthropic_client` was falsy (ANTHROPIC_API_KEY absent), so it selected the OpenAI branch. The code's INTENT is Anthropic (g29 class default `client_type: str = "anthropic"`; g12/g18/g24 all branch on `client_type == "anthropic"` first). The markdown matches the code's intent; the output reflects a misconfigured run.
- **Verdict: CAUSE_DOCUMENTED_ONLY.** The provider value is config-dependent (Anthropic if key set -> real call; OpenAI fallback otherwise; mock either way). It is NOT cleanly re-executable as a CAUSE_FIXED: re-exec'ing with the key would trigger REAL Anthropic calls (g12 `if client_type=="anthropic" and anthropic_client:` -> real call) and convert the notebook from its deliberately-committed MOCK mode (g32 interpretation explicitly discusses "Limites du mode mock" as a feature of the committed notebook) to non-deterministic real-LLM outputs -- a scope/character change beyond a clean §D.5 fix, and the real outputs would no longer be reproducible. Markdown-aligning "Anthropic"->"OpenAI" would be WRONG (misrepresent the notebook's intended Anthropic integration as OpenAI). The honest minimal fix documents WHY the executed output diverges. Parallel to #9046 (CAUSE_DOCUMENTED_ONLY).

## The fix

Appended an honest config-dependency caveat to g28: explains `SolidityLLMAssistant` prefers Anthropic by default and falls back to OpenAI when `ANTHROPIC_API_KEY` is absent, so the executed output shows `openai (gpt-4o)`; with the key it would show `anthropic (claude-sonnet-4-6)`; the rest runs in mock mode. Keeps the Anthropic integration as the section subject (no misrepresentation).

Markdown-only edit (C.2 exception -- no code cell touched, no re-exec needed). Diff: 1 insertion / 1 deletion (the caveat appended to g28's last source-list element).

## Method (delegation discipline)

Found by a sonnet read-only scan (20 SmartContract notebooks), then re-verified firsthand: read the full g29 class + the g6 config + instantiation, confirmed the fallback guard, checked the Anthropic key availability. NOT a blind edit from the scan. The scan's other candidate (SC-16 timing 1.04s vs 0.402s) is OWNED by PR #9001 -- de-conflicted, not touched.

## Acceptance criteria (verified firsthand)

- Defect confirmed firsthand: g28 markdown vs g29 output, root cause = instantiation fallback guard + absent Anthropic key.
- Markdown-only fix: 20 code cells sha256 unchanged, 19 outputs preserved (byte-untouched), 34 md cells stable.
- H.3: 0 null execution_count, 0 errors.
- content-loss guard: findings=0.
- Diff strictly minimal: 1 insertion / 1 deletion.
- Catalogue byte-identical to main (untouched).

See #8052.
