### PR TITLE
fix(search,#8052): Search-16-QuikGraph c10 BFS path cost 4+6=10 -> 2+4+6=12 (drops A->B edge)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-16-QuikGraph.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-16-QuikGraph.ipynb
@@ -595,7 +595,7 @@
     "\n",
     "\n",
     "\n",
-    "Sur le reseau routier `A..F` avec distances en km, BFS donnerait `A -> B -> D -> F` (3 sauts, 4+6=10 km) ou `A -> B -> D -> E -> F` (4 sauts, 2+4+1+2.5=9.5 km), mais le **vrai plus court chemin en km** est différent.\n",
+    "Sur le reseau routier `A..F` avec distances en km, BFS donnerait `A -> B -> D -> F` (3 sauts, 2+4+6=12 km) ou `A -> B -> D -> E -> F` (4 sauts, 2+4+1+2.5=9.5 km), mais le **vrai plus court chemin en km** est différent.\n",
     "\n",
     "\n",
     "\n",


### PR DESCRIPTION
Grain: MED/value (arithmetic, markdown-only) — lane myia-po-2024:CoursIA-2 — prev: #9133 App-5 (identity, Search/App family). This PR pivots to a **fresh family** (Search Part1-Foundations main series) and a **different defect class** (VALUE arithmetic vs the identity fixes of c.1103-1106).

lane: myia-po-2024:CoursIA-2

## What

VALUE defect in `Search-16-QuikGraph.ipynb` cell[10]. The markdown contrasts a BFS (hop-minimizing) path against the true shortest (Dijkstra) path on the notebook's own road graph `A..F`:

```
BFS donnerait `A -> B -> D -> F` (3 sauts, 4+6=10 km) ou
`A -> B -> D -> E -> F` (4 sauts, 2+4+1+2.5=9.5 km) ...
```

The first path `A -> B -> D -> F` is a **3-hop path (3 edges)**, but the stated sum "4+6=10" only adds **2 of the 3 edge weights** — it silently drops the A→B edge. From the notebook's OWN edge definitions (code cell[6]):

```
AjouterRue(A,B,2.0); AjouterRue(B,D,4.0); AjouterRue(D,F,6.0)
```

the path A→B→D→F = **2+4+6 = 12 km**, not 10. The second path (9.5) is correct and untouched. The committed Dijkstra output (cell[11]) confirms F = 9.00 km via E, so A→B→D→F (12) is indeed not the shortest — consistent with the markdown's point.

Found via the #8052 Explore-agent sweep of the Search Part1-Foundations main series; re-verified firsthand (L786-2) against the notebook's own edges + Dijkstra output.

## Defect (VALUE, markdown-only, 1 site)

cell[10] elem[4]: `4+6=10 km` → `2+4+6=12 km`. Markdown-only, no re-exec.

## Twin

Search-16-QuikGraph has **NO entry** in `scripts/notebook_tools/twin_pairs.d/` (not a registered twin — single C# notebook, no Python counterpart) → no rebaseline. 1 file.

## Verification (firsthand, #8052 lens)

- ground truth: edges from c[6] (A→B=2, B→D=4, D→F=6); path A→B→D→F = 12; Dijkstra c[11] F=9.00 via E (second path 9.5 confirmed correct);
- "4+6=10" unique in notebook markdown (c[10] elem[4]); post-edit 0 residual, "2+4+6=12" present, second path "2+4+1+2.5=9.5" preserved, path label `A -> B -> D -> F` preserved;
- Canonical JSON round-trip byte-identical pre/post (indent=1, ensure_ascii=False, trailing newline). diff = 1 real change (2 unified-diff lines); `assert len(diff) < 40` passed.

## Scope

1 file (1 markdown VALUE correction). No source change beyond the arithmetic fix.

See #8052 (semantic-sampling audit, Search Part1-Foundations main-series slice — Explore-agent sweep finding, re-verified firsthand L786-2).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
