### PR TITLE
refactor(qc,audit_projects): loaders raise instead of sys.exit on bad input

### DIFF
--- a/scripts/quantconnect/audit_projects.py
+++ b/scripts/quantconnect/audit_projects.py
@@ -43,30 +43,26 @@ MIN_SHARPE = -0.5  # Below this = structurally broken
 
 
 def load_projects(json_path: str) -> list[dict]:
-    """Load project list from MCP JSON output."""
-    try:
-        with open(json_path, encoding="utf-8") as f:
-            data = json.load(f)
-    except FileNotFoundError:
-        print(f"ERROR: File not found: {json_path}", file=sys.stderr)
-        sys.exit(1)
-    except json.JSONDecodeError as e:
-        print(f"ERROR: Invalid JSON in {json_path}: {e}", file=sys.stderr)
-        sys.exit(1)
+    """Load project list from MCP JSON output.
+
+    Raises:
+        FileNotFoundError: if json_path does not exist.
+        json.JSONDecodeError: if the file contents are not valid JSON.
+    """
+    with open(json_path, encoding="utf-8") as f:
+        data = json.load(f)
     return data.get("projects", [])
 
 
 def load_catalog(catalog_path: str) -> dict[int, dict]:
-    """Load catalog enrichment data keyed by project ID."""
-    try:
-        with open(catalog_path, encoding="utf-8") as f:
-            data = json.load(f)
-    except FileNotFoundError:
-        print(f"ERROR: Catalog not found: {catalog_path}", file=sys.stderr)
-        sys.exit(1)
-    except json.JSONDecodeError as e:
-        print(f"ERROR: Invalid JSON in catalog {catalog_path}: {e}", file=sys.stderr)
-        sys.exit(1)
+    """Load catalog enrichment data keyed by project ID.
+
+    Raises:
+        FileNotFoundError: if catalog_path does not exist.
+        json.JSONDecodeError: if the file contents are not valid JSON.
+    """
+    with open(catalog_path, encoding="utf-8") as f:
+        data = json.load(f)
     catalog = {}
     for entry in data.get("projects", []):
         pid = entry.get("projectId", 0)
