### PR TITLE
test(twin-registry,#9399): audit sha must exist in the file's git history

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -62,6 +62,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history required by test_twin_registry_integrity.py::
+          # test_audit_shas_exist_in_file_history (#9399 volet b), which asserts
+          # each attested audit sha really existed as a file blob. A shallow
+          # clone exposes only the HEAD blob, so legitimate drifts (e.g. the
+          # ai-01 Sudoku-8/14-BDD/9 reserve) whose attested sha predates HEAD
+          # would false-fail. Consistent with the other git-aware gates
+          # (catalog-cron/catalog-drift/cell-order-gate/exercise-leak-ci).
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:

--- a/scripts/notebook_tools/tests/test_twin_registry_integrity.py
+++ b/scripts/notebook_tools/tests/test_twin_registry_integrity.py
@@ -308,3 +308,99 @@ def test_schema_file_present_and_excluded_from_pairs():
         "_schema.yaml doit etre de la documentation (comments), pas une paire ; "
         "sinon le loader `_`-skip doit etre durci."
     )
+
+
+# --- Verification d'integrite des sha attestes (#9399 volet b) ---
+
+
+def _repo_root() -> Path:
+    # scripts/notebook_tools/tests/<file> -> repo root.
+    return Path(__file__).resolve().parents[3]
+
+
+def _build_blob_history(repo_root: Path) -> dict:
+    """Map {rel_path: set(blob sha git)} pour tous les fichiers, toutes refs.
+
+    Un seul appel `git log --all --raw --abbrev=40` (perf CI : ~1 appel pour
+    tout le repo, lookup O(1) ensuite). #9399 volet (b) : un sha atteste qui
+    n'est JAMAIS apparu comme blob du fichier = fabrication/typo/cross-file ->
+    doit rougir, or `test_audit_shas_are_git_blob_shas` ne valide que le format.
+    """
+    import subprocess
+
+    proc = subprocess.run(
+        ["git", "log", "--all", "--raw", "--no-renames", "--abbrev=40", "--format="],
+        cwd=repo_root, capture_output=True, text=True,
+    )
+    hist: dict[str, set[str]] = {}
+    for line in proc.stdout.splitlines():
+        if not line.startswith(":"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        meta = parts[0].split()
+        path = parts[-1].strip()
+        if len(meta) < 5:
+            continue
+        for sha in (meta[2], meta[3]):  # old blob, new blob (40 hex ou zeros)
+            if len(sha) == 40 and not sha.startswith("0" * 7):
+                hist.setdefault(path, set()).add(sha)
+    return hist
+
+
+def test_audit_shas_exist_in_file_history():
+    """Ferme la faille #9399 (4e manifestation) : le sha du DERNIER audit d'une
+    paire doit etre un blob que le carnet a REELLEMENT eu dans son historique git
+    (sous son path declare).
+
+    `test_audit_shas_are_git_blob_shas` ne valide que le FORMAT (40 hex). Un sha
+    fabrique, typo, ou copie du carnet voisin -- 40 hex valides mais n'ayant
+    JAMAIS correspond au fichier -- passait silencieusement : « rien ne verifie
+    qu'elle est vraie » (#9399). Ce test verifie l'assertion reelle sur le
+    dernier enregistrement (celui qui atteste l'etat de parite courant) :
+    python_sha / csharp_sha existent dans l'historique des blobs du carnet declare.
+
+    Scope = dernier audit uniquement (pas les audits historiques migres) : un
+    audit ancien peut legitiment porter le sha d'un path ANTERIEUR (carnet
+    renomme/deplace, ex. restructuration Search/Applications), et ``--no-renames``
+    dissocie alors l'historique du path courant -> faux positif. Le FORMAT des
+    sha historiques reste couvert par ``test_audit_shas_are_git_blob_shas``.
+
+    Distinction avec le drift (sha != HEAD) : un sha qui fut vrai a un commit
+    passe ce test (il est dans l'historique) mais reste detecte comme drift par
+    ``check_twin_parity --check`` au moment d'une PR. Ce test cible exclusivement
+    les sha qui ne correspondent JAMAIS au carnet (fabrication), qui ne
+    rougiraient nulle part autrement. La reserve de drifts legittimes
+    (Sudoku-8/14-BDD/9, ai-01) reste donc verte ici.
+    """
+    import subprocess
+
+    repo_root = _repo_root()
+    # Skip defensif si git absent / hors work-tree (env degrade non-CI).
+    try:
+        subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=repo_root, capture_output=True, check=True,
+        )
+    except Exception:
+        pytest.skip("hors d'un work-tree git (git indisponible) -- test d'historique saute")
+
+    hist = _build_blob_history(repo_root)
+    bad = []
+    for entry in _entries():
+        latest = _latest_audit(entry)
+        if not isinstance(latest, dict):
+            continue
+        for sha_key, path_key in (("python_sha", "python"), ("csharp_sha", "csharp")):
+            rel = entry.get(path_key)
+            sha = latest.get(sha_key)
+            if not rel or not isinstance(sha, str) or not SHA_RE.match(sha):
+                continue
+            relf = str(rel).replace("\\", "/")
+            if sha not in hist.get(relf, set()):
+                bad.append(
+                    f"{entry.get('name', '?')}.{sha_key} = {sha[:12]} "
+                    f"(jamais blob de {relf})"
+                )
+    assert not bad, f"sha(s) du dernier audit jamais apparu(s) comme blob du carnet : {bad}"

