### PR TITLE
fix(ci,twin-parity): tool reminder corrupted JSON report (stderr) + workflow stream separation

### DIFF
--- a/.github/workflows/twin-parity.yml
+++ b/.github/workflows/twin-parity.yml
@@ -76,10 +76,29 @@ jobs:
         id: check
         run: |
           set +e
-          OUTPUT=$(python scripts/notebook_tools/check_twin_parity.py --json --check --per-pair --base origin/main 2>&1)
+          # Separate stdout (the JSON report, the machine contract) from stderr (diagnostics).
+          # Previously `OUTPUT=$(... 2>&1)` merged tool warnings (missing-notebook notices etc.,
+          # check_twin_parity.py emits 6 `print(..., file=sys.stderr)` sites) INTO the JSON file,
+          # so json.load crashed with "Extra data" and the gate failed with a raw traceback on
+          # any PR where a warning fired -- masking the real drift verdict. Direct redirection
+          # captures python's exit code correctly AND keeps the report pure JSON.
+          python scripts/notebook_tools/check_twin_parity.py --json --check --per-pair --base origin/main > twin_parity_report.json 2>twin_parity_stderr.log
           EXIT=$?
-          echo "$OUTPUT" > twin_parity_report.json
           set -e
+          if [ -s twin_parity_stderr.log ]; then
+            echo "Twin-parity tool diagnostics (stderr, non-fatal):"
+            cat twin_parity_stderr.log
+          fi
+          # Guard: fail with a CLEAR ::error if the report is unparseable, instead of a raw
+          # json.load traceback. The report must be stdout-only JSON (stream separation above).
+          if ! python -c "import json; json.load(open('twin_parity_report.json'))" 2>/dev/null; then
+            echo "::error title=Twin parity report unparseable::The JSON report (twin_parity_report.json) could not be parsed. Tool exit was $EXIT. Report tail + stderr are shown below and uploaded as artifacts. This indicates the report stream was corrupted or the tool crashed before emitting JSON (see #8957 stream-separation fix)."
+            echo "--- report tail (last 400 chars) ---"
+            tail -c 400 twin_parity_report.json || true
+            echo "--- stderr ---"
+            cat twin_parity_stderr.log 2>/dev/null || true
+            exit 1
+          fi
           if [ $EXIT -eq 0 ]; then
             INTRO=$(python -c "import json; d=json.load(open('twin_parity_report.json')); print(d.get('drift_introduced',0))")
             PRE=$(python -c "import json; d=json.load(open('twin_parity_report.json')); print(d.get('drift_pre_existing',0))")
@@ -118,5 +137,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: twin-parity-report
-          path: twin_parity_report.json
+          path: |
+            twin_parity_report.json
+            twin_parity_stderr.log
           if-no-files-found: ignore

--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -755,12 +755,20 @@ def main(argv=None) -> int:
                 # empreinte qui a bouge. Dans ce cas le rebaseline --update va EN DERNIER,
                 # apres ces strips, sinon l'attestation est invalidee par le strip qui suit
                 # (piege naturel, #8957).
+                #
+                # Ce rappel est un DIAGNOSTIC destine a l'humain : il va sur stderr, pas stdout.
+                # En mode --json, stdout est un contrat machine (un unique objet JSON consomme
+                # par le workflow CI via json.load) ; imprimer ce rappel sur stdout apres le
+                # JSON -> json.load levait "Extra data" et faisait tomber le gate en raw
+                # traceback (PRs #9097/#9098, exit 1 sur drift introduit). stderr reste visible
+                # dans les logs CI sans corrompre le rapport.
                 print(
                     "\nRappel : si le DRIFT vient d'une normalisation outillee qui "
                     "deplace le blob SHA (strip_probe_banner.py --apply, "
                     "strip_machine_paths.py, scrub_papermill_paths.py), le rebaseline "
                     "--update va EN DERNIER, apres ces strips -- attester PUIS "
-                    "stripper invalide l'attestation (#8957)."
+                    "stripper invalide l'attestation (#8957).",
+                    file=sys.stderr,
                 )
             return 1
         return 0


