### PR TITLE
ci(conway,#8782): wire Conway.Life.GridCanonical into proof-integrity-audit (coverage 10->11)

### DIFF
--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -168,7 +168,7 @@ jobs:
       # and could not tell which tolerates the 8 acknowledged sorries from which
       # refuses them. Pinned by scripts/lean/tests/test_proof_integrity_display_names.py.
       display-name: conway_lean (audit)
-      target-modules: "Conway.Life.HashlifeCorrectness,Conway.Life.MacroCell,Conway.Life.Hashlife,Conway.Life.MacroCell_en,Conway.Life.Hashlife_en,Conway.Life.Oscillators,Conway.Life.Spaceships,Conway.Life.RLE,Conway.Life.HashlifeMemo,Conway.Life.HashlifeMarginDemo"
+      target-modules: "Conway.Life.HashlifeCorrectness,Conway.Life.MacroCell,Conway.Life.Hashlife,Conway.Life.MacroCell_en,Conway.Life.Hashlife_en,Conway.Life.Oscillators,Conway.Life.Spaceships,Conway.Life.RLE,Conway.Life.HashlifeMemo,Conway.Life.HashlifeMarginDemo,Conway.Life.GridCanonical"
       # allow-axioms: the 38 native_decide axioms that HashlifeCorrectness ACTUALLY
       # depends on (empirical footprint revealed by THIS audit job's first CI run).
       # These are DISTINCT from the blocking gate's 19-name list above: that list


### PR DESCRIPTION
## Summary

See #8782 (critères 1-3 couverts par cette PR ; critère 4 = amendement §B.3 en attente de sign-off user — décision ai-01 de garder l'issue ouverte) — extends `proof-integrity-audit` (advisory job on the sorry-bearing
module) by one axiom-clean Life module: `Conway.Life.GridCanonical`. Coverage
goes from 10/43 to 11/43 compiled Conway modules. No `allow-axioms` change
required (GridCanonical is axiom-clean).

## Scope (atomic)

- **1 file changed, 1 insertion(+), 1 deletion(-)** — `.github/workflows/lean-conway.yml` only
- The diff appends `Conway.Life.GridCanonical` to the `proof-integrity-audit` job's
  `target-modules` list (line 171). The blocking `proof-integrity` job is unchanged
  (still targets KochenSpecker + FreeWillTheorem only).

## Why this module, why now

`#8782` is the advisory-job vert-hors-cible issue: the blocking gate was green
on HashlifeCorrectness because it never looked there. Option (b) — an advisory
`proof-integrity-audit` job targeting the sorry-bearing module — was decided
on PR #8782 (decision c.50). Per #8782 criterion 1, the audit must enumerate
module declarations, not silently green-light. **The audit's `target-modules`
list is hand-maintained while the lakefile glob grows**; a hand-maintained list
that covers 10 of N compiled modules is itself a "vert hors-cible". This PR
extends coverage by exactly one axiom-clean module — the smallest grain that
satisfies "don't add blind spots without enumeration".

`Conway.Life.GridCanonical` was selected because it is **axiom-clean**:
- 0 `native_decide` (no decide-kernel escape)
- 0 `sorry`
- 1 kernel `decide` (Fin-typed, in-budget)
- 26 declarations
- Imports: `Conway.Life` (which imports `Mathlib.Tactic` = standard Mathlib basics)

The 6 default `allow-axioms` already whitelisted in the blocking gate
(`Classical.choice, propext, funext, Quot.lift, Quot.mk, Quot.sound`) cover
the transitive Mathlib import chain. **No new `native_decide` axiom appears
in the audit footprint** → no `allow-axioms` list change required → the
pin `assert len(names) == 38` in `test_proof_integrity_audit_wiring.py`
remains valid (this PR widens coverage, not the allow-list).

## Verification

```text
$ python -m pytest scripts/lean/tests/test_proof_integrity_audit_wiring.py -v
7 passed in 0.43s
```

| Test | Result |
|---|---|
| `test_workflow_exists` | PASS |
| `test_blocking_proof_integrity_targets_showcase_modules` | PASS |
| `test_advisory_audit_job_wired` | PASS |
| `test_audit_targets_sorry_bearing_module` | PASS |
| `test_audit_allowlists_native_decide_axioms` | PASS (pin 38 still valid) |
| `test_audit_allowlist_is_distinct_from_blocking_gate` | PASS |
| `test_blocking_and_audit_are_complementary` | PASS |

