### PR TITLE
fix(planners,#8056): correct under-declared cost metadata on Planners-10-LLM-Planning (local Qwen free / Anthropic optional)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
@@ -1882,8 +1882,8 @@
  ],
  "metadata": {
   "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
+   "api_usd_est": 0.03,
+   "api_provider": "Anthropic (claude-sonnet-5) / OpenAI-compatible (local Qwen qwen3.6-35b-a3b)",
    "qcc_tokens_est": 0,
    "cpu_min": 2,
    "gpu_min": 0,
@@ -1891,13 +1891,13 @@
    "vram_gb": 0,
    "vram_tier": "NONE",
    "network": true,
-   "external_account": "none",
+   "external_account": "Anthropic (optional; committed run = mock mode without keys)",
    "free_alternative": "self",
    "reduced_pedagogical": "LLM calls optional - degrades to printed expected examples without API keys (cf outputs)",
    "reproducibility": "MED",
-   "metadata_written": "2026-08-03",
-   "validator": "papermill",
-   "notes": "LLM-assisted planning; API guarded (openai/anthropic clients optional)"
+   "metadata_written": "2026-08-05",
+   "validator": "papermill+manual",
+   "notes": "LLM-assisted planning (generate_plan_direct, Chain-of-Thought, text_to_pddl, plan_repair, heuristique). Run commite = MODE MOCK (clients OpenAI/Anthropic Non configure -> exemples attendus imprimes, 0 USD, deterministe). API optionnelle si cles configurees: client OpenAI-compatible pointe sur Qwen LOCAL (qwen3.6-35b-a3b via OPENAI_BASE_URL = GRATUIT, self-hosted); client Anthropic (claude-sonnet-5) = ~9 appels courts => ~0.03 USD/run optionnel. #9289 avait declare api_provider:none (sous-declaration: le notebook PEUT appeler une API payante) - corrige vers declaration honnete."
   },
   "kernelspec": {
    "display_name": "Python 3",


### PR DESCRIPTION
## What & why (#8056)

`Planners-10-LLM-Planning.ipynb` **already had** a `metadata.cost` block (populated by #9289), but it **under-declared**: `api_provider: "none"` + `api_usd_est: 0.0` + `external_account: "none"`, while the code instantiates OpenAI/Anthropic clients (cell[5]) and calls `completions.create`/`messages.create` across 7 cells, reading `OPENAI_API_KEY`/`ANTHROPIC_API_KEY`/`OPENAI_BEARER_TOKEN`. The cost checker (#8056) flagged it **4×**: 2 CRITICAL `api_used_but_cost_zero` + 2 MAJOR `token_required_but_no_account`.

This is a **different defect profile** from SC-11 (#9440, missing metadata): here the metadata *exists* but is **inaccurate** — a reader seeing `api_provider: "none"` would wrongly believe this notebook never calls a paid API.

## G.1 firsthand — the local-Qwen nuance (vs SC-11)

Verified against committed source — a genuine nuance the under-declaration missed:
- The **"OpenAI client" is OpenAI-compatible pointing at a LOCAL Qwen server** (`model_openai: "qwen3.6-35b-a3b"`, `base_url` from `OPENAI_BASE_URL`) → **FREE / self-hosted**. This is the checker's documented FP-guard scenario, but `api_provider: "none"` did *not* trigger the free-provider exemption (`local`/`hf`/`ollama`).
- The **Anthropic client** (`claude-sonnet-5`) is genuinely **PAID** when configured.
- **Committed run = MOCK MODE** (both clients "Non configure", printed expected examples, $0, deterministic).

So the defect is real: the notebook *can* call a paid Anthropic API, yet declared `api_provider: none`. The honest stamp must reflect: local Qwen free, Anthropic optional paid, committed mock $0.

## Honest stamp (corrects the under-declaration, clears all 4 findings)

| Field | Before (#9289) | After |
|-------|----------------|-------|
| `api_usd_est` | 0.0 | **0.03** (optional Anthropic path; ~9 short calls at claude-sonnet-5 ~$3/1M in; local Qwen free; committed mock $0) |
| `api_provider` | `"none"` | `Anthropic (claude-sonnet-5) / OpenAI-compatible (local Qwen qwen3.6-35b-a3b)` |
| `external_account` | `"none"` | `Anthropic (optional; committed run = mock mode without keys)` |
| `free_alternative` | `"self"` | `"self"` (kept — local Qwen is self-hosted free) |
| `notes` (FR) | "API guarded (optional)" | run commite = MOCK 0 USD; OpenAI path = Qwen LOCAL gratuit; Anthropic = ~0.03 USD/run optionnel; #9289 under-declaration corrected |

## Build-safety

- **Metadata-only**: byte-surgical field replacement of the `cost` block (count-asserted=1, **no JSON round-trip**). **0 cells / source / outputs / execution_count touched** → C.2 trivially preserved (committed mock outputs unchanged).
- **6 ins / 6 del**, 0 CRLF.
- **NOT a twin pair** (absent from `twin_pairs.d/`) → no twin-parity `--update`.
- **Checker**: `check_cost_metadata.py Planners-10...ipynb` → **0 findings** post-stamp (was 4); exit 0.
- **No regression**: `test_check_cost_metadata.py` → **45 passed**.

## Scope & context

- `MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb` only.

Partial contribution to **#8056** (cost-matrix). SymbolicAI/Planners family (not GenAI/po-2025 or QC/po-2024 → no lane collision). Corrects the #9289 under-declaration on one notebook. Does **not** close #8056. See #8056, #4208.

---

`Grain: DEEP/tooling (#8056 cost-metadata) — lane myia-po-2023:CoursIA — prev: DEEP/tooling #9440`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
