### PR TITLE
fix(sc,#8052): SC-11 LLM-provider determinism (issue #9335 voie 3) — pin to notebook constant

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
@@ -6,10 +6,10 @@
    "id": "a1bead61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T14:04:21.255786Z",
-     "iopub.status.busy": "2026-06-05T14:04:21.255786Z",
-     "iopub.status.idle": "2026-06-05T14:04:21.266338Z",
-     "shell.execute_reply": "2026-06-05T14:04:21.265332Z"
+     "iopub.execute_input": "2026-08-04T00:36:55.209933Z",
+     "iopub.status.busy": "2026-08-04T00:36:55.209599Z",
+     "iopub.status.idle": "2026-08-04T00:36:55.215233Z",
+     "shell.execute_reply": "2026-08-04T00:36:55.214020Z"
     },
     "papermill": {
      "duration": 0.017832,
@@ -25,7 +25,13 @@
    "outputs": [],
    "source": [
     "# Parameters\n",
-    "BATCH_MODE = \"true\"\n"
+    "BATCH_MODE = \"true\"\n",
+    "\n",
+    "# Fournisseur LLM pour le run pedagogique (CONSTANTE du notebook,\n",
+    "# independante des cles d'environnement -> run DETERMINISTE : deux machines\n",
+    "# differemment configurees produisent la meme sortie). Cf. issue #9335.\n",
+    "# Valeurs: \"openai\" (gpt-4o, mode mock, aucun appel API reel) | \"anthropic\".\n",
+    "DEFAULT_PROVIDER = \"openai\"\n"
    ]
   },
   {
@@ -1315,9 +1321,11 @@
     "tags": []
    },
    "source": [
-    "## 6. Integration avec l'API Anthropic Claude\n",
+    "## 6. Intégration des APIs LLM (OpenAI / Anthropic)\n",
     "\n",
-    "Exemple d'integration complete avec Claude Sonnet 4.6 pour un workflow de développement.\n\n> **Note (depend de la config)** : `SolidityLLMAssistant` privilegie Anthropic Claude par defaut (`client_type=\"anthropic\"`) et bascule sur le fallback OpenAI quand la cle `ANTHROPIC_API_KEY` est absente. La sortie d'execution ci-dessous affiche donc `openai (gpt-4o)` (fallback faute de cle configuree) ; avec une cle Anthropic, elle afficherait `anthropic (claude-sonnet-4-6)`. Le reste du workflow s'execute en mode mock (generation de templates sans appel API reel)."
+    "Exemple d'intégration complète via `SolidityLLMAssistant`, une abstraction qui porte les deux fournisseurs (OpenAI et Anthropic Claude) et bascule entre eux par le paramètre `client_type`.\n",
+    "\n",
+    "> **Fournisseur déterministe (issue #9335).** Le run pédagogique épingle le fournisseur à la constante `DEFAULT_PROVIDER` (c0), **indépendante des clés d'environnement** : deux machines différemment configurées produisent une sortie identique sur la cellule d'instanciation. Le workflow s'exécute en mode mock (génération de templates sans appel API réel). Pour basculer le fournisseur démontré, changez `DEFAULT_PROVIDER` dans c0."
    ]
   },
   {
@@ -1326,10 +1334,10 @@
    "id": "bb827d76",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T14:04:24.053524Z",
-     "iopub.status.busy": "2026-06-05T14:04:24.053524Z",
-     "iopub.status.idle": "2026-06-05T14:04:24.074869Z",
-     "shell.execute_reply": "2026-06-05T14:04:24.073792Z"
+     "iopub.execute_input": "2026-08-04T00:36:56.813753Z",
+     "iopub.status.busy": "2026-08-04T00:36:56.813368Z",
+     "iopub.status.idle": "2026-08-04T00:36:56.823245Z",
+     "shell.execute_reply": "2026-08-04T00:36:56.822013Z"
     },
     "papermill": {
      "duration": 0.029449,
@@ -1345,7 +1353,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Assistant initialise avec openai (gpt-4o)\n"
+      "Assistant initialise avec openai (gpt-4o)\n",
+      "Fournisseur pedagogique = 'openai' (constante du notebook, deterministe)\n"
      ]
     }
    ],
@@ -1423,8 +1432,12 @@
     "\n",
     "\n",
     "# Initialiser l'assistant\n",
