### PR TITLE
feat(lean,#8869): convert DoomsdayLemmas native_decide -> kernel decide (4 theorems, 0 axiom)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/DoomsdayLemmas.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/DoomsdayLemmas.lean
@@ -29,20 +29,20 @@ namespace Conway
 
 /-- CALIBRATION (decide) : 2000 est bissextile (divisible par 400). -/
 theorem isLeapYear_2000 : isLeapYear 2000 = true := by
-  native_decide
+  decide
 
 /-- CALIBRATION (decide) : 1900 n'est PAS bissextile (divisible par 100, pas par 400). -/
 theorem isLeapYear_1900 : isLeapYear 1900 = false := by
-  native_decide
+  decide
 
 /-- CALIBRATION (decide) : 2024 est bissextile. -/
 theorem isLeapYear_2024 : isLeapYear 2024 = true := by
-  native_decide
+  decide
 
 /-- HOMMAGE + CALIBRATION : John Conway est décédé le samedi 11 avril 2020.
     Évaluation fermée de l'algorithme Doomsday. -/
 theorem dayOfWeek_conway_death : dayOfWeek 2020 4 11 = DayOfWeek.saturday := by
-  native_decide
+  decide
 
 /-- CALIBRATION (décomposition par cas) : ajouter une semaine complète est l'identité.
     Un `decide` naïf échoue (`d` est libre) ; nécessite `cases d`. -/

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/DoomsdayLemmas_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/DoomsdayLemmas_en.lean
@@ -31,20 +31,20 @@ open Conway
 
 /-- CALIBRATION (decide): 2000 is a leap year (divisible by 400). -/
 theorem isLeapYear_2000 : isLeapYear 2000 = true := by
-  native_decide
+  decide
 
 /-- CALIBRATION (decide): 1900 is NOT a leap year (divisible by 100, not 400). -/
 theorem isLeapYear_1900 : isLeapYear 1900 = false := by
-  native_decide
+  decide
 
 /-- CALIBRATION (decide): 2024 is a leap year. -/
 theorem isLeapYear_2024 : isLeapYear 2024 = true := by
-  native_decide
+  decide
 
 /-- HOMAGE + CALIBRATION: John Conway passed away on Saturday, April 11, 2020.
     Closed evaluation of the Doomsday algorithm. -/
 theorem dayOfWeek_conway_death : dayOfWeek 2020 4 11 = DayOfWeek.saturday := by
-  native_decide
+  decide
 
 /-- CALIBRATION (case-decomposition): adding a full week is the identity.
     A naive `decide` fails (`d` is free); requires `cases d`. -/


### PR DESCRIPTION
Grain: LEAN/native_decide-reduction -- lane myia-po-2023:CoursIA -- prev: MED/§D.5-claims-vs-outputs #9143

See #8869 (partial -- DoomsdayLemmas module). Converts 4 native_decide theorems to kernel decide in Conway/DoomsdayLemmas.lean (+ i18n sibling _en.lean, EPIC #4980).

## The conversion

4 theorems now proven by kernel decide instead of native_decide:

- isLeapYear_2000 : isLeapYear 2000 = true
- isLeapYear_1900 : isLeapYear 1900 = false
- isLeapYear_2024 : isLeapYear 2024 = true
- dayOfWeek_conway_death : dayOfWeek 2020 4 11 = DayOfWeek.saturday

These are pure-arithmetic Bool evaluations (leap-year + Doomsday day-of-week algorithm). They sit OUTSIDE the Computation.lean evolve-obstruction mapped in c.1079 (the c.1079 probe showed the Decidable instance passes isolated; the stuck native_decide are the evolve-calc ones in Life/Computation). So these convert cleanly like the 7 still-life microproofs in #9163 (which passed decide post-#8895 insertionSort swap).

dayOfWeek_add_seven already uses cases d <;> rfl (NOT native_decide) -- left untouched.

## Verification (firsthand, conway_lean cache warm, toolchain v4.31.0-rc1)

1. Probe scratch (Conway/ProbeDecide.lean, untracked, deleted): all 4 example goals closed by decide. lake build Conway.ProbeDecide SUCCESS (611 jobs, exit 0).
2. lake build Conway.DoomsdayLemmas (FR) SUCCESS (611 jobs, exit 0). lake build Conway.DoomsdayLemmas_en (EN) SUCCESS (611 jobs, exit 0).
3. Proof integrity #print axioms (the point of #8869 -- make native_decide kernel-reducible):
   - isLeapYear_2000/1900/2024: does not depend on ANY axioms (was native_decide codegen axiom ._native.native_decide.ax_1_1)
   - dayOfWeek_conway_death: depends on [propext, Quot.sound] (standard Mathlib foundation -- NOT sorryAx, NOT native_decide axiom)
   This is a STRICT proof-integrity improvement: axiom dependencies removed, none added.
4. Anti-regression: 0 sorry tactics (the lone grep hit is a docstring line "Tous les sorry ont ete elimines"). No proof replaced by sorry -- the opposite: native_decide (codegen axiom) upgraded to kernel decide.
5. i18n pair validity (check_i18n_siblings.py): OK, byte-identical body, 0 drift, 0 orphan. The tactic change (decide) is byte-identical across FR/EN (English tactic, #4980 convention); only docstrings differ (unchanged here).

## Scope

2 files, 8 insertions / 8 deletions (4 tactic lines per file: native_decide -> decide). Module-level docstrings unchanged (they already named "decide" as the calibration target; the 2 "decide / native_decide" mentions document the technique ladder and remain accurate). No sorry, no sorry-baseline change (0 sorry tactics, gate unaffected).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
