### PR TITLE
fix(search,#8052): Search-11b-Deep-Part4 c20 eval-count claim wrong (SA 500→~3000, contradicts code + own c12)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11b-Metaheuristiques-Deep-Part4.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11b-Metaheuristiques-Deep-Part4.ipynb
@@ -890,7 +890,7 @@
    "source": [
     "### Exercice 3 — Budget equivalent (comparaison equitable)\n",
     "\n",
-    "**Enonce** : La comparaison ci-dessus n'est pas totalement equitable : SA fait 500 evals, PSO/ABC font ~3000 evals. Refaites le benchmark en fixant un **budget d'evaluations de fonction** identique (ex: 3000 evals pour chaque algorithme) et observez si le classement change.\n",
+    "**Enonce** : La comparaison ci-dessus n'est pas totalement equitable : SA et PSO font ~3000 evals, mais ABC en fait ~6000 (phases employee + onlooker). Refaites le benchmark en fixant un **budget d'evaluations de fonction** identique (ex: 3000 evals pour chaque algorithme) et observez si le classement change.\n",
     "\n",
     "**Questions** : (a) A budget egal, quel algorithme est le plus efficace ? (b) SA (peu d'evals mais trajectoire longue) vs essaim (beaucoup d'evals) — qui exploite le mieux un budget fixe ?\n",
     "\n",


### PR DESCRIPTION
lane: myia-po-2024:CoursIA-2 · See #8052 (semantic-sampling audit) · eval-count claim-vs-code fix (markdown-only, 1 line)

# Search-11b-Deep-Part4 c20 — "SA fait 500 evals" is wrong (SA runs iters=3000 → ~3000 evals); contradicts both code and the notebook's own c12

## Défaut

La cellule **c20** (Exercice 3 énoncé) affiche un budget d'évaluations de SA **erroné** :

> "La comparaison ci-dessus n'est pas totalement equitable : **SA fait 500 evals**, PSO/ABC font ~3000 evals."

Or SA fait **~3000 evals**, pas 500. Ce chiffre est doublement faux :

1. **Contradit le code** (c7 signature SA) : `int iters = 3000` (défaut) + c9 harness `SA(f,d,s)` sans override → SA exécute 3000 itérations × 1 eval/iter + 1 init = **3001 evals ≈ 3000**, pas 500.
2. **Contradit le notebook lui-même** : c12 (Lecture du tableau) dit correctement "*SA (trajectoire unique, **3000 evals**) redevient competitif*". c12 et c20 se contredisent — c20 a le mauvais chiffre.

De plus, "PSO/ABC font ~3000 evals" est aussi inexact pour ABC : ABC fait **~6000 evals** (SN=30, maxCycles=100, phases employee + onlooker = 2×30×100 ≈ 6000), pas ~3000. Le vrai outlier de budget est ABC (~2× SA/PSO), pas SA.

Un·e étudiant·e lisant "SA fait 500 evals" comme prémisse de l'exercice d'égalisation de budget serait induit·e en erreur : SA est déjà à ~3000 evals (comme PSO), donc l'asymétrie réelle à corriger est ABC (~6000), pas SA.

## Correction (Fix)

**Chirurgicale, 1 ligne markdown** (c20 est une cellule markdown, pas d'output, pas de twin, pas de rebaseline) :

```
- SA fait 500 evals, PSO/ABC font ~3000 evals
+ SA et PSO font ~3000 evals, mais ABC en fait ~6000 (phases employee + onlooker)
```

La suite de l'énoncé ("ex: 3000 evals pour chaque algorithme", "observez si le classement change") reste valide : à budget 3000 plafonné, ABC (6k→3k) serait contraint, le classement pourrait changer — l'exercice garde son intérêt. La ligne Questions (b) "SA (peu d'evals) vs essaim (beaucoup)" est laissée telle quelle : c'est un prompt qualitatif (contraste trajectoire-vs-essaim, conceptuellement valide car ABC fait 2× les evals de SA), pas un nombre — le corriger serait du rewording prose hors-scope.

Diff : 1 ins / 1 del sur le notebook. JSON valide (23 cellules inchangées). Byte-surgical raw-string replace, structure source préservée.

## Vérification firsthand (C976-L — instrumenter avant d'asserter)

- **Re-vérification comptage evals depuis le code** (c7 + c9) :
  - SA : `for (it=0; it<iters; it++) f(xn)` avec `iters=3000` défaut, `SA(f,d,s)` sans override dans c9 → 1 + 3000 = **3001 evals**.
  - PSO : nParts=30 init + 30×100 loop = **3030 evals**.
  - ABC : 30 init + (30 employee + 30 onlooker)×100 cycles + scouts ≈ **6030+ evals**.
- **Self-consistency** : c12 dit déjà "SA 3000 evals" (correct) ; c20 disait "500" (erroné) → le fix aligne c20 sur c12 et le code.
- **Audit complet du notebook (23 cellules)** : le reste est CLEAN — c5 (4 benchmarks Sphere/Rastrigin/Rosenbrock/Ackley, sanity optima=0), c7 (SA/PSO/ABC standard-corrects), c9 (harness 3×4×3=36 runs), c11 (tableau comparatif : gagnants ABC ×4, Rastrigin/Rosenbrock/Ackley unambiguous, Sphere tie résolu ABC<PSO au voisinage de l'optimum), c14 (taux de succes arithmétiquement cohérents avec c11), c22 (synthese). Exercices c17/c19/c21 honest C.1 stubs.

## Diagnostic dérive

- **Classe** : défaut **code-fact** (comptage d'evals erroné en markdown) — c'est un **fait statique/architectural** (déterministe, dénombrable depuis le code : `iters=3000`, `SN=30`, `maxCycles=100`), **PAS une mesure drift-prone** (aucune cause a/env/kernel·c/moteur·d/régression·e/stochasticité). Cause **(b)** : chiffre statique fabriqué/erroné ("500") non sourcé au code.
- **Verdict** : **CAUSE_FIXED** — la correction passe par aligner le chiffre markdown sur le compte réel déterministe (~3000 SA, ~6000 ABC). La valeur corrigée est **déterministe** (structure de boucle figée, reproductible bit-à-bit depuis le code) → aucun risque de drift futur. Fait architectural/combinatoire, pas une mesure drift-prone.
- **Pourquoi markdown-align accepté ici** : cf c.1221-L★★ — les faits statiques/architecturaux (comptage d'evals depuis la structure de boucle) sont cause (b) NOT mesure-drift. La correction aligne un chiffre faux sur le fait déterministe sous-jacent (le code), pas sur une mesure qui re-drift au prochain kernel. Distinct des cas timing/WER/AUC.

## Périmètre & limites

- **1 fichier notebook** (Search-11b-Deep-Part4.ipynb, c20 markdown seul). Markdown-only → pas de re-exec, pas d'output sync, pas de twin (Part4 est une variante Deep C#-only, non jumelée — confirmé : aucune entrée twin_pairs.d ne référence Part4). Race-free (0 PR open touche le fichier).
- **Non touché (DEFER, hors-scope)** : le reste du notebook (c5 benchmarks, c7 algos, c9/c11/c14 harness+table+success, c22 conclusion) est CLEAN. Les timings metaheuristiques (non affichés ici) sont drift-prone par nature mais non-audités ce cycle.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
