### PR TITLE
Refactor(lean,#8696): Reidemeister1' surgery = field equalities (window 2/9)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -477,9 +477,12 @@ theorem tricolorable_invariant_fails_under_pr1_model :
            injection h with hval
            exact Fin.ext hval⟩
       exact ρ
-    · -- surgery (twist arm): d₂ = { d₁ with crossings := d₁.crossings ++ [⟨3,4,3,4⟩], numEdges := d₁.numEdges + 2 }.
+    · -- surgery (twist arm): field-equalities on a 2-field record
+      --     d₂.crossings = d₁.crossings ++ [⟨3,4,3,4⟩] ∧ d₂.numEdges = d₁.numEdges + 2.
+      --     Both conjuncts are defeq on the literal witness pair (concretely,
+      --     [⟨1,2,1,2⟩,⟨3,4,3,4⟩] = [⟨1,2,1,2⟩] ++ [⟨3,4,3,4⟩] and 4 = 2 + 2).
       left
-      rfl
+      exact ⟨rfl, rfl⟩
   -- (b) d₁ is NOT tricolorable: Fox at the sole crossing ⟨1,2,1,2⟩ forces the two
   --     edges to the same colour, contradicting the ≥2-colours requirement.
   · show ¬ IsTricolorable { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -567,39 +567,30 @@ theorem pr1_counterexample_excluded_under_rho_determined :
     ¬ Reidemeister1'
         { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
         { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 } := by
-  -- Unfold Reidemeister1': wf₁ ∧ wf₂ ∧ (∃ a, range ∧ (∃ ρ, surgery ∨ surgery)).
+  -- **Migration #8696 fenêtre 2/9** : post-migration field-equalities, la
+  -- surgery est `(h_cross ∧ h_num)` au lieu de `with`-surgery record. Le
+  -- `congrArg (·.crossings) ht` disparaît — `h_cross` EST directement
+  -- l'égalité de champs qu'on veut. Sur les literals concrets, le `simp` puis
+  -- `injection` puis `omega` ferment les deux branches (TWIST/UNTWIST).
   rintro ⟨_hwf₁, _hwf₂, a, _hrange₁, _hrange₂, _ρ, hsurg⟩
-  rcases hsurg with ht | ht
-  · -- TWIST arm: d₂ = { d₁ with crossings := d₁.crossings ++ [⟨a,a,3,4⟩], numEdges := 4 }.
-    -- d₁.numEdges = 2, so the appended crossing is ⟨a, a, 3, 4⟩.
-    -- Project .crossings off the record equality ht by congruence, then the RHS
-    -- ({ d₁ with crossings := X }).crossings reduces to X = d₁.crossings ++ [⟨a,a,3,4⟩].
-    have hfield :
-        ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 }
-          : KnotDiagram).crossings =
-        ({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
-          : KnotDiagram).crossings ++ [⟨a, a, 3, 4⟩] :=
-      congrArg (·.crossings) ht
-    -- The RHS reduces to [⟨1,2,1,2⟩] ++ [⟨a,a,3,4⟩]; second elements: ⟨3,4,3,4⟩ = ⟨a,a,3,4⟩.
+  -- `hsurg` is `(⟨h_cross, h_num⟩ | ⟨h_cross, h_num⟩)` — re-destructure each
+  -- branch's internal 2-conj to recover the field-equality on `.crossings`.
+  rcases hsurg with ⟨h_cross, _h_num⟩ | ⟨h_cross, _h_num⟩
+  · -- TWIST arm: d₂.crossings = d₁.crossings ++ [⟨a,a,3,4⟩] ∧ d₂.numEdges = 4.
+    --   d₁.numEdges = 2, so appended crossing is ⟨a, a, 3, 4⟩. h_cross IS
+    --   the field equality on `.crossings` directly (no projection needed).
     have h2nd : (⟨3, 4, 3, 4⟩ : PDCrossing) = ⟨a, a, 3, 4⟩ := by
-      simpa [List.append] using hfield
+      simpa [List.append] using h_cross
     -- Injectivity of PDCrossing (4 fields): e1 gives 3 = a, e2 gives 4 = a.
     injection h2nd with h_e1 h_e2 h_e3 h_e4
     omega
-  · -- UNTWIST arm: d₁ = { d₂ with crossings := d₂.crossings ++ [⟨a,a,5,6⟩], numEdges := 6 }.
-    -- d₂.numEdges = 4, so appended crossing = ⟨a, a, 5, 6⟩.
-    -- Project .crossings off the record equality by congruence (term-mode, robust
-    -- against literal-form mismatch that blocks `subst`/`rw`).
-    have hfield :
-        ({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
-          : KnotDiagram).crossings =
-        ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 }
-          : KnotDiagram).crossings ++ [⟨a, a, 5, 6⟩] :=
-      congrArg (·.crossings) ht
+  · -- UNTWIST arm: d₁.crossings = d₂.crossings ++ [⟨a,a,5,6⟩] ∧ d₁.numEdges = 6.
+    --   d₂.numEdges = 4, so appended crossing = ⟨a, a, 5, 6⟩. h_cross IS
+    --   the field equality on `.crossings` directly.
     -- Length contradiction: LHS has length 1, RHS has length 3.
     -- `simp at h` reduces the list lengths to concrete numbers (`1` and `3`),
     -- then closes the goal by deriving `False` from the contradiction `1 = 3`.
-    have h := congrArg List.length hfield
+    have h := congrArg List.length h_cross
     simp at h
 
 /-! ## 3c-bis. Le temoin #2938 est AUSSI exclu sous `Reidemeister1Connected` (option C)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
@@ -517,39 +517,30 @@ theorem pr1_counterexample_excluded_under_rho_determined :
     ¬ Reidemeister1'
         { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
         { crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 } := by
-  -- Unfold Reidemeister1': wf₁ ∧ wf₂ ∧ (∃ a, range ∧ (∃ ρ, surgery ∨ surgery)).
+  -- **Migration #8696 window 2/9**: post field-equalities migration, the
+  -- surgery is `(h_cross ∧ h_num)` instead of `with`-surgery record. The
+  -- `congrArg (·.crossings) ht` disappears — `h_cross` IS directly the
+  -- field equality we want. On concrete literals, `simp` then `injection`
+  -- then `omega` close both branches (TWIST/UNTWIST).
   rintro ⟨_hwf₁, _hwf₂, a, _hrange₁, _hrange₂, _ρ, hsurg⟩
-  rcases hsurg with ht | ht
-  · -- TWIST arm: d₂ = { d₁ with crossings := d₁.crossings ++ [⟨a,a,3,4⟩], numEdges := 4 }.
-    -- d₁.numEdges = 2, so the appended crossing is ⟨a, a, 3, 4⟩.
-    -- Project .crossings off the record equality ht by congruence, then the RHS
-    -- ({ d₁ with crossings := X }).crossings reduces to X = d₁.crossings ++ [⟨a,a,3,4⟩].
-    have hfield :
-        ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 }
-          : KnotDiagram).crossings =
-        ({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
-          : KnotDiagram).crossings ++ [⟨a, a, 3, 4⟩] :=
-      congrArg (·.crossings) ht
-    -- The RHS reduces to [⟨1,2,1,2⟩] ++ [⟨a,a,3,4⟩]; second elements: ⟨3,4,3,4⟩ = ⟨a,a,3,4⟩.
+  -- `hsurg` is `(⟨h_cross, h_num⟩ | ⟨h_cross, h_num⟩)` — re-destructure each
+  -- branch's internal 2-conj to recover the field-equality on `.crossings`.
+  rcases hsurg with ⟨h_cross, _h_num⟩ | ⟨h_cross, _h_num⟩
+  · -- TWIST arm: d₂.crossings = d₁.crossings ++ [⟨a,a,3,4⟩] ∧ d₂.numEdges = 4.
+    --   d₁.numEdges = 2, so appended crossing is ⟨a, a, 3, 4⟩. h_cross IS
+    --   the field equality on `.crossings` directly (no projection needed).
     have h2nd : (⟨3, 4, 3, 4⟩ : PDCrossing) = ⟨a, a, 3, 4⟩ := by
-      simpa [List.append] using hfield
+      simpa [List.append] using h_cross
     -- Injectivity of PDCrossing (4 fields): e1 gives 3 = a, e2 gives 4 = a.
     injection h2nd with h_e1 h_e2 h_e3 h_e4
     omega
-  · -- UNTWIST arm: d₁ = { d₂ with crossings := d₂.crossings ++ [⟨a,a,5,6⟩], numEdges := 6 }.
-    -- d₂.numEdges = 4, so appended crossing = ⟨a, a, 5, 6⟩.
-    -- Project .crossings off the record equality by congruence (term-mode, robust
-    -- against literal-form mismatch that blocks `subst`/`rw`).
-    have hfield :
-        ({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
-          : KnotDiagram).crossings =
-        ({ crossings := [⟨1, 2, 1, 2⟩, ⟨3, 4, 3, 4⟩], numEdges := 4 }
-          : KnotDiagram).crossings ++ [⟨a, a, 5, 6⟩] :=
-      congrArg (·.crossings) ht
+  · -- UNTWIST arm: d₁.crossings = d₂.crossings ++ [⟨a,a,5,6⟩] ∧ d₁.numEdges = 6.
+    --   d₂.numEdges = 4, so appended crossing = ⟨a, a, 5, 6⟩. h_cross IS
+    --   the field equality on `.crossings` directly.
     -- Length contradiction: LHS has length 1, RHS has length 3.
     -- `simp at h` reduces the list lengths to concrete numbers (`1` and `3`),
     -- then closes the goal by deriving `False` from the contradiction `1 = 3`.
-    have h := congrArg List.length hfield
+    have h := congrArg List.length h_cross
     simp at h
 
 /-! ## 3c-bis. The #2938 witness is ALSO excluded under `Reidemeister1Connected` (option C)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
@@ -431,9 +431,12 @@ theorem tricolorable_invariant_fails_under_pr1_model :
            injection h with hval
            exact Fin.ext hval⟩
       exact ρ
-    · -- surgery (twist arm): d₂ = { d₁ with crossings := d₁.crossings ++ [⟨3,4,3,4⟩], numEdges := d₁.numEdges + 2 }.
+    · -- surgery (twist arm): field-equalities on a 2-field record
+      --     d₂.crossings = d₁.crossings ++ [⟨3,4,3,4⟩] ∧ d₂.numEdges = d₁.numEdges + 2.
+      --     Both conjuncts are defeq on the literal witness pair (concretely,
+      --     [⟨1,2,1,2⟩,⟨3,4,3,4⟩] = [⟨1,2,1,2⟩] ++ [⟨3,4,3,4⟩] and 4 = 2 + 2).
       left
-      rfl
+      exact ⟨rfl, rfl⟩
   -- (b) d₁ is NOT tricolorable: Fox at the sole crossing ⟨1,2,1,2⟩ forces the two
   --     edges to the same colour, contradicting the ≥2-colours requirement.
   · show ¬ IsTricolorable { crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
@@ -88,8 +88,8 @@ def Reidemeister1 (d₁ d₂ : KnotDiagram) : Prop :=
   d₁.wf = true ∧ d₂.wf = true ∧
   (∃ c : PDCrossing,
      ∃ ρ : Fin (min d₁.numEdges d₂.numEdges) ↪ Fin (max d₁.numEdges d₂.numEdges),
-       d₂ = { d₁ with crossings := d₁.crossings ++ [c], numEdges := d₁.numEdges + 2 } ∨
-       d₁ = { d₂ with crossings := d₂.crossings ++ [c], numEdges := d₂.numEdges + 2 })
+       (d₂.crossings = d₁.crossings ++ [c] ∧ d₂.numEdges = d₁.numEdges + 2) ∨
+       (d₁.crossings = d₂.crossings ++ [c] ∧ d₁.numEdges = d₂.numEdges + 2))
 
 /-- R1 est symétrique : échanger `d₁`/`d₂` permute les deux bras de la
 disjonction de chirurgie ; le renommage dirigé par `min`/`max` est invariant
@@ -152,9 +152,14 @@ def Reidemeister1' (d₁ d₂ : KnotDiagram) : Prop :=
 theorem Reidemeister1'.implies_reidemeister1 {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1' d₁ d₂) : Reidemeister1 d₁ d₂ := by
   -- `Reidemeister1'` unfolds as `wf₁ ∧ wf₂ ∧ (∃ a, range ∧ (∃ ρ, surgery|surgery))`.
+  -- The surgery is `with`-form on a 2-field record; after `obtain rfl := hsurg`,
+  -- field projections reduce to literals, so `⟨rfl, rfl⟩` discharges the
+  -- field-equality pair.
   obtain ⟨hwf₁, hwf₂, a, _hrange₁, _hrange₂, ρ, hsurg | hsurg⟩ := h
-  · exact ⟨hwf₁, hwf₂, ⟨a, a, d₁.numEdges + 1, d₁.numEdges + 2⟩, ρ, Or.inl hsurg⟩
-  · exact ⟨hwf₁, hwf₂, ⟨a, a, d₂.numEdges + 1, d₂.numEdges + 2⟩, ρ, Or.inr hsurg⟩
+  · obtain rfl := hsurg
+    exact ⟨hwf₁, hwf₂, ⟨a, a, d₁.numEdges + 1, d₁.numEdges + 2⟩, ρ, Or.inl ⟨rfl, rfl⟩⟩
+  · obtain rfl := hsurg
+    exact ⟨hwf₁, hwf₂, ⟨a, a, d₂.numEdges + 1, d₂.numEdges + 2⟩, ρ, Or.inr ⟨rfl, rfl⟩⟩
 
 /-! ## R1 (option C, chirurgie connectée) — Phase 5 PR1.5c
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
@@ -134,32 +134,40 @@ L'équivalence remodelée et le lemme de transfert (PR2) seront construits sur
     nouveau croisement a la forme `⟨a, a, n+1, n+2⟩` : le brin anciennement
     labelisé `a` est le brin bouclé, et `{n+1, n+2}` sont les deux arêtes
     fraîches de la boucle. L'arc `a` vit dans `[1, numEdges]` du diagramme le
-    plus petit (labels PD 1-indexés, cohérents avec `KnotDiagram.wf`). -/
+    plus petit (labels PD 1-indexés, cohérents avec `KnotDiagram.wf`).
+
+    **Migration #8696 fenêtre 2/9** : la chirurgie `with`-surgery
+    `d₂ = { d₁ with ... }` est remplacée par une conjonction d'égalités de
+    champs `(d₂.crossings = ... ∧ d₂.numEdges = ...)` — pattern uniforme avec
+    `Reidemeister1` (fenêtre 1/9). Bénéfice : la def **contraint** un
+    diagramme donné (au lieu de construire un témoin hypothétique), ce qui
+    rend le champ d'invariant `wf` portable (cf acceptance #8696 §4). -/
 def Reidemeister1' (d₁ d₂ : KnotDiagram) : Prop :=
   d₁.wf = true ∧ d₂.wf = true ∧
   (∃ a : Nat,
      1 ≤ a ∧ a ≤ min d₁.numEdges d₂.numEdges ∧
      (∃ ρ : Fin (min d₁.numEdges d₂.numEdges) ↪ Fin (max d₁.numEdges d₂.numEdges),
-       (d₂ = { d₁ with crossings := d₁.crossings ++ [⟨a, a, d₁.numEdges + 1, d₁.numEdges + 2⟩],
-                            numEdges := d₁.numEdges + 2 } ∨
-        d₁ = { d₂ with crossings := d₂.crossings ++ [⟨a, a, d₂.numEdges + 1, d₂.numEdges + 2⟩],
-                            numEdges := d₂.numEdges + 2 })))
+       (d₂.crossings = d₁.crossings ++ [⟨a, a, d₁.numEdges + 1, d₁.numEdges + 2⟩] ∧
+        d₂.numEdges = d₁.numEdges + 2) ∨
+       (d₁.crossings = d₂.crossings ++ [⟨a, a, d₂.numEdges + 1, d₂.numEdges + 2⟩] ∧
+        d₁.numEdges = d₂.numEdges + 2)))
 
 /-- `Reidemeister1'` est un renforcement de `Reidemeister1` : toute boucle
     ρ-déterminée est, en particulier, un mouvement R1 (libre) avec `wf` des deux
     côtés. Le nouveau croisement `⟨a, a, n+1, n+2⟩` est le témoin de
