### PR TITLE
feat(ci,#9819): single requerrable PR gate — no check is required on main today

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,77 @@
+name: PR gate
+
+# The single check that can be made *required* on `main` without deadlocking
+# the repository. See issue #9819 and the module docstring of scripts/pr_gate.py.
+#
+# Background, measured firsthand 2026-08-07:
+#
+#   gh api repos/jsboige/CoursIA/branches/main/protection  -> no required_status_checks
+#   gh api repos/jsboige/CoursIA/rulesets                  -> []
+#
+# Nothing is required. A PR with a red build reports `UNSTABLE` (mergeable),
+# never `BLOCKED`, so the only gate is a human reading `gh pr checks` at ~180
+# merges/day. That failed on 2026-08-07: #9762 merged with
+# `ci / Lean CI (grothendieck_lean) -> fail`, and `main` stayed red ~5 hours.
+#
+# Why not simply require the Lean check instead: GitHub counts a check that
+# never started as **pending forever** -- a workflow skipped by its `paths:`
+# filter never reports `skipped`. Requiring any path-filtered check would make
+# every PR that does not touch that path permanently unmergeable. This workflow
+# has NO `paths:` filter for exactly that reason: it must reach a verdict on
+# every PR, including PRs that trigger no other CI at all.
+#
+# Enabling it is a repository-settings change and therefore owner-only:
+#   Settings > Branches > main > Require status checks > add "PR gate"
+# Until that flip, this job is informative rather than blocking -- which is
+# precisely the half that does not need the owner, delivered so the flip is a
+# one-click action instead of a design problem.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Head SHA to aggregate (defaults to the current ref)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  checks: read
+  statuses: read
+
+concurrency:
+  group: pr-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    # This string is the required-check name. Keep it stable: renaming it
+    # silently detaches the branch-protection rule, leaving a rule that
+    # references a check nobody produces -- pending forever, the very deadlock
+    # this workflow exists to avoid.
+    name: PR gate
+    runs-on: ubuntu-latest
+    # Above the script's own 90 min budget, so the script prints its verdict
+    # instead of the runner killing it mid-poll (a runner-killed job reports
+    # `cancelled`, which is far less legible than "timed out waiting for X").
+    timeout-minutes: 100
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Aggregate check verdicts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/pr_gate.py \
+            --repo "${{ github.repository }}" \
+            --sha "${{ github.event.pull_request.head.sha || github.sha }}" \
+            --self-name "PR gate" \
+            --timeout-min 90 \
+            --poll-sec 30 \
+            --settle-polls 2

--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""pr_gate.py -- the single requerrable check for `main` (issue #9819).
+
+## Why this exists
+
+`main` has NO required status check. Measured firsthand 2026-08-07:
+
+    gh api repos/jsboige/CoursIA/branches/main/protection   -> no required_status_checks
+    gh api repos/jsboige/CoursIA/rulesets                   -> []
+
+So a PR whose CI is red reports `UNSTABLE` (mergeable), never `BLOCKED`. The
+only thing standing between a red build and `main` is a human reading
+`gh pr checks` at ~180 merges/day. On 2026-08-07 that failed: #9762 was merged
+with `ci / Lean CI (grothendieck_lean) -> fail` AND a body that declared its own
+build gate as still running. `main` stayed red for ~5 hours.
+
+## Why the obvious fix does not work
+
+"Just mark `Lean CI (grothendieck_lean)` as required" DEADLOCKS the repository.
+GitHub counts a check that never started as **pending, forever** -- there is no
+`skipped` state for a workflow whose `paths:` filter did not match. Requiring a
+path-filtered check makes every PR that does not touch that path unmergeable.
+
+The only object that can be required without that trap is a check that runs on
+**every** PR and always reaches a verdict. That is this one.
+
+## What it does
+
+Waits for every other check on the head SHA to settle, then fails if any of
+them failed. One name to require; it covers whatever CI happens to exist,
+now and later, with no per-workflow wiring to maintain.
+
+## Design rules that matter
+
+1. **Bias to fail.** Timeout, API error, or a check with no verdict => exit 1.
+   A gate that passes when it does not know is not a gate. This is deliberate
+   and is the single most important property of the file.
+2. **Latest run per workflow wins.** GitHub's concurrency groups cancel
+   superseded runs, and re-runs leave the old attempt visible. Without
+   de-duplication, one benign `cancelled` from a superseded run would block a
+   perfectly good PR (observed on `main`: `Quarto Pages Deploy` cancelled on
+   401a68cd8 while the same SHA was otherwise green). We keep only the newest
+   run per workflow name and judge that one.
+3. **`cancelled` on the newest run fails.** After de-duplication, a cancelled
+   run means no verdict was produced. Per rule 1 that is a failure, not a pass.
+4. **Self-exclusion.** The gate never waits for itself.
+5. **Legacy commit statuses count too.** Some integrations post statuses, not
+   check runs; both are unioned.
+
+Exit codes: 0 = every settled check is non-failing (or there are none).
+            1 = at least one failure, or the state could not be established.
+
+Run locally against any PR head:
+
+    python scripts/pr_gate.py --repo jsboige/CoursIA --sha <head-sha> --timeout-min 1
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from typing import Iterable, Sequence
+
+# A check that reached one of these has produced a verdict we accept.
+CONCLUSION_OK = frozenset({"success", "neutral", "skipped"})
+
+# A check that reached one of these has produced a verdict we reject.
+# `cancelled` is here on purpose (see rule 3 in the module docstring): after
+# de-duplication it can no longer mean "superseded", only "no verdict".
+CONCLUSION_BAD = frozenset(
+    {"failure", "timed_out", "cancelled", "action_required", "stale", "startup_failure"}
+)
+
+# GitHub check_run.status values that mean "not finished".
+STATUS_PENDING = frozenset({"queued", "in_progress", "waiting", "pending", "requested"})
+
+DEFAULT_SELF_NAME = "PR gate"
+
+
+class GateError(RuntimeError):
+    """Raised when the check state cannot be established. Always fatal."""
+
+
+# --- pure decision layer (no network; this is what the unit tests pin) -------
+
+
+def dedupe_latest(checks: Sequence[dict]) -> list[dict]:
+    """Keep only the most recent entry per check name.
+
+    GitHub leaves superseded and re-run attempts visible on the same SHA. Judging
+    all of them makes a benign concurrency cancellation indistinguishable from a
+    real failure. Ordering key is `started_at` then `id`, both monotonic per name;
+    entries missing both keep their input order as a last resort.
+    """
+    best: dict[str, tuple[tuple, dict]] = {}
+    for index, check in enumerate(checks):
+        name = check.get("name") or ""
+        key = (check.get("started_at") or "", check.get("id") or 0, index)
+        current = best.get(name)
+        if current is None or key >= current[0]:
+            best[name] = (key, check)
+    return [entry[1] for entry in best.values()]
+
+
+def classify(
+    checks: Sequence[dict], self_name: str = DEFAULT_SELF_NAME
+) -> tuple[list[str], list[str], list[str]]:
+    """Split settled checks into (pending, bad, ok) name lists.
+
+    `self_name` is excluded so the gate never waits on itself. Matching is a
+    prefix test because GitHub renders a job inside a workflow as
+    "<workflow> / <job>", and the gate is required under its workflow name.
+    """
+    pending: list[str] = []
+    bad: list[str] = []
+    ok: list[str] = []
+
+    for check in dedupe_latest(checks):
+        name = check.get("name") or "<unnamed>"
+        if name == self_name or name.startswith(f"{self_name} /"):
+            continue
+
+        status = (check.get("status") or "").lower()
+        conclusion = (check.get("conclusion") or "").lower()
+
+        if status in STATUS_PENDING or not conclusion:
+            pending.append(name)
+        elif conclusion in CONCLUSION_OK:
+            ok.append(name)
+        elif conclusion in CONCLUSION_BAD:
+            bad.append(name)
+        else:
+            # Unknown conclusion: bias to fail (rule 1). A conclusion GitHub
+            # adds later must not silently become a pass.
+            bad.append(f"{name} (unknown conclusion '{conclusion}')")
+
+    return sorted(pending), sorted(bad), sorted(ok)
+
+
+def verdict(pending: Sequence[str], bad: Sequence[str], settled: bool) -> tuple[int, str]:
+    """Final decision. Returns (exit_code, human message).
+
+    `settled` is False when the wait loop ran out of time. Unsettled is a
+    failure even with zero bad checks: we do not know, therefore we refuse.
+    """
+    if bad:
+        return 1, "FAIL -- failing checks: " + ", ".join(bad)
+    if not settled:
+        listed = ", ".join(pending) if pending else "(none listed)"
+        return 1, f"FAIL -- timed out waiting for: {listed}"
+    if pending:
+        return 1, "FAIL -- still pending at settle time: " + ", ".join(pending)
+    return 0, "PASS -- no failing checks"
+
+
+# --- network layer ----------------------------------------------------------
+
+
+def _gh_api(path: str) -> object:
+    """Call `gh api <path>` and parse JSON. Any failure is fatal (rule 1)."""
+    try:
+        completed = subprocess.run(
+            ["gh", "api", path],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - environment problem
+        raise GateError(f"gh CLI not available: {exc}") from exc
+
+    if completed.returncode != 0:
+        raise GateError(
+            f"gh api {path} failed (exit {completed.returncode}): "
+            f"{completed.stderr.strip()[:400]}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise GateError(f"gh api {path} returned non-JSON: {exc}") from exc
+
+
+def fetch_checks(repo: str, sha: str) -> list[dict]:
+    """Union of check runs and legacy commit statuses for one SHA."""
+    checks: list[dict] = []
+
+    runs = _gh_api(f"repos/{repo}/commits/{sha}/check-runs?per_page=100")
+    if isinstance(runs, dict):
+        for run in runs.get("check_runs", []):
+            checks.append(
+                {
+                    "name": run.get("name"),
+                    "status": run.get("status"),
+                    "conclusion": run.get("conclusion"),
+                    "started_at": run.get("started_at"),
+                    "id": run.get("id"),
+                }
+            )
+
+    combined = _gh_api(f"repos/{repo}/commits/{sha}/status")
+    if isinstance(combined, dict):
+        for status in combined.get("statuses", []):
+            state = (status.get("state") or "").lower()
+            checks.append(
+                {
+                    "name": status.get("context"),
+                    "status": "in_progress" if state == "pending" else "completed",
+                    "conclusion": {
+                        "success": "success",
+                        "failure": "failure",
+                        "error": "failure",
+                    }.get(state, "" if state == "pending" else state),
+                    "started_at": status.get("created_at"),
+                    "id": status.get("id"),
+                }
+            )
+
+    return checks
+
+
+def wait_and_decide(
+    repo: str,
+    sha: str,
+    self_name: str,
+    timeout_min: float,
+    poll_sec: float,
+    settle_polls: int,
+    sleep=time.sleep,
+    fetch=fetch_checks,
+    now=time.monotonic,
+) -> tuple[int, str]:
+    """Poll until the check set is stable, then decide.
+
+    Stability is `settle_polls` consecutive polls with nothing pending -- a
+    single quiet poll is not enough, because a workflow queued milliseconds ago
+    has not surfaced yet and would be invisible.
+    """
+    deadline = now() + timeout_min * 60.0
+    quiet_streak = 0
+    pending: list[str] = []
+    bad: list[str] = []
+
+    while True:
+        checks = fetch(repo, sha)
+        pending, bad, ok = classify(checks, self_name)
+
+        if bad:
+            # Fail fast: a failure cannot be undone by waiting longer.
+            return verdict(pending, bad, settled=True)
+
+        if pending:
+            quiet_streak = 0
+        else:
+            quiet_streak += 1
+            if quiet_streak >= settle_polls:
+                print(f"[pr-gate] settled: {len(ok)} check(s) green", flush=True)
+                return verdict(pending, bad, settled=True)
+
+        if now() >= deadline:
+            return verdict(pending, bad, settled=False)
+
+        print(
+            f"[pr-gate] waiting on {len(pending)} check(s): "
+            f"{', '.join(pending[:6])}{' ...' if len(pending) > 6 else ''}",
+            flush=True,
+        )
+        sleep(poll_sec)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument("--sha", required=True, help="head SHA of the PR")
+    parser.add_argument("--self-name", default=DEFAULT_SELF_NAME)
+    parser.add_argument("--timeout-min", type=float, default=90.0)
+    parser.add_argument("--poll-sec", type=float, default=30.0)
+    parser.add_argument("--settle-polls", type=int, default=2)
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    try:
+        code, message = wait_and_decide(
+            args.repo,
+            args.sha,
+            args.self_name,
+            args.timeout_min,
+            args.poll_sec,
+            args.settle_polls,
+        )
+    except GateError as exc:
+        # Rule 1: an unreadable state is a failure, never a pass.
+        print(f"[pr-gate] FAIL -- cannot establish check state: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"[pr-gate] {message}", flush=True)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Unit tests for pr_gate.py -- the single requerrable check of #9819.
+
+What these pin, in order of how much damage getting them wrong would do:
+
+1. **Bias to fail.** Timeout, unreadable API, or an unrecognised conclusion must
+   exit 1. A gate that passes when it does not know is not a gate, and this is
+   the property the whole file exists to guarantee.
+2. **De-duplication by check name.** GitHub's concurrency groups cancel
+   superseded runs and leave them visible on the SHA. Observed on `main`:
+   `Quarto Pages Deploy` cancelled on 401a68cd8 while that same SHA was
+   otherwise fully green. Without de-duplication the gate would have blocked a
+   healthy commit -- and a gate that cries wolf gets disabled, which is worse
+   than not having one.
+3. **Self-exclusion**, or the gate waits for itself until timeout, i.e. blocks
+   100% of PRs.
+
+Run: python -m pytest scripts/tests/test_pr_gate.py
+"""
+import itertools
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pr_gate  # noqa: E402
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+def run(name, conclusion, status="completed", started_at="2026-08-07T00:00:00Z", rid=1):
+    return {
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "started_at": started_at,
+        "id": rid,
+    }
+
+
+def decide(checks, self_name=pr_gate.DEFAULT_SELF_NAME, settled=True):
+    pending, bad, _ok = pr_gate.classify(checks, self_name)
+    return pr_gate.verdict(pending, bad, settled=settled)
+
+
+# --- 1. bias to fail ---------------------------------------------------------
+
+
+def test_timeout_is_a_failure_even_with_zero_bad_checks():
+    """Unsettled means we do not know. Refusing is the whole point."""
+    code, msg = pr_gate.verdict(pending=["Lean CI"], bad=[], settled=False)
+    assert code == 1
+    assert "timed out" in msg
+    assert "Lean CI" in msg
+
+
+def test_unknown_conclusion_counts_as_failure():
+    """A conclusion GitHub adds later must not silently become a pass."""
+    code, msg = decide([run("Future CI", "quantum_superposition")])
+    assert code == 1
+    assert "Future CI" in msg
+
+
+def test_unreadable_api_exits_one(monkeypatch):
+    def boom(*_args, **_kwargs):
+        raise pr_gate.GateError("gh api exploded")
+
+    monkeypatch.setattr(pr_gate, "wait_and_decide", boom)
+    assert pr_gate.main(["--repo", "o/r", "--sha", "deadbeef"]) == 1
+
+
+def test_completed_without_conclusion_is_pending_not_pass():
+    """`status=completed, conclusion=null` is a transient GitHub state."""
+    pending, bad, ok = pr_gate.classify([run("Odd", None)])
+    assert pending == ["Odd"] and not bad and not ok
+
+
+# --- 2. de-duplication by check name ----------------------------------------
+
+
+def test_superseded_cancelled_run_does_not_block_a_green_sha():
+    """The 401a68cd8 case: cancelled by concurrency, then re-run green."""
+    checks = [
+        run("Quarto Pages Deploy", "cancelled", started_at="2026-08-07T05:25:00Z", rid=1),
+        run("Quarto Pages Deploy", "success", started_at="2026-08-07T05:26:00Z", rid=2),
+    ]
+    code, msg = decide(checks)
+    assert code == 0, msg
+
+
+def test_input_order_does_not_change_the_verdict():
+    """The API does not promise ordering; the timestamp must decide, not luck."""
+    newest = run("Build", "success", started_at="2026-08-07T05:26:00Z", rid=2)
+    oldest = run("Build", "cancelled", started_at="2026-08-07T05:25:00Z", rid=1)
+    assert decide([newest, oldest])[0] == 0
+    assert decide([oldest, newest])[0] == 0
+
+
+def test_cancelled_on_the_newest_run_still_fails():
+    """After de-duplication, cancelled can only mean 'no verdict' -- rule 1."""
+    checks = [
+        run("Build", "success", started_at="2026-08-07T05:25:00Z", rid=1),
+        run("Build", "cancelled", started_at="2026-08-07T05:26:00Z", rid=2),
+    ]
+    code, msg = decide(checks)
+    assert code == 1
+    assert "Build" in msg
+
+
+def test_distinct_names_are_never_merged():
+    checks = [run("A", "success", rid=1), run("B", "failure", rid=2)]
+    code, msg = decide(checks)
+    assert code == 1 and "B" in msg and "A" not in msg.split("failing checks: ")[1]
+
+
+# --- 3. self-exclusion -------------------------------------------------------
+
+
+def test_gate_does_not_wait_for_itself():
+    checks = [run("PR gate", None, status="in_progress"), run("Lean CI", "success")]
+    pending, bad, ok = pr_gate.classify(checks, "PR gate")
+    assert pending == [] and bad == [] and ok == ["Lean CI"]
+
+
+def test_self_exclusion_matches_workflow_slash_job_rendering():
+    checks = [run("PR gate / gate", None, status="queued")]
+    pending, _bad, _ok = pr_gate.classify(checks, "PR gate")
+    assert pending == []
+
+
+def test_self_exclusion_is_not_a_loose_prefix():
+    """"PR gateway" is a different check and must still be judged."""
+    checks = [run("PR gateway", "failure")]
+    _pending, bad, _ok = pr_gate.classify(checks, "PR gate")
+    assert bad == ["PR gateway"]
+
+
+# --- decision table ----------------------------------------------------------
+
+
+def test_no_checks_at_all_passes():
+    """A PR that triggers no other CI has nothing to gate."""
+    assert decide([])[0] == 0
+
+
+def test_skipped_and_neutral_are_green():
+    checks = [run("A", "skipped", rid=1), run("B", "neutral", rid=2)]
+    assert decide(checks)[0] == 0
+
+
+def test_failure_is_reported_by_name():
+    code, msg = decide([run("ci / Lean CI (grothendieck_lean)", "failure")])
+    assert code == 1
+    assert "ci / Lean CI (grothendieck_lean)" in msg
+
+
+def test_the_9762_shape_fails():
+    """Exactly what was merged on 2026-08-07 and made `main` red for ~5 h."""
+    checks = [
+        run("ci / Lean CI (grothendieck_lean)", "failure", rid=1),
+        run("proof-integrity / Proof integrity (grothendieck_lean)", "failure", rid=2),
+        run("Secret Scan", "success", rid=3),
+        run("banner-guard", "success", rid=4),
+    ]
+    code, msg = decide(checks)
+    assert code == 1
+    assert "Lean CI" in msg and "Proof integrity" in msg
+
+
+# --- wait loop ---------------------------------------------------------------
+
+
+def _clock(step=10):
+    counter = itertools.count(0, step)
+    return lambda: next(counter)
+
+
+def test_settle_requires_two_consecutive_quiet_polls():
+    """One quiet poll is not enough: a just-queued workflow has not surfaced."""
+    polls = []
+
+    def fetch(_repo, _sha):
+        polls.append(1)
+        # Quiet, then a late arrival, then quiet twice.
+        return {1: [], 2: [run("Late", None, status="queued")], 3: [], 4: []}[len(polls)]
+
+    code, msg = pr_gate.wait_and_decide(
+        "o/r", "sha", "PR gate", timeout_min=10, poll_sec=0,
+        settle_polls=2, sleep=lambda _s: None, fetch=fetch, now=_clock(),
+    )
+    assert code == 0, msg
+    assert len(polls) == 4, "the late arrival must reset the streak"
+
+
+def test_wait_loop_fails_fast_on_a_failure():
+    """Waiting cannot un-fail a check; do not burn 90 minutes to learn that."""
+    polls = []
+
+    def fetch(_repo, _sha):
+        polls.append(1)
+        return [run("Lean CI", "failure")]
+
+    code, msg = pr_gate.wait_and_decide(
+        "o/r", "sha", "PR gate", timeout_min=90, poll_sec=0,
+        settle_polls=2, sleep=lambda _s: None, fetch=fetch, now=_clock(),
+    )
+    assert code == 1 and "Lean CI" in msg
+    assert len(polls) == 1
+
+
+def test_wait_loop_times_out_into_a_failure():
+    def fetch(_repo, _sha):
+        return [run("Slow CI", None, status="in_progress")]
+
+    code, msg = pr_gate.wait_and_decide(
+        "o/r", "sha", "PR gate", timeout_min=0, poll_sec=0,
+        settle_polls=2, sleep=lambda _s: None, fetch=fetch, now=_clock(),
+    )
+    assert code == 1
+    assert "timed out" in msg and "Slow CI" in msg
+
+
+# --- legacy commit statuses --------------------------------------------------
+
+
+def test_legacy_status_error_maps_to_failure():
+    """Some integrations post `error`, which has no check-run equivalent."""
+    checks = [
+        {"name": "legacy/lint", "status": "completed", "conclusion": "failure",
+         "started_at": "2026-08-07T00:00:00Z", "id": 9},
+    ]
+    assert decide(checks)[0] == 1
+
+
+def test_pending_legacy_status_blocks_settling():
+    checks = [
+        {"name": "legacy/lint", "status": "in_progress", "conclusion": "",
+         "started_at": "2026-08-07T00:00:00Z", "id": 9},
+    ]
+    pending, _bad, _ok = pr_gate.classify(checks)
+    assert pending == ["legacy/lint"]


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: DEEP/lean #9798

## Le trou : rien n'est requis sur `main`, et ça vient de coûter 5 heures

Mesuré firsthand ce matin, après avoir cherché ce que j'avais mal lu :

```
$ gh api repos/jsboige/CoursIA/branches/main/protection
   -> aucun bloc "required_status_checks"
$ gh api repos/jsboige/CoursIA/rulesets
[]
```

**Aucun check n'est requis.** Une PR aux checks rouges affiche donc `UNSTABLE` — fusionnable — et **jamais** `BLOCKED`. Le seul gate CI réel est un humain qui lit `gh pr checks`, à ~180 merges/jour.

Il a cédé le 2026-08-07 : j'ai mergé **#9762** avec `ci / Lean CI (grothendieck_lean) -> fail` **et** un corps de PR qui déclarait lui-même son gate §B.2 comme non satisfait (« Build running in background… Log will be pasted here on completion »). `main` est resté rouge de **00:22 à 05:21Z**, réparé par #9818.

Ce n'était pas un défaut de raisonnement : le gate était **écrit comme pendant**, il suffisait de le lire. C'est exactement le cas où ajouter de la vigilance ne répare rien — il faut un organe.

## Pourquoi la solution évidente est un piège

« Il suffit de rendre `Lean CI (grothendieck_lean)` requis » **dead-locke le dépôt**.

GitHub compte un check qui n'a jamais démarré comme **`pending`, indéfiniment**. Un workflow écarté par son filtre `paths:` ne rapporte **jamais** `skipped` — il ne rapporte rien du tout. Rendre requis un check path-filtré rend donc **non-mergeable toute PR qui ne touche pas ce chemin**. Le remède naïf est pire que le mal, et c'est la raison pour laquelle #9819 dit que le remède n'est pas trivial.

Le seul objet requerrable sans ce piège est un check qui **tourne sur toute PR** et **atteint toujours un verdict**. C'est celui-ci.

## Ce que ça fait

`.github/workflows/pr-gate.yml` — **sans aucun filtre `paths:`**, délibérément — attend que tous les autres checks du SHA de tête se stabilisent, puis échoue si l'un d'eux a échoué. Un seul nom à rendre requis, qui couvre la CI telle qu'elle est *et telle qu'elle deviendra*, sans câblage par workflow à maintenir.

## Les quatre règles qui font la différence entre un gate et une décoration

**1. Biais à l'échec.** Timeout, erreur d'API, ou conclusion non reconnue ⇒ exit 1. Un gate qui passe quand il ne sait pas n'est pas un gate. C'est la propriété la plus importante du fichier, et trois tests la couvrent — dont une conclusion inventée (`quantum_superposition`) pour vérifier qu'une valeur que GitHub ajouterait demain ne devienne pas un succès silencieux.

**2. Déduplication par nom de check — le dernier run gagne.** Sans elle, le gate serait un crieur au loup. Cas réel sur `main` : `Quarto Pages Deploy` **cancelled** sur `401a68cd8` (annulation par groupe de concurrence) alors que le même SHA était par ailleurs vert. Un gate qui bloque un commit sain se fait désactiver — c'est pire que pas de gate du tout. On ne juge donc que le run le plus récent par nom.

**3. `cancelled` sur le run le plus récent échoue.** Après déduplication, `cancelled` ne peut plus vouloir dire « supplanté » : il veut dire « aucun verdict produit ». Règle 1 ⇒ échec.

**4. Auto-exclusion.** Sans elle, le gate s'attend lui-même jusqu'au timeout et bloque **100 %** des PRs. Le test `test_self_exclusion_is_not_a_loose_prefix` vérifie au passage qu'un hypothétique check `PR gateway` reste bien jugé — l'exclusion est un préfixe `"PR gate / "`, pas un `startswith` lâche.

Les statuts de commit hérités (postés par des intégrations, pas des check runs) sont unionés aux check runs : sinon un lint externe rouge serait invisible.

## Preuve — la contre-épreuve dans les deux directions

C'est celle que j'exige des workers ; elle vaut d'abord pour moi. Un détecteur qui ne rougit sur aucun cas connu ne détecte rien.

**Sens positif (le gate laisse passer ce qui est sain)** — PR #9801, ouverte, CI propre :

```
$ python scripts/pr_gate.py --repo jsboige/CoursIA --sha 2be606d1a00b6c6f1a85a5987da2887ed6dffe8e ...
[pr-gate] settled: 15 check(s) green
[pr-gate] PASS -- no failing checks
LIVE_EXIT=0
```

**Sens négatif (le gate attrape exactement ce qui est passé)** — le SHA de tête de **#9762**, c'est-à-dire l'état que j'avais sous les yeux au moment de merger :

```
$ python scripts/pr_gate.py --repo jsboige/CoursIA --sha 27dbd7fb440de3a00e65d0cb8826085b9b1e58a5 ...
[pr-gate] FAIL -- failing checks: ci / Lean CI (grothendieck_lean), proof-integrity / Proof integrity (grothendieck_lean)
EXIT_9762=1
```

Et sur le commit de merge qui a rougi `main` (`8aa92d338`), il ajoute quatre `Analyze (*)` CodeQL également rouges que je n'avais pas vus non plus.

**Tests unitaires — 20/20**, code de sortie lu **sans pipe** (un `| tail` rapporterait le statut de `tail`, toujours 0) :

```
$ python -m pytest scripts/tests/test_pr_gate.py -q > /tmp/prgate_tests.log 2>&1; echo "PYTEST_EXIT=$?"
PYTEST_EXIT=0
20 passed in 0.08s
```

Dont `test_the_9762_shape_fails`, qui rejoue la forme exacte du rollup de ce matin.

## Ce que cette PR ne fait PAS

**Elle ne rend rien bloquant.** Activer le check est un réglage de dépôt (`Settings > Branches > main > Require status checks > "PR gate"`), **owner-only** — hors de portée de tout workflow, comme `can_approve_pull_request_reviews` l'était. Cette PR livre la **moitié qui ne dépend pas du propriétaire**, pour que le flip soit un clic plutôt qu'un problème de conception.

D'ici là le job est informatif. Ce n'est pas un guard advisory déguisé : il **rougit** pour de bon, il n'est simplement pas encore câblé en bloquant. La différence est réelle — un advisory sort 0 par construction et son signal est le label ; celui-ci sort 1 et son signal est le code.

**Elle ne touche aucun workflow existant.** L'alternative — retirer `paths:` de chacun des ~23 workflows Lean et y ajouter détection de changement + job agrégateur — était un rollout de 23 instances scan-générables, c'est-à-dire précisément la monoculture que le protocole de variation interdit, pour une couverture inférieure.

## Note d'auto-test

Cette PR modifie `pr-gate.yml`, et comme le workflow n'a pas de filtre `paths:`, il tourne **sur cette PR même** — le gate se juge donc lui-même dès son premier commit. C'est la contrainte de #8712 (« un gate dont la première exécution est post-merge n'est pas un gate ») satisfaite par construction plutôt que par une liste de chemins à maintenir.

## Périmètre

3 fichiers ajoutés, 0 modifié. Catalogue non touché. Aucun secret, aucun token.

See #9819.
