### PR TITLE
docs(genai,#4959): add GenAI/tutorials README hub (FR-first, 4 guides indexed)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/tutorials/README.md
+++ b/MyIA.AI.Notebooks/GenAI/tutorials/README.md
@@ -1,0 +1,32 @@
+# Tutoriels GenAI — guides pratiques complémentaires
+
+Ce dossier rassemble des **guides pratiques approfondis** qui complètent les
+notebooks de la série [GenAI](../README.md). Là où les notebooks démontrent une
+technique pas à pas (cellule par cellule, sortie à l'appui), ces tutoriels
+présentent une vue d'ensemble réutilisable : écosystème d'un fournisseur,
+patterns d'intégration production, bibliothèques de templates pédagogiques. Ils
+se lisent indépendamment ou en parallèle d'un notebook de la série.
+
+## Sommaire des guides
+
+| Guide | Sujet couvert | Quand le lire |
+|-------|---------------|---------------|
+| [DALL-E 3 — guide complet](dalle3-complete-guide.md) | Génération d'images via l'API OpenAI : prompt engineering, variations, éditions, intégration aux workflows CoursIA, troubleshooting | Avant ou après les notebooks de la sous-série [Image](../Image/README.md) |
+| [GPT-5 multimodal — analyse d'images](gpt5-image-analysis-guide.md) | Analyse et description d'images via OpenRouter, conversations multimodales, alt-text pour l'accessibilité, intégration avec DALL-E | Pour approfondir la boucle génération → analyse |
+| [OpenRouter — écosystème](openrouter-ecosystem-guide.md) | Multi-endpoints, switching entre modèles, rate limiting, error handling, patterns d'intégration production | Avant de chaîner plusieurs fournisseurs dans un pipeline |
+| [Workflows pédagogiques GenAI](educational-workflows.md) | Création automatique de supports, évaluations visuelles, story-boarding, brand building étudiant, templates par matière, accessibilité | Pour les enseignants qui industrialisent la production de matériel |
+
+## Position dans la série
+
+Ces guides ne remplacent pas les notebooks : ils en élargissent le contexte. Le
+parcours canonique reste la [série GenAI principale](../README.md) (Environment →
+Image → Audio → Vidéo → Texte → Vibe-Coding), et l'on vient ici chercher un
+éclairage transverse sur un fournisseur (OpenAI, OpenRouter) ou un cas d'usage
+(pédagogie, accessibilité) qui déborde d'une seule modalité.
+
+## Note de maintenance
+
+Le sous-dossier [`Image/tutorials/`](../Image/tutorials/) contient actuellement
+une copie identique de ces quatre guides (duplication historique). La source
+autoritaire est le présent dossier `GenAI/tutorials/` ; la consolidation de la
+copie est tracée séparément (voir Epic nettoyage #9535).


### PR DESCRIPTION
Grain: LIGHT/readme — lane myia-po-2023:CoursIA-2 — prev: DEEP/lean prep c.9712

## Livrable

Le dossier `GenAI/tutorials/` regroupait 4 guides markdown complémentaires (DALL-E 3, GPT-5 multimodal, OpenRouter écosystème, workflows pédagogiques) sans aucun point d'entrée. Ce README indexe ces guides, précise leur position dans la série (compléments transverses, non substituts des notebooks), et oriente le lecteur.

## Preuve (firsthand, G.1)

- **Vrai manque, pas fabrication** : `git cat-file -e HEAD:MyIA.AI.Notebooks/GenAI/tutorials/README.md` → absent. Le dossier contient 4 guides `.md` sans index.
- **Contenu vérifié** : chaque guide décrit dans le tableau correspond à sa table des matières réelle (dalle3 = prompt engineering + variations ; gpt5 = analyse multimodale + alt-text ; openrouter = multi-endpoints + rate limiting ; educational-workflows = supports/évaluations/storyboarding).
- **Duplication signalée (hors scope)** : `GenAI/Image/tutorials/` contient une copie **byte-identique** des 4 mêmes guides (vérifié `diff` → IDENTICAL). La source autoritaire est `GenAI/tutorials/` (présent dossier) ; la consolidation de la copie `Image/tutorials/` est tracée dans l'Epic nettoyage #9535 (signalement dans le README + body, pas traitée ici — anti-régression : pas de suppression sans preuve de scope).

## Conformité

- **readme-french-first** : prose FR (nouveau contenu doc = FR, règle HARD 1).
- **catalog-pr-hygiene R1** : catalogue byte-identique à main (0 changement à `COURSE_CATALOG.generated.*`).
- **harness-hygiene** : 32 lignes, concis, renvois vers la doc parent, pas de gonflement.
- **L898 ★★★ + L972 ★** : `gh pr list --search` clean sur `GenAI/tutorials`, `#4959`, `readme` — 0 collision.

## Scope

`See #4959` (READMEs intermédiaires — contribution partielle à l'Epic, ne le clôt pas). `See #9535` (signalement duplication, ne le résout pas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)