### PR TITLE
docs(lean,#8052): reconcile decision_theory_lean README stale version + line-counts vs disk

### DIFF
--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/README.en.md
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/README.en.md
@@ -38,7 +38,7 @@ Lean companion notebook:
   the latter via the `Float→ℝ` port PR #5272). The **entire `Utility` and `Coherence`
   modules = 0 sorry** (fully proven, open milestones documented, not `sorry`-backed).
 - **Build**: `lake build Gittins Utility Coherence` (depends on Mathlib4)
-- **Dependencies**: Mathlib4 (`v4.30.0-rc2`) — real analysis for the discount lemmas,
+- **Dependencies**: Mathlib4 (`v4.31.0-rc1`) — real analysis for the discount lemmas,
   the ordered and affine structure of `ℝ` for vNM, `Finset` / inclusion–exclusion for
   de Finetti coherence
 
@@ -57,7 +57,7 @@ The formalization is split into a **proven** layer and a **stated** layer:
   `discount_monotone` (γ₁ ≤ γ₂ ⇒ ∑' γ₁^n ≤ ∑' γ₂^n). `discount_monotone` is
   proven **closed-form** via `geometric_series_converges` +
   `one_div_le_one_div_of_le`, sidestepping the missing `tsum_le_tsum` on bare `ℝ`
-  in Mathlib v4.30.0-rc2.
+  in Mathlib v4.31.0-rc1.
 - **Stated, intractable** (`GittinsTheorem.lean`): `gittinsIndex` (optimal
   stopping), `gittins_optimality` (the central theorem — the index policy maximizes
   expected discounted reward). The **2 residual `sorry`** are in the assembly of
@@ -71,18 +71,18 @@ The formalization is split into a **proven** layer and a **stated** layer:
 
 | File | Lines | sorry | Content |
 |------|-------|-------|---------|
-| `Gittins/Basic.lean` | 37 | 0 | Core types — `BanditArm`, `BanditInstance` (arms + discount γ), `Policy := Nat → Nat`, `RewardHistory`, `pullCount`, `empiricalMean`. Pure Lean 4, no Mathlib. |
-| `Gittins/Discount.lean` | 107 | 0 | Geometric discounting **proven** via Mathlib real analysis: `geometric_series_converges`, `one_minus_gamma_pos`, `present_value_constant`, `discount_monotone`. **Finite partial-sum companion** (PR #4252): `geometricPartialSum γ n` with `_zero`/`_succ` (telescoping recurrence) and `_closed` (closed form `(1−γ^n)/(1−γ)`). |
-| `Gittins/GittinsTheorem.lean` | 145 | 2 | The marquee theorem **partially proven**: `gittinsIndex` (def proven = `trueMean` in the known-mean model), `gittinsPolicy` (argmax), `gittins_index_known_arm` (**proven** `rfl`), `gittins_index_monotone_discount` (**proven** PR #5272 — `Float→ℝ` port, barrier B closed), `gittins_optimality` (sorry — MDP-intrinsic). (`gittins_beats_greedy` is a `: True := trivial` placeholder, not a sorry.) |
-| `Gittins.lean` | 19 | 0 | Umbrella imports |
-| `Utility/Basic.lean` | 91 | 0 | vNM primitives — `Lottery` (lottery on `Fintype`), `expectation`, convex `mix`, affine expectation identities (`expectation_mix`, `expectation_add`, `expectation_smul`, `expectation_const`, `expectation_affine`). |
-| `Utility/Axioms.lean` | 65 | 0 | The **four vNM axioms** — `IsComplete`, `IsTransitive`, `IsIndependent`, `IsContinuous` (mixture solvability), `IsRational`, plus `StrictPref`. |
-| `Utility/Representation.lean` | 236 | 0 | **Sound direction proven** (`rep_complete`, `rep_transitive`, `rep_independent`, `rep_continuous`, `expected_utility_rep_is_rational`) + **affine stability** (`affine_rep_is_rep`) + **strict/indifference characterization** (PR #4250: `rep_strict_iff` `StrictPref ↔ E_p > E_q`, `rep_indifference_iff`, `strict_irrefl`). Existence direction documented as open milestone. |
-| `Utility.lean` | ~30 | 0 | Umbrella imports + status doc |
+| `Gittins/Basic.lean` | 41 | 0 | Core types — `BanditArm`, `BanditInstance` (arms + discount γ), `Policy := Nat → Nat`, `RewardHistory`, `pullCount`, `empiricalMean`. Pure Lean 4, no Mathlib. |
+| `Gittins/Discount.lean` | 109 | 0 | Geometric discounting **proven** via Mathlib real analysis: `geometric_series_converges`, `one_minus_gamma_pos`, `present_value_constant`, `discount_monotone`. **Finite partial-sum companion** (PR #4252): `geometricPartialSum γ n` with `_zero`/`_succ` (telescoping recurrence) and `_closed` (closed form `(1−γ^n)/(1−γ)`). |
+| `Gittins/GittinsTheorem.lean` | 154 | 2 | The marquee theorem **partially proven**: `gittinsIndex` (def proven = `trueMean` in the known-mean model), `gittinsPolicy` (argmax), `gittins_index_known_arm` (**proven** `rfl`), `gittins_index_monotone_discount` (**proven** PR #5272 — `Float→ℝ` port, barrier B closed), `gittins_optimality` (sorry — MDP-intrinsic). (`gittins_beats_greedy` is a `: True := trivial` placeholder, not a sorry.) |
+| `Gittins.lean` | 36 | 0 | Umbrella imports |
+| `Utility/Basic.lean` | 96 | 0 | vNM primitives — `Lottery` (lottery on `Fintype`), `expectation`, convex `mix`, affine expectation identities (`expectation_mix`, `expectation_add`, `expectation_smul`, `expectation_const`, `expectation_affine`). |
+| `Utility/Axioms.lean` | 77 | 0 | The **four vNM axioms** — `IsComplete`, `IsTransitive`, `IsIndependent`, `IsContinuous` (mixture solvability), `IsRational`, plus `StrictPref`. |
+| `Utility/Representation.lean` | 348 | 0 | **Sound direction proven** (`rep_complete`, `rep_transitive`, `rep_independent`, `rep_continuous`, `expected_utility_rep_is_rational`) + **affine stability** (`affine_rep_is_rep`) + **strict/indifference characterization** (PR #4250: `rep_strict_iff` `StrictPref ↔ E_p > E_q`, `rep_indifference_iff`, `strict_irrefl`). Existence direction documented as open milestone. |
+| `Utility.lean` | 45 | 0 | Umbrella imports + status doc |
 | `Coherence/Basic.lean` | 52 | 0 | Finetti primitives — `Event` (= `Finset Ω`), `Price` (= `Event Ω → ℝ`), indicator `ind`, and the keystone `ind_inclusion_exclusion`. |
 | `Coherence/DutchBook.lean` | 101 | 0 | **Constructive direction proven** (`non_additive_implies_dutch_book`, explicit stakes `(1,1,−1,−1)`/inverse) + contrapositive `coherent_on_implies_additive`. Full reciprocal (LP duality) documented as open milestone. |
-| `Coherence/Probability.lean` | 255 | 0 | **Single-ticket coherence** (PR #4193: `single_coherent_iff_prob_bounds` — iff between single-ticket coherence and probability bounds `0 ≤ q ≤ 1`, via trichotomy on stake sign + explicit Dutch Books) + **weights-to-coherence** (PR #4244: `priceFromWeights_single_coherent`). The full `coherent_iff_probability` (arbitrary book sizes) remains open. |
-| `Coherence.lean` | 33 | 0 | Umbrella imports + status doc |
+| `Coherence/Probability.lean` | 367 | 0 | **Single-ticket coherence** (PR #4193: `single_coherent_iff_prob_bounds` — iff between single-ticket coherence and probability bounds `0 ≤ q ≤ 1`, via trichotomy on stake sign + explicit Dutch Books) + **weights-to-coherence** (PR #4244: `priceFromWeights_single_coherent`). The full `coherent_iff_probability` (arbitrary book sizes) remains open. |
+| `Coherence.lean` | 49 | 0 | Umbrella imports + status doc |
 
 ## Why the optimality theorem is intractable
 
@@ -93,7 +93,7 @@ A complete proof of `gittins_optimality` requires:
 3. **Induction on the planning horizon**, and
 4. A **formal expected value** over the reward distribution.
 
-Mathlib (v4.30.0-rc2) has **no MDP, bandit, or Bellman-equation** formalization,
+Mathlib (v4.31.0-rc1) has **no MDP, bandit, or Bellman-equation** formalization,
 nor a measure-theoretic expected-value API suitable here. A full proof is
 estimated at ~2000–5000 lines of supporting definitions — research-level, beyond
 a single PR. The theorem is therefore **stated** (with the precise statement

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/README.md
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/README.md
@@ -51,7 +51,7 @@ Notebook compagnon Lean :
   fidèlement — d'où le total lake standalone-sorry = 4). `Utility` et `Coherence`
   disposent aussi de leurs siblings EN.
 - **Build** : `lake build Gittins Utility Coherence` (dépend de Mathlib4)
-- **Dépendances** : Mathlib4 (`v4.30.0-rc2`) — analyse réelle pour les lemmes
+- **Dépendances** : Mathlib4 (`v4.31.0-rc1`) — analyse réelle pour les lemmes
   d'actualisation, structure ordonnée et affine de `ℝ` pour vNM, théorie des `Finset`
   / inclusion–exclusion pour la cohérence de de Finetti
 
@@ -71,7 +71,7 @@ La formalisation est scindée en une couche **prouvée** et une couche **énonc�
   `discount_monotone` (γ₁ ≤ γ₂ ⇒ ∑' γ₁^n ≤ ∑' γ₂^n). `discount_monotone` est prouvé
   **en forme close** via `geometric_series_converges` +
   `one_div_le_one_div_of_le`, en contournant l'absence de `tsum_le_tsum` sur le `ℝ`
-  nu dans Mathlib v4.30.0-rc2.
+  nu dans Mathlib v4.31.0-rc1.
 - **Énoncé, intractable** (`GittinsTheorem.lean`) : `gittinsIndex` (arrêt optimal),
   `gittins_optimality` (le théorème central — la politique à indice maximise la
   récompense actualisée espérée). Les **2 `sorry` résiduels** sont dans l'assemblage de
@@ -207,18 +207,18 @@ vNM, qui porte sur les *préférences* sous risque), mais purement *épistémiqu
 
 | Fichier | Lignes | sorry | Contenu |
 |---------|--------|-------|---------|
-| `Gittins/Basic.lean` | 37 | 0 | Types fondamentaux — `BanditArm`, `BanditInstance` (bras + actualisation γ), `Policy := Nat → Nat`, `RewardHistory`, `pullCount`, `empiricalMean`. Lean 4 pur, sans Mathlib. |
-| `Gittins/Discount.lean` | 107 | 0 | Actualisation géométrique **prouvée** via l'analyse réelle de Mathlib : `geometric_series_converges`, `one_minus_gamma_pos`, `present_value_constant`, `discount_monotone`. **Compagnon somme partielle finie** (PR #4252) : `geometricPartialSum γ n = ∑₀..n γ^k` avec `geometricPartialSum_zero`/`_succ` (récurrence télescopique) et `geometricPartialSum_closed` (forme close `(1−γ^n)/(1−γ)`). |
-| `Gittins/GittinsTheorem.lean` | 145 | 2 | Théorème phare **partiellement prouvé** : `gittinsIndex` (def prouvée = `trueMean` dans le modèle à moyenne connue), `gittinsPolicy` (argmax), `gittins_index_known_arm` (**prouvé** `rfl`), `gittins_index_monotone_discount` (**prouvé** PR #5272 — port `Float→ℝ`, barrière B fermée), `gittins_optimality` (sorry — MDP-intrinsic). Voir « État honnête » ci-dessous. (`gittins_beats_greedy` = placeholder `: True := trivial`, pas un sorry.) |
-| `Gittins.lean` | 19 | 0 | Imports parapluie |
-| `Utility/Basic.lean` | 91 | 0 | Primitives vNM — `Lottery` (loterie sur `Fintype`), `expectation`, mélange convexe `mix` (preuve de validité), identités affine d'espérance (`expectation_mix`, `expectation_add`, `expectation_smul`, `expectation_const`, `expectation_affine`). |
-| `Utility/Axioms.lean` | 65 | 0 | Les **quatre axiomes vNM** — `IsComplete`, `IsTransitive`, `IsIndependent`, `IsContinuous` (solvabilité des mélanges), `IsRational`, plus `StrictPref`. |
-| `Utility/Representation.lean` | 236 | 0 | **Direction saine prouvée** (`rep_complete`, `rep_transitive`, `rep_independent`, `rep_continuous`, `expected_utility_rep_is_rational`) + **stabilité affine** (`affine_rep_is_rep`) + **caractérisation stricte/indifférence** (PR #4250 : `rep_strict_iff` `StrictPref ↔ E_p > E_q`, `rep_indifference_iff` `(P p q ∧ P q p) ↔ E_p = E_q`, `strict_irrefl`). Direction d'existence documentée comme jalon ouvert. |
-| `Utility.lean` | ~30 | 0 | Imports parapluie + doc de statut |
+| `Gittins/Basic.lean` | 41 | 0 | Types fondamentaux — `BanditArm`, `BanditInstance` (bras + actualisation γ), `Policy := Nat → Nat`, `RewardHistory`, `pullCount`, `empiricalMean`. Lean 4 pur, sans Mathlib. |
+| `Gittins/Discount.lean` | 109 | 0 | Actualisation géométrique **prouvée** via l'analyse réelle de Mathlib : `geometric_series_converges`, `one_minus_gamma_pos`, `present_value_constant`, `discount_monotone`. **Compagnon somme partielle finie** (PR #4252) : `geometricPartialSum γ n = ∑₀..n γ^k` avec `geometricPartialSum_zero`/`_succ` (récurrence télescopique) et `geometricPartialSum_closed` (forme close `(1−γ^n)/(1−γ)`). |
+| `Gittins/GittinsTheorem.lean` | 154 | 2 | Théorème phare **partiellement prouvé** : `gittinsIndex` (def prouvée = `trueMean` dans le modèle à moyenne connue), `gittinsPolicy` (argmax), `gittins_index_known_arm` (**prouvé** `rfl`), `gittins_index_monotone_discount` (**prouvé** PR #5272 — port `Float→ℝ`, barrière B fermée), `gittins_optimality` (sorry — MDP-intrinsic). Voir « État honnête » ci-dessous. (`gittins_beats_greedy` = placeholder `: True := trivial`, pas un sorry.) |
+| `Gittins.lean` | 36 | 0 | Imports parapluie |
+| `Utility/Basic.lean` | 96 | 0 | Primitives vNM — `Lottery` (loterie sur `Fintype`), `expectation`, mélange convexe `mix` (preuve de validité), identités affine d'espérance (`expectation_mix`, `expectation_add`, `expectation_smul`, `expectation_const`, `expectation_affine`). |
+| `Utility/Axioms.lean` | 77 | 0 | Les **quatre axiomes vNM** — `IsComplete`, `IsTransitive`, `IsIndependent`, `IsContinuous` (solvabilité des mélanges), `IsRational`, plus `StrictPref`. |
+| `Utility/Representation.lean` | 348 | 0 | **Direction saine prouvée** (`rep_complete`, `rep_transitive`, `rep_independent`, `rep_continuous`, `expected_utility_rep_is_rational`) + **stabilité affine** (`affine_rep_is_rep`) + **caractérisation stricte/indifférence** (PR #4250 : `rep_strict_iff` `StrictPref ↔ E_p > E_q`, `rep_indifference_iff` `(P p q ∧ P q p) ↔ E_p = E_q`, `strict_irrefl`). Direction d'existence documentée comme jalon ouvert. |
+| `Utility.lean` | 45 | 0 | Imports parapluie + doc de statut |
 | `Coherence/Basic.lean` | 52 | 0 | Primitives de Finetti — `Event` (= `Finset Ω`), `Price` (= `Event Ω → ℝ`), indicatrice `ind`, et la clé de voûte `ind_inclusion_exclusion` (inclusion–exclusion des indicatrices). |
 | `Coherence/DutchBook.lean` | 101 | 0 | **Direction constructive prouvée** (`non_additive_implies_dutch_book`, mises explicites `(1,1,−1,−1)`/inverse) + contraposée `coherent_on_implies_additive`. Réciproque (dualité LP) documentée comme jalon ouvert. |
-| `Coherence/Probability.lean` | 255 | 0 | **Cohérence mono-ticket** (PR #4193 : `single_coherent_iff_prob_bounds` — *iff* entre cohérence d'un ticket unique et bornes de probabilité `0 ≤ q ≤ 1`, via trichotomie du signe de la mise + Dutch Books explicites pour chaque borne violée) + **des poids à la cohérence** (PR #4244 : `priceFromWeights_single_coherent` — des poids additifs normalisés on dérive une fonction de prix mono-cohérente). Le `coherent_iff_probability` complet (livrets de taille arbitraire) reste ouvert. |
-| `Coherence.lean` | 33 | 0 | Imports parapluie + doc de statut |
+| `Coherence/Probability.lean` | 367 | 0 | **Cohérence mono-ticket** (PR #4193 : `single_coherent_iff_prob_bounds` — *iff* entre cohérence d'un ticket unique et bornes de probabilité `0 ≤ q ≤ 1`, via trichotomie du signe de la mise + Dutch Books explicites pour chaque borne violée) + **des poids à la cohérence** (PR #4244 : `priceFromWeights_single_coherent` — des poids additifs normalisés on dérive une fonction de prix mono-cohérente). Le `coherent_iff_probability` complet (livrets de taille arbitraire) reste ouvert. |
+| `Coherence.lean` | 49 | 0 | Imports parapluie + doc de statut |
 
 ## État honnête du verrou Gittins (déc. 2026, #4039)
 
@@ -263,7 +263,7 @@ Une preuve complète de `gittins_optimality` requiert :
 3. Une **récurrence sur l'horizon de planification**, et
 4. Une **espérance formelle** sur la distribution de récompense.
 
-Mathlib (v4.30.0-rc2) n'a **aucune formalisation de MDP, de bandit ou d'équation de
+Mathlib (v4.31.0-rc1) n'a **aucune formalisation de MDP, de bandit ou d'équation de
 Bellman**, ni d'API d'espérance mesurée-théorique adaptée ici. Une preuve complète est
 estimée à ~2000–5000 lignes de définitions support — de niveau recherche, au-delà
 d'une seule PR. Le théorème est donc **énoncé** (avec l'énoncé précis préservé dans


### PR DESCRIPTION
Grain: MED/readme (#8052 decision_theory_lean README reconcile — stale Mathlib version + line-counts) — lane myia-po-2023:CoursIA — prev: MED/notebook-markdown #9474

## Ce que fait la PR

Réconcilie les **claims stale** du README de `Probas/decision_theory_lean` (FR `README.md` + EN `README.en.md` préservé) contre l'état réel du lake sur `origin/main`. Deux classes de défauts #8052 (claims vs outputs/disk), vérifiées firsthand :

### 1. Version Mathlib stale (6 pins)
Le README citait **Mathlib `v4.30.0-rc2`** en 3 endroits (FR l.54/74/266, EN l.41/60/96) — mais le lake est sur **`v4.31.0-rc1`** :
- `lean-toolchain` = `leanprover/lean4:v4.31.0-rc1`
- `lakefile.lean` `require mathlib ... @ "v4.31.0-rc1"`

Resync `v4.30.0-rc2` → `v4.31.0-rc1` (ENV-stable, mémoire `env-metadata-stable-vs-volatile`).

### 2. Table modules : 10/12 line-counts stale
La table « Modules » documentait des comptes de lignes périmés (les `.lean` ont grandi depuis — travail i18n/PR). Réconcilié vs `wc -l` sur `origin/main` :

| Fichier | README (stale) | réel (origin/main) |
|---|---|---|
| `Gittins/Basic.lean` | 37 | 41 |
| `Gittins/Discount.lean` | 107 | 109 |
| `Gittins/GittinsTheorem.lean` | 145 | 154 |
| `Gittins.lean` | 19 | 36 |
| `Utility/Basic.lean` | 91 | 96 |
| `Utility/Axioms.lean` | 65 | 77 |
| `Utility/Representation.lean` | 236 | 348 |
| `Utility.lean` | ~30 | 45 |
| `Coherence/Probability.lean` | 255 | 367 |
| `Coherence.lean` | 33 | 49 |

(`Coherence/Basic.lean` = 52 et `Coherence/DutchBook.lean` = 101 étaient déjà corrects — non touchés.)

## Ce qui n'est PAS touché (vérifié firsthand, G.1)

- **Colonne sorry = ACCURATE**, préservée. Le README claim « 2 sorry dans GittinsTheorem, 0 ailleurs » — vérifié : les `grep -c sorry` naïfs renvoyaient 6 sur `Representation.lean` / 3 sur `DutchBook.lean`, mais ce sont tous des **commentaires** (« sorry-free », « 0 sorry », « non sorry-backed »), pas des tactics. Vrais `sorry` tactics = 2 (GittinsTheorem l.99/103), 0 ailleurs. Blind-spot `lean-sorry-count-block-comment-blindspot` évité — pas de PR phantom « sorry regression ».
- **Section i18n (#4980)** accurate : documente correctement les 3 modules (Gittins/Utility/Coherence) avec siblings `_en` (vérifié : 12/12 paires byte-identical).
- **Catalogue / marqueurs CATALOG-STATUS** : aucun dans ce README (lake README, pas série). Pas de churn catalogue.
- **FR-first préservé** : `README.md` (FR canonique) + `README.en.md` (EN miroir) édités en sync.

## Verification firsthand (G.1)

- Mesures `wc -l` + `lean-toolchain` + `lakefile` faites sur un **worktree frais depuis `origin/main`** (l'arbre partagé po-2023 est stale+dirty : ahead 7583/behind 491 — il donnait des counts DIFFÉRENTS et plus anciens, ex. Representation 329 vs 348 sur origin/main). Bien vérifié contre `origin/main`, pas l'arbre partagé.
- Script de réconciliation avec `assert count==1` par remplacement (26/26 réussis), post-check `v4.30.0-rc2` absent + `v4.31.0-rc1` présent dans les deux READMEs. Diff = 26+/26−, 0 changement hors-scope. Pas de BOM introduit (UTF-8 préservé).

See #8052 (claims vs outputs/disk), #3973 (README feuille), #4980 (Lean i18n — section accurate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
