### PR TITLE
feat(cost,#8056): populate metadata.cost on Planners/04-NeuroSymbolic (3 NBs)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
@@ -1881,6 +1881,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "LLM calls optional - degrades to printed expected examples without API keys (cf outputs)",
+   "reproducibility": "MED",
+   "metadata_written": "2026-08-03",
+   "validator": "papermill",
+   "notes": "LLM-assisted planning; API guarded (openai/anthropic clients optional)"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
@@ -2684,6 +2684,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "papermill",
+   "notes": "unified-planning + up-fast-downward solver; deterministic PDDL"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-12-LOOP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-12-LOOP.ipynb
@@ -2706,6 +2706,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "GPU optional - runs on CPU (torch.cuda.is_available() guard, build is +cpu)",
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "papermill",
+   "notes": "LOOP neuro-symbolic; torch CPU-small, deterministic"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
Grain: COST/planners-neurosymbolic -- lane myia-po-2023:CoursIA -- prev: TEST/audit-migrate-cost #9288

## Summary

Add the 16-field `metadata.cost` block to the 3 neuro-symbolic Planners notebooks (Planners-10/11/12), the **04-NeuroSymbolic subdir not covered by the in-flight #9238** (which populates 02-Classical + 03-Advanced only).

## Honest values grounded in the actual notebook content/outputs

- **Planners-10-LLM-Planning** (48 cells): LLM clients (openai/anthropic) are **GUARDED** — API optional, degrades to printed expected examples without keys. Outputs prove the graceful degrade: `"OpenAI client: Non configure"`, `"Heuristique LLM: (API requise - valeur attendue: ~7/10)"`. So `api_usd_est=0.0` is honest (the notebook runs for $0 without keys), `external_account="none"` is honest, and `reduced_pedagogical` documents the degrade. `reproducibility=MED` (depends on optional keys).
- **Planners-11-Unified-Planning** (65 cells): `unified-planning` + `up-fast-downward` solver, deterministic PDDL, 20/20 executed, no API/GPU. `reproducibility=HIGH`, `network=True` (pip install).
- **Planners-12-LOOP** (60 cells): torch (**CPU-small, build is `+cpu`**), guarded CUDA (`device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')` → output `"Device: cpu"`). `gpu_required=False` is honest, `reduced_pedagogical` documents the CPU-fallback. 14/14 executed, `reproducibility=HIGH`.

## Proof (verifiable)

- `git diff --stat`: `3 files changed, 54 insertions(+)` — **+18/-0 each, purely additive**.
- **Byte-stable targeted insertion**: anchor `'\n "metadata": {\n'` verified unique (`count==1`) per notebook; `rt==raw=True` on all 3 (per the c.1155 per-notebook byte-stability lesson). No json round-trip → **0 churn** on cells, outputs, or existing metadata.
- Catalogue byte-identical to `main` (`git diff` shows no `COURSE_CATALOG.generated.*` change).
- Cost block inserted as the **first** metadata key (preserves all existing comma/key structure).

## Discipline

- **Collision-checked**: #9238 (OPEN) populates Planners-6/8/9 only (02-Classical + 03-Advanced); this PR targets 04-NeuroSymbolic (10/11/12) — no overlap.
- **Checker FP noted** (not fixed here — separate concern): `check_cost_metadata.py` still flags Planners-10 (`token_required_but_no_account`) and Planners-12 (`gpu_used_but_not_declared`) because it pattern-matches `os.getenv("OPENAI_API_KEY")` / `torch.cuda.is_available()` in the code without recognizing the **guarded** degrade. The committed `metadata.cost` is honest; the FP belongs to the checker's heuristic, not this PR.

See #8056
