### PR TITLE
fix(sc16,#8052,#3801): real tenseal CKKS exec replaces fabricated values (regle F RECOVERABLE-LOCAL)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
@@ -823,12 +823,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TenSEAL non installe.\n",
-      "Pour installer : pip install tenseal\n",
+      "CKKS AVEC TENSEAL\n",
+      "======================================================================\n",
+      "Degree du polynome : 8192\n",
+      "Scale (precision)  : 2^40\n",
       "\n",
-      "TenSEAL permet de manipuler des vecteurs chiffres avec le schema CKKS.\n",
-      "Les operations supportees incluent addition, multiplication, et produit scalaire.\n",
-      "L'erreur d'approximation est typiquement de l'ordre de 1e-6 a 1e-4.\n"
+      "v1 (clair)  : [1.5, 2.3, 4.7, 8.1]\n",
+      "v2 (clair)  : [0.5, 1.7, 3.3, 1.9]\n",
+      "\n",
+      "Addition chiffree :\n",
+      "  Resultat   : [2.0, 4.0, 8.0, 10.0]\n",
+      "  Attendu    : [2.0, 4.0, 8.0, 10.0]\n",
+      "  Erreur max : 3.00e-09\n",
+      "\n",
+      "Multiplication chiffree :\n",
+      "  Resultat   : [0.75, 3.910001, 15.510002, 15.390002]\n",
+      "  Attendu    : [0.75, 3.9099999999999997, 15.51, 15.389999999999999]\n",
+      "  Erreur max : 2.09e-06\n",
+      "\n",
+      "Produit scalaire chiffre :\n",
+      "  Resultat   : 35.560004\n",
+      "  Attendu    : 35.559999999999995\n",
+      "  Erreur     : 4.46e-06\n"
      ]
     }
    ],
@@ -920,7 +936,7 @@
    "source": [
     "### Interpretation : opérations CKKS sur des vecteurs chiffres\n",
     "\n",
-    "**Note d'exécution** : TenSEAL est installe et la cellule précédente a execute reellement les opérations CKKS. Les valeurs rapportees sont donc mesurees : l'addition est quasi-exacte (erreur max ~2.4e-9), la multiplication atteint une erreur de l'ordre de 2e-6 et le produit scalaire de l'ordre de 5e-6 — coherent avec une `global_scale = 2^40` dont l'erreur d'approximation CKKS est typiquement de **1e-6 a 1e-4**, croissant avec la profondeur multiplicative.\n",
+    "**Note d'exécution** : TenSEAL est installe et la cellule précédente a execute reellement les opérations CKKS. Les valeurs rapportees sont donc mesurees : l'addition est quasi-exacte (erreur max ~3.0e-9), la multiplication atteint une erreur de l'ordre de 2.1e-6 et le produit scalaire de l'ordre de 4.5e-6 — coherent avec une `global_scale = 2^40` dont l'erreur d'approximation CKKS est typiquement de **1e-6 a 1e-4**, croissant avec la profondeur multiplicative.\n",
     "\n",
     "**Points cles** :\n",
     "- L'erreur d'approximation provient de l'encodage CKKS qui injecte du bruit intentionnellement. La `global_scale = 2^40` contrôle la precision : plus la scale est elevee, plus la precision est bonne, mais moins de multiplications sont possibles avant bootstrapping\n",
@@ -970,13 +986,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TenSEAL non installe - benchmark ignore.\n",
+      "BENCHMARK CKKS (vecteur de 100 elements)\n",
+      "======================================================================\n",
+      "  Chiffrement        : 3.34 ms\n",
+      "  Addition chiffree  : 0.04 ms\n",
+      "  Multiplication     : 2.27 ms\n",
+      "  Dechiffrement      : 0.92 ms\n",
       "\n",
-      "Ordres de grandeur typiques CKKS (vecteur 100 elements) :\n",
-      "  Chiffrement       : ~1-5 ms\n",
-      "  Addition chiffree : ~0.1 ms\n",
-      "  Multiplication    : ~1-5 ms\n",
-      "  Overhead total    : ~1000x-10000x vs calcul en clair\n"
+      "  Overhead vs calcul en clair : ~1000x-10000x\n",
+      "  -> Le HE est couteux, a utiliser quand la confidentialite l'exige\n"
      ]
     }
    ],
@@ -1064,14 +1082,14 @@
     "\n",
     "| Opération | Temps mesuré CKKS | Remarque |\n",
     "|-----------|--------------------|----------|\n",
-    "| Chiffrement | 9.08 ms | |\n",
-    "| Addition chiffree | 0.10 ms | Très rapide (multiplication de polynomes) |\n",
-    "| Multiplication | 5.15 ms | Multiplication tensorielle + relinearisation |\n",
-    "| Dechiffrement | 1.92 ms | |\n",
+    "| Chiffrement | 3.34 ms | |\n",
+    "| Addition chiffree | 0.04 ms | Très rapide (multiplication de polynomes) |\n",
+    "| Multiplication | 2.27 ms | Multiplication tensorielle + relinearisation |\n",
+    "| Dechiffrement | 0.92 ms | |\n",
     "| Overhead total | ~1000x-10000x | vs calcul en clair |\n",
     "\n",
     "**Points cles** :\n",
