### PR TITLE
fix(qc,#9520): RiskParity quantbook de-pin false header + drop stale FABRICATED banners

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/RiskParity/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RiskParity/quantbook.ipynb
@@ -9,8 +9,11 @@
     "## Objectif\n",
     "Reproduire l'analyse exploratoire de `research.ipynb` avec les données natives QuantConnect.\n",
     "\n",
-    "## Performance actuelle\n",
-    "- **Sharpe**: 0.399, **CAGR**: 7.8%, **MaxDD**: 20.9%\n",
+    "## Ce notebook vs `main.py` — divergence assumée (C.4)\n",
+    "\n",
+    "Ce quantbook est une **baseline pédagogique inverse-vol simplifiée** (5 ETF, sans trend filter, sans safe haven). Ses métriques se lisent **dans les sorties des cellules de code ci-dessous** (hypothèses vol-window / rebalancement / univers) — elles ne sont **pas ré-épinglées ici** (règle #9434 : une métrique calculée se relit dans la cellule qui la produit, pas en prose d'en-tête). Ces sorties divergent **structurellement** de celles du backtest LEAN full-fidelity `main.py` (trend filter + BND safe haven), référencé dans le [README](README.md) et `research.ipynb` : l'écart, d'environ un ordre de grandeur sur le Sharpe, **est précisément le message pédagogique** du notebook — il quantifie ce que les optimisations de l'algo complet ajoutent au-dessus de la baseline naïve. Les sorties de ce notebook ne sont donc **pas** la performance de la stratégie déployée.\n",
+    "\n",
+    "## Configuration (déterministe)\n",
     "- **Stratégie**: Inverse-vol weighting (Bridgewater-style, sans levier)\n",
     "- **Univers**: SPY, EFA, GLD, DBC, TLT (5 classes d'actifs)\n",
     "- **Rebal**: Mensuel + drift trigger 5%\n",
@@ -322,14 +325,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
-    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Verdict H1\n",
     "\n",
     "60d est le standard. 20d trop reactif (bruit), 120d trop lent (retard)."
@@ -423,14 +418,6 @@
     "                              rebal_freq=freq, drift_trigger=drift)\n",
     "    results_rebal[name] = r\n",
     "    print(f\"{name:<20} {r['sharpe']:>8.3f} {r['cagr']:>7.1%} {r['max_dd']:>7.1%}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
-    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
    ]
   },
   {
@@ -535,14 +522,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
-    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Verdict H3\n",
     "\n",
     "Règle #3: TLT risk-off detruit la valeur. DBC = contango structurel.\n",
@@ -609,14 +588,6 @@
     "plt.tight_layout()\n",
     "plt.savefig('riskparity_quantbook_analysis.png', dpi=150, bbox_inches='tight')\n",
     "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
-    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Claims↔outputs honesty fix on the RiskParity quantbook — the **issue fille** required by pr-review-discipline §D.5 for #9515's `CAUSE_DOCUMENTED_ONLY` verdict. #9515 (my CoursIA-2 lane sibling) re-executed this quantbook 8/8 cells with fresh outputs, but the **markdown** still (a) pinned a "Performance actuelle" header that contradicts those fresh outputs, and (b) carried stale "FABRICATED / sortie strippee" banners contradicting the very outputs sitting next to them.

## G.1 firsthand findings (verified against committed outputs, not the issue title)

**Finding 1 — cell 0 header (the #9520 defect).** The header pinned:
> ## Performance actuelle
> - **Sharpe**: 0.399, **CAGR**: 7.8%, **MaxDD**: 20.9%

But the notebook's **own fresh outputs** (cell 9, exec_count=5, post-#9515) show the inverse-vol baseline at **Sharpe 0.037 (60d default) → 0.101 (120d best)** on the same 5-asset universe. The pinned 0.399 is ~10× the default — it is actually the full-fidelity `main.py` result (trend filter + BND safe haven), reading as if it were *this notebook's* performance. Classic claims↔outputs defect (#8052 class).

**Finding 2 — 4 stale "FABRICATED" banners (related, same defect class).** Cells 10/14/18/22 each carried:
> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud... see #6891.

Firsthand verification: each banner directly follows a code cell whose outputs are now **fresh and real**:
- cell 9 (vol-window table, ec=5, 4 stream outputs) → banner cell 10
- cell 13 (rebal table, ec=6, 7 outputs) → banner cell 14
- cell 17 (univers table, ec=7, 6 outputs) → banner cell 18
- cell 21 (PNG, ec=8, **249 KB, 1790×590, 256 byte-values = real plot, not blank**) → banner cell 22

#9515 re-executed the code cells but left these now-false banners in place — so the notebook was declaring its own genuine outputs "FABRICATED". Removing them.

## Fix (markdown-only, C.2 exception — no re-exec)

1. **Cell 0**: replaced the false "Performance actuelle" section with a **C.4 INTRINSIC divergence banner** — honestly frames this quantbook as a simplified inverse-vol baseline, points to the output cells (9/13/17) for its real metrics (not re-pinned in prose, #9434), and states the structural divergence from `main.py` (qualitatively "~un ordre de grandeur", cited to README/research.ipynb) as the pedagogical message. Deterministic config (stratégie/univers/rebal) preserved.
2. **Deleted 4 stale banners** (cells 10/14/18/22) — they contradicted the fresh outputs directly above them.

## Acceptance (#9520)

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Cell 0 free of untraced numbers, or values attributed to `main.py` | ✅ numbers removed; relationship to main.py stated qualitatively + cited to README |
| 2 | Divergence banner present (C.4 INTRINSIC) | ✅ "Ce notebook vs main.py — divergence assumée (C.4)" |
| 3 | Markdown-only diff, no re-exec | ✅ 0 code source/outputs/execution_count touched |

## Validation

- `git diff --stat`: 1 file, **+5/−34**, markdown-only (8 code cells intact: ec=1-8, outputs untouched, verified `0 +execution_count/+outputs lines` in diff).
- H.3: 0 code cell with `ec=None` + empty outputs. C.1: 0 `raise NotImplementedError`/`assert False`/`1/0`.
- JSON valid, round-trip stable (indent=1, ensure_ascii=False, list-of-lines source preserved). Non-twinned notebook (no twin-parity registry entry).
- Cell 0 source kept as list-of-lines (nbformat convention), consistent with all other cells.

Closes #9520
See #9515 (parent re-exec, `CAUSE_DOCUMENTED_ONLY` verdict now resolved in-notebook)
See #6891 (QC quantbook honesty epic — partial)
See #9434 (drainage mandate — quant metric held by computation, not prose)

## Grain

MED/value (#9520 RiskParity claims↔outputs header + stale-banner cleanup, issue fille §D.5 de #9515) - lane myia-po-2024:CoursIA - prev: MED/readme #9517
