### PR TITLE
fix(planners,#8052): Planners-3 §7.4 heading drift — 5x5 obstacles -> 11x11 terrain pondere

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb
@@ -1830,15 +1830,15 @@
    "source": [
     "---\n",
     "\n",
-    "## 7.4 Exemple guide : Grille 5x5 avec obstacles -- BFS vs A*\n",
+    "## 7.4 Exemple guide : Terrain pondere -- pourquoi A* se distingue de BFS\n",
     "\n",
-    "Avant de passer aux exercices, appliquons les algorithmes BFS et A* sur un problème plus riche : une grille 5x5 contenant plusieurs obstacles. Cet exemple montre concretement comment l'heuristique de Manhattan confere a A* un avantage decisif en termes de noeuds explorees.\n",
+    "Sur une grille **a cout uniforme** (chaque pas coute 1), BFS est deja optimal : le chemin avec le moins de pas est aussi le moins couteux, et A* ne peut pas faire mieux -- le differenciateur entre les algorithmes **n'apparait pas**. Pour le reveler, nous passons a un **terrain pondere** : une grille 11x11 dotee d'un marais central (cout 10 par case de marais, 1 sinon), avec le depart et le but alignes de part et d'autre du marais. C'est exactement la situation ou raisonner sur le **cout cumule** (A*, Dijkstra) plutot que sur le seul nombre de pas (BFS, Greedy) change le resultat.\n",
     "\n",
     "**Ce que nous allons faire** :\n",
-    "1. Définir une grille 5x5 avec 6 obstacles formant un mur partiel\n",
-    "2. Construire et visualiser le graphe d'etats avec les obstacles\n",
-    "3. Lancer BFS et A* sur ce même problème\n",
-    "4. Comparer le nombre de noeuds explores et les chemins trouves"
+    "1. Definir une grille 11x11 avec un marais central 5x5 (25 cases a cout 10, les autres a cout 1)\n",
+    "2. Lancer BFS, Greedy Best-First et A* sur ce meme terrain pondere\n",
+    "3. Visualiser les chemins : BFS plonge tout droit dans le marais, A* le contourne\n",
+    "4. Comparer le nombre de pas et le **cout** -- c'est la que l'optimalite d'A* se distingue\n"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/planners-3-state-space.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-3-state-space.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-31"
-    by: myia-po-2024:CoursIA-2 2026-07-31
-    python_sha: e8cbb855b1d3b44b93c091d28990202477441e96
+    date: "2026-08-01"
+    by: myia-po-2026:CoursIA 2026-08-01
+    python_sha: 97ba9b763f12116f3ffcf85b8e71ffb1bce6082a
     csharp_sha: a9306fbf5a3c02555bf3f63b03a35db099da423f
   known_differences:
     - "Concept : recherche dans l'espace d'etats (BFS/DFS/A* sur le graphe des etats reachables)."


### PR DESCRIPTION
## What

§D.5 prose-consistency fix on `Planners-3-State-Space.ipynb` — the "## 7.4 Exemple guide" heading + preamble (MD[42]) described an example that no longer exists. A faithful rewrite aligns it to what the notebook actually demonstrates.

See #8052 (§D.5 prose-drift epic — understanding-driven fix, not blind re-align).

## The defect

MD[42] (heading + preamble) said:
- `## 7.4 Exemple guide : Grille 5x5 avec obstacles -- BFS vs A*`
- "une grille 5x5 contenant plusieurs obstacles"
- "l'heuristique de Manhattan confere a A* un avantage decisif en termes de noeuds explorees"
- "Définir une grille 5x5 avec 6 obstacles formant un mur partiel"

But the actual CODE[43] demonstrates a **completely different, richer example**:
- `W = H = 11` — **Grille 11x11** with a central weighted marais (5×5 block, 25 cells, cost 10)
- Output: `Grille 11x11 | marais central de 25 cases (cout 10) | depart (0,5) -> but (10,5)`
- BFS / Greedy minimize the number of **PAS** (10 steps, cout **55**, cross the marais); A* minimizes the real **COUT** (16 steps, cout **16**, avoids the marais)
- CODE[43] comment: "terrain pondere -- BFS/Greedy minimisent les PAS, A* le COUT. C'est LE differenciateur d'optimalite"

This is a full **pedagogical-premise drift** (cost-vs-steps optimality on weighted terrain), not just the grid dimension — so a dimension-only fix would leave the internal prose incoherent. The fix is a faithful rewrite of the heading + preamble + "Ce que nous allons faire" steps.

## Multi-source corroboration (the truth is already in the notebook)

The correct story is fully present elsewhere — MD[42] was the lone stale cell:
- **CODE[43] output + comments**: 11x11 weighted marais, BFS cost 55 / A* cost 16, cost-vs-steps differentiator.
- **MD[44] (result interpretation)**: already correctly describes "terrain pondere / marais central / BFS cost 55 / A* cost 16 / optimalite" — **untouched**.
- **C# twin MD[11]/MD[13]**: already correctly describe "grille 11x11 cout uniforme" + "terrain pondere marais central cout 10" — the drift was **Python-side only** (no cross-twin fix needed).

The rewrite mirrors the canonical framing already in MD[44] + the C# twin (twin prose consistency).

## Verdict §D.5 markdown-fix

Deterministic logic (grid config `W=H=11`, marais fixed 5×5 block, costs 10/1 — byte-reproducible). Per the d5 lesson, deterministic logic with code already correct → markdown-fix (not re-exec). The pedagogical claim (cost-vs-steps optimality) is a **logic point**, not a perf/timing number — so the d5 "re-exec for timing" branch does not apply.

## Diff proof

- **Notebook**: +6/-6, markdown-only (MD[42]). No code cell, output, or `execution_count` changed → C.2 re-exec not required (markdown-only exception). H.3 validate: **0 errors** (1 pre-existing warning, confirmed present on origin/main too). C.1: 0 red-flags.
- **Twin yaml**: +3/-3, `python_sha` rebaselined → committed blob `97ba9b76` (c.819 protocol: rebaseline is the LAST op, working-tree == committed blob). `csharp_sha` unchanged (Python-side drift only). Invariant verified: `yaml python_sha == git rev-parse HEAD:<nb>` ✓.

Collision pre-flight: prior Planners-3 PRs are merged/closed on different topics (BFS/DFS twin #5534, h* admissibility #8988, CoutChemin #8488, A*-vs-BFS interpretation #3760) — none touch the §7.4 heading. No open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
