### PR TITLE
fix(arganalysis,#8052): Dung_AF_Semantics c26 "Utiliser le solveur" link target Tweety-5b-Lean -> Tweety-5-Abstract-Argumentation (JVM)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Dung_AF_Semantics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Dung_AF_Semantics.ipynb
@@ -1083,7 +1083,7 @@
     "\n",
     "### Prochaines étapes\n",
     "\n",
-    "- **Utiliser le solveur** : [Tweety-5](../Tweety/Tweety-5b-Lean-Argumentation.ipynb)\n",
+    "- **Utiliser le solveur** : [Tweety-5](../Tweety/Tweety-5-Abstract-Argumentation.ipynb)\n",
     "  applique ces sémantiques via TweetyProject (JVM) sur des AF plus grands, où l'énumération\n",
     "  exhaustive devient prohibitif. Le notebook [2-formal §6](Argument_Analysis_Agentic-2-formal.ipynb)\n",
     "  en fait usage dans le pipeline agentique.\n",


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

IDENTITY defect in `Argument_Analysis_Dung_AF_Semantics.ipynb` cell[26] (Conclusion → "Prochaines étapes"). Bullet 1:

```
- **Utiliser le solveur** : [Tweety-5](../Tweety/Tweety-5b-Lean-Argumentation.ipynb)
  applique ces sémantiques via TweetyProject (JVM) sur des AF plus grands, où l'énumération
  exhaustive devient prohibitif.
```

The label `[Tweety-5]` + the description "via TweetyProject (JVM)" designate the **JVM solver** notebook `Tweety-5-Abstract-Argumentation`, but the link TARGET written is `Tweety-5b-Lean-Argumentation` — the **Lean proof** notebook. Net effect: bullet 1 (promising the JVM solver) and bullet 2 (`[Tweety-5b-Lean]` Lean proof) both resolve to the **same Lean file**; the JVM-solver notebook is unreachable from the conclusion.

Same fabricated/mismatched-link family as App-5 CSP-1-NQueens (#9133), Search-9 SupplyChain (#9140), Search-11 Search-5-LocalSearch (#9136): **label correct, target wrong**.

## Ground truth (2 independent sources, same notebook)

- **cell[0]** links `[Tweety-5]` correctly → `../Tweety/Tweety-5-Abstract-Argumentation.ipynb`;
- **cell[26] bullet 2** correctly links `[Tweety-5b-Lean]` → `../Tweety/Tweety-5b-Lean-Argumentation.ipynb`;
- both target files exist (`git ls-tree origin/main -- SymbolicAI/Tweety/`: `Tweety-5-Abstract-Argumentation.ipynb`, `Tweety-5b-Lean-Argumentation.ipynb`).

## Fix

Bullet 1 target `Tweety-5b-Lean-Argumentation` → `Tweety-5-Abstract-Argumentation` (label `[Tweety-5]` **unchanged**, matches cell[0] usage; c.1103 doctrine: label = target basename). Markdown-only, no re-exec.

## Twin

`Argument_Analysis_Dung_AF_Semantics.ipynb` is Python-only (no `-Csharp` counterpart; no yaml in `scripts/notebook_tools/twin_pairs.d/` — only `tweety-5-…`/`tweety-6-…` for the Tweety notebooks themselves, the link targets). Single-file fix, no sha rebaseline.

## Verification (firsthand, #8052 lens)

- cell[26] bullet 1 anchor `[Tweety-5](...Tweety-5b-Lean-Argumentation.ipynb)` confirmed exactly 1 occurrence pre-edit; bullet 2 `[Tweety-5b-Lean](...Tweety-5b-Lean)` **preserved** (1 occ, not corrupted);
- post-edit: bullet 1 → `Tweety-5-Abstract-Argumentation` (matches cell[0]); 0 residual of the old bullet-1 anchor; bullet 2 unchanged;
- canonical JSON round-trip byte-identical (indent=1, ensure_ascii=False, trailing newline). diff = 1 real change (2 unified-diff lines); `assert len(diff) < 40` passed.

## Scope

1 file (1 Python notebook, 1 link-target relabel). No source change beyond the visible-link target.

Found via the #8052 Explore-agent sweep of SymbolicAI (non-Lean); re-verified firsthand (L786-2) against the committed notebook + filesystem.

See #8052 (semantic-sampling audit, SymbolicAI non-Lean slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
