### PR TITLE
fix(genai,#9434): drain 7 wall-clock claims from 02-3-MusicGen (MED audio advanced)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb
@@ -332,15 +332,15 @@
     "\n",
     "| Composant | Statut | Rôle |\n",
     "|-----------|--------|------|\n",
-    "| **GPU detecte** | RTX 3090 (24 GB VRAM) | Acceleration de la generation (10-50x plus rapide que CPU) |\n",
+    "| **GPU detecte** | RTX 3090 (24 GB VRAM) | *runtime *machine-dep* : acceleration de la generation (10-50x plus rapide que CPU) |\n",
     "| **Repertoire sortie** | `outputs/audio/musicgen/` | Stockage des fichiers WAV generes |\n",
     "| **Helpers audio** | Importes | Fonctions utilitaires pour lecture/sauvegarde |\n",
     "| **Logging** | INFO niveau | Suivi des opérations et debugging |\n",
     "\n",
     "**Verification GPU** :\n",
-    "La presence d'un GPU NVIDIA avec CUDA est critique pour MusicGen. En mode CPU, la generation prendrait 10-50x plus de temps.\n",
+    "La presence d'un GPU NVIDIA avec CUDA est critique pour MusicGen. En mode CPU, *runtime *machine-dep* : generation prendrait 10-50x plus de temps.\n",
     "\n",
-    "> **Note** : Si aucun GPU n'est detecte, le notebook passera automatiquement en mode CPU mais affichera un avertissement sur les temps de generation elonges."
+    "> **Note** : Si aucun GPU n'est detecte, le notebook passera automatiquement en mode CPU mais affichera un avertissement sur *runtime *machine-dep* : temps de generation elonges."
    ]
   },
   {
@@ -453,7 +453,7 @@
     "|--------|-----------|------|---------|--------|\n",
     "| `musicgen-small` | 300M | ~4 GB | Bonne | Rapide |\n",
     "| `musicgen-medium` | 1.5B | ~10 GB | Très bonne | Moyen |\n",
-    "| `musicgen-large` | 3.3B | ~20 GB | Excellente | Lent |\n",
+    "| `musicgen-large` | 3.3B | ~20 GB | Excellente | *runtime *machine-dep* : lent |\n",
     "| `musicgen-melody` | 1.5B | ~10 GB | Très bonne | Moyen |\n",
     "\n",
     "### Modes de generation\n",
@@ -590,7 +590,7 @@
     "\n",
     "| Aspect | Detail |\n",
     "|--------|--------|\n",
-    "| **Premier chargement** | Telechargement depuis HuggingFace Hub (~1-10 GB selon modèle) |\n",
+    "| **Premier chargement** | *runtime *machine-dep* : telechargement depuis HuggingFace Hub (~1-10 GB selon modèle) |\n",
     "| **Chargements suivants** | Cache local, beaucoup plus rapide |\n",
     "| **VRAM requise** | 4 GB (small) a 20 GB (large) |\n",
     "| **Sample rate** : 32 kHz | Qualite audio standard pour la musique generee |\n",
@@ -1306,7 +1306,7 @@
     "Cette section teste systematiquement l'impact de la temperature sur le style musical genere.\n",
     "\n",
     "**Hypotheses** :\n",
-    "- Temperature basse (0.5) : Generation conservatrice, repetitive, previsible\n",
+    "- Temperature basse (0.5) : *runtime *machine-dep* : generation conservatrice, repetitive, previsible\n",
     "- Temperature moyenne (0.8-1.0) : Equilibre entre coherence et creativite\n",
     "- Temperature elevee (1.2+) : Generation audacieuse, parfois incoherente\n",
     "\n",
@@ -1347,7 +1347,7 @@
     "| 1.2 | Très creatif, parfois incoherent | Experimentation |\n",
     "\n",
     "**Points cles** :\n",
-    "1. La temperature n'affecte pas significativement le temps de generation\n",
+    "1. *runtime *machine-dep* : la temperature n'affecte pas significativement le temps de generation\n",
     "2. Des temperatures elevees augmentent la diversite mais peuvent reduire la coherence\n",
     "3. Le cfg_coef contrôle la fidelite a la description (3.0 est un bon defaut)"
    ]


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #9684 (c.1312 02-4-Demucs audio advanced)

Refs #9434

# fix(genai,#9434): drain 7 wall-clock claims from 02-3-MusicGen-Generation (MED, audio advanced)

## Summary

Surgical markdown-only drainage on `MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb` — **7 insertions, 7 deletions, 1 file**. 7 préfixes `runtime *machine-dep*` injectés sur 5 cellules (cell[7] ×3 + cell[11] ×1 + cell[13] ×1 + cell[23] ×1 + cell[24] ×1) — zero cellule code touchée, 13/13 code cells execution_count préservés.

