### PR TITLE
feat(release,#9856): generate release notes from catalogue (v<annee>.S<semestre>)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ mono_crash.*
 [Dd]ebugPublic/
 [Rr]elease/
 [Rr]eleases/
+# Negation: scripts/release/ is intentional tooling (release notes generator, #9856),
+# not a Visual Studio Release/ build artefact. Without this, the [Rr]elease/
+# pattern above (which matches anywhere in the tree) would silently exclude it.
+!scripts/release/
 x64/
 x86/
 [Aa][Rr][Mm]/

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,0 +1,46 @@
+# scripts/release/
+
+Outils lies au cycle de release semestriel (`v<annee>.S<semestre>`). Source de
+la decision de design : issue **#9856** (« 0 tag / 0 release pour ~95 forks
+etudiants -- poser v2026.S2 et generer les notes »). Le depot a ete
+historiquement sans tag et sans release GitHub ; ce repertoire introduit la
+plomberie minimale pour les ajouter.
+
+## Pourquoi ces notes sont generees (et pas tapees a la main)
+
+L'acceptance **#9856** est explicite : « les notes citent des comptes **lus
+dans le catalogue**, jamais recopies a la main ». Taper les comptes a la
+main derive inevitablement avec le catalogue (cron quotidien) -- une release
+deja publiee devient obsolète des qu'une entree est ajoutee. Le script
+[`generate_release_notes.py`](generate_release_notes.py) re-calcule tout a
+chaque execution ; les notes sont donc byte-deterministes en fonction du
+catalogue seul (le seul element qui change entre deux executions est
+l'horodatage UTC injecte dans l'en-tete).
+
+## Scripts
+
+| Fichier | Role |
+|---|---|
+| [`generate_release_notes.py`](generate_release_notes.py) | Lit `COURSE_CATALOG.generated.json` et emet les notes markdown d'une release |
+
+## Tests
+
+`scripts/tests/test_generate_release_notes.py` -- 22 tests unitaires sur le
+module (load / count / render / CLI / determinism).
+
+## Utilisation type
+
+```bash
+# Notes v2026.S2 sur stdout (le catalogue est sur main par defaut)
+python scripts/release/generate_release_notes.py --tag v2026.S2
+
+# Notes dans un fichier, prete a etre injectees dans gh release create
+python scripts/release/generate_release_notes.py --tag v2026.S2 \
+    --out RELEASE_NOTES_v2026.S2.md
+
+# Section "ajouts depuis rentree" optionnelle
+python scripts/release/generate_release_notes.py --tag v2026.S2 \
+    --out RELEASE_NOTES_v2026.S2.md --since 2026-09-01
+```
+
+Aucune dependance hors stdlib Python 3.10+.

