### PR TITLE
docs(lean,#9377): Lean-12 — strip line-counts from markdown prose (data belongs to CI)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-12-Sensitivity-Theorem.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-12-Sensitivity-Theorem.ipynb
@@ -30,7 +30,7 @@
     "1. L'intuition combinatoire (hypercube, fonctions booleennes, sensibilite)\n",
     "2. La conjecture (1992-2019) et pourquoi elle a resiste\n",
     "3. L'idee de la preuve de Huang (signing matrix + Cauchy interlacing)\n",
-    "4. Le port Lean 4 du theoreme (491 lignes, 0 sorry)\n",
+    "4. Le port Lean 4 du theoreme (0 sorry)\n",
     "5. Verification `lake build`\n",
     "6. Pont avec Lean-11 TorchLean et les reseaux de neurones binarises\n",
     "7. Pour aller plus loin\n",
@@ -821,10 +821,10 @@
     "|-- lean-toolchain\n",
     "|-- Sensitivity.lean              (import principal)\n",
     "|-- Sensitivity/\n",
-    "    |-- Hypercube.lean             (124 lignes)  -- Q n, adjacent\n",
-    "    |-- VectorSpace.lean           (132 lignes)  -- V n, e, epsilon, duality\n",
-    "    |-- Operator.lean              (100 lignes)  -- f, g, f_squared\n",
-    "    |-- MainTheorem.lean           (135 lignes)  -- huang_degree_theorem\n",
+    "    |-- Hypercube.lean             -- Q n, adjacent\n",
+    "    |-- VectorSpace.lean           -- V n, e, epsilon, duality\n",
+    "    |-- Operator.lean              -- f, g, f_squared\n",
+    "    |-- MainTheorem.lean           -- huang_degree_theorem\n",
     "```\n",
     "\n",
     "**Graphe de dépendance** :\n",
@@ -832,7 +832,7 @@
     "Hypercube.lean --> VectorSpace.lean --> Operator.lean --> MainTheorem.lean\n",
     "```\n",
     "\n",
-    "**Total** : 4 fichiers, 491 lignes de code Lean, **0 sorry**."
+    "**Total** : 4 fichiers, **0 sorry**."
    ]
   },
   {
@@ -849,7 +849,7 @@
     "tags": []
    },
    "source": [
-    "### Hypercube.lean (124 lignes)\n",
+    "### Hypercube.lean\n",
     "\n",
     "Définit le type des sommets de l'hypercube et la relation d'adjacence :\n",
     "\n",
@@ -886,7 +886,7 @@
     "tags": []
    },
    "source": [
-    "### VectorSpace.lean (132 lignes)\n",
+    "### VectorSpace.lean\n",
     "\n",
     "Définit l'espace vectoriel libre sur les sommets de l'hypercube et les bases duales :\n",
     "\n",
@@ -933,7 +933,7 @@
     "tags": []
    },
    "source": [
-    "### Operator.lean (100 lignes)\n",
+    "### Operator.lean\n",
     "\n",
     "Définit les opérateurs lineaires correspondant aux matrices de Huang ($A_n$) et Knuth ($B_m$) :\n",
     "\n",
@@ -983,7 +983,7 @@
     "tags": []
    },
    "source": [
-    "### MainTheorem.lean (135 lignes)\n",
+    "### MainTheorem.lean\n",
     "\n",
     "Le résultat principal du port :\n",
     "\n",


### PR DESCRIPTION
## Contexte — See #9377 (mandat ai-01, user 2026-08-04)

> « Globalement les données quantitatives doivent être tenues par le CI, pas dans la prose manuelle. »

Les compteurs de **lignes** en prose pédagogique n'ont aucune fonction pédagogique (un étudiant n'a pas besoin de savoir que `Hypercube.lean` fait 124 lignes) et **dérivent à chaque édition de preuve** — exactement le tapis roulant dénoncé par #9377. Le notebook Lean-12 portait 10 occurrences `(N lignes)` dans sa prose markdown.

## Fix — transformation canonique #9377

Règle de tri : *le nombre porte-t-il une fonction pédagogique ?*
- **Garder** : `0 sorry` (dit que la preuve est complète) — fonction pédagogique.
- **Supprimer** : `(N lignes)` (taille de fichier source) — dérive, non pédagogique.

| Cell | Avant | Après |
|------|-------|-------|
| cell[0] | `(491 lignes, 0 sorry)` | `(0 sorry)` |
| cell[16] arbre | `(124 lignes)  -- Q n, adjacent` | `-- Q n, adjacent` |
| cell[16] Total | `4 fichiers, 491 lignes de code Lean, **0 sorry**` | `4 fichiers, **0 sorry**` |
| cell[17-20] headers | `### Hypercube.lean (124 lignes)` | `### Hypercube.lean` |

10 lignes, toutes en **markdown** (0 cellule code touchée).

## Validation

- **Markdown-only** : 0 cellule code, output, ou execution_count modifié (diff programmatique = NONE) → règle C.2 exception (modif markdown → outputs précédents valides).
- **`0 sorry` préservé** : 4 occurrences intactes (cell[0], cell[16] Total, + contexte preuve) — la fonction pédagogique (preuve complète) est conservée.
- **0 `(N lignes)` / `lignes de code` restant** dans le notebook.
- **Lean-12 n'est pas un twin** (kernel Python+Lean, pas de C#) → pas de gate twin-parity.
- Vérifié firsthand sur `origin/main` (SHA 6b18a371e) ; 0 collision (aucune PR ouverte sur le fichier).

## Note (hors scope)

Le notebook a un défaut pré-existant non lié : cell[30] (markdown) porte des propriétés de code-cell (`execution_count`, `outputs`) → `nbformat.validate` fail. **Pré-existant sur origin/main**, non introduit par cette PR (diff = +10/-10 sur cellules 0,16-20 uniquement). Grain potentiel pour un fix séparé.

Grain: MED/docs — lane myia-po-2023:CoursIA

See #9377
