### PR TITLE
feat(lean,#8869): flip Computation native_decide -> kernel decide + rewrite false docstrings

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Computation.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Computation.lean
@@ -10,7 +10,7 @@ gliders multi-periodes). Ce module fait partie de l'Epic #1647
 (Life-as-Computation).
 
 Choix de conception :
-- Tous les predicats renvoient `Bool` pour la compatibilite avec `native_decide`.
+- Tous les predicats renvoient `Bool` pour la decidabilite par calcul (`decide`).
 - Le `eater1` (fishhook / hamecon) est le primitif d'absorption de signal le
   plus simple, la premiere brique des portes logiques spartiates.
 - Les theoremes de coherence `evolveHashlife n g = evolve n g` verifient
@@ -48,77 +48,45 @@ Pour les entrees de niveau 2, `evolveHashlife` passe par `step4x4` (le cas
 de base du quadtree). Pour les entrees plus grandes, il retombe sur `step`.
 Dans les deux cas, le resultat doit coincider avec `evolve n g`.
 
-### Pourquoi `native_decide` (et non `decide`) — #8749, refine #8869 c.8126
+### Decidabilite par calcul (`decide`, zero axiome) — #8869 resolu par #9536
 
-Ces six theoremes d'equivalence utilisent `native_decide` par **necessite
-structurelle**, non par commodite. Le noyau Lean ne peut pas les prouver par
-`decide` : avec `set_option maxRecDepth 100000`, chacun echoue par
-`reduction got stuck at the Decidable instance` (compilation en erreur,
-en quelques secondes) — un echec *definitif*, pas un depassement de temps
-que davantage de profondeur de reduction leverait.
-
-**Locus precis de l'obstruction (sondage c.8126, 2026-08-05, PR ouverte)**.
-Une investigation en trois sondes a localise la cause **non pas** dans la
-liste `Int × Int` (sortDedup, post-#8895) mais dans la **couche
-`MacroCell`** :
-
-| Sonde | Enonce | decide ? |
-|-------|--------|----------|
-| `step block = block` | list-level path | **OUI** (PASS, coherent avec `block_still_life` L231) |
-| `mc.toGrid (0,0) = block` | MacroCell → Grid | **NON** (stuck sur `instDecidableEqList` apres unfold) |
-| `hashlifeStep1 mc = mc` | MacroCell quadtree | **NON** (stuck sur `instDecidableEqMacroCell.decEq`, recursion 4-quadrants `node nw ne sw se`) |
-
-L'erreur littérale de la sonde `mc.toGrid (0,0) = block` :
-
-```
-instDecidableEqList (MacroCell.toGrid (0, 0) (gridToMacroCellWithOffset block).2) block
-did not reduce to `isTrue` or `isFalse`.
-After unfolding the instance `instDecidableEqList`, reduction got stuck at
-the `Decidable` instance
-  match MacroCell.toGrid (0, 0) (gridToMacroCellWithOffset block).2 with
-  | [] => ... | a :: as => match decEq a b with ...
-```
-
-Le reductor unfold `instDecidableEqList` jusqu'au `match` sur la liste,
-mais **`MacroCell.toGrid` est une definition recursive** (`sortDedup` ∘
-`toCellsAux`, lui-meme recursive sur les 4 quadrants) que le kernel ne
-deplie **pas** en squelette littéral. C'est une **limitation structurelle
-du reductor**, indépendante de la profondeur de recursion
-(`maxRecDepth 1000000` deja applique). La voie `Grid = Nat × Nat`
-(autrefois envisagee comme echappatoire a `Int` non-reductible) **ne
-resoudrait pas** ce goulot d'etranglement : l'opacite est dans la couche
-`MacroCell`, pas dans le type des coordonnees.
-
-Les enonces sont VRAIS (temoins `#eval` natifs en section 5) : c'est
-exactement le role de `native_decide` — evaluer le calcul en code natif et
-ajouter le resultat a la base de confiance plutot que de le reverifier dans
-le noyau. Verifie par-theoreme pour les six declarations de cette section
-(sondage #8749, 2026-07-29, puis affine c.8126, 2026-08-05).
+Ces theoremes se prouvent par `decide` dans le noyau (zero axiome ajoute).
+Le diagnostic anterieur (c.8126, #8749) concluait a une opacite **intrinseque**
+de la couche `MacroCell` (et a la non-reductibilite de l'arithmetique `Int`) ;
+il a ete **refute** par bisect de sous-expressions (c.847, 2026-08-05). Le seul
+point bloquant etait `MacroCell.ceilLog2` (recursion `WellFounded` sur
+`(k+2+1)/2`, non structurellement plus petit → opaque au reducteur du noyau),
+un niveau plus profond que la couche `MacroCell` / `Int` incriminee. La PR #9536
+(mergee) reecrit `ceilLog2 k = if k ≤ 1 then 0 else Nat.log 2 (k-1) + 1`
+(recursion structurelle kernel-reductible de Mathlib, memes valeurs, spec
+re-prouvee via `Nat.lt_pow_succ_log_self` + `omega`). Apres ce fix, ces
+theoremes passent `decide` (noyau, zero axiome), supprimant les axiomes
+`native_decide` de la base de confiance. Temoins `#eval` natifs en section 5.
 -/
 
 /-- Hashlife et reference sont d'accord sur `block` apres 1 generation.
-    `native_decide` requis : non-reductible sous `decide` (voir Section 1, #8749 / refine #8869 c.8126). -/
-theorem hashlife_block_1 : evolveHashlife 1 block = evolve 1 block := by native_decide
+    (`decide` dans le noyau, zero axiome — reductible apres le fix `ceilLog2` #9536, #8869.) -/
+theorem hashlife_block_1 : evolveHashlife 1 block = evolve 1 block := by decide
 
 /-- Hashlife et reference sont d'accord sur `block` apres 4 generations.
-    `native_decide` requis : non-reductible sous `decide` (voir Section 1, #8749 / refine #8869 c.8126). -/
-theorem hashlife_block_4 : evolveHashlife 4 block = evolve 4 block := by native_decide
+    (`decide` dans le noyau, zero axiome — reductible apres le fix `ceilLog2` #9536, #8869.) -/
+theorem hashlife_block_4 : evolveHashlife 4 block = evolve 4 block := by decide
 
 /-- Hashlife et reference sont d'accord sur `blinker_h` apres 2 generations.
-    `native_decide` requis : non-reductible sous `decide` (voir Section 1, #8749 / refine #8869 c.8126). -/
-theorem hashlife_blinker_2 : evolveHashlife 2 blinker_h = evolve 2 blinker_h := by native_decide
+    (`decide` dans le noyau, zero axiome — reductible apres le fix `ceilLog2` #9536, #8869.) -/
+theorem hashlife_blinker_2 : evolveHashlife 2 blinker_h = evolve 2 blinker_h := by decide
 
 /-- Hashlife et reference sont d'accord sur `glider` apres 4 generations.
-    `native_decide` requis : non-reductible sous `decide` (voir Section 1, #8749 / refine #8869 c.8126). -/
-theorem hashlife_glider_4 : evolveHashlife 4 glider = evolve 4 glider := by native_decide
+    (`decide` dans le noyau, zero axiome — reductible apres le fix `ceilLog2` #9536, #8869.) -/
+theorem hashlife_glider_4 : evolveHashlife 4 glider = evolve 4 glider := by decide
 
 /-- Hashlife et reference sont d'accord sur `beacon` apres 2 generations.
-    `native_decide` requis : non-reductible sous `decide` (voir Section 1, #8749 / refine #8869 c.8126). -/
-theorem hashlife_beacon_2 : evolveHashlife 2 beacon = evolve 2 beacon := by native_decide
+    (`decide` dans le noyau, zero axiome — reductible apres le fix `ceilLog2` #9536, #8869.) -/
+theorem hashlife_beacon_2 : evolveHashlife 2 beacon = evolve 2 beacon := by decide
 
 /-- Hashlife et reference sont d'accord sur `toad` apres 2 generations.
-    `native_decide` requis : non-reductible sous `decide` (voir Section 1, #8749 / refine #8869 c.8126). -/
-theorem hashlife_toad_2 : evolveHashlife 2 toad = evolve 2 toad := by native_decide
+    (`decide` dans le noyau, zero axiome — reductible apres le fix `ceilLog2` #9536, #8869.) -/
+theorem hashlife_toad_2 : evolveHashlife 2 toad = evolve 2 toad := by decide
 
 /-! ## Section 2 : Eater 1 (Fishhook) — le puits de calcul le plus simple
 
@@ -152,9 +120,13 @@ purement calculatoire dans le noyau. (Le sondage #8749 du 2026-07-29, anterieur 
 #8895, avait correctement constate l'obstruction sous `mergeSort` ; celle-ci est
 levee depuis.)
 
-Contraste avec les equivalences `evolveHashlife n g = evolve n g` de la Section 1 :
-celles-ci exercent la machinerie quadtree complete sur `Grid = List (Int × Int)` et
-restent non-reductibles sous `decide` (`native_decide` requis, voir Section 1).
+Comme les equivalences `evolveHashlife n g = evolve n g` de la Section 1, le
+present theoreme se prouve par `decide` dans le noyau (zero axiome). Historiquement,
+`eater1_still_life` est devenu `decide`-reductible des le swap
+`mergeSort -> insertionSort` (#8895), tandis que les equivalences de la Section 1
+ont necessite en sus la reecriture de `ceilLog2` via `Nat.log 2` (#9536) : tant que
+celle-ci etait une recursion `WellFounded` opaque au reducteur, elles restaient
+`native_decide`. Le contraste historique pre-#9536 est documente en Section 1.
 -/
 
 /-- L'**eater 1** (fishhook), une vie stable de 7 cellules. -/
@@ -183,30 +155,33 @@ des fils de gliders.
 On verifie pour k = 1 (deja dans Life.lean), k = 2 et k = 3.
 Le cas k = 2 (8 generations) se verifie aussi via `evolveHashlife`.
 
-### Pourquoi `native_decide` — #8749, refine #8869 c.8126
+### Decidabilite par calcul (`decide`, zero axiome) — #8869 resolu par #9536
 
-Ces trois theoremes (periodicite du glider + coherence hashlife sur 8
-generations) ne se reduisent pas sous `decide` (`maxRecDepth 100000` :
-chacun stuck a l'instance `Decidable`, EXIT≠0, verifie par-theoreme).
-Cause structurelle localisee en c.8126 (2026-08-05) : la couche
-`MacroCell` quadtree (`toGrid` recursive + `instDecidableEqMacroCell.decEq`
-sur 4-quadrants) est opaque au reductor, PAS la liste `Int × Int` (voir
-Section 1 docstring pour le detail des 3 sondes `step` / `toGrid` /
-`hashlifeStep1`). Enonces VRAIS (`#eval` section 5) ; `native_decide`
-requis.
+Ces theoremes se prouvent par `decide` dans le noyau (zero axiome ajoute).
+Le diagnostic anterieur (c.8126, #8749) concluait a une opacite **intrinseque**
+de la couche `MacroCell` (et a la non-reductibilite de l'arithmetique `Int`) ;
+il a ete **refute** par bisect de sous-expressions (c.847, 2026-08-05). Le seul
+point bloquant etait `MacroCell.ceilLog2` (recursion `WellFounded` sur
+`(k+2+1)/2`, non structurellement plus petit → opaque au reducteur du noyau),
+un niveau plus profond que la couche `MacroCell` / `Int` incriminee. La PR #9536
+(mergee) reecrit `ceilLog2 k = if k ≤ 1 then 0 else Nat.log 2 (k-1) + 1`
+(recursion structurelle kernel-reductible de Mathlib, memes valeurs, spec
+re-prouvee via `Nat.lt_pow_succ_log_self` + `omega`). Apres ce fix, ces
+theoremes passent `decide` (noyau, zero axiome), supprimant les axiomes
+`native_decide` de la base de confiance. Temoins `#eval` natifs en section 5.
 -/
 
 /-- Apres 8 generations (2 periodes), le glider s'est deplace de (2, -2).
-    `native_decide` requis : non-reductible sous `decide` (voir Section 3, #8749 / refine #8869 c.8126). -/
-theorem glider_2periods : evolve 8 glider = shift (2, -2) glider := by native_decide
+    (`decide` dans le noyau, zero axiome — reductible apres le fix `ceilLog2` #9536, #8869.) -/
+theorem glider_2periods : evolve 8 glider = shift (2, -2) glider := by decide
 
 /-- Apres 12 generations (3 periodes), le glider s'est deplace de (3, -3).
-    `native_decide` requis : non-reductible sous `decide` (voir Section 3, #8749 / refine #8869 c.8126). -/
-theorem glider_3periods : evolve 12 glider = shift (3, -3) glider := by native_decide
+    (`decide` dans le noyau, zero axiome — reductible apres le fix `ceilLog2` #9536, #8869.) -/
+theorem glider_3periods : evolve 12 glider = shift (3, -3) glider := by decide
 
 /-- Hashlife et reference sont d'accord sur le glider apres 8 generations (2 periodes).
-    `native_decide` requis : non-reductible sous `decide` (voir Section 3, #8749 / refine #8869 c.8126). -/
-theorem hashlife_glider_8 : evolveHashlife 8 glider = evolve 8 glider := by native_decide
+    (`decide` dans le noyau, zero axiome — reductible apres le fix `ceilLog2` #9536, #8869.) -/
+theorem hashlife_glider_8 : evolveHashlife 8 glider = evolve 8 glider := by decide
 
 /-! ## Section 4 : verification de l'aller-retour MacroCell
 
@@ -215,35 +190,39 @@ preserve les cellules vivantes pour les patterns canoniques. Cela verifie
 l'encodage/decodage du quadtree a la couche MacroCell (independamment de
 step/evolve).
 
-### Pourquoi `native_decide` — #8749, refine #8869 c.8126
+### Decidabilite par calcul (`decide`, zero axiome) — #8869 resolu par #9536
 
-Ces trois theoremes d'aller-retour ne se reduisent pas sous `decide`
-(`maxRecDepth 100000` : chacun stuck a l'instance `Decidable`, EXIT≠0,
-verifie par-theoreme). Cause structurelle localisee en c.8126 (2026-08-05) :
-`mc.toGrid` (recursive MacroCell → Grid) est opaque au reductor, comme la
-sonde `probe_macrocell_togrid_block_unfolds` l'a verifie (sortie
-verbatim dans Section 1 docstring). L'egalite `mc.toGrid off == block`
-mobilise la meme instance `instDecidableEqList` non-reductible. Enonces
-VRAIS (`#eval` section 5) ; `native_decide` requis.
+Ces theoremes se prouvent par `decide` dans le noyau (zero axiome ajoute).
+Le diagnostic anterieur (c.8126, #8749) concluait a une opacite **intrinseque**
+de la couche `MacroCell` (et a la non-reductibilite de l'arithmetique `Int`) ;
+il a ete **refute** par bisect de sous-expressions (c.847, 2026-08-05). Le seul
+point bloquant etait `MacroCell.ceilLog2` (recursion `WellFounded` sur
+`(k+2+1)/2`, non structurellement plus petit → opaque au reducteur du noyau),
+un niveau plus profond que la couche `MacroCell` / `Int` incriminee. La PR #9536
+(mergee) reecrit `ceilLog2 k = if k ≤ 1 then 0 else Nat.log 2 (k-1) + 1`
+(recursion structurelle kernel-reductible de Mathlib, memes valeurs, spec
+re-prouvee via `Nat.lt_pow_succ_log_self` + `omega`). Apres ce fix, ces
+theoremes passent `decide` (noyau, zero axiome), supprimant les axiomes
+`native_decide` de la base de confiance. Temoins `#eval` natifs en section 5.
 -/
 
-/-- Le block survive a l'aller-retour MacroCell. `native_decide` requis :
-    non-reductible sous `decide` (voir Section 4, #8749 / refine #8869 c.8126). -/
+/-- Le block survive a l'aller-retour MacroCell. `decide` dans le noyau, zero axiome
+    — reductible apres le fix `ceilLog2` (#9536, #8869). -/
 theorem block_macrocell_roundtrip :
     (let (off, mc) := gridToMacroCellWithOffset block
-     mc.toGrid off == block) = true := by native_decide
+     mc.toGrid off == block) = true := by decide
 
-/-- Le glider survive a l'aller-retour MacroCell. `native_decide` requis :
-    non-reductible sous `decide` (voir Section 4, #8749 / refine #8869 c.8126). -/
+/-- Le glider survive a l'aller-retour MacroCell. `decide` dans le noyau, zero axiome
+    — reductible apres le fix `ceilLog2` (#9536, #8869). -/
 theorem glider_macrocell_roundtrip :
     (let (off, mc) := gridToMacroCellWithOffset glider
-     mc.toGrid off == glider) = true := by native_decide
+     mc.toGrid off == glider) = true := by decide
 
-/-- L'eater 1 survive a l'aller-retour MacroCell. `native_decide` requis :
-    non-reductible sous `decide` (voir Section 4, #8749 / refine #8869 c.8126). -/
+/-- L'eater 1 survive a l'aller-retour MacroCell. `decide` dans le noyau, zero axiome
+    — reductible apres le fix `ceilLog2` (#9536, #8869). -/
 theorem eater1_macrocell_roundtrip :
     (let (off, mc) := gridToMacroCellWithOffset eater1
-     mc.toGrid off == eater1) = true := by native_decide
+     mc.toGrid off == eater1) = true := by decide
 
 /-! ## Section 5 : temoins diagnostiques #eval
 
@@ -278,43 +257,46 @@ de `2^level` generations en une seule etape MacroCell. Ces theoremes
 verifient la correction du chemin rapide face a la reference `evolve` pour
 les patterns canoniques.
 
-### Pourquoi `native_decide` — #8749, refine #8869 c.8126
+### Decidabilite par calcul (`decide`, zero axiome) — #8869 resolu par #9536
 
-Ces six theoremes (chemin rapide `evolveHashlifeFast` vs reference) ne se
-reduisent pas sous `decide` (`maxRecDepth 100000` : chacun stuck aux
-instances `instDecidableEqBool`/`instDecidableEqList`/`instDecidableEqNat`/
-`Nat.decLe`, EXIT≠0, verifie par-theoreme). Cause structurelle localisee
-en c.8126 (2026-08-05) : la couche `MacroCell` quadtree est opaque au
-reductor, comme les sondes l'ont verifie (voir Section 1 docstring) ; le
-chemin rapide mobilise la meme arithmetique `MacroCell` recursive que
-`evolveHashlife`. Enonces VRAIS (`#eval` section 5) ; `native_decide`
-requis.
+Ces theoremes se prouvent par `decide` dans le noyau (zero axiome ajoute).
+Le diagnostic anterieur (c.8126, #8749) concluait a une opacite **intrinseque**
+de la couche `MacroCell` (et a la non-reductibilite de l'arithmetique `Int`) ;
+il a ete **refute** par bisect de sous-expressions (c.847, 2026-08-05). Le seul
+point bloquant etait `MacroCell.ceilLog2` (recursion `WellFounded` sur
+`(k+2+1)/2`, non structurellement plus petit → opaque au reducteur du noyau),
+un niveau plus profond que la couche `MacroCell` / `Int` incriminee. La PR #9536
+(mergee) reecrit `ceilLog2 k = if k ≤ 1 then 0 else Nat.log 2 (k-1) + 1`
+(recursion structurelle kernel-reductible de Mathlib, memes valeurs, spec
+re-prouvee via `Nat.lt_pow_succ_log_self` + `omega`). Apres ce fix, ces
+theoremes passent `decide` (noyau, zero axiome), supprimant les axiomes
+`native_decide` de la base de confiance. Temoins `#eval` natifs en section 5.
 -/
 
 /-- `evolveHashlifeFast` coincide avec la reference sur `block` apres 4 generations.
-    `native_decide` requis : non-reductible sous `decide` (voir Section 6, #8749 / refine #8869 c.8126). -/
-theorem hashlife_fast_block_4 : evolveHashlifeFast 4 block = evolve 4 block := by native_decide
+    (`decide` dans le noyau, zero axiome — reductible apres le fix `ceilLog2` #9536, #8869.) -/
+theorem hashlife_fast_block_4 : evolveHashlifeFast 4 block = evolve 4 block := by decide
 
 /-- `evolveHashlifeFast` coincide avec la reference sur le glider apres 4 generations.
-    `native_decide` requis : non-reductible sous `decide` (voir Section 6, #8749 / refine #8869 c.8126). -/
-theorem hashlife_fast_glider_4 : evolveHashlifeFast 4 glider = evolve 4 glider := by native_decide
+    (`decide` dans le noyau, zero axiome — reductible apres le fix `ceilLog2` #9536, #8869.) -/
+theorem hashlife_fast_glider_4 : evolveHashlifeFast 4 glider = evolve 4 glider := by decide
 
 /-- `evolveHashlifeFast` coincide avec la reference sur le glider apres 8 generations
-    (2 periodes completes, deplacement (2, -2)). `native_decide` requis : non-reductible
-    sous `decide` (voir Section 6, #8749 / refine #8869 c.8126). -/
-theorem hashlife_fast_glider_8 : evolveHashlifeFast 8 glider = shift (2, -2) glider := by native_decide
+    (2 periodes completes, deplacement (2, -2)). `decide` dans le noyau, zero axiome — reductible
+    apres le fix `ceilLog2` (#9536, #8869). -/
+theorem hashlife_fast_glider_8 : evolveHashlifeFast 8 glider = shift (2, -2) glider := by decide
 
 /-- `evolveHashlifeFast` coincide avec la reference sur `blinker` apres 2 generations.
-    `native_decide` requis : non-reductible sous `decide` (voir Section 6, #8749 / refine #8869 c.8126). -/
-theorem hashlife_fast_blinker_2 : evolveHashlifeFast 2 blinker_h = evolve 2 blinker_h := by native_decide
+    (`decide` dans le noyau, zero axiome — reductible apres le fix `ceilLog2` #9536, #8869.) -/
+theorem hashlife_fast_blinker_2 : evolveHashlifeFast 2 blinker_h = evolve 2 blinker_h := by decide
 
 /-- `evolveHashlifeFast` coincide avec la reference sur `beacon` apres 2 generations.
-    `native_decide` requis : non-reductible sous `decide` (voir Section 6, #8749 / refine #8869 c.8126). -/
-theorem hashlife_fast_beacon_2 : evolveHashlifeFast 2 beacon = evolve 2 beacon := by native_decide
+    (`decide` dans le noyau, zero axiome — reductible apres le fix `ceilLog2` #9536, #8869.) -/
+theorem hashlife_fast_beacon_2 : evolveHashlifeFast 2 beacon = evolve 2 beacon := by decide
 
 /-- `evolveHashlifeFast` coincide avec la reference sur `toad` apres 2 generations.
-    `native_decide` requis : non-reductible sous `decide` (voir Section 6, #8749 / refine #8869 c.8126). -/
-theorem hashlife_fast_toad_2 : evolveHashlifeFast 2 toad = evolve 2 toad := by native_decide
+    (`decide` dans le noyau, zero axiome — reductible apres le fix `ceilLog2` #9536, #8869.) -/
+theorem hashlife_fast_toad_2 : evolveHashlifeFast 2 toad = evolve 2 toad := by decide
 
 -- temoins #eval pour les sauts plus grands (valide le chemin recursif)
 #eval evolveHashlifeFast 16 block == evolve 16 block

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Computation_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Computation_en.lean
@@ -9,7 +9,7 @@ B3/S23 step, plus computational primitives (eaters, multi-period glider
 composition). This module is part of Epic #1647 (Life-as-Computation).
 
 Design choices:
-- All predicates return `Bool` for `native_decide` compatibility.
+- All predicates return `Bool` for computability via `decide`.
 - The `eater1` (fishhook) is the simplest signal-absorbing primitive,
   the first building block of Spartan logic gates.
 - Consistency theorems `evolveHashlife n g = evolve n g` verify the
@@ -47,50 +47,45 @@ For level-2 inputs, `evolveHashlife` routes through `step4x4` (the
 quadtree base case). For larger inputs, it falls back to `step`. In both
 cases, the result should match `evolve n g`.
 
-### Why `native_decide` (not `decide`) — #8749
+### Computability by reflection (`decide`, zero axiom) — #8869 resolved by #9536
 
-These six consistency theorems use `native_decide` out of **structural
-necessity**, not convenience. The Lean kernel cannot prove them with
-`decide`: under `set_option maxRecDepth 100000`, each one fails with
-`reduction got stuck at the Decidable instance` (a compile error, within a
-few seconds) — a *definitive* failure, not a timeout that more reduction
-depth would lift. The reason is that `Grid = List (Int × Int)`: the
-`evolveHashlife`/`evolve` computation (`sortDedup` over `Int × Int`, then
-comparison via the `instDecidableEqList` / `instDecidableEqNat` /
-`Bool.decEq` instances) does not reduce to normal form; the kernel gets
-stuck before reaching `isTrue`/`isFalse`. The statements are TRUE (native
-`#eval` witnesses in section 5): this is precisely the role of
-`native_decide` — evaluate the computation as native code and add the
-result to the trust base rather than re-checking it in the kernel. Verified
-per-theorem for all six declarations in this section (#8749 probe,
-2026-07-29). The escape hatch would be a `Grid = List (Nat × Nat)` refactor
-(`Nat` reduces, `Int` does not); a deep rewrite, out of scope for this
-triage (see #8749 caveat).
+These theorems are proved by `decide` in the kernel (zero axiom added). The
+prior diagnosis (c.8126, #8749) concluded the `MacroCell` layer was
+**intrinsically** opaque (and that `Int` arithmetic was non-reducible); it was
+**refuted** by sub-expression bisect (c.847, 2026-08-05). The only stuck point
+was `MacroCell.ceilLog2` (`WellFounded` recursion on `(k+2+1)/2`, not
+structurally smaller → opaque to the kernel reducer), one level deeper than the
+implicated `MacroCell` / `Int` layer. PR #9536 (merged) rewrites
+`ceilLog2 k = if k ≤ 1 then 0 else Nat.log 2 (k-1) + 1` (Mathlib structural
+recursion, kernel-reducible, same values, spec re-proved via
+`Nat.lt_pow_succ_log_self` + `omega`). After this fix, these theorems pass
+`decide` (kernel, zero axiom), removing the `native_decide` axioms from the
+trusted computing base. Native `#eval` witnesses in section 5.
 -/
 
 /-- Hashlife and reference agree on `block` after 1 generation.
-    `native_decide` required: not reducible by `decide` (see Section 1, #8749). -/
-theorem hashlife_block_1 : evolveHashlife 1 block = evolve 1 block := by native_decide
+    (`decide` in the kernel, zero axiom — reducible after the `ceilLog2` fix #9536, #8869.) -/
+theorem hashlife_block_1 : evolveHashlife 1 block = evolve 1 block := by decide
 
 /-- Hashlife and reference agree on `block` after 4 generations.
-    `native_decide` required: not reducible by `decide` (see Section 1, #8749). -/
-theorem hashlife_block_4 : evolveHashlife 4 block = evolve 4 block := by native_decide
+    (`decide` in the kernel, zero axiom — reducible after the `ceilLog2` fix #9536, #8869.) -/
+theorem hashlife_block_4 : evolveHashlife 4 block = evolve 4 block := by decide
 
 /-- Hashlife and reference agree on `blinker_h` after 2 generations.
-    `native_decide` required: not reducible by `decide` (see Section 1, #8749). -/
-theorem hashlife_blinker_2 : evolveHashlife 2 blinker_h = evolve 2 blinker_h := by native_decide
+    (`decide` in the kernel, zero axiom — reducible after the `ceilLog2` fix #9536, #8869.) -/
+theorem hashlife_blinker_2 : evolveHashlife 2 blinker_h = evolve 2 blinker_h := by decide
 
 /-- Hashlife and reference agree on `glider` after 4 generations.
-    `native_decide` required: not reducible by `decide` (see Section 1, #8749). -/
-theorem hashlife_glider_4 : evolveHashlife 4 glider = evolve 4 glider := by native_decide
+    (`decide` in the kernel, zero axiom — reducible after the `ceilLog2` fix #9536, #8869.) -/
+theorem hashlife_glider_4 : evolveHashlife 4 glider = evolve 4 glider := by decide
 
 /-- Hashlife and reference agree on `beacon` after 2 generations.
-    `native_decide` required: not reducible by `decide` (see Section 1, #8749). -/
-theorem hashlife_beacon_2 : evolveHashlife 2 beacon = evolve 2 beacon := by native_decide
+    (`decide` in the kernel, zero axiom — reducible after the `ceilLog2` fix #9536, #8869.) -/
+theorem hashlife_beacon_2 : evolveHashlife 2 beacon = evolve 2 beacon := by decide
 
 /-- Hashlife and reference agree on `toad` after 2 generations.
-    `native_decide` required: not reducible by `decide` (see Section 1, #8749). -/
-theorem hashlife_toad_2 : evolveHashlife 2 toad = evolve 2 toad := by native_decide
+    (`decide` in the kernel, zero axiom — reducible after the `ceilLog2` fix #9536, #8869.) -/
+theorem hashlife_toad_2 : evolveHashlife 2 toad = evolve 2 toad := by decide
 
 /-! ## Section 2: Eater 1 (Fishhook) — the simplest computational sink
 
@@ -122,9 +117,13 @@ Conway.Life.eater1_still_life` is empty (zero axioms) — a purely computational
 proof. (The #8749 probe of 2026-07-29, prior to #8895, correctly observed the
 obstruction under `mergeSort`; it has since been lifted.)
 
-Contrast with the `evolveHashlife n g = evolve n g` equivalences of Section 1: those
-exercise the full quadtree machinery on `Grid = List (Int × Int)` and remain
-non-reducible under `decide` (`native_decide` required, see Section 1).
+As with the `evolveHashlife n g = evolve n g` equivalences of Section 1, this
+theorem is proved by `decide` in the kernel (zero axiom). Historically,
+`eater1_still_life` became `decide`-reducible with the `mergeSort -> insertionSort`
+swap (#8895), whereas the Section 1 equivalences additionally required rewriting
+`ceilLog2` via `Nat.log 2` (#9536): as long as it was a `WellFounded` recursion
+opaque to the reducer, they remained `native_decide`. The historical pre-#9536
+contrast is documented in Section 1.
 -/
 
 /-- The **eater 1** (fishhook), a 7-cell still life. -/
@@ -153,26 +152,33 @@ glider wires.
 We verify for k = 1 (already in Life.lean), k = 2, and k = 3.
 The k = 2 case (8 generations) also verifies via `evolveHashlife`.
 
-### Why `native_decide` — #8749
+### Computability by reflection (`decide`, zero axiom) — #8869 resolved by #9536
 
-These three theorems (glider periodicity + hashlife coherence over 8
-generations) do not reduce under `decide` (`maxRecDepth 100000`: each stuck
-at the `Decidable` instance, EXIT≠0, verified per-theorem). Structural cause:
-`Grid = List (Int × Int)` (see Section 1). Statements TRUE (`#eval` section
-5); `native_decide` required.
+These theorems are proved by `decide` in the kernel (zero axiom added). The
+prior diagnosis (c.8126, #8749) concluded the `MacroCell` layer was
+**intrinsically** opaque (and that `Int` arithmetic was non-reducible); it was
+**refuted** by sub-expression bisect (c.847, 2026-08-05). The only stuck point
+was `MacroCell.ceilLog2` (`WellFounded` recursion on `(k+2+1)/2`, not
+structurally smaller → opaque to the kernel reducer), one level deeper than the
+implicated `MacroCell` / `Int` layer. PR #9536 (merged) rewrites
+`ceilLog2 k = if k ≤ 1 then 0 else Nat.log 2 (k-1) + 1` (Mathlib structural
+recursion, kernel-reducible, same values, spec re-proved via
+`Nat.lt_pow_succ_log_self` + `omega`). After this fix, these theorems pass
+`decide` (kernel, zero axiom), removing the `native_decide` axioms from the
+trusted computing base. Native `#eval` witnesses in section 5.
 -/
 
 /-- After 8 generations (2 periods), the glider has shifted by (2, -2).
-    `native_decide` required: not reducible by `decide` (see Section 3, #8749). -/
-theorem glider_2periods : evolve 8 glider = shift (2, -2) glider := by native_decide
+    (`decide` in the kernel, zero axiom — reducible after the `ceilLog2` fix #9536, #8869.) -/
+theorem glider_2periods : evolve 8 glider = shift (2, -2) glider := by decide
 
 /-- After 12 generations (3 periods), the glider has shifted by (3, -3).
-    `native_decide` required: not reducible by `decide` (see Section 3, #8749). -/
-theorem glider_3periods : evolve 12 glider = shift (3, -3) glider := by native_decide
+    (`decide` in the kernel, zero axiom — reducible after the `ceilLog2` fix #9536, #8869.) -/
+theorem glider_3periods : evolve 12 glider = shift (3, -3) glider := by decide
 
 /-- Hashlife and reference agree on glider after 8 generations (2 periods).
-    `native_decide` required: not reducible by `decide` (see Section 3, #8749). -/
-theorem hashlife_glider_8 : evolveHashlife 8 glider = evolve 8 glider := by native_decide
+    (`decide` in the kernel, zero axiom — reducible after the `ceilLog2` fix #9536, #8869.) -/
+theorem hashlife_glider_8 : evolveHashlife 8 glider = evolve 8 glider := by decide
 
 /-! ## Section 4: MacroCell round-trip verification
 
@@ -180,33 +186,39 @@ Structural sanity check: the `Grid → MacroCell → Grid` round-trip
 preserves live cells for canonical patterns. This verifies the quadtree
 encoding/decoding at the MacroCell layer (independent of step/evolve).
 
-### Why `native_decide` — #8749
+### Computability by reflection (`decide`, zero axiom) — #8869 resolved by #9536
 
-These three round-trip theorems do not reduce under `decide` (`maxRecDepth
-100000`: each stuck at the `Decidable` instance, EXIT≠0, verified
-per-theorem). Structural cause: `Grid = List (Int × Int)` (see Section 1).
-The equality `mc.toGrid off == block` mobilises the same non-reducible
-`instDecidableEqList` instance. Statements TRUE (`#eval` section 5);
-`native_decide` required.
+These theorems are proved by `decide` in the kernel (zero axiom added). The
+prior diagnosis (c.8126, #8749) concluded the `MacroCell` layer was
+**intrinsically** opaque (and that `Int` arithmetic was non-reducible); it was
+**refuted** by sub-expression bisect (c.847, 2026-08-05). The only stuck point
+was `MacroCell.ceilLog2` (`WellFounded` recursion on `(k+2+1)/2`, not
+structurally smaller → opaque to the kernel reducer), one level deeper than the
+implicated `MacroCell` / `Int` layer. PR #9536 (merged) rewrites
+`ceilLog2 k = if k ≤ 1 then 0 else Nat.log 2 (k-1) + 1` (Mathlib structural
+recursion, kernel-reducible, same values, spec re-proved via
+`Nat.lt_pow_succ_log_self` + `omega`). After this fix, these theorems pass
+`decide` (kernel, zero axiom), removing the `native_decide` axioms from the
+trusted computing base. Native `#eval` witnesses in section 5.
 -/
 
-/-- Block survives the MacroCell round-trip. `native_decide` required: not
-    reducible by `decide` (see Section 4, #8749). -/
+/-- Block survives the MacroCell round-trip. `decide` in the kernel, zero axiom
+    — reducible after the `ceilLog2` fix (#9536, #8869). -/
 theorem block_macrocell_roundtrip :
     (let (off, mc) := gridToMacroCellWithOffset block
-     mc.toGrid off == block) = true := by native_decide
+     mc.toGrid off == block) = true := by decide
 
-/-- Glider survives the MacroCell round-trip. `native_decide` required: not
-    reducible by `decide` (see Section 4, #8749). -/
+/-- Glider survives the MacroCell round-trip. `decide` in the kernel, zero axiom
+    — reducible after the `ceilLog2` fix (#9536, #8869). -/
 theorem glider_macrocell_roundtrip :
     (let (off, mc) := gridToMacroCellWithOffset glider
-     mc.toGrid off == glider) = true := by native_decide
+     mc.toGrid off == glider) = true := by decide
 
-/-- Eater 1 survives the MacroCell round-trip. `native_decide` required: not
-    reducible by `decide` (see Section 4, #8749). -/
+/-- Eater 1 survives the MacroCell round-trip. `decide` in the kernel, zero axiom
+    — reducible after the `ceilLog2` fix (#9536, #8869). -/
 theorem eater1_macrocell_roundtrip :
     (let (off, mc) := gridToMacroCellWithOffset eater1
-     mc.toGrid off == eater1) = true := by native_decide
+     mc.toGrid off == eater1) = true := by decide
 
 /-! ## Section 5: Diagnostic #eval witnesses
 
@@ -240,41 +252,46 @@ forward by `2^level` generations in a single MacroCell step. These
 theorems verify correctness of the fast path against the reference
 `evolve` for canonical patterns.
 
-### Why `native_decide` — #8749
+### Computability by reflection (`decide`, zero axiom) — #8869 resolved by #9536
 
-These six theorems (fast path `evolveHashlifeFast` vs reference) do not
-reduce under `decide` (`maxRecDepth 100000`: each stuck at the
-`instDecidableEqBool`/`instDecidableEqList`/`instDecidableEqNat`/`Nat.decLe`
-instances, EXIT≠0, verified per-theorem). Structural cause:
-`Grid = List (Int × Int)` (see Section 1); the fast path mobilises the same
-non-reducible `Int`/list arithmetic as `evolveHashlife`. Statements TRUE
-(`#eval` section 5); `native_decide` required.
+These theorems are proved by `decide` in the kernel (zero axiom added). The
+prior diagnosis (c.8126, #8749) concluded the `MacroCell` layer was
+**intrinsically** opaque (and that `Int` arithmetic was non-reducible); it was
+**refuted** by sub-expression bisect (c.847, 2026-08-05). The only stuck point
+was `MacroCell.ceilLog2` (`WellFounded` recursion on `(k+2+1)/2`, not
+structurally smaller → opaque to the kernel reducer), one level deeper than the
+implicated `MacroCell` / `Int` layer. PR #9536 (merged) rewrites
+`ceilLog2 k = if k ≤ 1 then 0 else Nat.log 2 (k-1) + 1` (Mathlib structural
+recursion, kernel-reducible, same values, spec re-proved via
+`Nat.lt_pow_succ_log_self` + `omega`). After this fix, these theorems pass
+`decide` (kernel, zero axiom), removing the `native_decide` axioms from the
+trusted computing base. Native `#eval` witnesses in section 5.
 -/
 
 /-- `evolveHashlifeFast` agrees with reference on block after 4 gens.
-    `native_decide` required: not reducible by `decide` (see Section 6, #8749). -/
-theorem hashlife_fast_block_4 : evolveHashlifeFast 4 block = evolve 4 block := by native_decide
+    (`decide` in the kernel, zero axiom — reducible after the `ceilLog2` fix #9536, #8869.) -/
+theorem hashlife_fast_block_4 : evolveHashlifeFast 4 block = evolve 4 block := by decide
 
 /-- `evolveHashlifeFast` agrees with reference on glider after 4 gens.
-    `native_decide` required: not reducible by `decide` (see Section 6, #8749). -/
-theorem hashlife_fast_glider_4 : evolveHashlifeFast 4 glider = evolve 4 glider := by native_decide
+    (`decide` in the kernel, zero axiom — reducible after the `ceilLog2` fix #9536, #8869.) -/
+theorem hashlife_fast_glider_4 : evolveHashlifeFast 4 glider = evolve 4 glider := by decide
 
 /-- `evolveHashlifeFast` agrees with reference on glider after 8 gens
-    (2 full periods, displacement (2, -2)). `native_decide` required: not reducible
-    by `decide` (see Section 6, #8749). -/
-theorem hashlife_fast_glider_8 : evolveHashlifeFast 8 glider = shift (2, -2) glider := by native_decide
+    (2 full periods, displacement (2, -2)). `decide` in the kernel, zero axiom — reducible
+    after the `ceilLog2` fix (#9536, #8869). -/
+theorem hashlife_fast_glider_8 : evolveHashlifeFast 8 glider = shift (2, -2) glider := by decide
 
 /-- `evolveHashlifeFast` agrees with reference on blinker after 2 gens.
-    `native_decide` required: not reducible by `decide` (see Section 6, #8749). -/
-theorem hashlife_fast_blinker_2 : evolveHashlifeFast 2 blinker_h = evolve 2 blinker_h := by native_decide
+    (`decide` in the kernel, zero axiom — reducible after the `ceilLog2` fix #9536, #8869.) -/
+theorem hashlife_fast_blinker_2 : evolveHashlifeFast 2 blinker_h = evolve 2 blinker_h := by decide
 
 /-- `evolveHashlifeFast` agrees with reference on beacon after 2 gens.
-    `native_decide` required: not reducible by `decide` (see Section 6, #8749). -/
-theorem hashlife_fast_beacon_2 : evolveHashlifeFast 2 beacon = evolve 2 beacon := by native_decide
+    (`decide` in the kernel, zero axiom — reducible after the `ceilLog2` fix #9536, #8869.) -/
+theorem hashlife_fast_beacon_2 : evolveHashlifeFast 2 beacon = evolve 2 beacon := by decide
 
 /-- `evolveHashlifeFast` agrees with reference on toad after 2 gens.
-    `native_decide` required: not reducible by `decide` (see Section 6, #8749). -/
-theorem hashlife_fast_toad_2 : evolveHashlifeFast 2 toad = evolve 2 toad := by native_decide
+    (`decide` in the kernel, zero axiom — reducible after the `ceilLog2` fix #9536, #8869.) -/
+theorem hashlife_fast_toad_2 : evolveHashlifeFast 2 toad = evolve 2 toad := by decide
 
 -- #eval witnesses for larger jumps (validates the recursive path)
 #eval evolveHashlifeFast 16 block == evolve 16 block


### PR DESCRIPTION
## feat(lean,#8869): flip Computation native_decide → kernel decide + rewrite false docstrings

**Grain:** MED/lean — lane `myia-po-2026:CoursIA` — executes ai-01's GO (msg-233116, 2026-08-06) on the #8869 conversion. `See #8869`.

### What (2 files, proof-lines + docstrings only)

**Flip** the 18 `native_decide` hashlife/evolution theorems in `Computation.lean` (+ `_en` sibling) to kernel `decide`. Proof-lines only: 18 theorems × 2 files (`+36/-36` tactic-line swap). Statements and all other code byte-identical.

**Rewrite the now-false docstrings** (ai-01: « le fichier se contredit lui-même »). The 18 per-theorem docstrings claimed `native_decide` was "required: not reducible by decide", and the 4 `### Pourquoi native_decide` prose blocks + the Section 2 "Contraste" paragraph explained an INTRINSIC `MacroCell`/`Int` opacity (diagnosis c.8126/#8749). All rewritten to state `decide`-reducibility, cite the `ceilLog2` root cause (#9536), and **preserve the retraction trace** (someone arriving via #8749 must understand why the conclusion changed). **0 proof lines touched** — verified: `by native_decide`→0, `by decide`=19 per file.

```lean
-- before                              -- after
theorem hashlife_block_1 := by native_decide   →   by decide
```

### Why now (the #9536 unlock)

`#8869` was **closed as a diagnostic** concluding "*`Int` ne se reduit pas sous `decide`*". That was the **wrong layer** — a sub-expression bisect (c.847) found the obstruction one level deeper: **`MacroCell.ceilLog2`** recursed on `(k+2+1)/2` (not structurally smaller) → **WellFounded recursion** → opaque to the kernel reducer → `decide` stuck. The `Int` arithmetic reduces fine. **#9536** (merged `17f8e7be2`) rewrote `ceilLog2` via `Nat.log 2` (Mathlib, structural). After that, the 18 theorems flip — the conversion the closed issue believed intrinsically native.

### Verification (deliverable, not source)

| Check | Result |
|-------|--------|
| `lake build Conway.Life.Computation Computation_en` (cold oleans, warm imports, `origin/main` base) | **Build completed successfully (2950 jobs), EXIT=0** |
| decide failures | **0** (all 18 theorems prove under kernel `decide` in both FR + EN) |
| Build time (18 kernel decide proofs, cold) | **132–149 s** (7 s incremental warm) — **perf exception chiffrée**, pas "par prudence" |
| `grep -c sorry` Computation.lean | **0** (unchanged) |
| Docstring rewrite touches 0 proof lines | confirmed: `by native_decide`→0, `by decide`=19/file |
| Exhaustive `#print axioms` (all 19 proof-bearing decls) | at most `[propext]` (a standard default) or none — **0 `native_decide` axiom remains** |

### Lean CI discipline §B

- `grep -c sorry`: 0 (unchanged).
- `lake build` SUCCESS measured firsthand on `origin/main` base.
- No axiom added — native_decide TCB axioms **removed** for these decls.
- FR + EN siblings flipped together (proof byte-identity per i18n #4980 sibling convention).
- Allow-list: **no change** — ai-01 verified firsthand that `Computation` is not in the audit's `target-modules`, so nothing to trim (per msg-233116, point 3 retracted).

### Precedent + perf note

ai-01 has merged `native_decide → decide` flips on other conway modules: #9208 (Life 7), #9199 (Angel), #9197 (Nim), #9190 (CollatzLike). This is the `Computation` continuation — the last holdout, unblocked by #9536. ai-01 has **accepted the 132–149 s cold-build CI cost** (msg-233116: « deux minutes de build contre des `_native.native_decide.ax_1_1` retirés de la base de confiance, c'est un bon échange »).

See #8869 (diagnostic issue closed; this PR delivers the conversion its pre-#9536 conclusion deemed impossible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
