### PR TITLE
feat(notebook_tools,#9812): --stale-threshold for check_lane_claim.py (bypass orphaned claims)

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -21,6 +21,13 @@ needs user sign-off; this is the mechanism that the rule will call):
     pick elsewhere. Exit 0 means the way is clear (optionally: your own lane
     already claimed, you are resuming).
 
+  - **--stale-threshold HOURS** (check mode): treat OTHER lanes' claims older
+    than HOURS as STALE -- the guard no longer blocks on them, it prints a
+    `STALE_CLAIM <lane> <age>h` warning instead. This unblocks a lane when a
+    prior claimer died (killed session, re-image, exhausted credit) without a
+    release. Age is the server `createdAt`, never the body. The new claimant
+    MUST still post its own `[CLAIMED]`; the stale claim is not a silent bypass.
+
   - **--claim "<intention>"**: post a `[CLAIMED] lane <machine:workspace>`
     comment. GitHub server-stamps it UTC -- the body carries NO timestamp, so
     Defaut 2 (local time wearing a `Z` suffix) is impossible by construction.
@@ -50,6 +57,7 @@ import re
 import subprocess
 import sys
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 # Shared lane reader (#9485) -- see scripts/grain_tag.py.
@@ -221,11 +229,59 @@ def _fmt_utc(iso: str | None) -> str:
 
 # --- modes -------------------------------------------------------------------
 
