### PR TITLE
test(golden,#9434): add data-unit TN cases (m9/m10) for unités-données FP

### DIFF
--- a/scripts/tests/golden_quantitative_claims.json
+++ b/scripts/tests/golden_quantitative_claims.json
@@ -14,7 +14,7 @@
       "real-<family>": "cas reel pioche dans un notebook du depot",
       "synthetic-boundary": "cas synthetique testant une frontiere de regex"
     },
-    "counts": { "total": 32, "machine": 8, "env": 7, "stochastic": 9, "structural": 8 }
+    "counts": { "total": 34, "machine": 10, "env": 7, "stochastic": 9, "structural": 8 }
   },
   "cases": [
     {"id": "m1", "text": "Le tri prend 24-127 ms selon la taille.", "cls": "machine", "expect": "match", "kind": "TP", "source": "issue-9434", "note": "PR #9427 App-11-Picross. Scanner matche '127 ms' (la 2eme valeur) — la 1ere '24-' n'a pas d'unite accolée."},
@@ -25,6 +25,8 @@
     {"id": "m6", "text": "L'inference dure 0.2 s par batch.", "cls": "machine", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "Unite monolettre 's' avec espace (exige par le scanner)."},
     {"id": "m7", "text": "execution en 30s", "cls": "machine", "expect": "match", "kind": "TP", "source": "synthetic-boundary", "note": "ANGLE-MORT: '30s' sans espace AVANT 's' n'est pas matche (le scanner exige \\ss). Humainement c'est machine-dependant — devrait matcher. xfail documente (le scanner le rate)."},
     {"id": "m8", "text": "Le port USB-C est connecte.", "cls": "machine", "expect": "nomatch", "kind": "TN", "source": "synthetic-boundary", "note": "TN propre: 'USB-C' ne contient pas d'unite de temps."},
+    {"id": "m9", "text": "Le temps moyen de trajet est de 15.33 min", "cls": "machine", "expect": "nomatch", "kind": "TN", "source": "real-probas", "note": "TN data-unit (Infer-101 cell19): '15.33 min' = moyenne arithmetique des durees de trajet-vélo (13+17+16)/3=15.33, PAS un runtime. Posterieur/statistique DETERMINISTE — reproductible a donnees+algorithme identiques, ne derive pas au re-run. ANGLE-MORT: le scanner FP sur l'unite 'min' (cf arbitrage #9434 2026-08-06 : la frontiere = machine-DEPENDANCE, pas 'nombre+unite'). xfail documente (scanner sur-flagge l'unite-data)."},
+    {"id": "m10", "text": "Le clip audio dure 30 sec de contenu", "cls": "machine", "expect": "nomatch", "kind": "TN", "source": "real-genai", "note": "TN data-unit: '30 sec' = duree du contenu audio (longueur du clip), PAS un runtime de traitement. Deterministe — ne derive pas avec la machine. ANGLE-MORT: le scanner FP sur l'unite 'sec' (indistinguable d'une latence a la regex). xfail documente."},
 
     {"id": "e1", "text": "Tourne sous NumPy 2.4.2", "cls": "env", "expect": "match", "kind": "TP", "source": "issue-9434", "note": "PR #9429 GT-4c. Version de librairie figee en prose (la cellule imprime deja la version dynamiquement)."},
     {"id": "e2", "text": "PyTorch 2.1.0 requis", "cls": "env", "expect": "match", "kind": "TP", "source": "real-genai", "note": "Forme canonique."},

--- a/scripts/tests/test_golden_quantitative_claims.py
+++ b/scripts/tests/test_golden_quantitative_claims.py
@@ -32,12 +32,16 @@ GOLDEN = HERE / "golden_quantitative_claims.json"
 
 
 # --- Angles-mort connus (scanner diverge de la ground truth) --------------- #
-# Ces cas DOIVENT matcher humainement mais le scanner actuel les rate.
+# Deux sens de divergence inventories :
+#  - FN (faux negatif) : le scanner RATE un cas qu'il devrait matcher (m7/s6/s8).
+#  - FP (faux positif) : le scanner SUR-FLAGGE un cas TN (m9/m10 unites-data).
 # Documentes pour prevenir qu'on les oublie ; xfail -> xpass signaling si fixe.
 XFAIL_KNOWN_GAPS: dict[str, str] = {
-    "m7": "ANGLE-MORT machine: '30s' sans \\ss (espace avant 's') n'est pas matche",
-    "s6": "ANGLE-MORT stochastic: 42.5 a 1 decimale, STOCHASTIC_NUM exige >=2",
-    "s8": "ANGLE-MORT stochastic: 'tentatives' hors KW + 1 decimale (App-7-Wordle)",
+    "m7": "ANGLE-MORT machine (FN): '30s' sans \\ss (espace avant 's') n'est pas matche",
+    "s6": "ANGLE-MORT stochastic (FN): 42.5 a 1 decimale, STOCHASTIC_NUM exige >=2",
+    "s8": "ANGLE-MORT stochastic (FN): 'tentatives' hors KW + 1 decimale (App-7-Wordle)",
+    "m9": "ANGLE-MORT machine (FP): '15.33 min' = posterieur Bayesian DETERMINISTE (Infer-101, moyenne de trajet-vélo), PAS runtime. L'unite 'min' est une UNITE-DE-DONNEE du domaine, indistinguable d'une latence a la regex. Arbitrage #9434 2026-08-06 : frontiere = machine-dependance, pas 'nombre+unite'. ADVISORY — le triage humain tranche.",
+    "m10": "ANGLE-MORT machine (FP): '30 sec' = duree du CONTENU audio (longueur de clip), PAS un runtime. Unite-de-donnee indistinguable d'une latence a la regex. ADVISORY — le triage humain tranche.",
     # "t1" (2.78e24x notation scientifique + x) retire : FIXE par #9564
     # (STRUCTURAL_RE etendu a e\d+x?) — les deux PRs #9560/#9564 etaient
     # in-flight simultanement, chacune verte isolement, rouges combinees.


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: DEEP/anti-regression-restore #9722

## What

EPIC **#9434** item **(b)** — *golden set à jour (unités-données = TN)*, per ai-01 AMENDEMENT (msg-nkpmqf, mandate user 06/08). Adds **2 TN cases (m9/m10)** to the golden set documenting the **data-unit posterior** class of scanner false-positives revealed by the 2026-08-06 arbitrage.

## Why

The arbitrage (jsboige 14:05:37Z) established the #9434 boundary as **machine-DÉPENDANCE (drift au re-run)**, *not* « nombre + unité temporelle ». The scanner `check_prose_quantitative_claims.py` is regex-based and cannot distinguish a **machine runtime** (drifts) from a **domain data-unit** (deterministic — does not drift):

- `15.33 min` = Infer-101 Bayesian **posterior mean** of travel-time data (cell19: (13+17+16)/3 = 15.33) → reproducible at identical data+algorithm → **no drift** → TN.
- `30 sec` = audio **clip content duration** (length of content), not a processing runtime → deterministic → TN.

The scanner's `MACHINE_RE` matches `min`/`sec` regardless of semantic context → **documented FP**. Per the arbitrage, the scanner stays **ADVISORY** and human triage decides. These cases encode that lesson into the regression suite as permanent `xfail` angle-morts.

## Cases added

| id | text | cls | expect | kind | source |
|----|------|-----|--------|------|--------|
| m9 | `Le temps moyen de trajet est de 15.33 min` | machine | nomatch | TN | real-probas (Infer-101) |
| m10 | `Le clip audio dure 30 sec de contenu` | machine | nomatch | TN | real-genai |

Both inventoried in `XFAIL_KNOWN_GAPS` with rationale citing the arbitrage. The gap-comment was widened to cover **both** divergence directions (FN = scanner misses a TP ; FP = scanner over-flags a TN) — the existing m7/s6/s8 are FN; m9/m10 are FP.

## Coordination — orthogonality with #9726

PR **#9726** (lane `myia-po-2023:CoursIA-2`) takes the **other half** of item (b): a **scanner fix** (`STUDENT_PACING_RE` line-exemption) that makes `### Durée estimée : X minutes` student-pacing a passing TN. The two PRs are **orthogonal**:

- **#9726** = scanner code (pacing keyword exemption) — does NOT touch the golden set.
- **This PR** = golden set (data-unit posteriors) — does NOT touch scanner code.

The m9/m10 data-unit cases are **NOT covered by #9726** (it exempts only `Durée estimée` keyword lines, not semantic data-unit context) and stay `xfail` **regardless of #9726** merge state — no sequencing coupling. A golden-set regression-guard case for the *pacing* half (to lock #9726's behaviour) is naturally #9726's responsibility (or a follow-up after it merges).

## Verification

```
scripts/tests/test_golden_quantitative_claims.py : 41 passed, 5 xfailed (m7/m9/m10/s6/s8)
scripts/notebook_tools/tests/test_check_prose_quantitative_claims.py : 19 passed
```
- `test_known_gap_count_is_documented` PASSES — m9/m10 are real divergences, correctly inventoried.
- `test_scanner_precision_recall_per_class` PASSES — xfail cases do not pollute precision/recall.
- `test_golden_set_has_tp_and_tn_per_class` PASSES — machine class still has both TP and TN.

See #9434 (closes after both halves of item b land). After this, #9434 closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)