### PR TITLE
fix(tests,#9399): surgical twin-parity tests robust to multi-record registry files

### DIFF
--- a/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
@@ -148,10 +148,15 @@ def test_diff_limited_to_target_block(registry_backup):
 
     Depuis #9399 (volet a, migration at-rest), le registre est en forme
     append-only `audits:`. Un rebaseline qui drift APPEND une nouvelle entree ;
-    l'enregistrement precedent survit comme item[0]. La garantie chirurgicale
-    (#8570) est preservee : aucune cle top-level hors audit
+    TOUS les enregistrements precedents survivent verbatim. La garantie
+    chirurgicale (#8570) est preservee : aucune cle top-level hors audit
     (name/family/python/csharp/parity_level/known_differences) ne change
     (anti-regression : on ne jette pas l'historique d'audit).
+
+    Robuste au multi-enregistrement (#9581) : la fixture est le premier fichier
+    du registre reel, qui peut legitimement porter >= 2 audits (c'est le POINT
+    de l'append-only). L'ancienne assertion `audits[0] == ancien latest` ne
+    valait que pour un fichier mono-enregistrement.
     """
     import yaml
 
@@ -160,7 +165,7 @@ def test_diff_limited_to_target_block(registry_backup):
     name = _pair_name(pfile)
     before = yaml.safe_load(raw)[0]
     old_audit = ctp._latest_audit(before)
-    old_py = old_audit["python_sha"]
+    before_audits = before.get("audits") or [before["last_audit"]]
 
     # SHA python change -> append a new entry (registry is audits: since the
     # #9399 volet a at-rest migration). The lazy legacy->audits migration of a
@@ -176,11 +181,11 @@ def test_diff_limited_to_target_block(registry_backup):
     for key in ("name", "family", "python", "csharp", "parity_level", "known_differences"):
         assert before.get(key) == after.get(key), f"cle non-audit modifiee : {key}"
 
-    # Le bloc a migre vers la forme append-only, en preservant l'historique.
+    # Forme append-only ; tout l'historique survit, le sentinel est appende.
     assert "last_audit" not in after, "le singleton legacy doit etre remplace"
     audits = after["audits"]
-    assert isinstance(audits, list) and len(audits) >= 2
-    assert audits[0]["python_sha"] == old_py, "l'ancien enregistrement doit survivre"
+    assert isinstance(audits, list) and len(audits) == len(before_audits) + 1
+    assert audits[:-1] == before_audits, "les enregistrements precedents doivent survivre verbatim"
     assert audits[-1]["python_sha"] == "f" * 40, "le nouvel enregistrement doit etre dernier"
     assert audits[-1]["by"] == "sentinelle-c8570"
 
@@ -190,6 +195,12 @@ def test_noop_is_byte_identical(registry_backup):
 
     Sans cette garantie, un rebaseline sur une paire a jour normaliserait le
     quoting (le registre melange 'x' et "x") et polluerait le diff.
+
+    Le candidat noop doit porter les MEMES cles de comparaison que le dernier
+    audit (#9581) : si celui-ci a des `content_*_sha` (rebaseline outil récent)
+    et que le candidat ne les a pas, `_cmp_pair_shas` compare content-sha vs
+    blob-sha -> faux drift -> append parasite. Un vrai rebaseline recalcule
+    toujours les deux familles de SHAs ; le test doit faire pareil.
     """
     import yaml
 
@@ -201,11 +212,13 @@ def test_noop_is_byte_identical(registry_backup):
     entry = data[0] if isinstance(data, list) else data
     audit = ctp._latest_audit(entry)
 
-    new_raw, touched = ctp.surgical_rebaseline(
-        raw,
-        {name: {"date": str(audit["date"]), "by": audit["by"],
-                "python_sha": audit["python_sha"], "csharp_sha": audit["csharp_sha"]}},
-    )
+    noop = {"date": str(audit["date"]), "by": audit["by"],
+            "python_sha": audit["python_sha"], "csharp_sha": audit["csharp_sha"]}
+    for k in ("content_python_sha", "content_csharp_sha"):
+        if k in audit:
+            noop[k] = audit[k]
+
+    new_raw, touched = ctp.surgical_rebaseline(raw, {name: noop})
     assert touched == 0
     assert new_raw == raw, "un no-op doit etre byte-identique"
 


### PR DESCRIPTION
Grain: MED/test — lane myia-ai-01:CoursIA — prev: MED/tooling #9603

## Summary

Fixes a latent single-record assumption in the surgical twin-parity tests (`test_check_twin_parity_surgical.py`) that turns them red the moment the alphabetically-first registry file (`app-1-nqueens.yaml`) legitimately carries a second audit record — which is exactly what the append-only registry (#9399) is designed to do, and exactly what #9581's rebaseline produced.

## The two fragilities

1. **`test_diff_limited_to_target_block`** asserted `audits[0]["python_sha"] == old_latest_python_sha` after a sentinel append. That only holds for a mono-record file: with 2 records, `_latest_audit` returns the *last* record, while `audits[0]` is the *first*. Rewritten to assert the real append-only contract: `audits[:-1] == before_audits` (every previous record survives verbatim) and the sentinel is appended last.

2. **`test_noop_is_byte_identical`** built its noop candidate from the 4 legacy keys (`date/by/python_sha/csharp_sha`). When the latest audit also carries `content_python_sha`/`content_csharp_sha` (any recent tooled rebaseline does), `_cmp_pair_shas` returns content-SHAs for the record but git blob-SHAs for the candidate → `_shas_match` compares apples to oranges → spurious drift → `touched == 1`. The candidate now mirrors the `content_*_sha` keys when present, as a real rebaseline recalculation does.

## Why now

#9581's CI went red on these two tests after `gh pr update-branch` — the only PR touching `app-1-nqueens.yaml`, the first file in `sorted(glob("*.yaml"))`. Sibling PRs #9573/#9576 with the identical rebaseline pattern on later-sorting files pass, which pinpointed the fixture ordering as the trigger. This is test-design debt, not a `check_twin_parity.py` bug: the tool's behavior is correct in both scenarios.

## Validation

Local, both ways:

- Main registry as-is: `12 passed`
- With `origin/fix/c1287-csp-nqueens-machine-dep-timing:…/app-1-nqueens.yaml` (2 audit records) overlaid: `12 passed` (was `2 failed, 10 passed` before this fix — exact CI reproduction)

Diff is test-file-only (+24/−11), no production code touched.

See #9399 (append-only registry) · unblocks #9581.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
