### PR TITLE
fix(sudoku,#9434): de-pin machine-dependent Z3 timing prose from Sudoku-12-Python twin

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
@@ -481,11 +481,10 @@
    "source": [
     "### Interpretation : Résultat Z3 Int\n",
     "\n",
-    "Le solveur Z3 avec des entiers a resolu le puzzle difficile en 340.86 ms.\n",
+    "Le solveur Z3 avec des entiers a resolu le puzzle difficile quasi-instantanement (temps mesure dynamiquement par la cellule de code ci-dessus).\n",
     "\n",
     "| Aspect | Valeur | Signification |\n",
     "|--------|--------|---------------|\n",
-    "| **Temps de resolution** | 340.86 ms | Performance acceptable |\n",
     "| **Statut** | sat | Solution trouvee |\n",
     "| **Type de variables** | Int | Entiers symboliques |\n",
     "\n",
@@ -494,7 +493,9 @@
     "2. **Théorie des entiers** : Z3 utilise QF_LIA (Linear Integer Arithmetic)\n",
     "3. **Flexibilite** : Z3 peut facilement etendre le modèle avec d'autres contraintes\n",
     "\n",
-    "> **Note technique** : La contrainte `Distinct` de Z3 est plus puissante que l'inegalite binaire car elle permet au solveur d'utiliser des algorithmes specialised pour la propagation."
+    "> **Note technique** : La contrainte `Distinct` de Z3 est plus puissante que l'inegalite binaire car elle permet au solveur d'utiliser des algorithmes specialised pour la propagation.\n",
+    ">\n",
+    "> **Regle #9434** : le temps de resolution (machine-dependant) est mesure dynamiquement par la cellule de code ci-dessus ; il n'est pas fige ici."
    ]
   },
   {
@@ -745,22 +746,24 @@
    "source": [
     "### Interpretation : Z3 Int vs BitVector\n",
     "\n",
-    "La comparaison montre que l'utilisation de **BitVectors 4 bits** est significativement plus rapide que les entiers.\n",
+    "La comparaison montre que l'utilisation de **BitVectors 4 bits** est significativement plus rapide que les entiers — le gain observe est de **~2x a ~6x selon le puzzle** (ordre de grandeur stable cross-machine, mesure dynamiquement par la cellule de benchmark ci-dessus).\n",
     "\n",
-    "| Puzzle | Z3 Int | Z3 BitVec | Amelioration |\n",
-    "|--------|--------|-----------|--------------|\n",
-    "| Puzzle 1 | 271.18 ms | 68.65 ms | **4.0x plus rapide** |\n",
-    "| Puzzle 2 | 462.26 ms | 71.84 ms | **6.4x plus rapide** |\n",
-    "| Puzzle 3 | 222.89 ms | 61.95 ms | **3.6x plus rapide** |\n",
-    "| Puzzle 4 | 389.18 ms | 117.54 ms | **3.3x plus rapide** |\n",
-    "| Puzzle 5 | 237.59 ms | 105.18 ms | **2.3x plus rapide** |\n",
+    "| Puzzle | Amelioration (BitVec vs Int) |\n",
+    "|--------|------------------------------|\n",
+    "| Puzzle 1 | ~4x plus rapide |\n",
+    "| Puzzle 2 | ~6x plus rapide |\n",
+    "| Puzzle 3 | ~4x plus rapide |\n",
+    "| Puzzle 4 | ~3x plus rapide |\n",
+    "| Puzzle 5 | ~2x plus rapide |\n",
     "\n",
     "**Points cles** :\n",
     "1. **BitVectors sont plus proches du hardware** : Z3 peut utiliser des opérations bit-level\n",
     "2. **Domaine restreint** : 4 bits = 16 valeurs, exactement ce qu'il faut pour 1-9\n",
     "3. **Propagation plus efficace** : Les contraintes bit-level sont plus simples a propager\n",
     "\n",
-    "> **Note technique** : Les BitVectors sont representes en precision fixe (4 bits ici), ce qui permet a Z3 d'utiliser des algorithmes de propagation plus efficaces. Les entiers symboliques en Z3 ont une precision arbitraire, ce qui ajoute de la complexite."
+    "> **Note technique** : Les BitVectors sont representes en precision fixe (4 bits ici), ce qui permet a Z3 d'utiliser des algorithmes de propagation plus efficaces. Les entiers symboliques en Z3 ont une precision arbitraire, ce qui ajoute de la complexite.\n",
+    ">\n",
+    "> **Regle #9434** : les temps absolus (machine-dependants) sont mesures dynamiquement par la cellule de benchmark ci-dessus ; seuls les ordres de grandeur du speedup (structurels, stables cross-machine) sont conserves ici."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-12-z3.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-12-z3.yaml
@@ -8,7 +8,14 @@
       by: myia-po-2023:CoursIA
       python_sha: b96f422f56c22836ef891e82a3f2df25d59453f1
       csharp_sha: 89dec9e761a784698299ac2fd1498107f08ebab2
+    - date: "2026-08-05"
+      by: myia-po-2023:CoursIA
+      python_sha: dc50ea9dcff0391b2f094da547ee7b50cf2fc791
+      csharp_sha: 89dec9e761a784698299ac2fd1498107f08ebab2
+      content_python_sha: 5a3f81362d1d616b3767f7f25cd96f6a8135fb803ff112d2ed329f6224c4499a
+      content_csharp_sha: 099683fd28d6afec1ed10897a481c81acf29cad19a40daf15ec5f619a509c04a
   known_differences:
     - "Socle pedagogique commun : resolution de Sudoku par SMT (Satisfiability Modulo Theories) avec le vrai solveur Z3 (Microsoft Research) -- modelisation des contraintes Sudoku comme formules logiques (BitVec, contraintes all-different sur lignes/colonnes/carres), resolution par le solveur SMT. Les deux cotes utilisent le VRAI Z3 SOTA (meme moteur sous-jacent), meme cas d'application (Sudoku). Les deux couvrent Z3, z3, BitVec, Solver."
     - "Divergence de binding : le C# accede a Z3 via Microsoft.Z3 (NuGet, bindings .NET natifs, 19 cellules code) ; le Python accede a Z3 via pyz3 (import z3, bindings Python, 11 cellules). C'est le meme solveur Z3 avec deux bindings idiomatiques -- c'est la definition meme de parity_level semantic (meme moteur, API idiomatique differente). Note : le Python reference aussi ortools (OR-Tools, alternative CP-SAT) en complement."
     - "Idiomes framework : C# = Microsoft.Z3 (NuGet) + System.*, 19 cellules code ; Python = pyz3 + ortools, 11 cellules code. Vrai Z3 SMT solver des deux cotes (SOTA veritable, pas de workaround), bindings langage differents."
+    - "#9434 drainage (2026-08-05, Python seulement) : cellules markdown 12 + 16 figeaient des temps absolus machine-dependants (340.86 ms, 271.18/68.65/462.26/71.84/222.89/61.95/389.18/117.54/237.59/105.18 ms) qui sont des frozen dups des outputs live des cellules code 11 (Z3Solver) et 15 (Z3BitVectorSolver + time). Drainage markdown-only : ms absolus remplaces par qualitatif + pointeur vers la cellule de benchmark live ; speedup structurel conserve (~2-6x, approximatif/observationnel, cf #9434 App-11 precedent). C# non touche (ses timings sont des estimations de duree, pas des frozen dups). Parite preservee : le contenu pedagogique (Z3 Int vs BitVec, points cles, note technique) est identique, seul le registre de mesure (prose figee -> live) change. content_*_sha enregistre pour la 1re fois -> futures derives prose-only immunisees (#9399)."


### PR DESCRIPTION
Grain: MED/notebook-markdown — lane myia-po-2023:CoursIA — prev: MED/lean #9502

See #9434

## Le défaut — frozen dups de temps machine-dépendants dans Sudoku-12-Python

Cas canonique #9434 (« calcule = légitime, prose = interdit ») : `Sudoku-12-Z3-Python.ipynb` figeait en prose markdown des **temps absolus machine-dépendants** qui sont des **duplications gelées des outputs live de cellules de code** :

- **Cellule 12** (markdown) : `« ...resolu le puzzle difficile en 340.86 ms »` + ligne de table `| Temps de resolution | 340.86 ms |` — **frozen dup parfait** de l'output live de la cellule 11 (`Z3Solver.solve` + `time`) qui affiche `« Résolu: True en 340.86 ms »`.
- **Cellule 16** (markdown) : table de comparaison Int vs BitVec figeant **10 valeurs ms absolues** (`271.18`, `68.65`, `462.26`, `71.84`, `222.89`, `61.95`, `389.18`, `117.54`, `237.59`, `105.18`) — **frozen dups** de l'output live de la cellule 15 (`Z3BitVectorSolver` benchmark + `time`) qui affiche ces ms puzzle par puzzle.

Sur une autre machine, les cellules de code produiraient des ms différents → la prose gelée deviendrait **stale/fausse**. C'est la pathologie #9434 : re-épingler en prose une valeur qui rebouge à chaque machine.

## Le fix — drainage markdown-only (retirer plutôt que re-épingler)

Drainage chirurgical (raw-JSON replace avec assertions `count==1`, pas de re-serialize) :

- **Cellule 12** : `340.86 ms` → qualitatif (« quasi-instantanément, temps mesuré dynamiquement par la cellule ci-dessus ») + ligne de table « Temps de resolution » retirée (lignes structurelles Statut=sat / Type=Int conservées). Note #9434 ajoutée.
- **Cellule 16** : colonnes ms absolues (`Z3 Int`, `Z3 BitVec`) retirées ; **speedup structurel conservé** (~4x, ~6x, ~4x, ~3x, ~2x — approximatif/observationnel, tilde signalant structural, cf précédent #9434 App-11 où `~68x` était conservé). L'ordre de grandeur du speedup BitVec-vs-Int est stable cross-machine (opérations bit-level vs entiers précision arbitraire) — c'est du contenu structurel légitime. Note #9434 ajoutée.

**Contenu pédagogique intact** : points clés (BitVec proches du hardware, domaine restreint, propagation efficace), note technique (précision fixe vs arbitraire) — seuls les registres ms figés sont drainés.

## Validation firsthand

- **Markdown-only** : 0 cellule code/output/execution_count modifiée (cellules 11/15 intactes, exec_count 4/6 préservé). C.3 (pas de re-exec), H.3 validé.
- **Scanner** : `check_prose_quantitative_claims.py --class machine` sur le notebook → **`[OK] aucun compteur quantitatif en prose`** (les 12 claims machine sont partis).
- **Twin-parity** : `check_twin_parity.py` — `[DRIFT] Sudoku-12 Z3` attendu (markdown change → blob SHA) → `--update` rebaseline + **enregistre `content_python_sha`/`content_csharp_sha` pour la 1re fois** (futures derives prose-only immunisées, #9399). `known_differences` documenté. `[OK] Sudoku-12 Z3` post-update.
- **CRLF** : 0. **Catalogue** : byte-identique.
- **Anti-collision** : 0 PR ouverte sur drainage timing Sudoku-12 (trafic récent #8277/#3401/#4972 = verdict-inversion/alignement-outputs/demos, orthogonaux).

## R6 / Variation
`MED/notebook-markdown` après `MED/lean #9502` — **family rotation Sudoku** (vs GameTheory SC-04 #9497, ma précédente drainage). La veine #9434 drainage est active sur 4 familles non-chevauchantes (po-2023: SC-04 GameTheory + Sudoku-12 ; po-2024: App-12 Search ; po-2025: GenAI/Texte) — 2866 claims/660 fichiers, travail massif. Genre notebook-markdown répété mais famille nouvelle (pas un mono-thème GenAI). G.1 angle-mort respecté : IIT/Sudoku/Probas scannés au préalable, la plupart = estimations de durée (FP, exclus) ; Sudoku-12 ms précis (4 significant figures) = signature golden-case.

## Scope
```
2 files changed
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb | 27 +++++++++-----------
 scripts/notebook_tools/twin_pairs.d/sudoku-12-z3.yaml | 7 ++++++
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
