### PR TITLE
fix(ml,#8052): series-wide "The Elements of Statistical Learning" citation-title corruption (Éléments -> Elements), 8 notebooks

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.1-Workflow-ML.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.1-Workflow-ML.ipynb
@@ -423,7 +423,7 @@
     "- L'accuracy de test **plafonne** puis **redescend** : au-delà d'une certaine complexité, le modèle apprend du bruit.\n",
     "- L'**écart de généralisation** (train − test) s'élargit avec la profondeur : c'est la signature visible du surapprentissage.\n",
     "\n",
-    "> **Référence.** Hastie, T., Tibshirani, R. & Friedman, J. (2009), *The Éléments of Statistical Learning*, Springer (2e éd.), sections 2.9 et 7. Le compromis biais-variance et le surapprentissage y sont analysés : la complexité du modèle augmente la variance et réduit la capacité de généralisation."
+    "> **Référence.** Hastie, T., Tibshirani, R. & Friedman, J. (2009), *The Elements of Statistical Learning*, Springer (2e éd.), sections 2.9 et 7. Le compromis biais-variance et le surapprentissage y sont analysés : la complexité du modèle augmente la variance et réduit la capacité de généralisation."
    ]
   },
   {
@@ -592,7 +592,7 @@
     "\n",
     "Plus la MAE est faible, meilleure est la régression (elle s'exprime dans la même unité que la cible).\n",
     "\n",
-    "> **Référence.** La MAE (mean absolute error) est l'un des estimateurs d'erreur les plus robustes pour la régression ; voir Hastie, Tibshirani & Friedman (2009), *The Éléments of Statistical Learning*, Springer (2e éd.), section 11.6 pour la comparaison des critères de perte (L1 vs L2)."
+    "> **Référence.** La MAE (mean absolute error) est l'un des estimateurs d'erreur les plus robustes pour la régression ; voir Hastie, Tibshirani & Friedman (2009), *The Elements of Statistical Learning*, Springer (2e éd.), section 11.6 pour la comparaison des critères de perte (L1 vs L2)."
    ]
   },
   {
@@ -813,7 +813,7 @@
     "1. Mitchell, T. (1997). *Machine Learning*. McGraw-Hill. — Le surapprentissage et la distinction entraînement/généralisation comme concept central de l'apprentissage supervisé.\n",
     "2. Stone, M. (1974). *Cross-Validatory Choice and Assessment of Statistical Predictions*. Journal of the Royal Statistical Society. Series B (Methodological) 36(2):111-147. — Le principe d'évaluation sur des données non vues.\n",
     "3. Breiman, L., Friedman, J., Olshen, R. & Stone, C. (1984). *Classification and Regression Trees*. Wadsworth. — Les arbres CART et la profondeur comme contrôle de complexité.\n",
-    "4. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Éléments of Statistical Learning*. Springer (2e éd.). — Compromis biais-variance, surapprentissage, critères de perte pour la régression.\n",
+    "4. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Elements of Statistical Learning*. Springer (2e éd.). — Compromis biais-variance, surapprentissage, critères de perte pour la régression.\n",
     "5. Pedregosa, F. et al. (2011). *Scikit-learn: Machine Learning in Python*. Journal of Machine Learning Research 12:2825-2830. — La bibliothèque scikit-learn utilisée dans tout ce notebook (`train_test_split`, `DecisionTreeClassifier`, `LinearRegression`, métriques, `Pipeline`)."
    ]
   }

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.2-Descente-de-gradient.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.2-Descente-de-gradient.ipynb
@@ -110,7 +110,7 @@
     "\n",
     "Apprendre le modèle revient donc à **minimiser** la fonction de coût MSE. Pour une régression linéaire, cette fonction est **convexe** (en forme de bol) : elle possède un minimum global unique, que la descente de gradient saura atteindre.\n",
     "\n",
