### PR TITLE
i18n(lean,#4980): localize FR canonical docstrings in 4 conway_lean modules (lot drain)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Angel.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Angel.lean
@@ -37,35 +37,35 @@ import Mathlib.Data.Finset.Prod
 
 namespace Conway
 
-/-- Chebyshev (king-move) distance on the integer lattice. -/
+/-- Distance de Chebyshev (coup de roi) sur le reseau entier. -/
 def chebyshev (a b : ℤ × ℤ) : ℤ :=
   max (|a.1 - b.1|) (|a.2 - b.2|)
 
-/-- Squares an Angel of power `k` can reach from `p`: the (2k+1)×(2k+1) Chebyshev
-    box around `p`, excluding `p` itself (the Angel must move). -/
+/-- Cases qu'un Ange de pouvoir `k` peut atteindre depuis `p` : le carre Chebyshev
+    (2k+1)×(2k+1) autour de `p`, `p` lui-meme exclu (l'Ange doit bouger). -/
 def angelMoves (k : ℕ) (p : ℤ × ℤ) : Finset (ℤ × ℤ) :=
   ((Finset.Icc (p.1 - (k : ℤ)) (p.1 + (k : ℤ))) ×ˢ
    (Finset.Icc (p.2 - (k : ℤ)) (p.2 + (k : ℤ)))).erase p
 
--- The power-1 Angel is exactly a chess king (8 moves); power-2 has 24.
+-- L'Ange de pouvoir 1 est exactement un roi d'echecs (8 coups) ; le pouvoir 2 en a 24.
 #eval (angelMoves 1 (0, 0)).card   -- 8
 #eval (angelMoves 2 (0, 0)).card   -- 24
 
-/-- Proved anchor: the Chebyshev distance from a square to itself is 0. -/
+/-- Ancre prouvee : la distance de Chebyshev d'une case a elle-meme vaut 0. -/
 theorem chebyshev_self (a : ℤ × ℤ) : chebyshev a a = 0 := by
   simp [chebyshev]
 
-/-- CALIBRATION (decide / native_decide): Conway's power-1 Angel is a king — 8 moves. -/
+/-- CALIBRATION (decide / native_decide) : l'Ange de pouvoir 1 de Conway est un roi — 8 coups. -/
 theorem kingMoves_card : (angelMoves 1 (0, 0)).card = 8 := by
   decide
 
-/-- CALIBRATION (decide / native_decide): the power-2 Angel has 24 moves. -/
+/-- CALIBRATION (decide / native_decide) : l'Ange de pouvoir 2 a 24 coups. -/
 theorem angelMoves2_card : (angelMoves 2 (0, 0)).card = 24 := by
   decide
 
-/-- CALIBRATION (Finset.card arithmetic, medium): an Angel of power `k` from any
-    square has exactly `(2k+1)^2 - 1` moves — the combinatorial heart of the Angel
-    problem setup (`card_erase_of_mem` + `card_product` + `Int.card_Icc`). -/
+/-- CALIBRATION (arithmetique Finset.card, moyen) : un Ange de pouvoir `k` depuis
+    n'importe quelle case a exactement `(2k+1)^2 - 1` coups — le cœur combinatoire du
+    setup du probleme de l'Ange (`card_erase_of_mem` + `card_product` + `Int.card_Icc`). -/
 theorem angelMoves_card (k : ℕ) (p : ℤ × ℤ) :
     (angelMoves k p).card = (2 * k + 1) ^ 2 - 1 := by
   simp [angelMoves, Finset.card_product, Int.card_Icc]

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/CollatzLike.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/CollatzLike.lean
@@ -101,18 +101,19 @@ import Conway.Fractran
 
 namespace Conway
 
-/-! ## Piecewise-linear functions
+/-! ## Fonctions linéaires par morceaux
 
-A Collatz-like function partitions ℤ into finitely many residue classes
-modulo `m`, and applies a different affine map `n ↦ (a·n + b) / c` to
-each class. The classic Collatz function (3n+1 problem) has m=2:
-  - n ≡ 0 (mod 2): n ↦ n/2
-  - n ≡ 1 (mod 2): n ↦ (3n+1)/2
+Une fonction de type Collatz partitionne ℤ en un nombre fini de classes
+de résidus modulo `m`, et applique une application affine différente
+`n ↦ (a·n + b) / c` à chaque classe. La fonction de Collatz classique
+(problème 3n+1) a m=2 :
+  - n ≡ 0 (mod 2) : n ↦ n/2
+  - n ≡ 1 (mod 2) : n ↦ (3n+1)/2
 
-Conway showed that for sufficiently complex choices of m, a, b, c,
-the question "does every trajectory reach 1?" becomes undecidable. -/
+Conway a montré que pour des choix suffisamment complexes de m, a, b, c,
+la question « toute trajectoire atteint-elle 1 ? » devient indécidable. -/
 
-/-- An affine map n ↦ (a·n + b) / c, applicable when the division is exact. -/
+/-- Application affine n ↦ (a·n + b) / c, applicable quand la division est exacte. -/
 structure AffineMap where
   a : Int
   b : Int
@@ -120,150 +121,152 @@ structure AffineMap where
   hc : c > 0
   deriving Repr
 
-/-- Apply an affine map, returning none if division isn't exact. -/
+/-- Applique une application affine, renvoie none si la division n'est pas exacte. -/
 def applyAffine (f : AffineMap) (n : Int) : Option Int :=
   let num := f.a * n + f.b
   if num % f.c = 0 then some (num / f.c) else none
 
-/-- A branch of a Collatz-like function: apply this map when
-    n mod m = r (for 0 ≤ r < m). -/
+/-- Une branche d'une fonction de type Collatz : appliquer cette application
+    quand n mod m = r (pour 0 ≤ r < m). -/
 structure CLBranch where
-  r : Nat          -- residue class
-  f : AffineMap    -- the map to apply
+  r : Nat          -- classe de résidu
+  f : AffineMap    -- l'application à appliquer
   deriving Repr
 
-/-- A Collatz-like function: partition ℤ into residue classes modulo m,
-    apply a different affine map to each. -/
+/-- Une fonction de type Collatz : partitionner ℤ en classes de résidus
+    modulo m, appliquer une application affine différente à chacune. -/
 structure CollatzLike where
-  m : Nat          -- modulus (number of cases)
+  m : Nat          -- module (nombre de cas)
   hm : m > 0
   branches : List CLBranch
   deriving Repr
 
-/-- The classic Collatz function as a CollatzLike.
-    n ≡ 0 (mod 2): n ↦ n/2 (i.e., a=1, b=0, c=2)
-    n ≡ 1 (mod 2): n ↦ (3n+1) (simplified as (3n+1)/1) -/
+/-- La fonction de Collatz classique comme CollatzLike.
+    n ≡ 0 (mod 2) : n ↦ n/2 (i.e., a=1, b=0, c=2)
+    n ≡ 1 (mod 2) : n ↦ (3n+1) (simplifié en (3n+1)/1) -/
 def collatz : CollatzLike where
   m := 2
   hm := by decide
   branches := [
-    ⟨0, ⟨1, 0, 2, by decide⟩⟩,   -- n even: n/2
-    ⟨1, ⟨3, 1, 1, by decide⟩⟩    -- n odd:  3n+1
+    ⟨0, ⟨1, 0, 2, by decide⟩⟩,   -- n pair : n/2
+    ⟨1, ⟨3, 1, 1, by decide⟩⟩    -- n impair : 3n+1
   ]
 
-/-- One step of a Collatz-like function. -/
+/-- Une étape d'une fonction de type Collatz. -/
 def clStep (f : CollatzLike) (n : Int) : Int :=
-  let r := ((n % f.m) + f.m) % f.m  -- non-negative residue
+  let r := ((n % f.m) + f.m) % f.m  -- résidu non négatif
   match f.branches.find? (fun b => b.r = r.natAbs) with
   | some branch => match applyAffine branch.f n with
     | some m => m
-    | none => n  -- stay put if division fails
-  | none => n    -- stay put if no branch matches
+    | none => n  -- rester sur place si la division échoue
+  | none => n    -- rester sur place si aucune branche ne correspond
 
-/-- Iterate a Collatz-like function for k steps. -/
+/-- Itère une fonction de type Collatz pendant k étapes. -/
 def clIterate (f : CollatzLike) : Int → Nat → List Int
   | n, 0 => [n]
   | n, k + 1 => n :: clIterate f (clStep f n) k
 
-/-! ## Proven properties of the classic Collatz function
+/-! ## Propriétés prouvées de la fonction de Collatz classique
 
-While the full Collatz conjecture ("every trajectory reaches 1") remains
-open, we can verify specific trajectories via `native_decide`. -/
+Bien que la conjecture de Collatz complète (« toute trajectoire atteint 1 »)
+reste ouverte, nous pouvons vérifier des trajectoires spécifiques via
+`native_decide`. -/
 
-/-- The classic 3n+1 step function: n ↦ n/2 if even, 3n+1 if odd. -/
+/-- Fonction d'étape 3n+1 classique : n ↦ n/2 si pair, 3n+1 si impair. -/
 def collatzStep (n : Int) : Int :=
   if n % 2 = 0 then n / 2 else 3 * n + 1
 
-/-- Verify the famous trajectory starting from 6:
+/-- Vérifie la célèbre trajectoire partant de 6 :
     6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1 -/
 theorem collatz_6_trajectory :
     clIterate collatz 6 8 = [6, 3, 10, 5, 16, 8, 4, 2, 1] := by
   decide
 
-/-- Verify trajectory from 27 (the longest under 100):
-    27 takes 111 steps to reach 1. We verify the first 10 steps. -/
+/-- Vérifie la trajectoire partant de 27 (la plus longue sous 100) :
+    27 prend 111 étapes pour atteindre 1. Nous vérifions les 10 premières. -/
 theorem collatz_27_first_10 :
     clIterate collatz 27 10 = [27, 82, 41, 124, 62, 31, 94, 47, 142, 71, 214] := by
   decide
 
-/-- Verify trajectory from 7:
+/-- Vérifie la trajectoire partant de 7 :
     7 → 22 → 11 → 34 → 17 → 52 → 26 → 13 → 40 → 20 → 10 → 5 → 16 → 8 → 4 → 2 → 1 -/
 theorem collatz_7_trajectory :
     clIterate collatz 7 16 = [7, 22, 11, 34, 17, 52, 26, 13, 40, 20, 10, 5, 16, 8, 4, 2, 1] := by
   decide
 
-/-! ## Conway's (3n+1)/2 variant
+/-! ## Variante (3n+1)/2 de Conway
 
-Conway often studied the compressed form where both operations are
-combined: n ≡ 0 (mod 2): n/2; n ≡ 1 (mod 2): (3n+1)/2.
-This halves the number of steps by combining the guaranteed-even step
-after 3n+1 with the subsequent division by 2. -/
+Conway étudiait souvent la forme compressée où les deux opérations sont
+combinées : n ≡ 0 (mod 2) : n/2 ; n ≡ 1 (mod 2) : (3n+1)/2.
+Cela divise par deux le nombre d'étapes en combinant l'étape garantie
+paire après 3n+1 avec la division par 2 qui s'ensuit. -/
 
-/-- The compressed Collatz function: n even → n/2, n odd → (3n+1)/2.
-    This is the form Conway analyzed in "Unpredictable Iterations". -/
+/-- La fonction de Collatz compressée : n pair → n/2, n impair → (3n+1)/2.
+    C'est la forme que Conway a analysée dans « Unpredictable Iterations ». -/
 def collatzCompressed : CollatzLike where
   m := 2
   hm := by decide
   branches := [
-    ⟨0, ⟨1, 0, 2, by decide⟩⟩,    -- n even: n/2
-    ⟨1, ⟨3, 1, 2, by decide⟩⟩     -- n odd:  (3n+1)/2
+    ⟨0, ⟨1, 0, 2, by decide⟩⟩,    -- n pair : n/2
+    ⟨1, ⟨3, 1, 2, by decide⟩⟩     -- n impair : (3n+1)/2
   ]
 
-/-- Verify compressed trajectory from 6:
-    6 → 3 → 5 → 8 → 4 → 2 → 1 (6 steps instead of 8) -/
+/-- Vérifie la trajectoire compressée partant de 6 :
+    6 → 3 → 5 → 8 → 4 → 2 → 1 (6 étapes au lieu de 8) -/
 theorem collatzCompressed_6 :
     clIterate collatzCompressed 6 6 = [6, 3, 5, 8, 4, 2, 1] := by
   decide
 
-/-- Verify compressed trajectory from 7:
+/-- Vérifie la trajectoire compressée partant de 7 :
     7 → 11 → 17 → 26 → 13 → 20 → 10 → 5 → 8 → 4 → 2 → 1 -/
 theorem collatzCompressed_7 :
     clIterate collatzCompressed 7 11 = [7, 11, 17, 26, 13, 20, 10, 5, 8, 4, 2, 1] := by
   decide
 
-/-! ## Connection to FRACTRAN
+/-! ## Connexion à FRACTRAN
 
-Conway showed that any FRACTRAN program can be converted into a
-Collatz-like function and vice versa. This is the key insight behind
-the undecidability result: since FRACTRAN is Turing-complete, and
-FRACTRAN halting reduces to Collatz-like termination, the latter is
-undecidable.
+Conway a montré que tout programme FRACTRAN peut être converti en une
+fonction de type Collatz et vice-versa. C'est l'idée clé derrière le
+résultat d'indécidabilité : puisque FRACTRAN est Turing-complet, et que
+l'arrêt de FRACTRAN se réduit à la terminaison des fonctions de type
+Collatz, cette dernière est indécidable.
 
-We verify one step of this correspondence: a simple FRACTRAN program
-that doubles a number corresponds to a specific Collatz-like function. -/
+Nous vérifions une étape de cette correspondance : un programme FRACTRAN
+simple qui double un nombre correspond à une fonction de type Collatz
+spécifique. -/
 
-/-- The "doubling" FRACTRAN program: n ↦ 2n.
-    Single fraction 2/1: at each step, multiply by 2. -/
+/-- Le programme FRACTRAN de « doublement » : n ↦ 2n.
+    Fraction unique 2/1 : à chaque étape, multiplier par 2. -/
 def doubleProgram : List Frac := [frac 2 1 (by decide)]
 
-/-- Verify: running the doubling program from 3 for 4 steps. -/
+/-- Vérifie : exécuter le programme de doublement depuis 3 pendant 4 étapes. -/
 theorem fractran_double_3 :
     fractranRun doubleProgram 3 4 = [3, 6, 12, 24, 48] := by
   decide
 
-/-! ## Conway's 7n+1 variant — an open problem
+/-! ## Variante 7n+1 de Conway — un problème ouvert
 
-One of the simplest open generalizations: 7n+1 instead of 3n+1.
-Is every trajectory periodic? Not known. We verify that some starting
-values do reach 1. -/
+L'une des généralisations ouvertes les plus simples : 7n+1 au lieu de
+3n+1. Toute trajectoire est-elle périodique ? On l'ignore. Nous vérifions
+que certaines valeurs de départ atteignent bien 1. -/
 
-/-- The 7n+1 function: n even → n/2, n odd → 7n+1. -/
+/-- La fonction 7n+1 : n pair → n/2, n impair → 7n+1. -/
 def sevenNPlusOne : CollatzLike where
   m := 2
   hm := by decide
   branches := [
-    ⟨0, ⟨1, 0, 2, by decide⟩⟩,    -- n even: n/2
-    ⟨1, ⟨7, 1, 1, by decide⟩⟩     -- n odd:  7n+1
+    ⟨0, ⟨1, 0, 2, by decide⟩⟩,    -- n pair : n/2
+    ⟨1, ⟨7, 1, 1, by decide⟩⟩     -- n impair : 7n+1
   ]
 
-/-- Verify 7n+1 trajectory from 3:
-    3 → 22 → 11 → 78 → 39 → 274 → 137 → 960 → 480 → 240 → 120 → 60 → 30 → 15 → 106 → 53 → 372 → 186 → 93 → 652 → 326 → 163 → 1142 → 571 → 3998 → ... (long!)
-    We verify the first 5 steps. -/
+/-- Vérifie la trajectoire 7n+1 partant de 3 :
+    3 → 22 → 11 → 78 → 39 → 274 → 137 → 960 → 480 → 240 → 120 → 60 → 30 → 15 → 106 → 53 → 372 → 186 → 93 → 652 → 326 → 163 → 1142 → 571 → 3998 → ... (longue !)
+    Nous vérifions les 5 premières étapes. -/
 theorem sevenNPlusOne_3 :
     clIterate sevenNPlusOne 3 5 = [3, 22, 11, 78, 39, 274] := by
   decide
 
-/-- 7n+1 from 1: 1 → 8 → 4 → 2 → 1 (short cycle). -/
+/-- 7n+1 depuis 1 : 1 → 8 → 4 → 2 → 1 (cycle court). -/
 theorem sevenNPlusOne_1 :
     clIterate sevenNPlusOne 1 4 = [1, 8, 4, 2, 1] := by
   decide

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Doomsday.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Doomsday.lean
@@ -66,14 +66,14 @@ import Mathlib.Data.Int.ModEq
 
 namespace Conway
 
-/-- Days of the week, starting from Sunday = 0 -/
+/-- Jours de la semaine, en partant de dimanche = 0 -/
 inductive DayOfWeek where
   | sunday | monday | tuesday | wednesday | thursday | friday | saturday
   deriving Repr, BEq, DecidableEq, Inhabited
 
 namespace DayOfWeek
 
-/-- Convert DayOfWeek to a Fin 7 -/
+/-- Convertit DayOfWeek en un Fin 7 -/
 def toFin : DayOfWeek → Fin 7
   | sunday => 0 | monday => 1 | tuesday => 2 | wednesday => 3
   | thursday => 4 | friday => 5 | saturday => 6
@@ -82,7 +82,7 @@ instance : Repr DayOfWeek := ⟨fun d _ => match d with
   | sunday => "Sun" | monday => "Mon" | tuesday => "Tue"
   | wednesday => "Wed" | thursday => "Thu" | friday => "Fri" | saturday => "Sat"⟩
 
-/-- Convert a Fin 7 to DayOfWeek -/
+/-- Convertit un Fin 7 en DayOfWeek -/
 def ofFin : Fin 7 → DayOfWeek
   | 0 => sunday | 1 => monday | 2 => tuesday | 3 => wednesday
   | 4 => thursday | 5 => friday | 6 => saturday
@@ -91,30 +91,30 @@ def ofFin : Fin 7 → DayOfWeek
 @[simp] theorem ofFin_toFin (d : DayOfWeek) : ofFin (toFin d) = d := by
   cases d <;> rfl
 
-/-- Add n days (modulo 7) -/
+/-- Ajoute n jours (modulo 7) -/
 def add (d : DayOfWeek) (n : Nat) : DayOfWeek :=
   ofFin ⟨(d.toFin + n) % 7, by omega⟩
 
-/-- Subtract n days (modulo 7) -/
+/-- Soustrait n jours (modulo 7) -/
 def sub (d : DayOfWeek) (n : Nat) : DayOfWeek :=
   ofFin ⟨(d.toFin + 7 - n % 7) % 7, by omega⟩
 
 end DayOfWeek
 
-/-- Check if a year is a leap year in the Gregorian calendar -/
+/-- Vérifie si une année est bissextile dans le calendrier grégorien -/
 def isLeapYear (year : Nat) : Bool :=
   year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
 
-/-- Century anchor day computation.
-  1700: Sunday, 1800: Friday, 1900: Wednesday, 2000: Tuesday, 2100: Sunday.
-  Formula: (5 * (c % 4) + 2) % 7 where c = year / 100 -/
+/-- Calcul du jour d'ancrage du siècle.
+  1700 : dimanche, 1800 : vendredi, 1900 : mercredi, 2000 : mardi, 2100 : dimanche.
+  Formule : (5 * (c % 4) + 2) % 7 où c = année / 100 -/
 def centuryAnchor (year : Nat) : DayOfWeek :=
   let c := year / 100
   DayOfWeek.ofFin ⟨(5 * (c % 4) + 2) % 7, by omega⟩
 
-/-- Conway's doomsday for a given year.
+/-- Doomsday de Conway pour une année donnée.
   doomsday = centuryAnchor + (yy / 12) + (yy % 12) + ((yy % 12) / 4)
-  where yy = year % 100 -/
+  où yy = année % 100 -/
 def doomsday (year : Nat) : DayOfWeek :=
   let yy := year % 100
   let a := yy / 12
@@ -122,11 +122,11 @@ def doomsday (year : Nat) : DayOfWeek :=
   let c := b / 4
   DayOfWeek.add (centuryAnchor year) (a + b + c)
 
-/-- The doomsday date (day of month) for each month.
-  January: 3 (non-leap) or 4 (leap)
-  February: 28 (non-leap) or 29 (leap)
-  March: 7, April: 4, May: 9, June: 6, July: 11, August: 8
-  September: 5, October: 10, November: 7, December: 12 -/
+/-- La date doomsday (jour du mois) pour chaque mois.
+  Janvier : 3 (non bissextile) ou 4 (bissextile)
+  Février : 28 (non bissextile) ou 29 (bissextile)
+  Mars : 7, Avril : 4, Mai : 9, Juin : 6, Juillet : 11, Août : 8
+  Septembre : 5, Octobre : 10, Novembre : 7, Décembre : 12 -/
 def doomsdayDate (month year : Nat) : Nat :=
   match month with
   | 1 => if isLeapYear year then 4 else 3
@@ -135,10 +135,11 @@ def doomsdayDate (month year : Nat) : Nat :=
   | 7 => 11 | 8 => 8 | 9 => 5 | 10 => 10
   | 11 => 7 | _ => 12
 
-/-- Compute the day of the week for any Gregorian date using Conway's Doomsday algorithm.
-  1. Find the doomsday for the year
-  2. Find the nearest doomsday date in the same month
-  3. Count the offset (positive or negative) to the target date -/
+/-- Calcule le jour de la semaine pour toute date grégorienne en utilisant
+  l'algorithme Doomsday de Conway.
+  1. Trouver le doomsday pour l'année
+  2. Trouver la date doomsday la plus proche dans le même mois
+  3. Compter le décalage (positif ou négatif) jusqu'à la date cible -/
 def dayOfWeek (year month day : Nat) : DayOfWeek :=
   let dd := doomsdayDate month year
   let d := doomsday year
@@ -147,16 +148,16 @@ def dayOfWeek (year month day : Nat) : DayOfWeek :=
   else
     DayOfWeek.sub d (dd - day)
 
--- Conway passed away on Saturday, April 11, 2020
+-- Conway est mort un samedi 11 avril 2020
 #eval dayOfWeek 2020 4 11 -- Saturday
 
--- September 11, 2001 was a Tuesday
+-- Le 11 septembre 2001 était un mardi
 #eval dayOfWeek 2001 9 11 -- Tuesday
 
--- Moon landing: July 20, 1969 was a Sunday
+-- Alunissage : le 20 juillet 1969 était un dimanche
 #eval dayOfWeek 1969 7 20 -- Sunday
 
--- D-Day: June 6, 1944 was a Tuesday
+-- Jour J : le 6 juin 1944 était un mardi
 #eval dayOfWeek 1944 6 6 -- Tuesday
 
 end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Oscillators.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Oscillators.lean
@@ -39,19 +39,19 @@ import Conway.Life
 namespace Conway
 namespace Life
 
-/-! ## Still lifes
+/-! ## Structures stables (still lifes)
 
-We add five classical still-lifes to complement `block` and `beehive`
-from `Conway.Life`:
+Nous ajoutons cinq structures stables classiques pour completer `block`
+et `beehive` de `Conway.Life` :
 
-- **Loaf**: 7-cell pattern, one of the four most common still lifes
-- **Boat**: 5-cell pattern, the smallest asymmetric still life
-- **Tub**: 4-cell pattern, smallest still life with rotational symmetry
-- **Pond**: 8-cell pattern, larger square-ish still life
-- **Ship**: 6-cell pattern, related to the boat (rotated boat with extra cell)
+- **Loaf** : motif a 7 cellules, l'une des quatre structures stables les plus courantes
+- **Boat** : motif a 5 cellules, la plus petite structure stable asymetrique
+- **Tub** : motif a 4 cellules, la plus petite structure stable a symetrie rotationnelle
+- **Pond** : motif a 8 cellules, une structure stable plus grande quasi carree
+- **Ship** : motif a 6 cellules, apparente au boat (boat tourne avec une cellule supplementaire)
 -/
 
-/-- The **Loaf**: a 7-cell still life.
+/-- Le **Loaf** : une structure stable a 7 cellules.
     ```
     .XX.
     X..X
@@ -61,7 +61,7 @@ from `Conway.Life`:
 def loaf : Grid :=
   [(0, 1), (0, 2), (1, 0), (1, 3), (2, 1), (2, 3), (3, 2)]
 
-/-- The **Boat**: a 5-cell still life. Smallest asymmetric still life.
+/-- Le **Boat** : une structure stable a 5 cellules. Plus petite structure stable asymetrique.
     ```
     XX.
     X.X
@@ -70,7 +70,7 @@ def loaf : Grid :=
 def boat : Grid :=
   [(0, 0), (0, 1), (1, 0), (1, 2), (2, 1)]
 
-/-- The **Tub**: a 4-cell still life with full rotational symmetry.
+/-- Le **Tub** : une structure stable a 4 cellules a symetrie rotationnelle complete.
     ```
     .X.
     X.X
@@ -79,7 +79,7 @@ def boat : Grid :=
 def tub : Grid :=
   [(0, 1), (1, 0), (1, 2), (2, 1)]
 
-/-- The **Pond**: an 8-cell still life.
+/-- Le **Pond** : une structure stable a 8 cellules.
     ```
     .XX.
     X..X
@@ -89,7 +89,7 @@ def tub : Grid :=
 def pond : Grid :=
   [(0, 1), (0, 2), (1, 0), (1, 3), (2, 0), (2, 3), (3, 1), (3, 2)]
 
-/-- The **Ship**: a 6-cell still life.
+/-- Le **Ship** : une structure stable a 6 cellules.
     ```
     XX.
     X.X
@@ -98,50 +98,53 @@ def pond : Grid :=
 def ship : Grid :=
   [(0, 0), (0, 1), (1, 0), (1, 2), (2, 1), (2, 2)]
 
-/-! ## Still-life verifications
+/-! ## Verifications des structures stables
 
-Each predicate is reduced to a `Bool` by the kernel and decided by
-`native_decide` after compilation. -/
+Chaque predicat est reduit a un `Bool` par le noyau et decide par
+`native_decide` apres compilation. -/
 
--- Sanity-check evaluations (re-evaluated by `#eval` at elaboration time)
+-- Evaluations de verification (re-evaluees par `#eval` au moment de l'elaboration)
 #eval isStillLife loaf
 #eval isStillLife boat
 #eval isStillLife tub
 #eval isStillLife pond
 #eval isStillLife ship
 
-/-- The Loaf is a still life. -/
+/-- Le Loaf est une structure stable. -/
 theorem loaf_still_life : isStillLife loaf = true := by native_decide
 
-/-- The Boat is a still life. -/
+/-- Le Boat est une structure stable. -/
 theorem boat_still_life : isStillLife boat = true := by native_decide
 
-/-- The Tub is a still life. -/
+/-- Le Tub est une structure stable. -/
 theorem tub_still_life : isStillLife tub = true := by native_decide
 
-/-- The Pond is a still life. -/
+/-- Le Pond est une structure stable. -/
 theorem pond_still_life : isStillLife pond = true := by native_decide
 
-/-- The Ship is a still life. -/
+/-- Le Ship est une structure stable. -/
 theorem ship_still_life : isStillLife ship = true := by native_decide
 
-/-! ## Oscillators (borderline patterns)
+/-! ## Oscillateurs (motifs a la limite)
 
-These two patterns are the smallest "large" oscillators in classical
-Conway's Life. They sit at the limit of what `native_decide` can
-verify in a reasonable kernel budget; the witnesses below are kept as
-definitions, and the theorems are commented out pending a local
-`lake build` check on the target machine. If `lake build` succeeds
-within the kernel reduction limit, the theorems may be uncommented.
+Ces deux motifs sont les plus petits des « grands » oscillateurs du
+Jeu de la Vie classique de Conway. Ils se situent a la limite de ce
+que `native_decide` peut verifier dans un budget noyau raisonnable ;
+les temoins ci-dessous sont conserves comme definitions, et les
+theoremes sont mis en commentaire en attente d'une verification
+`lake build` locale sur la machine cible. Si `lake build` reussit
+dans la limite de reduction du noyau, les theoremes peuvent etre
+decommentes.
 
-The 13x13 layout for the pulsar follows the standard literature
-positioning. The pentadecathlon is given in its minimal phase (12
-cells, 10 rows by 5 columns); after 15 steps it returns to itself
-modulo the canonical sort order.
+La disposition 13x13 du pulsar suit le positionnement standard de la
+litterature. Le pentadecathlon est donne dans sa phase minimale
+(12 cellules, 10 lignes par 5 colonnes) ; apres 15 etapes, il revient
+a lui-meme modulo l'ordre de tri canonique.
 -/
 
-/-- The **Pulsar**: a 48-cell period-3 oscillator, discovered by Conway
-    in 1970. The largest commonly-occurring oscillator in random soups.
+/-- Le **Pulsar** : un oscillateur de periode 3 a 48 cellules, decouvert par
+    Conway en 1970. Le plus grand oscillateur apparaissant couramment dans les
+    soupes aleatoires.
     ```
     ..XXX...XXX..   row 0
     .............   row 1
@@ -169,14 +172,14 @@ def pulsar : Grid :=
    (10, 0), (10, 5), (10, 7), (10, 12),
    (12, 2), (12, 3), (12, 4), (12, 8), (12, 9), (12, 10)]
 
--- Verify pulsar: evolve 3 steps and check equality
+-- Verifie le pulsar : evolution sur 3 etapes et verification d'egalite
 #eval isOscillator pulsar 3
-/-- The Pulsar has period 3. -/
+/-- Le Pulsar est de periode 3. -/
 theorem pulsar_period_three : isOscillator pulsar 3 = true := by native_decide
 
-/-- The **Pentadecathlon**: a 12-cell period-15 oscillator, discovered
-    by Conway in 1970. Resembles a stretched-out blinker that
-    "breathes" for 15 generations. Minimal-phase coordinates:
+/-- Le **Pentadecathlon** : un oscillateur de periode 15 a 12 cellules,
+    decouvert par Conway en 1970. Ressemble a un blinker etire qui
+    « respire » pendant 15 generations. Coordonnees en phase minimale :
     ```
     ..X..   row 0
     ..X..   row 1
@@ -201,9 +204,9 @@ def pentadecathlon : Grid :=
    (8, 2),
    (9, 2)]
 
--- Verify pentadecathlon: evolve 15 steps and check equality
+-- Verifie le pentadecathlon : evolution sur 15 etapes et verification d'egalite
 #eval isOscillator pentadecathlon 15
-/-- The Pentadecathlon has period 15. -/
+/-- Le Pentadecathlon est de periode 15. -/
 theorem pentadecathlon_period_15 : isOscillator pentadecathlon 15 = true := by
   native_decide
 


### PR DESCRIPTION
## Summary

Drain the i18n lot (EPIC #4980) — clear **4 HALF-DONE advisories** in `conway_lean` by translating the English per-def/theorem docstrings and section comments in the 4 FR canonical files to French. The 4 `_en` mirrors were already 100% English (correct) and are untouched.

Follows the ai-01 c.80 steer: « une PR qui vide le lot, MED critere de sortie verifiable » (verifiable exit = half-done advisory count drops).

## Files (FR canonical only, 154 ins / 147 del)

| File | Change |
|------|--------|
| `Conway/Angel.lean` | 10 docstrings EN→FR (accent-free, per file convention) |
| `Conway/CollatzLike.lean` | docstrings + comments inside data structures EN→FR |
| `Conway/Doomsday.lean` | docstrings + section comments EN→FR |
| `Conway/Life/Oscillators.lean` | docstrings EN→FR (accent-free, per file convention) |

## Verification — `check_i18n_siblings.py --all`

```
177/179 pairs byte-identical | 2 consumer-pattern | 0 drift | 0 orphan | 1 unbuilt | 10 half-done (advisory)
```

- **half-done: 14 → 10** (the 4 conway pairs cleared)
- **0 drift** — byte-identity holds (build-safe)
- All 4 target pairs now `OK`; none `HALF-DONE`
- Scope: only 4 FR canonical files; no `_en` mirrors touched

## Byte-identity (build-safety proof)

Only docstrings (`/-- ... -/`) and comments (`-- ...` / `/- ... -/`) changed. All `def`/`theorem` statements, tactics, lemma names, `namespace`, `import`s, and Mathlib refs are byte-identical between FR canonical and EN mirror.

## Accent convention

Each file matches its own established style (verified firsthand):
- **Angel + Oscillators**: accent-free ASCII-safe FR — matches root `Conway.lean` (also accent-free) and `Spaceships.lean` (#9409). Translations are accent-free.
- **CollatzLike + Doomsday**: pre-existing accented files — translations keep accents (internally consistent).

## Note for coordinator

`Doomsday.lean`'s own header documents an inline-bilingual (Option B) convention while a `Doomsday_en.lean` sibling (Option A) exists. This PR localizes the docstrings regardless (clearing the advisory, nudging toward sibling-pair consistency); the A/B header reconciliation is a separate doc-hygiene decision.

See #4980 (partial — lot drain, 4 of 14 advisories cleared; remaining 10 across ConeGeometry/GridCanonical/Hashlife/LightCone/MacroCell/Life_en/Shapley/Knots×3 are the next tranche).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Grain: MED/lean-i18n — lane myia-po-2024:CoursIA — prev: MED/lean-i18n #9409 (Spaceships)
