### PR TITLE
fix(gametheory,#8052,#9377): GT-4c delete hand-written NumPy version row (cell[2] = source of truth)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
@@ -134,7 +134,6 @@
     "\n",
     "| Bibliotheque | Version | Usage dans ce notebook |\n",
     "|--------------|---------|------------------------|\n",
-    "| NumPy | 2.4.2 | Calcul vectoriel, manipulation de matrices |\n",
     "| Matplotlib | - | Visualisation de fonctions et trajectoires |\n",
     "| Typing | - | Annotations de type pour les fonctions |\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-4c-nashexistence.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-4c-nashexistence.yaml
@@ -3,11 +3,15 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: c6db511801c503cacd18a0af26ffe0182d0b70f8
-    csharp_sha: ca1c73ac33c1ffbec1f99ba3a60da33bce3cfea1
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: c6db511801c503cacd18a0af26ffe0182d0b70f8
+      csharp_sha: ca1c73ac33c1ffbec1f99ba3a60da33bce3cfea1
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: d961920fe442d4cd9e6948327d5cd72c79f0c36b
+      csharp_sha: ca1c73ac33c1ffbec1f99ba3a60da33bce3cfea1
   known_differences:
     - "Socle pedagogique commun : existence d'un equilibre de Nash (theoreme de point fixe de Brouwer / Kakutani), structure de jeu et conditions d'existence. Meme concept mathematique (equilibre, point fixe, convexite), meme cas d'application (jeux strategiques, illustration de l'existence). Les deux couvrent le theoreme de Nash."
     - "Divergence d'implementation : le Python (numpy + matplotlib, 15 cellules code) calcule et visualise numeriquement les equilibres (support enumeration / approche numerique + tracé du best-response correspondence) ; le C# (pur System.* stdlib, 0 NuGet, 10 cellules code) demontre l'existence de maniere constructive/algebrique (sans solveur numerique externe). Meme theoreme, deux angles : numerique+visualisation cote Python vs construction algebrique cote C#."


### PR DESCRIPTION
## What & why (#8052 → #9377 correction)

`GameTheory-4c-NashExistence-Python.ipynb` cell[3] ("Bibliothèques importées" table) carried a **hand-written** `| NumPy | 2.4.2 |` version row. cell[2] prints `NumPy version: {np.__version__}` dynamically (= 2.4.6 on the committing env). The hand-written row had drifted at the env bump.

**This PR deletes the hand-written NumPy row — it does NOT re-align it to 2.4.6.** Per the #9377 mandate (quantitative data held by code/CI, not manual prose): cell[2] is already the single source of truth for the NumPy version; keeping a duplicate version in the markdown table re-drifts at every bump. The earlier "align 2.4.2→2.4.6" form (my prior commit on this branch) was the wrong gesture — as the coordinator noted, my own body had identified the right one ("cell[2] imprime la version dynamiquement, donc une source unique de vérité est trivialement restaurable") and done the other. This is the corrected fix.

| Cell | Before (origin/main) | After |
|------|----------------------|-------|
| cell[3] table | `\| NumPy \| 2.4.2 \| Calcul vectoriel… \|` (+ Matplotlib, Typing rows) | NumPy row **deleted**; Matplotlib + Typing rows kept (their Version = "−", not drift-prone) |

cell[2] (code, unchanged) remains the sole source: `print(f"NumPy version: {np.__version__}")` → `NumPy version: 2.4.6`.

## Diagnostic dérive (§D.5)

- **Cause: a — env/kernel.** The NumPy version drifted because the committing environment bumped 2.4.2 → 2.4.6; the markdown table was hand-pinned to 2.4.2 and did not track the bump (cell[2] did, via `np.__version__`).
- **Verdict: `CAUSE_FIXED`.** The drift cause (a duplicate hand-written version source) is **eliminated**, not merely documented: the row is deleted, leaving cell[2]'s dynamic print as the single source of truth. No number that can re-drift remains in the prose. (Not a perf/timing/accuracy/cost number — env-metadata version with a dynamic source cell — so §D.5's fresh-re-exec requirement for re-aligned metrics does not apply; this is a #9377 strip, not an align.)

## Build-safety (prose-only markdown)

- **Prose-only**: 1 markdown table row deleted; **0 code / output / `execution_count` cells touched** (all code cells retain `execution_count != null`, outputs unchanged — C.2 preserved).
- **Byte-level surgical delete** (raw physical-line removal, count-asserted = 1, no JSON round-trip) → structure byte-identical.
- **No re-exec needed** (C.2 markdown-only exception; deleting a stale prose row, cell[2] output is the ground truth and is unchanged).
- **0 CRLF** (LF preserved); diff vs origin/main: notebook 1 del, + twin registry rebaseline (append-only migration, see below).
- **Twin parity**: registry rebaselined via `check_twin_parity.py --update --pair "GameTheory-4c NashExistence" --by "myia-po-2023:CoursIA"` run **last** (after normalization; GT-4c has no probe-banner/machine-path, so strip hooks are no-ops — #8957 order respected). `gametheory-4c-nashexistence.yaml`: `last_audit:` singleton → append-only `audits:` [prior c6db5118, new d961920f]; committed notebook blob (d961920f) = registry latest `python_sha` (d961920f) → parity green. csharp twin untouched (sha ca1c73ac unchanged).

## Scope & context

- `MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb` + `scripts/notebook_tools/twin_pairs.d/gametheory-4c-nashexistence.yaml` only.

Rebased onto `origin/main` (0299036b1) before `--update`, per coordinator instruction. Surfaced by the #8052 GameTheory family scan; this is the **#9377 inside-notebook** half — the same gesture as #9425 (stripped hand-written file sizes from a README) and #9432 (stripped drift-prone manual cell counts), now applied to a hand-written version row inside a notebook.

See #8052, #9377, #3801.

---

`Grain: LIGHT/notebook-python (#9377 strip) — lane myia-po-2023:CoursIA — prev: LIGHT/notebook-python #9435`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
