### PR TITLE
fix(owui): réaligne Playwright-OWUI sur la v0.11 — un faux vert, un locator non scopé, un timeout avalé

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/02-navigation-authentification/02-navigation-auth.spec.ts
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/02-navigation-authentification/02-navigation-auth.spec.ts
@@ -15,7 +15,7 @@
  * les cookies et tokens de session.
  */
 import { test, expect } from '@playwright/test';
-import { MODEL, AUTH } from '../helpers/selectors';
+import { MODEL, AUTH, SETTINGS } from '../helpers/selectors';
 import { dismissModals } from '../helpers/chat';
 
 test.describe('02 — Navigation & Authentification', () => {
@@ -71,16 +71,52 @@ test.describe('02 — Navigation & Authentification', () => {
   /**
    * TEST 3 : Naviguer vers les reglages admin
    *
-   * La page /admin/settings contient la configuration globale
-   * de l'instance Open WebUI.
+   * CONCEPT : un test qui passe n'est pas forcement un test JUSTE.
+   *
+   * Jusqu'a la v0.10, /admin/settings etait une PAGE, avec un lien "Reglages"
+   * dans sa navigation. On assertait donc :
+   *
+   *     page.getByRole('link', { name: /réglages|settings/i }).first()
+   *
+   * La v0.11 a refondu l'interface : les reglages sont devenus des ONGLETS
+   * (role=tab) dans une fenetre unique, et /admin/settings REDIRIGE vers /.
+   *
+   * Le piege : cette ancienne assertion continuait de passer par moments.
+   * Mesure firsthand (2026-08-07, instance de cours en v0.11.0) :
+   *
+   *     t=4.3s  goto termine, url=/admin/settings, 0 correspondance
+   *     t=7.5s  <a href="/admin/settings">Reglages</a> APPARAIT (vestige)
+   *     t=10.7s l'app redirige vers /, le lien DISPARAIT
+   *
+   * L'ancienne assertion attrapait donc une fenetre transitoire d'environ 3
+   * secondes : verte sur une machine, rouge sur une autre (c'est exactement ce
+   * qui s'est produit entre deux suites lancees contre le MEME serveur).
+   * C'est un FAUX VERT — la pire categorie de test, car il ne signale rien.
+   *
+   * La regle : asserter l'etat STABILISE, jamais un etat de passage.
+   * Ici, on attend la redirection puis on cible un onglet d'administration.
+   *
+   * PIEGE (mode strict) : l'onglet "General" existe dans les deux groupes
+   * (utilisateur ET admin) -> 2 correspondances -> "strict mode violation".
+   * On vise "Authentification", qui n'existe que cote admin.
    */
   test('acceder aux reglages admin', async ({ page }) => {
     await page.goto('/admin/settings');
 
-    // Le lien "Reglages" / "Settings" devrait etre actif dans la navigation
+    // 1. Attendre l'etat STABILISE : la v0.11 redirige vers / en ouvrant la
+    //    fenetre de reglages. On tolere l'absence de redirection (versions
+    //    anterieures) pour que le test reste lisible sur une instance v0.10.
+    await page.waitForURL((url) => !url.pathname.startsWith('/admin/settings'), {
+      timeout: 30_000,
+    }).catch(() => {});
+
+    // 2. Asserter un onglet propre a l'administration (1 seule correspondance).
     await expect(
-      page.getByRole('link', { name: /réglages|settings/i }).first()
+      page.getByRole('tab', { name: SETTINGS.adminAuthTab })
     ).toBeVisible({ timeout: 15_000 });
+
+    // EXERCICE : verifiez que getByRole('tab', { name: /^général$/i }) renvoie
+    // DEUX elements, et expliquez pourquoi .first() est alors obligatoire.
   });
 
   /**

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/03-chat-streaming/03-chat-streaming.spec.ts
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/03-chat-streaming/03-chat-streaming.spec.ts
@@ -73,7 +73,11 @@ test.describe('03 — Chat & Streaming LLM', () => {
     // Les modeles "thinking" (Qwen3.5) affichent "En train de reflechir..."
     // avant la reponse finale. On attend le contenu final dans
     // #response-content-container avec un timeout genereux.
-    const response = await waitForResponse(page, 90_000);
+    //
+    // `optional: true` : ici, et ICI SEULEMENT, l'absence de reponse est un cas
+    // prevu (le modele local peut etre indisponible) et non une erreur. Partout
+    // ailleurs waitForResponse echoue franchement — voir helpers/chat.ts.
+    const response = await waitForResponse(page, 90_000, { optional: true });
 
     // Le modele peut rester en "thinking" pendant toute la duree du timeout.
     // Dans ce cas, response contient le texte du thinking ou le header.
@@ -181,9 +185,45 @@ test.describe('03 — Chat & Streaming LLM', () => {
    * TEST 6 : Editer un message envoye
    *
    * On peut modifier un message deja envoye pour le reformuler.
-   * Cela regenere automatiquement la reponse.
    *
    * CONCEPT : Workflow multi-etapes (hover → bouton → interface d'edition)
+   *
+   * CONCEPT : un locator NON SCOPE cherche dans TOUTE la page.
+   *
+   * L'ancienne version ecrivait ceci :
+   *
+   *     const userMsg = page.locator(CHAT.userMessage).last();
+   *     await userMsg.hover();                                      // (1)
+   *     page.getByRole('button', { name: /modifier|edit/i }).last()  // (2)
+   *
+   * La ligne (1) survole bien le message utilisateur, mais la ligne (2) repart
+   * de `page` : elle ratisse tout le document. Or le fil contient DEUX boutons
+   * "Modifier" — un sur le message utilisateur, un sur la reponse de
+   * l'assistant. `.last()` prend le dernier dans l'ordre du DOM, donc celui de
+   * l'ASSISTANT.
+   *
+   * Le piege, c'est que ce test passait quand meme la plupart du temps : selon
+   * l'instant ou l'assistant a fini d'afficher sa barre d'actions, `.last()`
+   * tombait tantot sur un bouton, tantot sur l'autre. Mesure firsthand le
+   * 2026-08-07, meme instance v0.11.0, deux executions a 40 min d'intervalle :
+   *   - une fois la barre UTILISATEUR  -> echec en mode strict (2 correspondances)
+   *   - une fois la barre ASSISTANT    -> echec sur un bouton absent
+   * Deux symptomes differents, une seule cause : le locator n'etait pas scope.
+   * Ne vous arretez donc pas au message d'erreur — il change d'une execution a
+   * l'autre alors que le defaut, lui, ne bouge pas.
+   *
+   * Et les deux barres ne sont pas interchangeables : les MEMES identifiants y
+   * ont un sens OPPOSE (detail dans helpers/selectors.ts) :
+   *
+   *                                message UTILISATEUR   reponse ASSISTANT
+   *   #save-edit-message-button     "Enregistrer"         (absent)
+   *   #confirm-edit-message-button  "Envoyer"             "Enregistrer"
+   *                                  corrige ET regenere   corrige, sans regenerer
+   *
+   * La correction consiste donc a repartir du message (`userMsg.getByRole(...)`)
+   * et non de la page. Le mode strict devient alors un allie : s'il reste une
+   * ambiguite A L'INTERIEUR du message, Playwright le dira, au lieu de choisir
+   * au hasard a notre place.
    */
   test('editer un message utilisateur', async ({ page }) => {
     await selectModel(page, CLOUD_MODEL);
@@ -193,16 +233,20 @@ test.describe('03 — Chat & Streaming LLM', () => {
     const userMsg = page.locator(CHAT.userMessage).last();
     await userMsg.hover();
 
-    // Cliquer le bouton Modifier/Edit
-    const editButton = page.getByRole('button', { name: /modifier|edit/i }).last();
-    await editButton.click();
+    // Cliquer le bouton Modifier DE CE MESSAGE (et non le dernier de la page)
+    await userMsg.getByRole('button', { name: /modifier|edit/i }).click();
 
-    // L'interface d'edition devrait apparaitre
-    await expect(
-      page.locator(CHAT.saveEditButton).or(page.locator(CHAT.confirmEditButton))
-    ).toBeVisible({ timeout: 10_000 });
+    // La barre d'edition du message utilisateur affiche ses deux actions
+    // simultanement : on les asserte separement, pour ce que chacune fait.
+    await expect(page.locator(CHAT.saveEditButton)).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator(CHAT.confirmEditButton)).toBeVisible({ timeout: 10_000 });
 
-    // EXERCICE : Modifiez le texte et sauvegardez, puis verifiez la nouvelle reponse
+    // EXERCICE 1 : Modifiez le texte puis cliquez « Enregistrer » — verifiez
+    // qu'AUCUNE nouvelle reponse n'est generee. Recommencez avec « Envoyer » :
+    // cette fois une nouvelle reponse doit apparaitre.
+    // EXERCICE 2 : Remettez `page.getByRole(...).last()` a la place de
+    // `userMsg.getByRole(...)`, relancez le test une dizaine de fois, et
+    // comptez les echecs. C'est la definition d'un test instable.
   });
 
   // =====================================================================

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/helpers/chat.ts
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/helpers/chat.ts
@@ -139,12 +139,45 @@ export async function sendMessage(page: Page, message: string): Promise<void> {
  *
  * Pendant la phase "thinking" (Qwen, Claude) : le container peut
  * afficher du texte de reflexion. On attend que le vrai contenu arrive.
+ *
+ * ---------------------------------------------------------------------------
+ * CONCEPT : ne JAMAIS avaler un timeout en silence.
+ *
+ * Ce helper contenait un `.catch(() => {})` sur l'attente du contenu. Quand la
+ * reponse n'arrivait pas, l'erreur etait donc jetee a la poubelle, et la
+ * fonction repartait sur son fallback : le texte complet de la bulle
+ * assistant... c'est-a-dire, quand elle est vide, juste le nom du modele
+ * (« gpt-5.1 »). Le test recevait une chaine non vide et continuait comme si
+ * de rien n'etait — pour echouer trois lignes plus loin, sur une assertion
+ * sans rapport avec la vraie cause.
+ *
+ * Autrement dit : le symptome s'affichait loin de l'origine. C'est la premiere
+ * chose a eliminer quand on diagnostique une suite instable (cf. le guide
+ * TRIAGE-INFRA-VS-TEST.md : « un test doit echouer pour la BONNE raison »).
+ *
+ * Le probleme est reel et mesure : le 2026-08-07 sur l'instance de cours en
+ * v0.11.0, environ une requete sur six revient en HTTP 200 sans que le
+ * contenu ne s'affiche jamais (aucune erreur console, bouton « Stop » qui
+ * reste affiche), alors que le meme modele appele directement en API repond
+ * en 1,7 s. C'est un souci d'INFRASTRUCTURE, pas de test — mais encore
+ * fallait-il que le test le dise clairement.
+ *
+ * @param optional  true = tolerer l'absence de reponse et rendre ce qui est
+ *                  affiche (utilise par le test « modele local », ou
+ *                  l'indisponibilite est un cas prevu et non une erreur).
+ *                  Par defaut false : on echoue, avec un message explicite.
+ * ---------------------------------------------------------------------------
  */
-export async function waitForResponse(page: Page, timeoutMs = 120_000): Promise<string> {
+export async function waitForResponse(
+  page: Page,
+  timeoutMs = 120_000,
+  { optional = false }: { optional?: boolean } = {},
+): Promise<string> {
   // Attendre que le message assistant apparaisse
   await expect(page.locator(CHAT.assistantMessage).last()).toBeVisible({ timeout: 30_000 });
 
   // Attendre le contenu complet via polling
+  let timedOut = false;
   await page.waitForFunction(
     () => {
       const containers = document.querySelectorAll('#response-content-container');
@@ -153,7 +186,19 @@ export async function waitForResponse(page: Page, timeoutMs = 120_000): Promise<
     },
     undefined,
     { timeout: timeoutMs, polling: 1000 },
-  ).catch(() => {});
+  ).catch(() => {
+    timedOut = true;
+  });
+
+  if (timedOut && !optional) {
+    throw new Error(
+      `Aucune reponse de l'assistant apres ${Math.round(timeoutMs / 1000)}s : `
+      + '#response-content-container est reste vide. '
+      + "Verifiez l'instance AVANT de suspecter le test — si l'API repond mais "
+      + "que l'interface reste bloquee sur « Stop », le probleme est cote "
+      + 'infrastructure (voir TRIAGE-INFRA-VS-TEST.md).',
+    );
+  }
 
   // Petit delai pour le rendu final Svelte
   await page.waitForTimeout(500);
@@ -164,7 +209,9 @@ export async function waitForResponse(page: Page, timeoutMs = 120_000): Promise<
   const content = await contentContainer.innerText({ timeout: 5_000 }).catch(() => '');
   if (content.trim()) return content.trim();
 
-  // Fallback : texte complet du message assistant
+  // Fallback : texte complet du message assistant.
+  // ATTENTION : sur une bulle vide, cela rend le nom du modele, pas une reponse.
+  // On ne l'atteint donc que dans le cas `optional`.
   return await page.locator(CHAT.assistantMessage).last().innerText();
 }
 

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/helpers/selectors.ts
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/helpers/selectors.ts
@@ -67,7 +67,26 @@ export const CHAT = {
   assistantMessage: '.chat-assistant',
   // Bouton de statut (apparait apres la generation)
   statusToggle: 'button[aria-label="Toggle status history"]',
-  // Boutons d'edition
+  // Boutons d'edition d'un message deja envoye.
+  //
+  // v0.11 (VERIFIE firsthand 2026-08-07, recoupe avec le code source :
+  // UserMessage.svelte L304-330 et ResponseMessage.svelte L780-806).
+  //
+  // ATTENTION : les deux types de message n'ont PAS la meme barre d'edition,
+  // et les MEMES identifiants n'y ont pas le meme sens.
+  //
+  //                              message UTILISATEUR    reponse ASSISTANT
+  //   #save-edit-message-button   « Enregistrer »        (absent)
+  //   #close-edit-message-button  « Annuler »            « Annuler »
+  //   #confirm-edit-message-button « Envoyer »           « Enregistrer »
+  //                                 (corrige ET regenere)  (corrige, NE regenere PAS)
+  //   « Enregistrer comme copie »  (absent)              present
+  //
+  // Autrement dit #confirm-edit-message-button DECLENCHE une generation sur un
+  // message utilisateur et n'en declenche AUCUNE sur une reponse. Un identifiant
+  // ne suffit donc pas a exprimer l'intention : il faut d'abord SE PLACER sur le
+  // bon message (voir module 03, ou un `.last()` non scope tombait au hasard sur
+  // l'une ou l'autre barre selon l'execution).
   saveEditButton: '#save-edit-message-button',
   closeEditButton: '#close-edit-message-button',
   confirmEditButton: '#confirm-edit-message-button',
@@ -91,8 +110,7 @@ export const SIDEBAR = {
 // VERIFIE firsthand contre v0.10.2 fr-FR (2026-07, lors de la generation des
 // captures du Tour). Le bouton avatar (bas de la sidebar) porte l'aria-label
 // localise "Menu utilisateur" (fr) / "User menu" (en) et n'a pas d'ID stable.
-// Les entrees du menu (Reglages, Conversations archivees, Deconnexion...) sont
-// des <button> cibles par leur libelle via getByRole('button', { name }).
+// Le bouton lui-meme est INCHANGE en v0.11 (reverifie 2026-08-07).
 export const ACCOUNT = {
   // Bouton avatar ouvrant le menu utilisateur.
   menuButton:
@@ -102,7 +120,40 @@ export const ACCOUNT = {
   settingsEntry: /r[ée]glages|param[èe]tres|settings/i,
   // Autres entrees du menu (multilingue)
   logout: /d[ée]connexion|log ?out|sign ?out/i,
+  // ATTENTION v0.11 : "Conversations archivees" n'est PLUS une entree du menu,
+  // c'est un ONGLET (role=tab) de la fenetre Reglages — voir SETTINGS ci-dessous.
+  // On garde le libelle ici, mais ciblez-le avec getByRole('tab', ...).
   archivedChats: /conversations archiv[ée]es|archived chats/i,
+} as const;
+
+// --- Fenetre Reglages (v0.11) ---
+// VERIFIE firsthand contre v0.11.0 fr-FR (2026-08-07, instance de cours).
+//
+// CE QUI A CHANGE : la v0.11 a refondu toute l'interface. Les reglages ne sont
+// plus des PAGES avec une navigation en liens : ce sont des ONGLETS (role=tab)
+// dans une fenetre unique. `/admin/settings` n'est plus une route stable — elle
+// redirige vers `/` en ouvrant cette fenetre sur la section admin.
+//
+// 28 onglets releves, en DEUX groupes :
+//   - utilisateur : General, Interface utilisateur, Notifications, Keyboard,
+//     Integrations, Personnalisation, Audio, Controles des donnees,
+//     Consommation de tokens, Conversations archivees, Compte, A propos
+//   - admin       : General, Authentification, Connexions, Modeles, Sub-agents,
+//     Interface utilisateur, Audio, Images, Evaluations, Analytique,
+//     Integrations, Documents, Recherche Web, Execution de code, Pipelines,
+//     Base de donnees
+//
+// PIEGE (mode strict) : "General", "Interface utilisateur", "Audio" et
+// "Integrations" existent dans LES DEUX groupes -> 2 correspondances -> erreur
+// "strict mode violation". Pour affirmer qu'on est bien dans la section ADMIN,
+// visez un onglet qui n'existe QUE la : Authentification, Base de donnees...
+export const SETTINGS = {
+  // Onglets propres a l'administration (1 seule correspondance chacun)
+  adminAuthTab: /authentification|authentication/i,
+  adminDatabaseTab: /base de donn[ée]es|database/i,
+  adminConnectionsTab: /connexions|connections/i,
+  // Onglet present dans les deux groupes -> exige .first() (piege pedagogique)
+  ambiguousGeneralTab: /^g[ée]n[ée]ral$|^general$/i,
 } as const;
 
 // =====================================================================


### PR DESCRIPTION
## Contexte

Les 7 instances Open WebUI (dont celle qui sert de terrain aux TP) sont passées en **v0.11.0** le 2026-08-07. La v0.11 refond l'interface : les réglages admin deviennent des **onglets** dans une fenêtre unique, `/admin/settings` redirige vers `/`, et les barres d'édition de message changent.

L'espace `Playwright-OWUI` n'avait jamais été rejoué contre la v0.11. C'est fait : **campagne complète des modules 01-06 contre l'instance réelle — 37 passed / 1 failed / 4 skipped en 6,7 min**. C'est la revalidation que `00-Parcours-QA-OWUI.md` listait encore comme « à venir ».

Trois problèmes en sont sortis. **Aucun n'est un bug de l'application** — ce sont trois défauts de test, et chacun illustre un point que le parcours enseigne déjà.

## 1. Module 02 — un faux vert (le plus grave)

L'assertion cherchait un **lien** « Réglages ». En v0.11 ce sont des **onglets**. Et pourtant le test passait, par intermittence.

Chronologie mesurée sur l'instance :

| t | état |
|---|---|
| 4,3 s | `goto` terminé, `url=/admin/settings`, **0 correspondance** |
| 7,5 s | `<a href="/admin/settings">Réglages</a>` **apparaît** (vestige) |
| 10,7 s | redirection vers `/`, le lien **disparaît** |

Une fenêtre transitoire d'environ 3 s. Le même code a donné vert dans une suite et rouge dans une autre, **contre le même serveur**. Un test qui passe sans rien vérifier ne signale rien — c'est pire qu'un rouge.

**Correction** : attendre l'état stabilisé (`waitForURL` hors de `/admin/settings`), puis asserter l'onglet « Authentification », propre à la section admin. → module 02 **vert, 9/9**.

## 2. Module 03 — un locator non scopé

Le test survolait bien le message utilisateur, puis repartait de `page` :

```ts
const userMsg = page.locator(CHAT.userMessage).last();
await userMsg.hover();                                       // (1) bon message
page.getByRole('button', { name: /modifier|edit/i }).last()  // (2) toute la page
```

Le fil contient **deux** boutons « Modifier » (message utilisateur, réponse assistant). `.last()` prenait celui de l'assistant.

Deux exécutions sur la même instance à 40 min d'intervalle ont donné **deux symptômes différents** : échec en mode strict (2 correspondances) une fois, échec sur un bouton absent l'autre. Une seule et même cause.

Et les deux barres d'édition ne sont pas interchangeables — recoupé avec le code source amont (`UserMessage.svelte` L304-330, `ResponseMessage.svelte` L780-806) :

| | message **utilisateur** | réponse **assistant** |
|---|---|---|
| `#save-edit-message-button` | « Enregistrer » | *(absent)* |
| `#confirm-edit-message-button` | « **Envoyer** » — corrige **et régénère** | « **Enregistrer** » — corrige, **sans** régénérer |

Le même identifiant déclenche une génération d'un côté et pas de l'autre : un `id` ne suffit pas à exprimer l'intention, il faut d'abord se placer sur le bon message.

**Correction** : partir du message (`userMsg.getByRole(...)`) et asserter les deux boutons séparément. → **vert** (15,9 s puis 11,8 s).

## 3. `helpers/chat.ts` — `waitForResponse()` avalait son propre timeout

```ts
await page.waitForFunction(/* … */).catch(() => {});   // l'erreur part à la poubelle
// …
return await page.locator(CHAT.assistantMessage).last().innerText();  // « gpt-5.1 »
```

Quand la réponse n'arrivait pas, la fonction repartait sur son fallback : le texte complet de la bulle assistant — c'est-à-dire, sur une bulle vide, **le seul nom du modèle**. Le test recevait une chaîne non vide, continuait, et échouait trois lignes plus loin sur une assertion sans rapport avec la cause.

`waitForResponse` échoue désormais franchement, en nommant la cause et en renvoyant vers `TRIAGE-INFRA-VS-TEST.md`. Un paramètre `optional` préserve le seul cas où l'absence de réponse est un scénario prévu (test « modèle local indisponible »).

Effet mesuré — avant/après, sur la même panne :

```
avant :  expected 8 to be greater than 50
après :  Aucune reponse de l'assistant apres 120s : #response-content-container
         est reste vide. Verifiez l'instance AVANT de suspecter le test — si
         l'API repond mais que l'interface reste bloquee sur « Stop », le
         probleme est cote infrastructure (voir TRIAGE-INFRA-VS-TEST.md).
```

## Constat d'infrastructure (hors périmètre de cette PR)

En instrumentant la panne ci-dessus : sur l'instance de cours en v0.11.0, **environ une requête de chat sur six revient en HTTP 200 sans jamais afficher son contenu** — bulle assistant vide, bouton « Stop » qui reste, **aucune erreur console**. Le même modèle appelé directement en API répond en **1,7 s** (`gpt-5.1`) et **3,6 s** (`qwen3.6-35b-a3b`). Mesuré sur 7 tours en navigateur plus 4 exécutions de la suite.

C'est un problème d'**infrastructure**, pas de test — précisément la distinction qu'enseigne `TRIAGE-INFRA-VS-TEST.md` (#9752, mergé). Les tests le signalent maintenant correctement au lieu de le masquer. Le suivi côté exploitation est fait ailleurs ; rien à corriger ici.

## Aussi

`helpers/selectors.ts` gagne un groupe `SETTINGS` documentant les **28 onglets** de la fenêtre de réglages v0.11 (12 utilisateur + 16 admin) et le piège « Général », présent dans **les deux** groupes donc ambigu en mode strict. `ACCOUNT.archivedChats` signale que « Conversations archivées » est devenu un onglet. Les deux points sont confirmés par le changelog amont v0.11.0, section *Changed* (« Admin settings moved into settings », « Archived chats moved to settings »).

## Vérification

- `npx tsc --noEmit` : propre
- module 02 : **9/9**
- module 03 : les deux tests corrigés **verts** ; le seul rouge restant est la panne d'infrastructure ci-dessus, désormais correctement attribuée

Refs #4433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
