### PR TITLE
fix(casestudies,#8052): Oncology-Planning heading gap -- ### 2.2 with no ### 2.1

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
@@ -652,6 +652,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "heading21onco",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Dans cette deuxième partie, nous adoptons une approche **probabiliste** : au lieu de règles déterministes, le médecin modélise son incertitude sur le profil du patient (résistant, normal, sensible) et la révise à mesure que les doses et les observations cliniques s'accumulent. Cette inférence bayésienne est implémentée avec **Pyro**.\n",
+    "\n",
+    "### 2.1. Le modèle probabiliste de patient (Pyro)\n",
+    "\n",
+    "Le cœur du médecin probabiliste est `OncoModel`, un modèle génératif qui relie les doses de chimiothérapie aux observations (toxicité cumulée, taux de globules blancs) via le profil latent du patient. Il sert de base à la fois à l'inférence du profil et à la prédiction de la réponse aux doses futures."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "b8e1e297",


### PR DESCRIPTION
Grain: LOW/structural -- lane myia-po-2023:CoursIA -- prev: LEAN/native_decide-reduction #9190

See #8052. Fixes a heading numbering gap in Oncology-Planning.ipynb (CaseStudies solution): the numbered subsection sequence jumped `### 1.1` -> `### 1.2` -> `### 2.2` with NO `### 2.1`. Partie 2 ("Le Medecin Probabiliste (Pyro)") had its heading immediately followed by the `OncoModel` code cell with no subsection heading introducing it.

## Defect (structural, c.1099-L)

Verified firsthand against the `origin/main` blob -- the only `\d\.\d` subsection headings were 1.1, 1.2, 2.2 (no 2.1 anywhere):

- [18] `## Partie 2 : Le Medecin Probabiliste (Pyro)`
- [19] `class OncoModel:` (the Pyro Bayesian patient-response model -- NO heading)
- [20] `### 2.2. Prediction et Prise de Decision`

This is the canonical "### 4.3 with no ### 4.2" pattern (cf Planners #9187/#9188). Class = **structural** (heading numbering gap), NOT a claim<->output value contradiction -> no §D.5 `## Diagnostic derive` owed (cf #9081, classe identite merged without diagnostic).

## Fix

Inserted ONE markdown cell between the Partie 2 heading [18] and the OncoModel code [19]:

- A brief Partie 2 intro (the section previously had ZERO intro text -- heading jumped straight to code).
- A `### 2.1. Le modele probabiliste de patient (Pyro)` heading that introduces the `OncoModel` definition.

The `OncoModel` IS the natural 2.1 content (the Bayesian patient model); "### 2.2. Prediction et Prise de Decision" then correctly follows as the second subsection. Resulting sequence: 1.1 -> 1.2 -> 2.1 -> 2.2 (clean).

## Verification (firsthand, #8052 lens)

- Heading sequence post-fix: 1.1 / 1.2 / **2.1** (new) / 2.2 -- no gap, no duplicate.
- `detect_markdown_rendering`: 0 violations.
- C.1: 0 forbidden patterns (no code touched).
- Outputs preserved: markdown-only insertion between [18] and the code cell -- no `execution_count` or `outputs` cell modified (11 code cells intact, 8 with exec_count+outputs).
- No internal Sommaire/TOC references 2.1 (checked) -- nothing else to reconcile.
- No collision: #9065 (MERGED) fixed a different defect (fabricated 98%/15%/83 values) on this file; no OPEN PR touches it.

## Scope

1 file, 14 insertions / 0 deletions (pure additive -- one new markdown cell). No code, no outputs changed. No re-execution needed (markdown insertion).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
