### PR TITLE
fix(qc,#6891): migrate 4 legacy configs language:Py -> algorithm-language:Python (See #6891 etape 2)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/DualMomentum/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DualMomentum/config.json
@@ -1,5 +1,5 @@
 {
   "cloud-id": 28692516,
   "organization-id": "d600793ee4caecb03441a09fc2d00f7f",
-  "language": "Py"
+  "algorithm-language": "Python"
 }

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion/config.json
@@ -1,6 +1,6 @@
 {
     "cloud-id": 30776121,
     "organization-id": "d600793ee4caecb03441a09fc2d00f7f",
-    "language": "Py",
+    "algorithm-language": "Python",
     "local-id": 396457801
 }

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following/config.json
@@ -1,6 +1,6 @@
 {
     "cloud-id": 28797562,
     "organization-id": "d600793ee4caecb03441a09fc2d00f7f",
-    "language": "Py",
+    "algorithm-language": "Python",
     "local-id": 517909399
 }

--- a/MyIA.AI.Notebooks/QuantConnect/projects/VolTarget-Momentum/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/VolTarget-Momentum/config.json
@@ -1,5 +1,5 @@
 {
   "cloud-id": 30784745,
   "organization-id": "d600793ee4caecb03441a09fc2d00f7f",
-  "language": "Py"
+  "algorithm-language": "Python"
 }

--- a/scripts/quantconnect/tests/test_validate_qc_project_configs.py
+++ b/scripts/quantconnect/tests/test_validate_qc_project_configs.py
@@ -167,6 +167,23 @@ class TestAuditOutOfScope:
         }
         assert audit_project_config("SomeProject", cfg) == []
 
+    def test_migrated_legacy_algorithm_language_with_cloud_id(self):
+        """Migration cible (issue #6891 etape 2):
+        `algorithm-language: Python` + `cloud-id` (integer) + pas de name/id/parameters
+        = legacy_cloud_id_holders (informationnel), pas de violation.
+
+        Couvre les 4 projets migres : DualMomentum, MeanReversion,
+        Trend-Following, VolTarget-Momentum. Avant migration, ils utilisaient
+        `language: Py` ; apres migration, ils gardent `cloud-id` legitime et
+        le validator les classe comme cloud-id holders (early-return L174).
+        """
+        cfg = {
+            "cloud-id": 28692516,
+            "algorithm-language": "Python",
+            "organization-id": "d600793ee4caecb03441a09fc2d00f7f",
+        }
+        assert audit_project_config("DualMomentum", cfg) == []
+
 
 # --- audit_all: integration ---
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA-2 — prev: MED/refactor #9849

## Résumé

Migration mécanique du champ legacy `language: "Py"` vers le schéma canonique `algorithm-language: "Python"` sur **4 configs QC** qui portent un `cloud-id` légitime (projets déjà poussés au cloud QC) : DualMomentum, MeanReversion, Trend-Following, VolTarget-Momentum. Voir issue #6891 (RESCOPE, étape 2). L'étape 1 (RESCOPE schema normalization sur les 5 configs sans cloud-id) a été livrée par #9834 MERGED.

## Motivation — pourquoi cette migration

L'issue #6891 a tracé deux lignes rouges autour du défaut d'origine :

1. **Fabrication de sorties** dans 8 quantbooks (RESCOPE principal — fix par re-exécution QC Cloud, RECOVERABLE-USER-HAND).
2. **Fabrication de schéma** dans `config.json` : un `cloud-id` inventé, un `language: "Py"` qui n'est pas le schéma canonique, ou des champs minimaux absents (ai-01 2026-07-25T17:04:07Z : « NE JAMAIS écrire un `cloud-id` qu'on n'a pas obtenu du cloud »).

L'étape 1 (#9834 MERGED) a normalisé les 5 configs **sans cloud-id** (les projets RESCOPE) pour qu'elles portent le schéma canonique `{algorithm-language, name, id, parameters, organization-id}`. Cette PR traite **l'autre moitié** : les configs qui ont **déjà** un cloud-id légitime (projet déjà poussé) mais utilisent encore l'ancien schéma `cloud-id + language: Py + organization-id` (avec parfois `local-id`).

