### PR TITLE
fix(ml,#8052): ML-8-Clustering-Python c0 nav points prev/next to C# twins instead of -Python siblings

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering-Python.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# ML-8 (Python) : Clustering non-supervisé avec K-Means\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Précédent](ML-7-Recommendation.ipynb) | [Jumeau .NET (ML.NET)](ML-8-Clustering.ipynb) | [Suivant >>](ML-9-Anomaly-Detection.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< ML-7-Recommendation](ML-7-Recommendation-Python.ipynb) | [Jumeau .NET (ML.NET)](ML-8-Clustering.ipynb) | [Suivant >> ML-9-Anomaly-Detection](ML-9-Anomaly-Detection-Python.ipynb)\n",
     "\n",
     "> Ce notebook est le **jumeau Python (scikit-learn)** de [ML-8-Clustering.ipynb](ML-8-Clustering.ipynb). Il couvre exactement le même parcours pédagogique — segmentation RFM, K-Means, normalisation, méthode du coude, silhouette — avec l'API idiomatique de scikit-learn au lieu de ML.NET. Le clustering est un problème **non-supervisé** : on ne dispose d'aucune étiquette, l'algorithme doit découvrir seul la structure des données.\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/ml-8-clustering.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-8-clustering.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: "2026-07-31"
     by: myia-po-2023:CoursIA
-    python_sha: 6b90768064064655d558f65a170c37dbdef0a74b
+    python_sha: 98249788bd0a3541acd82d2f47e1dd645ac154b1
     csharp_sha: 9406692311322fed00c51c257131dfe204399768
     reason: "rebaseline apres add metadata.cost (#8445) aux DEUX jumeaux (vrais CPU-only identiques) ; parite semantique preservee (metadata-only, 0 code churn)"
   known_differences:


### PR DESCRIPTION
Grain: MED/structural — lane myia-po-2024:CoursIA-2 — prev: MED/identity family-fix #9117 App-5/6/7 (R6 pivot Search/CSP→ML.Net, same #8052 audit, distinct family + defect class: ML twin nav STRUCTURAL vs CSP identity).

## What

Fixes a **STRUCTURAL** defect in `ML-8-Clustering-Python.ipynb` cell[0] Navigation line: the prev/next links point at the **C#** notebooks instead of the **-Python** siblings, breaking the Python reading chain. Markdown-only, no re-execution. Found via the #8052 audit ML.Net slice (Explore sweep on ML-4/ML-8/TP, re-verified firsthand).

## Ground truth (firsthand verified, L786-2)

The Python twin's c0 Navigation:
`[<< Précédent](ML-7-Recommendation.ipynb) | [Jumeau .NET (ML.NET)](ML-8-Clustering.ipynb) | [Suivant >>](ML-9-Anomaly-Detection.ipynb)`

- `<< Précédent` and `Suivant >>` target the **C#** notebooks.
- The dedicated "Jumeau .NET" slot **already** links the C# twin (ML-8-Clustering.ipynb) — so 3 of 4 links land in the .NET chain.

**Canonical convention** (ML-6-ONNX-Python c0): prev/next link the **-Python** siblings (notebook name as link text), with one "Jumeau .NET" slot for the C# twin:
`[<< ML-5-TimeSeries](ML-5-TimeSeries-Python.ipynb) | [Jumeau .NET (ML.NET)](ML-6-ONNX.ipynb) | [Suivant >> ML-7-Recommendation](ML-7-Recommendation-Python.ipynb)`

**Targets exist** (git cat-file -e): `ML-7-Recommendation-Python.ipynb` ✓ and `ML-9-Anomaly-Detection-Python.ipynb` ✓. (c.1081-L: verified the targets actually exist before fixing.)

**C# twin is CLEAN**: `ML-8-Clustering.ipynb` c0 `[<< précédent](ML-7-Recommendation.ipynb)` points to the C# chain — correct for the C# twin → Python-only fix.

## Defect (STRUCTURAL c.1062-L strong class)

| cell | element | wrong → correct |
|------|---------|-----------------|
| 0 | [2] | `[<< Précédent](ML-7-Recommendation.ipynb) … [Suivant >>](ML-9-Anomaly-Detection.ipynb)` → `[<< ML-7-Recommendation](ML-7-Recommendation-Python.ipynb) … [Suivant >> ML-9-Anomaly-Detection](ML-9-Anomaly-Detection-Python.ipynb)` |

("Jumeau .NET (ML.NET)](ML-8-Clustering.ipynb)" slot **preserved**.) Convention matches ML-6-ONNX-Python exactly.

## Verification (firsthand, #8052 lens)

- -Python targets exist (git cat-file -e); canonical convention confirmed (ML-6-ONNX-Python); C# twin clean;
- c0[2] anchor shape-confirmed pre-edit; Jumeau slot preserved; post-edit regex confirms **no prev/next target is a bare C# notebook**;
- Canonical JSON round-trip byte-identical pre/post (**trailing-adaptive** c.1086-L). diff = 2 lines (1 element), no code/output change. `assert len(diff) < 40` passed.

**ML-8-Clustering-Python IS twinned** (ml-8-clustering.yaml, semantic). C# unchanged → `python_sha` rebaselined `6b907680` → `98249788` (csharp_sha preserved). `check_twin_parity.py --check` [OK] ML-8 post-commit. (DRIFT pre-commit expected — C933-L: tool reads committed HEAD blob, resolved after commit.)

## Scope

2 files: notebook content + twin yaml (sha rebaseline only). No source changes beyond the 1 nav-line correction. cell[0] is the only nav line in the notebook.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
