### PR TITLE
fix(csp,#8052): CSP-6-Hybridization Py c35 phantom class "DynamicPortfolio" -> "comparaison de stratégies (solve_task_graph)"

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb
@@ -1915,7 +1915,7 @@
     "5. Activity-based\n",
     "\n",
     "**Consignes** :\n",
-    "1. Inspirez-vous du DynamicPortfolio de l'exemple ci-dessus\n",
+    "1. Inspirez-vous de la comparaison de stratégies de l'exemple ci-dessus (solve_task_graph)\n",
     "2. Ajoutez un paramètre `base_timeout` qui double après chaque echec\n",
     "3. Mesurez et affichez le temps passe dans chaque stratégie\n"
    ]

--- a/scripts/notebook_tools/twin_pairs.d/csp-6-hybridization.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-6-hybridization.yaml
@@ -4,9 +4,10 @@
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: e5664cf24396bd2f82fc0f1c788d0b30db9f3686
+    date: "2026-08-01"
+    by: myia-po-2024:CoursIA-2
+    python_sha: c768174f8ed98eb7efdd282081b21d2306b38a02
+    reason: "c.1128 #8052 Python c35 phantom class name DynamicPortfolio->comparaison de stratégies (solve_task_graph); 0 code occurrences; C# twin preserved"
     csharp_sha: d35a6e6262a3a2ac3e8837315c5b365d5ec95aff
   known_differences:
     - "Socle pedagogique commun : approches hybrides modernes en CP -- Lazy Clause Generation (LCG), architecture CP-SAT (CP + SAT + CDCL), hybridation CP + ML (prediction de faisabilite), integration LLM + CSP."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**Phantom class-name defect** in `CSP-6-Hybridization.ipynb` (Python), cell[35] (Exercice 3b markdown), `elem[14]`:

```
1. Inspirez-vous du DynamicPortfolio de l'exemple ci-dessus
```

**"DynamicPortfolio" is a phantom** — it appears **0 times** in the notebook's code. The "exemple ci-dessus" = cell[33] (Exemple guide 3 md) + cell[34] (code). cell[34] defines `solve_task_graph()` with a `strategies_to_test` list of **3 strategies** compared in a loop (matching c35's "5 stratégies au lieu de 3"). There is **no DynamicPortfolio class** — c34's construct is a strategy **comparison**, not a portfolio class. A student following the hint would search for `DynamicPortfolio` and find nothing.

The **C# twin's** equivalent exercise (CS c34) uses a **generic** reference — "Etendez l'exemple portefeuille précédent" (no phantom class) — because the C# guide-3 (CS c32/c33) **is** a genuine portfolio ("Exemple guide 3 : Portfolio de stratégies CP-SAT"). In PY, guide-3 (c33/c34) is a task-graph + strategy comparison, so the phantom `DynamicPortfolio` leaked from a C#-style assumption that a portfolio class exists above.

## Fix

Remove the phantom class name; refer to what c34 **actually** is, grounded in the real function name to prevent re-phantoming:

```diff
- 1. Inspirez-vous du DynamicPortfolio de l'exemple ci-dessus
+ 1. Inspirez-vous de la comparaison de stratégies de l'exemple ci-dessus (solve_task_graph)
```

"comparaison de stratégies" = exactly what c34's `strategies_to_test` loop does (compares 3 CP-SAT strategies: Defaut/Linearisation/Plus de travail), and c35 extends it to 5.

## Why Py-only

Authority = own PY c34 code (`solve_task_graph` + `strategies_to_test`; **0** `DynamicPortfolio`). The C# twin is **preserved** — its guide-3 is a genuine portfolio (different content), and it already uses a generic reference with no phantom. → rebaseline `python_sha` only, `csharp_sha` preserved.

markdown-only → no re-exec. Structural/phantom-name, not a re-exec-mutable measurement → **no §D.5 diagnostic** (coord c.1042: structural ≠ measure).

**Authority (firsthand, L786-2):** own PY c34 code (no `DynamicPortfolio`; IS `solve_task_graph` with `strategies_to_test`) + c35 "5 stratégies au lieu de 3" (matches c34's 3) + C# twin generic reference.

## Verification (firsthand, #8052 lens, L786-2)

- `DynamicPortfolio` = **0 occurrences** in code cells; the only notebook-wide occurrence was c35 `elem[14]` (the phantom ref);
- c34 defines `solve_task_graph()` with `strategies_to_test` (3 strategies);
- only c35 `elem[14]` changed (element diff); source list length-preserved (no collapse);
- `DynamicPortfolio` now **0 occurrences** notebook-wide; new anchor `solve_task_graph` present; 1 cell changed exactly;
- C# twin preserved (`d35a6e62`) — its guide-3 is a genuine portfolio, different content;
- yaml: `python_sha` e5664cf2→`c768174f`, `csharp_sha` d35a6e62 **PRESERVED**, date+by updated, reason;
- CR guard passed (LF-only, `eol=lf`; binary stdin `hash-object`, c.1115-L); form detected `indent=1`.

## Scope & coordination note

2 files (`CSP-6-Hybridization.ipynb` + `csp-6-hybridization.yaml`). No source change beyond 1 markdown hint line in c35 + `python_sha` rebaseline.

**Coordination:** my open PR **#9171** (c.1127) also touches CSP-6-Hybridization (cells c34/c37) and rebaselines `python_sha` from the same origin/main base (e5664cf2). This PR touches **c35** (distinct cell, no overlap). Whichever merges first wins the `python_sha`; the other will need a one-line sha rebaseline at merge — flagging for the coordinator. The two PRs are otherwise independent (different cells, different defects).

Found via the #8052 CSP Explore sweep (c.1124 catalog S6); re-verified firsthand (L786-2; phantom grep + full c34 code context) against own c34 `solve_task_graph` + C# twin. L898 PR-checked (uncontested: 0 open PRs mention "DynamicPortfolio"; my open CSP PRs touch CSP-5/3/7/8/9/4 + CSP-6 c34/c37 — disjoint cell).

See #8052 (semantic-sampling audit, CSP slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
