### PR TITLE
feat(genai,#8056): populate metadata.cost on 4 CaseStudies (Multi-agent SK + DALL-E paid OpenAI cloud)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb
@@ -993,6 +993,23 @@
    },
    "start_time": "2026-05-15T05:14:52.427256",
    "version": "2.6.0"
+  },
+  "cost": {
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "openai",
+   "api_provider": "openai",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
+   "reduced_pedagogical": null,
+   "reproducibility": "LOW",
+   "metadata_written": "2026-08-02T00:00Z",
+   "validator": "manual",
+   "api_usd_est": 0.25,
+   "cpu_min": 2,
+   "notes": "Case study multi-agent Semantic Kernel (barbie/ane + arbitre Etudiant). ChatCompletionAgent group chat (~6 appels gpt-4o) + 1 generation d'image DALL-E via OpenAITextToImage. Cout estime depuis le decompte des sites d'appel (G.1 firsthand) : multi-agent (ref SK-03 0.15) + 1 image DALL-E (ref 01-1-DALL-E-3). Repro LOW (reponses cloud variables). Alternative locale : 10_LocalLlama."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb
@@ -792,6 +792,23 @@
    },
    "start_time": "2026-05-13T00:23:26.155115",
    "version": "2.6.0"
+  },
+  "cost": {
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "openai",
+   "api_provider": "openai",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
+   "reduced_pedagogical": null,
+   "reproducibility": "LOW",
+   "metadata_written": "2026-08-02T00:00Z",
+   "validator": "manual",
+   "api_usd_est": 0.15,
+   "cpu_min": 1,
+   "notes": "Case study multi-agent Semantic Kernel (3 agents Fort Boyard, group chat multi-turn). ~6 appels gpt-4o (3 agents x tours). Cout calibre sur la ref SK-03 Agents (0.15, 3 agents). Repro LOW (cloud). Alternative locale : 10_LocalLlama."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
@@ -1200,6 +1200,23 @@
    },
    "start_time": "2026-05-15T05:15:37.931204",
    "version": "2.6.0"
+  },
+  "cost": {
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "openai",
+   "api_provider": "openai",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
+   "reduced_pedagogical": null,
+   "reproducibility": "LOW",
+   "metadata_written": "2026-08-02T00:00Z",
+   "validator": "manual",
+   "api_usd_est": 0.15,
+   "cpu_min": 2,
+   "notes": "Case study multi-agent medical (doctor/AI/pharmacist ChatCompletionAgent, 19 cellules). ~6 appels gpt-4o (3 agents + exercices prompts). Cout calibre sur la ref SK-03 Agents (0.15). Repro LOW (cloud). Alternative locale : 10_LocalLlama."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb
@@ -839,6 +839,23 @@
    },
    "start_time": "2026-05-15T05:15:53.706148",
    "version": "2.6.0"
