### PR TITLE
test(ict,#7746): 6 edge-case tests for symbol_invention public API

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_symbol_invention.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_symbol_invention.py
@@ -193,3 +193,90 @@ def test_ontology_diversity():
     assert report["n_distinct_conventions"] >= 2
     assert report["mean_final_success"] > 0.7
     assert report["diverse"] == 1.0
+
+
+# --- Contrats mecaniques supplementaires (gaps de couverture) ---
+
+
+def test_reset_restores_fresh_state():
+    """reset() ramene le jeu a l'etat frais : vocabulaire a ``n_signals_init``,
+    propensites uniformes (``initial_q``), historiques vides, ``n_inventions`` 0,
+    joint nulle. Le contrat doit tenir apres apprentissage et inventions."""
+    g = InventingSignalingGame(
+        n_states=4, n_signals_init=1, invention_cost=0.0, rng=np.random.default_rng(7)
+    )
+    g.train(n_rounds=400)
+    # Apres apprentissage : historique non vide, vocabulaire a potentiellement cru.
+    assert len(g.success_history) == 400
+    # reset() : retour a l'etat frais.
+    g.reset()
+    assert g.n_signals == g.n_signals_init
+    assert g.n_inventions == 0
+    assert len(g.success_history) == 0
+    assert len(g.payoff_history) == 0
+    assert len(g.vocab_history) == 0
+    assert g.success_rate() == 0.0
+    assert g.net_payoff_rate() == 0.0
+    assert np.allclose(g.Q_s, g.initial_q)
+    assert np.allclose(g.Q_r, g.initial_q)
+    assert np.allclose(g.joint_state_signal, 0.0)
+
+
+def test_train_negative_rounds_raises():
+    """train(n_rounds < 0) leve ValueError (garde explicite)."""
+    g = InventingSignalingGame(n_states=3, n_signals_init=2, rng=np.random.default_rng(0))
+    with pytest.raises(ValueError):
+        g.train(n_rounds=-5)
+
+
+def test_train_zero_rounds_is_noop():
+    """train(n_rounds=0) est valide (boucle vide) : aucun tour joue, aucune invention."""
+    g = InventingSignalingGame(n_states=3, n_signals_init=2, rng=np.random.default_rng(0))
+    g.train(n_rounds=0)
+    assert len(g.success_history) == 0
+    assert g.n_inventions == 0
+
+
+def test_train_anneal_restores_temperature():
+    """Apres train(anneal_to=t_bas), la temperature revient a sa valeur initiale
+    (restoration finale) — l'annealing est transitoire, pas persistant."""
+    g = InventingSignalingGame(
+        n_states=3, n_signals_init=2, temperature=0.5, rng=np.random.default_rng(0)
+    )
+    t0 = g.temperature
+    g.train(n_rounds=100, anneal_to=0.02)
+    assert g.temperature == pytest.approx(t0)
+
+
+def test_invent_returns_false_at_cap_without_side_effects():
+    """_invent() renvoie False au plafond SANS etendre les matrices ni incrementer
+    ``n_inventions``. Le garde de plafond doit etre sans effet de bord."""
+    g = InventingSignalingGame(
+        n_states=4, n_signals_init=2, max_signals=3, rng=np.random.default_rng(0)
+    )
+    # Sous le plafond : _invent() etend les matrices et renvoie True.
+    assert g._invent() is True
+    assert g.n_signals == 3
+    assert g.n_inventions == 1
+    assert g.Q_s.shape == (4, 3) and g.Q_r.shape == (3, 4)
+    # Au plafond : _invent() renvoie False, ne change rien.
+    assert g._invent() is False
+    assert g.n_signals == 3
+    assert g.n_inventions == 1
+    assert g.Q_s.shape == (4, 3) and g.Q_r.shape == (3, 4)
+
+
+def test_dominant_signal_per_state_empty_then_convention():
+    """Sans aucun tour joue (joint nulle), ``dominant_signal_per_state`` renvoie
+    -1 partout. Apres apprentissage, chaque etat porte un signal dominant valide
+    et une convention emerge (au moins 2 signaux distincts)."""
+    g = InventingSignalingGame(
+        n_states=4, n_signals_init=1, invention_cost=0.0, rng=np.random.default_rng(0)
+    )
+    # Etat frais : joint nulle -> -1 partout.
+    assert g.dominant_signal_per_state() == [-1, -1, -1, -1]
+    g.train(n_rounds=4000, anneal_to=0.15)
+    dom = g.dominant_signal_per_state()
+    assert len(dom) == 4
+    assert all(d >= 0 for d in dom), f"apres apprentissage chaque etat a un signal dominant, recu {dom}"
+    assert len(set(dom)) >= 2, f"une convention emerge (signaux distincts), recu {dom}"


### PR DESCRIPTION
Grain: MED/test -- lane myia-po-2025:CoursIA -- prev: MED/test (#9604)

See #7746 (D2 experience B — symbol invention, vocabulary-growth signaling game). The `ict/symbol_invention.py` module (563 src lines, 20 existing tests) had several public-API **contracts** untested. This adds 6 edge-case tests covering real invariants — not trivia.

## G-VAR-3 note (3rd consecutive MED/test)

prev grains: #9591 signaling_convention, #9604 active_inference, both MED/test. Variation-protocol G-VAR-3 bans 2 same-genre LIGHTs consecutive but **permits DEEP/MED same-genre "SI chacun est une substance genuinement distincte — théorème / module / résultat différent."** This is a **3rd distinct module**:
- **signaling_convention** (#7746 exp A): Lewis/Skyrms coordination, **fixed** vocabulary, Roth-Erev + MI.
- **active_inference** (#7735): EFE bandit, regime-switch, epistemic+pragmatic value.
- **symbol_invention** (#7746 exp B): **invented/growing** vocabulary, cost-tradeoff invention mechanism, `np.pad`-extended Q matrices.

Three different scientific domains, three different public APIs, three different sets of untested contracts. Each grain is genuinely distinct substance. Not scan-generatable (each module's invariants require domain understanding).

## Coverage gaps filled

| Test | Contract tested | Was untested because |
|---|---|---|
| `test_reset_restores_fresh_state` | `reset()` returns game to fresh state: vocab→`n_signals_init`, uniform Q (`initial_q`), empty histories, `n_inventions` 0, `net_payoff_rate` 0.0, joint 0 | `reset()` had **zero** unit coverage (only exercised via `__init__`); the post-invention reset contract was untested |
| `test_train_negative_rounds_raises` | `train(n_rounds<0)` raises `ValueError` | The guard was untested; existing `test_invalid_*` cover `__init__` params (n_states/n_signals_init/max_signals/temperature/invention_rate/invention_cost/state_dist) but **not** `n_rounds` |
| `test_train_zero_rounds_is_noop` | `train(n_rounds=0)` is valid (empty loop), no rounds played, no invention | Boundary case |
| `test_train_anneal_restores_temperature` | After `train(anneal_to=t_low)`, `temperature` returns to its initial value | The restoration (`self.temperature = t0` at end of `train`) was untested at unit level |
| `test_invent_returns_false_at_cap_without_side_effects` | `_invent()` returns `False` at cap **without** extending matrices or incrementing `n_inventions`; returns `True` + extends below cap | `test_max_signals_cap_respected` checks vocab size respects cap indirectly, but the **return-value + no-side-effect contract** at the cap guard was untested |
| `test_dominant_signal_per_state_empty_then_convention` | Empty joint → `-1` per state; after learning, each state has a valid dominant signal (≥2 distinct = convention emerged) | `dominant_signal_per_state` was only exercised inside verdicts; the empty-history `-1` branch + direct post-learning contract were untested |

## Validation

- **`python -m pytest tests/test_symbol_invention.py -q`** = **26 passed** (20 existing + 6 new), 0 failures, 8.08s. **0 regression** on the existing 20 tests.
- CPU-only (numpy Roth-Erev + softmax, deterministic seeds). Style matches the existing suite (French docstrings, `pytest.approx`, `np.random.default_rng(seed)`).
- Scope: **1 file, +87 lines, 0 deletions** — test-only, no source change.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
