### PR TITLE
fix(genai,#9434): drain 5 wall-clock claims from 02-9-AceStep-Music-Generation (MED, audio advanced)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-9-AceStep-Music-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-9-AceStep-Music-Generation.ipynb
@@ -146,7 +146,7 @@
     "- **Architecture hybride LM + DiT** : Le LM encode le texte et les paroles, le DiT genere les spectrogrammes\n",
     "- **Paroles structurees** : Support natif des tags `[verse]`, `[chorus]`, `[bridge]`, `[intro]`, `[outro]`\n",
     "- **Multilingue** : 50+ langues supportees (anglais, francais, espagnol, allemand, japonais, etc.)\n",
-    "- **Faible VRAM** : <4 GB avec cpu_offload, generation rapide (<10s pour 4 min sur RTX 3090)\n",
+    "- **Faible VRAM** : <4 GB avec cpu_offload, *runtime *machine-dep* : generation rapide (<10s pour 4 min sur RTX 3090)\n",
     "\n",
     "### Comparaison avec les alternatives\n",
     "\n",
@@ -320,7 +320,7 @@
     "\n",
     "| Composant | Statut | Rôle |\n",
     "|-----------|--------|------|\n",
-    "| **GPU detecte** | Variable (si disponible) | Acceleration de la generation |\n",
+    "| **GPU detecte** | Variable (si disponible) | *runtime *machine-dep* : acceleration de la generation |\n",
     "| **ACE-Step** | Importe ou instruction d'installation | Pipeline de generation musicale |\n",
     "| **Repertoire sortie** | `outputs/audio/acestep/` | Stockage des fichiers WAV generes |\n",
     "| **CPU offload** | Active par defaut | Permet de fonctionner avec <4 GB VRAM |\n",
@@ -504,7 +504,7 @@
     "| Aspect | Detail |\n",
     "|--------|--------|\n",
     "| **Premier chargement** | Telechargement depuis HuggingFace Hub (~7 GB pour le modèle base) |\n",
-    "| **Chargements suivants** | Cache local, chargement rapide |\n",
+    "| **Chargements suivants** | Cache local, *runtime *machine-dep* : chargement rapide |\n",
     "| **VRAM requise** | <4 GB avec cpu_offload, ~6 GB sans offload |\n",
     "| **CPU offload** | Deplace les couches non utilisees vers la RAM CPU |\n",
     "\n",
@@ -517,7 +517,7 @@
     "| MusicGen medium | 10 GB | 12 GB |\n",
     "| SongGen2 | 10 GB | 24 GB |\n",
     "\n",
-    "> **Note technique** : Le cpu_offload reduit la VRAM au prix d'une vitesse de generation legerement inferieure. Sur un GPU avec 8+ GB, desactiver cpu_offload accelere la generation de 30-50%."
+    "> **Note technique** : Le cpu_offload reduit la VRAM au prix d'une vitesse de generation legerement inferieure. Sur un GPU avec 8+ GB, desactiver cpu_offload *runtime *machine-dep* : accelere la generation de 30-50%."
    ]
   },
   {
@@ -5456,7 +5456,7 @@
     "**Points cles** :\n",
     "1. `guidance_scale` est le paramètre le plus impactant pour la fidelite au prompt\n",
     "2. `infer_step` affecte surtout la qualite audio (resolution des details)\n",
-    "3. Le temps de generation est proportionnel a `infer_step` (2x steps = ~2x temps)\n",
+    "3. *runtime *machine-dep* : le temps de generation est proportionnel a `infer_step` (2x steps = ~2x temps)\n",
     "4. La combinaison `cfg_type=\"apg\"` + `omega_scale=10` offre un bon compromis par defaut\n",
     "\n",
     "> **Note** : Le paramètre `guidance_interval=0.5` applique le guidance uniquement sur la première moitie du denoising. Cela ameliore la diversite tout en conservant la coherence."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #9690 (c.1316 02-8-Expressive-TTS audio advanced)

Refs #9434

# fix(genai,#9434): drain 5 wall-clock claims from 02-9-AceStep-Music-Generation (MED, audio advanced)

## Summary

Surgical markdown-only drainage on `MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-9-AceStep-Music-Generation.ipynb` — **5 insertions, 5 deletions, 1 file**. 5 préfixes `runtime *machine-dep*` injectés sur 4 cellules (cell[5] + cell[7] + cell[13] ×2 + cell[21]) — zero cellule code touchée, 13/13 code cells execution_count préservés.

Sub-family GenAI/Audio **advanced** musique ACE-Step v1.5 (Hybrid LM + DiT 3.5B params + cpu_offload <4 GB VRAM). **5ᵉ entrée advanced** post-c.1312 Demucs + c.1313 Song-Gen + c.1315 MusicGen + c.1316 Expressive-TTS. **Ferme quintette advanced music+tts** (Source Separation + Song Generation + Music Generation + Expressive-TTS + AceStep). 31ᵉ réutilisation archétype 6ᵉ #9434.

## Cells drained (4 cells, 5 préfixes)

| Cell | Row drained | Rationale §D.5 |
|------|-------------|----------------|
| **cell[5]** (Innovations clés) | `Faible VRAM : <4 GB avec cpu_offload, generation rapide (<10s pour 4 min sur RTX 3090)` → préfixe | axe a runtime claim — **VRAM `<4 GB` axe c structurel préservé** |
| **cell[7]** (Tableau env) | `\| GPU detecte \| Variable (si disponible) \| Acceleration de la generation \|` → préfixe | axe a runtime claim |
| **cell[13]** (Chargement modèle) | `\| Chargements suivants \| Cache local, chargement rapide \|` → préfixe | axe a chargement runtime claim |
| **cell[13]** (Note technique) | `desactiver cpu_offload accelere la generation de 30-50%` → préfixe | axe a runtime claim — **ratio `30-50%` COMPUTED préservé verbatim** HORS scope |
| **cell[21]** (Points clés) | `Le temps de generation est proportionnel a infer_step (2x steps = ~2x temps)` → préfixe | axe a runtime claim — **ratio `2x steps = ~2x temps` COMPUTED préservé verbatim** HORS scope |

**Total** : 5 préfixes `runtime *machine-dep*` insérés.

## Litmus §D.5 — 4 catégories timings (canonique)

1. **Wall-clock LOCAL inference latency** (axe a) — **DRAINABLE**
   - cell[5] `generation rapide (<10s pour 4 min sur RTX 3090)` runtime claim
   - cell[7] `Acceleration de la generation` runtime claim
   - cell[13] `chargement rapide` chargement claim
   - cell[13] `30-50% accelere` runtime claim
   - cell[21] `temps de generation proportionnel` runtime claim
2. **Audio duration** (axe c moteur upstream déterministe) — **NOT drainable**
   - cell[5] `<10s pour 4 min` ratio COMPUTED mais durée source 4 min axe c
   - cell[5] `~4 min` audio config
   - cell[7] `4 min` audio generation
   - cell[16] `Jusqu'a 4 minutes` architecture limit (axe c)
   - cell[16] `~30s` MusicGen comparison (axe c)
3. **Ratio structurel COMPUTED** (axe c computed) — **HORS scope** (c.1313-L3 ★ analogue)
   - cell[13] `30-50%` acceleration ratio CPU offload vs full GPU = COMPUTED préservé
   - cell[21] `2x steps = ~2x temps` infer_step ratio = COMPUTED préservé
4. **Chargement modèle** (axe a init time distinct de l'inférence) — **DRAINABLE**
   - cell[13] `Telechargement depuis HuggingFace Hub (~7 GB pour le modèle base)` —
     c.1315-L4 ★ analogue (5ᵉ entrée ext c.1309-L2 + c.1310-L2 + c.1313-L4 + c.1315-L4)

## Invariants préservés verbatim (10+)

- `<4 GB VRAM` cell[5]/cell[7]/cell[13] (axe c hardware spec — cpu_offload feature)
- `3.5B params` cell[5] (axe c architecture)
- `50+ langues` cell[5] multilingue (axe c feature)
- `44.1 kHz stereo` cell[5]+cell[16] sample rate (axe c)
- `~7 GB` cell[13] model size (axe c)
- `6 GB sans offload` cell[13] VRAM spec (axe c)
- `10 GB / 12 GB / 24 GB` cell[13] autres modèles VRAM (axe c)
- `~10 GB pour medium` cell[7] MusicGen comparison (axe c)
- `30s` cell[16] MusicGen durée (axe c)
- `44.1 kHz stereo vs 32 kHz mono` cell[16] sample rate comparison (axe c)
- `guidance_scale 5/15/25` cell[21] params (axe c)
- `infer_step 30/60/90` cell[21] params (axe c)
- `30-50% acceleration` cell[13] ratio COMPUTED HORS scope
- `2x steps = ~2x temps` cell[21] ratio COMPUTED HORS scope

## Acceptance

- [x] Validateur `validate_pr_notebooks.py` PASS (notebook tagged `runtime *machine-dep*` ≠ cellule code avec `severity:error`)
- [x] Aucune cellule code touchée (13/13 execution_count préservés, 13/13 outputs préservés)
- [x] Pas de ré-exécution kernel (markdown-only, scope strict)
- [x] Diff = **5 insertions, 5 deletions, 1 file** — purely surgical

## Tells archétypaux c.1317 spécifiques

- **c.1317-L1 ★** : **ACE-Step cpu_offload vs full GPU dichotomy** (extension c.1312-L1 ★ CHARGEMENT+INFERENCE+SEPARATION + c.1313-L4 ★ INSTALLATION). ACE-Step permet `cpu_offload` qui réduit VRAM à `<4 GB` au prix d'une vitesse légèrement inférieure. Pattern distinct de MusicGen c.1315 (mono-source 4 GB+ VRAM fixe) et Expressive-TTS c.1316 (3-modèle 14-18 GB VRAM).
- **c.1317-L2 ★** : **Hybrid LM + DiT architecture** (LM Encoder 3.5B + DiT diffusion denoising + VAE Decoder 44.1 kHz stereo) = innovation SOTA 2024-2025 vs autoregressif MusicGen (c.1315). Tell distinctif sub-family musique hybride LM+diffusion vs musique autoregressive pure.
- **c.1317-L3 ★** : **2 ratios COMPUTED HORS scope** (extension c.1308-L3/L7 + c.1310-L4 + c.1313-L3 + c.1315-L3) : cell[13] `30-50%` (cpu_offload vs full GPU) + cell[21] `2x steps = ~2x temps` (infer_step). Patterns de ratios COMPUTED = stabilité relative d'une configuration à l'autre, distincte du runtime claim adjacent drainé.
- **c.1317-L4 ★** : **5ᵉ entrée catégorie HuggingFace Hub** (extension c.1309-L2 + c.1310-L2 + c.1313-L4 + c.1315-L4) : cell[13] `Telechargement depuis HuggingFace Hub (~7 GB pour le modèle base)`. Catégorie téléchargement depuis Hub distincte du chargement en mémoire + installation + sdk cloud API (c.1316-L4 ★).

## Diagnostic §D.5

**Verdict** : `CAUSE_FIXED` — option alpha appliquée (préserver invariants structurels + drainer claims runtime machine-dep). Cause racine = prose pédagogique cite wall-clock concrets sans marquer leur dépendance à la machine d'exécution. Fix = préfixer par `runtime *machine-dep* :` sans modifier la valeur numérique. Pas de ré-alignement, pas de ré-exécution kernel (markdown-only).

## Validation per CLAUDE.md §B.5 + notebook-conventions C.1/C.2

| Check | Statut |
|-------|--------|
| Scope réel (Refs #9434 partiel) | ✅ claim = scope = diff |
| `git diff --stat` cohérent | ✅ 1 file, +5/-5 |
| Cellules code = `execution_count: <int>` + outputs cohérents | ✅ 13/13 préservés |
| 0 cellule `# Solution` / `# Exemple résolu` supprimée | ✅ (aucune touchée) |
| Stop & Repair règle 6 | ✅ cause = marqueur manquant, pas erreur à corriger |
| CR/LF/BOM preserved | ✅ vérifié post-write |
| C955-1 ★★★ surgical edit | ✅ metadata/texte uniquement |

🤖 Generated with [Claude Code](https://claude.com/claude-code)