### PR TITLE
feat(coord,#9774): lane-claim guard -- check before edit, server UTC stamps

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Lane-claim guard -- the "one command before you edit" of issue #9774.
+
+#9774 (mandat user 2026-08-06) diagnosed why two lanes delivered #9764 twice:
+the `[CLAIMED]` signal lived on the per-lane dashboard, which (a) does not cross
+lanes, (b) is garbage-collected by auto-condensation, and (c) mixed local and
+UTC timestamps -- a stamp `2026-08-07T00:52Z` that was actually 00:52 CEST
+inverted the cross-lane claim order and nearly got the coordinator to entrench
+the wrong priority. None of it was a discipline failure: both workers passed
+their `gh pr list` guard, which only sees PUSHED work. The collision is born in
+the "I decided to work on X" -> "I pushed" window, where the only signal is the
+claim, and the claim was in a silo.
+
+This tool operationalises the worker-side of the fix (the rule change itself
+needs user sign-off; this is the mechanism that the rule will call):
+
+  - **check** (default): before editing a file for a grain on issue #N, run
+        check_lane_claim.py N --lane myia-po-2024:CoursIA
+    It reads the issue comments, reconstructs the claim state per lane, and
+    exits 1 if ANOTHER lane holds an active (unreleased) claim -- do not start,
+    pick elsewhere. Exit 0 means the way is clear (optionally: your own lane
+    already claimed, you are resuming).
+
+  - **--claim "<intention>"**: post a `[CLAIMED] lane <machine:workspace>`
+    comment. GitHub server-stamps it UTC -- the body carries NO timestamp, so
+    Defaut 2 (local time wearing a `Z` suffix) is impossible by construction.
+
+  - **--release [--note "..."]**: post a `[RELEASED]` comment, closing the
+    active claim of this lane on the issue.
+
+The authoritative timestamp is the comment's server `createdAt`, NEVER a stamp
+written in the body. That is the whole of the Defaut-2 fix.
+
+The lane token is read by `grain_tag.extract_lane` -- the SAME reader the Grain
+tag and the G-VAR-2 organ use (#9485, single reader), so a claim comment and a
+PR body never disagree on what a lane is.
+
+Limitation (documented): claim state is comment-based. A merged PR that
+references the issue is not auto-detected as a release -- the lane should
+`--release` (or post `[DONE]`) when its PR lands. Detecting merges is a future
+flag; the comment contract is the MVP.
+
+Exit codes: 0 ok / 1 blocked (other lane holds active claim) / 2 io-or-gh error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Shared lane reader (#9485) -- see scripts/grain_tag.py.
+from grain_tag import extract_lane
+
+# --- markers -----------------------------------------------------------------
+
+# A comment is a claim EVENT only if it carries one of these bracketed markers.
+# `[DONE]`/`[RELEASED]`/`[CANCELLED]`/`[ABANDONED]` close a claim; `[CLAIMED]`
+# opens one. Read on ISSUE comments (the claim registry per #9774), not on the
+# dashboard. Case-insensitive, tolerates inner spaces.
+_MARKER_RE = re.compile(
+    r"\[\s*(CLAIMED|RELEASED|CANCELLED|ABANDONED|DONE)\s*\]", re.IGNORECASE
+)
+_OPEN = {"CLAIMED"}
+_CLOSE = {"RELEASED", "CANCELLED", "ABANDONED", "DONE"}
+
+
+class ClaimEvent(dict):
+    """Typed-ish view over a parsed claim event.
+
+    Keys: lane (str|None), action ("open"|"close"), marker (str upper),
+    created_at (str ISO, server UTC), author (str|None), url (str|None).
+    `created_at` comes from the comment's server field, never from the body.
+    """
+
+    @property
+    def lane(self) -> str | None:
+        return self.get("lane")
+
+    @property
+    def is_open(self) -> bool:
+        return self.get("action") == "open"
+
+    @property
+    def created_at(self) -> str | None:
+        return self.get("created_at")
+
+    @property
+    def marker(self) -> str | None:
+        return self.get("marker")
+
+    @property
+    def author(self) -> str | None:
+        return self.get("author")
+
+    @property
+    def url(self) -> str | None:
+        return self.get("url")
+
+
+def parse_claim_event(comment: dict) -> ClaimEvent | None:
+    """Classify one issue comment into a claim event, or None if not a marker.
+
+    The decisive marker is the LAST bracketed one in the body (final intent).
+    The lane is read by `extract_lane`; None when the body carries no lane token
+    (surfaced as "unattributed", never guessed). The timestamp is the comment's
+    server `createdAt` -- the Defaut-2 fix: body stamps are not trusted.
+    """
+    body = comment.get("body") or ""
+    marks = _MARKER_RE.findall(body)
+    if not marks:
+        return None
+    marker = marks[-1].upper()  # last marker = final intent in that comment
+    action = "open" if marker in _OPEN else "close"
+    author = (comment.get("author") or {}).get("login")
+    return ClaimEvent(
+        lane=extract_lane(body),
+        action=action,
+        marker=marker,
+        created_at=comment.get("createdAt"),
+        author=author,
+        url=comment.get("url"),
+    )
+
+
+def compute_active_claims(events: list[ClaimEvent]) -> tuple[dict, list[ClaimEvent]]:
+    """Reduce a chronologically-ordered event list to active claims per lane.
+
+    Returns `(active_by_lane, unattributed)`:
+      - `active_by_lane`: {lane: ClaimEvent} for lanes whose LATEST event is an
+        open. Computed by walking events in order (caller sorts); later events
+        overwrite earlier ones, and a close removes the lane.
+      - `unattributed`: events whose body carried a marker but no lane token --
+        the tool surfaces them for manual verification, it does not guess.
+    """
+    state: dict[str, ClaimEvent] = {}
+    unattributed: list[ClaimEvent] = []
+    for ev in events:
+        if ev.lane is None:
+            unattributed.append(ev)
+            continue
+        if ev.is_open:
+            state[ev.lane] = ev
+        else:
+            state.pop(ev.lane, None)
+    return state, unattributed
+
+
+# --- gh plumbing -------------------------------------------------------------
+
+def _gh_issue_comments(issue: str) -> dict:
+    """Fetch issue metadata + comments as JSON via `gh`. Raises on failure."""
+    proc = subprocess.run(
+        [
+            "gh", "issue", "view", str(issue),
+            "--json", "number,title,comments",
+        ],
+        capture_output=True, text=True, shell=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh issue view {issue} failed (exit {proc.returncode}): "
+            f"{proc.stderr.strip()}"
+        )
+    return json.loads(proc.stdout)
+
+
+def _sort_events(payload: dict) -> list[ClaimEvent]:
+    """Parse + chronologically sort claim events from an `gh issue view` payload."""
+    events = [
+        ev for c in payload.get("comments", [])
+        if (ev := parse_claim_event(c)) is not None
+    ]
+    # Server createdAt, ISO 8601 UTC -> lexicographic order == chronological.
+    events.sort(key=lambda e: e.created_at or "")
+    return events
+
+
+def _post_comment(issue: str, body: str) -> None:
+    """Post an issue comment via `gh issue comment --body-file`.
+
+    A body file (not --body) avoids shell-escaping the marker / em-dash / quotes
+    and keeps the posted text byte-exact. Written under the OS temp dir, not the
+    worktree, so it never leaks into a commit (cf L677-L4 body-file discipline).
+    """
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".md", delete=False, encoding="utf-8"
+    ) as fh:
+        fh.write(body)
+        path = fh.name
+    proc = subprocess.run(
+        ["gh", "issue", "comment", str(issue), "--body-file", path],
+        capture_output=True, text=True, shell=False,
+    )
+    Path(path).unlink(missing_ok=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh issue comment {issue} failed (exit {proc.returncode}): "
+            f"{proc.stderr.strip()}"
+        )
+
+
+# --- formatted output --------------------------------------------------------
+
+_CLAIM_BODY_TMPL = (
+    "[CLAIMED] lane {lane} -- {intention}\n\n"
+    "(check_lane_claim #9774 -- server-stamped UTC; body timestamps are NOT "
+    "authoritative. Release with `[RELEASED]` when your PR lands.)\n"
+)
+_RELEASE_BODY_TMPL = (
+    "[RELEASED] lane {lane} -- {note}\n"
+)
+
+
+def _fmt_utc(iso: str | None) -> str:
+    return (iso or "?").replace("T", " ").replace("Z", " UTC")
+
+
+# --- modes -------------------------------------------------------------------
+
+def _run_check(payload: dict, my_lane: str) -> int:
+    events = _sort_events(payload)
+    active, unattributed = compute_active_claims(events)
+    others = {ln: ev for ln, ev in active.items() if ln != my_lane}
+    mine = active.get(my_lane)
+
+    summary = {
+        "issue": payload.get("number"),
+        "title": payload.get("title"),
+        "my_lane": my_lane,
+        "my_active_claim": bool(mine),
+        "blocking_lanes": sorted(others),
+        "active_claims": {
+            ln: {
+                "claimed_at": ev.created_at,
+                "by": ev.author,
+                "marker": ev.marker,
+                "url": ev.url,
+            }
+            for ln, ev in sorted(active.items())
+        },
+        "unattributed_markers": len(unattributed),
+        "blocked": bool(others),
+    }
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+    # Human verdict after the JSON.
+    if others:
+        who = ", ".join(
+            f"{ln} (@{_fmt_active(ev)})" for ln, ev in sorted(others.items())
+        )
+        print(
+            f"\nBLOCKED: another lane holds an active claim on "
+            f"#{payload.get('number')}: {who}.\n"
+            f"Do not start -- pick another grain, or wait for release.",
+            file=sys.stderr,
+        )
+        return 1
+    note = " (resuming your own active claim)" if mine else ""
+    print(f"\nCLEAR: no other lane claims #{payload.get('number')}{note}.")
+    return 0
+
+
+def _fmt_active(ev: ClaimEvent) -> str:
+    return f"{ev.author or '?'}, {_fmt_utc(ev.created_at)}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description=(
+            "Lane-claim guard (#9774): check/post [CLAIMED] on an issue before "
+            "editing. Defaut-2-safe: server UTC timestamps only."
+        )
+    )
+    p.add_argument("issue", help="issue number (or URL)")
+    p.add_argument("--lane", required=True,
+                   help="your lane, e.g. myia-po-2024:CoursIA")
+    p.add_argument("--from-json", metavar="FILE",
+                   help="read `gh issue view` JSON from FILE (offline/test mode)")
+    act = p.add_mutually_exclusive_group()
+    act.add_argument("--claim", metavar="INTENTION",
+                     help="post a [CLAIMED] comment for your lane")
+    act.add_argument("--release", nargs="?", const="", default=None,
+                     metavar="NOTE", help="post a [RELEASED] comment")
+    args = p.parse_args(argv)
+
+    # Posting modes: short-circuit before any read.
+    if args.claim is not None:
+        body = _CLAIM_BODY_TMPL.format(lane=args.lane, intention=args.claim)
+        try:
+            _post_comment(args.issue, body)
+        except RuntimeError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        print(f"posted [CLAIMED] lane {args.lane} on #{args.issue}")
+        return 0
+    if args.release is not None:
+        note = args.release or "released"
+        body = _RELEASE_BODY_TMPL.format(lane=args.lane, note=note)
+        try:
+            _post_comment(args.issue, body)
+        except RuntimeError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        print(f"posted [RELEASED] lane {args.lane} on #{args.issue}")
+        return 0
+
+    # Check mode.
+    try:
+        if args.from_json:
+            payload = json.loads(Path(args.from_json).read_text(encoding="utf-8"))
+        else:
+            payload = _gh_issue_comments(args.issue)
+    except (RuntimeError, json.JSONDecodeError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return _run_check(payload, args.lane)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -90,6 +90,26 @@ def parse_grain_tag(body: str | None) -> dict | None:
     }
 
 