-    l'existentiel indépendant `∃ c` dans `Reidemeister1`. -/
+    l'existentiel indépendant `∃ c` dans `Reidemeister1`.
+
+    **Migration #8696 fenêtre 2/9** : post-migration field-equalities, le bridge
+    est trivial : chaque branche de la disjonction est `(h_cross ∧ h_num)`,
+    donc `rfl` sur `h_cross` ET `h_num` simultanément suffit à fermer
+    `Or.inl/inr ⟨rfl, rfl⟩` vers la cible R1 (qui est aussi en field-eqs). -/
 theorem Reidemeister1'.implies_reidemeister1 {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1' d₁ d₂) : Reidemeister1 d₁ d₂ := by
-  -- `Reidemeister1'` unfolds as `wf₁ ∧ wf₂ ∧ (∃ a, range ∧ (∃ ρ, surgery|surgery))`.
-  -- The surgery is `with`-form on a 2-field record; after `obtain rfl := hsurg`,
-  -- field projections reduce to literals, so `⟨rfl, rfl⟩` discharges the
-  -- field-equality pair.
+  -- `Reidemeister1'` unfolds as `wf₁ ∧ wf₂ ∧ (∃ a, range ∧ (∃ ρ, ⟨h_cross,h_num⟩ | ⟨h_cross,h_num⟩))`.
+  -- After field-eqs migration, `hsurg` is a 2-conj consumed by `⟨rfl, rfl⟩`.
   obtain ⟨hwf₁, hwf₂, a, _hrange₁, _hrange₂, ρ, hsurg | hsurg⟩ := h
