### PR TITLE
fix(probas,#8052): Infer-2 c19 predictive-variance equation arithmetically false (0.76+1.82!=4.58; correct 1.32+3.29=4.61)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
@@ -1812,7 +1812,7 @@
     "1. **Incertitude epistemique** : Nous ne connaissons pas exactement la vraie moyenne (notre estimation a une variance)\n",
     "2. **Incertitude aleatoire** : Même si nous connaissions parfaitement la moyenne, chaque trajet varie autour d'elle\n",
     "\n",
-    "$$\\text{Var}(\\text{prediction}) = \\text{Var}(\\mu) + \\text{Var}(\\text{bruit}) \\approx 0.76 + 1.82 = 4.58$$\n",
+    "$$\\text{Var}(\\text{prediction}) = \\text{Var}(\\mu) + \\mathbb{E}[1/\\tau] \\approx 1.32 + 3.29 = 4.61$$\n",
     "\n",
     "L'intervalle de confiance 95% `[11.1, 19.5] min` est assez large avec seulement 3 observations. Plus de données le reduiront."
    ]

--- a/scripts/notebook_tools/twin_pairs.d/probas-2-gaussian-mixtures.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-2-gaussian-mixtures.yaml
@@ -4,10 +4,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-30"
+    date: "2026-08-03"
     by: myia-po-2024:CoursIA-2
     python_sha: 643d15d579b04ba4d571684b542ae01c7afb60a9
-    csharp_sha: e7d5c58c04031bbfcc6654c036f337bf1ce0ea53
+    csharp_sha: d7a1c52b931cc357e49d7a123acb46bee23ba5ad
   known_differences:
   - 'Socle pedagogique commun : melanges de distributions gaussiennes (GMM) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2 · See #8052 (semantic-sampling audit) · Single-line markdown equation fix + twin sha rebaseline

# Infer-2-Gaussian-Mixtures c19 — predictive-variance equation is arithmetically false (wrong sum, wrong decomposition)

## Défaut

La cellule markdown **c19** (§ « Interpretation de la prediction ») décompose la variance prédictive par une équation LaTeX **arithmétiquement fausse** et **mal décomposée** :

> `Var(prediction) = Var(μ) + Var(bruit) ≈ 0.76 + 1.82 = 4.58`

Trois erreurs sur cette seule ligne :

1. **Arithmétique fausse** : `0.76 + 1.82 = 2.58`, **pas 4.58**. Un·e étudiant·e qui vérifie la somme tombe sur 2.58.
2. **Var(μ) mal étiquetée** : `0.76` est en réalité `1/1.32` = **précision** de μ, pas sa variance. La vraie `Var(μ) = 1.32` (postérieure c11 `Gaussian(15.33, 1.32)`).
3. **« Var(bruit) = 1.82 »** est le plug-in `1/E[τ] = 1/0.5482 = 1.82`, qui **sous-estime** l'espérance de la variance du bruit. La valeur correcte est `E[1/τ] = 3.29`.

**La cible 4.58 ≈ 4.613 est à peu près juste** (c18 sort `Gaussian(15.33, 4.613)`), mais les summands ET la somme sont faux.

## Cause racine (vérifiée firsthand, C976-L)

Re-dérivation indépendante de la décomposition de la variance prédictive (analytique + intégration numérique) :

Pour le modèle cycliste (`μ ~ Gaussian`, `τ ~ Gamma` précision), la variance prédictive d'un nouveau trajet se décompose en :

```
Var(prediction) = Var(μ) + E[1/τ]
```

- `Var(μ) = 1.32` (postérieure c11 `Gaussian(15.33, 1.32)`).
- `E[1/τ]` pour la postérieure Gamma(shape=2.242, scale=0.2445)[mean=0.5482] : `E[1/τ] = 1/(scale·(shape−1)) = 1/(0.2445 × 1.242) = 3.293` — **confirmé par intégration numérique** (`scipy.integrate.quad` = 3.2931).

→ `Var(prediction) = 1.32 + 3.29 = 4.61`, qui **matche bit-à-bit** la sortie calculée c18 `Gaussian(15.33, 4.613)` (le µ-écart 4.61 vs 4.613 = approximation EP).

Le moteur Infer.NET est **correct** (la variance prédictive 4.613 est juste) ; seul le résumé en prose qui l'expliquait la décomposait mal.

## Correction (Fix)

