### PR TITLE
fix(genai,#8052): correct Bonsai-Image Avantages quantization sizes to match section-2 table

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-5-Bonsai-Image-Ternary.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-5-Bonsai-Image-Ternary.ipynb
@@ -55,7 +55,7 @@
     "\n",
     "### Avantages\n",
     "\n",
-    "- **Taille modèle divisee par ~8** vs FP16 (4 GB vs 32 GB pour 4B paramètres bruts), avec overhead reel proche du minimum théorique.\n",
+    "- **Taille modèle divisee par ~10** vs FP16 (0.74 GB vs 7.45 GB pour 4B paramètres bruts), avec overhead reel proche du minimum théorique.\n",
     "- **Inference plus rapide** sur GPU avec kernels INT2 dedies (Gemlite optimise pour Ampere/Ada/Hopper).\n",
     "- **Qualite preservee** : la perte de qualite vs FP16 est de ~5-10 % sur les benchmarks d'image, vs ~30-50 % pour INT2 naif sans schema ternaire (voir section 5).\n",
     "\n",


### PR DESCRIPTION
## Summary

`02-5-Bonsai-Image-Ternary.ipynb` cell 1 (markdown Avantages) bullet, explicitly scoped "pour 4B parametres bruts", asserted:

> Taille modele divisee par ~8 vs FP16 (4 GB vs 32 GB pour 4B parametres bruts)

This contradicts the SAME notebook's section-2 comparison table (cell 4, `N_PARAMS = 4_000_000_000`, committed output):

| regime | bits_per_weight | taille_GB | ratio_vs_FP16 |
|---|---|---|---|
| FP16 | 16.000 | 7.45 | 1.000 |
| Ternaire 1.58-bit | 1.585 | 0.74 | 0.099 |

So for "4B parametres bruts": FP16 = **7.45 GB** (not 32 GB), ternaire = **0.74 GB** (not 4 GB), ratio **~10x** (not ~8x). Both absolute figures AND reduction ratio were wrong. Arithmetic: 4B x 16 bits / 8 = 8 GB raw = 7.45 GiB; no reading of "4B parametres bruts" in FP16 yields 32 GB (that needs ~16B params).

The #8052 pattern (cf #8993 GenAI/Texte, #8974 Infer-2): prose mis-describes a number in its own committed output. A student cross-checking the Avantages bullet against section 2's table sees the contradiction directly.

## The fix

Markdown-only, 1 bullet in cell 1: `~8` -> `~10`, `4 GB vs 32 GB` -> `0.74 GB vs 7.45 GB`. Code cell 4 and its output untouched. Re-execution not required (markdown-only, C.3 exception; previous outputs valid).

## Verification (firsthand, fresh origin/main worktree)

- Defect confirmed before editing (not from issue body alone): cell1 = ~8 / 4-32 GB, cell4 output = 7.45 FP16 / 0.74 ternaire / ratio 0.099.
- Post-edit: cell1 = ~10 / 0.74-7.45 GB; cell4 output unchanged (asserted `7.45          1.000` + `0.74          0.099` still present); JSON valid; 0 CRLF.
- H.3 validator: PASS.

## §D.5 Diagnostic

- Cause (b) -- claim anterieure erronee (wrong static size figures). Model size = n_params x bytes/param is a static architectural property: it does NOT re-derive on the next kernel pass (unlike a Stopwatch timing / WER / AUC). Either right or wrong.
- Verdict: CAUSE_FIXED. Single bullet aligned to the section-2 committed table (+1/-1, 1 file).

## Scope

One subject (correct the quantization-size figures to match the section-2 table), 1 file, +1/-1. Catalogue byte-identical to main.

Closes #8995

Grain: FIX/genai-image -- lane myia-po-2023:CoursIA -- prev: TEST/validation-tooling #9316

Co-Authored-By: Claude-Code <noreply@anthropic.com>