### PR TITLE
docs(ict,#7739): distil Thom Ch.6 teleology + formal section sigma

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/thom-synthese-distillation.md
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/thom-synthese-distillation.md
@@ -158,6 +158,122 @@ factitif mesure une **fronce double** entre états ; l'aspect perfectif
 explique pourquoi la trajectoire d'une **dissociation** ne montre que le
 point de rupture (pas la transition continue sous-jacente).
 
+## Socle transversal — la dynamique aristotélicienne : téléologie et section σ (Ch.6 §B, §D-E)
+
+Le chapitre 6 (« La dynamique aristotélicienne comme sémiophysique »,
+p.153-164) est le cœur ontologique de la lecture thomienne : c'est là que
+Thom **formalise le pont entre Aristote et la théorie des catastrophes**.
+Jusqu'ici le document n'en retenait que la liste des **8 axiomes** et la
+mention finale de la « section $\sigma$ » (cf. §Ponts transverses). Cette
+section en distille la **dérivation** — comment Thom passe du vocabulaire
+aristotélicien (téléologie, homéomères) à l'objet géométrique mesurable
+(la section $\sigma$ et son ensemble de catastrophe $K$) — et ce que cela
+change pour la lecture ICT.
+
+### Le triptyque τέλoς / τέλειν / τελευτή — distinguer l'organisateur, l'accompli, la fin
+
+Toute entité « d'ici-bas » a une naissance (γένεσις) et une fin (ϕθoρά) ;
+son graphe temporel finit « en général en un sommet unique, la fin
+(τελευτή) » (Ch.6 §B, p.155). Thom insiste sur une **ambiguïté
+fondatrice** qu'Aristote « ne souffre guère, mais qui souvent fait
+problème » : le mot τέλoς oscille entre **trois** acceptions qu'il faut
+distinguer :
+
+- **τέλειον / τέλειν** — l'état « parfait », l'âge adulte, là où « la
+  fonction "temps" a son maximum » (p.155). C'est un **sommet
+  d'intensité**, pas une terminaison.
+- **τελευτή** — la **terminaison** effective, la mort de l'entité
+  (ϕθoρά). Le point final du graphe.
+- **τέλoς** — ni l'un ni l'autre : le **centre organisateur**.
+
+La citation fondatrice (Ch.6 §B, p.155), in extenso :
+
+> « La citation [1] semble indiquer que le τέλoς est en quelque sorte le
+> point central de l'existence d'une entité ou d'un acte : il en détermine
+> en effet l'antérieur (τò πρότερον) et le postérieur (τò ἕφεξῆς). Selon
+> le point de vue catastrophiste, le τέλoς pourrait être ainsi considéré
+> comme le **centre organisateur d'un champ morphogénétique** d'êtres et
+> d'événements se déployant selon la temporalité. En ce cas le τέλoς
+> devrait être toujours distinct de la terminaison (τελευτή). »
+
+**Conséquence épistémique pour ICT.** Le pont « recouvrabilité →
+agentivité » (ICT-9, #8077 pont 2) et la triade moyen / fin / enjeu
+(ICT-18b, cf. §Ponts transverses « Privation = métastabilité ») reposent
+sur une fin **mesurable**. Thom fournit la distinction qui évite
+l'erreur de catégorie : la « fin » qu'on mesure n'est **jamais** la
+τελευτή (terminaison — par définition non observable avant qu'elle
+n'arrive), c'est le **τέλoς** comme centre organisateur. On n'observe pas
+la fin, on observe le **coût de s'en approcher** (le moyen, σ de
+production d'entropie). C'est exactement la structure du verdict
+« privation structurée » : la τελευτή absente est une forme prégnante qui
+**plie** la trajectoire autour de son absence — un τέλoς, pas une
+terminaison.
+
+### Homéomère / anhoméomère, puis la section σ — la forme naît de la discontinuité
+
+Thom construit ensuite l'objet géométrique. Une entité $H$ est
+**homéomère** si « toute partie $c$ de $H$ est considérée comme étant
+sémantiquement […] équivalente à $H$ » (Ch.6 §D, p.157) — substrat
+d'apparence homogène, « intrinsèquement "informes" » : eau, huile, sang,
+graisse. Une entité **anhoméomère** présente des « discontinuités
+qualitatives : il a donc une forme, un *situs partium* ». Aristote
+distingue ici le **tout** (πᾶν, homéomère) de la **totalité** (ὅλον,
+corps vivant à « parties canoniques » séparées par des surfaces). Thom en
+tire la proposition qui boucle la controverse Cuvier / Geoffroy (cf.
+§Ponts transverses Ch.5) :
+
+> « L'ensemble catastrophique est un support indispensable de la forme
+> (μορφή). Les parties en acte de l'entité sont limitées par les
+> anhoméomères. » (Ch.6 §D, p.157-158)
+
+Vient alors **la définition formelle** (Ch.6 §E, p.158) — l'objet que le
+§Ponts transverses cite sans le dériver :
+
+> « Si l'on désigne par $Y$ l'espace des "états internes locaux" de la
+> matière, l'"état" d'une entité $A$, de support $|A|$ pourrait être
+> défini par une **section $\sigma : |A| \to Y$** du produit fibré
+> $|A| \times Y \to |A|$. Cette section est **continue pour un
+> homéomère** ; pour un anhoméomère, elle est **discontinue sur un
+> ensemble $K$ de "points de catastrophe"** ; cet ensemble $K$ définit
+> l'organisation morphologique de l'entité $A$ (toute partie en acte de
+> $A$ a sa frontière dans $K$). »
+
+Ainsi $\sigma$ est **continue** là où la matière est homogène (homéomère,
+informe, en puissance) et **se brise** sur $K$ là où apparaît la forme
+(anhoméomère, en acte). Les homéomères portent des *dunameis*
+(puissances) qui « se réalisen[t] en acte sur les anhoméomères sièges
+des travaux et des activités (ἔργα καὶ πράξεις) » (p.158) : l'**acte se
+localise sur une surface de contact** — l'articulation entre deux os (le
+« conflit entre les deux "lieux" »), ou le poumon comme interface
+air/sang.
+
+**Conséquence pour la strate 6 (factorisation 4-objets).** La distinction
+homéomère / anhoméomère est l'ancêtre ontologique de la dissociation
+**saillance / prégnance** d'ICT : l'homéomère est le substrat continu,
+sans singularité — la saillance $s_t$ « perceptiblement présente »; et
+l'anhoméomère ($K$) est là où se condensent les prégnances — les
+singularités qui donnent leur forme aux π et $q$. Les **5 dissociations
+canoniques** de la matrice #7734, relues comme des « endroits où
+$\sigma$ casse » (cf. §Ponts transverses « Axiomatique »), ne sont donc
+pas une métaphore : ce sont des **discontinuités de section** au sens
+formel de Thom. Et les ponts falsifiables de #8077 opèrent précisément
+sur ces anhoméomères — les surfaces de contact où l'acte (usage causal,
+diffusion, généralisation) se localise et devient mesurable.
+
+### Limite de la lecture (honnêteté grade C)
+
+Thom **formalise** $\sigma : |A| \to Y$ géométriquement (produit fibré,
+section, ensemble de catastrophe $K$) mais ne la **quantifie** jamais
+numériquement — $Y$ et $K$ sont des objets de la géométrie
+différentielle, pas des vecteurs mesurables. La transposition ICT ($\sigma$
+→ dissociations scalaires mesurables, $K$ → singularités dans un espace
+de proxies $s, q, \pi, W$) est **nôtre**, pas thomienne (rectification A2
+#7733 : le grade A du cadre géométrique $\neq$ le grade C d'une lecture
+candidate). Le lien est une **analogie contrôlée**, pas une dérivation :
+Thom fournit le vocabulaire formel (section continue/discontinue,
+catastrophe-set comme support de la forme) qui légitime le *geste*
+mesurant — mais la mesure elle-même appartient au registre ICT.
+
 ## Socle strate 7 — genres comme espaces de possibles extensibles
 
 ### Ch.8 §B (bis) — Genres = préprogramme
@@ -409,8 +525,9 @@ extension, pas une redite.
   de prédation, blastula BP).
 - **Ch.5 — Plan Général d'Organisation** : cf. §Ponts transverses
   (Cuvier / Geoffroy, homéomère / anhoméomère).