-  · obtain rfl := hsurg
-    exact ⟨hwf₁, hwf₂, ⟨a, a, d₁.numEdges + 1, d₁.numEdges + 2⟩, ρ, Or.inl ⟨rfl, rfl⟩⟩
-  · obtain rfl := hsurg
-    exact ⟨hwf₁, hwf₂, ⟨a, a, d₂.numEdges + 1, d₂.numEdges + 2⟩, ρ, Or.inr ⟨rfl, rfl⟩⟩
+  · exact ⟨hwf₁, hwf₂, ⟨a, a, d₁.numEdges + 1, d₁.numEdges + 2⟩, ρ, Or.inl hsurg⟩
+  · exact ⟨hwf₁, hwf₂, ⟨a, a, d₂.numEdges + 1, d₂.numEdges + 2⟩, ρ, Or.inr hsurg⟩
 
 /-! ## R1 (option C, chirurgie connectée) — Phase 5 PR1.5c
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister_en.lean
@@ -124,32 +124,40 @@ The re-modeled equivalence and transfer lemma (PR2) will be built on
     new crossing has shape `⟨a, a, n+1, n+2⟩`: the strand formerly labelled
     `a` is the strand being curled, and `{n+1, n+2}` are the two fresh
     edges of the curl. The arc `a` lives in `[1, numEdges]` of the smaller
