### PR TITLE
fix(gametheory,#8052): GT-9 c23 says "tableau ci-dessus" but the table is below (ci-dessous)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction.ipynb
@@ -1344,7 +1344,7 @@
    "source": [
     "### 5.2 Interpretation : L'irrationalite peut etre \"rationnelle\"\n",
     "\n",
-    "Le tableau ci-dessus revele un résultat contre-intuitif mais profond :\n",
+    "Le tableau ci-dessous revele un résultat contre-intuitif mais profond :\n",
     "\n",
     "| p_rational | Gains totaux | Interpretation |\n",
     "|------------|--------------|----------------|\n",

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-9-backwardinduction.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-9-backwardinduction.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-31"
+    date: "2026-08-01"
     by: myia-po-2024:CoursIA-2
-    python_sha: 72661e4815611c05d9c88606ac8593e1ae46c4e9
+    python_sha: b8a8ccc15f082db239c2899eb07c871146de5ade
     csharp_sha: 0d8a290aead6260078144abe41c5987fc5c2893a
   known_differences:
     - "Socle pedagogique commun : l'algorithme d'induction en arriere (backward induction) pour resoudre les jeux sequentiels et calculer les equilibres de sous-jeu parfait (SPE, Selten 1965), applique aux paradoxes canoniques : jeu du mille-pattes (Centipede Game), guerre d'usure (War of Attrition), paradoxe de la chaine de magasins (Chain-Store paradox, Selten 1978). Distinct du GT-7 ExtensiveForm (qui pose la formalisme extensive-form + reduction extensive-vers-normale) : le GT-9 centre l'algorithme d'induction arriere et les paradoxes qu'il fait surgir."


### PR DESCRIPTION
Grain: LIGHT/structural (reference-direction) — lane myia-po-2024:CoursIA-2 — prev: MED/identity #9123 TP Exercise 4 (same #8052 audit, same GameTheory family, distinct defect class: STRUCTURAL reference-direction vs IDENTITY library-name).

lane: myia-po-2024:CoursIA-2

## What

Fixes a **STRUCTURAL reference-direction** defect in `GameTheory-9-BackwardInduction.ipynb` cell[23]: the markdown says **"Le tableau ci-dessus revele"** (the table *above* reveals), but the p_rational summary table it refers to is **directly BELOW** the sentence in the same cell (source elems 4-8). The sentence precedes its table (introduce-then-show, a natural French structure) — only the direction word is wrong. Fix: `ci-dessus` → `ci-dessous`. Markdown-only, 1 word, no re-execution. Found via the #8052 GameTheory residual re-investigation (DEFER'd grain from c.1086, re-verified firsthand this cycle).

## Ground truth (firsthand verified, L786-2)

- cell[23] elem[2] = `"Le tableau ci-dessus revele un résultat contre-intuitif mais profond :\n"`;
- the p_rational table is elems 4-8, i.e. **below** elem[2] in the same cell;
- no `p_rational`/`Gains` table exists in any cell *above* cell[23] (cells 21-22 = chain-store scenario + code) → "ci-dessus" has no valid referent above.

**#8052 VALUE cross-check (done firsthand, NOT assumed):** the hardcoded c23 table (`1 / ~4 / 12`) **MATCHES** the cell[25] COMPUTED simulation output (`1.00 / 3.95 / 12.00`) → **no value defect**. The table values are preserved verbatim; only the reference direction was wrong.

## Defect (STRUCTURAL c.1062-L; reference-direction)

cell[23] elem[2]: `Le tableau ci-dessus revele` → `Le tableau ci-dessous revele`. 1 element, markdown-only.

**Atomic scope — what is NOT in this PR:** the cell[23] header `### 5.2 Interpretation` (which appears *before* the `## 5.` header in cell[24] and collides with cell[24]'s `### 5.2 Alternatives`) is a **separate** structural/numbering reorder = judgment-call → **DEFERRED** (1 PR = 1 subject; not bundled). This PR is purely the unambiguous reference-direction fix.

## Twin

GT-9 IS twinned (`gametheory-9-backwardinduction.yaml`, semantic). The yaml's own `known_differences` document the structural asymmetry: *"C# 26 cellules, 10 sections ... Python 35 cellules, 7 sections + 4 exercices"* — the **C# twin genuinely LACKS** the cell[23] Interpretation content (verified firsthand: the C# twin's only "ci-dessus" = cell[20] *"voir indice ci-dessus"* = a valid, different usage referring to an exercise hint above it). **C# CLEAN** → Python-only fix + `python_sha` rebaseline (`72661e48` → `b8a8ccc1`; `csharp_sha` preserved; date 2026-08-01). `check_twin_parity --check` **[OK]** GT-9 post-commit.

## Verification (firsthand, #8052 lens)

- c23 elem[2] anchor shape-confirmed pre-edit; post-edit `"Le tableau ci-dessous revele"` present, **0 residual `"ci-dessus revele"`**;
- table values (`1 / ~4 / 12`) preserved; cross-checked vs c25 computed output (`1.00/3.95/12.00`) — no value drift;
- Canonical JSON round-trip byte-identical pre/post (**trailing-adaptive** c.1086-L). diff = 1 real change (2 unified-diff lines incl 1 unchanged separator re-shown in-hunk — difflib artifact, not extra edits); `assert len(diff) < 40` passed.

## Scope

2 files (nb 1ins/1del + yaml 2ins/2del). No source change beyond the 1-word reference correction.

See #8052 (semantic-sampling audit, GameTheory slice — GT-9 residual re-investigated firsthand; VALUE angle ruled out, structural reference-direction shipped).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
