### PR TITLE
docs(#9831): 34 outils roo-state-manager -> 15, et repointer vers le doc qui tient la promesse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Cadre de travail (adapté de Karpathy + ajout user) : ces principes gouvernent *
 | [reference/procedures-recurrentes.md](docs/reference/procedures-recurrentes.md) | Workflow PR, dispatch, validation notebook, audit anti-régression, pre-commit H.3 |
 | [reference/subagents-reference.md](docs/reference/subagents-reference.md) | 21 sous-agents + 17 skills, mapping side-tracks, usage async |
 | [reference/scripts-reference.md](docs/reference/scripts-reference.md) | Catalogue scripts (notebook CLI, exécution, qualité, maintenance) |
-| [reference/architecture_mcp_roo.md](docs/reference/architecture_mcp_roo.md) | Architecture MCP roo-state-manager (34 outils, RooSync) |
+| [reference/architecture_mcp_roo.md](docs/reference/architecture_mcp_roo.md) | Cycle de vie, logs et diagnostic des serveurs MCP (inventaire des 15 outils roo-state-manager : [HARNESS-OVERVIEW.md](https://github.com/jsboige/roo-extensions/blob/main/docs/harness/HARNESS-OVERVIEW.md) §2) |
 | [reference/regles-vigilance-detail.md](docs/reference/regles-vigilance-detail.md) · [regles-validation-detail.md](docs/reference/regles-validation-detail.md) | Détail G.1-G.9 et H.1-H.7 + incidents |
 | [reference/env-python-reparation.md](docs/reference/env-python-reparation.md) | Réparation env Python (règle F) |
 | [reference/stale-tree-drift-scan.md](docs/reference/stale-tree-drift-scan.md) · [orphan-branch-scan-l576.md](docs/reference/orphan-branch-scan-l576.md) | Scans anti-phantom (drift, branche orpheline) |

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
@@ -117,7 +117,7 @@ Les sections précédentes ([Claude Code](#claude-code---ateliers), [Roo Code](#
 
 ### roo-state-manager — le MCP d'orchestration
 
-[`roo-state-manager`](https://github.com/jsboige/roo-extensions) est un MCP maison qui regroupe **34 outils** d'orchestration inter-agents et de mémoire collective. La doc pérenne détaille le rôle de chacun : [docs/reference/architecture_mcp_roo.md](../../../docs/reference/architecture_mcp_roo.md).
+[`roo-state-manager`](https://github.com/jsboige/roo-extensions) est un MCP maison qui regroupe **15 outils** d'orchestration inter-agents et de mémoire collective. La doc pérenne détaille le rôle de chacun : [HARNESS-OVERVIEW.md §2](https://github.com/jsboige/roo-extensions/blob/main/docs/harness/HARNESS-OVERVIEW.md) (6 coordination + 4 mémoire/recherche + 5 infrastructure). Pour le cycle de vie et le diagnostic des serveurs MCP eux-mêmes, voir [docs/reference/architecture_mcp_roo.md](../../../docs/reference/architecture_mcp_roo.md).
 
 | Catégorie | Rôle | Quelques outils représentatifs (sur 34) |
 |-----------|------|------------------------------------------|

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/CLUSTER-ORCHESTRATION.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/CLUSTER-ORCHESTRATION.md
@@ -25,7 +25,7 @@ Un atelier « découverte Claude Code » (module 01) apprend à démarrer une se
 
 ## La brique centrale : `roo-state-manager` (RooSync)
 
-`roo-state-manager` est un serveur MCP maison ([roo-extensions](https://github.com/jsboige/roo-extensions)) qui expose une trentaine d'outils de coordination. C'est le **système nerveux** du cluster : tout agent qui s'y connecte peut lire l'état de la flotte, poster son avancement, chercher dans l'historique des conversations, et synchroniser sa configuration. Les outils se regroupent en cinq familles :
+`roo-state-manager` est un serveur MCP maison ([roo-extensions](https://github.com/jsboige/roo-extensions)) qui expose **15 outils** de coordination. C'est le **système nerveux** du cluster : tout agent qui s'y connecte peut lire l'état de la flotte, poster son avancement, chercher dans l'historique des conversations, et synchroniser sa configuration. Chaque outil porte plusieurs actions (`roosync_dashboard` couvre `read`/`write`/`append`/`list`/…), ce qui explique qu'un petit nombre d'outils suffise à une surface aussi large. Le détail outil par outil vit en amont, dans [HARNESS-OVERVIEW.md §2](https://github.com/jsboige/roo-extensions/blob/main/docs/harness/HARNESS-OVERVIEW.md) ; on les regroupe ici en cinq familles d'usage :
 
 | Famille | Outils représentatifs | Rôle |
 |---------|----------------------|------|

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Documentation vivante, active et liée depuis CLAUDE.md / `.claude/rules/`.
 |---------|-------------|
 | [reference/common-commands.md](reference/common-commands.md) | Environnement, validation notebooks, scripts CLI |
 | [reference/procedures-recurrentes.md](reference/procedures-recurrentes.md) | Workflow PR, dispatch, validation, pré-commit |
-| [reference/architecture_mcp_roo.md](reference/architecture_mcp_roo.md) | Architecture des 34 outils MCP roo-state-manager |
+| [reference/architecture_mcp_roo.md](reference/architecture_mcp_roo.md) | Cycle de vie, logs et diagnostic des serveurs MCP (l'inventaire des 15 outils roo-state-manager vit en amont : [HARNESS-OVERVIEW.md](https://github.com/jsboige/roo-extensions/blob/main/docs/harness/HARNESS-OVERVIEW.md) §2) |
 | [reference/kernels-runtime.md](reference/kernels-runtime.md) | .NET, Python, WSL, conda envs |
 | [reference/env-python-reparation.md](reference/env-python-reparation.md) | Réparation environnements Python |
 | [reference/claude-code-config.md](reference/claude-code-config.md) | Agents, skills, rules, model selection |

--- a/docs/reference/cluster-agents.md
+++ b/docs/reference/cluster-agents.md
@@ -180,7 +180,7 @@ Pour tout sprint / curriculum >= 3 étapes, creer **Epic GitHub** + sub-issues n
 
 ## Pointeurs cross-doc
 
-- Architecture RooSync (34 outils MCP roo-state-manager) : [docs/architecture_mcp_roo.md](architecture_mcp_roo.md)
+- Cycle de vie / diagnostic des serveurs MCP : [architecture_mcp_roo.md](architecture_mcp_roo.md) — inventaire des 15 outils roo-state-manager : [HARNESS-OVERVIEW.md §2](https://github.com/jsboige/roo-extensions/blob/main/docs/harness/HARNESS-OVERVIEW.md)
 - Règles de coordination Git + dashboard : [CLAUDE.md](../../CLAUDE.md) section A
 - Calendrier enseignement + scope ecoles : [docs/teaching-context.md](teaching-context.md)
 - Training BG avec checkpoints : `MyIA.AI.Notebooks/QuantConnect/shared/gpu_training.py` (classe `TrainingCheckpoint` ; 18 tests PR #7454, fixes GPU-thermal #7335/#7454/#7456 ; le wrapper outer-supervisor subprocess `scripts/training/train_with_checkpoints.py` documenté n'a jamais été créé — utiliser `gpu_training.py` directement)


### PR DESCRIPTION
Grain: MED/docs — lane myia-ai-01:CoursIA — prev: MED/guard #9822

## Ce que ça corrige

Cinq fichiers suivis publiaient le nombre d'outils de `roo-state-manager`. Les cinq étaient faux, et quatre renvoyaient le lecteur vers un document qui ne contient pas ce qu'ils annoncent.

| Fichier | Publié | Corrigé |
|---|---|---|
| `CLAUDE.md:31` | « Architecture MCP roo-state-manager (**34 outils**, RooSync) » | 15 + repointage |
| `docs/README.md:24` | « Architecture des **34 outils** MCP roo-state-manager » | 15 + repointage |
| `docs/reference/cluster-agents.md:183` | « Architecture RooSync (**34 outils** MCP…) » | 15 + repointage |
| `GenAI/Vibe-Coding/README.md:120` | « regroupe **34 outils** … détaille le rôle de chacun » | 15 + repointage |
| `GenAI/Vibe-Coding/docs/CLUSTER-ORCHESTRATION.md:28` | « expose **une trentaine d'outils** » | 15 + note multi-actions |

## Le compte réel : 15, vérifié deux fois indépendamment

1. **Énumération d'une session live** connectée au serveur : exactement 15 outils (`codebase_search`, `conversation_browser`, `export_data`, `read_vscode_logs`, `roosync_baseline`, `roosync_compare_config`, `roosync_config`, `roosync_dashboard`, `roosync_diagnose`, `roosync_indexing`, `roosync_inventory`, `roosync_mcp_management`, `roosync_messages`, `roosync_search`, `roosync_storage_management`).
2. **La doc amont** `jsboige/roo-extensions:docs/harness/HARNESS-OVERVIEW.md` (42 820 octets, 362 lignes) titre sa section 2 « `roo-state-manager` — **les 15 outils** », découpée en 6 + 4 + 5.

L'écart de 34 à 15 n'est pas une dérive de comptage : c'est une **consolidation d'API**. Les outils historiques ont fusionné en outils multi-actions — `roosync_dashboard` porte `read`/`write`/`append`/`list`/`delete`, `conversation_browser` porte `list`/`tree`/`view`/`summarize`/`rebuild`. Le dépôt a continué de publier le compte d'avant la fusion. C'est pourquoi la correction ajoute une phrase explicative dans `CLUSTER-ORCHESTRATION.md` plutôt qu'un simple chiffre : sans elle, « 15 outils » pour la surface décrite paraît invraisemblable et invite la prochaine dérive.

## Le défaut le plus gênant n'est pas le nombre

Quatre des cinq sites promettaient l'inventaire — « Architecture des 34 outils », « La doc pérenne détaille le rôle de chacun » — en pointant vers `docs/reference/architecture_mcp_roo.md`.

**Ce fichier ne contient aucun inventaire d'outils.** 119 lignes, quatre sections : architecture des processus, cycle de vie d'un serveur MCP Python `stdio`, configuration et logs, stratégie de diagnostic. C'est un document d'infrastructure exact et utile — il ne décrit simplement le rôle d'aucun outil. Le lecteur qui suivait le lien pour trouver « le rôle de chacun » ne le trouvait pas.

Un chiffre se corrige par un chiffre ; une promesse rompue se corrige en pointant vers le document qui la tient. `architecture_mcp_roo.md` reste donc cité, mais pour ce qu'il couvre réellement.

## Non touché, vérifié correct

- **Les cinq familles d'usage** de `CLUSTER-ORCHESTRATION.md` (Dashboards / Messagerie / Mémoire conversationnelle / Recherche sémantique / Inventaire & config) : grille pédagogique légitime, distincte de la grille en trois de `HARNESS-OVERVIEW.md`. Deux découpages valides du même ensemble — seul le cardinal était faux.
- Les **huit outils nommés** dans ce tableau existent tous et sont correctement décrits.
- **`docs/archive/**`** publie des comptes 22/32 : ils concernent `jupyter-papermill` et des états historiques. Hors périmètre, laissés tels quels.
- `INSTALLATION-CLAUDE-CODE.md:605` cite « environ 60 outils » pour `qc-mcp` — autre serveur, non vérifié ici, hors périmètre.

## Validation

```
$ git ls-files -z '*.md' '*.ipynb' | xargs -0 grep -nEi "(une trentaine|trente|3[0-9]) (outils|tools)" \
    | grep -viE "^docs/archive/" | grep -iE "roo-state|roosync"
(aucun résultat)

$ python scripts/check_docs_links.py --check
OK: No new broken links. (0 pre-existing, 4479 total)
```

**Note de méthode** : mon premier scan avait conclu à *quatre* sites. Il passait par un `head -15` qui l'a tronqué, et `cluster-agents.md:183` est tombé dans la partie coupée — la classe d'erreur exacte que je reproche aux autres. Le scan ci-dessus est refait sans troncature, et j'ai corrigé #9831 en conséquence.

## Périmètre

**5 fichiers, +5/−5, une ligne chacun.** Aucun fichier généré touché, catalogue byte-identique à `main`. `CLAUDE.md` est du harnais : couvert par le sign-off blanket harnais du user, et livré en PR relisable plutôt qu'en édition directe.

Closes #9831.
