### PR TITLE
fix(gametheory,#8052): GT-2-C# PD mixed-Nash prints invalid negative probability

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp.ipynb
@@ -714,7 +714,7 @@
        "=== Equilibres mixtes 2x2 (principe d'indifference) ===\r\n",
        "Pile ou Face       : J1 joue Heads à 0.500 / Tails à 0.500 ; J2 joue Heads à 0.500 / Tails à 0.500  (chaque joueur 1/2-1/2, valeur 0)\r\n",
        "Bataille des Sexes : J1 joue Opera à 0.667 / Foot à 0.333 ; J2 joue Opera à 0.333 / Foot à 0.667  (3e equilibre, mixte)\r\n",
-       "Dilemme Prisonnier : J1 joue Coop à -1.000 / Defect à 2.000 ; J2 joue Coop à -1.000 / Defect à 2.000\r\n"
+       "Dilemme Prisonnier : pas d'equilibre mixte interieur (Defect domine — seul (Defect,Defect) est equilibre)\r\n"
       ]
      },
      "metadata": {},
@@ -734,6 +734,10 @@
     "    if (Math.Abs(denomA) < 1e-12 || Math.Abs(denomB) < 1e-12) return null;  // pas d'interieur\n",
     "    double beta = (g.U1[1,1] - g.U1[0,1]) / denomB;\n",
     "    double alpha = (g.U2[1,1] - g.U2[1,0]) / denomA;\n",
+    "    // Une strategie mixte valide exige des probabilites dans [0, 1] ; hors de cet\n",
+    "    // intervalle il n'y a pas d'equilibre mixte interieur (ex. Dilemme du Prisonnier,\n",
+    "    // ou Defect domine strictement Coop -> seul (Defect,Defect) est equilibre).\n",
+    "    if (alpha < -1e-9 || alpha > 1 + 1e-9 || beta < -1e-9 || beta > 1 + 1e-9) return null;\n",
     "    return (alpha, beta);\n",
     "}\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform.yaml
@@ -4,10 +4,10 @@
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-31"
+    date: "2026-08-02"
     by: myia-po-2024:CoursIA-2
     python_sha: 183d8f84edcf34e6018de795ebc2540dfa3f74d0
-    csharp_sha: 4af2b2213ed29adf3390baee09d29c9d9429818d
+    csharp_sha: 193e39383c74f3ef0de15ba7c7d2a0db8cb2109c
   known_differences:
     - "Socle pedagogique commun : jeux sous forme normale (matrices de gains 2 joueurs), strategies pures, dominance, equilibres de Nash purs sur 5 jeux canoniques (Prisonnier, Stag Hunt, BoS, Poulet, Matching Pennies)."
     - "Idiomes framework : Python = `numpy` + `nashpy` (lib mature, Game(A,B), support_enumeration). C# = pur `System.*` (Linq, Collections), classes from-scratch (matrices A/B/Payoffs, pas de lib tiers)."


### PR DESCRIPTION
# GT-2-C# — Prisoner's Dilemma mixed-Nash printed invalid negative probabilities

**lane: po-2024** · See #8052 (semantic-sampling audit, umbrella — not fully resolved)

## Défaut

`GameTheory-2-NormalForm-Csharp.ipynb` cellule 12 — la méthode `MixedNash2x2`
appliquait la formule d'indifférence en forme fermée **sans validation de
plage** sur `alpha`/`beta`. Pour le Dilemme du Prisonnier (où Defect domine
strictement Coop), la formule retourne `alpha = -1.0`, `beta = -1.0` avec
`HasValue = True`, donc la cellule affichait :

```
Dilemme Prisonnier : J1 joue Coop à -1.000 / Defect à 2.000 ; J2 joue Coop à -1.000 / Defect à 2.000
```

Des **probabilités négatives** — une stratégie mixte invalide qui contredit le
framing pédagogique du notebook. La chaîne de fallback honnête
(`"pas d'equilibre mixte interieur"`) existait déjà mais était **du code mort** :
comme `denomB = -1 != 0`, la fonction ne retournait jamais `null`, donc le
fallback n'était jamais atteint.

## Fix

Ajout d'une garde de plage `[0,1]` (tolérance `1e-9`) avant le `return` :

```csharp
// Une strategie mixte valide exige des probabilites dans [0, 1] ; hors de cet
// intervalle il n'y a pas d'equilibre mixte interieur (ex. Dilemme du Prisonnier,
// ou Defect domine strictement Coop -> seul (Defect,Defect) est equilibre).
if (alpha < -1e-9 || alpha > 1 + 1e-9 || beta < -1e-9 || beta > 1 + 1e-9) return null;
```

Le Dilemme du Prisonnier affiche maintenant correctement l'absence d'équilibre
mixte intérieur (seul l'équilibre pur `(Defect,Defect)` existe). Les sorties
**MP (0.500)** et **BoS (0.667/0.333)** sont inchangées (leurs alpha/beta sont
déjà dans `[0,1]`).

## Vérification

- Re-exécution .NET console (instrument-avant-asserter) : PD → `alpha=-1.0`,
  `beta=-1.0` confirmé invalide avant le fix ; avec la garde → `null` → message
  fallback affiché.
- Sortie cellule 12 post-fix :
  `Dilemme Prisonnier : pas d'equilibre mixte interieur (Defect domine — seul (Defect,Defect) est equilibre)`
- Twin-parity (`check_twin_parity --check`) : `[OK]` après rebaseline du `csharp_sha`.
- Diff chirurgical byte-à-byte : 5 insertions, 1 délétion sur le `.ipynb` (aucun
  churn de metadata/timestamp/banner).

## Diagnostic dérive

**Défaut constaté** : la sortie committée cellule 12 contenait
`Coop à -1.000 / Defect à 2.000` pour le Dilemme du Prisonnier — des probabilités
négatives, i.e. une stratégie mixte mathématiquement invalide, présentée comme un
équilibre mixte existant.

**Ground truth (computed/code)** : une stratégie mixte est une distribution de
probabilité — par définition ses poids sont dans `[0, 1]` et somment à 1. La
formule d'indifférence en forme fermée ne garantit pas ce plage ; elle peut
produire des valeurs hors `[0,1]` précisément quand aucun équilibre mixte
intérieur n'existe (cas de dominance stricte, comme PD où Defect > Coop quoi que
fasse l'autre joueur). Le code lui-même (la chaîne de fallback `pas d'equilibre
mixte interieur`) documentait déjà cette intention, mais le garde-fou `return null`
n'était déclenché que par `denomB == 0`, jamais par le hors-plage — d'où le code mort.

**Cause racine** : absence de validation de plage `[0,1]` sur `alpha`/`beta` ;
la condition de nullité existante ne testait que le dénominateur nul.

**Fix** : garde `if (alpha < -1e-9 || alpha > 1 + 1e-9 || ...) return null;` qui
active le fallback honnête exactement quand la formule sort du simplex.

**Classe de défaut** : value-defect déterministe (STRONGEST per triage c.1062-L) —
non-timing, reproductible exactement à chaque exécution.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
