### PR TITLE
docs(owui,#4433): guide de triage infra-vs-test a partir d'incidents reels

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/README.md
@@ -58,6 +58,7 @@ Playwright-OWUI/
 ├── playwright.config.ts
 ├── WHATS-NEW-v0.9.1.md               # Nouveautés v0.9.1 (historique)
 ├── WHATS-NEW-v0.10.md                # Nouveautés v0.10 (côté étudiant)
+├── TRIAGE-INFRA-VS-TEST.md           # Guide transversal : app, test ou infra ?
 └── README.md                         # Ce fichier
 ```
 
@@ -232,6 +233,13 @@ npm run report
 Ces pièges ont été découverts lors de la validation initiale de la suite de tests.
 Ils sont documentés ici car ils sont représentatifs de vrais problèmes
 rencontrés lors du test E2E d'applications web modernes.
+
+> **Avant de corriger un test rouge, identifiez la cause.** Les quatre pièges
+> ci-dessous relèvent du test lui-même — mais une suite peut aussi rougir sans
+> qu'aucun test ni aucune ligne de code n'ait de problème. Le guide
+> **[TRIAGE-INFRA-VS-TEST.md](./TRIAGE-INFRA-VS-TEST.md)** apprend à distinguer
+> une régression applicative, une dérive de sélecteur et une panne
+> d'infrastructure, à partir de trois incidents réels de la flotte.
 
 ### 1. Modal "Quoi de neuf" (Changelog)
 

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/TRIAGE-INFRA-VS-TEST.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/TRIAGE-INFRA-VS-TEST.md
@@ -1,0 +1,197 @@
+# Triage — un test rouge n'est pas toujours un bug
+
+[← Retour Playwright-OWUI](./README.md)
+
+> **Pour qui ?** Étudiants du parcours QA-OWUI, à partir du module 03. Ce guide
+> répond à la question que se pose tout QA Engineer devant une suite qui rougit :
+> **« est-ce l'application, mon test, ou la machine ? »**
+>
+> Les trois cas d'étude ci-dessous sont des incidents **réels** survenus sur la
+> flotte multi-tenant qui sert de terrain à cette série. Aucun n'est inventé pour
+> l'exercice — c'est justement ce qui les rend instructifs.
+
+## Le réflexe à acquérir
+
+Un test qui échoue vous dit **qu'une attente n'a pas été satisfaite**. Il ne vous
+dit pas *pourquoi*. Trois causes très différentes produisent exactement le même
+rouge dans le rapport :
+
+| Cause | Ce qui a changé | Qui doit corriger |
+|-------|-----------------|-------------------|
+| **Régression applicative** | Le code de l'app | L'équipe de dev |
+| **Dérive de test** | L'UI a bougé, le test non (sélecteur obsolète) | Vous, le QA |
+| **Panne d'infrastructure** | Ni l'app ni le test : la machine, le réseau, un service | L'équipe ops |
+
+Confondre les trois coûte cher : on « corrige » un sélecteur qui n'avait rien,
+on ouvre un bug chez les devs pour une panne réseau, ou — le pire — on
+désactive un test qui avait raison.
+
+**Règle : on ne conclut pas sans avoir mesuré la couche du dessous.**
+
+---
+
+## Cas d'étude 1 — « Le site est mort » alors que l'application va bien
+
+**Symptôme.** Le site public renvoie `502 Bad Gateway`. Six instances sur sept
+sont injoignables. Toute la suite E2E échoue dès l'authentification.
+
+**Le réflexe naïf.** « L'application est plantée, il faut la redémarrer / prévenir
+les devs. »
+
+**Ce que dit la mesure.** En interrogeant chaque couche séparément :
+
+```
+/health DANS le conteneur ......... 200   ← l'application va parfaitement bien
+port de l'hôte (localhost:3010) ... 000   ← rien n'écoute côté hôte
+URL publique (via reverse proxy) .. 502   ← le proxy ne trouve personne
+```
+
+**Diagnostic.** L'application était saine du début à la fin. C'est la
+**redirection de port** entre l'hôte et le conteneur qui était morte (bug connu
+de Docker Desktop sous Windows). Le `502` du proxy n'était que l'écho de ce trou.
+
+**Leçon transposable.** Une requête traverse une pile :
+
+```
+test → DNS → reverse proxy → port de l'hôte → conteneur → application → base
+```
+
+Un échec vous donne le résultat **de bout en bout**. Pour localiser la panne,
+interrogez les couches **une par une, en partant du bas**. Le premier maillon
+vert en partant de l'application désigne le coupable juste au-dessus.
+
+---
+
+## Cas d'étude 2 — 22 tests rouges, et pourtant aucun bug
+
+**Symptôme.** Une exécution de la suite rend **22 échecs / 19 succès**. Les
+messages accusent tous un sélecteur : le bouton du sélecteur de modèles serait
+introuvable.
+
+**Le réflexe naïf.** « L'UI a changé, le sélecteur est obsolète, je le corrige. »
+
+**Ce que dit la preuve.** Playwright joint à chaque échec un instantané du DOM
+(`error-context.md`). En l'ouvrant, on y lit :
+
+```
+button "Modèle sélectionné : Samantha" [ref=e131]
+```
+
+Le bouton que le test « ne trouve pas » **est présent dans la capture prise au
+moment de l'échec**. Un sélecteur cassé ne se comporte pas ainsi : il produit un
+DOM où l'élément est *absent* ou *différent*.
+
+**Diagnostic.** La suite avait été lancée pendant qu'un téléchargement de 17 Go
+saturait le réseau et le disque de la même machine. Les pages mettaient plus
+longtemps à devenir interactives que le délai d'attente des tests. Les échecs
+étaient des **expirations de délai**, pas des erreurs d'assertion.
+
+**Leçon transposable.** Apprenez à lire la **nature** de l'erreur :
+
+| Indice | Interprétation probable |
+|--------|-------------------------|
+| `TimeoutError` + élément présent dans la capture | Environnement lent, pas dérive |
+| `TimeoutError` + élément absent de la capture | Vraie dérive de sélecteur, ou page non chargée |
+| Erreur d'**assertion** (`expect(...)` reçoit une autre valeur) | Régression applicative probable |
+| Échecs **massifs et simultanés** sur des tests sans rapport | Cause commune → suspectez l'infra |
+| Un seul test rouge, ciblé, reproductible | Suspectez le code ou le test |
+
+Le dernier critère est le plus discriminant : **une cause commune produit des
+symptômes communs**. Quand vingt tests indépendants tombent ensemble, ce n'est
+presque jamais vingt bugs.
+
+> ⚠️ **L'erreur que ce cas illustre vraiment** : la suite avait été lancée
+> *sciemment* pendant une opération lourde sur la même machine. Un résultat de
+> test obtenu dans des conditions non maîtrisées n'est pas un résultat — c'est
+> du bruit. Il fallait relancer au calme avant toute conclusion.
+
+---
+
+## Cas d'étude 3 — Mesurer avant d'accuser
+
+**Symptôme.** Des téléchargements qui « se bloquent » sans jamais échouer :
+aucune erreur, aucun octet, pas de fin.
+
+**Ce que dit la mesure.** Trois commandes suffisent à trancher :
+
+```bash
+# Débit réel vers un CDN rapide
+curl -o /dev/null -w 'debit=%{speed_download}o/s\n' --max-time 60 \
+  "https://speed.cloudflare.com/__down?bytes=25000000"
+
+# Latence
+ping 1.1.1.1
+```
+
+Relevé effectué pendant l'incident : **~140 Ko/s** de débit et une latence
+moyenne de **671 ms** (contre quelques millisecondes attendues). À ce régime,
+n'importe quelle attente de 30 secondes expire, et un transfert d'un gigaoctet
+demande des heures.
+
+**Diagnostic.** Rien n'était « bloqué » : tout était simplement **trop lent d'un
+facteur cent**. Un blocage et une lenteur extrême se ressemblent beaucoup vus
+d'en haut — seule la mesure les distingue.
+
+**Leçon transposable.** Avant d'écrire « c'est bloqué » dans un rapport de bug,
+produisez un **chiffre**. « Le pull ne fonctionne pas » n'est pas exploitable ;
+« 0 octet reçu en 240 s alors que le lien plafonne à 140 Ko/s » l'est.
+
+---
+
+## Mettre le triage dans le code
+
+Le meilleur triage est celui que la suite fait **toute seule**. Plutôt que de
+laisser vingt tests rougir parce qu'un service est absent, vérifiez l'infra une
+fois et signalez-le clairement.
+
+```typescript
+import { test, expect, request } from '@playwright/test';
+
+// Sonde d'infrastructure : si la plateforme ne repond pas, on ne fait pas
+// rougir la suite — on l'ignore avec un motif explicite. Un test rouge doit
+// vouloir dire "l'application a un probleme", jamais "la machine est absente".
+test.beforeAll(async ({ baseURL }) => {
+  const ctx = await request.newContext();
+  let healthy = false;
+  try {
+    const res = await ctx.get(`${baseURL}/health`, { timeout: 10_000 });
+    healthy = res.ok();
+  } catch {
+    healthy = false;            // DNS, refus de connexion, expiration...
+  } finally {
+    await ctx.dispose();
+  }
+  test.skip(!healthy, `Instance injoignable sur ${baseURL} — panne d'infrastructure, pas un echec de test`);
+});
+```
+
+Deux principes valables bien au-delà de Playwright :
+
+1. **Distinguer « en échec » de « non exécutable ».** Un test ignoré avec un
+   motif lisible informe ; un test rouge sans cause informe mal.
+2. **Ne jamais masquer un vrai échec.** Cette sonde ne doit couvrir que
+   l'indisponibilité *de la plateforme*, jamais une fonctionnalité qu'on teste.
+   Sinon on transforme un bug en silence — l'inverse du but recherché.
+
+Le module 03 applique déjà cette idée aux modèles indisponibles (« skip
+gracieux ») et le module 06 à la détection de fonctionnalité. Ce guide en donne
+la règle générale.
+
+## Checklist de triage
+
+Avant de conclure quoi que ce soit sur une suite rouge :
+
+- [ ] Les échecs sont-ils **massifs et simultanés** ? (→ cause commune)
+- [ ] L'erreur est-elle une **expiration** ou une **assertion** ?
+- [ ] L'élément « introuvable » figure-t-il dans la **capture jointe** ?
+- [ ] La machine était-elle **occupée** pendant l'exécution ?
+- [ ] Le débit et la latence ont-ils été **mesurés**, pas supposés ?
+- [ ] La pile a-t-elle été interrogée **couche par couche** ?
+- [ ] Une **relance au calme** reproduit-elle le résultat ?
+
+Tant que la dernière case n'est pas cochée, vous n'avez pas de verdict : vous
+avez une hypothèse.
+
+---
+
+*Guide transversal — cas d'étude issus d'incidents réels de la flotte multi-tenant, août 2026.*


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2023:CoursIA-2 — prev: MED/docs #9738

## Pourquoi

Le parcours QA-OWUI apprend à **écrire** des tests. Il n'apprend pas à **lire leurs échecs**.

Or sur une flotte réelle, une suite rouge veut dire aussi souvent « la machine a un problème » que « l'application a un bug » — et vues du rapport de test, les deux sont indiscernables. C'est la compétence qui sépare un QA junior d'un QA autonome : ne pas « corriger » un sélecteur qui n'avait rien, ne pas ouvrir un bug chez les devs pour une panne réseau, et surtout ne pas désactiver un test qui avait raison.

## Ce que ça ajoute

Un guide transversal (`TRIAGE-INFRA-VS-TEST.md`) bâti sur **trois incidents réellement survenus** sur la flotte multi-tenant qui sert de terrain à la série :

1. **`502` public alors que `/health` répond `200` dans le conteneur.** La redirection de port côté hôte était morte ; l'application allait parfaitement bien du début à la fin. → apprend à interroger la pile *couche par couche, en partant du bas*.
2. **Une suite à 22 échecs, sans un seul bug.** Tous les messages accusaient un sélecteur ; la capture DOM jointe à l'échec contenait pourtant le bouton « introuvable ». La suite avait été lancée pendant une opération lourde sur la même machine. → apprend à distinguer une **expiration** d'une **assertion**, et à se méfier des échecs massifs et simultanés (une cause commune produit des symptômes communs).
3. **Des téléchargements « bloqués » qui n'étaient que cent fois trop lents.** → apprend à produire un **chiffre** avant d'écrire « c'est bloqué ».

Le guide fournit aussi une **sonde d'infrastructure** en `beforeAll` (ignorer avec un motif lisible plutôt que rougir faussement, sans jamais masquer un vrai échec) et une **checklist de triage** en 7 points.

## Portée

- **Aucun module ajouté** → bloc `CATALOG-STATUS` **inchangé** (jamais régénéré à la main).
- Deux points d'entrée dans le README : l'arborescence, et un encart en tête de « Pièges courants » — les 4 pièges existants relèvent du test lui-même, le guide couvre le cas où ni le test ni le code n'ont de problème.
- Rédigé en FR, cohérent avec le fil rouge « QA Engineer d'une flotte GenAI multi-tenant ». Aucun secret, aucune URL interne, aucun identifiant.

## Gate `check_prose_quantitative_claims` — advisory, non applicable ici (§B.3)

Le contrôle remonte **3 signalements de classe `machine`** (`671 ms`, `240 s`, `30 secondes`) et sort en **`exit=0` (advisory)**.

Ces chiffres relèvent de l'**angle mort documenté par l'outil lui-même** :

> « un décompte **figé dans un récit au passé** est une preuve, et se garde. […] Ne PAS "corriger" un chiffre d'incident au motif que le guard l'a signalé : ce serait supprimer la preuve pour faire taire l'organe. »

Les trois valeurs sont exactement cela : les mesures **relevées pendant des incidents clos**, qui *fondent* le verdict du cas d'étude. Les retirer viderait le guide de sa démonstration — le cas 3 enseigne précisément qu'il faut chiffrer. Aucune n'est un compteur d'artefact vivant : personne n'ouvrira de PR pour les resynchroniser. Elles sont donc **conservées délibérément**.

(`30 secondes` désigne le délai d'attente par défaut de Playwright — une constante de l'outil, pas une mesure de cette machine.)

## Vérifications

- `check_prose_quantitative_claims --diff origin/main..HEAD --class all` → `exit=0` (advisory, arbitré ci-dessus)
- Aucun fichier de test modifié, aucune dépendance touchée
- `CATALOG-STATUS` non modifié

Refs #4433

🤖 Generated with [Claude Code](https://claude.com/claude-code)

