### PR TITLE
fix(sudoku,#9434): de-hardcode numpy version from markdown (ENV class)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
@@ -152,7 +152,7 @@
     "\n",
     "| Bibliotheque | Version | Rôle dans ce notebook |\n",
     "|-------------|---------|----------------------|\n",
-    "| numpy | 2.4.2 | Calculs numériques, statistiques (medianne, moyennes) |\n",
+    "| numpy | (cf. cellule) | Calculs numériques, statistiques (medianne, moyennes) |\n",
     "| matplotlib | - | Visualisations (barres, boxplots, radar) |\n",
     "| ortools | - | Solveur CP-SAT industriel (4e solveur du benchmark) |\n",
     "| time | - | Mesure des temps d'exécution |\n",

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-18-comparison.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-18-comparison.yaml
@@ -12,7 +12,12 @@
       by: myia-po-2023:CoursIA
       python_sha: 36401a556e3553e4dd2a7fc52d4222251f8d6c2e
       csharp_sha: 60eda1c910b9a3a4367e029fd308fb8a2983adda
+    - date: "2026-08-05"
+      by: myia-po-2023:CoursIA
+      python_sha: 40c4b0bd5db068bd716e75b0c0dbdae8a76212ef
+      csharp_sha: 60eda1c910b9a3a4367e029fd308fb8a2983adda
   known_differences:
+    - "Rebaseline 2026-08-05 : cote Python deplace par de-hardcodage de la version numpy depuis le markdown (classe ENV #9434, edition markdown-only). Parite semantique inchangee (aucune cellule code, aucune sortie, aucun exec_count touche) ; cote C# non modifie. Attestation = nouveau blob SHA du cote Python."
     - "Socle pedagogique commun : comparaison synthese de TOUS les solveurs de la serie Sudoku (backtracking, dancing links, genetic, OR-Tools, Z3, BDD, probabiliste), meme concept (tableau de benchmark croise : temps de resolution / robustesse / complexite), meme arc conclusif (Fin de serie)."
     - "Parite structurelle forte : Python et C# ont exactement la meme structure (25 cellules code / 43 markdown chacun), memes en-tetes de navigation ('Fin de serie'), memes solveurs compares. Les deux cotes instrumentent les memes familles de solveurs."
     - "Idiomes framework : chaque cote invoque les solveurs disponibles dans son ecosysteme (Python = ortools/z3/numpy/stdlib ; C# = Infer.NET/Choco/Z3/BDD/stdlib). La comparaison croisee est le livrable pedagogique commun."


### PR DESCRIPTION
Grain: LIGHT/notebook-markdown (#9434 ENV version-depin) — lane myia-po-2023:CoursIA — prev: MED/notebook-python #9444

## Ce que fait la PR

`Sudoku-18-Comparison-Python.ipynb` cell[3] (table « Bibliotheques utilisees ») : retire la version numpy **2.4.2** ecrite en dur, qui duplique ce que cell[2] imprime dynamiquement (`print(f"  numpy {np.__version__}")`). Classe ENV du mandat #9434 / #9377.

| Cellule | Avant | Apres |
|---|---|---|
| cell[3] table | `\| numpy \| **2.4.2** \| Calculs numeriques... \|` | `\| numpy \| (cf. cellule) \| Calculs numeriques... \|` |

Les autres lignes (matplotlib `-`, ortools `-`, time `-`) n'avaient pas de pin — intactes.

## Ligne de partage (#9434)

- **ENV « version observee » (DELETE)** : `2.4.2` — patch version qui derive a chaque bump, ET une cellule code imprime la version dynamiquement. Cible de cette PR.
- **Capability/non-version (KEEP)** : aucune ici (les `-` restent).

## Validation

- **C.2 exception (markdown-only)** : 0 cellule code touchee (25 code cells, 0 avec `execution_count` null). Outputs precedents valides — pas de re-exec.
- **Diff chirurgical** : `+1/-1`, uniquement le pin retire. Byte-identical (raw-text replace).
- **C.1** : 0 pattern interdit.

## Portee & G.1

Deuxieme famille de la veine #9434 « duplicate propre » (dynamic print + markdown restatement). Un scan tight repo-wide (markdown pin x.y.z + `__version__` imprime dans le meme notebook, sur `origin/main` frais) ne trouve que **2 notebooks** avec ce motif : GT-1-Setup (PR #9444) et Sudoku-18 (celle-ci). QC-Py-24 etait un faux positif (`1997.9.8` = citation, pas une version torch). Cette PR epuise donc la classe clean-duplicate connue.

G.1 : une premiere lecture tronquee (200 chars) de cell[2] m'a fait croire qu'il n'imprimait pas la version ; lecture complete -> `np.__version__` bien present. Lecon : `read-full-cell-body-not-comment`.

Grain: MED/notebook-python (#9434 ENV version-duplicate) — lane myia-po-2023:CoursIA — prev: MED/notebook-python #9444

See #9434
See #9377, #8052

🤖 Generated with [Claude Code](https://claude.com/claude-code)

