### PR TITLE
fix(ci,#9672): anchor validate_pr_notebooks perimeter on merge-base (stop main-side pollution)

### DIFF
--- a/scripts/notebook_tools/tests/test_validate_pr_mutation.py
+++ b/scripts/notebook_tools/tests/test_validate_pr_mutation.py
@@ -326,7 +326,7 @@ class TestGetChangedNotebooks:
         assert result == []
 
     def test_git_diff_called_when_no_paths(self):
-        """Without explicit paths, git diff is invoked."""
+        """Without explicit paths, merge-base then git diff are invoked (#9672)."""
         with patch("validate_pr_notebooks.subprocess.run") as mock_run:
             # Return a path that exists on disk so the filter passes
             nb_path = Path(__file__).resolve().parent.parent.parent / "MyIA.AI.Notebooks" / "Search" / "Part1-Foundations" / "Search-1-Introduction.ipynb"
@@ -334,7 +334,9 @@ class TestGetChangedNotebooks:
                 stdout=str(nb_path) + "\n", stderr=""
             )
             result = get_changed_notebooks("origin/main")
-            mock_run.assert_called_once()
+            assert mock_run.call_count == 2
+            assert "merge-base" in mock_run.call_args_list[0].args[0]
+            assert "diff" in mock_run.call_args_list[1].args[0]
             if nb_path.exists():
                 assert len(result) >= 1
             else:

--- a/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
+++ b/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
@@ -702,3 +702,61 @@ class TestBlankRenderVerdict:
         ], kernelspec={"name": "lean4", "language": "lean4"})
         result = validate_notebook(nb)
         assert result["forensic_verdict"] == "ADVISORY_NON_EXEC"
+
+
+# ---------------------------------------------------------------------------
+# get_changed_notebooks — perimeter anchored on merge-base (#9672)
+# ---------------------------------------------------------------------------
+
+class TestGetChangedNotebooksPerimeter:
+    """A file that changed on *base* after the branch was cut must NOT enter
+    the validation perimeter (#9672 blast radius: pre-existing main-side
+    violations failed unrelated PRs #9650/#9656/#9671/#9673)."""
+
+    @staticmethod
+    def _git(repo: Path, *args: str) -> str:
+        import subprocess
+        return subprocess.run(
+            ["git", *args], capture_output=True, text=True, check=True,
+            cwd=str(repo),
+        ).stdout.strip()
+
+    def _make_repo(self, tmp_path: Path) -> Path:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._git(repo, "init", "-b", "main")
+        self._git(repo, "config", "user.email", "t@t")
+        self._git(repo, "config", "user.name", "t")
+        _write_nb(repo / "on_main.ipynb", [_code("x = 1")])
+        _write_nb(repo / "on_branch.ipynb", [_code("y = 2")])
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-m", "init")
+        # branch cut here, then main moves on: on_main.ipynb changes on main
+        self._git(repo, "branch", "feature")
+        _write_nb(repo / "on_main.ipynb", [_code("x = 111")])
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-m", "main-side change")
+        # the branch changes only its own file
+        self._git(repo, "checkout", "feature")
+        _write_nb(repo / "on_branch.ipynb", [_code("y = 222")])
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-m", "branch-side change")
+        return repo
+
+    def test_main_side_change_excluded(self, tmp_path, monkeypatch):
+        import validate_pr_notebooks as vpn
+        repo = self._make_repo(tmp_path)
+        monkeypatch.setattr(vpn, "REPO_ROOT", repo)
+        names = [p.name for p in vpn.get_changed_notebooks("main")]
+        assert names == ["on_branch.ipynb"]
+
+    def test_uncommitted_worktree_change_included(self, tmp_path, monkeypatch):
+        """Diffing against the merge-base commit (not base..HEAD) keeps the
+        local pre-commit use case: uncommitted edits still enter the perimeter."""
+        import validate_pr_notebooks as vpn
+        repo = self._make_repo(tmp_path)
+        _write_nb(repo / "uncommitted.ipynb", [_code("z = 3")])
+        self._git(repo, "add", "uncommitted.ipynb")
+        monkeypatch.setattr(vpn, "REPO_ROOT", repo)
+        names = sorted(p.name for p in vpn.get_changed_notebooks("main"))
+        assert names == ["on_branch.ipynb", "uncommitted.ipynb"]

