### PR TITLE
fix(genai-video,#8056): honest cost redeclaration — DALL-E primary path was hidden (CRITICAL api_used_but_cost_zero)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-2-Video-Workflow-Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-2-Video-Workflow-Orchestration.ipynb
@@ -4603,21 +4603,21 @@
    }
   },
   "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
+   "api_usd_est": "<0.50",
+   "api_provider": "openai",
    "cpu_min": 4,
    "gpu_min": 1,
    "gpu_required": true,
    "vram_gb": 18,
    "vram_tier": "GPU_HIGH",
    "network": true,
-   "external_account": "huggingface",
-   "free_alternative": "self",
+   "external_account": "openai-key,huggingface",
+   "free_alternative": "self - bascule automatique vers SDXL locale si OPENAI_API_KEY absente (cell[5] : image_model 'gpt-image-1' -> 'sdxl')",
    "reduced_pedagogical": "self",
    "reproducibility": "LOW",
-   "metadata_written": "2026-07-24T02:30Z",
-   "validator": "papermill",
-   "notes": "Orchestration de pipelines video composites :\ntext->image (DALL-E/SDXL) -> video (SVD) -> upscale -> interpolation.\nChargement sequentiel des modeles (VRAM limitee 24 GB consumer).\nComparaison qualite/cout vs modeles monolithiques (HunyuanVideo/Wan)."
+   "metadata_written": "2026-08-03T00:00Z",
+   "validator": "papermill+manual",
+   "notes": "Orchestration de pipelines video composites :\ntext->image (DALL-E/SDXL) -> video (SVD) -> upscale -> interpolation.\nChargement sequentiel des modeles (VRAM limitee 24 GB consumer).\nComparaison qualite/cout vs modeles monolithiques (HunyuanVideo/Wan).\nCHEMIN PRIMAIRE par defaut : DALL-E 3 (gpt-image-1, API OpenAI payante, ~0.19 USD/image haute qualite) pour l'etape text->image. Fallback gratuit : SDXL locale (diffusers) active automatiquement si OPENAI_API_KEY absente. La declaration precedente (api_usd_est:0.0, api_provider:none) ne decrivait que le chemin de fallback degrade -> corrigee pour declarer le chemin primaire payant (validateur check_cost_metadata CRITICAL api_used_but_cost_zero)."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: FIX/cost-correctness -- lane myia-po-2023:CoursIA -- prev: COST #9263

FIX genre (cost-declaration correctness), distinct from #9263 (cost-add on
absent metadata). R6 genre rotation COST->FIX. Clears a CRITICAL validator
finding (`api_used_but_cost_zero`) via honest redeclaration, not suppression.

## What

`GenAI/Video/03-2-Video-Workflow-Orchestration.ipynb` declared
`api_usd_est:0.0 / api_provider:none / external_account:huggingface`, but its
**DEFAULT** path uses **DALL-E 3 (gpt-image-1, OpenAI paid API)** for text->image.
The declaration described only the degraded key-less fallback (SDXL local, free),
hiding the primary paid path — misleading per #8056.

## Audit-reassessment — CONFIRMED (not a scanner FP)

Verified firsthand against executable code (comments stripped):
- **cell[1]**: `image_model = "gpt-image-1"` (DALL-E) is the **DEFAULT**
- **cell[5]**: falls back to `"sdxl"` ONLY if `OPENAI_API_KEY` absent
- **cell[8]**: `client.images.generate(model="gpt-image-1", ...)` — real paid call

So DALL-E is the intended primary path; SDXL is graceful degradation. The
`check_cost_metadata.py` CRITICAL `api_used_but_cost_zero` is **legitimate**.

## Fix (metadata-only, 7 values, 0 cell churn)

| key | before | after |
|-----|--------|-------|
| `api_usd_est` | 0.0 | "<0.50" (gpt-image-1 ~0.19 USD/image HQ, batch) |
| `api_provider` | none | "openai" |
| `external_account` | huggingface | "openai-key,huggingface" (both required) |
| `free_alternative` | "self" | documents the SDXL auto-fallback |
| `notes` | (pipeline desc) | + DALL-E-primary / SDXL-fallback distinction |
| `metadata_written` / `validator` | — | stamped (papermill+manual review) |

Unchanged (accurate): cpu_min, gpu_min, gpu_required, vram_gb/tier, network,
reproducibility.

## Verification (firsthand, origin/main HEAD 4a163295a, fresh worktree)

1. `check_cost_metadata.py` on the notebook: **CRITICAL cleared** (`findings:`
   empty for the cost check; only an unrelated MINOR `gpu_no_visual_validator`
   #5780 remains, out of scope).
2. Byte-stable metadata surgery: 0 cell source/output churn (+7/-7 = cost-dict
   values only), trailing-nl EOF preserved
   (`json.dumps(indent=1)+\n == original` baseline).
3. Collision-guard: 0 PR (open or closed) touches this notebook.
4. Catalogue byte-identical (metadata-only, no notebook added/removed).

See #8056 (cost/resource matrix correctness).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
