### PR TITLE
fix(sl12,#8056): cost-metadata on SL-12 DifferentiableLogicGateNetworks (MAJOR gpu_used_but_not_declared)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12-DifferentiableLogicGateNetworks.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12-DifferentiableLogicGateNetworks.ipynb
@@ -1072,6 +1072,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "local",
+   "cpu_min": 2,
+   "gpu_min": 1,
+   "gpu_required": true,
+   "vram_gb": 8,
+   "vram_tier": "MEDIUM",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": null,
+   "reduced_pedagogical": "Fallback CPU existe (implementation=python, cell[9]) ~10x plus lent ; sans CUDA Toolkit systeme correspondant a torch.version.cuda (cell[3]), la compilation du noyau difflogic echoue (RuntimeError). MNIST auto-telecharge par torchvision au 1er run (~10 Mo).",
+   "reproducibility": "MEDIUM",
+   "metadata_written": "2026-08-05",
+   "validator": "manual",
+   "notes": "Entrainement local difflogic (LogicLayer + GroupSum) sur MNIST, DEVICE=cuda sur NVIDIA GeForce RTX 3070 Laptop GPU (VRAM 8.6 Go, CUDA dispo=True ; verifie firsthand outputs cell[3]). Implementation=python (nvcc absent) mais tenseurs sur GPU via DEVICE=cuda. ~2000-5000 iters, accuracy ~83% (cell[10]). Cout API nul (local self-hosted, aucun appel LLM/API). Aucun compte externe requis. GPU requis : CUDA Toolkit correspondant a torch.version.cuda (sinon RuntimeError compilation, cell[3]). Stamp metadata-only (byte-surgical, no JSON round-trip) ; execution GPU non relancee ce cycle."
+  },
   "kernelspec": {
    "display_name": "Python (difflogic-sl12)",
    "language": "python",


### PR DESCRIPTION
## Summary

**Cost-honesty stamp (#8056)** on `SL-12-DifferentiableLogicGateNetworks.ipynb` — resolves the **[MAJOR] `gpu_used_but_not_declared`** finding (GPU was used in the committed run but no `metadata.cost` block declared it). Follows the SC-11 (#9440) / Planners-10 (#9441) / Arg-Analysis-init (#9448) stamp pattern.

## Defect (G.1 firsthand, committed run on origin/main)

SL-12 trains a **difflogic** Differentiable Logic Gate Network on MNIST. The committed outputs prove GPU was used:

- **cell[3]** output: `Device : NVIDIA GeForce RTX 3070 Laptop GPU`, `VRAM : 8.6 GB`, `CUDA dispo : True`
- **cell[5]**: `DEVICE = "cuda" if torch.cuda.is_available() else "cpu"`; tensors moved via `.to(DEVICE)`
- **cell[9]**: comment `implementation='cuda' (GPU) : 5000 iters ~ 1-2 min`
- **cell[24]** (recap): `Execution committée : DEVICE=cuda, implementation python (nvcc absent), 2...` → tensors ran on GPU via `DEVICE=cuda` (the custom CUDA kernel wasn't compiled because `nvcc` was absent, but PyTorch tensor ops still ran on the GPU).

Yet the notebook carried **no `metadata.cost` block** → the checker flagged `[MAJOR] gpu_used_but_not_declared`.

## Honest stamp (15 fields, GPU template)

| Field | Value | Why |
|-------|-------|-----|
| `gpu_required` | **true** | `DEVICE=cuda`, RTX 3070 Laptop used (cell[3] output) |
| `vram_gb` | 8 | ran on 8 GB-class card (RTX 3070 Laptop) |
| `vram_tier` | MEDIUM | real CUDA GPU + matching CUDA Toolkit required |
| `api_usd_est` | **0.0** | local difflogic training, no LLM/API call |
| `api_provider` | local | self-hosted, MNIST via torchvision |
| `network` | false | no API/network for the committed run (MNIST auto-downloads ~10 Mo at first run, noted in `reduced_pedagogical`) |
| `external_account` | none | local GPU training, no external account |
| `reproducibility` | MEDIUM | GPU non-determinism on exact bit values; accuracy ~83 % stable |
| `notes` (FR) | — | Clarifies GPU constraint (CUDA Toolkit ↔ `torch.version.cuda`, else RuntimeError on kernel compilation per cell[3]); implementation='python' used (nvcc absent) but tensors on GPU |

**Why `gpu_required=true` even though `nvcc` was absent:** GPU use is decided by `DEVICE=cuda` (tensors on GPU), not by the custom difflogic CUDA kernel. PyTorch tensor ops ran on the RTX 3070; only the compiled kernel path was skipped. The committed outputs (device name, VRAM, CUDA available) are GPU evidence firsthand.

## Residual (documented, out-of-lane)

Declaring `gpu_required=true` surfaces a **[MINOR] `gpu_no_visual_validator`** advisory ("GPU notebook without `sk_visual` validator, cf sweep #5780"). This is a **visual-QA-of-figures** concern, not a cost-honesty one. Per the vision-routing mandate (#9344–#9347, #5780), figure vision-QA routes to a **CoursIA-2 (MiniMax)** lane or **ai-01** — **not po-2023** (GLM, no vision). I kept `validator: "manual"` honestly: the notebook bears papermill metadata but its `duration: 0.004228 s` shows papermill only stamped metadata (it did not execute the GPU training), so inflating to `papermill` to dodge the MINOR would be gaming. **Net effect of this PR: MAJOR → MINOR** (a genuine severity improvement; the cost-honesty defect is resolved).

## Build-safety

- **Metadata-only**: top-level `metadata.cost` block added via byte-surgical string insertion (NO JSON round-trip — preserves papermill float formatting `duration: 0.004228`).
- **0 cells / source / outputs / execution_count touched**. Verified: `+17/-0`, source-length and cell-count byte-identical pre/post, all 12 code cells carry `execution_count != null`.
- **nbformat `validate`**: OK (no papermill markdown-cell pollution).
- **NOT a twin pair** (no `SL-12`/`DifferentiableLogic` entry in `twin_pairs.d/`) → no `--update`, no parity drift.

## Verification

```
check_cost_metadata (this notebook):
   before: [MAJOR] gpu_used_but_not_declared
   after : [MINOR] gpu_no_visual_validator   (severity downgrade; cost defect cleared)
check_cost_metadata --family SymbolicAI:
   (on this branch, pre-#9448-merge): Notebooks avec finding : 5   Findings : 6
   — SL-12 MAJOR cleared; the family count includes the still-unmerged init stamp (#9448)
     and SL-12's residual MINOR. On main after #9448 + this PR: SL-12 downgrades MAJOR→MINOR.
nbformat.validate: OK
git diff --numstat: 17  0  (1 file)
```

## Grain

`MED/tooling (#8056 cost-honesty)` — lane `myia-po-2023:CoursIA` — prev: `MED/tooling #9448`

See #8056

🤖 Generated with [Claude Code](https://claude.com/claude-code)