--- a/scripts/notebook_tools/validate_pr_notebooks.py
+++ b/scripts/notebook_tools/validate_pr_notebooks.py
@@ -126,13 +126,33 @@ TEXT_RENDERED_ERROR_SIGNATURES = ('"severity": "error"', '"severity":"error"')
 
 
 def get_changed_notebooks(base: str, paths: list[str] | None = None) -> list[Path]:
-    """Get list of .ipynb files changed relative to base branch."""
+    """Get list of .ipynb files changed relative to base branch.
+
+    The diff anchor is merge-base(base, HEAD), not base itself: diffing
+    against base directly also lists every file that changed on *base*
+    since the branch was cut, so a violation landing on main (e.g. the
+    pre-existing GT-4b cell 28 error, #9672) failed unrelated PRs whose
+    diff never touched the file (#9650/#9656/#9671/#9673). Falls back to
+    base when merge-base is unavailable (shallow clone, detached ref).
+    """
     if paths:
         return [Path(p) for p in paths if p.endswith(".ipynb") and Path(p).exists()]
 
+    anchor = base
+    try:
+        mb = subprocess.run(
+            ["git", "merge-base", base, "HEAD"],
+            capture_output=True, text=True, check=True,
+            cwd=str(REPO_ROOT),
+        ).stdout.strip()
+        if mb:
+            anchor = mb
+    except subprocess.CalledProcessError:
+        pass
+
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", "--diff-filter=ACM", base],
+            ["git", "diff", "--name-only", "--diff-filter=ACM", anchor],
             capture_output=True, text=True, check=True,
             cwd=str(REPO_ROOT),
         )


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: DEEP/training #9653

## Summary

Ancre le périmètre de `validate_pr_notebooks.py` sur **merge-base(base, HEAD)** au lieu de `origin/main` directement.

## Problème (#9672, volet structurel)

Le diff two-dot contre `origin/main` liste aussi les fichiers modifiés **sur main** depuis la création de la branche — le validateur les balayait à la **version stale de la branche**. Conséquence mesurée : la violation pré-existante GT-4b cell 28 a fait FAIL des PRs dont le diff ne touchait pas le fichier (#9650, #9656, #9671, #9673 — reproduit firsthand en local sur la branche de #9671 : `passed: False` sur `GameTheory-4b-Lean-NashExistence.ipynb` absent du diff).

## Fix

- `get_changed_notebooks()` : calcule `git merge-base base HEAD` et diffe contre ce commit. Les fichiers main-side sortent du périmètre ; les modifications **non commitées** du working tree restent incluses (usage pre-commit local préservé). Fallback sur `base` si merge-base indisponible (shallow clone).
- CI : `fetch-depth: 0` déjà en place dans `notebook-execution-required.yml` → merge-base calculable.

## Validation

- 2 nouveaux tests (`TestGetChangedNotebooksPerimeter`) : exclusion d'un changement main-side post-branche ; inclusion des changements working-tree non commités.
- Suite complète : **59 passed** (57 existants + 2 nouveaux), `python -m pytest scripts/notebook_tools/tests/test_validate_pr_notebooks.py -q`.

## Complément du volet cellule (déjà livré)

Le volet « GT-4b cell 28 » de #9672 est résolu par #9679 (tag `raises-exception`, mergée) — diagnostic corrigé : formalisation pédagogique délibérément incomplète, pas une erreur de toolchain. Cette PR ferme le volet périmètre.

Closes #9672

🤖 Generated with [Claude Code](https://claude.com/claude-code)
