### PR TITLE
fix(symbolic,#8052): SW-1 c1 concepts table labels SPARQL as SW-5 (should be SW-4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-1-CSharp-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-1-CSharp-Setup.ipynb
@@ -83,7 +83,7 @@
     "| **Identifiants** | URI / IRI | Nommer de facon unique chaque ressource | SW-2 |\n",
     "| **Modèle de données** | RDF | Representer l'information en triplets | SW-2, SW-3 |\n",
     "| **Schema** | RDFS | Définir des classes et proprietes | SW-6 |\n",
-    "| **Requêtes** | SPARQL | Interroger des graphes RDF | SW-5 |\n",
+    "| **Requêtes** | SPARQL | Interroger des graphes RDF | SW-4 |\n",
     "| **Ontologies** | OWL | Raisonnement logique sur les données | SW-7 |\n",
     "| **Contraintes** | SHACL | Valider la conformite des données | SW-8 |\n",
     "\n",


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2

## What

**1 identity/phantom defect (1 table cell)** in `SW-1-CSharp-Setup.ipynb` (C#-only setup notebook, **not twinned**), cell[1] — the « Pourquoi le Web sémantique ? » concepts table maps the SPARQL row to **SW-5**, but SPARQL is **SW-4**. Markdown-only, **0 re-exec, 0 code/output change**.

## Defect (cell[1] — IDENTITY/phantom)

cell[1] concepts table:

| Concept | Techno | Rôle | Notebook (WRONG) |
|---------|--------|------|------------------|
| **Requêtes** | SPARQL | Interroger des graphes RDF | **SW-5** |

But this notebook's **own** cell[16] authoritative series index proves SPARQL = SW-4 and SW-5 = Linked Data:

```
| 4 | SW-4-SPARQL      | 45 min | Query Builder, SELECT, FILTER, OPTIONAL |
| 5 | SW-5-LinkedData  | 50 min | DBpedia, Wikidata, requêtes federees      |
```

So the SPARQL row should point at SW-4 (the dedicated SPARQL notebook), not SW-5 (Linked Data). The other c1 rows are correct (RDFS→SW-6, OWL→SW-7, SHACL→SW-8 — consistent with PR#9207's SHACL=SW-8 fix); only the SPARQL row was wrong.

## Fix (markdown-only, cell[1] only)

`Interroger des graphes RDF | SW-5` → `Interroger des graphes RDF | SW-4`.

## Class (no §D.5)

IDENTITY/phantom class — concept-to-notebook mapping naming the wrong notebook. No committed output drifted; not a measure/value drift → no §D.5 diagnostic owed. Precedent: SW Explore sweep phantom findings (SW-7 SHACL→SW-8 #9207, SW-10 nav #9209, SW-11 SHACL→SW-8 #9214).

## Verification (firsthand, #8052 lens, L786-2)

- Read cell[0] (header) + cell[1] (concepts table) + cell[16] (authoritative series index) directly from `origin/main`. Verified the target substring `Interroger des graphes RDF | SW-5` is unique in the notebook (count=1, only cell[1] elem[45]).
- Authority: SW-1 c16 series index `SW-4-SPARQL` / `SW-5-LinkedData` (firsthand, git show origin/main).
- Standard round-trippable JSON (RT exact match), element-level replace (c.1123-L) + `json.loads` re-parse: ONLY cell[1] changed; header cell[0] and the authoritative series-index cell[16] byte-identical.
- Lock: NB blob `6f7c94a1` == `origin/main` pre-edit. New NB blob `ee682f10`.
- Not twinned (no `sw-1-setup.yaml` in `twin_pairs.d`; SW-1 is a C#-only setup notebook) → single-file edit, no SHA rebaseline, no twin-parity gate.

## Scope & coordination

1 file: M C# notebook. Markdown-only, 0 re-exec. L898/DUP-GUARD clear (no open PR touches SW-1 content). R6: SW vein (10th SW finding: #9205 SW-2, #9206 SW-3, #9207 SW-7, #9209 SW-10, #9211/#9212 SW-12, #9214 SW-11, #9215 SW-8, this SW-1).

Note: SW-13 c88 reasoner finding (#3) deferred this cycle — PR#9112 already races on `sw-13-reasoners.yaml`; revisit once it merges.

See #8052 (SemanticWeb sweep — remaining findings re-verified firsthand and shipped in follow-up cycles).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
