### PR TITLE
fix(sudoku,#8056): notebook-specific cost notes S8/S14 Python + twin rebaseline (3 DRIFT audited)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Python.ipynb
@@ -1606,16 +1606,16 @@
   "cost": {
    "api_usd_est": 0.0,
    "api_provider": "none",
-   "cpu_min": 6,
+   "cpu_min": 1,
    "gpu_required": false,
    "network": false,
-   "external_account": null,
+   "external_account": "none",
    "free_alternative": null,
    "reduced_pedagogical": null,
    "reproducibility": "HIGH",
-   "metadata_written": null,
+   "metadata_written": "2026-08-05",
    "validator": "manual",
-   "notes": "Local execution via Python BDD library (dd) and human inference strategies (Naked/Hidden Singles, X-Wing, etc.). Deterministic constraint propagation and BDD/MDD operations. Sudoku puzzles loaded from local files. Reproducible given the same puzzles and library version."
+   "notes": "BDD/MDD implementes from scratch en Python pur (stdlib : dataclasses/typing — aucune dependance externe ; la lib dd n'est PAS utilisee). Operations deterministes sur graphes de decision, grilles definies dans le notebook (aucune E/S fichier), CPU pur."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
@@ -2642,16 +2642,16 @@
   "cost": {
    "api_usd_est": 0.0,
    "api_provider": "none",
-   "cpu_min": 8,
+   "cpu_min": 1,
    "gpu_required": false,
    "network": false,
-   "external_account": null,
+   "external_account": "none",
    "free_alternative": null,
    "reduced_pedagogical": null,
    "reproducibility": "HIGH",
-   "metadata_written": null,
+   "metadata_written": "2026-08-05",
    "validator": "manual",
-   "notes": "Local execution via Python BDD library (dd) and human inference strategies (Naked/Hidden Singles, X-Wing, etc.). Deterministic constraint propagation and BDD/MDD operations. Sudoku puzzles loaded from local files. Reproducible given the same puzzles and library version."
+   "notes": "Strategies humaines de deduction Sudoku en Python (Naked/Hidden Singles, Pointing Pairs, X-Wing, etc.) — numpy + stdlib, propagation deterministe, puzzles charges depuis les fichiers locaux du depot. CPU pur, aucune dependance externe."
   }
  },
  "nbformat": 4,

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-14-bdd.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-14-bdd.yaml
@@ -8,6 +8,12 @@
       by: myia-po-2023:CoursIA
       python_sha: 052095be135bdafe9306007fcd57a2b6ec69af55
       csharp_sha: 16a4db36adb2eef7e579206ddb5d5161d434e99e
+    - date: "2026-08-05"
+      by: myia-ai-01:CoursIA
+      python_sha: 876c046c2c841c51f433ecefdd5bd5c09db65598
+      csharp_sha: 64a6263dfb86db848ecc161a0423b944855be9a3
+      content_python_sha: 1bfc5722a332acb62b38fc19af0f8a32cdddb604b0867e3949607b1897c9db07
+      content_csharp_sha: 7b5aa2de9dab1095e0eaa9c161ccc48c27bd42c0090b20e25c69c6eb75251d39
   known_differences:
     - "Socle pedagogique commun : resolution du Sudoku par automates a decision binaire (BDD / MDD, Binary/Multi-valued Decision Diagrams), meme concept (codage booleen des contraintes, reduction canonique du graphe de decision, satisfaction via parcours). Le notebook Python declare explicitement etre le jumeau du C# (« Jumeau Python du notebook Sudoku-14-BDD-Csharp.ipynb »)."
     - "Divergence d'implementation : les deux cotes hand-rollent les BDD/MDD from scratch (pas de lib BDD tierce) -- le Python via dataclasses/typing, le C# via System.Collections.Generic + System.Linq. Meme reconstruction pedagogique de l'automate, idiomes de langage differents."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-8-humanstrategies.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-8-humanstrategies.yaml
@@ -8,6 +8,12 @@
       by: myia-po-2023:CoursIA
       python_sha: 7ce5db8ee3bb05faa0f72508bf26390e3ff70f87
       csharp_sha: 533b34ff9fb08626f3a41b3c8ce2acb0ffd6d239
+    - date: "2026-08-05"
+      by: myia-ai-01:CoursIA
+      python_sha: 2e2639b51ab554265538eae8d215395bc3e64f0a
+      csharp_sha: 44d99632663a0971a1d68599e6770b18208fb8c5
+      content_python_sha: 9a5f81431b6e705d090bdca3ea300badac8682763fe0587e7a32e7b39d67b120
+      content_csharp_sha: 7b206a8b33673102be8e83a36c7ec79a40ebc9d528994d45e6c94564cf9585a2
   known_differences:
     - "Socle pedagogique commun : strategies de resolution humaines (techniques d'inference -- naked/hidden singles, pointing pairs, box-line) appliquees au Sudoku, meme concept (simuler le raisonnement humain par couches d'inference successives plutot qu'un backtracking brut), meme arc pedagogique (theorie -> implementation -> benchmark)."
     - "Divergence d'implementation : le Python implemente les techniques d'inference from scratch + visualisation networkx du graphe de contraintes ; le C# implemente les memes strategies d'inference en stdlib avec un benchmark comparatif. Idiomes de visualisation differents (networkx cote Python)."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-9-graphcoloring.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-9-graphcoloring.yaml
@@ -8,6 +8,12 @@
       by: myia-po-2023:CoursIA
       python_sha: 8468688beb8513f870e571c57eded9224f2c9cb7
       csharp_sha: 1a629086fd9a29cd9fb4d705e44ba085d02a4583
+    - date: "2026-08-05"
+      by: myia-ai-01:CoursIA
+      python_sha: 8468688beb8513f870e571c57eded9224f2c9cb7
+      csharp_sha: b2a18da20d74ee1d24e4ee6d7b41e98033c74d79
+      content_python_sha: d55d8f692dc1a40ab7daab05f80a30312174bbf88e6d37d615a7ebb2570a1911
+      content_csharp_sha: ab8462506a99b8b29c5b0f596a61e6da0cf01a39519cce10799282b0efe5904a
   known_differences:
     - "Socle pedagogique commun : reformulation du Sudoku comme un probleme de coloration de graphe (une cellule = un noeud, le graphe de contraintes Sudoku, coloration propre a 9 couleurs), meme concept mathematique (graphe de conflits, coloration propre), meme cas d'application."
     - "Idiomes framework : Python = networkx (construction du graphe) + OR-Tools CP-SAT (resolution de la coloration) ; C# = construction du graphe + solveur de coloration en stdlib. Meme reformulation graph-coloring, libs de graphe differentes."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:CoursIA — prev: MED/docs #9516

## Contexte — cron twin-parity rouge 3× aujourd'hui

`twin-parity-cron.yml` échouait sur 3 paires Sudoku en DRIFT (dernier audit 2026-08-03, po-2023). Audit **blob-à-blob firsthand** de chaque dérive (`git diff <recorded_sha> <current_sha>`) :

| Paire | Cause de la dérive | Verdict parité |
|---|---|---|
| Sudoku-8 HumanStrategies | Py : cost-metadata #9227 · C# : cost-metadata #9321 | intacte |
| Sudoku-9 GraphColoring | C# : #9046 (vraie re-exec, retrait du timing `0.3449 ms` jamais mesuré) — 0 miroir Python | intacte |
| Sudoku-14 BDD | Py : cost-metadata #9227 · C# : #9413 (`~100ms` → `< 1 ms`, tables perf) — 0 miroir Python (`grep '100 *ms'` = 0) | intacte |

## Le défaut réel trouvé : la note `cost` de #9227 est un copier-coller fusionné, faux dans ses deux hôtes

#9227 a collé la **même** note dans les deux notebooks Python : « Local execution via Python BDD library (dd) and human inference strategies (Naked/Hidden Singles, X-Wing, etc.) … Sudoku puzzles loaded from local files ». Vérifié contre le code :

- **Sudoku-8-HumanStrategies-Python** : imports = `numpy` + stdlib, **aucun `import dd` ni BDD** ; stratégies humaines présentes ; puzzles bien chargés depuis fichiers. La moitié « BDD library (dd) » est fausse.
- **Sudoku-14-BDD-Python** : imports = stdlib pur (`dataclasses`/`typing`/`time`), le BDD/MDD est **implémenté from scratch** (la lib `dd` n'est PAS utilisée) ; **aucune** stratégie humaine ; **aucune** E/S fichier. Trois claims sur quatre faux.

Même classe que les findings claims↔outputs #8052, au niveau metadata.

## Fix (metadata-only, chirurgical)

Chaque note réécrite **spécifique et vraie** + violations de schéma ([cost-matrix.md](docs/notebook-metadata/cost-matrix.md)) corrigées :

- `cpu_min: 8` / `6` (minutes) contredits par les durées papermill **committées dans les mêmes fichiers** (2.8 s / 5.5 s) → `1` (best-case minute, aligné sur le jumeau C# #9321) ;
- `external_account: null` → `"none"` (le schéma exige la string) ;
- `metadata_written: null` → `"2026-08-05"` (champ obligatoire, daté de l'établissement).

**Aucune cellule source ni output touché** (exception C.2 : metadata seul, pas de ré-exécution requise). Puis rebaseline `--update --by myia-ai-01:CoursIA` des 3 paires, **en dernier** (#8957).

## Validation

- `check_twin_parity.py --check` → **156 OK / 0 DRIFT / 0 MISSING**, exit 0 (cron revient au vert)
- `check_cost_metadata.py` sur les 2 notebooks → **0 finding**
- `pytest test_twin_registry_integrity.py test_check_twin_parity.py` → **42 passed**
- JSON des 2 notebooks revalidé (`json.load` OK)

See #8056 (rollout cost-metadata — correctif de tranche), #8052 (classe claims↔metadata). Claim posé avant écriture : [commentaire #8056](https://github.com/jsboige/CoursIA/issues/8056#issuecomment-5197434687).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
