### PR TITLE
fix(symbolic,#8052): ArgumentProfile c1+c27 formal-dimension phantom sources (code never reads them)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_ArgumentProfile.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_ArgumentProfile.ipynb
@@ -42,7 +42,7 @@
     "| **Qualité** | `argument_quality_scores` | Est-il clair, bien fondé, pertinent ? |\n",
     "| **Contre-arguments** | `counter_arguments` (target) | Comment peut-on l'attaquer ? |\n",
     "| **Croyances JTMS** | `jtms_beliefs` | Est-il jugé valide dans le réseau de croyances ? |\n",
-    "| **Résultats formels** | `formal_synthesis_reports` | Est-il logiquement valide ? |\n",
+    "| **Résultats formels** | `propositional_analysis_results` / `fol_analysis_results` (par `arg_id`) | Est-il logiquement valide ? |\n",
     "\n",
     "Ces cinq verdicts sont **indépendants** : un argument peut etre formellement valide (pas d'erreur logique) mais rhétoriquement fallacieux (appel à l'autorité). Le profil est la seule vue qui les reunis.\n"
    ]
@@ -712,7 +712,7 @@
     "| Direction | Lien | Relation |\n",
     "|-----------|------|----------|\n",
     "| <-> Agentic-1-informal | [Detection de sophismes par taxonomie](Argument_Analysis_Agentic-1-informal.ipynb) | Couvre la **dimension 1** (sophismes). Ce notebook la reunis avec les 4 autres dans le profil. |\n",
-    "| <-> Dung AF Semantics | [Sémantiques de Dung](Argument_Analysis_Dung_AF_Semantics.ipynb) | La **dimension formelle** (AF_Dung) alimente le champ `formal_results` du profil. |\n",
+    "| <-> Dung AF Semantics | [Sémantiques de Dung](Argument_Analysis_Dung_AF_Semantics.ipynb) | Voisin conceptuel — les frameworks Dung vivent dans `dung_frameworks` (comptes dans les statistiques globales) et ne sont **pas** projetes dans le profil par argument (seuls les verdicts PL/FOL de la dimension 5 y entrent). |\n",
     "| <-> Restitution 3 Actes | [Restitution narrative](Argument_Analysis_Restitution_3_Actes.ipynb) | Le profil est l'unite de base restituee dans le recit en 3 actes (un argument = un personnage). |\n",
     "\n",
     "## 7. Conclusion\n",


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**2 phantom data-source defects** in `Argument_Analysis_ArgumentProfile.ipynb` (Python, NOT twinned) — markdown rows document data sources the profile code **never reads**. Verified firsthand against `argumentation_lib/_shared_state.py::get_argument_profile`. Markdown-only, **0 re-exec, 0 code/output change**.

## Defect 1 (cell[1] table — PHANTOM source field)

The « §1 Pourquoi un profil » table's « Résultats formels » row named the state source as `` `formal_synthesis_reports` ``:

| **Résultats formels** | `formal_synthesis_reports` | Est-il logiquement valide ? |

**Ground truth** (`_shared_state.py::get_argument_profile`, line 883) — the formal dimension reads **only**:
- `self.propositional_analysis_results` (line 44 → `profile.formal_results.append`)
- `self.fol_analysis_results` (line 47 → append)
- `self.nl_to_logic_translations` (line 50 → append)

`formal_synthesis_reports` is **never read** by the profile (grep inside `get_argument_profile` = 0 hits). The notebook **already corrects this itself** in cell[13]: *« `get_argument_profile` lit les résultats liés à un argument (`arg_id=`) : `add_propositional_analysis_result` (PL), `add_fol_analysis_result` (FOL)… »* + the honesty note *« `add_formal_synthesis_report` existe aussi, mais produit une synthèse débat-large (non liée à un `arg_id`) que le profil, par conception, ne projette pas. »* Cell[14] code uses only the two `*_analysis_result` helpers.

**Fix:** row source → `` `propositional_analysis_results` / `fol_analysis_results` (par `arg_id`) `` — matching the table convention (other rows use state-field names: `identified_fallacies`, `argument_quality_scores`, `counter_arguments`, `jtms_beliefs`).

## Defect 2 (cell[27] Dung bridge — PHANTOM `formal_results` projection)

The « Ponts avec la série » table's Dung AF Semantics row claimed: *« La **dimension formelle** (AF_Dung) alimente le champ `formal_results` du profil. »*

**Ground truth** (`_shared_state.py`): `add_dung_framework` writes to `self.dung_frameworks[df_id]`, and that dict appears **only** in the global-stats block (line 184: `"dung_framework_count": len(self.dung_frameworks)`) — **never** projected per-argument into `profile.formal_results`. The notebook never calls `add_dung_framework` either. (Only PL/FOL/NL-translation results enter `formal_results`, via dimension 5.)

**Fix:** honest « conceptual neighbour » framing — Dung frameworks live in `dung_frameworks` (counted in global stats) and are **not** projected into the per-argument profile (only PL/FOL verdicts of dimension 5 enter it). Parallel to the cell[13] honesty note.

## Class (no §D.5)

PHANTOM/identity class — prose documents a code data-source/path that **does not exist** (verified against the code itself, not a committed computed output). This is **not** a measure/value drift → no §D.5 diagnostic owed (coord c.1042: identity ≠ measure; precedent #9185 Ontology_AIF TOC/identity, #9188 Planners-1 dup-heading — both no-§D.5).

## Authority (firsthand, #8052 lens, L786-2)

Read cell[1], cell[13], cell[14], cell[27] directly from `origin/main`; grepped `get_argument_profile` in `_shared_state.py` for the three formal fields + `formal_synthesis_reports` + `dung_frameworks` (the crux of a phantom claim = the code path). The two phantom strings are each unique in the notebook (count = 1 pre-edit).

## Verification (firsthand)

- Byte-level raw-text edit (this notebook's JSON serialization is **non-round-trippable** by `json.dumps(indent=1)`, c.1136-L — same as Ontology_AIF); re-parsed via `json.loads` to confirm ONLY cells[1] and [27] changed.
- Cells[13] (the authority honesty note) and [14] (code) byte-preserved.
- Atomic commit `b9a20849`: `git diff-tree -r origin/main` = exactly 1 file; show --stat = 2 insertions, 2 deletions.
- Lock: NB blob `ea9cb315` == `origin/main` pre-edit (asserted in edit script).

## Scope & coordination

1 file NB, NOT twinned (single-file, no yaml rebaseline). Markdown-only, 0 re-exec. L898 uncontested — DUP-GUARD clear (no open PR touches ArgumentProfile). Argument_Analysis is non-Lean SymbolicAI → in po-2024 partition (not owner-locked).

Found via the #8052 Argument_Analysis sweep (sub-agent reported 12 findings; re-verified firsthand L786-2; shipped the 2 single-cell ArgumentProfile phantom fixes — the cheapest high-value, same-file-bundled). **DEFERRED (EPIC #8364 / author-judgment):** Ontology_Virtues STALE cluster (cells 0/7/8/15/17/23/25 — post-#763 ABox→owl:Class contrast died, needs pedagogical redesign incl. the conclusion cell); Ontology_CrossLinks cell[25] = **#9122 (PARALLEL-DELIVERY, c.1037-L) actively owns it → avoided**; Executor timing (cell 17/19/27 = timing class, c.1062-L weakest, LLM-latency-dependent → DEFER).

See #8052.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
