### PR TITLE
fix(search,#8052): App-7 Wordle intro prediction contradicts committed benchmark

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb
@@ -110,9 +110,9 @@
     "\n",
     "| # | Approche | Principe | Performance attendue |\n",
     "|---|----------|----------|---------------------|\n",
-    "| 1 | Filtrage simple | Eliminer les mots incompatibles, choisir au hasard | ~4-5 tentatives |\n",
-    "| 2 | CSP | Modeliser les contraintes sur les positions de lettres | ~4-5 tentatives (plus structure) |\n",
-    "| 3 | Entropie | Maximiser l'information gagnee par tentative | ~3.5 tentatives |"
+    "| 1 | Filtrage simple | Eliminer les mots incompatibles, choisir au hasard | ~3 tentatives |\n",
+    "| 2 | CSP | Modeliser les contraintes sur les positions de lettres | ~3 tentatives |\n",
+    "| 3 | Entropie | Maximiser l'information gagnee par tentative | ~2.9 tentatives |"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/app-7-wordle.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-7-wordle.yaml
@@ -12,6 +12,12 @@
       by: myia-po-2023:CoursIA
       python_sha: 539c43fa6b5e50f99c065e8aa97bf8594863225f
       csharp_sha: 2c8194226c9eabf6906fc907455aae6190dc571b
+    - date: "2026-08-05"
+      by: myia-po-2023:CoursIA
+      python_sha: 084159134a3f4fe4b21ab04487b171c7af0562dd
+      csharp_sha: 2c8194226c9eabf6906fc907455aae6190dc571b
+      content_python_sha: 41db3a285e9797839e6f821463c8f422ec2d6d26091e78cbf1960594cf02bfa9
+      content_csharp_sha: 2c3db01c13d46ede8e7eba70b16ad0dd2d29399c59be643f5c56c9077a0eca87
   known_differences:
     - "Socle pedagogique commun : Wordle (logique deductive + feedback, theorie de l'information) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = Counter/typing + matplotlib viz ; C# = System.IO + Microsoft.DotNet.Interactive formatting."


### PR DESCRIPTION
Grain: MED/value — lane myia-po-2023:CoursIA — prev: MED/notebook-markdown #9507

See #8052

## Le défaut — l'intro (cell 2) contredisait le benchmark committé (cell 41)

La table « Performance attendue » de l'intro (cellule 2 markdown) prédisait :
- Filtrage simple : `~4-5 tentatives`
- CSP : `~4-5 tentatives (plus structure)`
- Entropie : `~3.5 tentatives`

Mais le **benchmark committé** (cellule 41, `exec_count: 17`, seed=42, **déterministe**) mesure sur 100 parties :
```
Filtrage simple      3.11         5          100      0.1
CSP                  3.12         5          100      0.3
Entropie             2.86         5          100      0.2
```

L'intro annonçait donc une performance ~30 % moins bonne que ce que le notebook **démontre réellement** dans ses outputs — typique de la classe de défaut #8052 (claims↔outputs) : la **prose contredit les outputs déterministes committés**. Un étudiant lisant l'intro s'attend à ~4-5 tentatives, puis voit le solver en faire ~3 → discordance pédagogique.

## Le fix — aligner l'intro sur le benchmark (3 lignes de table)

- Filtrage : `~4-5 tentatives` → `~3 tentatives` (vs 3.11 réel)
- CSP : `~4-5 tentatives (plus structure)` → `~3 tentatives` (vs 3.12 réel)
- Entropie : `~3.5 tentatives` → `~2.9 tentatives` (vs 2.86 réel)

L'Entropie reste légèrement meilleure que Filtrage/CSP (~2.9 vs ~3), ce qui **préserve le récit pédagogique** (l'information-gain bat le hasard) — sans pour autant surpromettre.

## Validation data-verifiable

Les valeurs sont **déterministes** (seed=42, algorithme non-stochastique pour le tirage du lexique) → vérifiables par les outputs committés cellule 41, **pas vision-gated**. Vérification :
- `git show HEAD:...App-7-Wordle.ipynb` → cellule 41 outputs : `3.11 / 3.12 / 2.86` ✓
- Diff = **exactement 3 lignes de table** (numstat 3/3, 0 CRLF, 0 cellule code touchée)

## Twin registry — content_*_sha enregistrées (future prose-immune, #9399)

La paire App-7 Wordle (Python ↔ C#) est `parity_level: semantic`. La registry n'avait pas de `content_*_sha` → toute dérive markdown (blob) était flaguée DRIFT. Cette PR enregistre pour la 1re fois `content_python_sha` + `content_csharp_sha` : les dérivées **markdown-only** futures seront immunisées (le checker comparera le contenu des cellules code, pas le blob SHA). Même pattern que Sudoku-12-Z3 (#9507).

## Scope

- Cellule 2 (markdown intro) **uniquement** — 3 lignes de table.
- **Aucune cellule code touchée** → pas de re-exécution nécessaire (C.3 markdown-only exception, outputs précédents valides).
- Registry twin `app-7-wordle.yaml` : 1 entrée d'audit ajoutée (rebaseline post-fix).
- C# twin (App-7b-Wordle-CSharp.ipynb) **non touché** (son intro n'avait pas cette table de prédiction).

## R6 / Variété

`MED/value` après `MED/notebook-markdown #9507`. Pivot d'EPIC volontaire : #9434 (timing-drainage, ms machine-dépendants) → #8052 (claims↔outputs, **valeurs déterministes** contradictoires). Deux classes de défaut distinctes — la veine #9434 drainage était devenue monoculture cluster (cluster-wide pivot out), #8052 rouvre un angle de substance (correctness des claims déterministes vs outputs). Pas de 3e GenAI d'affilée (#9347 rotated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
