### PR TITLE
fix(quantconnect): pin LF line endings in provision_vix_csv write_csv

### DIFF
--- a/scripts/quantconnect/provision_vix_csv.py
+++ b/scripts/quantconnect/provision_vix_csv.py
@@ -90,7 +90,12 @@ def to_csv_lines(close) -> list[str]:
 
 def write_csv(path: Path, lines: list[str]) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    # ``newline="\n"`` pins LF line endings on Windows too: ``Path.write_text``
+    # otherwise translates ``\n`` -> ``\r\n``, so the ``date,close`` CSVs minted on
+    # a Windows worker would differ byte-for-byte from those minted under the
+    # Linux Docker ``lean research`` container that consumes them (non-reproducible
+    # data files). Matches the canonical pattern in ``populate_cost_metadata.py``.
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
     return path
 
 


### PR DESCRIPTION
Grain: LIGHT/fix -- lane myia-po-2023:CoursIA -- prev: COST/planners-neurosymbolic #9289

See #8056.

## Summary

`write_csv` in `scripts/quantconnect/provision_vix_csv.py` used `Path.write_text` without `newline="\n"`. On Windows, `Path.write_text` translates `\n` to `\r\n`, so the two `date,close` CSVs (vix_daily.csv / vix3m_daily.csv) minted on a worker machine arrived on disk as CRLF. These CSVs are mounted into the Linux Docker `lean research` container that consumes them via `pd.read_csv`; a Windows-minted file therefore differed byte-for-byte from a Linux-minted one — non-reproducible data files.

Fix: add `newline="\n"`, matching the canonical pattern already established in the sibling `populate_cost_metadata.py` (`write_text(..., newline="\n")`).

## Proof (firsthand, Windows)

```
write_csv(out, ['date,close','2011-12-01,27.41','2011-12-02,27.52'])
  -> bytes=45 CRLF_count=0 LF_total=3
  -> first 40 bytes: b'date,close\n2011-12-01,27.41\n2011-12-02,2'
VERDICT: LF-ONLY (fixed)
```

## Provenance / scope

- Surfaced in #9280 (test-only PR): its `write_csv` tests normalize line endings with a note flagging this exact divergence. This PR fixes the **source**.
- No new test in this PR, deliberately: `test_provision_vix_csv.py` is **absent on main** (created by the frozen #9280) — adding it here would create a 3-way file-creation conflict at merge (the collision pattern documented c.1162). The canonical `newline="\n"` convention + the firsthand LF proof carry correctness. A strict-LF regression assertion is a clean follow-up once #9280 merges.
- Single-file, single-subject (one CSV writer). The two other QC `write_text`-without-`newline=` sites (`audit_projects.py`, `audit_quantbooks_unexec.py`) write human-readable reports (cosmetic line-ending churn, not a parsing-correctness issue) — out of scope.

## Verification

- `python -c "import ast; ast.parse(...)"` — syntax OK.
- `pytest scripts/quantconnect/tests/` — 161 passed, 1 skipped. The 9 failures in `test_provision_lean_data.py` are **pre-existing** (the `scan_zip` 3->4 tuple unpack drift, documented c.1154, module `provision_LEAN_data` != `provision_VIX_csv`), owned by #9256 (jsboige). Isolated: my change touches `provision_vix_csv.py` only — 0 regression.
- Catalogue byte-identical to main (no notebook/catalogue touch).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
