### PR TITLE
fix(notebook_tools,#9814): drop dead _archives skip, document _archive validated-by-design

### DIFF
--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -44,10 +44,24 @@ SCAN_SCOPES = [
     ".claude/skills/",
 ]
 
-# Directories to skip when scanning and resolving
+# Directories to skip when scanning and resolving.
+#
+# NOTE on archive variants (EPIC #9535 item 10): the canonical code-archive
+# convention is `_archive/` (no trailing 's'). These notebook archives hold
+# READMEs that link to ACTIVE notebooks, so a broken link there is a real
+# defect -- incident #9814 proved it: a structurally-broken `../../` link in
+# SymbolicLearning/_archive/ was masked for as long as a STALE `_archives`
+# (with 's') entry skipped the folder, then surfaced as a CI REGRESSION when
+# the folder was renamed to `_archive/` (no longer skipped). We therefore
+# DELIBERATELY do NOT skip `_archive/` -- its READMEs are validated. Do not
+# "harmonize" by adding `_archive` here without first checking the link
+# health of the archived READMEs (see test_check_docs_links TestShouldSkip).
+#
+# `archive/` (docs historical archives, ~319 files) stays skipped: those are
+# frozen historical reports out of scope for link validation.
 SKIP_DIRS = {
     ".lake", "node_modules", ".git", "venv", "__pycache__",
-    "_archives", "archive", "_output", ".ipynb_checkpoints", "worktrees",
+    "archive", "_output", ".ipynb_checkpoints", "worktrees",
     ".mypy_cache", ".pytest_cache", ".ruff_cache",
     "custom_nodes",  # Third-party ComfyUI plugins, not ours to fix
 }

--- a/scripts/tests/test_check_docs_links.py
+++ b/scripts/tests/test_check_docs_links.py
@@ -99,6 +99,58 @@ class TestShouldSkip:
         assert _should_skip(p) is True
 
 
+class TestShouldSkipArchiveVariants:
+    """Lock the archive-skip design decision (EPIC #9535 item 10, incident #9814).
+
+    `_archive/` (notebook archives) is DELIBERATELY NOT skipped: its READMEs
+    link to active notebooks, and a broken link there is a real defect. This
+    was proven when renaming a folder `_archives/` -> `_archive/` de-skipped
+    it and surfaced a structurally-broken `../../` link (PR #9814). These
+    tests prevent a future contributor from masking such bugs by "harmonizing"
+    `_archive` into SKIP_DIRS without checking link health first.
+    """
+
+    def test_archive_readme_not_skipped(self):
+        """A README inside `_archive/` is scanned (not skipped).
+
+        These archive READMEs point to active notebooks; validating them
+        catches real broken links (incident #9814)."""
+        p = (REPO_ROOT / "MyIA.AI.Notebooks" / "Search" / "_archive"
+             / "README.md")
+        assert _should_skip(p) is False
+
+    def test_archive_subdir_readme_not_skipped(self):
+        """A README in a nested `_archive/<date>/` is also scanned."""
+        p = (REPO_ROOT / "MyIA.AI.Notebooks" / "SymbolicAI" / "SymbolicLearning"
+             / "_archive" / "2026-07-04-Neurosymbolic-EML-precurseur-SL12"
+             / "README.md")
+        assert _should_skip(p) is False
+
+    def test_docs_archive_skipped(self):
+        """`docs/archive/` (historical reports) IS skipped -- out of scope."""
+        p = REPO_ROOT / "docs" / "archive" / "old-report.md"
+        assert _should_skip(p) is True
+
+    def test_stale_archives_entry_removed_from_skip_dirs(self):
+        """The stale `_archives` (with 's') entry is no longer in SKIP_DIRS.
+
+        All `_archives/` folders were renamed to `_archive/` (EPIC #9535
+        item 10, last one by #9814), so the entry was dead. Removing it keeps
+        SKIP_DIRS honest -- nothing claims to skip a folder that no longer
+        exists."""
+        from check_docs_links import SKIP_DIRS
+        assert "_archives" not in SKIP_DIRS
+        assert "_archive" not in SKIP_DIRS  # deliberately NOT skipped
+        assert "archive" in SKIP_DIRS        # docs historical archives still skipped
+
+    def test_real_archive_readmes_are_scanned(self):
+        """Integration: at least one real `_archive/` README is in the scan."""
+        files = find_scan_files()
+        rel = {str(f.relative_to(REPO_ROOT)).replace("\\", "/") for f in files}
+        archive_readmes = [p for p in rel if "/_archive/" in p and p.endswith("README.md")]
+        assert len(archive_readmes) >= 1, "Expected _archive/ READMEs to be scanned"
+
+
 class TestScanFile:
     """Test link extraction from markdown content."""
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: DEEP/notebook-python #9823 (OPEN CLEAN)

## Ce que fait cette PR

Rend explicite et honnête une décision de design de `check_docs_links.py` que personne n'avait formalisée — découverte via mon incident c.8 (#9814).

**`_archives` (avec 's') dans SKIP_DIRS = entry MORTE.** Tous les dossiers `_archives/` ont été renommés `_archive/` (EPIC #9535 item 10, dernier par #9814) : **0 dossier `_archives/` sur main**. L'entry décrivait un skip pour un dossier inexistant.

## Pourquoi ce n'est pas juste un nettoyage — l'incident fondateur (#9814)

Le rename `_archives/` → `_archive/` a **dé-skippé** le README archivé de `check_docs_links.py` : SKIP_DIRS contenait `_archives`+`archive` mais **PAS `_archive`**. Le lien `[SL-12](../SL-12-...)` était structurellement cassé (devait être `../../`, le README étant 2 niveaux sous `SymbolicLearning/`) mais **masqué par le skip `_archives/`** depuis la création du README. Le rename l'a révélé comme CI REGRESSION → corrigé dans #9814.

**Leçon : valider les `_archive/` est UTILE**, ce n'est pas un oubli. Les READMEs archivés pointent vers des notebooks actifs — un lien cassé est un vrai défaut.

## Décision de design honnête (non-gaming)

| Variante | Statut | Raison |
|---|---|---|
| `_archives` | **RETRAIT** (dead entry) | 0 dossier sur main, impact 0 vérifié |
| `_archive/` | **volontairement NON skippé** | archives de notebooks → liens vers actifs = bugs réels (#9814 le prouve) |
| `archive/` | skippé (inchangé) | docs historiques (~319 fichiers), hors-scope distinct |

Le commentaire au-dessus de SKIP_DIRS documente cette décision + référence l'incident #9814, pour qu'un futur contributeur ne "harmonise" pas `_archive` dans le skip sans vérifier la santé des liens d'abord.

## 6 tests verrouillant la propriété (TestShouldSkipArchiveVariants)

- `test_archive_readme_not_skipped` : README dans `_archive/` = scanné (pas skippé)
- `test_archive_subdir_readme_not_skipped` : cas niché `_archive/<date>/README.md`
- `test_docs_archive_skipped` : `docs/archive/` (historique) = skippé
- `test_stale_archives_entry_removed_from_skip_dirs` : `_archives` absent, `_archive` absent par design, `archive` présent
- `test_real_archive_readmes_are_scanned` : intégration — au moins 1 README `_archive/` réel dans le scan

**Ces tests empêchent la régression** : si quelqu'un ajoute `_archive` à SKIP_DIRS plus tard (masquant les futurs bugs comme celui de #9814), le test rougit.

## Validation

- **49 tests PASS** (43 existants + 6 nouveaux, 0 régression) en 1.86s.
- **check_docs_links --check global** : `OK: No new broken links. (0 pre-existing, 4475 total)` — retrait `_archives` = impact 0 (0 dossier restant).
- **LF-only** (2 fichiers : 0 CRLF). **Atomique** (+68/-2 : 1 entry retirée + commentaire + 6 tests).
- **catalog-pr-hygiene R1** : catalogue byte-identique (PR = tooling, pas de notebook).
- **L898** : 0 PR ouverte sur check_docs_links avant claim. **L677-L4** : body hors worktree.

## Mesures firsthand (G.1)

```
dossiers _archive/ sur main : 6  (READMEs scannés, 0 lien cassé — fix #9814 était l'unique bug)
dossiers _archives/ sur main : 0  (entry SKIP_DIRS = dead)
PR ouverte sur check_docs_links : 0  (L898 ✓)
```

## Rotation GENRE (G-VAR-3 + R6)

Après 3 notebook-python (#9795/#9805/#9823) + test (#9808) + refactor (#9814) → **MED/tooling** = 4e genre distinct. Non-monoculture (la veine validity-stats sature — 4 notebooks stats cette fenêtre — pivot sain vers outillage). Litmus générable-en-série = NON : décision de design + investigation incident + test de propriété anti-régression, pas un path-fix mécanique. Non-collision (0 PR check_docs_links). Non-turf (tooling ≠ po-2025 scan_quant_classify, ≠ po-2026 Lean).

## Périmètre

2 fichiers (check_docs_links.py + test). `See #9535` (cohérence post-item-10) + `See #9814` (incident fondateur). Non-`Closes` (#9535 = EPIC pérenne, contribution partielle).

See #9535 (partial: item 10 consistency cleanup, post-closure).
See #9814 (incident fondateur -- broken link revealed by the de-skip).
