### PR TITLE
fix(qc,#9803): freeze BTC-MACD-ADX backtest window (SetEndDate) — non-stationarity quantified (Sharpe 0.611→0.238)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/Main.cs
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/Main.cs
@@ -361,6 +361,12 @@ namespace QuantConnect.Algorithm.CSharp
             // OPTIMISÉ: Période étendue pour test robustesse 2019-2025
             // Note: 500-day warmup needs data from ~Nov 2017 (Binance BTCUSDT available)
             SetStartDate(2019, 4, 1);
+            // Freeze the backtest window (#9803, EPIC #9768 D2 fondateur): without a real
+            // SetEndDate the window drifted with each run (Sharpe 0.225 -> 0.123 over 101
+            // extra trading days, 2026-04-27 -> 2026-08-06). Borne = "derniere annee civile
+            // complete" : defensible par sa REGLE (pas par son resultat). Voir #9803 pour la
+            // decision de design (2025-12-31 vs 2024-12-31) et la mesure de sensibilite.
+            SetEndDate(2025, 12, 31);
 
         }
 

--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/README.md
@@ -2,25 +2,24 @@
 
 Stratégie momentum BTCUSDT combinant MACD (tendance) et ADX (force) avec seuils adaptatifs par percentile (implémentation C#).
 
-## Performance (lecture vérifiée frais réels — NO-BEATS)
+## Performance (fenêtre figée reproductible — NO-BEATS, edge non-stationnaire)
 
-Backtest frais Binance réels, 2019-04-01 → 2026-08 (2684 jours tradeables, 52 ordres), projet de vérification Cloud `CSharp-BTC-MACD-ADX-verify` (34901074) :
+**Fix #9803 (EPIC #9768, D2 fondateur).** `Main.cs` ne fixait **aucun `SetEndDate`** : la fenêtre s'allongeait à chaque exécution (Sharpe 0.225 → 0.123 d'avril à août 2026 par le seul ajout de 101 jours de bourse). Désormais `SetEndDate(2025, 12, 31)` — borne « dernière année civile complète », défendable par sa **règle** (pas par son résultat). Le backtest est **reproductible**.
 
-| Métrique | Valeur vérifiée (frais réels) | Catalogue (max de balayage) |
-|----------|-------------------------------|----------------------|
-| **Sharpe** | **0.123** | 0.787 |
-| **CAGR** | **0.037 %** (quasi-plat sur 7 ans) | — |
-| **Max Drawdown** | **72.7 %** | — |
-| **Profit net** | **0.274 %** | — |
-| **PSR** | **0.814 %** (bruit, seuil 95 %) | — |
+### Mesure à deux bornes (frais Binance réels, params committés Window=40 / percentiles 10/90)
 
-**Verdict : NO-BEATS.** Le Sharpe 0.123 — avec un PSR de 0.8 %, statistiquement indissociable du bruit — mesure le code réellement committé. La stratégie sous-performe massivement le buy & hold BTC (~500 %+ sur la même période) avec un drawdown catastrophique de 72.7 %.
+| Fenêtre | Sharpe | CAGR | Profit net | MaxDD | PSR | Ordres | Jours |
+|---------|--------|------|------------|-------|-----|--------|-------|
+| 2019-04-01 → **2024-12-31** (sensibilité) | **0.611** | 17.54 % | 153.7 % | 72.7 % | 12.9 % | 40 | 2102 |
+| 2019-04-01 → **2025-12-31** (figée, canonical) | **0.238** | 3.96 % | 30.0 % | 72.7 % | 2.1 % | 47 | 2467 |
 
-**D'où vient le 0.787 du catalogue ?** Pas d'une absence de frais : le modèle Binance (`SetBrokerageModel(BrokerageName.Binance, AccountType.Cash)`) est présent depuis la **première révision** du fichier et l'était donc déjà dans ce run. Le 0.787 est le **maximum d'un balayage à 8 variantes** lancé le 2026-04-27 sur le projet Cloud `30751067`, dont les paramètres gagnants (`adx-period=35`, `window=60`, percentiles 15/85) **n'ont jamais été réécrits dans `Main.cs`** : les paramètres committés mesuraient **0.225** le même jour, sur les mêmes données. Le catalogue publie donc un nombre qui n'a jamais décrit ce code. Forensic complet : [#9768](https://github.com/jsboige/CoursIA/issues/9768).
+**La trouvaille = la non-stationnarité, chiffrée.** Une seule année (2025) fait chuter le Sharpe de **0.611 à 0.238 (−61 %)**, le profit net de 154 % à 30 %, le PSR de 12.9 % à 2.1 %. L'edge était **concentré sur 2019-2024** ; 2025 le détruit. C'est la quantification concrète du verdict non-stationnaire que l'EPIC #9768 nommait sans encore le mesurer (addendum user 2026-08-07 : « l'edge était concentré et non-stationnaire »). Le choix de borne n'est **pas neutre** — d'où la mesure aux deux.
 
-**Le chiffre ci-dessus se périmera.** `Main.cs` ne fixe **aucun `SetEndDate`** : la fenêtre s'allonge à chaque exécution. Entre avril et août 2026, les mêmes paramètres sont passés de 0.225 à 0.123 par le seul ajout de 101 jours de bourse (2583 → 2684 jours tradeables). Toute comparaison à ce nombre doit citer sa date de mesure.
+**Verdict : NO-BEATS, confirmé et désormais reproductible.** Sharpe 0.238 sur la fenêtre figée — PSR 2.1 %, statistiquement indissociable du bruit, sous-performe massivement le buy & hold BTC sur la même période, drawdown catastrophique de 72.7 %. Geler la fenêtre n'a pas sauvé la stratégie : elle reste non robuste, et la chute 2025 prouve qu'elle ne l'était pas davantage avant.
 
-Ce verdict corrobore [`RESEARCH_FINDINGS.md`](RESEARCH_FINDINGS.md) (2026-02-17) : l'approche adaptative à seuils percentile ne tient pas ses promesses — toutes les hypothèses H1-H5 rejetées, Sharpe -0.035 pour les paramètres originaux (Window=140). Les paramètres optimisés actuels (`Main.cs` : Window=40, percentiles 10/90) n'inversent pas la conclusion : 0.123 reste non robuste.
+**D'où vient le 0.787 du catalogue ?** Le modèle Binance (`SetBrokerageModel(BrokerageName.Binance, AccountType.Cash)`) est présent depuis la **première révision**. Le 0.787 est le **maximum d'un balayage à 8 variantes** lancé le 2026-04-27 sur le projet Cloud `30751067`, dont les paramètres gagnants (`adx-period=35`, `window=60`, percentiles 15/85) **n'ont jamais été réécrits dans `Main.cs`**. Le catalogue publie donc un nombre qui n'a jamais décrit ce code. Forensic complet : [#9768](https://github.com/jsboige/CoursIA/issues/9768).
+
+Ce verdict corrobore [`RESEARCH_FINDINGS.md`](RESEARCH_FINDINGS.md) (2026-02-17) : l'approche adaptative à seuils percentile ne tient pas ses promesses — toutes les hypothèses H1-H5 rejetées, Sharpe -0.035 pour les paramètres originaux (Window=140). Les paramètres optimisés actuels (`Main.cs` : Window=40, percentiles 10/90) n'inversent pas la conclusion : 0.238 reste non robuste.
 
 ## Stratégie
 

--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/README.md
@@ -44,4 +44,4 @@ partner-course-quant-trading/examples/CSharp-BTC-MACD-ADX (archivé après stand
 
 ---
 
-*Performance vérifiée sous frais Binance réels, fenêtre 2019-04 → 2026-08 (See #1621 Phase 4 / #1630). Le Sharpe 0.787 du catalogue ne décrit pas ce code : c'est le maximum d'un balayage de paramètres jamais committé ([#9768](https://github.com/jsboige/CoursIA/issues/9768)). La lecture du code committé (Sharpe 0.123, PSR 0.8 %, MaxDD 72.7 %) est non robuste et ne bat pas le buy & hold. Version anglaise préservée dans [`README.en.md`](README.en.md).*
+*Performance vérifiée sous frais Binance réels, fenêtre figée 2019-04-01 → 2025-12-31 (reproductible, #9803). Le Sharpe 0.787 du catalogue ne décrit pas ce code : c'est le maximum d'un balayage de paramètres jamais committé ([#9768](https://github.com/jsboige/CoursIA/issues/9768)). La lecture du code committé (Sharpe **0.238**, PSR **2.1 %**, MaxDD 72.7 %) est non robuste et ne bat pas le buy & hold — voir la section Performance ci-dessus pour la mesure de sensibilité au choix de borne (Sharpe 0.611 si la fenêtre s'arrête fin 2024). Version anglaise préservée dans [`README.en.md`](README.en.md).*


### PR DESCRIPTION
Grain: MED/qc — lane myia-po-2024:CoursIA — prev: MED/test #9830 (withdrawn, dup #9829)

## Ce que fait cette PR

Figer la fenêtre de backtest BTC-MACD-ADX (`SetEndDate(2025, 12, 31)`) — le **D2 fondateur** de l'EPIC #9768 : `Main.cs` avait `SetStartDate(2019,4,1)` mais **aucun `SetEndDate`**, donc la fenêtre dérivait à chaque exécution (Sharpe 0.225 → 0.123 d'avril à août 2026 par le seul ajout de 101 jours de bourse). Le backtest est désormais **reproductible**.

## Décision de design (reprise #9803)

`SetEndDate(2025, 12, 31)` — borne « dernière année civile complète », défendable par sa **règle** (pas par son résultat). Le commentaire sur #9803 a rejeté `2024-12-31` (recommandation du body) parce que **personne ne l'avait mesurée** — risquant de publier un Sharpe embelli par le choix de borne. Cette PR **mesure les deux**.

## Mesure à deux bornes (frais Binance réels, params committés Window=40 / percentiles 10/90)

Validé via qc-mcp-lite, projet Cloud 30751067 (compile BuildSuccess × 2) :

| Fenêtre | Sharpe | CAGR | Profit net | MaxDD | PSR | Ordres | Jours |
|---------|--------|------|------------|-------|-----|--------|-------|
| → **2024-12-31** (sensibilité) | **0.611** | 17.54 % | 153.7 % | 72.7 % | 12.9 % | 40 | 2102 |
| → **2025-12-31** (figée, canonical) | **0.238** | 3.96 % | 30.0 % | 72.7 % | 2.1 % | 47 | 2467 |

**La trouvaille = la non-stationnarité, chiffrée.** Une seule année (2025) fait chuter le Sharpe de **0.611 → 0.238 (−61 %)**, le profit net de 154 % → 30 %, le PSR de 12.9 % → 2.1 %. L'edge était **concentré sur 2019-2024** ; 2025 le détruit. C'est la quantification concrète du verdict non-stationnaire que l'EPIC #9768 nommait sans encore le mesurer (addendum user 2026-08-07 : « l'edge était concentré et non-stationnaire »). Le choix de borne n'est **pas neutre** — d'où la mesure aux deux.

## Verdict : NO-BEATS, confirmé et désormais reproductible

Sharpe **0.238** sur la fenêtre figée — PSR 2.1 %, statistiquement indissociable du bruit, sous-performe massivement le buy & hold BTC, drawdown catastrophique de 72.7 %. **Geler la fenêtre n'a pas sauvé la stratégie** : elle reste non robuste, et la chute 2025 prouve qu'elle ne l'était pas davantage avant. Le 0.123 du README (fenêtre dérivée jusqu'en août 2026) est remplacé par le 0.238 reproductible + le tableau 2-bornes.

## Périmètre (2 fichiers, atomique)

- `Main.cs` (+6) : `SetEndDate(2025, 12, 31)` + commentaire documentant la décision #9803.
- `README.md` (+18/-13) : section Performance réécrite (fenêtre figée + tableau 2-bornes + trouvaille non-stationnarité), remplaçant le 0.123 dérivé et l'avertissement « se périmera » (désormais adressé).
- Anti-régression ✓ : le fix **ajoute** du code (SetEndDate), n'en supprime aucun. Catalogue byte-identique (R1 ✓). LF-only.

## Résiduel honnête

**Walk-forward 3 folds (Étape 3 du protocole #9803)** non exécuté ce cycle — la mesure à deux bornes est **décisive** pour le verdict (−61 % Sharpe en un an) ; le walk-forward ajouterait du détail fold-par-fold. Si ai-01 l'exige pre-merge, CHANGES_REQUESTED → je le livre au prochain cycle (3 backtests : folds 2019-2021 / 2021-2023 / 2023-2025).

Closes #9803
