### PR TITLE
fix(qc,#8052): provision_lean_data scan_zip unpack drift 3->4 tuple (9 broken tests, real runtime bug)

### DIFF
--- a/scripts/quantconnect/provision_lean_data.py
+++ b/scripts/quantconnect/provision_lean_data.py
@@ -105,7 +105,7 @@ def resolve_dest(dest_arg: Optional[Path], workspace_arg: Optional[Path]) -> Pat
 
 def is_fresh(zip_path: Path, min_year: int) -> bool:
     """True iff the zip's last bar year >= min_year (presence != freshness, C942-L)."""
-    _first, last, _count = scan_zip(Path(zip_path))
+    _first, last, _count, _flat_tail = scan_zip(Path(zip_path))
     if last is None:
         return False
     return last.year >= min_year
@@ -132,13 +132,13 @@ def provision_universe(
     for ticker in spec["tickers"]:
         zip_path = dest / f"{ticker.lower()}.zip"
         if zip_path.exists() and not force:
-            _first, last, count = scan_zip(zip_path)
+            _first, last, count, _flat_tail = scan_zip(zip_path)
             if last is not None and last.year >= min_year:
                 print(f"[skip] {ticker}: FRESH (last {last}, {count} bars) -- --force to re-download")
                 results.append((ticker, "skip (fresh)", count, last))
                 continue
         bars = converter(ticker, dest, start, end, dry_run=False)
-        _first, last, _count = scan_zip(zip_path)
+        _first, last, _count, _flat_tail = scan_zip(zip_path)
         print(f"[ok]   {ticker}: provisioned {bars} bars (last {last})")
         results.append((ticker, "provisioned", bars, last))
     return results
@@ -155,7 +155,7 @@ def run_gate(dest: Path, tickers: list[str], min_year: int) -> list[tuple[str, O
     for ticker in tickers:
         zip_path = dest / f"{ticker.lower()}.zip"
         if zip_path.exists():
-            _first, last, count = scan_zip(zip_path)
+            _first, last, count, _flat_tail = scan_zip(zip_path)
             stale = True if last is None else last.year < min_year
         else:
             last, count = None, 0


### PR DESCRIPTION
Grain: FIX/bug -- lane myia-po-2023:CoursIA -- prev: TEST #9255

Fixes a real production bug + 9 broken tests (genre pivot from test-coverage
to fix-bug, R6 variety). Found while writing #9255: a sibling test file
(test_provision_lean_data.py) was failing on clean origin/main, which led to
the root cause below.

## What

`scan_zip` in `scripts/quantconnect/check_data_freshness.py` was extended to a
**4-tuple** `(first, last, count, flat_tail)` (added in #8895, 2026-07-30), but
the four call sites in `scripts/quantconnect/provision_lean_data.py` still
unpacked **3** values, raising `ValueError: too many values to unpack
(expected 3)` at runtime. This broke:

- `is_fresh()` (the freshness predicate),
- `provision_universe()` ×2 (skip-when-fresh branch + post-download log),
- `run_gate()` (the cabled freshness gate),

and 9/16 tests in `test_provision_lean_data.py` (all that exercise the gate).

## Fix

Surgical: all four call sites now unpack the 4th element as `_flat_tail`
(ignored — the callers use only `first`/`last`/`count`; the original year-based
gate behavior is preserved exactly). `+4/-4`, 1 file. No semantic change, no
anti-regression concern (this is API-alignment, not logic removal).

## Why not use flat_tail?

`flat_tail` (detects flat/anomalous trailing bars) could plausibly feed a
future "suspect data" gate verdict, but wiring it into the freshness logic is a
behavioral change (enhancement) — out of scope for this minimal fix. Preserving
the original behavior is the safe choice here.

## Verification (firsthand, origin/main HEAD 4a163295a, fresh worktree)

1. `pytest scripts/quantconnect/tests/test_provision_lean_data.py -q` -> 16
   passed (was 9 failed / 7 passed before the fix).
2. Broader sanity: `pytest scripts/quantconnect/tests/` -> **170 passed, 1
   skipped** (pre-existing skip). 0 regression.
3. Diff is minimal and surgical: `git diff` = +4/-4, only the four unpack
   sites changed.
4. Collision-guard: 0 open PR touches `scan_zip` / `provision_lean_data` /
   `check_data_freshness` (searched by symbol + filename).

## Root-cause note

Cross-module API change (`scan_zip` signature widened) shipped without updating
dependent callers — the kind of breakage that running the dependent test in CI
would have caught immediately. (This is exactly why the test-coverage tranches
this lane shipped — #9251/#9252/#9253/#9255 — matter: they lock real module
behavior so future drift fails loudly instead of silently.)

See #8052.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
