### PR TITLE
fix(symbolic,#8052): SW-12 c37 footer nav label off-by-one (12→11-KnowledgeGraphs)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
@@ -2067,7 +2067,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [<< 12-KnowledgeGraphs](SW-11-Python-KnowledgeGraphs.ipynb) | [Index](README.md)"
+    "**Navigation** : [<< 11-KnowledgeGraphs](SW-11-Python-KnowledgeGraphs.ipynb) | [Index](README.md)"
    ]
   },
   {


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**1 identity/phantom defect (1 nav label)** in `SW-12-Python-GraphRAG.ipynb` (Python rdflib, **not twinned**), cell[37] — the footer *« Navigation »* prev display label is off-by-one vs the notebook's own header. Markdown-only, **0 re-exec, 0 code/output change**.

## Defect (cell[37] — IDENTITY/phantom, nav off-by-one)

cell[37]'s footer prev link uses the correct **URL** but a wrong human-readable **label**:

| | header cell[0] (correct) | footer cell[37] (WRONG) | link URL (same, correct) |
|------|--------------------------|--------------------------|--------------------------|
| prev | `<< 11-KnowledgeGraphs` | `<< 12-KnowledgeGraphs` | `SW-11-Python-KnowledgeGraphs.ipynb` |

This notebook is **SW-12 (GraphRAG)**. The previous notebook IS **SW-11 (Knowledge Graphs)** — confirmed by the header cell[0] (`<< 11-KnowledgeGraphs` → `SW-11-Python-KnowledgeGraphs.ipynb`) and the prereq line « Notebook [SW-11-Python-KnowledgeGraphs] (construction de KG avec rdflib) ». So the footer's `12-KnowledgeGraphs` names a notebook that doesn't exist; the link URL was already correct, only the label was off-by-one.

## Fix (markdown-only, cell[37] only)

Footer prev display label: `12-KnowledgeGraphs` → `11-KnowledgeGraphs` (now matches header cell[0] exactly). Link URL (`SW-11-Python-KnowledgeGraphs.ipynb`) untouched.

## Class (no §D.5)

IDENTITY/phantom class — footer nav label naming a wrong notebook number vs the notebook's own header. No committed output drifted; not a measure/value drift → no §D.5 diagnostic owed. Precedent: SW Explore sweep phantom-label findings (SW-10 footer #9209, SW-7 SHACL→SW-8 #9207).

## Scope (1 subject — the « conclut la série » prose is a SEPARATE PR)

This PR is strictly the cell[37] nav-label off-by-one. The **same cell** also carries a *different* defect: « Ce notebook conclut la série Semantic Web … jusqu'à l'intégration avec les grands modèles de langage (SW-13) » — SW-12 (GraphRAG) does **not** conclude the series (SW-13 follows), and SW-13 is *Reasoners*, not LLM-integration (GraphRAG/LLM-integration is SW-12 itself). That prose rewrite requires wording judgment and is a distinct subject → byte-preserved here for a separate follow-up PR (1 PR = 1 subject per catalog-pr-hygiene).

PR#9211 (c.1152) edits SW-12 cells 58+59 (the « Exercice 5 » SW-12→SW-11 self-refs); this PR edits cell[37] — **different cells, no merge conflict**. cell[37] is byte-preserved in #9211; cells 58+59 are byte-preserved here.

## Verification (firsthand, #8052 lens, L786-2)

- Read cell[0] (header) + cell[37] (footer) directly from `origin/main`. Verified label uniqueness across the whole notebook: `12-KnowledgeGraphs`=1 (footer, the wrong label), `11-KnowledgeGraphs`=1 (header, correct) → the fix targets only the footer.
- Standard round-trippable JSON (RT exact match), element-level replace (c.1123-L) + `json.loads` re-parse: ONLY cell[37] changed; header cell[0] byte-identical; cells 58+59 byte-identical; « conclut la série » prose byte-identical (separate defect).
- Lock: NB blob `dae8fc2a` == `origin/main` pre-edit. New NB blob `185840e2`.
- Not twinned (no `sw-12-graphrag.yaml` in `twin_pairs.d`) → single-file edit, no SHA rebaseline, no twin-parity gate.

## Scope & coordination

1 file: M Python notebook. Markdown-only, 0 re-exec. L898/DUP-GUARD: PR#9211 touches SW-12 c58/c59 (different cells) — no content overlap, no conflict. R6: SW vein (7th SW finding: #9205 SW-2, #9206 SW-3, #9207 SW-7, #9209 SW-10, #9211 SW-12 c58/c59, this SW-12 c37).

See #8052 (SemanticWeb sweep — remaining findings re-verified firsthand and shipped in follow-up cycles).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
