### PR TITLE
fix(search,#9434): App-18 HyperparameterTuning machine-dep timing drain

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb
@@ -1219,7 +1219,7 @@
     "- **GA** explore a travers tout l'espace\n",
     "- **PSO** montre une exploration similaire a Random Search\n",
     "- **Meilleurs points** : toutes les méthodes tendent a trouver des solutions dans des regions similaires\n",
-    "- **Convergence** : a plat sur le tableau comparatif (idx précédent), **Bayesian (custom)** atteint le meilleur score (0.9626) dans le temps le plus court (43.9 s, 50 evaluations), tandis que **PSO** est la plus lente (247.9 s pour 100 evaluations) et reste sur un score legerement inferieur (0.9604). La \"convergence rapide\" est donc ici l'atout de l'optimisation bayesienne, pas de PSO\n",
+    "- **Convergence** : a plat sur le tableau comparatif (idx précédent), **Bayesian (custom)** atteint le meilleur score (0.9626) dans le temps le plus court (s live -- regle #9434, 50 evaluations), tandis que **PSO** est la plus lente (s live -- regle #9434 pour 100 evaluations) et reste sur un score legerement inferieur (0.9604). La \"convergence rapide\" est donc ici l'atout de l'optimisation bayesienne, pas de PSO\n",
     "- **Recommandation** : utiliser la visualisation pour identifier quelle méthode convient a votre problème spécifique\n",
     "\n",
     "**Poursuite** : testez d'autres combinaisons de paramètres (n_estimators, max_depth) pour voir comment la performance varie a travers l'espace."

--- a/scripts/notebook_tools/twin_pairs.d/app-18-hyperparametertuning.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-18-hyperparametertuning.yaml
@@ -8,6 +8,12 @@
       by: myia-po-2023:CoursIA
       python_sha: f0a4de716cc4796c74319bdee52f7cbec093fa37
       csharp_sha: b1153dbca5286ac4f8d140d63a067b3dcc1f211e
+    - date: "2026-08-06"
+      by: myia-po-2023:CoursIA
+      python_sha: 49aeadb7ca4e19417b562e50a495a7ea55f7413f
+      csharp_sha: b1153dbca5286ac4f8d140d63a067b3dcc1f211e
+      content_python_sha: 4f011a2bf5a16d2106e22829186d206782cee507c9aef6e0879026abb61de5d1
+      content_csharp_sha: 8ea2f1d19f52fe1e6313e8f8ef858ed072d086e6cb05e45a2ac6570590da7710
   known_differences:
     - "Socle pedagogique commun : Hyperparameter tuning (scipy.optimize + Gaussian Process / Bayes opt) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = scipy.optimize + scipy.stats norm + sklearn ; C# = BCL pure (System.*), 0 NuGet."


### PR DESCRIPTION
Grain: MED/drainage -- lane myia-po-2023:CoursIA -- prev: MED/drainage #9658

## Scope

Drainage #9434 (timing-drainage) sur **App-18 HyperparameterTuning** (Search/Applications/Hybrid).

La cellule markdown d'interpretation (cell 30, point **Convergence**) durcissait 2 durees machine-dependantes arrondies a la main -- dups des outputs de code live :

| Methode | Output code (live) | Prose figee (avant) |
|---------|-------------------|---------------------|
| Bayesian (custom) | `Temps: 43.89s` | `(43.9 s, 50 evaluations)` |
| PSO | `Temps: 247.87s` | `(247.9 s pour 100 evaluations)` |

Ces durees **derivent avec le hardware/env** : un re-run sur une autre machine donne des s differents, et la prose figeait une mesure specifique. Pattern #9434 : le quantitatif tenu par le CI (code live), pas la prose.

## Changement

Markdown-only (cell 30), 2 sous-chaines remplacees :
- `(43.9 s, 50 evaluations)` -> `(s live -- regle #9434, 50 evaluations)`
- `(247.9 s pour 100 evaluations)` -> `(s live -- regle #9434 pour 100 evaluations)`

## Preserve (TN explicites, pas machine-dep)

- Scores accuracy `0.9626` / `0.9604` = **deterministes** (cross_val_score sur dataset fixe seed 42), ne derivent pas
- Comptes d'evaluations `50` / `100` = **structurels** (n_iter * n_particles)
- Tous les outputs de code (`Temps: 43.89s` etc.) **intacts**
- Ordres de grandeur pedagogiques (`~50 min`, `45 minutes` = durees etudiant) non touches

## Verification (G.1 + regle 6)

- **Code-source invariant** : sha code+outputs identique a origin/main (regle 6 Stop & Repair, aucun hand-edit d'output)
- **Scanner canonique** `--all --class machine` : App-18 ne ressort plus (0 finding machine post-drain)
- **Byte-level raw replace** (pas de JSON round-trip) -> diff minimal : 1 ligne, +1/-1
- **Twin parity** (App-18 HyperparameterTuning, `parity_level: semantic`) : `drift_introduced=0` -- le twin C# (App-18b) tient sur le code, pas le blob ; pas de rebaseline requise

## C.2 exception

Edit markdown-only : aucune cellule code modifiee, outputs precedents valides (regle C.2 exception). Le notebook reste executable end-to-end avec ses outputs reels preserves.

See #9434 (drainage en cours -- contribution partielle, d'autres notebooks Search/CSP restent a drainer dans des PRs separees, atomique 1-sujet/PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)