### PR TITLE
fix(audiobook,#8052): 04-13 WER recap — fresh re-execution (§D.5 follow-up to #9068)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-13-Audiobook-FishAudio-S2Pro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-13-Audiobook-FishAudio-S2Pro.ipynb
@@ -3,66 +3,244 @@
   {
    "cell_type": "markdown",
    "id": "c96aaa95",
-   "source": "# Audiobook Agentique avec FishAudio S2-Pro\n\n**Module :** 04-Audio-Applications  \n**Niveau :** Applications avancees  \n**Technologies :** FishAudio S2-Pro, Whisper STT, GPT-4o-mini, pydub  \n**VRAM estimee :** ~6 GB (FishAudio S2-Pro sur GPU)  \n**Duree estimee :** 60 minutes  \n\n## Objectifs d'Apprentissage\n\n- [ ] Comprendre l'architecture d'un pipeline audiobook 8 phases (P0-P7)\n- [ ] Maitriser les 29 balises de prosodie officielles FishAudio S2-Pro\n- [ ] Executer l'annotation prosodique (P4) sur un extrait litteraire\n- [ ] Generer du TTS avec clonage vocal via FishAudio S2-Pro\n- [ ] Valider la qualite audio par mesure WER (Word Error Rate) avec Whisper\n\n## Prerequis\n\n- Notebook 04-6 (Pipeline Audiobook) pour les fondamentaux\n- Notebook 04-9 (Voice Casting) recommande\n- Cle API OpenAI configuree (`OPENAI_API_KEY` dans `.env`)\n- Service FishAudio S2-Pro actif (Docker, port 8197)\n- Service Whisper STT actif (Docker, port 8190)\n\n**Navigation :** [Index](../README.md) | [<< Précédent](04-12-Compilation-Audio.ipynb)",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "# Audiobook Agentique avec FishAudio S2-Pro\n",
+    "\n",
+    "**Module :** 04-Audio-Applications  \n",
+    "**Niveau :** Applications avancees  \n",
+    "**Technologies :** FishAudio S2-Pro, Whisper STT, GPT-4o-mini, pydub  \n",
+    "**VRAM estimee :** ~6 GB (FishAudio S2-Pro sur GPU)  \n",
+    "**Duree estimee :** 60 minutes  \n",
+    "\n",
+    "## Objectifs d'Apprentissage\n",
+    "\n",
+    "- [ ] Comprendre l'architecture d'un pipeline audiobook 8 phases (P0-P7)\n",
+    "- [ ] Maitriser les 29 balises de prosodie officielles FishAudio S2-Pro\n",
+    "- [ ] Executer l'annotation prosodique (P4) sur un extrait litteraire\n",
+    "- [ ] Generer du TTS avec clonage vocal via FishAudio S2-Pro\n",
+    "- [ ] Valider la qualite audio par mesure WER (Word Error Rate) avec Whisper\n",
+    "\n",
+    "## Prerequis\n",
+    "\n",
+    "- Notebook 04-6 (Pipeline Audiobook) pour les fondamentaux\n",
+    "- Notebook 04-9 (Voice Casting) recommande\n",
+    "- Cle API OpenAI configuree (`OPENAI_API_KEY` dans `.env`)\n",
+    "- Service FishAudio S2-Pro actif (Docker, port 8197)\n",
+    "- Service Whisper STT actif (Docker, port 8190)\n",
+    "\n",
+    "**Navigation :** [Index](../README.md) | [<< Précédent](04-12-Compilation-Audio.ipynb)"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "893e7da1",
-   "source": "# Parametres Papermill - JAMAIS modifier ce commentaire\n\n# Configuration notebook\nnotebook_mode = \"interactive\"\nskip_widgets = False\ndebug_level = \"INFO\"\n\n# Parametres pipeline v4\nllm_model = \"gpt-4o-mini\"\ndemo_segment_start = 0\ndemo_segment_end = 5  # Extraits courts pour la demonstration\nfishaudio_url = \"http://localhost:8197\"\nwhisper_url = \"http://localhost:8190/v1/audio/transcriptions\"\nwer_threshold = 0.15  # 15% WER max acceptable\n\n# Configuration FishAudio\nfishaudio_reference_ids = {\n    \"narrateur\": \"v4_narrator_male_neutral\",\n    \"elisabeth_rousset\": \"v4_boule_warm_distressed\",\n    \"comte\": \"v4_comte_onctuous\",\n}\n\n# Configuration sauvegarde\ngenerate_audio = True\nsave_audio_files = True",
-   "metadata": {},
    "execution_count": 1,
-   "outputs": []
+   "id": "893e7da1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-04T00:49:14.895554Z",
+     "iopub.status.busy": "2026-08-04T00:49:14.895324Z",
+     "iopub.status.idle": "2026-08-04T00:49:14.899622Z",
+     "shell.execute_reply": "2026-08-04T00:49:14.899070Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Parametres Papermill - JAMAIS modifier ce commentaire\n",
+    "\n",
+    "# Configuration notebook\n",
+    "notebook_mode = \"interactive\"\n",
+    "skip_widgets = False\n",
+    "debug_level = \"INFO\"\n",
+    "\n",
+    "# Parametres pipeline v4\n",
+    "llm_model = \"gpt-4o-mini\"\n",
+    "demo_segment_start = 0\n",
+    "demo_segment_end = 3  # Extraits courts pour la demonstration (TTS couteux : ~3 min/segment)\n",
+    "fishaudio_url = \"http://localhost:8197\"\n",
+    "whisper_url = \"http://localhost:8190/v1/audio/transcriptions\"\n",
+    "wer_threshold = 0.15  # 15% WER max acceptable\n",
+    "\n",
+    "# Configuration FishAudio\n",
+    "fishaudio_reference_ids = {\n",
+    "    \"narrateur\": \"v4_narrator_male_neutral\",\n",
+    "    \"elisabeth_rousset\": \"v4_boule_warm_distressed\",\n",
+    "    \"comte\": \"v4_comte_onctuous\",\n",
+    "}\n",
+    "\n",
+    "# Configuration sauvegarde\n",
+    "generate_audio = True\n",
+    "save_audio_files = True\n"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "933bd52b",
-   "source": "# Parameters\nBATCH_MODE = True\nskip_widgets = True",
-   "metadata": {},
    "execution_count": 2,
-   "outputs": []
+   "id": "933bd52b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-04T00:49:14.901532Z",
+     "iopub.status.busy": "2026-08-04T00:49:14.901213Z",
+     "iopub.status.idle": "2026-08-04T00:49:14.903593Z",
+     "shell.execute_reply": "2026-08-04T00:49:14.903189Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "BATCH_MODE = True\n",
+    "skip_widgets = True"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "b3321b3d",
-   "source": "Les paramètres du notebook sont configures. Les cellules suivantes chargent les bibliotheques et verifient la disponibilite des services.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "Les paramètres du notebook sont configures. Les cellules suivantes chargent les bibliotheques et verifient la disponibilite des services."
+   ]
   },
   {
    "cell_type": "code",
-   "id": "6544f387",
-   "source": "# Setup environnement et imports\nimport os\nimport sys\nimport json\nimport re\nimport time\nfrom pathlib import Path\nfrom datetime import datetime\nfrom typing import Dict, List, Any, Optional\n\nfrom IPython.display import Audio, display, HTML\nimport logging\n\nlogging.basicConfig(level=getattr(logging, debug_level))\nlogger = logging.getLogger('audiobook_v4')\n\n# Resolution GENAI_ROOT\nGENAI_ROOT = Path.cwd()\nwhile GENAI_ROOT.name != 'GenAI' and len(GENAI_ROOT.parts) > 1:\n    GENAI_ROOT = GENAI_ROOT.parent\n\n# Ajouter v4 au path\nV4_PATH = GENAI_ROOT / 'Audio' / '04-Applications' / 'v4'\nif V4_PATH.exists():\n    sys.path.insert(0, str(V4_PATH.parent))\n    print(f\"Module v4 detecte : {V4_PATH}\")\nelse:\n    print(f\"ATTENTION: module v4 non trouve\")\n\n# Chargement .env\nfrom dotenv import load_dotenv\nenv_path = GENAI_ROOT / '.env'\nif env_path.exists():\n    load_dotenv(env_path)\n    print(f\".env charge depuis : {env_path}\")\n\n# Repertoire de sortie\nOUTPUT_DIR = V4_PATH / 'outputs'\nOUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n\nprint(f\"\\nPipeline Audiobook v4 FishAudio S2-Pro\")\nprint(f\"Date : {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\")\nprint(f\"Mode : {notebook_mode}\")\nprint(f\"Demo segments : {demo_segment_start}-{demo_segment_end}\")\nprint(f\"Sortie : {OUTPUT_DIR}\")",
-   "metadata": {},
    "execution_count": 3,
+   "id": "6544f387",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-04T00:49:14.905754Z",
+     "iopub.status.busy": "2026-08-04T00:49:14.905593Z",
+     "iopub.status.idle": "2026-08-04T00:49:14.919797Z",
+     "shell.execute_reply": "2026-08-04T00:49:14.919186Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Module v4 detecte : D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\Audio\\04-Applications\\v4\n",
-      ".env charge depuis : D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n",
+      "Module v4 detecte : D:\\Dev\\CoursIA\\.claude\\worktrees\\audiobook-0413-wer\\MyIA.AI.Notebooks\\GenAI\\Audio\\04-Applications\\v4\n",
+      ".env charge depuis : D:\\Dev\\CoursIA\\.claude\\worktrees\\audiobook-0413-wer\\MyIA.AI.Notebooks\\GenAI\\.env\n",
       "\n",
       "Pipeline Audiobook v4 FishAudio S2-Pro\n",
-      "Date : 2026-05-26 08:56:39\n",
+      "Date : 2026-08-04 02:49:14\n",
       "Mode : interactive\n",
-      "Demo segments : 0-5\n",
-      "Sortie : D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\Audio\\04-Applications\\v4\\outputs\n"
+      "Demo segments : 0-3\n",
+      "Sortie : D:\\Dev\\CoursIA\\.claude\\worktrees\\audiobook-0413-wer\\MyIA.AI.Notebooks\\GenAI\\Audio\\04-Applications\\v4\\outputs\n"
      ]
     }
+   ],
+   "source": [
+    "# Setup environnement et imports\n",
+    "import os\n",
+    "import sys\n",
+    "import json\n",
+    "import re\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "from datetime import datetime\n",
+    "from typing import Dict, List, Any, Optional\n",
+    "\n",
+    "from IPython.display import Audio, display, HTML\n",
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(level=getattr(logging, debug_level))\n",
+    "logger = logging.getLogger('audiobook_v4')\n",
+    "\n",
+    "# Resolution GENAI_ROOT\n",
+    "GENAI_ROOT = Path.cwd()\n",
+    "while GENAI_ROOT.name != 'GenAI' and len(GENAI_ROOT.parts) > 1:\n",
+    "    GENAI_ROOT = GENAI_ROOT.parent\n",
+    "\n",
+    "# Ajouter v4 au path\n",
+    "V4_PATH = GENAI_ROOT / 'Audio' / '04-Applications' / 'v4'\n",
+    "if V4_PATH.exists():\n",
+    "    sys.path.insert(0, str(V4_PATH.parent))\n",
+    "    print(f\"Module v4 detecte : {V4_PATH}\")\n",
+    "else:\n",
+    "    print(f\"ATTENTION: module v4 non trouve\")\n",
+    "\n",
+    "# Chargement .env\n",
+    "from dotenv import load_dotenv\n",
+    "env_path = GENAI_ROOT / '.env'\n",
+    "if env_path.exists():\n",
+    "    load_dotenv(env_path)\n",
+    "    print(f\".env charge depuis : {env_path}\")\n",
+    "\n",
+    "# Repertoire de sortie\n",
+    "OUTPUT_DIR = V4_PATH / 'outputs'\n",
+    "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "print(f\"\\nPipeline Audiobook v4 FishAudio S2-Pro\")\n",
+    "print(f\"Date : {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\")\n",
+    "print(f\"Mode : {notebook_mode}\")\n",
+    "print(f\"Demo segments : {demo_segment_start}-{demo_segment_end}\")\n",
+    "print(f\"Sortie : {OUTPUT_DIR}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "4f62e979",
-   "source": "Les bibliotheques sont chargees et le module v4 est detecte. Verifions maintenant la disponibilite des services Docker (FishAudio S2-Pro et Whisper STT).\n\n---\n\n## Section 1 : Architecture du pipeline v4 (8 phases)\n\nLe pipeline v4 implemente un audiobook agentique complet en 8 phases. Chaque phase est un module Python dedie dans le repertoire `v4/` :\n\n| Phase | Module | Rôle | Model/Tool |\n|-------|--------|------|------------|\n| P0 | `p0_narrative_research` | Recherche narrative (personnages, actes, thèmes) | GPT-4o-mini |\n| P1 | `p1_voice_cloning` | Clonage vocal + casting (13 voix referencees) | FishAudio S2-Pro |\n| P1.5 | `p1_5_speaker_catalog` | Catalogue des locuteurs (figurants inclus) | GPT-4o-mini |\n| P2 | `p2_segmentation` | Segmentation texte (narration/dialogue) | GPT-4o-mini |\n| P3 | `p3_dramatic_context` | Contexte dramatique par segment | GPT-4o-mini |\n| P4 | `p4_annotation` | Annotation prosodique (29 tags officiels) | GPT-4o-mini |\n| P5 | `p5_tts` | Generation TTS avec tags inline | FishAudio S2-Pro |\n| P6 | `p6_compile` | Compilation MP3 finale | pydub + ffmpeg |\n| P7 | `p7_verify` | Verification qualite (WER + diarization) | Whisper STT |\n\n**Architecture complete :**\n\n```\nboule_de_suif_full.txt (texte source)\n         |\n    [P0] Recherche narrative\n         |  -> narrative_context.json (personnages, actes, thèmes)\n    [P1] Clonage vocal\n         |  -> fishaudio_references/manifest.json (13 voix)\n    [P1.5] Catalogue locuteurs\n         |  -> speaker_catalog.json (figurants identifies)\n    [P2] Segmentation\n         |  -> segments_v4.json (385 segments, narration/dialogue)\n    [P3] Contexte dramatique\n         |  -> dramatic_context.json (tension, emotions par segment)\n    [P4] Annotation prosodique\n         |  -> annotated_v4.json (texte avec [tags] inline)\n    [P5] Generation TTS\n         |  -> tts_v4/seg_*.mp3 (385 fichiers audio)\n    [P6] Compilation\n         |  -> audiobook_final/ (chapitres MP3 assembles)\n    [P7] Verification\n         |  -> quality_report.json (WER, diarization)\n```\n\n**Lecon critique (WER #1277/#1485)** : FishAudio S2-Pro *vocalise* le texte libre entre crochets au lieu de l'interpreter comme instruction vocale. Seuls les 29 tags officiels sont traites comme commandes de prosodie. Ce pipeline utilise exclusivement ces tags officiels.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "Les bibliotheques sont chargees et le module v4 est detecte. Verifions maintenant la disponibilite des services Docker (FishAudio S2-Pro et Whisper STT).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Section 1 : Architecture du pipeline v4 (8 phases)\n",
+    "\n",
+    "Le pipeline v4 implemente un audiobook agentique complet en 8 phases. Chaque phase est un module Python dedie dans le repertoire `v4/` :\n",
+    "\n",
+    "| Phase | Module | Rôle | Model/Tool |\n",
+    "|-------|--------|------|------------|\n",
+    "| P0 | `p0_narrative_research` | Recherche narrative (personnages, actes, thèmes) | GPT-4o-mini |\n",
+    "| P1 | `p1_voice_cloning` | Clonage vocal + casting (13 voix referencees) | FishAudio S2-Pro |\n",
+    "| P1.5 | `p1_5_speaker_catalog` | Catalogue des locuteurs (figurants inclus) | GPT-4o-mini |\n",
+    "| P2 | `p2_segmentation` | Segmentation texte (narration/dialogue) | GPT-4o-mini |\n",
+    "| P3 | `p3_dramatic_context` | Contexte dramatique par segment | GPT-4o-mini |\n",
+    "| P4 | `p4_annotation` | Annotation prosodique (29 tags officiels) | GPT-4o-mini |\n",
+    "| P5 | `p5_tts` | Generation TTS avec tags inline | FishAudio S2-Pro |\n",
+    "| P6 | `p6_compile` | Compilation MP3 finale | pydub + ffmpeg |\n",
+    "| P7 | `p7_verify` | Verification qualite (WER + diarization) | Whisper STT |\n",
+    "\n",
+    "**Architecture complete :**\n",
+    "\n",
+    "```\n",
+    "boule_de_suif_full.txt (texte source)\n",
+    "         |\n",
+    "    [P0] Recherche narrative\n",
+    "         |  -> narrative_context.json (personnages, actes, thèmes)\n",
+    "    [P1] Clonage vocal\n",
+    "         |  -> fishaudio_references/manifest.json (13 voix)\n",
+    "    [P1.5] Catalogue locuteurs\n",
+    "         |  -> speaker_catalog.json (figurants identifies)\n",
+    "    [P2] Segmentation\n",
+    "         |  -> segments_v4.json (385 segments, narration/dialogue)\n",
+    "    [P3] Contexte dramatique\n",
+    "         |  -> dramatic_context.json (tension, emotions par segment)\n",
+    "    [P4] Annotation prosodique\n",
+    "         |  -> annotated_v4.json (texte avec [tags] inline)\n",
+    "    [P5] Generation TTS\n",
+    "         |  -> tts_v4/seg_*.mp3 (385 fichiers audio)\n",
+    "    [P6] Compilation\n",
+    "         |  -> audiobook_final/ (chapitres MP3 assembles)\n",
+    "    [P7] Verification\n",
+    "         |  -> quality_report.json (WER, diarization)\n",
+    "```\n",
+    "\n",
+    "**Lecon critique (WER #1277/#1485)** : FishAudio S2-Pro *vocalise* le texte libre entre crochets au lieu de l'interpreter comme instruction vocale. Seuls les 29 tags officiels sont traites comme commandes de prosodie. Ce pipeline utilise exclusivement ces tags officiels."
+   ]
   },
   {
    "cell_type": "code",
-   "id": "6997d88d",
-   "source": "# Verification des services Docker\nimport requests as req\n\nprint(\"VERIFICATION DES SERVICES\")\nprint(\"=\" * 50)\n\n# FishAudio S2-Pro\nfishaudio_ok = False\ntry:\n    resp = req.post(\n        f\"{fishaudio_url}/v1/tts\",\n        json={\"text\": \"test\", \"reference_id\": \"v4_narrator_male_neutral\"},\n        timeout=5\n    )\n    fishaudio_ok = resp.status_code in (200, 400)  # 400 = bad params mais service actif\n    print(f\"FishAudio S2-Pro (port 8197) : {'ACTIF' if fishaudio_ok else 'INDISPONIBLE'}\")\nexcept Exception as e:\n    print(f\"FishAudio S2-Pro (port 8197) : INDISPONIBLE ({type(e).__name__})\")\n\n# Whisper STT\nwhisper_ok = False\napi_key = os.getenv(\"WHISPER_API_KEY\", \"\")\nif not api_key:\n    # Fallback: lire depuis Docker\n    try:\n        import subprocess\n        result = subprocess.run(\n            [\"docker\", \"inspect\", \"--format\", \"{{range .Config.Env}}{{println .}}{{end}}\", \"whisper-api\"],\n            capture_output=True, text=True,\n        )\n        for line in result.stdout.splitlines():\n            if line.startswith(\"API_KEY=\"):\n                api_key = line.split(\"=\", 1)[1].strip().strip('\"')\n                break\n    except Exception:\n        pass\n\nwhisper_ok = bool(api_key)\nprint(f\"Whisper STT (port 8190) : {'ACTIF' if whisper_ok else 'INDISPONIBLE'}\")\n\n# OpenAI API\nopenai_key = os.getenv(\"OPENAI_API_KEY\", \"\")\nopenai_ok = bool(openai_key and not openai_key.startswith(\"sk-or-\"))\nprint(f\"OpenAI API : {'ACTIF' if openai_ok else 'INDISPONIBLE'}\")\n\n# Imports conditionnels\nif openai_ok:\n    from openai import OpenAI\n    client = OpenAI(api_key=openai_key)\n\n# Resume\nall_ok = fishaudio_ok and whisper_ok and openai_ok\nprint(f\"\\n{'='*50}\")\nif all_ok:\n    print(\"Tous les services sont operationnels - pipeline complet disponible\")\nelse:\n    missing = []\n    if not fishaudio_ok: missing.append(\"FishAudio (docker start tts-fishaudio)\")\n    if not whisper_ok: missing.append(\"Whisper (docker start whisper-api)\")\n    if not openai_ok: missing.append(\"OpenAI API (.env)\")\n    print(f\"Services manquants : {', '.join(missing)}\")\n    print(\"Certaines sections seront executees en mode demonstration\")",
-   "metadata": {},
    "execution_count": 4,
+   "id": "6997d88d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-04T00:49:14.921618Z",
+     "iopub.status.busy": "2026-08-04T00:49:14.921439Z",
+     "iopub.status.idle": "2026-08-04T00:49:24.373190Z",
+     "shell.execute_reply": "2026-08-04T00:49:24.372639Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -76,7 +254,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FishAudio S2-Pro (port 8197) : INDISPONIBLE (ReadTimeout)\n",
+      "FishAudio S2-Pro (port 8197) : ACTIF\n",
       "Whisper STT (port 8190) : ACTIF\n",
       "OpenAI API : ACTIF\n"
      ]
