### PR TITLE
test(count,#9826): decouple test_count_by_subdir from committed prose freshness (main-rouge-24h)

### DIFF
--- a/scripts/notebook_tools/tests/test_count_by_subdir.py
+++ b/scripts/notebook_tools/tests/test_count_by_subdir.py
@@ -76,8 +76,22 @@ class TestCmdCountBySubdir:
         assert "Applications" in out
         assert "Part1-Foundations" in out
 
-    def test_real_repo_check_readme_search_ok(self):
-        """Search hub is currently OK (actual == declared). Locks the gate."""
+    def test_real_repo_check_readme_search_runs(self):
+        """--check-readme runs on the Search hub and emits a status table.
+
+        NOTE (#9826): this test NO LONGER asserts OK/MISMATCH against the
+        committed README prose. The prose count drifts after every notebook
+        merge (it is never auto-regenerated -- unlike the CATALOG-STATUS
+        marker refreshed daily by catalog-cron), so a freshness assertion
+        reddened ``main`` for up to 24h after each merge and mis-attributed
+        the failure to unrelated ``scripts/**`` PRs (the job is path-filtered
+        and never ran on the causal notebook PR). Prose-count freshness is
+        now the job of ``prose-counts-guard.yml`` (advisory today, strict
+        after #9377 stock resorption) -- the dedicated §E gate that runs ON
+        notebook/README PRs at the source. This test guards the FUNCTIONALITY
+        (check-readme produces a Search row + table header), not the
+        FRESHNESS of a committed artifact.
+        """
         buf = io.StringIO()
         with redirect_stdout(buf):
             rc = cmd_count_by_subdir(
@@ -86,8 +100,8 @@ class TestCmdCountBySubdir:
         assert rc == 0
         out = buf.getvalue()
         assert "Search" in out
-        assert "OK" in out
-        assert "MISMATCH" not in out  # Search is documented aligned.
+        assert "Actual" in out  # table header present (functionality works)
+        assert "Total" in out
 
     def test_real_repo_check_readme_all(self):
         """--check-readme across all 10 series produces a table with at least
@@ -108,14 +122,21 @@ class TestCmdCountBySubdir:
         assert rc == 0
         payload = json.loads(buf.getvalue())
         assert "Search" in payload
-        assert payload["Search"]["total"] >= 100  # Search = 115 currently
+        assert payload["Search"]["total"] >= 100  # Search pedagogical count (grows over time)
         assert "by_subfolder" in payload["Search"]
         # Subfolder keys are documented folder names.
         for sub in ["Applications", "Part1-Foundations", "Part4-Metaheuristics"]:
             assert sub in payload["Search"]["by_subfolder"]
 
     def test_real_repo_json_check_readme_enriched(self):
-        """--check-readme --json emits enriched entries with readme_declared + status."""
+        """--check-readme --json emits enriched entries with the contract keys.
+
+        NOTE (#9826): does NOT assert ``readme_declared == total`` (prose-
+        freshness gate removed -- see ``prose-counts-guard.yml`` for the §E
+        mechanism). Asserts the JSON CONTRACT: the entry exposes
+        ``status``, ``readme_declared``, ``total``, ``by_subfolder`` with
+        ``status`` in the documented enum, whatever the current drift state.
+        """
         buf = io.StringIO()
         with redirect_stdout(buf):
             rc = cmd_count_by_subdir(
@@ -130,8 +151,12 @@ class TestCmdCountBySubdir:
         payload = json.loads(out[json_start:])
         assert "Search" in payload
         search_entry = payload["Search"]
-        assert search_entry["status"] == "OK"
-        assert search_entry["readme_declared"] == search_entry["total"]
+        # Contract: enriched entry shape (NOT the freshness values).
+        assert "status" in search_entry
+        assert "readme_declared" in search_entry
+        assert "total" in search_entry
+        assert "by_subfolder" in search_entry
+        assert search_entry["status"] in {"OK", "MISMATCH", "no count"}
 
     def test_real_repo_all_includes_research(self):
         """--all produces a different (>=) total than the default."""


### PR DESCRIPTION
Grain: MED/test — lane myia-po-2024:CoursIA — prev: LIGHT/readme #9827

## Ce que fait cette PR

Désolidarise `test_count_by_subdir` de la **fraîcheur de la prose committée** — le défaut structurel qui rougissait `main` jusqu'à 24h après chaque merge de notebook (#9826).

## Le défaut (#9826, firsthand)

`Scripts Tests (CPU)` a rougi `main` aujourd'hui de 06:01Z (#9823 merge) jusqu'au cron suivant (~21h), et l'échec a été **imputé à tort** à #9825 (une PR `scripts/**` totalement étrangère). Mécanisme vérifié firsthand :

1. Le test asserte que le compte **prose** du README (lu via `extract_readme_count`, pattern `| Total | n |` / `n notebooks Python`) == compte **disque**.
2. La prose n'est **JAMAIS régénérée** automatiquement (contrairement au marqueur `CATALOG-STATUS`, rafraîchi quotidiennement par `catalog-cron`). Elle drift donc **permanent** après chaque merge, jusqu'à màj manuelle (#9827 a corrigé l'instance actuelle 115→116).
3. Le job est filtré `paths: scripts/**` → il **ne tourne jamais** sur la PR notebook causale. Le rouge apparaît a posteriori sur `main` + sur la première PR `scripts/**` qui passe.

Correction G.1 du body de #9826 : le body disait « le test asserte `pedagogical_count` du **marqueur** ». Firsthand, le test lit la **prose** (jamais auto-réparée), pas le marqueur (<24h cron) — le drift est donc **permanent**, pas async-tolérable.

## Fix — Option 2 du body (restreindre l'assertion à la fonctionnalité)

Retire le gate de fraîcheur prose du pytest, garde le **contrat fonctionnel**. La fraîcheur prose devient la responsabilité de **`prose-counts-guard.yml`** — le gate §E dédié (mandat user 2026-08-04) qui tourne **sur les PR notebook/README à la source**, là où le drift est causé et visible.

| Test | Avant (fragile) | Après (robuste) |
|---|---|---|
| `test_real_repo_check_readme_search_ok` → `_runs` | `assert "OK" in out`, `"MISMATCH" not in out` | `assert rc==0`, `"Search"/"Actual"/"Total" in out` (fonctionnalité) |
| `test_real_repo_json_check_readme_enriched` | `status == "OK"`, `readme_declared == total` | clés présentes + `status in {OK, MISMATCH, no count}` (contrat JSON) |

## Pourquoi pas l'Option 1 (disque ↔ catalogue recalculé en mémoire)

Investigation firsthand (subagent sonnet, preuves `file:line`) : `count_notebooks_in_dir` et `scan_all_notebooks` **divergent structurellement** :

| Divergence | `count_notebooks_in_dir` | `scan_all_notebooks` (catalog) |
|---|---|---|
| dir `output` | **inclus** | **exclu** (`EXCLUDE_PEDAGOGICAL` generate_catalog.py:44) |
| fichiers `_executed` | comptés | **skip** (generate_catalog.py:1128-1129) |
| notebooks corrompus (JSONDecodeError) | comptés (rglob seul) | **drop** (analyze_notebook → None, :783-784) |
| `EXCLUDE_ALWAYS` match | substring (`exc in part`) | exact-part (`part in EXCLUDE_ALWAYS`) |

Un test d'**égalité stricte** disque↔recalculé échouerait donc **aujourd'hui** pour de mauvaises raisons (divergence de règles de comptage, pas bug du générateur) — il déplacerait simplement le rouge. Réconcilier ces exclusions est un **scope séparé, plus large** (refonte du comptage). L'Option 2 résout proprement le défaut #9826 déclaré ; l'Option 1 est différée à une follow-up si les règles convergent.

## Validation

- **10 tests PASS** sur un checkout où Search est en **drift actif** (prose 115 vs disque 116) — exactement le scénario qui rougissait `main`.
- Suite large : `test_count_by_subdir` + `count_notebooks_by_series` + `_extra` = **60 passed**, 0 régression.
- **LF-only** (CRLF = 0). **Chirurgical** : +33/−8, 1 fichier.
- Pas d'autre test portant la même fragilité de fraîcheur prose (grep `readme_declared ==` / `"OK" in` sur `scripts/**/tests/` — seul ce fichier).

## Périmètre

1 fichier (`scripts/notebook_tools/tests/test_count_by_subdir.py`). `Closes #9826` (résout entièrement le défaut déclaré). Complémentaire de #9827 (instance immédiate du drift).

Closes #9826
