### PR TITLE
fix(search,#8052): Search-11-Metaheuristics-CSharp relabel fabricated "Search-5-LocalSearch" link label -> Search-4-LocalSearch

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "**Duree estimee** : ~1h30\n",
     "\n",
-    "**Prerequis** : [Search-5-LocalSearch](Search-4-LocalSearch.ipynb) (recuit simule, hill-climbing), notions d'algebre lineaire et de C# / .NET.\n",
+    "**Prerequis** : [Search-4-LocalSearch](Search-4-LocalSearch.ipynb) (recuit simule, hill-climbing), notions d'algebre lineaire et de C# / .NET.\n",
     "\n",
     "**Pourquoi un jumeau C# ?** Le notebook Python original s'appuie sur la librairie **`mealpy`** (PSO, ABC, SA, BRO, GWO, WOA, GA, DE) et `numpy`/`matplotlib` pour comparer des métaheuristiques sur des fonctions de benchmark. Ce jumeau reimplemente les **algorithmes majeurs depuis zero** en **C# .NET 9 (BCL seule, 0 NuGet)** : essaim particulaire (PSO), recuit simule (SA), algorithme génétique (GA). Les fonctions de benchmark (Sphere, Rastrigin, Rosenbrock, Ackley) sont codees explicitement, ainsi que la convergence, l'analyse de paramètres et un exemple d'optimisation de profit. Les graphiques `matplotlib` sont remplacés par des tables et traces ASCII. Les deux notebooks derivent les mêmes optima (f=0 sur les benchmarks, profit max sur l'exemple entreprise).\n"
    ]
@@ -1692,7 +1692,7 @@
     "### Prochaines étapes\n",
     "\n",
     "- [Search-3-Informed (A*)](Search-3-Informed-Csharp.ipynb) : recherche informe avec heuristiques (cas ou l'optimalite est garantie, contrairement aux métaheuristiques).\n",
-    "- [Search-5-LocalSearch](Search-4-LocalSearch.ipynb) : fondements du recuit simule et hill-climbing.\n",
+    "- [Search-4-LocalSearch](Search-4-LocalSearch.ipynb) : fondements du recuit simule et hill-climbing.\n",
     "- Applications métaheuristiques : [App-13-TSP](../Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb), [App-9-EdgeDetection](../Applications/Hybrid/App-9-EdgeDetection.ipynb).\n",
     "\n",
     "---\n",

--- a/scripts/notebook_tools/twin_pairs.d/search-11-metaheuristics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-11-metaheuristics.yaml
@@ -4,10 +4,10 @@
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-27"
+    date: "2026-08-01"
     by: po-2024
     python_sha: 9b8a7c5a644278888f991ab10ac8e87bd7ec6238
-    csharp_sha: 9de0aa08582035e96886cbada255c5ce9a7ceb3c
+    csharp_sha: b41a4e251e8bd06d6d2a51f14f5bbf96b48684f1
   known_differences:
     - "Socle commun : metaheuristiques d'optimisation (PSO Particle Swarm, SA Simulated Annealing), fonctions de benchmark, benchmark comparatif, analyse de parametres, exemple guide."
     - "Bibliotheque vs from-scratch : Python invoque MEALPy (librairie metaheuristique, 40+ algorithmes) pour PSO/ABC/SA/BRO ; C# implemente PSO/SA/GA from-scratch (System.Random, pas de NuGet metaheuristique)."


### PR DESCRIPTION
Grain: MED/identity (visible-label relabel) — lane myia-po-2024:CoursIA-2 — prev: #9135 Search-16-QuikGraph (value, Search Part1 main series). Same family as c.1107 (#8052 Search Part1 sweep), different defect class (IDENTITY vs VALUE) + different notebook.

lane: myia-po-2024:CoursIA-2

## What

IDENTITY defect in `Search-11-Metaheuristics-Csharp.ipynb`. The visible link LABEL `[Search-5-LocalSearch]` is a **fabricated name** — no notebook `Search-5-LocalSearch` exists (`Search-5` = `Search-5-GeneticAlgorithms`). The link TARGET `Search-4-LocalSearch.ipynb` is real and DOES cover the cited content: "recuit simule, hill-climbing" (Search-4-LocalSearch title = "Recherche Locale et métaheuristiques", covers Simulated Annealing + Hill-Climbing). Same family as the fabricated-label identity fix App-5 CSP-1-NQueens-CSharp (#9133): **label wrong, target correct**.

Fix: relabel visible text `[Search-5-LocalSearch]` → `[Search-4-LocalSearch]` (target UNCHANGED, c.1103 doctrine: target = ground truth). 2 occurrences (cell[0] Prerequis + cell[30] "Prochaines étapes"). Markdown-only, no re-exec.

Found via the #8052 Explore-agent sweep of the Search Part1-Foundations main series; re-verified firsthand (L786-2).

## Defect (IDENTITY, markdown-only, 2 sites / 1 C# notebook)

- cell[0]: `Prerequis : [Search-5-LocalSearch](Search-4-LocalSearch.ipynb) (recuit simule, hill-climbing)` → `[Search-4-LocalSearch]`
- cell[30]: `- [Search-5-LocalSearch](Search-4-LocalSearch.ipynb) : fondements du recuit simule et hill-climbing.` → `[Search-4-LocalSearch]`

## Twin

Search-11 is the C# twin (attested: search-11-metaheuristics.yaml, semantic). The Python twin Search-11-Metaheuristics verified CLEAN firsthand (0 fabricated "Search-5-LocalSearch", 4 correct "Search-4-LocalSearch") → C#-only fix → csharp_sha rebaselined (`9de0aa08` → `b41a4e25`; python_sha `9b8a7c5a` preserved). Twin-parity verified directly against the committed blob (== sha, both C# and Python).

## Verification (firsthand, #8052 lens)

- ground truth: no file `Search-5-LocalSearch` exists (Search-5=GeneticAlgorithms); target `Search-4-LocalSearch.ipynb` exists, title "Recherche Locale et métaheuristiques", covers SA/Hill-Climbing;
- cell[0]/[30] anchors confirmed pre-edit; post-edit 0 residual `Search-5-LocalSearch`, 0 residual `Search-5` of any form, `[Search-4-LocalSearch]` label ×2, targets `(Search-4-LocalSearch.ipynb)` ×2 preserved;
- Canonical JSON round-trip byte-identical pre/post (indent=1, ensure_ascii=False, NO trailing newline). diff = 2 real changes (4 unified-diff lines); `assert len(diff) < 40` passed;
- yaml surgical byte-replace (csharp_sha + date), LF preserved, python_sha + by preserved.

## Scope

2 files (1 C# notebook, 2 label relabels + 1 twin yaml, csharp_sha rebaseline). No source change beyond the visible-label relabel.

See #8052 (semantic-sampling audit, Search Part1-Foundations main-series slice — Explore-agent sweep finding, re-verified firsthand L786-2).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
