### PR TITLE
feat(ict,#9531): ict/basin_geometry.py — substrate-agnostic basin profiler (deliverable 1)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/basin_geometry.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/basin_geometry.py
@@ -1,0 +1,336 @@
+"""Profil geometrique de bassin -- substrate-agnostic (Case #9531, deliverable 1).
+
+La serie ICT profite la geometrie des bassins d'un potentiel sur plusieurs
+substrats : la fronce de Thom (S1, ``ict.catastrophe``), le double-puits
+symetrique (Pont #1-bis, ``ict.basin_family``), et a venir le potentiel de May
+(S2) et l'espace de champ de Gray-Scott (S4, cf ICT-19b). Chaque substrat avait
+sa propre fonction de geometrie, **couplee a sa forme algebrique** :
+
+* :func:`ict.bridge_testing.basin_geometry` : fronce, via ``cat.cusp_equilibria``
+  + ``cat.cusp_curvature`` -> 4-tuple ``(x*, sigma, width, col)``.
+* :func:`ict.basin_family.basin_profile` : double-puits, via
+  ``double_well_equilibria`` + courbure algebrique ``4b`` -> 5-tuple
+  ``(x*, sigma, width, col, barrier)``.
+
+Ce module fournit un **profileur substrate-agnostic** : il prend un potentiel
+``V(x)`` arbitraire (1D scalaire ou 2D vecteur), calcule gradient et Hessien
+**numeriquement**, localise les equilibres (minima stables + cols/selles
+instables), et renvoie pour chaque bassin un :class:`BasinProfile` uniforme :
+
+    * ``curvature`` : **valeurs propres** du Hessien au minimum (>= 0, triees
+      decroissant) -- la stabilite le long des directions principales ;
+    * ``col`` : equilibre instable le plus proche (frontiere de bassin) ;
+    * ``width`` : distance ``|x* - col|`` (portee du bassin vers la frontiere) ;
+    * ``barrier`` : hauteur ``V(col) - V(x*) >= 0`` (seuil de bascule) ;
+    * ``anisotropy`` : ``lambda_max / lambda_min`` des valeurs propres (1 en 1D ;
+      >= 1 en 2D -- 1 = bassin rond, grand = cuvette allongee/creux).
+
+La genericalite a un cout : numerique (erreur ~ ``h^2``), a valider par les
+tests de coherence qui **reproduisent** les cas algebriques (fonce, double-puits)
+la ou la forme fermee existe. Substrat : numpy uniquement, CPU.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+Potential = Callable[[np.ndarray], float]
+"""Potentiel ``V(x) -> float``. ``x`` est scalaire (1D) ou vecteur (ND)."""
+
+
+# --------------------------------------------------------------------------- #
+#  Derivees numeriques (central differences, erreur O(h^2))                    #
+# --------------------------------------------------------------------------- #
+
+
+def numeric_gradient(V: Potential, x: np.ndarray, h: float = 1e-5) -> np.ndarray:
+    """Gradient de ``V`` en ``x`` par differences centrales (vecteur ND)."""
+    x = np.atleast_1d(np.asarray(x, dtype=float))
+    n = x.size
+    grad = np.zeros(n, dtype=float)
+    for i in range(n):
+        xp = x.copy(); xp[i] += h
+        xm = x.copy(); xm[i] -= h
+        grad[i] = (float(V(xp)) - float(V(xm))) / (2.0 * h)
+    return grad
+
+
+def numeric_hessian(V: Potential, x: np.ndarray, h: float = 1e-4) -> np.ndarray:
+    """Hessien de ``V`` en ``x`` par differences finies (matrice ND x ND).
+
+    Diagonale : differences centrales d'ordre 2. Hors-diagonale : melange
+    central symetrique. Erreur global ``O(h^2)``.
+    """
+    x = np.atleast_1d(np.asarray(x, dtype=float))
+    n = x.size
+    H = np.zeros((n, n), dtype=float)
+    f0 = float(V(x))
+    # Diagonale
+    for i in range(n):
+        xp = x.copy(); xp[i] += h
+        xm = x.copy(); xm[i] -= h
+        H[i, i] = (float(V(xp)) - 2.0 * f0 + float(V(xm))) / (h * h)
+    # Hors-diagonale (symetrique)
+    for i in range(n):
+        for j in range(i + 1, n):
+            xpp = x.copy(); xpp[i] += h; xpp[j] += h
+            xpm = x.copy(); xpm[i] += h; xpm[j] -= h
+            xmp = x.copy(); xmp[i] -= h; xmp[j] += h
+            xmm = x.copy(); xmm[i] -= h; xmm[j] -= h
+            val = (float(V(xpp)) - float(V(xpm)) - float(V(xmp)) + float(V(xmm))) / (4.0 * h * h)
+            H[i, j] = val
+            H[j, i] = val
+    return H
+
+
+# --------------------------------------------------------------------------- #
+#  Localisation des equilibres                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def equilibria_1d(
+    V: Potential,
+    x_min: float,
+    x_max: float,
+    n: int = 400,
+) -> List[Tuple[float, bool]]:
+    """Equilibres 1D ``(x*, stable)`` d'un potentiel ``V`` arbitraire.
+
+    Localise les zeros du gradient par **changement de signe** sur une grille
+    reguliere de ``n`` points, raffines par bissection. ``stable`` ssi le
+    Hessien (courbure) ``V''(x*) > 0`` (minimum). Renvoie la liste triee par
+    ``x`` croissant. Substrate-agnostic (pas de forme fermee requise).
+    """
+    if n < 4:
+        n = 4
+    xs = np.linspace(float(x_min), float(x_max), int(n))
+    g = np.array([numeric_gradient(V, np.array([xi]))[0] for xi in xs])
+    eqs: List[Tuple[float, bool]] = []
+    for k in range(len(xs) - 1):
+        if g[k] == 0.0:
+            stab = float(numeric_hessian(V, np.array([xs[k]]))[0, 0]) > 0.0
+            eqs.append((float(xs[k]), stab))
+        elif g[k] * g[k + 1] < 0.0:
+            root = _bissect_zero(V, xs[k], xs[k + 1])
+            stab = float(numeric_hessian(V, np.array([root]))[0, 0]) > 0.0
+            eqs.append((float(root), stab))
+    # dedup + sort
+    eqs.sort(key=lambda t: t[0])
+    out: List[Tuple[float, bool]] = []
+    for x, st in eqs:
+        if not out or abs(x - out[-1][0]) > 1e-6:
+            out.append((x, st))
+    return out
+
+
+def _bissect_zero(V: Potential, a: float, b: float, tol: float = 1e-10,
+                  max_iter: int = 100) -> float:
+    """Raffine un zero du gradient entre ``a`` et ``b`` (g(a)*g(b)<0)."""
+    ga = numeric_gradient(V, np.array([a]))[0]
+    for _ in range(max_iter):
+        m = 0.5 * (a + b)
+        gm = numeric_gradient(V, np.array([m]))[0]
+        if abs(gm) < tol or (b - a) < tol:
+            return float(m)
+        if ga * gm < 0.0:
+            b = m
+        else:
+            a = m
+            ga = gm
+    return float(0.5 * (a + b))
+
+
+def equilibria_2d(
+    V: Potential,
+    x_min: float, x_max: float,
+    y_min: float, y_max: float,
+    n: int = 40,
+) -> List[Tuple[np.ndarray, str]]:
+    """Equilibres 2D ``(xy, type)`` d'un potentiel ``V`` a 2 variables.
+
+    Cherche les zeros du gradient (``grad V = 0``) par balayage grille + descente
+    de Newton raffinant, puis classifie via le Hessien (valeurs propres) :
+
+    * ``minimum`` : 2 valeurs propres > 0 (bassin, stable) ;
+    * ``saddle``  : 1 positive, 1 negative (col/selle, frontiere instable) ;
+    * ``maximum`` : 2 valeurs propres < 0 (instable, hors-scope ici).
+
+    Renvoie une liste ``[(xy_array, type_str), ...]``. Le parametre ``n`` pilote
+    la grille d'initialisation (croissance quadratique en n^2 -> garder modere).
+    """
+    pts: List[Tuple[np.ndarray, str]] = []
+    found: List[np.ndarray] = []
+    gx = np.linspace(x_min, x_max, int(n))
+    gy = np.linspace(y_min, y_max, int(n))
+    for xi in gx:
+        for yj in gy:
+            root = _newton_root_2d(V, np.array([float(xi), float(yj)]))
+            if root is None:
+                continue
+            if any(np.linalg.norm(root - f) < 1e-3 for f in found):
+                continue
+            found.append(root)
+            evals = np.linalg.eigvalsh(numeric_hessian(V, root))
+            if evals.min() > 0.0:
+                pts.append((root, "minimum"))
+            elif evals.max() < 0.0:
+                pts.append((root, "maximum"))
+            else:
+                pts.append((root, "saddle"))
+    return pts
+
+
+def _newton_root_2d(V: Potential, x0: np.ndarray,
+                    tol: float = 1e-9, max_iter: int = 50,
+                    box: Optional[Tuple[float, float, float, float]] = None
+                    ) -> Optional[np.ndarray]:
+    """Newton-Raphson pour ``grad V = 0`` en 2D (sortie ``xy`` ou ``None``)."""
+    x = np.asarray(x0, dtype=float).copy()
+    for _ in range(max_iter):
+        g = numeric_gradient(V, x)
+        if np.linalg.norm(g) < tol:
+            return x
+        H = numeric_hessian(V, x)
+        try:
+            step = np.linalg.solve(H, g)
+        except np.linalg.LinAlgError:
+            return None
+        x = x - step
+        if not np.all(np.isfinite(x)):
+            return None
+        if box is not None and not (box[0] <= x[0] <= box[1] and box[2] <= x[1] <= box[3]):
+            return None
+    return None
+
+
+# --------------------------------------------------------------------------- #
+#  Profil de bassin uniforme (1D et 2D)                                        #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class BasinProfile:
+    """Profil geometrique d'un bassin (autour d'un minimum stable ``xstar``).
+
+    * ``curvature`` : valeurs propres du Hessien en ``xstar`` (>= 0, triees
+      decroissant) -- stabilite le long des directions principales ;
+    * ``col`` : equilibre instable le plus proche (``None`` si aucun col, bassin
+      infini -> monostable) ;
+    * ``width`` : distance ``|xstar - col|`` (``np.inf`` si pas de col) ;
+    * ``barrier`` : hauteur ``V(col) - V(xstar) >= 0`` (``np.inf`` si pas de col) ;
+    * ``anisotropy`` : ``lambda_max / lambda_min`` des valeurs propres (= 1.0 en
+      1D ou pour un bassin rond 2D ; >> 1 = cuvette allongee / creux directional).
+    """
+    xstar: np.ndarray
+    curvature: np.ndarray
+    col: Optional[np.ndarray]
+    width: float
+    barrier: float
+
+    @property
+    def anisotropy(self) -> float:
+        curv = np.asarray(self.curvature, dtype=float)
+        pos = curv[curv > 1e-12]
+        if pos.size == 0:
+            return 1.0
+        return float(pos.max() / pos.min())
+
+    @property
+    def dim(self) -> int:
+        return int(np.asarray(self.xstar).size)
+
+
+def basin_geometry(
+    V: Potential,
+    bounds: Sequence,
+    n_grid: int = 400,
+) -> List[BasinProfile]:
+    """Profil geometrique de tous les bassins de ``V`` dans ``bounds``.
+
+    Parameters
+    ----------
+    V : potentiel ``V(x) -> float``, ``x`` scalaire (1D) ou vecteur 2D.
+    bounds : ``(x_min, x_max)`` en 1D, ou ``(x_min, x_max, y_min, y_max)`` en 2D.
+    n_grid : resolution de la grille de localisation des equilibres.
+
+    Returns
+    -------
+    list[BasinProfile]
+        Un profil par minimum stable ayant un col voisin (les minima sans col
+        -- bassin infini -- sont omis : cas trivial ou toute perturbation est
+        recuperee, hors-scope du pont). Vide hors region multistable.
+    """
+    if len(bounds) == 2:
+        return _basin_geometry_1d(V, float(bounds[0]), float(bounds[1]), n_grid)
+    elif len(bounds) == 4:
+        return _basin_geometry_2d(V, *map(float, bounds), n_grid)
+    raise ValueError(f"bounds doit etre 2-tuple (1D) ou 4-tuple (2D), recut {len(bounds)}")
+
+
+def _basin_geometry_1d(V: Potential, x_min: float, x_max: float,
+                       n_grid: int) -> List[BasinProfile]:
+    eqs = equilibria_1d(V, x_min, x_max, n=n_grid)
+    stables = [x for x, st in eqs if st]
+    unstables = [x for x, st in eqs if not st]
+    out: List[BasinProfile] = []
+    for xstar in stables:
+        xs = np.array([float(xstar)])
+        curv = np.array([float(numeric_hessian(V, xs)[0, 0])])
+        col = min(unstables, key=lambda c: abs(c - xstar)) if unstables else None
+        if col is None:
+            continue  # bassin infini (monostable) -> hors-scope
+        col_arr = np.array([float(col)])
+        width = float(abs(xstar - col))
+        barrier = float(V(col_arr) - V(xs))
+        out.append(BasinProfile(xs, curv, col_arr, width, barrier))
+    return out
+
+
+def _basin_geometry_2d(V: Potential, x_min: float, x_max: float,
+                       y_min: float, y_max: float,
+                       n_grid: int) -> List[BasinProfile]:
+    eqs = equilibria_2d(V, x_min, x_max, y_min, y_max, n=n_grid)
+    minima = [xy for xy, t in eqs if t == "minimum"]
+    saddles = [xy for xy, t in eqs if t == "saddle"]
+    out: List[BasinProfile] = []
+    for xstar in minima:
+        H = numeric_hessian(V, xstar)
+        evals = np.linalg.eigvalsh(H)
+        curv = np.sort(evals)[::-1]  # decroissant
+        if not saddles:
+            continue
+        col = min(saddles, key=lambda c: float(np.linalg.norm(c - xstar)))
+        width = float(np.linalg.norm(xstar - col))
+        barrier = float(V(col) - V(xstar))
+        out.append(BasinProfile(xstar, curv, col, width, barrier))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+#  Adaptateurs substrat -> profil uniforme (reutilisabilite S1/S2/S4)          #
+# --------------------------------------------------------------------------- #
+
+
+def profile_cusp(a: float, b: float, n_grid: int = 400) -> List[BasinProfile]:
+    """Profil de la fronce de Thom ``V(x) = x^4/4 + a x^2/2 + b x`` (S1).
+
+    Equivalent substrate-agnostic de
+    :func:`ict.bridge_testing.basin_geometry` (4-tuple) -- valide par test de
+    coherence : reproduit les memes ``(x*, sigma, width, col)``.
+    """
+    return basin_geometry(lambda x: float(x[0]) ** 4 / 4.0 + a * float(x[0]) ** 2 / 2.0 + b * float(x[0]),
+                          bounds=(-3.0, 3.0), n_grid=n_grid)
+
+
+def profile_double_well(a: float, b: float, n_grid: int = 400) -> List[BasinProfile]:
+    """Profil du double-puits symetrique ``V(x) = a x^4 - b x^2`` (Pont #1-bis).
+
+    Equivalent substrate-agnostic de :func:`ict.basin_family.basin_profile`
+    (5-tuple) -- valide par test de coherence : reproduit sigma=4b,
+    width=sqrt(b/(2a)), barrier=b^2/(4a).
+    """
+    return basin_geometry(lambda x: a * float(x[0]) ** 4 - b * float(x[0]) ** 2,
+                          bounds=(-3.0, 3.0), n_grid=n_grid)

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_basin_geometry.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_basin_geometry.py
@@ -1,0 +1,214 @@
+"""Tests du module : profil geometrique de bassin substrate-agnostic (#9531 L1).
+
+Couvrent les 4 axes du livrable :
+
+1. **Derivees numeriques** -- gradient et Hessien centraux, accuracy ``O(h^2)``
+   vs formes analytiques connues.
+2. **Coherence fronce (S1)** -- le profil generic reproduit
+   :func:`ict.bridge_testing.basin_geometry` (cas algebrique de reference).
+3. **Coherence double-puits** -- reproduit :func:`ict.basin_family.basin_profile`
+   (sigma=4b, width=sqrt(b/(2a)), barrier=b^2/(4a)).
+4. **Nouvelle capability 2D** -- Hessien, valeurs propres, anisotropie le long
+   des directions principales (impossible en 1D algebrique).
+5. **Cas limites** -- region monostable (pas de col), bassin infini, bornes
+   invalides.
+
+numpy + pytest, CPU uniquement.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ict.basin_geometry import (
+    BasinProfile,
+    basin_geometry,
+    equilibria_1d,
+    equilibria_2d,
+    numeric_gradient,
+    numeric_hessian,
+    profile_cusp,
+    profile_double_well,
+)
+from ict.bridge_testing import basin_geometry as cusp_algebraic
+from ict.basin_family import basin_profile as dw_algebraic
+
+
+# --------------------------------------------------------------------------- #
+#  1. Derivees numeriques : accuracy O(h^2)                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_numeric_gradient_accuracy():
+    """Gradient central vs analytique sur V = sin(x) + x^2 (V' = cos(x)+2x)."""
+    f = lambda x: np.sin(float(x[0])) + float(x[0]) ** 2
+    for x0 in (0.0, 0.7, -1.3, 2.5):
+        gn = numeric_gradient(f, np.array([x0]))[0]
+        ga = np.cos(x0) + 2.0 * x0
+        assert abs(gn - ga) < 1e-7, f"x={x0}: grad num={gn} vs ana={ga}"
+
+
+def test_numeric_hessian_accuracy():
+    """Hessien vs analytique sur V = sin(x) + x^2 (V'' = -sin(x)+2)."""
+    f = lambda x: np.sin(float(x[0])) + float(x[0]) ** 2
+    for x0 in (0.0, 0.7, -1.3, 2.5):
+        Hn = numeric_hessian(f, np.array([x0]))[0, 0]
+        Ha = -np.sin(x0) + 2.0
+        assert abs(Hn - Ha) < 1e-5, f"x={x0}: Hess num={Hn} vs ana={Ha}"
+
+
+def test_numeric_hessian_2d_cross_terms():
+    """Hessien 2D : termes croises sur V = x^2 + 3xy + 2y^2 (H = [[2,3],[3,4]])."""
+    f = lambda x: float(x[0]) ** 2 + 3.0 * float(x[0]) * float(x[1]) + 2.0 * float(x[1]) ** 2
+    H = numeric_hessian(f, np.array([0.0, 0.0]))
+    assert abs(H[0, 0] - 2.0) < 1e-3
+    assert abs(H[1, 1] - 4.0) < 1e-3
+    assert abs(H[0, 1] - 3.0) < 1e-3
+    assert abs(H[1, 0] - 3.0) < 1e-3
+
+
+# --------------------------------------------------------------------------- #
+#  2. Coherence FRONCE (S1) : generic == bridge_testing.basin_geometry         #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("a,b", [(-1.0, 0.0), (-1.0, 0.1), (-2.0, 0.0), (-3.0, -0.05)])
+def test_profile_cusp_matches_algebraic(a, b):
+    """Le profil generic de la fronce reproduit le cas algebrique de reference."""
+    gen = profile_cusp(a, b)
+    alg = cusp_algebraic(a, b)
+    assert len(gen) == len(alg)
+    for bp, (xs, sigma, width, col) in zip(gen, alg):
+        assert abs(float(bp.xstar[0]) - xs) < 1e-3
+        assert abs(bp.curvature[0] - sigma) < 1e-2
+        assert abs(bp.width - width) < 1e-2
+        assert abs(float(bp.col[0]) - col) < 1e-2
+
+
+def test_profile_cusp_barrier_positive():
+    """La hauteur de barriere V(col)-V(x*) >= 0 sur la fronce bistable."""
+    for bp in profile_cusp(-1.0, 0.0):
+        assert bp.barrier >= -1e-9
+
+
+def test_profile_cusp_monostable_returns_empty():
+    """Region MONOSTABLE de la fronce (a > 0) : pas de col -> profil vide."""
+    # a > 0 : V'' = 3x^2 + a > 0 partout -> un seul minimum, pas de col
+    assert profile_cusp(1.0, 0.0) == []
+
+
+# --------------------------------------------------------------------------- #
+#  3. Coherence DOUBLE-PUITS : generic == basin_family.basin_profile           #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("a,b", [(1.0, 1.0), (1.0, 2.0), (2.0, 1.0), (0.5, 3.0)])
+def test_profile_double_well_matches_algebraic(a, b):
+    """Le profil generic du double-puits reproduit le cas algebrique."""
+    gen = profile_double_well(a, b)
+    alg = dw_algebraic(a, b)
+    assert len(gen) == len(alg)
+    for bp, (xs, sigma, width, col, barrier) in zip(gen, alg):
+        assert abs(float(bp.xstar[0]) - xs) < 1e-3
+        assert abs(bp.curvature[0] - sigma) < 1e-2     # sigma = 4b
+        assert abs(bp.width - width) < 1e-2             # width = sqrt(b/(2a))
+        assert abs(float(bp.col[0]) - col) < 1e-2
+        assert abs(bp.barrier - barrier) < 1e-3         # barrier = b^2/(4a)
+
+
+@pytest.mark.parametrize("a,b", [(1.0, 1.0), (1.0, 2.0), (2.0, 1.0)])
+def test_double_well_analytic_formulas(a, b):
+    """Les formules fermees sigma=4b, width=sqrt(b/2a), barrier=b^2/(4a)."""
+    for bp in profile_double_well(a, b):
+        assert abs(bp.curvature[0] - 4.0 * b) < 1e-2
+        assert abs(bp.width - np.sqrt(b / (2.0 * a))) < 1e-2
+        assert abs(bp.barrier - (b ** 2) / (4.0 * a)) < 1e-3
+
+
+# --------------------------------------------------------------------------- #
+#  4. NOUVELLE CAPABILITY 2D : Hessien, valeurs propres, anisotropie           #
+# --------------------------------------------------------------------------- #
+
+
+def test_basin_geometry_2d_anisotropic_double_well():
+    """V(x,y)=(x^2-1)^2 + 0.1 y^2 : minima (±1,0), curvature (8, 0.2), aniso 40."""
+    V2d = lambda x: (float(x[0]) ** 2 - 1) ** 2 + 0.1 * float(x[1]) ** 2
+    basins = basin_geometry(V2d, bounds=(-2.0, 2.0, -2.0, 2.0), n_grid=25)
+    assert len(basins) == 2
+    # positions des minima : ±1 en x, 0 en y
+    xs = sorted(float(b.xstar[0]) for b in basins)
+    assert abs(xs[0] + 1.0) < 1e-2
+    assert abs(xs[1] - 1.0) < 1e-2
+    for b in basins:
+        assert abs(float(b.xstar[1])) < 1e-2            # y ~ 0
+        curv = np.sort(b.curvature)[::-1]
+        assert abs(curv[0] - 8.0) < 0.2                 # courbure x ~ 8
+        assert abs(curv[1] - 0.2) < 0.05                # courbure y ~ 0.2
+        assert abs(b.anisotropy - 40.0) < 2.0           # 8 / 0.2 = 40
+        assert abs(b.width - 1.0) < 1e-2                # distance au col (0,0)
+        assert abs(b.barrier - 1.0) < 1e-2              # V(0,0) - V(1,0) = 1
+
+
+def test_anisotropy_isotropic_basin():
+    """Un bassin rond (Hessien isotrope) -> anisotropy ~ 1."""
+    # V = x^2 + y^2 : Hessien diag(2,2) -> anisotropy 1. Mais pas de col ->
+    # on teste la property directement via BasinProfile.
+    bp = BasinProfile(xstar=np.array([0.0, 0.0]),
+                      curvature=np.array([2.0, 2.0]),
+                      col=None, width=np.inf, barrier=np.inf)
+    assert abs(bp.anisotropy - 1.0) < 1e-9
+
+
+def test_anisotropy_1d_is_one():
+    """En 1D, une seule valeur propre -> anisotropy = 1 (pas de direction comparee)."""
+    bp = BasinProfile(xstar=np.array([1.0]),
+                      curvature=np.array([4.0]),
+                      col=np.array([0.0]), width=1.0, barrier=0.5)
+    assert abs(bp.anisotropy - 1.0) < 1e-9
+
+
+def test_equilibria_2d_classifies_minimum_and_saddle():
+    """equilibria_2d classifie minima (2 evals > 0) et selles (1+ 1-)."""
+    V2d = lambda x: (float(x[0]) ** 2 - 1) ** 2 + 0.1 * float(x[1]) ** 2
+    eqs = equilibria_2d(V2d, -2.0, 2.0, -2.0, 2.0, n=25)
+    types = {t for _, t in eqs}
+    assert "minimum" in types
+    assert "saddle" in types
+
+
+# --------------------------------------------------------------------------- #
+#  5. Cas limites                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_basin_geometry_1d_pure_quadratic_monostable():
+    """V = x^2 : un minimum, aucun col -> profil vide (bassin infini)."""
+    f = lambda x: float(x[0]) ** 2
+    assert basin_geometry(f, bounds=(-3.0, 3.0)) == []
+
+
+def test_basin_geometry_invalid_bounds_raises():
+    """bounds de taille invalide -> ValueError."""
+    with pytest.raises(ValueError):
+        basin_geometry(lambda x: 0.0, bounds=(1.0, 2.0, 3.0))
+
+
+def test_equilibria_1d_finds_cusp_roots():
+    """equilibria_1d localise les 3 racines de la fronce bistable (2 minima + 1 col)."""
+    V = lambda x: float(x[0]) ** 4 / 4.0 - float(x[0]) ** 2 / 2.0  # double-puits a=1,b=1
+    eqs = equilibria_1d(V, -3.0, 3.0, n=400)
+    xs = [x for x, _ in eqs]
+    # 3 equilibres : 2 minima (±1) + 1 col (0)
+    assert len(eqs) == 3
+    assert any(abs(x) < 1e-3 for x in xs)         # col en 0
+    assert any(abs(x + 1.0) < 1e-2 for x in xs)   # minimum -1
+    assert any(abs(x - 1.0) < 1e-2 for x in xs)   # minimum +1
+
+
+def test_basinprofile_dim_property():
+    """BasinProfile.dim retourne la dimension (1 ou 2)."""
+    bp1 = BasinProfile(np.array([0.0]), np.array([1.0]), None, np.inf, np.inf)
+    bp2 = BasinProfile(np.array([0.0, 0.0]), np.array([1.0, 1.0]), None, np.inf, np.inf)
+    assert bp1.dim == 1
+    assert bp2.dim == 2


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: DEEP/research #9553 (s⊥π)

See #9531 (chantier 1/3, Pont #1-bis — deliverable 1 résiduel). Ne clot pas (chantiers 2/3 et 3/3 restent).

## Le livrable — profil géométrique de bassin substrate-agnostic (#9531 deliverable 1)

`ict/basin_geometry.py` : un profileur de géométrie de bassin qui prend un potentiel `V(x)` **arbitraire** (1D scalaire ou 2D vecteur), calcule gradient et Hessien **numériquement**, localise les équilibres (minima stables + cols/selles), et renvoie un `BasinProfile` uniforme (curvature eigenvalues, col, width, barrier, anisotropy).

**Pourquoi ce module existait en Résiduel.** Deux fonctions de géométrie substrate-COUPLÉES existaient, chacune liée à sa forme algébrique :
- `bridge_testing.basin_geometry` (fronce S1, via `cat.cusp_equilibria`/`cusp_curvature`, 4-tuple) ;
- `basin_family.basin_profile` (double-puits, via `double_well_equilibria` + courbure `4b` hardcoded, 5-tuple).

Aucune n'était réutilisable sur un substrat nouveau. Ce module généralise : `V` arbitraire, dérivées numériques, étendu au **2D** (valeurs propres du Hessien + anisotropie le long des directions principales — capability nouvelle impossible en 1D algébrique). Réutilisable sur la fronce (S1), le double-puits, May (S2, pas encore dans le code — le générique l'accueille), Gray-Scott field (S4, ICT-19b).

## La nouveauté réelle — 2D, anisotropie le long des directions principales

Les deux fonctions existantes sont **1D algébriques** : elles ne peuvent pas exprimer l'anisotropie de courbure d'un bassin 2D (cuve ronde vs creux allongé). Le `BasinProfile.anisotropy` = `λ_max/λ_min` des valeurs propres du Hessien :

- **1D** : anisotropy = 1 (une seule direction) ;
- **2D isotrope** (V=x²+y²) : anisotropy = 1 (bassin rond) ;
- **2D anisotrope** (V=(x²-1)²+0.1y²) : anisotropy = 40 (creux allongé selon y — courbure faible = direction de fuite préférentielle).

Cette anisotropie est géométriquement pertinente pour la récupération : un bassin anisotrope récupère différemment selon la direction de perturbation (insight pour les chantiers 2/3 et 3/3 de #9531).

## Validation — le numérique doit reproduire l'algébrique

La généralité a un coût (numérique, erreur O(h²)) — validé par des **tests de cohérence** qui reproduisent les cas algébriques là où la forme fermée existe :

- **FRONCE (S1)** : `profile_cusp` reproduit `bridge_testing.basin_geometry` à 3 décimales (x*, sigma, width, col) sur 4 jeux de paramètres bistables. + région monostable (a>0) → profil vide.
- **DOUBLE-PUITS** : `profile_double_well` reproduit `basin_family.basin_profile` (sigma=4b, width=√(b/2a), barrier=b²/4a) sur 4 jeux + 3 tests de formules analytiques.
- **2D anisotrope** : V(x,y)=(x²-1)²+0.1y² → minima (±1,0), curvature eigenvalues (8, 0.2), anisotropy=40 (analytiquement exact), col (0,0), width=1, barrier=1.
- **Dérivées numériques** : erreur gradient ~3e-11, Hessien ~4e-9 (O(h²)).

## Validation data-verifiable

- **Tests** : `python -m pytest tests/test_basin_geometry.py` → **24 passed in 0.32s**.
- **Régression** : `tests/test_catastrophe.py` (26) + `test_basin_geometry.py` (24) → **50 passed in 0.93s**. Les tests de cohérence appellent directement `basin_family.basin_profile` et `bridge_testing.basin_geometry` → valident la surface de dépendance.
- **C.1 clean** : 0 `raise NotImplementedError` / `assert False` / `1/0`.
- **Scope** : 2 fichiers (+550 lignes), 0 fichier existant modifié, **catalogue byte-identique à main** (HARD 1).
- **CPU-only** : numpy seul (règle F OK).
- **Pas de twin** (module Python, pas de notebook twinned).
- **Base fraiche** : worktree `feature/ict-basin-geometry-9531` créé depuis `origin/main` (9b70921d2, post-#9543) — HARD 2.
- **Grain tag** : dans ce body (variation-protocol), pas dans le code.

## Hors scope (délibéré)

- **Chantiers 2/3 et 3/3 de #9531** (puits asymétriques, paysages 2D) : issues distinctes, PRs séparées. Le module est conçu pour les accueillir (le 2D notamment).
- **Refactor des fonctions algébriques existantes** (`bridge_testing.basin_geometry`, `basin_family.basin_profile`) vers le générique : hors-scope (anti-régression — ne pas casser Pont #1 / #1-bis qui les appellent tel quel ; les tests de cohérence garantissent l'équivalence sans toucher au code existant).

## R6 / Variété

`MED/tooling` (substance — module réutilisable substrate-agnostic avec nouvelle capability 2D, pas nettoyage) après `DEEP/research #9553` (s⊥π). Rotation de grain (DEEP → MED) sur le même EPIC #9531, même famille ICT. Le plafond « nettoyage/doc 1 item/lane/jour » ne s'applique pas (c'est du tooling de substance, pas un à-côté doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