-- **Ch.6 — Axiomatique aristotélicienne** : cf. §Ponts transverses
-  (8 axiomes, section $\sigma$).
+- **Ch.6 — Axiomatique aristotélicienne** : cf. §Socle transversal
+  [Ch.6 §B/§D-E] (téléologie, section $\sigma$) et §Ponts transverses
+  (8 axiomes).
 - **Ch.7 — Continu et discret** : cf. §Ponts transverses (ABP/FBM,
   privation = métastabilité).
 - **Ch.8 — Perspectives aristotéliciennes en théorie du langage** :


### PR DESCRIPTION
Grain: DEEP/docs — lane myia-po-2025:CoursIA — prev: DEEP/docs (#9487 Ch.4 §C)

See #7739 (tranche Ch.6 §B/§D-E — partial delivery; résiduel: Ch.4 §D-E blastula détaillé, Ch.5 détaillé, Ch.6 §G+ acte transitif, Ch.7 §A/C/E+, Ch.8 §D-E). Part of #4588.

## Summary

Distille **Ch.6 §B et §D-E** (« La dynamique aristotélicienne comme sémiophysique », Thom 1991, p.155-158) dans `thom-synthese-distillation.md`. Cette section est le **cœur ontologique** du chapitre 6 : c'est là que Thom **formalise le pont entre Aristote et la théorie des catastrophes**. Jusqu'ici le document n'en retenait que la liste des 8 axiomes et la mention finale « section σ » (Pont transverse) — sans la **dérivation**. Cette PR la donne.

## Contenu nouveau (3 sous-sections, ~119 lignes)

1. **Le triptyque τέλoς / τέλειν / τελευτή — distinguer l'organisateur, l'accompli, la fin.** Thom insiste sur l'ambiguïté fondatrice d'Aristote : τέλoς oscille entre τέλειον (état parfait, âge adulte = max de la fonction temps), τελευή (terminaison/mort), et τέλoς lui-même. Citation fondatrice in extenso (Ch.6 §B, p.155) : le τέλoς « en détermine l'antérieur (τò πρότερον) et le postérieur (τò ἕφεξῆς) » ; lecture catastrophiste = **τέλoς comme centre organisateur d'un champ morphogénétique**, TOUJOURS distinct de la τελευή. — Conséquence ICT : la « fin » mesurable (triade moyen/fin/enjeu ICT-18b, #8077 pont 2) n'est jamais la τελευή (non-observable) mais le **τέλoς** dont on mesure le coût d'approche (le moyen σ). Précise le verdict « privation structurée ».

2. **Homéomère / anhoméomère, puis la section σ — la forme naît de la discontinuité.** Homéomère = toute partie sémantiquement équivalente au tout (substrat homogène, informe : eau, huile, sang). Anhoméomère = discontinuités qualitatives → forme, *situs partium*. πᾶν (tout) vs ὅλον (totalité à parties canoniques). Thom boucle Cuvier/Geoffroy : « L'ensemble catastrophique est un support indispensable de la forme (μορφή) ». Puis **la définition formelle** (Ch.6 §E, p.158) citée in extenso : section **σ : |A| → Y** du produit fibré — **continue pour un homéomère, discontinue sur un ensemble K de points de catastrophe** pour un anhoméomère ; K définit l'organisation morphologique. Les *dunameis* des homéomères « se réalisent en acte sur les anhoméomères » (ἔργα καὶ πράξεις) — **l'acte se localise sur une surface de contact**. — Conséquence strate 6 : homéomère/anhoméomère = ancêtre ontologique de saillance/prégnance (s_t = substrat continu ; K = singularités → π, q). Les 5 dissociations #7734 relues comme « discontinuités de section » ne sont pas une métaphore mais un objet formel thomien. Les ponts #8077 opèrent sur ces anhoméomères (surfaces de contact mesurables).

3. **Limite de la lecture (honnêteté grade C).** Thom formalise σ géométriquement mais ne la quantifie jamais — Y et K sont objets de géométrie différentielle, pas vecteurs mesurables. La transposition ICT (σ → dissociations scalaires, K → singularités dans l'espace de proxies) est **nôtre**, pas thomienne (rectification A2 #7733 : grade A du cadre ≠ grade C d'une lecture candidate). Analogie contrôlée, pas dérivation.

## Méthode — grounding firsthand (G.1/G.9)

- **Source** : `Thom-Semiophysique-1991.extracted.txt` (bibliothèque GDrive privée po-2025, **jamais dans le repo** — uniquement les citations in extenso).
- **Caveat safeguard respecté** (#7739) : lecture par **tranches ciblées** Ch.6 §B (lignes 5168-5199, ~31 lignes) + §D-E (lignes 5239-5313, ~75 lignes), jamais le fichier en bloc.
- **Citations vérifiées firsthand** par Read sur la source : « centre organisateur d'un champ morphogénétique » + « antérieur/postérieur » (l.5184-5189), « ensemble catastrophique est un support indispensable de la forme (μορφή) » (l.5268), définition formelle « section σ : |A| → Y [...] discontinue sur un ensemble K de "points de catastrophe" » (l.5284-5293), « se réalisen[t] en acte sur les anhoméomères » (l.5303-5304). Aucune citation fabriquée.
- **Cross-ref Ch.6** mise à jour pour pointer vers la nouvelle section §Socle transversal.

## Non-conflit avec #9487 (Ch.4 §C, OPEN)

#9487 insère §Socle transversal Ch.4 §C **avant §Ponts transverses** (ligne ~245) + édite le cross-ref Ch.4 (ligne ~408). Cette PR insère §Socle transversal Ch.6 **entre §Socle strate 6 et §Socle strate 7** (ligne ~160) + édite le cross-ref Ch.6 (ligne ~412). **Régions de diff disjointes** — un rebase éventuel se résout trivialement (deux insertions additives à des ancres distinctes). Construction indépendante sur origin/main (catalog-pr-hygiene HARD 2).

## Pourquoi c'est G.9-compliant (mandat strate-6/7 « laisser la mer monter »)

- **Distillation de source** (lecture + synthèse), pas une revendication empirique.
- Chaque claim Thom est **cité in extenso** avec référence chapitre/section/page.
- La transposition ICT est **marquée grade C** (« nôtre, pas thomienne »), pas maquillée en dérivation.
- Pattern établi (`thom-synthese-distillation.md`, #9487 antiéreur).

## Périmètre & garde-fous

- 1 fichier, +119/-2 (DEEP/docs). Catalogue byte-identique à main (non touché).
- L898 OK : 0 PR OPEN concurrente sur Thom/#7739 (#9487 = antiéreur, régions disjointes).
- Atome : 1 sujet (distillation Ch.6 §B/§D-E). Variation : DEEP/docs après DEEP/docs #9487 — G-VAR-3 autorise 2 DEEP same-genre consécutifs en domaine-cœur (ICT docs = turf natif po-2025) à substance genuinement distincte (Ch.6 téléologie/section σ ≠ Ch.4 prédation/p̂ ; litmus LIGHT = non, exige lecture philosophique firsthand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
