### PR TITLE
fix(genai,#9734): lien Epic #4433 vers l'issue (lien casse introduit par #9736)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/01-AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/01-AI-Engine-WordPress/README.md
@@ -150,7 +150,7 @@ attendues.
   — tableau structuré
 - [`livresagites-parcours.md`](livresagites-parcours.md) — cas
   d'usage concret
-- Epic [#4433](../../../../../docs/genai/genai-services.md) —
+- Epic [#4433](https://github.com/jsboige/CoursIA/issues/4433) —
   refonte pédagogique GenAI (ce parcours en est une extension)
 - Issue [#9734](https://github.com/jsboige/CoursIA/issues/9734) —
   mandat user à l'origine de ce dossier


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-ai-01:CoursIA — prev: MED/qc #9757

## Defaut

`#9736` (mergee cette nuit) a introduit dans `MyIA.AI.Notebooks/GenAI/Open-WebUI/01-AI-Engine-WordPress/README.md:153` :

```
Epic [#4433](../../../../../docs/genai/genai-services.md)
```

Cinq `../` depuis `MyIA.AI.Notebooks/GenAI/Open-WebUI/01-AI-Engine-WordPress/`, alors que la racine du depot est a **quatre** (`..`=Open-WebUI, `../..`=GenAI, `../../..`=MyIA.AI.Notebooks, `../../../..`=racine). Cible inexistante.

## Symptome

`check-links` remonte `REGRESSION: 1 new broken link(s)` sur **toute PR ouverte depuis**, y compris des PR qui ne touchent pas ce fichier — constate sur #9781 (dont le scope est deux README QuantConnect).

## Correction

Lien vers l'**issue GitHub** plutot que re-profondeur du chemin docs : un numero d'Epic se lie a son issue, et c'est deja la convention de la **ligne soeur** juste en dessous (`Issue [#9734](https://github.com/jsboige/CoursIA/issues/9734)`).

Verifie firsthand : `#4433` = « Refonte pedagogique GenAI/Playwright-OWUI — parcours QA narratif », **OPEN**.

See #9734.