### PR TITLE
fix(markdown-rendering): clear setext_oversized in Oncology-Planning student cell 25 (follow-on #9276)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb
@@ -761,6 +761,7 @@
     "## Partie 3 : Bonus Smart Contract\n",
     "\n",
     "**Objectif :** Garantir l'intégrité du plan de traitement.\n",
+    "\n",
     "---\n",
     "**Retour au sommaire** : [Index CaseStudies](../../README.md)\n"
    ]


### PR DESCRIPTION
Grain: FIX/markdown-rendering-setext -- lane myia-po-2023:CoursIA -- prev: TEST/audit #9284

## Summary

Follow-on to #9276 (7th notebook beyond that 6-NB `setext_oversized` tranche). The `## Partie 3 : Bonus Smart Contract` cell (`MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb` cell 25) rendered its objective prose as an oversized H2 **setext heading** because the `---` thematic-break line directly followed the text line with no blank line:

```
## Partie 3 : Bonus Smart Contract

**Objectif :** Garantir l'intégrité du plan de traitement.
---
**Retour au sommaire** : [Index CaseStudies](../../README.md)
```

markdown-it treats `prose\n---` (no blank line) as a setext H2 underline, so the whole objective renders title-sized. Inserting one blank-line source element before `---` makes it a proper thematic break (`<hr>`), fixing the rendering while preserving the author's intent (a separator between the objective and the back-to-index link).

## Proof (verifiable)

- `detect_markdown_rendering.py` on the Oncology folder: **1 → 0** findings (was `cell[25] setext_oversized`).
- `--check --baseline scripts/notebook_tools/markdown_rendering_baseline.json`: **`OK: no new ERROR-level markdown-rendering violations.`** (the fixed hash drops out of the baseline cleanly; no NEW error introduced).
- `git diff --stat`: `1 file changed, 1 insertion(+)` — the single source element `+    "\n",`. Byte-stable targeted string insertion, **0 churn** on code cells or outputs.

## Discipline

- **Markdown-only edit** (C.2 exception: code cells untouched, no re-execution required; existing outputs remain valid).
- **Collision-checked**: no open PR touches `student/Oncology-Planning.ipynb` (#9195 is a heading-gap fix on the `solution/` twin — different file, different defect). `rl_3` (the other fresh setext finding) was excluded because #9275 already edits that notebook → merge-conflict risk.
- One subject per PR; `solution/` twin already clean (detector total = 1 on the whole folder, only `student/`).

See #8052
