### PR TITLE
ci(conway,#8782): wire HashlifeMemo + HashlifeMarginDemo into proof-integrity-audit (coverage 10->12)

### DIFF
--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -157,7 +157,7 @@ jobs:
       # and could not tell which tolerates the 8 acknowledged sorries from which
       # refuses them. Pinned by scripts/lean/tests/test_proof_integrity_display_names.py.
       display-name: conway_lean (audit)
-      target-modules: "Conway.Life.HashlifeCorrectness,Conway.Life.MacroCell,Conway.Life.Hashlife,Conway.Life.MacroCell_en,Conway.Life.Hashlife_en,Conway.Life.Oscillators,Conway.Life.Spaceships,Conway.Life.RLE"
+      target-modules: "Conway.Life.HashlifeCorrectness,Conway.Life.MacroCell,Conway.Life.Hashlife,Conway.Life.MacroCell_en,Conway.Life.Hashlife_en,Conway.Life.Oscillators,Conway.Life.Spaceships,Conway.Life.RLE,Conway.Life.HashlifeMemo,Conway.Life.HashlifeMarginDemo"
       # allow-axioms: the 28 native_decide axioms that HashlifeCorrectness ACTUALLY
       # depends on (empirical footprint revealed by THIS audit job's first CI run).
       # These are DISTINCT from the blocking gate's 19-name list above: that list


### PR DESCRIPTION
## Wire 2 axiom-clean Life modules into proof-integrity-audit (coverage 10 to 12)

**Grain:** MED/`ci-guard` — lane `myia-po-2026:CoursIA` — follows ai-01 CI-revelation procedure (DM msg-090059 section 2). `See #8782`.

### What

Appends `Conway.Life.HashlifeMemo` + `Conway.Life.HashlifeMarginDemo` to the advisory `proof-integrity-audit` job `target-modules` (8 to 10 modules). Per procedure: added **WITHOUT** pre-filling `allow-axioms` — CI enumerates their declarations' axioms on the PR and reveals any missing names in the log.

### theorem to module table (per ai-01 acceptance condition)

| Module | Declarations audited | native_decide (static) | Expected axioms |
|--------|---------------------|------------------------|-----------------|
| `Conway.Life.HashlifeMemo` | 16 (defs + theorems: cacheOK_empty, CacheOK.insert, hashlifeResultMemo_correct, evolveHashlifeFastMemo_eq_evolveHashlifeFast, step/evolve empty lemmas, memo aux/run defs) | **0** `by native_decide`, 0 `by decide`, 0 sorry | foundational 6 only (imports MacroCell + Hashlife + Std.HashMap, all axiom-clean — NOT HashlifeCorrectness) |
| `Conway.Life.HashlifeMarginDemo` | 1 (`demoCell : Grid := [(0,0)]`) | **0** | foundational 6 only (pure Grid literal; imports HashlifeCorrectness but the decl cannot transitively depend on its sorry-bearing theorems) |

### Expected outcome

Both modules axiom-clean -> CI audit green, `allow-axioms` pin stays **46** (`test_proof_integrity_audit_wiring.py` `assert len(names) == 46` unchanged), coverage rises **10 to 12 of 53** compiled Conway modules. If CI reveals a forbidden axiom, I recopy the names per procedure in a follow-up commit.

### Computation.lean held (convergence point)

`Conway.Life.Computation` (18 real `by native_decide`) is **NOT** in this PR. It is the convergence point of the two lanes ai-01 distinguished (msg-090059: gate-wiring #8782 vs axiom-reduction #8869). My c.843 #8869 investigation (DM b6boda) proved its 18 native_decide are **INTRINSIC** (Int-arithmetic obstruction in `gridFrame`, not DecidableEq/sortDedup). ai-01's decision on #8869 is pending — wiring Computation's 18 axioms into the allow-list unilaterally would pre-empt that decision, so it is held.

### Lean CI discipline section B

- `allow-axioms` not pre-filled (CI-revelation procedure).
- No `sorry` introduced (workflow YAML change only, no `.lean` touched).
- Proof integrity: this PR widens the audit lens; it cannot weaken it (a new forbidden axiom = red).

See #8782 (partial — 2 of 3 residual modules; Computation held for #8869 decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
