### PR TITLE
fix(gametheory,#8052): GT-16 Lean-link cell stale line-counts (MechanismDesign/Arrow/Voting)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
@@ -2554,7 +2554,7 @@
    "id": "d1ea3388",
    "metadata": {},
    "source": [
-    "> **Lien avec la formalisation Lean** : L'incitativite de l'enchere de Vickrey est prouvee formellement dans [`game_theory_lean/SocialChoice/MechanismDesign.lean`](game_theory_lean/SocialChoice/MechanismDesign.lean) (76 lignes, 0 sorry). On y trouve la fonction d'utilite pour 2 et 3 encherisseurs, les theoremes `vickrey_truthful_bidder0/1` (stratégie dominante de verite) prouves par `omega` + `split_ifs`, et le contre-exemple `first_price_not_truthful` prouve par `native_decide`. Le notebook s'inscrit dans la serie Lean du choix social ([`game_theory_lean/SocialChoice/`](game_theory_lean/SocialChoice/)) qui formalise également les theoremes d'Arrow (701 lignes, 0 sorry), de Sen (358 lignes, 0 sorry) et les méthodes de vote (875 lignes, 0 sorry)."
+    "> **Lien avec la formalisation Lean** : L'incitativite de l'enchere de Vickrey est prouvee formellement dans [`game_theory_lean/SocialChoice/MechanismDesign.lean`](game_theory_lean/SocialChoice/MechanismDesign.lean) (213 lignes, 0 sorry). On y trouve la fonction d'utilite pour 2 et 3 encherisseurs, les theoremes `vickrey_truthful_bidder0/1` (stratégie dominante de verite) prouves par `omega` + `split_ifs`, et le contre-exemple `first_price_not_truthful` prouve par `native_decide`. Le notebook s'inscrit dans la serie Lean du choix social ([`game_theory_lean/SocialChoice/`](game_theory_lean/SocialChoice/)) qui formalise également les theoremes d'Arrow (714 lignes, 0 sorry), de Sen (358 lignes, 0 sorry) et les méthodes de vote (887 lignes, 0 sorry)."
    ]
   }
  ],

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-16-mechanismdesign.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-16-mechanismdesign.yaml
@@ -4,9 +4,9 @@
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-31"
+    date: "2026-08-04"
     by: myia-po-2024:CoursIA-2
-    python_sha: 2fe1a205b80c23fe6c79128e6f93576a805bccb9
+    python_sha: 3b689dad7bd6491d847869cb235d5319a24593ba
     csharp_sha: fd5fd04b331a2cbef35868a55e5e25436493b00f
   known_differences:
     - "Socle pedagogique commun : theorie des mecanismes et principe de revelation, encheres premier et second prix, Vickrey 1961 (sincerite de l'enchere au second prix), mecanisme VCG (Vickrey-Clarke-Groves) et regle de Clarke."


### PR DESCRIPTION
fix(gametheory,#8052): GT-16 Lean-link cell stale line-counts (MechanismDesign/Arrow/Voting)

Grain: MED/§D.5-count — lane myia-po-2024:CoursIA-2 — prev: MED/§D.5-count c.1248 #9359

## Le défaut

`GameTheory-16-MechanismDesign.ipynb` CELL[48] (« Lien avec la formalisation Lean ») gravait des **line-counts stale** pour 3 des 4 modules `game_theory_lean/SocialChoice/` référencés :

| fichier | claim gravée | vérité (`wc -l` sur `origin/main`) |
|---|---|---|
| `MechanismDesign.lean` | 76 lignes | **213** |
| `Arrow.lean` | 701 lignes | **714** |
| `Voting.lean` | 875 lignes | **887** |
| `Sen.lean` | 358 lignes | 358 (correct — non touché) |

Notamment, `Voting.lean = 887` est exactement la valeur corrigée dans SocialChoice-03 (PR #9315, c.1234-L★) — GT-16 portait encore le **875 pré-fix**. `MechanismDesign.lean` a crû 2.8× (76→213). Les claims « 0 sorry » sont, eux, corrects pour les quatre fichiers.

## Vérification firsthand (code = vérité)

- **`wc -l` sur les blobs `origin/main`** (read-only, `git show origin/main:<file> | wc -l`) : MechanismDesign.lean = 213, Arrow.lean = 714, Sen.lean = 358, Voting.lean = 887. Faits statiques déterministes.
- **Cross-vérification** : Voting.lean = 887 confirme la correction déjà livrée dans SocialChoice-03 (#9315). Sen.lean = 358 est correct → laissé intact.

## Fix

Byte-surgical (raw-JSON, markdown-only CELL[48]) — 1 ligne source, 3 valeurs :
- `MechanismDesign.lean` (76 → **213** lignes)
- `Arrow.lean` (701 → **714** lignes)
- `Voting.lean` (875 → **887** lignes)

**Préservé** : `Sen.lean` 358 (correct), les claims « 0 sorry » (correctes), l'énumération des théorèmes Lean (`vickrey_truthful_bidder0/1`, `first_price_not_truthful`), et tout le reste de CELL[48]. Aucune cellule de code ni output modifiée. Diff : 1 ins / 1 del, LF-only, 49 cellules préservées.

## Diagnostic dérive (§D.5)

- **Cause (b) — claim antérieure fabriquée.** Les modules `.lean` ont grossi (théorèmes ajoutés au fil du temps) mais la cellule Lean-link de GT-16 n'a pas été rafraîchie. Phénomène documenté (c.1234-L★ : SocialChoice-03 #9315 ; c.1248 : GT-13 #9359) — line-counts `.lean` drift, vérifier `wc -l` AVANT d'asserter.
- **Verdict : CAUSE_FIXED.** Les line-counts sont des **faits statiques déterministes** (`wc -l` sur fichiers versionnés) — ce ne sont PAS des mesures drift-prone (timing/WER/AUC soumis à EPIC #8364). Aligner la markdown sur `wc -l` est honnête et stable ; ça ne rebouge pas au prochain passage. Aucune re-exec requise (cellule modifiée = markdown, exception C.2).
- **Twin** : paire enregistrée `gametheory-16-mechanismdesign.yaml` (Python+C#, parité semantic). `python_sha` rebaselined sur le blob committé `3b689dad7…` ; `csharp_sha` **inchangé** (`fd5fd04b…` — le jumeau C# ne porte pas ces claims de line-count Lean). `check_twin_parity --check --per-pair --base origin/main` : GT-16 `base=OK head=OK` → 0 nouveau drift introduit.

See #8052 (semantic-sampling audit, GameTheory slice).

---

lane: myia-po-2024:CoursIA-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
