### PR TITLE
fix(markdown-rendering): clear setext_oversized HR-separator defect (6 NBs)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/solution/Diagnostic-Medical.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/solution/Diagnostic-Medical.ipynb
@@ -2475,6 +2475,7 @@
     " **Application Biomédicale** : Diagnostic du diabète de type 2\n",
     "\n",
     "Les compétences développées sont directement transférables à d'autres domaines nécessitant des systèmes de décision intelligents.\n",
+    "\n",
     "---\n",
     "**Retour au sommaire** : [Index CaseStudies](../../README.md)\n"
    ]

--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/student/Diagnostic-Medical.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/student/Diagnostic-Medical.ipynb
@@ -1387,6 +1387,7 @@
     " **Application Biomédicale** : Diagnostic du diabète de type 2\n",
     "\n",
     "Les compétences développées sont directement transférables à d'autres domaines nécessitant des systèmes de décision intelligents.\n",
+    "\n",
     "---\n",
     "**Retour au sommaire** : [Index CaseStudies](../../README.md)\n"
    ]

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day3-Data-Agents/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day3-Data-Agents/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb
@@ -677,7 +677,7 @@
    "source": [
     "## Exemple guidé\n",
     "\n",
-    "À vous de pratiquer la visualisation et la classification binaire !",
+    "À vous de pratiquer la visualisation et la classification binaire !\n",
     "\n",
     "---\n",
     "**Retour au sommaire** : [Index ML](../../../../README.md)\n"

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day3-Data-Agents/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day3-Data-Agents/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
@@ -518,7 +518,7 @@
    "source": [
     "## Exemple guidé\n",
     "\n",
-    "À vous d'étendre l'agent en lui ajoutant un nouvel outil mathématique !",
+    "À vous d'étendre l'agent en lui ajoutant un nouvel outil mathématique !\n",
     "\n",
     "---\n",
     "**Retour au sommaire** : [Index ML](../../../../README.md)\n"

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-7-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-7-Sequential.ipynb
@@ -35,6 +35,7 @@
     "**Duree estimee** : 90 minutes\n",
     "\n",
     "**Formalisation Lean complémentaire** : [`Infer-9-Lean-Gittins`](../DecInfer/DecInfer-9-Lean-Gittins.ipynb) preuve formelle de l'indice de Gittins et du theoreme d'optimalite (Lean 4 + Mathlib), et le projet Lake [`decision_theory_lean`](../../decision_theory_lean/) (types bandit, escompte geometrique prouve, theoreme d'optimalite enonce).\n",
+    "\n",
     "---\n",
     "\n",
     "| Notebook précèdent | Notebook suivant |\n",

--- a/MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb
@@ -944,6 +944,7 @@
     "- La **création d’un environnement Gym personnalisé**, validé ensuite par la fonction `check_env` et compatible avec tout algorithme Stable-Baselines3.\n",
     "\n",
     "Vous pouvez maintenant adapter et combiner ces techniques pour vos propres projets d’Apprentissage par Renforcement !\n",
+    "\n",
     "---\n",
     "**Retour au sommaire** : [Index RL](README.md)\n"
    ]


### PR DESCRIPTION
Grain: FIX/markdown-rendering-setext -- lane myia-po-2023:CoursIA -- prev: COST/search-foundations-csharp #9274

## Summary

Fix the `setext_oversized` rendering defect in 6 notebooks. A markdown cell where a non-blank text line is immediately followed by `---` (no blank line) renders the text line as a setext H2 heading (oversized), because markdown treats the `---` as a setext underline. The `---` is intended as an `<hr>` thematic-break separator before the "Retour au sommaire" nav link. Fix = insert a blank line before the `---` so it becomes a proper `<hr>`.

## Notebooks fixed (all MyIA.AI.Notebooks/)

- CaseStudies/Diagnostic-Medical/{solution,student}/Diagnostic-Medical.ipynb cell#32
- ML/DataScienceWithAgents/.../Lab5-Viz-ML.ipynb cell#21
- ML/DataScienceWithAgents/.../Lab6-First-Agent.ipynb cell#25
- Probas/DecisionTheory/PyMC/DecPyMC-7-Sequential.ipynb cell#0
- RL/rl_2_wrappers_sauvegarde_callbacks.ipynb cell#23

Defect verified firsthand per cell (NOT a code-fence false positive — all are markdown cells, each with exactly one `---` underline following non-blank text). Uniform defect class, uniform 1-line-per-cell fix, matching the frontmatter-sweep precedent (#9088, 7 NBs / 1 PR).

## Validation

- `detect_markdown_rendering.py` setext_oversized: **8 -> 2** (the 2 remaining are in collision with open PRs #9195 Oncology + #9275 RL-3, correctly excluded).
- Byte-stable: round-trip-exact on indent=1 verified for all 4 unique NBs; diff is ONLY the inserted blank lines (+6/-2, the -2 are line-boundary normalization on the text line preceding `---` in Lab5/Lab6, content identical).
- 0 cell-structure churn (no execution_count/outputs/cell_type changes). LF-only, no CRLF.
- Markdown-only => C.2 exception (no re-execution required).
- Collision-guard CLEAN: 2 of the original 8 setext NBs were in collision (#9195, #9275) and excluded.

## R6

Genre pivot COST->FIX (COST x3 recent c.1146/47/49; pivot to FIX this cycle). Family rotation: CaseStudies/ML/Probas/RL — all fresh vs the recent QC/Probas-cost/Search work. One detector defect class (setext_oversized), uniform fix.

See #8052

Co-Authored-By: Claude-Code <noreply@anthropic.com>
