### PR TITLE
fix(gametheory,#9434): drain 2 artifact-class claims from GT-1-Setup.ipynb

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "A la fin de ce notebook, vous saurez :\n",
     "1. Installer et verifier les bibliotheques principales (Nashpy, OpenSpiel)\n",
-    "2. Comprendre la structure de la serie de 17 notebooks\n",
+    "2. Comprendre la structure de la serie\n",
     "3. Modeliser un jeu simple avec une matrice de gains\n",
     "4. Trouver un equilibre de Nash avec Nashpy\n",
     "\n",
@@ -1305,7 +1305,7 @@
     "\n",
     "## 3. Structure de la serie\n",
     "\n",
-    "Cette serie comprend **17 notebooks** organises en 4 parties progressives :\n",
+    
     "\n",
     "### Partie 1 : Fondations (Notebooks 1-6)\n",
     "| # | Notebook | Contenu | Requis |\n",


### PR DESCRIPTION
Grain: MED/tooling/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/tooling/notebook-python #9638

## Résumé

Drain de 2 claims artifact-class `#9434` (`**17 notebooks**` = compteur hardcodé) depuis `GameTheory-1-Setup.ipynb`. Strip byte-level (C955-1 ★★★, JAMAIS resérialisation).

## Modifications

1 fichier, 2 cellules touchées (-96 bytes, atomicité R3 respectée) :
- **Cell#1 source[10]** : `"2. Comprendre la structure de la serie de 17 notebooks\n"` → `"2. Comprendre la structure de la serie\n"` (-16 bytes)
- **Cell#28 source[4]** : entrée entière `"Cette serie comprend **17 notebooks** organises en 4 parties progressives :\n"` retirée (+ son comma JSON fermant = 80 bytes), la liste `source` commence directement par `"### Partie 1 : Fondations (Notebooks 1-6)\n"` qui suit immédiatement

**Fingerprint** : `137785 → 137689` bytes. JSON valide (68 cells, 21 code cells avec `execution_count` + `outputs` intacts). LF-only CR=0, BOM=False.

## Invariants préservés (C.2 / C.4 / code ship)

- 68 cells préservées (C.2 outputs commit-with-outputs)
- 21/21 code cells avec `execution_count: <int>` + `outputs: [...]` inchangés
- Aucune sortie de cellule hand-éditée
- Whitespace byte-for-byte préservé hors les 96 bytes retirés
- Scanner `--class artifact` sur GT-1-Setup : **2 → 0 hits** (vérifié firsthand post-modif)

## C.4 Diagnostic dérive

**Cause = (b) claim antérieure fabriquée** : GT-1-Setup notebook setup de la série GT, contient un compteur hardcodé "17 notebooks" qui **n'est plus valide** (la série GT fait 19 notebooks post-ajouts récents, ou plus — pas le count exact, c'est irrelevant : le seul fait stable est que "17" est une prose inventée à un moment T et figée dans le markdown depuis).

**Verdict** = `CAUSE_FIXED` localement : les 2 occurrences sont retirées par byte-strip (pas de re-exécution kernel impliquée, c'est du markdown-only ; C.4 ne s'applique pas en mode "fix structurel sur prose sans output de cellule").

## Justification SOTA

Pas de moteur SOTA ni de problème algorithmique ici — c'est un drain de **claims figés** (prose), pas une exécution. Aucun verdict SOTA requis.

## G-VAR-3 respecté

c.944 (#9638) = MED/tooling `GameTheory-2-NormalForm` artifact-class counter `46 cellules` (notebook GT-2)
c.945 = MED/tooling `GameTheory-1-Setup` artifact-class counter `17 notebooks` (notebook GT-1)

Substance MD genuinely distincte : notebook différent + counter quantitatif différent. Deux MED/tooling/notebook-python consécutifs autorisés car substance distincte (variation-protocol §1 G-VAR-3 exception DEEP/MED spécialiste).

## Dispositions alternatives écartées

- **Reformuler en prose générique** ("une serie de notebooks") — fait, c'est exactement ce que la cellule 1 dit maintenant ("la serie" sans chiffre). La cellule 28 entry retirée → la `### Partie 1 : Fondations (Notebooks 1-6)` qui suit immédiatement annonce déjà la structure par partie, le claim parapluie est devenu redondant.
- **Count exact via ls** — overkill pour du markdown non-numeric, le claim est parapluie pas un décompte.

## C.9355-bis-L1 ★★ / L898 ★★★

PRE-FLIGHT `git log origin/main -- GameTheory-1-Setup.ipynb` vérifié (0 conflits récents sur cette branche). `gh pr list --state open --search "GameTheory-1-Setup"` vérifié = 0 PR OPEN.

## L898 ★★★

Pas de PR ouverte sur le chemin `MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb` au moment du push. Branche `feature/c945-gt1-setup-artifact-drain` unique sur ce fichier.

## Test plan

```bash
# Dry-run byte-level vérifié
python -c "
from pathlib import Path
data = Path(r'D:/Dev/CoursIA-2-c945-gt1-setup-artifact-drain/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb').read_bytes()
assert data.count(b'17 notebooks') == 0, 'still has claim'
print('OK: 0 hits in 137689 bytes')
"

# Scanner firsthand
python scripts/notebook_tools/check_prose_quantitative_claims.py --all --class artifact | grep "GameTheory-1-Setup"
# Expected : 0 lines
```

See #9434 partial (6+ notebooks to drain : c.943 ✓, c.944 ✓, c.945 ✓ = 3 MR ; reste GT-2-NormalForm 3 hits machine-class + autres notebooks GT familles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
