### PR TITLE
cost(qc,#8056): metadata.cost on QC-Py-18 + QC-Py-21 (inspection-validated)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-18-ML-Features-Engineering.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-18-ML-Features-Engineering.ipynb
@@ -4409,6 +4409,19 @@
    "parameters": {},
    "start_time": "2026-05-12T23:13:30.936864",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0,
+   "api_provider": "none",
+   "cpu_min": 15,
+   "gpu_required": false,
+   "network": false,
+   "external_account": "none",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02T18:00Z",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb
@@ -2795,7 +2795,20 @@
    "name": "python",
    "version": "3.10.0"
   },
-  "qc_reference": true
+  "qc_reference": true,
+  "cost": {
+   "api_usd_est": 0,
+   "api_provider": "none",
+   "cpu_min": 25,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-free",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-02T18:00Z",
+   "validator": "manual"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 5


### PR DESCRIPTION
Grain: COST/metadata -- lane myia-po-2023:CoursIA -- prev: TEST-COVERAGE #9242

See #8056 (metadata.cost EPIC). Adds cost metadata to 2 QuantConnect Python
notebooks that were without it (origin/main fresh probe), QC family rotation
(QC-Py progression now 124/205). These 2 were NOT in the frozen cost PRs
#9210 (07/08/09/11/12) or #9213 (13/14/16/27/28/35) -- non-duplicate, collision-
guard clean by exact file-path.

## What

- QC-Py-18-ML-Features-Engineering: sklearn ML (PCA / RandomForest / XGBoost /
  Lasso), local data (qc_reference ABSENT -> not a QuantBook). gpu=false,
  network=false, external_account=none, cpu_min=15.
- QC-Py-21-Portfolio-Optimization-ML: QuantBook (qc_reference=true) + ML
  (XGBoost/RandomForest/Keras Sequential), no torch.cuda. gpu=false, network=true,
  external_account=quantconnect-free, cpu_min=25.

## Honest profiling (firsthand inspection, not re-exec)

- GPU: probed torch.cuda / tf.config GPU / use_cuda -> only QC-Py-24 (excluded)
  had it; 18 and 21 have none -> gpu_required=false is honest (litmus 1 OK).
- API: no openai/anthropic/mistral -> api_usd_est=0, api_provider=none (litmus
  2/3/8 OK).
- validator="manual" : I inspected the profile without re-executing (no QC Cloud
  for 21, no QuantBook for 18). Affirming inspection only -> litmus 9 (null-exec
  cells: 18 has 3, 21 has 3) is NOT violated, since manual does not claim exec.

## Verification (firsthand, origin/main HEAD 4a163295a, fresh worktree)

1. check_cost_metadata.py on each NB -> EXIT 0, findings: (empty) on both.
2. surgical: +27/-1 across 2 files. The single -1 is "qc_reference": true ->
   "qc_reference": true, (comma added to insert the cost block AFTER, in
   top-level metadata). 0 source-cell churned (grep "source" += 0 on both).
3. catalogue byte-identical to main (no churn).
4. Collision-guard: 0 open PR touches QC-Py-18/21 (file-path exact). Not in my
   frozen cost PRs #9210/#9213.
5. byte-stability verified: json.dumps(indent=1, ensure_ascii=False) reproduces
   raw bytes; nl convention (trailing newline) detected + preserved.

## R6 note (genre + family rotation)

c.1122-1125 = ENRICHMENT x3 (#9239 ML -> #9240 Probas -> #9241 Search) then
TEST-COVERAGE #9242. This is the FIRST cost tranche in 4 cycles -> genre rotated,
not monotone. Family QC is fresh (last QC cost was #9213). RATIO policy in force.
The .NET enrichment vein was probed this cycle and confirmed DRAINED: all 4 rich
0-exercise candidates (GT-5, CSP-4, Planners-3, Infer-14, Infer-15) already have
3-4 exercises (patterns "Nb. Exercice" + "// Exercice :" defeat naive scanners --
confirmed cell-by-cell). Lean/§D.5/i18n/README confirmed DRAINED/CLEAN firsthand.

See #8056.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
