### PR TITLE
fix(search,#8052): App-1-NQueens c21+c32 intros cite N=1000 but scaling benchmarks stop at N=500

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb
@@ -1059,7 +1059,7 @@
    "source": [
     "### Le \"miracle\" de Min-Conflicts : scalabilite\n",
     "\n",
-    "Le résultat le plus remarquable de min-conflicts est sa capacite a résoudre des instances de **très grande taille**. Testons sur $N = 8, 50, 100, 500, 1000$ et observons l'evolution du temps."
+    "Le résultat le plus remarquable de min-conflicts est sa capacite a résoudre des instances de **très grande taille**. Testons sur $N = 8, 50, 100, 500$ et observons l'evolution du temps."
    ]
   },
   {
@@ -1536,7 +1536,7 @@
    "source": [
     "### Performance CP-SAT sur de grandes instances\n",
     "\n",
-    "Testons CP-SAT sur des tailles croissantes, jusqu'a $N = 1000$."
+    "Testons CP-SAT sur des tailles croissantes, jusqu'a $N = 500$."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/app-1-nqueens.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-1-nqueens.yaml
@@ -6,8 +6,9 @@
   last_audit:
     date: "2026-07-30"
     by: myia-po-2024:CoursIA-2
-    python_sha: 196bf38650379fdd7dfb4660d57aab39c6e8709e
+    python_sha: 36e761b00601e300e2e0755f3b6e75c5d446ef98
     csharp_sha: ed6af3b9ba5d65195099faab92b5bcee4987b70d
+    reason: "Markdown-only identity fix (Python cells 21+32): the two scaling-experiment intros cited N=1000 as a tested size, but the Python benchmarks never run it (cell 22 mc_sizes=[8,50,100,500], cell 33 cpsat_sizes=[8,50,100,500]; committed output + interpretation cells 27/34 cap at N=500). Aligned the intros to the actual cap of 500. The C# twin genuinely runs N=1000 (cell 14 sizes include 1000, output N=1000 resolu), so 1000 is a real tested size in C#, not a phantom; csharp unchanged, no parallel defect. No re-exec, no output change."
   known_differences:
     - "Socle pedagogique commun : N-Reines comme CSP canonique — formulation (variables Reines, domaines 1..N, contraintes alldifferent lignes/colonnes/diagonales), resolution par plusieurs approches. Les deux twins couvrent Backtracking + Min-Conflicts (recherche locale) ; Python ajoute OR-Tools CP-SAT (3eme approche) + section comparative, C# ajoute l'enumeration exhaustive de toutes les solutions."
     - "Idiomes framework : Python = OR-Tools CP-SAT (CpModel, AddAllDifferent) + backtracking/min-conflicts from-scratch, 54 cellules (formulation CSP, 3 approches, comparaison, exemple guide). C# = pur System.* (System / System.Collections.Generic / System.Linq), 0 NuGet, 5 using, 28 cellules (backtracking + min-conflicts + enumeration from-scratch, presentation compacte)."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**2 phantom-size defects** in `App-1-NQueens.ipynb` (Python, **twinned** with `App-1b-NQueens-CSharp.ipynb`), cells [21] + [32] — both scaling-experiment intros cite **N=1000** as a tested size, but the actual Python benchmarks (code + committed output + interpretation) stop at **N=500**. Markdown-only, **0 re-exec, 0 code/output change**.

## Defects (cells [21] + [32] — IDENTITY / phantom test-size)

**cell[21]** (Min-Conflicts scaling intro): *« Testons sur $N = 8, 50, 100, 500, 1000$ et observons l'évolution du temps. »*
- cell[22] code: `mc_sizes = [8, 50, 100, 500]` — no 1000.
- cell[22] committed output: rows `N = 8 / 50 / 100 / 500` (max **500**), last `500 | 72249.9 ms | 346 | Oui`.
- cell[27] interpretation: table 8/50/100/500, *« sur la plus grande instance committee (N=500) »*.

**cell[32]** (CP-SAT scaling intro): *« Testons CP-SAT sur des tailles croissantes, jusqu'a $N = 1000$. »*
- cell[33] code: `cpsat_sizes = [8, 50, 100, 500]` — no 1000.
- cell[33] committed output: rows `N = 8 / 50 / 100 / 500` (max **500**), last `500 | 60287.8 ms | UNKNOWN`.
- cell[34] interpretation: *« N=500 (plus grande instance committee) »*.

So **N=1000 is a phantom size in both Python intros** — the benchmark was capped at 500 (likely runtime: min-conflicts ~72 s at N=500), and the intros were not trimmed. `1000` appears in these 2 intros only (cell[39]'s qualitative `N=1000` table-column is a separate characterization — **deferred**, EPIC #8364).

## C# twin analysis (Python-only fix)

The C# twin `App-1b-NQueens-CSharp.ipynb` **genuinely runs N=1000** — cell[14] code `var sizes = new[] { 8, 50, 100, 200, 500, 1000 }` includes 1000, and its output prints *« N = 1000 résolu en quelques centaines d'itérations »*. So **1000 is a real tested size in C#, not a phantom** → the defect is Python-only, csharp is PRESERVED, no parallel defect. (Same situation as #9198 where the C# twin's engine differed from the Python label.)

## Fix (markdown-only, byte-level replace; both strings unique count=1)

- cell[21]: `8, 50, 100, 500, 1000` → `8, 50, 100, 500` (drops the phantom 1000).
- cell[32]: `jusqu'a $N = 1000$` → `jusqu'a $N = 500$` (aligns to the real cap).

## Class (no §D.5)

IDENTITY/phantom class — the intros name a test size (1000) the Python benchmarks never run (code + output + interp all cap at 500). This is **not** a measure/value drift of a committed output → no §D.5 diagnostic owed. Exact precedent: **#9198** (App-12 ConnectFour Participants table `MCTS(1000)`→`MCTS(500)`, same notebook family Search/Applications/CSP, same identity class, no §D.5).

## Authority (firsthand, #8052 lens, L786-2)

Read cell[21], cell[22] (code + committed output), cell[27], cell[32], cell[33] (code + committed output), cell[34] directly from `origin/main`. Verified `mc_sizes=[8,50,100,500]` + `cpsat_sizes=[8,50,100,500]` and the committed output rows stop at 500; both interpretation cells write "N=500 plus grande instance committee". Traced every other `1000` occurrence (c.1088-L): cell[2] `$N=10^6$` = theoretical literature claim; cell[20] `max_steps=max(5*n,1000)` = code min-floor; cell[39] `N=1000` = deferred qualitative column; cell[45] `random.seed(1000+...)` = code seed — none is the scaling benchmark. The 2 phantom-intro strings are byte-unique (count=1 each pre-edit).

## Verification (firsthand)

- NB JSON serialization is round-trippable, but used byte-level replace of the 2 unique source strings (most surgical) + `json.loads` re-parse to confirm ONLY cells[21]+[32] changed. Authority cells[22, 27, 33, 34] byte-preserved.
- Lock: NB blob `196bf386` == `origin/main` pre-edit (asserted in edit script). New NB blob `36e761b0`.
- **Twin parity gate (#8057) verified locally** with the exact CI command `check_twin_parity.py --json --check --per-pair --base origin/main`: exit 0, **drift_introduced=0**, `App-1 NQueens -> OK`. (Initial push without the yaml rebaseline failed this gate — the twin registry `app-1-nqueens.yaml` was missed because a trailing-slash `git ls-tree` returned empty; rebaselined and re-verified.)

## Scope & coordination

2 files: M notebook + M twin yaml `app-1-nqueens.yaml` (python_sha `196bf386`→`36e761b0`, csharp `ed6af3b9` PRESERVED, reason added — 0 pre-existing reason, c.1132-L safe). Markdown-only, 0 re-exec. L898 uncontested — DUP-GUARD clear (no open PR touches App-1-NQueens content; #9128/#9133/#9136 relabel **link labels** in *other* C# notebooks, #9198 is App-12).

**Deferred (EPIC #8364):** cell[39] qualitative comparison table has an `N=1000` column with fabricated "Rapide" characterizations (neither Python algorithm tested at 1000; min-conflicts 72 s at 500 and CP-SAT UNKNOWN at 500 contradict "Rapide" at 1000) — but fixing it needs a design decision on the right regime characterization at the real cap (backtracking Intraitable / min-conflicts ~72 s "Lent" / CP-Sat UNKNOWN "Lent"), not a byte-swap → separate follow-up.

See #8052 (Search/Applications slice).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