@@ -87,24 +265,112 @@
      "text": [
       "\n",
       "==================================================\n",
-      "Services manquants : FishAudio (docker start tts-fishaudio)\n",
-      "Certaines sections seront executees en mode demonstration\n"
+      "Tous les services sont operationnels - pipeline complet disponible\n"
      ]
     }
+   ],
+   "source": [
+    "# Verification des services Docker\n",
+    "import requests as req\n",
+    "\n",
+    "print(\"VERIFICATION DES SERVICES\")\n",
+    "print(\"=\" * 50)\n",
+    "\n",
+    "# FishAudio S2-Pro (probe par generation courte : le service n'expose pas de /health,\n",
+    "# donc on effectue une micro-synthese ; la premiere requete peut etre lente a chaud)\n",
+    "fishaudio_ok = False\n",
+    "try:\n",
+    "    resp = req.post(\n",
+    "        f\"{fishaudio_url}/v1/tts\",\n",
+    "        json={\"text\": \"test\", \"reference_id\": \"v4_narrator_male_neutral\"},\n",
+    "        timeout=30,\n",
+    "    )\n",
+    "    fishaudio_ok = resp.status_code in (200, 400)  # 400 = bad params mais service actif\n",
+    "    print(f\"FishAudio S2-Pro (port 8197) : {'ACTIF' if fishaudio_ok else 'INDISPONIBLE'}\")\n",
+    "except Exception as e:\n",
+    "    print(f\"FishAudio S2-Pro (port 8197) : INDISPONIBLE ({type(e).__name__})\")\n",
+    "\n",
+    "# Whisper STT\n",
+    "whisper_ok = False\n",
+    "api_key = os.getenv(\"WHISPER_API_KEY\", \"\")\n",
+    "if not api_key:\n",
+    "    # Fallback: lire depuis Docker\n",
+    "    try:\n",
+    "        import subprocess\n",
+    "        result = subprocess.run(\n",
+    "            [\"docker\", \"inspect\", \"--format\", \"{{range .Config.Env}}{{println .}}{{end}}\", \"whisper-api\"],\n",
+    "            capture_output=True, text=True,\n",
+    "        )\n",
+    "        for line in result.stdout.splitlines():\n",
+    "            if line.startswith(\"API_KEY=\"):\n",
+    "                api_key = line.split(\"=\", 1)[1].strip().strip('\"')\n",
+    "                break\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "\n",
+    "whisper_ok = bool(api_key)\n",
+    "print(f\"Whisper STT (port 8190) : {'ACTIF' if whisper_ok else 'INDISPONIBLE'}\")\n",
+    "\n",
+    "# OpenAI API\n",
+    "openai_key = os.getenv(\"OPENAI_API_KEY\", \"\")\n",
+    "openai_ok = bool(openai_key and not openai_key.startswith(\"sk-or-\"))\n",
+    "print(f\"OpenAI API : {'ACTIF' if openai_ok else 'INDISPONIBLE'}\")\n",
+    "\n",
+    "# Imports conditionnels\n",
+    "if openai_ok:\n",
+    "    from openai import OpenAI\n",
+    "    client = OpenAI(api_key=openai_key)\n",
+    "\n",
+    "# Resume\n",
+    "all_ok = fishaudio_ok and whisper_ok and openai_ok\n",
+    "print(f\"\\n{'='*50}\")\n",
+    "if all_ok:\n",
+    "    print(\"Tous les services sont operationnels - pipeline complet disponible\")\n",
+    "else:\n",
+    "    missing = []\n",
+    "    if not fishaudio_ok: missing.append(\"FishAudio (docker start tts-fishaudio)\")\n",
+    "    if not whisper_ok: missing.append(\"Whisper (docker start whisper-api)\")\n",
+    "    if not openai_ok: missing.append(\"OpenAI API (.env)\")\n",
+    "    print(f\"Services manquants : {', '.join(missing)}\")\n",
+    "    print(\"Certaines sections seront executees en mode demonstration\")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "e79536ae",
-   "source": "### Interpretation : Verification des services\n\n| Service | Port | Utilite dans le pipeline |\n|---------|------|--------------------------|\n| FishAudio S2-Pro | 8197 | TTS avec clonage vocal (P5) |\n| Whisper STT | 8190 | Validation WER (P7) |\n| OpenAI API | - | LLM pour P0-P4 |\n\nSi un service est indisponible, les sections correspondantes fonctionneront en mode demonstration avec des résultats precalcules.\n\n---\n\n## Section 2 : Les 29 balises de prosodie FishAudio S2-Pro\n\nFishAudio S2-Pro supporte 29 balises de prosodie officielles, placees entre crochets `[...]` dans le texte. Ces balises controlent la respiration, les reactions vocales, le rythme, le style vocal et les emotions du narrateur.\n\n**Attention** : Toute balise non reconnue (texte libre) sera **vocalisee** litteralement par le modèle, pas interpretee comme instruction. C'est la lecon critique apprise lors de la validation WER (issues #1277, #1485).",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Interpretation : Verification des services\n",
+    "\n",
+    "| Service | Port | Utilite dans le pipeline |\n",
+    "|---------|------|--------------------------|\n",
+    "| FishAudio S2-Pro | 8197 | TTS avec clonage vocal (P5) |\n",
+    "| Whisper STT | 8190 | Validation WER (P7) |\n",
+    "| OpenAI API | - | LLM pour P0-P4 |\n",
+    "\n",
+    "Si un service est indisponible, les sections correspondantes fonctionneront en mode demonstration avec des résultats precalcules.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Section 2 : Les 29 balises de prosodie FishAudio S2-Pro\n",
+    "\n",
+    "FishAudio S2-Pro supporte 29 balises de prosodie officielles, placees entre crochets `[...]` dans le texte. Ces balises controlent la respiration, les reactions vocales, le rythme, le style vocal et les emotions du narrateur.\n",
+    "\n",
+    "**Attention** : Toute balise non reconnue (texte libre) sera **vocalisee** litteralement par le modèle, pas interpretee comme instruction. C'est la lecon critique apprise lors de la validation WER (issues #1277, #1485)."
+   ]
   },
   {
    "cell_type": "code",
-   "id": "6ade1247",
-   "source": "# Les 29 balises de prosodie officielles FishAudio S2-Pro\nfrom v4.schemas import ALL_PROSODY_TAGS, ProsodyTag\n\n# Categorisation des tags\ncategories = {\n    \"Respiration & reactions vocales\": [\n        \"clears throat\", \"inhale\", \"inhalation\", \"exhale\", \"sigh\",\n        \"panting\", \"breathing\", \"gasp\",\n    ],\n    \"Sons vocaux\": [\n        \"groan\", \"moaning\", \"sobbing\", \"crying\", \"laughing\",\n        \"chuckling\", \"giggle\",\n    ],\n    \"Rythme\": [\n        \"pause\", \"short pause\", \"long pause\",\n    ],\n    \"Style vocal\": [\n        \"whispering\", \"whispering voice\", \"soft voice\", \"low voice\",\n        \"loud voice\", \"shouting\",\n    ],\n    \"Emotion\": [\n        \"excited\", \"angry\", \"sad\",\n    ],\n    \"Autres\": [\n        \"emphasis\", \"rustling sound\",\n    ],\n}\n\nprint(\"BALISES DE PROSODIE OFFICIELLES FISHAUDIO S2-PRO\")\nprint(f\"Total : {len(ALL_PROSODY_TAGS)} balises\\n\")\n\nfor cat, tags in categories.items():\n    print(f\"**{cat}** ({len(tags)}) :\")\n    for tag in tags:\n        print(f\"  [{tag}]\")\n    print()\n\n# Verifier que toutes les categories couvrent bien l'ensemble\ncategorized = set()\nfor tags in categories.values():\n    categorized.update(tags)\nuncategorized = ALL_PROSODY_TAGS - categorized\nif uncategorized:\n    print(f\"Tags non catégorisés : {uncategorized}\")\nelse:\n    print(f\"Tous les {len(ALL_PROSODY_TAGS)} tags sont couverts.\")",
-   "metadata": {},
    "execution_count": 5,
+   "id": "6ade1247",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-04T00:49:24.375309Z",
+     "iopub.status.busy": "2026-08-04T00:49:24.375001Z",
+     "iopub.status.idle": "2026-08-04T00:49:24.393803Z",
+     "shell.execute_reply": "2026-08-04T00:49:24.393346Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -161,46 +427,157 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\Audio\\04-Applications\\v4\\schemas.py:99: UserWarning: Field name \"register\" in \"VoiceReference\" shadows an attribute in parent \"BaseModel\"\n",
+      "D:\\Dev\\CoursIA\\.claude\\worktrees\\audiobook-0413-wer\\MyIA.AI.Notebooks\\GenAI\\Audio\\04-Applications\\v4\\schemas.py:99: UserWarning: Field name \"register\" in \"VoiceReference\" shadows an attribute in parent \"BaseModel\"\n",
       "  class VoiceReference(BaseModel):\n"
      ]
     }
