### PR TITLE
fix(search,#8052): Search-9-LinearProgramming Py c46 relabel fabricated "Search-App-8-SupplyChain" link label -> App-4-JobShopScheduling

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb
@@ -2614,7 +2614,7 @@
     "\n",
     "**Notebooks connexes** :\n",
     "- [App-10-Portfolio](../Applications/Hybrid/App-10-Portfolio.ipynb) - PL pour la finance\n",
-    "- [Search-App-8-SupplyChain](../Applications/CSP/App-4-JobShopScheduling.ipynb) - Chaînes d'approvisionnement\n",
+    "- [App-4-JobShopScheduling](../Applications/CSP/App-4-JobShopScheduling.ipynb) - Chaînes d'approvisionnement\n",
     "- [Sudoku-10-ORTools-Python](../../Sudoku/Sudoku-10-ORTools-Python.ipynb) - PLNE pour CSP\n",
     "\n",
     "**References** :\n",

--- a/scripts/notebook_tools/twin_pairs.d/search-9-linearprogramming.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-9-linearprogramming.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
+    date: "2026-08-01"
     by: myia-po-2023:CoursIA-2
-    python_sha: ae22433e64630b982cd566472591237bc76bb1d5
+    python_sha: d1d4f36599e49147f58195e85a475476d269680c
     csharp_sha: a6d7a7a59ded4ba7732054d17a66c5e40bb80c9f
   known_differences:
     - "Rebaseline c.34 (ai-01) : #8697 a insere le bloc `metadata.cost` (#8056) a l'identique sur les DEUX jumeaux — les deux blob SHA ont bouge, la parite semantique est inchangee. Attestation de parite, pas reparation."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

IDENTITY defect in `Search-9-LinearProgramming.ipynb` cell[46] ("Notebooks connexes"). The visible link LABEL `[Search-App-8-SupplyChain]` is a **fabricated name** — no notebook `Search-App-8-SupplyChain` exists (App-8 = MiniZinc; NO SupplyChain file exists anywhere in Applications). The link TARGET `../Applications/CSP/App-4-JobShopScheduling.ipynb` is real and DOES cover the cited content "Chaînes d'approvisionnement" (supply-chain / job-shop scheduling). Same fabricated-label family as App-5 CSP-1-NQueens-CSharp (#9133), Search-11 Search-5-LocalSearch (#9136): **label wrong, target correct**.

Fix: relabel visible text `[Search-App-8-SupplyChain]` → `[App-4-JobShopScheduling]` (target UNCHANGED, c.1103 doctrine: label = target basename; matches the sibling links `[App-10-Portfolio]` and `[Sudoku-10-ORTools-Python]` in the same cell). Markdown-only, no re-exec.

Found via the #8052 Explore-agent sweep of the Search Part1-Foundations main series; re-verified firsthand (L786-2).

## Defect (IDENTITY, markdown-only, 1 site / 1 Python notebook)

- cell[46] elem[76]: `- [Search-App-8-SupplyChain](../Applications/CSP/App-4-JobShopScheduling.ipynb) - Chaînes d'approvisionnement` → label `[Search-App-8-SupplyChain]` → `[App-4-JobShopScheduling]`

## Twin

Search-9 is a semantic twin (attested: `search-9-linearprogramming.yaml`). The C# twin `Search-9-LinearProgramming-Csharp.ipynb` verified CLEAN firsthand (0 "SupplyChain", 0 "Search-App-8" — its c27 has a separate simplex/StateSpace link, a **different** defect tracked separately) → Py-only fix → `python_sha` rebaselined (`ae22433e` → `d1d4f365`; `csharp_sha` `a6d7a7a5` preserved). Twin-parity verified directly against the committed blob (== sha, both Py and C#).

## Verification (firsthand, #8052 lens)

- ground truth: no file `Search-App-8-SupplyChain` / `App-8-SupplyChain` exists (App-8 = MiniZinc); target `App-4-JobShopScheduling.ipynb` exists, covers supply-chain/scheduling;
- cell[46] elem[76] anchor confirmed pre-edit; post-edit 0 residual `Search-App-8-SupplyChain`, 0 residual `SupplyChain` of any form, `[App-4-JobShopScheduling]` label ×1, target `(../Applications/CSP/App-4-JobShopScheduling.ipynb)` ×1 preserved;
- Canonical JSON round-trip byte-identical pre/post (indent=1, ensure_ascii=False, WITH trailing newline). diff = 1 real change (2 unified-diff lines); `assert len(diff) < 40` passed;
- yaml surgical byte-replace (python_sha + date), LF preserved, csharp_sha + by preserved.

## Scope

2 files (1 Python notebook, 1 link-label relabel + 1 twin yaml, python_sha rebaseline). No source change beyond the visible-label relabel.

See #8052 (semantic-sampling audit, Search Part1-Foundations main-series slice — Explore-agent sweep finding, re-verified firsthand L786-2).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
