### PR TITLE
fix(genai,#9434): drain 3 wall-clock claims from 04-11-Generation-TTS (LIGHT, audio 04-applications generation TTS)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-11-Generation-TTS.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-11-Generation-TTS.ipynb
@@ -126,9 +126,9 @@
     "\n",
     "| Modèle | Statut | Qualite | Latence | Expressivite |\n",
     "|--------|--------|---------|---------|-------------|\n",
-    "| **Kokoro** (local Docker) | Actif | Bonne | <2s | Tags base (speed, emotion) |\n",
-    "| **FishAudio S2-Pro** | Non deploye | Excellente | ~3s | 15000+ tags expressifs |\n",
-    "| **OpenAI TTS-1** | Cloud | Bonne | ~2s | 6 voix fixes |\n",
+    "| **Kokoro** (local Docker) | Actif | Bonne | *runtime *machine-dep* : <2s | Tags base (speed, emotion) |\n",
+    "| **FishAudio S2-Pro** | Non deploye | Excellente | *runtime *machine-dep* : ~3s | 15000+ tags expressifs |\n",
+    "| **OpenAI TTS-1** | Cloud | Bonne | *runtime *machine-dep* : ~2s | 6 voix fixes |\n",
     "\n",
     "Ce notebook utilise **Kokoro** pour la demo locale. Les tags expressifs FishAudio sont conserves dans les metadonnees pour generation production ultérieure."
    ]


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2024:CoursIA-2 — prev: LIGHT/notebook-python #9710 (c.1324 04-3-Music-Composition-Workflow)

Refs #9434

# fix(genai,#9434): drain 3 wall-clock claims from 04-11-Generation-TTS (LIGHT, audio 04-applications generation TTS)

## Summary

Surgical markdown-only drainage on `MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-11-Generation-TTS.ipynb` — **3 insertions, 3 deletions, 1 file**. 3 préfixes `runtime *machine-dep*` injectés sur 1 cellule (cell[2] tableau Architecture TTS) — zero cellule code touchée, 19/19 code cells execution_count préservés.

Sub-family GenAI/Audio **04-Applications** Generation TTS (3ᵉ entrée 04-Applications après c.1321 04-1-Educational-Audio-Content + c.1324 04-3-Music-Composition-Workflow), pipeline de generation TTS Kokoro (LOCAL Docker demo) + FishAudio S2-Pro (PRODUCTION HTTP GPU1 RTX 3090) + OpenAI TTS-1 (CLOUD) pour audiobook multi-voix. Comparaison latence 3-modèle pédagogique.

**CONFIRMATION** pathologie #9434 au niveau intégration (c.1324-L2) : Kokoro/FishAudio/OpenAI claims drainés au niveau standalone (c.1308 Kokoro + c.1316 Expressive TTS FishAudio + c.1307 OpenAI TTS) → RE-réutilisés ici dans le tableau de comparaison architecture. **3ᵉ entrée 04-Applications** confirme densité de la sous-famille. **39ᵉ réutilisation archétype 6ᵉ #9434**.

## Cells drained (1 cell, 3 préfixes)

| Cell | Row drained | Rationale §D.5 |
|------|-------------|----------------|
| **cell[2]** (Architecture TTS) | `\| **Kokoro** (local Docker) \| Actif \| Bonne \| <2s \| Tags base (speed, emotion) \|` → 1 préfixe | axe a wall-clock LOCAL Docker inference Kokoro DRAINABLE — **`Tags base (speed, emotion)` feature axe c + `Bonne` qualite axe c + `Actif` statut axe c préservés verbatim** |
| **cell[2]** (Architecture TTS) | `\| **FishAudio S2-Pro** \| Non deploye \| Excellente \| ~3s \| 15000+ tags expressifs \|` → 1 préfixe | axe a wall-clock HTTP GPU1 FishAudio DRAINABLE — **`Excellente` qualite axe c + `15000+ tags expressifs` feature axe c + `Non deploye` statut axe c préservés verbatim** |
| **cell[2]** (Architecture TTS) | `\| **OpenAI TTS-1** \| Cloud \| Bonne \| ~2s \| 6 voix fixes \|` → 1 préfixe | axe a wall-clock HTTP Cloud OpenAI DRAINABLE — **`Cloud` statut axe c + `Bonne` qualite axe c + `6 voix fixes` feature axe c préservés verbatim** |

**Total** : 3 préfixes `runtime *machine-dep*` insérés sur 3 lignes dans 1 cellule.

## Litmus §D.5 — 4 catégories timings (canonique)

