### PR TITLE
fix(rl,#8052): rl_7 c18 trend claim contradicts c15 output (draws peak then fall; X exploits to 65%)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb
@@ -750,7 +750,7 @@
     "tags": []
    },
    "source": [
-    "Avec TicTacToe, les deux agents devraient converger vers un jeu optimal, ou le joueur qui commence (X) ne peut pas perdre et le second joueur (O) peut au mieux forcer un match nul. La proportion de matchs nuls augmente avec l'entrainement, ce qui est coherent avec la théorie des jeux."
+    "Avec TicTacToe, les deux agents devraient converger vers un jeu optimal, ou le joueur qui commence (X) ne peut pas perdre et le second joueur (O) peut au mieux forcer un match nul. La proportion de matchs nuls augmente d'abord (de 13 % à près de 24 % vers 15 000 épisodes) puis redescend (à 20 % à 20 000), tandis que le joueur X apprend à exploiter son avantage et monte à 65 % de victoires : les agents apprennent à se bloquer, mais ne rejoignent pas le match nul systématique prédit par la théorie en 20 000 épisodes."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/value — lane myia-po-2024:CoursIA-2 — prev: MED/count #9108 rl_7 c29 (same notebook, distinct cell + defect class: c18 trend VALUE vs c29 recap COUNT).

## What

Fixes a **VALUE** defect in `rl_7_multi_agent_rl.ipynb` cell[18]: the interpretation prose claims the draws trend is **monotonic increasing** and **"coherent with game theory"** — both contradicted by the cell[15] **computed** training output. Markdown-only, no re-execution. Found via the #8052 claims↔outputs audit (RL slice), DEFERRED from the c29-count cycle as a distinct atomic subject.

## Ground truth (firsthand verified, L786-2)

cell[15] COMPUTED output (IQL training on TicTacToe, Ep 5000/10000/15000/20000):
- **Draws (Nul):** 13.3% → 20.9% → **23.7% @15000 (PEAK)** → **20.4% @20000 (FALL)** — non-monotonic
- **X wins:** 57.1% → 52.4% → 56.6% → **65.1% @20000** — X dominance GROWS
- O wins: 29.5% → 26.7% → 19.8% → 14.5% — declines

cell[18] (the claim): *"La proportion de matchs nuls **augmente** avec l'entrainement, ce qui est **coherent avec la théorie des jeux**."*

Both halves are contradicted:
1. **"augmente"** — false for the final phase (23.7% → 20.4% **decreases**; the peak is mid-training).
2. **"coherent avec la théorie des jeux"** — false. Game theory predicts optimal TicTacToe = draw (draws → 100%). The agents sit at **20.4% draws, falling**, with X exploiting at **65.1%**. They do **not** converge to the theoretical draw — the opposite of "coherent."

## c.1094-L distinction (NOT foreshadowing)

This is a **post-hoc interpretation of a COMPUTED output** (the training ran; the output is committed in the notebook), **not** foreshadowing of an un-run experiment. The #8052 lens (claim-vs-computed-output) applies directly. (Contrast: the rl_8 κ-value prose deferred last cycle was foreshadowing of an un-run exercise — NOT a #8052 defect. Here the output exists and is contradicted.)

## Defect (VALUE c.1062-L — firsthand verified)

| cell | element | wrong → correct |
|------|---------|-----------------|
| 18 | [0] | *"augmente avec l'entrainement, ce qui est coherent avec la théorie des jeux"* → grounded non-monotonic trend + X-dominance, citing only cell[15] numbers |

**Sentence 1** (theoretical background: *"X ne peut pas perdre, O peut au mieux forcer un match nul"*) is **CORRECT game theory** and is **preserved verbatim** — only the false trend sentence is rewritten.

## Verification (firsthand, #8052 lens)

Ground-truth locks in the edit script: cell[15] output confirmed to contain **13.3% / 23.7% / 20.4% / 65.1%** (draws non-monotonic + X dominance); the OLD false clause removed (count==0 in c18); sentence 1 (theory) preserved verbatim; the new clause cites **only** numbers present in cell[15]. Canonical JSON round-trip byte-identical pre/post (**trailing-adaptive** c.1086-L). diff = 2 lines (1 element), no code/output change. `assert len(diff) < 40` passed.

**rl_7 is NOT twinned** (no entry for `RL/rl_7_multi_agent_rl.ipynb` in `scripts/notebook_tools/twin_pairs.d/` — `gametheory-17-multiagent-rl.yaml` is a **name collision** referencing a different notebook, `GameTheory/GameTheory-17-MultiAgent-RL.ipynb`; confirmed via `git grep` of the YAML `python:` path, not the filename, c.1095-L) → no SHA rebaseline required.

## Scope

1 file content. No source changes beyond the trend-sentence rewrite. **Distinct subject from PR #9108** (c29 recap COUNT) — different cell (c18 interpretation vs c29 navigation recap), different defect class (VALUE vs COUNT); the two PRs touch non-adjacent cells and merge cleanly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
