### PR TITLE
fix(arganalysis,#8056): cost-metadata on Argument_Analysis init_agent (MAJOR token_required)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-0-init_agent.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-0-init_agent.ipynb
@@ -2149,6 +2149,22 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "OpenAI (gpt-5-mini, configuré via .env)",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "OpenAI requis (OPENAI_API_KEY + OPENAI_CHAT_MODEL_ID lus via dotenv cell[7]) pour amorcer le pipeline Argument_Analysis ; ce carnet d'init crée le service mais n'effectue aucun appel API dans le run commis",
+   "reduced_pedagogical": "sans clé OpenAI : avertissement 'Configuration OpenAI standard incomplète' (cell[5]/cell[7]), service LLM non créé, pipeline aval bloqué ; les cellules utilisant le LLM basculent en mode dégradé",
+   "reproducibility": "HIGH",
+   "metadata_written": "2026-08-05",
+   "validator": "manual",
+   "notes": "Carnet d'INIT (cell[0]) de la série Argument_Analysis_Agentic : configure Semantic Kernel + OpenAIChatCompletion (gpt-5-mini lu depuis .env) + JVM JPype/Tweety (42 JARs, Java 17.0.18 opérationnel dans le run commis), crée le service LLM global (cell[19]). Run commis : config chargée + service créé, AUCUNE complétion API (0 token, 0 USD) — l'init ne définit que les composants (état partagé, plugins, prompts PM). Le coût API réel est porté par les carnets aval (1-informal, 3-orchestration, capstone) qui enchaînent les invocations LLM. external_account déclaré car cell[7] lit OPENAI_API_KEY : un compte OpenAI configuré est nécessaire pour que l'init réussisse."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
## Summary

**Cost-honesty stamp (#8056)** on `Argument_Analysis_Agentic-0-init_agent.ipynb` — the init notebook of the Semantic Kernel multi-agent argumentation series. The cost checker flagged **[MAJOR] `token_required_but_no_account`**: cell[7] reads `OPENAI_API_KEY` via dotenv but the notebook declared no account. Follows the SC-11 (#9440) / Planners-10 (#9441) stamp pattern.

## Defect (G.1 firsthand, committed run on origin/main)

- **cell[7]** loads `.env` → committed output: `✅ Configuration OpenAI standard chargée (Modèle: gpt-5-mini). Org ID: Non fourni.`
- **cell[19]** creates `global_ai_service_instance = OpenAIChatCompletion(service_id=..., ai_model_id="gpt-5-mini", api_key=..., org_id=...)`. **Service construction is lazy — NO API completion is invoked** in the committed run (no token/usage/cost anywhere in outputs).
- The init notebook only **DEFINES** components: `RhetoricalAnalysisState` (via `argumentation_lib` shim), `StateManagerPlugin`, `ProjectManagerPlugin`, semantic prompts (`prompt_define_tasks_v17`, `prompt_write_conclusion_v8`), `setup_pm_kernel`, `PM_INSTRUCTIONS`. **No LLM invocation** — actual completions happen in the downstream notebooks (`1-informal`, `3-orchestration`, `capstone`).

## Honest stamp

| Field | Value | Why |
|-------|-------|-----|
| `api_usd_est` | **0.0** | Init = service creation; 0 completions in committed run |
| `api_provider` | OpenAI (gpt-5-mini, configuré via .env) | Verified in cell[7]/cell[19] outputs |
| `external_account` | **OpenAI requis** | cell[7] reads `OPENAI_API_KEY`/`OPENAI_CHAT_MODEL_ID`; without them cell[5] warns "Configuration OpenAI standard incomplète" and the downstream pipeline cannot amorce |
| `network` | true | LLM service is network-oriented (constructed, not invoked this run) |
| `gpu_required` | false | JVM/Tweety is CPU (Java 17, 42 JARs); no GPU |
| `reproducibility` | HIGH | Init/config + component definitions; deterministic |
| `notes` (FR) | — | Clarifies: real API cost borne by downstream notebooks (1-informal, 3-orchestration, capstone); this init creates the service but invokes no completion |

**Why `external_account` is required even though `api_usd_est=0`**: the checker's `token_required` finding is correct — the notebook READS the key (`os.getenv("OPENAI_API_KEY")` cell[7]) and the committed run had it configured (gpt-5-mini). A reader reproducing this notebook needs a configured OpenAI account for the init to succeed (else degraded mode). The cost is zero *for this init* but the account dependency is real and now declared.

## Build-safety

- **Metadata-only**: top-level `metadata.cost` block added via byte-surgical string insertion (NO JSON round-trip — preserves `papermill.duration` float formatting `61.610`).
- **0 cells / source / outputs / execution_count touched**. Verified: `+16/-0`, source-length and cell-count byte-identical pre/post.
- **NOT a twin pair** (no `Argument_Analysis` entry in `twin_pairs.d/`) → no `--update`, no parity drift.
- **C.2**: all 11 code cells carry `execution_count != null`.

## Verification

```
check_cost_metadata (this notebook):  findings: (empty)  -- was [MAJOR] token_required_but_no_account
check_cost_metadata --family SymbolicAI:
   Notebooks avec finding : 4   (was 5)
   Findings               : 5   (was 6)
JSON parses; cost block present (14 fields, api_usd_est=0.0).
```

## Pre-existing (NOT introduced by this PR)

1 markdown cell carries papermill `execution_count`/`outputs` pollution (nbformat strict `validate` rejects; verified present on `origin/main` before this PR). This is a papermill artifact on a markdown cell, unrelated to the metadata-only cost stamp, and out of scope here.

## Grain

`MED/tooling (#8056 cost-honesty)` — lane `myia-po-2023:CoursIA` — prev: `MED/tooling #9447`

See #8056

🤖 Generated with [Claude Code](https://claude.com/claude-code)