1. **Wall-clock LOCAL Docker + HTTP GPU + HTTP Cloud inference latency** (axe a env+GPU+réseau) — **DRAINABLE**
   - cell[2] `<2s` Kokoro LOCAL Docker latency drainé
   - cell[2] `~3s` FishAudio S2-Pro HTTP GPU1 RTX 3090 latency drainé
   - cell[2] `~2s` OpenAI TTS-1 HTTP Cloud latency drainé

2. **Audio duration** (axe c moteur upstream déterministe) — **NOT drainable**
   - cell[0] `metadonnees de generation (durees, tailles, paths)` pedagogique
   - cell[0] `Pass 4 : Generation audio via Kokoro TTS (demo) / FishAudio S2-Pro (production)` pedagogique
   - cell[12] `Duree estimee : 15 minutes` pedagogique exercice
   - cell[21] `Duree estimee : 15 minutes` pedagogique exercice
   - cell[35] `Duree estimee : 15-20 minutes` pedagogique exercice
   - generated audio durations from cell[28]+cell[34] (axe c structurel output)
   - cell[18] `122.5s vs 127.9s` audio output durations conclusion (axe c)

3. **Ratio structurel COMPUTED** (axe c computed) — **HORS scope** (c.1308-L3 ★ RTF / c.1316-L3 ★ RTF / c.1320-L3 ★ RTF / c.1321-L3 ★ round-trip / c.1322-L3 ★ RTF / c.1323-L3 ★ chunk count / c.1324-L3 ★ RTF analogues)
   - Aucun ratio COMPUTED runtime/wall-clock dans ce notebook
   - cell[18] `La duree totale est comparable (122.5s vs 127.9s)` = audio output duration comparison COMPUTED HORS scope (axe c)

4. **Chargement modèle / distribution** (axe a init time) — DRAINABLE part
   - cell[19] code `timeout=300` paramètre HTTP request (axe c structurel config, NOT drainable)
   - cell[19] code `print(f"Timeout: 300s | Text split: 60 mots max")` output config param (axe c)
   - cell[19] code `requests.get(... timeout=10)` health check config (axe c)
   - cell[26] code `audio_data = fishaudio_tts(chunk, timeout=300)` HTTP call param (axe c)

## Invariants préservés verbatim (15+)

- cell[0] `Epic #1028 | Pass 4 : Generation audio via Kokoro TTS (demo) / FishAudio S2-Pro (production)` pedagogique axe c
- cell[0] `1. Charger les annotations prosodiques P3 et la configuration vocale P2` pedagogique axe c
- cell[0] `3. Generer les fichiers audio pour les 14 segments du texte` pedagogique axe c
- cell[0] `4. Exporter les metadonnees de generation (durees, tailles, paths)` pedagogique axe c
- cell[2] `Modèle | Statut | Qualite | Latence | Expressivite` header tableau axe c structurel
- cell[2] `Tags base (speed, emotion)` Kokoro feature axe c
- cell[2] `15000+ tags expressifs` FishAudio feature axe c
- cell[2] `6 voix fixes` OpenAI TTS feature axe c
- cell[2] `Actif | Non deploye | Cloud` 3-model status axe c
- cell[2] `Bonne | Excellente | Bonne` 3-model qualite axe c
- cell[2] `Ce notebook utilise **Kokoro** pour la demo locale` pedagogique axe c
- cell[2] `Les tags expressifs FishAudio sont conserves dans les metadonnees pour generation production ultérieure` pedagogique axe c
- cell[12] `Duree estimee : 15 minutes` pedagogique exercice axe c
- cell[21] `Duree estimee : 15 minutes` pedagogique exercice axe c
- cell[35] `Duree estimee : 15-20 minutes` pedagogique exercice axe c
- cell[18] `122.5s vs 127.9s` audio output durations conclusion axe c
- cell[19] code `timeout=300` HTTP request config axe c structurel
- cell[19] code `print(f"Timeout: 300s | Text split: 60 mots max")` output config param
- cell[26] code `audio_data = fishaudio_tts(chunk, timeout=300)` HTTP call param

## Acceptance

- [x] Validateur `validate_pr_notebooks.py` PASS (notebook tagged `runtime *machine-dep*` ≠ cellule code avec `severity:error`)
- [x] Aucune cellule code touchée (19/19 execution_count préservés, 19/19 outputs préservés)
- [x] Pas de ré-exécution kernel (markdown-only, scope strict)
- [x] Diff = **3 insertions, 3 deletions, 1 file** — purely surgical
- [x] JSON validity vérifié (`json.load` parse OK, 37 cells + 19 code cells intacts)

