### PR TITLE
test(ict-14b,#7735): 5 edge-case tests for active_inference public API

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_active_inference.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_active_inference.py
@@ -151,3 +151,71 @@ def test_stationary_env_no_best_arm_change():
     before = env.true_best_arm(10)
     after = env.true_best_arm(90)
     assert before == after
+
+
+# --------------------------------------------------------------------------- #
+#  Dynamique non-stationnaire + métriques non couvertes                        #
+# --------------------------------------------------------------------------- #
+def test_bandit_regime_switches_optimal_arm_at_switch_t():
+    """La bascule de régime inverse le bras optimal exactement à switch_t.
+
+    Miroir non-stationnaire du test ci-dessus : par défaut probs_pre est
+    décroissante (bras 0 = 0.8 optimal) et probs_post l'inverse (dernier
+    bras = 0.8 optimal). Le bras vrai optimal bascule donc 0 -> K-1 à
+    switch_t — c'est le cœur de la non-stationnarité qui motive tout le banc."""
+    env = ai.NonStationaryBandit(n_arms=3, horizon=100, seed=0)
+    s = env.switch_t
+    assert env.true_best_arm(0) == 0               # début : bras 0 (p=0.8)
+    assert env.true_best_arm(s - 1) == 0           # juste avant bascule
+    assert env.true_best_arm(s) == 2               # à la bascule : dernier bras
+    assert env.true_best_arm(env.horizon - 1) == 2  # fin : dernier bras
+
+
+def test_optimal_reward_rate_equals_max_true_prob():
+    """optimal_reward_rate(t) = proba vraie maximale à l'instant t (borne de regret)."""
+    env = ai.NonStationaryBandit(n_arms=3, horizon=60, seed=0)
+    for t in (0, 5, env.switch_t, env.switch_t + 1, env.horizon - 1):
+        assert env.optimal_reward_rate(t) == pytest.approx(float(env._probs_t[t].max()))
+
+
+def test_cumulative_regret_equals_sum_and_nonneg():
+    """cumulative_regret(trace) = somme des regrets instantanés, et >= 0.
+
+    Le regret instantané = optimal_reward_rate(t) - p_vraie(arm choisi) =
+    max - p, donc toujours >= 0 ; la somme aussi. La fonction publique
+    cumulative_regret n'était pas exercée jusqu'ici."""
+    env = ai.NonStationaryBandit(n_arms=3, horizon=100, seed=0)
+    tr = ai.run_episode(env, lam=1.0)
+    assert ai.cumulative_regret(tr) == pytest.approx(float(tr["regret"].sum()))
+    assert ai.cumulative_regret(tr) >= 0.0
+    # Chaque pas est non négatif (max des probas - proba du bras tiré).
+    assert (tr["regret"] >= -1e-12).all()
+
+
+def test_recovery_rate_window_limit_and_empty_returns_nan():
+    """window limite la fenêtre post-bascule ; fenêtre vide (window=0) -> nan.
+
+    Exerce la branche ``end <= s`` (retour nan) du garde, non couverte par
+    test_recovery_rate_in_unit_interval qui n'utilise pas l'argument window."""
+    env = ai.NonStationaryBandit(n_arms=3, horizon=100, seed=3)
+    tr = ai.run_episode(env, lam=1.0)
+    # Fenêtre limitée : valeur dans [0, 1], évaluée sur moins de pas.
+    half = ai.recovery_rate(tr["actions"], env, window=10)
+    assert 0.0 <= half <= 1.0
+    # Fenêtre vide -> nan (branche de garde end <= s).
+    assert np.isnan(ai.recovery_rate(tr["actions"], env, window=0))
+
+
+def test_choose_greedy_lam_zero_picks_highest_mean():
+    """choose(lam=0) = politique gloutonne pure -> argmax(moyenne a posteriori).
+
+    Le terme pragmatique est strictement croissant en p_k pour c > 0.5,
+    donc lam=0 (epistémique ablaté) sélectionne le bras de moyenne la plus
+    haute. Vérifie la réduction greedy du choix indépendamment du tirage
+    aléatoire (l'écart net de moyenne l'emporte sur le bris d'égalité 1e-12)."""
+    b = ai.BetaBelief(n_arms=3)
+    for _ in range(20):
+        b.update(0, 1.0)  # bras 0 : que des succès -> moyenne ~0.95
+    rng = np.random.default_rng(0)
+    assert b.mean()[0] > b.mean()[1]  # prémisse : écart net
+    assert ai.choose(b, lam=0.0, rng=rng) == 0


### PR DESCRIPTION
Grain: MED/test — lane myia-po-2025:CoursIA — prev: MED/test (#9591)

See #7735 (ICT-14 lineage — "problème de la représentation interne", ICT-10→12→14→17). The `ict/active_inference.py` module (447 src lines, ICT-14b active-inference bandit) had 13 tests; several public-API **contracts** were untested. This adds 5 edge-case tests covering real invariants — not trivia.

## G-VAR-3 note (same-genre justification)

prev grain was `MED/test` (#9591, signaling_convention). Variation-protocol G-VAR-3 bans 2 same-genre LIGHTs consecutive but **permits DEEP/MED same-genre "SI chacun est une substance genuinement distincte — théorème / module / résultat différent."** active_inference is a **different module** (active inference / expected-free-energy bandit, 447 lines, regime-switch + EFE) vs signaling_convention (Lewis/Skyrms signaling games, 527 lines, Roth-Erev + MI). Different scientific domain, different public API, different untested contracts. Distinct substance — defensible same-genre MED.

## Coverage gaps filled

| Test | Contract tested | Was untested because |
|---|---|---|
| `test_bandit_regime_switches_optimal_arm_at_switch_t` | The non-stationarity core: `true_best_arm` flips 0→K-1 **exactly at** `switch_t` (mirror of the existing stationary test) | `true_best_arm` only exercised in the **stationary** case; the non-stationary regime switch (the whole point of the module) had no direct assertion |
| `test_optimal_reward_rate_equals_max_true_prob` | `optimal_reward_rate(t)` == max of true probs at t (the regret upper bound) | `optimal_reward_rate` had **zero** direct coverage (only used internally by `run_episode`) |
| `test_cumulative_regret_equals_sum_and_nonneg` | `cumulative_regret(trace)` == `trace["regret"].sum()` AND ≥ 0 (regret = max − p) | `cumulative_regret` is a **public function with zero tests** |
| `test_recovery_rate_window_limit_and_empty_returns_nan` | `window` limits the post-switch span; `window=0` → empty span → `nan` | The `window` arg and the `end <= s` → nan guard branch were untested (existing test only checked the unit-interval property without `window`) |
| `test_choose_greedy_lam_zero_picks_highest_mean` | `choose(lam=0)` reduces to argmax(posterior mean) — the greedy reduction | `choose`'s `lam=0` reduction was only shown indirectly via agent-B/C action equality; the direct greedy contract on a constructed belief was untested |

## Validation

- **`python -m pytest tests/test_active_inference.py -q`** = **18 passed** (13 existing + 5 new), 0 failures, 1.97s. **0 regression** on the existing 13 tests.
- CPU-only (numpy active-inference bandit, deterministic seeds). Style matches the existing suite (`ai.` import alias, French docstrings, `pytest.approx`, `np.random.default_rng(seed)`).
- Scope: **1 file, +68 lines, 0 deletions** — test-only, no source change.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
