### PR TITLE
fix(vibe-coding,#9725): prepare-workspaces.ps1 ne deployait aucune demo (chemin de base dans Scripts/)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Roo-Code/Scripts/prepare-workspaces.ps1
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Roo-Code/Scripts/prepare-workspaces.ps1
@@ -4,7 +4,8 @@ param (
     [string]$Workshop
 )
 
-$baseDemosPath = Join-Path $PSScriptRoot -ChildPath "." # ateliers/demo-roo-code
+# Racine des ateliers : le script vit dans Scripts/, les demos sont un niveau au-dessus
+$baseDemosPath = Split-Path -Parent $PSScriptRoot
 $userWorkspacesBase = Join-Path $baseDemosPath -ChildPath "workspaces"
 $userWorkspacePath = Join-Path $userWorkspacesBase -ChildPath $UserName
 
@@ -69,7 +70,8 @@ foreach ($demoRoot in $demoRootPaths) {
 
     if ($sourceItems.Count -gt 0) {
         # Détermine le chemin relatif de la démo par rapport à $baseDemosPath
-        $relativePath = $demoRoot.FullName.Substring($baseDemosPath.Length).TrimStart('/')
+        # TrimStart sur les deux separateurs : FullName utilise '\' sur Windows, '/' sur POSIX
+        $relativePath = $demoRoot.FullName.Substring($baseDemosPath.Length).TrimStart('\', '/')
 
         # Construit le chemin de destination pour cette démo dans le workspace de l'utilisateur
         $destinationDemoPath = Join-Path $userWorkspacePath -ChildPath $relativePath


### PR DESCRIPTION
`Grain: MED/tooling — lane myia-po-2025:CoursIA — prev: MED/genai`

## Summary

`prepare-workspaces.ps1` est le point d'entrée documenté par **3 READMEs étudiants** du parcours Roo-Code. Dans la disposition committée, il ne déploie **rien du tout** — et affiche quand même son message de succès.

Le script cherche les démos sous `$baseDemosPath = Join-Path $PSScriptRoot -ChildPath "."`, soit `Roo-Code/Scripts/.`. Or il vit dans `Scripts/` alors que les démos (`01-decouverte` … `05-projets-avances`) sont **un niveau au-dessus**, à `Roo-Code/`. Le `Get-ChildItem -Recurse` des lignes 42/50 ne trouve donc aucun répertoire `^\d{2}-` ni `demo-*` : `$demoRootPaths` est vide, la boucle `foreach` ne tourne jamais.

## Changements (1 fichier, +4 / −2)

| Ligne | Avant | Après | Pourquoi |
|---|---|---|---|
| 7 | `Join-Path $PSScriptRoot -ChildPath "."` | `Split-Path -Parent $PSScriptRoot` | Résout la racine réelle des démos depuis `Scripts/` |
| 71 | `.TrimStart('/')` | `.TrimStart('\', '/')` | Sur Windows `FullName` utilise `\` ; `TrimStart('/')` ne le retire pas |

Les deux corrections sont **indissociables** : le `/.` terminal rendait `$baseDemosPath` deux caractères trop long, ce qui décalait le `Substring` de la ligne 71 et masquait le défaut de séparateur. Corriger uniquement la ligne 7 aurait déplacé le bug — la destination aurait perdu son zéro initial (`01-decouverte` → `1-decouverte`).

## Preuve A/B par exécution réelle

Script exécuté sur une copie hors dépôt (l'écriture va dans `workspaces/`, pluriel, que le `.gitignore` local n'ignore pas — il ne couvre que `**/workspace/*` au singulier), même arborescence de démos dans les deux cas :

```
===== A / AVANT (script committé, tel quel) =====
Répertoire utilisateur créé : ...\Roo-Code\Scripts\.\workspaces\etudiant_A     <- le \.\ parasite
Recherche de tous les ateliers
Préparation de tous les workspaces terminée pour etudiant_A.                   <- succès annoncé

  démos déployées : AUCUNE
  fichiers copiés : 0

===== B / APRÈS (fix appliqué) =====
Répertoire utilisateur créé : ...\Roo-Code\workspaces\etudiant_B
Copie de README.md vers ...\etudiant_B\01-decouverte\README.md
Copie de docs      vers ...\etudiant_B\01-decouverte\demo-1-conversation\docs
[... 36 autres copies ...]

  répertoires déployés : 01-decouverte, 02-orchestration-taches, 03-assistant-pro,
                         04-creation-contenu, 05-projets-avances + 12 sous-démos
  fichiers copiés : 42
  zéro initial préservé : OK — aucun répertoire à chiffre unique
```

`0 → 42` fichiers, et aucune régression `1-decouverte`. Encodage vérifié : pas de BOM sur le `.ps1` (premiers octets `70 61 72`, pas `EF BB BF`).

## Discrimination avec #9721 (sujets bien disjoints)

Dans le run B, `demo-2-vision` reçoit toujours `ressourcesX` et **pas** `docs` : c'est exactement le défaut de *sélection d'items* que corrige #9721, et il survit intact à cette PR. Les deux corrections sont orthogonales et se composent — celle-ci fait que le déploiement **a lieu**, #9721 corrige **ce qui est déployé**. Hunks distincts (lignes 7/71 ici, clauses `Where-Object` là) : pas de conflit.

## Hors scope, signalé

- **`Claude-Code/Scripts/prepare-workspaces.ps1`** est un blob distinct sans cette construction de chemin — non concerné, non touché.
- Les **traces `roo_task_*.md`** (Sep 2025) montrent l'invocation historique `ateliers\demo-roo-code\prepare-workspaces.ps1`, c'est-à-dire depuis la racine des démos, où le script se trouvait alors. Elles documentent la disposition d'origine et sont des **enregistrements de session immuables** — non modifiées.
- Les 3 READMEs documentent `./prepare-workspaces.ps1` sans le préfixe `Scripts/`. Le chemin d'invocation côté doc reste donc à réaligner ; ce n'est pas le même sujet que la résolution interne du chemin et cela mérite sa propre PR.

Closes #9725
See #9535
