### PR TITLE
feat(lean,#4980): DecideProbe_en i18n sibling — completes Conway/Life bilingual rollout

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/DecideProbe_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/DecideProbe_en.lean
@@ -1,0 +1,131 @@
+/-
+  Copyright (c) 2026 CoursIA. All rights reserved.
+  Distributed under the Apache 2.0 License as described in the LICENSE file.
+
+  ## Per-theorem triage probe (c.8127, batch 1 of #8749)
+
+  This module is the **verifiable deliverable** of the per-theorem triage started
+  by c.8126: it runs firsthand the `decide + maxRecDepth` probe on each of the 5
+  `hashlife_*` theorems of Section 1 of `Computation.lean`, and keeps the
+  machine-readable trace of the verdict.
+
+  ### Result of the 5 probes (2026-08-05)
+
+  | Theorem                 | `decide` + maxRecDepth 1000000  | Verdict   |
+  |-------------------------|--------------------------------|-----------|
+  | `hashlife_block_1`      | **STUCK** on `evolveHashlife`  | INTRINSIC |
+  | `hashlife_block_4`      | (symmetric)                    | INTRINSIC |
+  | `hashlife_blinker_2`    | (symmetric)                    | INTRINSIC |
+  | `hashlife_glider_4`     | (symmetric)                    | INTRINSIC |
+  | `hashlife_beacon_2`     | (symmetric)                    | INTRINSIC |
+  | `hashlife_toad_2`       | (symmetric)                    | INTRINSIC |
+
+  Sanity-check (control): `eater1_still_life_sanity` PASSES in ~28 s under
+  `decide`, like the original proof L174 of `Computation.lean`. The probe
+  setup is therefore correct; the 5 `hashlife_*` are STUCK because
+  `evolveHashlife` crosses the recursive `MacroCell` layer (c.8126 probes
+  B and C).
+
+  ### Strategy: commented probes + real sanity-check
+
+  To avoid **introducing new axioms** (the conway_lean rule forbids increasing
+  `grep -c sorry` and adding `axiom`), the 6 `probe_*` are documented as
+  comments: the `by decide` code that would prove them is written, followed by
+  the INTRINSIC verdict. The sanity-check `eater1_still_life_sanity` succeeds
+  under `decide`, which proves the setup is honest.
+
+  To reproduce the verbatim error reported in the docstring (the error that
+  `by decide` produces), uncomment the corresponding `by decide` line and run
+  `lake build Conway.Life.DecideProbe_en`.
+
+  ### Cross-references
+
+  - c.8126 (#9482) — foundation diagnostic (3 probes, MacroCell quadtree)
+  - #8869 — parent issue (OPEN — closure deferred to the MacroCell refactor)
+  - #8782 — downstream CI plumbing (proof-integrity-audit option b)
+  - #8749 — parent issue (per-theorem triage, batch 1 of N)
+
+  This module is fully proved (real sanity-check).
+
+  i18n (#4980): English mirror of `Conway/Life/DecideProbe.lean`. Statements,
+  tactics and proofs are byte-identical; only docstrings and comments differ.
+-/
+
+import Conway.Life
+import Conway.Life.Computation
+
+namespace Conway_en
+open Conway
+namespace Life_en
+open Life
+
+set_option maxRecDepth 1000000
+
+/-! ### Sanity check (control)
+
+  `eater1_still_life` from `Computation.lean` L174 uses `by decide`. The
+  proof PASSES here too, which verifies that the probe is honest.
+-/
+
+/-- Sanity check: `isStillLife eater1 = true` is decide-reducible
+    (control that the probe is correctly configured). -/
+theorem eater1_still_life_sanity : isStillLife eater1 = true := by decide
+
+/-! ### Per-theorem probes (Section 1, 6 `hashlife_*` theorems)
+
+  Each probe is documented as a comment: the `by decide` code that would prove
+  it in the kernel is written, followed by the INTRINSIC verdict. Compilation
+  succeeds because the probes are commented out; unlocking them one by one
+  produces the verbatim error documented in the module header.
+-/
+
+-- Probe 1: `hashlife_block_1`. STUCK on `match evolveHashlife 1 block with`.
+-- INTRINSIC (cf c.8126 probe B: `mc.toGrid` recursive → opaque to the reducer).
+-- theorem probe_hashlife_block_1_stuck : evolveHashlife 1 block = evolve 1 block := by decide
+
+-- Probe 2: `hashlife_block_4`. Same MacroCell path. INTRINSIC.
+-- theorem probe_hashlife_block_4_stuck : evolveHashlife 4 block = evolve 4 block := by decide
+
+-- Probe 3: `hashlife_blinker_2`. Same path. INTRINSIC.
+-- theorem probe_hashlife_blinker_2_stuck : evolveHashlife 2 blinker_h = evolve 2 blinker_h := by decide
+
+-- Probe 4: `hashlife_glider_4`. Same path. INTRINSIC.
+-- theorem probe_hashlife_glider_4_stuck : evolveHashlife 4 glider = evolve 4 glider := by decide
+
+-- Probe 5: `hashlife_beacon_2`. Same path. INTRINSIC.
+-- theorem probe_hashlife_beacon_2_stuck : evolveHashlife 2 beacon = evolve 2 beacon := by decide
+
+-- Probe 6: `hashlife_toad_2`. Same path. INTRINSIC.
+-- theorem probe_hashlife_toad_2_stuck : evolveHashlife 2 toad = evolve 2 toad := by decide
+
+/-! ### Verbatim error (probe 1: `hashlife_block_1`)
+
+  Output of `lake build Conway.Life.DecideProbe_en` with probe 1's line
+  uncommented:
+
+  ```
+  After unfolding the instances `instDecidableEqBool`, `instDecidableEqList`,
+  `instDecidableEqNat`, `Bool.decEq`, and `Nat.decEq`, reduction got stuck
+  at the `Decidable` instance
+    match evolveHashlife 1 block with
+    | [] =>
+      match evolve 1 block with
+      | [] => isTrue ...
+      | head :: tail => isFalse ...
+    | a :: as =>
+      match evolve 1 block with
+      | [] => isFalse ...
+      | b :: bs =>
+        match decEq a b with ...
+  error: Lean exited with code 1
+  ```
+
+  The `instDecidableEqList` instance deployed, the reducer gets stuck on
+  `match evolveHashlife 1 block with` — a direct manifestation of probe
+  B of c.8126 (`mc.toGrid` recursive → opaque). The 6 theorems produce the
+  same error at the same place (`match evolveHashlife n g with`), because
+  they all take the `evolveHashlife → MacroCell quadtree` path.
+-/
+
+end Life_en
+end Conway_en


### PR DESCRIPTION
## Summary

**Grain** : DEEP/i18n-lean — nouveau fichier `Conway/Life/DecideProbe_en.lean`, miroir anglais du FR-first `DecideProbe.lean` (EPIC i18n #4980, ratifié user 2026-07-04). **DécideProbe était le DERNIER module de `Conway/Life/` sans sibling `_en`** (16/17 déjà bilingues) : ce port complète le rollout bilingue de la sous-librairie Life (**17/17 bilingue**).

## Découverte (cartographie i18n fraîche — le MEMORY était stale)

En cherchant un grain R6 après 2 cycles de saturation cluster, j'ai cartographié l'état i18n #4980 firsthand (le MEMORY "6/11 lakes FR-first" datait de c.16 et était stale) :
- Le rollout est **partiel** (~50% des fichiers ont un `_en` partout, pas binaire FR/EN).
- `decision_theory_lean` = déjà entièrement bilingue, `cooperative_games_lean` = WIP (autre session), `social_choice_lean` = quasi-vide (lakefile seul).
- **`conway_lean/Conway/Life/`** : 16/17 modules bilingues, le seul manquant = `DecideProbe`.

## Livrable

`DecideProbe_en.lean` (131 lignes) — miroir Pattern A du canonique FR :
- Header EN traduit (description c.8127, tableau des 6 sondes INTRINSIC, stratégie, cross-references, bloc verbatim erreur).
- `namespace Conway_en` / `open Conway` / `namespace Life_en` / `open Life` (pattern des siblings `_en` validés : PatternTour_en, HashlifeMarginFragment_en).
- `theorem eater1_still_life_sanity : isStillLife eater1 = true := by decide` — **byte-identique au FR**, prouve dans le noyau (zéro axiome, fix `ceilLog2` #9536). C'est la preuve de fidélité du miroir.
- 6 probes commentées (INTRINSIC, c.8127) — commentaires traduits EN, code identique.
- Bloc verbatim erreur — sortie Lean inchangée (le `match evolveHashlife` stuck, sonde B c.8126).

## Acceptance i18n Pattern A (#4980)

- [x] Namespace suffixé `_en` + `open` du canonique (anti-collision).
- [x] Imports identiques au FR (`Conway.Life` + `Conway.Life.Computation`) — DecideProbe_en est autonome (G2_en ne l'importe pas, pas d'impact amont).
- [x] Énoncés/tactiques/preuves/lemmas/réfs Mathlib **byte-identiques** — seules docstrings/commentaires diffèrent.
- [x] **lake build green EN firsthand** WSL v4.31.0-rc1 (2950 jobs, 11s) — log ci-dessous.
- [x] **0 sorry** (sanity-check par `decide`, zéro axiome) — ne touche pas au cliquet.
- [x] **Aucune modification des modules existants** — DecideProbe.lean FR canonical intact, fichier additif uniquement.
- [x] **Complète le rollout Conway/Life** (17/17 bilingue).

## Build (handfirst WSL sandbox, v4.31.0-rc1, post-#9796)

```
=== lake build Conway.Life.DecideProbe_en (EN mirror) ===
ℹ [2949/2950] Replayed Conway.Life.Computation
✔ [2950/2950] Built Conway.Life.DecideProbe_en (11s)
Build completed successfully (2950 jobs).
EN EXIT=0
sorry count : DecideProbe_en.lean = 0
substance : theorem=1 (eater1_still_life_sanity, by decide)
```

## Détails

- `git diff --stat` : 1 fichier nouveau (`Conway/Life/DecideProbe_en.lean`), +131/-0.
- 3e cycle Lean consécutif — argument G-VAR-3 : 3 genres structurellement **distincts** (Livrable B #9780 = framework de correction formelle / PatternTour #9796 = module pédagogique nouveau / DecideProbe_en = **i18n translation**). Le port ferme un livrable cohérent (rollout Conway/Life complet).
- Collision pre-flight VIERGE : 0 PR DecideProbe existante (uniquement #9490 qui a créé le FR + #9763/#9780 références).
- Catalogue byte-identique (fichier additif, pas de régén catalogue).
- Fresh worktree `feature/conway-decideprobe-i18n` depuis `origin/main` `06cda59aa` (inclut #9796 PatternTour mergé).

See #4980 (rollout i18n, contribution partielle — Conway/Life désormais complet, le rollout continue sur les autres lakes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
