### PR TITLE
test(notebook_tools,#9434): 17 tests for check_prose_quantitative_claims invariants

### DIFF
--- a/scripts/notebook_tools/tests/test_check_prose_quantitative_claims.py
+++ b/scripts/notebook_tools/tests/test_check_prose_quantitative_claims.py
@@ -1,0 +1,280 @@
+"""Tests for scripts/notebook_tools/check_prose_quantitative_claims.py.
+
+Le module est l'instrument central du drainage #9434 (PR #9476 MERGED) : il
+refuse les compteurs quantitatifs ecrits a la main dans la prose, en cinq
+classes (artifact / machine / env / stochastic / structural). 531 LOC, 0 test
+avant ce fichier -- vraie lacune infrastructure.
+
+Les tests verrouillent les COMPORTEMENTS DOCUMENTES :
+- les 5 regex flaggent ce qu'ils doivent flagger ET epargnent les faux positifs
+  pedagogiques documentes (« 4 joueurs », dimensions WxH, lib sans version) ;
+- la classe ``structural`` est LEGITIME-exclue (jamais echec, header taxonomie) ;
+- le gate ``stochastic`` exige la co-occurrence mot-clef + nombre (meme ligne) ;
+- l'exemption ``generated`` (un fichier qui se declare genere porte legitimement
+  des chiffres) ;
+- la fonction ``_resolve_classes`` et le gate seed notebook.
+
+Pattern herite de ``test_audit_c1_c3.py`` : sys.path.insert module-level,
+helpers synthetiques, fonctions pures. Aucun appel git/subprocess (on ne teste
+pas scan_diff, qui delegue a ``git diff``).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import check_prose_quantitative_claims as cqc  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+#  Classe artifact (COUNT_RE) : mesure d'artefact vivant = flag ; pedagogie = non
+# --------------------------------------------------------------------------- #
+
+
+def test_count_re_flags_artifact_measures():
+    """Les formes canoniques d'artefacts sont capturees : « (140 lignes) »,
+    « ~525 lignes », « **224** notebooks », « 87 cellules », « 10 files »."""
+    for snippet in ["140 lignes", "~525 lignes", "**224** notebooks",
+                    "87 cellules", "10 files"]:
+        assert cqc.COUNT_RE.search(snippet), f"devrait flagger {snippet!r}"
+
+
+def test_count_re_spares_pedagogical_counts():
+    """« 4 joueurs » et « 3 proprietes de Nash » sont du contenu pedagogique,
+    pas de l'etat de depot : le nom (joueurs/proprietes) n'est pas un nom
+    d'artefact (lignes/cellules/notebooks/modules/fichiers/files). Jamais flag."""
+    for snippet in ["4 joueurs", "3 proprietes de Nash", "2 joueurs, 3 strategies"]:
+        assert cqc.COUNT_RE.search(snippet) is None, (
+            f"ne doit PAS flagger le contenu pedagogique {snippet!r}"
+        )
+
+
+def test_count_re_requires_number_before_noun():
+    """« module 5 » (nombre APRES le nom) n'est pas un compteur d'artefact :
+    le nombre doit PRECEDER immediatement le nom. Jamais flag."""
+    assert cqc.COUNT_RE.search("module 5") is None
+    assert cqc.COUNT_RE.search("le module numero 5") is None
+
+
+# --------------------------------------------------------------------------- #
+#  Classe machine (MACHINE_RE) : duree absolue machine-dependante
+# --------------------------------------------------------------------------- #
+
+
+def test_machine_re_flags_durations():
+    """Durees canoniques : « 127 ms » (extrait de « 24-127 ms »), « ~144 ms »,
+    « 0.006 ms », « ~1.9 sec », « 2 min », « 0.2 s », « 5ms »."""
+    for snippet in ["24-127 ms", "~144 ms", "0.006 ms", "~1.9 sec",
+                    "2 min", "0.2 s", "5ms"]:
+        assert cqc.MACHINE_RE.search(snippet), f"devrait flagger {snippet!r}"
+
+
+def test_machine_re_monoletter_s_requires_space():
+    """L'unite monolettre « s » (secondes) exige un espace avant elle pour eviter
+    les collisions avec suffixes/abreviations. « 0.2s » (sans espace) n'est PAS
+    flage, alors que « 0.2 s » l'est -- invariant defensif documente."""
+    assert cqc.MACHINE_RE.search("0.2 s") is not None
+    assert cqc.MACHINE_RE.search("0.2s") is None
+
+
+# --------------------------------------------------------------------------- #
+#  Classe env (ENV_RE) : version de librairie figee en prose
+# --------------------------------------------------------------------------- #
+
+
+def test_env_re_flags_library_versions():
+    """« NumPy 2.4.2 », « PyTorch 2.1.0 », « Mathlib v4.31.0-rc1 » (regex
+    s'arrete au \\b apres le troisieme groupe, le suffixe -rc1 est hors-match)
+    sont flaggues : une version derive quand l'env monte."""
+    assert cqc.ENV_RE.search("NumPy 2.4.2")
+    assert cqc.ENV_RE.search("PyTorch 2.1.0")
+    m = cqc.ENV_RE.search("Mathlib v4.31.0-rc1")
+    assert m is not None and m.group(0) == "Mathlib v4.31.0"
+
+
+def test_env_re_spares_library_without_version():
+    """Une lib citee sans version (« NumPy » seul) ou avec version incomplete
+    (« NumPy 2 » = 0 groupe .\\d+) n'est PAS flagee : il faut >=1 groupe .\\d+."""
+    assert cqc.ENV_RE.search("Nous utilisons NumPy") is None
+    assert cqc.ENV_RE.search("NumPy 2") is None
+
+
+# --------------------------------------------------------------------------- #
+#  Classe stochastic : co-occurrence mot-clef + nombre (meme ligne)
+# --------------------------------------------------------------------------- #
+
+
+def test_stochastic_requires_keyword_and_number_same_line():
+    """Flagge « fitness 41.71 » (kw + >=2 decimales), PAS « 41.71 » seul
+    (pas de mot-clef), PAS « fitness 41 » (pas de decimale)."""
+    # kw + nombre a decimales -> flag
+    assert cqc.STOCHASTIC_KW_RE.search("fitness 41.71")
+    assert cqc.STOCHASTIC_NUM_RE.search("fitness 41.71")
+    # nombre sans kw -> le nombre matche NUM mais la ligne manque le kw
+    assert cqc.STOCHASTIC_KW_RE.search("41.71 final") is None
+    # kw sans decimale suffisante -> NUM ne matche pas
+    assert cqc.STOCHASTIC_NUM_RE.search("fitness 41") is None
+    assert cqc.STOCHASTIC_NUM_RE.search("loss 0.001")  # 3 decimales OK
+
+
+# --------------------------------------------------------------------------- #
+#  Classe structural (LEGITIME-exclue) : speedup deterministe vs dimensions WxH
+# --------------------------------------------------------------------------- #
+
+
+def test_structural_re_flags_speedups_not_dimensions():
+    """« 2.78e24x », « 4x », « 1,5x » sont des speedups deterministes (flag en
+    opt-in) ; « 100x100 » et « 1280x720 » sont des dimensions WxH (le \\b apres
+    le premier x echoue car suivi d'un chiffre -> jamais flag)."""
+    for snippet in ["2.78e24x", "4x", "1,5x", "speedup 2.78e24"]:
+        assert cqc.STRUCTURAL_RE.search(snippet), f"devrait reconnaitre {snippet!r}"
+    for snippet in ["100x100", "1280x720", "grille 9x9"]:
+        assert cqc.STRUCTURAL_RE.search(snippet) is None, (
+            f"ne doit pas flagger la dimension WxH {snippet!r}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+#  _resolve_classes : branching de --class
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_classes_branching():
+    """Rend (classes_a_detecter, est_purement_structural)."""
+    assert cqc._resolve_classes("artifact") == ({"artifact"}, False)
+    assert cqc._resolve_classes("machine") == ({"machine"}, False)
+    assert cqc._resolve_classes("env") == ({"env"}, False)
+    assert cqc._resolve_classes("stochastic") == ({"stochastic"}, False)
+    assert cqc._resolve_classes("structural") == ({"structural"}, True)
+    classes_all, structural_all = cqc._resolve_classes("all")
+    assert structural_all is False
+    assert classes_all == set(cqc.FLAGGABLE)  # artifact/machine/env/stochastic
+    assert "structural" not in classes_all  # structural jamais dans 'all'
+
+
+# --------------------------------------------------------------------------- #
+#  structural ne fait JAMAIS echouer (header taxonomie #9434)
+# --------------------------------------------------------------------------- #
+
+
+def test_structural_never_fails_even_with_findings(capsys):
+    """En mode structural_only, _emit_grouped retourne 0 (jamais d'echec) meme
+    avec des findings, et affiche la banniere LEGITIME. C'est le contrat
+    documente : structural est legitime (speedup deterministe), inventorie
+    seulement, jamais signale."""
+    findings = [("file.md", "structural", "4x"), ("file.md", "structural", "2x")]
+    rc = cqc._emit_grouped(findings, strict=True, structural_only=True)
+    captured = capsys.readouterr().out
+    assert rc == 0, "structural ne doit JAMAIS faire echouer (strict inclus)"
+    assert "LEGITIME" in captured or "structural" in captured
+
+
+def test_flaggable_strict_returns_one_with_findings(capsys):
+    """En mode flaggable (artifact) strict, _emit_grouped retourne 1 avec
+    findings (REFUS) et 0 sans findings (OK). Advisory (strict=False) -> 0."""
+    findings = [("a.md", "artifact", "140 lignes")]
+    assert cqc._emit_grouped(findings, strict=True, structural_only=False) == 1
+    assert cqc._emit_grouped(findings, strict=False, structural_only=False) == 0
+    assert cqc._emit_grouped([], strict=True, structural_only=False) == 0
+    assert "[OK]" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+#  _declares_generated : exemption generateur proprietaire
+# --------------------------------------------------------------------------- #
+
+
+def test_declares_generated_detects_generator_headers():
+    """Un en-tete qui revendique un generateur exonere le fichier (FR ou EN).
+
+    La regex FR exige « fichier » IMMEDIATEMENT suivi de « genere » (sans mot
+    intermediaire comme « est ») : « Ce fichier genere par cron » matche,
+    « Ce fichier est genere » ne matche PAS (mot intermediaire).
+    """
+    assert cqc._declares_generated("Ce fichier genere par cron")
+    assert cqc._declares_generated("auto-generated file")
+    assert cqc._declares_generated("do not edit by hand")
+    assert cqc._declares_generated("ne pas editer a la main")
+    assert cqc._declares_generated("n'est pas maintenu a la main")
+    # Prose normale : pas d'exemption.
+    assert cqc._declares_generated("Ce notebook presente l'algorithme A*") is False
+    assert cqc._declares_generated("Section 1 : introduction") is False
+
+
+# --------------------------------------------------------------------------- #
+#  _skipped : hors-perimetre (harnais, cache, vendored, genere)
+# --------------------------------------------------------------------------- #
+
+
+def test_skipped_paths():
+    """Les chemins du harnais/cache/vendored sont sautes ; la prose livree non."""
+    assert cqc._skipped(Path(".claude/rules/x.md")) is True
+    assert cqc._skipped(Path("proj/.lake/build/foo.olean")) is True
+    assert cqc._skipped(Path("a/b/.pytest_cache/y")) is True
+    assert cqc._skipped(Path("_peters/Knots/Basic.lean")) is True
+    assert cqc._skipped(Path("COURSE_CATALOG.generated.md")) is True
+    assert cqc._skipped(Path("COURSE_CATALOG.generated.json")) is True
+    # Prose livree a un etudiant : pas skippee.
+    assert cqc._skipped(Path("MyIA.AI.Notebooks/Search/Astar.ipynb")) is False
+
+
+# --------------------------------------------------------------------------- #
+#  _notebook_is_seeded : gate stochastic (carnet seme = reproductible)
+# --------------------------------------------------------------------------- #
+
+
+def _write_nb(path: Path, cells: list[dict]) -> Path:
+    path.write_text(
+        json.dumps({"cells": cells, "metadata": {}, "nbformat": 4, "nbformat_minor": 5}),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_notebook_is_seeded_detects_seed_in_code_cell(tmp_path):
+    """Un carnet dont une cellule code contient np.random.seed est reproductible."""
+    seeded = _write_nb(tmp_path / "seeded.ipynb", [
+        {"cell_type": "code", "source": ["import numpy as np\nnp.random.seed(42)"]},
+    ])
+    assert cqc._notebook_is_seeded(seeded) is True
+    unseeded = _write_nb(tmp_path / "unseeded.ipynb", [
+        {"cell_type": "code", "source": ["x = np.random.rand(5)"]},
+    ])
+    assert cqc._notebook_is_seeded(unseeded) is False
+    # Divers APIs de seed reconnues (torch, random, tf, jax).
+    for seed_call in ["torch.manual_seed(0)", "random.seed(1)",
+                      "tf.random.set_seed(7)", "rng = 42"]:
+        nb = _write_nb(tmp_path / f"{seed_call[:4]}.ipynb", [
+            {"cell_type": "code", "source": [seed_call]}])
+        assert cqc._notebook_is_seeded(nb) is True, f"seed non reconnu: {seed_call!r}"
+
+
+# --------------------------------------------------------------------------- #
+#  _findings_in_text : catalogue end-to-end + generated-marker skip
+# --------------------------------------------------------------------------- #
+
+
+def test_findings_in_text_catalogs_and_skips_generated_markers():
+    """Catalogue les findings par ligne ; saute les lignes portant un marqueur
+    genere (COURSE_CATALOG.generated / CATALOG-STATUS)."""
+    # artifact : deux findings sur une ligne.
+    out = cqc._findings_in_text("On a 140 lignes et 87 cellules.", "loc", {"artifact"})
+    assert out == [("loc", "artifact", "140 lignes"), ("loc", "artifact", "87 cellules")]
+    # Ligne avec marqueur genere : entierement ignoree (le catalogue porte legitimement
+    # des chiffres).
+    out2 = cqc._findings_in_text("COURSE_CATALOG.generated 224 notebooks", "loc", {"artifact"})
+    assert out2 == []
+    out3 = cqc._findings_in_text("<!-- CATALOG-STATUS:START --> 43 notebooks", "loc", {"artifact"})
+    assert out3 == []
+
+
+def test_findings_in_text_stochastic_needs_keyword_on_same_line():
+    """La ligne est l'unite de co-occurrence : nombre sans mot-clef -> 0 finding."""
+    assert cqc._findings_in_text("fitness 41.71 final", "loc", {"stochastic"}) == [
+        ("loc", "stochastic", "41.71")]
+    assert cqc._findings_in_text("41.71 final sans contexte", "loc", {"stochastic"}) == []


### PR DESCRIPTION
## Summary

`check_prose_quantitative_claims.py` (531 LOC) is the **central #9434 drainage instrument** (PR #9476 MERGED): it refuses hand-written quantitative counts in prose across 5 classes (artifact/machine/env/stochastic/structural). It had **0 tests** — a real infrastructure gap. This adds **17 tests** locking its documented behaviors, following the `test_audit_c1_c3.py` pattern (sys.path bootstrap, synthetic helpers, pure functions; no git/subprocess).

This is a **test-coverage** grain on the **tooling** family (scripts/notebook_tools), rotating R6 family off `ict/` (c.764). Genre=test but very distinct substance (regex scanner + class taxonomy + CLI vs ict/ numerical module).

## Invariants locked

- **COUNT_RE (artifact)**: flags `140 lignes`/`~525 lignes`/`**224** notebooks`/`87 cellules`/`10 files`; spares pedagogical counts (`4 joueurs`, `3 proprietes de Nash` — noun not an artifact name); requires number BEFORE the noun (`module 5` not flagged).
- **MACHINE_RE**: flags `24-127 ms`/`~144 ms`/`0.006 ms`/`~1.9 sec`/`2 min`/`0.2 s`/`5ms`; monoletter `s` REQUIRES a space (`0.2s` not flagged, `0.2 s` flagged) — documented defensive invariant.
- **ENV_RE**: flags `NumPy 2.4.2`/`PyTorch 2.1.0`/`Mathlib v4.31.0` (stops at `\b`, suffix `-rc1` out of match); spares lib-without-version (`NumPy` alone, `NumPy 2` with 0 `.digit` groups).
- **STOCHASTIC**: requires keyword + ≥2-decimal number on the SAME line (`fitness 41.71` flagged, `41.71` alone not, `fitness 41` not).
- **STRUCTURAL_RE**: flags speedups `2.78e24x`/`4x`/`1,5x`; spares dimensions WxH (`100x100`/`1280x720` — `\b` after first `x` fails on following digit).
- **`_resolve_classes`** branching (artifact/machine/env/stochastic/structural/all); structural never in the `all` set.
- **structural never fails** (returns 0 even with findings + strict): the LEGITIME contract — structural is a deterministic speedup, inventoried only, never signaled.
- flaggable strict returns 1 with findings (REFUS), 0 without (OK); advisory rc=0.
- **`_declares_generated`**: detects FR/EN generator headers; the FR regex requires `fichier` *immediately* followed by `genere`.
- **`_skipped`**: `.claude`/`.lake`/`.pytest_cache`/`_peters`/`COURSE_CATALOG.generated` skipped; delivered prose not.
- **`_notebook_is_seeded`**: detects `np.random.seed`/`torch.manual_seed`/`random.seed`/`tf.random.set_seed`/`rng=N` in code cells (seeded notebook = reproducible = no stochastic signal).
- **`_findings_in_text`**: catalogs per-line; skips lines with generated markers; stochastic needs keyword same line.

## Validation

```
17 new tests pass
full notebook_tools/tests suite: 3883 passed, 0 failures, 0 regression, 69.5s
```
CPU-only (no git/network).

## Scope

- **1 new file** (`test_check_prose_quantitative_claims.py`, +280/−0). Catalogue **byte-identique** to main.
- No notebook re-exec (C.3 n/a).
- Collision guard: 0 open PRs touching `check_prose_quantitative_claims.py` (verified `gh pr list`).

See #9434 (partial: tests the instrument; the drainage itself is tracked separately).

/claim test-coverage check_prose_quantitative_claims
