### PR TITLE
feat(lean,#8869): conway Life 7 native_decide -> kernel decide (zero-axiom)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life.lean
@@ -220,25 +220,25 @@ or `Quot.lift` involved.
 -/
 
 /-- The Block is a still life: `isStillLife block = true`. -/
-theorem block_still_life : isStillLife block = true := by native_decide
+theorem block_still_life : isStillLife block = true := by decide
 
 /-- The Beehive is a still life. -/
-theorem beehive_still_life : isStillLife beehive = true := by native_decide
+theorem beehive_still_life : isStillLife beehive = true := by decide
 
 /-- The horizontal Blinker oscillates with period 2. -/
-theorem blinker_period_two : isOscillator blinker_h 2 = true := by native_decide
+theorem blinker_period_two : isOscillator blinker_h 2 = true := by decide
 
 /-- One step turns the horizontal Blinker into the vertical Blinker. -/
-theorem blinker_step : (step blinker_h == blinker_v) = true := by native_decide
+theorem blinker_step : (step blinker_h == blinker_v) = true := by decide
 
 /-- The Toad oscillates with period 2. -/
-theorem toad_period_two : isOscillator toad 2 = true := by native_decide
+theorem toad_period_two : isOscillator toad 2 = true := by decide
 
 /-- The Beacon oscillates with period 2. -/
-theorem beacon_period_two : isOscillator beacon 2 = true := by native_decide
+theorem beacon_period_two : isOscillator beacon 2 = true := by decide
 
 /-- The Glider is a spaceship of period 4, displacement `(1, -1)`. -/
-theorem glider_spaceship : isSpaceship glider 4 (1, -1) = true := by native_decide
+theorem glider_spaceship : isSpaceship glider 4 (1, -1) = true := by decide
 
 end Life
 end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life_en.lean
@@ -220,25 +220,25 @@ or `Quot.lift` involved.
 -/
 
 /-- The Block is a still life: `isStillLife block = true`. -/
-theorem block_still_life : isStillLife block = true := by native_decide
+theorem block_still_life : isStillLife block = true := by decide
 
 /-- The Beehive is a still life. -/
-theorem beehive_still_life : isStillLife beehive = true := by native_decide
+theorem beehive_still_life : isStillLife beehive = true := by decide
 
 /-- The horizontal Blinker oscillates with period 2. -/
-theorem blinker_period_two : isOscillator blinker_h 2 = true := by native_decide
+theorem blinker_period_two : isOscillator blinker_h 2 = true := by decide
 
 /-- One step turns the horizontal Blinker into the vertical Blinker. -/
-theorem blinker_step : (step blinker_h == blinker_v) = true := by native_decide
+theorem blinker_step : (step blinker_h == blinker_v) = true := by decide
 
 /-- The Toad oscillates with period 2. -/
-theorem toad_period_two : isOscillator toad 2 = true := by native_decide
+theorem toad_period_two : isOscillator toad 2 = true := by decide
 
 /-- The Beacon oscillates with period 2. -/
-theorem beacon_period_two : isOscillator beacon 2 = true := by native_decide
+theorem beacon_period_two : isOscillator beacon 2 = true := by decide
 
 /-- The Glider is a spaceship of period 4, displacement `(1, -1)`. -/
-theorem glider_spaceship : isSpaceship glider 4 (1, -1) = true := by native_decide
+theorem glider_spaceship : isSpaceship glider 4 (1, -1) = true := by decide
 
 end Life_en
 end Conway_en


### PR DESCRIPTION
Grain: LEAN/native_decide-reduction -- lane myia-po-2023:CoursIA -- prev: LEAN/native_decide-reduction #9199

See #8869 (partial -- Life module). Converts 7 native_decide theorems to kernel
decide in Conway/Life.lean (+ i18n sibling Life_en.lean, EPIC #4980). Continues
the native_decide-reduction attack: #9163 (microproofs), #9189 (DoomsdayLemmas 4),
#9190 (CollatzLike 8), #9197 (Nim 8), #9199 (Angel 2), now Life 7.

## The conversion

7 theorems now proven by kernel decide instead of native_decide:

- block_still_life : isStillLife block = true
- beehive_still_life : isStillLife beehive = true
- blinker_period_two : isOscillator blinker_h 2 = true
- blinker_step : (step blinker_h == blinker_v) = true
- toad_period_two : isOscillator toad 2 = true
- beacon_period_two : isOscillator beacon 2 = true
- glider_spaceship : isSpaceship glider 4 (1, -1) = true

All are closed Boolean evaluations on the canonical Conway patterns (block,
beehive, blinker_h/v, toad, beacon, glider) -- finite List (Int x Int) literals
composed through `step`/`evolve`/`isStillLife`/`isOscillator`/`isSpaceship`.

This is the EXACT use-case the Life module docstring (lines 1-25) was designed
for: the list representation avoids the Quot.lift / Eq.rec bottleneck that
blocks kernel reduction on Finset equality, so list equality reduces
cons-par-cons in the kernel -> decide (not native_decide) suffices. The probe
(Conway.ProbeLife.lean, scratch, deleted) confirmed all 7 example goals close
by decide before conversion.

## Verification (firsthand, conway_lean cache warm, toolchain v4.31.0-rc1)

1. Probe scratch (Conway/ProbeLife.lean, untracked, deleted): all 7 example
   goals closed by decide. lake build Conway.ProbeLife SUCCESS.
2. lake build Conway.Life (FR) SUCCESS. lake build Conway.Life_en (EN) SUCCESS.
3. Proof integrity #print axioms (the point of #8869 -- make native_decide
   kernel-reducible): all 7 theorems depend on standard Lean foundation only
   (NOT sorryAx, NOT the native_decide codegen axiom).
   STRICT proof-integrity improvement: axiom surface reduced, none added.
4. Anti-regression: 0 sorry tactics. The module docstring prose mentions
   "native_decide" as the technique and remains accurate (it documents the
   decide/native_decide ladder); only the 7 tactic lines changed.
5. i18n pair validity (check_i18n_siblings.py): OK, byte-identical body on the
   tactic change (decide is English), 0 drift, 0 orphan.

## Scope

2 files, 14 insertions / 14 deletions (7 tactic lines per file: native_decide
-> decide, inline form). Module docstrings unchanged. No sorry, no
sorry-baseline change.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
