### PR TITLE
fix(twin-parity): remove duplicate csharp_sha key in App-6 registry (fleet-unblock)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/app-6-minesweeper.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-6-minesweeper.yaml
@@ -6,7 +6,6 @@
   last_audit:
     python_sha: 20ead2ac4fe55a2ec0d7dc3ad3434113aa3b8bab
     csharp_sha: 7435be2a68253f66e9e4a6639efc2a44d4aab4bd
-    csharp_sha: 7435be2a68253f66e9e4a6639efc2a44d4aab4bd
   known_differences:
     - "Socle pedagogique commun : Demineur (CSP : contraintes sommes exactes, library python-constraint) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = library python-constraint (ExactSum) + OR-Tools ; C# = BCL pure (System.*), 0 NuGet."


### PR DESCRIPTION
Grain: FIX/tooling-registry -- lane myia-po-2023:CoursIA -- prev: ENRICHMENT #9241 c.1195

## What

`app-6-minesweeper.yaml` had `csharp_sha` duplicated (identical value `7435be2a`, lines 8-9). This made `test_no_duplicate_keys_anywhere` FAIL on `Scripts Tests (CPU)` (strict yaml loader raises ConstructorError on dup keys). Since the test runs on every PR, this **blocked the whole fleet**.

## Fix (1 line removed)

Deleted one of the two identical `csharp_sha` lines. `python_sha` + remaining `csharp_sha` unchanged and match notebook blobs (git ls-tree HEAD) — no parity drift.

## Validation (firsthand)

- Strict custom-loader scan of all 157 twin-pair yamls on origin/main → app-6 is the ONLY file with a dup key.
- pytest test_twin_registry_integrity.py → 11/11 pass (was 10/11).
- yaml csharp_sha 7435be2a == git ls-tree HEAD blob → MATCH.
- Pre-existing on main (origin/main:app-6 also count=2) — surfaces via ci-gates-surface-preexisting-defects.

Unblocks Scripts Tests (CPU) for the fleet (incl #9319/#9241/#9245). See #8057, #8957.

Co-Authored-By: Claude-Code <noreply@anthropic.com>