### PR TITLE
fix(notebook,#9434): drain GameTheory-1-Setup machine-class timing claim (cell 1)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
@@ -42,10 +42,7 @@
     "### Prerequis\n",
     "\n",
     "- Python 3.9+ installe\n",
-    "- Connaissances basiques en Python et NumPy\n",
-    "\n",
-    "### Duree estimee : 20 minutes"
-   ]
+    "- Connaissances basiques en Python et NumPy\n"   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Grain: MED/tooling/notebook-python — lane myia-po-2023:CoursIA-2 — prev: LIGHT/guard #9624

# fix(notebook,#9434): drain GameTheory-1-Setup machine-class timing claim (cell 1)

**Branch** : `feature/c943-gt1-setup-timing-drain` based on `origin/main` @ `62e745802`.
**Refs** : #9434 (partial: GT-1-Setup pilot on the machine-class sweep).

## Contexte

Le scanner `check_prose_quantitative_claims.py --class machine` (4-class taxonomy #9484) flaggait 1 hit dans `GameTheory-1-Setup.ipynb` cell#1 markdown intro :

```
### Duree estimee : 20 minutes
```

C'est une **machine-class** claim (#9484 taxonomy) : le timing est dominé par `pip install nashpy openspiel` qui varie 10×+ entre machines (no GPU / container vs venv / network). Le prose ne peut pas tenir ce compteur honnêtement ; il appartient au log de run, pas au notebook (#9377 cadence : **CI tient les compteurs quantitatifs, prose tient le prédicat**).

Ce PR rejoint la cohorte `#9434 cadence` (#9620 SC-16 CKKS stochastic, #9398 sudoku, #9397 csp, #9439 search, #9406 sudoku-2, #9404 sudoku-1, #9444 gametheory-versions — toutes MERGED sauf GT-1-Setup resté hors balayage initial car sa version `cells[1].source[14]` n'avait pas été inspectée).

## Disposition (1 fichier, +1/-4 atomic)

| Fichier | Changement | Lignes |
|---|---|---:|
| `MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb` | Strip `### Duree estimee : 20 minutes` + entrée empty-line qui la précédait (séparateur de cellule#1 source) | 1+/4- |

**Aucun twin pair à mettre à jour** : `gametheory-1-setup` n'a pas de sibling C# dans `twin_pairs.d/` (vérifié).

## Preuves (G.9 verify-before-claiming, firsthand)

1. **Strip byte-level C955-1 ★★★** : fichier 137785 → 137736 bytes (delta -49). Le slice retiré = `,\n    "\n",\n    "### Duree estimee : 20 minutes"\n` (49 bytes), qui inclut la virgule de séparation + l'entrée empty-line redondante + l'entrée timing. JSON round-trip OK, 68 cellules préservées, total cell count inchangé.

2. **LF-only CR=0, BOM=False** (C9535-item4-bis-L1 ★★ Python byte-check = source de vérité) :
   ```
   data.count(b'\r') = 0
   data[:3] != b'\xef\xbb\xbf'
   ```

3. **Scanner** :
   ```
   check_prose_quantitative_claims.py --all --class machine | grep GameTheory-1-Setup.ipynb
   -> (vide, 0 hit)
   ```
   Avant : 1 hit ("20 minutes"). Après : 0 hit. Vérifié firsthand post-modif.

4. **Résidu artifact-class vérifié hors scope** : `--class artifact` flag encore `**17 notebooks**` (référence bibliographique au nombre de notebooks de la série GT, pas un timing). **Volontairement laissé intact** : c'est un claim structurel que le scanner traitera dans une tranche séparée (les claims artifact ne sont pas dans le périmètre machine-class).

5. **Cell#1 rendue intacte** : la cellule finit sur l'entrée Prerequis `'- Connaissances basiques en Python et NumPy\n'`. Pas de markdown cassé (juste un timing retiré, pas de titre H3 orphelin).

6. **L898 ★★★ collision guard** : `gh pr list --state open --json number,files` filtré sur `GameTheory-1-Setup.ipynb` = **0 PR OPEN**. `gh pr list --search "head:feature/c943-gt1-setup-timing-drain"` = 0 PR (branche fraîchement poussée).

7. **Diff scope** : 1 fichier, 1 insertion, 4 deletions = 5 lignes changed, 1 feature (drain machine-class claim), 1 domaine (notebook-python). R3 ✓ (<3000 lignes, <15 fichiers, <4 features).

## Diagnostic C.4 (cause + verdict)

**Cause** : la cellule#1 de GT-1-Setup a été introduite avec un titre H3 "Duree estimee : 20 minutes" sans mécanisme CI pour le tenir à jour (pas de compteur d'artefact, pas de log parsé). Le claim devenait progressivement faux (pip install Nashpy/OpenSpiel en 2026 ≠ 2024) sans qu'aucun re-exec ne le détecte, parce que la cellule est du markdown pur (pas de code → pas de cache miss).

**Verdict** : **CAUSE_FIXED** localement (claim retiré). Cause systémique (les claims prose-quantitatifs sans ancrage CI se dégradent en silence) = adressée par le scanner `#9484` qui les détecte, et par le guard `prose-quantitative-claims-guard.yml` qui les fail. **Prévention systémique** : **déjà en place** (#9484 scanner + cron CI quotidien). Aucune action supplémentaire requise côté worker.

## Disposition alternative écartée (G.9)

**Option « ré-exécuter pour mesurer le timing frais et le ré-ancrer »** : écartée — un notebook `Setup` n'a **pas de** `execution_count` durable (le re-exec varie selon le host), et ancrer un timing précis dans la prose = réintroduire la dérive (prose non gardée par CI run-time). Le claim-timing n'a pas sa place dans la doc pédagogique d'un setup.

**Option « remplacer par une fourchette "15-30 min selon machine" »** : écartée — c'est une **autre prose-quantitative-claim** (classe env, où le range reste un compteur non-ancré CI). Le scanner `env` la flaggera au prochain passage. Le pattern "strip, ne pas paraphrase" est la résolution canonique (#9377 + #9434).

## Suivi #9434 cadence

| Date | PR | Famille | Cell touchée | Classe | Statut |
|---|---|---|---|---|---|
| 2026-07 | [#9444](https://github.com/jsboige/CoursIA/pull/9444) | gametheory-versions | multi | machine | MERGED (mais timing GT-1-Setup non couvert) |
| 2026-08 | **cette PR** | gametheory-1-setup | cell#1 | machine | OPEN MERGEABLE |

**#9434 followups restants** (out of scope worker) :
- Gametheory-1-Setup **résidu artifact-class** `**17 notebooks**` — sera traité quand l'axe artifact sera sweepé (coordinateur).
- Autres notebooks GT potentiellement flaggés machine : à scanner en bloc, fenêtre multi-cycle.

## Leçons appliquées

- **C955-1 ★★★** : strip byte-level JAMAIS resérialisation (`json.load` + `json.dump` aurait ré-écrit le fichier avec whitespace différent et aurait pété la diff byte-level ; un sed/awk Python byte-level preserve).
- **L898 ★★★** : collision guard vérifié (0 PR OPEN sur le chemin du fichier) AVANT de push.
- **L677-L4 ★★** : PR body HORS worktree (ce fichier dans scratchpad).
- **L948 ★★** : 0 fabrication, 0 contournement, sources byte-identiques sauf la ligne strippée.
- **L989 ★★★ étendu (wakeup 39)** : push via `git -c http.extraHeader="Authorization: Basic ..."` car credential store global = `jsboigeEpita`.
- **C9535-item3-item6-L1 ★★** : `Co-Authored-By` trailer présent (vérifié via `git log -1 --format='%B' | grep Co-Authored-By`).
- **C9535-item4-bis-L1 ★★** : byte-check LF/BOM via Python `data.count(b'\r')` (source de vérité unique, pas shell).
- **C9535-item10-L1 ★★** : PR create via REST API PowerShell `Invoke-RestMethod` (gh pr create échoue car `jsboigeEpita` non-collaborator).

## Liens

- **#9434** — Issue parente (prose quantitative claims drain cadence)
- **#9484** — Scanner 4-class taxonomy (`check_prose_quantitative_claims.py`)
- **#9377** — Cadence "compteurs CI, prédicats prose"
- **#9620** — Sœur SC-16 CKKS stochastic (latest merged)
- **#9444** — Sœur gametheory-versions (machine-class sweep gametheory mais GT-1-Setup raté)
- **#9623** — Tests `check_prose_quantitative_claims` (17 invariants)
- CLAUDE.md global « Consolider != Archiver » — la prose quantitative non-ancrée CI est une dette qu'on drain
- `.claude/rules/catalog-pr-hygiene.md` — R3 atomique <3000L / <15 fichiers
- `.claude/rules/pr-review-discipline.md` — §E audit README fichier-entier (N/A ici, 1 fichier)
- `.claude/rules/anti-regression.md` — pas applicable (markdown pédagogique, pas de code de production)
