### PR TITLE
fix(search,#8052): CSP-3 C# twin honest parity-gap reframe (parité algorithmique prouvée -> instances distinctes)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced-Csharp.ipynb
@@ -55,7 +55,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -65,10 +65,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -83,7 +83,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -95,8 +95,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:cb14:11a:e100:1173:a4f3:3c59:d15d:2048/\",\"http://2a01:cb14:11a:e100:b11b:175f:51dc:cc9a:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::4050:b6c1:81f8:3162%21:2048/\",\"http://172.26.160.1:2048/\",\"http://fe80::dc9f:5891:8b6d:a0b8%32:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -145,13 +145,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced-Csharp.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "Ce notebook est le **binôme .NET** du [CSP-3-Advanced.ipynb](CSP-3-Advanced.ipynb) (Python/OR-Tools). Il utilise **Choco-solver 4.10.17** via **IKVM 8.15.0** et la DLL pré-compilée `org.chocosolver.solver.dll`.\n",
     "\n",
-    "**Objectifs pédagogiques** (mêmes optimums que la version Python, parité prouvée) :\n",
+    "**Objectifs pédagogiques** (parallèle d'implémentation des mêmes contraintes globales que la version Python ; instances distinctes, cf. known_differences du registre de parité) :\n",
     "1. Démontrer les **contraintes globales** Choco : `allDifferent`, `cumulative`, `circuit`, `table`.\n",
     "2. Mettre en œuvre **Large Neighborhood Search (LNS)** sur le TSP via freeze/unfreeze de variables.\n",
     "3. Montrer la **réification** : transformer une contrainte en variable booléenne.\n",
@@ -39,13 +39,128 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-03T04:44:52.302555Z",
-     "iopub.status.busy": "2026-07-03T04:44:52.297448Z",
-     "iopub.status.idle": "2026-07-03T04:44:53.572614Z",
-     "shell.execute_reply": "2026-07-03T04:44:53.570645Z"
+     "iopub.execute_input": "2026-08-01T09:33:28.020226Z",
+     "iopub.status.busy": "2026-08-01T09:33:28.014016Z",
+     "iopub.status.idle": "2026-08-01T09:33:29.872495Z",
+     "shell.execute_reply": "2026-08-01T09:33:29.866458Z"
     }
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:cb14:11a:e100:1173:a4f3:3c59:d15d:2048/\",\"http://2a01:cb14:11a:e100:b11b:175f:51dc:cc9a:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::4050:b6c1:81f8:3162%21:2048/\",\"http://172.26.160.1:2048/\",\"http://fe80::dc9f:5891:8b6d:a0b8%32:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '26200.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -91,10 +206,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-03T04:44:53.581588Z",
-     "iopub.status.busy": "2026-07-03T04:44:53.579554Z",
-     "iopub.status.idle": "2026-07-03T04:44:54.743047Z",
-     "shell.execute_reply": "2026-07-03T04:44:54.742354Z"
+     "iopub.execute_input": "2026-08-01T09:33:29.874123Z",
+     "iopub.status.busy": "2026-08-01T09:33:29.873922Z",
+     "iopub.status.idle": "2026-08-01T09:33:33.110046Z",
+     "shell.execute_reply": "2026-08-01T09:33:33.109462Z"
     }
    },
    "outputs": [
@@ -179,10 +294,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-03T04:44:54.745019Z",
-     "iopub.status.busy": "2026-07-03T04:44:54.744637Z",
-     "iopub.status.idle": "2026-07-03T04:44:54.801904Z",
-     "shell.execute_reply": "2026-07-03T04:44:54.801485Z"
+     "iopub.execute_input": "2026-08-01T09:33:33.112269Z",
+     "iopub.status.busy": "2026-08-01T09:33:33.111918Z",
+     "iopub.status.idle": "2026-08-01T09:33:33.187233Z",
+     "shell.execute_reply": "2026-08-01T09:33:33.186762Z"
     }
    },
    "outputs": [
@@ -235,10 +350,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-03T04:44:54.804344Z",
-     "iopub.status.busy": "2026-07-03T04:44:54.804030Z",
-     "iopub.status.idle": "2026-07-03T04:44:56.963571Z",
-     "shell.execute_reply": "2026-07-03T04:44:56.963220Z"
+     "iopub.execute_input": "2026-08-01T09:33:33.189465Z",
+     "iopub.status.busy": "2026-08-01T09:33:33.188934Z",
+     "iopub.status.idle": "2026-08-01T09:33:33.906199Z",
+     "shell.execute_reply": "2026-08-01T09:33:33.905824Z"
     }
    },
    "outputs": [
@@ -246,7 +361,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mini-Sudoku 4x4 resolu en 200 ms (trouve = True) :\r\n"
+      "Mini-Sudoku 4x4 resolu en 72 ms (trouve = True) :\r\n"
      ]
     },
     {
@@ -468,10 +583,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-03T04:44:56.966289Z",
-     "iopub.status.busy": "2026-07-03T04:44:56.965709Z",
-     "iopub.status.idle": "2026-07-03T04:44:57.531555Z",
-     "shell.execute_reply": "2026-07-03T04:44:57.530885Z"
+     "iopub.execute_input": "2026-08-01T09:33:33.907841Z",
+     "iopub.status.busy": "2026-08-01T09:33:33.907671Z",
+     "iopub.status.idle": "2026-08-01T09:33:34.117145Z",
+     "shell.execute_reply": "2026-08-01T09:33:34.116830Z"
     }
    },
    "outputs": [
@@ -479,21 +594,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cumulative 4/2 resolu en 44 ms - makespan = 9\r\n"
+      "Cumulative 4/2 resolu en 76 ms - makespan = 9\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Optimum identique version Python (cf. CSP-3-Advanced.ipynb cellule 8)\r\n"
+      "Instance C# (durees [3,4,2,5], cap 2) -> makespan 9 ; instance distincte du twin Python (makespan 6 sur [3,2,4,2] cap 2)\r\n"
      ]
     }
    ],
    "source": [
     "// Exemple resolu : Cumulative 4 taches / 2 machines (capacite 2)\n",
     "//   Taches : durees [3,4,2,5], consommations [1,2,1,1]\n",
-    "//   Optimum : makespan = 8 unites.\n",
+    "//   Optimum : makespan = 9 unites (borne inferieure ceil(18/2)=9).\n",
     "var model2 = new Model(\"Cumulative 4/2\");\n",
     "\n",
     "var durations2 = new[] { 3, 4, 2, 5 };\n",
@@ -530,7 +645,7 @@
     "sw2.Stop();\n",
     "\n",
     "Console.WriteLine($\"Cumulative 4/2 resolu en {sw2.ElapsedMilliseconds} ms - makespan = {bestMakespan2}\");\n",
-    "Console.WriteLine(\"Optimum identique version Python (cf. CSP-3-Advanced.ipynb cellule 8)\");\n"
+    "Console.WriteLine(\"Instance C# (durees [3,4,2,5], cap 2) -> makespan 9 ; instance distincte du twin Python (makespan 6 sur [3,2,4,2] cap 2)\");\n"
    ]
   },
   {
@@ -556,10 +671,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-03T04:44:57.535971Z",
-     "iopub.status.busy": "2026-07-03T04:44:57.535111Z",
-     "iopub.status.idle": "2026-07-03T04:44:57.917024Z",
-     "shell.execute_reply": "2026-07-03T04:44:57.916622Z"
+     "iopub.execute_input": "2026-08-01T09:33:34.118986Z",
+     "iopub.status.busy": "2026-08-01T09:33:34.118694Z",
+     "iopub.status.idle": "2026-08-01T09:33:34.272175Z",
+     "shell.execute_reply": "2026-08-01T09:33:34.271905Z"
     }
    },
    "outputs": [
@@ -567,7 +682,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TSP 5 villes resolu en 28 ms - cout = 18\r\n"
+      "TSP 5 villes resolu en 17 ms - cout = 18\r\n"
      ]
     },
     {
@@ -656,10 +771,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-03T04:44:57.919221Z",
-     "iopub.status.busy": "2026-07-03T04:44:57.918848Z",
-     "iopub.status.idle": "2026-07-03T04:44:58.042304Z",
-     "shell.execute_reply": "2026-07-03T04:44:58.041697Z"
+     "iopub.execute_input": "2026-08-01T09:33:34.274355Z",
+     "iopub.status.busy": "2026-08-01T09:33:34.273898Z",
+     "iopub.status.idle": "2026-08-01T09:33:34.393295Z",
+     "shell.execute_reply": "2026-08-01T09:33:34.392730Z"
     }
    },
    "outputs": [
@@ -731,10 +846,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-03T04:44:58.044464Z",
-     "iopub.status.busy": "2026-07-03T04:44:58.044078Z",
-     "iopub.status.idle": "2026-07-03T04:44:58.185846Z",
-     "shell.execute_reply": "2026-07-03T04:44:58.185379Z"
+     "iopub.execute_input": "2026-08-01T09:33:34.395601Z",
+     "iopub.status.busy": "2026-08-01T09:33:34.395144Z",
+     "iopub.status.idle": "2026-08-01T09:33:34.518252Z",
+     "shell.execute_reply": "2026-08-01T09:33:34.517837Z"
     }
    },
    "outputs": [
@@ -756,7 +871,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Temps : 2 ms\r\n"
+      "Temps : 1 ms\r\n"
      ]
     },
     {
@@ -855,10 +970,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-03T04:44:58.188387Z",
-     "iopub.status.busy": "2026-07-03T04:44:58.187995Z",
-     "iopub.status.idle": "2026-07-03T04:44:58.300010Z",
-     "shell.execute_reply": "2026-07-03T04:44:58.299567Z"
+     "iopub.execute_input": "2026-08-01T09:33:34.519629Z",
+     "iopub.status.busy": "2026-08-01T09:33:34.519422Z",
+     "iopub.status.idle": "2026-08-01T09:33:34.608014Z",
+     "shell.execute_reply": "2026-08-01T09:33:34.607400Z"
     }
    },
    "outputs": [
@@ -970,10 +1085,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-03T04:44:58.302380Z",
-     "iopub.status.busy": "2026-07-03T04:44:58.302065Z",
-     "iopub.status.idle": "2026-07-03T04:44:58.371623Z",
-     "shell.execute_reply": "2026-07-03T04:44:58.371305Z"
+     "iopub.execute_input": "2026-08-01T09:33:34.609833Z",
+     "iopub.status.busy": "2026-08-01T09:33:34.609628Z",
+     "iopub.status.idle": "2026-08-01T09:33:34.668869Z",
+     "shell.execute_reply": "2026-08-01T09:33:34.668660Z"
     }
    },
    "outputs": [
@@ -1076,10 +1191,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-22T01:29:48.844295Z",
-     "iopub.status.busy": "2026-07-22T01:29:48.844099Z",
-     "iopub.status.idle": "2026-07-22T01:29:48.882286Z",
-     "shell.execute_reply": "2026-07-22T01:29:48.881601Z"
+     "iopub.execute_input": "2026-08-01T09:33:34.670308Z",
+     "iopub.status.busy": "2026-08-01T09:33:34.670118Z",
+     "iopub.status.idle": "2026-08-01T09:33:34.711047Z",
+     "shell.execute_reply": "2026-08-01T09:33:34.710701Z"
     }
    },
    "outputs": [
@@ -1141,10 +1256,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-03T04:44:58.526290Z",
-     "iopub.status.busy": "2026-07-03T04:44:58.525844Z",
-     "iopub.status.idle": "2026-07-03T04:44:58.612608Z",
-     "shell.execute_reply": "2026-07-03T04:44:58.612281Z"
+     "iopub.execute_input": "2026-08-01T09:33:34.712820Z",
+     "iopub.status.busy": "2026-08-01T09:33:34.712394Z",
+     "iopub.status.idle": "2026-08-01T09:33:34.758686Z",
+     "shell.execute_reply": "2026-08-01T09:33:34.758492Z"
     }
    },
    "outputs": [
@@ -1197,7 +1312,7 @@
     "\n",
     "## Conclusion et parité .NET ⇄ Python\n",
     "\n",
-    "Ce notebook démontre la **parité algorithmique** entre **Choco-solver 4.10.17** (via IKVM 8.15.0) et **OR-Tools CP-SAT** (version Python du même notebook) :\n",
+    "Ce notebook présente le **parallèle d'implémentation** entre **Choco-solver 4.10.17** (via IKVM 8.15.0) et **OR-Tools CP-SAT** (version Python du même notebook) : mêmes contraintes globales, mais sur des **instances distinctes** (les optima numériques ne sont donc pas directement comparables d'un twin à l'autre, ex. cumulative makespan 9 côté C# vs 6 côté Python). La table ci-dessous compare les **API équivalentes** :\n",
     "\n",
     "| Contrainte / Stratégie | Choco 4.10.17 (.NET) | OR-Tools CP-SAT (Python) | Parité |\n",
     "|------------------------|----------------------|-------------------------|--------|\n",
@@ -1208,7 +1323,7 @@
     "| LNS | `MoveLNS(model, fraction=0.4)` | `model.AddLNS()` | ✅ |\n",
     "| Réification | `constraint.ReifyWith(b)` | `model.AddImplication(b, constraint)` | ✅ |\n",
     "\n",
-    "**Verdict SOTA** : SOTA-OK. Vrai solveur Choco exécuté réellement en-kernel via IKVM 8.15.0, optimums identiques à OR-Tools CP-SAT (parité prouvée par comparaison cellule-à-cellule).\n",
+    "**Verdict SOTA** : SOTA-OK. Vrai solveur Choco exécuté réellement en-kernel via IKVM 8.15.0. Les instances C# étant distinctes du twin Python, la comparaison porte sur les **patrons de modélisation** (mêmes contraintes globales, idiomes Choco vs CP-SAT), pas sur l'égalité numérique des optima.\n",
     "\n",
     "**Leçons cross-cycle** :\n",
     "- **C146** : API Choco 4.10.17 — vérification bytecode strings extraction avant écriture de code IKVM\n",
@@ -1228,6 +1343,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 2,
+   "external_account": "none",
+   "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-28",
+   "network": false,
+   "qcc_tokens_est": 0,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "manual",
+   "vram_gb": 0,
+   "vram_tier": "NONE"
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",
@@ -1238,24 +1370,7 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "qcc_tokens_est": 0,
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
-   "external_account": "none",
-   "free_alternative": "self",
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-07-28",
-   "validator": "manual"
+   "version": "13.0"
   }
  },
  "nbformat": 4,

