### PR TITLE
fix(ci,lean-axiom): discriminate the two causes of n_decls==0 (unblocks #9446)

### DIFF
--- a/.github/workflows/lean-axiom.yml
+++ b/.github/workflows/lean-axiom.yml
@@ -160,6 +160,8 @@ jobs:
 
         all_clean = True
         sorry_modules = []
+        zero_decl_design = []   # modules that legitimately declare nothing (root aggregators)
+        total_enumerated = 0    # lake-level non-vacuity (Gesture 2, ai-01 c.84)
         print(f"=== Proof integrity axiom check ({display_name}) ===")
         print(f"Project: {project_path}")
         print(f"Gate on sorry: {'yes' if fail_on_sorry else 'no (reported, not gated)'}")
@@ -187,6 +189,7 @@ jobs:
                 # via `fail-on-sorry: false` rather than staying permanently red.
             )
             n_decls = len(result["declarations"])
+            total_enumerated += n_decls
             print(f"  declarations: {n_decls} enumerated")
             # Criterion 1 (#8782): render WHICH declarations were audited, not
             # only the count. A bare count hides both directions of the blind
@@ -233,19 +236,34 @@ jobs:
 
             module_ok = result["success"]
 
-            # `fail_on_sorry` does double duty inside `check_axioms`: besides
-            # gating sorryAx, it also gates the "no declarations enumerated"
-            # guard (lean_server.py: `if fail_on_sorry: return success=False,
-            # error=no_declarations_enumerated`). So passing false to silence a
-            # known sorry would ALSO silence the guard that catches a module
-            # whose source could not be parsed -- and a check that enumerated
-            # zero declarations would report OK having verified nothing.
-            # That is the same defect this PR removes, merely mirrored: instead
-            # of a gate that can never go green, a gate that can never go red.
-            # Assert enumeration here, independently of the sorry policy.
-            if n_decls == 0:
+            # Discriminate the two causes of a zero enumeration (ai-01 c.84,
+            # #9446 CHANGES_REQUESTED). `lean_server.check_axioms` already
+            # classifies the empty case via `empty_reason`
+            # (`_classify_empty_enumeration`); only `declaration_free_module` is
+            # a pass -- every other reason (source_not_found,
+            # all_private_declarations, sorry_without_declaration,
+            # no_declarations_enumerated) is a gap where the gate inspected
+            # nothing and MUST fail loud, independently of the sorry policy
+            # (that is why we assert here and not only inside `check_axioms`:
+            # `fail_on_sorry` doubles as the "no declarations" guard there, so a
+            # false would otherwise silence a parse gap and yield a gate that
+            # can never go red). The previous `n_decls == 0 -> FAIL` conflated
+            # the two and red-flagged root aggregators (Grothendieck,
+            # .DirectImage, .MathlibMap, .SchemesTour) that the lake built and
+            # parsed clean but legitimately declare nothing. Vacuity moves to
+            # lake level (below) so a lake whose EVERY module is zero-decl is
+            # still caught without an exclusion list (ai-01: a list rots and
+            # does not scale to 20 lakes).
+            empty_reason = result.get("empty_reason")
+            if n_decls == 0 and empty_reason != "declaration_free_module":
                 module_ok = False
-                print(f"  FAIL: no declarations enumerated -- nothing was verified")
+                print(f"  FAIL: no declarations enumerated -- source gap "
+                      f"(empty_reason={empty_reason})")
+            elif n_decls == 0:
+                zero_decl_design.append(mod)
+                print(f"  NOTE: declaration-free by design "
+                      f"(empty_reason={empty_reason}) -- non-fatal; "
+                      f"vacuity guarded at lake level")
 
             if not module_ok:
                 all_clean = False
@@ -253,7 +271,22 @@ jobs:
             else:
                 print(f"  OK")
 
+        # Gesture 2 (ai-01 c.84): non-vacuity at LAKE level. A gate whose
+        # every module enumerated zero declarations inspected nothing. Asserting
+        # this once at lake level catches that without false-positiving on
+        # individual root aggregators (handled above via empty_reason). Neutre
+        # for lean-knot.yml / lean-conway.yml: none of their target modules
+        # enumerate zero.
+        if total_enumerated == 0:
+            all_clean = False
+            print(f"FAIL: lake-level non-vacuity -- all {len(modules)} "
+                  f"module(s) enumerated zero declarations (the gate inspected "
+                  f"nothing; check target-modules / module resolution).")
+
         print()
+        if zero_decl_design:
+            print(f"NOTE: {len(zero_decl_design)} module(s) declaration-free by "
+                  f"design (non-fatal): {', '.join(zero_decl_design)}")
         if sorry_modules and not fail_on_sorry:
             print(f"NOTE: sorry present in {', '.join(sorry_modules)} "
                   f"(reported, not gated -- fail-on-sorry is false for this lake).")
