### PR TITLE
fix(symbolic,#8052): SW-7-CSharp-OWL c4 stack diagram labels SHACL as SW-9 (should be SW-8)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb
@@ -203,7 +203,7 @@
     "\n",
     "```\n",
     "     +------------------+\n",
-    "     |   SHACL (SW-9)   |  <- Validation\n",
+    "     |   SHACL (SW-8)   |  <- Validation\n",
     "     +------------------+\n",
     "     |   OWL 2 (SW-7)   |  <- Logique descriptive  <-- Nous sommes ici\n",
     "     +------------------+\n",

--- a/scripts/notebook_tools/twin_pairs.d/sw-7-owl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-7-owl.yaml
@@ -7,7 +7,8 @@
     date: "2026-07-23"
     by: po-2024
     python_sha: 6c6b4450577e70359c9414dccd3baaec51d8615c
-    csharp_sha: 272171f25440e4d3aa967bcd6d03de29b9720f08
+    csharp_sha: 25c773f11a9fcdf9c6d03d88a3c3a39102399095
+    reason: "Identity/phantom fix (C# cell 4 ASCII stack-diagram « OWL 2 dans la pile du Web Semantique »): the SHACL layer was labelled « SHACL (SW-9) » but SHACL is notebook SW-8 (SW-8-CSharp-SHACL.ipynb / SW-8-Python-SHACL.ipynb on origin/main). The Python twin SW-7b already correctly says SW-8 (cell 28). Fixed SW-9 -> SW-8 (same char length, ASCII box alignment preserved). Other layers (OWL2 SW-7, RDFS SW-6, RDF SW-1/2/3) were already correct; SPARQL (SW-5) left untouched (debatable: dedicated SPARQL is SW-4, but SW-5 LinkedData uses SPARQL -- not an unambiguous error). Markdown-only, 0 re-exec, no output change. No §D.5 (identity/phantom class, not a measure/value drift). Python twin unchanged."
   known_differences:
     - "Socle commun : modelisation OWL (classes, proprietes, restrictions, axiomes)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Ontology` : OntologyGraph, OwlReasoner). Python = `owlready2` (API OWL orientee-objet dediee, world/Thing/Property). Deux librairies OWL matures mais aux philosophies differentes : dotNetRDF traite OWL comme une couche sur RDF ; owlready2 est nativement orientee OWL."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**1 identity/phantom defect (1 label)** in `SW-7-CSharp-OWL.ipynb` (C# dotNetRDF, **twinned** with `SW-7b-Python-OWL.ipynb`), cell[4] — the *« OWL 2 dans la pile du Web Sémantique »* ASCII stack diagram labels the SHACL layer with the **wrong notebook number**. Markdown-only, **0 re-exec, 0 code/output change**.

## Defect (cell[4] — IDENTITY/phantom)

cell[4]'s stack diagram has:

```
     +------------------+
     |   SHACL (SW-9)   |  <- Validation      ← WRONG: SHACL is SW-8
     +------------------+
     |   OWL 2 (SW-7)   |  <- Logique descriptive  <-- Nous sommes ici
     +------------------+
     |   RDFS (SW-6)    |  <- Vocabulaires, hiérarchies
     +------------------+
     | SPARQL (SW-5)    |  <- Interrogation
     +------------------+
     |   RDF (SW-1/2/3) |  <- Triplets, graphes
     +------------------+
```

**Authority (file listing on `origin/main`):** SHACL is notebook **SW-8** — `SW-8-CSharp-SHACL.ipynb` / `SW-8-Python-SHACL.ipynb`. SW-9 is JSON-LD. So "SHACL (SW-9)" names a notebook that is not SHACL.

The **Python twin SW-7b-Python-OWL already correctly says SW-8** (cell[28]: « **SW-8-Python-SHACL** : Validation de données avec pySHACL ») — so the C# diagram is the lone phantom. The other layers were already correct: OWL 2 (SW-7), RDFS (SW-6), RDF (SW-1/2/3).

## Fix (markdown-only, cell[4] only)

`SHACL (SW-9)` → `SHACL (SW-8)` in cell[4]. Same character length (9→8) so the ASCII box alignment is preserved.

**Deliberately left untouched:** `SPARQL (SW-5)`. The dedicated SPARQL notebook is SW-4, but SW-5 (Linked Data) does use SPARQL (federated queries to DBpedia/Wikidata) — so "SPARQL (SW-5)" is not an unambiguous error and is left for a separate follow-up if needed. This PR is strictly the unambiguous SHACL phantom.

## Class (no §D.5)

IDENTITY/phantom class — a diagram label naming the wrong notebook number (SHACL is SW-8, not SW-9). No committed output drifted; not a measure/value drift → no §D.5 diagnostic owed. Precedent: the SW Explore sweep's other phantom-label findings (SW-10 footer off-by-one, SW-11 SHACL→SW-9 refs, SW-12 nav).

## Verification (firsthand, #8052 lens, L786-2)

- Read cell[4] directly from `origin/main`; confirmed the diagram + the exact "SHACL (SW-9)" string (cell[4] elem[27], count=1, unique).
- Verified SHACL = SW-8 via `git ls-tree origin/main -- .../SemanticWeb` (SW-8-CSharp-SHACL + SW-8-Python-SHACL exist; no SW-9-SHACL).
- Verified the Python twin SW-7b cell[28] already says SW-8 (so C#-only fix, no asymmetry introduced).
- Standard round-trippable JSON (RT exact match), element-level replace (c.1123-L) + `json.loads` re-parse: ONLY cell[4] changed; SPARQL (SW-5) + all other layers byte-identical.
- Lock: NB blob `272171f2` == `origin/main` pre-edit. New NB blob `25c773f1`.
- **Twin-parity gate (#8057) verified locally** (drift_introduced=0, c.1039-L2): at HEAD, registry csharp_sha `25c773f1` == C# blob, python `6c6b4450` == Python blob; pair OK at base and at HEAD.

## Python twin (C#-only fix)

`SW-7b-Python-OWL.ipynb` already references SW-8 correctly (cell[28]) → **no parallel defect** → python PRESERVED.

## Scope & coordination

2 files: M C# notebook + M twin yaml `sw-7-owl.yaml` (csharp_sha `272171f2`→`25c773f1`, python `6c6b4450` PRESERVED, reason added — 0 pre-existing reason, c.1132-L safe). Markdown-only, 0 re-exec. L898/DUP-GUARD clear (no open PR touches SW-7 content). R6: SW vein (3rd SW finding: #9205 SW-2, #9206 SW-3, this SW-7).

See #8052 (SemanticWeb sweep — 8 more catalogued findings from the SW Explore agent will be re-verified firsthand and shipped in follow-up cycles).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
