### PR TITLE
enrich(ml,#2161): add learning_curve capstone exercise to 2.5-Biais-Variance-CV-ROC

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
@@ -1011,6 +1011,51 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 4 (capstone) : diagnostiquer biais et variance avec une courbe d'apprentissage\n",
+    "\n",
+    "Les exercices précédents comparent des modèles par *validation croisée* et lisent une *courbe ROC*. Il reste un outil de diagnostic central pour le compromis **biais / variance** : la **courbe d'apprentissage** (*learning curve*). Elle trace le score — en entraînement **et** en validation — en fonction de la taille du jeu d'entraînement, et permet de distinguer deux régimes :\n",
+    "\n",
+    "- **biais élevé (sous-apprentissage)** : les deux courbes convergent vers un score *faible* ; ajouter des données n'aide pas, il faut un modèle plus expressif ou de meilleures variables ;\n",
+    "- **variance élevée (sur-apprentissage)** : le score d'entraînement est *élevé* mais le score de validation reste *en dessous* ; l'écart se réduit avec plus de données, il faut en ajouter ou régulariser.\n",
+    "\n",
+    "**Objectif.** Pour la régression logistique **et** l'arbre de décision, tracer la courbe d'apprentissage sur `X_train` / `y_train` et identifier lequel souffre plutôt de biais, lequel plutôt de variance.\n",
+    "\n",
+    "- *Indice 1* : `from sklearn.model_selection import learning_curve`.\n",
+    "- *Indice 2* : `learning_curve(est, X, y, train_sizes=np.linspace(0.1, 1.0, 10), cv=5)` renvoie `(train_sizes, train_scores, test_scores)` où chaque ligne de scores correspond à un `train_sizes` et chaque colonne à un pli de la CV.\n",
+    "- *Indice 3* : tracer `train_scores.mean(axis=1)` et `test_scores.mean(axis=1)` ; ajouter une bande `fill_between(..., mean +/- std)` pour visualiser la variabilité. Un écart persistant entre les deux courbes = variance ; une convergence à un plateau bas = biais."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 12,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : tracer les courbes d'apprentissage.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 (capstone) : courbe d'apprentissage de la regression logistique\n",
+    "# et de l'arbre de decision sur breast_cancer.\n",
+    "# Etape 1 : importer learning_curve depuis sklearn.model_selection.\n",
+    "# Etape 2 : pour chacun des 2 modeles, calculer train_sizes + train_scores + test_scores\n",
+    "#           avec cv=5 et train_sizes=np.linspace(0.1, 1.0, 10).\n",
+    "# Etape 3 : tracer (2 sous-figures) le score moyen train vs validation +/- ecart-type,\n",
+    "#           et commenter : quel modele a un probleme de biais ? De variance ?\n",
+    "# Indice : la convergence des deux courbes vers un plateau bas signe un biais ;\n",
+    "#          un ecart persistant (train haut, validation basse) signe une variance.\n",
+    "resultat = None  # TODO etudiant\n",
+    "print(\"Exercice a completer : tracer les courbes d'apprentissage.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a50c0017",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
Grain: ENRICHMENT/substance -- lane myia-po-2023:CoursIA -- prev: COST/metadata #9238

See #2161 (>=3 exercises per notebook). Adds a 4th capstone exercise to
2.5-Biais-Variance-CV-ROC (bias/variance, cross-validation, ROC), exercising
an API that is central to the notebook's theme but was NOT yet used.

## What

**Exercice 4 (capstone) : diagnostiquer biais et variance avec une courbe
d'apprentissage.** Asks the student to plot `sklearn.model_selection.learning_curve`
for the logistic regression AND the decision tree on breast_cancer, and
classify which model suffers from bias vs variance.

Why this exercise: `learning_curve` is THE canonical bias/variance diagnostic
(score vs training-set size, train vs validation) -- the notebook's title is
literally "Biais, variance" yet `learning_curve` was ABSENT (verified firsthand:
learning_curve/validation_curve/StratifiedKFold all absent from the notebook).
This is the demonstrated-concept / un-exercised-primitive enrichment vein: the
notebook demonstrates the bias-variance concept and CV/ROC tools, but never
exercises the learning curve that directly visualizes the tradeoff.

The notebook had 3 exercises (Exercice 1 highest-variance model, Exercice 2
number of folds, Exercice 3 interpret AUC). This adds the 4th, consistent with
the cluster enrichment pattern (#9173 Infer-17, #9172 SC-15, #9170 GT-15,
#9165 SC-0 all add a 4th exercise).

## Verification (firsthand, origin/main HEAD 4a163295a, fresh worktree)

1. **C.1**: stub via `resultat = None  # TODO etudiant` + `print(...)`, no
   `raise NotImplementedError`/`assert False`/`1/0`. validate_pr_notebooks.py
   PASS (0 banned).
2. **C.2 (real execution)**: full notebook re-executed with papermill
   (python3 kernel, 26/26 cells, exit 0, ~7s). The new stub cell carries a
   REAL execution (execution_count=12, real stream output = the print string).
3. **C.3 (surgical, zero churn)**: the diff is **+45 / -0** across 1 file.
   ONLY the 2 new cells (markdown prompt + code stub) are added; every original
   cell is byte-identical (outputs + execution_count unchanged, verified
   programmatically: 0 original cells churned). A naive full-re-exec would have
   churned every matplotlib PNG + 4 ConvergenceWarning message-texts (sklearn
   version artifact, numbers identical) -- avoided by splicing only the new
   cell's real executed state into the original notebook.
4. **H.3**: validate_pr_notebooks.py = 1/1 passed; no cell with
   execution_count=None + empty outputs.
5. Catalogue untouched (COURSE_CATALOG.generated.* unchanged).
6. Collision-guard: no open PR touches 2.5-Biais-Variance-CV-ROC (nearest are
   #9177 ML-9 anomaly and #9162 Search-3, different notebooks/families).

## R6 note (honesty, genre rotation)

This is a deliberate SUBSTANCE / genre-rotation pivot after 4 consecutive
cost-metadata tranches (c.1119-1122: #9234-#9238). R6 bans a mono-theme
journée; enrichment (#2161, serie-notebook substance) is the sanctioned
plat-principal genre distinct from cost. Substance was confirmed saturated
firsthand this cycle (native_decide Conway done / knot deferred, §D.5 saturated
8+ G.1 catches c.1121, #9089 design-gate deferred, #8949 already-resolved).

See #2161, #3801.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
