### PR TITLE
feat(ci,#9819): add check-runs aggregator with verdict replay of #9762 (Step 1 safe)

### DIFF
--- a/.github/workflows/ci-required-aggregator.yml
+++ b/.github/workflows/ci-required-aggregator.yml
@@ -1,0 +1,90 @@
+name: CI Required Aggregator
+
+# Gate de coagulation CI : agrège les check-runs d'une PR en un seul verdict
+# PASS/FAIL requis au merge. Voir #9819 pour le diagnostic fondateur
+# (incident #9762 : `ci / Lean CI (grothendieck_lean)` rouge au merge,
+# `proof-integrity` rouge au merge, `gh pr merge` a passé quand même parce
+# que `required_status_checks` est vide sur `main`).
+#
+# Pourquoi un aggregator check-runs via API et pas un `needs:` cross-workflow :
+# GitHub Actions ne permet PAS à un workflow d'avoir un job qui `needs:` les
+# jobs d'un AUTRE workflow via workflow_call. Les seules options étaient :
+#   - regrouper les jobs des N workflows en UN seul workflow (invasif),
+#   - `workflow_run` trigger (complexe, lent, et ne déclenche pas de check),
+#   - ce pattern : UN workflow qui poll l'API `checks.listForRef`.
+# Ce pattern est le moins invasif et le plus rapide à itérer.
+#
+# La logique de classification/verdict vit dans `scripts/ci/aggregate_checks.py`
+# (stdlib only, 0 dépendance externe) — testable via pytest. Le workflow ne
+# fait que (a) fetch les check-runs via l'API, (b) pipe NDJSON au script,
+# (c) refléter le verdict (exit 1 = setFailed).
+#
+# Ce workflow n'altère PAS `required_status_checks` (étape 2 owner-only dans
+# #9819, gated user explicite). Il tourne, rapporte PASS/FAIL, et attend le
+# flip repo setting pour bloquer le merge. Tant qu'il n'est pas enregistré
+# comme `required_status_check`, il ne bloque rien -- observation seule.
+
+on:
+  pull_request:
+    branches: [main]
+
+# Lecture seule sur contents, lecture+écriture checks pour ajouter un
+# check_run récapitulatif (optionnel, met fin au débat "où est le verdict").
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  aggregate-checks:
+    name: Aggregate upstream check-runs
+    runs-on: ubuntu-latest
+    # Le job regarde ce que les AUTRES workflows ont produit. Si pas de
+    # check-runs à observer (PR ouverte depuis peu, ou self-only PR), on
+    # laisse le job fail-safe : core.setFailed avec un message explicite.
+    # Pas de skip silencieux -- "un aggregator qui ne peut pas rougir n'est
+    # pas un aggregator" (cf #9819 acceptance criterion 1).
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Fetch upstream check-runs
+        id: fetch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # Récupère tous les check-runs pour ce SHA, paginé.
+          # On utilise `gh api` (déjà authentifié via GITHUB_TOKEN) plutôt que
+          # github-script pour rester proche d'un script shell testable localement.
+          ALL_RUNS="[]"
+          PAGE=1
+          while :; do
+            PAGE_DATA=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/check-runs?per_page=100&page=${PAGE}")
+            PAGE_RUNS=$(echo "${PAGE_DATA}" | jq -c '.check_runs')
+            PAGE_COUNT=$(echo "${PAGE_RUNS}" | jq 'length')
+            ALL_RUNS=$(jq -c -s 'add' <(echo "${ALL_RUNS}") <(echo "${PAGE_RUNS}"))
+            echo "Fetched page ${PAGE}: ${PAGE_COUNT} check-runs (total so far: $(echo "${ALL_RUNS}" | jq 'length'))"
+            if [ "${PAGE_COUNT}" -lt 100 ]; then
+              break
+            fi
+            PAGE=$((PAGE + 1))
+          done
+          echo "${ALL_RUNS}" > check_runs.json
+          echo "Total check-runs saved to check_runs.json: $(jq 'length' check_runs.json)"
+
+      - name: Aggregate verdict
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # NDJSON : un check-run par ligne (format robuste consommé par
+          # aggregate_checks.main() — accepte aussi JSON array / API envelope).
+          jq -c '.[]' check_runs.json | python scripts/ci/aggregate_checks.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 testpaths =
     tests
     scripts/notebook_tools/tests
+    scripts/ci/tests
     scripts/lean/tests
     MyIA.AI.Notebooks/GameTheory/tests
     MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/tests
@@ -12,6 +13,7 @@ testpaths =
     GradeBookApp
 pythonpath =
     MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts
+    scripts/ci
 addopts = -v --tb=short --import-mode importlib
 filterwarnings =
     ignore::DeprecationWarning

--- a/scripts/ci/aggregate_checks.py
+++ b/scripts/ci/aggregate_checks.py
@@ -1,0 +1,241 @@
+"""CI check-runs aggregator -- logique de classification et verdict.
+
+Appelé par `.github/workflows/ci-required-aggregator.yml` pour décider si
+les check-runs d'une PR autorisent un verdict PASS ou FAIL au merge.
+
+Contexte fondateur : #9819 (incident #9762 : PR mergée avec
+`ci / Lean CI (grothendieck_lean)` rouge + `proof-integrity` rouge
+parce que `required_status_checks` est vide sur `main`). Étape 1
+safe : on livre un verdict observable SANS flipper le repo setting.
+Étape 2 (inscrire comme `required_status_check`) reste gated user.
+
+La logique :
+1. Filtrer le check-run de l'aggregator lui-même (sinon il s'auto-bloque).
+2. Filtrer les "advisory" / "non-blocking" (regex sur le nom).
+3. Classer en `failing` (failure/timed_out) / `pending` (non completed
+   ou conclusion inconnue) / `passing` (success/skipped/neutral/stale/cancelled).
+4. Verdict final : `failing > 0` ou `pending > 0` = FAIL (sinon, un
+   aggregator qui ne peut pas rougir n'est pas un aggregator, cf.
+   critère d'acceptation #9819.1).
+
+Stdlib only (Python 3.10+) -- cohérent avec `scan_d2_window_openness.py`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from typing import Any
+
+# L'aggregator est lui-même un check-run -- il faut l'ignorer sinon il
+# s'auto-bloque sur son propre verdict "pending".
+AGGREGATOR_SELF_KEY = "aggregate-checks"
+
+# Les checks "advisory" / "non-blocking" par convention_repo sont dans
+# le nom du job : "advisory", "non-blocking", "non blocking", préfixe
+# "skip:", ou mot "optional". Regex case-insensitive.
+ADVISORY_PATTERN = re.compile(r"advisory|non[-\s]?blocking|^skip[:\s]|optional", re.IGNORECASE)
+
+# Conclusions qui BLOQUENT le merge.
+FAILING_CONCLUSIONS = frozenset({"failure", "timed_out"})
+
+# Conclusions qui ne bloquent pas (succès, skip volontaire, neutral,
+# stale, cancelled = probablement retry en cours).
+PASSING_CONCLUSIONS = frozenset(
+    {"success", "skipped", "neutral", "stale", "cancelled"}
+)
+
+
+def is_self(name: str | None) -> bool:
+    """True si le check-run est l'aggregator lui-même."""
+    if not name:
+        return False
+    return AGGREGATOR_SELF_KEY.lower() in name.lower()
+
+
+def is_advisory(name: str | None) -> bool:
+    """True si le check-run est explicitement marqué advisory/non-blocking."""
+    if not name:
+        return False
+    return bool(ADVISORY_PATTERN.search(name))
+
+
+def classify_check_runs(
+    check_runs: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Classify check-runs into failing / pending / passing / ignored_advisory / ignored_self.
+
+    Each input is a dict with at minimum `name`, `status`, `conclusion`.
+
+    Returns a dict with five lists:
+    - `failing`: completed AND conclusion in FAILING_CONCLUSIONS -> would-block merge
+    - `pending`: not completed yet, or unexpected conclusion -> aggregator waits
+    - `passing`: completed AND conclusion in PASSING_CONCLUSIONS -> OK
+    - `ignored_advisory`: filtered out, non-blocking by repo convention
+    - `ignored_self`: the aggregator itself (prevent self-blocking)
+    """
+    failing: list[dict[str, Any]] = []
+    pending: list[dict[str, Any]] = []
+    passing: list[dict[str, Any]] = []
+    ignored_advisory: list[dict[str, Any]] = []
+    ignored_self: list[dict[str, Any]] = []
+
+    for run in check_runs:
+        name = run.get("name")
+        if is_self(name):
+            ignored_self.append(run)
+            continue
+        if is_advisory(name):
+            ignored_advisory.append(run)
+            continue
+        status = run.get("status")
+        conclusion = run.get("conclusion")
+        if status != "completed":
+            pending.append(run)
+            continue
+        if conclusion in FAILING_CONCLUSIONS:
+            failing.append(run)
+            continue
+        if conclusion in PASSING_CONCLUSIONS:
+            passing.append(run)
+            continue
+        # Conclusion inattendue (nouvelle valeur upstream ?) : on remonte
+        # en pending pour observabilité humaine plutôt que de classer
+        # silencieusement. Tell explicite pour ne jamais verdir un blanc.
+        pending.append(run)
+
+    return {
+        "failing": failing,
+        "pending": pending,
+        "passing": passing,
+        "ignored_advisory": ignored_advisory,
+        "ignored_self": ignored_self,
+    }
+
+
+def verdict(classified: dict[str, list[dict[str, Any]]]) -> dict[str, Any]:
+    """Aggregate verdict from a classified check-runs mapping.
+
+    Returns a dict with:
+    - `block_merge` (bool): True if the aggregator would block the merge
+    - `reason` (str): human-readable explanation (suitable for setFailed)
+    - `summary_counts` (dict): counts per category (for log lines)
+    """
+    n_failing = len(classified["failing"])
+    n_pending = len(classified["pending"])
+    n_passing = len(classified["passing"])
+    n_advisory = len(classified["ignored_advisory"])
+    n_self = len(classified["ignored_self"])
+
+    if n_failing > 0:
+        return {
+            "block_merge": True,
+            "reason": (
+                f"CI aggregator: {n_failing} blocking check-run(s) failing. "
+                f"Inspect the Actions tab or run `gh pr checks <PR>`."
+            ),
+            "summary_counts": {
+                "failing": n_failing,
+                "pending": n_pending,
+                "passing": n_passing,
+                "ignored_advisory": n_advisory,
+                "ignored_self": n_self,
+            },
+        }
+    if n_pending > 0:
+        return {
+            "block_merge": True,
+            "reason": (
+                f"CI aggregator: {n_pending} check-run(s) still pending or with "
+                f"unknown conclusion. The aggregator does not tolerate a blank "
+                f"verdict -- wait for upstream checks to settle or cancel orphan "
+                f"workflows."
+            ),
+            "summary_counts": {
+                "failing": n_failing,
+                "pending": n_pending,
+                "passing": n_passing,
+                "ignored_advisory": n_advisory,
+                "ignored_self": n_self,
+            },
+        }
+    return {
+        "block_merge": False,
+        "reason": (
+            f"CI aggregator: 0 failing, 0 pending. "
+            f"{n_passing} passing. MERGE-CLEAN from CI perspective."
+        ),
+        "summary_counts": {
+            "failing": n_failing,
+            "pending": n_pending,
+            "passing": n_passing,
+            "ignored_advisory": n_advisory,
+            "ignored_self": n_self,
+        },
+    }
+
+
+def format_log(classified: dict[str, list[dict[str, Any]]]) -> str:
+    """Render a human-readable log suitable for the workflow step output."""
+    lines: list[str] = []
+    for category in ("failing", "pending", "passing", "ignored_advisory", "ignored_self"):
+        label = category.replace("_", " ").upper()
+        runs = classified[category]
+        lines.append(f"=== {label} ({len(runs)}) ===")
+        if not runs:
+            lines.append("  (none)")
+        else:
+            for r in runs:
+                lines.append(
+                    f"  - {r.get('name', '?')} :: "
+                    f"status={r.get('status', '?')} "
+                    f"conclusion={r.get('conclusion', '?')}"
+                )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    """Entry point invoked by the workflow.
+
+    Reads check-runs JSON from stdin (one object per line, OR a single
+    JSON array -- GitHub CLI outputs NDJSON, GitHub API outputs array).
+    Prints the verdict log to stderr and exits 1 if the verdict blocks,
+    0 otherwise.
+    """
+    raw = sys.stdin.read().strip()
+    if not raw:
+        print(
+            "ERROR: no check-runs provided on stdin. "
+            "Pass JSON array or NDJSON via the workflow.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Accepte JSON array OU NDJSON (un objet par ligne) -- robuste aux
+    # deux formats que l'API et `gh` produisent.
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, list):
+            check_runs = parsed
+        elif isinstance(parsed, dict) and "check_runs" in parsed:
+            check_runs = parsed["check_runs"]
+        else:
+            check_runs = [parsed]
+    except json.JSONDecodeError:
+        check_runs = []
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            check_runs.append(json.loads(line))
+
+    classified = classify_check_runs(check_runs)
+    print(format_log(classified), file=sys.stderr)
+    v = verdict(classified)
+    print(v["reason"], file=sys.stderr)
+    return 1 if v["block_merge"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/tests/test_aggregate_checks.py
+++ b/scripts/ci/tests/test_aggregate_checks.py
@@ -1,0 +1,429 @@
+"""Tests for `scripts/ci/aggregate_checks.py`.
+
+Stdlib only (no pytest required for collection -- but pytest IS the
+canonical runner in this repo). Run with:
+    pytest scripts/ci/tests/test_aggregate_checks.py -v
+
+Falsifiability scope (acceptance criterion #9819.1) :
+- pass on docs-only PR (all success)
+- fail on a failing-Lean PR (failure mixed with success)
+- self-check filter prevents the aggregator from blocking itself
+- advisory filter exempts the right checks
+- pending checks block (no silent skip)
+- the verdict reproduces the post-mortem of #9762 (#9762 head SHA
+  27dbd7fb had 2 failures -- aggregator must block)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the parent dir importable when running from the repo root.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "ci"))
+
+import aggregate_checks  # noqa: E402
+
+
+# --- Fixtures / helpers ------------------------------------------------
+
+
+def _run(name, status="completed", conclusion="success"):
+    """Build a minimal check-run dict."""
+    return {"name": name, "status": status, "conclusion": conclusion}
+
+
+# --- is_self ----------------------------------------------------------
+
+
+class TestIsSelf:
+    def test_matches_aggregate_checks_exact(self):
+        assert aggregate_checks.is_self("aggregate-checks") is True
+
+    def test_matches_aggregate_checks_case_insensitive(self):
+        assert aggregate_checks.is_self("Aggregate-Checks") is True
+
+    def test_matches_aggregate_checks_substring(self):
+        # GitHub may suffix display labels: e.g. "aggregate-checks (main)".
+        assert aggregate_checks.is_self("aggregate-checks (main)") is True
+
+    def test_does_not_match_aggregate(self):
+        # "aggregate" without "checks" must NOT match -- too broad, could
+        # shadow legit workflows with "aggregate" in the name.
+        assert aggregate_checks.is_self("aggregate") is False
+
+    def test_does_not_match_unrelated(self):
+        assert aggregate_checks.is_self("Lean CI (grothendieck_lean)") is False
+
+    def test_handles_none(self):
+        assert aggregate_checks.is_self(None) is False
+
+    def test_handles_empty(self):
+        assert aggregate_checks.is_self("") is False
+
+
+# --- is_advisory ------------------------------------------------------
+
+
+class TestIsAdvisory:
+    def test_advisory_keyword(self):
+        assert aggregate_checks.is_advisory("CJK residue advisory (label, non-blocking)") is True
+
+    def test_non_blocking_with_space(self):
+        assert aggregate_checks.is_advisory("foo (non blocking)") is True
+
+    def test_non_blocking_with_dash(self):
+        assert aggregate_checks.is_advisory("foo (non-blocking)") is True
+
+    def test_skip_prefix_colon(self):
+        assert aggregate_checks.is_advisory("skip: flaky test") is True
+
+    def test_skip_prefix_space(self):
+        assert aggregate_checks.is_advisory("skip flaky test") is True
+
+    def test_optional_keyword(self):
+        assert aggregate_checks.is_advisory("optional validation") is True
+
+    def test_case_insensitive(self):
+        assert aggregate_checks.is_advisory("ADVISORY check") is True
+
+    def test_does_not_match_unrelated(self):
+        assert aggregate_checks.is_advisory("Lean CI (grothendieck_lean)") is False
+        assert aggregate_checks.is_advisory("Catalog Guard") is False
+        assert aggregate_checks.is_advisory("Gitleaks secret scanner") is False
+
+    def test_handles_none(self):
+        assert aggregate_checks.is_advisory(None) is False
+
+    def test_handles_empty(self):
+        assert aggregate_checks.is_advisory("") is False
+
+
+# --- classify_check_runs ---------------------------------------------
+
+
+class TestClassifyCheckRuns:
+    def test_empty_input(self):
+        result = aggregate_checks.classify_check_runs([])
+        assert all(len(v) == 0 for v in result.values())
+
+    def test_all_success(self):
+        runs = [
+            _run("Lean CI (grothendieck_lean)", "completed", "success"),
+            _run("CodeQL", "completed", "success"),
+            _run("Catalog Guard", "completed", "success"),
+        ]
+        result = aggregate_checks.classify_check_runs(runs)
+        assert len(result["passing"]) == 3
+        assert len(result["failing"]) == 0
+        assert len(result["pending"]) == 0
+        assert len(result["ignored_advisory"]) == 0
+        assert len(result["ignored_self"]) == 0
+
+    def test_one_failure_blocks(self):
+        # The post-mortem of #9762: a Lean failure mixed with success.
+        # Acceptance criterion #9819.1 says the aggregator MUST rouge.
+        runs = [
+            _run("ci / Lean CI (grothendieck_lean)", "completed", "failure"),
+            _run("proof-integrity / Proof integrity (grothendieck_lean)", "completed", "failure"),
+            _run("CodeQL", "completed", "success"),
+            _run("Catalog Guard", "completed", "success"),
+        ]
+        result = aggregate_checks.classify_check_runs(runs)
+        assert len(result["failing"]) == 2
+        assert len(result["passing"]) == 2
+        assert all(r["name"].startswith("ci / Lean CI") or r["name"].startswith("proof-integrity")
+                   for r in result["failing"])
+
+    def test_timed_out_blocks_like_failure(self):
+        runs = [
+            _run("flaky job", "completed", "timed_out"),
+            _run("CodeQL", "completed", "success"),
+        ]
+        result = aggregate_checks.classify_check_runs(runs)
+        assert len(result["failing"]) == 1
+
+    def test_cancelled_is_passing(self):
+        # cancelled = retry in progress, don't block.
+        runs = [
+            _run("flaky job", "completed", "cancelled"),
+            _run("CodeQL", "completed", "success"),
+        ]
+        result = aggregate_checks.classify_check_runs(runs)
+        assert len(result["passing"]) == 2
+        assert len(result["failing"]) == 0
+
+    def test_skipped_is_passing(self):
+        runs = [
+            _run("Lean CI (knot_lean)", "completed", "skipped"),  # path filter
+            _run("CodeQL", "completed", "success"),
+        ]
+        result = aggregate_checks.classify_check_runs(runs)
+        assert len(result["passing"]) == 2
+
+    def test_pending_blocks(self):
+        # in_progress must block, not silently skip.
+        runs = [
+            _run("Lean CI (grothendieck_lean)", "in_progress", None),
+            _run("CodeQL", "completed", "success"),
+        ]
+        result = aggregate_checks.classify_check_runs(runs)
+        assert len(result["pending"]) == 1
+        assert len(result["failing"]) == 0
+
+    def test_unknown_conclusion_blocks(self):
+        # Unknown conclusion = surface as pending (human review), never silent pass.
+        runs = [
+            _run("weird future conclusion", "completed", "weird_value"),
+        ]
+        result = aggregate_checks.classify_check_runs(runs)
+        assert len(result["pending"]) == 1
+        assert len(result["failing"]) == 0
+
+    def test_self_is_excluded(self):
+        # The aggregator must not block itself.
+        runs = [
+            _run("aggregate-checks", "completed", "failure"),  # Would be its own verdict
+            _run("CodeQL", "completed", "success"),
+        ]
+        result = aggregate_checks.classify_check_runs(runs)
+        assert len(result["ignored_self"]) == 1
+        assert len(result["failing"]) == 0
+
+    def test_advisory_is_excluded(self):
+        runs = [
+            _run("CJK residue advisory (label, non-blocking)", "completed", "failure"),
+            _run("CodeQL", "completed", "success"),
+        ]
+        result = aggregate_checks.classify_check_runs(runs)
+        assert len(result["ignored_advisory"]) == 1
+        assert len(result["failing"]) == 0
+
+    def test_mixed_self_and_advisory_and_real(self):
+        # Real-world PR: self + 2 advisories + 1 failure + 5 success + 1 pending.
+        runs = [
+            _run("aggregate-checks", "completed", "success"),  # self
+            _run("CJK residue advisory", "completed", "success"),  # advisory
+            _run("Exercises advisory (allowed)", "completed", "failure"),  # advisory
+            _run("ci / Lean CI (grothendieck_lean)", "completed", "failure"),  # real failure
+            _run("CodeQL", "completed", "success"),
+            _run("Catalog Guard", "completed", "success"),
+            _run("Gitleaks secret scanner", "completed", "success"),
+            _run("Grain tag conformity", "completed", "success"),
+            _run("No notebook regression", "completed", "success"),
+            _run("Some job", "in_progress", None),  # pending
+        ]
+        result = aggregate_checks.classify_check_runs(runs)
+        assert len(result["ignored_self"]) == 1
+        assert len(result["ignored_advisory"]) == 2
+        assert len(result["failing"]) == 1
+        assert len(result["passing"]) == 5
+        assert len(result["pending"]) == 1
+
+
+# --- verdict ----------------------------------------------------------
+
+
+class TestVerdict:
+    def test_all_passing_no_block(self):
+        runs = [
+            _run("CodeQL", "completed", "success"),
+            _run("Catalog Guard", "completed", "success"),
+        ]
+        v = aggregate_checks.verdict(aggregate_checks.classify_check_runs(runs))
+        assert v["block_merge"] is False
+        assert "MERGE-CLEAN" in v["reason"]
+
+    def test_one_failure_blocks(self):
+        runs = [
+            _run("Lean CI (knot_lean)", "completed", "failure"),
+            _run("CodeQL", "completed", "success"),
+        ]
+        v = aggregate_checks.verdict(aggregate_checks.classify_check_runs(runs))
+        assert v["block_merge"] is True
+        assert "1 blocking" in v["reason"]
+
+    def test_pending_blocks(self):
+        runs = [
+            _run("Some job", "in_progress", None),
+        ]
+        v = aggregate_checks.verdict(aggregate_checks.classify_check_runs(runs))
+        assert v["block_merge"] is True
+        assert "pending" in v["reason"].lower()
+
+    def test_two_failures_blocks(self):
+        # Replays #9762 exactly: 2 failures + 10 successes.
+        runs = [
+            _run("ci / Lean CI (grothendieck_lean)", "completed", "failure"),
+            _run("proof-integrity / Proof integrity (grothendieck_lean)", "completed", "failure"),
+            _run("CodeQL", "completed", "success"),
+            _run("Catalog Guard", "completed", "success"),
+            _run("Grain tag conformity", "completed", "success"),
+            _run("Gitleaks secret scanner", "completed", "success"),
+            _run("No catalog changes", "completed", "success"),
+            _run("G-VAR-2 light cap", "completed", "success"),
+            _run("Check base branch staleness", "completed", "success"),
+            _run("No notebook regression", "completed", "success"),
+            _run("Analyze (python)", "completed", "success"),
+            _run("Analyze (csharp)", "completed", "success"),
+        ]
+        v = aggregate_checks.verdict(aggregate_checks.classify_check_runs(runs))
+        assert v["block_merge"] is True
+        assert v["summary_counts"]["failing"] == 2
+        assert v["summary_counts"]["passing"] == 10
+
+
+# --- format_log -------------------------------------------------------
+
+
+class TestFormatLog:
+    def test_format_includes_all_categories(self):
+        runs = [
+            _run("aggregate-checks", "completed", "success"),  # self
+            _run("CJK advisory", "completed", "success"),  # advisory
+            _run("Lean CI", "completed", "failure"),  # failing
+            _run("CodeQL", "in_progress", None),  # pending
+            _run("Catalog Guard", "completed", "success"),  # passing
+        ]
+        classified = aggregate_checks.classify_check_runs(runs)
+        log = aggregate_checks.format_log(classified)
+        assert "FAILING (1)" in log
+        assert "PENDING (1)" in log
+        assert "PASSING (1)" in log
+        assert "IGNORED ADVISORY (1)" in log
+        assert "IGNORED SELF (1)" in log
+        assert "Lean CI" in log
+        assert "CodeQL" in log
+
+
+# --- main / stdin pipeline --------------------------------------------
+
+
+class TestMainPipeline:
+    """Exercise the stdin -> stdout -> exit code pipeline."""
+
+    def test_json_array_input_clean(self, tmp_path, capsys):
+        runs = [
+            _run("CodeQL", "completed", "success"),
+            _run("Catalog Guard", "completed", "success"),
+        ]
+        # Write JSON array to a file, redirect stdin via monkeypatch.
+        fake_stdin_path = tmp_path / "check_runs.json"
+        fake_stdin_path.write_text(json.dumps(runs))
+        original_stdin = sys.stdin
+        try:
+            sys.stdin = open(fake_stdin_path, "r")
+            exit_code = aggregate_checks.main()
+        finally:
+            sys.stdin.close()
+            sys.stdin = original_stdin
+        assert exit_code == 0  # MERGE-CLEAN
+
+    def test_json_array_input_blocking(self, tmp_path, capsys):
+        runs = [
+            _run("Lean CI", "completed", "failure"),
+            _run("CodeQL", "completed", "success"),
+        ]
+        fake_stdin_path = tmp_path / "check_runs.json"
+        fake_stdin_path.write_text(json.dumps(runs))
+        original_stdin = sys.stdin
+        try:
+            sys.stdin = open(fake_stdin_path, "r")
+            exit_code = aggregate_checks.main()
+        finally:
+            sys.stdin.close()
+            sys.stdin = original_stdin
+        assert exit_code == 1  # BLOCK
+
+    def test_api_envelope_input(self, tmp_path, capsys):
+        # GitHub API returns `{"check_runs": [...], "total_count": N}`
+        envelope = {
+            "total_count": 2,
+            "check_runs": [
+                _run("CodeQL", "completed", "success"),
+                _run("Catalog Guard", "completed", "success"),
+            ],
+        }
+        fake_stdin_path = tmp_path / "check_runs_envelope.json"
+        fake_stdin_path.write_text(json.dumps(envelope))
+        original_stdin = sys.stdin
+        try:
+            sys.stdin = open(fake_stdin_path, "r")
+            exit_code = aggregate_checks.main()
+        finally:
+            sys.stdin.close()
+            sys.stdin = original_stdin
+        assert exit_code == 0  # MERGE-CLEAN
+
+    def test_empty_input_exits_2(self, tmp_path, capsys):
+        fake_stdin_path = tmp_path / "empty.json"
+        fake_stdin_path.write_text("")
+        original_stdin = sys.stdin
+        try:
+            sys.stdin = open(fake_stdin_path, "r")
+            exit_code = aggregate_checks.main()
+        finally:
+            sys.stdin.close()
+            sys.stdin = original_stdin
+        assert exit_code == 2  # usage error
+
+    def test_ndjson_input(self, tmp_path, capsys):
+        # `gh api ... --jq '.check_runs[]'` produces NDJSON.
+        fake_stdin_path = tmp_path / "check_runs.ndjson"
+        lines = "\n".join(
+            json.dumps(_run(name, status, conclusion))
+            for name, status, conclusion in [
+                ("CodeQL", "completed", "success"),
+                ("Catalog Guard", "completed", "success"),
+            ]
+        )
+        fake_stdin_path.write_text(lines)
+        original_stdin = sys.stdin
+        try:
+            sys.stdin = open(fake_stdin_path, "r")
+            exit_code = aggregate_checks.main()
+        finally:
+            sys.stdin.close()
+            sys.stdin = original_stdin
+        assert exit_code == 0  # MERGE-CLEAN
+
+
+# --- Replay of post-mortem #9762 (acceptance criterion #9819.1) -----
+
+
+class TestPostMortem9762:
+    """Falsifiability: replay the post-mortem of #9762 exactly.
+
+    PR #9762 head SHA `27dbd7fb440de3a00e65d0cb8826085b9b1e58a5` had
+    2 failures (`ci / Lean CI (grothendieck_lean)` + `proof-integrity /
+    Proof integrity (grothendieck_lean)`) merged successfully because
+    `required_status_checks` was empty. The aggregator MUST rouge
+    on that exact data.
+    """
+
+    def test_replay_9762_blocks(self):
+        runs_9762 = [
+            _run("CodeQL", "completed", "success"),
+            _run("ci / Lean CI (grothendieck_lean)", "completed", "failure"),
+            _run("proof-integrity / Proof integrity (grothendieck_lean)", "completed", "failure"),
+            _run("No notebook health regression", "completed", "success"),
+            _run("Check Grain tag conformity", "completed", "success"),
+            _run("Gitleaks secret scanner", "completed", "success"),
+            _run("No catalog changes on feature branch", "completed", "success"),
+            _run("G-VAR-2 light cap (cross-PR)", "completed", "success"),
+            _run("Check base branch staleness", "completed", "success"),
+            _run("Analyze (javascript-typescript)", "completed", "success"),
+            _run("Analyze (actions)", "completed", "success"),
+            _run("Analyze (python)", "completed", "success"),
+            _run("Analyze (csharp)", "completed", "success"),
+        ]
+        v = aggregate_checks.verdict(aggregate_checks.classify_check_runs(runs_9762))
+        assert v["block_merge"] is True
+        assert v["summary_counts"]["failing"] == 2
+        assert v["summary_counts"]["passing"] == 11
+        # Verdict reason must mention the count, not generic "an error occurred".
+        assert "2 blocking" in v["reason"]


