### PR TITLE
refactor(twin-parity): migrate 153 legacy last_audit singletons to append-only audits (#9399 volet a)

### DIFF
--- a/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
@@ -146,12 +146,12 @@ def test_comments_survive_surgical_rebaseline():
 def test_diff_limited_to_target_block(registry_backup):
     """Seul le bloc d'audit de la paire ciblee bouge ; le reste est intact.
 
-    Depuis #9399, un rebaseline d'une paire legacy qui drift MIGRE le bloc
-    `last_audit:` vers la liste append-only `audits:` (ancien enregistrement +
-    nouveau). La garantie chirurgicale (#8570) est preservee : aucune cle
-    top-level hors audit (name/family/python/csharp/parity_level/known_differences)
-    ne change, et l'ancien enregistrement survit comme item[0] (anti-regression :
-    on ne jette pas l'historique d'audit).
+    Depuis #9399 (volet a, migration at-rest), le registre est en forme
+    append-only `audits:`. Un rebaseline qui drift APPEND une nouvelle entree ;
+    l'enregistrement precedent survit comme item[0]. La garantie chirurgicale
+    (#8570) est preservee : aucune cle top-level hors audit
+    (name/family/python/csharp/parity_level/known_differences) ne change
+    (anti-regression : on ne jette pas l'historique d'audit).
     """
     import yaml
 
@@ -159,12 +159,15 @@ def test_diff_limited_to_target_block(registry_backup):
     raw = pfile.read_text(encoding="utf-8")
     name = _pair_name(pfile)
     before = yaml.safe_load(raw)[0]
-    old_py = before["last_audit"]["python_sha"]
+    old_audit = ctp._latest_audit(before)
+    old_py = old_audit["python_sha"]
 
-    # SHA python change -> migration legacy -> audits:.
+    # SHA python change -> append a new entry (registry is audits: since the
+    # #9399 volet a at-rest migration). The lazy legacy->audits migration of a
+    # still-legacy yaml is covered by test_comments_survive_surgical_rebaseline.
     new_raw, touched = ctp.surgical_rebaseline(
         raw, {name: {"date": "1999-01-01", "by": "sentinelle-c8570",
-                     "python_sha": "f" * 40, "csharp_sha": before["last_audit"]["csharp_sha"]}}
+                     "python_sha": "f" * 40, "csharp_sha": old_audit["csharp_sha"]}}
     )
     assert touched == 1
     after = yaml.safe_load(new_raw)[0]
@@ -196,7 +199,7 @@ def test_noop_is_byte_identical(registry_backup):
 
     data = yaml.safe_load(raw)
     entry = data[0] if isinstance(data, list) else data
