### PR TITLE
fix(semanticweb,#8052): SW-13 RL someValuesFrom claim contradicts own output (cls-svf1)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
@@ -3461,20 +3461,20 @@
    "source": [
     "### Exercice 6 : Comparaison expressivite OWL 2 RL vs OWL 2 DL (someValuesFrom)\n",
     "\n",
-    "Les profils OWL 2 RL (owlrl, reasonable) et OWL 2 DL (HermiT) différent en **expressivite**. Une différence cle : la **classification automatique d'instances** par restrictions de classe (`someValuesFrom`). Verifiez empiriquement cette différence.\n",
+    "Les profils OWL 2 RL (owlrl, reasonable) et OWL 2 DL (HermiT) différent en **expressivite**. Une différence cle réside dans la portée des restrictions de classe couvertes : explorez d'abord `someValuesFrom`, puis `minCardinality`, pour localiser où le profil RL atteint sa limite. Verifiez empiriquement cette différence.\n",
     "\n",
     "**Consignes :**\n",
     "1. Construire une ontologie avec :\n",
     "   - Classe `MeatPizza` définie comme **equivalente** a `Pizza et (hasTopping some MeatTopping)`\n",
     "   - Instance `pizza1` declaree `Pizza` avec `pizza1 hasTopping topping1` ou `topping1 a MeatTopping`\n",
     "2. Appliquer **HermiT** (via OWLReady2) : `pizza1` doit etre **automatiquement classifiee** comme `MeatPizza`\n",
-    "3. Appliquer **owlrl** (profil RL) sur le même KG transcrit en rdflib : la classification automatique via `someValuesFrom` **n'est PAS supportee** en profil RL standard\n",
-    "4. Conclure : pour la classification riche par restrictions, DL est necessaire ; pour la materialisation rapide de hiérarchies subClassOf + propertyChainAxiom, RL suffit et est plus rapide\n",
+    "3. Appliquer **owlrl** (profil RL) sur le même KG transcrit en rdflib : contrairement à une idée répandue, owlrl **supporte** la classification `someValuesFrom` (via la règle cls-svf1 d'OWL 2 RL) — c'est sur la `minCardinality` (cf. `BigFamily = hasChild min 2`) que le profil RL montre sa limite\n",
+    "4. Conclure : RL suffit pour la classification `someValuesFrom` et la materialisation rapide de hiérarchies subClassOf + propertyChainAxiom ; DL reste nécessaire pour les constructions hors-profil-RL (cardinalités minimales, unions complexes)\n",
     "\n",
     "**Indices :**\n",
     "- OWLReady2 : `class MeatPizza(Pizza): equivalent_to = [Pizza & hasTopping.some(MeatTopping)]`\n",
     "- Après `sync_reasoner_hermit()`, verifier `MeatPizza in pizza1.is_a` ou `pizza1 in MeatPizza.instances()`\n",
-    "- En rdflib + owlrl : declarer `MeatPizza owl:equivalentClass [a owl:Restriction ; owl:onProperty :hasTopping ; owl:someValuesFrom :MeatTopping]` puis verifier l'absence de l'inference `pizza1 a MeatPizza` après expansion\n",
+    "- En rdflib + owlrl : declarer `MeatPizza owl:equivalentClass [a owl:Restriction ; owl:onProperty :hasTopping ; owl:someValuesFrom :MeatTopping]` puis verifier la **présence** de l'inference `pizza1 a MeatPizza` après expansion (règle cls-svf1) ; comparer avec la cardinalité `min 2` (`BigFamily`) que seul HermiT dérive\n",
     "- Pour rester clair pedagogiquement : afficher un mini-tableau avec `RL infere classification ?` vs `DL infere classification ?`\n",
     "- Question pedagogique : quel(s) profil(s) OWL 2 supporte(nt) `someValuesFrom` dans les axiomes d'equivalence ?"
    ]
@@ -3642,7 +3642,7 @@
     "\n",
     "Ce notebook a compare quatre raisonneurs OWL couvrant un spectre allant de l'implementation Python pure au code compile en Rust et en C, avec des profils OWL allant de RL (polynomial) a DL (NExpTime-complet). Les benchmarks sur l'ontologie pizza ont revele des ecarts de performance considerables : reasonable (Rust) est environ 70 fois plus rapide qu'owlrl (Python) sur l'ontologie pizza complete (et ~40 fois sur l'ontologie de test reduite a 40 triples), tandis qu'HermiT (Java, OWL 2 DL complet) offre une expressivite superieure au prix d'un temps d'exécution plus eleve.\n",
     "\n",
-    "La différence majeure entre les profils OWL 2 RL et OWL 2 DL a ete illustree par les exercices : le profil RL (owlrl, reasonable) materialise efficacement les hiérarchies de classes, les proprietes transitives et les inferences de base, mais ne supporte pas la classification automatique par restrictions `someValuesFrom`. Le profil DL (HermiT) detecte les incoherences ontologiques et classifie les instances selon des règles complexes, ce qui est indispensable dans les domaines critiques (medecine, industrie). Le choix du raisonneur depend donc du compromis entre expressivite requise et performances acceptables.\n",
+    "La différence majeure entre les profils OWL 2 RL et OWL 2 DL a ete illustree par les exercices : le profil RL (owlrl, reasonable) materialise efficacement les hiérarchies de classes, les proprietes transitives et les inferences de base, et couvre la classification `someValuesFrom` via la règle cls-svf1 d'OWL 2 RL (cf. exemple 6 : `pizza1` est bien classifiée `MeatPizza` par owlrl). Sa limite réelle se manifeste sur des constructions DL plus riches comme la `minCardinality` en position de super-classe, que seul un raisonneur DL (HermiT) traite intégralement. Le profil DL (HermiT) detecte les incoherences ontologiques et classifie les instances selon des règles complexes, ce qui est indispensable dans les domaines critiques (medecine, industrie). Le choix du raisonneur depend donc du compromis entre expressivite requise et performances acceptables.\n",
     "\n",
     "Ce notebook conclut la serie Semantic Web. Au fil des 13 notebooks, vous avez parcouru l'ensemble de la pile technologique : les triplets RDF (SW-1 a SW-3), les requêtes SPARQL (SW-4 a SW-5), les schemas et ontologies RDFS/OWL (SW-6 a SW-7), la validation SHACL (SW-8), les formats modernes JSON-LD et RDF-Star (SW-9 a SW-10), les graphes de connaissances (SW-11), l'integration avec les LLMs via GraphRAG (SW-12), et enfin les moteurs d'inference (SW-13)."
    ]

