### PR TITLE
fix(ml,#8052): ML-3/5/7/9-Python twin nav points prev/next to C# twins instead of -Python siblings

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement-Python.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# ML-3 (Python) : Entraînement et AutoML\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Précédent](ML-2-Data&Features.ipynb) | [Jumeau .NET (ML.NET)](ML-3-Entrainement&AutoML.ipynb) | [Suivant >>](ML-4-Evaluation.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< ML-2-Data&Features](ML-2-Data&Features-Python.ipynb) | [Jumeau .NET (ML.NET)](ML-3-Entrainement&AutoML.ipynb) | [Suivant >> ML-4-Evaluation](ML-4-Evaluation-Python.ipynb)\n",
     "\n",
     "> Ce notebook est le **jumeau Python (scikit-learn)** de [ML-3-Entrainement&AutoML.ipynb](ML-3-Entrainement&AutoML.ipynb). Il couvre le même parcours : entraînement de plusieurs régressieurs (linéaire, gradient boosting), compromis biais-variance, et **AutoML** — la sélection automatique du meilleur estimateur par validation croisée. L'API idiomatique scikit-learn remplace les `Trainers` ML.NET et `Auto().Regression()` devient une comparaison `cross_val_score` sur un dictionnaire d'estimateurs.\n",
     "\n",

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries-Python.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# ML-5 (Python) : Prévision de séries temporelles (STL + SARIMA)\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< ML-4-Evaluation](ML-4-Evaluation.ipynb) | [Jumeau .NET (ML.NET)](ML-5-TimeSeries.ipynb) | [Suivant >> ML-6-ONNX](ML-6-ONNX.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< ML-4-Evaluation](ML-4-Evaluation-Python.ipynb) | [Jumeau .NET (ML.NET)](ML-5-TimeSeries.ipynb) | [Suivant >> ML-6-ONNX](ML-6-ONNX-Python.ipynb)\n",
     "\n",
     "> Ce notebook est le **jumeau Python (statsmodels)** de [ML-5-TimeSeries.ipynb](ML-5-TimeSeries.ipynb) (ML.NET `ForecastBySsa`). Il couvre la même pédagogie (décomposition tendance / saisonnalité / bruit, prévision, intervalles de confiance, comparaison de configurations) avec les outils canoniques Python. Contrairement au jumeau .NET (dont les cellules ML.NET nécessitent un environnement SDK complet), **ce notebook s'exécute de bout en bout**.\n",
     "\n",

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation-Python.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# ML-7 (Python) : Systèmes de recommandation par factorisation de matrice (NMF)\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Précédent](ML-6-ONNX.ipynb) | [Jumeau .NET (ML.NET)](ML-7-Recommendation.ipynb) | [Suivant >>](ML-8-Clustering.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< ML-6-ONNX](ML-6-ONNX-Python.ipynb) | [Jumeau .NET (ML.NET)](ML-7-Recommendation.ipynb) | [Suivant >> ML-8-Clustering](ML-8-Clustering-Python.ipynb)\n",
     "\n",
     "> Ce notebook est le **jumeau Python (scikit-learn)** de [ML-7-Recommendation.ipynb](ML-7-Recommendation.ipynb) (ML.NET). Il couvre la même pédagogie (filtrage collaboratif par factorisation de matrice) avec `sklearn.decomposition.NMF`.\n",
     "\n",

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection-Python.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# ML-9 (Python) : Détection d'anomalies par PCA (erreur de reconstruction)\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Précédent](ML-8-Clustering.ipynb) | [Jumeau .NET (ML.NET)](ML-9-Anomaly-Detection.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< ML-8-Clustering](ML-8-Clustering-Python.ipynb) | [Jumeau .NET (ML.NET)](ML-9-Anomaly-Detection.ipynb)\n",
     "\n",
     "> Ce notebook est le **jumeau Python (scikit-learn)** de [ML-9-Anomaly-Detection.ipynb](ML-9-Anomaly-Detection.ipynb) (ML.NET). Il couvre la même pédagogie avec les outils du écosystème Python. La logique de détection est identique : on apprend le régime normal, puis on mesure l'écart d'un point à ce régime.\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: "2026-07-31"
     by: myia-po-2024:CoursIA-2
-    python_sha: 3c86b640ab9512ee3e6c66679c12fac732c2ccb8
+    python_sha: 695da4960a0c19888c1e5917040ed84d5ee520be
     csharp_sha: 23a665e9c31aa87889cbaf4630e4d87b3c32e8c2
     reason: "rebaseline python apres fix prose Exemple 2/AutoML (cellules 7/8/11, #8052) : la prose disait 'donnees quadratiques y=100x^2' et 'compare deux GradientBoosting' mais le code cellule 8 genere des SINUS (y=10sin(x)) et compare trois DecisionTreeRegressor (underfit/good/overfit) ; l'AutoML cellule 10 tourne sur ces memes donnees sinus (LinearRegression RMSE CV=7.01, RandomForest=3.06). Le comment cellule 8 'le RMSE test explose' contredisait l'output (overfit test=2.78, le plus bas). Fix aligne prose sur le code execute. Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:

--- a/scripts/notebook_tools/twin_pairs.d/ml-5-timeseries.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-5-timeseries.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: "2026-07-31"
     by: myia-po-2024:CoursIA-2
-    python_sha: 349824e5b0b13acdee29273dfac9e58656459e50
+    python_sha: 5e863ede175ce3bf689752df4e3750ac08f2a71f
     csharp_sha: 581fcb6c880b55928062698a37560736ff250681
     reason: "rebaseline python apres fix intro horizon (cellule 1, #8052) : la prose disait 'horizon = 7 jours (1 semaine)' mais le SARIMA prevoit 366 jours (2024 entiere, cellules 13/14/16). 7 = periode saisonniere hebdo, pas l'horizon. Python-only, csharp_sha unchanged, parite (surface) preservee."
   known_differences:

--- a/scripts/notebook_tools/twin_pairs.d/ml-7-recommendation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-7-recommendation.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: "2026-07-31"
     by: myia-po-2024:CoursIA-2
-    python_sha: a3279c176b3266566d06cd2eebb8274aba150d0e
+    python_sha: 77524721813b30cc81946ec94cf4f9ed6c69531a
     csharp_sha: 033dbe7f8ffda8fd0258a6f1a702436de69234df
     reason: "rebaseline python apres fix claim sparsite (cellules 1 et 22, #8052) : la prose disait 'La matrice est clairsemee (chaque utilisateur ne note que quelques films)' + table resume 'creuse' mais l'output cellule 4 affiche 'Notes observees : 23/25 (92% rempli)' (3 users sur 5 ont note TOUS les films) = matrice presque complete, l'oppose de clairsemee. Fix distingue systems reels (clairsemes, point pedago conserve) vs jouet (presque complet pour lisibilite). Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:

--- a/scripts/notebook_tools/twin_pairs.d/ml-9-anomaly-detection.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-9-anomaly-detection.yaml
@@ -6,7 +6,7 @@
   last_audit:
     date: "2026-07-31"
     by: myia-po-2024:CoursIA-2
-    python_sha: b58ed094f029113ec2976957d45593f5a52465a6
+    python_sha: 060c0e79c3e5c800eee790bddccf0f1462cce4d7
     csharp_sha: bf2ddbc3863d9cecf4045ddb73e80399149a2584
     reason: "rebaseline python apres fix prose difficulte detection (cellules 20 et 25, #8052) : (1) cellule 25 disait anomalies '~3 ecarts-types : faciles a detecter' mais le code cellule 6 genere ~2-3 sigma et l'AUC=0.87 / DR@10FP=0.60 (cellule 13) montrant une detection non-triviale (cellule 5 dit explicitement 'non-triviale') ; (2) cellule 20 disait qu'a FPR<=5% 'on raterait la plupart' mais le sweep cellule 19 donne TPR=0.60 a FPR=0.04 (60% detectees, contredisait aussi la phrase precedente de la meme cellule). Fix aligne prose sur les outputs executes. Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:


### PR DESCRIPTION
Grain: MED/structural (family-fix) — lane myia-po-2024:CoursIA-2 — prev: MED/structural #9120 ML-8 (same #8052 audit, same defect CLASS + fix; this PR extends the ML-Py twin nav fix to the remaining 4 affected twins).

## What

Structural **family-fix** (c.943-L2): the same "Py-twin nav points prev/next to C#" defect fixed in ML-8 (PR #9120) persists in **4 more ML-Python twins**. A family scan of all `ML-*.ipynb` twins found them. Markdown-only, no re-execution.

## Ground truth (firsthand verified, L786-2 + c.1081-L)

Each affected Py twin's cell[0] Navigation points `<< Précédent` and/or `Suivant >>` at the **C#** notebooks, while the `Jumeau .NET` slot **already** links the C# twin → 3/4 links land in the .NET chain.

| notebook | nav targets (before) | C# twin status |
|----------|----------------------|----------------|
| ML-3-Entrainement-Python | prev=ML-2-Data&Features.ipynb (C#), next=ML-4-Evaluation.ipynb (C#) | ML-3 C# CLEAN (C# chain) |
| ML-5-TimeSeries-Python | prev=ML-4-Evaluation.ipynb (C#), next=ML-6-ONNX.ipynb (C#) | ML-5 C# CLEAN |
| ML-7-Recommendation-Python | prev=ML-6-ONNX.ipynb (C#), next=ML-8-Clustering.ipynb (C#) | ML-7 C# CLEAN |
| ML-9-Anomaly-Detection-Python | prev=ML-8-Clustering.ipynb (C#) (no next — end of series) | ML-9 C# CLEAN |

**Canonical convention** = ML-6-ONNX-Python c0[2] (the clean twin): prev/next link the **-Python** siblings (notebook name as link text), with one `Jumeau .NET` slot for the C# twin.

**All -Python targets exist** (git cat-file -e): ML-2-Data&Features-Python, ML-4-Evaluation-Python, ML-6-ONNX-Python, ML-8-Clustering-Python ✓.

## Defect (STRUCTURAL c.1062-L strong class)

For each, cell[0] elem[2]: change prev/next targets from C# → -Python, preserve the `Jumeau .NET` slot. (ML-6 canonical form: link text = notebook name, target = -Python.)

## Verification (firsthand, #8052 lens)

- -Python targets exist (cat-file -e); canonical convention confirmed (ML-6-ONNX-Python); C# twins all CLEAN → Python-only;
- each c0[2] anchor shape-confirmed pre-edit; `Jumeau .NET (ML.NET)` slot preserved; post-edit **regex confirms no prev/next target is a bare C# notebook** (only the Jumeau slot may ref C#);
- Canonical JSON round-trip byte-identical pre/post (**trailing-adaptive** c.1086-L). diffs: 2 lines each (8 total); all `<40`. `assert` passed.

**Twin status**: ML-3/5/7/9 all twinned (semantic). C# unchanged → `python_sha` rebaselined for all 4 (csharp_sha preserved):
- ML-3: `3c86b640` → `695da496` (note: ML-3's twin yaml slug is `ml-3-entrainement-automl.yaml` — slug includes the "&AutoML" suffix; c.1095-L variant: verified via git grep on the `python:` path, not by guessing the slug)
- ML-5: `349824e5` → `5e863ede`
- ML-7: `a3279c17` → `77524721`
- ML-9: `b58ed094` → `060c0e79`

`check_twin_parity.py --check` [OK] for ML-3/5/7/9 post-commit. (DRIFT pre-commit expected — C933-L.)

## Scope

8 files: 4 notebooks + 4 twin yamls (sha rebaseline only). No source changes beyond the 4 nav-line corrections. **Distinct subject** from #9120 (different notebooks, same defect class — this PR extends the fix to the remaining ML-Py twins).

## Family closure

After #9120 (ML-8) + this PR (ML-3/5/7/9), the "ML-Py twin nav points to C#" defect is resolved across the whole ML-*.ipynb Py-twin family. (ML-2, ML-4, ML-6 confirmed CLEAN firsthand.)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
