### PR TITLE
fix(search,#9434): drain BT/FC/MAC frozen-dup ms from CSP-2 prose (consistency propagation)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
@@ -2468,15 +2468,15 @@
     "\n",
     "**Sortie obtenue** (cellule precedente) : sur le **vrai** probleme des 8-Reines (contraintes de rangees **et** de diagonales), la cascade de propagation se traduit directement en noeuds explores :\n",
     "\n",
-    "| Technique | Noeuds explores | Temps |\n",
-    "|-----------|-----------------|-------|\n",
-    "| BT (sans propagation) | 876 | ~5,4 ms |\n",
-    "| FC (forward checking) | 75 | ~2,6 ms |\n",
-    "| MAC (AC-3 complet) | 20 | ~3,4 ms |\n",
+    "| Technique | Noeuds explores |\n",
+    "|-----------|-----------------|\n",
+    "| BT (sans propagation) | 876 |\n",
+    "| FC (forward checking) | 75 |\n",
+    "| MAC (AC-3 complet) | 20 |\n",
     "\n",
     "MAC explore **44x moins** de noeuds que le backtracking naif, et FC environ **12x moins**. La propagation **en cascade** d AC-3 (qui se diffuse transitivement a toutes les variables liees apres chaque assignation) elimine des branches entieres que BT ne decouvre mortes qu en les parcourant noeud par noeud. FC, qui ne propage qu au voisinage direct de la variable assignee, se situe entre les deux : mieux que BT, sans la propagation transitive de MAC.\n",
     "\n",
-    "**Regle pratique** : sur des problemes fortement contraints (peu de solutions, graphe de contraintes dense comme les N-Reines), le surcout d AC-3 apres chaque assignation est largement compense par les noeuds evites -- ici MAC est meme plus rapide en temps mural (3,4 ms vs 5,4 ms) malgre le cout de propagation. Sur des problemes faiblement contraints, ce surcout peut rendre MAC plus lent que FC en temps mural meme s il explore moins de noeuds. Le choix depend du ratio **cout de propagation / cout d un noeud explore**."
+    "**Regle pratique** : sur des problemes fortement contraints (peu de solutions, graphe de contraintes dense comme les N-Reines), le surcout d AC-3 apres chaque assignation est largement compense par les noeuds evites -- ici MAC explore 44x moins de noeuds que BT malgre le cout de propagation. Sur des problemes faiblement contraints, ce surcout peut rendre MAC plus lent que FC en temps mural meme s il explore moins de noeuds. Le choix depend du ratio **cout de propagation / cout d un noeud explore**."
    ]
   },
   {
@@ -2742,7 +2742,7 @@
     "| **Backtracking** | Aucune | O(1) | 876 |\n",
     "| **Forward Checking** | Domaines des voisins directs | O(d * deg) | 75 |\n",
     "| **MAC** | AC-3 complet | O(e * d^3) | 20 |\n",
-    "**Source des chiffres** : `876 / 75 / 20` sont les **vraies mesures** observees dans ce notebook (cellule `Comparaison BT vs FC vs MAC sur 8-Reines`, sortie kernel `.net-csharp` via `dotnet-interactive 1.0.707101`) apres execution complete des trois solveurs. Voir la cellule d'interpretation \"MAC domine\" plus haut pour le tableau `BT=876 / FC=75 / MAC=20` avec temps d'execution associes (5,4 ms / 2,6 ms / 3,4 ms). Les ratios derives : **MAC explore 44x moins de noeuds que BT** (876/20 = 43,8) et **FC environ 12x moins** (876/75 = 11,7).\n",
+    "**Source des chiffres** : `876 / 75 / 20` sont les **vraies mesures** observees dans ce notebook (cellule `Comparaison BT vs FC vs MAC sur 8-Reines`, sortie kernel `.net-csharp` via `dotnet-interactive 1.0.707101`) apres execution complete des trois solveurs. Voir la cellule d'interpretation \"MAC domine\" plus haut pour le tableau `BT=876 / FC=75 / MAC=20` avec temps d'execution associes (ms live produits par la cellule de benchmark -- regle #9434, non figes en prose car machine-dependants). Les ratios derives : **MAC explore 44x moins de noeuds que BT** (876/20 = 43,8) et **FC environ 12x moins** (876/75 = 11,7).\n",
     "\n",
     "### Choco-solver vs implementations custom\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/csp-2-consistency.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-2-consistency.yaml
@@ -8,6 +8,12 @@
       by: myia-po-2023:CoursIA
       python_sha: e4bcb98f9b804b32f5116fdb79e253b7488cd030
       csharp_sha: e8fd63183edffb0de5cb32c437c1b4bbcdc8b688
+    - date: "2026-08-06"
+      by: myia-po-2023:CoursIA
+      python_sha: e4bcb98f9b804b32f5116fdb79e253b7488cd030
+      csharp_sha: 6d5e97dcecf99e4e5a9ae1881ba520072808d4d1
+      content_python_sha: f804bda0e8779cecd9234bef5ebdfe1bde4f1c5ff07f4db572579a3fafdc642d
+      content_csharp_sha: 15254f5d996c1c1b5ec961b8c1e9e1daaa88a500ee1ada38aca8eaf0696db073
   known_differences:
     - "Socle pedagogique commun : node consistency + AC-3 + Forward Checking + MAC, implementes from-scratch des deux cotes."
     - "Cote C# : extension Choco-solver 4.10.17 via IKVM 8.15.0 (memes recettes infrastructure que CSP-1) pour comparer les algorithmes custom avec la propagation native de Choco (variable x, contrainte arithmetique, model.getSolver().propagate())."


### PR DESCRIPTION
Grain: LIGHT/notebook-csharp — lane myia-po-2023:CoursIA — prev: MED/notebook-markdown #9578 (Tweety-2)

See #9434 (drainage des timings machine-dépendants). Ne clot pas l'epic. **Rotation famille R6** : Search/CSP (.NET C#, AC-3 / forward-checking / MAC, jamais touchée par moi).

## Le livrable — drainage CSP-2-Consistency-Csharp.ipynb (table BT/FC/MAC)

Les cellules markdown **43** (« Interpretation : MAC domine ») et **51** (« Récapitulatif ») figeaient des temps muraux machine-dépendants (**~5,4 ms / ~2,6 ms / ~3,4 ms**) = **frozen dups des outputs live** de la cellule code 42 (benchmark BT/FC/MAC sur 8-Reines via `dotnet-interactive`). Ces timings **dérivent avec la machine** (CPU, version .NET/IKVM, charge) → règle #9434 (la prose défère au code live, ne fige pas les timings).

**Drainage markdown-only** (raw-JSON `text.replace`, mirror #9507 / #9574 / #9578) :
- **cell 43 table BT/FC/MAC** : colonne « Temps » retirée, **GARDE les node counts DÉTERMINISTES** (876 / 75 / 20 — backtracking nodes, reproductible cross-machine) ;
- prose « temps mural (3,4 ms vs 5,4 ms) » → reframe « MAC explore 44× moins de nœuds » (ratio structurel stable) ;
- **cell 51** référence « (5,4 ms / 2,6 ms / 3,4 ms) » → pointeur live (règle #9434).
- **Ratios structurels CONSERVÉS** partout (MAC 44× moins, FC 12× moins).

## Règle 6 (Stop & Repair) — outputs PRESERVÉS

Les **OUTPUTS des cellules code** (ex. `876 noeuds, 5,4 ms` dans la sortie kernel `.net-csharp`) sont **PRESERVÉS intacts** — ce sont les **mesures live légitimes** (règle 6 : jamais hand-éditer une sortie de cellule). Seule la **PROSE markdown** qui re-figeait ces timings est drainée. C'est la distinction canonique #9434 : le code mesure (outputs = source de vérité), la prose ne duplique pas.

## Validation data-verifiable (scanner #9434)

`check_prose_quantitative_claims.py --all --class machine --root MyIA.AI.Notebooks/Search/Part2-CSP` :

| Notebook | AVANT (origin/main) | APRES (cette PR) |
|----------|---------------------|------------------|
| **CSP-2-Consistency-Csharp.ipynb** | 15 claims machine (~5,4 ms, ~2,6 ms, ~3,4 ms, 5,4 ms / 2,6 ms / 3,4 ms) | **7 claims résiduels TN légitimes** |

**Les 7 claims résiduels sont des TN légitimes** :
- `60 minutes` = **durée pédagogique** totale du notebook ;
- `~5 min` / `~8 min` / `~12 min` = **durées des sections** (Node/Arc Consistency, Forward Checking, MAC) ;
- `1 ms` / `50 ms` (cell 30) = **bounds qualitatifs** `<1 ms` / `<50 ms` = overhead IKVM structural (claim de connaissance du domaine, pas une mesure figée).

Les 6 ms précis frozen dups (5,4/2,6/3,4 × 2 cells) = **drainés**.

## Méthode — raw-JSON text.replace (pas json.dumps)

Édition **markdown-only** → exception C.2 (outputs précédents valides, pas de re-execution). Méthode **raw-JSON `text.replace`** (7 remplacements, chacun `count == 1`) et NON `json.dumps` : ce notebook a un polyfill JS dans la cellule 0 dont les trailing-whitespace-only lines sont normalisées par `json.dumps(indent=1)` (→ 5 hunks spurious hors-scope en début de fichier). Le raw-JSON touche **uniquement** les 2 hunks des cells 43/51 (diff scope vérifié clean). JSON validé post-édition.

## Twin-parity — registre rebaselined

`scripts/notebook_tools/twin_pairs.d/csp-2-consistency.yaml` : nouvelle audit entry (2026-08-06, par myia-po-2023:CoursIA). Le twin Python (`CSP-2-Consistency.ipynb`) n'est pas touché.

## Validation & scope

- **Scope** : 2 fichiers (notebook markdown drainage + twin-parity YAML), +13/−7. **0 fichier existant touché ailleurs**.
- **Catalogue byte-identique à main** (HARD 1).
- **CPU-only** : markdown-only, pas de re-execution (exception C.2).
- **Base fraîche** : worktree créé depuis `origin/main` (`b20ba9bc2`) — HARD 2.
- **Collision guard** : aucune PR ouverte ne touche CSP-2 (clean, re-vérifié avant push). J'évite App-11-Picross (prochain candidat probable d'un autre drain, exemple canonique #9434).

## R6 / Variété — transparence

Rotation de famille : après Sudoku (Z3) + Tweety (SAT), ce grain porte sur **Search/CSP** (.NET C#, AC-3 consistency propagation). Le coordinateur/user sweep activement la veine #9434 (PRs #9581 App-1, #9576 Search-5) — je pioche une cible non-collisionnée. **Track de fond parallèle** : cold-build Mathlib Lean lancé en BG ce cycle (worktree dédié) pour casser le blocage Lean persistant et permettre l'authoring de théorème next-cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
