### PR TITLE
fix(genai,#8056): cost under-declaration on Kokoro-TTS-Local (MAJOR gpu_used -> 0, family rotation)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb
@@ -2463,7 +2463,7 @@
    },
    "start_time": "2026-06-07T19:19:12.920496",
    "version": "2.6.0"
-  }, "cost": {"api_usd_est": 0.0, "api_provider": "local", "cpu_min": 5, "gpu_min": 0, "gpu_required": false, "vram_gb": 2, "vram_tier": "LITE", "network": true, "external_account": "none", "free_alternative": null, "reduced_pedagogical": null, "reproducibility": "HIGH", "metadata_written": "2026-07-24T00:00Z", "validator": "manual", "notes": "Kokoro TTS (hexgrad/Kokoro-82M, backend ONNX, licence MIT). Modele leger (82M) fonctionnant sur\nCPU ou GPU (VRAM ~2 GB). Cout nul (local self-hosted). Profil derive firsthand (config modele),\nexecution non relancee ce cycle."}},
+  }, "cost": {"api_usd_est": 0.0, "api_provider": "local", "cpu_min": 5, "gpu_min": 1, "gpu_required": true, "vram_gb": 2, "vram_tier": "LITE", "network": true, "external_account": "none", "free_alternative": null, "reduced_pedagogical": null, "reproducibility": "HIGH", "metadata_written": "2026-08-05T00:00Z", "validator": "manual", "notes": "Kokoro TTS (hexgrad/Kokoro-82M, backend ONNX, licence MIT). Modele leger (82M, VRAM ~2 GB), CPU-capable. CORRECTION sous-declaration (G.1 firsthand) : le run committé a utilise CUDA (cell[5] output 'GPU : NVIDIA GeForce RTX 3090 (24.0 GB VRAM)', cell[38] 'Backend : cuda') -> gpu_required false->true, gpu_min 0->1. Comparaison OpenAI TTS (cell[26]) SKIPPEE dans le run (cle absente, output le confirme) -> api_usd_est 0.0 / external_account none honnetes (Kokoro 100% local self-hosted free)."}},
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary

**Cost under-declaration correction** on `01-5-Kokoro-TTS-Local.ipynb`. The existing cost block declared `gpu_required: false`, but the committed run used **CUDA on an RTX 3090** — proven firsthand by the committed outputs. A reader seeing `gpu_required: false` is misled about the artifact of record. This is the **under-declaration class** (same as Whisper #9452), not a missing-metadata stamp.

**R6 family rotation**: after SymbolicAI cost (#9448/#9457), pivot to **GenAI/Audio** (fresh family).

## G.1 firsthand (committed outputs on origin/main)

- **cell[5] output**: `GPU : NVIDIA GeForce RTX 3090 (24.0 GB VRAM)` — the run detected & used the GPU.
- **cell[38] output**: `Backend : cuda` (Inflect-Nano-v1 section explicitly chose CUDA).
- **cell[12]/[34]**: `torch.cuda.memory_allocated(0)` — GPU memory actively measured.

The metadata said `gpu_required: false` / `gpu_min: 0` while the committed run was a CUDA run. That is the lie.

## Honest correction (what changed / what was kept)

| field | before | after | why |
|-------|--------|-------|-----|
| `gpu_required` | **false** | **true** | committed run used RTX 3090 (cell[5]/[38] prove) |
| `gpu_min` | 0 | 1 | GPU was used for model load + TTS inference |
| `metadata_written` | 2026-07-24 | 2026-08-05 | correction date |
| `api_usd_est` | 0.0 | **0.0 (kept)** | honest — Kokoro is 100% local free |
| `external_account` | "none" | **"none" (kept)** | honest — no external account needed |
| `vram_gb` / `vram_tier` | 2 / LITE | **2 / LITE (kept)** | Kokoro-82M is lightweight even on the 24 GB card |

**Why api/external stay honest**: the cell[26] "Kokoro vs OpenAI TTS" comparison was **SKIPPED** in the committed run — the output explicitly says `OpenAI API key non configuree - comparaison skippee`. So no paid OpenAI call was made; the `$0.75/$1.50` figures are pedagogical projections for 1h of narration, not actual calls. Kokoro itself is local self-hosted free.

## Verification

```
check_cost_metadata (this notebook):
   before: [MAJOR] gpu_used_but_not_declared
   after : 0 findings  (cleared)
nbformat.validate: OK
git diff --stat: 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Build-safety

- **Metadata-only** (byte-surgical edit of the single cost-block line, no JSON round-trip, preserves papermill float formatting + the notebook's compact inline cost layout).
- **+266 bytes, 1 line changed**. 0 cells / source / outputs / execution_count touched — fingerprint (cell_type, source, exec_count, output_types) verified identical pre/post.
- **nbformat `validate`**: OK.
- **Not a twin** (no `twin_pairs.d` entry) → no `--update`, no parity drift.

## Grain

`MED/tooling (#8056 cost-honesty / under-declaration correction)` — lane `myia-po-2023:CoursIA` — prev: `MED/tooling #9457`. R6: GenAI/Audio is a fresh family vs the prior SymbolicAI cost stamps.

See #8056

🤖 Generated with [Claude Code](https://claude.com/claude-code)