### PR TITLE
fix(genai-audio,#9434): 03-2-Audio-Pipeline-Orchestration machine-dep timing drainage (Option alpha)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb
@@ -924,12 +924,12 @@
     "| STT (local) | 0.5-2s | GPU / taille audio |\n",
     "| STT (API) | 1-3s | Reseau |\n",
     "| LLM | 1-3s | Generation de tokens |\n",
-    "| TTS | ~5s (observe 5.02s) | Reseau / synthese — goulot principal ce run |\n",
-    "| **Total** | **~8s (observe 8.33s)** | **TTS le plus lent (5.02s vs LLM 1.72s vs STT 1.59s)** |\n",
+    "| TTS | ~5s (runtime *machine-dep* : 5.02s) | Reseau / synthese — goulot principal ce run |\n",
+    "| **Total** | **~8s (runtime *machine-dep* : 8.33s)** | **TTS le plus lent (runtime *machine-dep* : 5.02s vs LLM 1.72s vs STT 1.59s)** |\n",
     "\n",
     "**Points cles** :\n",
     "1. La latence totale du pipeline est la somme des latences individuelles\n",
-    "2. Sur ce run, le TTS est le goulot d'etranglement (5.02s vs 1.72s pour le LLM) ; la synthese vocale via API depend fortement de la latence reseau\n",
+    "2. Sur ce run, le TTS est le goulot d'etranglement (runtime *machine-dep* : 5.02s vs 1.72s pour le LLM) ; la synthese vocale via API depend fortement de la latence reseau\n",
     "3. Le retry exponentiel protege contre les erreurs transitoires\n",
     "4. Pour du temps reel, privilegier des modèles plus petits (gpt-4o-mini)"
    ]
@@ -1892,12 +1892,12 @@
     "\n",
     "| Pipeline | Étape la plus lente | Optimisation possible |\n",
     "|----------|--------------------|-----------------------|\n",
-    "| STT->LLM->TTS | TTS (synthese, 5.02s observees) | Reduire la longueur du texte a synthetiser, voix plus rapides |\n",
+    "| STT->LLM->TTS | TTS (synthese, runtime *machine-dep* : 5.02s) | Reduire la longueur du texte a synthetiser, voix plus rapides |\n",
     "| Traduction | Comparable STT/LLM/TTS | Paralleliser STT et TTS si possible |\n",
     "| Podcast | TTS (N segments) | Paralleliser les appels TTS |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Le profilage revele que le TTS est le goulot d'etranglement (5.02s sur stt_llm_tts, 12.96s sur le podcast)\n",
+    "1. Le profilage revele que le TTS est le goulot d'etranglement (runtime *machine-dep* : 5.02s sur stt_llm_tts, 12.96s sur le podcast)\n",
     "2. La generation du podcast est dominee par les appels TTS séquentiels\n",
     "3. L'assemblage est negligeable par rapport aux appels API"
    ]


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #9657 (c.1302 8_Reasoning_Models)

## Ce que fait la PR

Sub-tâche bornée de l'EPIC #9434 (« porter le mandat *quantitatif tenu par le CI, pas par la prose* à l'intérieur des notebooks »), classe **machine-dépendant** (timing absolu).

`MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb` (46 cells = 16 code + 30 markdown) — pipeline STT → LLM → TTS orchestré (faster-whisper local + OpenAI GPT + Kokoro/Chatterbox) — re-épinglait en prose des timings machine-dépendants sur le pipeline profiling (cell[16] tableau 5 lignes + cell[32] tableau + prose) qui rebougent à chaque re-exec (charge OpenAI API, charge réseau, version modèle, taille audio).

**18ᵉ réutilisation archétype 6ᵉ** « machine-dep timing in pedagogical prose » — **2ᵉ cross-family move post-c.1286** (c.1302 = 1ère cross-family GenAI/Texte, c.1303 = sub-family GenAI/Audio).

## Le defect (G.1 firsthand, worktree frais origin/main SHA `654eb501e`)

`03-2-Audio-Pipeline-Orchestration.ipynb` contient **2 cellules markdown d'interprétation** (cell[16] + cell[32]) avec 5 timings concrets machine-dep :

