### PR TITLE
fix(sc,#9367): SC-11 model_anthropic claude-sonnet-4-6 (inexistant) -> claude-sonnet-5

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
@@ -255,7 +255,7 @@
     "    openai_api_key: str = os.getenv(\"OPENAI_API_KEY\", \"\") if HAS_DOTENV else \"\"\n",
     "    anthropic_api_key: str = os.getenv(\"ANTHROPIC_API_KEY\", \"\") if HAS_DOTENV else \"\"\n",
     "    model_openai: str = \"gpt-4o\"\n",
-    "    model_anthropic: str = \"claude-sonnet-4-6\"\n",
+    "    model_anthropic: str = \"claude-sonnet-5\"\n",
     "    temperature: float = 0.7\n",
     "    max_tokens: int = 2000\n",
     "\n",


### PR DESCRIPTION
Grain: FIX/smartcontracts -- lane myia-po-2023:CoursIA -- prev: FIX/tooling #9370 c.1196

See #9367.

## Bug

`SC-11-LLM-Assisted.ipynb` cell[6] config: `model_anthropic: str = "claude-sonnet-4-6"`. This identifier **does not exist** on the Anthropic API. SC-11 uses the **official Anthropic SDK** (`anthropic_client.messages.create(model=config.model_anthropic)`), NOT the Claudish proxy — so a student who sets a real key and switches `client_type='anthropic'` (exactly what the notebook proposes) gets a **404 on an invalid model id**, with no indication why.

`claude-sonnet-4-6` → `claude-sonnet-5` (valid Claude 5 family id; equivalent gamme to the `gpt-4o` default on the OpenAI side, per the issue).

## C.2 verification (firsthand)

Re-executed cells 0-6 (`nbformat` + `nbclient`, `python3` kernel) after the edit. cell[6] output is **byte-identical**: `Statut: OpenAI client: Non configure / Anthropic client: Non configure`. The `DEFAULT_PROVIDER='openai'` mock run (pinned by #9337) never prints the anthropic model name, so the change is output-neutral. Diff = **1 line** only (1 insertion + 1 deletion). C.1 clean (0 forbidden patterns), JSON valid, exec_count preserved.

## Scope / due diligence

- `model_openai` left as `gpt-4o` — valid (not a 404 risk); changing it would alter the committed output and is outside the issue's core ask.
- The string `claude-sonnet-4-6` appears repo-wide but in **different contexts**, deliberately left untouched: Claudish (`README.md`/`Claudish-Proxy.md` = a deliberate proxy remap token, Claudish remaps it to the budgeted tier model), Lean (`.env.example` calibration + prover baselines = separate infra that ran it successfully). SC-11 is a direct-Anthropic-SDK client, distinct from both.
- **Planners-10-LLM-Planning.ipynb** has the same dataclass pattern (`model_anthropic = 'claude-sonnet-4-6'`) — same bug class, but a separate notebook/issue (not touched here, per one-subject-per-PR).

Co-Authored-By: Claude-Code <noreply@anthropic.com>