### PR TITLE
tooling(#9485): heading-tolerant Grain tag reader via shared Python extractor

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -54,6 +54,16 @@ jobs:
     name: Check Grain tag conformity
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout the tag detector (sparse)
+        # #9485 : the tag-conformity verdict now comes from the SAME Python
+        # extractor (parse_grain) as the cap logic in the job below, so the two
+        # can no longer diverge on what a `Grain` tag is. Sparse-checkout of one
+        # file -- no full clone, the job stays cheap.
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/variation_light_cap.py
+
       - name: Inspect PR body for Grain tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -106,78 +116,29 @@ jobs:
             exit 0
           fi
 
-          # Le tag circule sous plusieurs habillages markdown observes en vrai :
-          # `**Grain: ...**`, `Grain: **DEEP/lean**`, et surtout `` `Grain: DEEP/lean` ``
-          # (backticks — la forme que le coordinateur lui-meme utilise). On neutralise
-          # asterisques et backticks avant de matcher, plutot que de multiplier les
-          # variantes de regex. Un tag rejete pour son habillage serait un faux
-          # negatif du guard, pas une non-conformite de l'auteur.
-          BODY_FLAT=$(printf '%s' "${PR_BODY:-}" | tr -d '*`')
+          # Extracteur unique (#9485) : le MEME parse_grain() qui porte la logique
+          # du cap (job check-light-cap ci-dessous) porte desormais la conformite
+          # du tag. Les deux jobs ne peuvent plus diverger sur ce qu'est un tag.
+          #
+          # L'outil est tolerant a la forme -- `## Grain` (titre de section, sans
+          # deux-points, le TIER suit sur la prochaine ligne non vide), `Grain :`
+          # (espace-deux-points-espace), `**Lane** :` -- la ou l'ancien grep bash
+          # (`Grain:` deux-points obligatoire) ratait le titre `## Grain` ENTIEREMENT
+          # et etiquettait des tags valides `variation-tag-missing` (11/30 merges
+          # d'une journee unattributed, budget G-VAR-2 sous-estime). La tolerance
+          # porte sur la FORME seulement : un body sans vrai TIER/GENRE reste
+          # `variation-tag-missing` (acceptance #9485 : pas de tolerance substance).
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+          python3 scripts/variation_light_cap.py \
+            --check-tag --body-file /tmp/pr_body.txt > /tmp/tagcheck.json 2>/tmp/tag.err || true
+          echo "--- tag-conformity verdict ---"
+          cat /tmp/tagcheck.json 2>/dev/null || true
+          [ -s /tmp/tag.err ] && { echo "--- tag-conformity stderr ---"; cat /tmp/tag.err; } || true
 
-          # Puce de liste ou citation toleree devant le tag.
-          GRAIN_LINE=$(printf '%s\n' "$BODY_FLAT" | grep -m1 -E '^[[:space:]]*[->+]?[[:space:]]*Grain:' || true)
-
-          # Chaque defaut constate est accumule ici, puis traduit en labels a la
-          # fin. Un `exit 0` precoce au cas nominal (l'ancienne structure) rendait
-          # impossible de verifier GENRE et `lane` : un TIER valide suffisait a
-          # clore le job. Les trois controles sont desormais independants.
-          DEFECTS=""
-          note_defect() { DEFECTS="$DEFECTS $1"; }
-
-          if [ -z "$GRAIN_LINE" ]; then
-            echo "::warning::Aucune ligne 'Grain:' dans le body. variation-protocol.md exige 'Grain: <TIER>/<GENRE> — lane <machine:workspace> — prev: <TIER>/<GENRE> #<PR>' (TIER = DEEP|MED|LIGHT)."
-            note_defect variation-tag-missing
-          else
-            echo "Ligne lue : $GRAIN_LINE"
-
-            TIER=$(printf '%s' "$GRAIN_LINE" | sed -nE 's|^[[:space:]]*[->+]?[[:space:]]*Grain:[[:space:]]*([A-Za-z]+)/.*|\1|p')
-            GENRE=$(printf '%s' "$GRAIN_LINE" | sed -nE 's|^[[:space:]]*[->+]?[[:space:]]*Grain:[[:space:]]*[A-Za-z]+/([A-Za-z0-9_-]+).*|\1|p')
-
-            case "$TIER" in
-              DEEP|MED|LIGHT)
-                echo "TIER=$TIER"
-                ;;
-              *)
-                echo "::warning::TIER non reconnu ('${TIER:-vide}'). Attendu DEEP, MED ou LIGHT — le TIER se decide par le litmus de variation-protocol.md, pas par auto-evaluation de valeur."
-                note_defect variation-tag-malformed
-                ;;
-            esac
-
-            # Enumeration §1, reproduite telle quelle. Un genre hors-liste n'est
-            # pas "invalide" : il est INCOMPARABLE, donc G-VAR-3 ne peut pas voir
-            # l'adjacence qu'il est cense fermer. Le remede est de le mapper sur
-            # le genre de la liste qui decrit le TYPE DE TRAVAIL — jamais la
-            # famille de fichiers traversee (c'est la seconde voie de
-            # contournement documentee en §1).
-            case "$GENRE" in
-              lean|qc|training|genai|notebook-python|notebook-dotnet|docs|guard|refactor|ledger|readme|test|tooling|research-code)
-                echo "GENRE=$GENRE (dans la liste §1)"
-                ;;
-              "")
-                echo "::warning::GENRE illisible sur la ligne Grain. Format attendu : 'Grain: <TIER>/<GENRE>'."
-                note_defect variation-tag-genre-offlist
-                ;;
-              *)
-                echo "::warning::GENRE '$GENRE' hors de l'enumeration §1 (lean, qc, training, genai, notebook-python, notebook-dotnet, docs, guard, refactor, ledger, readme, test, tooling, research-code). G-VAR-3 compare des genres consecutifs : un genre inedit rend l'adjacence invisible. Mappe-le sur le genre qui decrit le TYPE DE TRAVAIL, pas le repertoire traverse."
-                note_defect variation-tag-genre-offlist
-                ;;
-            esac
-
-            # `lane` : exigee par §3, cle d'agregation du cap G-VAR-2 (par lane,
-            # par jour). Cherchee d'abord sur la ligne du tag (sa place selon §1),
-            # puis dans le body — trouvee ailleurs, elle reste exploitable par un
-            # humain, donc simple note et pas de label. Un tag rejete pour son
-            # placement serait un faux negatif du guard.
-            LANE_RE='lane:?[[:space:]]+[A-Za-z0-9._-]+:[A-Za-z0-9._-]+'
-            if printf '%s' "$GRAIN_LINE" | grep -qiE "$LANE_RE"; then
-              echo "lane declaree sur la ligne du tag."
-            elif printf '%s\n' "$BODY_FLAT" | grep -qiE "$LANE_RE"; then
-              echo "::notice::lane declaree, mais hors de la ligne 'Grain:'. §1 la place sur la ligne du tag."
-            else
-              echo "::warning::Aucune 'lane <machine:workspace>' declaree. G-VAR-2 est un cap PAR LANE et PAR JOUR : un grain sans lane est structurellement incomptable, et le cap devient inapplicable sans que personne ne l'ait contourne (§3)."
-              note_defect variation-tag-lane-missing
-            fi
-          fi
+          # DEFECTS = liste de noms de labels (l'outil emet exactement les noms
+          # que la boucle de labeling ci-dessous attend -- single source, #9485).
+          DEFECTS=$(python3 -c "import json; print(' '.join(json.load(open('/tmp/tagcheck.json')).get('defects',[])))" 2>/dev/null || echo "")
+          echo "Defects: ${DEFECTS:-none (conforming)}"
 
           # Traduction en labels. Chaque classe de defaut a son propre label pour
           # que sa nature se lise dans `gh pr list --json labels`. Les labels