Sub-family GenAI/Audio **advanced** MusicGen (AudioCraft Meta) — 3ᵉ entrée advanced post-c.1312 Demucs Source Separation + c.1313 Song Generation (YuE + SongGen 2 cross-comparison). **Ferme le triplet advanced music** (Source Separation + Song Generation + Music Generation). 29ᵉ réutilisation archétype 6ᵉ #9434.

## Cells drained (5 cells, 7 préfixes)

| Cell | Row drained | Rationale §D.5 |
|------|-------------|----------------|
| **cell[7]** (Interpretation environnement) | `\| GPU detecte \| RTX 3090 (24 GB VRAM) \| Acceleration de la generation (10-50x plus rapide que CPU) \|` → préfixe | axe a hardware ack — **`10-50x` ratio COMPUTED préservé verbatim** HORS scope (c.1313-L3 ★ analogue) |
| **cell[7]** (Vérification GPU paragraphe) | `En mode CPU, la generation prendrait 10-50x plus de temps` → préfixe | axe a runtime claim — **`10-50x` ratio COMPUTED préservé verbatim** HORS scope |
| **cell[7]** (Note GPU absent) | `Si aucun GPU n'est detecte...temps de generation elonges` → préfixe | axe a CPU fallback qualitative runtime DRAINABLE |
| **cell[11]** (Tableau Variantes Vitesse) | `\| musicgen-large \| 3.3B \| ~20 GB \| Excellente \| Lent \|` → préfixe | axe a qualitative runtime label — **VRAM `~20 GB` axe c structurel préservé** |
| **cell[13]** (Chargement modèle) | `\| Premier chargement \| Telechargement depuis HuggingFace Hub (~1-10 GB selon modèle) \|` → préfixe | axe a 3ᵉ catégorie timings (c.1315-L4 ★ extension c.1309-L2 ★ + c.1310-L2 ★ + c.1313-L4 ★) DRAINABLE |
| **cell[23]** (Hypothèses temperature) | `- Temperature basse (0.5) : Generation conservatrice, repetitive, previsible` → préfixe | axe a runtime claim — `0.5` temperature value axe c préservé |
| **cell[24]** (Points clés parameters) | `1. La temperature n'affecte pas significativement le temps de generation` → préfixe | axe a runtime claim DRAINABLE |

**Total** : 7 préfixes `runtime *machine-dep*` insérés.

## Litmus §D.5 — 4 catégories timings (canonique)

1. **Wall-clock LOCAL inference latency** (axe a) — **DRAINABLE**
   - cell[7] `Acceleration de la generation (10-50x plus rapide que CPU)` hardware ack
   - cell[7] `En mode CPU, la generation prendrait 10-50x plus de temps`
   - cell[7] `temps de generation elonges` CPU fallback qualitative
   - cell[11] `Lent` musicgen-large qualitative label
2. **Audio duration** (axe c moteur upstream déterministe) — **NOT drainable**
   - cell[0] `Duree estimee : 45 minutes` pédagogique stable
   - cell[1] `duration_seconds = 10` audio config
   - cell[16] `duration : 10 secondes (configurable)` axe c
   - cell[19]/cell[25]/cell[31] `Duree estimee : 15 minutes` exercices
   - cell[36] `Duree max ~30s` architecture limit
   - cell[38] `Duree ~30s max` architecture limit
3. **Ratio structurel COMPUTED** (axe c computed) — **HORS scope** (c.1313-L3 ★ analogue)
   - cell[7] `10-50x plus rapide que CPU` = COMPUTED ratio
   - cell[7] `10-50x plus de temps` = COMPUTED ratio
   - cell[17] `0.24-0.27x (ce run)` RTF-style = COMPUTED
   - cell[18] `0.24-0.27x (observe, GPU)` idem COMPUTED
