### PR TITLE
fix(search,#8052): Search-12-PatternDatabases c9 forward-ref "(section 7)" -> section 6 (PDB additive lives in SOTA, not IDA*)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-12-PatternDatabases-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-12-PatternDatabases-Csharp.ipynb
@@ -378,7 +378,7 @@
     "\n",
     "On construit d'abord une PDB sur **un** motif de tuiles. BFS = coût unitaire =\n",
     "distances optimales depuis le but abstrait. Cette PDB unique couvre un sous-ensemble\n",
-    "de tuiles ; elle servira de brique, puis la **PDB additive** (section 7) en combinera\n",
+    "de tuiles ; elle servira de brique, puis la **PDB additive** (section 6) en combinera\n",
     "plusieurs pour couvrir les 15 tuiles."
    ]
   },

--- a/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-12-PatternDatabases.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-12-PatternDatabases.ipynb
@@ -257,7 +257,7 @@
     "\n",
     "On construit d'abord une PDB sur **un** motif de 4 tuiles. BFS = coût unitaire =\n",
     "distances optimales depuis le but abstrait. Cette PDB unique couvre 4 tuiles ;\n",
-    "elle servira de briques, puis la **PDB additive** (section 7) en combinera\n",
+    "elle servira de briques, puis la **PDB additive** (section 6) en combinera\n",
     "plusieurs pour couvrir les 15 tuiles."
    ],
    "id": "cell-28a5c873"

--- a/scripts/notebook_tools/twin_pairs.d/search-12-pattern-databases.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-12-pattern-databases.yaml
@@ -4,10 +4,10 @@
   csharp: MyIA.AI.Notebooks/Search/Part3-Advanced/Search-12-PatternDatabases-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-25"
+    date: "2026-08-01"
     by: po-2024
-    python_sha: bcdb32319ade2386884f9f0ff96a9b0b7e4281b8
-    csharp_sha: 282a079e88070b58473f64e7e32d91cfcca860c8
+    python_sha: 0b7a8f8777f3e2fdcff5540f0da1647af51f1e7d
+    csharp_sha: 2f13a4af6c57fcef3a4121a9b9ca7dd11aba3bc6
   known_differences:
     - "Socle pedagogique commun : taquin 4x4 (15-puzzle), heuristique Manhattan, puis construction d'une Pattern Database (PDB) pour un sous-ensemble de tuiles afin d'estimer h* plus precisement que Manhattan."
     - "Idiomes framework : Python = `collections.deque` (BFS sur l'espace des patterns) + `numpy`/`matplotlib` (matrices + visualisation du plateau). C# = pur BCL `System.Collections.Generic` + `System.Linq` (`Dictionary`, `Queue`, `Array.IndexOf`), sans dependance externe."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

STRUCTURAL defect in `Search-12-PatternDatabases` (**BOTH Python + C# twins**). cell[9] (section 5 "PDB simple") forward-references the additive PDB:

> ... la **PDB additive** (section 7) en combinera plusieurs pour couvrir les 15 tuiles.

but **section 7 is "IDA\* instrumenté"** (cell[13]) — unrelated. The PDB-additive-**combining** topic is **section 6** "La SOTA : PDB *additives* (Korf & Felner 2002)" (cell[11]):

> partitionner les 15 tuiles en groupes disjoints et construire une PDB par groupe ... On utilise une partition **4-4-4-3** (les groupes couvrent les 15 tuiles).

Section 8 ("Heuristique additive et vérification d'admissibilité") is about **admissibility checking**, not combining. So **section 6 is the definitive target**. This is the strongest #8052 defect class per c.1062-L (STRUCTURAL section-reference, deterministic — not timing/judgment).

Fix: `(section 7)` → `(section 6)` in cell[9] of **both** twins. Markdown-only, no re-exec. Identical defect, identical cell index, identical section numbering in both.

Found via the #8052 Explore-agent sweep of the Search Part3-Advanced main series; re-verified firsthand (L786-2) by reading the section 6/7/8 bodies.

## Defect (STRUCTURAL, markdown-only, 1 site / twin)

- `Search-12-PatternDatabases.ipynb` cell[9]: `elle servira de briques, puis la **PDB additive** (section 7) en combinera plusieurs` → `(section 6)`
- `Search-12-PatternDatabases-Csharp.ipynb` cell[9]: `de tuiles ; elle servira de brique, puis la **PDB additive** (section 7) en combinera plusieurs` → `(section 6)`

## Twin

Search-12 is a semantic twin (attested: `search-12-pattern-databases.yaml`). **BOTH** twins carry the defect → **BOTH** `python_sha` (`bcdb3231` → `0b7a8f87`) AND `csharp_sha` (`282a079e` → `2f13a4af`) rebaselined. `by` field (`po-2024`) preserved. Twin-parity verified directly against the committed blobs (== sha, both twins).

## Verification (firsthand, #8052 lens)

- ground truth: section headers read directly — S6="La SOTA : PDB additives" (combining, partition 4-4-4-3 covers 15 tuiles), S7="IDA\* instrumenté", S8="admissibilité";
- cell[9] `(section 7)` anchor confirmed pre-edit (exactly 1 occurrence per notebook); post-edit 0 residual `(section 7)`, `(section 6)` present in cell[9];
- Canonical JSON round-trip byte-identical pre/post per twin. PY form: indent=1, ensure_ascii=False, trailing=**True**. CS form: indent=1, ensure_ascii=False, trailing=**False** (auto-detect per-nb, c.1103-L). diff = 1 real change (2 unified-diff lines) each; `assert len(diff) < 40` passed;
- yaml surgical byte-replace (python_sha + csharp_sha + date), LF preserved, `by` preserved.

## Scope

3 files (2 notebooks, 1 markdown section-reference each + 1 twin yaml, BOTH shas rebaselined). No source change beyond the section-reference correction.

See #8052 (semantic-sampling audit, Search Part3-Advanced main-series slice — Explore-agent sweep finding, re-verified firsthand L786-2).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