-    "- L'addition chiffree est remarquablement rapide (~0.1 ms) car elle ne fait que multiplier des polynomes modulo\n",
+    "- L'addition chiffree est remarquablement rapide (~0.04 ms) car elle ne fait que multiplier des polynomes modulo\n",
     "- La multiplication est plus couteuse car elle necessite une multiplication tensorielle suivie d'une opération de relinearisation\n",
     "- Le paramètre `poly_modulus_degree=8192` offre un bon compromis entre securite et performance pour des vecteurs de taille moderee"
    ]


### PR DESCRIPTION
## What & why (#8052 + #3801)

`SC-16-Homomorphic-Encryption.ipynb` markdown cells 18 + 21 claimed **"TenSEAL est installe et la cellule précédente a execute reellement"** and cited specific **measured** values — but the committed code outputs (cells 17 + 20) were the `except ImportError` fallback (`TenSEAL non installe`), so those numbers were **fabricated** (they appear in no committed output).

**The fabricated values:**
| Cell | Claimed (fabricated) | Committed output (ImportError fallback) |
|------|----------------------|------------------------------------------|
| cell[18] | CKKS errors: add ~2.4e-9, mul ~2e-6, dot ~5e-6 | `TenSEAL non installe.` (no values measured) |
| cell[21] | benchmark: 9.08 / 0.10 / 5.15 / 1.92 ms | `TenSEAL non installe - benchmark ignore.` (only generic ranges ~1-5 ms) |

## Root cause + verdict (#3801 Prong A: install/re-exec, regle F)

This is **not** a markdown miscount — it's a **degraded-workaround consecration**. The committed output is an `except ImportError` fallback because **tenseal was not installed** on the execution machine. Per **regle F** (réparer, jamais contourner) + **#3801 Prong A** (the reflex is to install the real tool, not consecrate the fallback):

- **tenseal 0.3.16 IS importable on this machine** (Python 3.13.3) → verdict **RECOVERABLE-LOCAL**: no install needed, **re-execute for real values**.

## The fix (real tenseal re-execution)

Re-executed cells 17 (CKKS add/mul/dot) + 20 (100-element benchmark) with tenseal → committed the **real measured outputs**. Updated markdown 18 + 21 to the **real values**:

| Cell | Now (real, measured this run) |
|------|-------------------------------|
| cell[18] | CKKS errors: add ~3.0e-9, mul ~2.1e-6, dot ~4.5e-6 (committed: `Erreur max : 3.00e-09` / `2.09e-06` / `4.46e-06`) |
| cell[21] | benchmark: encrypt 3.34, add 0.04, mul 2.27, decrypt 0.92 ms (committed output lines) |

The "**Note d'exécution: TenSEAL est installe et la cellule précédente a execute reellement**" claim is now **TRUE** — the committed output is real CKKS computation, not an ImportError fallback. Benchmark timings are machine-dependent; the markdown already states "ils varient selon la machine et la charge".

(CKKS error magnitudes and timings are mildly non-deterministic run-to-run; the committed output is one real run, the markdown cites its order of magnitude — honest.)

## Build-safety (surgical re-execution)

- **Re-execution is real** (tenseal present, `try` branch ran, no exceptions — C.1 holds end-to-end).
- **Surgical**: only cells 17/18/20/21 changed; `execution_count` (6/7) **preserved** (they remain the 6th/7th code cells); **papermill metadata/timestamps preserved** (no churn); 0 CRLF; JSON valid.
- 35 ins / 17 del (real CKKS output is longer than the short ImportError fallback + 8 in-place markdown value fixes).

## Scope & context

- `MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb` only.

Surfaced by the **#8052 SmartContracts family sample** (delegated read-only scan, 7 notebooks read in full via `git show origin/main:<path>`): **6/7 notebooks CLEAN** — SC-7 (gas/allowance tables), SC-8 (AMM price-impact tables), SC-12, SC-13 (real `forge test` fuzz run), SC-14 (honest SMTChecker RECOVERABLE-MACHINE disclosure), SC-15 (R1CS/ZKP tables) all verified. **SC-16 was the sole defect** — and notably it's the inverse pattern of SC-14: interpretation cells asserting real execution + measured values where the committed output is an ImportError fallback.

See #8052 (claims-vs-outputs EPIC) + #3801 (SOTA Prong A — verdict **RECOVERABLE-LOCAL**).

---

`Grain: MED/notebook-python — lane myia-po-2023:CoursIA — prev: LIGHT/docs #9422`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
