### PR TITLE
feat(cost,#8056): IIT/PyPhi ICT-3 + ICT-7 cost-metadata (2 deterministic notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb
@@ -976,6 +976,23 @@
    "parameters": {},
    "start_time": "2026-06-29T01:06:51.138165+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": null,
+   "cpu_min": 6,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02T00:00Z",
+   "validator": "manual",
+   "notes": "IIT: robustesse et gratification delogee, numpy+matplotlib, calcul deterministe (seed fixe). CPU-only. Pas d'API/GPU/reseau."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb
@@ -1045,6 +1045,23 @@
    "parameters": {},
    "start_time": "2026-06-29T13:48:28.290858+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": null,
+   "cpu_min": 8,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02T00:00Z",
+   "validator": "manual",
+   "notes": "IIT: signatures scale-free, numpy+matplotlib, calcul deterministe. CPU-only. Pas d'API/GPU/reseau."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: COST/metadata -- lane myia-po-2023:CoursIA -- prev: COST/metadata #9230

See #8056 (acceptance: populate metadata.cost across notebook families).
Small follow-up to #9230: the two remaining DETERMINISTIC IIT/PyPhi
ICT-Series notebooks (ICT-3, ICT-7), completing the deterministic IIT
coverage opened by #9230.

## The 2 notebooks

| Notebook | code cells | cpu_min |
|----------|-----------|---------|
| ICT-3-RobustnessDelayedGratification | 11 | 6 |
| ICT-7-ScaleFreeSignatures | 10 | 8 |

Both are Python notebooks (numpy + matplotlib) computing IIT quantities
locally. Verified firsthand on origin/main: no requests/openai/anthropic,
no cuda/GPU, no token read, no network. ICT-3 uses a fixed seed (deterministic
simulation); ICT-7 is purely deterministic (no stochastic primitives).

## Cost profile

Same uniform local profile as #9230: api_usd_est 0.0 (local computation, not
an API call), api_provider none, gpu_required false, network false,
external_account null, reproducibility HIGH (deterministic; ICT-3 seed-fixed),
free_alternative null. The notes field documents the per-notebook computation.

## Verification (firsthand, origin/main HEAD 4a163295a)

1. Byte-surgical: +34 / -0 across 2 files, 0 source-cell churn
   (verified programmatically). json.dumps(indent=1, ensure_ascii=False)
   round-trip byte-identical.
2. scripts/audit/check_cost_metadata.py: exit 0 on both (0 litmus findings).
3. No catalog churn (COURSE_CATALOG.generated.* untouched).
4. No source-cell change -> outputs preserved valid (metadata-only edit).
5. Non-twinned: verified against scripts/notebook_tools/twin_pairs.d/*.yaml
   -- IIT/ICT notebooks are not listed as python:/csharp: in any twin entry.

## Scope

2 notebooks, metadata-only, same family as #9230 (IIT deterministic coverage
completion). Atomic, single-subject. No code change -> no re-exec required.

## Cycle note (honesty)

This cycle's substance investigation was exhaustive and confirmed saturated
firsthand BEFORE this cost follow-up:
- GameTheory §D.5 (GT-16-MechanismDesign): markdown claims match committed
  outputs (clean); also in-flight #9090 (collision-avoided).
- Lean sorry-elimination: Minimax.lean is already 0-sorry (grep matches are
  comments declaring "0 sorry"); remaining sorries are INTRINSIC (Folk/Gittins)
  or DEFERRED (HashlifeCorrectness #6724, knot_lean #8696).
- Enrichment #2161: low-count candidates confirmed to already have >=3
  exercises (counter false-negatives).
- A background §D.5 scan of the Search family (Part1-4, sub-agent) is in
  flight; if it surfaces a real defect it becomes a separate substance PR.

R6 honesty: cost-metadata has dominated today's tranches; this is a small
same-family follow-up (2 notebooks) completing the deterministic IIT coverage,
not a new cost tunnel. Substance remains the preferred genre and was pursued
exhaustively this cycle.

See #8056, #4208.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