-def _run_check(payload: dict, my_lane: str) -> int:
+def _claim_age_hours(created_at: str | None, now: datetime) -> float | None:
+    """Age of a claim in hours, from the server `createdAt` field.
+
+    Returns None when `created_at` is missing or unparseable -- conservatively
+    treated as NOT stale (we cannot prove an age, so we do not silently lift a
+    block on a claim we cannot date). `now` is injected for testability.
+    """
+    if not created_at:
+        return None
+    parsed = _parse_iso_utc(created_at)
+    if parsed is None:
+        return None
+    return (now - parsed).total_seconds() / 3600.0
+
+
+def _parse_iso_utc(iso: str) -> datetime | None:
+    """Parse a GitHub server `createdAt` (ISO 8601 UTC, trailing 'Z').
+
+    Tolerates a fractional second component and an explicit +00:00 offset.
+    Returns None on any parse failure rather than raising.
+    """
+    try:
+        s = iso.strip()
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        dt = datetime.fromisoformat(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+def _run_check(payload: dict, my_lane: str, stale_threshold=None,
+               now: datetime | None = None) -> int:
     events = _sort_events(payload)
     active, unattributed = compute_active_claims(events)
     others = {ln: ev for ln, ev in active.items() if ln != my_lane}
     mine = active.get(my_lane)
+
+    # Stale-claim handling (#9812): a claim older than `stale_threshold` hours
+    # (age from the server createdAt, NEVER the body) is treated as STALE -- it
+    # no longer blocks, but a warning is printed and the new claimant MUST post
+    # their own [CLAIMED] (this is not a silent bypass). Without the flag
+    # (default None), behaviour is unchanged: every active claim blocks.
+    stale_others: dict[str, ClaimEvent] = {}
+    if stale_threshold is not None:
+        now = now or datetime.now(timezone.utc)
+        for ln, ev in others.items():
+            age = _claim_age_hours(ev.created_at, now)
+            if age is not None and age >= stale_threshold:
+                stale_others[ln] = ev
+        others = {ln: ev for ln, ev in others.items() if ln not in stale_others}
 
     summary = {
         "issue": payload.get("number"),
@@ -233,6 +289,7 @@ def _run_check(payload: dict, my_lane: str) -> int:
         "my_lane": my_lane,
         "my_active_claim": bool(mine),
         "blocking_lanes": sorted(others),
+        "stale_claims": sorted(stale_others),
         "active_claims": {
             ln: {
                 "claimed_at": ev.created_at,
@@ -247,6 +304,16 @@ def _run_check(payload: dict, my_lane: str) -> int:
     }
     print(json.dumps(summary, ensure_ascii=False, indent=2))
 
+    # Stale warnings -- non-blocking, but loud enough to prompt a fresh claim.
+    for ln, ev in sorted(stale_others.items()):
+        age = _claim_age_hours(ev.created_at, now)
+        age_h = f"{age:.1f}" if age is not None else "?"
+        print(
+            f"STALE_CLAIM {ln} ({age_h}h >= {stale_threshold:g}h threshold) -- "
+            f"reprise autorisee, poster un nouveau [CLAIMED].",
+            file=sys.stderr,
+        )
+
     # Human verdict after the JSON.
     if others:
         who = ", ".join(
@@ -259,7 +326,12 @@ def _run_check(payload: dict, my_lane: str) -> int:
             file=sys.stderr,
         )
         return 1
-    note = " (resuming your own active claim)" if mine else ""
+    parts = []
+    if mine:
+        parts.append("resuming your own active claim")
+    if stale_others:
+        parts.append(f"{len(stale_others)} stale claim(s) bypassed")
+    note = f" ({'; '.join(parts)})" if parts else ""
     print(f"\nCLEAR: no other lane claims #{payload.get('number')}{note}.")
     return 0
 
@@ -280,6 +352,12 @@ def main(argv: list[str] | None = None) -> int:
                    help="your lane, e.g. myia-po-2024:CoursIA")
     p.add_argument("--from-json", metavar="FILE",
                    help="read `gh issue view` JSON from FILE (offline/test mode)")
+    p.add_argument("--stale-threshold", type=float, metavar="HOURS", default=None,
+                   help="treat OTHER lanes' claims older than HOURS as stale: "
+                        "warn and do not block (age from server createdAt, never "
+                        "the body). The new claimant must still post its own "
+                        "[CLAIMED] -- this is not a silent bypass. Without the "
+                        "flag every active claim blocks (current behaviour).")
     act = p.add_mutually_exclusive_group()
     act.add_argument("--claim", metavar="INTENTION",
                      help="post a [CLAIMED] comment for your lane")
@@ -317,7 +395,7 @@ def main(argv: list[str] | None = None) -> int:
     except (RuntimeError, json.JSONDecodeError, OSError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    return _run_check(payload, args.lane)
+    return _run_check(payload, args.lane, stale_threshold=args.stale_threshold)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -11,6 +11,7 @@ These tests replay that exact trap and assert the tool is not fooled.
 Run: python -m pytest scripts/tests/test_check_lane_claim.py
 """
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -221,3 +222,114 @@ def test_check_surfaces_unattributed(capsys):
     assert rc == 0
     out = capsys.readouterr().out
     assert '"unattributed_markers": 1' in out
+
+
+# --- --stale-threshold (#9812) ----------------------------------------------
+# A claim older than the threshold (age from server createdAt, never the body)
+# is treated as STALE: it no longer blocks, but a STALE_CLAIM warning is printed
+# and the claimant must still post its own [CLAIMED]. Without the flag, every
+# active claim blocks (behaviour unchanged).
+
+NOW = datetime(2026, 8, 7, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_claim_age_hours_basic():
+    # 48h ago at the fixed NOW.
+    age = clc._claim_age_hours("2026-08-05T12:00:00Z", NOW)
+    assert age is not None and abs(age - 48.0) < 1e-6
+
+
+def test_claim_age_hours_none_on_unparseable():
+    assert clc._claim_age_hours(None, NOW) is None
+    assert clc._claim_age_hours("not a date", NOW) is None
+
+
+def test_parse_iso_utc_tolerates_fractional_and_offset():
+    assert clc._parse_iso_utc("2026-08-07T12:00:00Z") is not None
+    assert clc._parse_iso_utc("2026-08-07T12:00:00.123Z") is not None
+    assert clc._parse_iso_utc("2026-08-07T12:00:00+00:00") is not None
+    assert clc._parse_iso_utc("garbage") is None
+
+
+def test_stale_threshold_unblocks_old_claim(capsys):
+    # Other lane claimed 48h ago; threshold 24h -> CLEAR with stale warning.
+    p = payload(comment(
+        "[CLAIMED] lane myia-po-2025:CoursIA -- working here",
+        "2026-08-05T12:00:00Z",
+    ))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA",
+                        stale_threshold=24.0, now=NOW)
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "STALE_CLAIM myia-po-2025:CoursIA" in captured.err
+    assert '"stale_claims"' in captured.out
+    assert '"blocked": false' in captured.out
+
+
+def test_stale_threshold_fresh_claim_still_blocks(capsys):
+    # Other lane claimed 2h ago; threshold 24h -> still BLOCKED.
+    p = payload(comment(
+        "[CLAIMED] lane myia-po-2025:CoursIA -- working here",
+        "2026-08-07T10:00:00Z",
+    ))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA",
+                        stale_threshold=24.0, now=NOW)
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "BLOCKED" in captured.err
+
+
+def test_stale_threshold_stale_plus_fresh_blocks_on_fresh(capsys):
+    # Two other lanes: one stale (48h), one fresh (1h). The fresh one blocks.
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA -- old",
+                "2026-08-05T12:00:00Z"),
+        comment("[CLAIMED] lane myia-po-2023:CoursIA -- fresh",
+                "2026-08-07T11:00:00Z"),
+    )
+    rc = clc._run_check(p, "myia-po-2024:CoursIA",
+                        stale_threshold=24.0, now=NOW)
+    assert rc == 1
+    captured = capsys.readouterr()
+    # The stale one is warned about, the fresh one blocks.
+    assert "STALE_CLAIM myia-po-2025:CoursIA" in captured.err
+    assert "BLOCKED" in captured.err
+    assert "myia-po-2023:CoursIA" in captured.out
+
+
+def test_stale_threshold_boundary_is_stale(capsys):
+    # Exactly 24h old, threshold 24h: >= means STALE (boundary goes to stale).
+    p = payload(comment(
+        "[CLAIMED] lane myia-po-2025:CoursIA -- exactly at boundary",
+        "2026-08-06T12:00:00Z",
+    ))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA",
+                        stale_threshold=24.0, now=NOW)
+    assert rc == 0
+    assert "STALE_CLAIM" in capsys.readouterr().err
+
+
+def test_no_stale_flag_blocks_old_claim_unchanged(capsys):
+    # Criterion 1: without the flag, an old claim still blocks (current behaviour).
+    p = payload(comment(
+        "[CLAIMED] lane myia-po-2025:CoursIA -- very old orphan",
+        "2026-08-01T00:00:00Z",
+    ))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA", now=NOW)
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "STALE_CLAIM" not in captured.err
+    assert "BLOCKED" in captured.err
+
+
+def test_stale_threshold_unparseable_not_treated_stale(capsys):
+    # A claim whose createdAt is unparseable cannot be dated -> NOT stale
+    # (conservative: we cannot prove an age, so we do not lift the block).
+    p = payload(comment(
+        "[CLAIMED] lane myia-po-2025:CoursIA -- undated",
+        "not-an-iso-date",
+    ))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA",
+                        stale_threshold=24.0, now=NOW)
+    assert rc == 1
+    assert "BLOCKED" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Grain: MED/guard — lane myia-po-2026:CoursIA — fille de #9774

Implémente `--stale-threshold HOURS` pour `scripts/check_lane_claim.py`. Le guard traitait tout `[CLAIMED]` comme actif indéfiniment : si une lane claimait puis mourait (session tuée, re-image, crédit épuisé) sans release, le claim orphelin **bloquait toutes les autres lanes pour toujours** — l'inverse du but de #9774 (fluidifier la déconfliction, pas créer des verrous fantômes).

## Comportement

Avec `--stale-threshold 24` (check mode) : un claim d'une autre lane plus vieux que 24h (âge = `createdAt` serveur, JAMAIS le body) est **STALE** — le guard ne bloque plus, il imprime `STALE_CLAIM <lane> <age>h` + un tableau `stale_claims` dans le JSON. Le nouveau claimant DOIT quand même poster son propre `[CLAIMED]` (pas un bypass silencieux). Sans le flag, comportement inchangé (critère 1).

**Defaut-2-safe par construction** : l'âge vient du champ serveur `createdAt` (déjà sur l'event), jamais d'un timestamp du body. Un `createdAt` non-parsable = NON stale (conservatif — ne pas lever silencieusement un blocage sur un claim qu'on ne peut pas dater).

## 4 critères d'acceptation (#9812)

- [x] **1. `--stale-threshold` optionnel, comportement inchangé sans le flag** — `default=None`, test `test_no_stale_flag_blocks_old_claim_unchanged` (un vieux claim bloque toujours sans le flag).
- [x] **2. Âge sur `createdAt` du commentaire (API), jamais le texte** — `_claim_age_hours(ev.created_at, now)` ; `ev.created_at` vient de `parse_claim_event` qui lit `comment.get("createdAt")`. Tests `test_claim_age_hours_basic` + Defaut-2-safe par construction.
- [x] **3. Tests pytest verts** — 25/25 PASS en 0.10s (16 existants + 9 nouveaux, 0 régression).
- [x] **4. Doc** — bloc de doc dans le header du script (section `--stale-threshold HOURS`, ~6 lignes).

## 9 nouveaux tests (couvrent les scénarios du livrable)

| Test | Scénario | Verdict |
|------|----------|---------|
| `test_claim_age_hours_basic` | 48h → 48.0 | âge correct |
| `test_claim_age_hours_none_on_unparseable` | None / date invalide | None (conservatif) |
| `test_parse_iso_utc_*` | Z, fractional, +00:00, garbage | tolérant robuste |
| `test_stale_threshold_unblocks_old_claim` | claim 48h, thr 24h | **CLEAR + warning** |
| `test_stale_threshold_fresh_claim_still_blocks` | claim 2h, thr 24h | **BLOCKED** |
| `test_stale_threshold_stale_plus_fresh_blocks_on_fresh` | stale 48h + fresh 1h | **BLOCKED sur fresh** |
| `test_stale_threshold_boundary_is_stale` | exactement 24h == thr 24h | **STALE (>=)** |
| `test_no_stale_flag_blocks_old_claim_unchanged` | vieux claim, pas de flag | **BLOCKED** (inchangé) |
| `test_stale_threshold_unparseable_not_treated_stale` | createdAt invalide | **BLOCKED** (conservatif) |

## Détails

- Diff additif : `check_lane_claim.py` +84/-3, `test_check_lane_claim.py` +112/-0 (25/25 tests).
- Pure LF (byte-level CRLF=0, pas de flip d'endings sur le fichier entier).
- 0 source churn intempestif (uniquement les régions touchées : helpers purs `_claim_age_hours`/`_parse_iso_utc`, `_run_check` signature + logique stale, argparse `--stale-threshold`, header doc).
- `_run_check` gagne `now` injectable → tests déterministes (pas de `datetime.now()` réel).

R6 ✓ : rotation genre (Lean/stats → tooling/guard CI, famille distincte, non-stats-monoculture). #9812 explicitement « Ouvert à toute lane ; po-2025 primauté naturelle mais sans exclusivité » — po-2025 a pivoté hors-tooling ce cycle. Claim posté sur #9812 (protocol #9774).

Closes #9812

🤖 Generated with [Claude Code](https://claude.com/claude-code)
