### PR TITLE
fix(tooling): G-VAR-2 organ reports unassessable as a third state, not as a pass

### DIFF
--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -283,6 +283,83 @@ def test_status_counts_the_open_candidate_in_denominator():
     assert st["cap_reached"] is True
 
 
+# --- unassessable vs assessed (#9464): the organ must not report a
+# --- measurement it could not take as a passing measurement.
+
+def _check_pr(tmp_path, merged, body, labels=None, capsys=None):
+    """Drive main() in --check-pr mode and return its parsed JSON line."""
+    import json as _json
+    mpath = tmp_path / "merged.json"
+    mpath.write_text(_json.dumps(merged), encoding="utf-8")
+    bpath = tmp_path / "body.txt"
+    bpath.write_text(body, encoding="utf-8")
+    argv = ["--replay", str(mpath), "--check-pr", "1", "--body-file", str(bpath)]
+    if labels is not None:
+        lpath = tmp_path / "labels.json"
+        lpath.write_text(_json.dumps(labels), encoding="utf-8")
+        argv += ["--labels-file", str(lpath)]
+    rc = vlc.main(argv)
+    out = capsys.readouterr().out.strip().splitlines()[-1]
+    return rc, _json.loads(out)
+
+
+def test_untagged_body_is_unassessable_not_false(tmp_path, capsys):
+    # The defect that made the gate green while blind: an untagged body was
+    # reported `cap_reached: false`, i.e. indistinguishable from "assessed and
+    # within budget". It must be the third state.
+    rc, res = _check_pr(tmp_path, [], "no tag anywhere in this body", capsys=capsys)
+    assert rc == 0                       # advisory posture preserved
+    assert res["cap_reached"] is None    # NOT False
+    assert "unassessable" in res["reason"]
+
+
+def test_light_without_lane_is_unassessable(tmp_path, capsys):
+    # Tier known, but the budget is per-lane: no lane -> no denominator.
+    rc, res = _check_pr(tmp_path, [], "Grain: LIGHT/guard -- no lane here", capsys=capsys)
+    assert rc == 0
+    assert res["cap_reached"] is None
+    assert "no lane" in res["reason"]
+
+
+def test_known_non_light_without_lane_is_assessed_false(tmp_path, capsys):
+    # Symmetric guard against over-broadening: a KNOWN MED/DEEP never spends
+    # the LIGHT budget, so it is a genuine `false` even with no lane. Only the
+    # lane's denominator suffers, which is `unattributed`'s business.
+    rc, res = _check_pr(tmp_path, [], "Grain: DEEP/lean -- no lane here", capsys=capsys)
+    assert rc == 0
+    assert res["cap_reached"] is False
+    assert res["reason"] == "not LIGHT (effective DEEP)"
+
+
+def test_tagged_light_still_assessed_normally(tmp_path, capsys):
+    # Non-regression: a fully tagged LIGHT is still assessed, not deflected
+    # into the new unassessable branch.
+    merged = [{"number": 1, "body": BODY_EMDASH, "mergedAt": "2026-08-05T03:00:00Z"}]
+    rc, res = _check_pr(tmp_path, merged, BODY_EMDASH, capsys=capsys)
+    assert rc == 0
+    assert res["cap_reached"] is True
+    assert res["lane"] == "myia-po-2023:CoursIA"
+
+
+def test_unattributed_lists_untagged_prs():
+    prs = [
+        {"number": 1, "body": BODY_EMDASH, "mergedAt": "2026-08-05T01:00:00Z"},
+        {"number": 2, "body": "ledger stamp, no tag", "mergedAt": "2026-08-05T02:00:00Z"},
+        {"number": 3, "body": "", "mergedAt": "2026-08-05T03:00:00Z"},
+    ]
+    assert [pr["number"] for pr in vlc.unattributed(prs)] == [2, 3]
+
+
+def test_untagged_day_replays_empty_but_is_not_clean():
+    # The c.85 measurement, pinned: 5 ledger stamps merged, zero tags. `replay`
+    # is legitimately empty -- the arithmetic is right -- but `unattributed`
+    # is what stops that emptiness reading as a clean day.
+    prs = [{"number": n, "body": "metadata.cost stamp", "mergedAt": f"2026-08-05T0{n}:00:00Z"}
+           for n in range(1, 6)]
+    assert vlc.replay(prs) == []
+    assert len(vlc.unattributed(prs)) == 5
+
+
 def test_budget_is_per_lane_not_global():
     # A busy lane's budget must not bleed into a quiet lane's.
     busy, quiet = "myia-po-2024:CoursIA-2", "myia-po-2025:CoursIA"

