### PR TITLE
feat(ml-training,#1454): fold-wise deployment protocol driver for DT-XRP

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_validate_xrp_dt_foldwise.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_validate_xrp_dt_foldwise.py
@@ -1,0 +1,163 @@
+"""Tests for validate_xrp_dt_foldwise.py -- pure-logic frame-slicing + aggregation.
+
+These cover the *protocol* logic of the fold-wise deployment driver (Epic
+#1454), not the DT training itself (which the real GPU sweep exercises):
+  - ``_quarter_after`` -- forward holdout window from an anchor (gap + 90d).
+  - ``_frame_for_window`` -- expanding vs sliding train-window slicing, the
+    place a leakage bug would hide (sliding must keep the holdout tail even
+    though it starts before the anchor).
+  - ``_summary_row`` -- cross-seed edge aggregation + sigma + DM p median.
+  - holdout-length guard -- an anchor whose 90d holdout runs past the data end
+    is skipped cleanly, not raised (the sweep must tolerate short last anchors).
+
+CPU-only, no torch import: the slicing helpers take a plain pandas frame and
+the aggregation helper takes plain dicts, so these run on any worker without a
+GPU and fast (<1s).
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Standalone script (sibling of tests/), not a package member.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from validate_xrp_dt_foldwise import (  # noqa: E402
+    GAP_DAYS,
+    HOLDOUT_DAYS,
+    _quarter_after,
+    _frame_for_window,
+    _summary_row,
+)
+
+
+def _frame(start="2020-01-01", end="2026-04-30", freq="D"):
+    """A synthetic OHLCV frame spanning the full XRP-ish date range."""
+    idx = pd.date_range(start, end, freq=freq)
+    n = len(idx)
+    rng = np.random.default_rng(0)
+    close = 1.0 + rng.standard_normal(n).cumsum() * 0.01 + np.arange(n) * 0.0005
+    return pd.DataFrame({
+        "Open": close, "High": close * 1.01, "Low": close * 0.99,
+        "Close": close, "Volume": rng.integers(1000, 100000, n).astype(float),
+    }, index=idx)
+
+
+class TestQuarterAfter:
+    def test_start_is_anchor_plus_gap(self):
+        start, end = _quarter_after("2025-06-30")
+        assert start == str((pd.Timestamp("2025-06-30")
+                             + pd.Timedelta(days=GAP_DAYS)).date())
+
+    def test_end_is_start_plus_holdout_days(self):
+        start, end = _quarter_after("2025-06-30")
+        gap = (pd.Timestamp(start) - pd.Timestamp("2025-06-30")).days
+        span = (pd.Timestamp(end) - pd.Timestamp(start)).days
+        assert gap == GAP_DAYS
+        assert span == HOLDOUT_DAYS
+
+    def test_no_overlap_with_train_anchor(self):
+        # The forward holdout must start strictly after the anchor (gap > 0).
+        for anchor in ["2024-06-30", "2025-12-31", "2026-03-31"]:
+            start, _ = _quarter_after(anchor)
+            assert pd.Timestamp(start) > pd.Timestamp(anchor)
+
+
+class TestFrameForWindow:
+    def test_expanding_keeps_all_history_up_to_holdout_end(self):
+        raw = _frame()
+        anchor = "2025-06-30"
+        _, holdout_end = _quarter_after(anchor)
+        frame = _frame_for_window(raw, anchor, "expanding")
+        # Expanding starts at the data start and ends at holdout_end.
+        assert frame.index.min() == raw.index.min()
+        assert frame.index.max() <= pd.Timestamp(holdout_end)
+        assert frame.index.max() == pd.Timestamp(holdout_end)
+
+    def test_sliding_drops_old_data_but_keeps_holdout_tail(self):
+        # THE leakage-guard test: a sliding window that drops everything older
+        # than (anchor - 3y) must STILL keep the forward holdout rows (they are
+        # AFTER the anchor), otherwise the eval frame is empty.
+        raw = _frame()
+        anchor = "2025-06-30"
+        _, holdout_end = _quarter_after(anchor)
+        frame = _frame_for_window(raw, anchor, "sliding")
+        assert frame.index.max() == pd.Timestamp(holdout_end)
+        # Old data (e.g. 2020) is dropped.
+        assert frame.index.min() >= pd.Timestamp("2022-01-01")
+
+    def test_sliding_keeps_approximately_three_years(self):
+        raw = _frame()
+        anchor = "2025-06-30"
+        frame = _frame_for_window(raw, anchor, "sliding")
+        # Train window anchor-3y .. anchor ; plus a lead for indicator warmup.
+        keep_from = pd.Timestamp(anchor) - pd.DateOffset(years=3) - pd.Timedelta(days=HOLDOUT_DAYS)
+        assert frame.index.min() <= pd.Timestamp(anchor) - pd.DateOffset(years=3)
+
+    def test_both_windows_end_at_holdout_end(self):
+        raw = _frame()
+        anchor = "2025-09-30"
+        _, holdout_end = _quarter_after(anchor)
+        for w in ("sliding", "expanding"):
+            frame = _frame_for_window(raw, anchor, w)
+            assert frame.index.max() == pd.Timestamp(holdout_end), \
+                f"window={w} did not end at holdout_end"
+
+    def test_anchor_near_data_end_frame_clipped(self):
+        # 2026-03-31 anchor + 90d holdout extends past the 2026-04-30 data end.
+        # The frame must clip to the available data (the holdout-length guard in
+        # _run_mode then skips this anchor, but _frame_for_window must not raise).
+        raw = _frame(end="2026-04-30")
+        anchor = "2026-03-31"
+        for w in ("sliding", "expanding"):
+            frame = _frame_for_window(raw, anchor, w)
+            assert frame.index.max() == raw.index.max()
+
+
+class TestSummaryRow:
+    def _seed(self, dt_net, bh, dm_p=None, elapsed=70.0):
+        dm = {"p_value": dm_p} if dm_p is not None else None
+        return {"dt_net_sharpe": dt_net, "bh_sharpe": bh,
+                "dm_dt_vs_bh": dm, "elapsed_s": elapsed}
+
+    def test_empty_returns_zero_n(self):
+        r = _summary_row([], "fresh/sliding")
+        assert r["n"] == 0
+
+    def test_edge_is_dt_minus_bh_mean(self):
+        per_seed = [self._seed(0.60, 0.40, dm_p=0.02),
+                    self._seed(0.64, 0.40, dm_p=0.03)]
+        r = _summary_row(per_seed, "fresh/sliding")
+        # mean edge = 0.62 - 0.40 = 0.22 -> 22 pp
+        assert r["edge_mean_pp"] == pytest.approx(22.0, abs=0.5)
+        assert r["dt_net_sharpe_mean"] == pytest.approx(0.62, abs=0.01)
+        assert r["bh_sharpe_mean"] == pytest.approx(0.40, abs=0.01)
+
+    def test_edge_sigma_zero_variance_is_none_or_large(self):
+        # All identical edges -> std=0 -> sigma huge (clamped division by 1e-12).
+        per_seed = [self._seed(0.50, 0.40) for _ in range(5)]
+        r = _summary_row(per_seed, "aged/expanding")
+        # edge_sigma is finite (1e-12 guard prevents ZeroDivision); sign positive.
+        assert r["edge_sigma"] is not None
+        assert r["edge_sigma"] > 0
+
+    def test_dm_p_median_aggregated(self):
+        per_seed = [self._seed(0.6, 0.4, dm_p=0.01),
+                    self._seed(0.6, 0.4, dm_p=0.20),
+                    self._seed(0.6, 0.4, dm_p=0.03)]
+        r = _summary_row(per_seed, "fresh/sliding")
+        assert r["dm_p_median"] == pytest.approx(0.03, abs=0.001)
+
+    def test_dm_p_none_when_all_missing(self):
+        per_seed = [self._seed(0.6, 0.4, dm_p=None)]
+        r = _summary_row(per_seed, "fresh/sliding")
+        assert r["dm_p_median"] is None
+
+    def test_mean_retrain_seconds(self):
+        per_seed = [self._seed(0.6, 0.4, elapsed=60.0),
+                    self._seed(0.6, 0.4, elapsed=80.0)]
+        r = _summary_row(per_seed, "fresh/sliding")
+        assert r["mean_retrain_s"] == pytest.approx(70.0, abs=0.1)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/validate_xrp_dt_foldwise.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/validate_xrp_dt_foldwise.py
@@ -1,0 +1,359 @@
+"""Fold-wise deployment protocol for the Decision Transformer on XRP (Epic #1454).
+
+This is the protocol script the holdout OOS (``validate_xrp_dt_holdout.py``,
+PR #9653) opened: the walk-forward BEATS@10bps did NOT survive model freezing
+(internal holdout = NO-BEATS, DT net -1.865 vs BH -0.592, 0/5 seeds). The edge
+comes from *re-training fold-wise* — so the operational question is no longer
+"does the model beat buy-and-hold?" but "**how often must we re-train, and at
+what window setting, before the freshly-retrained edge decays to zero?****
+
+Three questions, answered by one sweep over monthly/quarterly train anchors:
+
+  (1) **Cadence** (monthly vs quarterly): does the freshly-retrained edge hold
+      for one quarter of out-of-sample, or does it decay inside the quarter?
+  (2) **Sliding vs expanding window**: a fixed-width rolling train window
+      (drop old data as the anchor advances) vs an expanding window (keep all
+      history). Which preserves the edge better?
+  (3) **Decay curve + retraining cost**: edge of a *fresh* model (re-trained at
+      the anchor) vs an *aged* model (trained K months before the anchor, NOT
+      re-trained) — the slope of edge-vs-age tells you the re-training cadence
+      the strategy actually needs; the GPU-seconds/anchor tells you what it
+      costs.
+
+Building block. This script does NOT re-implement training: it loops the
+existing ``run_one_seed_holdout`` (train <= train_end, eval on a forward
+holdout, train-only normalisation, anti-leakage gap, net Sharpe post-TC, DM
+HAC test, >=4 seeds). What changes fold-to-fold is *which* data window is
+handed to ``run_one_seed_holdout`` (the ``raw`` frame) and the ``train_end`` /
+``holdout_start`` pair — never the training internals.
+
+Toy-scale on a laptop 3070 (8 GB). A single model (1 seed, 30 epochs) is
+~70 s on this GPU; the full sweep is sized so a worker can run it inside a
+session:
+
+    - anchors : quarterly (8 anchors, 2024-Q3 .. 2026-Q2)
+    - seeds   : 0/1/7/42/99 (shared with ai-01 for GPU-2 replication)
+    - windows : sliding (fixed 3-year rolling) + expanding (all history)
+    - modes   : fresh (re-train at each anchor) + aged-1q (train one quarter
+                before the anchor, do NOT re-train, eval at the anchor)
+
+Output: ``results/xrp_dt_validation/foldwise_<timestamp>.json`` plus a printed
+human-readable summary table (fresh vs aged, sliding vs expanding, decay
+slope, retraining cost).
+
+Usage
+-----
+    # toy-scale full sweep (GPU 0, ~45-60 min on a 3070)
+    CUDA_VISIBLE_DEVICES=0 python scripts/validate_xrp_dt_foldwise.py
+
+    # smoke (CPU synthetic, 2 anchors x 2 seeds x 2 epochs)
+    python scripts/validate_xrp_dt_foldwise.py --smoke
+
+Guardrails: train-only normalisation (anti-leakage), >=4 seeds, edge >= 2
+sigma cross-seed else INCONCLUSIVE, DM HAC Newey-West. No "promising".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+
+from validate_xrp_dt import COIN, CRYPTO_DIR, RESULTS_DIR, COMMISSION_BPS
+from validate_xrp_dt_holdout import run_one_seed_holdout
+from data_utils import compute_data_hash, load_data
+
+
+# Quarterly anchors covering the post-walk-forward data. The walk-forward run
+# of 2026-07-21 used folds up to ~2026-04, so anchors here run 2024-Q3 ->
+# 2026-Q2: each anchor's forward holdout (next quarter) is data the frozen
+# internal holdout already touched, but the *decay* signal (fresh vs aged) is
+# what we are measuring, not a contamination-free BEATS claim.
+QUARTERLY_ANCHORS = [
+    "2024-06-30", "2024-09-30", "2024-12-31",
+    "2025-03-31", "2025-06-30", "2025-09-30",
+    "2025-12-31", "2026-03-31",
+]
+# Forward holdout window per anchor = the quarter AFTER the anchor (3 months),
+# so the eval window moves with the anchor. ~63 trading days per quarter.
+HOLDOUT_DAYS = 90
+GAP_DAYS = 10              # anti-leakage gap (matches holdout script default)
+SLIDING_WINDOW_YEARS = 3   # fixed-width rolling train window
+
+
+def _quarter_after(anchor: str) -> str:
+    """holdout_start = anchor + GAP_DAYS (anti-leakage), holdout_end = +quarter."""
+    start = pd.Timestamp(anchor) + timedelta(days=GAP_DAYS)
+    end = start + timedelta(days=HOLDOUT_DAYS)
+    return str(start.date()), str(end.date())
+
+
+def _frame_for_window(raw: pd.DataFrame, anchor: str, window: str) -> pd.DataFrame:
+    """Slice ``raw`` to the train window requested, ending at the anchor.
+
+    ``expanding`` keeps the full history (truncated at the anchor + its forward
+    holdout, so the FeatureEngineer backward-only indicators still compute).
+    ``sliding`` keeps only the trailing ``SLIDING_WINDOW_YEARS`` years before
+    the anchor, plus the forward holdout needed to eval the anchor's quarter.
+    """
+    anchor_ts = pd.Timestamp(anchor)
+    holdout_start, holdout_end = _quarter_after(anchor)
+    end_ts = pd.Timestamp(holdout_end)
+    if window == "expanding":
+        return raw.loc[:end_ts]
+    # sliding: drop data older than (anchor - N years) but keep the holdout tail.
+    keep_from = anchor_ts - pd.DateOffset(years=SLIDING_WINDOW_YEARS)
+    # Keep a little lead so backward indicators at `keep_from` are warm.
+    keep_from -= timedelta(days=HOLDOUT_DAYS)
+    return raw.loc[(raw.index >= keep_from) & (raw.index <= end_ts)]
+
+
+def _run_mode(raw: pd.DataFrame, anchors, seeds, mode: str, window: str,
+              epochs: int, window_len: int, context_length: int, batch_size: int,
+              lr: float, d_model: int, nhead: int, num_layers: int, device: str,
+              commission_bps: int) -> dict:
+    """Run one (mode, window) combination across all anchors x seeds.
+
+    ``mode``:
+      - ``fresh``  : re-train at every anchor (train_end = anchor).
+      - ``aged-1q``: train one quarter BEFORE the anchor, do NOT re-train,
+                     eval on the anchor's forward quarter. This is the
+                     "deployed then left alone" scenario: the decay curve's
+                     first data point.
+    """
+    results = []
+    for anchor in anchors:
+        holdout_start, holdout_end = _quarter_after(anchor)
+        frame = _frame_for_window(raw, anchor, window)
+        if mode == "aged-1q":
+            # Train one quarter earlier; eval still on the anchor's forward q.
+            train_end = str((pd.Timestamp(anchor)
+                             - pd.DateOffset(months=3)).date())
+        else:  # fresh
+            train_end = anchor
+        # Guard: the frame must cover train_end and the full forward holdout.
+        # An anchor whose 90d holdout runs past the end of the data would make
+        # run_one_seed_holdout raise "holdout trop court"; skip it cleanly.
+        if frame.index.max() < pd.Timestamp(holdout_end):
+            print(f"  [{mode}/{window}] skip {anchor}: holdout_end {holdout_end} "
+                  f"past frame end ({frame.index.max().date()})")
+            continue
+        if frame.index.min() > pd.Timestamp(train_end):
+            print(f"  [{mode}/{window}] skip {anchor}: train_end {train_end} "
+                  f"before frame start ({frame.index.min().date()})")
+            continue
+
+        anchor_seed_sharpes = []
+        for seed in seeds:
+            t0 = time.time()
+            r = run_one_seed_holdout(
+                seed, frame, train_end, holdout_start, holdout_end,
+                epochs=epochs, window=window_len, context_length=context_length,
+                batch_size=batch_size, lr=lr, d_model=d_model, nhead=nhead,
+                num_layers=num_layers, device=device, commission_bps=commission_bps,
+            )
+            r["train_end"] = train_end
+            r["window"] = window
+            r["mode"] = mode
+            r["elapsed_s"] = round(time.time() - t0, 1)
+            results.append(r)
+            anchor_seed_sharpes.append(r["dt_net_sharpe"])
+        if anchor_seed_sharpes:
+            arr = np.array(anchor_seed_sharpes)
+            print(f"  [{mode}/{window}] {anchor}: DT net {arr.mean():+.3f} "
+                  f"(+/- {arr.std(ddof=1):.3f}) n={len(arr)} | "
+                  f"retrain~{np.mean([x['elapsed_s'] for x in results[-len(arr):]]):.0f}s/seed",
+                  flush=True)
+    return {"mode": mode, "window": window, "per_seed": results}
+
+
+def _summary_row(per_seed: list, label: str) -> dict:
+    """Aggregate cross-seed metrics for one (mode, window) bucket."""
+    if not per_seed:
+        return {"label": label, "n": 0}
+    nets = np.array([r["dt_net_sharpe"] for r in per_seed])
+    bhs = np.array([r["bh_sharpe"] for r in per_seed])
+    edge = nets - bhs
+    # DM p-values where present
+    dm_ps = [r["dm_dt_vs_bh"]["p_value"] for r in per_seed
+             if r.get("dm_dt_vs_bh") and "p_value" in r["dm_dt_vs_bh"]]
+    return {
+        "label": label,
+        "n_models": len(per_seed),
+        "dt_net_sharpe_mean": round(float(nets.mean()), 4),
+        "dt_net_sharpe_std": round(float(nets.std(ddof=1)), 4) if len(nets) > 1 else None,
+        "bh_sharpe_mean": round(float(bhs.mean()), 4),
+        "edge_mean_pp": round(float(edge.mean()) * 100, 2),
+        "edge_sigma": round(float(edge.mean() / (edge.std(ddof=1) + 1e-12)), 2)
+                      if len(edge) > 1 else None,
+        "dm_p_median": float(np.median(dm_ps)) if dm_ps else None,
+        "mean_retrain_s": round(float(np.mean([r["elapsed_s"] for r in per_seed])), 1),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--smoke", action="store_true",
+                        help="CPU synthetic sanity (2 anchors x 2 seeds x 2 epochs)")
+    parser.add_argument("--anchors", nargs="+", default=None,
+                        help="train_end anchors (default: quarterly set)")
+    parser.add_argument("--seeds", nargs="+", type=int, default=[0, 1, 7, 42, 99])
+    parser.add_argument("--epochs", type=int, default=30)
+    parser.add_argument("--d-model", type=int, default=128)
+    parser.add_argument("--nhead", type=int, default=4)
+    parser.add_argument("--num-layers", type=int, default=3)
+    parser.add_argument("--context-length", type=int, default=20)
+    parser.add_argument("--window", type=int, default=20)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--device", default=None)
+    parser.add_argument("--commission-bps", type=int, default=COMMISSION_BPS)
+    parser.add_argument("--modes", nargs="+",
+                        default=["fresh", "aged-1q"],
+                        choices=["fresh", "aged-1q"],
+                        help="Which deployment scenarios to sweep")
+    parser.add_argument("--windows", nargs="+",
+                        default=["sliding", "expanding"],
+                        choices=["sliding", "expanding"],
+                        help="Train window strategy")
+    args = parser.parse_args()
+
+    if args.smoke:
+        args.seeds = args.seeds[:2]
+        args.epochs = 2
+        device = "cpu"
+    else:
+        args.anchors = args.anchors or QUARTERLY_ANCHORS
+        device = args.device or ("cuda" if torch.cuda.is_available() else "cpu")
+
+    if args.smoke:
+        from data_utils import generate_synthetic_data
+        raw = generate_synthetic_data(1500)
+        if not isinstance(raw.index, pd.DatetimeIndex):
+            raw.index = pd.date_range("2018-01-01", periods=len(raw), freq="D")
+        data_hash = "synthetic-smoke"
+        # Derive smoke anchors from the synthetic frame so frame slicing stays
+        # in-range (the default quarterly anchors point at real 2024-2026 dates,
+        # which are outside synthetic data).
+        last = raw.index.max()
+        args.anchors = [
+            str((last - pd.DateOffset(months=6)).date()),
+            str((last - pd.DateOffset(months=3)).date()),
+        ]
+    else:
+        raw = load_data(CRYPTO_DIR, COIN)
+        data_hash = compute_data_hash(raw)
+
+    out_dir = RESULTS_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    print(f"=== XRP DT fold-wise deployment protocol (#1454) ===")
+    print(f"Date: {datetime.now().isoformat()} | device: {device} | smoke: {args.smoke}")
+    print(f"Data: {len(raw)} rows [{raw.index.min().date()} .. {raw.index.max().date()}] "
+          f"hash={data_hash[:12]}")
+    print(f"Anchors ({len(args.anchors)}): {args.anchors}")
+    print(f"Modes: {args.modes} | Windows: {args.windows}")
+    print(f"TC: {args.commission_bps} bps | seeds: {args.seeds} | epochs: {args.epochs}")
+    print(f"Forward holdout/anchor: {HOLDOUT_DAYS}d (+{GAP_DAYS}d gap) | "
+          f"sliding window: {SLIDING_WINDOW_YEARS}y")
+    print()
+
+    sweep = {}
+    t_sweep_start = time.time()
+    for window in args.windows:
+        for mode in args.modes:
+            key = f"{mode}/{window}"
+            print(f"--- {key} ---", flush=True)
+            sweep[key] = _run_mode(
+                raw, args.anchors, args.seeds, mode, window,
+                epochs=args.epochs, window_len=args.window,
+                context_length=args.context_length, batch_size=args.batch_size,
+                lr=args.lr, d_model=args.d_model, nhead=args.nhead,
+                num_layers=args.num_layers, device=device,
+                commission_bps=args.commission_bps,
+            )
+    sweep_elapsed = time.time() - t_sweep_start
+
+    # Aggregate per (mode, window) bucket.
+    summary_rows = []
+    for key, bucket in sweep.items():
+        summary_rows.append(_summary_row(bucket["per_seed"], key))
+
+    # Decay signal: fresh vs aged-1q, for each window (the cadence answer).
+    decay = {}
+    for window in args.windows:
+        if "fresh" in args.modes and "aged-1q" in args.modes:
+            f = _summary_row(sweep[f"fresh/{window}"]["per_seed"], f"fresh/{window}")
+            a = _summary_row(sweep[f"aged-1q/{window}"]["per_seed"], f"aged-1q/{window}")
+            if f.get("n_models") and a.get("n_models"):
+                decay[window] = {
+                    "fresh_edge_pp": f["edge_mean_pp"],
+                    "aged1q_edge_pp": a["edge_mean_pp"],
+                    "decay_pp_per_quarter": round(f["edge_mean_pp"] - a["edge_mean_pp"], 2),
+                }
+
+    summary = {
+        "timestamp": ts, "coin": COIN, "device": device, "smoke": args.smoke,
+        "data_hash": data_hash,
+        "config": {
+            "anchors": args.anchors, "seeds": args.seeds, "epochs": args.epochs,
+            "modes": args.modes, "windows": args.windows,
+            "holdout_days": HOLDOUT_DAYS, "gap_days": GAP_DAYS,
+            "sliding_window_years": SLIDING_WINDOW_YEARS,
+            "commission_bps": args.commission_bps,
+            "d_model": args.d_model, "window": args.window,
+            "context_length": args.context_length,
+        },
+        "sweep_elapsed_s": round(sweep_elapsed, 1),
+        "summary_by_bucket": summary_rows,
+        "decay_fresh_vs_aged1q": decay,
+        "sweep": sweep,
+    }
+    out_path = out_dir / f"foldwise_{ts}.json"
+    out_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    print()
+    print("=" * 78)
+    print("FOLD-WISE DEPLOYMENT PROTOCOL — summary")
+    print("=" * 78)
+    print(f"{'mode/window':<22}{'n':>4}{'DTnet':>9}{'BH':>8}{'edge_pp':>9}"
+          f"{'edge_sig':>9}{'DMp':>7}{'retrain_s':>10}")
+    print("-" * 78)
+    for r in summary_rows:
+        if not r.get("n_models"):
+            print(f"{r['label']:<22}{'-':>4}  (no models)")
+            continue
+        print(f"{r['label']:<22}{r['n_models']:>4}{r['dt_net_sharpe_mean']:>9.3f}"
+              f"{r['bh_sharpe_mean']:>8.3f}{r['edge_mean_pp']:>9.2f}"
+              f"{str(r['edge_sigma']):>9}{str(r['dm_p_median']):>7}"
+              f"{r['mean_retrain_s']:>10.0f}")
+    if decay:
+        print("-" * 78)
+        print("DECAY (fresh retrain vs aged-1q frozen): edge lost per quarter frozen")
+        for w, d in decay.items():
+            print(f"  {w:<12} fresh {d['fresh_edge_pp']:+.2f}pp -> aged-1q "
+                  f"{d['aged1q_edge_pp']:+.2f}pp  |  "
+                  f"decay = {d['decay_pp_per_quarter']:+.2f} pp/quarter")
+    print("-" * 78)
+    print(f"sweep elapsed: {sweep_elapsed/60:.1f} min | -> {out_path}")
+    print()
+    print("Interpretation key:")
+    print("  * edge_mean_pp > 0 with edge_sigma >= 2 and DMp < 0.05 => the mode")
+    print("    holds out-of-sample; the cadence is defensible.")
+    print("  * decay_pp_per_quarter is the COST of NOT re-training: if it is large")
+    print("    and positive, quarterly (or finer) re-training is required; if it is")
+    print("    ~0, a frozen model is fine and re-training cost is wasted.")
+    print("  * This sweep does NOT claim BEATS/NO-BEATS on unseen data (the frozen")
+    print("    internal holdout already answered that = NO-BEATS). It quantifies")
+    print("    the decay + cost of the fold-wise re-training the edge depends on.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Grain: DEEP/training — lane myia-po-2024:CoursIA — prev: MED/docs #9697 (c.771)

## Summary

Implements the **fold-wise deployment protocol** for the Decision Transformer on XRP — the operational question the holdout OOS (`validate_xrp_dt_holdout.py`, #9653) opened. The walk-forward BEATS@10bps did NOT survive model freezing (internal holdout = NO-BEATS, DT net -1.865 vs BH -0.592, 0/5 seeds), so the edge comes from *re-training fold-wise*. The question is no longer "does the model beat buy-and-hold?" but **how often must we re-train, and at what window setting, before the freshly-retrained edge decays to zero?**

This is the P0 dispatch from ai-01 (msg-20260806T083359) — toy-scale protocol on po-2024's 3070, config shared for ai-01 GPU-2 4090 full-scale replication.

## Design — one sweep, three deployment questions

`validate_xrp_dt_foldwise.py` loops the existing `run_one_seed_holdout` building block (train ≤ train_end, eval on forward holdout, train-only normalisation, anti-leakage gap, net Sharpe post-TC, DM HAC test, ≥4 seeds) over a sweep that answers three questions at once:

| Question | How the sweep answers it |
|----------|--------------------------|
| **(1) Cadence** | edge of a **fresh** model (re-trained at each quarterly anchor) vs an **aged-1q** model (trained one quarter before, NOT re-trained). The slope of edge-vs-age = the re-training cadence the strategy needs. |
| **(2) Sliding vs expanding window** | fixed 3-year rolling train window vs all-history expanding — which preserves the edge? |
| **(3) Retraining cost** | GPU-seconds/anchor measured, so the decay-vs-cost trade-off is explicit. |

**Toy-scale** (laptop 3070, ~36 s/seed): 8 quarterly anchors (2024-Q3..2026-Q2) × 5 seeds (0/1/7/42/99) × 2 modes (fresh/aged-1q) × 2 windows (sliding/expanding) = 160 models, ~96 min. The driver does NOT claim BEATS/NO-BEATS on unseen data (the frozen internal holdout already answered that = NO-BEATS); it quantifies the decay + cost of the fold-wise re-training the edge depends on.

## What was validated this cycle

- **Smoke CPU (synthetic data)**: full driver pipeline runs end-to-end, all 4 buckets complete, decay-curve aggregation prints, holdout-length guard skips short last anchor cleanly.
- **14 CPU unit tests** (`test_validate_xrp_dt_foldwise.py`, all green): `_quarter_after` (forward holdout = anchor + gap + 90d), `_frame_for_window` (expanding vs sliding — **incl. the leakage guard** that a sliding window must still keep the forward-holdout tail, else the eval frame is empty), `_summary_row` (edge = dt − bh, sigma, DM p median, retrain seconds), holdout-length guard.
- **Collection regression**: sibling suite 1023 tests collected (1009 prior + 14 new), 0 errors.
- **GPU timing calibrated**: 1 seed/30 epochs = ~36 s on the 3070 → sweep sized to fit a session.

## Honesty on scope

The full GPU sweep (~96 min) is **still running** at PR-open time (3/32 anchors done when this PR was pushed — fresh/sliding anchors 2024-06/09/12 complete with realistic cross-quarter variance). The protocol driver + its test battery are complete and validated; the **real decay-curve numbers will follow** (sweep runs to completion in the background; results land in `results/xrp_dt_validation/foldwise_<ts>.json`, gitignored). I will post the actual fresh-vs-aged decay + sliding-vs-expanding verdict as a PR comment or a follow-up commit once the sweep finishes — not as an unverified claim in this body.

## Rule F note (SOTA, not workaround)

The default `python3` on this machine is a CPU-only torch build (`2.11.0+cpu`); training fell back to CPU. Fixed per rule F by running via the `coursia-ml-training` conda env (`torch 2.6.0+cu124`, CUDA available, sees the 3070) — not by skipping GPU or faking results.

See #1454
