### PR TITLE
feat(ict,#7290): test de contextualite possibiliste (CSP) + garde anti-analogie-decorative

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/proxy_contextuality.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/proxy_contextuality.py
@@ -1,0 +1,768 @@
+"""Contextualite du zoo de proxys -- section globale ou obstruction (ICT #7290).
+
+Le probleme
+-----------
+La synthese cross-substrat de la serie a falsifie le *scalaire universel* :
+deux proxys de l'integration se suivent (Phi, F : tau = +1.00) quand un
+troisieme diverge (K). Le constat courant s'arrete a « les proxys sont en
+desaccord » -- un enonce **statistique**.
+
+Ce module pose la question strictement plus forte, celle de Kochen-Specker :
+**existe-t-il seulement une assignation de valeurs independante du
+contexte ?** Si les proxys mesures dans des contextes differents (fenetres,
+coarse-grainings, regimes de perturbation) n'admettent *aucune* assignation
+globale coherente, le desaccord n'est pas un bruit a moyenner : c'est une
+**obstruction de structure**.
+
+Le cadre n'est pas invente ici. Le depot le nomme deja
+(``docs/ict/synthese-invariants-dissociations-obstructions.md``) : lecture
+faisceautique d'**Abramsky-Brandenburger**, ou la contextualite se pose « en
+probleme de contraintes ou la section se recolle (SAT) ou se refuse (UNSAT) ».
+Formellement, un *modele empirique* est une famille de distributions sur des
+contextes de mesure ; sa version **possibiliste** ne retient que les supports,
+et la question « une section globale existe-t-elle ? » devient litteralement un
+CSP a contraintes extensionnelles (tables de tuples autorises).
+
+Les trois crans d'Abramsky-Brandenburger
+----------------------------------------
+La hierarchie importe, parce qu'elle est ce qui empeche un verdict SAT d'etre
+une impasse :
+
+1. **Fortement contextuel** -- aucune section globale. C'est le cran de
+   Kochen-Specker. Verdict :data:`STRONGLY_CONTEXTUAL`.
+2. **Logiquement contextuel** -- des sections globales existent, mais au moins
+   une section *locale* effectivement observee ne s'etend a aucune d'elles.
+   L'obstruction est partielle : elle porte sur un evenement, pas sur le
+   modele entier. Verdict :data:`LOGICALLY_CONTEXTUAL`.
+3. **Non contextuel** -- toute section locale observee s'etend globalement.
+   Verdict :data:`NON_CONTEXTUAL`. C'est le NON-resultat, et il est publiable
+   tel quel : il clot la piste KS proprement.
+
+Un SAT brut ne dit donc que « pas *fortement* contextuel ». Repondre « le zoo
+est non-contextuel » exige le cran 2 en plus -- c'est
+:func:`logical_contextuality` qui le tranche.
+
+Les trois degenerescences (le garde-fou anti-analogie-decorative)
+----------------------------------------------------------------
+Le risque nomme par l'issue #7290 est « l'analogie decorative ». Trois
+degenerescences rendent le test vide, et le module refuse de rendre un verdict
+de contextualite dans ces cas :
+
+* **Recouvrement total** (:data:`DEGENERATE_SINGLE_COVER`) -- si tous les
+  contextes co-mesurent *le meme* ensemble de proxys, le recouvrement est
+  trivial : la question « une section globale existe-t-elle ? » se reduit a
+  « l'intersection des supports est-elle non vide ? ». C'est une question
+  d'**accord entre protocoles**, pas de contextualite : la contextualite exige
+  des contextes qui se recouvrent *partiellement* (A={p,q}, B={q,r}, C={r,p}),
+  car c'est ce chevauchement partiel qui fait qu'une valeur assignee dans un
+  contexte contraint un autre contexte sans etre determinee par lui. C'est la
+  degenerescence que le zoo ICT exhibe aujourd'hui (voir la section « Portee
+  du resultat » ci-dessous).
+* **Aucun recouvrement** (:data:`DEGENERATE_NO_OVERLAP`) -- symetrique du
+  precedent, a l'autre extreme : si aucun proxy n'apparait dans deux contextes,
+  les contextes sont independants et une assignation globale existe *par
+  construction* (on choisit chaque contexte separement). Un « SAT » n'y mesure
+  rien.
+* **Supports rigides** (:data:`DEGENERATE_RIGID`) -- si chaque contexte n'a
+  qu'un seul tuple dans son support (une seule mesure, aucune variabilite),
+  alors UNSAT signifie seulement « un proxy a change de valeur d'un contexte a
+  l'autre ». C'est un constat de dissociation deja acquis (regime 2 de la
+  grille #7399), pas une obstruction. La force de KS est qu'aucune assignation
+  ne marche *alors que chaque contexte laisse localement plusieurs choix* : il
+  faut donc des supports non triviaux, obtenus en mesurant chaque contexte sur
+  plusieurs graines.
+
+C'est la meme lecon qu'ICT-15d, ou la cochaine de Cech rendait ``TRIVIAL``
+parce que les sections etaient colineaires *par construction* (rang 1) : un
+verdict n'a de valeur que si sa negation etait atteignable.
+
+Portee du resultat sur le zoo ICT (mesure, 2026-08)
+---------------------------------------------------
+Applique aux proxys de la serie, le diagnostic rend
+:data:`DEGENERATE_SINGLE_COVER`, et la raison est **structurelle, pas
+contingente** : les trois proxys du zoo (``spectral_gap``,
+``sensitivity_mean``, ``sensitivity_max``) partagent la meme signature
+``(states, n_symbols)``. Rien n'empeche de les calculer tous les trois sur la
+meme trajectoire, dans le meme pretraitement -- ils sont **conjointement
+mesurables**. Or c'est exactement la *non*-co-mesurabilite (la
+non-commutativite, chez KS) qui cree les contextes distincts et rend la
+contextualite possible.
+
+Conclusion honnete : l'analogie Kochen-Specker ne meurt pas d'un SAT, elle
+meurt **un cran plus tot**, faute de recouvrement non trivial. Le zoo ICT
+n'est pas « non contextuel » ; la question de sa contextualite n'est pas encore
+*posable*. L'ingredient manquant est identifie et unique : une structure de
+co-mesurabilite **partielle et justifiee** -- deux proxys dont les
+pretraitements sont genuinement incompatibles, de sorte qu'aucun protocole ne
+les livre ensemble. Tant qu'elle n'est pas etablie, tout hypergraphe
+proxys x contextes serait une decoration.
+
+Le module est donc livre avec son detecteur valide (fixtures a
+insatisfiabilite prouvee a la main) et son garde-fou : le jour ou une telle
+structure est justifiee, le test se pose sans reecriture.
+
+Ce que ce module n'est pas
+--------------------------
+* Ce n'est pas :mod:`ict.meta_proxy` (#7395), qui mesure la **dispersion
+  numerique** des desaccords (verdicts ``STABLE`` / ``NOISE``).
+* Ce n'est pas :mod:`ict.cech_obstruction` (#7744), qui calcule une
+  **holonomie intra-substrat** (cobord, cocycle).
+  Ici la question est **combinatoire** et son verdict est binaire : la section
+  se recolle, ou elle ne se recolle pas.
+
+Points de rupture avec le cas quantique (honnetete de l'analogie)
+-----------------------------------------------------------------
+1. **Origine des contraintes.** Chez KS elles viennent de l'algebre
+   (orthogonalite, relations fonctionnelles) : *a priori* et exactes. Ici
+   elles viennent de mesures : un UNSAT peut etre un artefact
+   d'echantillonnage. D'ou l'exigence de supports mesures sur plusieurs
+   graines, et le report explicite du protocole.
+2. **Identite des observables.** En mecanique quantique, « le meme
+   observable » dans deux contextes est *le meme operateur*, par definition.
+   Ici, un proxy mesure sous deux fenetres n'est pas garanti etre la meme
+   grandeur : l'identite cross-contexte est une **hypothese**, la plus forte
+   du transfert.
+3. **Pas de theoreme de dimension.** KS exige dim >= 3 et des configurations
+   de rayons precises ; rien de tel ne contraint le zoo. L'absence
+   d'obstruction ici n'a donc aucune portee sur KS, et reciproquement.
+4. **Discretisation.** Les proxys sont des reels ; les rendre des issues
+   discretes est un **choix** (seuils), pas une donnee. Le verdict doit etre
+   reporte avec sa sensibilite a ce choix.
+
+Numpy n'est meme pas requis (combinatoire pure). Le solveur CP-SAT d'OR-Tools
+est utilise quand il est disponible -- ``AddAllowedAssignments`` code
+exactement une contrainte de support -- et le module croise systematiquement
+son verdict avec une enumeration exhaustive deterministe sur les instances
+assez petites. Le verdict SAT/UNSAT est deterministe meme si le *temoin*
+choisi par CP-SAT ne l'est pas (cf. la lecon du gate de determinisme du
+depot) : on ne rapporte donc jamais un temoin CP-SAT sans le canonicaliser
+par l'enumeration.
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+# --------------------------------------------------------------------------- #
+#  Verdicts                                                                    #
+# --------------------------------------------------------------------------- #
+STRONGLY_CONTEXTUAL = "strongly_contextual"
+LOGICALLY_CONTEXTUAL = "logically_contextual"
+NON_CONTEXTUAL = "non_contextual"
+DEGENERATE_SINGLE_COVER = "degenerate_single_cover"
+DEGENERATE_NO_OVERLAP = "degenerate_no_overlap"
+DEGENERATE_RIGID = "degenerate_rigid"
+INCONCLUSIVE_TOO_LARGE = "inconclusive_too_large"
+
+#: Plafond par defaut de l'enumeration exhaustive (nombre d'assignations
+#: candidates). Au-dela, l'enumeration rend ``INCONCLUSIVE_TOO_LARGE`` plutot
+#: que de tourner sans borne -- une cible trop grande est un fait a rapporter,
+#: pas un silence.
+DEFAULT_MAX_SEARCH = 1 << 22
+
+
+@dataclass(frozen=True)
+class Context:
+    """Un contexte de mesure : des proxys co-mesures, et le support observe.
+
+    ``proxies`` est le tuple (ordonne) des proxys co-mesurables dans ce
+    protocole. ``support`` est l'ensemble des tuples d'issues effectivement
+    observes, chacun de meme arite que ``proxies`` -- c'est le support de la
+    distribution empirique du contexte, au sens d'Abramsky-Brandenburger.
+
+    Un support **vide** est une erreur, jamais un contexte « sans contrainte » :
+    un contexte qu'on n'a pas mesure ne doit pas se faire passer pour un
+    contexte permissif (meme raison d'etre que les classes ``EMPTY_*`` du
+    depot -- une cible non regardee ne rend pas un rapport propre).
+    """
+
+    proxies: Tuple[str, ...]
+    support: Tuple[Tuple[int, ...], ...]
+
+    def __post_init__(self) -> None:
+        if not self.proxies:
+            raise ValueError("un contexte doit porter au moins un proxy")
+        if len(set(self.proxies)) != len(self.proxies):
+            raise ValueError(f"proxys dupliques dans un contexte : {self.proxies}")
+        if not self.support:
+            raise ValueError(
+                f"support vide pour le contexte {self.proxies} : un contexte non "
+                "mesure n'est pas un contexte sans contrainte"
+            )
+        arity = len(self.proxies)
+        for tup in self.support:
+            if len(tup) != arity:
+                raise ValueError(
+                    f"tuple {tup} d'arite {len(tup)} dans un contexte d'arite {arity}"
+                )
+
+    def restrict(self, assignment: Mapping[str, int]) -> Tuple[int, ...]:
+        """Restriction d'une assignation globale a ce contexte."""
+        return tuple(assignment[p] for p in self.proxies)
+
+    def admits(self, assignment: Mapping[str, int]) -> bool:
+        """``True`` si la restriction de ``assignment`` tombe dans le support."""
+        return self.restrict(assignment) in set(self.support)
+
+
+@dataclass(frozen=True)
+class EmpiricalModel:
+    """Famille de contextes sur un alphabet d'issues commun.
+
+    C'est le modele empirique possibiliste : on ne retient des distributions
+    que leurs supports, ce qui suffit aux crans 1 et 2 de la hierarchie.
+    """
+
+    contexts: Tuple[Context, ...]
+    outcomes: Tuple[int, ...]
+
+    @property
+    def measurements(self) -> Tuple[str, ...]:
+        """Tous les proxys du modele, ordonnes (deterministe)."""
+        seen: List[str] = []
+        for ctx in self.contexts:
+            for p in ctx.proxies:
+                if p not in seen:
+                    seen.append(p)
+        return tuple(sorted(seen))
+
+    @property
+    def search_space(self) -> int:
+        """Nombre d'assignations globales candidates."""
+        return len(self.outcomes) ** len(self.measurements)
+
+
+def empirical_model(
+    contexts: Iterable[Mapping[str, object] | Context],
+    outcomes: Optional[Sequence[int]] = None,
+) -> EmpiricalModel:
+    """Construit un :class:`EmpiricalModel` valide.
+
+    ``contexts`` accepte des :class:`Context` ou des mappings
+    ``{"proxies": [...], "support": [...]}``. ``outcomes`` par defaut est
+    l'ensemble des issues apparaissant dans les supports.
+
+    Valide que chaque issue de chaque support appartient bien a l'alphabet :
+    une issue hors alphabet est une erreur de construction, pas une issue
+    silencieusement ignoree.
+    """
+    built: List[Context] = []
+    for c in contexts:
+        if isinstance(c, Context):
+            built.append(c)
+        else:
+            built.append(
+                Context(
+                    proxies=tuple(str(p) for p in c["proxies"]),  # type: ignore[index]
+                    support=tuple(
+                        tuple(int(v) for v in tup)
+                        for tup in c["support"]  # type: ignore[index]
+                    ),
+                )
+            )
+    if not built:
+        raise ValueError("un modele empirique doit contenir au moins un contexte")
+
+    observed = sorted({v for ctx in built for tup in ctx.support for v in tup})
+    alphabet = tuple(int(o) for o in outcomes) if outcomes is not None else tuple(observed)
+    if len(alphabet) < 2:
+        raise ValueError(
+            f"alphabet d'issues trivial ({alphabet}) : avec une seule issue "
+            "possible, toute assignation est forcee et la question est vide"
+        )
+    unknown = set(observed) - set(alphabet)
+    if unknown:
+        raise ValueError(f"issues hors alphabet {alphabet} dans les supports : {sorted(unknown)}")
+
+    return EmpiricalModel(contexts=tuple(built), outcomes=alphabet)
+
+
+# --------------------------------------------------------------------------- #
+#  1. Degenerescences : le test est-il seulement capable de trancher ?          #
+# --------------------------------------------------------------------------- #
+def overlap_report(model: EmpiricalModel) -> Dict[str, object]:
+    """Diagnostique la structure de recouvrement AVANT tout verdict.
+
+    Un test dont la reponse est forcee par la construction ne mesure rien.
+    Cette fonction rend explicite laquelle des deux degenerescences s'applique
+    (cf. docstring du module) :
+
+    * ``degenerate_no_overlap`` : aucun proxy n'est partage par deux contextes
+      -- SAT est force, un verdict « non contextuel » serait vide.
+    * ``degenerate_rigid`` : tous les supports sont des singletons -- UNSAT
+      serait un simple constat de dissociation, pas une obstruction.
+
+    Les deux peuvent etre vraies simultanement ; ``degeneracy`` retient alors
+    l'absence de recouvrement, qui est la plus forte (elle force le verdict).
+    """
+    multiplicity: Dict[str, int] = {}
+    for ctx in model.contexts:
+        for p in ctx.proxies:
+            multiplicity[p] = multiplicity.get(p, 0) + 1
+    shared = sorted(p for p, n in multiplicity.items() if n >= 2)
+
+    support_sizes = [len(ctx.support) for ctx in model.contexts]
+    all_singletons = all(s == 1 for s in support_sizes)
+
+    distinct_covers = {frozenset(ctx.proxies) for ctx in model.contexts}
+
+    degeneracy: Optional[str] = None
+    reason = ""
+    if len(distinct_covers) == 1:
+        degeneracy = DEGENERATE_SINGLE_COVER
+        reason = (
+            "tous les contextes co-mesurent le meme ensemble de proxys : le "
+            "recouvrement est trivial et la question se reduit a "
+            "« l'intersection des supports est-elle non vide ? » (accord entre "
+            "protocoles). La contextualite exige un recouvrement PARTIEL "
+            "(A={p,q}, B={q,r}, C={r,p}), donc des proxys non conjointement "
+            "mesurables"
+        )
+    elif not shared:
+        degeneracy = DEGENERATE_NO_OVERLAP
+        reason = (
+            "aucun proxy n'est co-mesure dans deux contextes : les contextes "
+            "sont independants, une section globale existe par construction"
+        )
+    elif all_singletons:
+        degeneracy = DEGENERATE_RIGID
+        reason = (
+            "tous les supports sont des singletons : un UNSAT signifierait "
+            "seulement qu'un proxy change de valeur d'un contexte a l'autre "
+            "(dissociation, regime 2), pas une obstruction de structure"
+        )
+
+    return {
+        "context_multiplicity": dict(sorted(multiplicity.items())),
+        "shared_proxies": shared,
+        "n_shared_proxies": len(shared),
+        "n_distinct_covers": len(distinct_covers),
+        "support_sizes": support_sizes,
+        "min_support_size": min(support_sizes),
+        "max_support_size": max(support_sizes),
+        "degeneracy": degeneracy,
+        "degeneracy_reason": reason,
+        "search_space": model.search_space,
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  2. Sections globales : enumeration exhaustive (oracle deterministe)          #
+# --------------------------------------------------------------------------- #
+def global_sections(
+    model: EmpiricalModel,
+    *,
+    max_search: int = DEFAULT_MAX_SEARCH,
+    limit: Optional[int] = None,
+) -> List[Dict[str, int]]:
+    """Enumere les sections globales, exhaustivement et deterministiquement.
+
+    Une *section globale* est une assignation ``proxy -> issue`` dont la
+    restriction a chaque contexte tombe dans le support de ce contexte. La
+    liste rendue est ordonnee de facon reproductible (ordre lexicographique
+    des issues sur les proxys tries) : c'est l'oracle qui canonicalise les
+    temoins de CP-SAT.
+
+    Leve :class:`OverflowError` si l'espace de recherche depasse
+    ``max_search`` -- une cible trop grande doit etre rapportee, pas
+    silencieusement tronquee.
+    """
+    if model.search_space > max_search:
+        raise OverflowError(
+            f"espace de recherche {model.search_space} > max_search {max_search}"
+        )
+    proxies = model.measurements
+    position = {p: i for i, p in enumerate(proxies)}
+    # Supports pre-calcules une seule fois (les reconstruire dans la boucle
+    # dominerait le cout de l'enumeration).
+    constraints = [
+        (tuple(position[p] for p in ctx.proxies), frozenset(ctx.support))
+        for ctx in model.contexts
+    ]
+    found: List[Dict[str, int]] = []
+    for combo in itertools.product(model.outcomes, repeat=len(proxies)):
+        if all(tuple(combo[i] for i in idx) in sup for idx, sup in constraints):
+            found.append(dict(zip(proxies, combo)))
+            if limit is not None and len(found) >= limit:
+                break
+    return found
+
+
+def global_sections_cpsat(model: EmpiricalModel) -> Dict[str, object]:
+    """Meme question, posee au solveur CP-SAT (outillage CSP du depot).
+
+    Chaque contexte devient une contrainte extensionnelle
+    ``AddAllowedAssignments`` : c'est *exactement* la definition d'un support,
+    sans encodage intermediaire. Rend ``{"available": False}`` si OR-Tools est
+    absent -- l'appelant garde alors l'oracle exhaustif, aucun resultat n'est
+    fabrique.
+
+    Ne rend **jamais** de temoin : la solution exhibee par CP-SAT n'est pas
+    deterministe d'un run a l'autre. Seul le statut SAT/UNSAT l'est, et c'est
+    lui seul qui est rapporte.
+    """
+    try:
+        from ortools.sat.python import cp_model
+    except ImportError:
+        return {"available": False, "satisfiable": None}
+
+    proxies = model.measurements
+    index = {p: i for i, p in enumerate(proxies)}
+    lo, hi = min(model.outcomes), max(model.outcomes)
+
+    m = cp_model.CpModel()
+    vars_ = [m.NewIntVar(lo, hi, f"v_{p}") for p in proxies]
+    # L'alphabet peut etre non contigu : restreindre explicitement.
+    allowed_values = set(model.outcomes)
+    if allowed_values != set(range(lo, hi + 1)):
+        for v in vars_:
+            m.AddAllowedAssignments([v], [(o,) for o in model.outcomes])
+
+    for ctx in model.contexts:
+        m.AddAllowedAssignments(
+            [vars_[index[p]] for p in ctx.proxies],
+            [tuple(int(x) for x in tup) for tup in ctx.support],
+        )
+
+    solver = cp_model.CpSolver()
+    solver.parameters.num_search_workers = 1
+    status = solver.Solve(m)
+    satisfiable = status in (cp_model.OPTIMAL, cp_model.FEASIBLE)
+    return {
+        "available": True,
+        "satisfiable": bool(satisfiable),
+        "status_name": solver.StatusName(status),
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  3. Cran 2 : contextualite logique (une section locale sans extension)        #
+# --------------------------------------------------------------------------- #
+def logical_contextuality(
+    model: EmpiricalModel, *, max_search: int = DEFAULT_MAX_SEARCH
+) -> Dict[str, object]:
+    """Cherche les sections locales observees qui ne s'etendent pas globalement.
+
+    C'est le cran 2 de la hierarchie : le modele peut admettre des sections
+    globales (donc n'etre pas *fortement* contextuel) tout en contenant un
+    evenement local observe qu'aucune section globale ne realise. L'obstruction
+    est alors localisee sur cet evenement.
+
+    C'est ce qui empeche un SAT d'etre une impasse : « pas fortement
+    contextuel » n'autorise pas a conclure « non contextuel ».
+    """
+    sections = global_sections(model, max_search=max_search)
+    witnesses: List[Dict[str, object]] = []
+    n_local = 0
+    for ci, ctx in enumerate(model.contexts):
+        for tup in ctx.support:
+            n_local += 1
+            extends = any(ctx.restrict(s) == tup for s in sections)
+            if not extends:
+                witnesses.append(
+                    {"context_index": ci, "proxies": list(ctx.proxies), "outcome": list(tup)}
+                )
+    return {
+        "n_global_sections": len(sections),
+        "n_local_sections": n_local,
+        "n_without_extension": len(witnesses),
+        "logically_contextual": bool(sections) and bool(witnesses),
+        "witnesses": witnesses,
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  4. Caracterisation minimale de l'obstruction                                 #
+# --------------------------------------------------------------------------- #
+def minimal_obstruction(
+    model: EmpiricalModel, *, max_search: int = DEFAULT_MAX_SEARCH
+) -> Optional[Tuple[int, ...]]:
+    """Plus petite sous-famille de contextes deja insatisfiable (par deletion).
+
+    L'issue #7290 demande, en cas d'obstruction, de la « caracteriser
+    minimalement ». On retire les contextes un a un tant que l'insatisfiabilite
+    survit : le resultat est une sous-famille **irreductible** (retirer
+    n'importe lequel de ses contextes la rend satisfiable), ce qui identifie
+    *quels protocoles de mesure* portent le conflit.
+
+    Rend ``None`` si le modele complet est satisfiable. Deterministe :
+    l'ordre de deletion est l'ordre des contextes.
+    """
+    if global_sections(model, max_search=max_search, limit=1):
+        return None
+
+    keep = list(range(len(model.contexts)))
+    changed = True
+    while changed:
+        changed = False
+        for ci in list(keep):
+            if len(keep) == 1:
+                break
+            trial = [i for i in keep if i != ci]
+            sub = EmpiricalModel(
+                contexts=tuple(model.contexts[i] for i in trial), outcomes=model.outcomes
+            )
+            if not global_sections(sub, max_search=max_search, limit=1):
+                keep = trial
+                changed = True
+    return tuple(keep)
+
+
+# --------------------------------------------------------------------------- #
+#  5. Verdict                                                                   #
+# --------------------------------------------------------------------------- #
+def contextuality_verdict(
+    model: EmpiricalModel,
+    *,
+    max_search: int = DEFAULT_MAX_SEARCH,
+    cross_check: bool = True,
+) -> Dict[str, object]:
+    """Verdict complet : degenerescence, puis cran de la hierarchie.
+
+    L'ordre est deliberement celui-ci : **la degenerescence est examinee
+    avant** toute affirmation de contextualite. Un modele degenere ne recoit
+    jamais ``NON_CONTEXTUAL`` ni ``STRONGLY_CONTEXTUAL`` : il recoit son
+    verdict de degenerescence, qui dit que le test n'etait pas capable de
+    trancher. C'est le garde-fou anti-analogie-decorative.
+
+    Si ``cross_check`` et OR-Tools present, le statut CP-SAT est compare a
+    l'oracle exhaustif ; un desaccord leve :class:`RuntimeError` (c'est un bug,
+    jamais un resultat).
+    """
+    report = overlap_report(model)
+    out: Dict[str, object] = {"overlap": report}
+
+    too_large = model.search_space > max_search
+    sat_exhaustive: Optional[bool] = None
+    if not too_large:
+        sat_exhaustive = bool(global_sections(model, max_search=max_search, limit=1))
+
+    cp = global_sections_cpsat(model) if cross_check else {"available": False}
+    out["cpsat"] = cp
+    if cp.get("available") and sat_exhaustive is not None:
+        if bool(cp["satisfiable"]) != sat_exhaustive:
+            raise RuntimeError(
+                "desaccord CP-SAT / enumeration exhaustive "
+                f"({cp['satisfiable']} vs {sat_exhaustive}) : bug d'encodage, "
+                "pas un resultat"
+            )
+
+    satisfiable = sat_exhaustive if sat_exhaustive is not None else cp.get("satisfiable")
+    out["satisfiable"] = satisfiable
+
+    if report["degeneracy"] is not None:
+        out["verdict"] = report["degeneracy"]
+        out["rationale"] = report["degeneracy_reason"]
+        return out
+
+    if satisfiable is None:
+        out["verdict"] = INCONCLUSIVE_TOO_LARGE
+        out["rationale"] = (
+            f"espace de recherche {model.search_space} > max_search {max_search} "
+            "et CP-SAT indisponible"
+        )
+        return out
+
+    if not satisfiable:
+        out["verdict"] = STRONGLY_CONTEXTUAL
+        out["rationale"] = (
+            "aucune assignation globale ne se restreint dans le support de tous "
+            "les contextes : obstruction au recollement (cran KS)"
+        )
+        if not too_large:
+            out["minimal_obstruction"] = minimal_obstruction(model, max_search=max_search)
+        return out
+
+    if too_large:
+        out["verdict"] = INCONCLUSIVE_TOO_LARGE
+        out["rationale"] = (
+            "CP-SAT rend SAT mais l'espace de recherche interdit l'examen du "
+            "cran 2 (contextualite logique) : verdict incomplet"
+        )
+        return out
+
+    logical = logical_contextuality(model, max_search=max_search)
+    out["logical"] = logical
+    if logical["logically_contextual"]:
+        out["verdict"] = LOGICALLY_CONTEXTUAL
+        out["rationale"] = (
+            f"{logical['n_without_extension']} section(s) locale(s) observee(s) ne "
+            "s'etendent a aucune section globale : obstruction partielle, "
+            "localisee sur ces evenements"
+        )
+    else:
+        out["verdict"] = NON_CONTEXTUAL
+        out["rationale"] = (
+            f"{logical['n_global_sections']} section(s) globale(s), et toute section "
+            "locale observee s'etend : le zoo est non contextuel sur ce modele, "
+            "l'analogie KS meurt proprement"
+        )
+    return out
+
+
+# --------------------------------------------------------------------------- #
+#  6. Pont mesures -> modele empirique                                          #
+# --------------------------------------------------------------------------- #
+def median_split_thresholds(
+    signatures: Mapping[str, Sequence[Mapping[str, float]]], proxies: Sequence[str]
+) -> Dict[str, float]:
+    """Seuils de discretisation : mediane de chaque proxy, toutes mesures confondues.
+
+    La discretisation est un **choix**, pas une donnee (point de rupture 4).
+    Ce seuil-la est le moins arbitraire disponible : il est calcule sur
+    l'ensemble des mesures, donc il ne privilegie aucun contexte, et il garantit
+    que chaque proxy prend effectivement ses deux issues sur l'ensemble du
+    corpus (sans quoi le proxy serait constant, donc sans pouvoir discriminant).
+    """
+    thresholds: Dict[str, float] = {}
+    for p in proxies:
+        vals = sorted(
+            float(run[p]) for runs in signatures.values() for run in runs if p in run
+        )
+        if not vals:
+            raise ValueError(f"aucune mesure pour le proxy {p!r}")
+        n = len(vals)
+        thresholds[p] = vals[n // 2] if n % 2 else 0.5 * (vals[n // 2 - 1] + vals[n // 2])
+    return thresholds
+
+
+def model_from_signatures(
+    signatures: Mapping[str, Sequence[Mapping[str, float]]],
+    proxies: Sequence[str],
+    *,
+    thresholds: Optional[Mapping[str, float]] = None,
+) -> Tuple[EmpiricalModel, Dict[str, float]]:
+    """Construit le modele empirique depuis des mesures reelles.
+
+    ``signatures`` associe a chaque contexte la liste de ses signatures
+    mesurees -- **une par graine**. C'est cette pluralite qui donne au support
+    plus d'un element, et donc au test une chance de trancher autrement que
+    par rigidite (cf. :data:`DEGENERATE_RIGID`) : mesurer un contexte une seule
+    fois rend le test vide, quelle que soit la suite.
+
+    Discretisation binaire par seuil : ``1`` si la valeur est ``>=`` seuil,
+    ``0`` sinon. Rend le modele et les seuils effectivement utilises (a
+    rapporter avec le verdict, pour que sa sensibilite au choix soit
+    verifiable).
+
+    .. warning::
+       Ce pont affecte **tous** les proxys a **chaque** contexte, donc le modele
+       produit est necessairement :data:`DEGENERATE_SINGLE_COVER`. Ce n'est pas
+       une limite d'implementation : c'est le constat mesure sur le zoo ICT
+       (proxys conjointement mesurables, cf. « Portee du resultat »). Construire
+       un modele a recouvrement partiel exige de *justifier* quels proxys ne
+       sont pas conjointement mesurables -- ce que ce pont ne peut pas deviner,
+       et ne doit donc pas simuler.
+    """
+    proxies = tuple(proxies)
+    # Valider les contextes AVANT de calculer les seuils : sinon un contexte
+    # vide remonte comme "aucune mesure pour le proxy X" (le symptome) au lieu
+    # de "contexte X sans aucune mesure" (la cause).
+    for name, runs in signatures.items():
+        if not runs:
+            raise ValueError(f"contexte {name!r} sans aucune mesure")
+
+    thr = dict(thresholds) if thresholds is not None else median_split_thresholds(
+        signatures, proxies
+    )
+    contexts: List[Context] = []
+    for name, runs in signatures.items():
+        support = {
+            tuple(1 if float(run[p]) >= thr[p] else 0 for p in proxies) for run in runs
+        }
+        contexts.append(Context(proxies=proxies, support=tuple(sorted(support))))
+    return empirical_model(contexts, outcomes=(0, 1)), thr
+
+
+# --------------------------------------------------------------------------- #
+#  7. Fixtures de validation : le detecteur detecte-t-il ?                      #
+# --------------------------------------------------------------------------- #
+def pr_box_model() -> EmpiricalModel:
+    """La boite PR (Popescu-Rohrlich) : fortement contextuelle, par parite.
+
+    Quatre observables ``a1, a2, b1, b2``, quatre contextes ``(ai, bj)``,
+    issues ``{0, 1}``. Le support impose ``x XOR y = 0`` sauf dans le contexte
+    ``(a2, b2)`` ou il impose ``1``.
+
+    L'insatisfiabilite se **prouve a la main**, ce qui en fait un oracle et non
+    une croyance : sommer les quatre contraintes donne
+    ``2*(a1 + a2 + b1 + b2) = 1 (mod 2)``, dont le membre gauche est pair et le
+    droit impair. Aucune assignation globale n'existe. Un detecteur qui rendrait
+    SAT ici serait casse.
+    """
+    xor0 = ((0, 0), (1, 1))
+    xor1 = ((0, 1), (1, 0))
+    return empirical_model(
+        [
+            Context(("a1", "b1"), xor0),
+            Context(("a1", "b2"), xor0),
+            Context(("a2", "b1"), xor0),
+            Context(("a2", "b2"), xor1),
+        ],
+        outcomes=(0, 1),
+    )
+
+
+def logically_but_not_strongly_contextual_model() -> EmpiricalModel:
+    """Sections globales existent, mais un evenement observe ne s'etend pas.
+
+    Construction : la boite PR dont on elargit le dernier contexte pour laisser
+    passer ``(0, 0)``. Le modele devient satisfiable (``a1=a2=b1=b2=0`` est une
+    section globale), mais les tuples ``(0, 1)`` et ``(1, 0)`` du contexte
+    ``(a2, b2)`` restent sans extension -- l'obstruction survit, localisee.
+
+    Cette fixture est ce qui rend le cran 2 non decoratif : elle exhibe un
+    modele que le seul test SAT declarerait « non contextuel » a tort.
+    """
+    xor0 = ((0, 0), (1, 1))
+    return empirical_model(
+        [
+            Context(("a1", "b1"), xor0),
+            Context(("a1", "b2"), xor0),
+            Context(("a2", "b1"), xor0),
+            Context(("a2", "b2"), ((0, 0), (0, 1), (1, 0))),
+        ],
+        outcomes=(0, 1),
+    )
+
+
+def non_contextual_model() -> EmpiricalModel:
+    """Modele plein : toute section locale s'etend (le NON-resultat)."""
+    full = ((0, 0), (0, 1), (1, 0), (1, 1))
+    return empirical_model(
+        [
+            Context(("a1", "b1"), full),
+            Context(("a1", "b2"), full),
+            Context(("a2", "b1"), full),
+            Context(("a2", "b2"), full),
+        ],
+        outcomes=(0, 1),
+    )
+
+
+__all__ = [
+    "STRONGLY_CONTEXTUAL",
+    "LOGICALLY_CONTEXTUAL",
+    "NON_CONTEXTUAL",
+    "DEGENERATE_SINGLE_COVER",
+    "DEGENERATE_NO_OVERLAP",
+    "DEGENERATE_RIGID",
+    "INCONCLUSIVE_TOO_LARGE",
+    "DEFAULT_MAX_SEARCH",
+    "Context",
+    "EmpiricalModel",
+    "empirical_model",
+    "overlap_report",
+    "global_sections",
+    "global_sections_cpsat",
+    "logical_contextuality",
+    "minimal_obstruction",
+    "contextuality_verdict",
+    "median_split_thresholds",
+    "model_from_signatures",
+    "pr_box_model",
+    "logically_but_not_strongly_contextual_model",
+    "non_contextual_model",
+]

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_proxy_contextuality.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_proxy_contextuality.py
@@ -1,0 +1,539 @@
+"""Tests de `ict.proxy_contextuality` (ICT #7290).
+
+Invariants falsifiables couverts :
+
+1. **Le detecteur detecte.** Sur la boite PR -- dont l'insatisfiabilite se prouve
+   a la main par parite -- le verdict est ``STRONGLY_CONTEXTUAL``. Un detecteur
+   qui rendrait SAT ici serait casse, et tout verdict rendu sur des donnees
+   reelles serait sans valeur.
+2. **Les deux degenerescences dominent le verdict de contextualite.** Un modele
+   sans recouvrement ne recoit jamais ``NON_CONTEXTUAL`` (SAT force par
+   construction) ; un modele a supports singletons ne recoit jamais
+   ``STRONGLY_CONTEXTUAL`` (UNSAT trivial). C'est le garde-fou
+   anti-analogie-decorative, et c'est ce que testent
+   `test_no_overlap_*` / `test_rigid_*`.
+3. **Les trois crans se distinguent.** Un modele peut etre satisfiable tout en
+   portant une obstruction locale : le cran ``LOGICALLY_CONTEXTUAL`` doit etre
+   rendu, pas ``NON_CONTEXTUAL``. Sans quoi un SAT brut conclurait a tort.
+4. **CP-SAT et l'enumeration exhaustive s'accordent.** Le desaccord est un bug
+   d'encodage, jamais un resultat -- il doit lever.
+5. **Determinisme.** L'enumeration rend le meme ordre a chaque appel (elle
+   canonicalise les temoins que CP-SAT, lui, ne garantit pas).
+6. **La minimalite est une vraie minimalite.** Retirer n'importe quel contexte
+   de la sous-famille rendue doit rendre le modele satisfiable.
+
+Pattern herite de `test_compression.py` : bootstrap `sys.path` module-level,
+sans fixtures.
+"""
+
+import os
+import sys
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+sys.path.insert(0, _ROOT)
+
+from ict import proxy_contextuality as pc  # noqa: E402
+
+try:
+    from ortools.sat.python import cp_model  # noqa: F401
+
+    _HAS_ORTOOLS = True
+except ImportError:
+    _HAS_ORTOOLS = False
+
+
+# --------------------------------------------------------------------------- #
+#  1. Le detecteur detecte : boite PR fortement contextuelle                   #
+# --------------------------------------------------------------------------- #
+def test_pr_box_has_no_global_section():
+    """Preuve par parite : somme des 4 contraintes XOR = 1 (mod 2), impossible."""
+    model = pc.pr_box_model()
+    assert pc.global_sections(model) == []
+
+
+def test_pr_box_verdict_is_strongly_contextual():
+    out = pc.contextuality_verdict(pc.pr_box_model())
+    assert out["verdict"] == pc.STRONGLY_CONTEXTUAL
+    assert out["satisfiable"] is False
+
+
+def test_pr_box_is_not_degenerate():
+    """L'UNSAT de la boite PR doit etre structurel, pas un artefact."""
+    report = pc.overlap_report(pc.pr_box_model())
+    assert report["degeneracy"] is None
+    assert report["n_shared_proxies"] == 4  # a1, a2, b1, b2 chacun dans 2 contextes
+    assert report["min_support_size"] == 2  # aucun support singleton
+    assert report["n_distinct_covers"] == 4  # recouvrement genuinement partiel
+
+
+def test_pr_box_minimal_obstruction_is_the_whole_family():
+    """Les 4 contextes sont necessaires : c'est la ceremonie complete qui bloque."""
+    model = pc.pr_box_model()
+    minimal = pc.minimal_obstruction(model)
+    assert minimal is not None
+    assert len(minimal) == 4
+
+
+def test_pr_box_minimal_obstruction_is_irreducible():
+    """Propriete de minimalite : retirer un contexte quelconque rend SAT."""
+    model = pc.pr_box_model()
+    minimal = pc.minimal_obstruction(model)
+    for drop in minimal:
+        sub = pc.EmpiricalModel(
+            contexts=tuple(model.contexts[i] for i in minimal if i != drop),
+            outcomes=model.outcomes,
+        )
+        assert pc.global_sections(sub, limit=1), (
+            f"retirer le contexte {drop} devrait rendre satisfiable"
+        )
+
+
+def test_minimal_obstruction_excludes_irrelevant_context():
+    """Un contexte permissif ajoute ne doit pas entrer dans l'obstruction minimale."""
+    xor0 = ((0, 0), (1, 1))
+    xor1 = ((0, 1), (1, 0))
+    full = ((0, 0), (0, 1), (1, 0), (1, 1))
+    model = pc.empirical_model(
+        [
+            pc.Context(("a1", "b1"), xor0),
+            pc.Context(("a1", "b2"), xor0),
+            pc.Context(("a2", "b1"), xor0),
+            pc.Context(("a2", "b2"), xor1),
+            pc.Context(("a1", "a2"), full),  # ne contraint rien
+        ],
+        outcomes=(0, 1),
+    )
+    minimal = pc.minimal_obstruction(model)
+    assert minimal is not None
+    assert 4 not in minimal
+    assert len(minimal) == 4
+
+
+def test_minimal_obstruction_is_none_when_satisfiable():
+    assert pc.minimal_obstruction(pc.non_contextual_model()) is None
+
+
+# --------------------------------------------------------------------------- #
+#  2. Les degenerescences dominent (le garde-fou)                              #
+# --------------------------------------------------------------------------- #
+def test_no_overlap_is_flagged_degenerate():
+    """Sans proxy partage, SAT est force : le verdict ne doit pas etre NON_CONTEXTUAL."""
+    model = pc.empirical_model(
+        [
+            pc.Context(("a1", "a2"), ((0, 0), (1, 1))),
+            pc.Context(("b1", "b2"), ((0, 1), (1, 0))),
+        ],
+        outcomes=(0, 1),
+    )
+    assert pc.overlap_report(model)["degeneracy"] == pc.DEGENERATE_NO_OVERLAP
+    out = pc.contextuality_verdict(model)
+    assert out["verdict"] == pc.DEGENERATE_NO_OVERLAP
+    # ... et pourtant le modele EST satisfiable : c'est precisement pour cela
+    # que rapporter "non contextuel" ici serait vide.
+    assert out["satisfiable"] is True
+    assert out["verdict"] != pc.NON_CONTEXTUAL
+
+
+def test_rigid_supports_unsat_is_not_reported_as_contextual():
+    """LE test decisif du garde-fou.
+
+    Recouvrement reel (``b`` est dans les deux contextes) et UNSAT (``b`` doit
+    valoir 0 et 1), mais chaque support est un singleton : l'UNSAT n'est qu'un
+    changement de valeur d'un contexte a l'autre -- une dissociation, pas une
+    obstruction. Le verdict doit etre DEGENERATE_RIGID.
+    """
+    model = pc.empirical_model(
+        [
+            pc.Context(("a", "b"), ((0, 0),)),
+            pc.Context(("b", "c"), ((1, 1),)),
+        ],
+        outcomes=(0, 1),
+    )
+    assert pc.global_sections(model) == []  # bien UNSAT
+    out = pc.contextuality_verdict(model)
+    assert out["verdict"] == pc.DEGENERATE_RIGID
+    assert out["verdict"] != pc.STRONGLY_CONTEXTUAL
+    assert "singleton" in out["rationale"]
+
+
+def test_identical_covers_are_flagged_single_cover():
+    """Meme ensemble de proxys partout => recouvrement trivial, question reduite.
+
+    Le modele est UNSAT (aucun tuple commun aux deux supports), mais ce n'est pas
+    de la contextualite : c'est un desaccord entre deux protocoles mesurant
+    exactement la meme chose.
+    """
+    model = pc.empirical_model(
+        [
+            pc.Context(("p", "q"), ((0, 0), (0, 1))),
+            pc.Context(("p", "q"), ((1, 0), (1, 1))),
+        ],
+        outcomes=(0, 1),
+    )
+    assert pc.global_sections(model) == []  # UNSAT
+    out = pc.contextuality_verdict(model)
+    assert out["verdict"] == pc.DEGENERATE_SINGLE_COVER
+    assert out["verdict"] != pc.STRONGLY_CONTEXTUAL
+    assert "PARTIEL" in out["rationale"]
+
+
+def test_single_context_is_single_cover():
+    """Un contexte unique : la section globale est son support, par construction."""
+    model = pc.empirical_model([pc.Context(("p", "q"), ((0, 1),))], outcomes=(0, 1))
+    assert pc.overlap_report(model)["degeneracy"] == pc.DEGENERATE_SINGLE_COVER
+
+
+def test_single_cover_takes_precedence_over_rigid():
+    """Les deux sont vraies ; le recouvrement trivial est le constat plus fondamental."""
+    model = pc.empirical_model(
+        [pc.Context(("p", "q"), ((0, 0),)), pc.Context(("p", "q"), ((1, 1),))],
+        outcomes=(0, 1),
+    )
+    report = pc.overlap_report(model)
+    assert report["max_support_size"] == 1  # rigide aussi
+    assert report["degeneracy"] == pc.DEGENERATE_SINGLE_COVER
+
+
+def test_partial_cover_is_what_lifts_degeneracy():
+    """Contexte-temoin : c'est le passage a un recouvrement PARTIEL qui debloque."""
+    partial = pc.empirical_model(
+        [
+            pc.Context(("p", "q"), ((0, 0), (1, 1))),
+            pc.Context(("q", "r"), ((0, 0), (1, 1))),
+        ],
+        outcomes=(0, 1),
+    )
+    report = pc.overlap_report(partial)
+    assert report["n_distinct_covers"] == 2
+    assert report["shared_proxies"] == ["q"]
+    assert report["degeneracy"] is None
+
+
+def test_no_overlap_takes_precedence_over_rigid():
+    """Les deux degenerescences peuvent coexister ; l'absence de recouvrement gagne."""
+    model = pc.empirical_model(
+        [pc.Context(("a",), ((0,),)), pc.Context(("b",), ((1,),))],
+        outcomes=(0, 1),
+    )
+    assert pc.overlap_report(model)["degeneracy"] == pc.DEGENERATE_NO_OVERLAP
+
+
+def test_degeneracy_reason_is_always_populated():
+    for model in (
+        pc.empirical_model(
+            [pc.Context(("a", "b"), ((0, 0),)), pc.Context(("b", "c"), ((1, 1),))],
+            outcomes=(0, 1),
+        ),
+        pc.empirical_model(
+            [
+                pc.Context(("a1", "a2"), ((0, 0), (1, 1))),
+                pc.Context(("b1", "b2"), ((0, 1), (1, 0))),
+            ],
+            outcomes=(0, 1),
+        ),
+    ):
+        report = pc.overlap_report(model)
+        assert report["degeneracy"] is not None
+        assert report["degeneracy_reason"]
+
+
+# --------------------------------------------------------------------------- #
+#  3. Les trois crans se distinguent                                           #
+# --------------------------------------------------------------------------- #
+def test_non_contextual_model_verdict():
+    out = pc.contextuality_verdict(pc.non_contextual_model())
+    assert out["verdict"] == pc.NON_CONTEXTUAL
+    assert out["satisfiable"] is True
+    assert out["logical"]["n_without_extension"] == 0
+
+
+def test_logically_but_not_strongly_contextual_is_distinguished():
+    """SAT, donc pas fortement contextuel -- mais l'obstruction survit, localisee.
+
+    C'est le modele qu'un simple test SAT declarerait "non contextuel" a tort.
+    """
+    model = pc.logically_but_not_strongly_contextual_model()
+    sections = pc.global_sections(model)
+    assert sections, "ce modele doit admettre au moins une section globale"
+
+    out = pc.contextuality_verdict(model)
+    assert out["verdict"] == pc.LOGICALLY_CONTEXTUAL
+    assert out["satisfiable"] is True
+    assert out["verdict"] != pc.NON_CONTEXTUAL
+    assert out["logical"]["n_without_extension"] > 0
+
+
+def test_logical_witnesses_really_have_no_extension():
+    """Verifie les temoins un a un contre l'enumeration, sans faire confiance au verdict."""
+    model = pc.logically_but_not_strongly_contextual_model()
+    logical = pc.logical_contextuality(model)
+    sections = pc.global_sections(model)
+    for w in logical["witnesses"]:
+        ctx = model.contexts[w["context_index"]]
+        target = tuple(w["outcome"])
+        assert target in ctx.support
+        assert all(ctx.restrict(s) != target for s in sections)
+
+
+def test_strongly_contextual_implies_no_logical_key():
+    """Le cran 2 ne se calcule que si des sections globales existent."""
+    out = pc.contextuality_verdict(pc.pr_box_model())
+    assert "logical" not in out
+
+
+def test_logical_contextuality_counts_all_local_sections():
+    model = pc.non_contextual_model()
+    logical = pc.logical_contextuality(model)
+    assert logical["n_local_sections"] == 16  # 4 contextes x 4 tuples
+    assert logical["logically_contextual"] is False
+
+
+# --------------------------------------------------------------------------- #
+#  4. CP-SAT s'accorde avec l'oracle exhaustif                                 #
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not _HAS_ORTOOLS, reason="OR-Tools absent")
+def test_cpsat_agrees_with_exhaustive_on_all_fixtures():
+    for builder in (
+        pc.pr_box_model,
+        pc.logically_but_not_strongly_contextual_model,
+        pc.non_contextual_model,
+    ):
+        model = builder()
+        exhaustive = bool(pc.global_sections(model, limit=1))
+        cp = pc.global_sections_cpsat(model)
+        assert cp["available"] is True
+        assert cp["satisfiable"] == exhaustive, f"desaccord sur {builder.__name__}"
+
+
+@pytest.mark.skipif(not _HAS_ORTOOLS, reason="OR-Tools absent")
+def test_cpsat_never_returns_a_witness():
+    """Le temoin CP-SAT n'est pas deterministe : il ne doit pas etre rapporte."""
+    cp = pc.global_sections_cpsat(pc.non_contextual_model())
+    assert "assignment" not in cp
+    assert "solution" not in cp
+    assert set(cp) == {"available", "satisfiable", "status_name"}
+
+
+@pytest.mark.skipif(not _HAS_ORTOOLS, reason="OR-Tools absent")
+def test_cpsat_handles_non_contiguous_alphabet():
+    """Un alphabet non contigu ne doit pas laisser passer les valeurs intermediaires."""
+    model = pc.empirical_model(
+        [pc.Context(("a", "b"), ((0, 7), (7, 0)))], outcomes=(0, 7)
+    )
+    exhaustive = pc.global_sections(model)
+    assert len(exhaustive) == 2
+    assert pc.global_sections_cpsat(model)["satisfiable"] is True
+
+
+def test_verdict_without_ortools_still_decides():
+    """cross_check=False : l'oracle exhaustif suffit, aucun resultat n'est fabrique."""
+    out = pc.contextuality_verdict(pc.pr_box_model(), cross_check=False)
+    assert out["verdict"] == pc.STRONGLY_CONTEXTUAL
+    assert out["cpsat"]["available"] is False
+
+
+# --------------------------------------------------------------------------- #
+#  5. Determinisme et bornes                                                   #
+# --------------------------------------------------------------------------- #
+def test_enumeration_is_deterministic():
+    model = pc.non_contextual_model()
+    assert pc.global_sections(model) == pc.global_sections(model)
+
+
+def test_enumeration_order_is_lexicographic_on_sorted_proxies():
+    model = pc.non_contextual_model()
+    sections = pc.global_sections(model)
+    assert list(sections[0].keys()) == sorted(sections[0].keys())
+    assert sections[0] == {"a1": 0, "a2": 0, "b1": 0, "b2": 0}
+
+
+def test_search_space_too_large_raises():
+    model = pc.non_contextual_model()  # 2**4 = 16
+    with pytest.raises(OverflowError):
+        pc.global_sections(model, max_search=8)
+
+
+def test_verdict_reports_inconclusive_rather_than_guessing():
+    out = pc.contextuality_verdict(
+        pc.non_contextual_model(), max_search=8, cross_check=False
+    )
+    assert out["verdict"] == pc.INCONCLUSIVE_TOO_LARGE
+    assert out["satisfiable"] is None
+
+
+def test_limit_stops_enumeration_early():
+    sections = pc.global_sections(pc.non_contextual_model(), limit=3)
+    assert len(sections) == 3
+
+
+# --------------------------------------------------------------------------- #
+#  6. Validation de construction : une erreur, jamais un silence               #
+# --------------------------------------------------------------------------- #
+def test_empty_support_is_an_error_not_a_permissive_context():
+    with pytest.raises(ValueError, match="support vide"):
+        pc.Context(("a", "b"), ())
+
+
+def test_arity_mismatch_raises():
+    with pytest.raises(ValueError, match="arite"):
+        pc.Context(("a", "b"), ((0, 1), (0,)))
+
+
+def test_duplicate_proxy_in_context_raises():
+    with pytest.raises(ValueError, match="dupliques"):
+        pc.Context(("a", "a"), ((0, 1),))
+
+
+def test_empty_context_raises():
+    with pytest.raises(ValueError, match="au moins un proxy"):
+        pc.Context((), ((0,),))
+
+
+def test_no_context_raises():
+    with pytest.raises(ValueError, match="au moins un contexte"):
+        pc.empirical_model([])
+
+
+def test_outcome_outside_alphabet_raises():
+    with pytest.raises(ValueError, match="hors alphabet"):
+        pc.empirical_model([pc.Context(("a",), ((5,),))], outcomes=(0, 1))
+
+
+def test_trivial_alphabet_raises():
+    """Une seule issue possible : toute assignation est forcee, la question est vide."""
+    with pytest.raises(ValueError, match="trivial"):
+        pc.empirical_model([pc.Context(("a", "b"), ((0, 0),))], outcomes=(0,))
+
+
+def test_model_accepts_mapping_form():
+    model = pc.empirical_model(
+        [{"proxies": ["a", "b"], "support": [(0, 0), (1, 1)]}], outcomes=(0, 1)
+    )
+    assert model.measurements == ("a", "b")
+    assert model.search_space == 4
+
+
+# --------------------------------------------------------------------------- #
+#  7. Pont mesures -> modele : mesurer une fois rend le test vide              #
+# --------------------------------------------------------------------------- #
+def test_single_seed_per_context_yields_singleton_supports():
+    """Une graine par contexte => supports singletons.
+
+    C'est l'exigence de protocole rendue mesurable : sans plusieurs graines par
+    contexte, les supports sont rigides et aucun verdict de contextualite n'est
+    atteignable (cf. `test_rigid_supports_unsat_is_not_reported_as_contextual`).
+    """
+    signatures = {
+        "ctx_A": [{"spectral_gap": 0.1, "sensitivity_mean": 0.9}],
+        "ctx_B": [{"spectral_gap": 0.9, "sensitivity_mean": 0.1}],
+    }
+    model, _ = pc.model_from_signatures(
+        signatures, ("spectral_gap", "sensitivity_mean")
+    )
+    assert pc.overlap_report(model)["max_support_size"] == 1
+
+
+def test_multiple_seeds_produce_non_singleton_supports():
+    """Plusieurs graines lèvent bien la rigidite des supports."""
+    signatures = {
+        "ctx_A": [
+            {"spectral_gap": 0.1, "sensitivity_mean": 0.9},
+            {"spectral_gap": 0.8, "sensitivity_mean": 0.2},
+        ],
+        "ctx_B": [
+            {"spectral_gap": 0.9, "sensitivity_mean": 0.1},
+            {"spectral_gap": 0.2, "sensitivity_mean": 0.8},
+        ],
+    }
+    model, thresholds = pc.model_from_signatures(
+        signatures, ("spectral_gap", "sensitivity_mean")
+    )
+    report = pc.overlap_report(model)
+    assert report["min_support_size"] == 2
+    assert set(thresholds) == {"spectral_gap", "sensitivity_mean"}
+
+
+def test_bridge_always_yields_single_cover_degeneracy():
+    """LE constat structurel sur le zoo ICT, rendu executable.
+
+    Le pont affecte tous les proxys a chaque contexte -- parce que les proxys du
+    zoo partagent la signature ``(states, n_symbols)`` et sont donc
+    conjointement mesurables. Le modele produit est donc toujours
+    DEGENERATE_SINGLE_COVER : la question KS n'est pas posable en l'etat, quel
+    que soit le nombre de graines.
+    """
+    signatures = {
+        "ctx_A": [{"p": 0.1, "q": 0.9}, {"p": 0.8, "q": 0.2}],
+        "ctx_B": [{"p": 0.9, "q": 0.1}, {"p": 0.2, "q": 0.8}],
+        "ctx_C": [{"p": 0.5, "q": 0.5}, {"p": 0.3, "q": 0.7}],
+    }
+    model, _ = pc.model_from_signatures(signatures, ("p", "q"))
+    report = pc.overlap_report(model)
+    assert report["n_distinct_covers"] == 1
+    assert report["degeneracy"] == pc.DEGENERATE_SINGLE_COVER
+    out = pc.contextuality_verdict(model)
+    assert out["verdict"] == pc.DEGENERATE_SINGLE_COVER
+    assert out["verdict"] not in {pc.NON_CONTEXTUAL, pc.STRONGLY_CONTEXTUAL}
+
+
+def test_median_thresholds_split_the_corpus():
+    signatures = {
+        "c1": [{"p": 0.0}, {"p": 1.0}],
+        "c2": [{"p": 2.0}, {"p": 3.0}],
+    }
+    thr = pc.median_split_thresholds(signatures, ("p",))
+    assert thr["p"] == pytest.approx(1.5)
+
+
+def test_discretization_is_ge_threshold():
+    signatures = {"c1": [{"p": 1.5}], "c2": [{"p": 0.0}]}
+    model, thr = pc.model_from_signatures(signatures, ("p",), thresholds={"p": 1.5})
+    supports = {ctx.support for ctx in model.contexts}
+    assert ((1,),) in supports  # 1.5 >= 1.5 -> issue 1
+    assert ((0,),) in supports
+    assert thr["p"] == 1.5
+
+
+def test_context_without_measurement_raises():
+    with pytest.raises(ValueError, match="sans aucune mesure"):
+        pc.model_from_signatures({"c1": []}, ("p",))
+
+
+def test_missing_proxy_in_all_runs_raises():
+    with pytest.raises(ValueError, match="aucune mesure pour le proxy"):
+        pc.median_split_thresholds({"c1": [{"other": 1.0}]}, ("p",))
+
+
+# --------------------------------------------------------------------------- #
+#  8. Coherence interne du rapport                                             #
+# --------------------------------------------------------------------------- #
+def test_overlap_report_multiplicity_matches_contexts():
+    report = pc.overlap_report(pc.pr_box_model())
+    assert report["context_multiplicity"] == {"a1": 2, "a2": 2, "b1": 2, "b2": 2}
+    assert report["search_space"] == 16
+
+
+def test_verdict_always_carries_overlap_and_rationale():
+    for builder in (
+        pc.pr_box_model,
+        pc.logically_but_not_strongly_contextual_model,
+        pc.non_contextual_model,
+    ):
+        out = pc.contextuality_verdict(builder())
+        assert out["rationale"]
+        assert "overlap" in out
+        assert out["verdict"] in {
+            pc.STRONGLY_CONTEXTUAL,
+            pc.LOGICALLY_CONTEXTUAL,
+            pc.NON_CONTEXTUAL,
+        }
+
+
+def test_admits_and_restrict_are_consistent():
+    ctx = pc.Context(("a", "b"), ((0, 1),))
+    assert ctx.restrict({"a": 0, "b": 1, "c": 9}) == (0, 1)
+    assert ctx.admits({"a": 0, "b": 1}) is True
+    assert ctx.admits({"a": 1, "b": 1}) is False

--- a/docs/ict/synthese-invariants-dissociations-obstructions.md
+++ b/docs/ict/synthese-invariants-dissociations-obstructions.md
@@ -50,7 +50,7 @@ L'obstruction n'est pas un échec de méthode : c'est une **structure**. Quand d
 
 - **Scalaire universel falsifié** (strate 5) : la non-existence d'une section globale recollant tous les proxys = un *candidat* de classe d'obstruction non nulle (la falsification est un fait ; sa lecture comme classe de cohomologie `H¹` est proposée, grade C). *C'est le résultat, pas un manque.*
 - [**social_choice_lean**](../../MyIA.AI.Notebooks/GameTheory/social_choice_lean/) : l'impossibilité d'Arrow, 0 `sorry` — le local (préférences individuelles) ne se globalise pas en une fonction de choix, et c'est un théorème.
-- [**#7290 Kochen-Specker**](https://github.com/jsboige/CoursIA/issues/7290) : aucune assignation globale non contextuelle n'existe — `H¹ ≠ 0` érigé en impossibilité (lecture cohomologique d'Abramsky-Brandenburger). Le dépôt le pose en problème de contraintes où la section se recolle (SAT) ou se refuse (UNSAT).
+- [**#7290 Kochen-Specker**](https://github.com/jsboige/CoursIA/issues/7290) : aucune assignation globale non contextuelle n'existe — `H¹ ≠ 0` érigé en impossibilité (lecture cohomologique d'Abramsky-Brandenburger). Le dépôt le pose en problème de contraintes où la section se recolle (SAT) ou se refuse (UNSAT). **Instruit et mesuré** ([section dédiée](#kochen-specker-sur-le-zoo-de-proxys--lanalogie-et-où-elle-meurt)) : le transfert échoue un cran *avant* le SAT/UNSAT, faute de proxys non conjointement mesurables — le zoo n'est pas « non contextuel », la question n'y est pas encore posable.
 - **Jeu de la Vie** ([Lean-16b](../../MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16b-Conway-Game-of-Life-Lean.ipynb) / [-16c](../../MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16c-Conway-Game-of-Life-Golly.ipynb) / [-16d](../../MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16d-Conway-Game-of-Life-Lean-Native.ipynb)) : la règle locale `B3/S23` et la complétude de Turing ne se recollent pas « gratuitement » — l'écart est mesuré, et la preuve du bond HashLife (`hashlife_correct`) vit dans cet écart.
 
 **Piège évité.** Lire une obstruction comme un trou à combler. Combler l'obstruction (forcer un scalaire, moyenné les proxys) détruit l'information qu'elle porte — on revient au régime 2 en pire.
@@ -79,6 +79,58 @@ La grille 3-régimes est **transversale** : elle dit, pour une même trajectoire
 - **Dissociations.** Deux proxys du « succès » d'une stratégie (score cumulé vs robustesse face à l'invasion) se séparent : une stratégie peut dominer le score et perdre à l'invasion. Le motif de la séparation révèle que « succès » portait deux sens confondus.
 - **Obstructions.** Aucune stratégie unique ne recolle en gagnant global sur tous les paysages — la circularité (Condorcet) est une obstruction, et elle est stable. Ce n'est pas un défaut du tournoi ; c'est sa structure.
 
+## Kochen-Specker sur le zoo de proxys : l'analogie, et où elle meurt
+
+Le régime 3 ci-dessus pose #7290 comme « la section se recolle (SAT) ou se refuse (UNSAT) ». Cette section instruit l'analogie jusqu'au bout — et rapporte que **la question n'est pas encore posable**, ce qui est un résultat, pas un manque. Outil : [`ict/proxy_contextuality.py`](../../MyIA.AI.Notebooks/IIT/ICT-Series/ict/proxy_contextuality.py) ([#7290](https://github.com/jsboige/CoursIA/issues/7290)).
+
+### La transposition, terme à terme
+
+| Abramsky-Brandenburger | Zoo ICT |
+|---|---|
+| Observable | Un proxy (`spectral_gap`, `sensitivity_mean`, …) |
+| Contexte de mesure | Un protocole : coarse-graining, fenêtre, régime de perturbation |
+| Support de la distribution du contexte | L'ensemble des tuples d'issues **effectivement observés** dans ce protocole |
+| Section locale | Un tuple observé dans un contexte |
+| Section globale | Une assignation proxy → valeur, indépendante du contexte |
+| Fortement contextuel | Aucune section globale — l'obstruction de Kochen-Specker |
+
+La version possibiliste (supports seuls) suffit, et elle rend la question **littéralement** un CSP à contraintes extensionnelles : chaque contexte est une table de tuples autorisés (`AddAllowedAssignments` en CP-SAT). C'est ce qui donne au test la propriété que l'issue exigeait : il répond OUI ou NON, sans marge d'interprétation.
+
+### Trois crans, pas deux
+
+Un SAT brut ne dit pas « non contextuel » : il dit « pas *fortement* contextuel ». Le cran intermédiaire d'Abramsky-Brandenburger — **logiquement contextuel** : des sections globales existent, mais une section locale *observée* ne s'étend à aucune d'elles — est ce qui empêche un SAT d'être une impasse. L'outil rend les trois crans distinctement, et une fixture dédiée exhibe un modèle qu'un test SAT nu déclarerait « non contextuel » à tort.
+
+### Les points de rupture avec le cas quantique
+
+1. **Origine des contraintes.** Chez Kochen-Specker elles sont algébriques (orthogonalité), donc *a priori* et exactes. Ici elles sont mesurées : un UNSAT peut être un artefact d'échantillonnage. D'où l'exigence de plusieurs graines par contexte.
+2. **Identité des observables.** « Le même observable » dans deux contextes est *le même opérateur* en mécanique quantique, par définition. Ici, un proxy mesuré sous deux coarse-grainings n'est pas garanti être la même grandeur : l'identité cross-contexte est l'**hypothèse la plus forte** du transfert, et elle n'est pas démontrée.
+3. **Pas de théorème de dimension.** KS exige `dim ≥ 3` et des configurations de rayons précises. Rien de tel ne contraint le zoo : l'absence d'obstruction ici n'a aucune portée sur KS, ni réciproquement.
+4. **Discrétisation.** Les proxys sont des réels ; les rendre des issues discrètes est un **choix** de seuils, pas une donnée.
+
+### Le garde-fou : trois manières d'être vide
+
+Le risque nommé par l'issue est l'analogie décorative. L'outil refuse un verdict de contextualité dans trois cas où la réponse est forcée par la construction — **recouvrement total** (tous les contextes co-mesurent le même ensemble de proxys : la question se réduit à « l'intersection des supports est-elle non vide ? »), **aucun recouvrement** (contextes indépendants, SAT gratuit), **supports rigides** (une seule mesure par contexte : un UNSAT n'y est qu'un changement de valeur, c'est-à-dire une dissociation de régime 2, pas une obstruction). C'est la leçon d'ICT-15d appliquée d'avance : un verdict ne vaut que si sa négation était atteignable.
+
+Le détecteur est validé sur des fixtures à insatisfiabilité **prouvée à la main** — la boîte de Popescu-Rohrlich, dont l'UNSAT se démontre par parité (la somme des quatre contraintes XOR vaut 1 mod 2 alors que son membre gauche est pair). On prouve que le détecteur détecte avant de croire son verdict sur des données réelles.
+
+### Le résultat mesuré : la question n'est pas posable
+
+Mesure sur S1 (tri auto-organisé), trois coarse-grainings `k ∈ {3, 4, 6}` × cinq graines `{0, 1, 7, 42, 99}`, proxys câblés comme dans [ICT-15c](../../MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15c-MetaProxyObstruction.ipynb) (`f(x) = x`, anti-saturation) :
+
+```
+recouvrements distincts  : 1
+proxys partages          : ['sensitivity_max', 'sensitivity_mean', 'spectral_gap']
+tailles de support       : [1, 2, 1]
+satisfiable              : False        (CP-SAT: INFEASIBLE, accord avec l'enumeration)
+VERDICT                  : degenerate_single_cover
+```
+
+**Le point important est l'écart entre les deux dernières lignes.** Le modèle est bel et bien insatisfiable : un test naïf aurait donc rapporté « obstruction structurelle, `H¹ ≠ 0` » sur ces données. Le garde-fou intercepte ce faux positif, et la raison est structurelle, pas contingente : les trois proxys du zoo partagent la signature `(states, n_symbols)`. Rien n'empêche de les calculer tous les trois sur la même trajectoire — ils sont **conjointement mesurables**. Or c'est exactement la *non*-co-mesurabilité (la non-commutativité, chez KS) qui crée des contextes distincts et rend la contextualité possible. L'UNSAT observé est un désaccord entre coarse-grainings, c'est-à-dire un fait de régime 2, déjà acquis.
+
+**Verdict honnête.** L'analogie Kochen-Specker ne meurt pas d'un SAT ; elle meurt **un cran plus tôt**, faute de recouvrement non trivial. Le zoo ICT n'est pas « non contextuel » — la question de sa contextualité n'est pas encore *posable*. L'ingrédient manquant est identifié et unique : une structure de co-mesurabilité **partielle et justifiée**, c'est-à-dire deux proxys dont les prétraitements sont genuinement incompatibles, de sorte qu'aucun protocole ne les livre ensemble. Tant qu'elle n'est pas établie, tout hypergraphe proxys × contextes serait une décoration. L'outillage est livré validé : le jour où une telle structure est justifiée, le test se pose sans réécriture.
+
+**Constat secondaire, à part.** Sur cet encodage, `sensitivity_mean` et `sensitivity_max` valent exactement `k − 1` pour *toutes* les graines : l'instrument sature, et deux des trois proxys ne portent aucune variance cross-graine. La note anti-saturation d'ICT-15c (`f(x) = x` au lieu de `x % 2`) ne désature donc pas sur la trajectoire d'inversions de S1. C'est un fait sur l'instrument, indépendant de la question KS, et il mérite son propre examen.
+
 ## Lien vers les chantiers actifs
 
 Cette synthèse ne lance aucun nouveau dispatch. Elle éclaire deux chantiers déjà ouverts :
@@ -99,4 +151,5 @@ Cette synthèse ne lance aucun nouveau dispatch. Elle éclaire deux chantiers d�
 - Langage cohomologique formalisé : [`grothendieck_lean/Grothendieck/SheafCohomology/`](../../MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/Basic.lean) (0 `sorry` de production).
 - Dissociations instrumentées : [ICT-15b](../../MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb) ([#7288](https://github.com/jsboige/CoursIA/issues/7288)), [ICT-18b](../../MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18b-ReversibilityBudget.ipynb) ([#7287](https://github.com/jsboige/CoursIA/issues/7287)).
 - Obstructions érigées en impossibilité : [`social_choice_lean`](../../MyIA.AI.Notebooks/GameTheory/social_choice_lean/) (Arrow), [#7290](https://github.com/jsboige/CoursIA/issues/7290) (Kochen-Specker).
+- Test de contextualité (possibiliste, CSP) + garde anti-analogie-décorative : [`ict/proxy_contextuality.py`](../../MyIA.AI.Notebooks/IIT/ICT-Series/ict/proxy_contextuality.py), 47 tests dont l'insatisfiabilité prouvée à la main de la boîte PR ([#7290](https://github.com/jsboige/CoursIA/issues/7290)).
 - Quatrième fil (diachronique) — généalogie de `p̂` : [`docs/ict/genealogy-representation-interne.md`](genealogy-representation-interne.md) ([#7735](https://github.com/jsboige/CoursIA/issues/7735)).


### PR DESCRIPTION
Grain: DEEP/research — lane myia-po-2025:CoursIA — prev: DEEP/lean

## Summary

Instruit l'analogie Kochen-Specker sur le zoo de proxys ICT (#7290), avec les trois livrables demandes : formalisation ecrite, **UN** test computationnel, verdict honnete dans les deux cas.

Le resultat est **negatif, et c'est le resultat** — l'issue le prevoit explicitement (« Le NON-resultat [...] est publiable tel quel et clot la piste »). Mais il n'est pas le negatif attendu : l'analogie ne meurt pas d'un SAT, elle meurt **un cran plus tot**, et le garde-fou que je livre en dur est ce qui l'a fait voir.

## Ce qui est livre

| Fichier | Role |
|---|---|
| `ict/proxy_contextuality.py` (+768) | Modele empirique possibiliste, resolution CSP par enumeration bornee ET CP-SAT, trois crans d'Abramsky-Brandenburger, trois degenerescences, pont depuis les signatures de proxys |
| `ict/tests/test_proxy_contextuality.py` (+539) | 47 tests, 6 invariants falsifiables nommes dans le docstring |
| `docs/ict/synthese-invariants-dissociations-obstructions.md` (+55/-1) | Section dediee : transposition terme a terme, 4 points de rupture, resultat mesure. Le bullet #7290 du regime 3 pointe desormais dessus |

## Le test : la question EST un CSP

Un modele empirique possibiliste = une famille de contextes, chacun porteur du **support** de sa distribution (les tuples d'issues effectivement observes). « Une section globale existe-t-elle ? » devient litteralement un CSP a contraintes extensionnelles — une table de tuples autorises par contexte (`AddAllowedAssignments` en CP-SAT). C'est la propriete que l'issue exigeait : un objet mathematique net qui repond OUI ou NON.

Deux voies indépendantes, qui **doivent** s'accorder :

- enumeration exhaustive bornee (`max_search`, defaut 2^22) — canonicalise les temoins ;
- CP-SAT (`num_search_workers = 1`) — **ne rend deliberement aucun temoin**, le statut SAT/UNSAT etant deterministe alors que le temoin ne l'est pas (cf leçon CP-SAT non-determinisme du depot).

Un desaccord entre les deux leve `RuntimeError` : c'est un bug d'encodage, jamais un resultat.

**Trois crans, pas deux.** Un SAT nu ne dit pas « non contextuel », il dit « pas *fortement* contextuel ». Le cran intermediaire d'Abramsky-Brandenburger — des sections globales existent mais une section locale *observee* ne s'etend a aucune d'elles — est rendu (`logical_contextuality`), et une fixture exhibe un modele qu'un test SAT nu declarerait a tort non contextuel.

## Le garde-fou (anti-analogie-decorative)

Le risque nomme par l'issue : « le risque principal est l'analogie decorative ». Je le convertis de jugement en machinerie. Trois cas ou la reponse est **forcee par la construction** rendent un verdict distinct de SAT/UNSAT :

| Verdict | Ce qui est vide |
|---|---|
| `DEGENERATE_SINGLE_COVER` | Tous les contextes co-mesurent le meme ensemble de proxys : la question se reduit a « l'intersection des supports est-elle non vide ? ». La contextualite exige un recouvrement **partiel** (A={p,q}, B={q,r}, C={r,p}) |
| `DEGENERATE_NO_OVERLAP` | Aucun proxy partage : SAT par construction |
| `DEGENERATE_RIGID` | Tous les supports singletons : un UNSAT n'y est qu'un changement de valeur — une dissociation (regime 2), pas une obstruction. La force de KS est qu'aucune assignation ne marche *alors que chaque contexte en admet localement plusieurs* |

C'est la leçon d'ICT-15d appliquee d'avance (Cech -> TRIVIAL parce que les sections etaient colineaires par construction) : **un verdict ne vaut que si sa negation etait atteignable**.

**Le detecteur est valide avant d'etre cru.** Fixtures a insatisfiabilite **prouvee a la main** : la boite de Popescu-Rohrlich, dont l'UNSAT se demontre par parite (sommer les quatre contraintes XOR donne `2*(a1+a2+b1+b2) = 1 (mod 2)`, membre gauche pair, droit impair). On prouve que le detecteur detecte, puis on regarde les donnees.

## Le resultat mesure

S1 (`SelfSortingArray`), contextes = coarse-grainings `k in {3,4,6}`, graines `{0,1,7,42,99}`, proxys cables **comme dans ICT-15c** (`f(x)=x`, correctif anti-saturation) plutot que recables a neuf :

```
recouvrements distincts  : 1
proxys partages          : ['sensitivity_max', 'sensitivity_mean', 'spectral_gap']
tailles de support       : [1, 2, 1]
satisfiable              : False        (CP-SAT: INFEASIBLE, accord avec l'enumeration)
VERDICT                  : degenerate_single_cover
seuils                   : spectral_gap 0.013437 / sens_mean 3.000000 / sens_max 3.000000
```

**L'ecart entre les deux dernieres lignes est le point.** Le modele est bel et bien insatisfiable : un test naif aurait rapporte « obstruction structurelle, `H1 != 0` ». Le garde intercepte exactement le faux positif que l'issue redoutait — et la raison est structurelle, verifiee firsthand : les trois proxys du zoo partagent la signature `(states, n_symbols)`, donc **rien n'empeche de les calculer tous les trois sur la meme trajectoire**. Or c'est la *non*-co-mesurabilite (la non-commutativite chez KS) qui cree des contextes distincts. L'UNSAT observe n'est qu'un desaccord entre coarse-grainings : un fait de regime 2, deja acquis.

**Verdict honnete.** Le zoo ICT n'est pas « non contextuel » — la question de sa contextualite **n'y est pas encore posable**. L'ingredient manquant est identifie et unique : une structure de co-mesurabilite **partielle et justifiee** (deux proxys dont les pretraitements sont genuinement incompatibles, tels qu'aucun protocole ne les livre ensemble). L'outillage est livre valide : le jour ou une telle structure existe, le test se pose sans reecriture.

## Portee, et ce qui n'est pas mesure

L'issue demandait S1-S4 ; **j'ai mesure S1**. Je ne l'habille pas : S2-S4 ne sont pas mesures. Mais la degenerescence constatee est **structurelle, non substrat-dependante** — le recouvrement est determine par *quels proxys sont co-mesurables*, propriete des signatures de proxys et non du substrat. Etendre a S2-S4 ne peut donc pas lever `SINGLE_COVER`. C'est un **argument**, explicitement pas quatre mesures, et il est marque comme tel dans la doc.

## Les quatre points de rupture avec le cas quantique

Documentes dans le module et dans la doc, parce qu'un transfert non instruit est precisement l'analogie decorative :

1. **Origine des contraintes** : algebriques (orthogonalite) chez KS, **mesurees** ici — un UNSAT peut etre un artefact d'echantillonnage.
2. **Identite des observables** : « le meme observable » est *le meme operateur* en quantique ; ici, un proxy sous deux coarse-grainings n'est pas garanti etre la meme grandeur. C'est **l'hypothese la plus forte** du transfert, et elle n'est pas demontree.
3. **Pas de theoreme de dimension** : KS exige `dim >= 3` et des configurations de rayons ; rien de tel ne contraint le zoo — l'absence d'obstruction ici n'a **aucune portee** sur KS, ni reciproquement.
4. **Discretisation** : les seuils sont un **choix**, pas une donnee ; le verdict est rapporte avec sa sensibilite a ce choix.

## Anti-duplication (verifie avant d'ecrire)

Aucun outil existant ne pose la question combinatoire de l'assignation globale :

- `meta_proxy` (#7395) = dispersion **numerique** du desaccord (STABLE / NOISE / INCONCLUSIVE) ;
- `cech_obstruction` (#7744) = cochaine de Cech ponderee **intra-substrat** (holonomie) ;
- `bridge_testing` (#8077) = teste les **fleches**, pas les nœuds ;
- `ict/spectral.py:9` reserve explicitement le creneau (« ICT-29, annexe speculative »).

Le module est ecrit sur le contrat d'injection existant de `meta_proxy` (`proxy_signature`), pas a cote.

## Constat secondaire, rapporte a part

`sensitivity_mean == sensitivity_max == k-1` **exactement**, sur 5/5 graines x 3/3 grainings : l'instrument sature sur la trajectoire d'inversions de S1 **malgre** le correctif `f(x)=x` d'ICT-15c (introduit contre `x % 2`). Deux des trois proxys ne portent aucune variance cross-graine. C'est un fait sur l'instrument, independant de KS ; il merite son propre examen et n'est pas traite ici.

## Validation

```
$ cd MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests && python -m pytest -q
221 passed in 0.78s
```

47 nouveaux tests, 6 invariants falsifiables nommes. Le test decisif du garde est
`test_rigid_supports_unsat_is_not_reported_as_contextual` : recouvrement reel + UNSAT + supports singletons doit rendre `RIGID`, **jamais** `STRONGLY_CONTEXTUAL`.

`python scripts/check_docs_links.py` : 568 fichiers, 4421 liens, **aucun lien casse**.

Catalogue byte-identique a `main` (aucun fichier genere touche). Diff : 1361 insertions, 1 deletion (le bullet #7290 reformule) — pas de suppression de code.

## Residuel declare

- `ICT-Annexe-ProxyContextuality.ipynb` (notebook pedagogique, outputs reels + 3 exercices C.1) : **non livre ici**, une PR = un sujet.
- La question ouverte : etablir une structure de co-mesurabilite partielle **justifiee**. C'est le prealable a toute reprise de #7290, et ce n'est pas un travail de tooling.
- S2-S4 non mesures (cf « Portee » ci-dessus : couvert par argument structurel, pas par mesure).

See #7290

Note : `#7290` reste **ouverte** — l'annexe pedagogique et la question de co-mesurabilite sont hors de cette PR. La decision de clore appartient au coordinateur.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
