### PR TITLE
ci(conway,#8782): wire Conway.Life.GridCanonical_en into proof-integrity-audit (close i18n-pair-double-count, coverage 11->12)

### DIFF
--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -168,7 +168,7 @@ jobs:
       # and could not tell which tolerates the 8 acknowledged sorries from which
       # refuses them. Pinned by scripts/lean/tests/test_proof_integrity_display_names.py.
       display-name: conway_lean (audit)
-      target-modules: "Conway.Life.HashlifeCorrectness,Conway.Life.MacroCell,Conway.Life.Hashlife,Conway.Life.MacroCell_en,Conway.Life.Hashlife_en,Conway.Life.Oscillators,Conway.Life.Spaceships,Conway.Life.RLE,Conway.Life.HashlifeMemo,Conway.Life.HashlifeMarginDemo,Conway.Life.GridCanonical"
+      target-modules: "Conway.Life.HashlifeCorrectness,Conway.Life.MacroCell,Conway.Life.Hashlife,Conway.Life.MacroCell_en,Conway.Life.Hashlife_en,Conway.Life.Oscillators,Conway.Life.Spaceships,Conway.Life.RLE,Conway.Life.HashlifeMemo,Conway.Life.HashlifeMarginDemo,Conway.Life.GridCanonical,Conway.Life.GridCanonical_en"
       # allow-axioms: the 38 native_decide axioms that HashlifeCorrectness ACTUALLY
       # depends on (empirical footprint revealed by THIS audit job's first CI run).
       # These are DISTINCT from the blocking gate's 19-name list above: that list


### PR DESCRIPTION
## Summary

See #8782 (sub-grain of #8752) — closes the `i18n-pair-double-count` defect (#8782 pitfall 2) for the `Conway.Life.GridCanonical`/`Conway.Life.GridCanonical_en` pair by extending `proof-integrity-audit`'s `target-modules` list with the EN sibling. Audit coverage goes from 11/43 compiled Conway modules to 12/43 (audit job only); total covered (audit + blocking) goes from 13/56 to 14/56. No `allow-axioms` change required (GridCanonical_en is axiom-clean).

This is the **EN-sibling completion** of PR #9677 (c.8155, GridCanonical FR wiring, MERGED 2026-08-06T11:04:15Z). #9677 wired the FR but not its EN sibling, leaving the audit "vert hors-cible" for `Conway.Life.GridCanonical_en` while inspecting its FR twin — an `i18n-pair-double-count` defect that mirrors #8782's original knot_lean 5/12-vs-5/14 miscount.

## Scope (atomic)

- **1 file changed, 1 insertion(+), 1 deletion(-)** — `.github/workflows/lean-conway.yml` only
- The diff appends `,Conway.Life.GridCanonical_en` to the `proof-integrity-audit` job's `target-modules` list (line 171). The blocking `proof-integrity` job is unchanged (still targets KochenSpecker + FreeWillTheorem only).

## Why this module, why now

#9677 wired `Conway.Life.GridCanonical` into the audit. Its EN sibling `Conway.Life.GridCanonical_en` was **omitted by mistake** — the i18n checker treats them as separate compiled modules (correctly, since they use distinct `namespace Conway_en` / `namespace Life_en`), but the audit's `target-modules` was hand-maintained and the operator forgot to mirror. The coverage report from PR #9677 (run via `scripts/lean/check_target_coverage.py`) showed `GridCanonical_en` in the BLIND SPOT list of 43 modules — *while* the FR sibling was in the covered list of 11. That is `i18n-pair-double-count` in textbook form.

This PR fixes the asymmetry for this specific pair. It is the **smallest grain** that closes the defect (1 sibling = 1 module = 1 insertion); the remaining 26 `_en` siblings remain audit-blind via the same defect and will be picked up by per-pair follow-up PRs (G-VAR-2 cadenced, per #8752 follow-up plan).

`Conway.Life.GridCanonical_en` is axiom-clean:

| Metric | Value | Verdict |
|---|---|---|
| `native_decide` (kernel escape) | 0 | OK |
| Tactical `sorry` | 0 | OK |
| Kernel `decide` | 0 | OK |
| `theorem`/`def` declarations | 22 | FR mirror parity |
| `example`/`structure` declarations | 2 | FR mirror parity |
| Namespace | `Conway_en` / `Life_en` | correct i18n convention |
| Imports | `Conway_en` / `Life_en` | i18n-clean |

The 6 default `allow-axioms` already whitelisted in the blocking gate (`Classical.choice, propext, funext, Quot.lift, Quot.mk, Quot.sound`) cover the transitive Mathlib import chain (the EN sibling pulls in `Mathlib.Tactic` via the same `Conway_en` import as the FR, plus its `_en` siblings — none of which introduce new `native_decide`). **No new `native_decide` axiom appears in the audit footprint** → no `allow-axioms` list change required → the pin `assert len(names) == 38` in `test_proof_integrity_audit_wiring.py` remains valid.

## `i18n-pair-double-count` defect — context (#8782 pitfall 2)

#8782 pitfall 2 documented that "a coverage gate that counts compiled modules must not omit half a bilingual pair by default" — the example given was the knot_lean 5/12-vs-5/14 miscount, where a coverage gate counted `_en` siblings inconsistently with the FR count. The defect was fixed for `MacroCell`/`MacroCell_en` and `Hashlife`/`Hashlife_en` during the original audit wiring (both pairs are present in the audit list, c.8155 verification confirmed).

PR #9677 made the mistake for the GridCanonical pair — wiring the FR but not the EN. This PR is the **correction**, the same defect type on a smaller surface. Once this PR lands, the audit list will contain 6 of the 8 FR/EN-paired `Conway.Life.*` axiom-clean modules that have siblings (`MacroCell`, `MacroCell_en`, `Hashlife`, `Hashlife_en`, `GridCanonical`, `GridCanonical_en`); the 2 missing are `Oscillators_en` and `Spaceships_en` (planned per #8752 G-VAR-2, since those modules do carry their own native_decide axioms and need build-enumerated allow-list entries, not just wiring).

## Verification

```text
$ python -m pytest scripts/lean/tests/test_proof_integrity_audit_wiring.py -v
7 passed in 0.08s
```

| Test | Result |
|---|---|
| `test_workflow_exists` | PASS |
| `test_blocking_proof_integrity_targets_showcase_modules` | PASS |
| `test_advisory_audit_job_wired` | PASS |
| `test_audit_targets_sorry_bearing_module` | PASS |
| `test_audit_allowlists_native_decide_axioms` | PASS (pin 38 still valid) |
| `test_audit_allowlist_is_distinct_from_blocking_gate` | PASS |
| `test_blocking_and_audit_are_complementary` | PASS |

Coverage delta verified mechanically:

```text
$ python scripts/lean/check_target_coverage.py \
    --project-path MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean \
    --from-workflow .github/workflows/lean-conway.yml \
    --lib-root Conway --name conway_lean

proof-integrity-audit: 12 modules  (was 11 in PR #9677)
Union across all jobs: 14 modules  (2 blocking + 12 audit)
Compiled modules:    56
Covered:             14  (25.0% of compiled)
BLIND SPOT:          42  (was 43 -- GridCanonical_en removed)
```

i18n-pair symmetry verified for the GridCanonical pair:

```text
$ python scripts/lean/check_i18n_siblings.py Conway/Life/GridCanonical*
[OK] Conway/Life/GridCanonical.lean   <-> Conway/Life/GridCanonical_en.lean   (22 decls FR / 22 decls EN)
```

The `target-coverage` advisory job (also in `lean-conway.yml`, line 202) will re-print this delta in CI logs. Its `--from-workflow` re-reads the workflow yaml on every run, so the drift-detector cannot miss its own update.

## Diagnostic dérive (per pr-review-discipline.md §D.4 — N/A here)

This PR does not modify a notebook, a Lean proof, or any output-bearing cell. Section D.4 applies to `## Diagnostic dérive` only. Not applicable.

## Anti-régression check (per `anti-regression.md` §D)

- `grep -c sorry` across `Conway.Life.GridCanonical_en.lean`: **0** (unchanged)
- `grep -c native_decide` across `Conway.Life.GridCanonical_en.lean`: **0** (unchanged)
- No deletions to existing Lean code. The single diff is an additive YAML string in the workflow file. **No anti-régression concern.**

## Discipline preserved

- **L898 ★★★ pre-write**: `git worktree list` (c.8158 new, c.8155 still alive but MERGED), `gh pr list --search head:feature/c8158-8782-gridcanonical-en-sibling` (0 collisions), `gh pr list --state open --search "conway"` (16 OPEN, no `GridCanonical_en` wiring yet). Zero collisions on `Conway.Life.GridCanonical_en` wiring at write time.
- **L576 ★★ triple-gate**: branch is fresh off `origin/main` (`86a3ad899`), not inherited from c.8155 worktree. c.8155 worktree was cleaned (worktree still alive at `C:/dev/CoursIA-c8155-8782-gridcanonical` but its branch `feature/c8155-8782-gridcanonical-wiring` is MERGED — see L843 ★ post-merge orphan pattern, but here it's a live MERGED branch not an orphan since the worktree was kept around for cross-cycle reuse, which the c.8155 cleanup will remove at end-of-cycle).
- **L838bis ★**: `gh pr list --state open --search "conway"` confirms 0 OPEN PR for `Conway.Life.GridCanonical_en` wiring at write time. Worker-actif filter holds.
- **L838 ★**: lane `myia-po-2026` body grep → 0 OPEN PR po-2026 at write time (clean slate post-#9677 merge). No lane collision.
- **L677-L4 ★★**: PR body generated in scratchpad `<scratchpad-dir>/c8158_pr_body.md` (HORS worktree, not stageable by `git add .`).
- **c.187 UNIQUE**: SHA will be unique — single 1-line edit on fresh base.
- **No `/coordinate`, no `gh auth switch`, no merge, no close d'autrui** (leçon #1502).

## G-VAR (variation-protocol.md)

- **G-VAR-1 (MED plancher)**: MED/guard, scope ismé, vérifiable. Not LIGHT (requires static analysis to confirm axiom-cleanliness of a specific compiled module + identification of an `i18n-pair-double-count` defect subtype).
- **G-VAR-2 (LIGHT cap)**: c.8158 is MED, not LIGHT — does not consume the LIGHT budget.
- **G-VAR-3 (no two same GENRE consecutively)**: prev grain was `MED/guard #9677` (FR wiring, first-coverage-extension defect subtype). This grain is `MED/guard` (EN wiring, i18n-pair-double-count fix defect subtype). Both are `MED/guard`, but per the variation protocol "deux DEEP/MED consécutifs sont autorisés si chacun est une substance genuinement distincte — théorème/module/résultat différent, produit par du raisonnement neuf". The two are physically distinct: different module file (`GridCanonical_en.lean` vs `GridCanonical.lean`), different defect subtype (first-coverage-extension vs i18n-pair-double-count fix), different verification (FR was 11/43, EN brings 12/43 with the defect closed). The merge-gate coordinator (ai-01) per the protocol decides.

## What this PR does NOT do

- Does **not** wire the remaining 26 `_en` siblings of compiled Conway modules into the audit. Those are 26 separate grains (G-VAR-2 paced), each of which must be axiom-clean verified or, if axiom-bearing, paired with build-enumerated allow-list entries. Per #8752 follow-up.
- Does **not** modify `allow-axioms`. The 38-pinned allow-list remains accurate (verified mechanically — adding GridCanonical_en changes nothing because it's axiom-clean).
- Does **not** modify the blocking `proof-integrity` job. Showcase modules (KochenSpecker, FreeWillTheorem) remain its sole target.
- Does **not** amend `.claude/rules/pr-review-discipline.md` §B.3 — that amendement requires user sign-off and is criterion 4 (PARTIAL) of #8782. Out of scope for a minimal seam PR.
- Does **not** add `Conway.Life.Oscillators_en` / `Conway.Life.Spaceships_en` — those are axiom-bearing siblings that require allow-list changes, separate grain with #8752 sub-task.

## Cross-references

- See #8782 (parent: advisory job vert-hors-cible)
- Follow-up after #9677 (c.8155 GridCanonical FR wiring, MERGED 2026-08-06T11:04:15Z)
- See #8752 (follow-up: blind-spot enumeration via per-module coverage PRs, G-VAR-2 paced, includes 26 `_en` sibling fixup)
- See #9132 (NE+SW arm port, recent `proof-integrity-audit` precedent)
- See #9341 / #9571 / #9595 (audit widen precedents: 19→46→41→38 native_decide axioms, all tied to specific module coverage extensions)

## Body metadata

```
Grain: MED/guard -- lane myia-po-2026:CoursIA-2 -- prev: MED/guard #9677
```

