### PR TITLE
fix(gametheory,#8052): GT-3-C# Matching Pennies wrong ordinal matrix (had a pure Nash)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2-Csharp.ipynb
@@ -320,7 +320,7 @@
        " Stag Hunt             | (4,1,3,2) | (4,3,1,2)\r\n",
        " Battle of Sexes       | (4,1,2,3) | (3,2,1,4)\r\n",
        " Chicken               | (3,2,4,1) | (3,4,2,1)\r\n",
-       " Matching Pennies      | (4,2,3,1) | (2,4,1,3)\r\n"
+       " Matching Pennies      | (4,1,2,3) | (1,4,3,2)\r\n"
       ]
      },
      "metadata": {},
@@ -335,7 +335,7 @@
     "    [\"Stag Hunt\"]          = new OrdinalGame(new[]{4,1,3,2}, new[]{4,3,1,2}, \"Stag\"),\n",
     "    [\"Battle of Sexes\"]    = new OrdinalGame(new[]{4,1,2,3}, new[]{3,2,1,4}, \"BoS\"),\n",
     "    [\"Chicken\"]            = new OrdinalGame(new[]{3,2,4,1}, new[]{3,4,2,1}, \"Chicken\"),\n",
-    "    [\"Matching Pennies\"]   = new OrdinalGame(new[]{4,2,3,1}, new[]{2,4,1,3}, \"MP\"),\n",
+    "    [\"Matching Pennies\"]   = new OrdinalGame(new[]{4,1,2,3}, new[]{1,4,3,2}, \"MP\"),\n",
     "};\n",
     "\n",
     "var sb = new System.Text.StringBuilder();\n",
@@ -525,7 +525,7 @@
     {
      "data": {
       "text/plain": [
-       "  PD -> Matching Pennies   : 3 swaps  [R12 -> C23 -> R34]"
+       "  PD -> Matching Pennies   : 5 swaps  [C12 -> C23 -> C12 -> R34 -> R23]"
       ]
      },
      "metadata": {},
@@ -731,7 +731,7 @@
        " Stag Hunt             |     2 | TL, BR\r\n",
        " Battle of Sexes       |     2 | TL, BR\r\n",
        " Chicken               |     2 | TR, BL\r\n",
-       " Matching Pennies      |     1 | TR\r\n"
+       " Matching Pennies      |     0 | (aucun)\r\n"
       ]
      },
      "metadata": {},
@@ -740,7 +740,7 @@
     {
      "data": {
       "text/plain": [
-       "Note : ces 5 jeux classiques ont tous 1 ou 2 Nash purs. Les jeux SANS aucun Nash pur (cycles de best-response) existent mais ne sont pas dans ce catalogue — voir l'histogramme cellule 7 (72/576 = 12,5% des jeux ordinaux ont 0 Nash pur)."
+       "Note : 4 de ces 5 jeux classiques ont 1 ou 2 Nash purs ; Matching Pennies (anti-coordination) est l'exception avec 0 Nash pur, seul tel exemple du catalogue — voir l'histogramme cellule 7 (72/576 = 12,5% des jeux ordinaux ont 0 Nash pur)."
       ]
      },
      "metadata": {},
@@ -777,7 +777,7 @@
     "    sb6.AppendLine($\" {kv.Key,-21} | {eq.Count,5} | {cells}\");\n",
     "}\n",
     "sb6.ToString().Display();\n",
-    "\"Note : ces 5 jeux classiques ont tous 1 ou 2 Nash purs. Les jeux SANS aucun Nash pur (cycles de best-response) existent mais ne sont pas dans ce catalogue — voir l'histogramme cellule 7 (72/576 = 12,5% des jeux ordinaux ont 0 Nash pur).\".Display();\n"
+    "\"Note : 4 de ces 5 jeux classiques ont 1 ou 2 Nash purs ; Matching Pennies (anti-coordination) est l'exception avec 0 Nash pur, seul tel exemple du catalogue — voir l'histogramme cellule 7 (72/576 = 12,5% des jeux ordinaux ont 0 Nash pur).\".Display();\n"
    ]
   },
   {
@@ -1085,11 +1085,11 @@
       "text/plain": [
        "                  Prisoner Stag Hun Battle o  Chicken Matching \r\n",
        "-----------------------------------------------------------\r\n",
-       "Prisoner's Di        0        2        5        2        3 \r\n",
-       "Stag Hunt            2        0        3        4        3 \r\n",
+       "Prisoner's Di        0        2        5        2        5 \r\n",
+       "Stag Hunt            2        0        3        4        5 \r\n",
        "Battle of Sex        5        3        0        7        4 \r\n",
-       "Chicken              2        4        7        0        3 \r\n",
-       "Matching Penn        3        3        4        3        0 \r\n"
+       "Chicken              2        4        7        0        5 \r\n",
+       "Matching Penn        5        5        4        5        0 \r\n"
       ]
      },
      "metadata": {},

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-3-topology2x2.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-3-topology2x2.yaml
@@ -4,10 +4,10 @@
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-31"
+    date: "2026-08-02"
     by: myia-po-2024:CoursIA-2
     python_sha: fb3b73b211652b5f98f80be2fb313371134d366d
