### PR TITLE
fix(symbolic,#8052): SW-11 c58+c61+c64 SHACL cross-refs point at SW-9 (should be SW-8)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
@@ -2737,7 +2737,7 @@
     "| Completude | Y a-t-il des données manquantes ? | SPARQL OPTIONAL + COUNT |\n",
     "| Coherence | Les valeurs sont-elles valides ? | Contraintes de domaine/range |\n",
     "| Unicite | Y a-t-il des doublons ? | SPARQL COUNT + GROUP BY |\n",
-    "| Conformite | Le KG respecte-t-il son schema ? | SHACL (cf. SW-9) |"
+    "| Conformite | Le KG respecte-t-il son schema ? | SHACL (cf. SW-8) |"
    ],
    "outputs": [],
    "execution_count": null
@@ -2879,7 +2879,7 @@
     "- Acteurs secondaires non renseignes\n",
     "- Genres multiples non captures (un film peut etre a la fois Action et Science-Fiction)\n",
     "\n",
-    "> **Lien avec SW-9** : La validation SHACL permet de formaliser ces règles de completude sous forme de \"shapes\" (contraintes declaratives) plutot que de requêtes ad-hoc."
+    "> **Lien avec SW-8** : La validation SHACL permet de formaliser ces règles de completude sous forme de \"shapes\" (contraintes declaratives) plutot que de requêtes ad-hoc."
    ],
    "outputs": [],
    "execution_count": null
@@ -3060,7 +3060,7 @@
     "| Genres définis | Genres sans label | `sh:minCount 1` sur rdfs:label |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Ces verifications ad-hoc sont utiles en développement, mais en production on prefere **SHACL** (cf. SW-9)\n",
+    "1. Ces verifications ad-hoc sont utiles en développement, mais en production on prefere **SHACL** (cf. SW-8)\n",
     "2. La qualite d'un KG est un processus continu, pas un contrôle ponctuel\n",
     "3. Les pipelines de construction de KG incluent systematiquement une étape de validation\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/sw-11-knowledge-graphs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-11-knowledge-graphs.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-CSharp-KnowledgeGraphs.ipynb
   parity_level: surface
   last_audit:
-    date: "2026-07-23"
+    date: "2026-08-02"
     by: po-2024
-    python_sha: d3d6083bd49c7fa2892e3f74edf2e17421a29c11
+    python_sha: d35fdfb5a6e398a925c74315a05d5ac7910d2379
     csharp_sha: 47e9629433702421b9bff134b157efe7673ed12c
+    reason: "c58+c61+c64 SHACL cross-refs pointed at SW-9 (Linked Data); SHACL is SW-8 (cf. own c0 header). Python-only, csharp PRESERVED (parity=surface)."
   known_differences:
     - "Socle commun : construction d'un graphe de connaissances (RDF + ontologie + requetage)."
     - "Asymetrie de profondeur (surface) : le Python combine TROIS librairies -- `rdflib` (RDF), `owlready2` (ontologie OWL), et `networkx` (algorithmes de graphe : centralite, composantes connexes, plus courts chemins). Le C# reste sur `dotNetRDF` seul (`VDS.RDF.Query`), sans dimension d'analyse de graphe (centralite/communautes)."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**1 identity/phantom defect class (3 SHACL cross-refs)** in `SW-11-Python-KnowledgeGraphs.ipynb` (Python rdflib/owlready2/networkx, **twinned** with `SW-11-CSharp-KnowledgeGraphs.ipynb`), cells 58+61+64 — three markdown cross-references point SHACL validation at **SW-9**, but SHACL is **SW-8**. Markdown-only, **0 re-exec, 0 code/output change**.

## Defect (cells 58+61+64 — IDENTITY/phantom)

Three cells cross-reference SHACL validation as SW-9, but SW-9 is JSON-LD / Linked Data; **SHACL is SW-8**. This notebook's **own header** cell[0] confirms the correct mapping:

