### PR TITLE
docs(symbolicai,#4959): complete SemanticWeb list-table (7 missing twins)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -242,22 +242,29 @@ Série de **25 notebooks** sur le Web Sémantique (12 Python + 12 C# + le notebo
 | 2 | [SW-2-CSharp-RDFBasics](SemanticWeb/SW-2-CSharp-RDFBasics.ipynb) | .NET C# | Triplets RDF, noeuds, serialisation (Turtle, N-Triples, RDF/XML) | 6 |
 | 2b | [SW-2b-Python-RDFBasics](SemanticWeb/SW-2b-Python-RDFBasics.ipynb) | Python | Équivalent Python avec rdflib | 5 |
 | 3 | [SW-3-CSharp-GraphOperations](SemanticWeb/SW-3-CSharp-GraphOperations.ipynb) | .NET C# | Parsers/Writers, fusion de graphes, LINQ sur RDF | 7 |
+| 3b | [SW-3b-Python-GraphOperations](SemanticWeb/SW-3b-Python-GraphOperations.ipynb) | Python | Twin Python (rdflib) — opérations sur graphes RDF | twin |
 | 4 | [SW-4-CSharp-SPARQL](SemanticWeb/SW-4-CSharp-SPARQL.ipynb) | .NET C# | Query Builder, SELECT/FILTER, OPTIONAL, UNION | 7 |
 | 4b | [SW-4b-Python-SPARQL](SemanticWeb/SW-4b-Python-SPARQL.ipynb) | Python | Équivalent Python avec SPARQLWrapper | 5 |
 | **Partie 2 : Données Liees et Ontologies** |
 | 5 | [SW-5-CSharp-LinkedData](SemanticWeb/SW-5-CSharp-LinkedData.ipynb) | .NET C# | DBpedia, Wikidata, requêtes federees SERVICE | 6 |
 | 5b | [SW-5b-Python-LinkedData](SemanticWeb/SW-5b-Python-LinkedData.ipynb) | Python | Équivalent Python | 5 |
 | 6 | [SW-6-CSharp-RDFS](SemanticWeb/SW-6-CSharp-RDFS.ipynb) | .NET C# | RDFS, inference automatique, OntologyGraph | 4 |
+| 6b | [SW-6b-Python-RDFS](SemanticWeb/SW-6b-Python-RDFS.ipynb) | Python | Sidetrack Python (rdflib + owlrl) — schéma et inférence RDFS | twin |
 | 7 | [SW-7-CSharp-OWL](SemanticWeb/SW-7-CSharp-OWL.ipynb) | .NET C# | OWL 2, profils (EL/QL/RL), restrictions | 5 |
 | 7b | [SW-7b-Python-OWL](SemanticWeb/SW-7b-Python-OWL.ipynb) | Python | Équivalent Python avec OWLReady2 | 5 |
-| **Partie 3 : Standards Modernes (Python)** |
+| **Partie 3 : Standards Modernes (Python + jumeaux C#)** |
 | 8 | [SW-8-Python-SHACL](SemanticWeb/SW-8-Python-SHACL.ipynb) | Python | SHACL, NodeShape, PropertyShape, pySHACL | 7 |
+| 8c | [SW-8-CSharp-SHACL](SemanticWeb/SW-8-CSharp-SHACL.ipynb) | .NET C# | Jumeau C# (dotNetRDF) — validation SHACL | twin |
 | 9 | [SW-9-Python-JSONLD](SemanticWeb/SW-9-Python-JSONLD.ipynb) | Python | JSON-LD, Schema.org, SEO | 7 |
+| 9c | [SW-9-CSharp-JSONLD](SemanticWeb/SW-9-CSharp-JSONLD.ipynb) | .NET C# | Jumeau C# (dotNetRDF) — JSON-LD | twin |
 | 10 | [SW-10-Python-RDFStar](SemanticWeb/SW-10-Python-RDFStar.ipynb) | Python | RDF 1.2, quoted triples, SPARQL-Star | 5 |
-| **Partie 4 : Graphes de Connaissances et IA** |
+| 10c | [SW-10-CSharp-RDFStar](SemanticWeb/SW-10-CSharp-RDFStar.ipynb) | .NET C# | Jumeau C# (dotNetRDF) — réification/annotation de triplets | twin |
+| **Partie 4 : Graphes de Connaissances et IA (Python + jumeaux C#)** |
 | 11 | [SW-11-Python-KnowledgeGraphs](SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb) | Python | kglab, OWLReady2, visualisation NetworkX | 6 |
+| 11c | [SW-11-CSharp-KnowledgeGraphs](SemanticWeb/SW-11-CSharp-KnowledgeGraphs.ipynb) | .NET C# | Jumeau C# (dotNetRDF) — construction/requête d'un KG | twin |
 | 12 | [SW-12-Python-GraphRAG](SemanticWeb/SW-12-Python-GraphRAG.ipynb) | Python | GraphRAG, extraction entites LLM | 6 |
 | **Bonus** | [SW-13-Python-Reasoners](SemanticWeb/SW-13-Python-Reasoners.ipynb) | Python | Comparaison raisonneurs OWL (owlrl, HermiT, reasonable) | 3 (faible) |
+| **Bonus** | [SW-13-Reasoners-CSharp](SemanticWeb/SW-13-Reasoners-CSharp.ipynb) | .NET C# | Jumeau C# (dotNetRDF) — raisonneurs RDF/OWL | twin |
 
 Documentation complète : [SemanticWeb/README.md](SemanticWeb/README.md)
 


### PR DESCRIPTION
## Summary

SymbolicAI hub README **§E list-table audit** (list-table-vs-disk) found the SemanticWeb "Structure détaillée" table **stale relative to the #4956 parity marathon**. The table was **internally inconsistent**: it listed Python twins for SW-2/4/5/7 (the `-b` rows) but **omitted SW-3b and SW-6b**, and it listed C# rows for SW-1..SW-7 but **stopped there, omitting the C# twins SW-8/9/10/11/13** — even though the prose one line above (line 234) explicitly names them ("dont les jumeaux SW-8/9/10/13 et les side-tracks SW-3b/SW-6b"). Textbook §E defect (pr-review-discipline §E): a corrected intro count left an obsolete notebook list one section below.

This is the **P0 of #4959** (READMEs intermédiaires & centraux, claimed by po-2024:CoursIA).

## Fix (surgical, additive)

Add the **7 missing rows** so the table enumerates all 24 pedagogical notebooks on disk (was 17):

| Added row | Notebook | Kernel |
|-----------|----------|--------|
| 3b | SW-3b-Python-GraphOperations | Python |
| 6b | SW-6b-Python-RDFS | Python |
| 8c | SW-8-CSharp-SHACL | .NET C# |
| 9c | SW-9-CSharp-JSONLD | .NET C# |
| 10c | SW-10-CSharp-RDFStar | .NET C# |
| 11c | SW-11-CSharp-KnowledgeGraphs | .NET C# |
| Bonus | SW-13-Reasoners-CSharp | .NET C# |

Plus rename "Partie 3/4 : (Python)" headers to "(Python + jumeaux C#)" to reflect the real dual C#/Python parity of those sections. The "Exercices" column shows `twin` for added rows (honest: points to the named sibling rather than fabricating a count I didn't verify).

## §E audit coverage (all 8 sub-series)

Subagent read-only audit (sonnet, list-table enumeration) + my editorial verification:

| Sub-series | Disk | Table | Verdict |
|-----------|:----:|:-----:|---------|
| Tweety | 32 | 31+probe-omitted | COHERENT (no edit) |
| Lean | 28 | 28 | COHERENT (no edit) |
| **SemanticWeb** | 24 | 17 | **DRIFT — fixed (this PR)** |
| Planners | 23+archive | 14 | mild (C# twins in prose only; hub convention = Python table + prose, no edit) |
| SmartContracts | 27 | 27 | COHERENT (no edit) |
| Argument_Analysis | 22 | 6 | illustrative-by-design (declared demo line 324, no edit) |
| SymbolicLearning | 20+2arch | 12 | mild (C# twins in prose blockquote line 364, no edit) |
| SMT | 46 | — | no per-notebook table (out of scope) |

**0 ghost rows** anywhere (no cited notebook missing from disk).

## Validation (firsthand)

- `verify_catalog_readme.py --series SymbolicAI` → **224 = 224 OK, 0 drift** (CATALOG-STATUS byte-identical to main).
- All 24 notebook links resolve to disk (0 ghost, verified via filesystem check).
- Table column consistency: 24 data rows = 6 pipes, 4 subheads = 2 pipes (matches header).
- 0 CRLF introduced.

## Scope

- **1 file** (`SymbolicAI/README.md`, +9/−2). No notebook re-exec (C.3 n/a, markdown-only).
- Atomic (1 hub, P0 of #4959). Catalogue byte-identique to main.
- Collision guard: 0 open PRs touching `SymbolicAI/README.md` (verified `gh pr list`).

See #4959 (partial: P0 SymbolicAI hub SemanticWeb table; does not close — central hub already current from 2026-08-06, other P1 hubs pending separate tranches). See #4956 (parity marathon origin of the missing twins).
