### PR TITLE
fix(genai,#8056): AnimateDiff gpu_used_but_not_declared cost stamp (false -> true)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-5-AnimateDiff-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-5-AnimateDiff-Introduction.ipynb
@@ -4188,7 +4188,7 @@
    "api_provider": "none",
    "cpu_min": 4,
    "gpu_min": 1,
-   "gpu_required": false,
+   "gpu_required": true,
    "vram_gb": 12,
    "vram_tier": "GPU_MID",
    "network": true,
@@ -4196,7 +4196,7 @@
    "free_alternative": "self",
    "reduced_pedagogical": "self",
    "reproducibility": "MED",
-   "metadata_written": "2026-07-23T14:00Z",
+   "metadata_written": "2026-08-05T00:00Z",
    "validator": "papermill",
    "notes": "AnimateDiff = motion adapter + Stable Diffusion v1.5.\nGeneration text-to-video (16 frames @ 8 fps = 2s).\nNecessite GPU 12+ GB VRAM (RTX 3060 12GB minimum).\nParametres cles : num_frames, guidance_scale, num_inference_steps.\nSortie GIF + MP4."
   }


### PR DESCRIPTION
Grain: LIGHT/ledger — lane myia-po-2023:CoursIA — prev: DEEP/sota #9462

## Cost stamp — `gpu_used_but_not_declared` correction (AnimateDiff)

`MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-5-AnimateDiff-Introduction.ipynb` declared `gpu_required: false` while the committed outputs prove the notebook ran a **real AnimateDiff text-to-video generation on an RTX 3090 (cuda)**. This closes the last unclaimed GenAI `gpu_used_but_not_declared` MAJOR.

### G.1 firsthand evidence (committed outputs on origin/main)
- cell[3] (VERIFICATION GPU) ec=4 output: `GPU : NVIDIA GeForce RTX 3090 | VRAM totale : 24.0 GB | CUDA : 12.8` + `AnimateDiff pipeline : disponible (import reussi)` + `Device : cuda` + `Generation activee : True`
- cell[5] ec=5: real pipeline load (`Motion adapter charge`, `Pipeline charge en 18.3s`, `VRAM utilisee`)
- cell[7]/cell[9] ec=6/11: real video generation — GIF/MP4 files saved (`animatediff_demo.gif 3123.6 KB`, `comparison_chat/ocean/fusee.gif`)
- cell[12] ec=12 session stats: `Device : cuda`, `VRAM pic session : 4.5 GB`, 5 generated files

The GPU was detected, used, and is the notebook's core mechanism (AnimateDiff needs a GPU — without CUDA `run_generation` is set False by cell[3]).

### Self-contradiction in the metadata (the defect)
The `metadata.cost` block was internally inconsistent: it already declared `gpu_min: 1`, `vram_gb: 12`, `vram_tier: GPU_MID`, and `notes: "...Necessite GPU 12+ GB VRAM (RTX 3060 12GB minimum)..."` — yet `gpu_required: false` was the lone outlier. The fix aligns `gpu_required` with the rest of the block and with the committed evidence.

### Change (metadata-only, +2/-2)
| Field | Before | After |
|-------|--------|-------|
| `gpu_required` | `false` | **`true`** |
| `metadata_written` | `2026-07-23T14:00Z` | `2026-08-05T00:00Z` |

`api_usd_est: 0.0` / `api_provider: none` / `external_account: huggingface` kept **HONEST** (purely local self-hosted generation, no paid API call; HF account only for model weights).

### Build-safety / honesty
- **Metadata-only edit**: 0 notebook cells touched (source, outputs, execution_count all byte-identical to origin/main). Verified by cell fingerprint (25/25 cells: cell_type + source + execution_count + outputs JSON all identical).
- `nbformat.validate` PASS; `json.dumps(indent=1, ensure_ascii=False)` round-trip byte-identical except the 2 changed fields (canonical repo format).
- `scripts/audit/check_cost_metadata.py --family GenAI/Video`: the AnimateDiff section is now **CLEAN** (no `gpu_used_but_not_declared` MAJOR). The remaining 6 family MAJORs are Qwen-VL (#9460 in flight) and ESRGAN (#9462 in flight), not yet merged to main.
- Catalogue byte-identical to main (no regen).

### Residual (out of scope, NOT introduced by this PR)
- cell[2] output contains a pre-existing `.env charge depuis: d:\Dev\...` machine path (present on origin/main). Not scrubbed (règle 6 / Stop & Repair — fixing it requires a clean-worktree re-exec, a separate concern from this metadata stamp). cell[5] output already uses the repo's `<USER_PATH>` placeholder convention.
- These are pre-existing; this PR introduces 0 new leak (0 machine path, 0 secret in the diff).

### Cycle context
This was selected after exhausting rotation across 6+ registers this cycle (Lean i18n ×19 lakes all FR-first, Lean sorries ×6 lakes all sorry-free/frontier, GenAI Image Prong-A drained, §D.5 #9127 already-resolved, #9345/#9346/#9347 vision/ComfyUI-blocked, version-contradiction 0 stale, README clean, #9345/#9458/#9460 collided) — all drained/blocked/collided. AnimateDiff was the **last unclaimed** GenAI cost defect; this PR closes the GenAI cost surface for the remaining notebooks (only in-flight PRs remain).

See #8056

🤖 Generated with [Claude Code](https://claude.com/claude-code)
