### PR TITLE
fix(smartcontracts,#9335): SC-11 provider deterministic (not runner-env)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
@@ -1317,7 +1317,9 @@
    "source": [
     "## 6. Integration avec l'API Anthropic Claude\n",
     "\n",
-    "Exemple d'integration complete avec Claude Sonnet 4.6 pour un workflow de développement.\n\n> **Note (depend de la config)** : `SolidityLLMAssistant` privilegie Anthropic Claude par defaut (`client_type=\"anthropic\"`) et bascule sur le fallback OpenAI quand la cle `ANTHROPIC_API_KEY` est absente. La sortie d'execution ci-dessous affiche donc `openai (gpt-4o)` (fallback faute de cle configuree) ; avec une cle Anthropic, elle afficherait `anthropic (claude-sonnet-4-6)`. Le reste du workflow s'execute en mode mock (generation de templates sans appel API reel)."
+    "Exemple d'integration complete avec Claude Sonnet 4.6 pour un workflow de développement.\n",
+    "\n",
+    "> **Note (deterministe)** : l'assistant est epingle a `client_type=\"anthropic\"` pour coherer avec le titre de section — la sortie commitee est donc identique sur toute machine, independamment des cles API presentes dans l'environnement. Sans `ANTHROPIC_API_KEY` configuree, le workflow s'execute en mode mock (generation de templates sans appel API reel) ; le mode actif est imprime avec la sortie ci-dessous. Configurer une cle activerait les veritables appels Anthropic Claude."
    ]
   },
   {
@@ -1345,7 +1347,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Assistant initialise avec openai (gpt-4o)\n"
+      "Assistant initialise avec anthropic (claude-sonnet-4-6) -- mode: mock (cle API absente -- aucun appel reseau)\n"
      ]
     }
    ],
@@ -1422,9 +1424,13 @@
     "        }\n",
     "\n",
     "\n",
-    "# Initialiser l'assistant\n",
-    "assistant = SolidityLLMAssistant(client_type=\"anthropic\" if anthropic_client else \"openai\")\n",
-    "print(f\"Assistant initialise avec {assistant.client_type} ({assistant.model})\")"
+    "# Initialiser l'assistant (provider epingle pour la reproductibilite, cause #9335).\n",
+    "# client_type=\"anthropic\" est deterministe pour coherer avec le titre de section ;\n",
+    "# la sortie ne depend plus de la presence d'une cle API sur le runner. Le mode mock\n",
+    "# reste actif sans cle configuree : aucun appel reseau, sortie reproductible.\n",
+    "assistant = SolidityLLMAssistant(client_type=\"anthropic\")\n",
+    "_mode = \"mock (cle API absente -- aucun appel reseau)\" if assistant.client is None else \"API reelle (cle configuree)\"\n",
+    "print(f\"Assistant initialise avec {assistant.client_type} ({assistant.model}) -- mode: {_mode}\")"
    ]
   },
   {


### PR DESCRIPTION
## What

Fixes the root cause of #9335: `SC-11-LLM-Assisted.ipynb` committed an output that **depended on the runner's environment**.

`SolidityLLMAssistant(client_type=\"anthropic\" if anthropic_client else \"openai\")` meant the committed output was `openai (gpt-4o)` (no `ANTHROPIC_API_KEY` on the runner) while the section title MD[28] promised **« Integration avec l'API Anthropic Claude »**. #9107 documented this honestly (`CAUSE_DOCUMENTED_ONLY`); this PR fixes the cause.

## Fix — voie 1 + voie 3 (deterministic + self-explicative)

- **CODE[29]**: pin `client_type=\"anthropic\"` deterministically. This **aligns the demo with its own section title** (the section is *about* Anthropic Claude), it is not a scope change. The active mode is now printed: `Assistant initialise avec anthropic (claude-sonnet-4-6) -- mode: mock (cle API absente -- aucun appel reseau)`.
- **MD[28]**: the #9107 caveat is reframed from « depend de la config » (describing the env-dependence) to « deterministe » (explaining the pinning choice) — the caveat « reste comme explication du choix » per #9335.

Mock mode is preserved: without a key, `assistant.client is None` ⇒ no network call, `generate_contract`/`audit_contract`/`generate_natspec` fall back to their mock templates. **The committed output is now identical on every machine**, regardless of which API keys are present.

## Validation (C.2)

- Re-executed end-to-end **in-process** (`mcp-jupyter-py310`, `anthropic` installed to match the committed `HAS_ANTHROPIC=True` state per Rule F, **both API keys unset** ⇒ mock mode reproduced). **20 code cells, 0 errors.**
- Only the instantiation cell's output changed (`openai (gpt-4o)` → `anthropic (claude-sonnet-4-6) -- mode: mock...`); **all other outputs byte-identical** to committed (config cell still reports both clients « Non configure »).
- `git diff`: 1 file, +11/−5, surgical (2 source cells + 1 output line). No stray churn.
- H.3 PASS (no `execution_count: null` with outputs); C.1 PASS (no `raise NotImplementedError`).

## Family check (acceptance)

`grep` of `SymbolicAI/SmartContracts/**/*.ipynb` for the env-dependent provider pattern (`client_type="..." if ..._client`) hits **SC-11 only** — the other notebooks are indemnes.

## Acceptance vs #9335

- [x] Committed output no longer depends on the runner env (pinned → deterministic).
- [x] Section title and output no longer contradict (both Anthropic).
- [x] No real LLM call introduced; mock mode remains the committed mode.
- [x] Other SC notebooks sharing the motif: declared indemnes (grep measure above).
- [x] C.2 respected (modified code cell re-executed).

Closes #9335. See #8052 (§D.5 audit), #9107 (the CAUSE_DOCUMENTED_ONLY fix whose cause this resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)