### PR TITLE
docs(privacy,#9862): root PRIVACY.md — repo-wide PII posture

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,64 @@
+# Confidentialité — CoursIA
+
+> Posture PII **du dépôt public** `jsboige/CoursIA`. Ce document décrit ce qui n'y figure
+> jamais, où vivent les données sensibles, et ce qui est publiquement exposé — pour qu'un
+> lecteur externe n'ait pas à le deviner.
+>
+> Il complète la notice RGPD du moteur de notation, [`GradeBookApp/PRIVACY.md`](GradeBookApp/PRIVACY.md),
+> qui détaille le traitement des données étudiantes par l'application elle-même.
+
+## 1. Ce qui n'est jamais dans ce dépôt
+
+Le dépôt est **public** et ne contient, par construction, **aucune donnée étudiante** :
+
+- **Copies et rendus** : jamais de travaux, de fichiers soumis, de notebooks d'étudiant.
+- **Notes et appréciations** : aucun relevé, aucune moyenne, aucun commentaire d'évaluation.
+- **Identités** : aucun nom, prénom, adresse e-mail, numéro étudiant, identifiant.
+- **Captures et artifacts nominatifs** : aucune capture d'écran, aucun log, aucune sortie
+  nommant une personne.
+
+Cette règle est vérifiée automatiquement : des gates CI refusent les commits introduisant
+des données étudiantes (`pii_no_output`) et le dépôt est audité pour les secrets en clair
+(`gitleaks`). L'historique public reste consultable.
+
+## 2. Où vivent les données sensibles
+
+Les pipelines de notation et les **données par cohorte** vivent sur un **stockage privé,
+hors dépôt**, accessible aux seuls enseignants concernés. Le chemin est résolu localement
+par le moteur via la variable `COURSIA_ROOT` (voir
+[`GradeBookApp/configs/README.md`](GradeBookApp/configs/README.md)). **Ce fichier ne cite
+ni le chemin exact, ni les noms de cohortes** : la posture se décrit sans exposer la
+topologie de stockage.
+
+## 3. Ce qui est public, et pourquoi
+
+Est publiquement exposé **uniquement le moteur générique** de notation
+([`GradeBookApp/`](GradeBookApp/)) : configuration, barèmes-types, code de calcul. Il est
+vide de données — utile pédagogiquement (reproductibilité, transparence de la méthode),
+sans risque pour les personnes. La notice de traitement de ce moteur est documentée
+séparément dans [`GradeBookApp/PRIVACY.md`](GradeBookApp/PRIVACY.md).
+
+Tout le reste du dépôt (notebooks, scripts, documentation) est du matériel **pédagogique
+sans données personnelles**.
+
+## 4. Finalité et durée
+
+- **Finalité unique** : évaluation et pilotage pédagogique des cours concernés. Aucune
+  finalité commerciale, de profilage ou de publicité.
+- **Conservation** : limitée au cycle de la promotion concernée. Les données privées hors
+  dépôt ne sont pas conservées au-delà de leur utilité pédagogique.
+
+## 5. Contact
+
+Pour une demande d'accès, de rectification ou d'effacement relative à des données traitées
+dans le cadre d'un cours, contacter l'enseignant responsable du dépôt (le propriétaire du
+compte `jsboige` sur GitHub). Le moteur étant exécuté localement par l'enseignant sur ses
+propres données, c'est ce dernier qui est responsable du traitement
+(cf. [`GradeBookApp/PRIVACY.md`](GradeBookApp/PRIVACY.md) §2).
+
+---
+
+Ce document décrit des **faits vérifiables** sur la structure du dépôt ; il ne constitue
+pas une attestation de conformité à un cadre normatif particulier. La responsabilité du
+traitement des données étudiantes revient à l'enseignant qui exécute le moteur, non au
+dépôt.

--- a/README.md
+++ b/README.md
@@ -505,6 +505,13 @@ Conventions : PEP 8 pour Python, conventions standard pour C#, pas d'emojis dans
 
 Ce projet est sous licence MIT - voir [LICENSE](LICENSE).
 
+## Confidentialité
+
+Le dépôt est public et **ne contient aucune donnée étudiante** (copies, notes, identités).
+Les pipelines et données de notation vivent sur un stockage privé hors dépôt ; seul le
+[moteur de notation générique](GradeBookApp/) est public, vide de données. Détails et
+posture PII : [PRIVACY.md](PRIVACY.md).
+
 ---
 
 Repository : [github.com/jsboige/CoursIA](https://github.com/jsboige/CoursIA)


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2025:CoursIA — prev: DEEP/notebook-python

## Ce que fait cette PR

Crée `PRIVACY.md` à la **racine du dépôt** documentant la posture PII **du dépôt public** : ce qui n'y figure jamais, où vivent les données sensibles, ce qui est exposé et pourquoi. Réponse à #9862 (revue multi-modèles externe : trois modèles ont conclu que le dépôt « se décrit mal lui-même » sur le PII, un concluant à tort que « GradeBook et des données RGPD sont dans le monorepo »).

## Contenu

- `PRIVACY.md` (nouveau, racine) — 5 sections couvrant l'acceptance #9862 :
  1. **Ce qui n'est jamais dans ce dépôt** (copies, notes, identités, captures nominatives) + gates CI qui l'enforcent (`pii_no_output`, `gitleaks`).
  2. **Où vivent les données sensibles** (stockage privé hors dépôt, résolu via `COURSIA_ROOT`) — **sans citer le chemin exact ni les noms de cohortes**.
  3. **Ce qui est public et pourquoi** (moteur générique `GradeBookApp/` seul, vide de données).
  4. **Finalité et durée** (pédagogique ; limitée au cycle de promotion).
  5. **Contact** (enseignant responsable).
- `README.md` — section `## Confidentialité` (footer, après `## Licence`) pointant vers `PRIVACY.md`.

## Non-duplication

Référence [`GradeBookApp/PRIVACY.md`](GradeBookApp/PRIVACY.md) (notice RGPD du moteur de notation, #8054/#8063) au lieu de la dupliquer. La notice moteur détaille le **traitement** des données par l'application ; ce fichier décrit la **posture du dépôt** (ce qui est public/privé). Périmères complémentaires.

## Acceptance #9862 (point par point)

- [x] `PRIVACY.md` présent, français, 5 points couverts.
- [x] Lien depuis le README racine (section `## Confidentialité`).
- [x] **Zero PII introduite** : vérifié `grep -niE "cohort|@.*\.(com|fr)|/home/|C:\\Users|G:\\|GDrive\\"` — les seules occurrences sont les termes *génériques* (« données par cohorte », « notebooks d'étudiant ») décrivant ce qui est absent ; **aucun nom de cohorte, aucun chemin de stockage, aucun e-mail**.
- [x] **Aucune affirmation de conformité non vérifiable** : pas de label « conforme RGPD » ; le document décrit des faits vérifiables (structure du dépôt, gates CI) et précise que la responsabilité du traitement revient à l'enseignant. Vérifié `grep "conforme"` = 0 self-awarded label.

## Coordination (partition avec #9847)

Conforme au garde-fou de coordination de #9862 : ce grain écrit `PRIVACY.md` + **une** section de lien. La section `## Confidentialité` est dans le **footer** du README (après `## Licence`, L507), **hors** des grains G1 (Structure/Cartographie) et G6 (Séries de notebooks) de #9847. po-2026 est sur G2 (Outils Claude Code) — aucune collision.

## Mesures (firsthand)

- L898 collision check : `gh pr list --search PRIVACY` — un précédent existe (PR #8063, `GradeBookApp/PRIVACY.md`), mais **aucune** PR pour un `PRIVACY.md` racine. Périmère distinct (moteur vs dépôt).
- Cibles de lien vérifiées exists : `GradeBookApp/PRIVACY.md`, `GradeBookApp/configs/README.md`, `GradeBookApp/`.
- Catalogue byte-identique à `main` (`git diff origin/main -- COURSE_CATALOG.generated.*` = vide).

See #9862.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
