### PR TITLE
docs(qc,#1621): FuturesTrend real backtest metrics (Sharpe 0.07) + fix wrong-strategy README

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/FuturesTrend/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/FuturesTrend/README.md
@@ -1,91 +1,87 @@
-# Futures Trend Following Strategy
+# FuturesTrend (Multi-Asset Trend Following v3.1)
 
-Stratégie de suivi de tendance sur les futures E-mini S&P 500 (ES).
+Stratégie de **suivi de tendance multi-actifs** sur 6 ETF diversifiés (SPY, GLD, EFA, VNQ, DBC, XLE), basée sur un breakout Donchian filtré par tendance. Malgré son nom historique, l'algorithme courant (`main.py`, classe `FuturesTrendFollowing`) trade des **ETF actions/matières premières** — non des contrats futures.
 
 ## Résumé
 
 | Paramètre | Valeur |
 |-----------|--------|
-| **Instrument** | ES (E-mini S&P 500) |
-| **Signal** | Donchian Channel Breakout |
-| **Entry** | 20-day high/low |
-| **Exit** | 10-day high/low |
-| **Position Sizing** | 1% risk per trade |
+| **Instrument** | 6 ETF (SPY, GLD, EFA, VNQ, DBC, XLE) |
+| **Univers** | Actions US, or, intl, immobilier, matières, énergie |
+| **Signal** | Breakout Donchian (20j) + filtre tendance SMA50 |
+| **Entry** | Clôture > Max(High, 20 jours) ET prix > SMA50 |
+| **Exit** | Clôture < Min(Low, 10 jours) |
+| **Position Sizing** | 33 % de poids fixe par position |
+| **Max positions** | 3 (concentrées sur les meilleures dynamiques) |
+| **Benchmark** | SPY |
 
-## Backtest Results (2019-2023)
+## Métriques de backtest (2015-2024)
 
-> Les métriques quantitatives (Total Return, CAGR, Sharpe, Max Drawdown, Win Rate) sont
-> machine-dépendantes : elles dérivent avec les données, la période et l'environnement
-> d'exécution. Elles ne sont pas attestées par un backtest figé ici. Les obtenir via
-> `lean backtest` (moteur Lean local) ou en poussant le projet sur QC Cloud. Seuls les
-> paramètres déterministes (instrument, signal, sizing) figurent dans le tableau ci-dessus.
+| Métrique | Valeur |
+|----------|--------|
+| Sharpe Ratio | 0.07 |
+| CAGR | 4.170% |
+| Max Drawdown | 15.500% |
+| Net Profit | 60.618% |
+| Total Orders | 463 |
+| Probabilistic Sharpe Ratio | 0.007% |
+
+> **Provenance** : backtest QC Cloud `b869c19d1320401e3c3a84ae7037abc4` (2026-08-05),
+> projet 28657834, IBKR margin, 2913 jours tradeables (2015-2024), $100k initial.
+> Re-exécuter via QC Cloud ou `lean backtest` pour recalculer.
+>
+> **Lecture honnête** : un Sharpe de 0,07 avec PSR 0,007 % est un **edge statistiquement
+> nul** — la stratégie ne bat pas de façon fiable le buy-and-hold de SPY. La docstring du
+> `main.py` épingle v3.1 = Sharpe 0,301 / CAGR 8,0 %, mesurés sur une fenêtre plus étroite
+> (antérieure à l'extension 2015-2024) ; sur la période complète, l'edge de trend-following
+> s'érode (0,301 → 0,07). C'est un contre-exemple pédagogique : une logique de suivi de
+> tendance séduisante en sample ne conserve pas son edge hors-échantillon. Les valeurs
+> `~0.5-0.8` auparavant inscrites en prose ici étaient **surévaluées** (de ~5-10x).
 
 ## Fichiers
 
-```
-FuturesTrend/
-├── main.py              # Donchian breakout strategy
-├── research.ipynb       # Analyse tendances, optimisation paramètres
-└── README.md            # Ce fichier
-```
+- `main.py` - Stratégie `FuturesTrendFollowing` v3.1 (breakout Donchian + filtre SMA50)
+- `research.ipynb` - Analyse des tendances, optimisation des paramètres
+- `quantbook.ipynb` - Notebook de recherche QuantConnect
 
 ## Logique
 
 ### Entry
-- **Long**: Prix clôture > Max(High, 20 jours)
-- **Short**: Prix clôture < Min(Low, 20 jours)
+- **Long** : sur les ETF en **tendance haussière** (prix > SMA50) dont la clôture casse le **Max(High, 20 jours)** (breakout Donchian).
+- Les candidats sont triés par momentum (prix / entry_high) ; seuls les **3 meilleurs** entrent (concentration sur les tendances les plus fortes).
 
 ### Exit
-- **Long exit**: Prix clôture < Min(Low, 10 jours)
-- **Short exit**: Prix clôture > Max(High, 10 jours)
+- **Long exit** : clôture < **Min(Low, 10 jours)** (canal Donchian de sortie).
 
 ### Position Sizing
-```python
-risk_amount = portfolio_value * 0.01  # 1% risque
-stop_distance = entry_price - exit_channel
-quantity = risk_amount / (stop_distance * 50)  # ES multiplier = $50
-```
+- **Poids fixe de 33 %** par position (`set_holdings(symbol, 0.33)`), jusqu'à **3 positions** simultanées (99 % max investis). Pas de sizing par risque/ATR (testé en v4.0, régressif — coupait les gagnants trop tôt).
 
 ## Configuration
 
 ```python
-self.entry_period = 20      # Donchian entry channel
-self.exit_period = 10       # Donchian exit channel
-self.risk_percent = 0.01    # 1% risque par trade
-self.es_multiplier = 50     # $50 par point ES
+self.entry_period = 20      # Canal Donchian d'entrée (high breakout)
+self.exit_period = 10       # Canal Donchian de sortie (low breakdown)
+self.trend_sma_period = 50  # Filtre de tendance long-terme
+self.weight = 0.33          # Poids fixe par position
+self.max_positions = 3      # Concentration maximale
 ```
-
-## Rollover Automatique
-
-La stratégie gère automatiquement le rollover des contrats :
-- Détecte le changement de contrat front-month
-- Ferme l'ancienne position
-- Ouvre la même position sur le nouveau contrat
-
-## Variante Multi-Futures
-
-Inclut une version diversifiée sur :
-- ES (S&P 500)
-- GC (Gold)
-- CL (Crude Oil)
-- ZB (Treasury Bonds)
 
 ## Risques
 
-- **Whipsaws**: Faux signaux en marchés range-bound
-- **Low Win Rate**: Beaucoup de petites pertes, peu de gros gains
-- **Leverage**: Futures = produit à effet de levier
-- **Rollover Costs**: Contango/Backwardation affecte les returns
+- **Whipsaws** : faux signaux en marchés range-bound (le breakout Donchian génère de nombreuses petites pertes en consolidation).
+- **Low Win Rate** : beaucoup de petites pertes, peu de grosses tendances gagnantes (profil asymétrique du trend-following).
+- **Drawdown** : 15,5 % observés sur 2015-2024 (le filtre SMA50 les atténue sans les éliminer).
+- **Regime dependency** : l'edge s'érode hors des régimes de tendance forte (cf. écart 0,301 → 0,07 entre fenêtre étroite et période complète).
 
-## Améliorations Possibles
+## Améliorations possibles
 
-- Filtre de volatilité (ATR)
-- Trailing stop
-- Pyramiding (ajouter sur confirmation)
-- Filtre de tendance long-terme
+- Filtre de volatilité (ATR) pour réduire les whipsaws.
+- Trailing stop (testé en v4.0 = régressif, à reprendre différemment).
+- Pyramiding (ajouter sur confirmation de tendance).
+- Dynamisation de l'univers (rotation sectorielle).
 
 ## Références
 
-- Richard Dennis: "Turtle Trading Rules"
-- Notebook: QC-Py-07-Futures-Forex.ipynb
-- CME Group: ES Futures Specifications
+- Curtis Faith (2007), *Way of the Turtle* — règles de trend-following Donchian.
+- Moskowitz, Ooi & Pedersen (2012), *Time Series Momentum* — trend-following multi-actifs.
+- Analyse détaillée : `research.ipynb`.


### PR DESCRIPTION
## Summary

Ran the **real backtest** of FuturesTrend via QC Cloud MCP (projectId 28657834) and replaced the #9508 drained pointer with **real, provenance-attested metrics**. **Plus a major G.1 finding**: the entire README described the *wrong strategy* (ES futures), which I corrected to match the real `main.py` (6-ETF trend follower) so the real metrics are attached to an honest description.

## Backtest result (2026-08-05, 2015-2024, IBKR margin, 463 orders, 2913 tradeable days)

| Metric | Value |
|--------|-------|
| Sharpe Ratio | **0.07** |
| CAGR | 4.170% |
| Max Drawdown | 15.500% |
| Net Profit | 60.618% |
| Probabilistic Sharpe Ratio | 0.007% |

Backtest-id: `b869c19d1320401e3c3a84ae7037abc4`.

## G.9 honesty finding — the README described the wrong instrument class

Firsthand (`main.py` verified): the strategy trades **6 ETFs (SPY, GLD, EFA, VNQ, DBC, XLE)** with a Donchian breakout filtered by SMA50, fixed 33% weight, max 3 positions. The README however described:
- "Futures E-mini S&P 500 (ES)" — **wrong, it's ETFs**
- "1% risk per trade", "ES multiplier = $50" — **these params don't exist in main.py**
- "Rollover Automatique" (futures contract rollover) — **no futures, no rollover in main.py**
- "Multi-Futures: ES, GC, CL, ZB" — **wrong universe** (real: SPY/GLD/EFA/VNQ/DBC/XLE)

Attaching real ETF-backtest metrics to an "ES futures" README would still mislead → I rewrote the README to match the real strategy (Résumé, Logique, Configuration all grounded in `main.py`) and **removed the fabricated Rollover/Multi-Futures sections** (they describe a strategy that doesn't exist in the code). `grep` confirms 0 stale ES-futures fabrications remain.

## G.9 honesty finding — blind prose overstated by ~5-10x

- The drained README (#9508) carried blind `Sharpe ~0.5-0.8` ranges.
- The `main.py` docstring pins v3.1 = Sharpe **0.301** (developer's grid-search, on a narrower window).
- The **real** 2015-2024 backtest = **Sharpe 0.07** (PSR 0.007% = zero statistical edge).

The honest reading: the v3.1=0.301 was measured on a shorter period; over the full 2015-2024 window the trend-following edge erodes (0.301→0.07). The blind ~0.5-0.8 overstated by ~5-10x. README now states real metrics with a provenance block (backtest-id + date + params) and frames this honestly as a pedagogical counter-example (in-sample trend logic doesn't survive out-of-sample). This is exactly the defect #9434 targets (blind prose misleads) and advances #1621 (QC reliability).

## §E fichier-entier

This is a coherent full-file rewrite (+57/−61), not a cosmetic intro fix leaving staleness below. Audited the whole README against `main.py`; every section (Résumé, Logique, Configuration, Risques, Améliorations, Références) now consistent with the real 6-ETF strategy. No CATALOG-STATUS marker in this file; catalogue byte-identique to main; no code/output/execution_count touched.

## Validation

- Real backtest via MCP qc-mcp-lite (compile BuildSuccess 0 errors → backtest Completed). Metrics read from `statistics`. `totalOrders: 463` + $60.6k net profit = genuine execution.
- Markdown-only (+57/−61, 1 README). No code touched (`main.py`/`research.ipynb`/`quantbook.ipynb` unchanged).
- 0 stale ES-futures fabrications remain (grep-verified).

## Grain

DEEP/qc-backtest (#1621 FuturesTrend real metrics via QC Cloud MCP — Sharpe 0.07 vs blind ~0.5-0.8 + correct stale ES-futures README to real 6-ETF strategy) - lane myia-po-2024:CoursIA - prev: MED/value #9523

See #1621
See #9434
