### PR TITLE
fix(socialchoice,#9434): de-pin machine-dependent SAT/Z3 timing prose from SC-04 twin pair

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3-Csharp.ipynb
@@ -1745,7 +1745,7 @@
     "\n",
     "**Pourquoi le SMT est l'extension naturelle pour les grandes instances.** L'encodage booléen d'Arrow explose en clauses a mesure que le nombre d'alternatives ou de votants augmente (IIA est quadratique en profils). Le SMT delegue le raisonnement arithmetique au solveur Z3, qui dispose d'apprentissage de clauses (CDCL) et d'une decision guidee par la théorie. C'est pourquoi le notebook Python original conclut sur Z3 pour les instances au-dela du cas jouet.\n",
     "\n",
-    "> **Limite honnete (règle G.2).** Sur cette instance jouet (3 alternatives, 2 votants), DPLL from-scratch (Prong B #3801) resout en ~0.1 ms tandis que Z3, malgre sa puissance, met plus de temps (initialisation du Context + resolution). Z3 n'est avantageux que sur des instances plus larges ; sur le cas jouet, DPLL est suffisant et plus leger (0 dépendance NuGet). Les deux outils cohabitent ici a but **pedagogique** : comparer deux paradigmes de resolution du même theoreme d'impossibilite."
+    "> **Limite honnete (règle G.2).** Sur cette instance jouet (3 alternatives, 2 votants), DPLL from-scratch (Prong B #3801) résout quasi-instantanément (temps mesuré dynamiquement par la cellule de benchmark ci-dessus) tandis que Z3, malgre sa puissance, met plus de temps (initialisation du Context + resolution). Z3 n'est avantageux que sur des instances plus larges ; sur le cas jouet, DPLL est suffisant et plus leger (0 dépendance NuGet). Les deux outils cohabitent ici a but **pedagogique** : comparer deux paradigmes de resolution du même theoreme d'impossibilite."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
@@ -836,13 +836,15 @@
    "source": [
     "### Interpretation de la complexite\n",
     "\n",
-    "| Alternatives | Electeurs | Profils | Variables | Temps d'encodage |\n",
-    "|--------------|-----------|---------|-----------|------------------|\n",
-    "| 2 | 2 | 4 | 8 | < 1 ms |\n",
-    "| 2 | 3 | 8 | 16 | < 1 ms |\n",
-    "| 3 | 2 | 36 | 216 | 2,7 ms |\n",
-    "| 3 | 3 | 216 | 1,296 | 91,4 ms |\n",
-    "| 4 | 2 | 576 | ~7,000 | Estime : plusieurs secondes |\n",
+    "| Alternatives | Electeurs | Profils | Variables |\n",
+    "|--------------|-----------|---------|-----------|\n",
+    "| 2 | 2 | 4 | 8 |\n",
+    "| 2 | 3 | 8 | 16 |\n",
+    "| 3 | 2 | 36 | 216 |\n",
+    "| 3 | 3 | 216 | 1,296 |\n",
+    "| 4 | 2 | 576 | ~7,000 |\n",
+    "\n",
+    "Le temps d'encodage (machine-dépendant) est mesuré dynamiquement par la cellule de code ci-dessus ; il n'est pas figé ici (règle #9434 : les mesures non reproductibles sont tenues par le code, pas par la prose).\n",
     "\n",
     "**Observation critique** : Le nombre de profils croit comme $(m!)^n$ ou $m$ est le nombre d'alternatives et $n$ le nombre d'electeurs. Pour 4 alternatives et 3 electeurs, on atteint plus de 13,000 profils, rendant l'encodage SAT prohibitif.\n",
     "\n",
@@ -1301,7 +1303,7 @@
    "source": [
     "### Analyse des performances\n",
     "\n",
-    "Les trois solveurs affichent des performances comparables sur ces instances modestes (de l ordre de quelques millisecondes : sous la milliseconde en petite configuration (3 alternatives, 2 electeurs), jusqu a une quinzaine de ms en grande configuration (3 alternatives, 3 electeurs) ou CaDiCaL103 depasse legerement Glucose3). MiniSat22 est le plus rapide sur les deux configurations, mais les differences restent negligeables a cette echelle.\n",
+    "Les trois solveurs affichent des performances comparables sur ces instances modestes (temps mesurés dynamiquement par la cellule de benchmark ci-dessus). L'ordre relatif observé est stable sur ce cas jouet (MiniSat22 généralement le plus rapide, CaDiCaL103 légèrement au-dessus de Glucose3), mais les valeurs absolues sont machine-dépendantes et ne sont pas figées ici (règle #9434) ; les différences restent négligeables à cette échelle.\n",
     "\n",
     "Pour des instances plus grandes (milliers de variables et clauses), les heuristiques de branchement et les stratégies d'apprentissage de clauses font une différence plus notable. Glucose3 est généralement prefere pour les problems difficiles grace a son agressivite dans l'apprentissage de clauses, tandis que CaDiCaL excelle sur les très grandes instances."
    ]

--- a/scripts/notebook_tools/twin_pairs.d/socialchoice-4-computational-aggregation-sat-z3.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/socialchoice-4-computational-aggregation-sat-z3.yaml
@@ -12,6 +12,12 @@
       by: myia-po-2023:CoursIA
       python_sha: b8a55a010f8bcfdaa4bb1c6141c6408decdf8348
       csharp_sha: ea3274f2b4e20d75fc199176ce4136c299295a0c
+    - date: "2026-08-05"
+      by: myia-po-2023:CoursIA
+      python_sha: 7cefe1660ded04739df2d88043ece199dbdbba03
+      csharp_sha: 1d6c34998a7a2dea80e2b4362daae247d9bb3227
+      content_python_sha: 27551984fc79a82c6bd43760d48cf2e37a0a437819b98c2957bf5a98a1ac9a35
+      content_csharp_sha: 28562df3c1f0e4f3f168812c1860e8b75d85279a78ec9abefd69c48b6fef4969
   known_differences:
     - "AVERTISSEMENT D'INGENIERIE : parity_level=surface. Asymetrie de solveur SAT : le jumeau Python INVOQUE 3 vrais solveurs SAT industriels via PySAT (Glucose3, Minisat22, Cadical103) et les benchmark en §6 ; le C# reimplémente DPLL from-scratch (§1.1) sans NuGet de solveur SAT. Meme concept (agregation computationnelle d'Arrow/Sen), machineries SAT differentes."
     - "Le C# est HONNETE sur ce point : il contient une section dediee '§5 Verdict SOTA (EPIC #3801)' qui auto-declare que DPLL from-scratch n'est pas un substitut SOTA aux solveurs modernes, plus une 'Limite honnête (Prong B)' sous la conclusion. Ce point SOTA est un candidat d'enrichissement future (brancher un vrai solveur SAT NuGet), pas un verdict parity."
@@ -19,3 +25,4 @@
     - "Parite Z3 CONFIRMEE : les deux cotes utilisent Z3 pour la branche SMT (Python z3-py ; C# Microsoft.Z3 4.12.2). Le SMT est nativement twinned ; l'asymetrie porte uniquement sur le SAT (PySAT 3-solveurs vs C# DPLL from-scratch)."
     - "Axes de benchmark differents : Python §6 = benchmark de SOLVERS (Glucose3 vs Minisat22 vs Cadical103 sur l'encodage d'Arrow) ; C# §6 = benchmark STRUCTUREL Arrow vs Sen (compare les deux theoremes, pas les solveurs). Visualisation : Python §7 'Espace des Solutions' via matplotlib/numpy ; C# sans librairie de plotting."
     - "Re-baseline 2026-08-01 (myia-po-2023:CoursIA, cycle c.1054, EPIC #8052) : SHA Python avance 871a25d6 -> bd66b19d via §D.5 markdown-fix cote Python uniquement (table d'encodage + solver-bound alignes aux outputs committes ; drift parite-preserving, le C# n'est pas touche). Cote C# non modifie (csharp_sha 64e14757 inchange). Drift verifie surface-preserving : prose markdown seule sur l'axe de couverture Python, aucune cellule de code C# touchee."
+    - "Re-baseline 2026-08-05 (myia-po-2023:CoursIA, EPIC #9434) : drainage des mesures de temps machine-dependantes de la prose des DEUX jumeaux. Python cell 18 : colonne 'Temps d'encodage' retiree de la table de complexite (la cellule de code 17 la mesure deja live via time.time ; colonnes deterministes Profils/Variables = combinatoire math preservees). Python cell 28 : 'sous la milliseconde' / 'quinzaine de ms' de-pingues -> observation qualitative + pointeur vers benchmark code 27. C# cell 29 : '~0.1 ms' de-pingue -> 'quasi-instantanement' + pointeur vers benchmark code 24. Markdown-only sur les deux cotes : aucune cellule de code touchee, execution_count et outputs preserves (C.3, pas de re-exec). content_sha desormais enregistre -> les futures derives prose-only seront immunisees. Regle #9434 : 'calcule = legitime, prose = interdit'."


### PR DESCRIPTION
Grain: MED/notebook-markdown — lane myia-po-2023:CoursIA — prev: DEEP/genai #9493

See #9434

## Le défaut (EPIC #9434 — mesures non reproductibles figées en prose)

Le mandat #9434 : « les données quantitatives doivent être tenues par le CI (le code qui calcule), pas par la prose manuelle ». Le jumeau SC-04 (SocialChoice Computational-Aggregation SAT-Z3) figeait en prose markdown des **temps d'exécution machine-dépendants** qui sont **déjà mesurés et affichés dynamiquement par des cellules de code** — duplication gelée qui dérive à chaque changement de machine.

## Le fix — retirer plutôt que re-épingler (3 cellules, markdown-only)

| Cellule | Avant (prose figée) | Après | Tenue par le code (live) |
|---|---|---|---|
| Python 18 | table « Temps d'encodage » : `< 1 ms`, `2,7 ms`, `91,4 ms`, `plusieurs secondes` | colonne retirée + pointeur | code cell 17 (`time.time`) affiche `Temps (ms)` |
| Python 28 | `sous la milliseconde… jusqu'à une quinzaine de ms` | observation qualitative + pointeur | code cell 27 benchmark (Glucose3/MiniSat22/CaDiCaL103) |
| C# 29 | `DPLL… résout en ~0.1 ms` | `quasi-instantanément` + pointeur | code cell 24 (`Stopwatch`) benchmark Arrow vs Sen |

Colonnes **déterministes** (Profils, Variables = combinatoire mathématique `(m!)^n`) **préservées** : ce sont des mesures machine-indépendantes, pas du drift.

## Validation firsthand

- **Markdown-only** : aucun code/output/execution_count modifié (C.3 → pas de re-exec). `validate_pr_notebooks.py` : **2/2 PASS, 33 cellules** (21 Python + 12 C#).
- **Code holds the value** : les cellules 17/27 (Python) et 24 (C#) mesurent déjà les temps via `time.time`/`Stopwatch` et les affichent dans leurs outputs committés — la prose n'était qu'un double figé.
- **Twin-parity** : `check_twin_parity.py --check` **OK (3/3, DRIFT=0)**. Rebaseline SC-04 (blob SHA + enregistre `content_*_sha` pour la 1re fois → futures derives prose-only immunisées). `known_differences` documente le drainage.
- **Anti-collision** : 0 PR ouverte touche le timing SC-04 (trafic récent = line-counts #9391, clause-typo #9017, cost #9237 — tous orthogonaux au timing).
- **Scanner** : `check_prose_quantitative_claims.py --diff` ne signale plus de claim machine dans le diff.
- **Catalogue** byte-identique à `origin/main` (règle catalog-pr-hygiene).

## Scope (3 fichiers, atomique)

2 fichiers notebook (prose, 11 insertions / 9 délétions) + 1 fichier registry twin-parity (rebaseline + traceabilité, 7 insertions).

Rotation R6 : après MED/guard #9489 + DEEP/genai #9493 → **notebook-markdown** (famille GameTheory, genre distinct). Substance : drainage anti-regression + upgrade registry (content-sha), pas un scan LIGHT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
