### PR TITLE
fix(ci,lean): swap step in lean-build/lean-axiom — hosted-runner OOM on cache-miss elaboration (unblocks #9798)

### DIFF
--- a/.github/workflows/lean-axiom.yml
+++ b/.github/workflows/lean-axiom.yml
@@ -91,6 +91,20 @@ jobs:
         key: lake-${{ inputs.display-name }}-axiom-${{ runner.os }}-${{ hashFiles(format('{0}/lakefile.lean', inputs.project-path), format('{0}/lakefile.toml', inputs.project-path), format('{0}/lean-toolchain', inputs.project-path)) }}
         restore-keys: lake-${{ inputs.display-name }}-axiom-${{ runner.os }}-
 
+    - name: Add swap space
+      # Same OOM guard as lean-build.yml (see the comment there): a cache-miss
+      # build of a large local module (conway_lean HashlifeCorrectness.lean)
+      # exceeds the 16 GB of hosted runners and the VM is torn down with exit 143.
+      # This workflow rebuilds the lake too (its cache key differs from
+      # lean-build's, so it can miss independently) — observed on PR #9798 where
+      # BOTH proof-integrity jobs died at exit 143 alongside the build job.
+      run: |
+        sudo fallocate -l 16G /mnt/lean-swap
+        sudo chmod 600 /mnt/lean-swap
+        sudo mkswap /mnt/lean-swap
+        sudo swapon /mnt/lean-swap
+        free -h
+
     - name: Lake build
       working-directory: ${{ inputs.project-path }}
       run: |

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -178,6 +178,23 @@ jobs:
         key: lake-${{ inputs.display-name }}-${{ runner.os }}-${{ hashFiles(format('{0}/lakefile.lean', inputs.project-path), format('{0}/lakefile.toml', inputs.project-path), format('{0}/lean-toolchain', inputs.project-path)) }}
         restore-keys: lake-${{ inputs.display-name }}-${{ runner.os }}-
 
+    - name: Add swap space
+      # Hosted ubuntu-latest runners have 16 GB RAM. Full (cache-miss) elaboration
+      # of a large local module — conway_lean HashlifeCorrectness.lean, 7300+ lines —
+      # exceeds that: the VM OOMs and the provisioner tears the runner down mid-build
+      # ("The runner has received a shutdown signal", exit 143, ~4 min after the
+      # Mathlib cache download completes). Observed 3x on PR #9798 (runs 31139*,
+      # 31141*, 31147588612, 2026-08-07) while the sibling PR #9806 — same lake,
+      # cache HIT on the big module — passed in ~6 min: the discriminant is the
+      # actions/cache miss, not the code. Swap absorbs the elaboration peak; on
+      # incremental (cache-hit) runs this step costs ~5 s and the swap is idle.
+      run: |
+        sudo fallocate -l 16G /mnt/lean-swap
+        sudo chmod 600 /mnt/lean-swap
+        sudo mkswap /mnt/lean-swap
+        sudo swapon /mnt/lean-swap
+        free -h
+
     - name: Lake build
       working-directory: ${{ inputs.project-path }}
       run: |


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-ai-01:CoursIA — prev: DEEP/lean #9806

## Summary

Ajoute une étape « Add swap space » (16 G sur `/mnt`) avant le `lake build` dans les **deux workflows Lean réutilisables** (`lean-build.yml` + `lean-axiom.yml`), pour que l'élaboration complète d'un gros module local survive aux runners hébergés 16 GB.

## Diagnostic (firsthand, 3 occurrences + 1 contre-exemple)

**Symptôme** : PR #9798 (qui modifie `HashlifeCorrectness.lean`, 7300+ lignes) a échoué **3 fois** avec la même signature, sur les **3 jobs Lean** (build + proof-integrity + proof-integrity-audit) :

```
##[error]The runner has received a shutdown signal. This can happen when the runner
service is stopped, or a manually started runner is canceled.
##[error]Process completed with exit code 143.
```

- Chronologie type (run 31147588612, job proof-integrity-audit) : cache Mathlib téléchargé à 04:31:11Z (8477 fichiers), runner tué à 04:35:50Z — **~4,5 min dans l'élaboration des modules locaux**.
- Runner : « Hosted Compute Agent », `ubuntu-latest` = 4 cœurs / **16 GB RAM**. Le shutdown-signal spontané en plein build est le pattern OOM au niveau VM (le provisioner tue la machine, pas le process).

**Contre-exemple discriminant** : PR #9806 (même lake, même workflows, ~même heure) est passée en ~6 min, les 3 jobs Lean verts — elle **n'ajoute qu'un module nouveau** et ne modifie pas `HashlifeCorrectness`, donc `actions/cache` fournit un `.lake/build` incrémental pour le gros module. #9798 le **modifie** → cache-miss sur ce contenu → ré-élaboration complète → pic mémoire > 16 GB → mort de la VM. `main` passe en 6m36s pour la même raison (cache chaud).

Les deux workflows buildent le lake indépendamment (clés de cache distinctes, `lake-<name>-` vs `lake-<name>-axiom-`) — d'où le fix dans **les deux**.

## Fix

Étape shell standard, ~5 s, avant le build :

```yaml
sudo fallocate -l 16G /mnt/lean-swap
sudo chmod 600 /mnt/lean-swap
sudo mkswap /mnt/lean-swap
sudo swapon /mnt/lean-swap
free -h
```

- `/mnt` a ~40-65 GB libres sur les runners hébergés ; `fallocate` est instantané.
- Sur un run cache-hit (le cas nominal), le swap n'est jamais touché — coût nul.
- Sur un run cache-miss, l'élaboration thrash au lieu de tuer la VM : plus lent, mais **terminant** — c'est exactement le compromis voulu pour un gate de correction.
- Le `free -h` loggue l'état pour tout diagnostic futur.

Aucune alternative gratuite : les runners plus gros sont payants, et réduire le parallélisme lake ne borne pas le pic d'élaboration d'un **seul** module de 7300 lignes.

## Validation

- `yaml.safe_load` OK sur les deux fichiers.
- Les workflows réutilisables sont référencés `@main` par les callers : le fix ne prend effet qu'au merge. **Validation réelle = re-run des checks de #9798 immédiatement après merge** (je m'y engage dans le fil de #9798 ; si le re-run passe, c'est la preuve de bout en bout).
- B.3 proof-integrity : non applicable — aucun `.lean` modifié ; ce fichier YAML est l'infrastructure du gate, pas son objet.

## Scope

2 fichiers, +31/-0, un seul sujet (résilience OOM des builds Lean CI). Pas de changement de sémantique des gates (baselines sorry, allow-axioms, fail-on-sorry intouchés).

See #9798 (PR bloquée par l'OOM) · See #6724 (EPIC P4/P5 dont #9798 est un grain)
