### PR TITLE
docs(lean-i18n,#4980): localize Information_en.lean mirror to EN

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Information.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Information.lean
@@ -191,9 +191,9 @@ theorem valueNoInfo_le_valuePerfect (D : DecisionProblem) :
     (valueSignal_le_valuePerfect D _)
 
 /-
-  Concrete check: the umbrella problem. Two equally likely states
-  (rain, sun), two actions (take the umbrella, leave it). Payoffs:
-  umbrella = 2 in rain, 0 in sun; no umbrella = -3 in rain, 3 in sun.
+  Vérification concrète : le problème du parapluie. Deux états équiprobables
+  (pluie, soleil), deux actions (prendre le parapluie, le laisser). Paiements :
+  parapluie = 2 en pluie, 0 en soleil ; pas de parapluie = -3 en pluie, 3 en soleil.
 -/
 
 /-- Problème de décision pluie-ou-soleil utilisé comme exemple vérifié au noyau. -/

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Information_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Information_en.lean
@@ -1,51 +1,50 @@
 /-
-  Valeur de l'information dans les problèmes de décision (Blackwell, cas déterministe)
+  Value of information in decision problems (Blackwell, deterministic case)
   =========================================================================
 
-  Un unique décideur fait face à un ensemble fini d'états avec une prior
-  `Nat` non normalisée (même encodage que `BayesGame2`) et choisit une
-  action parmi un ensemble fini non vide. Un *signal déterministe* est une
-  application des états vers les réalisations du signal — de manière
-  équivalente, une partition finie de l'espace d'états. On formalise trois
-  valeurs de référence :
+  A single decision maker faces a finite set of states with an unnormalized
+  `Nat` prior (same encoding as `BayesGame2`) and chooses an action from a
+  finite nonempty set. A *deterministic signal* is a map from states to signal
+  realizations — equivalently, a finite partition of the state space. We
+  formalize three reference values:
 
-  - `valueNoInfo` : choisir une action avant d'apprendre quoi que ce soit ;
-  - `valueSignal σ` : observer la réalisation de `σ`, puis choisir une action
-    optimalement à l'intérieur de chaque cellule de la partition ;
-  - `valuePerfect` : apprendre l'état exactement, puis choisir.
+  - `valueNoInfo`: choose an action before learning anything;
+  - `valueSignal σ`: observe the realization of `σ`, then choose an action
+    optimally within each cell of the partition;
+  - `valuePerfect`: learn the state exactly, then choose.
 
-  Théorèmes principaux (tous via le lemme maître `maxFin_sumFin_le` plus
-  l'identité de double-comptage `sumFin_partition`) :
+  Main theorems (all via the master lemma `maxFin_sumFin_le` plus the
+  double-counting identity `sumFin_partition`):
 
-  - `valueNoInfo_le_valueSignal` : l'information ne nuit jamais à un
-    décideur seul (la valeur de tout signal est non négative) ;
-  - `valueSignal_mono` : monotonie de Blackwell pour les partitions — si
-    `σ` est un raspberry (coarsening) de `τ` (i.e. `σ = h ∘ τ`), alors `τ`
-    vaut au moins autant que `σ` ;
-  - `valueSignal_le_valuePerfect` : l'information parfaite est le meilleur
-    signal déterministe.
+  - `valueNoInfo_le_valueSignal`: information never hurts a single decision
+    maker (the value of any signal is nonnegative);
+  - `valueSignal_mono`: Blackwell monotonicity for partitions — if `σ` is a
+    coarsening of `τ` (i.e. `σ = h ∘ τ`), then `τ` is worth at least as much
+    as `σ`;
+  - `valueSignal_le_valuePerfect`: perfect information is the best deterministic
+    signal.
 
-  Le fichier compagnon `InfoGames.lean` montre par contraste que dans un
-  *jeu*, plus d'information peut strictement nuire au joueur qui la reçoit
-  — la monotonie est un phénomène à un seul joueur.
+  The companion file `InfoGames.lean` shows by contrast that in a *game*, more
+  information can strictly hurt the player who receives it — monotonicity is a
+  single-player phenomenon.
 
-  Voir #2610 (formalisation GT-Lean, phase bayésienne 4).
+  See #2610 (GT-Lean formalization, Bayesian phase 4).
 -/
 
 import Bayesian.Max
 
-/-- Problème de décision fini à un seul agent avec une prior non normalisée. -/
+/-- A finite single-agent decision problem with an unnormalized prior. -/
 structure DecisionProblem where
-  /-- Nombre d'états du monde. -/
+  /-- Number of states of the world. -/
   nS : Nat
-  /-- Nombre d'actions moins un (les actions sont `Fin (nA + 1)`). -/
+  /-- Number of actions minus one (actions are `Fin (nA + 1)`). -/
   nA : Nat
-  /-- Poids de prior non normalisé de chaque état. -/
+  /-- Unnormalized prior weight of each state. -/
   w : Fin nS → Nat
-  /-- Paiement de l'action choisie dans un état. -/
+  /-- Payoff of the chosen action in a state. -/
   u : Fin nS → Fin (nA + 1) → Int
 
-/-- Paiement pondéré par la prior de l'action `a` dans l'état `s`. -/
+/-- Prior-weighted payoff of action `a` in state `s`. -/
 def wu (D : DecisionProblem) (s : Fin D.nS) (a : Fin (D.nA + 1)) : Int :=
   (D.w s : Int) * D.u s a
 
@@ -71,14 +70,14 @@ def valueSignal (D : DecisionProblem) {m : Nat} (σ : Signal D m) : Int :=
 def valuePerfect (D : DecisionProblem) : Int :=
   sumFin D.nS (fun s => maxFin D.nA (fun a => wu D s a))
 
-/-- Le signal totalement non informatif (une seule réalisation) vaut
-    exactement la valeur sans information. -/
+/-- The totally uninformative signal (a single realization) is worth
+    exactly the no-information value. -/
 theorem valueSignal_const (D : DecisionProblem) :
     valueSignal D (fun _ => (0 : Fin 1)) = valueNoInfo D := by
   unfold valueSignal valueNoInfo
   simp
 
-/-- Décomposition en fibres : sommer `f` sur les états classés par -/
+/-- Fiber decomposition: sum `f` over states grouped by -/
 theorem sumFin_fiber {n m p : Nat} (τ : Fin n → Fin p) (h : Fin p → Fin m)
     (k : Fin m) (f : Fin n → Int) :
     sumFin n (fun s => if h (τ s) = k then f s else 0) =
@@ -98,7 +97,7 @@ theorem sumFin_fiber {n m p : Nat} (τ : Fin n → Fin p) (h : Fin p → Fin m)
     by_cases h1 : h j = k <;> by_cases h2 : τ s = j <;> simp [h1, h2]
   rw [sumFin_congr swap, sumFin_single (τ s) (fun j => if h j = k then f s else 0)]
 
-/-- **Monotonie de Blackwell (cas déterministe).** Si le signal `σ` est -/
+/-- **Blackwell monotonicity (deterministic case).** If signal `σ` is -/
 theorem valueSignal_mono (D : DecisionProblem) {m p : Nat}
     (σ : Signal D m) (τ : Signal D p) (h : Fin (p + 1) → Fin (m + 1))
     (hfactor : ∀ s, σ s = h (τ s)) :
@@ -153,14 +152,14 @@ theorem valueSignal_mono (D : DecisionProblem) {m p : Nat}
         (sumFin_partition h (fun j => maxFin D.nA (fun a =>
           sumFin D.nS (fun s => if τ s = j then wu D s a else 0)))).symm
 
-/-- **L'information ne nuit jamais à un décideur seul** : tout signal vaut -/
+/-- **Information never hurts a single decision maker**: every signal is worth -/
 theorem valueNoInfo_le_valueSignal (D : DecisionProblem) {m : Nat}
     (σ : Signal D m) :
     valueNoInfo D ≤ valueSignal D σ := by
   rw [← valueSignal_const D]
   exact valueSignal_mono D (fun _ => (0 : Fin 1)) σ (fun _ => 0) (fun _ => rfl)
 
-/-- L'information parfaite domine tout signal : connaître l'état exactement -/
+/-- Perfect information dominates every signal: knowing the state exactly -/
 theorem valueSignal_le_valuePerfect (D : DecisionProblem) {m : Nat}
     (σ : Signal D m) :
     valueSignal D σ ≤ valuePerfect D := by
@@ -184,7 +183,7 @@ theorem valueSignal_le_valuePerfect (D : DecisionProblem) {m : Nat}
     _ = sumFin D.nS (fun s => maxFin D.nA (fun a => wu D s a)) :=
         (sumFin_partition σ (fun s => maxFin D.nA (fun a => wu D s a))).symm
 
-/-- Pas d'information est au plus l'information parfaite (composition des -/
+/-- No information is at most perfect information (composition of the -/
 theorem valueNoInfo_le_valuePerfect (D : DecisionProblem) :
     valueNoInfo D ≤ valuePerfect D :=
   Int.le_trans (valueNoInfo_le_valueSignal D (fun _ => (0 : Fin 1)))
@@ -196,7 +195,7 @@ theorem valueNoInfo_le_valuePerfect (D : DecisionProblem) :
   umbrella = 2 in rain, 0 in sun; no umbrella = -3 in rain, 3 in sun.
 -/
 
-/-- Problème de décision pluie-ou-soleil utilisé comme exemple vérifié au noyau. -/
+/-- Rain-or-shine decision problem used as a kernel-checked example. -/
 def umbrella : DecisionProblem where
   nS := 2
   nA := 1
@@ -205,12 +204,12 @@ def umbrella : DecisionProblem where
     if s.val = 0 then (if a.val = 0 then 2 else -3)
     else (if a.val = 0 then 0 else 3)
 
-/-- Non informé, le meilleur plan (toujours prendre le parapluie) vaut 2. -/
+/-- Uninformed, the best plan (always take the umbrella) is worth 2. -/
 theorem umbrella_valueNoInfo : valueNoInfo umbrella = 2 := by decide
 
-/-- Pleinement informé (parapluie ssi pluie), le plan vaut 5. -/
+/-- Fully informed (umbrella iff rain), the plan is worth 5. -/
 theorem umbrella_valuePerfect : valuePerfect umbrella = 5 := by decide
 
-/-- La valeur de l'information parfaite est strictement positive ici. -/
+/-- The value of perfect information is strictly positive here. -/
 theorem umbrella_strict_gain : valueNoInfo umbrella < valuePerfect umbrella := by
   decide


### PR DESCRIPTION
## Ce que fait la PR

Le miroir `_en` de `Bayesian/Information.lean` (valeur de l'information de Blackwell, cas déterministe) n'était que **partiellement traduit** : 4/16 docstrings étaient EN, le module doc + ~12 docstrings étaient encore FR (identiques au canonical FR) → advisory `HALF-DONE` du checker. C'est un défaut **`_en`-incomplete genuine** (PAS un FP module-doc-dup : les 4 docstrings traduites prouvent que le miroir est bien censé être EN).

### Changements (comment-only, convention sibling-pair #4980)
- **`Information_en.lean`** : module doc + ~12 docstrings FR → EN (decision maker, unnormalized prior, deterministic signal, Blackwell monotonicity, value of perfect information, exemple umbrella). Les 4 docstrings déjà EN et les tactic-comments EN sont intacts.
- **`Information.lean` (canonical)** : un bloc-comment EN en anomalie (« Concrete check: the umbrella problem », lignes ~193-197) localisé en FR — le canonical doit être pleinement FR ; ceci élimine aussi le dernier body partagé → le checker cleared.

### Build-safety (edit comment-only, pas de lake build requis)
- Strip de tous les comments, diff canonical vs `_en` : **130 lignes non-comment de chaque côté, 0 différence** (statements/tactics/proofs byte-identical FR↔EN).
- Block-comment balance OK dans les deux (22 openers = 22 closers dans le `_en`).
- sorry count 0 dans les deux.
- `check_i18n_siblings.py` : Information_en HALF-DONE (3 shared bodies) → **OK** (0 shared body ≥100 chars).

### Classification firsthand (lean-i18n-halfdone-module-doc-dup-fp)
Le canonical était déjà correctement FR (tous docstrings FR) ; le défaut était le miroir EN incomplet, pas un canonical half-done. Le lake Bayesian est TOUCHED (game_theory dev actif) → la veine productive est le re-scan des docstrings EN résiduels (cf c.1201 grothendieck SitePoints, même workflow dans l'autre direction).

`See #4980`

🤖 Generated with [Claude Code](https://claude.com/claude-code)