--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -22,18 +22,18 @@ BODY_MIDDOT_BOLD_LANE = (
 
 def test_parse_emdash_lowercase_lane():
     g = vlc.parse_grain(BODY_EMDASH)
-    assert g == {"tier": "LIGHT", "lane": "myia-po-2023:CoursIA"}
+    assert g == {"tier": "LIGHT", "genre": "guard", "lane": "myia-po-2023:CoursIA"}
 
 
 def test_parse_hyphen_bold():
     g = vlc.parse_grain(BODY_HYPHEN_BOLD)
-    assert g == {"tier": "LIGHT", "lane": "myia-ai-01:CoursIA"}
+    assert g == {"tier": "LIGHT", "genre": "guard", "lane": "myia-ai-01:CoursIA"}
 
 
 def test_parse_middot_bold_capital_lane():
     # bold + middot + capital **Lane:** + workspace with a hyphen (CoursIA-2)
     g = vlc.parse_grain(BODY_MIDDOT_BOLD_LANE)
-    assert g == {"tier": "LIGHT", "lane": "myia-po-2024:CoursIA-2"}
+    assert g == {"tier": "LIGHT", "genre": "refs", "lane": "myia-po-2024:CoursIA-2"}
 
 
 def test_parse_no_grain_returns_none():
@@ -51,9 +51,9 @@ def test_parse_non_light_tier():
 
 
 def test_parse_grain_without_lane():
-    # Tag present but lane missing -> tier read, lane None.
+    # Tag present but lane missing -> tier + genre read, lane None.
     g = vlc.parse_grain("Grain: LIGHT/guard -- no lane here")
-    assert g == {"tier": "LIGHT", "lane": None}
+    assert g == {"tier": "LIGHT", "genre": "guard", "lane": None}
 
 
 def test_second_light_same_lane_is_cap_reached():
@@ -368,3 +368,111 @@ def test_budget_is_per_lane_not_global():
             _pr(8, quiet, "LIGHT", "2026-07-31T08:00:00Z")]
     rows = vlc.replay(prs)
     assert {r["number"] for r in rows if r["cap_reached"]} == {8}  # quiet lane: budget 1