### PR DESCRIPTION
## Grain: DEEP/guard — lane myia-po-2024:CoursIA-2 — prev: DEEP/qc-tooling #9803

# CI aggregator (étape 1 safe de #9819)

> Diagnostic fondateur : #9819 — incident #9762 : PR mergée avec
> `ci / Lean CI (grothendieck_lean)` rouge + `proof-integrity` rouge
> parce que `required_status_checks` est vide sur `main`.
>
> **Étape 1 (ce PR, safe) :** on livre un aggregator qui **produit un
> verdict observable** (PASS/FAIL) sur chaque PR, sans toucher au
> repo setting. Le check_run apparaît dans l'UI GitHub, le merge reste
> possible tant que `required_status_checks` n'est pas flippé côté user.
>
> **Étape 2 (séparée, gated user) :** inscrire `aggregate-checks` comme
> `required_status_check` sur `main`. C'est un appel owner-only et un
> sujet distinct — pas inclus dans cette PR.

## Pourquoi ce pattern (et pas `needs:` cross-workflow)

GitHub Actions ne permet **PAS** à un workflow d'avoir un job qui
`needs:` les jobs d'un AUTRE workflow via `workflow_call`. Les seules
options étaient :

| Option | Pourquoi écartée |
|---|---|
| Regrouper N workflows en 1 | invasif, refacto de chaque workflow |
| `workflow_run` trigger | complexe, lent, et ne crée pas un check-run par PR |
| **`checks.listForRef` (ce PR)** | **le moins invasif et le plus rapide à itérer** |

