### PR TITLE
fix(csp,#8052): CSP-9-Distributed c44 stale self-label "Search-18" -> CSP-9-Distributed (C# twin correct)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb
@@ -2641,7 +2641,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Resume Search-18: CSP Distribues ===\n",
+      "=== Resume CSP-9-Distributed: CSP Distribues ===\n",
       "\n",
       "Concepts couverts:\n",
       "1. Formalisation DisCSP (agents, contraintes inter-agent)\n",
@@ -2661,7 +2661,7 @@
    ],
    "source": [
     "# Cellule finale - Resume du notebook\n",
-    "print(\"=== Resume Search-18: CSP Distribues ===\")\n",
+    "print(\"=== Resume CSP-9-Distributed: CSP Distribues ===\")\n",
     "print(\"\")\n",
     "print(\"Concepts couverts:\")\n",
     "print(\"1. Formalisation DisCSP (agents, contraintes inter-agent)\")\n",

--- a/scripts/notebook_tools/twin_pairs.d/csp-9-distributed.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-9-distributed.yaml
@@ -4,9 +4,10 @@
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: 1856a7a0540d7a680e35356a371b1e7fe1cee27d
+    date: "2026-08-01"
+    by: myia-po-2024:CoursIA-2
+    python_sha: adee0d476742b82cc2efb931e778f4fba271be35
+    reason: "c.1125 #8052 Python c44 stale pre-rename self-label Search-18->CSP-9-Distributed (C# twin already correct); print-literal src+out atomic"
     csharp_sha: 8324939a7b714bb232440bac11de6c84c0981a70
   known_differences:
     - "Socle commun : CSP distribue (DisCSP) -- formalisation, ABT (Asynchronous Backtracking, Yokoo 1992), AWC (Asynchronous Weak-Commitment, Yokoo 1995), Privacy-Preserving CSP, application multi-hopital, benchmark synthetique ABT vs AWC. Le C# se declare explicitement 'binome .NET du CSP-9-Distributed.ipynb' (H1) et cite Yokoo 1992."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

IDENTITY defect in `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb` (Python), cell[44] (final resume, code):

> `print("=== Resume Search-18: CSP Distribues ===")`

**"Search-18" is a stale pre-rename self-label.** The notebook is **CSP-9-Distributed** — its own nav (c0) and footer (c46) already use "CSP-9". The **C# twin** (c44) already uses the correct name:

```
Console.WriteLine("=== Resume CSP-9-Distributed : CSP Distribues ===");
```

So this is a **Python-only regression** (C# twin: 0 occurrences of "Search-18"). The fix brings the Python resume label in line with the notebook's actual name and the C# twin.

## Fix

```diff
- print("=== Resume Search-18: CSP Distribues ===")
+ print("=== Resume CSP-9-Distributed: CSP Distribues ===")
```

Source `elem[1]` + committed `output[0]` stream text updated **atomically** (print-literal source+output, c.1077-L). No re-exec, no logic change. Element-level source replace (c.1123-L); source LIST preserved.

**NOT a §D.5 measurement defect** — it's an **identity** defect (a name), no execution drift, so no `## Diagnostic dérive` is due (per coord c.1042 line: identity defects don't require §D.5; only the 8 refused were all `measure` class).

**Authority (firsthand, L786-2):** C# twin c44 committed resume line + own nav c0/c46. No narrative judgment — the defect is a name the twin already corrected.

## Verification (firsthand, #8052 lens, L786-2)

- PY c44 `elem[1]`: 1 occurrence "Search-18" (only element); c44 `output[0]`: 1 occurrence;
- c0 nav + c46 footer already "CSP-9" → c44 isolated regression;
- C# twin: 0 "Search-18", c44 says "CSP-9-Distributed" → **Python-only**;
- only `elem[1]` source changed (element diff); `output[0]` text elem updated; list intact (no collapse);
- no "Search-18" remains in c44 source or output; 1 cell changed across the notebook;
- yaml: `python_sha` 1856a7a0→`adee0d47`, `csharp_sha` 8324939a **PRESERVED**, date+by updated, reason;
- CR guard passed (LF-only, `eol=lf`; binary stdin `hash-object`, c.1115-L); form detected `indent=1`.

## Scope

2 files (`CSP-9-Distributed.ipynb` + `csp-9-distributed.yaml`). No source change beyond the 1 print literal in c44 (source+output) + `python_sha` rebaseline.

**DEFER** c14 "quelques nogoods": qualitative pedagogical prose (order-of-magnitude contrast small→few/large→many), not a hard count claim/print literal (c.1062-L narrative class) — not deterministic, deferred.

Found via the #8052 CSP Explore sweep (c.1124); re-verified firsthand (L786-2; exact-string grep) against C# twin c44 + c0/c46 nav. L898 PR-checked (uncontested: my open CSP PRs #9143/#9145/#9146 touch CSP-5/CSP-3/CSP-7 → disjoint; no open PR touches CSP-9-Distributed).

See #8052 (semantic-sampling audit, CSP slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