--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -283,7 +283,7 @@ def test_status_counts_the_open_candidate_in_denominator():
     assert st["cap_reached"] is True
 
 
-# --- unassessable vs assessed (#9464): the organ must not report a
+# --- unassessable vs assessed (#9465): the organ must not report a
 # --- measurement it could not take as a passing measurement.
 
 def _check_pr(tmp_path, merged, body, labels=None, capsys=None):

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -186,6 +186,19 @@ def _lane_of(pr: dict) -> str | None:
     return g["lane"] if g else None
 
 
+def unattributed(merged_prs: list[dict]) -> list[dict]:
+    """PRs the organ could NOT attribute to any lane (no readable `Grain:` tag).
+
+    These are invisible to every count above: absent from each lane's
+    numerator AND denominator. That is the right arithmetic -- guessing a lane
+    would be worse -- but it must never be reported as a clean day. An audit
+    that says `cap-reached: 0` over a set where most PRs landed here has
+    measured nothing; the summary prints this count so the two cannot be
+    confused (#9464).
+    """
+    return [pr for pr in merged_prs if _lane_of(pr) is None]
+
+
 def lane_grains(merged_prs: list[dict], target_lane: str) -> list[dict]:
     """Every merged PR attributed to `target_lane`, ANY tier.
 
@@ -358,12 +371,34 @@ def main(argv: list[str] | None = None) -> int:
         # Effective tier (#8970): a requalification label overrides the declared
         # one. Only an EFFECTIVE LIGHT is assessed against the cap.
         eff = effective_tier(body, cur_labels)
+        g = parse_grain(body)
+        # UNASSESSABLE vs ASSESSED (#9464). `cap_reached: false` must mean one
+        # thing only: "assessed, and within budget". A body with no readable
+        # tag, or a tag without a lane, is not an exemption -- it is a
+        # measurement the organ could not take, and reporting it as `false`
+        # made the gate green precisely where it was blind. `null` is the
+        # third state; the caller (variation-tag-guard.yml) compares against
+        # "True", so this stays advisory and no CI behaviour changes.
+        if eff is None or not g:
+            print(json.dumps({
+                "cap_reached": None,
+                "reason": "unassessable -- no Grain: tag in body",
+            }))
+            return 0
         if eff != "LIGHT":
+            # A KNOWN non-LIGHT tier is a genuine assessment, lane or not: a
+            # MED/DEEP grain never spends the LIGHT budget. Only the lane's
+            # denominator suffers, and that is `unattributed`'s business.
             print(json.dumps({"cap_reached": False, "reason": f"not LIGHT (effective {eff})"}))
             return 0
-        g = parse_grain(body)
-        if not g or not g["lane"]:
-            print(json.dumps({"cap_reached": False, "reason": "no lane in tag"}))
+        if not g["lane"]:
+            # An effective LIGHT with no lane is the one case where the tier is
+            # known and the answer still cannot be computed: the budget is
+            # per-lane, so without a lane there is no denominator to compare to.
+            print(json.dumps({
+                "cap_reached": None,
+                "reason": "unassessable -- effective LIGHT but no lane in tag",
+            }))
             return 0
         status = light_cap_status(merged, g["lane"])
         print(json.dumps({
@@ -376,13 +411,26 @@ def main(argv: list[str] | None = None) -> int:
     # replay mode: the acceptance test
     rows = replay(merged)
     flagged = [r for r in rows if r["cap_reached"]]
-    print(f"LIGHT PRs replayed: {len(rows)} | cap-reached: {len(flagged)}")
+    blind = unattributed(merged)
+    print(f"LIGHT PRs replayed: {len(rows)} | cap-reached: {len(flagged)}"
+          f" | unattributed: {len(blind)}/{len(merged)}")
+    if blind:
+        # Without this line a day whose PRs are all untagged prints exactly
+        # like a clean day (#9464): `replayed: 0 | cap-reached: 0`.
+        print(f"  WARNING: {len(blind)} of {len(merged)} merged PRs carry no "
+              f"readable `Grain:` tag -- they are counted in NO lane, so the "
+              f"figures above measure only the tagged remainder.")
+        print("  unattributed: "
+              + ", ".join(f"#{pr.get('number')}" for pr in blind))
     print(f"{'PR':>7}  {'lane':<28} {'mergedAt':<21} cap")
     for r in rows:
         mark = "CAP-REACHED" if r["cap_reached"] else "ok"
         print(f"  #{r['number']:<5} {r['lane']:<28} {r['mergedAt']:<21} {mark}"
               + (f"  (consumed by #{r['consumed_by']})" if r["cap_reached"] else ""))
-    print(json.dumps({"rows": rows}, ensure_ascii=False))
+    print(json.dumps({
+        "rows": rows,
+        "unattributed": [pr.get("number") for pr in blind],
+    }, ensure_ascii=False))
     return 0
 
 

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -194,7 +194,7 @@ def unattributed(merged_prs: list[dict]) -> list[dict]:
     would be worse -- but it must never be reported as a clean day. An audit
     that says `cap-reached: 0` over a set where most PRs landed here has
     measured nothing; the summary prints this count so the two cannot be
-    confused (#9464).
+    confused (#9465).
     """
     return [pr for pr in merged_prs if _lane_of(pr) is None]
 
