### PR TITLE
fix(search,#8052): Search-7-MCTS-And-Beyond-C# c13 Tic-Tac-Toe "~26 000 positions" -> 5 478 (matches own c31 + brute-force count)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb
@@ -309,7 +309,7 @@
     "La table ci-dessus compare Minimax (exploration complete, exact) a MCTS a 4 budgets d'itérations.\n",
     "\n",
     "**Points cles** (a lire sur la sortie reelle ci-dessus) :\n",
-    "1. **Avantage vitesse critique** : MCTS même a faible budget est considerablement plus rapide que Minimax, qui explore tout l'arbre du Morpion (~26 000 positionslegales avant elagage terminal).\n",
+    "1. **Avantage vitesse critique** : MCTS même a faible budget est considerablement plus rapide que Minimax, qui explore tout l'arbre du Morpion (~5 478 positionslegales avant elagage terminal).\n",
     "2. **Convergence progressive** : plus d'itérations rapprochent la valeur MCTS de 0 (la valeur optimale donnee par Minimax).\n",
     "3. **Stabilite tardive** : a 5000 itérations, la valeur estimee MCTS est très proche de l'optimal (0).\n",
     "4. **Variabilite des actions** : les actions choisies varient selon le budget, montrant que le nombre d'itérations influence la stabilite du choix.\n",

--- a/scripts/notebook_tools/twin_pairs.d/search-7-mcts-and-beyond.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-7-mcts-and-beyond.yaml
@@ -4,10 +4,10 @@
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-31"
+    date: "2026-08-01"
     by: myia-po-2024:CoursIA-2
     python_sha: c0ae3ae621be9a46d92e856679370f410859aa5f
-    csharp_sha: 86f8da452e5c093452ff0388b98f18a2fca5abe8
+    csharp_sha: 97aa863e71ed279785e9bdf3cdc14064b1a2d386
   known_differences:
     - "Rebaseline c.34 (ai-01) : #8697 a insere le bloc `metadata.cost` (#8056) a l'identique sur les DEUX jumeaux — les deux blob SHA ont bouge, la parite semantique est inchangee. Attestation de parite, pas reparation."
     - "Socle commun : limites de minimax, algorithme MCTS (selection/expansion/simulation/retropropagation), test sur Tic-Tac-Toe, comparaison MCTS vs minimax, framework OpenSpiel, AlphaGo/AlphaZero, extensions avancees. Structure des sections quasi-identique (le jumeau le plus proche cellule-a-cellule de la famille)."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

VALUE defect in `Search-7-MCTS-And-Beyond-Csharp.ipynb` cell[13]. The markdown says Minimax *"explore tout l'arbre du Morpion (~26 000 positions légales avant élagage terminal)"* — but the **same notebook cell[31]** states Tic-Tac-Toe has *"~5 478 positions légales (Minimax atteint les feuilles instantanément)"*. **Internal contradiction on the same game** (cross-cell consistency, c.1088-L / c.1051-L).

The "~26 000" figure is wrong on two counts (firsthand brute-force enumeration):
- distinct reachable **legal** Tic-Tac-Toe positions = **5478** (matches c31);
- the full game-tree node count = **549946** (not ~26 000 either).

So "~26 000 positions légales" is neither the legal-position count nor the tree-size count. This is the strongest #8052 defect class per c.1062-L (VALUE, deterministic — internal contradiction resolvable by enumeration).

Fix: `~26 000` → `~5 478` (align c13 with c31's own authoritative figure). Markdown-only, no re-exec.

Found via the #8052 Explore-agent sweep of the Search Part1-Foundations main series; re-verified firsthand (L786-2) by brute-force enumeration (5478) + cross-cell consistency with c31.

## Defect (VALUE, markdown-only, 1 site / 1 C# notebook)

- cell[13] elem[5]: `... qui explore tout l'arbre du Morpion (~26 000 positionslegales avant elagage terminal).` → `~26 000` → `~5 478`

## Twin

Search-7 is the C# twin (attested: `search-7-mcts-and-beyond.yaml`). The Python twin `Search-7-MCTS-And-Beyond.ipynb` cell[13] phrases this differently (*"Minimax exact ... car il explore tout l'arbre de jeu"*, with **no** "26 000" figure) and is CLEAN → C#-only fix → `csharp_sha` rebaselined (`86f8da45` → `97aa863e`; `python_sha` `c0ae3ae6` preserved). Twin-parity verified directly against the committed blob (== sha, both C# and Python).

## Verification (firsthand, #8052 lens)

- ground truth: brute-force enumeration of distinct reachable legal Tic-Tac-Toe positions = **5478**; full game-tree node count = **549946**; c31 already states "~5 478 positions légales";
- cell[13] elem[5] `~26 000` anchor confirmed pre-edit (exactly 1 occurrence); post-edit 0 residual `~26 000` / `26 000`, `~5 478 positions` now appears in **both** c13 and c31 (internal consistency restored);
- Canonical JSON round-trip byte-identical pre/post (indent=1, ensure_ascii=False, **NO** trailing newline). diff = 1 real change (2 unified-diff lines); `assert len(diff) < 40` passed;
- yaml surgical byte-replace (csharp_sha + date), LF preserved, python_sha + by preserved.

## Scope

2 files (1 C# notebook, 1 value correction + 1 twin yaml, csharp_sha rebaseline). No source change beyond the value correction.

See #8052 (semantic-sampling audit, Search Part1-Foundations main-series slice — Explore-agent sweep finding, re-verified firsthand L786-2 by brute-force enumeration + cross-cell consistency).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
