### PR TITLE
fix(gametheory,#8052): GT-12-ReputationGames c2 cross-ref -- chain-store paradox attributed to Notebook 8 (real = Notebook 9 BackwardInduction)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb
@@ -115,7 +115,7 @@
     "Avec **information complete** et jeu **fini** :\n",
     "- L'induction arriere elimine les effets de reputation\n",
     "- Toutes les menaces sont non-credibles a la fin\n",
-    "- Le paradoxe de la chaîne de magasins (Notebook 8)\n",
+    "- Le paradoxe de la chaîne de magasins (Notebook 9)\n",
     "\n",
     "### 1.3 La Solution: Incertitude sur les Types\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-12-reputationgames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-12-reputationgames.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-25"
-    by: po-2023
-    python_sha: 6ef5e387bca07af24e6b0a4c27d739227c069e9e
+    date: "2026-08-01"
+    by: myia-po-2024:CoursIA-2
+    python_sha: f076193833b42af315e24fa5c0c599582d348d2d
     csharp_sha: 4096d74c1b63d5ab1c43a8cdd0e03630934ce1de
+    reason: "rebaseline python apres fix cross-reference cellule 2 (#8052) : la section 1.2 disait 'Le paradoxe de la chaine de magasins (Notebook 8)' mais le paradoxe est couvert dans le Notebook 9 (BackwardInduction section 4 + code create_chain_store_game + ancres Selten 1978 / Rosenthal 1981), pas le Notebook 8 (Combinatorial Games). Fix (Notebook 8)->(Notebook 9). Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:
     - "Socle pedagogique commun : jeux de reputation dans les interactions repetees sous information incomplete -- pourquoi la reputation change tout, cheap talk (communication non couteuse), modele de Kreps-Wilson (reputation du « tough incumbent » dans la chaine de magasins), Gang of Four / KMRW (cooperation emergente dans le dilemme du prisonnier fini), equilibre bayesien parfait (PBE). Suit naturellement le GT-11 (jeux bayesiens) en appliquant le BNE aux dynamiques de reputation."
     - "Idiomes framework : Python = `scipy.optimize.fsolve` (resolution des conditions d'equilibre Kreps-Wilson) + `matplotlib` (courbes de gain / trajectoires de reputation) + `@dataclass`. C# = **BCL .NET pur 0 NuGet tiers** avec une **simulation numerique Monte-Carlo from-scratch** (Random + System.Math, etude de l'impact du parametre epsilon sur les gains)."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

IDENTITY cross-reference defect in `MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb`, cell[2], section "1.2 Le Problème". Listing the consequences of complete-information finite games, it points the reader to where the chain-store paradox was covered:

> - Le paradoxe de la chaîne de magasins **(Notebook 8)**

**(Notebook 8) is WRONG.**

| Claim | Reality | Authority |
|-------|---------|-----------|
| chain-store paradox = "Notebook 8" | Notebook 8 = **GameTheory-8-CombinatorialGames** (Sprague-Grundy, Nim, Wythoff) — `grep 'magasin'` returns **0 hits** in GT-8 | `git show origin/main:...GameTheory-8...ipynb` cell[0] title |
| where IS the chain-store paradox? | **Notebook 9 (BackwardInduction)** — dedicated section + code + scholarly anchors | GT-9 cell[21]/[22]/[32]/[34] (below) |

GT-9 is the canonical chain-store-paradox notebook:

- cell[21]: `## 4. Paradoxe de la Chaîne de Magasins (Selten)` — dedicated section
- cell[22]: `create_chain_store_game()` / `analyze_chain_store()` — full implementation
- cell[32]: `| Chain Store | Paradoxe de la reputation |` — summary table
- cell[34]: scholarly anchors — Rosenthal 1981 (*Predatory Pricing and the Chain-Store Paradox*), Selten 1978 (*The Chain Store Paradox*)

The chain-store paradox is also referenced by name in GT-10 (ForwardInduction) and GT-12 itself, but its coverage home is **Notebook 9**.

## Fix

cell[2] elem[15]:

```diff
- - Le paradoxe de la chaîne de magasins (Notebook 8)
+ - Le paradoxe de la chaîne de magasins (Notebook 9)
```

c.1088-L cross-reference defect (a number-claim contradicted by the actual content distribution across the series). Markdown-only (no code, no re-exec). **C# twin** (23 cells) mentions chain-store as a topic but has **no "(Notebook 8)" cross-reference** (`grep "Notebook 8"` → 0 in C#) → **Python-only** + `python_sha` rebaseline (`6ef5e387`→`f0761938`; `csharp_sha` `4096d74c` unchanged, parity OK — both shas match real origin/main blobs).

## Verification (firsthand, #8052 lens, L786-2)

- GT-8 = Combinatorial Games (cell[0] title); `grep 'magasin'` → 0 hits in GT-8;
- GT-9 section 4 + code + anchors = canonical chain-store coverage;
- C# twin has no "(Notebook 8)" cross-ref;
- 1-line diff (.ipynb cell[2].elem[15]); **CR guard passed (LF-only, `eol=lf`)**;
- twin-parity: real C# blob `4096d74c` == yaml `csharp_sha` (preserved).

## Scope

2 files (GT-12-ReputationGames.ipynb + gametheory-12-reputationgames.yaml). No source change beyond the cross-ref prose + python_sha rebaseline.

L898 PR-checked (uncontested: no open PR touches GT-12).

See #8052 (semantic-sampling audit, GameTheory slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