@@ -372,7 +372,7 @@ def main(argv: list[str] | None = None) -> int:
         # one. Only an EFFECTIVE LIGHT is assessed against the cap.
         eff = effective_tier(body, cur_labels)
         g = parse_grain(body)
-        # UNASSESSABLE vs ASSESSED (#9464). `cap_reached: false` must mean one
+        # UNASSESSABLE vs ASSESSED (#9465). `cap_reached: false` must mean one
         # thing only: "assessed, and within budget". A body with no readable
         # tag, or a tag without a lane, is not an exemption -- it is a
         # measurement the organ could not take, and reporting it as `false`
@@ -416,7 +416,7 @@ def main(argv: list[str] | None = None) -> int:
           f" | unattributed: {len(blind)}/{len(merged)}")
     if blind:
         # Without this line a day whose PRs are all untagged prints exactly
-        # like a clean day (#9464): `replayed: 0 | cap-reached: 0`.
+        # like a clean day (#9465): `replayed: 0 | cap-reached: 0`.
         print(f"  WARNING: {len(blind)} of {len(merged)} merged PRs carry no "
               f"readable `Grain:` tag -- they are counted in NO lane, so the "
               f"figures above measure only the tagged remainder.")


### PR DESCRIPTION
`Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/guard #9385`

## Le gate G-VAR-2 rapportait vert là où il était aveugle

Mesure de ce cycle, sur les 10 PR mergées de la journée :

```
$ python scripts/variation_light_cap.py --replay <merged.json> --replay-mode
LIGHT PRs replayed: 0 | cap-reached: 0
{"rows": []}
```

