### PR TITLE
docs(harness): reduit le detail global machine a un pointeur (canonique = roo-extensions)

### DIFF
--- a/docs/harness/global-rules-detail.md
+++ b/docs/harness/global-rules-detail.md
@@ -1,96 +1,19 @@
-# Règles globales machine — détail déporté
+# Règles globales machine — détail déporté (déplacé)
 
-Détail des règles portées par `~/.claude/CLAUDE.md` (harnais **machine**, auto-chargé dans tous les workspaces). La règle y reste succincte ; le détail — matrices complètes, verbatims, incidents fondateurs — vit ici et se lit à la demande.
+Ce détail vit désormais dans le dépôt **roo-extensions**, à côté du harnais global dont il porte le détail :
 
-**Source de vérité du harnais global** : `.claude/configs/user-global-claude.md` dans le dépôt **roo-extensions**, déployé en `~/.claude/CLAUDE.md` sur chaque machine. Un trim local est écrasé au prochain déploiement s'il n'est pas répercuté à la source.
+- Détail : `docs/harness/global-rules-detail.md` — matrice action→lecture de « Read Body Before Any Action », incident fondateur 2026-05-17, matrice de scope complète du « Multi-Machine Ping-Pong », verbatim du mandat 2026-05-19.
+- Règle : `.claude/configs/user-global-claude.md` — le harnais **machine**, déployé en `~/.claude/CLAUDE.md` dans tous les workspaces.
 
----
+**Pourquoi là-bas et pas ici.** Le harnais global est machine-level : il s'applique à tous les dépôts, et sa source de vérité est roo-extensions (un trim local est écrasé au prochain déploiement s'il n'y est pas répercuté). Son détail y rejoint les trois autres docs de référence que ce harnais pointait déjà — `roosync-tools-guide.md`, `conversation-browser-detailed.md`, `sddd-conversational-grounding.md`. Garder une seconde copie ici garantissait la dérive entre les deux : rien dans CoursIA ne référençait ce fichier, seul le harnais global le lisait.
 
-## Read Body Before Any Action
+Livré par jsboige/roo-extensions#3036 (mergée le 2026-08-05) ; cette copie n'est conservée en pointeur que le temps que les machines aient repris le déploiement.
 
-Règle HARD, aucune exception. Avant de **poster un commentaire**, **reviewer**, **merger**, **dispatcher du travail**, ou **commencer un fix** sur une issue/PR, lire :
+## Le détail propre à CoursIA
 
-1. **Le body complet** (description, scope, décisions, caveats déjà documentés)
-2. **Tous les commentaires existants** (`gh pr view N --json comments`, `gh issue view N --comments`)
-3. **Toutes les reviews déjà postées** (`gh pr view N --json reviews`) — humains ET bots, avec leur `state` (APPROVED / CHANGES_REQUESTED / COMMENTED)
-4. **Le diff** (`gh pr diff N` ou `git diff base..head`) avant review ou merge
+Les règles **projet** et leur détail restent ici :
 
