### PR TITLE
fix(search,#9434): de-pin machine-dependent DLX timing from Search-8 markdown conclusion

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb
@@ -3306,7 +3306,7 @@
     "\n",
     "### résultats mesures\n",
     "\n",
-    "L'implementation DLX est **~7x plus rapide** que l'Algorithme X naif sur matrice numpy (0.078 ms vs 0.563 ms). Sur de très petites instances, le cout de construction de la structure DLX peut contrebalancer le gain, mais DLX domine clairement quand le problème grandit.\n",
+    "L'implementation DLX surpasse l'Algorithme X naif dès que l'arbre de recherche devient vaste. Les temps absolus mesurés ci-dessus dépendent de la machine et fluctuent à chaque exécution ; le benchmark discriminant sur pentominoes montre l'avantage du DLX se creuser quand le problème grandit (rapport lu dans la sortie de la cellule de mesure, non figé en prose). Sur de très petites instances, le cout de construction de la structure DLX peut contrebalancer le gain.\n",
     "\n",
     "### Applications\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/search-8-dancinglinks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-8-dancinglinks.yaml
@@ -9,6 +9,12 @@
       python_sha: 16f7e7cdb38e559dcebf1ca3480c056d0690eec8
       csharp_sha: 6f8406e999d2e74ff5e615e32efb8c7342396c73
       reason: "Markdown-only identity fix (Python cells 53+54): the worked-example enonce (cell 53) and the code comment (cell 54) of the 5-element Exemple 1 instance both wrote S2 = {1, 4}, but the actual matrix row [0,1,0,1,0], the sets dict {1:{2,4}}, and the committed output (S2 couvre {2, 4}, Couverture exacte True) all use {2, 4} -- with {1,4} the cover would miss element 2 and double-cover 1, making an exact cover impossible. Aligned the enonce + comment to {2, 4}. NOTE: the early visualization cell 5 uses a SEPARATE 7-element instance where S2 = {1, 4} is correct (same instance as the C# twin) -- left untouched. C# twin is a different 7-element instance, no parallel defect. No re-exec, no output change."
+    - date: "2026-08-05"
+      by: myia-po-2023:CoursIA
+      python_sha: ce86217dba6f48a422de5dbd297e7f269aba7b95
+      csharp_sha: 6f8406e999d2e74ff5e615e32efb8c7342396c73
+      content_python_sha: 19acda85a22ee8187103dcc9e082067b84ce4f2e5af95b9a20e89777024d243d
+      content_csharp_sha: 67f0e2537692300f2ef1e246f3f8a06b368d2d11c60758541778cc210f147959
   known_differences:
     - "Rebaseline c.34 (ai-01) : #8697 a insere le bloc `metadata.cost` (#8056) a l'identique sur les DEUX jumeaux — les deux blob SHA ont bouge, la parite semantique est inchangee. Attestation de parite, pas reparation."
     - "Socle commun : probleme de couverture exacte, algorithme X de Knuth, structure de donnees Dancing Links (DLX), implementation DLX, application polyominos, comparaison de performances DLX vs backtracking."


### PR DESCRIPTION
Grain: LIGHT/notebook-markdown (#9434 timing class — EPIC reproducibility) — lane myia-po-2023:CoursIA — prev: MED/notebook-python #9469

## Ce que fait la PR

Sub-tâche bornée de l'EPIC #9434 (« porter le mandat *quantitatif tenu par le CI, pas par la prose* à l'intérieur des notebooks »), classe **machine-dépendant** (timing absolu). `Search-8-DancingLinks.ipynb` cell[59] (markdown « résultats mesurés ») re-épinglait en prose des valeurs qui dérivent à chaque re-exec.

### Le defect (G.1 firsthand, worktree frais origin/main)

Cell[59] markdown disait :
> L'implementation DLX est **~7x plus rapide** que l'Algorithme X naif sur matrice numpy (**0.078 ms vs 0.563 ms**).

- `0.078 ms vs 0.563 ms` provient des **sorties de code** cell[27] (DLX `Temps: 0.078 ms`) et cell[10] (naïf `Temps de recherche: 0.563 ms`) sur l'instance triviale d'exemple. La prose re-pin ces temps absolus → **dérive machine-dépendante** (le naïf utilise numpy/BLAS, le DLX est pure-Python pointer-chasing : le ratio sur une instance 6x7 est du bruit de constant-factor, pas un speedup structurel).
- `~7x` est le ratio sur cette instance triviale — **machine + instance-dépendant**, donc il re-dérive aussi.

Le **vrai** claim structurel (DLX domine quand l'arbre de recherche grandit) est déjà imprimé en **sortie de code** par le benchmark discriminant cell[49] (pentominoes, « DLX environ 3x plus rapide ») — qui se met à jour tout seul à chaque exécution. C'est la source de vérité ; la prose ne devrait pas la dupliquer en figeant des chiffres.

### Le fix (classe machine-dépendant, #9434)

Retirer les temps absolus + le ratio bruité, garder le claim qualitatif, renvoyer à la sortie de la cellule de benchmark (single source of truth) :
> L'implementation DLX surpasse l'Algorithme X naif dès que l'arbre de recherche devient vaste. Les temps absolus mesurés ci-dessus dépendent de la machine et fluctuent à chaque exécution ; le benchmark discriminant sur pentominoes montre l'avantage du DLX se creuser quand le problème grandit (rapport lu dans la sortie de la cellule de mesure, non figé en prose). Sur de très petites instances, le cout de construction de la structure DLX peut contrebalancer le gain.

**Ligne de partage #9434 respectée** : la classe *structurelle* (speedup déterminé par la taille du problème, ex `2^225` → `2.78e24x` #9427) reste légitime en prose ; la classe *machine-dépendante* (ms absolus, ratio sur instance fixe) est retirée.

### Modification

**Markdown-only** (raw-text byte surgery, +1/−1, 1 cellule). **Aucune cellule code touchée** → pas de re-exec (exception markdown C.2 : outputs précédents valides). Les sorties cell[10]/cell[27]/cell[49] sont inchangées et restent la source de vérité. `nbformat.validate` PASS.

### Twin-parity #8057

Search-8 DancingLinks est un jumeau Python/C# enregistré (sémantique). Le jumeau **C# est compact** (22 cells, pas de cellule de conclusion, aucun pin timing analogue — vérifié firsthand) → modification côté **Python uniquement**. Re-attestation `--update --pair` après commit (lit le blob commité) : `python_sha 16f7e7cd → ce86217d`, `csharp_sha` inchangé (`6f8406e9`). `check_twin_parity --check --per-pair --base origin/main` → Search-8 `base=OK head=OK` (**drift_introduced=0**). Reserve Sudoku-8/14-BDD/9 (DRIFT-PRE) intacte.

See #9434 (classe machine-dépendant), #9377, #8052. Pas de `Closes` (l'EPIC #9434 demande un census complet + note conventions + sign-off user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