-    "> **Référence.** Gauss (1809), *Theoria Motus Corporum Coelestium* — la méthode des moindres carrés (MCO/MSE) est la fondation historique de la régression linéaire ; voir aussi Hastie, Tibshirani & Friedman (2009), *The Éléments of Statistical Learning*, Springer (2e éd.), section 3.2.\n"
+    "> **Référence.** Gauss (1809), *Theoria Motus Corporum Coelestium* — la méthode des moindres carrés (MCO/MSE) est la fondation historique de la régression linéaire ; voir aussi Hastie, Tibshirani & Friedman (2009), *The Elements of Statistical Learning*, Springer (2e éd.), section 3.2.\n"
    ]
   },
   {
@@ -899,7 +899,7 @@
     "\n",
     "1. Cauchy, A.-L. (1847). *Méthode générale pour la résolution des systèmes d'équations simultanées*. Comptes Rendus de l'Académie des Sciences 25:536-538. — L'ancêtre de la descente de gradient.\n",
     "2. Nocedal, J. & Wright, S.J. (2006). *Numerical Optimization*. Springer (2e éd.). — Convergence, choix du pas (learning rate), analyse des méthodes de descente.\n",
-    "3. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Éléments of Statistical Learning*. Springer (2e éd.), section 3.2. — Régression linéaire par moindres carrés et fonction de coût MSE.\n",
+    "3. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Elements of Statistical Learning*. Springer (2e éd.), section 3.2. — Régression linéaire par moindres carrés et fonction de coût MSE.\n",
     "4. Rumelhart, D.E., Hinton, G.E. & Williams, R.J. (1986). *Learning representations by back-propagating errors*. Nature 323:533-536. — La descente de gradient appliquée aux réseaux de neurones (rétropropagation).\n",
     "5. Pedregosa, F. et al. (2011). *Scikit-learn: Machine Learning in Python*. Journal of Machine Learning Research 12:2825-2830. — `LinearRegression` et `StandardScaler` utilisés pour la validation.\n"
    ]

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.3-Regression-lineaire-logistique.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.3-Regression-lineaire-logistique.ipynb
@@ -565,7 +565,7 @@
     "\n",
     "Les deux modèles partagent le même **cœur linéaire** ($\\mathbf{w} \\cdot \\mathbf{x} + b$), mais le principe d'estimation diffère radicalement. Tous deux sont des cas particuliers de **modèles linéaires généralisés** (GLM).\n",
     "\n",
-    "> **Référence.** Hastie, T., Tibshirani, R. & Friedman, J. (2009), *The Éléments of Statistical Learning*, Springer (2e éd.), sections 4.2-4.4. La distinction entre estimation par moindres carrés (OLS) et par maximum de vraisemblance (MLE) y est posée comme le principe fondateur du choix de modèle."
+    "> **Référence.** Hastie, T., Tibshirani, R. & Friedman, J. (2009), *The Elements of Statistical Learning*, Springer (2e éd.), sections 4.2-4.4. La distinction entre estimation par moindres carrés (OLS) et par maximum de vraisemblance (MLE) y est posée comme le principe fondateur du choix de modèle."
    ]
   },
   {
@@ -875,7 +875,7 @@
     "\n",
     "1. Nelder, J.A. & Wedderburn, R.W.M. (1972). *Generalized Linear Models*. Journal of the Royal Statistical Society. Series A 135(3):370-384. — Le cadre unifiant régression linéaire (gaussienne) et logistique (binomiale).\n",
     "2. Cox, D.R. (1958). *The Regression Analysis of Binary Sequences*. Journal of the Royal Statistical Society. Series B (Methodological) 20(2):215-232. — La régression logistique, estimation par maximum de vraisemblance.\n",
-    "3. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Éléments of Statistical Learning*. Springer (2e éd.), §4.2-4.4. — OLS vs MLE comme principes d'estimation.\n",
+    "3. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Elements of Statistical Learning*. Springer (2e éd.), §4.2-4.4. — OLS vs MLE comme principes d'estimation.\n",
     "4. Hosmer, D.W., Lemeshow, S. & Sturdivant, R.X. (2013). *Applied Logistic Regression*. Wiley (3e éd.). — Interprétation des coefficients et des odds ratios.\n",
     "5. Pedregosa, F. et al. (2011). *Scikit-learn: Machine Learning in Python*. Journal of Machine Learning Research 12:2825-2830. — `LinearRegression`, `LogisticRegression`, métriques."
    ]

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.4-Arbres-Forets-Ensembles.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.4-Arbres-Forets-Ensembles.ipynb
@@ -492,7 +492,7 @@
     "\n",
     "Moyenner de nombreux arbres brisés produit une frontière **plus lisse**. La réduction de variance est **littéralement visible** en comparant côte à côte l'arbre seul et la forêt sur le même plan 2D.\n",
     "\n",