--- a/scripts/notebook_tools/twin_pairs.d/csp-3-advanced.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-3-advanced.yaml
@@ -4,11 +4,12 @@
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-31"
-    by: myia-po-2024:CoursIA-2
+    date: "2026-08-01"
+    by: myia-po-2023:CoursIA
     python_sha: ea4369680e7b982cb3a6efc2d73b060e4218a4df
-    csharp_sha: c6865e44c00885bccd47a4ee26cc0a3b45ff8099
+    csharp_sha: 35f5ba5d97ff26021053a59bff73ad42f155b294
   known_differences:
     - "Socle pedagogique commun : global constraints (all_different, sum, element) + backtracking avec propagation globale + symetrie breaking (lexicographique)."
     - "Cote C# : Choco-solver (memes recettes infrastructure) - global constraints implementes en Python pur (classe AllDifferent via matching de Hall), cote C# delegue a Choco.IntVar+Constraint via IKVM."
     - "Concepts avances : latin squares (N-Reines etendu), magic series, Golomb rulers. Cote Python = from-scratch, cote C# = Choco + benchmarks comparatifs."
+    - "Parity GAP (instances distinctes, meme classe de defect que CSP-5 #9127/#9143) : les deux twins couvrent les memes contraintes globales (allDifferent, cumulative, circuit, table) mais sur des jeux de donnees differents -- les optima numeriques ne sont PAS directement comparables d'un twin a l'autre (ex. cumulative : C# makespan 9 sur taches durees [3,4,2,5] cap 2 vs Python makespan 6 sur taches [3,2,4,2] cap 2). La comparaison porte sur les patrons d'API Choco vs CP-SAT, pas sur l'egalite des optima. Le recap C# (cellules objectifs + conclusion + cellule cumulative) a ete reframed de 'parite algorithmique prouvee / optimums identiques' (claims faux) vers 'parallele d'implementation sur instances distinctes' (honnête), et le code comment stale 'makespan = 8' aligne sur la vraie borne ceil(18/2)=9 + output Choco 9."

