### PR TITLE
feat(prose-guard,#9434): extend scanner with reproducibility taxonomy (machine/env/stochastic/structural)

### DIFF
--- a/scripts/notebook_tools/check_prose_quantitative_claims.py
+++ b/scripts/notebook_tools/check_prose_quantitative_claims.py
@@ -1,7 +1,8 @@
 """Refuse les compteurs quantitatifs ecrits a la main dans la prose.
 
 Mandat user 2026-08-04 : « les donnees quantitatives doivent etre tenues par le
-CI, pas dans la prose manuelle ». Registre : issue #9377.
+CI, pas dans la prose manuelle ». Registre : issue #9377 (compteurs d'artefacts
+du depot) ET issue #9434 (mesures non reproductibles : machine/env/stochastique).
 
 Le catalogue genere (`COURSE_CATALOG.generated.*` + marqueurs `CATALOG-STATUS`)
 a ete mis en place parce que les agents ouvraient des PR sans fin pour
@@ -39,13 +40,51 @@ D'ou le mode advisory par defaut -- l'arbitrage est humain. Ne PAS « corriger �
 un chiffre d'incident au motif que le guard l'a signale : ce serait supprimer
 la preuve pour faire taire l'organe.
 
+Taxonomie #9434 -- quatre classes de mesures non reproductibles
+---------------------------------------------------------------
+Le scanner couvre desormais, en plus du compteur d'artefacts #9377, les quatre
+classes de l'EPIC #9434 (mesures que la prose ne devrait pas figer parce qu'elles
+ne se recalculent pas a l'execution) :
+
+  - ``artifact``   (defaut, #9377) : nombre colle a un artefact du depot
+                    (« 140 lignes », « 224 notebooks »). Derive a chaque commit.
+  - ``machine``    (#9434) : duree absolue machine-dependante (« 24-127 ms »,
+                    « ~530 ms », « 1.9 s »). Derive avec la charge machine.
+  - ``env``        (#9434) : version de librairie/ecosystem figee en prose
+                    (« NumPy 2.4.2 », « Mathlib v4.31.0-rc1 »). Derive quand
+                    l'environnement monte de version -- doit etre tenu par le
+                    fichier d'environnement (toolchain, requirements), pas la prose.
+  - ``stochastic`` (#9434) : valeur a flotant non reproductible (« fitness 41.71 »)
+                    quand le carnet ne seme pas (pas de seed amont). Derive a
+                    chaque execution.
+  - ``structural`` (#9434) : ordre de grandeur d'un speedup determine par la
+                    taille du probleme (« 2.78e24x », « 4x »). **LEGITIME en
+                    prose** : deterministe, ne derive pas. Explicitement EXCLU
+                    du signalement -- il faut le demander explicitement
+                    (``--class structural``) pour le voir inventorier, et il
+                    ne fait jamais echouer.
+
+La classe par defaut reste ``artifact`` : le contrat CI
+(``prose-counts-guard.yml`` appelle ``--diff`` sans ``--class``) est preserve
+exact. Les classes #9434 s'auditent en opt-in, pour poser le before/after d'un
+drainage par classe.
+
 Usage
 -----
-    # CI sur une PR : ne juge que les lignes AJOUTEES
+    # CI sur une PR : ne juge que les lignes AJOUTEES (classe artifact, defaut)
     python check_prose_quantitative_claims.py --diff origin/main...HEAD
 
-    # Inventaire du stock restant (suivi #9377)
+    # Inventaire du stock #9377 restant
     python check_prose_quantitative_claims.py --all
+
+    # Inventaire d'une classe #9434 (drainage)
+    python check_prose_quantitative_claims.py --all --class machine
+    python check_prose_quantitative_claims.py --all --class env
+    python check_prose_quantitative_claims.py --all --class stochastic
+    python check_prose_quantitative_claims.py --all --class structural  # legitime, rc=0
+
+    # Toutes les classes flaggables (artifact + machine + env + stochastic)
+    python check_prose_quantitative_claims.py --all --class all
 
     # Bloquant (une fois le stock vide)
     python check_prose_quantitative_claims.py --diff origin/main...HEAD --strict
@@ -60,6 +99,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+# ----------------------------------------------------------------------------
+# Classe « artifact » (#9377) -- compteurs d'artefacts du depot
+# ----------------------------------------------------------------------------
 # Noms d'artefacts du depot. Un nombre colle a l'un d'eux est une mesure d'etat
 # du depot, donc perissable. Volontairement restreint : « 4 proprietes de Nash »
 # ou « 3 joueurs » sont du contenu pedagogique, pas de l'etat de depot, et ne
@@ -72,6 +114,93 @@ COUNT_RE = re.compile(
     r"(?<![\w.])~?\*{0,2}\d{1,6}\*{0,2}\s+" + ARTIFACT_NOUNS + r"(?![\w-])",
     re.IGNORECASE,
 )
+
+# ----------------------------------------------------------------------------
+# Classe « machine » (#9434) -- durees absolues machine-dependantes
+# ----------------------------------------------------------------------------
+# Formes attrapees : « 24-127 ms », « ~144 ms », « 0.006 ms », « ~1.9 sec »,
+# « 0.2 s », « 2 min ». Unite monolettre « s » (secondes) exige un espace
+# avant elle pour eviter les collisions (suffixes, abreviations) ; les unites
+# multilettres (ms/sec/min/...) tolerent un espace optionnel. Advisory : un FP
+# residuel est acceptable, l'arbitrage est humain (cf angle-mort header).
+MACHINE_RE = re.compile(
+    r"(?<![\w.])~?\d{1,6}(?:[.,]\d{1,3})?"
+    r"(?:"
+    r"\s?(?:ms|millisecondes?|sec(?:ondes?)?|min(?:utes?)?)"
+    r"|\ss"
+    r")"
+    r"(?![\w-])",
+    re.IGNORECASE,
+)
+
+# ----------------------------------------------------------------------------
+# Classe « env » (#9434) -- versions de librairie/ecosystem figees en prose
+# ----------------------------------------------------------------------------
+# Formes attrapees : « NumPy 2.4.2 », « JAX 0.4 », « Mathlib v4.31.0-rc1 »,
+# « PyTorch 2.1.0 ». Une version en prose derive quand l'env monte ; elle doit
+# etre portee par le fichier d'environnement (lean-toolchain, requirements,
+# .csproj), pas par la prose. Liste curee des libs presentes dans le depot.
+ENV_LIBS = (
+    r"NumPy|Pandas|PyTorch|TensorFlow|Keras|scikit-learn|sklearn|SciPy|"
+    r"Transformers|LangChain|spaCy|OpenCV|cv2|Matplotlib|Seaborn|NetworkX|"
+    r"SymPy|PyMC|ArviZ|Statsmodels|XGBoost|LightGBM|ONNX|vLLM|fastembed|"
+    r"jpype|Tweety|OpenSpiel|SemanticKernel|Mathlib|JAX|PyPhi|pyphi"
+)
+ENV_RE = re.compile(
+    r"\b(?:" + ENV_LIBS + r")\s+v?\d+(?:\.\d+){1,3}\b",
+    re.IGNORECASE,
+)
+
+# ----------------------------------------------------------------------------
+# Classe « stochastic » (#9434) -- valeurs non reproductibles sans seed
+# ----------------------------------------------------------------------------
+# Une mesure a virgule (>=2 decimales, signature d'un resultat numerique) co-
+# occurrent avec un mot-clef de metrique stochastique sur la meme ligne. Pour
+# un .ipynb, on n'accepte le signalement QUE si le carnet ne seme pas (aucun
+# seed amont) ; un carnet seme est reproductible, le chiffre est legitime. Pour
+# un .md isole (pas de cellule code amont a verifier), on signale en advisory
+# en documentant l'incertitude. Heuristique conservatrice : un carnet avec un
+# seed n'importe ou est suppose reproductible.
+STOCHASTIC_KW_RE = re.compile(
+    r"\b(?:fitness|accuracy|pr[eé]cision|score|scores|loss|perte|pertes|"
+    r"rendement|f1|wer|bleu|entropy|entropie|exactitude|rappel|recall|"
+    r"auc|roc|moyenne|moyen)\b",
+    re.IGNORECASE,
+)
+STOCHASTIC_NUM_RE = re.compile(r"(?<![\w.])~?\*{0,2}\d{1,6}\.\d{2,}\*{0,2}(?![\w])")
+SEED_RE = re.compile(
+    r"(?:np\.random\.seed|numpy\.random\.seed|random\.seed|"
+    r"torch\.manual_seed|tf\.random\.set_seed|jax\.random\.PRNGKey|"
+    r"random_state\s*=|seed\s*=\s*\d|rng\s*=\s*\d)",
+    re.IGNORECASE,
+)
+
+# ----------------------------------------------------------------------------
+# Classe « structural » (#9434) -- speedup deterministe par taille (LEGITIME)
+# ----------------------------------------------------------------------------
+# Formes attrapees : « 2.78e24x », « 2.78e24 », « 4x », « 1,5x ». C'est l'ordre
+# de grandeur d'un speedup fixe par la taille du probleme : deterministe, ne
+# derive pas. Explicitement EXCLU du signalement (header taxonomie #9434) ;
+# ne figure que sur demande explicite ``--class structural``, en banniere LEGITIME.
+STRUCTURAL_RE = re.compile(
+    r"(?<![\w.])~?\d+(?:[.,]\d+)?(?:e\d+|x)\b",
+    re.IGNORECASE,
+)
+
+# Classes reconnues par --class. L'ordre sert seulement a l'affichage.
+CLASS_CHOICES = ("artifact", "machine", "env", "stochastic", "structural", "all")
+# Classes flaggables (peuvent faire echouer en --strict). « structural » exclu.
+FLAGGABLE = ("artifact", "machine", "env", "stochastic")
+
+
+def _resolve_classes(klass: str) -> tuple[set[str], bool]:
+    """Rend (ensemble de classes a detecter, est_purement_structural)."""
+    if klass == "all":
+        return set(FLAGGABLE), False
+    if klass == "structural":
+        return {"structural"}, True
+    return {klass}, False
+
 
 # Une ligne de diff .ipynb qui ouvre un champ JSON autre que "source" est une
 # metadonnee machine-ecrite, pas de la prose.
@@ -140,25 +269,69 @@ def _iter_markdown_sources(nb_path: Path):
         yield idx, src
 
 
-def _findings_in_text(text: str, location: str) -> list[tuple[str, str]]:
-    out = []
+def _notebook_is_seeded(nb_path: Path) -> bool:
+    """Vrai si le carnet seme (une cellule code contient un seed).
+
+    Heuristique conservatrice : un seed n'importe ou dans le carnet rend le
+    resultat reproductible, donc la mesure stochastique est legitime.
+    """
+    try:
+        nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False  # indetermine -> on ne supprime pas le signalement
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        src = cell.get("source", "")
+        if isinstance(src, list):
+            src = "".join(src)
+        if SEED_RE.search(src):
+            return True
+    return False
+
+
+def _findings_in_text(text: str, location: str, classes: set[str]) -> list[tuple[str, str, str]]:
+    """Rend [(location, classe, snippet)] pour les classes demandees.
+
+    La ligne est l'unite de co-occurrence pour stochastic (mot-clef + nombre sur
+    la meme ligne) : evite les faux positifs d'un nombre et d'un mot-clef eloignes.
+    """
+    out: list[tuple[str, str, str]] = []
     for line in text.splitlines():
         if any(m in line for m in GENERATED_MARKERS):
             continue
-        for match in COUNT_RE.finditer(line):
-            out.append((location, match.group(0).strip()))
+        if "artifact" in classes:
+            for m in COUNT_RE.finditer(line):
+                out.append((location, "artifact", m.group(0).strip()))
+        if "machine" in classes:
+            for m in MACHINE_RE.finditer(line):
+                out.append((location, "machine", m.group(0).strip()))
+        if "env" in classes:
+            for m in ENV_RE.finditer(line):
+                out.append((location, "env", m.group(0).strip()))
+        if "structural" in classes:
+            for m in STRUCTURAL_RE.finditer(line):
+                out.append((location, "structural", m.group(0).strip()))
+        if "stochastic" in classes and STOCHASTIC_KW_RE.search(line):
+            for m in STOCHASTIC_NUM_RE.finditer(line):
+                out.append((location, "stochastic", m.group(0).strip()))
     return out
 
 
-def scan_all(root: Path) -> list[tuple[str, str]]:
-    findings: list[tuple[str, str]] = []
+def scan_all(root: Path, classes: set[str]) -> list[tuple[str, str, str]]:
+    findings: list[tuple[str, str, str]] = []
 
     for nb in root.rglob("*.ipynb"):
         if _skipped(nb):
             continue
         rel = nb.relative_to(root).as_posix()
+        # stochastic : un carnet seme est reproductible -> on ne signale pas
+        # cette classe pour lui (les autres classes restent actives).
+        eff_classes = set(classes)
+        if "stochastic" in eff_classes and _notebook_is_seeded(nb):
+            eff_classes = eff_classes - {"stochastic"}
         for idx, src in _iter_markdown_sources(nb):
-            findings += _findings_in_text(src, f"{rel} MD[{idx}]")
+            findings += _findings_in_text(src, f"{rel} MD[{idx}]", eff_classes)
 
     for md in root.rglob("*.md"):
         if _skipped(md):
@@ -178,12 +351,14 @@ def scan_all(root: Path) -> list[tuple[str, str]]:
                 text,
                 flags=re.DOTALL,
             )
-        findings += _findings_in_text(text, rel)
+        # Pour un .md isole, on n'a pas de cellule code amont a verifier : on
+        # garde stochastic en advisory (incertitude documentee, pas de gate seed).
+        findings += _findings_in_text(text, rel, classes)
 
     return findings
 
 
-def scan_diff(diff_range: str) -> list[tuple[str, str]]:
+def scan_diff(diff_range: str, classes: set[str]) -> list[tuple[str, str, str]]:
     """Ne juge que les lignes AJOUTEES : le stock existant ne fait pas echouer."""
     try:
         diff = subprocess.run(
@@ -195,7 +370,7 @@ def scan_diff(diff_range: str) -> list[tuple[str, str]]:
         print(f"[ERREUR] git diff a echoue : {exc}", file=sys.stderr)
         return []
 
-    findings: list[tuple[str, str]] = []
+    findings: list[tuple[str, str, str]] = []
     generated_cache: dict[str, bool] = {}
 
     def _is_generated_file(rel: str) -> bool:
@@ -207,6 +382,10 @@ def scan_diff(diff_range: str) -> list[tuple[str, str]]:
                 generated_cache[rel] = False
         return generated_cache[rel]
 
+    # Pour le mode diff, la verification seed par carnet est couteuse et le
+    # contrat CI ne demande que la classe artifact par defaut : on applique le
+    # gate seed stochastic seulement en --all (scan_all). En diff, stochastic
+    # reste advisory brut (incertitude documentee).
     current = "?"
     for line in diff.splitlines():
         if line.startswith("+++ b/"):
@@ -232,31 +411,71 @@ def scan_diff(diff_range: str) -> list[tuple[str, str]]:
                 continue
             if '"source"' not in line and not body.startswith('"'):
                 continue
-        findings += _findings_in_text(line[1:], current)
+        findings += _findings_in_text(line[1:], current, classes)
 
     return findings
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    g = ap.add_mutually_exclusive_group(required=True)
-    g.add_argument("--all", action="store_true", help="inventaire complet du stock (suivi #9377)")
-    g.add_argument("--diff", metavar="RANGE", help="ne juge que les lignes ajoutees (ex: origin/main...HEAD)")
-    ap.add_argument("--strict", action="store_true", help="rc=1 sur finding (defaut : advisory, rc=0)")
-    ap.add_argument("--root", default=".", help="racine du depot")
-    args = ap.parse_args()
+def _emit_grouped(findings: list[tuple[str, str, str]], strict: bool, structural_only: bool) -> int:
+    """Sortie multi-classes : une section par classe, ou banniere LEGITIME."""
+    if structural_only:
+        # structural est legitime (speedup deterministe) : on inventorie sans signaler.
+        if not findings:
+            print("[OK] classe structural : aucun speedup deterministe en prose.")
+            return 0
+        by_file: dict[str, list[str]] = {}
+        for loc, _klass, snippet in findings:
+            by_file.setdefault(loc.split(" MD[")[0], []).append(snippet)
+        print(
+            f"[LEGITIME -- structural] {len(findings)} speedup(s) deterministe(s) en "
+            f"prose, {len(by_file)} fichier(s). Exclus du signalement (ne derive pas). :\n"
+        )
+        for path in sorted(by_file):
+            preview = ", ".join(sorted(set(by_file[path]))[:6])
+            print(f"  {path}  ({len(by_file[path])})  {preview}")
+        return 0  # structural ne fait jamais echouer
 
-    findings = scan_all(Path(args.root).resolve()) if args.all else scan_diff(args.diff)
+    if not findings:
+        print("[OK] aucun compteur quantitatif en prose (classe(s) demandee(s)).")
+        return 0
 
+    # Regroupe les findings par classe, puis par fichier dans chaque classe.
+    by_class: dict[str, dict[str, list[str]]] = {}
+    for loc, klass, snippet in findings:
+        by_class.setdefault(klass, {}).setdefault(loc.split(" MD[")[0], []).append(snippet)
+
+    total = len(findings)
+    label = "REFUS" if strict else "ADVISORY"
+    classes_hdr = "/".join(by_class.keys())
+    print(f"[{label}] {total} compteur(s) quantitatif(s) en prose ({classes_hdr}), {len(by_class)} classe(s) :\n")
+    for klass in (k for k in FLAGGABLE if k in by_class):  # ordre stable
+        files = by_class[klass]
+        nclass = sum(len(v) for v in files.values())
+        print(f"=== [{klass}] {nclass} compteur(s), {len(files)} fichier(s) ===")
+        for path in sorted(files):
+            preview = ", ".join(sorted(set(files[path]))[:6])
+            print(f"  {path}  ({len(files[path])})  {preview}")
+        print()
+
+    print(
+        "Les donnees quantitatives sont tenues par le CI, pas par la prose "
+        "(#9377 compteurs d'artefacts, #9434 mesures non reproductibles).\n"
+        "Supprimer la mesure, garder le predicat : `(140 lignes, 0 sorry)` -> `(0 sorry)`."
+    )
+    return 1 if strict else 0
+
+
+def _emit_legacy(findings: list[tuple[str, str, str]], strict: bool) -> int:
+    """Sortie mono-classe artifact (format d'origine, contrat CI preserve)."""
     if not findings:
         print("[OK] aucun compteur quantitatif en prose.")
         return 0
 
     by_file: dict[str, list[str]] = {}
-    for loc, snippet in findings:
+    for loc, _klass, snippet in findings:
         by_file.setdefault(loc.split(" MD[")[0], []).append(snippet)
 
-    label = "REFUS" if args.strict else "ADVISORY"
+    label = "REFUS" if strict else "ADVISORY"
     print(f"[{label}] {len(findings)} compteur(s) quantitatif(s) en prose, {len(by_file)} fichier(s) :\n")
     for path in sorted(by_file):
         snippets = by_file[path]
@@ -267,7 +486,37 @@ def main() -> int:
         "\nLes donnees quantitatives sont tenues par le CI, pas par la prose (issue #9377)."
         "\nSupprimer la mesure, garder le predicat : `(140 lignes, 0 sorry)` -> `(0 sorry)`."
     )