-    "> **Référence.** Hastie, T., Tibshirani, R. & Friedman, J. (2009), *The Éléments of Statistical Learning*, Springer (2e éd.), §15.3. L'analyse théorique montre que la moyenne de $B$ arbres décorrélerés réduit la variance d'un facteur proche de $1/B$ lorsque les arbres sont peu corrélés : c'est le fondement quantitatif de la réduction de variance par *bagging*, que la figure suivante rend visible."
+    "> **Référence.** Hastie, T., Tibshirani, R. & Friedman, J. (2009), *The Elements of Statistical Learning*, Springer (2e éd.), §15.3. L'analyse théorique montre que la moyenne de $B$ arbres décorrélerés réduit la variance d'un facteur proche de $1/B$ lorsque les arbres sont peu corrélés : c'est le fondement quantitatif de la réduction de variance par *bagging*, que la figure suivante rend visible."
    ]
   },
   {
@@ -866,7 +866,7 @@
     "1. Breiman, L., Friedman, J.H., Olshen, R.A. & Stone, C.J. (1984). *Classification and Regression Trees*. Wadsworth. — Méthode CART : arbres de décision par partitionnement récursif *axis-aligned*.\n",
     "2. Breiman, L. (2001). *Random Forests*. Machine Learning 45(1):5-32. — Forêts aléatoires : bagging + sélection aléatoire de variables, réduction de variance.\n",
     "3. Friedman, J.H. (2001). *Greedy Function Approximation: A Gradient Boosting Machine*. Annals of Statistics 29(5):1189-1232. — Gradient boosting : modèle additif séquentiel par descente de gradient.\n",
-    "4. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Éléments of Statistical Learning*. Springer (2e éd.), §§9.2, 10.1, 15.3. — Arbres, forêts, boosting et compromis biais-variance.\n",
+    "4. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Elements of Statistical Learning*. Springer (2e éd.), §§9.2, 10.1, 15.3. — Arbres, forêts, boosting et compromis biais-variance.\n",
     "5. Pedregosa, F. et al. (2011). *Scikit-learn: Machine Learning in Python*. Journal of Machine Learning Research 12:2825-2830. — `DecisionTreeClassifier`, `RandomForestClassifier`, `GradientBoostingClassifier`."
    ]
   }

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
@@ -1049,7 +1049,7 @@
     "1. Geman, S., Bienenstock, É. & Doursat, R. (1992). *Neural Networks and the Bias/Variance Dilemma*. Neural Computation 4(1):1-58. — Décomposition biais-variance, l'arbitrage fondamental.\n",
     "2. Stone, M. (1974). *Cross-Validatory Choice and Assessment of Statistical Predictions*. Journal of the Royal Statistical Society. Series B 36(2):111-147. — La validation croisée comme estimation fiable de l'erreur de généralisation.\n",
     "3. Bradley, A.P. (1997). *The Use of the Area Under the ROC Curve in the Evaluation of Machine Learning Algorithms*. Pattern Recognition 30(6):1145-1159. — L'AUC, métrique seuil-indépendante pour comparer des classifieurs.\n",
-    "4. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Éléments of Statistical Learning*. Springer (2e éd.), §7.10-7.11. — Validation croisée et compromis biais-variance.\n",
+    "4. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Elements of Statistical Learning*. Springer (2e éd.), §7.10-7.11. — Validation croisée et compromis biais-variance.\n",
     "5. Pedregosa, F. et al. (2011). *Scikit-learn: Machine Learning in Python*. Journal of Machine Learning Research 12:2825-2830. — `cross_val_score`, `roc_curve`, `roc_auc_score`, `confusion_matrix`."
    ]
   }

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.7-Modeles-Non-Parametriques.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.7-Modeles-Non-Parametriques.ipynb
@@ -966,7 +966,7 @@
     "2. Vapnik, V. (1998). *Statistical Learning Theory*. Wiley. — Cadre théorique des SVM : minimisation structurelle du risque, bornes de généralisation fondées sur la marge.\n",
     "3. Cristianini, N. & Shawe-Taylor, J. (2000). *An Introduction to Support Vector Machines and Other Kernel-based Learning Methods*. Cambridge University Press. — Présentation pédagogique du kernel trick et des noyaux (linéaire, polynomial, RBF).\n",
     "4. Cover, T. & Hart, P. (1967). *Nearest Neighbor Pattern Classification*. IEEE Transactions on Information Theory 13(1):21-27. — La règle du 1-plus-proche-voisin et sa borne d'erreur asymptotique (≤ 2× l'erreur de Bayes).\n",
