### PR TITLE
fix(gt,#8052): GT-15c CELL[39] stale Lean-link (path + line-counts 473/1042→607/2024)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
@@ -1807,7 +1807,7 @@
     "tags": []
    },
    "source": [
-    "> **Lien avec la formalisation Lean** : Les concepts de ce notebook — jeux cooperatifs TU, valeur de Shapley, Core, convexite — sont construits formellement dans le notebook compagnon [GT-15b-Lean-CooperativeGames](GameTheory-15b-Lean-CooperativeGames.ipynb) et la librairie [`cooperative_games_lean/`](cooperative_games_lean/). Le module `Basic.lean` (473 lignes, 1 sorry) définit `TUGame`, les coalitions, le Core et la convexite, et prouve le theoreme de Bondareva-Shapley (condition necessaire et suffisante pour le Core non-vide). Le module `Shapley.lean` (1042 lignes, 0 sorry) formalise les 4 axiomes de Shapley (efficacite, symetrie, joueur nul, additivite) et prouve l'unicite de la valeur. Le jeu de gants (Glove Game) et le jeu de majorite illustres numeriquement ci-dessus y sont également traites."
+    "> **Lien avec la formalisation Lean** : Les concepts de ce notebook — jeux cooperatifs TU, valeur de Shapley, Core, convexite — sont construits formellement dans le notebook compagnon [GT-15b-Lean-CooperativeGames](GameTheory-15b-Lean-CooperativeGames.ipynb) et la librairie [`game_theory_lean/CooperativeGames/`](game_theory_lean/CooperativeGames/). Le module `Basic.lean` (607 lignes, 0 sorry) définit `TUGame`, les coalitions, le Core et la convexite, et prouve le theoreme de Bondareva-Shapley (condition necessaire et suffisante pour le Core non-vide). Le module `Shapley.lean` (2024 lignes, 0 sorry) formalise les 4 axiomes de Shapley (efficacite, symetrie, joueur nul, additivite) et prouve l'unicite de la valeur. Le jeu de gants (Glove Game) et le jeu de majorite illustres numeriquement ci-dessus y sont également traites."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-15c-cooperativegames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-15c-cooperativegames.yaml
@@ -5,8 +5,8 @@
   parity_level: semantic
   last_audit:
     date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 80a6bbf6ad351d92a0575ce0d649ce9d60f8d36c
+    by: myia-po-2024:CoursIA-2
+    python_sha: f8f5f0668e39d7bf74a51db430672bedbe7ddd3b
     csharp_sha: 2b5ecf27a189d00765e6f80edf7c48eb10372cfe
   known_differences:
     - "Socle pedagogique commun : jeux cooperatifs a utilite transferable (TU) -- valeur de Shapley (formule axiomatique, calcul sur permutations), le core (stabilite, imputations), coalitions. Meme concept mathematique (Shapley value phi_i = somme sur permutations, core comme polytope des imputations stables), meme cas d'application (repartition de gains cooperatifs). Les deux couvrent Shapley, core, Coalition."


### PR DESCRIPTION
fix(gt,#8052): GT-15c CELL[39] stale Lean-link (path + line-counts 473/1042→607/2024)

Grain: MED/§D.5-count+identity — lane myia-po-2024:CoursIA-2 — prev: MED/§D.5-count #9375 (c.1255)

## Le défaut

`GameTheory-15c-CooperativeGames-Python.ipynb` CELL[39] (Lien avec la formalisation Lean) gravait un **chemin de librairie stale** ET des **line-counts stale**. Vein **c1249-L★ GT-LEAN-LINK** (étendue à l'identity-path : `cooperative_games_lean/` a été renommée).

| Item | MANIFEST claim | vérité (origin/main) |
|---|---|---|
| chemin librairie | `cooperative_games_lean/` | **`game_theory_lean/CooperativeGames/`** (l'ancien n'existe PAS) |
| `Basic.lean` | 473 lignes, 1 sorry | **607 lignes, 0 sorry** |
| `Shapley.lean` | 1042 lignes, 0 sorry | **2024 lignes, 0 sorry** |

**Preuve croisée** : le notebook parent `GameTheory-15-CooperativeGames.ipynb` CELL[54] cite DÉJÀ les valeurs fraîches et le bon chemin — `[game_theory_lean/CooperativeGames/Basic.lean] (607 lignes)` et `[game_theory_lean/CooperativeGames/Shapley.lean] (2024 lignes, 0 sorry)` — confirmant que GT-15c portait les valeurs pré-croissance + l'ancien nom de librairie.

## Vérification firsthand (code = vérité)

- **`wc -l` sur blobs origin/main** : `Basic.lean` = 607, `Shapley.lean` = 2024.
- **Chemin `cooperative_games_lean/`** : `git ls-tree -r origin/main | grep cooperative_games_lean` = **0 entrée** (librairie inexistante / renommée). Le chemin canonique `game_theory_lean/CooperativeGames/` contient Basic.lean, Shapley.lean, ConeKernel.lean (+ variants `_en`).
- **Claims « sorry »** : `Basic.lean` grep `sorry` = 0 (vrai 0 tactic-hole). `Shapley.lean` grep `sorry` = 1 MAIS c'est du **comment-text** (« bullet-sorry stub » dans un bloc `/- ... -/`) → 0 vrai tactic-hole → la claim « 0 sorry » de Shapley est CORRECTE et préservée. La claim « 1 sorry » de Basic était fausse → corrigée en 0.

## Fix

Byte-surgical. CELL[39] source est une **liste de 1 élément** → remplacement au niveau élément sur `src[0]` (pas de collapse, c.1123-L★★★). Markdown-only, aucune re-exec. Diff : 1 ligne JSON (3 swaps : chemin + 2 line-counts + sorry Basic). 41 cellules préservées.

**Twin** : le C# (`GameTheory-15c-CooperativeGames-Csharp.ipynb`, 32 cellules) n'a **pas** de cellule Lean-link → défaut Python-only. YAML `gametheory-15c-cooperativegames.yaml` rebaselined (`python_sha` mis à jour vers le blob staged ; `csharp_sha` inchangé ; `parity_level: semantic`).

## Diagnostic dérive (§D.5)

- **Cause (b) — claim antérieure fabriquée.** Les line-counts ont été gravés avant que Basic.lean (+134) et Shapley.lean (+982) ne croissent, et le chemin `cooperative_games_lean/` date d'avant le renommage vers `game_theory_lean/CooperativeGames/`. La claim Basic « 1 sorry » a toujours été fausse (vrai 0). L'erreur a échappé à la review car la pédagogie (rôles des modules, théorème de Bondareva-Shapley, 4 axiomes de Shapley) restait correcte.
- **Verdict : CAUSE_FIXED.** Les line-counts sont des **faits statiques déterministes** (`wc -l` sur blobs versionnés) et le chemin est un **fait déterministe du dépôt** — PAS des mesures drift-prone (EPIC #8364 N/A). Ré-aligner sur `origin/main` + la référence canonique du sibling GT-15 CELL[54] est honnête et stable.
- **Twin** : le C# n'a pas de cellule Lean-link → 0 surface de drift de parité ; la PR touche 1 notebook + son yaml twin rebaselined.

See #8052 (semantic-sampling audit, GT Lean-link vein).

---

lane: myia-po-2024:CoursIA-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
