### PR TITLE
docs(lean,#9568): document the Decidable-instance non-propagation pitfall

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Cadre de travail (adapté de Karpathy + ajout user) : ces principes gouvernent *
 | [reference/regles-vigilance-detail.md](docs/reference/regles-vigilance-detail.md) · [regles-validation-detail.md](docs/reference/regles-validation-detail.md) | Détail G.1-G.9 et H.1-H.7 + incidents |
 | [reference/env-python-reparation.md](docs/reference/env-python-reparation.md) | Réparation env Python (règle F) |
 | [reference/stale-tree-drift-scan.md](docs/reference/stale-tree-drift-scan.md) · [orphan-branch-scan-l576.md](docs/reference/orphan-branch-scan-l576.md) | Scans anti-phantom (drift, branche orpheline) |
-| [lean/](docs/lean/) | Prover iteration history, intractable diagnosis, LLM endpoints |
+| [lean/](docs/lean/) | Prover iteration history, intractable diagnosis, LLM endpoints, pièges tactiques (propagation d'instance `Decidable`) |
 
 Notation étudiants : moteur générique = [GradeBookApp/configs/README.md](GradeBookApp/configs/README.md) ; **pipelines + données par cohorte = privés sur GDrive** `G:\Mon Drive\MyIA\Formation\<ecole>\<annee>\grading\` (PII, hors repo public).
 

--- a/docs/lean/decidable_instance_propagation.md
+++ b/docs/lean/decidable_instance_propagation.md
@@ -1,0 +1,97 @@
+# Lean 4 — Piège : l'instance `Decidable` ne se propage pas à travers une `def : Prop`
+
+**Date :** 2026-08-07
+**Auteur :** myia-po-2026 (PR #9780, Livrable B #9568)
+**Portée :** cross-lake — tout wrapper `def ... : Prop` autour d'une Prop qui a une instance `Decidable`.
+
+---
+
+## Résumé
+
+En Lean 4, définir un prédicat comme un wrapper `def` autour d'une proposition qui possède déjà une instance `Decidable` **ne propage pas automatiquement** cette instance à travers le wrapper. Résoudre le prédicat par `by decide` ou `by native_decide` échoue alors avec :
+
+```
+failed to synthesize Decidable (mon_predicat témoin)
+```
+
+alors même que l'instance sous-jacente existe bel et bien. C'est un piège récurrent
+lorsqu'on factorise un prédicat pédagogique ou de fragment au-dessus d'un prédicat
+« moteur » du codebase (margin, décidabilité, etc.).
+
+## Pourquoi
+
+Lean ne réduit **pas** une `def` non-`@[reducible]` lors de la synthèse d'instance.
+L'unificateur trouve l'instance `Decidable (Prop_sous-jacente x)` pour la tête
+`Prop_sous-jacente`, mais le wrapper `mon_predicat` est opaque : l'unificateur ne le
+déplie pas pour découvrir l'instance qu'il recouvre. La synthèse échoue donc au niveau
+du wrapper, pas de la Prop sous-jacente.
+
+## Les 3 fixes (par ordre de préférence)
+
+### 1. Instance compagnon (pattern canonique du codebase)
+
+Déclarer explicitement l'instance au niveau du wrapper, en se déchargeant sur l'instance
+sous-jacente via `inferInstanceAs`. C'est exactement ce que fait le codebase Conway :
+`BoxAssezGrandN` déclare sa propre instance au-dessus de l'instance native
+(`Conway/Life/HashlifeCorrectness.lean`, ~L227) :
+
+```lean
+def BoxAssezGrandN (g : Grid) (n : Nat) : Prop := box_assez_grandN g n = true
+
+instance (g : Grid) (n : Nat) : Decidable (BoxAssezGrandN g n) :=
+  inferInstanceAs (Decidable (box_assez_grandN g n = true))
+```
+
+Pour un wrapper au-dessus de `BoxAssezGrandN` :
+
+```lean
+def supportInMargin (c : MacroCell) (k : Nat) : Prop :=
+  BoxAssezGrandN (c.toGrid (0, 0)) (2^k)
+
+instance (c : MacroCell) (k : Nat) : Decidable (supportInMargin c k) :=
+  inferInstanceAs (Decidable (BoxAssezGrandN (c.toGrid (0, 0)) (2^k)))
+```
+
+### 2. `abbrev` au lieu de `def`
+
+`abbrev` est `@[reducible]` par construction, donc l'instance sous-jacente est trouvée
+par réduction. Convient quand le wrapper est purement un alias sans sémantique propre.
+
+### 3. `@[reducible] def`
+
+Même effet que `abbrev`, mais conserve la sémantique de `def`. À utiliser si l'on tient
+au mot-clé `def` pour la lisibilité.
+
+## Incident fondateur (PR #9780, Livrable B #9568)
+
+Le prédicat de fragment `supportInMargin c k := BoxAssezGrandN (c.toGrid (0,0)) (2^k)`
+(Livrable B #9568) enclenchait 4 sanity-checks `by native_decide` sur le bestiaire :
+
+```lean
+theorem cexBlock1_supportInMargin_k0 : supportInMargin cexBlock1 0 := by native_decide
+```
+
+Build WSL (v4.31.0-rc1) échouait sur les 4 avec
+`failed to synthesize Decidable (supportInMargin cexBlock1 0)`. L'instance
+`Decidable (BoxAssezGrandN g n)` existe pourtant (HashlifeCorrectness L227). Fix appliqué :
+instance compagnon (option 1), mirroir du pattern `BoxAssezGrandN`. Build repassé vert
+(FR 8500 jobs / EN 8500 jobs, EXIT 0).
+
+## Diagnostic — comment le reconnaître
+
+**Signal caractéristique :** `failed to synthesize Decidable (<votre_def> ...)` alors que
+la Prop sous-jacente a démontrableement une instance `Decidable`.
+
+**À ne pas faire :** chercher une instance manquante sur le type sous-jacent (elle existe,
+c'est le wrapper qui bloque). La cause est la non-réduction de la `def` lors de la
+synthèse, pas une instance absente.
+
+**Réflexe :** déclarer l'instance compagnon au niveau du wrapper.
+
+## Voir aussi
+
+- `Conway/Life/HashlifeCorrectness.lean` ~L227 — instance `Decidable (BoxAssezGrandN)`,
+  le pattern compagnon de référence.
+- PR #9780 — application concrète (`supportInMargin`, Livrable B #9568).
+- Issue #9568 — cadrage du fragment « fenêtre à marge » et de l'acceptance B.
+- Leçon mémoire `lean-decidable-instance-not-propagated-through-def-prop` (cycle c.939).


### PR DESCRIPTION
## Summary

**Grain** : MED/docs — nouveau doc `docs/lean/decidable_instance_propagation.md` (FR-first) capturant le piège Lean 4 rencontré en livrant le Livrable B #9780 : une `def foo : Prop := Bar x` wrapper **n'hérite pas** de l'instance `Decidable (Bar x)`, donc `by native_decide`/`by decide` sur `foo witness` échoue avec `failed to synthesize Decidable (foo witness)` alors que l'instance sous-jacente existe. Demandé par ai-01 (DM msg-ngg5o3) : la leçon méritait de vivre hors d'un DM — « typiquement ce qui se reperd ».

## Le piège

Lean ne réduit **pas** une `def` non-`@[reducible]` lors de la synthèse d'instance. L'unificateur trouve `Decidable (Bar x)` pour la tête `Bar`, mais le wrapper `foo` est opaque — il ne le déplie pas pour découvrir l'instance recouverte. La synthèse échoue au niveau du wrapper, pas de la Prop sous-jacente.

## Les 3 fixes documentés

1. **Instance compagnon** (pattern canonique codebase) — `inferInstanceAs`, exactement comme `BoxAssezGrandN` déclare la sienne au-dessus de l'instance native (`Conway/Life/HashlifeCorrectness.lean` ~L227).
2. **`abbrev`** — `@[reducible]` par construction, instance trouvée par réduction.
3. **`@[reducible] def`** — même effet, conserve le mot-clé `def`.

## Incident fondateur

PR #9780 (Livrable B #9568) : le prédicat `supportInMargin c k := BoxAssezGrandN (c.toGrid (0,0)) (2^k)` → 4 sanity-checks `by native_decide` échouaient `failed to synthesize Decidable (supportInMargin ...)`. Fix appliqué : instance compagnon (option 1), build repassé vert (FR/EN 8500 jobs EXIT 0). Vérifié firsthand WSL v4.31.0-rc1.

## Diagnostic (le tell)

`failed to synthesize Decidable (<votre_def> ...)` alors que la Prop sous-jacente a démontrablement une instance `Decidable` → **ne pas chercher une instance manquante** (elle existe), **déclarer l'instance compagnon au niveau du wrapper**.

## Détails

- `git diff --stat` : 2 fichiers (`docs/lean/decidable_instance_propagation.md` nouveau + `CLAUDE.md` pointeur 1 ligne), **+98/-1**.
- **FR-first** (readme-french-first mandate) — le fichier est en français.
- **§E docs audit** : nouveau fichier, cohérent en interne, références codebase (L227, PR #9780, issue #9568) vérifiées firsthand.
- **Catalogue byte-identique** (doc-only, aucun `.lean`/`.ipynb` touché).
- Fresh worktree isolé depuis `origin/main` `46c52adfb` (post-#9780 merged).
- La leçon vivait uniquement en mémoire machine (`lean-decidable-instance-not-propagated-through-def-prop`, c.939) ; maintenant dans `docs/` du repo pour visibilité cross-machine/cross-session.

See #9568 (Livrable B, PR #9780 où le piège a été rencontré).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
