### PR TITLE
fix(notebook-tools,#9768): reverse revision order in _build_revisions (D3/D4/D5 FP ~90%)

### DIFF
--- a/scripts/notebook_tools/scan_d1_d3_d4_d5.py
+++ b/scripts/notebook_tools/scan_d1_d3_d4_d5.py
@@ -604,8 +604,20 @@ def detect_d5(revisions: list[NotebookRevision]) -> list[ForensicFinding]:
 
 
 def _build_revisions(notebook: str, repo: str) -> list[NotebookRevision]:
-    """Construit la liste des NotebookRevision pour un notebook."""
+    """Construit la liste des NotebookRevision pour un notebook (chrono, ancien->recent).
+
+    ``get_revisions`` reflete l'ordre natif de ``git log`` (recent -> ancien),
+    mais les detecteurs D3/D4/D5 comparent chaque commit a ``revisions[i-1]``
+    en supposant que c'est son **predecesseur chronologique** (l'etat herite).
+    En ordre recent->ancien, ``revisions[i-1]`` est le voisin *plus recent* --
+    la derive d'un commit posterieur est alors attribuee a tort a un commit
+    anterieur innocent (FP massifs : ~90% sur les familles maturees, EPIC #9768
+    Phase 0). On retourne donc la liste en chrono (ancien -> recent) pour que
+    ``revisions[i-1]`` designe bien le vrai predecesseur. (get_revisions n'a
+    qu'un seul appelant : ce point d'etranglement.)
+    """
     revs_meta = get_revisions(notebook, repo)
+    revs_meta = list(reversed(revs_meta))  # ancien -> recent
     revs: list[NotebookRevision] = []
     for sha, subject in revs_meta:
         try:

--- a/scripts/notebook_tools/tests/test_scan_d1_d3_d4_d5.py
+++ b/scripts/notebook_tools/tests/test_scan_d1_d3_d4_d5.py
@@ -52,6 +52,7 @@ from scan_d1_d3_d4_d5 import (  # noqa: E402
     detect_d3,
     detect_d4,
     detect_d5,
+    _build_revisions,
     forensic_scan,
     render_text,
     main,
@@ -540,6 +541,89 @@ class TestDetectD5:
             _rev("bbb", "docs: empty", [], non_substantial=True),
         ]
         assert detect_d5(revs) == []
+
+
+# ============================================================================ #
+#  Regression : orientation chronologique des revisions (EPIC #9768 Phase 0)
+# ============================================================================ #
+
+
+class TestRevisionOrdering:
+    """Lock le contrat d'orientation chrono (ancien -> recent) des revisions.
+
+    Contexte : ``get_revisions`` renvoie l'ordre natif ``git log`` (recent ->
+    ancien), mais detect_d3/d4/d5 comparent chaque commit a
+    ``revisions[i-1]`` en supposant son **predecesseur chronologique**. Avant le
+    fix, _build_revisions passait l'ordre recent->ancien aux detecteurs ->
+    ``revisions[i-1]`` etait le voisin *plus recent* -> la derive d'un commit
+    posterieur etait attribuee a tort a un restore/rename/docs anterieur (FP
+    ~90% sur familles maturees ; ex Search-8 commit 8ee54921 "restore accents"
+    flaggue D3 alors qu'il a change 0 output). Ces tests reproduisent le
+    mecanisme du FP et echouent si l'orientation est re-inversee.
+    """
+
+    def test_d3_no_fp_when_restore_matches_predecessor(self):
+        # Ordre CHRONO (ancien -> recent) tel que produit par _build_revisions
+        # post-fix. Le restore (b) retablit fidelement l'etat de son
+        # predecesseur (a) : memes nombres -> PAS un D3+, meme si un commit
+        # posterieur (c) a change les nombres par ailleurs.
+        revs = [
+            _rev("aaa", "feat: initial", [800.0, 800.0]),          # ancien
+            _rev("bbb", "restore: rollback outputs", [800.0, 800.0]),  # = predecesseur
+            _rev("ccc", "feat: re-exec with new seed", [12.0, 44.0]),  # recent, different
+        ]
+        assert detect_d3(revs) == []
+
+    def test_d5_no_fp_when_docs_matches_predecessor(self):
+        # Un commit docs non-substantiel qui NE change PAS les outputs vs son
+        # predecesseur -> PAS un D5, meme si un commit posterieur a change les
+        # medianes (l'attribution doit porter sur le bon commit).
+        revs = [
+            _rev("aaa", "feat: content", [10.0, 10.0, 10.0]),
+            _rev("bbb", "docs(readme): typo", [10.0, 10.0, 10.0], non_substantial=True),
+            _rev("ccc", "feat: re-exec", [800.0, 800.0, 800.0]),
+        ]
+        assert detect_d5(revs) == []
+
+    def test_d3_still_flags_genuine_partial_restore(self):
+        # Garde-fou anti-surcorrection : un restore qui NE retablit PAS l'etat
+        # du predecesseur reste un vrai D3+.
+        revs = [
+            _rev("aaa", "feat: initial", [800.0, 800.0]),
+            _rev("bbb", "restore: rollback outputs", [12.0, 44.0]),  # != predecesseur
+        ]
+        findings = detect_d3(revs)
+        assert len(findings) == 1
+        assert findings[0].sha == "bbb"
+
+    def test_build_revisions_returns_oldest_first(self, tmp_path: Path):
+        # Test d'integration sur mini-repo : verifie que _build_revisions
+        # retourne les commits en ordre chronologique (ancien -> recent), pas
+        # l'ordre natif git log (recent -> ancien). C'est le contrat dont
+        # dependent detect_d3/d4/d5. Echoue si le reversed() est retire.
+        import subprocess
+        repo = tmp_path / "mini"
+        repo.mkdir()
+        for cmd in (
+            ["git", "init", "-q"],
+            ["git", "config", "user.email", "t@t"],
+            ["git", "config", "user.name", "T"],
+        ):
+            subprocess.run(cmd, cwd=str(repo), check=True)
+        nb_path = repo / "nb.ipynb"
+        # Trois commits distincts (contenu different a chaque fois pour que git
+        # cree bien 3 commits, sinon "nothing to commit" les collapse en 1).
+        for i, msg in enumerate(
+            ("feat: oldest commit", "feat: middle commit", "feat: newest commit")
+        ):
+            nb_path.write_text(json.dumps({"cells": [], "version": i}))
+            subprocess.run(["git", "add", "nb.ipynb"], cwd=str(repo), check=True)
+            subprocess.run(["git", "commit", "-q", "-m", msg], cwd=str(repo), check=True)
+        revs = _build_revisions("nb.ipynb", str(repo))
+        assert len(revs) == 3
+        # Ordre attendu : ancien -> recent (independant de l'ordre git log).
+        assert revs[0].subject == "feat: oldest commit"
+        assert revs[-1].subject == "feat: newest commit"
 
 
 # ============================================================================ #


### PR DESCRIPTION
Grain: DEEP/notebook-tools — lane myia-po-2025:CoursIA — prev: LIGHT/guard

## Ce que fait cette PR

Corrige un bug d'orientation des revisions dans le detecteur Phase 1 de
l'EPIC #9768 (`scan_d1_d3_d4_d5.py`), responsable de **faux positifs massifs
(~90%)** sur les familles maturees. Bug identifie + verifie firsthand pendant
mon echantillon Phase 0 (Search/CSP + Probas/Infer, c.1267/1268).

## Bug : inversion d'orientation chrono

`get_revisions` reflete l'ordre natif de `git log` (**recent -> ancien**), mais
`detect_d3`/`detect_d4`/`detect_d5` comparent chaque commit a
`revisions[i-1]` en supposant que c'est son **predecesseur chronologique**
(l'etat herite). En ordre recent->ancien, `revisions[i-1]` est le voisin *plus
recent* : la derive d'un commit posterieur est alors attribuee a tort a un
commit anterieur innocent.

### FP verifie firsthand (Search-8-DancingLinks, 45 revisions)

Le detecteur flaggait le commit `8ee54921` ("restore French accents") comme
**D3+** "Restore numerique : mediane 12 -> 800 (n 44 -> 21)". Verification
firsthand (G.1) :

- `git show 8ee54921 --stat` : 105 ins / 105 del, **104/105 lignes = accents
  francais**, **0 ligne touche les outputs/execution_count**. Le commit a
  change ZERO nombre de sortie.
- Reproduction de la signature du detecteur lui-meme sur les 3 voisins :

| Commit | position | mediane | count | n_cells |
|--------|----------|---------|-------|---------|
| `e87f698e3` | voisin **plus recent** | 12.0 | 44 | 21 |
| `8ee54921` | le commit "restore" | 800.0 | 21 | 20 |
| `5b00ff6f9` | vrai **predecesseur** (DAG) | 800.0 | 21 | 20 |

`8ee54921` et son vrai predecesseur `5b00ff6f9` sont **byte-identiques**
(mediane 800, std 487.762, count 21). Le "12 -> 800" provenait de la
comparaison avec le voisin *plus recent* `e87f698e3` — qui est le commit ayant
reellement change les outputs (n_cells 20 -> 21). Ce commit n'etant ni restore
ni non-substantiel, il etait correctement ignore, mais la derive etait
faussement attribuee au restore innocent.

## Fix (1 ligne au point d'etranglement)

`_build_revisions` est le **seul appelant** de `get_revisions`. On inverse la
liste en chrono (ancien -> recent) pour que `revisions[i-1]` designe bien le
vrai predecesseur. Les detecteurs et leurs tests (qui supposaient deja l'ordre
chronologique) deviennent coherents avec les donnees de production.

```python
revs_meta = get_revisions(notebook, repo)
revs_meta = list(reversed(revs_meta))  # ancien -> recent
```

Alternative envisagee (rejetee) : inverser la logique des detecteurs vers
`revisions[i+1]` + reecrire ~8 tests. Plus de churn, plus de risque, et la
narrative des tests ("aaa puis restore-to-aaa") est plus lisible en chrono.

## Validation

- **FP cleared (production)** : `Search-8` passe `D3+` (1 finding) -> **`SAIN`**
  (0 finding) sur ses 45 revisions.
- **Discrimination preservee** : scan post-fix de 40 notebooks Search = 12 SAIN
  + 28 flaggues (**tous D1** = axe non touche par le fix ; D3/D4/D5 = 0 sur
  famille maturee deterministe = coherent avec la conclusion Phase 0
  "deterministic mature families = 0 authentic degeneration").
- **Tests** : 68 passent (33 existants + 4 nouveaux tests de regression dans
  `TestRevisionOrdering` : FP D3 cleared, FP D5 cleared, vrai D3 partial-
  restore toujours detecte, contrat d'orientation `_build_revisions` verifie
  sur mini-repo). Suite `notebook_tools` liee : 97 passent au total.
- **Pas de sur-correction** : les tests unitaires couvrent les cas genuinenment
  drift (partial restore, docs-re-exec) qui restent flaggues.
- **Pas de consommateur externe casse** : `scan_d5_prose_outputs_alignment.py`
  ne fait qu'une reference docstring `:mod:` (pas d'import de code).

## Tests

```
python -m pytest scripts/notebook_tools/tests/test_scan_d1_d3_d4_d5.py -q
# 68 passed
python -m pytest scripts/notebook_tools/tests/test_scan_d1_d3_d4_d5.py scripts/notebook_tools/tests/test_forensic_scan.py -q
# 97 passed
```

Catalogue byte-identique a main (R1). LF-only, UTF-8 no-BOM. 2 fichiers,
atomique.

See #9768

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
