### PR TITLE
docs(#9831): fix last stale '34 outils' in docs/index.qmd

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -36,7 +36,7 @@ Catalogue des 21 sous-agents et 17 skills Claude Code, mapping Epic → speciali
 
 ### [Architecture MCP roo-state-manager](reference/architecture_mcp_roo.md)
 
-Architecture du MCP roo-state-manager (34 outils, RooSync), dashboards, coordination inter-machines.
+Architecture du MCP roo-state-manager (15 outils multi-actions, RooSync), dashboards, coordination inter-machines.
 
 ### [Subagents reference](reference/subagents-reference.md)
 


### PR DESCRIPTION
## Summary

PR #9832 fixed five `.md` files that published the stale "34 outils" count for `roo-state-manager`. It missed **one**: `docs/index.qmd` (Quarto documentation index), line 39.

| File | Before | After |
|------|--------|-------|
| `docs/index.qmd:39` | `(34 outils, RooSync)` | `(15 outils multi-actions, RooSync)` |

## Why "15 multi-actions" instead of just "15"

The 15→34 ratio looks implausible without context. `roo-state-manager` consolidated dozens of unit-purpose tools into multi-action families (e.g., `roosync_dashboard` alone carries `read`/`write`/`append`/`list`/`delete`/`update`/`refresh`/`read_overview`/`read_archive`). The "multi-actions" qualifier prevents the next reader from "correcting" 15 back to a higher number.

## Verification

```bash
# Before this PR:
$ grep -rn "34 outils" --include="*.md" --include="*.qmd" . | grep -i roo-state
./docs/index.qmd:39:Architecture du MCP roo-state-manager (34 outils, RooSync)...

# After:
$ grep -rn "34 outils" --include="*.md" --include="*.qmd" . | grep -i roo-state
(empty)
```

Authoritative count source: [HARNESS-OVERVIEW.md §2](https://github.com/jsboige/roo-extensions/blob/main/docs/harness/HARNESS-OVERVIEW.md) (roo-extensions repo, 42 820 octets, 361 lignes) — « `roo-state-manager` — les 15 outils », decomposé en 6 + 4 + 5.

## Scope

**1 file, +1/−1.** Catalogue byte-identique. No generated files touched.

Refs: roo-extensions#3054, CoursIA#9831, CoursIA PR #9832.

🤖 Generated with [Claude Code](https://claude.com/claude-code)