### PR TITLE
docs(smartgrid,#9377): strip drift-prone manual cell count from README

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/README.md
@@ -49,7 +49,7 @@ SmartGrid-Energy/
 └── README.md                     # Ce fichier
 ```
 
-Les deux notebooks partagent la même trame (20 cellules dont 8 de code) ; la version étudiante
+Les deux notebooks partagent la même trame ; la version étudiante
 remplace les corps de fonctions par des stubs guidés (`# TODO`, indices par étape), la version
 solution est committée exécutée de bout en bout.
 


### PR DESCRIPTION
## Context

Mandat **#9377** — « les données quantitatives appartiennent au CI, pas à la prose » (supprimer les compteurs manuels drift-prone des READMEs, cf #9422 SocialChoice counts, #9425 Crypto-MultiCanal Taille).

## Le défaut

`CaseStudies/SmartGrid-Energy/README.md` l.52 déclarait :

> Les deux notebooks partagent la même trame **(20 cellules dont 8 de code)** ; …

Comptage réel (origin/main `df7f122b9`) :

| Notebook | Total | Code | Markdown |
|----------|-------|------|----------|
| `solution/SmartGrid-Energy.ipynb` | **24** | 8 | 16 |
| `student/SmartGrid-Energy.ipynb` | 20 | 8 | 12 |

Le « **20** » est **faux pour la solution** (24) — drift classique #9377 : un compte manuel qui dérive dès qu'une cellule est ajoutée. Le « 8 de code » est stable aujourd'hui mais également manuel (dérivera pareil).

## Fix #9377-faithful

Strip du compte manuel drift-prone. Le qualitatif est préservé (« partagent la même trame », stubs guidés `# TODO`, solution committée exécutée de bout en bout) — la structure code/markdown est implicitement véhiculée par la distinction stubs-vs-exécutée. Le catalogue / CI suit les comptes ; la prose ne les déclare pas.

```diff
-Les deux notebooks partagent la même trame (20 cellules dont 8 de code) ; la version étudiante
+Les deux notebooks partagent la même trame ; la version étudiante
```

## Audit §E fichier-entier (reconciliation disk ↔ prose sur origin/main)

Tout le reste du fichier est reconcilié et accurate — **seul le compte cellules avait dérivé** :

- `subject.md` ✓ existe (énoncé + barème + exercices)
- **3 exercices d'extension** ✓ (réserve tournante n-1, sensibilité au prior, équité territoriale) — tous présents dans `subject.md` (l.65/67/69)
- **requirements** ✓ `ortools>=9.8`, `numpy>=1.24` — matches README claim
- **structure tree** ✓ (student/ + solution/ + subject.md + README.md) — tous présents sur disque
- **3 liens siblings** ✓ (Diagnostic-Medical, Oncology-Planning, CaseStudies READMEs) — tous résolvent
- table architecture 4 couches + table centrales + barème 20 pts — qualitatif stable, OK

Pas d'autre drift dans ce fichier.

## Scope

1 fichier, 1 ins / 1 del. Famille CaseStudies (fraîche — ni po-2023 ni po-2024 ne l'avaient touchée ce cycle). Genre cleanup/doc (à-côté, dans la cap 1/lane/jour), à côté du plat principal #9430 (twin-parity migration). Markdown-only → exception C.2 (pas de re-exec).

See #9377 (epic-wide strip, pas `Closes`).

Grain: #9377-smartgrid-count-strip | lane: myia-po-2024:CoursIA