### PR TITLE
feat(lean,#3846): evolve_box_agree — tight Chebyshev-box locality (c.91 redesign, sorry-free)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
@@ -384,6 +384,87 @@ theorem evolve_reach_chebyshev (t : Nat) (g : Grid) (q : Int × Int)
       have hrq_cheb : chebDist r q ≤ 1 := chebDist_le_one_of_moore r q hrq
       exact (chebDist_triangle p q r).trans (add_le_add hpr hrq_cheb)
 
+/-! ## Localité étroite (forme boîte Chebyshev) — dual d'accord de `evolve_reach_chebyshev`
+
+Le théorème d'atteinte étroit (`evolve_reach_chebyshev` ci-dessus) dit : si `q`
+est vivante après `t` générations, alors une cellule initialement vivante se
+trouve dans la boîte Chebyshev-`t` de `q`. Le **dual d'accord** manquant —
+nommé par le greenlight N2 étape 2 (c.91, redesign borné #3846) — est la
+réciproque opérationnelle : si deux grilles coïncident sur une boîte
+Chebyshev, leurs évolutions coïncident au centre. C'est le lemme-clé du
+redesign : la marge *étroite* `2^(k-1)` de la fenêtre centrale du supercell
+suffit pour un saut de `2^(k-1)` générations, alors que le cône Manhattan
+*lâche* `2*(2^(k-1))` déborde la fenêtre (le verdict « obstruction C » de la
+carte c.8124 était le symptôme de cette sur-marge). EPIC #3846. Sans sorry.
+-/
+
+/-- **Localité étroite à pas unique (forme boîte Chebyshev-1).** Si deux grilles
+    `g₁ g₂` coïncident sur la boîte Chebyshev de rayon 1 autour de `p` (la
+    cellule et ses huit voisins de Moore), alors après une étape elles ont la
+    même vivacité en `p`.
+
+    C'est l'analogue étroit de `step_local` (`HashlifeCorrectness` L901), qui
+    demandait le cône Manhattan-`2` *lâche* (13 cellules en diamant). Ici la
+    boîte Chebyshev-`1` *étroite* (9 cellules en carré) suffit : le voisinage
+    de Moore EST exactement la boule unité Chebyshev. -/
+theorem step_box_local (g₁ g₂ : Grid) (p : Int × Int)
+    (h_box : ∀ q, chebDist p q ≤ 1 → isAlive g₁ q = isAlive g₂ q) :
+    isAlive (step g₁) p = isAlive (step g₂) p := by
+  have h_self : isAlive g₁ p = isAlive g₂ p := by
+    apply h_box p
+    have heq : chebDist p p = 0 := chebDist_self p
+    omega
+  have h_nbrs : ∀ q ∈ mooreNeighbors p, isAlive g₁ q = isAlive g₂ q := by
+    intro q hq
+    exact h_box q (chebDist_le_one_of_moore p q hq)
+  have h_alive : aliveNext g₁ p = aliveNext g₂ p :=
+    aliveNext_local g₁ g₂ p h_self h_nbrs
+  rw [isAlive_step_eq_aliveNext, isAlive_step_eq_aliveNext, h_alive]
+
+/-- **Localité étroite (forme boîte Chebyshev, multi-étapes).** Si deux grilles
+    `g₁ g₂` coïncident sur la boîte Chebyshev de rayon `u` autour de `p` — i.e.
+    sur toute cellule `q` avec `chebDist p q ≤ u` — alors après `u` générations
+    d'évolution elles ont la même vivacité en `p`.
+
+    C'est l'analogue étroit de `step_light_cone` (`HashlifeCorrectness` L931),
+    qui demandait le cône Manhattan *lâche* de rayon `2*u` (un facteur 2 perdu).
+    Ici la boîte Chebyshev *étroite* de rayon `u` suffit exactement : une
+    génération B3/S23 étend la portée d'une coque de Moore (= boule unité
+    Chebyshev), donc `u` générations atteignent exactement le rayon Chebyshev
+    `u`. C'est le lemme-clé du redesign borné (#3846, c.91) : la marge nulle
+    `2^(k-1)` de la fenêtre centrale du supercell suffit pour un saut de
+    `2^(k-1)` générations, là où le cône Manhattan débordait.
+
+    Preuve par récurrence sur `u` (généralisée en `p`), mirant `step_light_cone`
+    mais avec `chebDist` au lieu de `manhattan`/`lightCone` :
+    - Base `u = 0` : `evolve 0 g = g`, et `chebDist p p = 0 ≤ 0`.
+    - Pas `u = n + 1` : `evolve (n+1) g = step (evolve n g)`. Par
+      `step_box_local`, il suffit que `evolve n g₁` et `evolve n g₂`
+      coïncident sur la boîte Chebyshev-`1` de `p`. Pour chaque tel `q`
+      (`chebDist p q ≤ 1`), l'HR (en `q`, rayon `n`) donne l'accord sous
+      `∀ r, chebDist q r ≤ n → isAlive g₁ r = isAlive g₂ r`, qui découle de
+      l'hypothèse au rayon `n+1` par `chebDist_triangle` :
+      `chebDist p r ≤ chebDist p q + chebDist q r ≤ 1 + n`. -/
+theorem evolve_box_agree (u : Nat) (g₁ g₂ : Grid) (p : Int × Int)
+    (h_box : ∀ q, chebDist p q ≤ u → isAlive g₁ q = isAlive g₂ q) :
+    isAlive (evolve u g₁) p = isAlive (evolve u g₂) p := by
+  induction u generalizing p with
+  | zero =>
+    simp only [evolve_zero]
+    have hpp : chebDist p p ≤ 0 := by
+      have heq : chebDist p p = 0 := chebDist_self p
+      omega
+    exact h_box p hpp
+  | succ n ih =>
+    simp only [evolve_succ]
+    apply step_box_local
+    intro q hpq
+    apply ih
+    intro r hqr
+    apply h_box r
+    have htri : chebDist p r ≤ chebDist p q + chebDist q r := chebDist_triangle p r q
+    omega
+
 /-! ## Couronnement N2 étape 3 : portée Chebyshev étroite ⊆ marge padCenter2
 
 La composition du théorème d'atteinte étroit (`evolve_reach_chebyshev`, une

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone_en.lean
@@ -237,6 +237,86 @@ theorem evolve_reach_chebyshev (t : Nat) (g : Grid) (q : Int × Int)
       have hrq_cheb : chebDist r q ≤ 1 := chebDist_le_one_of_moore r q hrq
       exact (chebDist_triangle p q r).trans (add_le_add hpr hrq_cheb)
 
+/-! ## Tight locality (Chebyshev-box form) — agreement dual of `evolve_reach_chebyshev`
+
+The tight reach theorem (`evolve_reach_chebyshev` above) says: if `q` is alive
+after `t` generations, then an initially-live cell lies in the Chebyshev-`t` box
+of `q`. The missing **agreement dual** — named by the N2 step-2 greenlight
+(c.91, bounded redesign #3846) — is the operational converse: if two grids
+coincide on a Chebyshev box, their evolutions coincide at the center. This is
+the redesign's key lemma: the *tight* margin `2^(k-1)` of the supercell's
+central window suffices for a `2^(k-1)`-generation jump, whereas the *loose*
+Manhattan cone `2*(2^(k-1))` spills outside the window (the "obstruction C"
+verdict of the c.8124 map was the symptom of that over-margin). EPIC #3846.
+Sorry-free.
+-/
+
+/-- **Tight single-step locality (Chebyshev-box-1 form).** If two grids `g₁ g₂`
+    coincide on the Chebyshev-1 box around `p` (the cell and its eight Moore
+    neighbors), then after one step they have the same liveness at `p`.
+
+    This is the tight analogue of `step_local` (`HashlifeCorrectness` L901),
+    which required the *loose* Manhattan-`2` cone (13 diamond cells). Here the
+    *tight* Chebyshev-`1` box (9 square cells) suffices: the Moore neighborhood
+    IS exactly the Chebyshev unit ball. -/
+theorem step_box_local (g₁ g₂ : Grid) (p : Int × Int)
+    (h_box : ∀ q, chebDist p q ≤ 1 → isAlive g₁ q = isAlive g₂ q) :
+    isAlive (step g₁) p = isAlive (step g₂) p := by
+  have h_self : isAlive g₁ p = isAlive g₂ p := by
+    apply h_box p
+    have heq : chebDist p p = 0 := chebDist_self p
+    omega
+  have h_nbrs : ∀ q ∈ mooreNeighbors p, isAlive g₁ q = isAlive g₂ q := by
+    intro q hq
+    exact h_box q (chebDist_le_one_of_moore p q hq)
+  have h_alive : aliveNext g₁ p = aliveNext g₂ p :=
+    aliveNext_local g₁ g₂ p h_self h_nbrs
+  rw [isAlive_step_eq_aliveNext, isAlive_step_eq_aliveNext, h_alive]
+
+/-- **Tight locality (Chebyshev-box form, multi-step).** If two grids `g₁ g₂`
+    coincide on the Chebyshev box of radius `u` around `p` — i.e. on every cell
+    `q` with `chebDist p q ≤ u` — then after `u` generations of evolution they
+    have the same liveness at `p`.
+
+    This is the tight analogue of `step_light_cone` (`HashlifeCorrectness` L931),
+    which required the *loose* Manhattan cone of radius `2*u` (a factor of 2
+    lost). Here the *tight* Chebyshev box of radius `u` suffices exactly: one
+    B3/S23 generation extends the reach by one Moore shell (= Chebyshev unit
+    ball), so `u` generations reach exactly Chebyshev radius `u`. This is the
+    key lemma of the bounded redesign (#3846, c.91): the zero-margin `2^(k-1)`
+    of the supercell's central window suffices for a `2^(k-1)`-generation jump,
+    where the Manhattan cone would spill over.
+
+    Proof by induction on `u` (generalized over `p`), mirroring `step_light_cone`
+    but with `chebDist` instead of `manhattan`/`lightCone`:
+    - Base `u = 0`: `evolve 0 g = g`, and `chebDist p p = 0 ≤ 0`.
+    - Step `u = n + 1`: `evolve (n+1) g = step (evolve n g)`. By
+      `step_box_local`, it suffices that `evolve n g₁` and `evolve n g₂`
+      coincide on the Chebyshev-`1` box of `p`. For each such `q`
+      (`chebDist p q ≤ 1`), the IH (at `q`, radius `n`) gives agreement under
+      `∀ r, chebDist q r ≤ n → isAlive g₁ r = isAlive g₂ r`, which follows from
+      the radius-`n+1` hypothesis via `chebDist_triangle`:
+      `chebDist p r ≤ chebDist p q + chebDist q r ≤ 1 + n`. -/
+theorem evolve_box_agree (u : Nat) (g₁ g₂ : Grid) (p : Int × Int)
+    (h_box : ∀ q, chebDist p q ≤ u → isAlive g₁ q = isAlive g₂ q) :
+    isAlive (evolve u g₁) p = isAlive (evolve u g₂) p := by
+  induction u generalizing p with
+  | zero =>
+    simp only [evolve_zero]
+    have hpp : chebDist p p ≤ 0 := by
+      have heq : chebDist p p = 0 := chebDist_self p
+      omega
+    exact h_box p hpp
+  | succ n ih =>
+    simp only [evolve_succ]
+    apply step_box_local
+    intro q hpq
+    apply ih
+    intro r hqr
+    apply h_box r
+    have htri : chebDist p r ≤ chebDist p q + chebDist q r := chebDist_triangle p r q
+    omega
+
 /-! ## N2 step 3 capstone: tight Chebyshev reach ⊆ padCenter2 margin
 
 Composing the tight reach theorem (`evolve_reach_chebyshev`, one Moore shell


### PR DESCRIPTION
## feat(lean,#3846): evolve_box_agree — tight Chebyshev-box locality (c.91 redesign, sorry-free)

**Grain:** DEEP/lean — lane myia-po-2026:CoursIA — delivers the pre-authorized `evolve_box_agree` steer (ai-01 msg-011051/012042, c.91 bounded redesign). `See #3846`, `See #6724`.

### What (2 new sorry-free lemmas, FR + `_en` mirror)

**`step_box_local`** — tight single-step locality (Chebyshev-box-1): if `g₁ g₂` coincide on the Chebyshev-1 box around `p` (the cell + its 8 Moore neighbors = 9 square cells), then `isAlive (step g₁) p = isAlive (step g₂) p`.

**`evolve_box_agree`** — tight multi-step locality: if `g₁ g₂` coincide on the Chebyshev box of radius `u` around `p` (`∀ q, chebDist p q ≤ u → isAlive g₁ q = isAlive g₂ q`), then `isAlive (evolve u g₁) p = isAlive (evolve u g₂) p`.

Placed in `LightCone.lean` (the Chebyshev↔Manhattan bridge module, right after `evolve_reach_chebyshev`), + `LightCone_en.lean` mirror. **0 lines deleted, 0 sorry added.** Pure additions (+161).

### Why (the c.91 redesign key — fills a named gap)

`evolve_reach_chebyshev` (LightCone.lean, sorry-free, on main) proves the tight **reach** (Chebyshev radius `t`). The matching tight **agreement** lemma was **missing** — only the **loose** agreement (`step_light_cone`/`evolve_cone_agree`, Manhattan radius `2*t`) existed. This PR fills that gap.

Why it matters for the c.91 redesign (#3846): the bounded p4 wall re-statements need a locality transport that fits **exactly** in the supercell's central window `[2^(k-1), 5·2^(k-1))` for a `2^(k-1)`-generation jump. The loose Manhattan cone `2*(2^(k-1))` **spills outside** (the "obstruction C" of the c.8124 map was the symptom). The tight Chebyshev box `2^(k-1)` fits with **zero margin** — this lemma is the transport.

### Proof (induction on `u` generalizing `p`, mirrors `step_light_cone`)

**`step_box_local`**: `aliveNext_local` (agree on `{p} ∪ mooreNeighbors p` → `aliveNext g₁ p = aliveNext g₂ p`) + `chebDist_le_one_of_moore` (Moore neighbor ⇒ chebDist ≤ 1) + `isAlive_step_eq_aliveNext`. The Moore neighborhood IS exactly the Chebyshev unit ball.

**`evolve_box_agree`** by induction on `u`:
- Base `u=0`: `evolve 0 g = g`, `chebDist p p = 0 ≤ 0`.
- Step `u=n+1`: `evolve (n+1) = step ∘ evolve n`. By `step_box_local`, need agreement of `evolve n g₁, evolve n g₂` on the Chebyshev-1 box of `p`. For each such `q` (chebDist p q ≤ 1), the IH at `q` (radius `n`) needs agreement of `g₁,g₂` on the Chebyshev-`n` box of `q`; by `chebDist_triangle`, `chebDist p r ≤ chebDist p q + chebDist q r ≤ 1 + n`, so the radius-`(n+1)` hypothesis covers it.

All ingredients sorry-free and pre-existing (`chebDist_self`, `chebDist_triangle`, `chebDist_le_one_of_moore`, `aliveNext_local`, `isAlive_step_eq_aliveNext`, `evolve_succ`, `evolve_zero`). No new sorry, no axiom.

### G.9 / c.91 method note

The statement is the standard cellular-automaton speed-of-light locality — the **agreement dual** of `evolve_reach_chebyshev` (already proven sorry-free on main). It is NOT at risk of the c.91 free-variable trap (#9565: the p4 walls were FALSE because `p : Int × Int` was free while the supercell covers only the central window). `evolve_box_agree` is a universal locality theorem over the full `Int × Int` grid — no window constraint in its statement, so the #9565 failure mode does not apply.

### Verification

| Check | Result |
|-------|--------|
| `lake build Conway.Life.LightCone` (FR, origin/main base `b20ba9bc2`, cold Conway chain) | **Build completed successfully (8506 jobs), EXIT=0, 374s** |
| FR/EN byte-identity (statements + proofs) | confirmed via structural diff (both theorems IDENTICAL) |
| sorry count | +0 (pure additions; the `grep sorry` hits are prose "sans sorry"/"Sorry-free" in docstrings, 0 tactic sorries) |
| `#print axioms step_box_local` | **`[propext, Classical.choice, Quot.sound]`** — standard defaults, 0 native_decide axiom |
| `#print axioms evolve_box_agree` | **`[propext, Classical.choice, Quot.sound]`** — standard defaults, 0 native_decide axiom |
| gate impact (lean-conway.yml) | none — `LightCone` not in any target-modules; yml byte-identical to origin/main |

See #3846 (bounded redesign), See #6724 (c.91 — p4 walls FALSE as stated; this lemma is the locality transport for the re-statements), See #9565 (machine-checked refutation that motivates the redesign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
