### PR TITLE
ci(translation,#6949): surface fill rate in drift annotation (SRC_DRIFT=0 on 0%-translated != 'up to date')

### DIFF
--- a/.github/workflows/translation-drift.yml
+++ b/.github/workflows/translation-drift.yml
@@ -69,12 +69,24 @@ jobs:
             exit 0
           fi
           COUNT="$(echo "$REPORT" | python -c 'import sys,json; print(json.load(sys.stdin)["anomaly_count"])')"
+          # Fill rate by target language (#6949 point 1): a drift count alone is
+          # non-informative while 0% of cells carry a translation. The check
+          # script already prints this on stderr and in the JSON report; here we
+          # surface it into the PR annotation so a SRC_DRIFT=0 on a 0%-translated
+          # table can no longer read as "up to date" at the merge gate (#8678:
+          # a bare count perishes, a count plus its denominator self-contradicts).
+          FILL_SUMMARY="$(echo "$REPORT" | python -c 'import sys,json; gf=json.load(sys.stdin).get("fill_rate",{}).get("global",{}); t=["en","es","ar","fa","zh","ru","pt"]; print(" ".join("%s=%s%%" % (l, gf.get(l,{}).get("pct",0.0)) for l in t))')"
+          ANY_FILLED="$(echo "$REPORT" | python -c 'import sys,json; gf=json.load(sys.stdin).get("fill_rate",{}).get("global",{}); t=["en","es","ar","fa","zh","ru","pt"]; print(any(gf.get(l,{}).get("filled",0)>0 for l in t))')"
           if [ "$COUNT" = "0" ]; then
-            echo "::notice title=Translation sync::All translation CSVs in sync with notebooks. No drift."
+            if [ "$ANY_FILLED" = "True" ]; then
+              echo "::notice title=Translation sync::All translation CSVs in sync with notebooks. No drift. (fill rate: $FILL_SUMMARY)"
+            else
+              echo "::notice title=Translation sync (caveat)::Drift count is 0, BUT no translation is deposited in ANY target language ($FILL_SUMMARY). 'No drift' does NOT mean 'translated' here — the drift count is non-informative while the fill rate is 0%. Re-translation is gated on the T3 motor GO (#6949 point 2)."
+            fi
             echo "drift=none" >> "$GITHUB_OUTPUT"
           else
             SUMMARY="$(echo "$REPORT" | python -c 'import sys,json; from collections import Counter; d=json.load(sys.stdin); print(", ".join(f"{v}={n}" for v,n in Counter(a["verdict"] for a in d["anomalies"]).items()))')"
-            echo "::notice title=Translation drift (informational)::$COUNT drift(s) detected ($SUMMARY). This does NOT block the PR. Re-translation is proposed here but executed manually by an agent (Argumentum motor, #4957 §3). See JSON report in the job log."
+            echo "::notice title=Translation drift (informational)::$COUNT drift(s) detected ($SUMMARY). Fill rate: $FILL_SUMMARY. This does NOT block the PR. Re-translation is proposed here but executed manually by an agent (Argumentum motor, #4957 §3). See JSON report in the job log."
             echo "$REPORT"
             echo "drift=detected" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## What & why (#6949 point 1)

The `check_translation_sync.py` script already computes and prints the **translation fill rate by target language** (commit `2df72406d`, well-tested: `test_csv_fill_stats_*`, `test_fill_pct_*`). But the CI workflow `translation-drift.yml` **did not surface it into the PR annotation** — it extracted only `anomaly_count` and posted, on a zero-drift run:

```
::notice title=Translation sync::All translation CSVs in sync with notebooks. No drift.
```

That is exactly the trap #6949 point 1 denounces: a `SRC_DRIFT=0` on a table where **no translation is deposited** (all target languages at 0%) reads as "up to date" at the merge gate. The current reality (measured firsthand on `origin/main`):

```
fill_rate.global : fr=99.9%   en=0.0% es=0.0% ar=0.0% fa=0.0% zh=0.0% ru=0.0% pt=0.0%
anomaly_count    : 6096  (24470 cells, 0 deposited translations across 7 target languages)
```

So a future resync-only PR that zeroed the `SRC_DRIFT` count would post "All in sync. No drift." while **nothing is translated** — the count alone perishes silently (#8678). This PR closes that gap.

## Change

Surface the fill rate into the annotation so the count can no longer be read as "up to date" on a 0%-translated table (#8678: a bare count perishes; a count plus its denominator self-contradicts):

- Extract `FILL_SUMMARY` (per-target-language pct) and `ANY_FILLED` from the JSON report's `fill_rate.global`.
- `anomaly_count=0` + `ANY_FILLED=False` → posts a **caveat** annotation:
  `Drift count is 0, BUT no translation is deposited in ANY target language (en=0.0% ...). 'No drift' does NOT mean 'translated' here — the drift count is non-informative while the fill rate is 0%.`
- `anomaly_count=0` + `ANY_FILLED=True` → honest annotation with fill rate shown.
- `anomaly_count>0` → existing drift notice, now also carrying the fill rate (context the reviewer needs).

The job stays **non-blocking** (`::notice`, never `::error`) — same read-only philosophy as `catalog-drift.yml`. This is the honest-signal half of #6949 point 1; the actual re-translation remains gated on the T3 motor GO (#6949 point 2, USER-HAND).

## Build-safety (tooling-only)

- **Tooling-only**: 1 workflow YAML, 0 code / notebook / output cells touched.
- **YAML validated** (`yaml.safe_load`); logic tested locally on 3 scenarios (0-drift/0%-translated = the bug case → caveat; 0-drift/partial → honest with fill rate; real 6096-drift/0% → drift + fill context), plus robustness for a report missing `fill_rate` (conservative defaults: 0.0% / `ANY_FILLED=False`).
- **No regression**: `scripts/translation/tests/` → **117 passed** (incl. the 15 `test_check_translation_sync.py` covering `csv_fill_stats` / `_fill_pct`).
- **0 CRLF** (LF preserved); diff vs origin/main: 14 ins / 2 del.

## Scope & context

- `.github/workflows/translation-drift.yml` only.

The check script's `fill_rate` computation (#6949 point 1, script half) was already shipped at `2df72406d`; this PR is the **workflow-wiring half** that makes the signal visible at the merge gate rather than buried in the job log stderr. See #6949 (the last comment frames point 1 as the executable grain) and #8678 (bare-count-perishes principle). Point 2 (T3 motor GO) remains USER-HAND, out of scope.

See #6949, #8678, #4957.

---

`Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: LIGHT/notebook-python #9429`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
