### PR TITLE
fix(ml,#8052): 2.6-Clustering-KMeans-PCA textbook title Éléments -> Elements (corruption)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.6-Clustering-KMeans-PCA.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.6-Clustering-KMeans-PCA.ipynb
@@ -754,7 +754,7 @@
     "\n",
     "Le **supervisé** (notebooks 2.1 à 2.5) dispose d'étiquettes et apprend à **prédire**. Le **non supervisé** (ce notebook) n'a pas d'étiquettes et **trouve** de la structure (clusters) ou **compresse** (PCA). En pratique, ces approches se combinent souvent : on peut appliquer une PCA avant un clustering, ou avant un modèle supervisé pour accélérer l'apprentissage et réduire le surajustement.\n",
     "\n",
-    "> **Référence.** Hastie, T., Tibshirani, R. & Friedman, J. (2009), *The Éléments of Statistical Learning*, Springer (2e éd.), §14.3. — Synthèse du clustering et de la réduction de dimension dans le cadre de l'apprentissage statistique."
+    "> **Référence.** Hastie, T., Tibshirani, R. & Friedman, J. (2009), *The Elements of Statistical Learning*, Springer (2e éd.), §14.3. — Synthèse du clustering et de la réduction de dimension dans le cadre de l'apprentissage statistique."
    ]
   },
   {
@@ -795,7 +795,7 @@
     "1. MacQueen, J. (1967). *Some Methods for Classification and Analysis of Multivariate Observations*. Proceedings of the Fifth Berkeley Symposium on Mathematical Statistics and Probability 1:281-297. — La méthode des k-moyennes, partitionnement par minimisation de l'inertie intra-cluster.\n",
     "2. Pearson, K. (1901). *On Lines and Planes of Closest Fit to Systems of Points in Space*. Philosophical Magazine 2(11):559-572. — Article fondateur de l'Analyse en Composantes Principales (axes de variance maximale).\n",
     "3. Jolliffe, I.T. (2002). *Principal Component Analysis*. Springer (2e éd.). — Référence sur l'ACP : variance expliquée, choix du nombre de composantes.\n",
-    "4. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Éléments of Statistical Learning*. Springer (2e éd.), §14.3. — Clustering et réduction de dimension.\n",
+    "4. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Elements of Statistical Learning*. Springer (2e éd.), §14.3. — Clustering et réduction de dimension.\n",
     "5. Pedregosa, F. et al. (2011). *Scikit-learn: Machine Learning in Python*. Journal of Machine Learning Research 12:2825-2830. — `KMeans`, `PCA`, `load_digits`."
    ]
   }


### PR DESCRIPTION
# 2.6-Clustering-KMeans-PCA — textbook cited as "The Éléments of Statistical Learning" → "Elements" (title corruption)

**lane: po-2024** · See #8052 (semantic-sampling audit, umbrella — not fully resolved)

## Défaut

`2.6-Clustering-KMeans-PCA.ipynb` citait le manuel de ML canonique comme
***The Éléments of Statistical Learning*** en **deux endroits** :

- **Cellule 20** (référence de synthèse, §6) :
  `Hastie, T., Tibshirani, R. & Friedman, J. (2009), *The Éléments of Statistical Learning*, Springer (2e éd.), §14.3.`
- **Cellule 22** (Références, item 4) :
  `Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Éléments of Statistical Learning*. Springer (2e éd.), §14.3.`

Le **vrai titre du livre est en anglais** : *"The **Elements** of Statistical
Learning: Data Mining, Inference, and Prediction"* (Hastie, Tibshirani &
Friedman, Springer 2009, 2ᵉ éd.). Le mot « Éléments » (français pluriel,
capitale accentuée É) **corrompt** le titre anglais « Elements ».

## Vérité terrain (Ground truth) (sources canoniques)

Vérifié auprès de sources faisant autorité :
- **Springer** (éditeur) : « The Elements of Statistical Learning » — [link.springer.com/book/10.1007/978-0-387-84858-7](https://link.springer.com/book/10.1007/978-0-387-84858-7)
- **Google Books** : « The Elements of Statistical Learning: Data Mining, Inference and Prediction », Springer 2009
- **Amazon / VitalSource** : même titre

Le titre est sans ambiguïté « **Elements** » (anglais).

**Preuve d'incohérence** : les 4 AUTRES citations du notebook conservent toutes
leur titre original en anglais (MacQueen « Some Methods for Classification… »,
Pearson « On Lines and Planes of Closest Fit… », Jolliffe « Principal Component
Analysis », Pedregosa « Scikit-learn: Machine Learning in Python »). Seule
celle-ci a été francisée — elle enfreint à la fois la convention de citation
académique (titres dans la langue originale) ET la propre convention du notebook.

## Correction (Fix)

Remplacement de jeton au niveau de l'octet : `Éléments` → `Elements` sur 2 lignes
source en markdown (cellule 20 + cellule 22). Diff : **2 ins / 2 del**, chirurgical
(aucune donnée de calcul touchée — correction de citation markdown uniquement).
Notebook **non-jumeau** (pas dans `scripts/notebook_tools/twin_pairs.d/`) →
pas de rebaseline de sha.

## Diagnostic dérive

**Défaut constaté** : deux citations du livre font apparaître « The Éléments of
Statistical Learning » au lieu de « The Elements of Statistical Learning ».

**Cause racine** : le mot du titre anglais « Elements » a été erronément
francisé en « Éléments » lors de la rédaction de la référence (transcription
dans la langue du notebook au lieu de préserver le titre original).

**Classe de défaut** : corruption de titre de citation (C.1 — exactitude
bibliographique), NON un défaut de valeur. Toutes les valeurs calculées dans
le notebook 2.6 (inertie KMeans 1165256.30 à k=10, variance PCA à 2 composantes
0.285 = 28,5 %) sont des sorties déterministes de sklearn, cohérentes en
interne.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
