### PR TITLE
feat(twin-parity,#9399-b): CI gate for recorded-SHA mismatch (advisory, B->A promotion criterion)

### DIFF
--- a/.github/workflows/twin-parity.yml
+++ b/.github/workflows/twin-parity.yml
@@ -141,3 +141,97 @@ jobs:
             twin_parity_report.json
             twin_parity_stderr.log
           if-no-files-found: ignore
+
+  twin-parity-sha-mismatch:
+    # Advisory gate (#9399 volet b) : verifie que les SHA enregistres dans
+    # le registre (last_audit.python_sha/csharp_sha, content_*_sha) sont
+    # identiques aux SHA calcules au HEAD du PR.
+    #
+    # Pourquoi ADVISORY d'abord : 3 paires en mismatch pre-existant sur main
+    # (Sudoku-8 / Sudoku-14 BDD / Sudoku-9 GraphColoring) -- detail cf
+    # c.1267 smoke test + rapport design-gate c.1205. Un gate bloquant
+    # rendrait main permanent red ; un gate advisory surface la regression
+    # sans bloquer le merge, et fournit une baseline quantifiee pour la
+    # promotion (B)->(A) post-rebaseline des 3 drifts.
+    #
+    # Promotion (B)->(A) : quand les 3 pre-existing Sudoku sont rebaselines
+    # (PR dediee cf #8264 batch precedent), basculer le if final en
+    # `exit 1` au lieu de `echo "::warning..."`. Cf twin-parity-drift-audit
+    # pour le precedent advisory-then-blocking.
+    name: "Twin parity SHA mismatch (#9399 volet b, advisory)"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Run recorded-SHA verification
+        id: verify
+        run: |
+          set +e
+          python scripts/notebook_tools/check_twin_parity.py --json --check --verify-recorded-sha > twin_sha_report.json 2>twin_sha_stderr.log
+          EXIT=$?
+          set -e
+          if [ -s twin_sha_stderr.log ]; then
+            echo "Twin-SHA tool diagnostics (stderr, non-fatal):"
+            cat twin_sha_stderr.log
+          fi
+          if ! python -c "import json; json.load(open('twin_sha_report.json'))" 2>/dev/null; then
+            echo "::error title=Twin SHA report unparseable::The JSON report (twin_sha_report.json) could not be parsed. Tool exit was $EXIT. Likely a tool crash before JSON emission."
+            tail -c 400 twin_sha_report.json || true
+            cat twin_sha_stderr.log 2>/dev/null || true
+            exit 1
+          fi
+          # Status dispatch (parity with twin-parity-drift-audit.yml pattern):
+          #   exit 0 = OK; exit 1 = mismatch found; exit !=0,1 = tool failure (RED).
+          python -c "import json; d=json.load(open('twin_sha_report.json')); [print(f'{k}={v}') for k,v in (('total',d.get('total',0)),('ok',d.get('ok',0)),('mismatch',d.get('mismatch',0)),('no_audit',d.get('no_audit',0)))]" | tee -a "$GITHUB_OUTPUT"
+          if [ "$EXIT" != "0" ] && [ "$EXIT" != "1" ]; then
+            echo "::error title=Twin SHA tool crashed::Tool exit code was $EXIT (neither 0=clean nor 1=mismatch). Tool failure, not a mismatch."
+            exit 1
+          fi
+
+      - name: Advisory SHA mismatch summary
+        if: always() && steps.verify.outcome == 'success'
+        run: |
+          MISMATCH="${{ steps.verify.outputs.mismatch }}"
+          NO_AUDIT="${{ steps.verify.outputs.no_audit }}"
+          TOTAL="${{ steps.verify.outputs.total }}"
+          OK="${{ steps.verify.outputs.ok }}"
+          {
+            echo "## Twin parity recorded-SHA verification"
+            echo ""
+            echo "Recorded pairs: **${TOTAL:-?}**. Recorded-SHA matches HEAD: **${OK:-?}**. Mismatch: **${MISMATCH:-?}**. No audit record: **${NO_AUDIT:-?}**."
+            echo ""
+            echo "**Advisory** (#9399 volet b, design-gate posture B): a non-zero mismatch count is a warning, not a red. Mismatch means the YAML's recorded `python_sha` / `csharp_sha` (or `content_*_sha` post-#9447) differs from the SHA computed at HEAD -- fix with \`python scripts/notebook_tools/check_twin_parity.py --update --pair \"<name>\" --by \"<machine:workspace>\"\`."
+            echo ""
+            if [ "${MISMATCH:-0}" != "0" ] || [ "${NO_AUDIT:-0}" != "0" ]; then
+              echo "Mismatched / un-audited pairs:"
+              python -c "import json; d=json.load(open('twin_sha_report.json')); [print(f\"- **{p['name']}** ({p.get('family','?')}): {p.get('status')}\") for p in d.get('pairs',[]) if p.get('status') != 'OK']" || true
+            else
+              echo "All recorded SHAs match HEAD. Promotion criterion (B)->(A) is met : this gate can flip to blocking."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Advisory: non-zero mismatch -> ::warning, exit 0. Tool failures above red.
+          if [ "${MISMATCH:-0}" != "0" ]; then
+            echo "::warning title=Twin parity recorded-SHA mismatch (advisory)::${MISMATCH:-?} pair(s) have a recorded python_sha/csharp_sha (or content_*_sha) that differs from the SHA computed at HEAD. Advisory per design-gate #9399 posture (B). See job summary. Run \`check_twin_parity.py --update --pair <name>\` to rebaseline. Volet (c) (#9447) added content_*_sha to make this gate metadata-immune."
+          fi
+
+      - name: Upload SHA report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: twin-sha-mismatch-report
+          path: |
+            twin_sha_report.json
+            twin_sha_stderr.log
+          if-no-files-found: ignore

--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -535,6 +535,95 @@ def update_pair(
     return audit, cur_py
 
 
+def verify_recorded_sha(repo_root: Path, pair: dict) -> dict:
+    """Verifie que les SHA enregistres dans le YAML correspondent aux SHA
+    calcules a HEAD (#9399 volet b).
+
+    Cible l'acceptance verbatim du design-gate (#9399 c.1205) :
+    « La CI calcule python_sha / csharp_sha / content_*_sha et echoue si le
+    YAML committé diverge ». Detecte un SHA invente / stale / corrompu en
+    comparant ce que `last_audit:` (legacy) ou `audits[-1]` (append-only)
+    declare au SHA reel du carnet a HEAD.
+
+    Distinction avec `check_pair` (mode --per-pair) :
+      - check_pair compare HEAD vs base-ref, et tolere DRIFT_PRE_EXISTING
+        (un rebaseline historique peut dater d'un main anterieur) ;
+      - verify_recorded_sha compare YAML-enregistre vs HEAD-calcule -- une
+        valeur recorded egale a la valeur courante est legit, une valeur
+        recorded divergente = MISMATCH (le sha a ete ecrit a la main, pas via
+        --update, ou le carnet a bouge sans rebaseline).
+
+    Migration progressive : les paires non encore re-auditees post-volet-(c)
+    ont `content_*_sha: None` ; on les SAUTE (pas un mismatch, juste
+    « pas encore migre »). Meme politique que les tests rename-aware (#9473).
+
+    Sortie : dict avec `status` ("OK" / "MISMATCH" / "NO_AUDIT"), `mismatches`
+    (liste de chaines courtes), `name` (utile au mode --json).
+    """
+    py = pair["python"]
+    cs = pair["csharp"]
+    audit = _latest_audit(pair)
+    if not audit:
+        return {
+            "name": pair.get("name", "?"),
+            "status": "NO_AUDIT",
+            "mismatches": [],
+        }
+
+    # SHA calcules a HEAD (jamais lus a la main -- re-calcules systematiquement).
+    cur_py = _git_blob_sha(repo_root, py)
+    cur_cs = _git_blob_sha(repo_root, cs)
+    cur_cpy = _content_sha(repo_root, py)
+    cur_ccs = _content_sha(repo_root, cs)
+
+    # SHA enregistres dans le YAML (forme append-only ou legacy, _latest_audit
+    # normalise les deux).
+    rec_py = audit.get("python_sha")
+    rec_cs = audit.get("csharp_sha")
+    rec_cpy = audit.get("content_python_sha")
+    rec_ccs = audit.get("content_csharp_sha")
+
+    mismatches = []
+    # Comparaison sur les blob SHA : compares stricte.
+    if rec_py is not None and rec_py != cur_py:
+        mismatches.append(
+            f"python_sha: recorded={rec_py[:12]} calculated={cur_py[:12]}"
+        )
+    if rec_cs is not None and rec_cs != cur_cs:
+        mismatches.append(
+            f"csharp_sha: recorded={rec_cs[:12]} calculated={cur_cs[:12]}"
+        )
+    # Comparaison sur les content_sha : on SKIP si recorded=None (migration
+    # progressive post-volet-(c) ; les paires legacy n'ont pas encore ces
+    # champs). Une comparaison `None != cur_cpy` serait un faux positif de
+    # masse (cf doctrine rename-aware #9473 -- tolerer les absences
+    # transitoires sur les champs ajoutes apres coup).
+    if rec_cpy is not None and rec_cpy != cur_cpy:
+        mismatches.append(
+            f"content_python_sha: recorded={rec_cpy[:12]} calculated={cur_cpy[:12]}"
+        )
+    if rec_ccs is not None and rec_ccs != cur_ccs:
+        mismatches.append(
+            f"content_csharp_sha: recorded={rec_ccs[:12]} calculated={cur_ccs[:12]}"
+        )
+
+    return {
+        "name": pair.get("name", "?"),
+        "family": pair.get("family", "?"),
+        "parity_level": pair.get("parity_level", "?"),
+        "status": "MISMATCH" if mismatches else "OK",
+        "mismatches": mismatches,
+        "current_python_sha": cur_py,
+        "current_csharp_sha": cur_cs,
+        "current_content_python_sha": cur_cpy,
+        "current_content_csharp_sha": cur_ccs,
+        "recorded_python_sha": rec_py,
+        "recorded_csharp_sha": rec_cs,
+        "recorded_content_python_sha": rec_cpy,
+        "recorded_content_csharp_sha": rec_ccs,
+    }
+
+
 # Cles scalaires d'un enregistrement d'audit (forme append-only ET legacy).
 # Partagees par le singleton `last_audit:` (legacy) et chaque element de la
 # liste `audits:` (append-only, #9399).
@@ -869,18 +958,27 @@ def main(argv=None) -> int:
                         "'myia-po-2024:CoursIA-2'). Avec --update, la date est "
                         "TOUJOURS mise a aujourd'hui : sans --by, l'entree garderait "
                         "l'auteur de l'audit precedent alors que les SHAs sont neufs.")
+    p.add_argument("--verify-recorded-sha", action="store_true",
+                   help="Gate CI #9399 volet b : verifie que les SHA enregistres "
+                        "dans le YAML (last_audit legacy OU audits[-1] append-only) "
+                        "correspondent aux SHA recalcules a HEAD (git ls-tree + "
+                        "SHA-256 metadata-immune). Exit 1 si MISMATCH sur au moins "
+                        "une paire (avec --check). Mode read-only : n'ecrit rien.")
     args = p.parse_args(argv)
 
     # Cross-validation : --per-pair <-> --base
-    if args.coverage and (args.update or args.per_pair or args.base):
+    if args.coverage and (args.update or args.per_pair or args.base or args.verify_recorded_sha):
         p.error("--coverage est un mode de recensement seul : incompatible avec "
-                "--update / --per-pair / --base.")
+                "--update / --per-pair / --base / --verify-recorded-sha.")
     if args.per_pair and not args.base:
         p.error("--per-pair necessite --base <ref>")
     if args.base and not args.per_pair:
         p.error("--base necessite --per-pair")
-    if args.update and (args.per_pair or args.base):
-        p.error("--update est incompatible avec --per-pair/--base")
+    if args.update and (args.per_pair or args.base or args.verify_recorded_sha):
+        p.error("--update est incompatible avec --per-pair/--base/--verify-recorded-sha")
+    if args.verify_recorded_sha and (args.per_pair or args.base or args.update):
+        p.error("--verify-recorded-sha est read-only : incompatible avec "
+                "--update/--per-pair/--base.")
     # --update exige un selecteur (anti-corruption silencieuse du registre, cf #8508)
     if args.update and not (args.family or args.pair or args.yes_all_pairs):
         p.error("--update exige un selecteur explicite : --family <f>, --pair <name>, "
@@ -1109,6 +1207,72 @@ def main(argv=None) -> int:
             "normaliser (strip_probe_banner / strip_machine_paths / scrub_papermill), "
             "refaites --update en dernier, apres (cf #8957)."
         )
+        return 0
+
+    # --- Mode --verify-recorded-sha : gate CI (#9399 volet b) ---
+    if args.verify_recorded_sha:
+        # Accepte --family comme selecteur (replique la politique --update) :
+        # en CI on cible generalement tout le registre, mais un audit local peut
+        # vouloir borner a une famille.
+        target_pairs = pairs
+        if args.family:
+            target_pairs = [pp for pp in target_pairs if pp.get("family") == args.family]
+            if not target_pairs:
+                print(
+                    f"Aucune paire pour la famille '{args.family}'.",
+                    file=sys.stderr,
+                )
+                # En --check ce serait un gate casse ; ici on retourne 2
+                # (distinct de 1=MISMATCH, 0=clean) pour discriminer le cas.
+                return 2
+
+        results = [verify_recorded_sha(repo_root, pp) for pp in target_pairs]
+        n_ok = sum(1 for r in results if r["status"] == "OK")
+        n_mismatch = sum(1 for r in results if r["status"] == "MISMATCH")
+        n_no_audit = sum(1 for r in results if r["status"] == "NO_AUDIT")
+
+        if args.json:
+            out = {
+                "mode": "verify_recorded_sha",
+                "registry": str(reg_path),
+                "total": len(results),
+                "ok": n_ok,
+                "mismatch": n_mismatch,
+                "no_audit": n_no_audit,
+                "pairs": results,
+            }
+            print(json.dumps(out, ensure_ascii=False, indent=2))
+        else:
+            tag_map = {"OK": "OK", "MISMATCH": "MISMATCH", "NO_AUDIT": "NO_AUDIT"}
+            for r in results:
+                if r["status"] == "OK":
+                    continue  # ne pas bruiter les OK en sortie humaine
+                tag = tag_map[r["status"]]
+                print(f"[{tag}] {r['name']} ({r.get('family','?')})")
+                for m in r.get("mismatches", []):
+                    print(f"       - {m}")
+            print(
+                f"\nTotal : {len(results)} paire(s) | "
+                f"OK={n_ok} MISMATCH={n_mismatch} NO_AUDIT={n_no_audit}"
+            )
+
+        if args.check and n_mismatch > 0:
+            # Gate CI : un seul mismatch = RED. Message d'erreur oriente
+            # l'auteur vers --update (le seul moyen legitime de resoudre :
+            # l'audit firsthand + rebaseline, cf #8508 selector policy).
+            print(
+                f"::error title=Twin parity SHA mismatch (#9399 volet b)::"
+                f"{n_mismatch} paire(s) ont un SHA enregistre dans le YAML qui ne "
+                f"correspond pas au SHA reel du carnet a HEAD. L'integrite du "
+                f"registre est corrompue (sha invente / stale / modifie a la "
+                f"main). Remediation : lancer "
+                f"`python scripts/notebook_tools/check_twin_parity.py --update "
+                f"--pair \"<nom>\" --by \"<machine:workspace>\"` APRES audit "
+                f"firsthand de la parite. Le selecteur --pair est obligatoire "
+                f"(cf #8508).",
+                file=sys.stderr,
+            )
+            return 1
         return 0
 
     results = [check_pair(repo_root, pp) for pp in pairs]

--- a/scripts/notebook_tools/tests/test_twin_registry_integrity.py
+++ b/scripts/notebook_tools/tests/test_twin_registry_integrity.py
@@ -33,7 +33,7 @@ yaml = pytest.importorskip("yaml")
 # Source unique de verite : le loader de check_twin_parity (evite de dupliquer
 # la logique d'agregation du repertoire file-per-entry).
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from check_twin_parity import load_registry, _slug, _latest_audit  # noqa: E402
+from check_twin_parity import load_registry, _slug, _latest_audit, verify_recorded_sha  # noqa: E402
 
 REGISTRY_DIR = Path(__file__).resolve().parents[1] / "twin_pairs.d"
 SCHEMA = REGISTRY_DIR / "_schema.yaml"
@@ -528,3 +528,165 @@ def test_classify_attested_sha_ok_fabricated_crossfile_renamed():
     v, d = _classify_attested_sha("shaX_renamed", "A/X.ipynb", path_blobs, blob_paths, declared)
     assert v == "renamed"
     assert "X_old" in d
+
+
+# --- tests verify_recorded_sha (#9399 volet b) ------------------------------
+#
+# Le mode CI --verify-recorded-sha detecte un SHA enregistre dans le YAML qui
+# ne correspond pas au SHA reel du carnet a HEAD. Cible l'acceptance verbatim
+# « la CI calcule python_sha/csharp_sha/content_*_sha et echoue si le YAML
+# committé diverge ». On unitarise les 4 branches (OK/PY-NOPE/CS-NOPE/BOTH-NOPE)
+# en mockant _git_blob_sha et _content_sha pour controler les valeurs
+# calculees, sans dependre de l'etat du repo.
+
+
+def test_verify_recorded_sha_ok_when_recorded_matches_calculated(tmp_path, monkeypatch):
+    """Recorded == calculated -> OK, pas de mismatch."""
+    fake_pair = {
+        "name": "Test-OK",
+        "family": "Test",
+        "python": "X.ipynb",
+        "csharp": "Y.ipynb",
+        "parity_level": "surface",
+        "last_audit": {
+            "date": "2026-08-05",
+            "by": "test",
+            "python_sha": "a" * 40,
+            "csharp_sha": "b" * 40,
+            "content_python_sha": "c" * 64,
+            "content_csharp_sha": "d" * 64,
+        },
+    }
+    # Mock les helpers de hash pour retourner des valeurs connues.
+    import check_twin_parity as ct
+    monkeypatch.setattr(ct, "_git_blob_sha", lambda *a, **kw: "a" * 40 if kw.get("git_ref") is None or "Y" not in str(a[1] if len(a) > 1 else "") else "b" * 40)
+    # Mock plus precis : return different sha based on path.
+    def _hash_blob(repo_root, path, git_ref="HEAD"):
+        return "a" * 40 if path == "X.ipynb" else "b" * 40
+    def _hash_content(repo_root, path, git_ref="HEAD"):
+        return "c" * 64 if path == "X.ipynb" else "d" * 64
+    monkeypatch.setattr(ct, "_git_blob_sha", _hash_blob)
+    monkeypatch.setattr(ct, "_content_sha", _hash_content)
+
+    r = verify_recorded_sha(tmp_path, fake_pair)
+    assert r["status"] == "OK"
+    assert r["mismatches"] == []
+    assert r["name"] == "Test-OK"
+
+
+def test_verify_recorded_sha_mismatch_on_python_sha(tmp_path, monkeypatch):
+    """Recorded python_sha diverge du SHA reel -> MISMATCH sur python_sha."""
+    fake_pair = {
+        "name": "Test-Mismatch-Py",
+        "family": "Test",
+        "python": "X.ipynb",
+        "csharp": "Y.ipynb",
+        "parity_level": "surface",
+        "last_audit": {
+            "date": "2026-08-05",
+            "by": "test",
+            "python_sha": "0" * 40,  # recorded = zeros
+            "csharp_sha": "b" * 40,
+        },
+    }
+    import check_twin_parity as ct
+    monkeypatch.setattr(ct, "_git_blob_sha", lambda rr, p, git_ref="HEAD": "a" * 40 if p == "X.ipynb" else "b" * 40)
+    monkeypatch.setattr(ct, "_content_sha", lambda rr, p, git_ref="HEAD": None)  # not used
+
+    r = verify_recorded_sha(tmp_path, fake_pair)
+    assert r["status"] == "MISMATCH"
+    assert len(r["mismatches"]) == 1
+    assert "python_sha" in r["mismatches"][0]
+    assert ("0" * 12) in r["mismatches"][0]
+    assert ("a" * 12) in r["mismatches"][0]
+
+
+def test_verify_recorded_sha_mismatch_on_both_sides(tmp_path, monkeypatch):
+    """Recorded python_sha ET csharp_sha divergent -> MISMATCH sur les 2."""
+    fake_pair = {
+        "name": "Test-Mismatch-Both",
+        "family": "Test",
+        "python": "X.ipynb",
+        "csharp": "Y.ipynb",
+        "parity_level": "surface",
+        "last_audit": {
+            "date": "2026-08-05",
+            "by": "test",
+            "python_sha": "0" * 40,
+            "csharp_sha": "0" * 40,
+        },
+    }
+    import check_twin_parity as ct
+    monkeypatch.setattr(ct, "_git_blob_sha", lambda rr, p, git_ref="HEAD": "a" * 40 if p == "X.ipynb" else "b" * 40)
+    monkeypatch.setattr(ct, "_content_sha", lambda rr, p, git_ref="HEAD": None)
+
+    r = verify_recorded_sha(tmp_path, fake_pair)
+    assert r["status"] == "MISMATCH"
+    assert len(r["mismatches"]) == 2
+    assert any("python_sha" in m for m in r["mismatches"])
+    assert any("csharp_sha" in m for m in r["mismatches"])
+
+
+def test_verify_recorded_sha_no_audit_record(tmp_path):
+    """Pas de last_audit ni audits -> NO_AUDIT, pas de MISMATCH."""
+    fake_pair = {
+        "name": "Test-NoAudit",
+        "family": "Test",
+        "python": "X.ipynb",
+        "csharp": "Y.ipynb",
+        "parity_level": "surface",
+        # pas de last_audit, pas de audits
+    }
+    r = verify_recorded_sha(tmp_path, fake_pair)
+    assert r["status"] == "NO_AUDIT"
+    assert r["mismatches"] == []
+
+
+def test_verify_recorded_sha_legacy_vs_append_only_equivalent(tmp_path, monkeypatch):
+    """Memes SHA dans `last_audit` (legacy) et `audits[-1]` (append-only) -> OK dans les 2 formes."""
+    sha_py = "a" * 40
+    sha_cs = "b" * 40
+    base = {
+        "name": "Test-Equiv",
+        "family": "Test",
+        "python": "X.ipynb",
+        "csharp": "Y.ipynb",
+        "parity_level": "surface",
+    }
+    import check_twin_parity as ct
+    monkeypatch.setattr(ct, "_git_blob_sha", lambda rr, p, git_ref="HEAD": sha_py if p == "X.ipynb" else sha_cs)
+    monkeypatch.setattr(ct, "_content_sha", lambda rr, p, git_ref="HEAD": None)
+
+    legacy = dict(base, last_audit={"date": "2026-08-05", "by": "test", "python_sha": sha_py, "csharp_sha": sha_cs})
+    append_only = dict(base, audits=[{"date": "2026-08-05", "by": "test", "python_sha": sha_py, "csharp_sha": sha_cs}])
+
+    r_legacy = verify_recorded_sha(tmp_path, legacy)
+    r_append = verify_recorded_sha(tmp_path, append_only)
+    assert r_legacy["status"] == "OK"
+    assert r_append["status"] == "OK"
+
+
+def test_verify_recorded_sha_skips_none_content_sha(tmp_path, monkeypatch):
+    """Recorded content_*_sha = None (migration post-volet-(c) pas faite) -> SKIP, pas MISMATCH."""
+    fake_pair = {
+        "name": "Test-NoContentSha",
+        "family": "Test",
+        "python": "X.ipynb",
+        "csharp": "Y.ipynb",
+        "parity_level": "surface",
+        "last_audit": {
+            "date": "2026-08-05",
+            "by": "test",
+            "python_sha": "a" * 40,
+            "csharp_sha": "b" * 40,
+            # content_*_sha absents -> devraient etre ignores (migration progressive)
+        },
+    }
+    import check_twin_parity as ct
+    monkeypatch.setattr(ct, "_git_blob_sha", lambda rr, p, git_ref="HEAD": "a" * 40 if p == "X.ipynb" else "b" * 40)
+    # _content_sha retourne une valeur meme si recorded=None : c'est OK, on
+    # ne signale pas de mismatch tant que recorded est None.
+    monkeypatch.setattr(ct, "_content_sha", lambda rr, p, git_ref="HEAD": "c" * 64 if p == "X.ipynb" else "d" * 64)
+
+    r = verify_recorded_sha(tmp_path, fake_pair)
+    assert r["status"] == "OK", f"unexpected mismatches: {r['mismatches']}"


### PR DESCRIPTION
Grain: DEEP/guard — lane myia-po-2024:CoursIA-2 — prev: MED/infer-cleanup

Volet-b of #9399 : the **recorded-SHA in YAML** vs **computed-SHA at HEAD** CI gate. This is the design-gate acceptance verbatim :

> [x] La CI calcule `python_sha` / `csharp_sha` / `content_*_sha` et échoue si le YAML committé diverge

(echoue -> advisory at the moment, cf § "Gate semantics" below for the B->A promotion criterion)

## What

1. `check_twin_parity.verify_recorded_sha(repo_root, pair)` — new function that compares the YAML-recorded `last_audit.python_sha`/`csharp_sha` (legacy) or `audits[-1]`-recorded (append-only) — plus `content_*_sha` post-#9447 — to the SHA actually computed at HEAD. Three statuses: `OK` / `MISMATCH` / `NO_AUDIT`.
2. `--verify-recorded-sha` CLI mode (with `--json` and `--check`). Read-only, exit 0 if OK, exit 1 on any MISMATCH, exit 2 if registry misses.
3. 6 new unit tests in `test_twin_registry_integrity.py` — OK / MISMATCH single-side / MISMATCH both-sides / NO_AUDIT / legacy-equivalence / `content_*_sha: None` skip-policy.
4. New CI job `twin-parity-sha-mismatch` in `.github/workflows/twin-parity.yml` parallel to the existing blocking job, advisory-only initially.

## Gate semantics

Advisory at the moment (posture B, mirroring the proven `twin-parity-drift-audit` precedent of #9443). Reason: **3 pairs on main are ALREADY in MISMATCH**:

| Pair | Family | Reason (pre-existing) |
|---|---|---|
| Sudoku-8 HumanStrategies | Sudoku | nb metadata stamp drift |
| Sudoku-14 BDD | Sudoku | nb metadata stamp drift |
| Sudoku-9 GraphColoring | Sudoku | nb metadata stamp drift |

A blocking gate would rouge main permanent. Promotion (B)->(A) criterion : 0 pre-existing mismatches at HEAD, attestable via `twin_sha_report.json` artifact (= the voluminous job summary that lists mismatched pairs). When the 3 Sudoku are rebaselined in a dedicated rebaseline PR (cf #8264 batch precedent), the new CI step flips from advisory `::warning` to blocking `exit 1`.

## Design notes

- **Why a new job, not a new step in the existing job** : the existing `twin-parity` job is BLOCKING on DRIFT_INTRODUCED. Adding an advisory step inside a blocking job would create one of two confusing postures (advisory-within-blocking : what does a step `if: failure()` mean here?). A parallel advisory job is cleaner and matches the pattern established by `twin-parity-drift-audit.yml`.
- **Why not merge `--verify-recorded-sha` into `--per-pair`** : the two gates have different acceptance semantics. `--per-pair` compares HEAD vs base-ref and tolerates `DRIFT_PRE_EXISTING` (a deliberate batch rebaseline can lag main). `--verify-recorded-sha` is a fixed-point check ("what the YAML says == what HEAD has") — no tolerance for any recorded != current divergence. Conflating them would lose the per-pair classification that the existing gate uses to keep single-side edits from blocking a PR.
- **Skip policy for `content_*_sha: None`** : the migration from `last_audit:` legacy form to append-only `audits:` (with optional `content_*_sha`) is progressive. A pair not yet re-audited post-#9447 has `content_*_sha: None` — we **skip** these silently, no mismatch. Documented in function docstring + test `test_verify_recorded_sha_skips_none_content_sha`.
- **No **B** codified for `verdict` per-pair (introduced / pre-existing)** : the mode is intentionally simpler than `--per-pair`. Classification per-PR for introduced-vs-pre-existing would require re-deriving the base-ref logic, which lives in `check_pair`. Out of scope for this PR; the design-gate says "verifies recorded == computed", the per-pair classification belongs to `--per-pair`.

## Verification

- 6 new unit tests pass (all paths : OK / MISMATCH python-only / MISMATCH both / NO_AUDIT / legacy-vs-append-only equivalence / `content_*_sha: None` skip).
- Full test suite green : `pytest scripts/notebook_tools/tests/` -> **3841 passed in 78.87s**.
- CLI smoke test on origin/main : `mode=verify_recorded_sha total=156 ok=153 mismatch=3 no_audit=0` — exactly the 3 Sudoku pre-existing drifts known to the design gate.
- Workflow YAML validates clean (`yaml.safe_load` -> no parse error).
- Diff is **+425/-5 across 3 files**, well below the 3000-line composite-split threshold (cf `.claude/rules/pr-review-discipline.md` A).

## Files

| File | +/- |
|---|---|
| `.github/workflows/twin-parity.yml` | +94 |
| `scripts/notebook_tools/check_twin_parity.py` | +172/-5 |
| `scripts/notebook_tools/tests/test_twin_registry_integrity.py` | +164 |

## Coordination

- (B) Posture rationale was ai-01's verbatim c.1205 design-gate ("advise d'abord vu 3 pre-existing drifts"), confirmed by smoke test firsthand this cycle.
- Lane: `myia-po-2024:CoursIA-2` (po-2024 single GPU machine, owner of `scripts/notebook_tools/` tooling per memory partition).
- Re-arm cron: **JOB 492f37f6**, every 30 minutes, per user mid-turn directive ("Reprends et réarme ton cron 30 minutes après une MAJ vscode"). Verified via `CronList` post-re-arm.

Closes #9399 (voilet b only ; volets a/c are #8057 and #9447)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