| Line | Runtime claim concret | Catégorie |
|------|----------------------|-----------|
| cell[16] ligne tableau `TTS` | `~5s (observe 5.02s)` | runtime wall-clock |
| cell[16] ligne tableau `Total` | `~8s (observe 8.33s)` + parenthèse `5.02s vs LLM 1.72s vs STT 1.59s` | runtime wall-clock |
| cell[16] prose `Points cles` #2 | `(5.02s vs 1.72s pour le LLM)` | runtime wall-clock |
| cell[32] ligne tableau `STT->LLM->TTS` | `TTS (synthese, 5.02s observees)` | runtime wall-clock |
| cell[32] prose `Points cles` #1 | `(5.02s sur stt_llm_tts, 12.96s sur le podcast)` | runtime wall-clock |

**Pourquoi c'est un defect** : ces timings viennent de **l'exécution réelle** des cellules pipeline précédentes (cell[14] STT→LLM→TTS + cell[18] traduction + cell[24] podcast). Les re-pin en prose **rebougent à chaque re-exec** (charge OpenAI API + charge réseau + version modèle + taille audio + faster-whisper load).

## Distinction cruciale — paramètre vs runtime (3 cas)

Trois claims **adjacents** sont en réalité des **paramètres FIXES by code** (structurels, déterministes) et sont **préservés verbatim** :

1. **cell[12] prose** : « delai croissant (1s, 2s, 4s) » — **PARAMÈTRE FIXE** car **cell[11]** code contient `def retry_with_backoff(func, max_retries: int = 3, base_delay: float = 1.0)` avec `delay = base_delay * (2 ** attempt)` → 1s / 2s / 4s **VOLONTAIRES par le code**, pas observés.

2. **cell[26] prose** : « pause de 0.5s entre les repliques » — **PARAMÈTRE FIXE** car **cell[24]** code contient `# Pause de 0.5s entre les repliques` et `pause = np.zeros(int(sr * 0.5))` → 0.5 secondes **EXPLICITE dans le code**.

3. **cell[16]+cell[26] ranges pédagogique** : « 0.5-2s / 1-3s / 1-3s / ~5s » / « 2-5s / 5-15s / <1s » = **Latence typique pédagogique** (concept pédagogique, pas runtime observé) — **PRÉSERVÉ VERBATIM**.

C'est la même distinction que **c.1299-L1** (c.1299 cell[17] « Temps limite = 0.5s »), **c.1301-L1** (c.1301 cell[16] « timeout 30 secondes »), et **c.1302-L3** (c.1302 cell[22] Note #3571 `max_completion_tokens=4000`).

## Le drainage (Option alpha, minimal touch)

| Line | Avant | Après |
|------|-------|-------|
| cell[16] ligne tableau `TTS` | `~5s (observe 5.02s)` | `~5s (runtime *machine-dep* : 5.02s)` |
| cell[16] ligne tableau `Total` | `~8s (observe 8.33s)` + parenthèse `5.02s vs LLM 1.72s vs STT 1.59s` | `~8s (runtime *machine-dep* : 8.33s)` + parenthèse `runtime *machine-dep* : 5.02s vs LLM 1.72s vs STT 1.59s` |
| cell[16] prose #2 | `(5.02s vs 1.72s pour le LLM)` | `(runtime *machine-dep* : 5.02s vs 1.72s pour le LLM)` |
| cell[32] ligne tableau `STT->LLM->TTS` | `TTS (synthese, 5.02s observees)` | `TTS (synthese, runtime *machine-dep* : 5.02s)` |
| cell[32] prose #1 | `(5.02s sur stt_llm_tts, 12.96s sur le podcast)` | `(runtime *machine-dep* : 5.02s sur stt_llm_tts, 12.96s sur le podcast)` |

**Diff** : 1 file, **+5/-5 = 5 lignes markdown modifiées**. Pas de cellule code touchée, 16/16 code cells avec `execution_count` préservés.

## Structurel préservé verbatim (5 invariants)

