### PR TITLE
docs(readme,#4959): central hub §E fichier-entier audit/reconcile

### DIFF
--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -17,7 +17,7 @@ maturity: BETA=773, ALPHA=49, DRAFT=24, TEMPLATE=4
 
 <sub>*Marqueur auto-régénéré quotidiennement par `.github/workflows/catalog-cron.yml` (file [`COURSE_CATALOG.generated.md`](../COURSE_CATALOG.generated.md) — source de vérité sur les volumes et la maturité). Toute PR qui modifierait ce bloc est refusée par `catalog-guard.yml` (catalog-pr-hygiene R1).*</sub>
 
-Dernière mise à jour : 2026-07-28
+Dernière mise à jour : 2026-08-05
 
 ## Vue d'ensemble
 
@@ -43,6 +43,8 @@ Dernière mise à jour : 2026-07-28
 
 **[IIT](IIT/README.md)** — La plus spéculative : la théorie de l'information intégrée et la mesure Phi (PyPhi) appliquées à des réseaux logiques — où l'on calcule, littéralement, des candidats quantitatifs à une mesure de la conscience. La série prolonge le Phi *statique* vers les **trajectoires** causales avec l'extension **ICT** (*Integrated Causal Trajectories*) : tri auto-organisé comme morphogenèse, émergence causale multi-échelles (Hoel, *Causal Emergence 2.0*). Le banc cross-substrat de l'ICT atteint désormais un **transformer réel** : les activations d'un LLM, lues à travers un autoencodeur parcimonieux (SAE), deviennent un quatrième substrat mesurable aux côtés du tri, de la réaction-diffusion (Gray-Scott) et de la morphodynamique stratégique (Axelrod) — et un axe *Global Workspace* (broadcast, ignition — module `ict/workspace.py`) confronte désormais empiriquement IIT et GWT sur ces mêmes traces, faisant du pont entre les deux grandes théories de la conscience une question **falsifiable** plutôt qu'un débat d'école. La série rejoint ainsi le fil rouge **causalité** du dépôt, où le même opérateur `do(·)` de Pearl s'instancie à travers quatre paradigmes — symbolique (Tweety), message passing (Infer.NET), MCMC (PyMC) et théorie de l'information (ICT).
 
+**[cross-series](cross-series/README.md)** (projets-capstones) — Annexe transversale, distincte des onze domaines ci-dessus : non pas une famille de notebooks supplémentaire, mais des **projets capstones** qui rejouent plusieurs séries sur une même application de bout en bout (ex. [`matching-cv`](cross-series/matching-cv/) : appariement CV ↔ poste par mots-clés, embeddings sémantiques et appariement stable de Gale-Shapley, mobilisant ML, GenAI et GameTheory).
+
 ### Progression pédagogique
 
 ```text
@@ -63,7 +65,7 @@ GenAI
 QuantConnect
 ├── Python/ - Cours progressifs QC-Py (fondamentaux → stratégies)
 ├── projects/ - Stratégies backtestées et ML (GARCH, Kelly, ensemble)
-├── ML-Training-Pipeline/ - Pipeline training thermal-safe + Ladder 13 arch.
+├── ML-Training-Pipeline/ - Pipeline training thermal-safe + Ladder #1409 (6 niveaux)
 └── partner-course-quant-trading/ - Cours partenaire Hands-On AI Trading
 
 SymbolicAI
@@ -98,7 +100,7 @@ Sudoku
 GameTheory
 ├── (à plat) - Nash, Minimax, Coopétition, MARL, Mechanism Design
 ├── SocialChoice/ - Arrow, Sen, Condorcet (Lean 4)
-└── *_lean/ + lean_game_defs(_ext)/ - 8 lakes (game_theory_lean [Arrow, Shapley, Stable Marriage], conway_cgt_lean, minimax_lean, repeated_games_lean, social_choice_lean, social_choice_lean_peters, lean_game_defs, lean_game_defs_ext — ces deux derniers en `lakefile.toml`, pas `.lean`)
+└── *_lean/ + lean_game_defs(_ext)/ - 8 lakes (game_theory_lean [Arrow, Shapley, Stable Marriage], conway_cgt_lean, minimax_lean, repeated_games_lean, social_choice_lean, social_choice_lean_peters [lake de référence externe], lean_game_defs, lean_game_defs_ext — ces deux derniers en `lakefile.toml`, pas `.lean`)
 
 ML
 ├── ML.Net/ - Tutoriels ML.NET C# (classification, régression, clustering)
@@ -115,6 +117,9 @@ CaseStudies
 IIT
 ├── ICT-Series/ - Integrated Causal Trajectories (4 substrats : tri, Gray-Scott, Axelrod, transformer+SAE)
 └── (à plat) - notebooks PyPhi : Intro, Advanced, Coarse-Graining Phi
+
+cross-series/
+└── (capstones) - Projets transversaux multi-séries (ex. matching-cv : ML + GenAI + GameTheory)
 ```
 
 ## Parité Python / .NET / Lean — différenciant structurant


### PR DESCRIPTION
## Summary

§E fichier-entier audit of the central hub `MyIA.AI.Notebooks/README.md` (issue #4959, **P0 central hub first — 1 PR = 1 hub** per ai-01 acceptance). Read-heavy recensement delegated to a sonnet subagent (evidence-cited); editorial judgment + fixes kept in-lane.

## Findings (3 fixed, rest verified OK)

**1. Fabricated "Ladder 13 arch." (HIGH)** — the structure tree asserted a hard architecture count found in NEITHER cited README. The hub's own note (L9) promises such counts are "vérifiés à la main dans les README de série." Firsthand verification:
- `ML-Training-Pipeline/README.md`: "L4 Decision Transformer (seul BEATS du ladder)"
- `QuantConnect/README.md`: "**5/6 ladder levels** sont NO BEATS"

→ Ladder = **6 levels** (5 NO BEATS + L4 BEATS), not 13. Fix: "Ladder 13 arch." → "Ladder #1409 (6 niveaux)".

**2. `cross-series/` invisible (HIGH)** — a real pedagogical directory on disk (own FR `README.md` + `README.en.md` Phase 0.5 + `matching-cv/` capstone project), completely absent from hub prose, structure tree, Vue d'ensemble, Parité table. Its README self-describes as "projets transversaux" — **capstone projects, NOT a notebook family** (not catalogued). Editorial call: the catalogue's 11 notebook-families is **CORRECT** (cross-series is not a family), so "onze domaines" stays aligned with the correct catalogue — cross-series is made visible as the capstone annex it is (prose paragraph + structure-tree entry), not promoted to a 12th family.

**3. GameTheory "8 lakes" wording gap (LOW)** — hub lists 8 lake dirs; `GameTheory/README.md` says "7 en propre + peters (lake externe)." They reconcile (7+1=8) but the hub didn't flag peters as external → added "[lake de référence externe]" to align hub ↔ series README.

**Verified OK (no change):** QC "18/19 + 20/22" (faithful to QC README + mapping doc), Probas "dix notebooks" (DecInfer-1..10 confirmed), IIT 4 substrats, GenAI 12 sub-series tree, all 15 family/sub-family links + 8 cited docs resolve, CATALOG-STATUS arithmetic (breakdown=850, maturity=850).

## §E fichier-entier acceptance

- **(a)** Disk count per cited subfolder verified firsthand (`ls`/`grep`).
- **(b)** disque ↔ CATALOG-STATUS ↔ prose reconciled. Catalogue (11 families, 850 total) is CORRECT — cross-series is a capstone annex, not a 12th family; no "false catalogue" to signal.
- **(c)** Structure tree, Vue d'ensemble, Parité table consistent — no stale list 100 lines down (the gap was a *missing* entry, now added).

## Validation

- Markdown-only: **+8/−3, 1 README**. No code/output/execution_count touched (C.3 — no re-exec needed).
- Catalogue **byte-identique to main** (CATALOG-STATUS block L11-16 untouched, no `COURSE_CATALOG.*` churn) — catalog-pr-hygiene R1 compliant.
- Collision-guard: 0 in-flight PRs touch the hub central README (12 open PRs checked).

See #4959

## Grain

MED/readme (#4959 central hub §E fichier-entier audit/reconcile — Ladder 6 not 13, cross-series capstone annex visible) - lane myia-po-2024:CoursIA - prev: DEEP/qc-backtest #9511
