### PR TITLE
fix(search,#8052): App-5/6/7 CSP prereq cites Search-6/7 (adversarial/MCTS) instead of CSP-1/2

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb
@@ -1320,7 +1320,7 @@
     "3. Le modèle separe clairement la structure (contraintes dures) de la qualite (objectif)\n",
     "4. Le temps de resolution reste faible grace aux techniques de propagation et d'elagage internes au solveur\n",
     "\n",
-    "> **Note technique** : CP-SAT utilise en interne une combinaison de backtracking, propagation de contraintes, et SAT solving (clause learning). C'est nettement plus sophistique que notre backtracking du Search-6."
+    "> **Note technique** : CP-SAT utilise en interne une combinaison de backtracking, propagation de contraintes, et SAT solving (clause learning). C'est nettement plus sophistique que notre backtracking du CSP-1."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb
@@ -59,7 +59,7 @@
     "### Prerequis\n",
     "- Python 3.10+, numpy, matplotlib\n",
     "- `python-constraint` (CSP)\n",
-    "- Notions de CSP (Search-6 et Search-7)\n",
+    "- Notions de CSP (CSP-1 et CSP-2)\n",
     "\n",
     "### Duree estimee : 50 minutes\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb
@@ -56,8 +56,8 @@
     "5. **Comparer** les trois approches en termes de performance moyenne\n",
     "\n",
     "### Prerequis\n",
-    "- Search-6 : Fondamentaux des CSP (variables, domaines, contraintes)\n",
-    "- Search-7 : Consistance et propagation de contraintes\n",
+    "- CSP-1 : Fondamentaux des CSP (variables, domaines, contraintes)\n",
+    "- CSP-2 : Consistance et propagation de contraintes\n",
     "- Python : collections, comprehensions, bases de numpy/matplotlib\n",
     "\n",
     "### Duree estimee : 45 minutes\n",
@@ -1402,7 +1402,7 @@
     "2. Les positions avec un vert convergent immediatement (domaine = 1)\n",
     "3. Les lettres grises ont un effet global : elles sont eliminees de toutes les positions\n",
     "\n",
-    "> **Lien avec Search-7** : cette reduction de domaines est une forme de forward checking, etudiee dans le notebook sur la consistance CSP."
+    "> **Lien avec CSP-2** : cette reduction de domaines est une forme de forward checking, etudiee dans le notebook sur la consistance CSP."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/app-5-timetabling.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-5-timetabling.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-25'
     by: po-2026
-    python_sha: e717ca87c5efa311c3e79e799327e7d19e2cc691
+    python_sha: a0ddc663d62d71dc6b524f03eeedf69fe9d8c73f
     csharp_sha: 52a9869b22cfe957076dd0819b8508ba7221e99a
   known_differences:
     - "Socle pedagogique commun : Emploi du temps / Timetabling (CSP : creneaux, salles, conflits) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."

--- a/scripts/notebook_tools/twin_pairs.d/app-6-minesweeper.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-6-minesweeper.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-25'
     by: po-2026
-    python_sha: a0a5d1ff2462770aa37fda5dd0c426ff6cd31589
+    python_sha: d87bc2b4ae3f2abfdb2be0283a8e0d337e0465aa
     csharp_sha: 7435be2a68253f66e9e4a6639efc2a44d4aab4bd
   known_differences:
     - "Socle pedagogique commun : Demineur (CSP : contraintes sommes exactes, library python-constraint) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."

--- a/scripts/notebook_tools/twin_pairs.d/app-7-wordle.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-7-wordle.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: '2026-07-25'
     by: po-2026
-    python_sha: f07a9680882345ad9f56a69e24f8092acfe8a68e
+    python_sha: b93a3bf2a9bdf0e1c20a642d6380e0a6360850ac
     csharp_sha: 2c8194226c9eabf6906fc907455aae6190dc571b
   known_differences:
     - "Socle pedagogique commun : Wordle (logique deductive + feedback, theorie de l'information) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."


### PR DESCRIPTION
Grain: MED/identity (family-fix) — lane myia-po-2024:CoursIA-2 — prev: MED/identity #9115 CSP-8 (same #8052 audit, same defect CLASS + fix; this PR closes the family by catching the 3 remaining App-* siblings).

## What

Identity **family-fix** (c.943-L2 bug-de-famille): the same "Search-6/7 mis-attribution" defect fixed in CSP-2 (PR #9084), CSP-3 (PR #9081), CSP-8 (PR #9115) persists in **3 App-* CSP application notebooks**. A family-wide grep (`Search-6`/`Search-7` across all CSP notebooks) found them. Markdown-only, no re-execution.

## Ground truth (firsthand verified, L786-2)

`git ls-tree origin/main` Search series:
- **Search-6 = AdversarialSearch** (minimax) — NOT CSP
- **Search-7 = MCTS-And-Beyond** — NOT CSP

Actual CSP-series content:
- **CSP-1-Fundamentals** = "Fondamentaux des CSP" / backtracking / formalisme
- **CSP-2-Consistency** = "Propagation de Contraintes et Consistance"

## Defects (5 elements / 3 notebooks)

| notebook | cell.elem | wrong → correct |
|----------|-----------|-----------------|
| App-5-Timetabling | c22[18] | `notre backtracking du Search-6` → `notre backtracking du CSP-1` |
| App-6-Minesweeper | c1[16] | `Notions de CSP (Search-6 et Search-7)` → `(CSP-1 et CSP-2)` |
| App-7-Wordle | c1[14] | `Search-6 : Fondamentaux des CSP` → `CSP-1 : ...` |
| App-7-Wordle | c1[15] | `Search-7 : Consistance et propagation` → `CSP-2 : ...` |
| App-7-Wordle | c25[16] | `**Lien avec Search-7** ... consistance CSP` → `**Lien avec CSP-2**` |

**App-5 note:** App-5 itself only has a glutton ("Le glouton ne revient jamais en arrière — pas de backtracking"), so "notre backtracking du Search-6" cross-refs the series' CSP backtracking = CSP-1 (confirmed by the CSP-2 fix: "Classe CSP / MRV (rappel de Search-6)" → "CSP-1"). Search-6 = AdversarialSearch has no CSP backtracking.

**Convention: plain-text replacement**, matching sibling PRs #9084/#9081 exactly. **Co-shipped** because it's one coherent subject (same root cause — stale aliases from the CSP-series split-out of Search; same fix pattern).

## Verification (firsthand, #8052 lens)

- Search-6/7 actual topics confirmed vs CSP-1/2 actual topics;
- each anchor shape-confirmed pre-edit;
- **0 residual "Search-6"/"Search-7"** anywhere in each notebook's markdown (c.943-L2 family-wide index);
- Canonical JSON round-trip byte-identical pre/post (**trailing-adaptive** c.1086-L). diffs: App-5=2, App-6=2, App-7=6 lines; all `<40`. `assert` passed.

All 3 **twinned (semantic)**. C# twins (App-5-CSharp, App-6-CSharp, App-7b-Wordle-CSharp) all have **ZERO** Search-6/7 (already clean) → **Python-only fix** → `python_sha` rebaselined for each (csharp_sha preserved):
- App-5: `e717ca87` → `a0ddc663`
- App-6: `a0a5d1ff` → `d87bc2b4`
- App-7: `f07a9680` → `b93a3bf2`

`check_twin_parity.py --check` [OK] for all 3 post-commit. (DRIFT pre-commit is expected — C933-L: tool reads committed HEAD blob, resolved after commit.)

## Scope

6 files: 3 notebooks + 3 twin yamls (sha rebaseline only). No source changes beyond the 5 identity corrections. **Distinct subject** from PRs #9081/#9084/#9115 (different notebooks, same defect class — this PR closes the family).

## Family closure

After this PR, the "Search-6/7 → CSP-1/2" identity defect is resolved across the entire CSP family: CSP-2 (#9084), CSP-3 (#9081), CSP-8 (#9115), App-5/App-6/App-7 (this PR). (CSP-1 confirmed CLEAN firsthand.)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
