### PR TITLE
docs(repo-size,#9860): repo size policy + advisory blob gate

### DIFF
--- a/.github/workflows/repo-size-advisory.yml
+++ b/.github/workflows/repo-size-advisory.yml
@@ -1,0 +1,59 @@
+# Repo size advisory — signale les gros blobs ajoutes par une PR (jamais bloquant)
+#
+# Politique : docs/reference/repo-size-policy.md (grain #9860). Les notebooks sont committes
+# AVEC leurs sorties (C.2) — le poids est attendu. Ce gate est ADVISORY (exit 0, ::warning::) :
+# il rend visible un blob > seuil pour ouvrir la conversation LFS-vs-justification, sans
+# bloquer le merge. Conforme au pattern de visibilite de variation-tag-guard.yml.
+#
+# Seuil : 10 MiB, calibre sur la mesure reelle (cf. policy §3) — capture datasets/checkpoints/
+# vendored-binaries (25-63 MB) tout en respectant la queue legitime des notebooks-avec-outputs.
+# ADVISORY, jamais bloquant : ce job sort toujours en exit 0.
+name: Repo Size Advisory
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  large-blob-advisory:
+    name: Large blob advisory (>= 10 MiB)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR (full history for blob diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan added blobs above threshold
+        env:
+          THRESHOLD_BYTES: 10485760  # 10 MiB
+        run: |
+          set -uo pipefail
+          # ADVISORY : on ne fail jamais, on collecte et on avertit.
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          echo "Scanning added blobs between ${BASE:0:12}..${HEAD:0:12} (threshold ${THRESHOLD_BYTES} bytes)"
+          found=0
+          # git diff --raw : ':<oldmode> <newmode> <oldsha> <newsha> <status>\t<path>'
+          # Pour un fichier ajoute (status A), oldsha est zeros, newsha est le blob SHA.
+          while IFS= read -r line; do
+            # extrait newsha (champ 4) et path (apres la tabulation)
+            newsha=$(printf '%s' "$line" | awk '{print $4}')
+            path=${line#*$'\t'}
+            [ -z "$newsha" ] || [ "$newsha" = "0000000000000000000000000000000000000000" ] && continue
+            size=$(git cat-file -s "$newsha" 2>/dev/null || echo 0)
+            if [ "$size" -gt "$THRESHOLD_BYTES" ]; then
+              mb=$(awk "BEGIN{printf \"%.1f\", $size/1048576}")
+              echo "::warning file=${path}::Blob ajoute de ${mb} MiB (> seuil advisory 10 MiB). Policy docs/reference/repo-size-policy.md : LFS candidate ou justification pedagogique requise."
+              found=1
+            fi
+          done < <(git diff --raw --diff-filter=A "${BASE}" "${HEAD}" 2>/dev/null)
+          if [ "$found" -eq 1 ]; then
+            echo "ATTENTION : un ou plusieurs blobs depassent le seuil advisory. Voir policy docs/reference/repo-size-policy.md."
+          else
+            echo "OK : aucun blob ajoute au-dela du seuil advisory."
+          fi
+          exit 0

--- a/docs/reference/repo-size-policy.md
+++ b/docs/reference/repo-size-policy.md
@@ -1,0 +1,99 @@
+# Politique de taille du dépôt — CoursIA
+
+> Le dépôt pèse ~1,2 GiB de pack pour un projet pédagogique. Ce document explique
+> **pourquoi** ce poids est le prix d'une décision délibérée, **ce qui est acquis** (et ne
+> sera pas réécrit), et **ce qui est surveillé** à l'avenir. Mesure, pas impression.
+
+## 1. Pourquoi les sorties de notebooks restent committées (C.2 / H.1)
+
+Les notebooks pédagogiques sont committés **avec leurs sorties**. C'est une règle dure du
+projet ([notebook-conventions](../../.claude/rules/notebook-conventions.md) C.2) : les
+outputs **sont** le livrable pédagogique — ils prouvent que le code s'exécute et montrent le
+résultat attendu. Retirer les sorties détruirait cette preuve (H.1 : validation = exécution
+complète + outputs vérifiés). Le poids du dépôt est donc, pour une large part, le coût
+d'une exigence de qualité, pas une négligence.
+
+## 2. Deux refus argumentés (acquis, non négociables)
+
+### 2.1 `nbstripout` : NON
+
+Stripping les sorties à l'indexation détruirait le livrable (C.2) et falsifierait la preuve
+d'exécution (H.1). Un notebook pédagogique sans ses outputs n'est plus qu'un script : il
+ne montre plus le résultat de l'algorithme, la figure générée, la métrique du backtest.
+Cette règle est **posée noir sur blanc pour clore le sujet** — la taille n'est pas un motif
+de retirer les sorties.
+
+### 2.2 Réécriture d'historique (`git filter-repo`, BFG) : NON
+
+Le dépôt compte ~95 forks étudiants. Réécrire l'historique casserait chacun d'eux (tout
+`pull` ultérieur entrerait en conflit). Le poids passé est **acquis** : les grands blobs
+déjà committés (cf. §3) restent dans l'historique. La politique est **entièrement tournée
+vers l'avenir** — on surveille ce qui entre, on ne défait pas ce qui est fait.
+
+## 3. Mesure réelle (plus gros blobs, ordre décroissant)
+
+Mesuré firsthand via `git rev-list --objects --all | git cat-file --batch-check` (équivalent
+fonctionnel à `git-sizer` pour le classement par blob, sans dépendance Go) :
+
+| Taille | Blob | Statut | Décision |
+|--------|------|--------|----------|
+| 63 MB | `Sudoku/IKVM.Java.dll` | vendored (pont Java IKVM pour Sudoku/Tweety, #4667) | acquis — vendored légitime |
+| 53 MB | `Argument_Analysis/libs/org.tweetyproject.tweety-full-1.28-…jar` | vendored (Tweety) | acquis — vendored légitime |
+| 29 MB | `QuantConnect/ML-Training-Pipeline/checkpoints/lstm/…/model.pt` | **supprimé** (history-only, désormais gitignoré) | incident passé — §4 empêche la récurrence |
+| 25 MB | `ML/ML.Net/taxi-fare.csv` | dataset pédagogique | candidat LFS futur (§5) |
+| 21 MB | `GenAI/Audio/02-Advanced/02-4-Demucs-Source-Separation.ipynb` (+ ×N révisions) | notebook + outputs (audio base64) | acquis — poids légitime C.2 |
+
+Le pack agrégé (~1,2 GiB bare) reflète : (a) les blobs vendored légitimes, (b) l'historique
+des notebooks-avec-outputs (chaque révision d'un notebook riche compte), (c) quelques
+incidents passés (le `model.pt`) désormais nettoyés de l'arbre courant.
+
+> **Note locale** : `git count-objects -vH` peut afficher `size-pack` plus élevé et des
+> `warning: garbage found: .git/objects/pack/tmp_pack_*` sur un clone de travail. Ces
+> `tmp_pack_*` sont du **garbage local** à la machine (un `git gc` les élimine), pas un
+> problème du dépôt distant. Ne pas les confondre avec le sujet.
+
+## 4. Ce qui ne doit JAMAIS entrer
+
+Ces catégories n'ont pas vocation dans le dépôt — un check advisory (§6) les signale, et le
+`.gitignore` les exclut quand elles sont prévisibles :
+
+- **Checkpoints de modèles** (`.pt`, `.pth`, `.ckpt`, `.safetensors` de training) — cf.
+  l'incident `model.pt` 29 MB, supprimé puis gitignoré. Un checkpoint n'est pas un livrable
+  pédagogique : le notebook documente *comment* l'entraîner, pas le poids binaire du résultat.
+- **Artefacts `_output` volumineux** (sorties Papermill `_output.ipynb` régénérées) — ce sont
+  des artefacts de processus, pas du matériel versionné.
+- **Caches** (`__pycache__/`, `.pytest_cache/`, `bin/`, `obj/`) — déjà couverts par
+  `.gitignore` et la convention `_archive/` (#9535).
+- **Données brutes volumineuses** non pédagogiques (dump de production, logs complets).
+
+## 5. Candidats Git LFS à l'avenir
+
+Pour les **futurs** ajouts (pas de rétro-conversion de l'existant), Git LFS est la voie
+désignée au-dessus du seuil advisory (§6) :
+
+- **Datasets** (`.csv`/`.parquet` pédagogiques au-delà du seuil, ex: `taxi-fare.csv`) — le
+  notebook les consomme mais le binaire n'a pas besoin d'être dans l'historique git.
+- **Assets binaires GenAI** (modèles de base, poids, datasets d'images).
+- **Renders et figures binaires** hors notebooks (galerie README) quand ils dépassent le seuil.
+
+Le seuil advisory (§6) est là pour **déclencher la conversation** : un blob > seuil dans une
+PR ouvre la question « LFS ou justification pédagogique ? », sans bloquer le merge.
+
+## 6. Check advisory (jamais bloquant)
+
+Un workflow CI (`.github/workflows/repo-size-advisory.yml`) signale, sur chaque PR, les blobs
+ajoutés au-dessus du seuil retenu. Il est **advisory** (`exit 0`, `::warning::`) — conforme au
+pattern des gates de visibilité (`variation-tag-guard`) : il rend le fait visible sans
+bloquer le travail.
+
+**Seuil retenu : 10 MiB**, justifié par la mesure §3 : il capture les datasets/checkpoints/
+vendored-binaries (25–63 MB) tout en respectant la queue légitime des notebooks-avec-outputs
+de taille modeste. Le seuil est calibré sur les chiffres réels, pas sur une intuition.
+
+## Voir aussi
+
+- [notebook-conventions.md](../../.claude/rules/notebook-conventions.md) — C.2 (outputs
+  committés), H.1 (validation = exécution + outputs)
+- [secrets-hygiene.md](../../.claude/rules/secrets-hygiene.md) — règle 6 (Stop & Repair,
+  jamais scrubber une sortie)
+- Convention `_archive/` — [#9535](https://github.com/jsboige/CoursIA/issues/9535)


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA — prev: MED/tooling (#9858 audit)

## Ce que fait cette PR

Pose une **politique de taille de dépôt** écrite + un check advisory, réponse à #9860 (la revue externe a fait du 1,18 GiB de pack un signal alarmant ; c'est en réalité le prix attendu d'une décision délibérée — notebooks committés AVEC leurs sorties, C.2 — mais le fait était indefendable de l'extérieur et non surveillé).

## Contenu (2 fichiers)

- **`docs/reference/repo-size-policy.md`** (nouveau, FR) :
  - §1 pourquoi les sorties restent committées (C.2/H.1).
  - §2 les **2 refus argumentés noir sur blanc** : `nbstripout` (détruit C.2, falsifie H.1) et `git filter-repo`/BFG (casserait ~95 forks étudiants). Le poids passé est **acquis**.
  - §3 **mesure réelle** : plus gros blobs classés (via `git rev-list --objects | git cat-file --batch-check`, équivalent fonctionnel à `git-sizer` sans dépendance Go) — IKVM.Java.dll 63 MB, tweety-full.jar 53 MB (vendored acquis), model.pt 29 MB (**supprimé + gitignoré**, incident passé), taxi-fare.csv 25 MB (LFS candidate), Demucs.ipynb 21 MB (notebook+outputs légitime).
  - §4 ce qui ne doit **jamais** entrer (checkpoints, `_output` volumineux, caches) — cite l'incident `model.pt`.
  - §5 candidats Git LFS futurs + seuil.
  - §6 renvoi au check advisory.
- **`.github/workflows/repo-size-advisory.yml`** (nouveau) : check **advisory** (exit 0, `::warning::`) conforme au pattern de visibilité de `variation-tag-guard`. Scanne les blobs ajoutés par la PR (`git diff --raw --diff-filter=A`), avertit au-delà de 10 MiB. Seuil justifié par la mesure §3 (capture datasets/checkpoints/vendored-binaries 25-63 MB, respecte la queue des notebooks-avec-outputs).

## Acceptance #9860 (point par point, firsthand)

- [x] **Seuils réels publiés** : §3 du policy doc + ce body (tableau des plus gros blobs mesurés firsthand).
- [x] `docs/reference/repo-size-policy.md` présent, FR, porte explicitement les **2 refus** (§2.1 nbstripout, §2.2 filter-repo).
- [x] Check advisory en place, seuil (10 MiB) **justifié par la mesure** §3, pas par intuition.
- [x] Mention du garbage local `tmp_pack_*` (§3 note locale : `git gc`, pas un problème distant).

## Non-duplication

Pas de régénération catalogue (byte-identique à main). Policy doc est nouveau (grep `docs/reference` — aucun `repo-size` existant). Le check advisory est un workflow distinct, pas une surcharge d'un gate existant (variation-tag-guard reste sur son périmètre tag/cap).

## Mesures (firsthand)

- **Blob-scan logic testée localement** : `git diff --raw --diff-filter=A HEAD~5 HEAD` parsé → extraction newsha+path correcte, size checké. Parsing validé.
- YAML valide (`yaml.safe_load`).
- `model.pt` vérifié **history-only** (supprimé de l'arbre courant, gitignoré) — incident passé, §4 empêche la récurrence.
- Catalogue byte-identique (`git diff origin/main -- COURSE_CATALOG.generated.*` = vide).

## Notes

- **git-sizer non installé** : fallback `git rev-list --objects --all | git cat-file --batch-check` donne le même classement par blob (taille + path), sans dépendance Go. La policy documente cette équivalence. `git-sizer` fournirait en sus des métriques d'arbre/historique (profondeur, nombre max de parents) — non bloquant pour le classement des blobs, qui est la question de la policy.
- Le check est **advisory par design** (exit 0) : il ne bloque aucun merge, conformément à l'acceptance (« jamais bloquant ») et au pattern variation-tag-guard. Il rend le gros-blob visible pour ouvrir la conversation LFS-vs-justification.

See #9860.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
