### PR TITLE
test(ict,#4588): 6 edge-case tests for tpm_estimation untested contracts

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_tpm_estimation.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_tpm_estimation.py
@@ -90,3 +90,75 @@ def test_flat_tpm_from_sbn_matches_andor_network():
     assert abs(CE.determinism(tpm) - 1.0) < 1e-9
     # (1,0,0) [index 1] -> (0,0,1) [index 4]
     assert tpm[1, 4] == 1.0
+
+
+# --------------------------------------------------------------- gap coverage
+def test_normalize_counts_invalid_unseen_raises():
+    """Le garde ``unseen`` invalide leve ValueError (branche d'erreur, ligne 69).
+    Les chemins 'self' et 'uniform' sont couverts ; le garde de validation ne
+    l'etait pas."""
+    # une matrice de comptes avec une ligne nulle force l'entree dans la branche
+    # ``if row_sums[i] <= 0`` ou ``unseen`` est valide.
+    counts_zero_row = np.array([[0.0, 0.0], [1.0, 1.0]])
+    try:
+        E.tpm_from_transitions([(0, 1)], mapping={0: 0, 1: 1}, unseen="bogus")
+        assert False, "aurait du lever ValueError pour unseen invalide"
+    except ValueError:
+        pass
+
+
+def test_state_index_map_accepts_hashable_tuple_labels():
+    """Le docstring promet ``n'importe quel label hachable (entier, tuple,
+    chaine)``. Seuls les entiers etaient testes ; on verifie les tuples (un
+    etat = configuration multi-noeuds, le cas d'usage reel des reseaux booleens)
+    et l'ordre de premiere apparition les preserve."""
+    states = [("a", 0), ("b", 1), ("a", 0), ("c", 2)]
+    mapping = E.state_index_map(states)
+    assert mapping == {("a", 0): 0, ("b", 1): 1, ("c", 2): 2}
+    # la TPM se construit correctement sur ces labels composites.
+    tpm, m2 = E.tpm_from_trajectory([("a", 0), ("b", 1), ("a", 0)])
+    assert m2 == {("a", 0): 0, ("b", 1): 1}
+    assert tpm.shape == (2, 2)
+
+
+def test_tpm_from_trajectories_with_provided_mapping():
+    """La branche ``mapping is not None`` (lignes 129-132) est un chemin de code
+    distinct du default : le mapping fourni est reutilise tel quel (pas de
+    reconstruction depuis l'union des etats). Etait non couvert."""
+    trajs = [[0, 1], [0, 1]]
+    provided = {0: 0, 1: 1}
+    tpm, mapping = E.tpm_from_trajectories(trajs, mapping=provided)
+    assert mapping is provided                      # reuse, pas de nouvel objet
+    assert abs(tpm[0, 1] - 1.0) < 1e-9             # 0 -> 1 deux fois = deterministe
+    assert np.allclose(tpm.sum(axis=1), 1.0)
+
+
+def test_tpm_from_trajectory_single_absorbing_state():
+    """Une trajectoire revenant toujours au meme etat ([0,0,0]) produit une TPM
+    1x1 auto-absorbante (Dirac sur soi-meme), sans crash. Cas limite d'un etat
+    puits."""
+    tpm, mapping = E.tpm_from_trajectory([0, 0, 0])
+    assert mapping == {0: 0}
+    assert tpm.shape == (1, 1)
+    assert abs(tpm[0, 0] - 1.0) < 1e-9
+
+
+def test_flat_tpm_from_sbn_single_node_oscillator():
+    """Le cas minimal ``n_nodes=1`` (TPM 2x2) etait non couvert (test existant =
+    3 noeuds). Un reseau NON (inverseur) oscille : 0 -> 1 -> 0 -> 1."""
+    sbn = np.array([[1], [0]])   # state 0 -> node devient 1 ; state 1 -> 0
+    tpm = E.flat_tpm_from_sbn(sbn, 1)
+    assert tpm.shape == (2, 2)
+    assert np.allclose(tpm.sum(axis=1), 1.0)
+    assert abs(CE.determinism(tpm) - 1.0) < 1e-9   # deterministe -> determinism=1
+    expected = np.array([[0.0, 1.0], [1.0, 0.0]])
+    assert np.allclose(tpm, expected)
+
+
+def test_tpm_from_transitions_empty_is_degenerate_but_safe():
+    """Une liste de transitions vide produit une TPM vide (0x0) et un mapping
+    vide -- cas degeneré (aucune observation) qui ne doit pas crasher. Le
+    comportement borne est documente ici."""
+    tpm, mapping = E.tpm_from_transitions([])
+    assert mapping == {}
+    assert tpm.shape == (0, 0)


### PR DESCRIPTION
Grain: MED/test — lane myia-po-2025:CoursIA — prev: MED/test (#9637 kin_sorting)

See #4588 (ICT series). The `ict/tpm_estimation.py` module (157 LOC, the trajectories→TPM bridge for causal-emergence analysis) had 8 tests covering the main paths, but several **guards, branches, and boundaries** were untested. This adds 6 edge-case tests covering genuine untested contracts — not trivia.

## G-VAR-3 note (2nd consecutive MED/test, distinct substance)

prev grain was MED/test kin_sorting (self-sorting *dynamics*). This is MED/test tpm_estimation (Markov *TPM estimation* / stochastic transitions). Same genre (test), consecutive #2 — permitted under G-VAR-3 because the substance is **genuinely distinct**: stochastic Markov-chain estimation ≠ deterministic self-sorting morphogenesis (different module, different mathematical domain). Follows the po-2024 precedent (3rd consecutive MED/test accepted on distinct-substance logic, #9617/#9623/#9630).

**Non-test rotation verified-blocked firsthand this cycle** (10+ axes G.9-checked before pivoting to test-extension): ict/ 51 modules all tested (new-module vein saturated); scripts/ root tools all tested; drainage = LIGHT (G-VAR-2 Budget SOLDE 0 blocks); #9535 cleanup items 4/6/8 already-done/false-positive (verified: dead scripts archived by #9607, FORMAL_STATUS.md absent, Audio _legacy/ empty), items 2/3/7 LIGHT-blocked; #2161 three-exercises drained; #9532 CLOSED; #9533 case-3 already TESTÉ (#9567 by po-2025, today), case-4 PRÉDIT chiffré (c.1245), rest GPU-gated; Search README §E clean (all counts reconcile); Lean/QC/GenAI gated (cold-Mathlib, QC-Cloud, GPU, vision). The CPU non-test MED/DEEP pool is genuinely exhausted today — confirmed independently by po-2024 (3rd test) + po-2026 (Lean-prover fallback).

## Coverage gaps filled (all verified firsthand against the 8 existing tests)

| Test | Contract tested | Was untested because |
|---|---|---|
| `test_normalize_counts_invalid_unseen_raises` | `unseen="bogus"` raises `ValueError` (line 69 error guard) | Existing tests cover `unseen="self"` and `"uniform"` but **not the invalid-value guard** |
| `test_state_index_map_accepts_hashable_tuple_labels` | `state_index_map` + `tpm_from_trajectory` work on **tuple labels** (hashable-generality contract: docstring promises "n'importe quel label hachable") | Only integer labels were tested; the multi-node config (tuple) use case — the real Boolean-network scenario — was untested |
| `test_tpm_from_trajectories_with_provided_mapping` | The `mapping is not None` branch (lines 129-132) **reuses** the provided mapping (distinct code path from default union-construction) | `test_tpm_from_trajectories_pools_transitions` uses default mapping; the provided-mapping branch was a separate untested path |
| `test_tpm_from_trajectory_single_absorbing_state` | `[0,0,0]` → 1x1 self-absorbing Dirac TPM (single sink-state boundary, no crash) | The single-state degenerate trajectory was untested |
| `test_flat_tpm_from_sbn_single_node_oscillator` | `n_nodes=1` boundary (2x2 TPM, NOT-gate oscillator, determinism=1) | Existing sbn test covers 3-node AND/OR; the minimal n_nodes=1 boundary was untested |
| `test_tpm_from_transitions_empty_is_degenerate_but_safe` | Empty transitions list → empty (0x0) TPM + empty mapping, no crash (degenerate-observation boundary) | The empty-input boundary was untested |

## Validation

- **`python -m pytest tests/test_tpm_estimation.py -q`** = **14 passed** (8 existing + 6 new), 0 failures, 1.76s. **0 regression** on the 8 existing tests.
- CPU-only (numpy + stdlib, fully deterministic — no randomness). Style matches the existing suite (module-level `def test_`, French docstrings, `np.allclose` / `abs() < 1e-9`).
- Scope: **1 file, +72 lines, 0 deletions** — test-only, no source change (git diff confirms 0 source files touched).
- **G.9 firsthand**: all 6 assertions verified by running the suite pre-claim + hand-traced against source (line 69 ValueError branch, line 47 first-appearance, lines 129-132 provided-mapping branch). No false assertions.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
