### PR TITLE
docs(ml,#8052): ML.Net README -- ML-4 cell-count drift 86 -> 87 (re-drift post #6914)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/README.md
+++ b/MyIA.AI.Notebooks/ML/ML.Net/README.md
@@ -67,7 +67,7 @@ Le notebook 2 plonge dans la préparation des données — l'étape la plus chro
 
 Le notebook 3 introduit l'entraînement proprement dit. Vous découvrirez SDCA (Stochastic Dual Coordinate Ascent) pour la régression linéaire, LightGBM pour les problèmes non linéaires, et surtout l'AutoML de ML.NET qui automatise la recherche d'hyperparamètres et la sélection d'algorithme. Vous verrez aussi les dangers du surapprentissage et comment l'arrêter précocement.
 
-Le notebook 4 est le plus dense (86 cellules) et le plus crucial : évaluation rigoureuse. Vous apprendrez à mesurer un modèle avec R², MAE, RMSE, à utiliser la validation croisée pour estimer la généralisation, et à expliquer les prédictions avec la Permutation Feature Importance (PFI) et le Feature Contribution Calculation (FCC). Ce notebook transforme un "modèle qui marche" en un modèle que vous comprenez et pouvez justifier.
+Le notebook 4 est le plus dense (87 cellules) et le plus crucial : évaluation rigoureuse. Vous apprendrez à mesurer un modèle avec R², MAE, RMSE, à utiliser la validation croisée pour estimer la généralisation, et à expliquer les prédictions avec la Permutation Feature Importance (PFI) et le Feature Contribution Calculation (FCC). Ce notebook transforme un "modèle qui marche" en un modèle que vous comprenez et pouvez justifier.
 
 ### Phase 2 : Fonctionnalités avancées (ML-5 à ML-9, ~2h30)
 


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

COUNT defect in `MyIA.AI.Notebooks/ML/ML.Net/README.md`, line 70:

> "Le notebook 4 est le plus dense **(86 cellules)** et le plus crucial : évaluation rigoureuse."

The real `ML-4-Evaluation.ipynb` has **87** cells (firsthand count on `origin/main`), not 86.

Prior PR **#6914** fixed this exact claim **82 → 86**; the notebook has since gained one cell, so the README **re-drifted** to a stale 86. Recurring cell-count drift on the same line (#6914 was 82→86; now 86→87) — the README prose count isn't auto-synced when a notebook gains a cell.

**Fix:** `(86 cellules)` → `(87 cellules)` (single phrase, L70). L416's `(le notebook le plus dense)` has no number → unchanged.

## Why deterministic

Settled by a firsthand cell count of `ML-4-Evaluation.ipynb` on `origin/main` (87 cells, `len(cells)`). No interpretation, no re-execution. Markdown-only (README, not a notebook) — no twin, no sha rebaseline.

## Verification (firsthand, #8052 lens, L786-2)

- README L70: `(86 cellules)` → `(87 cellules)`;
- real `ML-4-Evaluation.ipynb` cell count = **87** (json.load + len(cells));
- L416 `(le notebook le plus dense)` — numberless, unchanged;
- 1-line diff (1 insertion / 1 deletion); **CR guard passed (LF-only, `eol=lf`)**.

## Scope

1 file (ML/ML.Net/README.md). No source change beyond the cell-count prose fix.

Found via the #8052 Explore-agent sweep of ML/ML.Net; re-verified firsthand (L786-2) against the committed `ML-4-Evaluation.ipynb` cell count. L898 PR-checked (uncontested: prior #6914 MERGED 82→86; no open PR touches this line).

See #8052 (semantic-sampling audit, ML/ML.Net slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
