### PR TITLE
fix(ci,lean): swap 16G -> 32G — le pic d'elaboration intra-module OOM encore le runner (debloque #9840)

### DIFF
--- a/.github/workflows/lean-axiom.yml
+++ b/.github/workflows/lean-axiom.yml
@@ -98,8 +98,12 @@ jobs:
       # This workflow rebuilds the lake too (its cache key differs from
       # lean-build's, so it can miss independently) — observed on PR #9798 where
       # BOTH proof-integrity jobs died at exit 143 alongside the build job.
+      # 16 G -> 32 G (2026-08-07, PR #9840): teardown recurred with the swap step
+      # green, and the peak is inside a SINGLE module — see the long note in
+      # lean-build.yml for the measurements.
       run: |
-        sudo fallocate -l 16G /mnt/lean-swap
+        df -h /mnt
+        sudo fallocate -l 32G /mnt/lean-swap
         sudo chmod 600 /mnt/lean-swap
         sudo mkswap /mnt/lean-swap
         sudo swapon /mnt/lean-swap

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -188,8 +188,20 @@ jobs:
       # cache HIT on the big module — passed in ~6 min: the discriminant is the
       # actions/cache miss, not the code. Swap absorbs the elaboration peak; on
       # incremental (cache-hit) runs this step costs ~5 s and the swap is idle.
+      #
+      # 16 G -> 32 G (2026-08-07, PR #9840): the same exit-143 teardown recurred
+      # twice WITH this step green (run 31161731891, jobs 92824690001 et al.) —
+      # `Add swap space` = success, `Lake build` killed ~4 min 50 s after
+      # `Decompressed 8477 file(s)`, zero `.lean:L:C: error:` line. #9840 adds
+      # +756 lines of heartbeat-heavy P4 wall proofs (16 M cap on the SE mp arm)
+      # to HashlifeCorrectness.lean, so the peak sits in ONE module: lowering
+      # `lake -j` cannot split it, only more swap can absorb it. The same commit
+      # elaborates clean on WSL (`lake build` exit 0, 8556 jobs) — the ceiling is
+      # the runner's 16 GB RAM, not the proof. /mnt on ubuntu-latest carries
+      # ~70 GB free, so 32 G is affordable; `df -h /mnt` keeps that auditable.
       run: |
-        sudo fallocate -l 16G /mnt/lean-swap
+        df -h /mnt
+        sudo fallocate -l 32G /mnt/lean-swap
         sudo chmod 600 /mnt/lean-swap
         sudo mkswap /mnt/lean-swap
         sudo swapon /mnt/lean-swap


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/guard #9845

## Summary

Porte le swap des deux reusable workflows Lean (`lean-build.yml`, `lean-axiom.yml`) de **16 G a 32 G**. #9811 avait installe le swap de 16 G apres trois teardowns `exit 143` sur #9798 ; **#9840 reproduit le meme teardown avec ce step vert** — le pic d'elaboration tient dans **un seul module**, donc aucune reduction de `lake -j` ne peut le decouper.

## Mesures firsthand (run 31161731891, PR #9840)

Les trois jobs Lean de #9840 montrent la meme sequence :

| Step | Resultat |
|---|---|
| `Cache Lake build artifacts` | success |
| **`Add swap space`** | **success** (les 16 G de #9811 sont bien montes) |
| **`Lake build`** | **failure** — `##[error]The runner has received a shutdown signal`, `exit code 143` |
| `Setup Python` / `Run axiom check` | skipped |

Chronologie du job 92824690001 :

```
09:20:23.2  Downloaded: 8477 file(s) [attempted 8477/8477 = 100%]
09:20:23.9  Decompressed 8477 file(s)
09:25:13.4  Already decompressed 8477 file(s)
09:25:13.4  ##[error]The runner has received a shutdown signal...
09:25:13.4  ##[error]Process completed with exit code 143.
```

**Zero ligne `.lean:L:C: error:`** dans le log complet (le `::group::` de #8915 est vide) : ce n'est pas un echec de preuve, c'est la VM arrachee pendant l'elaboration, ~4 min 50 s apres la fin de la decompression du cache Mathlib.

## Pourquoi 32 G de swap et pas `lake -j 2`

- #9840 ajoute **+756 lignes** de preuves de murs P4 tres chargees en heartbeats (cap 16 M sur l'arm mp SE) **dans `HashlifeCorrectness.lean`**, deja un monolithe de 7300+ lignes. Le pic est donc **intra-module** : `lake -j` parallelise entre modules, il ne fractionne pas l'elaboration d'un module unique.
- Le **meme commit elabore proprement sur WSL** (`lake build` exit 0, 8556 jobs, rapporte dans le body de #9840) : le plafond est la RAM du runner (16 G), pas la preuve — verdict **RECOVERABLE-MACHINE** au sens de [sota-not-workaround](.claude/rules/sota-not-workaround.md), et la reparation est cote CI, pas cote Lean.
- `/mnt` sur `ubuntu-latest` porte **~70 GB libres** : 32 G de fichier swap est finançable. `df -h /mnt` est desormais imprime **avant** le `fallocate`, pour qu'un futur lake qui deborderait laisse une trace auditable au lieu d'un `fallocate` qui echoue en silence.
- Sur les runs **cache-hit** (le cas nominal), le step reste un no-op de ~5 s, swap inactif.

## Verification

- `yaml.safe_load` OK sur les deux fichiers.
- `grep -rn lean-swap .github/workflows/` : aucune autre occurrence — les deux fichiers touches sont les seuls porteurs.
- Aucun changement de logique de build : seuls la taille du fichier swap, le `df -h /mnt` d'observabilite et les commentaires de justification bougent.
- **Preuve d'effet attendue** : re-run des checks de #9840 apres merge (le `pull_request` merge ref reprend les workflows de `main`). Si le teardown persiste a 32 G, le verdict basculera en plafond CI documente sur #9840 et sera trace en issue — pas de merge sur un rouge non explique.

## Perimetre

2 fichiers, +18/−4, un seul sujet. Les 22 workflows appelants heritent du changement sans modification (la taille n'est pas un input).

See #9840 (PR bloquee) · #9811 (precedent 16 G) · #6724 (EPIC P4/P5)
