### PR TITLE
docs(qc,#1621): CSharp-BTC-EMA-Cross README FR + backtest frais + lecture honnête (NO-BEATS)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-EMA-Cross/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-EMA-Cross/README.md
@@ -1,13 +1,77 @@
-# BTC EMA Cross Daily (C#) (ID: 19050970)
+# BTC EMA Cross Daily (C#)
 
-Croisement EMA rapide/lente sur BTCUSDT en C#. Algorithme de reference.
+Croisement EMA rapide/lente sur `BTCUSDT` en C#. Algorithme de référence pour
+l'enseignement de la structure d'un algorithme QuantConnect en C#, des indicateurs
+EMA paramétrables, et du modèle de brokerage Binance (compte Cash, USDT).
+
+## Stratégie
+
+- **Actif** : `BTCUSDT` (Binance, résolution Daily, compte Cash en USDT)
+- **Signaux** : EMA rapide 18 / EMA lente 23 (périodes proches → croisements fréquents)
+- **Filtre anti-whipsaw** : bande de marge ±0,1 % (`UpCrossMargin 1.001` / `DownCrossMargin 0.999`) — on n'entre ou ne sort que sur dépassement franchi, pas sur micro-croisement
+- **Position** : long-only, 100 % (`SetHoldings 1.0`) à l'achat, `Liquidate` à la vente
+- **Capital initial** : 600 000 USDT
+- **Période** : 2017-10-01 → 2025-01-01 (bull 2017, bear 2018, recovery 2019, COVID 2020, bull 2020-21, bear 2022, recovery 2023-25)
+
+## Métriques de backtest (QC Cloud, run frais 2026-08-06)
+
+Backtest single-asset Daily sur 2 650 jours tradables, 50 ordres exécutés (≈ 25
+allers-retours, soit ~3,5 par an — la bande de marge filtre efficacement les
+micro-croisements).
+
+| Métrique | Valeur |
+|----------|--------|
+| Sharpe Ratio | 1.287 |
+| CAGR (rendement annuel composé) | 44.75 % |
+| Drawdown maximal | 54.60 % |
+| Rendement total net | +1367.5 % |
+| Probabilistic Sharpe Ratio (PSR) | 49.77 % |
+| Ordres exécutés | 50 |
+
+## Lecture honnête
+
+Le résultat est **nuancé**, et c'est ce qui le rend pédagogiquement intéressant —
+on n'est ni dans l'échec franc, ni dans l'edge miraculeux.
+
+1. **Sous-performance vs buy-and-hold en rendement brut.** Sur la même période, le
+   BTC nu passe de ~4 300 $ (oct. 2017) à ~96 000 $ (janv. 2025), soit ~+2 100 % et
+   un CAGR de l'ordre de ~53 % (estimation depuis les prix publics ; le benchmark
+   exact n'est pas repris dans les statistiques retournées). La stratégie
+   (+1 367 %, CAGR 44.75 %) laisse donc de l'argent sur la table : long-only avec
+   sortie sur croisement descendant, elle reste en USDT pendant les jambes de
+   reprise précoce et rate une partie de la tendance dominante. C'est le coût
+   structurel d'un indicateur lagging (l'EMA confirme la tendance après le fait)
+   sur un actif à tendance long-terme marquée.
+
+2. **Réduction du drawdown.** L'avantage : la stratégie coupe le portefeuille en
+   USDT sur les croisements descendants, ce qui limite le drawdown à 54.60 %, contre
+   ~80 % pour le BTC nu (krach 2018 ≈ -84 %, krach 2022 ≈ -76 %). Le timing achète
+   donc moins de rendement contre moins de douleur — un compromis risk-return, pas
+   un alpha.
+
+3. **Sharpe 1.287 mais PSR ~50 %.** Le Probabilistic Sharpe Ratio de 49.77 % signifie
+   que le Sharpe observé n'est **pas statistiquement distinguable du hasard** au seuil
+   usuel (on viserait PSR > 95 % pour un edge robuste). Sur un seul actif et une seule
+   période, ce n'est pas une preuve d'edge : c'est cohérent avec l'hypothèse qu'une
+   EMA cross est un filtre de tendance, pas un prédicteur.
+
+**Verdict honnête** : NO-BEATS en rendement brut (inférieur au buy-and-hold),
+drawdown réduit (54.6 % vs ~80 %), edge statistiquement non robuste (PSR ~50 %).
+Stratégie valable comme illustration pédagogique d'un croisement de moyennes avec
+filtre de marge et brokerage crypto — pas comme source d'alpha.
 
 ## Fichiers