-    return 1 if args.strict else 0
+    return 1 if strict else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--all", action="store_true", help="inventaire complet du stock (suivi #9377/#9434)")
+    g.add_argument("--diff", metavar="RANGE", help="ne juge que les lignes ajoutees (ex: origin/main...HEAD)")
+    ap.add_argument(
+        "--class",
+        dest="klass",
+        default="artifact",
+        choices=CLASS_CHOICES,
+        help="classe a auditer (defaut: artifact=#9377 ; machine/env/stochastic=#9434 ; "
+             "structural=legitime-exclu ; all=toutes les flaggables)",
+    )
+    ap.add_argument("--strict", action="store_true", help="rc=1 sur finding (defaut : advisory, rc=0)")
+    ap.add_argument("--root", default=".", help="racine du depot")
+    args = ap.parse_args()
+
+    classes, structural_only = _resolve_classes(args.klass)
+
+    if args.all:
+        findings = scan_all(Path(args.root).resolve(), classes)
+    else:
+        findings = scan_diff(args.diff, classes)
+
+    # Format legacy exact pour la classe artifact seule (contrat CI : --diff sans --class).
+    if args.klass == "artifact":
+        return _emit_legacy(findings, args.strict)
+    return _emit_grouped(findings, args.strict, structural_only)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: MED/tooling (#9434 instrument — étendre `check_prose_quantitative_claims.py` avec la taxonomie de reproductibilité) — lane myia-po-2023:CoursIA — prev: MED/readme #9475

## Ce que fait la PR

Étend le scanner `check_prose_quantitative_claims.py` (mandate #9377, appelé par `prose-counts-guard.yml`) avec la **taxonomie #9434** des mesures non reproductibles. C'est le grain dispatché par ai-01 (DM `msg-20260805T140223-s9qrve`, c.87) : « l'organe avant le rollout » — les 5 tranches #9434 à la main (5 PRs, dont ma #9474) drainaient un stock **non mesuré**. Cette PR pose l'instrument ; les PRs de drainage suivront, **une par classe**, avec le before/after du compteur comme preuve.

### La taxonomie (4 classes #9434 + la classe #9377 existante)

| `--class` | Défaut | Motif | Flaggable ? |
|---|---|---|---|
| `artifact` (#9377) | **oui** | nombre + nom d'artefact (« 140 lignes », « 224 notebooks ») | oui |
| `machine` (#9434) | non | durée absolue (`\d+([.,]\d+)? (ms\|s\|sec\|min)`) | oui |
| `env` (#9434) | non | version de lib figée (« NumPy 2.4.2 », « Mathlib v4.31.0-rc1 ») | oui |
| `stochastic` (#9434) | non | décimale ≥2 chiffres + mot-clef de métrique, carnet **non semé** amont | oui |
| `structural` (#9434) | non | speedup déterministe (« 2.78e24x », « 4x ») | **NON — légitime, exclu** |

`--class all` = les 4 flaggables (structural exclu). `--class structural` inventorie sous bannière `LEGITIME`, rc=0 **même en `--strict`** (l'ordre de grandeur d'un speedup fixé par la taille du problème ne dérive pas — écrit dans le body de #9434).

### Backward-compat (contrat CI préservé byte-for-byte)

La classe par défaut reste `artifact`. Le workflow `prose-counts-guard.yml` appelle `--diff origin/<base>...HEAD` **sans** `--class` → comportement inchangé, vérifié firsthand sur worktree frais depuis `origin/main` :

```
# avant (origin/main)        # après (cette PR)
--all   2630/569             --all   2630/569        # identique
--diff  [OK] rc=0            --diff  [OK] rc=0       # identique (CI)
--strict (artifact) rc=1     --strict rc=1           # identique
```

Les classes #9434 sont **opt-in** : elles n'ajoutent aucun finding au contrat CI advisory actuel.

### Le stock #9434 est désormais MESURÉ (valide la thèse ai-01)

```
$ python check_prose_quantitative_claims.py --all --class all
[ADVISORY] 9908 compteur(s) (artifact/machine/stochastic/env), 4 classe(s)
  [artifact]   2630   569 fichiers   (#9377, connu)
  [machine]    4618   956 fichiers   (#9434, NON mesuré avant)
  [stochastic] 2564   195 fichiers   (#9434, NON mesuré avant)
  [env]          96    50 fichiers   (#9434, NON mesuré avant)
$ python check_prose_quantitative_claims.py --all --class structural
[LEGITIME -- structural] 844 speedup(s) ... Exclus du signalement (ne derive pas).   rc=0
```

7278 claims #9434 (machine+env+stochastic) étaient **non mesurés** — on drainait à la main, un carnet à la fois, sans connaître l'étendue. L'instrument les dénombre ; exemples réels confirmés : `Mathlib v4.31.0-rc1` (game_theory_lean README — même drift que decision_theory #9475, encore présent ailleurs), `PyTorch 2.0`, `vLLM 0.6`, valeurs CFR `0.056/0.22/0.33` (GameTheory-13).

## Design faithful au DM ai-01

1. **Étendre, pas dupliquer** : un seul script (règle « pas de duplication », `scripts-reference`). La logique #9377 existante est préservée verbatim (mêmes regexes, même `_iter_markdown_sources`, même `scan_diff`).
2. **Motifs par classe** : machine (durées), env (versions), stochastic (décimale + mot-clef métrique + gate seed).
3. **`structural` explicitement exclue du signalement** : bannière `LEGITIME`, rc=0 même en `--strict`.
4. **Angle-mort VIVANTE-vs-FIGEE respecté** (header l.26-40) : advisory par défaut, l'arbitrage reste humain. **Pas de promotion `--strict`** dans cette PR.
5. **Sortie inventaire par classe avec compte**, comme `--all`.

## Vérifications firsthand (G.1)

- **Stochastic seed-gate correct** : spot-check `GameTheory-13-ImperfectInfo-CFR.ipynb` → `np.random` présent **sans seed** → carnet réellement non reproductible → la détection est juste (le gate ne filtre pas à tort). Heuristique conservatrice : un seed n'importe où dans le carnet → réputé reproductible.
- **Exit codes** : `--class structural --strict` rc=0 (jamais de signalement) ; `--class machine --strict` rc=1 (flaggable) ; `--class artifact --strict` rc=1 (backward-compat) ; `--diff --class machine` sur ma branche (0 changement prose) → `[OK]` rc=0.
- **Collision** : 0 PR ouverte ne touche ce fichier (ai-01 l'a lancé sur main mais n'a pas ouvert de PR).
- **Stochastique en .md isolé** : pas de cellule code amont à vérifier → signalé en advisory brut (incertitude documentée dans le code). Le gate seed ne s'applique qu'aux `.ipynb` (via `_notebook_is_seeded`).

## Hors scope (discipline one-subject-per-PR)

- **Pas de drainage** dans cette PR : elle pose l'instrument uniquement. Les PRs de drainage **une par classe** suivront (machine d'abord : 4618 claims), chacune avec before/after du compteur comme preuve — comme demandé par ai-01.
- **Pas de `--strict`** : l'advisory reste le mode (critère de sortie #9377 non encore atteint).
- Mes 4 PRs #9434 tenues par ai-01 (#9445/#9456/#9470/#9472/#9474) restent ouvertes ; leur travail se replie dans les futures PRs de drainage — rien n'est jeté.

See #9434 (EPIC reproductibilité), #9377 (compteurs d'artefacts). Dispatch ai-01 c.87 DM `msg-20260805T140223-s9qrve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
