### PR TITLE
feat(lean,#8869): convert Nim native_decide -> kernel decide (8 theorems)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Nim.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Nim.lean
@@ -55,7 +55,7 @@ theorem nimSum_nil : nimSum [] = 0 := rfl
 
 /-- CALIBRATION (decide) : la position [3,4,5] est gagnante pour le premier joueur. -/
 theorem isWinningNim_345 : isWinningNim [3, 4, 5] = true := by
-  native_decide
+  decide
 
 /-- CALIBRATION (unfold + zero_xor) : un tas unique a un nim-sum égal à sa taille. -/
 theorem nimSum_single (n : Nat) : nimSum [n] = n := by
@@ -84,7 +84,7 @@ du XOR qui la sous-tend. -/
     Utilisons [3, 5, 6] : 3 ^^^ 5 = 6, 6 ^^^ 6 = 0... aussi équilibrée.
     [3, 5, 7] : 3 ^^^ 5 = 6, 6 ^^^ 7 = 1 ≠ 0 — gagnante. -/
 theorem isWinningNim_357 : isWinningNim [3, 5, 7] = true := by
-  native_decide
+  decide
 
 /-- Après avoir retiré k pierres du tas i, le nouveau nim-sum est l'ancien nim-sum
     XOR avec le changement dans ce tas. C'est la clé algébrique de la stratégie
@@ -96,7 +96,7 @@ theorem isWinningNim_357 : isWinningNim [3, 5, 7] = true := by
     Nouvelle position [2, 5, 7] : 2 ^^^ 5 ^^^ 7 = 0. P-position ! -/
 theorem nimStrategy_357 :
     nimSum [2, 5, 7] = 0 ∧ 2 < 3 := by
-  native_decide
+  decide
 
 /-- Le XOR avec zéro est l'identité. -/
 theorem xor_zero (n : Nat) : n ^^^ 0 = n := by
@@ -120,20 +120,20 @@ theorem nimSum3_assoc (a b c : Nat) : a ^^^ b ^^^ c = a ^^^ (b ^^^ c) := by
 theorem winning_move_357 :
     nimSum [3, 5, 7] = 1 ∧
     nimSum [2, 5, 7] = 0 := by
-  native_decide
+  decide
 
 /-- Une autre stratégie concrète : la position [1, 2, 3] a un nimSum 0 (P-position),
     ce qui signifie que le SECOND joueur gagne. Tout coup du premier joueur mène
     à une N-position (nimSum non nul). -/
 theorem losing_position_123 : nimSum [1, 2, 3] = 0 := by
-  native_decide
+  decide
 
 /-- Après le coup du premier joueur depuis [1, 2, 3], toute position résultante
     a un nimSum non nul (N-position). -/
 theorem all_moves_from_123_winning :
     nimSum [0, 2, 3] ≠ 0 ∧ nimSum [1, 1, 3] ≠ 0 ∧ nimSum [1, 0, 3] ≠ 0 ∧
     nimSum [1, 2, 2] ≠ 0 ∧ nimSum [1, 2, 0] ≠ 0 := by
-  native_decide
+  decide
 
 /-- Si `a ^^^ s < a` où `s = nimSum heaps`, alors réduire le tas `a` à
     `a ^^^ s` annule le nim-sum. C'est la **propriété clé** de la stratégie
@@ -141,7 +141,7 @@ theorem all_moves_from_123_winning :
     au moins un tas a ce bit positionné, rendant `a ^^^ s < a` vrai.
 
     Nous vérifions cela sur des instances concrètes : -/
-theorem xor_reduce_3_1 : 3 ^^^ 1 = 2 ∧ 2 < 3 := by native_decide
+theorem xor_reduce_3_1 : 3 ^^^ 1 = 2 ∧ 2 < 3 := by decide
 
 /-- Pour [3, 5, 7] : la vérification complète de la stratégie.
     nimSum = 1. Réduire le tas 0 (taille 3) à 3 ^^^ 1 = 2 annule la somme. -/
@@ -150,7 +150,7 @@ theorem winning_move_verified_357 :
     s = 1 ∧
     (3 ^^^ s) < 3 ∧
     nimSum [3 ^^^ s, 5, 7] = 0 := by
-  native_decide
+  decide
 
 
 end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Nim_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Nim_en.lean
@@ -47,7 +47,7 @@ theorem nimSum_nil : nimSum [] = 0 := rfl
 
 /-- CALIBRATION (decide): the position [3,4,5] is a first-player win. -/
 theorem isWinningNim_345 : isWinningNim [3, 4, 5] = true := by
-  native_decide
+  decide
 
 /-- CALIBRATION (unfold + zero_xor): a single heap has nim-sum equal to its size. -/
 theorem nimSum_single (n : Nat) : nimSum [n] = n := by
@@ -75,7 +75,7 @@ on small instances, plus the general XOR property that makes it work. -/
     Let me use [3, 5, 6]: 3 ^^^ 5 = 6, 6 ^^^ 6 = 0... also balanced.
     [3, 5, 7]: 3 ^^^ 5 = 6, 6 ^^^ 7 = 1 ≠ 0 — winning. -/
 theorem isWinningNim_357 : isWinningNim [3, 5, 7] = true := by
-  native_decide
+  decide
 
 /-- After removing k stones from heap i, the new nim-sum is the old nim-sum
     XOR'd with the change in that heap. This is the algebraic key to the
@@ -87,7 +87,7 @@ theorem isWinningNim_357 : isWinningNim [3, 5, 7] = true := by
     New position [2, 5, 7]: 2 ^^^ 5 ^^^ 7 = 0. P-position! -/
 theorem nimStrategy_357 :
     nimSum [2, 5, 7] = 0 ∧ 2 < 3 := by
-  native_decide
+  decide
 
 /-- XOR with zero is the identity. -/
 theorem xor_zero (n : Nat) : n ^^^ 0 = n := by
@@ -111,20 +111,20 @@ theorem nimSum3_assoc (a b c : Nat) : a ^^^ b ^^^ c = a ^^^ (b ^^^ c) := by
 theorem winning_move_357 :
     nimSum [3, 5, 7] = 1 ∧
     nimSum [2, 5, 7] = 0 := by
-  native_decide
+  decide
 
 /-- Another concrete strategy: position [1, 2, 3] has nimSum 0 (P-position),
     meaning the SECOND player wins. Any move the first player makes leads
     to an N-position (non-zero nimSum). -/
 theorem losing_position_123 : nimSum [1, 2, 3] = 0 := by
-  native_decide
+  decide
 
 /-- After the first player's move from [1, 2, 3], every resulting position
     has non-zero nimSum (N-position). -/
 theorem all_moves_from_123_winning :
     nimSum [0, 2, 3] ≠ 0 ∧ nimSum [1, 1, 3] ≠ 0 ∧ nimSum [1, 0, 3] ≠ 0 ∧
     nimSum [1, 2, 2] ≠ 0 ∧ nimSum [1, 2, 0] ≠ 0 := by
-  native_decide
+  decide
 
 /-- If `a ^^^ s < a` where `s = nimSum heaps`, then reducing heap `a` to
     `a ^^^ s` zeros the nim-sum. This is the **key property** of the winning
@@ -132,7 +132,7 @@ theorem all_moves_from_123_winning :
     at least one heap has that bit set, making `a ^^^ s < a` true.
 
     We verify this on concrete instances: -/
-theorem xor_reduce_3_1 : 3 ^^^ 1 = 2 ∧ 2 < 3 := by native_decide
+theorem xor_reduce_3_1 : 3 ^^^ 1 = 2 ∧ 2 < 3 := by decide
 
 /-- For [3, 5, 7]: the full strategy verification.
     nimSum = 1. Reducing heap 0 (size 3) to 3 ^^^ 1 = 2 zeros the sum. -/
@@ -141,7 +141,7 @@ theorem winning_move_verified_357 :
     s = 1 ∧
     (3 ^^^ s) < 3 ∧
     nimSum [3 ^^^ s, 5, 7] = 0 := by
-  native_decide
+  decide
 
 
 end Conway_en


### PR DESCRIPTION
Grain: LEAN/native_decide-reduction -- lane myia-po-2023:CoursIA -- prev: LEAN/native_decide-reduction #9190

See #8869 (partial -- Nim module). Converts 8 native_decide theorems to kernel decide in Conway/Nim.lean (+ i18n sibling _en.lean, EPIC #4980). Continues the native_decide-reduction attack: #9163 (microproofs), #9189 (DoomsdayLemmas 4), #9190 (CollatzLike 8), now Nim 8.

## The conversion

8 theorems now proven by kernel decide instead of native_decide:

- isWinningNim_345 : isWinningNim [3, 4, 5] = true
- isWinningNim_357 : isWinningNim [3, 5, 7] = true
- nimStrategy_357 : nimSum [2, 5, 7] = 0 ∧ 2 < 3
- winning_move_357 : nimSum [3, 5, 7] = 1 ∧ nimSum [2, 5, 7] = 0
- losing_position_123 : nimSum [1, 2, 3] = 0
- all_moves_from_123_winning : nimSum [0,2,3] ≠ 0 ∧ ... (5 conjuncts)
- xor_reduce_3_1 : 3 ^^^ 1 = 2 ∧ 2 < 3  (inline form)
- winning_move_verified_357 : let s := nimSum [3,5,7]; s = 1 ∧ (3 ^^^ s) < 3 ∧ nimSum [3 ^^^ s, 5, 7] = 0

All are closed evaluations on list/nat literals (nimSum / isWinningNim / xor applied to literal lists). 7 use the block tactic form (`:= by\n  native_decide`), 1 uses inline form (`:= by native_decide`) -- the conversion handles both. The recursion in nimSum/isWinningNim is structural on the list, so the kernel reduces these cleanly (same pattern as CollatzLike #9190).

## Verification (firsthand, conway_lean cache warm, toolchain v4.31.0-rc1)

1. Probe scratch (Conway/ProbeNim.lean, untracked, deleted): all 8 example goals closed by decide. lake build Conway.ProbeNim SUCCESS (577 jobs, exit 0).
2. lake build Conway.Nim (FR) SUCCESS (576 jobs, exit 0). lake build Conway.Nim_en (EN) SUCCESS (577 jobs, exit 0).
3. Proof integrity #print axioms (the point of #8869 -- make native_decide kernel-reducible):
   - all 8 theorems: depend on `[propext]` only (standard Lean foundation -- NOT sorryAx, NOT the native_decide codegen axiom `._native.native_decide.ax_1_1`).
   STRICT proof-integrity improvement: axiom surface reduced (native_decide codegen axiom removed), none added, no sorryAx.
4. Anti-regression: 0 sorry tactics (the lone `native_decide` grep hit is the module docstring prose "à l'aide de native_decide"). No proof replaced by sorry -- the opposite: native_decide (codegen axiom) upgraded to kernel decide.
5. i18n pair validity (check_i18n_siblings.py): OK, byte-identical body, 0 drift, 0 orphan. The tactic change (decide) is byte-identical across FR/EN (English tactic, #4980 convention); only docstrings differ (unchanged here).

## Scope

2 files, 16 insertions / 16 deletions (8 tactic lines per file: native_decide -> decide; 7 block + 1 inline form). Module docstrings unchanged (the one "native_decide" mention in prose documents the technique and remains accurate). No sorry, no sorry-baseline change (0 sorry tactics, gate unaffected).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