-Le titre seul n'est pas la PR. Le `mergeStateStatus` seul n'est pas une review. Sauter cette lecture = agir à l'aveugle.
-
-### Matrice action → lecture obligatoire
-
-| Action | Lecture obligatoire avant |
-|---|---|
-| `gh pr comment N` | body PR + tous comments + toutes reviews existantes |
-| `gh pr review N` | idem + diff complet |
-| `gh pr merge N` | idem + `mergeStateStatus` + `reviews[].state == "CHANGES_REQUESTED"` **et** comments inline non-résolus → **NE PAS merger** si demandes non-adressées |
-| `gh issue comment N` | body issue + tous comments existants |
-| Dispatch d'une tâche sur une issue | body issue + comments + linked PRs |
-| Fix d'un bug basé sur une issue | body issue + comments + PRs liées + diagnostic existant |
-| Audit reassessment | body audit + le code source réel (vérification > mémo) |
-
-### Anti-patterns interdits
-
-- « Le titre dit X, je traite X » → lire le body, X peut être autre chose
-- « Le bot a APPROVED, je merge » → lire le body PR + comments humains + CHANGES_REQUESTED
-- « Je connais le sujet, je sais quoi dire » → lire ce qui a déjà été dit, ne pas dupliquer/contredire
-- « L'issue est ouverte depuis 2 jours, je commence à fix » → lire si un autre agent a déjà commencé/diagnostiqué/abandonné
-- « Pas de redite » en reviews : vérifier qu'aucun reviewer n'a déjà soulevé le point
-
-### Incident fondateur (2026-05-17, ai-01 sur CoursIA)
-
-6 reviews détaillées postées sur des PRs étudiantes EPITA Contraintes, avec des sections « Questions pour la soutenance » **en duplicate ET en conflit** avec les reviews brèves bienveillantes déjà postées par un autre agent (`jsboigeEpita`) — la veille de la soutenance.
-
-Si les comments existants avaient été lus AVANT, l'incident aurait été détecté : (a) style bref bienveillant déjà adopté, (b) un autre agent était en charge des reviews publiques, (c) fuite jury par-dessus la review de l'autre agent. La règle « lire avant » détecte les incohérences avant le post.
-
----
-
-## Multi-Machine Ping-Pong — Re-arm
-
-Le cluster ne fonctionne en continu que si chaque agent (coordinateur ET workers) ré-arme son réveil à la fin de chaque turn où il a terminé tout ce qu'il pouvait faire seul. Sans re-arme, l'agent s'endort pendant que le cluster continue à produire du travail (PRs, reviews, dispatches) — ping-pong rompu.
-
-Mandat user 2026-05-19 (incident R67/R68 sur ai-01) : « dans le cadre d'une tâche interactive avec messages utilisateurs, ça doit être systématique pour le ping-pong entre le coordinateur et les workers ».
-
-### Quand re-armer, par rôle
-
-| Rôle | Déclencheur | Prompt typique |
-|---|---|---|
-| **Coordinateur** | Après dispatch à TOUS les workers + complétion de ses tâches individuelles (merges, reviews, bilan), en attente des prochaines PRs/reports | `/coordinate` |
-| **Worker** | Après soumission de TOUTES ses PRs (attente review/merge) + complétion des tâches dispatchées, en attente du prochain dispatch | `/executor` ou prompt worker spécifique |
-
-### Cadence — cron porté, pas ScheduleWakeup
-
-`ScheduleWakeup` est clampé runtime à `[60, 3600]s` (max 1 h) : **il ne PEUT PAS porter un cycle multi-heures**. Conséquences :
-
-- **Coordinateur piloté par cron** : `CronCreate("<minute off-:00> */<N> * * *", "/coordinate")` (job session-only, auto-expire 7 j). **NE PAS re-armer un `ScheduleWakeup` par-dessus** — cela ré-introduirait un cycle plus court que la cadence décidée.
-- **Sessions interactives coord/worker NON pilotées par cron** : `ScheduleWakeup(delaySeconds: 3540, …)` à chaque fin de turn pour ne pas rompre le ping-pong. C'est le **plafond technique**, pas un mandat de cadence horaire.
-- **Jitter** : minute off-`:00` (ex. 3540 s = 59 min) pour éviter que tous les agents frappent l'API à la même seconde.
-- **Auto-régulation** via cap 3-IDLE (#2185, par exécutant) + override urgent `[WAKE-CLAUDE]` routé `machine:workspace` (début de ligne sur un append dashboard). **PAS** via timer adaptatif — ne pas faire varier l'intervalle « selon la charge perçue ».
-
-### Scope STRICT — quand la règle s'applique
-
-EXCLUSIVEMENT : sessions Claude Code **interactives** (REPL avec messages utilisateur) où l'agent joue **activement** un rôle **coordinateur** OU **worker** dans un workflow multi-machine.
-
-### Quand elle NE s'applique PAS
-
-| Type d'interaction | Re-arme ? | Pourquoi |
-|---|---|---|
-| Workers schedulés (Task Scheduler, cron, `start-claude-worker.ps1`) | **NON** | Cadence gérée externalement — re-armer = double-firing |
-| Méta-analystes scheduled (cycle 72 h) | **NON** | Cadence externe (`start-meta-audit.ps1`) |
-| Sessions interactives informationnelles (Q/R, pas de rôle coord/worker actif) | **NON** | Pas de ping-pong à entretenir |
-| Sessions interactives ad-hoc / debugging / one-shot | **NON** | Pas de ping-pong à entretenir |
-| Workspace single-machine (pas de cluster) | **NON** | Pas de cluster à animer |
-| Handoff documenté (un autre agent assume la suite) | **NON** | Continuité portée par l'autre agent |
-
-**Heuristique** : « Y a-t-il un cluster d'autres machines en train de produire du travail dont je dois m'occuper au tour suivant ? » — si OUI **et** session interactive **et** rôle coord/worker → re-arme. Sinon → pas de re-arme.
-
-Le champ `reason` du `ScheduleWakeup` doit être informatif (visible en télémétrie et par le user).
-
----
-
-## Voir aussi
-
-- `~/.claude/CLAUDE.md` — le harnais global (règles succinctes)
-- [`.claude/rules/harness-hygiene.md`](../../.claude/rules/harness-hygiene.md) — les 3 tiers d'information
+- [`.claude/rules/harness-hygiene.md`](../../.claude/rules/harness-hygiene.md) — les 3 tiers d'information (harnais succinct / doc pérenne / dashboard éphémère)
 - [`.claude/rules/coordinator-discipline.md`](../../.claude/rules/coordinator-discipline.md) — discipline coordinateur
-- [`.claude/rules/proactive-coordination.md`](../../.claude/rules/proactive-coordination.md) — L740 (re-arm des crons expirés)
+- [`.claude/rules/proactive-coordination.md`](../../.claude/rules/proactive-coordination.md) — L740, re-arm des crons expirés
+- [`docs/reference/`](../reference/) — détail déporté des règles projet


### PR DESCRIPTION
## Le problème que ça règle

#9483 a déporté le détail du harnais **global machine** dans `docs/harness/global-rules-detail.md` (CoursIA). C'était le mauvais dépôt.

Ce harnais-là est machine-level : il s'applique à tous les workspaces, et sa source de vérité est `.claude/configs/user-global-claude.md` dans **roo-extensions** — un trim local y est écrasé au prochain déploiement s'il n'est pas répercuté. Son détail doit vivre au même endroit, à côté des **trois autres docs de référence que ce harnais pointait déjà** (`roosync-tools-guide.md`, `conversation-browser-detailed.md`, `sddd-conversational-grounding.md`), tous dans roo-extensions.

Garder une seconde copie ici garantissait la dérive entre les deux, sans contrepartie : `grep -rn 'global-rules-detail'` sur CoursIA renvoie **zéro** référence — le seul lecteur du fichier était le harnais global lui-même.

## Preuve de préservation

Le contenu est canonique dans jsboige/roo-extensions#3036 (mergée le 2026-08-05), fichier `docs/harness/global-rules-detail.md` (7 327 o) — matrice action→lecture, incident fondateur 2026-05-17, matrice de scope du ping-pong, verbatim du mandat 2026-05-19. Ce fichier-ci devient un pointeur, il n'est pas supprimé : les machines qui n'ont pas encore repris le déploiement gardent un chemin qui explique où regarder.

Le détail des règles **projet** reste dans CoursIA — `docs/reference/` et `.claude/rules/` sont inchangés.

Grain: LIGHT/docs — lane `myia-ai-01:CoursIA` — prev: MED/docs #9483

See #9483