### PR TITLE
cost(#8056): declare gpu_required for 01-4-Video-Enhancement-ESRGAN

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb
@@ -1576,7 +1576,7 @@
    "api_provider": "none",
    "cpu_min": 4,
    "gpu_min": 1,
-   "gpu_required": false,
+   "gpu_required": true,
    "vram_gb": 4,
    "vram_tier": "GPU_LOW",
    "network": true,
@@ -1584,7 +1584,7 @@
    "free_alternative": "self",
    "reduced_pedagogical": "self",
    "reproducibility": "HIGH",
-   "metadata_written": "2026-07-23T14:00Z",
+   "metadata_written": "2026-08-05T00:00Z",
    "validator": "papermill",
    "notes": "Real-ESRGAN frame-by-frame upscaling (x2 ou x4) + RIFE interpolation\nconcept (24fps -> 60fps). Metriques PSNR/SSIM calculees pour\nevaluer qualite. Necessite GPU 4+ GB VRAM (RTX 3060 minimum).\nAlternative basique : scikit-image."
   }


### PR DESCRIPTION
## Cost stamp — `gpu_used_but_not_declared` correction

`01-4-Video-Enhancement-ESRGAN.ipynb` declared `gpu_required: false` while the committed cell[6] output reports **`GPU : NVIDIA GeForce RTX 3090 | VRAM : 24.0 GB`** — the GPU was detected and used for the verification/stats cells of the session.

### G.1 firsthand evidence (committed outputs on origin/main)
- cell[4] ec=3 output: `.env charge depuis: ... | Helpers GenAI importes`
- **cell[6] ec=4 output: `GPU : NVIDIA GeForce RTX 3090 | VRAM : 24.0 GB`** ← GPU detected/used
- cell[22] ec=10 output: `Date : 2026-05-23 17:15:16 | Mode : interactive | Scale factor : 2x`

### Change (metadata-only, +2/-2)
| Field | Before | After |
|-------|--------|-------|
| `gpu_required` | `false` | **`true`** |
| `metadata_written` | `2026-07-23T14:00Z` | `2026-08-05T00:00Z` |

`gpu_min: 1`, `vram_gb: 4`, `vram_tier: GPU_LOW` were already correct. `api_usd_est: 0.0` / `api_provider: none` / `external_account: none` kept **HONEST** — no API call (purely local upscaling).

### Build-safety / honesty
- **Metadata-only edit**: 0 notebook cells touched (source, outputs, execution_count all byte-identical). No re-execution needed, **no output scrubbing** (règle 6 / Stop & Repair).
- JSON fingerprint validated programmatically: `len(cells)` unchanged, all cell source/outputs/execution_count identical pre/post.
- Catalogue byte-identical to main (no regen).

### Residual (out of scope, tracked — NOT this PR)
cell[4]/cell[12] outputs say `Real-ESRGAN non installe - utilisation bicubique` — the notebook's *intended* SOTA tool (Real-ESRGAN) was not installed and it fell back to bicubic resize. This is a **Prong-A RECOVERABLE-LOCAL** concern (Real-ESRGAN installable via `pip install realesrgan`), a separate register from the cost stamp, requiring model-weight download + GPU re-exec. Left for a dedicated Prong-A PR. The cost stamp here is independent and correct regardless: the GPU *was* used by the session (detection + verification cells).

See #8056

🤖 Generated with [Claude Code](https://claude.com/claude-code)