### PR TITLE
feat(lean,#6724): prove p4_ne_supercell_agree + wire NE membership arm (sorry 6->5, baseline 7->6)

### DIFF
--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -8,28 +8,24 @@ name: Lean Conway CI
 # version in PR #2747 (same standalone-tactic mode, same baseline 8, now via the
 # shared lean-build.yml reusable workflow).
 #
-# Sorry profile (re-verified 2026-08-02 post-#9132, standalone-tactic mode,
-# baseline=9): conway has 9 real tactic sorries, ALL in HashlifeCorrectness.lean.
+# Sorry profile (re-verified 2026-08-07 post-#6724 NE quadrant, standalone-tactic
+# mode, baseline=6): conway has 6 real tactic sorries.
 # The standalone-tactic filter also counts the Lean case-bullet form `· sorry`
-# (fixed in lean-build.yml, See #2747). Prose mentions ("Each sorry is a
-# target", "Left as sorry", "remain sorry-gated") are excluded by the
-# sole-token check. Breakdown of the 9 (post-#9132 NE+SW arm port):
-#   - HashlifeCorrectness.lean: 9 =
-#       p4_nw_overlap_wall (1)        -- tree-locked #6875 (ai-01 turf)
-#       p4_ne_supercell_agree (1)     -- NE mirror of the NW overlap wall (#9132)
+# (fixed in lean-build.yml, See #2747) and EXCLUDES `*_en.lean` i18n siblings
+# (byte-identical mirrors of the FR file — counting both double-inflates,
+# C513-L1 #6429). Prose mentions ("Each sorry is a target", "Left as sorry",
+# "remain sorry-gated") are excluded by the sole-token check. Breakdown of the 6:
+#   - HashlifeCorrectness.lean: 5 =
 #       p4_sw_overlap_wall (1)        -- SW mirror of the NW overlap wall (#9132)
 #       p4_sw_supercell_agree (1)     -- SW supercell-agree scaffold (#9132)
-#       p4_sw_membership_arm (2)      -- SW membership-arm scaffolds (#9132;
-#                                       candidates for future reduction)
-#       p5_large_n_jump (1)           -- downstream P4-gated
-#       hashlife_correctN (1)         -- downstream P4-gated
+#       p4_se_overlap_wall (1)        -- SE mirror of the NW overlap wall
+#       p4_succ_membership (1)        -- succ-level membership (P4 assembly)
 #       p5_large_n_jumpN (1)          -- downstream P4-gated
-#     The #9132 NE+SW arm port REMOVED 4 sorries from p4_se_shift_lemma
-#     (c.8123 convention unification) and ADDED 5 defensive-factorization
-#     scaffolds (NE/SW overlap-wall mirrors) -> net +1 (8 -> 9). Each new
-#     scaffold is a structural mirror of the tree-locked NW wall, not a
-#     replaced proof (anti-regression §D respected; the SE cleanup is a real
-#     improvement). See #9132 body + diagnostic comment.
+#     7 -> 6 (this PR, See #6724): p4_ne_supercell_agree PROVED (strengthened
+#     signature) + NE membership arm wired at the succ call site — a proof,
+#     not a deletion (anti-regression §D).
+#   - HashlifeMarginFragment.lean: 1  -- documented framework sorry
+#     (hashlife_correct_margin, Livrable B #9568, acceptance-B state)
 #   - HashlifeMemo.lean:        0 (discharged since #2794, Phase 3c)
 #   - Pillars.lean:             0 (discharged since #2790, scaffolding witnesses)
 # Raising this baseline requires a documented justification in the PR body.
@@ -40,9 +36,9 @@ name: Lean Conway CI
 # lists 19 native_decide axioms EXPLICITEMENT (no wildcard `*native_decide*`:
 # that would destroy the "new native_decide = new red" property required to
 # triage any future introduction one-by-one). fail-on-sorry=true (the
-# 7 acknowledged tactic sorries (6 in HashlifeCorrectness.lean + 1 documented
+# 6 acknowledged tactic sorries (5 in HashlifeCorrectness.lean + 1 documented
 # framework sorry in HashlifeMarginFragment.lean) are governed by the
-# lean-build.yml `sorry-baseline: "7"`, not by this gate — no double-cover).
+# lean-build.yml `sorry-baseline: "6"`, not by this gate — no double-cover).
 #
 # Reprise rationale (ai-01 DM HIGH msg-20260728T231209-43cuju, c.950):
 #   1. allow-axioms MUST list the 19 explicit names — wildcard forbidden
@@ -91,7 +87,7 @@ jobs:
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
       display-name: conway_lean
-      sorry-baseline: "7"
+      sorry-baseline: "6"
       sorry-filter-mode: standalone-tactic
 
   # c.8133 (#8782 reconciliation): the blocking gate's allow-axioms list was

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -3317,6 +3317,109 @@ private theorem p4_nw_parent_agree_n5 (k : Nat)
     · exact Or.inr (Or.inr (Or.inl (Or.inr (Or.inl h))))
     · exact Or.inr (Or.inr (Or.inr (Or.inl h)))
 
+/-- Accord parent / `n3` (enfant NE, mur NE) translaté de `(0, 2·2^k)` sur
+    `[0, 2·2^k) × [2·2^k, 4·2^k)`. Le rectangle est exactement l'empreinte du
+    quadrant NE du parent : seul l'enfant NE survit, les trois autres quadrants
+    sont exclus par bornes. -/
+private theorem p4_ne_parent_agree_n3 (k : Nat)
+    (nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
+      sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se : MacroCell)
+    (hn1_l : (node nw_nw nw_ne nw_sw nw_se).level = k + 1)
+    (hn1_w : (node nw_nw nw_ne nw_sw nw_se).wf = true)
+    (x : Int × Int)
+    (hx : 0 ≤ x.1 ∧ x.1 < (2 ^ k : Int) + (2 ^ k : Int) ∧
+          (2 ^ k : Int) + (2 ^ k : Int) ≤ x.2 ∧
+          x.2 < (2 ^ k : Int) + (2 ^ k : Int) + (2 ^ k : Int) + (2 ^ k : Int)) :
+    isAlive ((node (node nw_nw nw_ne nw_sw nw_se) (node ne_nw ne_ne ne_sw ne_se)
+        (node sw_nw sw_ne sw_sw sw_se) (node se_nw se_ne se_sw se_se)).toGrid (0, 0)) x
+      = isAlive ((node ne_nw ne_ne ne_sw ne_se).toGrid
+          (0, (2 ^ k : Int) + (2 ^ k : Int))) x := by
+  obtain ⟨hx1, hx2, hx3, hx4⟩ := hx
+  apply p4_bool_eq_of_iff
+  rw [isAlive_true_iff_mem_local, isAlive_true_iff_mem_local]
+  have hBB : (2 ^ (k + 1) : Int) = (2 ^ k : Int) + (2 ^ k : Int) := by
+    rw [pow_succ]; ring
+  rw [mem_toGrid_node (nw := node nw_nw nw_ne nw_sw nw_se), hn1_l, hBB]
+  simp only [Int.zero_add, Int.add_zero]
+  constructor
+  · rintro (h | h | h | h)
+    · obtain ⟨-, hc⟩ := p4_mem_toGrid_lt _ _ _ x hn1_w h
+      rw [hn1_l, hBB] at hc
+      exfalso; omega
+    · exact h
+    · obtain ⟨hr, -⟩ := p4_mem_toGrid_origin_le _ _ _ x h
+      exfalso; omega
+    · obtain ⟨hr, -⟩ := p4_mem_toGrid_origin_le _ _ _ x h
+      exfalso; omega
+  · intro h
+    exact Or.inr (Or.inl h)
+
+/-- Accord parent / `n6` (mur NE) translaté de `(2^k, 2·2^k)` sur
+    `[2^k, 3·2^k) × [2·2^k, 4·2^k)`. Le rectangle chevauche les quadrants NE et
+    SE du parent ; à l'intérieur, seuls `ne_sw`/`ne_se` (moitié basse du NE) et
+    `se_nw`/`se_ne` (moitié haute du SE) survivent — exactement les quatre
+    enfants de `n6`. -/
+private theorem p4_ne_parent_agree_n6 (k : Nat)
+    (nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
+      sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se : MacroCell)
+    (hn1_l : (node nw_nw nw_ne nw_sw nw_se).level = k + 1)
+    (hn1_w : (node nw_nw nw_ne nw_sw nw_se).wf = true)
+    (hn3_l : (node ne_nw ne_ne ne_sw ne_se).level = k + 1)
+    (hn3_w : (node ne_nw ne_ne ne_sw ne_se).wf = true)
+    (hn6_l : (node ne_sw ne_se se_nw se_ne).level = k + 1)
+    (hn6_w : (node ne_sw ne_se se_nw se_ne).wf = true)
+    (hn7_l : (node sw_nw sw_ne sw_sw sw_se).level = k + 1)
+    (hn7_w : (node sw_nw sw_ne sw_sw sw_se).wf = true)
+    (x : Int × Int)
+    (hx : (2 ^ k : Int) ≤ x.1 ∧ x.1 < (2 ^ k : Int) + (2 ^ k : Int) + (2 ^ k : Int) ∧
+          (2 ^ k : Int) + (2 ^ k : Int) ≤ x.2 ∧
+          x.2 < (2 ^ k : Int) + (2 ^ k : Int) + (2 ^ k : Int) + (2 ^ k : Int)) :
+    isAlive ((node (node nw_nw nw_ne nw_sw nw_se) (node ne_nw ne_ne ne_sw ne_se)
+        (node sw_nw sw_ne sw_sw sw_se) (node se_nw se_ne se_sw se_se)).toGrid (0, 0)) x
+      = isAlive ((node ne_sw ne_se se_nw se_ne).toGrid
+          ((2 ^ k : Int), (2 ^ k : Int) + (2 ^ k : Int))) x := by
+  obtain ⟨hx1, hx2, hx3, hx4⟩ := hx
+  obtain ⟨hl_nenw, hl_nene, -, -, hw_nenw, hw_nene, -, -⟩ :=
+    wf_node_quad_level hn3_l hn3_w
+  obtain ⟨hl_nesw, -, hl_senw, -, -, -, -, -⟩ :=
+    wf_node_quad_level hn6_l hn6_w
+  apply p4_bool_eq_of_iff
+  rw [isAlive_true_iff_mem_local, isAlive_true_iff_mem_local]
+  have hBB : (2 ^ (k + 1) : Int) = (2 ^ k : Int) + (2 ^ k : Int) := by
+    rw [pow_succ]; ring
+  rw [mem_toGrid_node (nw := ne_sw) (ne := ne_se) (sw := se_nw) (se := se_ne), hl_nesw]
+  rw [mem_toGrid_node (nw := node nw_nw nw_ne nw_sw nw_se), hn1_l, hBB]
+  rw [mem_toGrid_node (nw := ne_nw) (ne := ne_ne) (sw := ne_sw) (se := ne_se), hl_nenw]
+  rw [mem_toGrid_node (nw := se_nw) (ne := se_ne) (sw := se_sw) (se := se_se), hl_senw]
+  simp only [Int.zero_add, Int.add_zero]
+  constructor
+  · rintro (h | (h | h | h | h) | h | (h | h | h | h))
+    · obtain ⟨-, hc⟩ := p4_mem_toGrid_lt _ _ _ x hn1_w h
+      rw [hn1_l, hBB] at hc
+      exfalso; omega
+    · obtain ⟨hr, -⟩ := p4_mem_toGrid_lt _ _ _ x hw_nenw h
+      rw [hl_nenw] at hr
+      exfalso; omega
+    · obtain ⟨hr, -⟩ := p4_mem_toGrid_lt _ _ _ x hw_nene h
+      rw [hl_nene] at hr
+      exfalso; omega
+    · exact Or.inl h
+    · exact Or.inr (Or.inl h)
+    · obtain ⟨-, hc⟩ := p4_mem_toGrid_lt _ _ _ x hn7_w h
+      rw [hn7_l, hBB] at hc
+      exfalso; omega
+    · exact Or.inr (Or.inr (Or.inl h))
+    · exact Or.inr (Or.inr (Or.inr h))
+    · obtain ⟨hr, -⟩ := p4_mem_toGrid_origin_le _ _ _ x h
+      exfalso; omega
+    · obtain ⟨hr, -⟩ := p4_mem_toGrid_origin_le _ _ _ x h
+      exfalso; omega
+  · rintro (h | h | h | h)
+    · exact Or.inr (Or.inl (Or.inr (Or.inr (Or.inl h))))
+    · exact Or.inr (Or.inl (Or.inr (Or.inr (Or.inr h))))
+    · exact Or.inr (Or.inr (Or.inr (Or.inl h)))
+    · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h))))
+
 /-! ### Étape 4 (préparation) — caractérisation par quadrant du supernœud résultat
 
 Le supernœud `node R1 R2 R4 R5` (niveau `k+1`) est caractérisé quadrant par