+def extract_lane(body: str | None) -> str | None:
+    """Extract the `<machine>:<workspace>` lane token from any text.
+
+    Same reader as `parse_grain_tag` (the single lane extractor, #9485): shared
+    by the Grain tag, the G-VAR-2 organ, and -- via `check_lane_claim` (#9774) --
+    by the lane-claim guard. A `[CLAIMED] lane myia-po-2024:CoursIA -- ...`
+    comment is not a Grain tag (it carries no `Grain TIER/GENRE`), so it cannot
+    go through `parse_grain_tag`; this wrapper reuses the exact same compiled
+    `_LANE_RE` so the two contexts never drift on what a lane token is.
+
+    Returns the `machine:workspace` string, or None when the body carries no
+    `lane <machine:workspace>` token.
+    """
+    if not body:
+        return None
+    flat = body.translate(_NOISE)
+    m = _LANE_RE.search(flat)
+    return m.group(1) if m else None
+
+
 # --- CLI (guard consumer) ---------------------------------------------------
 
 # The §1 enumeration is the guard's business (which labels to pose), not the

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Unit tests for check_lane_claim.py -- the lane-claim guard of #9774.
+
+Pins the claim state-machine and, crucially, the Defaut-2 fix: the
+authoritative timestamp is the comment's server `createdAt`, NEVER a stamp
+written in the body. The #9764 collision hinged on a body stamp
+`2026-08-07T00:52Z` that was 00:52 CEST (i.e. 22:52 UTC) -- wearing a `Z` it
+read as two hours LATER than it was, which inverted the cross-lane claim order.
+These tests replay that exact trap and assert the tool is not fooled.
+
+Run: python -m pytest scripts/tests/test_check_lane_claim.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_lane_claim as clc  # noqa: E402
+import grain_tag  # noqa: E402
+
+
+# --- helpers -----------------------------------------------------------------
+
+def comment(body, created_at, author="jsboige", url=None):
+    return {
+        "body": body,
+        "createdAt": created_at,
+        "author": {"login": author},
+        "url": url,
+    }
+
+
+def payload(*comments, number=9764, title="t"):
+    return {"number": number, "title": title, "comments": list(comments)}
+
+
+# --- extract_lane (grain_tag, now reused by the guard) -----------------------
+
+def test_extract_lane_claim_form():
+    # The #9774 issue-comment form carries the `lane` keyword.
+    assert grain_tag.extract_lane(
+        "[CLAIMED] lane myia-po-2024:CoursIA -- build the guard"
+    ) == "myia-po-2024:CoursIA"
+
+
+def test_extract_lane_none_when_no_lane_keyword():
+    # Legacy dashboard form (no `lane` keyword) is out of scope -- the tool
+    # surfaces it as an unattributed marker rather than guessing.
+    assert grain_tag.extract_lane(
+        "[CLAIMED] #9764 - myia-po-2025:CoursIA 2026-08-07T00:52Z"
+    ) is None
+    assert grain_tag.extract_lane("nothing here") is None
+
+
+# --- parse_claim_event -------------------------------------------------------
+
+def test_parse_open_claim():
+    ev = clc.parse_claim_event(comment(
+        "[CLAIMED] lane myia-po-2024:CoursIA -- build the guard",
+        "2026-08-06T22:43:31Z", author="jsboige",
+    ))
+    assert ev is not None
+    assert ev.is_open is True
+    assert ev.lane == "myia-po-2024:CoursIA"
+    assert ev.marker == "CLAIMED"
+    assert ev.created_at == "2026-08-06T22:43:31Z"
+    assert ev["author"] == "jsboige"
+
+
+def test_parse_close_markers():
+    for marker in ("RELEASED", "DONE", "CANCELLED", "ABANDONED"):
+        ev = clc.parse_claim_event(comment(
+            f"[{marker}] lane myia-po-2024:CoursIA -- done",
+            "2026-08-06T23:00:00Z",
+        ))
+        assert ev is not None
+        assert ev.is_open is False
+        assert ev.marker == marker
+
+
+def test_parse_non_marker_is_none():
+    assert clc.parse_claim_event(comment(
+        "just a status update, no bracket marker", "2026-08-06T22:00:00Z"
+    )) is None
+
+
+def test_parse_last_marker_wins():
+    # A comment that both opens and closes: the FINAL intent wins (close).
+    ev = clc.parse_claim_event(comment(
+        "[CLAIMED] lane X:CoursIA -- oops\n[DONE] lane X:CoursIA",
+        "2026-08-06T22:00:00Z",
+    ))
+    assert ev is not None and ev.is_open is False
+
+
+def test_parse_unattributed_marker():
+    # Marker present but no `lane` keyword -> lane None (surfaced, not guessed).
+    ev = clc.parse_claim_event(comment(
+        "[CLAIMED] #9764 some work", "2026-08-06T22:00:00Z"
+    ))
+    assert ev is not None
+    assert ev.lane is None
+
+
+# --- compute_active_claims (state machine) -----------------------------------
+
+def test_open_then_close_inactive():
+    events = [
+        clc.parse_claim_event(comment(
+            "[CLAIMED] lane A:CoursIA -- x", "2026-08-06T22:00:00Z")),
+        clc.parse_claim_event(comment(
+            "[RELEASED] lane A:CoursIA -- done", "2026-08-06T22:30:00Z")),
+    ]
+    active, unattrib = clc.compute_active_claims(events)
+    assert active == {}
+    assert unattrib == []
+
+
+def test_two_lanes_both_active():
+    events = [
+        clc.parse_claim_event(comment(
+            "[CLAIMED] lane A:CoursIA -- x", "2026-08-06T22:00:00Z")),
+        clc.parse_claim_event(comment(
+            "[CLAIMED] lane B:CoursIA-2 -- y", "2026-08-06T22:10:00Z")),
+    ]
+    active, _ = clc.compute_active_claims(events)
+    assert set(active) == {"A:CoursIA", "B:CoursIA-2"}
+
+
+def test_close_one_keeps_other():
+    events = [
+        clc.parse_claim_event(comment(
+            "[CLAIMED] lane A:CoursIA -- x", "2026-08-06T22:00:00Z")),
+        clc.parse_claim_event(comment(
+            "[CLAIMED] lane B:CoursIA-2 -- y", "2026-08-06T22:10:00Z")),
+        clc.parse_claim_event(comment(
+            "[RELEASED] lane A:CoursIA -- done", "2026-08-06T22:30:00Z")),
+    ]
+    active, _ = clc.compute_active_claims(events)
+    assert set(active) == {"B:CoursIA-2"}
+
+
+def test_unattributed_collected_not_active():
+    events = [
+        clc.parse_claim_event(comment(
+            "[CLAIMED] #9764 orphan", "2026-08-06T22:00:00Z")),
+    ]
+    active, unattrib = clc.compute_active_claims(events)
+    assert active == {}
+    assert len(unattrib) == 1
+
+
+# --- Defaut-2 regression: server createdAt orders, body stamps do not --------
+
+def test_defaut2_body_stamp_does_not_invert_order():
+    """The #9764 trap. po-2025's body bore `00:52Z` (really 00:52 CEST = 22:52
+    UTC). Naive body-stamp ordering would place it AFTER po-2023's 22:57Z claim.
+    The server `createdAt` (22:43Z) is EARLIER. The tool MUST order by the
+    server field, so po-2025 is correctly the first claimant."""
+    p = payload(
+        comment(
+            "[CLAIMED] lane myia-po-2025:CoursIA -- fix 2026-08-07T00:52Z",
+            "2026-08-06T22:43:31Z",  # SERVER: the real instant (22:43 UTC)
+            author="jsboige",
+        ),
+        comment(
+            "[CLAIMED] lane myia-po-2023:CoursIA-2 -- diag",
+            "2026-08-06T22:57:37Z",  # SERVER: later
+            author="jsboige",
+        ),
+    )
+    events = clc._sort_events(p)
+    assert [e.lane for e in events] == [
+        "myia-po-2025:CoursIA",      # earliest by server createdAt
+        "myia-po-2023:CoursIA-2",
+    ]
+    # The misleading body stamp did not leak into the event's timestamp.
+    assert events[0].created_at == "2026-08-06T22:43:31Z"
+
+
+# --- _run_check exit codes ---------------------------------------------------
+
+def test_check_clear_when_only_my_lane(capsys):
+    p = payload(comment(
+        "[CLAIMED] lane myia-po-2024:CoursIA -- build the guard",
+        "2026-08-06T22:43:31Z",
+    ))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "CLEAR" in out
+
+
+def test_check_blocked_when_other_lane_active(capsys):
+    p = payload(comment(
+        "[CLAIMED] lane myia-po-2025:CoursIA -- working here",
+        "2026-08-06T22:43:31Z",
+    ))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "BLOCKED" in captured.err
+    assert "myia-po-2025:CoursIA" in captured.out
+
+
+def test_check_clear_after_other_lane_releases(capsys):
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA -- working here",
+                "2026-08-06T22:43:31Z"),
+        comment("[RELEASED] lane myia-po-2025:CoursIA -- landed",
+                "2026-08-06T23:30:00Z"),
+    )
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    assert rc == 0
+
+
+def test_check_surfaces_unattributed(capsys):
+    p = payload(comment("[CLAIMED] #9764 orphan claim", "2026-08-06T22:00:00Z"))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    # Unattributed does not block (cannot attribute) but is surfaced.
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"unattributed_markers": 1' in out


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: DEEP/lean #9762

