### PR TITLE
feat(lean,#8869): convert Angel native_decide -> kernel decide (2 theorems)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Angel.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Angel.lean
@@ -57,11 +57,11 @@ theorem chebyshev_self (a : ℤ × ℤ) : chebyshev a a = 0 := by
 
 /-- CALIBRATION (decide / native_decide): Conway's power-1 Angel is a king — 8 moves. -/
 theorem kingMoves_card : (angelMoves 1 (0, 0)).card = 8 := by
-  native_decide
+  decide
 
 /-- CALIBRATION (decide / native_decide): the power-2 Angel has 24 moves. -/
 theorem angelMoves2_card : (angelMoves 2 (0, 0)).card = 24 := by
-  native_decide
+  decide
 
 /-- CALIBRATION (Finset.card arithmetic, medium): an Angel of power `k` from any
     square has exactly `(2k+1)^2 - 1` moves — the combinatorial heart of the Angel

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Angel_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Angel_en.lean
@@ -53,11 +53,11 @@ theorem chebyshev_self (a : ℤ × ℤ) : chebyshev a a = 0 := by
 
 /-- CALIBRATION (decide / native_decide): Conway's power-1 Angel is a king — 8 moves. -/
 theorem kingMoves_card : (angelMoves 1 (0, 0)).card = 8 := by
-  native_decide
+  decide
 
 /-- CALIBRATION (decide / native_decide): the power-2 Angel has 24 moves. -/
 theorem angelMoves2_card : (angelMoves 2 (0, 0)).card = 24 := by
-  native_decide
+  decide
 
 /-- CALIBRATION (Finset.card arithmetic, medium): an Angel of power `k` from any
     square has exactly `(2k+1)^2 - 1` moves — the combinatorial heart of the Angel


### PR DESCRIPTION
Grain: LEAN/native_decide-reduction -- lane myia-po-2023:CoursIA -- prev: LEAN/native_decide-reduction #9197

See #8869 (partial -- Angel module). Converts 2 native_decide theorems to kernel decide in Conway/Angel.lean (+ i18n sibling _en.lean, EPIC #4980). Continues the native_decide-reduction attack: #9163, #9189, #9190, #9197 (Nim 8), now Angel 2. This completes the convertible native_decide set in Conway (only the INTRINSIC lookAndSay_4 + the evolve-obstruction front in Life/Computation remain).

## The conversion

2 theorems now proven by kernel decide instead of native_decide:

- kingMoves_card : (angelMoves 1 (0, 0)).card = 8
- angelMoves2_card : (angelMoves 2 (0, 0)).card = 24

Both are closed cardinality evaluations: angelMoves applied to a literal power (1, 2) and the origin position, then `.card` on the resulting finite set. The recursion in angelMoves is structural/bounded, so the kernel reduces these cleanly.

## Verification (firsthand, conway_lean cache warm, toolchain v4.31.0-rc1)

1. Probe scratch (Conway/ProbeAngel.lean, untracked, deleted): both example goals closed by decide. lake build Conway.ProbeAngel SUCCESS (exit 0).
2. lake build Conway.Angel (FR) SUCCESS. lake build Conway.Angel_en (EN) SUCCESS.
3. Proof integrity #print axioms (the point of #8869 -- make native_decide kernel-reducible):
   - kingMoves_card / angelMoves2_card: depend on standard Lean foundation only (NOT sorryAx, NOT the native_decide codegen axiom `._native.native_decide.ax_1_1`).
   STRICT proof-integrity improvement: axiom surface reduced, none added, no sorryAx.
4. Anti-regression: 0 sorry tactics (the lone `native_decide` grep hits are the 2 module docstring CALIBRATION comments "decide / native_decide"). No proof replaced by sorry -- the opposite: native_decide (codegen axiom) upgraded to kernel decide.
5. i18n pair validity (check_i18n_siblings.py): OK, byte-identical body, 0 drift, 0 orphan. Tactic change (decide) byte-identical across FR/EN.

## Scope

2 files, 4 insertions / 4 deletions (2 tactic lines per file: native_decide -> decide). Module docstrings unchanged (the CALIBRATION comments already name "decide / native_decide" as the technique ladder and remain accurate). No sorry, no sorry-baseline change.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
