### PR TITLE
fix(sudoku,#8052): align Sudoku-14-BDD perf tables to committed output (0.46 ms)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
@@ -89,7 +89,7 @@
     "| **Structure** | Graphe de décision explicite | Formules logiques |\n",
     "| **Opérations** | Union, Intersection, Réduction | SAT solving |\n",
     "| **Mémoïsation** | Naturelle (partage de sous-graphes) | Via Z3 |\n",
-    "| **Performance** | Moyenne (~100ms) | Excellente (~20ms) |\n",
+    "| **Performance** | < 1 ms (résolution, cf. §6) | ~ 20 ms |\n",
     "| **Authenticité** | ⭐⭐⭐ Vrais automates | ⭐⭐ Compilation |\n",
     "\n",
     "### 1.2 Pourquoi BDD?\n",
@@ -2871,7 +2871,7 @@
     "| **Structure** | Variables Z3 + contraintes | Graphe de décision |\n",
     "| **Opérations** | Conjonction de contraintes | Produit d'automates |\n",
     "| **Vérification** | SAT solving | Parcours de graphe |\n",
-    "| **Performance** | ~20 ms | ~100 ms |\n",
+    "| **Performance** | ~ 20 ms | < 1 ms (résolution, cf. §6) |\n",
     "| **Authenticité** | ⭐⭐ Approche hybride | ⭐⭐⭐ Vrais automates |\n",
     "| **Pragmatisme** | ⭐⭐⭐ Production-ready | ⭐ Théorique |\n",
     "\n",
@@ -2943,7 +2943,7 @@
     "| # | Notebook | Approche | Temps (Easy) | Pureté \"automata\" |\n",
     "|---|----------|----------|--------------|-------------------|\n",
     "| 12 | **SFA + Z3** | Compilation vers SMT | ~20 ms | ⭐ |\n",
-    "| 13 | **BDD/MDD** | Automates purs | ~100 ms | ⭐⭐⭐ |\n",
+    "| 14 | **BDD/MDD** | Automates purs | < 1 ms (cf. §6) | ⭐⭐⭐ |\n",
     "\n",
     "Les deux approches ont leur place : l'une pour la pratique, l'autre pour la théorie."
    ]


### PR DESCRIPTION
## What & why (#8052)

`Sudoku-14-BDD-Csharp.ipynb` had a **claims-vs-outputs defect**: 3 comparison tables (intro §1.1, §7.1, §8.4 synthesis) claimed BDD/MDD resolution at **~100 ms**, contradicting the notebook's own committed output.

**Committed output (cell[31], verified firsthand G.1):**
```
Solution trouvé en 0,46 ms
```

**§6 narrative (cell[32]) was already honest** — "moins d'une milliseconde ... (0,46 ms mesurée)" + "l'approche pratique pour Sudoku utilise le backtracking direct" (MDD complets impraticables, cf §8.2.3 — the solver is pure backtracking). The ~100 ms value had no basis in any committed output.

## The fix (3 perf rows, prose-only)

| Cell | Before | After |
|------|--------|-------|
| §1.1 (cell[1]) | `\| Performance \| Moyenne (~100ms) \| Excellente (~20ms) \|` | `\| Performance \| < 1 ms (résolution, cf. §6) \| ~ 20 ms \|` |
| §7.1 (cell[33]) | `\| Performance \| ~20 ms \| ~100 ms \|` | `\| Performance \| ~ 20 ms \| < 1 ms (résolution, cf. §6) \|` |
| §8.4 (cell[34]) | `\| 13 \| BDD/MDD \| ~100 ms \|` | `\| 14 \| BDD/MDD \| < 1 ms (cf. §6) \|` |

Two honest adjustments beyond the raw value:
- **Dropped subjective qualifiers "Moyenne/Excellente"** (cell[1]) — they became self-contradictory: 0.46 ms is *faster* than Z3's ~20 ms, so "Moyenne (~100ms) vs Excellente (~20ms)" is inverted. Let the measured values speak.
- **Fixed §8.4 stale series # 13 → 14** — this notebook IS `Sudoku-14-BDD-Csharp.ipynb`; cell[1] self-references as "BDD/MDD (**ce notebook**)" paired against "Sudoku-12". `Sudoku-13` is `SymbolicAutomata` (a different notebook, not BDD). So the §8.4 BDD/MDD row paired with #12 must be #14, not #13.

## Build-safety (markdown-only)

- **Prose-only**: 3 markdown cells changed, 0 code/output/`execution_count` cells touched (verified — code cell[31] retains `exec=11 out=True`).
- **No re-exec needed** (C.2 markdown-only exception + Stop & Repair rule 6: aligning prose to committed output, NOT hand-editing the output).
- **0 CRLF** (origin blob is LF; preserved).
- Diff (vs origin/main): 3 insertions / 3 deletions, single file.

## Scope

- `MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb` only.

See #8052 (claims-vs-outputs EPIC). This is the significant Sudoku defect surfaced by the #8052 sampling pass (1 of 2 found; the other, Sudoku-18-Comparison-Csharp, is a separate minor dependency-table defect).

---

`Grain: MED/notebook-dotnet — lane myia-po-2023:CoursIA — prev: MED/lean #9410`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
