### PR TITLE
cost(smt): populate cost metadata for 5 Z3-Python-11..15 notebooks

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb
@@ -613,6 +613,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 1,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "none",
+   "network": true,
+   "external_account": false,
+   "free_alternative": "self",
+   "reduced_pedagogical": false,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "check_cost_metadata.py",
+   "notes": "Z3 SMT graph-coloring constraint solver + matplotlib visualization. Deterministic SMT solving, no randomness. CPU-only. 10/10 code cells executed."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb
@@ -435,6 +435,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 1,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "none",
+   "network": true,
+   "external_account": false,
+   "free_alternative": "self",
+   "reduced_pedagogical": false,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "check_cost_metadata.py",
+   "notes": "Z3 SMT real arithmetic (nonlinear real constraints). Deterministic SMT. CPU-only. 8/8 cells executed."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb
@@ -577,6 +577,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 1,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "none",
+   "network": true,
+   "external_account": false,
+   "free_alternative": "self",
+   "reduced_pedagogical": false,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "check_cost_metadata.py",
+   "notes": "Z3 unsat-core extraction. Deterministic SMT. CPU-only. 10/10 cells executed."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb
@@ -566,6 +566,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 1,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "none",
+   "network": true,
+   "external_account": false,
+   "free_alternative": "self",
+   "reduced_pedagogical": false,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "check_cost_metadata.py",
+   "notes": "Z3 BitVec overflow detection. Deterministic SMT. CPU-only. 10/10 cells executed."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-15-Nested-Arrays-2D.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-15-Nested-Arrays-2D.ipynb
@@ -564,6 +564,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 1,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "none",
+   "network": true,
+   "external_account": false,
+   "free_alternative": "self",
+   "reduced_pedagogical": false,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "check_cost_metadata.py",
+   "notes": "Z3 nested/2D array theory. Deterministic SMT. CPU-only. 8/8 cells executed."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
Grain: COST/smt -- lane myia-po-2023:CoursIA -- prev: COST/symlearn #9303
See #8056 (partial contribution to EPIC).

## Summary

Add `metadata.cost` (first metadata key) to 5 Z3 SMT Python notebooks: Z3-Python-11 (Graph-Coloring), 12 (Real-Arithmetic), 13 (UnsatCores), 14 (BitVectors-Overflow), 15 (Nested-Arrays-2D).

All deterministic Z3 SMT, CPU-only, `api_usd_est=0`, `gpu_required=false`, `network=true` (pip z3-solver), `reproducibility=HIGH`. No LLM API call, no GPU.

## Validation (forensic)

- `check_cost_metadata.py`: **0 findings** on all 5
- Byte-stable anchor-insertion (cost as first metadata key): `json.dumps(indent=1)` round-trips byte-identical
- 0 CRLF, +90/-0 purely additive (0 source/output churn)
- Metadata-only -> C.2 outputs-exception (no source cell modified)

## Collision-guard (file-level)

- #9229 covers Z3-Python-07..10
- my #9299 covers Z3-Python-01..06
- These 5 (11..15) are genuinely free

Co-Authored-By: Claude-Code <noreply@anthropic.com>