-    csharp_sha: 2af24ace90f1827f11fb857c728befa001822d16
+    csharp_sha: b09da0acd68389084b6ff1fac9c565169a85ab06
   known_differences:
     - "Socle pedagogique commun : representation ordinale des jeux 2x2 (4 rangs par joueur), classification topologique des 5 archetypes strategiques (Prisonnier, Stag Hunt, BoS, Poulet, Matching Pennies) sur le carre des preferences ordinales."
     - "Idiomes framework : Python = `numpy` + `matplotlib` + `networkx` + classe `OrdinalGame` from-scratch (dataclass + equals). C# = `System.*` (Collections.Generic, Linq) + classe `OrdinalGame` from-scratch (IEquatable<OrdinalGame>)."


### PR DESCRIPTION
# GT-3-C# — "Matching Pennies" used a wrong ordinal matrix (had a pure Nash)

**lane: po-2024** · See #8052 (semantic-sampling audit, umbrella — not fully resolved)

> ⚠️ **Parallel-delivery note (c.1037-L):** PR #9175 (other agent) edits the
> **Python** twin of GT-3 (cells 40/51, family-classification markdown) and also
> rebaselines `gametheory-3-topology2x2.yaml` (`python_sha`). This PR edits the
> **C#** twin and rebaselines the **same YAML** (`csharp_sha`). Different notebooks,
> different defects, different sha fields — a merge will need both `python_sha`
> (#9175) and `csharp_sha` (this PR) reconciled in the `last_audit` block. Flagging
> factually; not turf-competing (the defects are real and distinct).

## Défaut

`GameTheory-3-Topology2x2-Csharp.ipynb` — the "Matching Pennies" entry used payoff
ranks `(4,2,3,1)/(2,4,1,3)`, which is a **dominant-strategy game** (Row always plays
T, Col always plays R) with a pure Nash at TR. That contradicts:

- **Textbook Matching Pennies** — the canonical anti-coordination game with **no
  pure Nash** (the textbook example of a mixed-only equilibrium).
- **The Python semantic twin**, which correctly uses `(4,1,2,3)/(1,4,3,2)` → 0 pure
  Nash, classified `MIXED_ONLY` (confirmed by PR #9175's firsthand re-execution:
  MIXED_ONLY = 72/576 = 12.5%, the 0-Nash family).

The other 4 classic games (**PD, Stag, BoS, Chicken**) match the Python twin
byte-for-byte, so MP was a **transcription error** when porting Python → C#.

The wrong matrix propagated to several C# outputs:
- **cell13** Nash table: `Matching Pennies | 1 | TR` (false — MP has no pure NE)
- **cell9** PD→MP distance: `3 swaps` (wrong game → wrong BFS distance)
- **cell19** distance matrix: MP column/row off (`PD→MP=3` vs Python's `5`)
- **cell13** note: `"ces 5 jeux classiques ont tous 1 ou 2 Nash purs"` was only true
  *because* MP was mislabeled.

## Fix

Use the canonical MP matrix `(4,1,2,3)/(1,4,3,2)` matching the Python twin. Outputs
regenerated by re-running the exact C# BFS / best-response logic
(instrument-before-assert, C976-L):

- **MP → 0 Nash** (`(aucun)`) ✓
- **PD → MP = 5 swaps** `[C12 -> C23 -> C12 -> R34 -> R23]`
- **Distance matrix now matches the Python twin**: PD→MP=5, Stag→MP=5, BoS→MP=4,
  Chicken→MP=5 (symmetric) ✓
- **Note rewritten**: MP is now correctly the catalog's single 0-Nash example
  (`"4 de ces 5 jeux classiques ont 1 ou 2 Nash purs ; Matching Pennies
  (anti-coordination) est l'exception avec 0 Nash pur, seul tel exemple du catalogue"`).

Rebaselined `csharp_sha` in the twin-parity registry; `check_twin_parity --check`
`[OK]` post-commit. Diff: 10 ins / 10 del, byte-surgical (no metadata/timestamp/
banner churn).

## Diagnostic dérive

**Défaut constaté** : la sortie committée cellule 13 listait "Matching Pennies |
1 | TR" (un équilibre de Nash pur), et la matrice des distances (cellule 19)
donnait PD→MP = 3 swaps. Or Matching Pennies est le jeu anti-coordination
canonique **sans aucun équilibre de Nash pur** (seul équilibre = mixte ½-½).

**Ground truth (computed/canonical)** : (1) la théorie des jeux — MP n'a pas de Nash
pur ; (2) le jumeau Python, qui utilise la matrice canonique `(4,1,2,3)/(1,4,3,2)`
et classifie MP en `MIXED_ONLY` (0 Nash), confirmé par la ré-exécution firsthand de
PR #9175 (MIXED_ONLY = 72/576 = 12.5%). Le jumeau C# déviait des DEUX.

**Cause racine** : erreur de transcription du portage Python → C# — la matrice MP
`(4,2,3,1)/(2,4,1,3)` est un jeu à stratégies dominantes (famille DOMINANT), pas
Matching Pennies. Les 4 autres jeux classiques étaient portés correctement, ce qui
isole MP comme l'unique erreur.

**Fix** : aligner la matrice C# MP sur la canonique `(4,1,2,3)/(1,4,3,2)` ; les
sorties (Nash, distances BFS, note) se régénèrent mécaniquement à partir de la
matrice corrigée.

**Classe de défaut** : value-defect déterministe (STRONGEST per triage c.1062-L) —
non-timing, reproductible exactement. Twin-parity defect (les deux jumeaux
devraient s'accorder sur un jeu canonique nommé).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
