### PR TITLE
docs(sudoku,#3975): reconcile sudoku_lean tree with disk — add 4 i18n _en siblings

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -676,11 +676,15 @@ Sudoku/
 │   └── sudoku_rrn_v4_best.pt
 ├── sudoku_models/                         # Checkpoints d'entraînement comparatif
 │   └── checkpoints/
-├── sudoku_lean/                           # Lake Lean 4 (preuve de propagation, 3 modules, 0 sorry)
-│   ├── Sudoku.lean                        # Umbrella
-│   ├── Sudoku/Basic.lean
-│   ├── Sudoku/Propagation.lean
-│   ├── Sudoku/ExactCover.lean
+├── sudoku_lean/                           # Lake Lean 4 (preuve de propagation, 3 modules FR + siblings _en #4980, 0 sorry)
+│   ├── Sudoku.lean                        # Umbrella (FR canonique)
+│   ├── Sudoku_en.lean                     # Umbrella (sibling EN, i18n #4980)
+│   ├── Sudoku/Basic.lean                  # Module 1 : structures de base (FR)
+│   ├── Sudoku/Basic_en.lean               # Sibling EN
+│   ├── Sudoku/Propagation.lean            # Module 2 : propagation des contraintes (FR)
+│   ├── Sudoku/Propagation_en.lean         # Sibling EN
+│   ├── Sudoku/ExactCover.lean             # Module 3 : couverture exacte (FR)
+│   ├── Sudoku/ExactCover_en.lean          # Sibling EN
 │   ├── Sudoku.en.md
 │   ├── lakefile.lean
 │   ├── lake-manifest.json


### PR DESCRIPTION
## §E whole-file audit — Sudoku/README.md ↔ disk-truth reconciliation

**Grain:** LIGHT/docs — lane `myia-po-2026:CoursIA` — `See #3975` (leaf READMEs: SymbolicAI non-Lean + Sudoku + GameTheory).

### Defect found (only 1 — the README is well-maintained)

The `sudoku_lean/` structure tree (lines 679-687) was **stale**: it listed only the 4 FR `.lean` files (`Sudoku.lean` umbrella + `Basic`/`Propagation`/`ExactCover`), missing the **4 `_en` siblings** (`Sudoku_en`, `Basic_en`, `Propagation_en`, `ExactCover_en`) that the i18n #4980 rollout added and that ARE tracked on `origin/main`:

```
$ git ls-tree -r --name-only origin/main -- .../Sudoku/sudoku_lean | grep -E "\.lean$"
sudoku_lean/Sudoku.lean
sudoku_lean/Sudoku/Basic.lean
sudoku_lean/Sudoku/Basic_en.lean       <- missing from tree
sudoku_lean/Sudoku/ExactCover.lean
sudoku_lean/Sudoku/ExactCover_en.lean  <- missing from tree
sudoku_lean/Sudoku/Propagation.lean
sudoku_lean/Sudoku/Propagation_en.lean <- missing from tree
sudoku_lean/Sudoku_en.lean             <- missing from tree
sudoku_lean/lakefile.lean
```

Fix: the tree now lists all 8 module files (FR canonical + `_en` siblings) with per-module role comments, and the section header notes the bilingual structure (`3 modules FR + siblings _en #4980`).

### Full §E audit (every count checked against `origin/main` disk-truth)

| Claim | README | Disk-truth (origin/main) | Status |
|-------|--------|--------------------------|--------|
| Canonical notebooks | 36 | 36 (`git ls-tree` `.ipynb`, excl `_output`) | OK |
| Kernel breakdown | 17 C# + 18 Python + 1 Lean | 17 C# + 18 Python + 1 Lean (kernelspecs firsthand) | OK |
| CATALOG-STATUS `pedagogical_count` | 36 | 36 | OK (marker byte-identical) |
| `_output.ipynb` policy | gitignored, 0 committed | 0 tracked on origin/main | OK (L12 already correct) |
| `sudoku_lean` own `.lean` | tree listed 4 | 9 (4 FR + 4 `_en` + lakefile) | **FIXED** |
| `sudoku_lean` sorry | 0 | 0 (verified in all 9 own files) | OK |

Only 1 defect found → the diff is small because the file is well-maintained, not because the audit was shallow. A prior cycle already fixed the stale "8 `_output` committed" claim (L12); this PR closes the residual `sudoku_lean` tree drift.

### Hygiene
- CATALOG-STATUS marker + generated catalogue: **byte-identical** (untouched — catalog-pr-hygiene R1).
- Markdown-only (§E feuille; C.2 n/a — no notebook touched).
- FR-first preserved (readme-french-first).

See #3975 (partial — Sudoku leaf README disk-truth reconciliation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)