### PR TITLE
fix(symbolic,#8052): SW-12-Python-GraphRAG c58+c59 cite SW-12 for material that lives in SW-11

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
@@ -3122,10 +3122,10 @@
    "source": [
     "### Exercice 5 : Construire un mini-KG thematique\n",
     "\n",
-    "A partir du fichier `data/movies.csv` (utilise dans SW-12), construisez un KG et utilisez-le pour repondre a la question : \"Quels realisateurs ont dirige des acteurs en commun ?\"\n",
+    "A partir du fichier `data/movies.csv` (utilise dans SW-11), construisez un KG et utilisez-le pour repondre a la question : \"Quels realisateurs ont dirige des acteurs en commun ?\"\n",
     "\n",
     "**Indices** :\n",
-    "- Reutilisez le code de construction de KG de SW-12\n",
+    "- Reutilisez le code de construction de KG de SW-11\n",
     "- Ecrivez une requête SPARQL pour trouver les chemins realisateur -> film -> acteur -> film -> realisateur\n",
     "- Formatez le résultat comme contexte pour un prompt LLM"
    ]
@@ -3163,7 +3163,7 @@
     "# Exercice 5 : KG thematique a partir de movies.csv\n",
     "import pandas as pd\n",
     "\n",
-    "# Exercice : chargez data/movies.csv puis construisez le graphe RDF en adaptant le code de SW-12\n",
+    "# Exercice : chargez data/movies.csv puis construisez le graphe RDF en adaptant le code de SW-11\n",
     "# Puis : ecrivez une requete SPARQL trouvant les realisateurs partageant des acteurs\n",
     "# Enfin : formatez le resultat comme contexte GraphRAG et generez une reponse via safe_llm_call\n",
     "\n",


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**1 identity/phantom defect (3 self-references)** in `SW-12-Python-GraphRAG.ipynb` (Python rdflib, **not twinned**), cell[58]+cell[59] — the *« Exercice 5 : Construire un mini-KG thematique »* references the movies.csv material and the KG-construction code as being « in SW-12 », but this notebook **is** SW-12 — that material lives in the prerequisite **SW-11**. Markdown + comment-only, **0 re-exec, 0 code/output change**.

## Defect (cell[58]+[59] — IDENTITY/phantom, self-reference)

The Exercice 5 intro + code comment point students at SW-12 for material that is actually in SW-11:

| site | text (WRONG) | where it actually lives |
|------|--------------|-------------------------|
| cell[58] | « data/movies.csv (utilise dans **SW-12**) » | `read_csv("data/movies.csv")` is ONLY in **SW-11**:622 (git grep) |
| cell[58] | « Reutilisez le code de construction de KG de **SW-12** » | SW-12 cell[0] itself names **SW-11** as the KG-construction prereq |
| cell[59] | « construisez le graphe RDF en adaptant le code de **SW-12** » | (same — the KG builder is in SW-11) |

**Authority (origin/main):** `git grep 'read_csv("data/movies.csv")'` returns exactly one hit — `SW-11-Python-KnowledgeGraphs.ipynb:622`. And SW-12 cell[0] explicitly names SW-11 as the prerequisite: « Notebook [SW-11-Python-KnowledgeGraphs] (construction de KG avec rdflib) ». So the 3 « SW-12 » references send students to the notebook they are already reading, instead of the prerequisite where the dataset + KG-builder actually live.

## Fix (markdown cell 58 + comment cell 59; 3 SW-12 → SW-11)

- cell[58]: « (utilise dans SW-12) » → « (utilise dans SW-11) »
- cell[58]: « code de construction de KG de SW-12 » → « de SW-11 »
- cell[59]: « en adaptant le code de SW-12 » → « de SW-11 »

## Class (no §D.5)

IDENTITY/phantom class — self-reference to the wrong notebook (the prerequisite SW-11 is named as SW-12). No committed output drifted; not a measure/value drift → no §D.5 diagnostic owed. Precedent: SW Explore sweep phantom-label findings (SW-7 SHACL→SW-9 #9207, SW-10 nav #9209).

## Scope (1 subject — cell[37] footer phantom is a SEPARATE PR)

This PR is strictly the 3 cell[58]+[59] self-references. The same notebook's **cell[37] footer** has a *different* phantom (« 12-KnowledgeGraphs » should be « 11-KnowledgeGraphs », + « conclut la série » miscall) — that is finding #7, a distinct defect, left for a separate follow-up PR (1 PR = 1 subject per catalog-pr-hygiene). cell[37] is byte-preserved here.

## Verification (firsthand, #8052 lens, L786-2)

- Read cell[0] (header, correct SW-11 prereq) + cell[37] (footer, separate phantom) + cell[58] + cell[59] directly from `origin/main`. Verified the 3 target strings are unique in their cells (count=1 each) and in distinct source-array elements.
- `git grep 'read_csv("data/movies.csv")' origin/main` → single hit SW-11:622 (confirmed firsthand, not agent-said).
- Standard round-trippable JSON (RT exact match), element-level replace (c.1123-L) + `json.loads` re-parse: ONLY cells 58+59 changed; header cell[0] + footer cell[37] byte-identical.
- Lock: NB blob `dae8fc2a` == `origin/main` pre-edit. New NB blob `7e37bc42`.
- Not twinned (no `sw-12-graphrag.yaml` in `twin_pairs.d`) → single-file edit, no SHA rebaseline, no twin-parity gate.

## Scope & coordination

1 file: M Python notebook. Markdown + comment-only, 0 re-exec. L898/DUP-GUARD clear (no open PR touches SW-12 content). R6: SW vein (5th SW finding: #9205 SW-2, #9206 SW-3, #9207 SW-7, #9209 SW-10, this SW-12).

See #8052 (SemanticWeb sweep — 6 more catalogued findings from the SW Explore agent will be re-verified firsthand and shipped in follow-up cycles).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
