### PR TITLE
fix(audit,#8052): claims scanner reads .NET text/html + FR comma-decimal matching (FP-c.1229)

### DIFF
--- a/scripts/audit/extract_claims_vs_outputs.py
+++ b/scripts/audit/extract_claims_vs_outputs.py
@@ -165,6 +165,25 @@ def extract_code_outputs(cell: dict) -> dict:
                     # Extract numbers from text
                     for match in CLAIM_NUMERIC_RE.finditer(content):
                         numeric_values_found.add(match.group(0).strip())
+                elif mime == 'text/html':
+                    # .NET Interactive émet les affichages riches d'objets (tables
+                    # dni-treeview, matrices de confusion) en text/html SANS fallback
+                    # text/plain — les valeurs calculées vivent dans des cellules
+                    # <pre>...</pre> (ex <pre>0.8884018879298109</pre>). Sans cette
+                    # extraction, le scanner est aveugle à TOUS les outputs .NET ->
+                    # faux numeric_claim_not_in_outputs MAJOR sur chaque notebook
+                    # .NET qui cite ses propres résultats (FP-c.1229).
+                    #
+                    # On extrait UNIQUEMENT depuis les <pre> (cellules de valeurs),
+                    # pas du HTML brut : les index structurels <td>0</td>, <td>1</td>
+                    # (numéros de fold, positions de table) pollueraient numeric_values
+                    # par des single-digits qui false-matchent toute claim contenant
+                    # ce chiffre via le Litmus-1 « num in claim ».
+                    if isinstance(content, list):
+                        content = ''.join(content)
+                    for pre_match in re.finditer(r'<pre>(.*?)</pre>', content, re.DOTALL):
+                        for match in CLAIM_NUMERIC_RE.finditer(pre_match.group(1)):
+                            numeric_values_found.add(match.group(0).strip())
 
     return {
         'text': '\n'.join(text_chunks),
@@ -299,8 +318,16 @@ def audit_notebook(notebook_path: Path) -> dict:
     # Litmus 1 : claim numérique markdown qui n'apparaît pas dans outputs
     matched = unmatched = 0
     for claim in all_numeric_claims:
-        # Substring match (claim peut être avec unités)
-        if any(claim['value'] in num or num in claim['value']
+        # Substring match (claim peut être avec unités). Les notebooks sont
+        # FR-first : la prose cite des décimales à virgule (« R² ≈ 0,888 ») alors
+        # que les outputs .NET/Python affichent souvent le point décimal
+        # (« 0.8884018879298109 »). On normalise la virgule décimale vers le point
+        # des deux côtés avant le substring, sinon aucune claim à virgule ne
+        # matcherait un output à point (FP-c.1229). NB : les séparateurs de
+        # milliers FR utilisent l'espace (« 8 000 »), pas la virgule — la virgule
+        # est ici toujours un séparateur décimal.
+        cv = claim['value'].replace(',', '.')
+        if any(cv in num.replace(',', '.') or num.replace(',', '.') in cv
                for num in all_numeric_outputs):
             matched += 1
         else:

--- a/scripts/audit/tests/test_extract_claims_vs_outputs.py
+++ b/scripts/audit/tests/test_extract_claims_vs_outputs.py
@@ -217,3 +217,91 @@ def test_fix_C_display_data_extraction_unchanged(tmp_path):
     assert res["numeric_claims_unmatched"] == 0, (
         f"display_data extraction regression; findings={res['findings']}"
     )
+
+
+
+# === Fix D (FP-c.1229) : .NET Interactive text/html outputs must contribute numbers ===
+
+
+def test_fix_D_dotnet_html_output_numbers_are_extracted(tmp_path):
+    """FP-c.1229 : .NET Interactive emet les affichages riches d'objets (metriques
+    CV, contributions de features, matrices) en MIME ``text/html`` (tables
+    ``dni-treeview`` avec des cellules ``<pre>...</pre>``) SANS fallback
+    ``text/plain``. Le scanner n'extrait les nombres que de ``text/plain`` ->
+    ``numeric_values_found`` vide pour ces outputs -> faux
+    ``numeric_claim_not_in_outputs`` MAJOR sur chaque notebook .NET qui cite ses
+    propres resultats (ML-4, Sudoku-DLX, GameTheory, Probas/Infer, Search/CSP).
+
+    Ce test verifie qu'un markdown claim present dans un output ``text/html``
+    n'est plus flagge (avant Fix D : 1 faux MAJOR ; apres : 0)."""
+    mod = _load_extract()
+    # .NET treeview-style HTML: metric value lives inside <pre>0.8884</pre>
+    html_output = (
+        '<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead>'
+        '<tbody><tr><td>0</td><td><details class="dni-treeview"><summary>'
+        '<span class="dni-code-hint"><code>RegressionMetrics</code></span></summary>'
+        '<div><table><tbody>'
+        '<tr><td>RSquared</td><td><div class="dni-plaintext"><pre>0.8884018879298109</pre></div></td></tr>'
+        '<tr><td>RootMeanSquaredError</td><td><div class="dni-plaintext"><pre>3.230644533283385</pre></div></td></tr>'
+        '</tbody></table></div></details></td></tr></tbody></table>'
+    )
+    nb = _write_nb(
+        tmp_path / "dotnet-html.ipynb",
+        cells=[
+            _md("# Evaluation\nLa validation croisée donne **R² ≈ 0,8884** et **RMSE ≈ 3,2306**."),
+            _code(
+                "cvResults.Select(x => x.Metrics)",
+                outputs=[
+                    {
+                        "output_type": "execute_result",
+                        "execution_count": 1,
+                        "data": {"text/html": html_output},
+                        "metadata": {},
+                    }
+                ],
+            ),
+        ],
+        kernel_name=".net-csharp",
+    )
+    res = mod.audit_notebook(nb)
+    # Before Fix D : text/html ignored -> numbers not extracted -> false MAJOR.
+    # After  Fix D : "0.8884018879298109" and "3.230644533283385" extracted from
+    # the <pre> cells -> the markdown claims (0,8884 / 3,2306, locale-rounded
+    # prefixes) match via the Litmus-1 substring rule.
+    assert res["numeric_claims_unmatched"] == 0, (
+        f"markdown claims present in text/html output must not be flagged; "
+        f"matched={res['numeric_claims_matched']}, findings={res['findings']}"
+    )
+
+
+def test_fix_D_html_extraction_does_not_regress_text_plain(tmp_path):
+    """Contrôle : Fix D ajoute l'extraction text/html SANS régresser text/plain
+    (le chemin d'origine doit toujours extraire les nombres d'un output text/plain,
+    et un output mixte text/plain + text/html ne doit pas doubler le compte des
+    matched — la règle Litmus-1 en substring + le set numeric_values gèrent la
+    dédup)."""
+    mod = _load_extract()
+    nb = _write_nb(
+        tmp_path / "plain.ipynb",
+        cells=[
+            _md("# Resultat\nLa précision est **0.92**."),
+            _code(
+                "metrics",
+                outputs=[
+                    {
+                        "output_type": "execute_result",
+                        "execution_count": 1,
+                        "data": {"text/plain": "0.92"},
+                        "metadata": {},
+                    }
+                ],
+            ),
+        ],
+        kernel_name="python3",
+    )
+    res = mod.audit_notebook(nb)
+    assert res["numeric_claims_unmatched"] == 0, (
+        f"text/plain extraction regression; findings={res['findings']}"
+    )
+
+


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #9453 (sibling: stdout-channel #9453 + text/html-channel #9454)

## Summary

**Two scanner robustness fixes for `extract_claims_vs_outputs.py`** (#8052 claims-vs-outputs audit), uncovered by **firsthand audit-reassessment of `ML-4-Evaluation`** on `origin/main`. The scanner flagged **17 `[MAJOR] numeric_claim_not_in_outputs`** on ML-4 (CV `R² ≈ 0,888`, `RMSE ≈ 3,22`; FCC `rate_code -1779,6`, `trip_distance -803,3`, `payment_type.Bit1 +19,2`, `+10,6`) — yet the committed outputs prove every one of them honest. This is the **scanner being blind to .NET output channels + FR-decimal prose**, not notebook drift.

This is a **sibling of #9453** (which fixed the `stream`/stdout channel, FP-c.1228): that one made stdout numbers visible; this one makes **.NET `text/html` numbers visible** and lets **FR comma-decimal prose match dot-decimal outputs**. Different output channel, same tool, same audit register.

## G.1 firsthand (ML-4-Evaluation, committed outputs on origin/main)

The CV/FCC values live in `text/html` MIME blocks (.NET Interactive `dni-treeview` tables) with **no `text/plain` fallback**:

```
cell[33] CV output (text/html):  <pre>0.8884018879298109</pre> <pre>3.230644533283385</pre> ...
cell[75] FCC output (text/html): rate_code = -1779.6366, trip_distance = -803.3262,
                                 payment_type.Bit1 = 19.19871, payment_type.Bit0 = 10.600954
```

Markdown (cell[36]/cell[76]) cites the **rounded FR-decimal** versions: `R² ≈ 0,888`, `RMSE ≈ 3,22`, `rate_code (-1779,6)`, `trip_distance (-803,3)`, `payment_type.Bit1 (+19,2)`, `(+10,6)`. **Every claim maps to its committed output** (verified via `<pre>` extraction + rounding). ML-4 is honest; the scanner was (a) blind to `text/html`, and (b) couldn't match comma `0,888` to dot `0.8884`.

## Fix (bounded, root-cause)

**1. `extract_code_outputs` — extract numbers from `text/html` `<pre>` cells.** .NET emits computed values in `<pre>...</pre>` (e.g. `<pre>0.8884018879298109</pre>`). Extraction is **scoped to `<pre>` blocks only**: bare HTML index cells `<td>0</td>` (fold numbers, table positions) would pollute `numeric_values_found` with single-digits that **false-match any claim containing that digit** via Litmus-1 (`num in claim`) — I measured this and the raw-HTML version produced bogus "matches" (e.g. claim `0,888` "matched" standalone `0` and `8`). The `<pre>`-only version eliminates that.

**2. Litmus-1 — normalize comma→dot before substring matching.** Notebooks are FR-first: prose uses comma decimals (`R² ≈ 0,888`) while .NET/Python outputs print dot decimals (`0.8884018879298109`). Without normalization, no comma claim ever matches a dot output. FR thousands-separators use the space (`8 000`), so the comma is unambiguously a decimal separator here.

## Verification — fleet delta (measured firsthand, honest)

```
ML-4-Evaluation           matched 99/17  -> 116/0   (MAJOR 17 -> 0, real)
ML-1-Introduction         0/132   -> 0/132          (unchanged — residuals are
Sudoku-2-DancingLinks     0/94    -> 0/94            citation/version/structural-
GameTheory-2-NormalForm   84/5    -> 84/5            constant/timing FPs, distinct
GameTheory-7-ExtensiveForm 34/16  -> 34/16           classes, documented below)
```

The clean fix improves **only ML-4** in the sample — and that's the honest result. The other .NET notebooks' residuals are **different FP classes** (academic citations like `Stone 1974`/`Knuth cs/0011047`; tool versions like `.NET 9.0`; structural constants like `729`/`324`; machine-dependent benchmark timings like `290 ms`) that this PR deliberately does **not** touch. They warrant a separate, comprehensive scanner-robustness cycle (documented on the dashboard). Shipping a raw-HTML extraction that false-matches via index single-digits would have *hidden* real drift — rejected after measurement.

**Controls (no regression):** Python notebooks (e.g. IIT, which needs the #9453 stream fix) unchanged by this PR's two changes; `text/plain` extraction path verified intact.

## Tests

Two new tests pin the Fix D class:
- `test_fix_D_dotnet_html_output_numbers_are_extracted` — a markdown claim present in a **`text/html` `<pre>`** output must match (before Fix D → false MAJOR; after → 0).
- `test_fix_D_html_extraction_does_not_regress_text_plain` — regression guard: the `text/plain` path still extracts numbers.

Full audit suite: **393 passed**. (The 4 failures in `test_regen_img1_dalle3.py` are pre-existing network/DALL-E-API tests, confirmed failing on a clean `origin/main` base — unrelated. NB: running them regenerates 2 webp assets as a side-effect; discarded before commit.)

## Scope

- `scripts/audit/extract_claims_vs_outputs.py`: +29/-2 (`<pre>` html extraction + Litmus comma→dot normalization, both with documenting comments).
- `scripts/audit/tests/test_extract_claims_vs_outputs.py`: +86 (two Fix D tests).
- **No notebook touched** — ML-4 (and the .NET fleet) was honest; the scanner was blind to its output channels.

## Grain

`MED/tooling (#8052 claims-vs-outputs / anti-FP)` — lane `myia-po-2023:CoursIA` — prev: `MED/tooling #9453` (sibling: stream channel). **R6 note:** 2nd consecutive #8052 scanner cycle — justified because the .NET `text/html` channel is the dominant output format for the majority notebook family, and the gap was discovered via firsthand ML-4 audit-reassessment this cycle (not mindless grinding); next cycle rotates to a non-tooling register.

See #8052

🤖 Generated with [Claude Code](https://claude.com/claude-code)