+   ],
+   "source": [
+    "# Les 29 balises de prosodie officielles FishAudio S2-Pro\n",
+    "from v4.schemas import ALL_PROSODY_TAGS, ProsodyTag\n",
+    "\n",
+    "# Categorisation des tags\n",
+    "categories = {\n",
+    "    \"Respiration & reactions vocales\": [\n",
+    "        \"clears throat\", \"inhale\", \"inhalation\", \"exhale\", \"sigh\",\n",
+    "        \"panting\", \"breathing\", \"gasp\",\n",
+    "    ],\n",
+    "    \"Sons vocaux\": [\n",
+    "        \"groan\", \"moaning\", \"sobbing\", \"crying\", \"laughing\",\n",
+    "        \"chuckling\", \"giggle\",\n",
+    "    ],\n",
+    "    \"Rythme\": [\n",
+    "        \"pause\", \"short pause\", \"long pause\",\n",
+    "    ],\n",
+    "    \"Style vocal\": [\n",
+    "        \"whispering\", \"whispering voice\", \"soft voice\", \"low voice\",\n",
+    "        \"loud voice\", \"shouting\",\n",
+    "    ],\n",
+    "    \"Emotion\": [\n",
+    "        \"excited\", \"angry\", \"sad\",\n",
+    "    ],\n",
+    "    \"Autres\": [\n",
+    "        \"emphasis\", \"rustling sound\",\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "print(\"BALISES DE PROSODIE OFFICIELLES FISHAUDIO S2-PRO\")\n",
+    "print(f\"Total : {len(ALL_PROSODY_TAGS)} balises\\n\")\n",
+    "\n",
+    "for cat, tags in categories.items():\n",
+    "    print(f\"**{cat}** ({len(tags)}) :\")\n",
+    "    for tag in tags:\n",
+    "        print(f\"  [{tag}]\")\n",
+    "    print()\n",
+    "\n",
+    "# Verifier que toutes les categories couvrent bien l'ensemble\n",
+    "categorized = set()\n",
+    "for tags in categories.values():\n",
+    "    categorized.update(tags)\n",
+    "uncategorized = ALL_PROSODY_TAGS - categorized\n",
+    "if uncategorized:\n",
+    "    print(f\"Tags non catégorisés : {uncategorized}\")\n",
+    "else:\n",
+    "    print(f\"Tous les {len(ALL_PROSODY_TAGS)} tags sont couverts.\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "bb8bd2c3",
-   "source": "### Interpretation : Balises de prosodie\n\n| Catégorie | Nombre | Usage typique audiobook |\n|-----------|--------|------------------------|\n| Respiration | 8 | Transitions, moments de tension, hesitation |\n| Sons vocaux | 7 | Pleurs, rires, gemissements (dialogues emotionnels) |\n| Rythme | 3 | Pauses entre phrases, silences dramatiques |\n| Style vocal | 6 | Chuchotements, cris, voix basse (suspense) |\n| Emotion | 3 | Colere, tristesse, excitation (marqueurs directs) |\n| Autres | 2 | Emphase sur un mot, bruitage leger |\n\n**Règle d'or** : Maximum 3 tags par segment. Trop de tags deconcentre le modèle et degrade la qualite. Les tags se placent **avant** le texte qu'ils affectent.\n\n> **Lecon critique (WER #1277)** : Des tests systématiques ont montre que FishAudio S2-Pro *vocalise* litteralement toute balise non-officielle. Par exemple, `[speaking slowly, almost hesitant]` sera prononce mot a mot dans l'audio, au lieu de modifier le style vocal. Seules les 29 balises ci-dessus sont traitees comme commandes de prosodie.\n\n---\n\n## Section 3 : Annotation prosodique (P4) sur un extrait de demonstration\n\nCette section execute la phase P4 (annotation prosodique) sur un extrait court de \"Boule de Suif\". Le LLM analyse chaque segment et insere les balises de prosodie appropriees dans le texte.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Interpretation : Balises de prosodie\n",
+    "\n",
+    "| Catégorie | Nombre | Usage typique audiobook |\n",
+    "|-----------|--------|------------------------|\n",
+    "| Respiration | 8 | Transitions, moments de tension, hesitation |\n",
+    "| Sons vocaux | 7 | Pleurs, rires, gemissements (dialogues emotionnels) |\n",
+    "| Rythme | 3 | Pauses entre phrases, silences dramatiques |\n",
+    "| Style vocal | 6 | Chuchotements, cris, voix basse (suspense) |\n",
+    "| Emotion | 3 | Colere, tristesse, excitation (marqueurs directs) |\n",
+    "| Autres | 2 | Emphase sur un mot, bruitage leger |\n",
+    "\n",
+    "**Règle d'or** : Maximum 3 tags par segment. Trop de tags deconcentre le modèle et degrade la qualite. Les tags se placent **avant** le texte qu'ils affectent.\n",
+    "\n",
+    "> **Lecon critique (WER #1277)** : Des tests systématiques ont montre que FishAudio S2-Pro *vocalise* litteralement toute balise non-officielle. Par exemple, `[speaking slowly, almost hesitant]` sera prononce mot a mot dans l'audio, au lieu de modifier le style vocal. Seules les 29 balises ci-dessus sont traitees comme commandes de prosodie.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Section 3 : Annotation prosodique (P4) sur un extrait de demonstration\n",
+    "\n",
+    "Cette section execute la phase P4 (annotation prosodique) sur un extrait court de \"Boule de Suif\". Le LLM analyse chaque segment et insere les balises de prosodie appropriees dans le texte."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "aa5a4c14",
-   "source": "### Exercice : Detecteur de balises non-officielles\n\n**Duree estimee :** 10-15 minutes\n\n**Objectif** : Ecrire une fonction qui detecte les balises de prosodie non-officielles dans un texte annote. Toute balise qui n'appartient pas aux 29 tags officiels FishAudio S2-Pro sera signalee comme erreur potentielle (elle sera vocalisee au lieu d'etre interpretee).\n\n**Contexte** : L'incident WER #1277 a montre que des balises comme `[speaking slowly]` ou `[whisper of fear]` sont prononcees mot a mot par FishAudio, degradant le WER de 12% a plus de 150%.\n\n- **Étape 1 :** Définir la liste des 29 tags officiels (déjà disponible dans ALL_PROSODY_TAGS)\n- **Étape 2 :** Extraire toutes les balises [...] d'un texte annote avec une regex\n- **Étape 3 :** Comparer chaque balise extraite avec la liste officielle et signaler les intrus\n\n**Indice :** re.findall(r'\\[([^\\]]+)\\]', text) extrait le contenu de toutes les balises\n**Indice :** ALL_PROSODY_TAGS est un set Python, la recherche est en O(1)",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "e88f43ca",
-   "source": "# TODO etudiant : detecteur de balises non-officielles\n# Etape 1 : Les 29 tags officiels sont dans ALL_PROSODY_TAGS (deja importe)\n# Etape 2 : Ecrire la fonction de detection\ndef detect_unofficial_tags(annotated_text, official_tags):\n    \"\"\"Retourne la liste des balises non-officielles trouvees dans le texte.\"\"\"\n    # TODO etudiant : extraire les balises avec une regex et filtrer\n    return None  # TODO etudiant\n\n# Etape 3 : Tester avec un texte contenant des balises mixtes\ntest_text = \"[pause] Il dit bonjour [speaking softly] puis [sigh] partit [whisper of fear].\"\n# TODO etudiant : appeler detect_unofficial_tags et afficher les resultats\n\nprint(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": 1,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
-    }
+   "source": [
+    "### Exercice : Detecteur de balises non-officielles\n",
+    "\n",
+    "**Duree estimee :** 10-15 minutes\n",
+    "\n",
+    "**Objectif** : Ecrire une fonction qui detecte les balises de prosodie non-officielles dans un texte annote. Toute balise qui n'appartient pas aux 29 tags officiels FishAudio S2-Pro sera signalee comme erreur potentielle (elle sera vocalisee au lieu d'etre interpretee).\n",
+    "\n",
+    "**Contexte** : L'incident WER #1277 a montre que des balises comme `[speaking slowly]` ou `[whisper of fear]` sont prononcees mot a mot par FishAudio, degradant le WER de 12% a plus de 150%.\n",
+    "\n",
+    "- **Étape 1 :** Définir la liste des 29 tags officiels (déjà disponible dans ALL_PROSODY_TAGS)\n",
+    "- **Étape 2 :** Extraire toutes les balises [...] d'un texte annote avec une regex\n",
+    "- **Étape 3 :** Comparer chaque balise extraite avec la liste officielle et signaler les intrus\n",
+    "\n",
+    "**Indice :** re.findall(r'\\[([^\\]]+)\\]', text) extrait le contenu de toutes les balises\n",
+    "**Indice :** ALL_PROSODY_TAGS est un set Python, la recherche est en O(1)"
    ]
   },
   {
    "cell_type": "code",
-   "id": "e40c14a8",
-   "source": "# P4 : Annotation prosodique sur un extrait de demonstration\nfrom v4.p4_annotation import load_inputs, annotate_batch\n\nprint(\"P4 : ANNOTATION PROSODIQUE\")\nprint(\"=\" * 50)\n\n# Charger les segments et contextes existants\nsegments, contexts = load_inputs()\n\n# Selectionner les segments de demonstration\ndemo_segs = [s for s in segments if demo_segment_start <= s.seg_index < demo_segment_end]\nprint(f\"Segments de demonstration : {len(demo_segs)} (indices {demo_segment_start}-{demo_segment_end - 1})\")\nprint(f\"Locuteurs : {set(s.speaker for s in demo_segs)}\")\nprint(f\"Types : {set(s.type for s in demo_segs)}\")\n\n# Afficher les segments avant annotation\nprint(f\"\\n--- Segments avant annotation ---\")\nfor seg in demo_segs:\n    print(f\"  [{seg.seg_index:3d}] ({seg.speaker:20s}/{seg.type:10s}) : {seg.text[:80]}...\")\n\n# Executer P4 (annotation par batch de 10)\nannotated = []\nprev_tags = None\nif openai_ok and generate_audio:\n    batch_size = 10\n    for i in range(0, len(demo_segs), batch_size):\n        batch = demo_segs[i:i + batch_size]\n        batch_idx = i // batch_size + 1\n        result = annotate_batch(batch, contexts, batch_idx, prev_tags)\n        annotated.extend(result)\n        if result:\n            prev_tags = result[-1].prosody_tags\n\n    print(f\"\\n--- Segments apres annotation ---\")\n    for a in annotated:\n        print(f\"  [{a.seg_index:3d}] ({a.speaker:20s}) : {a.annotated_text[:100]}\")\n        print(f\"        Tags : {a.prosody_tags}\")\nelse:\n    print(\"\\nAnnotation sautee (OpenAI indisponible ou generate_audio=False)\")\n    print(\"Les segments seront utilises sans annotation prosodique.\")",
-   "metadata": {},
    "execution_count": 6,
+   "id": "e88f43ca",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-04T00:49:24.395464Z",
+     "iopub.status.busy": "2026-08-04T00:49:24.395301Z",
+     "iopub.status.idle": "2026-08-04T00:49:24.398453Z",
+     "shell.execute_reply": "2026-08-04T00:49:24.397934Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO etudiant : detecteur de balises non-officielles\n",
+    "# Etape 1 : Les 29 tags officiels sont dans ALL_PROSODY_TAGS (deja importe)\n",
+    "# Etape 2 : Ecrire la fonction de detection\n",
+    "def detect_unofficial_tags(annotated_text, official_tags):\n",
+    "    \"\"\"Retourne la liste des balises non-officielles trouvees dans le texte.\"\"\"\n",
+    "    # TODO etudiant : extraire les balises avec une regex et filtrer\n",
+    "    return None  # TODO etudiant\n",
+    "\n",
+    "# Etape 3 : Tester avec un texte contenant des balises mixtes\n",
+    "test_text = \"[pause] Il dit bonjour [speaking softly] puis [sigh] partit [whisper of fear].\"\n",
+    "# TODO etudiant : appeler detect_unofficial_tags et afficher les resultats\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e40c14a8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-04T00:49:24.400266Z",
+     "iopub.status.busy": "2026-08-04T00:49:24.399941Z",
+     "iopub.status.idle": "2026-08-04T00:49:36.448984Z",
+     "shell.execute_reply": "2026-08-04T00:49:36.448311Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -209,7 +586,7 @@
       "P4 : ANNOTATION PROSODIQUE\n",
       "==================================================\n",
       "  Loaded 385 segments, 385 dramatic contexts\n",
-      "Segments de demonstration : 5 (indices 0-4)\n",
+      "Segments de demonstration : 3 (indices 0-2)\n",
       "Locuteurs : {'narrateur'}\n",
       "Types : {'narration'}\n",
       "\n",
@@ -217,44 +594,86 @@
       "  [  0] (narrateur           /narration ) : BOULE DE SUIF...\n",
       "  [  1] (narrateur           /narration ) : Pendant plusieurs jours de suite des lambeaux d'armée en déroute avaient travers...\n",
       "  [  2] (narrateur           /narration ) : Des légions de francs-tireurs aux appellations héroïques: «les Vengeurs de la Dé...\n",
-      "  [  3] (narrateur           /narration ) : Leurs chefs, anciens commerçants en draps ou en graines, ex-marchands de suif ou...\n",
-      "  [  4] (narrateur           /narration ) : Les Prussiens allaient entrer dans Rouen, disait-on....\n",
-      "  [P4] Batch 1: annotating segments 0-4 (5 segments)\n"
+      "  [P4] Batch 1: annotating segments 0-2 (3 segments)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Tags: 10 total (10 official S2-Pro), 5/5 segments tagged\n",
+      "    Tags: 7 total (7 official S2-Pro), 3/3 segments tagged\n",
       "\n",
       "--- Segments apres annotation ---\n",
-      "  [  0] (narrateur           ) : [clears throat]BOULE DE SUIF\n",
-      "        Tags : ['clears throat']\n",
+      "  [  0] (narrateur           ) : [emphasis]BOULE DE SUIF\n",
+      "        Tags : ['emphasis']\n",
       "  [  1] (narrateur           ) : [low voice]Pendant plusieurs jours de suite des lambeaux d'armée en déroute avaient traversé la vill\n",
       "        Tags : ['low voice', 'short pause', 'pause']\n",
-      "  [  2] (narrateur           ) : [emphasis]Des légions de francs-tireurs aux appellations héroïques: «les Vengeurs de la Défaite--les\n",
-      "        Tags : ['emphasis', 'short pause']\n",
-      "  [  3] (narrateur           ) : [excited]Leurs chefs, anciens commerçants en draps ou en graines, ex-marchands de suif ou de savon, \n",
-      "        Tags : ['excited', 'pause']\n",
-      "  [  4] (narrateur           ) : [low voice]Les Prussiens allaient entrer dans Rouen, [short pause]disait-on.\n",
-      "        Tags : ['low voice', 'short pause']\n"
+      "  [  2] (narrateur           ) : [emphasis]Des légions de francs-tireurs aux appellations héroïques: [short pause]«les Vengeurs de la\n",
+      "        Tags : ['emphasis', 'short pause', 'pause']\n"
      ]
     }
