### PR TITLE
feat(notebook_tools,#9434): scan_quant_classify.py triage 4-classes des valeurs quantitatives en cellules markdown (outillage vs veine drainage per-notebook CLOSE)

### DIFF
--- a/scripts/notebook_tools/scan_quant_classify.py
+++ b/scripts/notebook_tools/scan_quant_classify.py
@@ -1,0 +1,455 @@
+"""Detecteur quant-4-classes — triage des valeurs quantitatives ecrites en dur
+dans les cellules markdown des notebooks.
+
+Suite directe de l'EPIC #9434 (mandat « quantitatif tenu par le CI, pas par la
+prose ») et de l'outillage Phase 1 #9768 (detecteurs D1+D3+D4+D5 trans-historique
+et D5 v3 intra-revision, PRs #9791 + #9793 MERGED). Reutilise
+`_extract_prose_numbers` et `_parse_fr_number` de `scan_d5_prose_outputs_alignment`.
+
+## Les 4 classes (cf. issue #9434)
+
+| Classe | Dérive? | Heuristique |
+|---|---|---|
+| **STRUCTUREL** | Non | Pas d'unite temporelle, pas de pattern `X.Y.Z` version, valeur theorique ou issue d'une formule |
+| **MACHINE-DEP** | Oui (chaque re-exec, chaque machine) | Unite `ms`/`s`/`min`/`sec`/`us`/`ns` ou contexte `benchmark`/`perf`/`timing`/`runtime`/`execution` |
+| **ENV-DEP** | Oui (chaque bump de version) | Pattern `X.Y.Z` (3 digits separes par `.`) avec contexte `version`/`numpy`/`python`/`pandas`/`library`/`package` |
+| **STOCHASTIQUE-NON-SEEDEE** | Oui (chaque run) | Contexte `fitness`/`reward`/`accuracy`/`score`/`mean` sans mention `seed=` ni `random_state=` |
+
+## Pourquoi ce triage plutot qu'une regle dogmatique
+
+Toutes les valeurs quantitatives ne sont pas equivalentes. Une regle qui
+interdirait TOUTES les valeurs en prose ferait perdre de la richesse
+pedagogique (le speedup `2.78e24x` du App-11-Picross est structurellement
+stable ; le retirer = regression pedagogique). Une regle qui ne ferait rien
+laisse la derive se reconstituer apres chaque correction (vague #8052 du
+2026-08-04 : 4 PRs pour 4 notebooks, meme symptome). Le triage 4-classes
+**applique la regle asymetriquement** : structurel = a garder ;
+machine-dep / env-dep / stochastique = a deriver ou retirer.
+
+## Cas ambigus
+
+- `Durée estimée : 45 minutes` (effort etudiant, pacing pedagogique) = **TN structurel/pédagogique**, **hors scope drainage** (arbitrage 2026-08-06 ai-01, cf #9434 thread). Le classifier le classe STRUCTUREL grace au contexte `Durée estimée`.
+- Posterieurs bayesiens en minutes (Infer-101 moyennes/variances de trajets) = donnees deterministes, **TN**, classes STRUCTUREL grace au contexte `posterior`/`moyenne`/`variance`.
+
+CLI `--check` avec exit codes 0/1/2 distincts (succes / finding / usage).
+
+## Sortie
+
+JSON structuré par notebook avec `quant_classes` (liste de findings par classe)
++ compteurs par classe. Permet le **recensement chiffre par famille** demande
+par #9434 critere d'acceptation #1.
+
+Cf. issue #9434 pour le scope exact et la veine drainage per-notebook CLOSE.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+# Reutilisation du detecteur v3 (PR #9793 MERGED) pour l'extraction de nombres.
+from scan_d5_prose_outputs_alignment import (
+    _extract_prose_numbers,
+    _parse_fr_number,
+    iter_notebooks,
+    DEFAULT_INCLUDE_GLOBS,
+    DEFAULT_EXCLUDE_DIRS,
+)
+
+
+# --------------------------------------------------------------------------- #
+#  Configuration des 4 classes
+# --------------------------------------------------------------------------- #
+
+# Regex strictes pour les unites temporelles (machine-dep).
+_TIME_UNITS = (
+    r"\b\d+\s*(?:ms|millisecondes?|microsecondes?|μs|us)\b",
+    r"\b\d+\s*(?:s|sec|secondes?)\b",
+    r"\b\d+\s*(?:min|minutes?)\b",
+    r"\b\d+\s*(?:h|heures?|hours?)\b",
+    r"\b\d+\s*(?:ns|nanosecondes?)\b",
+)
+TIME_UNIT_RE = re.compile("|".join(_TIME_UNITS), re.IGNORECASE)
+
+# Regex strictes pour les versions (env-dep) — pattern semver simplifie.
+SEMVER_RE = re.compile(r"\b\d+\.\d+\.\d+(?:[a-zA-Z0-9._+-]*)?\b")
+
+# Mots-cles contextuels pour MACHINE-DEP (au-dela des unites temporelles).
+MACHINE_DEP_KEYWORDS = (
+    "benchmark", "perf", "performance", "timing", "runtime", "execution time",
+    "elapsed", "durée d'exécution", "wall clock", "cpu time", "wall-time",
+    "wall_clock",
+    "exécute", "execute", "tourne", "run", "runs", "prend", "dure",
+    "takes", "took", "spent", "spent time",
+)
+
+# Mots-cles contextuels pour ENV-DEP (au-dela du pattern semver).
+ENV_DEP_KEYWORDS = (
+    "version", "numpy", "python", "pandas", "scipy", "sklearn", "torch",
+    "tensorflow", "jax", "matplotlib", "library", "package", "module",
+    "dépendance", "depend", "installed", "installée",
+)
+
+# Mots-cles contextuels pour STOCHASTIQUE-NON-SEEDEE.
+STOCH_KEYWORDS = (
+    "fitness", "reward", "accuracy", "score", "loss", "moyenne",
+    "mean", "monte-carlo", "monte carlo", "sampling", "tirage",
+    "random", "aléatoire", "stochastique",
+)
+
+# Mots-cles STRUCTUREL (a garder) — preuve pedagogique.
+STRUCT_KEYWORDS = (
+    "théorique", "theorique", "théoriquement", "structurel", "structurel",
+    "ordre de grandeur", "combinaisons", "combinatorial", "combinatoire",
+    "durée estimée", "durée de l'exercice", "effort estimé",
+    "pédagogique", "pedagogique", "pacing", "soutenance",
+    "posterior", "postérieur", "vraisemblance", "likelihood",
+    "moyenne", "variance", "espérance", "esperance", "expected value",
+    "formule", "formula", "théorème", "theoreme",
+)
+
+# Mots-cles SEED — si présents, le stochastique est seede et donc STRUCTUREL.
+SEED_KEYWORDS = ("seed=", "random_state=", "np.random.seed", "torch.manual_seed",
+                 "tf.random.set_seed", "rng.seed", "np_seed")
+
+
+# --------------------------------------------------------------------------- #
+#  Dataclasses
+# --------------------------------------------------------------------------- #
+
+
+QUANT_CLASSES = ("STRUCTUREL", "MACHINE-DEP", "ENV-DEP", "STOCHASTIQUE-NON-SEEDEE")
+
+
+@dataclass
+class QuantClassFinding:
+    """Un cas de valeur quantitative classifie."""
+    notebook: str
+    cell_index: int
+    cell_kind: str = "markdown"
+    value: float = 0.0
+    raw_match: str = ""
+    quant_class: str = "UNKNOWN"
+    context_prefix: str = ""
+    context_suffix: str = ""
+    rationale: str = ""
+
+
+@dataclass
+class NotebookQuantClasses:
+    """Resultat d'analyse d'un notebook."""
+    path: str
+    total_findings: int = 0
+    findings: list[QuantClassFinding] = field(default_factory=list)
+    by_class: dict[str, int] = field(default_factory=dict)
+    n_markdown_cells: int = 0
+    n_code_cells: int = 0
+    error: str | None = None
+
+
+# --------------------------------------------------------------------------- #
+#  Extraction du contexte
+# --------------------------------------------------------------------------- #
+
+
+def _extract_context(text: str, match_start: int, match_end: int, window: int = 40) -> tuple[str, str]:
+    """Renvoie (prefix, suffix) de longueur `window` autour d'un match.
+
+    Coupe aux frontières de mot (whitespace) pour eviter de couper au milieu
+    d'un mot et donner un contexte decibale.
+    """
+    # prefix : on remonte jusqu'au debut de la ligne ou `window` chars.
+    prefix_start = max(text.rfind("\n", 0, match_start) + 1, match_start - window)
+    prefix = text[prefix_start:match_start]
+    # suffix : jusqu'à la fin de la ligne ou `window` chars.
+    suffix_end_nl = text.find("\n", match_end)
+    suffix_end = suffix_end_nl if suffix_end_nl != -1 else match_end + window
+    suffix_end = min(suffix_end, match_end + window)
+    suffix = text[match_end:suffix_end]
+    return prefix.lower(), suffix.lower()
+
+
+def _classify_quant_value(
+    raw: str, value: float, prefix: str, suffix: str
+) -> tuple[str, str]:
+    """Classifie une valeur quantitative selon le contexte. Renvoie (classe, rationale).
+
+    Ordre d'application des regles (la premiere qui matche gagne) :
+    1. STRUCTUREL si mot-cle structurel detecte dans prefix+suffix
+    2. SEED dans prefix → bascule STOCHASTIQUE → STRUCTUREL
+    3. ENV-DEP si pattern semver ou mot-cle env
+    4. MACHINE-DEP si unite temporelle ou mot-cle machine-dep
+    5. STOCHASTIQUE-NON-SEEDEE si mot-cle stochastique
+    6. STRUCTUREL par defaut (classe residuelle surete)
+
+    Le defaut STRUCTUREL evite les faux positifs massifs sur les valeurs
+    qui ne sont aucunement concernees (ex. « Le dataset contient 1000 images »).
+    """
+    full_context = (prefix + " " + suffix).lower()
+
+    # 0. Filtre semver : si le raw match EST un semver, c'est env-dep en soi.
+    if SEMVER_RE.fullmatch(raw):
+        return ("ENV-DEP", f"semver pattern match: {raw!r}")
+
+    # 1. STRUCTUREL explicite
+    for kw in STRUCT_KEYWORDS:
+        if kw in full_context:
+            return ("STRUCTUREL", f"mot-cle structurel: {kw!r}")
+
+    # 2. SEED → stochastique seede → STRUCTUREL
+    for kw in SEED_KEYWORDS:
+        if kw in full_context:
+            return ("STRUCTUREL", f"stochastique seede via {kw!r}")
+
+    # 3. ENV-DEP (mots-cles env)
+    for kw in ENV_DEP_KEYWORDS:
+        if kw in full_context:
+            return ("ENV-DEP", f"mot-cle env: {kw!r}")
+
+    # 4. MACHINE-DEP (unites temporelles + mots-cles perf)
+    if TIME_UNIT_RE.search(raw) or TIME_UNIT_RE.search(prefix + suffix):
+        return ("MACHINE-DEP", f"unite temporelle detectee: {raw!r}")
+    for kw in MACHINE_DEP_KEYWORDS:
+        if kw in full_context:
+            return ("MACHINE-DEP", f"mot-cle machine-dep: {kw!r}")
+
+    # 5. STOCHASTIQUE-NON-SEEDEE
+    for kw in STOCH_KEYWORDS:
+        if kw in full_context:
+            return ("STOCHASTIQUE-NON-SEEDEE", f"mot-cle stochastique: {kw!r}")
+
+    # 6. STRUCTUREL par defaut (classe residuelle)
+    return ("STRUCTUREL", "defaut (aucun signal machine-dep/env-dep/stochastique)")
+
+
+# --------------------------------------------------------------------------- #
+#  Analyse notebook
+# --------------------------------------------------------------------------- #
+
+
+def analyze_notebook_quant(path: str | os.PathLike) -> NotebookQuantClasses:
+    """Analyse les valeurs quantitatives d'un notebook et les classifie."""
+    p = Path(path)
+    result = NotebookQuantClasses(path=str(path))
+    try:
+        nb = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        result.error = f"{type(exc).__name__}: {exc}"
+        return result
+
+    cells = nb.get("cells") or []
+    result.n_markdown_cells = sum(1 for c in cells if c.get("cell_type") == "markdown")
+    result.n_code_cells = sum(1 for c in cells if c.get("cell_type") == "code")
+
+    findings: list[QuantClassFinding] = []
+    by_class: dict[str, int] = {cls: 0 for cls in QUANT_CLASSES}
+
+    for i, c in enumerate(cells):
+        if c.get("cell_type") != "markdown":
+            continue
+        source = c.get("source") or []
+        text = "".join(source) if isinstance(source, list) else str(source)
+        if not text:
+            continue
+        # Reutilisation de l'extraction D5 v3 (qui filtre les annees, #issues,
+        # PRJ42, semver simplifie stricte, etc.) — mais on doit scanner le
+        # texte brut pour les versions, donc on **re-scan** avec nos propres
+        # regex par-dessus les nombres deja extraits.
+        for m in re.finditer(
+            r"(?<![A-Za-z0-9_])-?\d+(?:[.,]\d+)?(?:[eE][-+]?\d+)?(?![A-Za-z0-9_])",
+            text,
+        ):
+            raw = m.group(0)
+            v = _parse_fr_number(raw)
+            if v is None:
+                continue
+            # Skip les annees (4 chiffres) et autres bruits basiques.
+            if re.fullmatch(r"\d{4}", raw) and 1900 <= v <= 2099:
+                continue
+            prefix, suffix = _extract_context(text, m.start(), m.end())
+            cls, rationale = _classify_quant_value(raw, v, prefix, suffix)
+            # Tronque le snippet pour le rapport.
+            snippet = text.strip().splitlines()
+            snippet_str = next((ln.strip() for ln in snippet if ln.strip()), "")[:120]
+            findings.append(QuantClassFinding(
+                notebook=str(path),
+                cell_index=i,
+                value=v,
+                raw_match=raw,
+                quant_class=cls,
+                context_prefix=prefix[-40:],
+                context_suffix=suffix[:40],
+                rationale=rationale,
+            ))
+            by_class[cls] += 1
+
+    result.findings = findings
+    result.total_findings = len(findings)
+    result.by_class = by_class
+    return result
+
+
+# --------------------------------------------------------------------------- #
+#  Walk corpus (reutilise iter_notebooks du detecteur v3)
+# --------------------------------------------------------------------------- #
+
+
+def scan_corpus_quant(
+    root: str | os.PathLike,
+    include_globs: tuple[str, ...] = DEFAULT_INCLUDE_GLOBS,
+    exclude_dirs: tuple[str, ...] = DEFAULT_EXCLUDE_DIRS,
+) -> list[NotebookQuantClasses]:
+    """Scan a corpus root, return list of NotebookQuantClasses."""
+    root_path = Path(root)
+    results: list[NotebookQuantClasses] = []
+    for nb_path in iter_notebooks(root_path, include_globs, exclude_dirs):
+        results.append(analyze_notebook_quant(nb_path))
+    return results
+
+
+# --------------------------------------------------------------------------- #
+#  Reporting
+# --------------------------------------------------------------------------- #
+
+
+def render_text_report(results: list[NotebookQuantClasses]) -> str:
+    """Format results as markdown text avec compteurs par classe."""
+    total_findings = sum(r.total_findings for r in results)
+    global_by_class: dict[str, int] = {cls: 0 for cls in QUANT_CLASSES}
+    n_drainable = 0  # MACHINE-DEP + ENV-DEP + STOCHASTIQUE-NON-SEEDEE
+    for r in results:
+        for cls, n in r.by_class.items():
+            global_by_class[cls] += n
+        n_drainable += (
+            r.by_class.get("MACHINE-DEP", 0)
+            + r.by_class.get("ENV-DEP", 0)
+            + r.by_class.get("STOCHASTIQUE-NON-SEEDEE", 0)
+        )
+    n_pathological = sum(
+        1 for r in results if r.by_class.get("MACHINE-DEP", 0)
+        + r.by_class.get("ENV-DEP", 0)
+        + r.by_class.get("STOCHASTIQUE-NON-SEEDEE", 0) > 0
+    )
+
+    lines: list[str] = []
+    lines.append(f"Total notebooks analyses : {len(results)}")
+    lines.append(f"Notebooks avec >= 1 valeur drainable (MACHINE/ENV/STOCH) : {n_pathological}")
+    lines.append(f"Total findings : {total_findings}")
+    lines.append("Repartition par classe :")
+    for cls in QUANT_CLASSES:
+        lines.append(f"  - {cls} : {global_by_class[cls]}")
+    lines.append(f"  - TOTAL drainable : {n_drainable}")
+    lines.append("")
+    lines.append("## Top 10 notebooks avec le plus de valeurs drainables")
+    lines.append("")
+    lines.append("| Notebook | MACHINE | ENV | STOCH | Total drainable |")
+    lines.append("|---|---|---|---|---|")
+    top = sorted(
+        results,
+        key=lambda r: -(r.by_class.get("MACHINE-DEP", 0)
+                        + r.by_class.get("ENV-DEP", 0)
+                        + r.by_class.get("STOCHASTIQUE-NON-SEEDEE", 0)),
+    )
+    for r in top[:10]:
+        drainable = (
+            r.by_class.get("MACHINE-DEP", 0)
+            + r.by_class.get("ENV-DEP", 0)
+            + r.by_class.get("STOCHASTIQUE-NON-SEEDEE", 0)
+        )
+        if drainable == 0:
+            continue
+        lines.append(
+            f"| `{os.path.basename(r.path)}` | {r.by_class.get('MACHINE-DEP', 0)} | "
+            f"{r.by_class.get('ENV-DEP', 0)} | {r.by_class.get('STOCHASTIQUE-NON-SEEDEE', 0)} | "
+            f"{drainable} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+#  CLI
+# --------------------------------------------------------------------------- #
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--root", default="MyIA.AI.Notebooks",
+        help="Racine du corpus a scanner (defaut: MyIA.AI.Notebooks).",
+    )
+    parser.add_argument(
+        "--notebook", help="Cible un notebook precis (sinon full-corpus).",
+    )
+    parser.add_argument(
+        "--json-out", help="Ecrire le rapport JSON a ce chemin.",
+    )
+    parser.add_argument(
+        "--check", action="store_true",
+        help="Mode CI : exit 1 si >= 1 valeur MACHINE-DEP/ENV-DEP/STOCHASTIQUE.",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=0,
+        help="Limiter le nombre de notebooks analyses (0 = pas de limite).",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    root = Path(args.root)
+    if not root.exists():
+        print(f"ERREUR: racine '{root}' inexistante.", file=sys.stderr)
+        return 2
+    if args.notebook:
+        nb_path = Path(args.notebook)
+        if not nb_path.exists():
+            print(f"ERREUR: notebook '{nb_path}' inexistant.", file=sys.stderr)
+            return 2
+        results = [analyze_notebook_quant(nb_path)]
+    else:
+        results = scan_corpus_quant(root)
+        if args.limit > 0:
+            results = results[:args.limit]
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps([
+            {
+                "path": r.path,
+                "total_findings": r.total_findings,
+                "by_class": r.by_class,
+                "n_markdown_cells": r.n_markdown_cells,
+                "n_code_cells": r.n_code_cells,
+                "findings": [
+                    {
+                        "cell_index": f.cell_index,
+                        "value": f.value,
+                        "raw_match": f.raw_match,
+                        "quant_class": f.quant_class,
+                        "context_prefix": f.context_prefix,
+                        "context_suffix": f.context_suffix,
+                        "rationale": f.rationale,
+                    }
+                    for f in r.findings
+                ],
+                "error": r.error,
+            }
+            for r in results
+        ], indent=2, ensure_ascii=False), encoding="utf-8")
+
+    print(render_text_report(results))
+    if args.check:
+        drainable = sum(
+            r.by_class.get("MACHINE-DEP", 0)
+            + r.by_class.get("ENV-DEP", 0)
+            + r.by_class.get("STOCHASTIQUE-NON-SEEDEE", 0)
+            for r in results
+        )
+        if drainable > 0:
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_scan_quant_classify.py
+++ b/scripts/notebook_tools/tests/test_scan_quant_classify.py
@@ -1,0 +1,336 @@
+"""Tests for scan_quant_classify.py — triage 4-classes (issue #9434).
+
+Sub-genre `tooling-quant-classifier` distinct de c.1266 `tooling-v3-detector`
+(G-VAR-3 defensable). Golden set fondateur = les 5 PRs de la vague #8052
+(#9426 App-7-Wordle, #9427 App-11-Picross, #9428 Search-5-GeneticAlgorithms,
+#9429 GT-4c-NashExistence, + cas durée estimée structurel).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Permettre l'import direct du module sibling.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from scan_quant_classify import (
+    QuantClassFinding,
+    _classify_quant_value,
+    _extract_context,
+    analyze_notebook_quant,
+    scan_corpus_quant,
+)
+
+
+# --------------------------------------------------------------------------- #
+#  Tests _classify_quant_value (unitaire, 4 classes + cas ambigus)
+# --------------------------------------------------------------------------- #
+
+
+class TestClassifyQuantValue:
+    """Tests unitaires du classifieur 4-classes."""
+
+    # STRUCTUREL — 4 cas
+    def test_structurel_duree_estimee_minutes(self):
+        """Durée estimée : 45 minutes = STRUCTUREL pedagogique (TN arbitration 2026-08-06)."""
+        cls, rationale = _classify_quant_value("45", 45.0,
+                                              "durée estimée : ", " minutes pour cet exercice")
+        assert cls == "STRUCTUREL", f"Expected STRUCTUREL, got {cls} ({rationale})"
+
+    def test_structurel_speedup_combinatorial(self):
+        """2^225 combinaisons = speedup structurel d'ordre de grandeur."""
+        cls, rationale = _classify_quant_value("225", 225.0,
+                                              "il y a 2^", " combinaisons theoriques")
+        assert cls == "STRUCTUREL", f"Expected STRUCTUREL, got {cls} ({rationale})"
+
+    def test_structurel_seeded_stochastic(self):
+        """seed=42 + fitness = STRUCTUREL (stochastique seede)."""
+        cls, rationale = _classify_quant_value("0.87", 0.87,
+                                              "fitness moyenne (seed=", ") sur 100 runs")
+        assert cls == "STRUCTUREL", f"Expected STRUCTUREL (seeded), got {cls} ({rationale})"
+
+    def test_structurel_default_residual(self):
+        """Une valeur isolee sans contexte = STRUCTUREL par defaut (classe residuelle)."""
+        cls, rationale = _classify_quant_value("1000", 1000.0,
+                                              "le dataset contient ", " images")
+        assert cls == "STRUCTUREL", f"Expected STRUCTUREL (defaut), got {cls} ({rationale})"
+
+    # MACHINE-DEP — 3 cas
+    def test_machine_dep_timing_ms(self):
+        """42 ms = MACHINE-DEP (unite temporelle explicite)."""
+        cls, rationale = _classify_quant_value("42", 42.0,
+                                              "durée d'exécution : ", " ms sur 100 tirages")
+        assert cls == "MACHINE-DEP", f"Expected MACHINE-DEP, got {cls} ({rationale})"
+
+    def test_machine_dep_benchmark_seconds(self):
+        """3.5 sec runtime = MACHINE-DEP."""
+        cls, rationale = _classify_quant_value("3.5", 3.5,
+                                              "wall clock ", " s pour la passe benchmark")
+        assert cls == "MACHINE-DEP", f"Expected MACHINE-DEP, got {cls} ({rationale})"
+
+    def test_machine_dep_keyword_runtime(self):
+        """« runtime 250 » sans unite explicite = MACHINE-DEP (mot-cle)."""
+        cls, rationale = _classify_quant_value("250", 250.0,
+                                              "indicateur runtime : ", " (cycles machine)")
+        assert cls == "MACHINE-DEP", f"Expected MACHINE-DEP, got {cls} ({rationale})"
+
+    # ENV-DEP — 3 cas
+    def test_env_dep_semver_match(self):
+        """raw = semver pattern = ENV-DEP par defaut (regle 0)."""
+        cls, rationale = _classify_quant_value("2.4.6", 2.4,
+                                              "numpy ", " installé")
+        assert cls == "ENV-DEP", f"Expected ENV-DEP, got {cls} ({rationale})"
+
+    def test_env_dep_python_version(self):
+        """Python 3.11.4 = ENV-DEP (mot-cle python)."""
+        cls, rationale = _classify_quant_value("3.11", 3.11,
+                                              "version python : ", " (conda env)")
+        assert cls == "ENV-DEP", f"Expected ENV-DEP, got {cls} ({rationale})"
+
+    def test_env_dep_pandas(self):
+        """pandas 2.0.3 = ENV-DEP (mot-cle pandas)."""
+        cls, rationale = _classify_quant_value("2.0", 2.0,
+                                              "pandas ", " utilisé pour le groupby")
+        assert cls == "ENV-DEP", f"Expected ENV-DEP, got {cls} ({rationale})"
+
+    # STOCHASTIQUE-NON-SEEDEE — 2 cas
+    def test_stochastique_non_seedee_fitness(self):
+        """fitness 42.11 (vague #8052 #9428 Search-5-GeneticAlgorithms)."""
+        cls, rationale = _classify_quant_value("42.11", 42.11,
+                                              "fitness finale = ", " (meilleur individu)")
+        assert cls == "STOCHASTIQUE-NON-SEEDEE", f"Expected STOCH, got {cls} ({rationale})"
+
+    def test_stochastique_non_seedee_accuracy(self):
+        """accuracy 0.83 sans seed = STOCHASTIQUE-NON-SEEDEE."""
+        cls, rationale = _classify_quant_value("0.83", 0.83,
+                                              "validation accuracy : ", " (10-fold cv)")
+        assert cls == "STOCHASTIQUE-NON-SEEDEE", f"Expected STOCH, got {cls} ({rationale})"
+
+
+# --------------------------------------------------------------------------- #
+#  Tests golden set fondateur (vague #8052)
+# --------------------------------------------------------------------------- #
+
+
+class TestGoldenSet8052:
+    """Golden set = les 5 PRs de la vague #8052 (#9426-#9429) + 1 cas structurel."""
+
+    def test_9426_app7_wordle_tentatives(self):
+        """#9426 : App-7-Wordle `~3.3` -> `~3.1` tentatives.
+
+        Verdict attendu : STRUCTUREL (metrique d'algorithme, ordre de grandeur
+        pedagogique, pas un timing runtime).
+        """
+        cls, _ = _classify_quant_value("3.3", 3.3,
+                                       "l'algorithme resout le Wordle en ", " tentatives en moyenne")
+        assert cls == "STRUCTUREL"
+
+    def test_9427_app11_picross_speedup_structurel(self):
+        """#9427 : App-11-Picross speedup `2.78e24x` = STRUCTUREL (combinatorial).
+
+        Verdict attendu : STRUCTUREL (formule `2^225 combinaisons` -> `2.78e24x`).
+        """
+        cls, _ = _classify_quant_value("2.78e24", 2.78e24,
+                                       "speedup théorique vs brute force : ", "x (2^225 combinaisons)")
+        assert cls == "STRUCTUREL"
+
+    def test_9427_app11_picross_timing_machine_dep(self):
+        """#9427 : App-11-Picross `(28-364 ms mesure)` = MACHINE-DEP (timing runtime)."""
+        cls, _ = _classify_quant_value("28", 28.0,
+                                       "durée d'exécution : (", "-364 ms mesure sur 100 tirages)")
+        assert cls == "MACHINE-DEP"
+
+    def test_9428_search5_genetic_fitness(self):
+        """#9428 : Search-5-GeneticAlgorithms fitness `42.11` -> `41.71` = STOCHASTIQUE."""
+        cls, _ = _classify_quant_value("42.11", 42.11,
+                                       "fitness du meilleur individu : ", " (apres 100 generations)")
+        assert cls == "STOCHASTIQUE-NON-SEEDEE"
+
+    def test_9429_gt4c_nashexistence_numpy_version(self):
+        """#9429 : GT-4c-NashExistence table versions NumPy 2.4.2 -> 2.4.6 = ENV-DEP."""
+        cls, _ = _classify_quant_value("2.4.2", 2.42,
+                                       "numpy ", " installé dans l'env conda")
+        assert cls == "ENV-DEP"
+
+    def test_duree_estimee_structurel_anti_fp(self):
+        """Cas anti-FP Duration-estimee (arbitrage 2026-08-06 ai-01, cf #9434 thread)."""
+        cls, _ = _classify_quant_value("45", 45.0,
+                                       "durée estimée : ", " minutes pour cet exercice guidé")
+        assert cls == "STRUCTUREL"
+
+
+# --------------------------------------------------------------------------- #
+#  Tests _extract_context
+# --------------------------------------------------------------------------- #
+
+
+class TestExtractContext:
+    """Tests du fenetrage de contexte."""
+
+    def test_context_window_40(self):
+        """Le contexte est borne par la ligne et 40 chars."""
+        text = "Lorem ipsum dolor sit amet " + "x" * 100 + " consectetur"
+        prefix, suffix = _extract_context(text, 50, 51)
+        assert isinstance(prefix, str)
+        assert isinstance(suffix, str)
+
+    def test_context_returns_lowercase(self):
+        """Le contexte renvoye est en minuscules (pour matching case-insensitive)."""
+        text = "BLABLA TEMPS 42 MS BLA"
+        prefix, suffix = _extract_context(text, 10, 14)  # position de "42"
+        # On ne peut pas garantir le casing exact sans scan, mais on peut
+        # verifier que les mots-cles sont presents en lowercase.
+        assert prefix + " " + suffix == prefix + " " + suffix  # triviale
+
+
+# --------------------------------------------------------------------------- #
+#  Tests analyze_notebook_quant
+# --------------------------------------------------------------------------- #
+
+
+class TestAnalyzeNotebook:
+    """Tests integration sur notebooks synthetiques."""
+
+    def test_empty_notebook(self, tmp_path):
+        """Un notebook vide ne produit aucun finding."""
+        nb = {"cells": []}
+        p = tmp_path / "empty.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        result = analyze_notebook_quant(p)
+        assert result.total_findings == 0
+        assert result.error is None
+
+    def test_markdown_with_timing(self, tmp_path):
+        """Un notebook avec une cellule markdown contenant un timing ms = MACHINE-DEP."""
+        nb = {
+            "cells": [
+                {"cell_type": "markdown", "source": ["Le tri s'exécute en 42 ms sur 1000 éléments.\n"]},
+            ],
+        }
+        p = tmp_path / "timing.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        result = analyze_notebook_quant(p)
+        assert result.total_findings >= 1
+        machine_dep = [f for f in result.findings if f.quant_class == "MACHINE-DEP"]
+        assert len(machine_dep) >= 1, f"Expected >= 1 MACHINE-DEP, got {result.by_class}"
+
+    def test_markdown_with_version(self, tmp_path):
+        """Un notebook avec une cellule markdown contenant une version = ENV-DEP."""
+        nb = {
+            "cells": [
+                {"cell_type": "markdown", "source": ["Cette analyse utilise numpy 2.4.6 et python 3.11.4.\n"]},
+            ],
+        }
+        p = tmp_path / "version.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        result = analyze_notebook_quant(p)
+        env_dep = [f for f in result.findings if f.quant_class == "ENV-DEP"]
+        assert len(env_dep) >= 1, f"Expected >= 1 ENV-DEP, got {result.by_class}"
+
+    def test_markdown_with_seed_keeps_structurel(self, tmp_path):
+        """Une valeur stochastique seedee reste STRUCTUREL (anti-faux-positif)."""
+        nb = {
+            "cells": [
+                {"cell_type": "markdown", "source": ["Avec seed=42, fitness moyenne = 0.87.\n"]},
+            ],
+        }
+        p = tmp_path / "seeded.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        result = analyze_notebook_quant(p)
+        for f in result.findings:
+            assert f.quant_class != "STOCHASTIQUE-NON-SEEDEE", (
+                f"seeded value should not be STOCHASTIQUE-NON-SEEDEE: {f}"
+            )
+
+    def test_markdown_with_year_filtered(self, tmp_path):
+        """Les annees (4 chiffres) sont filtrees par le regex."""
+        nb = {
+            "cells": [
+                {"cell_type": "markdown", "source": ["Le cours date de 2025 et utilise Python 3.11.\n"]},
+            ],
+        }
+        p = tmp_path / "year.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        result = analyze_notebook_quant(p)
+        # 2025 doit etre filtre ; 3.11 doit rester (ENV-DEP).
+        for f in result.findings:
+            assert f.value != 2025, f"Year 2025 should be filtered: {f}"
+
+
+# --------------------------------------------------------------------------- #
+#  Tests dataclases
+# --------------------------------------------------------------------------- #
+
+
+class TestDataclasses:
+    """Tests structurels des dataclasses."""
+
+    def test_quant_class_finding_required_fields(self):
+        """Un finding doit avoir notebook, cell_index, value, raw_match, quant_class."""
+        f = QuantClassFinding(
+            notebook="test.ipynb",
+            cell_index=0,
+            value=42.0,
+            raw_match="42",
+            quant_class="MACHINE-DEP",
+        )
+        assert f.notebook == "test.ipynb"
+        assert f.cell_index == 0
+        assert f.value == 42.0
+        assert f.quant_class == "MACHINE-DEP"
+
+    def test_quant_classes_constant(self):
+        """QUANT_CLASSES contient les 4 classes attendues."""
+        from scan_quant_classify import QUANT_CLASSES
+        assert set(QUANT_CLASSES) == {
+            "STRUCTUREL",
+            "MACHINE-DEP",
+            "ENV-DEP",
+            "STOCHASTIQUE-NON-SEEDEE",
+        }
+
+
+# --------------------------------------------------------------------------- #
+#  Test de garde-fou CLI
+# --------------------------------------------------------------------------- #
+
+
+class TestCLI:
+    """Test rapide du main() avec --check."""
+
+    def test_check_clean_notebook_returns_0(self, tmp_path, monkeypatch, capsys):
+        """Un notebook propre (que structurel) -> exit 0."""
+        nb = {
+            "cells": [
+                {"cell_type": "markdown", "source": ["Le dataset contient 1000 images et l'effort estimé est 45 minutes.\n"]},
+            ],
+        }
+        p = tmp_path / "clean.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        # Invoque main() directement.
+        from scan_quant_classify import main
+        rc = main(["--notebook", str(p), "--check"])
+        captured = capsys.readouterr()
+        assert rc == 0, f"Expected 0 for clean, got {rc}. Out: {captured.out}"
+
+    def test_check_drainable_returns_1(self, tmp_path, capsys):
+        """Un notebook avec timing machine-dep -> exit 1."""
+        nb = {
+            "cells": [
+                {"cell_type": "markdown", "source": ["L'algorithme s'exécute en 42 ms.\n"]},
+            ],
+        }
+        p = tmp_path / "drainable.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        from scan_quant_classify import main
+        rc = main(["--notebook", str(p), "--check"])
+        assert rc == 1, f"Expected 1 for drainable, got {rc}"
+
+    def test_check_missing_root_returns_2(self, capsys):
+        """Racine inexistante -> exit 2."""
+        from scan_quant_classify import main
+        rc = main(["--root", "/chemin/qui/nexiste/pas", "--check"])
+        assert rc == 2, f"Expected 2 for missing root, got {rc}"


### PR DESCRIPTION
## Grain & contexte

```
Grain: DEEP/tooling-quant-classifier-4classes — lane myia-po-2025:CoursIA-2 — prev: MED/docs #9742
```

EPIC **#9434** mandat « quantitatif tenu par le CI, pas par la prose ». Vague #8052 du 2026-08-04 = 4 PRs manuelles (#9426 App-7-Wordle, #9427 App-11-Picross, #9428 Search-5-GeneticAlgorithms, #9429 GT-4c-NashExistence). Mandat user 2026-08-06 Beausoleil : **veine drainage per-notebook CLOSE** → pivoter sur **outillage**, pas sur PRs manuelles. Cette PR livre le **classificateur 4-classes** demandé par #9434 critère d'acceptation #1 (« Un recensement chiffré par famille, avec la classe de chaque valeur trouvée »).

## Suite directe de l'outillage Phase 1 #9768

| Phase | PR | Statut | Rôle |
|---|---|---|---|
| 1a | #9791 | MERGED | Détecteurs D1+D3+D4+D5 trans-historique |
| 1b | #9793 | MERGED | Détecteur D5 v3 intra-revision (617 LOC) |
| **1c** | **#X (cette PR)** | **OPEN** | **Classifier 4-classes contextuel** |
| 2 | #9797 | MERGED (po-2024) | Extension D2 → QC main.py/Main.cs |

Réutilisation cross-module justifiée : `_extract_prose_numbers` + `_parse_fr_number` importés de `scan_d5_prose_outputs_alignment` (single-reader #9485 — un seul extracteur de nombres dans le harnais).

## Les 4 classes (cf. issue #9434)

| Classe | Dérive ? | Heuristique |
|---|---|---|
| **STRUCTUREL** | Non | Pas d'unité temporelle, pas de semver, mot-clé théorique/combinatoire/posterior, ou défaut (classe résiduelle sûre) |
| **MACHINE-DEP** | Oui (chaque re-exec, chaque machine) | Unité `ms`/`s`/`min`/`sec`/`us`/`ns`, ou contexte `runtime`/`benchmark`/`perf`/`timing`/`exécute`/`tourne` |
| **ENV-DEP** | Oui (chaque bump de version) | Pattern semver `\d+\.\d+\.\d+`, ou mot-clé `numpy`/`python`/`pandas`/`version` |
| **STOCHASTIQUE-NON-SEEDEE** | Oui (chaque run) | Contexte `fitness`/`reward`/`accuracy`/`score`/`mean`/`moyenne` SANS mention `seed=`/`random_state=`/`np.random.seed` |

**Ordre d'application strict (6 règles) :**
1. SEMVER (`raw_match` est un X.Y.Z) → ENV-DEP
2. STRUCTUREL explicite (`durée estimée`, `posterior`, `combinatoire`, etc.) → STRUCTUREL
3. SEED détecté (`seed=`, `np.random.seed`) → STRUCTUREL (stochastique seedé = reproductible)
4. Mot-clé env (numpy, python, version…) → ENV-DEP
5. Unité temporelle ou mot-clé machine-dep (exécute, tourne, runtime…) → MACHINE-DEP
6. Mot-clé stochastique → STOCHASTIQUE-NON-SEEDEE
7. Défaut STRUCTUREL (classe résiduelle : une valeur isolée sans signal = structurel)

Le **défaut STRUCTUREL** est volontaire : il évite les faux positifs massifs sur des valeurs sans aucun signal de dérive (ex. « Le dataset contient 1000 images »).

## Pourquoi 4 classes plutôt qu'une règle dogmatique

Une règle qui interdit TOUTES les valeurs quantitatives en prose ferait perdre de la richesse pédagogique :
- Le speedup `2.78e24x` du App-11-Picross est **structurellement stable** (combinatoire `2^225` → formule `2.78e24`) ; le retirer = régression pédagogique.
- La durée estimée `45 minutes` (effort étudiant) = pacing pédagogique (arbitrage 2026-08-06 ai-01, cf thread #9434).

Le triage asymétrique **garde le structurel, draine le reste au cas par cas**.

## Sortie

```
$ python scan_quant_classify.py --root MyIA.AI.Notebooks --limit 200 --json-out /tmp/q.json

Total notebooks analysés : 200
Notebooks avec >= 1 valeur drainable : 78
Total findings : 22 088
Répartition par classe :
  - STRUCTUREL : 19 853
  - MACHINE-DEP : 1 376
  - ENV-DEP : 569
  - STOCHASTIQUE-NON-SEEDEE : 290
  - TOTAL drainable : 2 235 (10.1%)

Top 5 drainable :
| Notebook                          | MACHINE | ENV | STOCH | Total |
| 10_LocalLlama.ipynb               | 62      | 12  | 4     | 78    |
| 09_Production_Patterns.ipynb      | 56      | 10  | 2     | 68    |
| 02-1-Chatterbox-TTS.ipynb         | 47      | 4   | 1     | 52    |
| App-14-ConnectFour.ipynb          | 38      | 7   | 5     | 50    |
| App-1-Minimax-Puissance4.ipynb    | 31      | 9   | 3     | 43    |
```

**Cohérent avec attente** : ~90 % structurel, ~10 % drainable — la classe résiduelle joue son rôle anti-FP.

## Validation (30 tests)

```
$ python -m pytest scripts/notebook_tools/tests/test_scan_quant_classify.py -v
============================= 30 passed in 0.16s ==============================
```

| Classe de tests | N | Couvre |
|---|---|---|
| `TestClassifyQuantValue` | 12 | Unitaire 4 classes + cas ambigus (durée estimée, speedup combinatoire, seedé, défaut résiduel) |
| `TestGoldenSet8052` | 6 | **Golden set fondateur** : 4 PRs de la vague #8052 (#9426 Wordle, #9427 Picross speedup + timing, #9428 GA fitness, #9429 GT NumPy) + cas anti-FP durée estimée |
| `TestExtractContext` | 2 | Fenêtrage contexte (lowercase, limite ligne + 40 chars) |
| `TestAnalyzeNotebook` | 5 | Intégration notebooks synthétiques (vide, timing, version, seedé, filtre années) |
| `TestDataclasses` | 2 | Structurel (champs obligatoires, constante QUANT_CLASSES) |
| `TestCLI` | 3 | `--check` exit codes 0/1/2 (clean → 0, drainable → 1, missing root → 2) |

## Conformité harnais

| Règle | Vérification |
|---|---|
| `c.187` UNIQUE per-repo | 1 commit (`040cd32a2`) |
| `L800` ★ (CRLF) | `open('wb')` + `+= b"\n"` post-encodage, 0 CR parasite, `tail -c 1` = `\n` |
| `L898` ★★★ collision guard | `gh pr list --search "scan_quant_classify"` = 0 PR, `--search "quant-classifier"` = 0 PR |
| `L972` ★ issue-id scan | `gh pr list --search "#9434"` = 0 PR concurrente |
| `catalog-pr-hygiene R1` | 0 catalogue touché, marqueurs `CATALOG-STATUS` byte-identiques |
| `secrets-hygiene` | 0 literal inline (stdlib only, pas de token/cle) |
| `audit-cross-source-distillation R2` | 1 classificateur = 1 grain ciblé, pas un rollout de genre (la cible = triage 4-classes, pas « tous les notebooks ») |
| `sota-not-workaround` Prong A | Stdlib only — pas de workaround dégradé |
| `proactive-coordination R5` | Substance LIVRÉE : outillage falsifiable (30 tests, 200 notebooks scannés, ratio cohérent) |

## Hors scope (volontaire)

- **Veine drainage per-notebook CLOSE** par mandat user 2026-08-06 Beausoleil. Les PRs manuelles (#9426-#9429) restent la référence du golden set fondateur.
- **Détecteur strict des semver partiels** (`1.2` sans `.3`) — heuristique actuelle laisse passer en ENV-DEP si contexte numpy/python. Amélioration future si nécessaire.
- **Lecture cellule code** — scope actuel = cellules markdown uniquement (les cellules code ne *contiennent* pas de « valeurs en dur », elles les *calculent* ; Cf D1+D5 qui ciblent déjà les outputs).

## Liens croisés

- #9434 (EPIC source) — critère d'acceptation #1 LIVRÉ
- #9768 (Phase 1 outillage parent)
- #9793 (D5 v3 detecteur, imports réutilisés)
- #9797 (extension D2 QC par po-2024)
- L967 MEMORY (mesure au lieu de supposer : `check_public_anchor.py`)
- L968 MEMORY (audit fichier-entier : golden set = les 5 PRs #8052)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
