### PR TITLE
docs(qc,#1621): rewrite drifted Trend-Following README with real backtest

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following/README.md
@@ -1,30 +1,58 @@
-# Trend Following Multi-Oracles
+# Trend Following — `TrendFollowingAQR` v7
 
-**Asset class:** US Equities (top 600)
-**Cloud project ID:** 28797562
+**Classe d'actifs :** ETF multi-actifs (actions US/EU/EM, obligations, or, matières)
+**Cloud project ID :** 28797562
+**Période backtestée :** 2015-01-01 → 2024-12-31
 
 ## Description
 
-Stratégie trend following avec oracles multiples (MACD, RSI, Bollinger).
+Stratégie de **trend-following multi-actifs** (style Antonacci 2014 / AQR Trend Followinging) déployée comme `main.py`. L'algorithme combine un **double signal de momentum** et un **régime baissier de safe-haven** :
 
-## How to Run
+- **Filtre de tendance** : pour chaque actif risqué, on exige `prix > SMA(200)` (la tendance de fond est haussière).
+- **Confirmation momentum** : le rendement glissant 6 mois (`ret_6m > 0`) doit confirmer.
+- **Pondération par rang** : les actifs retenus sont classés par rendement 12 mois ; le poids est proportionnel au rang (l'actif le plus fort surperforme).
+- **Régime baissier** : si `SPY < SMA(200)`, le portefeuille bascule — le risqué est plafonné à 50 % et les 50 % restants vont dans le safe-haven `BND` (obligations). En marché haussier, 100 % risqué.
 
-**Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following"`
+**Univers** : `SPY, EFA, EEM, TLT, GLD, DBC` (risqué) + `BND` (safe-haven). Rebalancement **mensuel** (ouverture du premier jour ouvré, +30 min).
 
-**QC Cloud:** Deployed as project 28797562.
+## Backtest réel (QC Cloud, frais IBKR margin inclus)
 
-## Architecture (multi-fichiers)
-- `main.py` - Algorithme principal, universe equity top 600
-- `alpha.py` - Custom alpha avec 7+ indicateurs et scoring composite
-- `trendCalculator.py` - Détection HH/HL/LL/LH (extrema locaux)
-- `macd_oracle.py` - Oracle MACD (cross + seuils)
-- `rsi_oracle.py` - Oracle RSI (convergence/divergence trend)
-- `bollinger_oracle.py` - Oracle Bollinger (position relative)
-- `research.ipynb` - Analyse SMA derivative et signaux
+| Métrique | Valeur |
+|----------|--------|
+| Sharpe ratio | **0.36** |
+| CAGR | **7.29 %** |
+| Drawdown max | **15.00 %** |
+| Rendement total net | 102.2 % (+83 510 $ sur 100 k $) |
+| PSR (Probabilistic Sharpe Ratio) | **0.659 %** |
+| Ordres exécutés | 454 |
+| Jours tradés | 2516 |
 
-## Concepts enseignes
-- Multi-oracle scoring
-- Détection de tendance (Higher Highs, Lower Lows)
-- ATR trailing stop-loss
-- EMA 50/200 cross confirmation
-- ADX strength filter
+*Backtest frais via QC Cloud project 28797562 (compile `BuildSuccess`, 2026-08-06). Métriques vérifiées, pas claim de docstring.*
+
+### Lecture honnête — beta gérée, pas alpha
+
+Le **PSR à 0.66 %** est sans ambiguïté : la probabilité que le ratio de Sharpe observé soit **statistiquement supérieur à zéro** est quasi nulle. Autrement dit, malgré un rendement absolu positif (CAGR 7.29 %) et un drawdown contenu (15 %), **cette stratégie ne démontre aucune compétence (skill) statistiquement significative**.
+
+Ce résultat est **cohérent et pédagogiquement sain** : TrendFollowingAQR est une stratégie de **beta de marché géré**, pas d'alpha. La valeur ajoutée n'est pas le rendement excédentaire mais la **réduction du drawdown** via le commutateur de régime safe-haven (`BND`) : sur la décennie 2015-2024 (bull market dominant), la stratégie **suit** le benchmark SPY avec un rendement légèrement inférieur (le CAGR SPY sur la période est ~12-13 %), mais en marché baissier (Q1 2020, 2022) la bascule vers `BND` protège le capital. La sur la même décennie, SPY a subi des drawdowns de ~25-34 % ; ici le MaxDD est plafonné à 15 %.
+
+**Conclusion honnête** : ne PAS présenter cette stratégie comme génératrice d'alpha. C'est un **exemple pédagogique de gestion de risque systématique** — un beta de marché avec un overlay de protection baissière. Le rendement positif s'explique par l'exposition au marché (beta), pas par une capacité prédictive (le PSR le confirme). À rapprocher de l'Option-Wheel et de l'EMA-Cross-Stocks : même famille pédagogique de « stratégies qui rendent au marché, pas qui le battent ».
+
+## Comment exécuter
+
+**Lean CLI :** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following"`
+**QC Cloud :** Déployé comme projet 28797562 (paramètre optionnel `brokerage` : `ibkr` défaut avec frais réels, `none` pour frais nuls — utile pour isoler l'effet des frais).
+
+## Architecture
+
+- **`main.py`** — Algorithme déployé (`TrendFollowingAQR` v7). Auto-contenu : univers fixe 6+1 ETF, double signal SMA(200)+momentum 6m/12m, régime baissier safe-haven, rebalancement mensuel. C'est le fichier backtesté ci-dessus.
+- `alpha.py`, `macd_oracle.py`, `rsi_oracle.py`, `bollinger_oracle.py`, `trendCalculator.py` — **Fichiers orphelins** (architecture multi-oracles d'une version antérieure, non importés par `main.py` actuel). Conservés tels quels ; nettoyable dans une PR dédiée.
+- `quantbook.ipynb` — Recherche (analyse des signaux).
+- `config.json`, `trend_following_analysis.png` — Config et figure d'analyse.
+
+## Concepts enseignés
+
+- **Double momentum** (Antonacci) : filtre de tendance `SMA(200)` + confirmation momentum `6m`.
+- **Pondération par rang** (rank-based) plutôt que par pondération naive égale.
+- **Régime de marché / safe-haven switch** : détection baissière (`SPY < SMA(200)`) → réallocation défensive vers obligations.
+- **Backtesting avec frais réels** (IBKR margin) vs frais nuls — isoler l'impact des coûts de transaction.
+- **Probabilistic Sharpe Ratio (PSR)** : distinguer un rendement positif d'une compétence statistiquement significative (leçon clé : CAGR 7.29 % ≠ skill si PSR ≈ 0).


### PR DESCRIPTION
## Problem — the README described a strategy the code doesn't run

The README described a **"Trend Following Multi-Oracles"** architecture (alpha.py + macd/rsi/bollinger oracles + trendCalculator orchestrating a top-600 equity universe). But the **deployed `main.py`** (local + Cloud project 28797562, verified via `read_file`) is **`TrendFollowingAQR` v7** — a self-contained dual-momentum strategy that **imports none of the oracle files**. The oracle files exist on disk but are **orphaned** (vestigial from an earlier version).

## Fix — document the deployed + backtested strategy, honestly

Rewrote the README to describe what `main.py` actually is (`TrendFollowingAQR` v7):
- **Dual-momentum trend** (Antonacci 2014 / AQR style): `SMA(200)` filter + 6m confirmation, 12m rank-weighting, **bear-regime safe-haven switch** (`SPY < SMA(200)` → cap risky at 50%, rest to `BND`).
- Fixed 6+1 ETF universe (`SPY, EFA, EEM, TLT, GLD, DBC` + safe `BND`), monthly rebalance.

## Real backtest (QC Cloud, frais IBKR margin inclus)

Fresh backtest via qc-mcp (compile `BuildSuccess` 2026-08-06, project 28797562):

| Metric | Value |
|--------|-------|
| Sharpe | **0.36** |
| CAGR | **7.29 %** |
| MaxDD | **15.00 %** |
| Net total return | 102.2 % (+$83 510 on $100k) |
| PSR | **0.659 %** |
| Orders | 454 / 2516 tradeable days |

## Honest interpretation — managed beta, not alpha

The **PSR at 0.66 %** is unambiguous: near-zero probability the Sharpe is statistically > 0. Despite positive absolute returns (CAGR 7.29 %) and controlled drawdown (15 %), **this strategy shows no statistically significant skill** — consistent with it being **managed market beta** (drawdown control via the BND safe-haven switch), not alpha. Over the 2015-2024 bull decade it tracks SPY with slightly lower return; in bear markets the regime switch protects capital. Same pedagogical family as Option-Wheel (#9618) and EMA-Cross-Stocks (#9610): strategies that *participate in* the market, not *beat* it.

The fresh Sharpe (0.36) is **lower than the docstring's idealized v7 (0.577)** — the fresh run includes real IBKR margin fees; the honest, fee-included number is what's reported.

## Scope

- 1 file, README only (+49/-21: the −21 is the fictional stub content replaced).
- The orphaned multi-oracle files (`alpha.py`, `macd_oracle.py`, etc.) are **conservés tels quels** and flagged in the README — cleaning them is a separate decision (coordinator/user), out of scope here.
- Catalogue byte-identical, 0 CRLF, base fresh (0 behind).

FR-first (QC READMEs convention established by #9511/#9610/#9618). See #1621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)