### PR TITLE
docs(socialchoice,#9377): strip drift-prone manual counts from SocialChoice README

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/README.md
@@ -27,7 +27,7 @@ Cette sous-série du parcours [GameTheory](../README.md) explore ces résultats 
 
 **Durée totale** : ~3h25
 
-> **Parité .NET** : les notebooks [01-Arrow-Impossibility-Theorem-Csharp.ipynb](01-Arrow-Impossibility-Theorem-Csharp.ipynb) (jumeau du SC-01), [03-Voting-Methods-Csharp.ipynb](03-Voting-Methods-Csharp.ipynb) (jumeau du SC-03) et [04-Computational-Aggregation-SAT-Z3-Csharp.ipynb](04-Computational-Aggregation-SAT-Z3-Csharp.ipynb) (jumeau du SC-04) sont les miroirs C# (.NET Interactive) des originaux Python — mêmes algorithmes implémentés from-scratch en C#. Marathon parité .NET ⇄ Python (#4956). Ces trois jumeaux C# sont comptés dans le `pedagogical_count` de la sous-série (7 notebooks au total, tous formats confondus) mais arborent le statut `PARITÉ` dans le tableau ci-dessus pour les distinguer des quatre notebooks Python d'origine dont ils sont les retranscriptions .NET.
+> **Parité .NET** : les notebooks [01-Arrow-Impossibility-Theorem-Csharp.ipynb](01-Arrow-Impossibility-Theorem-Csharp.ipynb) (jumeau du SC-01), [03-Voting-Methods-Csharp.ipynb](03-Voting-Methods-Csharp.ipynb) (jumeau du SC-03) et [04-Computational-Aggregation-SAT-Z3-Csharp.ipynb](04-Computational-Aggregation-SAT-Z3-Csharp.ipynb) (jumeau du SC-04) sont les miroirs C# (.NET Interactive) des originaux Python — mêmes algorithmes implémentés from-scratch en C#. Marathon parité .NET ⇄ Python (#4956). Ces trois jumeaux C# sont comptés dans le `pedagogical_count` de la sous-série mais arborent le statut `PARITÉ` dans le tableau ci-dessus pour les distinguer des quatre notebooks Python d'origine dont ils sont les retranscriptions .NET.
 
 ## Parcours d'apprentissage
 
@@ -120,8 +120,8 @@ Les notebooks SC-01 et SC-02 renvoient au projet Lake `game_theory_lean/SocialCh
 
 | Résultat | Fichier | sorry | Statut |
 |----------|---------|-------|--------|
-| Théorème d'Arrow | `Arrow.lean` | 0 | Prouvé (~950 lignes) |
-| Théorème de Sen | `Sen.lean` | 0 | Prouvé (~300 lignes) |
+| Théorème d'Arrow | `Arrow.lean` | 0 | Prouvé |
+| Théorème de Sen | `Sen.lean` | 0 | Prouvé |
 | Modèles de vote | `Voting.lean` | 0 | Banks, STV, Median Voter |
 
 Le projet `social_choice_lean_peters/` (DominikPeters, Lean 4 + Mathlib) formalise 12 règles de vote et 4 théorèmes d'impossibilité supplémentaires (Gibbard-Satterthwaite, Condorcet Participation, Condorcet Reinforcement, Duggan-Schwartz). Inventaire détaillé : [LEAN_INVENTORY.md](../LEAN_INVENTORY.md).


### PR DESCRIPTION
## What & why (#9377)

Per **#9377** (user mandate 2026-08-04: « les données quantitatives doivent être tenues par le CI, pas dans la prose manuelle »), `GameTheory/SocialChoice/README.md` carried 3 drift-prone quantitative counts that carry **no pedagogical function**. Per the #9377 triage rule ("le nombre porte-t-il une fonction pédagogique ?"), source-file sizes and aggregate notebook counts belong in the generated catalog, not in hand-maintained prose.

**Removed (3 drift-prone counts, ~3h audit of the full file against disk):**
| Site | Before | After | Why it drifts |
|------|--------|-------|---------------|
| L30 prose | `…sous-série (7 notebooks au total, tous formats confondus)…` | `…sous-série…` | Aggregate notebook count — regenerates in `CATALOG-STATUS` (`pedagogical_count: 7`), redundant in prose |
| L123 table | `Arrow.lean \| 0 \| Prouvé (~950 lignes)` | `Arrow.lean \| 0 \| Prouvé` | Source-file line count — changes with every FR/EN docstring flip, never touched by a student |
| L124 table | `Sen.lean \| 0 \| Prouvé (~300 lignes)` | `Sen.lean \| 0 \| Prouvé` | Same — source-file size, drifts mechanically with proof edits |

**Preserved (legitimate per #9377 "garder" column):**
- `0 sorry` on Arrow/Sen/Voting (L42, L92, L169) — **says the proof is complete** (a property, not a size)
- Peters library scope `12 règles de vote` / `4 théorèmes` (L127, L160, L170) — identifies an **external reference**, not a drift-prone in-repo asset
- `quatre notebooks Python d'origine` (L30) — an **identifier** distinguishing the originals, not an aggregate count

**Full-file audit (§E requirement):** reconciled disk ↔ `CATALOG-STATUS` ↔ prose. `pedagogical_count: 7` marker matches exactly 7 table rows (4 Python originals + 3 C# twins) and 7 `.ipynb` on disk (verified via `git ls-tree`). The marker stays **untouched** (authoritative aggregated count); only the 3 redundant prose/size mentions removed.

## Build-safety (docs-only markdown)

- **Docs-only**: 3 markdown edits in 1 README; 0 code/notebook/CI touched.
- **0 CRLF** (LF preserved); diff (vs origin/main): 3 ins / 3 del.
- **No catalog churn** (`CATALOG-STATUS` marker byte-identical).

## Scope

- `MyIA.AI.Notebooks/GameTheory/SocialChoice/README.md` only.

See #9377. Companion to #9415 (QC/Python README, same epic). Bounded docs tranche (1 item/lane/day, R6 variety — rotating from notebook-family #8052 substance).

---

`Grain: LIGHT/docs — lane myia-po-2023:CoursIA — prev: LIGHT/notebook-python #9420`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
