### PR TITLE
fix(audit,#8052): extract_claims_vs_outputs stream FP — extract numbers from stdout (FP-c.1228, IIT 372 false MAJOR)

### DIFF
--- a/scripts/audit/extract_claims_vs_outputs.py
+++ b/scripts/audit/extract_claims_vs_outputs.py
@@ -139,6 +139,14 @@ def extract_code_outputs(cell: dict) -> dict:
             if isinstance(text, list):
                 text = ''.join(text)
             text_chunks.append(text)
+            # Extract numbers from stream text too — FP-c.1228 : les notebooks dont
+            # les outputs sont majoritairement du stdout (PyPhi/IIT imprime TPM,
+            # matrices, Φ via print()) n'avaient AUCUN numeric_values_found (le
+            # finditer n'était fait que sur data['text/plain'] des display_data).
+            # Résultat : 0% de match -> 125+ faux MAJOR numeric_claim_not_in_outputs
+            # qui masquaient tout. On extrait ici, miroir de la branche display_data.
+            for match in CLAIM_NUMERIC_RE.finditer(text):
+                numeric_values_found.add(match.group(0).strip())
             if out.get('name') == 'stderr':
                 if 'error' in text.lower() or 'traceback' in text.lower():
                     has_error = True

--- a/scripts/audit/tests/test_extract_claims_vs_outputs.py
+++ b/scripts/audit/tests/test_extract_claims_vs_outputs.py
@@ -153,3 +153,67 @@ def test_fix_B_python_kernel_still_flags_unimported_viz(tmp_path):
     assert "matplotlib" in res["sota_tools_mentioned_not_imported"], (
         "Regression guard: on Python, matplotlib-mentioned-not-imported must still fire"
     )
+
+
+# === Fix C (FP-c.1228) : stream outputs must contribute numbers ===
+
+
+def test_fix_C_stream_output_numbers_are_extracted(tmp_path):
+    """FP-c.1228 : les notebooks dont les outputs sont du stdout (output_type 'stream',
+    ex PyPhi/IIT imprime TPM/matrices/Φ via print()) n'avaient AUCUN numeric_values
+    extrait — le ``CLAIM_NUMERIC_RE.finditer`` n'était appliqué qu'à ``data['text/plain']``
+    des display_data. Résultat : 0% de match -> 125+ faux MAJOR
+    ``numeric_claim_not_in_outputs`` qui masquaient les vrais findings sur IIT-1/2/3.
+
+    Fix : on extrait aussi les nombres du texte des outputs stream (miroir display_data).
+    Ce test vérifie qu'un markdown claim présent dans un output STREAM n'est plus flaggé."""
+    mod = _load_extract()
+    nb = _write_nb(
+        tmp_path / "stream.ipynb",
+        cells=[
+            _md("# Computation\n\nLa matrice résultat est **0.5** et le rang **3**."),
+            _code(
+                "print('result: 0.5')\nprint('rank:', 3)",
+                outputs=[{"output_type": "stream", "name": "stdout", "text": "result: 0.5\nrank: 3\n"}],
+            ),
+        ],
+        kernel_name="python3",
+    )
+    res = mod.audit_notebook(nb)
+    # Before Fix C : stream numbers weren't extracted -> 0 matched -> 2 false MAJOR.
+    # After  Fix C : "0.5" and "3" are extracted from the stream output -> both match.
+    assert res["numeric_claims_matched"] >= 2, (
+        f"stream output numbers must be extracted; matched={res['numeric_claims_matched']}, "
+        f"unmatched={res['numeric_claims_unmatched']}"
+    )
+    assert res["numeric_claims_unmatched"] == 0, (
+        f"markdown claims present in stream output must not be flagged; findings={res['findings']}"
+    )
+
+
+def test_fix_C_display_data_extraction_unchanged(tmp_path):
+    """Contrôle : Fix C ajoute l'extraction stream SANS régresser l'extraction
+    display_data (le chemin d'origine doit toujours extraire les nombres)."""
+    mod = _load_extract()
+    nb = _write_nb(
+        tmp_path / "display.ipynb",
+        cells=[
+            _md("# Computation\nLa précision est **0.92**."),
+            _code(
+                "repr_res",
+                outputs=[
+                    {
+                        "output_type": "execute_result",
+                        "execution_count": 1,
+                        "data": {"text/plain": "0.92"},
+                        "metadata": {},
+                    }
+                ],
+            ),
+        ],
+        kernel_name="python3",
+    )
+    res = mod.audit_notebook(nb)
+    assert res["numeric_claims_unmatched"] == 0, (
+        f"display_data extraction regression; findings={res['findings']}"
+    )


### PR DESCRIPTION
## Summary

**Root-cause fix for a catastrophic false-positive in the `extract_claims_vs_outputs.py` audit scanner** (#8052 sampling audit). The scanner flagged **~371 false `[MAJOR] numeric_claim_not_in_outputs` findings** across the 3 IIT/PyPhi notebooks (125 + 174 + 73) — drowning the real signal — because it **only extracted numbers from `display_data`/`execute_result` outputs, never from `stream` (stdout) outputs**. PyPhi notebooks print all their numbers (TPM shapes, matrices, Φ) via `print()` → `stream`, so `numeric_values_found` was empty → 0 % match → every markdown "claim" flagged MAJOR.

This is a **different audit tool / register** than the recent cost-metadata stamps: this is the claims-vs-outputs extractor's robustness (#8052), not the cost checker (#8056).

## Defect (G.1 firsthand, on origin/main)

`extract_code_outputs()` (lines 137-159):
- `stream` outputs: text appended to `text_chunks`, but **no number extraction** into `numeric_values_found`.
- `execute_result`/`display_data`: numbers extracted (line 158).

For IIT notebooks (PyPhi, almost all stdout), this meant `numeric_values_found == set()` → the Litmus-1 matcher (`claim in num or num in claim`) matched **nothing** → every one of 125/174/73 markdown "claims" (mostly section numbers + descriptive prose, per the existing Fix A) emitted a MAJOR. The committed outputs clearly contain matching numbers (`PyPhi version: 1.2.0`, `TPM shape: (2, 2, 2, 3)`, matrices) — the scanner just couldn't see them.

## Fix (bounded, root-cause)

Extract numbers from `stream` output text too — mirror of the existing `display_data` branch (one `for match in CLAIM_NUMERIC_RE.finditer(text): numeric_values_found.add(...)` added to the stream branch, lines 142-149):

```python
if out.get('output_type') == 'stream':
    text = out.get('text', '')
    ...
    text_chunks.append(text)
    # Extract numbers from stream text too — FP-c.1228 ...
    for match in CLAIM_NUMERIC_RE.finditer(text):
        numeric_values_found.add(match.group(0).strip())
    if out.get('name') == 'stderr':
        ...
```

## Verification — fleet delta (measured firsthand, IIT + controls)

```
IIT-1-IntroToPyPhi        matched  0/125 -> 125/125   (MAJOR 125 -> 0)
IIT-2-AdvancedTopics      matched  0/174 -> 174/174   (MAJOR 174 -> 0)
IIT-3-CoarseGrainingMacro matched  0/ 73 ->  72/ 73   (MAJOR  73 -> 1, a legit residual)
```
The IIT-3 residual (`5 s` claim, cell[20]) is a **legitimate** finding now correctly surfaced for human review (a timing claim not matched by any output) — the scanner still catches real drift.

**Controls (no regression):**
```
QC-Py-12-Backtesting-Analysis  202/0 -> 202/0   (unchanged — display_data path intact)
QC-Py-04-Research-Workflow    121/17 -> 138/0   (improved — 17 prior FP stream-claims now match)
```

## Tests

Two new tests pin the Fix C class:
- `test_fix_C_stream_output_numbers_are_extracted` — a markdown claim present in a **stream** output must match (before Fix C → 2 false MAJOR; after → 0).
- `test_fix_C_display_data_extraction_unchanged` — regression guard: the original `display_data` path still extracts numbers.

Full claims-vs-outputs + cost suites: **50 passed**. (The 4 failures in `test_regen_img1_dalle3.py` are pre-existing network/DALL-E-API tests, confirmed failing on a clean `origin/main` base — unrelated to this change.)

## Scope

- `scripts/audit/extract_claims_vs_outputs.py`: +8 (stream number extraction + documenting comment).
- `scripts/audit/tests/test_extract_claims_vs_outputs.py`: +64 (two Fix C tests).
- **No notebook touched** — the IIT notebooks were honest; the scanner was blind to stdout.

## Grain

`MED/tooling (#8052 claims-vs-outputs / anti-FP)` — lane `myia-po-2023:CoursIA` — prev: `MED/tooling #9452`. **Genre rotation** (R6): after a run of #8056 cost stamps, this moves to a different audit tool's robustness.

See #8052

🤖 Generated with [Claude Code](https://claude.com/claude-code)
