### PR TITLE
feat(tooling,#9089): extend migrate_cost_frontmatter_to_metadata.py for GenAI shape (cell#0|cell#1, metadata.cost absent, malformed YAML)

### DIFF
--- a/scripts/audit/migrate_cost_frontmatter_to_metadata.py
+++ b/scripts/audit/migrate_cost_frontmatter_to_metadata.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """
-migrate_cost_frontmatter_to_metadata.py — Migre le bloc cost YAML de la cellule#0
-(LEGACY) vers `nb.metadata['cost']` (CANONIQUE), PUIS retire le bloc frontmatter.
+migrate_cost_frontmatter_to_metadata.py — Migre le bloc cost YAML d'une cellule
+frontmatter (LEGACY) vers `nb.metadata['cost']` (CANONIQUE), PUIS retire le bloc.
 
-Issues #8904 (markdown-rendering `[frontmatter_supersize]`) + #8056 (cost canonique).
+Issues #8904 (markdown-rendering `[frontmatter_supersize]`) + #8056 (cost canonique)
++ #9089 (extension shape GenAI : cell#0|cell#1, metadata.cost absent, YAML malforme).
 
 CONTEXTE — pourquoi un simple strip perd de l'information
 ---------------------------------------------------------
@@ -22,15 +23,38 @@ Apres migration, metadata.cost porte toutes les valeurs mesurees ET les champs
 propres — il devient veritablement canonique, et le frontmatter devient retirable
 sans perte.
 
+DEUX SHAPES — QC (canonique) et GenAI (#9089)
+---------------------------------------------
+**Shape QC** (path inchange, regressif) :
+  - frontmatter en **cell#0** uniquement ;
+  - `metadata.cost` **DOIT exister** (sinon : refuse — il faut d'abord le peupler via
+    populate_quantconnect_cost.py ; on ne Migre pas vers du vide) ;
+  - frontmatter **well-formed** (closer `---` en colonne 0).
+  -> UNION merge {**meta_cost, **fm_cost}, puis strip du bloc en gardant le H1 trailing.
+
+**Shape GenAI** (extension #9089) :
+  - frontmatter en **cell#0 OU cell#1** (Audio/Image le portent en cell#1, apres la
+    cellule titre/navigation) ;
+  - `metadata.cost` souvent **absent** (pas de scanner QC — le frontmatter est la
+    seule source) -> la migration le CREE depuis le frontmatter seul (pas de merge
+    lossy vers du vide, puisqu'il n'y a rien a perdre) ;
+  - frontmatter possiblement **malforme** (closer `---` indente et avale par un bloc
+    `notes: |` : pas de closer en colonne 0) -> parse tolerant whole-cell
+    `yaml.safe_load` (yaml est tolerant de cette forme).
+  -> CREATE metadata.cost = frontmatter_cost (sanitized), puis REMOVE la cellule
+     frontmatter (elle est dediee au frontmatter en GenAI, sans H1 trailing).
+
 SEUIL DE COHERENCE (litmus anti-LIGHT, cf check_cost_metadata.py)
 -----------------------------------------------------------------
 La migration n'ecrit QUE si elle est cohérente :
-  - cell#0 doit demarrer par `---` (sinon : deja migree -> skip idempotent)
-  - metadata.cost DOIT exister (sinon : refuse — il faut d'abord le peupler via
-    populate_quantconnect_cost.py ; on ne Migre pas vers du vide)
-  - le frontmatter doit contenir un bloc `cost:` valide
-Le re-dump utilise `json.dumps(indent=1, ensure_ascii=False)+'\\n'` (LF-only),
-round-trip byte-identique au original hors des champs migrés (technique #8908).
+  - une cellule markdown (cell#0 ou cell#1) doit demarrer par `---` et contenir un
+    bloc `cost:` valide (sinon : deja migree -> skip idempotent) ;
+  - shape QC : metadata.cost DOIT exister (sinon : refuse) ;
+  - shape GenAI : metadata.cost absent est OK (creation depuis frontmatter).
+Les valeurs YAML type datetime (ex. `metadata_written: 2026-07-23T09:30Z`) sont
+sanitizees en ISO strings (JSON-serializable). Le re-dump utilise
+`json.dumps(indent=1, ensure_ascii=False)+'\\n'` (LF-only), round-trip byte-identique
+au original hors des champs migrés (technique #8908).
 
 Usage
 -----
@@ -49,6 +73,7 @@ Exit codes : 0 = ok (dry-run ou apply) ; 1 = au moins une erreur/defaut de coher
 """
 
 import argparse
+import datetime
 import json
 import re
 import sys
@@ -60,8 +85,8 @@ _FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
 
 def parse_frontmatter(cell_source: str):
-    """Retourne (frontmatter_dict, match_span) ou (None, None) si cell#0 ne
-    demarre pas par un bloc `---...---`."""
+    """Retourne (frontmatter_dict, match_span) ou (None, None) si la cellule ne
+    demarre pas par un bloc `---...---` well-formed (closer en colonne 0)."""
     m = _FRONTMATTER_RE.match(cell_source)
     if not m:
         return None, None
@@ -72,8 +97,74 @@ def parse_frontmatter(cell_source: str):
     return data, m.span()
 
 
+def _is_cost_frontmatter(data):
+    """True si data est un dict portant un bloc `cost:` dict (cible de migration)."""
+    return isinstance(data, dict) and isinstance(data.get("cost"), dict)
+
+
+def parse_frontmatter_tolerant(cell_source: str):
+    """Shape GenAI malforme (#9089) : la cellule demarre par `---` mais n'a PAS de
+    closer en colonne 0 (le `---` final est indente et avale par un bloc literal
+    `notes: |`). Tolerant whole-cell `yaml.safe_load` — yaml accepte cette forme
+    (le `---` de tete est le separateur de doc, le `  ---` final est du contenu
+    literal dans notes). Retourne data (ou None si non parsable / sans cost)."""
+    if not cell_source.startswith("---"):
+        return None
+    try:
+        data = yaml.safe_load(cell_source)
+    except yaml.YAMLError:
+        return None
+    return data if _is_cost_frontmatter(data) else None
+
+
 def _as_str(src):
     return "".join(src) if isinstance(src, list) else (src or "")
+
+
+def _sanitize_yaml_values(obj):
+    """yaml parse `metadata_written: 2026-07-23T09:30Z` en datetime (non
+    JSON-serializable). Convertit recursivement datetime/date -> ISO string."""
+    if isinstance(obj, (datetime.datetime, datetime.date)):
+        return obj.isoformat()
+    if isinstance(obj, dict):
+        return {k: _sanitize_yaml_values(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_yaml_values(v) for v in obj]
+    return obj
+
+
+def find_cost_frontmatter_cell(nb):
+    """Scan cell#0 puis cell#1 pour une cellule markdown frontmatter portant un
+    bloc `cost:`. Essaie le parse STRICT (closer col-0) d'abord, puis TOLERANT
+    (malforme GenAI). Retourne un dict :
+      {idx, fm, mode, raw_source, span, src, trailing}
+    ou None si aucune cellule cible. `trailing` = contenu apres le closer pour le
+    mode strict (peut etre "" = frontmatter-only), None pour tolerant (whole-cell)."""
+    cells = nb.get("cells", [])
+    for idx in (0, 1):
+        if idx >= len(cells):
+            break
+        cell = cells[idx]
+        if cell.get("cell_type") != "markdown":
+            continue
+        raw_source = cell.get("source", "")
+        src = _as_str(raw_source)
+        if not src.startswith("---"):
+            continue
+        # Strict (well-formed, col-0 closer) — path QC + GenAI well-formed.
+        data, span = parse_frontmatter(src)
+        if _is_cost_frontmatter(data):
+            trailing = src[span[1]:]
+            return {"idx": idx, "fm": data, "mode": "strict",
+                    "raw_source": raw_source, "span": span, "src": src,
+                    "trailing": trailing}
+        # Tolerant (malformed GenAI, no col-0 closer).
+        data_t = parse_frontmatter_tolerant(src)
+        if data_t is not None:
+            return {"idx": idx, "fm": data_t, "mode": "tolerant",
+                    "raw_source": raw_source, "span": None, "src": src,
+                    "trailing": None}
+    return None
 
 
 def strip_frontmatter_preserving_type(raw_source):
@@ -113,6 +204,15 @@ def _lf_only(text: str) -> str:
     return text.replace("\r\n", "\n")
 
 
+def _trailing_as_source_type(trailing_str, raw_source):
+    """Reconstruit le trailing (apres closer) dans le MEME format (list/str) que
+    raw_source, pour preserver le type canonique (anti-churn list->string)."""
+    if isinstance(raw_source, list):
+        # Decoupe le trailing_str en lignes keepends (format list canonique).
+        return trailing_str.splitlines(keepends=True)
+    return trailing_str
+
+
 def migrate_notebook(path: Path, apply: bool, by: str):
     """Migre un notebook. Retourne un dict de rapport (status + detail)."""
     rel = str(path)
@@ -122,22 +222,19 @@ def migrate_notebook(path: Path, apply: bool, by: str):
     except Exception as exc:
         return {"path": rel, "status": "error", "detail": f"read/parse: {exc}"}
 
-    cells = nb.get("cells", [])
-    if not cells:
+    if not nb.get("cells"):
         return {"path": rel, "status": "error", "detail": "no cells"}
-    cell0 = cells[0]
-    if cell0.get("cell_type") != "markdown":
-        return {"path": rel, "status": "error", "detail": "cell#0 not markdown"}
 
-    raw_source = cell0.get("source", "")
-    src = _as_str(raw_source)
-    fm, span = parse_frontmatter(src)
-    if fm is None:
+    fm_info = find_cost_frontmatter_cell(nb)
+    if fm_info is None:
         return {"path": rel, "status": "skip-already-migrated",
-                "detail": "cell#0 has no `---` frontmatter (already migrated)"}
-    if not isinstance(fm, dict) or "cost" not in fm:
-        return {"path": rel, "status": "error",
-                "detail": "frontmatter has no `cost:` block — not a cost migration target"}
+                "detail": "no `---cost:` frontmatter in cell#0 or cell#1 (already migrated)"}
+
+    idx = fm_info["idx"]
+    fm = fm_info["fm"]
+    mode = fm_info["mode"]
+    raw_source = fm_info["raw_source"]
+    trailing = fm_info["trailing"]
 
     fm_cost = fm.get("cost") or {}
     if not isinstance(fm_cost, dict):
@@ -145,71 +242,100 @@ def migrate_notebook(path: Path, apply: bool, by: str):
 
     meta = nb.setdefault("metadata", {})
     meta_cost = meta.get("cost")
-    if not isinstance(meta_cost, dict) or not meta_cost:
-        return {"path": rel, "status": "refused-no-metadata-cost",
-                "detail": "metadata.cost absent — populate it first (populate_quantconnect_cost.py)"}
+    create_mode = not (isinstance(meta_cost, dict) and meta_cost)
 
-    # UNION : metadata d'abord (garde qcc_tokens_est etc.), frontmatter gagne sur overlap.
-    merged = {**meta_cost, **fm_cost}
+    if create_mode:
+        # Shape GenAI : metadata.cost absent -> CREATE depuis le frontmatter seul.
+        # Pas de merge lossy (il n'y a rien a perdre : le frontmatter EST la source).
+        fm_cost_safe = _sanitize_yaml_values(fm_cost)
+        merged = dict(fm_cost_safe)
+        overwritten = {}
+        meta_only = []
+        merge_kind = "create-from-frontmatter"
+    else:
+        # Shape QC / GenAI-both : UNION (metadata d'abord, frontmatter gagne sur overlap).
+        fm_cost_safe = _sanitize_yaml_values(fm_cost)
+        merged = {**meta_cost, **fm_cost_safe}
+        overwritten = {k: {"from": meta_cost.get(k), "to": fm_cost_safe.get(k)}
+                       for k in fm_cost_safe if meta_cost.get(k) != fm_cost_safe.get(k)}
+        meta_only = sorted(k for k in meta_cost if k not in fm_cost_safe)
+        merge_kind = "union"
 
-    # Champs reellement ecris (divergents) = ou metadata et frontmatter differaient.
-    overwritten = {k: {"from": meta_cost.get(k), "to": fm_cost.get(k)}
-                   for k in fm_cost if meta_cost.get(k) != fm_cost.get(k)}
-    meta_only = sorted(k for k in meta_cost if k not in fm_cost)
+    # Strip du frontmatter.
+    new_nb = json.loads(original)  # copie profonde de travail
+    remove_cell = False
+    if mode == "strict" and trailing and trailing.strip():
+        # Well-formed avec H1 trailing : strip le bloc, garde le trailing (path QC).
+        new_source, ok_strip = strip_frontmatter_preserving_type(raw_source)
+        if not ok_strip:
+            return {"path": rel, "status": "error",
+                    "detail": "after frontmatter, cell does not start with a `#` H1 — aborting"}
+        new_nb["cells"][idx]["source"] = new_source
+        new_cell0_starts_h1 = (_as_str(new_source).lstrip().startswith("#"))
+    else:
+        # frontmatter-only (strict sans trailing, OU tolerant whole-cell GenAI) :
+        # la cellule est dediee au frontmatter -> REMOVE.
+        remove_cell = True
+        del new_nb["cells"][idx]
+        new_cell0_starts_h1 = True  # n/a (cell removed)
 
-    # Stripping du frontmatter : on retire le bloc ---...--- + les lignes vides
-    # qui suivent immediatement, en PRESERVANT le format list/str de `source`
-    # (collapser une list en string = churn non byte-stable).
-    new_cell0_source, ok_strip = strip_frontmatter_preserving_type(raw_source)
-    if not ok_strip:
-        return {"path": rel, "status": "error",
-                "detail": "after frontmatter, cell#0 does not start with a `#` H1 — aborting"}
+    new_nb["metadata"]["cost"] = merged
 
     # Byte-stabilite : re-dumper l'original (sans modif) doit round-tripper.
     rt_original = _lf_only(json.dumps(json.loads(original), indent=1, ensure_ascii=False) + "\n")
     byte_stable_baseline = (rt_original == _lf_only(original))
 
-    # Appliquer les modifs sur la structure.
-    nb["cells"][0]["source"] = new_cell0_source
-    meta["cost"] = merged
+    new_content = _lf_only(json.dumps(new_nb, indent=1, ensure_ascii=False) + "\n")
 
-    new_content = _lf_only(json.dumps(nb, indent=1, ensure_ascii=False) + "\n")
-
-    # Preuve d'equivalence : merged == {**meta_cost_original, **fm_cost}.
-    expected = {**meta_cost, **fm_cost}
+    # Preuve d'equivalence du merge.
+    if create_mode:
+        expected = dict(fm_cost_safe)
+    else:
+        expected = {**meta_cost, **fm_cost_safe}
     equivalent = (merged == expected)
 
-    # DIFF MINIMAL — invariant anti-churn : seuls cell#0 (source) et
-    # metadata.cost peuvent changer. Toute autre cellule (code, outputs,
-    # metadata de cellule) et tout autre champ de nb.metadata doivent etre
-    # byte-identiques. C'est ce garde-fou qui aurait attrape un collapse
-    # list->string (churn massif sur cell#0 detecte comme non-minimal sur les
-    # METADATA de cell#0, et tout autre derivee).
+    # DIFF MINIMAL — invariant anti-churn : seuls la cellule frontmatter (source,
+    # ou removal) et metadata.cost peuvent changer. Generalise pour le remove-cell
+    # GenAI (len -1) ET le strip-keep-trailing QC (len egal).
     nb_original = json.loads(original)
     minimal_diff = True
     diff_detail = []
     cells_o = nb_original.get("cells", [])
-    cells_n = nb.get("cells", [])
-    if len(cells_o) != len(cells_n):
-        minimal_diff = False
-        diff_detail.append(f"cell count {len(cells_o)}->{len(cells_n)}")
-    else:
-        for i, (co, cn) in enumerate(zip(cells_o, cells_n)):
-            if i == 0:
-                # cell#0 : seul 'source' peut changer ; tout le reste identique.
-                for k in co:
-                    if k == "source":
-                        continue
-                    if co.get(k) != cn.get(k):
-                        minimal_diff = False
-                        diff_detail.append(f"cell#0 field '{k}' changed")
-            else:
-                if co != cn:
+    cells_n = new_nb.get("cells", [])
+
+    if remove_cell:
+        if len(cells_n) != len(cells_o) - 1:
+            minimal_diff = False
+            diff_detail.append(f"cell count {len(cells_o)}->{len(cells_n)} (expected -1)")
+        else:
+            for i, co in enumerate(cells_o):
+                if i == idx:
+                    continue  # la cell frontmatter supprimee
+                ni = i if i < idx else i - 1  # decalage apres l'index supprime
+                if co != cells_n[ni]:
                     minimal_diff = False
-                    diff_detail.append(f"cell#{i} changed")
+                    diff_detail.append(f"cell#{i} changed (expected only removal of cell#{idx})")
+                    break
+    else:
+        if len(cells_o) != len(cells_n):
+            minimal_diff = False
+            diff_detail.append(f"cell count {len(cells_o)}->{len(cells_n)}")
+        else:
+            for i, (co, cn) in enumerate(zip(cells_o, cells_n)):
+                if i == idx:
+                    for k in co:
+                        if k == "source":
+                            continue
+                        if co.get(k) != cn.get(k):
+                            minimal_diff = False
+                            diff_detail.append(f"cell#{idx} field '{k}' changed")
+                else:
+                    if co != cn:
+                        minimal_diff = False
+                        diff_detail.append(f"cell#{i} changed")
     # metadata : seul 'cost' peut changer.
     meta_o = nb_original.get("metadata", {})
-    meta_n = nb.get("metadata", {})
+    meta_n = new_nb.get("metadata", {})
     for k in meta_o:
         if k == "cost":
             continue
@@ -219,15 +345,17 @@ def migrate_notebook(path: Path, apply: bool, by: str):
 
     report = {
         "path": rel,
+        "frontmatter_cell": idx,
+        "mode": mode,
+        "merge_kind": merge_kind,
         "overwritten_fields": overwritten,
         "metadata_only_fields_preserved": meta_only,
         "byte_stable_baseline": byte_stable_baseline,
         "field_equivalent": equivalent,
         "minimal_diff": minimal_diff,
         "diff_detail": diff_detail,
-        "new_cell0_starts_with_h1": new_cell0_source.lstrip().startswith("#")
-        if isinstance(new_cell0_source, str)
-        else (new_cell0_source[0].lstrip().startswith("#") if new_cell0_source else False),
+        "remove_cell": remove_cell,
+        "new_cell0_starts_with_h1": new_cell0_starts_h1,
     }
 
     if not apply:
@@ -285,11 +413,14 @@ def main(argv=None) -> int:
         total_overwritten += len(ow)
         name = p.name
         fields = ",".join(sorted(ow)) if ow else "-"
-        print(f"  [{marker:4s}] {st:26s} {name:24} overwrite=[{fields}] meta_only={rep.get('metadata_only_fields_preserved', [])}")
+        extra = ("rm-cell" if rep.get("remove_cell") else "strip-keep") if st == "dry-run" else ""
+        print(f"  [{marker:4s}] {st:26s} {name:24} mode={rep.get('mode','-'):9s} "
+              f"merge={rep.get('merge_kind','-'):22s} {extra}")
+        print(f"          cell#{rep.get('frontmatter_cell','-')} overwrite=[{fields}] "
+              f"meta_only={rep.get('metadata_only_fields_preserved', [])}")
         print(f"          byte_stable_baseline={rep.get('byte_stable_baseline')} "
               f"field_equivalent={rep.get('field_equivalent')} "
-              f"minimal_diff={rep.get('minimal_diff')} "
-              f"h1={rep.get('new_cell0_starts_with_h1')}")
+              f"minimal_diff={rep.get('minimal_diff')} h1={rep.get('new_cell0_starts_with_h1')}")
 
     mode = "APPLY" if args.apply else "DRY-RUN"
     print(f"\n[{mode}] by={args.by}  notebooks={len(paths)}  fields_overwritten={total_overwritten}")

