### PR TITLE
test(prose-claims,#9434): golden set 32 cases to validate the quantitative-claims classifier (option alpha)

### DIFF
--- a/scripts/tests/golden_quantitative_claims.json
+++ b/scripts/tests/golden_quantitative_claims.json
@@ -1,0 +1,56 @@
+{
+  "_meta": {
+    "name": "Golden set — classification des claims quantitatifs en prose (#9434)",
+    "purpose": "Valider la precision du scanner check_prose_quantitative_claims.py sur les 4 classes (machine/env/stochastic/structural). Chaque cas = un snippet de prose + la ground-truth humaine (cls, expect). Le test compare la ground truth au comportement reel du scanner ; les ecarts connus sont marques xfail avec rationale (angle-mort documente, pas un bug du test).",
+    "classes": {
+      "machine": "duree absolue machine-dependante (ms/sec/min). Derive avec la charge.",
+      "env": "version de librairie figee en prose. Derive a chaque bump.",
+      "stochastic": "valeur a virgule (>=2 dec) + mot-clef metrique, non reproductible sans seed.",
+      "structural": "speedup deterministe par taille (LEGITIME en prose)."
+    },
+    "note_stochastic": "Au niveau texte, on teste la cooccurrence KW+NUM (regex). La logique seed du notebook (un carnet seme = legitime) est testee separement via fixtures mini-notebooks dans le test pytest.",
+    "sources": {
+      "issue-9434": "cas reel documente dans le tableau de l'issue #9434",
+      "real-<family>": "cas reel pioche dans un notebook du depot",
+      "synthetic-boundary": "cas synthetique testant une frontiere de regex"
+    },
+    "counts": { "total": 32, "machine": 8, "env": 7, "stochastic": 9, "structural": 8 }
+  },
+  "cases": [
+    {"id": "m1", "text": "Le tri prend 24-127 ms selon la taille.", "cls": "machine", "expect": "match", "kind": "TP", "source": "issue-9434", "note": "PR #9427 App-11-Picross. Scanner matche '127 ms' (la 2eme valeur) — la 1ere '24-' n'a pas d'unite accolée."},
+    {"id": "m2", "text": " temps de ~144 ms en moyenne", "cls": "machine", "expect": "match", "kind": "TP", "source": "real-genai", "note": "Forme canonique avec tilde."},
+    {"id": "m3", "text": "latence de 0.006 ms", "cls": "machine", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "Sous-milliseconde (3 decimales)."},
+    {"id": "m4", "text": "generation en ~1.9 sec", "cls": "machine", "expect": "match", "kind": "TP", "source": "real-genai", "note": "Unite 'sec' (multiletire)."},
+    {"id": "m5", "text": "la convergence prend 2 min", "cls": "machine", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "Minutes."},
+    {"id": "m6", "text": "L'inference dure 0.2 s par batch.", "cls": "machine", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "Unite monolettre 's' avec espace (exige par le scanner)."},
+    {"id": "m7", "text": "execution en 30s", "cls": "machine", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "ANGLE-MORT: '30s' sans espace AVANT 's' n'est pas matche (le scanner exige \\ss). Humainement c'est machine-dependant — devrait matcher. xfail documente (le scanner le rate)."},
+    {"id": "m8", "text": "Le port USB-C est connecte.", "cls": "machine", "expect": "nomatch", "kind": "TN", "source": "synthetic-boundary", "note": "TN propre: 'USB-C' ne contient pas d'unite de temps."},
+
+    {"id": "e1", "text": "Tourne sous NumPy 2.4.2", "cls": "env", "expect": "match", "kind": "TP", "source": "issue-9434", "note": "PR #9429 GT-4c. Version de librairie figee en prose (la cellule imprime deja la version dynamiquement)."},
+    {"id": "e2", "text": "PyTorch 2.1.0 requis", "cls": "env", "expect": "match", "kind": "TP", "source": "real-genai", "note": "Forme canonique."},
+    {"id": "e3", "text": "depend de Mathlib v4.31.0", "cls": "env", "expect": "match", "kind": "TP", "source": "real-lean", "note": "'v' optionnel devant la version."},
+    {"id": "e4", "text": "compile avec JAX 0.4", "cls": "env", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "1 seul chiffre de version apres le point."},
+    {"id": "e5", "text": "numpy 2.4.2 inclus", "cls": "env", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "Minuscule: le scanner est IGNORECASE."},
+    {"id": "e6", "text": "Nous utilisons NumPy pour le calcul vectoriel.", "cls": "env", "expect": "nomatch", "kind": "TN", "source": "synthetic-boundary", "note": "TN propre: lib citee sans numero de version."},
+    {"id": "e7", "text": "Pandas 1.5", "cls": "env", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "Version majeure.mineure courte."},
+
+    {"id": "s1", "text": "fitness moyen de 41.71", "cls": "stochastic", "expect": "match", "kind": "TP", "source": "issue-9434", "note": "PR #9428 Search-5-GeneticAlgorithms. GA non-seede: valeur qui derive a chaque run."},
+    {"id": "s2", "text": "accuracy de 0.95 sur le jeu de test", "cls": "stochastic", "expect": "match", "kind": "TP", "source": "real-ml", "note": "Metrique ML classique."},
+    {"id": "s3", "text": "WER de 12.34%", "cls": "stochastic", "expect": "match", "kind": "TP", "source": "real-genai", "note": "Word Error Rate (audio)."},
+    {"id": "s4", "text": "perte (loss) egale a 0.456", "cls": "stochastic", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "3 decimales, KW 'perte'/'loss'."},
+    {"id": "s5", "text": "F1-score atteint 0.88", "cls": "stochastic", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "KW 'f1' borne."},
+    {"id": "s6", "text": "moyenne de 42.5 sur 10 runs", "cls": "stochastic", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "KW 'moyenne'. GROUND TRUTH: stochastique (derive sur 10 runs). ANGLE-MORT: 42.5 a 1 decimale, STOCHASTIC_NUM exige >=2 -> le scanner le rate. xfail documente."},
+    {"id": "s7", "text": "score de 3 etoiles", "cls": "stochastic", "expect": "nomatch", "kind": "TN", "source": "synthetic-boundary", "note": "TN: entier (pas de decimale) — ne derive pas comme un flottant stochastique."},
+    {"id": "s8", "text": "3.3 tentatives en moyenne", "cls": "stochastic", "expect": "match", "kind": "TP", "source": "issue-9434", "note": "PR #9426 App-7-Wordle. GROUND TRUTH: stochastique (moyenne qui derive). ANGLE-MORT double: 'tentatives' n'est pas un KW, et 1 seule decimale -> le scanner le rate. xfail documente."},
+    {"id": "s9", "text": "l'entropie de Shannon vaut 2.31 bits", "cls": "stochastic", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "KW 'entropie' + 2 decimales."},
+
+    {"id": "t1", "text": "soit un speedup de 2.78e24x", "cls": "structural", "expect": "match", "kind": "TP", "source": "issue-9434", "note": "PR #9427 App-11-Picross. ANGLE-MORT MAJEUR: '2.78e24x' (notation scientifique + x) N'EST PAS matche par le scanner — xfail documente. La regex bute sur le '\\b' apres 'e24' avant le 'x'."},
+    {"id": "t2", "text": "acceleration de 4x", "cls": "structural", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "Forme canonique simple."},
+    {"id": "t3", "text": "gain de 1,5x", "cls": "structural", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "Virgule decimale francaise."},
+    {"id": "t4", "text": "ratio de plus de 300x", "cls": "structural", "expect": "match", "kind": "TP", "source": "issue-9434", "note": "Issue #9434 mentionne '300x' comme structurel legitime."},
+    {"id": "t5", "text": "ordre de grandeur 2.78e24", "cls": "structural", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "Notation scientifique SANS le 'x' — celle-la matche (frontiere revelant que c'est le 'x' apres 'e24' qui coince)."},
+    {"id": "t6", "text": "la variable x vaut 5", "cls": "structural", "expect": "nomatch", "kind": "TN", "source": "synthetic-boundary", "note": "TN propre: 'x' comme variable, pas un facteur."},
+    {"id": "t7", "text": "grille de 100x100 pixels", "cls": "structural", "expect": "nomatch", "kind": "TN", "source": "synthetic-boundary", "note": "TN propre: dimensions (WxH), pas un speedup. Le scanner ne matche PAS '100x100' car le \\b apres 'x' echoue (suivi du chiffre '1'). TN convergent — frontiere revelant que STRUCTURAL_RE est robuste aux dimensions."},
+    {"id": "t8", "text": "soit 16x plus rapide", "cls": "structural", "expect": "match", "kind": "TP", "source": "issue-9434", "note": "PR #9427 App-11-Picross ('~68x -> ~16x')."}
+  ]
+}

--- a/scripts/tests/test_golden_quantitative_claims.py
+++ b/scripts/tests/test_golden_quantitative_claims.py
@@ -1,0 +1,254 @@
+"""Golden set — validation du scanner check_prose_quantitative_claims.py (#9434).
+
+Le golden set (``golden_quantitative_claims.json``) est un ensemble de snippets de
+prose annotes a la main avec la ground-truth humaine (classe + expect match/nomatch).
+Ce test compare la ground truth au **comportement reel du scanner** en appelant la
+**meme fonction** (``_findings_in_text``) que le scanner utilise en production.
+
+Les cas ou le scanner actuel diverge de la ground truth (angles-mort connus) sont
+marques ``xfail`` avec un rationale documente. Un ``xfail`` n'est PAS un bug du test :
+c'est un angle-mort inventorie. Si le scanner est ameliore et matche enfin le cas,
+l'``xfail`` devient un echec (signaling) -> il faut alors le retirer.
+
+La logique seed (un carnet seme = reproductible = legitime) est validee separement
+via des fixtures mini-notebooks (on ne peut pas la tester au niveau texte seul).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# --- Import du scanner (meme fonction que la production) ------------------- #
+HERE = Path(__file__).resolve().parent
+NOTEBOOK_TOOLS = HERE.parent / "notebook_tools"
+sys.path.insert(0, str(NOTEBOOK_TOOLS))
+from check_prose_quantitative_claims import _findings_in_text, _notebook_is_seeded  # noqa: E402
+
+GOLDEN = HERE / "golden_quantitative_claims.json"
+
+
+# --- Angles-mort connus (scanner diverge de la ground truth) --------------- #
+# Ces cas DOIVENT matcher humainement mais le scanner actuel les rate.
+# Documentes pour prevenir qu'on les oublie ; xfail -> xpass signaling si fixe.
+XFAIL_KNOWN_GAPS: dict[str, str] = {
+    "m7": "ANGLE-MORT machine: '30s' sans \\ss (espace avant 's') n'est pas matche",
+    "s6": "ANGLE-MORT stochastic: 42.5 a 1 decimale, STOCHASTIC_NUM exige >=2",
+    "s8": "ANGLE-MORT stochastic: 'tentatives' hors KW + 1 decimale (App-7-Wordle)",
+    "t1": "ANGLE-MORT MAJEUR structural: '2.78e24x' (notation scientifique + x) "
+          "non matche — le \\b apres 'e24' coince avant le 'x' (App-11-Picross)",
+}
+
+
+def _load_cases() -> list[dict]:
+    data = json.loads(GOLDEN.read_text(encoding="utf-8"))
+    return data["cases"]
+
+
+CASES = _load_cases()
+
+
+# =========================================================================== #
+#  1. Cohherence du golden set lui-meme                                       #
+# =========================================================================== #
+
+
+def test_golden_set_has_expected_size():
+    """Le golden set cible >= 30 cas (mandat issue #9434 option alpha)."""
+    assert len(CASES) >= 30, f"Golden set trop petit: {len(CASES)} cas (< 30)"
+
+
+def test_golden_set_ids_unique():
+    ids = [c["id"] for c in CASES]
+    assert len(ids) == len(set(ids)), "IDs dupliques dans le golden set"
+
+
+def test_golden_set_covers_all_four_classes():
+    classes = {c["cls"] for c in CASES}
+    assert classes == {"machine", "env", "stochastic", "structural"}, (
+        f"Classes couvertes: {classes}"
+    )
+
+
+def test_golden_set_has_tp_and_tn_per_class():
+    """Chaque classe doit avoir au moins un cas qui matche (TP) et un TN."""
+    for cls in ("machine", "env", "stochastic", "structural"):
+        has_match = any(c["cls"] == cls and c["expect"] == "match" for c in CASES)
+        has_nomatch = any(c["cls"] == cls and c["expect"] == "nomatch" for c in CASES)
+        assert has_match, f"Classe {cls}: aucun cas expect=match (TP manquant)"
+        assert has_nomatch, f"Classe {cls}: aucun cas expect=nomatch (TN manquant)"
+
+
+def test_xfail_known_gaps_reference_real_cases():
+    """Chaque xfail declare pointe vers un cas reel du golden set."""
+    ids = {c["id"] for c in CASES}
+    for xfail_id in XFAIL_KNOWN_GAPS:
+        assert xfail_id in ids, f"XFAIL_KNOWN_GAPS reference un id absent: {xfail_id}"
+
+
+# =========================================================================== #
+#  2. Validation cas par cas (le coeur du golden set)                         #
+# =========================================================================== #
+
+
+def _scanner_matches(text: str, cls: str) -> bool:
+    """Le scanner reel trouve-t-il un finding de `cls` dans `text`?"""
+    findings = _findings_in_text(text, "golden-test", {cls})
+    return len(findings) > 0
+
+
+@pytest.mark.parametrize(
+    "case",
+    CASES,
+    ids=[c["id"] for c in CASES],
+)
+def test_scanner_matches_ground_truth(case):
+    """Pour chaque cas du golden set, le scanner doit respecter la ground truth.
+
+    Les angles-mort connus (XFAIL_KNOWN_GAPS) sont marques xfail : le scanner
+    actuel diverge, c'est inventorie. Si le scanner est ameliore, l'xfail echoue
+    (xpass strict) -> il faut retirer l'entree de XFAIL_KNOWN_GAPS.
+    """
+    case_id = case["id"]
+    expected_match = case["expect"] == "match"
+    actual_match = _scanner_matches(case["text"], case["cls"])
+
+    if case_id in XFAIL_KNOWN_GAPS:
+        # Angle-mort documente : on s'attend a ce que le scanner rate le cas.
+        pytest.xfail(XFAIL_KNOWN_GAPS[case_id])
+
+    assert actual_match == expected_match, (
+        f"[{case_id}] cls={case['cls']} expect={case['expect']} "
+        f"actual_match={actual_match} | text={case['text']!r} | note={case['note']}"
+    )
+
+
+# =========================================================================== #
+#  3. Logique seed (fixtures mini-notebooks)                                  #
+#  On ne peut pas tester au niveau texte: il faut un carnet.                  #
+# =========================================================================== #
+
+
+def _write_mini_notebook(path: Path, code_source: str) -> None:
+    """Cree un mini-notebook (1 cellule code) pour tester _notebook_is_seeded."""
+    nb = {
+        "cells": [
+            {"cell_type": "code", "execution_count": None,
+             "metadata": {}, "outputs": [],
+             "source": code_source},
+        ],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+
+def test_seeded_numpy_notebook_is_legitimate(tmp_path):
+    """Un carnet avec np.random.seed(...) est seme -> reproductible -> legitime."""
+    nb = tmp_path / "seeded_numpy.ipynb"
+    _write_mini_notebook(nb, "import numpy as np\nnp.random.seed(42)\nx = np.random.rand(5)")
+    assert _notebook_is_seeded(nb) is True
+
+
+def test_seeded_torch_notebook_is_legitimate(tmp_path):
+    """torch.manual_seed(...) rend aussi le carnet reproductible."""
+    nb = tmp_path / "seeded_torch.ipynb"
+    _write_mini_notebook(nb, "import torch\ntorch.manual_seed(0)\n_ = torch.rand(3)")
+    assert _notebook_is_seeded(nb) is True
+
+
+def test_seeded_random_state_sklearn_is_legitimate(tmp_path):
+    """random_state=42 (sklearn) est un seed -> legitime."""
+    nb = tmp_path / "seeded_sklearn.ipynb"
+    _write_mini_notebook(nb, "from sklearn.cluster import KMeans\nm = KMeans(random_state=42)")
+    assert _notebook_is_seeded(nb) is True
+
+
+def test_unseeded_notebook_is_not_legitimate(tmp_path):
+    """Un carnet sans seed -> stochastic non-reproductible -> a signaler."""
+    nb = tmp_path / "unseeded.ipynb"
+    _write_mini_notebook(nb, "import numpy as np\nx = np.random.rand(5)  # pas de seed")
+    assert _notebook_is_seeded(nb) is False
+
+
+def test_seeded_logic_independence_from_text_level():
+    """La logique seed est ORTHOGONALE a la detection texte: un carnet non-seede
+    avec 'fitness 41.71' en prose DOIT etre flagge, un carnet seede ne l'est pas.
+    Ce test documente la separation des deux niveaux (cf _meta.note_stochastic)."""
+    # Au niveau texte, 'fitness 41.71' est detecte (cooccurrence KW+NUM)
+    assert _scanner_matches("fitness moyen de 41.71", "stochastic") is True
+    # Mais c'est la logique seed du CARNET qui decide si c'est legitime —
+    # ce n'est pas testable au niveau texte (cf fixtures ci-dessus).
+
+
+# =========================================================================== #
+#  4. Metriques agregees (precision/recall par classe)                        #
+# =========================================================================== #
+
+
+def _confusion_for_class(cls: str) -> dict:
+    """Matrice de confusion du scanner sur les cas non-xfail d'une classe."""
+    tp = tn = fp = fn = 0
+    for c in CASES:
+        if c["cls"] != cls or c["id"] in XFAIL_KNOWN_GAPS:
+            continue
+        actual = _scanner_matches(c["text"], cls)
+        expected = c["expect"] == "match"
+        if expected and actual:
+            tp += 1
+        elif expected and not actual:
+            fn += 1
+        elif not expected and actual:
+            fp += 1
+        else:
+            tn += 1
+    return {"tp": tp, "tn": tn, "fp": fp, "fn": fn}
+
+
+def test_scanner_precision_recall_per_class():
+    """Sur les cas non-xfail, le scanner doit etre parfait (precision=recall=1).
+
+    C'est le contrat du golden set: les cas non-xfail sont des frontieres ou le
+    scanner est cense etre exact. Toute deviation ici = regression a investiguer.
+    Les angles-mort isoles dans XFAIL_KNOWN_GAPS ne penalisent pas cette metrique.
+    """
+    failures = []
+    for cls in ("machine", "env", "stochastic", "structural"):
+        cm = _confusion_for_class(cls)
+        precision = cm["tp"] / (cm["tp"] + cm["fp"]) if (cm["tp"] + cm["fp"]) else 1.0
+        recall = cm["tp"] / (cm["tp"] + cm["fn"]) if (cm["tp"] + cm["fn"]) else 1.0
+        if precision < 1.0 or recall < 1.0:
+            failures.append(
+                f"{cls}: precision={precision:.2f} recall={recall:.2f} cm={cm}"
+            )
+    assert not failures, (
+        "Le scanner n'est pas exact sur les frontieres non-xfail (regression):\n  "
+        + "\n  ".join(failures)
+    )
+
+
+def test_known_gap_count_is_documented():
+    """Anti-oubli: le nombre d'angles-mort doit correspondre au dict XFAIL.
+
+    Si on ajoute un cas xfail au golden set sans l'inventorier dans
+    XFAIL_KNOWN_GAPS (ou inversement), ce test echoue -> oblige a tenir le
+    registre a jour. C'est l'audit trail des angles-mort.
+    """
+    # Recalcule les divergences reelles (sans xfail precoce)
+    divergences = []
+    for c in CASES:
+        actual = _scanner_matches(c["text"], c["cls"])
+        expected = c["expect"] == "match"
+        if actual != expected:
+            divergences.append(c["id"])
+    assert set(divergences) == set(XFAIL_KNOWN_GAPS), (
+        f"Registre des angles-mort desynchronise.\n"
+        f"  Divergences reelles:    {sorted(divergences)}\n"
+        f"  XFAIL_KNOWN_GAPS declare: {sorted(XFAIL_KNOWN_GAPS)}\n"
+        f"  -> si un cas a commence a matcher (regression ou fixe), le retirer "
+        f"de XFAIL_KNOWN_GAPS ; si un nouvel angle-mort est trouve, l'inventorier."
+    )


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #9557

See #9434 (option alpha — validation du classifieur). Ne clot pas l'issue (le drainage des claims existants reste en cours sur d'autres fronts).

## Le livrable — golden set 32 cas pour valider le classifieur (#9434 option alpha)

Un ensemble de **32 cas** annotés à la main (ground-truth humaine) pour valider la précision du scanner `check_prose_quantitative_claims.py` sur les **4 classes** (machine/env/stochastic/structural). C'est l'option α de #9434 : valider le classifieur *avant* d'élargir son usage au drainage systématique.

Deux fichiers :

- **`golden_quantitative_claims.json`** : 32 cas (8 machine, 7 env, 9 stochastic, 8 structural). Chaque cas = `{id, text, cls, expect, source, note}`. Sources : 5 cas réels documentés dans le tableau de l'issue #9434 (App-7-Wordle, App-11-Picross, Search-5-GA, GT-4c) + cas réels piochés dans le dépôt + frontières synthétiques testant les bords de regex.
- **`test_golden_quantitative_claims.py`** : 44 tests (**40 passed, 4 xfailed**).

## Le test valide le VRAI scanner

Le test appelle la **même fonction** (`_findings_in_text`) que le scanner en production — pas une ré-implémentation. Sinon on validerait une copie, pas l'outil réel. Chaque cas du golden set → le scanner doit respecter la ground truth.

3 niveaux de test :

1. **Cas par cas** (paramétré, 32 tests) : `_findings_in_text(text, {cls})` doit respecter `expect`.
2. **Logique seed** (4 fixtures mini-notebooks) : un carnet seedé (np/torch/sklearn) = reproductible = légitime ; non-seedé = à signaler. Valide que la légitimité-seed est **orthogonale** à la détection texte (non testable au niveau texte seul).
3. **Audit trail** : `test_known_gap_count_is_documented` vérifie que le registre des angles-mort (`XFAIL_KNOWN_GAPS`) reste synchronisé avec les divergences réelles du scanner.

## 4 angles-mort inventoriés (xfail, pas des bugs du test)

| ID | Classe | Cas | Pourquoi le scanner rate |
|----|--------|-----|--------------------------|
| m7 | machine | `30s` | pas de `\ss` (espace avant `s`) |
| s6 | stochastic | `42.5` | 1 décimale, `STOCHASTIC_NUM` exige ≥2 |
| s8 | stochastic | `3.3 tentatives` | `tentatives` hors KW + 1 décimale (App-7-Wordle) |
| t1 | structural | `2.78e24x` | **ANGLE-MORT MAJEUR** — le `\b` après `e24` coince avant le `x` (App-11-Picross) |

Un xfail est un angle-mort **inventorié**. Si le scanner est amélioré et matche enfin le cas, l'xfail devient un échec (signaling) → il faut alors le retirer du registre. C'est la valeur du golden set : il **quantifie la précision** (precision=recall=1.0 sur les 28 cas non-xfail) ET **documente honnêtement** les 4 limites actuelles du classifieur.

## Validation data-verifiable

- **Tests** : `python -m pytest scripts/tests/test_golden_quantitative_claims.py` → **40 passed, 4 xfailed in 0.28s**.
- **Régression** : `python -m pytest scripts/tests/` → **1965 passed, 18 skipped, 4 xfailed** (les 4 xfails sont ceux du golden set). 0 régression.
- **Scope** : 2 nouveaux fichiers (+310 lignes), **0 fichier existant modifié**, **catalogue byte-identique à main** (HARD 1).
- **CPU-only** : stdlib json + pytest seul (règle F OK).
- **Pas de twin** (test + data, pas de notebook twinned).
- **Base fraîche** : worktree `feature/golden-quant-claims-9434` créé depuis `origin/main` (fc0aee474, post-#9505) — HARD 2.
- **Grain tag** : dans ce body (variation-protocol), pas dans le code.

## Hors scope (délibéré)

- **Fix des 4 angles-mort** (ex: matcher `2.78e24x` dans STRUCTURAL_RE) : PR distincte. Le golden set les *inventorie* d'abord — fixer sans harnais de validation = risquer de casser les 28 cas qui convergent. L'ordre est : harnais (cette PR) → fix ciblé → vérifier que l'xfail devient xpass → retirer du registre.
- **Drainage des claims existants** dans les notebooks du dépôt : autre front de #9434 (d'autres PR y travaillent).

## R6 / Variété

`MED/tooling` (substance — harnais de validation qui devient le guard anti-régression du classifieur, pas nettoyage) après `MED/tooling #9557` (basin_geometry). Rotation de **famille** ICT (#9553/#9557) → tooling/scripts (#9434) ; même tier MED. Le plafond « nettoyage/doc 1 item/lane/jour » ne s'applique pas (c'est du tooling de substance, pas un à-côté).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