## Ce que fait cette PR

Elle opérationnalise le **côté worker** de #9774 (mandat user 2026-08-06 sur les collisions de lanes CoursIA / CoursIA-2). Le **changement de règle** proposé par #9774 (le claim vit sur l'issue, pas le dashboard) exige un sign-off user avant d'entrer dans `.claude/rules/` — hors scope de cette PR. Ce qui est livré ici est le **mécanisme que la règle appellera** : le « check mécanique et cheap, une commande avant d'éditer » que #9774 point 1+3 identifie, avec les timestamps en **UTC serveur** (fix Defaut 2).

## Le diagnostic de #9774 en deux mots

Le 06/08, l'issue #9764 a été livrée deux fois (po-2023 CoursIA-2 + po-2025 CoursIA). Aucune lane n'a manqué à sa discipline : les deux ont passé leur garde `gh pr list` (L898), qui ne voit que le travail **déjà poussé**. La collision naît dans la fenêtre « je décide de travailler sur X » → « je pousse une PR », où le seul signal est le `[CLAIMED]`, rangé dans un silo par lane (le dashboard), qui (a) ne traverse pas les lanes, (b) se fait ramasser par l'auto-condensation, (c) mélangeait heure locale et UTC. Le point (c) a inversé l'ordre des claims : un stamp `2026-08-07T00:52Z` qui était en réalité 00:52 CEST (22:52 UTC) a lu comme 2 h plus tard, faillant faire entériner au coordinateur la priorité inversée.