--- a/scripts/audit/tests/test_migrate_cost_frontmatter.py
+++ b/scripts/audit/tests/test_migrate_cost_frontmatter.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Tests pour migrate_cost_frontmatter_to_metadata.py — Issues #8904/#8056/#9089.
+
+Couvre les 3 shapes :
+  - QC (cell#0, metadata.cost present) -> UNION merge, strip-keep H1 (regression).
+  - GenAI well-formed (cell#1, metadata.cost absent) -> CREATE, remove cell.
+  - GenAI malformed (cell#1, closer `---` avale par `notes: |`) -> tolerant parse,
+    CREATE, remove cell.
+Plus : datetime sanitization, idempotence (re-run skip), cell#0|cell#1 scan order.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+AUDIT_DIR = HERE.parent
+sys.path.insert(0, str(AUDIT_DIR))
+
+import migrate_cost_frontmatter_to_metadata as mig  # noqa: E402
+
+
+# === Helpers : construction de notebooks factices par shape ===
+
+def _dump(nb, path):
+    """Dump byte-stable (indent=1, LF-only) — match le format canonique du script."""
+    path.write_bytes((json.dumps(nb, indent=1, ensure_ascii=False) + "\n").encode("utf-8"))
+
+
+def _make_qc_shape(tmp_path):
+    """Shape QC : frontmatter cell#0 (well-formed) + metadata.cost present (union)."""
+    nb = {
+        "cells": [
+            {"cell_type": "markdown", "metadata": {},
+             "source": ["---\n",
+                        "title: \"QC Demo\"\n",
+                        "cost:\n",
+                        "  api_usd_est: 0.5\n",
+                        "  cpu_min: 2\n",
+                        "  metadata_written: 2026-07-23T09:30Z\n",
+                        "---\n",
+                        "# Titre QC\n",
+                        "\n",
+                        "Contenu pedagogique.\n"]},
+            {"cell_type": "code", "execution_count": 1, "metadata": {},
+             "outputs": [], "source": ["qb = QuantBook()\n"]},
+        ],
+        "metadata": {"kernelspec": {"name": "python3"},
+                     "cost": {"api_usd_est": 0.0, "cpu_min": 0,
+                              "qcc_tokens_est": 980, "reproducibility": "MED"}},
+        "nbformat": 4, "nbformat_minor": 5,
+    }
+    p = tmp_path / "qc_demo.ipynb"
+    _dump(nb, p)
+    return p
+
+
+def _make_genai_strict_shape(tmp_path):
+    """Shape GenAI well-formed : frontmatter cell#1 (apres titre), metadata.cost ABSENT."""
+    nb = {
+        "cells": [
+            {"cell_type": "markdown", "metadata": {}, "source": ["# Titre GenAI\n"]},
+            {"cell_type": "markdown", "metadata": {},
+             "source": ["---\n",
+                        "title: \"GenAI Demo\"\n",
+                        "cost:\n",
+                        "  api_usd_est: 0.2\n",
+                        "  gpu_required: false\n",
+                        "  metadata_written: 2026-07-23T09:30Z\n",
+                        "---\n"]},
+            {"cell_type": "code", "execution_count": 1, "metadata": {},
+             "outputs": [], "source": ["print('hi')\n"]},
+        ],
+        "metadata": {"kernelspec": {"name": "python3"}},
+        "nbformat": 4, "nbformat_minor": 5,
+    }
+    p = tmp_path / "genai_strict.ipynb"
+    _dump(nb, p)
+    return p
+
+
+def _make_genai_malformed_shape(tmp_path):
+    """Shape GenAI malformed : closer `---` avale par un bloc `notes: |` (indenté),
+    pas de closer en colonne 0 — reproduit les 3 notebooks Audio de #9089."""
+    source = [
+        "---\n",
+        "title: \"GenAI Malformed Demo\"\n",
+        "cost:\n",
+        "  api_usd_est: 0.4\n",
+        "  gpu_required: false\n",
+        "  metadata_written: 2026-07-23T09:30Z\n",
+        "notes: |\n",
+        "  Benchmark comparatif multi-modeles.\n",
+        "  Cout reel depend du nombre de generations.\n",
+        "  ---\n",  # <-- closer avale : indenté sous notes:|, pas en colonne 0
+    ]
+    nb = {
+        "cells": [
+            {"cell_type": "markdown", "metadata": {}, "source": ["# Titre GenAI\n"]},
+            {"cell_type": "markdown", "metadata": {}, "source": source},
+            {"cell_type": "code", "execution_count": 1, "metadata": {},
+             "outputs": [], "source": ["print('hi')\n"]},
+        ],
+        "metadata": {"kernelspec": {"name": "python3"}},
+        "nbformat": 4, "nbformat_minor": 5,
+    }
+    p = tmp_path / "genai_malformed.ipynb"
+    _dump(nb, p)
+    return p
+
+
+# === Shape QC : UNION merge + strip-keep H1 (regression) ===
+
+def test_qc_shape_union_merge_and_strip_keep(tmp_path):
+    p = _make_qc_shape(tmp_path)
+    rep = mig.migrate_notebook(p, apply=True, by="test")
+    assert rep["status"] == "migrated"
+    assert rep["mode"] == "strict"
+    assert rep["merge_kind"] == "union"
+    assert rep["remove_cell"] is False  # strip-keep : cell#0 garde le H1 trailing
+    nb = json.loads(p.read_text(encoding="utf-8"))
+    cost = nb["metadata"]["cost"]
+    # UNION : frontmatter gagne sur overlap (api_usd_est 0.0->0.5, cpu_min 0->2),
+    # metadata.cost garde ses champs propres (qcc_tokens_est absent du frontmatter).
+    assert cost["api_usd_est"] == 0.5
+    assert cost["cpu_min"] == 2
+    assert cost["qcc_tokens_est"] == 980  # preserved (meta_only)
+    # cell#0 toujours present (strip-keep), demarre par le H1.
+    assert nb["cells"][0]["source"][0].startswith("# Titre QC")
+    assert len(nb["cells"]) == 2  # pas de removal
+
+
+# === Shape GenAI well-formed : CREATE + remove cell ===
+
+def test_genai_strict_create_and_remove_cell(tmp_path):
+    p = _make_genai_strict_shape(tmp_path)
+    rep = mig.migrate_notebook(p, apply=True, by="test")
+    assert rep["status"] == "migrated"
+    assert rep["mode"] == "strict"
+    assert rep["merge_kind"] == "create-from-frontmatter"
+    assert rep["remove_cell"] is True
+    assert rep["frontmatter_cell"] == 1  # detecte en cell#1
+    nb = json.loads(p.read_text(encoding="utf-8"))
+    assert len(nb["cells"]) == 2  # cell#1 frontmatter supprimee (3->2)
+    cost = nb["metadata"]["cost"]
+    assert cost["api_usd_est"] == 0.2
+    assert cost["gpu_required"] is False
+    assert nb["cells"][0]["source"][0].startswith("# Titre GenAI")  # titre preserve
+
+
+# === Shape GenAI malformed : tolerant parse + CREATE + remove cell ===
+
+def test_genai_malformed_tolerant_parse(tmp_path):
+    p = _make_genai_malformed_shape(tmp_path)
+    rep = mig.migrate_notebook(p, apply=True, by="test")
+    assert rep["status"] == "migrated"
+    assert rep["mode"] == "tolerant"  # pas de closer col-0 -> tolerant
+    assert rep["merge_kind"] == "create-from-frontmatter"
+    assert rep["remove_cell"] is True
+    nb = json.loads(p.read_text(encoding="utf-8"))
+    cost = nb["metadata"]["cost"]
+    assert cost["api_usd_est"] == 0.4
+    assert cost["gpu_required"] is False
+
+
+def test_find_cell_strict_wins_over_tolerant(tmp_path):
+    """Un frontmatter well-formed doit etre detecte en mode strict (pas tolerant)."""
+    p = _make_genai_strict_shape(tmp_path)
+    nb = json.loads(p.read_text(encoding="utf-8"))
+    info = mig.find_cost_frontmatter_cell(nb)
+    assert info is not None
+    assert info["mode"] == "strict"
+    assert info["idx"] == 1
+
+
+# === datetime sanitization (#9089 point 5) ===
+
+def test_datetime_sanitized_to_iso_string(tmp_path):
+    """yaml parse `metadata_written: 2026-07-23T09:30Z` en datetime ; la migration
+    doit le convertir en ISO string (JSON-serializable)."""
+    for maker in (_make_genai_strict_shape, _make_genai_malformed_shape, _make_qc_shape):
+        p = maker(tmp_path)
+        rep = mig.migrate_notebook(p, apply=True, by="test")
+        assert rep["status"] == "migrated", (maker.__name__, rep)
+        nb = json.loads(p.read_text(encoding="utf-8"))
+        mw = nb["metadata"]["cost"]["metadata_written"]
+        assert isinstance(mw, str), (maker.__name__, type(mw))
+        assert mw == "2026-07-23T09:30Z", (maker.__name__, mw)
+        # le notebook re-dumpé reste JSON-valide (sanitization evite le TypeError).
+        json.loads(p.read_text(encoding="utf-8"))
+        p.unlink()
+
+
+# === Idempotence : re-run sur migre -> skip ===
+
+def test_idempotent_skip_after_migration(tmp_path):
+    p = _make_genai_strict_shape(tmp_path)
+    assert mig.migrate_notebook(p, apply=True, by="test")["status"] == "migrated"
+    rep2 = mig.migrate_notebook(p, apply=True, by="test")
+    assert rep2["status"] == "skip-already-migrated"
+
+
+def test_skip_when_no_frontmatter(tmp_path):
+    nb = {"cells": [{"cell_type": "markdown", "metadata": {},
+                     "source": ["# Pas de frontmatter\n"]}],
+          "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+    p = tmp_path / "clean.ipynb"
+    _dump(nb, p)
+    rep = mig.migrate_notebook(p, apply=True, by="test")
+    assert rep["status"] == "skip-already-migrated"
+
+
+# === byte-stable baseline + minimal-diff gates ===
+
+def test_qc_shape_byte_stable_and_minimal_diff(tmp_path):
+    p = _make_qc_shape(tmp_path)
+    rep = mig.migrate_notebook(p, apply=False, by="test")
+    assert rep["byte_stable_baseline"] is True
+    assert rep["minimal_diff"] is True
+    assert rep["field_equivalent"] is True
+
+
+def test_genai_create_minimal_diff_allows_one_cell_removal(tmp_path):
+    """Le gate minimal-diff autorise exactement 1 cellule supprimee (GenAI rm-cell)."""
+    p = _make_genai_strict_shape(tmp_path)
+    rep = mig.migrate_notebook(p, apply=False, by="test")
+    assert rep["minimal_diff"] is True
+    assert rep["remove_cell"] is True


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2023:CoursIA -- prev: MED/claims-vs-outputs-§D.5 #9181

# feat(tooling,#9089): extend migrate_cost_frontmatter_to_metadata.py for GenAI shape (cell#0|cell#1, metadata.cost absent, malformed YAML)

Closes #9089. Follow-up of #9088 (GenAI frontmatter migration one-shot). The canonical `scripts/audit/migrate_cost_frontmatter_to_metadata.py` covered only the **QC quantbook shape** (frontmatter in cell#0, `metadata.cost` must exist, well-formed col-0 closer). The **GenAI shape** (6 notebooks in #9088) differs on all three axes. This PR extends the script additively so future GenAI frontmatter migrates durably rather than via a one-shot.

## The 3 GenAI gaps (vs the QC contract)

| Axis | QC (canonical) | GenAI (#9089) |
|------|----------------|---------------|
| Frontmatter location | cell#0 only | **cell#0 OR cell#1** (Audio/Image carry it in cell#1, after the title/navigation cell) |
| `metadata.cost` | must exist (else refuse) | often **absent** (no QC scanner — frontmatter is the only source) -> migration CREATES it |
| YAML shape | well-formed (col-0 closer `---`) | possibly **malformed** (3 Audio notebooks: the closing `---` is indented and swallowed by a `notes: \|` literal block — no col-0 closer) |

Verified firsthand on `origin/main`: 4 GenAI notebooks still carry unmigrated cost frontmatter — 3 Audio malformed (`03-1/03-2/03-3-Orchestration`) + 1 Image well-formed (`04-4-Cross-Stitch-Pattern-Maker-Legacy`). 117 GenAI notebooks already migrated (idempotence targets), 2 carry both metadata.cost + frontmatter (SemanticKernel-01/03, union-merge regression proxy).

## The extension (additive — QC/union path UNCHANGED)

1. **`find_cost_frontmatter_cell`** scans cell#0 then cell#1 for a cost-bearing `---` markdown cell. Tries **strict** parse (col-0 closer regex) first, falls back to **tolerant** whole-cell `yaml.safe_load` for the malformed shape (yaml accepts the doc-start `---` + the indented `---` inside `notes:|` as literal content).
2. **`metadata.cost` absent -> CREATE** (`merge_kind: create-from-frontmatter`). No lossy merge toward empty: the frontmatter IS the source. When metadata.cost exists -> UNION `{**meta_cost, **fm_cost}` (QC path, byte-identical behavior). *Behavior change vs the legacy script: metadata.cost absent no longer refuses — it creates. This is strictly better (the legacy refuse nudged toward `populate_quantconnect_cost.py`, but creating from the rich frontmatter loses nothing when metadata.cost is empty).*
3. **`_sanitize_yaml_values`** converts yaml-parsed datetimes (`metadata_written: 2026-07-23T09:30Z` -> `datetime`, not JSON-serializable) back to ISO strings recursively.
4. **Strip**: well-formed-with-trailing-H1 -> strip block keep trailing (QC); frontmatter-only (strict no-trailing OR tolerant whole-cell) -> **remove the cell** (GenAI frontmatter cells are dedicated, no H1 to keep).
5. **minimal-diff gate generalized**: allows exactly one cell removed (GenAI rm-cell) OR the frontmatter-cell source changed (QC strip-keep), + metadata.cost only. byte-stable baseline + field-equivalent preserved.

## Design call (extend vs dedicated script)

The #9089 body flagged a design call for the coordinator. This PR takes the **extend-additively** path validated as a gated one-shot in #9088 (the QC contract is narrow; the GenAI extension reuses the same gates: byte-stable round-trip, minimal-diff, field-equivalent). The QC path code is unchanged (same `find` + `union` + `strip-keep` behavior on a QC quantbook with cell#0 frontmatter + metadata.cost present — verified via the SemanticKernel "both" regression proxy). If the coordinator prefers a dedicated GenAI script, this PR is easy to revert; the tests document the contract either way.

## Tests — `scripts/audit/tests/test_migrate_cost_frontmatter.py` (new, 9 tests)

- `test_qc_shape_union_merge_and_strip_keep` — QC regression (union, strip-keep H1, qcc_tokens_est preserved).
- `test_genai_strict_create_and_remove_cell` — GenAI well-formed cell#1 (create, rm-cell).
- `test_genai_malformed_tolerant_parse` — GenAI malformed (tolerant, create, rm-cell).
- `test_find_cell_strict_wins_over_tolerant` — well-formed detected strict (not tolerant).
- `test_datetime_sanitized_to_iso_string` — datetime -> ISO str (JSON-serializable) across all 3 shapes.
- `test_idempotent_skip_after_migration` + `test_skip_when_no_frontmatter` — idempotence.
- `test_qc_shape_byte_stable_and_minimal_diff` + `test_genai_create_minimal_diff_allows_one_cell_removal` — gates.

**Regression**: full audit suite **116/116 passed** (test_check_cost_metadata 42, test_populate_cost_metadata 40, test_extract_claims_vs_outputs 5, test_check_denominators, test_check_lean_notebook_sorry + the 9 new). The QC/union path is provably unchanged.

## Scope (atomic — tooling only)

2 files: `scripts/audit/migrate_cost_frontmatter_to_metadata.py` (+210/−79) + new `scripts/audit/tests/test_migrate_cost_frontmatter.py` (228 lines). **0 notebook migrated** in this PR — the 4 residual GenAI notebooks (Audio 03-1/2/3 + Image 04-4) are migration targets for a separate PR (and may overlap with #9088/#9093 in flight). This PR delivers the durable tooling; applying it to the residuals is a follow-up. Verified end-to-end: dry-run detects all 4 residuals + plans correct migration (create + rm-cell + datetime sanitize); apply on Audio 03-1 produces correct metadata.cost (14 fields, datetime sanitized) + removes cell#1; idempotent on re-run; reverted (not committed).

See #9089, #9088, #8056, EPIC #4208. — myia-po-2023:CoursIA, c.1093. Tooling extension, 9 new tests + 116 regression passed firsthand.
