### PR TITLE
feat(cost,#8056): populate metadata.cost on QC-Py-13/14/16/27/28/35 (6 NBs, tranche 2)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
@@ -2083,7 +2083,20 @@
    "name": "python",
    "version": "3.11.0"
   },
-  "qc_reference": true
+  "qc_reference": true,
+  "cost": {
+   "api_usd_est": 0,
+   "api_provider": "none",
+   "cpu_min": 8,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-free",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
@@ -3376,7 +3376,20 @@
    "pygments_lexer": "ipython3",
    "version": "3.10.0"
   },
-  "qc_reference": true
+  "qc_reference": true,
+  "cost": {
+   "api_usd_est": 0,
+   "api_provider": "none",
+   "cpu_min": 11,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-free",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
@@ -2495,7 +2495,20 @@
    "pygments_lexer": "ipython3",
    "version": "3.8.10"
   },
-  "qc_reference": true
+  "qc_reference": true,
+  "cost": {
+   "api_usd_est": 0,
+   "api_provider": "none",
+   "cpu_min": 8,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-free",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
@@ -2022,7 +2022,20 @@
    "name": "python",
    "version": "3.11.0"
   },
-  "qc_reference": true
+  "qc_reference": true,
+  "cost": {
+   "api_usd_est": 0,
+   "api_provider": "none",
+   "cpu_min": 7,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-free",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
@@ -2258,7 +2258,20 @@
    "name": "python",
    "version": "3.10.0"
   },
-  "qc_reference": true
+  "qc_reference": true,
+  "cost": {
+   "api_usd_est": 0,
+   "api_provider": "none",
+   "cpu_min": 10,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-free",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-35-RL-Portfolio-Construction.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-35-RL-Portfolio-Construction.ipynb
@@ -856,6 +856,19 @@
   "language_info": {
    "name": "python",
    "version": "3.10.0"
+  },
+  "cost": {
+   "api_usd_est": 0,
+   "api_provider": "none",
+   "cpu_min": 5,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-free",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: COST/metadata -- lane myia-po-2023:CoursIA -- prev: COST/metadata #9210

See #8056 (acceptance: populate metadata.cost on the QuantConnect family).
Second QC tranche — continues #9210 (c.1103: QC-Py-07/08/09/11/12). Populates
the cost schema on 6 more QC-Python notebooks that were missing metadata.cost.

## The 6 notebooks

All 6 are pure QuantConnect backtests (verified firsthand: QCAlgorithm-based,
NO QuantBook, NO external paid API, NO GPU, NO token). Cost is unambiguous
(quantconnect-free QCC credits, 0 USD, deterministic backtests):

| Notebook | code cells | cpu_min |
|----------|-----------|---------|
| QC-Py-13 Alpha-Models | 18 | 8 |
| QC-Py-14 Portfolio-Construction-Execution | 24 | 11 |
| QC-Py-16 Alternative-Data | 18 | 8 |
| QC-Py-27 Production-Deployment | 15 | 7 |
| QC-Py-28 Market-Regime-Detection | 21 | 10 |
| QC-Py-35 RL-Portfolio-Construction | 9 | 5 |

Common fields: api_usd_est 0 (QCC credits = QC free-tier currency, not USD),
api_provider none, gpu_required false, network true (QC Cloud),
external_account quantconnect-free, free_alternative null,
reduced_pedagogical null, reproducibility HIGH (deterministic backtests on QC
data), validator manual.

cpu_min calibrated on code-cell count against the already-populated QC-Py
reference (QC-Py-01/02/10 = 5/5/12 for 5/5/34 cells; my c.1103 QC-Py-07/12 =
8/15 for 18/34 cells). Ratio ~0.45 min/cell, rounded.

## Verification (firsthand)

1. Byte-surgical diff: only the `cost` block added to notebook metadata,
   0 cell/output churn. json.dumps(indent=1) round-trip byte-identical
   (verified dry-run on all 6 before editing).
2. scripts/audit/check_cost_metadata.py: exit 0 on all 6 (0 litmus findings
   -- no GPU-claim, no API-claim, no token-claim contradictions; the 0 external
   tokens is confirmed by scan: no OPENAI_API_KEY / ANTHROPIC / BINANCE / IBKR
   in any of the 6).
3. No catalog churn (COURSE_CATALOG.generated.* untouched).
4. No source-cell change -> outputs preserved valid (metadata-only edit).

## Scope

6 notebooks, metadata-only. No strategy/code change -> no QC backtest required.
Atomic, single-subject (QC-Py cost tranche 2).

## #8056 state after this PR

QC-Py population: was 110/205 on origin/main. After #9210 (+5) and this (+6):
122/205 (~59.5%). Residual QC-Py without cost: ML/training notebooks
(18/21/23b/24/30-34, GPU/ML — heavier, separate calibration) + QC-Py-Cloud
quantbooks (QuantBook-based, reproducibility QC-CLOUD-DEPENDENT — separate
honesty profile) + PaperTrading (40/41, external paper-trading creds). These
residuals need per-family calibration, not the simple backtest profile here.

See #8056, #4208.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
