### PR TITLE
docs(qc,#9768): BTC-MACD-ADX robustesse QC Cloud — MACD-only BEATS adaptative (0.988 vs 0.123), NO-BEATS buy-hold

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/RESEARCH_FINDINGS.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/RESEARCH_FINDINGS.md
@@ -391,3 +391,63 @@ But remember: **Complexity is not always better**. The research proves it.
 **Period**: 2019-01-01 → 2026-02-17 (2417 days)
 **Author**: Claude Opus 4.6 (qc-research-notebook agent)
 **Date**: 2026-02-17
+
+---
+
+## QC Cloud Validation (2026-08-07) — le verdict sur le moteur réel
+
+**Contexte.** L'analyse ci-dessus (février 2026) reposait sur des données Yahoo
+Finance **locales**, avec une conclusion forte : l'approche adaptative à seuils
+percentile échoue (H1-H5 rejetées, WFE 26 %), et la simplification (retirer le
+filtre ADX) rescousse la stratégie (MACD-only Sharpe local **0.939**). Cette
+conclusion n'avait **jamais été validée sur QC Cloud** avec frais Binance réels.
+Le mandat user (EPIC #9768) demande : *l'échec est-il intrinsèque, ou un défaut
+de robustesse réparable ?*
+
+**Protocole.** 3 backtests sur QC Cloud, brokerage **Binance Cash** (frais réels),
+**même fenêtre fixée** 2019-04-01 → 2026-08-06 (2684 jours tradeables). Projet de
+validation isolé `CSharp-BTC-MACD-ADX-robustness` (34914270) — le canonical
+(30751067) n'est pas touché.
+
+| Stratégie | Sharpe | PSR | CAGR | MaxDD | Profit net | Ordres |
+|-----------|--------|-----|------|-------|------------|--------|
+| Adaptative (code committé) | 0.123 | 0.814 % | ~0.04 % | 72.7 % | ~3.7 % | 52 |
+| **MACD-only (filtre ADX retiré)** | **0.988** | **29.605 %** | **32.35 %** | **55.30 %** | **685.75 %** | 188 |
+| **Buy & hold BTC** (baseline) | **1.180** | 35.697 % | 45.20 % | 76.40 % | 1453.37 % | 1 |
+
+### Verdict : BEATS-adaptative, NO-BEATS buy-hold — réparable mais sans alpha
+
+**1. La réparation fonctionne (l'échec N'ÉTAIT PAS intrinsèque).** Retirer le
+filtre ADX percentile multiplie le Sharpe par **8** (0.123 → 0.988) sur le moteur
+réel. Le PSR passe de bruit (0.8 %) à statistiquement significatif (29.6 %,
+au-dessus du seuil 10 %). Le diagnostic de février 2026 (sur-filtrage : 52 ordres
+vs 188, fenêtres percentile trop lentes pour la volatilité crypto) est **confirmé
+sur QC Cloud**. Le nombre local yfinance (0.939) survient quasi à l'identique sur
+le moteur réel (0.988) — l'analyse locale **n'était pas un artefact**.
+
+**2. Mais la stratégie ne bat pas le buy & hold BTC.** Sharpe 0.988 < 1.180,
+profit net 685 % < 1453 %. Le trend-following MACD sur BTC, même débarrassé de
+son filtre nuisible, **ne génère pas d'alpha** au-delà de l'exposition elle-même.
+
+**3. Le seul avantage réel est la gestion du risque.** MACD-only délivre ~47 % du
+rendement buy-hold pour un drawdown max de 55.3 % (vs 76.4 %) — soit environ 72 %
+du drawdown le plus profond. C'est une amélioration de profil de risque, **pas un
+edge prédictif**.
+
+### Conclusion actionnable
+
+- Le code committé (`Main.cs` adaptatif) est **démontrablement cassé** : 8× pire
+  que sa propre version simplifiée. Le filtre ADX percentile détruit de la valeur.
+- Recommandation : remplacer la logique adaptative par MACD-only (Option A de
+  l'analyse de février, confirmée sur QC Cloud). Le variant validé vit sur le
+  projet QC 34914270 (`Main.cs` « MACD-only »). **Ce déploiement est un changement
+  de stratégie** — laissé à la décision review (ni alpha ni urgence), hors scope de
+  cette validation.
+- Résiduel honnête : la fenêtre unique (2019-04 → 2026-08) ne constitue pas un
+  walk-forward out-of-sample. Les paramètres MACD (12/26/9) sont les **valeurs par
+  défaut standard**, non optimisés — le risque d'overfitting est donc faible, mais
+  une validation walk-forward (fenêtres train/test disjointes) reste l'étape de
+  robustesse suivante avant tout déploiement paper-trading.
+
+**Source des données** : QuantConnect Cloud (BTCUSDT daily, Binance Cash), 2026-08-07.
+**Auteur** : po-2025 (bras robustesse, mandat user EPIC #9768, steer ai-01 c.1265).


### PR DESCRIPTION
Grain: DEEP/qc — lane myia-po-2025:CoursIA — prev: DEEP/qc BlackLitterman #9786 (OPEN)

## Ce que fait cette PR

Valide sur **QC Cloud (frais Binance reels)** la conclusion de robustesse de
`RESEARCH_FINDINGS.md` (fev 2026, donnees Yahoo Finance locales) sur le bras
« robustesse » de l'EPIC #9768. Mandat user verbatim : « rendre l'algo plus
robuste ». Steer ai-01 (c.1265, provisioning DM) : l'echec est-il intrinseque ou
reparable ?

La conclusion locale (MACD-only Sharpe **0.939**, l'approche adaptative echoue)
n'avait **jamais ete validee sur le moteur reel**. Cette PR ferme le gap.

## Protocole (3 backtests QC Cloud, Binance Cash, fenetre fixee 2019-04 -> 2026-08)

Projet de validation isole `CSharp-BTC-MACD-ADX-robustness` (QC 34914270) — le
canonical (30751067) n'est pas touche. Variant MACD-only = filtre ADX percentile
retire des conditions d'entree/sortie (cause racine sur-filtrage identifiee en
fev 2026). 2684 jours tradeables.

| Strategie | Sharpe | PSR | CAGR | MaxDD | Net profit | Ordres |
|-----------|--------|-----|------|-------|------------|--------|
| Adaptative (committé) | 0.123 | 0.814 % | ~0.04 % | 72.7 % | ~3.7 % | 52 |
| **MACD-only (filtre ADX retiré)** | **0.988** | **29.605 %** | **32.35 %** | **55.30 %** | **685.75 %** | 188 |
| **Buy & hold BTC** (baseline) | **1.180** | 35.697 % | 45.20 % | 76.40 % | 1453.37 % | 1 |

## Verdict : BEATS-adaptative, NO-BEATS buy-hold — reparable mais sans alpha

1. **La reparation FONCTIONNE (l'echec n'etait PAS intrinseque).** Retirer le
   filtre ADX multiplie le Sharpe par 8 (0.123 -> 0.988) sur le moteur reel. PSR
   passe de bruit (0.8 %) a statistiquement significatif (29.6 %, > seuil 10 %).
   Le nombre local yfinance (0.939) survient quasi a l'identique sur QC Cloud
   (0.988) — l'analyse locale n'etait PAS un artefact. Diagnostic sur-filtrage
   confirme.

2. **MAIS la strategie ne bat pas le buy & hold BTC.** Sharpe 0.988 < 1.180,
   profit net 685 % < 1453 %. Pas d'alpha au-dela de l'exposition actions.

3. **Seul avantage reel : la gestion du risque.** MACD-only delivre ~47 % du
   rendement buy-hold pour MaxDD 55.3 % (vs 76.4 % buy-hold) — ~72 % du drawdown
   max. Amelioration de profil de risque, pas un edge predictif.

## Conclusion actionnable

- Le code committé adaptatif est **demontrablement casse** (8× pire que sa version
  simplifiee). Le filtre ADX percentile detruit de la valeur.
- Recommandation : remplacer la logique adaptative par MACD-only (Option A fev
  2026, confirmee sur QC Cloud). Variant valide sur QC project 34914270. **Ce
  deploiement est un changement de strategie** (ni alpha ni urgence) — laisse a la
  decision review, hors scope de cette validation. Canonical Main.cs NON modifie.
- Residuel honnete : fenetre unique = pas un walk-forward OOS. Params MACD
  (12/26/9) = valeurs par defort standard (peu de risque overfitting), mais
  walk-forward reste l'etape de robustesse suivante avant paper-trading.

## Validation

- 3 backtests QC Cloud MCP reels (create_compile -> BuildSuccess ->
  create_backtest -> read_backtest Completed), pas de sortie fabriquee.
- Claims ai-01 verified firsthand (G.1) sur origin/main : Sharpe 0.123, PSR 0.814 %,
  MaxDD 72.7 % (README honest-read #9754), 0.787 catalogue = sweep jamais committé,
  drift 0.225 -> 0.123.
- E fichier-entier : RESEARCH_FINDINGS.md lu entier (394 lignes + 60 ajoutees).
- Catalogue byte-identique (R1). LF-only, UTF-8 no-BOM. 1 fichier, atomique.

## Tests

Pas de code modifie (doc-only). Main.cs canonical non touche = pas de regression.

See #9768
See #1621
See #1630

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