+   ],
+   "source": [
+    "# P4 : Annotation prosodique sur un extrait de demonstration\n",
+    "from v4.p4_annotation import load_inputs, annotate_batch\n",
+    "\n",
+    "print(\"P4 : ANNOTATION PROSODIQUE\")\n",
+    "print(\"=\" * 50)\n",
+    "\n",
+    "# Charger les segments et contextes existants\n",
+    "segments, contexts = load_inputs()\n",
+    "\n",
+    "# Selectionner les segments de demonstration\n",
+    "demo_segs = [s for s in segments if demo_segment_start <= s.seg_index < demo_segment_end]\n",
+    "print(f\"Segments de demonstration : {len(demo_segs)} (indices {demo_segment_start}-{demo_segment_end - 1})\")\n",
+    "print(f\"Locuteurs : {set(s.speaker for s in demo_segs)}\")\n",
+    "print(f\"Types : {set(s.type for s in demo_segs)}\")\n",
+    "\n",
+    "# Afficher les segments avant annotation\n",
+    "print(f\"\\n--- Segments avant annotation ---\")\n",
+    "for seg in demo_segs:\n",
+    "    print(f\"  [{seg.seg_index:3d}] ({seg.speaker:20s}/{seg.type:10s}) : {seg.text[:80]}...\")\n",
+    "\n",
+    "# Executer P4 (annotation par batch de 10)\n",
+    "annotated = []\n",
+    "prev_tags = None\n",
+    "if openai_ok and generate_audio:\n",
+    "    batch_size = 10\n",
+    "    for i in range(0, len(demo_segs), batch_size):\n",
+    "        batch = demo_segs[i:i + batch_size]\n",
+    "        batch_idx = i // batch_size + 1\n",
+    "        result = annotate_batch(batch, contexts, batch_idx, prev_tags)\n",
+    "        annotated.extend(result)\n",
+    "        if result:\n",
+    "            prev_tags = result[-1].prosody_tags\n",
+    "\n",
+    "    print(f\"\\n--- Segments apres annotation ---\")\n",
+    "    for a in annotated:\n",
+    "        print(f\"  [{a.seg_index:3d}] ({a.speaker:20s}) : {a.annotated_text[:100]}\")\n",
+    "        print(f\"        Tags : {a.prosody_tags}\")\n",
+    "else:\n",
+    "    print(\"\\nAnnotation sautee (OpenAI indisponible ou generate_audio=False)\")\n",
+    "    print(\"Les segments seront utilises sans annotation prosodique.\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "ba1f2018",
-   "source": "### Interpretation : Annotation prosodique\n\n| Aspect | Observation | Remarque |\n|--------|------------|----------|\n| Tags par segment | 1-3 typiquement | Maximum recommande pour ne pas surcharger |\n| Tags officiels | 100% (après fix #1485) | Seuls les tags du Literal ProsodyTag sont generes |\n| Tags libres | 0 (après fix) | Le prompt interdit explicitement le langage naturel libre |\n| Couverture | Variable selon le type | Narration = pauses/sighs, Dialogue = emotions/voice style |\n\n**Ce qui a change avec le fix #1485** :\n- Avant : le LLM generait des instructions naturelles comme `(d'une voix tremblante)` que FishAudio vocalisait\n- Après : seuls les 29 tags officiels `[pause]`, `[sigh]`, `[whispering]`, etc. sont utilises\n- Résultat : WER moyen passe de 156% a 12% sur l'echantillon test\n\n---\n\n## Section 4 : Generation TTS avec FishAudio S2-Pro (P5)\n\nFishAudio S2-Pro est un modèle TTS qui supporte le clonage vocal a partir de references audio courtes (3-10 secondes). Chaque personnage a une voix de reference unique, et les balises de prosodie sont incluses directement dans le texte a synthetiser.",
-   "metadata": {}
+   "metadata": {},
+   "source": "### Interpretation : Annotation prosodique\n\n| Aspect | Observation | Remarque |\n|--------|------------|----------|\n| Tags par segment | 1-3 typiquement | Maximum recommande pour ne pas surcharger |\n| Tags officiels | attendus (fix #1485) | Seuls les 29 tags du Literal ProsodyTag sont valides |\n| Tags libres | a surveiller | gpt-4o-mini peut encore produire des directions en texte libre |\n| Couverture | Variable selon le type | Narration = pauses/sighs, Dialogue = emotions/voice style |\n\n**Ce qui a change avec le fix #1485** :\n- Avant : le LLM generait des instructions naturelles libres (ex. `(d'une voix tremblante)`) que FishAudio vocalisait mot a mot, faisant exploser le WER\n- Apres : le prompt demande les 29 tags officiels `[pause]`, `[sigh]`, `[whispering]`, etc.\n- **Sur le terrain (sortie P4 ci-dessus)** : l'annotation laisse parfois passer des directions en texte libre (ex. `[composed and neutral, even pace]`). Ces balises non-officielles sont vocalisees et degradent le WER -- c'est ce que mesure la validation P7 ci-apres.\n\n---\n\n## Section 4 : Generation TTS avec FishAudio S2-Pro (P5)\n\nFishAudio S2-Pro est un modèle TTS qui supporte le clonage vocal a partir de references audio courtes (3-10 secondes). Chaque personnage a une voix de reference unique, et les balises de prosodie sont incluses directement dans le texte a synthetiser."
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
    "id": "f44bc470",
-   "source": "# P5 : Generation TTS avec FishAudio S2-Pro\nfrom v4.p5_tts import _compose_tts_text\nfrom v4.fishaudio_client import fishaudio_tts, audio_duration_mp3\nfrom v4.p1_voice_cloning import SPEAKER_TO_VOICE\nfrom v4.schemas import AnnotatedSegment\n\nprint(\"P5 : GENERATION TTS FISHAUDIO S2-PRO\")\nprint(\"=\" * 50)\n\n# Repertoire de sortie demo\ndemo_tts_dir = OUTPUT_DIR / \"tts_demo_notebook\"\ndemo_tts_dir.mkdir(exist_ok=True, parents=True)\n\ntts_results = []\n\nif annotated and fishaudio_ok and generate_audio:\n    for seg_data in annotated:\n        seg_dict = seg_data.model_dump()\n        idx = seg_data.seg_index\n        \n        # Composer le texte TTS (extrait les tags du prefix)\n        tts_text = _compose_tts_text(seg_data)\n        \n        # Determiner la voix de reference\n        speaker = seg_data.speaker\n        ref_id = SPEAKER_TO_VOICE.get(speaker, SPEAKER_TO_VOICE.get(\"narrateur\", \"\"))\n        \n        mp3_path = demo_tts_dir / f\"seg_{idx:04d}.mp3\"\n        \n        if mp3_path.exists():\n            print(f\"  seg {idx}: cache ({mp3_path.stat().st_size} bytes)\")\n        else:\n            print(f\"  seg {idx}: generation TTS ({len(tts_text)} chars, ref={ref_id})...\")\n            audio = fishaudio_tts(tts_text, reference_id=ref_id)\n            if audio:\n                mp3_path.write_bytes(audio)\n                print(f\"    -> {len(audio)} bytes, sauvegarde\")\n            else:\n                print(f\"    -> ECHEC\")\n                tts_results.append({\"seg_index\": idx, \"status\": \"failed\"})\n                continue\n        \n        duration = audio_duration_mp3(str(mp3_path)) if mp3_path.exists() else 0\n        tts_results.append({\n            \"seg_index\": idx,\n            \"status\": \"ok\",\n            \"mp3_path\": str(mp3_path),\n            \"duration_s\": round(duration, 2),\n            \"speaker\": speaker,\n            \"tts_text_preview\": tts_text[:100],\n        })\n\n    # Ecouter le premier segment\n    if tts_results and tts_results[0][\"status\"] == \"ok\":\n        first_path = tts_results[0][\"mp3_path\"]\n        print(f\"\\nEcoute du segment {tts_results[0]['seg_index']} ({tts_results[0]['speaker']}) :\")\n        display(Audio(filename=first_path, autoplay=False))\n\n    # Tableau recapitulatif\n    print(f\"\\n{'#':<4} {'Speaker':<20} {'Durée (s)':<10} {'Aperçu texte TTS'}\")\n    print(\"-\" * 80)\n    for r in tts_results:\n        if r[\"status\"] == \"ok\":\n            print(f\"{r['seg_index']:<4} {r['speaker']:<20} {r['duration_s']:<10.1f} {r['tts_text_preview']}\")\nelse:\n    print(\"Generation TTS sautee (services indisponibles ou pas de segments annotes)\")",
-   "metadata": {},
-   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-04T00:49:36.451435Z",
+     "iopub.status.busy": "2026-08-04T00:49:36.451124Z",
+     "iopub.status.idle": "2026-08-04T00:49:36.501719Z",
+     "shell.execute_reply": "2026-08-04T00:49:36.500948Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -262,128 +681,468 @@
      "text": [
       "P5 : GENERATION TTS FISHAUDIO S2-PRO\n",
       "==================================================\n",
-      "Generation TTS sautee (services indisponibles ou pas de segments annotes)\n"
+      "  seg 0: cache (13634 bytes)\n",
+      "  seg 1: cache (261344 bytes)\n",
+      "  seg 2: cache (123517 bytes)\n",
+      "\n",
+      "Ecoute du segment 0 (narrateur) :\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "                <audio  controls=\"controls\" >\n",
+       "                    <source src=\"data:audio/mpeg;base64,//uQxAAAAAAAAAAAAAAAAAAAAAAAWGluZwAAAA8AAAAxAAA1QgAMDBISFhYcHCQkKSktLTIyNjY7O0BARUVNTVJSWlpgYGRkampwcHZ2fHyCgoiIjY2SkpKWlpuboKCkpKmpra2ysre3u7vAwMXFysrQ0NXV2dne3uLi5+fs7PDw9PT4+Pz8//8AAAA8TEFNRTMuMTAwBK8AAAAAAAAAABUgJAJAQQABzAAANULxNuHmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA//uwxAAAC1gJV6EMACmiFmn9h4x8AATlu232228IIoeeGAAAAAAeHh4eGAAAAAAeHh4ekAAAAAA8//1+AAIDw8PDwwAdwQPzH5hggAAAAPH/mGAAj/f//g7Azw8P/P+CP/oeHh4YAGf/////////6AFXMqpl9//9daw4IoS+ocgioV70P9UGkF8ORTGkpkcpnrKyvXr169VmjMzMyqqqqrWZmNmjEuuttMzOGbQlpUhl6f7GLQswhyCwGnC55YDGkGqiBATQQUyaURC4gvMRKSZOTB31M+rmFQACWFiJj7ZokmNBT8HcRCPFhpYApdQIiVTvml8yVpctdOBI6Nj5lAUg05FKD16I6oMzdz3rJGaCiKsgtkBRwbogaKB0DvIvlCDS44yuqRnXy5WSHvbNJHRsqKUqXZixw726l2uwl3OABNlWYmf9WyAIYBvYpAChOKl8FjoLK3UUYTFaLPSxCCQIxJ+zq5w7ZYddds/QJ1BPFrCCDWK44z5nd4FKoBWXcLoCjwQJi4TCWgPtWH1KWQmDi349dKtdg8dfjSbqE1eh17PzSgADdnmJj21ogBhpqRY2VEZDqm6c7yBQA4ohguCg5KiWLDk3LLq08eddOGlgAByhn+UtaOo+DdopIGPGBmuyCbLFnde/N1bnv12ANW3l/7E3fPxqX92ezp/2dun/912f/TW9/835e4l+30gQm8TN3f+1iJLYQtLCAqs8pUkn/FV/Q2wZgbNW7aHSQm0qGRFSNYuiIIDFqtbYiYmQ1tIm65Wb9NAvkftBNWVBAzMFCLmiSciRZg5MBdk6ve95YpQmIKGPekUF6qak0ffRpKX/+3DEzIAM6IU/7SRuYZCPZ/2mDZwANIeaqo91aIASoOioefV1AqeaPjS1WRB61wqAu5CYtQRkIgWsJDB4qMSXzFGW1L/eTd2ObOWbo+HlkvQhY9aEI4AOsN2Qr+8A2VNyqpxmFzY8L/djnJ++EeefCTTTkLev2r2v3t3f2X09+f2+/AAJmYaXeFR1R7/JEkCQAADqhU9joCW3OWCWEN4jFBoMESQ5IsYAQLEZ6TI+lty6XjhcCzZFKVSMmCCkLQXWukOAbCQyBsg6KyqQwvk4YEQGqOItitEU01McTRTJ81J8uJHC0YldFVToMhM6DLNmN01IP7a6bJsgg6kE3mpfWeNXdaLfZakaDOnaim8+mX0mNzdBTMndNTPs16FBNJNNbspSRoWqBURZ0z7MgpOpTb///88ln/1O//tQxPiADTRjPe0waSmMFCh9pI2UILUCNKd5SJh5eHf/yRxpkkFo5C5QHNLoNg9FRiYKFM9ULnmkACAjzhMhYxDDkMQlN1PdIxEUMCwIg2gBNsk0AQccjyjgougNZ9JhpELpjogFNbHD7+QzI2dT8DAo0u2zxBMqVujezcOQ5D7LZp9Y6/bKVGWSMEZ7f5dwhyfndyihp6r5s2as88RaesTkbkdDNSm5Uksgp6bUZgydYmsOoA4bmpfvhNU3HbqS+Wy6bq4T01vOgtzTFmmPPP/7cMTvgA3AcTv1lAAq3jpm/zUAAJGGr/hxd7gRak5hUn7+FrdexbvZV8dSrlbLV9lbDYebm4cAZwJK3IiEUu7pL9ukvTcqs9mNWd61hjKsqtLFqWW1JTqz+t7vXBKf////WbBFmJh1U5fJEldIuCwFg2nIQAYsdbmxRaTMoDXdDECMr0cD6iAKyOZ6SNOrm0GuLzVUaOKNdxSzLH/Hu8TBe42XpJd4rWaVX+pWEeBmkd1vt1d9XcjHPjSOddINbTn/uX37246hKW5ueeNVget0jaQoxh7VR5rUcRbRWig3SiE3hkZER2yIkOyWnUQpHXBy8w6DRWxvS3jZLEPy6Ru9SSmNzoPyeTBUtMTPOyHWUpCC4jUdjDXdo7SWu8wfD6WM1yynS70vfYpVX7q67Mj1sZbMrMyEpR7/+5DE7oAg8Z9N+ZyQAfOvqr+wgAFXZ3u90Vk976JTr3pupaozstnEnVl5VlR+wMndmaFXbVxAvFDvXIBP4iICwLinAGsfZoh3HElYCAYWdkUF3cl+iK5KMYI0eKhjw8YdFIBoTXpKWuKTmKn6yHpSeEHhvFkaCjqXWCjX6qggn7MZ3/DP/ncZW9ZEGVC4p/u/IKl/UGLNN5tLVQIoZZloj/e0l3IfIlyXn0B/I44EQOwmJ4C2OJKoDMUo3lC1UkXP05yB8Ui91XXgbjGRA4xdRDZCJih3hmbbmuaMqhbMzZiVeH/+fP+ZGaeXG/84RmS9TfLwpZyHV1tIoKhGd+mkl3X12v+zAVRWh2b25QBOnBgyJZAlr5QFAm20vLe3WmsyZfKzIgBBjAbRnnIkwYl6wYXAW0IrG0yRnnTk8rTLeNedr8nbIwCTJz7vltz+/PIvyl+l8cqu0lzNyI8ZBeLURHeIYEgjDoMjRr6KYzfNqgAEKFVWb2VMAOsMAJpLgVcKgZIwWqn1UTXe9KOlDi8kZGcpCwtCCDZRI4sRGLNZKSn/+2DE8gAOKXNV7CBRibCYK72HjLWYLkfIy3dCuW6/mhWu7YggxFp5qbl//fzpMR383FoHrzWPFJ6EmpDTKHRSHditKjCptJVIXmWWjJKtYACnCO7P9soQbWIHL2HGSoZC11QakRZXYg46b3dbNJbMVkU3VSzKHzt1dfN7zU4uy3jLoPyX282qCn+5fLn06ZgAnM+RCnzy8isKUiZzKMZzQiKNN2DiDE0vG5HcORTw9S7vxIRj5fbh4fZjn+p/8gEDM0Z4jfVQA24S4T4L1J4I+LeZzQpXy9XbZbUbb2B4jJKST0IVJA4pBOY9zcxqzaLrNpmTdM9rRTWViVcVemeecr3DxHP/+1DE+wANUUNf57Bs6aanqv2EjZUNOc6qxGzDe266NaVGUyOFSkQrqodGs86EJZSuq0IiP3c49zGUrb3LFw6RjS40zEbf9wALsKu1R9s4CrxGZFkdbDqAYeQAjQIqhdXcsVSyGXMguKCJvvdhyYQGqxGoZLuSouuTJ6/cpPzrynZn538id0qSeXn5P///DzzuU4yO4c+pRbFcq5VLGa580ikwx8XU1ofNrIXCu3dfIBVBV3l/vpSDZSDSlBUzUowYVpg0W2yWq02BUfXjabOd//tgxO4ADW03VewkbKG9oWr9gw4licolWdNIdy34d1sexjTl09eT4pAmWjiWv335rMurpnfJ7XF6ZY4Ch7TqbfG5kX/X9JCouzlZGdmMOkqOn3T90CAYRgiFeYbDcc0TgNout/9wALQqMsz9umQdMkuW9C8JEWmWMpNGeB33aCVDIHxuI52bvzQ2N2HSlrjcS77y0zfGYFDEo4/LC37IGBBwOzrUzql0QSvgE7Om5F/l3LyysU5VKuLXy7TbIs60//84Xa3PvMsjyv7wcGNx7Ln9ePsoqtxie+0QBWV1WY+1LKVpwAtPMkXOoWtAURYzfXzZm5Wy6IxSNS+I24XdnIepAxPo//tQxPiADwVZVewYsSGfJys9hI3MroUNhd4WmZTxckRmRqeyZ90OMmt2Y0hiOBA0coRiLvvJ+7dzGy3d1DRiaghZ1JMU1JUKp0VdfWOfCQoszjxUyAcVklmBaKrvtATaKh0afrSyXI8IqMWHTJLNHUaY8u3hd504U1Wdf34Brw1E7UgqTuFmUVLNpeJnBwg5DkIFB8e70/Pni8lpvHnVV7lWISUjGUBUVFY1jDhKhpI0sXW0qTfySsXesNhoPD2vYw6gaP7LkO7PSgEFh4cie//7YMTmAA41J1fsGFOh0KxqvYYNZSwIoykBRhohgS+CjKBC4zLBTiOwpvJ6NWoGq6pJFF5VZp5VA16kuoqEdpXjNAQgeqMPvD9zV0ipTn2e2LhUaDkMd2U48v6UqRra2byqUpmNO4xRYVDxIXLfSy/3UgegLINMViJv0AKNezamvurac82QHgkSVPFClfyBRVhSfDAKds9eMRCVVA8MqcSIQgBt+qgu1jtpFGEqzCSUUMW1/+ImtkqHWKqVtr6g8t057v/1j2mfn+qqf7rhixwz12HDp+qX9ebl9eOv9Pubjs5a4Z8fFMWWFvNK2H+o74DVACVbzLd4JFVF8kcUbTaYANQSAv/7YMTrAA55O1PsIFLhr5aqfYGapAw2L8WGEdk4AsiCS4aor+OwtMOVMwOBpI1iUCDC9zJmAICU7SBkuL7o2t5da+XpZUos0JYCYzh5+nOxZi7MCr8UEVypBM9Tl+W7wezn6eJKByxlkNMonqOWTUP3rkqnpizAMOTLjzUNwfJZRNTud23AsBSt5KtDdoHnhuH2aS+a33LmqSfmd4ynC5TVKSjuwfVk7XGGO5JOSepDFLT1KS3b3cuU2tarXdY/9WDW5NoxNrbryCNy+hi/Od/Pv////9/H96539f////bq28NYYZ6sZpBQ/Z/LzJipeI/11mlrbMgHha6DrCQMlKM6RBhSof/7YMTzAA19B0/sDLUh2yzqvrCABZsM2sZ6LIxYCENkA7bPMiEDApfZ1nzW60pnSWzKJ1Np1IdIGLETqm6OeZFDUidtzG2bKsWX5PS5MBUb4wc/M7Rshf2lkUO02MtcmehmzctSmxPxq7FdcjVLUlUq5TX5iWX7fy2mrU0W1VsRGV0lNWo9QzKatzkzjlficol1a5rfZTNztBVispqZaz1lvlLjd3jauZ6ztav632r/Md0s7uljNz7NLLdb3zn3q/M6U0LjSA46Lj2P/////QoDW6zMqZ+lbILbiVkQ7rtTVlKIhe5pTOVq8fa3Zu2JoOhQmEg6ZQoTI4uKEGEIUWlU1zuiK//7kMT5gByxkUH5rAADX6zpvzWACBkopzNOURMhTLMqyzSlIVFMxbOR1Sltvs6d77PKXvMtEu9j7J7IajOdbIlNT9jK+ziBJY1ZZgiXe0UtpsFJiYlod9I00UC6BGwB8V4IwOuaEWBDY8VVLh9j3OHglKQFFQFDgiHQ6CGOLnd0Md1RiEYaJkO7FWhFUioitkqitd93o6sIFOV2VHRUdEf5mnZMpjToZd66bS3tZjZDHWIChN7ijWhe1C9Sr0X/6RXVa5W6WpSqWZV4ka+M4UAQAAQApIQDNAYssGtEMYqr2Ig07dpM5E/tM3ZwaooGMmqzgWsCggMPhAw7YmnRD1A6Q+Bg14G6WgbMUZGZmXi0iSgyABzgDBDwGnwFhKJTWXSgXiZHeMmiAURA17UGwUBaGMR1rqPldB1FRIGxYtwNggY8R+Dbid1sZMy02PYuELbijitw1aKCDfGRUzLU7+u63LRSFyE+LnIoXAy+Op7tSp1K/7xbyHkuWCCORcjhOg+CIr2oHmrbq//7pGk3ZzAuIi/6VW27PVVM0yxh/xzuAP/7YMTggA4xXUP9goAhwaamvp5QAE+U5RAUh2AIwPgGySNPjZLo8b0kulExoBif4iwNR4j7ELd6/x7X1NvW4fxNisOFDbaKCPRaVC7fIZGttjR6jVIngZhzIoCcNEm5yI5DSHkWiXMY4Lc+kEhArwYbMTUyzSuqVSZatfOiZzskU7iYiUMNdGWhbE2NhGySHqqBhlufmQp0KTxwqZAxEeTxDDRIKiTSZSYqoYzJFQwWc+zAhLg6y+wVKX5SKt2iS2q1cGcQFuJWShEuGIQ+yfHuPWSmYbxqQ1IbqHQzuLspVCql0s4cm58dUIgvFnRIqrqUWwokhKIBQZzCXXFhsETLYGsZiv/7kMTngBqFj0H5uhALizDq/57wBbT55Y7L3WnohElnDyMQCOi91v2Ie9c4qcO/ZsoiEHEpyWsvMnSJW+pLP6XvsZFmanp0v21Jj40jNeG7MGP+VopRvnf34Ir/a5Ce7J6FmbGFFd/6AiOJm3SLJJk57gwBu5IaBh4amGk1HEElM0eZ5NMll8EukQ7bUhOESC0k63kOKnNxKNEnHgodM3ecpWuhmVKMYxnbQSsU80ReW83/r6TIszEBDqe5zCyCVDCxthvhKzxAbaWDLDxGZiAVdrtzj161h96ANqgESPQHoAdqYaoPSQpxjniXUD7JVEJcxDtI8F2mImuLgNBCDs+8fXDBh6Y6CXUQwSkR8KNZDt8s1c261OSMn/kVlIlPh5LDNQYUNG8MOLxHS//4rtCn+m2WNUI5rnKPwcVKDFEnesUA3qrhq/u/Re9eo6RlLGpG074S2NpK9gBeCIh6IzGLaXibWEJOYrLFPehlVsqtBoFEiiV4RQobOf4i4Q3UyMdKwk8uzLVlBYlef/8/d3t1FhK8Ck3RB/Wc///wxlO95f/7cMTSAA1g81fsGG+JmyDq/YSV0My3k/I/zGggMkp1IEadm6aNn7SVfLNNUbOhuxkoq/sIR+UMXezaMRd9t2yzgVB3bBk09km6t4oTGGu0S0TKElyrfUxS0ciyclJLs79zw9g6GRzzdGf/rTrQ5qHyEukxxjg2ZUffrkb1Vu9DFWS/oMAswNkCZrrdhYltkIV9dKnTQ0JRIVOGopN7levox9mcCRN6ZYrhEnBgTLkB5mFf7vXRxqd3ueazhMFQUDzoRQTXWUYQPWzSJBEwQAEGiEfTJCGgsARFzOR3P88yPr8JI79neOv5Zl1/ySmehvkeWU+dQ0Nr02bIIKDqUhV5qYpyKMNtBSVIjSpRNSwhEpmr5+ULLLNGvsnj0badFK1LZjP01SjP4ppudfXtze/fheuxPKGXTt7/+1DE+wAOSWtZ56Rs4aqsK72GDWW5UWRWbXCxOsXm/Y5zLdNXnTJ/9IKakWVR/+RfCvhXrJcQnV76y+JzNledtFiusVxYgohZ7JUlnGFtO4vxS790eRUKf0Wk3UI5iTeNioBWw5jC3k8PBrxI6wis2bvKtV8CJACD9CxOYDkBkBXDBXYtBOCFF6IaPQN00mC24qGrf6qjIukhlkbszau0a7bmuUxJBV6aT1mJI5JOxlz2r+R/htjGxW9D+Jcx7rFXau0khUVFlTTqQCkuRisH//tgxOoADQFlWewgT+nbrKs9hI30GGLGtPLXoYMaZkgVmgg+nJzUlBdA37yt85+/fnqmbTrkov9nlTj24Tl0l3X9zdzMxl6AAABExAYB5GOuAtQCOW0QsgJmkxK4oC4EmYJHNljs3sp4jje9u7kwdf++3SDhnAxWSNq7IYUzI8lTe/Wh33zkp8lnUdzpuU00BBB/LzYpoTI0CJnTxyaaHC0zIUOIVqgzTLbtp8Nfkdv5e1/dy9Rln2H9+qjsmrsVvzMzUOp0gAAAMcEC1YgQd+i5U2mMyZpLNHdYEw1YV9H9fWzhYiEmhKK7RProd1r/N8ftXJCnBxsyVIS7Lcz5M8LFFnqt//twxPKAEoFvUewxE8oyrqu88yZ0uNF7pSKAkJTJCWVxoiYFCiBopCUVlkRPfiKRxlUl0eW2MetkwgFcXNRHcUqXySdcSmKcilU6eertGs8J4yqt4wMi6eaw5W7JHxNjUWZ9bFoEka296k38wn+KSXxhyj7ZJ4qnnJ8ZVf+7uYmibMAAABEUtkiUHLa6kwmOqVKu1FWgPhD8aqR36eluZa/Cl1EKSvhdJXK7+/w33OUlmWtFSBExfNkBC+KKKFSWXGH9oGpdj7s1o1i0F5/V05pYlhK2cLliJk6WMtwISdJuZlsaJTpRZgUFBGFB4MtETm5kd0xmOOxNWGKT71CzLCETv0nuJBMPucT/83au9VuQAAAUoFhGpNQL6KbiS1ksWT3ay0iWN3Yk57/UOEuvO5rdu9WmrOdZNv/7cMT0AA/da2HnjTVira2p/YS+Ocwsr//93/l1FYTAOLOVZMjyB+XroXETu1SeE7/l8ef3Nx2uTaJwzyspBcBBIFAZikCxiRIB9R5IgogFlwe5JlqZR2NvEWYlqNr9VQ+sjlUxGZhsy9Uu1f+rqHmzSoAAAAWQ/hcUvW8SLKeiZqKcMKbQI4T4wHJp+KitoCR/20UHnNMwZvU4R9xyqjH9ZielgUNnSIjVSDAmPGsLHC3iwdQwmSeE1t7Owp9adtfM9LBy8/i29z91ggEiOxiQCSsRIzk7VG1XAYqCQRRCfUviUOh2pJB2kPy6jq/Vvlrv0jz8+HK/P7M1co3NvpfJ69+ghaOqKvZR35svFSpxgBVqs6g6GKEsElZkibHW2xbAz6G6R1YOuT2c/lnVkFmmsfvnbO/M9OT/+3DE8IARyWlV7CR1whQtKz2DCrnXr5tlzBYhKca9FqeJt0rzbY30vxy1TlzCfqQW1yf2O1m8mX1jt/fPYnkukFc+DbGPdJRxDdgUJilSAt61JAqPJOGy3TIorsRrbNN3pTOPvlTz/kpjOxC5sTQu04HMde+4eZimPIAAAACVHcBhFSIQBrAJosqNIOAul8H6VqEl2YG2VmT7291U+YrSZyvSLH3P6Zm2b1mplWOZUMiEWHVqgv26z7ZNpAtTcy1A9GdVvX4lKz4LZZlzOvDhs1Ko+gPFS45O1hEK8ZeP0NW+RimgLiSeCOJ5OMbmUYZGQlkNMvOzk0xKshWsRvvdtaPneqapSJ1N6lX9dQr8mVtQtdf/tXUXRPiAEcUb06CYqqCGLeIrMMT1ZAvyhfR2om2ztwVK8JT///twxPiAU71pUewlj8I2rip9hg64OVH3bm/8pt1wQyfz8JjEGgoDooOA7S7f0CE6h7KrREFHUPK0VL2uL3HIsdvZZBCRIix9qGxWVENY6KBVCSgIRYswb81NZEpphrtTTky22tA7brb/ooas3JzWjt+W/73tzMVuwAAABwFaEbE6E0AAgFsQhJCmYLQfKFotTH6/cZ0TDiMF4CtnGHqrO8cR7ixt3RwgAeHbiw0WjuHtIpJHLa9HDUtESS2m3upG1dsPaXUFUkaFG3Y5GBhcxFE8VokIrMjq4kRpZ2RMZMjCJNdpq1dSmm4ECmcwEuST1Mcnfvv1Otl/3u3ucy8gg1GsUIQewkAVokhLwjEIxBwIpTpCHEY3qobs2w9ZX0WbcWtLsEG/yKJi4wgwGRTGjSoU0plai2LIV//7cMT0gFP9b0/nsNXCCKQqvYQmqarfVTnjFEvY+4czGNxGMGDqLpIGBCaNmkBpAbjlFesZICxPdJxqVvTkDgqTyaohRARplTyC/72rq7Y1BANK1KwQFECxQTcQYBfjNVhHbXnALbQS0WzEL0th2X8s08rm5XVz5/re326m8KlEcDhL3U3/M6056dn3Nmy8np60f/trdvXvd/fDXLan2dttcpeFh1D3pj17BrxeKyszN7NVoe/ojtT9Oz7EQdGElgy0ftXV5dMeigMRwP4hQCgQYFgA1ljhklDQLmT42TeRyTZHKNdIbzDmRCDQ1bnBrCUS+bEpOgeDNa5VWyRGU3kMs1eZ2nn+Zn/mW37bjVrpZS63rpIG+ELgo+n/YpI10EAqdh8XNtWrPLIPYZRYEnwj/pzLyqIG0mj/+2DE9YBQxSFd56Ex6dYj6/zypuQTAuRPwixZyRCuAPY8BvF6eDrMk1aJR9NI3SnXe+ZYDJG+0TKih1J+bOdYWcEF2akjHM9469U1yVi4fKVKNG9VW/1Sv8bOPCzbEbuTGEeiVNeMTKSu5//ban+jJKwXbtHdObWa5A03GAmJoDREMBeC5hKxIgOQzgVJjswi6NUc5oHbDh0XJNMLVWp/Yg1sW847e+2lGgRb3lch15DaGwkY+iSkHR7e6kv7S5muf/lP2/Vc6vJ6RihsvT595hUliqHw6Oc+wdcUP0Lt7M3ccCjkbITJqH0jQnADkbwHEu45SVjFIMSgeo7EPVqIeDRksUb/+2DE74APBW9XzBhVwbshavjxmqgRHXnm1m7ly/xnzWHm//No9Hq1WQyY27lMrtWn5vlmuS3Jc+6zzZStX6fHCHrPCjNk+6n/Q6EvC1ZB2HubFigr61Pf8o3L3/7uoF2vuauYQJAG4uR9NJ6CGikhIQgaZLQ+Uol2pdlsDAL+Shazx9I+ElGk2t32e5zo0hzm9XsFB550ZBtmKn5LSppMitnDLkmZXLt/kyOH3wzZ9s78j5mXSgkh2MxeWl6DxTYFSx+l//lnicy8cgTbcQVhwwrjoLNl0AnGcAHAt0LskoK1FiLMkUHxW46vbMtkkmnC8i0lJseWjHgsrQbBQGlwLmPHINT/+1DE9AAM/WdZ54xVyaMkqrzzDiDC+ZH/XU8odJjzigr8fqzv3+ftGPSPoxXxDN2glcYSNPIh04C4lNvNEl1JL9jxWkjCYerhiTUkiobAOTMGwFJepEALElzUloM+lgtLLZRK97ULUwnL1PsqZqytjsy+KwwmuF2yo4cGaaAkRFOR2MzfNCfLb7ziVNDhIdin5fz/zVvIIhAiYcLLVFFTwQfTIECKvuCZpXcVvPAWLdEqATq7zsdUk40Fq6vkOzxEAH3CLNtxXCwrLm5Uj3Pt//tgxOkADYE7V+eYb2mvpKt88w31GJCiSoBbJuG1Lzly87bNZLXra+sQtNOQO5Oq5qC5Ds4oRVnNU/pFDEI6mVn/6cejOxjOYYDnRh6MvRDDHnQh2oUrNRmHIaySclQ5bhLIx8BprDxc/qABipvbl2S5EXUSGgJGkxPBtg8j9Ko7BRqkz0Ro5D/T1Xyme4hAr4ZS+X04Z/WsfjHqq6hzHnn0YWrZzZowkXovGQnD918fv2JSXSLo/Jn//elzXBKzMqpcWSiKj2hrRUAjGlnGfesKLt/fR0JqM1nc7sqLASiFjMAlQvAcYbANYHRIF8PYD8UhLE8hZOKwsXRGh9lToI133lMn//tgxPUADckJTeyYcKG0p2j9hg1p0bzVMSgaudo77qgybuZmh8MoiQc0SSV758hG2p05+Wf/lCRE0+xBpkvSam/kf9/L4ahAI7hzElhi2AiwF32Mro7JsjSLzdy3rBShdO4J80wwAvmYBhLAH+K8WAV0YjWxnXBcnNdWfRWRSx7ycxuaCQjnZ3mtLs9oelviV40NvfenRhdwesVFPKfowfrmZvCdiJQ9i6SnIeb20r+P5mXOn59/hmdrtpk5oV/Z+Won5sOK8S3VR3vM3sh4QAkXo+JKakHGQ5stUVeJRt+keIs8bwQ05EYjUfgCHbCglDnDroCQXH//NawAqAZw1q3dXRie//tQxP8ADnE3TewYr2GzI+j88wo4CMXTD92Q2IY4d2Yi89OOdebtuRey2yd0vIp7UV9n2OkxJGe/oVjkfGOwOQXxJys3Nzt2ozBLatETQcgHiWCZKNXZ+0ueX697twhXEy7EukES5DkWKImNsnPF1qSaf3vrYt89+LPrSmXO4123cHKNZBlvmtmUlIzvTKHONSl29rr5HnraXf59Q8/h5HO78B+2pGIyj9UnRIaQLKslv87e7spswTGpEVQgpdtAMqdUCYiX6+GkIpKaLra20f/7YMTsAA3xNU3npG0hwqypPPMOaY0BRY8YHa1yCp+tHctZjzojqDFKz3IICz1C2vWWh4WYPHdVa9WYxKCA9jIVxPr3K91+yPu6V+VWeyqRvdHaNtqrHc6/X86Y45QxvP3u7u22qBUjkZYt1UxZReaAEeI3ZnKcrSX9dx8XPd2hi54cmAtPoGotT3B6VFlrH2k516VJJr0UTNX9RMDWD7GGVdRUz3DmSVCRzpwtK66kZU4R2HGopjViKVbkR7VzL5pOLoZwuhyUYLybWVRSMe+s7byHXiZaLmAlqda029Lms6RrVjS9LiK9ay90FS+DoLiwhG5KmgTOil7K5o4CGJIk90ssrP/7UMTzgA1JZUvsDFHJtStqPYMOMasQ7OcYJzZi+Xhdyh+zFHE+nm/VvH6AqZuHjpyVtf5zP594ViedKmtShnUJhr/LHAPCLPJ/LhDndW8x/dN/11l5tOWM8+AikFEPAUDCArDNYwvz2HoRJZmAgUYeCuj5bF4vLW0qw7BUJyfWddGuYUdAqUridTHh3psxDijM285p5b6PuUKZETvlOEZH73Lh/9pO2gk2O+iD4LtDjAmWYAfHliEU/55Cs00y76nNvZcIyoyUQdA1RCFYSMr/+2DE5QANMSlR7DCsib0nKn2EDfhBbcFMW8TchIx1c2n6rl25wgmWININV9EIecetKnNxFPKxw4IkV43yzouiWBAQQKvTDgsPwRO3+841n5/zy5P75FdTy/cnODoVW9MkpiyhQg2JNcxkpa2u9t5mVdGVSTaBYtgnFxXDtDKA9KYOtrFmDVk/VzxpQ96r3yHwN3FhahahwRHSsPp8v/TFnbiNMpcVc1a73RAwPTUteUtqUtNUn+ebPOGUPhN5nqtc32zJsyGfMIWbJkly0e/DueRZ2kUy/RgeTGFYNL2Sdf+8mquCH1ZCSQVOX0YY0AOQWTWFddpSxFQwW9D9tIdzI4sHg9j/+2DE8IAObQVNzCRvybEi6jj0DiFA6MKp27hqfiqmuH3rcR1q3G5/TiVAVWtKbzOHja65v+lSGffKXFeZrpwnLokvx3EjnwXC+2ulOafnZpoTS9iwvbJ2IrqOQ3L/zc1NQJWAIgABxUHH4LiOWIwppK9ok+3BSsYM1dnkFuJDtfc1FNbqzgEyNAADCEEY3BGpBf30AGjJ9nn9qgQtBLMObD5P5Pc9Z/Neny/M04WhH1JqyBiaO6fAKhCWXOb7iCuX+350ec+Teq28uMys7NzajDvy5xL+rKqKQUsJKAAAlSmVAIIKMcgWgUsggfIDguz2LudqBT7W2wZNDkEyZ0xrwZDtbVb/+1DE+IANJTlT55hvCcktKnz0DjCsjt2FmnxOHz8nUyZrmTHUpsW2e5bluWU7M8oV6/lJwsgpmcvq7AWEuY5qGEKLhU96XLBBx7fxv1bdvHVyz7/6unioE4gCQABZCvUpmjqboD0BKxmWLYbI6DhNMcSGoFa/ZqRaPbpbFWh/C7hGMS8O3/XlWgAiytfO5IFMMwajRRUVXtV/Qindzo2dkNuJc9c/wZhWTX6NrILBFp8NKcNBUNy4RmfutJmf7cS/iNyM+ZW/501dWL2/av6c//tgxOgADaVzUcwgb0nfLan9gZp4uZiESxAoAABoFkLaCkZR3hMA5jPBeCPLBRp1qAteVKGQycEKFC5aoweolaUSY/M0eoFDihxV/n592dqhzQYyyW5/MoCuc/fIvy1hZfCJr0mL9RiHDgwo8IlWKjZMc/yBoDaRrnlRy5JblHL4/vmYeIkkjIJAACQlhAjE7CrAuDUGYUgkiFD6bhYUkdEduvDnXD9mmmX74k3KzqLlLaqpKgggSD7RP9mzDSBGsNXVU6H0xJ3u4bs/9Zjfxvp/G5dyzYMIYkadGahuqXYXBNIrUCDIdZI4uB7x29w1fXn7bFxfcxz872ryjICrpvrJqYoj//tgxO2ADdEhUeeYb0nnLSn9gZqxOshEAFEVM641UuawcHJWXbYonLC3teJ933lsQ4RDseoWty6Ugo96JeqX4XjsmA6Gj5n/4W2VRMVAdkujohQ+Hl5+t/uZX9mWZXeGfu6RWSjXkaZf8kqUNEeahbeFJPGlvcb1jP3Wd2W7qGNmK8ezjT6EFK/6ZmIlRORAkAAHdcFGxpSerY0LE9GtMyZG4S8KUkyZKt4xAuFDBtOQsvRb6OdFKs1VvtSQcIEt/HF3jdyCVIt1qbaLS41ntY3f53l4h+22uS6QcPJRHpRojsNPG2wd4rew1SZZSoGvwvt5VrljecPRYWsurQFE3br/3bmc//tgxPEADdE1U+ekbQH5LSn88pqYhX8TKABFgLqRJslwB7AHxylOKSQQSUf0iaOWRhrpUMks8Wr6eBBiTv7w4kL/GM/6+fPZ6xvf19MKZB9DEijFWV6DLMvQ99/Y2Xsh/3WnLmZVVeulkkiSyH0mi4N0WC2JUDssgjKtx4VrTD2X8qWbHfGxm7d0sDPeZpv/y7ibVE3aQdIfwLg8lkHWIGMJUhhkgNRdFogDnUqrrh4liBmSglBzLzSzCoTNivGs+PpAQTW3+qF5iSdQ8WyborJlvx/yvDQy//Li/nmrs4KoYow2LGwSRCBs25C1Sd9FhdeGQmR1Ve+6mpw2X1FohMRETwuw//tgxPKADxllUewVDgHfJun9h6FJNs0AUQTgmRvDGKAdYjJlpEyjlU/pMQqNtaQujjZgMopGRLm3+O8Fixr8/+m9FCSM93KsRPwv4fup8tz9exM8v//m+ptKOQaLn53M3wkfS+Ruv53Y9qZH1d2ODXjDO/v+zLh4ZV+abIMSgh5YQWGzFQQeSls2pfB6WOKYSTg3hOtZRmyAW2D2m1abi6ntaJHloYm4xig7q32oUx2HOwsZBczFJPIWlbo9pi1r97MvkYqvej2K5jDruav8hUbzM1+2kqP2caRo8uReupX+2paZVF2TLQUFigJBcVPWGi74wJKBvFKI+1VjjB2BvvepnoVE//tgxPIAT8FnWeeM2umcn2q88w4gooQo0QySekGO2XRR7rKp/LhLZs5+X1UH4O/kaiS+JmDnPkM97xP9H34hQ52Ovynn69X9DLOSf1rM+hqn2+shZkfwmeiRJMy5rTDNisn4aZCJJAkwV4A6kIAI2YRtF8qVRN1tBRC7kx07fooCOJmmoj9KX1mnKR6JVb8/76YR3Wiq2H7UTAkEtlqmJ2X/7q6tyqlb3te0v92UxrsZDlgootwFJqbHJNgJYukypWIqakrNmJh6NEurLIaToEZFqF43hQPWsrCtdnzM23c9toyQ1pL/4cVIv40WJi27ZjUv7Uy1y/Oa0t9R2FQjBTaoov6C//tQxPcADaFnVeekbomtLKp9hhWg4K4rM+8VVGKzu5i96auVFbc3v+tkOzKVNGKxvKa6IWhpCuUqsLGohQzBvdP876N7TNDTTImwbhLhWAAANSQpeFwFKDwUgsxhEIKJKHE9QtcWnOtDjGjT0UEwqodZ0CKKNChfw4KYv/NWCxgQlWEmiY5H3CAkDRM8w6ZA3+9As8gBmEr1J8KFgcIFS4DW+gSAEw5skqjJZ2Z4EydJTQMCPgpikJ8NAHMAmkJNwNBHBhDsN5CwpHODcOwUBf/7YMToAA2NaVHsIG9JoSApvPMKMJg1PnTz/XnNwuA+s3K+ewlRA181//rXKFW4TjAd4a6J9YDIOhHs6+m+Ontxt/1lliU7+TLcksp93ff8/YvzAB9HRnTrF01MsqYr2+7p2dakgS8uWJt2xIrEmLNcR6AxnkJOwg2jmEfJ60IJFPvqIkw3dqTiqfMnKLQApbdn98MXqvrf/v2gPZMMZqByJFT1e7Pa518/2NKoDCcWlbhKVYeCOWYMeOzV5pwSkh50WCJ5uE2G0by9QgLRU5CWqoZUVVgCS0pxElXY6NEpiD7Fz1jtgTCdF2FV2U1ZXHpQ40lBYwFlA5yLm2dN26QuEbn6+//7UMT1gA3tN0vsPK2JlpMpPPMOQKuLxFV67MZTsoFd0ZTCTvWdnKIMYHgEeKkyxYq0V05QjOtUSdFNREw5r5Ma9zZQYuuolnLyZDx7fpimmWeiJtpLGiB3hUFhAxGGBlBG2BCgRsgI9YQ5VOAuKG1rqhYGtrES78RaMw5GC8n0l/LO6ylvja3190U8baI0GiILDguRGHhpZx8DwWGufGvHKY51hJiWqM0+22q+7f/1/v3jaol2l2ZHbWqNEhzC+Q4LcU0FCLCdgj5UGOEMKdf/+2DE6IAOOIs/57DMicMX5/2HmKixdPxEaExKFUDIDGW0mYgFX2zaECMmF7kfPy0zk2NytzGW48KHcAnSWKirZ0+VRzkazHPiimJdejlhQ1W3pqqTc99rn1addS7xMOjttJIiQW+FrNGZrRyCCqeL21yt2VupX/XcnVoRRomcuY4p1UxCnURQdkLkjDrrk/SWnZYHcGq1HAOVBkBpCcJvqOSJpS7j81aK6qRWZfKoU0YLdts/7rNdTG1MmpiIWIeHf6ytogGeGaZCRQknI0HW4OQZ3PF1fsucJhNXPMbR1lqtRUcFEi6Tu1czJt9b+93ECYoyRzogw8YvXZulmZnnaXTuKUf/+2DE7wANkK817BivAZMRpvz0mch4NBEEhE1ZcVvIuMJgMMrexgrRoZZxq7lOV69xn7h0u8PDu8R9IkAAP86kA0tHEHo5Cuxfu3o0/zalKvJXmHF7G7LnGb83auZ+5fejDcZtAcy3GGsxi4AL4TeGtSXIi8Xymde8/YtxX5EZ7tbztXrbWuH4xtnWy/iCh14sz65Tit7vNvf/fyqmZ1d2h2+sjSAJQg85H6Ysv5FmuW3bluPY0HY9WgYIjg8op7orlEypW6ZkfTyc0oVjVnuYJJpKScNgyBoWmUhopGjIoiiBj4u088PKi/q0OKO1exzmNuVLVJdY4UmHZ3d4d/tq2iArAID/+1DE/gAMTJsz56RsgYKRJn2EjZDLIDGg2z0uMQpJTN84lkMGOzaTc4jpEcXQ8NoYaRlM1evFDqwj2RyM27mddiaZleHMWwLEXLTOhEMK2pIh9C3KaL7jLfXN6HaDPbrsoolKmHVnB3d//I0SAcQh6fYn8q0n6MJxtNMDbYdNnahjDrqTIgtwZPLiULtMgVZsMuJBoHWKcAmBxhFilNaYWgTRev67hlCVbB4pLqS+v9Por/dWQl1VWdmBvZEQAB3BGh6B0vjMardUuf/MzpKi//tQxPoADPTbM+ewZcGekCa88ZgFix2ItUnDs6aCrPsc91Wk6VYxXqlZ3Sexud5y3KrvrDnC2nNjMi6aDa8PJ65wmIucYECnm0cI/sXleJkXh3oUKibzReudIgWo3791/mqgAAAXfWyRECMnu2VzALJC5MecK1hIuTGCcIIDT2sCxIeogJlPQl6EjUgqAXgMMh0FksPDr0NbSlWkioihda9j3o1tJ0jm4SWSR9ZyTgCEIQif1/wic1F8n8X/EL+JnWfCEPli+ahCELwhIUxPwv/7UMTvgAuQozPsGGHBbBpmvMSMABX8xpnK2UuY3KWUoiHWQSDxaGVoiAIeM5WNloYxjRIWQzoa3KUOipni6kxBTUUzLjEwMKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqr/+1DE8QAKOGU154RlwZsoZjzzDAWqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq//tAxPIDCZhJL6CAQcEqN6KEAJa5qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqo=\" type=\"audio/mpeg\" />\n",
+       "                    Your browser does not support the audio element.\n",
+       "                </audio>\n",
+       "              "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.Audio object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "#    Speaker              Durée (s)  Aperçu texte TTS\n",
+      "--------------------------------------------------------------------------------\n",
+      "0    narrateur            0.0        [composed and neutral, even pace]  [emphasis] BOULE DE SUIF\n",
+      "1    narrateur            0.0        [cold and detached, clinical] [low voice]  Pendant plusieurs jours de suite des lambeaux d'armée en \n",
+      "2    narrateur            0.0        [ironic and dry, with a smirk] [emphasis]  Des légions de francs-tireurs aux appellations héroïques:\n"
      ]
     }
