### PR TITLE
fix(search,#8052): CSP-7-Soft C# twin honest Verdict SOTA (parité cellule-à-cellule -> conceptuelle)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-7-Soft-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-7-Soft-Csharp.ipynb
@@ -1106,7 +1106,7 @@
     "| Multi-objectif pondéré | `SetObjective(weighted_obj, MINIMIZE)` | `model.Minimize(weighted_obj)` | ✅ |\n",
     "| SoftAllDifferent | Réification pairwise + coût | `model.AddForbiddenAssignments` pondéré | ✅ |\n",
     "\n",
-    "**Verdict SOTA** : SOTA-OK. Vrai solveur Choco exécuté réellement en-kernel via IKVM 8.15.0, optimums identiques à OR-Tools CP-SAT (parité prouvée par comparaison cellule-à-cellule).\n",
+    "**Verdict SOTA** : SOTA-OK. Vrai solveur Choco exécuté réellement en-kernel via IKVM 8.15.0. Les deux twins partagent le problème de réunion Weighted CSP (même optimum : créneau 9h, coût total 1) mais couvrent par ailleurs des ensembles de sous-problèmes distincts (côté C# : routage sur graphe, SoftAllDifferent, multi-objectif pondéré ; côté Python : framework sémiring, CSP flou, nurse scheduling équitable, voyage, configuration PC). La comparaison est donc **conceptuelle** (cf. table des capacités ci-dessus), pas une parité numérique cellule-à-cellule.\n",
     "\n",
     "**Leçons cross-cycle** :\n",
     "- **C146** : API Choco 4.10.17 — vérification bytecode strings extraction avant écriture de code IKVM\n",

--- a/scripts/notebook_tools/twin_pairs.d/csp-7-soft.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-7-soft.yaml
@@ -4,10 +4,10 @@
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-7-Soft-Csharp.ipynb
   parity_level: surface
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
+    date: "2026-08-01"
+    by: myia-po-2023:CoursIA
     python_sha: 0e8feced8f0f63f740959dc9b8ba4cad2e972fce
-    csharp_sha: 0b0caba11ae41d8473a87e2b19547772f9be0232
+    csharp_sha: 48fa33f84a0b73e3afd33cf0055a87363befb084
   known_differences:
     - "AVERTISSEMENT DE PERIMETRE : le jumeau C# est un twin PARTIEL. parity_level=surface (pas semantic) car le C# (24 cellules, 11 code) couvre UNIQUEMENT le Weighted CSP (min cout de violation), alors que le Python (53 cellules, 20 code) couvre 4 paradigmes : Semiring-based CSP (cadre algebrique), Fuzzy CSP, Weighted CSP, plus integration OR-Tools CP-SAT. Les sections Python Semiring et Fuzzy sont entierement absentes du C#."
     - "Solver SOTA distinct : Python = OR-Tools CP-SAT (moteur SAT-based, ortools.sat.python.cp_model) ; C# = Choco-solver 4.10.17 via IKVM 8.15.0 (moteur Java, dll vendoree org.chocosolver.solver). Deux moteurs SOTA reels, idiomes et contraintes natives differentes."


### PR DESCRIPTION
Grain: LOW/§D.5-parity-gap -- lane myia-po-2023:CoursIA -- prev: MED/§D.5-parity-gap #9145

Same copy-pasted false-claim Verdict SOTA as CSP-3 (#9145) / CSP-5 (#9143), applied to CSP-7-Soft-Csharp. Markdown-only (1 line). The verdict contradicts both md[0] of the same notebook AND the twin yaml's own `known_differences`.

## The defect (verified firsthand vs `origin/main`)

`md[23]` Verdict SOTA claimed: « optimums identiques à OR-Tools CP-SAT (**parité prouvée par comparaison cellule-à-cellule**) ». But the two twins cover **different sub-problem sets** — so no cell-to-cell comparison is possible:

- **C# twin** (24 cells): Weighted CSP réunion + routage sur graphe + SoftAllDifferent + multi-objectif pondéré + CostRegular.
- **Python twin** (53 cells): framework sémiring + Fuzzy CSP + Weighted CSP réunion + nurse scheduling équitable + voyage + configuration PC (Hierarchical).

Only **ONE** problem is shared — the réunion Weighted CSP — and there the optima do match (C# code[5] `créneau 9h, coût 1` = Python code[17] `9h, total_cost 1`). Everything else differs.

This is **already documented**: the twin yaml `csp-7-soft.yaml` sets `parity_level: surface` (not semantic) with 5 `known_differences` bullets stating « le C# (24 cellules) couvre UNIQUEMENT le Weighted CSP… alors que le Python (53 cellules) couvre 4 paradigmes », and md[0] of the same notebook already says « parité **conceptuelle** » + « Distinction pédagogique importante ». Only md[23]'s verdict line was stale/false.

## Fix (Option B — align verdict with existing documentation)

`md[23]` Verdict SOTA reframed: acknowledge the shared réunion optimum (créneau 9h, coût 1 — true), then « la comparaison est donc **conceptuelle** (cf. table des capacités ci-dessus), pas une parité numérique cellule-à-cellule ». The capability table (API equivalence ✅) is untouched — it was already honest.

## Verification (firsthand, post-edit)

- **Markdown-only**: 1 ins / 1 del on `md[23]`; `git diff` confirms only cell[23] source changed, all code cells + outputs + `execution_count` untouched (C.2 exception — outputs unchanged).
- **markdown-rendering** (`detect_markdown_rendering.py`): 0 violations. **content-loss** (`detect_md_content_loss.py`): 0 findings (7985 → 8307 normalized chars = content added, none lost).
- **twin-parity gate** (`check_twin_parity.py --check --per-pair --base origin/main`): CSP-7 verdict `OK`, `drift_introduced=0`.
- **yaml invariant**: `csharp_sha` `48fa33f8` == `git rev-parse HEAD:<nb>`. LF-only.

See #8052 (§D.5 EPIC), #9143 (CSP-5), #9145 (CSP-3) — same defect class, this PR closes the CSP-7 instance of the copy-pasted verdict.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
