### PR TITLE
fix(conway,#8869): reduce 7 Phase-1 microproofs native_decide -> kernel decide

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life.lean
@@ -220,25 +220,25 @@ or `Quot.lift` involved.
 -/
 
 /-- The Block is a still life: `isStillLife block = true`. -/
-theorem block_still_life : isStillLife block = true := by native_decide
+theorem block_still_life : isStillLife block = true := by decide
 
 /-- The Beehive is a still life. -/
-theorem beehive_still_life : isStillLife beehive = true := by native_decide
+theorem beehive_still_life : isStillLife beehive = true := by decide
 
 /-- The horizontal Blinker oscillates with period 2. -/
-theorem blinker_period_two : isOscillator blinker_h 2 = true := by native_decide
+theorem blinker_period_two : isOscillator blinker_h 2 = true := by decide
 
 /-- One step turns the horizontal Blinker into the vertical Blinker. -/
-theorem blinker_step : (step blinker_h == blinker_v) = true := by native_decide
+theorem blinker_step : (step blinker_h == blinker_v) = true := by decide
 
 /-- The Toad oscillates with period 2. -/
-theorem toad_period_two : isOscillator toad 2 = true := by native_decide
+theorem toad_period_two : isOscillator toad 2 = true := by decide
 
 /-- The Beacon oscillates with period 2. -/
-theorem beacon_period_two : isOscillator beacon 2 = true := by native_decide
+theorem beacon_period_two : isOscillator beacon 2 = true := by decide
 
 /-- The Glider is a spaceship of period 4, displacement `(1, -1)`. -/
-theorem glider_spaceship : isSpaceship glider 4 (1, -1) = true := by native_decide
+theorem glider_spaceship : isSpaceship glider 4 (1, -1) = true := by decide
 
 end Life
 end Conway


### PR DESCRIPTION
Grain: LEAN/native_decide-reduction -- lane myia-po-2023:CoursIA -- prev: LEAN/native_decide-reduction #8981

# Reduce 7 Phase-1 microproofs `native_decide` -> kernel `decide` (#8869 critère 2)

Follows up on #8895 (mergeSort -> insertionSort swap, merged) which made `sortDedup` decide-reducible. This PR converts the 7 Phase-1 microproofs in `Conway/Life.lean` from `:= by native_decide` to `:= by decide`:

| Line | Theorem | Before | After |
|------|---------|--------|-------|
| 223 | `block_still_life` | `native_decide` | `decide` |
| 226 | `beehive_still_life` | `native_decide` | `decide` |
| 229 | `blinker_period_two` | `native_decide` | `decide` |
| 232 | `blinker_step` | `native_decide` | `decide` |
| 235 | `toad_period_two` | `native_decide` | `decide` |
| 238 | `beacon_period_two` | `native_decide` | `decide` |
| 241 | `glider_spaceship` | `native_decide` | `decide` |

Diff is 7 insertions / 7 deletions, **tactic-only** — no `def`/signature touched.

## Lean PR discipline §B checklist

**1. `grep -c sorry` avant/après (`Conway/Life.lean`) :**
- Avant : 0
- Après : 0
- No regression (no `sorry` introduced).

**2. Lake build SUCCESS :**
- **Local proof (insertionSort-equivalent probe):** The shared tree sits on the stale `po2023-main-sync` branch (= `mergeSort`, pre-#8895), so I could not run `lake build` against the *real* `insertionSort` `Life.lean` directly. Instead I ran a faithful probe (`ProbeAllPatterns.lean`, scratch, deleted after) that imports `Conway.Life` (for `block`/`beehive`/`blinker_h`/`blinker_v`/`toad`/`beacon`/`glider`/`candidates`/`aliveNext`/`lexLe`) and redefines `sortDedup' := (List.insertionSort (fun a b => lexLe a b = true) l).dedup` — **a byte-exact copy of origin/main L135** — plus `step'`/`evolve'`/`isStillLife'`/`isOscillator'`/`isSpaceship'` identical to `Life.lean`. All 7 `example ... := by decide` **PASS, exit 0, ~12s**. Since `sortDedup'` is identical to origin/main's `sortDedup`, this is a faithful proof that the 7 theorems reduce under kernel `decide` once `sortDedup = insertionSort`.
- **`lake build Conway.Life` on origin/main (worktree `D:/Dev/CoursIA-conway-pr1080`): BLOCKER this cycle.** Lean attempts `git clone mathlib` (`.lake/packages/mathlib` not satisfiable from shared cache: junction -> git-conflict `invalid index-pack`; physical robocopy `/MIR` copy -> lake still tries `git fetch`, same `fetch-pack: invalid index-pack`). Network-side clone failure, not a code defect.
- **CI `lean-conway.yml`** will validate the real origin/main build. Requesting coordinator (ai-01) revalidation against a warm Lean cache before merge (lean-merge-discipline §1 HARD: `lake build Conway.Life` local before merge).

**3. Proof integrity (axiom check):** `decide` synthesizes the `Decidable` instance for `Bool`-equality — no new axioms, no `sorry`. `native_decide` removal can only *strengthen* proof trust (kernel-checked vs native-evaluated).

**4. No prover-harness refactor** — pure Lean proof-mode change.

## Residual `native_decide` (6 occurrences, all in comments/docstrings)

Lines 20, 63, 159, 186, 216-217 mention `native_decide` in module docs / docstrings describing the original design rationale (Bool predicates + native_decide to avoid Decidable synthesis). They are left intact to keep this PR purely tactic-mechanical; a doc follow-up can reframe the rationale now that kernel `decide` succeeds. None is in executable code (verified by `grep -n`).

## Scope

- `See #8869` (partial — resolves critère 2 for `Life.lean`; `hashlife` module has a deeper `evolve`-calc reduction obstruction, documented in #8869 c.1079, not addressed here).
- Catalogue byte-identical to main (no catalog files touched).

— myia-po-2023:CoursIA, Lean relay (see #8869 c.60 ai-01 greenlight Option 4, c.1079 discriminant measurement).