### PR TITLE
docs(gametheory,#8052): GT-17-MultiAgent-RL c37 resume forward-ref -- fabricated "Notebooks 16-19" + wrong "Serie Lean 4" + wrong "suivants" (last nb)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL.ipynb
@@ -2173,7 +2173,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Notebooks suivants** : Serie Lean 4 pour les formalisations (Notebooks 16-19)"
+    "**Pour aller plus loin** : les formalisations Lean de la théorie des jeux (notebooks 2b, 4b, 5b, 8b, 11b, 15b) approfondissent les preuves formelles ; la série [RL/](../RL/README.md) prolonge le MARL (apprentissage par renforcement)."
    ]
   }
  ],

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-17-multiagent-rl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-17-multiagent-rl.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-25"
-    by: po-2023
-    python_sha: 3be092acbcd19093e20425200c97a973c99ff75f
+    date: "2026-08-01"
+    by: myia-po-2024:CoursIA-2
+    python_sha: d4ac08ac2355bc71628bbaab8934d54e94b010bd
     csharp_sha: 06dff5d8a085846f7feb1dc3e08765da35c5f2ce
+    reason: "rebaseline python apres fix forward-ref cellule 37 resume (#8052) : la ligne disait 'Notebooks suivants : Serie Lean 4 pour les formalisations (Notebooks 16-19)' mais la serie compte 17 notebooks (pas de 18/19, cf #9149 GT-1), 'Serie Lean 4' est un faux label (Lean = notebooks b-suffixes 2b/4b/5b/8b/11b/15b), et 'suivants' est faux car GT-17 est le dernier (#17). Fix -> pointe vers la serie RL/ (README L136 'fait le pont avec l'apprentissage par renforcement') + liste les vrais notebooks Lean. Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:
     - "Socle pedagogique commun : apprentissage par renforcement multi-agent (MARL), self-play et auto-competition, fictitious play (Brown 1951), exploitabilite / distance a Nash, Neural Fictitious Self-Play (NFSP, Heinrich & Silver 2016), PSRO (Policy-Space Response Oracles, Lanctot et al. 2017)."
     - "Idiomes framework : Python = `numpy` + `matplotlib` + `pyspiel` (OpenSpiel) + `tqdm` (integration framework MARL a l'echelle). C# = BCL .NET 9 pur (`System.Linq`, 0 NuGet), fictitious play / NFSP table-based / PSRO from-scratch."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

STRUCTURAL/IDENTITY forward-reference defect in `MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL.ipynb`, cell[37] "Résumé et Points Clés" (the summary cell). It ended with:

> **Notebooks suivants** : Serie Lean 4 pour les formalisations (Notebooks 16-19)

**This line has THREE deterministic defects:**

| # | Defect | Why it's wrong | Authority |
|---|--------|----------------|-----------|
| 1 | "Notebooks 16-19" FABRICATED | The series has **17 notebooks** (1-17). There is **no notebook 18 or 19**. | `git ls-tree` (max = GameTheory-17); README L70/L136; same family fixed in GT-1 #9149 |
| 2 | "Serie Lean 4" wrong label | The Lean formalizations are the **b-suffixed** notebooks (2b, 4b, 5b, 8b, 11b, 15b), NOT a contiguous "16-19" block. | `git ls-tree` (GameTheory-{2b,4b,5b,8b,11b,15b}-Lean-*.ipynb); same mislabel as #9149 Partie 4 |
| 3 | "suivants" (next) wrong | GT-17 **IS notebook #17 — the LAST** in the series. Nothing follows it. GT-16 cell[47] correctly points forward *to* GT-17; GT-17 cannot claim 16-19 are "suivants". | series structure |

## Why deterministic (not narrative judgment)

The c.1116 Explore sweep flagged this as a "narrative judgment" DEFER. But the fix is fully grounded — no invention:

- **README L136** (authority): *"Le notebook 17 (Multi-Agent RL) **fait le pont avec l'apprentissage par renforcement**."* → GT-17's documented forward bridge is the **RL/** series (`RL/README.md` exists). Linking to RL/ is authoritative, not invented.
- The Lean notebook list (2b/4b/5b/8b/11b/15b) is factual (`git ls-tree`).
- "16-19" fabricated = same family as the #9149 GT-1 fix.

## Fix

cell[37] elem[30]:

```diff
- **Notebooks suivants** : Serie Lean 4 pour les formalisations (Notebooks 16-19)
+ **Pour aller plus loin** : les formalisations Lean de la théorie des jeux (notebooks 2b, 4b, 5b, 8b, 11b, 15b) approfondissent les preuves formelles ; la série [RL/](../RL/README.md) prolonge le MARL (apprentissage par renforcement).
```

- "suivants" (wrong, 17 is last) → "Pour aller plus loin" (going further) — grounded in README L136.
- "Serie Lean 4 (16-19)" (fabricated) → real Lean list (2b/4b/5b/8b/11b/15b).
- Adds the RL/ bridge (README L136).

Markdown-only (no code, no re-exec). **C# twin** (`-Csharp.ipynb`, 24 cells) has **no such line** (grep `suivants`/`16-19`/`Serie Lean` → 0) → **Python-only** + `python_sha` rebaseline (`3be092ac`→`d4ac08ac`; `csharp_sha` `06dff5d8` unchanged, parity OK — both shas match real origin/main blobs).

## Verification (firsthand, #8052 lens, L786-2)

- `git ls-tree` confirms no GT-18/GT-19 (series = 1-17);
- Lean notebooks confirmed: 2b/4b/5b/8b/11b/15b;
- README L136 grounds the RL/ bridge; `RL/README.md` exists;
- C# twin (24 cells) has no equivalent line;
- 1-line diff (.ipynb cell[37].elem[30] only); **CR guard passed (LF-only, `eol=lf`)**;
- twin-parity: real C# blob `06dff5d8` == yaml `csharp_sha` (preserved).

## Scope

2 files (GT-17-MultiAgent-RL.ipynb + gametheory-17-multiagent-rl.yaml). No source change beyond the summary forward-ref prose + python_sha rebaseline.

L898 PR-checked (uncontested: no open PR touches GT-17; the "16-19" keyword hit is my own #9149 on GT-1, not GT-17).

See #8052 (semantic-sampling audit, GameTheory slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
