### PR TITLE
fix(genai,#8056): cost under-declaration on Qwen-VL-Video-Analysis (MAJOR gpu_used -> 0, Video family)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-3-Qwen-VL-Video-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-3-Qwen-VL-Video-Analysis.ipynb
@@ -2342,7 +2342,7 @@
    "api_provider": "none",
    "cpu_min": 4,
    "gpu_min": 1,
-   "gpu_required": false,
+   "gpu_required": true,
    "vram_gb": 18,
    "vram_tier": "GPU_HIGH",
    "network": true,
@@ -2350,9 +2350,9 @@
    "free_alternative": "self",
    "reduced_pedagogical": "ollama",
    "reproducibility": "MED",
-   "metadata_written": "2026-07-23T14:00Z",
+   "metadata_written": "2026-08-05T00:00Z",
    "validator": "papermill",
-   "notes": "Qwen2.5-VL-7B-Instruct charge via transformers (bf16 ~14 GB).\nVideo understanding avec echantillonnage FPS dynamique + temporal\ngrounding + OCR. Necessite GPU 18+ GB VRAM (RTX 3090, A100).\nAlternative cloud : GPT-5-mini (notebook 01-2)."
+   "notes": "Qwen2.5-VL-7B-Instruct charge via transformers (bf16 ~14 GB).\nVideo understanding avec echantillonnage FPS dynamique + temporal\ngrounding + OCR. Necessite GPU 18+ GB VRAM (RTX 3090, A100).\nAlternative cloud : GPT-5-mini (notebook 01-2).  [CORRECTION sous-declaration (G.1 firsthand) : gpu_required false->true -- le run committé a detecté RTX 3090 (cell[6] GPU: NVIDIA RTX 3090, Device final: cuda, bfloat16) et tenté le chargement Qwen sur cuda (cell[8]). Le download HF a échoué (WinError 10054/10038, réseau transient) -> dégradation gracieuse, analyse désactivée (cell[14]), sans infirmer l'exigence GPU (bf16 7B ~14 GB, vram déclarée 18 GB).]"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

**Cost under-declaration correction** on `01-3-Qwen-VL-Video-Analysis.ipynb`. The cost block declared `gpu_required: false` while **every other field confirmed the GPU need** (`gpu_min: 1`, `vram_gb: 18`, `vram_tier: GPU_HIGH`) — a lone inconsistent field. The committed run was a CUDA run. Same under-declaration class as #9458 (Kokoro/Audio), **fresh family GenAI/Video**.

## G.1 firsthand (committed outputs on origin/main)

- **cell[6] output** (GPU verification): `GPU : NVIDIA GeForce RTX 3090`, `CUDA : 12.6`, `Device final : cuda`, `Precision : bfloat16` — GPU detected and selected.
- **cell[8] output** (model load): `Chargement de Qwen/Qwen2.5-VL-7B-Instruct... Device : cuda` — load attempted on cuda, but **the HF download failed on a transient network error** (`WinError 10054`/`10038`, "Une connexion existante a dû être fermée") → `Erreur chargement modele : ReadError... Le notebook continuera sans executer les analyses.`
- **cell[14] output**: `Analyse desactivee` — graceful degradation.

The model load **failed**, but that was a **transient network failure**, not a GPU-absence issue. The notebook **requires** a GPU to function (Qwen2.5-VL-7B bf16 ≈ 14 GB; the metadata's own `vram_gb: 18` confirms). The committed artifact shows it was a CUDA run (GPU detected + load attempted on cuda).

## Honest correction

| field | before | after | why |
|-------|--------|-------|-----|
| `gpu_required` | **false** | **true** | committed run used CUDA (RTX 3090, cell[6]/[8]); notebook requires GPU |
| `metadata_written` | 2026-07-23 | 2026-08-05 | correction date |
| `notes` | (unchanged body) | + honest caveat | documents the transient HF download failure so a reader isn't misled |
| `api_usd_est` / `api_provider` | 0.0 / "none" | **kept** | honest — local model, no paid API |
| `external_account` | "huggingface" | **kept** | honest — model from HF |
| `gpu_min` / `vram_gb` / `vram_tier` | 1 / 18 / GPU_HIGH | **kept** | already correct |

## Verification

```
check_cost_metadata (this notebook):
   before: [MAJOR] gpu_used_but_not_declared
   after : 0 findings  (cleared)
nbformat.validate: OK
git diff --stat: 1 file changed, 3 insertions(+), 3 deletions(-)
```

## Build-safety

- **Metadata-only** (byte-surgical edit of 3 lines in the cost block, no JSON round-trip, preserves the notebook's formatting + papermill metadata).
- **+410 bytes, 3 lines changed**. 0 cells / source / outputs / execution_count touched — fingerprint verified identical pre/post.
- **nbformat `validate`**: OK. **Not a twin** (no `twin_pairs.d` entry) → no `--update`.

## Grain

`MED/tooling (#8056 cost-honesty / under-declaration correction)` — lane `myia-po-2023:CoursIA` — prev: `MED/notebook-markdown #9459` (§D.5 Tweety). R6: GenAI/Video is a fresh family; this is the 2nd PR of the wakeup window.

See #8056

🤖 Generated with [Claude Code](https://claude.com/claude-code)