### PR TITLE
fix(gametheory,#8052): GT-3 "A retenir" claimed 1 swap PD->Stag Hunt/Chicken; committed = 2

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2.ipynb
@@ -2462,7 +2462,7 @@
     "| Classes (symetrie joueur) | **78** |\n",
     "| Nash : 0, 1, 2, 3+ | 12,5% / **75%** / 12,5% / 0% |\n",
     "\n",
-    "**Insight central** : un **seul swap** de préférences peut transformer un Dilemme du Prisonnier en Stag Hunt ou Chicken. Cette proximite topologique modelise comment les institutions (contrats, reputation, loi) modifient les incitations vers la cooperation.\n",
+    "**Insight central** : deux **swaps** de préférences peuvent transformer un Dilemme du Prisonnier en Stag Hunt ou Chicken. Cette proximite topologique modelise comment les institutions (contrats, reputation, loi) modifient les incitations vers la cooperation.\n",
     "\n",
     "**Unicite du PD** : seul jeu classique ou l'equilibre de Nash unique (D,D)=(2,2) est **Pareto-domine** par (C,C)=(3,3) - la signature structurelle du conflit rationalite individuelle vs collective.\n"
    ]

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-3-topology2x2.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-3-topology2x2.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-08-02"
+    date: "2026-08-04"
     by: myia-po-2024:CoursIA-2
-    python_sha: fb3b73b211652b5f98f80be2fb313371134d366d
+    python_sha: 43a33d1adc042c615204fc64cc4fc8e72d89b05b
     csharp_sha: b09da0acd68389084b6ff1fac9c565169a85ab06
   known_differences:
     - "Socle pedagogique commun : representation ordinale des jeux 2x2 (4 rangs par joueur), classification topologique des 5 archetypes strategiques (Prisonnier, Stag Hunt, BoS, Poulet, Matching Pennies) sur le carre des preferences ordinales."


### PR DESCRIPTION
fix(gametheory,#8052): GT-3 "A retenir" claimed 1 swap PD→Stag Hunt/Chicken; committed = 2

Grain: MED/§D.5-count — lane myia-po-2024:CoursIA-2 — prev: MED/§D.5-structural c.1246 #9356

## Le défaut

`GameTheory-3-Topology2x2.ipynb` CELL[51] (« A retenir ») gravait comme insight central :

> « un **seul swap** de préférences peut transformer un Dilemme du Prisonnier en Stag Hunt ou Chicken. »

C'est faux — le notebook lui-même calcule **2 swaps** à quatre endroits indépendants :

| cellule | type | vérité committée |
|---|---|---|
| CELL[13] (code) | output | `Swaps necessaires: ['ROW_3-4', 'COL_3-4']` = **2 swaps** (BFS `find_swap_path(PD, Stag Hunt)`) |
| CELL[23] (code) | output | matrice de distances `nx.shortest_path_length` : `Prisoner's Dilemma → Stag Hunt = 2`, `→ Chicken = 2` |
| CELL[12] (md) | prose | « PD et Stag Hunt ne sont distants que de **2 swaps** » |
| CELL[25] (md) | prose | « **Jeux proches (2 swaps)** » : liste `PD ↔ Stag Hunt` et `PD ↔ Chicken` dans la bande 2-swap |

## Vérification firsthand (code = vérité)

- **CELL[13]** exécute `find_swap_path(pd, sh)` (BFS sur le treillis des swaps adjacents 1↔2, 2↔3, 3↔4 pour chaque joueur) et imprime `Swaps necessaires: ['ROW_3-4', 'COL_3-4']` — exactement 2 swaps, appliqués pas-à-pas dans la même cellule (`Apres ROW_3-4:` → `Apres COL_3-4:`).
- **CELL[23]** construit `G_full` (graphe NetworkX des 576 jeux, arêtes = swaps adjacents) et imprime la matrice des distances par `nx.shortest_path_length` : ligne `Prisoner's Dilemma` → `Stag Hunt = 2`, `Chicken = 2`. C'est le BFS le plus court chemin = 2, pas 1.
- La CELL[51] est la seule à porter le « un seul swap » erroné. Le tableau de la même cellule (576 jeux, 144 distincts, 78 classes, Nash 12,5%/75%/12,5%/0%) est correct — seul le compte de swaps est faux.

## Fix

Byte-surgical (raw-JSON, markdown-only CELL[51]) :
- `un **seul swap** de préférences peut transformer un Dilemme du Prisonnier en Stag Hunt ou Chicken` → `deux **swaps** de préférences peuvent transformer un Dilemme du Prisonnier en Stag Hunt ou Chicken`

La phrase « peut transformer un PD en Stag Hunt ou Chicken » reste vraie (les deux sont à distance 2) — seul le compte est corrigé. Aucune cellule de code ni output modifiée (les outputs disent déjà 2). Diff : 1 ins / 1 del, LF-only, 54 cellules préservées.

## Diagnostic dérive (§D.5)

- **Cause (b) — claim antérieure fabriquée.** Le rédacteur a gravé « un seul swap » (intuition trompeuse : un swap adjacent paraît minimal) au lieu du compte réel calculé par le BFS du notebook. Détecté car le notebook se contredit lui-même (4 cellules disent 2, seule CELL[51] dit 1).
- **Verdict : CAUSE_FIXED.** Le compte de swaps est un **fait statique déterministe** (BFS shortest-path sur le treillis fixe des 576 jeux 2×2, swaps adjacents (3,4)/(2,3)/(1,2) par joueur) — ce n'est PAS une mesure drift-prone (timing/WER/AUC soumis à EPIC #8364). Aligner la markdown sur les sorties committées est honnête et stable ; ça ne rebouge pas au prochain passage kernel. Aucune re-exec requise (cellule modifiée = markdown, exception C.2 ; les cellules de code/output qui calculent `2` ne sont pas touchées).
- **Twin** : paire enregistrée `gametheory-3-topology2x2.yaml` (Python+C#, parité semantic). `python_sha` rebaselined sur le blob committé `43a33d1ad…` ; `csharp_sha` **inchangé** (`b09da0acd…` — le jumeau C# ne porte pas cette Conclusion « A retenir », il décrit correctement « chaque arête = un swap adjacent »). `check_twin_parity --check --per-pair --base origin/main` : GT-3 `base=OK head=OK` → 0 nouveau drift introduit.

See #8052 (semantic-sampling audit, GameTheory slice).

---

lane: myia-po-2024:CoursIA-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