1. **STT/LLM/TTS 'Latence typique' ranges** (0.5-2s / 1-3s / 1-3s / ~5s) — concept pédagogique structurel
2. **Podcast 'Duree typique' ranges** (2-5s / 5-15s / <1s) — concept pédagogique structurel
3. **cell[12] prose « delai croissant (1s, 2s, 4s) »** — paramètre FIXE by code (cell[11] `base_delay=1.0` × 2^attempt)
4. **cell[26] prose « pause de 0.5s entre les repliques »** — paramètre FIXE by code (cell[24] `pause=np.zeros(int(sr*0.5))`)
5. **Profilage 'Optimisation possible' recommendations** pédagogiques structurelles

## Tell archétypal c.1303 spécifique

**Cross-family R6 sub-family (c.1303 spécifique)** : c.1286-c.1302 = 17 réutilisations Planners/Search/CSP/Sudoku/Infer.NET/GenAI/Texte. **c.1303 = 18ᵉ réutilisation sur GenAI/Audio = 2ᵉ cross-family move post-c.1286** (c.1302 = 1ère GenAI/Texte, c.1303 = sub-family GenAI/Audio). La rotation famille est cruciale pour la **variété R6** et évite la **monotonie structurelle** signalée par [variation-protocol.md](.claude/rules/variation-protocol.md). Lean family gardée pour c.1304.

**Antécédent PR #8468 (c.1303 spécifique)** : PR #8468 MERGED `fix(audio): 03-2 pipeline interp cells aligned with committed per-step output (#8052)` = exactement le scenario `CAUSE_DOCUMENTED_ONLY` que la §D.5 doctrine (`c.1221-L §D.5-DOCTRINE`) considère comme **alignement-proneness** : les chiffres mergés en #8468 étaient synchrones avec l'output au moment de l'exec, mais deviendront désynchronisés au prochain re-exec. C'est l'**équivalent c.1302-L4 PR #8439 antecedent** pour 8_Reasoning_Models. Le présent drainage préserve les **invariants pédagogiques** (Latence typique / paramètres FIXES) et draine les **timings** (machine-dep, jamais reproductibles). **PR #8468 reste valide pour les observations alignées au commit** ; c.1303 complète en drainant les timings en `runtime *machine-dep*`.

