### PR TITLE
feat(lean,#8869): convert CollatzLike native_decide -> kernel decide (8 theorems, 0 axiom)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/CollatzLike.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/CollatzLike.lean
@@ -178,19 +178,19 @@ def collatzStep (n : Int) : Int :=
     6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1 -/
 theorem collatz_6_trajectory :
     clIterate collatz 6 8 = [6, 3, 10, 5, 16, 8, 4, 2, 1] := by
-  native_decide
+  decide
 
 /-- Verify trajectory from 27 (the longest under 100):
     27 takes 111 steps to reach 1. We verify the first 10 steps. -/
 theorem collatz_27_first_10 :
     clIterate collatz 27 10 = [27, 82, 41, 124, 62, 31, 94, 47, 142, 71, 214] := by
-  native_decide
+  decide
 
 /-- Verify trajectory from 7:
     7 → 22 → 11 → 34 → 17 → 52 → 26 → 13 → 40 → 20 → 10 → 5 → 16 → 8 → 4 → 2 → 1 -/
 theorem collatz_7_trajectory :
     clIterate collatz 7 16 = [7, 22, 11, 34, 17, 52, 26, 13, 40, 20, 10, 5, 16, 8, 4, 2, 1] := by
-  native_decide
+  decide
 
 /-! ## Conway's (3n+1)/2 variant
 
@@ -213,13 +213,13 @@ def collatzCompressed : CollatzLike where
     6 → 3 → 5 → 8 → 4 → 2 → 1 (6 steps instead of 8) -/
 theorem collatzCompressed_6 :
     clIterate collatzCompressed 6 6 = [6, 3, 5, 8, 4, 2, 1] := by
-  native_decide
+  decide
 
 /-- Verify compressed trajectory from 7:
     7 → 11 → 17 → 26 → 13 → 20 → 10 → 5 → 8 → 4 → 2 → 1 -/
 theorem collatzCompressed_7 :
     clIterate collatzCompressed 7 11 = [7, 11, 17, 26, 13, 20, 10, 5, 8, 4, 2, 1] := by
-  native_decide
+  decide
 
 /-! ## Connection to FRACTRAN
 
@@ -239,7 +239,7 @@ def doubleProgram : List Frac := [frac 2 1 (by decide)]
 /-- Verify: running the doubling program from 3 for 4 steps. -/
 theorem fractran_double_3 :
     fractranRun doubleProgram 3 4 = [3, 6, 12, 24, 48] := by
-  native_decide
+  decide
 
 /-! ## Conway's 7n+1 variant — an open problem
 
@@ -261,11 +261,11 @@ def sevenNPlusOne : CollatzLike where
     We verify the first 5 steps. -/
 theorem sevenNPlusOne_3 :
     clIterate sevenNPlusOne 3 5 = [3, 22, 11, 78, 39, 274] := by
-  native_decide
+  decide
 
 /-- 7n+1 from 1: 1 → 8 → 4 → 2 → 1 (short cycle). -/
 theorem sevenNPlusOne_1 :
     clIterate sevenNPlusOne 1 4 = [1, 8, 4, 2, 1] := by
-  native_decide
+  decide
 
 end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/CollatzLike_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/CollatzLike_en.lean
@@ -109,19 +109,19 @@ def collatzStep (n : Int) : Int :=
     6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1 -/
 theorem collatz_6_trajectory :
     clIterate collatz 6 8 = [6, 3, 10, 5, 16, 8, 4, 2, 1] := by
-  native_decide
+  decide
 
 /-- Verify trajectory from 27 (the longest under 100):
     27 takes 111 steps to reach 1. We verify the first 10 steps. -/
 theorem collatz_27_first_10 :
     clIterate collatz 27 10 = [27, 82, 41, 124, 62, 31, 94, 47, 142, 71, 214] := by
-  native_decide
+  decide
 
 /-- Verify trajectory from 7:
     7 → 22 → 11 → 34 → 17 → 52 → 26 → 13 → 40 → 20 → 10 → 5 → 16 → 8 → 4 → 2 → 1 -/
 theorem collatz_7_trajectory :
     clIterate collatz 7 16 = [7, 22, 11, 34, 17, 52, 26, 13, 40, 20, 10, 5, 16, 8, 4, 2, 1] := by
-  native_decide
+  decide
 
 /-! ## Conway's (3n+1)/2 variant
 
@@ -144,13 +144,13 @@ def collatzCompressed : CollatzLike where
     6 → 3 → 5 → 8 → 4 → 2 → 1 (6 steps instead of 8) -/
 theorem collatzCompressed_6 :
     clIterate collatzCompressed 6 6 = [6, 3, 5, 8, 4, 2, 1] := by
-  native_decide
+  decide
 
 /-- Verify compressed trajectory from 7:
     7 → 11 → 17 → 26 → 13 → 20 → 10 → 5 → 8 → 4 → 2 → 1 -/
 theorem collatzCompressed_7 :
     clIterate collatzCompressed 7 11 = [7, 11, 17, 26, 13, 20, 10, 5, 8, 4, 2, 1] := by
-  native_decide
+  decide
 
 /-! ## Connection to FRACTRAN
 
@@ -170,7 +170,7 @@ def doubleProgram : List Frac := [frac 2 1 (by decide)]
 /-- Verify: running the doubling program from 3 for 4 steps. -/
 theorem fractran_double_3 :
     fractranRun doubleProgram 3 4 = [3, 6, 12, 24, 48] := by
-  native_decide
+  decide
 
 /-! ## Conway's 7n+1 variant — an open problem
 
@@ -192,11 +192,11 @@ def sevenNPlusOne : CollatzLike where
     We verify the first 5 steps. -/
 theorem sevenNPlusOne_3 :
     clIterate sevenNPlusOne 3 5 = [3, 22, 11, 78, 39, 274] := by
-  native_decide
+  decide
 
 /-- 7n+1 from 1: 1 → 8 → 4 → 2 → 1 (short cycle). -/
 theorem sevenNPlusOne_1 :
     clIterate sevenNPlusOne 1 4 = [1, 8, 4, 2, 1] := by
-  native_decide
+  decide
 
 end Conway_en


### PR DESCRIPTION
Grain: LEAN/native_decide-reduction -- lane myia-po-2023:CoursIA -- prev: LEAN/native_decide-reduction #9189

See #8869 (partial -- CollatzLike module). Converts 8 native_decide theorems to kernel decide in Conway/CollatzLike.lean (+ i18n sibling _en.lean, EPIC #4980). Continues the native_decide-reduction attack started in #9189 (DoomsdayLemmas, 4 theorems).

## The conversion

8 theorems now proven by kernel decide instead of native_decide:

- collatz_6_trajectory : clIterate collatz 6 8 = [6,3,10,5,16,8,4,2,1]
- collatz_27_first_10 : clIterate collatz 27 10 = [...10 steps...]
- collatz_7_trajectory : clIterate collatz 7 16 = [...16 steps...]
- collatzCompressed_6 : clIterate collatzCompressed 6 6 = [...]
- collatzCompressed_7 : clIterate collatzCompressed 7 11 = [...]
- fractran_double_3 : fractranRun doubleProgram 3 4 = [3,6,12,24,48]
- sevenNPlusOne_3 : clIterate sevenNPlusOne 3 5 = [...]
- sevenNPlusOne_1 : clIterate sevenNPlusOne 1 4 = [1,8,4,2,1]

All are closed bounded-iteration evaluations: clIterate / fractranRun applied to a literal starting value for a literal number of steps. The recursion is structural on the step counter (a Nat literal), NOT well-founded recursion on a computed value -- so the kernel reduces them cleanly. (Contrast: lookAndSay_4 in the sibling module uses well-founded recursion and does NOT reduce -- left native_decide there.)

## Verification (firsthand, conway_lean cache warm, toolchain v4.31.0-rc1)

1. Probe scratch (Conway/ProbeCollatz.lean, untracked, deleted): all 8 example goals closed by decide. lake build Conway.ProbeCollatz SUCCESS (4 jobs, exit 0).
2. lake build Conway.CollatzLike (FR) SUCCESS (3 jobs, exit 0). lake build Conway.CollatzLike_en (EN) SUCCESS (3 jobs, exit 0).
3. Proof integrity #print axioms (the point of #8869 -- make native_decide kernel-reducible):
   - collatz_6_trajectory / collatz_27_first_10 / fractran_double_3 / sevenNPlusOne_1 (sampled): does not depend on ANY axioms (was native_decide codegen axiom ._native.native_decide.ax_1_1).
   STRICT proof-integrity improvement: axiom dependencies removed, none added, no sorryAx.
4. Anti-regression: 0 sorry tactics (the lone grep hit is a docstring word). No proof replaced by sorry -- the opposite: native_decide (codegen axiom) upgraded to kernel decide.
5. i18n pair validity (check_i18n_siblings.py): OK, byte-identical body, 0 drift, 0 orphan. The tactic change (decide) is byte-identical across FR/EN. (Pre-existing HALF-DONE advisory on shared FR/EN module docstrings is unchanged by this PR.)

## Scope

2 files, 16 insertions / 16 deletions (8 tactic lines per file: native_decide -> decide). Module docstrings unchanged (they already named "native_decide" / "decide" in the technique descriptions; the 4/2 docstring mentions remain accurate). No sorry, no sorry-baseline change (0 sorry tactics, gate unaffected). The `by decide` instances inside the CollatzLike structure definitions (hm, branches proofs) were already `by decide` and are untouched.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
