### PR TITLE
fix(search,#8052): App-14-ConnectFour-Adversarial exercise hint cross-refs "section 3" but run_benchmark_depth is in section 6

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb
@@ -2264,7 +2264,7 @@
     "\n\n",
     "**objectif** : comparer Alpha-Beta aux profondeurs 4, 6 et 8, et déterminer la profondeur optimale pour un budget de 1 seconde. C'est le levier classique du compromis temps/profondeur en recherche adverse.\n\n",
     "\n\n",
-    "**Indices** : `run_benchmark_depth()` (section 3) comme base ; mesurer temps + nombre de noeuds ; faire jouer les algorithmes entre eux pour juger la qualite des coups, pas seulement la vitesse."
+    "**Indices** : `run_benchmark_depth()` (section 6) comme base ; mesurer temps + nombre de noeuds ; faire jouer les algorithmes entre eux pour juger la qualite des coups, pas seulement la vitesse."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/app-14-connectfour-adversarial.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-14-connectfour-adversarial.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial-CSharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-31"
+    date: "2026-08-01"
     by: myia-po-2024:CoursIA-2
-    python_sha: 63f23b87a3e1bc62f89faf34745d206caf1befdb
+    python_sha: 49ee6ce53f51c17c64db939771844e036310e778
     csharp_sha: 2ec088ff8d391f7e8bc39e967730ca6c7c821b01
   known_differences:
     - "Socle pedagogique commun : Puissance 4 adversarial (variant Connect-4, IA jeux combinatoires) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."


### PR DESCRIPTION
Grain: LIGHT/structural (section cross-ref) — lane myia-po-2024:CoursIA-2 — prev: MED/identity #9129 App-3/App-11 Search-8→CSP-3 (same #8052 audit, same Search/App family, distinct defect class: STRUCTURAL section-xref vs IDENTITY prereq alias).

lane: myia-po-2024:CoursIA-2

## What

STRUCTURAL cross-reference defect in `App-14-ConnectFour-Adversarial.ipynb` cell[37] (Exercice 1 hints). The markdown says `` `run_benchmark_depth()` (section 3) comme base ``, but `run_benchmark_depth` is **defined in code cell[21]**, which falls under `## 6. Benchmark Comparatif` (cell[20]). Section 3 is `## 3. Algorithme Minimax` (cell[8]) and contains no such function.

Section map (ground truth, verified firsthand):
- `## 3. Algorithme Minimax` (cell 8) — no `run_benchmark_depth`
- `## 6. Benchmark Comparatif` (cell 20) — `def run_benchmark_depth` (cell 21) is here

Fix: `section 3` → `section 6`. Markdown-only, 1 element. Found via the #8052 family-wide Explore sweep; re-verified firsthand (L786-2).

## Defect (STRUCTURAL, markdown-only)

cell[37] elem[4]: `` `run_benchmark_depth()` (section 3) `` → `` (section 6) ``. "section 3" is unique in the notebook's markdown; post-edit 0 residual.

## Twin

App-14 is the Python notebook (attested: app-14-connectfour-adversarial.yaml, semantic). The C# twin (App-14-ConnectFour-Adversarial-CSharp.ipynb) verified CLEAN firsthand (no such `run_benchmark_depth`/section reference) → Python-only fix → python_sha rebaselined (`63f23b87` → `49ee6ce5`; csharp_sha preserved). Twin-parity verified directly against the committed blob (== sha).

## Verification (firsthand, #8052 lens)

- ground truth: `def run_benchmark_depth` in code cell[21] under `## 6. Benchmark Comparatif` (cell[20]); section 3 = `## 3. Algorithme Minimax` (cell[8]);
- cell[37] elem[4] anchor confirmed pre-edit; "section 3" unique in markdown; post-edit `section 6` present, 0 residual `section 3`;
- Canonical JSON round-trip byte-identical pre/post (byte-stable: indent=1, ensure_ascii=False, trailing newline). diff = 1 real change (2 unified-diff lines); `assert len(diff) < 40` passed;
- yaml surgical byte-replace (python_sha + date), LF preserved, csharp_sha preserved.

## Scope

2 files (1 Python notebook, 1 section-xref correction + 1 twin yaml, python_sha rebaseline). No source change beyond the section-number correction.

See #8052 (semantic-sampling audit, Search/Applications slice — Explore-agent family sweep finding, re-verified firsthand L786-2).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
