### PR TITLE
Add resync-only CI advisory for translations/*.csv (#6949 second half)

### DIFF
--- a/scripts/translation/README.md
+++ b/scripts/translation/README.md
@@ -84,6 +84,8 @@ python scripts/translation/check_translation_sync.py translations/ --check
 
 En phase POC (T1, seule la colonne pivot est remplie), le script ne remonte que du `SRC_DRIFT` éventuel ; l'absence de traductions déposées n'est pas un drift (c'est l'état attendu pré-T3). Le pivot (`fr`) étant le notebook source lui-même, sa cohérence est couverte par `SRC_DRIFT` — pas de faux `MISSING_LANG` sur le pivot.
 
+**Advisory resync-only** (`scripts/translation/check_resync_only.py`, #6949 second half) : un PR qui ne touche QUE `translations/**/*.csv` ET n'ajoute aucun contenu `text_<lang>`/`hash_<lang>` (lang ∈ {en,es,ar,fa,zh,ru,pt}) est signalé `::notice` non-bloquant (cf [ruling coordinateur 2026-07-28](https://github.com/jsboige/CoursIA/issues/6949#issuecomment-2328497962) — « plus de PR resync-only jusqu'au GO moteur »). Le pivot `text_fr`/`hash_fr` reste autorisé (but légitime du resync).
+
 **Harmonisation taxonomie Argumentum (#6949)** : ce script couvre désormais 4 des 5 classes de drift du fork `multilingual-drift-audit.py` — `MISSING`/`ORPHAN` (MISSING_LANG/ORPHAN_ROW), `WRONG_SCRIPT` (script Unicode attendu absent, c.734 #7714), `FR_CONTAM` (c.738). La 5e classe `COGNATE` (noms propres / faux-amis légitimement répétés, `kind == "name"`, **informationnelle** — hors `total_drift` dans le fork) est **N/A** par construction : notre modèle est cell-based (pas de distinction name/prose).
 
 ## CI

--- a/scripts/translation/check_resync_only.py
+++ b/scripts/translation/check_resync_only.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Detect "resync-only" PRs touching translations/**/*.csv without depositing
+translations (#6949 second half, c.9717).
+
+A "resync-only" PR satisfies BOTH:
+
+1. ALL changed files match ``translations/**/*.csv`` (no notebook change, no
+   script change, no doc change). A normal resync of T1 (extract) after an
+   accent-cure campaign or a notebook rename lands exactly here.
+2. NONE of the diff hunks add content in a ``text_<lang>`` or ``hash_<lang>``
+   column for lang ∈ {en, es, ar, fa, zh, ru, pt} (the 7 target languages).
+   Pure ``text_fr`` / ``hash_fr`` refresh (the source pivot) is allowed and is
+   in fact the entire purpose of the resync.
+
+Pattern measured on the 8 resync PRs that landed between 2026-07-21 and
+2026-07-25 (#7577, #7695, #7772, #7773, #7806, #7916, #7949, #8431):
+each one was a single CSV file with insertions ≈ deletions and zero
+content in any non-fr column.
+
+This script is a **CI advisory, non-blocking** by design. It codifies ai-01's
+coordinator ruling of 2026-07-28 (issue #6949, see c.757 for context):
+"plus de PR *resync-only* sur ``translations/**/*.csv`` jusqu'au GO moteur".
+The ruling remains a coordinator decision — this advisory only surfaces it at
+merge-gate review time so a human reviewer (or ai-01) can re-confirm the
+intentionality of a resync against current policy.
+
+Exit codes:
+- 0: PR is NOT resync-only (or no diff to inspect).
+- 0 with ``verdict: "resync_only"`` in the JSON: PR IS resync-only. CI prints
+  a notice annotation; merge is **NOT** blocked (ai-01 policy).
+- 2: usage error (CLI).
+
+Stdlib-only (csv/json/subprocess/sys/pathlib/argparse/dataclasses).
+Hermetic — does not call out to LLM, network, or filesystem outside the
+provided ``--diff-range`` git invocation and the CSV headers (read inline).
+
+Usage (CI):
+    python scripts/translation/check_resync_only.py \
+        --diff-range origin/main...HEAD
+
+Usage (one-off, against a recorded range):
+    python scripts/translation/check_resync_only.py \
+        --diff-range origin/main...refs/pull/9842/head
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import dataclasses
+import io
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+ALL_LANGS = ("en", "es", "ar", "fa", "zh", "ru", "pt")
+PIVOT_LANG = "fr"
+
+# ``translations/...csv`` paths only. Anything else (a notebook .ipynb, a
+# script, a doc) breaks the "resync-only" verdict immediately.
+TRANSLATIONS_RE = re.compile(r"^translations/.*\.csv$")
+
+
+@dataclasses.dataclass
+class FileDiff:
+    """One file in a ``git diff --stat`` output."""
+
+    path: str
+    insertions: int
+    deletions: int
+
+
+@dataclasses.dataclass
+class Report:
+    """Advisory verdict for one PR."""
+
+    diff_range: str
+    changed_files: list[FileDiff]
+    translations_only: bool
+    lang_columns_added: list[str]  # empty = no translation content added
+    verdict: str  # "resync_only" | "ok"
+    policy_url: str = (
+        "https://github.com/jsboige/CoursIA/issues/6949#issuecomment-2328497962"
+    )
+
+    def to_json(self) -> dict:
+        return {
+            "diff_range": self.diff_range,
+            "changed_files": [dataclasses.asdict(f) for f in self.changed_files],
+            "translations_only": self.translations_only,
+            "lang_columns_added": self.lang_columns_added,
+            "verdict": self.verdict,
+            "policy_url": self.policy_url,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Git diff parsing
+# ---------------------------------------------------------------------------
+
+def _git_changed_files(diff_range: str) -> list[FileDiff]:
+    """Run ``git diff --stat`` for the range and parse file-level changes.
+
+    Lines look like::
+
+        translations/planners/planners.csv | 394 +++---
+        1 file changed, 394 insertions(+), 394 deletions(-)
+
+    We only need ``path``, ``insertions``, ``deletions`` per file. We do not
+    fail on renames (``=>``) because renames are not the target case.
+    """
+    proc = subprocess.run(
+        ["git", "diff", "--stat", diff_range, "--"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"git diff --stat {diff_range!r} failed (exit {proc.returncode}): "
+            f"{proc.stderr.strip()}"
+        )
+    files: list[FileDiff] = []
+    for line in proc.stdout.splitlines():
+        if not line or "|" not in line:
+            continue
+        # Skip summary line(s) ("N file(s) changed, ... +/-")
+        if "file" in line.split("|", 1)[1] and "+/-" in line:
+            continue
+        left, right = line.split("|", 1)
+        path = left.strip()
+        right = right.strip()
+        plus = right.count("+")
+        minus = right.count("-")
+        files.append(FileDiff(path=path, insertions=plus, deletions=minus))
+    return files
+
+
+def _git_added_lines(diff_range: str, paths: Iterable[str]) -> str:
+    """Return the ``+``-side of the unified diff for the given paths.
+
+    Useful to inspect which columns gained content. We use ``--diff-filter=AM``
+    (Added + Modified) to ignore deletions (they cannot add a translation)
+    and ``-U0`` to keep the diff terse.
+    """
+    cmd = [
+        "git", "diff", "-U0", "--diff-filter=AM", diff_range, "--",
+        *paths,
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8",
+                          check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"git diff -U0 --diff-filter=M {diff_range!r} failed "
+            f"(exit {proc.returncode}): {proc.stderr.strip()}"
+        )
+    return proc.stdout
+
+
+def _csv_columns() -> list[str]:
+    """Canonical CSV header (single source of truth, see check_translation_sync)."""
+    langs = list(ALL_LANGS)
+    cols = [
+        "notebook", "cell_id", "cell_type", "src_lang", "src_hash",
+        "text_fr",
+    ]
+    cols += [f"text_{L}" for L in langs]
+    cols += ["hash_fr"]
+    cols += [f"hash_{L}" for L in langs]
+    return cols
+
+
+def _added_lang_columns(diff_text: str) -> list[str]:
+    """Find which ``text_<lang>``/``hash_<lang>`` columns gained non-empty content.
+
+    We accept the very first line of an added CSV row as evidence of "added
+    translation content"; a same-row text_fr and text_en update counts as both
+    fr (legitimate) and en (genuine translation), so this detector would
+    correctly NOT flag it.
+
+    The detector does NOT chase cell-level edits: it only checks whether the
+    diff added any non-empty content in any non-fr column. That is sufficient
+    to discriminate resync-only PRs (where columns 7-13 stay empty) from a
+    genuine T3 deposit (which would add content in column 7+).
+    """
+    cols = _csv_columns()
+    target_cols = {c for c in cols if c.startswith(("text_", "hash_"))
+                   and not c.endswith(f"_{PIVOT_LANG}")}
+    # We parse diff hunks. Each hunk starts with @@ -A,B +C,D @@, then ``+``
+    # lines. CSV row lines start with a notebook path (contains ``.ipynb``)
+    # followed by comma-separated quoted/unquoted fields.
+    found: set[str] = set()
+    hunk_re = re.compile(r"^\+\+\+\s", re.MULTILINE)
+    if not hunk_re.search(diff_text):
+        return []
+    # Split per added hunk body (lines starting with ``+`` but NOT ``+++``).
+    for line in diff_text.splitlines():
+        if not line.startswith("+"):
+            continue
+        if line.startswith("+++"):  # hunk header
+            continue
+        body = line[1:]
+        if not body:
+            continue
+        # CSV row — parse with stdlib csv on the body alone.
+        try:
+            row = next(csv.reader(io.StringIO(body)))
+        except csv.Error:
+            continue
+        if len(row) != len(cols):
+            continue  # malformed / header / not a row
+        if row[0] == cols[0]:
+            continue  # the canonical CSV header (its values ARE col names)
+        for idx, col in enumerate(cols):
+            if col in target_cols and row[idx].strip():
+                found.add(col)
+    return sorted(found)
+
+
+# ---------------------------------------------------------------------------
+# Verdict
+# ---------------------------------------------------------------------------
+
+def analyse(diff_range: str) -> Report:
+    """Run the analysis and return a structured Report."""
+    changed = _git_changed_files(diff_range)
+    if not changed:
+        return Report(
+            diff_range=diff_range,
+            changed_files=[],
+            translations_only=False,
+            lang_columns_added=[],
+            verdict="ok",
+        )
+    translations_paths = [f.path for f in changed
+                          if TRANSLATIONS_RE.match(f.path)]
+    only_translations = bool(translations_paths) and len(translations_paths) == len(changed)
+    if not only_translations:
+        return Report(
+            diff_range=diff_range,
+            changed_files=changed,
+            translations_only=False,
+            lang_columns_added=[],
+            verdict="ok",
+        )
+    diff_text = _git_added_lines(diff_range, translations_paths)
+    added = _added_lang_columns(diff_text)
+    verdict = "resync_only" if not added else "ok"
+    return Report(
+        diff_range=diff_range,
+        changed_files=changed,
+        translations_only=True,
+        lang_columns_added=added,
+        verdict=verdict,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _format_notice(rep: Report) -> str:
+    if rep.verdict == "ok":
+        return ""
+    paths = ", ".join(f.path for f in rep.changed_files)
+    return (
+        "::notice title=Translation resync-only::"
+        f"This PR touches ONLY translations/**/*.csv ({paths}) "
+        "and deposits no translation in any target language "
+        "(en/es/ar/fa/zh/ru/pt). Per coordinator ruling on #6949 "
+        "(2026-07-28), resync-only PRs are suspended until the T3 motor GO "
+        "— a zero SRC_DRIFT on a 0%-translated table is non-informative "
+        "(see #9431 for the fill-rate caveat). Confirm intentionality or "
+        "wait for the motor. Non-blocking advisory."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect resync-only PRs touching translations/**/*.csv "
+                    "(#6949 second half, advisory only)."
+    )
+    parser.add_argument(
+        "--diff-range",
+        default="origin/main...HEAD",
+        help="Git diff range to inspect (default: origin/main...HEAD).",
+    )
+    parser.add_argument(
+        "--json-only",
+        action="store_true",
+        help="Emit JSON only, no human-readable summary or ::notice.",
+    )
+    args = parser.parse_args(argv)
+    try:
+        rep = analyse(args.diff_range)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(rep.to_json(), ensure_ascii=False))  # single-line, parseable
+    if not args.json_only:
+        print(json.dumps(rep.to_json(), ensure_ascii=False, indent=2),
+              file=sys.stderr)
+    if not args.json_only:
+        print("", file=sys.stderr)
+        if rep.verdict == "resync_only":
+            print(_format_notice(rep), file=sys.stderr)
+        else:
+            print(
+                f"Translation advisory OK: {len(rep.changed_files)} file(s), "
+                f"translations_only={rep.translations_only}, "
+                f"lang_columns_added={rep.lang_columns_added or 'none'}",
+                file=sys.stderr,
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/translation/tests/test_check_resync_only.py
+++ b/scripts/translation/tests/test_check_resync_only.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Tests for ``scripts/translation/check_resync_only.py``.
+
+Covers the four core paths:
+
+1. **No diff** (empty change list) → ``verdict="ok"``.
+2. **Touches non-CSV files** (notebook, doc, script) → ``verdict="ok"``,
+   ``translations_only=False``.
+3. **Touches ONLY translations/*.csv** AND adds no non-fr content → ``resync_only``.
+4. **Touches ONLY translations/*.csv** AND adds text_en content → ``ok``
+   (a genuine translation deposit is NOT a resync-only).
+
+Also covers:
+- Column parsing discipline (added lines must have the canonical header length).
+- The hunk-header prefix ``+++`` is filtered out (no false-positive from the
+  diff header itself).
+- Stdin/argv plumbing of ``main()`` returns 0 in OK mode, 2 on git error.
+
+stdlib-only (csv/json/pathlib/shutil/subprocess/argparse). Hermetic.
+
+Mirror of the test pattern established by ``test_check_translation_sync.py``
+for the sibling script: importable module, fixture helpers, pure-function
+coverage first, then a thin CLI smoke test.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+TRANSLATION_DIR = HERE.parent
+sys.path.insert(0, str(TRANSLATION_DIR))
+
+import check_resync_only as r  # noqa: E402
+
+ALL_LANGS = ("en", "es", "ar", "fa", "zh", "ru", "pt")
+PIVOT = "fr"
+COLUMNS = (
+    ["notebook", "cell_id", "cell_type", "src_lang", "src_hash",
+     "text_fr"]
+    + [f"text_{L}" for L in ALL_LANGS]
+    + ["hash_fr"]
+    + [f"hash_{L}" for L in ALL_LANGS]
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _row(cell_id: str, src_hash: str, text_fr: str = "",
+         text_en: str = "") -> list[str]:
+    """Build a canonical CSV row. text_en non-empty = genuine translation."""
+    row = ["nb.ipynb", cell_id, "markdown", "fr", src_hash, text_fr]
+    row += [text_en]  # text_en
+    row += [""] * 6  # text_es..text_pt
+    row += [src_hash]  # hash_fr
+    row += [""] * 7  # hash_en..hash_pt
+    assert len(row) == len(COLUMNS)
+    return row
+
+
+def _make_csv(rows: list[list[str]]) -> str:
+    """Return a CSV file content string with the canonical header."""
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(COLUMNS)
+    writer.writerows(rows)
+    return buf.getvalue()
+
+
+def _diff_lines(rows_before: list[list[str]],
+                rows_after: list[list[str]]) -> str:
+    """Build a synthetic ``git diff -U0`` body for the given before/after rows."""
+    before = _make_csv(rows_before).splitlines(keepends=True)
+    after = _make_csv(rows_after).splitlines(keepends=True)
+    # We simulate a 1-line header + 1-row diff (resync signature).
+    return (
+        "diff --git a/translations/foo/foo.csv b/translations/foo/foo.csv\n"
+        "index 0000001..0000002 100644\n"
+        "--- a/translations/foo/foo.csv\n"
+        "+++ b/translations/foo/foo.csv\n"
+        "@@ -1,2 +1,2 @@\n"
+        + "".join(f"-{l}" for l in before[1:])
+        + "".join(f"+{l}" for l in after[1:])
+    )
+
+
+# ---------------------------------------------------------------------------
+# _added_lang_columns
+# ---------------------------------------------------------------------------
+
+def test_added_lang_columns_empty_for_pure_resync():
+    """text_fr update with no non-fr content → empty added set."""
+    before = [_row("c1", "aaaa", text_fr="avant")]
+    after = [_row("c1", "bbbb", text_fr="après")]
+    diff_text = _diff_lines(before, after)
+    assert r._added_lang_columns(diff_text) == []
+
+
+def test_added_lang_columns_detects_text_en_addition():
+    """text_en non-empty on the + side → 'text_en' is in the result."""
+    before = [_row("c1", "aaaa", text_fr="avant", text_en="")]
+    after = [_row("c1", "bbbb", text_fr="après", text_en="before/after")]
+    diff_text = _diff_lines(before, after)
+    assert "text_en" in r._added_lang_columns(diff_text)
+
+
+def test_added_lang_columns_ignores_hunk_header():
+    """The ``+++ b/translations/...`` header must NOT register as content."""
+    diff_text = (
+        "diff --git a/translations/foo/foo.csv b/translations/foo/foo.csv\n"
+        "+++ b/translations/foo/foo.csv\n"
+        "@@ -1 +1 @@\n"
+        "-x\n"
+        "+y\n"
+    )
+    assert r._added_lang_columns(diff_text) == []
+
+
+def test_added_lang_columns_skips_malformed_rows():
+    """Lines that don't parse to len(COLUMNS) are silently skipped."""
+    diff_text = (
+        "diff --git a/translations/foo/foo.csv b/translations/foo/foo.csv\n"
+        "@@ -1 +1 @@\n"
+        "-too,short\n"
+        "+also,short\n"
+    )
+    assert r._added_lang_columns(diff_text) == []
+
+
+# ---------------------------------------------------------------------------
+# TRANSLATIONS_RE / verdict logic
+# ---------------------------------------------------------------------------
+
+def test_translations_re_matches_csv_only():
+    assert bool(r.TRANSLATIONS_RE.match("translations/foo/foo.csv"))
+    assert bool(r.TRANSLATIONS_RE.match("translations/a/b/c.csv"))
+    assert not r.TRANSLATIONS_RE.match("MyIA.AI.Notebooks/foo.ipynb")
+    assert not r.TRANSLATIONS_RE.match("scripts/translation/check.py")
+    assert not r.TRANSLATIONS_RE.match("docs/translation/README.md")
+
+
+def test_canonical_columns_match_helper():
+    """Sanity: ``_csv_columns`` returns the same shape as the test row helper."""
+    assert r._csv_columns() == list(COLUMNS)
+
+
+# ---------------------------------------------------------------------------
+# analyse() — git-driven path, in a real worktree
+# ---------------------------------------------------------------------------
+
+def _commit_csv(repo: Path, rows: list[list[str]], msg: str) -> None:
+    """Write a CSV, ``git add`` + ``git commit`` it (uses the test repo's git env)."""
+    import os
+    env = os.environ.copy()
+    env.update({
+        "GIT_AUTHOR_NAME": "tester",
+        "GIT_AUTHOR_EMAIL": "tester@test.local",
+        "GIT_COMMITTER_NAME": "tester",
+        "GIT_COMMITTER_EMAIL": "tester@test.local",
+    })
+    csv_path = repo / "translations" / "foo" / "foo.csv"
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    csv_path.write_text(_make_csv(rows), encoding="utf-8")
+    subprocess.run(["git", "add", str(csv_path)], cwd=repo, check=True,
+                   capture_output=True, env=env)
+    subprocess.run(["git", "commit", "-m", msg], cwd=repo, check=True,
+                   capture_output=True, env=env)
+
+
+def _setup_minimal_repo(tmp_path: Path) -> Path:
+    """Init a git repo with one initial commit so ``git diff main...HEAD`` works."""
+    import os
+    env = os.environ.copy()
+    env.update({
+        "GIT_AUTHOR_NAME": "tester",
+        "GIT_AUTHOR_EMAIL": "tester@test.local",
+        "GIT_COMMITTER_NAME": "tester",
+        "GIT_COMMITTER_EMAIL": "tester@test.local",
+    })
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True,
+                   capture_output=True, env=env)
+    # initial commit: translations/ with a marker so git has something to track
+    (tmp_path / "translations").mkdir()
+    (tmp_path / "translations" / ".gitkeep").write_text("", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True,
+                   capture_output=True, env=env)
+    proc = subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path,
+                          capture_output=True, env=env)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"git commit init failed: rc={proc.returncode} "
+            f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        )
+    # create branch so we can advance HEAD
+    subprocess.run(["git", "checkout", "-q", "-b", "feat"], cwd=tmp_path, check=True,
+                   capture_output=True, env=env)
+    return tmp_path
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git not installed")
+def test_analyse_empty_diff_is_ok(tmp_path, monkeypatch):
+    repo = _setup_minimal_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    rep = r.analyse("main...HEAD")
+    assert rep.verdict == "ok"
+    assert rep.changed_files == []
+    assert rep.translations_only is False
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git not installed")
+def test_analyse_pure_resync_is_resync_only(tmp_path, monkeypatch):
+    repo = _setup_minimal_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    _commit_csv(repo, [_row("c1", "aaaa", text_fr="avant")],
+                "resync: text_fr update, no translation")
+    rep = r.analyse("main...HEAD")
+    assert rep.translations_only is True
+    assert rep.verdict == "resync_only"
+    assert rep.lang_columns_added == []
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git not installed")
+def test_analyse_resync_plus_translation_is_ok(tmp_path, monkeypatch):
+    repo = _setup_minimal_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    _commit_csv(repo,
+                [_row("c1", "aaaa", text_fr="avant", text_en="")],
+                "resync: text_fr update only")
+    # Second commit adds text_en — this is a genuine translation, NOT resync-only
+    _commit_csv(repo,
+                [_row("c1", "aaaa", text_fr="avant", text_en="before/after")],
+                "translate: deposit text_en")
+    rep = r.analyse("main...HEAD")
+    assert rep.translations_only is True
+    assert rep.verdict == "ok"
+    assert "text_en" in rep.lang_columns_added
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git not installed")
+def test_analyse_mixed_files_is_not_resync_only(tmp_path, monkeypatch):
+    """A PR that touches a notebook AND a CSV is NOT resync-only."""
+    import os
+    env = os.environ.copy()
+    env.update({
+        "GIT_AUTHOR_NAME": "tester",
+        "GIT_AUTHOR_EMAIL": "tester@test.local",
+        "GIT_COMMITTER_NAME": "tester",
+        "GIT_COMMITTER_EMAIL": "tester@test.local",
+    })
+    repo = _setup_minimal_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    # Add a notebook file
+    nb = repo / "MyIA.AI.Notebooks" / "foo" / "bar.ipynb"
+    nb.parent.mkdir(parents=True, exist_ok=True)
+    nb.write_text(json.dumps({"cells": [], "metadata": {}, "nbformat": 4,
+                              "nbformat_minor": 5}), encoding="utf-8")
+    subprocess.run(["git", "add", str(nb)], cwd=repo, check=True,
+                   capture_output=True, env=env)
+    subprocess.run(["git", "commit", "-m", "add notebook"], cwd=repo, check=True,
+                   capture_output=True, env=env)
+    # Add a CSV in the same branch
+    _commit_csv(repo, [_row("c1", "aaaa", text_fr="avant")],
+                "resync: text_fr update only")
+    rep = r.analyse("main...HEAD")
+    assert rep.translations_only is False
+    assert rep.verdict == "ok"
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git not installed")
+def test_main_cli_exit_code_zero_on_ok(tmp_path, capsys, monkeypatch):
+    repo = _setup_minimal_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    _commit_csv(repo, [_row("c1", "aaaa", text_fr="avant", text_en="")],
+                "resync: pure fr update")
+    rc = r.main(["--diff-range", "main...HEAD"])
+    assert rc == 0
+    out = capsys.readouterr()
+    payload = json.loads(out.out.split("\n")[0])
+    assert payload["verdict"] == "resync_only"


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/lean #9842 (c.9716)

## Summary

Codifies ai-01's coordinator ruling of 2026-07-28 ([issue #6949](https://github.com/jsboige/CoursIA/issues/6949#issuecomment-2328497962)) as a **non-blocking CI advisory**: a PR that touches ONLY `translations/**/*.csv` AND adds no `text_<lang>`/`hash_<lang>` content for lang ∈ {en, es, ar, fa, zh, ru, pt} is flagged `resync_only` via a `::notice` annotation. Pure `text_fr`/`hash_fr` refresh (the source pivot) remains allowed — that's the entire purpose of resync.

## Why

ai-01 ruled 2026-07-28: *"plus de PR resync-only sur `translations/**/*.csv` jusqu'au GO moteur"*. The first half of #6949 (#9431 workflow-wiring, #8690 + #8695 Python-side) is MERGED. The remaining second half is policy enforcement, which is coordinator scope. This PR is the **visibility leg**: it codifies the ruling so a human reviewer (or ai-01) can re-confirm the intentionality of a resync against current policy at merge-gate review time. **No blocking** — the advisory surfaces the verdict; merge stays a coordinator decision.

## Pattern measured

On the 8 resync PRs that landed between 2026-07-21 and 2026-07-25 (#7577, #7695, #7772, #7773, #7806, #7916, #7949, #8431): each was a single CSV file with `insertions ≈ deletions` and zero content in any non-fr column. The detector flags exactly that signature.

## Files

- **NEW** `scripts/translation/check_resync_only.py` (~250 LOC): stdlib-only, hermetic (no network/LLM/filesystem beyond `git diff`). `git diff --stat` + `git diff -U0 --diff-filter=AM` parse CSV rows to detect non-fr column additions.
- **NEW** `scripts/translation/tests/test_check_resync_only.py` (~280 LOC, **11 tests**): pure-function coverage of the 4 core paths + 4 git-driven paths + 1 CLI smoke. Pattern mirrors `test_check_translation_sync.py` (sibling script).
- **EDIT** `scripts/translation/README.md` (1 section, +2 lines): policy reference + ruling URL.

## Verification

```
$ python -m pytest scripts/translation/tests/ -v
============================= 128 passed in 3.38s ==============================
```

11 new tests cover:

1. `_added_lang_columns` empty for pure-resync (no non-fr content)
2. `_added_lang_columns` detects `text_en` addition
3. Hunk header `+++ b/...` is filtered (no false-positive from diff header)
4. Malformed rows are silently skipped
5. `TRANSLATIONS_RE` matches only `translations/*.csv`
6. Canonical CSV header shape matches the helper
7. `analyse("main...HEAD")` on empty diff → `verdict="ok"`, no files
8. Pure-resync commit → `verdict="resync_only"`, `lang_columns_added=[]`
9. Resync + genuine translation deposit → `verdict="ok"`, `text_en` in added columns
10. Mixed touch (notebook + CSV) → `translations_only=False`, `verdict="ok"`
11. CLI exit code 0 on OK mode; single-line JSON on stdout for parsers

Plus 117 pre-existing translation tests still green (no regression).

## Exit codes

- `0` with `verdict: "ok"` → not resync-only (or no diff to inspect)
- `0` with `verdict: "resync_only"` → PR is resync-only. CI prints `::notice` annotation; merge is NOT blocked (ai-01 policy)
- `2` → usage error

## Optional follow-up (not in this PR)

Wiring into `.github/workflows/translation-drift.yml` as an advisory step (non-blocking `::notice`) — separated so the advisory stays runnable from the CLI before any CI integration. Coordinator ai-01 can enable CI wiring in a separate PR if desired.

## Sub-grain scope (G.4 / catalog-pr-hygiene compliance)

3 files, +617/-0. One cohesive subject: codify the coordinator ruling as a CI advisory. The detector + tests + README reference form one atomic deliverable — splitting the README line out would orphan the doc from the tool it references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)