### PR TITLE
fix(csp-csharp,#9434): drain Choco-solver JVM timing dups (CSP-1 Fundamentals)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
@@ -1335,7 +1335,7 @@
    "id": "d2d3ac0d",
    "metadata": {},
    "source": [
-    "**Interpretation** : Choco-solver resout la coloration de l'Australie en 63,82 ms au premier appel, puis seulement 2,94 ms une fois la JVM chaude (cf. enumeration cellule suivante). Le premier appel paie le demarrage de la JVM Java (IKVM) sous-jacente ; en regime etabli, le coeur metier (propagation + backtracking) est bien inferieur a 10 ms.\n",
+    "**Interpretation** : Choco-solver resout la coloration de l'Australie en (ms live -- regle #9434) au premier appel, puis seulement (ms live -- regle #9434) une fois la JVM chaude (cf. enumeration cellule suivante). Le premier appel paie le demarrage de la JVM Java (IKVM) sous-jacente ; en regime etabli, le coeur metier (propagation + backtracking) est bien inferieur a 10 ms.\n",
     "\n",
     "| Aspect | Implementation manuelle C# | Choco-solver 4.10.17 |\n",
     "|--------|---------------------------|----------------------|\n",

--- a/scripts/notebook_tools/twin_pairs.d/csp-1-fundamentals.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-1-fundamentals.yaml
@@ -8,6 +8,12 @@
       by: myia-po-2023:CoursIA-2
       python_sha: 7013d56a565f9243bbf1b7d7e49529c4048bba24
       csharp_sha: aa7c1005e14400fc680e55691f69da5828d3a46e
+    - date: "2026-08-06"
+      by: myia-po-2023:CoursIA
+      python_sha: 7013d56a565f9243bbf1b7d7e49529c4048bba24
+      csharp_sha: affc4fa92d76e6cb9dbe157d41f967a20c43ad94
+      content_python_sha: 0148af8590584a1234e23b1d9599151ffa6e7bf36c3d71fdfc5c6604cd07644a
+      content_csharp_sha: fa531f46e6aa9dc764062c9927a5417a8f9560182c7c66597c031e1de036e017
   known_differences:
     - "Socle pedagogique commun (parity semantic) : les deux cotes implementent une classe CSP generique + backtracking simple + heuristique MRV + value-ordering LCV, depuis zero (pas de lib externe pour le coeur). Cote Python : classe CSP dict/list pure Python. Cote C# : classe CSP generique C# (Dictionary/List) qui reflete la Python."
     - "Extension solveur ASYMETRIQUE : le cote C# ajoute Choco-solver 4.10.17 (Java solver via IKVM 8.15.0, recette #4711) avec des cellules (coloration Australie par Choco, enumeration de TOUTES les solutions, 8-Reines par Choco) qui n'ont PAS d'equivalent direct cote Python. Le cote Python reste pur from-scratch sur tout le notebook."


### PR DESCRIPTION
Grain: MED/drainage -- lane myia-po-2023:CoursIA -- prev: MED/drainage #9695

## Scope

Drainage #9434 (timing-drainage) sur **CSP-1-Fundamentals-Csharp** (Search/Part2-CSP, famille .NET).

La cellule markdown d'interpretation (cell 27) durcissait 2 durees machine-dependantes -- dups **exactes** des outputs de code live :

| Prose figee (avant) | Output code (live) | Source |
|---------------------|-------------------|--------|
| `63,82 ms au premier appel` | `Temps : 63,82 ms` | cell26 (JVM froide) |
| `2,94 ms une fois la JVM chaude` | `enumeration : 2,94 ms` | cell28 (JVM chaude) |

Ces durees **derivent avec le hardware/OS/JVM (IKVM)** : un re-run sur une autre machine donne des ms differents. Pattern #9434 : le quantitatif tenu par le CI (code live), pas la prose.

## Changement

Markdown-only (cell 27), 2 sous-chaines remplacees :
- `en 63,82 ms au premier appel` -> `en (ms live -- regle #9434) au premier appel`
- `puis seulement 2,94 ms une fois la JVM chaude` -> `puis seulement (ms live -- regle #9434) une fois la JVM chaude`

## Preserve (TN explicites, pas machine-dep)

- `inferieur a 10 ms` (coeur metier) = **borne**, pas mesure figee
- `~1-5 ms (Python overhead)`, `< 10 ms` (md 29) = **ranges**
- `moins de 50 ms` (md 32, 8-Reines) = **borne**
- `~5 min`, `~8 min`, `~10 min` = **durees pedagogiques** (temps etudiant)

Le scanner advisory restant (`10 ms`, `5 ms`, `50 ms`) = FP sur ces bornes -- le scanner ne distingue pas semantiquement "10 ms" borne vs mesure ; arbitrage humain G.1 les garde (cf drainage-vein-boundary : ranges/order-of-magnitude = TN).

## Verification

- **Code-source invariant** : sha code+outputs identique a origin/main (regle 6 Stop & Repair)
- **Byte-level raw replace** (pas de JSON round-trip) -> diff minimal : 1 ligne, +1/-1
- **Twin parity** (CSP-1 Fundamentals, `parity_level: semantic`) : `drift_introduced=0`, verdict OK -- le twin Python tient sur le code, pas le blob ; pas de rebaseline requise

## C.2 exception

Edit markdown-only : aucune cellule code modifiee, outputs precedents valides (regle C.2 exception).

See #9434 (drainage en cours -- contribution partielle, 1 notebook par PR atomique).

🤖 Generated with [Claude Code](https://claude.com/claude-code)