### PR TITLE
fix(genai,#9434): drain GPT-5 Image-Gen 3 runtime dups (7.76s/19.14s/25.73s)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb
@@ -1837,7 +1837,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "GPT-5 image generation (via OpenRouter) incarne l'approche **multimodale native** : le modèle ne se contente pas de générer des images à partir d'un prompt texte, il analyse et produit dans un même flux, ce qui ouvre trois modes d'usage pédagogique distincts — quick (206 chars, 7.76s), detailed (2606 chars, 19.14s), educational (2908 chars, 25.73s). Le ratio coût d'inférence / richesse du contenu est directement exposé à l'utilisateur par le choix du mode.\n",
+    "GPT-5 image generation (via OpenRouter) incarne l'approche **multimodale native** : le modèle ne se contente pas de générer des images à partir d'un prompt texte, il analyse et produit dans un même flux, ce qui ouvre trois modes d'usage pédagogique distincts — quick (206 chars), detailed (2606 chars), educational (2908 chars). Le ratio coût d'inférence / richesse du contenu est directement exposé à l'utilisateur par le choix du mode.\n",
     "\n",
     "**Apport spécifique de la multimodalité native** : la génération automatique d'alt text (114 chars optimal, sous le seuil 125 chars des référentiels d'accessibilité WCAG) intègre la description d'image comme **livrable de première classe**, pas comme un post-traitement optionnel. Pour les 5 cas d'usage éducatif couverts (Histoire, Sciences, Géographie, Art et Culture, Médecine), c'est un gain d'accessibilité substantiel par rapport aux modèles purement text-to-image.\n",
     "\n",


### PR DESCRIPTION
Grain: DRAINAGE/9434-timing -- lane myia-po-2023:CoursIA -- prev: DRAINAGE/9434-timing #9703

Cell 29 markdown dupliquait 3 runtimes API image-generation EXACTS de l output code cell14. Drain le plus légitime (G.1 firsthand, runtime machine-dep).

| Md cell29 | Code cell14 output |
|---|---|
| quick (206 chars, 7.76s) vers (206 chars) | Temps: 7.76s |
| detailed (2606 chars, 19.14s) vers (2606 chars) | Temps: 19.14s |
| educational (2908 chars, 25.73s) vers (2908 chars) | Temps: 25.73s |

Runtimes machine-dep (latence API OpenRouter, varient a chaque appel). Preserve : char-counts deterministes (206/2606/2908), labels mode.

Preuves : diff 1+/1- byte-level, code-source invariant OK (hash code-cells AVANT==APRES), markdown-only (#9434 + C.2 exception), non twin-registre (pas de rebaseline). Famille fraiche (GenAI/Image) rotation R6.6.

See #9434.

Generated with Claude Code (https://claude.com/claude-code)