### PR TITLE
fix(probas,#8052,#9377): PyMC-11 strip machine-dependent '56 secondes' MCMC timing from markdown

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Topic-Models.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Topic-Models.ipynb
@@ -501,7 +501,7 @@
    "source": [
     "### Interpretation de l'echantillonnage avec priors symetriques\n",
     "\n",
-    "L'echantillonnage NUTS a converge en 56 secondes avec des priors uniformes (Dirichlet(1,...,1)) sur phi et theta. En sortie, les trois sujets presentent des distributions de mots quasi-identiques, avec les mêmes mots dominants (atome, recette, four) dans des proportions similaires (~0.11-0.15). Les proportions theta sont également uniformes (~0.33 par sujet pour chaque document).\n",
+    "L'echantillonnage NUTS a converge avec des priors uniformes (Dirichlet(1,...,1)) sur phi et theta. En sortie, les trois sujets presentent des distributions de mots quasi-identiques, avec les mêmes mots dominants (atome, recette, four) dans des proportions similaires (~0.11-0.15). Les proportions theta sont également uniformes (~0.33 par sujet pour chaque document).\n",
     "\n",
     "Ce résultat est le **problème de symetrie** attendu : sans information a priori pour differencier les sujets, l'echantillonneur ne peut pas les distinguer et converge vers une solution ou tous les sujets sont identiques. La cellule suivante affiche les distributions estimees et confirme cette non-differenciation."
    ]

--- a/scripts/notebook_tools/twin_pairs.d/probas-11-topic-models.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-11-topic-models.yaml
@@ -12,6 +12,10 @@
       by: myia-po-2023:CoursIA
       python_sha: 60fbbf573921efe05e991d4d04f773144f4a6779
       csharp_sha: 479d24e0d69d1bb2ee6dcca6d6d4b15c5e29aad0
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: 18339f3b723901441ff4b4bb333019edcd80bd0f
+      csharp_sha: 479d24e0d69d1bb2ee6dcca6d6d4b15c5e29aad0
   known_differences:
   - 'Socle pedagogique commun : modeles de topics (LDA / allocation de Dirichlet) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
## What & why (#8052 + #9377)

`PyMC-11-Topic-Models.ipynb` cell[9] (markdown interpretation of the LDA symmetric sampling) claimed the NUTS sampling **"a converge en 56 secondes"**. The committed cell[8] output — the ground truth, for that exact sampling — prints:

```
Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 30 seconds.
```

**`56` appears nowhere in any committed output.** It is a stale markdown hardcode: the prose was written when the sampling took ~56 s on a slower machine; the committed output (30 s) is from a faster one. Classic env/kernel drift — and a #8052 contradiction (56 ≠ 30) on top of it.

| Cell | Before | After |
|------|--------|-------|
| cell[9] markdown | `L'échantillonnage NUTS a converge en 56 secondes avec des priors uniformes (Dirichlet(1,...,1)) sur phi et theta.` | `L'échantillonnage NUTS a converge avec des priors uniformes (Dirichlet(1,...,1)) sur phi et theta.` |

**Why strip (not align 56→30)?** MCMC sampling wall-clock time is **machine-dependent** (CPU speed / cores / load), not stochastic and not structural — it re-drifts on every kernel and every machine. Re-pinning to `30` would reconstitute the defect one kernel later. Per the **#9377 mandate** (quantitative data held by the dynamic source, not by manual prose): the sampler in cell[8] already prints the time dynamically (`... took N seconds.`), so it is already the single source of truth. The markdown's absolute is a duplicate source that drifts at every bump — **delete it**, don't realign it. Same gesture as #9427 (Picross ms range), #9425 (README file sizes), #9432 (manual cell count), #9429 (NumPy version row). The **pedagogy is preserved** — the sentence's point is *uniform priors → symmetry problem*, which is structural; the speed is incidental and remains visible in cell[8]'s output.

## Diagnostic dérive (§D.5)

- **Cause: a — env/kernel.** The sampling time drifted because the committing environment is faster (30 s) than the machine on which the prose was hand-pinned (56 s). The committed output tracked the current env; the markdown did not.
- **Verdict: `CAUSE_FIXED`.** The drift cause (a hand-written machine-dependent absolute) is **eliminated, not merely documented**: the absolute is removed, leaving cell[8]'s dynamic sampler print as the single source of truth. No machine-dependent number that can re-drift remains in the prose. (Not a stochastic/seeded value — machine-dependent timing — so the seed-vs-rephrase posture does not apply; this is the settled #9377 strip.)

## Build-safety (prose-only markdown)

- **Prose-only**: 1 markdown line edited; **0 code / output / `execution_count` cells touched** (cell[8] code+output unchanged, still reports `took 30 seconds`; all code cells retain `execution_count != null`, outputs unchanged — C.2 preserved).
- **Byte-level surgical edit** (raw `a converge en 56 secondes avec` → `a converge avec`, count-asserted = 1, no JSON round-trip) → structure byte-identical.
- **No re-exec needed** (C.2 markdown-only exception: aligning/striping prose against the committed output, which is the ground truth; cell[8] output is unchanged and is the timing source).
- **0 CRLF** (LF preserved); diff vs origin/main: **1 ins / 1 del**.
- **Twin parity**: registry rebaselined via `check_twin_parity.py --update --pair "Probas-11 Topic-Models" --by "myia-po-2023:CoursIA"` run **last** (after the prose edit; no normalization strips involved, so `--update` is the only step — #8957 order respected). Committed notebook blob (18339f3b) = registry latest `python_sha` (18339f3b) → parity green (drift_introduced=0 verified).

## Scope & context

- `MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Topic-Models.ipynb` + `scripts/notebook_tools/twin_pairs.d/probas-11-topic-models.yaml` only.

This is a **partial contribution to #9434** (port the #9377 mandate inside notebooks). It targets the **clear-cut machine-dependent class** (absolute timing in prose that the code prints dynamically) — the settled gesture, merged 3× this session (#9425/#9432/#9433). The **seed-vs-rephrase posture for the unseeded-stochastic class** (e.g. GA fitness, MCCCR utilities) remains GATED on coordinator decision and is **not** touched here.

See #9434, #9377, #8052, #8364.

---

`Grain: MED/notebook-python (#9377 strip) — lane myia-po-2023:CoursIA — prev: LIGHT/notebook-python #9435`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
