### PR TITLE
feat(cost,#8056): populate metadata.cost on Tweety-Csharp logics (7 NBs)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2b-Semantics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2b-Semantics-Csharp.ipynb
@@ -992,6 +992,23 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 8,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02",
+   "validator": "manual",
+   "notes": "Formal-logic solving via local Tweety (TweetyProject, Java via IKVM). No API, no GPU; deterministic logic reasoning. Requires a configured Java env (JAVA_HOME + Tweety jars) to execute, but the solving itself is deterministic -> reproducibility HIGH. Self-contained (no external account)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2c-FOL-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2c-FOL-Csharp.ipynb
@@ -901,6 +901,23 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 10,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02",
+   "validator": "manual",
+   "notes": "Formal-logic solving via local Tweety (TweetyProject, Java via IKVM). No API, no GPU; deterministic logic reasoning. Requires a configured Java env (JAVA_HOME + Tweety jars) to execute, but the solving itself is deterministic -> reproducibility HIGH. Self-contained (no external account)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Conditional-Logics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Conditional-Logics-Csharp.ipynb
@@ -499,6 +499,23 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 6,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02",
+   "validator": "manual",
+   "notes": "Formal-logic solving via local Tweety (TweetyProject, Java via IKVM). No API, no GPU; deterministic logic reasoning. Requires a configured Java env (JAVA_HOME + Tweety jars) to execute, but the solving itself is deterministic -> reproducibility HIGH. Self-contained (no external account)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Dung-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Dung-Csharp.ipynb
@@ -837,6 +837,23 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 8,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02",
+   "validator": "manual",
+   "notes": "Formal-logic solving via local Tweety (TweetyProject, Java via IKVM). No API, no GPU; deterministic logic reasoning. Requires a configured Java env (JAVA_HOME + Tweety jars) to execute, but the solving itself is deterministic -> reproducibility HIGH. Self-contained (no external account)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-ModalLogic-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-ModalLogic-Csharp.ipynb
@@ -627,6 +627,23 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 6,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02",
+   "validator": "manual",
+   "notes": "Formal-logic solving via local Tweety (TweetyProject, Java via IKVM). No API, no GPU; deterministic logic reasoning. Requires a configured Java env (JAVA_HOME + Tweety jars) to execute, but the solving itself is deterministic -> reproducibility HIGH. Self-contained (no external account)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-QBF-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-QBF-Csharp.ipynb
@@ -515,6 +515,23 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 6,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02",
+   "validator": "manual",
+   "notes": "Formal-logic solving via local Tweety (TweetyProject, Java via IKVM). No API, no GPU; deterministic logic reasoning. Requires a configured Java env (JAVA_HOME + Tweety jars) to execute, but the solving itself is deterministic -> reproducibility HIGH. Self-contained (no external account)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Aspic-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Aspic-Csharp.ipynb
@@ -878,6 +878,23 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 8,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02",
+   "validator": "manual",
+   "notes": "Formal-logic solving via local Tweety (TweetyProject, Java via IKVM). No API, no GPU; deterministic logic reasoning. Requires a configured Java env (JAVA_HOME + Tweety jars) to execute, but the solving itself is deterministic -> reproducibility HIGH. Self-contained (no external account)."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: COST/metadata -- lane myia-po-2023:CoursIA -- prev: COST/metadata #9220

See #8056 (acceptance: populate metadata.cost across notebook families).
Seventh cost tranche, Tweety C# logics sub-family -- a new family never
previously touched for cost, with a uniform clean profile (local logic solver).

## The 7 notebooks

All 7 are C# notebooks solving formal-logic problems via local Tweety
(TweetyProject, Java via IKVM). Verified firsthand on origin/main: api=False,
rng=0 (no stochasticity), no token read, no GPU. Tweety runs locally as a
deterministic logic-reasoning library.

| Notebook | code cells | cpu_min |
|----------|-----------|---------|
| Tweety-2b-Semantics-Csharp | 12 | 8 |
| Tweety-2c-FOL-Csharp | 15 | 10 |
| Tweety-3-Conditional-Logics-Csharp | 9 | 6 |
| Tweety-3-Dung-Csharp | 12 | 8 |
| Tweety-3-ModalLogic-Csharp | 10 | 6 |
| Tweety-3-QBF-Csharp | 9 | 6 |
| Tweety-4-Aspic-Csharp | 12 | 8 |

## Cost profile for the Tweety-Csharp family

api_usd_est 0.0 (local Tweety logic library, not an API call), api_provider
none, gpu_required false, network false (self-contained local solving),
external_account null, reproducibility HIGH (deterministic logic reasoning --
Tweety is deterministic given the same input/version), free_alternative null
(Tweety IS the free open-source logic library itself). The notes field
documents honestly that execution requires a configured Java env (JAVA_HOME +
Tweety jars), but the solving itself is deterministic.

## Verification (firsthand, origin/main HEAD 4a163295a)

1. Byte-surgical: only the cost block added to notebook metadata,
   119 insertions / 0 deletions across 7 files, 0 cell/output churn.
   json.dumps(indent=1, ensure_ascii=False) round-trip byte-identical
   (byte-stability dry-run verified BEFORE editing on all 7).
2. scripts/audit/check_cost_metadata.py: exit 0 on all 7 (tokens_required=[]
   = 0 litmus findings).
3. No catalog churn (COURSE_CATALOG.generated.* untouched -- catalog-pr-hygiene
   compliant).
4. No source-cell change -> outputs preserved valid (metadata-only edit).
5. Non-twinned: verified against scripts/notebook_tools/twin_pairs.d/tweety-*.yaml
   -- these 7 C# notebooks are not listed as python:/csharp: in any twin entry,
   so no yaml rebaseline is needed (a cost-only metadata edit on a non-twinned
   notebook does not enter the twin-parity gate).

## Scope

7 notebooks, metadata-only. No code change -> no re-exec required.
Atomic, single-subject (Tweety C# logics cost tranche). Single family, single
defect type (missing metadata.cost).

## #8056 state after this PR

Tweety-Csharp population: 0/18 -> 7/18. Many Tweety notebooks remain
(non-twinned Python + twinned pairs which would need rebaseline), plus large
residual across other families (SMT-API, SmartContracts, Planners, SemanticWeb,
GameTheory Python).

## Cycle note (honesty)

This is a 7th consecutive cost tranche. The intended substance pivot this
cycle was investigated and found objectively exhausted for a quick-win:
- Lean conway native_decide->decide (arc #8869): CONVERTIBLE arc is TERMINATED;
  residual Oscillators pulsar/pentadecathlon are documented "borderline, at the
  limit of native_decide" (Oscillators.lean header) -- converting to the more
  restrictive `decide` would almost certainly kernel-timeout. Not a quick-win.
- Lean sorry-elimination: residual sorry are either in prose comments (FP) or
  explicitly documented intractable (Lattice "tentatives stagnees").
- Enrichment #2161: scanner false-negatives -- the ML/Lab notebooks flagged
  <3 exercises actually have >=3 (verified Lab4-DataWrangling has 3, NumPy
  notebook has >=3) in guided-stub styles the regex misses.
- #8696 (knot Reidemeister refactor): explicitly "pas pour etre prise dans
  l'immediat" (deferred, multi-cycle blast radius).
- #3975 (README feuilles): owner po-2025:CoursIA-2 (not my turf).
Cost in a NEW family (Tweety, family rotation for R6 variety) is the productive
accumulable fallback while the merge-gate remains frozen (ai-01 down).

See #8056, #4208.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