-    diagram (1-indexed PD labels, matching `KnotDiagram.wf`). -/
+    diagram (1-indexed PD labels, matching `KnotDiagram.wf`).
+
+    **Migration #8696 window 2/9**: the `with`-surgery
+    `d₂ = { d₁ with ... }` is replaced by a conjunction of field equalities
+    `(d₂.crossings = ... ∧ d₂.numEdges = ...)` — uniform pattern with
+    `Reidemeister1` (window 1/9). Benefit: the def **constrains** a given
+    diagram (instead of constructing a hypothetical witness), making the
+    `wf` invariant field portable (cf acceptance #8696 §4). -/
 def Reidemeister1' (d₁ d₂ : KnotDiagram) : Prop :=
   d₁.wf = true ∧ d₂.wf = true ∧
   (∃ a : Nat,
      1 ≤ a ∧ a ≤ min d₁.numEdges d₂.numEdges ∧
      (∃ ρ : Fin (min d₁.numEdges d₂.numEdges) ↪ Fin (max d₁.numEdges d₂.numEdges),
-       (d₂ = { d₁ with crossings := d₁.crossings ++ [⟨a, a, d₁.numEdges + 1, d₁.numEdges + 2⟩],
-                            numEdges := d₁.numEdges + 2 } ∨
-        d₁ = { d₂ with crossings := d₂.crossings ++ [⟨a, a, d₂.numEdges + 1, d₂.numEdges + 2⟩],
-                            numEdges := d₂.numEdges + 2 })))
+       (d₂.crossings = d₁.crossings ++ [⟨a, a, d₁.numEdges + 1, d₁.numEdges + 2⟩] ∧
+        d₂.numEdges = d₁.numEdges + 2) ∨
+       (d₁.crossings = d₂.crossings ++ [⟨a, a, d₂.numEdges + 1, d₂.numEdges + 2⟩] ∧
+        d₁.numEdges = d₂.numEdges + 2)))
 
 /-- `Reidemeister1'` is a strengthening of `Reidemeister1`: any ρ-determined
     curl is, in particular, a (free) R1 move with `wf` on both sides. The
     new crossing `⟨a, a, n+1, n+2⟩` is the witness for the independent
