### PR TITLE
fix(sc,#8052): align prereq link labels with renumbered targets (stale -2 shift, 9 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "### Prerequis\n",
     "\n",
-    "- [SC-1](SC-3-Solidity-Basics.ipynb) a [SC-3](SC-5-Inheritance.ipynb) completes\n",
+    "- [SC-3](SC-3-Solidity-Basics.ipynb) a [SC-5](SC-5-Inheritance.ipynb) completes\n",
     "- Comprendre les transactions Ethereum (gas, reverts)\n",
     "\n",
     "### Duree estimee : 30 minutes"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-10-Account-Abstraction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-10-Account-Abstraction.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "### Prerequis\n",
     "\n",
-    "- [SC-1](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) a [SC-7](SC-9-DAO-Governance.ipynb) completes\n",
+    "- [SC-3](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) a [SC-9](SC-9-DAO-Governance.ipynb) completes\n",
     "- Comprendre le modèle de compte Ethereum (EOA vs contrats)\n",
     "- Notions sur ERC-4337 (optionnel, couvert dans le notebook)\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "### Prerequis\n",
     "\n",
-    "- [SC-1](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) a [SC-4](../01-Solidity-Foundation/SC-6-Errors-Events.ipynb) completes\n",
+    "- [SC-3](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) a [SC-6](../01-Solidity-Foundation/SC-6-Errors-Events.ipynb) completes\n",
     "- Notions de standards ERC (ERC-20, ERC-721)\n",
     "- Connaissance de base des wallets Ethereum\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "### Prerequis\n",
     "\n",
-    "- [SC-1](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) a [SC-5](SC-7-Token-Standards.ipynb) completes\n",
+    "- [SC-3](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) a [SC-7](SC-7-Token-Standards.ipynb) completes\n",
     "- Notions de finance decentralisee (AMM, liquidite)\n",
     "- Maitrise des interfaces et appels externes Solidity\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-9-DAO-Governance.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-9-DAO-Governance.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "### Prerequis\n",
     "\n",
-    "- [SC-1](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) a [SC-6](SC-8-DeFi-Primitives.ipynb) completes\n",
+    "- [SC-3](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) a [SC-8](SC-8-DeFi-Primitives.ipynb) completes\n",
     "- Concepts de gouvernance on-chain et votes\n",
     "- Tokens ERC-20 et delégation (SC-5)\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
@@ -57,7 +57,7 @@
     "\n",
     "### Prerequis\n",
     "\n",
-    "- [SC-9](SC-12-Foundry-Testing.ipynb) et [SC-10](SC-13-Fuzz-Invariants.ipynb) completes\n",
+    "- [SC-12](SC-12-Foundry-Testing.ipynb) et [SC-13](SC-13-Fuzz-Invariants.ipynb) completes\n",
     "- Notions de logique formelle (optionnel)\n",
     "- Foundry installe, acces a Certora ou Halmos recommande\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-21-Move-Sui.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-21-Move-Sui.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "### Prerequis\n",
     "\n",
-    "- [SC-1](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) a [SC-4](../01-Solidity-Foundation/SC-6-Errors-Events.ipynb) completes (concepts)\n",
+    "- [SC-3](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) a [SC-6](../01-Solidity-Foundation/SC-6-Errors-Events.ipynb) completes (concepts)\n",
     "- Notions de programmation orientee ressources\n",
     "- Sui CLI installe (voir instructions dans le notebook)\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "### Prerequis\n",
     "\n",
-    "- [SC-1](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) a [SC-4](../01-Solidity-Foundation/SC-6-Errors-Events.ipynb) completes (concepts)\n",
+    "- [SC-3](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) a [SC-6](../01-Solidity-Foundation/SC-6-Errors-Events.ipynb) completes (concepts)\n",
     "- Notions de base en Rust (variables, ownership, structs)\n",
     "- Solana CLI et Anchor installe (voir setup dans le notebook)\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-23-Cross-Chain.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-23-Cross-Chain.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "### Prerequis\n",
     "\n",
-    "- [SC-1](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) a [SC-8](../02-Solidity-Advanced/SC-10-Account-Abstraction.ipynb) completes\n",
+    "- [SC-3](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) a [SC-10](../02-Solidity-Advanced/SC-10-Account-Abstraction.ipynb) completes\n",
     "- Notions de bridges et messaging cross-chain\n",
     "- Compte sur un testnet Ethereum (Sepolia recommande)\n",
     "\n",


### PR DESCRIPTION
Grain: MED/xref-integrity -- lane myia-po-2023:CoursIA -- prev: LOW/§D.5-parity-gap #9146

Systematic renumbering artifact across 9 SmartContracts notebooks: the `### Prerequis` link **labels** are stale (off by −2) while their **targets** were correctly updated to the renumbered filenames. Same mismatched-cross-reference-link family as #9133/#9136/#9140/#9144, **inverse sub-class** (label wrong, target correct).

## The defect (verified firsthand on `origin/main`)

When the SC series was renumbered (SC-0/1/2 Setup moved to `00-Foundations`, shifting Solidity notebooks to SC-3+), the prereq link **targets** were updated to the new filenames, but the **display labels** kept the old numbers. Every prereq label `[SC-N]` points to a target whose actual number is `N+2`.

Example — `SC-6-Errors-Events.ipynb` cell[0] prereq:
```
- [SC-1](SC-3-Solidity-Basics.ipynb) a [SC-3](SC-5-Inheritance.ipynb) completes
```
- Target `SC-3-Solidity-Basics.ipynb` is **correct** (it IS Solidity Basics). But the label `[SC-1]` is wrong — SC-1 is `Setup-Foundry`, not Solidity Basics.
- A student reading `[SC-1]` clicks expecting SC-1's notebook, lands on SC-3 instead.

The full defect map (18 links, 9 notebooks) — all confirmed systematic, all targets semantically correct, all labels stale:

| Notebook | Prereq range (stale label) | → (corrected label) |
|----------|-----------------------------|---------------------|
| SC-6 | `[SC-1]→SC-3` ... `[SC-3]→SC-5` | `[SC-3]` ... `[SC-5]` |
| SC-7 | `[SC-1]→SC-3` ... `[SC-4]→SC-6` | `[SC-3]` ... `[SC-6]` |
| SC-8 | `[SC-1]→SC-3` ... `[SC-5]→SC-7` | `[SC-3]` ... `[SC-7]` |
| SC-9 | `[SC-1]→SC-3` ... `[SC-6]→SC-8` | `[SC-3]` ... `[SC-8]` |
| SC-10 | `[SC-1]→SC-3` ... `[SC-7]→SC-9` | `[SC-3]` ... `[SC-9]` |
| SC-14 | `[SC-9]→SC-12` ... `[SC-10]→SC-13` | `[SC-12]` ... `[SC-13]` |
| SC-21 | `[SC-1]→SC-3` ... `[SC-4]→SC-6` | `[SC-3]` ... `[SC-6]` |
| SC-22 | `[SC-1]→SC-3` ... `[SC-4]→SC-6` | `[SC-3]` ... `[SC-6]` |
| SC-23 | `[SC-1]→SC-3` ... `[SC-8]→SC-10` | `[SC-3]` ... `[SC-10]` |

After the fix each prereq range reads coherently (e.g. SC-7: "SC-3 à SC-6 completes" = the Solidity-Foundation series SC-3/4/5/6).

## Why this is not a false positive

- The +2 offset is **consistent across all 9 notebooks** (not random fabrication) → renumbering artifact, confirmed.
- The ordinal interpretation is ruled out: SC-7's range ending at label `[SC-4]` pointing to SC-6 is incoherent as an ordinal (the "4th" notebook pointing to the 6th makes no sense); only `label = target number` is consistent.
- **Nav-bar links** (`[<< Inheritance](SC-5-Inheritance.ipynb)`, `[Token Standards >>](SC-7)`) use **topic labels**, not `SC-N` labels → correctly left untouched (verified: they match their targets).

## Fix

Raw-text relabel of the 18 prereq links: `[SC-oldnum](target)` → `[SC-newnum](target)` where newnum = target basename number. Targets (paths) **unchanged**. Markdown-only.

## Verification (firsthand, post-edit)

- **9 notebooks, 1 markdown cell changed each, 0 outputs changed, 0 `execution_count` changed, cell count unchanged** → C.2 exception (outputs unchanged, no re-exec needed).
- **markdown-rendering** (`detect_markdown_rendering.py`): 0 violations (all 9). **content-loss** (`detect_md_content_loss.py`): 0 findings (all 9, normalized_chars stable).
- **twin-parity gate**: `drift_introduced=0` (SC notebooks are not registered as twins — no yaml rebaseline needed).
- Collision guard: no open PR touches SC-6/7/8/9/10/14/21/22/23 (#9001=SC-16, #9107=SC-11 are different notebooks).

See #8052 (EPIC). Same xref-integrity vein as #9133/#9136/#9140/#9144.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