--- a/scripts/release/generate_release_notes.py
+++ b/scripts/release/generate_release_notes.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Generate release notes for a CoursIA semester tag (v<annee>.S<semestre>) from
+the on-disk COURSE_CATALOG.generated.json (issue #9856).
+
+WHY THIS EXISTS (per #9856): "0 tag / 0 release pour ~95 forks etudiants --
+poser v2026.S2 et generer les notes". The acceptance is explicit:
+
+    gh release list renvoie au moins une release, dont les notes citent
+    des comptes **lus dans le catalogue**, jamais recopies a la main.
+
+This script makes the acceptance literal: every number in the rendered
+markdown comes from the JSON, recomputed at tag-time. Re-running the script
+on a newer catalogue produces a newer set of counts -- there is no notion of
+"stale hand-typed count" because there is no hand-typed count anywhere.
+
+DESIGN (per #9856 design decision): the tag schema is v<annee>.S<semestre>.
+The next tag is v2026.S2. Pedagogical repository = semester-based, not semver
+(no API to version). Argument ``--tag v2026.S2`` is the only positional
+required. Argument ``--catalogue`` defaults to the standard path on main
+(the cron-regenerated file). Argument ``--out`` defaults to stdout.
+
+CONSTRAINTS (these exist for reasons):
+
+  - Stdlib-only. CI advisory tools in this repo (grain_tag.py,
+    variation_light_cap.py, check_lane_claim.py) are all stdlib-only so the
+    CI matrix does not depend on a per-script venv. A release-notes generator
+    is no different: it ships with the PR that introduced it.
+
+  - Counts are derived, not interpolated. If a user runs the script with a
+    catalogue that says 6 in some count, the markdown says 6. No smoothing,
+    no rounding to nearest 10.
+
+  - The "series added since rentree" section is OPTIONAL (--since YYYY-MM-DD).
+    If omitted, that section is skipped -- we never fabricate series additions
+    we cannot attest from the catalogue.
+
+  - The series README links are derived from the ``serie`` field via the
+    standard MyIA.AI.Notebooks/<serie>/README.md convention. If a README does
+    not exist on disk, the link is rendered with a leading "(README absent) "
+    prefix and a verification command is printed -- NOT silently dropped.
+
+USAGE
+
+    # default: read catalogue from standard path, write markdown to stdout
+    python scripts/release/generate_release_notes.py --tag v2026.S2
+
+    # write to file
+    python scripts/release/generate_release_notes.py --tag v2026.S2 \
+        --out RELEASE_NOTES_v2026.S2.md
+
+    # with "added since rentree" section
+    python scripts/release/generate_release_notes.py --tag v2026.S2 \
+        --since 2026-09-01
+
+EXIT CODES
+
+  - 0: success. Notes are written (or printed).
+  - 2: catalogue missing or unreadable JSON.
+  - 3: catalogue is empty (no entries). We refuse to emit a release on an
+       empty catalogue -- better to fail loud than ship a release with a
+       single zero-line table.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+# The standard location, on main, of the catalogue the cron regenerates daily.
+DEFAULT_CATALOGUE = Path("COURSE_CATALOG.generated.json")
+
+# Conventional README path per serie. The script does NOT assert these exist --
+# it renders the link anyway and annotates "(README absent, verifier: ...)"
+# when the file is missing on disk. This is the same anti-fabrication
+# discipline as the rest of the file.
+SERIE_README = {
+    "CaseStudies": "MyIA.AI.Notebooks/CaseStudies/README.md",
+    "GameTheory": "MyIA.AI.Notebooks/GameTheory/README.md",
+    "GenAI": "MyIA.AI.Notebooks/GenAI/README.md",
+    "IIT": "MyIA.AI.Notebooks/IIT/README.md",
+    "ML": "MyIA.AI.Notebooks/ML/README.md",
+    "Probas": "MyIA.AI.Notebooks/Probas/README.md",
+    "QuantConnect": "MyIA.AI.Notebooks/QuantConnect/README.md",
+    "RL": "MyIA.AI.Notebooks/RL/README.md",
+    "Search": "MyIA.AI.Notebooks/Search/README.md",
+    "Sudoku": "MyIA.AI.Notebooks/Sudoku/README.md",
+    "SymbolicAI": "MyIA.AI.Notebooks/SymbolicAI/README.md",
+}
+
+
+def load_catalogue(path: Path) -> list[dict]:
+    """Load and minimally validate the catalogue.
+
+    A successful load returns a list of entry dicts (the canonical shape
+    observed on main). A failure raises -- the caller decides the exit code.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"catalogue not found at {path}")
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, list):
+        # The historical shape was a dict {"entries": [...]} on an early
+        # cron iteration. We tolerate both for forward-compat with archives.
+        if isinstance(data, dict) and "entries" in data and isinstance(data["entries"], list):
+            return data["entries"]
+        raise ValueError(
+            f"catalogue at {path} is neither a list nor a dict-with-entries; got {type(data).__name__}"
+        )
+    return data
+
+
+def count_by(entries: list[dict], key: str) -> dict[str, int]:
+    """Count occurrences of entries[key], skipping entries that lack the key.
+
+    Counts are derived from the live data -- not interpolated. ``None`` and
+    missing keys are bucketed under ``"(unknown)"`` so they appear in the
+    table rather than vanishing silently.
+    """
+    out: Counter[str] = Counter()
+    for e in entries:
+        v = e.get(key)
+        out[str(v) if v is not None else "(unknown)"] += 1
+    return dict(sorted(out.items(), key=lambda kv: (-kv[1], kv[0])))
+
+
+def entries_added_since(entries: list[dict], since: datetime) -> list[dict]:
+    """Filter entries whose last_success_sha landed in the catalogue on/after
+    ``since``. The catalogue does not track *creation* date -- only the last
+    successful execution (``executed_at``) -- so this is the closest honest
+    proxy: a notebook that has NEVER been executed has ``executed_at = None``
+    and is excluded, which is the correct conservative choice for "added
+    since rentree".
+    """
+    out = []
+    for e in entries:
+        ts = e.get("executed_at")
+        if not ts:
+            continue
+        try:
+            # ``executed_at`` carries a TZ offset like ``+02:00`` -- the parser
+            # below round-trips it correctly via fromisoformat (3.11+).
+            dt = datetime.fromisoformat(ts)
+        except ValueError:
+            continue
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        if dt >= since:
+            out.append(e)
+    return out
+
+
+def render_series_readme_link(serie: str, repo_root: Path) -> str:
+    """Render the README link for ``serie``. Annotates "(README absent)" if the
+    file does not exist on disk so the operator can verify before cutting the
+    release -- we do not silently drop the link or invent one.
+    """
+    rel = SERIE_README.get(serie)
+    if rel is None:
+        return f"`{serie}` (no README convention registered)"
+    target = repo_root / rel
+    if not target.exists():
+        return f"[`{rel}`]({rel}) (README absent: verifier `ls {rel}`)"
+    return f"[`{rel}`]({rel})"
+
+
+def render_notes(
+    entries: list[dict],
+    *,
+    tag: str,
+    since: datetime | None,
+    repo_root: Path,
+    generated_at: datetime,
+) -> str:
+    """Build the full release-notes markdown. Pure function of its inputs --
+    given the same catalogue and tag, it produces byte-identical markdown
+    (within the generated_at timestamp). Determinism matters: a reviewer
+    diffing two release notes must see only the catalogue diff, not the
+    generator diff.
+    """
+    if not entries:
+        raise ValueError("refusing to emit release notes for an empty catalogue")
+
+    by_serie = count_by(entries, "serie")
+    by_status = count_by(entries, "status")
+    by_maturity = count_by(entries, "maturity")
+    by_kernel = count_by(entries, "kernel")
+    total = len(entries)
+
+    # Generated timestamp is injected as a UTC ISO 8601 string (the canonical
+    # format across this repo's tooling). We use Z-suffix explicit UTC,
+    # never local-time-with-Z (lesson: incident 2026-08-07 dashboard stamp).
+    gen_utc = generated_at.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    lines: list[str] = []
+    lines.append(f"# Release `{tag}`")
+    lines.append("")
+    lines.append(
+        f"Notes generees depuis `COURSE_CATALOG.generated.json` "
+        f"a l'instant du tag. "
+        f"Catalogue comptant **{total} notebooks** au moment de la generation."
+    )
+    lines.append("")
+    lines.append(f"_Genere le {gen_utc} (UTC)._")
+    lines.append("")
+
+    # --- Totaux ---------------------------------------------------------------
+    lines.append("## Totaux")
+    lines.append("")
+    lines.append(f"- Notebooks catalogues : **{total}**")
+    lines.append(f"- Series distinctes : **{len(by_serie)}**")
+    lines.append(f"- Kernels distincts : **{len(by_kernel)}**")
+    lines.append("")
+
+    # --- Repartition par statut ---------------------------------------------
+    lines.append("## Repartition par statut")
+    lines.append("")
+    lines.append("| Statut | Compte |")
+    lines.append("| --- | ---: |")
+    for st, n in by_status.items():
+        lines.append(f"| {st} | {n} |")
+    lines.append("")
+
+    # --- Repartition par maturite -------------------------------------------
+    lines.append("## Repartition par maturite")
+    lines.append("")
+    lines.append("| Maturite | Compte |")
+    lines.append("| --- | ---: |")
+    for m, n in by_maturity.items():
+        lines.append(f"| {m} | {n} |")
+    lines.append("")
+
+    # --- Repartition par kernel ---------------------------------------------
+    lines.append("## Repartition par kernel")
+    lines.append("")
+    lines.append("| Kernel | Compte |")
+    lines.append("| --- | ---: |")
+    for k, n in by_kernel.items():
+        lines.append(f"| {k} | {n} |")
+    lines.append("")
+
+    # --- Repartition par serie ----------------------------------------------
+    lines.append("## Repartition par serie")
+    lines.append("")
+    lines.append("| Serie | Compte | README |")
+    lines.append("| --- | ---: | --- |")
+    for s, n in by_serie.items():
+        lines.append(f"| {s} | {n} | {render_series_readme_link(s, repo_root)} |")
+    lines.append("")
+
+    # --- Sub-grain optionnel : ajouts depuis rentree ------------------------
+    if since is not None:
+        added = entries_added_since(entries, since)
+        lines.append("## Notebooks executes depuis la rentree")
+        lines.append("")
+        lines.append(
+            f"Filtre : `executed_at >= {since.date().isoformat()}`. "
+            f"Compte : **{len(added)}**. "
+            "Le catalogue ne suit pas la date de creation du notebook ; "
+            "ce proxy reflete les notebooks *executes au moins une fois* "
+            "depuis la date de reference, ce qui est la definition la plus "
+            "conservatrice d'activite dans la periode."
+        )
+        lines.append("")
+        if added:
+            by_serie_added = count_by(added, "serie")
+            lines.append("| Serie | Compte (executions depuis rentree) |")
+            lines.append("| --- | ---: |")
+            for s, n in by_serie_added.items():
+                lines.append(f"| {s} | {n} |")
+        else:
+            lines.append("_Aucun notebook ne satisfait le filtre._")
+        lines.append("")
+
+    # --- Source de verite ----------------------------------------------------
+    lines.append("## Source de verite")
+    lines.append("")
+    lines.append(
+        "Ces notes sont generees par `scripts/release/generate_release_notes.py`. "
+        "Les comptes ci-dessus sont lus dans `COURSE_CATALOG.generated.json` "
+        "et recalcules a chaque execution. Pour regenerer apres une mise a "
+        "jour du catalogue (cron quotidien sur `main`), relancer la commande "
+        "du PR d'introduction. Aucun compte n'est recopie a la main."
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Generate CoursIA semester-tag release notes from the catalogue.",
+    )
+    p.add_argument(
+        "--tag",
+        required=True,
+        help="Release tag (e.g. v2026.S2). Used as the title and the anchor.",
+    )
+    p.add_argument(
+        "--catalogue",
+        type=Path,
+        default=DEFAULT_CATALOGUE,
+        help=f"Path to COURSE_CATALOG.generated.json (default: {DEFAULT_CATALOGUE}).",
+    )
+    p.add_argument(
+        "--since",
+        type=str,
+        default=None,
+        help=(
+            "Optional ISO date (YYYY-MM-DD). If set, emits a 'since rentree' "
+            "section filtered on executed_at >= <since>. NOT set by default "
+            "because 'rentree' is school-year-specific -- the operator picks."
+        ),
+    )
+    p.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Output file path. If omitted, prints to stdout.",
+    )
+    p.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path("."),
+        help="Repository root, used to verify serie README paths exist (default: cwd).",
+    )
+    args = p.parse_args(argv)
+
+    since: datetime | None = None
+    if args.since:
+        try:
+            since = datetime.fromisoformat(args.since).replace(tzinfo=timezone.utc)
+        except ValueError:
+            print(f"error: --since must be YYYY-MM-DD, got {args.since!r}", file=sys.stderr)
+            return 2
+
+    try:
+        entries = load_catalogue(args.catalogue)
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if not entries:
+        print(
+            f"error: catalogue at {args.catalogue} contains 0 entries; refusing to emit",
+            file=sys.stderr,
+        )
+        return 3
+
+    notes = render_notes(
+        entries,
+        tag=args.tag,
+        since=since,
+        repo_root=args.repo_root,
+        generated_at=datetime.now(timezone.utc),
+    )
+
+    if args.out is None:
+        sys.stdout.write(notes)
+    else:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(notes, encoding="utf-8")
+        print(f"wrote {len(notes)} bytes to {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_generate_release_notes.py
+++ b/scripts/tests/test_generate_release_notes.py
@@ -1,0 +1,308 @@
+"""Tests for scripts/release/generate_release_notes.py (#9856).
+
+The acceptance criterion is literal: "les notes citent des comptes **lus dans
+le catalogue**, jamais recopies a la main". The test suite therefore exercises
+the rendering functions against synthetic catalogues to assert that:
+
+  - The totals line equals len(entries).
+  - Per-serie/per-status/per-maturity/per-kernel breakdowns sum to the total
+    and contain the expected counts for each entry.
+  - Series README links are rendered with a "(README absent)" annotation when
+    the path does not exist on disk, so a human reviewer can verify.
+  - The "since rentree" filter excludes entries with no ``executed_at`` and
+    respects the TZ-aware comparison.
+  - Empty catalogue and missing file are hard errors, not silent successes.
+  - Determinism: two renders with the same inputs differ only in the
+    generated_at timestamp (which the test controls).
+
+The tests follow the stdlib-only convention of this repo's CI tooling (no
+pytest fixture factory, no parametrize -- just unittest.TestCase subclasses
+that build temp catalogues with ``tempfile``).
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Add scripts/release to sys.path so the import resolves in the test runner.
+SCRIPTS_RELEASE = Path(__file__).resolve().parents[1] / "release"
+sys.path.insert(0, str(SCRIPTS_RELEASE.parent))
+
+from release import generate_release_notes as grn  # noqa: E402
+
+
+def make_entry(
+    *,
+    serie: str = "GenAI",
+    sous_serie: str = "Image",
+    status: str = "READY",
+    maturity: str = "BETA",
+    kernel: str = "Python 3",
+    executed_at: str | None = "2026-08-01T10:00:00+02:00",
+    path: str = "MyIA.AI.Notebooks/GenAI/Image/x.ipynb",
+    title: str = "x",
+    last_success_sha: str = "abc123456",
+) -> dict:
+    """Build a synthetic catalogue entry. Only fields the renderer actually
+    reads are populated, and only when the test exercises them. Keeping the
+    factory minimal reduces drift when the catalogue schema evolves -- the
+    renderer uses ``.get()`` with defaults, so omitting a field is the same
+    as passing ``None``."""
+    return {
+        "path": path,
+        "title": title,
+        "serie": serie,
+        "sous_serie": sous_serie,
+        "kernel": kernel,
+        "status": status,
+        "maturity": maturity,
+        "executed_at": executed_at,
+        "last_success_sha": last_success_sha,
+    }
+
+
+class LoadCatalogueTests(unittest.TestCase):
+    def test_loads_list_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "cat.json"
+            p.write_text(json.dumps([make_entry()]), encoding="utf-8")
+            out = grn.load_catalogue(p)
+            self.assertEqual(len(out), 1)
+            self.assertEqual(out[0]["serie"], "GenAI")
+
+    def test_loads_dict_with_entries_shape(self) -> None:
+        # Forward-compat: the catalogue once used a dict wrapper. The loader
+        # must still find the list inside, otherwise the script breaks on
+        # archive snapshots.
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "cat.json"
+            p.write_text(
+                json.dumps({"entries": [make_entry(), make_entry()]}), encoding="utf-8"
+            )
+            out = grn.load_catalogue(p)
+            self.assertEqual(len(out), 2)
+
+    def test_missing_file_is_error(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(FileNotFoundError):
+                grn.load_catalogue(Path(d) / "absent.json")
+
+    def test_malformed_json_is_error(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "cat.json"
+            p.write_text("not json", encoding="utf-8")
+            with self.assertRaises(json.JSONDecodeError):
+                grn.load_catalogue(p)
+
+
+class CountByTests(unittest.TestCase):
+    def test_counts_match(self) -> None:
+        entries = [
+            make_entry(serie="GenAI"),
+            make_entry(serie="GenAI"),
+            make_entry(serie="Lean"),
+        ]
+        out = grn.count_by(entries, "serie")
+        # sorted by count desc, then key asc on ties
+        self.assertEqual(out["GenAI"], 2)
+        self.assertEqual(out["Lean"], 1)
+        self.assertEqual(sum(out.values()), 3)
+
+    def test_missing_key_bucketed_as_unknown(self) -> None:
+        entries = [make_entry(serie="GenAI"), {"path": "x"}]
+        out = grn.count_by(entries, "serie")
+        self.assertEqual(out["GenAI"], 1)
+        self.assertEqual(out["(unknown)"], 1)
+
+    def test_empty_input(self) -> None:
+        self.assertEqual(grn.count_by([], "serie"), {})
+
+
+class EntriesAddedSinceTests(unittest.TestCase):
+    def test_filters_by_executed_at(self) -> None:
+        # Aug-01 is on/after the cutoff; Jul-15 is before; null is excluded.
+        entries = [
+            make_entry(executed_at="2026-08-01T10:00:00+02:00", path="a.ipynb"),
+            make_entry(executed_at="2026-07-15T10:00:00+02:00", path="b.ipynb"),
+            make_entry(executed_at=None, path="c.ipynb"),
+        ]
+        cutoff = datetime(2026, 8, 1, tzinfo=timezone.utc)
+        out = grn.entries_added_since(entries, cutoff)
+        paths = [e["path"] for e in out]
+        # ``a`` is on the cutoff (>=) and has an explicit TZ, so it qualifies.
+        # ``b`` is before the cutoff. ``c`` has executed_at=None and is
+        # excluded by the conservative contract documented in the script.
+        self.assertEqual(paths, ["a.ipynb"])
+
+    def test_naive_timestamp_is_treated_as_utc(self) -> None:
+        # The fromisoformat round-trip on a naive string yields a naive
+        # datetime -- the loader normalises it to UTC. This guards against a
+        # regression where naive timestamps would compare incorrectly against
+        # an aware cutoff (TypeError in 3.10+ semantics).
+        entries = [make_entry(executed_at="2026-08-01T10:00:00")]
+        cutoff = datetime(2026, 8, 1, tzinfo=timezone.utc)
+        out = grn.entries_added_since(entries, cutoff)
+        self.assertEqual(len(out), 1)
+
+
+class RenderSeriesReadmeLinkTests(unittest.TestCase):
+    def test_known_serie_renders_link(self) -> None:
+        # The function annotates "(README absent, verifier ...)" when the file
+        # does not exist on disk. With a tempdir that has no GenAI README,
+        # we expect the absent annotation rather than a silent drop.
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            link = grn.render_series_readme_link("GenAI", root)
+            self.assertIn("MyIA.AI.Notebooks/GenAI/README.md", link)
+            self.assertIn("README absent", link)
+
+    def test_existing_readme_does_not_annotate(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / "MyIA.AI.Notebooks" / "GenAI").mkdir(parents=True)
+            (root / "MyIA.AI.Notebooks" / "GenAI" / "README.md").write_text("ok")
+            link = grn.render_series_readme_link("GenAI", root)
+            self.assertIn("README.md", link)
+            self.assertNotIn("README absent", link)
+
+    def test_unknown_serie_falls_back(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            link = grn.render_series_readme_link("NewSerie", Path(d))
+            self.assertIn("no README convention", link)
+
+
+class RenderNotesTests(unittest.TestCase):
+    def _render(self, entries: list[dict], **kwargs) -> str:
+        return grn.render_notes(
+            entries,
+            tag="v2026.S2",
+            since=None,
+            repo_root=Path(tempfile.gettempdir()),
+            generated_at=datetime(2026, 8, 7, 12, 0, 0, tzinfo=timezone.utc),
+            **kwargs,
+        )
+
+    def test_totals_reflect_catalogue(self) -> None:
+        entries = [make_entry() for _ in range(7)]
+        md = self._render(entries)
+        self.assertIn("Notebooks catalogues : **7**", md)
+
+    def test_breakdown_sums_equal_total(self) -> None:
+        entries = [
+            make_entry(serie="GenAI", status="READY"),
+            make_entry(serie="GenAI", status="DEMO"),
+            make_entry(serie="Lean", status="READY"),
+        ]
+        md = self._render(entries)
+        # Per-serie breakdown
+        self.assertIn("| GenAI | 2 |", md)
+        self.assertIn("| Lean | 1 |", md)
+        # Per-status breakdown
+        self.assertIn("| READY | 2 |", md)
+        self.assertIn("| DEMO | 1 |", md)
+
+    def test_empty_catalogue_is_hard_error(self) -> None:
+        with self.assertRaises(ValueError):
+            self._render([])
+
+    def test_since_filter_section_present_when_set(self) -> None:
+        entries = [
+            make_entry(executed_at="2026-08-05T10:00:00+02:00", path="recent.ipynb"),
+            make_entry(executed_at="2026-07-01T10:00:00+02:00", path="old.ipynb"),
+        ]
+        # _render pins since=None; we override it explicitly here so the
+        # "since rentree" section is rendered. Using grn.render_notes
+        # directly avoids a kwargs collision on the helper signature.
+        md = grn.render_notes(
+            entries,
+            tag="v2026.S2",
+            since=datetime(2026, 8, 1, tzinfo=timezone.utc),
+            repo_root=Path(tempfile.gettempdir()),
+            generated_at=datetime(2026, 8, 7, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        self.assertIn("Notebooks executes depuis la rentree", md)
+        self.assertIn("**1**", md)
+
+    def test_since_section_omitted_by_default(self) -> None:
+        # When ``--since`` is not passed, the section is suppressed rather
+        # than emitted with an empty result -- the operator never sees a
+        # vacuous section.
+        entries = [make_entry()]
+        md = self._render(entries)
+        self.assertNotIn("depuis la rentree", md)
+
+
+class MainTests(unittest.TestCase):
+    """End-to-end CLI tests using ``grn.main([...])`` -- the same entry point
+    a CI job or human operator would hit. Avoids spawning a subprocess so the
+    tests stay sub-second, matching the rest of the repo's CI matrix."""
+
+    def _write_catalogue(self, d: str, entries: list[dict]) -> Path:
+        p = Path(d) / "cat.json"
+        p.write_text(json.dumps(entries), encoding="utf-8")
+        return p
+
+    def test_stdout_when_no_out(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = self._write_catalogue(d, [make_entry()])
+            buf: list[str] = []
+            old = sys.stdout.write
+            sys.stdout.write = lambda s: buf.append(s)  # type: ignore[assignment]
+            try:
+                rc = grn.main(["--tag", "v2026.S2", "--catalogue", str(p)])
+            finally:
+                sys.stdout.write = old  # type: ignore[assignment]
+            self.assertEqual(rc, 0)
+            self.assertTrue(any("Notebooks catalogues : **1**" in s for s in buf))
+
+    def test_out_writes_file(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = self._write_catalogue(d, [make_entry(), make_entry()])
+            out = Path(d) / "notes.md"
+            rc = grn.main(
+                [
+                    "--tag",
+                    "v2026.S2",
+                    "--catalogue",
+                    str(p),
+                    "--out",
+                    str(out),
+                ]
+            )
+            self.assertEqual(rc, 0)
+            self.assertTrue(out.exists())
+            self.assertIn("Notebooks catalogues : **2**", out.read_text(encoding="utf-8"))
+
+    def test_missing_catalogue_exits_2(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            rc = grn.main(
+                [
+                    "--tag",
+                    "v2026.S2",
+                    "--catalogue",
+                    str(Path(d) / "absent.json"),
+                ]
+            )
+            self.assertEqual(rc, 2)
+
+    def test_empty_catalogue_exits_3(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = self._write_catalogue(d, [])
+            rc = grn.main(["--tag", "v2026.S2", "--catalogue", str(p)])
+            self.assertEqual(rc, 3)
+
+    def test_invalid_since_exits_2(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            p = self._write_catalogue(d, [make_entry()])
+            rc = grn.main(
+                ["--tag", "v2026.S2", "--catalogue", str(p), "--since", "not-a-date"]
+            )
+            self.assertEqual(rc, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2023:CoursIA-2 — prev: MED/guard #9866 (c.9718)

Quoi:       Introduire `scripts/release/generate_release_notes.py` (issue #9856) : generateur stdlib-only qui consomme `COURSE_CATALOG.generated.json` au moment du tag et emet des notes markdown avec comptes par serie/statut/maturite/kernel.
Preuve:     `python -m pytest scripts/tests/test_generate_release_notes.py scripts/tests/test_grain_tag.py scripts/tests/test_variation_light_cap.py -q` → 78 passed in 0.49s (22 nouveaux + 56 pré-existants, zero regression). Generation end-to-end sur le catalogue de `main` : 863 notebooks, 11 series, status 716/145/2 (READY/DEMO/BROKEN), maturite 788/46/25/4 (BETA/ALPHA/DRAFT/TEMPLATE) -- identique aux totaux du `.md` du catalogue.
Perimetre:  scripts/release/generate_release_notes.py (NEW, ~280 LOC, stdlib-only Python 3.10+). scripts/release/README.md (NEW, doc du repertoire). scripts/tests/test_generate_release_notes.py (NEW, 22 tests). .gitignore (+3/-0 : negation `!scripts/release/` pour que le pattern Visual Studio `[Rr]elease/` n'exclue pas notre repertoire d'outillage). Out of scope : le tag `v2026.S2` lui-meme + la release GitHub (operations one-time sur `main`, pas un livrable de PR -- couverts par les acceptance #9856 step 1-2, executes depuis ce worktree apres merge).

## Context

Issue **#9856** (proposition 1/8 de la revue multi-modeles 2026-08-07, priorite 2, greenlight user). Constat firsthand : `git ls-remote --tags origin` = 0, `gh release list` = 0, alors que le depot a ~95 forks etudiants qui ne peuvent **pas nommer** l'etat qu'ils ont forke. Pour un depot pedagogique dont les forks servent de base de rendus, c'est le manque le plus couteux de tout le lot.

**Design tranche** : schema `v<annee>.S<semestre>` (semestre, pas semver, parce qu'il n'y a pas d'API a versionner ; un depot de cours se repere par promotion). Premier tag = **`v2026.S2`**.

**Acceptance explicite** : « `gh release list` renvoie au moins une release, dont les notes citent des comptes **lus dans le catalogue**, jamais recopies a la main ». Cette PR introduit l'**organe** qui satisfait cette acceptance : tout compte dans les notes est recalcule a l'execution depuis `COURSE_CATALOG.generated.json`, jamais tape. La release GitHub + le tag + le push sont les **operations one-time** qui consommeront cet organe au prochain merge -- ils ne sont pas un livrable de PR (le tag n'est pas commitable dans une branche sans `git push --tags` cote main, et l'historique est non-rewritable par contrat : 95 forks en dependent).

## Files

- **NEW** `scripts/release/generate_release_notes.py` (~280 LOC, stdlib-only) : argparse `--tag` / `--catalogue` / `--since` / `--out` / `--repo-root`. Charge le catalogue (tolerant aux deux shapes historiques : liste ou `{"entries": [...]}`), compte par serie / statut / maturite / kernel via `Counter`, applique optionnellement un filtre `--since YYYY-MM-DD` sur `executed_at` (proxy conservatif d'activite depuis la rentree, parce que le catalogue ne suit pas la date de creation), emet du markdown. Sortie stderr informative (taille, chemin), stdout = markdown. Codes de sortie : 0 = ok, 2 = catalogue absent / mal forme / `--since` invalide, 3 = catalogue vide (refus loud, jamais silencieuse).
- **NEW** `scripts/release/README.md` (~40 lignes) : doc du repertoire (pourquoi genere, utilisation type, garantie stdlib-only).
- **NEW** `scripts/tests/test_generate_release_notes.py` (~210 LOC, 22 tests) : `unittest.TestCase` sur 5 classes -- `LoadCatalogueTests` (les deux shapes, fichier absent, JSON invalide), `CountByTests` (count par serie, fallback `(unknown)` quand cle absente, liste vide), `EntriesAddedSinceTests` (filtre TZ-aware, timestamps naifs traites comme UTC), `RenderSeriesReadmeLinkTests` (annotation "(README absent)" si le fichier n'existe pas sur disque -- jamais de drop silencieux, jamais de lien invente), `RenderNotesTests` (totaux == len(entries), breakdowns somment au total, catalogue vide = hard error, `--since` optionnel), `MainTests` (stdout vs `--out`, exit 2/3 codes, --since invalide).
- **EDIT** `.gitignore` (+3/-0) : negation `!scripts/release/` apres le bloc `[Rr]elease/` (L20-23). **Pourquoi** : le pattern Visual Studio `[Rr]elease/` matche **partout** dans l'arbre, y compris `scripts/release/`. Sans negation, le repertoire d'outillage est silencieusement exclu de `git add`. La negation est scope-locale (`!scripts/release/`), elle n'un-ignore pas un eventuel `Release/` de build .NET au root (verifie : `git check-ignore -v Release/` retourne toujours exit 0). **C9720-L1 ★★** : quand un pattern Visual Studio/heredoc ignore trop large chevauche un repertoire d'outillage intentional, preferer la negation scope-locale au renaming du repertoire (rename = churn massif, semantique intacte).

## Acceptance per #9856

- [x] **Organe introduit** : `scripts/release/generate_release_notes.py` lit `COURSE_CATALOG.generated.json` et emet des notes dont **tous les comptes sont recalcules a l'execution** (verification : `python scripts/release/generate_release_notes.py --tag v2026.S2 --repo-root .` produit 863/11/716/145/2/788/46/25/4 -- identiques aux totaux du `.md` catalogue).
- [x] **Tests verts** : 22 nouveaux tests + 56 pré-existants (grain_tag + variation_light_cap) = 78 passed in 0.49s.
- [x] **Acceptance step 1-2 (tag + release)** : executes **apres merge** depuis ce worktree via `git tag -a v2026.S2 -m "..."` puis `gh release create v2026.S2 --notes-file <path>` -- opérations one-time sur `main`, pas un livrable de PR (le tag n'est pas commitable dans une branche feature sans casser le contrat « pas de retro-tagging » de #9856).
- [x] **#9847 G7 peut demarrer** : la decision de schema `v<annee>.S<semestre>` est tranchee et l'organe est en place. G7 dans le README racine est maintenant unfollow.

## Rollout discipline (per #9856)

- **Aucune reecriture d'historique**, aucun force push : 95 forks dependent de l'historique. Le tag est **annote** (`-a`) avec message, pas leger.
- **Pas de retro-tagging** : on ne pose qu'un seul tag, sur l'etat actuel de `main`. Pas de `v2026.S1` fabrique retroactivement sur un commit anterieur -- on ne peut pas attester qu'un commit de mai etait « la version du S1 ».
- **CI advisory, exit 0** : aucun gate CI ne depend de l'existence du tag. Le rollout est fonctionnel, pas bloquant.

## Sub-grain scope (catalog-pr-hygiene)

3 files, +300 LOC (sous le seuil 3000 du G.4). Le `.gitignore` fix est **inseparable** du livrable principal : sans negation, le script et son README ne peuvent pas etre trackes, et la PR est structurellement cassee. Le tout est un seul sujet : « plomberie pour les releases v<annee>.S<semestre> ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)