### PR TITLE
feat(cost,#8056): Sudoku Python BDD/inference family cost-metadata (2 notebooks, local-deterministic)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Python.ipynb
@@ -1602,6 +1602,20 @@
    "parameters": {},
    "start_time": "2026-07-06T04:21:09.526268+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 6,
+   "gpu_required": false,
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual",
+   "notes": "Local execution via Python BDD library (dd) and human inference strategies (Naked/Hidden Singles, X-Wing, etc.). Deterministic constraint propagation and BDD/MDD operations. Sudoku puzzles loaded from local files. Reproducible given the same puzzles and library version."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
@@ -2638,6 +2638,20 @@
    "parameters": {},
    "start_time": "2026-05-02T18:34:34.293848",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 8,
+   "gpu_required": false,
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual",
+   "notes": "Local execution via Python BDD library (dd) and human inference strategies (Naked/Hidden Singles, X-Wing, etc.). Deterministic constraint propagation and BDD/MDD operations. Sudoku puzzles loaded from local files. Reproducible given the same puzzles and library version."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: COST/metadata -- lane myia-po-2023:CoursIA -- prev: COST/metadata #9226

See #8056 (acceptance: populate metadata.cost across notebook families).
Cost tranche, Sudoku Python (BDD/inference) sub-family -- local-deterministic
Python notebooks never previously touched for cost.

## The 2 notebooks

Both are Python notebooks exercising local deterministic solving:
- Sudoku-14-BDD-Python: pure BDD/MDD (Binary Decision Diagrams) via the 'dd'
  library, hand-rolled BDDNode/MDDNode classes, deterministic apply/and/or/not
  operations with computed tables.
- Sudoku-8-HumanStrategies-Python: human inference strategies (Naked Single,
  Hidden Single, Naked Pair, Pointing Pair, X-Wing, Swordfish, XY-Wing),
  deterministic constraint propagation on puzzles loaded from local files.

Verified firsthand on origin/main: no openai/anthropic API, no GPU/.cuda,
no token reads, no uncontrolled randomness.

| Notebook | code cells | cpu_min |
|----------|-----------|---------|
| Sudoku-14-BDD-Python | 14 | 6 |
| Sudoku-8-HumanStrategies-Python | 22 | 8 |

## Cost profile for the Sudoku Python BDD/inference family

api_usd_est 0.0 (local BDD/inference), api_provider none, gpu_required false,
network false (self-contained local solving), external_account null,
reproducibility HIGH (deterministic BDD/MDD operations and constraint
propagation; puzzles loaded from local files, reproducible given the same
puzzles and library version), free_alternative null (the 'dd' library and
inference logic ARE the free open-source tools).

## Verification (firsthand, origin/main HEAD 4a163295a)

1. Byte-surgical: only the cost block added, 0 cell/output churn.
2. scripts/audit/check_cost_metadata.py: exit 0 on both.
3. No catalog churn (catalog-pr-hygiene compliant).
4. No source-cell change -> outputs preserved valid (metadata-only edit).
5. Non-twinned -> no yaml rebaseline needed.
6. Sudoku-15-Infer-Python and Sudoku-18-Comparison-Python deliberately skipped:
   both use uncontrolled 'random'/'np.random' (no fixed seed) -> stochastic,
   would need per-notebook reproducibility calibration rather than the uniform
   HIGH profile applied here.

See #8056, #4208.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
