### PR TITLE
feat(genai,#8056): populate metadata.cost on 4 GenAI 00-Environment setup notebooks (QC->GenAI rotation)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/00-1-Environment-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/00-1-Environment-Setup.ipynb
@@ -874,6 +874,23 @@
    },
    "start_time": "2026-06-25T04:46:00.872943",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "openai/openrouter",
+   "cpu_min": 1,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02T00:00Z",
+   "validator": "manual",
+   "notes": "Setup/validation standardise CoursIA. Test de generation opt-in (test_generation=False par defaut, ~0.01 USD si active). Health checks + listing CPU. Lit OPENAI_API_KEY/OPENROUTER_API_KEY pour config. Aucun GPU."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/00-2-Docker-Services-Management.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/00-2-Docker-Services-Management.ipynb
@@ -1213,6 +1213,23 @@
    },
    "start_time": "2026-05-09T22:49:57.309394",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 1,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02T00:00Z",
+   "validator": "manual",
+   "notes": "Gestion docker compose des services GenAI auto-heberges (ComfyUI/Qwen/Forge). Aucun appel API payant, aucun GPU dans les cellules (management CPU; wall-clock plus long du fait des I/O docker)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/00-3-API-Endpoints-Configuration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/00-3-API-Endpoints-Configuration.ipynb
@@ -2232,6 +2232,23 @@
    },
    "start_time": "2026-06-25T07:09:34.259441",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 1,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02T00:00Z",
+   "validator": "manual",
+   "notes": "Configuration des endpoints API (ecriture config .env/services). Aucun appel API, aucun GPU. Setup pur, deterministe."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/00-4-Environment-Validation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/00-4-Environment-Validation.ipynb
@@ -845,6 +845,23 @@
    "parameters": {},
    "start_time": "2026-05-09T22:49:57.243454",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "openai/openrouter",
+   "cpu_min": 1,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02T00:00Z",
+   "validator": "manual",
+   "notes": "Validation environnement via GET /v1/models (gratuit sur OpenAI/OpenRouter, aucune generation). Lit OPENAI_API_KEY/OPENROUTER_API_KEY. Aucun GPU, aucun cout."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: COST/metadata -- lane myia-po-2023:CoursIA -- prev: COST/metadata #9213

See #8056 (acceptance: populate metadata.cost across notebook families).
Third cost tranche -- FAMILY ROTATION QC -> GenAI (po-2023 lane). Populates
the GenAI cost schema on 4 environment/setup notebooks of the GenAI
00-GenAI-Environment series that were missing metadata.cost.

## The 4 notebooks

All 4 are CPU/config/setup notebooks (verified firsthand on origin/main:
no GPU compute in cells, no `from openai` SDK call, no paid generation in
default config). Family-rotation from the QC tranches (#9210/#9213).

| Notebook | cells | profile |
|----------|-------|---------|
| 00-1-Environment-Setup | 6 | standardized env setup + validation; reads OPENAI/OPENROUTER keys for config; opt-in generation test (test_generation=False default) |
| 00-2-Docker-Services-Management | 7 | docker compose management of self-hosted GenAI services (ComfyUI/Qwen/Forge); no API, no GPU in cells |
| 00-3-API-Endpoints-Configuration | 10 | writes API endpoint config (.env/services); no calls, no GPU |
| 00-4-Environment-Validation | 6 | validation via GET /v1/models (FREE on OpenAI/OpenRouter, no generation); reads OPENAI/OPENROUTER keys |

Common GenAI cost fields: gpu_min 0, gpu_required false, vram_gb 0,
vram_tier NONE, network true, free_alternative null, reduced_pedagogical
null, reproducibility HIGH (deterministic setup/config), validator manual,
metadata_written 2026-08-02.

Per-notebook honesty (calibrated firsthand):
- 00-1 / 00-4: api_usd_est 0.0, api_provider "openai/openrouter",
  external_account "openai". Rationale: 00-4 calls only GET /v1/models
  (free model-listing, no tokens consumed); 00-1's generation test is
  opt-in (test_generation=False by default -> 0 USD default run, ~0.01 if
  enabled, documented in notes). Both read OPENAI_API_KEY/OPENROUTER_API_KEY
  -> external_account="openai" satisfies litmus 3.
- 00-2 / 00-3: api_usd_est 0.0, api_provider "none", external_account null.
  Pure local infra/config, no tokens, no calls.

## Why gpu_required=false for all 4

These are setup/config/management notebooks. Their cells are import guards,
config writes, docker compose commands, and HTTP health/model-list GETs --
all CPU. They do NOT compute on a GPU. (The self-hosted *services* they
configure/deploy use GPU, but the notebook cells themselves do not -- noted
in the 00-2 notes.) gpu_required=true would require a sk_visual/papermill
validator (litmus 6), which is not honestly claimable for a metadata-only
pass. The GPU-deploying notebooks (00-5 ComfyUI-Local-Test, 00-6
Local-Docker-Deployment) are INTENTIONALLY EXCLUDED from this tranche --
they need gpu_required=true + sk_visual validation, a separate heavier
calibration.

## Verification (firsthand, origin/main HEAD d0a6287d1)

1. Byte-surgical diff: only the `cost` block added to notebook metadata,
   68 insertions / 0 deletions across 4 files, 0 cell/output churn.
   json.dumps(indent=1, ensure_ascii=False) round-trip byte-identical
   (byte-stability dry-run verified on all 4 BEFORE editing).
2. scripts/audit/check_cost_metadata.py: exit 0 on all 4 (0 findings --
   empty `findings:` list). Litmus 2 (no `from openai`/`claude`/`gemini`
   in code), litmus 3 (external_account reflects token reads), litmus 6
   (gpu_required false -> no sk_visual needed), litmus 9 (all code cells
   carry non-null execution_count) all satisfied.
3. No catalog churn (COURSE_CATALOG.generated.* untouched --
   catalog-pr-hygiene compliant; the daily cron picks up cost via the
   generator on main).
4. No source-cell change -> outputs preserved valid (metadata-only edit,
   C.2 re-exec not triggered).

## Scope

4 notebooks, metadata-only. No code/strategy change -> no re-exec required.
Atomic, single-subject (GenAI 00-Environment cost tranche). Single family,
single defect type (missing metadata.cost).

## #8056 state after this PR

GenAI population: was 119/144 on origin/main. After this (+4): 123/144
(~85%). Residual GenAI without cost: 00-5/00-6 (GPU, need sk_visual),
Audio/03 x3 + Image/04-4 + Claudish (frontmatter-defect, in-flight #9082/
#9088), CaseStudies x4 (external GenAI APIs, per-notebook calibration),
Playwright-OWUI x7 (local OWUI QA, separate sub-project #4433),
RAG/01-Hands-On (embeddings API), SemanticKernel/fort-boyard-csharp,
_e2e_quant_validation. These residuals need per-sub-family calibration
(GPU-via-service, external API cost, Playwright profile), not the simple
setup/config profile here.

See #8056, #4208.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
