### PR TITLE
fix(search,#8052): Search-1-StateSpace-C# c27 "via le sud" distance ~1775 km -> 1475 km (contradicts committed c26 output)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace-Csharp.ipynb
@@ -2350,7 +2350,7 @@
    "source": [
     "### Interpretation : Nombre d'étapes vs cout\n",
     "\n",
-    "**Sortie obtenue** : deux itineraires de longueur différente (2 sauts vs 5 sauts) compares en distance reelle. Le chemin via Paris l'emporte clairement en distance (1075 km vs ~1775 km via le sud).\n",
+    "**Sortie obtenue** : deux itineraires de longueur différente (2 sauts vs 5 sauts) compares en distance reelle. Le chemin via Paris l'emporte clairement en distance (1075 km vs 1475 km via le sud).\n",
     "\n",
     "**Lecon de portee** :\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/search-1-statespace.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-1-statespace.yaml
@@ -4,10 +4,10 @@
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
+    date: "2026-08-01"
     by: myia-po-2023:CoursIA-2
     python_sha: eec0668ba49d9b95a067fafc1674a83edccdb055
-    csharp_sha: bd37f3c7d0f3cffd8a4f5a2d495798de7bb50b85
+    csharp_sha: 1b1fc49cdd3b82a9d6af5c15829256ab5a183c17
   known_differences:
     - "Socle pedagogique commun : modelisation d'un espace d'etats (noeuds, aretes, etat initial, etat but, successeurs). Exemples : grille 8-puzzle, monde du aspirateur, labyrinthe."
     - "Idiomes framework distincts : Python = dataclasses + frozenset pour etats hashables + `import typing`. C# = `using System.Collections.Generic;` (HashSet<T> pour etats visites, Dictionary<TState, IEnumerable<TState>> pour successeurs, struct/record pour etat)."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

VALUE defect in `Search-1-StateSpace-Csharp.ipynb` cell[27]. The markdown states:

    Le chemin via Paris l'emporte clairement en distance (1075 km vs ~1775 km via le sud).

but the notebook's OWN committed output (code cell[26]) prints the two itineraries:

    Itineraire 1 : via Paris  -> Distance totale : 1075 km
    Itineraire 2 : via le sud  -> Distance totale : 1475 km   (250+250+170+315+490)
    Difference : 400 km

1775 is wrong; the via-sud distance is **1475 km** (1075 + 400 = 1475, consistent). The via-Paris value (1075) is already correct in the markdown. Same defect class as the committed-output-vs-hand-claim value fixes (#9091 GT-9, #9099 rl_10). This is the **strongest** #8052 defect class per c.1062-L (VALUE/structural beat timing).

Fix: `~1775 km via le sud` → `1475 km via le sud` (match the committed output exactly). Markdown-only, no re-exec.

Found via the #8052 Explore-agent sweep of the Search Part1-Foundations main series; re-verified firsthand (L786-2) against the notebook's own c26 output.

## Defect (VALUE, markdown-only, 1 site / 1 C# notebook)

- cell[27] elem[2]: `Le chemin via Paris l'emporte clairement en distance (1075 km vs ~1775 km via le sud).` → `~1775 km via le sud` → `1475 km via le sud`

## Twin

Search-1 is the C# twin (attested: search-1-statespace.yaml, semantic). The Python twin `Search-1-StateSpace.ipynb` correctly states its OWN distance (**1465 km** — a slightly different graph: Toulouse→Montpellier 240 not 250), and is CLEAN of the 1775 drift → C#-only fix → `csharp_sha` rebaselined (`bd37f3c7` → `1b1fc49c`; `python_sha` `eec0668b` preserved). Twin-parity verified directly against the committed blob (== sha, both C# and Python).

## Verification (firsthand, #8052 lens)

- ground truth: c26 committed output prints `1075 km` (Paris) / `1475 km` (sud) / `Difference : 400 km` (250+250+170+315+490 = 1475);
- c[27] elem[2] anchor confirmed pre-edit; post-edit 0 residual `1775`, `1075 km vs 1475 km via le sud` present;
- Canonical JSON round-trip byte-identical pre/post (indent=1, ensure_ascii=False, WITH trailing newline). diff = 1 real change (2 unified-diff lines); `assert len(diff) < 40` passed;
- yaml surgical byte-replace (csharp_sha + date), LF preserved, python_sha + by preserved.

## Scope

2 files (1 C# notebook, 1 distance VALUE correction + 1 twin yaml, csharp_sha rebaseline). No source change beyond the value correction.

See #8052 (semantic-sampling audit, Search Part1-Foundations main-series slice — Explore-agent sweep finding, re-verified firsthand L786-2).

## Diagnostic dérive (§D.5)

- **Cause (b) — claim antérieure fabriquée.** c27 prose stated « ~1775 km via le sud », contradicting c26's committed deterministic output « Distance totale : 1475 km » (250+250+170+315+490 = 1475; « Difference : 400 km » = 1475−1075). The route distances are hardcoded graph edges (deterministic, not stochastic) — 1475 reproduces on every run. The ~1775 was an anterior wrong claim (miscalculation, or stale residue from an earlier graph version) that never matched this graph's own committed output.
- **Verdict: CAUSE_FIXED.** The fix realigns the prose to the deterministic committed output (1475). Because the value is a graph-distance sum (not a noisy perf measurement), §D.5 pt3 does not apply — no fresh re-execution is needed and no perf decimal remains to drift; any re-exec of c26 prints exactly 1475. The wrong claim does not survive the PR (removed, not documented) → **no child issue owed**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