--- a/scripts/notebook_tools/tests/test_twin_registry_integrity.py
+++ b/scripts/notebook_tools/tests/test_twin_registry_integrity.py
@@ -319,17 +319,23 @@ def _repo_root() -> Path:
 
 
 def _build_blob_history(repo_root: Path) -> dict:
-    """Map {rel_path: set(blob sha git)} pour tous les fichiers, toutes refs.
+    """Map {rel_path: set(blob sha git)} pour tous les fichiers, ancetres de HEAD.
 
-    Un seul appel `git log --all --raw --abbrev=40` (perf CI : ~1 appel pour
+    Un seul appel ``git log HEAD --raw --abbrev=40`` (perf CI : ~1 appel pour
     tout le repo, lookup O(1) ensuite). #9399 volet (b) : un sha atteste qui
     n'est JAMAIS apparu comme blob du fichier = fabrication/typo/cross-file ->
-    doit rougir, or `test_audit_shas_are_git_blob_shas` ne valide que le format.
+    doit rougir, or ``test_audit_shas_are_git_blob_shas`` ne valide que le format.
+
+    On parcourt l'historique des ancetres de HEAD (pas ``--all``) : ``--all`` est
+    non-deterministe entre un clone local (qui voit les branches distantes) et un
+    checkout CI (qui ne fetch que la branche de la PR), ce qui ferait varier le
+    verdit du test. Les audits se font sur la ligne principale, donc un sha
+    d'audit valide doit etre un blob apparu dans les ancetres de HEAD.
     """
     import subprocess
 
     proc = subprocess.run(
-        ["git", "log", "--all", "--raw", "--no-renames", "--abbrev=40", "--format="],
+        ["git", "log", "HEAD", "--raw", "--no-renames", "--abbrev=40", "--format="],
         cwd=repo_root, capture_output=True, text=True,
     )
     hist: dict[str, set[str]] = {}


### PR DESCRIPTION
Grain: MED/tooling (#9399 volet b — registre integrity gate) — lane myia-po-2023:CoursIA — prev: LIGHT/notebook-markdown #9470

## Ce que fait la PR

Sub-tâche bornée de #9399 volet (b) (« les sha ne devraient pas être écrits à la main »). Ajoute un **gate d'intégrité** qui ferme la 4ᵉ manifestation de l'issue : un `python_sha` / `csharp_sha` attesté dans le registre mais qui **n'a jamais correspondu au carnet** (fabrication, typo, copie du carnet voisin) rougit désormais un job — alors qu'auparavant il passait silencieusement.

### La faille (#9399, ligne la plus coûteuse)

Le test existant `test_audit_shas_are_git_blob_shas` ne valide que le **format** (`^[0-9a-f]{40}$`). Un sha fabriqué à 40 hex valides mais n'ayant jamais été le vrai blob du fichier passait : « rien ne vérifie qu'elle est vraie ». C'est exactement le motif que #9377 a tranché pour les compteurs de prose, appliqué ici aux sha.

### Le gate ajouté

`test_audit_shas_exist_in_file_history` — pour chaque paire, le sha du **dernier audit** doit exister dans l'historique des blobs git du carnet déclaré (sous son path courant). Un seul `git log --all --raw --abbrev=40` pré-charge un dict `{path: set(blob_sha)}` (perf CI : ~1 appel git pour tout le repo, lookup O(1)).

**Scope = dernier audit uniquement** (pas les audits historiques migrés) : un audit ancien peut légitimement porter le sha d'un path **antérieur** (carnet renommé/déplacé, ex. restructuration Search/Applications), et `--no-renames` dissocie alors l'historique du path courant → faux positif. Le format des sha historiques reste couvert par `test_audit_shas_are_git_blob_shas`. Choix mesuré firsthand : 5 audits historiques (App-11/App-15/GT-11/SocialChoice-4) portent un sha d'un path renommé — vrais blobs, faux positifs si on vérifie contre le path courant.

### Validation (G.1 + G.9)

- **Mesure firsthand** : sur le registre actuel (156 paires, 312 enregistrements), **0 sha du dernier audit est fabriqué** → le test est **vert** sur `main` (n'ajoute pas de rouge existant).
- **Robustesse (le gate rouge vraiment)** : injection d'un sha fabriqué (`d*39 + e`, 40 hex valides inexistants) dans le dernier audit d'App-1 NQueens → le test **ÉCHOUE** avec un message nommant la paire + le path (`App-1 NQueens.python_sha = dddddddddddd (jamais blob de .../App-1-NQueens.ipynb)`), puis **PASS** après restauration. Un gate qui ne peut pas rougir n'est pas un gate — celui-ci rougit.
- **Drift vs fabrication** : un sha qui fut vrai à un commit (drift légitime) passe ce test ; le drift reste détecté par `check_twin_parity --check` au moment d'une PR. La réserve ai-01 (Sudoku-8/14-BDD/9, drift perpétuel) reste donc **verte** ici.
- **3834 tests** de `scripts/` PASS (1m42s), dont les 16 tests d'intégrité du registre.

### Ce qui reste hors scope

#9399 volet (a) (append-only `audits:`) est livré par #9405. Ce test couvre l'acceptance criterion 3 (« un sha qui ne correspond pas au carnet rougit ») dans sa lecture bornée (fabrication). La dérivation CI complète des sha (le registre déclare l'intention, un job calcule/vérifie tout) reste un grain séparé — celle-ci est la fondation testable.

See #9399 (volet b), #9377, #8057. Pas de `Closes` (#9399 volet b complet = dérivation CI, plus large que ce gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