Ce lot contient **cinq stamps `metadata.cost`** (#9448, #9449, #9451, #9452, #9457) — cinq `LIGHT/ledger` du rollout #8056, exactement la vague que G-VAR-2 existe pour compter. L'organe en a vu **zéro**, et l'a dit sous une forme qui se lit comme une journée propre.

Même chose côté CI, sur chaque PR ouverte :

```
$ ... --check-pr 9463 --body-file ... --labels-file ...
{"cap_reached": false, "reason": "not LIGHT (effective None)"}
```

`effective None` — l'organe *sait* qu'il n'a pas lu de tier, et conclut quand même `false`. Or `false` a un seul sens utile : « mesuré, et dans le budget ». Ici il signifie « pas mesuré ». Les deux états sont confondus, et comme 100 % des PR ouvertes sont aujourd'hui sans tag `Grain:`, le gate **ne peut plus rougir du tout** tout en restant vert.

C'est la même classe de défaut que les deux autres gardes traités cette semaine — `lean-axiom.yml` où `n_decls == 0` confond « rien parsé » et « rien à déclarer » (#9446), et `ict-tests.yml` où un seul `exit 1` couvre trois causes dont deux muettes (#9436). Une entrée manquante ou ambiguë y produit silencieusement le verdict **permissif**.

## Ce que la PR change

**Un troisième état, pas une nouvelle politique.** Faire compter les PR sans tag *comme* des LIGHT serait un changement de règle que personne n'a demandé, et bloquerait d'un coup la quasi-totalité des PR ouvertes. La réparation honnête est de rendre l'inconnu **visible**, en laissant le jugement au coordinateur.

1. **`--check-pr` renvoie `cap_reached: null`** (au lieu de `false`) quand le tier n'est pas lisible, ou quand un LIGHT effectif n'a pas de lane — le budget étant par lane, sans lane il n'y a pas de dénominateur.
2. **Garde de symétrie** : un tier **connu** non-LIGHT reste un `false` légitime, lane ou pas. Un MED/DEEP ne dépense jamais le budget LIGHT ; seul le dénominateur de sa lane en souffre, et c'est l'affaire du point 3. Sans cette garde, la correction s'élargirait jusqu'à marquer « non mesuré » les grains substantiels, qui sont le bon cas.
3. **`--replay-mode` compte et nomme les non-attribués**, au lieu de les laisser tomber en silence des deux côtés de la fraction.

Sur le même lot qu'en tête :

```
LIGHT PRs replayed: 0 | cap-reached: 0 | unattributed: 9/10
  WARNING: 9 of 10 merged PRs carry no readable `Grain:` tag -- they are counted
  in NO lane, so the figures above measure only the tagged remainder.
  unattributed: #9457, #9455, #9453, #9452, #9451, #9450, #9449, #9448, #9447
```

## Rayon d'explosion : nul côté CI, vérifié avant d'écrire

Le seul consommateur est [`variation-tag-guard.yml`](.github/workflows/variation-tag-guard.yml) L215-334, délibérément advisory (`# Ce job rend le fait VISIBLE (advisory, exit 0)`). Il appelle le script avec `|| true`, puis lit :

```bash
CAP=$(python3 -c "import json; print(json.load(open('/tmp/status.json')).get('cap_reached'))" ... || echo "False")
if [ "$CAP" = "True" ]; then ...
```

`null` s'imprime `None`, qui n'est pas `"True"` — donc même branche qu'avec `False` auparavant. Vérifié en exécutant la one-liner du workflow sur la sortie réelle : `workflow one-liner reads: [None]`. **Le script conserve `exit 0` dans tous les cas** ; aucun comportement CI ne change. Le cas non-taggé reste par ailleurs signalé en CI par le job frère, via le label `variation-tag-missing`.

## Tests

`scripts/tests/test_variation_light_cap.py` : **29 → 35**, tous verts.

```
35 passed in 0.20s
```

Les six nouveaux pinnent le contrat exact : untagged → `null` et non `false` ; LIGHT sans lane → `null` ; **DEEP sans lane → `false`** (la garde de symétrie, qui échouerait sur une correction trop large) ; un LIGHT complètement taggé continue d'être évalué normalement ; `unattributed` liste bien les non-taggés ; et la mesure de ce cycle est figée telle quelle — `replay == []` **et** `unattributed == 5` sur une journée de cinq stamps sans tag, pour que ce vide-là ne puisse plus jamais se lire comme une journée propre.

`rc == 0` est asserté dans chaque test du chemin CI : la posture advisory est pinnée, pas seulement supposée.

## Ce que ça ne fait pas

Ça ne remplit pas les tags manquants et ça ne bloque personne. La cause reste que les workers déclarent leur grain sur le dashboard plutôt que dans le body — un dashboard qui condense emporte l'attribution avec lui, et la machine ne sait lire que le body. Cette PR fait seulement que l'organe **dise** qu'il ne mesure rien, au lieu de rapporter que tout va bien. J'y ai ma part : c'est en lisant `cap-reached: 0` comme une journée propre que j'ai mergé cinq `LIGHT/ledger` consécutifs cette nuit.

See #8964, #8056
