### PR TITLE
fix(symbolic,#8052): Argument_Analysis CrossLinks Limitations stale 1,5% -> 59,9% post-#763

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb
@@ -1174,7 +1174,7 @@
     "- **Argumentum upstream** (`Cards/Fallacies/Argumentum Fallacies - Taxonomy.csv`) — source canonique.\n",
     "- **Walton, Reed & Macagno 2008** — Argumentation Schemes (60 schemes référencés).\n",
     "\n",
-    "**Limitations disclosed** : AIF mapping 5% (tâche d'annotation lourde), crossLink 1,5% (taxonomie plate), `argumentum_virtues.owl` absent upstream, `AIF_skosOther` toujours vide (réservé usage futur)."
+    "**Limitations disclosed** : AIF mapping 5% (tâche d'annotation lourde), crossLink 59,9 % de couverture (844/1 408 sophismes ; 40 % restants sans relation transversale, cf. §10), `argumentum_virtues.owl` absent upstream, `AIF_skosOther` toujours vide (réservé usage futur)."
    ]
   }
  ],


### PR DESCRIPTION
Grain: LOW/§D.5-markdown-fix -- lane myia-po-2023:CoursIA -- prev: LOW/§D.5-markdown-fix #9113

## Diagnostic dérive (§D.5 — EPIC #8052)

**Defect** — `Argument_Analysis_Ontology_CrossLinks.ipynb` cell[25] `source[17]` ("Limitations disclosed") cites `crossLink 1,5% (taxonomie plate)`. This is the **PRE-#763** coverage figure, and it **self-contradicts the notebook's own committed evidence**:

| Source | What it says |
|--------|-------------|
| cell[12] output | `Couverture par sophisme: 844 / 1408 = 59.9%` |
| cell[14] output | `844 sophismes = 59,9 %` |
| cell[17] (Honnêteté) | `"59,9 % (et non plus 1,5 %)"` — **explicitly marks 1,5 % obsolete** |
| cell[25] source[3] (Substance PR-B) | `couverture 59,9 %` |

The "Limitations disclosed" line is the **lone stale remnant** — every other mention in the notebook already carries the corrected post-#763 value.

**Cause (b)** — claim antérieure stale. PRs #141 / #763 raised crossLink coverage 1,5 % → 59,9 % (844/1408). The substance paragraph (source[3]) and the honesty cell (cell[17]) were refreshed; the **Limitations** enumeration (source[17]) was missed.

**Verdict : markdown-fix.** `844/1408` is a **deterministic count on a fixed canonical CSV** (`Argumentum Fallacies - Taxonomy.csv`, 1408 sophismes) — it reproduces **identically at every run**. No re-exec needed (it is not a perf/timing/cost number — cf [[claims-vs-outputs-d5-perf-number-reexec-not-markdown]]). The **real residual limitation is preserved honestly**: ~40 % of sophismes (1408 − 844 = 564) still carry no crossLink post-#763 — the obsolete "taxonomie plate" framing is replaced by the accurate residual.

## Fix

cell[25] source[17], sub-string only (rest of line preserved):

```
- crossLink 1,5% (taxonomie plate)
+ crossLink 59,9 % de couverture (844/1 408 sophismes ; 40 % restants sans relation transversal, cf. §10)
```

The other Limitations items (`AIF mapping 5%`, `argumentum_virtues.owl` absent upstream, `AIF_skosOther` vide) are untouched — they remain accurate.

## Gates

- **byte-stable** baseline OK (notebook has no trailing newline; format matched exactly)
- **code_sha unchanged** (markdown-only edit, 11 code cells untouched)
- **diff** : 1 ins / 1 del — `cell[25] source[17]` sub-string only
- **content-loss** findings = 0 (md cells 15→15, normalized_chars 13387→13446)
- **rendering** 0 violations (`detect_markdown_rendering.py --base origin/main`)
- **H.3** : null execution_count = 0, errors = 0 ; cell[25] is **markdown** (C.2 exception — markdown-only edit, previous outputs valid, no re-exec required)

## Collision note

#9007 (my own, merged) fixed a **different** defect in this same notebook (recap claimed "22 cells" → corrected to "1081"). This "1,5 %" limitation is a **legitimate second defect** — missed by #9007. **Not a twin** → no yaml rebaseline.

See #8052. See #9007 (sibling fix, same notebook).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
