### PR TITLE
fix(csp,#8052): CSP-4-Scheduling-C# exercise+verdict cell-ref off-by-2 (cellule 6/8/10 -> 8/10/12)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling-Csharp.ipynb
@@ -820,7 +820,7 @@
     "| **API Java/.NET** | Pas de friction | Légère friction IKVM (bootstrap, `Task` désambiguïsation) |\n",
     "| **Richesse pédagogique** | Excellente | Excellente (bibliothèque mature, +20 ans) |\n",
     "\n",
-    "**Verdict** : les deux solveurs **modélisent les mêmes problèmes** (JSSP-3×3, RCPSP-6×2×2, Nurse-6×7×3) avec les mêmes contraintes globales (`NoOverlap`/`AddNoOverlap`, `Cumulative`/`AddCumulative`). Sur le **binôme Python** ([CSP-4-Scheduling.ipynb](CSP-4-Scheduling.ipynb)), OR-Tools CP-SAT résout à l'optimal (makespans = 11/10/42). Ce binôme .NET applique les mêmes modèles via Choco-IKVM : l'exécution end-to-end et les valeurs exactes des makespans sont visibles dans les outputs des cellules 6, 8, 10 ci-dessus (sous réserve de la capture iopub — voir [#5005](https://github.com/jsboige/CoursIA/issues/5005))."
+    "**Verdict** : les deux solveurs **modélisent les mêmes problèmes** (JSSP-3×3, RCPSP-6×2×2, Nurse-6×7×3) avec les mêmes contraintes globales (`NoOverlap`/`AddNoOverlap`, `Cumulative`/`AddCumulative`). Sur le **binôme Python** ([CSP-4-Scheduling.ipynb](CSP-4-Scheduling.ipynb)), OR-Tools CP-SAT résout à l'optimal (makespans = 11/10/42). Ce binôme .NET applique les mêmes modèles via Choco-IKVM : l'exécution end-to-end et les valeurs exactes des makespans sont visibles dans les outputs des cellules 8, 10, 12 ci-dessus (sous réserve de la capture iopub — voir [#5005](https://github.com/jsboige/CoursIA/issues/5005))."
    ]
   },
   {
@@ -855,9 +855,9 @@
     }
    ],
    "source": [
-    "// EXERCICE 1 : JSSP avec deadlines (variante du modèle de la cellule 6)\n",
+    "// EXERCICE 1 : JSSP avec deadlines (variante du modèle de la cellule 8)\n",
     "//\n",
-    "// Énoncé : Reprenez le JSSP 3 jobs × 3 machines de la cellule 6 et ajoutez une\n",
+    "// Énoncé : Reprenez le JSSP 3 jobs × 3 machines de la cellule 8 et ajoutez une\n",
     "// **deadline** (date de fin au plus tard) pour chaque job : Job 0 ≤ 10, Job 1 ≤ 12, Job 2 ≤ 8.\n",
     "// Minimisez le **retard maximal** (max_lateness = max(0, completion - deadline)).\n",
     "//\n",
@@ -870,7 +870,7 @@
     "//\n",
     "// Données :\n",
     "//   int[] deadlines = { 10, 12, 8 };\n",
-    "//   jobsData, horizon identiques à la cellule 6.\n",
+    "//   jobsData, horizon identiques à la cellule 8.\n",
     "\n",
     "// Votre code ici\n",
     "Console.WriteLine(\"Exercice à compléter\");"
@@ -898,9 +898,9 @@
     }
    ],
    "source": [
-    "// EXERCICE 2 : RCPSP avec budget (variante du modèle de la cellule 8)\n",
+    "// EXERCICE 2 : RCPSP avec budget (variante du modèle de la cellule 10)\n",
     "//\n",
-    "// Énoncé : Étendez le RCPSP de la cellule 8 avec une **ressource non-renouvelable** :\n",
+    "// Énoncé : Étendez le RCPSP de la cellule 10 avec une **ressource non-renouvelable** :\n",
     "// budget = 14 unités. Chaque tâche a un coût (3, 2, 4, 1, 2, 1 respectivement) ;\n",
     "// la somme des coûts des tâches doit rester ≤ 14. Le makespan reste à minimiser.\n",
     "//\n",
@@ -914,7 +914,7 @@
     "// Données :\n",
     "//   int[] costs = { 3, 2, 4, 1, 2, 1 };  // somme = 13, budget = 14 → 1 unité de marge\n",
     "//   int budget = 14;\n",
-    "//   Reste des paramètres identique à la cellule 8.\n",
+    "//   Reste des paramètres identique à la cellule 10.\n",
     "\n",
     "// Votre code ici\n",
     "Console.WriteLine(\"Exercice à compléter\");"
@@ -942,12 +942,12 @@
     }
    ],
    "source": [
-    "// EXERCICE 3 : Nurse Scheduling avec équilibrage de charge (variante cellule 10)\n",
+    "// EXERCICE 3 : Nurse Scheduling avec équilibrage de charge (variante cellule 12)\n",
     "//\n",
-    "// Énoncé : Modifiez le modèle Nurse de la cellule 10 pour imposer un **équilibrage strict** :\n",
+    "// Énoncé : Modifiez le modèle Nurse de la cellule 12 pour imposer un **équilibrage strict** :\n",
     "//   1. Chaque infirmier doit travailler **au moins 6 shifts** sur la semaine (min_shifts = 6).\n",
     "//   2. Pas plus de **5 jours consécutifs** travaillés (contrainte supplémentaire).\n",
-    "//   3. Continuez à minimiser le total des shifts (= 42 = couverture exacte, comme la cellule 10).\n",
+    "//   3. Continuez à minimiser le total des shifts (= 42 = couverture exacte, comme la cellule 12).\n",
     "//\n",
     "// Indice pour la contrainte \"5 jours consécutifs\" :\n",
     "//   Pour chaque infirmier n et chaque jour d de 0 à 2 (= 7-5) :\n",
@@ -956,7 +956,7 @@
     "//\n",
     "// Données :\n",
     "//   int minShifts = 6;\n",
-    "//   Reste identique à la cellule 10.\n",
+    "//   Reste identique à la cellule 12.\n",
     "\n",
     "// Votre code ici\n",
     "Console.WriteLine(\"Exercice à compléter\");"

--- a/scripts/notebook_tools/twin_pairs.d/csp-4-scheduling.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-4-scheduling.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
+    date: "2026-08-01"
+    by: myia-po-2024:CoursIA-2
     python_sha: 20b459c9021a688c4bb67adc3bbf36c273d6445d
-    csharp_sha: 1e5b22494e86fd48c2c3fcd0c4dbaf4ed3b6d76a
+    csharp_sha: 1453d9a535aaad7d4c4f8d72b9fdff44c9dbbba3
+    reason: "c.1126 #8052 C# c13/15/16/17 exercise+verdict cell-ref off-by-2 (cellule 6/8/10 -> 8/10/12 after OR-Tools config cells inserted); PY twin clean (0 cellule refs)"
   known_differences:
     - "Socle pedagogique commun : interval scheduling + cumulative constraints + disjunctive (no-overlap) + precedence constraints."
     - "Cote C# : Choco-solver via IKVM (Cumulative, Disjunctive, precedence). Cote Python = from-scratch (classe Task avec start/end/duration, propagation par difference constraints)."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**STRUCTURAL cell-reference off-by-2** in `CSP-4-Scheduling-Csharp.ipynb`. The OR-Tools config cells (c5 markdown `## Configuration OR-Tools CP-SAT` + c6 code `#r "nuget: Google.OrTools"`) were inserted, shifting the model code cells from **6/8/10** to **8/10/12**. The exercise stubs and the comparison verdict still cite the OLD numbers:

| cell | type | wrong ref | correct |
|------|------|-----------|---------|
| c13 | markdown verdict | "les outputs des **cellules 6, 8, 10** ci-dessus" | **cellules 8, 10, 12** |
| c15 | EXERCICE 1 JSSP (code comment, ×3) | "**cellule 6**" | **cellule 8** |
| c16 | EXERCICE 2 RCPSP (code comment, ×3) | "**cellule 8**" | **cellule 10** |
| c17 | EXERCICE 3 Nurse (code comment, ×4) | "**cellule 10**" | **cellule 12** |

**Verified firsthand (L786-2):** model code cells are objectively at **c8 (JSSP), c10 (RCPSP), c12 (Nurse)** — the `using Google.OrTools.Sat;` cells under headers `## 1./2./3.` at c7/c9/c11. So every exercise/verdict reference is off by exactly 2.

## Fix

Element-level per-cell replacement (c.1123-L), per-cell scoping (so `6→8` in c15 doesn't bleed into c16's `8→10`):
- c13: `"cellules 6, 8, 10"` → `"cellules 8, 10, 12"` (1 element)
- c15: `"cellule 6"` → `"cellule 8"` (elems 0, 2, 15)
- c16: `"cellule 8"` → `"cellule 10"` (elems 0, 2, 16)
- c17: `"cellule 10"` → `"cellule 12"` (elems 0, 2, 5, 14)

**Scope completeness (c.1088-L):** all sibling cell-ref claims fixed together — leaving c13 at 6/8/10 while fixing c15/16/17 would create a *new* internal inconsistency, so c13 is fixed too.

## Why C#-only

The Python twin (`CSP-4-Scheduling.ipynb`, 43 cells) has **ZERO "cellule" references** — it uses markdown exercise sections (`### Exercice 1/2/3`) with prose, no cell-number refs. → rebaseline `csharp_sha` only, `python_sha` preserved.

The references live in code **comments** (c15/16/17) and markdown prose (c13) → **0 output change, 0 re-exec** (stub outputs are just `"Exercice à compléter"`). Structural cell-ref renumbering, not a re-exec-mutable measurement → **no §D.5 diagnostic** (coord c.1042: structural/identity ≠ measure).

**Authority (firsthand, L786-2):** own committed model cells c8/c10/c12 (headers c7/c9/c11) + Python twin (0 "cellule" refs). No narrative judgment — the cells are objectively at 8/10/12.

## Verification (firsthand, #8052 lens, L786-2)

- model code cells: JSSP=c8, RCPSP=c10, Nurse=c12 (headers c7/c9/c11);
- c13 composite ref fixed (1 elem); c15 ×3, c16 ×3, c17 ×4 — element-level, list lengths preserved (no collapse);
- **"cellule 6" = 0 occurrences** across the notebook after fix; outputs of c13/15/16/17 UNCHANGED;
- 4 cells changed exactly; PY twin: 0 "cellule" refs → C#-only;
- yaml: `csharp_sha` 1e5b2249→`1453d9a5`, `python_sha` 20b459c9 **PRESERVED**, date+by updated, reason;
- CR guard passed (LF-only, `eol=lf`; binary stdin `hash-object`, c.1115-L); form detected `indent=1`.

## Scope

2 files (`CSP-4-Scheduling-Csharp.ipynb` + `csp-4-scheduling.yaml`). No source change beyond the cellule number refs in c13/15/16/17 (comments+prose) + `csharp_sha` rebaseline.

Found via the #8052 CSP Explore sweep (c.1124 catalog S1); re-verified firsthand (L786-2; exact-string + structural map) against model cells c8/c10/c12 + Python twin. L898 PR-checked (uncontested: my open CSP PRs #9143/#9145/#9146/#9167/#9168 = CSP-5/3/7/8/9 → disjoint; no open PR touches CSP-4).

See #8052 (semantic-sampling audit, CSP slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