> `- SW-8 (SHACL) et SW-9 (Linked Data) pour les fondations RDF/SPARQL`

| site | text (WRONG) | authority |
|------|--------------|-----------|
| cell[58] | `\| Conformite \| ... \| SHACL (cf. SW-9) \|` | SHACL = SW-8 (own c0 + file listing) |
| cell[61] | `> **Lien avec SW-9** : La validation SHACL permet de formaliser ...` | sentence is entirely about SHACL validation; nothing about SW-9/Linked-Data |
| cell[64] | `1. ... en production on prefere **SHACL** (cf. SW-9)` | SHACL = SW-8 |

So all three send a reader to SW-9 (Linked Data) looking for SHACL content that isn't there. File listing: `SW-8-CSharp-SHACL.ipynb` / `SW-8-Python-SHACL.ipynb`; `SW-9-CSharp-JSONLD.ipynb` / `SW-9-Python-JSONLD.ipynb`. This same SHACL=SW-8 fact was file-listing-proven in PR#9207 (SW-7 c4) within this sweep.

## Fix (markdown-only, cells 58+61+64 only)

SHACL-context SW-9 → SW-8:
- cell[58]: `SHACL (cf. SW-9)` → `SHACL (cf. SW-8)`
- cell[61]: `**Lien avec SW-9**` → `**Lien avec SW-8**`
- cell[64]: `**SHACL** (cf. SW-9)` → `**SHACL** (cf. SW-8)`

## Class (no §D.5)

IDENTITY/phantom class — cross-references naming the wrong notebook (SW-9) for SHACL which is SW-8. No committed output drifted; not a measure/value drift → no §D.5 diagnostic owed. Precedent: SW Explore sweep phantom findings (SW-7 SHACL→SW-8 #9207, SW-10 nav #9209, SW-12 self-ref #9211).

## Verification (firsthand, #8052 lens, L786-2)

- Read header cell[0] + cells 58/61/64 directly from `origin/main`. The SW Explore agent reported this as « x4 (c0/c58/c61/c64) » but **cell[0] is already correct** (`SW-8 (SHACL) et SW-9 (Linked Data)`) — the agent mislabeled a correct cell as a defect (c.1081-L); only cells 58/61/64 carry the phantom (3, not 4).
- Standard round-trippable JSON (RT exact match), element-level replace (c.1123-L) + `json.loads` re-parse: ONLY cells 58+61+64 changed; header cell[0] byte-identical.
- Lock: PY NB blob `d3d6083b` == `origin/main` pre-edit. New PY NB blob `d35fdfb5`.
- **Twin-parity gate (#8057) verified locally** (drift_introduced=0, c.1039-L2): yaml python_sha `d35fdfb5` == committed PY NB blob; csharp_sha `47e96294` == base C# blob (PRESERVED).

## C# twin (Python-only fix)

`SW-11-CSharp-KnowledgeGraphs.ipynb` has **0 SHACL/SW-9 references** (parity_level=`surface`: the C# is a truncated pendant — dotNetRDF only, no networkx analysis, no §6 Qualité/validation SHACL section) → **no parallel defect** → csharp PRESERVED. Twin yaml `sw-11-knowledge-graphs.yaml`: python_sha rebaselined (`d3d6083b`→`d35fdfb5`), csharp `47e96294` PRESERVED, reason added (0 pre-existing reason, c.1132-L safe).

## Scope & coordination

2 files: M Python notebook + M twin yaml. Markdown-only, 0 re-exec. L898/DUP-GUARD clear (no open PR touches SW-11 content). R6: SW vein (8th SW finding: #9205 SW-2, #9206 SW-3, #9207 SW-7, #9209 SW-10, #9211/#9212 SW-12, this SW-11).

See #8052 (SemanticWeb sweep — remaining findings re-verified firsthand and shipped in follow-up cycles).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