+
+
+# --- form tolerance (#9485): `## Grain` heading + `Grain :` space-colon -------
+#
+# The tag circulates as a section heading (`## Grain`, no colon, tier on the next
+# non-empty line) and with space-colon-space (`Grain :`), neither of which the
+# old `Grain:` (colon-required) reader matched -- 11/30 of a day's merges landed
+# unattributed (#9485). Tolerance is on FORM only: a heading with no real
+# TIER/GENRE still returns no tag (no substance tolerance).
+
+BODY_HEADING = (
+    "## Grain\n\n"
+    "MED/tooling (#8056 cost-honesty / under-declaration) -- lane "
+    "myia-po-2023:CoursIA -- prev: MED/tooling #9457\n\nSee #8056"
+)
+BODY_SPACE_COLON = "Grain : DEEP/research-code -- lane myia-po-2025:CoursIA"
+BODY_BOLD_LANE_SPACE_COLON = (
+    "**Grain:** MED/lean . **Lane** : myia-po-2026:CoursIA"
+)
+
+
+def test_parse_heading_form_no_colon():
+    # The main #9485 defect: `## Grain` section heading, tier on the next line.
+    g = vlc.parse_grain(BODY_HEADING)
+    assert g == {"tier": "MED", "genre": "tooling", "lane": "myia-po-2023:CoursIA"}
+
+
+def test_parse_space_colon_form():
+    # `Grain :` (space-colon-space) -- the colon is not flush against `Grain`.
+    g = vlc.parse_grain(BODY_SPACE_COLON)
+    assert g == {"tier": "DEEP", "genre": "research-code", "lane": "myia-po-2025:CoursIA"}
+
+
+def test_parse_bold_lane_space_colon():
+    # `**Lane** :` (bold + space-colon-space) -- the lane is not flush either.
+    g = vlc.parse_grain(BODY_BOLD_LANE_SPACE_COLON)
+    assert g == {"tier": "MED", "genre": "lean", "lane": "myia-po-2026:CoursIA"}
+
+
+def test_parse_prose_grain_word_no_match():
+    # The word "grain" in prose must NOT match: no `/` follows the next word.
+    assert vlc.parse_grain("a grain of truth in the MED analysis") is None
+
+
+def test_parse_heading_without_substance_returns_none():
+    # A `## Grain` heading carrying NO TIER/GENRE is still missing -- the heading
+    # form is READ, not excused (no substance tolerance, #9485 acceptance).
+    assert vlc.parse_grain("## Grain\n\nsome prose with no tier/genre token") is None
+
+
+def test_parse_heading_h3_also_works():
+    # `### Grain` (deeper heading) -- same tolerance.
+    g = vlc.parse_grain("### Grain\n\nLIGHT/docs -- lane myia-po-2024:CoursIA")
+    assert g == {"tier": "LIGHT", "genre": "docs", "lane": "myia-po-2024:CoursIA"}
+
+
+def test_check_tag_conformity_heading_is_conforming():
+    # The acceptance: a `## Grain` heading with valid TIER/GENRE + lane is
+    # CONFORMING (no defect), not missing.
+    assert vlc.check_tag_conformity(BODY_HEADING)["defects"] == []
+
+
+def test_check_tag_conformity_missing():
+    assert vlc.check_tag_conformity("no tag here")["defects"] == [vlc.DEFECT_MISSING]
+
+
+def test_check_tag_conformity_malformed_tier():
+    res = vlc.check_tag_conformity("Grain: HUH/lean -- lane x:y")
+    assert vlc.DEFECT_MALFORMED in res["defects"]
+
+
+def test_check_tag_conformity_genre_offlist():
+    # `refs` is a real off-list genre (the old bash guard flagged it too).
+    res = vlc.check_tag_conformity("Grain: LIGHT/refs -- lane x:y")
+    assert vlc.DEFECT_GENRE_OFFLIST in res["defects"]
+
+
+def test_check_tag_conformity_lane_missing():
+    # Heading form parsed, but no lane -> lane-missing defect (this is the
+    # legitimate residual on #9477, where a DEEP tag had no lane).
+    res = vlc.check_tag_conformity("## Grain\n\nDEEP/research-code -- no lane")
+    assert res["tier"] == "DEEP"
+    assert vlc.DEFECT_LANE_MISSING in res["defects"]
+
+
+def test_check_tag_cli_heading(tmp_path, capsys):
+    # Drive main() in --check-tag mode: the workflow's tag-conformity job calls
+    # this. A heading-form body must emit a clean (empty-defects) verdict.
+    import json as _json
+    bpath = tmp_path / "body.txt"
+    bpath.write_text(BODY_HEADING, encoding="utf-8")
+    rc = vlc.main(["--check-tag", "--body-file", str(bpath)])
+    assert rc == 0
+    out = capsys.readouterr().out.strip().splitlines()[-1]
+    res = _json.loads(out)
+    assert res["defects"] == []
+    assert res == {"defects": [], "tier": "MED", "genre": "tooling",
+                   "lane": "myia-po-2023:CoursIA"}
+
+
+def test_check_tag_cli_requires_no_replay(tmp_path, capsys):
+    # --check-tag short-circuits before the --replay requirement: tag conformity
+    # is decidable from one body, no merged set needed.
+    import json as _json
+    bpath = tmp_path / "body.txt"
+    bpath.write_text("Grain: LIGHT/guard -- lane x:y", encoding="utf-8")
+    rc = vlc.main(["--check-tag", "--body-file", str(bpath)])
+    assert rc == 0  # did not error on missing --replay

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -31,18 +31,37 @@ Modes
                        and comment: `cap_reached`, `lane`, `consumed_by` (the
                        earlier LIGHT that spent the budget, with its merge time).
 
