### PR TITLE
fix(rl,#8052): rl_6d_sac c28 "alpha decroit naturellement" wrong -> auto-adjustee/fluctue (own c25 trace: alpha rises 0.1558->0.3191 ep100->150)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb
@@ -993,7 +993,7 @@
     "\n",
     "**Points cles** :\n",
     "1. SAC est **off-policy** : il reutilise les expériences passees, donc il apprend plus vite qu'A2C ou PPO\n",
-    "2. La temperature alpha decroit naturellement au fil de l'entrainement (moins besoin d'explorer)\n",
+    "2. La temperature alpha est auto-adjustee par l'agent (elle fluctue au fil de l'entrainement selon le besoin d'exploration, cf. trace Alpha ci-dessus)\n",
     "3. Pendulum-v1 est un problème de contrôle continu : impossible avec DQN pur"
    ]
   },


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

VALUE defect in `MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb` (Python), cell[28] "Points clés" item 2:

> `2. La temperature alpha decroit naturellement au fil de l'entrainement (moins besoin d'explorer)`

This contradicts the notebook's **own committed output**. cell[25] (the SAC training run, 200 episodes) prints the alpha trace:

```
Episode  50/200 | ... | Alpha: 0.2179
Episode 100/200 | ... | Alpha: 0.1558
Episode 150/200 | ... | Alpha: 0.3191   ← RISES from ep100 (more than doubles)
Episode 200/200 | ... | Alpha: 0.0949
```

Alpha is **not monotonically decreasing**: it rises `0.1558 → 0.3191` between episodes 100 and 150, before dropping to 0.0949 by episode 200. So "decroit naturellement au fil de l'entrainement" is factually wrong — the auto-tuned temperature *fluctuates* as the policy's entropy need changes (the whole point of auto-tuned SAC temperature).

The same cell's table (elem[6]) already labels alpha **"Temperature auto-adjustee"** (correct). Fixing point 2 to match that wording + the observed fluctuation makes the cell internally coherent (c.1088-L cross-claim consistency).

## Fix

```diff
- 2. La temperature alpha decroit naturellement au fil de l'entrainement (moins besoin d'explorer)
+ 2. La temperature alpha est auto-adjustee par l'agent (elle fluctue au fil de l'entrainement selon le besoin d'exploration, cf. trace Alpha ci-dessus)
```

The **"Alpha final ~0.1-0.3"** table cell (elem[6]) is **preserved** — 0.0949 ≈ 0.1 rounded, the band holds at its lower bound; not contradicted.

Markdown-only (1 Points-clés bullet) → no code, no output, no re-exec. **NOT twinned** (no `twin_pairs.d` yaml references `rl_6d_sac`) → single `.ipynb`, no sha rebaseline.

**Authority (firsthand, L786-2):** own committed output cell[25] (alpha trace) + own table cell[28] elem[6] ("Temperature auto-adjustee").

## Verification (firsthand, #8052 lens, L786-2)

- cell[25] output: alpha 0.2179/0.1558/**0.3191**/0.0949 (ep 50/100/**150**/200) → non-monotone (rises ep100→150);
- cell[28] elem[11]: only point 2 reworded; source **LIST preserved** (lengths match, no collapse, c.1123-L);
- elem[6] table row `| Alpha final | ~0.1-0.3 | Temperature auto-adjustee |` UNDISTURBED;
- no `decroit naturellement` remains; 1 cell changed across the notebook;
- CR guard passed (LF-only, `eol=lf`; binary stdin `hash-object`, c.1115-L); form detected `indent=1`; not twinned.

## Scope

1 file (`RL/rl_6d_sac_from_scratch.ipynb`). No source change beyond the 1 Points-clés bullet.

Found via the #8052 RL Explore sweep (c.1121, deferred to next cycles); re-verified firsthand (L786-2; c.1087-L grep on exact string) against cell[25] committed alpha trace. L898 PR-checked (uncontested: no open PR touches `rl_6d_sac`; disjoint from my open RL PRs #9094/#9105/#9108/#9158/#9159/#9160 → rl_13/rl_8/rl_7/rl_11/rl_6e/rl_4).

See #8052 (semantic-sampling audit, RL slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
