### PR TITLE
fix(symbolic,#8052): SW-10-Python-RDFStar c58 footer nav labels off-by-one vs own header

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb
@@ -2888,7 +2888,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [<< 10-JSONLD](SW-9-Python-JSONLD.ipynb) | [Index](README.md) | [12-KnowledgeGraphs >>](SW-11-Python-KnowledgeGraphs.ipynb)"
+    "**Navigation** : [<< 9-JSONLD](SW-9-Python-JSONLD.ipynb) | [Index](README.md) | [11-KnowledgeGraphs >>](SW-11-Python-KnowledgeGraphs.ipynb)"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/sw-10-rdf-star.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-10-rdf-star.yaml
@@ -6,8 +6,9 @@
   last_audit:
     date: "2026-07-23"
     by: po-2024
-    python_sha: 23bb1656347488b97e360b34c9c67bcd52e29784
+    python_sha: d173db2d9c447699c7b3b2bae1a08c473dfde79d
     csharp_sha: e184307cf2a6180399e776bf200058e283fb9bf2
+    reason: "Identity/phantom fix (Python cell 58 footer Navigation): the display labels were off-by-one vs the notebook OWN header (cell 0). Header says « 9-JSONLD » and « 11-KnowledgeGraphs », but the footer said « 10-JSONLD » and « 12-KnowledgeGraphs ». The link URLs were already correct in both (SW-9-Python-JSONLD.ipynb, SW-11-Python-KnowledgeGraphs.ipynb) -- only the human-readable labels were wrong. Fixed the 2 footer labels to match the header. Markdown-only, 0 re-exec, no output change. No §D.5 (identity/phantom class, not a measure/value drift). C# twin SW-10-CSharp-RDFStar nav uses a different structure (points to the Python jumeau, no KnowledgeGraphs forward link) and is correct -> csharp unchanged."
   known_differences:
     - "Socle commun : meta-modelisation RDF-star (triplets sur des triplets, quotes nestees)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Query` support RDF-star). Python = `rdflib` (`rdflib.term` triplets-nommes). RDF-star est une extension communautaire (pas encore W3C standardise) ; support experimental des deux cotes."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**1 identity/phantom defect (2 display labels)** in `SW-10-Python-RDFStar.ipynb` (Python rdflib, **twinned** with `SW-10-CSharp-RDFStar.ipynb`), cell[58] — the footer *« Navigation »* display labels are off-by-one vs the notebook's own header. Markdown-only, **0 re-exec, 0 code/output change**.

## Defect (cell[58] — IDENTITY/phantom)

cell[58]'s footer "Navigation" links use correct **URLs** but wrong human-readable **labels**:

| | header cell[0] (correct) | footer cell[58] (WRONG) | link URL (same, correct) |
|------|--------------------------|--------------------------|--------------------------|
| prev | `<< 9-JSONLD` | `<< 10-JSONLD` | `SW-9-Python-JSONLD.ipynb` |
| next | `11-KnowledgeGraphs >>` | `12-KnowledgeGraphs >>` | `SW-11-Python-KnowledgeGraphs.ipynb` |

This notebook is **SW-10 (RDF-Star)**. The previous notebook IS **SW-9 (JSON-LD)** and the next IS **SW-11 (Knowledge Graphs)** — so the footer's `10-JSONLD` and `12-KnowledgeGraphs` name notebooks that don't exist. The link URLs were already correct in both cells; only the display labels were off-by-one.

## Fix (markdown-only, cell[58] only)

Footer display labels: `10-JSONLD` → `9-JSONLD`, `12-KnowledgeGraphs` → `11-KnowledgeGraphs` (now matches the header cell[0] exactly). Link URLs (`SW-9-Python-JSONLD.ipynb`, `SW-11-Python-KnowledgeGraphs.ipynb`) untouched.

## Class (no §D.5)

IDENTITY/phantom class — footer nav labels naming wrong notebook numbers vs the notebook's own header. No committed output drifted; not a measure/value drift → no §D.5 diagnostic owed. Precedent: the SW Explore sweep's other phantom-label findings (SW-7 SHACL→SW-9, #9207; SW-12 nav).

## Verification (firsthand, #8052 lens, L786-2)

- Read cell[0] (header) + cell[58] (footer) directly from `origin/main`. Verified the footer nav is cell[58] elem[6] (single element). Verified label uniqueness across the WHOLE notebook: `10-JSONLD`=1 (footer, the wrong label), `12-KnowledgeGraphs`=1 (footer, wrong), `9-JSONLD`=1 (header, correct), `11-KnowledgeGraphs`=1 (header, correct) — so the fix targets only the footer.
- Standard round-trippable JSON (RT exact match), element-level replace (c.1123-L) + `json.loads` re-parse: ONLY cell[58] changed; header cell[0] + link URLs byte-identical.
- Lock: NB blob `23bb1656` == `origin/main` pre-edit. New NB blob `d173db2d`.
- **Twin-parity gate (#8057) verified locally** (drift_introduced=0, c.1039-L2): at HEAD, registry python_sha `d173db2d` == Python blob, csharp `e184307c` == C# blob; pair OK at base and at HEAD.

## C# twin (Python-only fix)

`SW-10-CSharp-RDFStar.ipynb` nav uses a different structure (cell[25] points to the Python jumeau `SW-10-Python-RDFStar`, no KnowledgeGraphs forward link) and is already correct → **no parallel defect** → csharp PRESERVED.

## Scope & coordination

2 files: M Python notebook + M twin yaml `sw-10-rdf-star.yaml` (python_sha `23bb1656`→`d173db2d`, csharp `e184307c` PRESERVED, reason added — 0 pre-existing reason, c.1132-L safe). Markdown-only, 0 re-exec. L898/DUP-GUARD clear (no open PR touches SW-10 content). R6: SW vein (4th SW finding: #9205 SW-2, #9206 SW-3, #9207 SW-7, this SW-10).

See #8052 (SemanticWeb sweep — 7 more catalogued findings from the SW Explore agent will be re-verified firsthand and shipped in follow-up cycles).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
