### PR TITLE
docs(probas,#4959): fix PyMC summary table stale numbering (file-order parity)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -159,7 +159,7 @@ Si vous préférez Python au C#, commencez par **PyMC-1-Setup** (introduction st
 
 #### Parcours PyMC complet (26 notebooks, ~17h)
 
-Les notebooks PyMC portent les modèles Infer.NET en Python avec PyMC et l'échantillonnage NUTS : le corpus bayésien dans `PyMC/` (fondations 1-3, modèles classiques 4-13, inférence causale 14, processus gaussien épars 15, frontières 16-19 : hiérarchiques, filtre de Kalman, change-point, analyse de survie) et le cœur de l'arc décision dans `DecisionTheory/PyMC/` (7 notebooks renumérotés 1-7). Ils constituent un excellent complément pour comparer les approches d'inférence (message passing vs MCMC) et rejoindre l'écosystème Python data science. La progression suit la même structure pédagogique en 3 phases que la série Infer.NET.
+Les notebooks PyMC portent les modèles Infer.NET en Python avec PyMC et l'échantillonnage NUTS : le corpus bayésien dans `PyMC/`, **numéroté 1:1 avec son jumeau C# Infer** (fondations 1-3 ; modèles classiques 4-13 dont l'inférence causale en 5 et les modèles hiérarchiques en 12 ; séquences 14 et recommandation 15 ; frontières 16-19 : processus gaussien épars, filtre de Kalman, change-point, analyse de survie), et le cœur de l'arc décision dans `DecisionTheory/PyMC/` (7 notebooks renumérotés 1-7). Ils constituent un excellent complément pour comparer les approches d'inférence (message passing vs MCMC) et rejoindre l'écosystème Python data science. La progression suit la même structure pédagogique en 3 phases que la série Infer.NET.
 
 ## Quel stack choisir ?
 
@@ -272,18 +272,18 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 | 2 | Gaussian Mixtures | Mélanges gaussiens MCMC, trace plots, convergence diagnostics |
 | 3 | Factor Graphs | Inférence discrète avec PyMC, comparaison Infer.NET vs PyMC |
 | 4 | Bayesian Networks | Réseaux bayésiens MCMC, CPT, explaining away |
-| 5 | Skills (IRT) | IRT en Python, estimation de compétences par MCMC |
-| 6 | TrueSkill | TrueSkill avec NUTS, online learning bayésien |
-| 7 | Classification | Classification bayésienne, régression logistique |
-| 8 | Model Sélection | Model comparison MCMC, LOO, WAIC, Bayes Factors empiriques |
-| 9 | Topic Models | LDA avec NUTS, gestion variables latentes, inférence approximation |
-| 10 | Crowdsourcing | Agrégation de labels crowdsourcing, worker communities |
-| 11 | Séquences | HMM MCMC, forward-backward avec échantillonnage |
-| 12 | Recommenders | Factorisation matricielle bayésienne MCMC |
-| 13 | Debugging | Trace plots, R-hat, effective sample size, bonnes pratiques MCMC |
-| 14 | Causal Inference | `pm.do`, do-calculus de Pearl, contrefactuel bayésien |
-| 15 | Sparse Gaussian Process | NUTS sur géométrie latente (cf. asymétrie structurelle Infer-16 EP) |
-| 16 | Modèles Hiérarchiques | Shrinkage bayésien, divergences NUTS sur le funnel (cf. asymétrie structurelle Infer-12 EP) |
+| 5 | Causal Inference | `pm.do`, do-calculus de Pearl, contrefactuel bayésien |
+| 6 | Debugging | Trace plots, R-hat, effective sample size, bonnes pratiques MCMC |
+| 7 | Skills (IRT) | IRT en Python, estimation de compétences par MCMC |
+| 8 | TrueSkill | TrueSkill avec NUTS, online learning bayésien |
+| 9 | Classification | Classification bayésienne, régression logistique |
+| 10 | Model Sélection | Model comparison MCMC, LOO, WAIC, Bayes Factors empiriques |
+| 11 | Topic Models | LDA avec NUTS, gestion variables latentes, inférence approximation |
+| 12 | Modèles Hiérarchiques | Shrinkage bayésien, divergences NUTS sur le funnel (cf. asymétrie structurelle Infer-12 EP) |
+| 13 | Crowdsourcing | Agrégation de labels crowdsourcing, worker communities |
+| 14 | Séquences | HMM MCMC, forward-backward avec échantillonnage |
+| 15 | Recommenders | Factorisation matricielle bayésienne MCMC |
+| 16 | Sparse Gaussian Process | NUTS sur géométrie latente (cf. asymétrie structurelle Infer-16 EP) |
 | 17 | Kalman Filter | Value-add MCMC (estimation jointe Q/R/drift) |
 | 18 | Change-Point | Switch bayésien, catastrophes minières (Poisson) |
 | 19 | Survival Analysis | Weibull inféré directement, sélection LOO arviZ |


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2024:CoursIA — prev: MED/test #9665 (c.770)