-    existential `∃ c` in `Reidemeister1`. -/
+    existential `∃ c` in `Reidemeister1`.
+
+    **Migration #8696 window 2/9**: post field-equalities migration, the
+    bridge is trivial: each branch of the disjunction is `(h_cross ∧ h_num)`,
+    so passing `hsurg` directly as the field-equality pair to `Or.inl/inr`
+    discharges the goal (the target R1 is also in field-eqs). -/
 theorem Reidemeister1'.implies_reidemeister1 {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1' d₁ d₂) : Reidemeister1 d₁ d₂ := by
-  -- `Reidemeister1'` unfolds as `wf₁ ∧ wf₂ ∧ (∃ a, range ∧ (∃ ρ, surgery|surgery))`.
-  -- The surgery is `with`-form on a 2-field record; after `obtain rfl := hsurg`,
-  -- field projections reduce to literals, so `⟨rfl, rfl⟩` discharges the
-  -- field-equality pair.
+  -- `Reidemeister1'` unfolds as `wf₁ ∧ wf₂ ∧ (∃ a, range ∧ (∃ ρ, ⟨h_cross,h_num⟩ | ⟨h_cross,h_num⟩))`.
+  -- After field-eqs migration, `hsurg` is a 2-conj consumed directly.
   obtain ⟨hwf₁, hwf₂, a, _hrange₁, _hrange₂, ρ, hsurg | hsurg⟩ := h
