### PR TITLE
fix(search,#8052): App-12 ConnectFour c33 "Participants" table names MCTS(1000) but tournament uses MCTS(500)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb
@@ -1860,7 +1860,7 @@
     "| Greedy | Heuristique | 1 coup |\n",
     "| Minimax(d=4) | Arbre adversaire | Profondeur 4, alpha-beta |\n",
     "| Minimax(d=6) | Arbre adversaire | Profondeur 6, alpha-beta |\n",
-    "| MCTS(1000) | Monte Carlo | 1000 itérations |"
+    "| MCTS(500) | Monte Carlo | 500 itérations |"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/app-12-connectfour.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-12-connectfour.yaml
@@ -6,7 +6,8 @@
   last_audit:
     date: '2026-07-25'
     by: po-2026
-    python_sha: 7b29b76a0a3644fc6b05d18d2e47cc294018165e
+    python_sha: 77bf96c05321f063ddad84755458050e16154329
+    reason: "Markdown-only identity fix (cell 33 Participants table): row named MCTS(1000)/1000 itérations, but the actual tournament uses MCTS(500) — cell 34 code `MCTS(500): make_mcts_ai(500)`, cell 36 output ranking MCTS(500), cell 39 interpretation MCTS(500). Aligned to MCTS(500)/500 itérations. No re-exec, no output change. C# twin untouched (different System.* BCL engine)."
     csharp_sha: 540ef653a9252b9040e1eeff424c36c64c9bd82c
   known_differences:
     - "Socle pedagogique commun : Puissance 4 / Connect Four (IA jeux combinatoires : minimax alpha-beta, MCTS, framework AIMA) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**1 identity defect** in `App-12-ConnectFour.ipynb` (Python, twinned `app-12-connectfour.yaml`), cell[33] — the « Participants » table of the round-robin tournament names the MCTS entrant as **MCTS(1000) / 1000 itérations**, but the actual tournament runs **MCTS(500)**. Markdown-only, **0 re-exec, 0 code/output change**.

## Defect (cell[33] — IDENTITY / entrant mis-label)

cell[33] table row: `| MCTS(1000) | Monte Carlo | 1000 itérations |`

**Ground truth (the actual tournament in the same notebook):**
- cell[34] code: `'MCTS(500)': make_mcts_ai(500),  # Reduit a 500 pour le tournoi`
- cell[36] committed output, ranking row: `MCTS(500)  14 ... 983.6`
- cell[39] interpretation writes **MCTS(500)** throughout (*« Balaye MCTS(500) 6W-0D-0L »*, *« Competitive contre Minimax(d=6) »*).

So the entrant is MCTS(500); the Participants table mis-labels it MCTS(1000). `MCTS(500)` appears 13× correctly elsewhere; only this table row is wrong.

## Fix (markdown-only, element-level byte replace)

cell[33] row → `| MCTS(500) | Monte Carlo | 500 itérations |` (aligns with cell[34] code + cell[36] output + cell[39]). The full row string is byte-unique (count = 1).

## Class (no §D.5)

IDENTITY class — an entrant label in a table contradicts the entrant the tournament actually uses (code + output). This is **not** a measure/value drift of a committed output → no §D.5 diagnostic owed (coord c.1042: identity ≠ measure; precedent #9188 Planners-1 dup-heading, #9185 Ontology_AIF — all no-§D.5 identity).

## Authority (firsthand, #8052 lens, L786-2)

Read cell[33], cell[34] (code), cell[36] (committed output), cell[39] directly from `origin/main`. Verified `make_mcts_ai(500)` + output `MCTS(500)` + cell[39] MCTS(500). The mis-labelled row string is unique (count = 1).

## Verification (firsthand)

- This notebook's JSON serialization is **non-round-trippable** (`json.dumps(indent=1)` ≠ raw, c.1136-L) → byte-level raw-text replace + re-parse `json.loads` to confirm ONLY cell[33] changed.
- Cells[34, 36, 39] (the MCTS(500) authority) byte-preserved.
- Atomic commit `94fbf8f6`: `git diff-tree -r origin/main` = exactly 2 files (M notebook, M yaml); show --stat = 3 insertions, 2 deletions.
- Lock: NB blob `7b29b76a` == `origin/main` == twin yaml `python_sha` pre-edit (asserted in edit script).

## Scope & coordination

1 file NB + 1 twin-yaml rebaseline (`app-12-connectfour.yaml`): `python_sha` `7b29b76a → 77bf96c0`; `csharp_sha` `540ef653` **unchanged** (different System.* BCL engine, no MCTS-iteration label of this kind); `reason` added (no pre-existing `reason:` → no dup-key risk c.1132-L; parses clean c.1134-L). Python-only markdown identity fix; parity is semantic. L898 uncontested — DUP-GUARD clear (no open PR touches App-12-ConnectFour; #9128 relabels App-1b/2b/11b, #9117 prereq is App-5/6/7).

Found via the #8052 App/Applications sweep (sub-agent reported 24 findings; re-verified firsthand L786-2; shipped the cleanest uncontested single-cell identity fix. **Skipped by DUP-GUARD (c.1117-L):** F10 App-7b 296→297 = already owned by open **#9124**; timing-class findings (F5/F6/F7/F8/F21-F24) deferred per c.1062-L. Other VALUE findings in App-11-Picross / App-1-NQueens are future candidates — bundle-able per-notebook if uncontested.)

See #8052.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
