### PR TITLE
docs(probas,#9434): DecInfer-10 timing prose — ordre de grandeur, pas ms absolus

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
@@ -670,7 +670,7 @@
    "source": [
     "## 4. Reutiliser le moteur compile (problematique runtime)\n",
     "\n",
-    "Un bandit reel rejoue des centaines de fois, et le posterior de chaque bras evolue a chaque recompense. Si l'on reconstruisait le modèle a chaque pas, Infer.NET **recompilerait** a chaque fois (~236 ms par compilation, mesure en section 4.1). La solution : un modèle a **taille fixe** `MAX` ou un **masque** `mask[i]` dit quelles cases de `obs[i]` sont de vraies observations. On compile une fois, puis on met seulement a jour `ObservedValue` des tableaux : Infer.NET **reutilise** le code compile (~0,05 ms par re-inference, mesure en section 4.1 -- soit ~5000x moins qu'une compilation).\n",
+    "Un bandit reel rejoue des centaines de fois, et le posterior de chaque bras evolue a chaque recompense. Si l'on reconstruisait le modèle a chaque pas, Infer.NET **recompilerait** a chaque fois (plusieurs centaines de ms par compilation, cf. mesure §4.1 cellule suivante). La solution : un modèle a **taille fixe** `MAX` ou un **masque** `mask[i]` dit quelles cases de `obs[i]` sont de vraies observations. On compile une fois, puis on met seulement a jour `ObservedValue` des tableaux : Infer.NET **reutilise** le code compile (sub-milliseconde par re-inference sur modele pre-compile, cf. mesure §4.1 -- soit plusieurs ordres de grandeur de moins qu'une compilation).\n",
     "\n",
     "On encapsule ce pattern dans une classe `BayesArm` : un bras dont Infer.NET calcule le posterior."
    ]
@@ -1365,7 +1365,7 @@
     "## 8. Limites honnetes\n",
     "\n",
     "- **Cas conjugue favorable** : pour un bandit Bernoulli, le posterior Beta est analytique. L'apport d'Infer.NET n'est pas la (le moteur recouvre la formule fermee) mais dans la **generalisation** a des modèles non conjugues (ex. bras Gaussiennes de variance inconnue, effets contextuels) ou seule l'inference approchee (EP/VMP) sait calculer le posterior.\n",
-    "- **Cout d'inference** : chaque pas de Thompson requiert `K` inferences posteriors. Grace au modèle masque reutilise (~0,2 ms/call), cela reste negligeable pour `K` petit et `T` modere. Pour un grand `K` (centaines de bras) ou un modèle lourd, l'overhead devient un facteur — c'est la ou un posterior conjugue code a la main (cf DecInfer-8 section 8) garde sa place.\n",
+    "- **Cout d'inference** : chaque pas de Thompson requiert `K` inferences posteriors. Grace au modèle masque reutilise (sub-milliseconde/call, cf. mesure §4.1), cela reste negligeable pour `K` petit et `T` modere. Pour un grand `K` (centaines de bras) ou un modèle lourd, l'overhead devient un facteur — c'est la ou un posterior conjugue code a la main (cf DecInfer-8 section 8) garde sa place.\n",
     "- **Non-stationnarite** : si les vraies `theta*` changent au cours du temps, le posterior Beta s'accumule indefiniment et devient trop confident. Il faut alors introduire un **facteur d'oubli** (sliding window, discount) — voir exercice 2."
    ]
   },


### PR DESCRIPTION
Grain: MED/notebook-markdown (#9434 timing prose machine-dépendante) — lane myia-po-2023:CoursIA — prev: MED/notebook-markdown #9470

## Ce que fait la PR

Volet #9434 sur `DecInfer-10-Thompson-Sampling.ipynb` (Probas/DecisionTheory, Infer.NET Thompson Sampling) : la prose markdown ré-épinglait des **timings machine-dépendants** que la cellule output mesurait déjà, créant un double qui dérive dès que la machine change.

### Le defect (classe #9434 machine-dépendant)

`cell[12]` (intro §4) répétait dans la prose les 3 valeurs mesurées par `cell[15]` (la source de vérité) :

| cell[15] OUTPUT (source de vérité) | cell[12] PROSE (ré-épinglé, dérive) |
|---|---|
| `Compilation ... : 235,9 ms` | `~236 ms par compilation` |
| `Re-inference ... : 0,046 ms` | `~0,05 ms par re-inference` |
| `Ratio ... : 5100x` | `~5000x moins qu'une compilation` |

Et `cell[23]` (limites) : `~0,2 ms/call` — soit **~4× la valeur réelle** (0,046 ms), dans un contexte qualitatif.

Ces ms absolus + le ratio bruité (`236/0,05 ≈ 4720` arrondi à `5000x`) vont mismatcher `cell[15]` dès qu'un worker ré-exécute sur une autre machine (le mandat #9434 : « la vague #8052 re-épingle des valeurs qui rebougeront »).

### Le fix : ordre de grandeur qualitatif

`cell[14]` (intro §4.1) montrait **déjà le bon pattern** : `~centaines de ms`, `sub-milliseconde`. J'aligne `cell[12]` et `cell[23]` dessus, en pointant vers §4.1 / `cell[15]` comme source unique :

- `cell[12]` : `(plusieurs centaines de ms par compilation, cf. mesure §4.1 cellule suivante)` + `(sub-milliseconde par re-inference sur modele pre-compile, cf. mesure §4.1 -- soit plusieurs ordres de grandeur de moins qu'une compilation)`.
- `cell[23]` : `(sub-milliseconde/call, cf. mesure §4.1)`.

Le claim qualitatif (« compilation coûteuse, re-inference négligeable, plusieurs ordres de grandeur d'écart ») est **préservé** — seule la précision machine-dépendante est retirée.

## Verification firsthand (G.1)

- **Raw-text byte surgery** (`raw.replace` ×3, assertion `count==1`), +2/−2 sur 2 cellules **markdown uniquement**. `nbformat.validate` PASS, 32 cells inchangées.
- **0 cellule code touchée** : `git diff` montre uniquement 2 lignes `"source"` markdown. `execution_count is None` = 0 → **outputs préservés** (règle C.2 exception markdown : pas de re-exec).
- **Source de vérité confirmée** : `cell[15]` output contient bien `235,9 ms` / `0,046 ms` / `5100x` — c'est la mesure réelle, laissée intacte comme single source of truth.
- **Pas une paire twin** (`grep -l DecInfer-10 twin_pairs.d/` = 0) → pas de rebaseline registre.

## Hors scope

- Autres notebooks Sudoku/ML de la même veine (31 notebooks ont des hits `ms` en markdown) : la majorité pointent déjà vers une cellule output ou sont des fourchettes legit. DecInfer-10 était le cas net (prose dupliquée + ratio bruité + valeur 4× off). Vague #8052 drainée en fresh families ; ce grain est un résiduel isolé.
- #9470 (Search-8 DancingLinks) traitait la même classe sur une autre famille.

See #9434 (EPIC quantitatif-tenu-par-CI), #8052, #9377, #9470 (Search-8 même veine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