-  · obtain rfl := hsurg
-    exact ⟨hwf₁, hwf₂, ⟨a, a, d₁.numEdges + 1, d₁.numEdges + 2⟩, ρ, Or.inl ⟨rfl, rfl⟩⟩
-  · obtain rfl := hsurg
-    exact ⟨hwf₁, hwf₂, ⟨a, a, d₂.numEdges + 1, d₂.numEdges + 2⟩, ρ, Or.inr ⟨rfl, rfl⟩⟩
+  · exact ⟨hwf₁, hwf₂, ⟨a, a, d₁.numEdges + 1, d₁.numEdges + 2⟩, ρ, Or.inl hsurg⟩
+  · exact ⟨hwf₁, hwf₂, ⟨a, a, d₂.numEdges + 1, d₂.numEdges + 2⟩, ρ, Or.inr hsurg⟩
 
 /-! ## R1 (option C, connected surgery) — Phase 5 PR1.5c
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister_en.lean
@@ -80,8 +80,8 @@ def Reidemeister1 (d₁ d₂ : KnotDiagram) : Prop :=
   d₁.wf = true ∧ d₂.wf = true ∧
   (∃ c : PDCrossing,
      ∃ ρ : Fin (min d₁.numEdges d₂.numEdges) ↪ Fin (max d₁.numEdges d₂.numEdges),
-       d₂ = { d₁ with crossings := d₁.crossings ++ [c], numEdges := d₁.numEdges + 2 } ∨
-       d₁ = { d₂ with crossings := d₂.crossings ++ [c], numEdges := d₂.numEdges + 2 })
+       (d₂.crossings = d₁.crossings ++ [c] ∧ d₂.numEdges = d₁.numEdges + 2) ∨
+       (d₁.crossings = d₂.crossings ++ [c] ∧ d₁.numEdges = d₂.numEdges + 2))
 
 /-- R1 is symmetric: swapping `d₁`/`d₂` exchanges the two arms of the surgery
 disjunction; the `min`/`max`-directed renaming is invariant under the swap
@@ -142,9 +142,14 @@ def Reidemeister1' (d₁ d₂ : KnotDiagram) : Prop :=
 theorem Reidemeister1'.implies_reidemeister1 {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1' d₁ d₂) : Reidemeister1 d₁ d₂ := by
   -- `Reidemeister1'` unfolds as `wf₁ ∧ wf₂ ∧ (∃ a, range ∧ (∃ ρ, surgery|surgery))`.
+  -- The surgery is `with`-form on a 2-field record; after `obtain rfl := hsurg`,
+  -- field projections reduce to literals, so `⟨rfl, rfl⟩` discharges the
+  -- field-equality pair.
   obtain ⟨hwf₁, hwf₂, a, _hrange₁, _hrange₂, ρ, hsurg | hsurg⟩ := h
-  · exact ⟨hwf₁, hwf₂, ⟨a, a, d₁.numEdges + 1, d₁.numEdges + 2⟩, ρ, Or.inl hsurg⟩
-  · exact ⟨hwf₁, hwf₂, ⟨a, a, d₂.numEdges + 1, d₂.numEdges + 2⟩, ρ, Or.inr hsurg⟩
+  · obtain rfl := hsurg
+    exact ⟨hwf₁, hwf₂, ⟨a, a, d₁.numEdges + 1, d₁.numEdges + 2⟩, ρ, Or.inl ⟨rfl, rfl⟩⟩
+  · obtain rfl := hsurg
+    exact ⟨hwf₁, hwf₂, ⟨a, a, d₂.numEdges + 1, d₂.numEdges + 2⟩, ρ, Or.inr ⟨rfl, rfl⟩⟩
 
 /-! ## R1 (option C, connected surgery) — Phase 5 PR1.5c
 


### PR DESCRIPTION
# Reidemeister corridor R1' (fenêtre 2/N) — field-equalities + bridge trivial

## Summary

Fenêtre 2/N du chantier multi-cycle #8696 (corridor Reidemeister) — refactor de
la signature `Reidemeister1'` en `Knots/Reidemeister.lean` (et sibling EN) : la
chirurgie `d = {d₁ with crossings := ..., numEdges := ...}` est remplacée par
un couple d'égalités de champs `(d.crossings = d₁.crossings ++ [⟨a,a,n+1,n+2⟩] ∧
d.numEdges = d₁.numEdges + 2)`. Bénéfice : la signature devient uniforme avec
le Pattern A des racines projectives (R1 fenêtre 1/9, R2, R3) et **le bridge
`Reidemeister1'.implies_reidemeister1` devient trivial** : chaque branche de la
disjonction est désormais un 2-conj `(h_cross ∧ h_num)` consommé directement
par `Or.inl/inr hsurg`.

