### PR TITLE
cost(genai-audio,#8056): metadata.cost on Audio/03-Orchestration trio (real API+GPU)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb
@@ -2187,6 +2187,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": "<0.50",
+   "api_provider": "openai",
+   "cpu_min": 5,
+   "gpu_min": 15,
+   "gpu_required": true,
+   "vram_gb": 12,
+   "vram_tier": "HIGH",
+   "network": true,
+   "external_account": "openai-key",
+   "free_alternative": "faster-whisper (local STT) + Kokoro/Chatterbox (local TTS) : GPU-only, 0 API",
+   "reduced_pedagogical": null,
+   "reproducibility": "MEDIUM",
+   "metadata_written": "2026-08-03T00:00Z",
+   "validator": "manual",
+   "notes": "Comparaison multi-modeles audio (module 03-Audio-Orchestration). Hybride : OpenAI Whisper API + OpenAI TTS (payant, cles .env) ET modeles locaux Chatterbox/Kokoro (~12 Go VRAM, GPU CUDA). CPU reduit (5 min) ; GPU requis pour la branche locale. API non deterministe (MEDIUM) ; la branche locale est deterministe. Couts API faibles mais variables selon le nombre de modeles compares."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb
@@ -2433,6 +2433,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": "<0.30",
+   "api_provider": "openai",
+   "cpu_min": 5,
+   "gpu_min": 20,
+   "gpu_required": true,
+   "vram_gb": 14,
+   "vram_tier": "HIGH",
+   "network": true,
+   "external_account": "openai-key",
+   "free_alternative": "pipeline 100% local : faster-whisper + LLM local + Kokoro (GPU-only)",
+   "reduced_pedagogical": null,
+   "reproducibility": "MEDIUM",
+   "metadata_written": "2026-08-03T00:00Z",
+   "validator": "manual",
+   "notes": "Pipeline STT->LLM->TTS orchestre (module 03-Audio-Orchestration). faster-whisper local (STT) + OpenAI GPT (LLM, payant) + Kokoro/Chatterbox locaux (TTS). ~14 Go VRAM (STT + TTS locaux simultanes). GPU requis pour STT/TTS locaux. API GPT non deterministe (MEDIUM). Notebook volumineux (outputs audio base64)."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-3-Realtime-Voice-API.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-3-Realtime-Voice-API.ipynb
@@ -2089,6 +2089,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": "<0.20",
+   "api_provider": "openai",
+   "cpu_min": 3,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "openai-key",
+   "free_alternative": null,
+   "reduced_pedagogical": "pipeline local 03-2 (faster-whisper + LLM local + Kokoro) approxime le cycle voix hors temps-reel",
+   "reproducibility": "LOW",
+   "metadata_written": "2026-08-03T00:00Z",
+   "validator": "manual",
+   "notes": "OpenAI Realtime Voice API (gpt-4o-realtime-preview) via WebSocket (module 03-Audio-Orchestration). 100% API cloud, AUCUN GPU local (VRAM NONE). Cout facture a la minute de session temps-reel. Reproductibilite LOW : streaming audio bidirectionnel non deterministe. Aucune alternative gratuite temps-reel equivalente (pipeline local 03-2 hors-ligne comme approximation pedagogique)."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
Grain: COST/metadata -- lane myia-po-2023:CoursIA -- prev: TEST #9262

Cost/metadata tranche, HIGH-VALUE family (GenAI Audio with real paid API + GPU).
R6 genre pivot after 4 consecutive test-coverage cycles (c.1133-1136) — cost is a
fresh genre this run, 1 item (R6 à-côté cap 1/lane/jour respected, first cost item
2026-08-03).

## What

Adds `metadata.cost` to 3 GenAI Audio orchestration notebooks (module
03-Audio-Orchestration, was uncosted). These are exactly the HIGH-VALUE cost
targets #8056 prioritizes — real paid OpenAI API + local GPU VRAM:

- **03-1-Multi-Model-Audio-Comparison** — OpenAI Whisper API + OpenAI TTS (paid)
  AND local Chatterbox/Kokoro (~12 GB VRAM). `api_usd_est <0.50`, `vram_tier HIGH`,
  `gpu_required`. `free_alternative`: faster-whisper + Kokoro local (GPU-only, 0 API).
- **03-2-Audio-Pipeline-Orchestration** — STT→LLM→TTS pipeline: faster-whisper local
  + OpenAI GPT (paid) + Kokoro/Chatterbox local (~14 GB VRAM). `api_usd_est <0.30`,
  `HIGH`. `free_alternative`: 100% local pipeline.
- **03-3-Realtime-Voice-API** — OpenAI Realtime API (gpt-4o-realtime-preview,
  WebSocket). 100% cloud, **NO local GPU** (`vram_tier NONE`). `api_usd_est <0.20`,
  `reproducibility LOW` (bidirectional streaming, non-deterministic).
  `reduced_pedagogical`: local pipeline 03-2 approximates offline.

Resource data taken from the notebooks' own intro cells (which state the VRAM) +
code inspection (OpenAI client calls, PyTorch/CUDA, Whisper/TTS model loads).

## Surgery

Byte-stable metadata insertion: cost added as the **first key** of the `metadata`
block. **0 source/output cell churn** (+17 lines each = the cost dict only).
Trailing-newline EOF convention preserved (verified:
`json.dumps(nb, indent=1, ensure_ascii=False) + "\n" == original` baseline for all 3).

## Verification (firsthand, origin/main HEAD 4a163295a, fresh worktree)

1. `check_cost_metadata.py --all` → **0 findings** against the 3 notebooks (no
   `api_used_but_cost_zero`, no `gpu_used_but_not_declared` — API + GPU accurately
   declared). Pre-existing findings on other families (Planners/SW/SC/SL) are
   out-of-scope, separate grains.
2. Byte-stable: `(json round-trip + "\n") == original` for all 3 before surgery;
   diff is cost-block-only (+51/-0 across 3 files, 0 cell churn).
3. Collision-guard: the 3 notebooks are NOT in any of my ~49 open PRs (excluded via
   PR file-union scan); clean targets.
4. Catalogue byte-identical (metadata-only change, no notebook added/removed).

GenAI/Audio cost coverage: the 03-Orchestration module (3/3) now documented.

See #8056 (cost/resource matrix).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
