### PR TITLE
enrich(sc,#2161): SC-0-Cypherpunk add signature-verification exercise (4th, re-exec)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-0-Cypherpunk-Origins.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-0-Cypherpunk-Origins.ipynb
@@ -5,10 +5,10 @@
    "id": "header",
    "metadata": {
     "papermill": {
-     "duration": 0.005513,
-     "end_time": "2026-06-03T07:40:00.957156+00:00",
+     "duration": 0.008528,
+     "end_time": "2026-08-01T15:32:52.825901",
      "exception": false,
-     "start_time": "2026-06-03T07:40:00.951643+00:00",
+     "start_time": "2026-08-01T15:32:52.817373",
      "status": "completed"
     },
     "tags": []
@@ -42,10 +42,10 @@
    "id": "cypherpunk-manifesto",
    "metadata": {
     "papermill": {
-     "duration": 0.003679,
-     "end_time": "2026-06-03T07:40:00.964577+00:00",
+     "duration": 0.002962,
+     "end_time": "2026-08-01T15:32:52.847476",
      "exception": false,
-     "start_time": "2026-06-03T07:40:00.960898+00:00",
+     "start_time": "2026-08-01T15:32:52.844514",
      "status": "completed"
     },
     "tags": []
@@ -83,16 +83,16 @@
    "id": "filiation-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:40:00.972920Z",
-     "iopub.status.busy": "2026-06-03T07:40:00.972725Z",
-     "iopub.status.idle": "2026-06-03T07:40:00.979543Z",
-     "shell.execute_reply": "2026-06-03T07:40:00.978519Z"
+     "iopub.execute_input": "2026-08-01T15:32:52.854041Z",
+     "iopub.status.busy": "2026-08-01T15:32:52.853838Z",
+     "iopub.status.idle": "2026-08-01T15:32:52.860555Z",
+     "shell.execute_reply": "2026-08-01T15:32:52.860021Z"
     },
     "papermill": {
-     "duration": 0.011957,
-     "end_time": "2026-06-03T07:40:00.980209+00:00",
+     "duration": 0.011063,
+     "end_time": "2026-08-01T15:32:52.861376",
      "exception": false,
-     "start_time": "2026-06-03T07:40:00.968252+00:00",
+     "start_time": "2026-08-01T15:32:52.850313",
      "status": "completed"
     },
     "tags": []
@@ -157,10 +157,10 @@
    "id": "filiation-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.003049,
-     "end_time": "2026-06-03T07:40:00.986277+00:00",
+     "duration": 0.00263,
+     "end_time": "2026-08-01T15:32:52.866887",
      "exception": false,
-     "start_time": "2026-06-03T07:40:00.983228+00:00",
+     "start_time": "2026-08-01T15:32:52.864257",
      "status": "completed"
     },
     "tags": []
@@ -180,10 +180,10 @@
    "id": "hash-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002915,
-     "end_time": "2026-06-03T07:40:00.992040+00:00",
+     "duration": 0.002372,
+     "end_time": "2026-08-01T15:32:52.871885",
      "exception": false,
-     "start_time": "2026-06-03T07:40:00.989125+00:00",
+     "start_time": "2026-08-01T15:32:52.869513",
      "status": "completed"
     },
     "tags": []
@@ -209,16 +209,16 @@
    "id": "hash-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:40:00.998757Z",
-     "iopub.status.busy": "2026-06-03T07:40:00.998565Z",
-     "iopub.status.idle": "2026-06-03T07:40:01.003269Z",
-     "shell.execute_reply": "2026-06-03T07:40:01.002656Z"
+     "iopub.execute_input": "2026-08-01T15:32:52.878137Z",
+     "iopub.status.busy": "2026-08-01T15:32:52.877742Z",
+     "iopub.status.idle": "2026-08-01T15:32:52.881485Z",
+     "shell.execute_reply": "2026-08-01T15:32:52.881141Z"
     },
     "papermill": {
-     "duration": 0.009036,
-     "end_time": "2026-06-03T07:40:01.003879+00:00",
+     "duration": 0.007931,
+     "end_time": "2026-08-01T15:32:52.882317",
      "exception": false,
-     "start_time": "2026-06-03T07:40:00.994843+00:00",
+     "start_time": "2026-08-01T15:32:52.874386",
      "status": "completed"
     },
     "tags": []
@@ -269,10 +269,10 @@
    "id": "hash-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.002805,
-     "end_time": "2026-06-03T07:40:01.009738+00:00",
+     "duration": 0.002483,
+     "end_time": "2026-08-01T15:32:52.887616",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.006933+00:00",
+     "start_time": "2026-08-01T15:32:52.885133",
      "status": "completed"
     },
     "tags": []