-    "5. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Éléments of Statistical Learning*. Springer (2e éd.), §§12.2-12.3. — SVM, noyaux et méthodes basées sur les voisins (k-NN).\n",
+    "5. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Elements of Statistical Learning*. Springer (2e éd.), §§12.2-12.3. — SVM, noyaux et méthodes basées sur les voisins (k-NN).\n",
     "6. Pedregosa, F. et al. (2011). *Scikit-learn: Machine Learning in Python*. Journal of Machine Learning Research 12:2825-2830. — `SVC`, `KNeighborsClassifier`, `StandardScaler`, `make_moons`, `make_circles`, `load_breast_cancer`."
    ]
   }

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
@@ -1200,7 +1200,7 @@
     "## Références\n",
     "\n",
     "**Transformations de features**\n",
-    "- Hastie, T., Tibshirani, R., & Friedman, J. (2009). *The Éléments of Statistical Learning: Data Mining, Inference, and Prediction* (2nd ed.). Springer. — variables catégorielles et encodage one-hot (section 3.6), termes d'interaction (feature cross).\n",
+    "- Hastie, T., Tibshirani, R., & Friedman, J. (2009). *The Elements of Statistical Learning: Data Mining, Inference, and Prediction* (2nd ed.). Springer. — variables catégorielles et encodage one-hot (section 3.6), termes d'interaction (feature cross).\n",
     "- Manning, C. D., Raghavan, P., & Schütze, H. (2008). *Introduction to Information Retrieval*. Cambridge University Press. — modélisation par n-grams de mots et de caractères (featurisation de texte).\n",
     "- Weinberger, K., Dasgupta, A., Langford, J., Smola, A., & Attenberg, J. (2009). *Feature Hashing for Large Scale Multitask Learning*. ICML. — « hashing trick », sous-jacent à la vectorisation `FeaturizeText` de ML.NET.\n",
     "\n",

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
@@ -2333,7 +2333,7 @@
     "1. L. Breiman, *Random Forests*, Machine Learning, 45(1):5-32, 2001. Origine de l'importance des caractéristiques par permutation (PFI).\n",
     "2. M. Stone, *Cross-Validatory Choice and Assessment of Statistical Predictions*, Journal of the Royal Statistical Society. Series B (Methodological), 36(2):111-147, 1974. Formalisation de la validation croisée (K-fold).\n",
     "3. T. Fawcett, *An Introduction to ROC Analysis*, Pattern Recognition Letters, 27(8):861-874, 2006. Courbe ROC et aire sous la courbe (AUC).\n",
-    "4. T. Hastie, R. Tibshirani, J. Friedman, *The Éléments of Statistical Learning*, Springer, 2009. Métriques d'évaluation et théorie de l'apprentissage statistique.\n",
+    "4. T. Hastie, R. Tibshirani, J. Friedman, *The Elements of Statistical Learning*, Springer, 2009. Métriques d'évaluation et théorie de l'apprentissage statistique.\n",
     "5. A. R. Ahmed et al., *Hands-On Machine Learning with ML.NET*, Packt, 2019. Référence appliquée pour l'écosystème ML.NET (API `Evaluate`, `PermutationFeatureImportance`, `CrossValidate`)."
    ],
    "id": "cell-b14f7bd2"

--- a/scripts/notebook_tools/twin_pairs.d/ml-2-data-features.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-2-data-features.yaml
@@ -4,11 +4,11 @@
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-31"
+    date: "2026-08-02"
     by: myia-po-2024:CoursIA-2
     python_sha: 101ab5a0f5a70557bcddc84c4ebfebadbb8ecc64