### PR DESCRIPTION
Grain: HIGH/ci-tooling -- lane myia-po-2023:CoursIA -- prev: LOW/§D.5-markdown-fix #9124

See #8057 (twin-parity gate). Fixes a CI gate crash that masked the real drift verdict on PRs #9097/#9098 (and any PR introducing drift).

## The symptom

The twin-parity gate (`twin-parity.yml`) crashed with a raw `json.load` traceback on PRs that introduce drift:

```
Traceback (most recent call last):
    raise JSONDecodeError("Extra data", s, end)
json.decoder.JSONDecodeError: Extra data: line 1687 column 1 (char 44180)
##[error]Process completed with exit code 1.
```

This made `mergeStateStatus: UNSTABLE` on #9097/#9098 and — worse — **hid the actual drift verdict** behind a tool crash. Re-running CI reproduced it deterministically (not transient).

## Root cause (two compounding bugs)

**Bug 1 — TOOL (root cause, `check_twin_parity.py`).** The #8957 strip-order reminder (added in #9087) is printed to **stdout** after the JSON object, in `--json --check --per-pair` mode when `n_introduced > 0`. The reminder block (line 750) sits **outside** the `if args.json` / `else` — so it runs in BOTH modes. In `--json` mode: `stdout = {json object}\n\nRappel: si le DRIFT vient...` → `json.load` raises "Extra data" (non-JSON content after the object). This fires on EVERY PR that introduces drift, which is precisely when the gate most needs to report the verdict.

Verified firsthand: at #9098 HEAD, `--json --check --per-pair --base origin/main` stdout = `{...}` + `\nRappel: ...(#8957).` → the extra content at char ~44174 is the reminder verbatim. At `origin/main` (0 introduced drift) the block is skipped → clean JSON → that's why most PRs pass and only drift-introducing ones crash.

**Bug 2 — WORKFLOW (latent footgun, `twin-parity.yml`).** `OUTPUT=$(python ... 2>&1)` merges tool **stderr** warnings (the tool has 6 `print(..., file=sys.stderr)` sites) into the JSON report file. The `--check --per-pair` path doesn't emit those today, but any future change that makes one fire would re-corrupt the report the same way. With bug 1 fixed (reminder → stderr), this `2>&1` would put the reminder *back* into the report — so both fixes are required together.

## Fix

1. **Tool**: the reminder is a human diagnostic → `print(..., file=sys.stderr)`. `stdout` is a machine contract (one JSON object consumed by the CI `json.load`); diagnostics belong on stderr. The reminder remains visible in CI logs (stderr is logged), it just no longer corrupts the JSON. (1 semantic line + an explanatory comment.)

2. **Workflow**: separate the streams — `> twin_parity_report.json 2>twin_parity_stderr.log`; surface stderr as a non-fatal log block; add a **JSON-validity guard** before the verdict branch so any *future* corruption fails with a clear `::error` (+ report tail + stderr) instead of a raw traceback; upload the stderr log as an artifact alongside the report.

## Verification

- **Reproduced the crash** at #9098 HEAD with the original tool (`json.load` → "Extra data").
- **Confirmed the combined fix**: with both fixes, at #9098 HEAD, `json.load(open(report))` now succeeds and returns `drift_introduced=1, drift_pre_existing=8, total=149` — i.e. the gate now **reports the real verdict** (1 introduced drift) instead of crashing. The reminder is on stderr (279 chars), the report is pure JSON.
- **No regression**: all 55 twin-parity tests pass (`pytest scripts/notebook_tools/tests/ -k "twin or parity"`).

## Note for #9097/#9098

Once this gate fix merges, #9097/#9098 will correctly report `drift_introduced=1` (they each forgot the twin yaml rebaseline — `twin-parity-rebaseline-on-merge-mandatory`). Those rebaselines are separate (per-PR yaml attests), tracked on each PR. This PR only fixes the gate so it can *tell them* what to rebaseline instead of crashing.

See #8957 (the strip-order reminder whose #9087 introduction created bug 1).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
