### PR TITLE
test(audit): hermetic cover for audit_genai_corruption detection (0->23)

### DIFF
--- a/scripts/audit/tests/test_audit_genai_corruption.py
+++ b/scripts/audit/tests/test_audit_genai_corruption.py
@@ -1,0 +1,224 @@
+"""Tests for scripts/audit_genai_corruption.py — GenAI notebook corruption audit.
+
+Hermetic: targets the pure detection functions (no filesystem, no glob). The
+module's side-effects live under `if __name__ == "__main__"`, so importing it
+via importlib is safe (the glob never runs).
+
+Covers the two detection classes the audit reports on:
+  - corruption   : a code cell collapsed onto a single >500-char line carrying
+                   import / def / dotenv (the minified-cell signature).
+  - env-pattern  : which .env-loading idiom the first env-marked code cell uses,
+                   with the original priority chain preserved.
+"""
+import importlib.util
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_PATH = HERE.parent.parent / "audit_genai_corruption.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("audit_genai_corruption", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _code(src_lines):
+    """Build a code cell from a list of source lines."""
+    return {"cell_type": "code", "source": list(src_lines), "execution_count": 1}
+
+
+def _md(text):
+    return {"cell_type": "markdown", "source": [text]}
+
+
+def _nb(*cells):
+    return {"cells": list(cells), "metadata": {}, "nbformat": 4}
+
+
+# ---------------------------------------------------------------------------
+# is_corrupted_line
+# ---------------------------------------------------------------------------
+
+def test_is_corrupted_line_long_import():
+    m = _load()
+    assert m.is_corrupted_line("import " + "x" * 600) is True
+
+
+def test_is_corrupted_line_long_def():
+    m = _load()
+    assert m.is_corrupted_line("def " + "f" * 600 + "():") is True
+
+
+def test_is_corrupted_line_long_dotenv():
+    m = _load()
+    assert m.is_corrupted_line("dotenv" + " " * 600) is True
+
+
+def test_is_corrupted_line_short_is_clean():
+    m = _load()
+    assert m.is_corrupted_line("import os") is False
+
+
+def test_is_corrupted_line_long_without_markers_is_clean():
+    m = _load()
+    # long line but no import/def/dotenv -> not the corruption signature
+    assert m.is_corrupted_line("x" * 600) is False
+
+
+def test_is_corrupted_line_boundary_500_is_clean():
+    m = _load()
+    # exactly 500 chars -> not > 500 -> clean (boundary is strict)
+    assert m.is_corrupted_line("import " + "x" * 493) is False  # len == 500
+
+
+# ---------------------------------------------------------------------------
+# count_corrupted_cells
+# ---------------------------------------------------------------------------
+
+def test_count_zero_for_clean_notebook():
+    m = _load()
+    nb = _nb(_code(["import os", "print(1)"]), _md("text"), _code(["x = 1"]))
+    assert m.count_corrupted_cells(nb) == 0
+
+
+def test_count_one_per_offending_cell_not_per_line():
+    m = _load()
+    long1 = "import " + "a" * 600
+    long2 = "def " + "b" * 600
+    # one code cell with TWO corrupted lines still counts as ONE cell
+    nb = _nb(_code([long1, long2]))
+    assert m.count_corrupted_cells(nb) == 1
+
+
+def test_count_multiple_corrupted_cells():
+    m = _load()
+    long = "import " + "a" * 600
+    nb = _nb(_code([long]), _md("ignore"), _code([long]), _code(["clean"]))
+    assert m.count_corrupted_cells(nb) == 2
+
+
+def test_count_ignores_markdown_cells():
+    m = _load()
+    long = "import " + "a" * 600
+    # markdown cell carrying the signature must NOT count
+    nb = _nb(_md(long))
+    assert m.count_corrupted_cells(nb) == 0
+
+
+def test_count_handles_empty_and_no_cells():
+    m = _load()
+    assert m.count_corrupted_cells({"cells": []}) == 0
+    assert m.count_corrupted_cells({}) == 0
+
+
+# ---------------------------------------------------------------------------
+# classify_env_pattern (priority chain)
+# ---------------------------------------------------------------------------
+
+def test_env_pattern_none_when_no_env_marker():
+    m = _load()
+    assert m.classify_env_pattern(_nb(_code(["print(1)"]))) is None
+
+
+def test_env_pattern_env_loaded_highest_priority():
+    m = _load()
+    # src carries every marker -> env_loaded wins (first in the chain)
+    src = "load_dotenv() GENAI_ROOT find_dotenv env_loaded while current_path.name .env"
+    assert m.classify_env_pattern(_nb(_code([src]))) == "env_loaded flag"
+
+
+def test_env_pattern_priority_order():
+    m = _load()
+    cases = [
+        ("env_loaded flag", "import dotenv; env_loaded=True"),
+        ("while loop", "while current_path.name: pass  # .env"),
+        ("GENAI_ROOT", "GENAI_ROOT = '/x'"),
+        ("find_dotenv", "from dotenv import find_dotenv"),
+        ("simple load_dotenv", "load_dotenv()"),
+        ("other", "x = '.env'"),
+    ]
+    for expected, src in cases:
+        assert m.classify_env_pattern(_nb(_code([src]))) == expected, src
+
+
+def test_env_pattern_first_matching_cell_wins():
+    m = _load()
+    # cell 0 (load_dotenv) comes before cell 1 (env_loaded) -> load_dotenv wins
+    nb = _nb(_code(["load_dotenv()"]), _code(["env_loaded = True"]))
+    assert m.classify_env_pattern(nb) == "simple load_dotenv"
+
+
+def test_env_pattern_skips_non_code_cells():
+    m = _load()
+    # markdown carrying the marker is ignored; the code cell after classifies
+    nb = _nb(_md("load_dotenv here"), _code(["GENAI_ROOT = '/x'"]))
+    assert m.classify_env_pattern(nb) == "GENAI_ROOT"
+
+
+# ---------------------------------------------------------------------------
+# classify_series
+# ---------------------------------------------------------------------------
+
+def test_classify_series_known_roots():
+    m = _load()
+    for series in ["Audio", "Image", "Video", "Texte",
+                   "00-GenAI-Environment", "SemanticKernel"]:
+        assert m.classify_series(f"{series}/sub/nb.ipynb") == series
+
+
+def test_classify_series_unknown_is_other():
+    m = _load()
+    assert m.classify_series("FineTuning/FT-01.ipynb") == "Other"
+    assert m.classify_series("Whatever/x.ipynb") == "Other"
+
+
+def test_classify_series_backslash_normalized():
+    m = _load()
+    assert m.classify_series("Audio\\04-Applications\\nb.ipynb") == "Audio"
+
+
+# ---------------------------------------------------------------------------
+# status_label
+# ---------------------------------------------------------------------------
+
+def test_status_label_boundaries():
+    m = _load()
+    assert m.status_label(0) == "OK"
+    assert m.status_label(20) == "OK"      # 20 is NOT > 20
+    assert m.status_label(21) == "MOYEN"
+    assert m.status_label(50) == "MOYEN"   # 50 is NOT > 50
+    assert m.status_label(51) == "CRITIQUE"
+    assert m.status_label(100) == "CRITIQUE"
+
+
+# ---------------------------------------------------------------------------
+# audit_notebook (integration)
+# ---------------------------------------------------------------------------
+
+def test_audit_notebook_clean_no_env():
+    m = _load()
+    nb = _nb(_code(["import os", "print(1)"]))
+    assert m.audit_notebook(nb) == (0, None)
+
+
+def test_audit_notebook_corrupted_with_env():
+    m = _load()
+    long = "import " + "a" * 600
+    nb = _nb(_code([long, "load_dotenv()"]))
+    count, pattern = m.audit_notebook(nb)
+    assert count == 1
+    assert pattern == "simple load_dotenv"
+
+
+# ---------------------------------------------------------------------------
+# shorten_path
+# ---------------------------------------------------------------------------
+
+def test_shorten_path_strips_prefix_and_normalizes():
+    m = _load()
+    assert m.shorten_path("MyIA.AI.Notebooks/GenAI/Audio/04-Applications/nb.ipynb") \
+        == "Audio/04-Applications/nb.ipynb"
+    # backslash variant
+    assert "Audio" in m.shorten_path("MyIA.AI.Notebooks/GenAI\\Audio\\nb.ipynb")

