### PR TITLE
fix(cost,#8056): rl-cpu gate cuda-probe FP + populate rl_6e_grpo cost (17th RL NB)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb
@@ -842,6 +842,23 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.13"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 0,
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "metadata_written": "2026-08-04",
+   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/scripts/audit/check_cost_metadata.py
+++ b/scripts/audit/check_cost_metadata.py
@@ -74,10 +74,15 @@ import yaml
 # === Patterns de détection ===
 
 # Cellule code GPU
+# Note FP-c.831 : `torch.cuda.is_available()` est une SONDE bénigne (affichée pour
+# info par les notebooks PyTorch CPU pédagogiques, ex rl_6e GRPO — output committé
+# « CUDA=False », tourne en CPU). On l'exonère via lookahead négatif ; les vrais
+# signaux GPU (`torch.cuda.synchronize`, `torch.cuda.empty_cache`, `.cuda()`,
+# `.to("cuda")`) restent détectés.
 GPU_PATTERNS = [
     r'\.cuda\(\)',
     r'\.to\("cuda"\)',
-    r'torch\.cuda\.',
+    r'torch\.cuda\.(?!is_available\b)',
     r'tensorflow\.gpu',
     r'with\s+tf\.device\(["\']/gpu',
 ]

--- a/scripts/audit/populate_cost_metadata.py
+++ b/scripts/audit/populate_cost_metadata.py
@@ -360,8 +360,10 @@ def build_search_cpu_cost(nb: dict, by: str, today: str) -> dict:
 # appel API cloud ne soit fait — gymnasium/SB3 sont des libs LOCALES. Le `_API_RE`
 # générique (mot isolé « openai ») FP-skipperait rl_1 (intro CartPole), rl_6c (PPO),
 # rl_6d (SAC) — les notebooks les plus pédagogiques. On matche donc un VRAI appel API
-# (import/instance), pas le mot isolé. Le signal GPU réel (`torch.cuda`,
-# `.cuda(`) est conservé → rl_6e (GRPO, CUDA-hard) reste correctement skippé.
+# (import/instance), pas le mot isolé. Le signal GPU réel (`.cuda(`,
+# `torch.cuda.synchronize`) est conservé ; la SONDE `torch.cuda.is_available()`
+# (bénigne, affichée pour info par les notebooks CPU pédagogiques) est neutralisée —
+# corrige le faux-négatif rl_6e (GRPO from-scratch = CPU pédagogique, CUDA=False).
 _RL_API_RE = re.compile(
     # Imports explicites des SDK cloud (jamais en prose) — couvre `import openai`,
     # `from openai import …`, `import anthropic`, `from anthropic import Anthropic`.
@@ -376,19 +378,30 @@ _RL_API_RE = re.compile(
 )
 
 
+_CUDA_AVAIL_PROBE_RE = re.compile(r"torch\.cuda\.is_available\s*\(\s*\)")
+
+
 def is_rl_cpu_pure(nb: dict) -> bool:
     """True si notebook RL CPU-pur : pas de QuantBook, pas de GPU réel, pas d'appel
     API cloud explicite.
 
     Plus précise que `is_cpu_pure` pour RL : ignore le FP prose « openai »
     (gym.openai.com, « jeux d'OpenAI ») qui n'est PAS un appel API. Gymnasium et
-    stable-baselines3 sont des libs locales CPU. Le signal GPU réel (`torch.cuda`,
-    `.cuda(`) est conservé (rl_6e GRPO = CUDA-hard → skippé).
+    stable-baselines3 sont des libs locales CPU.
+
+    Sonde CUDA ≠ exigence CUDA : beaucoup de notebooks PyTorch pédagogiques
+    affichent `torch.cuda.is_available()` pour information puis tournent en CPU
+    (`device="cpu"`). On neutralise cette SONDE avant `_GPU_RE` pour ne pas la
+    confondre avec un usage GPU réel. Le vrai signal GPU (`.cuda(`,
+    `torch.cuda.synchronize`, `.to('cuda')`) reste détecté. Corrige le
+    faux-négatif sur rl_6e (GRPO from-scratch, CPU pédagogique — output committé
+    « PyTorch 2.11.0+cpu, CUDA=False », entraînement multi-seed complet sur CPU).
     """
     if _uses_quantbook(nb):
         return False
     src = _source_text(nb)
-    if _GPU_RE.search(src):  # torch.cuda.is_available() etc. → GPU réel
+    src_no_probe = _CUDA_AVAIL_PROBE_RE.sub("", src)
+    if _GPU_RE.search(src_no_probe):  # .cuda(, torch.cuda.synchronize, ... → GPU réel
         return False
     if _ACCOUNT_RE.search(src):  # token / env-var secret
         return False

--- a/scripts/audit/tests/test_check_cost_metadata.py
+++ b/scripts/audit/tests/test_check_cost_metadata.py
@@ -112,6 +112,16 @@ def test_litmus1_gpu_declared_no_finding(tmp_path):
     assert "gpu_used_but_not_declared" not in _patterns(res["findings"])
 
 
+def test_litmus1_cuda_availability_probe_is_not_gpu_usage(tmp_path):
+    """La SONDE `torch.cuda.is_available()` (affichée pour info par les notebooks
+    PyTorch CPU pédagogiques) ne doit PAS déclencher gpu_used_but_not_declared.
+    Couvre rl_6e (GRPO from-scratch, CPU pédagogique — output committé CUDA=False).
+    FP corrigé c.831 : la sonde ≠ exigence/usage GPU."""
+    code = "import torch\nprint(torch.cuda.is_available())\nx = torch.FloatTensor([1.0])"
+    res = _findings_for(tmp_path, code, cost_meta={"gpu_required": False})
+    assert "gpu_used_but_not_declared" not in _patterns(res["findings"])
+
+
 # ---------------------------------------------------------------------------
 # Litmus 2 — api_used_but_cost_zero (FP guard: local provider, #8589)
 # ---------------------------------------------------------------------------
@@ -553,12 +563,15 @@ def test_litmus9_detail_names_the_cell_indices(tmp_path):
 
 
 def _fleet_notebooks(tmp_path):
-    """Trois notebooks : deux porteurs de findings distincts, un sain."""
+    """Trois notebooks : deux porteurs de findings distincts, un sain.
+    a/b utilisent un VRAI signal GPU non déclaré (model.cuda()) — la sonde
+    torch.cuda.is_available() est bénigne (FP corrigé c.831) et ne porte pas
+    de finding, donc on ne l'utilise plus comme finding-bearer ici."""
     a = tmp_path / "a.ipynb"
-    _notebook(a, ["import torch; torch.cuda.is_available()"],
+    _notebook(a, ["import torch", "model = net.cuda()"],
               cost_meta={"validator": "papermill", "gpu_required": False})
     b = tmp_path / "sub" / "b.ipynb"
-    _notebook(b, ["import torch; torch.cuda.is_available()"],
+    _notebook(b, ["import torch", "model = net.cuda()"],
               cost_meta={"validator": "manual", "gpu_required": False})
     clean = tmp_path / "clean.ipynb"
     _notebook(clean, ["x = 1"], cost_meta={"validator": "manual", "gpu_required": False})

--- a/scripts/audit/tests/test_populate_cost_metadata.py
+++ b/scripts/audit/tests/test_populate_cost_metadata.py
@@ -342,7 +342,9 @@ def test_search_cpu_preserves_cells(tmp_path):
 
 def _make_rl_cpu(n_code: int = 10, gpu: bool = False) -> dict:
     """Un notebook RL CPU-pur minimal (gymnasium/stable-baselines3), n cellules code.
-    Si `gpu=True`, ajoute un vrai signal GPU (torch.cuda) pour tester le skip."""
+    Si `gpu=True`, ajoute un VRAI signal GPU (transfert explicite .cuda()) pour tester le skip.
+    (Uniquement `torch.cuda.is_available()` ne compte PAS — c'est une sonde bénigne,
+    cf test_is_rl_cpu_pure_true_for_cuda_availability_probe.)"""
     nb = {
         "cells": [
             {"cell_type": "markdown", "metadata": {},
@@ -352,7 +354,7 @@ def _make_rl_cpu(n_code: int = 10, gpu: bool = False) -> dict:
         "nbformat": 4, "nbformat_minor": 5,
     }
     first = ("import torch\n"
-             f"print(torch.cuda.is_available())  # info\n") if gpu else "import gymnasium as gym\n"
+             "model = Policy().cuda()  # real GPU transfer\n") if gpu else "import gymnasium as gym\n"
     nb["cells"].append({"cell_type": "code", "execution_count": 1, "metadata": {},
                         "outputs": [], "source": [first]})
     for _ in range(n_code - 1):
@@ -384,9 +386,25 @@ def test_is_rl_cpu_pure_false_for_quantbook():
 
 
 def test_is_rl_cpu_pure_false_for_real_gpu():
-    """Vrai signal GPU (`torch.cuda`, `.cuda(`) → skippé. Couvre rl_6e (GRPO, CUDA-hard)."""
+    """Vrai signal GPU (transfert explicite `.cuda()`, `torch.cuda.synchronize`) → skippé.
+    Le gate reste conservateur sur l'usage GPU réel : un notebook qui déplace tenseurs/modèles
+    vers le GPU n'est PAS CPU-pur."""
     assert not pcm.is_rl_cpu_pure(_make_rl_cpu(10, gpu=True))
     assert not pcm.is_rl_cpu_pure(_nb_with("device = torch.device('cuda')\nx = x.cuda()\n"))
+    assert not pcm.is_rl_cpu_pure(_nb_with("torch.cuda.synchronize()\n"))
+
+
+def test_is_rl_cpu_pure_true_for_cuda_availability_probe():
+    """Sonde CUDA ≠ exigence CUDA : un notebook qui affiche `torch.cuda.is_available()`
+    pour info puis tourne en CPU (`device="cpu"`) reste rl-cpu-pur. Couvre rl_6e (GRPO
+    from-scratch, CPU pédagogique — output committé « PyTorch 2.11.0+cpu, CUDA=False »,
+    entraînement multi-seed [0,7,42] complet sur CPU). La sonde seule ne doit PAS
+    skipper — c'était le faux-négatif qui laissait rl_6e sans cost metadata."""
+    src_probe = ("import torch\n"
+                 "print(f'CUDA={torch.cuda.is_available()}')\n"
+                 "def rollout(env, policy, device='cpu'):\n"
+                 "    return torch.FloatTensor(s).to(device)\n")
+    assert pcm.is_rl_cpu_pure(_nb_with(src_probe))
 
 
 def test_is_rl_cpu_pure_false_for_real_api_call():


### PR DESCRIPTION
## What

Fixes a real false-negative in the rl-cpu cost gate, then populates `metadata.cost` on `rl_6e_grpo_from_scratch.ipynb` — the lone RL notebook left without cost metadata. Completes the RL cost-metadata family (#8666 covered 16/17 RL notebooks; this adds the 17th that the gate FP blocked).

See #8056 (matrice coût/ressource).

## The defect (verified firsthand against committed output)

`rl_6e_grpo_from_scratch.ipynb` was skipped by the `rl-cpu` gate as "CUDA-hard". The assumption (in both the populate gate `is_rl_cpu_pure` and the validator `check_cost_metadata` `GPU_PATTERNS`) was that `torch.cuda.is_available()` = GPU usage. It is not — it is an availability **probe**. The notebook's **committed output** proves it runs on CPU:

```
CODE[2] output: PyTorch 2.11.0+cpu, CUDA=False
CODE[11] output: seed 0/7/42 trained, "Entrainement termine."
CODE[13] output: VERDICT GRPO, "GRPO Sharpe (moyenne cross-seed) : +0.023"
```

- PyTorch **CPU wheel** (`2.11.0+cpu`), `CUDA=False`
- `device="cpu"` throughout (default + explicit in `CODE[10]`/`CODE[11]`)
- synthetic portfolio (no network), multi-seed `[0,7,42]` with `torch.manual_seed`/`np.random.seed`
- config comment: "config légères pour pédagogie CPU, ~2-4 min"

So rl_6e is genuinely CPU-pedagogical — exactly what `rl-cpu` is meant to cover.

## The fix (consistent across both detection paths)

| File | Change |
|---|---|
| `populate_cost_metadata.py` `is_rl_cpu_pure` | Neutralize the `torch.cuda.is_available()` probe before `_GPU_RE`; real GPU usage (`.cuda(`, `torch.cuda.synchronize`, `.to('cuda')`) still skips correctly. |
| `check_cost_metadata.py` `GPU_PATTERNS` | `torch\.cuda\.(?!is_available\b)` so the probe no longer triggers `gpu_used_but_not_declared`; real signals kept. |
| `populate_cost_metadata.py` + `check_cost_metadata.py` | Correct the stale comments/docstrings ("rl_6e GRPO = CUDA-hard" → rl_6e is CPU-pedagogical). |

Then populate rl_6e via the canonical `--profile rl-cpu`:

```yaml
metadata.cost:
  api_usd_est: 0.0, api_provider: none, qcc_tokens_est: 0
  cpu_min: 2, gpu_min: 0, gpu_required: false
  vram_gb: 0, vram_tier: NONE
  network: false, external_account: none
  free_alternative: self      # already free (local CPU)
  reduced_pedagogical: null   # notebook-specific, honestly null (not fabricated)
  reproducibility: MED        # RL training is stochastic (seeds) — rl-cpu profile convention
  validator: manual           # source inspection, not a machine re-exec claim
```

Honest: `reproducibility: MED` (RL training stochasticity, per rl-cpu profile), `reduced_pedagogical: null` (not fabricated), `validator: manual` (source inspection against committed output).

## Tests (84 passed, 0 regression)

`scripts/audit/tests/test_populate_cost_metadata.py` + `test_check_cost_metadata.py`:
- **Added** `test_is_rl_cpu_pure_true_for_cuda_availability_probe` — a notebook with only the probe + `device="cpu"` IS rl-cpu-pure (the corrected rl_6e case).
- **Added** `test_litmus1_cuda_availability_probe_is_not_gpu_usage` — the probe does not trigger `gpu_used_but_not_declared`.
- **Updated** `_make_rl_cpu(gpu=True)` and `_fleet_notebooks` to use a real `.cuda()` signal instead of the probe (the fleet fixture's "finding-bearer" notebooks must bear a *real* finding).
- All 84 tests green; validator reports 0 findings on rl_6e.

## Diff

5 files, +78/−12:
- `rl_6e_grpo_from_scratch.ipynb` +17 (metadata.cost only — no cell/source/output/execution_count changed)
- `populate_cost_metadata.py` +18/−5 (gate fix + comment)
- `check_cost_metadata.py` +6/−1 (GPU_PATTERNS fix + comment)
- 2 test files +37/−6

## Collision pre-flight

`gh pr list --search "rl_6e cost"` / `"grpo cost 8056"` → only #8666/#8867 (merged, covered the other 16 RL notebooks, excluded rl_6e via this FP). No open PR. Base fresh on origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
