### PR TITLE
feat(twin-parity,#8057): register 3 Sudoku Python/C# twin pairs (coverage 7->4)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/sudoku-1-backtracking.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-1-backtracking.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-1 Backtracking"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-08-03"
+    by: myia-po-2023:CoursIA
+    python_sha: 8a1465a542c0f9ec6634036ffd993e934667cb0a
+    csharp_sha: 37c65d0a912695c7b4387b8fc373d3a6458ea5f5
+  known_differences:
+    - "Socle pedagogique commun : algorithme de backtracking (retour sur trace) pour resoudre un mini-Sudoku, meme concept algorithmique (recursion + propagation de contraintes + retour-arriere sur conflit), meme cas d'application pedagogique (grille partiellement remplie, recherche systematique)."
+    - "Divergence d'implementation : le Python implemente le backtracking from scratch (fonction recursive + suivi des conflits) avec une visualisation matplotlib/numpy du deroulement ; le C# implemente le backtracking pur en stdlib (System.*) sans visualisation. Meme algorithme, niveau d'abstraction et d'enrichissement visuel differents."
+    - "Asymetrie structurelle : Python 13 cellules code / 20 markdown (implementation complete + benchmark/visualisation + exercices) ; C# 8 cellules code / 11 markdown (resolution compacte). Idiomes framework : C# = stdlib System.*, Python = numpy + matplotlib + time."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-10-ortools.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-10-ortools.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-10 ORTools"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-08-03"
+    by: myia-po-2023:CoursIA
+    python_sha: 25c9790ba0ba6e5e4747515ff7fc7c60829569bb
+    csharp_sha: 6ebe0a7c46546711129754780fe82a4df7eebad2
+  known_differences:
+    - "Socle pedagogique commun : resolution du Sudoku par programmation par contraintes avec OR-Tools CP-SAT (Google.OrTools), meme solveur sous-jacent, meme modelisation (variables IntVar par case, contraintes AllDifferent sur lignes/colonnes/blocs, objectif de satisfaction)."
+    - "Idiomes framework symetriques : Python = `from ortools.sat.python import cp_model` (binding Python natif), C# = NuGet `#r \"nuget: Google.OrTools\"` + `using IntVar / SimpleCPSolver / SimpleConstraint` (binding .NET). Les deux cotes deleguent au meme moteur CP-SAT de Google, seules les API de binding different."
+    - "Parite structurelle proche : Python 13 cellules code / 17 markdown ; C# 14 cellules code / 21 markdown. Arc pedagogique identique (formulation CP-SAT -> exemple resolu -> benchmark de passage a l'echelle)."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-14-bdd.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-14-bdd.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-14 BDD"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-08-03"
+    by: myia-po-2023:CoursIA
+    python_sha: 052095be135bdafe9306007fcd57a2b6ec69af55
+    csharp_sha: 16a4db36adb2eef7e579206ddb5d5161d434e99e
+  known_differences:
+    - "Socle pedagogique commun : resolution du Sudoku par automates a decision binaire (BDD / MDD, Binary/Multi-valued Decision Diagrams), meme concept (codage booleen des contraintes, reduction canonique du graphe de decision, satisfaction via parcours). Le notebook Python declare explicitement etre le jumeau du C# (« Jumeau Python du notebook Sudoku-14-BDD-Csharp.ipynb »)."
+    - "Divergence d'implementation : les deux cotes hand-rollent les BDD/MDD from scratch (pas de lib BDD tierce) -- le Python via dataclasses/typing, le C# via System.Collections.Generic + System.Linq. Meme reconstruction pedagogique de l'automate, idiomes de langage differents."
+    - "Parite structurelle proche : Python 14 cellules code / 19 markdown ; C# 15 cellules code / 25 markdown. Arc pedagogique identique (construction du BDD -> reduction -> resolution)."


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2023:CoursIA -- prev: COST/gametheory #9297

## Summary

`check_twin_parity.py --coverage` reported **7 UNREGISTERED** real Sudoku Python/C# twin pairs (true twins invisible to the drift gate). Register a **tranche of 3** after firsthand parity audit (per #8057: "par tranche APRES audit firsthand, jamais en masse"):

| Pair | algorithm | idioms |
|---|---|---|
| Sudoku-1 Backtracking | backtracking | PY from-scratch + numpy/matplotlib viz, CS pure stdlib |
| Sudoku-10 ORTools | OR-Tools CP-SAT | both sides Google.OrTools (NuGet on C#, ortools.sat on PY) — symmetric |
| Sudoku-14 BDD | BDD/MDD | hand-rolled both sides (PY dataclasses, CS System.*); PY declares itself the explicit twin |

Each yaml: `parity_level=semantic`, `last_audit` with `git ls-tree HEAD` blob SHAs, 3 `known_differences` bullets grounded in actual framework idioms.

## Validation
- `check_twin_parity --json`: all 3 new pairs status **OK**
- coverage: **7 → 4** unregistered (tranche, not mass)
- `pytest test_check_twin_parity + test_check_twin_parity_update_guard`: **17 passed**
- yaml schema valid (single-elem list, all keys, SHAs present)
- diff: **+3 new files, 0 source/notebook churn**

## Collision-guard
File-level vs all open PRs: #9283/#9047 touch ALREADY-registered sudoku yamls (sudoku-3-genetic, sudoku-13-symbolicautomata), not these 3. #9106 rebaselines EXISTING drifted pairs, does not ADD coverage. 4 pairs remain unregistered (Sudoku-8/9/15/18) for a follow-on tranche.

## R6 note
Genre rotation: COST → tooling (registry-coverage), fresh family Sudoku. Twin-parity rebaseline vein collided (all 8 drifted pairs covered by #9106); coverage-registration is a distinct, collision-free operation.

See #8057

Co-Authored-By: Claude-Code <noreply@anthropic.com>
