### PR TITLE
fix(audit): tighten cost-validator gemini pattern (FP on Conway GoL pattern)

### DIFF
--- a/scripts/audit/check_cost_metadata.py
+++ b/scripts/audit/check_cost_metadata.py
@@ -91,7 +91,15 @@ API_PATTERNS = {
     'openai': r'openai\.ChatCompletion|openai\.Image|openai\.Audio|from openai',
     'anthropic': r'anthropic\.\w|from anthropic|claude',
     'mistral': r'mistralai|from mistral',
-    'google': r'google\.generativeai|gemini',
+    # FP-c.1172 : le `gemini` nu matchait le pattern "Gemini" de Conway's
+    # Game of Life (Andrew Wade, 2010, self-replicator) dans les notebooks
+    # Lean-16b/16c (variable `gemini_node`, fichier `gemini.rle`). On resserre
+    # au contexte API reel : import du SDK `google.generativeai`, endpoint REST
+    # `generativelanguage.googleapis`, ou nom de modele versionne
+    # (`gemini-1.5`, `gemini-pro`, `gemini-2.0`). Le mot nu ne signale jamais
+    # un appel API. Complement du fix c.912 qui avait resserre `anthropic.` mais
+    # laisse `gemini`/`claude` nus (cf commentaire lignes 86-89).
+    'google': r'google\.generativeai|generativelanguage\.googleapis|gemini-\d|gemini-pro|gemini-flash',
     'replicate': r'replicate\.',
     'hf_inference_api': r'huggingface_hub\.InferenceClient',
 }

--- a/scripts/audit/tests/test_check_cost_metadata.py
+++ b/scripts/audit/tests/test_check_cost_metadata.py
@@ -142,6 +142,38 @@ def test_litmus2_api_used_cost_zero_local_provider_suppressed(tmp_path):
         )
 
 
+def test_litmus2_gemini_bare_word_fp_suppressed(tmp_path):
+    """FP-c.1172 : bare `gemini` matched the Conway's Game of Life self-replicator
+    pattern (Andrew Wade, 2010) in notebooks Lean-16b/16c — variable `gemini_node`,
+    file `gemini.rle`, print("Gemini ..."). A bare word is never an API call.
+    The GoL code must NOT trigger api_used_but_cost_zero."""
+    code = (
+        'gemini_node, gemini_cells = load_pattern("gemini.rle")\n'
+        'print("Gemini (Andrew Wade, 2010) - self-replicator oblique")\n'
+    )
+    res = _findings_for(
+        tmp_path, code, cost_meta={"api_usd_est": 0.0, "api_provider": "none"}
+    )
+    assert "api_used_but_cost_zero" not in _patterns(res["findings"]), (
+        "bare 'gemini' (GoL pattern) must not be detected as a Google API call"
+    )
+
+
+def test_litmus2_gemini_real_api_call_still_detected(tmp_path):
+    """Real Gemini API references (SDK import or versioned model name) are still
+    detected after the c.1172 tightening."""
+    for code in (
+        "import google.generativeai as genai\ngenai.GenerativeModel('gemini-1.5-flash')",
+        "model = 'gemini-pro'\nresp = client.generate(model)",
+    ):
+        res = _findings_for(
+            tmp_path, code, cost_meta={"api_usd_est": 0.0, "api_provider": "none"}
+        )
+        assert "api_used_but_cost_zero" in _patterns(res["findings"]), (
+            f"real Gemini API call should still fire; code=\n{code}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Litmus 3 — token_required_but_no_account
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Grain: FIX/tooling -- lane myia-po-2023:CoursIA -- prev: COST/lean #9308
See #8056

## Problem

The cost-matrix validator (`check_cost_metadata.py`) `api_used_but_cost_zero` litmus had a bare-word `gemini` in its Google-provider `API_PATTERNS` regex:

```
google: r"google\.generativeai|gemini"
```

That bare `gemini` matched the **Gemini** self-replicator pattern of Conway's Game of Life (Andrew Wade, 2010) in notebooks Lean-16b / Lean-16c, where it appears as the variable `gemini_node`, the file `gemini.rle`, and inside `print("Gemini ...")` strings. The validator flagged these as **CRITICAL** `api_used_but_cost_zero` ("Cellule code appelle google") even though there is **zero** Google API reference (`grep` confirms: no `google.generativeai`, no model name).

## Root cause / FP-c.912 completion

This completes the FP-c.912 fix. The c.912 comment (lines 86-89) explicitly noted "`claude`/`gemini` nus prenaient des panos SOTA en prose" but only tightened `anthropic.`, leaving `gemini` bare. This PR tightens `gemini` to require a real API/model context:

```
google: r"google\.generativeai|generativelanguage.googleapis|gemini-\d|gemini-pro|gemini-flash"
```

A bare word is never an API call; real references are the SDK import (`google.generativeai`, already covered), the REST endpoint, or a versioned model name (`gemini-1.5-flash`, `gemini-pro`, `gemini-2.0`). The GoL variable `gemini_node` / file `gemini.rle` no longer matches.

## Verification

- `grep "gemini"` on Lean-16b/16c: only GoL-pattern references (variable `gemini_node`, file `gemini.rle`, `print("Gemini ...")`), zero API context.
- After fix: Lean-16b/16c report `api_used=[]` (was `[google]`).
- `pytest scripts/audit/tests/test_check_cost_metadata.py`: **44 passed** (2 new regression tests: bare-word GoL `gemini` suppressed, real SDK import + `gemini-pro` model name still detected).

+41/-1, 2 files (validator + tests).

Co-Authored-By: Claude-Code <noreply@anthropic.com>