+   ],
+   "source": [
+    "# P5 : Generation TTS avec FishAudio S2-Pro\n",
+    "from v4.p5_tts import _compose_tts_text\n",
+    "from v4.fishaudio_client import fishaudio_tts, audio_duration_mp3\n",
+    "from v4.p1_voice_cloning import SPEAKER_TO_VOICE\n",
+    "from v4.schemas import AnnotatedSegment\n",
+    "\n",
+    "print(\"P5 : GENERATION TTS FISHAUDIO S2-PRO\")\n",
+    "print(\"=\" * 50)\n",
+    "\n",
+    "# Repertoire de sortie demo\n",
+    "demo_tts_dir = OUTPUT_DIR / \"tts_demo_notebook\"\n",
+    "demo_tts_dir.mkdir(exist_ok=True, parents=True)\n",
+    "\n",
+    "tts_results = []\n",
+    "\n",
+    "if annotated and fishaudio_ok and generate_audio:\n",
+    "    for seg_data in annotated:\n",
+    "        seg_dict = seg_data.model_dump()\n",
+    "        idx = seg_data.seg_index\n",
+    "        \n",
+    "        # Composer le texte TTS (extrait les tags du prefix)\n",
+    "        tts_text = _compose_tts_text(seg_data)\n",
+    "        \n",
+    "        # Determiner la voix de reference\n",
+    "        speaker = seg_data.speaker\n",
+    "        ref_id = SPEAKER_TO_VOICE.get(speaker, SPEAKER_TO_VOICE.get(\"narrateur\", \"\"))\n",
+    "        \n",
+    "        mp3_path = demo_tts_dir / f\"seg_{idx:04d}.mp3\"\n",
+    "        \n",
+    "        if mp3_path.exists():\n",
+    "            print(f\"  seg {idx}: cache ({mp3_path.stat().st_size} bytes)\")\n",
+    "        else:\n",
+    "            print(f\"  seg {idx}: generation TTS ({len(tts_text)} chars, ref={ref_id})...\")\n",
+    "            audio = fishaudio_tts(tts_text, reference_id=ref_id)\n",
+    "            if audio:\n",
+    "                mp3_path.write_bytes(audio)\n",
+    "                print(f\"    -> {len(audio)} bytes, sauvegarde\")\n",
+    "            else:\n",
+    "                print(f\"    -> ECHEC\")\n",
+    "                tts_results.append({\"seg_index\": idx, \"status\": \"failed\"})\n",
+    "                continue\n",
+    "        \n",
+    "        duration = audio_duration_mp3(str(mp3_path)) if mp3_path.exists() else 0\n",
+    "        tts_results.append({\n",
+    "            \"seg_index\": idx,\n",
+    "            \"status\": \"ok\",\n",
+    "            \"mp3_path\": str(mp3_path),\n",
+    "            \"duration_s\": round(duration, 2),\n",
+    "            \"speaker\": speaker,\n",
+    "            \"tts_text_preview\": tts_text[:100],\n",
+    "        })\n",
+    "\n",
+    "    # Ecouter le premier segment\n",
+    "    if tts_results and tts_results[0][\"status\"] == \"ok\":\n",
+    "        first_path = tts_results[0][\"mp3_path\"]\n",
+    "        print(f\"\\nEcoute du segment {tts_results[0]['seg_index']} ({tts_results[0]['speaker']}) :\")\n",
+    "        display(Audio(filename=first_path, autoplay=False))\n",
+    "\n",
+    "    # Tableau recapitulatif\n",
+    "    print(f\"\\n{'#':<4} {'Speaker':<20} {'Durée (s)':<10} {'Aperçu texte TTS'}\")\n",
+    "    print(\"-\" * 80)\n",
+    "    for r in tts_results:\n",
+    "        if r[\"status\"] == \"ok\":\n",
+    "            print(f\"{r['seg_index']:<4} {r['speaker']:<20} {r['duration_s']:<10.1f} {r['tts_text_preview']}\")\n",
+    "else:\n",
+    "    print(\"Generation TTS sautee (services indisponibles ou pas de segments annotes)\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "ecdccdd6",
-   "source": "### Interpretation : Generation TTS\n\n| Aspect | Observation | Remarque |\n|--------|------------|----------|\n| Delai par segment | 5-15 secondes | Proportionnel a la longueur du texte |\n| Taille audio | 30-300 KB/segment | Proportionnel a la duree |\n| Qualite vocale | Naturelle, expressive | Le clonage vocal respecte le timbre de reference |\n| Impact des tags | Modulation subtile | `[pause]` ajoute un silence, `[whispering]` baisse le volume |\n\n**Fonction `_compose_tts_text()`** : extrait les tags officiels du prefix et les integre dans le texte. Les tags libres (non-officiels) sont supprimes pour eviter la vocalisation parasite.\n\n---\n\n## Section 5 : Validation WER avec Whisper (P7)\n\nLa validation WER (Word Error Rate) mesure la fidelite de la synthese vocale. On transcrit l'audio genere via Whisper, puis on compare avec le texte de reference via la distance de Levenshtein mot a mot. Un WER <= 15% est considere comme acceptable pour un audiobook.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Interpretation : Generation TTS\n",
+    "\n",
+    "| Aspect | Observation | Remarque |\n",
+    "|--------|------------|----------|\n",
+    "| Delai par segment | 5-15 secondes | Proportionnel a la longueur du texte |\n",
+    "| Taille audio | 30-300 KB/segment | Proportionnel a la duree |\n",
+    "| Qualite vocale | Naturelle, expressive | Le clonage vocal respecte le timbre de reference |\n",
+    "| Impact des tags | Modulation subtile | `[pause]` ajoute un silence, `[whispering]` baisse le volume |\n",
+    "\n",
+    "**Fonction `_compose_tts_text()`** : extrait les tags officiels du prefix et les integre dans le texte. Les tags libres (non-officiels) sont supprimes pour eviter la vocalisation parasite.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Section 5 : Validation WER avec Whisper (P7)\n",
+    "\n",
+    "La validation WER (Word Error Rate) mesure la fidelite de la synthese vocale. On transcrit l'audio genere via Whisper, puis on compare avec le texte de reference via la distance de Levenshtein mot a mot. Un WER <= 15% est considere comme acceptable pour un audiobook."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
    "id": "577bb3cd",
-   "source": "# P7 : Validation WER avec Whisper\nimport requests as req\n\ndef normalize_text(t):\n    \"\"\"Normalise le texte pour la comparaison WER.\"\"\"\n    t = t.lower().strip()\n    t = re.sub(r\"[^\\w\\s]\", \"\", t)\n    t = re.sub(r\"\\s+\", \" \", t)\n    return t\n\ndef compute_wer(ref, hyp):\n    \"\"\"Calcule le WER (Word Error Rate) par distance de Levenshtein mot a mot.\"\"\"\n    ref_words = normalize_text(ref).split()\n    hyp_words = normalize_text(hyp).split()\n    if not ref_words:\n        return 0.0 if not hyp_words else float(\"inf\")\n    n, m = len(ref_words), len(hyp_words)\n    dp = [[0] * (m + 1) for _ in range(n + 1)]\n    for i in range(n + 1):\n        dp[i][0] = i\n    for j in range(m + 1):\n        dp[0][j] = j\n    for i in range(1, n + 1):\n        for j in range(1, m + 1):\n            if ref_words[i - 1] == hyp_words[j - 1]:\n                dp[i][j] = dp[i - 1][j - 1]\n            else:\n                dp[i][j] = 1 + min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])\n    return dp[n][m] / n\n\nprint(\"P7 : VALIDATION WER\")\nprint(\"=\" * 50)\n\nwer_results = []\nverified = 0\npassed = 0\n\nif tts_results and whisper_ok and api_key:\n    for r in tts_results:\n        if r[\"status\"] != \"ok\":\n            continue\n        idx = r[\"seg_index\"]\n        mp3_path = r[\"mp3_path\"]\n\n        # Texte de reference (original, sans tags)\n        ref_text = next(\n            (a.text for a in annotated if a.seg_index == idx),\n            \"\"\n        )\n\n        try:\n            with open(mp3_path, \"rb\") as af:\n                resp = req.post(\n                    whisper_url,\n                    headers={\"Authorization\": f\"Bearer {api_key}\"},\n                    files={\"file\": (\"audio.mp3\", af, \"audio/mpeg\")},\n                    data={\"model\": \"large-v3-turbo\", \"language\": \"fr\"},\n                    timeout=30,\n                )\n            if resp.status_code != 200:\n                print(f\"  seg {idx}: API error {resp.status_code}\")\n                continue\n            transcription = resp.json().get(\"text\", \"\")\n        except Exception as e:\n            print(f\"  seg {idx}: erreur {e}\")\n            continue\n\n        wer = compute_wer(ref_text, transcription)\n        verified += 1\n        conform = wer <= wer_threshold\n        if conform:\n            passed += 1\n\n        wer_results.append({\n            \"seg_index\": idx,\n            \"speaker\": r.get(\"speaker\", \"?\"),\n            \"wer\": round(wer, 4),\n            \"conform\": conform,\n        })\n        status = \"PASS\" if conform else \"FAIL\"\n        print(f\"  seg {idx} ({r.get('speaker','?'):>20s}): WER={wer*100:5.1f}% [{status}]\")\n\n    if verified > 0:\n        avg_wer = sum(r[\"wer\"] for r in wer_results) / verified\n        pass_rate = 100 * passed / verified\n        print(f\"\\n--- Resume WER ---\")\n        print(f\"  Verifies : {verified}\")\n        print(f\"  Passes (WER<={wer_threshold*100:.0f}%) : {passed}/{verified} ({pass_rate:.1f}%)\")\n        print(f\"  WER moyen : {avg_wer*100:.2f}%\")\n    else:\n        print(\"Aucun segment verifie\")\nelse:\n    print(\"Validation WER sautee (services indisponibles)\")\n    # Afficher les resultats precalculules\n    print(\"\\nResultats de reference (validation complete sur 385 segments) :\")\n    print(\"  Act 1 (segments 0-20) : 76.2% pass rate, WER moyen 12.07%\")\n    print(\"  Act 2 (segments 70-90) : en cours de validation\")",
-   "metadata": {},
-   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-04T00:49:36.504217Z",
+     "iopub.status.busy": "2026-08-04T00:49:36.504046Z",
+     "iopub.status.idle": "2026-08-04T00:49:45.100702Z",
+     "shell.execute_reply": "2026-08-04T00:49:45.099988Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "P7 : VALIDATION WER\n",
-      "==================================================\n",
-      "Validation WER sautee (services indisponibles)\n",
+      "==================================================\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  seg 0 (           narrateur): WER= 33.3% [FAIL]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  seg 1 (           narrateur): WER= 58.7% [FAIL]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  seg 2 (           narrateur): WER= 21.4% [FAIL]\n",
       "\n",
-      "Resultats de reference (validation complete sur 385 segments) :\n",
-      "  Act 1 (segments 0-20) : 76.2% pass rate, WER moyen 12.07%\n",
-      "  Act 2 (segments 70-90) : en cours de validation\n"
+      "--- Resume WER ---\n",
+      "  Verifies : 3\n",
+      "  Passes (WER<=15%) : 0/3 (0.0%)\n",
+      "  WER moyen : 37.83%\n"
      ]
     }