## Livrables

- **`scripts/check_lane_claim.py`** — le guard.
  - `check_lane_claim.py <issue> --lane <machine:workspace>` : lit `gh issue view N --json comments`, reconstruit l'état des claims par lane (machine à états `[CLAIMED]` ouvre / `[RELEASED]`·`[DONE]`·`[CANCELLED]`·`[ABANDONED]` ferme), exit **1** si une **autre** lane tient un claim actif non levé, exit 0 sinon.
  - `--claim "<intention>"` / `--release [--note ...]` : postent le commentaire `[CLAIMED] lane <machine:workspace>` / `[RELEASED]`. Le corps **ne porte aucun timestamp** → GitHub le sert en UTC → Defaut 2 impossible par construction.
  - `--from-json FILE` : mode offline/test (lit une sortie `gh issue view` sauvegardée).
  - **Timestamp autoritatif = `comment.createdAt` serveur**, jamais un stamp écrit dans le corps. C'est tout le fix Defaut 2.
- **`scripts/grain_tag.py`** — `extract_lane(body)` : wrapper public sur `_LANE_RE` existant. Philosophie #9485 « single reader » : le guard, le tag Grain et l'organe G-VAR-2 lisent la lane avec le **même** regex, pour qu'un commentaire de claim et un body de PR ne divergent jamais sur ce qu'est une lane. Ajout non-cassant (les 13 tests `test_grain_tag` + 35 `test_variation_light_cap` restent verts).
- **`scripts/tests/test_check_lane_claim.py`** — 16 tests : machine à états (open/close, deux lanes, release partiel, marqueur orphelin non attribué), **régression Defaut 2** (l'ordering par `createdAt` serveur l'emporte sur le stamp body mensonger du cas #9764), exit codes du check.

## Validation

- `python -m pytest scripts/tests/test_check_lane_claim.py scripts/tests/test_grain_tag.py scripts/tests/test_variation_light_cap.py` → **64 passed**.
- Smoke CLI offline (`--from-json`) : scénario #9764 → po-2024 BLOCKED (exit 1), po-2025 voit po-2023 bloquant (exit 1) — la collision réelle est détectée.
- Read `gh` réel sur #9774 (0 commentaires) → CLEAR, exit 0.

## Périmètre & résiduel

- **Limitation documentée** : l'état du claim est basé sur les commentaires. Une PR mergée qui référence l'issue n'est pas auto-détectée comme release — la lane doit `--release` (ou poster `[DONE]`) quand sa PR atterrit. La détection des merges est un flag futur ; le contrat par commentaire est le MVP.
- La convention lue est celle de #9774 (`lane <machine:workspace>`, avec le mot-clé `lane`), identique au tag Grain. Un claim legacy sans mot-clé `lane` (forme dashboard) est remonté comme « marqueur orphelin » à vérifier manuellement, jamais deviné.
- **Scope fichier-entier §E** : N/A (3 fichiers, tous listés ci-dessus, pas un README).

See #9774 (contribution partielle : mécanisme worker-side ; le changement de règle reste gated sign-off user).
