### PR TITLE
feat(twin-parity,#8057): register 4 remaining Sudoku twin pairs (coverage 4->0)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/sudoku-15-infer.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-15-infer.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-15 Infer"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-08-03"
+    by: myia-po-2023:CoursIA
+    python_sha: d1282426b7eea1e38e808669eace82467deb0567
+    csharp_sha: ef5632ca0b72c78238ffff335fd612369c064a78
+  known_differences:
+    - "Socle pedagogique commun : resolution PROBABILISTE du Sudoku par inference bayesienne/probabiliste, meme concept (modeliser l'incertitude sur les cases, inferrer les valeurs les plus probables), meme angle (approche non-deterministe par contraste avec les solveurs exacts de la serie)."
+    - "Divergence de framework probabiliste : Python = NumPyro (MCMC, inference variationnelle, stochastic) ; C# = Infer.NET (modelisation probabiliste .NET, message passing). Meme paradigme (inference probabiliste), deux frameworks stochastiques distincts -- les sorties numeriques different d'une execution a l'autre (MCMC sampling), parite au niveau du concept et de la demarche, pas des valeurs exactes."
+    - "Asymetrie structurelle : Python 13 cellules code / 21 markdown ; C# 19 cellules code / 28 markdown. Arc pedagogique identique (modelisation probabiliste -> inférence -> comparaison aux solveurs exacts)."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-18-comparison.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-18-comparison.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-18 Comparison"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-08-03"
+    by: myia-po-2023:CoursIA
+    python_sha: 36401a556e3553e4dd2a7fc52d4222251f8d6c2e
+    csharp_sha: 7e11e158decc0f844680740fe09cdcfed43a9535
+  known_differences:
+    - "Socle pedagogique commun : comparaison synthese de TOUS les solveurs de la serie Sudoku (backtracking, dancing links, genetic, OR-Tools, Z3, BDD, probabiliste), meme concept (tableau de benchmark croise : temps de resolution / robustesse / complexite), meme arc conclusif (Fin de serie)."
+    - "Parite structurelle forte : Python et C# ont exactement la meme structure (25 cellules code / 43 markdown chacun), memes en-tetes de navigation ('Fin de serie'), memes solveurs compares. Les deux cotes instrumentent les memes familles de solveurs."
+    - "Idiomes framework : chaque cote invoque les solveurs disponibles dans son ecosysteme (Python = ortools/z3/numpy/stdlib ; C# = Infer.NET/Choco/Z3/BDD/stdlib). La comparaison croisee est le livrable pedagogique commun."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-8-humanstrategies.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-8-humanstrategies.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-8 HumanStrategies"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-08-03"
+    by: myia-po-2023:CoursIA
+    python_sha: 7ce5db8ee3bb05faa0f72508bf26390e3ff70f87
+    csharp_sha: 533b34ff9fb08626f3a41b3c8ce2acb0ffd6d239
+  known_differences:
+    - "Socle pedagogique commun : strategies de resolution humaines (techniques d'inference -- naked/hidden singles, pointing pairs, box-line) appliquees au Sudoku, meme concept (simuler le raisonnement humain par couches d'inference successives plutot qu'un backtracking brut), meme arc pedagogique (theorie -> implementation -> benchmark)."
+    - "Divergence d'implementation : le Python implemente les techniques d'inference from scratch + visualisation networkx du graphe de contraintes ; le C# implemente les memes strategies d'inference en stdlib avec un benchmark comparatif. Idiomes de visualisation differents (networkx cote Python)."
+    - "Asymetrie structurelle : Python 22 cellules code / 30 markdown ; C# 19 cellules code / 30 markdown. Arc identique (techniques d'inference + mesure de performance)."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-9-graphcoloring.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-9-graphcoloring.yaml
@@ -1,0 +1,14 @@
+- name: "Sudoku-9 GraphColoring"
+  family: Sudoku
+  python: MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
+  csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-08-03"
+    by: myia-po-2023:CoursIA
+    python_sha: 8468688beb8513f870e571c57eded9224f2c9cb7
+    csharp_sha: 1a629086fd9a29cd9fb4d705e44ba085d02a4583
+  known_differences:
+    - "Socle pedagogique commun : reformulation du Sudoku comme un probleme de coloration de graphe (une cellule = un noeud, le graphe de contraintes Sudoku, coloration propre a 9 couleurs), meme concept mathematique (graphe de conflits, coloration propre), meme cas d'application."
+    - "Idiomes framework : Python = networkx (construction du graphe) + OR-Tools CP-SAT (resolution de la coloration) ; C# = construction du graphe + solveur de coloration en stdlib. Meme reformulation graph-coloring, libs de graphe differentes."
+    - "Parite structurelle proche : Python 11 cellules code / 18 markdown ; C# 14 cellules code / 22 markdown."


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2023:CoursIA -- prev: COST/smt-z3 #9299

## Summary

Completes the Sudoku twin-parity coverage queue started in #9298 (which registered Sudoku-1/10/14). `check_twin_parity --coverage` reported 4 remaining UNREGISTERED real Sudoku pairs; register them after firsthand parity audit (per #8057: "par tranche APRES audit, jamais en masse"):

| Pair | concept | idioms |
|---|---|---|
| Sudoku-8 HumanStrategies | human inference strategies | PY from-scratch + networkx, CS stdlib + benchmark |
| Sudoku-9 GraphColoring | Sudoku as graph coloring | PY networkx+OR-Tools, CS stdlib |
| Sudoku-15 Infer | **probabilistic** solving | PY NumPyro (MCMC), CS Infer.NET — semantic twin at concept level |
| Sudoku-18 Comparison | solver-series synthesis | identical 25code/43md structure both sides |

Sudoku-15 noted honestly: stochastic frameworks (NumPyro vs Infer.NET) differ — parity at concept/demarche level, not exact values.

## Validation
- `check_twin_parity --json`: all 4 new pairs **OK**
- `pytest test_check_twin_parity + update_guard`: **17 passed**
- yaml schema valid (all 4: SHAs via `git ls-tree HEAD`)
- diff: **+56/-0** (4 new yaml), 0 source/notebook churn
- collision-guard: all 4 yaml FREE; distinct from #9298 (Sudoku-1/10/14) — no overlap

## R6 note
Genre rotation within c.1168: COST/SMT (#9299) → tooling/Sudoku (this PR). Completes the multi-cycle Sudoku registration queue (tranche 1 #9298 + tranche 2 here). No mass registration — each pair audited firsthand.

See #8057

Co-Authored-By: Claude-Code <noreply@anthropic.com>
