### PR TITLE
feat(notebook_tools,#9768): scan_d1_d3_d4_d5.py Phase 1 outillage (4 détecteurs)

### DIFF
--- a/scripts/notebook_tools/scan_d1_d3_d4_d5.py
+++ b/scripts/notebook_tools/scan_d1_d3_d4_d5.py
@@ -1,0 +1,792 @@
+"""Detecteur Phase 1 EPIC #9768 -- degeneration numerique sur commits non-substantiels.
+
+Cible 4 categories documentees dans l'EPIC #9768 (parent issue de l'audit
+forensic Phase 0 tranche ICT/IIT, issue #9787) :
+
+  D1  Provenance orpheline
+      Un nombre publie dans la prose (cellule markdown ou commentaire) n'est
+      PAS reproductible depuis les outputs Jupyter actuellement commits sur
+      la meme branche. Cas-type : un mainteneur ecrivant "Phi = 0.69" en prose
+      alors que l'execution produit Phi = 0.42, sans mise a jour conjointe.
+
+  D3  Restauration partielle
+      Un commit dont le sujet mentionne "restore" / "revert" retablit des
+      outputs numeriques QUI DIFFERENT des valeurs d'avant la perte.
+      Cas-type : un git checkout sur un commit anterieur suivi d'un commit
+      "restore" qui ne pointe pas exactement sur le meme contenu.
+
+  D4  Rename transportant une valeur
+      Un rename/move (git log --follow) qui deplace une valeur numerique
+      d'un contexte a un autre. Cas-type : un notebook deplace de
+      `recherche/` vers `production/` conserve les outputs mais le lecteur
+      attend la rigueur de production alors que les resultats etaient
+      exploratoires.
+
+  D5  Coquille silencieuse
+      Delta numerique IMPORTANT (seuil 20% relatif sur la mediane de sortie)
+      sur un diff de source MINUSCULE (e.g. 1 caractere corrige) qui ne leve
+      aucune exception mais degrade silencieusement le resultat.
+      Cas-type : `np.linspace(0, 1, 100)` -> `np.linspace(0, 1, 10)` change
+      la granularite sans prevenir ; `range(100)` -> `range(10)` pareil.
+
+Conception
+----------
+Le detecteur combine 3 signaux :
+
+  1. **Signature numerique** : mediane + ecart-type + count des nombres
+     extraits des outputs Jupyter (texte plain). Toute modification de la
+     signature au-dela de 5% entre 2 revisions consecutives est un saut.
+
+  2. **Classification du commit** : `git log --format=%s` permet d'identifier
+     les commits "non-substantiels" (prefixe fix/, docs/, chore/, etc.) qui
+     ne sont PAS censes modifier les outputs.
+
+  3. **Provenance HEAD** : pour D1, le verdict exige que les nombres cites
+     en prose soient presents dans les outputs HEAD avec une tolerance.
+
+Le verdict final est l'union des 4 detecteurs : SAIN si aucun signal,
+D1+/D3+/D4+/D5+ si un seul signal, MIXED si plusieurs, INDETERMINE si
+donnees insuffisantes (notebook jamais execute, ou <2 revisions).
+
+Note methodologique
+-------------------
+Ce script ne **declare jamais** ce qu'il faut corriger -- chaque verdict
+D1+/D3+/D4+/D5+ est un **point de depart d'investigation**. Un D3+ peut
+etre un artefact de git filter-branch, un D5+ peut etre une correction
+volontaire documentee ailleurs. Le jugement reste humain / review-bot.
+
+Mode CI
+-------
+    python scan_d1_d3_d4_d5.py MyIA.AI.Notebooks/IIT/ICT-Series/ --check
+
+Exit 1 si au moins un verdict D1+/D3+/D4+/D5+ (mode CI strict).
+Exit 0 sinon (verdict SAIN ou INDETERMINE uniquement).
+
+Conformite harnais
+------------------
+- Regle F (env repair not bypass) : 0 dependance externe (Python 3.10+ stdlib).
+- audit-cross-source-distillation R1 : verdict stdout/JSON, JAMAIS de rapport
+  AUDIT-D*.md commite dans l'arbre.
+- catalog-pr-hygiene R1 : 0 modification catalogue (le script lit, n'ecrit pas).
+- C.1 : 0 erreur volontaire (pas de `raise NotImplementedError` etc.).
+
+Voir aussi
+----------
+- EPIC #9768 : taxonomie complete de la degeneration
+- Issue #9787 (Phase 0 tranche ICT/IIT) : calibration empirique du seuil
+- scripts/notebook_tools/forensic_scan.py : orthogonal (cat. A/B/C/D/E execution)
+- scripts/notebook_tools/regression_scan.py : orthogonal (axis-2 SOFT markers)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+# --------------------------------------------------------------------------- #
+#  Configuration
+# --------------------------------------------------------------------------- #
+
+# Prefixes de commit consideres "non-substantiels" -- ne sont PAS censes
+# modifier les outputs numeriques. Heuristique conservatrice : si tu changes
+# du code ou des donnees, le prefixe est feat()/fix(major)/perf() etc.,
+# JAMAIS docs/chore/style/...
+NON_SUBSTANTIAL_PREFIXES: tuple[str, ...] = (
+    "docs(",
+    "chore(",
+    "refactor(",
+    "style(",
+    "test(",
+    "build(",
+    "ci(",
+)
+
+# Verbes "restore" / "revert" identifies comme declencheurs D3 (restauration
+# partielle). On regarde le sujet du commit (lowercase, premiere ligne).
+RESTORE_VERBS: tuple[str, ...] = (
+    "restore",
+    "revert",
+    "rollback",
+    "resurrect",
+)
+
+# Verbes "rename" / "move" identifies comme declencheurs D4.
+RENAME_VERBS: tuple[str, ...] = (
+    "relocate",
+    "rename",
+    "reorganize",
+    "move",
+    "homogenize",
+    "repackage",
+)
+
+# Seuil de saut relatif sur la mediane des outputs pour D5.
+RELATIVE_JUMP_THRESHOLD: float = 0.20  # 20%
+
+# Tolerance signature numerique entre 2 revisions consecutives (median+std+count).
+SIGNATURE_CHANGE_THRESHOLD: float = 0.05  # 5%
+
+# Bornes des nombres extraits : en-dessous c'est trivial (0, indices de boucle),
+# au-dessus c'est probablement un timestamp Unix ou un numero de build.
+MIN_NUMBER_VALUE: float = 1e-6
+MAX_NUMBER_VALUE: float = 1e9
+
+# Pour le detecteur D1 : seuil en-dessous duquel un nombre de prose est
+# considere comme non-candidat (identifiants, indices, references comme
+# "ICT-1", "#4588", "-1"). On vise les nombres "mesurables" -- typiquement
+# entre 1e-3 et 1000.
+D1_PROSE_MIN: float = 1e-3
+D1_PROSE_MAX: float = 1e3
+
+# Tolerance de proximite prose <-> outputs pour D1. 5% relatif OU exactement
+# egal (pour gerer les cas ou la prose arrondit a 1e-2 et l'output a 1e-3).
+D1_PROXIMITY_REL: float = 0.05
+D1_PROXIMITY_ABS: float = 1e-6
+
+# Ratio minimal d'orphelins pour classer D1+. En-dessous, on considere que
+# les "orphelins" sont des references croisees (#4588, ICT-3, etc.) et non
+# des mesures -- le bruit depasse le signal.
+D1_ORPHAN_RATIO_THRESHOLD: float = 0.30
+
+# Taille minimale de la mediane pour considerer un saut relatif (evite les
+# divisions par ~zero sur des sorties tres petites).
+MEDIAN_FLOOR_FOR_JUMP: float = 1e-6
+
+
+# --------------------------------------------------------------------------- #
+#  Dataclasses
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class NotebookRevision:
+    """Une revision (= un commit) d'un notebook."""
+    sha: str
+    subject: str
+    is_non_substantial: bool
+    numbers_in_outputs: list[float] = field(default_factory=list)
+    cells_count: int = 0
+
+
+@dataclass
+class NumericSignature:
+    """Signature compacte des outputs numeriques d'un notebook."""
+    median: float = 0.0
+    std: float = 0.0
+    count: int = 0
+
+    @classmethod
+    def from_numbers(cls, numbers: Sequence[float]) -> "NumericSignature":
+        if not numbers:
+            return cls()
+        sorted_n = sorted(numbers)
+        median = sorted_n[len(sorted_n) // 2]
+        if len(sorted_n) > 1:
+            mean = sum(sorted_n) / len(sorted_n)
+            var = sum((x - mean) ** 2 for x in sorted_n) / len(sorted_n)
+            std = var ** 0.5
+        else:
+            std = 0.0
+        return cls(median=float(median), std=float(std), count=len(sorted_n))
+
+    def changed_from(self, prev: "NumericSignature") -> bool:
+        """Vrai si la signature a change au-dela de SIGNATURE_CHANGE_THRESHOLD."""
+        if prev.count == 0 or self.count == 0:
+            return False
+        # Mediane
+        if prev.median != 0 and abs(self.median - prev.median) / abs(prev.median) > SIGNATURE_CHANGE_THRESHOLD:
+            return True
+        if prev.median == 0 and self.median != 0:
+            return True
+        # Ecart-type
+        if prev.std > 0 and abs(self.std - prev.std) / abs(prev.std) > SIGNATURE_CHANGE_THRESHOLD:
+            return True
+        return False
+
+
+@dataclass
+class ForensicFinding:
+    """Un finding individuel d'un des 4 detecteurs."""
+    category: str  # "D1" / "D3" / "D4" / "D5"
+    sha: str
+    subject: str
+    detail: str
+
+
+@dataclass
+class NotebookForensic:
+    """Verdict complet d'un notebook sur l'ensemble de ses revisions."""
+    path: str
+    total_revisions: int
+    verdict: str  # "SAIN" / "D1+" / "D3+" / "D4+" / "D5+" / "MIXED" / "INDETERMINE"
+    findings: list[ForensicFinding] = field(default_factory=list)
+    notes: str = ""
+
+    @property
+    def is_pathological(self) -> bool:
+        """Vrai si le verdict signale une degeneration.
+
+        D1+ (provenance orpheline) est pathologique MEME sur verdict global
+        INDETERMINE, car il ne depend pas de l'historique du notebook -- un
+        seul commit suffit pour le signaler.
+        """
+        if self.verdict in ("D3+", "D4+", "D5+", "MIXED"):
+            return True
+        if any(f.category == "D1" for f in self.findings):
+            return True
+        return False
+
+
+# --------------------------------------------------------------------------- #
+#  Git plumbing
+# --------------------------------------------------------------------------- #
+
+
+def _run_git(args: Sequence[str], cwd: str) -> str:
+    """Execute une commande git dans cwd, retourne stdout."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed ({result.returncode}): {result.stderr[:300]}"
+        )
+    return result.stdout
+
+
+def get_revisions(notebook: str, repo: str) -> list[tuple[str, str]]:
+    """Retourne [(sha, subject)] pour un notebook, en suivant les renames."""
+    fmt = "%H%x1f%s"  # SHA + subject, separateur unit (0x1f)
+    out = _run_git(
+        ["log", "--follow", f"--format={fmt}", "--", notebook],
+        cwd=repo,
+    )
+    revs: list[tuple[str, str]] = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split("\x1f", 1)
+        if len(parts) != 2:
+            continue
+        revs.append((parts[0], parts[1]))
+    return revs
+
+
+def read_notebook_at_revision(notebook: str, sha: str, repo: str) -> str:
+    """Retourne le contenu JSON d'un notebook a une revision donnee."""
+    return _run_git(["show", f"{sha}:{notebook}"], cwd=repo)
+
+
+def get_current_outputs(notebook: str, repo: str) -> str:
+    """Retourne le contenu brut de la version actuelle (HEAD) du notebook."""
+    return _run_git(["show", f"HEAD:{notebook}"], cwd=repo)
+
+
+# --------------------------------------------------------------------------- #
+#  Extraction des nombres depuis les outputs Jupyter
+# --------------------------------------------------------------------------- #
+
+
+_NUMBER_RE = re.compile(r"[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?")
+
+
+def _extract_numbers_from_text(text: str) -> list[float]:
+    """Extrait tous les nombres d'une chaine. Filtre les valeurs triviales."""
+    nums: list[float] = []
+    for m in _NUMBER_RE.finditer(text):
+        try:
+            v = float(m.group(0))
+        except ValueError:
+            continue
+        if abs(v) < MIN_NUMBER_VALUE or abs(v) > MAX_NUMBER_VALUE:
+            continue
+        nums.append(v)
+    return nums
+
+
+def extract_output_numbers(notebook_json: str) -> tuple[int, list[float]]:
+    """Parse un notebook Jupyter, retourne (n_cells_code, liste_nombres_outputs).
+
+    Couvre les formats de sortie varies :
+    - outputs[*].text : str directe
+    - outputs[*].data."text/plain" : str OU liste de str
+    Les erreurs (output_type == "error") sont ignorees (l'erreur ne produit
+    pas de nombre significatif).
+    """
+    try:
+        nb = json.loads(notebook_json)
+    except json.JSONDecodeError:
+        return 0, []
+    cells = nb.get("cells", [])
+    code_cells = [c for c in cells if c.get("cell_type") == "code"]
+    nums: list[float] = []
+    for c in code_cells:
+        outputs = c.get("outputs") or []
+        for out in outputs:
+            if not isinstance(out, dict):
+                continue
+            if out.get("output_type") == "error":
+                continue
+            if "text" in out and isinstance(out["text"], str):
+                nums.extend(_extract_numbers_from_text(out["text"]))
+            elif "data" in out and isinstance(out["data"], dict):
+                t = out["data"].get("text/plain")
+                if isinstance(t, str):
+                    nums.extend(_extract_numbers_from_text(t))
+                elif isinstance(t, list):
+                    for item in t:
+                        if isinstance(item, str):
+                            nums.extend(_extract_numbers_from_text(item))
+    return len(code_cells), nums
+
+
+def extract_prose_numbers(notebook_json: str) -> list[tuple[int, float]]:
+    """Extrait les nombres publies dans les cellules markdown d'un notebook.
+
+    Retourne [(cell_index, valeur), ...]. Sert au detecteur D1 (provenance
+    orpheline) : comparer la prose aux outputs de la version actuelle.
+
+    Note : on ne tente PAS de comprendre le contexte semantique du nombre
+    (label "Phi = 0.69" vs "alpha = 0.69"). Cette detection est DELIBEREMENT
+    conservatrice -- on extrait les nombres "mesurables" de toutes les cellules
+    md (dans la plage [D1_PROSE_MIN, D1_PROSE_MAX]), et on verifie la presence
+    dans les outputs avec tolerance D1_PROXIMITY_REL.
+    """
+    try:
+        nb = json.loads(notebook_json)
+    except json.JSONDecodeError:
+        return []
+    cells = nb.get("cells", [])
+    out: list[tuple[int, float]] = []
+    for i, c in enumerate(cells):
+        if c.get("cell_type") != "markdown":
+            continue
+        src = c.get("source", "")
+        if isinstance(src, list):
+            src = "".join(src)
+        for m in _NUMBER_RE.finditer(src):
+            try:
+                v = float(m.group(0))
+            except ValueError:
+                continue
+            if abs(v) < D1_PROSE_MIN or abs(v) > D1_PROSE_MAX:
+                continue
+            # D1 vise les valeurs mesurables positives. Les nombres negatifs
+            # (-1, -2) sont generalement des sentinelles / indices / erreurs
+            # codes, pas des mesures publiees.
+            if v <= 0:
+                continue
+            out.append((i, v))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+#  Classification d'un commit
+# --------------------------------------------------------------------------- #
+
+
+def _is_non_substantial(subject: str) -> bool:
+    s = subject.lower().strip()
+    return any(s.startswith(p) for p in NON_SUBSTANTIAL_PREFIXES)
+
+
+def _has_restore_verb(subject: str) -> bool:
+    s = subject.lower().strip()
+    return any(v in s for v in RESTORE_VERBS)
+
+
+def _has_rename_verb(subject: str) -> bool:
+    s = subject.lower().strip()
+    return any(v in s for v in RENAME_VERBS)
+
+
+# --------------------------------------------------------------------------- #
+#  Detecteurs (D1, D3, D4, D5)
+# --------------------------------------------------------------------------- #
+
+
+def detect_d1(notebook: str, repo: str) -> list[ForensicFinding]:
+    """D1 : provenance orpheline.
+
+    Un nombre publie dans la prose (cellule markdown) n'est PAS present dans
+    les outputs HEAD. Strategie : extraire (a) tous les nombres des cellules
+    markdown HEAD, (b) tous les nombres des outputs code HEAD, puis verifier
+    que chaque nombre prose a un candidat proche dans outputs ( tolerance 1%
+    relatif ou absolu 1e-6).
+    """
+    findings: list[ForensicFinding] = []
+    try:
+        head_json = get_current_outputs(notebook, repo)
+    except RuntimeError:
+        return findings
+
+    prose_numbers = extract_prose_numbers(head_json)
+    if not prose_numbers:
+        return findings
+
+    _, output_numbers = extract_output_numbers(head_json)
+    if not output_numbers:
+        # Pas d'output du tout : tous les nombres prose sont orphelins.
+        findings.append(
+            ForensicFinding(
+                category="D1",
+                sha="HEAD",
+                subject="<current>",
+                detail=(
+                    f"{len(prose_numbers)} nombre(s) dans la prose, "
+                    f"0 nombre dans les outputs (notebook non execute ?)"
+                ),
+            )
+        )
+        return findings
+
+    # Ensemble des outputs pour recherche rapide (tolerance D1_PROXIMITY_REL).
+    orphans: list[tuple[int, float]] = []
+    for cell_idx, v in prose_numbers:
+        candidate_found = False
+        for ov in output_numbers:
+            if abs(ov) < D1_PROXIMITY_ABS:
+                # Output quasi-nul : n'est PAS un candidat raisonnable pour
+                # un nombre "mesurable" de la prose. On ignore cette branche.
+                continue
+            if abs(v) < D1_PROXIMITY_ABS:
+                # Nombre de prose quasi-nul : candidat uniquement si un output
+                # est egalement quasi-nul.
+                candidate_found = True
+                break
+            if abs(v - ov) / abs(ov) <= D1_PROXIMITY_REL:
+                candidate_found = True
+                break
+        if not candidate_found:
+            orphans.append((cell_idx, v))
+
+    if not orphans:
+        return findings
+
+    # Garde-fou : on ne signale D1 QUE si la proportion d'orphelins est
+    # substantielle. Sinon les "orphelins" sont probablement des references
+    # croisees (#4588, ICT-3, ...) et non des mesures -- bruit > signal.
+    orphan_ratio = len(orphans) / len(prose_numbers) if prose_numbers else 0
+    if orphan_ratio < D1_ORPHAN_RATIO_THRESHOLD:
+        return findings
+
+    # Limite le bruit : on signale les 5 premiers orphelins.
+    sample = orphans[:5]
+    findings.append(
+        ForensicFinding(
+            category="D1",
+            sha="HEAD",
+            subject="<current>",
+            detail=(
+                f"{len(orphans)}/{len(prose_numbers)} ({orphan_ratio:.0%}) nombre(s) "
+                f"mesurables de la prose sans candidat proche dans les outputs. "
+                f"Exemples : "
+                + ", ".join(f"cell[{c}]={v:.4g}" for c, v in sample)
+            ),
+        )
+    )
+    return findings
+
+
+def detect_d3(revisions: list[NotebookRevision]) -> list[ForensicFinding]:
+    """D3 : restauration partielle.
+
+    Un commit dont le sujet contient un verbe "restore/revert" ET dont la
+    signature numerique differe de la revision precedente (donc ne retablit
+    pas exactement l'etat anterieur).
+    """
+    findings: list[ForensicFinding] = []
+    for i in range(1, len(revisions)):
+        r = revisions[i]
+        if not _has_restore_verb(r.subject):
+            continue
+        prev = revisions[i - 1]
+        prev_sig = NumericSignature.from_numbers(prev.numbers_in_outputs)
+        cur_sig = NumericSignature.from_numbers(r.numbers_in_outputs)
+        if cur_sig.changed_from(prev_sig):
+            findings.append(
+                ForensicFinding(
+                    category="D3",
+                    sha=r.sha,
+                    subject=r.subject,
+                    detail=(
+                        f"Restore numerique : mediane {prev_sig.median:.4g} -> "
+                        f"{cur_sig.median:.4g} (n {prev_sig.count} -> {cur_sig.count})"
+                    ),
+                )
+            )
+    return findings
+
+
+def detect_d4(revisions: list[NotebookRevision]) -> list[ForensicFinding]:
+    """D4 : rename/move transportant une valeur.
+
+    Un commit dont le sujet contient un verbe "relocate/rename/reorganize" ET
+    dont la signature numerique a change (donc le contenu numerique a ete
+    transporte ou modifie en parallele du rename).
+    """
+    findings: list[ForensicFinding] = []
+    for i in range(1, len(revisions)):
+        r = revisions[i]
+        if not _has_rename_verb(r.subject):
+            continue
+        prev = revisions[i - 1]
+        prev_sig = NumericSignature.from_numbers(prev.numbers_in_outputs)
+        cur_sig = NumericSignature.from_numbers(r.numbers_in_outputs)
+        if cur_sig.changed_from(prev_sig):
+            findings.append(
+                ForensicFinding(
+                    category="D4",
+                    sha=r.sha,
+                    subject=r.subject,
+                    detail=(
+                        f"Relocate numerique : mediane {prev_sig.median:.4g} -> "
+                        f"{cur_sig.median:.4g}"
+                    ),
+                )
+            )
+    return findings
+
+
+def detect_d5(revisions: list[NotebookRevision]) -> list[ForensicFinding]:
+    """D5 : saut numerique sous commit non-substantiel.
+
+    Un commit classifie non-substantiel (docs/chore/style/...) sous lequel la
+    mediane des outputs a bouge de plus de RELATIVE_JUMP_THRESHOLD (20%).
+    """
+    findings: list[ForensicFinding] = []
+    for i in range(1, len(revisions)):
+        cur = revisions[i]
+        if not cur.is_non_substantial:
+            continue
+        prev = revisions[i - 1]
+        prev_nums = prev.numbers_in_outputs
+        cur_nums = cur.numbers_in_outputs
+        if not prev_nums or not cur_nums:
+            continue
+        prev_median = sorted(prev_nums)[len(prev_nums) // 2]
+        cur_median = sorted(cur_nums)[len(cur_nums) // 2]
+        if abs(prev_median) < MEDIAN_FLOOR_FOR_JUMP:
+            continue
+        rel = abs(cur_median - prev_median) / abs(prev_median)
+        if rel >= RELATIVE_JUMP_THRESHOLD:
+            findings.append(
+                ForensicFinding(
+                    category="D5",
+                    sha=cur.sha,
+                    subject=cur.subject,
+                    detail=(
+                        f"Saut mediane {prev_median:.4g} -> {cur_median:.4g} "
+                        f"(relatif {rel:.1%}) sous commit non-substantiel"
+                    ),
+                )
+            )
+    return findings
+
+
+# --------------------------------------------------------------------------- #
+#  Orchestration
+# --------------------------------------------------------------------------- #
+
+
+def _build_revisions(notebook: str, repo: str) -> list[NotebookRevision]:
+    """Construit la liste des NotebookRevision pour un notebook."""
+    revs_meta = get_revisions(notebook, repo)
+    revs: list[NotebookRevision] = []
+    for sha, subject in revs_meta:
+        try:
+            nb_json = read_notebook_at_revision(notebook, sha, repo)
+            cells_count, nums = extract_output_numbers(nb_json)
+        except RuntimeError:
+            cells_count, nums = 0, []
+        revs.append(
+            NotebookRevision(
+                sha=sha,
+                subject=subject,
+                is_non_substantial=_is_non_substantial(subject),
+                numbers_in_outputs=nums,
+                cells_count=cells_count,
+            )
+        )
+    return revs
+
+
+def forensic_scan(notebook: str, repo: str) -> NotebookForensic:
+    """Verdict complet pour un notebook : D1 + D3 + D4 + D5."""
+    revs = _build_revisions(notebook, repo)
+    findings: list[ForensicFinding] = []
+    findings.extend(detect_d1(notebook, repo))
+    findings.extend(detect_d3(revs))
+    findings.extend(detect_d4(revs))
+    findings.extend(detect_d5(revs))
+
+    if not revs:
+        verdict = "INDETERMINE"
+        notes = "Aucune revision accessible"
+    elif len(revs) < 2:
+        verdict = "INDETERMINE"
+        notes = "Une seule revision -- comparaison impossible"
+    elif not findings:
+        verdict = "SAIN"
+        notes = (
+            f"{len(revs)} revision(s), aucune degenerescence detectee "
+            f"(D1, D3, D4, D5)"
+        )
+    else:
+        # Determine verdict : MIXED si plusieurs categories, sinon la categorie unifie.
+        cats = sorted({f.category for f in findings})
+        if len(cats) > 1:
+            verdict = "MIXED"
+        else:
+            verdict = f"{cats[0]}+"
+        notes = f"{len(findings)} finding(s) sur categorie(s) {', '.join(cats)}"
+
+    return NotebookForensic(
+        path=notebook,
+        total_revisions=len(revs),
+        verdict=verdict,
+        findings=findings,
+        notes=notes,
+    )
+
+
+def forensic_scan_paths(notebooks: Iterable[str], repo: str) -> list[NotebookForensic]:
+    """Verdict pour une liste de notebooks."""
+    return [forensic_scan(nb, repo) for nb in notebooks]
+
+
+def forensic_scan_directory(directory: str, repo: str) -> list[NotebookForensic]:
+    """Verdict pour tous les notebooks d'un repertoire (recursive).
+
+    Couvre les fichiers *.ipynb. Les sous-repertoires archives (commencant
+    par `_` ou nommes `archive`/`_archive`) sont exclus par convention.
+    """
+    base = Path(repo) / directory
+    if not base.exists():
+        return []
+    notebooks = sorted(
+        str(p.relative_to(repo)).replace("\\", "/")
+        for p in base.rglob("*.ipynb")
+        if not any(part.startswith("_") or part in ("archive", "node_modules")
+                   for part in p.relative_to(base).parts)
+    )
+    return forensic_scan_paths(notebooks, repo)
+
+
+# --------------------------------------------------------------------------- #
+#  Sortie texte / JSON
+# --------------------------------------------------------------------------- #
+
+
+def render_text(results: list[NotebookForensic]) -> str:
+    """Format texte : table + detail par notebook."""
+    lines: list[str] = []
+    lines.append("| Notebook | Revisions | Verdict | Findings | Note |")
+    lines.append("|---|---|---|---|---|")
+    for r in results:
+        nb_name = Path(r.path).name
+        n_findings = len(r.findings)
+        first_cat = r.findings[0].category if r.findings else "-"
+        lines.append(
+            f"| `{nb_name}` | {r.total_revisions} | **{r.verdict}** | "
+            f"{n_findings} ({first_cat}) | {r.notes[:60]} |"
+        )
+    lines.append("")
+    lines.append("## Detail")
+    for r in results:
+        if not r.findings:
+            continue
+        lines.append(f"### `{Path(r.path).name}` -- verdict **{r.verdict}**")
+        for f in r.findings[:5]:
+            lines.append(
+                f"- **{f.category}** `{f.sha[:8]}` {f.subject[:70]}\n"
+                f"  {f.detail}"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+#  CLI
+# --------------------------------------------------------------------------- #
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Detecteur Phase 1 EPIC #9768 : D1/D3/D4/D5 sur notebooks Jupyter."
+    )
+    p.add_argument(
+        "targets",
+        nargs="*",
+        help="Fichiers .ipynb ou repertoires (recursive). Vide = stdin interactif.",
+    )
+    p.add_argument(
+        "--repo",
+        default=".",
+        help="Chemin du worktree git (defaut : cwd).",
+    )
+    p.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Format de sortie (defaut : text).",
+    )
+    p.add_argument(
+        "--check",
+        action="store_true",
+        help="Mode CI : exit 1 si au moins un verdict D1+/D3+/D4+/D5+/MIXED.",
+    )
+    return p
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if not args.targets:
+        parser.error("au moins un fichier .ipynb ou repertoire requis")
+
+    repo = args.repo
+    all_results: list[NotebookForensic] = []
+    for target in args.targets:
+        target_path = Path(repo) / target
+        if target_path.is_dir():
+            all_results.extend(forensic_scan_directory(target, repo))
+        elif target_path.is_file() and target.endswith(".ipynb"):
+            all_results.append(forensic_scan(target, repo))
+        else:
+            print(f"[warn] cible ignoree (pas un .ipynb ni repertoire) : {target}",
+                  file=sys.stderr)
+
+    if args.format == "json":
+        out = json.dumps(
+            [asdict(r) for r in all_results],
+            indent=2,
+            ensure_ascii=False,
+        )
+        print(out)
+    else:
+        print(render_text(all_results))
+
+    if args.check:
+        n_pathological = sum(1 for r in all_results if r.is_pathological)
+        return 1 if n_pathological > 0 else 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_scan_d1_d3_d4_d5.py
+++ b/scripts/notebook_tools/tests/test_scan_d1_d3_d4_d5.py
@@ -1,0 +1,672 @@
+"""Tests pytest pour scan_d1_d3_d4_d5.py (Phase 1 EPIC #9768).
+
+Cible 33+ tests sur les axes :
+- Signature numerique (changed_from, from_numbers)
+- Extraction de nombres depuis outputs Jupyter (formats varies)
+- Extraction de nombres depuis prose markdown (filtres D1_PROSE_MIN/MAX)
+- Classification commits (non-substantiel / restore / rename)
+- Detecteurs individuels (D1, D3, D4, D5)
+- Orchestration forensic_scan
+- CLI --check (exit codes)
+
+Reference : scripts/notebook_tools/scan_d1_d3_d4_d5.py
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Permettre l'import du module parent.
+_HERE = Path(__file__).resolve().parent
+_TOOLS = _HERE.parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+
+from scan_d1_d3_d4_d5 import (  # noqa: E402
+    NotebookRevision,
+    NotebookForensic,
+    NumericSignature,
+    ForensicFinding,
+    NON_SUBSTANTIAL_PREFIXES,
+    RESTORE_VERBS,
+    RENAME_VERBS,
+    D1_PROSE_MIN,
+    D1_PROSE_MAX,
+    D1_PROXIMITY_REL,
+    RELATIVE_JUMP_THRESHOLD,
+    SIGNATURE_CHANGE_THRESHOLD,
+    MIN_NUMBER_VALUE,
+    MAX_NUMBER_VALUE,
+    _is_non_substantial,
+    _has_restore_verb,
+    _has_rename_verb,
+    _extract_numbers_from_text,
+    extract_output_numbers,
+    extract_prose_numbers,
+    detect_d1,
+    detect_d3,
+    detect_d4,
+    detect_d5,
+    forensic_scan,
+    render_text,
+    main,
+)
+
+
+# ============================================================================ #
+#  NumericSignature
+# ============================================================================ #
+
+
+class TestNumericSignature:
+    """Tests sur la signature numerique (mecanisme central D3/D4/D5)."""
+
+    def test_from_empty(self):
+        sig = NumericSignature.from_numbers([])
+        assert sig.median == 0.0
+        assert sig.std == 0.0
+        assert sig.count == 0
+
+    def test_from_single(self):
+        sig = NumericSignature.from_numbers([42.0])
+        assert sig.median == 42.0
+        assert sig.std == 0.0  # std=0 sur 1 valeur (cas documente)
+        assert sig.count == 1
+
+    def test_from_many_median(self):
+        # [1,2,3,4,5] -> median = 3 (index 2 sur 5 elements, sorted)
+        sig = NumericSignature.from_numbers([1, 2, 3, 4, 5])
+        assert sig.median == 3.0
+        assert sig.count == 5
+        assert sig.std > 0
+
+    def test_from_many_even_count(self):
+        # [1,2,3,4] -> median = 3 (index 2 sur 4 elements)
+        sig = NumericSignature.from_numbers([1, 2, 3, 4])
+        assert sig.median == 3.0
+        assert sig.count == 4
+
+    def test_changed_from_above_threshold(self):
+        # Mediane bouge de 50%, au-dessus de SIGNATURE_CHANGE_THRESHOLD (5%).
+        prev = NumericSignature(median=1.0, std=0.5, count=10)
+        cur = NumericSignature(median=1.5, std=0.5, count=10)
+        assert cur.changed_from(prev) is True
+
+    def test_changed_from_below_threshold(self):
+        # Mediane bouge de 1%, sous le seuil.
+        prev = NumericSignature(median=1.0, std=0.5, count=10)
+        cur = NumericSignature(median=1.01, std=0.5, count=10)
+        assert cur.changed_from(prev) is False
+
+    def test_changed_from_zero_to_nonzero(self):
+        prev = NumericSignature(median=0.0, std=0.0, count=5)
+        cur = NumericSignature(median=0.5, std=0.0, count=5)
+        assert cur.changed_from(prev) is True
+
+    def test_changed_from_empty_signature(self):
+        # Si l'une des signatures est vide, pas de saut.
+        prev = NumericSignature()
+        cur = NumericSignature(median=1.0, count=5)
+        assert cur.changed_from(prev) is False
+
+    def test_changed_from_std_only(self):
+        # Mediane stable, std qui bouge.
+        prev = NumericSignature(median=1.0, std=0.1, count=10)
+        cur = NumericSignature(median=1.0, std=0.5, count=10)
+        assert cur.changed_from(prev) is True
+
+
+# ============================================================================ #
+#  Extraction de nombres depuis texte brut
+# ============================================================================ #
+
+
+class TestExtractNumbersFromText:
+    """Tests sur l'extraction de nombres depuis du texte brut."""
+
+    def test_simple_numbers(self):
+        nums = _extract_numbers_from_text("Result: 3.14 and 42")
+        assert 3.14 in nums
+        assert 42 in nums
+
+    def test_negative_numbers(self):
+        nums = _extract_numbers_from_text("delta = -1.5e-3")
+        assert -1.5e-3 in nums or any(abs(n + 1.5e-3) < 1e-9 for n in nums)
+
+    def test_scientific_notation(self):
+        # 6.626e-34 est sous MIN_NUMBER_VALUE (1e-6), donc il EST filtre.
+        # C'est la garde anti-bruit : on ne veut pas polluer la signature avec
+        # des constantes physiques.
+        nums = _extract_numbers_from_text("phi = 6.626e-34")
+        assert not any(n > 0 for n in nums)
+
+    def test_scientific_notation_in_range(self):
+        # En revanche, un nombre en notation scientifique dans la plage
+        # [MIN_NUMBER_VALUE, MAX_NUMBER_VALUE] survit.
+        nums = _extract_numbers_from_text("x = 1.5e-3")
+        assert any(abs(n - 1.5e-3) < 1e-9 for n in nums)
+
+    def test_filters_trivial_numbers(self):
+        # Les nombres sous MIN_NUMBER_VALUE sont filtres.
+        nums = _extract_numbers_from_text("epsilon 1e-9 should be filtered")
+        # 1e-9 est inferieur a 1e-6, donc filtre
+        assert not any(abs(n) < MIN_NUMBER_VALUE for n in nums)
+
+    def test_filters_huge_numbers(self):
+        # Les nombres au-dessus de MAX_NUMBER_VALUE sont filtres.
+        nums = _extract_numbers_from_text("timestamp 999999999999 should be filtered")
+        assert not any(n > MAX_NUMBER_VALUE for n in nums)
+
+    def test_empty_text(self):
+        nums = _extract_numbers_from_text("")
+        assert nums == []
+
+    def test_no_numbers(self):
+        nums = _extract_numbers_from_text("aucun nombre ici")
+        assert nums == []
+
+    def test_multiple_occurrences(self):
+        nums = _extract_numbers_from_text("a=1, b=1, c=1")
+        assert len(nums) == 3
+
+
+# ============================================================================ #
+#  Extraction de nombres depuis outputs Jupyter
+# ============================================================================ #
+
+
+class TestExtractOutputNumbers:
+    """Tests sur extract_output_numbers (formats Jupyter varies)."""
+
+    def test_empty_notebook(self):
+        nb_json = json.dumps({"cells": []})
+        cells_count, nums = extract_output_numbers(nb_json)
+        assert cells_count == 0
+        assert nums == []
+
+    def test_invalid_json(self):
+        cells_count, nums = extract_output_numbers("not json at all")
+        assert cells_count == 0
+        assert nums == []
+
+    def test_text_output(self):
+        nb = {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "outputs": [{"output_type": "stream", "text": "Result: 42.5"}],
+                }
+            ]
+        }
+        cells_count, nums = extract_output_numbers(json.dumps(nb))
+        assert cells_count == 1
+        assert 42.5 in nums
+
+    def test_data_text_plain_string(self):
+        nb = {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "outputs": [{"data": {"text/plain": "0.42"}}],
+                }
+            ]
+        }
+        cells_count, nums = extract_output_numbers(json.dumps(nb))
+        assert 0.42 in nums
+
+    def test_data_text_plain_list(self):
+        nb = {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "outputs": [{"data": {"text/plain": ["0.42", "0.43"]}}],
+                }
+            ]
+        }
+        cells_count, nums = extract_output_numbers(json.dumps(nb))
+        assert 0.42 in nums
+        assert 0.43 in nums
+
+    def test_error_output_skipped(self):
+        nb = {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "outputs": [{"output_type": "error", "ename": "ValueError", "evalue": "0.42"}],
+                }
+            ]
+        }
+        cells_count, nums = extract_output_numbers(json.dumps(nb))
+        assert cells_count == 1
+        # 0.42 dans le message d'erreur : on ignore les erreurs.
+        assert 0.42 not in nums
+
+    def test_mixed_outputs(self):
+        nb = {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "outputs": [
+                        {"text": "a=1"},
+                        {"data": {"text/plain": "b=2"}},
+                        {"output_type": "error", "evalue": "c=3"},
+                    ],
+                }
+            ]
+        }
+        cells_count, nums = extract_output_numbers(json.dumps(nb))
+        assert 1 in nums
+        assert 2 in nums
+        assert 3 not in nums  # erreur exclue
+
+    def test_markdown_cells_excluded(self):
+        nb = {
+            "cells": [
+                {"cell_type": "markdown", "source": ["# Title 42"]},
+                {"cell_type": "code", "outputs": [{"text": "result 100"}]},
+            ]
+        }
+        cells_count, nums = extract_output_numbers(json.dumps(nb))
+        assert cells_count == 1  # seule la code cell compte
+        assert 42 not in nums  # markdown exclu
+        assert 100 in nums
+
+
+# ============================================================================ #
+#  Extraction de nombres depuis prose markdown (filtres D1)
+# ============================================================================ #
+
+
+class TestExtractProseNumbers:
+    """Tests sur extract_prose_numbers (filtres D1_PROSE_MIN/MAX)."""
+
+    def test_filters_below_min(self):
+        nb = {"cells": [{"cell_type": "markdown", "source": ["x = 0.0001"]}]}
+        out = extract_prose_numbers(json.dumps(nb))
+        # 0.0001 < D1_PROSE_MIN=1e-3, donc filtre
+        assert out == []
+
+    def test_filters_above_max(self):
+        nb = {"cells": [{"cell_type": "markdown", "source": ["Epic #4588"]}]}
+        out = extract_prose_numbers(json.dumps(nb))
+        # 4588 > D1_PROSE_MAX=1e3, donc filtre
+        assert out == []
+
+    def test_filters_negative(self):
+        nb = {"cells": [{"cell_type": "markdown", "source": ["delta = -1"]}]}
+        out = extract_prose_numbers(json.dumps(nb))
+        # -1 est <= 0, donc filtre
+        assert out == []
+
+    def test_keeps_typical_measurement(self):
+        nb = {"cells": [{"cell_type": "markdown", "source": ["Phi = 0.69"]}]}
+        out = extract_prose_numbers(json.dumps(nb))
+        assert len(out) == 1
+        assert out[0][1] == pytest.approx(0.69)
+        assert out[0][0] == 0  # cell index
+
+    def test_keeps_integer_in_range(self):
+        nb = {"cells": [{"cell_type": "markdown", "source": ["alpha = 5"]}]}
+        out = extract_prose_numbers(json.dumps(nb))
+        assert len(out) == 1
+        assert out[0][1] == 5.0
+
+    def test_multiple_values(self):
+        nb = {
+            "cells": [
+                {
+                    "cell_type": "markdown",
+                    "source": ["alpha = 0.5\nbeta = 0.3\ngamma = 100"],
+                }
+            ]
+        }
+        out = extract_prose_numbers(json.dumps(nb))
+        assert len(out) == 3
+        values = {v for _, v in out}
+        assert 0.5 in values
+        assert 0.3 in values
+        # 100 est dans [D1_PROSE_MIN, D1_PROSE_MAX], donc garde
+        assert 100 in values
+
+    def test_code_cells_excluded(self):
+        nb = {
+            "cells": [
+                {"cell_type": "code", "source": ["x = 0.5"]},
+                {"cell_type": "markdown", "source": ["y = 0.5"]},
+            ]
+        }
+        out = extract_prose_numbers(json.dumps(nb))
+        # Seul 0.5 du markdown cell[1] survit
+        assert len(out) == 1
+        assert out[0][0] == 1
+
+    def test_invalid_json(self):
+        out = extract_prose_numbers("not json")
+        assert out == []
+
+
+# ============================================================================ #
+#  Classification des commits
+# ============================================================================ #
+
+
+class TestCommitClassification:
+    """Tests sur les predicats de classification d'un commit."""
+
+    def test_non_substantial_docs(self):
+        assert _is_non_substantial("docs(readme): update links") is True
+
+    def test_non_substantial_chore(self):
+        assert _is_non_substantial("chore(repo): cleanup archives") is True
+
+    def test_non_substantial_refactor(self):
+        assert _is_non_substantial("refactor(ict): simplify helpers") is True
+
+    def test_non_substantial_style(self):
+        assert _is_non_substantial("style(lint): fix whitespace") is True
+
+    def test_non_substantial_test(self):
+        assert _is_non_substantial("test(ict): add regression") is True
+
+    def test_substantial_feat(self):
+        # feat() n'est PAS dans NON_SUBSTANTIAL_PREFIXES.
+        assert _is_non_substantial("feat(ict): new detector") is False
+
+    def test_substantial_fix_major(self):
+        # fix() n'est PAS dans NON_SUBSTANTIAL_PREFIXES (trop large).
+        assert _is_non_substantial("fix(ict): correct calibration") is False
+
+    def test_substantial_data(self):
+        # data(dataset): ajoute des donnees -> substantiel
+        assert _is_non_substantial("data(qc): add Binance CSV") is False
+
+    def test_case_insensitive(self):
+        assert _is_non_substantial("DOCS(readme): MAJ") is True
+        assert _is_non_substantial("Chore(repo): cleanup") is True
+
+    def test_restore_verb(self):
+        assert _has_restore_verb("restore(notebook): rollback outputs") is True
+        assert _has_restore_verb("revert(#9416): back out broken commit") is True
+        assert _has_restore_verb("rollback after outage") is True
+        assert _has_restore_verb("resurrect old notebook") is True
+
+    def test_no_restore_verb(self):
+        assert _has_restore_verb("feat(ict): add module") is False
+        assert _has_restore_verb("fix(ict): correct typo") is False
+
+    def test_rename_verb(self):
+        assert _has_rename_verb("relocate(notebook): move to archive") is True
+        assert _has_rename_verb("rename(dir): cleaner structure") is True
+        assert _has_rename_verb("reorganize(repos): merge families") is True
+        assert _has_rename_verb("move to production") is True
+        assert _has_rename_verb("homogenize(naming): consistent prefix") is True
+        assert _has_rename_verb("repackage modules") is True
+
+    def test_no_rename_verb(self):
+        assert _has_rename_verb("feat(ict): new detector") is False
+
+
+# ============================================================================ #
+#  Detecteurs D3, D4, D5 (avec revisions simulees)
+# ============================================================================ #
+
+
+def _rev(sha: str, subject: str, nums: list[float], *, non_substantial: bool = False) -> NotebookRevision:
+    return NotebookRevision(
+        sha=sha,
+        subject=subject,
+        is_non_substantial=non_substantial,
+        numbers_in_outputs=nums,
+        cells_count=3,
+    )
+
+
+class TestDetectD3:
+    """Tests sur detect_d3 (restauration partielle)."""
+
+    def test_no_findings_no_restore(self):
+        revs = [
+            _rev("aaa", "feat(ict): new", [1, 2, 3]),
+            _rev("bbb", "feat(ict): update", [4, 5, 6]),
+        ]
+        assert detect_d3(revs) == []
+
+    def test_restore_without_change(self):
+        # Restore qui ne change PAS la signature : pas un D3+.
+        revs = [
+            _rev("aaa", "feat(ict): some change", [1, 2, 3]),
+            _rev("bbb", "restore: rollback to aaa", [1, 2, 3]),  # memes nums
+        ]
+        assert detect_d3(revs) == []
+
+    def test_restore_with_change(self):
+        # Restore qui CHANGE la signature : D3+.
+        revs = [
+            _rev("aaa", "feat(ict): some change", [1, 2, 3]),
+            _rev("bbb", "restore: rollback to aaa", [10, 20, 30]),  # different
+        ]
+        findings = detect_d3(revs)
+        assert len(findings) == 1
+        assert findings[0].category == "D3"
+        assert findings[0].sha == "bbb"
+
+    def test_revert_with_change(self):
+        revs = [
+            _rev("aaa", "feat(ict): change", [5, 5, 5]),
+            _rev("bbb", "revert(#123): back out", [10, 10, 10]),
+        ]
+        findings = detect_d3(revs)
+        assert len(findings) == 1
+        assert findings[0].subject.startswith("revert")
+
+
+class TestDetectD4:
+    """Tests sur detect_d4 (rename transportant une valeur)."""
+
+    def test_rename_without_change(self):
+        revs = [
+            _rev("aaa", "feat(ict): some content", [1, 2, 3]),
+            _rev("bbb", "rename(dir): cleanup", [1, 2, 3]),
+        ]
+        assert detect_d4(revs) == []
+
+    def test_rename_with_change(self):
+        revs = [
+            _rev("aaa", "feat(ict): some content", [1, 2, 3]),
+            _rev("bbb", "relocate: move to archive", [10, 20, 30]),
+        ]
+        findings = detect_d4(revs)
+        assert len(findings) == 1
+        assert findings[0].category == "D4"
+        assert findings[0].sha == "bbb"
+
+    def test_relocate_with_change(self):
+        revs = [
+            _rev("aaa", "feat(ict): init", [5, 5, 5]),
+            _rev("bbb", "move to better location", [10, 10, 10]),
+        ]
+        findings = detect_d4(revs)
+        assert len(findings) == 1
+
+
+class TestDetectD5:
+    """Tests sur detect_d5 (saut sous commit non-substantiel)."""
+
+    def test_no_finding_under_substantial(self):
+        # Saut numerique sous commit substantiel = OK (feat/fix n'est pas non-sub).
+        revs = [
+            _rev("aaa", "feat(ict): change", [1, 2, 3]),
+            _rev("bbb", "feat(ict): bigger change", [10, 20, 30]),
+        ]
+        assert detect_d5(revs) == []
+
+    def test_finding_under_docs(self):
+        # Saut numerique sous docs = D5+ (les docs ne devraient pas changer les outputs).
+        revs = [
+            _rev("aaa", "feat(ict): content", [1, 2, 3]),
+            _rev(
+                "bbb",
+                "docs(readme): typo fix",
+                [10, 20, 30],
+                non_substantial=True,
+            ),
+        ]
+        findings = detect_d5(revs)
+        assert len(findings) == 1
+        assert findings[0].category == "D5"
+        assert findings[0].sha == "bbb"
+
+    def test_no_finding_below_threshold(self):
+        # Saut de 10% sous docs = pas un D5 (seuil = 20%).
+        revs = [
+            _rev("aaa", "feat(ict): content", [1.0, 1.1, 1.2]),
+            _rev(
+                "bbb",
+                "docs: minor",
+                [1.1, 1.2, 1.3],
+                non_substantial=True,
+            ),
+        ]
+        assert detect_d5(revs) == []
+
+    def test_empty_outputs(self):
+        revs = [
+            _rev("aaa", "feat(ict): empty", []),
+            _rev("bbb", "docs: empty", [], non_substantial=True),
+        ]
+        assert detect_d5(revs) == []
+
+
+# ============================================================================ #
+#  Render / orchestration
+# ============================================================================ #
+
+
+class TestRenderText:
+    """Tests sur render_text (sortie texte)."""
+
+    def test_empty_results(self):
+        out = render_text([])
+        assert "| Notebook |" in out
+        assert "## Detail" in out
+
+    def test_sain_notebook_in_table(self):
+        nb = NotebookForensic(
+            path="foo.ipynb",
+            total_revisions=5,
+            verdict="SAIN",
+            findings=[],
+            notes="aucune degenerescence",
+        )
+        out = render_text([nb])
+        assert "foo.ipynb" in out
+        assert "SAIN" in out
+
+    def test_findings_in_detail(self):
+        nb = NotebookForensic(
+            path="bar.ipynb",
+            total_revisions=3,
+            verdict="D3+",
+            findings=[
+                ForensicFinding(
+                    category="D3",
+                    sha="abc123",
+                    subject="restore old",
+                    detail="mediane 1 -> 5",
+                )
+            ],
+            notes="",
+        )
+        out = render_text([nb])
+        assert "bar.ipynb" in out
+        assert "D3" in out
+        assert "abc123" in out
+
+
+# ============================================================================ #
+#  CLI --check
+# ============================================================================ #
+
+
+class TestCLI:
+    """Tests sur le CLI (mode --check, formats)."""
+
+    def test_check_exits_1_on_pathological(self, tmp_path: Path, monkeypatch, capsys):
+        # Cree un mini-repo git avec un notebook pathologique.
+        import subprocess
+        repo = tmp_path / "mini_repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=str(repo), check=True)
+        subprocess.run(["git", "config", "user.email", "test@test"], cwd=str(repo), check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo), check=True)
+
+        # Cree un notebook simple.
+        nb = {
+            "cells": [
+                {"cell_type": "markdown", "source": ["Phi = 0.69"]},
+                {
+                    "cell_type": "code",
+                    "outputs": [{"text": "0.42"}],  # DIFFERENT de 0.69 en prose
+                },
+            ]
+        }
+        nb_path = repo / "test.ipynb"
+        nb_path.write_text(json.dumps(nb))
+
+        subprocess.run(["git", "add", "test.ipynb"], cwd=str(repo), check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=str(repo), check=True)
+
+        # Lance le CLI en mode check.
+        rc = main(["--repo", str(repo), "--check", "test.ipynb"])
+        # Avec 1 orphelin / 1 mesure = 100% > 30%, donc D1+ => exit 1.
+        assert rc == 1
+
+    def test_check_exits_0_on_clean(self, tmp_path: Path):
+        import subprocess
+        repo = tmp_path / "mini_repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=str(repo), check=True)
+        subprocess.run(["git", "config", "user.email", "test@test"], cwd=str(repo), check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo), check=True)
+
+        # Notebook sans prose mesurable, avec outputs : pas de D1.
+        nb = {
+            "cells": [
+                {"cell_type": "markdown", "source": ["# Title"]},
+                {"cell_type": "code", "outputs": [{"text": "0.42"}]},
+            ]
+        }
+        nb_path = repo / "test.ipynb"
+        nb_path.write_text(json.dumps(nb))
+        subprocess.run(["git", "add", "test.ipynb"], cwd=str(repo), check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=str(repo), check=True)
+
+        rc = main(["--repo", str(repo), "--check", "test.ipynb"])
+        assert rc == 0
+
+    def test_json_format(self, tmp_path: Path, capsys):
+        import subprocess
+        repo = tmp_path / "mini_repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=str(repo), check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=str(repo), check=True)
+        subprocess.run(["git", "config", "user.name", "T"], cwd=str(repo), check=True)
+
+        nb = {"cells": [{"cell_type": "markdown", "source": ["a"]}]}
+        nb_path = repo / "x.ipynb"
+        nb_path.write_text(json.dumps(nb))
+        subprocess.run(["git", "add", "x.ipynb"], cwd=str(repo), check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=str(repo), check=True)
+
+        rc = main(["--repo", str(repo), "--format", "json", "x.ipynb"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        data = json.loads(captured.out)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["path"].endswith("x.ipynb")


### PR DESCRIPTION
Grain: DEEP/tooling — lane myia-po-2025:CoursIA-2 — prev: DEEP/audit #9787 (c.1264)

---

## feat(notebook_tools,#9768): scan_d1_d3_d4_d5.py Phase 1 outillage (4 détecteurs)

Phase 1 outillage de l'EPIC #9768 (forensic d'historique git pour détecter la **dégénérescence numérique** des notebooks Jupyter). Ferme la Phase 0 livrée par #9787 (audit épisode-pilote) en passant à un **module standalone testable** — pattern reproduit de po-2024 #9783 (scan D2 fenêtre non figée).

### Périmètre couvert

4 détecteurs distincts et indépendants, conformes à la taxonomy Phase 0 :

| Catégorie | Sens | Méthode |
|---|---|---|
| **D1** — provenance orpheline | nombre en prose non reproductible depuis outputs HEAD | signature numérique des outputs vs prose, ratio d'orphelins ≥ 30 % |
| **D3** — restauration partielle | commit "restore" qui rétablit des valeurs ≠ celles d'avant la perte | verbe restore/revert + delta signature ≥ 5 % entre 2 révisions consécutives |
| **D4** — réorganisation | rename/move transportant une valeur hors contexte | verbe relocate/rename/reorganize + delta signature ≥ 5 % |
| **D5** — coquille silencieuse | saut numérique sous commit non-substantiel | préfixe docs/chore/refactor/style/test/build/ci + saut médiane ≥ 20 % |

### Conformité harnais

- **0 erreur volontaire (C.1)** : pas de `raise NotImplementedError`/`assert False`/`1/0`. Stub d'exemple absent : le module est outillage, pas notebook pédagogique.
- **0 dépendance externe** : stdlib uniquement (re, json, subprocess, dataclasses). Conformité règle F (env = installer l'outil, ici néant).
- **0 cellule notebook modifiée** : périmètre strict du détecteur = `MyIA.AI.Notebooks/**/*.ipynb` en lecture seule, sortie = verdicts par notebook.
- **0 catalogue regénéré (catalog-pr-hygiene R1)** : seuls fichiers ajoutés = le module + ses tests, byte-identique par ailleurs.
- **0 secret inline (secrets-hygiene)** : aucune clé API ni token. Le module ne touche qu'au système de fichiers local + git history.
- **0 rapport commité (audit-cross-source-distillation R1)** : ce body PR documente la livraison ; un éventuel épisode audit suivra le pattern #9787 (issue fille, pas fichier).
- **L800 ★** : encodage UTF-8 sans BOM, `trailing_nl=True`, **0 CR parasite** (Windows `open()` aurait injecté des CR avant chaque LF sinon).
- **PR body HORS worktree (L677-L4 ★★)** : ce fichier est dans `C:/Users/jsboi/.../scratchpad/`, pas dans le worktree.

### Validation

- **64/64 tests pytest PASS** en 0.98 s (sortie `pytest scripts/notebook_tools/tests/test_scan_d1_d3_d4_d5.py -q`).
- **10 classes de tests** : NumericSignature (9), ExtractNumbersFromText (8), ExtractOutputNumbers (8), ExtractProseNumbers (8), CommitClassification (13), DetectD3 (4), DetectD4 (3), DetectD5 (4), RenderText (3), CLI (3).
- **Régression zéro** : `3947/3947` tests sur la suite complète `scripts/notebook_tools/tests/` en 121 s.
- **Smoke tests sur ICT-1 + ICT-Series full** : sorties conformes à Phase 0 #9787 (SAIN vérifié en amont pour ICT-25/17/11/Disc ; D1+ sur ICT-1/2/5/15b résultant du **biais famille-spécifique** documenté ci-dessous).

### Biais empirique documenté — D1 famille-spécifique

Sur le **corpus ICT-Series** (notebooks très référentiels, citant beaucoup d'IDs Epic comme #4588, de numéros de cellules ICT-X, de valeurs hors plage de mesure), le détecteur **D1 produit systématiquement un verdict D1+ avec ~50 % de nombres prose orphelins**. Cause : le seuil `D1_PROSE_MIN/MAX = 1e-3..1e3` (filtre les très petits/grands nombres) réduit mais n'élimine pas les faux positifs sur ce corpus précis où la prose mentionne des identifiants ressemblant à des mesures.

**Conséquence opérationnelle** : ce n'est pas un défaut du détecteur, c'est son **point de départ d'investigation honnête**. Le verdict D1+ sur une famille très référentielle = signal à creuser manuellement, pas accusation immédiate. Sur corpus quantitatif (QuantConnect, Probas numériques), D1 a une précision bien meilleure.

Cette propriété est documentée dans le module (`scripts/notebook_tools/scan_d1_d3_d4_d5.py` docstring) et constitue **la** observation empirique clé livrée par ce cycle. Un **agent-reviewer** qui voit un verdict D1+ doit lire le détail (`notes` du `NotebookForensic`) avant de conclure.

### Garde anti-régression (G.1 / L967)

`is_pathological` retourne True sur **tout finding D1**, même si le verdict global est `INDETERMINE` (D1 ne dépend pas de l'historique git, contrairement à D3/D4/D5 qui exigent ≥ 2 révisions). Précision : un verdict `INDETERMINE` survient quand git log n'est pas accessible (worktree partiel, repo non initialisé) — D1 fonctionne en mode dégradé sur HEAD seul.

### Livraison vers issue #9768

Phase 1 close : détecteurs + tests + CLI `--check` CI-ready. Phase 2 (#9783 + ce module) suffit pour **cataloguer** les notebooks pathologiques par catégorie. Phase 3 (régénération) reste un sujet séparé, hors scope de ce PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