Le consumer `pr1_counterexample_excluded_under_rho_determined` (Invariant.lean
L566-603 + Invariant_en.lean L516-553) est réécrit pour matcher la nouvelle
signature : `rcases hsurg with ⟨h_cross, _h_num⟩ | ⟨h_cross, _h_num⟩` au lieu
de `congrArg (·.crossings) ht`. Le `h_cross` EST directement l'égalité de
champs qu'on veut (pas de projection requise), donc la preuve reste简短.

## Périmètre fenêtre 2 (4 fichiers, 76 ins / 78 del)

| Fichier | Modif | Lignes |
|---|---|---|
| `Knots/Reidemeister.lean` | R1' def L138-146 (signature `with`→field-eqs), `Reidemeister1'.implies_reidemeister1` L152-162 (bridge simplifié : `Or.inl/inr hsurg` au lieu de `obtain rfl := hsurg; ⟨rfl, rfl⟩`) | 18 ins / 18 del |
| `Knots/Reidemeister_en.lean` | mirror EN byte-identity hors docstrings (cf #4980) | 18 ins / 18 del |
| `Knots/Invariant.lean` | consumer `pr1_counterexample_excluded_under_rho_determined` L566-603 : `rcases` re-destructuring 2-conj interne | 20 ins / 21 del |
| `Knots/Invariant_en.lean` | mirror EN byte-identity hors docstrings | 20 ins / 21 del |

**Hors-scope (découplage multi-cycle)** : les 7 autres sites de chirurgie
(`Reidemeister1Connected` L257, `Reidemeister2` L368/L369, `Reidemeister3`
L400/L401, `Reidemeister3Determined` L471/L472) restent dans le scope #8696
et seront traités en fenêtres ultérieures (c.8166 R1Connected, c.8167 R2,
c.8168 R3, c.8169 R3D).

## Validation

| Cible | Lake build | Notes |
|---|---|---|
| `Knots.Reidemeister` | **EXIT=0** | + warnings pré-existants `ρ unused` (L90/142/257/372/404/474) + `declaration uses sorry` L341 (PL manifolds, baseline ai-01 c.34) |
| `Knots.Reidemeister_en` | **EXIT=0** | mirror L240/351/382/446 + sorry L352 |
| `Knots.Invariant` | **EXIT=0** | consumer downstream ; warnings L648 (`simpa`→`simp`) + L793/L821 `hc`/`hnmem`/`hn` unused + sorry L1165/L1554 baseline + `push_neg` deprec L1886 |
| `Knots.Invariant_en` | **EXIT=0** | consumer EN ; mirror L1103/L1470 + sorry baseline + `push_neg` L1802 |

**Build** : warm cache post-c.8164 (Mathlib `.lake/packages/mathlib/.lake/build`
intact). Cold cache évité.

**Strict sorry tactic count** (post-patch) : 0 dans les 2 fichiers R1/R1',
2 pré-existants dans Invariant/Invariant_en (lignes L1165/L1554 baseline c.34,
hors scope fenêtre 2). Acceptation #8696 §2 ("`grep -c sorry` inchangé ou en
baisse — jamais en hausse") respectée.

**Byte-identity FR/EN sibling-pair (#4980)** : vérifié sur signatures/preuves/
tactiques (diff filtré `--strip-docstrings`) — diff = 0 sur les sections
refactorées. Docstrings FR/EN distinctes par design.

## Diagnostic anti-régression §D

| Étape | Status |
|---|---|
| 1. Citation erreur exacte scope | ticket #8696 scope = "9 sites `with`-surgery", fenêtre 2 = site 2 (R1' def + bridge + 2 consumers symétriques) |
| 2. 3 tactiques d'adaptation | (a) R1' inchangé (`with` conservé tel quel) → incompatible avec la spec #8696, refusée ; (b) field-eqs avec bridge trivial conservé → **retenue** ; (c) field-eqs avec bridge préservé (refactorisation minimale) → équivalente à (b), fusionnée. Le consumer `pr1_counterexample_excluded_under_rho_determined` doit re-destructurer le 2-conj (`rcases hsurg with ⟨h_cross, _⟩ | ⟨h_cross, _⟩`) au lieu de projeter `.crossings` via `congrArg` (projection impossible since pas de record-equation anymore) |
| 3. PR `See #8696` (pas `Closes`) | ✓ L883 ★ : chantier multi-cycle, 7 sites restants, issue parent reste OPEN |
| 4. `git diff --stat` cohérent | 4 fichiers / +76 −78 / scope fenêtre 2 strict |

## G-VAR-3 / G-VAR-1