Le workflow ne fait que (a) fetch les check-runs du SHA via l'API, (b)
pipe NDJSON au script Python, (c) refléter le verdict (exit 1 = `FAIL`,
exit 0 = `success`).

## Logique (dans `scripts/ci/aggregate_checks.py`, stdlib only)

1. **Filtre self** : `is_self(name)` — retire "aggregate-checks" du
   verdict (sinon l'aggregator s'auto-bloque sur son propre `pending`).
2. **Filtre advisory** : `is_advisory(name)` — match `advisory`,
   `non-blocking` / `non blocking`, préfixe `skip:` ou `skip `, mot
   `optional`. Regex case-insensitive.
3. **Classification** :
   - `failing` : `failure` / `timed_out`
   - `pending` : `status != "completed"` **OU** conclusion inattendue
     → on remonte en pending pour observabilité humaine, jamais de
     "verdict blanc silencieux" (cf. acceptance criterion #9819.1).
   - `passing` : `success` / `skipped` / `neutral` / `stale` / `cancelled`
4. **Verdict** : `failing > 0` ou `pending > 0` ⇒ **FAIL** (exit 1).
   Sinon ⇒ **PASS** (exit 0).
   *"Un aggregator qui ne peut pas rougir n'est pas un aggregator."*

## Falsifiabilité (acceptance criterion #9819.1)

`scripts/ci/tests/test_aggregate_checks.py` — **39 tests, 100% PASS en 0.10s** :

- `TestIsSelf` (7 tests) — match exact / case-insensitive / substring,
  refute "aggregate" seul, refute unrelated, handles `None`/empty.
- `TestIsAdvisory` (10 tests) — keyword `advisory`, `non-blocking` /
  `non blocking`, préfixe `skip:` / `skip `, `optional`, case-insensitive,
  refute unrelated, handles `None`/empty.
- `TestClassifyCheckRuns` (11 tests) — empty, all-success,
  one-failure-blocks, timed_out-blocks, cancelled-passing,
  skipped-passing, pending-blocks, unknown-conclusion-blocks,
  self-excluded, advisory-excluded, mixed.
- `TestVerdict` (4 tests) — all-passing-no-block, one-failure-blocks,
  pending-blocks, two-failures-blocks (#9762 replay).
- `TestFormatLog` (1 test) — toutes catégories présentes.
- `TestMainPipeline` (5 tests) — JSON array clean / blocking, API
  envelope, empty → exit 2 (usage), NDJSON.
- `TestPostMortem9762` (1 test) — **replay exact de #9762** : 2
  failures + 11 successes ⇒ `block_merge=True`, `summary_counts.failing=2`,
  `summary_counts.passing=11`, `"2 blocking"` dans la reason.

Le test `test_replay_9762_blocks` est la **preuve de non-régression** :
si la logique régresse et laisse passer #9762 à nouveau, ce test rouge.

## Pipeline workflow

```
on: pull_request (branches: [main])
  ↓
[Fetch] gh api /commits/{sha}/check-runs?per_page=100 (paginé)
       → check_runs.json (JSON array)
  ↓
[Aggregate] jq -c '.[]' check_runs.json | python scripts/ci/aggregate_checks.py
       → exit 0 = PASS, exit 1 = FAIL (→ core.setFailed)
```

Bash + Python stdlib only. Pas de dépendance externe ajoutée.

## Ce que ce PR ne fait PAS (volontairement)

- ❌ **Ne flippe pas `required_status_checks` sur `main`.** Étape 2,
  owner-only call. À faire dans une PR séparée **après** validation
  de cette étape 1 sur quelques PRs réelles.
- ❌ **Ne consolide pas les workflows existants.** Pas de migration
  forcée. On ajoute un check-run, c'est tout.
- ❌ **Ne tente pas de merger avec le verdict.** Le check-run apparaît
  dans l'UI, le bouton merge reste actif tant que l'étape 2 n'est pas
  posée. C'est l'observation, pas le blocage — par design (safe rollout).

## Fichiers

| Fichier | Statut | LOC |
|---|---|---|
| `.github/workflows/ci-required-aggregator.yml` | NEW | ~85 |
| `scripts/ci/aggregate_checks.py` | NEW | ~180 |
| `scripts/ci/tests/test_aggregate_checks.py` | NEW | ~310 |
| `pytest.ini` | MODIFIED | +2 (testpaths + pythonpath) |

**Tests :** `python -m pytest scripts/ci/tests/test_aggregate_checks.py -v`
→ **39 passed in 0.10s**.

**Validation locale :** replay du post-mortem #9762 (`2 failures + 11
successes` via `jq -c '.[]' | python scripts/ci/aggregate_checks.py`)
→ exit 1, "2 blocking check-run(s) failing" — exactement le verdict
qu'on veut sur le SHA `27dbd7fb`.

## Cadrage suite (#9819 étape 2 — gated user)

Une fois ce PR mergé et 1-2 cycles d'observation passés :

1. **Gated user** : `gh api repos/jsboige/CoursIA/branches/main/protection/required_status_checks`
   avec body `{"contexts": ["aggregate-checks"]}`. **Owner-only** — un
   worker n'a pas les droits `MergePullRequest`/`EditRepoProtection`
   sur ce repo (cf. coordinateur-discipline R1).
2. **Issue de cadrage** : à ouvrir le moment venu avec le diagnostic
   "1+ cycles d'observation verts + signature user".

Cf. #9819 pour le scope complet.

## Voir aussi

- #9819 — diagnostic fondateur
- #9762 — PR incident (post-mortem)
- `scripts/notebook_tools/scan_d2_window_openness.py` — précédent
  "stdlib only + pytest dans ce repo"
- `.claude/rules/anti-regression.md` — protocole 4 étapes (cadrage
  PREALABLE PR code production : OK, ce PR ajoute l'outillage
  testable, ne touche pas le code de production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)