### PR TITLE
docs(qc,#9434,#1621): EMA-Cross-Alpha README — real backtest metrics (Sharpe -0.01 vs blind ~1.00)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Alpha/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Alpha/README.md
@@ -19,16 +19,28 @@ lean backtest --project .
 
 **QC Cloud :** Ouvrir le projet 28885488 dans l'IDE QuantConnect et cliquer sur « Backtest ».
 
-## Métriques de backtest (2015-2026)
+## Métriques de backtest (2015-2024)
 
 | Métrique | Valeur |
 |----------|--------|
+| Sharpe Ratio | -0.01 |
+| CAGR | 2.799% |
+| Max Drawdown | 14.000% |
+| Net Profit | 31.824% |
+| Total Orders | 314 |
 | Benchmark | SPY |
 | Rebalance | Quotidien |
 | Univers | 5 actions tech |
 
-> **Sharpe Ratio** : non épinglé — métrique machine-dépendante qui dérive avec les
-> données et la période. L'obtenir via `lean backtest` ou le projet QC Cloud 28885488.
+> **Provenance** : backtest QC Cloud `8119728de11270cec45b8db81ed30a0b` (2026-08-05),
+> projet 28885488, IBKR margin, 2516 jours tradeables (2015-2024). Re-exécuter via
+> QC Cloud pour recalculer.
+>
+> **Lecture honnête** : un Sharpe de -0,01 est un edge statistiquement nul (PSR 0,006%),
+> et un CAGR de 2,8 % est sous le risk-free — la stratégie **ne bat pas le benchmark**.
+> C'est un contre-exemple pédagogique : un croisement EMA naïf (fast=20, slow=50) sur
+> 5 grandes valeurs tech sous-performe le buy & hold de SPY sur 2015-2024. La valeur
+> aveugle « ~1,00 » auparavant inscrite ici était fausse (deux ordres de grandeur).
 
 ## Fichiers
 


### PR DESCRIPTION
## Summary

Ran the **real backtest** of EMA-Cross-Alpha via QC Cloud MCP (projectId 28885488 — the creds ai-01 deblocked for C529-L1) and replaced the #9508 "obtain via lean backtest" pointer with **real, provenance-attested metrics**.

## Backtest result (2026-08-05, 2015-2024, IBKR margin, 314 orders, 2516 tradeable days)

| Metric | Value |
|--------|-------|
| Sharpe Ratio | **-0.01** |
| CAGR | 2.799% |
| Max Drawdown | 14.000% |
| Net Profit | 31.824% |
| Probabilistic Sharpe Ratio | 0.006% |

Backtest-id: `8119728de11270cec45b8db81ed30a0b`.

## G.9 honesty finding — the blind prose was wrong by ~100x

The README previously pinned `Sharpe Ratio | ~1,00` (the blind prose #9508 drained into a pointer). The **real** Sharpe is **-0.01** — two orders of magnitude lower. PSR 0.006% = statistically indistinguishable from zero edge; CAGR 2.8% ≈ risk-free. **The strategy does not beat the benchmark.**

This is exactly the defect the **#9434** mandate targets: blind prose misleads, and here it misled *badly* (a -0.01 strategy presented as ~1.0 = "good"). The README now:
1. States the real metrics with a **provenance block** (backtest-id + date + params) so the value is **re-derivable, not blind** — compliant with #9434 ("calcule = legitime, prose = interdit").
2. Frames the strategy honestly as the **pedagogical counter-example it is**: a naive EMA 20/50 crossover on 5 mega-cap tech stocks underperforms SPY buy & hold over 2015-2024. This is pedagogically *more* valuable than the false "~1.0" — a strategy that doesn't work is a better teaching artifact than one dressed up to look good.

Also corrected the heading period: was "2015-2026", `main.py` uses `set_end_date(2024, 12, 31)` → real period is **2015-2024**.

## Validation

- Real backtest run via MCP qc-mcp-lite (compile BuildSuccess 0 errors → backtest Completed). Metrics read from `statistics`.
- `totalOrders: 314` confirms the strategy trades actively (not the `read_backtest` 0-artifact — 314 real orders + $31.8k net profit = genuine execution).
- Markdown-only (+15/-3, 1 README). Catalogue byte-identique. No code touched (`main.py`/`quantbook.ipynb` unchanged).

## Grain

DEEP/qc-backtest (#9434/#1621 EMA-Cross-Alpha real metrics via deblocked creds — G.9 honest Sharpe -0.01 vs blind ~1.00) - lane myia-po-2024:CoursIA - prev: LIGHT/docs #9508

See #9434
See #1621