-    csharp_sha: f08215df5b5be9b9a64577a165a13fc386719c70
-    reason: "rebaseline python apres 2 fixes (#8052) : (1) table parite cellule 0 disait ColumnTransformer remainder='passthrough' mais code cellule 7 = remainder='drop' (passthrough ferait fuiter fare_amount le label dans les features) ; (2) cellules 4 et 18 citaient df.info() mais le code cellule 5 utilise df.dtypes (output=Series dtypes, pas rendering info()) -- df.describe()/isna() etait reels, seul df.info() fantome. Fix API-config identity. Python-only, csharp_sha unchanged, parite semantique preservee."
+    csharp_sha: 843d8d2493cb938e8c381706369a380ac24d6cfa
+    reason: "rebaseline csharp apres fix citation-title (#8052) : reference Hastie/Tibshirani/Friedman (2009) -- le titre anglais The Elements of Statistical Learning etait corrupt par francisation (le mot Elements remplace par le mot francais equivalent a capitale accentuee) -> restore titre canonique EN. Springer 2009 2e ed. Python twin unchanged, python_sha preserve. Parite semantique preservee (citation bibliographique, pas de valeur calculee)."
   known_differences:
     - "Socle pedagogique commun : featurization (encodage categoriel one-hot, normalisation, imputation) sur donnees tabulaires."
     - "Idiomes framework : C# = `mlContext.Transforms.Categorical.OneHotEncoding` (OutputKind.Binary) sur IDataView (LoadFromEnumerable). Python = `sklearn.preprocessing` (OneHotEncoder, StandardScaler, SimpleImputer) composes via `ColumnTransformer` + `Pipeline`."

--- a/scripts/notebook_tools/twin_pairs.d/ml-4-evaluation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-4-evaluation.yaml
@@ -4,10 +4,11 @@
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
   parity_level: surface
   last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
+    date: "2026-08-02"
+    by: myia-po-2024:CoursIA-2
     python_sha: 2d84290fefedd8f816a737a8de1f270c2a4a328b
-    csharp_sha: 583ce5c7234878fc5ec2b668289b131b640ef1ac
+    csharp_sha: 3702afa3bac062ae4d142e0debd3ffce521940ab
+    reason: "rebaseline csharp apres fix citation-title (#8052) : reference Hastie/Tibshirani/Friedman (2009) -- le titre anglais The Elements of Statistical Learning etait corrupt par francisation (le mot Elements remplace par le mot francais equivalent a capitale accentuee) -> restore titre canonique EN. Springer 2009 2e ed. Python twin unchanged, python_sha preserve. Parite surface preservee (citation bibliographique, pas de valeur calculee)."
   known_differences:
     - "ASYSMETRIE MAJEURE DE PROFONDEUR : C# = 40 cellules de code (tour exhaustif d'evaluation : FastTree, OneHotEncoding, ReplaceMissingValues, Concatenate Features + `mlContext.Auto().Regression` AutoML complet) ; Python = 10 cellules (pendant tronque : LinearRegression + RandomForestRegressor + cross_validate/GridSearchCV)."
     - "Le pendant Python couvre le CONCEPT (evaluer + GridSearchCV + metrics r2/MAE/MSE) mais n'egale pas l'exhaustivite du C# (AutoML ML.NET absent cote Python, feature engineering detaille reduit)."


### PR DESCRIPTION
# Series-wide ESL citation-title corruption — "Éléments" → "Elements" (8 notebooks)

**lane: po-2024** · See #8052 (semantic-sampling audit, umbrella) · Sibling of #9254 (2.6, already fixed)

## Défaut

Le manuel de ML canonique ***The Elements of Statistical Learning: Data Mining, Inference, and Prediction*** (Hastie, Tibshirani & Friedman, Springer 2009, 2ᵉ éd.) était cité avec son mot-titre anglais **« Elements »** corrompu en **« Éléments »** (français pluriel, capitale accentuée É) à travers tout le catalogue de cours ML :

