### PR TITLE
fix(symbolic,#8052): SW-3-CSharp-GraphOperations c13 compression claims inverted vs own measured output

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb
@@ -502,9 +502,9 @@
     "\n",
     "**NTriples** : format verbeux — chaque triplet occupe une ligne complete avec les URIs en entier. 4 triplets = 4 lignes. Pas de prefixe, pas de compression.\n",
     "\n",
-    "**Turtle compresse** : format compact — les prefixes sont définis une fois (`@prefix`), les noeuds blancs sont regroupes avec `;` (même sujet) et les proprietes sont imbriquees avec `[...]`. Le même graphe tient en 3 lignes au lieu de 4.\n",
+    "**Turtle compresse** : format compact — les prefixes sont définis une fois (`@prefix`), les noeuds blancs sont regroupes avec `;` (même sujet) et les proprietes sont imbriquees avec `[...]`. Les 4 triplets NTriples sont regroupes en une seule instruction Turtle, mais les 5 déclarations `@prefix` s'ajoutent en tête : sur ce petit graphe, le résultat fait 8 lignes au total (plus que les 4 de NTriples).\n",
     "\n",
-    "Le ratio de compression est ici d'environ 2:1 (NTriples ~400 caractères vs Turtle ~300 caractères). Sur des graphes plus grands avec beaucoup de prefixes, le gain peut atteindre 5:1 ou plus."
+    "Sur ce tout petit graphe, Turtle est paradoxalement PLUS long que NTriples (531 caractères vs 448) : les 5 déclarations `@prefix` coûtent plus qu'elles ne rapportent. La compression n'apparaît qu'à partir de graphes plus grands, avec beaucoup de prefixes réutilisés — où le gain peut alors atteindre 5:1 ou plus."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/sw-3-graph-operations.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-3-graph-operations.yaml
@@ -7,7 +7,8 @@
     date: "2026-07-31"
     by: myia-po-2023:CoursIA
     python_sha: 67d24fdcfb3ccfb484eabf75578a71e9639131d6
-    csharp_sha: 4938f5755414ebf12ea5a66c56aee03645359853
+    csharp_sha: 07cea4cbbc82bdb3c2a3f863b418b9a8b2a44fa2
+    reason: "Measure/value fix (C# cell 13 « Interpretation : Comparaison des formats de sortie »): 2 inverted-size claims contradicted the committed cell 12 output (4-triplet graphe Example.ttl). c12 measures NTriples 448 car / 4 lines and Turtle 531 car / 8 lines (5 @prefix + 1 statement), so Turtle is LARGER here (ratio 0.84:1) -- yet c13 claimed « tient en 3 lignes au lieu de 4 » (Turtle is 8 lines) and « ratio 2:1 (NTriples ~400 car vs Turtle ~300 car) » (backwards: Turtle 531 > NTriples 448). On this tiny graphe the 5 @prefix declarations dominate; compression appears only on larger graphs. Realigned both claims to the measured output (8 lines total; 531 vs 448 car, Turtle paradoxalement plus long) while preserving the valid general point « 5:1 ou plus sur des graphes plus grands ». Markdown-only, 0 re-exec, no output change. Python twin SW-3b uses rdflib with different output sizes (separate analysis), python unchanged."
   known_differences:
     - "Socle commun : parcours de graphe RDF, iteration des triplets, gestionnaires de parsing (handlers)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Parsing.Handlers`, iterate via `Graph.Triples`). Python = `rdflib` (`rdflib.collection`, `rdflib.parser`, iteration via `graph` set semantics)."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**1 measure/value defect (2 claims)** in `SW-3-CSharp-GraphOperations.ipynb` (C# dotNetRDF, **twinned** with `SW-3b-Python-GraphOperations.ipynb`), cell[13] — the *« Interpretation : Comparaison des formats de sortie »* inverts the NTriples-vs-Turtle size comparison vs the notebook's own committed output. Markdown-only, **0 re-exec, 0 code/output change**.

## Defect (cell[13] — VALUE/measure, output-proven)

cell[13] is the interpretation of the format-comparison demo (cell[12]). Two of its claims are backwards vs cell[12]'s committed output (4-triplet graphe `Example.ttl`):

Measured from cell[12] output:
- **NTriples**: 448 chars, 4 lines
- **Turtle** (CompressingTurtleWriter): 531 chars, 8 non-empty lines (5 `@prefix` declarations + one grouped statement over 3 physical lines)

| cell[13] claim (WRONG) | measured | verdict |
|------------------------|----------|---------|
| « Le même graphe tient en 3 lignes au lieu de 4 » | Turtle = **8 lines** | WRONG (Turtle is 8 lines, not 3) |
| « ratio ~2:1 (NTriples ~400 car vs Turtle ~300 car) » | NTriples **448** / Turtle **531** | WRONG (Turtle is **LARGER**, ratio 0.84:1 — the INVERSE of claimed) |

On this tiny 4-triplet graphe the 5 `@prefix` declarations (~280 car) dominate; Turtle only compresses on larger graphs with reused prefixes.

## §D.5 — Diagnostic dérive

- **Cause (b)** : claim antérieure — les affirmations de ratio/lignes inversées prédatent / ont dérivé de la sortie réelle de `CompressingTurtleWriter` pour ce graphe ; sur un graphe minimal, les `@prefix` rendent Turtle plus long, pas plus court.
- **Verdict** : CAUSE_FIXED — les 2 claims inversés sont réalignés sur la sortie mesurée ; aucun ne survit la PR → pas d'issue enfant.
- **Authority** : cell[12] committed output (NTriples + Turtle Compresse blocks) — byte-préservé.

## Fix (markdown-only, cell[13] only; realigned to cell[12] output)

- « tient en 3 lignes au lieu de 4 » → les 4 triplets NTriples sont regroupés en une seule instruction Turtle, mais les 5 `@prefix` s'ajoutent → **8 lignes au total** (plus que les 4 de NTriples).
- « ratio 2:1 (~400 vs ~300) » → sur ce petit graphe, Turtle est paradoxalement **PLUS long** (531 vs 448 car) ; les `@prefix` coûtent plus qu'ils ne rapportent.
- The valid general point « 5:1 ou plus sur des graphes plus grands » is **preserved** (it is correct and not contradicted by this output).

## Verification (firsthand, #8052 lens, L786-2)

- Read cell[12] output + cell[13] directly from `origin/main`. Measured the NTriples (448 car / 4 lines) and Turtle (531 car / 8 lines) blocks character-by-character from the committed output. Verified the 2 wrong claims are unique source-array elements (elem[4] "3 lignes", elem[6] "ratio 2:1"; count=1 each).
- Standard round-trippable JSON (RT exact match), element-level replace (c.1123-L) + `json.loads` re-parse: ONLY cell[13] changed; cell[12] (output authority) byte-identical.
- Lock: NB blob `4938f575` == `origin/main` pre-edit. New NB blob `07cea4cb`.
- **Twin-parity gate (#8057) verified locally** (drift_introduced=0, c.1039-L2): at HEAD, registry csharp_sha `07cea4cb` == C# blob, python `67d24fdc` == Python blob; pair OK at base and at HEAD.

## Python twin (C#-only fix)

`SW-3b-Python-GraphOperations.ipynb` uses **rdflib** with different serializer output sizes → the same prose-vs-output analysis must be done separately there → **python PRESERVED** for this PR (C#-only fix, self-contained: the C# interpretation cell contradicts the C# output).

## Scope & coordination

2 files: M C# notebook + M twin yaml `sw-3-graph-operations.yaml` (csharp_sha `4938f575`→`07cea4cb`, python `67d24fdc` PRESERVED, reason added — 0 pre-existing reason, c.1132-L safe). Markdown-only, 0 re-exec. L898/DUP-GUARD clear (no open PR touches SW-3 content). R6: SW vein (2nd of the catalogued SW Explore findings: #9205 was SW-2, this is SW-3 — same defect shape, serialization-size prose vs measured output).

See #8052 (SemanticWeb sweep — 9 more catalogued findings from the SW Explore agent will be re-verified firsthand and shipped in follow-up cycles).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
