### PR TITLE
fix(audit,#8052): add rounding tolerance to §D.5 claims-vs-outputs scanner (Fix E)

### DIFF
--- a/scripts/audit/extract_claims_vs_outputs.py
+++ b/scripts/audit/extract_claims_vs_outputs.py
@@ -89,6 +89,25 @@ def _on_header_line(cell_source: str, start: int) -> bool:
     return cell_source[line_start:].lstrip().startswith('#')
 
 
+# Fix E — tolérance d'arrondi (FP-c.909, Infer-101 Probas).
+_NUM_FLOAT_RE = re.compile(r'\d+(?:\.\d+)?')
+
+
+def _to_float(s: str):
+    """Premier float d'une chaîne numérique normalisée (virgule→point déjà fait).
+    Renvoie None si aucun nombre parsable (ex. marqueur non numérique)."""
+    m = _NUM_FLOAT_RE.search(s)
+    return float(m.group()) if m else None
+
+
+def _decimal_places(s: str) -> int:
+    """Nombre de chiffres après le point décimal du premier nombre de `s` (FR déjà normalisé).
+    0 si le nombre est entier (ex. '10' → 0 → tolérance 0, match exact requis)."""
+    m = re.search(r'\d+\.(\d+)', s)
+    return len(m.group(1)) if m else 0
+
+
+
 def extract_markdown_claims(cell_source: str) -> dict:
     """Extrait les claims numériques/qualitatifs d'une cellule markdown."""
     claims = []
@@ -327,17 +346,36 @@ def audit_notebook(notebook_path: Path) -> dict:
         # milliers FR utilisent l'espace (« 8 000 »), pas la virgule — la virgule
         # est ici toujours un séparateur décimal.
         cv = claim['value'].replace(',', '.')
-        if any(cv in num.replace(',', '.') or num.replace(',', '.') in cv
-               for num in all_numeric_outputs):
+        outputs_norm = [num.replace(',', '.') for num in all_numeric_outputs]
+        if any(cv in num or num in cv for num in outputs_norm):
             matched += 1
         else:
-            unmatched += 1
-            findings.append({
-                'cell_idx': claim['cell_idx'],
-                'pattern': 'numeric_claim_not_in_outputs',
-                'claim_value': claim['value'],
-                'severity': 'MAJOR',  # MAJOR = claim exagéré possible
-            })
+            # Fix E — tolérance d'arrondi (FP-c.909, Infer-101 Probas). La prose
+            # pédagogique arrondit les outputs à moins de décimales (« 9.79 » vs
+            # output « 9.785 »). Le substring échoue sur cette troncature, d'où un
+            # FP MAJOR. Conservateur : la tolérance = demi-ulna de la PRÉCISION de
+            # la claim (±0.005 pour 2 décimales), et seulement APRÈS l'échec du
+            # substring — les matches exacts sont inchangés. Les claims entières
+            # (« 10 ») gardent une tolérance nulle (match exact requis) pour ne
+            # pas absorber des valeurs sans rapport. Un vrai écart (« 0.95 » vs
+            # « 0.85 ») reste signalé : |0.85−0.95| = 0.10 > ±0.005.
+            claim_f = _to_float(cv)
+            ndec = _decimal_places(cv)
+            tol = 0.5 * (10 ** (-ndec)) if ndec > 0 and claim_f is not None else None
+            if tol is not None and any(
+                _to_float(num) is not None
+                and abs(_to_float(num) - claim_f) <= tol
+                for num in outputs_norm
+            ):
+                matched += 1
+            else:
+                unmatched += 1
+                findings.append({
+                    'cell_idx': claim['cell_idx'],
+                    'pattern': 'numeric_claim_not_in_outputs',
+                    'claim_value': claim['value'],
+                    'severity': 'MAJOR',  # MAJOR = claim exagéré possible
+                })
 
     # Litmus 4 : SOTA tool mentionné mais pas importé (canonicalisé pour reporting)
     # On déduplique au niveau canonique AVANT la soustraction (sinon 4 tokens internes

--- a/scripts/audit/tests/test_extract_claims_vs_outputs.py
+++ b/scripts/audit/tests/test_extract_claims_vs_outputs.py
@@ -305,3 +305,135 @@ def test_fix_D_html_extraction_does_not_regress_text_plain(tmp_path):
     )
 
 
