### PR TITLE
fix(rl): clear setext_oversized in rl_3_experience_replay_dqn cell#34 (HR-separator)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb
@@ -1493,6 +1493,7 @@
     "\n",
     "Avec cela, vous disposez d’une base solide pour traiter des tâches plus complexes en Apprentissage par Renforcement, où l’agent doit atteindre des objectifs spécifiques.",
     "\n",
+    "\n",
     "---\n",
     "**Retour au sommaire** : [Index RL](README.md)\n",
     "\n\n### References academiques\n\n- Andrychowicz, M., Wolski, F., Ray, A., Schneider, J., Fong, R., Welinder, P., McGrew, B., Kohl, J., Zaremba, W. & Abbeel, P. (2017). Hindsight Expérience Replay. NeurIPS 2017. arXiv:1707.01495.\n- Haarnoja, T., Zhou, A., Abbeel, P. & Levine, S. (2018). Soft Actor-Critic: Off-Policy Maximum Entropy Deep Reinforcement Learning with a Stochastic Actor. ICML 2018. arXiv:1801.01290.\n- Lillicrap, T.P., Hunt, J.J., Pritzel, A., Heess, N., Erez, T., Tassa, Y., Silver, D. & Wierstra, D. (2016). Continuous Control with Deep Reinforcement Learning. ICLR 2016. arXiv:1509.02971.\n- Sutton, R.S. & Barto, A.G. (2018). Reinforcement Learning: An Introduction (2nd ed.). MIT Press.\n\n"


### PR DESCRIPTION
Grain: LOW/rl-markdown -- lane myia-po-2023:CoursIA -- prev: MED/genai-rendering #9325

See #8352 (markdown-rendering guard EPIC). Clears 1 setext_oversized occurrence not covered by #9276 (6 notebooks) nor #9285 (Oncology). rl_3_experience_replay_dqn was the 8th and last remaining setext_oversized flagged by detect_markdown_rendering.

## Defect

cell#34 (markdown, Conclusion). A `---` directly under a text line (no blank line) is a setext H2 underline: the preceding paragraph `Avec cela, vous disposez d une base solide pour traiter des taches plus complexes...` was promoted to an absurd H2 heading. The `---` separates the conclusion from the `Retour au sommaire` link — it is meant as an `<hr>` separator, not a heading.

## Fix

Insert one blank line before the `---` (mirrors the #9276 HR-separator pattern on Diagnostic-Medical: same `+    "\n",` insertion). The `---` now renders as an `<hr>` separator as intended.

## Gates

- detect_markdown_rendering: rl_3 cell#34 no longer flagged; setext_oversized 8 -> 7 repo-wide (remaining 7 are #9276 + #9285 pending merge)
- code-cell sha256: 13/13 unchanged
- outputs: 46 unchanged
- structural audit: ONLY cell#34 source differs (one blank-line element added); every other cell + top-level metadata byte-identical
- C.2 markdown-only exception: no re-exec needed (only cell#34 markdown touched)
- H.3 validator: PASS
- idempotent: blank line already present -> not re-applied

Diff: 1 file, 1 insertion, 0 deletions (surgical).

Co-Authored-By: Claude-Code <noreply@anthropic.com>