### PR TITLE
fix(smartcontracts,#8056): stamp honest cost metadata on SC-11-LLM-Assisted (was 4 cost-honesty findings)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
@@ -2503,6 +2503,23 @@
    },
    "start_time": "2026-06-05T14:04:19.407943",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.05,
+   "api_provider": "OpenAI (gpt-4o) / Anthropic (claude-sonnet-5)",
+   "cpu_min": 3,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "OpenAI or Anthropic (optional; committed run uses mock mode, no key required)",
+   "free_alternative": "ollama",
+   "reduced_pedagogical": "mock mode: same Solidity generation/audit/NatSpec flow with canned responses; real LLM quality needs API key or local model",
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-05",
+   "validator": "manual",
+   "notes": "Assistant LLM pour generation/audit/NatSpec Solidity. DEFAULT_PROVIDER=openai (gpt-4o) tourne en MODE MOCK par defaut (reponses codees, 0 USD, deterministe, aucun appel API reel) = run commite. API reelle optionnelle si cle configuree (gpt-4o ~2.5 USD/1M in, claude-sonnet-5 ~3 USD/1M in; ~10-15 prompts courts Solidity => ~0.05 USD/run). Alternative locale gratuite: Ollama (LocalLLMAssistant, qwen2.5-coder:7b, cell 34)."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What & why (#8056)

`SC-11-LLM-Assisted.ipynb` is an **LLM-API notebook** (OpenAI/Anthropic client instantiation in cell[6], `completions.create` across cells 12/18/24/45, reads `OPENAI_API_KEY`) but carried **no `metadata.cost` at all** — a notebook that *can* incur paid API cost declared nothing. The cost-honesty checker (`check_cost_metadata.py`, #8056) flagged it **4×**: 2 CRITICAL `api_used_but_cost_zero` + 2 MAJOR `token_required_but_no_account`.

## G.1 firsthand — actual behavior (audit-reassessment §2)

The flag is **real, not a false positive** (unlike SW-7b, where "OpenAI"/"Llama" were OWL ontology *data*, not API calls). Verified against committed source:

- `DEFAULT_PROVIDER = "openai"` (gpt-4o) runs in **MODE MOCK by default** (cell[0]: *"mode mock, aucun appel API reel"*) — canned responses, deterministic, $0. **This is the committed run** (outputs say *"Contrat genere par LLM (mock)"*).
- Real API is **OPTIONAL**: cell[6] initializes clients only `if HAS_OPENAI and config.openai_api_key`. The Anthropic provider path makes real calls if a key is set.
- **Free local alternative** exists: `LocalLLMAssistant` (cell 34, Ollama `qwen2.5-coder:7b`, `localhost:11434`).

So the defect is genuine: the notebook can cost money, yet declares nothing. An honest stamp must capture *"mock default = $0, real API optional, free local alternative"*.

## Honest cost stamp (clears all 4 findings, checker exit 0)

| Field | Value | Why honest |
|-------|-------|------------|
| `api_usd_est` | **0.05** | Real optional-API run: ~10-15 short Solidity prompts (generate/audit/NatSpec/workflow/ERC-20). gpt-4o ~$2.5/1M in, claude-sonnet-5 ~$3/1M in → ~$0.05-0.09/run. Conservative midpoint. |
| `api_provider` | OpenAI (gpt-4o) / Anthropic (claude-sonnet-5) | The two providers the code instantiates (#9372 fixed model_anthropic to claude-sonnet-5). |
| `external_account` | OpenAI or Anthropic (optional; committed run = mock, no key) | ≠ `none` → clears token_required_but_no_account. |
| `free_alternative` | `ollama` | Canonical sentinel; notebook genuinely supports Ollama via LocalLLMAssistant cell 34. Mock-mode default noted in `notes`. |
| `network` | true | Conditional on API mode; default mock is local. |
| `notes` (FR) | full context | mock default = $0 deterministe (run committé); API réelle optionnelle ~0.05 USD; alternative locale Ollama. |

## Build-safety

- **Metadata-only**: a single top-level `"cost"` key inserted as sibling of `papermill` (byte-surgical `raw.replace`, count-asserted=1, **no JSON round-trip**). **0 cells / source / outputs / execution_count touched** → C.2 trivially preserved (committed mock outputs unchanged).
- **17 ins / 0 del**, 0 CRLF.
- **SC-11 is NOT a twin pair** (absent from `twin_pairs.d/`) → no twin-parity `--update` needed.
- **Checker verification**: `check_cost_metadata.py SC-11...ipynb` → **0 findings** post-stamp (was 4); exit 0.
- **No regression**: `test_check_cost_metadata.py` → **45 passed**.

## Scope & context

- `MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb` only.

Partial contribution to **#8056** (cost-matrix population). Targets the **SymbolicAI family** — not GenAI (po-2025) or QC (po-2024) territory, so no lane collision. The checker found 7 SymbolicAI notebooks with cost findings; this fixes 1 (the strongest-signal LLM-API one). Does **not** close #8056 (GenAI/QC/other SymbolicAI notebooks remain, owned by their lanes).

Note: a sibling FP was ruled out firsthand — `SW-7b-Python-OWL` was also flagged (`api_used_but_cost_zero`) but its "OpenAI"/"Anthropic"/"Llama" are **OWL ontology individuals** (model names as data in a HermiT-reasoning example), not API calls. Its existing cost metadata (`api_usd_est: 0.0`, note *"aucune API externe"*) is **correct** — not touched.

See #8056, #4208, #8052.

---

`Grain: DEEP/tooling (#8056 cost-metadata) — lane myia-po-2023:CoursIA — prev: MED/notebook-python #9439`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
