### PR TITLE
feat(cost,#8056): SmartContracts Foundry family cost-metadata (6 notebooks, local-deterministic)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb
@@ -2047,6 +2047,20 @@
    },
    "start_time": "2026-06-08T02:09:26.175907",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 5,
+   "gpu_required": false,
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual",
+   "notes": "Local execution via Foundry (forge/cast/anvil). Requires Foundry installed (curl -L https://foundry.paradigm.xyz). anvil provides local test accounts with funded ETH; execution is deterministic given the same Foundry version."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-4-Functions-State.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-4-Functions-State.ipynb
@@ -1865,6 +1865,20 @@
    },
    "start_time": "2026-06-03T00:13:47.545516+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 4,
+   "gpu_required": false,
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual",
+   "notes": "Local execution via Foundry (forge/cast/anvil). Requires Foundry installed (curl -L https://foundry.paradigm.xyz). anvil provides local test accounts with funded ETH; execution is deterministic given the same Foundry version."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-5-Inheritance.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-5-Inheritance.ipynb
@@ -1694,6 +1694,20 @@
    "parameters": {},
    "start_time": "2026-06-01T22:43:30.819961",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 4,
+   "gpu_required": false,
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual",
+   "notes": "Local execution via Foundry (forge/cast/anvil). Requires Foundry installed (curl -L https://foundry.paradigm.xyz). anvil provides local test accounts with funded ETH; execution is deterministic given the same Foundry version."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
@@ -1465,6 +1465,20 @@
    "parameters": {},
    "start_time": "2026-06-08T00:48:51.432799",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 3,
+   "gpu_required": false,
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual",
+   "notes": "Local execution via Foundry (forge/cast/anvil). Requires Foundry installed (curl -L https://foundry.paradigm.xyz). anvil provides local test accounts with funded ETH; execution is deterministic given the same Foundry version."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
@@ -1422,6 +1422,20 @@
    "parameters": {},
    "start_time": "2026-07-12T02:19:11.423206+00:00",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 4,
+   "gpu_required": false,
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual",
+   "notes": "Local execution via Foundry (forge/cast/anvil). Requires Foundry installed (curl -L https://foundry.paradigm.xyz). anvil provides local test accounts with funded ETH; execution is deterministic given the same Foundry version."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
@@ -2978,6 +2978,20 @@
    "parameters": {},
    "start_time": "2026-06-03T07:41:06.352905+00:00",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 8,
+   "gpu_required": false,
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual",
+   "notes": "Local execution via Foundry (forge/cast/anvil). Requires Foundry installed (curl -L https://foundry.paradigm.xyz). anvil provides local test accounts with funded ETH; execution is deterministic given the same Foundry version."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: COST/metadata -- lane myia-po-2023:CoursIA -- prev: COST/metadata #9222

See #8056 (acceptance: populate metadata.cost across notebook families).
Eighth cost tranche, SmartContracts Foundry sub-family -- a new family never
previously touched for cost, with a uniform clean profile (local Foundry
forge/cast/anvil Ethereum toolchain).

## The 6 notebooks

All 6 are C#-hosted Solidity notebooks exercising local Foundry (forge test,
cast call, anvil local Ethereum node). Verified firsthand on origin/main:
no openai/anthropic API, no GPU/.cuda, no token reads. The only https URLs
are Foundry install instructions (curl foundry.paradigm.xyz), not runtime
API calls. Foundry runs locally as a deterministic Ethereum toolchain.

| Notebook | code cells | cpu_min |
|----------|-----------|---------|
| SC-3-Solidity-Basics | 18 | 5 |
| SC-4-Functions-State | 15 | 4 |
| SC-5-Inheritance | 12 | 4 |
| SC-6-Errors-Events | 11 | 3 |
| SC-8-DeFi-Primitives | 8 | 4 |
| SC-12-Foundry-Testing | 23 | 8 |

## Cost profile for the SmartContracts Foundry family

api_usd_est 0.0 (local Foundry toolchain, not an API call), api_provider
none, gpu_required false, network false (self-contained local execution once
Foundry installed), external_account null (anvil provides funded test
accounts), reproducibility HIGH (deterministic local blockchain -- anvil
with fixed block numbers and forge test are deterministic given the same
Foundry version), free_alternative null (Foundry IS the free open-source
Ethereum toolchain itself). The notes field documents honestly that
execution requires Foundry installed (one-time setup), but execution itself
is deterministic.

## Verification (firsthand, origin/main HEAD 4a163295a)

1. Byte-surgical: only the cost block added to notebook metadata,
   84 insertions / 0 deletions across 6 files, 0 cell/output churn.
2. scripts/audit/check_cost_metadata.py: exit 0 on all 6 (tokens_required=[]
   = 0 litmus findings).
3. No catalog churn (COURSE_CATALOG.generated.* untouched -- catalog-pr-hygiene
   compliant).
4. No source-cell change -> outputs preserved valid (metadata-only edit).
5. Non-twinned: no SmartContracts entries in scripts/notebook_tools/twin_pairs.d/
   -> no yaml rebaseline needed (cost-only metadata edit on non-twinned notebooks
   does not enter the twin-parity gate).

## Scope

6 notebooks, metadata-only. No code change -> no re-exec required.
Atomic, single-subject (SmartContracts Foundry cost tranche). Single family,
single defect type (missing metadata.cost).

See #8056, #4208.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
