### PR TITLE
test(provision-vix,#8052): add --start forwarding + empty-data guard (2 tests, reconciled vs #9280)

### DIFF
--- a/scripts/quantconnect/tests/test_provision_vix_csv.py
+++ b/scripts/quantconnect/tests/test_provision_vix_csv.py
@@ -184,3 +184,45 @@ def test_main_apply_writes_both_csvs(monkeypatch, tmp_path, capsys):
     assert text.startswith("date,close\n")
     assert "2024-01-02,1.0" in text
     assert "Done: 2 CBOE series provisioned" in capsys.readouterr().out
+
+
+
+# ---------------------------------------------------------------------------
+# main() integration: --start forwarding + fetch_series empty-data guard.
+# These two paths are NOT exercised by test_main_dry_run / test_main_apply
+# above (no --start passed; fetch_series mocked out entirely). Added in the
+# #9255 tranche to pin the remaining contracts.
+# ---------------------------------------------------------------------------
+
+def test_main_start_argument_forwarded_to_fetch_series(monkeypatch, tmp_path):
+    """The --start flag is forwarded to fetch_series once per SERIES entry."""
+    stub = _series([18.5], dates=["2024-01-02"])
+    captured = []
+
+    def _capture(ticker, start):
+        captured.append(start)
+        return stub
+
+    monkeypatch.setattr(pvc, "fetch_series", _capture)
+    pvc.main([
+        "--dry-run", "--out-folder", str(tmp_path), "--start", "2015-06-01"])
+    # fetch_series called once per SERIES entry, each forwarded the custom start.
+    assert len(captured) == len(pvc.SERIES)
+    assert all(s == "2015-06-01" for s in captured)
+
+
+def test_fetch_series_raises_on_empty(monkeypatch):
+    """fetch_series raises RuntimeError when yfinance returns empty/None.
+
+    Injects a fake yfinance module (lazy-imported inside fetch_series) so the
+    real import + network are not needed; exercises the empty-data guard at
+    module line 71 (`if df is None or df.empty: raise RuntimeError(...)`).
+    """
+    import sys
+    import types
+
+    fake_yf = types.ModuleType("yfinance")
+    fake_yf.download = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "yfinance", fake_yf)
+    with pytest.raises(RuntimeError, match="no data"):
+        pvc.fetch_series("^VIX", "2010-01-01")


### PR DESCRIPTION
Grain: TEST/coverage -- lane myia-po-2023:CoursIA -- prev: TEST #9253

**Reconciled against #9280 (MERGED)** after rebase exposed an add/add conflict (both branches independently added `test_provision_vix_csv.py`). #9280 shipped 14 hermetic tests for the pure helpers; this PR now adds ONLY the 2 integration paths #9280 left uncovered.

## Reconciliation (honest scope reduction 17 -> 2)

My original 17-test draft overlapped #9280 entirely except 2 genuinely unique tests. The rebased diff vs main is now +2 tests (+42 lines), atomic:

- **test_main_start_argument_forwarded_to_fetch_series** — pins the `--start` -> `fetch_series` forwarding contract. #9280's `main()` tests pass no `--start` and its stub ignores the arg, so this was uncovered.
- **test_fetch_series_raises_on_empty** — exercises the empty-data `RuntimeError` guard (module line 71 `if df is None or df.empty`) via a fake yfinance module. #9280 mocks `fetch_series` out entirely and never reaches it.

Dropped as redundant: `test_main_returns_zero` (#9280's `test_main_dry_run` already asserts `rc == 0`).

## Verification
- `python -m pytest scripts/quantconnect/tests/test_provision_vix_csv.py -q` -> **16 passed** (14 from #9280 + 2 new), 0.5s, offline/hermetic.
- Diff vs main: `1 file changed, 42 insertions(+)` — only the appended test block.
- yfinance stays lazy-imported + mocked; no network in CI.

See #8052. Co-Authored-By: Claude-Code <noreply@anthropic.com>