### PR TITLE
fix(search,#8052): Search-2-Uninformed-C# c19 IDDFS "profondeur 3 / 4 itérations" wrong -> depth 2 / 3 itérations (own output Sauts:2; Py twin clean)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb
@@ -1389,7 +1389,7 @@
    "source": [
     "### Interpretation : IDDFS et l'overhead de re-exploration\n",
     "\n",
-    "IDDFS termine quand une DLS atteint le but. Sur Bordeaux -> Strasbourg (but a profondeur 3), il exécute **4 itérations** : DLS(0), DLS(1), DLS(2), DLS(3). Chaque itération re-exploré les niveaux précédents -- c'est l'**overhead** visible dans `NodesExpanded` (somme cumulee des 4 itérations).\n",
+    "IDDFS termine quand une DLS atteint le but. Sur Bordeaux -> Strasbourg (but a profondeur 2), il exécute **3 itérations** : DLS(0), DLS(1), DLS(2). Chaque itération re-exploré les niveaux précédents -- c'est l'**overhead** visible dans `NodesExpanded` (somme cumulee des 3 itérations).\n",
     "\n",
     "**Avantage clé** : la mémoire utilisée par DLS(k) est O(b*k), donc au pire O(b*d) -- bien meilleur que BFS (O(b^d)). Le compromis : un facteur de re-exploration borne par `b/(b-1)` sur un arbre regulier, donc asymptotiquement équivalent a BFS en temps.\n"
    ]

--- a/scripts/notebook_tools/twin_pairs.d/search-2-uninformed.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-2-uninformed.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
+    date: "2026-08-01"
+    by: myia-po-2024:CoursIA-2
     python_sha: a52a0221e059b9823dac05b04f25f81413f7199d
-    csharp_sha: e8a25ef312f51ab75be56de9db60a9819033eb09
+    csharp_sha: b2370d89b77a1eca64d780900798e9b02ba8a06f
+    reason: "c.1123 #8052 C# c19 IDDFS depth/iteration count (profondeur 3->2, 4->3 itérations); Python twin clean (generic d-table)"
   known_differences:
     - "Socle pedagogique commun : BFS (largeur), DFS (profondeur), UCS (cout uniforme), iterative deepening. Exemples : labyrinthe, 8-puzzle, Arrive en Roumanie."
     - "Idiomes framework : Python = `from collections import deque` (BFS FIFO) + `import heapq` (UCS priority queue). C# = `System.Collections.Generic.Queue<T>` (BFS) + `PriorityQueue<TElement, TPriority>` (.NET 6+, UCS) ; recursion via Stack<T> pour DFS."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

COUNT/VALUE defect in `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb` (C#), cell[19] (markdown) — the IDDFS interpretation gets the depth and iteration count wrong:

> `Sur Bordeaux -> Strasbourg (but a profondeur 3), il exécute **4 itérations** : DLS(0), DLS(1), DLS(2), DLS(3). ... (somme cumulee des 4 itérations).`

This contradicts the notebook's **own committed output**. cell[18] (the actual IDDFS run on Bordeaux → Strasbourg) prints:

```
Chemin : Bordeaux -> Paris -> Strasbourg
Cout   : 1075
Sauts  : 2          ← depth 2 (2 edges)
Noeuds explores  : 2
```

The goal is at **depth 2**, not 3. IDDFS terminates when the DLS at the goal's depth finds it → it runs DLS(0), DLS(1), DLS(2) = **3 iterations** (DLS(2) finds it). The cell claims depth 3 and 4 iterations, and lists a phantom DLS(3) that never runs.

## Fix

Three number-claims corrected in cell[19] elem[2]:

```diff
- ... Sur Bordeaux -> Strasbourg (but a profondeur 3), il exécute **4 itérations** : DLS(0), DLS(1), DLS(2), DLS(3). ... (somme cumulee des 4 itérations).
+ ... Sur Bordeaux -> Strasbourg (but a profondeur 2), il exécute **3 itérations** : DLS(0), DLS(1), DLS(2). ... (somme cumulee des 3 itérations).
```

The **Python twin** (`Search-2-Uninformed.ipynb`) is **CLEAN** — it uses a generic `$d$`-parameterised table and never makes this concrete "profondeur 3 / 4 itérations" claim — so this is a **C#-only regression**. Fix C# + rebaseline `csharp_sha` only (`python_sha` preserved).

**Authority (firsthand, L786-2):** own C# committed output cell[18] (`Sauts: 2` → depth 2) + the IDDFS construction (goal at depth d → d+1 iterations). The prose math "somme cumulée des 4 itérations" was doubly wrong — a depth-3 goal is itself 4 iterations, but the goal is depth 2, so 3 iterations is correct on both counts.

## Verification (firsthand, #8052 lens, L786-2)

- cell[18] output: `Sauts : 2` + `Chemin : Bordeaux -> Paris -> Strasbourg` → depth 2;
- cell[19] elem[2]: profondeur 3→2, 4→3 itérations, DLS(3) dropped; **only elem[2] changed** (asserted element-by-element);
- post-edit: no `profondeur 3` or `4 itérations` remains in c19; 1 cell changed across the notebook;
- Python twin: CLEAN (no profondeur-3 / 4-itérations claim) → C#-only;
- yaml: `csharp_sha` `e8a25ef3`→`b2370d89`, `python_sha` `a52a0221` **PRESERVED**, date+by updated, reason added;
- CR guard passed (LF-only, `eol=lf`; binary stdin `hash-object`, c.1115-L); CS form detected `indent=1, ensure_ascii=False`.

## Scope

2 files (`Search-2-Uninformed-Csharp.ipynb` + `search-2-uninformed.yaml`). No source change beyond the 3 number-claims in c19 markdown + `csharp_sha` rebaseline.

Found via the #8052 Search Explore sweep; re-verified firsthand (L786-2; c.1087-L grep on exact strings) against cell[18] output + Python twin. L898 PR-checked (uncontested: no open PR touches `Search-2-Uninformed-Csharp`; my open Search PRs #9131/#9133/#9135/#9136/#9137/#9139/#9140/#9142 touch App-14/App-5/Search-16/Search-11/Search-1/Search-12/Search-9/Search-7 → disjoint).

See #8052 (semantic-sampling audit, Search slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