## Tells archétypaux c.1325 spécifiques

- **c.1325-L1 ★** : **04-11 / 04-Applications Generation TTS** — sub-family GenAI/Audio **04-Applications** = pipeline de generation TTS **3-modèle** pédagogique (Kokoro LOCAL Docker demo + FishAudio S2-Pro PRODUCTION HTTP GPU1 RTX 3090 + OpenAI TTS-1 CLOUD). **3ᵉ entrée 04-Applications** après c.1321 04-1-Educational-Audio-Content (pipeline intégré 6-étapes LLM→TTS→Whisper round-trip) et c.1324 04-3-Music-Composition-Workflow (pipeline intégré MusicGen→Demucs→pydub composition musicale). **DISTINCTION** vs c.1321/c.1324 = **3-modèle pédagogique COMPARATIF** (Kokoro vs FishAudio vs OpenAI TTS-1 dans un même tableau architecture), vs c.1321 (modèle unique narratif) vs c.1324 (modèles multiples mais en chaîne MusicGen→Demucs). Tell distinctif = **`Kokoro <2s | FishAudio ~3s | OpenAI TTS-1 ~2s`** comparaison latence pédagogique côte-à-côte vs c.1324 **séquentiel** MusicGen→Demucs. **Aucun autre notebook 04-Applications ne fait cette comparaison côte-à-côte**.
- **c.1325-L2 ★** : **3ᵉ confirmation pathologie #9434 au niveau intégration** — Kokoro standalone c.1308 (TTS HTTP/LOCAL foundation) + FishAudio standalone c.1316 (TTS Expressif Fish S2 Pro + Dia + Kokoro) + OpenAI TTS standalone c.1307 (TTS HTTP) déjà drainés en standalone. **c.1325 draine les MÊMES 3-modèles ré-utilisés côte-à-côte dans un notebook d'application** = pathologie #9434 se manifeste AU NIVEAU intégration cross-modèle (pas seulement audio building blocks c.1324-L2). Pattern reproductible : standalone drain c.1307/c.1308/c.1316 + intégration 3-modèle drain c.1325 = cohérence cross-notebook + cross-modèle.
- **c.1325-L3 ★** : **`timeout=300` config paramètre = HORS scope canonique** — cell[19]+cell[26] `timeout=300` secondes est un **paramètre de configuration HTTP request** (axe c structurel), pas un wall-clock claim. Tell distinctif : **toi qui voit `timeout=XXX` dans un notebook, ce n'est PAS drainable** — c'est un paramètre du code, pas une mesure de runtime observé. Distinction fine vs c.1324-L3 ★ ratio `10-30/8s` COMPUTED HORS scope. Pattern reproductible : `timeout=Xs` HORS scope | `durée observée Xs/y audio` DRAINABLE.
- **c.1325-L4 ★** : **Rotation R6 dense 04-Applications** — c.1321 04-1 (educational content) → c.1324 04-3 (music composition) → **c.1325 04-11** (generation TTS comparaison 3-modèle). 3 entrées 04-Applications sur 4 grain IDs (c.1321 / c.1324 / c.1325) = densité sub-family. Tell distinctif = **3ᵉ entrée 04-Applications confirme expansion rapide** de la sous-famille (educational content + music composition + generation TTS). Autres 04-Applications anticipés par c.1324-L4 ★ pipeline pattern : TTS-Voice-Benchmark (04-7), LiveCoding-LLM-Music (04-5), Audiobook-Pipeline (04-6).

## Lessons c.1325-L1..L4

- **c.1325-L1 ★** : 04-Applications Generation TTS = pipeline génération TTS **3-modèle** pédagogique comparatif (Kokoro LOCAL demo + FishAudio S2-Pro PRODUCTION HTTP GPU1 RTX 3090 + OpenAI TTS-1 CLOUD), 3ᵉ entrée 04-Applications post-c.1321 + c.1324. **Distinct** = comparaison côte-à-côte vs c.1321 (mono-modèle narratif) + c.1324 (multi-modèle séquentiel).
- **c.1325-L2 ★** : 3-modèle claims drainés côte-à-côte dans un tableau comparatif = **3ᵉ confirmation pathologie #9434 au niveau intégration cross-modèle**. Kokoro c.1308 + FishAudio c.1316 + OpenAI TTS c.1307 standalone déjà drainés → c.1325 draine les MÊMES 3 claims ré-utilisés ensemble. Pattern reproductible : standalone drain + intégration 3-modèle drain = cohérence cross-notebook + cross-modèle.
- **c.1325-L3 ★** : **`timeout=Xs` configuration parameter** = HORS scope canonique (axe c structurel config, pas wall-clock claim). `toi qui voit timeout=XXX dans un notebook, ce n'est PAS drainable`. Distinction fine vs ratio COMPUTED HORS scope c.1324-L3.
- **c.1325-L4 ★** : Rotation R6 dense 04-Applications : c.1321 04-1 → c.1324 04-3 → c.1325 04-11 (3 entrées sur 4 grain IDs). Expansion rapide de la sous-famille. Tell distinctif = **tableau comparatif 3-modèle côte-à-côte** (vs c.1324 séquentiel MusicGen→Demucs).

