### PR TITLE
fix(ict,#9764): voisinage structurel dans local_sensitivity — le lissage de Laplace rendait le graphe dense

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/sensitivity.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/sensitivity.py
@@ -51,13 +51,50 @@ from typing import Callable, Dict, Sequence
 
 import numpy as np
 
-from .spectral import transition_graph
+from .spectral import observed_adjacency, transition_graph
 
 __all__ = [
     "local_sensitivity",
     "sensitivity_distribution",
     "huang_conjecture_test",
 ]
+
+
+# --------------------------------------------------------------------------- #
+#  Encodage des labels (mutualise)                                              #
+# --------------------------------------------------------------------------- #
+def _encode_labels(states: Sequence, n_symbols: int) -> list:
+    """Encode les labels de ``states`` en entiers ``0..n_symbols-1``.
+
+    Ordre d'attribution : **premiere apparition** dans la trajectoire.
+    L'encodage est donc **compact** -- les ``n_visited`` noeuds
+    effectivement visites occupent exactement les ids ``0..n_visited-1``,
+    et les ids restants correspondent aux noeuds jamais visites. Cette
+    propriete est utilisee par :func:`sensitivity_distribution`.
+
+    On accepte exactement ``n_symbols`` labels distincts ; un depassement
+    (= un 11eme label alors que ``n_symbols=10``) declenche une
+    ``ValueError`` explicite.
+
+    Mutualise entre :func:`local_sensitivity` et
+    :func:`huang_conjecture_test` : cette derniere passait auparavant les
+    labels **bruts** a :func:`ict.spectral.transition_graph`, qui fait un
+    ``int(s)`` -- donc ``ValueError: invalid literal for int()`` sur des
+    labels chaines, alors que :func:`local_sensitivity` les acceptait.
+    L'invariance par label est une propriete du module : elle doit valoir
+    pour les trois fonctions publiques (issue #9764).
+    """
+    label_to_id: Dict[object, int] = {}
+    ids: list = []
+    for s in states:
+        if s not in label_to_id:
+            if len(label_to_id) >= n_symbols:
+                raise ValueError(
+                    f"More unique states (>={n_symbols + 1}) than n_symbols ({n_symbols})"
+                )
+            label_to_id[s] = len(label_to_id)
+        ids.append(label_to_id[s])
+    return ids
 
 
 # --------------------------------------------------------------------------- #
@@ -73,9 +110,30 @@ def local_sensitivity(
     """Sensibilite locale ``s_x(f)`` pour chaque noeud du graphe.
 
     Pour chaque etat ``x`` du vocabulaire, on evalue la fonction d'etat
-    ``f(x)`` et on compte le nombre de **voisins** ``y`` (au sens du
-    graphe de transition) ou ``f(y) != f(x)``. Le voisinage est
-    determine par :func:`ict.spectral.transition_graph` (TPM symmetrisee).
+    ``f(x)`` et on compte le nombre de **voisins** ``y`` ou
+    ``f(y) != f(x)``. Le voisinage est celui de
+    :func:`ict.spectral.observed_adjacency` : ``y`` est voisin de ``x``
+    si et seulement si la transition ``x -> y`` ou ``y -> x`` a ete
+    **effectivement observee** dans la trajectoire.
+
+    .. note:: **Correctif #9764.**
+
+       Le voisinage etait auparavant lu dans
+       :func:`ict.spectral.transition_graph` via ``W[x] > 0``. Or ``W``
+       est **lissee par defaut** (``laplace_smoothing=1e-9``), donc dense
+       hors diagonale : tout noeud y etait declare voisin de tout noeud.
+       Consequence mesuree : avec une fonction d'etat **injective** (p.
+       ex. ``f(x) = x``), la sensibilite valait mecaniquement
+       ``n_symbols - 1`` en **chaque** noeud -- y compris en des noeuds
+       **jamais visites** -- d'ou ``mean == max == n_symbols - 1`` et
+       ``std == 0``. Le proxy mesurait la **taille du vocabulaire**, pas
+       la sensibilite. Le contre-exemple minimal est un cycle sur 3
+       symboles d'un alphabet de 6 : la mesure renvoyait ``[5]*6`` au
+       lieu de ``[2, 2, 2, 0, 0, 0]``.
+
+       Le lissage reste correct pour les usages **spectraux** (Laplacien,
+       gap), ou une ligne nulle casserait la diagonalisation. Il est
+       simplement inadapte a un **comptage de voisins**.
 
     Parametres :
       - ``states`` : sequence d'etats de la trajectoire (memes labels que
@@ -86,34 +144,29 @@ def local_sensitivity(
         booleennes, mais peut etre a valeurs dans ``{0, ..., m-1}`` pour
         des fonctions multi-valentes -- le basculement est alors defini
         comme ``f(y) != f(x)``).
-      - ``laplace_smoothing`` : transmis a la construction du graphe.
+      - ``laplace_smoothing`` : **n'affecte plus le voisinage** (cf. note
+        ci-dessus). Conserve pour la compatibilite de signature, et
+        toujours transmis au graphe **pondere** de
+        :func:`huang_conjecture_test` (calcul de ``deg_proxy``).
 
     Retourne un vecteur numpy de forme ``(n_symbols,)`` ou
-    ``s_x[i] = s_x_i(f)``.
+    ``s_x[i] = s_x_i(f)``. Un noeud jamais visite a une sensibilite de 0
+    (aucun voisin observe), et ``s_x[i] <= `` degre observe de ``i``.
     """
-    # Encodage des labels en entiers 0..n_symbols-1. On accepte
-    # exactement n_symbols labels distincts ; un depassement (= un
-    # 11eme label alors que n_symbols=10) declenche l'erreur.
-    label_to_id: Dict[object, int] = {}
-    ids: list = []
-    for s in states:
-        if s not in label_to_id:
-            if len(label_to_id) >= n_symbols:
-                raise ValueError(
-                    f"More unique states (>={n_symbols + 1}) than n_symbols ({n_symbols})"
-                )
-            label_to_id[s] = len(label_to_id)
-        ids.append(label_to_id[s])
+    ids = _encode_labels(states, n_symbols)
 
-    W = transition_graph(ids, n_symbols, laplace_smoothing=laplace_smoothing)
+    # Voisinage STRUCTUREL : transitions effectivement observees. Ne pas
+    # utiliser transition_graph ici -- son lissage la rend dense et tout
+    # noeud y serait voisin de tout noeud (issue #9764).
+    A = observed_adjacency(ids, n_symbols)
 
     # Valeurs de f sur tous les noeuds du vocabulaire.
     f_vals = np.array([state_function(i) for i in range(n_symbols)], dtype=int)
 
-    # Pour chaque noeud x : compter les voisins y ou W[x, y] > 0 et f(y) != f(x).
+    # Pour chaque noeud x : compter les voisins observes y ou f(y) != f(x).
     sensitivity = np.zeros(n_symbols, dtype=int)
     for x in range(n_symbols):
-        neighbors = np.where(W[x] > 0)[0]
+        neighbors = np.where(A[x])[0]
         f_x = f_vals[x]
         sensitivity[x] = int(np.sum(f_vals[neighbors] != f_x))
     return sensitivity
@@ -137,29 +190,23 @@ def sensitivity_distribution(
     """
     s = local_sensitivity(states, n_symbols, state_function, laplace_smoothing=laplace_smoothing)
 
-    visited = set()
-    for st in states:
-        # Encodage rapide (memes regles que local_sensitivity).
-        # Note : on ne peut pas reutiliser le label_to_id ici sans le
-        # reconstruire, donc on encode separement. Acceptable car
-        # ``states`` est borne par la trajectoire (<= 10^5 tokens
-        # typiquement).
-        visited.add(st)
-
-    visited_ids: list = []
-    label_to_id: Dict[object, int] = {}
-    for st in visited:
-        if st not in label_to_id:
-            label_to_id[st] = len(label_to_id)
-        visited_ids.append(label_to_id[st])
-
-    s_visited = s[visited_ids] if visited_ids else s
+    # Les noeuds visites occupent exactement les ids 0..n_visited-1 :
+    # _encode_labels attribue les ids par ordre de PREMIERE APPARITION,
+    # donc l'encodage est compact et les ids >= n_visited correspondent aux
+    # noeuds jamais visites. Le prefixe suffit, sans reconstruire le mapping.
+    #
+    # La version anterieure calculait la meme chose de facon opaque (elle
+    # iterait sur un `set` pour re-attribuer des ids, ce qui redonne
+    # toujours `range(n_visited)`). Resultat identique -- verifie -- mais
+    # on pouvait raisonnablement le lire comme une erreur d'indexation.
+    n_visited = len(set(states))
+    s_visited = s[:n_visited] if n_visited else s
     return {
         "max": float(np.max(s_visited)) if s_visited.size else 0.0,
         "mean": float(np.mean(s_visited)) if s_visited.size else 0.0,
         "std": float(np.std(s_visited)) if s_visited.size else 0.0,
         "p95": float(np.percentile(s_visited, 95)) if s_visited.size else 0.0,
-        "n_visited": int(len(visited_ids)),
+        "n_visited": int(n_visited),
     }
 
 
@@ -188,9 +235,40 @@ def huang_conjecture_test(
         :func:`local_sensitivity`.
       - ``proxy_degree_fn`` : callable optionnel ``(states, n_symbols)
         -> float`` estimant ``deg_proxy(f)``. Si ``None`` (defaut), on
-        utilise le degre moyen du voisinage ``np.mean(W.sum(axis=1))``
-        comme proxy -- c'est l'operationalisation **la plus
-        conservatrice** (elle borne la sensibilite par le degre local).
+        utilise ``np.mean(W.sum(axis=1))`` sur le graphe **pondere**.
+
+    .. warning:: **Le proxy par defaut est faible, et ce n'est pas un degre.**
+
+       ``W.sum(axis=1)`` est la **masse de probabilite** par ligne de la
+       TPM symmetrisee, pas un nombre de voisins. ``P`` etant
+       stochastique par ligne, cette masse vaut **1.0 par construction**,
+       independamment de la topologie. Mesure sur trois cycles :
+
+       ==========================  ==========  ==================
+       trajectoire                 deg_proxy   degre observe moyen
+       ==========================  ==========  ==================
+       cycle-4 (k=4)               1.000000    2.0
+       cycle-5 (k=5)               1.000000    2.0
+       cycle-3 sur alphabet 6      0.916667    1.0
+       ==========================  ==========  ==================
+
+       ``deg_proxy`` ne bouge pas quand le degre change. Donc
+       ``threshold = sqrt(deg_proxy) ~ 1.0`` quasiment toujours, et le
+       verdict est ``consistent`` des que ``s_max >= 1`` -- c'est-a-dire
+       des que ``f`` n'est pas constante.
+
+       La docstring anterieure decrivait ce proxy comme « le degre moyen
+       du voisinage » et « l'operationalisation la plus conservatrice
+       (elle borne la sensibilite par le degre local) » : les deux
+       affirmations sont fausses. Un degre se lit ``(W > 0).sum(axis=1)``,
+       pas ``W.sum(axis=1)``.
+
+       Ce point n'est **pas corrige ici** : changer ``deg_proxy``
+       changerait les verdicts et releve d'un sujet distinct (une PR = un
+       sujet). Il est documente pour que personne ne lise un verdict
+       ``consistent`` comme une confirmation de la conjecture. Passer un
+       ``proxy_degree_fn`` explicite reste le moyen de tester une vraie
+       borne.
 
     Retourne un dict avec ``s_max``, ``deg_proxy``, ``threshold`` (le
     second membre de l'inegalite), ``ratio`` (``s_max / threshold``),
@@ -203,8 +281,17 @@ def huang_conjecture_test(
     s_max = int(np.max(s))
 
     if proxy_degree_fn is None:
-        # Proxy par defaut : degre moyen du voisinage (= mean degree of W).
-        W = transition_graph(states, n_symbols, laplace_smoothing=laplace_smoothing)
+        # Proxy par defaut : masse de ligne moyenne du graphe pondere.
+        # Ce N'EST PAS un degre (cf. avertissement de la docstring) : la
+        # valeur vaut ~1.0 par construction. Conserve tel quel -- le
+        # changer changerait les verdicts, sujet distinct.
+        # Les labels sont encodes AVANT l'appel : transition_graph fait un
+        # int(s) et plantait sur des labels chaines (issue #9764).
+        W = transition_graph(
+            _encode_labels(states, n_symbols),
+            n_symbols,
+            laplace_smoothing=laplace_smoothing,
+        )
         deg_proxy = float(np.mean(W.sum(axis=1)))
     else:
         deg_proxy = float(proxy_degree_fn(states, n_symbols))

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/spectral.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/spectral.py
@@ -21,7 +21,11 @@ Quatre primitives :
 
 1. :func:`transition_graph` : graphe symetrise depuis la TPM (matrice
    d'adjacence ponderee non-dirigee, ``W = (P + P^T) / 2``) -- le
-   substrat canonique.
+   substrat canonique. **Ponderee et lissee, donc dense** : voir
+   :func:`observed_adjacency` pour le voisinage structurel.
+1bis. :func:`observed_adjacency` : adjacence **booleenne non lissee**
+   (« la transition a-t-elle ete observee ? »). A utiliser des qu'on
+   compte des voisins plutot qu'on pondere des flux (issue #9764).
 2. :func:`signed_adjacency` : matrice de signes (-1/+1) construite
    depuis les flux nets de transition (le "courant" Markovien). C'est
    l'analogue direct de la matrice de signes de Huang 2019 sur
@@ -47,6 +51,7 @@ from .time_arrow import transition_matrix
 
 __all__ = [
     "transition_graph",
+    "observed_adjacency",
     "signed_adjacency",
     "laplacian_spectrum",
     "spectral_gap",
@@ -69,8 +74,30 @@ def transition_graph(
     symmetrisee). Pour chaque paire ``(i, j)``, on moyenne les
     probabilites de transition dans les deux directions : si
     ``P[i, j] > 0`` ou ``P[j, i] > 0``, l'arete est isante avec un
-    poids = moyenne des deux flux directionnels. Les aretes absentes
-    du graphe Markovien restent a 0.
+    poids = moyenne des deux flux directionnels.
+
+    .. warning::
+
+       **``W`` n'est PAS une matrice d'adjacence structurelle.** Des que
+       ``laplace_smoothing > 0`` -- c'est-a-dire **par defaut** --
+       :func:`ict.time_arrow.transition_matrix` ajoute un plancher
+       strictement positif a *chaque* coefficient (c'est precisement son
+       role : donner une distribution uniforme aux etats non observes
+       plutot qu'une ligne nulle). ``W`` est donc **dense hors
+       diagonale**, et un test d'adjacence ``W[i, j] > 0`` renvoie
+       ``True`` pour **toutes** les paires, y compris pour des etats
+       jamais visites par la trajectoire.
+
+       Pour obtenir le voisinage *structurel* (« la transition a-t-elle
+       ete observee ? »), utiliser :func:`observed_adjacency`, qui ne
+       depend d'aucun lissage. Le lissage de ``W`` est fait pour les
+       usages *spectraux* (Laplacien, gap), ou une ligne nulle casserait
+       la diagonalisation -- pas pour compter des voisins.
+
+       Une version anterieure de cette docstring affirmait « les aretes
+       absentes du graphe Markovien restent a 0 » : c'etait faux des que
+       le lissage est actif, et cette fausse premisse a produit un
+       defaut de mesure dans :mod:`ict.sensitivity` (issue #9764).
 
     Pourquoi PAS le minimum des flux nets ``min(pi_i P[i,j], pi_j P[j,i])``
     : sur une chaine asymetrique (ex. cycle unidirectionnel), le flux
@@ -88,7 +115,9 @@ def transition_graph(
       - ``laplace_smoothing`` : transmis a :func:`transition_matrix`.
 
     Retourne une matrice carree ``(n_symbols, n_symbols)`` symmetrique,
-    a diagonale nulle, a coefficients >= 0.
+    a diagonale nulle, a coefficients >= 0 -- et **strictement** positifs
+    hors diagonale des que ``laplace_smoothing > 0`` (cf. avertissement
+    ci-dessus).
     """
     P = transition_matrix(states, n_symbols, laplace_smoothing=laplace_smoothing)
     # Matrice de transition symmetrisee : moyenne des flux directionnels.
@@ -101,6 +130,58 @@ def transition_graph(
     W = (P + P.T) / 2.0
     np.fill_diagonal(W, 0.0)
     return W
+
+
+def observed_adjacency(
+    states: Sequence,
+    n_symbols: int,
+) -> np.ndarray:
+    """Adjacence **structurelle** du graphe de transition : booleenne, non lissee.
+
+    ``A[i, j]`` est ``True`` si et seulement si la transition ``i -> j``
+    **ou** ``j -> i`` a ete **effectivement observee** dans ``states``
+    (paires consecutives). C'est la reponse a « ``j`` est-il un voisin de
+    ``i`` ? », question **structurelle** qui ne doit dependre d'aucune
+    ponderation ni d'aucun lissage.
+
+    Pourquoi cette primitive existe separement de
+    :func:`transition_graph` : ``transition_graph`` est ponderee et
+    **lissee par defaut**, donc dense hors diagonale (cf. son
+    avertissement). Deriver un voisinage d'un ``W[i, j] > 0`` y declare
+    tout noeud voisin de tout noeud -- ce qui transforme silencieusement
+    tout comptage de voisins en comptage de la **taille du vocabulaire**.
+    C'est la cause du defaut de mesure de l'issue #9764.
+
+    Les **boucles sont exclues** (diagonale ``False``), par coherence avec
+    la diagonale nulle de :func:`transition_graph` : un etat n'est pas son
+    propre voisin, et une transition ``i -> i`` (le systeme reste sur
+    place) n'est pas une arete du graphe.
+
+    Un etat **jamais visite** a une ligne entierement ``False`` : degre 0,
+    aucun voisin. C'est le comportement voulu -- contrairement au lissage,
+    qui lui attribue une distribution uniforme sur tout le vocabulaire.
+
+    Parametres :
+      - ``states`` : sequence d'etats **deja encodes** en entiers
+        ``0..n_symbols-1`` (meme convention que
+        :func:`ict.time_arrow.transition_matrix` ; les paires hors bornes
+        sont ignorees silencieusement, comme la-bas).
+      - ``n_symbols`` : taille du vocabulaire ``k``.
+
+    Retourne une matrice ``(n_symbols, n_symbols)`` booleenne, symetrique
+    (``A.T == A``), a diagonale ``False``. Aucune division : ni ``NaN``,
+    ni ``RuntimeWarning``, meme quand aucune transition n'est observee.
+    """
+    states_int = [int(s) for s in states]
+    A = np.zeros((n_symbols, n_symbols), dtype=bool)
+    for s, t in zip(states_int[:-1], states_int[1:]):
+        if s == t:
+            # Boucle : le systeme reste sur place, pas une arete.
+            continue
+        if 0 <= s < n_symbols and 0 <= t < n_symbols:
+            A[s, t] = True
+            A[t, s] = True
+    return A
 
 
 # --------------------------------------------------------------------------- #

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_sensitivity.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_sensitivity.py
@@ -19,7 +19,7 @@ import numpy as np
 import pytest
 
 from ict import sensitivity as SE
-from ict.spectral import transition_graph
+from ict.spectral import observed_adjacency, transition_graph
 
 
 # --------------------------------------------------------------------------- #
@@ -183,11 +183,22 @@ class TestLocalSensitivityEdgeCases:
         assert np.array_equal(s, np.array([2, 2, 2, 2]))
 
     def test_point_function_localizes_to_k(self):
-        # f(x)=1 ssi x=k(=0) : s_0 = n-1 (bascule vers tous les autres),
-        # chaque autre bascule uniquement vers k => s = 1.
+        # f(x)=1 ssi x=k(=0). Sur le 4-cycle 0-1-2-3-0, le voisinage OBSERVE est
+        # {1,3} pour 0, {0,2} pour 1, {1,3} pour 2, {0,2} pour 3. D'ou :
+        #   s_0 = 2 (ses deux voisins 1 et 3 basculent),
+        #   s_1 = s_3 = 1 (seul le voisin 0 bascule),
+        #   s_2 = 0 (2 n'est PAS voisin de 0 : aucun basculement).
+        #
+        # CORRECTION #9764 -- cette assertion valait auparavant
+        # ``s[0] == n-1`` et ``s[2] == 1``, ce qui n'etait vrai que sous le
+        # defaut : local_sensitivity lisait le voisinage dans le graphe LISSE
+        # (laplace_smoothing > 0 rend toutes les aretes strictement positives),
+        # donc tout noeud etait voisin de tout noeud et s_x valait k-1 par
+        # construction. Le test encodait donc le bug : il rendait la saturation
+        # obligatoire au lieu de la detecter. s_2 == 0 est la valeur
+        # discriminante -- elle est impossible sur un graphe dense.
         s = SE.local_sensitivity(_CYCLE4, _N_CYCLE, _point_k(0))
-        assert s[0] == _N_CYCLE - 1
-        assert s[1] == 1 and s[2] == 1 and s[3] == 1
+        assert np.array_equal(s, np.array([2, 1, 0, 1]))
 
     def test_raises_on_too_many_unique_labels(self):
         # Plus de labels distincts que n_symbols => ValueError (garde-fou).
@@ -233,3 +244,74 @@ class TestHuangConjectureEdgeCases:
         )
         assert out["deg_proxy"] == fixed
         assert out["threshold"] == pytest.approx(math.sqrt(fixed))
+
+
+# --------------------------------------------------------------------------- #
+#  Non-regression #9764 : saturation mecanique de la sensibilite               #
+# --------------------------------------------------------------------------- #
+class TestSaturationRegression9764:
+    """Le voisinage doit etre STRUCTUREL (transitions observees), pas lisse.
+
+    Defaut d'origine : ``local_sensitivity`` definissait les voisins par
+    ``transition_graph(...)[x] > 0``. Or ``transition_graph`` applique un
+    lissage de Laplace (``1e-9`` par defaut) qui rend *toutes* les entrees
+    strictement positives -- le graphe est dense hors diagonale. Tout noeud
+    etait donc voisin de tout noeud, et avec une fonction d'etat injective la
+    sensibilite valait ``k-1`` partout : ``mean == max == k-1``, ``std == 0``.
+    Le proxy mesurait la taille de l'alphabet, pas la sensibilite.
+    """
+
+    def test_never_visited_states_have_zero_sensitivity(self):
+        # CAS DECISIF. Trajectoire cyclant sur {0,1,2} d'un alphabet de 6 :
+        # 3, 4 et 5 ne sont JAMAIS visites, donc de degre 0 -> sensibilite 0.
+        # Avant le correctif : [5,5,5,5,5,5], soit une sensibilite maximale
+        # attribuee a trois etats que le systeme n'a jamais occupes.
+        cycle = [i % 3 for i in range(120)]
+        s = SE.local_sensitivity(cycle, 6, lambda x: x)
+        assert np.array_equal(s, np.array([2, 2, 2, 0, 0, 0]))
+
+    def test_sensitivity_is_not_mechanically_k_minus_one(self):
+        # Une trajectoire quelconque ne doit pas produire la saturation
+        # ``mean == max == k-1`` avec ``std == 0`` par simple construction.
+        rng = np.random.default_rng(42)
+        for k in (4, 6):
+            traj = sorted(rng.integers(0, k, size=120).tolist(), reverse=True)
+            dist = SE.sensitivity_distribution(traj, k, lambda x: x)
+            assert dist["max"] < k - 1, f"saturation persistante pour k={k}"
+            assert dist["std"] > 0.0, f"distribution degeneree pour k={k}"
+
+    def test_heterogeneous_degrees_give_nonzero_std(self):
+        # Chaine lineaire 0-1-2-3-4 : les extremites ont 1 voisin, l'interieur
+        # en a 2. Avec f=identite la sensibilite suit le degre -> [1,2,2,2,1].
+        line = [0, 1, 2, 3, 4, 3, 2, 1, 0] * 6
+        s = SE.local_sensitivity(line, 5, lambda x: x)
+        assert np.array_equal(s, np.array([1, 2, 2, 2, 1]))
+        assert SE.sensitivity_distribution(line, 5, lambda x: x)["std"] > 0.0
+
+    def test_adjacency_is_independent_of_smoothing(self):
+        # Le voisinage ne doit plus dependre du lissage : c'est precisement le
+        # couplage qui causait le defaut.
+        cycle = [i % 3 for i in range(60)]
+        base = SE.local_sensitivity(cycle, 6, lambda x: x)
+        for smoothing in (0.0, 1e-9, 1e-3, 1.0):
+            s = SE.local_sensitivity(
+                cycle, 6, lambda x: x, laplace_smoothing=smoothing
+            )
+            assert np.array_equal(s, base)
+
+    def test_observed_adjacency_excludes_self_loops(self):
+        # Une repetition (s -> s) n'est pas une arete : coherent avec le
+        # ``fill_diagonal(W, 0.0)`` de ``transition_graph``.
+        A = observed_adjacency([0, 0, 0, 1, 1, 0], 2)
+        assert not A[0, 0] and not A[1, 1]
+        assert A[0, 1] and A[1, 0]
+
+    def test_huang_accepts_string_labels(self):
+        # Regression : ``huang_conjecture_test`` passait les labels BRUTS a
+        # ``transition_graph``, qui fait ``int(s)`` -> ValueError sur des
+        # chaines, alors que ``local_sensitivity`` les acceptait et que
+        # l'invariance par label est une propriete testee du module.
+        out_str = SE.huang_conjecture_test(["a", "b", "c"] * 8, 3, lambda x: x)
+        out_int = SE.huang_conjecture_test([0, 1, 2] * 8, 3, lambda x: x)
+        assert out_str["verdict"] == out_int["verdict"]
+        assert out_str["s_max"] == out_int["s_max"]


### PR DESCRIPTION
`Grain: DEEP/code+test — lane myia-po-2025:CoursIA — prev: MED/notebook-python #9744`

## Ce que fait cette PR

Repare le defaut mesure derriere #9764 : `local_sensitivity` lisait le voisinage
dans un graphe **dense**, ce qui rendait la sensibilite mecaniquement egale a
`k-1` partout.

> **Collision assumee avec #9766 — arbitrage coordinateur demande.** #9766
> (po-2023, lane `CoursIA-2`, poussee 22:59Z, avant mon `[CLAIMED]` 00:52Z)
> traite la meme issue et **diagnostique** la saturation. Cette PR la **repare**.
> Detail du recouvrement et de l'ordre de merge en fin de body. Je n'ai ni
> ferme ni bloque #9766 : ce n'est pas la decision d'un worker.

## Mecanisme (G.1, mesure firsthand)

`transition_graph` applique un lissage de Laplace (`1e-9` par defaut) qui pose un
plancher **strictement positif sur toutes les entrees** de la matrice de
transition. `local_sensitivity` definissait les voisins par `np.where(W[x] > 0)`,
donc **tout noeud etait voisin de tout noeud**. Avec une fonction d'etat
injective (`f(x) = x`, le cablage anti-saturation d'ICT-15c), la sensibilite
valait `k-1` partout : `mean == max == k-1`, `std == 0`. Le proxy mesurait la
**taille de l'alphabet**, pas la sensibilite.

La docstring de `transition_graph` affirmait « les aretes absentes du graphe
Markovien restent a 0 ». C'etait **faux des que le lissage est > 0**, donc par
defaut. C'est cette premisse fausse que `local_sensitivity` a suivie.

### Mesure qui separe les deux causes candidates

Un **6-cycle** visite les 6 etats et les 6 aretes — la couverture de trajectoire
est donc complete au sens de #9766 — et pourtant le degre structurel est 2 :

| graphe | degres mesures |
|---|---|
| `laplace_smoothing=1e-9` (defaut) | `[5, 5, 5, 5, 5, 5]` |
| `laplace_smoothing=0.0` | `[2, 2, 2, 2, 2, 2]` |

Coefficient minimum hors-diagonale au defaut : exactement `5.000e-11`, le
plancher de lissage. **La densite vient du plancher, pas de la couverture.**

### Contre-exemple minimal

Cycle sur `{0,1,2}` d'un alphabet de 6, `f(x) = x` :

| | sensibilite |
|---|---|
| avant | `[5, 5, 5, 5, 5, 5]` |
| apres | `[2, 2, 2, 0, 0, 0]` |

Avant le correctif, les etats 3, 4 et 5 — **jamais visites** — recevaient la
sensibilite **maximale**. Aucun choix de `f` ne corrige cela : c'est un defaut,
pas un domaine de validite.

## Changements

1. **`spectral.py` — nouvelle primitive `observed_adjacency(states, n_symbols)`.**
   Adjacence booleenne des transitions effectivement observees. **Aucune
   division** : ni `NaN`, ni `RuntimeWarning`. C'est pourquoi
   `laplace_smoothing=0.0` n'etait pas la reparation — les lignes des etats non
   visites somment a zero et `P / row_sums` produit `NaN` avec
   `RuntimeWarning: invalid value encountered in divide` (`time_arrow.py:89`).
   Boucles `s -> s` exclues, coherent avec le `fill_diagonal(W, 0.0)` existant.

2. **`spectral.py` — docstring de `transition_graph` corrigee.** L'affirmation
   fausse est remplacee par un avertissement : `W` n'est pas une matrice
   d'adjacence structurelle, elle est dense hors diagonale des que le lissage
   est > 0. Le lissage reste legitime pour les usages **spectraux** (laplacien,
   gap), ou une ligne nulle casse la diagonalisation.

3. **`sensitivity.py` — `local_sensitivity` lit `observed_adjacency`.**
   `laplace_smoothing` n'affecte plus le voisinage (parametre conserve pour la
   compatibilite de signature).

4. **`sensitivity.py` — plantage sur labels chaine corrige.**
   `huang_conjecture_test` passait les labels **bruts** a `transition_graph`, qui
   fait `int(s)` : `ValueError: invalid literal for int() with base 10: 'a'`.
   `local_sensitivity` acceptait pourtant ces labels, et l'invariance par label
   est une propriete **testee** du module. Corrige en extrayant `_encode_labels`.

## Tests

| suite | avant | apres |
|---|---|---|
| `tests/test_sensitivity.py` | 19 | **25 passed** (+6 non-regression) |
| `ict/tests/` (complet) | 212 passed | **212 passed**, identique |
| `tests/` (complet) | 918 passed / 866s | **924 passed** / 549s, zero echec |

Les deux repertoires de tests ne peuvent pas etre collectes ensemble
(`import file mismatch` sur le basename `test_sensitivity`, pas d'`__init__.py`) :
**preexistant**, hors scope, lances separement.

### Un test existant encodait le bug

`test_point_function_localizes_to_k` affirmait `s[0] == k-1` et `s[2] == 1`. Sur
le 4-cycle `0-1-2-3-0` avec `f = point(0)`, le voisinage de 2 est `{1,3}` : aucun
basculement, donc `s[2] == 0`. Les valeurs attendues n'etaient vraies que **sous
le defaut** — le test rendait la saturation obligatoire au lieu de la detecter.
Corrige en `[2,1,0,1]`, valeur exacte verifiee empiriquement, avec la
justification ecrite dans le test. C'est la seule assertion modifiee.

## Retractation d'un constat que j'ai poste sur le dashboard

J'ai annonce un **second defaut** dans `sensitivity_distribution` (mauvaise
selection des noeuds visites par iteration sur un `set`). **C'est faux.**
`_encode_labels` attribue les identifiants par ordre de premiere apparition,
donc l'encodage est **compact** : les noeuds visites occupent exactement
`0..n_visited-1` et la selection etait correcte. Le code etait juste par
accident plutot que par construction ; je l'ai rendu explicite sans changer son
comportement (verifie identique). Aucun second defaut.

## Constat lateral **non corrige** (delibere)

`deg_proxy` est documente comme « le degre moyen du voisinage » et comme
« l'operationalisation la plus conservatrice (elle borne la sensibilite par le
degre local) ». **Les deux affirmations sont fausses** : `W.sum(axis=1)` est la
**masse de probabilite** d'une ligne, ~1.0 par construction.

| trajectoire | `deg_proxy` | degre observe moyen |
|---|---|---|
| cycle-4 | 1.000000 | 2.0 |
| cycle-5 | 1.000000 | 2.0 |
| cycle-3 sur alphabet 6 | 0.916667 | 1.0 |

Donc `threshold = sqrt(deg_proxy) ~ 1.0` toujours, et le verdict est
`consistent` des que `f` est non constante. Documente honnetement dans la
docstring, **non corrige ici** : changer le proxy changerait les verdicts, c'est
un autre sujet. Issue dediee ouverte : **#9771**.

## Recouvrement avec #9766 et ordre de merge

**Ce qui se recoupe** : le constat que la saturation est reelle et le rejet de H1
(elle persiste sur marche aleatoire). #9766 est arrivee la premiere sur ce point.

**Ce que cette PR apporte en propre** : la cause exacte (le plancher de lissage,
pas la couverture de trajectoire), la reparation, la primitive
`observed_adjacency`, le plantage sur labels chaine, et 6 tests de non-regression
dont le cas jamais-visite.

**Ou nos conclusions divergent.** #9766 conclut a une « degenerescence du
cablage » — graphe « effectivement (k-1)-regulier » parce que la trajectoire le
couvre — et recommande d'employer une `f` non injective. La mesure du 6-cycle
ci-dessus refute ce mecanisme : la couverture est complete et le degre reste 2.
Et aucun choix de `f` ne rend correcte une sensibilite de 5 sur un etat jamais
visite. Le defaut est **RECOVERABLE-LOCAL**, pas un domaine de validite a
documenter.

**Compatibilite verifiee, pas supposee** : les **3 tests** de
`test_sensitivity_non_regression.py` de #9766 **passent** contre ce code corrige
(j'ai d'abord cru le troisieme casse en ne testant que sa branche `std > 0`, en
oubliant son `OU max < 5.0` — verifie : 5/5 non-trivial). Les deux PR sont donc
compatibles au niveau comportemental.

**Conflit textuel** : les deux editent la docstring de `ict/sensitivity.py`. Un
rebase manuel sera necessaire pour la seconde mergee. Si #9766 passe en premier,
je rebase et j'ajuste sa formulation « domaine de validite » pour refleter la
reparation. **L'ordre de merge est la decision du coordinateur, pas la mienne.**

Closes #9764
See #9771
See #9766
See #7290
See #4588

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
