### PR TITLE
fix(planners,#8052): Planners-7 section 4 numbering gap (### 4.3 with no ### 4.2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-7-OR-Tools.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-7-OR-Tools.ipynb
@@ -1064,7 +1064,7 @@
     "tags": []
    },
    "source": [
-    "### 4.3 Resolution et affichage des routes\n",
+    "### 4.2 Resolution et affichage des routes\n",
     "\n",
     "Maintenant que les données sont définies, nous configurons le **Routing Model** d'OR-Tools avec les callbacks de distance et de capacite, puis resolvons le problème."
    ]

--- a/scripts/notebook_tools/twin_pairs.d/planners-7-or-tools.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-7-or-tools.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-7-OR-Tools-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-31"
-    by: po-2024
-    python_sha: 18f1256f3021de76f79c10e2ef2959f1bdd65dbf
+    date: "2026-08-02"
+    by: myia-po-2024:CoursIA-2
+    python_sha: db8c36c20afafe5918b1dec884d406597700e6f7
     csharp_sha: 6acd159baa6ba26452ad2397b1c6a8a92395da92
+    reason: "rebaseline python apres 1 fix structurel (#8052) : section 4 (VRP) sautait ### 4.1 -> ### 4.3 (pas de ### 4.2) ; 'Donnees du probleme VRP' (cellule 24) est une Interpretation non-numerotee (convention de la section 3 Job Shop), donc renumerotation cellule 25 ### 4.3 -> ### 4.2 (section 4 maintenant contigue 4.1/4.2). Fix content-neutral (edition de texte de titre, aucun changement de corps, aucune perte de contenu), 0 re-exec. Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:
     - "Concept : planification orientee satisfaction de contraintes (Job-Shop scheduling, CP-SAT)."
     - "Python : OR-Tools CP-SAT Python bindings (solveur SOTA). C# : from-scratch BCL .NET (0 NuGet, Job-Shop modelise main, instance canonique Fisher & Thompson ft3 reprise cote Python)."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**1 structural numbering-gap defect** in `Planners-7-OR-Tools.ipynb` (Python) — hand-written markdown heading, no computed-output drift, **content-neutral** (no body change, no content loss):

### Section 4 (VRP) jumps `### 4.1` → `### 4.3` (no `### 4.2`)

- `### 4.1 Definition du problème` (cell 22)
- `### Interpretation : Données du problème VRP` (cell 24, unnumbered)
- `### 4.3 Resolution et affichage des routes` (cell 25) ← should be **4.2**

**Fix:** renumber cell 25 `### 4.3` → `### 4.2`. Section 4 is now contiguous (4.1, 4.2).

## Authority (firsthand, #8052 lens, L786-2)

The notebook's OWN section-4 headings (`### 4.1` cell 22, `### 4.3` cell 25, no `### 4.2`) + the section-3 (Job Shop) convention, where `### Interpretation : Données du problème Job Shop` (cell 13) is an **unnumbered** interpretation under `### 3.1 Definition du problème` — not its own numbered subsection. By that convention, the VRP "Données" interpretation belongs under 4.1, so the resolution subsection is the 2nd numbered one → 4.2.

Structural / numbering (**identity**), **not** a measure/value drift → no §D.5 diagnostic owed (coord c.1042: identity ≠ measure). markdown → 0 re-exec. **Content-neutral** (heading text edit only) → no markdown-content-loss concern.

## How

Element-level in-place edit (c.1123-L★★★: source-list shape preserved, `list[len=3]` kept): cell 25 `elem[0]` `'### 4.3 Resolution et affichage des routes\n'` → `'### 4.2 Resolution et affichage des routes\n'`; `elem[1]`/`elem[2]` (body) untouched. Standard round-trippable form (`json.dumps(indent=1, ensure_ascii=False)`). Exactly cell[25] changed.

## Verification (firsthand)

- `### 4.3` now **0 occurrences**; `### 4.2` ×1 (`### 4.2 Resolution et affichage des routes`); `### 4.1 Definition du problème` preserved;
- exactly cell **[25]** changed; cell[25] body (`elem[1]`, `elem[2]`) byte-preserved;
- source-list shape preserved (`list[len=3]`); JSON re-parses clean; LF-only (`eol=lf`).

## Scope & coordination

1 file NB + twin-yaml rebaseline (`planners-7-or-tools.yaml`, python-only → `python_sha` updated, `csharp_sha` UNCHANGED, `reason` added; yaml had no prior `reason` → no dup-key risk, c.1132-L). **NOT twinned-content** change — parity is semantic; this is a markdown heading edit on the Python side only. L898 uncontested — no open PR touches `Planners-7-OR-Tools.ipynb`.

**Deferred (out of scope, for a follow-up):** Planners-7's tail has a messier structural cluster — unnumbered `## Resume et perspectives` duplicating `## 7. Resume et points clés`, the 3 exercises positioned *after* `## Resume`/`## Ressources`, and `## Exercice : …` (cell 43) at heading-level `##` while siblings are `### Exercice 2/3`. That needs a holistic renumber + reposition (cell moves), kept out of this PR to stay atomic + content-neutral.

**Planners-5 DEFERRED (coordination, c.1037-L):** the Planners Explore sweep also found 3 structural grains in `Planners-5-Heuristics.ipynb` (section gap `## 8`→`## 10` missing `## 9`; run-on headings cells 15/49; `ci-dessous`→`ci-dessus`), but **#9178 (lane myia-po-2023)** is actively restructuring that notebook (rewrites cells 17–55, shifts cell indices 56→58). My cell-49 grain is in po-2023's blast zone → deferred to a post-#9178 follow-up to avoid a parallel-delivery race.

Found via the #8052 Planners Explore sweep; re-verified firsthand (L786-2).

See #8052 (semantic-sampling audit, Planners slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
