### PR TITLE
fix(catalog,#9535): classify _archive/_archives as RESEARCH (status consistency)

### DIFF
--- a/scripts/notebook_tools/generate_catalog.py
+++ b/scripts/notebook_tools/generate_catalog.py
@@ -36,8 +36,13 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 NOTEBOOKS_DIR = REPO_ROOT / "MyIA.AI.Notebooks"
 
 EXCLUDE_ALWAYS = {".ipynb_checkpoints", "obj", "bin", "__pycache__", ".git"}
-EXCLUDE_PEDAGOGICAL = {"research", "archive", "_output", "output", "partner-course", "examples"}
-RESEARCH_DIR_KEYWORDS = {"research", "archive", "examples", "partner-course"}
+# ``_archive``/``_archives`` mirror ``archive`` (convention #9535 item 10): the
+# pedagogical exclusion below uses a substring match (so ``archive`` already
+# catches ``_archive``), but ``_is_research_path`` matches dir names EXACTLY --
+# listing them explicitly keeps the RESEARCH STATUS consistent with the count
+# exclusion and survives a future refactor of either match strategy.
+EXCLUDE_PEDAGOGICAL = {"research", "archive", "_archive", "_archives", "_output", "output", "partner-course", "examples"}
+RESEARCH_DIR_KEYWORDS = {"research", "archive", "_archive", "_archives", "examples", "partner-course"}
 
 SERIES_ORDER = [
     "GenAI", "Search", "ML", "SymbolicAI", "QuantConnect",

--- a/scripts/notebook_tools/tests/test_generate_catalog.py
+++ b/scripts/notebook_tools/tests/test_generate_catalog.py
@@ -1039,6 +1039,27 @@ class TestDetermineStatusEdgeCases:
             pedagogical=False,
         ) == "RESEARCH"
 
+    def test_research_archive_underscore_path_is_research(self):
+        """Convention #9535 item 10: archived notebooks live under ``_archive``
+        (or ``_archives``). Their pedagogical COUNT is excluded via substring
+        match on ``archive``, but their STATUS must also be RESEARCH (consistent
+        with ``archive/``). Before this fix, ``_is_research_path`` matched dir
+        names exactly and missed ``_archive`` -- archived notebooks got
+        READY/BROKEN instead of RESEARCH. Regression guard."""
+        nb = _nb([_code("x=1", [_stream_output()])])
+        code_cells = [nb["cells"][0]]
+        reqs = {"requires_api": False, "requires_gpu": False,
+                "requires_cloud": False, "requires_wsl": False}
+        assert determine_status(
+            self._make_path("Search/_archive/Old.ipynb"), nb, code_cells, reqs,
+            pedagogical=False,
+        ) == "RESEARCH"
+        # The ``_archives`` variant (SymbolicLearning convention) too.
+        assert determine_status(
+            self._make_path("SymbolicAI/SymbolicLearning/_archives/Old.ipynb"),
+            nb, code_cells, reqs, pedagogical=False,
+        ) == "RESEARCH"
+
 
 # --- classify_maturity edge cases ---
 


### PR DESCRIPTION
## Summary

`generate_catalog.py` uses **two mechanisms** for archive notebooks, and they diverged after #9612 renamed `Search/archive` → `_archive` (convention #9535 item 10):

1. **Pedagogical COUNT exclusion** (~line 1128): substring match (`exc in str(path)`) — `archive` already catches `_archive`, so the pedagogical **count is correct** (Search=115, the 2 `_archive` notebooks excluded).
2. **RESEARCH STATUS classification** (`_is_research_path`, ~line 264): **exact** dir-name match (`part in RESEARCH_DIR_KEYWORDS`) — `archive` does **not** catch `_archive`, so `_archive` notebooks got `READY`/`BROKEN`/`DEMO` status instead of `RESEARCH` in the non-pedagogical catalogue view. **Inconsistent** with their count exclusion.

## Fix (root-cause)

Add `_archive` and `_archives` (the SymbolicLearning convention variant) to **both** `EXCLUDE_PEDAGOGICAL` and `RESEARCH_DIR_KEYWORDS`. Now the STATUS is consistent with the COUNT (both treat `_archive*` as archive), and the classification survives a future refactor of either match strategy (substring ↔ exact).

## Honest scope

This fixes a **STATUS-label inconsistency** in the secondary (non-pedagogical) catalogue view only. The headline pedagogical counts in README markers **were already correct** (substring match) — verified firsthand: Search=115, SymbolicAI=224, both unchanged by this fix. 4 notebooks affected:

- `Search/_archive/CSPs_Intro.ipynb`, `Search/_archive/Exploration_non_informée...ipynb`
- `SymbolicAI/SymbolicLearning/_archives/.../EML-NAND-Compose.ipynb`, `EML-NAND-Explore.ipynb`

(I initially [CLAIMED] "4 notebooks mis-counted as pedagogical" — G.9 firsthand verification **refuted** that: the count is correct; only the STATUS was inconsistent. The PR body corrects the record.)

## Validation

```
new test test_research_archive_underscore_path_is_research: PASS
  (asserts _archive AND _archives → RESEARCH, mirroring test_research_archive_path)
full generate_catalog suite: 171 passed (169 prior + 2 archive), 0 regression, 0.49s
pedagogical counts: Search=115, SymbolicAI=224 — UNCHANGED (count was already correct)
catalogue markers: byte-identical (not regenerated on branch — cron/catalog-drift bot handles on main)
```

## Scope

- **2 files**: `generate_catalog.py` (+2 keywords × 2 sets), `test_generate_catalog.py` (+20 lines, 1 test method).
- Atomic. No notebook re-exec. No catalogue regen on branch (catalog-pr-hygiene R1).
- Collision guard: 0 open CoursIA PRs touching `generate_catalog.py` exclusion logic.

See #9535 item 10 (archive nomenclature — makes the catalogue robust to the `_archive` convention variant introduced by #9612).
