### PR TITLE
fix(rl,#8052): rl_4_multi_armed_bandits c36 table -- e-greedy regret "O(log T)" wrong -> Sous-linéaire (own output + sweep + Points-clés agree)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb
@@ -1595,7 +1595,7 @@
     "|-----------|--------|-------------|--------------|----------------|\n",
     "| **Random** | linéaire | Maximal | Simple, bonne base de référence | N'apprend jamais |\n",
     "| **Greedy** | Sous-linéaire | Minimal (init seulement) | rapide si bonne initialisation | Peut se bloquer sur un bras sous-optimal |\n",
-    "| **e-greedy** | $O(\\log T)$ | paramètre fixe | Simple, robuste | Continue a explorer même après convergence |\n",
+    "| **e-greedy** | Sous-linéaire | paramètre fixe | Simple, robuste | Continue a explorer même après convergence |\n",
     "| **UCB** | $O(\\log T)$ | Automatique | **Robuste** (optimal asymptotique $O(\\log T)$, sans warmup, cf. sweep ci-dessus) | Suppose des bornes sur les récompenses |\n",
     "| **Thompson** | $O(\\log T)$ | Automatique (bayesien) | Elegante, adaptée aux priors | spécifique au type de distribution |\n",
     "\n",


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

VALUE/STRUCTURAL defect in `MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb` (Python), cell[36] comparison TABLE. The e-greedy row classifies its regret as `$O(\log T)$`:

> `| **e-greedy** | $O(\log T)$ | paramètre fixe | Simple, robuste | Continue a explorer même après convergence |`

This contradicts the notebook's **own committed output** (triple authority):

**1. cell[32] (T=2000 benchmark) output** — classifies the regret *type* per strategy, reserving `O(log T) asymptotique` for **UCB alone**:

| Stratégie | Regret | % optimal | Type de regret |
|-----------|--------|-----------|----------------|
| e-greedy (0.1) | 97.1 | 94.2% | **Sous-lineaire (borne)** |
| e-greedy (0.01) | 199.8 | 88.1% | **Sous-lineaire (borne)** |
| UCB (c=2) | 271.1 | 83.8% | **O(log T) asymptotique** |

**2. cell[34] (horizon sweep) output** — final regret by horizon, e-greedy **diverges** while UCB stays sub-linear:

| Stratégie | T=1000 | T=3000 | T=10000 | T=30000 |
|-----------|--------|--------|---------|---------|
| e-greedy (0.1) | 53.2 | 125.5 | 391.6 | **1088.2** (~linear) |
| UCB (c=√2) | 123.9 | 224.6 | 381.2 | **546.9** (sub-linear) |

**3. cell[36]'s own "Points clés"** — item 1 groups e-greedy under **"sous-linéaire"** only; item 2 names **only "UCB et Thompson Sampling"** as asymptotiquement optimaux `O(log T)` — e-greedy is explicitly *excluded* from the `O(log T)` class by the cell's own prose.

(The theory agrees: a **fixed**-ε e-greedy never stops exploring, so its regret is linear in the worst case — not `O(log T)`; only a *decaying* schedule reaches `O(log T)`. The notebook uses fixed ε=0.1/0.01 throughout.)

## Fix

Align the table row to `Sous-linéaire` — matching the Greedy row style, the cell's own Points clés item 1 ("sous-linéaire"), and the cell[32] committed classification:

```diff
- | **e-greedy** | $O(\log T)$ | paramètre fixe | Simple, robuste | Continue a explorer même après convergence |
+ | **e-greedy** | Sous-linéaire | paramètre fixe | Simple, robuste | Continue a explorer même après convergence |
```

The `paramètre fixe` exploration column and the `Continue a explorer même après convergence` weakness are **correct and preserved** — they are exactly *why* fixed-ε is sub-linear rather than logarithmic. The **UCB and Thompson rows keep their `$O(\log T)$`** (they genuinely are asymptotically optimal); only the e-greedy row is corrected.

Markdown-only (1 table cell) → no code, no output, no re-exec. **NOT twinned** (no `twin_pairs.d` yaml references `rl_4_multi_armed_bandits`) → single `.ipynb`, no sha rebaseline.

## Verification (firsthand, #8052 lens, L786-2)

- cell[32] output: e-greedy = "Sous-lineaire (borne)", UCB = "O(log T) asymptotique";
- cell[34] output: e-greedy 53.2→1088.2 (diverging) vs UCB 123.9→546.9 (sub-linear);
- cell[36] elem[6] = e-greedy row (source LIST, 15 elems); only elem[6] changed (asserted element-by-element);
- UCB row `| **UCB** | $O(\log T)$ |` and Thompson row `| **Thompson** | $O(\log T)$ |` preserved (asserted pre+post);
- Greedy row ("Sous-linéaire") undisturbed; exactly 1 cell changed across the notebook;
- CR guard passed (LF-only, `eol=lf`; binary stdin `hash-object`, c.1115-L); form detected `indent=1, ensure_ascii=False`; not twinned.

## Scope

1 file (`RL/rl_4_multi_armed_bandits.ipynb`). No source change beyond the 1 table cell.

Found via the #8052 RL Explore sweep (deferred to "next cycle" c.1121); re-verified firsthand (L786-2; c.1087-L grep on exact string) against cell[32]/[34]/[36] committed outputs + Points clés. L898 PR-checked (uncontested: no open PR touches `rl_4_multi_armed_bandits`; disjoint from my open RL PRs #9094/#9105/#9108/#9158/#9159 → rl_13/rl_8/rl_7/rl_11/rl_6e).

See #8052 (semantic-sampling audit, RL slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
