### PR TITLE
fix(ci): resync test pins desynced by in-flight merge collisions (main red)

### DIFF
--- a/scripts/lean/tests/test_proof_integrity_audit_wiring.py
+++ b/scripts/lean/tests/test_proof_integrity_audit_wiring.py
@@ -102,7 +102,16 @@ def test_audit_allowlists_native_decide_axioms():
     without review and turned `main` red until the widening was justified in
     writing. Raising it is only ever legitimate alongside that justification --
     a new name that is NOT attributable to a newly covered module means an
-    unproven `native_decide` slipped in, and the pin must stay put instead."""
+    unproven `native_decide` slipped in, and the pin must stay put instead.
+
+    **Shrunk to 41 by #9571** (`feat(lean,#8869)`): the ceilLog2 rewrite (#9536)
+    made kernel `decide` tractable for the 5 Oscillators still-life theorems
+    (`loaf|boat|tub|pond|ship_still_life`), which were flipped from
+    `native_decide` to `decide` — their 5 axiom names genuinely left the
+    build-enumerated footprint. A shrink attributable to a native_decide ->
+    decide flip is the virtuous ratchet direction (fewer trusted-kernel
+    escapes), so the pin follows the footprint down. Same rule as widening:
+    any future shrink must name the flipped theorems."""
     jobs = _load_jobs()
     audit = jobs["proof-integrity-audit"].get("with", {})
     allow = audit.get("allow-axioms", "")
@@ -112,10 +121,10 @@ def test_audit_allowlists_native_decide_axioms():
     # the blocking gate's 19) is caught -- and so any future widening has to
     # come with the module-attribution argument, as #9341's did.
     names = [a.strip() for a in allow.split(",") if a.strip()]
-    assert len(names) == 46, (
-        f"audit allow-list must carry the 46 native_decide axioms of the 7 "
-        f"covered Life modules (empirical footprint, #8782 + #9341); got "
-        f"{len(names)}")
+    assert len(names) == 41, (
+        f"audit allow-list must carry the 41 native_decide axioms of the 7 "
+        f"covered Life modules (empirical footprint, #8782 + #9341, shrunk by "
+        f"the #9571 still-life decide flips); got {len(names)}")
     # Sample members from each family revealed by the audit (P4 base cases,
     # box-assez-grand lemmas, hashlife_correct_implies bridges).
     for sample in [

--- a/scripts/tests/test_golden_quantitative_claims.py
+++ b/scripts/tests/test_golden_quantitative_claims.py
@@ -38,8 +38,9 @@ XFAIL_KNOWN_GAPS: dict[str, str] = {
     "m7": "ANGLE-MORT machine: '30s' sans \\ss (espace avant 's') n'est pas matche",
     "s6": "ANGLE-MORT stochastic: 42.5 a 1 decimale, STOCHASTIC_NUM exige >=2",
     "s8": "ANGLE-MORT stochastic: 'tentatives' hors KW + 1 decimale (App-7-Wordle)",
-    "t1": "ANGLE-MORT MAJEUR structural: '2.78e24x' (notation scientifique + x) "
-          "non matche — le \\b apres 'e24' coince avant le 'x' (App-11-Picross)",
+    # "t1" (2.78e24x notation scientifique + x) retire : FIXE par #9564
+    # (STRUCTURAL_RE etendu a e\d+x?) — les deux PRs #9560/#9564 etaient
+    # in-flight simultanement, chacune verte isolement, rouges combinees.
 }
 
 


### PR DESCRIPTION
Grain: LIGHT/test — lane myia-ai-01:CoursIA — prev: coordinator merge-pass (no PR)

## Main red — two test pins desynced by in-flight merge collisions

The 2026-08-06 merge batch (21 PRs) produced two semantic collisions, each pair individually green, red combined on `main` (`Scripts Tests (CPU)` FAILED, verified locally on 83dc21e7e):

### 1. `test_golden_quantitative_claims.py::test_known_gap_count_is_documented`

- #9560 shipped the golden set with `t1` (`2.78e24x` scientific-notation+x) registered as a known scanner blind spot.
- #9564 shipped the 1-char `STRUCTURAL_RE` fix that closes exactly that blind spot.
- Both were in-flight simultaneously → combined, `t1` matches and the XFAIL registry is stale.

**Fix**: remove `t1` from `XFAIL_KNOWN_GAPS` (comment documents the collision). The t1 golden case now runs as a normal assertion and passes.

### 2. `test_proof_integrity_audit_wiring.py::test_audit_allowlists_native_decide_axioms`

- #9571 flipped 5 Oscillators still-life theorems (`loaf/boat/tub/pond/ship_still_life`) from `native_decide` to kernel `decide` (enabled by the #9536 ceilLog2 rewrite) and updated `lean-conway.yml` allow-axioms 46 → 41 names.
- The pin `assert len(names) == 46` was not updated, and `Scripts Tests` is path-filtered so a workflow-only diff never runs it — the desync only fired on the NEXT unrelated PRs.

**Fix**: pin 46 → 41 with written module-attribution (the docstring now records the shrink rule symmetrically to the #9341 widening rule: any shrink must name the flipped theorems). The 4 sample-membership names are unaffected (none of the 5 removed).

### Validation

`python -m pytest scripts/tests/test_golden_quantitative_claims.py scripts/lean/tests/test_proof_integrity_audit_wiring.py` → **48 passed, 3 xfailed** (was 2 FAILED).

Unblocks the 6 open PRs currently red on `Scripts Tests (CPU)` through no fault of their own (#9573/#9576/#9581/#9585/#9587/#9588).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
