### PR TITLE
feat(genai,#8056): metadata.cost on fort-boyard-csharp (SK C# cloud) + RAG/01 (fastembed local free)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/01-Hands-On-Grounding.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/01-Hands-On-Grounding.ipynb
@@ -719,6 +719,23 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.9"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02T00:00Z",
+   "validator": "manual",
+   "notes": "Grounding RAG pratique avec fastembed (embeddings locaux, modele BAAI/bge-small embarque). Aucune API payante, aucun token, aucun GPU requis (fastembed tourne CPU). Deterministe et reproductible (embeddings locaux fixes). Utilise Qdrant Docker local optionnel pour le vector store. Profil radicalement different des notebooks GenAI cloud : 0 USD, reproducibilite HIGH."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/fort-boyard-csharp.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/fort-boyard-csharp.ipynb
@@ -412,6 +412,23 @@
      }
     ]
    }
+  },
+  "cost": {
+   "api_usd_est": 0.15,
+   "api_provider": "openai",
+   "cpu_min": 1,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
+   "reduced_pedagogical": null,
+   "reproducibility": "LOW",
+   "metadata_written": "2026-08-02T00:00Z",
+   "validator": "manual",
+   "notes": "Case study multi-agent Fort Boyard en C# (.NET Interactive, SemanticKernel). ChatCompletionAgent group chat via AddOpenAIChatCompletion/AddAzureOpenAIChatCompletion, lit settingsConfig['apikey']. ~6 appels gpt-4o (3 agents x tours). Cout calibre sur le twin Python (CaseStudies/fort-boyard-python, 0.15). Repro LOW (cloud). Alternative locale : 10_LocalLlama."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: COST/metadata -- lane myia-po-2023:CoursIA -- prev: COST/metadata #9218

See #8056 (acceptance: populate metadata.cost across notebook families).
Fifth cost tranche. Two GenAI notebooks with RADICALLY OPPOSITE profiles
(C# cloud-paid vs Python local-free), two languages (.NET vs Python), two
sub-families never touched for cost (SemanticKernel C# + RAG).

## The 2 notebooks

| Notebook | lang | profile | api_usd_est | repro |
|----------|------|---------|-------------|-------|
| SemanticKernel/fort-boyard-csharp | C# (.NET) | SK multi-agent + OpenAI/Azure cloud PAID | 0.15 | LOW |
| RAG-et-Memoire-Semantique/01-Hands-On-Grounding | Python | fastembed LOCAL embeddings (FREE) | 0.0 | HIGH |

## Honest cost calibration (firsthand on origin/main)

### fort-boyard-csharp (C# .NET Interactive, SemanticKernel)
Multi-agent Fort Boyard case study in C#. Uses AddOpenAIChatCompletion /
AddAzureOpenAIChatCompletion, reads settingsConfig["apikey"]. 2 declared
agents (+ arbitre Etudiant = 3 conceptually), group chat multi-turn.
- api_usd_est 0.15 calibrated on the twin Python (CaseStudies/
  fort-boyard-python, 0.15 in #9218) — same scenario, same agent count.
- external_account "openai" (consumes OpenAI/Azure cloud).
- reproducibility LOW (cloud-stochastic, SK-series convention).

### RAG/01-Hands-On-Grounding (Python, fastembed)
Grounding/RAG hands-on using fastembed (BAAI/bge-small embeddings model,
EMBEDDED LOCALLY). No paid API, no token, no GPU (fastembed runs CPU).
Optional Qdrant Docker local for the vector store.
- api_usd_est 0.0 (local model, not an API call).
- api_provider "none", external_account null, network false (self-contained).
- reproducibility HIGH (deterministic local embeddings — byte-identical
  across runs, unlike cloud-embedding APIs).
- free_alternative null (this IS the free local alternative itself).
- Profile is the OPPOSITE end of the cost spectrum from fort-boyard-csharp:
  demonstrates the 0-USD / HIGH-reproducibility pole.

## Verification (firsthand, origin/main HEAD 4a163295a)

1. Byte-surgical diff: only the `cost` block added to notebook metadata,
   34 insertions / 0 deletions across 2 files, 0 cell/output churn.
   - fort-boyard-csharp: json.dumps(indent=1, ensure_ascii=False)+'\n' round-trip byte-identical (verified BEFORE editing).
   - RAG/01: json.dumps(indent=1, ensure_ascii=False) WITHOUT trailing
     newline round-trip byte-identical (this notebook has no trailing \n;
     adding one would churn — tested with/without trailing, stable only
     without). Both byte-stability dry-runs verified BEFORE editing.
2. scripts/audit/check_cost_metadata.py: exit 0 findings on both (0 litmus
   findings). Litmus 2 (fort-boyard-csharp: no `from openai` direct SDK —
   uses SemanticKernel connectors, api_usd_est>0 + api_provider "openai"
   coherent; RAG: no API at all, 0.0 coherent), litmus 3 (fort-boyard-csharp:
   external_account "openai"; RAG: external_account null, no token read),
   litmus 4 (free_alternative exists / null-OK), litmus 6 (gpu_required
   false both), litmus 9 (all code cells non-null execution_count) all
   satisfied.
3. No catalog churn (COURSE_CATALOG.generated.* untouched).
4. No source-cell change -> outputs preserved valid (metadata-only edit).
5. Neither notebook is in the twin registry (no yaml rebaseline needed —
   cost-only metadata edit doesn't enter twin-parity gate).

## Scope

2 notebooks, metadata-only. No code change -> no re-exec required.
Atomic, single-subject (GenAI cost tranche 5, two opposite-cost-profile
notebooks). Two languages (.NET + Python) for R6 family/language variety.

## #8056 state after this PR

GenAI population: was 127/144 (after #9218). After this (+2): 129/144
(~90%). Residual GenAI without cost: 00-5/00-6 (GPU, need sk_visual),
Audio/03 x3 + Image/04-4 + Claudish (frontmatter-defect, in-flight #9082/
#9088), Playwright-OWUI x7 (local OWUI QA, sub-project #4433),
_e2e_quant_validation.

See #8056, #4208.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