+   ],
+   "source": [
+    "# P7 : Validation WER avec Whisper\n",
+    "import requests as req\n",
+    "\n",
+    "def normalize_text(t):\n",
+    "    \"\"\"Normalise le texte pour la comparaison WER.\"\"\"\n",
+    "    t = t.lower().strip()\n",
+    "    t = re.sub(r\"[^\\w\\s]\", \"\", t)\n",
+    "    t = re.sub(r\"\\s+\", \" \", t)\n",
+    "    return t\n",
+    "\n",
+    "def compute_wer(ref, hyp):\n",
+    "    \"\"\"Calcule le WER (Word Error Rate) par distance de Levenshtein mot a mot.\"\"\"\n",
+    "    ref_words = normalize_text(ref).split()\n",
+    "    hyp_words = normalize_text(hyp).split()\n",
+    "    if not ref_words:\n",
+    "        return 0.0 if not hyp_words else float(\"inf\")\n",
+    "    n, m = len(ref_words), len(hyp_words)\n",
+    "    dp = [[0] * (m + 1) for _ in range(n + 1)]\n",
+    "    for i in range(n + 1):\n",
+    "        dp[i][0] = i\n",
+    "    for j in range(m + 1):\n",
+    "        dp[0][j] = j\n",
+    "    for i in range(1, n + 1):\n",
+    "        for j in range(1, m + 1):\n",
+    "            if ref_words[i - 1] == hyp_words[j - 1]:\n",
+    "                dp[i][j] = dp[i - 1][j - 1]\n",
+    "            else:\n",
+    "                dp[i][j] = 1 + min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])\n",
+    "    return dp[n][m] / n\n",
+    "\n",
+    "print(\"P7 : VALIDATION WER\")\n",
+    "print(\"=\" * 50)\n",
+    "\n",
+    "wer_results = []\n",
+    "verified = 0\n",
+    "passed = 0\n",
+    "\n",
+    "if tts_results and whisper_ok and api_key:\n",
+    "    for r in tts_results:\n",
+    "        if r[\"status\"] != \"ok\":\n",
+    "            continue\n",
+    "        idx = r[\"seg_index\"]\n",
+    "        mp3_path = r[\"mp3_path\"]\n",
+    "\n",
+    "        # Texte de reference (original, sans tags)\n",
+    "        ref_text = next(\n",
+    "            (a.text for a in annotated if a.seg_index == idx),\n",
+    "            \"\"\n",
+    "        )\n",
+    "\n",
+    "        try:\n",
+    "            with open(mp3_path, \"rb\") as af:\n",
+    "                resp = req.post(\n",
+    "                    whisper_url,\n",
+    "                    headers={\"Authorization\": f\"Bearer {api_key}\"},\n",
+    "                    files={\"file\": (\"audio.mp3\", af, \"audio/mpeg\")},\n",
+    "                    data={\"model\": \"large-v3-turbo\", \"language\": \"fr\"},\n",
+    "                    timeout=30,\n",
+    "                )\n",
+    "            if resp.status_code != 200:\n",
+    "                print(f\"  seg {idx}: API error {resp.status_code}\")\n",
+    "                continue\n",
+    "            transcription = resp.json().get(\"text\", \"\")\n",
+    "        except Exception as e:\n",
+    "            print(f\"  seg {idx}: erreur {e}\")\n",
+    "            continue\n",
+    "\n",
+    "        wer = compute_wer(ref_text, transcription)\n",
+    "        verified += 1\n",
+    "        conform = wer <= wer_threshold\n",
+    "        if conform:\n",
+    "            passed += 1\n",
+    "\n",
+    "        wer_results.append({\n",
+    "            \"seg_index\": idx,\n",
+    "            \"speaker\": r.get(\"speaker\", \"?\"),\n",
+    "            \"wer\": round(wer, 4),\n",
+    "            \"conform\": conform,\n",
+    "        })\n",
+    "        status = \"PASS\" if conform else \"FAIL\"\n",
+    "        print(f\"  seg {idx} ({r.get('speaker','?'):>20s}): WER={wer*100:5.1f}% [{status}]\")\n",
+    "\n",
+    "    if verified > 0:\n",
+    "        avg_wer = sum(r[\"wer\"] for r in wer_results) / verified\n",
+    "        pass_rate = 100 * passed / verified\n",
+    "        print(f\"\\n--- Resume WER ---\")\n",
+    "        print(f\"  Verifies : {verified}\")\n",
+    "        print(f\"  Passes (WER<={wer_threshold*100:.0f}%) : {passed}/{verified} ({pass_rate:.1f}%)\")\n",
+    "        print(f\"  WER moyen : {avg_wer*100:.2f}%\")\n",
+    "    else:\n",
+    "        print(\"Aucun segment verifie\")\n",
+    "else:\n",
+    "    print(\"Validation WER sautee (services indisponibles)\")\n",
+    "    # Afficher les resultats precalculules\n",
+    "    print(\"\\nResultats de reference (validation complete sur 385 segments) :\")\n",
+    "    print(\"  Act 1 (segments 0-20) : 76.2% pass rate, WER moyen 12.07%\")\n",
+    "    print(\"  Act 2 (segments 70-90) : en cours de validation\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "80b4b1b1",
-   "source": "### Exercice : Analyser la sensibilite du seuil WER\n\n**Duree estimee :** 15-20 minutes\n\n**Objectif** : Etudier comment le seuil WER (`wer_threshold`) influence le taux de conformite des segments, en calculant le pass rate pour différents seuils sur un jeu de résultats precalcule.\n\n**Contexte** : Le pipeline utilise un seuil de 15% pour valider les segments TTS. Un seuil trop strict rejette des segments acceptables, un seuil trop laxiste laisse passer des erreurs.\n\n- **Étape 1 :** Définir une liste de seuils a tester (5%, 10%, 15%, 20%, 25%, 30%)\n- **Étape 2 :** Pour chaque seuil, calculer le nombre de segments passant (simule avec un echantillon de WER precalcule)\n- **Étape 3 :** Tracer la courbe pass_rate vs seuil et identifier le point d'inflexion optimal\n\n**Indice :** Utilisez des données simulees : [0.05, 0.12, 0.08, 0.22, 0.15, 0.31, 0.10, 0.18, 0.07, 0.25]\n**Indice :** Le pass_rate = count(wer <= threshold) / total_segments\n**Indice :** Matplotlib pour la courbe, plt.axvline() pour marquer le seuil actuel",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Exercice : Analyser la sensibilite du seuil WER\n",
+    "\n",
+    "**Duree estimee :** 15-20 minutes\n",
+    "\n",
+    "**Objectif** : Etudier comment le seuil WER (`wer_threshold`) influence le taux de conformite des segments, en calculant le pass rate pour différents seuils sur un jeu de résultats precalcule.\n",
+    "\n",
+    "**Contexte** : Le pipeline utilise un seuil de 15% pour valider les segments TTS. Un seuil trop strict rejette des segments acceptables, un seuil trop laxiste laisse passer des erreurs.\n",
+    "\n",
+    "- **Étape 1 :** Définir une liste de seuils a tester (5%, 10%, 15%, 20%, 25%, 30%)\n",
+    "- **Étape 2 :** Pour chaque seuil, calculer le nombre de segments passant (simule avec un echantillon de WER precalcule)\n",
+    "- **Étape 3 :** Tracer la courbe pass_rate vs seuil et identifier le point d'inflexion optimal\n",
+    "\n",
+    "**Indice :** Utilisez des données simulees : [0.05, 0.12, 0.08, 0.22, 0.15, 0.31, 0.10, 0.18, 0.07, 0.25]\n",
+    "**Indice :** Le pass_rate = count(wer <= threshold) / total_segments\n",
+    "**Indice :** Matplotlib pour la courbe, plt.axvline() pour marquer le seuil actuel"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "id": "28be5e4f",
-   "source": "# TODO etudiant : analyser la sensibilite du seuil WER\n# Etape 1 : Definir les seuils a tester\nthresholds = None  # TODO etudiant : liste de seuils en decimal (0.05, 0.10, ...)\n# Etape 2 : Donnees simulees de WER pour 10 segments\nsimulated_wers = None  # TODO etudiant : liste de WER en decimal\n# Etape 3 : Calculer le pass rate pour chaque seuil\npass_rates = None  # TODO etudiant : liste de pass rates\n\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-04T00:49:45.103460Z",
+     "iopub.status.busy": "2026-08-04T00:49:45.103165Z",
+     "iopub.status.idle": "2026-08-04T00:49:45.106986Z",
+     "shell.execute_reply": "2026-08-04T00:49:45.106546Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer\n"
      ]
     }
