### PR TITLE
fix(gametheory,#8052): GT-14 Conclusion re-engraved pre-fix buggy K(0)=0.4277 / K=100 / 1525

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
@@ -2391,9 +2391,9 @@
     "\n",
     "1. **L'avantage du premier joueur** : le leader Stackelberg gagne +12.5% par rapport a Cournot, mais le follower perd -43.75%. L'industrie dans son ensemble est **moins efficace** (1519 vs 1800).\n",
     "\n",
-    "2. **Jeux LQ et equation de Riccati** : les stratégies feedback sont lineaires (u_i = -K_i * x), avec K_1(0)=0.4277 et K_2(0)=-0.4277 dans la course publicitaire. La dynamique est stable.\n",
+    "2. **Jeux LQ et equation de Riccati** : les stratégies feedback sont lineaires (u_i = -K_i * x), avec K_1(0)=0.5450 et K_2(0)=-0.5450 dans la course publicitaire. La dynamique est stable.\n",
     "\n",
-    "3. **Dissuasion d'entree** : en augmentant sa capacite a K=100, le monopole peut dissuader l'entree, mais le profit revient au niveau du monopole (1525).\n",
+    "3. **Dissuasion d'entree** : en augmentant sa capacite a K≈61.7, le monopole peut dissuader l'entree, mais le profit revient au niveau du monopole (1716).\n",
     "\n",
     "**Suite** : [GT-15 - Jeux cooperatifs](GameTheory-15b-Lean-CooperativeGames.ipynb) | [Retour au sommaire](README.md)"
    ]

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-14-differentialgames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-14-differentialgames.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-31"
-    by: myia-po-2023:CoursIA
-    python_sha: 1fadd569c0e0fd7da3d20263db1734e008f8c325
+    date: "2026-08-04"
+    by: myia-po-2024:CoursIA-2
+    python_sha: b60f1ce2b23e6a3f0fde01b9e0bbc9ad16a047d1
     csharp_sha: 88e961fdf00ed0525c1918f9ac71132dcbbd8056
   known_differences:
     - "Socle pedagogique commun : jeux differentiels et jeux dynamiques, equilibres de Stackelberg (von Stackelberg 1934) leader-follower, duopole a demande lineaire, comparaison avec Cournot, decisions dynamiques et leadership strategique."


