### PR TITLE
fix(genai,#9434): drain 2 wall-clock claims from 04-3-Music-Composition-Workflow (LIGHT, audio 04-applications music composition)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-3-Music-Composition-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-3-Music-Composition-Workflow.ipynb
@@ -538,7 +538,7 @@
     "\n",
     "| Aspect | Valeur | Signification |\n",
     "|--------|--------|---------------|\n",
-    "| Temps de generation | ~2-5s par section (small) | Rapide même pour de la musique complexe |\n",
+    "| Temps de generation | *runtime *machine-dep* : ~2-5s par section (small) | Rapide même pour de la musique complexe |\n",
     "| Qualite | 32kHz mono | Suffisante pour prototypage, pas pour production finale |\n",
     "| Contrôle | Via le prompt textuel | Le style depend fortement de la description |\n",
     "\n",
@@ -713,7 +713,7 @@
     "- **htdemucs_ft** : Version fine-tuned, meilleure qualite\n",
     "- **mdx_extra** : Modèle MDX, specialise pour certains types de musique\n",
     "\n",
-    "La separation prend environ 10-30 secondes pour 8 secondes d'audio sur GPU, selon le modèle."
+    "La separation prend environ *runtime *machine-dep* : 10-30 secondes pour 8 secondes d'audio sur GPU, selon le modèle."
    ]
   },
   {


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2024:CoursIA-2 — prev: LIGHT/notebook-python #9706 (c.1323 03-3-Realtime-Voice-API)

Refs #9434

# fix(genai,#9434): drain 2 wall-clock claims from 04-3-Music-Composition-Workflow (LIGHT, audio 04-applications music composition)

## Summary

Surgical markdown-only drainage on `MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-3-Music-Composition-Workflow.ipynb` — **2 insertions, 2 deletions, 1 file**. 2 préfixes `runtime *machine-dep*` injectés sur 2 cellules (cell[11] + cell[14]) — zero cellule code touchée, 16/16 code cells execution_count préservés.

Sub-family GenAI/Audio **04-Applications** Music Composition Workflow (2ᵉ entrée 04-Applications après c.1321 04-1-Educational-Audio-Content), pipeline intégré MusicGen + Demucs + pydub + scipy pour composition musicale multi-sections. Workflow appliqué : génération MusicGen → séparation Demucs → remix stems → effets audio (reverb, EQ, delay) → assemblage multi-sections (crossfade 500ms, fade in/out). **38ᵉ réutilisation archétype 6ᵉ #9434**.

## Cells drained (2 cells, 2 préfixes)

| Cell | Row drained | Rationale §D.5 |
|------|-------------|----------------|
| **cell[11]** (Interpretation : Generation MusicGen) | `\| Temps de generation \| ~2-5s par section (small) \| Rapide même pour de la musique complexe \|` → préfixe | axe a wall-clock LOCAL inference MusicGen DRAINABLE — **`Qualite \| 32kHz mono` axe c quality + `Contrôle \| Via le prompt textuel` axe c feature préservés verbatim** |
| **cell[14]** (Preparation de la separation) | `La separation prend environ 10-30 secondes pour 8 secondes d'audio sur GPU, selon le modèle.` → préfixe | axe a LOCAL GPU inference Demucs DRAINABLE — **`htdemucs/htdemucs_ft/mdx_extra` modèles architecture axe c + `8 secondes d'audio` audio input metadata axe c + ratio `10-30s pour 8s = 1.25-3.75x real-time` COMPUTED HORS scope préservés verbatim** |

**Total** : 2 préfixes `runtime *machine-dep*` insérés sur 2 lignes.

## Litmus §D.5 — 4 catégories timings (canonique)

1. **Wall-clock LOCAL inference latency** (axe a env+GPU/CPU) — **DRAINABLE**
   - cell[11] `~2-5s par section (small)` MusicGen generation latency drainée
   - cell[14] `10-30 secondes pour 8 secondes d'audio sur GPU` Demucs separation latency drainée

2. **Audio duration** (axe c moteur upstream déterministe) — **NOT drainable**
   - cell[0] `Duree estimee : 60 minutes` pedagogique
   - cell[8] `Duree max | 30s` MusicGen output max structurel (axe c moteur)
   - cell[8] `30s` musicgen-small/medium/large max duration paramètre
   - cell[8] `VRAM | ~4 GB / ~8 GB / ~14 GB` specs (axe c architecture)
   - cell[11] `32kHz mono` qualite audio sample rate (axe c structurel)
   - cell[14] `8 secondes d'audio` audio input metadata (axe c)
   - cell[26] `Duree estimee : 20-25 minutes` pedagogique exercice
   - cell[42] `Duree estimee : 35-40 minutes` pedagogique exemple guide
   - cell[24] `Reverb | decay=0.4, delay=50ms` paramètres effet (axe c)
   - cell[28] `Intro | 4-8s | Couplet | 8-16s | Refrain | 8-16s | Outro | 4-8s` structure musicale (axe c)
   - cell[31] `Crossfade (500ms) | Fade in/out` paramètres transition (axe c)
   - cell[33] `Crossfade | 500ms | Fade in/out | 500ms | Normalisation | -0.5 dBFS (0.95)` (axe c)
   - cell[42] `crossfades de 500ms entre les sections` indices exercice (axe c)

3. **Ratio structurel COMPUTED** (axe c computed) — **HORS scope** (c.1308-L3 ★ RTF / c.1312-L3 ★ ratio / c.1319-L3 ★ RTF / c.1322-L3 ★ RTF / c.1323-L3 ★ chunk count analogues)
   - cell[14] ratio `10-30 secondes pour 8 secondes d'audio sur GPU` = `gen_time × duration_ratio` COMPUTED, propriété intrinsèque conservée verbatim
   - cell[11] `~2-5s par section (small)` génération = `time_per_output_section` ratio partial, COMPUTED HORS scope préservé verbatim
   - cell[14] `selon le modèle` = variante structurelle par modèle Demucs (mdx_extra vs htdemucs_ft)

4. **Chargement modèle / distribution** (axe a init time) — DRAINABLE part
   - Aucun claim runtime dans cette catégorie sur ce notebook

## Invariants préservés verbatim (15+)

- cell[0] `Duree estimee : 60 minutes` pedagogique axe c
- cell[8] `musicgen-small 300M ~4 GB Correcte 30s` / `musicgen-medium 1.5B ~8 GB Bonne 30s` / `musicgen-large 3.3B ~14 GB Excellente 30s` specs axe c architecture
- cell[8] `Duree max | 30s` paramètre moteur MusicGen axe c structurel
- cell[11] `Qualite | 32kHz mono | Suffisante pour prototypage, pas pour production finale` axe c quality
- cell[11] `Contrôle | Via le prompt textuel | Le style depend fortement de la description` axe c feature
- cell[14] `La separation de stems est une technologie qui permet d'isoler les différents éléments d'un mix audio.` pedagogique axe c
- cell[14] `htdemucs / htdemucs_ft / mdx_extra` modèles Demucs architecture axe c
- cell[14] `8 secondes d'audio` audio input metadata axe c
- cell[14] ratio `10-30 secondes pour 8 secondes d'audio sur GPU` COMPUTED HORS scope préservé verbatim
- cell[14] `selon le modèle` variante structurelle par modèle axe c
- cell[26] `Duree estimee : 20-25 minutes` pedagogique exercice axe c
- cell[42] `Duree estimee : 35-40 minutes` pedagogique exemple guide axe c
- cell[8] `VRAM | ~4 GB / ~8 GB / ~14 GB` specs axe c architecture
- cell[11] `Rapide même pour de la musique complexe` significance column axe c pédagogique
- cell[11] `Le modèle large offre une qualite significativement superieure au small` axe c feature

## Acceptance

- [x] Validateur `validate_pr_notebooks.py` PASS (notebook tagged `runtime *machine-dep*` ≠ cellule code avec `severity:error`)
- [x] Aucune cellule code touchée (16/16 execution_count préservés, 16/16 outputs préservés)
- [x] Pas de ré-exécution kernel (markdown-only, scope strict)
- [x] Diff = **2 insertions, 2 deletions, 1 file** — purely surgical

## Tells archétypaux c.1324 spécifiques

- **c.1324-L1 ★** : **04-3 / 04-Applications Music Composition Workflow** — sub-family GenAI/Audio **04-Applications** = pipeline intégré MusicGen + Demucs + pydub + scipy pour composition musicale multi-sections (intro 4-8s + couplet 8-16s + refrain 8-16s + outro 4-8s, crossfade 500ms). **2ᵉ entrée 04-Applications** après c.1321 04-1-Educational-Audio-Content (Educational content pipeline intégré 6-étapes LLM→TTS→Whisper round-trip). **DISTINCTION** vs c.1321 = (a) composition musicale multi-stems (MusicGen + Demucs source separation) vs (b) educational content narration (LLM markers + multi-voix TTS) ; (c) **`Duree max 30s`** MusicGen output max structurel vs **`round-trip >95%` similarité** Whisper validation. Tell distinctif = `musicgen-large 3.3B ~14 GB` (axe c architecture) + `htdemucs/htdemucs_ft/mdx_extra` 3 variantes Demucs (axe c architecture) + `4-8s/8-16s/4-8s` structure composition standard (axe c pédagogique).
- **c.1324-L2 ★** : **Wall-clock claims dans NOT standalone mais applications notebook** — c.1312 (Demucs standalone 02-4-Demucs-Source-Separation) a déjà drainé Demucs wall-clock (`Temps de separation | 3.35s (observe, 10s d'audio) | ~3x real-time sur GPU`) + c.1315 (MusicGen standalone 02-3-MusicGen-Generation) a drainé MusicGen wall-clock. **c.1324 draine les MÊMES claims ré-utilisés dans un notebook d'application** = la pathologie #9434 se manifeste AUSSI au niveau intégration, pas seulement au niveau standalone. Ratio `10-30s / 8s = 1.25-3.75x real-time` analogue au ratio `~3x real-time` c.1312 (Demucs standalone) — cohérence cross-notebook.
- **c.1324-L3 ★** : **Ratios structurels COMPUTED HORS scope cohérents** — `10-30 secondes pour 8 secondes d'audio sur GPU` = ratio COMPUTED HORS scope analogue c.1308-L3 ★ RTF Kokoro + c.1312-L3 ★ Demucs `~3x real-time` + c.1319-L3 ★ XTTS RTF `2-5x GPU` + c.1320-L3 ★ gateway RTF `8-10x/4-5x/~1x`. Pattern reproductible : `wall-clock claim + audio duration` → ratio COMPUTED stable → HORS scope préservé verbatim.
- **c.1324-L4 ★** : **Pipeline intégré audio MULTI-ÉTAPES** — c.1324 illustre le pattern « pipeline audio multi-étapes » complémentaire au c.1321 (Educational content pipeline LLM→TTS→Whisper round-trip) et c.1322 (Multi-Model Audio Comparison benchmark framework). 3 entrées 04-Applications anticipées par famille pipeline pédagogique : (a) educational content c.1321, (b) music composition c.1324, (c) autres (TTS-Voice-Benchmark, LiveCoding-LLM-Music, Audiobook-Pipeline) à drainer ensuite. Tell distinctif = **sub-family rotation R6** : c.1321 04-1 → c.1322 03-1 (cross) → c.1323 03-3 (close 03) → **c.1324 04-3** (retour 04).

## Lessons c.1324-L1..L4

- **c.1324-L1 ★** : 04-Applications Music Composition Workflow = pipeline intégré MusicGen + Demucs + pydub + scipy, 2ᵉ entrée 04-Applications post-c.1321 Educational content. Sub-family rotation R6 active : c.1321 04 → c.1322 03-1 (cross) → c.1323 03-3 (close 03) → c.1324 04-3.
- **c.1324-L2 ★** : Wall-clock claims apparaissent AUSSI au niveau intégration (04-3 utilise MusicGen + Demucs comme building blocks) — la pathologie #9434 n'est pas confinée aux notebooks standalone. Pattern reproductible : standalone drain c.1312/c.1315 + applications drain c.1324 = cohérence cross-notebook.
- **c.1324-L3 ★** : Ratios COMPUTED HORS scope cohérents (`10-30s pour 8s audio = 1.25-3.75x real-time`) = extension pattern c.1308-L3 / c.1312-L3 / c.1319-L3 / c.1320-L3. `wall-clock claim + audio duration` → ratio COMPUTED stable → HORS scope préservé verbatim.
- **c.1324-L4 ★** : Pipeline intégré audio MULTI-ÉTAPES pattern pédagogique : (a) educational content c.1321 LLM→TTS→Whisper, (b) music composition c.1324 MusicGen→Demucs→pydub, (c) autres à drainer (TTS-Voice-Benchmark, LiveCoding-LLM-Music, Audiobook-Pipeline). 3 entrées 04-Applications anticipées.

## Cross-references #9434 vein (GenAI/Audio)

| Grain | Sub-family | PR | Statut | Tells |
|-------|-----------|-----|--------|-------|
| c.1303 | Audio orchestration (multi-call HTTP) | #9661 | OPEN | multi-call LLM+TTS+STT+retries+pauses |
| c.1306-c.1310 | Audio foundation 5× (STT/TTS HTTP+LOCAL matrice 2×2) | #9671/9675/9676/9678/9680 | OPEN | CHARGEMENT vs INFERENCE + RTF |
| c.1312-c.1320 | Audio advanced 8× (Demucs/SongGen/MusicGen/Expressive/AceStep/MIDI/XTTS/TTS-Gateway) | #9684-#9694 | OPEN | 8 sub-family nouveaux distincts |
| c.1321 | Audio 04-Applications educational content | #9700 | OPEN | pipeline intégré 6-étapes + multi-voix nova/onyx + 1ère entrée 04-Applications |
| c.1322 | Audio 03-Orchestration multi-model benchmark | #9704 | OPEN | benchmark framework pédagogique + matrice 2×2 STT + matrice 3-modèle TTS |
| c.1323 | Audio 03-Orchestration realtime voice API | #9706 | OPEN | WebSocket Realtime unifié + VAD server-side + barge-in + tool calling intégré + cost analysis 6-15x |
| **c.1324** | **Audio 04-Applications music composition workflow** | **#XXXX** | **OPEN** | **pipeline intégré MusicGen + Demucs + pydub + scipy + structure composition multi-sections + 2 wall-clock claims drainés (cell[11] MusicGen `~2-5s/section` + cell[14] Demucs `10-30s/8s audio GPU`)** |

## Diagnostic §D.5

**Verdict** : `CAUSE_FIXED` — option alpha appliquée (préserver invariants structurels + drainer claims runtime machine-dep). Cause racine = prose pédagogique cite wall-clock concrets (MusicGen `~2-5s par section (small)` + Demucs `10-30 secondes pour 8 secondes d'audio sur GPU, selon le modèle`) sans marquer leur dépendance à la machine d'exécution + connectivité réseau + charge GPU serveur + modèle sélectionné (small/medium/large MusicGen + htdemucs/htdemucs_ft/mdx_extra Demucs). Fix = préfixer par `runtime *machine-dep* :` sans modifier la valeur numérique. Pas de ré-alignement, pas de ré-exécution kernel (markdown-only).

## Validation per CLAUDE.md §B.5 + notebook-conventions C.1/C.2

| Check | Statut |
|-------|--------|
| Scope réel (Refs #9434 partiel) | ✅ claim = scope = diff |
| `git diff --stat` cohérent | ✅ 1 file, +2/-2 |
| Cellules code = `execution_count: <int>` + outputs cohérents | ✅ 16/16 préservés (1, 2, 3, 4, 5, 6, 1, 7, 8, 1, 14, 9, 10, 11, 12, 13) |
| 0 cellule `# Solution` / `# Exemple résolu` supprimée | ✅ (aucune touchée) |
| Stop & Repair règle 6 | ✅ cause = marqueur manquant, pas erreur à corriger |
| CR/LF/BOM preserved | ✅ LF-only + final LF preserved |
| JSON validity | ✅ `json.load` parse OK + 47 cells + 16 code cells intacts |
| C955-1 ★★★ surgical edit | ✅ metadata/texte uniquement |

Refs #9434

🤖 Generated with [Claude Code](https://claude.com/claude-code)