### PR TITLE
feat(cost,#8056): populate metadata.cost on Argument_Analysis formal-argumentation tranche

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Dung_AF_Semantics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Dung_AF_Semantics.ipynb
@@ -1097,6 +1097,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "metadata_written": "2026-08-03",
+   "notes": "Argumentation abstraite de Dung (grounded/preferred/stable) - pure Python, CPU-only, deterministe."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Formal_Richness_Matrix.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Formal_Richness_Matrix.ipynb
@@ -785,6 +785,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "metadata_written": "2026-08-03",
+   "notes": "Matrice de richesse formelle (evaluation des decisions d'un solveur) - pure Python, CPU-only, deterministe."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb
@@ -1230,6 +1230,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "metadata_written": "2026-08-03",
+   "notes": "Ontologie AIF.owl (OWL2 + annotation-space) - parsing/inspection RDF/OWL, CPU-only, deterministe."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ranking_Semantics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ranking_Semantics.ipynb
@@ -618,6 +618,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "metadata_written": "2026-08-03",
+   "notes": "Argumentation graduee - semantiques de classement (h-Categoriser & fardeau) - pure Python, CPU-only, deterministe."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
Grain: MED/cost -- lane myia-po-2023:CoursIA -- prev: TEST/datasets #9292

See #8056.

## Summary

Add the `#8056` cost block to 4 foundational **formal-argumentation** notebooks in `SymbolicAI/Argument_Analysis` -- a family with **0 cost coverage and no open cost PR**. This advances the `#8056` EPIC burn-down on a family untouched by cost population so far.

- `Argument_Analysis_Dung_AF_Semantics` (Dung grounded/preferred/stable)
- `Argument_Analysis_Formal_Richness_Matrix` (solver-decision richness eval)
- `Argument_Analysis_Ontology_AIF` (AIF.owl OWL2 ontology inspection)
- `Argument_Analysis_Ranking_Semantics` (graduated/ranking semantics)

## Cost values (derived firsthand from content)

All four are **CPU-pure deterministic Python** notebooks (no API, no GPU, no network): `api_usd_est=0.0`, `api_provider=none`, `gpu_required=False`, `vram_tier=NONE`, `network=False`, `reproducibility=HIGH`, `validator=papermill`. Probed each notebook's code cells for resource markers (openai/anthropic/requests/torch/cuda/transformers/pip-install) -- none present (pure symbolic-logic computation). Content-specific `notes` per notebook.

## Byte-stable surgery

Cost inserted as the **first metadata key** via the unique `'\n "metadata": {\n'` anchor (count==1 verified), `write_bytes` (no CRLF). **+72/-0 purely additive**, 0 churn on cells/outputs. This anchor method is immune to cells-formatting: `Ontology_AIF` is `rt==raw=False` (a full `json.dumps` round-trip would churn its output cells), but anchor insertion sidesteps that (lesson `json-dumps-indent1-byte-identical-notebook-surgery`).

## Verification

- `check_cost_metadata.py` on each: **0 findings** (no checker FP).
- 0 CRLF, JSON valid (16 fields each), exec cells 11/9/12/10 intact, structure parseable.
- **0 collision** (exact-path: no open PR touches these 4 files). `Argument_Analysis_Ontology_CrossLinks` deliberately excluded -- #9122 already edits that file.

## Discovery note (G.3 honest)

This cycle's first target (Lean conway `native_decide`→`decide`, #8869) was abandoned after self-collision check: my 5 frozen PRs (#9189/#9190/#9197/#9199/#9208) already cover every reducible module, and the 19 `Life/Computation` cases are INTRINSIC (require the #8869 architectural refactor + a coordinator design decision -- ai-01 is DOWN). Lean i18n backlog is drained too (inventory cycle-38). TEST pool is genuinely saturated (the two remaining candidates, `check_docs_links` and `validation/dispatch`, already have test files). The Argument_Analysis cost tranche is a clean, non-colliding, fresh-family substance grain.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
