### PR TITLE
fix(rl,#8052): rl_7 c29 series recap table omits RL-6e (GRPO depuis zero)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb
@@ -1204,6 +1204,7 @@
     "| RL-6b | Actor-Critic (A2C) |\n",
     "| RL-6c | PPO depuis zero |\n",
     "| RL-6d | SAC depuis zero |\n",
+    "| RL-6e | GRPO depuis zero (DeepSeek-R1) |\n",
     "| RL-7 | Multi-Agent RL, IQL, PettingZoo |\n",
     "\n",
     "**Pour aller plus loin en Multi-Agent RL** :\n",


### PR DESCRIPTION
Grain: MED/count — lane myia-po-2024:CoursIA-2 — prev: LIGHT/rendering #9105 rl_8 (same RL family, distinct substance: recap-table count omission vs LaTeX-escape rendering).

## What

Fixes a **COUNT** defect in `rl_7_multi_agent_rl.ipynb` cell[29] ("Ce que nous avons vu dans cette serie"): the recap table lists **RL-1 … RL-6d, RL-7** (10 rows) but **omits RL-6e (GRPO depuis zéro)**. Markdown-only, no re-execution. Found via the #8052 claims↔outputs audit (RL slice).

## Ground truth (firsthand verified, L786-2)

Three independent confirmations that RL-6e belongs in the series:
- **README** (`MyIA.AI.Notebooks/RL/README.md`) has a `6e` row: `| 6e | [rl_6e_grpo_from_scratch] | GRPO depuis zéro (DeepSeek-R1), avantage relatif intra-groupe (sans critic) … |`
- **rl_6e exists and self-declares the from-scratch chain** (cell[0] breadcrumb): `> **Serie RL from scratch** | [RL-6c PPO] · [RL-6d SAC] · **RL-6e GRPO**`
- **rl_7's own from-scratch colleagues appear in the recap** — RL-6b (Actor-Critic), RL-6c (PPO depuis zero), RL-6d (SAC depuis zero) are all listed; RL-6e is the only gap.

## Defect (COUNT c.1062-L — strong class)

| cell | element | fix |
|------|---------|-----|
| 29 | insert after RL-6d row (idx 22) | add `| RL-6e | GRPO depuis zero (DeepSeek-R1) |` |

The concise label matches the sibling rows' local convention ("PPO depuis zero", "SAC depuis zero").

## Scope decision: COUNT only; c18 trend claim DEFERRED (L786-2)

The sweep also flagged cell[18]'s trend claim ("La proportion de matchs nuls augmente" contradicted by cell[15] output: draws peak at 23.7% @ 15 000 then **fall** to 20.4% @ 20 000). That is a genuine VALUE defect, but it is a **single-sentence trend rewording on a different cell** — a distinct subject. Per PR atomicity (1 PR = 1 subject), it is **DEFERRED to a separate cycle**, not mixed into this COUNT fix.

## Verification (firsthand, #8052 lens)

Ground-truth locks in the edit script: README `6e` row present, rl_6e exists on `origin/main` (`git cat-file -e` confirms the omitted notebook is real), the c29[22] RL-6d anchor + c29[23] RL-7 anchor shape-confirmed, RL-6e was absent pre-edit, and **0 residual "RL-6e"** elsewhere in notebook markdown (only the new recap row). Canonical JSON round-trip byte-identical pre/post (**trailing-adaptive** c.1086-L). diff = 1 line (1 element insert), no code/output change. `assert len(diff) < 40` passed.

**rl_7 is NOT twinned** (`RL/rl_7_multi_agent_rl.ipynb` has no entry in `scripts/notebook_tools/twin_pairs.d/` — the similarly-named `gametheory-17-multiagent-rl.yaml` refers to a **different** notebook, `GameTheory/GameTheory-17-MultiAgent-RL.ipynb`) → no SHA rebaseline required.

## Scope

1 file content. No source changes beyond the missing-row insertion.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
