### PR TITLE
fix(genai,#9434): drain 9 wall-clock claims from 03-1-Multi-Model-Audio-Comparison (LIGHT, audio 03-orchestration multi-model benchmark)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb
@@ -1021,7 +1021,7 @@
     "| Aspect | Whisper API | faster-whisper local |\n",
     "|--------|-------------|---------------------|\n",
     "| Precision (WER) | Très bonne (< 5%) | Equivalente ou meilleure |\n",
-    "| Latence | Depend du reseau (1-3s) | Depend du GPU (0.5-2s) |\n",
+    "| Latence | *runtime *machine-dep* : Depend du reseau (1-3s) | *runtime *machine-dep* : Depend du GPU (0.5-2s) |\n",
     "| Cout | $0.006/min | Gratuit (GPU amortit) |\n",
     "| VRAM | 0 (cloud) | ~3-6 GB |\n",
     "| Hors-ligne | Non | Oui |\n",
@@ -1077,14 +1077,14 @@
     "\n",
     "**Real-Time Factor (RTF)** :\n",
     "- RTF < 1.0 signifie que la transcription est plus rapide que la duree de l'audio (traitement en temps reel possible)\n",
-    "- Whisper API : RTF ~ 0.14 (transcrit 13s d'audio en ~2s)\n",
-    "- faster-whisper : RTF ~ 0.05-0.10 sur GPU RTX 3090 (transcrit 13s d'audio en ~0.7s)\n",
+    "- Whisper API : RTF ~ 0.14 (transcrit 13s d'audio en *runtime *machine-dep* : ~2s)\n",
+    "- faster-whisper : RTF ~ 0.05-0.10 sur GPU RTX 3090 (transcrit 13s d'audio en *runtime *machine-dep* : ~0.7s)\n",
     "\n",
     "**Impact du reseau** :\n",
-    "- La variabilité des latences Whisper API (1.05s à 2.77s) illustre l'impact de la latence reseau\n",
+    "- La variabilité des latences Whisper API (*runtime *machine-dep* : 1.05s à 2.77s) illustre l'impact de la latence reseau\n",
     "- Les modèles locaux offrent une latence plus predictable\n",
     "\n",
-    "**Conclusion** : pour un usage intensif (> 1h/jour), le cout de l'API ($18/mois) justifie l'investissement dans un GPU local (~$30/mois amorti sur 2 ans)."
+    "**Conclusion** : pour un usage intensif (> 1h/jour), le cout de l'API (*runtime *machine-dep* : $18/mois) justifie l'investissement dans un GPU local (*runtime *machine-dep* : ~$30/mois amorti sur 2 ans)."
    ]
   },
   {
@@ -1366,7 +1366,7 @@
     "| Aspect | OpenAI TTS | Chatterbox | Kokoro |\n",
     "|--------|-----------|------------|--------|\n",
     "| Qualite (MOS) | ~4.5 (meilleur) | ~4.2 (expressif) | ~4.0 (bon) |\n",
-    "| Latence | 1-3s (reseau) | 2-5s (GPU) | 0.5-1s (leger) |\n",
+    "| Latence | *runtime *machine-dep* : 1-3s (reseau) | *runtime *machine-dep* : 2-5s (GPU) | *runtime *machine-dep* : 0.5-1s (leger) |\n",
     "| VRAM | 0 (cloud) | ~8 GB | ~2 GB |\n",
     "| Cout | $15/1M chars | Gratuit | Gratuit |\n",
     "| Emotions | Non | Oui (exaggeration) | Non |\n",
@@ -1428,7 +1428,7 @@
     "\n",
     "**Kokoro 82M** :\n",
     "- Architecture légere (82M paramètres vs plusieurs milliards pour les concurrents)\n",
-    "- Performance : latence < 1s sur GPU moderne pour un texte standard\n",
+    "- Performance : latence *runtime *machine-dep* : < 1s sur GPU moderne pour un texte standard\n",
     "- Compromis : qualite vocale legèrement inferieure, pas de contrôle emotionnel\n",
     "\n",
     "Le choix depend donc de votre priorite : qualité absolue (OpenAI), personnalisation (Chatterbox) ou performance (Kokoro)."
@@ -1803,8 +1803,8 @@
     "| Usage | Volume | Cout API | Cout local (electricite) |\n",
     "|-------|--------|----------|-------------------------|\n",
     "| Prototype | 10 min/jour | ~$2/mois | ~$0 |\n",
-    "| Application | 1h/jour | ~$15/mois | ~$5/mois (GPU) |\n",
-    "| Production | 10h/jour | ~$150/mois | ~$30/mois (GPU) |"
+    "| Application | 1h/jour | ~$15/mois | *runtime *machine-dep* : ~$5/mois (GPU) |\n",
+    "| Production | 10h/jour | ~$150/mois | *runtime *machine-dep* : ~$30/mois (GPU) |"
    ]
   },
   {


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2024:CoursIA-2 — prev: LIGHT/notebook-python #9700 (c.1321 04-1-Educational-Audio-Content)

Refs #9434

# fix(genai,#9434): drain 9 wall-clock claims from 03-1-Multi-Model-Audio-Comparison (LIGHT, audio 03-orchestration multi-model benchmark)

## Summary

Surgical markdown-only drainage on `MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb` — **9 insertions, 9 deletions, 1 file**. 9 préfixes `runtime *machine-dep*` injectés sur 4 cellules (cell[17] + cell[20]×4 + cell[24] + cell[27] + cell[34]×2) — zero cellule code touchée, 15/15 code cells execution_count préservés.

Sub-family GenAI/Audio **03-Orchestration** benchmark framework multi-modèle cross-comparison (Whisper API vs faster-whisper local + OpenAI TTS vs Chatterbox vs Kokoro). **Succède à c.1321 04-1-Educational-Audio-Content** comme **cross sous-family rotation 04-Applications → 03-Orchestration** post-c.1303 03-2-Audio-Pipeline-Orchestration déjà drainné. **36ᵉ réutilisation archétype 6ᵉ #9434**.

## Cells drained (4 cells, 9 préfixes)

| Cell | Row drained | Rationale §D.5 |
|------|-------------|----------------|
| **cell[17]** (STT tableau cross-comparison) | `\| Latence \| Depend du reseau (1-3s) \| Depend du GPU (0.5-2s) \|` → préfixe | axe a runtime claim — **`~3-6 GB` VRAM faster-whisper axe c + `< 5%` WER axe c quality metric préservés** |
| **cell[20]** (RTF local) | `Whisper API : RTF ~ 0.14 (transcrit 13s d'audio en ~2s)` → préfixe | axe a wall-clock — **RTF ratio `0.14` COMPUTED HORS scope préservé verbatim** |
| **cell[20]** (RTF GPU) | `faster-whisper : RTF ~ 0.05-0.10 sur GPU RTX 3090 (transcrit 13s d'audio en ~0.7s)` → préfixe | axe a wall-clock — **RTF ratio `0.05-0.10` COMPUTED HORS scope préservé verbatim** |
| **cell[20]** (variabilite latences) | `La variabilité des latences Whisper API (1.05s à 2.77s) illustre l'impact de la latence reseau` → préfixe | axe a runtime claim |
| **cell[20]** (cout API vs GPU) | `**Conclusion** : pour un usage intensif (> 1h/jour), le cout de l'API ($18/mois) justifie l'investissement dans un GPU local (~$30/mois amorti sur 2 ans).` → préfixe | axe a hardware/cost — **2 valeurs runtime distinctes préfixées** |
| **cell[24]** (TTS tableau cross-comparison) | `\| Latence \| 1-3s (reseau) \| 2-5s (GPU) \| 0.5-1s (leger) \|` → préfixe | axe a runtime claim — **`~4.5/4.2/4.0` MOS axe c + `~8 GB`/`~2 GB` VRAM axe c + `$15/1M chars` cout OpenAI axe c préservés** |
| **cell[27]** (Kokoro 82M) | `Performance : latence < 1s sur GPU moderne pour un texte standard` → préfixe | axe a runtime claim — **`82M paramètres` Kokoro architecture axe c préservé** |
| **cell[34]** (cout Application GPU) | `\| Application \| 1h/jour \| ~$15/mois \| ~$5/mois (GPU) \|` → préfixe | axe a hardware/electricite — **`~$15/mois` API cost axe c préservé** |
| **cell[34]** (cout Production GPU) | `\| Production \| 10h/jour \| ~$150/mois \| ~$30/mois (GPU) \|` → préfixe | axe a hardware/electricite — **`~$150/mois` API cost axe c préservé** |

**Total** : 9 préfixes `runtime *machine-dep*` insérés.

## Litmus §D.5 — 4 catégories timings (canonique)

1. **Wall-clock API HTTP + LOCAL GPU latency** (axe a env+réseau+hardware GPU/CPU) — **DRAINABLE**
   - cell[17] `Depend du reseau (1-3s) | Depend du GPU (0.5-2s)` STT latence drainée
   - cell[20] `~2s` Whisper API transcrit 13s drainé
   - cell[20] `~0.7s` faster-whisper GPU RTX 3090 drainé
   - cell[20] `1.05s à 2.77s` variabilite latences Whisper API drainée
   - cell[20] `$18/mois` API cost + `~$30/mois` GPU amorti sur 2 ans drainés
   - cell[24] `1-3s (reseau) | 2-5s (GPU) | 0.5-1s (leger)` TTS latence drainée
   - cell[27] `latence < 1s` Kokoro GPU moderne drainée
   - cell[34] `~$5/mois (GPU)` Application cout drainé
   - cell[34] `~$30/mois (GPU)` Production cout drainé

2. **Audio duration** (axe c moteur upstream déterministe) — **NOT drainable**
   - cell[0] `Duree estimee : 60 minutes` pedagogique
   - cell[18] `Duree estimee : 15 minutes` pedagogique exercice
   - cell[25] `Duree estimee : 15 minutes` pedagogique exercice
   - cell[38] `Duree estimee : 20-25 minutes` pedagogique exemple guide
   - cell[25] `1 minute de parole ~= 150 mots ~= 800 caractères` (axe c pedagogique)

3. **Ratio structurel COMPUTED** (axe c computed) — **HORS scope** (c.1313-L3 ★ + c.1315-L3 ★ + c.1319-L3 ★ analogues)
   - cell[20] `RTF ~ 0.14` / `RTF ~ 0.05-0.10` ratios RTF = COMPUTED préservé verbatim
   - cell[20] `5% à 25%` WER range (axe c quality metric)

4. **Chargement modèle / distribution** (axe a init time) — DRAINABLE part
   - cell[0] `~12 GB VRAM` (axe c hardware spec — non drainé, structurel)
   - cell[17] `~3-6 GB` VRAM faster-whisper (axe c structurel)
   - cell[21] `~8 GB` Chatterbox + `~2 GB` Kokoro + `0` OpenAI cloud (axe c architecture)
   - cell[24] `~8 GB` / `~2 GB` VRAM (axe c architecture)
   - cell[27] `82M paramètres` Kokoro architecture (axe c)
   - cell[32] `Temps de froid (cold start)` cold start runtime info (axe a)

## Invariants préservés verbatim (15+)

- `Duree estimee : 60 minutes` cell[0] (axe c pedagogique)
- `~12 GB VRAM` cell[0] VRAM totale (axe c hardware spec)
- `< 5%` cell[17] WER Whisper API (axe c quality)
- `~3-6 GB` cell[17] VRAM faster-whisper (axe c)
- `Equivalente ou meilleure` cell[17] WER faster-whisper (axe c)
- `$0.006/min` cell[17] cout API (axe c référence)
- `Hors-ligne | Non | Oui` cell[17] matrice (axe c feature)
- `RTF ~ 0.14` cell[20] ratio COMPUTED HORS scope
- `RTF ~ 0.05-0.10` cell[20] ratio COMPUTED HORS scope
- `5% à 25%` cell[20] WER range (axe c quality metric)
- `RTF < 1.0` cell[20] real-time factor seuil (axe c)
- `~4.5/4.2/4.0 MOS` cell[24] qualitatif (axe c quality)
- `~8 GB` / `~2 GB` cell[24] VRAM specs (axe c architecture)
- `$15/1M chars` cell[24] cout OpenAI (axe c)
- `82M paramètres` cell[27] Kokoro architecture (axe c)
- `~$2/mois` cell[34] Prototype API cost (axe c)
- `~$15/mois` + `~$150/mois` cell[34] API cout (axe c)
- `Duree estimee : 15 minutes` cell[18] pedagogique axe c
- `Duree estimee : 15 minutes` cell[25] pedagogique axe c
- `Duree estimee : 20-25 minutes` cell[38] pedagogique axe c
- `1 minute de parole ~= 150 mots ~= 800 caractères` cell[25] (axe c)

## Acceptance

- [x] Validateur `validate_pr_notebooks.py` PASS (notebook tagged `runtime *machine-dep*` ≠ cellule code avec `severity:error`)
- [x] Aucune cellule code touchée (15/15 execution_count préservés, 15/15 outputs préservés)
- [x] Pas de ré-exécution kernel (markdown-only, scope strict)
- [x] Diff = **9 insertions, 9 deletions, 1 file** — purely surgical

## Tells archétypaux c.1322 spécifiques

- **c.1322-L1 ★** : **03-1 / 03-Orchestration benchmark framework multi-modèle cross-comparison** — sub-family GenAI/Audio **03-Orchestration** = benchmark framework pédagogique (cross-comparison Whisper API vs faster-whisper + OpenAI TTS vs Chatterbox vs Kokoro), **distinct** de c.1303 03-2-Audio-Pipeline-Orchestration (orchestration générique multi-call) et c.1320 02-5-Multi-Model-TTS-Gateway (gateway HTTP). Paradigme = **benchmark framework pédagogique** (matrices 2×2 STT + 3-modèle TTS) vs **orchestration infrastructure** (c.1303) vs **gateway HTTP multi-modèle** (c.1320). Tell distinctif = `BenchmarkResult` class + matrices 2×2 STT + 3-modèle TTS comparative evaluation.
- **c.1322-L2 ★** : **Matrice 2×2 STT benchmark** (Whisper API vs faster-whisper local) — extension cross-comparison (c.1303 multi-call, c.1313 2-modèle YuE+SongGen, c.1316 3-modèle Fish+Dia+Kokoro, c.1320 3-modèle Kokoro+TADA+Qwen3 HTTP). Cross-cutting axis = **API HTTP vs LOCAL GPU** (decision matrix), pondération VRAM = `0 (cloud)` vs `~3-6 GB` (axe c architecture choix). Tell distinctif = `BenchmarkResult` class latence + VRAM + cost + quality_score + sample_rate.
- **c.1322-L3 ★** : **Matrice 3-modèle TTS benchmark** (OpenAI TTS cloud vs Chatterbox ~8 GB vs Kokoro 82M ~2 GB) — extension cross-comparison. **RTF ratios COMPUTED HORS scope préservé verbatim** : analogie cross-modèles SOTA 2024-2025 (Kokoro 82M `~10x` c.1308/c.1320 + TADA `~5x` c.1320 + Qwen3 `~1x` c.1320). Tell distinctif = MOS qualitatif `~4.5/4.2/4.0` (axe c quality) + cout API `$15/1M chars` (axe c référence).
- **c.1322-L4 ★** : **Cost analysis infrastructure** (Prototype `~$2/mois` 10min/jour + Application `~$15/mois` 1h/jour + Production `~$150/mois` 10h/jour) — pattern pédagogique de **decision matrix cout** (axe a hardware/electricite) qui complète **latence** (axe a runtime) + **VRAM** (axe c architecture) + **MOS** (axe c quality). Tell distinctif = mat 3×3 (Usage × Volume × Cout API × Cout local) qui démontre que `~$5 à $30/mois` GPU electricite vs `$15 à $150/mois` API = break-even selon volume usage.

## Lessons c.1322-L1..L4

- **c.1322-L1 ★** : 03-Orchestration benchmark framework = benchmark framework pédagogique, distinct orchestration infrastructure (c.1303) + gateway HTTP (c.1320). Matrices 2×2 STT + 3-modèle TTS = pattern reproductible pour notebooks cross-comparison à venir.
- **c.1322-L2 ★** : Matrice 2×2 STT benchmark (API vs LOCAL) = pondération VRAM `0 vs ~3-6 GB` + cout `$0.006/min vs gratuit` + WER `< 5% equivalent` + latence `1-3s reseau vs 0.5-2s GPU` + hors-ligne `non vs oui`. Pattern 5 dimensions pour benchmark pédagogique.
- **c.1322-L3 ★** : Matrice 3-modèle TTS benchmark (cloud ~4.5 MOS vs Chatterbox ~4.2 MOS vs Kokoro ~4.0 MOS) = RTF ratios COMPUTED HORS scope préservés verbatim + VRAM specs (`0/~8/~2 GB`) + cout (`$15/1M chars / gratuit / gratuit`) + emotions (`non / oui / non`). Tell distinctif = `82M paramètres` Kokoro architecture (axe c) + latence < 1s GPU drainée.
- **c.1322-L4 ★** : Cost analysis 3×3 (Usage × Volume × Cout API × Cout local) = pattern pédagogique de decision matrix. `~$5-$30/mois` GPU electricite vs `$15-$150/mois` API = break-even pedagogique. Tell distinctif = amortissement 2 ans GPU `~$30/mois` = axe a hardware cost.

## Cross-references #9434 vein (GenAI/Audio)

| Grain | Sub-family | PR | Statut | Tells |
|-------|-----------|-----|--------|-------|
| c.1303 | Audio orchestration (multi-call) | #9661 | OPEN | multi-call LLM+TTS+STT+retries+pauses |
| c.1306-c.1310 | Audio foundation 5× (STT/TTS HTTP/LOCAL matrice 2×2) | #9671/9675/9676/9678/9680 | OPEN | CHARGEMENT vs INFERENCE + RTF |
| c.1312-c.1320 | Audio advanced 8× (Demucs/SongGen/MusicGen/Expressive/AceStep/MIDI/XTTS/TTS-Gateway) | #9684-#9694 | OPEN | 8 sub-family nouveaux distincts |
| c.1321 | Audio 04-Applications educational content | #9700 | OPEN | pipeline intégré 6-étapes + multi-voix nova/onyx + 1ère entrée 04-Applications |
| **c.1322** | **Audio 03-Orchestration multi-model benchmark** | **#XXXX** | **OPEN** | **benchmark framework pédagogique + matrice 2×2 STT + matrice 3-modèle TTS + cost analysis 3×3 + 4 cellules drainées** |

## Diagnostic §D.5

**Verdict** : `CAUSE_FIXED` — option alpha appliquée (préserver invariants structurels + drainer claims runtime machine-dep). Cause racine = prose pédagogique cite wall-clock concrets (latence STT `1-3s reseau / 0.5-2s GPU`, RTF transcrit 13s en `~2s`/`~0.7s`, variabilite latences Whisper API `1.05s à 2.77s`, cout API `$18/mois` + GPU `~$30/mois`, TTS latence `1-3s/2-5s/0.5-1s`, Kokoro latence `< 1s GPU moderne`, cout Application `~$5/mois` GPU + Production `~$30/mois` GPU) sans marquer leur dépendance à la machine d'exécution + connectivité réseau + charge GPU serveur. Fix = préfixer par `runtime *machine-dep* :` sans modifier la valeur numérique. Pas de ré-alignement, pas de ré-exécution kernel (markdown-only).

## Validation per CLAUDE.md §B.5 + notebook-conventions C.1/C.2

| Check | Statut |
|-------|--------|
| Scope réel (Refs #9434 partiel) | ✅ claim = scope = diff |
| `git diff --stat` cohérent | ✅ 1 file, +9/-9 |
| Cellules code = `execution_count: <int>` + outputs cohérents | ✅ 15/15 préservés (séquentiel + 3 ré-exécutions cell[7,9,11]) |
| 0 cellule `# Solution` / `# Exemple résolu` supprimée | ✅ (aucune touchée) |
| Stop & Repair règle 6 | ✅ cause = marqueur manquant, pas erreur à corriger |
| CR/LF/BOM preserved | ✅ LF-only + final LF preserved |
| C955-1 ★★★ surgical edit | ✅ metadata/texte uniquement |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
