### PR TITLE
feat(probas,#2161): DecInfer-1 add Exercice 4 (equivalent certain + CRRA risk-aversion deduction)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-1-Utility-Foundations.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-1-Utility-Foundations.ipynb
@@ -2527,6 +2527,120 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "## Exercice 4 : Equivalent certain et deduction de l'aversion au risque\n",
+    "\n",
+    "### Objectif\n",
+    "\n",
+    "Pour un ensemble de loteries dont on observe l'**equivalent certain**, deduire le coefficient d'aversion au risque (rho pour CRRA) de l'agent, puis tester la **coherence** de ces choix avec un unique profil d'utilite (axiome de representation).\n",
+    "\n",
+    "### Contexte\n",
+    "\n",
+    "Un investisseur declare etre indifferent entre une somme certaine et chacune des loteries suivantes :\n",
+    "\n",
+    "- **Loterie A** : 50% de chance de gagner 2 000 EUR, 50% de 0  ↔  equivalent certain observe X*_A = 800 EUR\n",
+    "- **Loterie B** : 50% de chance de gagner 5 000 EUR, 50% de 0  ↔  equivalent certain observe X*_B = 1 500 EUR\n",
+    "- **Loterie C** : 80% de chance de gagner 2 000 EUR, 20% de 0  ↔  equivalent certain observe X*_C = 1 400 EUR\n",
+    "\n",
+    "On suppose une fonction d'utilite CRRA : U(x) = x^(1-rho) / (1-rho).\n",
+    "\n",
+    "### Etapes\n",
+    "\n",
+    "1. Implementez la fonction `UtiliteCRRA(x, rho)`.\n",
+    "2. Pour chaque loterie, resolvez numeriquement le rho verifiant U(X*) = E[U(loterie)] (methode de bissection sur [0.01, 0.99]).\n",
+    "3. Calculez la **prime de risque** = E[gain] - equivalent certain pour chaque loterie.\n",
+    "4. Comparez les trois rho deduits : sont-ils coherents ? Que revele une incoherence ?\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- **Indice 1** : pour une loterie {proba : gain, (1-proba) : 0}, comme U(0) = 0, l'indifference se simplifie en U(X*) = proba * U(gain).\n",
+    "- **Indice 2** : un agent rationnel (axiomes VNM) possede un unique rho ; si les trois rho divergent, c'est une violation des axiomes (effet de certitude / theorie des perspectives).\n",
+    "- **Indice 3** : comparez la Loterie A (50%) et la Loterie C (80%) sur le meme gain de 2 000 EUR — le passage de 50% a 80% devrait faire baisser la prime de risque de maniere prevvisible sous CRRA.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "e5f6g7h8",
+   "metadata": {},
+   "execution_count": 17,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "=== Exercice 4 : Deduction de l'aversion au risque ===\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "(A) rho deduit : 0,000 | prime de risque : 0 EUR\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "(B) rho deduit : 0,000 | prime de risque : 0 EUR\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "(C) rho deduit : 0,000 | prime de risque : 0 EUR\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Question : les trois rho sont-ils coherents ?\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Indice : une incoherence revele une violation des axiomes VNM (effet de certitude).\r\n"
+    }
+   ],
+   "source": [
+    "// Exercice 4 : Equivalent certain et deduction de l'aversion au risque (CRRA)\n",
+    "\n",
+    "// Trois loteries avec leurs equivalents certains observes\n",
+    "double gainA = 2000.0; double probaA = 0.5; double eqCertainA = 800.0;\n",
+    "double gainB = 5000.0; double probaB = 0.5; double eqCertainB = 1500.0;\n",
+    "double gainC = 2000.0; double probaC = 0.8; double eqCertainC = 1400.0;\n",
+    "\n",
+    "// TODO 1 : Fonction d'utilite CRRA\n",
+    "// Indice : U(x) = x^(1-rho) / (1-rho)  (rho != 1). U(0) = 0.\n",
+    "double UtiliteCRRA(double x, double rho)\n",
+    "{\n",
+    "    return 0.0;  // TODO : a completer\n",
+    "}\n",
+    "\n",
+    "// TODO 2 : Deduire rho par bissection sur [0.01, 0.99]\n",
+    "// Indice : U(X*) = proba * U(gain)  (car U(0)=0)\n",
+    "double DeduireRho(double gain, double proba, double eqCertain)\n",
+    "{\n",
+    "    return 0.0;  // TODO : a completer\n",
+    "}\n",
+    "\n",
+    "// TODO 3 : Prime de risque = E[gain] - equivalent certain\n",
+    "double PrimeRisque(double gain, double proba, double eqCertain)\n",
+    "{\n",
+    "    return 0.0;  // TODO : a completer\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"=== Exercice 4 : Deduction de l'aversion au risque ===\");\n",
+    "Console.WriteLine($\"(A) rho deduit : {DeduireRho(gainA, probaA, eqCertainA):F3} | prime de risque : {PrimeRisque(gainA, probaA, eqCertainA):F0} EUR\");\n",
+    "Console.WriteLine($\"(B) rho deduit : {DeduireRho(gainB, probaB, eqCertainB):F3} | prime de risque : {PrimeRisque(gainB, probaB, eqCertainB):F0} EUR\");\n",
+    "Console.WriteLine($\"(C) rho deduit : {DeduireRho(gainC, probaC, eqCertainC):F3} | prime de risque : {PrimeRisque(gainC, probaC, eqCertainC):F0} EUR\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Question : les trois rho sont-ils coherents ?\");\n",
+    "Console.WriteLine(\"Indice : une incoherence revele une violation des axiomes VNM (effet de certitude).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d0552d66",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## What

DecInfer-1-Utility-Foundations taught the full utility-foundations arc (lotteries, VNM axioms, representation theorem, calibration, CARA/CRRA) but carried only **2 exercises** (Exercice 2: sequential medical test; Exercice 3: CARA vs CRRA risk premia). Added **Exercice 4** to reach the 3-exercise threshold (#2161).

See #2161 (partial contribution — the 3-exercise rollout is a repo-wide epic; this PR completes one notebook).

## Exercise 4 — *Equivalent certain et deduction de l'aversion au risque*

Consolidation exercise (pure C#, no Infer.NET dependency). Given 3 loteries with observed certainty equivalents:

- **A**: 50% × 2000 EUR, 50% × 0 ↔ equivalent certain observé X\*_A = 800 EUR
- **B**: 50% × 5000 EUR, 50% × 0 ↔ equivalent certain observé X\*_B = 1500 EUR
- **C**: 80% × 2000 EUR, 20% × 0 ↔ equivalent certain observé X\*_C = 1400 EUR

The student must:
1. Implement `UtiliteCRRA(x, rho)` — `U(x) = x^(1-rho)/(1-rho)`
2. Deduce `rho` per lottery via bisection on `[0.01, 0.99]` (`U(X*) = proba*U(gain)` since `U(0)=0`)
3. Compute the **risk premium** = `E[gain] - equivalent certain`
4. Compare the 3 deduced rhos — test VNM axiom consistency (divergence reveals a certainty-effect / prospect-theory violation)

Consolidates the central themes of the notebook: calibration + certainty-equivalent + risk aversion + axiom representation.

## Compliance

**C.1 (no voluntary error).** Stubs use `return 0.0;` (no `throw`/`NotImplementedException`/`assert`). The notebook runs end-to-end with exercises uncompleted — verified `17/17 cells OK`.

**C.2 (commit WITH outputs).** The new code cell carries `execution_count: 17` (ordinal position) + 7 real outputs (stub output: `rho=0.000 / prime=0 EUR` for each uncompleted stub + the consistency question/hint text). Output captured by `exec_single_cell.py` on a fresh `.net-csharp` kernel (Rule F: Infer.NET environment viable — confirmed `16/16` then `17/17` exec).

**H.3 (pre-commit validation).** `notebook_tools validate` → 0 errors, 1 warning.

**metadata.cost preserved.** Raw-JSON edit (NOT `NotebookEdit`, which corrupts the notebook's top-level `metadata.cost`), byte-identical preservation verified: `metadata.cost identical: True`.

## Diff proof (additive, no regression)

```
1 file changed, 114 insertions(+)
```

Cell-by-cell diff vs `origin/main`:
- `source changed (existing): 0`
- `outputs changed (existing): 0`
- `exec_count changed (existing): 0`
- `NEW cells: [(42, 'a1b2c3d4', 'markdown'), (43, 'e5f6g7h8', 'code')]`

Purely additive (+1 markdown intro, +1 code stub). Zero existing cell touched.

**Anti-régression §D**: +114/-0, no deletion of any `# Solution`/`# Exemple résolu` cell. Substantive exercise authoring (not a cosmetic/accents change).

**Exercise count**: 3 headers (Exercices 2, 3, 4) — threshold met (was 2).

**Not a twin** (no `twin_pairs.d/*.yaml` rebaseline needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
