### PR TITLE
fix(prover,#1453): wire _build_check_or_revert into the compile-fail streak

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -1179,6 +1179,50 @@ class TacticTools:
             self._state.consecutive_delta0_compiles = self._consecutive_delta0
             self._state.consecutive_compile_fail = self._consecutive_compile_fail  # P4 (c.317b)
 
+    def _bump_compile_fail(self) -> None:
+        """Count a build failure in _build_check_or_revert toward the fail streak.
+
+        compile() maintains _consecutive_compile_fail (inc on fail at tools.py:2067,
+        reset on success at 2021), but _build_check_or_revert() — the dominant
+        structural-edit path (~75 vs ~5 compile() calls per forensic trace) — did
+        NOT touch it, leaving the workflow yield-guard (workflow.py
+        FAIL_STREAK_HARDCAP=12, read between iterations) and the intra-turn
+        BUILD_FAIL_STORM entry-guards blind to build_check fails. Forensic #1453
+        (cycle-98): a single TacticAgent turn burned 1352s / 14 invisible
+        build_check fails on Voting L338 because the counter stayed at 0
+        throughout. Mirrors compile()'s semantic — every failed build (crash,
+        sorry-regressed veto, or hard revert) increments — so the dominant
+        file_replace_* path finally feeds the same streak the autonomous loop
+        already tracked.
+        """
+        self._consecutive_compile_fail += 1
+        if self._state is not None:
+            self._state.consecutive_compile_fail = self._consecutive_compile_fail
+
+    def _build_fail_storm_guard(self, tool_name: str) -> Optional[str]:
+        """Intra-turn entry-guard: stop editing once the fail streak hits the cap.
+
+        The workflow.py guard (FAIL_STREAK_HARDCAP) reads the counter BETWEEN agent
+        turns and yields, but a single TacticAgent turn issues many file_replace_*
+        calls in a row — so within one turn the counter could climb far past the
+        cap with no interruption (forensic #1453 cycle-98: 14 fails in one turn,
+        1352s burned). This guard returns a hard JSON error before any edit lands,
+        directing the agent to submit its best tactic or yield instead of
+        churning more fails. Sits right after _check_tool_loop in both
+        file_replace_lines and file_replace_sorry, so it caps both entry points.
+        """
+        if self._consecutive_compile_fail >= self._fail_streak_threshold:
+            return json.dumps({
+                "error": (
+                    f"BUILD_FAIL_STORM: {self._consecutive_compile_fail} "
+                    f"consecutive build failures (cap={self._fail_streak_threshold}). "
+                    f"The last {self._consecutive_compile_fail} edits all broke the "
+                    f"build — further editing is the same pathology. STOP editing. "
+                    f"Submit your best tactic via submit_tactic, or yield."
+                ),
+            }, ensure_ascii=False)
+        return None
+
     def _build_check_or_revert(self, original_content: str, operation: str
                                ) -> Optional[Dict]:
         """After writing, run lake build. If it fails, revert and return diagnostics.
@@ -1209,6 +1253,10 @@ class TacticTools:
         except Exception as e:
             # Verifier itself blew up — revert defensively and surface the error.
             Path(self._filepath).write_text(original_content, encoding="utf-8")
+            # #1453 forensic (cycle-98): a verifier crash is still a build fail
+            # for stagnation purposes — count it so the workflow / intra-turn
+            # guards see the streak (otherwise 14 invisible fails burned 1352s).
+            self._bump_compile_fail()
             return {
                 "error": f"Verifier crashed during {operation} build-check: {e}. Reverted.",
                 "reverted": True,
@@ -1231,6 +1279,10 @@ class TacticTools:
                 count_real_sorries(_content),
                 _count_sorries_from_build_output(result.get("raw_output", "")),
             )
+            # #1453 forensic (cycle-98): build succeeded -> reset the fail streak
+            # (mirrors compile() at tools.py:2021). _record_sorry_count then
+            # mirrors the reset counter into shared state.
+            self._consecutive_compile_fail = 0
             self._record_sorry_count(sorry_count)
             return None
 
@@ -1264,6 +1316,9 @@ class TacticTools:
                 count_real_sorries(_content),
                 _count_sorries_from_build_output(raw_output),
             )
+            # #1453 forensic (cycle-98): sorry-only build is logically a SUCCESS
+            # (no new syntax errors) -> reset the streak, mirroring compile().
+            self._consecutive_compile_fail = 0
             self._record_sorry_count(current_sorry)
             return None
 
@@ -1290,6 +1345,12 @@ class TacticTools:
                     tool_result=str(non_sorry_errors[:3]),
                 )
             # Return the errors so the agent knows what's broken, but don't revert
+            # #1453 forensic (cycle-98): the veto preserves progress but the build
+            # STILL failed — count it for streak parity with compile() (which
+            # increments on every fail regardless of sorry progress). _best_content
+            # is already saved above, so no progress is lost if the storm guard
+            # fires on the next edit.
+            self._bump_compile_fail()
             return {
                 "error": (
                     f"BUILD has {len(non_sorry_errors)} non-sorry errors, but sorry "
@@ -1305,6 +1366,10 @@ class TacticTools:
         Path(self._filepath).write_text(original_content, encoding="utf-8")
         raw_output = result.get("raw_output", "") or result.get("errors", "")
         errors = _parse_lean_errors(raw_output)  # #6790: authoritative parser
+        # #1453 forensic (cycle-98): the dominant-path gap — this is the branch
+        # that fired 14x invisibly on Voting L338. Bump the streak so the
+        # workflow / intra-turn guards can finally see a build_check fail storm.
+        self._bump_compile_fail()
 
         if self._trace:
             self._trace.log(
@@ -1338,6 +1403,9 @@ class TacticTools:
         loop_err = self._check_tool_loop("file_replace_lines", f"{start}:{end}:{new_content[:80]}")
         if loop_err:
             return loop_err
+        storm = self._build_fail_storm_guard("file_replace_lines")  # #1453 forensic (cycle-98)
+        if storm:
+            return storm
 
         # Context boundary: only allow replacing near the target sorry
         if self._sorry_ctx:
@@ -1687,6 +1755,9 @@ class TacticTools:
         loop_err = self._check_tool_loop("file_replace_sorry", f"{sorry_line}:{replacement[:80]}")
         if loop_err:
             return loop_err
+        storm = self._build_fail_storm_guard("file_replace_sorry")  # #1453 forensic (cycle-98)
+        if storm:
+            return storm
         try:
             # Context boundary: only allow replacing the target sorry
             if self._sorry_ctx:

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -3919,3 +3919,161 @@ def test_empty_response_guard_injects_fallback(monkeypatch):
     assert kwargs["role"] == "empty_response_guard"
     assert "injected fallback" in kwargs["content"]
 
+
+# ──────────────────────────────────────────────────────────────────────────
+# #1453 forensic (cycle-98) — _build_check_or_revert feeds the fail streak
+# ──────────────────────────────────────────────────────────────────────────
+# compile() maintains _consecutive_compile_fail (inc on fail at tools.py:2067,
+# reset on success at 2021), but _build_check_or_revert() — the dominant
+# file_replace_* path (~75 vs ~5 compile() calls per forensic trace) — did NOT
+# touch it. Result: 14 invisible build_check fails burned 1352s in a single
+# TacticAgent turn on Voting L338, because the counter stayed at 0 and neither
+# the workflow yield-guard (FAIL_STREAK_HARDCAP=12, read between turns) nor any
+# intra-turn guard could see the streak. The fix: every build_check fail
+# (crash / veto / hard-revert) bumps the streak, every success resets it, and
+# an intra-turn BUILD_FAIL_STORM entry-guard stops editing once the cap is hit.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _fail_verifier_factory(raw_output=(
+        "Fake.lean:5:3: error: unknown identifier 'bar'\n"
+)):
+    """A verifier whose verify_project_file always reports a NON-sorry error.
+
+    The raw_output carries a real compile error (unknown identifier) so
+    _build_check_or_revert reaches the hard-revert branch (not the sorry-only
+    acceptance branch) — exercising the dominant forensic failure path.
+    """
+
+    class _FailVerifier:
+        def verify_project_file(self, rel, force=False):
+            return {"success": False, "errors": raw_output,
+                    "raw_output": raw_output}
+
+    return lambda *a, **k: _FailVerifier()
+
+
+def _success_verifier_factory():
+
+    class _OkVerifier:
+        def verify_project_file(self, rel, force=False):
+            return {"success": True, "errors": "", "raw_output": ""}
+
+    return lambda *a, **k: _OkVerifier()
+
+
+def _patch_verifier(monkeypatch, factory):
+    import prover.verifier as vmod
+    monkeypatch.setattr(vmod, "get_verifier", factory)
+
+
+def _pad(body, sorry_line_target):
+    """Pad a body with comments so the file-size guard (>50% delta) never fires.
+
+    Mirrors the tactic_tools fixture padding.
+    """
+    head = "\n".join(f"-- comment line {i}" for i in range(50))
+    tail = "\n".join(f"-- trailing line {i}" for i in range(50))
+    return head + "\n" + body + tail + "\n"
+
+
+def test_build_check_revert_increments_fail_streak(monkeypatch, tmp_path):
+    """A build_check fail (hard-revert branch) must bump _consecutive_compile_fail.
+
+    Regression fence for the #1453 cycle-98 forensic: before the fix, the
+    dominant file_replace path left the counter at 0 even after many reverts,
+    so the workflow/intra-turn guards were blind to the fail storm.
+    """
+    fake = tmp_path / "Fake.lean"
+    inner = "theorem t : True := by\n  sorry\n"
+    body = _pad(inner, 5)
+    fake.write_text(body, encoding="utf-8")
+    sorry_line = next(i + 1 for i, ln in enumerate(body.split("\n"))
+                      if "sorry" in ln)
+
+    state = ProofState(theorem_statement="t")
+    sctx = SorryContext(filepath=str(fake), sorry_line=sorry_line,
+                        indentation=2, indent_str="  ", full_file=body)
+    tt = TacticTools(state, str(fake), sctx)
+
+    _patch_verifier(monkeypatch, _fail_verifier_factory())
+
+    # current on disk == original => sorry unchanged => NOT the veto branch =>
+    # the hard-revert branch (the one the forensic trace hit 14x).
+    result = tt._build_check_or_revert(original_content=body, operation="test")
+
+    assert result is not None and result.get("reverted") is True, result
+    assert tt._consecutive_compile_fail == 1, "revert must bump the fail streak"
+    assert state.consecutive_compile_fail == 1, "streak must mirror to shared state"
+    # File was reverted to the original.
+    assert fake.read_text(encoding="utf-8") == body
+
+
+def test_build_check_success_resets_fail_streak(monkeypatch, tmp_path):
+    """A successful build_check must reset _consecutive_compile_fail to 0.
+
+    Mirrors compile():2021. Without the reset, a single success after a long
+    storm would leave the streak high enough to trip the entry-guard on the
+    next (normal) edit.
+    """
+    fake = tmp_path / "Fake.lean"
+    body = "import Mathlib.Tactic\ntheorem t : True := by\n  trivial\n"
+    fake.write_text(body, encoding="utf-8")
+    state = ProofState(theorem_statement="t")
+    sctx = SorryContext(filepath=str(fake), sorry_line=3,
+                        indentation=2, indent_str="  ", full_file=body)
+    tt = TacticTools(state, str(fake), sctx)
+
+    # Pre-arm a streak as if prior edits had failed.
+    tt._consecutive_compile_fail = 5
+    state.consecutive_compile_fail = 5
+
+    _patch_verifier(monkeypatch, _success_verifier_factory())
+
+    result = tt._build_check_or_revert(original_content=body, operation="test")
+
+    assert result is None, "successful build_check must return None"
+    assert tt._consecutive_compile_fail == 0, "success must reset the fail streak"
+    assert state.consecutive_compile_fail == 0, "reset must mirror to shared state"
+
+
+def test_build_fail_storm_guard_blocks_editing_at_cap(tactic_tools):
+    """Once the streak hits the cap, file_replace_sorry returns BUILD_FAIL_STORM.
+
+    This is the intra-turn guard the forensic asked for: the workflow guard
+    only reads the counter BETWEEN turns, so within one turn an agent could
+    churn many more fails. The entry-guard short-circuits before any edit.
+    """
+    import json
+    tt = tactic_tools
+    cap = tt._fail_streak_threshold
+    tt._consecutive_compile_fail = cap
+    before = Path(tt._filepath).read_text(encoding="utf-8")
+
+    out = json.loads(
+        tt.file_replace_sorry(tt._test_sorry_line, "trivial", build_check=False)
+    )
+
+    assert "error" in out
+    assert "BUILD_FAIL_STORM" in out["error"]
+    assert str(cap) in out["error"]
+    # No edit landed, no further fail counted: file + counter unchanged.
+    assert Path(tt._filepath).read_text(encoding="utf-8") == before
+    assert tt._consecutive_compile_fail == cap
+
+
+def test_build_fail_storm_guard_passes_below_cap(tactic_tools):
+    """Below the cap the guard must let the edit through (no false positive)."""
+    import json
+    tt = tactic_tools
+    tt._consecutive_compile_fail = tt._fail_streak_threshold - 1
+
+    out = json.loads(
+        tt.file_replace_sorry(tt._test_sorry_line, "trivial", build_check=False)
+    )
+
+    # No BUILD_FAIL_STORM error (the edit went through; build_check=False so it
+    # reports success without touching the verifier).
+    err = out.get("error", "")
+    assert "BUILD_FAIL_STORM" not in err
+


### PR DESCRIPTION
## Forensic finding (cycle-98, autonomous L338 Voting)

`_build_check_or_revert` — the dominant `file_replace_*` path (~75 vs ~5 `compile()` calls per forensic trace) — did **NOT** touch `_consecutive_compile_fail`. A single TacticAgent turn burned **1352s / 14 invisible build_check fails** on Voting L338 because the counter stayed at `0` throughout:

- the workflow yield-guard (`FAIL_STREAK_HARDCAP=12`, read **between** agent turns) never saw the streak;
- there was no intra-turn guard at all.

This is the remaining gap after PR #6102 (P4 / c.317b), which wired the counter to **`compile()`** only — the periodic autonomous-loop path (~5 calls). The dominant per-edit path stayed dark.

| Path | Counter wired? | Calls/trace |
|------|----------------|-------------|
| `compile()` | ✅ (#6102) | ~5 |
| `_build_check_or_revert` (`file_replace_*`) | ❌ **(this PR)** | ~75 |

## Fix — two related changes, one PR

**1. `_build_check_or_revert` now feeds the streak** (`prover/tools.py`), mirroring `compile()`'s semantic — every failed build increments, every success resets (`tools.py:2021/2067`):
- crash branch → `_bump_compile_fail()`
- sorry-regressed veto branch → `_bump_compile_fail()` (build still failed; `_best_content` already saved so no progress lost)
- hard-revert branch (the one the forensic hit 14×) → `_bump_compile_fail()`
- clean-success & sorry-only-success branches → `self._consecutive_compile_fail = 0`

`_bump_compile_fail()` mirrors the incremented value into `self._state.consecutive_compile_fail`, so the workflow guard sees it on the next turn.

**2. New intra-turn entry-guard** `_build_fail_storm_guard()`: once the streak hits `_fail_streak_threshold` (12), `file_replace_lines` and `file_replace_sorry` return a hard `BUILD_FAIL_STORM` JSON error **before any edit lands**. This closes the within-turn gap the workflow guard cannot reach — it only reads the counter between agent turns.

## Not a refactor

Per [pr-review-discipline.md](.claude/rules/pr-review-discipline.md) §B (prover-Python changes must be justified toward the Lean claim): this is a **targeted bug fix**, not a refactor. It extends an existing stagnation invariant (already enforced on `compile()`) to the dominant edit path, so the harness stops burning iteration budget on invisible fail storms — directly serving the Lean proof goal (#1453 acceptance: ≥1 forensic finding + ≥1 harness PR).

## Validation (real, not keyword)

```
626 passed in 3.25s   # full prover suite (26 files), 0 regression
```

4 new hermetic regression tests in `test_prover_guards.py` (mock verifier — no lake / no network):
- `test_build_check_revert_increments_fail_streak` — fail → bump + mirror + file reverted
- `test_build_check_success_resets_fail_streak` — success → reset + mirror (pre-armed streak=5 → 0)
- `test_build_fail_storm_guard_blocks_editing_at_cap` — at cap → `BUILD_FAIL_STORM`, no edit, counter unchanged
- `test_build_fail_storm_guard_passes_below_cap` — cap−1 → edit goes through (no false positive)

No `*.lean` file touched (0), so the §B `grep -c sorry` / `lake build` criteria are N/A — this is harness Python only.

## Files

| File | Change |
|------|--------|
| `prover/tools.py` | 2 helpers (`_bump_compile_fail`, `_build_fail_storm_guard`) + 4 increment/reset points in `_build_check_or_revert` + 2 entry-guards (`file_replace_lines`, `file_replace_sorry`) |
| `tests/test_prover_guards.py` | 4 regression tests + mock-verifier helpers |

See #1453 (partial: 1 forensic finding + 1 harness PR). Related: #6102 (the `compile()` half of this same counter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)