-    audit = entry["last_audit"]
+    audit = ctp._latest_audit(entry)
 
     new_raw, touched = ctp.surgical_rebaseline(
         raw,

--- a/scripts/notebook_tools/twin_pairs.d/app-1-nqueens.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-1-nqueens.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-1b-NQueens-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 52c83a05acef9340568c3a81c617ebc4dfc89592
-    csharp_sha: 17128d989d96c86221f698d1586f00ddf5f6feb1
-    reason: "Markdown-only identity fix (Python cells 21+32): the two scaling-experiment intros cited N=1000 as a tested size, but the Python benchmarks never run it (cell 22 mc_sizes=[8,50,100,500], cell 33 cpsat_sizes=[8,50,100,500]; committed output + interpretation cells 27/34 cap at N=500). Aligned the intros to the actual cap of 500. The C# twin genuinely runs N=1000 (cell 14 sizes include 1000, output N=1000 resolu), so 1000 is a real tested size in C#, not a phantom; csharp unchanged, no parallel defect. No re-exec, no output change."
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 52c83a05acef9340568c3a81c617ebc4dfc89592
+      csharp_sha: 17128d989d96c86221f698d1586f00ddf5f6feb1
+      reason: "Markdown-only identity fix (Python cells 21+32): the two scaling-experiment intros cited N=1000 as a tested size, but the Python benchmarks never run it (cell 22 mc_sizes=[8,50,100,500], cell 33 cpsat_sizes=[8,50,100,500]; committed output + interpretation cells 27/34 cap at N=500). Aligned the intros to the actual cap of 500. The C# twin genuinely runs N=1000 (cell 14 sizes include 1000, output N=1000 resolu), so 1000 is a real tested size in C#, not a phantom; csharp unchanged, no parallel defect. No re-exec, no output change."
   known_differences:
     - "Socle pedagogique commun : N-Reines comme CSP canonique — formulation (variables Reines, domaines 1..N, contraintes alldifferent lignes/colonnes/diagonales), resolution par plusieurs approches. Les deux twins couvrent Backtracking + Min-Conflicts (recherche locale) ; Python ajoute OR-Tools CP-SAT (3eme approche) + section comparative, C# ajoute l'enumeration exhaustive de toutes les solutions."
     - "Idiomes framework : Python = OR-Tools CP-SAT (CpModel, AddAllDifferent) + backtracking/min-conflicts from-scratch, 54 cellules (formulation CSP, 3 approches, comparaison, exemple guide). C# = pur System.* (System / System.Collections.Generic / System.Linq), 0 NuGet, 5 using, 28 cellules (backtracking + min-conflicts + enumeration from-scratch, presentation compacte)."

--- a/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: dad13c7fac88520807664b25ab6b95095f608677
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+      csharp_sha: dad13c7fac88520807664b25ab6b95095f608677
   known_differences:
     - "Socle pedagogique commun : Optimisation de portefeuille (convex opt cvxpy + GeneticSharp C#) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = cvxpy convex optimization + math.comb ; C# = GeneticSharp NuGet (GA)."

--- a/scripts/notebook_tools/twin_pairs.d/app-11-picross.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-11-picross.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-11b-Picross-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 0a90f51abb3cd11a411f066ab9c4e4a26828ffbd
-    csharp_sha: 1fc425b660a9f944860ed9c56971f1ae433c40e3
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 0a90f51abb3cd11a411f066ab9c4e4a26828ffbd
+      csharp_sha: 1fc425b660a9f944860ed9c56971f1ae433c40e3
   known_differences:
     - "Socle pedagogique commun : Picross / Nonogram (CSP : contraintes lignes/colonnes, OR-Tools) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = OR-Tools CP-SAT + matplotlib colors + search_helpers ; C# = BCL pure (System.*), 0 NuGet."

--- a/scripts/notebook_tools/twin_pairs.d/app-12-connectfour.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-12-connectfour.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: '2026-07-25'
-    by: po-2026
-    python_sha: 77bf96c05321f063ddad84755458050e16154329
-    reason: "Markdown-only identity fix (cell 33 Participants table): row named MCTS(1000)/1000 itérations, but the actual tournament uses MCTS(500) — cell 34 code `MCTS(500): make_mcts_ai(500)`, cell 36 output ranking MCTS(500), cell 39 interpretation MCTS(500). Aligned to MCTS(500)/500 itérations. No re-exec, no output change. C# twin untouched (different System.* BCL engine)."
-    csharp_sha: 540ef653a9252b9040e1eeff424c36c64c9bd82c
+  audits:
+    - date: '2026-07-25'
+      by: po-2026
+      python_sha: 77bf96c05321f063ddad84755458050e16154329
+      reason: "Markdown-only identity fix (cell 33 Participants table): row named MCTS(1000)/1000 itérations, but the actual tournament uses MCTS(500) — cell 34 code `MCTS(500): make_mcts_ai(500)`, cell 36 output ranking MCTS(500), cell 39 interpretation MCTS(500). Aligned to MCTS(500)/500 itérations. No re-exec, no output change. C# twin untouched (different System.* BCL engine)."
+      csharp_sha: 540ef653a9252b9040e1eeff424c36c64c9bd82c
   known_differences:
     - "Socle pedagogique commun : Puissance 4 / Connect Four (IA jeux combinatoires : minimax alpha-beta, MCTS, framework AIMA) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = numpy/matplotlib + framework AIMA (Game, namedtuple) + viz ; C# = System.* BCL pure, 0 NuGet, 29 cellules compactes."

--- a/scripts/notebook_tools/twin_pairs.d/app-13-tsp-metaheuristics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-13-tsp-metaheuristics.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13b-TSP-Metaheuristics-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 9b312c4b7666b477baa6bdb620194ad1d862b37b
-    csharp_sha: c1aa93b3ef1995aad5abe0f24e07b8fa3efff577
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 9b312c4b7666b477baa6bdb620194ad1d862b37b
+      csharp_sha: c1aa93b3ef1995aad5abe0f24e07b8fa3efff577
   known_differences:
     - "Socle pedagogique commun : TSP / Voyageur de commerce (metaheuristiques + OR-Tools routing) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = OR-Tools constraint_solver routing + permutations ; C# = BCL pure (System.*), 0 NuGet."

--- a/scripts/notebook_tools/twin_pairs.d/app-14-connectfour-adversarial.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-14-connectfour-adversarial.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 49ee6ce53f51c17c64db939771844e036310e778
-    csharp_sha: 2ec088ff8d391f7e8bc39e967730ca6c7c821b01
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 49ee6ce53f51c17c64db939771844e036310e778
+      csharp_sha: 2ec088ff8d391f7e8bc39e967730ca6c7c821b01
   known_differences:
     - "Socle pedagogique commun : Puissance 4 adversarial (variant Connect-4, IA jeux combinatoires) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = collections + typing (variant Connect-4 adversarial) ; C# = System.* BCL pure (System.Text), 0 NuGet."

--- a/scripts/notebook_tools/twin_pairs.d/app-16-crossword-csp.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-16-crossword-csp.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-03"
-    by: po-2026
-    python_sha: e24fce0a7a9e69057a9ceab84319f5f933a0f238
-    csharp_sha: 210ee14839bb9260ab115cabbc6cb5de4b897c23
+  audits:
+    - date: "2026-08-03"
+      by: po-2026
+      python_sha: e24fce0a7a9e69057a9ceab84319f5f933a0f238
+      csharp_sha: 210ee14839bb9260ab115cabbc6cb5de4b897c23
   known_differences:
     - "Socle pedagogique commun : Generateur de mots croises (CSP : slots, intersections, dictionnaire) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = OR-Tools CP-SAT + dataclass + viz grille + stats ; C# = BCL pure (System.Linq/Text), 0 NuGet, 24 cellules."

--- a/scripts/notebook_tools/twin_pairs.d/app-17-vrp-logistics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-17-vrp-logistics.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-17-VRP-Logistics.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-17b-VRP-Logistics-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 430afccc5a4826bee7f8d6f5a199bb3f2bb42c56
-    csharp_sha: 0e542d4ddc5b90bf79aecb9cf7d151223512ef92
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 430afccc5a4826bee7f8d6f5a199bb3f2bb42c56
+      csharp_sha: 0e542d4ddc5b90bf79aecb9cf7d151223512ef92
   known_differences:
     - "Socle pedagogique commun : VRP / Routing logistique (CSP + OR-Tools routing, distances) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = OR-Tools routing + math.sqrt distances ; C# = BCL pure (System.*), 0 NuGet."

--- a/scripts/notebook_tools/twin_pairs.d/app-18-hyperparametertuning.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-18-hyperparametertuning.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: f0a4de716cc4796c74319bdee52f7cbec093fa37
-    csharp_sha: b1153dbca5286ac4f8d140d63a067b3dcc1f211e
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: f0a4de716cc4796c74319bdee52f7cbec093fa37
+      csharp_sha: b1153dbca5286ac4f8d140d63a067b3dcc1f211e
   known_differences:
     - "Socle pedagogique commun : Hyperparameter tuning (scipy.optimize + Gaussian Process / Bayes opt) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = scipy.optimize + scipy.stats norm + sklearn ; C# = BCL pure (System.*), 0 NuGet."

--- a/scripts/notebook_tools/twin_pairs.d/app-19-proceduralgeneration-wfc.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-19-proceduralgeneration-wfc.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: bda7564c053e78077d109fd86f2aac543ddfe883
-    csharp_sha: 7422b47e09f277958bd16c05b60e45fbda93fdd1
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: bda7564c053e78077d109fd86f2aac543ddfe883
+      csharp_sha: 7422b47e09f277958bd16c05b60e45fbda93fdd1
   known_differences:
     - "Socle pedagogique commun : Generation procedurale WFC / Wave Function Collapse (CSP + ipywidgets interactif) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = WFC + ipywidgets interactif + matplotlib GridSpec ; C# = BCL pure (System.Text), 0 NuGet."

--- a/scripts/notebook_tools/twin_pairs.d/app-2-graphcoloring.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-2-graphcoloring.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-2b-GraphColoring-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 20f639cb0363ff592acc1c04a735f71f2eebaa63
-    csharp_sha: 6d9767a24d2c2d78165b68cd9dab09872c1a143e
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 20f639cb0363ff592acc1c04a735f71f2eebaa63
+      csharp_sha: 6d9767a24d2c2d78165b68cd9dab09872c1a143e
   known_differences:
     - "Socle pedagogique commun : coloration de graphes comme CSP canonique -- formulation (variable couleur par sommet, domaines 1..k, contraintes != sur les aretes), heuristiques (Greedy, DSATUR, Welsh-Powell) + calcul exact du nombre chromatique chi. Cas d'etude partagees : graphe de Petersen, dodecaedre, graphes aleatoires G(n,p) (benchmark Erdos-Renyi)."
     - "Divergence sur la methode EXACTE (chi) : Python utilise OR-Tools CP-SAT (ortools.sat.python.cp_model.CpModel + solver, solveur industriel SAT-based, SOTA) pour le chi optimal ; le C# implemente un backtracking from-scratch (CanColor / k-coloriable, 0 dependance externe, 0 NuGet). Meme resultat (chi exact), deux paradigmes : solveur SOTA cote Python vs implementation pedagogique a la main cote C#."

--- a/scripts/notebook_tools/twin_pairs.d/app-20-sudokubenchmark.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-20-sudokubenchmark.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 5a773fde57018c807f03804ac5c313172b9f9a19
-    csharp_sha: 0f2dbea5dad14954250d2262b6e5baa3ba60df6a
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 5a773fde57018c807f03804ac5c313172b9f9a19
+      csharp_sha: 0f2dbea5dad14954250d2262b6e5baa3ba60df6a
   known_differences:
     - "Socle pedagogique commun : Benchmark Sudoku (comparaison solveurs, timing) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = typing + random + time (from-scratch benchmark) ; C# = System.Diagnostics (Stopwatch) BCL pure."

--- a/scripts/notebook_tools/twin_pairs.d/app-3-nursescheduling.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-3-nursescheduling.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-3b-NurseScheduling-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 3ac0cea2b314a0dadb0429f451a8a3a458c9a97e
-    csharp_sha: 52f7b50aa5d1f9553673ecce518df546dd4c1f93
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 3ac0cea2b314a0dadb0429f451a8a3a458c9a97e
+      csharp_sha: 52f7b50aa5d1f9553673ecce518df546dd4c1f93
   known_differences:
     - "Socle pedagogique commun : Planning d'infirmieres (CSP : contraintes horaires, preferences, couverture) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = OR-Tools CP-SAT + matplotlib gantt + search_helpers ; C# = BCL pure (System.*), 0 NuGet."

--- a/scripts/notebook_tools/twin_pairs.d/app-4-jobshopscheduling.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-4-jobshopscheduling.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-4b-JobShopScheduling-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 5cf5d87d0fe48187eb90f1fb29a6ec22e21acf4e
-    csharp_sha: e16eeb2276ddc4c9edb0d8c4b7505691d88f7e35
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 5cf5d87d0fe48187eb90f1fb29a6ec22e21acf4e
+      csharp_sha: e16eeb2276ddc4c9edb0d8c4b7505691d88f7e35
   known_differences:
     - "Socle pedagogique commun : Job-shop scheduling (CSP : ordonnancement machines, makespan minimal) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = OR-Tools CP-SAT + deepcopy/state + search_helpers ; C# = BCL pure (System.*), 0 NuGet."

--- a/scripts/notebook_tools/twin_pairs.d/app-5-timetabling.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-5-timetabling.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: a80035cb146ea49ef5901ddb940cf573e600017f
-    csharp_sha: 1df664fbb228832fec6d05c12efe390465bd65c0
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: a80035cb146ea49ef5901ddb940cf573e600017f
+      csharp_sha: 1df664fbb228832fec6d05c12efe390465bd65c0
   known_differences:
     - "Socle pedagogique commun : Emploi du temps / Timetabling (CSP : creneaux, salles, conflits) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = OR-Tools CP-SAT + itertools combinations + search_helpers ; C# = BCL pure (System.*), 0 NuGet."

--- a/scripts/notebook_tools/twin_pairs.d/app-6-minesweeper.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-6-minesweeper.yaml
@@ -3,9 +3,9 @@
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    python_sha: 20ead2ac4fe55a2ec0d7dc3ad3434113aa3b8bab
-    csharp_sha: 7435be2a68253f66e9e4a6639efc2a44d4aab4bd
+  audits:
+    - python_sha: 20ead2ac4fe55a2ec0d7dc3ad3434113aa3b8bab
+      csharp_sha: 7435be2a68253f66e9e4a6639efc2a44d4aab4bd
   known_differences:
     - "Socle pedagogique commun : Demineur (CSP : contraintes sommes exactes, library python-constraint) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = library python-constraint (ExactSum) + OR-Tools ; C# = BCL pure (System.*), 0 NuGet."

--- a/scripts/notebook_tools/twin_pairs.d/app-7-wordle.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-7-wordle.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: '2026-07-31'
-    by: po-2024
-    python_sha: 87a7299b929d77d103c6264c39e251e26544decf
-    csharp_sha: 2c8194226c9eabf6906fc907455aae6190dc571b
+  audits:
+    - date: '2026-07-31'
+      by: po-2024
+      python_sha: 87a7299b929d77d103c6264c39e251e26544decf
+      csharp_sha: 2c8194226c9eabf6906fc907455aae6190dc571b
   known_differences:
     - "Socle pedagogique commun : Wordle (logique deductive + feedback, theorie de l'information) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = Counter/typing + matplotlib viz ; C# = System.IO + Microsoft.DotNet.Interactive formatting."

--- a/scripts/notebook_tools/twin_pairs.d/app-8-minizinc.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-8-minizinc.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 5a3556edb46ca5f2be12979620d2f723e3a5b364
-    csharp_sha: 2bce8a6cdcbc8659b9287c737f49321a98a0ac90
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 5a3556edb46ca5f2be12979620d2f723e3a5b364
+      csharp_sha: 2bce8a6cdcbc8659b9287c737f49321a98a0ac90
   known_differences:
     - "Socle pedagogique commun : MiniZinc (modeling language CSP, OR-Tools CP-SAT cross-solve) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = minizinc + OR-Tools CP-SAT ; C# = Google.OrTools.Sat NuGet (C# binding du meme solver OR-Tools)."

--- a/scripts/notebook_tools/twin_pairs.d/app-9-edgedetection.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-9-edgedetection.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 5aa7d42e6e941a86dfcedbb3c9aded569d32d2b4
-    csharp_sha: a2cc061a4109cfd9aef63b92fd16d152f5430a73
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 5aa7d42e6e941a86dfcedbb3c9aded569d32d2b4
+      csharp_sha: a2cc061a4109cfd9aef63b92fd16d152f5430a73
   known_differences:
     - "Socle pedagogique commun : Detection de contours / Edge detection (metaheuristique DEAP + scipy sobel) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = DEAP metaheuristique + scipy.signal/sobel + matplotlib ; C# = System.Net.Http + SkiaSharp (traitement bitmap)."

--- a/scripts/notebook_tools/twin_pairs.d/csp-1-fundamentals.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-1-fundamentals.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: 7013d56a565f9243bbf1b7d7e49529c4048bba24
-    csharp_sha: aa7c1005e14400fc680e55691f69da5828d3a46e
+  audits:
+    - date: "2026-07-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 7013d56a565f9243bbf1b7d7e49529c4048bba24
+      csharp_sha: aa7c1005e14400fc680e55691f69da5828d3a46e
   known_differences:
     - "Socle pedagogique commun (parity semantic) : les deux cotes implementent une classe CSP generique + backtracking simple + heuristique MRV + value-ordering LCV, depuis zero (pas de lib externe pour le coeur). Cote Python : classe CSP dict/list pure Python. Cote C# : classe CSP generique C# (Dictionary/List) qui reflete la Python."
     - "Extension solveur ASYMETRIQUE : le cote C# ajoute Choco-solver 4.10.17 (Java solver via IKVM 8.15.0, recette #4711) avec des cellules (coloration Australie par Choco, enumeration de TOUTES les solutions, 8-Reines par Choco) qui n'ont PAS d'equivalent direct cote Python. Le cote Python reste pur from-scratch sur tout le notebook."

--- a/scripts/notebook_tools/twin_pairs.d/csp-2-consistency.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-2-consistency.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: e4bcb98f9b804b32f5116fdb79e253b7488cd030
-    csharp_sha: e8fd63183edffb0de5cb32c437c1b4bbcdc8b688
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: e4bcb98f9b804b32f5116fdb79e253b7488cd030
+      csharp_sha: e8fd63183edffb0de5cb32c437c1b4bbcdc8b688
   known_differences:
     - "Socle pedagogique commun : node consistency + AC-3 + Forward Checking + MAC, implementes from-scratch des deux cotes."
     - "Cote C# : extension Choco-solver 4.10.17 via IKVM 8.15.0 (memes recettes infrastructure que CSP-1) pour comparer les algorithmes custom avec la propagation native de Choco (variable x, contrainte arithmetique, model.getSolver().propagate())."

--- a/scripts/notebook_tools/twin_pairs.d/csp-3-advanced.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-3-advanced.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2023:CoursIA
-    python_sha: ea4369680e7b982cb3a6efc2d73b060e4218a4df
-    csharp_sha: 712df1e071c744065601cfcfd71b86da7458c23f
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2023:CoursIA
+      python_sha: ea4369680e7b982cb3a6efc2d73b060e4218a4df
+      csharp_sha: 712df1e071c744065601cfcfd71b86da7458c23f
   known_differences:
     - "Socle pedagogique commun : global constraints (all_different, sum, element) + backtracking avec propagation globale + symetrie breaking (lexicographique)."
     - "Cote C# : Choco-solver (memes recettes infrastructure) - global constraints implementes en Python pur (classe AllDifferent via matching de Hall), cote C# delegue a Choco.IntVar+Constraint via IKVM."

--- a/scripts/notebook_tools/twin_pairs.d/csp-4-scheduling.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-4-scheduling.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 20b459c9021a688c4bb67adc3bbf36c273d6445d
-    csharp_sha: 1453d9a535aaad7d4c4f8d72b9fdff44c9dbbba3
-    reason: "c.1126 #8052 C# c13/15/16/17 exercise+verdict cell-ref off-by-2 (cellule 6/8/10 -> 8/10/12 after OR-Tools config cells inserted); PY twin clean (0 cellule refs)"
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 20b459c9021a688c4bb67adc3bbf36c273d6445d
+      csharp_sha: 1453d9a535aaad7d4c4f8d72b9fdff44c9dbbba3
+      reason: "c.1126 #8052 C# c13/15/16/17 exercise+verdict cell-ref off-by-2 (cellule 6/8/10 -> 8/10/12 after OR-Tools config cells inserted); PY twin clean (0 cellule refs)"
   known_differences:
     - "Socle pedagogique commun : interval scheduling + cumulative constraints + disjunctive (no-overlap) + precedence constraints."
     - "Cote C# : Choco-solver via IKVM (Cumulative, Disjunctive, precedence). Cote Python = from-scratch (classe Task avec start/end/duration, propagation par difference constraints)."

--- a/scripts/notebook_tools/twin_pairs.d/csp-5-optimization.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-5-optimization.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 4c6ddd792c6842627cb4029718d378b3b2337381
-    csharp_sha: cd0d73e8fee0fe5c17b2a5df10554a32f2d9498e
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 4c6ddd792c6842627cb4029718d378b3b2337381
+      csharp_sha: cd0d73e8fee0fe5c17b2a5df10554a32f2d9498e
   known_differences:
     - "Socle pedagogique commun (parity semantic) : les deux cotes couvrent les 4 problemes classiques d'optimisation combinatoire -- Bin Packing (BPP), Knapsack 0/1, Cutting Stock, Optimisation de Portefeuille -- avec la meme progression pedagogique (formulation variables/constraints/objectif -> exemple resolu -> interpretation). Meme theorie sous-jacente (minimisation bins, maximisation valeur sous capacite, patterns de coupe optimaux, allocation lineaire sous contraintes de risque)."
     - "Idiomes framework : Python = **OR-Tools CP-SAT** (`ortools.sat.python.cp_model`) + `numpy` + `matplotlib` (visualisation du bin packing, benchmark de passage a l'echelle). C# = **Choco-solver via IKVM** (`org.chocosolver.solver.dll`, recette #4711) sur runtime .NET -- le solveur Java est invoque depuis C# via l'assembleur IKVM."

--- a/scripts/notebook_tools/twin_pairs.d/csp-6-hybridization.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-6-hybridization.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2024:CoursIA-2
-    python_sha: fd2931b15681647be5458c009420315234cba14b
-    csharp_sha: d35a6e6262a3a2ac3e8837315c5b365d5ec95aff
-    reason: "c.1127 #8052 Python c34 code mislabeled Exercice 3->Exemple resolu (sister guide-cells c26/30/38 convention) + c37 anchor Exercice 1->1b (PY exercises are 1b/2b/3b/4b, no Exercice 1); C# twin preserved"
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2024:CoursIA-2
+      python_sha: fd2931b15681647be5458c009420315234cba14b
+      csharp_sha: d35a6e6262a3a2ac3e8837315c5b365d5ec95aff
+      reason: "c.1127 #8052 Python c34 code mislabeled Exercice 3->Exemple resolu (sister guide-cells c26/30/38 convention) + c37 anchor Exercice 1->1b (PY exercises are 1b/2b/3b/4b, no Exercice 1); C# twin preserved"
   known_differences:
     - "Socle pedagogique commun : approches hybrides modernes en CP -- Lazy Clause Generation (LCG), architecture CP-SAT (CP + SAT + CDCL), hybridation CP + ML (prediction de faisabilite), integration LLM + CSP."
     - "Cas etudies : N-Reines (LCG via CP-SAT), Job-Shop Scheduling (exploration des parametres CP-SAT : DEFAULT / FIXED_SEARCH / PORTFOLIO), generation d'instances CSP aleatoires + prediction de faisabilite par features (n_vars, n_constraints, density)."

--- a/scripts/notebook_tools/twin_pairs.d/csp-7-soft.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-7-soft.yaml
@@ -3,9 +3,9 @@
   python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-7-Soft.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-7-Soft-Csharp.ipynb
   parity_level: surface
-  last_audit:
-    python_sha: 1a0e83fca696c8c9b301b8c387d4ea5e8383a80e
-    csharp_sha: 48fa33f84a0b73e3afd33cf0055a87363befb084
+  audits:
+    - python_sha: 1a0e83fca696c8c9b301b8c387d4ea5e8383a80e
+      csharp_sha: 48fa33f84a0b73e3afd33cf0055a87363befb084
   known_differences:
     - "AVERTISSEMENT DE PERIMETRE : le jumeau C# est un twin PARTIEL. parity_level=surface (pas semantic) car le C# (24 cellules, 11 code) couvre UNIQUEMENT le Weighted CSP (min cout de violation), alors que le Python (53 cellules, 20 code) couvre 4 paradigmes : Semiring-based CSP (cadre algebrique), Fuzzy CSP, Weighted CSP, plus integration OR-Tools CP-SAT. Les sections Python Semiring et Fuzzy sont entierement absentes du C#."
     - "Solver SOTA distinct : Python = OR-Tools CP-SAT (moteur SAT-based, ortools.sat.python.cp_model) ; C# = Choco-solver 4.10.17 via IKVM 8.15.0 (moteur Java, dll vendoree org.chocosolver.solver). Deux moteurs SOTA reels, idiomes et contraintes natives differentes."

--- a/scripts/notebook_tools/twin_pairs.d/csp-8-temporal.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-8-temporal.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2024:CoursIA-2
-    python_sha: e18d331835a9dea4aeb55447bd0b4c2c3c210925
-    reason: "c.1124 rebase c.1241: Python c7 Allen composition-table 270->169 (13x13=169); C# twin clean"
-    csharp_sha: 3859f46c9ec9b09dbbc50e7fc344d8844f82796b
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2024:CoursIA-2
+      python_sha: e18d331835a9dea4aeb55447bd0b4c2c3c210925
+      reason: "c.1124 rebase c.1241: Python c7 Allen composition-table 270->169 (13x13=169); C# twin clean"
+      csharp_sha: 3859f46c9ec9b09dbbc50e7fc344d8844f82796b
   known_differences:
     - "Socle commun : algebre d'intervalle d'Allen (13 relations), STP (Simple Temporal Problem) avec Floyd-Warshall, TCSP (Temporal CSP a intervalles multiples), application planification de reunion. Couverture conceptuelle COMPLETE des deux cotes (le twin le plus proche de la famille CSP au sens cellule-a-cellule : 42 vs 41 cellules, 17 vs 16 code)."
     - "Meme famille de solveur SOTA, bindings natifs : Python = ortools.sat.cp_model ; C# = Google.OrTools.Sat. Les deux cotes invoquent OR-Tools CP-SAT (moteur SAT-based identique) -- parite de solveur confirmee, pas de divergence de machinerie."

--- a/scripts/notebook_tools/twin_pairs.d/csp-9-distributed.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-9-distributed.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2024:CoursIA-2
-    python_sha: adee0d476742b82cc2efb931e778f4fba271be35
-    reason: "c.1125 #8052 Python c44 stale pre-rename self-label Search-18->CSP-9-Distributed (C# twin already correct); print-literal src+out atomic"
-    csharp_sha: 8324939a7b714bb232440bac11de6c84c0981a70
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2024:CoursIA-2
+      python_sha: adee0d476742b82cc2efb931e778f4fba271be35
+      reason: "c.1125 #8052 Python c44 stale pre-rename self-label Search-18->CSP-9-Distributed (C# twin already correct); print-literal src+out atomic"
+      csharp_sha: 8324939a7b714bb232440bac11de6c84c0981a70
   known_differences:
     - "Socle commun : CSP distribue (DisCSP) -- formalisation, ABT (Asynchronous Backtracking, Yokoo 1992), AWC (Asynchronous Weak-Commitment, Yokoo 1995), Privacy-Preserving CSP, application multi-hopital, benchmark synthetique ABT vs AWC. Le C# se declare explicitement 'binome .NET du CSP-9-Distributed.ipynb' (H1) et cite Yokoo 1992."
     - "PARITE CELLULAIRE EXACTE : 47 cellules des deux cotes (19 code, 28 markdown) -- le twin le plus proche cellule-a-cellule des 5 residuels. Sections logiques 1-7 identiques ; le C# concentre parfois plusieurs H2 logiques dans une meme cellule markdown (surcomptage brut d'en-tetes a 34) mais la couverture structurelle reelle matche le Python."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-10-forwardinduction-spe.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-10-forwardinduction-spe.yaml
@@ -3,9 +3,9 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    python_sha: 71947cbdecde8ce79b25ec916fd4053c19d6365c
-    csharp_sha: 111bf7e843ba260a52ff4bb8abb585e1b34067d6
+  audits:
+    - python_sha: 71947cbdecde8ce79b25ec916fd4053c19d6365c
+      csharp_sha: 111bf7e843ba260a52ff4bb8abb585e1b34067d6
   known_differences:
     - "Socle pedagogique commun : les raffinements d'equilibre au-dela du SPE (Selten 1965) -- sous-jeux et equilibre parfait, menaces et promesses credibles, induction avant (forward induction), perfection en mains tremblantes (trembling-hand perfection, Selten 1975), application canonique du jeu du « Burn Money » (signal costly), comparaison des raffinements. Distinct du GT-9 (induction arriere + paradoxes) : le GT-10 porte sur les RAFFINEMENTS de la notion d'equilibre (forward induction, trembling-hand), pas sur l'algorithme de resolution."
     - "Idiomes framework : Python = `matplotlib` (patches `Ellipse` pour rendre les ensembles d'information / infosets sur l'arbre de jeu) + `itertools` + `@dataclass`. C# = **BCL .NET pur 0 NuGet** (modele d'arbre + sous-jeux + raffinements from-scratch, sortie console)."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-12-reputationgames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-12-reputationgames.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2024:CoursIA-2
-    python_sha: f076193833b42af315e24fa5c0c599582d348d2d
-    csharp_sha: 4096d74c1b63d5ab1c43a8cdd0e03630934ce1de
-    reason: "rebaseline python apres fix cross-reference cellule 2 (#8052) : la section 1.2 disait 'Le paradoxe de la chaine de magasins (Notebook 8)' mais le paradoxe est couvert dans le Notebook 9 (BackwardInduction section 4 + code create_chain_store_game + ancres Selten 1978 / Rosenthal 1981), pas le Notebook 8 (Combinatorial Games). Fix (Notebook 8)->(Notebook 9). Python-only, csharp_sha unchanged, parite semantique preservee."
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2024:CoursIA-2
+      python_sha: f076193833b42af315e24fa5c0c599582d348d2d
+      csharp_sha: 4096d74c1b63d5ab1c43a8cdd0e03630934ce1de
+      reason: "rebaseline python apres fix cross-reference cellule 2 (#8052) : la section 1.2 disait 'Le paradoxe de la chaine de magasins (Notebook 8)' mais le paradoxe est couvert dans le Notebook 9 (BackwardInduction section 4 + code create_chain_store_game + ancres Selten 1978 / Rosenthal 1981), pas le Notebook 8 (Combinatorial Games). Fix (Notebook 8)->(Notebook 9). Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:
     - "Socle pedagogique commun : jeux de reputation dans les interactions repetees sous information incomplete -- pourquoi la reputation change tout, cheap talk (communication non couteuse), modele de Kreps-Wilson (reputation du « tough incumbent » dans la chaine de magasins), Gang of Four / KMRW (cooperation emergente dans le dilemme du prisonnier fini), equilibre bayesien parfait (PBE). Suit naturellement le GT-11 (jeux bayesiens) en appliquant le BNE aux dynamiques de reputation."
     - "Idiomes framework : Python = `scipy.optimize.fsolve` (resolution des conditions d'equilibre Kreps-Wilson) + `matplotlib` (courbes de gain / trajectoires de reputation) + `@dataclass`. C# = **BCL .NET pur 0 NuGet tiers** avec une **simulation numerique Monte-Carlo from-scratch** (Random + System.Math, etude de l'impact du parametre epsilon sur les gains)."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-13-imperfectinfo-cfr.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-13-imperfectinfo-cfr.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 07b46a9434ca9cc29a312c9727057d5d212f4183
-    csharp_sha: 1d6da069eae78cde4f5b345be9b1e04193e90ab8
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 07b46a9434ca9cc29a312c9727057d5d212f4183
+      csharp_sha: 1d6da069eae78cde4f5b345be9b1e04193e90ab8
   known_differences:
     - "Socle pedagogique commun : jeux a information imparfaite, Kuhn Poker (Kuhn 1950/1953) comme jeu de reference, regret matching (Hannan), CFR vanilla (Zinkevich et al. 2007) avec recursion contrefactuelle, variante CFR+ (Tammelin 2014), convergence de la strategie moyenne vers la valeur du jeu / equilibre de Nash."
     - "Idiomes framework : Python = `numpy` + `matplotlib` (courbes de convergence) + OpenSpiel (cfr/CFR+/Linear CFR, benchmark Leduc Poker, comparaisons a l'echelle) + MCCFR external sampling. C# = pur `System.*` (Linq, Collections.Generic, `#nullable enable`), 0 NuGet, CFR/CFR+/RegretMatcher from-scratch, visualisation ASCII (valeur du jeu vs iterations)."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-14-differentialgames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-14-differentialgames.yaml
@@ -3,10 +3,10 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    python_sha: 924092dad22d0d395af77067e636d92d773484ec
-    csharp_sha: 88e961fdf00ed0525c1918f9ac71132dcbbd8056
+  audits:
+    - date: "2026-08-04"
+      python_sha: 924092dad22d0d395af77067e636d92d773484ec
+      csharp_sha: 88e961fdf00ed0525c1918f9ac71132dcbbd8056
   known_differences:
     - "Socle pedagogique commun : jeux differentiels et jeux dynamiques, equilibres de Stackelberg (von Stackelberg 1934) leader-follower, duopole a demande lineaire, comparaison avec Cournot, decisions dynamiques et leadership strategique."
     - "Idiomes framework : Python = `scipy.integrate.odeint` (integration ODE) + `scipy.optimize.minimize` + `numpy` + `matplotlib`. C# = BCL .NET 9 pur (`System.*`, 0 NuGet, 0 numpy, 0 scipy), integrateur RK4 from-scratch (section 'Pourquoi RK4 et pas Euler ?') + formes analytiques Stackelberg/Cournot."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-15-cooperativegames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-15-cooperativegames.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 9e82048c4ad2393af7e012c036ce714b590380e8
-    csharp_sha: 7d0fca43674a5478f7a96de1af75ffe165005a2f
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 9e82048c4ad2393af7e012c036ce714b590380e8
+      csharp_sha: 7d0fca43674a5478f7a96de1af75ffe165005a2f
   known_differences:
     - "Socle pedagogique commun : jeux cooperatifs a utilite transferable, fonction caracteristique et coalitions, valeur de Shapley (Shapley 1953) et ses axiomes (efficacite, symetrie, joueur nul, additivite), glove game (jeu des gants) comme exemple canonique."
     - "Idiomes framework : Python = `numpy` + `matplotlib` + module local `cooperative_games` + `itertools` (enumeration des coalitions/permutations). C# = BCL .NET 9 pur (`System.Linq`, `System.Collections.Generic`, 0 NuGet), calcul de Shapley from-scratch via permutations Linq."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-15c-cooperativegames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-15c-cooperativegames.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 6a0f9876a9e7b2563a4a451da57f5722408b5245
-    csharp_sha: 2b5ecf27a189d00765e6f80edf7c48eb10372cfe
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 6a0f9876a9e7b2563a4a451da57f5722408b5245
+      csharp_sha: 2b5ecf27a189d00765e6f80edf7c48eb10372cfe
   known_differences:
     - "Socle pedagogique commun : jeux cooperatifs a utilite transferable (TU) -- valeur de Shapley (formule axiomatique, calcul sur permutations), le core (stabilite, imputations), coalitions. Meme concept mathematique (Shapley value phi_i = somme sur permutations, core comme polytope des imputations stables), meme cas d'application (repartition de gains cooperatifs). Les deux couvrent Shapley, core, Coalition."
     - "Divergence d'implementation : le Python (numpy + scipy + matplotlib, 18 cellules code) calcule les valeurs de Shapley et visualise le core (polytope, extremites) ; le C# (pur System.* stdlib, 0 NuGet, 15 cellules code) implemente le calcul de Shapley (iteration sur permutations) et la verification d'appartenance au core sans libs numeriques. Meme theoreme, deux angles : numerique+visualisation cote Python vs implementation constructive cote C#."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-16-mechanismdesign.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-16-mechanismdesign.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2024:CoursIA-2
-    python_sha: d81bda661b8e79970e4c818eb4b0a8904b5405d1
-    csharp_sha: fd5fd04b331a2cbef35868a55e5e25436493b00f
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2024:CoursIA-2
+      python_sha: d81bda661b8e79970e4c818eb4b0a8904b5405d1
+      csharp_sha: fd5fd04b331a2cbef35868a55e5e25436493b00f
   known_differences:
     - "Socle pedagogique commun : theorie des mecanismes et principe de revelation, encheres premier et second prix, Vickrey 1961 (sincerite de l'enchere au second prix), mecanisme VCG (Vickrey-Clarke-Groves) et regle de Clarke."
     - "Idiomes framework : Python = `numpy` + `matplotlib` + `abc`/`itertools` (classes abstraites de mecanismes). C# = BCL .NET 9 pur (`System.Linq`, `System.Text`, 0 NuGet), encheres et VCG from-scratch avec lecture-interpreter des resultats."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-17-multiagent-rl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-17-multiagent-rl.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: d4ac08ac2355bc71628bbaab8934d54e94b010bd
-    csharp_sha: 45c01bd69738c1140eba9b6702718861db90c816
-    reason: "rebaseline python apres fix forward-ref cellule 37 resume (#8052) : la ligne disait 'Notebooks suivants : Serie Lean 4 pour les formalisations (Notebooks 16-19)' mais la serie compte 17 notebooks (pas de 18/19, cf #9149 GT-1), 'Serie Lean 4' est un faux label (Lean = notebooks b-suffixes 2b/4b/5b/8b/11b/15b), et 'suivants' est faux car GT-17 est le dernier (#17). Fix -> pointe vers la serie RL/ (README L136 'fait le pont avec l'apprentissage par renforcement') + liste les vrais notebooks Lean. Python-only, csharp_sha unchanged, parite semantique preservee."
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: d4ac08ac2355bc71628bbaab8934d54e94b010bd
+      csharp_sha: 45c01bd69738c1140eba9b6702718861db90c816
+      reason: "rebaseline python apres fix forward-ref cellule 37 resume (#8052) : la ligne disait 'Notebooks suivants : Serie Lean 4 pour les formalisations (Notebooks 16-19)' mais la serie compte 17 notebooks (pas de 18/19, cf #9149 GT-1), 'Serie Lean 4' est un faux label (Lean = notebooks b-suffixes 2b/4b/5b/8b/11b/15b), et 'suivants' est faux car GT-17 est le dernier (#17). Fix -> pointe vers la serie RL/ (README L136 'fait le pont avec l'apprentissage par renforcement') + liste les vrais notebooks Lean. Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:
     - "Socle pedagogique commun : apprentissage par renforcement multi-agent (MARL), self-play et auto-competition, fictitious play (Brown 1951), exploitabilite / distance a Nash, Neural Fictitious Self-Play (NFSP, Heinrich & Silver 2016), PSRO (Policy-Space Response Oracles, Lanctot et al. 2017)."
     - "Idiomes framework : Python = `numpy` + `matplotlib` + `pyspiel` (OpenSpiel) + `tqdm` (integration framework MARL a l'echelle). C# = BCL .NET 9 pur (`System.Linq`, 0 NuGet), fictitious play / NFSP table-based / PSRO from-scratch."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-02"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 183d8f84edcf34e6018de795ebc2540dfa3f74d0
-    csharp_sha: 193e39383c74f3ef0de15ba7c7d2a0db8cb2109c
+  audits:
+    - date: "2026-08-02"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 183d8f84edcf34e6018de795ebc2540dfa3f74d0
+      csharp_sha: 193e39383c74f3ef0de15ba7c7d2a0db8cb2109c
   known_differences:
     - "Socle pedagogique commun : jeux sous forme normale (matrices de gains 2 joueurs), strategies pures, dominance, equilibres de Nash purs sur 5 jeux canoniques (Prisonnier, Stag Hunt, BoS, Poulet, Matching Pennies)."
     - "Idiomes framework : Python = `numpy` + `nashpy` (lib mature, Game(A,B), support_enumeration). C# = pur `System.*` (Linq, Collections), classes from-scratch (matrices A/B/Payoffs, pas de lib tiers)."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-3-topology2x2.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-3-topology2x2.yaml
@@ -3,10 +3,10 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    python_sha: ac9b8aee4ae0785bfefe6c10f64cfb3e13a38c54
-    csharp_sha: b09da0acd68389084b6ff1fac9c565169a85ab06
-    reason: "c.1129 #8052 Python c40 SINGLE_NASH ~75%->50% (family vs 1-nash count confusion; 288/576=50%) + DOMINANT subcategory->distinct family (144/25%) + c51 un seul swap->deux swaps (c13/c23: PD->Stag Hunt=PD->Chicken=2); C# twin preserved"
+  audits:
+    - python_sha: ac9b8aee4ae0785bfefe6c10f64cfb3e13a38c54
+      csharp_sha: b09da0acd68389084b6ff1fac9c565169a85ab06
+      reason: "c.1129 #8052 Python c40 SINGLE_NASH ~75%->50% (family vs 1-nash count confusion; 288/576=50%) + DOMINANT subcategory->distinct family (144/25%) + c51 un seul swap->deux swaps (c13/c23: PD->Stag Hunt=PD->Chicken=2); C# twin preserved"
   known_differences:
     - "Socle pedagogique commun : representation ordinale des jeux 2x2 (4 rangs par joueur), classification topologique des 5 archetypes strategiques (Prisonnier, Stag Hunt, BoS, Poulet, Matching Pennies) sur le carre des preferences ordinales."
     - "Idiomes framework : Python = `numpy` + `matplotlib` + `networkx` + classe `OrdinalGame` from-scratch (dataclass + equals). C# = `System.*` (Collections.Generic, Linq) + classe `OrdinalGame` from-scratch (IEquatable<OrdinalGame>)."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: c74eabd61cd743f4247dd1e29cc9a4f813859e74
-    reason: "Markdown-only cross-file count refresh (cell 33): the companion Lean notebook GT-4b-Lean-NashExistence grew from 38 to 44 cells since the cite was written (verified firsthand by parsing origin/main: ...GameTheory-4b-Lean-NashExistence.ipynb -> 44 cells). No re-exec, no output change. C# twin untouched (different from-scratch engine, no Lean refs)."
-    csharp_sha: 1c90b37ab7d6098dcf07d5d141875b752b315afd
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: c74eabd61cd743f4247dd1e29cc9a4f813859e74
+      reason: "Markdown-only cross-file count refresh (cell 33): the companion Lean notebook GT-4b-Lean-NashExistence grew from 38 to 44 cells since the cite was written (verified firsthand by parsing origin/main: ...GameTheory-4b-Lean-NashExistence.ipynb -> 44 cells). No re-exec, no output change. C# twin untouched (different from-scratch engine, no Lean refs)."
+      csharp_sha: 1c90b37ab7d6098dcf07d5d141875b752b315afd
   known_differences:
     - "Socle pedagogique commun : calcul des equilibres de Nash (purs + mixtes), meilleure reponse, support des equilibres mixtes."
     - "Idiomes framework : Python = `nashpy` + `scipy.optimize.linprog` (resolution des mixtes via programmation lineaire). C# = `BestResponseRow` from-scratch (enumeration des meilleures reponses en pur Linq, pas de solveur LP externe)."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-4c-nashexistence.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-4c-nashexistence.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: c6db511801c503cacd18a0af26ffe0182d0b70f8
-    csharp_sha: ca1c73ac33c1ffbec1f99ba3a60da33bce3cfea1
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: c6db511801c503cacd18a0af26ffe0182d0b70f8
+      csharp_sha: ca1c73ac33c1ffbec1f99ba3a60da33bce3cfea1
   known_differences:
     - "Socle pedagogique commun : existence d'un equilibre de Nash (theoreme de point fixe de Brouwer / Kakutani), structure de jeu et conditions d'existence. Meme concept mathematique (equilibre, point fixe, convexite), meme cas d'application (jeux strategiques, illustration de l'existence). Les deux couvrent le theoreme de Nash."
     - "Divergence d'implementation : le Python (numpy + matplotlib, 15 cellules code) calcule et visualise numeriquement les equilibres (support enumeration / approche numerique + tracé du best-response correspondence) ; le C# (pur System.* stdlib, 0 NuGet, 10 cellules code) demontre l'existence de maniere constructive/algebrique (sans solveur numerique externe). Meme theoreme, deux angles : numerique+visualisation cote Python vs construction algebrique cote C#."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-5-zerosum-minimax.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-5-zerosum-minimax.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-5-ZeroSum-Minimax.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-5-ZeroSum-Minimax-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: db8ae4743bf4e902074bd3e65e27f38e46305d30
-    csharp_sha: 94f0d6b6640128cda025b0988435209110697c9e
+  audits:
+    - date: "2026-07-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: db8ae4743bf4e902074bd3e65e27f38e46305d30
+      csharp_sha: 94f0d6b6640128cda025b0988435209110697c9e
   known_differences:
     - "Socle pedagogique commun : jeux a somme nulle, theoreme minimax (valeur du jeu v), strategies mixtes optimales sigma/tau via programmation lineaire."
     - "Idiomes framework : Python = `scipy.optimize.linprog` (solveur LP mature pour le minimax). C# = **Simplexe from-scratch** `SimplexMax` (methode de Dantzig + regle de Bland anti-cyclage) + `SolveMatrixGame` qui reduit le jeu matriciel a un LP et lit sigma dans les variables duales."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-6-evolutiontrust.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-6-evolutiontrust.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: db8f5ea35f0f891863bcf212bc112b031cafa494
-    csharp_sha: b1352e95a88555910b1b7bcfb90feb12891dc752
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: db8f5ea35f0f891863bcf212bc112b031cafa494
+      csharp_sha: b1352e95a88555910b1b7bcfb90feb12891dc752
   known_differences:
     - "Socle pedagogique commun : Dilemme du Prisonnier Itere (IPD), tournoi d'Axelrod, strategies classiques (TitForTat, Pavlov, Generous TitForTat), dynamique evolutive (processus de Moran), emergence de la cooperation."
     - "Idiomes framework : Python = `numpy` + `matplotlib` + `matplotlib.animation` (viz dynamique du tournoi round-robin + courbes de Moran). C# = pur `System.*` (Collections.Generic, Linq) + moteur IPD from-scratch (T=5/R=3/P=1/S=0 convention Axelrod) ; 0 NuGet tiers."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-6c-repeatedgames-folktheorem.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-6c-repeatedgames-folktheorem.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-6c-RepeatedGames-FolkTheorem.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-6c-RepeatedGames-FolkTheorem-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: e693b35dc15d0fed5b60cfc83e1ffb3de0c20a0f
-    csharp_sha: 510f61137fbcee6997eb12d0dc7bd28ceace25bd
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: e693b35dc15d0fed5b60cfc83e1ffb3de0c20a0f
+      csharp_sha: 510f61137fbcee6997eb12d0dc7bd28ceace25bd
   known_differences:
     - "Socle commun : jeux repétés et théorème Folk -- jeu étape (Dilemme du Prisonnier), horizon fini, horizon infini avec facteur d'escompte, grim trigger, tit-for-tat vs grim, Folk Theorem (ensemble des paiements faisables et individuellement rationnels)."
     - "PARITE CELLULAIRE EXACTE : 22 cellules des deux cotes (9 code, 13 markdown) -- un des twins les plus proches cellule-a-cellule du registre. Memes 6 sections dans le meme ordre + Exercice 1/2/3 + Conclusion. Le C# ajoute une sous-section 'Parité avec le notebook Python' sous la conclusion (intention de parite declaree)."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-7-extensiveform.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-7-extensiveform.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: f8eeb850da37e7d2e6723d1250f98c3aa187f643
-    reason: "Markdown-only hint fix (cell 25): Ultimatum backward-induction Indices 2/3 said x=0 / offre de 0 euro, but the discrete offer set is {2,4,5,6,8} (0 not admissible) and the notebook own stated SPE is spe_offer=2; aligned Indice 2/3 to x=2. No re-exec, no output change. C# twin untouched (different from-scratch engine)."
-    csharp_sha: c73ff346285a169f7f382044373ad1e72b533951
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: f8eeb850da37e7d2e6723d1250f98c3aa187f643
+      reason: "Markdown-only hint fix (cell 25): Ultimatum backward-induction Indices 2/3 said x=0 / offre de 0 euro, but the discrete offer set is {2,4,5,6,8} (0 not admissible) and the notebook own stated SPE is spe_offer=2; aligned Indice 2/3 to x=2. No re-exec, no output change. C# twin untouched (different from-scratch engine)."
+      csharp_sha: c73ff346285a169f7f382044373ad1e72b533951
   known_differences:
     - "Socle pedagogique commun : jeux sous forme extensive (arbre de jeu sequentiel avec noeuds de decision/terminal/chance + infosets), backward induction (induction en arriere) pour calculer les SPE (Subgame Perfect Equilibria), exemple canonique du jeu d'entree sur le marche (entrant vs incumbente)."
     - "Idiomes framework : Python = `@dataclass` + `networkx` (graphe arborescent + rendu matplotlib des arbres de jeu) + implementation manuelle de `backward_induction` + `ConvertToNormal` (reduction extensive-vers-normal). C# = **BCL .NET pur 0 NuGet** (modele `GameNode` decision/terminal/chance + `ExtensiveFormGame` from-scratch) + **rendu ASCII de l'arbre** (pas de viz graphique, fidele a la contrainte 0-NuGet de la serie)."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-8-combinatorialgames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-8-combinatorialgames.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-8-CombinatorialGames.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-8-CombinatorialGames-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 934b533de1507708f0834c6476d28595664af3d6
-    csharp_sha: 128acc9dee64fc2ff748dcce9e0eb727dc6d2ecd
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 934b533de1507708f0834c6476d28595664af3d6
+      csharp_sha: 128acc9dee64fc2ff748dcce9e0eb727dc6d2ecd
   known_differences:
     - "Socle pedagogique commun : theorie des jeux combinatoires impartiaux (positions P/N, jeu de Nim, nim-sum / theoreme de Bouton 1901, fonction mex (minimum excludant), valeurs de Grundy, theoreme de Sprague-Grundy, jeux de soustraction). Mathematique pure sans solveur tiers (les deux cotes implementent mex + Grundy + nim-sum from-scratch)."
     - "Idiomes framework : Python = `numpy` + `matplotlib` (rendu visuel des sequences de valeurs de Grundy / partition P-N sur les tas de Nim). C# = **BCL .NET pur 0 NuGet** (noms: `GameNode`/`GrundyValue`/`Mex`/`NimSum` from-scratch, XOR bit-a-bit sur `int` pour le nim-sum) -- aucun package tiers, fidele a la contrainte 0-NuGet de la serie."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-8c-combinatorialgames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-8c-combinatorialgames.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Python.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: c75a0237be52f739818b9e2df4ddece02a484d5d
-    csharp_sha: 71822adc60c62edbe98ca11e6509dbb474e22ffe
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: c75a0237be52f739818b9e2df4ddece02a484d5d
+      csharp_sha: 71822adc60c62edbe98ca11e6509dbb474e22ffe
   known_differences:
     - "Socle pedagogique commun : theorie des jeux combinatoires (Sprague-Grundy, nombres de Grundy, theoreme de Sprague-Grundy sur la somme de jeux, Nim et sa strategie gagnante XOR des tas). Meme concept mathematique (fonction de Grundy/g(x), XOR nim-sum, jeux impartiaux a information complete), meme cas canonique (Nim). Les deux couvrent Nim, Sprague, Grundy."
     - "Divergence d'implementation : le Python (numpy + matplotlib, 14 cellules code) implemente les nombres de Grundy et le XOR nim-sum avec visualisation (graphe de jeu, table de Grundy) ; le C# (pur System.* stdlib, 0 NuGet, 14 cellules code) implemente la meme logique combinatoire (Sprague-Grundy, nim-sum) sans dependance numerique. Meme theoreme, meme contenu algorithmique, sorties differentes (visualisation Python vs sorties texte/table C#)."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-9-backwardinduction.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-9-backwardinduction.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 42ffe90e4fb6c1d688dc6bb5c8e5258fb805246f
-    csharp_sha: a76af28befd0e36fe0209bbb401852bcbc9c2c41
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 42ffe90e4fb6c1d688dc6bb5c8e5258fb805246f
+      csharp_sha: a76af28befd0e36fe0209bbb401852bcbc9c2c41
   known_differences:
     - "Socle pedagogique commun : l'algorithme d'induction en arriere (backward induction) pour resoudre les jeux sequentiels et calculer les equilibres de sous-jeu parfait (SPE, Selten 1965), applique aux paradoxes canoniques : jeu du mille-pattes (Centipede Game), guerre d'usure (War of Attrition), paradoxe de la chaine de magasins (Chain-Store paradox, Selten 1978). Distinct du GT-7 ExtensiveForm (qui pose la formalisme extensive-form + reduction extensive-vers-normale) : le GT-9 centre l'algorithme d'induction arriere et les paradoxes qu'il fait surgir."
     - "Idiomes framework : Python = `networkx` (arbre de jeu) + `numpy` + `matplotlib` (rendu graphique des arbres et des trajectoires d'induction) + `@dataclass` + implementation manuelle de l'induction arriere. C# = **BCL .NET pur 0 NuGet** (modele d'arbre de jeu from-scratch + section dediee « Visualisation ASCII de l'arbre de jeu » en sortie console)."

--- a/scripts/notebook_tools/twin_pairs.d/ml-1-introduction.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-1-introduction.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-31"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 736ca5bc84443703871b0889ec8fe8413b5246c3
-    csharp_sha: 0e5a5f450b7d111d2ae1bb4507dde72790604527
-    reason: "rebaseline python apres 2 fixes (#8052) : (1) cellule 21 '(environ 76 min)' mais output cellule 20 = 75.1 minutes (arrondit a 75) ; (2) cellule 34 resume 'Trois familles abordees' mais n'enumere que 2 familles (regression + classification) -- 'familles' est une transposition de 'exemples' (cellule 0 dit 'trois exemples guides'). Fix value + count. Python-only, csharp_sha unchanged, parite semantique preservee."
+  audits:
+    - date: "2026-07-31"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 736ca5bc84443703871b0889ec8fe8413b5246c3
+      csharp_sha: 0e5a5f450b7d111d2ae1bb4507dde72790604527
+      reason: "rebaseline python apres 2 fixes (#8052) : (1) cellule 21 '(environ 76 min)' mais output cellule 20 = 75.1 minutes (arrondit a 75) ; (2) cellule 34 resume 'Trois familles abordees' mais n'enumere que 2 familles (regression + classification) -- 'familles' est une transposition de 'exemples' (cellule 0 dit 'trois exemples guides'). Fix value + count. Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:
     - "Socle pedagogique commun : regression lineaire (R2, MAE) + regression logistique (accuracy, ROC-AUC). Dataset : prediction de prix / classification binaire."
     - "Idiomes framework : C# = `Microsoft.ML` (API imperative MLContext -> PredictionEngine, schema via classes [ColumnName]). Python = `sklearn.linear_model` (LinearRegression, LogisticRegression) fonctionnel (estimator.fit/predict), metrics `r2_score, mean_absolute_error, accuracy_score, roc_auc_score`."

--- a/scripts/notebook_tools/twin_pairs.d/ml-2-data-features.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-2-data-features.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-02"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 101ab5a0f5a70557bcddc84c4ebfebadbb8ecc64
-    csharp_sha: 843d8d2493cb938e8c381706369a380ac24d6cfa
-    reason: "rebaseline csharp apres fix citation-title (#8052) : reference Hastie/Tibshirani/Friedman (2009) -- le titre anglais The Elements of Statistical Learning etait corrupt par francisation (le mot Elements remplace par le mot francais equivalent a capitale accentuee) -> restore titre canonique EN. Springer 2009 2e ed. Python twin unchanged, python_sha preserve. Parite semantique preservee (citation bibliographique, pas de valeur calculee)."
+  audits:
+    - date: "2026-08-02"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 101ab5a0f5a70557bcddc84c4ebfebadbb8ecc64
+      csharp_sha: 843d8d2493cb938e8c381706369a380ac24d6cfa
+      reason: "rebaseline csharp apres fix citation-title (#8052) : reference Hastie/Tibshirani/Friedman (2009) -- le titre anglais The Elements of Statistical Learning etait corrupt par francisation (le mot Elements remplace par le mot francais equivalent a capitale accentuee) -> restore titre canonique EN. Springer 2009 2e ed. Python twin unchanged, python_sha preserve. Parite semantique preservee (citation bibliographique, pas de valeur calculee)."
   known_differences:
     - "Socle pedagogique commun : featurization (encodage categoriel one-hot, normalisation, imputation) sur donnees tabulaires."
     - "Idiomes framework : C# = `mlContext.Transforms.Categorical.OneHotEncoding` (OutputKind.Binary) sur IDataView (LoadFromEnumerable). Python = `sklearn.preprocessing` (OneHotEncoder, StandardScaler, SimpleImputer) composes via `ColumnTransformer` + `Pipeline`."

--- a/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-31"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 695da4960a0c19888c1e5917040ed84d5ee520be
-    csharp_sha: 23a665e9c31aa87889cbaf4630e4d87b3c32e8c2
-    reason: "rebaseline python apres fix prose Exemple 2/AutoML (cellules 7/8/11, #8052) : la prose disait 'donnees quadratiques y=100x^2' et 'compare deux GradientBoosting' mais le code cellule 8 genere des SINUS (y=10sin(x)) et compare trois DecisionTreeRegressor (underfit/good/overfit) ; l'AutoML cellule 10 tourne sur ces memes donnees sinus (LinearRegression RMSE CV=7.01, RandomForest=3.06). Le comment cellule 8 'le RMSE test explose' contredisait l'output (overfit test=2.78, le plus bas). Fix aligne prose sur le code execute. Python-only, csharp_sha unchanged, parite semantique preservee."
+  audits:
+    - date: "2026-07-31"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 695da4960a0c19888c1e5917040ed84d5ee520be
+      csharp_sha: 23a665e9c31aa87889cbaf4630e4d87b3c32e8c2
+      reason: "rebaseline python apres fix prose Exemple 2/AutoML (cellules 7/8/11, #8052) : la prose disait 'donnees quadratiques y=100x^2' et 'compare deux GradientBoosting' mais le code cellule 8 genere des SINUS (y=10sin(x)) et compare trois DecisionTreeRegressor (underfit/good/overfit) ; l'AutoML cellule 10 tourne sur ces memes donnees sinus (LinearRegression RMSE CV=7.01, RandomForest=3.06). Le comment cellule 8 'le RMSE test explose' contredisait l'output (overfit test=2.78, le plus bas). Fix aligne prose sur le code execute. Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:
     - "Socle pedagogique commun : comparaison de trainers de regression (lineaire vs boosting) + evaluation RMSE train/test."
     - "Zoos de modeles distincts : C# = `Regression.Trainers.Sdca` (Stochastic Dual Coord Ascent) + `LightGbm` (binding ML.NET LightGBM natif). Python = `LinearRegression` + `GradientBoostingRegressor, RandomForestRegressor, DecisionTreeRegressor, SVR` (ensemble sklearn)."

--- a/scripts/notebook_tools/twin_pairs.d/ml-4-evaluation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-4-evaluation.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
   parity_level: surface
-  last_audit:
-    date: "2026-08-02"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 2d84290fefedd8f816a737a8de1f270c2a4a328b
-    csharp_sha: 3702afa3bac062ae4d142e0debd3ffce521940ab
-    reason: "rebaseline csharp apres fix citation-title (#8052) : reference Hastie/Tibshirani/Friedman (2009) -- le titre anglais The Elements of Statistical Learning etait corrupt par francisation (le mot Elements remplace par le mot francais equivalent a capitale accentuee) -> restore titre canonique EN. Springer 2009 2e ed. Python twin unchanged, python_sha preserve. Parite surface preservee (citation bibliographique, pas de valeur calculee)."
+  audits:
+    - date: "2026-08-02"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 2d84290fefedd8f816a737a8de1f270c2a4a328b
+      csharp_sha: 3702afa3bac062ae4d142e0debd3ffce521940ab
+      reason: "rebaseline csharp apres fix citation-title (#8052) : reference Hastie/Tibshirani/Friedman (2009) -- le titre anglais The Elements of Statistical Learning etait corrupt par francisation (le mot Elements remplace par le mot francais equivalent a capitale accentuee) -> restore titre canonique EN. Springer 2009 2e ed. Python twin unchanged, python_sha preserve. Parite surface preservee (citation bibliographique, pas de valeur calculee)."
   known_differences:
     - "ASYSMETRIE MAJEURE DE PROFONDEUR : C# = 40 cellules de code (tour exhaustif d'evaluation : FastTree, OneHotEncoding, ReplaceMissingValues, Concatenate Features + `mlContext.Auto().Regression` AutoML complet) ; Python = 10 cellules (pendant tronque : LinearRegression + RandomForestRegressor + cross_validate/GridSearchCV)."
     - "Le pendant Python couvre le CONCEPT (evaluer + GridSearchCV + metrics r2/MAE/MSE) mais n'egale pas l'exhaustivite du C# (AutoML ML.NET absent cote Python, feature engineering detaille reduit)."

--- a/scripts/notebook_tools/twin_pairs.d/ml-5-timeseries.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-5-timeseries.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
   parity_level: surface
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 5e863ede175ce3bf689752df4e3750ac08f2a71f
-    csharp_sha: 111b1731ff6a189ae30eb3202fc4f6a2f9781d45
-    reason: "rebaseline csharp apres fix Note CELL[5] (#8052) : la Note technique disait faussement que les cellules Partie 1-4 \"requierent [package] non resolu par le kernel .NET Interaction local\" (avec des trous de texte : nom de package et adjectif manquants) alors que TOUTES les cellules code ont tourne (execution_count + outputs : CELL[14] \"Modele entraine avec succes\", CELL[17] MAE/RMSE). Voie(B) : prose honnete alignee sur les sorties committées, aucun nombre fabrique. Csharp-only, python_sha unchanged, parite (surface) preservee."
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 5e863ede175ce3bf689752df4e3750ac08f2a71f
+      csharp_sha: 111b1731ff6a189ae30eb3202fc4f6a2f9781d45
+      reason: "rebaseline csharp apres fix Note CELL[5] (#8052) : la Note technique disait faussement que les cellules Partie 1-4 \"requierent [package] non resolu par le kernel .NET Interaction local\" (avec des trous de texte : nom de package et adjectif manquants) alors que TOUTES les cellules code ont tourne (execution_count + outputs : CELL[14] \"Modele entraine avec succes\", CELL[17] MAE/RMSE). Voie(B) : prose honnete alignee sur les sorties committées, aucun nombre fabrique. Csharp-only, python_sha unchanged, parite (surface) preservee."
   known_differences:
     - "FAMILLES ALGORITHMIQUES DIFFERENTES (pas un simple idiome swap) : C# = `Microsoft.ML.Transforms.TimeSeries` -> `ForecastBySsa` (Singular Spectrum Analysis, decomposition spectrale ML.NET-native). Python = `statsmodels` -> `STL` (seasonal-trend LOESS decomposition) + `SARIMAX` (seasonal ARIMA classique)."
     - "Aucune lib Python n'expose SSA de facon pedagogique equivalente ; le pendant Python choisit donc l'approche statistique classique (STL+SARIMAX) pour couvrir le meme besoin (forecast saisonnier) avec un OUTIL different."

--- a/scripts/notebook_tools/twin_pairs.d/ml-6-onnx-integration.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-6-onnx-integration.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 40517222f60d7acaacb6beeefdc225798309315e
-    csharp_sha: e8b19d04356dab090cb82f001db007990261ac73
-    reason: "rebaseline csharp apres fix prose CELL[2] (#8052) : la Note disait faussement \"nous allons creer un modele ONNX simple\" alors que le C# CHARGE un modele pre-exporte (iris_model.onnx, sklearn, scripts/ml/generate_iris_onnx.py) -- verifie par header \"Charger un modele ONNX externe\", CELL[7] (code de chargement), et known_differences ci-dessous. Aligne la Note sur le code. Csharp-only, python_sha unchanged, parite semantique preservee."
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 40517222f60d7acaacb6beeefdc225798309315e
+      csharp_sha: e8b19d04356dab090cb82f001db007990261ac73
+      reason: "rebaseline csharp apres fix prose CELL[2] (#8052) : la Note disait faussement \"nous allons creer un modele ONNX simple\" alors que le C# CHARGE un modele pre-exporte (iris_model.onnx, sklearn, scripts/ml/generate_iris_onnx.py) -- verifie par header \"Charger un modele ONNX externe\", CELL[7] (code de chargement), et known_differences ci-dessous. Aligne la Note sur le code. Csharp-only, python_sha unchanged, parite semantique preservee."
   known_differences:
     - "Socle pedagogique commun : integration de modeles ONNX (chargement, inference, inspection du graph, exercices). C# = ML.NET OnnxTransformer + OnnxRuntime ; Python = skl2onnx (export sklearn->ONNX) + onnxruntime (inference) + onnx (inspection structurelle). Cree comme twin de parite explicite en #5607 (EPIC #4956 .NET<->Python)."
     - "Asymetrie export-vs-load (pont Python->.NET) : le C# charge un modele ONNX pre-exporte (iris_model.onnx genere par scripts/ml/generate_iris_onnx.py, RandomForest sklearn) car l'export ML.NET->ONNX est experimental (documente en commentaire, c13/c15) ; le Python effectue l'export sklearn->ONNX lui-meme via skl2onnx (opset 15, zipmap=False). Le twin Python est le cote 'producteur' du pont ONNX, le C# le cote 'consommateur'."

--- a/scripts/notebook_tools/twin_pairs.d/ml-7-recommendation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-7-recommendation.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 77524721813b30cc81946ec94cf4f9ed6c69531a
-    csharp_sha: 10759ec1e2d7f09f47e811dcb7c6c81173aeccc5
-    reason: "c.1130 #8052 csharp c11 comment 'Film 3 (qu il n a pas note)' FALSE (User1 rated Film3=1: c3 data literal MovieRating UserId=1 MovieId=3 Rating=1 + c11 own output 'vraie note = 1'; matrix full 15/15 so NO unrated movies -> demo predicts a KNOWN rating, parenthetical removed) + c19 md/c20 print-literal cellule 17->18 off-by-one (c17=markdown metrics table computes nothing; c18=eval cell output RMSE 2,955 / R2 -33,939). Python twin preserved (a3279c17 sparsite rebaseline prior). Structural/identity + comment -> 0 output change, 0 re-exec."
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 77524721813b30cc81946ec94cf4f9ed6c69531a
+      csharp_sha: 10759ec1e2d7f09f47e811dcb7c6c81173aeccc5
+      reason: "c.1130 #8052 csharp c11 comment 'Film 3 (qu il n a pas note)' FALSE (User1 rated Film3=1: c3 data literal MovieRating UserId=1 MovieId=3 Rating=1 + c11 own output 'vraie note = 1'; matrix full 15/15 so NO unrated movies -> demo predicts a KNOWN rating, parenthetical removed) + c19 md/c20 print-literal cellule 17->18 off-by-one (c17=markdown metrics table computes nothing; c18=eval cell output RMSE 2,955 / R2 -33,939). Python twin preserved (a3279c17 sparsite rebaseline prior). Structural/identity + comment -> 0 output change, 0 re-exec."
   known_differences:
     - "Socle pedagogique commun : filtrage collaboratif par factorisation de matrices (recommandation user-item, K facteurs latents)."
     - "Idiomes framework : C# = `mlContext.Recommendation().Trainers.MatrixFactorization` (trainer dedie + MapValueToKey pour UserId/MovieId). Python = `sklearn.decomposition.NMF` (Non-negative Matrix Factorization generique, init='nndsvda', solver='mu') avec erreur de reconstruction explicite."

--- a/scripts/notebook_tools/twin_pairs.d/ml-8-clustering.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-8-clustering.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-31"
-    by: myia-po-2023:CoursIA
-    python_sha: 98249788bd0a3541acd82d2f47e1dd645ac154b1
-    csharp_sha: 9406692311322fed00c51c257131dfe204399768
-    reason: "rebaseline apres add metadata.cost (#8445) aux DEUX jumeaux (vrais CPU-only identiques) ; parite semantique preservee (metadata-only, 0 code churn)"
+  audits:
+    - date: "2026-07-31"
+      by: myia-po-2023:CoursIA
+      python_sha: 98249788bd0a3541acd82d2f47e1dd645ac154b1
+      csharp_sha: 9406692311322fed00c51c257131dfe204399768
+      reason: "rebaseline apres add metadata.cost (#8445) aux DEUX jumeaux (vrais CPU-only identiques) ; parite semantique preservee (metadata-only, 0 code churn)"
   known_differences:
     - "metadata.cost ajoute symetriquement aux deux jumeaux (#8445, po-2023) : valeurs identiques (api_usd_est=0.0, gpu_required=false, vram_tier=NONE, free_alternative=self) — addition metadata-only, n'affecte pas la parite comportementale."
     - "Socle pedagogique commun : K-Means (K=3) avec normalisation MinMax preprocess ; evaluation par metriques de cohesion de clusters."

--- a/scripts/notebook_tools/twin_pairs.d/ml-9-anomaly-detection.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-9-anomaly-detection.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 060c0e79c3e5c800eee790bddccf0f1462cce4d7
-    csharp_sha: f249f653b3d7572d14f7c5cb1ec12a3da74a4cb8
-    reason: "rebase c.1241: Python prose-difficulty fix (cells 20/25, #8052) + C# c31 COUNT off-by-one 10->9 (cell 27 loop t=1..9); both twins fixed, parity preserved"
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 060c0e79c3e5c800eee790bddccf0f1462cce4d7
+      csharp_sha: f249f653b3d7572d14f7c5cb1ec12a3da74a4cb8
+      reason: "rebase c.1241: Python prose-difficulty fix (cells 20/25, #8052) + C# c31 COUNT off-by-one 10->9 (cell 27 loop t=1..9); both twins fixed, parity preserved"
   known_differences:
     - "metadata.cost ajoute symetriquement aux deux jumeaux (#8445, po-2023) : valeurs identiques (api_usd_est=0.0, gpu_required=false, vram_tier=NONE, free_alternative=self) — addition metadata-only, n'affecte pas la parite comportementale."
     - "Socle pedagogique commun : detection d'anomalies par PCA (Analyse en Composantes Principales) sur donnees capteurs."

--- a/scripts/notebook_tools/twin_pairs.d/planners-1-introduction.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-1-introduction.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-02"
-    by: myia-po-2024:CoursIA-2
-    python_sha: b8b4aab5c7f937970c850710f50d8f9b3166ad6a
-    csharp_sha: 684de6ba81caa8202262c6f7f1b3830bc4af8291
-    reason: "rebaseline python apres 1 fix structurel (#8052) : le titre ### 4.2 Implementation avec unified-planning apparaissait DEUX FOIS -- cellule 7 (intro) et cellule 9 (re-ouvert, byte-identique), avec seulement le code de verification de version (cellule 8) entre les deux ; la section 4 avait donc 4.1, 4.2, 4.2 (dup), 4.3. Fix = suppression du titre duplique de la cellule 9 (cellule 7 l'avait deja), la phrase d'introduction distincte de la cellule 9 est conservee (elle devient un pont entre la verification de version cellule 8 et le code de modelisation cellule 10, tous sous ### 4.2 ouvert a la cellule 7). Python-only (le jumeau C# from-scratch BCL n'a pas d'unified-planning, 0 titre ### 4.2), csharp_sha unchanged, parite semantique preservee (0 re-exec, 0 output/code modifie)."
+  audits:
+    - date: "2026-08-02"
+      by: myia-po-2024:CoursIA-2
+      python_sha: b8b4aab5c7f937970c850710f50d8f9b3166ad6a
+      csharp_sha: 684de6ba81caa8202262c6f7f1b3830bc4af8291
+      reason: "rebaseline python apres 1 fix structurel (#8052) : le titre ### 4.2 Implementation avec unified-planning apparaissait DEUX FOIS -- cellule 7 (intro) et cellule 9 (re-ouvert, byte-identique), avec seulement le code de verification de version (cellule 8) entre les deux ; la section 4 avait donc 4.1, 4.2, 4.2 (dup), 4.3. Fix = suppression du titre duplique de la cellule 9 (cellule 7 l'avait deja), la phrase d'introduction distincte de la cellule 9 est conservee (elle devient un pont entre la verification de version cellule 8 et le code de modelisation cellule 10, tous sous ### 4.2 ouvert a la cellule 7). Python-only (le jumeau C# from-scratch BCL n'a pas d'unified-planning, 0 titre ### 4.2), csharp_sha unchanged, parite semantique preservee (0 re-exec, 0 output/code modifie)."
   known_differences:
     - "Concept : introduction a la planification classique (domaine, probleme, plan = sequence d'actions)."
     - "Python : unified-planning (API moderne, modelisation Fluent/Action). C# : from-scratch BCL .NET (dataclasses d'Action/Etat, 0 NuGet)."

--- a/scripts/notebook_tools/twin_pairs.d/planners-2-pddl-basics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-2-pddl-basics.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-31"
-    by: po-2024
-    python_sha: c83be596acfef24a0d6b22bab6405f2e68074374
-    csharp_sha: 241758247433d536fb0f1f324962446cd6d12af5
+  audits:
+    - date: "2026-07-31"
+      by: po-2024
+      python_sha: c83be596acfef24a0d6b22bab6405f2e68074374
+      csharp_sha: 241758247433d536fb0f1f324962446cd6d12af5
   known_differences:
     - "Concept : syntaxe PDDL (domain.pddl + problem.pddl), predicats, actions, etat initial/but."
     - "Python : generation PDDL via unified-planning PDDLWriter + parsing. C# : from-scratch PDDL text builder/parser BCL."

--- a/scripts/notebook_tools/twin_pairs.d/planners-3-state-space.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-3-state-space.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2026:CoursIA 2026-08-01
-    python_sha: 97ba9b763f12116f3ffcf85b8e71ffb1bce6082a
-    csharp_sha: a9306fbf5a3c02555bf3f63b03a35db099da423f
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2026:CoursIA 2026-08-01
+      python_sha: 97ba9b763f12116f3ffcf85b8e71ffb1bce6082a
+      csharp_sha: a9306fbf5a3c02555bf3f63b03a35db099da423f
   known_differences:
     - "Concept : recherche dans l'espace d'etats (BFS/DFS/A* sur le graphe des etats reachables)."
     - "Python : BFS/DFS/Greedy/A* via networkx + matplotlib heatmap terrain. C# : from-scratch BFS/DFS/Greedy/A* BCL .NET 9 + PriorityQueue (meme algorithme, implementation idiomatic)."

--- a/scripts/notebook_tools/twin_pairs.d/planners-4-fast-downward.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-4-fast-downward.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-23"
-    by: po-2023
-    python_sha: fb091daf6b35345dc6ceb726af32411b687f5f87
-    csharp_sha: 71b179583900de65dc00fbe28ada0f088ec57253
+  audits:
+    - date: "2026-07-23"
+      by: po-2023
+      python_sha: fb091daf6b35345dc6ceb726af32411b687f5f87
+      csharp_sha: 71b179583900de65dc00fbe28ada0f088ec57253
   known_differences:
     - "Concept : planificateur classique Fast Downward (SAS+, heuristic search, A*/GBFS/EHC)."
     - "Python : invoque le VRAI solveur SOTA Fast Downward via conteneur Docker (jsboige/coursia-fast-downward) + unified-planning. C# : from-scratch BCL .NET (reimplementation pedagogique, ne peut pas invoquer fast-downward)."

--- a/scripts/notebook_tools/twin_pairs.d/planners-5-heuristics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-5-heuristics.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2026:CoursIA
-    python_sha: 8101b548a7ae06bfa2e807a7cf658583c01a32fa
-    csharp_sha: 38fbe3dd8890dae8c1e0772807baed5762eb1eda
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2026:CoursIA
+      python_sha: 8101b548a7ae06bfa2e807a7cf658583c01a32fa
+      csharp_sha: 38fbe3dd8890dae8c1e0772807baed5762eb1eda
   known_differences:
     - "Concept : heuristiques admissibles (relaxation, h_add, h_max, delete-relaxation)."
     - "Python : unified-planning + fast-downward heuristics. C# : from-scratch delete-relaxation BCL."

--- a/scripts/notebook_tools/twin_pairs.d/planners-6-domains.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-6-domains.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: ff148663a6bc7f6aa902861ac81c210ac343c22f
-    csharp_sha: a2cea4c4062bedc965149e009e8d5e1533194a53
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: ff148663a6bc7f6aa902861ac81c210ac343c22f
+      csharp_sha: a2cea4c4062bedc965149e009e8d5e1533194a53
   known_differences:
     - "Concept : domaines classiques de planification (Block World, Logistics, Gripper, Ferry, Hanoi)."
     - "Python : modelisation unified-planning des domaines canoniques. C# : from-scratch BCL .NET (meme domaines de reference)."

--- a/scripts/notebook_tools/twin_pairs.d/planners-7-or-tools.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-7-or-tools.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-7-OR-Tools.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-7-OR-Tools-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-02"
-    by: myia-po-2024:CoursIA-2
-    python_sha: db8c36c20afafe5918b1dec884d406597700e6f7
-    csharp_sha: 6acd159baa6ba26452ad2397b1c6a8a92395da92
-    reason: "rebaseline python apres 1 fix structurel (#8052) : section 4 (VRP) sautait ### 4.1 -> ### 4.3 (pas de ### 4.2) ; 'Donnees du probleme VRP' (cellule 24) est une Interpretation non-numerotee (convention de la section 3 Job Shop), donc renumerotation cellule 25 ### 4.3 -> ### 4.2 (section 4 maintenant contigue 4.1/4.2). Fix content-neutral (edition de texte de titre, aucun changement de corps, aucune perte de contenu), 0 re-exec. Python-only, csharp_sha unchanged, parite semantique preservee."
+  audits:
+    - date: "2026-08-02"
+      by: myia-po-2024:CoursIA-2
+      python_sha: db8c36c20afafe5918b1dec884d406597700e6f7
+      csharp_sha: 6acd159baa6ba26452ad2397b1c6a8a92395da92
+      reason: "rebaseline python apres 1 fix structurel (#8052) : section 4 (VRP) sautait ### 4.1 -> ### 4.3 (pas de ### 4.2) ; 'Donnees du probleme VRP' (cellule 24) est une Interpretation non-numerotee (convention de la section 3 Job Shop), donc renumerotation cellule 25 ### 4.3 -> ### 4.2 (section 4 maintenant contigue 4.1/4.2). Fix content-neutral (edition de texte de titre, aucun changement de corps, aucune perte de contenu), 0 re-exec. Python-only, csharp_sha unchanged, parite semantique preservee."
   known_differences:
     - "Concept : planification orientee satisfaction de contraintes (Job-Shop scheduling, CP-SAT)."
     - "Python : OR-Tools CP-SAT Python bindings (solveur SOTA). C# : from-scratch BCL .NET (0 NuGet, Job-Shop modelise main, instance canonique Fisher & Thompson ft3 reprise cote Python)."

--- a/scripts/notebook_tools/twin_pairs.d/planners-8-temporal.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-8-temporal.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: dea984c63c87f8fd18e79a7c3a679f8afeb75605
-    csharp_sha: 131d4a0bea72a0ad043ed44798468fd98dd7a2e5
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: dea984c63c87f8fd18e79a7c3a679f8afeb75605
+      csharp_sha: 131d4a0bea72a0ad043ed44798468fd98dd7a2e5
   known_differences:
     - "Concept : planification temporelle (actions duratives, ordonnancement avec parallelisme)."
     - "Python : unified-planning temporal + CP-SAT + Gantt. C# : from-scratch BCL .NET (ordonnancement usine)."

--- a/scripts/notebook_tools/twin_pairs.d/planners-9-htn.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-9-htn.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 8efefd483570bca7815d101844863f71f9f3c436
-    csharp_sha: a502d4c462d6667187a8ec6d827bfe1027271e9f
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 8efefd483570bca7815d101844863f71f9f3c436
+      csharp_sha: a502d4c462d6667187a8ec6d827bfe1027271e9f
   known_differences:
     - "Concept : Hierarchical Task Network (decomposition de taches, methodes, backtracking)."
     - "Python : unified-planning HTN. C# : from-scratch BCL .NET (Predicat grounde, Etat, decomposition de methodes)."

--- a/scripts/notebook_tools/twin_pairs.d/probas-1-setup.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-1-setup.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: d66cca0ab2869a855a3d57c7a23072d9409c9ab5
-    csharp_sha: 08d80a7b526cec74e667ecb04eca32cc443374de
+  audits:
+    - date: "2026-07-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: d66cca0ab2869a855a3d57c7a23072d9409c9ab5
+      csharp_sha: 08d80a7b526cec74e667ecb04eca32cc443374de
   known_differences:
   - "Premier modele partage : les deux notebooks demarrent par le modele classique des deux pieces (Two Coins) -- prior Beta, vraisemblance Bernoulli, inference du biais de la piece. Socle pedagogique commun au-dela de la dimension setup (installation Infer.NET cote C# vs PyMC cote Python). Note : #8183 avait initialement exclu cette paire comme 'env-config mecanique, pas de demonstration de concept' (analogue ML-6 ONNX) ; relecture firsthand (ai-01 c.36, po-2023 c.941) confirme la presence substantive du modele Two Coins dans les DEUX notebooks (Infer-1-Setup : piece x15 / Bernoulli x10 / Beta x8 ; PyMC-1-Setup : coin x6 / piece x13 / Beta x12) -> la rationale d'exclusion initiale etait incomplete, paire re-enregistree."
   - "Moteurs d'inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation, modele compile en code d'inference) ; Python PyMC = echantillonnage MCMC (NUTS/HMC) + ADVI sur backend PyTensor. Memes concepts (Beta-Bernoulli two-coins), paradigmes d'inference differents -- les ecarts numeriques attendus (point estimate EP vs posterior samples NUTS) ne sont pas des defauts."

--- a/scripts/notebook_tools/twin_pairs.d/probas-10-model-selection.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-10-model-selection.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Model-Selection.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 4aef3828fcb8976eabcfbc56000d50487dc619e2
-    csharp_sha: 00c3d935ea7b4573c2a3dd6950bf955a39fe793c
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 4aef3828fcb8976eabcfbc56000d50487dc619e2
+      csharp_sha: 00c3d935ea7b4573c2a3dd6950bf955a39fe793c
   known_differences:
   - 'Socle pedagogique commun : selection de modele (WAIC/LOO, evidence) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational

--- a/scripts/notebook_tools/twin_pairs.d/probas-12-modeles-hierarchiques.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-12-modeles-hierarchiques.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Modeles-Hierarchiques.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 91a08f3e69ac3eec7a3341d281a7b5386f018b5a
-    csharp_sha: d9c7d20cdaa32ffa09e33a08a0646da228e08e84
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 91a08f3e69ac3eec7a3341d281a7b5386f018b5a
+      csharp_sha: d9c7d20cdaa32ffa09e33a08a0646da228e08e84
   known_differences:
   - 'Socle pedagogique commun : modeles hierarchiques (effets aleatoires emboites) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational

--- a/scripts/notebook_tools/twin_pairs.d/probas-13-crowdsourcing.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-13-crowdsourcing.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Crowdsourcing.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 246ba905ee53e1dcbae37a711e47a1622eac72b7
-    csharp_sha: bc9a5dc802eb397cff7bc8aa0e7dc270c3e0f8d4
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 246ba905ee53e1dcbae37a711e47a1622eac72b7
+      csharp_sha: bc9a5dc802eb397cff7bc8aa0e7dc270c3e0f8d4
   known_differences:
   - '2026-07-28 (myia-po-2023) #8711 / See #8081 : FERME l''asymetrie sources entre jumeaux -- Infer-13 portait une
     cellule "Sources canoniques" (table Raykar 2010, Karger 2011, Dawid-Skene 1979, Whitehill 2009, Kim-Ghahramani

--- a/scripts/notebook_tools/twin_pairs.d/probas-14-sequences.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-14-sequences.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Sequences.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 81c45947b4322974083d5dedaff85a5aa8dc97d8
-    csharp_sha: 1780a6871a8dd4eb0d5fbc8a8a137c229bf67ae7
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 81c45947b4322974083d5dedaff85a5aa8dc97d8
+      csharp_sha: 1780a6871a8dd4eb0d5fbc8a8a137c229bf67ae7
   known_differences:
   - 'Socle pedagogique commun : modeles de sequences (chaines de Markov cachees / HMM) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational

--- a/scripts/notebook_tools/twin_pairs.d/probas-15-recommenders.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-15-recommenders.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 2139bf0a6063766923006eb2a30fa9791dd01e2d
-    csharp_sha: c841d0e3694526d1df2b901e3c2d170c91809703
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 2139bf0a6063766923006eb2a30fa9791dd01e2d
+      csharp_sha: c841d0e3694526d1df2b901e3c2d170c91809703
   known_differences:
   - 'Socle pedagogique commun : systemes de recommandation (filtrage collaboratif) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational

--- a/scripts/notebook_tools/twin_pairs.d/probas-16-sparse-gaussian-process.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-16-sparse-gaussian-process.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-16-Sparse-Gaussian-Process.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 5743c084f9060ed197a7acf541bf2611f89c7505
-    csharp_sha: 6f3548830ed7e67e883b0d6d789c022fad96d6c4
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 5743c084f9060ed197a7acf541bf2611f89c7505
+      csharp_sha: 6f3548830ed7e67e883b0d6d789c022fad96d6c4
   known_differences:
   - 'Socle pedagogique commun : gaussiens parcimonieux (Sparse GP, points induits) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational

--- a/scripts/notebook_tools/twin_pairs.d/probas-17-kalman-filter.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-17-kalman-filter.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Kalman-Filter.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2023:CoursIA
-    python_sha: 92f49cfd7f33fff4e811fdb0842db13c5223fb57
-    csharp_sha: d939f2694311d205a9c0980da216033ee4481389
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2023:CoursIA
+      python_sha: 92f49cfd7f33fff4e811fdb0842db13c5223fb57
+      csharp_sha: d939f2694311d205a9c0980da216033ee4481389
   known_differences:
   - 'Socle pedagogique commun : filtre de Kalman (etat latent dynamique lineaire-gaussien) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational

--- a/scripts/notebook_tools/twin_pairs.d/probas-18-change-point.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-18-change-point.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Change-Point.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: f295cceb90dc134cb19ebda5860bb121a77e2174
-    csharp_sha: 95033cfe1c4ee9b1562c17faaddbe482f92d5e38
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: f295cceb90dc134cb19ebda5860bb121a77e2174
+      csharp_sha: 95033cfe1c4ee9b1562c17faaddbe482f92d5e38
   known_differences:
   - 'Socle pedagogique commun : points de changement (change-point detection) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational

--- a/scripts/notebook_tools/twin_pairs.d/probas-19-survival-analysis.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-19-survival-analysis.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Survival-Analysis.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: d4ab43338f4c2f7ace1f3377830af97bed5acf4b
-    csharp_sha: 8f48b984561f4a441c9b3f68fb0cb6c301c71323
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: d4ab43338f4c2f7ace1f3377830af97bed5acf4b
+      csharp_sha: 8f48b984561f4a441c9b3f68fb0cb6c301c71323
   known_differences:
   - 'Socle pedagogique commun : analyse de survie (modelisation de durees / censure) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational

--- a/scripts/notebook_tools/twin_pairs.d/probas-3-factor-graphs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-3-factor-graphs.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-3-Factor-Graphs.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: 5929bd4bbe321ca89056a4d92209fdb5b30bc821
-    csharp_sha: fa2c2ffdbc5dc5aaff9bfe03316c262cd926f150
+  audits:
+    - date: "2026-07-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 5929bd4bbe321ca89056a4d92209fdb5b30bc821
+      csharp_sha: fa2c2ffdbc5dc5aaff9bfe03316c262cd926f150
   known_differences:
   - 'Socle pedagogique commun : graphes de facteurs et variables aleatoires modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational

--- a/scripts/notebook_tools/twin_pairs.d/probas-4-bayesian-networks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-4-bayesian-networks.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-4-Bayesian-Networks.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-30"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 1eaf878c9bd25b664c687b12d6e61bc68eb20533
-    csharp_sha: d443d6ac8369bd9cc602b13ff47e7b406294ea80
+  audits:
+    - date: "2026-07-30"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 1eaf878c9bd25b664c687b12d6e61bc68eb20533
+      csharp_sha: d443d6ac8369bd9cc602b13ff47e7b406294ea80
   known_differences:
   - 'Socle pedagogique commun : reseaux bayesiens (DAG de dependances conditionnelles) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational

--- a/scripts/notebook_tools/twin_pairs.d/probas-5-causal-inference.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-5-causal-inference.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Causal-Inference.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: 9c569a28a0d7395d0211dfc26a9d0a00cd03f4d2
-    csharp_sha: 85bc41d76098400b0727d7ea7b6184d021704f4c
+  audits:
+    - date: "2026-07-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 9c569a28a0d7395d0211dfc26a9d0a00cd03f4d2
+      csharp_sha: 85bc41d76098400b0727d7ea7b6184d021704f4c
   known_differences:
   - 'Socle pedagogique commun : inference causale (do-calculus, ajustement) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational

--- a/scripts/notebook_tools/twin_pairs.d/probas-7-skills-irt.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-7-skills-irt.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-7-Skills-IRT.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: f1f4080df62766027a4583aaee04b435dd931374
-    csharp_sha: b878dadd1b0836b518e89e16642e88265d490669
+  audits:
+    - date: "2026-07-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: f1f4080df62766027a4583aaee04b435dd931374
+      csharp_sha: b878dadd1b0836b518e89e16642e88265d490669
   known_differences:
   - '2026-07-28 (myia-po-2023) #8711 / See #8081 : FERME l''asymetrie creee par #8530 -- le backfill attribution MBML
     Ch.2 n''avait touche que le twin C# (Infer-7), laissant PyMC-7 sans rattachement au chapitre alors que son jumeau

--- a/scripts/notebook_tools/twin_pairs.d/probas-8-trueskill.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-8-trueskill.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-TrueSkill.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2026:CoursIA
-    python_sha: 14097169f417cf18752f051f0f41f61802871844
-    csharp_sha: c9a371fce477c487466ee3549cae114c9963d418
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2026:CoursIA
+      python_sha: 14097169f417cf18752f051f0f41f61802871844
+      csharp_sha: c9a371fce477c487466ee3549cae114c9963d418
   known_differences:
   - "2026-07-28 (myia-po-2026) #8704/#8715 : backfill section 14 \"Pour aller plus loin\" -- formules fermees EP V(t)/W(t)/tau^2 (Herbrich-Minka-Graepel 2007) ajoutees en markdown + NOUVELLE cellule code .NET executee (#r MathNet.Numerics, computation closed-form). Add-only (65 -> 69 cellules), 0 cellule existante alteree, 0 output drift sur les sections 1-13. Variance utilise la forme canonique sigma^2*(1-(sigma^2/c^2)*W(t)) (facteur de gain de Kalman sigma^2/c^2 present) -> posterior sigma=7,19 match exact Infer.NET cellule 16 N(29,21,7,19). python_sha inchange a ce stade (note: PyMC-8 cell29 portait la variante sans facteur sigma^2/c^2 -> bug source trace/corrige en #8718). csharp_sha rebaseline suite au changement de blob."
   - '2026-07-28 (myia-po-2023) #8718 / See #8081 : FIX defaut mathematique cote Python -- cellule 29 (code execute) et cellule 28 (prose LaTeX) de la section 7 bis contractaient la variance par W(t) seul au lieu du facteur canonique (sigma_w^2 / c^2) * W(t) (Herbrich-Minka-Graepel 2007). La cellule imprimait sigma 8,33 -> 5,02 alors que le jumeau C# Infer-8 cellule 16 (vrai moteur EP) imprime N(29,21, 7,19). Correction des 2 lignes de code + alignement LaTeX + callout pedagogique + RE-EXECUTION cellule 29 (Stop & Repair, sortie reelle sigma -> 7,19 des deux cotes, match exact Infer-8). Source de l''erreur propagee dans #8709 cote C# (superseded par #8715 po-2026). python_sha rebaseline suite au changement de blob ; csharp_sha desormais porteur du fix #8715 (reconcilie au rebase).'

--- a/scripts/notebook_tools/twin_pairs.d/probas-9-classification.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-9-classification.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-9-Classification.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: 5171f5eac673b08f03930ad3cf8ba67516cea121
-    csharp_sha: 536e512f086a44306ebfb1bf241536c5055a8123
+  audits:
+    - date: "2026-07-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 5171f5eac673b08f03930ad3cf8ba67516cea121
+      csharp_sha: 536e512f086a44306ebfb1bf241536c5055a8123
   known_differences:
   - 'Socle pedagogique commun : classification bayesienne modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational

--- a/scripts/notebook_tools/twin_pairs.d/search-1-statespace.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-1-statespace.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2023:CoursIA-2
-    python_sha: eec0668ba49d9b95a067fafc1674a83edccdb055
-    csharp_sha: 1b1fc49cdd3b82a9d6af5c15829256ab5a183c17
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2023:CoursIA-2
+      python_sha: eec0668ba49d9b95a067fafc1674a83edccdb055
+      csharp_sha: 1b1fc49cdd3b82a9d6af5c15829256ab5a183c17
   known_differences:
     - "Socle pedagogique commun : modelisation d'un espace d'etats (noeuds, aretes, etat initial, etat but, successeurs). Exemples : grille 8-puzzle, monde du aspirateur, labyrinthe."
     - "Idiomes framework distincts : Python = dataclasses + frozenset pour etats hashables + `import typing`. C# = `using System.Collections.Generic;` (HashSet<T> pour etats visites, Dictionary<TState, IEnumerable<TState>> pour successeurs, struct/record pour etat)."

--- a/scripts/notebook_tools/twin_pairs.d/search-10-symbolicautomata.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-10-symbolicautomata.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata-Csharp.ipynb
   parity_level: surface
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 5542ba3e5ac011dbb7e9af495067833f0f75e28c
-    csharp_sha: 922dc82ca0574bbc967eff0b6070b9408a0c022c
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 5542ba3e5ac011dbb7e9af495067833f0f75e28c
+      csharp_sha: 922dc82ca0574bbc967eff0b6070b9408a0c022c
   known_differences:
     - "AVERTISSEMENT DE PERIMETRE : le jumeau C# est explicitement un twin PARTIEL -- son titre porte '(tranche 1)' et sa conclusion s'intitule 'Bilan (tranches 1 + 2)'. parity_level=surface (pas semantic) car la couverture C# est incomplete vs Python."
     - "Asymetrie de couverture forte : Python (91 cellules, 24 code) couvre §1-9 (automates finis avec automata-lib, automates symboliques avec Z3, verification de proprietes, lien Sudoku, Automata.Net) ; C# (39 cellules, 14 code) couvre §1-4 uniquement (automates finis a la main, automates symboliques avec Microsoft.Z3). Les sections 'verification de proprietes', 'lien Sudoku', 'Automata.Net' sont absentes du C#."

--- a/scripts/notebook_tools/twin_pairs.d/search-11-metaheuristics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-11-metaheuristics.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: po-2024
-    python_sha: 037f3e5c663a9448b1009878f454be67951f9217
-    csharp_sha: b41a4e251e8bd06d6d2a51f14f5bbf96b48684f1
-    reason: "Measure/value fix (Python cell 21 « Interpretation : ABC sur Rosenbrock »): 3 value claims output-proven FALSE. The committed cell 20 output gives Solution ~[0.46,0.23,..] ~ [0,..,0] with Objectif 8.134688 (output itself prints «Optimal attendu: [1,..,1], f=0»), yet c21 claimed «solution proche de [1,..,1]» (near optimum) and table row «Vecteur proche de [1,..,1]» -- both backwards. Point 1 claimed «ABC adaptee a Rosenbrock», contradicted by c31 benchmark (ABC Rosenbrock 135.7250) and c34 synthesis «Catastrophique sur Rosenbrock (135,7)». Realigned all 3 to outputs (solution near [0,..,0] far from optimum f=8.13; «ABC peine sur Rosenbrock» with both §5 demo ~8.13 and §8 benchmark 135.7 cited). Markdown-only, 0 re-exec, no output change. C# twin has NO ABC (PSO/SA/GA/TSP from-scratch only, see known_differences), csharp unchanged."
+  audits:
+    - date: "2026-08-01"
+      by: po-2024
+      python_sha: 037f3e5c663a9448b1009878f454be67951f9217
+      csharp_sha: b41a4e251e8bd06d6d2a51f14f5bbf96b48684f1
+      reason: "Measure/value fix (Python cell 21 « Interpretation : ABC sur Rosenbrock »): 3 value claims output-proven FALSE. The committed cell 20 output gives Solution ~[0.46,0.23,..] ~ [0,..,0] with Objectif 8.134688 (output itself prints «Optimal attendu: [1,..,1], f=0»), yet c21 claimed «solution proche de [1,..,1]» (near optimum) and table row «Vecteur proche de [1,..,1]» -- both backwards. Point 1 claimed «ABC adaptee a Rosenbrock», contradicted by c31 benchmark (ABC Rosenbrock 135.7250) and c34 synthesis «Catastrophique sur Rosenbrock (135,7)». Realigned all 3 to outputs (solution near [0,..,0] far from optimum f=8.13; «ABC peine sur Rosenbrock» with both §5 demo ~8.13 and §8 benchmark 135.7 cited). Markdown-only, 0 re-exec, no output change. C# twin has NO ABC (PSO/SA/GA/TSP from-scratch only, see known_differences), csharp unchanged."
   known_differences:
     - "Socle commun : metaheuristiques d'optimisation (PSO Particle Swarm, SA Simulated Annealing), fonctions de benchmark, benchmark comparatif, analyse de parametres, exemple guide."
     - "Bibliotheque vs from-scratch : Python invoque MEALPy (librairie metaheuristique, 40+ algorithmes) pour PSO/ABC/SA/BRO ; C# implemente PSO/SA/GA from-scratch (System.Random, pas de NuGet metaheuristique)."

--- a/scripts/notebook_tools/twin_pairs.d/search-12-pattern-databases.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-12-pattern-databases.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Part3-Advanced/Search-12-PatternDatabases.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part3-Advanced/Search-12-PatternDatabases-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: po-2024
-    python_sha: 0b7a8f8777f3e2fdcff5540f0da1647af51f1e7d
-    csharp_sha: 2f13a4af6c57fcef3a4121a9b9ca7dd11aba3bc6
+  audits:
+    - date: "2026-08-01"
+      by: po-2024
+      python_sha: 0b7a8f8777f3e2fdcff5540f0da1647af51f1e7d
+      csharp_sha: 2f13a4af6c57fcef3a4121a9b9ca7dd11aba3bc6
   known_differences:
     - "Socle pedagogique commun : taquin 4x4 (15-puzzle), heuristique Manhattan, puis construction d'une Pattern Database (PDB) pour un sous-ensemble de tuiles afin d'estimer h* plus precisement que Manhattan."
     - "Idiomes framework : Python = `collections.deque` (BFS sur l'espace des patterns) + `numpy`/`matplotlib` (matrices + visualisation du plateau). C# = pur BCL `System.Collections.Generic` + `System.Linq` (`Dictionary`, `Queue`, `Array.IndexOf`), sans dependance externe."

--- a/scripts/notebook_tools/twin_pairs.d/search-13-limited-discrepancy-search.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-13-limited-discrepancy-search.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Part3-Advanced/Search-13-LimitedDiscrepancySearch.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part3-Advanced/Search-13-LimitedDiscrepancySearch-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 78a207157e912197358a83086ab8428e3847ca0e
-    csharp_sha: c371375a5fcdabb870072c6db55fbc42c42e210b
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 78a207157e912197358a83086ab8428e3847ca0e
+      csharp_sha: c371375a5fcdabb870072c6db55fbc42c42e210b
   known_differences:
     - "Socle pedagogique commun : sac a dos 0/1, Limited Discrepancy Search (LDS) borne le nombre d'ecarts a l'heuristique gloutonne (ratio valeur/poids decroissant) pour trouver l'optimum sans explorer tout l'arbre."
     - "Idiomes framework : Python = tuples nommes `(name, weight, value)` + fonctions pures (`greedy_knapsack`, `lds`). C# = `record Item(string Name, int Weight, int Value)` (immuable) + methodes retournant un tuple `(Value, Selection, Nodes)`."

--- a/scripts/notebook_tools/twin_pairs.d/search-14-weighted-a.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-14-weighted-a.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Part3-Advanced/Search-14-WeightedAstar.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part3-Advanced/Search-14-WeightedAstar-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: b97a441e1192d137bf999626a8685d071fc2056f
-    csharp_sha: dd94da21212e5d8179c62068e111d4caa6ced713
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: b97a441e1192d137bf999626a8685d071fc2056f
+      csharp_sha: dd94da21212e5d8179c62068e111d4caa6ced713
   known_differences:
     - "Socle pedagogique commun : Weighted A* (best-first sur f(n)=g(n)+W*h(n), W>=1) sur un terrain pondere, balayage de W, garantie de sous-optimalite bornee cout <= W*C* (Pohl 1970)."
     - "Idiomes framework : Python = `heapq` (min-heap, re-push sur meilleur g) + `itertools.product` + `random.Random(seed)` (Mersenne Twister). C# = `PriorityQueue<T, double>` (.NET 6+, min-heap natif) + `Random(seed)` (.NET PRNG, distinct du Mersenne Twister Python)."

--- a/scripts/notebook_tools/twin_pairs.d/search-15-networkx.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-15-networkx.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX-Csharp.ipynb
   parity_level: surface
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 0c683cf6e0555230549c7fc0cea61995c876eb3e
-    csharp_sha: eb47af5f9ac0e8a1dab26989671bfd0b6baad2c4
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 0c683cf6e0555230549c7fc0cea61995c876eb3e
+      csharp_sha: eb47af5f9ac0e8a1dab26989671bfd0b6baad2c4
   known_differences:
     - "Bibliotheque vs from-scratch : Python invoque NetworkX (librairie mature, algorithmes de graphes prets a l'emploi : plus courts chemins, centralites, flot max, Louvain, matching) ; C# implemente les algorithmes from-scratch sur une adjacency list maison (BFS, DFS, Dijkstra, Ford-Fulkerson). parity_level=surface (meme plan pedagogique, implementations independantes)."
     - "Asymetrie de couverture : Python (42 cellules, 21 code) couvre §1-10 (construction, visualisation matplotlib, plus courts chemins, centralites, flot maximum, detection de communautes Louvain, matching pondere, Prong-B #3801) ; C# (20 cellules, 9 code) couvre §1-6 (graphe pondere, BFS/DFS, Dijkstra, centralites, flot maximum Ford-Fulkerson, visualisation ASCII). Louvain, matching pondere et Prong-B sont absents du C#."

--- a/scripts/notebook_tools/twin_pairs.d/search-2-uninformed.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-2-uninformed.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: bd3d87d8d9a4e4dc00e53a306cbd1979dc8e4901
-    csharp_sha: b2370d89b77a1eca64d780900798e9b02ba8a06f
-    reason: "c.1123 #8052 C# c19 IDDFS depth/iteration count (profondeur 3->2, 4->3 itérations); Python twin clean (generic d-table)"
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: bd3d87d8d9a4e4dc00e53a306cbd1979dc8e4901
+      csharp_sha: b2370d89b77a1eca64d780900798e9b02ba8a06f
+      reason: "c.1123 #8052 C# c19 IDDFS depth/iteration count (profondeur 3->2, 4->3 itérations); Python twin clean (generic d-table)"
   known_differences:
     - "Socle pedagogique commun : BFS (largeur), DFS (profondeur), UCS (cout uniforme), iterative deepening. Exemples : labyrinthe, 8-puzzle, Arrive en Roumanie."
     - "Idiomes framework : Python = `from collections import deque` (BFS FIFO) + `import heapq` (UCS priority queue). C# = `System.Collections.Generic.Queue<T>` (BFS) + `PriorityQueue<TElement, TPriority>` (.NET 6+, UCS) ; recursion via Stack<T> pour DFS."

--- a/scripts/notebook_tools/twin_pairs.d/search-3-informed.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-3-informed.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 2ead147f031bb101e5db38c15bf0223628626fce
-    csharp_sha: bf8c96dd9e8698d84e62e40933356e8394d4fe58
-    reason: "rebase c.1241: Python Ex4 phantom-label fix (c63, markdown-only); C# heuristic drift c.1123 (c5/c8/c12/c19) unchanged"
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 2ead147f031bb101e5db38c15bf0223628626fce
+      csharp_sha: bf8c96dd9e8698d84e62e40933356e8394d4fe58
+      reason: "rebase c.1241: Python Ex4 phantom-label fix (c63, markdown-only); C# heuristic drift c.1123 (c5/c8/c12/c19) unchanged"
   known_differences:
     - "Socle pedagogique commun : A* et Greedy Best-First avec differentes heuristiques (distance Manhattan, euclidienne, h=0=degenere en UCS). Arrive en Roumanie + 8-puzzle."
     - "Idiomes framework : Python = `import heapq` (priority queue avec (f, tie_breaker, noeud)). C# = `PriorityQueue<AStarNode, double>` (f-cost = g + h)."

--- a/scripts/notebook_tools/twin_pairs.d/search-4-localsearch.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-4-localsearch.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2023:CoursIA
-    python_sha: 952bcfdc76d9081394fc63e46f999c1d826c54a4
-    csharp_sha: d82c3b21f1f515ae25ec06eb1dc733ace1d39b05
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2023:CoursIA
+      python_sha: 952bcfdc76d9081394fc63e46f999c1d826c54a4
+      csharp_sha: d82c3b21f1f515ae25ec06eb1dc733ace1d39b05
   known_differences:
     - "Socle pedagogique commun : metaheuristiques de recherche locale — Hill Climbing (variations steepest/first-improvement + diagnosis plateau/ridge), Simulated Annealing (schema de refroidissement, critere de Metropolis), Tabu Search (liste tabou, memoire a court terme). Comparaison empirique sur N-Reines. Les deux twins implementent les 3 algorithmes from-scratch (parite algorithmique, pas seulement narratif)."
     - "Citations canoniques presentes des deux cotes (audit #8081 po-2023 c.909) : Kirkpatrick/Gelatt/Vecchi 1983 (Simulated Annealing, Science), Glover 1986/1989 (Tabu Search), Russell & Norvig AIMA (cadre local search)."

--- a/scripts/notebook_tools/twin_pairs.d/search-5-geneticalgorithms.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-5-geneticalgorithms.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2026:CoursIA
-    python_sha: 302e714c9920f536e87ce2d89bff63125d45d0a4
-    csharp_sha: e250e1fc294bd7be5cac4a85ca5a25d25e989ef2
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2026:CoursIA
+      python_sha: 302e714c9920f536e87ce2d89bff63125d45d0a4
+      csharp_sha: e250e1fc294bd7be5cac4a85ca5a25d25e989ef2
   known_differences:
     - "Rebaseline c.34 (ai-01) : #8697 a insere le bloc `metadata.cost` (#8056) a l'identique sur les DEUX jumeaux — les deux blob SHA ont bouge, la parite semantique est inchangee. Attestation de parite, pas reparation."
     - "Socle pedagogique commun : algorithmes genetiques (AG) — composants d'un AG (population, fonction de fitness, selection (roulette/tournoi), crossover, mutation), schemas d'evolution, probleme OneMax. Les deux twins implementent le cycle evolutionnaire from-scratch (population initiale → evaluation fitness → selection → croisement → mutation → nouvelle generation)."

--- a/scripts/notebook_tools/twin_pairs.d/search-6-adversarialsearch.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-6-adversarialsearch.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: 9f45a455403482150ba47f98eb38746900ca057c
-    csharp_sha: a1d30fc3fabf281b7f7297e79718c7a63c2c1de4
+  audits:
+    - date: "2026-07-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 9f45a455403482150ba47f98eb38746900ca057c
+      csharp_sha: a1d30fc3fabf281b7f7297e79718c7a63c2c1de4
   known_differences:
     - "Rebaseline c.34 (ai-01) : #8697 a insere le bloc `metadata.cost` (#8056) a l'identique sur les DEUX jumeaux — les deux blob SHA ont bouge, la parite semantique est inchangee. Attestation de parite, pas reparation."
     - "Socle commun : jeux a somme nulle a information parfaite (Tic-Tac-Toe/Morpion), minimax, elagage alpha-beta, iterative deepening, tables de transposition."

--- a/scripts/notebook_tools/twin_pairs.d/search-7-mcts-and-beyond.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-7-mcts-and-beyond.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 3cd0115d7c5acb77ac420e198b1492db0a674798
-    csharp_sha: 97aa863e71ed279785e9bdf3cdc14064b1a2d386
-    reason: "Markdown-only structural fix (Python cell 13): the MCTS-vs-Minimax comparison table omitted the MCTS(500) column even though the introducing sentence («100, 500, 1000, 5000 iterations») and the cell-12 benchmark output (5 rows: Minimax, MCTS(100), MCTS(500), MCTS(1000), MCTS(5000)) both include it. Added the MCTS(500) column with the committed-output values (Temps 0.009773->~0.010, Valeur 0.528455->~0.53, Action 4->centre). No re-exec, no output change. The C# twin uses a different comparison-table structure (Aspect|Signification), no parallel defect, csharp unchanged."
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 3cd0115d7c5acb77ac420e198b1492db0a674798
+      csharp_sha: 97aa863e71ed279785e9bdf3cdc14064b1a2d386
+      reason: "Markdown-only structural fix (Python cell 13): the MCTS-vs-Minimax comparison table omitted the MCTS(500) column even though the introducing sentence («100, 500, 1000, 5000 iterations») and the cell-12 benchmark output (5 rows: Minimax, MCTS(100), MCTS(500), MCTS(1000), MCTS(5000)) both include it. Added the MCTS(500) column with the committed-output values (Temps 0.009773->~0.010, Valeur 0.528455->~0.53, Action 4->centre). No re-exec, no output change. The C# twin uses a different comparison-table structure (Aspect|Signification), no parallel defect, csharp unchanged."
   known_differences:
     - "Rebaseline c.34 (ai-01) : #8697 a insere le bloc `metadata.cost` (#8056) a l'identique sur les DEUX jumeaux — les deux blob SHA ont bouge, la parite semantique est inchangee. Attestation de parite, pas reparation."
     - "Socle commun : limites de minimax, algorithme MCTS (selection/expansion/simulation/retropropagation), test sur Tic-Tac-Toe, comparaison MCTS vs minimax, framework OpenSpiel, AlphaGo/AlphaZero, extensions avancees. Structure des sections quasi-identique (le jumeau le plus proche cellule-a-cellule de la famille)."

--- a/scripts/notebook_tools/twin_pairs.d/search-8-dancinglinks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-8-dancinglinks.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: 16f7e7cdb38e559dcebf1ca3480c056d0690eec8
-    csharp_sha: 6f8406e999d2e74ff5e615e32efb8c7342396c73
-    reason: "Markdown-only identity fix (Python cells 53+54): the worked-example enonce (cell 53) and the code comment (cell 54) of the 5-element Exemple 1 instance both wrote S2 = {1, 4}, but the actual matrix row [0,1,0,1,0], the sets dict {1:{2,4}}, and the committed output (S2 couvre {2, 4}, Couverture exacte True) all use {2, 4} -- with {1,4} the cover would miss element 2 and double-cover 1, making an exact cover impossible. Aligned the enonce + comment to {2, 4}. NOTE: the early visualization cell 5 uses a SEPARATE 7-element instance where S2 = {1, 4} is correct (same instance as the C# twin) -- left untouched. C# twin is a different 7-element instance, no parallel defect. No re-exec, no output change."
+  audits:
+    - date: "2026-07-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 16f7e7cdb38e559dcebf1ca3480c056d0690eec8
+      csharp_sha: 6f8406e999d2e74ff5e615e32efb8c7342396c73
+      reason: "Markdown-only identity fix (Python cells 53+54): the worked-example enonce (cell 53) and the code comment (cell 54) of the 5-element Exemple 1 instance both wrote S2 = {1, 4}, but the actual matrix row [0,1,0,1,0], the sets dict {1:{2,4}}, and the committed output (S2 couvre {2, 4}, Couverture exacte True) all use {2, 4} -- with {1,4} the cover would miss element 2 and double-cover 1, making an exact cover impossible. Aligned the enonce + comment to {2, 4}. NOTE: the early visualization cell 5 uses a SEPARATE 7-element instance where S2 = {1, 4} is correct (same instance as the C# twin) -- left untouched. C# twin is a different 7-element instance, no parallel defect. No re-exec, no output change."
   known_differences:
     - "Rebaseline c.34 (ai-01) : #8697 a insere le bloc `metadata.cost` (#8056) a l'identique sur les DEUX jumeaux — les deux blob SHA ont bouge, la parite semantique est inchangee. Attestation de parite, pas reparation."
     - "Socle commun : probleme de couverture exacte, algorithme X de Knuth, structure de donnees Dancing Links (DLX), implementation DLX, application polyominos, comparaison de performances DLX vs backtracking."

--- a/scripts/notebook_tools/twin_pairs.d/search-9-linearprogramming.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-9-linearprogramming.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2023:CoursIA-2
-    python_sha: d1d4f36599e49147f58195e85a475476d269680c
-    csharp_sha: a6d7a7a59ded4ba7732054d17a66c5e40bb80c9f
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2023:CoursIA-2
+      python_sha: d1d4f36599e49147f58195e85a475476d269680c
+      csharp_sha: a6d7a7a59ded4ba7732054d17a66c5e40bb80c9f
   known_differences:
     - "Rebaseline c.34 (ai-01) : #8697 a insere le bloc `metadata.cost` (#8056) a l'identique sur les DEUX jumeaux — les deux blob SHA ont bouge, la parite semantique est inchangee. Attestation de parite, pas reparation."
     - "Solveur SOTA distinct : Python = PuLP (interface declarative, solveur CBC par defaut) ; C# = Google.OrTools (GLOP simplexe pour PL continue, CBC pour PLNE). Les deux invoquent un vrai solveur industriel -- parite SOTA, pas reimplementation."

--- a/scripts/notebook_tools/twin_pairs.d/sl-1-logicallearning.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-1-logicallearning.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-01"
-    by: myia-po-2023:CoursIA
-    python_sha: 54e32cb14b4791558f1017d16974ea0ee19d62af
-    csharp_sha: 8013c9d785020bb014f29f74e4cf64e4a413f595
+  audits:
+    - date: "2026-08-01"
+      by: myia-po-2023:CoursIA
+      python_sha: 54e32cb14b4791558f1017d16974ea0ee19d62af
+      csharp_sha: 8013c9d785020bb014f29f74e4cf64e4a413f595
   known_differences:
     - "Socle commun : apprentissage logique symbolique -- Current-Best-Hypothesis (CBH) et Version Space / Candidate Elimination, sur le domaine restaurant (AIMA)."
     - "Asymetrie de couverture : le jumeau Python (58 cellules, 18 code) couvre 9 sections incluant visualisation de l'evolution du Version Space et une section 'implementation de reference : aima-python' ; le jumeau C# (21 cellules, 9 code) est plus compact (10 sections, pas de visualisation graphique)."

--- a/scripts/notebook_tools/twin_pairs.d/sl-10-activeautomatalearning.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-10-activeautomatalearning.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning-Csharp.ipynb
   parity_level: native-both
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: fdeaf01f01084c49f4a24079d8191092609312b8
-    csharp_sha: 329bc61e49b55b0261a76bb80305f29d4556d67c
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: fdeaf01f01084c49f4a24079d8191092609312b8
+      csharp_sha: 329bc61e49b55b0261a76bb80305f29d4556d67c
   known_differences:
     - "Socle commun : apprentissage actif d'automates -- algorithme L* d'Angluin, modele MAT (Minimally Adequate Teacher), table d'observation, oracle d'equivalence, pont vers Infer.NET (DFA exact a reconnaissance probabiliste)."
     - "Structure quasi-identique : 45 cellules les deux cotes (17 code, 28 markdown), memes 9 sections dans le meme ordre -- c'est le twin le plus proche cellule-a-cellule de la famille SL (parite native-both)."

--- a/scripts/notebook_tools/twin_pairs.d/sl-2-knowledgebasedlearning.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-2-knowledgebasedlearning.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 6eaf20ca712b255fb724606ee37772ee2b24f691
-    csharp_sha: 275bd7259ed84ce600bb09308af699878965cf38
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 6eaf20ca712b255fb724606ee37772ee2b24f691
+      csharp_sha: 275bd7259ed84ce600bb09308af699878965cf38
   known_differences:
     - "Socle commun : Explanation-Based Learning (EBL) et Relevance-Based Learning (RBL) -- variabilisation, extraction de regle, speedup, determinations."
     - "Asymetrie de couverture : Python (44 cellules, 15 code) couvre EBL (simplification arithmetique, variabilisation, implementation complete, efficacite) + RBL (introduction aux determinations) ; C# (18 cellules, 9 code) couvre EBL (chainage avant avec unification, speedup) + RBL (verification de determination) -- structure plus serree."

--- a/scripts/notebook_tools/twin_pairs.d/sl-3-relevancelearning.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-3-relevancelearning.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 40f2cd7c36fcbb293ad79aae55109190e0272458
-    csharp_sha: 7b065b84b9a88aa7f1986fda628aa70d2127e4ba
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 40f2cd7c36fcbb293ad79aae55109190e0272458
+      csharp_sha: 7b065b84b9a88aa7f1986fda628aa70d2127e4ba
   known_differences:
     - "Socle commun : Relevance-Based Learning (RBL) approfondi -- determinations fonctionnelles, treillis des determinations, algorithme MINIMAL-CONSISTENT-DET, selection d'attributs guidee."
     - "Asymetrie de couverture : Python (42 cellules, 17 code) couvre determinations + treillis + MINIMAL-CONSISTENT-DET + lien Web Semantique + defi presentation ; C# (23 cellules, 11 code) couvre determinations + treillis (powerset) + determination minimale + application activite biologique + borne PAC + information mutuelle. Les deux cotes apportent des enrichissements distincts (Web Semantique cote Python, borne PAC + information mutuelle cote C#)."

--- a/scripts/notebook_tools/twin_pairs.d/sl-4-inductivelogicprogramming.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-4-inductivelogicprogramming.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming-Csharp.ipynb
   parity_level: surface
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 5989c12479280ccd887129b7fd6bd98ae98c0734
-    csharp_sha: ea011ad638e69c982deb3f508e45841b3d71a75a
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 5989c12479280ccd887129b7fd6bd98ae98c0734
+      csharp_sha: ea011ad638e69c982deb3f508e45841b3d71a75a
   known_differences:
     - "AVERTISSEMENT D'INGENIERIE : parity_level=surface car le jumeau Python INVOQUE un vrai moteur ILP SOTA (SWI-Prolog via pyswip + reference a Popper 'Learning From Failures') tandis que le C# reimplémente FOIL from-scratch (pas de moteur Prolog). Meme concept pedagogique, machineries differentes."
     - "Asymetrie de couverture : Python (48 cellules, 19 code) couvre clauses Horn + unification, FOIL top-down, resolution inverse bottom-up, application FOIL pas-a-pas, ILP et Knowledge Graphs, + section dediee au vrai moteur Popper (LFF) ; C# (25 cellules, 10 code) couvre clauses Horn + unification, briques FOIL, probleme des ancetres, evaluation de clauses candidates, resolution inverse, FOIL pas-a-pas, mini KG."

--- a/scripts/notebook_tools/twin_pairs.d/sl-5-inverseresolution.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-5-inverseresolution.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb
   parity_level: surface
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: c132ed57588fa697b3725533daeeb2d21816c7f5
-    csharp_sha: 4b57327282a8e9eddace41724e021c03a05d30b9
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: c132ed57588fa697b3725533daeeb2d21816c7f5
+      csharp_sha: 4b57327282a8e9eddace41724e021c03a05d30b9
   known_differences:
     - "AVERTISSEMENT D'INGENIERIE : parity_level=surface. Python INVOQUE SWI-Prolog (moteur reel) pour la resolution et l'unification ; C# reimplemente LGG (Plotkin), theta-subsomption, clause bottom from-scratch."
     - "Socle commun : resolution inverse, LGG (Least General Generalization, Plotkin 1970), theta-subsomption (ordre du treillis), clause bottom (saturation), recherche a la Progol."

--- a/scripts/notebook_tools/twin_pairs.d/sl-6-modernilp.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-6-modernilp.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-ModernILP.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-ModernILP-Csharp.ipynb
   parity_level: surface
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 5987b939ee2725614feb3a08a51b54b20be6018e
-    csharp_sha: b2861f9b3f92d79a57666890cfab01846d60805d
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 5987b939ee2725614feb3a08a51b54b20be6018e
+      csharp_sha: b2861f9b3f92d79a57666890cfab01846d60805d
   known_differences:
     - "AVERTISSEMENT D'INGENIERIE : parity_level=surface. Python INVOQUE SWI-Prolog et documente les 4 moteurs ILP modernes (Aleph, Metagol/MIL, Popper/LFF, dILP/Lernd) en prose ; C# reimplémente FOIL (Quinlan 1990) from-scratch comme demonstration pedagogique unique."
     - "Socle commun : moteurs ILP modernes -- la tache commune est 'apprendre ancestor' (programme recursif)."

--- a/scripts/notebook_tools/twin_pairs.d/sl-8-knowledgegraphs-ilp.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-8-knowledgegraphs-ilp.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-KnowledgeGraphs-ILP.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-KnowledgeGraphs-ILP-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: c7e229126c670dac3e3d119b56b8f727003bce8a
-    csharp_sha: 376249822ecee95d86a8d1f806a99b7595486bc7
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: c7e229126c670dac3e3d119b56b8f727003bce8a
+      csharp_sha: 376249822ecee95d86a8d1f806a99b7595486bc7
   known_differences:
     - "Socle commun : ILP moderne sur Knowledge Graphs -- construction du KG familial, extraction des relations, rule mining (decouverte de regles de Horn), enumeration des candidats, passage des regles d'association aux regles logiques, completion du KG."
     - "Librairies SOTA distinctes mais equivalents : Python = rdflib (construction/manipulation RDF) + AMIE (rule mining) ; C# = dotNetRDF (equivalent .NET de rdflib) + AMIE. parity_level=semantic car les deux cotes invoquent de vraies librairies KG (pas from-scratch) -- c'est le twin le plus proche lib-vs-lib de la famille SL."

--- a/scripts/notebook_tools/twin_pairs.d/socialchoice-1-arrow-impossibility.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/socialchoice-1-arrow-impossibility.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: b23da83abdc8fe436d3c7883147671432a451dcd
-    csharp_sha: b45fe4157ec3f2fe355fdc31b14c5f82f6b6b7ac
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: b23da83abdc8fe436d3c7883147671432a451dcd
+      csharp_sha: b45fe4157ec3f2fe355fdc31b14c5f82f6b6b7ac
   known_differences:
     - "Socle pedagogique commun : theoreme d'impossibilite d'Arrow (1951) — formalisation d'un profil de preferences social, les 3 axiomes (Unanimite/Pareto, Independence of Irrelevant Alternatives/IIA, Non-dictature), et demonstration qu'aucune agregation ne peut satisfaire les 3 simultanement. Les deux twins couvrent les axiomes + une approche de refutation (encodage SAT / enumeration force-brute montrant la contradiction)."
     - "Idiomes framework : Python = demonstrations riches (41 cellules, preuve formelle en 4 etapes d'apres Geanakoplos 2005, visualisation de la synthese des resultats). C# = pur System.* (System / System.Collections.Generic / System.Linq / System.Globalization), 0 NuGet, 4 using, 30 cellules (regles de vote from-scratch + structure de la preuve + refutation par enumeration complete force-brute)."

--- a/scripts/notebook_tools/twin_pairs.d/socialchoice-3-voting-methods.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/socialchoice-3-voting-methods.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 7d3ea48c681d137b25725c50e9c4d78678fd6ba8
-    csharp_sha: 0d127926ec65642b24c16d7ca24cfa88cae11830
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 7d3ea48c681d137b25725c50e9c4d78678fd6ba8
+      csharp_sha: 0d127926ec65642b24c16d7ca24cfa88cae11830
   known_differences:
     - "2026-07-25 (po-2024) #8052 case-A : median-voter preference order -- cell#29 (devenu #29 apres #8566) table disait pic=5 => '4 > 6 > 2 > 0 > 8 > 10' mais l'output code (Electeur 4 pic=5: [4,6,2,8,0,10]) prouve '4 > 6 > 2 > 8 > 0 > 10' (single_peaked_preference sort stable par |x-5|). Markdown-only 1-line swap, no re-exec. csharp_sha inchange. python_sha rebaseline suite a ce changement de blob."
     - "2026-07-25 (po-2024) #8564 : IIA verdict honnetete + contre-exemple Copeland -- cell#23 imprimait `=> respecte IIA` des que le compteur Monte-Carlo tombait a 0, mais Copeland (Condorcet-consistante) VIOLE IIA (theoreme). Fix : verdict existentiel seul (0/100 => 'aucune violation observee, n'etablit pas respecte IIA' ; >0 => 'VIOLE IIA (N contre-exemples)'). Ajout cellule contre-exemple constructif (profil cyclique 4 alts A>B>C>D / B>C>D>A / C>D>A>B : A bat B pairwise, Copeland classe B>A avec C,D vs A>B sans -- inversion = IIA violée prouvee). markdown cell#24 (devenu #26) corrigé ('Copeland respecte IIA car pairwise' etait faux). csharp_sha inchange (twin C# non touche). python_sha rebaseline suite a ce changement de blob."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-1-backtracking.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-1-backtracking.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-03"
-    by: myia-po-2023:CoursIA
-    python_sha: 8a1465a542c0f9ec6634036ffd993e934667cb0a
-    csharp_sha: 37c65d0a912695c7b4387b8fc373d3a6458ea5f5
+  audits:
+    - date: "2026-08-03"
+      by: myia-po-2023:CoursIA
+      python_sha: 8a1465a542c0f9ec6634036ffd993e934667cb0a
+      csharp_sha: 37c65d0a912695c7b4387b8fc373d3a6458ea5f5
   known_differences:
     - "Socle pedagogique commun : algorithme de backtracking (retour sur trace) pour resoudre un mini-Sudoku, meme concept algorithmique (recursion + propagation de contraintes + retour-arriere sur conflit), meme cas d'application pedagogique (grille partiellement remplie, recherche systematique)."
     - "Divergence d'implementation : le Python implemente le backtracking from scratch (fonction recursive + suivi des conflits) avec une visualisation matplotlib/numpy du deroulement ; le C# implemente le backtracking pur en stdlib (System.*) sans visualisation. Meme algorithme, niveau d'abstraction et d'enrichissement visuel differents."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-10-ortools.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-10-ortools.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 25c9790ba0ba6e5e4747515ff7fc7c60829569bb
-    csharp_sha: 6e23876720519849d48a72d95365cc0cc95384bd
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 25c9790ba0ba6e5e4747515ff7fc7c60829569bb
+      csharp_sha: 6e23876720519849d48a72d95365cc0cc95384bd
   known_differences:
     - "Socle pedagogique commun : resolution du Sudoku par programmation par contraintes avec OR-Tools CP-SAT (Google.OrTools), meme solveur sous-jacent, meme modelisation (variables IntVar par case, contraintes AllDifferent sur lignes/colonnes/blocs, objectif de satisfaction)."
     - "Idiomes framework symetriques : Python = `from ortools.sat.python import cp_model` (binding Python natif), C# = NuGet `#r \"nuget: Google.OrTools\"` + `using IntVar / SimpleCPSolver / SimpleConstraint` (binding .NET). Les deux cotes deleguent au meme moteur CP-SAT de Google, seules les API de binding different."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-11-choco.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-11-choco.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: aa49b097f61d8b7feb617d65304c7a327df489cc
-    csharp_sha: b1cedb474514fc7a8afdf87594c5fc229b6f4c0c
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: aa49b097f61d8b7feb617d65304c7a327df489cc
+      csharp_sha: b1cedb474514fc7a8afdf87594c5fc229b6f4c0c
   known_differences:
     - "Socle pedagogique commun : resolution de Sudoku par programmation par contraintes (CP) avec le solveur Choco -- modelisation (variables, domaines, contraintes), propagation, recherche. Meme solveur (Choco), meme cas d'application (Sudoku). Les deux couvrent Choco, choco, Solver."
     - "Divergence d'implementation : le C# accede a Choco via IKVM (bridge Java->.NET, NuGet IKVM 8.15.0 + IKVM.Image) -- Choco etant une lib Java, le C# la consomme a travers le runtime IKVM ; le Python (pur stdlib, 0 dependance Choco) implemente un solveur CP a la Choco from scratch (propagation, recherche). Meme paradigme CP, deux niveaux : le C# wrappe le vrai Choco via IKVM (RECOVERABLE-MACHINE per SOTA ledger Entry #008 : IKVM instable dans dotnet-interactive), le Python reconstruit la logique CP didactiquement."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-12-z3.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-12-z3.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: b96f422f56c22836ef891e82a3f2df25d59453f1
-    csharp_sha: 89dec9e761a784698299ac2fd1498107f08ebab2
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: b96f422f56c22836ef891e82a3f2df25d59453f1
+      csharp_sha: 89dec9e761a784698299ac2fd1498107f08ebab2
   known_differences:
     - "Socle pedagogique commun : resolution de Sudoku par SMT (Satisfiability Modulo Theories) avec le vrai solveur Z3 (Microsoft Research) -- modelisation des contraintes Sudoku comme formules logiques (BitVec, contraintes all-different sur lignes/colonnes/carres), resolution par le solveur SMT. Les deux cotes utilisent le VRAI Z3 SOTA (meme moteur sous-jacent), meme cas d'application (Sudoku). Les deux couvrent Z3, z3, BitVec, Solver."
     - "Divergence de binding : le C# accede a Z3 via Microsoft.Z3 (NuGet, bindings .NET natifs, 19 cellules code) ; le Python accede a Z3 via pyz3 (import z3, bindings Python, 11 cellules). C'est le meme solveur Z3 avec deux bindings idiomatiques -- c'est la definition meme de parity_level semantic (meme moteur, API idiomatique differente). Note : le Python reference aussi ortools (OR-Tools, alternative CP-SAT) en complement."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-13-symbolicautomata.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-13-symbolicautomata.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: f2171a8b02c88b0727db809bf176f11a6c31f59d
-    csharp_sha: b372afaf4f67fcf120fb4acb9931936754182ac9
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: f2171a8b02c88b0727db809bf176f11a6c31f59d
+      csharp_sha: b372afaf4f67fcf120fb4acb9931936754182ac9
   known_differences:
     - "Socle pedagogique commun : automates symboliques et resolution de Sudoku via Z3 (automates finis symboliques, representation symbolique des contraintes, liens avec SMT). Meme concept (automates symboliques + Z3 comme backend de decision), meme cas d'application (Sudoku). Les deux couvrent Z3, z3, symbolic, Solver."
     - "Divergence d'implementation : le C# (pur System.* stdlib, 0 NuGet, 18 cellules code) construit la logique d'automate symbolique from scratch avec references a Z3 ; le Python (pyz3, 10 cellules code) utilise les bindings Z3 directement pour la partie symbolique. Meme enseignement (automates symboliques + Z3), deux niveaux : construction from scratch cote C# vs bindings Z3 cote Python."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-14-bdd.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-14-bdd.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-03"
-    by: myia-po-2023:CoursIA
-    python_sha: 052095be135bdafe9306007fcd57a2b6ec69af55
-    csharp_sha: 16a4db36adb2eef7e579206ddb5d5161d434e99e
+  audits:
+    - date: "2026-08-03"
+      by: myia-po-2023:CoursIA
+      python_sha: 052095be135bdafe9306007fcd57a2b6ec69af55
+      csharp_sha: 16a4db36adb2eef7e579206ddb5d5161d434e99e
   known_differences:
     - "Socle pedagogique commun : resolution du Sudoku par automates a decision binaire (BDD / MDD, Binary/Multi-valued Decision Diagrams), meme concept (codage booleen des contraintes, reduction canonique du graphe de decision, satisfaction via parcours). Le notebook Python declare explicitement etre le jumeau du C# (« Jumeau Python du notebook Sudoku-14-BDD-Csharp.ipynb »)."
     - "Divergence d'implementation : les deux cotes hand-rollent les BDD/MDD from scratch (pas de lib BDD tierce) -- le Python via dataclasses/typing, le C# via System.Collections.Generic + System.Linq. Meme reconstruction pedagogique de l'automate, idiomes de langage differents."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-15-infer.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-15-infer.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-03"
-    by: myia-po-2023:CoursIA
-    python_sha: d1282426b7eea1e38e808669eace82467deb0567
-    csharp_sha: ef5632ca0b72c78238ffff335fd612369c064a78
+  audits:
+    - date: "2026-08-03"
+      by: myia-po-2023:CoursIA
+      python_sha: d1282426b7eea1e38e808669eace82467deb0567
+      csharp_sha: ef5632ca0b72c78238ffff335fd612369c064a78
   known_differences:
     - "Socle pedagogique commun : resolution PROBABILISTE du Sudoku par inference bayesienne/probabiliste, meme concept (modeliser l'incertitude sur les cases, inferrer les valeurs les plus probables), meme angle (approche non-deterministe par contraste avec les solveurs exacts de la serie)."
     - "Divergence de framework probabiliste : Python = NumPyro (MCMC, inference variationnelle, stochastic) ; C# = Infer.NET (modelisation probabiliste .NET, message passing). Meme paradigme (inference probabiliste), deux frameworks stochastiques distincts -- les sorties numeriques different d'une execution a l'autre (MCMC sampling), parite au niveau du concept et de la demarche, pas des valeurs exactes."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-2-dancinglinks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-2-dancinglinks.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: 59e277684255099f42d578085c52c3fb749b7fa1
-    csharp_sha: 156c7c4e68a21a5348a91ca49c279ffa92a79593
+  audits:
+    - date: "2026-07-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 59e277684255099f42d578085c52c3fb749b7fa1
+      csharp_sha: 156c7c4e68a21a5348a91ca49c279ffa92a79593
   known_differences:
     - "Socle pedagogique commun : algorithme Dancing Links (DLX) de Knuth / Algorithm X pour la couverture exacte (exact cover), applique a un mini-Sudoku 4x4. Meme concept mathematique (matrice binaire de couverture, selection de colonnes a cardinalite minimale, unlinking/relinking des noeuds), meme cas d'application (mini-Sudoku 4x4), meme exercice pedagogique (construire la matrice de couverture, stub TODO)."
     - "Divergence d'implementation : le C# delegue a la lib DlxLib (NuGet `#r \"nuget: DlxLib\"`, classe `DancingLinkSolver : ISudokuSolver` qui wrappe le solveur de la lib, importe le socle `Sudoku-0-Environment-Csharp.ipynb`) ; le Python implemente Dancing Links ENTIEREMENT from scratch (`class DancingLinksNode` a 4 voisins gauche/droite/haut/bas + `class DancingLinks` construisant la matrice creuse et executant l'Algorithm X de Knuth manuellement). Meme algorithme, deux niveaux d'abstraction : lib industrielle cote C# vs reconstruction pedagogique a la main cote Python."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-3-genetic.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-3-genetic.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-03"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 9d99369424476c432f9edad3e34d8f66af430f2d
-    csharp_sha: 7dfa219dc44150c1a09f884bc1f6c4f22c98f0eb
+  audits:
+    - date: "2026-08-03"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 9d99369424476c432f9edad3e34d8f66af430f2d
+      csharp_sha: 7dfa219dc44150c1a09f884bc1f6c4f22c98f0eb
   known_differences:
     - "Socle pedagogique commun : algorithme genetique (GA) applique au Sudoku -- population d'individus, selection, crossover, mutation, fonction de fitness (nombre de conflits). Meme concept evolutionnaire, meme cas d'application (resolution/amelioration d'une grille de Sudoku). Les deux exposent les memes primitives : Population, Crossover, Mutation, GeneticAlgorithm."
     - "Divergence d'implementation : le C# delegue a la lib GeneticSharp (NuGet, expose GeneticAlgorithm/Population/Crossover/Mutation au niveau framework) ; le Python implemente le GA from scratch sur numpy (Population/Crossover/Mutation codes a la main, fitness a base de conflits). Meme paradigme genetique, deux niveaux d'abstraction : framework SOTA cote C# vs reconstruction pedagogique a la main cote Python."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-4-simulatedannealing.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-4-simulatedannealing.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: 39980a85c8895cd5edb2443ba28a12d07ae4b8f2
-    csharp_sha: 1e982c6661c13ce0cb9f1ed1b40a81b85bd856ea
+  audits:
+    - date: "2026-07-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 39980a85c8895cd5edb2443ba28a12d07ae4b8f2
+      csharp_sha: 1e982c6661c13ce0cb9f1ed1b40a81b85bd856ea
   known_differences:
     - "Socle pedagogique commun : recuit simule (Simulated Annealing) applique au Sudoku -- schema de refroidissement (cooling schedule), temperature T decroissante, acceptation de Metropolis (accepter une solution pire avec probabilite exp(-delta/T)), voisinage par mutation locale. Meme algorithme, meme cas d'application (optimisation stochastique d'une grille)."
     - "Implementation from scratch des deux cotes (ni lib dediee C# ni framework Python) : le C# est pur stdlib System.* (0 NuGet, 17 cellules code) ; le Python utilise numpy/math/random (19 cellules code). Les deux codent le schedule de temperature, la mutation et le critere d'acceptation de Metropolis manuellement -- c'est la paire la plus proche d'une traduction native, mais les 2 implementations restent independantes (idiomes langage, structures de donnees), d'ou parity_level semantic et non native-both."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-5-pso.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-5-pso.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-30"
-    by: myia-po-2023:CoursIA-2
-    python_sha: cdf6f4ac64d6577faf16ce163cdac5a11b3764ed
-    csharp_sha: a65d1739c559cff2f65d1e24d679a10e8637f0da
+  audits:
+    - date: "2026-07-30"
+      by: myia-po-2023:CoursIA-2
+      python_sha: cdf6f4ac64d6577faf16ce163cdac5a11b3764ed
+      csharp_sha: a65d1739c559cff2f65d1e24d679a10e8637f0da
   known_differences:
     - "Socle pedagogique commun : optimisation par essaim de particules (Particle Swarm Optimization) appliquee au Sudoku -- population de particules, vecteurs position/vitesse, update via best personnel (pbest) et global (gbest), fonction de fitness (conflits Sudoku). Meme algorithme, meme cas d'application (optimisation stochastique d'une grille)."
     - "Divergence d'implementation : le Python (numpy + matplotlib, 15 cellules code) implemente le PSO avec visualisation (convergence de la fitness, trajectoires de l'essaim) ; le C# (pur System.* stdlib, 0 NuGet, 13 cellules code) implemente le PSO from scratch sans visualisation (sorties texte). Meme algorithme, deux angles : numerique+visualisation cote Python vs implementation pedagogique cote C#."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-6-aima-csp.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-6-aima-csp.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: fe336af927a925430b9b91f845559017e8caddbc
-    csharp_sha: 5fcb492875082155fdb8d9b04c7ce0fb450dfbb5
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: fe336af927a925430b9b91f845559017e8caddbc
+      csharp_sha: 5fcb492875082155fdb8d9b04c7ce0fb450dfbb5
   known_differences:
     - "Socle pedagogique commun : resolution de Sudoku comme probleme de satisfaction de contraintes (CSP), suivant le formalisme AIMA (Artificial Intelligence: A Modern Approach) -- AC-3 (arc consistency / propagation de contraintes), backtracking avec heuristiques (MRV, LCV), assign/eliminate (Norvig-style propagation). Meme concept mathematique (variables, domaines, contraintes binaires, arc consistency), meme cas canonique (Sudoku). Les deux couvrent AC3, backtracking, Norvig, AIMA, csp."
     - "Divergence d'implementation : le Python (numpy, 19 cellules code) implemente le framework CSP a la AIMA (classe CSP, AC-3, backtracking) ; le C# (pur System.* stdlib, 0 NuGet, 18 cellules code) implemente le meme framework CSP (AC-3, backtracking, assign/eliminate) sans dependance externe. Paire proche d'une traduction native (meme algorithmes, meme structure AIMA), mais les 2 implementations restent independantes (idiomes langage, structures de donnees), d'ou parity_level semantic et non native-both."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-7-norvig.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-7-norvig.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 953832780bf8b101e6fcba553c9deeb30cc4cef1
-    csharp_sha: f1ff5df6a78d6e57050c38a17ef37073494ffce3
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 953832780bf8b101e6fcba553c9deeb30cc4cef1
+      csharp_sha: f1ff5df6a78d6e57050c38a17ef37073494ffce3
   known_differences:
     - "Socle pedagogique commun : solveur de Sudoku de Peter Norvig (combinaison de constraint propagation + search) -- fonctions assign (assigner une valeur en eliminant des candidats) et eliminate (propager les contraintes via les unites/peers), backtracking search quand la propagation seule ne suffit pas. Meme algorithme (Norvig's solver), meme cas canonique (Sudoku). Les deux couvrent backtracking, Norvig, eliminate, assign."
     - "Implementation from scratch des deux cotes (NI lib dediee C# NI framework Python) : le C# est pur stdlib System.* (0 NuGet, 15 cellules code) ; le Python est aussi pur stdlib (0 numpy, 12 cellules code). C'est la paire la plus proche d'une traduction native : les deux codent assign/eliminate/search manuellement selon l'algorithme de Norvig. Mais les 2 implementations restent independantes (idiomes langage : dict/sets cote Python vs Dictionary/HashSet cote C#), d'ou parity_level semantic et non native-both."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-8-humanstrategies.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-8-humanstrategies.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-03"
-    by: myia-po-2023:CoursIA
-    python_sha: 7ce5db8ee3bb05faa0f72508bf26390e3ff70f87
-    csharp_sha: 533b34ff9fb08626f3a41b3c8ce2acb0ffd6d239
+  audits:
+    - date: "2026-08-03"
+      by: myia-po-2023:CoursIA
+      python_sha: 7ce5db8ee3bb05faa0f72508bf26390e3ff70f87
+      csharp_sha: 533b34ff9fb08626f3a41b3c8ce2acb0ffd6d239
   known_differences:
     - "Socle pedagogique commun : strategies de resolution humaines (techniques d'inference -- naked/hidden singles, pointing pairs, box-line) appliquees au Sudoku, meme concept (simuler le raisonnement humain par couches d'inference successives plutot qu'un backtracking brut), meme arc pedagogique (theorie -> implementation -> benchmark)."
     - "Divergence d'implementation : le Python implemente les techniques d'inference from scratch + visualisation networkx du graphe de contraintes ; le C# implemente les memes strategies d'inference en stdlib avec un benchmark comparatif. Idiomes de visualisation differents (networkx cote Python)."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-9-graphcoloring.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-9-graphcoloring.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-03"
-    by: myia-po-2023:CoursIA
-    python_sha: 8468688beb8513f870e571c57eded9224f2c9cb7
-    csharp_sha: 1a629086fd9a29cd9fb4d705e44ba085d02a4583
+  audits:
+    - date: "2026-08-03"
+      by: myia-po-2023:CoursIA
+      python_sha: 8468688beb8513f870e571c57eded9224f2c9cb7
+      csharp_sha: 1a629086fd9a29cd9fb4d705e44ba085d02a4583
   known_differences:
     - "Socle pedagogique commun : reformulation du Sudoku comme un probleme de coloration de graphe (une cellule = un noeud, le graphe de contraintes Sudoku, coloration propre a 9 couleurs), meme concept mathematique (graphe de conflits, coloration propre), meme cas d'application."
     - "Idiomes framework : Python = networkx (construction du graphe) + OR-Tools CP-SAT (resolution de la coloration) ; C# = construction du graphe + solveur de coloration en stdlib. Meme reformulation graph-coloring, libs de graphe differentes."

--- a/scripts/notebook_tools/twin_pairs.d/sw-10-rdf-star.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-10-rdf-star.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-CSharp-RDFStar.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 2043be1e638157cf01189d44cfa70f5c4ae061d0
-    csharp_sha: e184307cf2a6180399e776bf200058e283fb9bf2
-    reason: "Identity/phantom fix (Python cell 58 footer Navigation): the display labels were off-by-one vs the notebook OWN header (cell 0). Header says « 9-JSONLD » and « 11-KnowledgeGraphs », but the footer said « 10-JSONLD » and « 12-KnowledgeGraphs ». The link URLs were already correct in both (SW-9-Python-JSONLD.ipynb, SW-11-Python-KnowledgeGraphs.ipynb) -- only the human-readable labels were wrong. Fixed the 2 footer labels to match the header. Markdown-only, 0 re-exec, no output change. No §D.5 (identity/phantom class, not a measure/value drift). C# twin SW-10-CSharp-RDFStar nav uses a different structure (points to the Python jumeau, no KnowledgeGraphs forward link) and is correct -> csharp unchanged."
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 2043be1e638157cf01189d44cfa70f5c4ae061d0
+      csharp_sha: e184307cf2a6180399e776bf200058e283fb9bf2
+      reason: "Identity/phantom fix (Python cell 58 footer Navigation): the display labels were off-by-one vs the notebook OWN header (cell 0). Header says « 9-JSONLD » and « 11-KnowledgeGraphs », but the footer said « 10-JSONLD » and « 12-KnowledgeGraphs ». The link URLs were already correct in both (SW-9-Python-JSONLD.ipynb, SW-11-Python-KnowledgeGraphs.ipynb) -- only the human-readable labels were wrong. Fixed the 2 footer labels to match the header. Markdown-only, 0 re-exec, no output change. No §D.5 (identity/phantom class, not a measure/value drift). C# twin SW-10-CSharp-RDFStar nav uses a different structure (points to the Python jumeau, no KnowledgeGraphs forward link) and is correct -> csharp unchanged."
   known_differences:
     - "Socle commun : meta-modelisation RDF-star (triplets sur des triplets, quotes nestees)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Query` support RDF-star). Python = `rdflib` (`rdflib.term` triplets-nommes). RDF-star est une extension communautaire (pas encore W3C standardise) ; support experimental des deux cotes."

--- a/scripts/notebook_tools/twin_pairs.d/sw-11-knowledge-graphs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-11-knowledge-graphs.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-CSharp-KnowledgeGraphs.ipynb
   parity_level: surface
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: a10e51c238cde777905354166118fd1bc5ad199a
-    csharp_sha: 47e9629433702421b9bff134b157efe7673ed12c
-    reason: "c58+c61+c64 SHACL cross-refs pointed at SW-9 (Linked Data); SHACL is SW-8 (cf. own c0 header). Python-only, csharp PRESERVED (parity=surface)."
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: a10e51c238cde777905354166118fd1bc5ad199a
+      csharp_sha: 47e9629433702421b9bff134b157efe7673ed12c
+      reason: "c58+c61+c64 SHACL cross-refs pointed at SW-9 (Linked Data); SHACL is SW-8 (cf. own c0 header). Python-only, csharp PRESERVED (parity=surface)."
   known_differences:
     - "Socle commun : construction d'un graphe de connaissances (RDF + ontologie + requetage)."
     - "Asymetrie de profondeur (surface) : le Python combine TROIS librairies -- `rdflib` (RDF), `owlready2` (ontologie OWL), et `networkx` (algorithmes de graphe : centralite, composantes connexes, plus courts chemins). Le C# reste sur `dotNetRDF` seul (`VDS.RDF.Query`), sans dimension d'analyse de graphe (centralite/communautes)."

--- a/scripts/notebook_tools/twin_pairs.d/sw-13-reasoners.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-13-reasoners.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: a5ef2be10882b29368b2d0ec680ecf828ab59213
-    csharp_sha: 2bf1075659212ac6ca9f5e5ce46206791d3a9933
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: a5ef2be10882b29368b2d0ec680ecf828ab59213
+      csharp_sha: 2bf1075659212ac6ca9f5e5ce46206791d3a9933
   known_differences:
     - "Socle commun : raisonnement automatique sur ontologies (forward-chaining, inference RDFS/OWL)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Query.Inference` : IInferenceEngine, OwlReasoner integre). Python = `rdflib` + `owlrl` (moteur de closure OWL-RL/RDFS). Deux approches du raisonnement : moteur natif cote C# vs closure deductive cote Python."

--- a/scripts/notebook_tools/twin_pairs.d/sw-2-rdf-basics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-2-rdf-basics.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 1ec640b95feee7021d0f7df93e598101b878dd13
-    csharp_sha: fcea9bfbc914f113a7448e2511941ec09908d787
-    reason: "Measure/value fix (C# cell 46 « Comparaison des tailles de serialisation » table): 2 rows contradicted the committed cell 45 measured output (17-triplet graphe social). c45 measures RDF/XML 1567 car = 95 % and JSON-LD 2069 car = 126 %, but c46 claimed RDF/XML « ~70-90 % » (95 % outside) and JSON-LD « ~60-80 % » (126 % wrong direction -- JSON-LD is MORE verbose than NTriples here, not more compact). Realigned both rows to the measured output (RDF/XML ~95 %, JSON-LD ~126 %, format le plus lourd), keeping the « valeurs exactes varient » caveat. Turtle 49 % (in 40-60 OK) and NTriples 100 % ref left unchanged. Markdown-only, 0 re-exec, no output change. Python twin SW-2b uses rdflib with different serializer sizes (separate analysis), python unchanged."
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 1ec640b95feee7021d0f7df93e598101b878dd13
+      csharp_sha: fcea9bfbc914f113a7448e2511941ec09908d787
+      reason: "Measure/value fix (C# cell 46 « Comparaison des tailles de serialisation » table): 2 rows contradicted the committed cell 45 measured output (17-triplet graphe social). c45 measures RDF/XML 1567 car = 95 % and JSON-LD 2069 car = 126 %, but c46 claimed RDF/XML « ~70-90 % » (95 % outside) and JSON-LD « ~60-80 % » (126 % wrong direction -- JSON-LD is MORE verbose than NTriples here, not more compact). Realigned both rows to the measured output (RDF/XML ~95 %, JSON-LD ~126 %, format le plus lourd), keeping the « valeurs exactes varient » caveat. Turtle 49 % (in 40-60 OK) and NTriples 100 % ref left unchanged. Markdown-only, 0 re-exec, no output change. Python twin SW-2b uses rdflib with different serializer sizes (separate analysis), python unchanged."
   known_differences:
     - "Socle pedagogique commun : construction d'un premier graphe RDF (triplets sujet-predicat-objet), namespaces W3C (RDF/RDFS/XSD)."
     - "Lib-vs-lib : C# = `dotNetRDF 3.2.1` (`#r \"nuget: dotNetRDF, 3.2.1\"`, espaces `VDS.RDF` / `VDS.RDF.Parsing` / `VDS.RDF.Writing`). Python = `rdflib` (`from rdflib import Graph, URIRef, Literal, BNode, Namespace` + `rdflib.namespace` RDF/RDFS/XSD/FOAF/DC)."

--- a/scripts/notebook_tools/twin_pairs.d/sw-3-graph-operations.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-3-graph-operations.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 91c69994024084bea93a0823230255624b828ce1
-    csharp_sha: 07cea4cbbc82bdb3c2a3f863b418b9a8b2a44fa2
-    reason: "Measure/value fix (C# cell 13 « Interpretation : Comparaison des formats de sortie »): 2 inverted-size claims contradicted the committed cell 12 output (4-triplet graphe Example.ttl). c12 measures NTriples 448 car / 4 lines and Turtle 531 car / 8 lines (5 @prefix + 1 statement), so Turtle is LARGER here (ratio 0.84:1) -- yet c13 claimed « tient en 3 lignes au lieu de 4 » (Turtle is 8 lines) and « ratio 2:1 (NTriples ~400 car vs Turtle ~300 car) » (backwards: Turtle 531 > NTriples 448). On this tiny graphe the 5 @prefix declarations dominate; compression appears only on larger graphs. Realigned both claims to the measured output (8 lines total; 531 vs 448 car, Turtle paradoxalement plus long) while preserving the valid general point « 5:1 ou plus sur des graphes plus grands ». Markdown-only, 0 re-exec, no output change. Python twin SW-3b uses rdflib with different output sizes (separate analysis), python unchanged."
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 91c69994024084bea93a0823230255624b828ce1
+      csharp_sha: 07cea4cbbc82bdb3c2a3f863b418b9a8b2a44fa2
+      reason: "Measure/value fix (C# cell 13 « Interpretation : Comparaison des formats de sortie »): 2 inverted-size claims contradicted the committed cell 12 output (4-triplet graphe Example.ttl). c12 measures NTriples 448 car / 4 lines and Turtle 531 car / 8 lines (5 @prefix + 1 statement), so Turtle is LARGER here (ratio 0.84:1) -- yet c13 claimed « tient en 3 lignes au lieu de 4 » (Turtle is 8 lines) and « ratio 2:1 (NTriples ~400 car vs Turtle ~300 car) » (backwards: Turtle 531 > NTriples 448). On this tiny graphe the 5 @prefix declarations dominate; compression appears only on larger graphs. Realigned both claims to the measured output (8 lines total; 531 vs 448 car, Turtle paradoxalement plus long) while preserving the valid general point « 5:1 ou plus sur des graphes plus grands ». Markdown-only, 0 re-exec, no output change. Python twin SW-3b uses rdflib with different output sizes (separate analysis), python unchanged."
   known_differences:
     - "Socle commun : parcours de graphe RDF, iteration des triplets, gestionnaires de parsing (handlers)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Parsing.Handlers`, iterate via `Graph.Triples`). Python = `rdflib` (`rdflib.collection`, `rdflib.parser`, iteration via `graph` set semantics)."

--- a/scripts/notebook_tools/twin_pairs.d/sw-4-sparql.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-4-sparql.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 441dbb88b6d54217818a9ebbca05d097b79cd932
-    csharp_sha: 8423823352423ed333872a3c24dc84d946992957
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 441dbb88b6d54217818a9ebbca05d097b79cd932
+      csharp_sha: 8423823352423ed333872a3c24dc84d946992957
   known_differences:
     - "Socle commun : execution de requetes SPARQL 1.1 (SELECT/CONSTRUCT/ASK) sur un graphe RDF."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Query` moteur Leviathan + `VDS.RDF.Query.Builder` fluent). Python = `rdflib` (`graph.query()` natif). Moteurs SPARQL equivalents, syntaxe de binding idiomatique differente."

--- a/scripts/notebook_tools/twin_pairs.d/sw-5-linked-data.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-5-linked-data.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 607ce735712708a08ebc37db2f5a7d19a0d16dfc
-    csharp_sha: 9cfb80bc05aa73594102d90d93276e52356a4977
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 607ce735712708a08ebc37db2f5a7d19a0d16dfc
+      csharp_sha: 9cfb80bc05aa73594102d90d93276e52356a4977
   known_differences:
     - "Socle commun : consommation de Linked Data distante (dereferencement d'URI, endpoints SPARQL)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Query` remote endpoint). Python = `SPARQLWrapper` (client dedie endpoints SPARQL) + `rdflib`. Asymetrie leger : Python ajoute `SPARQLWrapper` specialise pour le reseau distant, le C# unifie dans dotNetRDF."

--- a/scripts/notebook_tools/twin_pairs.d/sw-6-rdfs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-6-rdfs.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 9e4785fc0879d45754e3e40fd0ae418ca2462993
-    csharp_sha: f7a8a4f6cd60d8ce6484a1eac41072fe304e60f5
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 9e4785fc0879d45754e3e40fd0ae418ca2462993
+      csharp_sha: f7a8a4f6cd60d8ce6484a1eac41072fe304e60f5
   known_differences:
     - "Socle commun : raisonnement RDFS (subClassOf, subPropertyOf, inference de hierarchies)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Ontology` OntologyGraph + `VDS.RDF.Query`). Python = `rdflib` + `owlrl` (moteur de closure RDFS/OWL-RL, derive les triplets inferes). Approche legerement differente : C# expose le modele ontologique oriente-objet ; Python deroule la closure de raisonnement explicitement."

--- a/scripts/notebook_tools/twin_pairs.d/sw-7-owl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-7-owl.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 95f6fb513c53bb133e9f47966e26e812ba86ad11
-    csharp_sha: 25c773f11a9fcdf9c6d03d88a3c3a39102399095
-    reason: "Identity/phantom fix (C# cell 4 ASCII stack-diagram « OWL 2 dans la pile du Web Semantique »): the SHACL layer was labelled « SHACL (SW-9) » but SHACL is notebook SW-8 (SW-8-CSharp-SHACL.ipynb / SW-8-Python-SHACL.ipynb on origin/main). The Python twin SW-7b already correctly says SW-8 (cell 28). Fixed SW-9 -> SW-8 (same char length, ASCII box alignment preserved). Other layers (OWL2 SW-7, RDFS SW-6, RDF SW-1/2/3) were already correct; SPARQL (SW-5) left untouched (debatable: dedicated SPARQL is SW-4, but SW-5 LinkedData uses SPARQL -- not an unambiguous error). Markdown-only, 0 re-exec, no output change. No §D.5 (identity/phantom class, not a measure/value drift). Python twin unchanged."
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 95f6fb513c53bb133e9f47966e26e812ba86ad11
+      csharp_sha: 25c773f11a9fcdf9c6d03d88a3c3a39102399095
+      reason: "Identity/phantom fix (C# cell 4 ASCII stack-diagram « OWL 2 dans la pile du Web Semantique »): the SHACL layer was labelled « SHACL (SW-9) » but SHACL is notebook SW-8 (SW-8-CSharp-SHACL.ipynb / SW-8-Python-SHACL.ipynb on origin/main). The Python twin SW-7b already correctly says SW-8 (cell 28). Fixed SW-9 -> SW-8 (same char length, ASCII box alignment preserved). Other layers (OWL2 SW-7, RDFS SW-6, RDF SW-1/2/3) were already correct; SPARQL (SW-5) left untouched (debatable: dedicated SPARQL is SW-4, but SW-5 LinkedData uses SPARQL -- not an unambiguous error). Markdown-only, 0 re-exec, no output change. No §D.5 (identity/phantom class, not a measure/value drift). Python twin unchanged."
   known_differences:
     - "Socle commun : modelisation OWL (classes, proprietes, restrictions, axiomes)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Ontology` : OntologyGraph, OwlReasoner). Python = `owlready2` (API OWL orientee-objet dediee, world/Thing/Property). Deux librairies OWL matures mais aux philosophies differentes : dotNetRDF traite OWL comme une couche sur RDF ; owlready2 est nativement orientee OWL."

--- a/scripts/notebook_tools/twin_pairs.d/sw-8-shacl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-8-shacl.yaml
@@ -3,12 +3,12 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 7415f9039debcbcd90e75a12eab087aba94a7e41
-    csharp_sha: fce2451b700090a2515d64a49e550eae1e0c0e6b
-    reason: "c1 rdflib self-ref pointed at SW-8 (this notebook); rdflib introduced in SW-2b-Python-RDFBasics. Python-only, csharp PRESERVED."
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 7415f9039debcbcd90e75a12eab087aba94a7e41
+      csharp_sha: fce2451b700090a2515d64a49e550eae1e0c0e6b
+      reason: "c1 rdflib self-ref pointed at SW-8 (this notebook); rdflib introduced in SW-2b-Python-RDFBasics. Python-only, csharp PRESERVED."
   known_differences:
     - "Socle commun : validation de graphe RDF par contraintes SHACL (Shapes Constraint Language, W3C 2017)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Shacl` moteur de validation integre). Python = `pyshacl` (validateur SHACL dedie, reference) + `rdflib` pour le graphe. pyshacl est l'implementation de reference Python ; dotNetRDF embarque SHACL depuis la v3."

--- a/scripts/notebook_tools/twin_pairs.d/sw-9-json-ld.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-9-json-ld.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 3c4a93bbf202cea7b12de79ff69d36291c49fc0b
-    csharp_sha: 3caa1ec0ce4787f1c7b8a222a370c0cca24e8dbe
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 3c4a93bbf202cea7b12de79ff69d36291c49fc0b
+      csharp_sha: 3caa1ec0ce4787f1c7b8a222a370c0cca24e8dbe
   known_differences:
     - "Socle commun : serialisation JSON-LD (Linked Data en JSON, W3C) d'un graphe RDF."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Writing` JsonLdWriter). Python = `rdflib` (plugin JSON-LD via `rdflib-jsonld` integre, `graph.serialize(format='json-ld')`)."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-10-mln.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-10-mln.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-10-MLN.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-10-MLN-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 0dea8c32c031cda45adcb6eff1d499f7a6dbdfa3
-    csharp_sha: 362f5ad69fcfb34e063ca7414c28e4fbda6fdc77
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 0dea8c32c031cda45adcb6eff1d499f7a6dbdfa3
+      csharp_sha: 362f5ad69fcfb34e063ca7414c28e4fbda6fdc77
   known_differences:
     - "Socle commun : reseaux logiques markoviens (MLN, Markov Logic Networks) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`#r \"org.tweetyproject.tweety-mln.dll\"` + `using org.tweetyproject.logics.mln.syntax`). Python via JPype (`from java.util import ArrayList` + `from jpype.types import JObject, JInt`). Meme moteur MLN Java."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-11-causal.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-11-causal.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-11-Causal.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-11-Causal-Csharp.ipynb
   parity_level: surface
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 95aa9b6f604e806ef2e5b08c4cc2f0bb633820cc
-    csharp_sha: d60c424c0e1334c0dbf3f9fa6b9376bad215c330
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 95aa9b6f604e806ef2e5b08c4cc2f0bb633820cc
+      csharp_sha: d60c424c0e1334c0dbf3f9fa6b9376bad215c330
   known_differences:
     - "Socle commun : inference causale et do-calculus (Pearl) sur modeles causaux structurels."
     - "Asymetrie de profondeur (surface) : le Python s'appuie sur la vraie bibliotheque Java Tweety `causal-1.30.jar` via JPype (`from org.tweetyproject.causal.reasoner import ArgumentationBasedCausal`) ; le C# est un jumeau **from-scratch** (titre explicite 'twin C# from-scratch', aucune reference a org.tweetyproject) qui reimplemente le do-calcul pedagogiquement. Parite `surface` (C# = pendant reimplante, pas de librairie)."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-2-basic-logics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-2-basic-logics.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: d9bd33ad8b9e97f30827123edbfece15a1d630a8
-    csharp_sha: 91f537b4dabe9e9846e6474d42af960bf5288122
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: d9bd33ad8b9e97f30827123edbfece15a1d630a8
+      csharp_sha: 91f537b4dabe9e9846e6474d42af960bf5288122
   known_differences:
     - "Socle commun : logiques classiques propositionnelles et du premier ordre (FOL) via la bibliotheque Java TweetyProject."
     - "Lib-vs-lib meme moteur Java : C# via IKVM (`#r \"nuget: IKVM, 8.15.0\"` + `#r \"org.tweetyproject.tweety-pl.dll\"` + `using org.tweetyproject.*` ; bytecode Java traduit en .NET, pas de JVM au runtime). Python via JPype (`import jpype` + `from org.tweetyproject.* import` + `from java.util import` ; pont vers une JVM)."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-3-advanced-logics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-3-advanced-logics.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 26ba41f102395886cb452772ebd7a1df8bdcc584
-    csharp_sha: 52fd778d91449e795a6abe56218dda183b008190
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 26ba41f102395886cb452772ebd7a1df8bdcc584
+      csharp_sha: 52fd778d91449e795a6abe56218dda183b008190
   known_differences:
     - "Socle commun : logiques avancees (conditionnelle, modale, QBF) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`#r \"org.tweetyproject.tweety-advanced-logics.dll\"` + `using org.tweetyproject.logics.cl.reasoner` etc.). Python via JPype (`from org.tweetyproject.logics.cl.reasoner import SimpleCReasoner`). Meme moteur Java TweetyProject, deux ponts (IKVM traduit vs JPype JVM)."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-4-belief-revision.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-4-belief-revision.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: a4518639c3bc575395b112d7cf3d57f4518ec09d
-    csharp_sha: a1787c539d0e66bfb4f097a519e55c15dfb9e217
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: a4518639c3bc575395b112d7cf3d57f4518ec09d
+      csharp_sha: a1787c539d0e66bfb4f097a519e55c15dfb9e217
   known_differences:
     - "Socle commun : revision des croyances (AGM, contraction/revision) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`using org.tweetyproject.*`). Python via JPype (`from java.util import ArrayList, HashSet` + `from jpype.types import *`). Meme fondement Java, idiomatique de pont differente."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-5-abstract-argumentation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-5-abstract-argumentation.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2026:CoursIA
-    python_sha: 809a7fa5443afb8aa73aeeb82f870c575aaf1e52
-    csharp_sha: 0993ec2e3068216e3b07f1448dd5776de232692b
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2026:CoursIA
+      python_sha: 809a7fa5443afb8aa73aeeb82f870c575aaf1e52
+      csharp_sha: 0993ec2e3068216e3b07f1448dd5776de232692b
   known_differences:
     - "Socle commun : argumentation abstraite de Dung (semantiques grounded/preferred/stable) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`#r \"org.tweetyproject.tweety-dung.dll\"`). Python via JPype (`from java.util import Collection, HashSet`). Meme moteur Dung de TweetyProject."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-6-structured-argumentation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-6-structured-argumentation.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation-Csharp.ipynb
   parity_level: surface
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: ed308f9e16da32919d2cebbe1e760f2f61d59d89
-    csharp_sha: bbc10e74936be928073378a65393fb513fd6884a
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: ed308f9e16da32919d2cebbe1e760f2f61d59d89
+      csharp_sha: bbc10e74936be928073378a65393fb513fd6884a
   known_differences:
     - "Socle commun : argumentation structuree (ASPIC+, construction d'arguments a partir de regles)."
     - "Asymetrie de profondeur (surface) : le Python invoque la vraie bibliotheque Java TweetyProject (ASPIC+) via JPype ; le C# REIMPLEMENTE le moteur ASPIC+ **from-scratch** (cellule de setup : 'aucune dependance externe -- moteur ASPIC+ from-scratch'), sans la bibliotheque. Le C# est un pendant pedagogique reimplante, pas une parite de librairie -> `surface`."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-7a-extended-frameworks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-7a-extended-frameworks.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 25a8e8d7427c1a8415b03f70cc26dee4a2d4956a
-    csharp_sha: 62f6921da965958ab0277d2cee822d284a47e568
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 25a8e8d7427c1a8415b03f70cc26dee4a2d4956a
+      csharp_sha: 62f6921da965958ab0277d2cee822d284a47e568
   known_differences:
     - "Socle commun : frameworks d'argumentation etendus (bipolaire, valeur-based) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (helpers `#!import` chargeant les DLL TweetyProject traduites). Python via JPype (`from java.util import HashSet, Set as JavaSet`). Meme moteur Java."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-7b-ranking-probabilistic.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-7b-ranking-probabilistic.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 8fa3516822bcc10cbc76d6cc77b2bc4d3881d945
-    csharp_sha: c0b08647723dabc8be38dde312640cc43ea67a96
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 8fa3516822bcc10cbc76d6cc77b2bc4d3881d945
+      csharp_sha: c0b08647723dabc8be38dde312640cc43ea67a96
   known_differences:
     - "Socle commun : semantiques de rangement et probabilistes (ranking, division) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`#r \"org.tweetyproject.tweety-rpcl.dll\"`). Python via JPype (`from org.tweetyproject.arg.dung.divisions import Division`). Meme moteur Java."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-8-agent-dialogues.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-8-agent-dialogues.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-8-Agent-Dialogues.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-8-Agent-Dialogues-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 3ab6594d3173ebe0a612eeddc6014bceaf460636
-    csharp_sha: f5d641c0f4a0dba162b5596f27d9e10d739dc67e
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 3ab6594d3173ebe0a612eeddc6014bceaf460636
+      csharp_sha: f5d641c0f4a0dba162b5596f27d9e10d739dc67e
   known_differences:
     - "Socle commun : dialogues multi-agents argumentatifs (protocols, ExecutableExtension) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (helpers chargeant les DLL TweetyProject). Python via JPype (`from org.tweetyproject.agents.dialogues import ExecutableExtension`). Meme moteur Java."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-9-preferences.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-9-preferences.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: c2f0fd49cc676439ac5d626abd51f39dca5680a0
-    csharp_sha: 3e015103eb4cddb301a19f10dd1b8940eefe0fbb
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: c2f0fd49cc676439ac5d626abd51f39dca5680a0
+      csharp_sha: 3e015103eb4cddb301a19f10dd1b8940eefe0fbb
   known_differences:
     - "Socle commun : argumentation preferentielle (PreferenceReasoner) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`#r \"nuget: IKVM.Image, 8.15.0\"`). Python via JPype (`from org.tweetyproject.arg.dung.reasoner import SimplePreferredReasoner`). Meme moteur Java."

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-01-introduction.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-01-introduction.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 1dce7f1d5495aacad37cdac4fd21f9d211589840
-    csharp_sha: 8b10f3c8fd958afee15f332405689369d26bd71c
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 1dce7f1d5495aacad37cdac4fd21f9d211589840
+      csharp_sha: 8b10f3c8fd958afee15f332405689369d26bd71c
   known_differences:
     - "Python : pyz3 (z3-solver), `from z3 import *`, API fonctionnelle (Solver(), Int('x'), s.check() -> sat/unsat)."
     - "C# : Microsoft.Z3 .NET, `using Microsoft.Z3;`, API orientee Context (ctx.MkSolver(), ctx.MkConst(...), Status.TRUE)."

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-02-sudoku.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-02-sudoku.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 31ede72cdc3c4895792d29b26e360cb2d31b66da
-    csharp_sha: fedc5982513ac15be379f4b0ed0845032d2dc9a6
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 31ede72cdc3c4895792d29b26e360cb2d31b66da
+      csharp_sha: fedc5982513ac15be379f4b0ed0845032d2dc9a6
   known_differences:
     - "Python : pyz3. C# : Microsoft.Z3 .NET (idiomes API comme NB-01)."
     - "Cote Python : modelisation Sudoku (81 cellules Int 1-9, alldifferent lignes/colonnes/blocs). Doc-honesty cures c.19 (PR #8045 : compte indices ~35 -> 30 pour puzzle_facile). SHA rebaseline c.802 apres DRIFT detecte par check_twin_parity.py : 4dcb5921 -> 1d3b1932 (commit e8a3be3ae merge le 2026-07-23)."

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-03-tactics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-03-tactics.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 596992096613fb08367a5e41fae56b1b01254572
-    csharp_sha: 414f62ee58470a82f189ed74cc5c46a12692648a
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 596992096613fb08367a5e41fae56b1b01254572
+      csharp_sha: 414f62ee58470a82f189ed74cc5c46a12692648a
   known_differences:
     - "Python : pyz3 (Tactic('simplify'), Then(), With()). C# : Microsoft.Z3 .NET (Tactic(ctx, ...))."
     - "Concept demontre (simplify elimine une redondance, ctx-solver-simplify la garde) verifie firsthand cote Python (NB-03 CLEAN)."

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-04-strings-regex.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-04-strings-regex.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 4c04fe94faf2b0e2aea04dead81f1f46edf60b11
-    csharp_sha: c8f8372242c5da1bdecbc1e03be05e2d28ce2154
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 4c04fe94faf2b0e2aea04dead81f1f46edf60b11
+      csharp_sha: c8f8372242c5da1bdecbc1e03be05e2d28ce2154
   known_differences:
     - "Python : pyz3 (Range, Concat, Plus, Re, InRe, Length sur Seq). C# : Microsoft.Z3 .NET (ctx.MkRange, MkConcat, MkRe...)."
     - "Cote Python : fix code-correctness c.17 (PR #8040) — date AAAA-MM-JJ sous-contrainte (Plus(Range)=[0-9]+ variable) resverree en groupes longueur-fixe [0-9]{n} via helper chiffres(n). Le concept (string regex Z3) est commun aux deux cotes ; le detail du fix date est specifique au notebook Python."

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-05-quantifiers-proofs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-05-quantifiers-proofs.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 6d85c875a279e2db3161677684c9fb2433503195
-    csharp_sha: dcc4aa5c50ff122180e2b2dd97bf25cdbb4d1b2a
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 6d85c875a279e2db3161677684c9fb2433503195
+      csharp_sha: dcc4aa5c50ff122180e2b2dd97bf25cdbb4d1b2a
   known_differences:
     - "Python : pyz3 (ForAll, Exists, prove() par refutation). C# : Microsoft.Z3 .NET (ctx.MkForall, MkExists, Solver+unsat)."
     - "Concept demontre (preuve par refutation, Exists sat/unsat, Fermat unknown) verifie cote Python (structure CLEAN c.20)."

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-06-advanced-optimization.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-06-advanced-optimization.yaml
@@ -3,11 +3,11 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-08-04"
-    by: myia-po-2023:CoursIA
-    python_sha: 21568eafac5f6a33ccccf09748fabdb00ac651ce
-    csharp_sha: 09839b0862080005043750fa15b42b91a8ab13cb
+  audits:
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 21568eafac5f6a33ccccf09748fabdb00ac651ce
+      csharp_sha: 09839b0862080005043750fa15b42b91a8ab13cb
   known_differences:
     - "Python : pyz3 (Optimize, maximize/minimize, assert_soft pour MaxSAT, front de Pareto). C# : Microsoft.Z3 .NET (ctx.MkOptimize, MkMaximize, MkAssertSoft)."
     - "Concept demontre (objectifs hierarchiques, MaxSAT, front de Pareto) verifie cote Python (structure CLEAN c.20)."


### PR DESCRIPTION
## Context

`#9399` — twin registry: le singleton `last_audit` est un aimant à collision. Le singleton `last_audit:` réécrit en place est un **aimant à collision mécanique** sous lanes parallèles (4 manifestations en un cycle : #9171 clé dupliquée, #9237/#9245 CONFLICT content bloqués 2 jours, et l'inversion silencieuse c.1127 écrasant c.1128).

**La mécanique append-only a été livrée par #9405 (MERGED)** — `check_twin_parity.py` gère désormais `audits:` (liste) avec priorité sur `last_audit:` (legacy fallback). **Ce qui restait : appliquer la migration at-rest** aux 153 yamls encore en forme singleton, pour que la forme append-only soit effective sur tout le registre et que les collisions disparaissent réellement (et non seulement quand un drift déclenche la lazy migration du checker).

## What this PR does

Convertit les **153** yamls `twin_pairs.d/*.yaml` encore en `last_audit:` singleton → liste append-only `audits:` (le singleton comme item[0]). 3 yamls déjà migrés + 1 sans audit = inchangés. 157 total.

```yaml
# BEFORE
  last_audit:
    date: "2026-08-04"
    by: myia-po-2023:CoursIA
    python_sha: 52c83a05...
    csharp_sha: 17128d98...
    reason: "..."

# AFTER (1-element list, append-ready)
  audits:
    - date: "2026-08-04"
      by: myia-po-2023:CoursIA
      python_sha: 52c83a05...
      csharp_sha: 17128d98...
      reason: "..."
```

## Why it is semantics-preserving (3 independent proofs)

1. **By construction** : le body enregistré (date/by/python_sha/csharp_sha/reason, quoting inclus) est **déplacé, pas re-sérialisé**. Seuls changent le header (`last_audit:`→`audits:`) et l'indentation en 1er item de liste, via `_legacy_body_as_list_item` — **le même convertisseur byte-faithful** que le checker utilise pour sa lazy migration au drift. Les **SHA ne sont PAS recalculés** (pas de fausse attestation) : on déplace le SHA enregistré tel quel, seul le conteneur change.

2. **Self-check assertion** (dans le script de migration) : pour **chacun** des 153, `_latest_audit(yaml.safe_load(AVANT)) == _latest_audit(yaml.safe_load(APRÈS))` — la fonction que le checker utilise pour lire l'audit le plus récent retourne le même dict. **0 failures sur 153.** Transactionnel : phase 1 compute+verify all (zéro écriture), phase 2 write all seulement si 0 failure — aucune migration partielle possible.

3. **Checker empirique** : `check_twin_parity.py --per-pair --base origin/main --check` → **0 drift introduit**, 156 paires parsées, **exit 0**. Les verdicts PASS/DRIFT sont préservés (les SHA enregistrés sont les mêmes, les notebooks inchangés).

Résiduel `last_audit:` legacy : **0/157**.

## Scope

153 fichiers, **100% `.yaml` dans `twin_pairs.d/`**, zéro notebook, zéro code hors du registre. Diff ~10-12 lignes/yaml (bloc audit uniquement).

## What remains open (#9399 volet b)

Volet **(a)** = COMPLET (mécanique #9405 + migration at-rest cette PR). Volet **(b)** — "les SHA ne devraient pas être écrits à la main", un **job CI schedulé fleet-wide** qui dérive/vérifie les SHA au-delà du gate per-PR — reste ouvert (réconciliation c.1205 : le gate per-PR existe déjà et rougit sur un SHA faux, mais il n'y a pas d'audit schedulé qui couvre le registre entier entre les PRs). D'où `See #9399`, pas `Closes`.

Grain: #9399-volet-a-migration | lane: myia-po-2024:CoursIA