--- a/scripts/notebook_tools/twin_pairs.d/csp-3-advanced.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-3-advanced.yaml
@@ -7,7 +7,7 @@
     date: "2026-08-01"
     by: myia-po-2023:CoursIA
     python_sha: ea4369680e7b982cb3a6efc2d73b060e4218a4df
-    csharp_sha: 35f5ba5d97ff26021053a59bff73ad42f155b294
+    csharp_sha: 712df1e071c744065601cfcfd71b86da7458c23f
   known_differences:
     - "Socle pedagogique commun : global constraints (all_different, sum, element) + backtracking avec propagation globale + symetrie breaking (lexicographique)."
     - "Cote C# : Choco-solver (memes recettes infrastructure) - global constraints implementes en Python pur (classe AllDifferent via matching de Hall), cote C# delegue a Choco.IntVar+Constraint via IKVM."


### PR DESCRIPTION
Grain: MED/§D.5-parity-gap -- lane myia-po-2023:CoursIA -- prev: MED/§D.5-parity-gap #9143

Same false-parity-claim defect class as CSP-5 (#9143), applied to CSP-3-Advanced-Csharp. Markdown + 1 code comment + 1 WriteLine (re-executed). Resolves the "parité algorithmique prouvée / optimums identiques" false claim via Option B (canonical `parity-gap-vs-drift` resolution).

## The defect (verified firsthand vs `origin/main`)

The C# twin (`CSP-3-Advanced-Csharp.ipynb`) and the Python twin use **different concrete instances** for their global-constraint demos — so the numerical optima are NOT comparable, yet 3 sites claimed "parité prouvée / optimums identiques":

- **cumulative**: C# tasks `[3,4,2,5]` cap 2 → makespan **9** (borne inf. ceil(18/2)=9); Python twin tasks `[3,2,4,2]` cap 2 → makespan **6**. Different instances → not comparable.
- The C# **code comment itself** documented a stale wrong optimum `makespan = 8` (true Choco output = 9).

## Fix (Option B — document the gap honestly)

3 cells edited:
- **cell[0]** (id `5c448bff`): objectifs `(mêmes optimums que la version Python, parité prouvée)` → `(parallèle d'implémentation des mêmes contraintes globales que la version Python ; instances distinctes, cf. known_differences du registre de parité)`.
- **cell[8] code**: comment `Optimum : makespan = 8 unites.` → `Optimum : makespan = 9 unites (borne inferieure ceil(18/2)=9).`; `Console.WriteLine` inner text `Optimum identique version Python (cf. CSP-3-Advanced.ipynb cellule 8)` → honest `Instance C# (durees [3,4,2,5], cap 2) -> makespan 9 ; instance distincte du twin Python (makespan 6 sur [3,2,4,2] cap 2)`.
- **cell[25]** (id `b23796f6`): header `démontre la **parité algorithmique**` → `présente le **parallèle d'implémentation** ... instances distinctes ... ex. cumulative makespan 9 côté C# vs 6 côté Python`; Verdict SOTA `optimums identiques à OR-Tools CP-SAT (parité prouvée par comparaison cellule-à-cellule)` → `la comparaison porte sur les **patrons de modélisation** (mêmes contraintes globales, idiomes Choco vs CP-SAT), pas sur l'égalité numérique des optima`.

## Verification (firsthand, post-edit)

- **Stop & Repair honored**: the cell[8] `Console.WriteLine` **output** was regenerated via `jupyter nbconvert --execute` (exit 0) from the edited source — NOT hand-edited. The output stream now carries the honest `makespan 9 ; instance distincte` line (real Choco re-exec).
- **nbconvert re-exec**: exit 0, 0 errors (C.1), `execution_count` 1-12 (H.3), 26 cells intact, target ids `5c448bff`/`b23796f6` present.
- **markdown-rendering** (`detect_markdown_rendering.py`): 0 violations. **content-loss** (`detect_md_content_loss.py`): 0 findings (content added, none lost).
- **H.3 validate_pr_notebooks**: PASS (10/10 cells execution-complete; code comment + WriteLine = code edit, re-exec'd).
- **twin-parity gate** (`check_twin_parity.py --check --per-pair --base origin/main`): CSP-3 verdict `OK` (base=OK head=OK), `drift_introduced=0` (the 8 pre-existing drifts are unrelated pairs, not introduced by this PR).
- **yaml invariant**: `csharp_sha` `35f5ba5d` == `git rev-parse HEAD:CSP-3-Advanced-Csharp.ipynb` == `git hash-object` of the C# notebook. LF-only.

## Complements #9106 / #9143

- **#9106** (po-2026) rebaselines the **python_sha** pre-existing drift on a different twin yaml (`csp-5-optimization.yaml`); no overlap with this CSP-3 yaml.
- **#9143** (CSP-5, my PR) is the same defect class on the CSP-5 twin — this PR applies the identical Option B treatment to CSP-3.
- Option A (align instances for true numerical parity — the #4956 marathon goal) remains an additive follow-up; it does not conflict with this honest reframe.

See #8052 (§D.5 EPIC), #9127 (Option B reference), #9143 (CSP-5 twin).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
