### PR TITLE
fix(genai,#8364): correct SK-08 notebook count claim 18->19 (markdown-prior drift)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/08-SemanticKernel-MCP.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/08-SemanticKernel-MCP.ipynb
@@ -912,7 +912,7 @@
     "\n",
     "**Requête utilisateur** : \"Liste les fichiers Python dans le répertoire courant\"\n",
     "\n",
-    "**Résultat obtenu** : L'agent identifie 18 notebooks `.ipynb` (contenant du Python) au lieu de fichiers `.py`\n",
+    "**Résultat obtenu** : L'agent identifie 19 notebooks `.ipynb` (contenant du Python) au lieu de fichiers `.py`\n",
     "\n",
     "| Étape | Action de l'agent | Outil utilisé |\n",
     "|-------|-------------------|---------------|\n",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/qc #9837

## Ce que fait cette PR

Corrige un claim quantitatif erroné dans le notebook `08-SemanticKernel-MCP.ipynb` : l'interprétation md[22] affirmait « L'agent identifie **18** notebooks `.ipynb` » alors que l'output committé code[19] (vraie réponse d'agent GPT listant le dossier SemanticKernel) en liste **19**. Off-by-one, aligné markdown ↔ output (#8364 markdown-prior drift).

## Diagnostic dérive (#8364, §D obligatoire)

- **Recomptage strict firsthand** : l'output code[19] contient exactement **19** lignes `- <name>.ipynb` (01-SemanticKernel-Intro … Workbook-Template), pas 18.
- **Cause** : **(b) claim antérieure fabriquée / markdown-prior obsolète.** Le run code[19] est réel et déterministe (l'agent liste le contenu réel du dossier `GenAI/SemanticKernel/`, qui contient 19 notebooks `.ipynb`). Le markdown md[22] portait un compte erroné (18) — soit erreur de compte initiale, soit le dossier avait 18 notebooks au moment de la rédaction puis un 19e a été ajouté et le run re-exécuté sans mettre à jour le markdown.
- **Verdict** : `CAUSE_FIXED`. La valeur ré-alignée (19) est un **compte d'items** tiré de l'output committé (vérité du run réel stable), pas un nombre de perf/timing/coût re-exécutable — l'aligner au markdown est la correction fidèle, pas une consécration.
- **Pas case (B) degraded run** : l'output code[19] montre une vraie réponse d'agent GPT (ton professionnel, liste structurée, suggestions) — pas un run dégradé/skippé.

## Périmètre (1 fichier, atomique, byte-surgical)

- `08-SemanticKernel-MCP.ipynb` (+1/−1) : md[22] « 18 notebooks » → « 19 notebooks ». **Byte-surgical raw text-replace** (pas de `json.dumps` round-trip → 0 churn sur les 28 autres cellules, MEMORY `nbformat-write-churns-untouched-cells`).
- Chaîne source « 18 notebooks » vérifiée **unique** dans le fichier (1 occurrence brute, 0 « 19 notebooks » avant fix). L'occurrence « 18 » indépendante de md[9] (« Node.js 18+ ») n'est pas touchée (prérequis système, pas un mismatch).

## Validation

- JSON valide (29 cellules préservées), LF-only (0 CRLF), 0 `execution_count: null` introduit (H.3 OK).
- C.2 exception **markdown-only** : la modification ne touche aucune cellule code ni output → aucune re-exécution requise. Le diagnostic #8364 ci-dessus documente la cause.
- Catalogue byte-identique à main (R1 ✓) — seul le notebook est modifié.
- L898 ★★★ collision guard clean : 0 PR (open/all, repo jsboige/CoursIA) sur le path `SemanticKernel/08-*` ; po-2023 actif sur SK-01/02/03 seulement (PR #8449/#8452/#9083).

## Contexte veine

SK-06 (ProcessFramework) audité FAITHFUL ce cycle (ne PAS re-miner) : md[2] fidèle au code code[1] (`OpenAIChatCompletion(service_id="default")`), md[12]/[17] matchent outputs (1039/822 caracteres, True, 1/3 iterations), stubs C.1 conformes. Pattern MEMORY confirmé : SK au-delà de 01/02/07 soigneusement écrit. SK-08 était le seul defect trouvé (count off-by-one).

See #8364 (partial — 1 notebook). See #8052 (claims↔outputs audit).
