### PR TITLE
fix(prover,#9402): retire residual substring sorry counters (FX-7 completion)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/multi_agent_proof.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/multi_agent_proof.py
@@ -36,6 +36,7 @@ from prover import (
 from prover.config import LEAN_PROJECT_DIR
 from prover.verifier import verify_with_lean
 from prover.trace import TraceLogger as _TL
+from prover.lean_utils import count_real_sorries  # #9402: real-token counter
 
 
 def main():
@@ -76,7 +77,7 @@ def main():
             sys.exit(1)
 
         content = lean_path.read_text(encoding="utf-8")
-        sorry_count = content.count("sorry")
+        sorry_count = count_real_sorries(content)  # #9402: real tokens, not prose
         if sorry_count == 0:
             print(f"No sorry found in {lean_path}")
             sys.exit(0)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/baselines/run_baselines.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/baselines/run_baselines.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 from prover import DEMOS, TraceLogger
 from prover.provers import MultiAgentSorryProver, AutonomousProver
 from prover.config import create_client
+from prover.lean_utils import count_real_sorries  # #9402: real-token counter
 
 
 BASELINES_DIR = Path(__file__).parent
@@ -34,7 +35,7 @@ def run_multi_baseline(demo_num: int, max_iterations: int = 5,
     demo = DEMOS[demo_num]
     filepath = demo["file"]
     original = Path(filepath).read_text(encoding="utf-8")
-    original_sorry = original.count("sorry")
+    original_sorry = count_real_sorries(original)
 
     trace = TraceLogger(output_dir=str(TRACES_DIR))
     prover = MultiAgentSorryProver(trace=trace, provider=provider)
@@ -45,7 +46,7 @@ def run_multi_baseline(demo_num: int, max_iterations: int = 5,
 
     # Verify file was restored
     final = Path(filepath).read_text(encoding="utf-8")
-    final_sorry = final.count("sorry")
+    final_sorry = count_real_sorries(final)
     file_ok = final == original or final_sorry < original_sorry
 
     trace.save(f"multi_demo{demo_num}")
@@ -80,7 +81,7 @@ def run_auto_baseline(demo_num: int, max_iterations: int = 5,
     demo = DEMOS[demo_num]
     filepath = demo["file"]
     original = Path(filepath).read_text(encoding="utf-8")
-    original_sorry = original.count("sorry")
+    original_sorry = count_real_sorries(original)
 
     trace = TraceLogger(output_dir=str(TRACES_DIR))
     prover = AutonomousProver(trace=trace, provider=provider)
@@ -90,7 +91,7 @@ def run_auto_baseline(demo_num: int, max_iterations: int = 5,
     elapsed = time.time() - start
 
     final = Path(filepath).read_text(encoding="utf-8")
-    final_sorry = final.count("sorry")
+    final_sorry = count_real_sorries(final)
     file_ok = final == original or final_sorry < original_sorry
 
     trace.save(f"auto_demo{demo_num}")

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
@@ -1256,3 +1256,47 @@ def suggest_decomposition(goal: str) -> list:
         })
 
     return suggestions
+
+
+# ─── #9402: reusable CLI for PR-body sorry counts ─────────────────────────
+# Replaces the raw `grep -c sorry` prescribed in anti-regression.md and
+# pr-review-discipline.md §B.1, which over-counts prose mentions in Lean
+# comments/docstrings. Usage:
+#   python -m prover.lean_utils path/to/File.lean        # "9<TAB>File.lean"
+#   python prover/lean_utils.py File.lean --quiet        # just the grand total
+# Returns 0 on a file whose every "sorry" sits in a comment/docstring.
+
+
+def _main_cli() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="lean_utils",
+        description=(
+            "Count REAL sorry tokens (comment-stripped, word-bounded) in one or "
+            "more Lean files. Use this instead of the raw substring grep in PR "
+            "bodies (#9402): substring counts over-count prose mentions."
+        ),
+    )
+    parser.add_argument("files", nargs="+", help="one or more .lean files")
+    parser.add_argument(
+        "-q", "--quiet", action="store_true",
+        help="print only the grand total (a single number), no per-file lines",
+    )
+    args = parser.parse_args()
+
+    grand = 0
+    for filepath in args.files:
+        n = count_real_sorries(Path(filepath).read_text(encoding="utf-8"))
+        grand += n
+        if not args.quiet:
+            print(f"{n}\t{filepath}")
+    if args.quiet:
+        print(grand)
+    elif len(args.files) > 1:
+        print(f"{grand}\t(total)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main_cli())

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover_bg.py
@@ -66,6 +66,7 @@ from target_guard import (  # noqa: E402
 from prover.config import DEMOS  # noqa: E402
 from prover.provers import MultiAgentSorryProver  # noqa: E402
 from prover.trace import TraceLogger  # noqa: E402
+from prover.lean_utils import count_real_sorries  # noqa: E402  (#9402: real-token counter)
 from prover.tree_lock import (  # noqa: E402
     acquire_tree_lock,
     find_lean_project_root,
@@ -79,8 +80,13 @@ def _bg(line: str) -> None:
 
 
 def _peek_sorry_count(filepath: str) -> int:
+    # #9402: count REAL sorry tokens (comment-stripped, word-bounded) so the
+    # pre/post DELTA forensic signal reflects discharged proofs, not prose
+    # mentions in docstrings/comments. The legacy raw substring counter
+    # over-counted x4-x13 on prose-dense files (HashlifeCorrectness: 52
+    # substring hits vs 9 real tokens on origin/main 2026-08-04).
     try:
-        return Path(filepath).read_text(encoding="utf-8").count("sorry")
+        return count_real_sorries(Path(filepath).read_text(encoding="utf-8"))
     except OSError:
         return -1
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -2054,16 +2054,27 @@ def test_fx7_count_real_sorries_massively_undercounts_comment_prose():
 
 
 def test_fx7_no_legacy_substring_counter_in_prover_source():
-    """FX-7 regression guard: no prover source module may reintroduce the
-    legacy `.count("sorry")` substring counter on file content — every gate,
-    snapshot, and report must go through count_real_sorries so deltas stay
-    consistent. The only allowed mention is the historical docstring in
-    lean_utils.py describing the retired counter."""
+    """FX-7 regression guard (#9402 widened): no agent_tests PRODUCTION module
+    may reintroduce the legacy `.count("sorry")` substring counter on file
+    content — every gate, snapshot, and report must go through
+    count_real_sorries so deltas stay consistent. The original guard scanned
+    only `prover/*.py` (non-recursive), which let residual substring counters
+    survive in `prover/baselines/run_baselines.py`, the root `run_prover_bg.py`
+    `_peek_sorry_count`, and `multi_agent_proof.py` — the very blind spot #9402
+    documents. This scan covers the whole agent_tests tree EXCLUDING tests/
+    (fixtures legitimately cite the substring form to document the retired
+    counter). The only allowed production mention is the historical docstring
+    in lean_utils.py (marked # FX-7-ALLOW)."""
     from pathlib import Path
 
-    prover_dir = Path(__file__).resolve().parent.parent / "prover"
+    agent_tests = Path(__file__).resolve().parent.parent
     legacy = []
-    for py in sorted(prover_dir.glob("*.py")):
+    for py in sorted(agent_tests.rglob("*.py")):
+        # Skip the test suite — fixtures legitimately cite the legacy substring
+        # form to document/verify the retired counter.
+        rel_parts = py.relative_to(agent_tests).parts
+        if "tests" in rel_parts:
+            continue
         for ln, line in enumerate(py.read_text(encoding="utf-8").splitlines(), 1):
             if '.count("sorry")' in line:
                 # lean_utils.py keeps ONE historical mention in the
@@ -2072,11 +2083,57 @@ def test_fx7_no_legacy_substring_counter_in_prover_source():
                 # allow survives a docstring reformat (NanoClaw #4936 △ Mineur).
                 if py.name == "lean_utils.py" and "# FX-7-ALLOW" in line:
                     continue
-                legacy.append(f"{py.name}:{ln}: {line.strip()}")
+                legacy.append(f"{py.relative_to(agent_tests)}:{ln}: {line.strip()}")
     assert not legacy, (
         "FX-7 violated — legacy substring `.count(\"sorry\")` reintroduced:\n"
         + "\n".join(legacy)
     )
+
+
+def test_peek_sorry_count_counts_real_tokens_not_prose(tmp_path):
+    """#9402: the `_peek_sorry_count` function that feeds the pre/post DELTA
+    forensic signal in run_prover_bg must return the REAL (comment-stripped,
+    word-bounded) token count, not the raw substring count. A prose-dense file
+    where every 'sorry' mention lives in comments/docstrings must read 0, and a
+    file mixing prose + real tokens must read only the real ones. Reverting
+    `_peek_sorry_count` to the raw substring counter reds this test."""
+    import sys
+
+    agent_tests = Path(__file__).resolve().parent.parent
+    if str(agent_tests) not in sys.path:
+        sys.path.insert(0, str(agent_tests))
+    import run_prover_bg  # noqa: E402
+
+    # Prose only: header docstring + line comment mention 'sorry' repeatedly,
+    # but there is NO real sorry token. Substring would over-count; real = 0.
+    prose_only = tmp_path / "prose_only.lean"
+    prose_only.write_text(
+        "/-!\n"
+        "This file used to be sorry everywhere; we removed sorry after sorry\n"
+        "until only sorry mentions in this docstring remained (sorry, sorry).\n"
+        "-/\n"
+        "-- NB: the word sorry in this line comment is NOT an obligation.\n"
+        "theorem t : True := by trivial\n",
+        encoding="utf-8",
+    )
+    assert run_prover_bg._peek_sorry_count(str(prose_only)) == 0
+    # Sanity: the raw substring counter WOULD have over-counted here.
+    assert prose_only.read_text(encoding="utf-8").count("sorry") >= 5
+
+    # Mixed: 2 real sorry tokens buried under the same prose. Real = 2.
+    mixed = tmp_path / "mixed.lean"
+    mixed.write_text(
+        "/-! Header mentions sorry many times (sorry sorry sorry). -/\n"
+        "-- a line comment saying sorry too\n"
+        "theorem a : True := by sorry\n"
+        "theorem b : True := by\n"
+        "  exact sorry\n",
+        encoding="utf-8",
+    )
+    assert run_prover_bg._peek_sorry_count(str(mixed)) == 2
+
+    # Missing file: the OSError contract returns -1 (unchanged behavior).
+    assert run_prover_bg._peek_sorry_count(str(tmp_path / "absent.lean")) == -1
 
 
 # --- FX-6b (#1453): sorry_is_in_statement + in-statement entry refusal ------


### PR DESCRIPTION
## What & why (#9402)

The forensic `sorry_delta` signal that `run_prover_bg._peek_sorry_count` feeds (`DELTA = pre_sorry - post_sorry`) still used the raw `.count("sorry")` **substring** counter — the very defect #9402 documents. On prose-dense files the substring counter measures comments, not proof obligations: on `origin/main` today, `HashlifeCorrectness.lean` has **52 substring hits vs 9 real sorry tokens** (the issue's hand-count). A `DELTA 1` therefore cannot distinguish a discharged proof from a rewritten comment sentence.

**G.1 note on the issue's numbers:** the issue cited 99 substring / 9 real. On current `origin/main` (6ca7957) I measured **52 substring / 9 real firsthand** — the file's prose has been trimmed since filing, but the real count is unchanged at 9, so the acceptance criterion "rend 9" holds exactly. (The `count_real_sorries` docstring's older "4 real / 33 substring" snapshot is stale; the 9 figure is the live value.)

## Root cause — a blind spot in the FX-7 guard

`count_real_sorries` (comment-stripped, word-bounded) **already existed** and was already FX-6 tested — the issue author didn't know. The reason 6 call sites still used the raw substring counter: the FX-7 regression guard `test_fx7_no_legacy_substring_counter_in_prover_source` scanned only `prover/*.py` **non-recursively**, so it never saw:
- `agent_tests/run_prover_bg.py:_peek_sorry_count` (root file)
- `agent_tests/prover/baselines/run_baselines.py` (4 sites — under `prover/baselines/`, missed by `glob`)
- `agent_tests/multi_agent_proof.py` (root file)

## Changes

| File | Change |
|------|--------|
| `run_prover_bg.py` | `_peek_sorry_count` → `count_real_sorries` (returns 9, not 52) |
| `prover/baselines/run_baselines.py` | 4 `original/final.count("sorry")` → `count_real_sorries` |
| `multi_agent_proof.py` | `sorry_count = content.count("sorry")` → `count_real_sorries` |
| `prover/lean_utils.py` | New reusable CLI (`python -m prover.lean_utils F.lean`) for PR-body authors, replacing raw `grep -c sorry` (issue point 3) |
| `tests/test_prover_guards.py` | **Widened** the FX-7 guard to scan the full `agent_tests` production tree (`rglob`, excluding `tests/`); **new** behavioral lock `test_peek_sorry_count_counts_real_tokens_not_prose` |

## Acceptance criteria (#9402) — all met

- [x] Counter renders **9** on `HashlifeCorrectness.lean` (not 52 substring) — verified firsthand
- [x] Renders **0** on a file whose every `sorry` is in a comment — `test_peek_sorry_count_counts_real_tokens_not_prose` prose-only fixture asserts `== 0`
- [x] Does not count `sorryAx` / `no_sorry` (word delimiter) — existing FX-6 `test_count_real_sorries_word_boundary` (utility unchanged)
- [x] Nested block comments `/- /- -/ -/` handled — existing `test_count_real_sorries_ignores_nested_block_comments` + `strip_lean_comments` nesting test
- [x] A test locks the behavior so a revert to substring reds — `_peek_sorry_count` revert reds the new behavioral test (prose-only would read ≥5 vs asserted 0) **and** the widened FX-7 source guard

## Validation

```
$ python -m pytest tests/test_prover_guards.py tests/test_lean_utils.py tests/test_check_axioms.py -q
269 passed in 4.62s
$ python -m prover.lean_utils ../conway_lean/Conway/Life/HashlifeCorrectness.lean
9	../conway_lean/Conway/Life/HashlifeCorrectness.lean
```

Tooling-only: 0 `.lean` proofs touched, 0 `.ipynb` touched. Atomic single-subject PR (5 files, +123/-14, all in `agent_tests/` prover harness).

Closes #9402. See #1453 (prover Epic), #9377 (quantitative-data-in-CI principle).
