### PR TITLE
ci(twin-parity,#9399): add metadata-immune content_sha (volet c)

### DIFF
--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -129,6 +129,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as _dt
+import hashlib
 import json
 import re
 import subprocess
@@ -278,6 +279,33 @@ def _git_blob_sha(repo_root: Path, rel_path: str, git_ref: str = "HEAD") -> str 
     return None
 
 
+def _content_sha(repo_root: Path, rel_path: str, git_ref: str = "HEAD") -> str | None:
+    """SHA-256 canonique du notebook SANS sa metadonnee de niveau carnet (#9399 volet c).
+
+    Hache le contenu pedagogique (cellules + leurs outputs) en excluant
+    `nb["metadata"]` (cost, papermill, kernelspec, language_info) : un tampon
+    `metadata.cost` seul ne porte aucune divergence pedagogique et ne doit PAS
+    faire rougir le gate (les 2 faux positifs Sudoku-8/14 BDD du 2026-08-04,
+    ou seul le bloc cost a bouge). Les cellules (et leur `metadata` cellulaire)
+    restent hachees : un fix de prose (cellule markdown) ou une re-exec (output
+    change) continuent de produire un DRIFT (vrais positifs, critere
+    d'acceptation ai-01 : la correction de prose de #9413 rougit toujours).
+
+    Canonique : `json.dumps(sort_keys=True, separators=(",",":"))` -- le SHA
+    est stable d'une machine a l'autre et independant du formatage du fichier.
+    """
+    content = _git_show_file(repo_root, git_ref, rel_path)
+    if content is None:
+        return None
+    try:
+        nb = json.loads(content)
+    except (ValueError, TypeError):
+        return None
+    stripped = {k: v for k, v in nb.items() if k != "metadata"}
+    canonical = json.dumps(stripped, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
 def _git_show_file(repo_root: Path, git_ref: str, rel_path: str) -> str | None:
     """Contenu d'un fichier versionne a `git_ref` (None si absent).
 
@@ -418,14 +446,40 @@ def check_pair(repo_root: Path, pair: dict, git_ref: str = "HEAD") -> dict:
         details.append(f"C# MANQUANT dans git : {cs}")
         status = "MISSING"
 
+    # content_*_sha (#9399 volet c) : metadata-immune. Calcules LAZILY -- UNIQUEMENT
+    # quand l'audit les a enregistrees. Les paires legacy (aucune content_*_sha
+    # enregistree) tombent sur les git blob SHA sans payer le surcout d'un git show
+    # + json.loads par carnet ; ainsi la flotte actuelle (entierement legacy) garde
+    # sa perf d'avant volet (c). Seules les paires --update'ees (rollout progressif)
+    # declenchent le calcul metadata-immune.
+    use_content = (audit.get("content_python_sha") is not None
+                   and audit.get("content_csharp_sha") is not None)
+    cur_cpy = _content_sha(repo_root, py, git_ref) if use_content else None
+    cur_ccs = _content_sha(repo_root, cs, git_ref) if use_content else None
+
     if status == "OK":
-        py_drift = (rec_py is not None and cur_py != rec_py)
-        cs_drift = (rec_cs is not None and cur_cs != rec_cs)
-        no_baseline = (rec_py is None or rec_cs is None)
-        if py_drift:
-            details.append(f"Python a drift : {rec_py[:8]} -> {cur_py[:8]}")
-        if cs_drift:
-            details.append(f"C# a drift : {rec_cs[:8]} -> {cur_cs[:8]}")
+        # Verdict DRIFT : preferer les content_*_sha (metadata-immunes) quand
+        # l'audit les enregistre ; sinon retomber sur les git blob SHA (legacy).
+        # Un tampon metadata.cost seul -> content inchange -> PAS de DRIFT
+        # (faux positif). Un fix de prose / re-exec -> content change -> DRIFT
+        # (vrai positif, critere d'acceptation ai-01 #9399).
+        rec_cpy, rec_ccs = _cmp_pair_shas(audit)
+        if use_content:
+            py_drift = (cur_cpy is not None and cur_cpy != rec_cpy)
+            cs_drift = (cur_ccs is not None and cur_ccs != rec_ccs)
+            no_baseline = (cur_cpy is None or cur_ccs is None)
+            if py_drift:
+                details.append(f"Python a drift (content) : {str(rec_cpy)[:8]} -> {cur_cpy[:8]}")
+            if cs_drift:
+                details.append(f"C# a drift (content) : {str(rec_ccs)[:8]} -> {cur_ccs[:8]}")
+        else:
+            py_drift = (rec_py is not None and cur_py != rec_py)
+            cs_drift = (rec_cs is not None and cur_cs != rec_cs)
+            no_baseline = (rec_py is None or rec_cs is None)
+            if py_drift:
+                details.append(f"Python a drift : {rec_py[:8]} -> {cur_py[:8]}")
+            if cs_drift:
+                details.append(f"C# a drift : {rec_cs[:8]} -> {cur_cs[:8]}")
         if no_baseline:
             details.append("Pas de last_audit_sha enregistre (--update requis)")
         if py_drift or cs_drift or no_baseline:
@@ -440,6 +494,8 @@ def check_pair(repo_root: Path, pair: dict, git_ref: str = "HEAD") -> dict:
         "status": status,
         "current_python_sha": cur_py,
         "current_csharp_sha": cur_cs,
+        "current_content_python_sha": cur_cpy,
+        "current_content_csharp_sha": cur_ccs,
         "recorded_python_sha": rec_py,
         "recorded_csharp_sha": rec_cs,
         "last_audit_date": audit.get("date"),
@@ -465,11 +521,16 @@ def update_pair(
     cs = pair["csharp"]
     cur_py = _git_blob_sha(repo_root, py)
     cur_cs = _git_blob_sha(repo_root, cs)
+    # content_*_sha (#9399 volet c) : SHA-256 du notebook sans nb["metadata"].
+    cur_cpy = _content_sha(repo_root, py)
+    cur_ccs = _content_sha(repo_root, cs)
     audit = {
         "date": date or _dt.date.today().isoformat(),
         "by": by or _latest_audit(pair).get("by", "manual"),
         "python_sha": cur_py,
         "csharp_sha": cur_cs,
+        "content_python_sha": cur_cpy,
+        "content_csharp_sha": cur_ccs,
     }
     return audit, cur_py
 
@@ -477,7 +538,14 @@ def update_pair(
 # Cles scalaires d'un enregistrement d'audit (forme append-only ET legacy).
 # Partagees par le singleton `last_audit:` (legacy) et chaque element de la
 # liste `audits:` (append-only, #9399).
-_AUDIT_KEYS = ("date", "by", "python_sha", "csharp_sha")
+_AUDIT_KEYS = (
+    "date", "by", "python_sha", "csharp_sha",
+    # content_*_sha (#9399 volet c) : SHA-256 du notebook sans nb["metadata"].
+    # metadata-immune : un tampon cost seul ne fait plus rougir le gate ni
+    # declencher un faux audit au --update. Ajoutes a cote (anti-regression :
+    # les blob SHA python_sha/csharp_sha restent enregistres pour inspection).
+    "content_python_sha", "content_csharp_sha",
+)
 
 
 def _latest_audit(pair: dict) -> dict:
@@ -573,12 +641,35 @@ def _parse_latest_audit_entry(body_lines):
     return latest
 
 
-def _shas_match(record: dict, new_py, new_cs) -> bool:
-    """True ssi `record` enregistre deja exactement ces deux SHAs (no-op)."""
+def _cmp_pair_shas(d: dict) -> tuple:
+    """SHAs de comparaison (no-op / drift) extraits d'un enregistrement d'audit.
+
+    Prefer les `content_*_sha` (metadata-immunes, #9399 volet c) quand l'audit
+    les porte ; sinon retombe sur les `python_sha`/`csharp_sha` (git blob SHA,
+    legacy pre-content_sha). Centralise la regle de preference afin que
+    `_shas_match` (no-op au --update) et `verify_pair` (DRIFT au --check)
+    appliquent la MEME definition de « rien n'a change ».
+    """
+    cp = d.get("content_python_sha")
+    cc = d.get("content_csharp_sha")
+    if cp is not None and cc is not None:
+        return cp, cc
+    return d.get("python_sha"), d.get("csharp_sha")
+
+
+def _shas_match(record: dict, new_entry: dict) -> bool:
+    """True ssi `record` et `new_entry` partagent les memes SHAs de comparaison (no-op).
+
+    Un changement **metadata-only** (ex: tampon `metadata.cost`) change les git
+    blob SHAs mais PAS les `content_*_sha` : via `_cmp_pair_shas` cela devient un
+    no-op, donc le `--update` n'APPEND PAS de nouvelle entree d'audit pour un
+    changement qui n'est pas pedagogique (faux audit, cf ai-01 design-gate #9399).
+    """
+    rec_py, rec_cs = _cmp_pair_shas(record)
+    new_py, new_cs = _cmp_pair_shas(new_entry)
     if new_py is None or new_cs is None:
         return False
-    return (str(record.get("python_sha", "")) == str(new_py)
-            and str(record.get("csharp_sha", "")) == str(new_cs))
+    return str(rec_py) == str(new_py) and str(rec_cs) == str(new_cs)
 
 
 def _legacy_body_as_list_item(body_lines):
@@ -631,18 +722,15 @@ def _transform_audit_block(form: str, block: list[str], new_entry: dict) -> tupl
         (l'ancien enregistrement, `reason` compris, devient item[0]).
     """
     body = block[1:]
-    new_py = new_entry.get("python_sha")
-    new_cs = new_entry.get("csharp_sha")
-
     if form == "audits":
         latest = _parse_latest_audit_entry(body)
-        if _shas_match(latest, new_py, new_cs):
+        if _shas_match(latest, new_entry):
             return block, False
         return block + _render_new_audit_entry(new_entry), True
 
     # form == "last_audit" -> migration vers la forme append-only
     old_pairs = _parse_flat_audit(body)
-    if _shas_match(dict(old_pairs), new_py, new_cs):
+    if _shas_match(dict(old_pairs), new_entry):
         return block, False
     new_block = ["  audits:\n"]
     if old_pairs:

--- a/scripts/notebook_tools/tests/test_check_twin_parity_content_sha.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_content_sha.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""content_sha du registre de parite (#9399 volet c) — metadata-immune, prose-sensitive.
+
+Avant #9399 volet (c), le gate comparait le **git blob SHA** du notebook entier.
+Or un tampon `metadata.cost` seul (niveau carnet, jamais compile) deplace le blob
+SHA -> DRIFT faux positif (les 2 Sudoku-8/14 BDD du 2026-08-04, ou seul le bloc
+cost avait bouge). Pire, lancer `--update` apres un tel tampon ecrivait une entree
+d'audit datee pour un changement NON pedagogique -> faux audit (ai-01 design-gate #9399).
+
+Volet (c) ajoute un `content_*_sha` (SHA-256 du notebook **sans `nb["metadata"]`**),
+enregistre a cote des `python_sha`/`csharp_sha` (anti-regression : les blob SHA
+restent pour inspection). Le verdict DRIFT prefere le content_sha quand l'audit
+l'enregistre ; retombe sur le blob pour les paires legacy (pre-content_sha).
+
+Ces tests pincent le critere d'acceptation ai-01 :
+  - un tampon metadata.cost SEUL sur un carnet enregistre ne produit AUCUN DRIFT ;
+  - une correction de prose (cellule markdown) en produit toujours un.
+
+Run:
+    pytest scripts/notebook_tools/tests/test_check_twin_parity_content_sha.py
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import check_twin_parity as ctp  # noqa: E402
+
+
+# --- helpers -----------------------------------------------------------------
+
+def _git_repo(tmp_path: Path) -> Path:
+    """Un mini-depot git pret a committer des notebooks."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for args in (("init", "-q"), ("config", "user.email", "t@t"),
+                 ("config", "user.name", "t")):
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+    return repo
+
+
+def _commit(repo: Path, rel: str, nb: dict, msg: str) -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(nb), encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", msg], cwd=repo,
+                   check=True, capture_output=True)
+
+
+def _nb(source: list[str] | None = None, cost: float | None = None) -> dict:
+    return {
+        "cells": [{
+            "cell_type": "markdown",
+            "source": source if source is not None else ["# Title\n"],
+            "metadata": {},
+        }],
+        "metadata": ({"cost": {"api_usd_est": cost}} if cost is not None
+                     else {"kernelspec": {"name": "python3"}}),
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+# --- 1. _content_sha : metadata-immune + prose-sensitive ---------------------
+
+def test_content_sha_ignores_notebook_level_metadata(tmp_path):
+    repo = _git_repo(tmp_path)
+    rel = "nb.ipynb"
+    _commit(repo, rel, _nb(cost=0.0), "base")
+    before = ctp._content_sha(repo, rel)
+    _commit(repo, rel, _nb(cost=9.99), "cost stamp only")
+    after = ctp._content_sha(repo, rel)
+    assert before == after, (
+        "un tampon metadata.cost seul ne doit PAS changer le content_sha "
+        f"(before={before}, after={after})"
+    )
+
+
+def test_content_sha_detects_prose_change(tmp_path):
+    repo = _git_repo(tmp_path)
+    rel = "nb.ipynb"
+    _commit(repo, rel, _nb(source=["# Title\n"]), "base")
+    before = ctp._content_sha(repo, rel)
+    _commit(repo, rel, _nb(source=["# Different Title\n"]), "prose edit")
+    after = ctp._content_sha(repo, rel)
+    assert before != after, (
+        "une correction de prose DOIT changer le content_sha "
+        "(critere d'acceptation ai-01 #9399)"
+    )
+
+
+def test_content_sha_is_sha256_hex_64():
+    # shape contract : 64-char lowercase hex (distinct du git blob 40-hex)
+    import re
+    # pas de git ici : on construit le canonique a la main pour verifier la forme.
+    nb = _nb(cost=1.0)
+    stripped = {k: v for k, v in nb.items() if k != "metadata"}
+    canon = json.dumps(stripped, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    sha = hashlib.sha256(canon.encode("utf-8")).hexdigest()
+    assert re.fullmatch(r"[0-9a-f]{64}", sha)
+
+
+# --- 2. _cmp_pair_shas : prefer content, fall back blob ----------------------
+
+def test_cmp_pair_shas_prefers_content_when_recorded():
+    d = {"python_sha": "blobP", "csharp_sha": "blobC",
+         "content_python_sha": "cp", "content_csharp_sha": "cc"}
+    assert ctp._cmp_pair_shas(d) == ("cp", "cc")
+
+
+def test_cmp_pair_shas_falls_back_to_blob_for_legacy():
+    d = {"python_sha": "blobP", "csharp_sha": "blobC"}  # no content_*_sha
+    assert ctp._cmp_pair_shas(d) == ("blobP", "blobC")
+
+
+# --- 3. _shas_match : metadata-only = no-op (pas de faux audit) -------------
+
+def test_shas_match_metadata_only_change_is_noop():
+    # l'ancien audit a enregistre content_sha ; une metadata-only change ne
+    # doit PAS declencher un nouvel audit (faux audit, ai-01 design-gate).
+    record = {"content_python_sha": "cp", "content_csharp_sha": "cc"}
+    new_entry = {"python_sha": "newBlob",  # blob a change (metadata)
+                 "csharp_sha": "blobC",
+                 "content_python_sha": "cp",  # content inchange
+                 "content_csharp_sha": "cc"}
+    assert ctp._shas_match(record, new_entry) is True
+
+
+def test_shas_match_prose_change_is_not_noop():
+    record = {"content_python_sha": "cp", "content_csharp_sha": "cc"}
+    new_entry = {"content_python_sha": "cp2",  # prose a change le content
+                 "content_csharp_sha": "cc"}
+    assert ctp._shas_match(record, new_entry) is False
+
+
+def test_shas_match_legacy_blob_path_still_works():
+    # paires legacy (pas de content_sha) : comparaison blob inchangee.
+    record = {"python_sha": "blobP", "csharp_sha": "blobC"}
+    new_entry = {"python_sha": "blobP", "csharp_sha": "blobC"}
+    assert ctp._shas_match(record, new_entry) is True

--- a/scripts/notebook_tools/twin_pairs.d/_schema.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/_schema.yaml
@@ -13,6 +13,16 @@
 #     (`audits[-1]` ou `last_audit`). La migration legacy -> audits: est paresseuse
 #     (a la volee, sur le 1er drift reel) -- pas de reecriture massive.
 #
+# Depuis #9399 volet (c), chaque enregistrement porte en plus
+# `content_python_sha` / `content_csharp_sha` (SHA-256 du notebook SANS
+# `nb["metadata"]` -- cost, papermill, kernelspec, language_info). Le verdict
+# DRIFT preferere ces content_sha (metadata-immunes) quand l'audit les enregistre
+# et retombe sur les git blob SHA (`python_sha`/`csharp_sha`) pour les paires
+# legacy. Un tampon `metadata.cost` seul ne fait plus rougir le gate ni declencher
+# de faux audit au --update ; les vrais changements (prose, re-exec) derives
+# toujours. Les content_sha sont ajoutés A COTE des blob SHA (anti-regression :
+# ces derniers restent enregistres pour inspection humaine).
+#
 # Le check `check_twin_parity.py` compare le SHA courant (git ls-tree HEAD) au
 # SHA audite : DRIFT = un cote a evolue sans re-audit -> parite a reverifier.
 # Apres une audit firsthand, rebaseline UNE paire avec :


### PR DESCRIPTION
## Summary

**Volet (c) of #9399 design-gate (ai-01 c.82)** — the third and final panel of the twin-parity metadata-immunity fix. Excludes `nb["metadata"]` (carnet-level) from the parity hash so a `metadata.cost` stamp alone no longer reddens like a content change.

Follows **volet (a)** (#9405 append-only `audits:` list, #9430 migration of 153 singletons) and **volet (b)** (#9443 fleet-wide drift-audit cron, advisory posture B).

## Design (ai-01 #9399, verbatim)

> Le correctif est borné et ne sur-supprime pas : **exclure** `nb["metadata"]` (niveau carnet) du hachage... pour rester compatible avec l'existant, ajouter un `content_sha` calculé à côté du `python_sha`/`csharp_sha` actuels plutôt que redéfinir ces derniers en place — la migration reste lisible et l'historique d'audit n'est pas jeté (`anti-regression.md`).

**Acceptance criteria (ai-01 #9399):**

> après volet (c), un tampon `metadata.cost` seul sur un carnet enregistré ne produit **aucun** `DRIFT`, et la correction de prose de #9413 en produit toujours un.

Both **proven firsthand** (see Verification).

## What changes

| File | Change |
|------|--------|
| `check_twin_parity.py` | +115/-17. Adds `_content_sha()` (SHA-256 of notebook minus `nb["metadata"]`), `_cmp_pair_shas()` (prefers content, falls back to blob), rewrites `_shas_match()` (dict-based, metadata-immune). `verify_pair()` drift verdict prefers `content_*_sha` when recorded, falls back to blob for legacy. `update_pair()` records `content_python_sha`/`content_csharp_sha` BESIDE the blob SHAs. |
| `twin_pairs.d/_schema.yaml` | +10. Documents the new `content_python_sha`/`content_csharp_sha` fields, the lazy-migration posture, and the prefer-content-fallback-blob verdict. |
| `tests/test_check_twin_parity_content_sha.py` | **NEW** (8 tests). Pins the ai-01 acceptance: content_sha metadata-immune + prose-sensitive, sha256-64-hex shape, `_cmp_pair_shas` preference+fallback, `_shas_match` metadata-noop + prose-not-noop + legacy-blob. |

### Anti-regression: content_sha is additive

The `content_*_sha` are added **A COTE** of the existing `python_sha`/`csharp_sha` git blob SHAs — the blob SHAs stay recorded for human inspection, nothing is thrown away. The verdict *prefers* content_sha when the audit recorded one and *falls back* to blob for legacy pairs. So:

- At **merge**: behavior is **IDENTICAL** (no pair has `content_*_sha` yet).
- Each `--update` (progressive rollout) adds the content SHAs.
- A pair that drifts while still legacy migrates lazily on rebaseline (#9399 volet a posture).

### Performance: lazy content_sha

`content_sha` is computed **LAZILY** — only when the audit recorded a `content_*_sha` (the `use_content` branch). Legacy pairs (the entire current fleet) skip the `git show` + `json.loads` entirely, so volet (c) is a **no-op cost** for them. Only `--update`'d pairs pay it. This keeps the per-pair gate mode at ~29s (it was timing out at 2 min before the lazy fix, when content_sha was computed unconditionally for all 156 pairs × 2 refs).

## Verification

### ai-01 acceptance criteria — firsthand PASS

```
test_content_sha_ignores_notebook_level_metadata  PASSED   # metadata.cost stamp -> SAME content_sha (NO drift)
test_content_sha_detects_prose_change             PASSED   # "# Title" -> "# Different Title" -> DIFFERENT content_sha (DRIFT)
test_shas_match_metadata_only_change_is_noop      PASSED   # blob moved, content same -> _shas_match True (no false audit)
test_shas_match_prose_change_is_not_noop          PASSED   # content changed -> _shas_match False (real audit)
```

Plus an **e2e** run on the real **App-1 NQueens** pair: a `metadata.cost`-only commit leaves `content_sha` unchanged → `OK`; a prose edit flips it → `DRIFT`.

### Test suite — no regression

```
scripts/notebook_tools/tests/test_check_twin_parity_content_sha.py ......... 8 passed (0.51s)
parity/audit/twin/sha/drift subset (-k "...") .............................. 293 passed, 3540 deselected (13.18s)
python -m pytest scripts/notebook_tools/tests/ -q ......................... 3833 passed (91.62s)
```

### Fleet + gate behavior — unchanged

```
--json --check (fleet, advisory cron path):  total=156 ok=153 drift=3 missing=0   # identical to pre-volet-(c)
--json --check --per-pair --base origin/main (gate path):
    drift_introduced=0  drift_resolved=0  drift_pre_existing=3  elapsed=29.1s  exit=0
```

`drift_introduced=0` confirms this PR introduces no drift (it touches no notebook — only the check script, schema, tests). The pre-existing drift=3 is the known Sudoku-8/14 metadata-stamp class that volet (c) is designed to *shrink* once those pairs are `--update`'d with content SHAs.

## Why this unblocks posture (B)→(A) promotion

Per the design-gate, the advisory cron (#9443, posture B) can be **promoted to blocking** once the fleet-wide drift count reaches 0. The current drift=3 is precisely the metadata-stamp false positives that volet (c) makes re-baselineable without a false audit (a `--update` after a cost stamp now records an unchanged content_sha → no DRIFT). Volet (c) is the mechanism that shrinks that count.

## Grain

`MED/tooling (#9399 volet c content_sha)` — lane `myia-po-2023:CoursIA` — prev: `MED/tooling #9446`

See #9399

🤖 Generated with [Claude Code](https://claude.com/claude-code)
