### PR TITLE
docs(qc,#9434): drain blind prose-pinned backtest metrics from 3 QC READMEs

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Alpha/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Alpha/README.md
@@ -23,10 +23,12 @@ lean backtest --project .
 
 | Métrique | Valeur |
 |----------|--------|
-| Sharpe Ratio | ~1,00 |
 | Benchmark | SPY |
 | Rebalance | Quotidien |
 | Univers | 5 actions tech |
+
+> **Sharpe Ratio** : non épinglé — métrique machine-dépendante qui dérive avec les
+> données et la période. L'obtenir via `lean backtest` ou le projet QC Cloud 28885488.
 
 ## Fichiers
 

--- a/MyIA.AI.Notebooks/QuantConnect/projects/FuturesTrend/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/FuturesTrend/README.md
@@ -14,13 +14,11 @@ Stratégie de suivi de tendance sur les futures E-mini S&P 500 (ES).
 
 ## Backtest Results (2019-2023)
 
-| Métrique | Valeur |
-|----------|--------|
-| Total Return | ~40-60% |
-| CAGR | ~9-12% |
-| Sharpe Ratio | ~0.5-0.8 |
-| Max Drawdown | ~-25% à -35% |
-| Win Rate | ~35-45% |
+> Les métriques quantitatives (Total Return, CAGR, Sharpe, Max Drawdown, Win Rate) sont
+> machine-dépendantes : elles dérivent avec les données, la période et l'environnement
+> d'exécution. Elles ne sont pas attestées par un backtest figé ici. Les obtenir via
+> `lean backtest` (moteur Lean local) ou en poussant le projet sur QC Cloud. Seuls les
+> paramètres déterministes (instrument, signal, sizing) figurent dans le tableau ci-dessus.
 
 ## Fichiers
 

--- a/MyIA.AI.Notebooks/QuantConnect/projects/OptionsIncome/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/OptionsIncome/README.md
@@ -24,12 +24,10 @@ Stratégies de génération de revenus via la vente d'options.
 
 ## Backtest Results - Covered Call (2020-2023)
 
-| Métrique | Valeur |
-|----------|--------|
-| Total Return | ~25-35% |
-| Premium Collected | ~$8,000-12,000 |
-| Max Drawdown | ~-25% à -30% |
-| Sharpe Ratio | ~0.5-0.8 |
+> Les métriques quantitatives (Total Return, Premium, Max Drawdown, Sharpe) sont
+> machine-dépendantes : elles dérivent avec les données, la période et l'environnement
+> d'exécution. Elles ne sont pas attestées par un backtest figé ici. Les obtenir via
+> `lean backtest` (moteur Lean local) ou en poussant le projet sur QC Cloud.
 
 ## Fichiers
 


### PR DESCRIPTION
## Summary

3 QC project READMEs (`FuturesTrend`, `OptionsIncome`, `EMA-Cross-Alpha`) carried **blind prose-pinned backtest metrics** in "Backtest Results" tables — `~range` values (Sharpe ~0.5-1.0, CAGR, Max Drawdown, Win Rate) with **no provenance**: no backtest-id, no `research.ipynb` cell-ref, no dated execution attestation. Per the **#9434 mandate** ("calcule = legitime, prose = interdit") and **#1621** (QC consolidation wants reliable metrics), machine-dependent values pinned in prose are the defect — they drift with data/period/environment.

## Drainage (replace blind tables → pointer to live backtest)

| README | Before (blind, no provenance) | After |
|--------|-------------------------------|-------|
| FuturesTrend | `Sharpe ~0.5-0.8`, `CAGR ~9-12%`, `MaxDD ~-25-35%`, `Win ~35-45%` (2019-2023) | note: obtain via `lean backtest` / QC Cloud |
| OptionsIncome | `Total Return ~25-35%`, `Sharpe ~0.5-0.8`, `MaxDD ~-25-30%`, `Premium ~$8-12k` (2020-2023) | note: obtain via `lean backtest` / QC Cloud |
| EMA-Cross-Alpha | `Sharpe Ratio \| ~1,00` (cloud-id 28885488) | row drained; pointer to QC Cloud project 28885488 + `lean backtest` |

**Preserved**: deterministic parameter rows (instrument, signal, sizing, benchmark, universe, rebalance). **Untouched**: strategy code (`main.py`, `quantbook.ipynb`, `research.ipynb`).

## G.1 firsthand triage (skip the legitimately-sourced)

Drained ONLY the blind `~range` tables with zero provenance. **Skipped** READMEs whose metrics carry real provenance (these are LEGITIMATE "calcule", not "prose"):
- **Backtest-id**: `Crypto-MultiCanal` (`82fae2cde...`, dated 2026-06-14, reproducibility proof)
- **Cell-ref**: `RiskParity` (`research.ipynb cell[10].out[0]`), `LongShortHarvest` (`cell[9].out[0]`)
- **Dated attestation**: `Stoploss-Volatility-ML` ("QC Cloud executed 2026-05-11, project 29463529")
- **Archived**: `MomentumStrategy` (ARCHIVE.md documents Sharpe ceiling ~0.48; the README ~0.8-1.0 conflicts with its own archive — left for a dedicated archive-reconciliation)

## Validation

- Markdown-only: **3 README.md**, `+12/-14`. No code/output/execution_count touched. Catalogue byte-identique.
- Post-drain grep: 0 blind `~Sharpe` ranges remain in the 3 touched READMEs.
- Note: the #9434 instrument `check_prose_quantitative_claims.py` is **notebook-scoped** (`.ipynb`); this PR extends the mandate to QC project READMEs (`.md`). The principle (quant held by computation, not prose) is repo-wide; #1621 covers QC README metrics.

See #9434
See #1621

## Grain

LIGHT/docs (#9434 drainage - QC README blind backtest metrics -> live-backtest pointer) - lane myia-po-2024:CoursIA - prev: MED/notebook-markdown #9501
