### PR TITLE
fix(notebook_tools,#9835): scope-aware extract_readme_count anchored on CATALOG-STATUS marker

### DIFF
--- a/scripts/notebook_tools/count_notebooks_by_series.py
+++ b/scripts/notebook_tools/count_notebooks_by_series.py
@@ -65,39 +65,52 @@ def count_notebooks_in_dir(
 
 
 def extract_readme_count(readme_path: Path) -> int | None:
-    """Try to extract a notebook count from a README file.
+    """Extract the AUTHORITATIVE series notebook count from a README.
 
-    Looks for patterns like "N notebooks", "N notebooks Python",
-    table rows with "Notebooks" label, or blockquote stats.
-    Returns the first plausible match (> 0).
+    Scope-aware (#9835): anchored on the generated ``<!-- CATALOG-STATUS -->``
+    marker (``pedagogical_count``, maintained daily by ``catalog-cron.yml``),
+    which is the canonical per-series total. Falls back to an explicitly-anchored
+    prose "Total" only when the marker is absent -- never the first number that
+    matches anywhere in the file. That first-match behaviour compared notebooks
+    to sub-section headers (e.g. SymbolicAI's "28 notebooks Lean" while the
+    series has 226) and to exercise counts (IIT: 53 notebooks vs "3 exercices").
+
+    A count of exercises is NOT a count of notebooks: the former prose-fallback
+    ``(\\d+)\\s+exercices`` is removed. A series with no marker and no explicit
+    Total returns None ("no count") -- an honest silence, not a number caught at
+    random.
     """
     if not readme_path.exists():
         return None
 
     text = readme_path.read_text(encoding="utf-8")
 
-    # Specific patterns ordered by reliability
-    patterns = [
-        # Blockquote: > **28 notebooks Python**
-        r"\*\*(\d+)\s*notebooks",
-        # Table row: | Notebooks | 28 |
-        r"\|\s*Notebooks?\s*\|\s*(\d+)",
-        # Inline: "28 notebooks Python"
-        r"(\d+)\s+notebooks?\s+Python",
-        # Inline: "N notebooks"
-        r"(\d+)\s+notebooks",
+    # Primary anchor: the generated CATALOG-STATUS marker (canonical,
+    # cron-maintained, per-series). See #9835.
+    marker = re.search(r"<!--\s*CATALOG-STATUS\b(.*?)-->", text, re.S)
+    if marker:
+        m = re.search(r"pedagogical_count:\s*(\d+)", marker.group(1))
+        if m:
+            val = int(m.group(1))
+            if val > 0:
+                return val
+
+    # Fallback (marker absent): an explicitly-anchored series-total in prose.
+    # Require an explicit "Total" anchor -- NOT the first "N notebooks" anywhere
+    # (often a sub-section header, e.g. "28 notebooks Lean"). See #9835.
+    for pattern in (
         # Table row: | Total | 84 |
         r"\|\s*Total\s*\|\s*(\d+)",
-        # French: "N exercices"
-        r"(\d+)\s+exercices",
-    ]
-
-    for pattern in patterns:
+        # Explicit "N notebooks total"
+        r"(\d+)\s+notebooks?\s+total",
+    ):
         match = re.search(pattern, text, re.IGNORECASE)
         if match:
             val = int(match.group(1))
             if val > 0:
                 return val
+
+    # No marker, no explicit total -> honest silence (not a random number).
     return None
 
 

--- a/scripts/notebook_tools/tests/test_count_notebooks_by_series.py
+++ b/scripts/notebook_tools/tests/test_count_notebooks_by_series.py
@@ -127,56 +127,77 @@ class TestExtractReadmeCount:
         result = extract_readme_count(tmp_path / "nonexistent.md")
         assert result is None
 
-    def test_bold_notebooks(self, tmp_path):
-        p = tmp_path / "README.md"
-        p.write_text("Some intro\n\n> **28 notebooks** Python\n", encoding="utf-8")
-        assert extract_readme_count(p) == 28
+    # --- Scope-aware behavior (#9835) -------------------------------------
+    # extract_readme_count is anchored on the generated CATALOG-STATUS marker
+    # (pedagogical_count). Bare prose numbers are NO LONGER caught: they were
+    # the bug (sub-section headers, exercise counts compared to notebooks).
 
-    def test_table_row(self, tmp_path):
-        p = tmp_path / "README.md"
-        p.write_text("| Notebooks | 45 |\n", encoding="utf-8")
-        assert extract_readme_count(p) == 45
+    _MARKER = (
+        "<!-- CATALOG-STATUS\n"
+        "series: Demo\n"
+        "pedagogical_count: {count}\n"
+        "breakdown: A=10, B={rest}\n"
+        "maturity: BETA={count}\n"
+        "-->\n"
+    )
 
-    def test_inline_notebooks_python(self, tmp_path):
+    def test_marker_primary(self, tmp_path):
+        """With a CATALOG-STATUS marker, return its pedagogical_count."""
         p = tmp_path / "README.md"
-        p.write_text("This series has 12 notebooks Python.\n", encoding="utf-8")
-        assert extract_readme_count(p) == 12
+        p.write_text(self._MARKER.format(count=226, rest=216), encoding="utf-8")
+        assert extract_readme_count(p) == 226
 
-    def test_inline_notebooks(self, tmp_path):
+    def test_marker_wins_over_misleading_prose(self, tmp_path):
+        """The SymbolicAI bug: marker total (226) must win over a sub-section
+        header '**28 notebooks**' that appears in the prose below the marker."""
         p = tmp_path / "README.md"
-        p.write_text("Contient 7 notebooks de cours.\n", encoding="utf-8")
-        assert extract_readme_count(p) == 7
+        body = self._MARKER.format(count=226, rest=216)
+        body += "\n## Lean - Verification Formelle\n\n**28 notebooks** dans cette sous-serie.\n"
+        p.write_text(body, encoding="utf-8")
+        assert extract_readme_count(p) == 226
 
-    def test_total_row(self, tmp_path):
+    def test_marker_exercices_not_caught(self, tmp_path):
+        """The IIT bug: marker total (53) must win over an 'exercices' phrase
+        that previously served as a fallback and compared notebooks to exercises."""
+        p = tmp_path / "README.md"
+        body = self._MARKER.format(count=53, rest=43)
+        body += "\nLes **3 exercices** vous font varier les sous-systemes.\n"
+        p.write_text(body, encoding="utf-8")
+        assert extract_readme_count(p) == 53
+
+    def test_total_row_fallback_no_marker(self, tmp_path):
+        """Without a marker, an explicitly-anchored '| Total | N |' still works."""
         p = tmp_path / "README.md"
         p.write_text("| Total | 84 |\n", encoding="utf-8")
         assert extract_readme_count(p) == 84
 
-    def test_exercices(self, tmp_path):
+    def test_bare_notebooks_not_caught(self, tmp_path):
+        """No marker + bare '**N notebooks**' (often a sub-section header) ->
+        None, not the first number. This is the core scope-aware fix (#9835)."""
+        p = tmp_path / "README.md"
+        p.write_text("Some intro\n\n> **28 notebooks** Python\n", encoding="utf-8")
+        assert extract_readme_count(p) is None
+
+    def test_exercices_not_caught(self, tmp_path):
+        """No marker + 'N exercices' -> None. An exercise count is not a
+        notebook count; the former fallback is removed (#9835)."""
         p = tmp_path / "README.md"
         p.write_text("La serie comprend 15 exercices.\n", encoding="utf-8")
-        assert extract_readme_count(p) == 15
+        assert extract_readme_count(p) is None
 
-    def test_no_match(self, tmp_path):
+    def test_no_marker_no_total_is_none(self, tmp_path):
+        """Honest silence: no marker and no explicit Total -> None, not a
+        number caught at random (#9835 acceptance 4)."""
         p = tmp_path / "README.md"
         p.write_text("Some random text without numbers.\n", encoding="utf-8")
         assert extract_readme_count(p) is None
 
-    def test_zero_ignored(self, tmp_path):
+    def test_marker_zero_falls_through(self, tmp_path):
+        """A marker with pedagogical_count: 0 is ignored (val > 0), and the
+        function falls through to the prose fallback (or None)."""
         p = tmp_path / "README.md"
-        p.write_text("We have 0 notebooks.\n", encoding="utf-8")
-        result = extract_readme_count(p)
-        assert result is None
-
-    def test_first_pattern_wins(self, tmp_path):
-        p = tmp_path / "README.md"
-        p.write_text("**5 notebooks** and also 10 notebooks Python.\n", encoding="utf-8")
-        assert extract_readme_count(p) == 5
-
-    def test_case_insensitive(self, tmp_path):
-        p = tmp_path / "README.md"
-        p.write_text("**28 Notebooks** in this series.\n", encoding="utf-8")
-        assert extract_readme_count(p) == 28
+        p.write_text(self._MARKER.format(count=0, rest=0), encoding="utf-8")
+        assert extract_readme_count(p) is None
 
     def test_empty_file(self, tmp_path):
         p = tmp_path / "README.md"

--- a/scripts/notebook_tools/tests/test_count_notebooks_by_series_extra.py
+++ b/scripts/notebook_tools/tests/test_count_notebooks_by_series_extra.py
@@ -121,34 +121,45 @@ class TestExtractReadmeCount:
         assert extract_readme_count(tmp_path / "nope.md") is None
 
     def test_bold_notebooks_pattern(self, tmp_path):
+        # Bare prose number (no CATALOG-STATUS marker, no explicit Total anchor)
+        # is NO LONGER caught since #9835: it was the scope bug (sub-section
+        # headers like SymbolicAI's "**28 notebooks**" Lean read as the series
+        # total). The marker is the canonical anchor now.
         readme = tmp_path / "README.md"
         readme.write_text("# Title\n\n> **28 notebooks Python**\n", encoding="utf-8")
-        assert extract_readme_count(readme) == 28
+        assert extract_readme_count(readme) is None
 
     def test_table_notebooks_pattern(self, tmp_path):
+        # Bare "| Notebooks | N |" (no marker) no longer caught (#9835).
         readme = tmp_path / "README.md"
         readme.write_text("| Metric | Value |\n| Notebooks | 42 |\n", encoding="utf-8")
-        assert extract_readme_count(readme) == 42
+        assert extract_readme_count(readme) is None
 
     def test_inline_notebooks_python(self, tmp_path):
+        # Bare inline "N notebooks Python" (no marker) no longer caught (#9835).
         readme = tmp_path / "README.md"
         readme.write_text("This series has 15 notebooks Python.\n", encoding="utf-8")
-        assert extract_readme_count(readme) == 15
+        assert extract_readme_count(readme) is None
 
     def test_inline_notebooks_generic(self, tmp_path):
+        # Bare inline "N notebooks" (no marker) no longer caught (#9835).
         readme = tmp_path / "README.md"
         readme.write_text("The collection includes 10 notebooks.\n", encoding="utf-8")
-        assert extract_readme_count(readme) == 10
+        assert extract_readme_count(readme) is None
 
     def test_table_total_pattern(self, tmp_path):
+        # Explicitly-anchored "| Total | N |" fallback is INTACT (#9835).
         readme = tmp_path / "README.md"
         readme.write_text("| Total | 84 |\n", encoding="utf-8")
         assert extract_readme_count(readme) == 84
 
     def test_french_exercices_pattern(self, tmp_path):
+        # The "(\\d+)\\s+exercices" fallback is REMOVED (#9835 acceptance 2):
+        # an exercise count is not a notebook count. This was the IIT bug
+        # (53 notebooks vs "3 exercices").
         readme = tmp_path / "README.md"
         readme.write_text("Cette serie contient 12 exercices.\n", encoding="utf-8")
-        assert extract_readme_count(readme) == 12
+        assert extract_readme_count(readme) is None
 
     def test_no_count_returns_none(self, tmp_path):
         readme = tmp_path / "README.md"
@@ -160,7 +171,9 @@ class TestExtractReadmeCount:
         pass  # This is tested implicitly — the function checks val > 0
 
     def test_bold_pattern_priority(self, tmp_path):
-        """Bold pattern should be found before generic inline."""
+        # No longer applicable: bare prose numbers are not caught at all since
+        # #9835, so there is no "priority" between bare-prose patterns. The
+        # only priority is: CATALOG-STATUS marker > explicit Total > None.
         readme = tmp_path / "README.md"
         readme.write_text("**5 notebooks** and also mentions 99 notebooks elsewhere.", encoding="utf-8")
-        assert extract_readme_count(readme) == 5
+        assert extract_readme_count(readme) is None


### PR DESCRIPTION
## Summary

Grain: MED/notebook-tools (primitive fix) — lane myia-po-2026:CoursIA — Dispatch ai-01 (#9835) — See #9835

`extract_readme_count` retournait le **premier nombre** matchant un motif prose **où que ce soit** dans le README, sans notion de portée. Sur 9/10 séries il attrapait un en-tête de sous-section ou un compte d'exercices au lieu du total de la série : SymbolicAI 280 vs 28 (en-tête `**28 notebooks**` sous-section Lean), QuantConnect 219 vs 29 (`29 notebooks Python` = une piste de 219), IIT 53 vs 3 (`3 exercices` attrapé par le fallback final). Ce sont des **erreurs de catégorie**, pas des dérives de fraîcheur. #9826 n'était que le symptôme visible (Search était la seule série où le premier match tombait sur le vrai total — par chance).

## Correctif scope-aware (acceptance 1)

Ancrage sur le marqueur généré `<!-- CATALOG-STATUS -->` (`pedagogical_count`, maintenu quotidiennement par `catalog-cron.yml`, présent sur les 10 séries), repli sur un Total prose explicitement ancré **seulement** si le marqueur est absent. Les nombres prose « nus » ne sont plus attrapés. Le fallback `(\d+)\s+exercices` est **retiré** (acceptance 2) — un compte d'exercices n'est pas un compte de notebooks.

## Tableau avant/après (acceptance 3, mesuré sur main, mode pédagogique)

```
Series        disk   buggy   new   buggy_status  new_status
GenAI          141     141    141   OK            OK
Search         116     116    116   OK            OK
ML              48      10     48   MISMATCH      OK
SymbolicAI     226      28    226   MISMATCH      OK
QuantConnect   106      29    106   MISMATCH      OK
GameTheory      50       7     55   MISMATCH      MISMATCH (vraie dérive: marker=55, disk=50)
Sudoku          37      18     37   MISMATCH      OK
Probas          58      58     58   OK            OK
IIT             53       3     53   MISMATCH      OK
RL              17      17     17   OK            OK
MISMATCH count: buggy=6  new=1
```

Le 1 MISMATCH restant (GameTheory) est une petite dérive réelle et explicable — exactement le signal honnête que le gate doit émettre. Sortie `--check-readme` en direct post-fix : 9 OK + 1 GameTheory MISMATCH. Une série sans marqueur et sans Total explicite retourne `None` ("no count") — un silence honnête (acceptance 4).

## Détails

- `count_notebooks_by_series.py`: `extract_readme_count` réécrite (+ marqueur primaire, repli Total prose seulement, repli exercices retiré).
- `test_count_notebooks_by_series.py`: `TestExtractReadmeCount` réécrite — la classe encodait l'ANCIEN comportement unscoped (`test_bold_notebooks`, `test_exercices`, `test_first_pattern_wins`…). Remplacée par 9 tests scope-aware : marker primaire, marker-wins-over-misleading-prose (cas SymbolicAI), exercices-not-caught (cas IIT), total-row-fallback-no-marker, bare-notebooks-not-caught, no-marker-no-total-is-none.
- **60 tests passent, 0 régression** (25 count-notebooks-by-series + 11 count-by-subdir #9829 inchangés + 24 verify-catalog-readme).
- LF-only (0 CRLF), pas d'erreur whitespace.

## Attribution

Finding: **po-2024** (en marge de son yield #9830). Vérification firsthand + instruction des 3 cas : ai-01. Dispatch vers po-2026 : ai-01 (#9835 body — « contexte frais post-#9829 »). `See #9835` (le crédit de découverte revient à po-2024, porté explicitement dans le corps de l'issue).

See #9835

🤖 Generated with [Claude Code](https://claude.com/claude-code)