## Pourquoi migrer vers `algorithm-language` plutôt que garder `language`

Le champ `algorithm-language` est le **schéma canonique QC Cloud** (cf. la documentation QC pour `cloud push`). Le champ `language: "Py"` est un **vestige de l'ancien format** qui :
- n'est pas reconnu par certains outils QC récents ;
- empêche la détection programmatique de projets Python (regex sur `language: "Py"` vs `algorithm-language: "Python"`) ;
- crée une **dissonance de schéma** dans le dépôt (27 configs modernes + 8 legacy, dont 4 avec cloud-id).

Cette migration est purement mécanique et **préserve le comportement** du validator (#9834 MERGED) : les 4 configs restent dans `legacy_cloud_id_holders` (informationnel, pas de violation) car le **early-return** `if "cloud-id" in cfg: return []  # hors scope` (validate_qc_project_configs.py:174) les classe comme cloud-id holders, indépendamment du champ `language`/`algorithm-language`.

## Le changement

### `MyIA.AI.Notebooks/QuantConnect/projects/{DualMomentum,MeanReversion,Trend-Following,VolTarget-Momentum}/config.json`

Changement minimal d'une ligne par fichier :

```diff
-  "language": "Py"
+  "algorithm-language": "Python"
```

| Fichier | Format préservé | local-id préservé | cloud-id préservé |
|---|---|---|---|
| `DualMomentum/config.json` | 2-space (moderne) | absent | 28692516 ✓ |
| `MeanReversion/config.json` | 4-space (legacy) | 396457801 ✓ | 30776121 ✓ |
| `Trend-Following/config.json` | 4-space (legacy) | 517909399 ✓ | 28797562 ✓ |
| `VolTarget-Momentum/config.json` | 2-space (moderne) | absent | 30784745 ✓ |

Le **formatting original** (2-space vs 4-space) et le **trailing newline** sont préservés (c.1331+20-L3 ★★ byte-identity). Aucun `cloud-id` n'est modifié, ajouté ou supprimé. Aucun `local-id` n'est modifié. Aucun autre champ n'est touché.

### `scripts/quantconnect/tests/test_validate_qc_project_configs.py`

**+1 test** (`test_migrated_legacy_algorithm_language_with_cloud_id`) dans `TestAuditOutOfScope` qui fige le comportement post-migration : un projet avec `cloud-id` (integer) + `algorithm-language: "Python"` + aucun `name`/`id`/`parameters` doit retourner `[]` (pas de violation, classé `legacy_cloud_id_holders` informationnel).

Ce test **documente et protège** la migration contre une régression future (un PR qui re-casserait le early-return cloud-id serait détecté par ce test).

## Vérification end-to-end (empirical, post-edit sur worktree)

| Gate | Résultat |
|---|---|
| Tests ciblés validator | `35 passed in 0.34s` (+1 nouveau test, 34 existants) |
| Régression `scripts/quantconnect/tests/` | `250 passed, 1 skipped in 1.70s` (+1 vs baseline 249) |
| Validator `--check` (CI gate) | `exit=0`, 0 violation, 26 legacy informationnel (inchangé) |
| Validator JSON | `conformant_rescope`=5, `conformant_other`=4, `legacy_cloud_id_holders`=26, `violations`=[] |
| Diff stat | 5 fichiers, +21/-4, 1 domaine (QC tooling) |
| Trailing newline byte-identity | 4/4 configs préservent `\n` final |
| Aucun `cloud-id` modifié/fabriqué | `git diff` confirme : 0 ligne touchée dans les valeurs `cloud-id` |

**Aucune régression** : le validator retourne exactement le même rapport avant/après (mêmes 5+4+26 split), seul le **schéma** des 4 configs a changé. C'est une migration **neutre pour le gate CI** mais qui aligne le dépôt sur le schéma canonique QC Cloud.

## Pourquoi cette PR est sûre (anti-regression rule D)

1. **Comportement préservé** : aucun outil ne se basait sur le champ `language: "Py"` (grep = 0 hits en dehors des 4 fichiers modifiés et du validator lui-même qui distingue les deux via `_is_legacy_cloud_id_schema`).
2. **Pas de fabrication** : les 4 configs ont un `cloud-id` **légitime** (entier obtenu du cloud), donc la migration ne viole pas la ligne rouge d'ai-01 (ne JAMAIS écrire un cloud-id non obtenu du cloud).
3. **Pas de suppression de code de production** : on **ajoute** `algorithm-language` (nouveau champ) tout en **ôtant** `language` (champ legacy). C'est un remplacement, pas une suppression.
4. **Pas de secret leak** : les fichiers modifiés ne contiennent que des IDs publics (`cloud-id`, `organization-id`, `local-id`) — aucun secret.
5. **Formatage préservé** : chaque config garde son format d'origine (2-space ou 4-space) pour minimiser le diff et faciliter la revue.

## Acceptance criteria

- [x] 4 configs migrées : `language: "Py"` → `algorithm-language: "Python"` (DualMomentum, MeanReversion, Trend-Following, VolTarget-Momentum)
- [x] Aucun `cloud-id` modifié (ai-01 line rouge respectée : tous les cloud-id étaient déjà légitimes)
- [x] Aucun `local-id` modifié (MeanReversion, Trend-Following)
- [x] Formatage byte-preserved (2-space ou 4-space selon original)
- [x] Trailing newline byte-preserved (c.1331+20-L3 ★★)
- [x] +1 test dans `TestAuditOutOfScope` fige le comportement post-migration
- [x] Validator `--check` exit=0 (CI green-ready)
- [x] Régression 250/250 + 1 skipped (vs baseline 249 + 1 skipped)
- [x] Aucun changement dans la classification du validator (mêmes 5+4+26)

## Fichiers modifiés

| Fichier | Statut | Lignes |
|---|---|---|
| `MyIA.AI.Notebooks/QuantConnect/projects/DualMomentum/config.json` | modified | +1/-1 |
| `MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion/config.json` | modified | +1/-1 |
| `MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following/config.json` | modified | +1/-1 |
| `MyIA.AI.Notebooks/QuantConnect/projects/VolTarget-Momentum/config.json` | modified | +1/-1 |
| `scripts/quantconnect/tests/test_validate_qc_project_configs.py` | modified | +17/0 |

Total : 5 fichiers, +21/-4, 1 domaine, 0 notebook/Lean/code production hors-scope touché.

## Out of scope (grains séparés)

- **Migrer les 5 configs bare `{local-id}`** (AllWeather, HAR-RV-Kelly, Vol-Ensemble-Conservative, Vol-GARCH-Target, + 1) : ces projets n'ont **pas** de cloud-id (pas poussés au cloud). La migration requerrait soit d'**obtenir un cloud-id** (RECOVERABLE-USER-HAND), soit de les ajouter au scope RESCOPE (mais ils n'ont pas de description/parameters), soit de les laisser bare. **Travail séparé**, scope par issue dédiée.
- **Re-exécution des 8 quantbooks** (#6891 epic principal) : RECOVERABLE-USER-HAND, creds QC absents. **GATED user sign-off** (cf. message ai-01 dans #6891).
- **Ouvrir le validator en CI** (workflow PR `MyIA.AI.Notebooks/QuantConnect/projects/**/config.json`) : grain séparé, MED/tooling, atomique. À faire **après** cette migration (pour ne pas faire rougeurer la CI sur les configs bare).

## Liens

- Issue #6891 (Epic : 7 quantbooks en honnêteté intérimaire)
- PR #9834 MERGED (étape 1 RESCOPE schema normalization)
- PR #9849 OPEN (refactor audit_projects loaders — grain précédent)
- Validator : `scripts/quantconnect/validate_qc_project_configs.py` (PR #9834)
- Test anti-regression : `scripts/quantconnect/tests/test_validate_qc_project_configs.py::TestAuditOutOfScope::test_migrated_legacy_algorithm_language_with_cloud_id`