+   ],
+   "source": [
+    "# TODO etudiant : analyser la sensibilite du seuil WER\n",
+    "# Etape 1 : Definir les seuils a tester\n",
+    "thresholds = None  # TODO etudiant : liste de seuils en decimal (0.05, 0.10, ...)\n",
+    "# Etape 2 : Donnees simulees de WER pour 10 segments\n",
+    "simulated_wers = None  # TODO etudiant : liste de WER en decimal\n",
+    "# Etape 3 : Calculer le pass rate pour chaque seuil\n",
+    "pass_rates = None  # TODO etudiant : liste de pass rates\n",
+    "\n",
+    "print(\"Exercice a completer\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "436d6b0b",
-   "source": "### Interpretation : Validation WER\n\n| Aspect | Observation | Remarque |\n|--------|------------|----------|\n| Seuil WER | 15% | Standard pour un audiobook de qualite |\n| Methodologie | Levenshtein mot a mot | Normalisation : minuscule, ponctuation supprimee |\n| Whisper model | large-v3-turbo | Rapide (~2s/segment) et précis en francais |\n| Cause d'echec typique | Segments longs (>400 chars) | TTS peut omettre ou paraphraser des passages |\n\n**Avant/après le fix des tags officiels** :\n\n| Metrique | Avant (tags libres) | Après (29 tags officiels) | Amelioration |\n|----------|--------------------|--------------------------|-------------|\n| Pass rate | 25.6% | 43.7% | +18.1 points |\n| WER moyen | 156.96% | 62.44% | -60% |\n| Segments WER>100% | 98/385 | 61/385 | -38% |\n\nL'amelioration est significative mais pas totale. Les segments restants a WER eleve sont principalement des segments longs (>400 caractères) ou la synthese TTS omet des passages.\n\n---\n\n## Section 6 : Résultats de la validation complete (385 segments)\n\nLa validation complete du pipeline a ete executee en dehors de ce notebook via des scripts dedies. Voici les résultats consolides.",
-   "metadata": {}
+   "metadata": {},
+   "source": "### Interpretation : Validation WER\n\n| Aspect | Observation | Remarque |\n|--------|------------|----------|\n| Seuil WER | 15% | Standard pour un audiobook de qualite |\n| Methodologie | Levenshtein mot a mot | Normalisation : minuscule, ponctuation supprimee |\n| Whisper model | large-v3-turbo | Rapide et precis en francais |\n| Cause d'echec typique | Tags/directions vocalises | Le texte libre entre crochets est prononce, pas interprete |\n\n**Lecture du resultat live (cellule P7 ci-dessus)** : sur l'echantillon demo (3\nsegments, execution fraiche), la validation donne un WER moyen de **37.83%** et un\ntaux de conformite de **0%** (0/3 au seuil de 15%). Ce chiffre eleve n'est ni un\nsymptome d'audio cassee ni une erreur de reconnaissance : Whisper transcrit\ncorrectement le francais -- la mesure etendue (cellule suivante) atteint 20.45% de\nWER moyen et les meilleurs segments sont a ~0%. Il s'explique directement par la\n**vocalisation des balises libres**.\n\n**Pourquoi le WER depasse parfois 100%** : le WER est le nombre d'insertions +\nsubstitutions + deletions rapporte au nombre de mots de reference. L'annotation P4\nproduit ici des directions de jeu en texte libre (visibles dans l'aperçu TTS ci-dessus :\n« [composed and neutral, even pace] », « [ironic and dry, with a smirk] ») que\nFishAudio **vocalise litteralement** au lieu de les interpreter comme des commandes.\nLa transcription Whisper contient alors tous ces mots en insertion, et le rapport\nexplose -- c'est exactement le mecanisme qui poussait le WER au-dela de 100% dans\nl'etude offline citee precedemment. Seules les 29 balises officielles (`pause`,\n`sigh`, `whispering`, ...) sont traitees comme des commandes de prosodie ; tout\ntexte libre est prononce mot a mot (incident #1277/#1485).\n\n> **Lecon critique (WER #1277/#1485)** : les balises libres (non officielles) sont\n> vocalisees litteralement et font grimper le WER par insertion, parfois au-dela de\n> 100%. Le pipeline v4 doit n'injecter que les 29 tags officiels pour ramener la\n> narration a un WER qualitatif (mesure etendue dans la cellule suivante).\n\n---\n\n## Section 6 : Resultats de la validation WER\n\nLa validation etendue du pipeline a ete executee en dehors de ce notebook via les\nscripts dedies du pipeline v4. La cellule suivante presente les mesures reelles\n(artifact du pipeline + execution fraiche P7)."
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
    "id": "61193934",
-   "source": "# Resultats de la validation complete (precalcules)\nprint(\"RESULTATS VALIDATION COMPLETE (385 segments)\")\nprint(\"=\" * 50)\n\n# Charger les resultats de la validation complete si disponibles\nwer_post_fix = OUTPUT_DIR / \"wer_validation_post_fix.json\"\nwer_tags_only = OUTPUT_DIR / \"wer_tags_only_test.json\"\n\nresults_loaded = False\n\nif wer_post_fix.exists():\n    with open(wer_post_fix, encoding=\"utf-8\") as f:\n        post_fix = json.load(f)\n    results_loaded = True\n\n    print(\"Resultats POST-fix (385 segments, tags officiels uniquement) :\")\n    print(f\"  Segments verifies : {post_fix.get('verified', 'N/A')}\")\n    print(f\"  Pass rate : {post_fix.get('pass_rate_pct', 'N/A')}%\")\n    print(f\"  WER moyen : {post_fix.get('avg_wer_pct', 'N/A')}%\")\n    print()\n\nif wer_tags_only.exists():\n    with open(wer_tags_only, encoding=\"utf-8\") as f:\n        tags_only = json.load(f)\n    print(\"Resultats tags-only (segments 0-20, re-annotation fraiche) :\")\n    print(f\"  Segments verifies : {tags_only.get('verified', 'N/A')}\")\n    print(f\"  Pass rate : {tags_only.get('pass_rate_pct', 'N/A')}%\")\n    print(f\"  WER moyen : {tags_only.get('avg_wer_pct', 'N/A')}%\")\n    print()\n\nif not results_loaded:\n    print(\"Fichiers de resultats non trouves.\")\n    print(\"Executez les scripts de validation pour generer les donnees :\")\n    print(\"  python v4/wer_validate_post_fix.py\")\n    print(\"  python v4/test_tags_tts_wer.py\")\n\n# Tableau comparatif synthetique\nprint(\"\\n\" + \"=\" * 50)\nprint(\"TABLEAU COMPARATIF CONSOLIDE\")\nprint(\"=\" * 50)\ncomparison = \"\"\"\n| Metrique                  | Baseline (pre-fix) | Post-fix (#1485) | Tags-only (P4 re-run) |\n|---------------------------|--------------------|------------------|-----------------------|\n| Segments verifies         | 309/385            | 371/385          | 21/21 (echantillon)   |\n| Pass rate (WER<=15%)      | 25.6%              | 43.7%            | 76.2%                 |\n| WER moyen                 | 156.96%            | 62.44%           | 12.07%                |\n| Segments WER>100%         | 98                 | 61               | 2                     |\n| Amelioration vs baseline  | --                 | +18.1pp / -60%   | +50.6pp / -92%        |\n\nLe pipeline v4 avec tags officiels uniquement atteint un WER moyen de 12% sur l'echantillon\nAct 1 (narrateur seul), ce qui est un niveau qualitatif pour un audiobook.\n\"\"\"\nprint(comparison)",
-   "metadata": {},
-   "execution_count": 9,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-04T00:49:45.109415Z",
+     "iopub.status.busy": "2026-08-04T00:49:45.109007Z",
+     "iopub.status.idle": "2026-08-04T00:49:45.116787Z",
+     "shell.execute_reply": "2026-08-04T00:49:45.116341Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RESULTATS VALIDATION COMPLETE (385 segments)\n",
+      "RESULTATS VALIDATION WER\n",
       "==================================================\n",
-      "Resultats POST-fix (385 segments, tags officiels uniquement) :\n",
-      "  Segments verifies : 371\n",
-      "  Pass rate : 43.7%\n",
-      "  WER moyen : 62.44%\n",
+      "Mesure etendue (verification_transcript.json, tags officiels) :\n",
+      "  Segments verifies : 22/25\n",
+      "  Pass rate (WER<=15%) : 54.5%\n",
+      "  WER moyen : 20.45%\n",
+      "  CER moyen : 15.59%\n",
       "\n",
-      "Resultats tags-only (segments 0-20, re-annotation fraiche) :\n",
-      "  Segments verifies : 21\n",
-      "  Pass rate : 76.2%\n",
-      "  WER moyen : 12.07%\n",
+      "Mesure live P7 (echantillon demo, execution fraiche) :\n",
+      "  Segments verifies : 3\n",
+      "  Pass rate (WER<=15%) : 0.0%\n",
+      "  WER moyen : 37.83%\n",
       "\n",
-      "\n",
-      "==================================================\n",
-      "TABLEAU COMPARATIF CONSOLIDE\n",
-      "==================================================\n",
-      "\n",
-      "| Metrique                  | Baseline (pre-fix) | Post-fix (#1485) | Tags-only (P4 re-run) |\n",
-      "|---------------------------|--------------------|------------------|-----------------------|\n",
-      "| Segments verifies         | 309/385            | 371/385          | 21/21 (echantillon)   |\n",
-      "| Pass rate (WER<=15%)      | 25.6%              | 43.7%            | 76.2%                 |\n",
-      "| WER moyen                 | 156.96%            | 62.44%           | 12.07%                |\n",
-      "| Segments WER>100%         | 98                 | 61               | 2                     |\n",
-      "| Amelioration vs baseline  | --                 | +18.1pp / -60%   | +50.6pp / -92%        |\n",
-      "\n",
-      "Le pipeline v4 avec tags officiels uniquement atteint un WER moyen de 12% sur l'echantillon\n",
-      "Act 1 (narrateur seul), ce qui est un niveau qualitatif pour un audiobook.\n",
-      "\n"
+      "NOTE : valeurs sourcies (artifact reel + execution fraiche). Une version\n",
+      "anterieure citait un WER baseline de 156.96% (tags libres) issu d'une etude\n",
+      "offline dont l artifact (wer_validation_post_fix.json) n est pas present ici :\n",
+      "non reproduit. Le mecanisme -- les tags/texte libres sont vocalises par FishAudio\n",
+      "et font exploser le WER via des insertions -- est visible dans les segments\n",
+      "WER>100% : la transcription contient la direction de jeu pronouncee mot a mot.\n"
      ]
     }
