### PR TITLE
docs(rl,#8052): rl_6e_grpo c22 "## 10. Conclusion" phantom section number -> unnumbered (no section 9; sibling convention)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb
@@ -808,7 +808,7 @@
     "| <-> RL-6d | [SAC depuis zero](rl_6d_sac_from_scratch.ipynb) | SAC stabilise par **entropie max** ; GRPO par **KL vs reference** -- deux reponses au même problème (effondrement). |\n",
     "| <-> RL-1 | [Intro CartPole](rl_1_intro_cartpole.ipynb) | Bases MDP, recompense, retour. GRPO = loop PPO sans critic. |\n",
     "\n",
-    "## 10. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "**GRPO** est l'algorithme qui a rendu l'entrainement RL des LLM reasoning (DeepSeek-R1) scalable :\n",
     "en supprimant le critic au profit d'un **avantage relatif intra-groupe**, il reduit la complexite et\n",


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

STRUCTURAL defect in `MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb` (Python), cell[22] (markdown). The conclusion header carries a **phantom section number**:

> `## 10. Conclusion`

The notebook's numbered H2 sections run **1 → 8**, then an unnumbered `## Ponts avec la serie` (also c22), then `## 10. Conclusion`. **There is no section 9** — the numbering jumps 8 → 10:

| cell | header |
|------|--------|
| c1 | `## 1. Pourquoi GRPO ?` |
| c3 | `## 2. Environnement...` |
| c5 | `## 3. Reseau de politique` |
| c7 | `## 4. La mise a jour GRPO` |
| c9 | `## 5. Boucle d'entrainement` |
| c12 | `## 6. Résultats et verdict` |
| c15 | `## 7. Ce que GRPO change` |
| c16 | `## 8. Exercices` |
| c22 | `## Ponts avec la serie` (unnumbered) |
| c22 | `## 10. Conclusion` ← **phantom (no §9)** |

## Fix

Drop the phantom number, matching the **sibling convention** — all 5 checked RL "from scratch" siblings end with an **unnumbered** `## Conclusion`:

| sibling | conclusion header |
|---------|-------------------|
| rl_2 | `## Conclusion` (c23) |
| rl_6 | `## Conclusion` (c27) |
| rl_6c | `## Conclusion` (c27) |
| rl_6d | `## Conclusion` (c38) |
| rl_12 | `## Conclusion` (c29) |

rl_6e is the only one that numbers its conclusion, and the number it picks doesn't exist in its own section sequence.

```diff
- ## 10. Conclusion
+ ## Conclusion
```

Markdown-only (1 header) → no code, no output, no re-exec. **NOT twinned** (no `twin_pairs.d` yaml references `rl_6e_grpo`) → single `.ipynb`, no sha rebaseline. The unnumbered `## Ponts avec la serie` (same cell) is correct and untouched.

## Verification (firsthand, #8052 lens, L786-2)

- H2 headers enumerated: Objectifs, 1, 2, 3, 4, 5, 6, 7, 8, (unnumbered Ponts), 10 → **no section 9**;
- anchor `## 10. Conclusion` whole-nb unique (count=1); `## Conclusion` did not pre-exist;
- asserted `'## 9.' not in nb` (confirms 10 is genuinely a phantom, not following a hidden 9);
- cell[22] `## Ponts avec la serie` preserved; conclusion now unnumbered;
- CR guard passed (LF-only, `eol=lf`; binary stdin `hash-object`, c.1115-L); not twinned.

## Scope

1 file (`RL/rl_6e_grpo_from_scratch.ipynb`). No source change beyond the 1 markdown header.

Found via the #8052 RL Explore sweep (under-scanned subset); re-verified firsthand (L786-2; c.1087-L grep on exact strings) against the notebook's own H2 sequence + 5 sibling notebooks. L898 PR-checked (uncontested: no open PR touches `rl_6e_grpo`; disjoint from my open RL PRs #9094/#9105/#9108/#9158 → rl_13/rl_8/rl_7/rl_11).

See #8052 (semantic-sampling audit, RL slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
