### PR TITLE
tool(lean,#8782): detect sorries no public declaration anchors (1/47 cohort-wide)

### DIFF
--- a/scripts/lean/README.md
+++ b/scripts/lean/README.md
@@ -9,8 +9,79 @@ Outils pour le cycle de vie des projets Lean 4 du dépôt.
 | `setup_shared_mathlib.ps1` | Mutualisation des checkouts Mathlib via junctions NTFS (voir ci-dessous) |
 | `lean_kernel_check.py` | Diagnostic kernel Lean (toolchain, oleans, env Python) |
 | `smoke_test_epita_is.py` | Smoke tests du parcours EPITA-IS (notebooks + preuves) |
+| `check_public_anchor.py` | Detecte les `sorry` qu'aucune declaration publique n'atteint — l'angle mort residuel du gate `proof-integrity` (voir ci-dessous) |
 
 Tests unitaires dans `tests/`.
+
+---
+
+## `check_public_anchor.py` — les `sorry` hors de portee du gate (issue #8782)
+
+### Problème
+
+Le gate `proof-integrity` (`lean-axiom.yml`) mesure les axiomes via `#print axioms`
+sur les declarations **publiques** d'un module. `_enumerate_module_declarations`
+(`agent_tests/lean_server.py`) saute les declarations `private`, a raison : Lean 4
+les mangle en `_private.<Module>.<hash>.<name>`, donc `#print axioms` repondrait
+`unknown constant` et ferait tomber le verdict du module entier (#8722). La
+justification ecrite dans ce code est que rien n'est perdu, *car un lemme prive
+n'atteint le kernel qu'a travers les theoremes publics qui l'utilisent, et ceux-la
+sont enumeres*.
+
+C'est vrai **quand un theoreme public consomme effectivement la chaine**. Quand ce
+n'est pas le cas — chaine privee sur toute sa longueur, ou lemme prive que personne
+ne cite — le `sorryAx` n'apparait dans la cloture d'**aucune** declaration enumeree.
+Le module est alors correctement cible, correctement enumere, et rapporte propre
+alors qu'il porte un `sorry`. Le garde `enumerated=0` ne couvre pas ce cas : il ne
+se declenche que si le module **entier** enumere vide, pas pour une declaration
+privee orpheline dans un module par ailleurs sain.
+
+Cet outil verifie mecaniquement cette hypothese, module par module.
+
+### Pourquoi une analyse statique suffit — et est complete
+
+En Lean 4, `private` est de portee **module** : une declaration privee n'est pas
+referencable depuis un autre module. La cloture arriere d'une declaration privee est
+donc entierement contenue dans son propre fichier, ce qui rend l'analyse mono-fichier
+*complete* pour cette question, pas approximative. Aucun kernel, aucun Mathlib
+construit : l'outil tourne sur n'importe quelle machine.
+
+### Biais assume : jamais de fausse alarme, silences possibles
+
+Le graphe de references est bati sur les noms — un token identique a un nom de
+declaration compte comme une reference. C'est une **sur**-approximation des aretes
+(une variable locale homonyme en cree une qui n'existe pas), et l'effet va toujours
+dans le meme sens : plus d'aretes = plus de chances de trouver un ancrage =
+**moins** de verdicts `unanchored`. L'outil peut donc taire un angle mort reel, il
+ne peut pas en inventer un. C'est le bon biais pour un advisory.
+
+Les commentaires sont retires avant l'analyse (via `strip_comments` de
+`check_i18n_siblings.py`), sans quoi une mention en prose compterait comme une
+citation : c'est exactement ce qui distingue ce detecteur d'un `grep -c`.
+
+### Usage
+
+```bash
+python scripts/lean/check_public_anchor.py <fichier.lean> [...]
+python scripts/lean/check_public_anchor.py --lake MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
+python scripts/lean/check_public_anchor.py --lake <dir> --json
+python scripts/lean/check_public_anchor.py --lake <dir> --fail-on-unanchored
+```
+
+Advisory (exit 0) par defaut : l'outil rend visible, il ne decide pas.
+`--fail-on-unanchored` est opt-in. Une cible vide ou absente est une **erreur**, pas
+un rapport propre — un detecteur d'angle mort ne doit jamais se taire parce qu'il
+n'a rien regarde (meme raison d'etre que les classifications `EMPTY_*` de #8940).
+
+### Verdicts
+
+| Verdict | Sens |
+|---------|------|
+| `anchored_public` | le porteur du `sorry` est lui-meme public — le gate le voit |
+| `anchored_transitive` | porteur prive, mais une declaration publique le rejoint — vu transitivement |
+| `unanchored` | porteur prive qu'aucune declaration publique ne rejoint — **invisible du gate** |
+| `anonymous` | `example` : sans nom, jamais enumerable |
+| `orphan_sorry` | `sorry` hors de toute declaration |
 
 ---
 

--- a/scripts/lean/check_public_anchor.py
+++ b/scripts/lean/check_public_anchor.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Detecte les ``sorry`` qu'aucune declaration PUBLIQUE n'atteint (issue #8782).
+
+## Le defaut vise
+
+Le gate ``proof-integrity`` mesure les axiomes via ``#print axioms`` sur les
+declarations **publiques** d'un module. ``_enumerate_module_declarations``
+(``agent_tests/lean_server.py``) saute deliberement les declarations
+``private`` -- a raison, car Lean 4 les mangle en
+``_private.<Module>.<hash>.<name>`` et ``#print axioms`` repondrait
+``unknown constant`` (#8722). La justification ecrite dans ce code est :
+
+    "Nothing is lost by skipping them: a private lemma reaches the kernel only
+    through the public theorems that use it, and those are enumerated, so its
+    axioms are still counted transitively."
+
+Elle est correcte **mais conditionnelle** : elle suppose qu'un theoreme public
+consomme effectivement la chaine. Quand ce n'est pas le cas -- chaine privee sur
+toute sa longueur, ou lemme prive que personne ne cite -- le ``sorryAx`` du
+``sorry`` n'apparait dans la cloture d'AUCUNE declaration enumeree. Le module
+est alors correctement cible, correctement enumere, et **rapporte propre alors
+qu'il porte des sorry**.
+
+Cet outil verifie mecaniquement cette hypothese, module par module.
+
+## Pourquoi une analyse statique suffit (et est complete)
+
+En Lean 4, ``private`` est **de portee module** : une declaration privee n'est
+pas referencable depuis un autre module. La cloture arriere d'une declaration
+privee est donc **entierement contenue dans son propre fichier**, ce qui rend
+l'analyse mono-fichier *complete* pour cette question, pas approximative. Aucun
+kernel Lean, aucun Mathlib construit n'est requis -- l'outil tourne sur
+n'importe quelle machine.
+
+## Biais assume : jamais de fausse alarme, silences possibles
+
+Le graphe de references est bati sur les **noms** (un token identique a un nom de
+declaration compte comme une reference). C'est une **sur**-approximation des
+aretes : une variable locale homonyme cree une arete qui n'existe pas. L'effet
+va toujours dans le meme sens -- plus d'aretes = plus de chances de trouver un
+ancrage public = **moins** de verdicts UNANCHORED. L'outil peut donc taire un
+angle mort reel, il ne peut pas en inventer un. C'est le bon biais pour un
+advisory : un UNANCHORED rapporte merite d'etre regarde.
+
+## Usage
+
+    python scripts/lean/check_public_anchor.py <fichier.lean> [...]
+    python scripts/lean/check_public_anchor.py --lake MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
+    python scripts/lean/check_public_anchor.py --lake <dir> --json
+    python scripts/lean/check_public_anchor.py --lake <dir> --fail-on-unanchored
+
+Sortie advisory (exit 0) par defaut, comme ``check_target_coverage`` : l'outil
+rend visible, il ne decide pas. ``--fail-on-unanchored`` est opt-in.
+
+See #8782 (2e etage), #8722 (cause du saut des private), #8940 (classification
+des enumerations vides), #8678 (un compteur nu se perime, un compteur avec son
+denominateur se contredit tout seul).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_i18n_siblings import strip_comments  # noqa: E402
+
+# Tetes de declaration porteuses de preuve. ``structure`` / ``inductive`` sont
+# exclues : elles ne portent pas de ``sorry`` de preuve.
+_DECL_HEAD = re.compile(
+    r"^\s*(?P<mods>(?:@\[[^\]]*\]\s*)?"
+    r"(?:private\s+|protected\s+|partial\s+|noncomputable\s+|unsafe\s+|scoped\s+)*)"
+    r"(?P<kind>theorem|lemma|def|abbrev|instance|example)\b"
+    r"(?:\s+(?P<name>[A-Za-z_][A-Za-z0-9_'!?₀-₉]*(?:\.[A-Za-z_][A-Za-z0-9_'!?₀-₉]*)*))?"
+)
+
+_NAMESPACE_OPEN = re.compile(r"^\s*namespace\s+(?P<ns>[\w.]+)")
+_NAMESPACE_CLOSE = re.compile(r"^\s*end\s+(?P<ns>[\w.]+)\s*$")
+
+# Un identifiant Lean, points inclus (``Conway.Life.foo``).
+_TOKEN = re.compile(r"[A-Za-z_][A-Za-z0-9_'!?₀-₉]*(?:\.[A-Za-z_][A-Za-z0-9_'!?₀-₉]*)*")
+
+# Verdicts, du plus sain au plus preoccupant.
+ANCHORED_PUBLIC = "anchored_public"          # le porteur est lui-meme public
+ANCHORED_TRANSITIVE = "anchored_transitive"  # prive, mais un public le rejoint
+UNANCHORED = "unanchored"                    # prive, aucun public ne le rejoint
+ANONYMOUS = "anonymous"                      # ``example`` : jamais adressable
+ORPHAN = "orphan_sorry"                      # hors de toute declaration
+
+
+@dataclass
+class Decl:
+    """Une declaration et son corps (jusqu'a la tete suivante)."""
+
+    name: str
+    kind: str
+    line: int
+    private: bool
+    anonymous: bool
+    end: int = 0
+    body: str = ""
+    refs: set[str] = field(default_factory=set)
+
+    @property
+    def label(self) -> str:
+        return self.name if not self.anonymous else f"<{self.kind}@{self.line}>"
+
+
+def parse_declarations(stripped: str) -> list[Decl]:
+    """Indexe les declarations du source (deja depouille de ses commentaires).
+
+    Les noms sont qualifies par la pile de ``namespace`` ouverts, avec la meme
+    prudence que ``lean_server`` : on ne depile que si le ``end`` reference bien
+    le namespace au sommet (un ``end`` de ``section`` ne doit pas desequilibrer
+    la pile, cf #8722).
+    """
+    lines = stripped.splitlines()
+    ns: list[str] = []
+    decls: list[Decl] = []
+    for idx, line in enumerate(lines, start=1):
+        m_open = _NAMESPACE_OPEN.match(line)
+        if m_open:
+            ns.append(m_open.group("ns"))
+            continue
+        m_close = _NAMESPACE_CLOSE.match(line)
+        if m_close:
+            if ns and ns[-1] == m_close.group("ns"):
+                ns.pop()
+            continue
+        m = _DECL_HEAD.match(line)
+        if not m:
+            continue
+        raw = m.group("name")
+        anonymous = raw is None
+        if anonymous:
+            name = f"__{m.group('kind')}_{idx}"
+        elif raw.startswith("_root_."):
+            name = raw[len("_root_.") :]
+        else:
+            name = ".".join(ns + [raw]) if ns else raw
+        decls.append(
+            Decl(
+                name=name,
+                kind=m.group("kind"),
+                line=idx,
+                private="private" in (m.group("mods") or ""),
+                anonymous=anonymous,
+            )
+        )
+    for i, d in enumerate(decls):
+        d.end = decls[i + 1].line - 1 if i + 1 < len(decls) else len(lines)
+        d.body = "\n".join(lines[d.line - 1 : d.end])
+    return decls
+
+
+def build_reference_graph(decls: list[Decl]) -> None:
+    """Renseigne ``d.refs`` : les declarations citees dans le corps de ``d``.
+
+    Un token est reconnu s'il egale un nom qualifie OU son dernier composant --
+    une reference intra-namespace s'ecrit couramment en nom court.
+    """
+    by_qualified = {d.name: d.name for d in decls if not d.anonymous}
+    by_short: dict[str, set[str]] = {}
+    for d in decls:
+        if d.anonymous:
+            continue
+        by_short.setdefault(d.name.rsplit(".", 1)[-1], set()).add(d.name)
+    for d in decls:
+        hits: set[str] = set()
+        for tok in _TOKEN.findall(d.body):
+            if tok in by_qualified:
+                hits.add(tok)
+            hits |= by_short.get(tok.rsplit(".", 1)[-1], set())
+        d.refs = hits - {d.name}
+
+
+def public_closure_reaches(target: str, decls: list[Decl]) -> tuple[bool, list[str]]:
+    """La cloture ARRIERE de ``target`` contient-elle une declaration publique ?
+
+    Retourne ``(atteint, ancrages_publics_tries)``.
+    """
+    callers: dict[str, set[str]] = {d.name: set() for d in decls}
+    for d in decls:
+        for r in d.refs:
+            if r in callers:
+                callers[r].add(d.name)
+    by_name = {d.name: d for d in decls}
+    seen: set[str] = set()
+    frontier = [target]
+    while frontier:
+        cur = frontier.pop()
+        for caller in callers.get(cur, ()):
+            if caller not in seen:
+                seen.add(caller)
+                frontier.append(caller)
+    anchors = sorted(
+        n for n in seen if n in by_name and not by_name[n].private and not by_name[n].anonymous
+    )
+    return bool(anchors), anchors
+
+
+def analyze_module(path: Path) -> dict:
+    """Verdict d'un module : un enregistrement par ``sorry`` en position de code."""
+    src = path.read_text(encoding="utf-8", errors="replace")
+    stripped = strip_comments(src)
+    decls = parse_declarations(stripped)
+    build_reference_graph(decls)
+
+    sites: list[dict] = []
+    for idx, line in enumerate(stripped.splitlines(), start=1):
+        for _ in re.finditer(r"(?<![A-Za-z0-9_'])sorry(?![A-Za-z0-9_'])", line):
+            owner = None
+            for d in decls:
+                if d.line <= idx <= d.end:
+                    owner = d
+            if owner is None:
+                sites.append({"line": idx, "verdict": ORPHAN, "owner": None, "anchors": []})
+                continue
+            if owner.anonymous:
+                verdict, anchors = ANONYMOUS, []
+            elif not owner.private:
+                verdict, anchors = ANCHORED_PUBLIC, [owner.name]
+            else:
+                reached, anchors = public_closure_reaches(owner.name, decls)
+                verdict = ANCHORED_TRANSITIVE if reached else UNANCHORED
+            sites.append(
+                {
+                    "line": idx,
+                    "verdict": verdict,
+                    "owner": owner.label,
+                    "owner_private": owner.private,
+                    "anchors": anchors,
+                }
+            )
+
+    return {
+        "module": str(path),
+        "declarations": len(decls),
+        "private_declarations": sum(1 for d in decls if d.private),
+        "sorry_sites": len(sites),
+        "unanchored": sum(1 for s in sites if s["verdict"] == UNANCHORED),
+        "sites": sites,
+    }
+
+
+def lean_sources(root: Path) -> list[Path]:
+    """Les ``*.lean`` d'un lake, hors ``.lake/`` (deps vendorees)."""
+    return sorted(p for p in root.rglob("*.lean") if ".lake" not in p.parts)
+
+
+def _render(reports: list[dict]) -> None:
+    print("=== ADVISORY: sorry sans ancrage public (proof-integrity 2e etage, #8782) ===")
+    tot_sorry = sum(r["sorry_sites"] for r in reports)
+    tot_unanchored = sum(r["unanchored"] for r in reports)
+    print(f"Modules analyses      : {len(reports)}")
+    print(f"Sorry en position code: {tot_sorry}")
+    print(f"Dont SANS ancrage     : {tot_unanchored}")
+    if tot_sorry:
+        print(f"Couverture du gate    : {tot_sorry - tot_unanchored}/{tot_sorry} "
+              f"({100.0 * (tot_sorry - tot_unanchored) / tot_sorry:.1f}%)")
+    for r in reports:
+        flagged = [s for s in r["sites"] if s["verdict"] in (UNANCHORED, ANONYMOUS, ORPHAN)]
+        if not flagged:
+            continue
+        print(f"\n-- {r['module']}")
+        print(f"   {r['declarations']} declarations ({r['private_declarations']} private), "
+              f"{r['sorry_sites']} sorry")
+        for s in flagged:
+            owner = s["owner"] or "(hors declaration)"
+            print(f"   L{s['line']:<6} {s['verdict']:<21} {owner}")
+    if not tot_unanchored:
+        print("\nAucun sorry hors de portee des declarations publiques enumerees.")
+    else:
+        print("\nUn sorry UNANCHORED n'apparait dans la cloture d'axiomes d'AUCUNE")
+        print("declaration enumeree : le gate peut rapporter propre sur ce module.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Detecte les sorry qu'aucune declaration publique n'atteint (#8782)."
+    )
+    ap.add_argument("paths", nargs="*", type=Path, help="Fichiers .lean a analyser")
+    ap.add_argument("--lake", type=Path, help="Racine d'un lake (recursif, hors .lake/)")
+    ap.add_argument("--json", action="store_true", help="Sortie machine-lisible")
+    ap.add_argument(
+        "--fail-on-unanchored",
+        action="store_true",
+        help="Exit 1 si au moins un sorry est sans ancrage public (defaut: advisory, exit 0)",
+    )
+    args = ap.parse_args(argv)
+
+    if not args.paths and not args.lake:
+        ap.error("fournir au moins un fichier .lean ou --lake <dir>")
+
+    # Un detecteur d'angle mort ne doit jamais se taire parce qu'il n'a rien
+    # regarde -- c'est la classe de defaut qu'il traque (cf EMPTY_* de #8940).
+    # Une cible vide ou absente est une ERREUR, pas un rapport propre.
+    targets: list[Path] = []
+    for p in args.paths:
+        if not p.is_file():
+            ap.error(f"fichier introuvable : {p}")
+        targets.append(p)
+    if args.lake:
+        if not args.lake.is_dir():
+            ap.error(f"lake introuvable : {args.lake}")
+        found = lean_sources(args.lake)
+        if not found:
+            ap.error(f"aucun .lean hors .lake/ sous {args.lake} -- cible vide, rien analyse")
+        targets += found
+
+    reports = [analyze_module(p) for p in targets]
+    if args.json:
+        print(json.dumps(reports, indent=2, ensure_ascii=False))
+    else:
+        _render(reports)
+
+    unanchored = sum(r["unanchored"] for r in reports)
+    return 1 if (args.fail_on_unanchored and unanchored) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lean/tests/test_check_public_anchor.py
+++ b/scripts/lean/tests/test_check_public_anchor.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Tests de ``check_public_anchor`` (issue #8782, 2e etage du gate).
+
+    pytest scripts/lean/tests/test_check_public_anchor.py
+    python  scripts/lean/tests/test_check_public_anchor.py
+
+Les cas sont construits en fixtures Lean minimales : ce qui est teste, c'est la
+**logique d'ancrage**, pas la capacite de Lean a compiler les fixtures. Un seul
+test touche le depot reel (``HashlifeCorrectness.lean``), et il est skippe si le
+module a evolue -- c'est un temoin, pas un oracle fige.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_public_anchor import (  # noqa: E402
+    ANCHORED_PUBLIC,
+    ANCHORED_TRANSITIVE,
+    ANONYMOUS,
+    UNANCHORED,
+    analyze_module,
+    build_reference_graph,
+    main,
+    parse_declarations,
+    public_closure_reaches,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HASHLIFE = (
+    REPO_ROOT
+    / "MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean"
+)
+
+
+def _write(tmp_path: Path, body: str, name: str = "M.lean") -> Path:
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def _verdicts(path: Path) -> list[str]:
+    return [s["verdict"] for s in analyze_module(path)["sites"]]
+
+
+# --------------------------------------------------------------------------
+# Parsing : visibilite, namespaces, commentaires
+# --------------------------------------------------------------------------
+
+
+def test_parse_marks_private_and_public():
+    decls = parse_declarations(
+        "theorem pub : True := trivial\n"
+        "private theorem priv : True := trivial\n"
+        "private lemma with_attr : True := trivial\n"
+    )
+    assert [(d.name, d.private) for d in decls] == [
+        ("pub", False),
+        ("priv", True),
+        ("with_attr", True),
+    ]
+
+
+def test_parse_qualifies_by_namespace_and_handles_root():
+    decls = parse_declarations(
+        "namespace Foo\n"
+        "namespace Bar\n"
+        "theorem inner : True := trivial\n"
+        "end Bar\n"
+        "theorem outer : True := trivial\n"
+        "theorem _root_.escaped : True := trivial\n"
+        "end Foo\n"
+    )
+    assert [d.name for d in decls] == ["Foo.Bar.inner", "Foo.outer", "escaped"]
+
+
+def test_parse_ignores_end_of_section_when_popping_namespace():
+    """``end`` d'une section ne doit pas desequilibrer la pile (cf #8722)."""
+    decls = parse_declarations(
+        "namespace Foo\nsection Helpers\ntheorem a : True := trivial\nend Helpers\n"
+        "theorem b : True := trivial\nend Foo\n"
+    )
+    assert [d.name for d in decls] == ["Foo.a", "Foo.b"]
+
+
+def test_sorry_in_prose_is_ignored(tmp_path):
+    """Le mot ``sorry`` en docstring ou en commentaire ne produit aucun site."""
+    p = _write(
+        tmp_path,
+        "/-- Ce lemme evite un `sorry` en reduisant au cas fini. -/\n"
+        "theorem clean : True := trivial\n"
+        "-- TODO: remplacer le sorry historique\n",
+    )
+    assert _verdicts(p) == []
+
+
+def test_sorryax_and_sorry_prefixed_names_are_not_sorry(tmp_path):
+    p = _write(
+        tmp_path,
+        "theorem a : True := by exact sorryAx _\ntheorem b : True := by sorry_like\n",
+    )
+    assert _verdicts(p) == []
+
+
+# --------------------------------------------------------------------------
+# Ancrage : les quatre verdicts
+# --------------------------------------------------------------------------
+
+
+def test_public_sorry_is_anchored(tmp_path):
+    p = _write(tmp_path, "theorem visible : True := by sorry\n")
+    assert _verdicts(p) == [ANCHORED_PUBLIC]
+
+
+def test_private_cited_by_public_is_transitively_anchored(tmp_path):
+    p = _write(
+        tmp_path,
+        "private theorem helper : True := by sorry\ntheorem exposed : True := by exact helper\n",
+    )
+    assert _verdicts(p) == [ANCHORED_TRANSITIVE]
+
+
+def test_private_cited_by_nobody_is_unanchored(tmp_path):
+    p = _write(tmp_path, "private theorem dead : True := by sorry\n")
+    assert _verdicts(p) == [UNANCHORED]
+
+
+def test_private_chain_private_all_the_way_is_unanchored(tmp_path):
+    """Le coeur du defaut #8782 : chaine privee sur toute sa longueur."""
+    p = _write(
+        tmp_path,
+        "private theorem leaf : True := by sorry\n"
+        "private theorem mid : True := by exact leaf\n"
+        "private theorem top : True := by exact mid\n",
+    )
+    assert _verdicts(p) == [UNANCHORED]
+
+
+def test_private_chain_becomes_anchored_when_a_public_joins_it(tmp_path):
+    """Meme chaine, plus un consommateur public : le gate la voit."""
+    p = _write(
+        tmp_path,
+        "private theorem leaf : True := by sorry\n"
+        "private theorem mid : True := by exact leaf\n"
+        "theorem exposed : True := by exact mid\n",
+    )
+    assert _verdicts(p) == [ANCHORED_TRANSITIVE]
+
+
+def test_example_sorry_is_anonymous(tmp_path):
+    """``example`` n'a pas de nom : jamais enumerable, quelle que soit la chaine."""
+    p = _write(tmp_path, "example : True := by sorry\n")
+    assert _verdicts(p) == [ANONYMOUS]
+
+
+def test_multiple_sorries_attributed_to_their_own_owner(tmp_path):
+    p = _write(
+        tmp_path,
+        "private theorem hidden : True := by\n"
+        "  have h : True := by sorry\n"
+        "  sorry\n"
+        "theorem shown : True := by sorry\n",
+    )
+    assert _verdicts(p) == [UNANCHORED, UNANCHORED, ANCHORED_PUBLIC]
+
+
+def test_short_name_reference_across_namespace_counts(tmp_path):
+    """Une reference intra-namespace en nom court doit creer l'arete."""
+    p = _write(
+        tmp_path,
+        "namespace N\nprivate theorem helper : True := by sorry\n"
+        "theorem exposed : True := by exact helper\nend N\n",
+    )
+    assert _verdicts(p) == [ANCHORED_TRANSITIVE]
+
+
+def test_self_reference_does_not_anchor(tmp_path):
+    """Une declaration recursive ne s'ancre pas elle-meme."""
+    p = _write(tmp_path, "private def loop (n : Nat) : Nat := by sorry\n")
+    assert _verdicts(p) == [UNANCHORED]
+
+
+def test_public_closure_reaches_returns_the_anchors(tmp_path):
+    decls = parse_declarations(
+        "private theorem leaf : True := by sorry\n"
+        "private theorem mid : True := by exact leaf\n"
+        "theorem alpha : True := by exact mid\n"
+        "theorem beta : True := by exact mid\n"
+    )
+    build_reference_graph(decls)
+    reached, anchors = public_closure_reaches("leaf", decls)
+    assert reached and anchors == ["alpha", "beta"]
+
+
+# --------------------------------------------------------------------------
+# Rapport et CLI
+# --------------------------------------------------------------------------
+
+
+def test_module_report_counts(tmp_path):
+    p = _write(
+        tmp_path,
+        "private theorem dead : True := by sorry\ntheorem live : True := by sorry\n",
+    )
+    r = analyze_module(p)
+    assert r["declarations"] == 2
+    assert r["private_declarations"] == 1
+    assert r["sorry_sites"] == 2
+    assert r["unanchored"] == 1
+
+
+def test_clean_module_is_silent(tmp_path):
+    p = _write(tmp_path, "theorem ok : True := trivial\nprivate theorem h : True := trivial\n")
+    r = analyze_module(p)
+    assert r["sorry_sites"] == 0 and r["unanchored"] == 0
+
+
+def test_cli_is_advisory_by_default(tmp_path, capsys):
+    p = _write(tmp_path, "private theorem dead : True := by sorry\n")
+    assert main([str(p)]) == 0
+    assert "unanchored" in capsys.readouterr().out
+
+
+def test_cli_fail_on_unanchored_is_opt_in(tmp_path):
+    p = _write(tmp_path, "private theorem dead : True := by sorry\n")
+    assert main([str(p), "--fail-on-unanchored"]) == 1
+
+
+def test_cli_fail_flag_stays_green_when_all_anchored(tmp_path):
+    p = _write(tmp_path, "theorem shown : True := by sorry\n")
+    assert main([str(p), "--fail-on-unanchored"]) == 0
+
+
+def test_cli_rejects_empty_lake(tmp_path):
+    """Cible vide = erreur, jamais un rapport propre (classe EMPTY_* de #8940)."""
+    (tmp_path / "empty_lake").mkdir()
+    with pytest.raises(SystemExit) as e:
+        main(["--lake", str(tmp_path / "empty_lake")])
+    assert e.value.code == 2
+
+
+def test_cli_rejects_missing_lake(tmp_path):
+    with pytest.raises(SystemExit) as e:
+        main(["--lake", str(tmp_path / "nope")])
+    assert e.value.code == 2
+
+
+def test_cli_rejects_missing_file(tmp_path):
+    with pytest.raises(SystemExit) as e:
+        main([str(tmp_path / "absent.lean")])
+    assert e.value.code == 2
+
+
+def test_cli_ignores_lake_dot_lake_subtree(tmp_path):
+    """Les deps vendorees sous .lake/ ne doivent pas etre analysees."""
+    lake = tmp_path / "lk"
+    (lake / ".lake" / "packages" / "mathlib").mkdir(parents=True)
+    (lake / ".lake" / "packages" / "mathlib" / "Dep.lean").write_text(
+        "private theorem vendored : True := by sorry\n", encoding="utf-8"
+    )
+    (lake / "Own.lean").write_text("theorem mine : True := trivial\n", encoding="utf-8")
+    assert [p.name for p in __import__("check_public_anchor").lean_sources(lake)] == ["Own.lean"]
+
+
+def test_cli_json_is_parseable(tmp_path, capsys):
+    import json
+
+    p = _write(tmp_path, "private theorem dead : True := by sorry\n")
+    assert main([str(p), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["unanchored"] == 1
+
+
+# --------------------------------------------------------------------------
+# Temoin sur le depot reel
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not HASHLIFE.is_file(), reason="conway_lean absent de cet arbre")
+def test_hashlife_exhibits_the_blind_spot():
+    """Temoin #8782 : le module cible par la CI porte des sorry sans ancrage.
+
+    Non fige sur un compte exact (le module evolue, cf #8981) : ce qui est
+    verifie, c'est que la classe de defaut est instanciee ET qu'une partie des
+    sorry est bien visible du gate -- l'angle mort est partiel, pas total.
+    """
+    r = analyze_module(HASHLIFE)
+    if r["sorry_sites"] == 0:
+        pytest.skip("module assaini depuis la mesure de reference")
+    assert r["unanchored"] > 0, "l'angle mort a disparu : mettre a jour le temoin"
+    assert any(s["verdict"] == ANCHORED_PUBLIC for s in r["sites"]), (
+        "aucun sorry public : le module aurait change de nature"
+    )
+    owners = {s["owner"] for s in r["sites"] if s["verdict"] == UNANCHORED}
+    assert all(s["owner_private"] for s in r["sites"] if s["verdict"] == UNANCHORED)
+    assert owners, "les sorry sans ancrage doivent nommer leur porteur"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
`Grain: DEEP/lean — lane myia-po-2025:CoursIA — prev: MED/tooling`

## Summary

`.github/workflows/lean-conway.yml:134-139` énonce une propriété de sûreté :

> Criterion 1 (#8782, reformulated): [...] A module whose sorry sat in a private chain
> no public decl closes would read `enumerated=0` explicitly (lean-axiom.yml guards it),
> **never as a silent clean.**

Cette PR livre l'outil qui **mesure** cette propriété au lieu de la supposer, et
trouve l'instance où elle ne tient pas — sur `origin/main`, aujourd'hui.

Le garde `enumerated=0` se déclenche quand un module **entier** énumère vide. Il ne
peut pas se déclencher pour une déclaration privée orpheline dans un module par
ailleurs sain : `HashlifeCorrectness` énumère 177 déclarations, pas 0. Un `sorry`
porté par une privée que rien ne cite n'apparaît donc dans la clôture d'**aucune**
déclaration énumérée — et le module est bien ciblé, bien énuméré, et rapporte propre.

## Le défaut, instancié

```
$ python scripts/lean/check_public_anchor.py --lake .../conway_lean
Sorry en position code: 9
Dont SANS ancrage     : 1
Couverture du gate    : 8/9 (88.9%)

   L3883   unanchored   Conway.Life.p4_sw_overlap_wall
```

La cérémonie 4 coins de `p4_*_overlap_wall` / `p4_*_supercell_agree` est symétrique
**sauf pour un membre**. Citations en code (après retrait des commentaires) :

| Lemme (tous `private`) | Déclaration | Consommateur |
|---|---|---|
| `p4_nw_overlap_wall` | L2991 | `exact p4_nw_overlap_wall k hk1` (L3354) |
| `p4_ne_supercell_agree` | L3581 | `rw [p4_ne_supercell_agree k hk1` (L3738) |
| **`p4_sw_overlap_wall`** | **L3859** | **aucun** |
| `p4_sw_supercell_agree` | L3906 | `rw [p4_sw_supercell_agree k hk1` (L4028) |
| `p4_se_overlap_wall` | L4082 | `exact p4_se_overlap_wall k hk1` (L4177) |

Les 4 autres sont ancrés transitivement par `hashlifeResult_central_correct` (public),
donc leur `sorryAx` remonte — le mémo #8782 a raison sur eux. `p4_sw_overlap_wall`
est le seul dont la clôture arrière ne contient aucune déclaration publique.

**Un `grep` aurait conclu l'inverse** : ce nom apparaît 4 fois dans le fichier, mais
3 occurrences sont de la prose (« carries the residual `p4_sw_overlap_wall` sorry »,
« (DEFERRED, »). D'où le retrait des commentaires avant analyse — c'est précisément
ce qui sépare ce détecteur d'un compteur d'occurrences.

## Portée : la prémisse tient 46/47

Balayage des 24 lakes du dépôt (statique, sans build) :

| Lake | `sorry` en code | sans ancrage |
|---|---|---|
| `SymbolicAI/Lean/conway_lean` | 9 | **1** |
| `SymbolicAI/Lean/knot_lean` | 32 | 0 |
| `Probas/decision_theory_lean` | 4 | 0 |
| `GameTheory/game_theory_lean` | 2 | 0 |
| **total** | **47** | **1** |

La justification écrite dans `lean_server.py` est donc **correcte dans 46 cas sur 47**.
Cette PR ne renverse pas la conception du gate : elle convertit une hypothèse écrite en
invariant mesurable, et exhibe le seul endroit où elle est fausse — dans le module que
le job `proof-integrity-audit` cible spécifiquement, c'est-à-dire là où un reviewer
accorde le plus de confiance au vert.

## Pourquoi une analyse statique, et pourquoi elle est complète

En Lean 4, `private` est de portée **module** : une déclaration privée n'est pas
référençable depuis un autre module (elle est manglée en
`_private.<Module>.<hash>.<name>` — c'est la raison même pour laquelle
`_enumerate_module_declarations` la saute, #8722). La clôture arrière d'une
déclaration privée est donc **entièrement contenue dans son propre fichier** : une
analyse mono-fichier est *complète* pour cette question, pas approximative. Aucun
kernel, aucun Mathlib construit — l'outil tourne sur n'importe quelle machine, y
compris une lane sans junction Mathlib chaude.

**Biais assumé.** Le graphe de références est bâti sur les noms, donc il
**sur**-approxime les arêtes (un token homonyme d'une locale crée une arête qui
n'existe pas). L'effet va toujours dans le même sens : plus d'arêtes → plus de
chances de trouver un ancrage → **moins** de verdicts `unanchored`. L'outil peut
taire un angle mort réel ; il ne peut pas en inventer un. C'est le bon biais pour un
advisory, et c'est documenté dans le module comme dans le README.

## Livrable (3 fichiers)

- `scripts/lean/check_public_anchor.py` — détecteur. 5 verdicts
  (`anchored_public` / `anchored_transitive` / `unanchored` / `anonymous` /
  `orphan_sorry`), CLI fichiers ou `--lake`, `--json`, advisory **exit 0** par défaut
  (`--fail-on-unanchored` opt-in : l'outil rend visible, il ne décide pas).
  Réutilise `strip_comments` de `check_i18n_siblings.py` (nesting-aware,
  préserve les lignes) plutôt que d'en dupliquer un second.
- `scripts/lean/tests/test_check_public_anchor.py` — **26 tests, tous verts**.
  Couvrent les 5 verdicts, la chaîne privée intégrale, la même chaîne redevenue
  ancrée dès qu'un public la rejoint, `sorry` en docstring/commentaire ignoré,
  `sorryAx` non compté, référence en nom court intra-namespace, `end` de section qui
  ne doit pas dépiler le namespace (#8722), auto-référence qui n'ancre pas, exclusion
  de `.lake/`, et les codes de sortie.
- `scripts/lean/README.md` — une ligne de table + une section (problème, argument de
  complétude, biais, usage, table des verdicts).

Une **cible vide ou absente est une erreur**, pas un rapport propre : un détecteur
d'angle mort qui se tairait parce qu'il n'a rien regardé reproduirait le défaut qu'il
traque (même raison d'être que les classifications `EMPTY_*` de #8940). Défaut trouvé
en écrivant la PR : `--lake <chemin-inexistant>` répondait « fournir au moins un
fichier » — trompeur, puisque l'argument *était* fourni. Corrigé + testé.

## Correction G.1 sur ma propre mesure

Ma première mesure — postée en `[CLAIMED]` sur le dashboard — annonçait **8 `sorry`
dont 5 sans ancrage** sous `p4_nw_supercell_agree` / `p4_se_shift_lemma`, et affirmait
que `check_target_coverage.py` était absent du dépôt malgré #8787. **Les trois sont
faux** : je mesurais sur l'arbre partagé `d:\dev\CoursIA`, périmé
(`bcadb97d292d` ≠ `8965d65eba4e` sur `origin/main`). La mesure juste est 9 `sorry` /
1 sans ancrage — et `scripts/lean/check_target_coverage.py` **existe**, avec son test.
Mes prétendues « corrections » au mémo d'ai-01 du 07-29 (numéros de ligne périmés,
`p4_nw_overlap_wall` introuvable) étaient elles aussi l'artefact de cet arbre : le mémo
était exact. Retracté sur le dashboard.

Le compte de 9 corrobore indépendamment le `sorry-baseline: "9"` de `lean-conway.yml:93`.

## Hors scope, explicitement

- **Câblage CI.** Aucun workflow n'est modifié ici. Précédent établi : outil (#8787),
  puis câblage (#8794), puis pytest (#8789) — PRs distinctes. `--fail-on-unanchored`
  existe pour ce câblage futur mais reste inactif.
- **Le `sorry` lui-même.** `p4_sw_overlap_wall` appartient au front **#6724**, dont
  l'historique (`b20ba9bc2`, #9565) est une réfutation machine-vérifiée des murs P4 NW.
  Son propriétaire décide s'il faut le prouver, le brancher, ou le retirer comme code
  mort — je ne touche pas le `.lean` (anti-régression : pas de suppression sans le
  diagnostic du propriétaire).
- **Critère 4 de #8782** — reste gated sur le sign-off user
  (`pr-review-discipline.md` §B.3), non abordé.
- **Signalé, non corrigé** : la table de `scripts/lean/README.md` omet 4 outils
  existants (`check_i18n_siblings`, `check_target_coverage`, `check_mathlib_cache`,
  `audit_conway_blocking_gate_whitelist`) ; et `lean-conway.yml` écrit « 8 sorries »
  L141 contre « 9 » L12/L17/L93/L120. Deux tranches doc distinctes, pas ce sujet.

See #8782
