### PR TITLE
docs(readme,#9847): Claude Code tools — real counts + canonical pointer (grain G2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,13 +466,9 @@ Un workflow GitHub Actions valide automatiquement les notebooks à chaque pull r
 
 ## Outils Claude Code
 
-Le dépôt inclut une configuration Claude Code avec des agents spécialisés et des commandes slash pour la maintenance des notebooks.
+Le dépôt embarque une configuration Claude Code complète pour la maintenance et l'enrichissement des notebooks : **21 sous-agents** spécialisés (notebooks, QuantConnect, Lean/preuves, GenAI, README/slides, training ML, coordination multi-machines…) et **16 commandes slash** (`/verify-notebooks`, `/enrich-notebooks`, `/build-notebook`, `/coordinate`, `/review-student-prs`…).
 
-**Commandes principales** : `/verify-notebooks`, `/enrich-notebooks`, `/cleanup-notebooks`, `/build-notebook`, `/execute-notebook`, `/validate-genai`, `/qc-iterative-improve`
-
-**Agents spécialisés** : notebook-enricher, notebook-validator, notebook-executor, qc-strategy-analyzer, qc-strategy-improver, readme-updater, et d'autres.
-
-Configuration dans `.claude/agents/` et `.claude/skills/`.
+Le roster exhaustif — agents, skills, scripts dédiés et mapping side-tracks Epic — est tenu à jour dans [`docs/reference/subagents-reference.md`](docs/reference/subagents-reference.md). Cette liste canonique prime sur tout inventaire figé dans le README, qui se périmerait à chaque ajout. Configuration physique : `.claude/agents/` et `.claude/skills/`.
 
 ---
 


### PR DESCRIPTION
## Summary

Grain: **MED/readme** — `#9847` grain **G2/7** (Outils Claude Code). Lane `myia-po-2026:CoursIA`. Dispatch: P2 self-pick (pool global, 0 claim sur #9847, variété docs après 5 cycles tooling).

La section `## Outils Claude Code` du README racine citait **7 commandes slash sur 16 réelles** et **6 agents sur 21 réels** (« et d'autres ») — une énumération partielle figée qui sous-représente l'outillage de ~55 % (defect **D4** vérifié firsthand par ai-01) et dérive silencieusement à chaque ajout.

## Correctif — « pointer, pas recopier » (pattern #9831)

Remplacement par les **comptes réels** (21 agents, 16 skills) + **pointeur** vers le roster canonique [`docs/reference/subagents-reference.md`](docs/reference/subagents-reference.md). Même leçon que #9831 (« 34 outils » → 15) : un inventaire figé dans le README se périme, le doc canonique non.

## Mesures firsthand (sur `origin/main`, avant édition)

| Quantité | README (avant) | Réel (git ls-tree) |
|----------|----------------|---------------------|
| Sous-agents `.claude/agents/*.md` | 6 nommés + « et d'autres » | **21** |
| Skills `.claude/skills/*/` | 7 slash commands | **16** |
| `docs/reference/subagents-reference.md` | non cité | **EXISTS** (cible du pointeur) |
| 5 slash commands citées (post-fix) | — | toutes résolvent vers un skill dir réel |

## Périmètre (§E whole-file audit)

`#9847` décompose le README racine (512 lignes, 26 sections) en **7 grains** parce qu'un audit fichier-entier en une PR serait un composite (G.4). Cette PR livre **G2 uniquement** (section `## Outils Claude Code`, L467-475). Les autres défauts vérifiés par ai-01 restent ouverts comme grains frères — **non ignorés, scoping explicite** :

- **G1** (D1+D2+D3 Structure du dépôt : `tools/` inexistant, dossiers trackés manquants)
- **G3** (D5 table dépendances externes), **G4/G5/G6/G7**…

Aucun marqueur `CATALOG-STATUS` dans le README racine (ce n'est pas un README de série) → catalogue byte-identique à main (`catalog-pr-hygiene` R1 respecté).

## Acceptance G2 (mappée)

- ✅ Compte réel (21 agents / 16 skills) au lieu de l'énumération partielle.
- ✅ Pointeur vers `docs/reference/subagents-reference.md` (anti-dérive).
- ✅ `EXCLUDE_ALWAYS`/`bin` **hors scope** (corrigé séparément par po-2024 sur #9851).

## Détails

- `README.md` : section `## Outils Claude Code` réécrite, +2/−6 (plus concis).
- LF-only (0 CRLF vérifié byte-level).
- Diff minimal, 1 fichier, 1 section.

See #9847 (grain G2/7 — contribution partielle à l'EPIC multi-grain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