| Notebook | Occurrences |
|----------|-------------|
| 02-ML-Cours/2.1-Workflow-ML.ipynb | 3 |
| 02-ML-Cours/2.2-Descente-de-gradient.ipynb | 2 |
| 02-ML-Cours/2.3-Regression-lineaire-logistique.ipynb | 2 |
| 02-ML-Cours/2.4-Arbres-Forets-Ensembles.ipynb | 2 |
| 02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb | 1 |
| 02-ML-Cours/2.7-Modeles-Non-Parametriques.ipynb | 1 |
| ML.Net/ML-2-Data&Features.ipynb (C# twin) | 1 |
| ML.Net/ML-4-Evaluation.ipynb (C# twin) | 1 |
| **Total** | **13 sur 8 notebooks** |

C'est le **même défaut récurrent** déjà corrigé pour `2.6-Clustering-KMeans-PCA.ipynb` dans PR #9254 (jumeau). Découvert lors d'un audit #8052 ciblant 2.5 → un `git grep` révèle l'ampleur systémique série-entière.

## Vérité terrain (sources canoniques)

Vérifié auprès de sources faisant autorité :
- **Springer** (éditeur) : « The Elements of Statistical Learning » — [link.springer.com/book/10.1007/978-0-387-84858-7](https://link.springer.com/book/10.1007/978-0-387-84858-7)
- **Google Books** : « The Elements of Statistical Learning: Data Mining, Inference and Prediction », Springer 2009
- **Amazon / VitalSource** : même titre

Le titre est sans ambiguïté « **Elements** » (anglais). Le mot « Éléments » **corrompt** le titre anglais.

**Preuve d'incohérence** : dans CHAQUE notebook affecté, les AUTRES citations conservent toutes leur titre original en langue originale (Geman « Neural Networks… », Stone « Cross-Validatory… », Bradley « The Use of the Area… », Pearson « On Lines and Planes… », MacQueen « Some Methods… », Jolliffe « Principal Component Analysis », Pedregosa « Scikit-learn… », Gauss « Theoria Motus… »). **Seul** le titre ESL a été francisé. Cela enfreint à la fois la convention de citation académique (titres dans la langue originale) ET la propre convention de chaque notebook. La corruption échappait aux correcteurs orthographiques naïfs car « Éléments » est un mot français valide.

## Correction (Fix)

Remplacement de jeton au niveau de l'octet : `Éléments` → `Elements` sur 13 lignes source en markdown, via substitution brute d'octets (`b"Éléments"` → `b"Elements"`). **Aucune re-sérialisation JSON** → aucun drift de fin de ligne ni structurel. Diff : **13 ins / 13 del**, chirurgical (aucune donnée de calcul touchée — correction de citation markdown uniquement).

## Jumeaux (twin rebaseline)

`ML-2-Data&Features` et `ML-4-Evaluation` sont des **jumeaux C#** (paires C#/Python). **Seul le côté C#** portait la corruption :
- Les jumeaux Python (`ML-2-Data&Features-Python.ipynb`, `ML-4-Evaluation-Python.ipynb`) ont été vérifiés **propres** (`git grep "Éléments"` → 0 correspondance) → `python_sha` **inchangé**.
- `csharp_sha` **rebaseliné** dans `ml-2-data-features.yaml` (`f08215df` → `843d8d24`) et `ml-4-evaluation.yaml` (`583ce5c7` → `3702afa3`) avec raison documentée.
- `check_twin_parity.py` : **[OK]** pour les deux paires post-commit (le DRIFT pré-commit attendu c.1162-L — yaml enregistre le nouveau sha vs blob HEAD encore ancien — se résout au commit).

Les six notebooks `02-ML-Cours` (2.1–2.7 sauf 2.6) sont **non-jumeaux** (pas dans `scripts/notebook_tools/twin_pairs.d/`) → pas de rebaseline de sha.

## Diagnostic dérive

**Défaut constaté** : 13 citations du livre ESL font apparaître « The Éléments of Statistical Learning » au lieu de « The Elements of Statistical Learning », réparties sur 8 notebooks du catalogue ML.

**Cause racine** : le mot du titre anglais « Elements » a été systématiquement francisé en « Éléments » lors de la rédaction des références (transcription dans la langue du notebook au lieu de préserver le titre original). Le caractère systématique (présent dans 8 notebooks indépendants, toujours sur le même titre) indique un motif de rédaction récurrent plutôt que des coquilles isolées.

**Classe de défaut** : corruption de titre de citation (C.1 — exactitude bibliographique), NON un défaut de valeur. Toutes les valeurs calculées dans ces notebooks (métriques KMeans/PCA, scores CV, AUC, pertes de descente de gradient, coefficients de régression, précisions arbres/forêts, pipelines de featurization, métriques d'évaluation ML.NET) sont des sorties déterministes de sklearn/numpy/ML.NET, intactes et cohérentes en interne.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
