### PR TITLE
fix(probas,#8052,#9377): PyMC-1 Setup strip machine-dependent '21 secondes' MCMC timing from markdown

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
@@ -285,7 +285,7 @@
    "source": [
     "### Interpretation de l'echantillonnage\n",
     "\n",
-    "L'echantillonneur NUTS (*No-U-Turn Sampler*, Hoffman & Gelman 2014) a genere 4 chaînes de 2000 echantillons chacune (plus 1000 de warmup), pour un total de 8000 tirages du posterior en 21 secondes. Le posterior analytique est **Beta(8, 4)** car le prior Beta(1,1) se combine avec 7 faces et 3 piles.\n",
+    "L'echantillonneur NUTS (*No-U-Turn Sampler*, Hoffman & Gelman 2014) a genere 4 chaînes de 2000 echantillons chacune (plus 1000 de warmup), pour un total de 8000 tirages du posterior. Le posterior analytique est **Beta(8, 4)** car le prior Beta(1,1) se combine avec 7 faces et 3 piles.\n",
     "\n",
     "| Paramètre | Prior | Données | Posterior analytique | Estime MCMC |\n",
     "|-----------|-------|---------|---------------------|-------------|\n",

--- a/scripts/notebook_tools/twin_pairs.d/probas-1-setup.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-1-setup.yaml
@@ -3,11 +3,15 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb
   parity_level: semantic
-  last_audit:
-    date: "2026-07-29"
-    by: myia-po-2023:CoursIA-2
-    python_sha: d66cca0ab2869a855a3d57c7a23072d9409c9ab5
-    csharp_sha: 08d80a7b526cec74e667ecb04eca32cc443374de
+  audits:
+    - date: "2026-07-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: d66cca0ab2869a855a3d57c7a23072d9409c9ab5
+      csharp_sha: 08d80a7b526cec74e667ecb04eca32cc443374de
+    - date: "2026-08-04"
+      by: myia-po-2023:CoursIA
+      python_sha: d7f6c2180b23d7ba10cbf84c317130a14bad28e5
+      csharp_sha: 08d80a7b526cec74e667ecb04eca32cc443374de
   known_differences:
   - "Premier modele partage : les deux notebooks demarrent par le modele classique des deux pieces (Two Coins) -- prior Beta, vraisemblance Bernoulli, inference du biais de la piece. Socle pedagogique commun au-dela de la dimension setup (installation Infer.NET cote C# vs PyMC cote Python). Note : #8183 avait initialement exclu cette paire comme 'env-config mecanique, pas de demonstration de concept' (analogue ML-6 ONNX) ; relecture firsthand (ai-01 c.36, po-2023 c.941) confirme la presence substantive du modele Two Coins dans les DEUX notebooks (Infer-1-Setup : piece x15 / Bernoulli x10 / Beta x8 ; PyMC-1-Setup : coin x6 / piece x13 / Beta x12) -> la rationale d'exclusion initiale etait incomplete, paire re-enregistree."
   - "Moteurs d'inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation, modele compile en code d'inference) ; Python PyMC = echantillonnage MCMC (NUTS/HMC) + ADVI sur backend PyTensor. Memes concepts (Beta-Bernoulli two-coins), paradigmes d'inference differents -- les ecarts numeriques attendus (point estimate EP vs posterior samples NUTS) ne sont pas des defauts."


### PR DESCRIPTION
## What & why (#8052 + #9377)

`PyMC-1-Setup.ipynb` cell[8] (markdown, the setup notebook's first posterior interpretation) claimed the NUTS sampling produced **"8000 tirages du posterior en 21 secondes"**. The committed cell[7] output — the ground truth, for that exact sampling — prints:

```
Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 20 seconds.
```

**`21` appears nowhere in any committed output** → stale markdown hardcode: the prose was hand-pinned at 21 s, the committed output (20 s) drifted one second across kernels.

| Cell | Before | After |
|------|--------|-------|
| cell[8] markdown | `...pour un total de 8000 tirages du posterior en 21 secondes. Le posterior analytique est **Beta(8, 4)**...` | `...pour un total de 8000 tirages du posterior. Le posterior analytique est **Beta(8, 4)**...` |

**Why strip (not align 21→20)?** MCMC wall-clock time is **machine-dependent** (CPU speed/cores/load) — it re-drifts on every kernel. Re-pinning to `20` reconstitutes the defect next kernel. Per **#9377** (quantitative data held by the dynamic source, not manual prose): cell[7]'s sampler already prints the time dynamically, so it is the single source of truth — the markdown absolute is a duplicate that drifts; **delete it**. The **structural `8000 tirages`** (4 chains × 2000 draws) and the **analytic `Beta(8,4)`** pedagogy are preserved. Same gesture as #9437 (PyMC-11), #9427 (Picross), #9425/#9432 (README counts).

## Diagnostic dérive (§D.5)

- **Cause: a — env/kernel.** Sampling time drifted 21→20 s across kernels; the committed output tracked the env, the markdown did not.
- **Verdict: `CAUSE_FIXED`.** The hand-written machine-dependent absolute is **eliminated**; cell[7]'s dynamic sampler print is the sole source. No re-drifting value remains. (Machine-dependent timing, not stochastic — seed-vs-rephrase does not apply.)

## Build-safety (prose-only markdown)

- **Prose-only**: 1 markdown line edited; **0 code / output / `execution_count` cells touched** (cell[7] code+output unchanged, still `took 20 seconds`; C.2 preserved).
- **Byte-level surgical edit** (count-asserted = 1, no JSON round-trip) → structure byte-identical.
- **No re-exec needed** (C.2 markdown-only exception; cell[7] output unchanged = ground truth).
- **0 CRLF** (LF preserved); diff vs origin/main: **1 ins / 1 del**.
- **Twin parity**: registry rebaselined via `check_twin_parity.py --update --pair "Probas-1 Setup" --by "myia-po-2023:CoursIA"` run **last** (#8957). Singleton `last_audit:` → append-only `audits:` (form migration); committed blob = registry latest `python_sha` → drift_introduced=0 verified.

## Scope & context

- `MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb` + `scripts/notebook_tools/twin_pairs.d/probas-1-setup.yaml` only.

Partial contribution to **#9434** — the clear-cut **machine-dependent** class (settled #9377 gesture). The seed-vs-rephrase posture for unseeded-stochastic remains GATED on coordinator decision, not touched here.

See #9434, #9377, #8052, #8364.

---

`Grain: MED/notebook-python (#9377 strip) — lane myia-po-2023:CoursIA — prev: MED/notebook-python #9437`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
