### PR TITLE
fix(arganalysis,#8052): Ontology_AIF Sommaire off-by-2 (2 sections missing) + "Trois"->"Quatre" exos (4 present)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb
@@ -29,7 +29,7 @@
     "3. Extraire les **labels multilingues** (`skos:prefLabel`, 2 816 = 1 408 FR + 1 408 EN) et reperer les **schemes de Walton** (100 classes de forme `*_Inference_*` materialisees depuis les mappings AIF_skos).\n",
     "4. Inventorier les **relations** (AnnotationAssertion-resource) : hiérarchie (`broader`/`narrower`/`inScheme`), **crossLink** (`mirrors`/`isRelatedTo`/`leverages`/… = 1 977) et **AIF attack** (`aifAttackedNode` = 93 → RA/I/CA-node).\n",
     "5. Construire le **sous-graphe de l'Equivoque** (`semanticAmbiguity`) et montrer qu'il est desormais **type par AIF** (`aifAttackedNode → RA-node`).\n",
-    "6. Trois exercices formels (règle #2161).\n",
+    "6. Quatre exercices formels (règle #2161).\n",
     "\n",
     "**Sommaire** :\n",
     "\n",
@@ -39,8 +39,10 @@
     "4. Schemes de Walton (100 classes materialisees + labels)\n",
     "5. Relations : inventaire des AnnotationAssertion-resource (crossLink + AIF)\n",
     "6. Grappe Equivoque : sous-graphe type AIF\n",
-    "7. Exercices\n",
-    "8. Ponts avec la serie"
+    "7. Distribution des attaques AIF par type de node\n",
+    "8. Scheme vs conflict : l'attaque AIF est-elle un scheme ou un conflit ?\n",
+    "9. Exercices\n",
+    "10. Ponts avec la serie"
    ]
   },
   {
@@ -977,7 +979,7 @@
    "source": [
     "## 9. Exercices\n",
     "\n",
-    "Trois exercices formels (règle #2161 : >= 3 exos par notebook pedagogique). Chaque exercice est un *stub* `print(\"Exercice a completer\")` que l'etudiant complete.\n",
+    "Quatre exercices formels (règle #2161 : >= 3 exos par notebook pedagogique). Chaque exercice est un *stub* `print(\"Exercice a completer\")` que l'etudiant complete.\n",
     "\n",
     "### Exercice 1 -- Distribution des concepts par prefixe de scheme\n",
     "\n",


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**2 bundled structural defects** in `Argument_Analysis_Ontology_AIF.ipynb` (Python) — both in hand-written markdown, no computed-output drift:

### 1. Table-of-contents off-by-2 (cell 0 Sommaire)

The notebook has **10 sections** (`## 1.` … `## 10.`), but the Sommaire lists only **8** entries. Sections **7** ("Distribution des attaques AIF par type de node", cell 20) and **8** ("Scheme vs conflict : l'attaque AIF…", cell 23) were added later and are **absent** from the TOC; the last two TOC entries are mis-numbered `"7. Exercices"` / `"8. Ponts avec la serie"` (actual sections are `## 9. Exercices` / `## 10. Ponts`).

**Fix:** insert the 2 missing TOC entries + renumber Exercices 7→9, Ponts 8→10.

### 2. Exercise count "Trois" → "Quatre"

The notebook has **4** exercises (`### Exercice 1/2/3/4` at cells 26/28/30/32; rule #2161 "≥3 exos" satisfied) but two markdown strings claim **"Trois exercices formels"** (cell 0 objectifs `elem[15]` + cell 26 section intro `elem[2]`).

## Authority (firsthand, #8052 lens, L786-2)

The notebook's OWN `## N.` headings (`## 1.` … `## 10.`, 10 sections) + the 4 `### Exercice` headings. Both drifts = stale prose left after sections 7/8 and the 4th exercise were added without syncing the TOC / objectifs count.

Structural / count (**identity**), **not** a measure/value drift → no §D.5 diagnostic owed (coord c.1042: identity ≠ measure). markdown → 0 re-exec.

## How (serialization note)

This notebook uses a **non-standard JSON format** (some array-close + key pairs are inlined on one line, e.g. `],   "source"`), so `json.dumps(indent=1)` does **not** round-trip it (length off by 2). The `source` arrays themselves **are** standard (one element per line), so the edits are applied as **targeted byte-level replacement** on the raw text (C876/C913 raw-JSON pattern), then re-parsed to confirm JSON validity and that **exactly cells 0 and 26 changed** (no whole-file reformat).

## Verification (firsthand)

- Sommaire now lists 10 entries with the 2 new titles (`7. Distribution des attaques AIF…`, `8. Scheme vs conflict…`) + renumbered `9. Exercices` / `10. Ponts`; stale `7. Exercices` / `8. Ponts` TOC items gone;
- `Trois exercices` now **0 occurrences**; `Quatre exercices` ×2;
- exactly cells **[0, 26]** changed (cell 0 source +2 elements, cell 26 same length); JSON re-parses clean; no CR (`eol=lf`);
- **PRESERVED**: actual section headings `## 7.` / `## 8.` / `## 9.` / `## 10.` untouched.

## Scope & coordination

1 file (`Argument_Analysis_Ontology_AIF.ipynb`). **NOT twinned** (no `twin_pairs.d` yaml). L898 uncontested — open PRs touching `Argument_Analysis` are **#9122** (CrossLinks) + **#9144** (Dung_AF_Semantics), **different notebooks** entirely.

Found via the #8052 Argument_Analysis Explore sweep; re-verified firsthand (L786-2).

See #8052 (semantic-sampling audit, Argument_Analysis slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
