### PR TITLE
docs(lean-i18n,#4980): localize 3 EN module-doc blocks in Conway/Life/Spaceships.lean

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Spaceships.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Spaceships.lean
@@ -40,10 +40,10 @@ import Conway.Life
 namespace Conway
 namespace Life
 
-/-! ## Lightweight Spaceship (LWSS)
+/-! ## Vaisseau leger (LWSS)
 
-The smallest period-4 spaceship after the glider, with 9 live cells.
-Phase 1 (heading east):
+Le plus petit vaisseau de periode 4 apres le planeur, avec 9 cellules vivantes.
+Phase 1 (vers l'est) :
 
 ```
 .OOOO
@@ -52,7 +52,7 @@ O...O
 O..O.
 ```
 
-After 4 generations the pattern reappears, translated by `(0, 2)`.
+Apres 4 generations le motif reapparait, translate de `(0, 2)`.
 -/
 
 /-- The **LWSS** (Lightweight Spaceship), phase 1, east-bound. -/
@@ -71,10 +71,10 @@ def lwss : Grid :=
 /-- The LWSS is a spaceship of period 4 and displacement `(0, 2)`. -/
 theorem lwss_spaceship : isSpaceship lwss 4 (0, 2) = true := by native_decide
 
-/-! ## Middleweight Spaceship (MWSS)
+/-! ## Vaisseau moyen (MWSS)
 
-A period-4 spaceship with 11 live cells: LWSS extended by one column and
-crowned with a single "hat" cell. Phase 1 (heading east):
+Un vaisseau de periode 4 avec 11 cellules vivantes : LWSS etendu d'une colonne
+et couronne d'une cellule "chapeau". Phase 1 (vers l'est) :
 
 ```
 .OOOOO
@@ -84,7 +84,7 @@ O...O.
 ..O...
 ```
 
-After 4 generations the pattern reappears, translated by `(0, 2)`.
+Apres 4 generations le motif reapparait, translate de `(0, 2)`.
 -/
 
 /-- The **MWSS** (Middleweight Spaceship), phase 1, east-bound. -/
@@ -103,10 +103,10 @@ def mwss : Grid :=
 /-- The MWSS is a spaceship of period 4 and displacement `(0, 2)`. -/
 theorem mwss_spaceship : isSpaceship mwss 4 (0, 2) = true := by native_decide
 
-/-! ## Heavyweight Spaceship (HWSS)
+/-! ## Vaisseau lourd (HWSS)
 
-A period-4 spaceship with 13 live cells: LWSS extended by two columns and
-crowned with a two-cell "hat". Phase 1 (heading east):
+Un vaisseau de periode 4 avec 13 cellules vivantes : LWSS etendu de deux colonnes
+et couronne d'un "chapeau" a deux cellules. Phase 1 (vers l'est) :
 
 ```
 .OOOOOO
@@ -116,7 +116,7 @@ O....O.
 ..OO...
 ```
 
-After 4 generations the pattern reappears, translated by `(0, 2)`.
+Apres 4 generations le motif reapparait, translate de `(0, 2)`.
 -/
 
 /-- The **HWSS** (Heavyweight Spaceship), phase 1, east-bound. -/


### PR DESCRIPTION
## What & why (#4980 — Lean i18n rollout, partial)

`check_i18n_siblings.py` flagged `Conway/Life/Spaceships.lean` as `HALF-DONE`: its 3 module documentation blocks (`/-! ## Lightweight/Middleweight/Heavyweight Spaceship`) were in English, byte-identical to the EN mirror `Spaceships_en.lean` — "FR was probably never localized".

Localized the 3 module-doc prose blocks to French, matching the file's existing FR style (accent-free mathematical French: the header lines 1-27 use "Vaisseaux Leger/Moyen/Lourd", "periode 4", "deplacement", "translatant", "Decouverts"). ASCII diagrams and `(0, 2)` displacement notation preserved verbatim. EN mirror unchanged.

## Build-safety — byte-identity proof (per po-2023 #9398 pattern)

Docstring/comment-only edits. The structural surface is byte-identical to `main`:
- `def` / `theorem` / `namespace` / `import` / `#eval` lines — **byte-identical** (verified by grep diff: empty)
- `sorry` count: **0 → 0** (no proof touched)
- Lean comment-block delimiters balanced: 3 `/-!` openers, matched `-/` closers
- Only the 3 module-doc prose blocks changed (12 lines, FR↔EN)

A full Mathlib build (~25 min) is disproportionate for 3 docstring translations; byte-identity is the load-bearing proof (the established pattern for FR-first #4980 docstring localization).

## Verification

```
$ python scripts/lean/check_i18n_siblings.py --all
OK      .../Conway/Life/Spaceships_en.lean        # was HALF-DONE
177/179 pairs byte-identical | 2 consumer-pattern | 0 drift | 0 orphan | 1 unbuilt | 16 half-done (was 17)
```
- Advisory **lifted**: HALF-DONE → OK (17 → 16 half-done)
- 0 drift, 0 orphan (EN mirror unchanged, FR changed → they now correctly differ on docstrings only)
- 30 checker self-tests pass

## Collision note

po-2023 ceded the conway lane explicitly (c.1201: "conway/knot laissés aux owners actifs pour éviter collision"). Firsthand file-level collision check before claiming: **0 open PRs touch Spaceships.lean**, not in shared-tree WIP (`Angel.lean`/`Nim.lean` are the WIP'd files, not Spaceships). So no actual collision exists — the cession was precautionary. lane myia-po-2024:CoursIA.

See #4980 (partial — one file of the rollout), #9398 (po-2023 sibling pattern reference).
