### PR TITLE
docs(lean-i18n,#4980): localize 4 remaining EN docstrings in grothendieck SitePoints.lean (FR canonical)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SitePoints.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SitePoints.lean
@@ -161,11 +161,11 @@ Note : ceci requiert `LocallySmall.{w} C` pour faire correspondre les
 niveaux d'univers entre `shrinkYoneda` et `Φ.fiber`.
 -/
 
-/-- The fiber of the (shrunk) Yoneda embedding at a point recovers the
-    fiber functor value. This is `shrinkYonedaCompPresheafFiberIso` from Mathlib:
+/-- La fibre du plongement de Yoneda (réduit) en un point retrouve la
+    valeur du foncteur fibre. C'est `shrinkYonedaCompPresheafFiberIso` de Mathlib :
     `shrinkYoneda ⋙ Φ.presheafFiber ≅ Φ.fiber`.
-    It shows that the presheaf fiber functor extends the fiber functor
-    from objects to presheaves via the Yoneda embedding. -/
+    Cela montre que le foncteur fibre des préfaisceaux étend le foncteur fibre
+    des objets aux préfaisceaux via le plongement de Yoneda. -/
 noncomputable def fiber_yoneda_iso {C : Type u} [Category.{v} C]
     {J : GrothendieckTopology C} [LocallySmall.{w} C]
     (Φ : GrothendieckTopology.Point.{w} J) :
@@ -184,18 +184,18 @@ Ceci permet de construire des applications *depuis* la fibre en utilisant
 la propriété universelle des colimites.
 -/
 
-/-- The colimit cocone that defines the presheaf fiber.
-    Uses `presheafFiberCocone` from Mathlib. -/
+/-- Le cocône colimite qui définit la fibre du préfaisceau.
+    Utilise `presheafFiberCocone` de Mathlib. -/
 noncomputable def presheaf_fiber_cocone {C : Type u} [Category.{v} C]
     {J : GrothendieckTopology C}
     (Φ : GrothendieckTopology.Point.{w} J) (P : Cᵒᵖ ⥤ Type (max u w)) :
     Cocone ((CategoryOfElements.π Φ.fiber).op ⋙ P) :=
   Φ.presheafFiberCocone P
 
-/-- The presheaf fiber cocone is a colimit. This gives the universal
-    property: any compatible family of elements indexed by (X, x) extends
-    uniquely to a map from the fiber.
-    Uses `isColimitPresheafFiberCocone` from Mathlib. -/
+/-- Le cocône de fibre du préfaisceau est une colimite. Cela donne la
+    propriété universelle : toute famille compatible d'éléments indexée par
+    (X, x) se prolonge de manière unique en une application depuis la fibre.
+    Utilise `isColimitPresheafFiberCocone` de Mathlib. -/
 noncomputable def is_colimit_presheaf_fiber {C : Type u} [Category.{v} C]
     {J : GrothendieckTopology C}
     (Φ : GrothendieckTopology.Point.{w} J) (P : Cᵒᵖ ⥤ Type (max u w)) :
@@ -211,9 +211,10 @@ coïncident sur tous les « germes » (X, x) : pour tout X : C et x :
 l'inclusion canonique.
 -/
 
-/-- Extensionality for maps from the presheaf fiber: two maps f, g from
-    Φ.presheafFiber.obj P agree iff they agree on all toPresheafFiber inclusions.
-    Uses `presheafFiber_hom_ext` from Mathlib. -/
+/-- Extensionnalité pour les applications depuis la fibre du préfaisceau :
+    deux applications f, g depuis Φ.presheafFiber.obj P coïncident si et
+    seulement si elles coïncident sur toutes les inclusions `toPresheafFiber`.
+    Utilise `presheafFiber_hom_ext` de Mathlib. -/
 theorem presheaf_fiber_hom_ext {C : Type u} [Category.{v} C]
     {J : GrothendieckTopology C}
     (Φ : GrothendieckTopology.Point.{w} J) {P : Cᵒᵖ ⥤ Type (max u w)}


### PR DESCRIPTION
## Summary

Grain: MED/lean-i18n — lane myia-po-2023:CoursIA — See #4980 (Lean i18n EPIC, FR-first rollout).

Localizes the 4 remaining English docstrings in `grothendieck_lean/Grothendieck/SitePoints.lean` (the FR canonical). The file was already FR-first for its module + section docstrings but left 4 theorem/def docstrings in English (identical to the `SitePoints_en.lean` mirror) — flagged `HALF-DONE` by `check_i18n_siblings` ("FR was probably never localized" for these remnants).

## Changes

Localized 4 docstrings to French (matching the file's existing mathematical French style):
- `fiber_yoneda_iso` (l.164) — "La fibre du plongement de Yoneda (réduit)…"
- `presheaf_fiber_cocone` (l.187) — "Le cocône colimite qui définit la fibre du préfaisceau…"
- `is_colimit_presheaf_fiber` (l.195) — "Le cocône de fibre du préfaisceau est une colimite…"
- `presheaf_fiber_hom_ext` (l.214) — "Extensionnalité pour les applications depuis la fibre…"

All Lean identifiers, Mathlib lemma references, and the `def`/`theorem` signatures + bodies are byte-identical (docstring-only edit). The EN mirror keeps its English docstrings → FR/EN now correctly differ on docstrings only (#4980 sibling-pair convention).

## Preuves vérifiables

- `check_i18n_siblings.py grothendieck_lean` → `SitePoints_en.lean` **OK**, lake **0 half-done** (was 1), **0 drift**, **0 orphan** (statements byte-identical FR↔EN).
- Block-comment nesting walk: final depth 0, no unmatched `-/` (syntax-valid Lean).
- Diff purely within `/-- ... -/` blocks (14 insertions / 13 deletions, no statement/tactic line touched).
- **Build-safety**: docstring-only edit (comment-only-safety lemma — `/-- ... -/` docstrings do not affect Lean elaboration). A full grothendieck Mathlib build (~25 min) would only re-confirm this guarantee; disproportionate for a 4-docstring translation. The statement byte-identity (checker `drift=0`) is the load-bearing proof.

## Scope résiduel

The `check_i18n_siblings --all` scan (origin/main) shows **16 more HALF-DONE advisories** across conway_lean / knot_lean / game_theory_lean / grothendieck (FR canonicals with un-localized English docstring remnants). These are the FR-first rollout frontier — each is an independent bounded grain. This PR clears 1 of 17. Conway/knot advisories are left to their active owners (conway = proof-integrity zone; knot = #8696 parked refactor) to avoid coordination collision.

See #4980.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
