### PR TITLE
cost(lean): populate cost metadata for 5 SymbolicAI/Lean Python notebooks

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Grothendieck-Tribute.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Grothendieck-Tribute.ipynb
@@ -1817,6 +1817,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "none",
+   "network": true,
+   "external_account": false,
+   "free_alternative": "self",
+   "reduced_pedagogical": false,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "check_cost_metadata.py",
+   "cpu_min": 3,
+   "notes": "Lean formal-math tribute (Grothendieck) via local lake build + Mathlib. Deterministic proof checking, CPU-heavy. No LLM, no GPU. Network=toolchain/Mathlib fetch (cached)."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15b-Lean-Grothendieck.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15b-Lean-Grothendieck.ipynb
@@ -2382,6 +2382,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "none",
+   "network": true,
+   "external_account": false,
+   "free_alternative": "self",
+   "reduced_pedagogical": false,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "check_cost_metadata.py",
+   "cpu_min": 4,
+   "notes": "Lean Grothendieck-style proofs (18 cells) via local lake build + Mathlib. Deterministic, CPU-heavy build. No LLM, no GPU. Network=toolchain fetch."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16a-Conway-Man-and-Work.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16a-Conway-Man-and-Work.ipynb
@@ -1950,6 +1950,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "none",
+   "network": true,
+   "external_account": false,
+   "free_alternative": "self",
+   "reduced_pedagogical": false,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "check_cost_metadata.py",
+   "cpu_min": 2,
+   "notes": "Conway biography + Lean formal math (Game of Life, surreal numbers) via lake build. Deterministic. No LLM, no GPU. Network=toolchain fetch."
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16f-Conway-Free-Will-Theorem.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16f-Conway-Free-Will-Theorem.ipynb
@@ -1494,6 +1494,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "none",
+   "network": true,
+   "external_account": false,
+   "free_alternative": "self",
+   "reduced_pedagogical": false,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "check_cost_metadata.py",
+   "cpu_min": 2,
+   "notes": "Conway-Kochen Free Will Theorem formalization in Lean via lake build + Python illustration (random.seed). Deterministic. No LLM, no GPU. Network=toolchain fetch."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-18-Search-AStar-Optimality.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-18-Search-AStar-Optimality.ipynb
@@ -1513,6 +1513,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "none",
+   "network": true,
+   "external_account": false,
+   "free_alternative": "self",
+   "reduced_pedagogical": false,
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-03",
+   "validator": "check_cost_metadata.py",
+   "cpu_min": 2,
+   "notes": "A* search optimality theorem: Lean formal proof via lake build + Python A* demo. Deterministic. No LLM, no GPU. Network=toolchain fetch."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
Grain: COST/lean -- lane myia-po-2023:CoursIA -- prev: COST/tweety #9307
See #8056 (partial contribution to EPIC).

## Summary

Add `metadata.cost` (first metadata key) to 5 SymbolicAI/Lean Python notebooks: Lean-15 (Grothendieck-Tribute), Lean-15b (Lean-Grothendieck), Lean-16a (Conway-Man-and-Work), Lean-16f (Conway-Free-Will-Theorem), Lean-18 (Search-AStar-Optimality).

All deterministic Lean (local `lake` build + Mathlib) + Python illustration, CPU-only, `api_usd_est=0`, `gpu_required=false`, `network=true` (Lean toolchain + Mathlib fetched on first build, cached), `reproducibility=HIGH`. No LLM, no GPU.

## SOTA honesty (Prong-A)

Verified 0 LLM API call.

## Validation (forensic)

- `check_cost_metadata.py`: **0 findings** on all 5
- Byte-stable anchor-insertion (cost as first metadata key)
- 0 CRLF, +90/-0 purely additive (0 source/output churn)

## Notes

Lean-16b/16c deferred: validator flagged CRITICAL `api_used_but_cost_zero` ("appelle google"), but `grep` confirms **zero "google" occurrences** in either notebook (confirmed false positive). Deferred to avoid reviewer dispute.

## Collision-guard (file-level, path-normalized)

Lean-1/7/7b/8/9/10 already have cost. These 5 (gpu-free) are genuinely free.

Co-Authored-By: Claude-Code <noreply@anthropic.com>