### PR TITLE
fix(lean,#9681): tag 4 INTRINSIC Lean pedagogical cells as raises-exception (validator CI unblock tranche 2/2)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/02-Lean-SocialChoice-Formal.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/02-Lean-SocialChoice-Formal.ipynb
@@ -2309,7 +2309,9 @@
      "start_time": "2026-06-07T20:37:14.478640+00:00",
      "status": "completed"
     },
-    "tags": []
+    "tags": [
+     "raises-exception"
+    ]
    },
    "outputs": [
     {
@@ -3370,7 +3372,9 @@
      "start_time": "2026-06-07T20:37:15.856649+00:00",
      "status": "completed"
     },
-    "tags": []
+    "tags": [
+     "raises-exception"
+    ]
    },
    "outputs": [
     {
@@ -4304,7 +4308,9 @@
      "start_time": "2026-06-07T20:37:16.935989+00:00",
      "status": "completed"
     },
-    "tags": []
+    "tags": [
+     "raises-exception"
+    ]
    },
    "outputs": [
     {

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-12b-Lean-Sensitivity-Theorem.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-12b-Lean-Sensitivity-Theorem.ipynb
@@ -401,7 +401,9 @@
      "start_time": "2026-06-26T19:48:05.309959+00:00",
      "status": "completed"
     },
-    "tags": []
+    "tags": [
+     "raises-exception"
+    ]
    },
    "outputs": [
     {


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #9680 (c.1310 01-4-Whisper-Local STT LOCAL)

Closes #9681

# fix(lean,#9681): tag 4 INTRINSIC Lean pedagogical cells as raises-exception (validator CI unblock tranche 2/2)

## Summary

Surgical metadata injection on 4 Lean pedagogical cells across 2 files to unblock the `validate_pr_notebooks.py` CI check (ligne 358 escape hatch documented post #5176). The 4 cells contain deliberate pedagogical INTRINSIC errors where the alectryon output IS the deliverable — tagging them `raises-exception` exempts them from the `severity:error` check without altering source/outputs/execution_count.

This is tranche 2/2, following PR #9679 which fixed GT-4b-Lean-NashExistence cell 28 (tranche 1/2).

## Cells tagged (4 cells × 2 files)

| File | Cell | Pedagogical pattern |
|------|------|---------------------|
| `GameTheory/SocialChoice/02-Lean-SocialChoice-Formal.ipynb` | 29 | `-- TODO etudiant : Definir dictatorship` + `theorem dictatorship_pareto` (student TODO incomplet) |
| `GameTheory/SocialChoice/02-Lean-SocialChoice-Formal.ipynb` | 44 | `SatisfiesPareto` / `SatisfiesUnanimity` definitions (VotingRule type incomplet) |
| `GameTheory/SocialChoice/02-Lean-SocialChoice-Formal.ipynb` | 57 | `IsOptimistSP` (Duggan-Schwartz multi-winner definition, type-mismatch pédagogique) |
| `SymbolicAI/Lean/Lean-12b-Lean-Sensitivity-Theorem.ipynb` | 8 | `#check Sensitivity.Q` — espace de noms `Sensitivity` non défini, démo de ce qui doit être formalisé |

## Litmus INTRINSIC (per §D.5)

Toutes les 4 cellules :
- Présentes sur main depuis longtemps (execution_count/outputs intacts, source inchangée)
- Markdown suivante mentionne `TODO etudiant` / `Interpretation des axiomes` / `Interpretation de Duggan-Schwartz` / `3.2 Espace vectoriel libre`
- Pas de warning de compilation = type-error DIDACTIQUE, pas une cellule silencieusement cassée
- L'erreur fait partie du parcours pédagogique : l'étudiant voit l'erreur, lit l'interprétation, complète le TODO

## Acceptance

- [x] Validator `validate_pr_notebooks.py` PASS sur les 2 fichiers (4/4 cells exemptées via `tags: ["raises-exception"]`)
- [x] Aucune cellule code touchée (execution_count/outputs byte-identique à main)
- [x] Pas de re-exécution, pas de hand-edit d'output (Stop & Repair règle 6)
- [x] Diff = **12 insertions, 4 deletions, 2 files** — purely surgical

## Validation per CLAUDE.md §B.5 + notebook-conventions C.1/C.2

| Check | Statut |
|-------|--------|
| Scope réel (uniquement #9681) | ✅ claim = scope = diff |
| `git diff --stat` cohérent | ✅ 2 files, +12/-4 |
| Cellules code = `execution_count: <int>` + outputs cohérents | ✅ 4/4 préservés |
| 0 cellule `# Solution` / `# Exemple résolu` supprimée | ✅ (aucune touchée) |
| Stop & Repair règle 6 | ✅ cause = marqueur manquant, pas erreur à corriger |
| CR/LF/BOM preserved | ✅ vérifié post-write (cf c.1311-L1 ★) |
| C955-1 ★★★ surgical edit | ✅ metadata uniquement |

## Lesson c.1311-L1 ★ — TRAILING-NEWLINE gotcha post-json.dump

`json.dumps(nb).encode() + b'\n'` ajoute systématiquement un trailing newline. Quand l'`origin` du fichier n'a PAS de newline final (vérifié via `git show HEAD:<path> | od -c | tail`), le strip final est nécessaire pour préserver byte-identique. **Premier passage : j'ai strippé les 2 fichiers alors qu'un seul n'avait pas de newline (Lean-12b)** — corrigé en re-checkant `git show HEAD:...` et en restaurant le newline du SC file. Coût : 1 round-trip `git diff` + 1 strip + 1 restore.

Tell discriminant : `od -c file | tail -3` AVANT json.dump → mémoriser `original_ends_with_newline` → restaurer à l'identique. Évite pollution diff anti-régression (cf c.1086-L).

Closes #9681