### PR TITLE
feat(notebook_tools,#9790): scan_d5_prose_outputs_alignment.py v3 coherence prose <-> outputs intra-revision

### DIFF
--- a/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
@@ -1,0 +1,617 @@
+"""Detecteur v3 -- coherence prose <-> outputs intra-revision (D5), full-corpus.
+
+Suite logique de l'EPIC #9768 (Phase 1 outillage #9791 + Phase 0 audit #9787).
+Le detecteur D5 de :mod:`scan_d1_d3_d4_d5` compare les outputs **entre revisions
+consecutives** -- d'ou la dependance a l'historique git et l'impossibilite de
+signaler les drifts dont les outputs n'ont jamais bouge (cf. le cas fondateur
+ICT-1-PhiTrajectories commit ``7de14792c`` / issue #9416, prose « un pic a
+2,31, le reste a 0,19 » qui omettait le 3ᵉ niveau 0.6875 deja present dans
+les outputs ``cell[7]`` depuis toujours).
+
+Ce module leve cette limitation en travaillant **intra-revision** :
+il extrait les nombres de la prose (cellules markdown) et des outputs
+(cellules code) du **meme** notebook tel qu'il est sur disque (HEAD par
+defaut, ou n'importe quelle revision), puis signale deux classes de
+desalignement :
+
+1. **MISSING_FROM_OUTPUTS** : un nombre est affirme dans la prose mais n'a
+   aucun correspondant dans les outputs de la revision, a tolerance
+   relative 5% / absolue 1e-6 pres. Ex. : « Phi = 0.69 » alors que les
+   outputs ne contiennent que 0.1875 et 2.3125.
+2. **MISSING_FROM_PROSE_ENUMERATION** : la prose enumere une liste de
+   niveaux (ou valeurs distinctes) en indiquant un compte N, mais les
+   outputs exhibent strictement plus de niveaux distincts a tolerance
+   raisonnable. C'est la classe #9416 -- **la plus dangereuse**, parce que
+   la prose parait complete et l'omission est invisible a un lecteur qui
+   ne recompte pas les outputs.
+
+Pas de dependance externe. NumPy n'est PAS requis. CLI ``--check`` avec
+exit codes argparse 0/1/2 distincts (succes / finding / usage -- lecon
+po-2024 #9783 : un chemin inexistant ne PEUT PAS retourner 1).
+
+Cf. issue #9790 pour le scope exact et le cas fondateur.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+# --------------------------------------------------------------------------- #
+#  Configuration
+# --------------------------------------------------------------------------- #
+
+# Formes numeriques reconnues dans la prose francaise ET anglaise :
+# - decimale anglaise : 0.69, 1,234.56, 1e-3
+# - decimale francaise : 0,69 ; 1 234,56 ; 1,5e-3
+# On accepte virgule ET point comme separateurs ; l'ambiguite « 1,234 » est
+# resolue par contexte (presence d'un second separateur desambiguisant).
+FR_DECIMAL_RE = re.compile(
+    r"""
+    (?<![A-Za-z0-9_])              # pas au milieu d'un identifier
+    -?
+    (?:
+        \d{1,3}(?:[\s ]\d{3})*(?:[.,]\d+)?    # 1 234,56 ou 1,234.56
+      | \d+[.,]\d+                                  # 0.69 ou 0,69
+      | \d+                                         # 1234
+    )
+    (?:[eE][-+]?\d+)?
+    (?![A-Za-z0-9_])                # pas au milieu d'un identifier
+    """,
+    re.VERBOSE,
+)
+
+
+# Bruits a filtrer systematiquement : annees, numeros de PR / issue, versions.
+# On filtre en post-processing -- le filtre strict etait trop fragile en c.1264.
+EXCLUDE_PATTERNS = (
+    re.compile(r"^\d{4}$"),                # annees 1900-2099 (detectees par 4 chiffres seuls)
+    re.compile(r"^#\d+$"),                 # numeros d'issue/PR : #9416
+    re.compile(r"^v\d+$"),                 # versions semver simplifiees
+    re.compile(r"^cell\[\d+\]$"),          # indices cell[N]
+    re.compile(r"^[A-Z]+\d+$"),            # PRJ42, ABC123 -- discutable, mais limite
+)
+
+
+# Faux positifs semantiques : regex strictes (mot complet + caractere de
+# liaison) pour eviter de matcher au milieu d'une phrase legit.
+# Format : hint = substring qui DOIT etre immediatement suivi du nombre matche.
+SEMANTIC_FALSE_POSITIVE_HINTS = (
+    "## ", "### ", "#### ",            # titres markdown (ligne commence par titres)
+    "year ", "annee ",                  # contexte temporel
+    "PR #", "issue #", "cf. #", "see #",   # references croisees (suivi de #)
+    "§ ", "section ", "chapter ",      # structure
+    "depuis ", "after ", "before ",    # contexte temporel
+)
+
+
+# Tolerances pour le matching prose <-> outputs.
+RELATIVE_TOLERANCE = 0.05     # 5%
+ABSOLUTE_TOLERANCE = 1e-6
+
+# Bornes physiques pour eviter les nombres triviaux ou astronomiques.
+MIN_NUMBER_VALUE = 1e-9
+MAX_NUMBER_VALUE = 1e15
+
+
+# --------------------------------------------------------------------------- #
+#  Dataclasses
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class AlignmentFinding:
+    """Un cas de desalignement detecte."""
+    notebook: str
+    cell_index: int                  # index de la cellule markdown fautive
+    cell_kind: str                   # toujours 'markdown' ici
+    category: str                    # 'MISSING_FROM_OUTPUTS' ou 'MISSING_FROM_PROSE_ENUMERATION'
+    prose_text: str                  # extrait du markdown (tronque)
+    prose_number: float
+    closest_output_number: float | None
+    tolerance_used: str             # 'relative' ou 'absolute' ou 'none'
+    details: str = ""
+
+
+@dataclass
+class NotebookAlignment:
+    """Resultat d'analyse d'un notebook."""
+    path: str
+    total_findings: int
+    findings: list[AlignmentFinding]
+    n_prose_numbers: int = 0
+    n_output_numbers: int = 0
+    n_markdown_cells: int = 0
+    n_code_cells: int = 0
+    error: str | None = None
+
+    @property
+    def is_pathological(self) -> bool:
+        return self.total_findings > 0 and self.error is None
+
+
+# --------------------------------------------------------------------------- #
+#  Extraction de nombres
+# --------------------------------------------------------------------------- #
+
+
+def _parse_fr_number(text: str) -> float | None:
+    """Parse un token numerique au format FR ou EN vers float.
+
+    Heuristique : si le token contient un point ET une virgule, le dernier
+    des deux est le separateur decimal ; les autres sont des separateurs de
+    milliers et doivent etre retires. Sinon, la presence d'un des deux
+    suffit comme decimal.
+    """
+    t = text.replace(" ", "").replace(" ", "")  # espaces insécables
+    if not t:
+        return None
+    has_dot = "." in t
+    has_comma = "," in t
+    if has_dot and has_comma:
+        # dernier séparateur = décimal
+        if t.rfind(".") > t.rfind(","):
+            t = t.replace(",", "")
+        else:
+            t = t.replace(".", "").replace(",", ".")
+    elif has_comma:
+        t = t.replace(",", ".")
+    # Exposant e déjà ASCII
+    try:
+        v = float(t)
+    except ValueError:
+        return None
+    if abs(v) < MIN_NUMBER_VALUE or abs(v) > MAX_NUMBER_VALUE:
+        return None
+    return v
+
+
+def _extract_prose_numbers(text: str) -> list[float]:
+    """Extrait les nombres d'un texte markdown en filtrant les faux positifs semantiques."""
+    if not text:
+        return []
+    out: list[float] = []
+    for m in FR_DECIMAL_RE.finditer(text):
+        raw = m.group(0)
+        # Filtre bruit : années, numéros d'issue, etc.
+        if any(p.match(raw) for p in EXCLUDE_PATTERNS):
+            continue
+        # Filtre semantique : on regarde **la meme ligne** (avant-dernier
+        # newline), pas les 60 chars precedents. Un header `## 4.2` sur
+        # la ligne N ne doit pas filtrer un nombre legit sur la ligne N+1.
+        # Les hints sont concis (chacun demarre par un mot complet) pour
+        # eviter de matcher au milieu d'un titre.
+        line_start = text.rfind("\n", 0, m.start()) + 1
+        prefix = text[line_start:m.start()].lower()
+        if any(h in prefix for h in SEMANTIC_FALSE_POSITIVE_HINTS):
+            continue
+        v = _parse_fr_number(raw)
+        if v is None:
+            continue
+        out.append(v)
+    return out
+
+
+def _extract_output_numbers(output: dict) -> list[float]:
+    """Extrait les nombres d'un dict output Jupyter (text/plain ou data)."""
+    nums: list[float] = []
+    if not isinstance(output, dict):
+        return nums
+    # 1. 'text' peut etre str OU list[str] (format Jupyter stream).
+    t = output.get("text")
+    if isinstance(t, str):
+        nums.extend(_extract_prose_numbers(t))
+    elif isinstance(t, list):
+        for item in t:
+            if isinstance(item, str):
+                nums.extend(_extract_prose_numbers(item))
+    # 2. data['text/plain'] (liste ou string)
+    data = output.get("data")
+    if isinstance(data, dict):
+        tp = data.get("text/plain")
+        if isinstance(tp, str):
+            nums.extend(_extract_prose_numbers(tp))
+        elif isinstance(tp, list):
+            for item in tp:
+                if isinstance(item, str):
+                    nums.extend(_extract_prose_numbers(item))
+    # 3. data['text/latex'] ou similaire -- on laisse pour l'instant.
+    return nums
+
+
+# --------------------------------------------------------------------------- #
+#  Alignement prose <-> outputs
+# --------------------------------------------------------------------------- #
+
+
+def _is_close(a: float, b: float) -> bool:
+    """Vrai si a == b à tolérance relative 5% / absolue 1e-6 près."""
+    if a == b:
+        return True
+    diff = abs(a - b)
+    if diff <= ABSOLUTE_TOLERANCE:
+        return True
+    base = max(abs(a), abs(b))
+    if base == 0:
+        return False
+    return diff / base <= RELATIVE_TOLERANCE
+
+
+def _closest_output(prose_val: float, output_vals: list[float]) -> float | None:
+    """Trouve la valeur de output la plus proche de prose_val, si dans la tolérance."""
+    if not output_vals:
+        return None
+    best = min(output_vals, key=lambda v: abs(v - prose_val))
+    if _is_close(prose_val, best):
+        return best
+    return None
+
+
+# --------------------------------------------------------------------------- #
+#  Détection d'énumération prose (MISSING_FROM_PROSE_ENUMERATION)
+# --------------------------------------------------------------------------- #
+#
+# Catégorie #9416 : la prose déclare une liste de N niveaux/valeurs distincts
+# (via un mot-clé d'énumération : « N niveaux : a, b, c », « les3 valeurs sont »,
+# « on observe3 phases »), mais les outputs exhibent strictement plus de niveaux
+# distincts à tolérance raisonnable. L'omission est invisible au lecteur qui
+# ne recompte pas les outputs.
+#
+# Limites assumées :
+# - On ne parse que les énumérations **explicites** (mot-clé d'annonce avant la
+#   liste). Une prose vague (« il y a plusieurs pics ») n'est pas attrapée — la
+#   catégorie #2 reste un point de départ d'investigation.
+# - La tolérance de groupement est RELATIVE_TOLERANCE (5%) pour rester cohérent
+#   avec MISSING_FROM_OUTPUTS ; on n'invente pas une métrique distincte.
+#
+# Heuristique regex :
+#   - Mot-clé d'annonce : `(N|niveau|niveaux|valeur|valeurs|état|états|
+#     phase|phases|pic|pics|cluster|clusters|classe|classes|catégorie|
+#     catégories|étape|étapes|graphe|graphes)`.
+#   - Séparateur d'annonce : `:` ou `sont` ou `observ(e|ent|ons)` ou
+#     `correspondent à` ou ` vaut `.
+#   - Suite : nombres FR/EN séparés par virgules (accepte «, », « , », « ; »).
+
+
+# Heuristique d'annonce d'une énumération : soit (a) un mot-clé fort
+# (« N niveaux : », « les 3 valeurs sont »), soit (b) une formulation
+# naturelle « un/une <mot> à X, ... le reste à Y » qui déclare implicitement
+# 2 groupes. (b) attrape le cas fondateur ICT-1 (#9416) sans surcharger.
+#
+# NB : on utilise un lookbehind pour ne PAS consommer le chiffre qui suit
+# « à/a » -- sinon on mange la 1ère valeur de l'énumération.
+_ENUMERATION_KEYWORDS_RE = re.compile(
+    r"""
+    (?:
+        \d+\s+
+        (?:niveaux|valeurs|états|phases|pics|clusters|classes|
+            catégories|étapes|graphes|sommets|options)
+      | les\s+\d+\s+\w+
+      | on\s+observ(?:e|ent|ons)\s+\d+\s+\w+
+      | il\s+y\s+a\s+\d+\s+\w+
+      | (?<!\d)(?:un|une|le|la|des)\s+(?:pic|pics|cluster|clusters|groupe|
+            groupes|paquet|paquets|état|états|niveau|niveaux|phase|phases|
+            valeur|valeurs|classe|classes|catégorie|catégories)\s+[àa]
+    )
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+
+def _detect_prose_enumeration(text: str) -> list[float] | None:
+    """Si `text` annonce une liste de N valeurs, retourne la liste parsee.
+
+    Retourne None si le pattern d'annonce n'est pas trouvé (la cellule ne
+    déclare pas une énumération, donc la catégorie #9416 ne s'applique pas).
+
+    Cas couverts :
+    (a) « N niveaux : a, b, c » -- la liste suit le mot-clé d'annonce.
+    (b) « un pic à X, le reste à Y » -- formulation naturelle à 2 valeurs :
+        on extrait TOUS les nombres de la phrase, dans l'ordre (l'auteur
+        déclare implicitement qu'il n'y en a que 2 dans cette formulation).
+
+    Heuristique de portee : on s'arrete au prochain signe de « fin
+    d'enumeration » ou 200 chars. C'est CLAIREMENT plus restrictif que le
+    paragraphe entier, sinon la cellule Conclusion d'ICT-1 (avec son cycle
+    2-3-3 et l'attracteur 1) declencherait prose=6 distincts alors que
+    l'auteur n'en annonce que 2.
+
+    Filtre LaTeX : `$2{,}31$` ne doit pas être découpé en 3 tokens (`2`,
+    `31`). On retire les délimiteurs LaTeX `{,}` (et la TeX thin space)
+    ainsi que les dollars `$...$` avant l'extraction.
+    """
+    latex_clean = text.replace("{,}", ".").replace("{\\,}", ".").replace("{\\;}", ".")
+    # Strip $...$ delimiters (apres fusion des separateurs).
+    latex_clean = re.sub(r"\$([^$]*)\$", r" \1 ", latex_clean)
+    m = _ENUMERATION_KEYWORDS_RE.search(latex_clean)
+    if not m:
+        return None
+    # On extrait les nombres UNIQUEMENT APRES le mot-cle d'annonce.
+    # Le `N` dans « les 3 valeurs » est avant le mot-cle et doit etre ignore.
+    after = latex_clean[m.end():m.end()+200]
+    # Cas (a)/(b) : on prend la PHRASE courante a partir du mot-cle.
+    sentence = after.split("\n", 1)[0]
+    nums = _extract_prose_numbers(sentence)
+    return nums if len(nums) >= 2 else None
+
+
+def _distinct_levels(values: list[float], tol: float = RELATIVE_TOLERANCE) -> int:
+    """Compte le nombre de valeurs distinctes dans `values` à tolérance près.
+
+    Algorithme : tri O(n log n) puis groupement linéaire. Deux valeurs sont
+    « même niveau » si leur ratio <= tol (et > 0).
+    """
+    if not values:
+        return 0
+    s = sorted(values)
+    count = 1
+    for v in s[1:]:
+        base = max(abs(s[count - 1]), abs(v))
+        if base == 0:
+            # 0 == 0 -> même niveau.
+            continue
+        if abs(v - s[count - 1]) / base > tol:
+            count += 1
+    return count
+
+
+def analyze_notebook(path: str | os.PathLike) -> NotebookAlignment:
+    """Analyse l'alignement prose <-> outputs pour un notebook."""
+    p = Path(path)
+    try:
+        nb = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        return NotebookAlignment(
+            path=str(path), total_findings=0, findings=[],
+            error=f"{type(exc).__name__}: {exc}",
+        )
+    cells = nb.get("cells") or []
+    n_md = sum(1 for c in cells if c.get("cell_type") == "markdown")
+    n_code = sum(1 for c in cells if c.get("cell_type") == "code")
+    output_vals: list[float] = []
+    prose_vals_per_cell: list[tuple[int, str, list[float]]] = []
+    for i, c in enumerate(cells):
+        ctype = c.get("cell_type")
+        source = c.get("source") or []
+        if isinstance(source, list):
+            text = "".join(source)
+        else:
+            text = str(source)
+        if ctype == "code":
+            for out in (c.get("outputs") or []):
+                output_vals.extend(_extract_output_numbers(out))
+        elif ctype == "markdown":
+            nums = _extract_prose_numbers(text)
+            if nums:
+                prose_vals_per_cell.append((i, text, nums))
+    # Alignement : pour chaque cellule markdown, pour chaque nombre,
+    # cherche le plus proche dans output_vals.
+    findings: list[AlignmentFinding] = []
+    for cell_idx, text, nums in prose_vals_per_cell:
+        # Tronque le texte pour le rapport (60 premiers chars non vides).
+        snippet = text.strip().splitlines()
+        snippet = next((ln.strip() for ln in snippet if ln.strip()), "")[:120]
+        for v in nums:
+            closest = _closest_output(v, output_vals)
+            if closest is None:
+                # Determine la tolerance affichee.
+                tol = "none"
+                findings.append(AlignmentFinding(
+                    notebook=str(path),
+                    cell_index=cell_idx,
+                    cell_kind="markdown",
+                    category="MISSING_FROM_OUTPUTS",
+                    prose_text=snippet,
+                    prose_number=v,
+                    closest_output_number=None,
+                    tolerance_used=tol,
+                ))
+    # Tour 2 : MISSING_FROM_PROSE_ENUMERATION (#9416).
+    # Pour chaque cellule markdown qui annonce une énumération de N niveaux,
+    # compare N au nombre de niveaux distincts dans output_vals.
+    if output_vals:
+        output_levels = _distinct_levels(output_vals)
+        for cell_idx, text, nums in prose_vals_per_cell:
+            enum = _detect_prose_enumeration(text)
+            if not enum:
+                continue
+            prose_levels = _distinct_levels(enum)
+            if prose_levels == 0 or output_levels <= prose_levels:
+                continue
+            # Trouve la valeur output « orpheline » la plus loin de la liste prose.
+            orphan = None
+            orphan_dist = -1.0
+            for ov in output_vals:
+                closest_p = min(enum, key=lambda p: abs(p - ov))
+                base = max(abs(closest_p), abs(ov))
+                if base == 0:
+                    continue
+                dist = abs(ov - closest_p) / base
+                if dist > orphan_dist:
+                    orphan_dist = dist
+                    orphan = ov
+            snippet = text.strip().splitlines()
+            snippet = next((ln.strip() for ln in snippet if ln.strip()), "")[:120]
+            findings.append(AlignmentFinding(
+                notebook=str(path),
+                cell_index=cell_idx,
+                cell_kind="markdown",
+                category="MISSING_FROM_PROSE_ENUMERATION",
+                prose_text=snippet,
+                prose_number=float(prose_levels),
+                closest_output_number=orphan if orphan is not None else None,
+                tolerance_used="enumeration-vs-outputs",
+                details=(
+                    f"prose enumere {prose_levels} niveaux distincts, "
+                    f"outputs exhibent {output_levels} niveaux distincts "
+                    f"(orphan={orphan:.4g}, dist={orphan_dist:.1%})"
+                ),
+            ))
+    return NotebookAlignment(
+        path=str(path),
+        total_findings=len(findings),
+        findings=findings,
+        n_prose_numbers=sum(len(v) for _, _, v in prose_vals_per_cell),
+        n_output_numbers=len(output_vals),
+        n_markdown_cells=n_md,
+        n_code_cells=n_code,
+    )
+
+
+# --------------------------------------------------------------------------- #
+#  Walk full-corpus
+# --------------------------------------------------------------------------- #
+
+
+DEFAULT_INCLUDE_GLOBS = ("*.ipynb",)
+DEFAULT_EXCLUDE_DIRS = (
+    "_archive", "_archives", "archive", "archives",
+    "node_modules", ".git", "__pycache__",
+)
+
+
+def iter_notebooks(
+    root: Path,
+    include_globs: tuple[str, ...] = DEFAULT_INCLUDE_GLOBS,
+    exclude_dirs: tuple[str, ...] = DEFAULT_EXCLUDE_DIRS,
+) -> Iterable[Path]:
+    """Yield notebook paths under root, honoring exclusion dirs."""
+    if not root.exists():
+        return
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Prune excluded dirs in-place so os.walk skips them.
+        dirnames[:] = [d for d in dirnames if d not in exclude_dirs]
+        for fn in filenames:
+            if any(fn.endswith(g.lstrip("*")) for g in include_globs):
+                yield Path(dirpath) / fn
+
+
+def scan_corpus(
+    root: str | os.PathLike,
+    include_globs: tuple[str, ...] = DEFAULT_INCLUDE_GLOBS,
+    exclude_dirs: tuple[str, ...] = DEFAULT_EXCLUDE_DIRS,
+) -> list[NotebookAlignment]:
+    """Scan a corpus root, return list of NotebookAlignment."""
+    root_path = Path(root)
+    results: list[NotebookAlignment] = []
+    for nb_path in iter_notebooks(root_path, include_globs, exclude_dirs):
+        results.append(analyze_notebook(nb_path))
+    return results
+
+
+# --------------------------------------------------------------------------- #
+#  Reporting
+# --------------------------------------------------------------------------- #
+
+
+def render_text_report(results: list[NotebookAlignment]) -> str:
+    """Format results as markdown text."""
+    total_findings = sum(r.total_findings for r in results)
+    n_pathological = sum(1 for r in results if r.is_pathological)
+    by_cat: dict[str, int] = {}
+    for r in results:
+        for f in r.findings:
+            by_cat[f.category] = by_cat.get(f.category, 0) + 1
+    lines: list[str] = []
+    lines.append(f"Total notebooks analyses : {len(results)}")
+    lines.append(f"Notebooks avec >= 1 finding : {n_pathological}")
+    lines.append(f"Total findings : {total_findings}")
+    if by_cat:
+        lines.append("Repartition par categorie :")
+        for k, v in sorted(by_cat.items()):
+            lines.append(f"  - {k} : {v}")
+    lines.append("")
+    lines.append("## Notebooks avec findings")
+    lines.append("")
+    lines.append("| Notebook | Findings | n_prose | n_outputs | Top finding |")
+    lines.append("|---|---|---|---|---|")
+    for r in sorted(results, key=lambda x: -x.total_findings):
+        if r.total_findings == 0:
+            continue
+        top = r.findings[0]
+        snippet = f"{top.category}: {top.prose_number:.4g} (cell[{top.cell_index}])"
+        lines.append(
+            f"| `{os.path.basename(r.path)}` | {r.total_findings} | "
+            f"{r.n_prose_numbers} | {r.n_output_numbers} | {snippet} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+#  CLI
+# --------------------------------------------------------------------------- #
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--root", default="MyIA.AI.Notebooks",
+        help="Racine du corpus a scanner (defaut: MyIA.AI.Notebooks).",
+    )
+    parser.add_argument(
+        "--notebook", help="Cible un notebook precis (sinon full-corpus).",
+    )
+    parser.add_argument(
+        "--json-out", help="Ecrire le rapport JSON a ce chemin.",
+    )
+    parser.add_argument(
+        "--check", action="store_true",
+        help="Mode CI : exit 1 si >= 1 finding, exit 2 si usage/erreur.",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=0,
+        help="Limiter le nombre de notebooks analyses (0 = pas de limite).",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    root = Path(args.root)
+    if not root.exists():
+        print(f"ERREUR: racine '{root}' inexistante.", file=sys.stderr)
+        return 2
+    if args.notebook:
+        nb_path = Path(args.notebook)
+        if not nb_path.exists():
+            print(f"ERREUR: notebook '{nb_path}' inexistant.", file=sys.stderr)
+            return 2
+        results = [analyze_notebook(nb_path)]
+    else:
+        results = scan_corpus(root)
+        if args.limit > 0:
+            results = results[:args.limit]
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps([
+            {
+                "path": r.path,
+                "total_findings": r.total_findings,
+                "n_prose_numbers": r.n_prose_numbers,
+                "n_output_numbers": r.n_output_numbers,
+                "n_markdown_cells": r.n_markdown_cells,
+                "n_code_cells": r.n_code_cells,
+                "findings": [
+                    {
+                        "cell_index": f.cell_index,
+                        "category": f.category,
+                        "prose_number": f.prose_number,
+                        "closest_output_number": f.closest_output_number,
+                        "prose_text": f.prose_text,
+                    }
+                    for f in r.findings
+                ],
+                "error": r.error,
+            }
+            for r in results
+        ], indent=2, ensure_ascii=False), encoding="utf-8")
+    print(render_text_report(results))
+    if args.check and any(r.is_pathological for r in results):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
@@ -1,0 +1,553 @@
+"""Tests du detecteur v3 coherence prose <-> outputs intra-revision.
+
+Issue #9790 : scope borne, contre-epreuve positive obligatoire sur
+ICT-1-PhiTrajectories pre-`7de14792c` (le commit fix #9416 a corrige la
+dérive, mais le notebook parent `e8dc56ac9` doit etre signale par le
+detecteur -- c'est la definition du succes de la v3).
+
+10 classes de tests, ~30 tests attendus.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+import scan_d5_prose_outputs_alignment as mod
+
+
+# --------------------------------------------------------------------------- #
+#  Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_notebook(cells: list[dict], path: Path) -> None:
+    """Atomically write a notebook JSON file."""
+    payload = {
+        "cells": cells,
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=1),
+                    encoding="utf-8")
+
+
+def _markdown_cell(source: str) -> dict:
+    return {"cell_type": "markdown", "metadata": {}, "source": [source]}
+
+
+def _code_cell(source: str, outputs: list[dict]) -> dict:
+    return {
+        "cell_type": "code",
+        "metadata": {},
+        "source": [source],
+        "outputs": outputs,
+        "execution_count": 1,
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  Parsing FR / EN
+# --------------------------------------------------------------------------- #
+
+
+class TestParseFrNumber:
+    def test_simple_integer(self):
+        assert mod._parse_fr_number("42") == 42.0
+
+    def test_simple_decimal_en(self):
+        assert mod._parse_fr_number("0.69") == 0.69
+
+    def test_simple_decimal_fr(self):
+        assert mod._parse_fr_number("0,69") == 0.69
+
+    def test_thousands_separator_fr(self):
+        assert mod._parse_fr_number("1 234") == 1234.0
+        assert mod._parse_fr_number("1 234,56") == 1234.56
+
+    def test_thousands_separator_en(self):
+        assert mod._parse_fr_number("1,234.56") == 1234.56
+
+    def test_scientific(self):
+        assert mod._parse_fr_number("1e-3") == 1e-3
+        assert mod._parse_fr_number("1,5e-3") == 1.5e-3
+
+    def test_negative(self):
+        assert mod._parse_fr_number("-3.14") == -3.14
+
+    def test_out_of_range_filtered(self):
+        # MAX_NUMBER_VALUE = 1e15 ; 1e16 doit etre filtre, 1e14 doit passer.
+        assert mod._parse_fr_number("0") is None              # < 1e-9
+        assert mod._parse_fr_number("1e14") is not None
+        assert mod._parse_fr_number("1e16") is None           # > 1e15
+
+    def test_unparseable(self):
+        assert mod._parse_fr_number("") is None
+        assert mod._parse_fr_number("abc") is None
+
+
+# --------------------------------------------------------------------------- #
+#  Extraction prose
+# --------------------------------------------------------------------------- #
+
+
+class TestExtractProseNumbers:
+    def test_basic_en(self):
+        nums = mod._extract_prose_numbers("The value is 0.69 here.")
+        assert 0.69 in nums
+
+    def test_basic_fr(self):
+        nums = mod._extract_prose_numbers("La valeur est 0,69 ici.")
+        assert 0.69 in nums
+
+    def test_filter_years(self):
+        nums = mod._extract_prose_numbers("En 2026, on a vu 0.5.")
+        assert 2026 not in nums
+        assert 0.5 in nums
+
+    def test_filter_issue_numbers(self):
+        nums = mod._extract_prose_numbers("Voir #9416 pour le detail, ratio 0.82.")
+        assert 9416 not in nums
+        assert 0.82 in nums
+
+    def test_filter_section_headers(self):
+        nums = mod._extract_prose_numbers("## 4.2 Resultats\nLe ratio est 0.7.")
+        # 4.2 dans titre markdown = filtre semantique ; 0.7 dans prose = garde
+        # L'implementation actuelle utilise un prefix-window de 60 chars, ce qui
+        # peut laisser passer 4.2 si le titre est tres court -- on accepte
+        # les deux comportements, on verifie juste que 0.7 est la.
+        assert 0.7 in nums
+
+    def test_filter_versions(self):
+        nums = mod._extract_prose_numbers("Version v3 de l'algo, score 0.95.")
+        assert 0.95 in nums
+
+    def test_filter_cell_indices(self):
+        nums = mod._extract_prose_numbers("Voir cell[7] pour output, resultat 0.69.")
+        assert 0.69 in nums
+
+    def test_multiple_numbers(self):
+        nums = mod._extract_prose_numbers("Trois niveaux : 0.19, 0.69, 2.31.")
+        assert 0.19 in nums
+        assert 0.69 in nums
+        assert 2.31 in nums
+
+
+# --------------------------------------------------------------------------- #
+#  Extraction outputs
+# --------------------------------------------------------------------------- #
+
+
+class TestExtractOutputNumbers:
+    def test_text_plain_string(self):
+        nums = mod._extract_output_numbers({"text": "0.6875\n"})
+        assert 0.6875 in nums
+
+    def test_text_plain_list(self):
+        nums = mod._extract_output_numbers({"data": {"text/plain": ["0.1875", "0.6875"]}})
+        assert 0.1875 in nums
+        assert 0.6875 in nums
+
+    def test_data_with_text_plain(self):
+        nums = mod._extract_output_numbers({"data": {"text/plain": "result=0.95"}})
+        assert 0.95 in nums
+
+    def test_non_dict(self):
+        assert mod._extract_output_numbers("not a dict") == []
+
+    def test_empty(self):
+        assert mod._extract_output_numbers({}) == []
+
+
+# --------------------------------------------------------------------------- #
+#  Detection d'enumeration prose (MISSING_FROM_PROSE_ENUMERATION)
+# --------------------------------------------------------------------------- #
+
+
+class TestDetectProseEnumeration:
+    """Detecteur de la categorie MISSING_FROM_PROSE_ENUMERATION (#9416)."""
+
+    def test_two_levels_fr_keyword(self):
+        # Pattern fort « N niveaux : a, b »
+        nums = mod._detect_prose_enumeration("On observe 2 niveaux : 0,19 et 2,31.")
+        assert nums is not None
+        assert 0.19 in nums
+        assert 2.31 in nums
+
+    def test_three_levels_fr_keyword(self):
+        nums = mod._detect_prose_enumeration("les 3 valeurs sont 0.19, 0.69 et 2.31.")
+        assert nums is not None
+        assert len(nums) == 3
+
+    def test_four_levels_colon(self):
+        nums = mod._detect_prose_enumeration("Le systeme a 4 phases : 0.1, 0.3, 0.5, 0.7.")
+        assert nums is not None
+        assert len(nums) == 4
+
+    def test_natural_phrase_two_groups(self):
+        # Cas fondateur ICT-1 : « un pic a X, le reste a Y »
+        # Ne contient PAS de mot-cle fort mais la formulation naturelle
+        # « un <mot> a X, ... le reste a Y » est une enumeration de 2.
+        nums = mod._detect_prose_enumeration("un pic a 2,31, le reste a 0,19")
+        assert nums is not None
+        assert 2.31 in nums
+        assert 0.19 in nums
+
+    def test_not_enumeration_no_match(self):
+        # Pas de mot-cle, pas d'enumeration -> None
+        assert mod._detect_prose_enumeration("La temperature est 0.69.") is None
+        assert mod._detect_prose_enumeration("Plusieurs pics apparaissent.") is None
+        assert mod._detect_prose_enumeration("") is None
+
+
+class TestDistinctLevels:
+    """Comptage de niveaux distincts a tolerance pres."""
+
+    def test_three_well_separated(self):
+        # 3 valeurs bien espacees (cas ICT-1 outputs)
+        assert mod._distinct_levels([0.1875, 0.6875, 2.3125]) == 3
+
+    def test_two_close_one_far(self):
+        # 2 valeurs proches (0.18, 0.20) + 1 lointaine (2.5)
+        # 0.18 et 0.20 sont à 10% > 5% (donc 2 niveaux entre eux),
+        # 2.5 est isolé. Total : 3 niveaux.
+        assert mod._distinct_levels([0.18, 0.20, 2.5]) == 3
+
+    def test_single_value(self):
+        assert mod._distinct_levels([0.5]) == 1
+
+    def test_empty(self):
+        assert mod._distinct_levels([]) == 0
+
+    def test_two_identical(self):
+        assert mod._distinct_levels([0.5, 0.5]) == 1
+
+    def test_two_within_tolerance(self):
+        # 2 valeurs à 4% l'une de l'autre : DANS la tolérance -> 1 seul niveau.
+        # base = max(|0.5|, |0.48|) = 0.5 ; diff = 0.02 ; ratio = 4% < 5%
+        assert mod._distinct_levels([0.5, 0.48]) == 1
+
+    def test_two_outside_tolerance(self):
+        # 2 valeurs à 10% l'une de l'autre : HORS tolérance -> 2 niveaux.
+        # base = max(|0.5|, |0.45|) = 0.5 ; diff = 0.05 ; ratio = 10% > 5%
+        assert mod._distinct_levels([0.5, 0.45]) == 2
+
+
+class TestMissingFromProseEnumeration:
+    """Integration : MISSING_FROM_PROSE_ENUMERATION attrape le cas ICT-1."""
+
+    def test_ict1_founder_signaled(self, tmp_path):
+        """Cas fondateur #9416 : prose dit « 2,31 + 0,19 » (2 niveaux)
+        mais outputs exhibent 3 niveaux dont 0.6875 omis."""
+        nb = tmp_path / "ict1_founder.ipynb"
+        _make_notebook([
+            _markdown_cell("un pic a 2,31, le reste a 0,19"),
+            _code_cell("print(0.1875); print(0.6875); print(2.3125)",
+                       [{"text": "0.1875\n0.6875\n2.3125\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        assert result.total_findings >= 1
+        enum_findings = [f for f in result.findings
+                         if f.category == "MISSING_FROM_PROSE_ENUMERATION"]
+        assert len(enum_findings) == 1, (
+            f"Cas fondateur ICT-1 doit produire exactement 1 finding "
+            f"MISSING_FROM_PROSE_ENUMERATION, trouve {len(enum_findings)}"
+        )
+        f = enum_findings[0]
+        assert f.prose_number == pytest.approx(2)
+        assert "3 niveaux distincts" in f.details
+        assert "2 niveaux" in f.details
+
+    def test_no_signal_when_outputs_match_prose(self, tmp_path):
+        """Si la prose enumere N niveaux ET outputs en exhibent N, RAS."""
+        nb = tmp_path / "clean_enum.ipynb"
+        _make_notebook([
+            _markdown_cell("les 3 valeurs sont 0.19, 0.69 et 2.31."),
+            _code_cell("print(0.19); print(0.69); print(2.31)",
+                       [{"text": "0.19\n0.69\n2.31\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        enum_findings = [f for f in result.findings
+                         if f.category == "MISSING_FROM_PROSE_ENUMERATION"]
+        assert enum_findings == [], (
+            f"3 niveaux prose + 3 niveaux outputs ne doit pas signaler "
+            f"MISSING_FROM_PROSE_ENUMERATION, trouve {len(enum_findings)}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+#  Tolerances
+# --------------------------------------------------------------------------- #
+
+
+class TestIsClose:
+    def test_exact(self):
+        assert mod._is_close(0.69, 0.69)
+
+    def test_within_relative(self):
+        assert mod._is_close(0.69, 0.70)  # ~1.4%
+
+    def test_outside_relative(self):
+        assert not mod._is_close(0.69, 0.90)  # ~30%
+
+    def test_within_absolute(self):
+        assert mod._is_close(1e-9, 1e-9 + 1e-12)
+
+    def test_zero(self):
+        assert mod._is_close(0.0, 0.0)
+        assert not mod._is_close(0.0, 1.0)
+
+
+# --------------------------------------------------------------------------- #
+#  Analyse notebooks
+# --------------------------------------------------------------------------- #
+
+
+class TestAnalyzeNotebook:
+    def test_clean_notebook(self, tmp_path):
+        nb = tmp_path / "clean.ipynb"
+        _make_notebook([
+            _markdown_cell("## Resultats\nLe ratio est 0.7."),
+            _code_cell("print(0.7)", [{"text": "0.7\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        assert result.total_findings == 0
+        assert result.n_prose_numbers == 1
+        assert result.n_output_numbers == 1
+
+    def test_prose_value_missing(self, tmp_path):
+        nb = tmp_path / "missing.ipynb"
+        _make_notebook([
+            _markdown_cell("Phi = 0.69"),
+            _code_cell("print(0.1875)", [{"text": "0.1875\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        assert result.total_findings == 1
+        f = result.findings[0]
+        assert f.category == "MISSING_FROM_OUTPUTS"
+        assert f.prose_number == pytest.approx(0.69)
+
+    def test_prose_within_tolerance(self, tmp_path):
+        nb = tmp_path / "tol.ipynb"
+        _make_notebook([
+            _markdown_cell("Phi = 0.69"),
+            _code_cell("print(0.70)", [{"text": "0.70\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        assert result.total_findings == 0
+
+    def test_invalid_notebook(self, tmp_path):
+        nb = tmp_path / "bad.ipynb"
+        nb.write_text("not json", encoding="utf-8")
+        result = mod.analyze_notebook(nb)
+        assert result.error is not None
+        assert result.total_findings == 0
+
+
+# --------------------------------------------------------------------------- #
+#  Contre-epreuve positive ICT-1
+# --------------------------------------------------------------------------- #
+
+
+class TestICT1CounterEvidence:
+    """Le detecteur v3 DOIT signaler ICT-1 PRE-`7de14792c` (issue #9416).
+
+    A la revision `e8dc56ac9` (parent du fix), la prose dit
+    « un pic a 2,31, le reste a 0,19 » (2 niveaux) mais les outputs
+    exhibent 3 niveaux dont 0.6875 qui ne figure pas dans la prose.
+
+    Note : cette contre-epreuve lit le notebook depuis le worktree parent
+    (D:/dev/CoursIA-2-c1266-9790-v3-prose-outputs) ou depuis la copie
+    principale. Si le notebook est absent (lint ignore), on skip avec un
+    pytest.skip explicite -- le test est OPTIONNEL selon la disponibilite
+    du fichier, mais RECOMMANDE en pre-merge.
+    """
+
+    # Cherchons d'abord une racine de repo presente (worktree parent
+    # OU copie principale OU env var). Le path Linux/Windows natif est
+    # developper-specific (cf Hermes review nit) -- on prend n'importe
+    # lequel qui existe, sinon on skip explicitement.
+    _CANDIDATE_ROOTS = (
+        Path("D:/dev/CoursIA-2"),
+        Path("D:/dev/CoursIA"),
+        Path(os.environ.get("COURSIA_ROOT", "") or "_/_"),
+    )
+    REPO_ROOT = next((p for p in _CANDIDATE_ROOTS if p.exists() and p.is_dir()), _CANDIDATE_ROOTS[0])
+    NB_PATH = "MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb"
+
+    def test_pre_fix_ict_1_signaled(self):
+        """Lecture du notebook a la revision parente du fix #9416 via git show.
+
+        Le commit fix est `7de14792c` (« ICT-1 conclusion restores the 0.69
+        intermediate Phi relief »). Son parent = `7de14792c^` = l'etat
+        pre-fix avec prose « un pic a 2,31, le reste a 0,19 » qui omet le
+        3e niveau 0.6875 deja present dans `cell[7]`.
+
+        Skip si aucune racine de repo n'est accessible (path developper-specific
+        sur le runner CI). Cf Hermes review nit PR #9793.
+        """
+        if not self.REPO_ROOT.exists():
+            pytest.skip(f"Repo root {self.REPO_ROOT} absent (developper-specific path)")
+        try:
+            content = subprocess.check_output(
+                ["git", "show", "7de14792c^:MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb"],
+                cwd=str(self.REPO_ROOT),
+                stderr=subprocess.PIPE,
+            )
+        except subprocess.CalledProcessError:
+            pytest.skip("ICT-1 absent ou commit absent localement")
+        # Ecriture dans un tmp pour analyse via le module.
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".ipynb", delete=False) as f:
+            f.write(content)
+            tmp_path = Path(f.name)
+        try:
+            result = mod.analyze_notebook(tmp_path)
+        finally:
+            tmp_path.unlink()
+        # La prose pre-#9416 inclut « 2,31 » et « 0,19 » mais PAS « 0,69 ».
+        # Les outputs incluent 0.6875 (avec arrondi). Le detecteur DOIT
+        # signaler au moins un finding MISSING_FROM_OUTPUTS sur la valeur
+        # 0.69 OU un cas ou la prose enonce « un pic a 2,31, le reste a 0,19 »
+        # (donc pretend qu'il n'y a que 2 niveaux) mais les outputs en
+        # exhibent 3.
+        # C'est la classe MISSING_FROM_PROSE_ENUMERATION si implementee,
+        # ou MISSING_FROM_OUTPUTS sinon (au moins un nombre de la prose
+        # qui ne matche pas les outputs directement).
+        # Pour cette V1, on accepte tout finding dans ICT-1 pre-fix.
+        assert result.total_findings >= 1, (
+            f"Contre-epreuve positive ICT-1 pre-#9416 devrait signaler "
+            f"au moins 1 finding, mais 0 trouve. "
+            f"prose_n={result.n_prose_numbers}, output_n={result.n_output_numbers}"
+        )
+        # La definition du succes de v3 (issue #9790) : la categorie
+        # MISSING_FROM_PROSE_ENUMERATION DOIT etre parmi les findings,
+        # pas seulement MISSING_FROM_OUTPUTS (qui peut etre silencieux
+        # si les 2 niveaux de la prose matchent au tolerance pres).
+        enum_findings = [f for f in result.findings
+                         if f.category == "MISSING_FROM_PROSE_ENUMERATION"]
+        assert enum_findings, (
+            f"Contre-epreuve ICT-1 doit produire >= 1 finding "
+            f"MISSING_FROM_PROSE_ENUMERATION (cas fondateur #9416), "
+            f"aucun trouve parmi {len(result.findings)} findings. "
+            f"categories={[f.category for f in result.findings]}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+#  Walk full-corpus
+# --------------------------------------------------------------------------- #
+
+
+class TestIterNotebooks:
+    def test_simple(self, tmp_path):
+        _make_notebook(
+            [_markdown_cell("x = 0.5"), _code_cell("print(0.5)", [{"text": "0.5"}])],
+            tmp_path / "a.ipynb",
+        )
+        (tmp_path / "sub").mkdir()
+        _make_notebook(
+            [_markdown_cell("y = 0.3"), _code_cell("print(0.3)", [{"text": "0.3"}])],
+            tmp_path / "sub" / "b.ipynb",
+        )
+        results = list(mod.iter_notebooks(tmp_path))
+        assert len(results) == 2
+
+    def test_excludes_archive_dirs(self, tmp_path):
+        _make_notebook(
+            [_markdown_cell("x = 0.5"), _code_cell("print(0.5)", [{"text": "0.5"}])],
+            tmp_path / "a.ipynb",
+        )
+        (tmp_path / "_archive").mkdir()
+        _make_notebook(
+            [_markdown_cell("y = 0.3"), _code_cell("print(0.3)", [{"text": "0.3"}])],
+            tmp_path / "_archive" / "b.ipynb",
+        )
+        results = list(mod.iter_notebooks(tmp_path))
+        assert len(results) == 1
+        assert results[0].name == "a.ipynb"
+
+    def test_root_does_not_exist(self, tmp_path):
+        results = list(mod.iter_notebooks(tmp_path / "does_not_exist"))
+        assert results == []
+
+
+# --------------------------------------------------------------------------- #
+#  Smoke full-corpus (limite pour CI)
+# --------------------------------------------------------------------------- #
+
+
+class TestCorpusScanSmoke:
+    """Smoke test sur le corpus reel avec --limit=10 (CI-friendly)."""
+
+    def test_scan_real_corpus_limited(self):
+        # Cherchons une racine corpus accessible (worktree, copie principale, env var).
+        candidates = (
+            Path("D:/dev/CoursIA-2-c1266-9790-v3-prose-outputs/MyIA.AI.Notebooks"),
+            Path("D:/dev/CoursIA-2/MyIA.AI.Notebooks"),
+            Path("D:/dev/CoursIA/MyIA.AI.Notebooks"),
+            Path(os.environ.get("COURSIA_NOTEBOOKS", "") or "_/_"),
+        )
+        p = next((c for c in candidates if c.exists() and c.is_dir()), candidates[0])
+        if not p.exists():
+            pytest.skip(f"Corpus {p} non disponible (developper-specific path)")
+        results = mod.scan_corpus(p, exclude_dirs=mod.DEFAULT_EXCLUDE_DIRS)
+        # On prend juste les 10 premiers pour le smoke.
+        results = results[:10]
+        for r in results:
+            assert r.error is None or r.findings  # soit OK, soit finding documente
+            assert r.n_code_cells >= 0  # au moins parse
+
+
+# --------------------------------------------------------------------------- #
+#  CLI
+# --------------------------------------------------------------------------- #
+
+
+class TestCLI:
+    def test_exit_code_2_on_missing_root(self, tmp_path):
+        """Lecon po-2024 #9783 : chemin inexistant DOIT retourner 2, pas 0 ni 1."""
+        result = subprocess.run(
+            [sys.executable, "-m", "scan_d5_prose_outputs_alignment",
+             "--root", str(tmp_path / "absent"), "--check"],
+            cwd=_ROOT, capture_output=True, text=True,
+        )
+        assert result.returncode == 2, f"attendu 2, obtenu {result.returncode}\n{result.stderr}"
+
+    def test_exit_code_1_on_pathological(self, tmp_path):
+        """Si un notebook a un finding et --check, exit 1."""
+        nb = tmp_path / "bad.ipynb"
+        _make_notebook([
+            _markdown_cell("Phi = 0.69"),
+            _code_cell("print(0.1875)", [{"text": "0.1875\n"}]),
+        ], nb)
+        result = subprocess.run(
+            [sys.executable, "-m", "scan_d5_prose_outputs_alignment",
+             "--root", str(tmp_path), "--check"],
+            cwd=_ROOT, capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+
+    def test_exit_code_0_on_clean(self, tmp_path):
+        nb = tmp_path / "ok.ipynb"
+        _make_notebook([
+            _markdown_cell("Ratio OK 0.7"),
+            _code_cell("print(0.7)", [{"text": "0.7\n"}]),
+        ], nb)
+        result = subprocess.run(
+            [sys.executable, "-m", "scan_d5_prose_outputs_alignment",
+             "--root", str(tmp_path), "--check"],
+            cwd=_ROOT, capture_output=True, text=True,
+        )
+        assert result.returncode == 0


### PR DESCRIPTION
## c.1267 amend — PR #9793 — MISSING_FROM_PROSE_ENUMERATION implemented + Linux path fix

Grain: DEEP/tooling — lane myia-po-2025:CoursIA-2 — prev: DEEP/tooling #9793 c.1266

---

## Corps d'amend (à coller via `gh pr edit 9793 --body-file`)

**Suite de [PR #9793 c.1266](https://github.com/jsboige/CoursIA/pull/9793)** — amend légitime (L284, c.187 UNIQUE, force-push sa propre branche uniquement).

### Changements (2 fichiers, +322 / -13)

**1. `scripts/notebook_tools/scan_d5_prose_outputs_alignment.py`** — implémentation de la catégorie `MISSING_FROM_PROSE_ENUMERATION` décrite dans le docstring mais non livrée en c.1266. Cible les **deux concerns** soulevés par la review Hermes (po-2026) sur #9793 :

| Concern Hermes | Fix c.1267 |
|---|---|
| "MISSING_FROM_PROSE_ENUMERATION advertised mais pas implémenté" | Tour 2 dans `analyze_notebook()` : compare le nombre de niveaux distincts dans la prose (énoncés via « N niveaux : a, b, c » OU formulation naturelle « un pic à X, le reste à Y ») au nombre de niveaux distincts dans les outputs. Si l'écart est strict (`output_levels > prose_levels`), finding émis avec `orphan` = la valeur output la plus distante de la liste prose. |
| "Test ICT-1 contre-épreuve ambigu (seulement total_findings >= 1)" | Test `TestICT1CounterEvidence::test_pre_fix_ict_1_signaled` renforcé : exige **explicitement** `>= 1 finding` de catégorie `MISSING_FROM_PROSE_ENUMERATION` (pas seulement `MISSING_FROM_OUTPUTS`). Et pointe désormais `7de14792c^` (parent du fix #9416 = « ICT-1 conclusion restores the 0.69 intermediate Phi relief »). |

**Fonctions ajoutées** : `_ENUMERATION_KEYWORDS_RE` (regex patterns FR/EN + formulation naturelle 2-groupes), `_detect_prose_enumeration(text)` (filtre LaTeX `{,}` → `.` + extraction après mot-clé d'annonce uniquement), `_distinct_levels(values, tol)` (comptage O(n log n) à tolérance près via tri + groupement linéaire), hook dans `analyze_notebook()`.

**Bug latent corrigé en passant** : `_extract_output_numbers` ne lisait que `output['text']` quand c'était une string — Jupyter stocke parfois `text: list[str]` (format `stream`). Sans ce fix, les outputs de `cell[7]` de ICT-1 (qui contiennent Phi=0.6875) étaient silencieusement vides.

**2. `scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py`** — tests dédiés (16 nouveaux) :
- `TestDetectProseEnumeration` (5) : keyword fort FR/EN, formulation naturelle 2-groupes, faux positifs (textes sans énumération).
- `TestDistinctLevels` (6) : bien séparés, proches, unique, vide, identiques, à la frontière de tolérance.
- `TestMissingFromProseEnumeration` (2) : cas fondateur ICT-1, ratio nominal-vs-orphan, et cas nominal (prose = outputs = 3 niveaux → RAS).

### Validation

- **53/53 tests pytest PASS** en 21.26s (`pytest scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py -q`).
- **CI** : force-push post-amend, le job CI re-évalue (le test ICT-1 ne fail plus sur `FileNotFoundError` Linux : `_CANDIDATE_ROOTS` tuple + `pytest.skip` propre).
- **c.187 UNIQUE** : `0d6187f35 → 2c0b3f292` sur la branche feature/c1266-9790-v3-prose-outputs-coherence, seul commit UNIQUE du livrable.
- **L284 amend légitime** : single commit + force-push sa propre branche uniquement, SHA documenté ici.

### Conformité harnais

- **L800 ★** : encodage UTF-8 sans BOM, trailing newline True, **0 CR parasite**.
- **L284** : amend légitime (single commit + force-push sa branche uniquement).
- **L898 ★★★ + L972 ★** : triple-check scan rejoué avant claim ; aucune collision cross-lane (`gh pr list --search "v3-prose-outputs"` renvoie PR #9793 uniquement).
- **catalog-pr-hygiene R1** : 0 catalogue regénéré sur branche feature (`COURSE_CATALOG.generated.json` byte-identique à `origin/main`).
- **secrets-hygiene** : 0 cle API, 0 token, 0 literal inline. Le module reste stdlib-only.
- **audit-cross-source-distillation R1** : 0 rapport commité (ce body PR documente la livraison).
- **L677-L4 ★★** : body PR dans scratchpad hors worktree. `git status` propre avant push.

### Suite directe EPIC #9768

Le détecteur v3 livre maintenant les **deux catégories** documentées dans le docstring de c.1266. La CI de PR #9793 devrait passer en vert une fois l'amend CI-complet. La Phase 2 (#9768, calibration precision/recall par famille) reste un sujet séparé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
