### PR TITLE
fix(ml,#8052): TP-prevision-ventes Exercice 3 asks temporal features but SalesData has NO date field -> impossible exercise -> reframe

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/TP-prevision-ventes.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/TP-prevision-ventes.ipynb
@@ -1054,7 +1054,7 @@
     "\n",
     "### Exercice 3 : Feature engineering pour les ventes\n",
     "\n",
-    "Créez de nouvelles features a partir des données existantes : jour de la semaine, mois, trimestre et indicateur de week-end. Entrainez un modèle avec ces nouvelles features et comparez les performances avec le modèle de base (Partie 2).\n",
+    "Créez de nouvelles features a partir des données existantes : ratios dérivés (revenu par année de contrat, part du revenu consacrée à la prime), variables d'interaction (âge et niveau d'études) et discrétisation par tranches (âge ou revenu). Entrainez un modèle avec ces nouvelles features et comparez les performances avec le modèle de base (Partie 2).\n",
     "\n",
     "**Indice** : Definissez une nouvelle classe `SalesDataEnhanced` avec les proprietes derivees. Utilisez les opérations LINQ pour enrichir les données. Comparez le R2 et le MAE avec le modèle original."
    ]


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**Impossible-exercise phantom** in `TP-prevision-ventes.ipynb` (C#/.NET), **cell[17] Exercice 3** (Feature engineering), `elem[4]`:

> Créez de nouvelles features a partir des données existantes : **jour de la semaine, mois, trimestre et indicateur de week-end**. …

The exercise asks students to derive **temporal features** (day-of-week, month, quarter, weekend indicator) "a partir des données existantes". But `SalesData` (idx 4) has **no date/time field** — only:

```
Age, Income, FamilyStatus, EducationLevel, ContractType, ContractDuration, PremiumAmount, Region, SalesAmount   (all float)
```

Day-of-week / month / quarter / weekend **cannot be derived** from demographic/contract numeric fields. The exercise is **impossible as written** — there is no date dimension to derive temporal features from.

## Authority (firsthand, #8052 lens, L786-2)

`SalesData` class literal (idx 4): 9 float fields, **0 temporal**. Root cause = the exercise reached for a generic temporal-feature template without checking the schema (**schema-mismatch, not missing-implementation**). This is a bounded premise fix, **not** a data redesign — the dataset is intentionally insurance/sales demographic data; temporal features were never appropriate; only the exercise *premise* is wrong (EPIC #8364 root-cause checked).

## Fix

Honest reframe: replace the impossible temporal-feature ask with **achievable feature engineering** derivable from the actual numeric fields:
- **ratios** — revenu par année de contrat (`Income/ContractDuration`), part du revenu consacrée à la prime (`PremiumAmount/Income`)
- **variables d'interaction** — âge et niveau d'études (`Age × EducationLevel`)
- **discrétisation par tranches** — âge ou revenu (`bin(Age)` / `bin(Income)`)

Preserves the pedagogical frame ("Créez de nouvelles features … comparez les performances avec le modèle de base (Partie 2)") and `elem[6]` Indice (`SalesDataEnhanced` class + LINQ + compare R²/MAE — all still valid for the reframed features). **Only `elem[4]` changes.**

Phantom / identity (exercise asks for a data dimension that does not exist), **not** a measure/value drift → no §D.5 diagnostic owed (coord c.1042: identity ≠ measure). markdown → 0 re-exec.

## Verification (firsthand, #8052 lens, L786-2)

- `jour de la semaine` / `indicateur de week-end` / `trimestre et indicateur` now **0 occurrences**; new anchors present (`revenu par année de contrat`, `discrétisation par tranches`);
- only cell[17] elem[4] changed (element-level); source list length-preserved (no collapse, c.1123-L); exactly 1 cell changed;
- **PRESERVED**: exercise frame + `elem[6]` Indice (`SalesDataEnhanced`, `Comparez le R2 et le MAE`) + `### Exercice 3 : Feature engineering` header;
- CR guard passed (LF-only, `eol=lf`; binary stdin `hash-object`, c.1115-L); form detected `indent=1 ensure_ascii=False`.

## Scope & coordination

1 file (`TP-prevision-ventes.ipynb`), 1 cell. **NOT twinned** (no twin, no `twin_pairs.d` yaml). L898 uncontested — open PRs touching this notebook: **#9123** (Exercice 4 / XPlot→ScottPlot) + my **#9182** (Exercice 2 / `numFolds`→`numberOfFolds`), both **disjoint cells** (4/2 vs 17); single notebook, no twin-parity gate → clean coexistence / trivial rebase whichever merges first.

Found via the #8052 ML.Net Explore sweep; re-verified firsthand (L786-2: `SalesData` class literal idx 4).

See #8052 (semantic-sampling audit, ML.Net slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
