### PR TITLE
fix(scanner,#9434): exclude issue refs #NNNN from measure regexes (FP ICT-21 #5101)

### DIFF
--- a/scripts/notebook_tools/check_prose_quantitative_claims.py
+++ b/scripts/notebook_tools/check_prose_quantitative_claims.py
@@ -110,8 +110,12 @@ ARTIFACT_NOUNS = r"(?:lignes?|lines?|cellules?|cells?|notebooks?|modules?|fichie
 
 # Formes attrapees : « (140 lignes) », « ~525 lignes », « **224** notebooks »,
 # « 87 cellules ». Le nombre doit preceder immediatement le nom d'artefact.
+#
+# Note fix (#9434 angle-mort t2) : le lookbehind exclut aussi « # » -- un nombre
+# precedent immediatement un diese est une reference (issue/PR GitHub « #5101 »,
+# couleur hex « #333333 », ancre/titre markdown), jamais une mesure d'artefact.
 COUNT_RE = re.compile(
-    r"(?<![\w.])~?\*{0,2}\d{1,6}\*{0,2}\s+" + ARTIFACT_NOUNS + r"(?![\w-])",
+    r"(?<![\w.#])~?\*{0,2}\d{1,6}\*{0,2}\s+" + ARTIFACT_NOUNS + r"(?![\w-])",
     re.IGNORECASE,
 )
 
@@ -123,8 +127,14 @@ COUNT_RE = re.compile(
 # avant elle pour eviter les collisions (suffixes, abreviations) ; les unites
 # multilettres (ms/sec/min/...) tolerent un espace optionnel. Advisory : un FP
 # residuel est acceptable, l'arbitrage est humain (cf angle-mort header).
+#
+# Note fix (#9434 angle-mort t2, incident ICT-21) : le lookbehind exclut « # »
+# -- sinon un numero d'issue « #5101 s'en dérive » (cell26 ICT-21) etait matche
+# comme la duree « 5101 s ». Idem pour toute reference « #NNNN » suivie d'un mot
+# en s-/m-/ms/sec/min (144 occurrences repertoriees : issues, couleurs hex).
+# Une vraie mesure « ~50 s » (precedee de ~, pas de #) reste capturee.
 MACHINE_RE = re.compile(
-    r"(?<![\w.])~?\d{1,6}(?:[.,]\d{1,3})?"
+    r"(?<![\w.#])~?\d{1,6}(?:[.,]\d{1,3})?"
     r"(?:"
     r"\s?(?:ms|millisecondes?|sec(?:ondes?)?|min(?:utes?)?)"
     r"|\ss"
@@ -167,7 +177,7 @@ STOCHASTIC_KW_RE = re.compile(
     r"auc|roc|moyenne|moyen)\b",
     re.IGNORECASE,
 )
-STOCHASTIC_NUM_RE = re.compile(r"(?<![\w.])~?\*{0,2}\d{1,6}\.\d{2,}\*{0,2}(?![\w])")
+STOCHASTIC_NUM_RE = re.compile(r"(?<![\w.#])~?\*{0,2}\d{1,6}\.\d{2,}\*{0,2}(?![\w])")
 SEED_RE = re.compile(
     r"(?:np\.random\.seed|numpy\.random\.seed|random\.seed|"
     r"torch\.manual_seed|tf\.random\.set_seed|jax\.random\.PRNGKey|"
@@ -191,7 +201,7 @@ SEED_RE = re.compile(
 # 'x' optionnel. Les dimensions WxH (ex. « 100x100 », « 1280x720 ») restent
 # exclues : le ``\b`` apres le premier 'x' echoue (suivi d'un chiffre).
 STRUCTURAL_RE = re.compile(
-    r"(?<![\w.])~?\d+(?:[.,]\d+)?(?:e\d+x?|x)\b",
+    r"(?<![\w.#])~?\d+(?:[.,]\d+)?(?:e\d+x?|x)\b",
     re.IGNORECASE,
 )
 

--- a/scripts/notebook_tools/tests/test_check_prose_quantitative_claims.py
+++ b/scripts/notebook_tools/tests/test_check_prose_quantitative_claims.py
@@ -82,6 +82,37 @@ def test_machine_re_monoletter_s_requires_space():
     assert cqc.MACHINE_RE.search("0.2s") is None
 
 
+def test_issue_reference_not_flagged_as_measure():
+    """Une reference d'issue/PR GitHub « #NNNN » suivie d'un mot commencant par
+    s/m/ms/sec/min ne doit JAMAIS etre matchee comme une duree -- un nombre
+    precedent immediatement un diese est une reference (issue/PR, couleur hex,
+    ancre/titre markdown), pas une mesure.
+
+    Incident fondateur (#9434 angle-mort t2) : ICT-21 portait « Issue : #5101. »
+    et « amendé de #5101 s'en dérive » -> le scanner classait « 5101 s » en duree
+    machine (2 FP confirmes sur origin/main). Idem un ledger « #015 Argument... »
+    flagge comme « 015 s ». Fix : lookbehind « (?<![\\w.#]) » sur les 4 regex de
+    mesure. La vraie mesure « ~50 s sur GPU » (precedee de ~, pas de #) reste
+    capturee -- c'est le contrat du fix (corriger le FP sans perdre la mesure)."""
+    # Issue/PR refs + mot en s/m/ms/sec/min : JAMAIS une duree machine.
+    for snippet in ["amendé de #5101 s'en dérive",
+                    "Issue : #5101.",
+                    "ce notebook = #5101 ;",
+                    "merge #866 sur claim non-verifie",
+                    "couleur #333333 sur fond clair"]:
+        assert cqc.MACHINE_RE.search(snippet) is None, (
+            f"ne doit PAS flagger la reference #NNNN {snippet!r}"
+        )
+    # La vraie mesure (sans # precedent) reste capturee : contrat du fix.
+    assert cqc.MACHINE_RE.search("prend ~50 s sur GPU") is not None
+    assert cqc.MACHINE_RE.search("duree : 12 ms") is not None
+    # Le guard « # » couvre les 4 classes de mesure : un numero reference n'est
+    # ni un artefact, ni un speedup, ni une valeur stochastique.
+    assert cqc.COUNT_RE.search("voir PR #140 lignes supprimees") is None
+    assert cqc.STRUCTURAL_RE.search("ref issue #4x") is None
+    assert cqc.STOCHASTIC_NUM_RE.search("score fitness #41.71") is None
+
+
 # --------------------------------------------------------------------------- #
 #  Classe env (ENV_RE) : version de librairie figee en prose
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Grain: MED/script-python — lane myia-po-2023:CoursIA — prev: MED/notebook-python #9625 (App-11-Picross drain)

See #9434 (EPIC mesures non reproductibles) + #9377 (compteurs d artefacts). **Partial** : amelioration de precision du scanner advisory que TOUT le cluster utilise pour le drainage #9434, pas un drainage notebook.

## Le bug

Le scanner canonique `check_prose_quantitative_claims.py` (merge via #9427/#9476) flaggait les **references d issue/PR GitHub** `#NNNN` suivies d un mot en s-/m-/ms-/sec-/min- comme des **durees machine-dependantes**. Confirme firsthand sur origin/main :

```
python ... --all --class machine
-> MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb  (2)  5101 s, ~50 s
```

Mais `5101 s` = `#5101 s en derive` (cell26 : « amendé de #5101 s en dérive ») = **reference d issue #5101 + mot commencant par s**, PAS une mesure. Cell0 : « Issue : #5101. », cell27 : « ce notebook = #5101 » — tous des FP.

Root cause : `#` est le sigil universel de reference (issue/PR GitHub, couleur hex `#333333`, ancre/titre markdown). Le lookbehind `(?<![\w.])` ne bloquait pas `#` car ce n est ni un word-char ni un `.`. Un chiffre immediatement precede de `#` n est JAMAIS une mesure, pour aucune classe.

## Le fix

Ajout de `#` au lookbehind negatif des **4 regex de mesure** :

| Regex | Classe | Avant | Apres |
|-------|--------|-------|-------|
| `COUNT_RE` | artifact #9377 | `(?<![\w.])` | `(?<![\w.#])` |
| `MACHINE_RE` | machine #9434 | `(?<![\w.])` | `(?<![\w.#])` |
| `STOCHASTIC_NUM_RE` | stochastic #9434 | `(?<![\w.])` | `(?<![\w.#])` |
| `STRUCTURAL_RE` | structural #9434 | `(?<![\w.])` | `(?<![\w.#])` |

`ENV_RE` non concernee (matche `<Lib> <version>`, commence par un mot).

## Validation (preuves verifiables)

- **18 tests passent** (17 existants + 1 nouveau test de regression). **0 regression** sur les cas documentes.
- **2 FP confirmes elimines** dans le contenu scanne reel :
  - ICT-21 `5101 s` (#5101 issue ref) — le notebook passe de `(2) 5101 s, ~50 s` a `(1) ~50 s`
  - ledger `docs/archive/ledgers-reviews/2026-07-10-h4-sweep-5963.md` `015 s` (#015 Argument_Analysis ref) — passe de `(2) 015 s, 30min` a `(1) 30min`
- **Vraies mesures PRESERVEES** (precedees de `~` ou rien, pas de `#`) : `prend ~50 s sur GPU` (ICT-21 cell6, duree extraction GPU), `12 ms`, `30min` restent flagguees.
- **Test anti-regression** : le nouveau test `test_issue_reference_not_flagged_as_measure` **ECHOUE** sur le scanner origin/main (matche `5101 s`) -> la regression est verrouillee.

## Pourquoi MED/script-python (pas LIGHT)

L instrument est central : le scanner est invoque par la CI (`prose-counts-guard.yml`) et par tout agent faisant du drainage #9434 (audit advisory avant/apres). Reduire ses FP = meilleur signal/bruit pour le cluster entier. Scope du bug a l echelle repo : 144 occurrences brutes du pattern `#NNNN` + mot en s/m/ms/sec/min (issues, couleurs hex), dont la grande majorite dans `.claude/` (harnais skippe) ou des cellules code (non scannees) — 2 touchent le contenu livre.

## R6 / Variete

Rotation 7e famille/genre ce cycle : apres 5 drainages notebook (LocalLama x2, SC-16, SW-13, App-11), pivot vers **tooling substance** (ameliorer l outil de mesure plutot que l utiliser). Coherent avec R6.6 (variete genres ET familles : le tarissement du drainage ne doit pas bloquer la production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)