@@ -328,7 +324,7 @@ def generate_report(
     return "\n".join(lines)
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(description="QC Cloud Projects Audit")
     parser.add_argument("--from-json", required=True, help="Path to projects JSON from MCP")
     parser.add_argument("--catalog", help="Path to catalog enrichment JSON (backtest data)")
@@ -337,14 +333,23 @@ def main():
     parser.add_argument("--verbose", action="store_true", help="Verbose output")
     args = parser.parse_args()
 
-    projects = load_projects(args.from_json)
+    try:
+        projects = load_projects(args.from_json)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
     if not projects:
         print(f"ERROR: No projects found in {args.from_json}", file=sys.stderr)
-        sys.exit(1)
+        return 1
 
     catalog = None
     if args.catalog:
-        catalog = load_catalog(args.catalog)
+        try:
+            catalog = load_catalog(args.catalog)
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 1
 
     report = generate_report(projects, catalog)
 
@@ -362,6 +367,8 @@ def main():
     else:
         print(report)
 
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/quantconnect/tests/test_audit_projects.py
+++ b/scripts/quantconnect/tests/test_audit_projects.py
@@ -50,8 +50,14 @@ class TestLoadProjects:
         assert result == []
 
     def test_missing_file(self):
-        with pytest.raises(SystemExit):
+        with pytest.raises(FileNotFoundError):
             load_projects("/nonexistent/path.json")
+
+    def test_invalid_json(self, tmp_path):
+        p = tmp_path / "garbage.json"
+        p.write_text("{invalid json,", encoding="utf-8")
+        with pytest.raises(json.JSONDecodeError):
+            load_projects(str(p))
 
 
 # --- load_catalog ---
@@ -71,6 +77,16 @@ class TestLoadCatalog:
         p.write_text(json.dumps({}), encoding="utf-8")
         result = load_catalog(str(p))
         assert result == {}
+
+    def test_missing_file(self):
+        with pytest.raises(FileNotFoundError):
+            load_catalog("/nonexistent/catalog.json")
+
+    def test_invalid_json(self, tmp_path):
+        p = tmp_path / "garbage.json"
+        p.write_text("{invalid json,", encoding="utf-8")
+        with pytest.raises(json.JSONDecodeError):
+            load_catalog(str(p))
 
 
 # --- get_catalog_sharpe / get_catalog_bt_count ---


### PR DESCRIPTION
Grain: MED/refactor — lane myia-po-2024:CoursIA-2 — prev: MED/qc-tooling #9834

## Résumé

Refactor de `scripts/quantconnect/audit_projects.py` pour aligner les loaders sur le pattern canonique déjà présent dans le sibling `scripts/quantconnect/check_data_freshness.py` : `load_projects` et `load_catalog` ne tuent plus le process sur erreur d'entrée, elles **lèvent** `FileNotFoundError` / `json.JSONDecodeError`. `main()` est converti en `main() -> int` et traduit ces exceptions en `ERROR: ...` propre sur stderr + exit 1. Le test encode `pytest.raises(SystemExit)` qui figeait l'anti-pattern est remplacé par `pytest.raises(FileNotFoundError)`, et 3 tests error-path sont ajoutés (la classe `load_catalog` n'en avait aucun).

## Motivation — l'anti-pattern

Les deux loaders de `audit_projects.py` étaient des **library-style helpers qui appellent `sys.exit(1)`** sur des erreurs récupérables (`FileNotFoundError`, `json.JSONDecodeError`) :

```python
def load_projects(json_path: str) -> list[dict]:
    try:
        with open(json_path, encoding="utf-8") as f:
            data = json.load(f)
    except FileNotFoundError:
        print(f"ERROR: File not found: {json_path}", file=sys.stderr)
        sys.exit(1)        # <-- tue le process
    except json.JSONDecodeError as e:
        print(f"ERROR: Invalid JSON in {json_path}: {e}", file=sys.stderr)
        sys.exit(1)        # <-- tue le process
    return data.get("projects", [])
```

Conséquence : tout importeur de ces fonctions hérite d'un **kill de process** sur entrée invalide, au lieu d'une exception catchable. Le test encode cette propriété nocive :

```python
def test_missing_file(self):
    with pytest.raises(SystemExit):        # <-- fige l'anti-pattern
        load_projects("/nonexistent/path.json")
```

`load_catalog` n'avait **aucun** test error-path (juste happy-path + empty dict).

## Le sibling canonique

`scripts/quantconnect/check_data_freshness.py:150-265` montre le bon pattern :

- Helpers : `return None` ou `raise`.
- `def main() -> int:` (signature annotée).
- Codes de sortie par `return 0/1/2` selon la branche.
- `if __name__ == "__main__": sys.exit(main())` au pied du fichier.

`audit_projects.py` ne respectait aucune de ces conventions. Cette PR l'aligne.

## Le changement

### `scripts/quantconnect/audit_projects.py`

| Avant | Après |
|---|---|
| `load_projects` : try/except + `sys.exit(1)` | `load_projects` : `with open(...) as f: data = json.load(f)` (lève naturellement) + docstring `Raises:` |
| `load_catalog` : try/except + `sys.exit(1)` (idem) | idem |
| `def main(): ... sys.exit(1)` inline (L341-343) | `def main() -> int:` + try/except wrapping les deux loaders → `print ERROR + return 1` ; empty-projects → `return 1` ; fin → `return 0` |
| `if __name__ == "__main__": main()` | `if __name__ == "__main__": sys.exit(main())` |

**Comportement préservé pour l'utilisateur CLI** : fichier manquant/invalide → message `ERROR:` propre sur stderr (fourni par l'exception native) + exit 1 ; exit 0 sur succès. **Comportement amélioré pour l'importeur** : `load_projects`/`load_catalog` lèvent `FileNotFoundError` / `json.JSONDecodeError`, catchables.

### `scripts/quantconnect/tests/test_audit_projects.py`

- `TestLoadProjects.test_missing_file` : `pytest.raises(SystemExit)` → `pytest.raises(FileNotFoundError)`.
- **+3 nouveaux tests** :
  - `TestLoadProjects.test_invalid_json` (tmp_path, garbage `{invalid json,`)
  - `TestLoadCatalog.test_missing_file` (la classe `load_catalog` n'en avait aucun)
  - `TestLoadCatalog.test_invalid_json` (idem)

## Vérification end-to-end (empirical, on worktree post-FF)

| Gate | Résultat |
|---|---|
| Tests ciblés | `38 passed in 0.12s` (35 existants + 3 nouveaux error-path) |
| Régression `scripts/quantconnect/tests/` | `218 passed, 1 skipped in 1.98s` (+3 vs baseline = exactement les nouveaux tests, 0 cassé) |
| CLI fichier manquant | `ERROR: [Errno 2] No such file or directory: '...'` puis exit 1 (préservé) |
| CLI projets vides | `ERROR: No projects found in ...` puis exit 1 (préservé) |
| Composabilité | `load_projects('/nonexistent')` lève `FileNotFoundError` (3/3 cas testés) — plus de `SystemExit` |

## Risque

**Zéro importeur externe dépend du `sys.exit`** (vérifié par `grep -rn 'from audit_projects\|load_projects\|load_catalog' scripts/` → seuls `audit_projects.py` main() et son test). Les autres `load_catalog`/`load_catalogue` trouvés dans le grep sont des **fonctions distinctes** dans `check_editorial_review.py`, `expand_catalog_markers.py`, `generate_parcours.py` — sans rapport.

## Acceptance criteria

- [x] `load_projects` et `load_catalog` lèvent `FileNotFoundError` / `json.JSONDecodeError` (test error-path explicite)
- [x] `main()` : `main() -> int`, codes 0/1, `sys.exit(main())` au pied
- [x] `pytest.raises(SystemExit)` retiré du test
- [x] 3 nouveaux tests error-path (1 load_projects invalid JSON, 2 load_catalog)
- [x] 38/38 ciblés + 218/218 régression = vert
- [x] CLI : comportement utilisateur préservé (ERROR propre + exit 1)

## Fichiers modifiés

| Fichier | Statut | Lignes |
|---|---|---|
| `scripts/quantconnect/audit_projects.py` | modified | +31/-26 |
| `scripts/quantconnect/tests/test_audit_projects.py` | modified | +16/-2 |

Total : 2 fichiers, +49/-26, 1 domaine, 0 notebook/Lean/code production touché hors scope.

## Out of scope (grains séparés)

- `check_data_freshness.py --json` (sibling parity) — out of scope de cette PR (atomique R3).
- Couverture test de `get_container_for_project` — out of scope.
- Nettoyage des one-shots (`fix_catalog_drift.py`, `optimize_dvs.py`) — out of scope.