### PR TITLE
fix(audit,#8056): check_cost_metadata FP-c.1226 — exempt benign GPU probes + bare claude word (Lean-11 + SW-7b reassessment)

### DIFF
--- a/scripts/audit/check_cost_metadata.py
+++ b/scripts/audit/check_cost_metadata.py
@@ -79,10 +79,18 @@ import yaml
 # « CUDA=False », tourne en CPU). On l'exonère via lookahead négatif ; les vrais
 # signaux GPU (`torch.cuda.synchronize`, `torch.cuda.empty_cache`, `.cuda()`,
 # `.to("cuda")`) restent détectés.
+# Note FP-c.1226 : `torch.cuda.get_device_name` et `torch.cuda.device_count` sont
+# aussi des sondes bénignes (affichage du nom/nombre de GPU pour info, typiquement
+# dans un `if cuda_available:`). Lean-11 TorchLean-Python : output committé
+# « CUDA disponible: False / PyTorch 2.12.0+cpu », run 100% CPU — la seule occurrence
+# `torch.cuda.get_device_name(0)` est dans une branche `if cuda_available:` jamais
+# exécutée. On étend le lookahead négatif c.831 à ces fonctions de requête pures ;
+# les signaux GPU réels (synchronize, empty_cache, set_device, .cuda(), .to("cuda"))
+# restent détectés.
 GPU_PATTERNS = [
     r'\.cuda\(\)',
     r'\.to\("cuda"\)',
-    r'torch\.cuda\.(?!is_available\b)',
+    r'torch\.cuda\.(?!is_available\b|get_device_name\b|device_count\b|current_device\b)',
     r'tensorflow\.gpu',
     r'with\s+tf\.device\(["\']/gpu',
 ]
@@ -94,7 +102,13 @@ GPU_PATTERNS = [
 # `anthropic.Anthropic(...)`, élimine le faux positif typographique).
 API_PATTERNS = {
     'openai': r'openai\.ChatCompletion|openai\.Image|openai\.Audio|from openai',
-    'anthropic': r'anthropic\.\w|from anthropic|claude',
+    # FP-c.1226 (suite c.912/c.1172) : le `claude` nu matchait l'entité ontologie
+    # `LLM("Claude")` du notebook SW-7b-Python-OWL (KR À PROPOS des LLM, qui n'en
+    # appelle aucun — owlready2/HermiT, CPU). On resserre au contexte API reel :
+    # import du SDK (`from anthropic`), appel qualifie (`anthropic.\w`), endpoint
+    # REST (`api.anthropic.com`), ou nom de modele versionne (`claude-<digit>`,
+    # `claude-opus/sonnet/haiku`). Le mot nu ne signale jamais un appel API.
+    'anthropic': r'anthropic\.\w|from anthropic|api\.anthropic\.com|claude-\d|claude-opus|claude-sonnet|claude-haiku',
     'mistral': r'mistralai|from mistral',
     # FP-c.1172 : le `gemini` nu matchait le pattern "Gemini" de Conway's
     # Game of Life (Andrew Wade, 2010, self-replicator) dans les notebooks

--- a/scripts/audit/tests/test_check_cost_metadata.py
+++ b/scripts/audit/tests/test_check_cost_metadata.py
@@ -122,6 +122,27 @@ def test_litmus1_cuda_availability_probe_is_not_gpu_usage(tmp_path):
     assert "gpu_used_but_not_declared" not in _patterns(res["findings"])
 
 
+def test_litmus1_cuda_get_device_name_probe_is_not_gpu_usage(tmp_path):
+    """Les sondes `torch.cuda.get_device_name` / `device_count` (affichage du nom/
+    nombre de GPU pour info, typiquement dans un `if cuda_available:`) ne doivent
+    PAS déclencher gpu_used_but_not_declared. Couvre Lean-11 TorchLean-Python :
+    output committé « CUDA disponible: False / PyTorch 2.12.0+cpu », run 100% CPU —
+    la seule occurrence `torch.cuda.get_device_name(0)` est dans une branche
+    `if cuda_available:` jamais exécutée. FP corrigé c.1226 (extension du lookahead
+    négatif c.831 aux fonctions de requête pures). Les signaux GPU réels
+    (synchronize, empty_cache, .cuda(), .to("cuda")) restent détectés."""
+    code = (
+        "import torch\n"
+        "cuda_available = torch.cuda.is_available()\n"
+        "if cuda_available:\n"
+        "    print(torch.cuda.get_device_name(0))\n"
+        "    print(torch.cuda.device_count())\n"
+        "x = torch.FloatTensor([1.0])"
+    )
+    res = _findings_for(tmp_path, code, cost_meta={"gpu_required": False})
+    assert "gpu_used_but_not_declared" not in _patterns(res["findings"])
+
+
 # ---------------------------------------------------------------------------
 # Litmus 2 — api_used_but_cost_zero (FP guard: local provider, #8589)
 # ---------------------------------------------------------------------------
@@ -181,6 +202,43 @@ def test_litmus2_gemini_real_api_call_still_detected(tmp_path):
         )
         assert "api_used_but_cost_zero" in _patterns(res["findings"]), (
             f"real Gemini API call should still fire; code=\n{code}"
+        )
+
+
+def test_litmus2_claude_bare_word_fp_suppressed(tmp_path):
+    """FP-c.1226 (suite c.912/c.1172) : bare `claude` matched the OWL ontology
+    entity `LLM("Claude")` in SW-7b-Python-OWL — a knowledge-representation
+    notebook ABOUT LLMs (owlready2/HermiT, CPU) that calls NONE. A bare word /
+    entity name is never an API call. Must NOT trigger api_used_but_cost_zero."""
+    code = (
+        'from owlready2 import Thing\n'
+        'class LLM(Thing): pass\n'
+        'claude = LLM("Claude")\n'
+        'humaneval = Benchmark("HumanEval")\n'
+    )
+    res = _findings_for(
+        tmp_path, code, cost_meta={"api_usd_est": 0.0, "api_provider": "none"}
+    )
+    assert "api_used_but_cost_zero" not in _patterns(res["findings"]), (
+        "bare 'claude' (OWL entity) must not be detected as an Anthropic API call"
+    )
+
+
+def test_litmus2_claude_real_api_call_still_detected(tmp_path):
+    """Real Claude/Anthropic API references (SDK import, qualified call, REST
+    endpoint, or versioned model name) are still detected after the c.1226
+    tightening."""
+    for code in (
+        "from anthropic import Anthropic\nclient = Anthropic()",
+        "resp = anthropic.Anthropic().messages.create(model='claude-3-5-sonnet')",
+        "requests.post('https://api.anthropic.com/v1/messages')",
+        "model = 'claude-opus-4'\nresp = client.invoke(model)",
+    ):
+        res = _findings_for(
+            tmp_path, code, cost_meta={"api_usd_est": 0.0, "api_provider": "none"}
+        )
+        assert "api_used_but_cost_zero" in _patterns(res["findings"]), (
+            f"real Anthropic/Claude API call should still fire; code=\n{code}"
         )
 
 


### PR DESCRIPTION
## Summary

**Root-cause fix for two same-class `#8056` cost-detector false positives**, both from regex over-matching *benign mentions* (same family as the existing **FP-c.831** `is_available` and **FP-c.1172** bare-`gemini` fixes). Per the audit-reassessment protocol (the checker EXTRACTS, the agent DECIDES), firsthand verification showed both notebooks were honest CPU/local runs → the SOTA-correct fix is the **tool** (the checker's regex), not lying about the notebooks (declaring `gpu_required:true` / inflating `api_usd_est` would be dishonest — anti-regression / audit-reassessment Step 4: FP → do not patch the notebook).

### (1) GPU-probe FP — Lean-11 TorchLean-Python `[MAJOR] gpu_used_but_not_declared`

Committed run is **100 % CPU**:
```
PyTorch: 2.12.0+cpu
CUDA disponible: False
```
The only GPU signal was `torch.cuda.get_device_name(0)` inside a `if cuda_available:` branch that **never executed** — a pure display query. The c.831 negative lookahead exempted `is_available` but missed `get_device_name`.

**Fix:** extend the lookahead to also exempt `get_device_name` / `device_count` / `current_device` (pure query functions). Real GPU signals stay detected (`synchronize`, `empty_cache`, `set_device`, `.cuda()`, `.to("cuda")`).

### (2) Bare-claude FP — SW-7b-Python-OWL `[CRITICAL] api_used_but_cost_zero`

A **knowledge-representation notebook ABOUT LLMs** (owlready2 / HermiT reasoner, CPU) that calls none. The bare word `claude` matched the OWL ontology entity `LLM("Claude")`. The c.912/c.1172 tightening had narrowed `anthropic.` and bare `gemini` but **left `claude` bare** (explicitly noted in the c.1172 comment).

**Fix:** completes c.912/c.1172 for `claude` — keep `anthropic\.\w` / `from anthropic` / `api\.anthropic\.com` + versioned `claude-<digit>` / `claude-opus` / `claude-sonnet` / `claude-haiku`. Drop the bare word. Mirrors exactly the c.1172 gemini pattern.

## Verification — fleet delta (measured firsthand, `--all`, before → after)

```
gpu_used_but_not_declared   15 -> 14   CLEARED: Lean-11 (FP). 14 genuine-GPU stay flagged.
api_used_but_cost_zero       2 ->  1   CLEARED: SW-7b (FP). Restitution_3_Actes stays (real API).
NEW findings: none.
```

- The 14 genuine-GPU notebooks (GenAI Audio/Video, QC RL, **SL-12**) are unaffected — they carry real signals, not just the query probe. **SL-12 stays flagged** → its honest GPU declaration (#9449) remains justified.
- **9 notebooks with real Anthropic usage** (`from anthropic` / `anthropic.\w` / `claude-<digit>` / `claude-opus`) remain fully detectable — only the bare-word/ontology-entity FP is eliminated.

## Tests

Three new tests pin the FP classes + real-detection preservation:
- `test_litmus1_cuda_get_device_name_probe_is_not_gpu_usage` (mirrors c.831 `is_available`)
- `test_litmus2_claude_bare_word_fp_suppressed` (mirrors c.1172 `gemini`)
- `test_litmus2_claude_real_api_call_still_detected`

Full suite: **48 passed**.

## Scope

- `scripts/audit/check_cost_metadata.py`: +17/-2 (two regex lookaheads + documenting comments).
- `scripts/audit/tests/test_check_cost_metadata.py`: +58 (three new tests).
- **No notebook touched** — both notebooks were honest; the checker was wrong.

## Grain

`MED/tooling (#8056 cost-honesty / anti-FP)` — lane `myia-po-2023:CoursIA` — prev: `MED/tooling #9449`

See #8056

🤖 Generated with [Claude Code](https://claude.com/claude-code)
