### PR TITLE
fix(genai,#8056): correct under-declared cost on 01-4-Whisper-Local (hidden OpenAI API call, MAJOR token_required)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb
@@ -1946,7 +1946,7 @@
    },
    "start_time": "2026-05-26T13:37:38.134914",
    "version": "2.6.0"
-  }, "cost": {"api_usd_est": 0.0, "api_provider": "local", "cpu_min": 0, "gpu_min": 4, "gpu_required": true, "vram_gb": 10, "vram_tier": "MEDIUM", "network": true, "external_account": "none", "free_alternative": null, "reduced_pedagogical": null, "reproducibility": "HIGH", "metadata_written": "2026-07-24T00:00Z", "validator": "manual", "notes": "faster-whisper (backend CTranslate2), cuda/float16, compare les tailles de modeles. VRAM ~10 GB.\nCout nul (local self-hosted). Modele public HuggingFace. Profil derive firsthand (config modele\n+ device/compute_type), execution GPU non relancee ce cycle."}},
+  }, "cost": {"api_usd_est": 0.01, "api_provider": "local (faster-whisper) + OpenAI (whisper-1 API, comparaison cell[23])", "cpu_min": 0, "gpu_min": 4, "gpu_required": true, "vram_gb": 10, "vram_tier": "MEDIUM", "network": true, "external_account": "OpenAI requis (whisper-1 transcription API, comparaison cell[23] ; committed run = 1 appel court ~11s)", "free_alternative": null, "reduced_pedagogical": null, "reproducibility": "HIGH", "metadata_written": "2026-07-24T00:00Z", "validator": "manual", "notes": "faster-whisper (backend CTranslate2), cuda/float16, compare les tailles de modeles. VRAM ~10 GB.\nCout principal local (faster-whisper GPU) ; cell[23] compare vs API OpenAI whisper-1 (1 appel payant court ~$0.001, committed run ; api_usd_est arrondi a 0.01). Le reste est local self-hosted. Modele public HuggingFace. Profil derive firsthand (config modele\n+ device/compute_type), execution GPU non relancee ce cycle."}},
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary

**Cost-under-declaration correction (#8056)** on `01-4-Whisper-Local.ipynb`. This notebook **already had a cost block** (written by the populate script) but it was **wrong**: it declared `api_provider: "local"` / `external_account: "none"` / `api_usd_est: 0.0`, while the committed run made a **real paid OpenAI API call** (whisper-1) in a comparison cell. Same defect class as Planners-10 (#9441): a reader seeing `external_account: "none"` would wrongly believe no paid API is needed.

This is an **audit-reassessment** (Step 1-2 of the protocol): the checker flagged `[MAJOR] token_required_but_no_account` (reads `OPENAI_API_KEY` but declares no account) and the question was *FP or genuine?* — firsthand verification answered **genuine under-declaration**.

## Defect (G.1 firsthand, committed run on origin/main)

`01-4-Whisper-Local` is a faster-whisper (local CTranslate2) notebook — but it also compares local transcription against the **OpenAI Whisper API**. cell[23] committed output proves the API call happened:

```
--- API (whisper-1) ---
INFO:httpx:HTTP Request: POST https://api.openai.com/v1/audio/transcriptions "HTTP/1.1 200 OK"
Texte : Speech recognition converts spoken language into written text...
Temps : 1.66s
```

The committed run: faster-whisper ran locally on GPU (RTX 3090, large-v3-turbo) **AND** made **1 real `whisper-1` API POST** (HTTP 200 OK) in the comparison cell. Yet the cost block declared `external_account: "none"` and `api_usd_est: 0.0` — false.

## Honest correction (3 fields + notes, metadata-only)

| Field | Before (wrong) | After (honest) | Why |
|-------|------|------|-----|
| `api_usd_est` | 0.0 | **0.01** | 1 whisper-1 transcription (~11 s audio ≈ $0.001 at $0.006/min); rounded up conservatively |
| `api_provider` | "local" | **"local (faster-whisper) + OpenAI (whisper-1 API, comparaison cell[23])"** | both engines ran |
| `external_account` | "none" | **"OpenAI requis (whisper-1 transcription API, comparaison cell[23] ; committed run = 1 appel court ~11 s)"** | a real paid API call happened |
| `notes` | "Cout nul (local self-hosted)" | clarifies the local principal cost + the cell[23] OpenAI comparison call | honest framing |

`gpu_required: true` (RTX 3090, faster-whisper) unchanged. The local faster-whisper path is genuinely free; the OpenAI comparison cell is the paid dependency.

## Residual (documented, out-of-lane)

`[MINOR] gpu_no_visual_validator` remains (pre-existing, unrelated to this fix) — figures vision-QA routes to CoursIA-2/MiniMax or ai-01, not po-2023 (GLM, no vision). **Net effect of this PR: MAJOR token_required → cleared** (the account is now declared); the residual MINOR is the out-of-lane vision advisory.

## Build-safety

- **Metadata-only**: 3 fields corrected within the existing compact `metadata.cost` block via byte-surgical string replacement (NO JSON round-trip). `+1/-1` (one compact metadata line).
- **0 cells / source / outputs / execution_count touched** (verified: outputs/source/exec_count byte-identical pre/post; all code cells carry `execution_count != null`).
- **nbformat `validate`**: OK.
- **NOT a twin pair** → no `--update`, no parity drift.

## Verification

```
check_cost_metadata (this notebook):
   before: [MAJOR] token_required_but_no_account   (reads OPENAI_API_KEY, declared external_account:"none")
   after : [MINOR] gpu_no_visual_validator          (token_required cleared; account now declared)
nbformat.validate: OK
git diff --stat: 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Grain

`MED/tooling (#8056 cost-honesty / under-declaration)` — lane `myia-po-2023:CoursIA` — prev: `MED/tooling #9451`

See #8056

🤖 Generated with [Claude Code](https://claude.com/claude-code)
