### PR TITLE
test(ict-4,#4588): 6 edge-case tests for kin_sorting untested branches

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_kin_sorting.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_kin_sorting.py
@@ -98,3 +98,102 @@ def test_repulsion_segregates():
 def test_kin_sign_validation():
     with pytest.raises(ValueError):
         KinSortingArray([1, 2, 3], kin_sign=0)
+
+
+# --- Contrats supplementaires : branches et cibles non couvertes ---
+
+
+def test_record_false_reaches_fixed_point_without_per_step_snapshots():
+    """run(record=False) suit un chemin de code separe (pas d'appel a step(),
+    donc pas de snapshot par pas) : il n'enregistre que l'etat final. Doit
+    quand meme atteindre le point fixe (tri + aucun mouvement), mais la sonde
+    ne contient que l'instantane initial + le final -- jamais la trajectoire
+    pas-a-pas. Contraste avec record=True qui accumule un instantane par pas."""
+    vals, algos = _value_classes(6, 4, seed=2)
+    a = KinSortingArray(vals, algotypes=algos, seed=2, kin_affinity=True).run(record=False)
+    assert a.values == sorted(vals)          # tri preserve malgre l'absence de snapshots par pas
+    assert a.has_move() is False             # point fixe atteint (ni tri ni kin)
+    assert len(a.probe.values) == 2          # initial + final seulement
+    # Contraste : record=True accumule un instantane par pas (init + un par step).
+    b = KinSortingArray(vals, algotypes=algos, seed=2, kin_affinity=True).run()
+    assert len(b.probe.values) == b.steps + 1
+    assert len(b.probe.values) > 2
+
+
+def test_max_steps_caps_run_before_convergence():
+    """max_steps plafonne le nombre d'activations : sur un grand tableau non
+    trie, run(max_steps=5) s'arrete au bout d'exactement 5 pas sans avoir
+    converge (has_move encore vrai) -- c'est le plafond, pas le point fixe,
+    qui arrete la dynamique."""
+    for s in range(5):
+        v = random.Random(s).sample(range(24), 24)
+        algos = _alternating(24)
+        a = KinSortingArray(v, algotypes=algos, seed=s,
+                            kin_affinity=False).run(max_steps=5)
+        assert a.steps == 5                  # plafond atteint exactement
+        assert a.has_move() is True          # 5 pas ne suffisent pas a trier 24 elements
+
+
+def test_has_move_false_at_fixed_point():
+    """Au point fixe, has_move() est False (ni tri ni kin) -- c'est la condition
+    d'arret de run(). Les tests existants verifier values==sorted ; celui-ci
+    verifie directement le signal d'inactivite du systeme converge."""
+    for s in range(5):
+        vals, algos = _value_classes(6, 4, seed=s)
+        a = KinSortingArray(vals, algotypes=algos, seed=s, kin_affinity=True).run()
+        assert a.has_move() is False
+
+
+def test_all_frozen_is_inert():
+    """Un tableau entierement gele est inerte : aucune cellule ne peut agir.
+    has_move()==False, step()==False (retour anticipe avant tout increment),
+    run() est un no-op (0 pas), valeurs inchangees, et la sonde ne contient
+    que l'instantane initial."""
+    vals = [3, 1, 2, 1]
+    algos = ["bubble", "insertion", "bubble", "insertion"]
+    frozen = [True, True, True, True]
+    a = KinSortingArray(vals, algotypes=algos, frozen=frozen, seed=0)
+    assert a.has_move() is False
+    assert a.step() is False                 # retour anticipe, pas de step/snapshot
+    a.run()
+    assert a.steps == 0
+    assert a.values == vals                  # rien n'a bouge
+    assert len(a.probe.values) == 1          # instantane initial seulement
+
+
+def test_bidirectional_false_disables_repair():
+    """Le drapeau bidirectional=False desactive la reparation par second voisin
+    dans KinSortingArray lui-meme : sur l'alternance d'algotypes (impasse
+    chimerique), le tri echoue au moins parfois. Mirroir direct de
+    test_bidirectional_cures_chimeric_deadlock, mais isole le drapeau sur la
+    classe KinSortingArray (pas seulement le constat que SelfSortingArray cale)."""
+    n = 20
+    failed = 0
+    for s in range(20):
+        v = random.Random(s).sample(range(n), n)
+        algos = _alternating(n)
+        a = KinSortingArray(v, algotypes=algos, seed=s,
+                            bidirectional=False, kin_affinity=False).run()
+        if a.values != sorted(v):
+            failed += 1
+    assert failed > 0                        # sans reparation, l'impasse chimerique persiste
+
+
+def test_targeting_helpers_and_frozen_exclusion():
+    """Contrats des fonctions de ciblage, testes directement (white-box) :
+    _sort_target localise une inversion selon la direction primaire de
+    l'algotype ; _kin_adjacency (static) compte les paires adjacentes de meme
+    algotype ; _kin_target exclut un voisin gele meme s'il a la meme valeur."""
+    # _sort_target : bubble regarde a droite, insertion a gauche.
+    a = KinSortingArray([2, 1], algotypes=["bubble", "insertion"], seed=0)
+    assert a._sort_target(0) == 1            # bubble, 2 > 1 -> voisin de droite
+    assert a._sort_target(1) == 0            # insertion, 1 < 2 -> voisin de gauche
+    # _kin_adjacency (static) compte les paires adjacentes de meme algotype.
+    assert KinSortingArray._kin_adjacency(["bubble", "bubble", "insertion", "insertion"]) == 2
+    assert KinSortingArray._kin_adjacency(["bubble", "insertion", "bubble"]) == 0
+    # _kin_target : voisin gele exclu meme s'il a la meme valeur.
+    b = KinSortingArray([1, 1, 1], algotypes=["insertion", "bubble", "insertion"],
+                        frozen=[True, False, False], seed=0)
+    # cellule 1 (bubble, valeur 1) : le voisin 0 est gele -> exclu ; le voisin 2
+    # est sain, de valeur egale, et l'echange augmente l'agregation -> seul candidat.
+    assert b._kin_target(1) == 2


### PR DESCRIPTION
Grain: MED/test — lane myia-po-2025:CoursIA — prev: LIGHT/notebook-python (#9628)

See #4588 (ICT series). The `ict/kin_sorting.py` module (231 src lines, ICT-4: self-sorting arrays with bidirectional repair + kin affinity / Schelling segregation) had 6 existing tests covering the main behaviors, but several **code branches and targeting contracts** were untested. This adds 6 edge-case tests covering genuine untested paths — not trivia.

## G-VAR-3 note (test genre, distinct substance)

prev grain was LIGHT/notebook-python (#9628 Sudoku drainage). This pivots to MED/test on a **distinct module + domain**: kin_sorting (self-sorting **dynamics** with kin affinity + bidirectional repair) ≠ my prior test grains (signaling_convention / active_inference / symbol_invention — signaling/bandit games) ≠ po-2024's sorting_metrics (metrics, not dynamics). Each is a genuinely distinct scientific domain with its own untested contracts.

## Coverage gaps filled (all verified firsthand against the 6 existing tests)

| Test | Contract tested | Was untested because |
|---|---|---|
| `test_record_false_reaches_fixed_point_without_per_step_snapshots` | `run(record=False)` is a **separate code path** (no `step()` call, no per-step snapshot) that still reaches the fixed point; probe holds only init+final (len==2), vs record=True (len==steps+1) | The entire `record=False` branch was never exercised (all tests use default `record=True`) |
| `test_max_steps_caps_run_before_convergence` | `run(max_steps=5)` stops at exactly 5 steps with `has_move()` still True (cap, not fixed-point, stops it) | The `max_steps` cap behavior was untested (all tests rely on default 40000 and full convergence) |
| `test_has_move_false_at_fixed_point` | After full `run()`, `has_move() is False` (the actual termination signal) | Existing tests check `values==sorted` but never the `has_move()==False` signal directly |
| `test_all_frozen_is_inert` | All-frozen array: `has_move()==False`, `step()==False` (early return before steps++/snapshot), `run()` no-op (0 steps), values unchanged, probe==1 snapshot | The all-frozen inertness contract was untested |
| `test_bidirectional_false_disables_repair` | `bidirectional=False` disables the second-neighbor fallback in `KinSortingArray` itself → chimeric deadlock persists on alternating algotypes | `test_bidirectional_cures_chimeric_deadlock` proves bidirectional=True cures deadlock via `SelfSortingArray` comparison, but the `bidirectional=False` flag on the `KinSortingArray` class was not isolated |
| `test_targeting_helpers_and_frozen_exclusion` | `_sort_target` direction per algotype, `_kin_adjacency` static count, `_kin_target` **excludes a frozen neighbor** even with equal value | The targeting helpers (`_sort_target`, `_kin_target`, `_kin_adjacency`) were only exercised indirectly via `run()`; the frozen-exclusion-in-kin-target contract (frozen neighbor skipped → target shifts to healthy neighbor) was untested |

## Validation

- **`python -m pytest tests/test_kin_sorting.py -q`** = **12 passed** (6 existing + 6 new), 0 failures, 3.36s. **0 regression** on the 6 existing tests.
- CPU-only (stdlib `random` + pytest, deterministic seeds). Style matches the existing suite (French docstrings, `random.Random(seed)`, `_value_classes`/`_alternating` helpers reused).
- Scope: **1 file, +99 lines, 0 deletions** — test-only, no source change (git diff confirms 0 source files touched).
- **G.9 firsthand**: all assertions verified by running the suite before claiming — no false assertions (unlike a blind write). The `_kin_target(1)==2` frozen-exclusion invariant was hand-traced against the source (line 166 `not self.cells[j].frozen`) before assertion.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
