### PR TITLE
feat(cost,#8056): SMT Z3-Python family cost-metadata (4 notebooks, local-deterministic)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb
@@ -526,6 +526,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.3"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 5,
+   "gpu_required": false,
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual",
+   "notes": "Local execution via Z3 SMT solver (z3-solver Python package). Deterministic constraint solving: Z3 is deterministic given the same assertions and version. Runs entirely locally (no external API, no GPU)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb
@@ -830,6 +830,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.7"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 6,
+   "gpu_required": false,
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual",
+   "notes": "Local execution via Z3 SMT solver (z3-solver Python package). Deterministic constraint solving: Z3 is deterministic given the same assertions and version. Runs entirely locally (no external API, no GPU)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb
@@ -722,6 +722,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.7"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 5,
+   "gpu_required": false,
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual",
+   "notes": "Local execution via Z3 SMT solver (z3-solver Python package). Deterministic constraint solving: Z3 is deterministic given the same assertions and version. Runs entirely locally (no external API, no GPU)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb
@@ -507,6 +507,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.3"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 5,
+   "gpu_required": false,
+   "network": false,
+   "external_account": null,
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": null,
+   "validator": "manual",
+   "notes": "Local execution via Z3 SMT solver (z3-solver Python package). Deterministic constraint solving: Z3 is deterministic given the same assertions and version. Runs entirely locally (no external API, no GPU)."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: COST/metadata -- lane myia-po-2023:CoursIA -- prev: COST/metadata #9228

See #8056 (acceptance: populate metadata.cost across notebook families).
Cost tranche, SMT/Z3-API Z3-Python sub-family -- local-deterministic Python
notebooks (distinct from the Z3-Linq2Z3 C# family covered in #9220).

## The 4 notebooks

All 4 are Python notebooks exercising the local Z3 SMT solver (z3-solver
package) on declarative style, scheduling (ordonnancement), the Einstein
enigma, and cryptarithmetic. Verified firsthand on origin/main: no
openai/anthropic API, no GPU/.cuda, no token reads. Z3 runs locally as a
deterministic constraint solver.

| Notebook | code cells | cpu_min |
|----------|-----------|---------|
| Z3-Python-07-Style-Declaratif-Linq | 7 | 5 |
| Z3-Python-08-Ordonnancement | 9 | 6 |
| Z3-Python-09-Enigme-Einstein | 7 | 5 |
| Z3-Python-10-Cryptarithmetic | 7 | 5 |

## Cost profile for the SMT/Z3-Python family

api_usd_est 0.0 (local Z3 solver, not an API call), api_provider none,
gpu_required false, network false (self-contained local solving),
external_account null, reproducibility HIGH (Z3 is deterministic given the
same assertions and version), free_alternative null (Z3 IS the free
open-source SMT solver).

## Verification (firsthand, origin/main HEAD 4a163295a)

1. Byte-surgical: only the cost block added, 0 cell/output churn (+56/-0).
2. scripts/audit/check_cost_metadata.py: exit 0 on all 4.
3. No catalog churn (catalog-pr-hygiene compliant).
4. No source-cell change -> outputs preserved valid (metadata-only edit).
5. Non-twinned -> no yaml rebaseline needed.

See #8056, #4208.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
