### PR TITLE
docs(rl,#8052): RL/README FAQ -- Bellman equation mis-attributed to notebook 3 (self-contradiction, real = notebook 5)

### DIFF
--- a/MyIA.AI.Notebooks/RL/README.md
+++ b/MyIA.AI.Notebooks/RL/README.md
@@ -449,7 +449,7 @@ Non. Les notebooks 1-5 (SB3, wrappers, goal-conditioned, bandits, tabulaire) tou
 
 ### Qu'est-ce qu'un MDP et pourquoi est-ce central ?
 
-Un **MDP** (Markov Decision Process) est le modèle mathématique du RL : un ensemble d'états S, d'actions A, de transitions T(s'|s,a), de récompenses R(s,a), et d'un facteur d'actualisation gamma. Tout problème de RL se formalise comme un MDP. L'équation de Bellman (notebook 3) définit récursivement la valeur optimale. Si vous avez fait la série Probas, les MDP généralisent les chaînes de Markov avec des décisions.
+Un **MDP** (Markov Decision Process) est le modèle mathématique du RL : un ensemble d'états S, d'actions A, de transitions T(s'|s,a), de récompenses R(s,a), et d'un facteur d'actualisation gamma. Tout problème de RL se formalise comme un MDP. L'équation de Bellman (notebook 5) définit récursivement la valeur optimale. Si vous avez fait la série Probas, les MDP généralisent les chaînes de Markov avec des décisions.
 
 ### Quelle est la différence entre on-policy et off-policy ?
 


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

STRUCTURAL self-contradiction in `MyIA.AI.Notebooks/RL/README.md`, FAQ section "Qu'est-ce qu'un MDP ?":

> "Tout problème de RL se formalise comme un MDP. **L'équation de Bellman (notebook 3)** définit récursivement la valeur optimale."

**"(notebook 3)" is wrong.** The SAME README attributes the Bellman equation to **notebook 5** in **four other sections**:

| README location | Text |
|-----------------|------|
| L92 (narrative) | "Le notebook 5 formalise le problème RL (MDP, **équation de Bellman**, Value/Policy Iteration)..." |
| L38 (index table) | `\| 5 \| rl_5_mdp_dp_qlearning \| MDP, Value/Policy Iteration, Q-Learning tabulaire \|` |
| L187 (figure caption, nb-5 block) | `\| Value Iteration \| Équation de Bellman, convergence \|` |
| L395 ("Algorithmes couverts") | `\| **Bellman equation** \| Relation de récurrence pour V et Q \| 5 \|` |

**File content settles it authoritatively** (firsthand, L786-2):
- `rl_3_experience_replay_dqn.ipynb` → string "Bellman" count = **0**;
- `rl_5_mdp_dp_qlearning.ipynb` → "Bellman" count = **5**;
- `rl_3` cell[0] title = "Notebook 3 – Hindsight Expérience Replay (HER) et Sauvegarde Avancée" (replay/HER, **not** Bellman).

The Bellman equation / MDP formalism / Value+Policy Iteration is notebook 5's core topic. The "(notebook 3)" in the FAQ is the outlier — likely a confusion with `rl_3`'s filename (`..._dqn`) or its experience-replay theme.

**Fix:** `(notebook 3)` → `(notebook 5)` — single phrase, aligns the FAQ with its 4 sibling sections + the notebook file contents (c.1088-L cross-section consistency).

## Why deterministic

Settled by the README's own 4 sibling sections + notebook file contents (`grep -c Bellman`: rl_3=0, rl_5=5). No interpretation, no re-execution. Markdown-only (README, not a notebook) — no twin, no sha rebaseline.

## Verification (firsthand, #8052 lens, L786-2)

- README FAQ (L452): "L'équation de Bellman (notebook 3)" → "(notebook 5)";
- 4 sibling README sections already say notebook 5 (L38/L92/L187/L395) — unchanged;
- file content: rl_3 "Bellman"=0, rl_5=5;
- 1-line diff (1 insertion / 1 deletion); **CR guard passed (LF-only, `eol=lf`)**.

## Scope

1 file (RL/README.md). No source change beyond the FAQ cross-reference fix.

Found via the #8052 Explore-agent sweep of RL; re-verified firsthand (L786-2; c.1087-L: grep on exact strings, not line numbers) against the README's own sibling sections + notebook file contents. L898 PR-checked (uncontested: prior RL/README PRs #5032/#4637/#3751 MERGED, none touch the FAQ Bellman attribution).

See #8052 (semantic-sampling audit, RL slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
