### PR TITLE
fix(search,#8052): CSP-8 c0 prereq cites Search-6/7 (adversarial/MCTS) instead of CSP-1/2

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb
@@ -32,8 +32,8 @@
     "5. **Appliquer** a la planification avec fenêtres de temps (Bloom : evaluer)\n",
     "\n",
     "### Prerequis\n",
-    "- Search-6 : formalisme CSP\n",
-    "- Search-7 : propagation de contraintes, arc consistency\n",
+    "- CSP-1 : formalisme CSP\n",
+    "- CSP-2 : propagation de contraintes, arc consistency\n",
     "- Bases de théorie des graphes (plus courts chemins)\n",
     "\n",
     "### Duree estimee : 60 minutes"

--- a/scripts/notebook_tools/twin_pairs.d/csp-8-temporal.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-8-temporal.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: "2026-07-29"
     by: myia-po-2023:CoursIA-2
-    python_sha: ada044d55500fef591dde86222fc041326dcfb14
+    python_sha: ded7deb24733cfda6621c66209b4f9702b86e340
     csharp_sha: 3859f46c9ec9b09dbbc50e7fc344d8844f82796b
   known_differences:
     - "Socle commun : algebre d'intervalle d'Allen (13 relations), STP (Simple Temporal Problem) avec Floyd-Warshall, TCSP (Temporal CSP a intervalles multiples), application planification de reunion. Couverture conceptuelle COMPLETE des deux cotes (le twin le plus proche de la famille CSP au sens cellule-a-cellule : 42 vs 41 cellules, 17 vs 16 code)."


### PR DESCRIPTION
Grain: MED/identity — lane myia-po-2024:CoursIA-2 — prev: MED/value #9110 rl_7 c18 (R6 pivot RL→Search/CSP, same #8052 audit, distinct family + defect class: CSP prereq IDENTITY vs RL trend VALUE).

## What

Fixes an **IDENTITY** defect in `CSP-8-Temporal.ipynb` cell[0] "### Prerequis": the temporal-CSP notebook cites **Search-6** and **Search-7** as prerequisites for "formalisme CSP" and "propagation de contraintes" — but those Search notebooks cover **completely different topics**. Markdown-only, no re-execution. Found via the #8052 claims↔outputs audit (Search/CSP slice). This is the CSP-8 grain flagged real in c.1087-L (alongside CSP-2) but not yet shipped.

## Ground truth (firsthand verified, L786-2)

`git ls-tree origin/main` on the Search series:
- **Search-6 = AdversarialSearch** (minimax, alpha-beta) — NOT "formalisme CSP"
- **Search-7 = MCTS-And-Beyond** — NOT "propagation de contraintes, arc consistency"

The **actual** CSP-series predecessors (verified by reading their c0 titles/objectives):
- **CSP-1-Fundamentals** = *"Fondamentaux des CSP"* / *"formalisme des CSP"* ✓ matches "formalisme CSP"
- **CSP-2-Consistency** = *"Propagation de Contraintes et Consistance"* ✓ matches "propagation de contraintes, arc consistency"

So CSP-8's prereq block cites the wrong notebooks (adversarial-search / MCTS) for content that lives in CSP-1/CSP-2.

## Defect (IDENTITY c.1062-L — strong class; same family as PR #9084 + PR #9081)

| cell | element | wrong → correct |
|------|---------|-----------------|
| 0 | [18] | `Search-6 : formalisme CSP` → `CSP-1 : formalisme CSP` |
| 0 | [19] | `Search-7 : propagation de contraintes, arc consistency` → `CSP-2 : propagation de contraintes, arc consistency` |

**Convention: plain-text replacement** (not linkified), matching sibling PRs #9084 (CSP-2) and #9081 (CSP-3) **exactly** — their diffs replace "Search-6"→"CSP-1", "Search-7"→"CSP-2" as plain text. Kept consistent so the coordinator reviews a uniform fix across the CSP series.

## Verification (firsthand, #8052 lens)

Ground-truth locks in the edit script:
- Search-6/7 actual topics confirmed (AdversarialSearch, MCTS-And-Beyond) vs CSP-1/2 actual topics (Fundamentals=formalisme, Consistency=propagation);
- the c0[18]/c0[19] anchors shape-confirmed pre-edit;
- **0 residual "Search-6"/"Search-7"** anywhere in notebook markdown (c.943-L2 family-wide index — only the 2 prereq lines were affected);
- Canonical JSON round-trip byte-identical pre/post (**trailing-adaptive** c.1086-L). diff = 4 lines (2 elements), no code/output change. `assert len(diff) < 40` passed.

**CSP-8 IS twinned** (`csp-8-temporal.yaml`, semantic). The C# twin (`CSP-8-Temporal-Csharp.ipynb`) has **ZERO** "Search-6"/"Search-7" references (already clean, verified firsthand) → **Python-only fix** → `python_sha` rebaselined `ada044d5` → `ded7deb2` (csharp_sha preserved). `check_twin_parity.py --check` [OK] post-commit.

## Scope

2 files: notebook content + twin yaml (sha rebaseline only). No source changes beyond the 2 prereq-line identity corrections. **Distinct subject** from PRs #9081/#9084 (different notebook, same defect class).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
