### PR TITLE
fix(symbolic,#8052): SW-8 c1 rdflib self-reference (déjà utilisée dans SW-8 → SW-2b)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb
@@ -51,7 +51,7 @@
     "## 0. Installation des dependances\n",
     "\n",
     "Installons les deux bibliotheques necessaires :\n",
-    "- **rdflib** : manipulation de graphes RDF (déjà utilisee dans SW-8)\n",
+    "- **rdflib** : manipulation de graphes RDF (déjà utilisee dans SW-2b)\n",
     "- **pyshacl** : moteur de validation SHACL pour Python"
    ]
   },

--- a/scripts/notebook_tools/twin_pairs.d/sw-8-shacl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-8-shacl.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-23"
+    date: "2026-08-02"
     by: po-2024
-    python_sha: 4d4511936245c8c4b5d8665149a9461ae519df2e
+    python_sha: 47597549035c04803da74b9361a5b8c825e4f884
     csharp_sha: fce2451b700090a2515d64a49e550eae1e0c0e6b
+    reason: "c1 rdflib self-ref pointed at SW-8 (this notebook); rdflib introduced in SW-2b-Python-RDFBasics. Python-only, csharp PRESERVED."
   known_differences:
     - "Socle commun : validation de graphe RDF par contraintes SHACL (Shapes Constraint Language, W3C 2017)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Shacl` moteur de validation integre). Python = `pyshacl` (validateur SHACL dedie, reference) + `rdflib` pour le graphe. pyshacl est l'implementation de reference Python ; dotNetRDF embarque SHACL depuis la v3."


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**1 identity/phantom defect (1 self-reference)** in `SW-8-Python-SHACL.ipynb` (Python pyshacl/rdflib, **twinned** with `SW-8-CSharp-SHACL.ipynb`), cell[1] — the dependencies-intro cell says rdflib was « déjà utilisée dans SW-8 », but this notebook **is** SW-8. Markdown-only, **0 re-exec, 0 code/output change**.

## Defect (cell[1] — IDENTITY/phantom, self-reference)

cell[1] `## 0. Installation des dependances` introduces rdflib + pyshacl:

```
- **rdflib** : manipulation de graphes RDF (déjà utilisee dans SW-8)
- **pyshacl** : moteur de validation SHACL pour Python
```

« déjà utilisée dans SW-8 » is a **self-reference**: this notebook *is* SW-8, and cell[1] is the dependencies-intro cell (rdflib has not been used yet in this notebook). The point of the parenthetical is "you've already encountered rdflib in a previous notebook" — that previous notebook is **SW-2b-Python-RDFBasics**, whose c0 header reads:

> `## RDF en Python avec rdflib - Fondamentaux`

So the referent should be SW-2b, not SW-8.

## Fix (markdown-only, cell[1] only)

`(déjà utilisee dans SW-8)` → `(déjà utilisee dans SW-2b)`.

## Class (no §D.5)

IDENTITY/phantom class — self-reference (a notebook pointing at itself as the place a dependency was "already" used). No committed output drifted; not a measure/value drift → no §D.5 diagnostic owed. Precedent: SW Explore sweep self/phantom findings (SW-12 self-ref #9211, SW-11 SHACL→SW-8 #9214).

## Verification (firsthand, #8052 lens, L786-2)

- Read cell[0] (header) + cell[1] (deps) directly from `origin/main`. Verified the target phrase `(déjà utilisee dans SW-8)` is unique in the notebook (count=1, only in cell[1]).
- Authority: `SW-2b-Python-RDFBasics.ipynb` c0 header `## RDF en Python avec rdflib - Fondamentaux` introduces rdflib (firsthand, git show origin/main).
- Standard round-trippable JSON (RT exact match), element-level replace (c.1123-L) + `json.loads` re-parse: ONLY cell[1] changed; header cell[0] byte-identical.
- Lock: PY NB blob `4d451193` == `origin/main` pre-edit. New PY NB blob `47597549`.
- **Twin-parity gate (#8057) verified locally** (drift_introduced=0, c.1039-L2): yaml python_sha `47597549` == committed PY NB blob; csharp_sha `fce2451b` == base C# blob (PRESERVED).

## C# twin (Python-only fix)

`SW-8-CSharp-SHACL.ipynb` has no parallel self-reference (its c1 loads dotNetRDF, no « déjà utilisée dans SW-N » cross-ref) → **no parallel defect** → csharp PRESERVED. Twin yaml `sw-8-shacl.yaml` (parity_level=semantic): python_sha rebaselined (`4d451193`→`47597549`), csharp `fce2451b` PRESERVED, reason added (0 pre-existing reason, c.1132-L safe).

## Scope & coordination

2 files: M Python notebook + M twin yaml. Markdown-only, 0 re-exec. L898/DUP-GUARD clear (no open PR touches SW-8 content). R6: SW vein (9th SW finding: #9205 SW-2, #9206 SW-3, #9207 SW-7, #9209 SW-10, #9211/#9212 SW-12, #9214 SW-11, this SW-8).

See #8052 (SemanticWeb sweep — remaining findings re-verified firsthand and shipped in follow-up cycles).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