@@ -295,10 +295,10 @@
    "id": "880f1c6f",
    "metadata": {
     "papermill": {
-     "duration": 0.002673,
-     "end_time": "2026-06-03T07:40:01.015184+00:00",
+     "duration": 0.002502,
+     "end_time": "2026-08-01T15:32:52.892563",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.012511+00:00",
+     "start_time": "2026-08-01T15:32:52.890061",
      "status": "completed"
     },
     "tags": []
@@ -325,16 +325,16 @@
    "id": "288c78b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:40:01.021688Z",
-     "iopub.status.busy": "2026-06-03T07:40:01.021505Z",
-     "iopub.status.idle": "2026-06-03T07:40:01.024830Z",
-     "shell.execute_reply": "2026-06-03T07:40:01.024308Z"
+     "iopub.execute_input": "2026-08-01T15:32:52.899749Z",
+     "iopub.status.busy": "2026-08-01T15:32:52.899447Z",
+     "iopub.status.idle": "2026-08-01T15:32:52.902553Z",
+     "shell.execute_reply": "2026-08-01T15:32:52.902235Z"
     },
     "papermill": {
-     "duration": 0.007637,
-     "end_time": "2026-06-03T07:40:01.025572+00:00",
+     "duration": 0.006787,
+     "end_time": "2026-08-01T15:32:52.903118",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.017935+00:00",
+     "start_time": "2026-08-01T15:32:52.896331",
      "status": "completed"
     },
     "tags": []
@@ -375,10 +375,10 @@
    "id": "chain-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002529,
-     "end_time": "2026-06-03T07:40:01.030688+00:00",
+     "duration": 0.002465,
+     "end_time": "2026-08-01T15:32:52.908189",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.028159+00:00",
+     "start_time": "2026-08-01T15:32:52.905724",
      "status": "completed"
     },
     "tags": []
@@ -402,16 +402,16 @@
    "id": "chain-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:40:01.037421Z",
-     "iopub.status.busy": "2026-06-03T07:40:01.037243Z",
-     "iopub.status.idle": "2026-06-03T07:40:01.042109Z",
-     "shell.execute_reply": "2026-06-03T07:40:01.041462Z"
+     "iopub.execute_input": "2026-08-01T15:32:52.914588Z",
+     "iopub.status.busy": "2026-08-01T15:32:52.914420Z",
+     "iopub.status.idle": "2026-08-01T15:32:52.919270Z",
+     "shell.execute_reply": "2026-08-01T15:32:52.918869Z"
     },
     "papermill": {
-     "duration": 0.009345,
-     "end_time": "2026-06-03T07:40:01.042683+00:00",
+     "duration": 0.00901,
+     "end_time": "2026-08-01T15:32:52.919877",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.033338+00:00",
+     "start_time": "2026-08-01T15:32:52.910867",
      "status": "completed"
     },
     "tags": []
@@ -424,20 +424,20 @@
       "MINI-BLOCKCHAIN (4 blocs)\n",
       "======================================================================\n",
       "Bloc 0 : Bloc Genesis\n",
-      "  Hash     : 43161fda8648c3aae1130fe3c6742878...\n",
+      "  Hash     : 772a18cdb54c4f7ed863e5a6eb30136e...\n",
       "  Prev     : 00000000000000000000000000000000...\n",
       "\n",
       "Bloc 1 : Alice envoie 10 BTC a Bob\n",
-      "  Hash     : 3b0b24b8f44451ef5ef068287fc878a2...\n",
-      "  Prev     : 43161fda8648c3aae1130fe3c6742878...\n",
+      "  Hash     : f588d68b5d22b8bee5606f4bd3fa7137...\n",
+      "  Prev     : 772a18cdb54c4f7ed863e5a6eb30136e...\n",
       "\n",
       "Bloc 2 : Bob envoie 5 BTC a Charlie\n",
-      "  Hash     : 72423393d8101157b74ee8a28006accc...\n",
-      "  Prev     : 3b0b24b8f44451ef5ef068287fc878a2...\n",
+      "  Hash     : 3cebe538b85ec801d62ccc617fc46fae...\n",
+      "  Prev     : f588d68b5d22b8bee5606f4bd3fa7137...\n",
       "\n",
       "Bloc 3 : Charlie envoie 2 BTC a Dave\n",
-      "  Hash     : 1f15925e404d668431f5b74c46afe025...\n",
-      "  Prev     : 72423393d8101157b74ee8a28006accc...\n",
+      "  Hash     : ba627c14989df6735a38b41aedbe1880...\n",
+      "  Prev     : 3cebe538b85ec801d62ccc617fc46fae...\n",
       "\n"
      ]
     }
