### PR TITLE
feat(cost,#8056): populate metadata.cost on QC-Py-07/08/09/11/12 (5 NBs)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
@@ -2296,7 +2296,20 @@
    "name": "python",
    "version": "3.11.0"
   },
-  "qc_reference": true
+  "qc_reference": true,
+  "cost": {
+   "api_usd_est": 0,
+   "api_provider": "none",
+   "cpu_min": 8,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-free",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-08-Multi-Asset-Strategies.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-08-Multi-Asset-Strategies.ipynb
@@ -2379,7 +2379,20 @@
    "pygments_lexer": "ipython3",
    "version": "3.11.0"
   },
-  "qc_reference": true
+  "qc_reference": true,
+  "cost": {
+   "api_usd_est": 0,
+   "api_provider": "none",
+   "cpu_min": 10,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-free",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-09-Order-Types.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-09-Order-Types.ipynb
@@ -1925,7 +1925,20 @@
    "pygments_lexer": "ipython3",
    "version": "3.11.0"
   },
-  "qc_reference": true
+  "qc_reference": true,
+  "cost": {
+   "api_usd_est": 0,
+   "api_provider": "none",
+   "cpu_min": 8,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-free",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
@@ -2313,7 +2313,20 @@
    "name": "python",
    "version": "3.11.0"
   },
-  "qc_reference": true
+  "qc_reference": true,
+  "cost": {
+   "api_usd_est": 0,
+   "api_provider": "none",
+   "cpu_min": 8,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-free",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
@@ -2662,7 +2662,20 @@
    "name": "python",
    "version": "3.10.0"
   },
-  "qc_reference": true
+  "qc_reference": true,
+  "cost": {
+   "api_usd_est": 0,
+   "api_provider": "none",
+   "cpu_min": 15,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-free",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 5


### PR DESCRIPTION
Grain: COST/metadata -- lane myia-po-2023:CoursIA -- prev: LEAN/native_decide-reduction #9208

See #8056 (acceptance: populate metadata.cost on the QuantConnect family).
Populates the cost schema on 5 QC-Python notebooks that were missing
metadata.cost (part of the 38 QC-Py without cost on origin/main).

## The 5 notebooks

All 5 are pure QuantConnect backtests (verified firsthand: no GPU usage,
no external paid API, no ML training, no token beyond the QC account):

| Notebook | code cells | cpu_min | rationale |
|----------|-----------|---------|-----------|
| QC-Py-07 Futures-Forex | 18 | 8 | AddForex/Futures, several QCAlgorithm classes |
| QC-Py-08 Multi-Asset | 20 | 10 | multi-asset strategies, more cells |
| QC-Py-09 Order-Types | 20 | 8 | order type examples |
| QC-Py-11 Technical-Indicators | 18 | 8 | indicator examples |
| QC-Py-12 Backtesting-Analysis | 34 | 15 | heaviest, analysis-heavy |

Common fields: api_usd_est 0 (QC free-tier QCC credits, not USD),
api_provider none, gpu_required false, network true (QC Cloud),
external_account quantconnect-free, free_alternative null,
reduced_pedagogical null, reproducibility HIGH (deterministic backtests
on QC data), validator manual.

## Why these values (honest cost estimation)

These are QC backtests run on QuantConnect Cloud with a free account:
- No USD cost (QCC credits are the QC free-tier currency, api_usd_est 0).
- No GPU (QC backtests are CPU; gpu_required false).
- No external paid API (the scan regex flagged "forex/Oanda/Nasdaq" but
  those are QC market data via AddForex / Market.Oanda, not an external
  API call -- verified firsthand on the source).
- cpu_min proportional to notebook complexity (cell count + backtest
  depth), calibrated against the already-populated QC-Py-01/02/10
  reference (5/5/12 min for similar backtest notebooks).

## Verification (firsthand)

1. Byte-surgical diff: only the `cost` block added to notebook metadata
   (after qc_reference), 0 cell/output churn, 70 ins / 5 del across 5
   files. json.dumps(indent=1) round-trip byte-identical (verified dry-run
   on QC-Py-07 and QC-Py-12 before editing).
2. scripts/audit/check_cost_metadata.py: exit 0 on all 5 (0 litmus
   findings -- no GPU-claim, no API-claim, no token-claim contradictions).
3. No catalog churn (COURSE_CATALOG.generated.* untouched --
   catalog-pr-hygiene compliant; the daily cron will pick up cost via the
   generator on main).
4. No source-cell change -> outputs preserved valid (metadata-only edit,
   C.2 re-exec not triggered).

## Scope

5 notebooks, metadata-only. No strategy/code change -> no QC backtest
required (pr-review section G targets strategy changes, not metadata).
Atomic, single-subject (QC-Py cost tranche).

See #8056, #4208.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
