### PR TITLE
fix(search,#8052): Wordle CSP/filtrage stale ~3.3 attempts -> ~3.1 (align to committed output)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb
@@ -2666,8 +2666,8 @@
     "\n",
     "| Approche | Moy. tentatives | Complexite par tentative | Avantage |\n",
     "|----------|-----------------|--------------------------|----------|\n",
-    "| Filtrage simple | ~3.3 | $O(n)$ | Simple et rapide |\n",
-    "| CSP | ~3.3 | $O(n)$ | Structure explicite |\n",
+    "| Filtrage simple | ~3.1 | $O(n)$ | Simple et rapide |\n",
+    "| CSP | ~3.1 | $O(n)$ | Structure explicite |\n",
     "| Entropie | ~2.9 | $O(n^2)$ | Optimal en information |\n",
     "\n",
     "### Ce qu'il faut retenir\n",
@@ -2735,7 +2735,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce notebook a modélisé le jeu Wordle comme un problème de recherche d'information et comparé trois stratégies de résolution. Le **filtrage simple** élimine les candidats incompatibles mais choisit au hasard, menant à ~3.3 tentatives en moyenne. Le **CSP** structure le problème avec des domaines par position et des contraintes déduites du feedback, offrant une visualisation claire de la propagation. L'approche par **entropie de Shannon** maximise l'information attendue de chaque tentative, réduisant la moyenne à ~2.9 tentatives grâce au choix optimal du mot le plus discriminant. La comparaison des distributions de feedback montre que le meilleur mot d'ouverture répartit uniformément les candidats entre les patterns, tandis qu'un mauvais mot les concentre dans un seul groupe. Cette leçon transcende le Wordle : maximiser le gain d'information est une stratégie fondamentale en diagnostic médical, dans les arbres de décision et dans tout problème de recherche avec retours partiels."
+    "Ce notebook a modélisé le jeu Wordle comme un problème de recherche d'information et comparé trois stratégies de résolution. Le **filtrage simple** élimine les candidats incompatibles mais choisit au hasard, menant à ~3.1 tentatives en moyenne. Le **CSP** structure le problème avec des domaines par position et des contraintes déduites du feedback, offrant une visualisation claire de la propagation. L'approche par **entropie de Shannon** maximise l'information attendue de chaque tentative, réduisant la moyenne à ~2.9 tentatives grâce au choix optimal du mot le plus discriminant. La comparaison des distributions de feedback montre que le meilleur mot d'ouverture répartit uniformément les candidats entre les patterns, tandis qu'un mauvais mot les concentre dans un seul groupe. Cette leçon transcende le Wordle : maximiser le gain d'information est une stratégie fondamentale en diagnostic médical, dans les arbres de décision et dans tout problème de recherche avec retours partiels."
    ]
   }
  ],

--- a/scripts/notebook_tools/twin_pairs.d/app-7-wordle.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-7-wordle.yaml
@@ -3,11 +3,15 @@
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: '2026-07-31'
-    by: po-2024
-    python_sha: 87a7299b929d77d103c6264c39e251e26544decf
-    csharp_sha: 2c8194226c9eabf6906fc907455aae6190dc571b
+  audits:
+    - date: '2026-07-31'
+      by: po-2024
+      python_sha: 87a7299b929d77d103c6264c39e251e26544decf
+      csharp_sha: 2c8194226c9eabf6906fc907455aae6190dc571b
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 539c43fa6b5e50f99c065e8aa97bf8594863225f
+      csharp_sha: 2c8194226c9eabf6906fc907455aae6190dc571b
   known_differences:
     - "Socle pedagogique commun : Wordle (logique deductive + feedback, theorie de l'information) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = Counter/typing + matplotlib viz ; C# = System.IO + Microsoft.DotNet.Interactive formatting."


### PR DESCRIPTION
## What & why (#8052)

`App-7-Wordle.ipynb` markdown recap cells cited a **stale `~3.3` average-attempts** value for the Filtrage simple and CSP strategies, contradicting the committed benchmark output.

**Committed output (verified firsthand G.1):** Filtrage simple = `3.11`, CSP = `3.12` (→ `~3.1`).

**Internal contradiction:** the notebook's OWN cell[42] summary table already uses `~3.1` for both — so cell[52] (recap table) and cell[54] (conclusion) were stale from a prior run and inconsistent with both the output and cell[42].

| Cell | Before | After |
|------|--------|-------|
| cell[52] table | `Filtrage simple \| ~3.3` / `CSP \| ~3.3` | `~3.1` / `~3.1` |
| cell[54] conclusion | `menant à ~3.3 tentatives en moyenne` | `~3.1` |

Classic #8052 stale-value-after-re-execution: the benchmark was re-run (output 3.11/3.12) but two markdown recap cells kept the old `~3.3`. (Entropie `~2.9` left untouched — matches its output and cell[42].)

## Build-safety (prose-only markdown)

- **Prose-only**: 3 markdown value edits; 0 code / output / `execution_count` cells touched.
- **Byte-level surgical edit** (raw `~3.3` → `~3.1`, count-asserted = 3 occurrences, no JSON round-trip) → structure byte-identical.
- **No re-exec needed** (C.2 markdown-only exception + Stop & Repair rule 6: aligning prose to committed output, NOT hand-editing the output).
- **0 CRLF** (LF preserved); diff vs origin/main: 3 ins / 3 del.

## Scope & context

- `MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb` only.

Surfaced by the **#8052 Search/CSP family scan** (read-only, 153 notebooks): scan reported 4 candidate defects; **firsthand G.1 verification confirmed 2 (App-7, App-11), rejected MGS-16 (correct cross-notebook citation of MGS-10), and re-scoped Search-5 (cell[72] has empty output — needs re-exec, separate task)**. This PR is one of the 2 confirmed clean fixes.

See #8052 (claims-vs-outputs EPIC).

---


## Diagnostic dérive (§D.5)

- **Cause: b — claim antérieure stale.** The prose `~3.3` (filtrage simple + CSP average attempts) was stale vs the committed seeded-benchmark output (`~3.1`). The solver is seeded (`random.seed(42)`, per-word `random.seed(hash(answer) % 2**31)`, `benchmark_solver(seed=42)`), so the committed `~3.1` is reproducible; `~3.3` was a leftover from an earlier solver/word-list state.
- **Verdict: `CAUSE_FIXED`.** Aligned to the seeded deterministic committed output; seeded → stable across machines/runs, will not re-drift. (Algorithmic metric on a fixed word list, not a wall-clock perf number — §D.5's fresh-re-exec requirement for re-aligned timing/perf does not apply; the value is deterministic given the seed.)

**Twin parity**: registry rebaselined via `check_twin_parity.py --update --pair "App-7 Wordle"` (run last, #8957); committed python blob (539c43fa) = registry latest `python_sha` → parity green. C# twin (App-7b) untouched.

`Grain: LIGHT/notebook-python — lane myia-po-2023:CoursIA — prev: LIGHT/docs #9425`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