## Cross-references #9434 vein (GenAI/Audio)

| Grain | Sub-family | PR | Statut | Tells |
|-------|-----------|-----|--------|-------|
| c.1303 | Audio orchestration (multi-call HTTP) | #9661 | OPEN | multi-call LLM+TTS+STT+retries+pauses |
| c.1306-c.1310 | Audio foundation 5× (STT/TTS HTTP+LOCAL matrice 2×2) | #9671/9675/9676/9678/9680 | OPEN | CHARGEMENT vs INFERENCE + RTF |
| c.1307 | TTS HTTP OpenAI | #9675 | OPEN | INVERSION (audio OUTPUT axe c) + multi-call + ratio HORS scope |
| c.1308 | TTS LOCAL Kokoro | #9676 | OPEN | RTF=duration/gen_time + 2ᵉ auteur-conscient |
| c.1312-c.1320 | Audio advanced 8× | #9684-#9694 | OPEN | 8 sub-family nouveaux distincts |
| c.1316 | TTS Expressif Fish S2 Pro | #9690 | OPEN | Fish S2 Pro + Dia + Kokoro + tags inline 15000+ + Dual-AR |
| c.1321 | Audio 04-Applications educational content | #9700 | OPEN | pipeline intégré 6-étapes + multi-voix nova/onyx + 1ère entrée 04-Applications |
| c.1324 | Audio 04-Applications music composition workflow | #9710 | OPEN | pipeline intégré MusicGen + Demucs + pydub + scipy + 2ᵉ entrée 04-Applications |
| **c.1325** | **Audio 04-Applications generation TTS 3-modèle** | **#XXXX** | **OPEN** | **tableau comparatif 3-modèle côte-à-côte (Kokoro LOCAL <2s + FishAudio S2-Pro HTTP GPU1 ~3s + OpenAI TTS-1 CLOUD ~2s) + 3ᵉ entrée 04-Applications + 3ᵉ confirmation pathologie #9434 au niveau intégration cross-modèle + 3 wall-clock claims drainés sur 1 cellule (cell[2])** |

## Diagnostic §D.5

**Verdict** : `CAUSE_FIXED` — option alpha appliquée (préserver invariants structurels + drainer claims runtime machine-dep). Cause racine = prose pédagogique cite wall-clock concrets (Kokoro LOCAL Docker `<2s` + FishAudio S2-Pro HTTP GPU1 RTX 3090 `~3s` + OpenAI TTS-1 HTTP Cloud `~2s`) sans marquer leur dépendance à la machine d'exécution + charge GPU1 RTX 3090 (FishAudio) + latence réseau Cloud OpenAI + charge Kokoro LOCAL Docker. Fix = préfixer par `runtime *machine-dep* :` sans modifier la valeur numérique. Pas de ré-alignement, pas de ré-exécution kernel (markdown-only).

## Validation per CLAUDE.md §B.5 + notebook-conventions C.1/C.2

| Check | Statut |
|-------|--------|
| Scope réel (Refs #9434 partiel) | ✅ claim = scope = diff |
| `git diff --stat` cohérent | ✅ 1 file, +3/-3 |
| Cellules code = `execution_count: <int>` + outputs cohérents | ✅ 19/19 préservés (1, 2, 3, 4, 5, 6, 1, 7, 8, 9, 10, 1, 11, 12, 13, 14, 15, 16, 1) |
| 0 cellule `# Solution` / `# Exemple résolu` supprimée | ✅ (aucune touchée) |
| Stop & Repair règle 6 | ✅ cause = marqueur manquant, pas erreur à corriger |
| CR/LF/BOM preserved | ✅ LF-only + final LF preserved |
| JSON validity | ✅ `json.load` parse OK + 37 cells + 19 code cells intacts |
| C955-1 ★★★ surgical edit | ✅ metadata/texte uniquement |

Refs #9434

🤖 Generated with [Claude Code](https://claude.com/claude-code)