### PR TITLE
fix(planners,#8052): Planners-1 duplicate ### 4.2 heading (cell 9 re-opens section already at cell 7)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb
@@ -369,8 +369,6 @@
     "tags": []
    },
    "source": [
-    "### 4.2 Implementation avec unified-planning\n",
-    "\n",
     "Modelisation du problème de l'interrupteur en utilisant l'API unified-planning avec un environnement explicite et des paramètres d'action typés."
    ]
   },

--- a/scripts/notebook_tools/twin_pairs.d/planners-1-introduction.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-1-introduction.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-31"
-    by: po-2024
-    python_sha: 15b48a88234daf564512b163ffce816ca1b5a0d7
+    date: "2026-08-02"
+    by: myia-po-2024:CoursIA-2
+    python_sha: b8b4aab5c7f937970c850710f50d8f9b3166ad6a
     csharp_sha: 684de6ba81caa8202262c6f7f1b3830bc4af8291
+    reason: "rebaseline python apres 1 fix structurel (#8052) : le titre ### 4.2 Implementation avec unified-planning apparaissait DEUX FOIS -- cellule 7 (intro) et cellule 9 (re-ouvert, byte-identique), avec seulement le code de verification de version (cellule 8) entre les deux ; la section 4 avait donc 4.1, 4.2, 4.2 (dup), 4.3. Fix = suppression du titre duplique de la cellule 9 (cellule 7 l'avait deja), la phrase d'introduction distincte de la cellule 9 est conservee (elle devient un pont entre la verification de version cellule 8 et le code de modelisation cellule 10, tous sous ### 4.2 ouvert a la cellule 7). Python-only (le jumeau C# from-scratch BCL n'a pas d'unified-planning, 0 titre ### 4.2), csharp_sha unchanged, parite semantique preservee (0 re-exec, 0 output/code modifie)."
   known_differences:
     - "Concept : introduction a la planification classique (domaine, probleme, plan = sequence d'actions)."
     - "Python : unified-planning (API moderne, modelisation Fluent/Action). C# : from-scratch BCL .NET (dataclasses d'Action/Etat, 0 NuGet)."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**1 structural duplicate-heading defect** in `Planners-1-Introduction.ipynb` (Python) — hand-written markdown, no computed-output drift, **0 content loss** (distinct paragraph preserved; only the verbatim-duplicate heading line is removed):

### Section 4 emits `### 4.2 Implementation avec unified-planning` twice

- `### 4.1 Modelisation conceptuelle` (cell 6)
- `### 4.2 Implementation avec unified-planning` (cell 7) — intro: "Utilisons la bibliotheque unified-planning pour modeliser ce problème simple"
- cell 8 — unified-planning version-check code (prints version)
- `### 4.2 Implementation avec unified-planning` (cell 9) ← **duplicate**, byte-identical to cell 7's
- cell 10 — the actual unified-planning modeling code
- `### 4.3 Resolution du problème` (cell 12)

So section 4 listed 4.1, 4.2, 4.2 (dup), 4.3.

**Fix:** drop cell 9's duplicate `### 4.2` heading (cell 7 already carries it verbatim), **keep** cell 9's distinct lead-in sentence ("Modelisation du problème de l'interrupteur en utilisant l'API unified-planning avec un environnement explicite et des paramètres d'action typés"). Cell 9 becomes a bridge paragraph between the version-check (cell 8) and the modeling code (cell 10), all under `### 4.2` opened at cell 7.

## Authority (firsthand, #8052 lens, L786-2)

The notebook's OWN section-4 headings: `### 4.1` cell 6, `### 4.2` cell 7 **and** cell 9 (byte-identical), `### 4.3` cell 12. The two `### 4.2` are exact duplicates with only the version-check code between them (no intervening subsection).

Structural / numbering (**identity**), **not** a measure/value drift → no §D.5 diagnostic owed (coord c.1042: identity ≠ measure). markdown → 0 re-exec.

## How

Element-level edit: cell 9 source `['### 4.2 …\n', '\n', "<lead-in>"]` → `[<lead-in>]` (drop the duplicate heading + its blank separator; the distinct lead-in paragraph is byte-preserved as the cell's sole content). Standard round-trippable form (`json.dumps(indent=1, ensure_ascii=False)`). Exactly cell[9] changed.

**On content loss:** this removes a single **duplicate** heading line (it exists verbatim at cell 7) — correctness, not loss. The notebook's distinct pedagogical content (cell 9's lead-in) is preserved byte-for-byte.

## Verification (firsthand)

- `### 4.2 Implementation avec unified-planning` now **1 occurrence** (cell 7); section-4 subsections contiguous `4.1 / 4.2 / 4.3` (regex `^### 4\.(\d+)` → `['1','2','3']`);
- exactly cell **[9]** changed; cell[9] lead-in byte-preserved (`nb2[9].source[0] == orig[9].source[2]`);
- `### 4.3 Resolution du problème` (cell 12) and all other section headings untouched; JSON re-parses clean; LF-only (`eol=lf`).

## Scope & coordination

1 file NB + twin-yaml rebaseline (`planners-1-introduction.yaml`, python-only → `python_sha` updated, `csharp_sha` UNCHANGED, `reason` added; yaml had no prior `reason` → no dup-key risk, c.1132-L). **Python-only defect** — the C# twin uses from-scratch BCL (no unified-planning), `### 4.2` count = 0. Parity is semantic; this is a markdown heading dedup on the Python side only. L898 uncontested — no open PR touches `Planners-1-Introduction.ipynb`.

**Deferred (out of scope):** Planners-1 also has a duplicate `## 5. Types de Planification` section (cells 16 + 17, with two divergent table versions — de-accented vs accented) → that fix removes substantial duplicate *table* content and needs a careful content-placement decision (merge the Note pédagogique vs strip), so it is deferred to a separate PR to keep this one atomic and risk-free on the content-loss check.

Found via the #8052 Planners Explore sweep; re-verified firsthand (L786-2).

See #8052 (semantic-sampling audit, Planners slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
