### PR TITLE
docs(lean,#8960): fix Conservative_en + MayerVietorisSquare_en Partie->Part (#8976 complement)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Conservative_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Conservative_en.lean
@@ -1,5 +1,5 @@
 /-
-Grothendieck Partie 19 — Les familles conservatives de points
+Grothendieck Part 19 — Les familles conservatives de points
 
 La Partie 18 (ConstantSheaf.lean) a introduit le foncteur faisceau constant et son
 adjonction avec les sections globales.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare_en.lean
@@ -1,5 +1,5 @@
 /-
-Grothendieck Partie 21 — Les carrés de Mayer-Vietoris
+Grothendieck Part 21 — Les carrés de Mayer-Vietoris
 
 La Partie 20 (SheafCohomology/Basic.lean) a introduit les groupes de cohomologie
 des faisceaux H^n(F) basés sur Ext, le préfaisceau de cohomologie, et la fonctorialité.


### PR DESCRIPTION
## What

Completes the `grothendieck_lean` Partie-injectivity work from **#8976** (merged). #8976 renumbered the 26/27 collision group (Comma/Limits/Equivalences/Construction/KanExtensions/MonoidalCategories/DirectImage/MathlibMap) to a contiguous injective `1..33` and aligned the README tables — but **missed two EN-sibling files** that still carry spurious FR-style `Partie N` headers (verbatim-copied during incomplete translation). This PR fixes those two files, achieving the full injectivity that #8976 claimed but did not reach.

See #8960 (two incompatible `Partie N` numberings). This is the **complement** to #8976 — the small bounded residual ai-01 measured post-#8976.

## The defect (measured firsthand on origin/main = current main)

Two EN-mirror files carry FR-style headers that collide with their FR twins in scheme B:

| file (origin/main) | line 2 header | collides with |
|---|---|---|
| `Conservative_en.lean` | `Grothendieck Partie 19 — ...` | `Conservative.lean` (`Partie 19`) |
| `MayerVietorisSquare_en.lean` | `Grothendieck Partie 21 — ...` | `MayerVietorisSquare.lean` (`Partie 21`) |

All other EN-sibling files already use the correct EN convention `Part N` (established by #8976): `Comma_en` → `Part 27`, `Limits_en` → `Part 28`, `Equivalences_en` → `Part 29`, etc. `Conservative_en` and `MayerVietorisSquare_en` were the lone holdouts.

## Fix

Minimal docstring-only edit, line 2 of each:
- `Conservative_en.lean`: `Grothendieck Partie 19` → `Grothendieck Part 19`
- `MayerVietorisSquare_en.lean`: `Grothendieck Partie 21` → `Grothendieck Part 21`

Diff: `+2/-2`, comment text only (inside `/- ... -/` block). Proof / tactics / signatures / namespaces byte-identical to origin/main.

## Measurement command + verdict (acceptance criterion 1)

```python
import re, glob, os, collections
base="MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck"
fr=collections.defaultdict(list); en=collections.defaultdict(list)
for f in sorted(glob.glob(f"{base}/*.lean")):
    h3='\n'.join(open(f,encoding='utf-8').read().split('\n')[:3])
    mf=re.search(r'Partie\s+(\d+)', h3)
    me=re.search(r'(?<![a-z])Part\s+(\d+)', h3)
    if mf: fr[int(mf.group(1))].append(os.path.basename(f))
    elif me: en[int(me.group(1))].append(os.path.basename(f))
print("FR collisions:", {n:v for n,v in fr.items() if len(v)>1} or "NONE - injective")
print("EN collisions:", {n:v for n,v in en.items() if len(v)>1} or "NONE - injective")
```

**Verdict (post-edit, on this branch):**
- FR scheme (`Partie N`): **28 files / 28 distinct numbers — NONE carried by 2 files ✓**
- EN scheme (`Part N`): **28 files / 28 distinct numbers — NONE carried by 2 files ✓**
- `Partie 19` sole-carrier = `Conservative.lean`; `Part 19` sole-carrier = `Conservative_en.lean`. Same for 21.

(Pre-edit / on origin/main, the same command reports FR collisions `{19: [...], 21: [...]}` — confirming the defect this PR removes.)

## Acceptance criteria

1. **Injective numbering** ✓ — measured above (command included). No `Partie N` / `Part N` carried by two files.
2. **`lake build` SUCCESS on touched target** — the change is **docstring-only** (comment text inside `/- ... -/`); delimiters balanced (`Conservative_en` 15 opens / 15 closes, `MayerVietorisSquare_en` 11/11); proof/tactics/signatures byte-identical to origin/main which builds clean. Structurally zero compilation impact. (Note: the po-2026 local `grothendieck_lean` cache is partial — 40 local + 238 Mathlib `.olean`, the 2 imported Mathlib modules COLD — so a verify `lake build` would trigger a full Mathlib compile at session scale. The change is provably comment-only, so the touched targets parse+compile identically to main.)
3. **Navmap `MathlibMap*.lean`** ✓ — verified `MathlibMap.lean` / `MathlibMap_en.lean` (on origin/main, post-#8976) reference **neither** `Partie 19`/`Partie 21` **nor** `Conservative`/`MayerVietorisSquare`. The numbers 19/21 are unchanged by this PR (only the FR/EN header language of two `_en` files), so no navmap update is required.

## Collision pre-flight

`gh pr list --state all --search "8960"` → only merged/closed PRs on other sub-topics; #8976 is the relevant one and **does not touch** `Conservative_en` / `MayerVietorisSquare_en` (confirmed by reading its file list firsthand). No open PR on this exact residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
