### PR TITLE
fix(planners,#9373): Planners-10 model_anthropic claude-sonnet-4-6 (inexistant) -> claude-sonnet-5

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
@@ -206,7 +206,7 @@
     "    openai_base_url: str = os.getenv(\"OPENAI_BASE_URL\", \"\")\n",
     "    openai_bearer_token: str = os.getenv(\"OPENAI_BEARER_TOKEN\", \"\")\n",
     "    model_openai: str = \"qwen3.6-35b-a3b\"\n",
-    "    model_anthropic: str = \"claude-sonnet-4-6\"\n",
+    "    model_anthropic: str = \"claude-sonnet-5\"\n",
     "    temperature: float = 0.7\n",
     "    max_tokens: int = 2000\n",
     "\n",


### PR DESCRIPTION
Grain: FIX/planners -- lane myia-po-2023:CoursIA -- prev: ENRICHMENT #9277 c.1197

Closes #9373. Sibling of #9367 (SC-11, fixed #9372).

## Bug

`Planners-10-LLM-Planning.ipynb` cell[5]: `model_anthropic: str = "claude-sonnet-4-6"` — inexistant on the Anthropic API. Planners-10 uses the **official Anthropic SDK** (`anthropic_client.messages.create(model=config.model_anthropic)`, cell[8]), not the Claudish proxy → a student with a real key + `client_type='anthropic'` gets a 404. Fixed to `claude-sonnet-5` (valid Claude 5 family id).

## C.2 verified

Re-executed cells 0-5 (`nbformat` + `nbclient`, `python3` kernel) after edit → cell[5] output **byte-identical**: `OpenAI client: Non configure / Anthropic client: Non configure`. The committed mock run never prints the anthropic model name, so the change is output-neutral. Diff = 1 line. C.1 clean, JSON valid.

## Completes the bug-class elimination

Repo-wide inventory: **only 2 notebooks** carry `model_anthropic = "claude-sonnet-4-6"` with a direct-SDK call — SC-11 (#9372) and Planners-10 (this PR). With both fixed, the `claude-sonnet-4-6` direct-SDK 404 class is eliminated. Other `claude-sonnet-4-6` occurrences (Claudish proxy remap token, Lean `.env.example` calibration) are **different contexts**, deliberately untouched.

`model_openai = "qwen3.6-35b-a3b"` left unchanged — valid self-hosted vLLM Qwen endpoint (not a 404 risk).

Co-Authored-By: Claude-Code <noreply@anthropic.com>