### PR TITLE
docs(readme,#9847): reconcile Structure tree with disk — remove tools/, add 4 missing dirs, GenAI subtree (grain G1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,8 @@ CoursIA/
     ML/                        Machine Learning (C#, Python)
     RL/                        Reinforcement Learning (Python)
     GenAI/                     IA Générative (Python)
-      Image/ Audio/ Video/ Texte/ SemanticKernel/ FineTuning/ PostTraining/
-      Open-WebUI/ Vibe-Coding/ RAG-et-Memoire-Semantique/ CaseStudies/
+      00-GenAI-Environment/ Image/ Audio/ Video/ Texte/ SemanticKernel/ FineTuning/ PostTraining/
+      Open-WebUI/ Vibe-Coding/ RAG-et-Memoire-Semantique/ CaseStudies/ tutorials/
     QuantConnect/              Trading algorithmique (Python)
       Python/                  Notebooks pédagogiques
       projects/                Stratégies backtestées
@@ -296,11 +296,14 @@ CoursIA/
 
   scripts/                     Validation, exécution, analyse
   docs/                        Documentation pérenne (procédures, inventaires, leçons consolidées)
-  tools/                       Outils transverses (audit, qualité, maintenance)
+  translations/                Données de traduction multilingue (dataset Argumentum, #6949)
   slides/                      Présentations pédagogiques
   docker-configurations/       Infrastructure Docker GPU
   GradeBookApp/                Notation étudiants
+  GradeBookApp.Tests/          Tests du moteur de notation
   MyIA.AI.Shared/              Bibliothèque C# partagée
+  MyIA.AI.Shared.Tests/        Tests de la bibliothèque partagée
+  MyIA.Trading.Converter/      Conversion de formats de données de trading
 ```
 
 ---


### PR DESCRIPTION
## Summary

Grain: **MED/readme** (disk reconciliation) — `#9847` grain **G1/7** (Structure & cartographie, defects D1+D2+D3). Lane `myia-po-2026:CoursIA`. Dispatch: P2 self-pick (pool global, 0 claim sur G1).

L'arbre `## Structure du dépôt` du README racine avait dérivé du disque réel de 3 façons vérifiées firsthand par ai-01. Cette PR réconcilie l'arbre avec le disque — chaque entrée listée existe, aucun dossier réel manquant.

## Defects corrigés (mesurés `git ls-tree` sur origin/main)

| # | Defect | Avant | Après | Preuve disque |
|---|--------|-------|-------|---------------|
| **D1** | `tools/` listé comme dossier racine | `tools/  Outils transverses` | **retiré** | `git ls-tree -d` = 0 match (n'existe pas) |
| **D2** | 4 dossiers racines trackés absents de l'arbre | manquants | **ajoutés** : `translations/` (59 fichiers), `GradeBookApp.Tests/` (5), `MyIA.AI.Shared.Tests/` (8), `MyIA.Trading.Converter/` (25) | chacun vérifié `git ls-tree -d` |
| **D3** | GenAI subtree listait 11/13 sous-séries pédagogiques | manquaient `00-GenAI-Environment/` + `tutorials/` | **ajoutés** | `git ls-tree -d ...:GenAI` = 16 dirs, 13 pédagogiques |

Support dirs GenAI (`assets/` modèles, `shared/` helpers, `temp/` .gitkeep) délibérément omis — non-pédagogiques.

## §E whole-file audit

- **Cartographie rapide (L23)** : vérifiée séparément, **déjà correcte** (12 séries pédagogiques, pas de `tools/`, `Config/` légitimement omis comme non-pédagogique). Intacte.
- **Arbre réconcilié end-to-end** : post-fix, chaque entrée racine de l'arbre (`scripts`, `docs`, `translations`, `slides`, `docker-configurations`, `GradeBookApp`, `GradeBookApp.Tests`, `MyIA.AI.Shared`, `MyIA.AI.Shared.Tests`, `MyIA.Trading.Converter`) résout vers un vrai dir `git ls-tree -d`. Les 5 occurrences résiduelles de `tools/` dans le fichier sont toutes `scripts/notebook_tools/` (le vrai module) — bénignes.
- 13 dirs top-level `MyIA.AI.Notebooks/` tous présents dans l'arbre (ICT est une sous-série sous `IIT/`, pas top-level — correct).

## Périmètre (anti-composite G.4)

`#9847` décompose le README racine en 7 grains. Cette PR = **G1 uniquement** (arbre Structure). Autres défauts : **D4 fait en #9853** (mon cycle précédent), D5 (deps table) / G3-G7 restent ouverts comme grains frères.

Aucun marqueur `CATALOG-STATUS` dans le README racine → catalogue byte-identique à main (`catalog-pr-hygiene` R1).

## Détails

- `README.md` : arbre `## Structure du dépôt` réconcilié, +6/−3.
- LF-only (0 CRLF byte-level). Diff minimal, 1 fichier, 1 section.

See #9847 (grain G1/7 — contribution partielle à l'EPIC multi-grain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