+  --check-tag          Tag-conformity mode (#9485): read --body/--body-file and
+                       emit the defect classes (missing/malformed/genre-offlist/
+                       lane-missing) as JSON. Drives the workflow's `Check Grain
+                       tag conformity` job so it shares ONE extractor with the
+                       cap logic (no second implementation to diverge). No
+                       --replay set needed -- a body's tag conformity is decidable
+                       on its own.
+
 Parsing
 -------
 Bodies are read as FULL TEXT, never line-by-line. The line-by-line bug measured
 hand counted "18/38 untagged" when the true figure was "2/38": the tag is often
 on the 2nd+ line of a multi-line body, and a per-line scan misses it (#8964).
 
-Agnostic to separator and case (#8938): the three shapes observed in the wild
-all parse identically after markdown noise is stripped --
+Agnostic to separator and case (#8938): the shapes observed in the wild all
+parse identically after markdown noise (`*`, backticks, `#`, `>`) is stripped --
 
     Grain: LIGHT/guard -- lane myia-po-2023:CoursIA      (em-dash)
     **Grain:** LIGHT/guard - lane myia-ai-01:CoursIA     (bold, hyphen)
     `Grain: LIGHT/refs` . **Lane:** myia-po-2024:CoursIA-2  (backticks, middot)
+
+Form-tolerant (#9485): the tag also circulates as a section heading (no colon)
+and with space-colon-space, both of which the old `Grain:` (colon-required)
+reader missed -- leaving 11/30 of a day's merges unattributed. The heading form
+recollens to the next non-empty line; `lane` is read anywhere in the body,
+including the `**Lane** :` shape --
+
+    ## Grain\n\nMED/tooling (...) -- lane myia-po-2023:CoursIA   (section heading)
+    Grain : DEEP/lean -- lane myia-po-2025:CoursIA               (space-colon)
+
+Tolerance is on FORM only: a body with no real TIER/GENRE still returns no tag.
 
 Exit 0 always (advisory).
 """
@@ -56,39 +75,104 @@ from pathlib import Path
 
 # --- parsing ---------------------------------------------------------------
 
-# Markdown noise to strip before matching: asterisks (bold) and backticks.
-# Mirrors the workflow's `tr -d '*\`'` so the two stay in lockstep.
-_NOISE = str.maketrans({"*": "", "`": ""})
+# Markdown noise to strip before matching: asterisks (bold), backticks, and --
+# form-tolerance (#9485) -- `#` (section headings like `## Grain`) and `>` (block
+# quotes). Stripping the heading marker (rather than matching it) keeps the tag
+# regex agnostic to whether `Grain` is a line (`Grain:`) or a section (`## Grain`).
+_NOISE = str.maketrans({"*": "", "`": "", "#": "", ">": ""})
 
-# `Grain:` (case-insensitive) then TIER / GENRE. TIER is the word before `/`.
-_GRAIN_TIER_RE = re.compile(r"Grain:\s*([A-Za-z]+)\s*/", re.IGNORECASE)
+# `Grain` (case-insensitive) then TIER / GENRE. Form-tolerant (#9485): the tag
+# circulates as `Grain:` (line), `## Grain` (section heading, NO colon -- the
+# tier follows on the next non-empty line, so `\s*` swallows the newline(s)), and
+# `Grain :` (space-colon-space). The colon is OPTIONAL and tolerates whitespace
+# on both sides. TIER is the word before `/`; GENRE is the word after (letters,
+# digits, underscore, hyphen). The `/` after the tier word is what distinguishes
+# a real tag from the prose word "grain".
+_GRAIN_RE = re.compile(
+    r"Grain\s*:?\s*([A-Za-z]+)\s*/\s*([A-Za-z0-9_-]+)", re.IGNORECASE
+)
 
-# `lane` (case-insensitive), optional colon, whitespace, then machine:workspace.
-# machine = myia-po-2024 (letters, digits, dot, underscore, hyphen); workspace
-# likewise (CoursIA-2). Captured as the single token "<machine>:<workspace>".
+# `lane` (case-insensitive), form-tolerant (#9485): `lane X:Y`, `lane: X:Y`, and
+# `Lane : X:Y` (the `**Lane** :` form once bold is stripped -- whitespace around
+# an optional colon). `\b` stops the word "lane" matching inside e.g. "plane".
+# machine = myia-po-2024; workspace = CoursIA-2. Captured as "<machine>:<workspace>".
 _LANE_RE = re.compile(
-    r"lane:?\s+([A-Za-z0-9._-]+:[A-Za-z0-9._-]+)", re.IGNORECASE
+    r"\blane\s*:?\s*([A-Za-z0-9._-]+:[A-Za-z0-9._-]+)", re.IGNORECASE
 )
 
 
 def parse_grain(body: str) -> dict | None:
-    """Extract {tier, lane} from a PR body, full-text + separator-agnostic.
+    """Extract {tier, genre, lane} from a PR body, full-text + form-agnostic.
 
-    Returns None when no `Grain:` line is found. `tier` is upper-cased
-    (LIGHT/MED/DEEP) or None if the TIER could not be read. `lane` is the
-    "<machine>:<workspace>" string or None.
+    Returns None when no `Grain` tag is found in ANY of the observed forms:
+    `Grain:` line, `## Grain` section heading (#9485), or `Grain :` space-colon.
+    `tier` is upper-cased (LIGHT/MED/DEEP). `genre` is the word after `<TIER>/`
+    (None if unreadable). `lane` is "<machine>:<workspace>" or None.
+
+    Form-tolerance is on PRESENTATION only (#9485): a body without a real
+    TIER/GENRE token still returns None -- the heading form is READ, not excused.
     """
     if not body:
         return None
     flat = body.translate(_NOISE)
-    tier_m = _GRAIN_TIER_RE.search(flat)
-    if not tier_m:
+    m = _GRAIN_RE.search(flat)
+    if not m:
         return None
     lane_m = _LANE_RE.search(flat)
     return {
-        "tier": tier_m.group(1).upper(),
+        "tier": m.group(1).upper(),
+        "genre": m.group(2),
         "lane": lane_m.group(1) if lane_m else None,
     }
+
+
+# --- tag conformity (variation-protocol §1, #9485) -------------------------
+
+# The §1 GENRE enumeration and the TIER set, reproduced verbatim from
+# .claude/rules/variation-protocol.md. The workflow's `Check Grain tag
+# conformity` job calls check_tag_conformity() below -- ONE extractor for both
+# the cap job and the tag job (#9485: the two must read the body identically,
+# not diverge into two implementations that drift).
+TIERS = ("DEEP", "MED", "LIGHT")
+GENRES = (
+    "lean", "qc", "training", "genai",
+    "notebook-python", "notebook-dotnet",
+    "docs", "guard", "refactor", "ledger", "readme", "test",
+    "tooling", "research-code",
+)
+
+# Defect label names (mirror the labels created by variation-tag-guard.yml so
+# the workflow can map verdict -> label with no translation table).
+DEFECT_MISSING = "variation-tag-missing"
+DEFECT_MALFORMED = "variation-tag-malformed"
+DEFECT_GENRE_OFFLIST = "variation-tag-genre-offlist"
+DEFECT_LANE_MISSING = "variation-tag-lane-missing"
+
+
+def check_tag_conformity(body: str | None) -> dict:
+    """Tag-conformity verdict for the workflow's `Check Grain tag conformity` job.
+
+    Single extractor (#9485): the same parse_grain that drives the cap logic also
+    drives tag conformity, so the cap job and the tag job can never diverge on
+    what a tag is. Returns {defects, tier, genre, lane} where `defects` is a list
+    drawn from the four DEFECT_* labels (empty list = conforming tag).
+
+    Tolerance is on FORM only (line / heading / space-colon-space): a body with
+    no real TIER/GENRE substance still raises variation-tag-missing -- the
+    heading form is read, not excused. Acceptance (#9485): a `## Grain` heading
+    carrying a valid TIER/GENRE + lane is CONFORMING (no defect), not missing.
+    """
+    g = parse_grain(body or "")
+    if g is None:
+        return {"defects": [DEFECT_MISSING], "tier": None, "genre": None, "lane": None}
+    defects = []
+    if g["tier"] not in TIERS:
+        defects.append(DEFECT_MALFORMED)
+    if g["genre"] is None or g["genre"] not in GENRES:
+        defects.append(DEFECT_GENRE_OFFLIST)
+    if not g["lane"]:
+        defects.append(DEFECT_LANE_MISSING)
+    return {"defects": defects, "tier": g["tier"], "genre": g["genre"], "lane": g["lane"]}
 
 
 # --- requalification (coordinator override of the declared tag) ------------
@@ -319,7 +403,10 @@ def _load(path: str) -> list[dict]:
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     p.add_argument("--replay", metavar="FILE",
-                   help="JSON array of the day's merged PRs (the counting set)")
+                   help="JSON array of the day's merged PRs (the counting set). "
+                        "Required for --replay-mode and --check-pr; NOT used by "
+                        "--check-tag (a single body's tag conformity is decidable "
+                        "on its own).")
     g = p.add_mutually_exclusive_group(required=True)
     g.add_argument("--replay-mode", action="store_true",
                    help="acceptance-test mode: report cap_reached for every "
@@ -327,17 +414,35 @@ def main(argv: list[str] | None = None) -> int:
     g.add_argument("--check-pr", metavar="N", type=int,
                    help="CI mode: assess PR <N> (the current open PR) against "
                         "the --replay merged set")
+    g.add_argument("--check-tag", action="store_true",
+                   help="tag-conformity mode (#9485): read --body/--body-file and "
+                        "emit the defect classes as JSON. Drives the workflow's "
+                        "`Check Grain tag conformity` job so it shares ONE "
+                        "extractor with the cap logic. No --replay set needed.")
     p.add_argument("--body", metavar="TEXT",
-                   help="--check-pr only: body of the current PR (the open PR "
-                        "is not in the merged set, so its tag is read here)")
+                   help="--check-pr / --check-tag: body of the PR whose tag is "
+                        "read (the open PR is not in the merged set; for "
+                        "--check-tag this is the only input).")
     p.add_argument("--body-file", metavar="FILE",
-                   help="--check-pr only: path to a file holding the current "
-                        "PR body (alternative to --body)")
+                   help="--check-pr / --check-tag: path to a file holding the PR "
+                        "body (alternative to --body).")
     p.add_argument("--labels-file", metavar="FILE",
                    help="--check-pr only: JSON array of the current PR's labels "
                         "(so a requalification label on the open PR is honored; "
                         "symmetric to the requalification read on merged PRs)")
     args = p.parse_args(argv)