+
+# === Fix E (FP-c.909) : tolérance d'arrondi prose↔output ===
+
+
+def test_fix_E_rounded_claim_matches_full_precision_output(tmp_path):
+    """FP-c.909 : la prose pédagogique arrondit les outputs (« **9.79** ») alors
+    que la cellule affiche la pleine précision (« 9.785 »). Le substring échoue
+    sur la troncature -> faux MAJOR ``numeric_claim_not_in_outputs``. La famille
+    Probas (Infer-101) était FULLY CLEAN mais apparaissait sale à cause de ça.
+
+    Fix E : après l'échec du substring, si la claim a des décimales, on compare
+    en float à la précision de la claim (±0.005 pour 2 décimales). Ce test
+    vérifie qu'un markdown claim arrondi présent (en pleine précision) dans un
+    output n'est plus flaggé."""
+    mod = _load_extract()
+    nb = _write_nb(
+        tmp_path / "rounding.ipynb",
+        cells=[
+            _md("# Évaluation\nLa MAE est **9.79** et le biais **-45.80**."),
+            _code(
+                "metrics",
+                outputs=[
+                    {
+                        "output_type": "execute_result",
+                        "execution_count": 1,
+                        "data": {"text/plain": "MAE=9.785, bias=-45.79730358385471"},
+                        "metadata": {},
+                    }
+                ],
+            ),
+        ],
+        kernel_name="python3",
+    )
+    res = mod.audit_notebook(nb)
+    assert res["numeric_claims_unmatched"] == 0, (
+        f"rounded claims (9.79 / -45.80) must match full-precision outputs "
+        f"(9.785 / -45.797...) via Fix E tolerance; "
+        f"matched={res['numeric_claims_matched']}, findings={res['findings']}"
+    )
+
+
+def test_fix_E_fr_comma_claim_matches_dot_output(tmp_path):
+    """La claim FR à virgule (« **9,79** ») doit matcher l'output à point
+    (« 9.785 ») via la même tolérance d'arrondi (la normalisation virgule→point
+    s'applique avant le calcul float)."""
+    mod = _load_extract()
+    nb = _write_nb(
+        tmp_path / "fr-rounding.ipynb",
+        cells=[
+            _md("# Évaluation\nLa MAE est **9,79**."),
+            _code(
+                "metrics",
+                outputs=[
+                    {
+                        "output_type": "execute_result",
+                        "execution_count": 1,
+                        "data": {"text/plain": "9.785"},
+                        "metadata": {},
+                    }
+                ],
+            ),
+        ],
+        kernel_name="python3",
+    )
+    res = mod.audit_notebook(nb)
+    assert res["numeric_claims_unmatched"] == 0, (
+        f"FR comma claim (9,79) must match dot output (9.785) via Fix E; "
+        f"findings={res['findings']}"
+    )
+
+
+def test_fix_E_genuine_mismatch_still_flagged(tmp_path):
+    """Contrôle anti-complaisance : Fix E ne doit PAS absorber un VRAI écart.
+    Une claim « **0.95** » contre un output « 0.85 » = |0.85−0.95| = 0.10,
+    très supérieur au ±0.005 de tolérance (2 décimales) -> doit rester signalé
+    comme ``numeric_claim_not_in_outputs`` MAJOR. Sans ce garde-fou, Fix E
+    masquerait des claims exagérées (le vrai objectif du Litmus 1)."""
+    mod = _load_extract()
+    nb = _write_nb(
+        tmp_path / "genuine-mismatch.ipynb",
+        cells=[
+            _md("# Évaluation\nLa précision est **0.95**."),
+            _code(
+                "metrics",
+                outputs=[
+                    {
+                        "output_type": "execute_result",
+                        "execution_count": 1,
+                        "data": {"text/plain": "0.85"},
+                        "metadata": {},
+                    }
+                ],
+            ),
+        ],
+        kernel_name="python3",
+    )
+    res = mod.audit_notebook(nb)
+    assert res["numeric_claims_unmatched"] >= 1, (
+        f"genuine mismatch (0.95 vs 0.85) must stay flagged; Fix E must not "
+        f"absorb real exaggerations; findings={res['findings']}"
+    )
+
+
+def test_fix_E_integer_claim_requires_exact_match(tmp_path):
+    """Contrôle : une claim entière (« **10** ») garde une tolérance nulle
+    (ndec=0 -> tol=None -> match exact substring requis uniquement). Une claim
+    « 10 » ne doit pas absorber un output « 12 » (|12−10|=2) — et ne doit pas
+    non plus matcher « 10 » au sein d'un grand nombre par tolérance float."""
+    mod = _load_extract()
+    nb = _write_nb(
+        tmp_path / "integer.ipynb",
+        cells=[
+            _md("# Décompte\nIl y a **10** clusters."),
+            _code(
+                "count",
+                outputs=[
+                    {
+                        "output_type": "execute_result",
+                        "execution_count": 1,
+                        "data": {"text/plain": "12"},
+                        "metadata": {},
+                    }
+                ],
+            ),
+        ],
+        kernel_name="python3",
+    )
+    res = mod.audit_notebook(nb)
+    assert res["numeric_claims_unmatched"] >= 1, (
+        f"integer claim (10 vs 12) must stay flagged — Fix E tolerance is "
+        f"disabled for integer claims; findings={res['findings']}"
+    )


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA — prev: MED/docs (#9513)

See #8052. Améliore le scanner §D.5 `scripts/audit/extract_claims_vs_outputs.py` avec une tolérance d'arrondi (Fix E) qui élimine les faux `numeric_claim_not_in_outputs` MAJOR causés par l'arrondi pédagogique prose↔output.

## Le FP corrigé

Le scanner fait un **substring match exact** entre les claims numériques markdown et les outputs de code. La prose pédagogique **arrondit** les outputs (« **9.79** », « **-45.80** ») alors que la cellule affiche la pleine précision (« 9.785 », « -45.79730358385471 »). Le substring échoue sur cette troncature → faux MAJOR. Audit c.909 : la famille **Probas (Infer-101) était FULLY CLEAN** mais apparaissait sale (4 FPs) à cause de ça.

## Fix E — tolérance d'arrondi conservative

Fallback **après** l'échec du substring (les matches exacts sont inchangés) :

- Helpers `_to_float()` / `_decimal_places()` : premier float + compte des décimales (virgule FR→point normalisé en amont).
- Pour les claims **à décimales** : tolérance = demi-ulna de la précision de la claim (±0.005 pour 2 décimales). Match si `|output − claim| ≤ tol`.
- Claims **entières** (« 10 ») : tolérance nulle (match exact substring requis uniquement) → n'absorbe pas des valeurs sans rapport.
- Une **vraie exagération** (« 0.95 » vs « 0.85 » → Δ=0.10 > ±0.005) **reste signalée**.

## Tests (4 nouveaux, 13/13 passent)

| Test | Garde-fou |
|------|-----------|
| `test_fix_E_rounded_claim_matches_full_precision_output` | 9.79↔9.785 et -45.80↔-45.797… matchent (le FP c.909) |
| `test_fix_E_fr_comma_claim_matches_dot_output` | 9,79 (FR) ↔ 9.785 (dot) via normalisation |
| `test_fix_E_genuine_mismatch_still_flagged` | 0.95 vs 0.85 **reste MAJOR** (anti-complaisance) |
| `test_fix_E_integer_claim_requires_exact_match` | 10 vs 12 **reste MAJOR** (tolérance désactivée pour entiers) |

Les 9 tests existants (Fix A/B/C/D) passent sans régression.

## Validation firsthand (sur le livrable)

| Check | Result |
|-------|--------|
| `pytest scripts/audit/tests/test_extract_claims_vs_outputs.py -v` | **13 passed** (9 existing + 4 new Fix E) |
| Re-scan Infer-101 | 4 findings → **1** (résiduel `30 min` = claim durée, hors scope Fix E) |
| Re-scan Pyro_RSA_Hyperbole | résiduels = classe FP distincte (params déterministes vs valeurs mesurées) → fix futur, pas ce PR |
| Diff atomique | 2 fichiers (`extract_claims_vs_outputs.py` +56, `test_extract_claims_vs_outputs.py` +132), +179/-9 |
| L898 collision | `gh pr list --search extract_claims_vs_outputs` = 0 OPEN ; #9510 (autre PR #8052) = notebook App-7 Wordle, fichier/scope différents |

## Pourquoi MED (pas LIGHT)

Fix E ne se déclare pas sur un pitch : il fallait (1) **G.9-vérifier firsthand** que les 4 findings Infer-101 étaient tous des FPs d'arrondi (lire les cellules markdown + outputs réels), (2) **mesurer** que la tolérance élimine les FPs **sans** absorber de vraies exagérations (d'où les 2 tests anti-complaisance), (3) calibrer le demi-ulna pour qu'un écart réel (0.10) reste au-dessus du seuil. Litmus LIGHT « générable en série par scan » → **non** : le seuil de tolérance est un jugement par décimale. MED/tooling.

## Scope

1 sujet (tolérance d'arrondi du scanner §D.5), atomique. `See #8052` (l'epic reste ouverte — résiduel : la classe FP param-vs-measured de Pyro, future fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
