### PR TITLE
docs(qc,#3976): Option-Wheel README — real backtest metrics + FR canonical + wheel-not-alpha honesty caveat

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel/README.en.md
@@ -1,0 +1,41 @@
+# Option-Wheel
+
+**Asset class:** US Equities (SPY Options)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Options wheel strategy on SPY: sells OTM put options (5% OTM, ~21 DTE) to collect premium.
+If assigned, sells OTM covered calls on the resulting SPY position. Full wheel cycle.
+
+VIX regime filter: skips put selling when VIX > 20 (high volatility). Aggressive selling when VIX < 15.
+Cash-secured puts with 80% max exposure and margin disabled for safety. Minute-resolution backtest.
+
+## How to Run
+
+**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel"`
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Starting Capital | $1,000,000 |
+| Resolution | Minute |
+| Put OTM | 5% |
+| DTE | 21 days |
+| VIX Filter | Skip selling if VIX > 20 |
+
+## Files
+
+- `main.py` - Strategy (wheel: short put -> covered call)
+- `research.ipynb` - Options premium analysis and DTE/OTM optimization
+
+## References
+
+- Options wheel strategy: systematic premium collection via put/call selling
+- Interactive Brokers brokerage model (cash account)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel/README.md
@@ -1,41 +1,85 @@
 # Option-Wheel
 
-**Asset class:** US Equities (SPY Options)
-**Cloud project ID:** None (local only)
+**Classe d'actifs :** Actions US (options sur SPY)
+**ID projet Cloud :** 34881290
 
 ## Description
 
-Options wheel strategy on SPY: sells OTM put options (5% OTM, ~21 DTE) to collect premium.
-If assigned, sells OTM covered calls on the resulting SPY position. Full wheel cycle.
+Stratégie du « wheel » (roue) sur options SPY : vend des puts hors-cours
+(OTM 5 %, ~21 DTE) pour encaisser la prime. En cas d'assignation, vend des
+calls couverts sur la position SPY résultante. Cycle complet : put nu →
+assignation → call couvert → cession → put nu.
 
-VIX regime filter: skips put selling when VIX > 20 (high volatility). Aggressive selling when VIX < 15.
-Cash-secured puts with 80% max exposure and margin disabled for safety. Minute-resolution backtest.
+Filtre de régime VIX : désactive la vente de puts quand VIX > 20 (volatilité
+élevée / stress de marché) ; vente agressive quand VIX < 15. Puts cash-secured
+avec exposition maximale 80 % et marge désactivée pour la sécurité.
+Backtest en résolution minute, compte Cash IBKR.
 
-## How to Run
+Paramètres clés (`main.py`, vérifiés firsthand) :
+- Période : 2015-01-01 → 2024-12-31 (10 ans, inclut crash COVID + récupération)
+- Capital initial : 1 000 000 $
+- DTE : 21 jours (`days_to_expiry`)
+- OTM : 5 % (`otm_threshold`)
+- Exposition max : 80 % (`max_exposure_fraction`)
+- Filtre VIX : skip puts si VIX > 20 ; agressif si VIX < 15
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel"`
+## Comment exécuter
+
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel"`
 ```bash
 lean backtest --project .
 ```
 
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**QC Cloud :** Ouvrir le projet 34881290 dans l'IDE QuantConnect et cliquer sur « Backtest ».
 
-## Backtest Metrics (2015-2026)
+## Métriques de backtest (2015-2024)
 
-| Metric | Value |
-|--------|-------|
-| Starting Capital | $1,000,000 |
-| Resolution | Minute |
-| Put OTM | 5% |
-| DTE | 21 days |
-| VIX Filter | Skip selling if VIX > 20 |
+| Métrique | Valeur |
+|----------|--------|
+| Sharpe Ratio | 0.575 |
+| CAGR | 13.088% |
+| Max Drawdown | 26.500% |
+| Net Profit | 242.406% |
+| PSR | 4.230% |
+| Total Orders | 1029 |
+| Benchmark | SPY |
+| Résolution | Minute |
+| Compte | IBKR Cash |
+| DTE / OTM | 21 jours / 5% |
 
-## Files
+> **Provenance** : backtest QC Cloud `4b8c217c3927ab637379f8641f676679` (2026-08-06),
+> projet 34881290, IBKR Cash account, capital initial 1 000 000 $, résolution minute,
+> 2516 jours tradeables (2015-01-01 → 2024-12-31). Re-exécuter via QC Cloud pour
+> recalculer.
+>
+> **Lecture honnête** : le wheel est une stratégie *très populaire* dans la littérature
+> de « revenu passif par les options », souvent présentée comme quasi-garantie. Les
+> chiffres montrent le contraire. Un CAGR de 13,1 % sur 2015-2024 est **comparable au
+> buy & hold de SPY** sur la même période (≈ 13-14 %), mais avec un **Sharpe de 0,575
+> nettement inférieur** à celui du benchmark (~0,7-0,8) et un **PSR de 4,2 %**
+> catastrophique — l'edge statistique est nul, très loin du seuil de confiance de
+> 50 % (et a fortiori 95 %). Le Max Drawdown de 26,5 % (creux COVID 2020) est par
+> ailleurs substantiel.
+>
+> En d'autres termes : la vente de primes d'options n'extrait **pas d'alpha** ici ;
+> elle réplique approximativement l'exposition long-SPY en ajoutant de la complexité,
+> des frais de transaction et un risque d'assignation. **C'est un contre-exemple
+> pédagogique** à l'encontre du narratif « wheel = revenu garanti ». La valeur
+> pédagogique est dans la démonstration (via filtre VIX, gestion cash-secured,
+> cycle put→call) du *mécanisme* du wheel, pas dans un quelconque alpha. Comparer
+> avec EMA-Cross-Stocks (même univers US, Sharpe 0.991 mais beta Mag7) et
+> EMA-Cross-Alpha (contre-exemple framework Alpha Model, Sharpe -0,01).
 
-- `main.py` - Strategy (wheel: short put -> covered call)
-- `research.ipynb` - Options premium analysis and DTE/OTM optimization
+## Fichiers
 
-## References
+- `main.py` - Stratégie wheel (put nu → call couvert, filtre VIX, gestion exposition)
+- `research.ipynb` - Analyse des primes d'options et optimisation DTE/OTM
+- `quantbook.ipynb` - Recherche QC (chaînes d'options, grecques)
+- `wheel_analysis.png` - Visualisation d'analyse
+- `README.en.md` - Version anglaise (original historique, non mise à jour)
 
-- Options wheel strategy: systematic premium collection via put/call selling
-- Interactive Brokers brokerage model (cash account)
+## Références
+
+- Wheel strategy : collection systématique de primes via vente put/call couvert
+- Brokerage : Interactive Brokers (modèle compte Cash, marge désactivée)
+- Réf : Tastytrade research sur delta/DTE pour la vente de primes d'options


### PR DESCRIPTION
Grain: MED/readme — lane inconnue (body restauré par ai-01 ; le `--body-file -` du worker a produit un body vide « @- », même mode d'échec que #9610)

## Summary

README du projet QC **Option-Wheel** : bascule FR canonical (`README.md` en français) avec préservation de l'original anglais en `README.en.md` byte-identique (règle readme-french-first #1650 Phase 0.5), + remplacement des paramètres statiques par les **vraies métriques de backtest** QC Cloud, + caveat d'honnêteté « wheel = collecte de prime, pas de l'alpha ».

## Métriques (backtest QC Cloud réel)

| Métrique | Valeur |
|---|---|
| Sharpe | 0.575 |
| CAGR | 13.088% |
| Max Drawdown | 26.500% |
| Net Profit | 242.406% ($2,127,458) |
| PSR | 4.230% |
| Total Orders | 1029 |

Provenance : backtest `4b8c217c3927ab637379f8641f676679` (« Option-Wheel baseline IBKR Cash 2015-2024 », complété 2026-08-06 04:49Z), projet Cloud **34881290**, 2516 tradeable dates.

## Vérification G.1 (coordinateur, avant merge)

`read_backtest(34881290, 4b8c217c…)` via MCP qc-mcp-lite : **les 6 métriques du README matchent exactement** la sortie API (Sharpe 0.575 / CAGR 13.088% / DD 26.500% / NetProfit 242.406% / PSR 4.230% / 1029 orders). Backtest status `Completed`, pas de fabrication.

See #3976 (rollout READMEs QC avec métriques réelles ; l'epic reste ouvert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