+
+    if args.check_tag:
+        # Tag conformity is decidable from a single body -- no merged set needed
+        # (#9485). This branch short-circuits before the --replay requirement.
+        if args.body is not None:
+            body = args.body
+        elif args.body_file:
+            body = Path(args.body_file).read_text(encoding="utf-8")
+        else:
+            p.error("--check-tag requires --body or --body-file")
+        print(json.dumps(check_tag_conformity(body), ensure_ascii=False))
+        return 0
 
     if not args.replay:
         p.error("--replay FILE (the merged-PR set) is required")


### PR DESCRIPTION
## Summary

The `variation-tag-guard` job and the `variation_light_cap` organ **both** required a colon in the Grain tag (`_GRAIN_TIER_RE` needed `:`, the guard `grep 'Grain:'` needed `:`). So `## Grain` section headings — where the TIER/GENRE sits on the next non-empty line, **no colon on the heading line itself** — were missed entirely. Consequence: **11/30** of a day's merges went unattributed, silently under-counting the G-VAR-2 light-cap budget.

Per #9485 acceptance ("le guard et l'organe partagent le meme extracteur — pas deux implementations qui divergeront"), the two now share **ONE** extractor: `variation_light_cap.py` exposes `parse_grain()` (form-tolerant) + a new `check_tag_conformity()`, and the guard's bash job calls `variation_light_cap.py --check-tag --body-file` and maps the JSON `defects` to the existing labels. Single source of truth — no second implementation that would diverge again.

