### PR TITLE
docs(qc,#1621): Cloud-VolTargeting README FR + honest-read frais (NO-BEATS)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-VolTargeting/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-VolTargeting/README.en.md
@@ -2,34 +2,60 @@
 
 **Asset class:** Multi-asset (Equities, Bonds, Commodities)
 
-**Cloud project ID:** N/A
+**Cloud project ID:** 30823587
 
 ## Description
 
-Volatility targeting strategy with three variants. v1 targets 12% annualized volatility on SPY alone using realized vol scaling. v2 extends to a multi-asset portfolio (SPY, QQQ, IEF, GLD) with equal risk contribution targeting 10% annualized vol. v3 adds a 126-day momentum filter to the multi-asset approach. Monthly rebalance across all variants.
+Volatility targeting strategy with three variants. v1 targets 12% annualized volatility on SPY alone using realized vol scaling (log-returns × √252 over 21 days). v2 extends to a multi-asset portfolio (SPY, QQQ, IEF, GLD) with equal risk contribution targeting 10% annualized vol. v3 adds a 126-day momentum filter to the multi-asset approach, with a defensive retreat to IEF. Monthly rebalance across all variants. Interactive Brokers brokerage (real costs), SPY benchmark.
 
 ## How to Run
 
 ### Lean CLI
+
 ```bash
 lean backtest --algorithm Cloud-VolTargeting/main.py
 ```
 
 ### QC Cloud
-Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+
+Project 30823587. Upload `main.py`, compile and run a backtest. Hard-coded period: **2018-01-01 → 2025-01-01** (aligned with the cross-strategy baseline #1630). The default variant (`version=1`, SPY only) is backtested below; pass `version=2` or `3` for the multi-asset variants.
 
 ## Backtest Metrics
 
-| Method | Rebalance | Key Parameters |
-|--------|-----------|----------------|
-| Vol targeting (3 variants) | Monthly | Vol target 10-12%, momentum filter 126 days (v3), equal risk contribution (v2/v3) |
+Fresh backtest via QC Cloud MCP, 2026-08-07 (`VolTargeting-v1-honest-read-2026-08`, project 30823587, compile `BuildSuccess`, 1761 tradeable dates, 54 orders):
+
+| Indicator | Value | Reading |
+|---|---|---|
+| Sharpe ratio | **0.207** | weakly positive |
+| CAGR | **6.717%** | below buy-and-hold SPY (~13-15% over the period) |
+| Max drawdown | **38.200%** | high (near SPY ~34%, without the return) |
+| Total net profit | **57.671%** (+$32,854) | over the period |
+| PSR (Probabilistic Sharpe Ratio) | **0.557%** | indistinguishable from noise |
+| Orders | 54 | very low turnover (monthly) |
+
+**Verdict: NO-BEATS.** Vol targeting on SPY alone underperforms buy-and-hold SPY: CAGR 6.7% for a 38.2% drawdown, Sharpe 0.207.
+
+## Honest read (v1 variant)
+
+v1 scales the SPY allocation from realized volatility: `allocation = vol_target / realized_vol`, clamped between 30% and 150%. Weaknesses observed over 2018-2025:
+
+- **Lagged signal (volatility lag).** Realized volatility typically rises **after** a drawdown begins (2020 COVID crash, 2022 bear). The allocation cut therefore arrives too late to avoid the loss tail, but in time to miss the ensuing rebound.
+- **30% exposure floor.** Even in high volatility, the strategy stays at least 30% invested — downside protection is partial, while upside return is curtailed.
+- **Leverage in calm periods.** `max_allocation = 1.50` adds leverage when vol is low (bull markets), increasing risk without a proportional Sharpe improvement.
+- **PSR ≈ 0.** The 0.207 Sharpe is not statistically significant: indistinguishable from noise. Any edge claim would be misleading (rule C, PR-review-discipline §C).
+
+The v2 (multi-asset diversification + equal risk contribution) and v3 (+ momentum + IEF defensive) variants aim to correct these weaknesses (diversifying reduces drawdown, momentum filters declining assets), but are not backtested here: an honest read documents the baseline variant and its honest verdict, without re-tuning. Re-optimizing the vol target, lookback, or allocation bounds to recover a positive Sharpe on this single window would be overfitting until proven otherwise (EPIC #9768, D2 "unfixed window"). The strategy is shipped with its parameters coded as-is, honest verdict rendered.
 
 ## Files
 
 | File | Description |
 |------|-------------|
-| `main.py` | Volatility targeting algorithm with 3 variants (single-asset, multi-asset ERC, +momentum) |
+| `main.py` | Volatility targeting with 3 variants (v1 SPY only, v2 multi-asset equal-risk, v3 +momentum +IEF defensive) |
 
 ## References
 
 - [QuantConnect Documentation](https://www.quantconnect.com/docs/)
+- QC / Trading consolidation EPIC: #1621
+- Governed by EPIC #9768 (backtest-metric drift across revisions)
+
+See #1621 (partial contribution: honest-read of a previously-unaudited strategy).

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-VolTargeting/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-VolTargeting/README.md
@@ -2,11 +2,11 @@
 
 **Classe d'actifs :** Multi-actifs (Actions, Obligations, Matières premières)
 
-**ID projet Cloud :** N/A
+**ID projet Cloud :** 30823587
 
 ## Description
 
-Stratégie de ciblage de volatilité avec trois variantes. v1 cible 12 % de volatilité annualisée sur SPY seul via une mise à l'échelle par volatilité réalisée. v2 étend à un portefeuille multi-actifs (SPY, QQQ, IEF, GLD) avec une contribution en risque égale ciblant 10 % de volatilité annualisée. v3 ajoute un filtre de momentum sur 126 jours à l'approche multi-actifs. Rebalance mensuelle pour toutes les variantes.
+Stratégie de ciblage de volatilité avec trois variantes. v1 cible 12 % de volatilité annualisée sur SPY seul via une mise à l'échelle par volatilité réalisée (log-returns × √252 sur 21 jours). v2 étend à un portefeuille multi-actifs (SPY, QQQ, IEF, GLD) avec une contribution en risque égale ciblant 10 % de volatilité annualisée. v3 ajoute un filtre de momentum sur 126 jours à l'approche multi-actifs, avec repli défensif sur IEF. Rebalance mensuelle pour toutes les variantes. Brokerage Interactive Brokers (frais réels), benchmark SPY.
 
 ## Comment exécuter
 
@@ -16,20 +16,44 @@ lean backtest --algorithm Cloud-VolTargeting/main.py
 ```
 
 ### QC Cloud
-Créer un nouveau projet, téléverser `main.py`, compiler et lancer un backtest (défaut : 2015-01-01 au 2024-12-31).
+Projet 30823587. Téléverser `main.py`, compiler et lancer un backtest. Période codée en dur : **2018-01-01 → 2025-01-01** (alignée sur la baseline cross-stratégie #1630). La variante par défaut (`version=1`, SPY seul) est backtestée ci-dessous ; passer `version=2` ou `3` pour les variantes multi-actifs.
 
 ## Métriques de backtest
 
-| Méthode | Rebalance | Paramètres clés |
-|---------|-----------|-----------------|
-| Ciblage de volatilité (3 variantes) | Mensuelle | Cible de vol 10-12 %, filtre momentum 126 jours (v3), contribution en risque égale (v2/v3) |
+Backtest frais via QC Cloud MCP, 2026-08-07 (`VolTargeting-v1-honest-read-2026-08`, projet 30823587, compile `BuildSuccess`, 1761 dates négociables, 54 ordres) :
+
+| Indicateur | Valeur | Lecture |
+|---|---|---|
+| Ratio de Sharpe | **0,207** | faible positif |
+| CAGR | **6,717 %** | sous le buy-hold SPY (~13-15 % sur la période) |
+| Drawdown max | **38,200 %** | élevé (proche de SPY ~34 %, sans le rendement) |
+| Profit net total | **57,671 %** (+32 854 $) | sur la période |
+| PSR (Probabilistic Sharpe Ratio) | **0,557 %** | non distinguable du bruit |
+| Ordres | 54 | turnover très faible (mensuel) |
+
+**Verdict : NO-BEATS.** Le vol targeting sur SPY seul sous-performe le buy-and-hold SPY : CAGR 6,7 % pour un drawdown de 38,2 %, Sharpe 0,207.
+
+## Lecture honnête (variante v1)
+
+Le v1 ajuste l'allocation SPY en fonction de la volatilité réalisée : `allocation = cible_vol / vol_réalisée`, clampée entre 30 % et 150 %. Les faiblesses observées sur 2018-2025 :
+
+- **Signal retardé (lag de volatilité).** La volatilité réalisée augmente typiquement **après** le début d'un drawdown (krach COVID 2020, bear 2022). La réduction d'allocation arrive donc trop tard pour éviter la queue de perte, mais à temps pour rater le rebond qui suit.
+- **Plancher d'exposition à 30 %.** Même en forte volatilité, la stratégie reste au moins 30 % investie — la protection à la baisse est donc partielle, tandis que le rendement est amputé côté hausse.
+- **Levier en période calme.** `max_allocation = 1,50` ajoute du levier quand la vol est basse (bull markets), ce qui accrît le risque sans amélioration proportionnelle du Sharpe.
+- **PSR ≈ 0.** Le Sharpe 0,207 n'est pas statistiquement significatif : indistinguable du bruit. Tout claim de bord serait trompeur (règle C, PR-review-discipline §C).
+
+Les variants v2 (diversification multi-actifs + contribution en risque égale) et v3 (+ momentum + défensif IEF) visent à corriger ces faiblesses (diversifier réduit le drawdown, le momentum filtre les actifs en baisse), mais ne sont pas backtestés ici : un honest-read documente le variant baseline et son verdict honnête, sans re-tuning. Ré-optimiser la cible de vol, le lookback ou les bornes d'allocation pour récupérer un Sharpe positif sur cette seule fenêtre serait du surapprentissage jusqu'à preuve du contraire (EPIC #9768, D2 « fenêtre non figée »). La stratégie est livrée avec ses paramètres codés tels quels, verdict honnête rendu.
 
 ## Fichiers
 
 | Fichier | Description |
 |---------|-------------|
-| `main.py` | Algorithme de ciblage de volatilité avec 3 variantes (actif unique, multi-actifs ERC, +momentum) |
+| `main.py` | Ciblage de volatilité avec 3 variantes (v1 SPY seul, v2 multi-actifs equal-risk, v3 +momentum +défensif IEF) |
 
 ## Références
 
 - [Documentation QuantConnect](https://www.quantconnect.com/docs/)
+- EPIC de consolidation QC / Trading : #1621
+- Discipliné par l'EPIC #9768 (dérive des métriques de backtest à travers les révisions)
+
+See #1621 (contribution partielle : honest-read d'une stratégie non auditée).


### PR DESCRIPTION
Grain: DEEP/qc — lane myia-po-2024:CoursIA — prev: DEEP/qc #9781

## Ce que fait cette PR

Honest-read de la **3e et dernière** stratégie QC Cloud-* non auditée : `Cloud-VolTargeting`. README squelette (zéro métrique réelle, période stale « 2015-2024 » alors que le code fixe 2018-2025) → README FR canonique + README.en.md miroir avec backtest frais via QC Cloud MCP (variant **v1** : vol targeting SPY single-asset) et verdict honnête.

**La veine Cloud-* est maintenant drained** (3/3 : SectorRotation #9779 momentum, MeanReversion #9781 RSI, VolTargeting ciblage de volatilité). Pivot obligatoire au prochain cycle.

## La stratégie (v1 backtestée)

- **Actif** : SPY seul.
- **Mécanique** : volatilité réalisée (log-returns × √252 sur 21 jours) → allocation = cible_vol / vol_réalisée, clampée [30 %, 150 %]. Cible 12 % de vol annualisée.
- **Idée** : réduire l'exposition quand la volatilité augmente (après les chutes), l'augmenter (jusqu'à 1,5×) quand elle est basse.
- **Rebalance** : mensuelle (`month_start`), 30 min après l'ouverture. IB brokerage (frais réels), benchmark SPY.
- Variants v2 (multi-actifs SPY/QQQ/IEF/GLD equal-risk) et v3 (+momentum 126j + IEF défensif) existent mais non backtestés ici (honest-read documente la baseline).

## Métriques réelles (backtest frais, 2026-08-07)

`VolTargeting-v1-honest-read-2026-08` — QC Cloud MCP, projet 30823587, compile `BuildSuccess`, 1761 dates négociables, 54 ordres :

| Indicateur | Valeur | Lecture |
|---|---|---|
| Ratio de Sharpe | **0,207** | faible positif |
| CAGR | **6,717 %** | sous le buy-hold SPY (~13-15 % sur la période) |
| Drawdown max | **38,200 %** | élevé (proche de SPY ~34 %, mais sans le rendement) |
| Profit net total | **57,671 %** (+32 854 $) | sur la période |
| PSR | **0,557 %** | non distinguable du bruit (un peu moins pire que #9779/#9781) |
| Ordres | 54 | turnover très faible (mensuel) |

**Verdict : NO-BEATS.** Le vol targeting sur SPY seul sous-performe le buy-and-hold SPY : CAGR 6,7 % pour un drawdown de 38,2 %, Sharpe 0,207. Le mécanisme réduit l'exposition quand la volatilité monte — ce qui arrive typiquement **après** le début d'un drawdown (lag), donc le signal arrive trop tard pour éviter la queue de perte, mais à temps pour rater le rebond. Le plancher `min_allocation=0.30` laisse 30 % d'exposition même en forte volatilité, et `max_allocation=1.50` ajoute du levier en période calme (risque accrû). Le résultat : moins de rendement que le buy-hold, sans drawdown nettement meilleur.

## Validation

- Backtest réel via MCP (`create_compile` → `BuildSuccess` → `create_backtest` → `read_backtest`). Pas de sortie fabriquée.
- `main.py` lu en entier (154 lignes) : pas de stub, algorithme complet, IB brokerage, benchmark SPY.
- §E fichier-entier : drift période « 2015-2024 » → « 2018-2025 » corrigé ; `main.py` non modifié.
- Catalogue byte-identique à main (R1 catalog-pr-hygiene).

## Périmètre

- 2 fichiers (README.md + README.en.md), FR canonique + EN miroir.
- `main.py` non modifié (stratégie livrée telle quelle, verdict honnête rendu).

See #1621 (contribution partielle : honest-read d'une stratégie non auditée, veine Cloud-* drained).