@@ -4435,38 +4538,264 @@ private theorem p4_nw_membership_arm
     rw [hbridge]
     omega
 
-/-- **NE super-cell agreement (P4, G3 for the NE quadrant, c.8122 — defensive factorization).**
-    Symmetric to `p4_nw_supercell_agree` (L3156) but for the NE supercell
-    `node nw_ne ne_nw nw_se ne_sw` with wave-1 sub-cells `n2 n3 n5 n6`
-    (each of level `(k-1)+2 = k+1`, derived via `ih` at level `k-1`).
-    The bridge compares the **same** parent double-half-step LHS
-    `evolve (2^(k-1)) (evolve (2^(k-1)) <parent-grid>)` at `p`
-    against the NE supercell's wave-0 (level `k`) result
-    `(node R2 R3 R5 R6).toGrid (0,0)` at the NE-centered offset
-    `p - (2^k, 2^k + 2^(k-1)) + (2^(k-1), 2^(k-1))`.
+/-- **Mur de chevauchement NE (P4 (a), miroir de `p4_nw_overlap_wall`).**
+    Même géométrie que le mur NW — fenêtre centrale, boîte Chebyshev de rayon
+    `2^(k-1)`, hypothèses structurelles `hn*` — mais pour le supercell NE
+    `node R2 R3 R5 R6` ancré à `(2^(k-1), 2^k + 2^(k-1))` dans le parent.
+    Les quatre quadrants du supercell correspondent aux recombinaisons
+    `n2` (NO, translatée `(0, 2^k)`), `n3` (NE, `(0, 2·2^k)` — l'enfant NE
+    du parent), `n5` (SO, `(2^k, 2^k)` — LE MÊME nœud centre que le mur NW,
+    `p4_nw_parent_agree_n5` est réutilisé tel quel) et `n6` (SE,
+    `(2^k, 2·2^k)`). L'ensemble d'hypothèses structurelles s'élargit à
+    `{n1..n7}` : `n1`/`n4`/`n7` n'ont pas de `hcc` (purement structurels,
+    pour les exclusions de bornes des lemmes d'accord parent). -/
+private theorem p4_ne_overlap_wall
+    (k : Nat) (hk1 : 1 ≤ k)
+    (nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
+     sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se : MacroCell)
+    (R2 R3 R5 R6 : MacroCell)
+    (hR2 : R2 = hashlifeResultAux (k + 1) (node nw_ne ne_nw nw_se ne_sw))
+    (hR3 : R3 = hashlifeResultAux (k + 1) (node ne_nw ne_ne ne_sw ne_se))
+    (hR5 : R5 = hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
+    (hR6 : R6 = hashlifeResultAux (k + 1) (node ne_sw ne_se se_nw se_ne))
+    (hn1_l : (node nw_nw nw_ne nw_sw nw_se).level = k + 1)
+    (hn2_l : (node nw_ne ne_nw nw_se ne_sw).level = k + 1)
+    (hn3_l : (node ne_nw ne_ne ne_sw ne_se).level = k + 1)
+    (hn4_l : (node nw_sw nw_se sw_nw sw_ne).level = k + 1)
+    (hn5_l : (node nw_se ne_sw sw_ne se_nw).level = k + 1)
+    (hn6_l : (node ne_sw ne_se se_nw se_ne).level = k + 1)
+    (hn7_l : (node sw_nw sw_ne sw_sw sw_se).level = k + 1)
+    (hn1_w : (node nw_nw nw_ne nw_sw nw_se).wf = true)
+    (hn2_w : (node nw_ne ne_nw nw_se ne_sw).wf = true)
+    (hn3_w : (node ne_nw ne_ne ne_sw ne_se).wf = true)
+    (hn4_w : (node nw_sw nw_se sw_nw sw_ne).wf = true)
+    (hn5_w : (node nw_se ne_sw sw_ne se_nw).wf = true)
+    (hn6_w : (node ne_sw ne_se se_nw se_ne).wf = true)
+    (hn7_w : (node sw_nw sw_ne sw_sw sw_se).wf = true)
+    (hR2_l : R2.level = k) (hR3_l : R3.level = k)
+    (hR5_l : R5.level = k) (hR6_l : R6.level = k)
+    (hcc2 : centralCorrect (node nw_ne ne_nw nw_se ne_sw) (k - 1))
+    (hcc3 : centralCorrect (node ne_nw ne_ne ne_sw ne_se) (k - 1))
+    (hcc5 : centralCorrect (node nw_se ne_sw sw_ne se_nw) (k - 1))
+    (hcc6 : centralCorrect (node ne_sw ne_se se_nw se_ne) (k - 1))
+    (p : Int × Int)
+    (hp : (2^k : Int) ≤ p.1 ∧ p.1 < (2^k : Int) + 2^((k - 1) + 1) ∧
+          ((2^k + (2^k : Int))) ≤ p.2 ∧
+          p.2 < ((2^k + (2^k : Int))) + 2^((k - 1) + 1)) :
+    ∀ q, chebDist p q ≤ 2^(k - 1) →
+      isAlive (evolve (2^(k - 1))
+          ((node (node nw_nw nw_ne nw_sw nw_se) (node ne_nw ne_ne ne_sw ne_se)
+                 (node sw_nw sw_ne sw_sw sw_se) (node se_nw se_ne se_sw se_se)).toGrid
+            (0, 0))) q
+        = isAlive ((node R2 R3 R5 R6).toGrid (0, 0))
+            (q.1 - (2^(k - 1) : Int), q.2 - ((2^k : Int) + (2^(k - 1) : Int))) := by
+  -- Assemblage miroir du mur NW : fenêtre → quadrant → localité Chebyshev
+  -- (`evolve_box_agree_local`) sur le nœud de recombinaison du quadrant →
+  -- caractérisation `p4_nw_rside_char_*` (paramétrique) du supernœud résultat.
+  intro q hq
+  obtain ⟨hp1, hp2, hp3, hp4⟩ := hp
+  have hA : (2 ^ (k - 1 + 1) : Int) = (2 ^ k : Int) := by
+    have hk : k - 1 + 1 = k := by omega
+    rw [hk]
+  have hu2 : (2 ^ k : Int) = (2 ^ (k - 1) : Int) + (2 ^ (k - 1) : Int) := by
+    rw [← hA, pow_succ]; ring
+  have hcastu : ((2 ^ (k - 1) : Nat) : Int) = (2 ^ (k - 1) : Int) := by norm_cast
+  rw [hA] at hp2 hp4
+  obtain ⟨hq1, hq2⟩ := coord_bound_of_chebDist_le p q _ hq
+  by_cases hcx1 : q.1 - (2 ^ (k - 1) : Int) < (2 ^ k : Int) <;>
+    by_cases hcx2 : q.2 - ((2 ^ k : Int) + (2 ^ (k - 1) : Int)) < (2 ^ k : Int)
+  · -- Quadrant NO du supercell : `n2`, translaté `(0, 2^k)`.
+    have hbox : ∀ r, chebDist q r ≤ 2 ^ (k - 1) →
+        isAlive ((node (node nw_nw nw_ne nw_sw nw_se) (node ne_nw ne_ne ne_sw ne_se)
+            (node sw_nw sw_ne sw_sw sw_se) (node se_nw se_ne se_sw se_se)).toGrid (0, 0)) r
+          = isAlive (shift ((0 : Int), (2 ^ k : Int))
+              ((node nw_ne ne_nw nw_se ne_sw).toGrid (0, 0))) r := by
+      intro r hr
+      obtain ⟨hr1, hr2⟩ := coord_bound_of_chebDist_le q r _ hr
+      rw [isAlive_shift, ← p4_isAlive_toGrid_shift]
+      exact p4_nw_parent_agree_n2 k nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
+        sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se hn1_l hn1_w hn2_l hn2_w r
+        ⟨by omega, by omega, by omega, by omega⟩
+    have hL := evolve_box_agree_local (2 ^ (k - 1)) _ _ q hbox
+    rw [hL, ← evolve_shift, isAlive_shift]
+    have hx' : 0 ≤ q.1 - (2 ^ (k - 1) : Int) ∧ q.1 - (2 ^ (k - 1) : Int) < (2 ^ k : Int) ∧
+        0 ≤ q.2 - ((2 ^ k : Int) + (2 ^ (k - 1) : Int)) ∧
+        q.2 - ((2 ^ k : Int) + (2 ^ (k - 1) : Int)) < (2 ^ k : Int) :=
+      ⟨by omega, by omega, by omega, by omega⟩
+    rw [p4_nw_rside_char_nw k hk1 _ _ _ _ R2 R3 R5 R6 hR2 hR3 hR5 hR6 hR2_l
+        hcc2 hcc3 hcc5 hcc6
+        (q.1 - (2 ^ (k - 1) : Int), q.2 - ((2 ^ k : Int) + (2 ^ (k - 1) : Int))) hx']
+    congr 1
+    ext <;> (try dsimp only) <;> omega
+  · -- Quadrant NE du supercell : `n3` (l'enfant NE du parent), translaté `(0, 2·2^k)`.
+    have hbox : ∀ r, chebDist q r ≤ 2 ^ (k - 1) →
+        isAlive ((node (node nw_nw nw_ne nw_sw nw_se) (node ne_nw ne_ne ne_sw ne_se)
+            (node sw_nw sw_ne sw_sw sw_se) (node se_nw se_ne se_sw se_se)).toGrid (0, 0)) r
+          = isAlive (shift ((0 : Int), (2 ^ k : Int) + (2 ^ k : Int))
+              ((node ne_nw ne_ne ne_sw ne_se).toGrid (0, 0))) r := by
+      intro r hr
+      obtain ⟨hr1, hr2⟩ := coord_bound_of_chebDist_le q r _ hr
+      rw [isAlive_shift, ← p4_isAlive_toGrid_shift]
+      exact p4_ne_parent_agree_n3 k nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
+        sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se hn1_l hn1_w r
+        ⟨by omega, by omega, by omega, by omega⟩
+    have hL := evolve_box_agree_local (2 ^ (k - 1)) _ _ q hbox
+    rw [hL, ← evolve_shift, isAlive_shift]
+    have hx' : 0 ≤ q.1 - (2 ^ (k - 1) : Int) ∧ q.1 - (2 ^ (k - 1) : Int) < (2 ^ k : Int) ∧
+        (2 ^ k : Int) ≤ q.2 - ((2 ^ k : Int) + (2 ^ (k - 1) : Int)) ∧
+        q.2 - ((2 ^ k : Int) + (2 ^ (k - 1) : Int)) < (2 ^ k : Int) + (2 ^ k : Int) :=
+      ⟨by omega, by omega, by omega, by omega⟩
+    rw [p4_nw_rside_char_ne k hk1 _ _ _ _ R2 R3 R5 R6 hR2 hR3 hR5 hR6 hR2_l
+        hcc2 hcc3 hcc5 hcc6
+        (q.1 - (2 ^ (k - 1) : Int), q.2 - ((2 ^ k : Int) + (2 ^ (k - 1) : Int))) hx']
+    congr 1
+    ext <;> (try dsimp only) <;> omega
+  · -- Quadrant SO du supercell : `n5` (nœud centre, PARTAGÉ avec le mur NW),
+    -- translaté `(2^k, 2^k)`. Réutilisation directe de `p4_nw_parent_agree_n5`.
+    have hbox : ∀ r, chebDist q r ≤ 2 ^ (k - 1) →
+        isAlive ((node (node nw_nw nw_ne nw_sw nw_se) (node ne_nw ne_ne ne_sw ne_se)
+            (node sw_nw sw_ne sw_sw sw_se) (node se_nw se_ne se_sw se_se)).toGrid (0, 0)) r
+          = isAlive (shift ((2 ^ k : Int), (2 ^ k : Int))
+              ((node nw_se ne_sw sw_ne se_nw).toGrid (0, 0))) r := by
+      intro r hr
+      obtain ⟨hr1, hr2⟩ := coord_bound_of_chebDist_le q r _ hr
+      rw [isAlive_shift, ← p4_isAlive_toGrid_shift]
+      exact p4_nw_parent_agree_n5 k nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
+        sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se hn1_l hn1_w hn2_l hn2_w
+        hn4_l hn4_w hn5_l hn5_w r
+        ⟨by omega, by omega, by omega, by omega⟩
+    have hL := evolve_box_agree_local (2 ^ (k - 1)) _ _ q hbox
+    rw [hL, ← evolve_shift, isAlive_shift]
+    have hx' : (2 ^ k : Int) ≤ q.1 - (2 ^ (k - 1) : Int) ∧
+        q.1 - (2 ^ (k - 1) : Int) < (2 ^ k : Int) + (2 ^ k : Int) ∧
+        0 ≤ q.2 - ((2 ^ k : Int) + (2 ^ (k - 1) : Int)) ∧
+        q.2 - ((2 ^ k : Int) + (2 ^ (k - 1) : Int)) < (2 ^ k : Int) :=
+      ⟨by omega, by omega, by omega, by omega⟩
+    rw [p4_nw_rside_char_sw k hk1 _ _ _ _ R2 R3 R5 R6 hR2 hR3 hR5 hR6 hR2_l
+        hcc2 hcc3 hcc5 hcc6
+        (q.1 - (2 ^ (k - 1) : Int), q.2 - ((2 ^ k : Int) + (2 ^ (k - 1) : Int))) hx']
+    congr 1
+    ext <;> (try dsimp only) <;> omega
+  · -- Quadrant SE du supercell : `n6`, translaté `(2^k, 2·2^k)`.
+    have hbox : ∀ r, chebDist q r ≤ 2 ^ (k - 1) →
+        isAlive ((node (node nw_nw nw_ne nw_sw nw_se) (node ne_nw ne_ne ne_sw ne_se)
+            (node sw_nw sw_ne sw_sw sw_se) (node se_nw se_ne se_sw se_se)).toGrid (0, 0)) r
+          = isAlive (shift ((2 ^ k : Int), (2 ^ k : Int) + (2 ^ k : Int))
+              ((node ne_sw ne_se se_nw se_ne).toGrid (0, 0))) r := by
+      intro r hr
+      obtain ⟨hr1, hr2⟩ := coord_bound_of_chebDist_le q r _ hr
+      rw [isAlive_shift, ← p4_isAlive_toGrid_shift]
+      exact p4_ne_parent_agree_n6 k nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
+        sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se hn1_l hn1_w hn3_l hn3_w
+        hn6_l hn6_w hn7_l hn7_w r
+        ⟨by omega, by omega, by omega, by omega⟩
+    have hL := evolve_box_agree_local (2 ^ (k - 1)) _ _ q hbox
+    rw [hL, ← evolve_shift, isAlive_shift]
+    have hx' : (2 ^ k : Int) ≤ q.1 - (2 ^ (k - 1) : Int) ∧
+        q.1 - (2 ^ (k - 1) : Int) < (2 ^ k : Int) + (2 ^ k : Int) ∧
+        (2 ^ k : Int) ≤ q.2 - ((2 ^ k : Int) + (2 ^ (k - 1) : Int)) ∧
+        q.2 - ((2 ^ k : Int) + (2 ^ (k - 1) : Int)) < (2 ^ k : Int) + (2 ^ k : Int) :=
+      ⟨by omega, by omega, by omega, by omega⟩
+    rw [p4_nw_rside_char_se k hk1 _ _ _ _ R2 R3 R5 R6 hR2 hR3 hR5 hR6 hR2_l
+        hcc2 hcc3 hcc5 hcc6
+        (q.1 - (2 ^ (k - 1) : Int), q.2 - ((2 ^ k : Int) + (2 ^ (k - 1) : Int))) hx']
+    congr 1
+    ext <;> (try dsimp only) <;> omega
 
-    **Diagnostic (c.15 — explicit factorization livrable)**:
-    The residual sorry here is the **NE-mirror of `p4_nw_overlap_wall`** (L2945)
-    — same shape, only the wave-1 sub-cell index set changes (NW: `{1,2,4,5}` →
-    NE: `{2,3,5,6}`) and the offset shifts from `(2^k, 2^k)` to
-    `(2^k, 2^k + 2^(k-1))`. The obstruction is **structurally identical**
-    to the NW wall (the 4-corner overlap of the NE wave-1 sub-cells with the
-    centered region `[2^k, 2^k + 2^k)²` of the parent grid); the c.18 ai-01
-    authorization for the NW arm extends to the NE arm by symmetry of the
-    double-nine Hashlife decomposition. The `evolve_half_step` fold on the
-    LHS is mechanical (`← evolve_half_step k hk1`, sorry-free) — the residual
-    G3 half is the same 4-corner overlap wall, just indexed at `{2,3,5,6}`.
+/-- **Bridge G3 NE (miroir de `p4_nw_g3_bridge`).** Décharge la moitié (b)
+    outer-locality : le double half-step du parent, évalué au point recentré du
+    supercell NE, se transporte par `evolve_shift` + `evolve_box_agree_local`
+    sur le mur `p4_ne_overlap_wall`. Le vecteur de shift est
+    `(2^(k-1), 2^k + 2^(k-1))` (l'ancre du supercell NE dans le parent). -/
+private theorem p4_ne_g3_bridge
+    (k : Nat) (hk1 : 1 ≤ k)
+    (nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
+     sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se : MacroCell)
+    (R2 R3 R5 R6 : MacroCell)
+    (hR2 : R2 = hashlifeResultAux (k + 1) (node nw_ne ne_nw nw_se ne_sw))
+    (hR3 : R3 = hashlifeResultAux (k + 1) (node ne_nw ne_ne ne_sw ne_se))
+    (hR5 : R5 = hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
+    (hR6 : R6 = hashlifeResultAux (k + 1) (node ne_sw ne_se se_nw se_ne))
+    (hn1_l : (node nw_nw nw_ne nw_sw nw_se).level = k + 1)
+    (hn2_l : (node nw_ne ne_nw nw_se ne_sw).level = k + 1)
+    (hn3_l : (node ne_nw ne_ne ne_sw ne_se).level = k + 1)
+    (hn4_l : (node nw_sw nw_se sw_nw sw_ne).level = k + 1)
+    (hn5_l : (node nw_se ne_sw sw_ne se_nw).level = k + 1)
+    (hn6_l : (node ne_sw ne_se se_nw se_ne).level = k + 1)
+    (hn7_l : (node sw_nw sw_ne sw_sw sw_se).level = k + 1)
+    (hn1_w : (node nw_nw nw_ne nw_sw nw_se).wf = true)
+    (hn2_w : (node nw_ne ne_nw nw_se ne_sw).wf = true)
+    (hn3_w : (node ne_nw ne_ne ne_sw ne_se).wf = true)
+    (hn4_w : (node nw_sw nw_se sw_nw sw_ne).wf = true)
+    (hn5_w : (node nw_se ne_sw sw_ne se_nw).wf = true)
+    (hn6_w : (node ne_sw ne_se se_nw se_ne).wf = true)
+    (hn7_w : (node sw_nw sw_ne sw_sw sw_se).wf = true)
+    (hR2_l : R2.level = k) (hR3_l : R3.level = k)
+    (hR5_l : R5.level = k) (hR6_l : R6.level = k)
+    (hcc2 : centralCorrect (node nw_ne ne_nw nw_se ne_sw) (k - 1))
+    (hcc3 : centralCorrect (node ne_nw ne_ne ne_sw ne_se) (k - 1))
+    (hcc5 : centralCorrect (node nw_se ne_sw sw_ne se_nw) (k - 1))
+    (hcc6 : centralCorrect (node ne_sw ne_se se_nw se_ne) (k - 1))
+    (p : Int × Int)
+    (hp : (2^k : Int) ≤ p.1 ∧ p.1 < (2^k : Int) + 2^((k - 1) + 1) ∧
+          ((2^k + (2^k : Int))) ≤ p.2 ∧
+          p.2 < ((2^k + (2^k : Int))) + 2^((k - 1) + 1)) :
+    isAlive (evolve (2^k)
+        ((node (node nw_nw nw_ne nw_sw nw_se) (node ne_nw ne_ne ne_sw ne_se)
+               (node sw_nw sw_ne sw_sw sw_se) (node se_nw se_ne se_sw se_se)).toGrid
+          (0, 0))) p
+      = isAlive (evolve (2^(k - 1)) ((node R2 R3 R5 R6).toGrid (0, 0)))
+          (p.1 - (2^k : Int) + (2^(k - 1) : Int),
+           p.2 - ((2^k + (2^k : Int)) : Int) + (2^(k - 1) : Int)) := by
+  rw [evolve_half_step k hk1]
+  have h2k : (2^k : Int) = (2^(k - 1) : Int) + (2^(k - 1) : Int) := by
+    have hn : 2^k = 2^(k - 1) + 2^(k - 1) := by
+      set m := k - 1 with hm
+      have hkm : k = m + 1 := by omega
+      rw [hkm, Nat.pow_succ]; ring
+    exact_mod_cast hn
+  have hpt1 : p.1 - (2^k : Int) + (2^(k - 1) : Int) = p.1 - (2^(k - 1) : Int) := by omega
+  have hpt2 : p.2 - ((2^k + (2^k : Int)) : Int) + (2^(k - 1) : Int)
+      = p.2 - ((2^k : Int) + (2^(k - 1) : Int)) := by omega
+  rw [hpt1, hpt2]
+  have hR : isAlive (evolve (2^(k - 1)) ((node R2 R3 R5 R6).toGrid (0, 0)))
+        (p.1 - (2^(k - 1) : Int), p.2 - ((2^k : Int) + (2^(k - 1) : Int)))
+      = isAlive (evolve (2^(k - 1))
+          (shift ((2^(k - 1) : Int), (2^k : Int) + (2^(k - 1) : Int))
+            ((node R2 R3 R5 R6).toGrid (0, 0)))) p := by
+    rw [← evolve_shift, isAlive_shift]
+  rw [hR]
+  apply evolve_box_agree_local
+  intro q hq
+  rw [isAlive_shift]
+  exact p4_ne_overlap_wall k hk1
+    nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
+    sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se
+    R2 R3 R5 R6 hR2 hR3 hR5 hR6
+    hn1_l hn2_l hn3_l hn4_l hn5_l hn6_l hn7_l
+    hn1_w hn2_w hn3_w hn4_w hn5_w hn6_w hn7_w
+    hR2_l hR3_l hR5_l hR6_l
+    hcc2 hcc3 hcc5 hcc6 p hp q hq
 
-    **Hypotheses** (c.27 — properly-hypothesized statement, mirroring the
-    `p4_nw_supercell_agree` post-#8609 form): wf/level for the 4 R_j
-    + centralCorrect for each of the 4 wave-1 sub-cells n2/n3/n5/n6.
-    Extraction moves the bare `sorry` from `p4_succ_membership` mp NE branch
-    into this named lemma without changing the net count (4 → 4).
+/-- **NE super-cell agreement (P4, G3 pour le quadrant NE) — PROUVÉ (miroir c.94).**
+    Symétrique de `p4_nw_supercell_agree` pour le supercell NE
+    `node R2 R3 R5 R6` (recombinaisons `n2 n3 n5 n6`, chacune de niveau `k+1`,
+    G2 au niveau `k-1` via `ih`). Compare le double half-step du parent à `p`
+    contre le résultat wave-0 du supercell NE au point recentré
+    `p - (2^k, 2·2^k) + (2^(k-1), 2^(k-1))`.
 
-    Sorry count FLAT (8 → 8) : aucune preuve supprimée, l'énoncé est *renforcé*
-    (anti-régression §D ne s'applique pas). ai-01 en garde la preuve (tree-lock
-    #6875) ; la frontière reste au niveau `evolve` pour la compilabilité du
-    câblage. -/
+    **Renforcement d'énoncé (verdict prover BG DEMO — la forme libre était
+    FAUSSE)** : comme pour le mur NW (c.91-c.93), le quantificateur `p` libre
+    rendait l'énoncé réfutable (le point d'évaluation n'était pas contraint à
+    la fenêtre que le supercell représente). L'énoncé porte désormais :
+    (1) la fenêtre `hp` — la forme EXACTE des bornes produites par
+    `p4_ne_shift_lemma` (`hsup.2` dans `p4_ne_membership_arm`, zéro friction
+    de câblage) ; (2) les hypothèses structurelles `hn1..hn7` (niveau `k+1` +
+    `wf` des recombinaisons ET des enfants du parent touchés par les
+    exclusions de bornes — le mur NE en requiert 7 là où le mur NW en
+    requiert 4, car ses quadrants chevauchent les enfants NE/SE/SO du parent).
+    La preuve est le miroir exact de la chaîne NW :
+    `← evolve_half_step` → `p4_ne_g3_bridge` → `p4_ne_overlap_wall`. -/
 private theorem p4_ne_supercell_agree
     (k : Nat) (hk1 : 1 ≤ k)
     (nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
@@ -4476,13 +4805,30 @@ private theorem p4_ne_supercell_agree
     (hR3 : R3 = hashlifeResultAux (k + 1) (node ne_nw ne_ne ne_sw ne_se))
     (hR5 : R5 = hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
     (hR6 : R6 = hashlifeResultAux (k + 1) (node ne_sw ne_se se_nw se_ne))
+    (hn1_l : (node nw_nw nw_ne nw_sw nw_se).level = k + 1)
+    (hn2_l : (node nw_ne ne_nw nw_se ne_sw).level = k + 1)
+    (hn3_l : (node ne_nw ne_ne ne_sw ne_se).level = k + 1)
+    (hn4_l : (node nw_sw nw_se sw_nw sw_ne).level = k + 1)
+    (hn5_l : (node nw_se ne_sw sw_ne se_nw).level = k + 1)
+    (hn6_l : (node ne_sw ne_se se_nw se_ne).level = k + 1)
+    (hn7_l : (node sw_nw sw_ne sw_sw sw_se).level = k + 1)
+    (hn1_w : (node nw_nw nw_ne nw_sw nw_se).wf = true)
+    (hn2_w : (node nw_ne ne_nw nw_se ne_sw).wf = true)
+    (hn3_w : (node ne_nw ne_ne ne_sw ne_se).wf = true)
+    (hn4_w : (node nw_sw nw_se sw_nw sw_ne).wf = true)
+    (hn5_w : (node nw_se ne_sw sw_ne se_nw).wf = true)
+    (hn6_w : (node ne_sw ne_se se_nw se_ne).wf = true)
+    (hn7_w : (node sw_nw sw_ne sw_sw sw_se).wf = true)
     (hR2_l : R2.level = k) (hR3_l : R3.level = k)
     (hR5_l : R5.level = k) (hR6_l : R6.level = k)
     (hcc2 : centralCorrect (node nw_ne ne_nw nw_se ne_sw) (k - 1))
     (hcc3 : centralCorrect (node ne_nw ne_ne ne_sw ne_se) (k - 1))
     (hcc5 : centralCorrect (node nw_se ne_sw sw_ne se_nw) (k - 1))
     (hcc6 : centralCorrect (node ne_sw ne_se se_nw se_ne) (k - 1))
-    (p : Int × Int) :
+    (p : Int × Int)
+    (hp : (2^k : Int) ≤ p.1 ∧ p.1 < (2^k : Int) + 2^((k - 1) + 1) ∧
+          ((2^k + (2^k : Int))) ≤ p.2 ∧
+          p.2 < ((2^k + (2^k : Int))) + 2^((k - 1) + 1)) :
     isAlive (evolve (2^(k - 1)) (evolve (2^(k - 1))
         ((node (node nw_nw nw_ne nw_sw nw_se) (node ne_nw ne_ne ne_sw ne_se)
                (node sw_nw sw_ne sw_sw sw_se) (node se_nw se_ne se_sw se_se)).toGrid
@@ -4490,13 +4836,15 @@ private theorem p4_ne_supercell_agree
       = isAlive (evolve (2^(k - 1)) ((node R2 R3 R5 R6).toGrid (0, 0)))
           (p.1 - (2^k : Int) + (2^(k - 1) : Int),
            p.2 - ((2^k + (2^k : Int)) : Int) + (2^(k - 1) : Int)) := by
-  -- The LHS fold `evolve 2^k = evolve 2^(k-1) ∘ evolve 2^(k-1)` is mechanical
-  -- (same as NW, sorry-free via `evolve_half_step` L2370). The residual is the
-  -- 4-corner overlap wall at indices `{2,3,5,6}` (NE wave-1 sub-cells) — the
-  -- structural mirror of `p4_nw_overlap_wall` (L2945) — and lives as its own
-  -- named lemma `p4_ne_overlap_wall` (DEFERRED, see diagnostic in body).
   rw [← evolve_half_step k hk1]
-  sorry
+  exact p4_ne_g3_bridge k hk1
+    nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
+    sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se
+    R2 R3 R5 R6 hR2 hR3 hR5 hR6
+    hn1_l hn2_l hn3_l hn4_l hn5_l hn6_l hn7_l
+    hn1_w hn2_w hn3_w hn4_w hn5_w hn6_w hn7_w
+    hR2_l hR3_l hR5_l hR6_l
+    hcc2 hcc3 hcc5 hcc6 p hp
 
 /-- **P4.4 NE-quadrant shift lemma (c.8122, defensive factorization).**
     Caractérise l'appartenance pointwise `p ∈ (hashlifeResultAux (k+1) q_ne).toGrid (2^k, 2^k + 2^k)`
@@ -4538,14 +4886,16 @@ private theorem p4_ne_shift_lemma
   exact centralCorrect_mem_shift (node r1 r2 r4 r5) (k - 1)
     (2^k) (2^k + (2^k : Int)) p hcc
 
-set_option maxHeartbeats 1000000 in
+set_option maxHeartbeats 4000000 in
 /-- **NE membership arm (opaque-binder, sorry-free wiring — c.8122 mirror of NW).**
     Discharges the NE quadrant of `p4_succ_membership` over OPAQUE wave-1
     results `R2 R3 R5 R6` (NE supercell wave-1 sub-cells), so this declaration
     gets a fresh 200000-heartbeat budget. The `p4_succ_membership` call site
     merely *applies* this arm with `R_j := hashlifeResultAux (k+1) n_j`
-    (pure substitution, no whnf). The one residual sorry lives in
-    `p4_ne_supercell_agree`; here everything else is wired.
+    (pure substitution, no whnf). `p4_ne_supercell_agree` is now PROVED
+    (strengthened with the `hp` window + `hn1..hn7` structural hypotheses,
+    mirror of the NW chain); the arm feeds it `hsup.2` — the shift-lemma
+    window — as `hp`, zero wiring friction.
 
     Chain: `p4_ne_shift_lemma.mp` (supercell isAlive at `p'` + window bounds
     at NE offset `(2^k, 2^k + 2^(k-1))`) → `mem_restrictGridTo` →
@@ -4562,14 +4912,20 @@ private theorem p4_ne_membership_arm
     (hR3 : R3 = hashlifeResultAux (k + 1) (node ne_nw ne_ne ne_sw ne_se))
     (hR5 : R5 = hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
     (hR6 : R6 = hashlifeResultAux (k + 1) (node ne_sw ne_se se_nw se_ne))
+    (hn1_l : (node nw_nw nw_ne nw_sw nw_se).level = k + 1)
     (hn2_l : (node nw_ne ne_nw nw_se ne_sw).level = k + 1)
     (hn3_l : (node ne_nw ne_ne ne_sw ne_se).level = k + 1)
+    (hn4_l : (node nw_sw nw_se sw_nw sw_ne).level = k + 1)
     (hn5_l : (node nw_se ne_sw sw_ne se_nw).level = k + 1)
     (hn6_l : (node ne_sw ne_se se_nw se_ne).level = k + 1)
+    (hn7_l : (node sw_nw sw_ne sw_sw sw_se).level = k + 1)
+    (hn1_w : (node nw_nw nw_ne nw_sw nw_se).wf = true)
     (hn2_w : (node nw_ne ne_nw nw_se ne_sw).wf = true)
     (hn3_w : (node ne_nw ne_ne ne_sw ne_se).wf = true)
+    (hn4_w : (node nw_sw nw_se sw_nw sw_ne).wf = true)
     (hn5_w : (node nw_se ne_sw sw_ne se_nw).wf = true)
     (hn6_w : (node ne_sw ne_se se_nw se_ne).wf = true)
+    (hn7_w : (node sw_nw sw_ne sw_sw sw_se).wf = true)
     (hR1_l : R1.level = k) (hR2_l : R2.level = k) (hR3_l : R3.level = k)
     (hR5_l : R5.level = k) (hR6_l : R6.level = k)
     (hR1_w : R1.wf = true) (hR2_w : R2.wf = true) (hR3_w : R3.wf = true)
@@ -4598,11 +4954,11 @@ private theorem p4_ne_membership_arm
   -- consumes `hout_nw_l : hout_nw.level = k`. Then the NE shift lemma's `.mp`
   -- is whnf-clean over opaque `R_j` (fresh budget).
   rw [show (k + 1) = (k - 1) + 2 from by omega] at hne
-  have hpow : (2^hout_nw.level : Int) = (2^k : Int) :=
-    congrArg (fun n => (2^n : Int)) hout_nw_l
-  have hbridge : (2^k + (2^hout_nw.level : Int)) = (2^k + (2^k : Int)) := by
-    rw [hpow]
-  rw [hbridge] at hne
+  -- Inline bridge (no residual context equations: leftover `hpow`/`hbridge`
+  -- hypotheses with `2^hout_nw.level` atoms poison every downstream `omega`
+  -- preprocessing pass — cumulative heartbeat exhaustion, cf. build c.8122-NE).
+  rw [show (2^k + (2^hout_nw.level : Int)) = (2^k + (2^k : Int)) from by
+    rw [congrArg (fun n => (2^n : Int)) hout_nw_l]] at hne
   have hsup := (p4_ne_shift_lemma k hk1 R2 R3 R5 R6
       hR2_l hR3_l hR5_l hR6_l hR2_w hR3_w hR5_w hR6_w ih p).mp hne
   -- hsup.1 : isAlive (evolve 2^(k-1) ((node R2 R3 R5 R6).toGrid 0)) p' = true
@@ -4628,7 +4984,9 @@ private theorem p4_ne_membership_arm
           nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
           sw_nw sw_ne sw_sw sw_se se_nw se_ne se_sw se_se
           R2 R3 R5 R6 hR2 hR3 hR5 hR6
-          hR2_l hR3_l hR5_l hR6_l hcc2 hcc3 hcc5 hcc6 p]
+          hn1_l hn2_l hn3_l hn4_l hn5_l hn6_l hn7_l
+          hn1_w hn2_w hn3_w hn4_w hn5_w hn6_w hn7_w
+          hR2_l hR3_l hR5_l hR6_l hcc2 hcc3 hcc5 hcc6 p hsup.2]
     exact hsup.1
   · -- 2^k ≤ p.1
     exact hsup.2.1
@@ -5388,6 +5746,10 @@ noncomputable def p4_succ_membership
                                               hnw_sw_w hnw_se_w hsw_nw_w hsw_ne_w
       have r_nw_sw := wave1_result_facts k hk1 (node nw_sw nw_se sw_nw sw_ne)
                                           hn_nw_sw.2 hn_nw_sw.1
+      -- n7 = node sw_nw sw_ne sw_sw sw_se (the OUTER SW child of the parent —
+      -- structural-only hypothesis for the NE wall's bound exclusions, no hcc).
+      have hn7 := node_wf_level_of_four hsw_nw_l hsw_ne_l hsw_sw_l hsw_se_l
+                                        hsw_nw_w hsw_ne_w hsw_sw_w hsw_se_w
       -- Normalize hne's Nat-cast offset `↑(2^k + 2^(k-1))` to the Int form so
       -- it unifies with the arm's hypothesis. Then construct the OUTER NW
       -- supercell `out_nw = R1.node R2 (R_nw_sw) R5` (the level-(k+1) input cell
@@ -5442,8 +5804,8 @@ noncomputable def p4_succ_membership
         (hashlifeResultAux (k + 1) (node nw_se ne_sw sw_ne se_nw))
         (hashlifeResultAux (k + 1) (node ne_sw ne_se se_nw se_ne))
         rfl rfl rfl rfl rfl
-        hn2.1 hn3.1 hn5.1 hn6.1
-        hn2.2 hn3.2 hn5.2 hn6.2
+        hn1.1 hn2.1 hn3.1 hn_nw_sw.1 hn5.1 hn6.1 hn7.1
+        hn1.2 hn2.2 hn3.2 hn_nw_sw.2 hn5.2 hn6.2 hn7.2
         r1.1 r2.1 r3.1 r5.1 r6.1
         (wf_of_cellWf r1.2) (wf_of_cellWf r2.2) (wf_of_cellWf r3.2)
         (wf_of_cellWf r5.2) (wf_of_cellWf r6.2)


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-ai-01:CoursIA — prev: MED/notebook-python #9792

## Summary

Quadrant NE de P4 dans `HashlifeCorrectness.lean` (miroir de la chaîne NW prouvée) :

- **`p4_ne_supercell_agree` PROUVÉ** (signature renforcée : 16 binders `MacroCell` + R2/R3/R5/R6 + hypothèses level/wf `hn1..hn7` + point `p` borné — la leçon #9565 : jamais de quantificateur `p` libre).
- **Corollaire shift-lemma NE + `p4_ne_membership_arm` câblés au site d'appel succ** (`evolve_half_step k`, `ih` sur les 4 cellules centrales hcc2/hcc3/hcc5/hcc6, bullets de bornes).
- **Décrément de baseline 7 → 6 dans la même PR** (gate bidirectionnelle #8853/#8856) + réalignement du bloc de profil de `lean-conway.yml`, resté à l'ère-9 alors que la valeur était déjà à 7.

## Preuve de progrès (§B pr-review-discipline)

**B.1 — comptes avant/après (firsthand, deux compteurs)** :

| Compteur | Avant | Après |
|---|---|---|
| `python -m prover.lean_utils` (mode `real`, canonique) sur `HashlifeCorrectness.lean` | 6 | **5** |
| Réplication exacte du script CI standalone-tactic (`tr -d '\302\267' \| grep -cE '^\s*sorry\s*$'`, hors `*_en.lean`, hors `.lake/`), total lake | 7 | **6** = HashlifeCorrectness 5 + HashlifeMarginFragment 1 (framework sorry Livrable B #9568, hors scope) |

Sorries restants de `HashlifeCorrectness.lean`, tous listés par le build : `p4_sw_overlap_wall` (5106), `p4_sw_supercell_agree` (5153), `p4_se_overlap_wall` (5329), `p4_succ_membership` (5620), `p5_large_n_jumpN` (6516).

**B.2 — lake build SUCCESS (local WSL)** : `lake build Conway.Life.HashlifeCorrectness` → `Build completed successfully (8498 jobs)`, exit 0, exactement 5 warnings `declaration uses sorry` aux 5 lignes ci-dessus. Branche rebasée sur `origin/main` (post-#9780) avant le build de la CI.

**B.3 — proof-integrity : non applicable pour ce module (écrit explicitement, #8782)**. La gate bloquante de `lean-conway.yml` cible `Conway.KochenSpecker` + `Conway.FreeWillTheorem`, dont la clôture d'imports n'atteint pas `Conway.Life.HashlifeCorrectness`. Le module est couvert par le job advisory ` (audit)` (`fail-on-sorry: false`, honesty knob) : le `sorryAx` des 5 sorries restants y est ATTEINT, pas caché.

**B.4** — aucun refactor du prover Python (le diff ne touche que le `.lean` + `lean-conway.yml`).

## Incident heartbeat + fix (diagnostic)

Premier build : `(deterministic) timeout at whnf, maximum heartbeats (1000000)` dans le bras NE (mort à `hcc3`), alors que le bras NW passe au budget par défaut (200k) et SW/SE à 1M avec le même squelette. Diagnostic : la signature NE plus large (16 binders + 5 R + hyps hn1..hn7) laisse des équations de contexte `hpow`/`hbridge` avec atomes `2^hout_nw.level` qui empoisonnent chaque passe de préprocessing `omega` en aval — épuisement cumulatif. Fix : **bridge inline** (`rw [show … from by rw [congrArg …]]`, zéro équation résiduelle dans le contexte) + budget 1M → 4M (précédent existant à 4M ligne 4070 du même fichier).

## Anti-régression (§D)

`git diff --stat` : 1 fichier Lean, **+411/−49** (insertions ≫ deletions). Aucune preuve remplacée par sorry — au contraire : le scaffold `p4_ne_supercell_agree` (sorry depuis #9132) devient une preuve. Le décrément de baseline est la conséquence mécanique de la gate bidirectionnelle.

## Scope

2 fichiers : `HashlifeCorrectness.lean` + `.github/workflows/lean-conway.yml` (décrément + profil). Catalogue byte-identique à main. Reste du lake intouché — les miroirs SW/SE (`p4_sw_overlap_wall`, `p4_sw_supercell_agree`, `p4_se_overlap_wall`) restent sorried, périmètre po-2023 (#6724).

See #6724 (partial: NE quadrant) · See #9568 (MarginFragment hors scope, compté dans la baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
