### PR TITLE
i18n(lean,#4980): localize FR canonical docstrings in 3 conway_lean/Life modules (tranche 2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/ConeGeometry.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/ConeGeometry.lean
@@ -133,134 +133,144 @@ import Mathlib
 namespace Conway
 namespace Life
 
-/-! ## Chebyshev (chessboard) distance and the tight locality cone
+/-! ## Distance de Chebyshev (échiquier) et cône de localité étroite
 
-The *tight* Game-of-Life locality is governed by the Chebyshev (L∞) distance:
-one B3/S23 generation reaches exactly the Moore neighborhood (Chebyshev radius
-1), so `t` generations reach Chebyshev radius `t`. The `lightCone` machinery in
-`LightCone` uses the Manhattan (L1) distance, which over-approximates the tight
-reach by a factor of 2 — `step_light_cone` demands Manhattan radius `2 * t`. The
-lemmas below formalize the Chebyshev cone structure that a *tight* single-jump
-correctness proof chains through:
+La localité *étroite* du Jeu de la Vie est gouvernée par la distance de
+Chebyshev (L∞) : une génération B3/S23 atteint exactement le voisinage de Moore
+(rayon de Chebyshev 1), donc `t` générations atteignent le rayon de Chebyshev
+`t`. La machinerie `lightCone` dans `LightCone` utilise la distance de Manhattan
+(L1), qui sur-approxime la portée étroite d'un facteur 2 — `step_light_cone`
+exige le rayon de Manhattan `2 * t`. Les lemmes ci-dessous formalisent la
+structure du cône de Chebyshev qu'une preuve de correction à saut unique
+*étroite* enchaîne :
 
-- the cone fits in a margin-`t` box (**margin sufficiency** — the geometric fact
-  that makes the `padCenter2` margin `2^k` sufficient for a single jump of `2^k`
-  generations: the tight Chebyshev reach `2^k` fits exactly in a margin-`2^k`
-  box, whereas the loose Manhattan-`2^k` light cone would need `2^(k+1)`); and
+- le cône tient dans une boîte de marge `t` (**suffisance de marge** — le fait
+  géométrique qui rend la marge `padCenter2` `2^k` suffisante pour un saut de
+  `2^k` générations : la portée Chebyshev étroite `2^k` tient exactement dans
+  une boîte de marge `2^k`, alors que le cône de lumière Manhattan-`2^k`
+  lâche nécessiterait `2^(k+1)`) ; et
 
-These are the elementary distance facts; they do not assert anything about
-`evolve` (the locality statement `step_light_cone` lives in `HashlifeCorrectness`).
-Epic #3846 (Hashlife correctness infrastructure, N2 tight-locality groundwork). -/
+Ce sont les faits de distance élémentaires ; ils n'affirment rien sur `evolve`
+(l'énoncé de localité `step_light_cone` vit dans `HashlifeCorrectness`).
+EPIC #3846 (infrastructure de correction Hashlife, fondation N2 de localité
+étroite). -/
 
-/-- Chebyshev (chessboard / L∞) distance between two cells: the larger of the
-    absolute coordinate displacements. -/
+/-- Distance de Chebyshev (échiquier / L∞) entre deux cellules : le plus grand
+    des déplacements absolus de coordonnées. -/
 def chebDist (p q : Int × Int) : Nat :=
   max (Int.natAbs (q.1 - p.1)) (Int.natAbs (q.2 - p.2))
 
-/-- Reflexivity: a cell is at Chebyshev distance 0 from itself. -/
+/-- Réflexivité : une cellule est à distance de Chebyshev 0 d'elle-même. -/
 theorem chebDist_self (p : Int × Int) : chebDist p p = 0 := by
   unfold chebDist; omega
 
-/-- Symmetry: the Chebyshev distance is invariant under swapping the two cells. -/
+/-- Symétrie : la distance de Chebyshev est invariante par échange des deux cellules. -/
 theorem chebDist_comm (p q : Int × Int) : chebDist p q = chebDist q p := by
   unfold chebDist; omega
 
-/-- Monotonicity in the radius: a larger radius weakly contains the cone. -/
+/-- Monotonie en le rayon : un rayon plus grand contient faiblement le cône. -/
 theorem chebDist_le_trans {t₁ t₂ : Nat} (h : t₁ ≤ t₂) {p q : Int × Int}
     (hd : chebDist p q ≤ t₁) : chebDist p q ≤ t₂ := hd.trans h
 
-/-- Margin sufficiency: a cell within Chebyshev radius `t` of `p` lies in the
-    margin-`t` box — each coordinate is within `t` of `p`'s coordinate. This is
-    the geometric reason a box margin of `t` (e.g. `padCenter2`'s `2^k` margin
-    at a level advancing `2^k` generations) covers the *tight* Chebyshev-`t`
-    reach, even though that same margin `t` does not cover the *loose*
-    Manhattan-`t` light cone (which reaches `2 * t`). -/
+/-- Suffisance de marge : une cellule à distance Chebyshev `≤ t` de `p` se
+    trouve dans la boîte de marge `t` — chaque coordonnée est à distance `≤ t`
+    de la coordonnée de `p`. C'est la raison géométrique pour laquelle une marge
+    de boîte `t` (par ex. la marge `2^k` de `padCenter2` à un niveau avançant de
+    `2^k` générations) couvre la portée Chebyshev-`t` *étroite*, alors que cette
+    même marge `t` ne couvre pas le cône de lumière Manhattan-`t` *lâche* (qui
+    atteint `2 * t`). -/
 theorem coord_bound_of_chebDist_le (p q : Int × Int) (t : Nat)
     (h : chebDist p q ≤ t) :
     Int.natAbs (q.1 - p.1) ≤ t ∧ Int.natAbs (q.2 - p.2) ≤ t := by
   unfold chebDist at h
   omega
 
-/-! ## Chebyshev triangle inequality and cone growth by a Moore step
+/-! ## Inégalité triangulaire de Chebyshev et croissance du cône par pas de Moore
 
-The foundational metric fact (`chebDist_triangle`) and the **tight-cone growth
-theorem** named by ai-01's N2 greenlight: a cell lies in the Chebyshev-`(t+1)`
-cone of `p` iff one can reach it from the Chebyshev-`t` cone via a single Moore
-neighborhood step. This is the inductive engine of the tight-locality statement
-(after one B3/S23 generation, reach expands by exactly one Moore shell), and the
-reason the tight Chebyshev reach grows linearly with `t` rather than as `2*t`.
+Le fait métrique fondateur (`chebDist_triangle`) et le **théorème de croissance
+du cône étroit** nommé par le greenlight N2 d'ai-01 : une cellule se trouve
+dans le cône Chebyshev-`(t+1)` de `p` ssi on peut l'atteindre depuis le cône
+Chebyshev-`t` par un seul pas de voisinage de Moore. C'est le moteur inductif de
+l'énoncé de localité étroite (après une génération B3/S23, la portée s'étend
+d'exactement une coque de Moore), et la raison pour laquelle la portée Chebyshev
+étroite croît linéairement avec `t` plutôt qu'en `2*t`.
 -/
 
-/-- Triangle inequality for the Chebyshev distance. -/
+/-- Inégalité triangulaire pour la distance de Chebyshev. -/
 theorem chebDist_triangle (p q r : Int × Int) :
     chebDist p q ≤ chebDist p r + chebDist r q := by
   unfold chebDist
   omega
 
-/-- The Chebyshev cone grows by exactly one Moore step: `q` is within Chebyshev
-    radius `t+1` of `p` iff there is a cell `r` within Chebyshev radius `t` of `p`
-    that is a Moore neighbor of `q` (Chebyshev radius `≤ 1`). Forward direction
-    steps from `q` toward `p` by one unit in each nonzero coordinate; backward
-    direction is the triangle inequality. This is the additive-growth lemma that
-    underpins the tight `t`-step locality (one Moore shell per generation). -/
+/-- Le cône de Chebyshev croît d'exactement un pas de Moore : `q` est à distance
+    Chebyshev `t+1` de `p` ssi il existe une cellule `r` à distance Chebyshev `t`
+    de `p` qui soit un voisin de Moore de `q` (distance Chebyshev `≤ 1`). La
+    direction forward progresse de `q` vers `p` d'une unité sur chaque coordonnée
+    non nulle ; la direction backward est l'inégalité triangulaire. C'est le
+    lemme de croissance additive qui sous-tend la localité étroite à `t` étapes
+    (une coque de Moore par génération). -/
 theorem chebDist_le_succ_iff (p q : Int × Int) (t : Nat) :
     chebDist p q ≤ t + 1 ↔
       ∃ r : Int × Int, chebDist p r ≤ t ∧ chebDist r q ≤ 1 := by
   constructor
-  · -- forward: step from `q` toward `p` by one unit in each nonzero coordinate
+  · -- forward : progresser de `q` vers `p` d'une unité sur chaque coordonnée non nulle
     intro h
     unfold chebDist at h
     refine ⟨(q.1 - if q.1 - p.1 = 0 then 0 else if 0 < q.1 - p.1 then 1 else -1,
              q.2 - if q.2 - p.2 = 0 then 0 else if 0 < q.2 - p.2 then 1 else -1), ?_, ?_⟩
     all_goals unfold chebDist; omega
-  · -- backward: triangle inequality
+  · -- backward : inégalité triangulaire
     rintro ⟨r, hr, hq⟩
     exact (chebDist_triangle p q r).trans (add_le_add hr hq)
 
-/-- The tight Chebyshev cone is nested in its successor: radius `t` ⊆ radius
-    `t+1`. Corollary of `chebDist_le_succ_iff` (or directly `Nat.le_succ`). -/
+/-- Le cône de Chebyshev étroit est inclus dans son successeur : rayon `t` ⊆
+    rayon `t+1`. Corollaire de `chebDist_le_succ_iff` (ou directement
+    `Nat.le_succ`). -/
 theorem chebDist_le_succ (p q : Int × Int) (t : Nat) (h : chebDist p q ≤ t) :
     chebDist p q ≤ t + 1 := h.trans (Nat.le_succ t)
 
-/-! ## W3 tight cone-in-domain: Chebyshev-tight locality stays in the domain
+/-! ## W3 cône étroit dans le domaine : la localité Chebyshev-étroite reste dans le domaine
 
-The tight Chebyshev analog of `window_cone_in_domain` (the **S2** closed lemma in
-`HashlifeCorrectness`, which used the *loose* Manhattan cone `manhattan p q ≤ 2^k`).
-For a point `p` in the centered window `[2^k, 2^k + 2^(k+1))²` (the region a
-Hashlife result covers), any cell `q` within **Chebyshev** radius `2^k` — the
-*tight* GoL speed-of-light cone, strictly smaller than the loose Manhattan-`2^k`
-cone (a Chebyshev-`t` ball fits in a Manhattan-`2t` ball, not the reverse) — stays
-inside the full MacroCell domain `[0, 2^(k+2))²`.
+L'analogue Chebyshev étroit de `window_cone_in_domain` (le lemme fermé **S2**
+dans `HashlifeCorrectness`, qui utilisait le cône Manhattan *lâche*
+`manhattan p q ≤ 2^k`). Pour un point `p` dans la fenêtre centrée
+`[2^k, 2^k + 2^(k+1))²` (la région couverte par un résultat Hashlife), toute
+cellule `q` à distance **Chebyshev** `2^k` — le cône de vitesse de la
+lumière GoL *étroit*, strictement plus petit que le cône Manhattan-`2^k`
+lâche (une boule Chebyshev-`t` tient dans une boule Manhattan-`2t`, pas
+l'inverse) — reste dans le domaine MacroCell complet `[0, 2^(k+2))²`.
 
-This is the missing tight locality bound for the N2 redesign arc (EPIC #3846, W3).
-The loose `window_cone_in_domain` demanded Manhattan-`2^k` agreement, over-
-approximating the real reach by a factor of 2; the tight version demands only
-Chebyshev-`2^k` agreement (the actual one-Moore-shell-per-generation reach
-formalized by `evolve_reach_chebyshev`). Because Chebyshev distance bounds each
-coordinate directly, the proof is **simpler** than the loose analog: it consumes
-`coord_bound_of_chebDist_le` (per-coordinate bound immediately) rather than
-bridging through `manhattan_deviation`. No `hashlifeResultAux`, no whnf wall —
-pure `Int` window arithmetic. Sorry-free.
+C'est la borne de localité étroite manquante pour l'arc de refonte N2 (EPIC
+#3846, W3). Le `window_cone_in_domain` lâche exigeait l'accord Manhattan-`2^k`,
+sur-approximant la portée réelle d'un facteur 2 ; la version étroite n'exige
+que l'accord Chebyshev-`2^k` (la portée réelle d'une-coque-de-Moore-par-
+génération formalisée par `evolve_reach_chebyshev`). Comme la distance de
+Chebyshev borne directement chaque coordonnée, la preuve est **plus simple**
+que l'analogue lâche : elle consomme `coord_bound_of_chebDist_le` (borne par
+coordonnée immédiate) au lieu de ponter via `manhattan_deviation`. Pas de
+`hashlifeResultAux`, pas de mur `whnf` — arithmétique de fenêtre `Int` pure.
+Sans sorry.
 
-This lemma lives in `ConeGeometry` (not `LightCone`) so that the P5
-`p5_large_n_jump` path in `HashlifeCorrectness` can consume it directly via
-`import Conway.Life.ConeGeometry`, without the circular reverse-import that would
-arise if it stayed in `LightCone` (which imports `HashlifeCorrectness`). The
-proof substance is independent of the P4 mono-verru. -/
+Ce lemme vit dans `ConeGeometry` (pas dans `LightCone`) pour que le chemin P5
+`p5_large_n_jump` dans `HashlifeCorrectness` puisse le consommer directement via
+`import Conway.Life.ConeGeometry`, sans l'import inverse circulaire qui
+surviendrait s'il restait dans `LightCone` (qui importe `HashlifeCorrectness`).
+La substance de la preuve est indépendante du mono-verrou P4. -/
 
-/-- Power identity `2^(k+1) = 2 · 2^k` in `Int`, proven in pure `Nat` (rw +
-`Nat.pow_succ`) then lifted via `exact_mod_cast`. Shared by the two window-
-membership theorems `window_cheb_cone_in_domain` (this module) and
-`window_cone_in_domain` (`HashlifeCorrectness`, which imports this module),
-hence factored here rather than duplicated inline in each consumer. -/
+/-- Identité de puissance `2^(k+1) = 2 · 2^k` dans `Int`, prouvée en `Nat` pur
+(rw + `Nat.pow_succ`) puis remontée via `exact_mod_cast`. Partagée par les deux
+théorèmes d'appartenance à la fenêtre `window_cheb_cone_in_domain` (ce module)
+et `window_cone_in_domain` (`HashlifeCorrectness`, qui importe ce module), d'où
+sa factorisation ici plutôt que sa duplication inline dans chaque consommateur. -/
 lemma pow_two_add_one_int (k : Nat) : (2^(k+1) : Int) = 2 * (2^k : Int) := by
   have h : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
     rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
   exact_mod_cast h
 
-/-- Power identity `2^(k+2) = 4 · 2^k` in `Int`, proven in pure `Nat` (rw +
-`Nat.pow_succ` over two steps) then lifted via `exact_mod_cast`. Same shared
-rationale as `pow_two_add_one_int`: consumed by both window-membership theorems. -/
+/-- Identité de puissance `2^(k+2) = 4 · 2^k` dans `Int`, prouvée en `Nat` pur
+(rw + `Nat.pow_succ` sur deux étapes) puis remontée via `exact_mod_cast`. Même
+rationale de partage que `pow_two_add_one_int` : consommée par les deux
+théorèmes d'appartenance à la fenêtre. -/
 lemma pow_two_add_two_int (k : Nat) : (2^(k+2) : Int) = 4 * (2^k : Int) := by
   have h1 : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
     rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
@@ -274,27 +284,28 @@ theorem window_cheb_cone_in_domain (k : Nat) (p q : Int × Int)
     (hp2_lo : (2^k : Int) ≤ p.2) (hp2_hi : p.2 < 2^k + 2^(k+1))
     (hc : chebDist p q ≤ 2^k) :
     (0 : Int) ≤ q.1 ∧ q.1 < 2^(k+2) ∧ (0 : Int) ≤ q.2 ∧ q.2 < 2^(k+2) := by
-  -- Chebyshev radius bounds each coordinate directly (no manhattan bridge).
+  -- Le rayon de Chebyshev borne directement chaque coordonnée (pas de pont Manhattan).
   obtain ⟨hq1, hq2⟩ := coord_bound_of_chebDist_le p q (2^k) hc
-  -- `coord_bound_of_chebDist_le` types its bounds as `Nat` (`Int.natAbs ... ≤
-  -- 2^k`); the window hypotheses below use native-Int `(2^k : Int)` (`HPower`).
-  -- Bridge the Nat-bound to an `Int.abs`-typed bound (mirroring the loose
-  -- analog's `manhattan_deviation` output, which is already Int-typed), then
-  -- unify the atoms via `Nat.cast_pow`.
+  -- `coord_bound_of_chebDist_le` type ses bornes comme `Nat` (`Int.natAbs ... ≤
+  -- 2^k`) ; les hypothèses de fenêtre ci-dessous utilisent du `(2^k : Int)` natif
+  -- (`HPower`). On ponte la borne `Nat` vers une borne typée `Int.abs` (miroir
+  -- de la sortie `manhattan_deviation` de l'analogue lâche, déjà typée Int),
+  -- puis on unifie les atomes via `Nat.cast_pow`.
   have hk_pow : (↑((2:Nat)^k) : Int) = (2^k : Int) := Nat.cast_pow 2 k
   have hq1' : |q.1 - p.1| ≤ (2^k : Int) := by
     rw [hk_pow.symm, Int.abs_eq_natAbs]; exact_mod_cast hq1
   have hq2' : |q.2 - p.2| ≤ (2^k : Int) := by
     rw [hk_pow.symm, Int.abs_eq_natAbs]; exact_mod_cast hq2
-  -- Power facts in pure `Nat`, lifted to `Int` (linarith reads the atoms),
-  -- factored into the named lemmas `pow_two_add_one_int`/`pow_two_add_two_int`
-  -- above (shared with `window_cone_in_domain` in `HashlifeCorrectness`).
+  -- Faits de puissance en `Nat` pur, remontés vers `Int` (linarith lit les
+  -- atomes), factorisés dans les lemmes nommés
+  -- `pow_two_add_one_int`/`pow_two_add_two_int` ci-dessus (partagés avec
+  -- `window_cone_in_domain` dans `HashlifeCorrectness`).
   have hpe1 : (2^(k+1) : Int) = 2 * (2^k : Int) := pow_two_add_one_int k
   have hpe2 : (2^(k+2) : Int) = 4 * (2^k : Int) := pow_two_add_two_int k
-  -- `Int.abs` bound unpacked into a two-sided `Int` clamp on `q.i - p.i`.
+  -- Borne `Int.abs` dépaquetée en un clamp `Int` bilatéral sur `q.i - p.i`.
   obtain ⟨hq1lo, hq1hi⟩ := abs_le.mp hq1'
   obtain ⟨hq2lo, hq2hi⟩ := abs_le.mp hq2'
-  -- Rewrite every power occurrence into a multiple of the single atom `2^k`.
+  -- Réécriture de chaque occurrence de puissance en un multiple du seul atome `2^k`.
   rw [hpe1] at hp1_hi hp2_hi
   rw [hpe2]
   refine ⟨?_, ?_, ?_, ?_⟩ <;> linarith

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical.lean
@@ -167,32 +167,32 @@ import Conway.Life
 namespace Conway
 namespace Life
 
-/-! ## The lexicographic comparator: order axioms -/
+/-! ## Le comparateur lexicographique : axiomes d'ordre -/
 
-/-- `lexLt` in terms of linear integer arithmetic. -/
+/-- `lexLt` en termes d'arithmétique linéaire sur les entiers. -/
 theorem lexLt_iff {a b : Int × Int} :
     lexLt a b = true ↔ a.1 < b.1 ∨ (a.1 = b.1 ∧ a.2 < b.2) := by
   unfold lexLt
   split_ifs <;> simp <;> omega
 
-/-- `lexLe` in terms of linear integer arithmetic. -/
+/-- `lexLe` en termes d'arithmétique linéaire sur les entiers. -/
 theorem lexLe_iff {a b : Int × Int} :
     lexLe a b = true ↔ a.1 < b.1 ∨ (a.1 = b.1 ∧ a.2 ≤ b.2) := by
   simp only [lexLe, Bool.or_eq_true, lexLt_iff, beq_iff_eq, Prod.ext_iff]
   omega
 
-/-- `lexLe` is total — the hypothesis `List.pairwise_insertionSort` needs. -/
+/-- `lexLe` est total — l'hypothèse qu'exige `List.pairwise_insertionSort`. -/
 theorem lexLe_total (a b : Int × Int) : (lexLe a b || lexLe b a) = true := by
   simp only [Bool.or_eq_true, lexLe_iff]
   omega
 
-/-- `lexLe` is transitive. -/
+/-- `lexLe` est transitif. -/
 theorem lexLe_trans (a b c : Int × Int)
     (hab : lexLe a b = true) (hbc : lexLe b c = true) : lexLe a c = true := by
   simp only [lexLe_iff] at *
   omega
 
-/-- `lexLe` is antisymmetric — what makes sorted Nodup lists rigid. -/
+/-- `lexLe` est antisymétrique — ce qui rend les listes triées Nodup rigides. -/
 theorem lexLe_antisymm (a b : Int × Int)
     (hab : lexLe a b = true) (hba : lexLe b a = true) : a = b := by
   simp only [lexLe_iff] at hab hba
@@ -210,24 +210,24 @@ instance lexLe.isTotal : Std.Total fun a b : Int × Int => lexLe a b = true :=
     rw [Bool.or_eq_true_eq_eq_true_or_eq_true] at h
     exact h⟩
 
-/-! ## Canonical grids -/
+/-! ## Grilles canoniques -/
 
-/-- A grid in canonical form: lexicographically sorted and duplicate-free.
-    Invariant of every `sortDedup` image, preserved by `filter`. -/
+/-- Une grille sous forme canonique : triée lexicographiquement et sans
+    doublon. Invariant de toute image de `sortDedup`, préservé par `filter`. -/
 def Canonical (g : Grid) : Prop :=
   g.Pairwise (fun a b => lexLe a b = true) ∧ g.Nodup
 
-/-- `sortDedup` always produces a canonical grid: sortedness comes from
-    `pairwise_insertionSort` (using totality and transitivity of `lexLe`) and
-    survives `dedup` because `dedup` yields a sublist; freedom from
-    duplicates is `nodup_dedup`.
+/-- `sortDedup` produit toujours une grille canonique : le tri vient de
+    `pairwise_insertionSort` (utilisant la totalité et la transitivité de
+    `lexLe`) et survit à `dedup` car `dedup` produit une sous-liste ; l'absence
+    de doublons est `nodup_dedup`.
 
-    `insertionSort` (not `mergeSort`) is used in `sortDedup` because the
-    kernel reducer can evaluate `List.insertionSort` under `decide` whereas
-    `List.mergeSort` stays stuck (measured po-2026 c.786). The Mathlib lemma
-    `List.pairwise_insertionSort` is typeclass-based (`[Std.Total r]`
-    `[IsTrans α r]`); we discharge those instances locally from
-    `lexLe_total` and `lexLe_trans`. -/
+    `insertionSort` (et non `mergeSort`) est utilisé dans `sortDedup` car le
+    réducteur du noyau peut évaluer `List.insertionSort` sous `decide` alors que
+    `List.mergeSort` reste bloqué (mesuré po-2026 c.786). Le lemme Mathlib
+    `List.pairwise_insertionSort` est basé sur des typeclasses
+    (`[Std.Total r]` `[IsTrans α r]`) ; nous déchargeons ces instances
+    localement à partir de `lexLe_total` et `lexLe_trans`. -/
 theorem canonical_sortDedup (l : List (Int × Int)) : Canonical (sortDedup l) := by
   unfold sortDedup
   have hsort : List.Pairwise (fun a b => lexLe a b = true)
@@ -235,24 +235,24 @@ theorem canonical_sortDedup (l : List (Int × Int)) : Canonical (sortDedup l) :=
     List.pairwise_insertionSort _ l
   exact ⟨hsort.sublist (List.dedup_sublist _), List.nodup_dedup _⟩
 
-/-- Filtering preserves canonical form (`filter` yields a sublist). -/
+/-- Le filtrage préserve la forme canonique (`filter` produit une sous-liste). -/
 theorem Canonical.filter {g : Grid} (h : Canonical g) (q : (Int × Int) → Bool) :
     Canonical (g.filter q) :=
   ⟨List.Pairwise.sublist List.filter_sublist h.1,
    List.Nodup.sublist List.filter_sublist h.2⟩
 
-/-- **Rigidity of canonical grids**: two canonical grids with the same
-    members are equal as lists. Same-membership gives a permutation
-    (`perm_ext_iff_of_nodup`), and a permutation between two lex-sorted
-    lists is the identity by antisymmetry (`Perm.eq_of_pairwise`). -/
+/-- **Rigidité des grilles canoniques** : deux grilles canoniques avec les
+    mêmes membres sont égales comme listes. La même-appartenance donne une
+    permutation (`perm_ext_iff_of_nodup`), et une permutation entre deux listes
+    lex-triées est l'identité par antisymétrie (`Perm.eq_of_pairwise`). -/
 theorem Canonical.ext {g₁ g₂ : Grid} (h₁ : Canonical g₁) (h₂ : Canonical g₂)
     (h : ∀ p, p ∈ g₁ ↔ p ∈ g₂) : g₁ = g₂ :=
   List.Perm.eq_of_pairwise (fun a b _ _ hab hba => lexLe_antisymm a b hab hba)
     h₁.1 h₂.1 ((List.perm_ext_iff_of_nodup h₁.2 h₂.2).mpr h)
 
-/-- The workhorse corollary: two `sortDedup` images are equal **iff** their
-    input lists have the same members. List equality of canonical grids is
-    exactly set equality. -/
+/-- Le corollaire workhorse : deux images `sortDedup` sont égales **ssi** leurs
+    listes d'entrée ont les mêmes membres. L'égalité de listes des grilles
+    canoniques est exactement l'égalité ensembliste. -/
 theorem sortDedup_eq_sortDedup_iff {l₁ l₂ : List (Int × Int)} :
     sortDedup l₁ = sortDedup l₂ ↔ ∀ p, p ∈ l₁ ↔ p ∈ l₂ := by
   constructor
@@ -262,21 +262,21 @@ theorem sortDedup_eq_sortDedup_iff {l₁ l₂ : List (Int × Int)} :
     exact Canonical.ext (canonical_sortDedup _) (canonical_sortDedup _)
       (fun p => by rw [mem_sortDedup, mem_sortDedup]; exact h p)
 
-/-! ## Canonicity of the Life-engine grids -/
+/-! ## Canonicité des grilles du moteur Life -/
 
-/-- `step` produces canonical grids. -/
+/-- `step` produit des grilles canoniques. -/
 theorem canonical_step (g : Grid) : Canonical (step g) :=
   canonical_sortDedup _
 
-/-- `evolve n` produces canonical grids for `n ≥ 1` (for `n = 0` the
-    output is the input, which need not be canonical). -/
+/-- `evolve n` produit des grilles canoniques pour `n ≥ 1` (pour `n = 0` la
+    sortie est l'entrée, qui n'a pas besoin d'être canonique). -/
 theorem canonical_evolve_of_pos {n : Nat} (hn : 0 < n) (g : Grid) :
     Canonical (evolve n g) := by
   obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
   rw [evolve_succ]
   exact canonical_step _
 
-/-- `shift` produces canonical grids. -/
+/-- `shift` produit des grilles canoniques. -/
 theorem canonical_shift (v : Int × Int) (g : Grid) : Canonical (shift v g) :=
   canonical_sortDedup _
 
@@ -321,8 +321,8 @@ theorem aliveNext_shift (v : Int × Int) (g : Grid) (p : Int × Int) :
     aliveNext (shift v g) p = aliveNext g (p.1 - v.1, p.2 - v.2) := by
   simp [aliveNext, isAlive_shift, liveNeighborCount_shift]
 
-/-- Membership in a `step` image, unfolded to the rule: `p` is in `step g`
-    iff it is a candidate and `aliveNext` accepts it. -/
+/-- Appartenance à une image de `step`, dépliée en la règle : `p` est dans
+    `step g` ssi c'est un candidat et `aliveNext` l'accepte. -/
 theorem mem_step_iff {g : Grid} {p : Int × Int} :
     p ∈ step g ↔ p ∈ candidates g ∧ aliveNext g p = true := by
   unfold step

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
@@ -164,25 +164,25 @@ import Conway.Life.HashlifeCorrectness
 namespace Conway
 namespace Life
 
-/-! ## Monotonicity: larger radius → larger cone
+/-! ## Monotonie : rayon plus grand → cône plus grand
 
-A light cone of radius `t₁` is contained in the light cone of any larger
-radius `t₂ ≥ t₁`. This follows directly from the membership characterization
-(`mem_lightCone_of_manhattan_le` / `manhattan_le_of_mem_lightCone`): a cell in
-the smaller cone is at Manhattan distance `≤ t₁ ≤ t₂`, hence in the larger
-cone. -/
+Un cône de lumière de rayon `t₁` est contenu dans le cône de lumière de tout
+rayon plus grand `t₂ ≥ t₁`. Cela découle directement de la caractérisation par
+appartenance (`mem_lightCone_of_manhattan_le` /
+`manhattan_le_of_mem_lightCone`) : une cellule dans le cône plus petit est à
+distance Manhattan `≤ t₁ ≤ t₂`, donc dans le cône plus grand. -/
 theorem lightCone_subset_of_le (p : Int × Int) {t₁ t₂ : Nat} (h : t₁ ≤ t₂) :
     lightCone p t₁ ⊆ lightCone p t₂ := by
   intro q hq
   exact mem_lightCone_of_manhattan_le p q t₂
     ((manhattan_le_of_mem_lightCone p q t₁ hq).trans h)
 
-/-! ## Per-coordinate bound: membership bounds each coordinate
+/-! ## Borne par coordonnée : l'appartenance borne chaque coordonnée
 
-A cell in `lightCone p t` has each coordinate within `t` of `p`'s
-corresponding coordinate. This is the "Manhattan-`t` ⊆ Chebyshev-`t`"
-direction (each coordinate's displacement is bounded by the total Manhattan
-distance). -/
+Une cellule dans `lightCone p t` a chaque coordonnée à distance `≤ t` de la
+coordonnée correspondante de `p`. C'est la direction « Manhattan-`t` ⊆
+Chebyshev-`t` » (le déplacement de chaque coordonnée est borné par la distance
+Manhattan totale). -/
 theorem coord_bound_of_mem_lightCone (p q : Int × Int) (t : Nat)
     (h : q ∈ lightCone p t) :
     Int.natAbs (p.1 - q.1) ≤ t ∧ Int.natAbs (p.2 - q.2) ≤ t := by
@@ -190,18 +190,19 @@ theorem coord_bound_of_mem_lightCone (p q : Int × Int) (t : Nat)
   unfold manhattan at hm
   refine ⟨?_, ?_⟩ <;> omega
 
-/-! ## Speed-of-light principle: Chebyshev-`t` ⊆ Manhattan-`2*t`
+/-! ## Principe de vitesse de la lumière : Chebyshev-`t` ⊆ Manhattan-`2*t`
 
-The converse direction that makes `2*t` the **tight** GoL radius. If each
-coordinate of `q` is within `t` of `p` (Chebyshev distance `≤ t`) — the exact
-region a single B3/S23 step can reach in one generation, lifted to `t` steps
-— then the Manhattan distance is `≤ 2*t`, so `q ∈ lightCone p (2 * t)`.
+La direction converse qui fait de `2*t` le rayon GoL **étroit**. Si chaque
+coordonnée de `q` est à distance `≤ t` de `p` (distance Chebyshev `≤ t`) — la
+région exacte qu'un seul pas B3/S23 peut atteindre en une génération, étendue
+à `t` pas — alors la distance Manhattan est `≤ 2*t`, donc
+`q ∈ lightCone p (2 * t)`.
 
-This is the formal justification for `step_light_cone`'s `2 * t` radius: the
-Moore-neighborhood influence of one generation has Chebyshev radius `1`, so
-`t` generations reach Chebyshev radius `t`, and that Chebyshev ball is
-contained in the Manhattan ball of twice the radius. The factor `2` is
-tight (the diagonal neighbor is at Manhattan distance `2`). -/
+C'est la justification formelle du rayon `2 * t` de `step_light_cone` :
+l'influence du voisinage de Moore d'une génération a un rayon Chebyshev `1`,
+donc `t` générations atteignent le rayon Chebyshev `t`, et cette boule
+Chebyshev est contenue dans la boule Manhattan de rayon double. Le facteur
+`2` est serré (le voisin diagonal est à distance Manhattan `2`). -/
 theorem mem_lightCone_of_chebyshev_le (p q : Int × Int) (t : Nat)
     (h1 : Int.natAbs (p.1 - q.1) ≤ t) (h2 : Int.natAbs (p.2 - q.2) ≤ t) :
     q ∈ lightCone p (2 * t) := by
@@ -209,15 +210,16 @@ theorem mem_lightCone_of_chebyshev_le (p q : Int × Int) (t : Nat)
   unfold manhattan
   omega
 
-/-! ## Translation invariance: shifting the center shifts the cone
+/-! ## Invariance par translation : décaler le centre décale le cône
 
-The light cone is translation-equivariant: membership of `q` in `lightCone p t`
-depends only on the displacement `q - p`, not on the absolute position `p`. This
-is the Grid-level counterpart of the `toGrid` offset-shift machinery in
-`HashlifeCorrectness` (`toGrid_shift`, `toGrid_shift_between`), and is the
-structural fact needed to relate the light cone before and after a `hashlifeJump`
-shifts the grid by `jumpResultOff` in `evolveHashlifeFastAux`. The cone is an
-isometry of the Manhattan metric, so its shape is preserved under translation. -/
+Le cône de lumière est équivariant par translation : l'appartenance de `q` à
+`lightCone p t` ne dépend que du déplacement `q - p`, pas de la position
+absolue `p`. C'est le pendant au niveau Grid de la machinerie de décalage
+`toGrid` dans `HashlifeCorrectness` (`toGrid_shift`,
+`toGrid_shift_between`), et le fait structurel nécessaire pour relier le cône
+de lumière avant et après qu'un `hashlifeJump` décale la grille de
+`jumpResultOff` dans `evolveHashlifeFastAux`. Le cône est une isométrie de la
+métrique Manhattan, donc sa forme est préservée par translation. -/
 theorem lightCone_translate (p q : Int × Int) (t : Nat) :
     q ∈ lightCone p t ↔ (q.1 - p.1, q.2 - p.2) ∈ lightCone (0, 0) t := by
   constructor
@@ -230,75 +232,82 @@ theorem lightCone_translate (p q : Int × Int) (t : Nat) :
     have hm := manhattan_le_of_mem_lightCone (0, 0) _ t h
     unfold manhattan at *; omega
 
-/-! ## Chebyshev (chessboard) distance and the tight locality cone
+/-! ## Distance de Chebyshev (échiquier) et cône de localité étroite
 
-The *tight* Game-of-Life locality is governed by the Chebyshev (L∞) distance:
-one B3/S23 generation reaches exactly the Moore neighborhood (Chebyshev radius
-1), so `t` generations reach Chebyshev radius `t`. The `lightCone` machinery
-above uses the Manhattan (L1) distance, which over-approximates the tight reach
-by a factor of 2 — `step_light_cone` demands Manhattan radius `2 * t`. The
-lemmas below formalize the Chebyshev cone structure that a *tight* single-jump
-correctness proof chains through:
+La localité *étroite* du Jeu de la Vie est gouvernée par la distance de
+Chebyshev (L∞) : une génération B3/S23 atteint exactement le voisinage de Moore
+(rayon de Chebyshev 1), donc `t` générations atteignent le rayon de Chebyshev
+`t`. La machinerie `lightCone` ci-dessus utilise la distance de Manhattan (L1),
+qui sur-approxime la portée étroite d'un facteur 2 — `step_light_cone` exige le
+rayon de Manhattan `2 * t`. Les lemmes ci-dessous formalisent la structure du
+cône de Chebyshev qu'une preuve de correction à saut unique *étroite* enchaîne :
 
-- the cone fits in a margin-`t` box (**margin sufficiency** — the geometric fact
-  that makes the `padCenter2` margin `2^k` sufficient for a single jump of `2^k`
-  generations: the tight Chebyshev reach `2^k` fits exactly in a margin-`2^k`
-  box, whereas the loose Manhattan-`2^k` light cone would need `2^(k+1)`); and
-- the tight cone is contained in the loose Manhattan-`2*t` light cone.
+- le cône tient dans une boîte de marge `t` (**suffisance de marge** — le fait
+  géométrique qui rend la marge `padCenter2` `2^k` suffisante pour un saut de
+  `2^k` générations : la portée Chebyshev étroite `2^k` tient exactement dans
+  une boîte de marge `2^k`, alors que le cône de lumière Manhattan-`2^k` lâche
+  nécessiterait `2^(k+1)`) ; et
+- le cône étroit est contenu dans le cône de lumière Manhattan-`2*t` lâche.
 
-These are the elementary distance facts; they do not yet assert anything about
-`evolve` (the locality statement `step_light_cone` lives in `HashlifeCorrectness`).
-Epic #3846 (Hashlife correctness infrastructure, N2 tight-locality groundwork). -/
+Ce sont les faits de distance élémentaires ; ils n'affirment encore rien sur
+`evolve` (l'énoncé de localité `step_light_cone` vit dans
+`HashlifeCorrectness`).
+EPIC #3846 (infrastructure de correction Hashlife, fondation N2 de localité
+étroite). -/
 
-/- The pure Chebyshev metric facts — `chebDist`, `chebDist_self`, `chebDist_comm`,
-   `chebDist_le_trans`, `coord_bound_of_chebDist_le` (margin sufficiency) — now
-   live in `Conway.Life.ConeGeometry` (the Mathlib-only base, extracted for the
-   EPIC #3846 cycle-break). They are in scope here via `import
-   Conway.Life.ConeGeometry` above, under the same `Conway.Life.*` names, so the
-   GoL-coupled bridges below resolve them unchanged. The first bridge,
-   `manhattan_le_of_chebDist_le`, ties the tight Chebyshev metric to the loose
-   Manhattan `manhattan` (defined in `HashlifeCorrectness`). -/
+/- Les faits métriques purs de Chebyshev — `chebDist`, `chebDist_self`,
+   `chebDist_comm`, `chebDist_le_trans`, `coord_bound_of_chebDist_le`
+   (suffisance de marge) — vivent désormais dans `Conway.Life.ConeGeometry`
+   (la base Mathlib uniquement, extraite pour le cycle-break EPIC #3846). Ils
+   sont dans le scope ici via l'`import Conway.Life.ConeGeometry` ci-dessus,
+   sous les mêmes noms `Conway.Life.*`, donc les ponts couplés au GoL
+   ci-dessous les résolvent inchangés. Le premier pont,
+   `manhattan_le_of_chebDist_le`, relie la métrique Chebyshev étroite à la
+   métrique Manhattan `manhattan` lâche (définie dans
+   `HashlifeCorrectness`). -/
 
-/-- Tight ⊆ loose (distance form): Chebyshev radius `t` is bounded by Manhattan
-    radius `2 * t`, because each coordinate displacement is `≤ t` and the
-    Manhattan distance is their sum. -/
+/-- Étroit ⊆ lâche (forme distance) : le rayon Chebyshev `t` est borné par le
+    rayon Manhattan `2 * t`, car chaque déplacement de coordonnée est `≤ t` et
+    la distance Manhattan est leur somme. -/
 theorem manhattan_le_of_chebDist_le (p q : Int × Int) (t : Nat)
     (h : chebDist p q ≤ t) : manhattan p q ≤ 2 * t := by
   unfold chebDist at h
   unfold manhattan
   omega
 
-/-- A cell within Chebyshev radius `t` lies in the Manhattan-`(2*t)` light cone.
-    This is the bridge from the tight Chebyshev reach to the loose
-    `lightCone p (2 * t)` radius that `step_light_cone` operates on. -/
+/-- Une cellule à distance Chebyshev `≤ t` se trouve dans le cône de lumière
+    Manhattan-`(2*t)`. C'est le pont depuis la portée Chebyshev étroite vers le
+    rayon lâche `lightCone p (2 * t)` sur lequel opère `step_light_cone`. -/
 theorem mem_lightCone_of_chebDist_le (p q : Int × Int) (t : Nat)
     (h : chebDist p q ≤ t) : q ∈ lightCone p (2 * t) :=
   mem_lightCone_of_manhattan_le p q (2 * t) (manhattan_le_of_chebDist_le p q t h)
 
-/-! ## Tight Chebyshev reach — the Game-of-Life speed of light
+/-! ## Portée Chebyshev étroite — la vitesse de la lumière du Jeu de la Vie
 
-The reach theorem below composes the pure metric facts `chebDist_triangle`,
-`chebDist_le_succ_iff`, and `chebDist_le_succ` (now in `Conway.Life.ConeGeometry`)
-with the B3/S23 `evolve` semantics, so it stays in this module (which imports
-both `ConeGeometry` and `HashlifeCorrectness`).
+Le théorème d'atteinte ci-dessous compose les faits métriques purs
+`chebDist_triangle`, `chebDist_le_succ_iff` et `chebDist_le_succ` (désormais
+dans `Conway.Life.ConeGeometry`) avec la sémantique `evolve` B3/S23, il reste
+donc dans ce module (qui importe à la fois `ConeGeometry` et
+`HashlifeCorrectness`).
 
-The fundamental TIGHT locality result, stated as a *reach* theorem: after `t`
-generations, a cell alive at `evolve t g` lies within Chebyshev distance `t` of
-some initially alive cell of `g`. This is the speed-of-light bound — strictly
-sharper than the Manhattan-`2*t` light cone demanded by `step_light_cone`. It
-wires the set-level growth (`chebDist_le_succ_iff`, one Moore shell adds
-Chebyshev-1) into the B3/S23 semantics: `candidates g = g ++ g.flatMap
-mooreNeighbors` is exactly the Chebyshev-1 dilation of the alive set, so each
-`step` grows the reachable region by exactly one Moore shell. Epic #3846, N2
-step 2. Sorry-free. -/
+Le résultat fondamental de localité ÉTROITE, énoncé comme théorème d'*atteinte*
+: après `t` générations, une cellule vivante à `evolve t g` se trouve à distance
+Chebyshev `≤ t` d'une cellule initialement vivante de `g`. C'est la borne de
+vitesse de la lumière — strictement plus fine que le cône de lumière
+Manhattan-`2*t` exigé par `step_light_cone`. Il câble la croissance au niveau
+ensemble (`chebDist_le_succ_iff`, une coque de Moore ajoute Chebyshev-1) dans la
+sémantique B3/S23 : `candidates g = g ++ g.flatMap mooreNeighbors` est exactement
+la dilation Chebyshev-1 de l'ensemble vivant, donc chaque `step` fait croître la
+région atteignable d'exactement une coque de Moore. EPIC #3846, N2 étape 2. Sans
+sorry. -/
 
-/-- Bridge between `isAlive` (Boolean membership) and List membership. -/
+/-- Pont entre `isAlive` (appartenance booléenne) et l'appartenance comme List. -/
 theorem isAlive_true_iff_mem (g : Grid) (p : Int × Int) :
     isAlive g p = true ↔ p ∈ g := by
   rw [isAlive]; exact List.elem_iff
 
-/-- A Moore neighbor of `p` is at Chebyshev distance at most 1 — the tight
-    bound (vs `manhattan_moore_le_two`'s loose `≤ 2`). -/
+/-- Un voisin de Moore de `p` est à distance Chebyshev au plus 1 — la borne
+    étroite (vs le `≤ 2` lâche de `manhattan_moore_le_two`). -/
 theorem chebDist_le_one_of_moore (p q : Int × Int)
     (hq : q ∈ mooreNeighbors p) : chebDist p q ≤ 1 := by
   unfold chebDist mooreNeighbors at *
@@ -330,20 +339,21 @@ theorem chebDist_le_one_of_moore (p q : Int × Int)
     rw [hd1, hd2]; decide
   · simp at h
 
-/-- **Tight GoL speed of light (reach form).** If `q` is alive after `t`
-    generations of evolution from `g`, then `q` is within Chebyshev radius `t`
-    of some initially-alive cell of `g`.
+/-- **Vitesse de la lumière GoL étroite (forme atteinte).** Si `q` est vivante
+    après `t` générations d'évolution depuis `g`, alors `q` est à distance
+    Chebyshev `≤ t` d'une cellule initialement vivante de `g`.
 
-    Proof by induction on `t`:
-    - Base `t = 0`: `evolve 0 g = g`, witness `p = q`, `chebDist q q = 0`.
-    - Step `t = n + 1`: `isAlive (evolve (n+1) g) q = aliveNext (evolve n g) q`
-      (by `isAlive_step_eq_aliveNext`), and `aliveNext … = true` puts
-      `q ∈ candidates (evolve n g)`. Membership splits (`List.mem_append`) into:
-      (a) `q ∈ evolve n g` — `q` alive at gen `n`, so the IH gives a witness
-      within `chebDist ≤ n ≤ n+1`; or (b) `q ∈ (evolve n g).flatMap mooreNeighbors`
-      — some `r` alive at gen `n` with `q ∈ mooreNeighbors r`, so the IH gives a
-      witness within `chebDist p r ≤ n`, `chebDist_le_one_of_moore` gives
-      `chebDist r q ≤ 1`, and the triangle inequality yields `≤ n+1`. -/
+    Preuve par récurrence sur `t` :
+    - Base `t = 0` : `evolve 0 g = g`, témoin `p = q`, `chebDist q q = 0`.
+    - Pas `t = n + 1` : `isAlive (evolve (n+1) g) q = aliveNext (evolve n g) q`
+      (par `isAlive_step_eq_aliveNext`), et `aliveNext … = true` place
+      `q ∈ candidates (evolve n g)`. L'appartenance se scinde (`List.mem_append`)
+      en : (a) `q ∈ evolve n g` — `q` vivante à la génération `n`, donc l'HR
+      donne un témoin à `chebDist ≤ n ≤ n+1` ; ou (b)
+      `q ∈ (evolve n g).flatMap mooreNeighbors` — un `r` vivant à la génération
+      `n` avec `q ∈ mooreNeighbors r`, donc l'HR donne un témoin à
+      `chebDist p r ≤ n`, `chebDist_le_one_of_moore` donne `chebDist r q ≤ 1`,
+      et l'inégalité triangulaire donne `≤ n+1`. -/
 theorem evolve_reach_chebyshev (t : Nat) (g : Grid) (q : Int × Int)
     (h_alive : isAlive (evolve t g) q = true) :
     ∃ p, isAlive g p = true ∧ chebDist p q ≤ t := by
@@ -359,12 +369,12 @@ theorem evolve_reach_chebyshev (t : Nat) (g : Grid) (q : Int × Int)
     unfold candidates at hmem
     rw [List.mem_append] at hmem
     rcases hmem with h_self | h_nbr
-    · -- (a) q alive at gen n: IH directly
+    · -- (a) q vivante à la génération n : HR directement
       have hq : isAlive (evolve n g) q = true :=
         (isAlive_true_iff_mem (evolve n g) q).mpr h_self
       obtain ⟨p, hp, hcheb⟩ := ih q hq
       exact ⟨p, hp, hcheb.trans (Nat.le_succ n)⟩
-    · -- (b) q is a Moore neighbor of some r alive at gen n
+    · -- (b) q est un voisin de Moore d'un r vivant à la génération n
       rw [List.mem_flatMap] at h_nbr
       obtain ⟨r, hr_mem, hrq⟩ := h_nbr
       have hr : isAlive (evolve n g) r = true :=
@@ -374,44 +384,48 @@ theorem evolve_reach_chebyshev (t : Nat) (g : Grid) (q : Int × Int)
       have hrq_cheb : chebDist r q ≤ 1 := chebDist_le_one_of_moore r q hrq
       exact (chebDist_triangle p q r).trans (add_le_add hpr hrq_cheb)
 
-/-! ## N2 step 3 capstone: tight Chebyshev reach ⊆ padCenter2 margin
+/-! ## Couronnement N2 étape 3 : portée Chebyshev étroite ⊆ marge padCenter2
 
-Composing the tight reach theorem (`evolve_reach_chebyshev`, one Moore shell
-per generation) with the margin-arithmetic lemma
-(`padCenter2_margin_ge_jumpReach`, `2^k ≤ 3·2^(k-1)`, proven in
-`HashlifeCorrectness` L1102) yields the full sorry-free bridge named by ai-01's
-N2 greenlight: for a level-`k ≥ 1` MacroCell, a `2^k`-generation jump (the
-Hashlife `jumpSize k = 2^k`) reaches only cells within the per-side `padCenter2`
-margin `3·2^(k-1)` of some initially-alive cell. The **tight** Chebyshev-`2^k`
-reach — not the loose Manhattan-`2^(k+1)` cone — is what makes the `2^k` margin
-sufficient with 50% headroom (the diagonal of the reach is `2^k`, the margin is
+La composition du théorème d'atteinte étroit (`evolve_reach_chebyshev`, une
+coque de Moore par génération) avec le lemme d'arithmétique de marge
+(`padCenter2_margin_ge_jumpReach`, `2^k ≤ 3·2^(k-1)`, prouvé dans
+`HashlifeCorrectness` L1102) produit le pont complet sans sorry nommé par le
+greenlight N2 d'ai-01 : pour un MacroCell de niveau `k ≥ 1`, un saut de `2^k`
+générations (le `jumpSize k = 2^k` de Hashlife) n'atteint que des cellules dans
+la marge par côté `padCenter2` `3·2^(k-1)` d'une cellule initialement vivante.
+C'est la portée Chebyshev-`2^k` **étroite** — pas le cône Manhattan-`2^(k+1)`
+lâche — qui rend la marge `2^k` suffisante avec 50 % de marge restante (la
+diagonale de la portée est `2^k`, la marge est
 `3·2^(k-1) = 1.5·2^k`).
 
-Evaluation of the three MacroCell-layer ingredients ai-01 flagged (these govern
-the eventual wire into `p5_large_n_jump`, which remains P4-gated and out of
-scope here):
-- `padCenter2 c = padToLevelPlus1 (padToLevelPlus1 c)` (`Hashlife.lean` L260):
-  lifts a level-`k` cell into a level-`(k+2)` frame of side `2^(k+2) = 4·2^k`,
-  giving per-side margin `(4·2^k − 2^k)/2 = 3·2^(k-1)`.
-- `level_padCenter2` (`HashlifeCorrectness` L1638): `(padCenter2 c).level =
-  c.level + 2` — the level companion certifying the frame lift.
-- `hashlifeResult_central_correct` (`HashlifeCorrectness` L2753): the P4
-  decompose-compose theorem; its `succ` arm carries one of the two residual
-  sorries (L2734), so the MacroCell offset-wire is blocked on the P4 inductive
-  step (`p4_succ_membership`).
+Évaluation des trois ingrédients de couche MacroCell signalés par ai-01 (ils
+gouvernent le câblage éventuel dans `p5_large_n_jump`, qui reste gated-P4 et
+hors scope ici) :
+- `padCenter2 c = padToLevelPlus1 (padToLevelPlus1 c)` (`Hashlife.lean` L260) :
+  remonte une cellule de niveau `k` dans un cadre de niveau `(k+2)` de côté
+  `2^(k+2) = 4·2^k`, donnant une marge par côté
+  `(4·2^k − 2^k)/2 = 3·2^(k-1)`.
+- `level_padCenter2` (`HashlifeCorrectness` L1638) :
+  `(padCenter2 c).level = c.level + 2` — le compagnon de niveau certifiant le
+  lift de cadre.
+- `hashlifeResult_central_correct` (`HashlifeCorrectness` L2753) : le théorème
+  P4 de décompose-compose ; son bras `succ` porte l'un des deux sorries
+  résiduels (L2734), donc le câblage d'offset MacroCell est bloqué sur l'étape
+  inductive P4 (`p4_succ_membership`).
 
-This capstone is the **Grid-level / set-distance half** of the bridge — proved
-from already-sorry-free ingredients, so it is itself sorry-free and additive
-(anti-regression §D: the two residual sorries of `HashlifeCorrectness` are
-untouched). EPIC #3846, N2 step 3. -/
+Ce couronnement est la **moitié Grid-level / distance-ensembliste** du pont —
+prouvé à partir d'ingrédients déjà sans sorry, il est donc lui-même sans sorry
+et additif (anti-régression §D : les deux sorries résiduels de
+`HashlifeCorrectness` sont intouchés). EPIC #3846, N2 étape 3. -/
 
-/-- **Reach ⊆ padCenter2 margin** (N2 step 3, sorry-free capstone).
-    After `2^k` generations of evolution, every alive cell `q` has each
-    coordinate within the `padCenter2` per-side margin `3·2^(k-1)` of some
-    initially-alive cell `p`. This composes the tight Chebyshev reach
-    (`evolve_reach_chebyshev`, giving `chebDist p q ≤ 2^k`), the per-coordinate
-    bound (`coord_bound_of_chebDist_le`, giving `|q.i − p.i| ≤ 2^k`), and the
-    margin arithmetic (`padCenter2_margin_ge_jumpReach`, `2^k ≤ 3·2^(k-1)`). -/
+/-- **Atteinte ⊆ marge padCenter2** (N2 étape 3, couronnement sans sorry).
+    Après `2^k` générations d'évolution, toute cellule vivante `q` a chaque
+    coordonnée dans la marge par côté `padCenter2` `3·2^(k-1)` d'une cellule
+    initialement vivante `p`. Ceci compose la portée Chebyshev étroite
+    (`evolve_reach_chebyshev`, donnant `chebDist p q ≤ 2^k`), la borne par
+    coordonnée (`coord_bound_of_chebDist_le`, donnant `|q.i − p.i| ≤ 2^k`), et
+    l'arithmétique de marge (`padCenter2_margin_ge_jumpReach`,
+    `2^k ≤ 3·2^(k-1)`). -/
 theorem evolve_reach_within_padCenter2_margin (k : Nat) (hk : 1 ≤ k)
     (g : Grid) (q : Int × Int)
     (h_alive : isAlive (evolve ((2 : Nat)^k) g) q = true) :
@@ -424,12 +438,13 @@ theorem evolve_reach_within_padCenter2_margin (k : Nat) (hk : 1 ≤ k)
   have hmargin := padCenter2_margin_ge_jumpReach k hk
   exact ⟨p, hp, hb1.trans hmargin, hb2.trans hmargin⟩
 
-/-! ## W3 tight cone-in-domain — migrated to `Conway.Life.ConeGeometry`
+/-! ## W3 cône étroit dans le domaine — migré vers `Conway.Life.ConeGeometry`
 
-The tight Chebyshev cone-in-domain lemma `window_cheb_cone_in_domain` (W3,
-EPIC #3846) was extracted to `Conway.Life.ConeGeometry` — the Mathlib-only base
-module — as the dependency-cycle break that lets `HashlifeCorrectness` reach it
-for the P5 `p5_large_n_jump` wire without the circular reverse-import this module
-would otherwise impose (it imports `HashlifeCorrectness`). It is in scope here
-unchanged via the `import Conway.Life.ConeGeometry` above. See that module for
-the statement, proof, and the architectural wiring note. -/
+Le lemme de cône étroit dans le domaine `window_cheb_cone_in_domain` (W3,
+EPIC #3846) a été extrait vers `Conway.Life.ConeGeometry` — le module de base
+Mathlib uniquement — comme break de cycle de dépendances qui permet à
+`HashlifeCorrectness` de l'atteindre pour le câblage P5 `p5_large_n_jump` sans
+l'import inverse circulaire que ce module imposerait sinon (il importe
+`HashlifeCorrectness`). Il est dans le scope ici inchangé via l'`import
+Conway.Life.ConeGeometry` ci-dessus. Voir ce module pour l'énoncé, la preuve, et
+la note de câblage architectural. -/


### PR DESCRIPTION
## Summary

Drain the i18n lot (EPIC #4980) — clear **HALF-DONE advisories** in 3 `conway_lean/Life` FR canonical files by translating their English docstrings and comments to French. The `_en` mirrors are already English (correct) and untouched. Tranche 2 of the conway lot (tranche 1 = #9411).

Follows the ai-01 c.80 steer: « une PR qui vide le lot, MED critère de sortie verifiable » (half-done advisory count drops).

## Files (FR canonical only, 298 ins / 272 del)

| File | Advisory blocks cleared |
|------|------------------------|
| `Conway/Life/ConeGeometry.lean` | 8 |
| `Conway/Life/GridCanonical.lean` | 6 |
| `Conway/Life/LightCone.lean` | 14 |

## Verification — `check_i18n_siblings.py` (run firsthand on the worktree)

```
26/26 pairs byte-identical | 0 consumer-pattern | 0 drift | 0 orphan | 0 unbuilt | 7 half-done (advisory)
```

- **the 3 target pairs: HALF-DONE → OK** (ConeGeometry, GridCanonical, LightCone)
- conway half-done: 10 → 7 (the 3 cleared; remainder = Hashlife/MacroCell giants tranche 3 + Life_en + 4 already-tranche-1)
- **0 drift** — byte-identity holds (build-safe)
- scope: only 3 FR canonical files; 0 `_en` mirrors touched

## Byte-identity (build-safety proof)

Only docstrings (`/-- ... -/`) and comments (`-- ...` / `/- ... -/`) changed. All `def`/`theorem`/`lemma`/`instance` statements, tactics, names, `namespace`, `import`s, Mathlib refs are byte-identical between FR canonical and EN mirror.

- **sorry = 0 tactics** (HEAD:0, NOW:0). The word "sorry" appears only in prose ("Sans sorry." = "Sorry-free.", in docstrings/comments), not as a tactic.

## Accent convention

These 3 files are **pre-existingly accented** (ConeGeometry ~80, GridCanonical ~104, LightCone ~104 accented chars pre-edit). Translations use French accents (é/è/à/ç/ê) to match each file's established style — distinct from the accent-free files (Angel/Oscillators/Spaceships) handled in #9411. Post-edit: 151/128/210 accents (translations enriched the accented style, consistent).

## Judgment call (transparent)

One benign comment typo corrected during translation: ConeGeometry "mono-verru" → "mono-verrou" (lock). The `_en` mirror already reads "mono-verrou" (verru was a typo, not established jargon — grep confirms "verru" appears nowhere else in the lake). This aligns FR with the already-correct EN mirror. A comment, not code.

## Remaining conway lot

- Hashlife (24 advisory blocks, 543 lines) + MacroCell (32, 805 lines) = **tranche 3**, giants, dedicated PR (G.4 size). Both accent-free → will need de-accent like Angel/Oscillators (#9411).
- Life_en root aggregator (11).
- Angel/CollatzLike/Doomsday/Oscillators = cleared in #9411 (waiting merge).

See #4980 (partial — lot drain, conway tranche 2).

---
Grain: MED/lean-i18n — lane myia-po-2024:CoursIA — prev: MED/lean-i18n #9411 (conway tranche 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
