### PR TITLE
feat(ict,#7290): annexe pedagogique ProxyContextuality — 21 cellules executees, 3 exercices

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Annexe-ProxyContextuality.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Annexe-ProxyContextuality.ipynb
@@ -1,0 +1,805 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell0",
+   "metadata": {},
+   "source": [
+    "# ICT — Annexe : la contextualité du zoo de proxys est un CSP\n",
+    "\n",
+    "> **Annexe spéculative, non numérotée.** Registre : issue #7290, dans l'épic ICT #4588.\n",
+    "> Cette annexe *instruit* un transfert conceptuel — elle ne le proclame pas. Le résultat\n",
+    "> qu'elle établit est **négatif**, et c'est précisément son intérêt.\n",
+    "\n",
+    "## La question\n",
+    "\n",
+    "Le « zoo de proxys » de la série ICT mesure une même trajectoire par plusieurs\n",
+    "instruments (écart spectral, sensibilité moyenne, sensibilité maximale), sous\n",
+    "plusieurs **grains de description** (*coarse-grainings*). Deux instruments peuvent\n",
+    "être en désaccord. La question de cette annexe :\n",
+    "\n",
+    "> Ce désaccord est-il un simple **désaccord de valeurs** — chaque instrument mesure\n",
+    "> quelque chose de légèrement différent — ou une **obstruction structurelle**, au sens\n",
+    "> où *aucune* attribution de valeurs cohérente n'existe globalement, bien que chaque\n",
+    "> instrument soit localement parfaitement cohérent ?\n",
+    "\n",
+    "La seconde forme porte un nom en mécanique quantique : c'est la **contextualité** au sens\n",
+    "de Kochen–Specker, formalisée par Abramsky et Brandenburger dans un cadre de faisceaux.\n",
+    "Elle a une propriété rare pour un concept importé : **elle se calcule**. Nous allons voir\n",
+    "qu'elle se ramène littéralement à un problème de satisfaction de contraintes (CSP).\n",
+    "\n",
+    "## Le plan\n",
+    "\n",
+    "1. Traduire le vocabulaire terme à terme, et **valider l'instrument sur un cas dont la\n",
+    "   réponse est prouvée à la main** avant de le croire sur des données.\n",
+    "2. Voir qu'il y a **trois crans**, pas deux — un `SAT` nu ne dit pas « non contextuel ».\n",
+    "3. Installer le **garde-fou** : trois manières pour un verdict d'être vide.\n",
+    "4. Mesurer sur le substrat S1, et rendre un verdict **honnête**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell1",
+   "metadata": {},
+   "source": [
+    "## 1. Le dictionnaire\n",
+    "\n",
+    "Le cadre d'Abramsky–Brandenburger se transpose terme à terme. C'est ce tableau qui rend\n",
+    "le transfert *instruit* plutôt que décoratif — chaque ligne est une correspondance qu'on\n",
+    "peut contester nommément.\n",
+    "\n",
+    "| Cadre quantique (Kochen–Specker) | Zoo de proxys ICT |\n",
+    "|---|---|\n",
+    "| Observable | un proxy (`spectral_gap`, `sensitivity_mean`, …) |\n",
+    "| Contexte de mesure (observables co-mesurables) | un protocole : quels proxys sont calculés ensemble |\n",
+    "| Support de la distribution du contexte | les tuples d'issues **effectivement observés** |\n",
+    "| Section locale | une attribution de valeurs cohérente dans **un** contexte |\n",
+    "| Section globale | une attribution cohérente **simultanément dans tous** les contextes |\n",
+    "| Fortement contextuel | aucune section globale n'existe |\n",
+    "\n",
+    "La dernière ligne est le cœur calculable : « une section globale existe-t-elle ? » est un\n",
+    "CSP à **contraintes extensionnelles** — une table de tuples autorisés par contexte. En\n",
+    "CP-SAT cela s'écrit directement (`AddAllowedAssignments`).\n",
+    "\n",
+    "### Valider le détecteur avant de le croire\n",
+    "\n",
+    "On ne braque pas un instrument neuf sur des données inconnues. On le braque d'abord sur\n",
+    "un cas dont la réponse est **prouvée à la main** : la **boîte de Popescu–Rohrlich**, objet\n",
+    "canonique fortement contextuel. Son insatisfiabilité se démontre par parité — les quatre\n",
+    "contraintes XOR somment à\n",
+    "\n",
+    "$$2\\,(a_1 + a_2 + b_1 + b_2) \\equiv 1 \\pmod 2$$\n",
+    "\n",
+    "dont le membre de gauche est pair et celui de droite impair. Aucune attribution ne peut\n",
+    "donc satisfaire les quatre contextes ensemble."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cell2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T16:45:26.205874Z",
+     "iopub.status.busy": "2026-08-06T16:45:26.205737Z",
+     "iopub.status.idle": "2026-08-06T16:45:26.534294Z",
+     "shell.execute_reply": "2026-08-06T16:45:26.533686Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "contextes :\n",
+      "  ('a1', 'b1')  support = [(0, 0), (1, 1)]\n",
+      "  ('a1', 'b2')  support = [(0, 0), (1, 1)]\n",
+      "  ('a2', 'b1')  support = [(0, 0), (1, 1)]\n",
+      "  ('a2', 'b2')  support = [(0, 1), (1, 0)]\n",
+      "\n",
+      "observables      : ('a1', 'a2', 'b1', 'b2')\n",
+      "espace de recherche : 16\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "satisfiable : False\n",
+      "VERDICT     : strongly_contextual\n",
+      "CP-SAT      : {'available': True, 'satisfiable': False, 'status_name': 'INFEASIBLE'}\n",
+      "obstruction minimale : (0, 1, 2, 3)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from ict import proxy_contextuality as pc\n",
+    "\n",
+    "# La boite PR : 4 contextes, chacun co-mesurant 2 observables sur {0,1}.\n",
+    "pr = pc.pr_box_model()\n",
+    "\n",
+    "print(\"contextes :\")\n",
+    "for ctx in pr.contexts:\n",
+    "    print(f\"  {ctx.proxies}  support = {sorted(ctx.support)}\")\n",
+    "print(f\"\\nobservables      : {pr.measurements}\")\n",
+    "print(f\"espace de recherche : {pr.search_space}\")\n",
+    "\n",
+    "verdict = pc.contextuality_verdict(pr)\n",
+    "print(f\"\\nsatisfiable : {verdict['satisfiable']}\")\n",
+    "print(f\"VERDICT     : {verdict['verdict']}\")\n",
+    "print(f\"CP-SAT      : {verdict['cpsat']}\")\n",
+    "print(f\"obstruction minimale : {pc.minimal_obstruction(pr)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell3",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "Le détecteur retrouve `strongly_contextual` sur un cas dont nous connaissons la réponse\n",
+    "par un argument de parité, et les **deux voies indépendantes s'accordent** : l'énumération\n",
+    "exhaustive bornée et CP-SAT. Un désaccord entre elles lèverait une `RuntimeError` — ce\n",
+    "serait un bug d'encodage, jamais un résultat.\n",
+    "\n",
+    "Noter que CP-SAT **ne rend délibérément aucun témoin**. Le statut `SAT`/`UNSAT` est\n",
+    "déterministe ; le témoin ne l'est pas (le solveur peut renvoyer une solution différente\n",
+    "d'une exécution à l'autre). Rapporter un témoin non canonique serait fabriquer de la\n",
+    "dérive dans les sorties committées.\n",
+    "\n",
+    "L'**obstruction minimale** répond à une exigence de l'issue : en cas d'obstruction, dire\n",
+    "*quels protocoles* portent le conflit. C'est une sous-famille irréductible — en retirer\n",
+    "n'importe quel contexte rend le modèle satisfiable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell4",
+   "metadata": {},
+   "source": [
+    "## 2. Trois crans, pas deux\n",
+    "\n",
+    "Voici l'erreur qu'un test naïf commet. On construit le CSP, il répond `SAT`, on conclut\n",
+    "« non contextuel ». **C'est faux.** `SAT` dit seulement « pas *fortement* contextuel ».\n",
+    "\n",
+    "Abramsky et Brandenburger distinguent un cran intermédiaire, la **contextualité logique** :\n",
+    "des sections globales existent, mais il existe un événement local **effectivement observé**\n",
+    "qu'aucune de ces sections globales ne réalise. L'obstruction n'est pas globale, elle est\n",
+    "*localisée sur cet événement* — et un test SAT nu ne la voit pas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T16:45:26.536913Z",
+     "iopub.status.busy": "2026-08-06T16:45:26.536618Z",
+     "iopub.status.idle": "2026-08-06T16:45:26.545338Z",
+     "shell.execute_reply": "2026-08-06T16:45:26.544705Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "modele                   SAT     verdict                  sections   locales sans extension\n",
+      "--------------------------------------------------------------------------------------------\n",
+      "boite PR                 False   strongly_contextual      0          8/8\n",
+      "logique mais pas forte   True    logically_contextual     1          5/9\n",
+      "non contextuel           True    non_contextual           16         0/16\n"
+     ]
+    }
+   ],
+   "source": [
+    "modeles = {\n",
+    "    \"boite PR\": pc.pr_box_model(),\n",
+    "    \"logique mais pas forte\": pc.logically_but_not_strongly_contextual_model(),\n",
+    "    \"non contextuel\": pc.non_contextual_model(),\n",
+    "}\n",
+    "\n",
+    "print(f\"{'modele':<24} {'SAT':<7} {'verdict':<24} {'sections':<10} {'locales sans extension'}\")\n",
+    "print(\"-\" * 92)\n",
+    "for nom, m in modeles.items():\n",
+    "    v = pc.contextuality_verdict(m)\n",
+    "    lc = pc.logical_contextuality(m)\n",
+    "    print(\n",
+    "        f\"{nom:<24} {str(v['satisfiable']):<7} {v['verdict']:<24} \"\n",
+    "        f\"{lc['n_global_sections']:<10} \"\n",
+    "        f\"{lc['n_without_extension']}/{lc['n_local_sections']}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell6",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "La ligne du milieu est celle qui compte. Le modèle est **satisfiable** — un test naïf\n",
+    "aurait conclu « non contextuel » — et pourtant il porte des témoins : des événements\n",
+    "observés localement qu'aucune section globale n'étend. Le verdict correct est\n",
+    "`logically_contextual`.\n",
+    "\n",
+    "C'est la raison pour laquelle le module rend `logical_contextuality` séparément : sans ce\n",
+    "cran, la moitié des obstructions passent pour des absences d'obstruction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell7",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — construire un modèle et prédire son cran\n",
+    "\n",
+    "Le recouvrement **partiel** est ce qui rend la question non triviale : trois contextes\n",
+    "$A=\\{p,q\\}$, $B=\\{q,r\\}$, $C=\\{r,p\\}$ se chevauchent deux à deux sans qu'aucun ne\n",
+    "contienne les trois proxys. C'est la structure en cycle qui porte les obstructions.\n",
+    "\n",
+    "Construis un tel modèle avec `pc.empirical_model`, **prédis** son cran avant de lancer le\n",
+    "test, puis compare. Le format attendu par `empirical_model` est une liste de mappings\n",
+    "`{\"proxies\": [...], \"support\": [(...), ...]}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T16:45:26.547642Z",
+     "iopub.status.busy": "2026-08-06T16:45:26.547436Z",
+     "iopub.status.idle": "2026-08-06T16:45:26.551361Z",
+     "shell.execute_reply": "2026-08-06T16:45:26.550923Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO etudiant : construire un modele a recouvrement partiel en cycle.\n",
+    "#\n",
+    "# Indice 1 : trois contextes A={p,q}, B={q,r}, C={r,p}, issues dans {0,1}.\n",
+    "# Indice 2 : pour forcer une obstruction, demande a chaque contexte que ses deux\n",
+    "#            proxys DIFFERENT (support = [(0,1),(1,0)]). Un cycle impair de\n",
+    "#            contraintes « different » est insatisfiable -- c'est le meme argument\n",
+    "#            de parite que la boite PR.\n",
+    "# Indice 3 : pour obtenir un modele satisfiable, remplace l'un des trois supports\n",
+    "#            par [(0,0),(1,1)] (« egaux ») et refais le test.\n",
+    "#\n",
+    "# Etape 1 : ecrire les trois contextes\n",
+    "contextes = None\n",
+    "\n",
+    "# Etape 2 : construire le modele\n",
+    "# modele = pc.empirical_model(contextes)\n",
+    "\n",
+    "# Etape 3 : predire le verdict AVANT de le calculer, puis verifier\n",
+    "prediction = None\n",
+    "\n",
+    "print(\"Exercice 1 a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell9",
+   "metadata": {},
+   "source": [
+    "## 3. Le garde-fou : trois manières d'être vide\n",
+    "\n",
+    "C'est le point méthodologique central de cette annexe, et il vaut bien au-delà d'elle.\n",
+    "\n",
+    "L'issue #7290 nomme le risque : *« le risque principal est l'analogie décorative »* — un\n",
+    "appareil impressionnant qui rend un verdict dont la réponse était **forcée par la\n",
+    "construction**. La série ICT en a déjà fait l'expérience avec l'obstruction de Čech\n",
+    "(ICT-15d) : verdict `TRIVIAL`, parce que les sections étaient colinéaires par construction.\n",
+    "\n",
+    "La leçon est convertie ici en machinerie plutôt qu'en vigilance : **un verdict ne vaut que\n",
+    "si sa négation était atteignable**. Trois configurations reçoivent donc un verdict *distinct*\n",
+    "de `SAT`/`UNSAT`, qui dit « le test n'était pas capable de trancher » :\n",
+    "\n",
+    "| Verdict de dégénérescence | Ce qui est vide |\n",
+    "|---|---|\n",
+    "| `degenerate_single_cover` | Tous les contextes co-mesurent **le même** ensemble de proxys. La question se réduit à « l'intersection des supports est-elle non vide ? ». Il n'y a pas de contextes distincts, donc pas de contextualité possible. |\n",
+    "| `degenerate_no_overlap` | Aucun proxy n'est partagé. `SAT` est forcé : chaque contexte se satisfait indépendamment. |\n",
+    "| `degenerate_rigid` | Tous les supports sont des singletons. Un `UNSAT` n'est alors qu'un **changement de valeur** — une dissociation, pas une obstruction. La force de Kochen–Specker est qu'aucune attribution ne marche *alors que chaque contexte en admet localement plusieurs*. |\n",
+    "\n",
+    "L'ordre de priorité est `single_cover` → `no_overlap` → `rigid` : on retient la\n",
+    "dégénérescence la plus forte, celle qui force le verdict de la façon la plus complète."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cell10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T16:45:26.553384Z",
+     "iopub.status.busy": "2026-08-06T16:45:26.553226Z",
+     "iopub.status.idle": "2026-08-06T16:45:26.558334Z",
+     "shell.execute_reply": "2026-08-06T16:45:26.557930Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "construction             SAT     verdict\n",
+      "--------------------------------------------------------------\n",
+      "recouvrement unique      True    degenerate_single_cover\n",
+      "aucun recouvrement       True    degenerate_no_overlap\n",
+      "supports rigides         False   degenerate_rigid\n"
+     ]
+    }
+   ],
+   "source": [
+    "demos = {\n",
+    "    \"recouvrement unique\": [\n",
+    "        {\"proxies\": [\"p\", \"q\"], \"support\": [(0, 0), (0, 1)]},\n",
+    "        {\"proxies\": [\"p\", \"q\"], \"support\": [(0, 0), (1, 1)]},\n",
+    "    ],\n",
+    "    \"aucun recouvrement\": [\n",
+    "        {\"proxies\": [\"p\"], \"support\": [(0,), (1,)]},\n",
+    "        {\"proxies\": [\"q\"], \"support\": [(0,), (1,)]},\n",
+    "    ],\n",
+    "    \"supports rigides\": [\n",
+    "        {\"proxies\": [\"p\", \"q\"], \"support\": [(0, 1)]},\n",
+    "        {\"proxies\": [\"q\", \"r\"], \"support\": [(0, 1)]},\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "print(f\"{'construction':<24} {'SAT':<7} {'verdict'}\")\n",
+    "print(\"-\" * 62)\n",
+    "for nom, ctxs in demos.items():\n",
+    "    v = pc.contextuality_verdict(pc.empirical_model(ctxs))\n",
+    "    print(f\"{nom:<24} {str(v['satisfiable']):<7} {v['verdict']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell11",
+   "metadata": {},
+   "source": [
+    "### Lecture — la ligne décisive est la troisième\n",
+    "\n",
+    "« supports rigides » est **insatisfiable** : le contexte 1 impose `q = 1`, le contexte 2\n",
+    "impose `q = 0`. Un test naïf aurait rapporté « obstruction structurelle », et cela aurait\n",
+    "été un **faux positif** — pas une erreur de calcul, mais une erreur d'interprétation. Il\n",
+    "n'y a là aucune obstruction au sens de Kochen–Specker : simplement deux protocoles qui ne\n",
+    "mesurent pas la même chose. Chaque contexte n'admettant qu'une seule section locale, il\n",
+    "n'y avait aucune liberté à contraindre.\n",
+    "\n",
+    "C'est exactement le faux positif que l'issue redoutait, et le garde l'intercepte."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell12",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — falsifier le garde\n",
+    "\n",
+    "Un garde-fou qu'on n'a pas essayé de casser n'est pas un garde-fou. Écris un modèle qui\n",
+    "soit **à la fois** insatisfiable **et** de supports rigides, mais avec un recouvrement\n",
+    "*réel* (au moins un proxy partagé, et pas le même ensemble de proxys partout).\n",
+    "\n",
+    "Vérifie que le verdict rendu est bien `degenerate_rigid` et **jamais**\n",
+    "`strongly_contextual`. Si tu parviens à obtenir `strongly_contextual` sur un modèle à\n",
+    "supports tous singletons, tu as trouvé un bug : signale-le sur l'issue #7290."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T16:45:26.560845Z",
+     "iopub.status.busy": "2026-08-06T16:45:26.560624Z",
+     "iopub.status.idle": "2026-08-06T16:45:26.564474Z",
+     "shell.execute_reply": "2026-08-06T16:45:26.564105Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO etudiant : fabriquer un piege pour le garde-fou.\n",
+    "#\n",
+    "# Indice 1 : recouvrement REEL veut dire que les ensembles de proxys ne sont pas\n",
+    "#            tous identiques (sinon c'est single_cover, une autre degenerescence,\n",
+    "#            et elle a la priorite).\n",
+    "# Indice 2 : supports rigides = chaque support ne contient qu'un seul tuple.\n",
+    "# Indice 3 : le test decisif du module s'appelle\n",
+    "#            test_rigid_supports_unsat_is_not_reported_as_contextual --\n",
+    "#            tu es en train d'en ecrire une variante.\n",
+    "#\n",
+    "# Etape 1 : construire le modele piege\n",
+    "piege = None\n",
+    "\n",
+    "# Etape 2 : verifier le verdict et l'assertion attendue\n",
+    "# v = pc.contextuality_verdict(pc.empirical_model(piege))\n",
+    "# attendu : v[\"satisfiable\"] is False et v[\"verdict\"] == pc.DEGENERATE_RIGID\n",
+    "\n",
+    "print(\"Exercice 2 a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell14",
+   "metadata": {},
+   "source": [
+    "## 4. La mesure appliquée : le zoo ICT\n",
+    "\n",
+    "Tout est en place. On braque maintenant l'instrument validé sur des données réelles.\n",
+    "\n",
+    "**Protocole.** Substrat S1 (`SelfSortingArray`), trajectoire du désordre mesurée par le\n",
+    "nombre d'inversions. Contextes = trois grains de description ($k \\in \\{3,4,6\\}$ symboles).\n",
+    "Graines $\\{0, 1, 7, 42, 99\\}$. Les proxys sont câblés **comme dans ICT-15c** — avec le\n",
+    "correctif anti-saturation $f(x) = x$ — plutôt que recâblés à neuf, pour que la mesure porte\n",
+    "sur le zoo tel qu'il est et non sur une variante de circonstance.\n",
+    "\n",
+    "Les valeurs continues sont discrétisées en issues binaires par **médiane du corpus** :\n",
+    "c'est un **choix**, pas une donnée, et le verdict est à lire avec cette réserve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cell15",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T16:45:26.566716Z",
+     "iopub.status.busy": "2026-08-06T16:45:26.566596Z",
+     "iopub.status.idle": "2026-08-06T16:45:26.591846Z",
+     "shell.execute_reply": "2026-08-06T16:45:26.590909Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "coarse_graining_k3\n",
+      "  seed= 0  gap=0.0193  sens_mean=2.0000  sens_max=2.0000\n",
+      "  seed= 1  gap=0.0195  sens_mean=2.0000  sens_max=2.0000\n",
+      "  seed= 7  gap=0.0135  sens_mean=2.0000  sens_max=2.0000\n",
+      "  seed=42  gap=0.0230  sens_mean=2.0000  sens_max=2.0000\n",
+      "  seed=99  gap=0.0238  sens_mean=2.0000  sens_max=2.0000\n",
+      "coarse_graining_k4\n",
+      "  seed= 0  gap=0.0134  sens_mean=3.0000  sens_max=3.0000\n",
+      "  seed= 1  gap=0.0133  sens_mean=3.0000  sens_max=3.0000\n",
+      "  seed= 7  gap=0.0115  sens_mean=3.0000  sens_max=3.0000\n",
+      "  seed=42  gap=0.0169  sens_mean=3.0000  sens_max=3.0000\n",
+      "  seed=99  gap=0.0172  sens_mean=3.0000  sens_max=3.0000\n",
+      "coarse_graining_k6\n",
+      "  seed= 0  gap=0.0085  sens_mean=5.0000  sens_max=5.0000\n",
+      "  seed= 1  gap=0.0098  sens_mean=5.0000  sens_max=5.0000\n",
+      "  seed= 7  gap=0.0067  sens_mean=5.0000  sens_max=5.0000\n",
+      "  seed=42  gap=0.0110  sens_mean=5.0000  sens_max=5.0000\n",
+      "  seed=99  gap=0.0121  sens_mean=5.0000  sens_max=5.0000\n"
+     ]
+    }
+   ],
+   "source": [
+    "from ict import sensitivity as SE\n",
+    "from ict import spectral as SP\n",
+    "from ict.meta_proxy import proxy_signature\n",
+    "from ict.self_sorting import SelfSortingArray\n",
+    "\n",
+    "\n",
+    "def inversions(v):\n",
+    "    return sum(1 for i in range(len(v)) for j in range(i + 1, len(v)) if v[i] > v[j])\n",
+    "\n",
+    "\n",
+    "def trajectory(seed, n_steps=120):\n",
+    "    # Trajectoire du desordre du substrat S1.\n",
+    "    arr = SelfSortingArray(values=[5, 3, 8, 1, 9, 2, 7, 4, 6, 0], seed=seed)\n",
+    "    traj = [inversions(arr.values)]\n",
+    "    # step() rend False pour un tick sans mouvement, PAS pour une terminaison :\n",
+    "    # on ne coupe donc pas sur False.\n",
+    "    for _ in range(n_steps):\n",
+    "        arr.step()\n",
+    "        traj.append(inversions(arr.values))\n",
+    "    return traj\n",
+    "\n",
+    "\n",
+    "def discretize(traj, n_symbols):\n",
+    "    # Coarse-graining : bins de largeur egale sur l'amplitude observee.\n",
+    "    lo, hi = min(traj), max(traj)\n",
+    "    if hi == lo:\n",
+    "        return [0] * len(traj)\n",
+    "    return [min(n_symbols - 1, int((x - lo) / (hi - lo) * n_symbols)) for x in traj]\n",
+    "\n",
+    "\n",
+    "SEEDS = (0, 1, 7, 42, 99)\n",
+    "GRAININGS = (3, 4, 6)\n",
+    "PROXIES = (\"spectral_gap\", \"sensitivity_mean\", \"sensitivity_max\")\n",
+    "\n",
+    "signatures = {}\n",
+    "for k in GRAININGS:\n",
+    "    runs = []\n",
+    "    for seed in SEEDS:\n",
+    "        states = discretize(trajectory(seed), k)\n",
+    "        sig = proxy_signature(\n",
+    "            states,\n",
+    "            k,\n",
+    "            spectral_fn=lambda s, n: float(SP.spectral_summary(s, n)[\"spectral_gap\"]),\n",
+    "            sensitivity_mean_fn=lambda s, n: float(\n",
+    "                SE.sensitivity_distribution(s, n, lambda x: x)[\"mean\"]\n",
+    "            ),\n",
+    "            sensitivity_max_fn=lambda s, n: float(\n",
+    "                SE.sensitivity_distribution(s, n, lambda x: x)[\"max\"]\n",
+    "            ),\n",
+    "        )\n",
+    "        runs.append({p: sig[p] for p in PROXIES})\n",
+    "    signatures[f\"coarse_graining_k{k}\"] = runs\n",
+    "\n",
+    "for ctx, runs in signatures.items():\n",
+    "    print(ctx)\n",
+    "    for seed, r in zip(SEEDS, runs):\n",
+    "        print(\n",
+    "            f\"  seed={seed:>2}  gap={r['spectral_gap']:.4f}  \"\n",
+    "            f\"sens_mean={r['sensitivity_mean']:.4f}  sens_max={r['sensitivity_max']:.4f}\"\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cell16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T16:45:26.594535Z",
+     "iopub.status.busy": "2026-08-06T16:45:26.594296Z",
+     "iopub.status.idle": "2026-08-06T16:45:26.599382Z",
+     "shell.execute_reply": "2026-08-06T16:45:26.598928Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Seuils de discretisation (medianes du corpus)\n",
+      "  spectral_gap       0.013437\n",
+      "  sensitivity_mean   3.000000\n",
+      "  sensitivity_max    3.000000\n",
+      "\n",
+      "Diagnostic de recouvrement\n",
+      "  contextes                : 3\n",
+      "  recouvrements distincts  : 1\n",
+      "  proxys partages          : ['sensitivity_max', 'sensitivity_mean', 'spectral_gap']\n",
+      "  tailles de support       : [1, 2, 1]\n",
+      "\n",
+      "  satisfiable              : False\n",
+      "  CP-SAT                   : {'available': True, 'satisfiable': False, 'status_name': 'INFEASIBLE'}\n",
+      "  VERDICT                  : degenerate_single_cover\n"
+     ]
+    }
+   ],
+   "source": [
+    "model, seuils = pc.model_from_signatures(signatures, PROXIES)\n",
+    "report = pc.overlap_report(model)\n",
+    "out = pc.contextuality_verdict(model)\n",
+    "\n",
+    "print(\"Seuils de discretisation (medianes du corpus)\")\n",
+    "for p, t in seuils.items():\n",
+    "    print(f\"  {p:<18} {t:.6f}\")\n",
+    "\n",
+    "print(\"\\nDiagnostic de recouvrement\")\n",
+    "print(f\"  contextes                : {len(model.contexts)}\")\n",
+    "print(f\"  recouvrements distincts  : {report['n_distinct_covers']}\")\n",
+    "print(f\"  proxys partages          : {report['shared_proxies']}\")\n",
+    "print(f\"  tailles de support       : {report['support_sizes']}\")\n",
+    "\n",
+    "print(\"\\n  satisfiable              : {}\".format(out[\"satisfiable\"]))\n",
+    "print(f\"  CP-SAT                   : {out['cpsat']}\")\n",
+    "print(f\"  VERDICT                  : {out['verdict']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell17",
+   "metadata": {},
+   "source": [
+    "### Lecture — l'écart entre les deux dernières lignes **est** le résultat\n",
+    "\n",
+    "Le modèle est **insatisfiable**, et le verdict n'est **pas** « fortement contextuel ». Cet\n",
+    "écart est tout le propos de l'annexe.\n",
+    "\n",
+    "Un test naïf aurait rapporté ici « obstruction structurelle dans le zoo de proxys ». Le\n",
+    "garde intercepte, et la raison est structurelle — vérifiable sans le solveur : les trois\n",
+    "proxys du zoo partagent la même signature d'appel `(states, n_symbols)`. **Rien n'empêche\n",
+    "donc de les calculer tous les trois sur la même trajectoire.** Or c'est précisément la\n",
+    "*non*-co-mesurabilité — l'analogue de la non-commutativité chez Kochen–Specker — qui crée\n",
+    "des contextes distincts. Il n'y a qu'un seul recouvrement : `degenerate_single_cover`.\n",
+    "\n",
+    "L'`UNSAT` observé n'est donc qu'un désaccord entre grains de description : un fait déjà\n",
+    "acquis par ailleurs dans la série, et d'une autre nature.\n",
+    "\n",
+    "### Le verdict honnête\n",
+    "\n",
+    "Le zoo ICT n'est **pas** « non contextuel ». La question de sa contextualité **n'y est pas\n",
+    "encore posable** — le transfert échoue un cran *avant* le `SAT`/`UNSAT`, faute de proxys\n",
+    "non conjointement mesurables.\n",
+    "\n",
+    "L'ingrédient manquant est identifié, et il est unique : une structure de co-mesurabilité\n",
+    "**partielle et justifiée** — deux proxys dont les prétraitements sont *genuinement*\n",
+    "incompatibles, tels qu'aucun protocole ne les livre ensemble. L'outillage est livré validé :\n",
+    "le jour où une telle structure existe, le test se pose sans réécriture.\n",
+    "\n",
+    "C'est un résultat négatif, et il est publiable tel quel. Ce qu'il ferme est une piste\n",
+    "séduisante ; ce qu'il laisse est un critère net pour la rouvrir.\n",
+    "\n",
+    "### Un constat secondaire, rapporté à part\n",
+    "\n",
+    "Les sorties ci-dessus montrent `sensitivity_mean == sensitivity_max == k - 1`\n",
+    "**exactement**, sur les 5 graines et les 3 grains. L'instrument sature sur la trajectoire\n",
+    "d'inversions de S1 **malgré** le correctif $f(x) = x$ d'ICT-15c. Deux des trois proxys ne\n",
+    "portent donc aucune variance inter-graines. C'est un fait sur l'instrument, indépendant de\n",
+    "Kochen–Specker, et il mérite son propre examen — il n'est pas traité ici."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell18",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — poser la question rendue impossible\n",
+    "\n",
+    "C'est l'exercice ouvert, et le seul dont la réponse n'est pas connue.\n",
+    "\n",
+    "L'annexe conclut que le zoo manque d'une structure de co-mesurabilité **partielle**.\n",
+    "Propose-en une, puis teste-la.\n",
+    "\n",
+    "Un candidat sérieux doit répondre par écrit à : *pourquoi ces deux proxys ne peuvent-ils\n",
+    "pas être calculés sur la même trajectoire ?* Une réponse acceptable invoque une\n",
+    "incompatibilité de **prétraitement** — par exemple deux discrétisations, deux fenêtrages ou\n",
+    "deux normalisations qu'aucun pipeline ne peut appliquer simultanément à la même série.\n",
+    "\n",
+    "Attention au piège que cette annexe vient de documenter : si ta structure produit un\n",
+    "recouvrement unique, le garde rendra `degenerate_single_cover` et la question sera de\n",
+    "nouveau non posable. Il faut un recouvrement **partiel** en cycle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cell19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-06T16:45:26.601920Z",
+     "iopub.status.busy": "2026-08-06T16:45:26.601754Z",
+     "iopub.status.idle": "2026-08-06T16:45:26.604844Z",
+     "shell.execute_reply": "2026-08-06T16:45:26.604412Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO etudiant : proposer une structure de co-mesurabilite partielle JUSTIFIEE.\n",
+    "#\n",
+    "# Indice 1 : la justification est la partie difficile, et elle est textuelle.\n",
+    "#            Ecris-la en commentaire ci-dessous AVANT de coder quoi que ce soit ;\n",
+    "#            un decoupage arbitraire des proxys en contextes ne demontrerait rien\n",
+    "#            (ce serait exactement l'analogie decorative que l'annexe refuse).\n",
+    "# Indice 2 : la structure viable est un cycle -- A={p,q}, B={q,r}, C={r,p} --\n",
+    "#            avec p, q, r deux a deux co-mesurables mais jamais les trois ensemble.\n",
+    "# Indice 3 : verifie d'abord pc.overlap_report(...)['n_distinct_covers'] > 1\n",
+    "#            AVANT de regarder le verdict. Si le recouvrement est unique,\n",
+    "#            la question n'est pas posee et le verdict ne veut rien dire.\n",
+    "#\n",
+    "# Ma justification (a rediger) :\n",
+    "#   proxys retenus  : ...\n",
+    "#   incompatibilite : ...\n",
+    "#   pourquoi elle n'est pas un artefact de mise en oeuvre : ...\n",
+    "\n",
+    "structure = None\n",
+    "\n",
+    "# Etape 1 : construire le modele a partir de la structure proposee\n",
+    "# Etape 2 : verifier le recouvrement AVANT le verdict\n",
+    "# Etape 3 : rendre le verdict et l'interpreter avec les trois crans\n",
+    "\n",
+    "print(\"Exercice 3 a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell20",
+   "metadata": {},
+   "source": [
+    "## 5. Où l'analogie meurt — quatre points de rupture\n",
+    "\n",
+    "Un transfert non instruit *est* l'analogie décorative. Ces quatre points sont les endroits\n",
+    "où le cadre quantique et le zoo de proxys cessent de se correspondre, et ils doivent\n",
+    "accompagner tout usage de cette machinerie.\n",
+    "\n",
+    "1. **Origine des contraintes.** Chez Kochen–Specker, les contraintes sont **algébriques**\n",
+    "   (relations d'orthogonalité entre projecteurs) : elles sont exactes. Ici, elles sont\n",
+    "   **mesurées** — un support est un ensemble de tuples *observés*. Un `UNSAT` peut donc\n",
+    "   être un artefact d'échantillonnage plutôt qu'une obstruction.\n",
+    "\n",
+    "2. **Identité des observables.** En quantique, « le même observable dans deux contextes »\n",
+    "   est littéralement *le même opérateur*. Ici, un proxy calculé sous deux grains de\n",
+    "   description n'est pas garanti être la même grandeur. C'est **l'hypothèse la plus forte**\n",
+    "   du transfert, et elle n'est pas démontrée.\n",
+    "\n",
+    "3. **Pas de théorème de dimension.** Kochen–Specker exige $\\dim \\geq 3$ et des\n",
+    "   configurations de rayons précises ; rien de tel ne contraint le zoo. Conséquence\n",
+    "   symétrique et souvent oubliée : l'absence d'obstruction ici n'a **aucune portée** sur le\n",
+    "   théorème de Kochen–Specker, ni réciproquement.\n",
+    "\n",
+    "4. **Discrétisation.** Les seuils qui transforment des valeurs continues en issues\n",
+    "   discrètes sont un **choix**. Un verdict doit être rapporté avec sa sensibilité à ce\n",
+    "   choix, sans quoi il mesure le seuil autant que le substrat.\n",
+    "\n",
+    "## Ce qu'il faut retenir\n",
+    "\n",
+    "La contribution de cette annexe n'est pas un verdict de contextualité — il n'y en a pas.\n",
+    "C'est une **méthode** :\n",
+    "\n",
+    "- une question conceptuelle importée peut devenir un objet calculable, et c'est ce qui la\n",
+    "  rend contestable plutôt que décorative ;\n",
+    "- un détecteur se **valide sur un cas prouvé à la main** avant d'être braqué sur des\n",
+    "  données ;\n",
+    "- et surtout : **un verdict ne vaut que si sa négation était atteignable.** Les trois\n",
+    "  dégénérescences ne sont pas un raffinement cosmétique — ce sont elles qui ont transformé\n",
+    "  un faux positif séduisant en un résultat négatif utilisable.\n",
+    "\n",
+    "> **Note de grade C** (discipline #8182) : la lecture de la contextualité comme\n",
+    "> « obstruction au recollement » circule dans la littérature adjacente (*boundary problem*).\n",
+    "> Elle est ici un **hook documentaire**, jamais créditée comme résultat.\n",
+    "\n",
+    "**Références et suites.** Issue #7290 (registre de cette annexe) · module `ict/proxy_contextuality.py`\n",
+    "et sa suite de tests · `docs/ict/synthese-invariants-dissociations-obstructions.md`\n",
+    "(section dédiée) · ICT-15d pour la leçon d'origine sur les verdicts vides."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: DEEP/research #9740

> **PR empilee sur #9740** (base = `feature/ict-proxy-contextuality-7290`, pas `main`) : le notebook importe `ict/proxy_contextuality.py`, livre par cette PR-la. GitHub re-ciblera automatiquement sur `main` au merge de #9740. **Merger #9740 d'abord.** Le diff affiche ici est donc exactement le notebook, rien d'autre.

## Summary

Livre le **residuel que j'avais declare** dans le body de #9740 (« `ICT-Annexe-ProxyContextuality.ipynb` : non livre ici, une PR = un sujet »). Le module y etait valide par 47 tests ; il lui manquait le carnet qui le fait tourner devant un lecteur.

Un fichier, 805 insertions, 0 suppression.

## Ce que le notebook fait

21 cellules — 13 markdown FR, 8 code **toutes executees** (`exec_count` 1..8, 0 erreur, outputs reels committes) :

| Etape | Cellule | Sortie mesuree |
|---|---|---|
| Valider l'instrument avant de le croire | boite de Popescu-Rohrlich | `strongly_contextual`, UNSAT, CP-SAT `INFEASIBLE`, obstruction minimale `(0,1,2,3)` |
| Trois crans, pas deux | les 3 fixtures oracles | `logically_contextual` **avec SAT=True** et 5/9 sections locales sans extension |
| Le garde-fou | les 3 degenerescences | `single_cover` / `no_overlap` / **`rigid` (SAT=False)** |
| La mesure appliquee | S1, 3 grains x 5 graines | UNSAT **mais** verdict `degenerate_single_cover` |

**La ligne qui porte la PR est la derniere.** Le modele est insatisfiable et le verdict n'est pas « fortement contextuel » : le garde intercepte le faux positif « obstruction structurelle » que #7290 designait comme le risque principal (« le risque principal est l'analogie decorative »). Un lecteur voit le faux positif se produire et se faire arreter, sur des donnees reelles — c'est ce qu'un module + des tests ne montrent pas.

## Pedagogie

- **3 exercices** (regle #2161, seuil atteint : `count_exercises.py` -> 3/3 conforme), gradues : (1) construire un modele a recouvrement partiel en cycle et **predire** son cran avant de le calculer ; (2) **essayer de casser le garde-fou** — fabriquer UNSAT + supports rigides + recouvrement reel, et verifier qu'on n'obtient jamais `strongly_contextual` ; (3) l'exercice **ouvert**, dont la reponse n'est pas connue : proposer une structure de co-mesurabilite partielle *justifiee*, avec l'exigence que la justification soit ecrite **avant** tout code.
- **C.1 conforme** : stubs `pass` / `print("Exercice a completer")` / `None`, `# TODO` / `# Indice` / `# Etape N` conserves. Zero `raise NotImplementedError` / `assert False` / `1/0` — verifie par comptage sur la source des 8 cellules code. Le notebook s'execute de bout en bout exercices non completes (c'est ce que montrent les outputs).
- La conclusion enonce les **quatre points de rupture** avec le cas quantique, dont le point souvent oublie : l'absence d'obstruction ici n'a **aucune portee** sur le theoreme de Kochen-Specker, ni reciproquement.

## Honnetete des claims

Chaque chiffre de la prose est lisible dans les outputs de la cellule qui precede. En particulier la saturation rapportee — `sensitivity_mean == sensitivity_max == k-1` **exactement** — est verifiable ligne a ligne dans la sortie : `2.0000` a k=3, `3.0000` a k=4, `5.0000` a k=6, sur les 5 graines. Rapportee comme constat secondaire sur l'instrument, explicitement **pas** traitee ici.

Le verdict de fond est negatif et ecrit comme tel : le zoo n'est pas « non contextuel », **la question n'y est pas encore posable**, et l'ingredient manquant est nomme.

## Validation

```
nbconvert --execute --inplace          -> 0 erreur, exec_count 1..8, outputs reels
count_exercises.py                     -> 3 exercices, seuil >= 3 atteint
check_c2_compliance.py --path          -> 1/1 compliant, "All clear!"
check_notebook_navlinks.py <path>      -> 0 lien casse (mode cible : le mode --check
                                          est tracked-only et aurait ignore un
                                          notebook neuf, faux EXIT 0)
detect_papermill_path_leak.py --outputs -> []
check_prose_quantitative_claims.py --all --class all
    -> le notebook n'apparait dans AUCUNE des 4 classes (#9377 / #9434)
```

Le dernier point n'est pas decoratif : #9434 documente que la prose des notebooks re-epingle des valeurs machine/env/stochastiques. Ce notebook n'en introduit aucune — les seuls nombres de sa prose sont structurels (`k-1`, `dim >= 3`) ou des parametres de protocole.

JSON : `indent=1`, `ensure_ascii=False`, **LF-only** (nbconvert avait reecrit en CRLF ; renormalise apres verification que les 805 CR etaient **tous** des separateurs JSON et **aucun** dans le contenu — 0 sortie modifiee, pas de scrub). `nbformat.validate()` OK, ids v4.5 presents.

Catalogue byte-identique a la base (aucun fichier genere touche).

## Residuel

- La question ouverte de #7290 — etablir une structure de co-mesurabilite partielle **justifiee** — reste ouverte, et c'est desormais l'**exercice 3** du notebook. `#7290` ne se ferme pas ici : la decision appartient au coordinateur.
- S2-S4 non mesures (couvert par l'argument structurel de #9740, pas par de la mesure).

See #7290
See #2161

Co-Authored-By: Claude-Code <noreply@anthropic.com>