+  },
+  "cost": {
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "openai",
+   "api_provider": "openai",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
+   "reduced_pedagogical": null,
+   "reproducibility": "LOW",
+   "metadata_written": "2026-08-02T00:00Z",
+   "validator": "manual",
+   "api_usd_est": 0.15,
+   "cpu_min": 1,
+   "notes": "Case study multi-agent Semantic Kernel (3 agents recipe maker, group chat). ~6 appels gpt-4o. Cout calibre sur la ref SK-03 Agents (0.15). Repro LOW (cloud). Alternative locale : 10_LocalLlama."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: COST/metadata -- lane myia-po-2023:CoursIA -- prev: COST/metadata #9216

See #8056 (acceptance: populate metadata.cost across notebook families).
Fourth cost tranche, GENAI CASE-STUDIES sub-family. RADICALLY DIFFERENT cost
profile from #9216 (00-Environment setup/config, api_usd_est 0, deterministic):
these 4 CaseStudies are Multi-agent Semantic Kernel applications that consume
PAID OpenAI cloud APIs (ChatCompletionAgent group chat + DALL-E image gen).
Non-trivial honest calibration (estimated api_usd_est from call-count, repro
LOW convention for cloud-stochastic notebooks).

## The 4 notebooks

All 4 are Semantic Kernel multi-agent case studies (verified firsthand on
origin/main: OpenAIChatCompletion + ChatCompletionAgent, read OPENAI_API_KEY,
inject into kernel; NOT self-hosted local stack — genuine paid OpenAI cloud).

| Notebook | agents | profile | api_usd_est |
|----------|--------|---------|-------------|
| barbie-schreck | 2 + DALL-E | group chat + OpenAITextToImage image gen | 0.25 |
| fort-boyard-python | 3 | multi-turn group chat | 0.15 |
| medical_chatbot | 3 (doctor/AI/pharmacist) | group chat, 19 cells | 0.15 |
| recipe_maker (receipe_maker) | 3 | group chat | 0.15 |

## Honest cost calibration (firsthand, anchored on existing GenAI refs)

Anchored on the already-populated SemanticKernel series (01-05) which share
the EXACT same consumption pattern (kernel.invoke via OpenAIChatCompletion):

- api_usd_est 0.15 = 3-agent multi-turn group chat (~6 gpt-4o calls), ref
  SK-03 Agents (0.15). Applied to fort-boyard/medical/recipe (3 agents each).
- api_usd_est 0.25 = barbie-schreck = multi-agent chat (0.15, ref SK-03) +
  1 DALL-E image generation (ref 01-1-DALL-E-3 image-gen notebooks 0.3-0.4,
  discounted for a single image).
- api_usd_est is ESTIMATED from the call-count read firsthand (number of
  ChatCompletionAgent declarations + kernel.invoke sites), NOT measured by
  a paid run. Documented transparently in each `notes` field.

Common GenAI cost fields: api_provider "openai", external_account "openai"
(litmus 3: reads OPENAI_API_KEY), gpu_min 0, gpu_required false (cloud API,
CPU local), vram_gb 0, vram_tier NONE, network true, free_alternative
"MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb" (litmus 4: EXISTS on
origin/main, verified), reduced_pedagogical null, validator manual,
metadata_written 2026-08-02.

## Why reproducibility: LOW (NOT HIGH)

These notebooks call OpenAI Cloud (ChatCompletionAgent + DALL-E) whose
responses are VARIABLE across runs. This matches the convention of the
already-populated SemanticKernel series (01-05 all reproducibility: LOW for
the same reason). Setting HIGH would be dishonest (a re-run does not produce
byte-identical outputs). HIGH is reserved for deterministic notebooks (QC
backtests, local config). Documented in notes.

## Verification (firsthand, origin/main HEAD 4a163295a)

1. Byte-surgical diff: only the `cost` block added to notebook metadata,
   68 insertions / 0 deletions across 4 files, 0 cell/output churn.
   json.dumps(indent=1, ensure_ascii=False) round-trip byte-identical
   (byte-stability dry-run verified on all 4 BEFORE editing).
2. scripts/audit/check_cost_metadata.py: exit 0 findings on all 4 (0
   litmus findings). Litmus 2 (no `from openai` direct SDK call — these use
   semantic_kernel.connectors.ai.open_ai, but api_usd_est>0 + api_provider
  "openai" is coherent and not contradicted), litmus 3 (external_account
  "openai" reflects OPENAI_API_KEY reads), litmus 4 (free_alternative
  exists), litmus 6 (gpu_required false -> no sk_visual needed), litmus 9
  (all code cells carry non-null execution_count) all satisfied.
3. No catalog churn (COURSE_CATALOG.generated.* untouched --
   catalog-pr-hygiene compliant; daily cron picks up cost on main).
4. No source-cell change -> outputs preserved valid (metadata-only edit,
   C.2 re-exec not triggered).

## Scope

4 notebooks, metadata-only. No code change -> no re-exec required.
Atomic, single-subject (GenAI CaseStudies cost tranche). Single sub-family,
single defect type (missing metadata.cost).

## #8056 state after this PR

GenAI population: was 123/144 (after #9216). After this (+4): 127/144
(~88%). Residual GenAI without cost: 00-5/00-6 (GPU, need sk_visual),
Audio/03 x3 + Image/04-4 + Claudish (frontmatter-defect, in-flight #9082/
#9088), Playwright-OWUI x7 (local OWUI QA, sub-project #4433),
RAG/01-Hands-On (embeddings API), SemanticKernel/fort-boyard-csharp,
_e2e_quant_validation.

See #8056, #4208.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
