### PR TITLE
fix(csp-5,#9127): reframe cell[13] Comparison verdict — phantom 9 barres + false parity (distinct from #9258 cell[18])

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization-Csharp.ipynb
@@ -775,7 +775,7 @@
     "| **API Bin Packing** | `Add(x in bin) + AddElement` | `BoolVar pieceInBin + scalar + compacité` (plus verbose) |\n",
     "| **API Portfolio** | idem Knapsack | idem Knapsack + cardinalité |\n",
     "\n",
-    "**Verdict** : Choco et OR-Tools CP-SAT donnent les **mêmes optimaux** sur les instances de référence (Bin Packing 2 bins / Knapsack valeur 31 / Cutting Stock 9 barres / Portfolio rendement 27). La différence est dans l'**API** : OR-Tools CP-SAT est plus haut-niveau (notamment `AddElement` intégré pour Bin Packing), Choco nécessite de **reformuler** Bin Packing en termes de `BoolVar` + `scalar` (plus de variables, même optimum)."
+    "**Verdict** : Choco (C#/.NET) et OR-Tools CP-SAT (Python) résolvent chacun **à l'optimum** leurs instances de référence respectives (C# : Bin Packing 3 bins / Knapsack valeur 31 / Cutting Stock 10 barres / Portfolio rendement 27 ; Python : Bin Packing 2 bins / Cutting Stock 4 barres). Les **instances diffèrent** entre les deux twins (Bin Packing C# `sizes = {2, 5, 4, 7, 2}` vs Python `items = [2, 2, 2, 3, 5, 6]` ; Cutting Stock C# 13 pièces vs Python instance plus simple), donc les optima diffèrent légitimement : ce notebook démontre le **parallèle d'implémentation** des deux solveurs sur des problèmes équivalents, non une parité de résultats. La différence essentielle est dans l'**API** : OR-Tools CP-SAT est plus haut-niveau (notamment `AddElement` intégré pour Bin Packing), Choco nécessite de **reformuler** Bin Packing en termes de `BoolVar` + `scalar` (plus de variables, même optimum sur une instance donnée)."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/csp-5-optimization.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-5-optimization.yaml
@@ -5,9 +5,9 @@
   parity_level: semantic
   last_audit:
     date: "2026-08-04"
-    by: myia-po-2026:CoursIA
+    by: myia-po-2023:CoursIA
     python_sha: 4c6ddd792c6842627cb4029718d378b3b2337381
-    csharp_sha: 056338a84a6e3491bcc5ce5be7fd8904a4f9783b
+    csharp_sha: cd0d73e8fee0fe5c17b2a5df10554a32f2d9498e
   known_differences:
     - "Socle pedagogique commun (parity semantic) : les deux cotes couvrent les 4 problemes classiques d'optimisation combinatoire -- Bin Packing (BPP), Knapsack 0/1, Cutting Stock, Optimisation de Portefeuille -- avec la meme progression pedagogique (formulation variables/constraints/objectif -> exemple resolu -> interpretation). Meme theorie sous-jacente (minimisation bins, maximisation valeur sous capacite, patterns de coupe optimaux, allocation lineaire sous contraintes de risque)."
     - "Idiomes framework : Python = **OR-Tools CP-SAT** (`ortools.sat.python.cp_model`) + `numpy` + `matplotlib` (visualisation du bin packing, benchmark de passage a l'echelle). C# = **Choco-solver via IKVM** (`org.chocosolver.solver.dll`, recette #4711) sur runtime .NET -- le solveur Java est invoque depuis C# via l'assembleur IKVM."


### PR DESCRIPTION
## Summary

Grain: MED/§D.5-prose-honesty — lane myia-po-2023:CoursIA — See #9127 (EPIC #8052 §D.5).

Honest reframe of the **cell[13] "## 5. Comparaison OR-Tools CP-SAT vs Choco" verdict** in `CSP-5-Optimization-Csharp.ipynb`. This is a **distinct cell** from the Conclusion recap fixed by the merged #9258 — see the scope-clarification section below.

## The defect (verified firsthand against `origin/main`, 2026-08-04, post-#9258)

`cell[13]` verdict still reads (untouched by #9258, which targeted `cell[18]`):

> **Verdict** : Choco et OR-Tools CP-SAT donnent les **mêmes optimaux** sur les instances de référence (Bin Packing 2 bins / Knapsack valeur 31 / Cutting Stock **9 barres** / Portfolio rendement 27).

Two factual defects (same class as the #9127 recap, different cell):

1. **"9 barres" is a ghost value** — neither twin computes 9. Committed outputs firsthand:
   - C# `cell[10]`: `Cutting Stock : nombre optimal de barres = 10` (13 pieces `{4×6, 7×4, 9×3}`, stock length 10).
   - Python `cell[20]`: `Nombre de barres: 4`.
2. **"mêmes optimaux" (same optima) is FALSE** — the two twins run **different instances**. Verified firsthand:
   - Bin Packing: C# `sizes = {2, 5, 4, 7, 2}` (5 items, cap 10) → **3 bins**; Python `items = [2, 2, 2, 3, 5, 6]` (6 items) → **2 bins**.
   - Different inputs → different optima legitimately; this is not parity.

## The fix

Reframe the verdict: each side resolves **to optimum on its own instances** (C#: Bin Packing 3 bins / Knapsack 31 / Cutting Stock 10 barres / Portfolio 27; Python: Bin Packing 2 bins / Cutting Stock 4 barres), the **instances differ** between the two twins, so the optima differ legitimately — this notebook demonstrates the **implementation parallel** of the two solvers on equivalent problems, not a result parity. Each row now cites the actual computed output rather than a mixed/ghost value.

Markdown-only edit (single verdict line). No code-cell source changed → C.2 exception (previous outputs valid, no re-exec needed). Twin-parity `--update` follows (markdown edit drifts the whole-blob gate).

## Scope clarification — NOT a duplicate of #9258 / #9143 / #9363

`#9127`'s primary evidence is the **`cell[18]` Conclusion recap** ("parité démontrée" + "Optimum (référence Python)" column + phantom "9 barres"). That recap was fixed by the **merged #9258** (2026-08-02). `#9143` and `#9363` were closed as duplicates of #9258 — both also targeted the `cell[18]` recap.

This PR targets **`cell[13]` (the "## 5. Comparaison" verdict)**, a distinct cell. Firsthand verification on `origin/main` (2026-08-04):
- `cell[18]` Conclusion: **clean** — "Cutting Stock 10 barres", "Portfolio 27 (actifs {0,1,4})", no "9 barres", no "parité démontrée" (#9258 applied). ✓
- `cell[13]` Comparaison: **still defective** — "9 barres" present, "mêmes optimaux" present (NOT covered by #9258).

`See #9127` (not `Closes`): the issue's primary scope (`cell[18]`) is already resolved by #9258; this PR fixes an additional instance of the same defect class in a different cell, leaving the issue's closure to the owner.

## Preuves vérifiables (B.2 lean-merge-discipline / H.1)

- `git diff origin/main..HEAD --stat`: 2 files, +3/−3 (notebook 1 markdown line + yaml re-attest).
- `cell[13]` defect on origin/main: `git show origin/main:<nb>` → grep "9 barres"/"mêmes optimaux" = True (pre-edit); post-edit = False.
- Twin-parity: `check_twin_parity.py --check --pair "CSP-5 Optimization"` → [OK] (re-attested to new C# blob `cd0d73e8`, known_differences unchanged → semantic parity preserved).
- `cell[18]` clean on origin/main: confirms #9258 scope (Conclusion recap), distinct from this PR's `cell[13]`.

## Scope résiduel

- The deeper design-gate (Option A: align the two twins' concrete instances so the optima are genuinely comparable) is **deferred to owner decision** per the #9127 body ("Décision coordinateur/user"). This PR (Option B: honest markdown reframe) does not preclude it.

See #9127. Related: #9258 (merged, cell[18] recap fix), #9143/#9363 (closed, cell[18] recap duplicates), EPIC #8052 (§D.5 prose-honesty).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
