### PR TITLE
fix(iit,#8052): ICT-1 conclusion restores the 0.69 intermediate Phi relief (AND/OR landscape)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb
@@ -960,7 +960,7 @@
     "En appliquant la notion de **trajectoire** a $\\Phi$ lui-même, on a vu que :\n",
     "\n",
     "1. **$\\Phi$ a un paysage.** Pour un même nombre de noeuds, ce paysage peut etre\n",
-    "   accidente (AND/OR : un pic a $2{,}31$, le reste a $0{,}19$) ou parfaitement plat\n",
+    "   accidente (AND/OR : un pic a $2{,}31$, un relief intermediaire a $0{,}69$, le reste a $0{,}19$) ou parfaitement plat\n",
     "   (XOR : $1{,}875$ partout). L'information integree est une fonction de l'etat,\n",
     "   pas seulement du cablage.\n",
     "2. **$\\Phi$ a une trajectoire.** Sur l'attracteur d'AND/OR — un cycle de longueur\n",


### PR DESCRIPTION
## What & why (#8052)

`ICT-1-PhiTrajectories.ipynb` conclusion (cell[24], point 1) described the AND/OR Φ landscape as **"un pic à 2,31, le reste à 0,19"** — a binary peak/flat framing that **drops the intermediate value**. This is a claims-vs-outputs defect: the conclusion contradicts both the committed output AND the notebook's own earlier prose.

**Committed output (cell[7], verified firsthand G.1):**
```
etat (1, 0, 1) : AND/OR Phi=0.6875   XOR Phi=1.8750
AND/OR   min=0.1875  max=2.3125  moyenne=0.5156  amplitude=2.1250
```
The AND/OR landscape has **THREE** distinct Φ levels: 0.1875 (6 states), 0.6875 (state `101`), 2.3125 (state `100`) — not two.

**The notebook's OWN earlier markdown (cell[9]) already states this correctly:**
> "la plupart des etats ont un Φ faible (≈ 0,19), mais un etat — `100` — culmine a Φ ≈ 2,31, **et `101` forme un relief intermediaire (≈ 0,69)**."

So cell[24]'s "le reste à 0,19" lumps the 0,69 state into the 0,19 floor — inconsistent with the data and with cell[9].

## The fix (cell[24] point 1, prose-only)

| | |
|---|---|
| **Before** | `accidenté (AND/OR : un pic à 2,31, le reste à 0,19)` |
| **After** | `accidenté (AND/OR : un pic à 2,31, un relief intermédiaire à 0,69, le reste à 0,19)` |

Restored the intermediate relief using cell[9]'s exact framing, matching the committed cell[7] output. Severity: MINOR — the qualitative "peaky AND/OR vs flat XOR" contrast holds; only the literal "le reste à 0,19" over-simplified by dropping 1 of 8 states.

## Build-safety (markdown-only)

- **Prose-only**: 1 markdown phrase changed; 0 code/output/`execution_count` cells touched.
- **No re-exec needed** (C.2 markdown-only exception + Stop & Repair rule 6: aligning prose to committed output, NOT hand-editing the output).
- **0 CRLF** (origin blob LF + trailing `\n}\n` preserved).
- Diff (vs origin/main): 1 insertion / 1 deletion, single file, single phrase.

## Scope & context

- `MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb` only.

Surfaced by the **#8052 IIT/PyPhi family claims-vs-outputs sample** (delegated read-only scan): **6/7 notebooks CLEAN** (IIT-1-IntroToPyPhi, IIT-2-AdvancedTopics, IIT-3-CoarseGrainingMacroPhi, ICT-7-ScaleFreeSignatures, ICT-8-AttractorLandscapesEWS, ICT-16-MDLTwoPartCode) — all load-bearing quantitative claims (Φ values, ρ/τ/α/KS coefficients, bit counts, partition counts) match their committed outputs. ICT-1 was the single defect.

See #8052 (claims-vs-outputs EPIC).

---

`Grain: LIGHT/notebook-python — lane myia-po-2023:CoursIA — prev: MED/notebook-dotnet #9414`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
