### PR TITLE
fix(ml,#8052): 2.5-Biais-Variance CELL[19] print claims lower threshold raises FP vs own matrices (FP=8 unchanged)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
@@ -853,8 +853,10 @@
       "\n",
       "Interpretation : la matrice de confusion s'organise en\n",
       "[[vrais negatifs, faux positifs], [faux negatifs, vrais positifs]].\n",
-      "Un seuil plus bas reduit les faux negatifs mais augmente les faux positifs :\n",
-      "c'est exactement le compromis decrit par la courbe ROC.\n"
+      "Ici, abaisser le seuil de 0.5 a 0.3 ramene les faux negatifs de 2 a 0\n",
+      "sans augmenter les faux positifs (8 aux deux seuils) : sur ce modele bien\n",
+      "calibre, le gain est gratuit. Le cout en faux positifs n'apparait qu'a\n",
+      "des seuils plus bas (cf. courbe ROC).\n"
      ]
     }
    ],
@@ -870,8 +872,10 @@
     "print(confusion_matrix(y_test, pred_03))\n",
     "print(\"\\nInterpretation : la matrice de confusion s'organise en\")\n",
     "print(\"[[vrais negatifs, faux positifs], [faux negatifs, vrais positifs]].\")\n",
-    "print(\"Un seuil plus bas reduit les faux negatifs mais augmente les faux positifs :\")\n",
-    "print(\"c'est exactement le compromis decrit par la courbe ROC.\")"
+    "print(\"Ici, abaisser le seuil de 0.5 a 0.3 ramene les faux negatifs de 2 a 0\")\n",
+    "print(\"sans augmenter les faux positifs (8 aux deux seuils) : sur ce modele bien\")\n",
+    "print(\"calibre, le gain est gratuit. Le cout en faux positifs n'apparait qu'a\")\n",
+    "print(\"des seuils plus bas (cf. courbe ROC).\")"
    ]
   },
   {


### PR DESCRIPTION
fix(ml,#8052): 2.5-Biais-Variance CELL[19] print claims lower threshold "augmente les faux positifs" vs own matrices FP=8 unchanged

Grain: MED/§D.5-count — lane myia-po-2024:CoursIA-2 — prev: MED/§D.5-formula #9365 (c.1250)

## Le défaut

`2.5-Biais-Variance-CV-ROC.ipynb` CELL[19] (« Choisir un seuil de décision ») — le **code de la cellule lui-même** imprime, juste après ses deux matrices de confusion, une claim pédagogique réfutée par ces mêmes matrices.

CELL[19] sortie committée (déterministe, `train_test_split(random_state=42, stratify=y)` + `LogisticRegression(max_iter=1000)`) :

```
Seuil = 0.5 (par defaut)
[[ 56   8]      <- [[VN, FP], [FN, VP]]  => FP=8, FN=2
 [  2 105]]
Seuil = 0.3 (plus sensible aux positifs)
[[ 56   8]      => FP=8 (INCHANGÉ), FN=0
 [  0 107]]
```

Puis la claim imprimée (hardcodée dans le code source de la cellule) :

> « Un seuil plus bas reduit les faux negatifs **mais augmente les faux positifs** : c'est exactement le compromis decrit par la courbe ROC. »

**Réfutation dans la même cellule** : abaisser le seuil de 0.5 à 0.3 ramène les FN de 2 à 0, mais les FP restent **8 aux deux seuils** (inchangés). La claim « augmente les faux positifs » est fausse pour la comparaison démontrée. Le coût en FP n'apparaît qu'à des seuils bien plus bas (sweep empirique ci-dessous : FP monte à 9 pour seuil 0.15, 11 pour 0.10, 14 pour 0.05 — jamais entre 0.5 et 0.3).

La pédagogie générale (seuil plus bas → plus de FP) est VRAIE dans l'absolu, MAIS la démo committée ne la montre pas : à 0.5→0.3 le gain est gratuit (FN→0, FP stable). La claim imprimée prétendait un compromis FP-vs-FN qui ne se produit pas à ce seuil sur ce modèle bien calibré.

## Vérification firsthand (code = vérité)

- **Déterminisme reproduit bit-identique** : re-exec du setup exact (breast_cancer, test_size=0.3, random_state=42, stratify=y, LogisticRegression(max_iter=1000)) → matrices `[[56,8],[2,105]]` (seuil 0.5) et `[[56,8],[0,107]]` (seuil 0.3) — **exactement les outputs committés**. La `ConvergenceWarning` (lbfgs) est pré-existante sur origin/main (max_iter=1000) — ignorée dans la re-exec (`warnings.filterwarnings`) sans toucher au comportement.
- **Sweep empirique** confirmant où les FP augmentent réellement :
  ```
  thr  | VN FP FN VP
  0.50 | 56  8  2 105   <- démo committée
  0.30 | 56  8  0 107   <- démo committée (FP=8 stable)
  0.15 | 55  9  0 107   <- FP commence à monter
  0.10 | 53 11  0 107
  0.05 | 50 14  0 107
  ```
  Donc la claim « augmente les faux positifs » ne tient qu'au-delà de seuil ~0.15, pas dans la démo 0.5 vs 0.3.

## Fix

Byte-surgical sur les 2 lignes `print(...)` de la claim CELL[19] + **re-exec CELL[19]** (sortie texte = la claim elle-même, doit régénérer pour cohérence source/output, C.2). Aucune figure dans CELL[19] (text stream only) → re-exec déterministe, zéro drift PNG.

- ancien (2 prints) :
  ```
  print("Un seuil plus bas reduit les faux negatifs mais augmente les faux positifs :")
  print("c'est exactement le compromis decrit par la courbe ROC.")
  ```
- nouveau (4 prints, alignés sur les données committées) :
  ```
  print("Ici, abaisser le seuil de 0.5 a 0.3 ramene les faux negatifs de 2 a 0")
  print("sans augmenter les faux positifs (8 aux deux seuils) : sur ce modele bien")
  print("calibre, le gain est gratuit. Le cout en faux positifs n'apparait qu'a")
  print("des seuils plus bas (cf. courbe ROC).")
  ```

**Préservé** : les 2 matrices de confusion (`[[56,8],[2,105]]`, `[[56,8],[0,107]]`) bit-identiques dans la sortie régénérée (déterminisme confirmé), la légende `[[VN,FP],[FN,VP]]`, `execution_count=10`, et les 25 autres cellules non touchées. CELL[20] (Synthèse) mentionne correctement « choisir son seuil selon le coût des faux positifs/faux négatifs » — non touchée (correct). Aucune autre cellule ne porte la claim FP-fausse (grep verified). Diff : 8 ins / 4 del, LF-only, 26 cellules préservées.

## Diagnostic dérive (§D.5)

- **Cause (b) — claim antérieure fabriquée.** Le code de démo imprimait la leçon pédagogique générique (« seuil plus bas augmente les FP ») au lieu de décrire ce que les données committées montrent réellement (FN→0, FP stable à 8). L'écart a échappé à la review car la claim générale est vraie dans l'absolu.
- **Verdict : CAUSE_FIXED.** Les matrices de confusion sont des **faits déterministes** (`random_state=42`, modèle linéaire déterministe, seuils fixes) — ce ne sont PAS des mesures drift-prone (timing/WER/AUC soumis à EPIC #8364). Re-aligner la claim imprimée sur les sorties committées + reproduire le déterminisme est honnête et stable ; ça ne rebouge pas au prochain passage kernel. La re-exec CELL[19] est l'application C.2 (la claim est une sortie texte, doit refléter le source corrigé).
- **Twin** : 2.5-Biais-Variance-CV-ROC n'a **pas** de jumeau C# (ML-Cours = Python-only, `twin_pairs.d` = 0 entrée) → PR notebook-only (1 fichier), 0 surface drift parité, 0 changement registre.

See #8052 (semantic-sampling audit, ML/ML-Cours slice).

---

lane: myia-po-2024:CoursIA-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