--- a/scripts/audit_genai_corruption.py
+++ b/scripts/audit_genai_corruption.py
@@ -1,82 +1,160 @@
-"""Audit GenAI notebook corruption - single-line code cells diagnostic."""
-import json
+"""Audit GenAI notebook corruption - single-line code cells diagnostic.
+
+Detects two classes of GenAI-notebook degradation:
+  * **corruption** -- a code cell collapsed onto a single line > 500 chars
+    carrying `import` / `def ` / `dotenv` (a tell-tale of a minified/corrupted
+    cell that papermill or a botched edit produced).
+  * **.env-loading inconsistency** -- which of several competing env-loading
+    patterns the notebook uses (env_loaded flag, while-loop walk, GENAI_ROOT,
+    find_dotenv, plain load_dotenv, ...), so the fleet can converge.
+
+The detection logic is split into pure functions (no I/O) so it can be unit-
+tested hermetically; `main()` does the filesystem walk + reporting. Behaviour
+is byte-identical to the original module-level script.
+"""
 import glob
+import json
 import os
 from collections import defaultdict
 
-notebooks = glob.glob("MyIA.AI.Notebooks/GenAI/**/*.ipynb", recursive=True)
-# Exclude EPF student notebooks
-notebooks = [n for n in notebooks if os.sep + "EPF" + os.sep not in n and "/EPF/" not in n]
+GENAI_PREFIX = "MyIA.AI.Notebooks/GenAI/"
+SERIES_ORDER = [
+    "Audio", "Image", "Video", "Texte",
+    "00-GenAI-Environment", "SemanticKernel", "Other",
+]
+_VALID_SERIES = set(SERIES_ORDER) - {"Other"}
 