+   ],
+   "source": [
+    "# Resultats de la validation WER (mesures reelles : artifact + execution fraiche)\n",
+    "print(\"RESULTATS VALIDATION WER\")\n",
+    "print(\"=\" * 50)\n",
+    "\n",
+    "# 1. Mesure etendue (artifact du pipeline v4, tags officiels)\n",
+    "wer_ext_path = OUTPUT_DIR / \"verification_transcript.json\"\n",
+    "if wer_ext_path.exists():\n",
+    "    with open(wer_ext_path, encoding=\"utf-8\") as f:\n",
+    "        ext = json.load(f)\n",
+    "    print(\"Mesure etendue (verification_transcript.json, tags officiels) :\")\n",
+    "    print(f\"  Segments verifies : {ext.get('verified')}/{ext.get('total_segments')}\")\n",
+    "    print(f\"  Pass rate (WER<={wer_threshold*100:.0f}%) : {ext.get('pass_rate')}%\")\n",
+    "    print(f\"  WER moyen : {ext.get('avg_wer')*100:.2f}%\")\n",
+    "    print(f\"  CER moyen : {ext.get('avg_cer')*100:.2f}%\")\n",
+    "else:\n",
+    "    print(\"Mesure etendue : artifact verification_transcript.json absent\")\n",
+    "    print(\"  (genere par le pipeline v4 : python v4/p7_verify.py)\")\n",
+    "\n",
+    "print()\n",
+    "\n",
+    "# 2. Mesure live (echantillon demo, cellule P7 ci-dessus, execution fraiche)\n",
+    "if wer_results:\n",
+    "    live_avg = sum(r[\"wer\"] for r in wer_results) / len(wer_results)\n",
+    "    live_pass = 100 * sum(1 for r in wer_results if r[\"conform\"]) / len(wer_results)\n",
+    "    print(\"Mesure live P7 (echantillon demo, execution fraiche) :\")\n",
+    "    print(f\"  Segments verifies : {len(wer_results)}\")\n",
+    "    print(f\"  Pass rate (WER<={wer_threshold*100:.0f}%) : {live_pass:.1f}%\")\n",
+    "    print(f\"  WER moyen : {live_avg*100:.2f}%\")\n",
+    "else:\n",
+    "    print(\"Mesure live P7 : sautee (services indisponibles, voir cellule P7 ci-dessus)\")\n",
+    "\n",
+    "print()\n",
+    "print(\"NOTE : valeurs sourcies (artifact reel + execution fraiche). Une version\")\n",
+    "print(\"anterieure citait un WER baseline de 156.96% (tags libres) issu d'une etude\")\n",
+    "print(\"offline dont l artifact (wer_validation_post_fix.json) n est pas present ici :\")\n",
+    "print(\"non reproduit. Le mecanisme -- les tags/texte libres sont vocalises par FishAudio\")\n",
+    "print(\"et font exploser le WER via des insertions -- est visible dans les segments\")\n",
+    "print(\"WER>100% : la transcription contient la direction de jeu pronouncee mot a mot.\")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "ab24087a",
-   "source": "### Interpretation : Résultats complets\n\nL'amelioration majeure vient de l'elimination des balises libres. Le passage de 156% a 12% de WER moyen sur l'echantillon Act 1 confirme que FishAudio S2-Pro ne traite que les 29 balises officielles comme commandes de prosodie.\n\n**Limites identifiees** :\n1. **Segments longs (>400 chars)** : FishAudio peut omettre ou condenser des passages, causant un WER eleve\n2. **Dialogues multi-voix** : le WER est plus eleve que pour la narration seule (transitions speaker)\n3. **WER != qualite percue** : un WER de 10% peut correspondre a des erreurs mineures (article manquant) ou a des omissions significatives\n\n---\n\n## Section 7 : Lecons apprises et synthese\n\n### Ce notebook a couvert\n\n| Étape | Phase | Ce qui a ete realise |\n|-------|-------|---------------------|\n| Section 1 | Architecture | Diagramme du pipeline 8 phases P0-P7 |\n| Section 2 | Prosodie | 29 balises officielles S2-Pro categorisees |\n| Section 3 | P4 | Annotation prosodique par LLM sur extrait demo |\n| Section 4 | P5 | Generation TTS avec clonage vocal FishAudio |\n| Section 5 | P7 | Validation WER avec Whisper STT |\n| Section 6 | Résultats | Tableau comparatif baseline/post-fix/tags-only |\n\n### Lecons critiques\n\n1. **Tags officiels uniquement** : FishAudio S2-Pro vocalise le texte libre. Seules les 29 balises testees et validees fonctionnent comme commandes de prosodie\n2. **WER comme metrique de qualite** : La validation systématique par Whisper STT est essentielle pour detecter les regressions silencieuses\n3. **Clonage vocal** : FishAudio S2-Pro produit des voix distinctes et naturelles a partir de references de 3-10 secondes\n4. **Architecture modulaire** : Chaque phase (P0-P7) est independante et peut etre re-executee separement avec `--force`\n\n### Extensions possibles\n\n- Integrer le contrôle du debit (vitesse de parole) dans les tags\n- Paralleliser la generation TTS avec `asyncio` pour accelerer le pipeline\n- Ajouter une passe de normalisation audio (loudness, EQ) avant compilation\n- Explorer les modèles de musique Ace-Step pour generer des jingles entre les chapitres",
-   "metadata": {}
+   "metadata": {},
+   "source": "### Interpretation : Resultats complets\n\nLa mesure etendue (22 segments en tags officiels, artifact `verification_transcript.json`)\natteint un WER moyen de **20.45%** (pass-rate 54.5% au seuil de 15%) : un niveau modere\nqui confirme que FishAudio S2-Pro traite les 29 balises officielles comme des commandes\nde prosodie et retranscrit une narration francaise claire avec une bonne fidelite\n(meilleurs segments a ~0% de WER). La mesure live P7 (37.83% sur l'echantillon demo)\nest plus elevee parce que l'annotation P4 y a laisse passer des directions de jeu en\ntexte libre, vocalisees mot a mot : c'est la signature du mecanisme #1277/#1485, et la\nraison pour laquelle le pipeline doit n'injecter que des balises officielles.\n\n**Limites identifiees** :\n1. **Segments longs (>400 chars)** : FishAudio peut omettre ou condenser des passages, causant un WER eleve\n2. **Dialogues multi-voix** : le WER est plus eleve que pour la narration seule (transitions speaker)\n3. **WER != qualite percue** : un WER de 10% peut correspondre a des erreurs mineures (article manquant) ou a des omissions significatives\n\n---\n\n## Section 7 : Lecons apprises et synthese\n\n### Ce notebook a couvert\n\n| Étape | Phase | Ce qui a ete realise |\n|-------|-------|---------------------|\n| Section 1 | Architecture | Diagramme du pipeline 8 phases P0-P7 |\n| Section 2 | Prosodie | 29 balises officielles S2-Pro categorisees |\n| Section 3 | P4 | Annotation prosodique par LLM sur extrait demo |\n| Section 4 | P5 | Generation TTS avec clonage vocal FishAudio |\n| Section 5 | P7 | Validation WER avec Whisper STT |\n| Section 6 | Resultats | Mesures reelles (artifact + execution fraiche) |\n\n### Lecons critiques\n\n1. **Tags officiels uniquement** : FishAudio S2-Pro vocalise le texte libre. Seules les 29 balises testees et validees fonctionnent comme commandes de prosodie\n2. **WER comme metrique de qualite** : La validation systematique par Whisper STT est essentielle pour detecter les regressions silencieuses\n3. **Clonage vocal** : FishAudio S2-Pro produit des voix distinctes et naturelles a partir de references de 3-10 secondes\n4. **Architecture modulaire** : Chaque phase (P0-P7) est independente et peut etre re-executee separement avec `--force`\n\n### Extensions possibles\n\n- Integrer le contrôle du debit (vitesse de parole) dans les tags\n- Paralleliser la generation TTS avec `asyncio` pour accelerer le pipeline\n- Ajouter une passe de normalisation audio (loudness, EQ) avant compilation\n- Explorer les modèles de musique Ace-Step pour generer des jingles entre les chapitres"
   },
   {
    "cell_type": "markdown",
    "id": "2c637c37",
-   "source": "---\n\n## Exercice : Explorer l'impact des balises de prosodie sur la qualite TTS\n\n**Duree estimee :** 20-25 minutes\n\n### Objectif\nComparer la qualite audio d'un segment avec et sans balises de prosodie, en mesurant l'impact sur le WER et la qualite percue.\n\n### Instructions\n1. Choisir un segment du pipeline (entre 100 et 300 caractères)\n2. Generer une version \"brute\" (sans balises) et une version \"annotee\" (avec balises)\n3. Calculer le WER pour chaque version\n4. Ecouter et comparer subjectivement\n\n### Indices\n- Utilisez `_compose_tts_text()` pour preparer le texte annote\n- Les balises `[pause]` et `[sigh]` sont les plus impactantes pour la narration\n- Comparez les spectrogrammes si vous avez `librosa` installe",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercice : Explorer l'impact des balises de prosodie sur la qualite TTS\n",
+    "\n",
+    "**Duree estimee :** 20-25 minutes\n",
+    "\n",
+    "### Objectif\n",
+    "Comparer la qualite audio d'un segment avec et sans balises de prosodie, en mesurant l'impact sur le WER et la qualite percue.\n",
+    "\n",
+    "### Instructions\n",
+    "1. Choisir un segment du pipeline (entre 100 et 300 caractères)\n",
+    "2. Generer une version \"brute\" (sans balises) et une version \"annotee\" (avec balises)\n",
+    "3. Calculer le WER pour chaque version\n",
+    "4. Ecouter et comparer subjectivement\n",
+    "\n",
+    "### Indices\n",
+    "- Utilisez `_compose_tts_text()` pour preparer le texte annote\n",
+    "- Les balises `[pause]` et `[sigh]` sont les plus impactantes pour la narration\n",
+    "- Comparez les spectrogrammes si vous avez `librosa` installe"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
    "id": "e94899fa",
-   "source": "# TODO: Choisir un segment du pipeline et generer deux versions\n# Indice: Utilisez load_inputs() pour acceder aux segments existants\n# Indice: Comparez avec/sans balises [pause], [sigh], [whispering]\n\n# Exemple de structure :\n# seg_text_raw = \"Le texte brut du segment\"\n# seg_text_tagged = \"[pause] Le texte brut du segment [sigh]\"\n\n# TODO: Generer les deux versions TTS avec FishAudio\n# Indice: Utilisez fishaudio_tts(text, reference_id=\"v4_narrator_male_neutral\")\n\n# TODO: Calculer le WER pour chaque version\n# Indice: Utilisez compute_wer(ref_text, transcription)\n\n# TODO: Ecouter et comparer\n# Indice: display(Audio(filename=path1)) puis display(Audio(filename=path2))\n\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-04T00:49:45.118768Z",
+     "iopub.status.busy": "2026-08-04T00:49:45.118459Z",
+     "iopub.status.idle": "2026-08-04T00:49:45.122787Z",
+     "shell.execute_reply": "2026-08-04T00:49:45.121978Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -392,16 +1151,65 @@
       "Exercice a completer\n"
      ]
     }
+   ],
+   "source": [
+    "# TODO: Choisir un segment du pipeline et generer deux versions\n",
+    "# Indice: Utilisez load_inputs() pour acceder aux segments existants\n",
+    "# Indice: Comparez avec/sans balises [pause], [sigh], [whispering]\n",
+    "\n",
+    "# Exemple de structure :\n",
+    "# seg_text_raw = \"Le texte brut du segment\"\n",
+    "# seg_text_tagged = \"[pause] Le texte brut du segment [sigh]\"\n",
+    "\n",
+    "# TODO: Generer les deux versions TTS avec FishAudio\n",
+    "# Indice: Utilisez fishaudio_tts(text, reference_id=\"v4_narrator_male_neutral\")\n",
+    "\n",
+    "# TODO: Calculer le WER pour chaque version\n",
+    "# Indice: Utilisez compute_wer(ref_text, transcription)\n",
+    "\n",
+    "# TODO: Ecouter et comparer\n",
+    "# Indice: display(Audio(filename=path1)) puis display(Audio(filename=path2))\n",
+    "\n",
+    "print(\"Exercice a completer\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "6d84ecc4",
-   "source": "### Critères de succes\n- [ ] Segment choisi (100-300 caractères, avec emotion contextuelle)\n- [ ] Version brute generee (sans balises)\n- [ ] Version annotee generee (avec 1-3 balises officielles)\n- [ ] WER calcule pour les deux versions\n- [ ] Comparaison subjective ecrite (quel effet ont les balises ?)\n\n### Extension (optionnel)\n- [ ] Tester 3 combinaisons de balises différentes sur le même segment\n- [ ] Generer un spectrogramme comparatif avec `librosa`\n- [ ] Mesurer la duree des pauses generees par `[pause]` vs `[long pause]`",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Critères de succes\n",
+    "- [ ] Segment choisi (100-300 caractères, avec emotion contextuelle)\n",
+    "- [ ] Version brute generee (sans balises)\n",
+    "- [ ] Version annotee generee (avec 1-3 balises officielles)\n",
+    "- [ ] WER calcule pour les deux versions\n",
+    "- [ ] Comparaison subjective ecrite (quel effet ont les balises ?)\n",
+    "\n",
+    "### Extension (optionnel)\n",
+    "- [ ] Tester 3 combinaisons de balises différentes sur le même segment\n",
+    "- [ ] Generer un spectrogramme comparatif avec `librosa`\n",
+    "- [ ] Mesurer la duree des pauses generees par `[pause]` vs `[long pause]`"
+   ]
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "openai",
+   "api_usd_est": 0.6,
+   "cpu_min": 4,
+   "external_account": "openai",
+   "free_alternative": "GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb",
+   "gpu_min": 1,
+   "gpu_required": true,
+   "metadata_written": "2026-07-23T09:30Z",
+   "network": true,
+   "notes": "Pipeline complet audiobook v4 (8 phases) : segmentation (gpt-4o-mini) -> voice casting\nreference -> generation FishAudio S2-Pro (clonage vocal) -> validation WER Whisper STT.\nVRAM ~6 GB annoncee cellule[0] (\"VRAM estimee : ~6 GB FishAudio S2-Pro sur GPU\").\nCout reel depend duree chapters + nombre personnages + iterations WER validation.\n---\n",
+   "reduced_pedagogical": "GenAI/Audio/02-Advanced/02-1-Chatterbox-TTS.ipynb",
+   "reproducibility": "MED",
+   "validator": "papermill",
+   "vram_gb": 6,
+   "vram_tier": "MID"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -417,24 +1225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
-  },
-  "cost": {
-   "api_usd_est": 0.6,
-   "api_provider": "openai",
-   "cpu_min": 4,
-   "gpu_min": 1,
-   "gpu_required": true,
-   "vram_gb": 6,
-   "vram_tier": "MID",
-   "network": true,
-   "external_account": "openai",
-   "free_alternative": "GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb",
-   "reduced_pedagogical": "GenAI/Audio/02-Advanced/02-1-Chatterbox-TTS.ipynb",
-   "reproducibility": "MED",
-   "metadata_written": "2026-07-23T09:30Z",
-   "validator": "papermill",
-   "notes": "Pipeline complet audiobook v4 (8 phases) : segmentation (gpt-4o-mini) -> voice casting\nreference -> generation FishAudio S2-Pro (clonage vocal) -> validation WER Whisper STT.\nVRAM ~6 GB annoncee cellule[0] (\"VRAM estimee : ~6 GB FishAudio S2-Pro sur GPU\").\nCout reel depend duree chapters + nombre personnages + iterations WER validation.\n---\n"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Follow-up to #9068 (merged). #9068 aligned the WER recap markdown to the committed (stale) output via byte-surgery. ai-01 CR'd it under §D.5: a perf number must come from a **fresh re-execution**, not a markdown-align on the old output. This PR delivers that fresh re-execution.

See #8052 (claims-vs-outputs EPIC), #3801 (SOTA).

## What changed

Re-executed the notebook end-to-end against the self-hosted stack on the GenAI machine (po-2023):
- **FishAudio S2-Pro** (localhost:8197) stood up via `docker start tts-fishaudio`
- **Whisper STT** (localhost:8190, large-v3-turbo) stood up via `genai.py audio-apis start whisper-api`

The previous run marked FishAudio INDISPONIBLE because cell 6's probe used `timeout=5` while a real TTS generation takes >5s; bumped to 30s (legitimate — the service exposes no `/health`, so the probe does a micro-synthesis). `demo_segment_end` 5->3 because TTS generation is ~3 min/segment (5 long segments exceed any single execution window; cache-reuse makes it incremental).

## Fresh measurements (this run)

| Source | Segments | WER moyen | Pass-rate (<=15%) |
|--------|----------|-----------|------------------|
| **Live P7** (Whisper on freshly-TTS'd demo, this kernel) | 3 | **37.83%** | 0/3 (0%) |
| **Extended** (`verification_transcript.json`, real pipeline artifact) | 22/25 | **20.45%** | 54.5% |

Per-segment (live): seg0=33.3%, seg1=58.7%, seg2=21.4%.

## Diagnostic derive (§D.5)

- **Verdict: CAUSE_FIXED.** The recap numbers now come from a fresh exec (cell P7) + a real on-disk artifact (cell 20 loads `verification_transcript.json`), not from a byte-align on stale committed output.
- **156.96% root cause (diagnosed, cited evidence):** NOT broken audio, NOT a Whisper-French failure — the best segments transcribe at **~0% WER** (long narration passages, e.g. seg 16/19 in the artifact). The 156.96% (and the live 37.83%) is driven by **vocalized free-text stage directions**. The P4 annotation emits directions like `[composed and neutral, even pace]` / `[ironic and dry, with a smirk]` that FishAudio pronounces **literally** instead of interpreting; Whisper transcribes the spoken direction-words as insertions, and WER (insertions+sub+del / ref-words) explodes past 100%. Smoking gun: seg 24 REF="Tous avaient les memes projets..." vs HYP="**Avec une ironie legere, presque seche,** tous avaient les memes projets..." (WER 111%). This is the live #1277/#1485 mechanism.
- The non-reproducible `156.96%` hardcoded literal in cell 20 (its source file `wer_validation_post_fix.json` is absent on the GenAI machine) is dropped; cell 20 now sources from the present real artifact + the live result. The mechanism is still documented (cells 13/19 narrative + the WER>100% segments).
- **Spin-off finding (NOT addressed here, out of scope):** the live `p4_annotation` (gpt-4o-mini) still emits free-text directions despite the #1485 fix — so cell 13's old "100% tags officiels / 0 tags libres" claim was falsified by the live output; cell 13 is updated to match. Tightening the P4 prompt to forbid free text is a separate grain.

## Integrity

- code_changed: cells 1 (param), 6 (timeout), 20 (sourced loader) — all legitimate enablers of the fresh exec.
- md_changed: cells 13, 19, 21 — interpretation FOLLOWING the fresh outputs (sourced, not recopied).
- Fresh outputs committed: all code cells `execution_count` [1..12], 0 errors, 0 `raise NotImplementedError` (C.1), no `LOCAL_MODE`, no secrets.
- H.3 pre-commit: notebook carries real outputs (C.2). No hand-editing of outputs (rule 6) — every number is from a real exec/artifact.
- Verdict **SOTA-OK**: real FishAudio + Whisper invoked; the committed WER is their genuine output.

## Non-duplication

#9068 (merged) did the markdown byte-align (the §D.5-defective approach this PR supersedes with a real exec). #6948 (merged) fixed the `verify_transcript` WER normalization (different cell/function).



---
Grain: FIX/notebook-reexec — lane myia-po-2023:CoursIA — prev: §D.5 stochastic WER vein (#9068 resolved)