@@ -481,10 +481,10 @@
    "id": "ycu6xb9a2k",
    "metadata": {
     "papermill": {
-     "duration": 0.003016,
-     "end_time": "2026-06-03T07:40:01.048852+00:00",
+     "duration": 0.002658,
+     "end_time": "2026-08-01T15:32:52.925150",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.045836+00:00",
+     "start_time": "2026-08-01T15:32:52.922492",
      "status": "completed"
     },
     "tags": []
@@ -499,16 +499,16 @@
    "id": "tamper-detection",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:40:01.056301Z",
-     "iopub.status.busy": "2026-06-03T07:40:01.056024Z",
-     "iopub.status.idle": "2026-06-03T07:40:01.061503Z",
-     "shell.execute_reply": "2026-06-03T07:40:01.060829Z"
+     "iopub.execute_input": "2026-08-01T15:32:52.931915Z",
+     "iopub.status.busy": "2026-08-01T15:32:52.931711Z",
+     "iopub.status.idle": "2026-08-01T15:32:52.936436Z",
+     "shell.execute_reply": "2026-08-01T15:32:52.936111Z"
     },
     "papermill": {
-     "duration": 0.010052,
-     "end_time": "2026-06-03T07:40:01.062029+00:00",
+     "duration": 0.009366,
+     "end_time": "2026-08-01T15:32:52.937068",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.051977+00:00",
+     "start_time": "2026-08-01T15:32:52.927702",
      "status": "completed"
     },
     "tags": []
@@ -523,14 +523,14 @@
       "Bloc 1 original : 'Alice envoie 10 BTC a Bob'\n",
       "Bloc 1 modifie  : 'Alice envoie 1000 BTC a Bob'\n",
       "\n",
-      "Hash original   : 3b0b24b8f44451ef5ef068287fc878a2aac6c1d1...\n",
-      "Hash recalcule  : 0e6acb4c28a793760b5fcee7618e0d2c54508ad7...\n",
+      "Hash original   : f588d68b5d22b8bee5606f4bd3fa71375d32e170...\n",
+      "Hash recalcule  : b48db6c35a2f0e5f35e26a9f63f77d9971bb831d...\n",
       "\n",
       "VERIFICATION DE LA CHAINE :\n",
       "  Bloc 1 -> previous_hash OK\n",
       "  Bloc 2 -> previous_hash INVALIDE\n",
-      "    Attendu : 0e6acb4c28a793760b5fcee7618e0d2c...\n",
-      "    Trouve  : 3b0b24b8f44451ef5ef068287fc878a2...\n",
+      "    Attendu : b48db6c35a2f0e5f35e26a9f63f77d99...\n",
+      "    Trouve  : f588d68b5d22b8bee5606f4bd3fa7137...\n",
       "  Bloc 3 -> previous_hash OK\n",
       "\n",
       "-> Le bloc 2 pointe vers l'ancien hash du bloc 1 : la fraude est detectee !\n",
@@ -586,10 +586,10 @@
    "id": "chain-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.003146,
-     "end_time": "2026-06-03T07:40:01.068198+00:00",
+     "duration": 0.003078,
+     "end_time": "2026-08-01T15:32:52.942976",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.065052+00:00",
+     "start_time": "2026-08-01T15:32:52.939898",
      "status": "completed"
     },
     "tags": []
@@ -610,10 +610,10 @@
    "id": "merkle-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002895,
-     "end_time": "2026-06-03T07:40:01.074328+00:00",
+     "duration": 0.00257,
+     "end_time": "2026-08-01T15:32:52.948604",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.071433+00:00",
+     "start_time": "2026-08-01T15:32:52.946034",
      "status": "completed"
     },
     "tags": []
@@ -652,16 +652,16 @@
    "id": "merkle-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:40:01.083579Z",
-     "iopub.status.busy": "2026-06-03T07:40:01.083113Z",
-     "iopub.status.idle": "2026-06-03T07:40:01.089779Z",
-     "shell.execute_reply": "2026-06-03T07:40:01.089142Z"
+     "iopub.execute_input": "2026-08-01T15:32:52.955054Z",
+     "iopub.status.busy": "2026-08-01T15:32:52.954602Z",
+     "iopub.status.idle": "2026-08-01T15:32:52.959725Z",
+     "shell.execute_reply": "2026-08-01T15:32:52.959383Z"
     },
     "papermill": {
-     "duration": 0.011358,
-     "end_time": "2026-06-03T07:40:01.090407+00:00",
+     "duration": 0.008895,
+     "end_time": "2026-08-01T15:32:52.960338",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.079049+00:00",
+     "start_time": "2026-08-01T15:32:52.951443",
      "status": "completed"
     },
     "tags": []
