### PR TITLE
fix(notebook-tools,#9790): dense-cell orphan-ratio gate on D5 intra-revision detector (FP -42%)

### DIFF
--- a/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
@@ -100,6 +100,18 @@ ABSOLUTE_TOLERANCE = 1e-6
 MIN_NUMBER_VALUE = 1e-9
 MAX_NUMBER_VALUE = 1e15
 
+# Gate anti-bruit pour MISSING_FROM_OUTPUTS (EPIC #9768 Phase 0 : le detecteur
+# v2 emettait 21589 findings full-corpus dont l'inspection firsthand montre
+# ~99% de faux positifs -- nombres de prose qui sont des references, numeros
+# de section, dates, identifiants, et non des mesures). Comme le detecteur D1
+# (scan_d1_d3_d4_d5.py D1_ORPHAN_RATIO_THRESHOLD), on ne signale une cellule
+# que si une fraction significative de SES nombres prose sont orphelins : une
+# cellule dont 1 nombre sur 10 est absent = bruit (reference croisee) ; une
+# cellule dont 5 sur 10 sont absents = derive authentique (la prose decrit des
+# resultats non calcules).
+MISSING_FROM_OUTPUTS_CELL_RATIO = 0.50   # >=50% des nombres prose orphelins (cell dense)
+MISSING_FROM_OUTPUTS_CELL_MIN = 3        # seuil "dense" (cell >=3 nombres prose)
+
 
 # --------------------------------------------------------------------------- #
 #  Dataclasses
@@ -398,21 +410,34 @@ def analyze_notebook(path: str | os.PathLike) -> NotebookAlignment:
         # Tronque le texte pour le rapport (60 premiers chars non vides).
         snippet = text.strip().splitlines()
         snippet = next((ln.strip() for ln in snippet if ln.strip()), "")[:120]
+        # Gate anti-bruit (EPIC #9768 Phase 0) : on collecte d'abord les
+        # orphelins de cette cellule. Pour les cellules DENSES (>= MIN nombres
+        # prose), on n'emet QUE si la majorite des nombres sont orphelins
+        # (ratio >= seuil) -- une cellule avec 1 orphelin sur 10 = reference
+        # croisee (bruit), une cellule avec 5/10 = derive authentique. Les
+        # cellules clairsemes (1-2 nombres) sont preservees : une seule
+        # mesure manquante ("Sharpe = 0.512") reste un signal valide.
+        orphans: list[float] = []
         for v in nums:
             closest = _closest_output(v, output_vals)
             if closest is None:
-                # Determine la tolerance affichee.
-                tol = "none"
-                findings.append(AlignmentFinding(
-                    notebook=str(path),
-                    cell_index=cell_idx,
-                    cell_kind="markdown",
-                    category="MISSING_FROM_OUTPUTS",
-                    prose_text=snippet,
-                    prose_number=v,
-                    closest_output_number=None,
-                    tolerance_used=tol,
-                ))
+                orphans.append(v)
+        if len(nums) >= MISSING_FROM_OUTPUTS_CELL_MIN:
+            ratio = len(orphans) / len(nums)
+            if ratio < MISSING_FROM_OUTPUTS_CELL_RATIO:
+                continue  # bruit : pas assez d'orphelins sur cette cellule dense
+        # Emet les orphelins survivants.
+        for v in orphans:
+            findings.append(AlignmentFinding(
+                notebook=str(path),
+                cell_index=cell_idx,
+                cell_kind="markdown",
+                category="MISSING_FROM_OUTPUTS",
+                prose_text=snippet,
+                prose_number=v,
+                closest_output_number=None,
+                tolerance_used="none",
+            ))
     # Tour 2 : MISSING_FROM_PROSE_ENUMERATION (#9416).
     # Pour chaque cellule markdown qui annonce une énumération de N niveaux,
     # compare N au nombre de niveaux distincts dans output_vals.

--- a/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
@@ -356,6 +356,73 @@ class TestAnalyzeNotebook:
 
 
 # --------------------------------------------------------------------------- #
+#  Gate anti-bruit dense-cell (EPIC #9768 Phase 0)
+# --------------------------------------------------------------------------- #
+
+
+class TestDenseCellOrphanGate:
+    """Lock le gate anti-bruit sur les cellules denses (>=3 nombres prose).
+
+    Contexte : le detecteur v2 emettait 21589 findings full-corpus dont
+    l'inspection firsthand montre ~99% de FP (prose = references, numeros de
+    section, dates, identifiants). Le gate n'emet MISSING_FROM_OUTPUTS pour une
+    cellule DENSE que si la majorite de ses nombres sont orphelins (ratio >=
+    MISSING_FROM_OUTPUTS_CELL_RATIO). Les cellules clairsemees (1-2 nombres)
+    sont preservees : une mesure unique manquante reste un signal valide.
+    """
+
+    def test_sparse_cell_single_missing_still_emitted(self, tmp_path):
+        # Cellule clairsemee (1 nombre) : la mesure manquante reste signalee.
+        # C'est le contrat preserve (cf test_prose_value_missing).
+        nb = tmp_path / "sparse.ipynb"
+        _make_notebook([
+            _markdown_cell("Sharpe = 0.69"),
+            _code_cell("print(0.1875)", [{"text": "0.1875\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        assert result.total_findings == 1
+        assert result.findings[0].category == "MISSING_FROM_OUTPUTS"
+
+    def test_dense_cell_minority_orphan_suppressed(self, tmp_path):
+        # Cellule dense (5 nombres) avec 1 orphelin sur 5 = 20% < seuil 50%.
+        # C'est du bruit (4 nombres presentes, 1 reference croisee) -> supprime.
+        nb = tmp_path / "dense_minority.ipynb"
+        _make_notebook([
+            _markdown_cell("a=0.5, b=0.6, c=0.7, d=0.8, ref=42"),
+            _code_cell("print([0.5, 0.6, 0.7, 0.8])",
+                       [{"text": "[0.5, 0.6, 0.7, 0.8]\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        mfo = [f for f in result.findings if f.category == "MISSING_FROM_OUTPUTS"]
+        assert mfo == [], f"dense cell with minority orphan should be suppressed, got {mfo}"
+
+    def test_dense_cell_majority_orphan_emitted(self, tmp_path):
+        # Cellule dense (5 nombres) avec 4 orphelins sur 5 = 80% >= seuil 50%.
+        # C'est de la derive authentique (la prose decrit des resultats non
+        # calcules) -> signale.
+        nb = tmp_path / "dense_majority.ipynb"
+        _make_notebook([
+            _markdown_cell("a=0.5, b=0.6, c=0.7, d=0.8, e=0.9"),
+            _code_cell("print(0.5)", [{"text": "0.5\n"}]),  # seul 0.5 present
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        mfo = [f for f in result.findings if f.category == "MISSING_FROM_OUTPUTS"]
+        assert len(mfo) == 4, f"4 orphans should survive the gate, got {len(mfo)}"
+
+    def test_dense_cell_threshold_boundary(self, tmp_path):
+        # Cellule dense (4 nombres) avec 2 orphelins sur 4 = 50% = seuil exact.
+        # >= seuil -> signale (frontiere inclusive).
+        nb = tmp_path / "boundary.ipynb"
+        _make_notebook([
+            _markdown_cell("a=0.5, b=0.6, c=0.7, d=0.8"),
+            _code_cell("print([0.5, 0.6])", [{"text": "[0.5, 0.6]\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        mfo = [f for f in result.findings if f.category == "MISSING_FROM_OUTPUTS"]
+        assert len(mfo) == 2, f"50% orphan at boundary should emit, got {len(mfo)}"
+
+
+# --------------------------------------------------------------------------- #
 #  Contre-epreuve positive ICT-1
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
Grain: DEEP/notebook-tools — lane myia-po-2025:CoursIA — prev: DEEP/notebook-tools #9804

## Ce que fait cette PR

Ajoute un **gate anti-bruit** au detecteur D5 intra-revision
(`scan_d5_prose_outputs_alignment.py`, #9793) qui emettait **21589 faux
positifs** full-corpus (99% des notebooks flaggues). Le gate require qu'une
cellule markdown DENSE (>=3 nombres prose) ait une **majorite** de ses nombres
orphelins des outputs (ratio >= 50%) avant d'emettre MISSING_FROM_OUTPUTS.

## Diagnostic (full-corpus, EPIC #9768 Phase 0)

Suite au fix d'orientation #9804, j'ai lance le detecteur D5 intra-revision
(#9793) en full-corpus (962 notebooks) pour completer #9790 :

| Metrique | Avant gate | Apres gate |
|----------|-----------|-----------|
| Notebooks flagges | 921 (95%) | 689 (72%) |
| MISSING_FROM_OUTPUTS | 21589 | 12574 (-42%) |
| MISSING_FROM_PROSE_ENUMERATION | 160 | 160 (intact) |

Inspection firsthand (G.1) des 21589 findings : ~99% de FP. Les nombres prose
signales etaitent des references croisees, numeros de section, dates,
identifiants — pas des mesures. Exemples verifies :
- `GameTheory-6` cell[27] num=33 : header "### Interpretation"
- `research_piotroski` num=343 : ID projet dans le titre
- `GameTheory-3` num=30.1/40.2 : numeros de version/cell

La classe AUTHENTIQUE (`MISSING_FROM_PROSE_ENUMERATION`, le cas fondateur
ICT-1 cell[24] "deux niveaux" vs outputs "trois") reste a **160 findings
intacts** — c'est le signal de derive actionnable, preserve par le gate.

## Le fix (dense-cell orphan-ratio gate)

```python
MISSING_FROM_OUTPUTS_CELL_RATIO = 0.50   # majorite orpheline requise (cell dense)
MISSING_FROM_OUTPUTS_CELL_MIN = 3        # seuil "dense"
```

Logique :
- **Cellule clairsemee (1-2 nombres)** : preservee telle quelle. Une mesure
  unique manquante ("Sharpe = 0.69") reste un signal valide — c'est le
  contrat du detecteur (cf `test_prose_value_missing`).
- **Cellule dense (>=3 nombres)** : MISSING_FROM_OUTPUTS emis uniquement si
  >= 50% des nombres sont orphelins. Une cellule avec 1 orphelin sur 10 =
  reference croisee (bruit) ; 5/10 = derive authentique.

Cohérence avec le detecteur D1 (`scan_d1_d3_d4_d5.py
D1_ORPHAN_RATIO_THRESHOLD`) qui resout le meme probleme prose-vs-outputs avec
le meme principe de ratio. Les deux detecteurs sont desormais alignes.

## Validation

- **Full-corpus** : 962 notebooks, 21589 -> 12574 MFO (-42%), MFPE 160 intact.
- **Cas fondateur ICT-1** : `MISSING_FROM_PROSE_ENUMERATION` = 1 toujours
  detecte (la derive authentique 0.69, cell[24]).
- **Tests** : 57 passent (53 existants + 4 nouveaux `TestDenseCellOrphanGate`
  : sparse preserve / dense-minority supprime / dense-majority emis /
  frontiere 50% inclusive).
- **Tous les tests existants preserves** (le gate ne casse aucun contrat —
  sparse cells inchangees).

## Residuel honnete

Le detecteur reste **bruyant** (12574 MFO) : la prose contient legitiment
beaucoup de non-mesures (theorie, exemples, refs) que le ratio-gate ne peut
pas distinguer. Une correction complete requerait un **filtre de contexte de
mesure** (nombre precede de "=", unite, mot-clef metrique) — design plus
large, future work. Cette PR est un **amelioration incrementale** (principe
du gate aligne sur D1 + preservation du signal authentique), pas un fix
complet. Le signal actionnable reste `MISSING_FROM_PROSE_ENUMERATION` (160
findings full-corpus).

Catalogue byte-identique a main (R1). LF-only, UTF-8 no-BOM. 2 fichiers,
atomique.

See #9790
See #9768

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