--- a/scripts/notebook_tools/twin_pairs.d/sw-13-reasoners.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-13-reasoners.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-31"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 7131d0cdb8d17a1e10d1419682e0de2230bf4959
+    date: "2026-08-01"
+    by: myia-po-2023:CoursIA
+    python_sha: ffd32bd612d9dc2220f473250e9e4c318189a542
     csharp_sha: 2bf1075659212ac6ca9f5e5ce46206791d3a9933
   known_differences:
     - "Socle commun : raisonnement automatique sur ontologies (forward-chaining, inference RDFS/OWL)."


### PR DESCRIPTION
Grain: MED/logic -- lane myia-po-2023:CoursIA -- prev: MED/smartcontracts #9107

See #8052 (claims↔outputs EPIC). The notebook self-contradicted on whether OWL 2 RL (owlrl) supports `someValuesFrom` classification.

## Summary

`SW-13-Python-Reasoners.ipynb` claimed owlrl (OWL 2 RL) "**ne supporte pas** la classification automatique par restrictions `someValuesFrom`" — but the notebook's **own worked solution** (code cell 68) prints `owlrl (RL) : pizza1 classifiee comme MeatPizza ? True` and explicitly names the responsible OWL 2 RL rule:

> Note : contrairement a une idee repandue, owlrl implemente la regle **cls-svf1** d'OWL 2 RL, ce qui lui permet ICI de deriver la classification via someValuesFrom.

The **lecture cell 69 already carried the correct reading**: "sur `someValuesFrom` [...], owlrl *reussit* la classification car cette construction-la *est* couverte par RL." So the notebook contradicted itself: solution (c68) + lecture (c69) = truth, but the exercise consigne (c84) + the Resume (c88) = stale (they predate the cls-svf1 note).