-corrupted = defaultdict(list)
-clean = defaultdict(int)
-pattern_count = defaultdict(int)
 
-for nb_path in sorted(notebooks):
-    try:
-        with open(nb_path, "r", encoding="utf-8") as f:
-            nb = json.load(f)
+def is_corrupted_line(line):
+    """True when a single source line exceeds 500 chars and looks like
+    collapsed code (import / def / dotenv). This is the corruption signature."""
+    return len(line) > 500 and ("import" in line or "def " in line or "dotenv" in line)
 
-        short = nb_path.replace("MyIA.AI.Notebooks/GenAI/", "").replace("MyIA.AI.Notebooks/GenAI\\", "")
-        parts = short.replace("\\", "/").split("/")
-        series = parts[0] if parts[0] in ["Audio", "Image", "Video", "Texte", "00-GenAI-Environment", "SemanticKernel"] else "Other"
 
-        has_corruption = False
-        corrupt_cells = 0
-        for i, cell in enumerate(nb.get("cells", [])):
-            if cell.get("cell_type") == "code":
-                src = "".join(cell.get("source", []))
-                for line in src.strip().split("\n"):
-                    if len(line) > 500 and ("import" in line or "def " in line or "dotenv" in line):
-                        has_corruption = True
-                        corrupt_cells += 1
-                        break
+def count_corrupted_cells(nb):
+    """Number of code cells in `nb` whose source contains at least one
+    corrupted line (one count per offending cell, not per line)."""
+    count = 0
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        src = "".join(cell.get("source", []))
+        for line in src.strip().split("\n"):
+            if is_corrupted_line(line):
+                count += 1
+                break
+    return count
 
-        # Check env pattern
-        for cell in nb.get("cells", []):
-            if cell.get("cell_type") == "code":
-                src = "".join(cell.get("source", []))
-                if "dotenv" in src or "GENAI_ROOT" in src or ".env" in src:
-                    if "env_loaded" in src:
-                        pattern_count["env_loaded flag"] += 1
-                    elif "while current_path.name" in src:
-                        pattern_count["while loop"] += 1
-                    elif "GENAI_ROOT" in src:
-                        pattern_count["GENAI_ROOT"] += 1
-                    elif "find_dotenv" in src:
-                        pattern_count["find_dotenv"] += 1
-                    elif "load_dotenv" in src:
-                        pattern_count["simple load_dotenv"] += 1
-                    else:
-                        pattern_count["other"] += 1
-                    break
 