@@ -755,10 +755,10 @@
    "id": "ksp2wjxkt8",
    "metadata": {
     "papermill": {
-     "duration": 0.003045,
-     "end_time": "2026-06-03T07:40:01.096608+00:00",
+     "duration": 0.002604,
+     "end_time": "2026-08-01T15:32:52.965718",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.093563+00:00",
+     "start_time": "2026-08-01T15:32:52.963114",
      "status": "completed"
     },
     "tags": []
@@ -773,16 +773,16 @@
    "id": "merkle-proof",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:40:01.103958Z",
-     "iopub.status.busy": "2026-06-03T07:40:01.103770Z",
-     "iopub.status.idle": "2026-06-03T07:40:01.109471Z",
-     "shell.execute_reply": "2026-06-03T07:40:01.108908Z"
+     "iopub.execute_input": "2026-08-01T15:32:52.972200Z",
+     "iopub.status.busy": "2026-08-01T15:32:52.972021Z",
+     "iopub.status.idle": "2026-08-01T15:32:52.977007Z",
+     "shell.execute_reply": "2026-08-01T15:32:52.976632Z"
     },
     "papermill": {
-     "duration": 0.010424,
-     "end_time": "2026-06-03T07:40:01.110029+00:00",
+     "duration": 0.009176,
+     "end_time": "2026-08-01T15:32:52.977687",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.099605+00:00",
+     "start_time": "2026-08-01T15:32:52.968511",
      "status": "completed"
     },
     "tags": []
@@ -855,10 +855,10 @@
    "id": "merkle-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.002916,
-     "end_time": "2026-06-03T07:40:01.115911+00:00",
+     "duration": 0.002595,
+     "end_time": "2026-08-01T15:32:52.982989",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.112995+00:00",
+     "start_time": "2026-08-01T15:32:52.980394",
      "status": "completed"
     },
     "tags": []
@@ -884,10 +884,10 @@
    "id": "pow-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.003053,
-     "end_time": "2026-06-03T07:40:01.122120+00:00",
+     "duration": 0.002707,
+     "end_time": "2026-08-01T15:32:52.988515",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.119067+00:00",
+     "start_time": "2026-08-01T15:32:52.985808",
      "status": "completed"
     },
     "tags": []
@@ -914,16 +914,16 @@
    "id": "pow-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:40:01.129398Z",
-     "iopub.status.busy": "2026-06-03T07:40:01.129154Z",
-     "iopub.status.idle": "2026-06-03T07:40:01.310391Z",
-     "shell.execute_reply": "2026-06-03T07:40:01.309805Z"
+     "iopub.execute_input": "2026-08-01T15:32:52.994671Z",
+     "iopub.status.busy": "2026-08-01T15:32:52.994498Z",
+     "iopub.status.idle": "2026-08-01T15:32:53.159256Z",
+     "shell.execute_reply": "2026-08-01T15:32:53.158693Z"
     },
     "papermill": {
-     "duration": 0.185507,
-     "end_time": "2026-06-03T07:40:01.310841+00:00",
+     "duration": 0.169388,
+     "end_time": "2026-08-01T15:32:53.160563",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.125334+00:00",
+     "start_time": "2026-08-01T15:32:52.991175",
      "status": "completed"
     },
     "tags": []
@@ -958,7 +958,7 @@
       "Difficulte 4 (cible: 0000xxxx) :\n",
       "  Nonce    :     39,430\n",
       "  Hash     : 000034fef981e1dc59961bd97dcd6c69...\n",
-      "  Temps    : 0.0273s\n",
+      "  Temps    : 0.0241s\n",
       "  Essais   : ~39,430 (theorique: ~65,536)\n",
       "\n"
      ]
@@ -967,17 +967,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Difficulte 5 (cible: 00000xxx) :"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "Difficulte 5 (cible: 00000xxx) :\n",
       "  Nonce    :    214,484\n",
       "  Hash     : 00000bb794a36ce9ac55025613a1a499...\n",
-      "  Temps    : 0.1483s\n",
+      "  Temps    : 0.1357s\n",
       "  Essais   : ~214,484 (theorique: ~1,048,576)\n",
       "\n"
      ]
@@ -1022,10 +1015,10 @@
    "id": "pow-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.002827,
-     "end_time": "2026-06-03T07:40:01.316685+00:00",
+     "duration": 0.005775,
+     "end_time": "2026-08-01T15:32:53.169799",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.313858+00:00",
+     "start_time": "2026-08-01T15:32:53.164024",
      "status": "completed"
     },
     "tags": []
@@ -1055,10 +1048,10 @@
    "id": "d62f7b61",
    "metadata": {
     "papermill": {
-     "duration": 0.011811,
-     "end_time": "2026-06-03T07:40:01.331349+00:00",
+     "duration": 0.004286,
+     "end_time": "2026-08-01T15:32:53.178009",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.319538+00:00",
+     "start_time": "2026-08-01T15:32:53.173723",
      "status": "completed"
     },
     "tags": []
@@ -1080,16 +1073,16 @@
    "id": "a9882e7f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:40:01.345630Z",
-     "iopub.status.busy": "2026-06-03T07:40:01.345335Z",
-     "iopub.status.idle": "2026-06-03T07:40:01.350340Z",
-     "shell.execute_reply": "2026-06-03T07:40:01.349215Z"
+     "iopub.execute_input": "2026-08-01T15:32:53.185715Z",
+     "iopub.status.busy": "2026-08-01T15:32:53.185420Z",
+     "iopub.status.idle": "2026-08-01T15:32:53.189448Z",
+     "shell.execute_reply": "2026-08-01T15:32:53.188815Z"
     },
     "papermill": {
-     "duration": 0.012757,
-     "end_time": "2026-06-03T07:40:01.351403+00:00",
+     "duration": 0.009475,
+     "end_time": "2026-08-01T15:32:53.190796",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.338646+00:00",
+     "start_time": "2026-08-01T15:32:53.181321",
      "status": "completed"
     },
     "tags": []
