### PR TITLE
test(ict,#4588): argumentation grounded edge-cases (self-loop, tweety, chain alternation)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_argumentation.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_argumentation.py
@@ -231,3 +231,77 @@ def test_phase_a_verdict_tpm_derivable():
         f"Phase A : la TPM doit avoir >= 2 etats, recu {n_states} -> FAIL"
     )
     assert np.allclose(P.sum(axis=1), 1.0)
+
+
+# --------------------------------------------------------------------------- #
+#  Gate 11 : self-loop = cycle de longueur 1 -> undec (corner case Dung)      #
+# --------------------------------------------------------------------------- #
+
+
+def test_grounded_self_loop_is_undec():
+    """Un argument qui s'auto-attaque (self-loop ``(a, a)``) reste ``undec``.
+
+    Corner case sémantique de Dung : un self-loop est un cycle de longueur 1.
+    L'algorithme par point fixe ne crédite jamais ``a`` comme ``in`` (il
+    faudrait que son unique attaquant -- lui-même -- soit d'abord ``out``, ce
+    qui exigerait qu'un ``in`` l'attaque, impasse), ni comme ``out`` (aucun
+    ``in`` ne l'attaque). Il tombe donc ``undec``, exactement comme un cycle
+    classique (Nixon diamond). Ce test protège la sémantique contre une
+    « optimisation » qui traiterait les self-loops comme des attaques
+    incontestées -> ``out`` (convention non standard).
+    """
+    af = arg.DungAF([0], [(0, 0)])
+    label = arg.grounded_labeling(af)
+    assert label[0] == "undec", (
+        f"self-loop doit etre undec (cycle longueur 1), recu {label[0]!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+#  Gate 12 : tweety_bird() resout le conflit (vs Nixon diamond)               #
+# --------------------------------------------------------------------------- #
+
+
+def test_tweety_bird_resolves_conflict():
+    """Le schéma canonique *Tweety* (oiseau vs autruche) se résout par soutien
+    indirect -- contrairement au *Nixon diamond* (cycle non résolu).
+
+    AF : 0 <-> 1 (conflit direct Tweety vole / ne vole pas), 2 -> 1 (le fait
+    « oiseau » attaque la négation). Grounded : 2 (non attaqué) = ``in`` ;
+    1 (attaqué par 2 ``in``) = ``out`` ; 0 (son seul attaquant 1 est ``out``)
+    = ``in``. Labeling attendu : {0: in, 1: out, 2: in}, aucun ``undec``.
+    C'est le contrepoint canonique au Nixon diamond (les deux ``undec``) :
+    l'ajout d'un attaquant externe non contesté (2) brise la symétrie.
+    """
+    af = arg.tweety_bird()
+    label = arg.grounded_labeling(af)
+    assert label == {0: "in", 1: "out", 2: "in"}, (
+        f"tweety_bird doit se resoudre en {{0:in, 1:out, 2:in}}, recu {label}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+#  Gate 13 : controversial_chain(n) = alternance in/out stricte               #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("n", [2, 3, 4, 5, 8])
+def test_controversial_chain_alternation(n):
+    """Une chaîne d'attaques ``0 -> 1 -> ... -> n-1`` produit une alternance
+    stricte ``in / out / in / out / ...`` en sémantique grounded.
+
+    Propriété documentée dans la docstring de :func:`controversial_chain` :
+    0 (non attaqué) = ``in``, 1 (attaqué par 0 ``in``) = ``out``, 2 (attaqué
+    par 1 ``out``, donc défendu) = ``in``, etc. Ce test formalise cette
+    propriété d'alternance (que le docstring énonce mais ne vérifiait pas) :
+    ``label[i] == 'in'`` si ``i`` pair, ``'out'`` si ``i`` impair. C'est le
+    substrat canonique d'une TPM non triviale (bascules propres).
+    """
+    af = arg.controversial_chain(n)
+    label = arg.grounded_labeling(af)
+    for i in range(n):
+        expected = "in" if i % 2 == 0 else "out"
+        assert label[i] == expected, (
+            f"arg {i} dans controversial_chain({n}) : attendu {expected!r}, "
+            f"recu {label[i]!r} (alternance in/out cassee)"
+        )


### PR DESCRIPTION
Grain: MED/test — lane myia-po-2025:CoursIA — prev: DEEP/docs (#9491 Ch.6)

See #4588. Adds 7 edge-case tests to `ict/tests/test_argumentation.py` (3 new Gates 11-13) covering documented-but-untested semantic corners of the Dung grounded labeling + canonical AF constructors.

## Summary

The existing `test_argumentation.py` (15 tests, Gates 1-10) covered the happy path of `grounded_labeling`, `belief_transition_matrix`, `discourse_irreversibility`. Three semantic corner cases documented in the module docstrings were **not** asserted by any test. This PR formalizes them as regression tests (Gates 11-13).

## New tests (3 Gates, 7 test cases)

1. **Gate 11 — `test_grounded_self_loop_is_undec`**: a self-loop `(a, a)` stays `undec`. Corner case of Dung semantics: a self-loop is a cycle of length 1. The fixpoint algorithm never credits `a` as `in` (its only attacker is itself, which would need to be `out` first — impasse) nor `out` (no `in` attacks it). It falls `undec`, exactly like a classical cycle (Nixon diamond). Protects against an "optimization" that would treat self-loops as uncontested attacks → `out` (non-standard convention).

2. **Gate 12 — `test_tweety_bird_resolves_conflict`**: the canonical *Tweety* schema (bird vs ostrich) resolves via indirect support — unlike *Nixon diamond* (unresolved cycle). AF: `0 <-> 1` (direct conflict), `2 -> 1` (the "bird" fact attacks the negation). Grounded: `2` (unattacked) = `in` ; `1` (attacked by `2 in`) = `out` ; `0` (its only attacker `1` is `out`) = `in`. Labeling `{0:in, 1:out, 2:in}`, no `undec`. Canonical counterpoint to Nixon diamond: adding an uncontested external attacker breaks the symmetry.

3. **Gate 13 — `test_controversial_chain_alternation`** (parametrized n=2,3,4,5,8 → 5 cases): an attack chain `0 -> 1 -> ... -> n-1` produces a strict `in/out/in/out/...` alternation. Property stated in the `controversial_chain` docstring but not previously asserted: `label[i] == 'in'` if `i` even, `'out'` if `i` odd. This is the canonical substrate for a non-trivial TPM (clean belief flips).

## Why this is MED/test (not LIGHT)

Each test asserts a **distinct semantic property** of Dung's grounded labeling (self-loop = undec, indirect-support resolution, chain alternation) — not a mechanical re-instantiation. The litmus "could I generate a dozen by scanning the next function?" → no: each encodes a corner case that required reading the algorithm's behavior by hand and deriving the expected labeling. The 3 properties are pedagogically documented in the module but were unprotected against regression.

## Validation (firsthand, on the deliverable)

| Check | Result |
|-------|--------|
| Baseline `ict/tests/test_argumentation.py` (before) | **15 passed** |
| After adding Gates 11-13 | **22 passed** (15 + 7) |
| Full `ict/tests/` suite | collection clean, no regression |
| C.1 sanity (no `raise NotImplementedError`/`assert False`/`1/0`) | **0 violations** |
| `tests/` dir (separate CI matrix suite) | NOT touched by this PR (test-only edit in `ict/tests/`) |

The double-dir collection collision (running `ict/tests/ tests/` together) is the pre-existing structural issue #9387/#9401 (documented in MEMORY `ict-two-parallel-test-dirs-both-active`) — the CI `ict-tests.yml` runs each dir as a **separate matrix job** precisely to avoid it. This PR does not affect `tests/`.

## Scope & guards

- 1 file, +74/-0 (MED/test). Catalogue byte-identical to main (untouched).
- L898 OK: no concurrent OPEN PR on `test_argumentation.py` (`gh search prs` = 0).
- Atomic: 1 subject (edge-case coverage for argumentation grounded semantics).
- Variation: MED/test after DEEP/docs #9487 + #9491 — genre distinct (test ≠ docs), G-VAR-3 satisfied, G-VAR-1 floor held by MED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
