### PR TITLE
fix(ml,#8052): TP Exercise 4 names XPlot.Plotly but notebook only loads ScottPlot

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/TP-prevision-ventes.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/TP-prevision-ventes.ipynb
@@ -1117,9 +1117,9 @@
    "source": [
     "### Exercice 4 : Visualisation des prédictions\n",
     "\n",
-    "Après avoir effectue des prédictions sur les données de test, tracez un graphique scatter des ventes réelles vs prédites avec XPlot.Plotly et calculez le MAPE (Mean Absolute Percentage Error).\n",
+    "Après avoir effectue des prédictions sur les données de test, tracez un graphique scatter des ventes réelles vs prédites avec ScottPlot et calculez le MAPE (Mean Absolute Percentage Error).\n",
     "\n",
-    "**Indice** : Le MAPE = moyenne(|réel - prédit| / |réel|) * 100. Utilisez XPlot.Plotly pour un scatter plot avec une ligne diagonale de référence (x = y) representant les prédictions parfaites."
+    "**Indice** : Le MAPE = moyenne(|réel - prédit| / |réel|) * 100. Utilisez ScottPlot pour un scatter plot avec une ligne diagonale de référence (x = y) representant les prédictions parfaites."
    ]
   },
   {
@@ -1158,7 +1158,7 @@
     "// Etape 1 : utiliser les predictions du modele (testPredictions de la Partie 2)\n",
     "// Etape 2 : extraire les valeurs reelles et predites en tableaux\n",
     "// Etape 3 : calculer le MAPE (Mean Absolute Percentage Error)\n",
-    "// Etape 4 : creer un scatter plot avec XPlot.Plotly (reel en X, predit en Y) + ligne diagonale\n",
+    "// Etape 4 : creer un scatter plot avec ScottPlot (reel en X, predit en Y) + ligne diagonale\n",
     "\n",
     "var mape = 0.0; // TODO etudiant : remplacer par le calcul du MAPE\n",
     "Console.WriteLine(\"Exercice a completer : visualisation des predictions et calcul du MAPE\");"


### PR DESCRIPTION
Grain: MED/identity — lane myia-po-2024:CoursIA-2 — prev: MED/structural family-fix #9121 ML-Py nav (same #8052 audit, same ML.Net family, distinct defect class: library-name IDENTITY vs nav STRUCTURAL).

## What

Fixes an **IDENTITY** defect in `TP-prevision-ventes.ipynb` Exercise 4 (cells 19-20): the exercise instructs students to plot with **XPlot.Plotly**, but the notebook **never loads XPlot.Plotly** — it uses **ScottPlot** throughout. Markdown + 1 code comment, no re-execution. Found via the #8052 audit ML.Net slice (Explore sweep finding T4, re-verified firsthand).

## Ground truth (firsthand verified, L786-2)

- **cell 1** loads ONLY `#r "nuget: ScottPlot, 5.0.55"` (no XPlot.Plotly nuget);
- **cell 0 objective 5** itself says "Visualiser les prédictions avec **ScottPlot**" (canonical);
- **cells 4/9** build `new ScottPlot.Plot()`.

So XPlot.Plotly is a stale/wrong library name for a notebook that uses ScottPlot end-to-end.

## Defect (IDENTITY c.1062-L strong class)

Family-wide index (c.943-L2) — 3 sites, all `XPlot.Plotly` → `ScottPlot`:

| cell | element | wrong → correct |
|------|---------|-----------------|
| 19 | [2] (markdown exercise) | `tracez ... avec XPlot.Plotly` → `avec ScottPlot` |
| 19 | [4] (markdown Indice) | `Utilisez XPlot.Plotly pour un scatter plot` → `Utilisez ScottPlot` |
| 20 | [6] (code COMMENT) | `// Etape 4 : creer un scatter plot avec XPlot.Plotly` → `ScottPlot` |

The cell[20] change is a **comment only** → cell execution/output unaffected (output is a print statement). Same safe pattern as the CSP-2 code-comment fix in PR #9084. No re-execution needed.

## Verification (firsthand, #8052 lens)

- cell 1 nuget = ScottPlot only (no XPlot); cell 0 objective 5 = ScottPlot;
- the 3 XPlot anchors shape-confirmed pre-edit; **0 residual "XPlot"** anywhere in the notebook post-edit (c.943-L2 family index);
- cell[20] output (`Exercice a completer : visualisation des predictions et calcul du MAPE`) preserved verbatim;
- Canonical JSON round-trip byte-identical pre/post (**trailing-adaptive** c.1086-L). diff = 3 real changes (8 unified-diff lines incl 1 unchanged separator re-shown in-hunk — difflib artifact, not extra edits), no code/output change. `assert len(diff) < 40` passed.

**TP-prevision-ventes is NOT twinned** (`git grep` of the notebook path in `twin_pairs.d/` = empty, c.1095-L: verified via grep not filename guess) → no SHA rebaseline required.

## Scope

1 file content. No source changes beyond the 3 library-name corrections.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
