### PR TITLE
fix(genai,#9434): drain 5 wall-clock claims from 02-2-XTTS-Voice-Cloning (MED, audio advanced voice cloning)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-2-XTTS-Voice-Cloning.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-2-XTTS-Voice-Cloning.ipynb
@@ -199,10 +199,10 @@
     "\n",
     "**Points cles** :\n",
     "1. Le GPU RTX 3090 offre 24 GB de VRAM, largement suffisant pour XTTS v2 (~6 GB necessaires)\n",
-    "2. Le fallback vers CPU est automatique si aucun GPU n'est disponible (mais beaucoup plus lent)\n",
+    "2. Le fallback vers CPU est automatique si aucun GPU n'est disponible (*runtime *machine-dep* : beaucoup plus lent)\n",
     "3. Les helpers audio facilitent la lecture et la sauvegarde des fichiers generes\n",
     "\n",
-    "> **Note technique** : Sur CPU, le temps de generation peut etre 10-20x plus lent que sur GPU. Pour un usage en production, un GPU est fortement recommande."
+    "> **Note technique** : Sur CPU, *runtime *machine-dep* : le temps de generation peut etre 10-20x plus lent que sur GPU. Pour un usage en production, un GPU est fortement recommande."
    ]
   },
   {
@@ -461,9 +461,9 @@
     "\n",
     "| Étape | Description | Temps typique |\n",
     "|-------|-------------|---------------|\n",
-    "| Premier lancement | Telechargement du modèle depuis HuggingFace | 5-10 min (selon connexion) |\n",
-    "| Chargements suivants | Chargement depuis le cache local | 10-30s |\n",
-    "| Allocation GPU | Transfert du modèle en VRAM | 2-5s |\n",
+    "| Premier lancement | Telechargement du modèle depuis HuggingFace | *runtime *machine-dep* : 5-10 min (selon connexion) |\n",
+    "| Chargements suivants | Chargement depuis le cache local | *runtime *machine-dep* : 10-30s |\n",
+    "| Allocation GPU | Transfert du modèle en VRAM | *runtime *machine-dep* : 2-5s |\n",
     "| VRAM utilisee | Modèle charge en memoire | ~6 GB |\n",
     "\n",
     "**Points cles** :\n",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #9692 (c.1318 02-6-MIDI-Generation audio advanced symbolic)

Refs #9434

# fix(genai,#9434): drain 5 wall-clock claims from 02-2-XTTS-Voice-Cloning (MED, audio advanced voice cloning)

## Summary

Surgical markdown-only drainage on `MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-2-XTTS-Voice-Cloning.ipynb` — **5 insertions, 5 deletions, 1 file**. 5 préfixes `runtime *machine-dep*` injectés sur 2 cellules (cell[5]×2 + cell[12]×3) — zero cellule code touchée, 14/14 code cells execution_count préservés.

Sub-family GenAI/Audio **advanced** **voice cloning zero-shot** (Coqui XTTS v2, sequence-to-sequence VITS-like architecture, ~1.8 GB model, 17 langues cross-lingual). **7ᵉ entrée advanced** post-c.1312 Demucs + c.1313 Song-Gen + c.1315 MusicGen + c.1316 Expressive-TTS + c.1317 AceStep + c.1318 MIDI Symbolic. 33ᵉ réutilisation archétype 6ᵉ #9434.

## Cells drained (2 cells, 5 préfixes)

| Cell | Row drained | Rationale §D.5 |
|------|-------------|----------------|
| **cell[5]** (Config env) | `Le fallback vers CPU est automatique si aucun GPU n'est disponible (mais beaucoup plus lent)` → préfixe | axe a runtime claim — **VRAM `24 GB` + `~6 GB` axe c préservés** |
| **cell[5]** (Note technique) | `> Note technique : Sur CPU, le temps de generation peut etre 10-20x plus lent que sur GPU` → préfixe | axe a runtime claim — **ratio `10-20x` COMPUTED HORS scope préservé verbatim** |
| **cell[12]** (Tableau chargement) | `\| Premier lancement \| 5-10 min (selon connexion) \|` → préfixe | axe a runtime claim — **`~1.8 GB` model size axe c préservé** |
| **cell[12]** (Tableau chargement) | `\| Chargements suivants \| 10-30s \|` → préfixe | axe a runtime claim (cache load) |
| **cell[12]** (Tableau chargement) | `\| Allocation GPU \| 2-5s \|` → préfixe | axe a runtime claim (GPU transfer) — **`~6 GB` VRAM axe c préservé** |

**Total** : 5 préfixes `runtime *machine-dep*` insérés.

## Litmus §D.5 — 4 catégories timings (canonique)

1. **Wall-clock LOCAL inference latency** (axe a) — **DRAINABLE**
   - cell[5] `beaucoup plus lent` runtime claim drainé
   - cell[5] `temps de generation CPU 10-20x plus lent` runtime claim drainé
   - cell[12] `5-10 min (selon connexion)` runtime claim drainé (axe a connectivité+hardware)
   - cell[12] `10-30s` cache load drainé
   - cell[12] `2-5s` allocation GPU drainé
2. **Audio duration** (axe c moteur upstream déterministe) — **NOT drainable**
   - cell[0] `Duree estimee : 45 minutes` pedagogique
   - cell[15] audio généré cross-lingual (axe c structurel)
3. **Ratio structurel COMPUTED** (axe c computed) — **HORS scope** (c.1313-L3 ★ analogue)
   - cell[5] `10-20x CPU vs GPU` ratio runtime/concept = COMPUTED préservé verbatim
   - cell[15] `Ratio temps reel 2-5x (GPU)` RTF ratio = COMPUTED préservé verbatim
   - cell[30] `Ratio temps reel (GPU) 2-5x` synthèse = COMPUTED préservé verbatim
4. **Chargement modèle** (axe a init time distinct de l'inférence) — DRAINABLE
   - cell[12] `Telechargement depuis HuggingFace` + cache load + allocation GPU =
     **c.1309-L2 ★ extension CHARGEMENT (3ᵉ subdivision download + load + allocate)**
     distincte du c.1315-L4 ★ Hub 3ᵉ catégorie (4ᵉ entrée ext c.1309/c.1310/c.1313/c.1315)

## Invariants préservés verbatim (10+)

- `~6 GB VRAM` cell[3]+cell[5] (axe c hardware spec — pré-requis XTTS)
- `RTX 3090 24 GB VRAM` cell[5] (axe c hardware spec)
- `~1.8 GB` cell[12] model size (axe c distribution)
- `~6 GB` cell[12] VRAM utilisée (axe c architecture)
- `17 langues` cell[10] cross-lingual (axe c feature)
- `Ratio temps reel 2-5x (GPU)` cell[15] ratio COMPUTED HORS scope préservé verbatim
- `Ratio temps reel (GPU) 2-5x` cell[30] ratio COMPUTED HORS scope préservé verbatim
- `10-20x CPU vs GPU` cell[5] ratio COMPUTED HORS scope préservé verbatim
- `Duree estimee : 45 minutes` cell[0] pedagogique axe c
- `0.75-0.90 cosine` cell[25] similarité axe c feature

## Acceptance

- [x] Validateur `validate_pr_notebooks.py` PASS (notebook tagged `runtime *machine-dep*` ≠ cellule code avec `severity:error`)
- [x] Aucune cellule code touchée (14/14 execution_count préservés, 14/14 outputs préservés)
- [x] Pas de ré-exécution kernel (markdown-only, scope strict)
- [x] Diff = **5 insertions, 5 deletions, 1 file** — purely surgical

## Tells archétypaux c.1319 spécifiques

- **c.1319-L1 ★** : **VOICE CLONING ZERO-SHOT sub-family nouveau** — 7ᵉ entrée advanced ouvre un **sub-family nouveau** = clonage vocal zero-shot à partir d'un clip reference (vs Kokoro c.1308 single-voice / Chatterbox c.1309 single-voice). Paradigme distinct : `XttsConfig` + speaker embedding extrait du reference clip + cross-lingual timbre preserved. Tell distinctif = clip audio de référence 6-30s WAV en entrée + génération cross-lingue 17 langues.
- **c.1319-L2 ★** : **3ᵉ subdivision CHARGEMENT** (extension c.1309-L2 ★ audio + c.1310-L2 ★ STT + c.1312-L1 ★ audio advanced). cell[12] = 3 phases distinctes : (a) `Telechargement` 5-10 min connexion Hub = 1ère fois, (b) `Chargement cache local` 10-30s = runs suivants, (c) `Allocation GPU` 2-5s = `.to(device)` transfer VRAM. Cumul chargement = `5-10 min` cold + `10-30s+2-5s` = `12-37s` warm. Tell distinctif vs c.1318 midi-model `~200 MB` distribution PyPI/git clone (6ᵉ catégorie distincte) : c.1319 = HuggingFace Hub standard (4ᵉ entrée ext c.1309/c.1310/c.1313/c.1315).
- **c.1319-L3 ★** : **Ratio temps réel 2-5x GPU** (cell[15] + cell[30]) — **structurel COMPUTED HORS scope** (axe c concept, identique à c.1309 ratio MusicGen `10-50x`). RTF (Real-Time Factor) = audio_duration / generation_time. Ratio reste stable cross-configurations car linéaire en fonction de la longueur audio générée. Préservation verbatim du ratio est essentielle.
- **c.1319-L4 ★** : **Fallback CPU 10-20x** (cell[5]) — runtime claim drainable. Ratio runtime claim drainable MAIS ratio concept COMPUTED HORS scope. Tell distinctif vs c.1308 Kokoro `5-20x` GPU range et c.1309 Chatterbox `10-50x` CPU fallback. Pattern cross-modèle : LOCAL inference CPU = 10-50x plus lent que GPU (constant cross-modèles SOTA 2024-2025).

## Diagnostic §D.5

**Verdict** : `CAUSE_FIXED` — option alpha appliquée (préserver invariants structurels + drainer claims runtime machine-dep). Cause racine = prose pédagogique cite wall-clock concrets sans marquer leur dépendance à la machine d'exécution. Fix = préfixer par `runtime *machine-dep* :` sans modifier la valeur numérique. Pas de ré-alignement, pas de ré-exécution kernel (markdown-only).

## Validation per CLAUDE.md §B.5 + notebook-conventions C.1/C.2

| Check | Statut |
|-------|--------|
| Scope réel (Refs #9434 partiel) | ✅ claim = scope = diff |
| `git diff --stat` cohérent | ✅ 1 file, +5/-5 |
| Cellules code = `execution_count: <int>` + outputs cohérents | ✅ 14/14 préservés |
| 0 cellule `# Solution` / `# Exemple résolu` supprimée | ✅ (aucune touchée) |
| Stop & Repair règle 6 | ✅ cause = marqueur manquant, pas erreur à corriger |
| CR/LF/BOM preserved | ✅ vérifié post-write |
| C955-1 ★★★ surgical edit | ✅ metadata/texte uniquement |

🤖 Generated with [Claude Code](https://claude.com/claude-code)