### PR TITLE
refactor(twin-parity,#9399): append-only audits: list (volet a)

### DIFF
--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -14,17 +14,29 @@ personne ne re-audite la parite. Aujourd'hui la parite est **declarative**
 Le registre vit dans le repertoire `twin_pairs.d/` (a cote de ce script,
 #8542 Option C) : **un fichier YAML par paire** + `_schema.yaml` (documentation).
 Chaque entree decrit une paire : le chemin des deux notebooks, le `parity_level`
-(surface | semantic | native-both), le `last_audit` (date, auteur, et le **git
-blob SHA** de chaque notebook au moment de l'audit) et les `known_differences`
-documentees. Le file-per-entry supprime a la source la classe de conflit serie
-qui frappait l'ancien mono-fichier (recurrences #8415/#8476/#8499/#8505/#8526/#8499).
+(surface | semantic | native-both), l'**enregistrement d'audit** (date, auteur,
+et le **git blob SHA** de chaque notebook au moment de l'audit) et les
+`known_differences` documentees. Le file-per-entry supprime a la source la
+classe de conflit serie qui frappait l'ancien mono-fichier (recurrences
+#8415/#8476/#8499/#8505/#8526/#8499).
+
+L'enregistrement d'audit existe en deux formes (#9399 volet a) : le singleton
+legacy `last_audit:` ou la liste **append-only** `audits:`. Le singleton etait
+un aimant a collision (deux audits concurrents de la meme paire ecrivaient les
+memes lignes -> CONFLICT ou ecrasement silencieux du plus recent, #9171/#9237/
+#9245) ; la forme append-only fait que chaque audit ajoute une entree distincte
+-> rien n'ecrase plus rien. La migration legacy -> audits: est paresseuse (a la
+volee, sur le 1er drift reel) pour eviter qu'une reecriture massive des ~158
+fichiers ne soit elle-meme un aimant a collision. Le reader `_latest_audit`
+lit le dernier enregistrement quelle que soit la forme.
 
 Comment ca marche
 -----------------
 Pour chaque paire du registre, on :
   1. lit le **git blob SHA courant** de chaque notebook via `git ls-tree HEAD`
      (le contenu versionne, pas le working tree — reproductible) ;
-  2. compare le SHA courant au `last_audit.{python,csharp}_sha` enregistre ;
+  2. compare le SHA courant au `{python,csharp}_sha` du **dernier
+     enregistrement d'audit** (`last_audit` legacy ou `audits[-1]`, #9399) ;
   3. **DRIFT** si l'un des deux a change depuis le dernier audit -> la paire
      doit etre re-auditee (un cote a evolue, la parite n'est plus garantie) ;
   4. **MISSING** si le chemin n'existe pas dans git (typo, deplacement, jumeau
@@ -136,9 +148,6 @@ except ImportError:  # pragma: no cover
 # d'une entree -- triviale, mais meme code, memes garanties (seules les lignes
 # `last_audit` changent, commentaires du fichier preserves).
 DEFAULT_REGISTRY = Path(__file__).resolve().parent / "twin_pairs.d"
-
-# Sentinelle : distingue « cle absente de l'update » de « valeur None ».
-_MISSING = object()
 
 
 def _slug(name: str) -> str:
@@ -392,7 +401,7 @@ def check_pair(repo_root: Path, pair: dict, git_ref: str = "HEAD") -> dict:
     name = pair.get("name", "?")
     py = pair["python"]
     cs = pair["csharp"]
-    audit = pair.get("last_audit", {}) or {}
+    audit = _latest_audit(pair)
     rec_py = audit.get("python_sha")
     rec_cs = audit.get("csharp_sha")
 
@@ -458,15 +467,45 @@ def update_pair(
     cur_cs = _git_blob_sha(repo_root, cs)
     audit = {
         "date": date or _dt.date.today().isoformat(),
-        "by": by or pair.get("last_audit", {}).get("by", "manual"),
+        "by": by or _latest_audit(pair).get("by", "manual"),
         "python_sha": cur_py,
         "csharp_sha": cur_cs,
     }
     return audit, cur_py
 
 
-# Cles scalaires du bloc `last_audit` reecrites par le rebaseline chirurgical.
+# Cles scalaires d'un enregistrement d'audit (forme append-only ET legacy).
+# Partagees par le singleton `last_audit:` (legacy) et chaque element de la
+# liste `audits:` (append-only, #9399).
 _AUDIT_KEYS = ("date", "by", "python_sha", "csharp_sha")
+
+
+def _latest_audit(pair: dict) -> dict:
+    """Retourne le dernier enregistrement d'audit d'une paire.
+
+    Supporte les deux formes du registre (#9399) :
+      - append-only : `audits:` est une liste d'enregistrements (date/by/shas) ;
+        le plus recent est le dernier element. Deux audits concurrents sur la
+        meme paire ecrivent alors des entrees distinctes -> git les fusionne
+        seul (fin de la collision mecanique du singleton legacy).
+      - legacy : `last_audit:` singleton (forme historique des ~158 fichiers).
+
+    Priorite a `audits:` (nouvelle forme) si present et non vide, sinon fallback
+    sur `last_audit:`. Renvoie `{}` si ni l'un ni l'autre (paire non encore
+    auditee -> DRIFT au prochain --check, comme avant).
+
+    Cette retro-compatibilite permet une migration **a la volee** (chaque
+    `--update` migre sa paire vers la forme append-only) plutot qu'une
+    reecriture massive des 158 fichiers en un coup, qui serait elle-meme un
+    aimant a collision (#9399 critere d'acceptation : preserve l'historique).
+    """
+    audits = pair.get("audits")
+    if isinstance(audits, list) and audits:
+        # Les enregistrements legacy peuvent omettre `by`/`date` ; tolerer.
+        last = audits[-1]
+        if isinstance(last, dict):
+            return last
+    return pair.get("last_audit") or {}
 
 
 def _fmt_audit_value(key: str, value) -> str:
@@ -501,20 +540,141 @@ def write_registry_text(path: Path, text: str) -> None:
         fh.write(text)
 
 
+def _parse_flat_audit(body_lines):
+    """Paires (cle, valeur_textuelle) d'un bloc `last_audit:` legacy (mapping plat).
+
+    Preserve l'ordre du fichier : `reason` est optionnel et libre (texte long de
+    justification d'audit), on ne PEUT PAS se restreindre a `_AUDIT_KEYS` sous
+    peine de jeter l'historique d'audit (#9399 critere 4, anti-regression).
+    """
+    items = []
+    for ln in body_lines:
+        m = re.match(r"^\s+(\w+):\s*(.*)$", ln)
+        if m:
+            items.append((m.group(1), m.group(2).strip().strip("\"'")))
+    return items
+
+
+def _parse_latest_audit_entry(body_lines):
+    """Dernier element de liste d'un bloc `audits:` -> dict des cles scalaires.
+
+    Sert au no-op check : si la derniere entree enregistre deja les SHAs
+    courants, on n'ajoute pas de doublon (evite la croissance infinie de la
+    liste sur des `--update` successifs sans changement reel).
+    """
+    latest = {}
+    for ln in body_lines:
+        m_item = re.match(r"^\s+-\s+(\w+):\s*(.*)$", ln)
+        m_kv = re.match(r"^\s{2,}(\w+):\s*(.*)$", ln)
+        if m_item:
+            latest = {m_item.group(1): m_item.group(2).strip().strip("\"'")}
+        elif m_kv:
+            latest[m_kv.group(1)] = m_kv.group(2).strip().strip("\"'")
+    return latest
+
+
+def _shas_match(record: dict, new_py, new_cs) -> bool:
+    """True ssi `record` enregistre deja exactement ces deux SHAs (no-op)."""
+    if new_py is None or new_cs is None:
+        return False
+    return (str(record.get("python_sha", "")) == str(new_py)
+            and str(record.get("csharp_sha", "")) == str(new_cs))
+
+
+def _legacy_body_as_list_item(body_lines):
+    """Convertit un body legacy (mapping plat indent 4) en 1er item de `audits:`.
+
+    Mecanique pure : la 1re ligne recoit `- ` apres son indentation, les
+    suivantes +2 espaces (alignement sous la 1re cle). La VALEUR (quotes
+    comprises) est preservee byte-faithful -- crucial pour `reason` (texte libre
+    long) : on ne re-quotationne pas, on deplace juste la marge.
+    """
+    out = []
+    for idx, ln in enumerate(body_lines):
+        m = re.match(r"^(\s+)(\S.*?)(\r?\n)?$", ln)
+        if not m:
+            out.append(ln)
+            continue
+        indent, content, eol = m.group(1), m.group(2), m.group(3) or "\n"
+        if idx == 0:
+            out.append(f"{indent}- {content}{eol}")
+        else:
+            out.append(f"  {indent}{content}{eol}")
+    return out
+
+
+def _render_new_audit_entry(entry: dict) -> list[str]:
+    """Rendre une NOUVELLE entree (sortie d'`update_pair`) en item de liste `audits:`."""
+    lines = []
+    keys = [k for k in _AUDIT_KEYS if entry.get(k) is not None]
+    for idx, key in enumerate(keys):
+        val = _fmt_audit_value(key, entry[key])
+        if idx == 0:
+            lines.append(f"    - {key}: {val}\n")
+        else:
+            lines.append(f"      {key}: {val}\n")
+    return lines
+
+
+def _transform_audit_block(form: str, block: list[str], new_entry: dict) -> tuple[list[str], bool]:
+    """Transforme un bloc d'audit (header + body) pour une paire ciblee.
+
+    form = "last_audit" (legacy singleton) ou "audits" (liste append-only).
+    Retourne (nouvelles_lignes_du_bloc, a_change).
+
+    Semantique append-only (#9399) :
+      - audits: + SHAs inchanges -> no-op (pas de doublon).
+      - audits: + SHAs changes   -> APPEND d'une nouvelle entree.
+      - last_audit: + SHAs inchanges -> no-op (on reste legacy ; migration
+        paresseuse a la volee, uniquement quand la paire drift reelement).
+      - last_audit: + SHAs changes   -> MIGRATION vers audits: [ancien, nouveau]
+        (l'ancien enregistrement, `reason` compris, devient item[0]).
+    """
+    body = block[1:]
+    new_py = new_entry.get("python_sha")
+    new_cs = new_entry.get("csharp_sha")
+
+    if form == "audits":
+        latest = _parse_latest_audit_entry(body)
+        if _shas_match(latest, new_py, new_cs):
+            return block, False
+        return block + _render_new_audit_entry(new_entry), True
+
+    # form == "last_audit" -> migration vers la forme append-only
+    old_pairs = _parse_flat_audit(body)
+    if _shas_match(dict(old_pairs), new_py, new_cs):
+        return block, False
+    new_block = ["  audits:\n"]
+    if old_pairs:
+        new_block += _legacy_body_as_list_item(body)
+    new_block += _render_new_audit_entry(new_entry)
+    return new_block, True
+
+
 def surgical_rebaseline(raw: str, updates: dict[str, dict]) -> tuple[str, int]:
-    """Reecrit UNIQUEMENT les lignes `last_audit` des paires ciblees.
+    """Reecrit UNIQUEMENT le bloc d'audit des paires ciblees (forme append-only).
 
     Pourquoi ne pas re-serialiser via `yaml.safe_dump` (comportement d'avant
     #8570) : un dump complet detruit **tout** le fichier autour des donnees.
     Mesure firsthand sur le registre a 116 paires -- un rebaseline d'UNE paire
     produisait `1108 insertions(+), 658 deletions(-)` et supprimait les **67
     lignes de commentaire**, dont l'en-tete de 15 lignes qui documente le
-    schema et le vocabulaire `parity_level`. Le vrai changement (4 lignes)
-    devenait irreviewable, et la documentation du registre disparaissait sans
-    que personne ne l'ait demande.
+    schema et le vocabulaire `parity_level`. Le vrai changement devenait
+    irreviewable, et la documentation du registre disparaissait sans que
+    personne ne l'ait demande.
 
     L'edition ligne-a-ligne ci-dessous preserve commentaires, ordre, quoting et
     espacement : le diff d'un rebaseline vaut exactement les lignes changees.
+
+    Depuis #9399 (volet a), l'ecriture est **append-only** : le singleton
+    `last_audit:` est un aimant a collision (deux audits concurrents de la meme
+    paire visent les memes lignes -> CONFLICT ou ecrasement silencieux du plus
+    recent par le plus ancien, cf #9171/#9237/#9245). La forme cible est une
+    liste `audits:` ou chaque audit ajoute une entree distincte -> git fusionne
+    sans intervention, et rien n'ecrase plus un enregistrement plus recent.
+    La migration legacy -> audits: est **paresseuse** (a la volee, sur le 1er
+    drift reel) pour eviter qu'une reecriture massive des ~158 fichiers ne soit
+    elle-meme un aimant a collision.
 
     Args:
         raw: contenu texte du registre YAML.
@@ -523,37 +683,40 @@ def surgical_rebaseline(raw: str, updates: dict[str, dict]) -> tuple[str, int]:
     Returns:
         (nouveau_texte, nombre_de_paires_effectivement_touchees)
     """
+    lines = raw.splitlines(keepends=True)
     out: list[str] = []
     current: str | None = None
-    in_audit = False
     touched: set[str] = set()
 
-    for line in raw.splitlines(keepends=True):
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
         m_entry = re.match(r"^-\s+name:\s*(.+?)\s*$", line)
         if m_entry:
             current = m_entry.group(1).strip().strip("\"'")
-            in_audit = False
-        elif re.match(r"^\s{2}last_audit:\s*$", line):
-            in_audit = current in updates
-        elif re.match(r"^\s{2}\S", line):
-            # toute autre cle de premier niveau de l'entree ferme le bloc
-            in_audit = False
+            out.append(line)
+            i += 1
+            continue
 
-        if in_audit:
-            m_kv = re.match(r"^(\s+)(\w+):\s*(.*)$", line)
-            if m_kv and m_kv.group(2) in _AUDIT_KEYS:
-                key = m_kv.group(2)
-                new = updates[current].get(key, _MISSING)
-                # On ne reecrit que si la VALEUR change : sinon un rebaseline
-                # sur une paire deja a jour normaliserait le quoting (le
-                # registre melange 'x' et "x") et polluerait le diff de lignes
-                # sans changement reel.
-                old = m_kv.group(3).strip().strip("\"'")
-                if new is not _MISSING and str(new) != old:
-                    line = f"{m_kv.group(1)}{key}: {_fmt_audit_value(key, new)}\n"
-                    touched.add(current)
+        m_hdr = re.match(r"^\s{2}(last_audit|audits):\s*$", line)
+        if m_hdr and current in updates:
+            form = m_hdr.group(1)
+            # Corps du bloc = lignes suivantes indentees a 4+ espaces.
+            block = [line]
+            j = i + 1
+            while j < n and re.match(r"^\s{4,}\S", lines[j]):
+                block.append(lines[j])
+                j += 1
+            new_block, did = _transform_audit_block(form, block, updates[current])
+            if did:
+                touched.add(current)
+            out.extend(new_block)
+            i = j
+            continue
 
         out.append(line)
+        i += 1
 
     return "".join(out), len(touched)
 

--- a/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
@@ -109,22 +109,33 @@ def test_comments_survive_surgical_rebaseline():
     """Le bug fondateur : `safe_dump` supprimait les commentaires.
 
     Raw craft pour que la garde soit deterministe -- elle ne doit pas dependre
-    de quel fichier d'entree porte, ce jour-la, un commentaire.
+    de quel fichier d'entree porte, ce jour-la, un commentaire. Depuis #9399,
+    un rebaseline d'une paire legacy qui drift migre vers la forme append-only
+    `audits:` ; la garantie porte toujours : aucun commentaire n'est supprime.
     """
     raw = (
         "# en-tete documentaire de l'entree\n"
         "- name: Paire-Temoin\n"
+        "  family: Test\n"
         "  python: a.ipynb\n"
         "  csharp: b.ipynb\n"
+        "  parity_level: full\n"
         "  # commentaire interne, au milieu du bloc\n"
         "  last_audit:\n"
         "    date: '2020-01-01'\n"
         "    by: auditeur-precedent\n"
+        "    python_sha: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2\n"
+        "    csharp_sha: 0f1e2d3c4b5a0f1e2d3c4b5a0f1e2d3c4b5a0f1e\n"
     )
     before = sum(1 for line in raw.splitlines() if line.lstrip().startswith("#"))
     assert before == 2
 
-    new_raw, touched = ctp.surgical_rebaseline(raw, {"Paire-Temoin": {"by": "test-lane"}})
+    # SHA python change -> declenche la migration legacy -> audits:.
+    new_raw, touched = ctp.surgical_rebaseline(raw, {"Paire-Temoin": {
+        "date": "2026-08-04", "by": "test-lane",
+        "python_sha": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+        "csharp_sha": "0f1e2d3c4b5a0f1e2d3c4b5a0f1e2d3c4b5a0f1e",
+    }})
     after = sum(1 for line in new_raw.splitlines() if line.lstrip().startswith("#"))
     assert touched == 1
     assert after == before, "un rebaseline ne doit supprimer aucun commentaire"
@@ -133,22 +144,42 @@ def test_comments_survive_surgical_rebaseline():
 
 
 def test_diff_limited_to_target_block(registry_backup):
-    """Seules les lignes changees de la paire ciblee bougent."""
+    """Seul le bloc d'audit de la paire ciblee bouge ; le reste est intact.
+
+    Depuis #9399, un rebaseline d'une paire legacy qui drift MIGRE le bloc
+    `last_audit:` vers la liste append-only `audits:` (ancien enregistrement +
+    nouveau). La garantie chirurgicale (#8570) est preservee : aucune cle
+    top-level hors audit (name/family/python/csharp/parity_level/known_differences)
+    ne change, et l'ancien enregistrement survit comme item[0] (anti-regression :
+    on ne jette pas l'historique d'audit).
+    """
+    import yaml
+
     pfile = registry_backup[0]
     raw = pfile.read_text(encoding="utf-8")
     name = _pair_name(pfile)
+    before = yaml.safe_load(raw)[0]
+    old_py = before["last_audit"]["python_sha"]
 
+    # SHA python change -> migration legacy -> audits:.
     new_raw, touched = ctp.surgical_rebaseline(
-        raw, {name: {"by": "sentinelle-c8570", "date": "1999-01-01"}}
+        raw, {name: {"date": "1999-01-01", "by": "sentinelle-c8570",
+                     "python_sha": "f" * 40, "csharp_sha": before["last_audit"]["csharp_sha"]}}
     )
     assert touched == 1
+    after = yaml.safe_load(new_raw)[0]
 
-    before, after = raw.splitlines(), new_raw.splitlines()
-    assert len(before) == len(after), "aucune ligne ajoutee ni supprimee"
-    changed = [i for i, (b, a) in enumerate(zip(before, after)) if b != a]
-    assert len(changed) == 2, f"attendu 2 lignes (date + by), obtenu {len(changed)}"
-    assert all("sentinelle-c8570" in after[i] or "1999-01-01" in after[i]
-               for i in changed)
+    # Aucune cle top-level hors audit n'a bouge.
+    for key in ("name", "family", "python", "csharp", "parity_level", "known_differences"):
+        assert before.get(key) == after.get(key), f"cle non-audit modifiee : {key}"
+
+    # Le bloc a migre vers la forme append-only, en preservant l'historique.
+    assert "last_audit" not in after, "le singleton legacy doit etre remplace"
+    audits = after["audits"]
+    assert isinstance(audits, list) and len(audits) >= 2
+    assert audits[0]["python_sha"] == old_py, "l'ancien enregistrement doit survivre"
+    assert audits[-1]["python_sha"] == "f" * 40, "le nouvel enregistrement doit etre dernier"
+    assert audits[-1]["by"] == "sentinelle-c8570"
 
 
 def test_noop_is_byte_identical(registry_backup):
@@ -203,8 +234,12 @@ def test_other_pair_files_untouched(registry_backup):
     name = _pair_name(target)
     others_before = {f: f.read_bytes() for f in files[1:]}
 
+    # Entree complete (SHA python change) -> migration legacy -> audits: bien formee.
     new_raw, _ = ctp.surgical_rebaseline(
-        target.read_text(encoding="utf-8"), {name: {"by": "sentinelle-c8570"}}
+        target.read_text(encoding="utf-8"), {name: {
+            "date": "1999-01-01", "by": "sentinelle-c8570",
+            "python_sha": "f" * 40, "csharp_sha": "e" * 40,
+        }}
     )
     target.write_text(new_raw, encoding="utf-8")
 
@@ -270,7 +305,10 @@ def test_write_preserves_lf_on_every_platform(tmp_path):
         "le registre doit rester en LF : un CRLF fait apparaitre chaque ligne "
         "inchangee comme modifiee et noie la ligne reellement auditee"
     )
-    assert written.decode("utf-8").count("\n") == original.count("\n")
+    # La garantie LF est relative au TEXTE CALCULE (la migration #9399 ajoute
+    # legitimement des lignes) : l'ecriture ne doit ni traduire les LF en CRLF,
+    # ni en ajouter/supprimer vs ce que surgical_rebaseline a calcule.
+    assert written.decode("utf-8").count("\n") == new_raw.count("\n")
 
 
 def test_registry_blobs_are_lf_only():
@@ -298,3 +336,105 @@ def test_registry_blobs_are_lf_only():
     crlf = [line.split("\t")[-1] for line in out.stdout.splitlines()
             if line.startswith("i/crlf")]
     assert not crlf, f"blobs de registre en CRLF : {', '.join(crlf)}"
+
+
+# --- Forme append-only `audits:` (#9399 volet a) ---
+#
+# Le singleton `last_audit:` etait un aimant a collision : deux audits
+# concurrents de la meme paire ecrivaient les memes lignes -> CONFLICT git, ou
+# pire, ecrasement silencieux du plus recent par le plus ancien (#9171, #9237,
+# #9245, + 4e manifestation invisible). La liste append-only `audits:` fait que
+# chaque audit ajoute une entree distincte : rien n'ecrase plus rien.
+
+
+def test_legacy_migration_preserves_reason_and_history():
+    """La migration legacy -> audits: preserve `reason` et l'enregistrement ancien.
+
+    `reason` est un texte libre long de justification d'audit. Le rejeter
+    reviendrait a jetter l'historique d'audit -> anti-regression (#9399 critere 4).
+    On preserve byte-faithful via re-indentation mecanique (pas de re-quoting).
+    """
+    raw = (
+        "- name: Paire-R\n"
+        "  last_audit:\n"
+        "    date: \"2026-08-01\"\n"
+        "    by: lane-prev:CoursIA\n"
+        "    python_sha: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        "    csharp_sha: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+        "    reason: \"Markdown-only fix: cell 13 cited N=1000 but caps at 500.\"\n"
+    )
+    new_raw, touched = ctp.surgical_rebaseline(
+        raw, {"Paire-R": {"date": "2026-08-04", "by": "po-2023:CoursIA",
+                          "python_sha": "c" * 40, "csharp_sha": "b" * 40}}
+    )
+    assert touched == 1
+    import yaml
+    entry = yaml.safe_load(new_raw)[0]
+    assert "last_audit" not in entry and "audits" in entry
+    audits = entry["audits"]
+    assert len(audits) == 2
+    # L'ancien enregistrement (item[0]) garde son reason + ses SHAs.
+    assert audits[0]["reason"].startswith("Markdown-only fix"), "reason perdu !"
+    assert audits[0]["python_sha"].startswith("a" * 8)
+    # Le nouvel enregistrement (item[1]) porte le nouveau SHA.
+    assert audits[1]["python_sha"] == "c" * 40
+
+
+def test_concurrent_audits_never_silently_overwrite():
+    """LE garant central de #9399 : deux audits ne s'ecrasent jamais silencieusement.
+
+    Simule deux lanes auditant la meme paire depuis la meme base legacy :
+    chacune migre -> audits:[old, sienne]. Apres les deux, l'ETAT REGROUPE les
+    deux enregistrements -- aucun n'a ecrase l'autre. Avec le singleton, la 2e
+    aurait silencieusement remplace la 1ere (inversion chronologique, 4e
+    manifestation d'#9399). Ici les deux SHAs survivent.
+    """
+    base = (
+        "- name: Paire-C\n"
+        "  last_audit:\n"
+        "    python_sha: 0a1b2c3d4e5f0a1b2c3d4e5f0a1b2c3d4e5f0a1b\n"
+        "    csharp_sha: 1f2e3d4c5b6a1f2e3d4c5b6a1f2e3d4c5b6a1f2e\n"
+    )
+    audit_a = {"date": "2026-08-04", "by": "lane-a:CoursIA",
+               "python_sha": "a" * 40, "csharp_sha": "b" * 40}
+    audit_b = {"date": "2026-08-04", "by": "lane-b:CoursIA",
+               "python_sha": "c" * 40, "csharp_sha": "d" * 40}
+    # Chaque lane part de `base` (le scenario du merge 3-way concurrent).
+    out_a, _ = ctp.surgical_rebaseline(base, {"Paire-C": audit_a})
+    out_b, _ = ctp.surgical_rebaseline(base, {"Paire-C": audit_b})
+    # La resolution du merge concurrent = on regroupe les entrees des deux cotes
+    # (ce que fait un humain/agent en quelques secondes, sans perte de donnees).
+    import yaml
+    audits_a = yaml.safe_load(out_a)[0]["audits"]
+    audits_b = yaml.safe_load(out_b)[0]["audits"]
+    merged_entries = [audits_a[1], audits_b[1]]  # item[0] est le vieux, identique
+    shas = {e["python_sha"] for e in merged_entries}
+    assert shas == {"a" * 40, "c" * 40}, (
+        "les deux audits doivent survivre au merge ; un ecrasement silencieux "
+        "n'en laisserait qu'un"
+    )
+    # Preuve que rien n'a ete ecrase : chaque sortie contient encore le vieux
+    # enregistrement de base (item[0]) -- l'historique est intact des deux cotes.
+    assert audits_a[0]["python_sha"] == "0a1b2c3d4e5f0a1b2c3d4e5f0a1b2c3d4e5f0a1b"
+    assert audits_b[0]["python_sha"] == "0a1b2c3d4e5f0a1b2c3d4e5f0a1b2c3d4e5f0a1b"
+
+
+def test_append_only_noop_does_not_grow_list():
+    """Re-auditer une paire deja a jour n'ajoute pas de doublon (anti-inflation).
+
+    Sans cette garde, des `--update` successifs sans changement reel gonfleraient
+    la liste indefiniment. Le no-op (SHAs inchanges) est byte-identical.
+    """
+    raw = (
+        "- name: Paire-N\n"
+        "  audits:\n"
+        "    - date: \"2026-08-01\"\n"
+        "      by: lane:CoursIA\n"
+        "      python_sha: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        "      csharp_sha: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+    )
+    same = {"date": "2026-08-04", "by": "lane:CoursIA",
+            "python_sha": "a" * 40, "csharp_sha": "b" * 40}
+    out, touched = ctp.surgical_rebaseline(raw, {"Paire-N": same})
+    assert touched == 0
+    assert out == raw, "un no-op sur la forme append-only doit etre byte-identique"

--- a/scripts/notebook_tools/tests/test_check_twin_parity_update_guard.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_update_guard.py
@@ -211,8 +211,11 @@ def test_update_with_pair_selector_succeeds_on_existing_pair(registry_backup):
     after = ctp.load_registry(REGISTRY_DIR)
 
     # 1) La cible a les SHAs courants (= ce que `git rev-parse HEAD:<path>` retourne).
+    # Depuis #9399, la cible drift est MIGREE vers la forme append-only `audits:` ;
+    # `_latest_audit` lit le dernier enregistrement quelle que soit la forme
+    # (legacy `last_audit:` ou liste `audits:`).
     target_after = next(p for p in after if p.get("name") == target_name)
-    a_audit = target_after.get("last_audit") or {}
+    a_audit = ctp._latest_audit(target_after)
     assert a_audit.get("python_sha") == expected_py_sha, (
         f"Cible {target_name!r}.python_sha = {a_audit.get('python_sha')!r}, "
         f"attendu {expected_py_sha!r} (git ls-tree HEAD)."
@@ -233,8 +236,8 @@ def test_update_with_pair_selector_succeeds_on_existing_pair(registry_backup):
         if before is None:
             drifted.append(f"{name}: disparu du registre")
             continue
-        b_audit = before.get("last_audit") or {}
-        a_audit_other = p.get("last_audit") or {}
+        b_audit = ctp._latest_audit(before)
+        a_audit_other = ctp._latest_audit(p)
         for sha_key in ("python_sha", "csharp_sha"):
             if b_audit.get(sha_key) != a_audit_other.get(sha_key):
                 drifted.append(

--- a/scripts/notebook_tools/tests/test_twin_registry_integrity.py
+++ b/scripts/notebook_tools/tests/test_twin_registry_integrity.py
@@ -33,16 +33,19 @@ yaml = pytest.importorskip("yaml")
 # Source unique de verite : le loader de check_twin_parity (evite de dupliquer
 # la logique d'agregation du repertoire file-per-entry).
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from check_twin_parity import load_registry, _slug  # noqa: E402
+from check_twin_parity import load_registry, _slug, _latest_audit  # noqa: E402
 
 REGISTRY_DIR = Path(__file__).resolve().parents[1] / "twin_pairs.d"
 SCHEMA = REGISTRY_DIR / "_schema.yaml"
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-# Cle minimale qu'une entree doit posseder (sous-ensemble).
-REQUIRED_KEYS = {"name", "family", "python", "csharp", "parity_level", "last_audit"}
+# Cles structurelles qu'une entree doit POSSEDER (sous-ensemble). L'enregistrement
+# d'audit n'est pas liste ici : depuis #9399 volet (a) il peut prendre deux formes
+# -- le singleton legacy `last_audit:` ou la liste append-only `audits:` -- et une
+# entree valide possede l'UN des deux (cf `_has_audit_record` / `test_has_audit_record`).
+REQUIRED_KEYS = {"name", "family", "python", "csharp", "parity_level"}
 ALLOWED_KEYS = {
     "name", "family", "python", "csharp", "parity_level",
-    "last_audit", "known_differences",
+    "last_audit", "audits", "known_differences",
 }
 # Plancher d'entrees (post-migration #8542 : 116 paires sur origin/main). En
 # mode file-per-entry, une entree perdue = un fichier supprime ; ce plancher le
@@ -53,6 +56,32 @@ MIN_ENTRIES = 116
 
 def _entries() -> list:
     return load_registry(REGISTRY_DIR)
+
+
+def _has_audit_record(entry: dict) -> bool:
+    """Une entree valide possede un enregistrement d'audit sous l'une des deux
+    formes (#9399) : le singleton legacy `last_audit:` ou la liste append-only
+    `audits:` (non vide, chaque element un dict)."""
+    if "last_audit" in entry and isinstance(entry["last_audit"], dict):
+        return True
+    audits = entry.get("audits")
+    return isinstance(audits, list) and len(audits) > 0 and all(
+        isinstance(a, dict) for a in audits
+    )
+
+
+def _all_audit_records(entry: dict) -> list:
+    """Tous les enregistrements d'audit d'une entree (last_audit + chaque
+    element de audits:). Sert a valider les SHAs PARTOUT, pas seulement le
+    dernier -- un ancien enregistrement migre doit garder des SHAs valides
+    (anti-regression : on ne jette pas l'historique, cf #9399 critere 4)."""
+    records = []
+    if isinstance(entry.get("last_audit"), dict):
+        records.append(entry["last_audit"])
+    for a in (entry.get("audits") or []):
+        if isinstance(a, dict):
+            records.append(a)
+    return records
 
 
 def _pair_files() -> list[Path]:
@@ -128,15 +157,33 @@ def test_required_keys_present():
     assert not missing, f"entrees incompletes : {missing}"
 
 
+def test_has_audit_record():
+    """Chaque entree porte un enregistrement d'audit (last_audit OU audits:, #9399).
+
+    Les deux formes coexistent pendant la migration paresseuse a la volee : une
+    entree n'en avoir AUCUNE est une corruption (paire enregistree sans jamais
+    etre auditee -> DRIFT permanent non trace).
+    """
+    no_record = [
+        e.get("name", "?") for e in _entries() if not _has_audit_record(e)
+    ]
+    assert not no_record, f"entrees sans enregistrement d'audit : {no_record}"
+
+
 def test_audit_shas_are_git_blob_shas():
-    """Les shas sont des blob SHA git (40 hex), pas des hashes de contenu."""
+    """Les shas sont des blob SHA git (40 hex), pas des hashes de contenu.
+
+    Valide les SHAs de TOUS les enregistrements (singleton last_audit + chaque
+    element de la liste audits:) : un ancien enregistrement migre doit conserver
+    des SHAs valides (#9399 critere 4 : on ne jette pas l'historique).
+    """
     bad = []
     for entry in _entries():
-        audit = entry.get("last_audit") or {}
-        for key in ("python_sha", "csharp_sha"):
-            sha = audit.get(key)
-            if not isinstance(sha, str) or not SHA_RE.match(sha):
-                bad.append(f"{entry.get('name', '?')}.{key} = {sha!r}")
+        for audit in _all_audit_records(entry):
+            for key in ("python_sha", "csharp_sha"):
+                sha = audit.get(key)
+                if not isinstance(sha, str) or not SHA_RE.match(sha):
+                    bad.append(f"{entry.get('name', '?')}.{key} = {sha!r}")
     assert not bad, f"shas invalides : {bad}"
 
 
@@ -174,6 +221,63 @@ def test_entry_count_floor():
         f"le registre a perdu des entrees : {n} < {MIN_ENTRIES} "
         f"(fichier d'entree supprime ou fusion accidentee ? cf #8542)"
     )
+
+
+# --- Forme append-only `audits:` (#9399 volet a) ---
+
+
+def test_audit_form_is_exclusive():
+    """Une entree ne porte pas BOTH `last_audit` ET `audits` (source de verite unique).
+
+    La migration (#9399) REMPLACE le singleton par la liste (l'ecrivain retire
+    `last_audit:` quand il migre). Coexistence = main-edit corrompue ou migration
+    a moitie faite -> le reader `_latest_audit` privilegierait `audits` et le
+    `last_audit` residuel mentirait (SHAs potentiellement perimes).
+    """
+    both = [
+        e.get("name", "?") for e in _entries()
+        if "last_audit" in e and "audits" in e
+    ]
+    assert not both, f"entrees avec les deux formes d'audit : {both}"
+
+
+def test_latest_audit_resolves_for_every_entry():
+    """`_latest_audit` resout en un enregistrement a SHAs pour CHAQUE entree.
+
+    Valide le reader polyvalent (#9399) sur le registre reel : quelle que soit la
+    forme (legacy `last_audit` ou append-only `audits`), le dernier enregistrement
+    porte des SHAs exploitables par le gate. Une entree dont le reader renvoie
+    `{}` ou des SHAs absents -> DRIFT silencieux si la paire n'est pas checkee.
+    """
+    unresolved = []
+    for entry in _entries():
+        latest = _latest_audit(entry)
+        if not isinstance(latest, dict) or not latest.get("python_sha") or not latest.get("csharp_sha"):
+            unresolved.append(entry.get("name", "?"))
+    assert not unresolved, f"entrees sans dernier audit resolu : {unresolved}"
+
+
+def test_append_only_entries_well_formed():
+    """Toute entree `audits:` est une liste non vide de dicts a SHAs valides.
+
+    Un enregistrement d'audit (ancien ou nouveau) sans python_sha/csharp_sha est
+    inutilisable par le gate (le reader renverrait None -> DRIFT bruyant, mais
+    silencieux si la paire n'est pas checkee). On valide a l'inscription.
+    """
+    bad = []
+    for entry in _entries():
+        audits = entry.get("audits")
+        if not isinstance(audits, list):
+            continue
+        for idx, rec in enumerate(audits):
+            if not isinstance(rec, dict):
+                bad.append(f"{entry.get('name', '?')}[{idx}] n'est pas un dict")
+                continue
+            for key in ("python_sha", "csharp_sha"):
+                sha = rec.get(key)
+                if not isinstance(sha, str) or not SHA_RE.match(sha):
+                    bad.append(f"{entry.get('name', '?')}[{idx}].{key} = {sha!r}")
+    assert not bad, f"entrees audits: mal formees : {bad}"
 
 
 # --- Nouveaux tests : validation de la structure file-per-entry (#8542) ---

--- a/scripts/notebook_tools/twin_pairs.d/_schema.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/_schema.yaml
@@ -1,8 +1,17 @@
 # Registre de parite des jumeaux Python/C# (#8057, parent #4208).
 #
 # Chaque entree decrit une paire de notebooks jumeaux : le chemin des deux
-# cotes, le niveau de parite, le dernier audit (date + auteur + git blob SHA de
-# chaque notebook au moment de l'audit) et les differences connues documentees.
+# cotes, le niveau de parite, l'enregistrement d'audit (date + auteur + git blob
+# SHA de chaque notebook au moment de l'audit) et les differences connues documentees.
+#
+# L'enregistrement d'audit a deux formes (#9399 volet a) :
+#   - `last_audit:` singleton (forme legacy, historique) ;
+#   - `audits:` liste append-only (forme cible) : chaque audit ajoute une entree
+#     distincte, rien n'ecrase plus rien. Le singleton etait un aimant a collision
+#     sous lanes paralleles (#9171 cle dupliquee, #9237/#9245 CONFLICT, ecrasement
+#     silencieux du plus recent). Le reader lit le dernier enregistrement
+#     (`audits[-1]` ou `last_audit`). La migration legacy -> audits: est paresseuse
+#     (a la volee, sur le 1er drift reel) -- pas de reecriture massive.
 #
 # Le check `check_twin_parity.py` compare le SHA courant (git ls-tree HEAD) au
 # SHA audite : DRIFT = un cote a evolue sans re-audit -> parite a reverifier.
@@ -11,8 +20,10 @@
 #       --pair "<nom exact de l'entree>" --by "<machine:workspace>"
 # `--update` refuse de tourner sans selecteur (--pair / --family / --yes-all-pairs) :
 # sans lui il rebaselinerait les 116 paires d'un coup et masquerait des DRIFTs
-# legitimes (#8508). L'ecriture est chirurgicale : seules les lignes `last_audit`
-# de la paire ciblee changent, ce fichier garde ses commentaires (#8570).
+# legitimes (#8508). L'ecriture est chirurgicale : seul le bloc d'audit de la
+# paire ciblee change (les autres cles top-level et les commentaires sont
+# preserves, #8570) ; depuis #9399 un rebaseline d'une paire legacy qui drift la
+# migre vers `audits:` en preservant l'ancien enregistrement (item[0]).
 #
 # parity_level :
 #   surface     = meme plan/sections, implimentations independantes


### PR DESCRIPTION
## Volet (a) de #9399 — supprimer la collision du singleton `last_audit:`

Le singleton `last_audit:` (réécrit en place à chaque `--update`) est un **aimant à collision** sous lanes parallèles : deux audits concurrents de la même paire visent les mêmes lignes → `CONFLICT` git (#9237/#9245, PRs bloquées 2j) ou clé dupliquée (#9171), et surtout **écrasement silencieux** du plus récent par le plus ancien (4e manifestation, invisible pour la CI). 4 manifestations d'une seule cause dans un seul cycle (mesure firsthand #9399).

### Ce que fait la PR

- **Nouvelle forme append-only `audits:`** (liste d'enregistrements). Chaque audit ajoute une entrée distincte → rien n'écrase plus rien, l'inversion chronologique disparaît.
- **Reader polyvalent `_latest_audit(pair)`** : retourne `audits[-1]` si la liste est présente, sinon fallback `last_audit` (legacy). Les 3 sites de lecture passent par lui.
- **Writer `surgical_rebaseline` réécrit** pour l'append-only :
  - `audits:` + SHAs inchangés → no-op (pas de doublon, anti-inflation) ;
  - `audits:` + SHAs changés → APPEND ;
  - `last_audit:` + SHAs inchangés → no-op (reste legacy) ;
  - `last_audit:` + SHAs changés → **MIGRATION** vers `audits:[ancien, nouveau]`.
- **Migration paresseuse à la volée** (sur le 1er drift réel) — pas de réécriture massive des ~156 fichiers (qui serait elle-même un aimant à collision). L'ancien enregistrement (`reason` compris) est préservé byte-faithful comme item[0] (anti-régression : on ne jette pas l'historique).

### Critères d'acceptation #9399

| # | Critère | Statut |
|---|---------|--------|
| 1 | Deux audits sur paires **différentes** ne conflicteraient plus | ✅ file-per-entry (#8542) — déjà vrai |
| 2 | Deux audits sur la **même** paire : fusionnent ou échouent bruyamment, **jamais écrasement silencieux** | ✅ append-only → conflict LOUD + SAFE (keep both), jamais silent overwrite |
| 3 | Un `python_sha` faux **rougit** un job | ⏸ volet (b) — DEFERRED (PR tooling séparée). Le gate `--check` rougit déjà sur mismatch (DRIFT) |
| 4 | La migration **préserve** les enregistrements existants | ✅ ancien enregistrement (avec `reason`) = item[0] |
| 5 | `test_twin_registry_integrity.py` **étendu, pas contourné** | ✅ +4 tests, schéma relaxé, validation SHAs sur tous les enregistrements |

### Portée honnête (G.3)

Deux audits concurrents de la **même** paire depuis la même base produisent encore un `CONFLICT` git (les deux ajoutent un `- date:` à la même position) — mais **LOUD et SAFE** : la résolution = garder les deux entrées, jamais de perte. L'auto-merge sans intervention **n'est pas atteignable côté serveur** : un merge driver `union` n'est jamais honoré par GitHub (documenté `.gitattributes` L31-33, « Ne PAS le ré-ajouter »). La branche « échouent bruyamment » du critère 2 est donc le vrai plafond — et les classes **silencieuses** (écrasement, clé dupliquée) sont éliminées à la source.

### Preuve

- **31 tests twin-parity PASS** (integrity 15 + surgical 12 + update_guard 4).
- **Gate `--per-pair --base origin/main`** : `drift_introduced=0` sur les 156 paires (3 DRIFT pré-existants Sudoku, non introduits par cette PR).
- **Round-trip YAML réel** validé sur 2 fichiers (`app-1-nqueens` avec `reason`, `app-10-portfolio` sans) : migration → `audits:` liste bien formée, `reason` préservé.
- **Test de merge git empirique** : deux appends concurrents → conflict loud, résolution lossless (les deux SHAs survivent).
- pyflakes CLEAN. Aucun fichier de données du registre modifié (uniquement tooling + doc `_schema.yaml`).

Volet (b) (SHA calculés par CI, pas écrits à la main) = PR tooling séparée.

See #9399

🤖 Generated with [Claude Code](https://claude.com/claude-code)