-    "assistant = SolidityLLMAssistant(client_type=\"anthropic\" if anthropic_client else \"openai\")\n",
-    "print(f\"Assistant initialise avec {assistant.client_type} ({assistant.model})\")"
+    "# Instanciation DETERMINISTE : fournisseur epingle a DEFAULT_PROVIDER\n",
+    "# (constante du notebook, pas une variable d'environnement) -> reproductible\n",
+    "# sur toute machine. Cf. issue #9335 (voie 3 choisie).\n",
+    "assistant = SolidityLLMAssistant(client_type=DEFAULT_PROVIDER)\n",
+    "print(f\"Assistant initialise avec {assistant.client_type} ({assistant.model})\")\n",
+    "print(f\"Fournisseur pedagogique = {DEFAULT_PROVIDER!r} (constante du notebook, deterministe)\")"
    ]
   },
   {


### PR DESCRIPTION
fix(sc,#8052): SC-11 LLM-provider determinism (issue #9335, voie 3) — pin to notebook constant, independent of env keys

Closes #9335 (child issue of merged #9107 §D.5 CAUSE_DOCUMENTED_ONLY → now CAUSE_FIXED structurally).

Grain: MED/identity — lane myia-po-2024:CoursIA-2 — prev: MED/value #9085 GT-14 (R6 family-variety pivot to SmartContracts, distinct family)

## Le défaut résiduel (#9335)

`SC-11-LLM-Assisted.ipynb` c29 instancie son assistant ainsi :

```python
assistant = SolidityLLMAssistant(client_type="anthropic" if anthropic_client else "openai")
```

La sortie commitée dépendait donc de **quelle variable d'environnement était définie sur la machine d'exécution** : `ANTHROPIC_API_KEY` présente → `anthropic (claude-sonnet-4-6)`, absente → `openai (gpt-4o)`. Au run commité elle était absente, d'où la section c28 titrée « Intégration avec l'API Anthropic Claude » dont la sortie affichait `Assistant initialise avec openai (gpt-4o)` — non-reproductible : le prochain agent sur une machine Anthropic-configurée produirait un diff de sortie sans rien changer au code.

#9107 avait documenté honnêtement la config-dépendance (caveat en prose). #9335 demande de rendre la cause **structurellement déterministe** (pas seulement documentée).

## Fix — voie 3 (least invasive, most honest — issue's recommendation)

**Pin le fournisseur à une CONSTANTE du notebook**, indépendante des clés d'environnement :

1. **c0 (Parameters)** — ajoute `DEFAULT_PROVIDER = "openai"` (constante de configuration du notebook). Commentaire documente : « CONSTANTE du notebook, indépendante des clés d'environnement → run DETERMINISTE ».
2. **c29 (instantiation)** — `client_type=DEFAULT_PROVIDER` (au lieu du ternaire `if anthropic_client else "openai"`). + ligne de sortie explicative : `Fournisseur pedagogique = 'openai' (constante du notebook, deterministe)` → tout futur diff de sortie est auto-explicatif.
3. **c28 (section title + note)** — titre `## 6. Intégration des APIs LLM (OpenAI / Anthropic)` (couvre réellement les deux fournisseurs — la classe porte les deux) + note déterministe (rempplace le caveat env-dépendant de #9107).

## Preuve de déterminisme (firsthand, instrumentée AVANT d'asserter)

Re-exécution **deux fois** avec configurations différentes :

| Environnement | Sortie c29 |
|---|---|
| Aucune clé (runner vierge) | `openai (gpt-4o)` + ligne déterministe |
| `ANTHROPIC_API_KEY` set (machine Anthropic) | **`openai (gpt-4o)`** (IDENTIQUE — DEFAULT_PROVIDER gagne, pas la clé env) |

→ **Critère d'acceptation #9335 rempli** : deux machines différemment configurées produisent une sortie identique sur la cellule d'instanciation.

**Mode mock préservé** : aucun appel LLM réel introduit (la voie « re-exécuter avec ANTHROPIC_API_KEY pour faire coller la sortie au titre » est explicitement exclue par #9335 — la classe g12/g18/g24 déclencherait de vrais appels Anthropic). Le workflow s'exécute en mode mock (templates sans appel API).

## Scan de famille (critère d'acceptation #9335)

`git grep -nE "if (anthropic_client|openai_client)|client_type=\"(anthropic|openai)\" if" origin/main -- SmartContracts/` : **SC-11 est le SEUL notebook** de la famille (20 notebooks SC scannés) avec le motif provider-dépendant-de-l'environnement. Les 4 correspondances sont toutes dans SC-11 lui-même. Famille déclarée **indemne** avec mesure à l'appui.

## Diagnostic dérive (§D.5)

- **Cause (e) → maintenant CAUSE_FIXED (structurel, pas documenté).** La dérive était une **stochasticité d'environnement** (cause **e**) : la sortie pédagogique était décidée par la présence d'une clé d'environnement sur le runner, pas par le code du notebook. Le correctif **élimine la cause** (le fournisseur est désormais une constante du notebook, indépendante de l'environnement) — la sortie ne peut plus diverger entre machines. Distinct d'une mesure volatile (timing/WER) : ici la valeur est un label de provider, et le fix la **rend déterministe par construction**, pas par re-alignement markdown.
- **Verdict : CAUSE_FIXED.** La cause (config-dépendance) ne survit pas la PR — elle est supprimée structurellement, pas documentée. Le caveat de #9107 devient superflu (remplacé par la note déterministe c28). Aucune issue fille due.

## Périmètre & limites

- **1 fichier** (`SC-11-LLM-Assisted.ipynb`), **3 cellules** (c0/c28/c29) + sortie c29 régénérée. Diff byte-surgical : 27 ins / 14 del. Cellules non-modifiées : outputs + metadata (timestamps) **préservés** du commit (restauration post-re-exec) → diff minimal, pas de churn de timestamps sur 50 cellules.
- **C.2 respectée** : c0 + c29 re-exécutées (mode mock, 0 appel API réel). LF-only (0 CRLF). 54 cellules préservées.
- **Non touché (exclu par #9335)** : re-exécuter avec `ANTHROPIC_API_KEY` pour « faire coller » la sortie au titre Anthropic (déclencherait de vrais appels API, sortirait du mode mock, non-reproductible, facturable). #9107 avait déjà instruit et rejeté cette voie.

See #9335, #9107, #8052, #8957

---
lane: myia-po-2024:CoursIA-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
