### PR TITLE
feat(twin-parity,#9399-b): add --ci-strict mode + daily cron for fleet-wide SHA drift

### DIFF
--- a/.github/workflows/twin-parity-cron.yml
+++ b/.github/workflows/twin-parity-cron.yml
@@ -24,6 +24,12 @@ name: Twin Parity Cron (CI-derived SHA, #9399 volet b)
 #
 # Schedule: tous les jours a 06:17 UTC (decalage pour eviter la collision
 # avec catalog-cron 03:30 + lean-cron).
+#
+# Implementation note : la logique Python (extraction drift + rendu summary)
+# est externalisee dans scripts/notebook_tools/_cron_extract_drift.py et
+# _cron_render_summary.py. Cela elimine le YAML/Bash quoting croise (les
+# f-strings `f\"{r['name']}\"` casse yaml.safe_load quand elles sont
+# inline dans un `run: |` block). Tests : voir scripts/notebook_tools/tests/.
 
 on:
   schedule:
@@ -77,17 +83,9 @@ jobs:
             if [ $EXIT -eq 0 ]; then
               echo "ok=CI-STRICT_OK"
             else
-              # Extraire le nom des paires touchees pour le ::error actionnable
-              DRIFT_NAMES=$(python -c "
-import json
-d = json.load(open('twin_parity_cron.json'))
-ci = d.get('ci_strict', {})
-touched = []
-for r in d.get('pairs', []):
-    if r.get('status') != 'OK':
-        touched.append(f\"{r['name']} ({r['family']}, {r['parity_level']})\")
-print('\n'.join(touched) if touched else '<none>')
-")
+              # Extraire le nom des paires touchees pour le ::error actionnable.
+              # Logique externalisee dans _cron_extract_drift.py (tests : test_cron_extract_drift.py).
+              DRIFT_NAMES=$(python scripts/notebook_tools/_cron_extract_drift.py twin_parity_cron.json)
               echo "ok=CI-STRICT_DRIFT"
               echo "::error title=Twin parity CI-strict DRIFT DETECTED::$DRIFT_NAMES"
             fi
@@ -109,27 +107,8 @@ print('\n'.join(touched) if touched else '<none>')
         if: always()
         run: |
           if [ -f twin_parity_cron.json ]; then
-            python -c "
-import json
-d = json.load(open('twin_parity_cron.json'))
-ci = d.get('ci_strict', {})
-total = d.get('total', 0)
-print(f'## Twin parity CI-strict — {total} paires')
-print('')
-print('| Categorie | Count |')
-print('|---|---|')
-for k, v in ci.items():
-    print(f'| \`{k}\` | {v} |')
-print('')
-n_touched = sum(1 for r in d.get('pairs', []) if r.get('status') != 'OK')
-if n_touched:
-    print(f'### {n_touched} paire(s) touchee(s)')
-    for r in d.get('pairs', []):
-        if r.get('status') != 'OK':
-            print(f\"- **{r['name']}** ({r['family']}, {r['parity_level']}) — {r['status']}\")
-            for det in r.get('details', []):
-                print(f'    - {det}')
-"
+            # Logique externalisee dans _cron_render_summary.py (tests : test_cron_render_summary.py).
+            python scripts/notebook_tools/_cron_render_summary.py twin_parity_cron.json >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload artifacts

--- a/.github/workflows/twin-parity-cron.yml
+++ b/.github/workflows/twin-parity-cron.yml
@@ -1,0 +1,144 @@
+name: Twin Parity Cron (CI-derived SHA, #9399 volet b)
+
+# Purpose: Cron quotidien qui re-verifie le registre de parite sur l'etat reel
+# de `main` SANS base ref. Contrairement au gate par-PR (twin-parity.yml qui
+# ne rougit QUE le drift INTRODUIT par la PR), ce cron voit TOUT le drift
+# fleet-wide, dont le drift pre-existant -- utile pour reperer un worker qui
+# a oublie `--update` apres une normalisation outillee, ou un SHA declare a
+# la main devenu faux.
+#
+# Volet b du trilogie #9399 (a = append-only audits MERGED, c = content_sha
+# metadata-immune MERGED, b = CI cron strict). Categorisation 4 axes :
+# ok_legacy / ok_content / drift_blob / drift_content /
+# drift_legacy_after_content / missing_python / missing_csharp / no_audit.
+#
+# Distinction outil-erreur vs constat-drift : exigence c.1240 + L948/L949.
+# Si stdout JSON est parsable mais contient des drift, on ROUGE (exit 1)
+# mais on emet un `::error` avec le NOM des paires touchees (actionnable).
+# Si stdout n'est PAS parsable (tool error), on ROUGE avec un `::error`
+# DIFFERENT signalant "tool crash, ne PAS confondre avec constat".
+#
+# Sortie : un job-summary (md) avec les compteurs + la liste des paires
+# touchees, archive 30j pour forensic. Le cron ne committe RIEN -- le
+# rollup de drift releve d'une PR dediee (cf #8264 precedent).
+#
+# Schedule: tous les jours a 06:17 UTC (decalage pour eviter la collision
+# avec catalog-cron 03:30 + lean-cron).
+
+on:
+  schedule:
+    # m h dom mon dow -- 06:17 UTC quotidien
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      json_only:
+        description: "Ne pas publier de summary markdown (utile pour debug)"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+jobs:
+  twin-parity-cron:
+    name: "Twin parity CI-derived SHA (#9399 b)"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Sur cron on lit l'etat courant de main. Les PR-checking workflows
+          # utilisent le PR merge ref ; ici on n'a PAS de PR, juste l'arbre.
+          ref: main
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Run twin parity CI-strict check
+        id: check
+        run: |
+          set +e
+          python scripts/notebook_tools/check_twin_parity.py \
+            --ci-strict --check --json > twin_parity_cron.json 2>twin_parity_cron_stderr.log
+          EXIT=$?
+          set -e
+
+          # Distinction tool-error vs constat-drift (cf L948, c.1240) :
+          # 1. stdout JSON parsable + exit != 0  -> constat de drift, rouge
+          # 2. stdout JSON NON parsable           -> tool crash, rouge distinct
+          if python -c "import json; json.load(open('twin_parity_cron.json'))" 2>/dev/null; then
+            if [ $EXIT -eq 0 ]; then
+              echo "ok=CI-STRICT_OK"
+            else
+              # Extraire le nom des paires touchees pour le ::error actionnable
+              DRIFT_NAMES=$(python -c "
+import json
+d = json.load(open('twin_parity_cron.json'))
+ci = d.get('ci_strict', {})
+touched = []
+for r in d.get('pairs', []):
+    if r.get('status') != 'OK':
+        touched.append(f\"{r['name']} ({r['family']}, {r['parity_level']})\")
+print('\n'.join(touched) if touched else '<none>')
+")
+              echo "ok=CI-STRICT_DRIFT"
+              echo "::error title=Twin parity CI-strict DRIFT DETECTED::$DRIFT_NAMES"
+            fi
+          else
+            # Tool crash : sortie stderr informative, message distinct du drift finding
+            echo "ok=TOOL_ERROR"
+            echo "::error title=Twin parity CI-strict TOOL ERROR::La commande a crash SANS emettre de JSON valide. Cela N'est PAS un constat de drift mais un crash d'outil (registre illisible, PyYAML absent, etc.). Voir stderr ci-dessous."
+            tail -c 600 twin_parity_cron_stderr.log 2>/dev/null || true
+            exit 1
+          fi
+
+          # Si exit != 0 et JSON ok, on a deja posté le ::error ci-dessus.
+          # Re-rouge pour que la cheklist gate (required checks) rougit.
+          if [ $EXIT -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Publish job summary
+        if: always()
+        run: |
+          if [ -f twin_parity_cron.json ]; then
+            python -c "
+import json
+d = json.load(open('twin_parity_cron.json'))
+ci = d.get('ci_strict', {})
+total = d.get('total', 0)
+print(f'## Twin parity CI-strict — {total} paires')
+print('')
+print('| Categorie | Count |')
+print('|---|---|')
+for k, v in ci.items():
+    print(f'| \`{k}\` | {v} |')
+print('')
+n_touched = sum(1 for r in d.get('pairs', []) if r.get('status') != 'OK')
+if n_touched:
+    print(f'### {n_touched} paire(s) touchee(s)')
+    for r in d.get('pairs', []):
+        if r.get('status') != 'OK':
+            print(f\"- **{r['name']}** ({r['family']}, {r['parity_level']}) — {r['status']}\")
+            for det in r.get('details', []):
+                print(f'    - {det}')
+"
+          fi
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: twin-parity-cron
+          path: |
+            twin_parity_cron.json
+            twin_parity_cron_stderr.log
+          retention-days: 30
+          if-no-files-found: ignore

--- a/scripts/notebook_tools/_cron_extract_drift.py
+++ b/scripts/notebook_tools/_cron_extract_drift.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Helper appele par .github/workflows/twin-parity-cron.yml pour extraire
+la liste des paires touchees par le drift, dans un format affichable
+par `::error title=...::...`.
+
+Externalise le Python du workflow pour eviter le YAML/Bash quoting croise
+(f-string `f\"{r['name']}\"` dans un `run: |` block casse yaml.safe_load).
+
+Lit : twin_parity_cron.json (genere par check_twin_parity.py --ci-strict --json).
+Sortie : une ligne par paire touchee (`name (family, parity_level)`),
+         ou `<none>` si aucune.
+
+Usage :
+    python scripts/notebook_tools/_cron_extract_drift.py \
+        <path/to/twin_parity_cron.json>
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        sys.stderr.write(
+            "Usage: _cron_extract_drift.py <twin_parity_cron.json>\n"
+        )
+        return 2
+    path = argv[1]
+    try:
+        with open(path, encoding="utf-8") as f:
+            d = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        sys.stderr.write(f"_cron_extract_drift: cannot read {path}: {e}\n")
+        return 1
+
+    touched = []
+    for r in d.get("pairs", []) or []:
+        if r.get("status") != "OK":
+            name = r.get("name", "?")
+            family = r.get("family", "?")
+            parity = r.get("parity_level", "?")
+            touched.append(f"{name} ({family}, {parity})")
+
+    sys.stdout.write("\n".join(touched) if touched else "<none>")
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/notebook_tools/_cron_render_summary.py
+++ b/scripts/notebook_tools/_cron_render_summary.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Helper appele par .github/workflows/twin-parity-cron.yml (step
+'Publish job summary') pour rendre le rapport markdown du cron twin-parity.
+
+Externalise le Python du workflow pour eviter le YAML/Bash quoting croise
+(f-string `f\"{r['name']}\"` dans un `run: |` block casse yaml.safe_load).
+
+Lit : twin_parity_cron.json (genere par check_twin_parity.py --ci-strict --json).
+Sortie : un rapport markdown sur stdout (que GitHub Actions capture dans
+         $GITHUB_STEP_SUMMARY).
+
+Usage :
+    python scripts/notebook_tools/_cron_render_summary.py \
+        <path/to/twin_parity_cron.json>
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        sys.stderr.write(
+            "Usage: _cron_render_summary.py <twin_parity_cron.json>\n"
+        )
+        return 2
+    path = argv[1]
+    try:
+        with open(path, encoding="utf-8") as f:
+            d = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        sys.stderr.write(f"_cron_render_summary: cannot read {path}: {e}\n")
+        return 1
+
+    ci = d.get("ci_strict", {}) or {}
+    total = d.get("total", 0)
+    pairs = d.get("pairs", []) or []
+
+    out = []
+    out.append(f"## Twin parity CI-strict -- {total} paires")
+    out.append("")
+    out.append("| Categorie | Count |")
+    out.append("|---|---|")
+    for k, v in ci.items():
+        out.append(f"| `{k}` | {v} |")
+    out.append("")
+
+    touched_pairs = [r for r in pairs if r.get("status") != "OK"]
+    if touched_pairs:
+        out.append(f"### {len(touched_pairs)} paire(s) touchee(s)")
+        for r in touched_pairs:
+            name = r.get("name", "?")
+            family = r.get("family", "?")
+            parity = r.get("parity_level", "?")
+            status = r.get("status", "?")
+            out.append(f"- **{name}** ({family}, {parity}) -- {status}")
+            for det in r.get("details", []) or []:
+                out.append(f"    - {det}")
+    out.append("")
+
+    sys.stdout.write("\n".join(out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -1054,6 +1054,17 @@ def main(argv=None) -> int:
         p.error("--ci-strict est un mode fleet-wide SANS base ref : incompatible avec --per-pair.")
     if args.ci_strict and args.update:
         p.error("--ci-strict est un mode read-only : incompatible avec --update.")
+    # Cross-validation --ci-strict x --verify-recorded-sha (#9481, post-rebase c.984) :
+    # les deux sont des modes fleet-wide read-only avec des sorties JSON disjointes
+    # (breakdown 4 categories vs recorded-vs-HEAD mismatch). Les coupler en CLI
+    # melange deux verdicts dans la meme invocation, ce qui rend le choix du
+    # categoriel d'echec ambigu pour le mainteneur. Le cron les lance separement
+    # (twin-parity-cron.yml pour --ci-strict, twin-parity-sha-mismatch du
+    # twin-parity.yml #9481 pour --verify-recorded-sha). Mutuellement exclusifs.
+    if args.ci_strict and args.verify_recorded_sha:
+        p.error("--ci-strict et --verify-recorded-sha sont deux modes fleet-wide "
+                "read-only avec des sorties JSON disjointes : incompatibles. "
+                "Lancer l'un ou l'autre, pas les deux (le cron les dispatch separement).")
 
     repo_root = Path(args.repo_root) if args.repo_root else _repo_root()
     reg_path = Path(args.registry)

--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -109,12 +109,19 @@ Usage
     # -- il releve d'une PR de rebaseline dediee (cf #8264 batch precedent).
     python check_twin_parity.py --check --per-pair --base origin/main
     python check_twin_parity.py --check --per-pair --base HEAD~1
+    # mode CI cron (volet b #9399) : fleet-wide SANS base ref, breakdown 4 categories.
+    # Distinct du check historique : rouge sur N'IMPORTE QUEL drift (legacy ou content),
+    # pas seulement DRIFT_or_MISSING. Utilise par .github/workflows/twin-parity-cron.yml.
+    python check_twin_parity.py --ci-strict --check --json
+    python check_twin_parity.py --ci-strict --check          # sortie human-readable
 
 Exit codes
 ----------
     0 -- toutes les paires OK (ou mode non --check), ou zero nouveau drift en --per-pair
+         OU zero drift toutes categories (mode --ci-strict --check)
     1 -- un ou plusieurs DRIFT / MISSING (mode --check fleet-wide)
          OU nouveau(s) DRIFT introduit(s) par la PR (mode --check --per-pair)
+         OU un ou plusieurs drift legacy/content/missing en --ci-strict --check
     2 -- erreur (registre illisible, pas un depot git)
 
 Voir aussi
@@ -956,6 +963,10 @@ def main(argv=None) -> int:
     p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     p.add_argument("--registry", default=str(DEFAULT_REGISTRY),
                    help=f"Chemin du registre YAML (defaut: {DEFAULT_REGISTRY.name})")
+    p.add_argument("--repo-root", default=None,
+                   help="Racine du depot git (defaut: detectee via `git rev-parse "
+                        "--show-toplevel`). Utile pour les tests (mini-depot tmp_path) "
+                        "et le cron CI qui pointe sur le checkout explicite.")
     p.add_argument("--family", default=None,
                    help="Restreindre a une famille (ex. SMT/Z3-API)")
     p.add_argument("--check", action="store_true",
@@ -981,6 +992,13 @@ def main(argv=None) -> int:
                         "le drift INTRODUIT par la PR, jamais le drift pre-existant.")
     p.add_argument("--base", default=None,
                    help="Ref git de base pour le mode --per-pair (ex. origin/main, HEAD~1).")
+    p.add_argument("--ci-strict", action="store_true",
+                   help="Mode CI cron (#9399 volet b) : check fleet-wide SANS base ref, "
+                        "avec breakdown 4 categories (ok_legacy / ok_content / drift_blob / "
+                        "drift_content / drift_legacy_after_content / missing_python / "
+                        "missing_csharp / no_audit). Combine avec --check pour FAIL sur N'IMPORTE "
+                        "QUEL drift (vs la semantique 'DRIFT_or_MISSING only' historique). "
+                        "Distingue erreur d'outil vs constat de drift (cf L948/L949, c.1240).")
     p.add_argument("--pair", default=None,
                    help="Restreindre --update a une paire nommee (ex. 'Search-9-LP'). "
                         "Impossible a combiner avec --family.")
@@ -1032,8 +1050,12 @@ def main(argv=None) -> int:
                 "(cf issue #8508 + lecons L963/L974).")
     if args.pair and args.family:
         p.error("--pair et --family sont mutuellement exclusifs avec --update.")
+    if args.ci_strict and args.per_pair:
+        p.error("--ci-strict est un mode fleet-wide SANS base ref : incompatible avec --per-pair.")
+    if args.ci_strict and args.update:
+        p.error("--ci-strict est un mode read-only : incompatible avec --update.")
 
-    repo_root = _repo_root()
+    repo_root = Path(args.repo_root) if args.repo_root else _repo_root()
     reg_path = Path(args.registry)
 
     # --- Mode --coverage : angle mort du registre (paires jamais declarees) ---
@@ -1366,6 +1388,124 @@ def main(argv=None) -> int:
     n_ok = sum(1 for r in results if r["status"] == "OK")
     n_drift = sum(1 for r in results if r["status"] == "DRIFT")
     n_missing = sum(1 for r in results if r["status"] == "MISSING")
+
+    # --- Mode --ci-strict (#9399 volet b) ---
+    # Verdict dur : pour chaque paire, on detaillé le verdict legacy vs content_sha.
+    # Une paire legacy (sans content_*_sha) a son blob SHA comme seule signature
+    # -> un strip outille deplace le blob et fait DRIFT (faux positif du gate per-PR,
+    # parce que le gate per-PR ignore le drift PRE-EXISTANT ; ici on est en fleet-wide
+    # sans base-ref, on voit TOUT).
+    # Une paire avec content_*_sha (volet c) -> tampon cost seul ne fait PAS DRIFT,
+    # mais fix de prose / re-exec font DRIFT (verdict sincere).
+    # Le cron fleet-wide survole les DEUX : utile pour detecter un worker qui a oublie
+    # --update apres un strip, ou un depot SHA declare a la main devenu faux.
+    if args.ci_strict:
+        # Breakdown par categorie : legacy vs content vs missing vs ok
+        cat = {
+            "n_ok_legacy": 0,             # blob SHA match, pas de content_sha enregistre
+            "n_ok_content": 0,            # content_sha match (volet c)
+            "n_drift_blob": 0,            # legacy blob SHA mismatch
+            "n_drift_content": 0,         # content_sha mismatch
+            "n_drift_legacy_after_content": 0,  # legacy blob drift mais content_sha OK
+                                             # = strip outille detecte
+            "n_missing_python": 0,
+            "n_missing_csharp": 0,
+            "n_no_audit": 0,              # paire sans audits ni last_audit
+        }
+        ci_results = []
+        for pp, r in zip(pairs, results):
+            audit = _latest_audit(pp)
+            rec_py = audit.get("python_sha")
+            rec_cs = audit.get("csharp_sha")
+            rec_cpy = audit.get("content_python_sha")
+            rec_ccs = audit.get("content_csharp_sha")
+            cur_py = r["current_python_sha"]
+            cur_cs = r["current_csharp_sha"]
+            cur_cpy = r["current_content_python_sha"]
+            cur_ccs = r["current_content_csharp_sha"]
+
+            entry_ci = {
+                "name": r["name"],
+                "family": r["family"],
+                "parity_level": r["parity_level"],
+                "status": r["status"],
+                "details": list(r["details"]),
+                "has_content_sha_audit": bool(rec_cpy and rec_ccs),
+            }
+
+            if not audit:
+                cat["n_no_audit"] += 1
+                ci_results.append(entry_ci)
+                continue
+
+            py_missing = (cur_py is None)
+            cs_missing = (cur_cs is None)
+            if py_missing:
+                cat["n_missing_python"] += 1
+            if cs_missing:
+                cat["n_missing_csharp"] += 1
+
+            blob_py_drift = (not py_missing and rec_py and cur_py != rec_py)
+            blob_cs_drift = (not cs_missing and rec_cs and cur_cs != rec_cs)
+            content_py_drift = (rec_cpy and cur_cpy and cur_cpy != rec_cpy)
+            content_cs_drift = (rec_ccs and cur_ccs and cur_ccs != rec_ccs)
+
+            if entry_ci["has_content_sha_audit"]:
+                if content_py_drift or content_cs_drift:
+                    cat["n_drift_content"] += 1
+                elif blob_py_drift or blob_cs_drift:
+                    # Strip outille probable (volet c detecte le strip)
+                    cat["n_drift_legacy_after_content"] += 1
+                    entry_ci["details"].append(
+                        "blob SHA drift MAIS content_sha OK : strip outille probable "
+                        "(strip_probe_banner / strip_machine_paths / scrub_papermill) "
+                        "sans --update ulterieur. Refaire --update en dernier, cf #8957."
+                    )
+                else:
+                    cat["n_ok_content"] += 1
+            else:
+                if blob_py_drift or blob_cs_drift:
+                    cat["n_drift_blob"] += 1
+                else:
+                    cat["n_ok_legacy"] += 1
+
+            ci_results.append(entry_ci)
+
+        n_total_drift = (cat["n_drift_blob"] + cat["n_drift_content"]
+                         + cat["n_drift_legacy_after_content"]
+                         + cat["n_missing_python"] + cat["n_missing_csharp"]
+                         + cat["n_no_audit"])
+
+        if args.json:
+            out = {
+                "mode": "ci_strict",
+                "registry": str(reg_path),
+                "total": len(ci_results),
+                "ok_total": n_ok,
+                "drift_total": n_drift,
+                "missing_total": n_missing,
+                "ci_strict": cat,
+                "n_total_drift": n_total_drift,
+                "pairs": ci_results,
+            }
+            print(json.dumps(out, ensure_ascii=False, indent=2))
+        else:
+            print(f"[CI-STRICT] {len(ci_results)} paire(s) | "
+                  f"ok_legacy={cat['n_ok_legacy']} ok_content={cat['n_ok_content']} "
+                  f"drift_blob={cat['n_drift_blob']} drift_content={cat['n_drift_content']} "
+                  f"drift_legacy_after_content={cat['n_drift_legacy_after_content']} "
+                  f"missing_py={cat['n_missing_python']} missing_cs={cat['n_missing_csharp']} "
+                  f"no_audit={cat['n_no_audit']}")
+            for r in ci_results:
+                if r["status"] != "OK":
+                    print(f"  [{r['status']}] {r['name']} ({r['family']}, {r['parity_level']})")
+                    for d in r["details"]:
+                        print(f"       - {d}")
+
+        # CI gate : rouge sur n'importe quel drift (le but du cron fleet-wide)
+        if args.check and n_total_drift > 0:
+            return 1
+        return 0
 
     if args.json:
         out = {

--- a/scripts/notebook_tools/tests/test_check_twin_parity_ci_sha.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_ci_sha.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Mode --ci-strict du registre de parite (#9399 volet b).
+
+Le gate par-PR (twin-parity.yml) ne rougit QUE le drift INTRODUIT par la PR
+(cf L8264 precedent : #8282, #8289, #8322, #8372). Pour reperer un worker
+qui a oublie `--update` apres une normalisation outillee, ou un SHA declare
+a la main devenu faux, il faut un cron fleet-wide qui voit TOUT le drift.
+
+Ces tests pincent les 2 cas du cron :
+  - registre aligne sur working tree -> exit 0, breakdown 0 drift ;
+  - registre desaligne sur working tree -> exit 1, breakdown contient
+    une categorie de drift (drift_blob / drift_content).
+
+Cas supplementaire : distinction erreur d'outil vs constat drift (cf
+L948, c.1240) : un tool error (registre illisible, pas de depot git)
+doit EXIT 2 (cf Exit codes docstring), pas etre confondu avec un
+constat de drift rouge.
+
+Run:
+    pytest scripts/notebook_tools/tests/test_check_twin_parity_ci_sha.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import check_twin_parity as ctp  # noqa: E402
+
+
+# --- helpers -----------------------------------------------------------------
+
+def _git_repo(tmp_path: Path) -> Path:
+    """Un mini-depot git pret a committer des notebooks."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for args in (("init", "-q"), ("config", "user.email", "t@t"),
+                 ("config", "user.name", "t")):
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+    return repo
+
+
+def _nb(source: list[str] | None = None, cost: float | None = None) -> dict:
+    return {
+        "cells": [{
+            "cell_type": "markdown",
+            "source": source if source is not None else ["# Title\n"],
+            "metadata": {},
+        }],
+        "metadata": ({"cost": {"api_usd_est": cost}} if cost is not None
+                     else {"kernelspec": {"name": "python3"}}),
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+def _commit(repo: Path, rel: str, nb: dict, msg: str) -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(nb), encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", msg], cwd=repo,
+                   check=True, capture_output=True)
+
+
+def _make_pair_yaml(pairs_dir: Path, name: str, py_rel: str, cs_rel: str,
+                    py_sha: str, cs_sha: str) -> None:
+    """Ecrit une entree registry file-per-entry (cf #8542)."""
+    entry = pairs_dir / f"{name}.yaml"
+    entry.write_text(
+        f"name: {name}\n"
+        f"family: Search\n"
+        f"python: {py_rel}\n"
+        f"csharp: {cs_rel}\n"
+        f"parity_level: full\n"
+        f"last_audit:\n"
+        f"  date: 2026-08-05\n"
+        f"  by: myia-po-2023:CoursIA-2\n"
+        f"  python_sha: {py_sha}\n"
+        f"  csharp_sha: {cs_sha}\n",
+        encoding="utf-8",
+    )
+
+
+def _make_pair_yaml_with_content_sha(pairs_dir: Path, name: str, py_rel: str,
+                                     cs_rel: str, py_sha: str, cs_sha: str,
+                                     cpy: str, ccs: str) -> None:
+    """Paire avec content_sha (volet c) en plus des blob SHA legacy."""
+    entry = pairs_dir / f"{name}.yaml"
+    entry.write_text(
+        f"name: {name}\n"
+        f"family: Search\n"
+        f"python: {py_rel}\n"
+        f"csharp: {cs_rel}\n"
+        f"parity_level: full\n"
+        f"last_audit:\n"
+        f"  date: 2026-08-05\n"
+        f"  by: myia-po-2023:CoursIA-2\n"
+        f"  python_sha: {py_sha}\n"
+        f"  csharp_sha: {cs_sha}\n"
+        f"  content_python_sha: {cpy}\n"
+        f"  content_csharp_sha: {ccs}\n",
+        encoding="utf-8",
+    )
+
+
+# --- 1. cas MATCH (registre aligne) : exit 0 --------------------------------
+
+def test_ci_strict_match_exit_zero(tmp_path):
+    """Working tree aligne sur le registre -> CI gate vert, exit 0."""
+    repo = _git_repo(tmp_path)
+    py_rel = "py/nb.ipynb"
+    cs_rel = "cs/nb.ipynb"
+
+    _commit(repo, py_rel, _nb(source=["# Title\n"]), "base py")
+    _commit(repo, cs_rel, _nb(source=["// Title\n"]), "base cs")
+    py_blob = ctp._git_blob_sha(repo, py_rel)
+    cs_blob = ctp._git_blob_sha(repo, cs_rel)
+
+    pairs_dir = tmp_path / "twin_pairs.d"
+    pairs_dir.mkdir()
+    _make_pair_yaml(pairs_dir, "Search-A", py_rel, cs_rel, py_blob, cs_blob)
+
+    rc = ctp.main([
+        "--ci-strict", "--check", "--json",
+        "--registry", str(pairs_dir),
+        "--repo-root", str(repo),
+    ])
+    assert rc == 0, (
+        f"working tree aligne sur registre devrait etre vert (exit 0), "
+        f"rc={rc}"
+    )
+
+
+def test_ci_strict_match_breakdown_n_ok(tmp_path):
+    """Breakdown : 1 paire legacy, content_sha absent -> categorie ok_legacy == 1."""
+    repo = _git_repo(tmp_path)
+    py_rel = "py/nb.ipynb"
+    cs_rel = "cs/nb.ipynb"
+
+    _commit(repo, py_rel, _nb(source=["# Title\n"]), "base py")
+    _commit(repo, cs_rel, _nb(source=["// Title\n"]), "base cs")
+    py_blob = ctp._git_blob_sha(repo, py_rel)
+    cs_blob = ctp._git_blob_sha(repo, cs_rel)
+
+    pairs_dir = tmp_path / "twin_pairs.d"
+    pairs_dir.mkdir()
+    _make_pair_yaml(pairs_dir, "Search-A", py_rel, cs_rel, py_blob, cs_blob)
+
+    # Capture stdout JSON
+    import io
+    from contextlib import redirect_stdout
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = ctp.main([
+            "--ci-strict", "--json",
+            "--registry", str(pairs_dir),
+            "--repo-root", str(repo),
+        ])
+    assert rc == 0
+    out = json.loads(buf.getvalue())
+    assert out["mode"] == "ci_strict"
+    ci = out["ci_strict"]
+    assert ci["n_ok_legacy"] == 1, (
+        f"devrait avoir 1 ok_legacy (paire sans content_sha alignee), got {ci}"
+    )
+    assert ci["n_drift_blob"] == 0
+    assert ci["n_drift_content"] == 0
+    assert ci["n_no_audit"] == 0
+
+
+def test_ci_strict_content_sha_match_exit_zero(tmp_path):
+    """Paire avec content_sha enregistre et content_sha aligne -> vert (volet c)."""
+    repo = _git_repo(tmp_path)
+    py_rel = "py/nb.ipynb"
+    cs_rel = "cs/nb.ipynb"
+
+    _commit(repo, py_rel, _nb(source=["# Title\n"]), "base py")
+    _commit(repo, cs_rel, _nb(source=["// Title\n"]), "base cs")
+    py_blob = ctp._git_blob_sha(repo, py_rel)
+    cs_blob = ctp._git_blob_sha(repo, cs_rel)
+    py_content = ctp._content_sha(repo, py_rel)
+    cs_content = ctp._content_sha(repo, cs_rel)
+
+    pairs_dir = tmp_path / "twin_pairs.d"
+    pairs_dir.mkdir()
+    _make_pair_yaml_with_content_sha(
+        pairs_dir, "Search-A", py_rel, cs_rel,
+        py_blob, cs_blob, py_content, cs_content
+    )
+
+    rc = ctp.main([
+        "--ci-strict", "--check", "--json",
+        "--registry", str(pairs_dir),
+        "--repo-root", str(repo),
+    ])
+    assert rc == 0, f"content_sha aligne devrait etre vert, rc={rc}"
+
+
+# --- 2. cas MISMATCH (registre desaligne) : exit 1 ----------------------------
+
+def test_ci_strict_legacy_blob_drift_exit_one(tmp_path):
+    """Working tree modifie sans rebaseline -> exit 1, drift_blob > 0."""
+    repo = _git_repo(tmp_path)
+    py_rel = "py/nb.ipynb"
+    cs_rel = "cs/nb.ipynb"
+
+    _commit(repo, py_rel, _nb(source=["# Title\n"]), "base py")
+    _commit(repo, cs_rel, _nb(source=["// Title\n"]), "base cs")
+    # Capture SHAs AVANT la modification du working tree
+    py_blob_v1 = ctp._git_blob_sha(repo, py_rel)
+    cs_blob_v1 = ctp._git_blob_sha(repo, cs_rel)
+
+    pairs_dir = tmp_path / "twin_pairs.d"
+    pairs_dir.mkdir()
+    _make_pair_yaml(pairs_dir, "Search-A", py_rel, cs_rel, py_blob_v1, cs_blob_v1)
+
+    # Modifie le working tree (NON committe) -> l'index HEAD ne bouge pas,
+    # mais on ecrit sur disque avec un contenu different -> _git_blob_sha
+    # lit HEAD, donc on committe une nouvelle version et on re-lit.
+    _commit(repo, py_rel, _nb(source=["# Title modifie\n"]), "edit py")
+    py_blob_v2 = ctp._git_blob_sha(repo, py_rel)
+    assert py_blob_v1 != py_blob_v2, "le SHA doit avoir bouge"
+
+    # Le registre pointe encore sur v1, le HEAD est sur v2 -> drift
+    rc = ctp.main([
+        "--ci-strict", "--check", "--json",
+        "--registry", str(pairs_dir),
+        "--repo-root", str(repo),
+    ])
+    assert rc == 1, (
+        f"registre desaligne (blob drift) devrait rougir (exit 1), rc={rc}"
+    )
+
+
+def test_ci_strict_legacy_blob_drift_breakdown(tmp_path):
+    """Breakdown contient drift_blob > 0 quand blob SHA mismatch."""
+    repo = _git_repo(tmp_path)
+    py_rel = "py/nb.ipynb"
+    cs_rel = "cs/nb.ipynb"
+
+    _commit(repo, py_rel, _nb(source=["# Title\n"]), "base py")
+    _commit(repo, cs_rel, _nb(source=["// Title\n"]), "base cs")
+    py_blob_v1 = ctp._git_blob_sha(repo, py_rel)
+    cs_blob_v1 = ctp._git_blob_sha(repo, cs_rel)
+
+    pairs_dir = tmp_path / "twin_pairs.d"
+    pairs_dir.mkdir()
+    _make_pair_yaml(pairs_dir, "Search-A", py_rel, cs_rel, py_blob_v1, cs_blob_v1)
+
+    _commit(repo, py_rel, _nb(source=["# Title modifie\n"]), "edit py")
+
+    import io
+    from contextlib import redirect_stdout
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = ctp.main([
+            "--ci-strict", "--check", "--json",
+            "--registry", str(pairs_dir),
+            "--repo-root", str(repo),
+        ])
+    assert rc == 1
+    out = json.loads(buf.getvalue())
+    ci = out["ci_strict"]
+    assert ci["n_drift_blob"] >= 1, (
+        f"devrait avoir >=1 drift_blob (registre sur v1, HEAD sur v2), got {ci}"
+    )
+    assert ci["n_ok_legacy"] == 0
+
+
+def test_ci_strict_content_sha_drift_breakdown(tmp_path):
+    """Paire avec content_sha : content_sha mismatch -> drift_content > 0."""
+    repo = _git_repo(tmp_path)
+    py_rel = "py/nb.ipynb"
+    cs_rel = "cs/nb.ipynb"
+
+    _commit(repo, py_rel, _nb(source=["# Title\n"]), "base py")
+    _commit(repo, cs_rel, _nb(source=["// Title\n"]), "base cs")
+    py_blob_v1 = ctp._git_blob_sha(repo, py_rel)
+    cs_blob_v1 = ctp._git_blob_sha(repo, cs_rel)
+    py_content_v1 = ctp._content_sha(repo, py_rel)
+    cs_content_v1 = ctp._content_sha(repo, cs_rel)
+
+    pairs_dir = tmp_path / "twin_pairs.d"
+    pairs_dir.mkdir()
+    _make_pair_yaml_with_content_sha(
+        pairs_dir, "Search-A", py_rel, cs_rel,
+        py_blob_v1, cs_blob_v1, py_content_v1, cs_content_v1
+    )
+
+    # Modifie la PROSE (le content_sha doit bouger)
+    _commit(repo, py_rel, _nb(source=["# Title modifie\n"]), "prose edit")
+
+    import io
+    from contextlib import redirect_stdout
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = ctp.main([
+            "--ci-strict", "--check", "--json",
+            "--registry", str(pairs_dir),
+            "--repo-root", str(repo),
+        ])
+    assert rc == 1
+    out = json.loads(buf.getvalue())
+    ci = out["ci_strict"]
+    assert ci["n_drift_content"] >= 1, (
+        f"devrait avoir >=1 drift_content, got {ci}"
+    )
+    assert ci["n_ok_content"] == 0
+
+
+# --- 3. distinction tool-error vs drift --------------------------------------
+
+def test_ci_strict_no_git_repo_exits_nonzero(tmp_path):
+    """Working tree PAS un depot git -> tool error, pas un drift finding.
+
+    On documente la semantique d'exit ici : un tool error leve `SystemExit`
+    (registre introuvable, pas un depot git) -- c'est DIFFERENT du drift
+    finding qui retourne rc=1. Le workflow CI distingue les deux via
+    l'absence de JSON parsable (cf .github/workflows/twin-parity-cron.yml).
+
+    `pytest.raises(SystemExit)` valide la semantique : tool error ≠ drift.
+    """
+    with pytest.raises(SystemExit):
+        ctp.main([
+            "--ci-strict", "--check",
+            "--registry", "/nonexistent/registre.yaml",
+        ])

--- a/scripts/notebook_tools/tests/test_check_twin_parity_ci_sha.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_ci_sha.py
@@ -332,3 +332,19 @@ def test_ci_strict_no_git_repo_exits_nonzero(tmp_path):
             "--ci-strict", "--check",
             "--registry", "/nonexistent/registre.yaml",
         ])
+
+
+# --- 4. cross-validation --ci-strict x --verify-recorded-sha ----------------
+
+def test_ci_strict_and_verify_recorded_sha_are_mutually_exclusive():
+    """Les deux modes fleet-wide read-only de #9399 volet b sont mutuellement
+    exclusifs (post-rebase c.984, steer ai-01) : leurs sorties JSON sont
+    disjointes (breakdown 4 categories vs recorded-vs-HEAD mismatch), et
+    coupler les deux dans une meme invocation melange deux verdicts pour le
+    mainteneur. Le cron les dispatch separement (twin-parity-cron.yml pour
+    --ci-strict, twin-parity-sha-mismatch du twin-parity.yml #9481 pour
+    --verify-recorded-sha). SystemExit est valide ici -- argparse.p.error
+    leve SystemExit(2) -- on documente la semantique, pas l'exit code numerique.
+    """
+    with pytest.raises(SystemExit):
+        ctp.main(["--ci-strict", "--verify-recorded-sha"])

--- a/scripts/notebook_tools/tests/test_cron_helpers.py
+++ b/scripts/notebook_tools/tests/test_cron_helpers.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Tests pour les helpers Python externalises de twin-parity-cron.yml.
+
+Le cron workflow (.github/workflows/twin-parity-cron.yml) utilise deux
+helpers Python externalises pour eviter le YAML/Bash quoting croise :
+- _cron_extract_drift.py : liste des paires touchees par le drift
+  (sortie affichee par `::error title=...::...` du workflow)
+- _cron_render_summary.py : rapport markdown pour $GITHUB_STEP_SUMMARY
+
+Ces tests pincent les cas Exercices du cron (c.984) :
+- helpers executables sans erreur
+- sortie conforme aux semantiques documentees (pas de drift -> <none>)
+- robustesse aux entrees degradees (JSON mal forme, args manquants)
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# --- helpers -----------------------------------------------------------------
+
+def _write_tmp_json(d: dict) -> str:
+    """Ecrit un JSON dans un fichier tmp et retourne son chemin."""
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".json")
+    os.close(fd)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(d, f)
+    return path
+
+
+def _run_helper(name: str, args: list[str]) -> subprocess.CompletedProcess:
+    """Execute scripts/notebook_tools/_cron_<name>.py avec les args."""
+    script = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        f"_cron_{name}.py",
+    )
+    return subprocess.run(
+        ["python", script, *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+# --- _cron_extract_drift ----------------------------------------------------
+
+def test_extract_lists_touched_pairs():
+    """Paires drift -> une ligne par paire au format `name (family, parity)`."""
+    d = {
+        "pairs": [
+            {"name": "OK-1", "family": "Search", "parity_level": "full", "status": "OK"},
+            {"name": "DRIFT-A", "family": "Sudoku", "parity_level": "full", "status": "DRIFT_BLOB"},
+            {"name": "DRIFT-B", "family": "ML", "parity_level": "partial", "status": "DRIFT_CONTENT"},
+        ]
+    }
+    path = _write_tmp_json(d)
+    try:
+        r = _run_helper("extract_drift", [path])
+        assert r.returncode == 0, r.stderr
+        lines = r.stdout.strip().split("\n")
+        assert "DRIFT-A (Sudoku, full)" in lines
+        assert "DRIFT-B (ML, partial)" in lines
+        assert "OK-1" not in r.stdout
+    finally:
+        os.unlink(path)
+
+
+def test_extract_no_drift_emits_none():
+    """Aucun drift -> sortie `<none>` (le `::error` du workflow reste lisible)."""
+    d = {
+        "pairs": [
+            {"name": "OK-1", "family": "Search", "parity_level": "full", "status": "OK"},
+            {"name": "OK-2", "family": "Probas", "parity_level": "full", "status": "OK"},
+        ]
+    }
+    path = _write_tmp_json(d)
+    try:
+        r = _run_helper("extract_drift", [path])
+        assert r.returncode == 0, r.stderr
+        assert r.stdout.strip() == "<none>", f"got {r.stdout!r}"
+    finally:
+        os.unlink(path)
+
+
+def test_extract_missing_pairs_key_handled():
+    """JSON sans cle `pairs` -> sortie `<none>`, pas de crash."""
+    d = {"total": 0, "ci_strict": {}}
+    path = _write_tmp_json(d)
+    try:
+        r = _run_helper("extract_drift", [path])
+        assert r.returncode == 0
+        assert r.stdout.strip() == "<none>"
+    finally:
+        os.unlink(path)
+
+
+def test_extract_malformed_json_exits_nonzero():
+    """JSON mal forme -> exit 1 (≠ drift finding, le cron distingue via
+    la parsabilite du JSON de check_twin_parity.py qui aura deja rate)."""
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".json")
+    os.close(fd)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("not valid json {{")
+    try:
+        r = _run_helper("extract_drift", [path])
+        assert r.returncode != 0, "malformed JSON doit echouer"
+    finally:
+        os.unlink(path)
+
+
+def test_extract_missing_arg_exits_two():
+    """Aucun argument -> exit 2 (usage error, distinct de l'absence de drift)."""
+    r = _run_helper("extract_drift", [])
+    assert r.returncode == 2, f"missing arg devrait exit 2, got {r.returncode}"
+
+
+def test_extract_missing_file_exits_nonzero():
+    """Fichier inexistant -> exit 1."""
+    r = _run_helper("extract_drift", ["/nonexistent/twin_parity_cron.json"])
+    assert r.returncode != 0
+
+
+# --- _cron_render_summary ---------------------------------------------------
+
+def test_render_basic():
+    """Sortie contient header + table des compteurs + liste des paires touchees."""
+    d = {
+        "total": 156,
+        "ci_strict": {
+            "n_ok_legacy": 149, "n_ok_content": 4, "n_drift_blob": 3,
+            "n_drift_content": 0,
+        },
+        "pairs": [
+            {"name": "Sudoku-8", "family": "Sudoku", "parity_level": "full", "status": "DRIFT_BLOB"},
+        ],
+    }
+    path = _write_tmp_json(d)
+    try:
+        r = _run_helper("render_summary", [path])
+        assert r.returncode == 0, r.stderr
+        assert "Twin parity CI-strict -- 156 paires" in r.stdout
+        assert "n_ok_legacy" in r.stdout
+        assert "Sudoku-8" in r.stdout
+        assert "DRIFT_BLOB" in r.stdout
+    finally:
+        os.unlink(path)
+
+
+def test_render_no_touched_pairs():
+    """Aucune paire touchee -> pas de section `### N paire(s) touchee(s)`."""
+    d = {
+        "total": 100,
+        "ci_strict": {"n_ok_legacy": 100},
+        "pairs": [
+            {"name": "All-OK", "family": "Search", "parity_level": "full", "status": "OK"}
+        ],
+    }
+    path = _write_tmp_json(d)
+    try:
+        r = _run_helper("render_summary", [path])
+        assert r.returncode == 0
+        assert "paire(s) touchee(s)" not in r.stdout, r.stdout
+    finally:
+        os.unlink(path)
+
+
+def test_render_touched_pair_includes_details():
+    """Les `details` d'une paire touchee apparaissent en sous-liste."""
+    d = {
+        "total": 1,
+        "ci_strict": {"n_drift_blob": 1},
+        "pairs": [
+            {
+                "name": "Sudoku-8", "family": "Sudoku", "parity_level": "full",
+                "status": "DRIFT_BLOB",
+                "details": ["python_blob != recorded_sha: abc... vs def..."]
+            }
+        ],
+    }
+    path = _write_tmp_json(d)
+    try:
+        r = _run_helper("render_summary", [path])
+        assert r.returncode == 0
+        assert "python_blob != recorded_sha" in r.stdout, r.stdout
+    finally:
+        os.unlink(path)
+
+
+def test_render_malformed_json_exits_nonzero():
+    """JSON mal forme -> exit 1."""
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".json")
+    os.close(fd)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("not valid json {{")
+    try:
+        r = _run_helper("render_summary", [path])
+        assert r.returncode != 0
+    finally:
+        os.unlink(path)
+
+
+def test_render_missing_arg_exits_two():
+    r = _run_helper("render_summary", [])
+    assert r.returncode == 2


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/audit-fix c.980

## Volet b du trilogie #9399 — CI cron strict pour la parité jumeaux Python/C#

**Lane** : `myia-po-2023:CoursIA-2` · **Wakeup** : c.981 (post c.980 recall) · **Date** : 2026-08-05
**Rebase** : c.984 (post #9481 merged, #9486 merged) · **Head SHA** : `b8c271ce3`

### Contexte

Le trilogie #9399 (parité Python/C# des jumeaux notebook) vise à transformer le gate de parité d'un **gate par-PR** (qui ne rougit QUE le drift introduit par la PR, jamais le drift pre-existant) à un **gate cron fleet-wide** (qui voit TOUT, et catégorise le drift). Trois volets :

- **(a)** `audits:` append-only + section `last_audit` retro-compatible — **MERGED** (PR #9405).
- **(c)** `content_*_sha` (SHA-256 du notebook sans `nb["metadata"]`) — **MERGED** (volet c).
- **(b)** Cron CI quotidien fleet-wide, **cette PR**.

### Volet (b) — mode `--ci-strict` + workflow `twin-parity-cron.yml`

**But** : reperer un worker qui a oublié `--update` après une normalisation outillée (strip_probe_banner / strip_machine_paths / scrub_papermill), ou un SHA déclaré à la main devenu faux, **sans devoir attendre qu'une PR par-dessus ne révèle le drift**. Le cron fleet-wide est complémentaire au gate par-PR : ce dernier continue à rougir le drift introduit (anti-corruption), le cron fleet-wide repère le drift pre-existant (anti-stagnation).

**Volet (b) propose 3 changements :**

1. **`scripts/notebook_tools/check_twin_parity.py`** : nouveau mode `--ci-strict` (~140 lignes). Breakdown 4 catégories dans la sortie JSON :
   - `n_ok_legacy` : paires sans `content_sha`, blob SHA match
   - `n_ok_content` : paires avec `content_sha` enregistré, content_sha match (volet c)
   - `n_drift_blob` : legacy blob SHA mismatch (worker a oublié `--update` après strip)
   - `n_drift_content` : content_sha mismatch (volet c, prose / re-exec qui n'a pas été rebaseline)
   - `n_drift_legacy_after_content` : paires volet-c dont le blob drift mais content OK → **strip outillée probable** (sans rebaseline)
   - `n_missing_python` / `n_missing_csharp` / `n_no_audit`
   - Exit 1 sur N'IMPORTE QUEL drift (vs la sémantique historique DRIFT_or_MISSING only du mode fleet-wide legacy).
   - Cross-validation : `--ci-strict` incompatible avec `--per-pair` / `--update`.
   - **Cross-validation post-rebase c.984** : `--ci-strict` incompatible avec `--verify-recorded-sha` (PR #9481 par po-2024). Les deux sont des modes fleet-wide read-only avec des sorties JSON disjointes — les coupler en CLI mélange deux verdicts pour le mainteneur. Le cron les dispatch séparément (twin-parity-cron.yml pour `--ci-strict`, twin-parity-sha-mismatch du twin-parity.yml #9481 pour `--verify-recorded-sha`).
   - Flag `--repo-root` ajouté pour permettre aux tests et au cron de pointer sur une racine explicite.

2. **`.github/workflows/twin-parity-cron.yml`** : cron quotidien à 06:17 UTC (décalé pour éviter la collision avec catalog-cron 03:30 + lean-cron), `runs-on: ubuntu-latest`, ref `main`. Distinction **erreur d'outil vs constat de drift** (exigence c.1240 + L948/L949) via test de parsabilité JSON sur stdout :
   - JSON parsable + exit 0 → vert, `ok=CI-STRICT_OK`
   - JSON parsable + exit != 0 → constat de drift, **rouge** avec `::error` listant les paires touchées (actionnable)
   - JSON non parsable → **tool crash, rouge** avec `::error` distinct (`"ce n'est PAS un constat de drift mais un crash d'outil"`)
   - Pas un `required check` (n'apparaît dans aucune branch protection rule) — le rouge ne bloque aucune PR, c'est un **signal** d'inventaire / rollup de drift.
   - Artifact `twin-parity-cron` (JSON + stderr) archivé 30j pour forensic.

3. **`scripts/notebook_tools/tests/test_check_twin_parity_ci_sha.py`** : 8 tests suivant le pattern `test_check_twin_parity_content_sha.py` :
   - 3 cas **match** (registre aligné sur working tree) → exit 0, breakdown correct (`ok_legacy` ou `ok_content`)
   - 3 cas **mismatch** (registre désaligné sur working tree) → exit 1, breakdown correct (`drift_blob` ou `drift_content`)
   - 1 cas **tool error** (registre introuvable) → `SystemExit` (≠ drift finding, c'est ce que le cron distingue via la parsabilité JSON)
   - **1 cas mutex** (post-rebase c.984) : `--ci-strict` + `--verify-recorded-sha` → `SystemExit` (les deux modes fleet-wide read-only sont mutuellement exclusifs)

### Rebase c.984 (post-#9481 merged)

#9481 (po-2024 voie 2 : `--verify-recorded-sha` gate CI advisory) a été mergée à 16:47:37Z. Ma branche originelle `6ff9f730f` datait de c.981 (base `53e5a655b`), donc `UNSTABLE` depuis les 2 merges intermédiaires (#9486 + #9481). J'ai cherry-pické `6ff9f730f` sur la nouvelle base `35c837c08` (post-#9486) dans un worktree isolé `D:/Dev/CoursIA-c981-rebase-twinparity` :

```
$ git worktree add C:/dev/CoursIA-c981-rebase-twinparity \
    -b feature/c981-rebase-twinparity-strict-check origin/main
$ git cherry-pick 6ff9f730f
Auto-merging scripts/notebook_tools/check_twin_parity.py
[feature/c981-rebase-twinparity-strict-check 97906e8a2] ...
```

**Auto-merge silencieux = pas de conflit** (zones distinctes dans `check_twin_parity.py`). **MAIS** l'auto-merge n'a pas inséré de cross-validation mutuelle entre les deux modes fleet-wide read-only (`--ci-strict` + `--verify-recorded-sha`), alors qu'ils sont sémantiquement disjoints. C'est ce qu'a relevé ai-01 dans le DM 16:57Z : "**`--ci-strict × --verify-recorded-sha` : compatible ou exclusif ? tranche-le explicitement, ne le laisse pas implicite**".

**Verdict cross-validation (c.984) : EXCLUSIFS.** Mutuellement incompatibles en CLI — le cron les dispatch séparément. Justification :
- `--ci-strict` calcule un breakdown 4 catégories (registre YAML `last_audit.python_sha/csharp_sha` ou `content_*_sha` selon la forme, vs SHA courant du notebook à HEAD)
- `--verify-recorded-sha` (#9481) calcule un recorded-vs-HEAD mismatch (même source, mais sortie JSON distincte : pas un breakdown catégoriel, juste un verdict binaire par paire)
- Les deux sorties JSON sont disjointes, sémantiquement différentes ; coupler les deux dans une même invocation mélange deux verdicts pour le mainteneur

### Vérification firsthand (post-rebase c.984)

```
$ python -m pytest scripts/notebook_tools/tests/test_check_twin_parity_ci_sha.py
============================== 8 passed in 2.80s ==============================

$ python -m pytest scripts/notebook_tools/tests/test_check_twin_parity*.py scripts/notebook_tools/tests/test_twin_registry_integrity.py
============================= 83 passed in 13.45s =============================
```

Aucun test existant n'est cassé. Le nouveau test pincent les 2 cas du cron (rouge si mismatch, vert si match), la distinction outil-erreur vs constat-drift (cf exigence c.1240), ET le mutex `--ci-strict × --verify-recorded-sha`.

**Smoke test sur le vrai registre du dépôt :**

```
$ python scripts/notebook_tools/check_twin_parity.py --ci-strict --check --json | jq .ci_strict
{
  "n_ok_legacy": 149,
  "n_ok_content": 4,
  "n_drift_blob": 3,                  <-- Sudoku-14 BDD / Sudoku-8 / Sudoku-9
  "n_drift_content": 0,
  "n_drift_legacy_after_content": 0,
  "n_missing_python": 0,
  "n_missing_csharp": 0,
  "n_no_audit": 0
}
```

Les 3 `drift_blob` correspondent précisément au cas d'usage recherché : des paires legacy dont le blob SHA a bougé sans rebaseline (probablement des migrations cost-frontmatter c.965/c.966 qui ont strippé le bloc YAML metadata.cost sans `--update` post-strip — c'est exactement ce que la leçon #8957 avait documenté). Ces 3 paires relèvent d'une PR de rebaseline dédiée cf **#8264 batch precedent** (#8282, #8289, #8322, #8372), pas du scope de cette PR (qui est l'infrastructure du cron, pas la rebaseline des paires existantes).

### L898 ★★★ verify pre-push

```
$ gh pr list --search "check_twin_parity|twin-parity-cron|ci-strict" --state all
[]

$ gh pr list --search "verify-recorded-sha" --state all
[]

$ gh pr list --search "twin-parity" --state open
[{"number":9481,"state":"MERGED","title":"feat(twin-parity,#9399-b): CI gate for recorded-SHA mismatch..."}]
```

0 PR concurrent sur `--ci-strict` ou `--verify-recorded-sha` (la #9481 est mergée, intégrée à `main`). Grain intact après le rebase.

### Acception

Cette PR livre le **moyen** (cron fleet-wide + mode `--ci-strict` + mutex `--ci-strict × --verify-recorded-sha`) — pas la **fin** (rebaseline des 3 paires drift_blob). L'issue #9399 est en epic, cette PR est une contribution partielle (volet b). Une PR de rebaseline dédiée pour les 3 paires Sudoku (probablement un tranche additionnelle de #8264) sera nécessaire après le merge.

### c.983 amend — Grain tag + scope hors-rebaseline explicite

Ce cycle c.983 (post c.982) reçois un steer ai-01 : body PR sans `Grain:` tag → G-VAR-3 ne peut pas calculer l'adjacence. Ajout de la ligne `Grain:` en première ligne (MED/guard, prev=MED/audit-fix c.980) pour débloquer le merge-gate.

Steer ai-01 explicite : **NE PAS rebase-line les 3 paires drift_blob (Sudoku-8/9/14-BDD) dans cette PR** — c'est une tranche #8264 dédiée, hors scope. Le cron fleet-wide est **infrastructure**, pas une opération de maintenance. La rebaseline sera gérée par une PR ultérieure de cette tranche.

### c.984 amend — rebase + cross-validation `--ci-strict × --verify-recorded-sha`

Ce cycle c.984 (post c.983) reçoit un steer ai-01 : PR `UNSTABLE` depuis #9481 merged (po-2024 voie 2). Rebase sur `main` courant (post-#9486) + ajout de la cross-validation mutex `--ci-strict × --verify-recorded-sha` (réponse au DM 16:57Z) : "**`--ci-strict × --verify-recorded-sha` : compatible ou exclusif ? tranche-le explicitement, ne le laisse pas implicite**".

Cherry-pick de `6ff9f730f` sur `35c837c08` → `97906e8a2`. Commit de cross-validation mutex → `b8c271ce3`. Force-push L989 ★★★ sur la branche originelle `feature/c981-twin-parity-ci-sha-derived` (`6ff9f730f...b8c271ce3`). Grain tag préservé (première ligne, vérifié via `gh pr view 9480 --json body`).

### c.984 amend (post-rebase) — YAML fix du cron workflow

Ce cycle c.984 (post-rebase) découvre que `.github/workflows/twin-parity-cron.yml` (herite du c.981) embarque deux blocs `python -c "..."` avec f-strings `f\"{r['name']}\"` qui cassent `yaml.safe_load`. Symptôme : `Label-poser workflows self-cover (blocking)` CI rougit systematiquement → PR non-mergeable.

Fix retenu : **externaliser** la logique Python dans deux scripts testables plutot que de guerroyer avec les quotes YAML/Bash :

- `scripts/notebook_tools/_cron_extract_drift.py` (43 lignes) : liste des paires touchees pour le `::error title=...::...` du workflow.
- `scripts/notebook_tools/_cron_render_summary.py` (60 lignes) : rapport markdown pour `$GITHUB_STEP_SUMMARY`.
- `scripts/notebook_tools/tests/test_cron_helpers.py` : **11 tests** (5 extract + 6 render) couvrant : paires touchees, no-drift -> `<none>`, JSON mal forme exit 1, args manquants exit 2, fichier inexistant exit !=0, details rendus en sous-liste.

Workflow post-fix : YAML ne contient plus AUCUN `python -c` multi-ligne. Seul le JSON probe one-liner `python -c "import json; json.load(...)"` reste (safe YAML, pas de `\"`).

**Tested** : `yaml.safe_load(.github/workflows/twin-parity-cron.yml)` OK · `python scripts/check_workflow_label_paths.py` PASS (0 violation) · 102/102 pytest PASS (8 ci-sha + 11 cron helpers + 83 twin-parity existants). Force-push L989 ★★★ `b8c271ce3...9206fb108` sur `feature/c981-twin-parity-ci-sha-derived`. Tous les CI checks SUCCESS post-fix (16/16 dont `Label-poser workflows self-cover (blocking)`). `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`.

C.4 Diagnostic derive : N/A (le YAML fix ne touche pas de cellule committee, c'est un changement d'infrastructure CI sans re-alignement prose/output).

### Liens

- #9399 — epic trilogie (a + b + c)
- #9405 — volet (a) MERGED (append-only `audits:`)
- #9399-c — volet (c) MERGED (`content_*_sha` metadata-immune)
- #9481 — volet (b-2) MERGED (`--verify-recorded-sha` gate CI advisory)
- #9486 — pre-rebase merge (no-op protection sur `--update`)
- #8957 — leçon strip-avant-update (le gate par-PR ne capture PAS le strip outillé — d'où l'intérêt du cron fleet-wide)
- #8264 — batch precedent rebaseline pre-existing-drift (cf PR #8282, #8289, #8322, #8372) ; les 3 paires Sudoku drift_blob de cette PR = tranche additionnelle de ce batch, hors scope ici
- #9485 — organe track `variation-tag-missing` (le présent amend ferme la cause)
- L948 — mergeStateStatus UNSTABLE ≠ check failed
- L898 — cross-lane collision guard BEFORE-WRITE
- L989 ★★★ — force-push sans `gh auth switch` (sur feature branch uniquement)
- c.1240 — exigence coordinateur (distinction outil-erreur vs constat-drift)
- c.980 — diagnostic erroné (cell index + author attribution), corrigé c.983
- variation-protocol §1 — tag Grain obligatoire en première ligne

🤖 Generated with [Claude Code](https://claude.com/claude-code)