### PR TITLE
docs(hygiene,#7422): root slice — drain PARCOURS.md stale pins + wire root portals into link-check

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'CLAUDE.md'
+      - 'index.md'
       - 'PARCOURS.md'
       - '.claude/rules/**'
       - 'docs/**'

--- a/PARCOURS.md
+++ b/PARCOURS.md
@@ -3,13 +3,19 @@
 Cinq parcours de formation en intelligence artificielle, des fondamentaux aux sujets avances.
 Chaque parcours reference des notebooks tries par serie et maturite.
 
-| # | Parcours | Notebooks | Focus |
-|---|----------|-----------|-------|
-| 1 | [IA Classique](docs/curriculum/ia-classique.md) | 13 | Recherche, CSP, Sudoku |
-| 2 | [IA Symbolique](docs/curriculum/ia-symbolique.md) | 82 | Lean, Tweety, SemanticWeb, Planning |
-| 3 | [GenAI Multimodale](docs/curriculum/genai.md) | 68 | Image, Audio, Video, Texte |
-| 4 | [Trading Algorithmique](docs/curriculum/trading.md) | 56 | QuantConnect, ML, Probas |
-| 5 | [Recherche Avancee](docs/curriculum/recherche.md) | 51 | Infer.NET, Pyro, IIT, RL, GameTheory |
+| # | Parcours | Focus |
+|---|----------|-------|
+| 1 | [IA Classique](docs/curriculum/ia-classique.md) | Recherche, CSP, Sudoku |
+| 2 | [IA Symbolique](docs/curriculum/ia-symbolique.md) | Lean, Tweety, SemanticWeb, Planning |
+| 3 | [GenAI Multimodale](docs/curriculum/genai.md) | Image, Audio, Video, Texte |
+| 4 | [Trading Algorithmique](docs/curriculum/trading.md) | QuantConnect, ML, Probas |
+| 5 | [Recherche Avancee](docs/curriculum/recherche.md) | Infer.NET, Pyro, IIT, RL, GameTheory |
+
+> Les comptes de notebooks par parcours vivent dans les pages generees elles-memes
+> (regenerees chaque jour depuis le catalogue par `catalog-cron.yml`) -- ils ne sont
+> pas epingles ici, ou ils derivaient silencieusement (constat 2026-08-05 : la
+> colonne manuelle etait fausse d'un ordre de grandeur, 13/82/68/56/51 pour des
+> pages a 143/221/135/198/173).
 
 ## Legende maturite
 

--- a/index.md
+++ b/index.md
@@ -4,13 +4,16 @@ Ce document sert de **portail d'entrée éditorial** vers le contenu pédagogiqu
 
 > **Catalogue à jour** — Pour l'inventaire exhaustif et toujours synchronisé (total à jour, comptes exacts par série, statuts, maturité, owner), consultez **[`COURSE_CATALOG.generated.md`](COURSE_CATALOG.generated.md)** (en-tête « Total notebooks », régénéré automatiquement chaque jour par le workflow `catalog-cron.yml`). Le catalogue fait foi sur les chiffres et les statuts.
 
-## 🎯 Trois niveaux de lecture
+## 🎯 Quatre niveaux de lecture
 
 - **Entrée** (le présent fichier, [`index.md`](index.md)) — portail éditorial : thématiques + parcours. Maintenance manuelle, modifications rares.
 - **Vue d'ensemble** ([`README.md`](README.md)) — cartographie rapide du dépôt + parcours d'apprentissage par niveau. Maintenance manuelle, vue pédagogique consolidée.
+- **Parcours thématiques** ([`PARCOURS.md`](PARCOURS.md)) — cinq parcours de formation (IA classique, symbolique, GenAI, trading, recherche) dont les pages détaillées sont **générées** depuis le catalogue.
 - **Catalogue à jour** ([`COURSE_CATALOG.generated.md`](COURSE_CATALOG.generated.md)) — inventaire exhaustif : total à jour (en-tête « Total notebooks »), décompte par série, statuts, maturités, owners. Maintenance **automatique** (workflow `catalog-cron.yml` quotidien).
 
-Les trois niveaux sont complémentaires : l'`index.md` répond à *« quelles thématiques ? »*, le `README.md` à *« par où commencer ? »*, le catalogue à *« quel notebook précis dans quelle série ? »*.
+Les quatre niveaux sont complémentaires : l'`index.md` répond à *« quelles thématiques ? »*, le `README.md` à *« par où commencer ? »*, `PARCOURS.md` à *« quel enchaînement suivre ? »*, le catalogue à *« quel notebook précis dans quelle série ? »*.
+
+> **Cadence de maintenance** : les liens de ces fichiers racine (`index.md`, `PARCOURS.md`, `README.md`) sont vérifiés par la CI à chaque PR (`docs-link-check.yml`), les comptes et statuts vivent dans les artefacts générés (catalogue + pages de parcours, régénérés quotidiennement) — la prose manuelle ne porte ni chiffres ni listes de notebooks, ce qui est précisément ce qui lui permet de rester juste sans entretien calendaire.
 
 ## 🗂️ Thématiques pédagogiques
 
@@ -45,7 +48,7 @@ Chaque série est introduite par son thème central, ses prérequis et un pointe
 
 ## 🚀 Comment choisir son point d'entrée
 
-Pour un plan d'apprentissage guidé par niveau (débutant, intermédiaire, avancé), consultez la section **[Parcours recommandés](README.md#parcours-recommandés)** du `README.md` racine.
+Pour un plan d'apprentissage guidé par niveau (débutant, intermédiaire, avancé), consultez la section **[Parcours recommandés](README.md#parcours-recommandés)** du `README.md` racine. Pour un enchaînement thématique complet trié par maturité, consultez **[`PARCOURS.md`](PARCOURS.md)**.
 
 Pour un inventaire technique exhaustif (notebook par notebook, statuts d'exécution, owners), consultez **[`COURSE_CATALOG.generated.md`](COURSE_CATALOG.generated.md)**.
 

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Check for broken relative markdown links and orphan docs across the repository.
 
-Scans CLAUDE.md, docs/, .claude/rules/, .claude/agents/, .claude/skills/,
-and all README.md files for relative links and verifies targets exist.
+Scans CLAUDE.md, index.md, PARCOURS.md, docs/, .claude/rules/, .claude/agents/,
+.claude/skills/, and all README.md files for relative links and verifies targets
+exist.
 
 Also detects orphan .md files in docs/ (not referenced by any scanned file).
 
@@ -32,6 +33,11 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # Directories and files to scan for links
 SCAN_SCOPES = [
     "CLAUDE.md",
+    # Root entry points (#7422 root slice): index.md rotted historically precisely
+    # because no organ watched it -- the portal and the parcours front page are
+    # now link-checked like everything else.
+    "index.md",
+    "PARCOURS.md",
     "docs/",
     ".claude/rules/",
     ".claude/agents/",


### PR DESCRIPTION
Grain: MED/docs — lane myia-ai-01:CoursIA — prev: LIGHT/docs #9500

## Summary

Tranche **racine** du rollout #7422 (scope point 3) — les fichiers exacts du mandat user 2026-07-19 (« même à la racine avec le fichier `index.md` qui semble avoir été oublié depuis un petit moment »). Claim posé sur l'issue avant écriture (vérif L898 : aucune PR ouverte sur `index.md`/`README.md`/`PARCOURS.md`, aucune des 14 tranches précédentes ne couvre la racine).

### 1. `PARCOURS.md` — drainage d'une dérive d'un ordre de grandeur (C.5)

La colonne « Notebooks » épinglée à la main portait **13 / 82 / 68 / 56 / 51** ; les pages générées (`docs/curriculum/*.md`, régénérées quotidiennement depuis le catalogue) portent **143 / 221 / 135 / 198 / 173** (sommes des sections `(N notebooks)`, mesurées firsthand ce jour). Dernier commit du fichier : 2026-06-11 — la colonne mentait depuis ~8 semaines sans que rien ne le signale.

Traitement C.5 : **retirer, pas re-épingler** — la colonne saute, une note datée renvoie aux pages générées (seule source légitime des comptes).

### 2. Organe : `index.md` + `PARCOURS.md` entrent dans `check_docs_links.py`

`SCAN_SCOPES` couvrait `CLAUDE.md`, `docs/`, `.claude/*` et tous les `README.md` — mais **pas les deux portails racine**. `index.md` a pourri historiquement précisément parce qu'aucun organe ne le surveillait (sa propre ligne 3 le raconte). Le workflow `docs-link-check.yml` déclarait `PARCOURS.md` dans ses triggers **sans que le script ne le scanne** (trigger sans dents), et ne déclarait pas `index.md` du tout.

Après câblage : 4223 → **4248 liens scannés, 0 cassé** — tout lien cassé dans les portails racine rougit désormais la CI à chaque PR.

### 3. `index.md` — `PARCOURS.md` découvrable + cadence de maintenance posée

`PARCOURS.md` n'était référencé nulle part dans le portail (4e doc racine invisible). Il devient le 4e niveau de lecture, et la **cadence de maintenance demandée par le scope** est écrite là où un mainteneur la cherchera : liens = CI à chaque PR ; chiffres/statuts = artefacts générés quotidiens ; la prose manuelle ne porte ni comptes ni listes — c'est ce qui lui permet de rester juste **sans entretien calendaire**.

Vérifié inchangé et laissé tel quel : `(105 notebooks au catalogue)` du README racine (exact aujourd'hui — 105 mesurés dans `COURSE_CATALOG.generated.json` — et attribué à sa source) ; l'ancre `README.md#parcours-recommandés` (existe, L43).

## Validation

- `python scripts/check_docs_links.py --check` → `OK: No new broken links. (0 pre-existing, 4248 total)`
- `python -m pytest scripts/tests/test_check_docs_links.py -q` → **44 passed**
- Catalogue non touché (byte-identique à `main`).

See #7422 (tranche racine ; le rollout continue — `docs/notebook-metadata/` est claimé par po-2023:CoursIA-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
