### PR TITLE
feat(lean,#8869): flip Spaceships native_decide -> kernel decide (c.91, 0 axiom)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Spaceships.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Spaceships.lean
@@ -17,8 +17,8 @@ Convention de coordonnees (heritee de `Conway.Life`) :
 - Chaque cellule est une paire `(row, col) : Int × Int`.
 - Les motifs sont stockes en `List (Int × Int)` dans l'ordre
   lexicographique trie (row d'abord, puis col) pour que `step`
-  produise une liste dans le meme ordre, permettant a
-  `native_decide` de verifier l'egalite par comparaison structurelle.
+  produise une liste dans le meme ordre, permettant au `decide` du
+  noyau de verifier l'egalite par comparaison structurelle.
 - Un deplacement `(dr, dc)` translate chaque cellule de `dr` lignes
   et `dc` colonnes. Les vaisseaux ci-dessous vont vers l'est :
   `dr = 0`, `dc = 2`.
@@ -69,7 +69,7 @@ def lwss : Grid :=
 #eval isSpaceship lwss 4 (0, 2)
 
 /-- The LWSS is a spaceship of period 4 and displacement `(0, 2)`. -/
-theorem lwss_spaceship : isSpaceship lwss 4 (0, 2) = true := by native_decide
+theorem lwss_spaceship : isSpaceship lwss 4 (0, 2) = true := by decide
 
 /-! ## Vaisseau moyen (MWSS)
 
@@ -101,7 +101,7 @@ def mwss : Grid :=
 #eval isSpaceship mwss 4 (0, 2)
 
 /-- The MWSS is a spaceship of period 4 and displacement `(0, 2)`. -/
-theorem mwss_spaceship : isSpaceship mwss 4 (0, 2) = true := by native_decide
+theorem mwss_spaceship : isSpaceship mwss 4 (0, 2) = true := by decide
 
 /-! ## Vaisseau lourd (HWSS)
 
@@ -133,7 +133,7 @@ def hwss : Grid :=
 #eval isSpaceship hwss 4 (0, 2)
 
 /-- The HWSS is a spaceship of period 4 and displacement `(0, 2)`. -/
-theorem hwss_spaceship : isSpaceship hwss 4 (0, 2) = true := by native_decide
+theorem hwss_spaceship : isSpaceship hwss 4 (0, 2) = true := by decide
 
 end Life
 end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Spaceships_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Spaceships_en.lean
@@ -16,7 +16,7 @@ Coordinate convention (inherited from `Conway.Life`):
 - Each cell is a pair `(row, col) : Int × Int`.
 - Patterns are stored as `List (Int × Int)` in sorted lexicographic order
   (row first, then column) so that `step` produces a list in the same
-  order, enabling `native_decide` to verify equality by structural
+  order, enabling kernel `decide` to verify equality by structural
   comparison.
 - A displacement `(dr, dc)` shifts every cell by `dr` rows and `dc`
   columns. The spaceships below are east-bound: `dr = 0`, `dc = 2`.
@@ -68,7 +68,7 @@ def lwss : Grid :=
 #eval isSpaceship lwss 4 (0, 2)
 
 /-- The LWSS is a spaceship of period 4 and displacement `(0, 2)`. -/
-theorem lwss_spaceship : isSpaceship lwss 4 (0, 2) = true := by native_decide
+theorem lwss_spaceship : isSpaceship lwss 4 (0, 2) = true := by decide
 
 /-! ## Middleweight Spaceship (MWSS)
 
@@ -100,7 +100,7 @@ def mwss : Grid :=
 #eval isSpaceship mwss 4 (0, 2)
 
 /-- The MWSS is a spaceship of period 4 and displacement `(0, 2)`. -/
-theorem mwss_spaceship : isSpaceship mwss 4 (0, 2) = true := by native_decide
+theorem mwss_spaceship : isSpaceship mwss 4 (0, 2) = true := by decide
 
 /-! ## Heavyweight Spaceship (HWSS)
 
@@ -132,7 +132,7 @@ def hwss : Grid :=
 #eval isSpaceship hwss 4 (0, 2)
 
 /-- The HWSS is a spaceship of period 4 and displacement `(0, 2)`. -/
-theorem hwss_spaceship : isSpaceship hwss 4 (0, 2) = true := by native_decide
+theorem hwss_spaceship : isSpaceship hwss 4 (0, 2) = true := by decide
 
 end Life_en
 end Conway_en


### PR DESCRIPTION
Flip the 3 period-4 spaceship theorems (lwss/mwss/hwss) from `native_decide` to kernel `decide` (+ rewrite the module docstring's false claim that `native_decide` is required). MEASURED via `lake build` (no `maxRecDepth`, unlike the pulsar). `#print axioms` = 'does not depend on any axioms' on all 3 (FR+EN), 0 `native_decide`. FR/EN byte-identity on statements+proofs+tactics confirmed. Follows the Computation (#9544) + Oscillators (#9571) pattern; the glider on main already uses kernel decide.\n\nSee #8869, See #6724.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)