@@ -1126,10 +1119,10 @@
    "id": "sig-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.003354,
-     "end_time": "2026-06-03T07:40:01.359223+00:00",
+     "duration": 0.006138,
+     "end_time": "2026-08-01T15:32:53.203070",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.355869+00:00",
+     "start_time": "2026-08-01T15:32:53.196932",
      "status": "completed"
     },
     "tags": []
@@ -1156,16 +1149,16 @@
    "id": "sig-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:40:01.365486Z",
-     "iopub.status.busy": "2026-06-03T07:40:01.365336Z",
-     "iopub.status.idle": "2026-06-03T07:40:01.441649Z",
-     "shell.execute_reply": "2026-06-03T07:40:01.441042Z"
+     "iopub.execute_input": "2026-08-01T15:32:53.216224Z",
+     "iopub.status.busy": "2026-08-01T15:32:53.215834Z",
+     "iopub.status.idle": "2026-08-01T15:32:53.274886Z",
+     "shell.execute_reply": "2026-08-01T15:32:53.274449Z"
     },
     "papermill": {
-     "duration": 0.080088,
-     "end_time": "2026-06-03T07:40:01.442075+00:00",
+     "duration": 0.068646,
+     "end_time": "2026-08-01T15:32:53.276374",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.361987+00:00",
+     "start_time": "2026-08-01T15:32:53.207728",
      "status": "completed"
     },
     "tags": []
@@ -1177,12 +1170,12 @@
      "text": [
       "SIGNATURES NUMERIQUES (Courbes Elliptiques)\n",
       "======================================================================\n",
-      "Cle privee (secret) : 0x53afde1f5ba8f9014f05775064bec6...\n",
-      "Cle publique X      : 0x7becc8b3eb702f18f5a6f4165b699f...\n",
-      "Cle publique Y      : 0x5741c182cf88775a246df69150f444...\n",
+      "Cle privee (secret) : 0x8deb01a81e0662fbd021475baf12de...\n",
+      "Cle publique X      : 0xcb9422e58e193429df741a6b1c8d07...\n",
+      "Cle publique Y      : 0x7af6358ddbb94eb5613fabf03363e8...\n",
       "\n",
       "Transaction : Envoyer 1 ETH de 0xAlice a 0xBob\n",
-      "Signature   : 87116ea461c50ecd8d09039e64ad4c3a686deef4af5498bf66751bffc338a53e...\n",
+      "Signature   : 1bafed5f9be62206eb091d4a91726bca3ff80698f7800479138fe53d0e115cc4...\n",
       "Taille      : 64 octets\n",
       "\n",
       "Verification : VALIDE (la transaction est authentique)\n",
@@ -1248,10 +1241,10 @@
    "id": "sig-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.002792,
-     "end_time": "2026-06-03T07:40:01.448008+00:00",
+     "duration": 0.004694,
+     "end_time": "2026-08-01T15:32:53.286391",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.445216+00:00",
+     "start_time": "2026-08-01T15:32:53.281697",
      "status": "completed"
     },
     "tags": []