@@ -266,7 +299,8 @@ jobs:
             # gate that misreports its own cause is worse than no gate.
             print("FAIL: see per-module breakdown above "
                   "(`error:` for build/lookup failures, "
-                  "`declarations: 0` for a module whose source was not parsed, "
+                  "`empty_reason` != declaration_free_module for a source gap, "
+                  "lake-level non-vacuity if every module enumerated zero, "
                   "`forbidden:` for axiom violations"
                   + (", `has_sorry:` for sorryAx)." if fail_on_sorry else ")."))
             sys.exit(1)


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: LIGHT/ledger #9463

## fix(ci,lean-axiom): discriminate the two causes of `n_decls == 0`

Addresses ai-01's **CHANGES_REQUESTED** on #9446 (c.84): the grothendieck proof-integrity gate refused, but not for the reason it believed. ai-01 directed: *"La correction est dans `lean-axiom.yml`, pas ici."* This PR fixes the reusable workflow (not #9446's caller file), so once merged to `main`, #9446 re-runs against `lean-axiom.yml@main` and verdicts green.

### The defect
The gate asserted `if n_decls == 0: FAIL` (lean-axiom.yml L246). This conflated two causes of a zero enumeration:
- **"0 parce que rien n'a été parsé"** (a source gap — the defect the guard targets)
- **"0 parce que le module ne déclare rien"** (a design fact — a root aggregator / prose module)

It red-flagged four grothendieck modules (`Grothendieck`, `.DirectImage`, `.MathlibMap`, `.SchemesTour`) that the lake built clean (2828 jobs, EXIT=0), parsed clean, and legitimately declare nothing — `forbidden: []`, `has_sorry: False`, no `error:`.

### The two gestures (ai-01 c.84 design, implemented verbatim)

**Gesture 1 — per-module discriminant.** `lean_server.check_axioms` *already* classifies the empty case via `empty_reason` (`_classify_empty_enumeration`); only `declaration_free_module` is a pass. The gate now reads it:
- `n_decls == 0 AND empty_reason != declaration_free_module` → **FAIL** (source gap: `source_not_found` / `all_private_declarations` / `sorry_without_declaration` / `no_declarations_enumerated`). This stays independent of the sorry policy — that was the whole point of asserting here (`fail_on_sorry` doubles as the "no declarations" guard inside `check_axioms`, so a `false` would otherwise silence a parse gap).
- `n_decls == 0 AND empty_reason == declaration_free_module` → **non-fatal** (root aggregator; counted in the summary).

The discriminant is `empty_reason` (not just `error`): it is always present at `n_decls==0` and robust to `fail_on_sorry=False`, so a prover-path parse gap is still caught (the `error` field alone is `fail_on_sorry`-gated).

**Gesture 2 — non-vacuity at LAKE level.** The vacuity guard ("the gate inspected nothing") moves up: after the module loop, if **every** module enumerated zero, the gate FAILs once at lake level. This catches "a gate that inspects nothing" without an **exclusion list** (ai-01: a list rots — a theorem added to `SchemesTour.lean` in six months stays unverified forever — and does not scale to the 20 remaining lakes, each with a zero-decl root aggregator).

### Firsthand verification (real grothendieck source, no build needed)
Ran the real `_classify_empty_enumeration` + `_enumerate_module_declarations` on the four modules:
```
Grothendieck             decls=  0 empty_reason=declaration_free_module -> NON-FATAL (pass)
Grothendieck.DirectImage decls=  0 empty_reason=declaration_free_module -> NON-FATAL (pass)
Grothendieck.MathlibMap  decls=  0 empty_reason=declaration_free_module -> NON-FATAL (pass)
Grothendieck.SchemesTour decls=  0 empty_reason=declaration_free_module -> NON-FATAL (pass)
```
→ grothendieck's 4 false-positives become non-fatal; the other 30 target-modules have decls (`total_enumerated > 0`) so lake-level non-vacuity passes. **#9446 unblocked.**

### Neutrality for knot/conway (verified)
knot target-modules all enumerate >0 decls: `Knots.Basic`=36, `Knots.Conway`=15, `Knots.Invariant`=31, `Knots.Reidemeister`=26, `Knots.Lidman`=4. The new branches fire only under `n_decls == 0`; for any module with decls the behaviour is byte-identical (`total_enumerated` is a passive counter). conway is the same (its 19 `native_decide` modules enumerate decls). Neutre par construction.

### Build-safety / honesty
- YAML valid; embedded Python `ast.parse` OK.
- Single file, +47/-13, additive logic (no existing protection removed — the parse-gap FAIL is preserved and sharpened; only the false-positive on declaration-free modules is removed).
- No exclusion list introduced; the four cases of empty are all still FAIL except the one genuine pass.
- Catalogue byte-identical to main (no regen).

See #8782 (proof-integrity EPIC), #9446 (grothendieck cabling, CHANGES_REQUESTED this unblocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
