### PR TITLE
fix(genai,#8056): cost-metadata on _e2e_quant_validation (MAJOR token_required, family rotation SymbolicAI->GenAI)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/_e2e_quant_validation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/_e2e_quant_validation.ipynb
@@ -1019,6 +1019,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "local (vLLM Z-Image GGUF Q4_K_M + ComfyUI Qwen Nunchaku INT4 + Wan2.1 video, self-hoste)",
+   "cpu_min": 1,
+   "gpu_min": 1,
+   "gpu_required": true,
+   "vram_gb": 16,
+   "vram_tier": "HIGH",
+   "network": true,
+   "external_account": "services locaux self-hostes (tokens VLLM_API_KEY + COMFYUI_API_TOKEN/COMFYUI_AUTH_TOKEN/COMFYUI_VIDEO_TOKEN pour endpoints locaux HTTP ; non payant externe)",
+   "free_alternative": null,
+   "reduced_pedagogical": "Sans GPU CUDA (>=16 Go VRAM pour modeles quantises) et sans stack GenAI local demarre (vLLM port 8001, ComfyUI ports 8188/8189), les 3 tests de generation sont sautes. Les health-checks HTTP tombent en echec. Le carnet necessite le stack GenAI Docker (cf docs/genai/genai-services.md) sur une machine GPU (po-2023 GPU non dispo ; route vers po-2024/ai-01).",
+   "reproducibility": "MEDIUM",
+   "metadata_written": "2026-08-05",
+   "validator": "manual",
+   "notes": "Validation e2e du stack GenAI quantise post-migration. Run commis SUCCESS : GPU0 RTX 3080 Ti Laptop (16384 Mo) + GPU1 RTX 3090 (24576 Mo), 3 generations reelles (image Z-Image via vLLM, edit Qwen Nunchaku INT4, video Wan2.1 via ComfyUI). Services 100% locaux self-hostes -> cout API nul (gratuit). gpu_required=true (CUDA requis pour inference quantisee, verifie firsthand outputs cell[2]). Account = tokens des endpoints locaux (non un compte payant externe). Stamp metadata-only (byte-surgical, no JSON round-trip) ; execution GPU non relancee ce cycle (GPU non dispo sur la lane dedition)."
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
## Summary

**Cost-honesty stamp (#8056)** on `_e2e_quant_validation.ipynb` — the reproducible end-to-end validation of the quantized local GenAI stack. Resolves the **[MAJOR] `token_required_but_no_account`** finding (the notebook reads several service tokens via dotenv but declared no account). Follows the SC-11 (#9440) / Planners-10 (#9441) / Arg-Analysis-init (#9448) / SL-12 (#9449) stamp pattern. **Family rotation**: SymbolicAI → GenAI.

## Defect (G.1 firsthand, committed run on origin/main)

`_e2e_quant_validation` is an e2e validation of the self-hosted quantized GenAI services (post-migration). The committed run **succeeded genuinely**:

- **cell[2]** output (GPU baseline):
  ```
  GPU0: NVIDIA GeForce RTX 3080 Ti Laptop GPU — 6215/16384 MB (37.9%)
  GPU1: NVIDIA GeForce RTX 3090 — 21399/24576 MB (87.1%)
  ```
- **cell[4]**: Service Health Check — `[OK] Z-Image (vLLM): HTTP …` (services up)
- **cell[6]**: Z-Image image generation via vLLM (GGUF Q4_K_M) — image produced
- **cell[8]**: Qwen Image Edit via ComfyUI (Nunchaku INT4) — edit produced
- **cell[10]**: ComfyUI Video (Wan2.1) — video produced
- **cell[12]**: E2E summary

Yet the notebook read tokens (`VLLM_API_KEY`, `COMFYUI_API_TOKEN`/`COMFYUI_AUTH_TOKEN`/`COMFYUI_VIDEO_TOKEN`) via `dotenv` but carried **no `metadata.cost` block** → checker flagged `[MAJOR] token_required_but_no_account`.

## Honest stamp (15 fields, GPU template)

| Field | Value | Why |
|-------|-------|-----|
| `gpu_required` | **true** | dual-GPU run (RTX 3080 Ti 16 Go + RTX 3090 24 Go), cell[2] output |
| `vram_gb` | 16 | quantized models (GGUF Q4 / Nunchaku INT4) need ≥16 Go |
| `vram_tier` | HIGH | local CUDA GPU required for quantized inference |
| `api_usd_est` | **0.0** | **100 % local self-hosted** (vLLM + ComfyUI) — no paid API |
| `api_provider` | local (vLLM Z-Image GGUF Q4_K_M + ComfyUI Qwen Nunchaku INT4 + Wan2.1) | local services, quantized |
| `network` | true | HTTP to local endpoints (vLLM :8001, ComfyUI :8188/8189) |
| `external_account` | services locaux self-hébergés (tokens VLLM_API_KEY + COMFYUI_* pour endpoints locaux HTTP ; **non payant externe**) | tokens authenticate the **local** endpoints, not a paid cloud account |
| `reproducibility` | MEDIUM | quantized-inference bit values vary; e2e pass/fail stable |
| `notes` (FR) | — | clarifies the run was a genuine success on local GPUs; account = local service tokens; GPU re-exec not rerun this cycle (GPU not available on the editing lane) |

The key honesty point: the tokens are **local-endpoint auth**, **not** a paid external account. A reader reproducing this notebook needs the local GenAI Docker stack up (vLLM + ComfyUI on the right ports) on a CUDA GPU — declared explicitly in `reduced_pedagogical`.

## Residual (documented, out-of-lane)

Declaring `gpu_required=true` surfaces a **[MINOR] `gpu_no_visual_validator`** advisory ("GPU notebook without `sk_visual` validator, cf sweep #5780"). This is a **visual-QA-of-figures** concern (the notebook produces images/video), not a cost-honesty one. Per the vision-routing mandate (#9344–#9347, #5780), figure vision-QA routes to a **CoursIA-2 (MiniMax)** lane or **ai-01** — **not po-2023** (GLM, no vision). I kept `validator: "manual"` honestly: the run genuinely used GPU and produced real outputs (verified firsthand from cell outputs), but the figure *rendering* QA is out of this lane. **Net effect: MAJOR → MINOR** (the cost-honesty defect is resolved; a genuine severity improvement).

## Build-safety

- **Metadata-only**: top-level `metadata.cost` block added via byte-surgical string insertion (NO JSON round-trip).
- **0 cells / source / outputs / execution_count touched**. Verified: `+17/-0`, source-length and cell-count byte-identical pre/post, all 7 code cells carry `execution_count != null`.
- **nbformat `validate`**: OK.
- **NOT a twin pair** (no `_e2e_quant` entry in `twin_pairs.d/`) → no `--update`, no parity drift.

## Pre-existing (NOT introduced, out of scope)

cell[1] committed output prints a machine path (`.env loaded from: D:\Dev\CoursIA\…`). This is a pre-existing path-leak in a committed output, unrelated to the metadata-only cost stamp, and **not scrubbed** (Stop & Repair: fixing it requires a GPU re-exec on a lane with the GenAI stack up, which po-2023 lacks). Out of scope here; tracked separately per the secrets-hygiene rule.

## Verification

```
check_cost_metadata (this notebook):
   before: [MAJOR] token_required_but_no_account
   after : [MINOR] gpu_no_visual_validator   (severity downgrade; cost/account defect cleared)
nbformat.validate: OK
git diff --numstat: 17  0  (1 file)
```

## Grain

`MED/tooling (#8056 cost-honesty)` — lane `myia-po-2023:CoursIA` — prev: `MED/tooling #9450`

See #8056

🤖 Generated with [Claude Code](https://claude.com/claude-code)