Chirurgicale, **1 ligne markdown uniquement** (l'équation LaTeX de c19) :

```
- Var(prediction) = Var(μ) + Var(bruit) ≈ 0.76 + 1.82 = 4.58
+ Var(prediction) = Var(μ) + E[1/τ] ≈ 1.32 + 3.29 = 4.61
```

`τ` = précision (cohérent avec la notation du notebook : `GaussianFromMeanAndPrecision`, postérieure Gamma de la précision en c11). **Aucun code / logique / calcul touché** → c11/c18 outputs **invariants** (la re-dérivation le prouve : la valeur cible 4.613 est déjà correcte, on ne fait que corriger l'explication).

Diff : 1 ins / 1 del sur le notebook (byte-minimal, raw-targeted edit — pas de re-sérialisation JSON, structure source préservée). nbformat VALID.

## Vérification firsthand (C976-L — instrumenter avant d'asserter)

- **Re-exécution .NET/Infer.NET non requise** : le fix est **computation-invariant** (markdown-only, aucun changement de code). La variance prédictive c18 `4.613` est **préservée** telle quelle.
- **Re-dérivation numpy/scipy** : `E[1/τ]` calculé deux façons (formule Gamma `1/(scale·(shape−1))` = 3.2931 ET intégration numérique = 3.2931) → `Var(μ) + E[1/τ] = 1.32 + 3.29 = 4.61 ≈ 4.613` bit-match avec la sortie committée.
- **Audit complet du notebook (85 cellules)** : tout le reste est CLEAN — c7/c9/c11 (modèle Gaussien simple : moyenne post 15.33 = (13+17+16)/3 ✓, écart-type bruit 1.35 = √(1/0.5482) ✓) ; c15/c18/c22 (prédictive `Gaussian(15.33, 4.613)`, IC 95 % [11.1, 19.5] = 15.33±1.96×2.15 ✓, P(x<18)=0.89 / P(x<15)=0.44 / P(14<x<18)=0.65 ✓) ; section GMM c51–c71 (c58 sorties cluster 15.07/26.69 + Dirichlet 7.995:4.005 → 67 %/33 % = postérieure (1,1)+comptes souples ≈7/3 ✓ ; c62 tableau matche c58 ✓ ; c65 « EP a permuté les composantes » = label-switching correct ✓ ; c67 prédictive mélange `Gaussian(18.48, 33.39)` √=5.78 ✓) ; c71/c75 (mélange 3 composantes : données 13-obs {8,10,12,18,17,19,20,28,32,35,11,18,30}, clusters durs {8,10,11,12}→10.25 / {17,18,18,19,20}→18.4 / {28,30,32,35}→31.25 matchent les sorties 10.2/18.4/31.2 ✓) ; c82 BIC = stub C.1 honnête ✓.

## Diagnostic dérive

- **Classe** : defect **claim-vs-output** (c.1047-L) en prose markdown — une équation LaTeX hardcodée qui contredit la sortie calculée (c18 `4.613`) ET l'arithmétique élémentaire (`0.76+1.82≠4.58`). Sous-classe VALUE/arithmetic : somme fausse + décomposition erronée (précision confondue avec variance ; plug-in `1/E[τ]` confondu avec `E[1/τ]`).
- **Aucun §D.5 numérique recalculé** : aucune valeur de sortie n'est modifiée. La variance prédictive 4.613 committée est **préservée** (vérifiée correcte). Seule la prose qui l'expliquait mal est corrigée.
- **Twin** : `probas-2-gaussian-mixtures.yaml` (`parity_level: semantic`). Le fix markdown-only ne change **aucun** calcul → la parité sémantique C#(Infer.NET)↔Python(PyMC) est **préservée**. Seul le `csharp_sha` est rebaseliné (`e7d5c58c` → `d7a1c52b`), date → 2026-08-03, `by` inchangé. Côté Python (PyMC-2) non touché. `check_twin_parity --check --pair probas-2-gaussian-mixtures` = **[OK]**.

## Périmètre & limites

- **1 fichier notebook** (Infer-2-Gaussian-Mixtures.ipynb, cellule c19 markdown) + **1 twin yaml** rebaseliné (`csharp_sha` + date). Race-free (aucun PR ouvert ne touche Infer-2 ou `probas-2-gaussian-mixtures.yaml` : #9106 = cost-migration sur `probas-8-trueskill.yaml` uniquement, confirmé firsthand).
- **Non touché (DEFER, hors-scope)** : la prose pédagogique autour (c19 « Incertitude epistemique/aleatoire ») est correcte et laissée telle quelle. Le stub BIC c82 = exercice à compléter (C.1 honnête, pas de valeur fabriquée).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