-        if has_corruption:
-            corrupted[series].append((short.replace("\\", "/"), corrupt_cells))
-        else:
-            clean[series] += 1
-    except Exception as e:
-        pass
+def classify_env_pattern(nb):
+    """Env-loading pattern label for the FIRST code cell that carries an env
+    marker, or None when no cell uses dotenv/GENAI_ROOT/.env.
 
-print("=== ETAT DE CORRUPTION DES NOTEBOOKS GENAI (hors EPF) ===\n")
-total_corrupt = 0
-total_clean = 0
-for series in ["Audio", "Image", "Video", "Texte", "00-GenAI-Environment", "SemanticKernel", "Other"]:
-    c = len(corrupted.get(series, []))
-    cl = clean.get(series, 0)
-    total = c + cl
-    total_corrupt += c
-    total_clean += cl
-    if total > 0:
-        pct = round(c / total * 100) if total > 0 else 0
-        status = "CRITIQUE" if pct > 50 else "MOYEN" if pct > 20 else "OK"
-        print(f"{series}: {c}/{total} corrompus ({pct}%) [{status}]")
-        for path, cells in corrupted.get(series, []):
-            print(f"  X {path} ({cells} cellules)")
+    Priority chain (first match wins, mirroring the original elif ladder):
+    env_loaded flag > while loop > GENAI_ROOT > find_dotenv > load_dotenv > other.
+    """
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        src = "".join(cell.get("source", []))
+        if "dotenv" in src or "GENAI_ROOT" in src or ".env" in src:
+            if "env_loaded" in src:
+                return "env_loaded flag"
+            if "while current_path.name" in src:
+                return "while loop"
+            if "GENAI_ROOT" in src:
+                return "GENAI_ROOT"
+            if "find_dotenv" in src:
+                return "find_dotenv"
+            if "load_dotenv" in src:
+                return "simple load_dotenv"
+            return "other"
+    return None
 
-print(f"\nTOTAL: {total_corrupt} corrompus, {total_clean} sains, sur {total_corrupt + total_clean}")
-print(f"Taux de corruption: {round(total_corrupt / (total_corrupt + total_clean) * 100)}%")
 
-print(f"\n=== PATTERNS .env (inconsistance) ===")
-for p, count in sorted(pattern_count.items(), key=lambda x: -x[1]):
-    print(f"  {p}: {count} notebooks")
+def classify_series(short_path):
+    """Top-level GenAI series for a notebook path relative to the GenAI root
+    (e.g. ``Audio/04-Applications/foo.ipynb`` -> ``Audio``). Unknown roots
+    collapse to ``Other``."""
+    parts = short_path.replace("\\", "/").split("/")
+    return parts[0] if parts and parts[0] in _VALID_SERIES else "Other"
+
+
+def status_label(pct):
+    """Fleet-health bucket for a corruption percentage."""
+    if pct > 50:
+        return "CRITIQUE"
+    if pct > 20:
+        return "MOYEN"
+    return "OK"
+
+
+def shorten_path(nb_path):
+    """Strip the GenAI root prefix (forward- and back-slash variants) and
+    normalise remaining separators to ``/``."""
+    short = nb_path.replace(GENAI_PREFIX, "").replace("MyIA.AI.Notebooks/GenAI\\", "")
+    return short.replace("\\", "/")
+
+
+def audit_notebook(nb):
+    """Aggregate per-notebook verdict: (corrupted_cell_count, env_pattern).
+
+    Returns ``(0, None)`` for a clean notebook with no env loading."""
+    return count_corrupted_cells(nb), classify_env_pattern(nb)
+
+
+def main():
+    notebooks = glob.glob("MyIA.AI.Notebooks/GenAI/**/*.ipynb", recursive=True)
+    # Exclude EPF student notebooks
+    notebooks = [n for n in notebooks
+                 if os.sep + "EPF" + os.sep not in n and "/EPF/" not in n]
+
+    corrupted = defaultdict(list)
+    clean = defaultdict(int)
+    pattern_count = defaultdict(int)
+
+    for nb_path in sorted(notebooks):
+        try:
+            with open(nb_path, "r", encoding="utf-8") as f:
+                nb = json.load(f)
+            short = shorten_path(nb_path)
+            series = classify_series(short)
+            corrupt_cells, env_pattern = audit_notebook(nb)
+            if env_pattern is not None:
+                pattern_count[env_pattern] += 1
+            if corrupt_cells:
+                corrupted[series].append((short, corrupt_cells))
+            else:
+                clean[series] += 1
+        except Exception:
+            pass
+
+    print("=== ETAT DE CORRUPTION DES NOTEBOOKS GENAI (hors EPF) ===\n")
+    total_corrupt = 0
+    total_clean = 0
+    for series in SERIES_ORDER:
+        c = len(corrupted.get(series, []))
+        cl = clean.get(series, 0)
+        total = c + cl
+        total_corrupt += c
+        total_clean += cl
+        if total > 0:
+            pct = round(c / total * 100)
+            status = status_label(pct)
+            print(f"{series}: {c}/{total} corrompus ({pct}%) [{status}]")
+            for path, cells in corrupted.get(series, []):
+                print(f"  X {path} ({cells} cellules)")
+
+    print(f"\nTOTAL: {total_corrupt} corrompus, {total_clean} sains, "
+          f"sur {total_corrupt + total_clean}")
+    if total_corrupt + total_clean:
+        print(f"Taux de corruption: "
+              f"{round(total_corrupt / (total_corrupt + total_clean) * 100)}%")
+
+    print("\n=== PATTERNS .env (inconsistance) ===")
+    for p, count in sorted(pattern_count.items(), key=lambda x: -x[1]):
+        print(f"  {p}: {count} notebooks")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Grain: MED/test — lane myia-po-2023:CoursIA — prev: TOOLING/twin-parity c.1184 (30 PRs)