-- `Main.cs` - EMA cross avec marges configurables (up/down cross margin)
-- `Research.ipynb` - Uncorrelated Assets (C# Research Environment)
 
-## Concepts enseignes
-- Structure algorithme C# QC
-- Indicateurs EMA avec parametres
-- Plotting (Chart API)
-- Binance brokerage model
+- `Main.cs` — `BtcEmaCrossDaily1Algorithm` : EMA cross avec marges configurables,
+  charting (Price / Portfolio Value / Fast EMA / Slow EMA), Binance Cash brokerage
+- `research_robustness.ipynb` — étude de robustesse (C# Research Environment)
+- `RESEARCH_INSTRUCTIONS.md` — consignes de l'étude de recherche
+
+## Concepts enseignés
+
+- Structure d'un algorithme QuantConnect en C# (`QCAlgorithm`)
+- Indicateurs EMA paramétrés (`[Parameter]` ema-fast / ema-slow / marges)
+- Bande de marge anti-whipsaw (up/down cross margin)
+- Chart API (`Chart` / `Series` / `Plot`) + `Schedule.On`
+- Modèle de brokerage Binance, compte Cash, devise USDT
+- Lecture critique d'un backtest : rendement vs drawdown vs significance statistique (PSR)


### PR DESCRIPTION
## Summary

**Grain** : DEEP/qc — `CSharp-BTC-EMA-Cross` (BtcEmaCrossDaily1Algorithm, EMA 18/23 `BTCUSDT` Daily, long-only Cash Binance). README FR concis **sans table de métriques** et avec une référence stale (`Research.ipynb` inexistant) + Cloud ID 19050970 inexistant. Cette PR ajoute un **backtest QC Cloud frais** + une **lecture honnête** du résultat.

Contexte lane : lake.exe WDAC-blocked sur po-2026 (A.4 G2 Lean env-gated, RECOVERABLE-MACHINE admin) → pivot vers QC (famille courante). Le sweep ML-* README FR+backtest (#9702/#9709/#9714) est owned par une autre lane ; cette PR prend une stratégie **non-ML hors-sweep**, en C# (expertise .NET de la lane).

## Backtest QC Cloud frais (2026-08-06)

Projet Cloud jetable `btc-ema-cross-cs-po2026` (34899265), compile `BuildSuccess` (0 erreur), backtest 2017-10-01 → 2025-01-01 (2 650 jours tradables, 50 ordres) :

| Métrique | Valeur |
|----------|--------|
| Sharpe Ratio | 1.287 |
| CAGR | 44.75 % |
| Drawdown maximal | 54.60 % |
| Rendement total net | +1367.5 % |
| Probabilistic Sharpe Ratio | 49.77 % |

## Lecture honnête — verdict NO-BEATS (nuancé)

1. **Sous-performe le buy-and-hold en rendement brut** : CAGR 44.75 % vs ~53 % pour le BTC nu (~4 300 → ~96 000 USD sur la même période). Long-only avec sortie sur croisement descendant, la stratégie reste en USDT pendant les jambes de reprise précoce — coût structurel d'un indicateur lagging sur un actif à tendance long-terme marquée.
2. **Réduit le drawdown** : 54.60 % vs ~80 % pour le BTC nu (krach 2018 ≈ -84 %, krach 2022 ≈ -76 %). Le timing achète moins de rendement contre moins de douleur — un compromis risk-return, pas un alpha.
3. **Sharpe 1.287 mais PSR ~50 %** : edge **non statistiquement robuste** (on viserait PSR > 95 %). Cohérent avec une EMA cross = filtre de tendance, pas un prédicteur.

Stratégie valable comme **illustration pédagogique** (structure algo C# QC, EMA paramétrés, bande anti-whipsaw, Chart API, brokerage Binance Cash) — pas comme source d'alpha.

## Corrections annexes (même fichier)

- Référence stale `Research.ipynb` (fichier absent) → `research_robustness.ipynb` + `RESEARCH_INSTRUCTIONS.md` (fichiers réels tracés sur origin/main, vérifiés `git ls-tree`).
- Accents FR sur la prose éditée (#2876).
- Cloud ID 19050970 stale (projet inexistant, vérifié `read_project`) supprimé.

## Validation

- `git diff --stat` : 1 fichier (README.md), +74/−10. **0 ligne de code C# touchée** (Main.cs byte-identique).
- **Catalogue byte-identique à main** (0 churn — README-only, pas de marqueur CATALOG-STATUS).
- Backtest exécuté via MCP qc-mcp-lite (compile + backtest réels, métriques ci-dessus).
- Fresh worktree isolé depuis `origin/main` (096c624ce) — arbre partagé sale (WIP Lean/BTC-ML/prover d'autres sessions) non touché.

See #1621 (consolidation QC/Trading — contribution partielle, 1 README stratégie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