@@ -1279,13 +1272,97 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c8ed81e3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005349,
+     "end_time": "2026-08-01T15:32:53.297166",
+     "exception": false,
+     "start_time": "2026-08-01T15:32:53.291817",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Vérification de signature (authenticité d'une transaction)\n",
+    "\n",
+    "L'exemple ci-dessus délègue la vérification à `verifier.verify()`, qui **lève une\n",
+    "`ValueError`** si la signature est invalide. En pratique, on préfère une fonction\n",
+    "qui **retourne un booléen** (`True` = authentique, `False` = falsifiée) plutôt\n",
+    "qu'une exception qu'il faut intercepter à chaque appel.\n",
+    "\n",
+    "**Objectif** : implémenter `verifier_signature(cle_publique, message, signature)`\n",
+    "qui renvoie `True` si la signature ECDSA est valide pour ce message et cette clé\n",
+    "publique, `False` sinon.\n",
+    "\n",
+    "**Indice** : encapsuler `DSS.new(cle_publique, 'fips-186-3')\n",
+    ".verify(SHA256.new(message), signature)` dans un bloc `try/except ValueError` —\n",
+    "`verify` lève `ValueError` quand la signature ne correspond pas au message.\n",
+    "\n",
+    "**Étape 1** : créer le vérifieur avec la clé publique et le mode `'fips-186-3'`.\n",
+    "**Étape 2** : appeler `.verify(...)` dans un `try`. **Étape 3** : retourner `True`\n",
+    "si aucune exception n'est levée, `False` si une `ValueError` est interceptée."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "b981be86",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T15:32:53.304654Z",
+     "iopub.status.busy": "2026-08-01T15:32:53.304404Z",
+     "iopub.status.idle": "2026-08-01T15:32:53.308397Z",
+     "shell.execute_reply": "2026-08-01T15:32:53.307880Z"
+    },
+    "papermill": {
+     "duration": 0.009441,
+     "end_time": "2026-08-01T15:32:53.309870",
+     "exception": false,
+     "start_time": "2026-08-01T15:32:53.300429",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice : Verification de signature (retourne un booleen, pas une exception)\n",
+    "# TODO etudiant : implementer verifier_signature qui retourne True/False.\n",
+    "\n",
+    "from Crypto.Hash import SHA256\n",
+    "from Crypto.Signature import DSS\n",
+    "\n",
+    "def verifier_signature(cle_publique, message, signature):\n",
+    "    \"\"\"Vérifier l'authenticité d'un message signé.\n",
+    "\n",
+    "    Retourner True si la signature ECDSA est valide pour\n",
+    "    (cle_publique, message), False sinon. Ne PAS lever d'exception.\n",
+    "    \"\"\"\n",
+    "    # Etape 1 : creer le verifieur avec la cle publique et le mode 'fips-186-3'\n",
+    "    # Etape 2 : appeler .verify(SHA256.new(message), signature) dans un try\n",
+    "    # Etape 3 : retourner True si pas d'exception, False si ValueError\n",
+    "    return False  # TODO etudiant : implementer\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "dht-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.003104,
-     "end_time": "2026-06-03T07:40:01.464725+00:00",
+     "duration": 0.006461,
+     "end_time": "2026-08-01T15:32:53.322858",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.461621+00:00",
+     "start_time": "2026-08-01T15:32:53.316397",
      "status": "completed"
     },
     "tags": []
@@ -1307,20 +1384,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "dht-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:40:01.471043Z",
-     "iopub.status.busy": "2026-06-03T07:40:01.470873Z",
-     "iopub.status.idle": "2026-06-03T07:40:01.475839Z",
-     "shell.execute_reply": "2026-06-03T07:40:01.475273Z"
+     "iopub.execute_input": "2026-08-01T15:32:53.332628Z",
+     "iopub.status.busy": "2026-08-01T15:32:53.332322Z",
+     "iopub.status.idle": "2026-08-01T15:32:53.337480Z",
+     "shell.execute_reply": "2026-08-01T15:32:53.337030Z"
     },
     "papermill": {
-     "duration": 0.008894,
-     "end_time": "2026-06-03T07:40:01.476310+00:00",
+     "duration": 0.012182,
+     "end_time": "2026-08-01T15:32:53.338378",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.467416+00:00",
+     "start_time": "2026-08-01T15:32:53.326196",
      "status": "completed"
     },
     "tags": []
@@ -1393,10 +1470,10 @@
    "id": "tfj33xjo5me",
    "metadata": {
     "papermill": {
-     "duration": 0.00266,
-     "end_time": "2026-06-03T07:40:01.481733+00:00",
+     "duration": 0.002797,
+     "end_time": "2026-08-01T15:32:53.344134",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.479073+00:00",
+     "start_time": "2026-08-01T15:32:53.341337",
      "status": "completed"
     },
     "tags": []
@@ -1407,20 +1484,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "bencode-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:40:01.487938Z",
-     "iopub.status.busy": "2026-06-03T07:40:01.487792Z",
-     "iopub.status.idle": "2026-06-03T07:40:01.492661Z",
-     "shell.execute_reply": "2026-06-03T07:40:01.492213Z"
+     "iopub.execute_input": "2026-08-01T15:32:53.350751Z",
+     "iopub.status.busy": "2026-08-01T15:32:53.350420Z",
+     "iopub.status.idle": "2026-08-01T15:32:53.355605Z",
+     "shell.execute_reply": "2026-08-01T15:32:53.355228Z"
     },
     "papermill": {
-     "duration": 0.008594,
-     "end_time": "2026-06-03T07:40:01.493120+00:00",
+     "duration": 0.009297,
+     "end_time": "2026-08-01T15:32:53.356334",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.484526+00:00",
+     "start_time": "2026-08-01T15:32:53.347037",
      "status": "completed"
     },
     "tags": []
@@ -1491,10 +1568,10 @@
    "id": "dht-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.002869,