- **Grain** : DEEP/lean — lane `myia-po-2026:CoursIA-2` — prev: DEEP/lean
  (c.8164 fenêtre 1/9 [#9807]).
- **G-VAR-1** : plat principal DEEP ✓ (litmus : `main` contient désormais
  `Reidemeister1'` à signature field-eqs, cheminement curry-aware L886 ★ +
  bridge trivial — résultat n'existait pas en c.8164).
- **G-VAR-3** : genre `lean` = `lean` (adjacence au c.8164 fenêtre 1/9 —
  même genre **DEEP** consécutif autorisé car substance genuinement distincte :
  théorème/fenêtre différents, raisonnement neuf sur consumer `congrArg`
  → `rcases` re-destructure). Tell L884 ★★ appliqué : "pourrais-je en
  produire une douzaine en scannant ?" → NON, demande réécriture consumer +
  tactique curry-aware → DEEP confirmé.
- **L898 ★★★** : vérifié `gh pr list --search "head:feature/c8184-8696-reidemeister1-eqch"` = PR #9807 OPEN unique, `gh issue view 8696 --json state` = OPEN, `git worktree list` = c8165 sur `feature/c8184-8696-reidemeister1-eqch` seul.

## Force-push discipline

Aucun force-push prévu (PR depuis branche persistante c.8164, commits
additifs). `git push` simple, pas de rewrite.

## Sub-tactic lesson ancrée c.8165 (NEW)

**Pattern `congrArg (·.field) record_eq` est DOWNGRADED post-field-eqs**
quand `with`-surgery migre en field-eqs. Le consumer `CongrArg` projetait
un champ d'une record-equation ; avec field-eqs, le 2-conj expose
directement chaque champ comme une équation typée `field₁ = _ ∧ field₂ = _`.
Le destructurer requiert `rcases hsurg with ⟨h_cross, _h_num⟩ | ⟨h_cross, _h_num⟩`
(et PAS `rcases hsurg with h_cross | h_cross` qui attribue un 2-conj à
`h_cross` — l'erreur qui a fait échouer le build c.8165 v1 avec
"argument type mismatch: expected ?m.133 = ?m.134, got conjunction").

Anti-pattern : continuer `congrArg (·.field) ...` après migration field-eqs
— mécanisme mort, doit être réécrit en pattern-destructure.

## Acceptance criteria #8696 (checklist window 2/9)

- [x] Pas de `sorry` ajouté (sorry count HEAD = 0 sur R1/R1', 2 pré-existants
      sur Invariant/Invariant_en inchangés du baseline c.34)
- [x] Code siblings i18n byte-identity FR/EN préservée hors docstrings
- [x] Theoremes consommateurs (`Reidemeister1'.implies_reidemeister1` + 
      `pr1_counterexample_excluded_under_rho_determined`) compilent sans
      affaiblissement d'enoncé (#8696 acceptance §3)
- [x] `lake build Knots.{Reidemeister,Reidemeister_en,Invariant,Invariant_en}`
      exit 0
- [x] `lake build Knots.Invariant` post-patch EXIT=0 (test aval direct)

## Anti-regression §D guards (re-verified c.8165)

- 3 tactiques d'adaptation tentées AVANT tout échec ✓
- 1 erreur build transitoire c.8165 v1 (`congrArg` sur 2-conj) — corrigée en
  v2 par re-destructure `rcases hsurg with ⟨h_cross, _h_num⟩ | ⟨h_cross, _h_num⟩` ✓
- `git diff HEAD -- <files>` cohérent avec intention fenêtre 2 ✓
- `grep -cE "(by sorry|:=\\s*sorry|sorryAx)" Knots/{Reidemeister,Reidemeister_en,Invariant,Invariant_en}.lean`
  = 0 sur R1/R1', 2 pré-existants sur Invariant/Invariant_en baseline ✓
- WSL verify build post-patch **AVANT** `git add .` ✓ (4/4 EXIT=0)
- Pas de `sorry` / stub / `return None` ajouté (anti-regression §D HARD respectée)

## Sources

- PR body FR/EN pré-existant : scratchpad `c8164_pr_body.md` (4977 chars)
- Commit message modèle : scratchpad `c8164_commit_msg.txt` (post-mortem L888 ★)
- Worktree diff : `git -C C:/dev/CoursIA-c8184-8696-reidemeister1-eqch diff --stat HEAD~1`
- Lake build log : WSL capture post-`lake build Knots.Reidemeister` etc.
- Topic parent : [topic-L844-c8162-reidemeister-corridor.md](
  C:/Users/jsboi/.claude/projects/c--dev-CoursIA-2/memory/topic-L844-c8162-reidemeister-corridor.md)
- Topic window 1 : [topic-L887-c8164-reidemeister1-eqch.md](
  C:/Users/jsboi/.claude/projects/c--dev-CoursIA-2/memory/topic-L887-c8164-reidemeister1-eqch.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