## Dogfood

This very PR body uses the `## Grain` **heading** form (no colon on the heading line) below. If the `Check Grain tag conformity` job passes with **no** `variation-tag-*` label, that is live CI proof the new reader handles the previously-missed form.

## Root cause (same defect in both readers)

| Reader | Old code | Defect |
|--------|----------|--------|
| Organ `variation_light_cap.py` | `_GRAIN_TIER_RE = re.compile(r"Grain\s*:\s*...")` | colon **required** |
| Guard `variation-tag-guard.yml` | `GRAIN_LINE=$(printf '%s' "$PR_BODY" \| grep 'Grain:')` | colon **required** |

Fixing only one would have left them divergent. Both now defer to `parse_grain()`.

## Form-tolerance vs substance-tolerance

The heading form is **READ, not excused**. Tolerance is on FORM only (optional colon, heading `#` markers, quote `>` markers, bold `**...**`, `Grain :` space-colon). A body without a real TIER/GENRE still returns `variation-tag-missing`; a heading without a lane still returns `variation-tag-lane-missing`.

## Four distinct defect classes (each its own label)

| Defect | Label | Meaning |
|--------|-------|---------|
| no `Grain` tag at all | `variation-tag-missing` | PR body has no tag |
| TIER not in DEEP/MED/LIGHT | `variation-tag-malformed` | TIER invalid |
| GENRE off the §1 enumeration | `variation-tag-genre-offlist` | GENRE not in list |
| no `lane <machine:workspace>` | `variation-tag-lane-missing` | G-VAR-2 cap uncountable |