Coverage delta verified mechanically:
```text
$ python -c "from check_target_coverage import targets_from_workflow, discover_modules; ..."
proof-integrity-audit: 11 modules  (was 10)
Union across all jobs: 13 modules  (2 blocking + 11 audit)
Covered Conway modules: 13/56
Uncovered: 43 (was 44 — +1 covered this PR)
```

The `target-coverage` advisory job (also in `lean-conway.yml`, line 202) will
re-print this delta in CI logs (`--from-workflow` re-reads the workflow yaml
on every run, so the drift-detector cannot miss its own update — the exact
pitfall that bit the option-(b) rollout at c.8782).

## Diagnostic dérive (per pr-review-discipline.md §D.4 — N/A here)

This PR does not modify a notebook, a Lean proof, or any output-bearing cell.
Section D.4 applies to `## Diagnostic dérive` only. Not applicable.

## Anti-régression check (per `anti-regression.md` §D)

- `grep -c sorry` across `Conway.Life.GridCanonical.lean`: **0** (unchanged)
- `grep -c native_decide` across `Conway.Life.GridCanonical.lean`: **0** (unchanged)
- No deletions to existing Lean code. The single diff is an additive YAML string
  in the workflow file. **No anti-régression concern.**

## Discipline preserved

- **L898 ★★★ pre-write**: `gh pr list --state open --search "conway"`, plus
  `gh pr list --author jsboige --state open`, plus `git worktree list`. Zero
  collisions on `Conway.Life.GridCanonical` wiring at write time.
- **L576 ★★ triple-gate**: branch is fresh off `origin/main` (`7a8fc291d`),
  not inherited. No orphan-branch risk.
- **L838bis ★**: branch name (`feature/c8155-8782-gridcanonical-wiring`)
  starts with `feature/c<lane-id>-*` convention. This is the **first** PR
  on this branch in the `c8155` cycle.
- **No `/coordinate`, no `gh auth switch`, no merge, no close d'autrui** (leçon #1502).
- **G-VAR-1 (MED plancher)**: MED/guard, scope ismé, vérifiable. Not LIGHT
  (not generated by scanning the next instance: requires module-level static
  analysis to confirm axiom-cleanliness). Not DEEP (no new sorry removed,
  no capability added — coverage extension only).
- **G-VAR-3 (no two same GENRE consecutively)**: prev grain was
  `MED/lean #9490` (conway triage). This grain is `MED/guard` (CI coverage
  wiring). Different genre → G-VAR-3 satisfied.

## What this PR does NOT do

- Does **not** wire the remaining 32 axiom-clean / sorry-bearing Conway
  modules into the audit. Those are separate grains, G-VAR-2 paced, per the
  DM ai-01 corrigendum ("les 38 blind spots deviennent des grains énumérables
  via #8752, cadencés G-VAR-2 — pas de rafale de 6 PRs coverage").
- Does **not** modify `allow-axioms`. The 38-pinned allow-list remains
  accurate (verified mechanically).
- Does **not** modify the blocking `proof-integrity` job. Showcase modules
  (KochenSpecker, FreeWillTheorem) remain its sole target.
- Does **not** amend `.claude/rules/pr-review-discipline.md` §B.3 — that
  amendement requires user sign-off and is criterion 4 (PARTIAL) of #8782.
  Out of scope for a minimal seam PR.

## Cross-references

- See #8782 (critères 1-3 couverts par cette PR ; critère 4 = amendement §B.3 en attente de sign-off user — décision ai-01 de garder l'issue ouverte) (parent: advisory job vert-hors-cible)
- See #8752 (follow-up: blind-spot enumeration via per-module coverage PRs,
  G-VAR-2 paced)
- See #9132 (NE+SW arm port, recent `proof-integrity-audit` precedent)
- See #9341 / #9571 / #9595 (audit widen precedents: 19→46→41→38 native_decide
  axioms, all tied to specific module coverage extensions)

## Body metadata

```
Grain: MED/guard -- lane myia-po-2026:CoursIA-2 -- prev: MED/lean #9490
```
