### PR TITLE
feat(prose,#9434): add machine_dep + env_dep classes to prose quant scanner

### DIFF
--- a/scripts/notebook_tools/check_prose_quantitative_claims.py
+++ b/scripts/notebook_tools/check_prose_quantitative_claims.py
@@ -49,6 +49,36 @@ Usage
 
     # Bloquant (une fois le stock vide)
     python check_prose_quantitative_claims.py --diff origin/main...HEAD --strict
+
+Ligne de partage #9434 (4 classes de valeurs quantitatives)
+-----------------------------------------------------------
+Le mandat #9377 a ete applique aux README (cf PR #9384, #9425, #9432).
+La vague #8052/#9426-9429 l'a etendu a l'interieur des notebooks : les
+memes PR qui re-alignent la prose sur une sortie commisee re-epinglent
+des valeurs qui rebougeront au prochain passage kernel. Pour rendre la
+regle applicable plutot que dogmatique, le scanner distingue 4 classes :
+
+  - **structurel**   : ordre de grandeur stable cross-machine (autorise).
+                       Le scanner NE remonte PAS cette classe : elle est
+                       du contenu pedagogique reel, pas une mesure d'etat.
+  - **artifact**     : compteur d'artefact (lignes/cells/notebooks), le
+                       stock historique remonte depuis #9377.
+  - **machine_dep**  : temps absolu en unite de duree (`(28-364 ms)`,
+                       `~2.4s`, `12 min`) — derive a chaque re-execution.
+                       Re-epingler cette classe = fabriquer de la derive.
+  - **env_dep**      : version de librairie (`NumPy 2.4.2`, `Python 3.11+`,
+                       `PyTorch 2.4.1+cu121`) — derive a chaque bump.
+                       Cf PR #9429 GT-4c-NashExistence.
+  - **stochastique** : fitness/score d'un GA non-seeded, accuracy non-
+                       seedee — derive a chaque run. La detection de cette
+                       classe necessite un contexte semantique que le
+                       regex seul ne peut pas trancher ; le scanner s'en
+                       remet a l'oeil humain sur l'output `git diff`.
+
+    # Tri par classe (le plus utile : cibler une PR precise)
+    python check_prose_quantitative_claims.py --diff origin/main...HEAD --class=artifact
+    python check_prose_quantitative_claims.py --diff origin/main...HEAD --class=machine_dep
+    python check_prose_quantitative_claims.py --diff origin/main...HEAD --class=env_dep
 """
 
 from __future__ import annotations
@@ -71,6 +101,45 @@ ARTIFACT_NOUNS = r"(?:lignes?|lines?|cellules?|cells?|notebooks?|modules?|fichie
 COUNT_RE = re.compile(
     r"(?<![\w.])~?\*{0,2}\d{1,6}\*{0,2}\s+" + ARTIFACT_NOUNS + r"(?![\w-])",
     re.IGNORECASE,
+)
+
+# --- ligne de partage #9434 : 4 classes de valeurs quantitatives en prose -----
+# Le mandat #9377/#9434 distingue :
+#  - structurel     : ordre de grandeur stable cross-machine (autorise en prose)
+#  - machine_dep    : temps absolus en ms/s/... ; derive a chaque re-exec
+#  - env_dep        : versions de librairie ; derive a chaque bump
+#  - stochastique   : fitness/score non-seeded ; derive a chaque run
+# Les 3 dernieres re-epinglent une valeur qui rebougera, cf PR #9426-9429.
+# CATALOG-STATUS deja neutralise par GENERATED_MARKERS.
+
+# machine_dep : `(28-364 ms)`, `24.5ms`, `~2.4s`, `0.3 us`, `12 min`, `2 h`.
+# On accepte un nombre flottant precede ou non de `~`, suivi de l'unite.
+# Les plages `28-364 ms` / `24-127 ms` sont capturees integralement (un seul
+# finding par plage, pas un par borne) pour eviter le bruit de doublons.
+TIMING_RE = re.compile(
+    r"(?<![\w.])~?(?:\d+(?:\.\d+)?\s*-\s*)?\d+(?:\.\d+)?\s*"
+    r"(?:µs|us|ms|s|min|h|hr|hours?|minutes?|seconds?|milliseconds?|microseconds?)\b",
+    re.IGNORECASE,
+)
+
+# env_dep : `NumPy 2.4.2`, `Python 3.11`, `Python 3.10+`, `PyTorch 2.4.1+cu121`.
+# Liste fermee de packages : ajouter une entree = modifier le guard, c'est
+# voulu (cf regle anti-monoculture vocab). Le `+` final accepte `3.10+`.
+ENV_RE = re.compile(
+    r"\b(?:Python|CPython|NumPy|numpy|TensorFlow|PyTorch|torch|Java|dotnet|"
+    r"\.NET|scikit-learn|sklearn|Pandas|pandas|Matplotlib|matplotlib|"
+    r"SciPy|scipy|SymPy|sympy|Jupyter|IPython|papermill|"
+    r"transformers|datasets|huggingface_hub|"
+    r"ortools|OR-Tools|pulp|PuLP|z3|CPLEX|Gurobi)\s+"
+    r"\d+\.\d+(?:\.\d+)?\+?",
+    re.IGNORECASE,
+)
+
+# Patterns regroupes pour scan ; ordre = priorite (machine_dep avant env_dep
+# car un env peut etre precede d'un timing dans le meme bloc).
+CLASS_PATTERNS = (
+    ("machine_dep", TIMING_RE),
+    ("env_dep", ENV_RE),
 )
 
 # Une ligne de diff .ipynb qui ouvre un champ JSON autre que "source" est une
@@ -140,17 +209,37 @@ def _iter_markdown_sources(nb_path: Path):
         yield idx, src
 
 
-def _findings_in_text(text: str, location: str) -> list[tuple[str, str]]:
+def _findings_in_text(
+    text: str, location: str, klass_filter: str | None = None
+) -> list[tuple[str, str]]:
+    """Renvoie (location, snippet) pour chaque finding.
+
+    `klass_filter` ∈ {"artifact", "machine_dep", "env_dep", None}.
+    - "artifact"      : ne renvoie QUE les compteurs attaches a un artefact
+                        (le comportement historique, COUNT_RE).
+    - "machine_dep"   : ne renvoie QUE les temps en unite de duree.
+    - "env_dep"       : ne renvoie QUE les versions de librairie.
+    - None (defaut)   : renvoie TOUTES les classes (artifact + machine_dep + env_dep).
+    """
     out = []
     for line in text.splitlines():
         if any(m in line for m in GENERATED_MARKERS):
             continue
-        for match in COUNT_RE.finditer(line):
-            out.append((location, match.group(0).strip()))
+        # Classe artifact : comportement historique inchange.
+        if klass_filter in (None, "artifact"):
+            for match in COUNT_RE.finditer(line):
+                out.append((location, match.group(0).strip()))
+        # Classes #9434 : machine_dep / env_dep.
+        if klass_filter in (None, "machine_dep", "env_dep"):
+            for klass_label, pattern in CLASS_PATTERNS:
+                if klass_filter is not None and klass_filter != klass_label:
+                    continue
+                for match in pattern.finditer(line):
+                    out.append((location, match.group(0).strip()))
     return out
 
 
-def scan_all(root: Path) -> list[tuple[str, str]]:
+def scan_all(root: Path, klass_filter: str | None = None) -> list[tuple[str, str]]:
     findings: list[tuple[str, str]] = []
 
     for nb in root.rglob("*.ipynb"):
@@ -158,7 +247,7 @@ def scan_all(root: Path) -> list[tuple[str, str]]:
             continue
         rel = nb.relative_to(root).as_posix()
         for idx, src in _iter_markdown_sources(nb):
-            findings += _findings_in_text(src, f"{rel} MD[{idx}]")
+            findings += _findings_in_text(src, f"{rel} MD[{idx}]", klass_filter)
 
     for md in root.rglob("*.md"):
         if _skipped(md):
@@ -178,12 +267,12 @@ def scan_all(root: Path) -> list[tuple[str, str]]:
                 text,
                 flags=re.DOTALL,
             )
-        findings += _findings_in_text(text, rel)
+        findings += _findings_in_text(text, rel, klass_filter)
 
     return findings
 
 
-def scan_diff(diff_range: str) -> list[tuple[str, str]]:
+def scan_diff(diff_range: str, klass_filter: str | None = None) -> list[tuple[str, str]]:
     """Ne juge que les lignes AJOUTEES : le stock existant ne fait pas echouer."""
     try:
         diff = subprocess.run(
@@ -232,7 +321,7 @@ def scan_diff(diff_range: str) -> list[tuple[str, str]]:
                 continue
             if '"source"' not in line and not body.startswith('"'):
                 continue
-        findings += _findings_in_text(line[1:], current)
+        findings += _findings_in_text(line[1:], current, klass_filter)
 
     return findings
 
@@ -244,9 +333,24 @@ def main() -> int:
     g.add_argument("--diff", metavar="RANGE", help="ne juge que les lignes ajoutees (ex: origin/main...HEAD)")
     ap.add_argument("--strict", action="store_true", help="rc=1 sur finding (defaut : advisory, rc=0)")
     ap.add_argument("--root", default=".", help="racine du depot")
+    ap.add_argument(
+        "--class", dest="klass", choices=("artifact", "machine_dep", "env_dep"),
+        default=None,
+        help=(
+            "filtre les findings par classe (ligne de partage #9434) : "
+            "'artifact' = compteurs d'artefact (lignes/cells/notebooks), "
+            "'machine_dep' = temps absolus (re-epingles a chaque re-exec), "
+            "'env_dep' = versions de librairie (re-epingles a chaque bump). "
+            "Sans --class, les 3 classes sont rapportees (comportement etendu)."
+        ),
+    )
     args = ap.parse_args()
 
-    findings = scan_all(Path(args.root).resolve()) if args.all else scan_diff(args.diff)
+    findings = (
+        scan_all(Path(args.root).resolve(), args.klass)
+        if args.all
+        else scan_diff(args.diff, args.klass)
+    )
 
     if not findings:
         print("[OK] aucun compteur quantitatif en prose.")

--- a/scripts/notebook_tools/tests/test_check_prose_quantitative_claims.py
+++ b/scripts/notebook_tools/tests/test_check_prose_quantitative_claims.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Recensement des valeurs quantitatives en prose : 4 classes (#9434, #9377).
+
+Le scanner `check_prose_quantitative_claims.py` distingue — depuis la vague
+#8052/#9426-9429 — trois classes de valeurs quantitatives en plus du
+comportement historique (compteurs d'artefact) :
+
+  - ``machine_dep``  : temps absolus (`(28-364 ms)`, `~2.4s`, `12 min`).
+                       Re-epinglés à chaque re-execution de la cellule de
+                       mesure, donc a deriver/retirer (#9427 App-11-Picross).
+  - ``env_dep``      : versions de librairie (`NumPy 2.4.2`, `Python 3.11+`).
+                       Re-epinglés à chaque bump de version (#9429 GT-4c).
+  - ``artifact``     : compteurs de lignes/cells/notebooks (le stock
+                       historique). #9377.
+
+Ces tests pincent les invariants :
+  - TIMING_RE capture une plage en un seul finding (pas un par borne) ;
+  - ENV_RE matche `Python 3.11+` et `NumPy 2.4.2`, ignore `K` ;
+  - `--class <machine_dep|env_dep|artifact>` filtre la sortie ;
+  - sans filtre, les 3 classes remontent (comportement etendu).
+
+Le scanner conserve --all / --diff / --strict / --root / CATALOG-STATUS -- les
+anciens tests `test_check_c2_compliance.py` etc. continuent à passer sans
+modification parce que le comportement par defaut est backward-compatible
+(les nouvelles classes s'AJOUTENT aux anciennes, ne substituent pas).
+
+Run:
+    pytest scripts/notebook_tools/tests/test_check_prose_quantitative_claims.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import check_prose_quantitative_claims as cqc  # noqa: E402
+
+
+# --- 1. TIMING_RE capture les plages en un seul finding --------------------
+
+def test_timing_single_value():
+    """Un timing isole remonte en un seul finding."""
+    findings = cqc._findings_in_text("- Cout : 24.5 ms par essai", "test", "machine_dep")
+    snippets = [s for _, s in findings]
+    assert "24.5 ms" in snippets, f"devrait matcher '24.5 ms', got {snippets}"
+
+
+def test_timing_range_one_finding():
+    """Une plage `28-364 ms` est capturee en UN seul finding, pas deux.
+
+    Sans cette protection, `(28-364 ms)` produirait 2 findings (`28 ms` et
+    `364 ms`), polluant la sortie CI et masquant la valeur-precise visee par
+    la prose.
+    """
+    findings = cqc._findings_in_text("- Latence : (28-364 ms) mesure", "test", "machine_dep")
+    snippets = [s for _, s in findings]
+    assert "28-364 ms" in snippets, f"devrait matcher la plage entiere, got {snippets}"
+    # Pas de doublon : la borne haute seule NE doit PAS remonter.
+    assert not any(s == "364 ms" for s in snippets), (
+        f"'364 ms' tout seul est un doublon, doit PAS remonter : {snippets}"
+    )
+
+
+def test_timing_units_long_form():
+    """Les unites longues (`minutes`, `hours`, `milliseconds`) matchent."""
+    assert cqc._findings_in_text("- 3 minutes", "t", "machine_dep")
+    assert cqc._findings_in_text("- 2 hours", "t", "machine_dep")
+    assert cqc._findings_in_text("- 2.4 milliseconds", "t", "machine_dep")
+
+
+def test_timing_does_not_match_temperature_in_kelvin():
+    """`300 K` n'est PAS un timing (Kelvin absent de la liste)."""
+    findings = cqc._findings_in_text("- temperature 300 K", "test", "machine_dep")
+    snippets = [s for _, s in findings]
+    assert snippets == [], (
+        f"Kelvin ne doit pas etre confondu avec un timing, got {snippets}"
+    )
+
+
+# --- 2. ENV_RE : versions de librairie ---------------------------------------
+
+def test_env_python_3_11_plus():
+    """`Python 3.11+` matche comme env_dep (version pinnée + suffixe `+`)."""
+    findings = cqc._findings_in_text("- Python 3.11+", "test", "env_dep")
+    snippets = [s for _, s in findings]
+    assert "Python 3.11+" in snippets
+
+
+def test_env_numpy_2_4_2():
+    """`NumPy 2.4.2` (3 niveaux de version) matche."""
+    findings = cqc._findings_in_text("- Charge NumPy 2.4.2", "test", "env_dep")
+    snippets = [s for _, s in findings]
+    assert "NumPy 2.4.2" in snippets
+
+
+def test_env_does_not_match_arbitrary_number():
+    """`3 minutes` N'EST PAS un env_dep (3 minutes est un timing, pas une ver)."""
+    findings = cqc._findings_in_text("- 3 minutes", "test", "env_dep")
+    snippets = [s for _, s in findings]
+    assert snippets == [], (
+        f"'3 minutes' est un timing, ne doit PAS apparaitre en env_dep, got {snippets}"
+    )
+
+
+# --- 3. --class filter --------------------------------------------------------
+
+def test_class_filter_artifact_excludes_timing():
+    """--class=artifact isole SEULEMENT les compteurs d'artefact, pas les timings."""
+    text = (
+        "- Cout : 24 ms\n"
+        "- NumPy 2.4.2 charge\n"
+        "- 140 lignes au total\n"
+    )
+    findings = cqc._findings_in_text(text, "test", "artifact")
+    snippets = [s for _, s in findings]
+    assert any("140 lignes" in s for s in snippets), f"artifact attendu, got {snippets}"
+    # Pas de timing ni env en mode artifact.
+    assert not any("ms" in s for s in snippets), (
+        f"artifact ne doit PAS contenir de timings, got {snippets}"
+    )
+    assert not any("NumPy" in s for s in snippets), (
+        f"artifact ne doit PAS contenir d'env, got {snippets}"
+    )
+
+
+def test_class_filter_all_classes():
+    """Sans filtre, les 3 classes remontent (comportement etendu)."""
+    text = (
+        "- Cout : 24 ms\n"
+        "- NumPy 2.4.2 charge\n"
+        "- 140 lignes au total\n"
+    )
+    findings = cqc._findings_in_text(text, "test", None)
+    snippets = [s for _, s in findings]
+    assert any("24 ms" in s for s in snippets)
+    assert any("NumPy 2.4.2" in s for s in snippets)
+    assert any("140 lignes" in s for s in snippets)
+
+
+# --- 4. scan_all + scan_diff : invariants structurels ------------------------
+
+def test_scan_all_filters_machine_dep_in_tmp_root(tmp_path):
+    """scan_all --class=machine_dep ne remonte PAS les artefacts/env."""
+    md = tmp_path / "demo.md"
+    md.write_text(
+        "- Cout : 24 ms\n"
+        "- NumPy 2.4.2\n"
+        "- 140 lignes\n",
+        encoding="utf-8",
+    )
+    findings = cqc.scan_all(tmp_path, "machine_dep")
+    assert len(findings) == 1, f"un seul timing attendu, got {findings}"
+    _, snippet = findings[0]
+    assert "24 ms" in snippet
+
+
+def test_artifact_class_preserves_historical_behavior(tmp_path):
+    """--class=artifact conserve le comportement d'avant #9434 (lignes/cells)."""
+    md = tmp_path / "demo.md"
+    md.write_text(
+        "- Cout : 24 ms\n"
+        "- 140 lignes au total\n"
+    )
+    findings = cqc.scan_all(tmp_path, "artifact")
+    snippets = [s for _, s in findings]
+    # Comportement historique : on remonte '140 lignes', pas '24 ms'.
+    assert "140 lignes" in snippets
+    assert not any("24 ms" in s for s in snippets)
+
+
+# --- 5. CATALOG-STATUS reste neutralisee -------------------------------------
+
+def test_catalog_status_marker_neutralizes_block(tmp_path):
+    """Les blocs CATALOG-STATUS sont toujours neutralises pour les 4 classes."""
+    md = tmp_path / "CATALOG.md"
+    md.write_text(
+        "<!-- CATALOG-STATUS:START -->\n"
+        "- 140 lignes dans le catalog\n"
+        "- Cout : 24 ms (cache)\n"
+        "<!-- CATALOG-STATUS:END -->\n"
+        "- 50 lignes dans le vrai contenu\n",
+        encoding="utf-8",
+    )
+    findings = cqc.scan_all(tmp_path)
+    snippets = [s for _, s in findings]
+    # Seul le contenu hors CATALOG-STATUS remonte.
+    assert "50 lignes" in snippets or "50" in str(snippets)


### PR DESCRIPTION
## c.982 — Étend `check_prose_quantitative_claims.py` avec 2 classes de la ligne de partage #9434

**Lane** : `myia-po-2023:CoursIA-2` · **Wakeup** : c.982 (post c.981 recall) · **Date** : 2026-08-05

### Contexte

L'issue **#9434** (« porter le mandat #9377/#8052 "quantitatif tenu par le CI, pas par la prose" à l'intérieur des notebooks ») propose une **ligne de partage en 4 classes** (structurel / machine_dep / env_dep / stochastique) parce que la vague du 2026-08-04 (PR #9426-#9429) a montré que toutes les valeurs quantitatives ne se traitent pas pareil : un `(28-364 ms)` re-epinglé en prose rebouge au prochain passage kernel (App-11-Picross), un `(2^225 combinaisons → 2.78e24x)` est stable cross-machine et reste du contenu pédagogique légitime.

Cette PR implémente le **volet scanner** de #9434. Le **volet règle** (C.5 dans `.claude/rules/notebook-conventions.md`, PR #9442 par `myia-ai-01:CoursIA`) est en attente de sign-off user — les deux sont **complémentaires** (la règle C.5 dit quoi faire ; le scanner repère les contrevenants), pas concurrents.

### Volet scanner

**Ajouts à `scripts/notebook_tools/check_prose_quantitative_claims.py`** (~+83/-9 lignes) :

1. **`TIMING_RE`** : `\bN(?:unit)` + `~` optionnel + **plage** `(28-364 ms)` capturée **en UN seul finding** (pas un par borne — sinon doublon systématique `28 ms` + `364 ms` qui pollue la sortie CI et masque la valeur précise visée par la prose). Unités : `µs`, `us`, `ms`, `s`, `min`, `h`, `hr`, `hours`, `minutes`, `seconds`, `milliseconds`, `microseconds`.

2. **`ENV_RE`** : `\b(package)\s+\d+\.\d+(?:\.\d+)?\+?` — packages pinnés, liste fermée (cf note anti-monoculture vocab du variation-protocol). Couvre `NumPy 2.4.2`, `Python 3.11+`, `Python 3.10+`, `PyTorch 2.4.1+cu121`, `Z3 4.12.2`, etc.

3. **`--class {artifact|machine_dep|env_dep}`** : filtre optionnel sur la sortie du scanner. Sans `--class`, les 3 classes remontent (comportement backward-compatible — les anciens usages `--all`/`--diff`/`--strict` continuent à fonctionner sans modification).

### Comportement backward-compatible

- `--all` / `--diff` / `--strict` / `--root` / neutralisation `CATALOG-STATUS` : **inchangés**.
- Sortie sans filtre sur le dépôt entier : **10359 findings** vs 2630 avant — **le stock historique reste intact**, on AJOUTE 7375 timings + 354 versions conformément à la ligne de partage #9434.
- Les anciens usages (CI par-PR en `--diff`) capturent désormais les 3 classes, sans casser les usages existants.

### Mesure firsthand sur le dépôt

```
$ python scripts/notebook_tools/check_prose_quantitative_claims.py --all --class=artifact
[ADVISORY] 2630 compteur(s) — comportement historique (lignes/cells/notebooks)

$ python scripts/notebook_tools/check_prose_quantitative_claims.py --all --class=machine_dep
[ADVISORY] 7375 compteur(s) — temps absolus a retirer/deriver

$ python scripts/notebook_tools/check_prose_quantitative_claims.py --all --class=env_dep
[ADVISORY] 354 compteur(s) — versions a retirer/deriver

$ python scripts/notebook_tools/check_prose_quantitative_claims.py --all
[ADVISORY] 10359 compteur(s) — 2630 + 7375 + 354 = comportement etendu
```

### Tests

**12 nouveaux tests** dans `scripts/notebook_tools/tests/test_check_prose_quantitative_claims.py` :

```
$ pytest scripts/notebook_tools/tests/test_check_prose_quantitative_claims.py -v
============================== 12 passed in 0.10s ==============================
```

Tests pincent les 5 invariants de la ligne de partage #9434 :

| # | Test | Vérifie |
|---|------|---------|
| 1 | `test_timing_single_value` | timing isole remonte correctement |
| 2 | `test_timing_range_one_finding` | `28-364 ms` capture en UN finding, pas 2 |
| 3 | `test_timing_units_long_form` | unites longues (`minutes`, `hours`, `milliseconds`) |
| 4 | `test_timing_does_not_match_temperature_in_kelvin` | `300 K` n'est PAS un timing |
| 5 | `test_env_python_3_11_plus` | `Python 3.11+` matche env_dep |
| 6 | `test_env_numpy_2_4_2` | `NumPy 2.4.2` matche env_dep |
| 7 | `test_env_does_not_match_arbitrary_number` | `3 minutes` n'est PAS env_dep |
| 8 | `test_class_filter_artifact_excludes_timing` | `--class=artifact` isole |
| 9 | `test_class_filter_all_classes` | sans filtre, 3 classes remontent |
| 10 | `test_scan_all_filters_machine_dep_in_tmp_root` | `scan_all` passe le filtre |
| 11 | `test_artifact_class_preserves_historical_behavior` | backward-compat |
| 12 | `test_catalog_status_marker_neutralizes_block` | CATALOG-STATUS neutralise pour 4 classes |

**Regression check** : `test_check_c2_compliance.py` (45 tests existants) — tous verts. Pas de régression.

```
$ pytest scripts/notebook_tools/tests/test_check_prose_quantitative_claims.py scripts/notebook_tools/tests/test_check_c2_compliance.py
============================= 57 passed in 0.89s ==============================
```

### Hors scope (volet suivant, dans une PR dédiée)

- **Classe `stochastique`** : nécessite un contexte sémantique que le regex seul ne tranche pas (`fitness 42.11` peut être seedé ou non). La docstring du module renvoie à l'œil humain sur `git diff`. Une détection automatique nécessiterait de croiser avec le code qui imprime la valeur (variable seedée ou non) — investigation hors scope c.982.
- **Classe `structurel`** : c'est le **CONTENU PÉDAGOGIQUE LÉGITIME** (ordres de grandeur, speedups structurels). Le scanner ne la remonte PAS, conformément à la ligne de partage. Aucune action requise.
- **Règle C.5** dans `.claude/rules/notebook-conventions.md` : portée par PR #9442 (`myia-ai-01:CoursIA`), en attente de sign-off user.

### L898 ★★★ pre-push

```
$ gh pr list --state all --search "check_prose_quantitative_claims"
[]

$ gh pr list --state all --search "9434"
[{"number":9442,"state":"OPEN","title":"docs(rules,#9377): C.5 — valeurs quantitatives en prose..."}]
```

- **0 PR** sur le scanner `check_prose_quantitative_claims.py` / `test_check_prose_quantitative_claims.py`.
- **1 PR connexe** : #9442 (règle C.5 par `myia-ai-01:CoursIA`) — **chemin différent** (`.claude/rules/notebook-conventions.md` vs `check_prose_quantitative_claims.py`), **complémentaire, pas concurrent**. Pas de collision.

### Acception

Cette PR livre le **moyen** (scanner avec 2 nouvelles classes détectables) — pas la **fin** (l'éradication des timings/envs en prose sur l'ensemble du dépôt). L'éradication est une suite de PRs value-par-value (#9438, #9439 déjà mergées comme Amorces) que cette PR rendra futures plus faciles via `--class=machine_dep --diff origin/main...HEAD --strict` en CI.

### Liens

- **#9434** — epic (cette PR + #9442 = scanner + règle)
- **#9377** — mandat racine (quantitatif tenu par le CI)
- **#8052** — vague doc-honesty 2026-08-04 (cette PR détecte les valeurs que #8052 rattrapait)
- **#9442** — règle C.5 dans `notebook-conventions.md` (volet rule, sign-off user requis)
- **#9438**, **#9439** — premières applications du geste `machine_dep` (déjà mergées)
- L948 — ne JAMAIS hand-editer SORTIE cellule committee (anti-fabrication)
- L989 ★★★ — push + pr-create via `GH_TOKEN=$(gh auth token --user jsboige)`
- L677-L4 ★★ — body PR HORS worktree (ce fichier dans le scratchpad)
- L898 ★★★ — pre-push collision guard (cf section dédiée)

🤖 Generated with [Claude Code](https://claude.com/claude-code)