### PR TITLE
docs(qc,#1621): Cloud-SectorRotation-Momentum README FR + honest-read frais (NO-BEATS)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-SectorRotation-Momentum/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-SectorRotation-Momentum/README.en.md
@@ -2,34 +2,59 @@
 
 **Asset class:** Equities, Bonds, Commodities (ETF rotation)
 
-**Cloud project ID:** N/A
+**Cloud project ID:** 30821748
 
 ## Description
 
-Momentum-weighted trend following on a 5-ETF universe (QQQ, SPY, EFA, GLD, IWM) with SHY as the defensive cash equivalent. Uses a dual filter (price above SMA200 AND positive 6-month momentum) to select trending assets, then allocates proportionally to their rate-of-change (ROC) momentum scores. Rebalances every 21 trading days.
+Momentum-weighted trend following on a 5-ETF universe (QQQ, SPY, EFA, GLD, IWM) with SHY as the defensive cash equivalent. Uses a dual filter (price above SMA200 **and** positive 6-month / 126-trading-day momentum) to select trending assets, then allocates proportionally to their rate-of-change (ROC) momentum scores. Rebalances every 21 trading days. Interactive Brokers brokerage (real costs), SPY benchmark.
 
 ## How to Run
 
 ### Lean CLI
+
 ```bash
 lean backtest --algorithm Cloud-SectorRotation-Momentum/main.py
 ```
 
 ### QC Cloud
-Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+
+Project 30821748. Upload `main.py`, compile and run a backtest. Hard-coded period: **2018-01-01 → 2025-01-01** (aligned with the cross-strategy baseline #1630; the code sets no moving end date, so the window is fixed by the source dates).
 
 ## Backtest Metrics
 
-| Method | Rebalance | Key Parameters |
-|--------|-----------|----------------|
-| Momentum-weighted trend following | 21 days | SMA200 + 6m momentum dual filter, ROC proportional weighting |
+Fresh backtest via QC Cloud MCP, 2026-08-07 (`SectorRotation-honest-read-2026-08`, 1761 tradeable dates, 345 orders):
+
+| Indicator | Value | Reading |
+|---|---|---|
+| Sharpe ratio | **−0.029** | near-zero, slightly negative |
+| CAGR | **2.118%** | below the risk-free rate over the period |
+| Max drawdown | **42.700%** | catastrophic |
+| Total net profit | **15.812%** (≈ +$12,369 on $100k) | over ~7 years |
+| PSR (Probabilistic Sharpe Ratio) | **0.050%** | performance indistinguishable from noise |
+| Orders | 345 (~49/year) | moderate turnover |
+
+**Verdict: NO-BEATS.** The strategy does not beat the buy-and-hold SPY benchmark, and does so with materially higher risk. Over 2018-2025, buy-and-hold SPY posts a double-digit CAGR with a max drawdown on the order of 25-34% (2020 COVID crash + 2022 bear market); here the CAGR collapses to ~2% for a 42.7% drawdown. Risk-adjusted (Sharpe), the strategy destroys value.
+
+## Honest read
+
+The dual filter (SMA200 + positive 126-day momentum) and the momentum-proportional weighting do not protect against the adverse regimes of 2018-2025:
+
+- **Concentration on upside momentum.** ROC-proportional allocation over-exposes the most volatile assets on the way up; when momentum reverses (Q4 2018, COVID 2020, 2022 bear), those positions amplify the drawdown. The SMA200 filter is reactive (it only trips after a breakdown), so the move to defensive SHY arrives too late.
+- **Defensive SHY = too late.** The retreat to SHY happens only when **no** asset passes the dual filter — a lagging signal that leaves the strategy fully invested at the start of drawdowns.
+- **PSR ≈ 0.** With a PSR of 0.05%, the observed Sharpe is not statistically significant: this result cannot be distinguished from a random draw. Any edge claim would be misleading (rule C, PR-review-discipline §C).
+
+**No re-tuning.** Re-optimizing the parameters (momentum lookback, rebalance period, universe) to recover a positive Sharpe on this single window would be overfitting until proven otherwise — exactly the bias flagged in EPIC #9768 (D2 "unfixed window"). The strategy is shipped with its parameters coded as-is, honest verdict rendered.
 
 ## Files
 
 | File | Description |
 |------|-------------|
-| `main.py` | Sector rotation with momentum-weighted allocation and dual trend filter |
+| `main.py` | Sector rotation with momentum-weighted allocation and dual trend filter (v4) |
 
 ## References
 
 - [QuantConnect Documentation](https://www.quantconnect.com/docs/)
+- QC / Trading consolidation EPIC: #1621
+- Governed by EPIC #9768 (backtest-metric drift across revisions)
+
+See #1621 (partial contribution: honest-read of a previously-unaudited strategy).

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-SectorRotation-Momentum/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-SectorRotation-Momentum/README.md
@@ -2,11 +2,11 @@
 
 **Classe d'actifs :** Actions, Obligations, Matières premières (rotation d'ETF)
 
-**ID projet Cloud :** N/A
+**ID projet Cloud :** 30821748
 
 ## Description
 
-Trend-following pondéré par momentum sur un univers de 5 ETF (QQQ, SPY, EFA, GLD, IWM) avec SHY comme équivalent cash défensif. Utilise un double filtre (prix au-dessus du SMA200 ET momentum positif sur 6 mois) pour sélectionner les actifs en tendance, puis alloue proportionnellement à leurs scores de momentum mesurés par taux de variation (ROC). Rebalance tous les 21 jours de bourse.
+Trend-following pondéré par momentum sur un univers de 5 ETF (QQQ, SPY, EFA, GLD, IWM) avec SHY comme équivalent cash défensif. Utilise un double filtre (prix au-dessus du SMA200 **et** momentum positif sur 6 mois / 126 jours de cotation) pour sélectionner les actifs en tendance, puis alloue proportionnellement à leurs scores de momentum mesurés par taux de variation (ROC). Rebalance tous les 21 jours de bourse. Brokerage Interactive Brokers (frais réels), benchmark SPY.
 
 ## Comment exécuter
 
@@ -16,20 +16,43 @@ lean backtest --algorithm Cloud-SectorRotation-Momentum/main.py
 ```
 
 ### QC Cloud
-Créer un nouveau projet, téléverser `main.py`, compiler et lancer un backtest (défaut : 2015-01-01 au 2024-12-31).
+Projet 30821748. Téléverser `main.py`, compiler et lancer un backtest. Période codée en dur : **2018-01-01 → 2025-01-01** (alignée sur la baseline cross-stratégie #1630 ; le code ne fixe pas de date de fin mobile, donc la fenêtre est figée par les dates du source).
 
 ## Métriques de backtest
 
-| Méthode | Rebalance | Paramètres clés |
-|---------|-----------|-----------------|
-| Trend-following pondéré par momentum | 21 jours | Double filtre SMA200 + momentum 6 mois, pondération proportionnelle au ROC |
+Backtest frais via QC Cloud MCP, 2026-08-07 (`SectorRotation-honest-read-2026-08`, 1761 dates négociables, 345 ordres) :
+
+| Indicateur | Valeur | Lecture |
+|---|---|---|
+| Ratio de Sharpe | **−0,029** | quasi nul, légèrement négatif |
+| CAGR | **2,118 %** | sous le risque-free sur la période |
+| Drawdown max | **42,700 %** | catastrophique |
+| Profit net total | **15,812 %** (≈ +12 369 $ sur 100 k $) | sur ~7 ans |
+| PSR (Probabilistic Sharpe Ratio) | **0,050 %** | performance non distinguable du bruit |
+| Ordres | 345 (~49/an) | turnover modéré |
+
+**Verdict : NO-BEATS.** La stratégie ne bat pas le benchmark buy-and-hold SPY, avec un risque bien supérieur. Sur 2018-2025, SPY buy-and-hold ressort à un CAGR à deux chiffres pour un drawdown max de l'ordre de 25-34 % (krach COVID 2020 + bear market 2022) ; ici le CAGR tombe à ~2 % pour un drawdown de 42,7 %. Ajusté au risque (Sharpe), la stratégie détruit de la valeur.
+
+## Lecture honnête
+
+Le double filtre (SMA200 + momentum 126 j positif) et la pondération proportionnelle au momentum ne protègent pas dans les régimes adverses du 2018-2025 :
+
+- **Concentration sur le momentum haussier.** L'allocation proportionnelle au ROC surexpose les actifs les plus volatils en hausse ; lorsque le momentum s'inverse (Q4 2018, COVID 2020, bear 2022), ces positions amplifient le drawdown. Le filtre SMA200 est réactif (il ne se déclenche qu'après cassure), donc le passage en défensif SHY arrive trop tard.
+- **SHY défensif = trop tardif.** Le repli sur SHY ne se produit que lorsqu'**aucun** actif ne passe le double filtre, un signal retardé qui laisse la stratégie pleinement investie au début des drawdowns.
+- **PSR ≈ 0.** Avec un PSR de 0,05 %, le Sharpe observé n'est pas statistiquement significatif : on ne peut pas distinguer ce résultat d'un tirage aléatoire. Tout claim de bord serait trompeur (règle C, PR-review-discipline §C).
+
+**Pas de re-tuning.** Re-optimiser les paramètres (lookback momentum, période de rebalancement, univers) pour récupérer un Sharpe positif sur cette seule fenêtre serait du surapprentissage jusqu'à preuve du contraire, le biais dénoncé dans l'EPIC #9768 (D2 « fenêtre non figée »). La stratégie est livrée avec ses paramètres codés tels quels, verdict honnête rendu.
 
 ## Fichiers
 
 | Fichier | Description |
 |---------|-------------|
-| `main.py` | Rotation sectorielle avec allocation pondérée par momentum et double filtre de tendance |
+| `main.py` | Rotation sectorielle avec allocation pondérée par momentum et double filtre de tendance (v4) |
 
 ## Références
 
 - [Documentation QuantConnect](https://www.quantconnect.com/docs/)
+- EPIC de consolidation QC / Trading : #1621
+- Discipliné par l'EPIC #9768 (dérive des métriques de backtest à travers les révisions)
+
+See #1621 (contribution partielle : honest-read d'une stratégie non auditée).


### PR DESCRIPTION
Grain: DEEP/qc — lane myia-po-2024:CoursIA — prev: MED/tooling #9775

## Ce que fait cette PR

Honest-read d'une stratégie QC **non auditée** jusque-là : `Cloud-SectorRotation-Momentum`. README squelette de 35 lignes (zéro métrique réelle, période stale « 2015-2024 » alors que le code fixe 2018-2025) → README FR canonique + README.en.md miroir avec backtest frais via QC Cloud MCP et verdict honnête **NO-BEATS**.

## Métriques réelles (backtest frais, 2026-08-07)

`SectorRotation-honest-read-2026-08` — QC Cloud MCP, projet 30821748, compile `BuildSuccess` 0 erreur, 1761 dates négociables, 345 ordres :

| Indicateur | Valeur |
|---|---|
| Sharpe | **−0,029** |
| CAGR | **2,118 %** |
| MaxDD | **42,700 %** |
| PSR | **0,050 %** |
| Net profit | 15,812 % sur ~7 ans |

**Verdict NO-BEATS** : CAGR ~2 % (sous le risk-free) pour un drawdown de 42,7 %, PSR ≈ 0 (performance indistinguible du bruit). Nettement inférieur au buy-and-hold SPY (~double-digit CAGR, DD 25-34 % sur la même période).

## Lecture honnête (dans le README)

Le double filtre SMA200 + momentum 126 j et la pondération ROC-proportionnelle ne protègent pas dans les régimes adverses 2018-2025 : concentration sur le momentum haussier (amplifie les drawdowns à l'inversion), SHY défensif trop tardif (signal retardé), PSR ≈ 0 (non significatif). **Pas de re-tuning** : re-optimiser sur cette seule fenêtre = surapprentissage (biais EPIC #9768 D2).

## Validation

- **Backtest réel via MCP** : `create_compile` → `BuildSuccess` → `create_backtest` → `read_backtest` (Completed, 1761 dates, 345 ordres). Pas de sortie fabriquée.
- Code `main.py` lu en entier (120 lignes) : pas de stub, algorithme complet, IB brokerage (frais réels), benchmark SPY.
- **§E fichier-entier** : `main.py` + les 2 READMEs audités ; drift de période « 2015-2024 » → « 2018-2025 » corrigé (le code ne fixe pas de `SetEndDate` mobile).
- Catalogue byte-identique à main (R1 catalog-pr-hygiene) — pas de régénération.

## Périmètre

- 2 fichiers (README.md + README.en.md), FR canonique + EN miroir, même structure et métriques (readme-french-first §1/§2).
- Algorithme `main.py` **non modifié** (stratégie livrée telle quelle, verdict honnête rendu — règle anti-régression : pas de re-tuning).

See #1621 (contribution partielle : honest-read d'une stratégie QC non auditée).