### PR DESCRIPTION
fix(gametheory,#8052): GT-14 Conclusion re-engraved pre-fix buggy K(0)=0.4277 / K=100 / 1525

Grain: MED/§D.5-structural — lane myia-po-2024:CoursIA-2 — prev: MED/§D.5-count c.1245 #9352

## Le défaut

`GameTheory-14-DifferentialGames.ipynb` CELL[39] (Conclusion) gravait des valeurs que le **corps du notebook lui-même** identifie comme la sortie buggee écartée. Le corps (CELL[14]/[15]/[30]/[31]) a été corrigé mais la Conclusion n'a pas été mise à jour — un reliquat de régression.

| point | claim gravée (CELL[39]) | vérité committée |
|---|---|---|
| 2 (Riccati) | `K_1(0)=0.4277 et K_2(0)=-0.4277` | CELL[14] output `K1(0) = 0.5450, K2(0) = -0.5450` ; CELL[15] « L'ancienne valeur K_1(0) = 0.4277 etait issue d'une Riccati couplee buggee » |
| 3 (Dissuasion) | `capacite a K=100` | CELL[30] `Capacite de deterrence: K* = 61.72` ; CELL[31] documente K=100 comme l'ancien comportement buggé du solveur (bord du domaine, π_entrant jamais atteint) |
| 3 (Dissuasion) | `profit ... (1525)` | CELL[30] ligne dissuasion `61.72 → 1716.42` ; 1525 = ligne « Monopole sans investissement » (K=0), pas le scénario de dissuasion |

## Vérification firsthand (code = vérité)

- **Le notebook se contredit lui-même** : CELL[14] (output committé) imprime `K1(0) = 0.5450, K2(0) = -0.5450`. CELL[15] (markdown de correction) dit explicitement que `0.4277` est l'« ancienne valeur » issue d'une Riccati buggee (3× la factorisation du terme quadratique au lieu d'1×, cf Engwerda 2005). Seule la Conclusion CELL[39] portait encore le `0.4277` écarté.
- **Dissuasion** : CELL[30] output committé = `Capacite de deterrence: K* = 61.72` + ligne `Deterrence par capacite 61.72 1716.42 True`. CELL[31] donne la forme analytique `K* = 90 − 2√F ≈ 61.7` et décrit `K=100` comme le bord retourné par le solveur quand le mécanisme de surcapacité n'était PAS modelisé (l'ancien bug). `1525` est la ligne « Monopole sans investissement » (K=0), pas la dissuasion.
- **Parité C#** : le jumeau C# (`-Csharp.ipynb`) ne porte PAS ces valeurs buggées (il affiche déjà `0.5450` ×5) → seul le jumeau Python avait le reliquat. La parité est `semantic`, le C# n'est pas édité.

## Fix

Byte-surgical (raw-JSON, markdown-only CELL[39]) — 2 lignes source, 3 valeurs :
- `K_1(0)=0.4277 et K_2(0)=-0.4277` → `K_1(0)=0.5450 et K_2(0)=-0.5450`
- `capacite a K=100` → `capacite a K≈61.7`
- `niveau du monopole (1525)` → `niveau du monopole (1716)`

**Préservé** : CELL[15] retient légitimement `0.4277` comme valeur buggee documentée (phrasé LaTeX `$K_1(0) = 0.4277$`, distinct) — non touchée. La table Stackelberg/Cournot de CELL[39] (q=30/900, q=45/1012, 1519, +112, −394, +12.5%, −43.75%) vérifiée CLEAN au bit — non touchée. Aucune cellule de code ni output modifiée (les outputs disaient déjà 0.5450 / 61.72 / 1716.42). Diff : 2 ins / 2 del, LF-only, 40 cellules préservées.

## Diagnostic dérive (§D.5)

- **Cause (b) + (d) — claim antérieure fabriquée + régression dépendance.** Une correction du solveur Riccati (CELL[14]/[15], « correction c.767 ») et du mécanisme de dissuasion Dixit/Spence (CELL[30]/[31]) a été appliquée au corps du notebook, mais la Conclusion CELL[39] n'a pas été mise à jour — elle gravait encore les valeurs pré-fix. Le notebook documente lui-même chaque valeur remplacée comme un bug, donc aucune ambiguïté.
- **Verdict : CAUSE_FIXED.** Les 3 valeurs sont des **faits déterministes** : (a) gains Riccati `K1(0)=0.5450` = intégration backward avec params fixes (q1=r1=1, b1=1, etc.), (b) `K*≈61.7` = forme analytique `90 − 2√F` (F=200), (c) profit modèle déterministe. Ce ne sont PAS des mesures drift-prone (timing/WER/AUC soumis à EPIC #8364). Aligner la markdown sur la sortie committée + la forme analytique + le jumeau C# est honnête et stable ; ça ne rebouge pas au prochain passage kernel. Aucune re-exec requise (cellules modifiées = markdown, exception C.2 ; les cellules de code/output qui calculent `0.5450`/`61.72`/`1716.42` ne sont pas touchées).
- **Twin** : paire enregistrée `gametheory-14-differentialgames.yaml` (Python+C#, parité semantic). `python_sha` rebaselined sur le blob committé `b60f1ce2b…` ; `csharp_sha` **inchangé** (`88e961fd…`, le C# n'est pas édité). `check_twin_parity --check --per-pair --base origin/main` : GT-14 `base=OK head=OK` → 0 nouveau drift introduit.

See #8052 (semantic-sampling audit, GameTheory slice).

---

lane: myia-po-2024:CoursIA-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
