### PR TITLE
fix(rl,#8052): rl_3 c20 replay-buffer reload clobbers c10 buffer (AVANT/APRÈS 0 -> APRÈS=5000)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb
@@ -1111,16 +1111,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Taille de la replay buffer APRÈS rechargement : 0\n"
+      "Taille de la replay buffer APRÈS rechargement : 5000\n"
      ]
     }
    ],
    "source": [
-    "# 1) Sauvegarde\n",
-    "model_sac.save(\"her_sac_parking\")  # ne sauvegarde pas la replay buffer\n",
-    "model_sac.save_replay_buffer(\"her_sac_parking_replay_buffer\")\n",
+    "# Rechargement du modele + de sa replay buffer (sauvegardee a l'entrainement)\n",
     "\n",
-    "# 2) Rechargement du modèle + de la buffer\n",
     "model_sac_2 = SAC.load(\"her_sac_parking\", env=env)\n",
     "print(\"Taille de la replay buffer AVANT rechargement :\", model_sac_2.replay_buffer.size())\n",
     "\n",


### PR DESCRIPTION
**lane: po-2024** · See #8052 (semantic-sampling audit) · Single-notebook code/output fix

# rl_3 — replay-buffer reload demonstration silently fails (AVANT=0, APRÈS=0)

## Défaut

La cellule c20 du notebook `rl_3_experience_replay_dqn.ipynb` (« Sauvegarde et Chargement de la Replay Buffer ») produit en sortie **commitée** :

```
Taille de la replay buffer AVANT rechargement : 0
Taille de la replay buffer APRÈS rechargement : 0
```

Cela **contredit** la prose de la cellule markdown c19 qui l'introduit :

> « on peut la sauvegarder à part avec `model.save_replay_buffer(path)`, puis la recharger avec `model.load_replay_buffer(path)`. Cela permet de **reprendre un entraînement** où on l'avait laissé, **en conservant tout l'historique** d'expériences collectées. »

Aucune cellule d'interprétation n'explique le `0/0` : il est présenté comme une démonstration réussie, alors qu'il montre que **rien n'est rechargé**. L'étudiant·e en conclut (à tort) que `load_replay_buffer` ne fait rien.

## Cause racine (vérifiée par re-exécution firsthand)

Le flux d'objets `model_sac` garantit le `0/0` de manière **déterministe** (sémantique SB3 documentée : `SAC.load()` ne restaure **pas** la replay buffer) :

1. **c10** : `model_sac.learn(total_timesteps=5000)` peuple le buffer (~5000 transitions), puis `model_sac.save_replay_buffer("her_sac_parking_replay_buffer")` sauvegarde le **bon** buffer, puis `del model_sac`.
2. **c13** : `model_sac = SAC.load("her_sac_parking", env=env)` — le modèle rechargé a un buffer **vide (0)**.
3. **c20 (buggée)** : `model_sac.save_replay_buffer("her_sac_parking_replay_buffer")` **écrase** le bon buffer de c10 par le buffer vide de c13 (0 entrées). Puis `model_sac_2.load_replay_buffer(...)` recharge ce buffer **vide** → `AVANT=0, APRÈS=0`.

La ligne `model_sac.save("her_sac_parking")` + `model_sac.save_replay_buffer(...)` en tête de c20 est à la fois **redondante** (c10 a déjà sauvegardé les deux) et **destructrice** (elle écrase le buffer valide par un buffer vide).

## Correction (Fix)

Suppression du bloc de sauvegarde redondant en tête de c20 (les 3 lignes `# 1) Sauvegarde` + `model_sac.save(...)` + `model_sac.save_replay_buffer(...)`). c20 devient une démonstration pure du **rechargement** : `model_sac_2 = SAC.load(...)` → `AVANT=0`, puis `load_replay_buffer(...)` → **`APRÈS=5000`** (le buffer de c10 est correctement récupéré).

Diff chirurgical : **2 insertions / 5 suppressions**, aucun autre fichier touché.

## Vérification firsthand (C976-L — instrumenter avant d'asserter)

Re-exécuté avec `stable-baselines3==2.9.0` + `highway-env==1.12.0` (env réparé, règle F) :

- **Code buggé (tel que commité)** : re-exéc → `AVANT=0, APRÈS=0` — **reproduit EXACT** le défaut.
- **Code corrigé** : re-exéc → `AVANT=0, APRÈS=5000` — le buffer de c10 (5000 transitions) est bien récupéré, démontrant la persistance comme l'annonce c19.

Sortie c20 commitée après fix :
```
Wrapping the env with a `Monitor` wrapper
Wrapping the env in a DummyVecEnv.
Taille de la replay buffer AVANT rechargement : 0
Taille de la replay buffer APRÈS rechargement : 5000
```

> Note : SB3 émet un `UserWarning` bénin (« The last trajectory in the replay buffer will be truncated ») lors du `load_replay_buffer` d'un buffer sauvegardé en milieu d'épisode — comportement documenté, sans impact sur la taille (5000).

## Périmètre & limites

- **Notebook Py uniquement** (pas de jumeau C#) → pas de rebaseline `python_sha` / `check_twin_parity`.
- Les **valeurs stochastiques** de récompense (c13 SAC `-52.48`, c18 DDPG `-77.66`) et les rollouts d'entraînement **ne sont pas touchées** — ce sont des sorties d'entraînement non déterministes (catégorie TIMING/drift, c.1062-L, EPIC #8364), laissées telles quelles. Seul le défaut **déterministe** c20 (bug de flux de code) est corrigé.
- Aucune dépendance aval cassée : c25 (vidéo) utilise la variable Python `model_sac` en mémoire, pas le fichier sauvegardé.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
