### PR TITLE
fix(search,#8052): Search-5 GA observation stale 42.11 -> 41.71 (align to committed cell[72] output)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb
@@ -3451,7 +3451,7 @@
     "### Observations (Prong B illustre)\n",
     "\n",
     "1. **Sur la plus petite instance (8 villes), le GA trouve l'optimum** par chance combinatoire : l'espace de recherche reste suffisamment petit pour que la recherche génétique converge vers la solution exacte. C'est un **cas degeneré** ou la discrimination GA/exact est invisible. Des n=9, le GA stagne dans un optimum local (35.75 vs 31.66, gap ~1.13x) : la discrimination GA/exact devient visible.\n",
-    "2. **A 10 villes, le GA commence a degrader** : gap de 14% (42.11 vs 36.99) = demonstration quantitative de l'inadequation progressive du GA quand l'espace de recherche grandit exponentiellement. Le brute force exact O(n!) reste faisable (1 sec) et trouve l'optimum.\n",
+    "2. **A 10 villes, le GA commence a degrader** : gap de ~13% (41.71 vs 36.99) = demonstration quantitative de l'inadequation progressive du GA quand l'espace de recherche grandit exponentiellement. Le brute force exact O(n!) reste faisable (1 sec) et trouve l'optimum.\n",
     "3. **Garantie d'optimalite** : le brute force est **complet** (visite tous les chemins), le GA est **heuristique** (depend de la population initiale, du seed, des opérateurs). Pour des applications critiques (logistique, circuits imprimes, planification de tournees), un solveur exact ou une heuristique de plus haute qualite (LKH, OR-Tools) est preferable.\n",
     "4. **Valeur pedagogique du GA** : illustre la **famille des méthodes evolutionnistes** (population + sélection + variation) applicable quand l'espace est trop grand pour l'exhaustif (TSP > 15-20 villes, O(n!) ou O(2^n n^2) intractable). Le GA brille sur des problemes ou une **bonne solution rapide** suffit (temps réel, approximative search).\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/search-5-geneticalgorithms.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-5-geneticalgorithms.yaml
@@ -3,11 +3,15 @@
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2026:CoursIA
-    python_sha: 302e714c9920f536e87ce2d89bff63125d45d0a4
-    csharp_sha: e250e1fc294bd7be5cac4a85ca5a25d25e989ef2
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2026:CoursIA
+      python_sha: 302e714c9920f536e87ce2d89bff63125d45d0a4
+      csharp_sha: e250e1fc294bd7be5cac4a85ca5a25d25e989ef2
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 3200b27e66e012b484e1eef9f3d72138e983def2
+      csharp_sha: e250e1fc294bd7be5cac4a85ca5a25d25e989ef2
   known_differences:
     - "Rebaseline c.34 (ai-01) : #8697 a insere le bloc `metadata.cost` (#8056) a l'identique sur les DEUX jumeaux — les deux blob SHA ont bouge, la parite semantique est inchangee. Attestation de parite, pas reparation."
     - "Socle pedagogique commun : algorithmes genetiques (AG) — composants d'un AG (population, fonction de fitness, selection (roulette/tournoi), crossover, mutation), schemas d'evolution, probleme OneMax. Les deux twins implementent le cycle evolutionnaire from-scratch (population initiale → evaluation fitness → selection → croisement → mutation → nouvelle generation)."


### PR DESCRIPTION
## What & why (#8052)

`Search-5-GeneticAlgorithms.ipynb` cell[71] (Prong-B #3801 GA-vs-bruteforce comparison) had an **internal contradiction**: the table cited the 10-ville GA distance as `41.71`, but observation #2 cited `42.11`. `42.11` appears in **no committed output**.

**Ground truth — committed cell[72] output (deterministic, seed=42):**
```
10 villes : GA 41.71 vs exact 36.99, gap ~1.13x
```

So `41.71` (table) was correct, `42.11` (observation) was the stale/typo value. Real gap = 41.71/36.99 = 12.8 % → **~13 %** (the observation's "14 %" was consistent with the wrong 42.11; 42.11/36.99 = 13.8 %).

| Cell | Before | After |
|------|--------|-------|
| cell[71] obs #2 | `gap de 14% (42.11 vs 36.99)` | `gap de ~13% (41.71 vs 36.99)` |

## Scope note (why not a re-execution)

The accompanying scan flagged this cell with an *empty-output* concern and proposed re-executing cell[72]. On firsthand re-verification, **cell[72] already has committed output** (1049-char comparison table) that confirms `41.71` — it was never empty. (The "empty" read was a string-vs-list extraction artifact in the verification helper.) So no re-execution is needed or appropriate: the committed cell[72] output is correct and is itself the ground truth cited above. This PR is a **1-line markdown alignment** of observation #2 to that committed output. The cell[71] table and cell[72] output are untouched (already correct, including GA/exact ms which are wall-clock and match the committed run).

## Build-safety (prose-only markdown)

- **Prose-only**: 1 markdown value edit (observation #2); 0 code / output / `execution_count` cells touched.
- **Byte-level surgical edit** (raw `gap de 14% (42.11 vs 36.99)` → `gap de ~13% (41.71 vs 36.99)`, count-asserted = 1, no JSON round-trip) → structure byte-identical.
- **No re-exec needed** (C.2 markdown-only exception).
- **0 CRLF** (LF preserved); diff vs origin/main: 1 ins / 1 del.

## Scope & context

- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb` only.

Third of the 3 G.1-confirmed defects from the #8052 Search/CSP family scan (companions: #9426 App-7-Wordle, #9427 App-11-Picross). The scan's 4th candidate (MGS-16) was a false positive (correct cross-notebook citation of MGS-10).

See #8052 (claims-vs-outputs EPIC).

---


## Diagnostic dérive (§D.5)

- **Cause: b — claim antérieure stale.** The prose `42.11` / `gap 14%` (GA fitness at 10 villes) was stale vs the committed seeded output `41.71` / `~13%` (cell[72], which cites « Chiffres GA de la cellule 51, PyGAD TSP 8→10 villes, seed=42 »). The GA is seeded throughout (`SEED = 42`, `random.seed`/`np.random.seed`/PyGAD `random_seed=SEED`), so the committed `41.71` is reproducible; `42.11` was a leftover from an earlier run state.
- **Verdict: `CAUSE_FIXED`.** Aligned to the seeded deterministic committed output; seeded → stable across machines/runs, will not re-drift. (GA fitness on a fixed TSP instance, not a wall-clock perf number — §D.5's fresh-re-exec requirement for re-aligned timing/perf does not apply; the value is deterministic given the seed.)

**Twin parity**: registry rebaselined via `check_twin_parity.py --update --pair "Search-5 GeneticAlgorithms"` (run last, #8957); committed python blob (3200b27e) = registry latest `python_sha` → parity green. C# twin untouched.

`Grain: LIGHT/notebook-python — lane myia-po-2023:CoursIA — prev: LIGHT/notebook-python #9427`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

