### PR TITLE
fix(guard,#9399): metadata-only blob churn is informational, not a red gate

### DIFF
--- a/.github/workflows/twin-parity-cron.yml
+++ b/.github/workflows/twin-parity-cron.yml
@@ -12,6 +12,15 @@ name: Twin Parity Cron (CI-derived SHA, #9399 volet b)
 # ok_legacy / ok_content / drift_blob / drift_content /
 # drift_legacy_after_content / missing_python / missing_csharp / no_audit.
 #
+# `drift_legacy_after_content` (blob SHA bouge, content_sha identique) est
+# INFORMATIF et ne rougit PAS : `_content_sha` hache les cellules ET leurs
+# outputs en n'excluant que `nb["metadata"]`, donc ce cas ne peut signifier que
+# du churn de metadata carnet (cost / papermill / kernelspec) -- precisement le
+# faux positif que le volet c elimine. Ne PAS le re-inclure dans le total
+# bloquant : le 2026-08-07 il rougissait main pour Sudoku-8/14 BDD avec un
+# `::error ...::<none>` sans nom de paire, et son remede prescrit (`--update`)
+# refusait en no-op par design. Le gate rougit sur `n_blocking_drift`.
+#
 # Distinction outil-erreur vs constat-drift : exigence c.1240 + L948/L949.
 # Si stdout JSON est parsable mais contient des drift, on ROUGE (exit 1)
 # mais on emet un `::error` avec le NOM des paires touchees (actionnable).

--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -1465,12 +1465,30 @@ def main(argv=None) -> int:
                 if content_py_drift or content_cs_drift:
                     cat["n_drift_content"] += 1
                 elif blob_py_drift or blob_cs_drift:
-                    # Strip outille probable (volet c detecte le strip)
+                    # Churn metadata-only carnet : INFORMATIF, jamais bloquant.
+                    # `_content_sha` hache les cellules ET leurs outputs, en
+                    # n'excluant que `nb["metadata"]` (cost / papermill /
+                    # kernelspec / language_info). Donc « blob bouge, content
+                    # identique » ne peut signifier QUE du churn de metadata
+                    # carnet -- exactement le faux positif que le volet c a ete
+                    # construit pour tuer (cf docstring de `_content_sha`).
+                    # Rougir ici le re-fabriquerait au niveau du cron : incident
+                    # du 2026-08-07, cron rouge sur main pour Sudoku-8/14 BDD --
+                    # les 2 paires nommees dans cette meme docstring -- avec un
+                    # `::error ...::<none>` qui ne designait aucune paire (leur
+                    # `status` reste OK, donc `_cron_extract_drift` n'en listait
+                    # aucune). Et le remede prescrit (`--update`) est un NO-OP
+                    # par design puisque `_shas_match` compare les content_sha :
+                    # un gate que son propre remede ne peut pas eteindre.
                     cat["n_drift_legacy_after_content"] += 1
+                    entry_ci["metadata_only_blob_drift"] = True
                     entry_ci["details"].append(
-                        "blob SHA drift MAIS content_sha OK : strip outille probable "
-                        "(strip_probe_banner / strip_machine_paths / scrub_papermill) "
-                        "sans --update ulterieur. Refaire --update en dernier, cf #8957."
+                        "blob SHA drift MAIS content_sha OK : churn metadata-only "
+                        "(metadata.cost / papermill / kernelspec) -- aucune divergence "
+                        "pedagogique. INFORMATIF : ne fait pas rougir le gate. "
+                        "`--update` est un no-op par design ici (il compare les "
+                        "content_sha) ; re-tamponner le blob SHA exigerait --force et "
+                        "n'apporterait aucune information nouvelle (cf #9399 critere 2)."
                     )
                 else:
                     cat["n_ok_content"] += 1
@@ -1482,10 +1500,15 @@ def main(argv=None) -> int:
 
             ci_results.append(entry_ci)
 
-        n_total_drift = (cat["n_drift_blob"] + cat["n_drift_content"]
-                         + cat["n_drift_legacy_after_content"]
-                         + cat["n_missing_python"] + cat["n_missing_csharp"]
-                         + cat["n_no_audit"])
+        # Anomalies BLOQUANTES (celles qui font rougir le gate).
+        # `n_drift_legacy_after_content` en est volontairement EXCLU : blob
+        # bouge + content identique == churn metadata-only, informatif (cf la
+        # classification ci-dessus). `n_total_drift` reste le total de TOUTES
+        # les anomalies, pour le reporting.
+        n_blocking_drift = (cat["n_drift_blob"] + cat["n_drift_content"]
+                            + cat["n_missing_python"] + cat["n_missing_csharp"]
+                            + cat["n_no_audit"])
+        n_total_drift = n_blocking_drift + cat["n_drift_legacy_after_content"]
 
         if args.json:
             out = {
@@ -1497,6 +1520,7 @@ def main(argv=None) -> int:
                 "missing_total": n_missing,
                 "ci_strict": cat,
                 "n_total_drift": n_total_drift,
+                "n_blocking_drift": n_blocking_drift,
                 "pairs": ci_results,
             }
             print(json.dumps(out, ensure_ascii=False, indent=2))
@@ -1512,9 +1536,22 @@ def main(argv=None) -> int:
                     print(f"  [{r['status']}] {r['name']} ({r['family']}, {r['parity_level']})")
                     for d in r["details"]:
                         print(f"       - {d}")
+            # Les paires en churn metadata-only gardent `status == OK` (aucune
+            # divergence pedagogique) : sans cette boucle elles ne seraient
+            # nommees NULLE PART, et un compteur non nul sans nom n'est pas
+            # actionnable (c'est le `::error ...::<none>` du 2026-08-07).
+            for r in ci_results:
+                if r.get("metadata_only_blob_drift"):
+                    print(f"  [INFO metadata-only] {r['name']} "
+                          f"({r['family']}, {r['parity_level']})")
+                    for d in r["details"]:
+                        print(f"       - {d}")
 
-        # CI gate : rouge sur n'importe quel drift (le but du cron fleet-wide)
-        if args.check and n_total_drift > 0:
+        # CI gate : rouge sur les anomalies BLOQUANTES uniquement (le but du
+        # cron fleet-wide). Le churn metadata-only est compte et nomme, mais
+        # ne rougit pas -- sinon on re-fabrique le faux positif que le volet c
+        # a elimine, et sur un gate dont le remede prescrit est un no-op.
+        if args.check and n_blocking_drift > 0:
             return 1
         return 0
 

--- a/scripts/notebook_tools/tests/test_check_twin_parity_ci_sha.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_ci_sha.py
@@ -348,3 +348,152 @@ def test_ci_strict_and_verify_recorded_sha_are_mutually_exclusive():
     """
     with pytest.raises(SystemExit):
         ctp.main(["--ci-strict", "--verify-recorded-sha"])
+
+# --- 5. churn metadata-only : INFORMATIF, jamais bloquant ---------------------
+#
+# `_content_sha` hache les cellules ET leurs outputs, en n'excluant que
+# `nb["metadata"]`. Donc « blob SHA bouge / content_sha identique » ne peut
+# signifier QUE du churn de metadata carnet (cost, papermill, kernelspec) --
+# exactement le faux positif que le volet c a ete construit pour tuer. Le gate
+# ne doit donc PAS rougir dessus, sinon il le re-fabrique au niveau du cron.
+#
+# Incident fondateur : cron rouge sur main le 2026-08-07 pour Sudoku-8 et
+# Sudoku-14 BDD (les 2 paires nommees dans la docstring de `_content_sha`),
+# avec un `::error DRIFT DETECTED::<none>` qui ne designait aucune paire, et
+# dont le remede prescrit (`--update`) refusait en no-op par design.
+
+def test_metadata_only_churn_is_not_blocking(tmp_path):
+    """Seul `metadata.cost` bouge -> blob drift, content OK -> exit 0."""
+    repo = _git_repo(tmp_path)
+    py_rel = "py/nb.ipynb"
+    cs_rel = "cs/nb.ipynb"
+
+    _commit(repo, py_rel, _nb(source=["# Title\n"], cost=0.10), "base py")
+    _commit(repo, cs_rel, _nb(source=["// Title\n"]), "base cs")
+    py_blob_v1 = ctp._git_blob_sha(repo, py_rel)
+    cs_blob_v1 = ctp._git_blob_sha(repo, cs_rel)
+    py_content_v1 = ctp._content_sha(repo, py_rel)
+    cs_content_v1 = ctp._content_sha(repo, cs_rel)
+
+    pairs_dir = tmp_path / "twin_pairs.d"
+    pairs_dir.mkdir()
+    _make_pair_yaml_with_content_sha(
+        pairs_dir, "Search-A", py_rel, cs_rel,
+        py_blob_v1, cs_blob_v1, py_content_v1, cs_content_v1
+    )
+
+    # Re-tampon du seul bloc `metadata.cost` : les CELLULES sont intactes.
+    _commit(repo, py_rel, _nb(source=["# Title\n"], cost=0.42), "cost stamp")
+    assert ctp._git_blob_sha(repo, py_rel) != py_blob_v1, "le blob doit bouger"
+    assert ctp._content_sha(repo, py_rel) == py_content_v1, (
+        "le content_sha doit etre STABLE (metadata carnet exclue)"
+    )
+
+    rc = ctp.main([
+        "--ci-strict", "--check", "--json",
+        "--registry", str(pairs_dir),
+        "--repo-root", str(repo),
+    ])
+    assert rc == 0, (
+        f"churn metadata-only ne doit PAS rougir le gate (faux positif que le "
+        f"volet c elimine, et dont le remede --update est un no-op), rc={rc}"
+    )
+
+
+def test_metadata_only_churn_is_counted_and_named(tmp_path):
+    """Non bloquant MAIS compte et NOMME : un compteur sans nom n'est pas actionnable."""
+    repo = _git_repo(tmp_path)
+    py_rel = "py/nb.ipynb"
+    cs_rel = "cs/nb.ipynb"
+
+    _commit(repo, py_rel, _nb(source=["# Title\n"], cost=0.10), "base py")
+    _commit(repo, cs_rel, _nb(source=["// Title\n"]), "base cs")
+    py_blob_v1 = ctp._git_blob_sha(repo, py_rel)
+    cs_blob_v1 = ctp._git_blob_sha(repo, cs_rel)
+    py_content_v1 = ctp._content_sha(repo, py_rel)
+    cs_content_v1 = ctp._content_sha(repo, cs_rel)
+
+    pairs_dir = tmp_path / "twin_pairs.d"
+    pairs_dir.mkdir()
+    _make_pair_yaml_with_content_sha(
+        pairs_dir, "Search-A", py_rel, cs_rel,
+        py_blob_v1, cs_blob_v1, py_content_v1, cs_content_v1
+    )
+    _commit(repo, py_rel, _nb(source=["# Title\n"], cost=0.42), "cost stamp")
+
+    import io
+    from contextlib import redirect_stdout
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = ctp.main([
+            "--ci-strict", "--json",
+            "--registry", str(pairs_dir),
+            "--repo-root", str(repo),
+        ])
+    assert rc == 0
+    out = json.loads(buf.getvalue())
+    ci = out["ci_strict"]
+    assert ci["n_drift_legacy_after_content"] == 1, (
+        f"le churn doit rester COMPTE (visibilite), got {ci}"
+    )
+    assert out["n_blocking_drift"] == 0, (
+        f"mais hors du total bloquant, got n_blocking_drift={out['n_blocking_drift']}"
+    )
+    assert out["n_total_drift"] == 1, (
+        "n_total_drift reste le total de TOUTES les anomalies (reporting)"
+    )
+    named = [p for p in out["pairs"] if p.get("metadata_only_blob_drift")]
+    assert len(named) == 1 and named[0]["name"] == "Search-A", (
+        f"la paire doit etre NOMMEE (sinon `::error ...::<none>`), got {named}"
+    )
+
+
+def test_real_content_drift_still_blocks_alongside_metadata_churn(tmp_path):
+    """Garde-fou anti-desserrage : une vraie divergence de contenu rougit toujours."""
+    repo = _git_repo(tmp_path)
+    pairs_dir = tmp_path / "twin_pairs.d"
+    pairs_dir.mkdir()
+
+    # Paire A : churn metadata-only (informatif)
+    _commit(repo, "a/py.ipynb", _nb(source=["# A\n"], cost=0.10), "a py")
+    _commit(repo, "a/cs.ipynb", _nb(source=["// A\n"]), "a cs")
+    _make_pair_yaml_with_content_sha(
+        pairs_dir, "Search-A", "a/py.ipynb", "a/cs.ipynb",
+        ctp._git_blob_sha(repo, "a/py.ipynb"),
+        ctp._git_blob_sha(repo, "a/cs.ipynb"),
+        ctp._content_sha(repo, "a/py.ipynb"),
+        ctp._content_sha(repo, "a/cs.ipynb"),
+    )
+    _commit(repo, "a/py.ipynb", _nb(source=["# A\n"], cost=0.42), "a cost stamp")
+
+    # Paire B : vraie edition de prose (content_sha bouge) -> doit rougir
+    _commit(repo, "b/py.ipynb", _nb(source=["# B\n"]), "b py")
+    _commit(repo, "b/cs.ipynb", _nb(source=["// B\n"]), "b cs")
+    _make_pair_yaml_with_content_sha(
+        pairs_dir, "Search-B", "b/py.ipynb", "b/cs.ipynb",
+        ctp._git_blob_sha(repo, "b/py.ipynb"),
+        ctp._git_blob_sha(repo, "b/cs.ipynb"),
+        ctp._content_sha(repo, "b/py.ipynb"),
+        ctp._content_sha(repo, "b/cs.ipynb"),
+    )
+    _commit(repo, "b/py.ipynb", _nb(source=["# B modifie\n"]), "b prose edit")
+
+    import io
+    from contextlib import redirect_stdout
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = ctp.main([
+            "--ci-strict", "--check", "--json",
+            "--registry", str(pairs_dir),
+            "--repo-root", str(repo),
+        ])
+    assert rc == 1, "une divergence pedagogique reelle doit TOUJOURS rougir"
+    out = json.loads(buf.getvalue())
+    ci = out["ci_strict"]
+    assert ci["n_drift_content"] == 1, f"Search-B doit etre drift_content, got {ci}"
+    assert ci["n_drift_legacy_after_content"] == 1, (
+        f"Search-A doit rester informatif, got {ci}"
+    )
+    assert out["n_blocking_drift"] == 1, (
+        f"seule Search-B est bloquante, got {out['n_blocking_drift']}"
+    )


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: LIGHT/docs #9839

## Symptôme

`Twin Parity Cron` rouge sur `main` (run du 2026-08-07 06:41:43Z, commit `db3a1812`), avec un `::error` qui **ne nommait aucune paire** :

```
::error title=Twin parity CI-strict DRIFT DETECTED::<none>
```

## Diagnostic (mesuré firsthand, pas déduit)

Reproduit localement — `REAL_EXIT=1` alors que `drift_blob=0` / `drift_content=0` :

```
[CI-STRICT] 156 paire(s) | ok_legacy=104 ok_content=50 drift_blob=0 drift_content=0
                           drift_legacy_after_content=2 missing_py=0 missing_cs=0 no_audit=0
```

Le rouge venait entièrement de `n_drift_legacy_after_content=2` : **Sudoku-14 BDD** et **Sudoku-8 HumanStrategies**. SHAs mesurés :

| Carnet | blob courant | blob enregistré | verdict |
|---|---|---|---|
| Sudoku-14-BDD-Python | `8672bbe7` | `876c046c` | DRIFT |
| Sudoku-14-BDD-Csharp | `64a6263d` | `64a6263d` | MATCH |
| Sudoku-8-…-Python | `c51f3d8f` | `2e2639b5` | DRIFT |
| Sudoku-8-…-Csharp | `44d99632` | `44d99632` | MATCH |

Les `content_sha` sont identiques des deux côtés. Or `_content_sha` (volet c) **hache les cellules ET leurs outputs**, en n'excluant que `nb["metadata"]` (cost / papermill / kernelspec / language_info). Donc « blob bouge + content identique » ne peut signifier **que** du churn de metadata carnet — et la docstring de `_content_sha` nomme littéralement ces deux paires comme les faux positifs que le volet c a été écrit pour tuer :

> « les 2 faux positifs Sudoku-8/14 BDD du 2026-08-04, ou seul le bloc cost a bouge »

Le gate cron re-fabriquait donc, au niveau fleet-wide, exactement le faux positif que le volet c élimine au niveau par-PR.

### Le remède prescrit ne pouvait pas éteindre le gate

Le message actionnable disait « Refaire `--update` en dernier, cf #8957 ». Or `--update` **refuse en no-op par design** dans ce cas : `_shas_match` compare les SHAs renvoyés par `_cmp_pair_shas`, qui **préfère les `content_sha`** (inchangés). Sortie réelle :

```
Refusees (no-op, --update facultatif post-volet-b : les SHAs enregistres sont deja ceux
du carnet a HEAD) : Sudoku-14 BDD
0 paire(s) mise(s) a jour
```

C'était donc **un gate dont le propre remède prescrit est structurellement incapable de l'éteindre** — même classe que #9819 / #9826. Le seul contournement, `--force`, écrit une attestation dont l'information nouvelle se réduit au blob SHA, et accuse au passage l'opérateur de fabriquer un « faux audit au sens du design-gate #9399 critère 2 » — accusation elle-même fausse ici (l'entrée écrite *diffère* bien, sur `python_sha`), mais qui confirme que la garde no-op ignore les blob SHAs.

## Correctif

1. **`n_drift_legacy_after_content` devient informatif** : exclu de `n_blocking_drift` (nouveau champ, celui sur lequel le gate rougit), conservé dans `n_total_drift` pour le reporting.
2. **Les paires concernées sont désormais NOMMÉES** : elles gardent `status == "OK"` (aucune divergence pédagogique), donc `_cron_extract_drift` ne les listait pas — d'où le `::none>`. Une ligne `[INFO metadata-only] <paire>` + le flag JSON `metadata_only_blob_drift` les rendent visibles. Un compteur non nul sans nom n'est pas actionnable.
3. **Message corrigé** : il disait « strip outillé probable […] refaire `--update` ». Il dit maintenant la vérité — churn metadata-only, non bloquant, `--update` no-op par design.
4. En-tête de `twin-parity-cron.yml` documente la sémantique, pour qu'un futur lecteur ne re-serre pas le gate.

**Le registre n'est pas touché.** J'avais d'abord restampé les 2 paires avec `--force` (ça éteignait le rouge), puis je l'ai reverté : affirmer « le drift blob-only n'est pas un drift » tout en enregistrant une attestation blob-only serait incohérent, et c'est précisément le faux audit que #9399 critère 2 interdit.

## Vérification

Registre réel, **sans** restamp :

```
REAL_EXIT=0
[CI-STRICT] 156 paire(s) | ok_legacy=104 ok_content=50 drift_blob=0 drift_content=0
                           drift_legacy_after_content=2 ...
  [INFO metadata-only] Sudoku-14 BDD (Sudoku, semantic)
  [INFO metadata-only] Sudoku-8 HumanStrategies (Sudoku, semantic)
```

Tests — 3 ajoutés, dont un **garde-fou anti-desserrage** :

- `test_metadata_only_churn_is_not_blocking` — seul `metadata.cost` bouge → exit 0
- `test_metadata_only_churn_is_counted_and_named` — compté (`n_drift_legacy_after_content == 1`), hors total bloquant (`n_blocking_drift == 0`), **nommé**
- `test_real_content_drift_still_blocks_alongside_metadata_churn` — 2 paires, une en churn metadata / une en vraie édition de prose → **rougit toujours** (`n_blocking_drift == 1`)

```
scripts/notebook_tools/tests/test_check_twin_parity_ci_sha.py  11 passed
pytest -k twin                                                 94 passed
```

Le garde-fou n° 3 est la raison de ne pas craindre un desserrage : une re-exécution (outputs modifiés) ou un fix de prose bougent le `content_sha` et rougissent comme avant.

See #9399 (volet b)