## Summary

Fix a §E list-table drift in the Probas hub README (`MyIA.AI.Notebooks/Probas/README.md`). The summary **"Série PyMC"** table (parallel to the "Série Infer.NET" table, identical header `| # | Notebook | Apport pédagogique |`) listed the **old pedagogical numbering** that no longer matches disk, the Infer summary table, or the hub's own 1:1 parity claim.

## The drift (3 concordant sources confirm file-number parity is the convention)

The PyMC sub-series was renumbered to a **1:1 file parity with Infer** (PyMC-5 ↔ Infer-5 = causal inference, PyMC-14 ↔ Infer-14 = sequences). Three sources agree:
- **Disk**: `PyMC-5-Causal-Inference.ipynb`, `PyMC-6-Debugging.ipynb`, `PyMC-7-Skills-IRT.ipynb`, …
- **Sub-series authority** (`PyMC/README.md` line 143): *"PyMC est numérotée 1:1 avec son jumeau C# Infer (PyMC-5 ↔ Infer-5 = inférence causale, PyMC-14 ↔ Infer-14 = séquences)"*
- **Hub prose** (line 16): *"en parité 1:1 avec Infer"*

But the hub's PyMC summary table still carried the old order: `#5=Skills, #6=TrueSkill, #13=Debugging, #14=Causal` — making the two parallel summary tables (`### Série Infer.NET` vs `### Série PyMC`) **mean different things by `#`**, which defeats their side-by-side comparability.

## Fix

Reordered the 12 affected rows so `#` = file number in **both** summary tables:

| # | Was (stale) | Now (file parity) |
|---|-------------|-------------------|
| 5 | Skills (IRT) | **Causal Inference** |
| 6 | TrueSkill | **Debugging** |
| 7 | Classification | **Skills (IRT)** |
| 12 | Recommenders | **Modèles Hiérarchiques** |
| 13 | Debugging | **Crowdsourcing** |
| 14 | Causal Inference | **Séquences** |
| 15 | Sparse GP | **Recommenders** |
| 16 | Modèles Hiérarchiques | **Sparse GP** |

Plus the same stale numbering in the "Parcours PyMC complet" prose (line 162) — rewritten to state the 1:1 parity explicitly with the key reordering points (causal=5, hiérarchiques=12, séquences=14, reco=15).

## Whole-file §E audit (pr-review-discipline §E)

Not a line-fix: the whole file was re-audited against disk + the two PyMC sub-series READMEs:
- 58-notebook total: **correct** (28 C# + 28 Python + 2 Lean 4, matches disk)
- "Série Infer.NET" summary table: **correct** (file numbering throughout)
- "Parcours inférence comparée" table: **correct** (file numbering)
- Detailed phase-by-phase PyMC breakdown (Phase 1/2/4): **correct** (uses file links)
- The drift was confined to the single summary table + one prose paragraph

## Validation

```
verify_catalog_readme.py --series Probas
  Probas  58  58  OK
  OK: 1 | DRIFT: 0 | NO_MARKER: 0
```
CATALOG-STATUS marker **byte-identical** (not regenerated on the branch — rule HARD 1 of catalogue hygiene). Diff = +13/−13 (pure reorder + one prose rewrite), single file, no code/catalogue touched.

See #4959
