### PR TITLE
fix(gametheory,#8052): GT-4 NashEquilibrium c33 stale companion-cell count 38 -> 44 (GT-4b grew)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
@@ -1722,7 +1722,7 @@
   {
    "cell_type": "markdown",
    "id": "50abde10",
-   "source": "> **Lien avec la formalisation Lean** : Le théorème d'existence de Nash est formalisé dans le notebook compagnon [GT-4b-Lean-NashExistence](GameTheory-4b-Lean-NashExistence.ipynb) (38 cellules, kernel Lean 4). On y trouve la construction du simplexe standard (`Simplex`), le produit de simplexes (`SimplexProduct`), la structure `FiniteGame`, les profils de stratégies mixtes, le gain espéré et la définition formelle de l'équilibre de Nash — le tout sans import Mathlib. Le théorème de Brouwer (point fixe sur le simplexe) y est axiomatisé comme fondement de la preuve d'existence. Le notebook Python [GT-4c-NashExistence-Python](GameTheory-4c-NashExistence-Python.ipynb) illustre numériquement ces mêmes concepts.",
+   "source": "> **Lien avec la formalisation Lean** : Le théorème d'existence de Nash est formalisé dans le notebook compagnon [GT-4b-Lean-NashExistence](GameTheory-4b-Lean-NashExistence.ipynb) (44 cellules, kernel Lean 4). On y trouve la construction du simplexe standard (`Simplex`), le produit de simplexes (`SimplexProduct`), la structure `FiniteGame`, les profils de stratégies mixtes, le gain espéré et la définition formelle de l'équilibre de Nash — le tout sans import Mathlib. Le théorème de Brouwer (point fixe sur le simplexe) y est axiomatisé comme fondement de la preuve d'existence. Le notebook Python [GT-4c-NashExistence-Python](GameTheory-4c-NashExistence-Python.ipynb) illustre numériquement ces mêmes concepts.",
    "metadata": {}
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
@@ -6,7 +6,8 @@
   last_audit:
     date: "2026-07-28"
     by: myia-po-2024:CoursIA-2
-    python_sha: e2d19dec8863909c0d4f785db97bfaadc8b575da
+    python_sha: c74eabd61cd743f4247dd1e29cc9a4f813859e74
+    reason: "Markdown-only cross-file count refresh (cell 33): the companion Lean notebook GT-4b-Lean-NashExistence grew from 38 to 44 cells since the cite was written (verified firsthand by parsing origin/main: ...GameTheory-4b-Lean-NashExistence.ipynb -> 44 cells). No re-exec, no output change. C# twin untouched (different from-scratch engine, no Lean refs)."
     csharp_sha: fb4ff1f41cf14d9deb11ab755609cb3fb657d390
   known_differences:
     - "Socle pedagogique commun : calcul des equilibres de Nash (purs + mixtes), meilleure reponse, support des equilibres mixtes."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**1 stale cross-file COUNT defect** in `GameTheory-4-NashEquilibrium.ipynb` (Python), cell[33] — the « Lien avec la formalisation Lean » blockquote cites the companion Lean notebook `GT-4b-Lean-NashExistence.ipynb` size as **« 38 cellules »**, but it has since grown to **44 cells**. Markdown-only, **0 re-exec, 0 output/code change**.

## Defect (cell[33] — COUNT / stale cross-file doc)

- cell[33]: `...[GT-4b-Lean-NashExistence](GameTheory-4b-Lean-NashExistence.ipynb) (38 cellules, kernel Lean 4).`
- **Actual** (firsthand, `json.loads` of `origin/main:...GameTheory-4b-Lean-NashExistence.ipynb`): **44 cells**.

COUNT/identity class (stale doc cross-reference), **not** a measure drift of a committed output → no §D.5 diagnostic owed (coord c.1042: identity ≠ measure). Same clean class as the GT-11 Lean line-count fix (#9192).

## Fix (markdown-only)

cell[33]: `38 cellules` → `44 cellules`. The count-string is unique in the notebook (verified count = 1 pre-edit). No other prose/conclusion change.

## Authority (firsthand, #8052 lens, L786-2)

Verified directly by parsing `origin/main:MyIA.AI.Notebooks/GameTheory/GameTheory-4b-Lean-NashExistence.ipynb` → 44 cells. (The GT-4b notebook itself is owner-locked Lean / not touched here — only the cite in GT-4 is refreshed.)

## Verification (firsthand)

- Canonical: `json.loads(new)` parses; ONLY cell[33] changed; `44 cellules` present, `38 cellules` absent.
- Atomic commit `bee3939a`: `git diff-tree -r origin/main` = exactly 2 files (M notebook, M yaml); show --stat = 3 insertions, 2 deletions.
- Lock: `origin/main` NB blob `e2d19dec` == twin yaml `python_sha` pre-edit (ground-truth lock asserted in the edit script).

## Scope & coordination

1 file NB + 1 twin-yaml rebaseline (`gametheory-4-nashequilibrium.yaml`): `python_sha` `e2d19dec → c74eabd6`; `csharp_sha` `fb4ff1f4` **unchanged** (different from-scratch BCL engine, no Lean refs); `reason` added (no pre-existing `reason:` → no dup-key risk c.1132-L; parses clean c.1134-L). Python-only markdown fix; parity is semantic. L898 uncontested — no open PR touches GT-4 cell[33] (DUP-GUARD clear).

Found via the #8052 GameTheory value sweep (sub-agent reported, re-verified firsthand L786-2). See #8052.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