## What

Refactor `scripts/audit_genai_corruption.py` — the GenAI notebook-corruption audit (live tool, cataloged in `scripts-reference.md`, invoked by `repair_genai_notebooks.py`) — from a module-level inline script into **pure detection functions** so it is unit-testable, then add **23 hermetic tests**.

Extracted pure functions (no I/O): `is_corrupted_line`, `count_corrupted_cells`, `classify_env_pattern` (priority chain), `classify_series`, `status_label`, `audit_notebook`, `shorten_path`. Side-effects move under `if __name__ == "__main__":` (`main()`).

## Behaviour equivalence

Byte-identical to the original on the live GenAI tree — same verdict, same per-series breakdown, same env-pattern counts:

```
TOTAL: 1 corrompus, 143 sains, sur 144   (FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb)
PATTERNS .env: simple load_dotenv 35, GENAI_ROOT 31, env_loaded flag 29, other 13, while loop 3
```

The only defensive change: a zero-division guard on the global `Taux de corruption` line when the tree is empty (the original raised `ZeroDivisionError` on 0 notebooks). Not a regression — strictly more robust.

## Tests (23, hermetic)

- `is_corrupted_line`: >500 boundary (strict), import/def/dotenv markers, long-without-markers clean.
- `count_corrupted_cells`: one-per-offending-cell (not per-line), skips markdown, handles empty.
- `classify_env_pattern`: full priority chain (env_loaded > while > GENAI_ROOT > find_dotenv > load_dotenv > other), first-matching-cell-wins, skips non-code.
- `classify_series`: known roots + Other + backslash normalisation.
- `status_label`: 20/50 boundaries.
- `audit_notebook`: integration (count + pattern).
- `shorten_path`: prefix strip + backslash normalisation.

Full `scripts/audit/tests/` suite: **321 passed**, no regression.

## Scope

`scripts/audit_genai_corruption.py` (+156/-78, refactor) + `scripts/audit/tests/test_audit_genai_corruption.py` (new, 23 tests). No notebook change, catalogue byte-identical to main.

See #8052 (audit tooling). Rationale: hardens the audit tool the §D.5 / repair pipeline (`repair_genai_notebooks.py`) relies on; rotation from the cost/twin-parity work of c.1184.

Note: the audit surfaces one real corrupted notebook (`FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb`) — out of scope here (separate §D.5/repair grain).

Co-Authored-By: Claude-Code <noreply@anthropic.com>