### PR TITLE
docs(lean,#8924): Lean dev-machine disk-hygiene perennial note

### DIFF
--- a/docs/reference/lean-dev-disk-hygiene.md
+++ b/docs/reference/lean-dev-disk-hygiene.md
@@ -1,0 +1,103 @@
+# Lean dev-machine disk hygiene
+
+Structural note (perennial). Source: #8924 cluster disk-hygiene grain, measured
+2026-08-05 on `myia-po-2026`. Records the *normal* Lean disk footprint on a dev
+machine, the experiment-worktree accumulation pattern, and the safe-removal
+protocol — so agents do not (a) chase a false "disk full" premise, (b) destroy
+production build cache, or (c) remove another workspace's worktrees.
+
+## The normal footprint (not waste)
+
+A CoursIA dev machine carrying the Lean fleet legitimately holds **~34–51 GB of
+`.lake` build cache**. This is the compiled Mathlib + per-lake olean set. It is:
+
+- **Needed** for cycles — `lake build` on a warm cache is seconds/minutes; a cold
+  rebuild is hours. Deleting `.lake` to "free space" trades disk for every
+  downstream cycle.
+- **Mutualized via junctions** (#4363): a central Mathlib clone is junctioned
+  into each lake's `.lake/packages/mathlib`. The junction is **fragile** — a
+  `lake build` on the wrong tree can wipe it (lesson
+  `lake-build-shared-tree-mathlib-update-wipe.md`). Do NOT hand-edit `.lake`.
+- **Lives in the main shared tree** (`c:\dev\CoursIA\...\<lake>\.lake`), not in
+  worktrees. The worktrees themselves are small; the cache is central.
+
+If a measurement says "C: is near full", the `.lake` cache is almost certainly
+the largest line item — and it is the *wrong* target. Verify the premise before
+acting (see "Measure first" below).
+
+## Experiment-worktree accumulation
+
+The genuinely reclaimable disk is **orphaned Lean experiment worktrees**, each of
+which carries its own `.lake` build (5–13 GB). These accumulate across cycles
+(`-nw` native-decide probes, P4 quadrant experiments, knot/axiom scratch). A
+typical stale set on this machine:
+
+```
+CoursIA-c6724-c31-p4nw   13.0 GB   (Lean experiment, .lake build)
+hashlife-l2536-nw          8.2 GB   (Lean experiment, .lake build)
+CoursIA-c488-nw-lemma      7.7 GB   (Lean experiment, .lake build)
+CoursIA-c710-hashlife-s3   5.3 GB   (Lean experiment, .lake build)
+```
+
+These are safe to remove **only** when all of: branch merged-or-abandoned,
+`git status` clean, no unpushed commits, AND the worktree belongs to your
+workspace (see below).
+
+## Cross-workspace coexistence — NEVER remove another workspace's worktree
+
+`c:\dev` holds **two** CoursIA clones side by side: `CoursIA` (this workspace)
+and `CoursIA-2` (the sibling workspace). Each clone administers its own
+worktrees, but the worktree *directories* all live under `c:\dev\CoursIA-*` and
+are visually indistinguishable. **Ownership is determined by the worktree's
+`.git` pointer**, not by directory name.
+
+```bash
+cat C:/dev/<worktree>/.git
+# gitdir: C:/dev/CoursIA-2/.git/worktrees/<name>   → belongs to CoursIA-2, DO NOT TOUCH from CoursIA
+# gitdir: C:/dev/CoursIA/.git/worktrees/<name>     → belongs to CoursIA, yours to manage
+```
+
+Removing another workspace's worktree violates "Stay in YOUR workspace"
+(global CLAUDE.md) and #1502, and can destroy in-flight work the other lane has
+not pushed. **Always read the `.git` pointer before removing any worktree.**
+
+## Safe-removal protocol (4 gates, no `-f`)
+
+A worktree may be removed only after all four gates pass:
+
+1. **Ownership** — `.git` pointer resolves to YOUR clone (`CoursIA/.git`).
+2. **No uncommitted work** — `git -C <wt> status --porcelain` is empty (`dirty=0`).
+3. **No unpushed commits** — `git -C <wt> log --oneline origin/<branch>..HEAD` is
+   empty. (If `<branch>` is not on `origin`, *all* its commits are local-only;
+   `git worktree remove` still preserves the branch in `.git`, so commits are not
+   lost — but confirm you intend to keep only the branch, not the checkout.)
+4. **No force** — `git worktree remove <wt>` (never `-f`). The refusal under
+   `-f`-less removal when dirty is the guardrail (lesson
+   `worktree-triage-squash-merge-merged-pr-xref.md`).
+
+Preserving the branch (default) honors "Consolider != Archiver": the work
+survives in `.git` even after the checkout is gone. Remote branches are never
+deleted by this protocol.
+
+## Measure first (G.1)
+
+Before any recovery, measure the actual disk state — prior reports go stale fast
+(other machines recover, pruning frees space). 2026-08-05 baseline on this
+machine:
+
+```
+C:  721.9 / 952.9 GB used  (75.8%)   ← "99%" reported elsewhere was stale
+```
+
+If your measurement contradicts the premise that sent you, **report the
+measurement and follow it** rather than acting on the stale figure. The
+acceptance criterion for a disk grain is: measure-before → recover-preserving →
+measure-after → perennial-note (this file).
+
+## See also
+
+- #4363 — Mathlib mutualization (central clone + per-lake junctions)
+- #8924 — cluster disk-hygiene grain (source of this note)
+- `lake-build-shared-tree-mathlib-update-wipe.md` (memory) — junction fragility
+- `worktree-triage-squash-merge-merged-pr-xref.md` (memory) — no-`-f` guardrail
+- [procedures-recurrentes.md](procedures-recurrentes.md) — "Consolider != Archiver"


### PR DESCRIPTION
## docs(lean,#8924): Lean dev-machine disk-hygiene perennial note

**Grain:** MED/docs — lane `myia-po-2026:CoursIA` — follows ai-01 #8924 disk-hygiene directive (acceptance criterion 4: "ce qui est structurel va dans une note pérenne"). `See #8924`.

### What

Adds `docs/reference/lean-dev-disk-hygiene.md` — a structural note distilled from the #8924 cluster disk-hygiene grain (measured 2026-08-05 on `myia-po-2026`). Docs-only, +103 lines, single new file.

### Why it is perennial (not an ephemeral report)

The note captures **durable dev-machine disk facts + protocols** that every Lean-working agent on the cluster needs, not cycle-specific state:

1. **The normal footprint is not waste.** A CoursIA dev machine legitimately holds ~34–51 GB of `.lake` build cache — the compiled Mathlib + per-lake oleans, mutualized via junctions (#4363). Deleting it trades disk for hours of cold rebuild. It is the *wrong* target when a measurement says "disk near full".
2. **Experiment-worktree accumulation** — the genuinely reclaimable disk is orphaned Lean experiment worktrees (each 5–13 GB of `.lake`), which accumulate across native-decide/P4/knot cycles.
3. **Cross-workspace `.git`-pointer ownership check** — `c:\dev` holds two CoursIA clones (`CoursIA` + `CoursIA-2`) whose worktrees are visually indistinguishable. Ownership is determined by `cat <worktree>/.git`, not by directory name. Removing another workspace's worktree violates "stay in your workspace" + #1502. (This G.9 catch prevented damage during the grain: 4 large experiment worktrees turned out to belong to CoursIA-2.)
4. **4-gate safe-removal protocol** — ownership + `git status` clean + no unpushed commits + no `-f` (the refusal under force-less removal when dirty is the guardrail). Preserves the branch in `.git` ("Consolider != Archiver").

### Measurement recorded in the grain (for context)

The grain measured C: at **75.8 % (721.9/952.9 GB, 231 GB free)** — not the "99 %" that triggered the grain (stale figure). Per ai-01's "si la cause est ailleurs que dans mes suspects, dis-le et suis ta mesure", the measurement was followed. The large reclaimable chunk (~34 GB) lives in CoursIA-2's experiment worktrees — outside the reporter's workspace scope, flagged for the CoursIA-2 lane / cross-workspace action. This cycle-specific measurement is **reported on the dashboard + DM**, not in this note (harness-hygiene: ephemeral → dashboard, structural → docs).

### Lean CI discipline section B

- No `sorry`, no axiom change (docs-only, no `.lean` touched).
- Single new file, +103 lines, no catalogue/README/markers touched.

See #8924 (the disk grain). The note does not close #8924 — the grain's acceptance is the measurement + report, which is delivered separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
