### PR TITLE
feat(cost,#8056): metadata.cost on Search/Part4-Metaheuristics MGS benchmark slice (5 NBs)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-6-Benchmarks.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-6-Benchmarks.ipynb
@@ -622,6 +622,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "dotnet-interactive",
+   "notes": "GA MetaGeneticSharp sur fonctions-benchmarks. Local CPU, sans API ni GPU. Prerequis: dotnet build ../MetaGeneticSharp/MetaGeneticSharp.sln (fork local, DLLs chargees via #r). GA seede (BasicRandomization.ResetSeed)."
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7-TSP.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7-TSP.ipynb
@@ -1267,6 +1267,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "dotnet-interactive",
+   "notes": "GA TSP MetaGeneticSharp, N=20 villes, plusieurs configs. Local CPU, sans API ni GPU. Prerequis: dotnet build ../MetaGeneticSharp/MetaGeneticSharp.sln. Reproductible: BasicRandomization.ResetSeed(42), villes generees une fois."
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7b-LandscapeMultidim.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7b-LandscapeMultidim.ipynb
@@ -796,6 +796,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 3,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "dotnet-interactive",
+   "notes": "Echantillonnage de paysage multi-dimensionnel (grille) x 4 graines (Random 2026/42/99/777). Local CPU, sans API ni GPU. Prerequis: dotnet build ../MetaGeneticSharp/MetaGeneticSharp.sln. Seed explicite."
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7c-RosenbrockGriewank.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7c-RosenbrockGriewank.ipynb
@@ -493,6 +493,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 1,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "dotnet-interactive",
+   "notes": "Analyse de paysage Rosenbrock + Griewank. Local CPU, sans API ni GPU. Prerequis: dotnet build ../MetaGeneticSharp/MetaGeneticSharp.sln. Seed explicite (Random 42/7)."
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7d-MichalewiczDixonPrice.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7d-MichalewiczDixonPrice.ipynb
@@ -552,6 +552,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 1,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "dotnet-interactive",
+   "notes": "Analyse de paysage Michalewicz + Dixon-Price. Local CPU, sans API ni GPU. Prerequis: dotnet build ../MetaGeneticSharp/MetaGeneticSharp.sln. Seed explicite (Random 42/7)."
+  },
   "authors": [
    {
     "name": "myia-po-2024"


### PR DESCRIPTION
Grain: COST/search -- lane myia-po-2023:CoursIA -- prev: TEST/quantconnect #9280

See #8056. Adds top-level metadata.cost to 5 MetaGeneticSharp benchmark/landscape notebooks in Search/Part4-Metaheuristics (MGS-6/7/7b/7c/7d) -- a slice distinct from the foundational MGS-1/2/4/5 covered by #9226.

## What
All 5 are .NET (C#) local genetic-algorithm notebooks -- local CPU, no API, no GPU:
- MGS-6-Benchmarks -- cpu_min=2, repro=HIGH -- GA on benchmark functions
- MGS-7-TSP -- cpu_min=2, repro=HIGH -- TSP GA N=20, BasicRandomization.ResetSeed(42)
- MGS-7b-LandscapeMultidim -- cpu_min=3, repro=HIGH -- grid x 4 seeds (2026/42/99/777)
- MGS-7c-RosenbrockGriewank -- cpu_min=1, repro=HIGH -- 2 landscape functions (Random 42/7)
- MGS-7d-MichalewiczDixonPrice -- cpu_min=1, repro=HIGH -- 2 landscape functions (Random 42/7)

Common: api_usd_est=0.0, gpu_required=false, vram_tier=NONE, network=false, free_alternative=self, validator=dotnet-interactive. Each notes the one-time local-fork build prereq (dotnet build ../MetaGeneticSharp/MetaGeneticSharp.sln; DLLs loaded via #r -- offline at notebook runtime).

## How (surgical)
Cost block injected as the FIRST key of the top-level metadata via a unique line-start anchor. 5 files, +90/-0 -- zero other bytes touched (no full json.dumps round-trip, so no output-content churn). All 5 remain valid JSON; outputs/execution_count preserved (metadata-only edit, no re-exec per C.2 exception).

## Verification (firsthand)
- Determinism: MGS-7-TSP uses BasicRandomization.ResetSeed(42); MGS-7b/c/d use Random(42/7/2026/99/777). No API hints (grep openai/anthropic/requests/QuantBook/api_key = none). Kernel = .NET (C#).
- Collision-checked: distinct from my #9226 (MGS-1/2/4/5); no other open PR touches these 5 files.
- Catalogue byte-identical to main; no cell/source changes.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