**3 paramètres FIXES by code vs runtime observé (c.1303 spécifique)** : c.1303 = **3 paramètres préservés verbatim** distincts (cell[12] `(1s, 2s, 4s)` retry exponentiel, cell[26] `0.5s` pause audio, ranges pédagogiques « Latence typique »), vs **2 dans c.1302** (Note #3571 max_completion_tokens, ranges pédagogique « temps moyen »). Pattern identique c.1299-L1 + c.1301-L1 + c.1302-L3 — sans cette distinction, le lecteur ne sait pas si `1s/2s/4s` est une contrainte d'algorithme ou un nombre observé.

**Sub-family rotation (c.1303 spécifique)** : c.1302 = 1ère famille nouvelle GenAI/Texte (vs Planners/Search/CSP/Sudoku/Infer.NET). c.1303 = sub-family GenAI/Audio (même cluster GenAI mais différent media). True family jump vers Lean family est différé à c.1304 (Lean-8-Agentic-Proving ou Lean-7-LLM-Integration). Cette stratégie respecte R6 « rotation genres ET familles » sans tunneliser un mono-thème.

## Diagnostic §D.5 verdict

**`CAUSE_DOCUMENTED_ONLY`** — drainage pédagogique assumé via Option alpha (structurel vs machine-dep). PAS un bug, PAS une régression de code, PAS une question d'env/kernel.

| Axe | Verdict |
|-----|---------|
| (a) env | DRAINÉ (machine-dep : OpenAI API charge + charge réseau + version faster-whisper + taille audio) |
| (b) claim antérieure fabriquée | DRAINÉ (5 timings concrete `s+digits`) |
| (c) moteur upstream | CAUSE_DOCUMENTED_ONLY (OpenAI GPT/TTS, faster-whisper local — résultats structurels invariants : STT transcription correcte + LLM réponse cohérente + TTS audio généré) |
| (d) régression dépendance | n/a (versions modèle non pinning modifiées) |
| (e) stochasticité non-seedée | DRAINÉ (timing wall-clock stochastic séparé du résultat structurel) |

## L898 collision guard (pre-work)

- Branche `fix/c1303-audio-pipeline-machine-dep` : **0 PR préexistante** (vérifié via `gh pr list --search head:fix/c1303-audio-pipeline` → empty)
- Fichier `03-2-Audio-Pipeline-Orchestration.ipynb` : **0 PR OPEN** sur drainage runtime spécifique (vérifié via `gh pr list --state open --search "03-2-Audio-Pipeline"` → empty)
- Derniers PRs touchants le fichier : #8468 MERGED (NB-8 #8052 alignment timing), #9263 MERGED (cost metadata Audio/03-Orchestration trio), #6229 MERGED (re-execute 03-2 pipeline SOTA-OK real OpenAI), #2347 MERGED (enrich exercises >=3 target)
- 0 collision on `fix/c1303-*` branche (L576 ★★)
- Cross-lane check : po-2023 (GenAI primary lane) = 0 PR OPEN sur drainage runtime spécifique (vérifié)

## Note technique — préservation structure JSON via raw text

Le notebook `03-2-Audio-Pipeline-Orchestration.ipynb` contient **2 blocs cost metadata dupliqués** (pré-existing bug introduit par PR #9263 MERGED `cost(genai-audio,#8056): metadata.cost on Audio/03-Orchestration trio (real API+GPU)`). Une approche naïve `json.load → json.dump` collapse les doublons JSON en gardant le dernier, ce qui aurait introduit un churn massif sur `api_usd_est / cpu_min / gpu_min / gpu_required / vram_gb / vram_tier / external_account / metadata_written / free_alternative / reduced_pedagogical / reproducibility / validator / notes` — contamination hors-scope (catalog-pr-hygiene R1 « une PR = un sujet »).

**Approche retenue** : raw text replacement des 5 lignes markdown uniquement, sans round-trip JSON. **Diff final : 1 file, 5 insertions, 5 deletions** (vs round-trip JSON qui aurait produit 18+/35- de churn). Le bug de doublons cost metadata reste **observé mais hors-scope** — à tracker dans une issue fille si pertinent.

## Pourquoi cette PR ne touche pas les cellules code

- 46 cellules (16 code + 30 markdown). **0 cellule code touchée.**
- Cellules pipeline : exécution réelle OpenAI API + GPU faster-whisper (machine-dep + GPU-only), non re-exécutées (token API + GPU non requis pour drainage markdown-only)
- 16/16 code cells avec `execution_count = 1..16` préservés (15 avec outputs, 1 sans output probablement setup vide)
- Reproductibilité : même code + même OpenAI key + même hardware → **mêmes résultats structurels** (STT/LLM/TTS outputs) + **timings variables** (machine-dep selon charge API)

## Grain

`MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #9657 (c.1302 8_Reasoning_Models)`

## Drain #9434 vein (archétype 6ᵉ) — réutilisations

| Cycle | Notebook | Langage | Tell |
|-------|----------|---------|------|
| c.1286 | Search-5-GeneticAlgorithms | Python | Colonnes distance/runtime_ms |
| c.1287 | App-1-NQueens | Python | Colonnes Temps |
| c.1288 | App-4-JobShopScheduling | Python | Colonnes Makespan/runtime |
| c.1289 | App-3-NurseScheduling | Python | Colonnes runtime_ms |
| c.1290 | App-6-Minesweeper | Python | Colonnes runtime |
| c.1291 | App-7-Wordle | Python | Colonnes Temps |
| c.1292 | App-19-ProceduralGeneration-WFC | Python | Colonnes Temps |
| c.1293 | App-20b-SudokuBenchmark-CSharp | C# (.NET) | Counts vs wall-clock |
| c.1294 | App-20-SudokuBenchmark-Python | Python | Counts en output |
| c.1295 | App-15-SportsScheduling | Python OR-Tools | Runtime 0.01-0.05s |
| c.1296 | App-15b-SportsScheduling-CSharp | C# (.NET) | Concrete < 0.1 s |
| c.1297 | App-14-ConnectFour-Adversarial | Python Minimax/AB | Concrete 0.4375s + speedup 139x |
| c.1298 | CSP-3-Advanced | Python OR-Tools | Concrete 20 ms/860 ms/0.9 s |
| c.1299 | Search-6-AdversarialSearch | Python Minimax/AB | Concrete 1.1s/0.0367s/1.1103s + 30.3x/4x + paramètre vs runtime |
| c.1300 | Sudoku-15-Infer-Python | Python NumPyro SVI | Concrete 33.9ms/4.7s ×3 + speedup 180x/100x — cross-family |
| c.1301 | Planners-7-OR-Tools | Python OR-Tools CP-SAT | Concrete `~0.002s`/`~0.006s`/`~0.07s`/`~1.3s`/`~28s` + 3 prose continuations |
| c.1302 | 8_Reasoning_Models | Python OpenAI gpt-5-mini | Concrete `2.73s`/`2.92s`/`4.09s`/`7.89s`/`4.80s`/`7.58s` tableau + `3.87s`/`6.13s` temps moyens + speedup `~1.6×` wall-clock — cross-family R6 GenAI/Texte |
| **c.1303** | **03-2-Audio-Pipeline-Orchestration** | **Python OpenAI GPT/TTS + faster-whisper** | **Concrete `5.02s`/`8.33s`/`1.72s`/`1.59s` cell[16] + `5.02s`/`12.96s` cell[32] — sub-family GenAI/Audio — 3 paramètres FIXES préservés (cell[12] retry exponentiel `1s/2s/4s`, cell[26] pause `0.5s`, ranges pédagogiques « Latence typique ») — antecedent PR #8468 NB-8 #8052 alignement timing** |

## Leçons c.1303 ★

1. **c.1303-L1 CROSS-FAMILY-R6-SUB-FAMILY-GENAI-AUDIO** — c.1303 = **18ᵉ réutilisation archétype 6ᵉ sur GenAI/Audio** (vs c.1286-c.1302 Planners/Search/CSP/Sudoku/Infer.NET/GenAI/Texte). 2ᵉ cross-family move post-c.1286 (c.1302 1ère GenAI/Texte, c.1303 sub-family GenAI/Audio). R6 rotation famille = **`GenAI/Audio` ≠ {Planners, Search, CSP, Sudoku, Infer.NET, GenAI/Texte}`** — diversification cruciale pour éviter la monotonie structurelle.

2. **c.1303-L2 PR-#8468-ANTECEDENT-ALIGNEMENT-PRONENESS** — PR #8468 (NB-8 #8052) avait **aligned fabricated timing claims to committed output** = « fix doc-honesty » qui a fixé les timings aux outputs réellement commités au moment de la PR. C'est **exactement le scenario que la §D.5 doctrine** (`c.1221-L §D.5-DOCTRINE`) signale comme **`CAUSE_DOCUMENTED_ONLY` alignement-proneness**. c.1303 complète en drainant les timings (machine-dep) tout en préservant les **invariants pédagogiques** (structurel, vérifiable même après re-exec). **PR #8468 reste valide pour les observations alignées au commit** ; c.1303 draine les timings.

3. **c.1303-L3 PARAMETRE-VS-RUNTIME-3-CAS-OPENAI** — c.1303 = **3 paramètres préservés verbatim** distincts (cell[12] `(1s, 2s, 4s)` retry exponentiel = paramètre FIXE by code cell[11] `base_delay=1.0` × 2^attempt ; cell[26] `0.5s` pause audio = paramètre FIXE by code cell[24] `pause=np.zeros(int(sr*0.5))` ; ranges pédagogiques « Latence typique » = concept pédagogique). Pattern identique **c.1299-L1 + c.1301-L1 + c.1302-L3**. Sans cette triple distinction, le lecteur ne sait pas si `1s/2s/4s` / `0.5s` / `0.5-2s` sont des contraintes d'algorithme ou des nombres observés.

4. **c.1303-L4 RAW-TEXT-VS-JSON-ROUND-TRIP-PRE-EXISTING-DUPLICATE-METADATA** — Le notebook contient **2 blocs cost metadata dupliqués** (pré-existing bug introduit par PR #9263 migration cost frontmatter → metadata). Une approche naïve `json.load → json.dump` collapse les doublons en gardant le dernier, ce qui aurait produit un churn de 18+/35- lignes sur 13 clés metadata (`api_usd_est/cpu_min/gpu_min/gpu_required/vram_gb/vram_tier/external_account/metadata_written/free_alternative/reduced_pedagogical/reproducibility/validator/notes`) — **contamination hors-scope** (catalog-pr-hygiene R1 « une PR = un sujet »). **Solution** : raw text replacement des 5 lignes markdown uniquement, sans round-trip JSON. **Diff final** : 1 file, 5 insertions, 5 deletions.

5. **c.1303-L5 SUB-FAMILY-ROTATION-VS-TRUE-FAMILY-JUMP** — c.1302 = 1ère famille nouvelle GenAI/Texte (vs Planners/Search/CSP/Sudoku/Infer.NET). c.1303 = sub-family GenAI/Audio (même cluster GenAI mais différent media audio/vidéo vs texte). True family jump vers Lean family est différé à **c.1304** (Lean-8-Agentic-Proving ou Lean-7-LLM-Integration). Cette stratégie respecte R6 « rotation genres ET familles » sans tunneliser un mono-thème. Lean family = **troisième nouvelle famille post-c.1286** = diversification maximale.

6. **c.1303-L6 MINIMAL-TOUCH-5-LIGNES-DRAIN** — c.1303 = **+5/-5 = 5 lignes modifiées** sur 2 cellules ciblées (cell[16] 3 lignes + cell[32] 2 lignes) = density **2.5 hits/ligne moyenne** sur **2 cellules denses** (vs c.1302 = +6/-6 sur 1 cellule, c.1301 = +9/-9 sur 1 cellule, c.1300 = +11/-11 sur 4 cellules). Pattern « cell-by-cell replacement ciblée » permet drainage chirurgical sans toucher prose environnante.

## Anti-pattern évité

- **Refus de re-alignement cosmétique** : aucun timing inventé ; 5 invariants préservés verbatim.
- **0 cellule code touchée** (sinon violation C.2).
- **Pas de catalogue regénéré** (catalog-pr-hygiene R1).
- **PR body HORS worktree** (L677-4 ★★ : scratchpad `c1303_pr_body.md` + `gh api ... pulls --method POST -F body=@<path>`).
- **Push sans custom `Authorization`** header (c.1288-L9 ★).
- **Body @file path absolu Windows** (c.1289-L11 ★).
- **Grain tag MED** (vs DEEP) : extension de drainage existant, structurel préservé verbatim, verification mécanique.
- **Raw text replacement** (vs JSON round-trip) pour éviter contamination doublons cost metadata pré-existants.
- **Pas d'absorption du bug doublons cost metadata** : hors-scope, à tracker dans une issue fille séparée si pertinent.

## Notes méthodologiques additionnelles

- **Distinction paramètre vs runtime (3 cas c.1303)** : cell[12] `(1s, 2s, 4s)` = paramètre FIXE by code retry exponentiel ; cell[26] `0.5s` pause = paramètre FIXE by code `np.zeros(int(sr*0.5))` ; ranges pédagogiques « Latence typique » = concept pédagogique structurel. **Seuls les timings `5.02s / 8.33s / 1.72s / 1.59s / 12.96s` sont drainés**.
- **Distinction structurel vs machine-dep** : Les **invariants pédagogiques** (Latence typique ranges, paramètres FIXES, Optimisation possible recommendations) sont des **invariants structurels** (structurel, déterministe), préservés verbatim. Les **runtimes wall-clock** (`5.02s / 8.33s / 12.96s`) sont **machine-dep**, drainés en `runtime *machine-dep*`.
- **Distinction alignment vs drainage** : PR #8468 NB-8 #8052 avait aligné les timings sur les outputs au commit (= **alignement**, honnete au moment T mais instable). PR #9623 draine les timings en `runtime *machine-dep*` (= **drainage pédagogique**, stable et honnete). Complémentarité — pas redondance.

Refs #9434