### PR TITLE
docs(qc,#9377): drop drift-prone manual file sizes from Crypto-MultiCanal README

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Crypto-MultiCanal/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Crypto-MultiCanal/README.md
@@ -79,12 +79,12 @@ channel_params = {
 
 ## Fichiers
 
-| Fichier | Taille | Description |
-|---------|--------|-------------|
-| `main.py` | ~930 lignes | Algorithme complet : helpers, ZigZag, canaux, entrées/sorties, OCO |
-| `fix_ipynb_quotes.py` | petit | Utilitaire de nettoyage pour le notebook research |
-| `research.ipynb` | 210K | Notebook de recherche et visualisation (cloud QC) |
-| `research_archive.ipynb` | archive | Version archivée du notebook research |
+| Fichier | Description |
+|---------|-------------|
+| `main.py` | Algorithme complet : helpers, ZigZag, canaux, entrées/sorties, OCO |
+| `fix_ipynb_quotes.py` | Utilitaire de nettoyage pour le notebook research |
+| `research.ipynb` | Notebook de recherche et visualisation (cloud QC) |
+| `research_archive.ipynb` | Version archivée du notebook research |
 
 ## Concepts pédagogiques
 


### PR DESCRIPTION
## What & why (#9377)

`QuantConnect/partner-course-quant-trading/examples/Crypto-MultiCanal/README.md` carried a **Fichiers** table with a `Taille` column of source-file line counts and blob sizes that drift on every edit and carry no pedagogical function. Per **#9377** (user mandate 2026-08-04: « les données quantitatives doivent être tenues par le CI, pas dans la prose manuelle »), source-file sizes belong in the generated catalog, not in hand-maintained prose.

## Full-file audit (§E) — reconciled every row against disk on `origin/main`

| Row | Claimed (Taille) | Actual on disk | Verdict |
|-----|------------------|----------------|---------|
| `main.py` | `~930 lignes` | **423 lines** (22271 B) | **STALE — wrong by 2.2×** (file refactored, README not updated) |
| `research.ipynb` | `210K` | **227K** (232578 B, 3584 cells-lines) | mildly stale (~8 %) |
| `fix_ipynb_quotes.py` | `petit` | 3956 B / 115 lines | qualitative, accurate |
| `research_archive.ipynb` | `archive` | 358648 B | qualitative, accurate |

The `main.py` count is the canonical #9377 defect: a source-file line count that is **already factually wrong** (2.2× off) and structurally drift-prone. The `research.ipynb` size is borderline-stale. Rather than re-insert numbers that drift again on the next edit, the `Taille` column is dropped wholesale — the `Description` column already identifies each file's role, so no information of pedagogical value is lost.

## Build-safety (docs-only markdown)

- **Docs-only**: 1 README, 0 code/notebook/CI touched.
- **Byte-level surgical edit** (drop one column + re-align separator) — structure otherwise byte-identical, no JSON round-trip.
- **0 CRLF** (LF preserved); diff vs origin/main: 6 ins / 6 del.
- No catalog touched (`COURSE_CATALOG.*` byte-identical to main).

## Scope & context

- `MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Crypto-MultiCanal/README.md` only.
- Companion to #9422 (SocialChoice README, same epic, same pattern). Own material (regularly edited — accent restoration #2876, etc.), not vendored.

See #9377.

---

`Grain: LIGHT/docs — lane myia-po-2023:CoursIA — prev: LIGHT/docs #9422`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
