### PR TITLE
fix(lean,#8869): rewrite ceilLog2 via Nat.log 2 — root cause of Computation native_decide

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
@@ -160,28 +160,35 @@ La construction est directe mais un peu fastidieuse :
 
 namespace MacroCell
 
-/-- Plus petit `n` tel que `2 ^ n >= k`. -/
+/-- Plus petit `n` tel que `2 ^ n >= k`.
+
+    Implementation note (#8869, c.847) : la recursion precedente
+    `| k + 2 => 1 + ceilLog2 ((k + 2 + 1) / 2)` etait **WellFounded** (l'argument
+    `(k+2+1)/2` n'est pas structurellement plus petit), donc **opaque au reducteur
+    du noyau** — `decide` ne pouvait pas l'evaluer, bloquant `gridFrame lvl` puis
+    toute la chaine `buildFromGrid`/`toGrid`/`evolveHashlife` (les 14 theoremes de
+    coherence de `Computation.lean` etaient `native_decide` par symptome, pas par
+    necessite intrinseque). Reformulee via `Nat.log 2` (recursion structurelle de
+    Mathlib, noyau-reductible) : `ceilLog2 k = if k ≤ 1 then 0 else Nat.log 2 (k-1) + 1`.
+    Meme fonction (valeurs invariantes, cf `ceilLog2_spec`), mais desormais
+    decidable. Diagnostic firsthand : `ceilLog2 6 = 3` passe sous `decide` apres
+    rewrite (echouait avant, meme avec `maxRecDepth 1000000`, meme sur 1 pas). -/
 def ceilLog2 (k : Nat) : Nat :=
-  match k with
-  | 0     => 0
-  | 1     => 0
-  | k + 2 => 1 + ceilLog2 ((k + 2 + 1) / 2)
+  if k ≤ 1 then 0 else Nat.log 2 (k - 1) + 1
 
 /-- `ceilLog2 k` est assez grand pour que `2 ^ ceilLog2 k >= k`. C'est le
     coeur arithmetique du lemme de containment de `gridFrame`. -/
 theorem ceilLog2_spec (k : Nat) : 2 ^ ceilLog2 k >= k := by
-  induction k using Nat.strong_induction_on with
-  | _ k ih =>
-    match k with
-    | 0 => simp [ceilLog2]
-    | 1 => simp [ceilLog2]
-    | m + 2 =>
-      simp only [ceilLog2]
-      have h : 2 ^ ceilLog2 ((m + 2 + 1) / 2) >= (m + 2 + 1) / 2 :=
-        ih ((m + 2 + 1) / 2) (by omega)
-      have h2 : 2 * 2 ^ ceilLog2 ((m + 2 + 1) / 2) >= m + 2 := by omega
-      rw [Nat.pow_add, Nat.pow_one]
-      exact h2
+  by_cases hk : k ≤ 1
+  · -- k = 0 ou 1 : ceilLog2 k = 0, et 2^0 = 1 ≥ k
+    simp only [ceilLog2, hk, reduceIte]
+    omega
+  · -- k ≥ 2 : ceilLog2 k = Nat.log 2 (k-1) + 1, et k ≤ 2^((k-1).log+1) par la
+    -- borne superieure de Nat.log (Mathlib : n < b^(log b n + 1)).
+    simp only [ceilLog2, hk, reduceIte]
+    have h := Nat.lt_pow_succ_log_self Nat.one_lt_two (k - 1)
+    rw [Nat.succ_eq_add_one] at h
+    omega
 
 /-- Construit une `MacroCell` de niveau `n` couvrant le carre
     `[r0, r0 + 2^n) x [c0, c0 + 2^n)`, avec les cellules vivantes donnees par


### PR DESCRIPTION
## fix(lean,#8869): rewrite ceilLog2 via Nat.log 2 — root cause of Computation.lean native_decide

**Grain:** MED/lean — lane `myia-po-2026:CoursIA` — executes ai-01's #8869 bounded probe (msg-165936). `See #8869`.

### Root cause (empirical, firsthand, sub-expression bisect)

The 14-15 `native_decide` theorems in `Computation.lean` were NOT intrinsically native. The single stuck point is **`MacroCell.ceilLog2`**, which recursed on `(k+2+1)/2` — **not structurally smaller** → Lean compiles **WellFounded recursion** → **opaque to the kernel reducer** → `decide` cannot evaluate it → `gridFrame lvl` stuck → `buildFromGrid`/`toGrid`/`evolveHashlife` all stuck downstream.

Sub-expression bisect (kernel `decide`, worktree `CoursIA-8869`, Mathlib rc1 `d568c8c0` warm):
- `gridRowMin/Max block` (Int foldl min/max): **reduce** ✓
- gridFrame's Int arithmetic — `rMin-2` (Int.sub), `rMax-rMin+5` (Int.add), `.toNat`: **all reduce** ✓ (my earlier c.843 "Int obstruction" was wrong — retracted)
- `MacroCell.ceilLog2 6 = 3`: **FAILS** — even `ceilLog2 2 = 1` (one recursion step), even with `maxRecDepth 1000000`. WF-opacity, not depth.
- `Nat.log 2` (Mathlib, structural): **reduces** ✓

### The fix (body-only, same signature, same values)

```lean
def ceilLog2 (k : Nat) : Nat :=
  if k ≤ 1 then 0 else Nat.log 2 (k - 1) + 1
```

Same function (values invariant for all k: 0,1→0; 2→1; 3,4→2; 5,6,7,8→3; 9..16→4 …), so `ceilLog2_spec` (statement unchanged: `2 ^ ceilLog2 k ≥ k`) is re-proved via Mathlib's `Nat.lt_pow_succ_log_self` + `omega`. **No `sorry`, no axiom, no signature change.** Downstream `ceilLog2_ge_three_of_ge_five` and the HashlifeCorrectness proofs use `ceilLog2_spec` as a black box — unaffected (lake build SUCCESS on MacroCell + Computation + HashlifeCorrectness verified).

### Measurement (ai-01's acceptance: ≥7/15 = real path)

Re-stated all 15 `native_decide` theorems with `by decide` in a probe module: **15/15 PASS** (`lake build Conway.Life.Probe8869Measure` Build completed successfully, 0 decide failures). The ceilLog2 rewrite flips **every** theorem — decisively validates the path (≥7 criterion met at 100 %).

### Scope of THIS PR (root fix only)

This PR lands the **MacroCell.lean `ceilLog2` rewrite only** (+24/−17, body + spec re-proof). It does NOT flip the `Computation.lean` theorems (`native_decide` → `decide`) nor touch the proof-integrity gate — those are a **follow-up PR** because:
1. **Build perf**: kernel `decide` is slower than `native_decide`; the probe module built in ~123 s. Flipping the 15 theorems needs a build-time evaluation to avoid CI timeouts (the original `native_decide` choice may have been for perf, now that the obstruction is lifted both options are viable — a deliberate choice, not a drive-by).
2. **Gate impact**: flipping removes 15 `._native.native_decide.ax_1_1` from the audit allow-list + the `len(names)==46` pin — ai-01's CI-revelation procedure + gate turf.

This PR is safe standalone: the rewrite improves `ceilLog2` reducibility with no observable change to existing proofs (they still use `native_decide`, still pass). It **enables** the follow-up.

### Overturns the gridFrame Nat-indexing prescription

ai-01's msg-165936 prescribed Nat-indexing `gridFrame`. The probe proves the obstruction is **one layer deeper** (`ceilLog2`), and gridFrame's Int arithmetic already reduces. The fix is a 1-line body rewrite, not a layer-wide refactor. Reported to ai-01 (DM msg-...222331); this PR is the verified root fix the measurement points to.

### Lean CI discipline §B

- `grep -c sorry` unchanged (0 in MacroCell; the 9 in HashlifeCorrectness untouched).
- `lake build Conway.Life.MacroCell` SUCCESS, `Conway.Life.Computation` SUCCESS, `Conway.Life.HashlifeCorrectness` SUCCESS (downstream).
- No axiom added (one removed-from-TCB *opportunity* — the 15 native_decide axioms become *removable* in the follow-up, not here).

See #8869 (partial — root fix; theorem-flip + gate cleanup follow-up pending ai-01 sanction + perf eval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
