### PR TITLE
fix(lean-ci,#8782): re-pin audit allow-list 28->46 — main rouge bloquait les 13 PR

### DIFF
--- a/scripts/lean/tests/test_proof_integrity_audit_wiring.py
+++ b/scripts/lean/tests/test_proof_integrity_audit_wiring.py
@@ -81,25 +81,41 @@ def test_audit_targets_sorry_bearing_module():
 
 
 def test_audit_allowlists_native_decide_axioms():
-    """The audit allow-lists the native_decide axioms its module ACTUALLY depends
+    """The audit allow-lists the native_decide axioms its modules ACTUALLY depend
     on, so it reports only a FORBIDDEN axiom (beyond them) as red. The first CI
     run of this audit (#8782) revealed HashlifeCorrectness depends on **28**
     native_decide axioms -- a footprint DISTINCT from the blocking gate's 19-name
     list (triaged from the showcase modules KochenSpecker/FreeWillTheorem, #8749,
-    a different scope; the two sets have ZERO overlap). The audit audits a
-    different module, so its allow-list is its own (not a copy of the blocking
-    gate's). All 28 are decide-kernel (`._native.native_decide.ax_1_N`)."""
+    a different scope; the two sets have ZERO overlap). The audit audits
+    different modules, so its allow-list is its own (not a copy of the blocking
+    gate's). All are decide-kernel (`._native.native_decide.ax_1_N`).
+
+    **Widened to 46 by #9341** (`ci(lean,#8782)`), which took the audit from 3 to
+    7 covered modules by adding Oscillators/Spaceships/RLE. The 18 added entries
+    are the build-enumerated footprint of exactly those new modules -- 10 new
+    theorems, all still-life/spaceship/oscillator decidability
+    (`boat|loaf|pond|ship|tub_still_life`, `lwss|mwss|hwss_spaceship`,
+    `pulsar_period_three`, `pentadecathlon_period_15`). Coverage went UP, so the
+    widening is an expansion of what is audited, not a dilution of the gate.
+
+    This pin is the ratchet's ratchet: it caught #9341 widening the allow-list
+    without review and turned `main` red until the widening was justified in
+    writing. Raising it is only ever legitimate alongside that justification --
+    a new name that is NOT attributable to a newly covered module means an
+    unproven `native_decide` slipped in, and the pin must stay put instead."""
     jobs = _load_jobs()
     audit = jobs["proof-integrity-audit"].get("with", {})
     allow = audit.get("allow-axioms", "")
     assert "native_decide" in allow, (
         "audit must allow-list the native_decide axioms or it false-fails")
-    # The 28 revealed by the audit's first run -- pin the empirical footprint so
-    # a silent re-shrink (or accidental copy of the blocking gate's 19) is caught.
+    # Pin the empirical footprint so a silent re-shrink (or accidental copy of
+    # the blocking gate's 19) is caught -- and so any future widening has to
+    # come with the module-attribution argument, as #9341's did.
     names = [a.strip() for a in allow.split(",") if a.strip()]
-    assert len(names) == 28, (
-        f"audit allow-list must carry the 28 HashlifeCorrectness native_decide "
-        f"axioms (empirical footprint); got {len(names)}")
+    assert len(names) == 46, (
+        f"audit allow-list must carry the 46 native_decide axioms of the 7 "
+        f"covered Life modules (empirical footprint, #8782 + #9341); got "
+        f"{len(names)}")
     # Sample members from each family revealed by the audit (P4 base cases,
     # box-assez-grand lemmas, hashlife_correct_implies bridges).
     for sample in [


### PR DESCRIPTION
`Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/docs #9382`

## `main` est rouge, et c'est lui qui bloque la file — pas les PR

Les **13 PR ouvertes en `UNSTABLE`** portent toutes exactement **un** check en echec, `Scripts Tests (CPU)`, y compris celles qui ne touchent que du markdown ou du yaml. Un defaut par-PR ne se distribue pas comme ca. Verifie sur `main` local (HEAD `8139d04a2`), hors CI :

```
FAILED scripts/notebook_tools/tests/test_twin_registry_integrity.py::test_no_duplicate_keys_anywhere
FAILED scripts/lean/tests/test_proof_integrity_audit_wiring.py::test_audit_allowlists_native_decide_axioms
2 failed, 6433 passed, 24 skipped
```

Deux echecs sur `main`. Cette PR corrige le second ; le premier est deja corrige par **#9370** (APPROVED, `app-6-minesweeper.yaml`, la clé `csharp_sha` dupliquee — son auteur avait bien diagnostique, d'ou son etiquette « fleet-unblock »). Les deux ensemble reverdissent la file.

**Note de procedure** : plusieurs rapports workers annoncent depuis quelques cycles « CI pending (cluster sature), 0 fail ». La mesure dit `fail=1, pending=0` sur les 13. C'est le mode d'echec que ma propre lecon `merge-gate-list-failures-explicitly` decrit — un `head -N` trie masque le FAILURE. Le bon geste est de filtrer sur la conclusion, pas de lire les premieres lignes.

## Le cliquet a fonctionne — c'est pour ca qu'il ne faut pas l'assouplir

`test_audit_allowlists_native_decide_axioms` epingle la **taille** de la liste `allow-axioms` du job `proof-integrity-audit`. Sa docstring dit son role : *« pin the empirical footprint so a silent re-shrink is caught »*.

**#9341** (`ci(lean,#8782): widen conway proof-integrity-audit to 4 axiom-clean Life modules`) a fait passer la liste de **28 a 46** sans toucher a l'epingle. Le cliquet a donc rougi — exactement ce pour quoi il existe. `pr-review-discipline` §B.3 est explicite : la liste blanche `native_decide` s'enumere en **noms explicites, jamais en wildcard**, precisement pour que « tout nouveau `native_decide` produise un nom absent de la liste → le gate rougit ». Un gate qui ne peut plus rougir n'est pas un gate.

## L'elargissement est-il legitime ? Verifie, pas suppose

`native_decide` est la classe la plus dangereuse des trois interdites (reduction par le noyau **sans preuve** — elle vide le theoreme de son contenu). Un +18 sur sa liste blanche merite d'etre mesure avant d'etre entérine, et le titre de #9341 se contredit en façade : « axiom-clean » **et** +18 `native_decide`.

Attribution des 18 entrees ajoutees, par difference sur le workflow :

| 10 theoremes nouveaux | module |
|---|---|
| `boat_still_life`, `loaf_still_life`, `pond_still_life`, `ship_still_life`, `tub_still_life` | `Conway.Life.Oscillators` / `Spaceships` |
| `lwss_spaceship`, `mwss_spaceship`, `hwss_spaceship` | `Conway.Life.Spaceships` |
| `pulsar_period_three`, `pentadecathlon_period_15` | `Conway.Life.Oscillators` |

Et la liste de modules du job passe bien de 3 a 7, en ajoutant `Oscillators`, `Spaceships`, `RLE`. **Les 18 axiomes tombent exactement dans les modules nouvellement couverts** : la couverture d'audit AUGMENTE, la liste blanche suit son perimetre. C'est une extension, pas une dilution. Verdict : elargissement **legitime**, epingle a relever.

## Le fix

`28 -> 46`, avec la justification ecrite **dans la docstring** plutot que dans le seul historique git — pour que la prochaine personne qui voit ce test rougir sache a quelle question repondre :

> Un nom nouveau qui n'est **pas** attribuable a un module nouvellement couvert signifie qu'un `native_decide` non prouve s'est glisse dedans, et l'epingle doit alors rester en place.

C'est la difference entre relever un cliquet (legitime, argumente) et le desamorcer (interdit). Aucune assertion n'est retiree : les 4 echantillons par famille restent, le test de disjonction d'avec la liste du gate bloquant reste.

```
7 passed in 0.15s   (scripts/lean/tests/test_proof_integrity_audit_wiring.py)
```

See #8782