-     "end_time": "2026-06-03T07:40:01.498697+00:00",
+     "duration": 0.003062,
+     "end_time": "2026-08-01T15:32:53.362387",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.495828+00:00",
+     "start_time": "2026-08-01T15:32:53.359325",
      "status": "completed"
     },
     "tags": []
@@ -1520,10 +1597,10 @@
    "id": "timeline-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002639,
-     "end_time": "2026-06-03T07:40:01.504317+00:00",
+     "duration": 0.002923,
+     "end_time": "2026-08-01T15:32:53.368227",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.501678+00:00",
+     "start_time": "2026-08-01T15:32:53.365304",
      "status": "completed"
     },
     "tags": []
@@ -1539,20 +1616,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "timeline-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:40:01.510618Z",
-     "iopub.status.busy": "2026-06-03T07:40:01.510456Z",
-     "iopub.status.idle": "2026-06-03T07:40:01.514970Z",
-     "shell.execute_reply": "2026-06-03T07:40:01.514427Z"
+     "iopub.execute_input": "2026-08-01T15:32:53.375629Z",
+     "iopub.status.busy": "2026-08-01T15:32:53.375358Z",
+     "iopub.status.idle": "2026-08-01T15:32:53.380262Z",
+     "shell.execute_reply": "2026-08-01T15:32:53.379853Z"
     },
     "papermill": {
-     "duration": 0.008631,
-     "end_time": "2026-06-03T07:40:01.515573+00:00",
+     "duration": 0.009544,
+     "end_time": "2026-08-01T15:32:53.380861",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.506942+00:00",
+     "start_time": "2026-08-01T15:32:53.371317",
      "status": "completed"
     },
     "tags": []
@@ -1644,10 +1721,10 @@
    "id": "2d4142b6",
    "metadata": {
     "papermill": {
-     "duration": 0.002642,
-     "end_time": "2026-06-03T07:40:01.521013+00:00",
+     "duration": 0.00295,
+     "end_time": "2026-08-01T15:32:53.386818",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.518371+00:00",
+     "start_time": "2026-08-01T15:32:53.383868",
      "status": "completed"
     },
     "tags": []
@@ -1674,10 +1751,10 @@
    "id": "exercise-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002722,
-     "end_time": "2026-06-03T07:40:01.526485+00:00",
+     "duration": 0.00303,
+     "end_time": "2026-08-01T15:32:53.392851",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.523763+00:00",
+     "start_time": "2026-08-01T15:32:53.389821",
      "status": "completed"
     },
     "tags": []
@@ -1692,20 +1769,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "exercise-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:40:01.532768Z",
-     "iopub.status.busy": "2026-06-03T07:40:01.532632Z",
-     "iopub.status.idle": "2026-06-03T07:40:01.535898Z",
-     "shell.execute_reply": "2026-06-03T07:40:01.535521Z"
+     "iopub.execute_input": "2026-08-01T15:32:53.399631Z",
+     "iopub.status.busy": "2026-08-01T15:32:53.399294Z",
+     "iopub.status.idle": "2026-08-01T15:32:53.402938Z",
+     "shell.execute_reply": "2026-08-01T15:32:53.402571Z"
     },
     "papermill": {
-     "duration": 0.007375,
-     "end_time": "2026-06-03T07:40:01.536489+00:00",
+     "duration": 0.007713,
+     "end_time": "2026-08-01T15:32:53.403519",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.529114+00:00",
+     "start_time": "2026-08-01T15:32:53.395806",
      "status": "completed"
     },
     "tags": []
