### PR TITLE
cost(qc,#8056): metadata.cost on QC-Py ML-training tranche (5 local NBs)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23b-PatchTST-iTransformer.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23b-PatchTST-iTransformer.ipynb
@@ -1129,6 +1129,20 @@
    "parameters": {},
    "start_time": "2026-05-04T23:31:22.779575",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 10,
+   "gpu_required": false,
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "papermill",
+   "notes": "Comparaison PatchTST (d_model=128, n_heads=8, n_layers=3) vs iTransformer sur series synthetiques. Modeles petits, entraînement CPU pur (aucun device/cuda). ~10 min CPU."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-24-Autoencoders-Anomaly.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-24-Autoencoders-Anomaly.ipynb
@@ -3134,7 +3134,24 @@
    "start_time": "2026-05-04T23:48:52.408546",
    "version": "2.6.0"
   },
-  "qc_reference": true
+  "qc_reference": true,
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 5,
+   "gpu_min": 3,
+   "gpu_required": true,
+   "vram_gb": 2,
+   "vram_tier": "LOW",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "manual",
+   "notes": "Autoencoder LSTM anomaly-detection (hidden_size=32, latent_dim=8). Modele tiny, torch GPU mais VRAM modeste. ~5 min GPU."
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
@@ -2707,6 +2707,23 @@
    "parameters": {},
    "start_time": "2026-04-28T18:47:08.983287+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 4,
+   "gpu_min": 5,
+   "gpu_required": true,
+   "vram_gb": 2,
+   "vram_tier": "LOW",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "manual",
+   "notes": "LSTM training (HIDDEN_DIM=128, NUM_LAYERS=3, EPOCHS=30, BATCH=32). torch.cuda avec degrade CPU (warning). Hyperparams reduits thermal-safe laptop GPU. ~15-20 min GPU."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-31-Transformer-Training.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-31-Transformer-Training.ipynb
@@ -3309,6 +3309,23 @@
    "parameters": {},
    "start_time": "2026-04-29T15:28:23.459865+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 4,
+   "gpu_min": 5,
+   "gpu_required": true,
+   "vram_gb": 4,
+   "vram_tier": "LOW",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "manual",
+   "notes": "Transformer encoder training (SEQ_LEN=60, BATCH=32, EPOCHS=25). torch.cuda thermal-safe laptop GPU. ~15 min GPU."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
@@ -2116,6 +2116,23 @@
    "parameters": {},
    "start_time": "2026-04-30T14:00:59.807623",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 4,
+   "gpu_min": 3,
+   "gpu_required": true,
+   "vram_gb": 2,
+   "vram_tier": "LOW",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "papermill",
+   "notes": "RL DQN trading (QNetwork hidden_dim=256, replay buffer 100k, batch=128). torch.cuda DEVICE fallback CPU. Petit modele RL. ~10 min GPU."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Populate `metadata.cost` for the **QC-Py ML-training sub-cluster** (5 notebooks, all LOCAL torch ML — no QuantBook, no external API, small laptop-GPU thermal-safe models). Epic **#8056** QC cost burn-down.

Grain: `COST/qc-py-ml-training` — lane `myia-po-2023:CoursIA` — prev: `TEST/qc-cost-populate-logic` #9270. **R6 GENRE PIVOT** TEST→COST (TEST×6 consecutive c.1139-1145 = monotone register; this cycle pivots to COST, a distinct operation).

## Profiles (established by FIRSTHAND cell inspection — G.1)

All 5 verified firsthand: NO QuantBook, NO external API, local torch ML-training.
- **QC-Py-23b** (PatchTST/iTransformer comparison): **CPU-only** (0 device/cuda lines), small models (d_model=128, n_heads=8, n_layers=3). `validator=papermill` (0 null cells).
- **QC-Py-24** (Autoencoders Anomaly): GPU, tiny LSTM autoencoder (hidden=32, latent=8).
- **QC-Py-30** (LSTM Training): GPU, HIDDEN_DIM=128/3 layers/30 epochs, thermal-safe.
- **QC-Py-31** (Transformer Training): GPU, SEQ_LEN=60/25 epochs, thermal-safe.
- **QC-Py-32** (RL DQN Trading): GPU, QNetwork hidden=256, small DQN. `validator=papermill` (0 null cells).

## Honesty fix

QC-Py-24/30/31 use `validator="manual"` (3 unexecuted code cells each — claiming `papermill` would be a false execution claim, flagged by the validator). QC-Py-23b/32 keep `"papermill"` (0 null cells, honestly executed). Matches existing convention (13 QC-Py NBs already use `manual`).

## Verification

- `check_cost_metadata` validator **EXIT 0** on all 5
- The residual `gpu_no_visual_validator` MINOR advisory is non-blocking and carried by ALL existing costed GPU QC-Py NBs (QC-Py-22/23/24/25) — accepted convention, not a blocker
- Byte-stable metadata surgery: **+83/-1 across 5 files, 0 cell churn** (the -1 is a benign comma on QC-Py-24 `qc_reference`; content preserved — verified `qc_reference=True` intact, cells-sha identical)
- Collision-guard: all 5 notebooks verified absent from open PRs (82 uncosted QC NBs collision-free; this coherent ML-training sub-cluster selected)

## Scope

5 notebooks, 1 subject (cost-population of one coherent ML-training sub-cluster), 0 cell churn. `See #8056`.

Co-Authored-By: Claude-Code <noreply@anthropic.com>