### PR TITLE
docs(rules,#9377): C.5 — valeurs quantitatives en prose, retirer plutot que re-epingler

### DIFF
--- a/.claude/rules/notebook-conventions.md
+++ b/.claude/rules/notebook-conventions.md
@@ -100,7 +100,7 @@ Ré-aligner sans diagnostic = consacrer la dégénérescence : le notebook re-d�
 | Classe | Exemple | Décision |
 |--------|---------|----------|
 | **Structurel** | `2^225` combinaisons → speedup `~2.8e24x` ; nombre de contraintes ; complexité | **GARDER** — stable d'une machine à l'autre, c'est du contenu pédagogique réel |
-| **Machine-dépendant** | temps absolus (`~21 s`, `24-127 ms`) | **RETIRER** — renvoi à la cellule de mesure, ou ordre de grandeur |
+| **Machine-dépendant** | temps absolus (`~21 s`, `24-127 ms`) | **RETIRER** — renvoi à la cellule de mesure ; si le coût relatif porte le propos, l'écrire en **rapport** (cf ci-dessous) |
 | **Env-dépendant (observé)** | table de versions `NumPy 2.4.2` écrite à la main | **RETIRER** quand une cellule imprime déjà la version (source unique = l'output) |
 | **Env-dépendant (exigé)** | `Python 3.10+`, `.NET 9.0` | **GARDER** — c'est une **décision de projet**, pas une observation ; ne dérive pas |
 | **Stochastique seedé** | fitness d'un GA à `seed=42` | **GARDER** — reproductible, donc stable |
@@ -114,6 +114,14 @@ Les deux règles se croisent sur toute PR « alignement doc-honesty » et semble
 - **#9377** dit de **préférer retirer** l'épingle.
 
 **Quand les deux s'appliquent, retirer gagne** — parce que retirer sort définitivement la valeur du domaine de §D.5. Une prose qui ne cite plus de nombre volatil ne peut plus dériver, donc ne peut plus déclencher un #8052 au prochain passage kernel. C'est la seule des deux issues qui **ferme** la boucle au lieu de la déplacer d'un cran.
+
+### Le coût relatif se garde, le coût absolu se retire
+
+C'est la classe la plus fournie en pratique (temps de calcul comparant deux approches), et « retirer » y perd parfois du contenu réel : quand le propos **est** que telle approche coûte plus cher que telle autre, effacer les chiffres efface la leçon.
+
+La sortie est de passer de l'absolu au **rapport**. `0.2 s contre 0.1 s` devient `~2x le coût du filtrage` : les deux mesures viennent de la même exécution sur la même machine, donc leur rapport est **invariant** là où chacune dérive. Le lecteur garde l'information qui compte (l'ordre de grandeur relatif) et la prose sort du domaine de §D.5.
+
+Deux réserves : le rapport n'est valable que si les deux termes sont **mesurés dans la même cellule** (comparer un timing d'aujourd'hui à un timing d'une ancienne exécution ne vaut rien), et il ne remplace pas une complexité — `$O(n^2)$` reste la bonne façon de dire un coût asymptotique.
 
 ### Reformuler ne doit pas maquiller la contradiction
 

--- a/.claude/rules/notebook-conventions.md
+++ b/.claude/rules/notebook-conventions.md
@@ -91,3 +91,39 @@ Commit UNIQUEMENT les notebooks dont la source a change (`git diff <nb> | grep -
 
 Ré-aligner sans diagnostic = consacrer la dégénérescence : le notebook re-dérive au cycle suivant (cf vague SW-13 #7751→#7872→#7944→#8343, 4 PRs pour colmater des claims fabriquées en série). Voir aussi [sota-not-workaround.md](sota-not-workaround.md) (axe-2 SOTA), [secrets-hygiene.md](secrets-hygiene.md) règle 6 (jamais hand-editer un output — corriger la cause + re-executer).
 
+## Valeurs quantitatives en prose : retirer plutôt que ré-épingler (rule C.5)
+
+**Mandat user #9377** — « les données quantitatives doivent être tenues par le CI, pas dans la prose manuelle ». Appliqué aux README (comptes de notebooks #9377, tailles #9425, comptes de cellules #9432), il vaut **à l'intérieur des notebooks**, où la même pathologie rouvre un ticket #8052 à chaque re-exécution.
+
+**Toutes les valeurs ne sont pas équivalentes** — c'est ce qui rend la règle applicable plutôt que dogmatique :
+
+| Classe | Exemple | Décision |
+|--------|---------|----------|
+| **Structurel** | `2^225` combinaisons → speedup `~2.8e24x` ; nombre de contraintes ; complexité | **GARDER** — stable d'une machine à l'autre, c'est du contenu pédagogique réel |
+| **Machine-dépendant** | temps absolus (`~21 s`, `24-127 ms`) | **RETIRER** — renvoi à la cellule de mesure, ou ordre de grandeur |
+| **Env-dépendant (observé)** | table de versions `NumPy 2.4.2` écrite à la main | **RETIRER** quand une cellule imprime déjà la version (source unique = l'output) |
+| **Env-dépendant (exigé)** | `Python 3.10+`, `.NET 9.0` | **GARDER** — c'est une **décision de projet**, pas une observation ; ne dérive pas |
+| **Stochastique seedé** | fitness d'un GA à `seed=42` | **GARDER** — reproductible, donc stable |
+| **Stochastique non seedé** | utilité CFR après une itération unique | **RETIRER** ou **seeder** — jamais citer une valeur d'instance |
+
+### L'arbitrage §D.5 ↔ #9377 : retirer gagne
+
+Les deux règles se croisent sur toute PR « alignement doc-honesty » et semblent se contredire :
+
+- **§D.5** ([pr-review-discipline.md](pr-review-discipline.md)) gouverne le **ré-épinglage** : si l'on remplace un nombre volatil par un autre nombre, celui-ci doit venir d'une **re-exécution fraîche**, jamais d'un alignement à la main sur une vieille sortie.
+- **#9377** dit de **préférer retirer** l'épingle.
+
+**Quand les deux s'appliquent, retirer gagne** — parce que retirer sort définitivement la valeur du domaine de §D.5. Une prose qui ne cite plus de nombre volatil ne peut plus dériver, donc ne peut plus déclencher un #8052 au prochain passage kernel. C'est la seule des deux issues qui **ferme** la boucle au lieu de la déplacer d'un cran.
+
+### Reformuler ne doit pas maquiller la contradiction
+
+Retirer la valeur ne veut pas dire écrire une affirmation théorique qui *a l'air* fausse à côté d'un output qui la contredit. Si la sortie committée affiche `-0.033` et que la prose devient « converge vers `-1/18` », le lecteur voit toujours l'écart.
+
+La prose honnête dit ce qui est réellement vrai : la valeur théorique **et** le fait que l'instance affichée s'en écarte, avec la raison (« une exécution unique de CFR fluctue ; la convergence est en espérance sur les itérations »). Le contenu pédagogique, c'est la loi **plus** l'écart, pas la loi seule.
+
+### Critère de relecture
+
+Une seule question sur la prose modifiée : **cite-t-elle encore un nombre qui rebougera au prochain passage kernel ?** Si oui, la PR ré-épingle et §D.5 s'applique dans toute sa rigueur (re-exécution fraîche exigée). Si non, la boucle est fermée.
+
+See #9377, #8052.
+


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-ai-01:CoursIA — prev: MED/tooling #9430

**Cette PR modifie `.claude/rules/` : elle attend le sign-off user** (CLAUDE.md §A). Elle est prête, pas urgente — matière pour la revue au calme.

## Ce que ça fait

Porte le mandat #9377 — *« les données quantitatives doivent être tenues par le CI, pas dans la prose manuelle »* — **à l'intérieur des notebooks**. Il a déjà été appliqué aux README (comptes de notebooks #9377, tailles #9425, comptes de cellules #9432) ; il ne l'avait jamais été aux cellules markdown, où la même pathologie rouvre un ticket #8052 à chaque re-exécution.

Une seule section ajoutée, `## Valeurs quantitatives en prose (rule C.5)`, dans `.claude/rules/notebook-conventions.md`. +36 lignes, 1 fichier.

## Pourquoi maintenant : la vague du 2026-08-04

Quatre PR le même après-midi alignent une valeur de prose sur une sortie committée. Les quatre corrigent une contradiction **réelle** ; la table les classe avec les six classes de la règle :

| PR | notebook | valeur ré-alignée | classe C.5 | verdict |
|---|---|---|---|---|
| #9426 | App-7-Wordle | `~3.3` → `~3.1` tentatives | stochastique **seedé** (`random.seed(42)`, `benchmark_solver(seed=42)`) | garder — reproductible |
| #9427 | App-11-Picross | speedups `~68x` → `~16x`, `~1M-100Mx` → `~2.8e24x` | structurel (`2^225` combinaisons) | garder — stable d'une machine à l'autre |
| #9427 | App-11-Picross | `(28-364 ms mesuré)` → `(24-127 ms mesuré)` | **machine-dépendant** | **retirer** |
| #9428 | Search-5-GeneticAlgorithms | fitness `42.11` → `41.71` | stochastique **seedé** (`SEED = 42`, PyGAD `random_seed=SEED`) | garder — reproductible |
| #9429 | GT-4c-NashExistence | table de versions `NumPy 2.4.2` → `2.4.6` | **env observé** | **retirer** |

J'avais compté trois ré-épinglages volatils en ouvrant cette PR ; la vérification des seeds en laisse **deux**. Les deux autres sont des ré-alignements légitimes — et c'est précisément ce que la table doit produire. Une règle qui condamnerait les quatre dévorerait du contenu pédagogique réel ; le tri est la substance de la proposition, pas un préambule.

#9429 dit lui-même dans son body — *« cell[2] imprime la version dynamiquement, donc une source unique de vérité est trivialement restaurable »* — puis ré-épingle la table à la main. C'est le cas le plus net : la source unique existe déjà, la prose la recopie.

## Pourquoi le geste valeur-par-valeur ne referme pas la boucle

Vérifié après merge, sur `main`. #9426 a corrigé `~3.3` → `~3.1` à deux endroits d'App-7-Wordle (table de comparaison, conclusion). Le tableau d'introduction du même notebook, `md[2]`, n'était pas dans son scope et porte toujours :

| # | Approche | Performance attendue |
|---|----------|---------------------|
| 1 | Filtrage simple | **~4-5 tentatives** |
| 2 | CSP | **~4-5 tentatives** |
| 3 | Entropie | **~3.5 tentatives** |

Le benchmark committé du même notebook (`cell[41]`) mesure **3.11 / 3.12 / 2.86**. Le lecteur entre donc sur une prédiction que le notebook réfute trente-neuf cellules plus loin sans jamais le dire — et pour l'entropie dans le mauvais sens : annoncée la moins bonne des trois à `~3.5`, elle est la meilleure à `2.86`.

Ce n'est pas un reproche à #9426, dont le scope était l'observation contredite, pas la prédiction d'intro. C'est la démonstration du problème : un alignement valeur-par-valeur, fait soigneusement, laisse toujours la valeur suivante à une cellule de distance. Sous C.5 `md[2]` ne se ré-épingle pas à `3.1 / 3.1 / 2.9` — la colonne devient qualitative (« la moins efficace / structurée, coût similaire / la plus efficace »), et la cellule sort du domaine de #8052 définitivement.

## Le cœur : l'arbitrage §D.5 ↔ #9377

Les deux règles se croisent sur toute PR « alignement doc-honesty » et semblent se contredire :

- **§D.5** ([pr-review-discipline.md](../blob/main/.claude/rules/pr-review-discipline.md)) gouverne le **ré-épinglage** : un nombre qui en remplace un autre doit venir d'une re-exécution fraîche.
- **#9377** dit de **préférer retirer** l'épingle.

**Retirer gagne** — parce que retirer sort définitivement la valeur du domaine de §D.5. Une prose qui ne cite plus de nombre volatil ne peut plus dériver, donc ne peut plus déclencher un #8052 au prochain passage kernel. C'est la seule des deux issues qui **ferme** la boucle au lieu de la déplacer d'un cran.

## Ce que la règle ne dit pas (les deux garde-fous)

**Toutes les valeurs ne se retirent pas.** La table distingue six classes ; trois se gardent. Un `2^225` combinaisons → speedup `2.8e24x` est stable d'une machine à l'autre : c'est du contenu pédagogique réel. Un `Python 3.10+` n'est pas une observation mais une **décision de projet** — il ne dérive pas tout seul, contrairement à une table de versions *observées*. Cette distinction ENV exigé / ENV observé vient du recensement po-2023 (6 planchers de prérequis contre 1 table observée) et évite que la règle dévore des prérequis légitimes.

**Reformuler ne doit pas maquiller la contradiction.** Si la sortie affiche `-0.033` et que la prose devient « converge vers `-1/18` », on a remplacé une affirmation fausse par une affirmation vraie *qui a l'air* fausse. La prose honnête dit la loi **et** l'écart, avec sa raison. Cas concret trouvé par po-2023 en recensant : GT-13 md#14 affirme « proche de `-1/18` » pour un `-0.033` qui en est **plus loin** que le `-0.055` d'origine — pendant que md#22 du même notebook dit déjà la bonne chose (« l'utilité finale fluctue car on observe une seule itération »).

## Matière première

Le recensement de po-2023 (55 valeurs machine-dépendantes, 6 planchers de prérequis, 53 stochastiques déjà seedées, 1 table de versions observées) est la mesure sur laquelle la ligne de partage est calibrée. #9438 et #9439, mergées ce cycle, sont les deux premières applications du geste (strip d'un `21 secondes` MCMC et de 5 timings de métaheuristiques).

## Vérification

- [x] 1 fichier, +36/-0, aucune ligne existante modifiée — la section s'ajoute après C.4 sans la toucher.
- [x] Aucun marqueur `CATALOG-STATUS` ni artefact généré touché.
- [x] Prose en français (cf [readme-french-first.md](../blob/main/.claude/rules/readme-french-first.md)).
- [ ] **Sign-off user** — requis pour tout `.claude/rules/`, non contourné.

See #9377
See #8052
