### PR TITLE
fix(d5,#9790): filter ATX heading lines (H1-H6) to close title FP gap

### DIFF
--- a/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
@@ -79,6 +79,14 @@ EXCLUDE_PATTERNS = (
     re.compile(r"^[A-Z]+\d+$"),            # PRJ42, ABC123 -- discutable, mais limite
 )
 
+# Ligne de titre markdown ATX (CommonMark) : 0-3 espaces puis 1-6 `#` puis un
+# espace ou fin de ligne. Les hints `## `/`### `/`#### ` ci-dessous couvraient
+# H2-H6 mais laissaient fuiter les titres H1 (`# SC-8-...`, `# MGS-9`,
+# `# SocialChoice 03`), source documentee de FP dans le corpus run #9790 (taux
+# de FP ~90 %, echantillon relu main). Un nombre sur une ligne de titre est un
+# numero de section/exercice/titre, jamais une mesure calculee.
+_ATX_HEADING_LINE_RE = re.compile(r"\s{0,3}#{1,6}(?:\s|$)")
+
 
 # Faux positifs semantiques : regex strictes (mot complet + caractere de
 # liaison) pour eviter de matcher au milieu d'une phrase legit.
@@ -202,6 +210,13 @@ def _extract_prose_numbers(text: str) -> list[float]:
         # eviter de matcher au milieu d'un titre.
         line_start = text.rfind("\n", 0, m.start()) + 1
         prefix = text[line_start:m.start()].lower()
+        # Filtre titres ATX (H1-H6) : la ligne entiere du nombre est un titre
+        # markdown. Les hints `## `/`### ` filtraient deja H2+ par prefixe ;
+        # ce check regex (ancre debut de ligne) ferme le gap H1 et durcit la
+        # detection (titre = structural, jamais une mesure d'output). On
+        # examine le debut de ligne brut (le `#` n'a pas de casse).
+        if _ATX_HEADING_LINE_RE.match(text[line_start:m.start() + len(raw)]):
+            continue
         if any(h in prefix for h in SEMANTIC_FALSE_POSITIVE_HINTS):
             continue
         v = _parse_fr_number(raw)

--- a/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
@@ -123,11 +123,30 @@ class TestExtractProseNumbers:
 
     def test_filter_section_headers(self):
         nums = mod._extract_prose_numbers("## 4.2 Resultats\nLe ratio est 0.7.")
-        # 4.2 dans titre markdown = filtre semantique ; 0.7 dans prose = garde
-        # L'implementation actuelle utilise un prefix-window de 60 chars, ce qui
-        # peut laisser passer 4.2 si le titre est tres court -- on accepte
-        # les deux comportements, on verifie juste que 0.7 est la.
+        # 4.2 sur une ligne de titre ATX = filtre (titre structural) ;
+        # 0.7 dans la prose du corps = garde.
         assert 0.7 in nums
+        assert 4.2 not in nums
+
+    def test_filter_h1_title_notebook_id(self):
+        # Gap documente dans le corpus run #9790 : les titres H1 (`# SC-8`,
+        # `# MGS-9`, `# SocialChoice 03`) fuyaient car les hints couvraient
+        # H2+ mais pas H1. Le numero d'ID du notebook est structural.
+        nums = mod._extract_prose_numbers("# SC-8-DeFi-Primitives\n\nLe solde est 0.69.")
+        assert 8 not in nums
+        assert 0.69 in nums
+
+    def test_filter_h1_title_count(self):
+        nums = mod._extract_prose_numbers("# SocialChoice 03 - Methodes\nLe ratio 0.7.")
+        assert 3 not in nums
+        assert 0.7 in nums
+
+    def test_h1_heading_does_not_filter_following_body(self):
+        # Un nombre sur la ligne SUIVANT un titre H1 (corps de paragraphe)
+        # doit etre preserve -- le filtre cible la ligne de titre, pas le
+        # paragraphe d'apres.
+        nums = mod._extract_prose_numbers("# Titre du notebook\n\nSharpe = 0.512.")
+        assert 0.512 in nums
 
     def test_filter_versions(self):
         nums = mod._extract_prose_numbers("Version v3 de l'algo, score 0.95.")


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2025:CoursIA — prev: DEEP/notebook-python #9821 (Toulmin, MERGED)

## Ce que fait cette PR

Micro-fix de précision sur le détecteur D5 `scan_d5_prose_outputs_alignment.py`, découvert pendant la **mesure d'acceptance #9790** (rapport détaillé posté en commentaire de #9790 ce cycle).

**Gap documenté** : `SEMANTIC_FALSE_POSITIVE_HINTS` couvrait les titres markdown H2-H6 (`## `, `### `, `#### `) mais **laissait fuiter les titres H1** (`# SC-8-DeFi-Primitives`, `# MGS-9`, `# SocialChoice 03`). Le corpus run #9790 montrait ces numéros d'ID de notebook comme findings `MISSING_FROM_OUTPUTS` (FP — un titre n'a jamais d'output calculé).

**Fix** : détection regex d'une ligne de titre ATX CommonMark (`_ATX_HEADING_LINE_RE = \s{0,3}#{1,6}(\s|$)`), ancrée en début de ligne, qui filtre H1-H6 uniformément. Ferme le gap H1 et durcit la détection (titre = structural, jamais une mesure).

## Mesures (firsthand, post-fix)

- **FP reduction** : 12 796 → 12 589 findings full-corpus **(-1,6 %, -207 findings)**. Modeste et honnête : le gap H1 était réel mais n'est pas la source dominante de FP (la majorité est dans les cellules de paragraphe d'interprétation, cf. cause racine dans le rapport #9790).
- **Contre-épreuve ICT-1 #9416 préservée** : le détecteur ressignale toujours `cell[24] MISSING_FROM_PROSE_ENUMERATION prose_n=2.0` sur l'état pré-`7de14792c` (la cellule conclusion est un paragraphe, pas un titre — le filtre ne l'atteint pas). Aucun vrai positif perdu.
- **Tests** : 60/60 PASS (57 existants + 3 nouveaux : `test_filter_h1_title_notebook_id`, `test_filter_h1_title_count`, `test_h1_heading_does_not_filter_following_body`), + `test_filter_section_headers` renforcé (assertion `4.2 not in nums`).

## Honnêteté du grain

Ce fix est **volontairement borné et modeste** (LIGHT) — il accompagne le livrable de substance du cycle qui est la **mesure d'acceptance #9790** (contre-épreuve ICT-1 + corpus 968 notebooks/dénominateur nommé + FP ~90 % mesuré sur échantillon relu main, rapport posté en commentaire de #9790). Il ne prétend pas faire passer le détecteur en précision de gate : la cause racine dominante des FP (le comptage `_distinct_levels(output_vals)` sur tous les outputs du notebook, incluant les séries parallèles type AND/OR vs XOR) demande un scoping sémantique hors d'un fix borné.

See #9790, #9768.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
