### PR TITLE
fix(symbolic,#8052): Formal_Richness_Matrix c3 "40/40 capacites" vs own computed "24/24" + wrong ci-dessus ref

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Formal_Richness_Matrix.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Formal_Richness_Matrix.ipynb
@@ -113,7 +113,7 @@
     "tags": []
    },
    "source": [
-    "La mesure naïve ci-dessus est précisément ce qu'il faut **ne pas** faire. Elle répondrait « 40/40 capacités » alors que la moitié ne décide rien. Construisons l'instrument honnête : une fonction de **classification par la sortie**."
+    "La mesure naïve ci-dessous est précisément ce qu'il faut **ne pas** faire. Elle répondrait « 24/24 capacités » alors que 10 cellules sur 24 ne décident rien de substantif (14 substantive / 6 honest_absent / 3 unavailable / 1 théâtre — tally cellule 9). Construisons l'instrument honnête : une fonction de **classification par la sortie**."
    ]
   },
   {


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**1 value/count self-contradiction** in `Argument_Analysis_Formal_Richness_Matrix.ipynb` (Python, NOT twinned), cell[3] — prose says the naïve measure answers **« 40/40 capacités »** and calls it « la mesure naïve **ci-dessus** », but the notebook's own committed naive measure (cell[9]) answers **24/24** (8 caps × 3 corpora). Markdown-only, **0 re-exec, 0 code/output change**.

## Defect (cell[3] — VALUE/count + wrong reference)

cell[3]: *« La mesure naïve **ci-dessus** est précisément ce qu'il faut **ne pas** faire. Elle répondrait « **40/40** capacités » alors que la moitié ne décide rien. »*

Two defects against the notebook's own deterministic outputs:
1. **« 40/40 » is wrong.** The naïve measure lives in cell[9] (`build_matrix`), whose committed output is *« Mesure naïve (grep de présence) : **24/24** capacités 'couvertes' »*. cell[8] sets the matrix at **8 capacités × 3 corpus = 24**; cell[10] also states the naïve measure is *« **24/24** cellules couvertes »*. So cell[3]'s 40/40 contradicts cell[9] + cell[10] for the **same** measure. (« 40 » appears only as a *hypothetical illustration* in cell[0]: « Un système peut afficher 40 capacités formelles… et ne décider réellement que 5 choses. » — not the real matrix.)
2. **« ci-dessus » is wrong.** cells 0–2 are prose; the naïve measure is in cell[9], which is **below** cell[3] → should be « ci-dessous ».

**Fix:** « 40/40 capacités » → « 24/24 capacités » (align with cell[9] output + cell[10]); « la moitié ne décide rien » → precise tally « 10 cellules sur 24 ne décident rien de substantif (14 substantive / 6 honest_absent / 3 unavailable / 1 théâtre — tally cellule 9) »; « ci-dessus » → « ci-dessous ».

## Diagnostic dérive (§D.5 required — measure/value class)

- **Cause : (b) claim antérieure fabriquée.** The prose fabricated « 40/40 » (mixing cell[0]'s hypothetical « 40 capacités » with the real matrix) and mis-pointed the reference as « ci-dessus ». The committed naïve measure is **deterministic** (cell[9]) and did NOT move — it is 24/24.
- **Verdict : CAUSE_FIXED.** The claim is realigned to the committed 24/24 + tally (cell[9]: substantive 14 / honest_absent 6 / unavailable 3 / theatre 1 = 24; so 10/24 non-substantif). The fabricated « 40/40 » does **not** survive the PR → **no child issue owed**.
- **Stop & Repair (rule 6) :** no cell output hand-edited; markdown-only, 0 re-exec. cell[9] committed output preserved untouched as ground truth.

## Authority (firsthand, #8052 lens, L786-2)

Read cell[0], cell[3], cell[8], cell[9] (code + committed output), cell[10] directly from `origin/main`. Verified the naïve-measure output is *« 24/24 »* (cell[9] output) and cell[10] agrees. The « 40/40 » string is unique in the notebook (count = 1 pre-edit). The « 40 » is traceable to cell[0]'s hypothetical (per c.1088-L I checked it isn't computed elsewhere) — but cell[3] attributes it to the real naïve measure, which is the contradiction.

## Verification (firsthand)

- This notebook's JSON serialization **is** round-trippable (`json.dumps(indent=1)` == raw), so used canonical round-trip + element-level replace (c.1123-L) of cell[3].source.
- Trailing newline: raw ends with `}` (no trailing newline) → preserved (c.1086-L).
- ONLY cell[3] changed; cells[0,9,10] (the authority) byte-preserved.
- Atomic commit `9faf6378`: `git diff-tree -r origin/main` = exactly 1 file; show --stat = 1 insertion, 1 deletion.
- Lock: NB blob `f67005b9` == `origin/main` pre-edit (asserted in edit script).

## Scope & coordination

1 file NB, NOT twinned (single-file, no yaml rebaseline). Markdown-only, 0 re-exec. L898 uncontested — DUP-GUARD clear (no open PR touches Formal_Richness_Matrix). §D.5 section placed BEFORE the footer (c.1140-L).

Found via the #8052 Argument_Analysis sweep (sub-agent flagged as medium-confidence; re-verified firsthand L786-2 — the 24/24 authority is unambiguous). See #8052.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