@@ -1758,10 +1835,10 @@
    "id": "summary",
    "metadata": {
     "papermill": {
-     "duration": 0.002671,
-     "end_time": "2026-06-03T07:40:01.541858+00:00",
+     "duration": 0.00293,
+     "end_time": "2026-08-01T15:32:53.409289",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.539187+00:00",
+     "start_time": "2026-08-01T15:32:53.406359",
      "status": "completed"
     },
     "tags": []
@@ -1797,10 +1874,10 @@
    "id": "24b12a75",
    "metadata": {
     "papermill": {
-     "duration": 0.002695,
-     "end_time": "2026-06-03T07:40:01.547221+00:00",
+     "duration": 0.002831,
+     "end_time": "2026-08-01T15:32:53.415226",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.544526+00:00",
+     "start_time": "2026-08-01T15:32:53.412395",
      "status": "completed"
     },
     "tags": []
@@ -1820,10 +1897,10 @@
    "id": "643a6d4d",
    "metadata": {
     "papermill": {
-     "duration": 0.003295,
-     "end_time": "2026-06-03T07:40:01.553494+00:00",
+     "duration": 0.002758,
+     "end_time": "2026-08-01T15:32:53.420765",
      "exception": false,
-     "start_time": "2026-06-03T07:40:01.550199+00:00",
+     "start_time": "2026-08-01T15:32:53.418007",
      "status": "completed"
     },
     "tags": []
@@ -1851,18 +1928,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.913131,
-   "end_time": "2026-06-03T07:40:01.685234+00:00",
+   "duration": 2.839669,
+   "end_time": "2026-08-01T15:32:53.550814",
    "environment_variables": {},
    "exception": null,
-   "input_path": "SC-0-Cypherpunk-Origins.ipynb",
-   "output_path": "SC-0-Cypherpunk-Origins.ipynb",
+   "input_path": "MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-0-Cypherpunk-Origins.ipynb",
+   "output_path": "_sc0_exec.ipynb",
    "parameters": {},
-   "start_time": "2026-06-03T07:39:55.772103+00:00",
+   "start_time": "2026-08-01T15:32:50.711145",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
Grain: DEEP/notebook-enrichment -- lane myia-po-2023:CoursIA -- prev: LEAN/native_decide-reduction #9163

# SC-0-Cypherpunk-Origins : add a 4th exercise on signature verification (#2161)

SmartContracts is an under-touched family this cycle. SC-0 (a foundational Python notebook on the Cypherpunk origins of blockchain) had **3 exercises** (commitment scheme, PoW analyzer, mini-blockchain) but the **ECDSA signature primitive — demonstrated in a worked example (key generation, signing, verification, falsification detection) — was never exercised by the student**. Signatures are arguably THE central Cypherpunk primitive (authenticity, non-repudiation: PGP, Bitcoin transaction authorization), so a focused exercise reinforcing it is genuine pedagogical value, not cosmetic.

## The exercise

Adds, right after the signature worked-example + its interpretation cell, a `### Exercice : Vérification de signature` markdown cell + a code stub:

```python
def verifier_signature(cle_publique, message, signature):
    """Retourner True si la signature ECDSA est valide, False sinon."""
    # Etape 1 : creer le verifieur (cle publique, 'fips-186-3')
    # Etape 2 : .verify(SHA256.new(message), signature) dans un try
    # Etape 3 : True si pas d'exception, False si ValueError
    return False  # TODO etudiant : implementer
```

The worked example delegates verification to `verifier.verify()` which **raises `ValueError`** on a bad signature; the exercise makes the student wrap it into a **boolean-returning** helper (the more practical API). The stub follows the existing exercise pattern (`return False` + `# TODO etudiant` + `# Etape N` + `print("Exercice a completer")`), no `raise NotImplementedError` (C.1).

## Notebook PR checklist (§D)

- **C.1 (no banned patterns):** verified `0 raise NotImplementedError / assert False / 1/0` across the notebook (grep).
- **C.2 (commit WITH outputs):** re-executed end-to-end via **papermill, kernel python3, 42/42 cells, 0 errors, 0 null execution_count**. The new cell carries `execution_count=11` + output `Exercice a completer`.
- **#2161 (≥3 exercises):** SC-0 now has **4 formal exercises** (was 3). Counted by reading cell content (headers `### Exercice` and `## N. Exercice`), not title-only.
- **Anti-regression:** no example/solution stripped, no `sorry`-equivalent. Pure addition (+2 cells).
- **CPU-only, no workaround:** pycryptodome (ECC/DSS) is the real SOTA crypto lib and is installed locally (regle F honored — kernel available, no degraded stub). The notebook imports `Crypto.PublicKey.ECC` / `Crypto.Signature.DSS` guarded by `try/except ImportError` (pre-existing pattern).

## Honest note on re-exec outputs (Stop & Repair, not scrubbing)

The worked-example ECC cell calls `ECC.generate(curve='P-256')`, which is **non-deterministic** — every run produces fresh key material. Re-executing the notebook (required by C.2 after adding code cells) therefore regenerates the committed `Clé privée` / `Clé publique X/Y` / signature hex values. These differ from the previous committed run **by the notebook's own design**, not by hand-editing. No output was scrubbed or hand-fabricated (secrets-hygiene rule 6). The interpretation (signatures guarantee authenticity, falsification is rejected) remains valid.

## Methodological note (G.1 / counting blind-spot)

A read-only scout initially reported SC-0 had "2 exercises". Firsthand verification showed **3**: the third (`## 9. Exercice : Construire une mini-blockchain`) was missed because a number prefix (`9. Exercice`) breaks naive `### Exercice` regex counting — the known `count-exercises-structured-section-false-negative` blind-spot. So this PR is an **enrichment** (3→4, exercising an un-exercised primitive), not a "<3 floor fix". Scope is honest about that.

## Scope

- `See #2161` (contributes to the ≥3-exercises convention; does not close it — rollout is per-family, ongoing).
- Catalogue byte-identical to main (no catalog files touched).
- One notebook, one family, one defect type = atomic.

— myia-po-2023:CoursIA, c.1081. Verified firsthand on origin/main; re-exec papermill SUCCESS.
