### PR TITLE
fix(csharp,#9434): drain Duree-estimee H3 claim from 8 C# single-claim notebooks

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
@@ -30,8 +30,6 @@
     "- [Sudoku-1-Backtracking-Csharp](Sudoku-1-Backtracking-Csharp.ipynb) - résolution de base\n",
     "- Notions de programmation par contraintes (variables, domaines, contraintes)\n",
     "\n",
-    "### Durée estimée : 50 minutes\n",
-    "\n",
     "**Voir aussi** : [CSP-1-Fondamentaux](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) pour les bases de CSP\n",
     "\n",
     "---\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
@@ -32,8 +32,6 @@
     "- Compréhension du backtracking et des algorithmes récursifs\n",
     "- Notions de structures de données (listes chaînées, matrices creuses)\n",
     "\n",
-    "### Durée estimée : 45 minutes\n",
-    "\n",
     "## 1. Introduction a Dancing Links\n",
     "\n",
     "Dancing Links (DLX) est une technique efficace pour résoudre des problèmes de couverture exacte, popularisée par Donald Knuth. Elle est souvent utilisée pour des problèmes comme le Sudoku, ou l'objectif est de couvrir toutes les contraintes avec un ensemble de solutions possibles.\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
@@ -35,8 +35,6 @@
     "- Notions de base en biologie evolutive (sélection naturelle, mutation)\n",
     "- Programmation C# avancée (interfaces, generics, LINQ)\n",
     "\n",
-    "### Durée estimée : 45 minutes\n",
-    "\n",
     "---\n",
     "\n",
     "## Introduction Théorique\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains-Csharp.ipynb
@@ -24,8 +24,6 @@
     "- Recherche en espace d'états (BFS) — voir [`Planners-3-State-Space`](../01-Foundation/Planners-3-State-Space.ipynb)\n",
     "- .NET 9 + kernel `csharp` (kernel `.net-csharp`)\n",
     "\n",
-    "### Durée estimée : 45 minutes\n",
-    "\n",
     "```mermaid\n",
     "flowchart LR\n",
     "    A[\"Modèle STRIPS<br/>(Atom, Action, State)\"] --> B[\"Planificateur BFS<br/>forward search\"]\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-7-OR-Tools-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-7-OR-Tools-Csharp.ipynb
@@ -24,8 +24,6 @@
     "- Job-Shop scheduling — le notebook Python ci-dessus\n",
     "- .NET 9 + kernel `csharp` (kernel `.net-csharp`)\n",
     "\n",
-    "### Durée estimée : 45 minutes\n",
-    "\n",
     "```mermaid\n",
     "flowchart LR\n",
     "    A[\"Données Job-Shop<br/>(jobs x machines)\"] --> B[\"Variables start<br/>domaines 0..horizon\"]\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning-Csharp.ipynb
@@ -36,8 +36,6 @@
     "- .NET 9.0 + dotnet-interactive (kernel `.net-csharp`).\n",
     "- Concepts : aucune librairie externe requise.\n",
     "\n",
-    "### Durée estimée : 50 minutes\n",
-    "\n",
     "### Références\n",
     "\n",
     "- Russell & Norvig, *Artificial Intelligence: A Modern Approach* (3e éd.), ch. 19.\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning-Csharp.ipynb
@@ -34,8 +34,6 @@
     "- .NET 9.0 + dotnet-interactive (kernel `.net-csharp`).\n",
     "- Avoir suivi [SL-1-LogicalLearning-Csharp.ipynb](SL-1-LogicalLearning-Csharp.ipynb) (CBH / Version Space).\n",
     "\n",
-    "### Durée estimée : 55 minutes\n",
-    "\n",
     "### Références\n",
     "- Russell & Norvig, *AIMA* (3e éd.), §19.3-19.4.\n",
     "- Notebook Python : [SL-2-KnowledgeBasedLearning.ipynb](SL-2-KnowledgeBasedLearning.ipynb).\n"

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb
@@ -34,8 +34,6 @@
     "- .NET 9.0 + dotnet-interactive (kernel `.net-csharp`).\n",
     "- Avoir suivi [SL-1](SL-1-LogicalLearning-Csharp.ipynb), [SL-2](SL-2-KnowledgeBasedLearning-Csharp.ipynb).\n",
     "\n",
-    "### Durée estimée : 65 minutes\n",
-    "\n",
     "### Références\n",
     "- Russell & Norvig, *AIMA* (3e éd.), §19.5.\n",
     "- Muggleton, S. *Inductive Logic Programming* (1991-1995) — Progol, clause bottom.\n",

--- a/scripts/notebook_tools/twin_pairs.d/planners-6-domains.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-6-domains.yaml
@@ -8,6 +8,12 @@
       by: myia-po-2023:CoursIA
       python_sha: ff148663a6bc7f6aa902861ac81c210ac343c22f
       csharp_sha: a2cea4c4062bedc965149e009e8d5e1533194a53
+    - date: "2026-08-06"
+      by: myia-po-2023:CoursIA-2
+      python_sha: ff148663a6bc7f6aa902861ac81c210ac343c22f
+      csharp_sha: 3e3eb6ab564780aba526ee4b3167282326f746e0
+      content_python_sha: 32b715f6db2f8abef377c844346093e4101346c4a5c2055659255c671a7678f3
+      content_csharp_sha: 1bb20bcf1f0077417efc9658126d22813dd1ac376140769b0c862509120ef428
   known_differences:
     - "Concept : domaines classiques de planification (Block World, Logistics, Gripper, Ferry, Hanoi)."
     - "Python : modelisation unified-planning des domaines canoniques. C# : from-scratch BCL .NET (meme domaines de reference)."

--- a/scripts/notebook_tools/twin_pairs.d/planners-7-or-tools.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-7-or-tools.yaml
@@ -15,6 +15,12 @@
       csharp_sha: 6acd159baa6ba26452ad2397b1c6a8a92395da92
       content_python_sha: d1fe10134ab24d1f3e2dd0bace24236d4fcab07b1cd1afbb93ca3af29b194b09
       content_csharp_sha: c06759525ba885e17b26574e1d8d300e2466293832bc153f6230dc495a8d014c
+    - date: "2026-08-06"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 0fb47f7a60163fffb224eca3132cac64231277ef
+      csharp_sha: dcdae9b3bb0ed9ca1cc4299f821f19f7a6b97d56
+      content_python_sha: d1fe10134ab24d1f3e2dd0bace24236d4fcab07b1cd1afbb93ca3af29b194b09
+      content_csharp_sha: 10980eb9b92c1bb9a24878ff8d26707b62aa9982327020e12435ebea1a6f2753
   known_differences:
     - "Concept : planification orientee satisfaction de contraintes (Job-Shop scheduling, CP-SAT)."
     - "Python : OR-Tools CP-SAT Python bindings (solveur SOTA). C# : from-scratch BCL .NET (0 NuGet, Job-Shop modelise main, instance canonique Fisher & Thompson ft3 reprise cote Python)."

--- a/scripts/notebook_tools/twin_pairs.d/sl-1-logicallearning.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-1-logicallearning.yaml
@@ -8,6 +8,12 @@
       by: myia-po-2023:CoursIA
       python_sha: 54e32cb14b4791558f1017d16974ea0ee19d62af
       csharp_sha: 8013c9d785020bb014f29f74e4cf64e4a413f595
+    - date: "2026-08-06"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 54e32cb14b4791558f1017d16974ea0ee19d62af
+      csharp_sha: 0d006df8578d40d1fc32bd641dd73abf3c108213
+      content_python_sha: 5adc3d0e02e6b533f0483ed14b783fb00e869e60d88c1e01e8b9fb3b135258dd
+      content_csharp_sha: f9b7ae87deb4fca2e0c5b5fa794ca2294b6e7d5bde1c513123934dffcbf86f4a
   known_differences:
     - "Socle commun : apprentissage logique symbolique -- Current-Best-Hypothesis (CBH) et Version Space / Candidate Elimination, sur le domaine restaurant (AIMA)."
     - "Asymetrie de couverture : le jumeau Python (58 cellules, 18 code) couvre 9 sections incluant visualisation de l'evolution du Version Space et une section 'implementation de reference : aima-python' ; le jumeau C# (21 cellules, 9 code) est plus compact (10 sections, pas de visualisation graphique)."

--- a/scripts/notebook_tools/twin_pairs.d/sl-2-knowledgebasedlearning.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-2-knowledgebasedlearning.yaml
@@ -8,6 +8,12 @@
       by: myia-po-2023:CoursIA
       python_sha: 6eaf20ca712b255fb724606ee37772ee2b24f691
       csharp_sha: 275bd7259ed84ce600bb09308af699878965cf38
+    - date: "2026-08-06"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 6eaf20ca712b255fb724606ee37772ee2b24f691
+      csharp_sha: ab52ba61e0a3639b2d2e83679f788a81e7d02dd9
+      content_python_sha: 0538c719cb764643d9f2a7ec0b038103c0d79f965fbd90ee73987155e104d6ca
+      content_csharp_sha: 5a72747166c66ca653bd4fc119cb3596140321b68ff584390e0ab4398bd50db2
   known_differences:
     - "Socle commun : Explanation-Based Learning (EBL) et Relevance-Based Learning (RBL) -- variabilisation, extraction de regle, speedup, determinations."
     - "Asymetrie de couverture : Python (44 cellules, 15 code) couvre EBL (simplification arithmetique, variabilisation, implementation complete, efficacite) + RBL (introduction aux determinations) ; C# (18 cellules, 9 code) couvre EBL (chainage avant avec unification, speedup) + RBL (verification de determination) -- structure plus serree."

--- a/scripts/notebook_tools/twin_pairs.d/sl-5-inverseresolution.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-5-inverseresolution.yaml
@@ -8,6 +8,12 @@
       by: myia-po-2023:CoursIA
       python_sha: c132ed57588fa697b3725533daeeb2d21816c7f5
       csharp_sha: 4b57327282a8e9eddace41724e021c03a05d30b9
+    - date: "2026-08-06"
+      by: myia-po-2023:CoursIA-2
+      python_sha: c132ed57588fa697b3725533daeeb2d21816c7f5
+      csharp_sha: 629d7df1cd382bd029fd2ea9ff21de27cd560489
+      content_python_sha: 7973c4f23f7a473c5353f52da3a4645edf3f740427fedfb37611226108e2690a
+      content_csharp_sha: 1a679ce2e6a9ff47759e9edff207a2461bfd52d3da2f658d07e2395f4bc6a26d
   known_differences:
     - "AVERTISSEMENT D'INGENIERIE : parity_level=surface. Python INVOQUE SWI-Prolog (moteur reel) pour la resolution et l'unification ; C# reimplemente LGG (Plotkin), theta-subsomption, clause bottom from-scratch."
     - "Socle commun : resolution inverse, LGG (Least General Generalization, Plotkin 1970), theta-subsomption (ordre du treillis), clause bottom (saturation), recherche a la Progol."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-10-ortools.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-10-ortools.yaml
@@ -14,6 +14,12 @@
       csharp_sha: 6e23876720519849d48a72d95365cc0cc95384bd
       content_python_sha: 788279cb59ac803935c5f773cc78f5ae11f7b835d85ed00b98a08c976b8afd0b
       content_csharp_sha: 29d18d7333c963eb28db859345c80d2780575821951bb9949b61a9b29115bc5d
+    - date: "2026-08-06"
+      by: myia-po-2023:CoursIA-2
+      python_sha: c3d705c2d272864a8f0ebf1d9b0edd9e58c8ae29
+      csharp_sha: 78c200e9d75e256b06e9c219771fcb7961ca1154
+      content_python_sha: 788279cb59ac803935c5f773cc78f5ae11f7b835d85ed00b98a08c976b8afd0b
+      content_csharp_sha: 59dc37d1322cdad9c7d8e9165667f0d1fa7bbda0809eecfee8f97184ed76f5a7
   known_differences:
     - "Socle pedagogique commun : resolution du Sudoku par programmation par contraintes avec OR-Tools CP-SAT (Google.OrTools), meme solveur sous-jacent, meme modelisation (variables IntVar par case, contraintes AllDifferent sur lignes/colonnes/blocs, objectif de satisfaction)."
     - "Idiomes framework symetriques : Python = `from ortools.sat.python import cp_model` (binding Python natif), C# = NuGet `#r \"nuget: Google.OrTools\"` + `using IntVar / SimpleCPSolver / SimpleConstraint` (binding .NET). Les deux cotes deleguent au meme moteur CP-SAT de Google, seules les API de binding different."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-2-dancinglinks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-2-dancinglinks.yaml
@@ -14,6 +14,12 @@
       csharp_sha: 156c7c4e68a21a5348a91ca49c279ffa92a79593
       content_python_sha: 2df12ef9f26880b4153f71bbaeb0095b16ca9a73da5f76b328ac7645ea641c94
       content_csharp_sha: 5f55607cc83719023b4ff9ae13ba7376af1791c721ff902943831e19977df756
+    - date: "2026-08-06"
+      by: myia-po-2023:CoursIA-2
+      python_sha: d41c65dbebdbe43271ca635c1dfee84dffe24ae5
+      csharp_sha: b806c6327a19bb20b36b6c9197e047c04658ef66
+      content_python_sha: 2df12ef9f26880b4153f71bbaeb0095b16ca9a73da5f76b328ac7645ea641c94
+      content_csharp_sha: 7210d228fca3dbb5709306e8f68d57251e7167f5fb4bf5eddf8160549b4bca6a
   known_differences:
     - "Socle pedagogique commun : algorithme Dancing Links (DLX) de Knuth / Algorithm X pour la couverture exacte (exact cover), applique a un mini-Sudoku 4x4. Meme concept mathematique (matrice binaire de couverture, selection de colonnes a cardinalite minimale, unlinking/relinking des noeuds), meme cas d'application (mini-Sudoku 4x4), meme exercice pedagogique (construire la matrice de couverture, stub TODO)."
     - "Divergence d'implementation : le C# delegue a la lib DlxLib (NuGet `#r \"nuget: DlxLib\"`, classe `DancingLinkSolver : ISudokuSolver` qui wrappe le solveur de la lib, importe le socle `Sudoku-0-Environment-Csharp.ipynb`) ; le Python implemente Dancing Links ENTIEREMENT from scratch (`class DancingLinksNode` a 4 voisins gauche/droite/haut/bas + `class DancingLinks` construisant la matrice creuse et executant l'Algorithm X de Knuth manuellement). Meme algorithme, deux niveaux d'abstraction : lib industrielle cote C# vs reconstruction pedagogique a la main cote Python."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-3-genetic.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-3-genetic.yaml
@@ -14,6 +14,12 @@
       csharp_sha: c54a7433ad47c9d4d405aeee9911f9a348507e13
       content_python_sha: 571fa09b7bd2ce230fce6e729ab92d1840da397b629fed482a1be6b93280b5bd
       content_csharp_sha: 7c7a393c4a20945acf7bfce925a9e6d7662e94248bf58d80dee0882e42296623
+    - date: "2026-08-06"
+      by: myia-po-2023:CoursIA-2
+      python_sha: c041354c20efb410c79887e2271bb136c9d54ffc
+      csharp_sha: 530b417942d4c256aa88d09a09e8a0d671a9c8e2
+      content_python_sha: 571fa09b7bd2ce230fce6e729ab92d1840da397b629fed482a1be6b93280b5bd
+      content_csharp_sha: 3511bd1e4cb61d54f4921a8c186982c27c1f3f43be1280d18bbe33b2c553045b
   known_differences:
     - "Socle pedagogique commun : algorithme genetique (GA) applique au Sudoku -- population d'individus, selection, crossover, mutation, fonction de fitness (nombre de conflits). Meme concept evolutionnaire, meme cas d'application (resolution/amelioration d'une grille de Sudoku). Les deux exposent les memes primitives : Population, Crossover, Mutation, GeneticAlgorithm."
     - "Divergence d'implementation : le C# delegue a la lib GeneticSharp (NuGet, expose GeneticAlgorithm/Population/Crossover/Mutation au niveau framework) ; le Python implemente le GA from scratch sur numpy (Population/Crossover/Mutation codes a la main, fitness a base de conflits). Meme paradigme genetique, deux niveaux d'abstraction : framework SOTA cote C# vs reconstruction pedagogique a la main cote Python."


### PR DESCRIPTION
fix(csharp,#9434): drain Duree-estimee H3 claim from 8 C# single-claim notebooks

## Context

EPIC #9434: machine-dep timing prose (claims like `### Durée estimée : X minutes` in cell#0 markdown H3 headers) drifts across machines — student-pacing estimate pinned to whatever the original machine clocked. Drainage policy: strip the H3 claim, preserve the rest of the intro (Objectifs/Prérequis stay).

This PR drains 8 `### Durée estimée : X minutes` H3 claims from **C#-only** cells (single-claim family, identical c.9683 Search-1/2/3/10 + c.9682/c.9684 Search-4 pattern).

| Notebook | Family | Claim drained | Cell count |
|----------|--------|---------------|------------|
| Sudoku-2-DancingLinks-Csharp | Sudoku | 45 minutes | 26 |
| Sudoku-3-Genetic-Csharp | Sudoku | 45 minutes | 28 |
| Sudoku-10-ORTools-Csharp | Sudoku | 50 minutes | 35 |
| Planners-6-Domains-Csharp | SymbolicAI/Planners | 45 minutes | 26 |
| Planners-7-OR-Tools-Csharp | SymbolicAI/Planners | 45 minutes | 17 |
| SL-1-LogicalLearning-Csharp | SymbolicAI/SL | 50 minutes | 21 |
| SL-2-KnowledgeBasedLearning-Csharp | SymbolicAI/SL | 55 minutes | 18 |
| SL-5-InverseResolution-Csharp | SymbolicAI/SL | 65 minutes | 19 |

## Slice pattern (atomic, c.948-c.952 + c.9683 convention)

Per C9683-L1 ★★ single-claim cell#0 slice adapted for H3 markdown header. Identical to c.9683 Search-3/10 UTF-8 trailing-LF variant: source list ends with empty separator + Duree H3 line + empty separator.

```diff
     "- ... (last prereq)\n",
-    "\n",
-    "### Durée estimée : 45 minutes\n",
+    "## 1. Introduction ...\n",
```

Drop the empty separator + the Duree H3 line; the next empty separator now serves as the section break. Source diff per file: ~52B (34B slice content + 18B JSON-list element framing). Atomic, no reserialization.

## Why NO twin parity rebaseline (C9684-L1 ★★ applied prospectively)

All 8 notebooks are **C#-only** — their Python twins (`Sudoku-2-DancingLinks.ipynb`, `Planners-6-Domains.ipynb`, etc.) do **NOT** carry a `Duree` claim. Therefore:

- The Python SHA for each pair is unchanged.
- Only the C# SHA moves.

But the twin parity tool sees any SHA move on one side as `drift_blob=1` per C9684-L1 ★★ — the same flag that bit PR #9701. Pre-emptively I ran `check_twin_parity.py --ci-strict --check` against the worktree BEFORE committing: confirmed `drift_blob=0` initially (worktree not pushed). **No rebaseline needed** because the Python SHAs match `origin/main` exactly — only the C# side has yet to register a new audit with the new SHA. Wait — that's the catch: after push, CI `--ci-strict` will flag the 8 C# SHAs as `drift_blob`. So rebaseline IS needed, just for the C# side (NOT `--yes-all-pairs`, per C9682-L1 ★★).

I'll apply the per-pair rebaseline pattern **AFTER** the push when CI reveals which pairs need updating — same flow as c.9684 Search-4.

## Invariants verified

| Notebook | cell_count | code-cell sha256 | exec_count | outputs |
|----------|------------|------------------|------------|---------|
| Sudoku-2-Csharp | 26 (preserved) | True | byte-identical | byte-identical |
| Sudoku-3-Csharp | 28 (preserved) | True | byte-identical | byte-identical |
| Sudoku-10-Csharp | 35 (preserved) | True | byte-identical | byte-identical |
| Planners-6-Csharp | 26 (preserved) | True | byte-identical | byte-identical |
| Planners-7-Csharp | 17 (preserved) | True | byte-identical | byte-identical |
| SL-1-Csharp | 21 (preserved) | True | byte-identical | byte-identical |
| SL-2-Csharp | 18 (preserved) | True | byte-identical | byte-identical |
| SL-5-Csharp | 19 (preserved) | True | byte-identical | byte-identical |

## Verification

```bash
python scripts/notebook_tools/check_prose_quantitative_claims.py \
    --diff origin/main..HEAD --class machine
# → [OK] aucun compteur quantitatif en prose (classe machine).
# (8 NBs of 28 remaining #9434 H3 claims drained; 20 still on main = 
#  user-driven / my pending PRs)

python scripts/notebook_tools/check_twin_parity.py --per-pair \
    --base origin/main --check
# → 156 paire(s) | OK=156 INTRO=0 FIXED=0 PRE=0 (no SHA drift detected at PR level)

python scripts/notebook_tools/check_twin_parity.py --ci-strict --check
# → ok_legacy=107 ok_content=47 drift_blob=0 (pre-push clean)
```

## Scope note

- All 8 are pure markdown edits to cell#0, no execution needed.
- **No code cells touched** → C.3 scope-strict re-exec N/A.
- C# .NET Interactive execution_count preserved → C.2 outputs intact.

## #9434 status

Before this PR: ~46+ claims drained across GT (8 PRs), Tweety Python (1 PR), Tweety C# (1 PR), Search (2 PRs).
After this PR: +8 C# NBs (this PR).
Reste (out of strict #9434 H3 scope, mostly Python-only):
  IIT-1, ICT-2, Probas-Pyro_RSA, Texte-19_OWUI, Sudoku-16, Search-11b, Search-11b-Part2.
  Sudoku-14-BDD {Python,Csharp} (both 25 min, non-H3 shortform `25 min`).
  
ACTIVE PRs in flight (out of my scope this round):
  PR #9698 my c.9683 (Search-1/2/3/10 + Search-10-Csharp),
  PR #9703 user-driven (Sudoku-7-Norvig-Csharp),
  PR #9695 user-driven (Search-9-LinProg-Csharp),
  PR #9700 user-driven (Audio 04-1),
  PR #9673 my c.951 (Tweety 1/2/7a/7b Python),
  PR #9670 user-driven (SW-13-Python-Reasoners).

## Compliance

- **L898 ★★★**: pre-worktree `gh pr list --search "Sudoku-2\|Planners-6\|..."` — 0 active PRs on these 8 paths (only the user-driven #9703 Sudoku-7).
- **L989 ★★★**: push via `git -c http.extraHeader=Authorization: Basic ...` (no `gh auth switch` global; use `gh auth token --user jsboige`).
- **C955-1 ★★★**: byte-level surgical slice, NEVER reserialize — 8 files, 0 insertions, 16 deletions atomic.
- **C962-1 ★★**: `git commit -F <scratchpad>` heredoc (single -F).
- **C9535-item3-6 ★★**: `Co-Authored-By: Claude-Code <noreply@anthropic.com>` trailer mandatory.
- **C967-1 ★★★**: preflight `git log --oneline HEAD vs origin/main` clean (0 commits ahead).
- **L677-L4 ★★**: PR body in scratchpad HORS worktree (no `git add .` contamination).
- **C9683-L1 ★★**: single-claim cell#0 slice pattern (drop trailing empties + Duree line + trailing empties).
- **C9683-L2 ★★**: `json.dumps` trailing newline re-append check applied (only 2/8 files lacked original trailing \n).
- **C9682-L1 ★★ + C9684-L1 ★★**: per-pair rebaseline on legit cell-source drift (NO `--yes-all-pairs`). Will apply AFTER first push when CI reveals specific pair names.
- **See #9434** (partial — 8/28+ remaining H3 claims drained; epic remains OPEN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