Four labels (vs one catch-all) so the nature of the gap reads in `gh pr list --json labels` without opening job logs.

## Replay (2026-07-30 wave)

`unattributed` merges drop **11 -> 2**. Both residuals are genuinely unattributable per #9485 acceptance:
- **#9477** — has a tag but **no lane** declared (correctly flagged `variation-tag-lane-missing`, but not attributable to a lane for G-VAR-2).
- **#9462** — **no `Grain` substring at all** (correctly flagged `variation-tag-missing`).

Neither can be attributed by any reader — they are real gaps, not parser misses.

## Tests

48 pass (36 original + 12 new). New coverage: heading form (`## Grain`), space-colon form (`Grain :`), bold-lane form (`**Lane** :`), prose "grain" word no-match, heading-without-substance returns None, h3 heading, and all four conformity defect classes via both the `check_tag_conformity()` function and the `--check-tag` CLI mode.

## Grain

MED/tooling (#9485 shared-extractor + heading-tolerant Grain tag reader) — lane myia-po-2024:CoursIA — prev: MED/guard #9436

## Validation

- `python -m pytest scripts/tests/test_variation_light_cap.py -q` -> 48 passed
- `python3 scripts/variation_light_cap.py --check-tag --body-file <heading-body>` -> `{"defects": [], ...}` (conforming)
- `--check-tag` on a tagless body -> `{"defects": ["variation-tag-missing"], ...}`
- `--check-tag` on a heading without lane -> `{"defects": ["variation-tag-lane-missing"], ...}`
- YAML validated: jobs = check-variation-tag, check-light-cap; sparse-checkout added; divergent bash block replaced by shared-extractor call.

Closes #9485
