### PR TITLE
feat(cost,#8056): populate metadata.cost on SMT/Z3-Linq2Z3 (6 NBs)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb
@@ -1503,6 +1503,23 @@
      }
     ]
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 6,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02",
+   "validator": "manual",
+   "notes": "SMT solving via local Z3 (Linq2Z3). No API, no GPU; deterministic solver; reproducibility HIGH. Self-contained (no external account)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb
@@ -503,6 +503,23 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "12.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 5,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02",
+   "validator": "manual",
+   "notes": "SMT solving via local Z3 (Linq2Z3). No API, no GPU; deterministic solver; reproducibility HIGH. Self-contained (no external account)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb
@@ -2084,6 +2084,23 @@
      }
     ]
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 6,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02",
+   "validator": "manual",
+   "notes": "SMT solving via local Z3 (Linq2Z3). No API, no GPU; deterministic solver; reproducibility HIGH. Self-contained (no external account)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb
@@ -1150,6 +1150,23 @@
      }
     ]
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 6,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02",
+   "validator": "manual",
+   "notes": "SMT solving via local Z3 (Linq2Z3). No API, no GPU; deterministic solver; reproducibility HIGH. Self-contained (no external account)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb
@@ -580,6 +580,23 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "12.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 4,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02",
+   "validator": "manual",
+   "notes": "SMT solving via local Z3 (Linq2Z3). No API, no GPU; deterministic solver; reproducibility HIGH. Self-contained (no external account)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb
@@ -933,6 +933,23 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "12.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 5,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02",
+   "validator": "manual",
+   "notes": "SMT solving via local Z3 (Linq2Z3). No API, no GPU; deterministic solver; reproducibility HIGH. Self-contained (no external account)."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: COST/metadata -- lane myia-po-2023:CoursIA -- prev: COST/metadata #9219

See #8056 (acceptance: populate metadata.cost across notebook families).
Sixth cost tranche, SMT/Z3-Linq2Z3 sub-family -- a family never previously
touched for cost, with a uniform clean profile (local SMT solver).

## The 6 notebooks

All 6 are C# notebooks solving SMT constraints via local Z3 (Linq2Z3).
Verified firsthand on origin/main: no HttpClient / openai / anthropic, no
cuda/GPU, no token read. Z3 runs locally as a deterministic constraint solver.

| Notebook | code cells | cpu_min |
|----------|-----------|---------|
| 01_Linq2Z3_Intro | 12 | 6 |
| 03_Sudoku_Modes_Comparison | 8 | 5 |
| 04_Array_Theory | 11 | 6 |
| 12_Graph_Coloring_Petersen | 10 | 6 |
| 13_Cryptarithmetic_SMT | 7 | 4 |
| 14_Optimize_MaxSAT | 8 | 5 |

## Cost profile established for the SMT/Z3-Linq2Z3 family

api_usd_est 0.0 (local Z3 solver, not an API call), api_provider none,
gpu_required false, network false (self-contained local solving),
external_account null, reproducibility HIGH (deterministic local SMT -- Z3 is
deterministic given the same input/version), free_alternative null (Z3 IS the
free open-source SMT solver itself).

## Verification (firsthand, origin/main HEAD 4a163295a)

1. Byte-surgical: only the cost block added to notebook metadata,
   102 insertions / 0 deletions across 6 files, 0 cell/output churn.
   json.dumps(indent=1, ensure_ascii=False) round-trip byte-identical
   (byte-stability dry-run verified BEFORE editing, tested WITH and WITHOUT
   trailing newline: 01/03/12 stable WITH trailing, 04/13/14 stable WITHOUT).
2. scripts/audit/check_cost_metadata.py: exit 0 on all 6 (tokens_required=[]
   = 0 litmus findings).
3. No catalog churn (COURSE_CATALOG.generated.* untouched -- catalog-pr-hygiene
   compliant; the daily cron picks up cost via the generator on main).
4. No source-cell change -> outputs preserved valid (metadata-only edit).
5. None of the 6 are in the twin registry (no yaml rebaseline needed -- a
   cost-only metadata edit does not enter the twin-parity gate).

## Scope

6 notebooks, metadata-only. No code change -> no re-exec required.
Atomic, single-subject (SMT/Z3-Linq2Z3 cost tranche). Single family, single
defect type (missing metadata.cost).

## #8056 state after this PR

SMT/Z3-Linq2Z3 population: 0/14 -> 6/14 (new family opened for cost). Many
families still have large residual (SMT/Z3-API, Tweety, SmartContracts,
Planners, SemanticWeb, GameTheory Python). These need per-family calibration
(local-solver vs external-API vs GPU profiles), not the single uniform profile
here.

## Cycle note

This cycle's intended substance pivot (#9096 GT-14 C# twin Riccati divergence)
was independently re-derived and confirmed correct, but a collision-guard
revealed PR #9101 (CLEAN/MERGEABLE) already delivers that exact fix (Closes
#9096). The independent re-derivation (Engwerda coupled-Riccati, 3P^2+0.2P-1=0
-> 0.5450) and standalone C# verification confirm #9101 is mathematically
correct. Falling back to the cost EPIC (#8056) backlog to meet the floor
without duplicating #9101.

See #8056, #4208.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
