### PR TITLE
docs(readme,#9377): remove drift-prone notebook-counts from root + series-overview prose

### DIFF
--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -85,8 +85,8 @@ Search
 └── search_lean/ - Lake d'optimalité A* (consistance + heuristique)
 
 Probas
-├── Infer/ - 19 notebooks Infer.NET (graphes de facteurs, C#)
-├── PyMC/ - 19 notebooks PyMC (MCMC, Python) — miroir Infer
+├── Infer/ - notebooks Infer.NET (graphes de facteurs, C#)
+├── PyMC/ - notebooks PyMC (MCMC, Python) — miroir Infer
 ├── DecisionTheory/ - Arc décision DecInfer 1-10 (vNM, Gittins, Thompson) + Causal-Bridges (do(·) Pearl cross-paradigmes)
 └── decision_theory_lean/ - Axiomes VNM + Gittins (Lean 4)
 
@@ -96,7 +96,7 @@ Sudoku
     └── 10..19 spécialisations (Z3, OR-Tools, Choco, Lean, LLM, NN)
 
 GameTheory
-├── (à plat) - 17 notebooks : Nash, Minimax, Coopétition, MARL, Mechanism Design
+├── (à plat) - Nash, Minimax, Coopétition, MARL, Mechanism Design
 ├── SocialChoice/ - Arrow, Sen, Condorcet (Lean 4)
 └── *_lean/ + lean_game_defs(_ext)/ - 8 lakes (game_theory_lean [Arrow, Shapley, Stable Marriage], conway_cgt_lean, minimax_lean, repeated_games_lean, social_choice_lean, social_choice_lean_peters, lean_game_defs, lean_game_defs_ext — ces deux derniers en `lakefile.toml`, pas `.lean`)
 
@@ -114,7 +114,7 @@ CaseStudies
 
 IIT
 ├── ICT-Series/ - Integrated Causal Trajectories (4 substrats : tri, Gray-Scott, Axelrod, transformer+SAE)
-└── (à plat) - 3 notebooks PyPhi : Intro, Advanced, Coarse-Graining Phi
+└── (à plat) - notebooks PyPhi : Intro, Advanced, Coarse-Graining Phi
 ```
 
 ## Parité Python / .NET / Lean — différenciant structurant

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ MyIA.AI.Notebooks/
   GameTheory/      -> Théorie des jeux, équilibres de Nash, mechanism design, social choice
   IIT/             -> Information intégrée (Tononi, PyPhi) + banc ICT : trajectoires causales, du tri au LLM
   CaseStudies/     -> Études de cas interdisciplinaires
-  SymbolicAI/      -> Raisonnement formel (Lean 4, Tweety, Semantic Web, Smart Contracts, Planners, SMT, Argument Analysis, Symbolic Learning) -- la plus vaste série du dépôt (224 notebooks)
-  GenAI/           -> IA générative (Image, Audio, Video, Texte, Semantic Kernel, Vibe Coding) -- l'une des plus vastes séries (141 notebooks)
+  SymbolicAI/      -> Raisonnement formel (Lean 4, Tweety, Semantic Web, Smart Contracts, Planners, SMT, Argument Analysis, Symbolic Learning) -- la plus vaste série du dépôt
+  GenAI/           -> IA générative (Image, Audio, Video, Texte, Semantic Kernel, Vibe Coding) -- l'une des plus vastes séries
   QuantConnect/    -> Trading algorithmique (notebooks pédagogiques + stratégies backtestées + pipeline ML)
   cross-series/    -> Applications transverses (matching-cv : data science multi-domaines)
 ```


### PR DESCRIPTION
## What

Removes 6 hand-written notebook-volume counts from the 2 root-level overview READMEs, per the **2026-08-04 user mandate #9377**: *« les données quantitatives doivent être tenues par le CI, pas dans la prose manuelle »*. The generated catalog (`COURSE_CATALOG.generated.*`) is the authoritative source; these prose counts drift on every series addition (the "resync treadmill" — 11 such PRs merged in 3 weeks, per the issue).

## Changes (markdown-only, no re-exec — C.2 exception)

| File | Removed | Why drift-prone |
|------|---------|-----------------|
| `README.md` (root) L35 | `(224 notebooks)` on SymbolicAI card | series volume grows on every addition |
| `README.md` (root) L36 | `(141 notebooks)` on GenAI card | same |
| `MyIA.AI.Notebooks/README.md` L88 | `19 notebooks` Infer | Probas Infer volume drifts |
| `MyIA.AI.Notebooks/README.md` L89 | `19 notebooks` PyMC | mirror count drifts with Infer |
| `MyIA.AI.Notebooks/README.md` L99 | `17 notebooks` GameTheory | main-track volume drifts |
| `MyIA.AI.Notebooks/README.md` L117 | `3 notebooks` PyPhi | IIT volume drifts |

Both files already declare the catalog authoritative in their headers (root L13 "il fait foi sur les chiffres"; notebooks L122 "marqueur CATALOG-STATUS source de vérité pour les volumes") — these 6 counts self-contradicted that policy.

## Kept deliberately (NOT drift-prone)

- root README L209 `(105 notebooks au catalogue)` — already defers to catalog explicitly.
- notebooks README `8 lakes` — 8 named lakes listed inline, self-verifying (structural, not volume).
- notebooks README Sudoku `19 problèmes` — fixed pedagogical problem set, not a series volume.

## §E full-file audit (per pr-review-discipline §E)

Both files re-audited in full against disk: no other drift-prone notebook-volume counts remain in either. The remaining numerical prose is either catalog-deferred, structural, or self-verifying.

## Scope

Markdown-only, 2 files, +6/-6. No catalog files touched (catalog hygiene — byte-identical to main). No notebook re-execution needed.

See #9377 (partial — this is one tranche of the larger perimeter; the issue spans 44 notebooks + ~30 READMEs and needs decomposition by a coordinator, as many candidate matches are live cell outputs or exercise questions, not manual prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)