Aligned c84 + c88 to the truth the code already carries: **RL COVERS `someValuesFrom` (via cls-svf1); the genuine RL limit is `minCardinality` in super-class position** (cf. example 6's BigFamily part, where owlrl returns `False` and HermiT returns `True`).

## The defect (firsthand, G.1)

| Cell | Type | Claim (stale) | Contradicted by |
|------|------|---------------|-----------------|
| **c88** Resume | md | "le profil RL [...] **ne supporte pas** la classification automatique par restrictions `someValuesFrom`" | c68 output `owlrl (RL): pizza1 MeatPizza ? True` + c69 lecture |
| **c84** consigne 3 | md (exercise) | "la classification [...] via `someValuesFrom` **n'est PAS supportee** en profil RL standard" | c68 (True) |
| **c84** indice | md (exercise) | "verifier l'**absence** de l'inference `pizza1 a MeatPizza`" | c68 (inference IS present) |

The worked solution (c68) tests TWO constructions: `someValuesFrom` (MeatPizza) — both RL and DL return `True` (no difference); `minCardinality` (BigFamily min 2) — RL `False`, DL `True` (the real difference). The Resume/consigne located the RL/DL difference on the wrong construction.

## The fix (markdown-only, 5 elements)

- **c88[4] (Resume)**: "ne supporte pas someValuesFrom" → RL covers `someValuesFrom` via cls-svf1; its real limit is `minCardinality` in super-class position.
- **c84[2] (intro)**: reframe the exercise to explore `someValuesFrom` THEN `minCardinality` to localize where RL reaches its limit (matches what the solution actually demonstrates).
- **c84[9] (consigne 3)**: "n'est PAS supportee" → owlrl **supports** someValuesFrom (cls-svf1); the RL limit shows on `minCardinality` (BigFamily min 2).
- **c84[10] (consigne 4)**: "DL est necessaire pour la classification riche par restrictions" → RL suffices for someValuesFrom + subClassOf; DL needed for out-of-profile constructions (cardinalities, unions).
- **c84[15] (indice)**: "verifier l'**absence**" → "verifier la **presence**" (cls-svf1), then contrast with minCardinality that only HermiT derives.

No rewording of the worked solution (c68) or lecture (c69) — they were already correct; the drift was localized to the consigne + Resume that predated them.

## Diagnostic dérive (§D.5)

- **Cause (b) — claim antérieure stale.** The Resume (c88) and exercise consigne (c84) were written when the common belief was "RL does not support someValuesFrom". Later, the cls-svf1 note + corrected lecture (c68/c69) were added to the worked solution, but the Resume/consigne were not updated to match. The notebook accumulated an internal contradiction: the teaching (solution+lecture) evolved, the framing (consigne+Resume) did not.
- **Verdict: markdown-fix (deterministic LOGIC claim).** This is a factual/logical claim ("RL does/does not support someValuesFrom") grounded in a deterministic classification result (`True`/`False`), not a perf/timing/WER number. The §D.5 re-exec mandate (`claims-vs-outputs-d5-perf-number-reexec`) applies to perf/timing/cost numbers that move between kernel passes; it does **not** apply to a deterministic logical classification that reproduces identically (`True`) on every run. Markdown-align to the committed output is the honest and complete remedy.

## Acceptance criteria (verified firsthand)

- **Re-exec n/a**: deterministic logical claim, not a perf number. The grounding output (c68 `owlrl (RL): pizza1 MeatPizza ? True`) is deterministic and reproduces on every run.
- **Markdown-only**: 5 insertions / 5 deletions, 1 notebook file. 31 code cells + all outputs byte-identical (code_sha unchanged, verified). 0 code cell touched.
- **H.3**: 0 null execution_count, 0 errors (31 code cells).
- **content-loss guard**: findings=0 (md cells 58→58 stable; +503 normalized chars = content added, none lost).
- **rendering detector**: 0 violations (no frontmatter_supersize).
- **Twin parity**: SW-13 Reasoners [OK]. Invariant `git rev-parse HEAD:<nb>` == yaml `python_sha` (ffd32bd6) verified. C# sha unchanged.
- **Twin C# audited** (cf `twin-bugfix-propagate-cross-twin-audit`): SW-13-Reasoners-CSharp (23 cells, dotNetRDF) does **not** carry the someValuesFrom exercise → no cross-twin fix.
- **Catalogue byte-identical** to origin/main (untouched).

See #8052, #3801.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
