### PR TITLE
fix(notebook-tools): oversized_hint now fence-aware (skip code-block hint comments)

### DIFF
--- a/scripts/notebook_tools/detect_markdown_rendering.py
+++ b/scripts/notebook_tools/detect_markdown_rendering.py
@@ -272,7 +272,12 @@ def scan_cell(cell) -> list[dict]:
                 break  # one per cell is enough
 
     # ---- oversized hint (hint keyword as a heading) ------------------------------
-    for ln in lines:
+    # Fence-aware (parity with setext_oversized above): a hint keyword inside a
+    # verbatim code block (e.g. a `# Indice :` Python comment in an exercise
+    # scaffold) renders as literal code, NOT as an oversized heading -- skip it.
+    for idx, ln in enumerate(lines):
+        if idx in fenced:
+            continue
         m = _HEADING_RE.match(ln)
         if not m:
             continue

--- a/scripts/notebook_tools/tests/test_detect_markdown_rendering.py
+++ b/scripts/notebook_tools/tests/test_detect_markdown_rendering.py
@@ -148,5 +148,66 @@ class TestScanCell:
         assert scan_cell(_md(["\n"])) == []
 
 
+# --- oversized_hint fence-awareness ----------------------------------------
+
+
+class TestOversizedHintFenceAware:
+    """A hint keyword (`# Indice`/`# Hint`/`# Astuce`) that appears INSIDE a
+    fenced code block is a code comment (e.g. an exercise-scaffold line like
+    ``# Indice : reutilisez sf.branching_avalanche_sizes(...)``), NOT a rendered
+    markdown heading. The detector must skip fenced lines (parity with the
+    already-fence-aware ``setext_oversized`` rule). Founding FP: ICT-7
+    ScaleFreeSignatures exercise scaffolds (~14 false oversized_hint hits)."""
+
+    def _rules(self, cell):
+        return [f["rule"] for f in scan_cell(cell)]
+
+    def test_hint_comment_inside_backtick_fence_not_flagged(self):
+        # Canonical exercise scaffold: `# Indice :` as a Python comment inside a
+        # fenced code block -- renders as literal code, not an H1.
+        cell = _md([
+            "### Exercice 1\n",
+            "\n",
+            "Calculez la valeur.\n",
+            "\n",
+            "```\n",
+            "# Indice : reutilisez sf.branching_avalanche_sizes(mu, N, rng).\n",
+            "# Etape 1 : construire la liste des mu.\n",
+            "```\n",
+        ])
+        assert "oversized_hint" not in self._rules(cell)
+
+    def test_hint_comment_inside_tilde_fence_not_flagged(self):
+        # Tilde fences (~~~) are equivalent CommonMark fenced-code markers and
+        # must be treated identically.
+        cell = _md([
+            "### Exercice\n",
+            "\n",
+            "~~~\n",
+            "# Hint : use a heap for O(n log n).\n",
+            "~~~\n",
+        ])
+        assert "oversized_hint" not in self._rules(cell)
+
+    def test_real_hint_heading_outside_fence_still_flagged(self):
+        # Regression guard: a genuine `# Indice :` H1 in rendered markdown (no
+        # fence) IS a defect and must still be reported.
+        cell = _md([
+            "## Exercice\n",
+            "\n",
+            "Calculez.\n",
+            "\n",
+            "# Indice : pensez a la symetrie du probleme pour simplifier.\n",
+        ])
+        assert "oversized_hint" in self._rules(cell)
+
+    def test_subsection_hint_outside_fence_still_flagged(self):
+        # A `### Astuces` subsection heading outside a fence is still detected
+        # (this is the detector's current behaviour for rendered hint headings;
+        # the fix only adds fence-skipping, it does not change that policy).
+        cell = _md(["### Astuces\n", "\n", "- Utilisez X.\n"])
+        assert "oversized_hint" in self._rules(cell)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Grain: TOOLING/notebook-tools -- lane myia-po-2023:CoursIA -- prev: COST/search #9281

## Bug
The `oversized_hint` rule (detect_markdown_rendering.py) flags hint keywords written as markdown headings. Unlike its sibling `setext_oversized` (fence-aware), oversized_hint iterated raw lines WITHOUT skipping fenced-code blocks -- so a hint keyword that is a **Python comment inside a fenced exercise scaffold** was falsely reported as an oversized rendered heading.

Founding FP -- ICT-7 ScaleFreeSignatures cell#21:
```
### Exercice 1 -- Localiser la criticalite
...prose...
```
# Indice : reutilisez sf.branching_avalanche_sizes(mu, N, rng).
# Indice : stockez (mu, verdict, alpha, KS).
```
The `# Indice :` lines are Python comments inside a fenced code block (exercise scaffold) -- they render as literal code (grey, monospace), NOT as H1 titles.

## Fix
Loop with `enumerate` + `continue` on `idx in fenced` (parity with setext_oversized's `if j in fenced: continue`). One-line behavioural change.

## Impact (measured on full corpus)
- oversized_hint: 164 -> 153 findings (-11 false positives removed)
- setext_oversized / frontmatter_*: unchanged (no regression)

## Tests (+4, 13 -> 17)
- hint comment inside backtick fence -> not flagged
- hint comment inside tilde fence -> not flagged
- regression guards: real `# Indice :` heading outside a fence still flagged; `### Astuces` subsection still flagged
- Legacy sibling scripts/tests/test_detect_markdown_rendering.py still green (18)

## Why this matters
This FP class would have driven a wrong remediation PR (dismantling exercise scaffolds by demoting `# Indice :` comments to blockquotes). Caught by reading the flagged cell's context before editing -- the detector reported ~11 such FPs across the corpus.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
