### PR TITLE
fix(sl,#8052): SL-1 c16 recap 'VS s'effondre a l'exemple 9' -> 10e exemple (k=10)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -1027,7 +1027,7 @@
     "\n",
     "> **Point cle** : Le Version Space represente **implicitement** toutes les hypotheses consistantes. Même s'il y en a des milliers, seules les frontieres G et S sont stockees.\n",
     "> **Résultat observe ici** : sur les exemples du restaurant, G et S s'effondrent\n",
-    "> a l'exemple 9 (`|G| = |S| = 0`) : **aucune conjonction unique ne peut representer\n",
+    "> au 10e exemple (`|G| = |S| = 0`, k=10) : **aucune conjonction unique ne peut representer\n",
     "> WillWait**. Le concept reel (AIMA 19.3) est un arbre de decision, c'est-a-dire\n",
     "> une combinaison disjonctive de cas --- le biais de representation conjonctif est\n",
     "> trop fort pour ce domaine. C'est un résultat pedagogique important, pas un bug :\n",

--- a/scripts/notebook_tools/twin_pairs.d/sl-1-logicallearning.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-1-logicallearning.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-31"
-    by: po-2024
-    python_sha: 491d562cf789839411bf8f755dd1476da1120d86
+    date: "2026-08-01"
+    by: myia-po-2023:CoursIA
+    python_sha: 54e32cb14b4791558f1017d16974ea0ee19d62af
     csharp_sha: 8013c9d785020bb014f29f74e4cf64e4a413f595
   known_differences:
     - "Socle commun : apprentissage logique symbolique -- Current-Best-Hypothesis (CBH) et Version Space / Candidate Elimination, sur le domaine restaurant (AIMA)."


### PR DESCRIPTION
Grain: MED/claims-vs-outputs -- lane myia-po-2023:CoursIA -- prev: REVIEW/integrity-correction c.1074

## What

VALUE defect in `SL-1-LogicalLearning.ipynb` **cell[16]** (recap `### Interpretation : Résultat du Version Space`). The recap claimed the Version Space collapses "à l'exemple 9 (`|G| = |S| = 0`)", but this contradicts the notebook's **own committed output** and its **own code comment**.

## Defect (firsthand, G.1 against origin/main)

The convergence table printed by **code cell[42]** (committed output) is:

```
  k  | |G| | |S| | etat
 ------------------------------------------
  9 |   1 |   1 | converge (G == S)
 10 |   0 |   0 | VIDE (effondrement)
```

So `|G| = |S| = 0` (effondrement) happens at **k=10**, NOT k=9. At k=9 the VS is still `|G|=1, |S|=1` ("converge"). The recap attributing `|G|=|S|=0` to "exemple 9" is directly falsified by the k=9 row.

The notebook's **own code comment** in cell[42] confirms the convention: `# s'effondre au 10e exemple (k=10)`. So "exemple 9" was off-by-one vs the established 1-indexed k convention used everywhere else in the notebook.

> Note on the 0-indexing ambiguity (why this is still a clean defect): a programmatic reading "EXAMPLES[9] = the 10th element" could make "9" internally defensible. But the recap is **pedagogical French prose** ("s'effondrent à l'exemple 9"), and the notebook itself describes this same event as "10e exemple (k=10)" in its code comment — so the recap's "9" contradicts both the output table (k=9 row) and the notebook's own stated convention. A student reading "exemple 9" and looking at the k-column lands on a non-collapsed row.

## Fix

cell[16]: `a l'exemple 9 (\`|G| = |S| = 0\`)` → `au 10e exemple (\`|G| = |S| = 0\`, k=10)`. Aligns the recap with the output table (k=10) and the code comment ("10e exemple").

Markdown-only: **1 source line of 1 markdown cell changed; 0 code cells, 0 outputs, 0 `execution_count`, cell count unchanged (58=58)** → C.2 exception (no re-exec). Minimal raw-text surgery (1 ins / 1 del), JSON-validated, byte-stable.

## Twin

SL-1 has a C# twin (`parity_level: semantic`). The edit touches only the Python recap (a Python-specific richer cell with no C# parallel). `sl-1-logicallearning.yaml` `python_sha` rebaselined to the new blob (invariant `git rev-parse HEAD:<nb>` == yaml `python_sha` verified). **`drift_introduced = 0`** (SL-1 `base=OK head=OK`; no pair went base=OK → head=DRIFT). C# twin untouched.

## Verification (firsthand, post-edit)

- **content-loss** (`detect_md_content_loss.py`): `findings=0` (normalized_chars 38526→38532, stable — the +6 chars are the added `, k=10` + `9→10e`, no content lost).
- **markdown-rendering** (`detect_markdown_rendering.py`): 0 violations on SL-1.
- **H.3** (`validate_pr_notebooks.py`): 1/1 passed, 18 code cells checked.
- **twin-parity** (`check_twin_parity.py --check`): SL-1 `base=OK head=OK`, drift_introduced=0.

## Collision guard

- **#9056** (MERGED, po-2024) touched SL-1-LogicalLearning.ipynb but with a **different scope** ("wrong attribute Alt→Hungry", "plusieurs hypothèses vs empty VS", stale train/test split, majority undercount). It did **not** touch the "exemple 9" line in cell[16] — that line is still on `origin/main` as fixed by this PR.
- **No open PR** touches SL-1-LogicalLearning.ipynb (open PRs in the area are GameTheory/Search/ML/RL/Tweety/IIT/Planners — none on SL-1 Python).

Found via a delegated sonnet scan (SL/ML/GT families, claims-vs-outputs defect class) which flagged this cell as borderline; re-verified firsthand G.1 against the committed output table + the notebook's own code comment, which removes the ambiguity → clean defect.

`See #8052` (EPIC — claims-vs-outputs), not `Closes` (partial contribution to the epic).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
