### PR TITLE
fix(smt,#8052): Z3-Linq2Z3 Job-Shop conclusion recap — glouton Cmax 12h -> 16h

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb
@@ -1260,7 +1260,7 @@
     "\n",
     "| Approche | Cmax | Méthode |\n",
     "|----------|------|----------|\n",
-    "| Glouton FIFO | 12h | Décisions locales séquentielles |\n",
+    "| Glouton FIFO | 16h | Décisions locales séquentielles |\n",
     "| Z3.Linq SMT | 9h | Exploration SMT complète |\n",
     "| Borne inférieure | 9h | Charge Machine A = 3+4+2 |\n",
     "\n",


### PR DESCRIPTION
## What

§D.5 markdown-fix on `11_Job_Shop_Scheduling.ipynb` — the "## Conclusion" recap table (MD[26]) claimed the FIFO glouton achieves Cmax = **12h** on the 3×2 instance, but the committed code prints Cmax = **16h** (twice, independently).

See #8052 (§D.5 prose-drift epic — understanding-driven fix, not a blind re-align).

## The defect

CODE[5] (FIFO glouton section) and CODE[16] (comparison section) both print:
```
Cmax glouton = 16h  (borne inf. = 9h → écart = 7h)        [CODE 5]
Cmax glouton : 16h  (sous-optimal)  /  Cmax Z3 : 9h       [CODE 16]
```

The MD[26] conclusion table:
```
| Approche        | Cmax | Méthode                     |
| Glouton FIFO    | 12h  | Décisions locales séquentielles |   <- stale
| Z3.Linq SMT     | 9h   | Exploration SMT complète    |   <- correct
| Borne inférieure| 9h   | Charge Machine A = 3+4+2    |   <- correct
```

The two other rows (Z3 = 9h, Borne inf = 9h) match the code **exactly** — only the glouton row drifted (12h vs 16h). **Partial-match signature** = prose drift, not a stale-output shift (a stale output would desync all rows).

## Why markdown-fix (not re-exec)

The Cmax value is **deterministic** — FIFO ordering (J0→J1→J2) on a fixed 3-machine × 2-job instance, byte-reproducible. The code output is current and the source of truth; only the markdown recap was stale. Per the d5 lesson (re-exec for drifting timing/perf, markdown-fix for deterministic logic where code is already correct), this is a markdown-fix.

## The fix

`| Glouton FIFO | 12h |` → `| Glouton FIFO | 16h |`

## Diff proof

```
1 file changed, 1 insertion(+), 1 deletion(-)
```
Markdown-only (MD[26] table row). No code cell, output, or `execution_count` changed → C.2 re-exec not required (markdown-only exception). Not a twin (no `twin_pairs.d` entry for this Z3-Linq2Z3 file). H.3 validate: **OK=1, 0 errors, 0 warnings**. Collision pre-flight: only prior PR on this file is #5336 (merged, French accents) — no open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
Grain: FIX/notebook — lane myia-po-2023:CoursIA — prev: §D.5 recap-drift scan (#8052)
