### PR TITLE
fix(search,#8052): App-3/App-11-Python prereq "Search-8 (CSP Advanced)" -> CSP-3 (Advanced)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb
@@ -62,7 +62,7 @@
     "5. **Generer** des puzzles Picross a partir d'images pixelisees\n",
     "\n",
     "### Prerequis\n",
-    "- Search-8 (CSP Advanced) : contraintes globales, OR-Tools CP-SAT\n",
+    "- CSP-3 (Advanced) : contraintes globales, OR-Tools CP-SAT\n",
     "- Python : itertools, numpy, matplotlib\n",
     "\n",
     "### Duree estimee : 40 minutes"

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb
@@ -67,7 +67,7 @@
     "\n",
     "### Prerequis\n",
     "- Python 3.10+\n",
-    "- Search-8 (CSP Advanced) : programmation par contraintes avec OR-Tools\n",
+    "- CSP-3 (Advanced) : programmation par contraintes avec OR-Tools\n",
     "- Notions de base sur les problemes d'optimisation combinatoire\n",
     "\n",
     "### Duree estimee : 60 minutes\n",

--- a/scripts/notebook_tools/twin_pairs.d/app-11-picross.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-11-picross.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-11b-Picross-CSharp.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-25'
+    date: '2026-08-01'
     by: po-2026
-    python_sha: c74eb8bc47ad9556f85778d653086915b18480ce
+    python_sha: aa67371119c2d29ebd2bc269fad184bb723a56c5
     csharp_sha: 973726eeb2c0cdb97ddf65a47013f42f1fbadd55
   known_differences:
     - "Socle pedagogique commun : Picross / Nonogram (CSP : contraintes lignes/colonnes, OR-Tools) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."

--- a/scripts/notebook_tools/twin_pairs.d/app-3-nursescheduling.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-3-nursescheduling.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-3b-NurseScheduling-CSharp.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-25'
+    date: '2026-08-01'
     by: po-2026
-    python_sha: 4fdd12c2d22df5dd64e280b12af5b4709d586b5a
+    python_sha: 46db7b7f58336a9d3e7c2875a766381071982542
     csharp_sha: 52f7b50aa5d1f9553673ecce518df546dd4c1f93
   known_differences:
     - "Socle pedagogique commun : Planning d'infirmieres (CSP : contraintes horaires, preferences, couverture) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."


### PR DESCRIPTION
Grain: MED/identity (family-fix) — lane myia-po-2024:CoursIA-2 — prev: MED/identity #9128 App-1b/2b/11b-CSharp Search-9→CSP-1 (same #8052 audit, same Search/App family, same defect class, distinct notebooks: these are the Python prereq aliases Search-8 vs those C# link labels Search-9).

lane: myia-po-2024:CoursIA-2

## What

IDENTITY family-fix (c.943-L2) in 2 Search Applications CSP **Python** notebooks. The prerequisite line names `Search-8 (CSP Advanced)`, but `Search-8` is `Search-8-DancingLinks` (Dancing Links algorithm) — a different topic entirely. The gloss "(CSP Advanced)" describes `CSP-3-Advanced`, the real advanced-CSP notebook. Internal consistency confirms the direction: sibling **App-4-JobShopScheduling cell[0]** correctly cites `[CSP-3 : Advanced](../../Part2-CSP/CSP-3-Advanced.ipynb) (contraintes globales, OR-Tools)` for exactly this content. Same defect family as the Search-6/7→CSP-1/2 (#9084/#9081/#9115/#9117) and Search-9→CSP-1 (#9128) identity fixes shipped earlier — a stale "Search-N" alias for a CSP notebook. Found via the #8052 family-wide Explore sweep; both occurrences re-verified firsthand (L786-2).

## Defect (IDENTITY, markdown-only, plain-text relabel)

The prereq list is plain-text (`- NAME (GLOSS) : desc`, no links) — matching the surrounding format. Surgical fix `Search-8 (CSP Advanced)` → `CSP-3 (Advanced)`:
- `App-3-NurseScheduling.ipynb` cell[1] elem[15]: `- Search-8 (CSP Advanced) : programmation par contraintes avec OR-Tools`
- `App-11-Picross.ipynb` cell[1] elem[20]: `- Search-8 (CSP Advanced) : contraintes globales, OR-Tools CP-SAT`

The name moves to the correct notebook (CSP-3); the gloss simplifies "(CSP Advanced)" → "(Advanced)" (CSP context now in the name), matching App-4's canonical "CSP-3 : Advanced". Markdown-only, no re-execution.

## Twin

Both are Python notebooks (attested: app-3-nursescheduling.yaml, app-11-picross.yaml, semantic). The C# twins (App-3b-NurseScheduling-CSharp, App-11b-Picross-CSharp) verified CLEAN firsthand (0 `Search-8` occurrences) → Python-only fix → python_sha rebaselined (csharp_sha preserved):
- App-3: 4fdd12c2 → 46db7b7f
- App-11: c74eb8bc → aa673711

Twin-parity verified directly against the commit (yaml python_sha == committed Python blob sha) for both.

**Merge with open PR #9128** (c.1103, rebaselined the C# twin's csharp_sha in app-11-picross.yaml): this PR changes python_sha (different line) + date. Both PRs set date to `'2026-08-01'` (single-quoted, identical) → clean 3-way merge (distinct sha lines, agreeing date line).

## Verification (firsthand, #8052 lens)

- ground truth: `git ls-tree` confirms Search-8 = `Search-8-DancingLinks`, CSP-3 = `CSP-3-Advanced`; canonical citation form = App-4 cell[0];
- each anchor shape-confirmed pre-edit (exact cell/elem); post-edit 0 residual `Search-8 (CSP Advanced)`, `CSP-3 (Advanced)` present;
- Canonical JSON round-trip byte-identical pre/post per notebook (auto-detect_form per c.1103-L: both App-3/App-11 = indent 1 + ensure_ascii=False + trailing newline). diffs: 2 lines each; `assert len(diff) < 40` passed;
- yaml surgical byte-replace (python_sha + date), LF preserved, csharp_sha preserved.

## Scope

4 files (2 Python nbs, 2 relabels + 2 twin yamls, python_sha rebaseline). No source change beyond the plain-text name relabel.

See #8052 (semantic-sampling audit, Search/Applications slice — Explore-agent family sweep finding, both occurrences re-verified firsthand L786-2).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