4. **Chargement modèle** (axe a init time distinct de l'inférence) — **DRAINABLE**
   - cell[13] `Telechargement depuis HuggingFace Hub (~1-10 GB selon modèle)` —
     c.1315-L4 ★ 4ᵉ entrée 3ᵉ catégorie timings après c.1309 (Chatterbox audio) +
     c.1310 (Whisper STT) + c.1313 (YuE/SongGen installation)

## Invariants préservés verbatim (10)

- `Duree estimee : 45 minutes` cell[0] (axe c pédagogique)
- `Duree estimee : 15 minutes` cell[19]/cell[25]/cell[31] (axe c exercices)
- `duration_seconds = 10` cell[1] config (axe c)
- `duration : 10 secondes (configurable)` cell[16] (axe c)
- `Duree max ~30s` cell[36] architecture limit (axe c)
- `Duree ~30s max` cell[38] architecture limit (axe c)
- VRAM specs `4 GB / 10 GB / 20 GB / 24 GB` (axe c hardware structurel)
- Paramètres modèles `300M / 1.5B / 3.3B` (axe c architecture)
- Sample rate `32 kHz mono` (axe c)
- Ratios COMPUTED `10-50x / 0.24-0.27x` (structurel HORS scope)
- 120 BPM tempo cell[14] (axe c moteur upstream)

## Acceptance

- [x] Validateur `validate_pr_notebooks.py` PASS (notebook tagged `runtime *machine-dep*` ≠ cellule code avec `severity:error`)
- [x] Aucune cellule code touchée (13/13 execution_count préservés, 13/13 outputs préservés)
- [x] Pas de ré-exécution kernel (markdown-only, scope strict)
- [x] Diff = **7 insertions, 7 deletions, 1 file** — purely surgical

## Tells archétypaux c.1315 spécifiques

- **c.1315-L1 ★** : **Triplet advanced music close** (Source Separation + Song Generation + Music Generation). 3ᵉ entrée advanced post-c.1312 Demucs Source Separation (#9684 MERGED) + c.1313 Song Generation cross-comparison (#9685 OPEN). MusicGen (AudioCraft Meta) = génération musique mono-source depuis descriptions textuelles + melody conditioning — différent des 2ᵉ précédentes par scope (musique instrumentale vs séparation sources vs génération chanson voix+instrumentale).
- **c.1315-L2 ★** : **3 entrées advanced music complémentaires** : c.1312 (séparation 4-stems drums/bass/vocals/other) + c.1313 (génération chanson 2-modèles) + c.1315 (génération musique depuis texte). Pattern distinct = MusicGen = **mono-source texte-only** (vs c.1313 multi-source voix+instrumentale). Mêmes tells hardware-bound `RTX 3090` (c.1312-L2 ★★) + `RTX 4090` (c.1313-L2 ★★) = accélération GPU/CPU ordre de grandeur 10x conservé.
- **c.1315-L3 ★ COMPUTED RTF HORS scope** (extension c.1308-L3/L7 + c.1310-L4 + c.1313-L3) : cell[7] `10-50x` + cell[17]+cell[18] `0.24-0.27x` = ratios COMPUTED GPU/CPU et RTF-style `duration/gen_time` — propriété intrinsèque du moteur pour specs données. PRÉSERVÉ verbatim (juste préfixe le claim runtime adjacent). Critère discriminant stable : ratio COMPUTED = structurel HORS scope.
- **c.1315-L4 ★ 3ᵉ catégorie timings HuggingFace Hub** (extension c.1309-L2 ★ audio + c.1310-L2 ★ STT + c.1313-L4 ★ YuE/SongGen installation) : cell[13] `Telechargement depuis HuggingFace Hub (~1-10 GB selon modèle)` = 4ᵉ entrée catégorie "chargement + installation modèle" = axe (a) init time distinct de l'inférence. Catégorie distincte du chargement en mémoire + de l'installation = téléchargement depuis Hub (1-10 GB selon variante small/medium/large/melody). Sub-family advanced music = modèles 3.3B+ = temps chargement Hub significatif = drainage explicite via préfixe canonique.

## Diagnostic §D.5

**Verdict** : `CAUSE_FIXED` — option alpha appliquée (préserver invariants structurels + drainer claims runtime machine-dep). Cause racine = prose pédagogique cite wall-clock concrets sans marquer leur dépendance à la machine d'exécution. Fix = préfixer par `runtime *machine-dep* :` sans modifier la valeur numérique. Pas de ré-alignement, pas de ré-exécution kernel (markdown-only).

## Validation per CLAUDE.md §B.5 + notebook-conventions C.1/C.2

| Check | Statut |
|-------|--------|
| Scope réel (Refs #9434 partiel) | ✅ claim = scope = diff |
| `git diff --stat` cohérent | ✅ 1 file, +7/-7 |
| Cellules code = `execution_count: <int>` + outputs cohérents | ✅ 13/13 préservés |
| 0 cellule `# Solution` / `# Exemple résolu` supprimée | ✅ (aucune touchée) |
| Stop & Repair règle 6 | ✅ cause = marqueur manquant, pas erreur à corriger |
| CR/LF/BOM preserved | ✅ vérifié post-write |
| C955-1 ★★★ surgical edit | ✅ metadata/texte uniquement |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
