### PR TITLE
docs(notebooks,#9857): 3 notebook counters reconciliation + --check assertion

### DIFF
--- a/docs/reference/notebook-counters.md
+++ b/docs/reference/notebook-counters.md
@@ -1,0 +1,206 @@
+# Compteurs de notebooks — catalogue / outil / disque
+
+**Date** : 2026-08-07
+**Issue** : [#9857](https://github.com/jsboige/CoursIA/issues/9857)
+**Lane** : po-2023 (CoursIA-2)
+
+---
+
+## TL;DR — les trois compteurs au même SHA (`e7307a717`, 2026-08-07)
+
+| Source | Compte | Définition courte | Répond à la question |
+|--------|-------:|-------------------|----------------------|
+| **Catalogue** | **863** | `COURSE_CATALOG.generated.json` (cron `catalog-cron.yml`) | « Combien de notebooks le dépôt **présente** publiquement ? » |
+| **Outil** | **863** | `count_notebooks_by_series.py` (mode pédagogique) | « Combien de notebooks **pédagogiques** (hors recherche/archive/artefacts) ? » |
+| **Disque** | **974** | `find MyIA.AI.Notebooks -name '*.ipynb'` (hors `.ipynb_checkpoints`) | « Combien de fichiers `.ipynb` **physiquement présents** ? » |
+
+> **Les compteurs catalogue et outil convergent à 863** depuis le correctif
+> `#9851` (bug `bin`/`CombinatorialGames` qui sous-comptait l'outil à 866).
+> L'écart résiduel **863 vs 974 = 111 fichiers** est entièrement expliqué par
+> les règles d'exclusion ci-dessous (réconciliation fichier-près, qui se
+> referme exactement).
+
+---
+
+## Les trois définitions, en détail
+
+### 1. Catalogue — `COURSE_CATALOG.generated.json` (863)
+
+**Source** : le fichier généré par [`scripts/notebook_tools/generate_catalog.py`](../../scripts/notebook_tools/generate_catalog.py), régénéré quotidiennement par le cron [`.github/workflows/catalog-cron.yml`](../../.github/workflows/catalog-cron.yml) sur `main`.
+
+**Compte** : tout `.ipynb` non exclu par `EXCLUDE_PEDAGOGICAL` du générateur, **et** qui porte une entrée curée (`issue_pr_associee`, `owner_logique`, etc.). Le catalogue est donc un sous-ensemble **curé** : un notebook présent sur le disque mais non encore curé n'apparaît pas.
+
+**Exclut** (par design du générateur) : `research/`, `archive/`, `_output`, `output`, `partner-course`, `examples`. Les notebooks non-curés (drift) sont également absents jusqu'à curation manuelle ou passage du cron.
+
+**Répond à** : « Combien de notebooks le dépôt présente-t-il publiquement ? » — c'est le chiffre citable dans un README, des release notes, ou la vitrine Pages.
+
+### 2. Outil — `count_notebooks_by_series.py` mode pédagogique (863)
+
+**Source** : [`scripts/notebook_tools/count_notebooks_by_series.py`](../../scripts/notebook_tools/count_notebooks_by_series.py).
+
+**Compte** : tout `.ipynb` sous `MyIA.AI.Notebooks/` dont le **segment racine** (`parts[0]`) est l'une des 11 séries reconnues (`GenAI`, `Search`, `ML`, `SymbolicAI`, `QuantConnect`, `GameTheory`, `Sudoku`, `Probas`, `IIT`, `RL`, `EPF`), après application des exclusions. Les notebooks hors de ces 11 séries (ex. `CaseStudies/`) tombent dans la ligne `(other)` — **comptés dans le TOTAL mais pas rattachés à une série**.
+
+**Exclut** deux ensembles distincts (cf code lignes 30-43) :
+
+- `EXCLUDE_ALWAYS` (noms de **répertoires** uniquement, jamais le nom de fichier — leçon `#9851`) : `.ipynb_checkpoints`, `obj`, `bin`, `__pycache__`, `.git`.
+- `EXCLUDE_PEDAGOGICAL` (sous-chaîne sur le **chemin relatif**) : `research`, `archive`, `_output`, `partner-course`, `examples`.
+
+**Répond à** : « Combien de notebooks pédagogiques (hors recherche, archives, artefacts papermill, exemples partenaires) ? » — c'est le chiffre de cohérence interne entre séries.
+
+### 3. Disque — `find` brut (974)
+
+**Source** : `find MyIA.AI.Notebooks -name '*.ipynb' -not -path '*/.ipynb_checkpoints/*'` (équivalent Python : `pathlib.Path("MyIA.AI.Notebooks").rglob("*.ipynb")`).
+
+**Compte** : **tout** fichier `.ipynb` physiquement présent sous `MyIA.AI.Notebooks/`, y compris la recherche, les archives, les artefacts, les exemples partenaires. **Aucun filtre** sémantique.
+
+**Répond à** : « Combien de fichiers `.ipynb` existe-t-il sur le disque ? » — c'est la mesure la plus large, et celle qu'un clone frais obtient.
+
+> **Note `git ls-files`** : `git ls-files 'MyIA.AI.Notebooks/**/*.ipynb'` donne **973** (un de moins que le disque = un fichier non-tracké résiduel). La mesure « disque » de cette doc utilise le `find` brut (974), conforme à l'acceptance de #9857.
+
+---
+
+## Réconciliation disque → outil (111 fichiers exclus, fichier-près)
+
+La réconciliation se referme **exactement** : `974 (disque) − 111 (exclus) = 863 (outil)`.
+Les 111 exclus se décomposent en deux ensembles, chacun reproductible par script.
+
+### (a) `EXCLUDE_PEDAGOGICAL` — 110 fichiers
+
+| Catégorie | Compte | Motif | Exemples typiques |
+|-----------|-------:|-------|-------------------|
+| `research/` | 101 | notebooks de recherche (ML-Training-Pipeline, quantbooks QC) | `QuantConnect/ML-Training-Pipeline/*_research.ipynb`, `QuantConnect/research/` |
+| `archive/` | 6 | archives/legacy | `SymbolicAI/_archive/`, `SymbolicAI/Planners/_archive/`, `Search/_archive/` |
+| `partner-course` | 0 | cours partenaires (aucun sur le disque à ce SHA) | — |
+| `examples/` | 3 | démonstrations techniques sans valeur catalogue | `GenAI/Image/examples/*.ipynb` |
+| `_output` | 0 | artefacts papermill (gitignored) | — |
+
+> **Somme exacte, sans recouvrement** : `101 + 6 + 0 + 3 + 0 = 110`. Chaque
+> fichier est attribué à son **premier** motif matché dans l'ordre du tableau
+> (logique `count_notebooks_by_series.py` lignes 69-73). À ce SHA, aucun
+> fichier ne matche plusieurs motifs à la fois.
+
+### (b) Hors 11 séries — 7 fichiers, deux destins distincts
+
+Les 7 fichiers dont le segment racine n'est pas dans `SERIES_ORDER` ne sont
+**pas** traités uniformément par l'outil : tout dépend de savoir si l'entrée
+racine est un **répertoire** (parcouru) ou un **fichier** (ignoré).
+
+| Entrée racine | Compte | Compté par l'outil ? | Raison |
+|---------------|-------:|----------------------|--------|
+| `CaseStudies/` (répertoire) | 6 | **Oui** — ligne `(other)` du TOTAL | Répertoire, donc parcouru ; racine `CaseStudies` hors `SERIES_ORDER` → bucket `(other)` |
+| `GradeBook.ipynb` (fichier racine) | 1 | **Non** | Fichier à la racine de `MyIA.AI.Notebooks/` ; l'outil n'itère que les **répertoires** (`if not series_dir.is_dir(): continue`, ligne 162 du script) |
+
+**Conséquence sur les totaux** :
+
+- L'outil compte `857 (11 séries) + 6 (CaseStudies → other) = 863`.
+- `GradeBook.ipynb` est le **111ᵉ fichier** du gap disque→outil : `974 − 863 = 111 = 110 (EXCLUDE_PEDAGOGICAL) + 1 (fichier racine non parcouru)`.
+- Le catalogue compte lui aussi **863 entrées** : les 6 `CaseStudies` sont
+  curés (la 1ʳᵉ entrée du catalogue est `CaseStudies/Diagnostic-Medical/...`),
+  `GradeBook.ipynb` en est absent, et les 110 pédagogiquement exclus le sont
+  aussi. D'où la convergence catalogue = outil = 863.
+
+### (c) `EXCLUDE_ALWAYS` — 0 fichier
+
+Sur le worktree frais (`e7307a717`), aucun notebook ne vit sous
+`.ipynb_checkpoints/`, `obj/`, `bin/`, `__pycache__/` ou `.git/` de manière
+trackée. Cette catégorie est **structurellement vide** sur `main` ; elle
+n'existe dans le code que comme garde-fou contre les artefacts locaux.
+
+---
+
+## Vérification reproductible
+
+```bash
+# Disque (974)
+find MyIA.AI.Notebooks -name '*.ipynb' -not -path '*/.ipynb_checkpoints/*' | wc -l
+
+# Outil pédagogique (863)
+python scripts/notebook_tools/count_notebooks_by_series.py | tail -3   # → TOTAL 863
+
+# Catalogue (863)
+python -c "import json; print(len(json.load(open('COURSE_CATALOG.generated.json'))))"
+
+# Réconciliation détaillée : --all inclut research/archive/examples (toujours 110),
+# mais GradeBook.ipynb (fichier racine) reste non parcouru → 973 = 974 - 1
+python scripts/notebook_tools/count_notebooks_by_series.py --all | tail -3   # → 973
+
+# Assertion outillée (acceptance #9857) : rougit si catalogue et outil divergent
+python scripts/notebook_tools/count_notebooks_by_series.py --check           # → OK (863 == 863)
+```
+
+---
+
+## Assertion outillée — `--check` (acceptance #9857)
+
+Le mode `--check` de [`count_notebooks_by_series.py`](../../scripts/notebook_tools/count_notebooks_by_series.py)
+compare le compte **outil** (pédagogique) au compte **catalogue** (curé) et
+**sort en code 1** (`sys.exit(1)`) s'ils divergent :
+
+```
+CHECK -- convergence catalogue / outil
+  Outil (pedagogical) : 863
+  Catalogue (curated) : 863
+  Statut              : OK -- convergent (863 == 863)
+```
+
+**Pourquoi cette assertion** : les deux sources appliquent le même ensemble
+`EXCLUDE_PEDAGOGICAL`, donc toute divergence est un signal actionnable — pas
+un bruit attendu. Deux causes légitimes (diagnostiquées dans le message de
+sortie) :
+
+- **`outil > catalogue`** : drift de curation (notebook fraîchement ajouté,
+  non encore curé) → résolu par `catalog-cron.yml` en `< 24h`.
+- **`catalogue > outil`** : notebook curé mais exclu par chemin outil (ex. un
+  `examples/` promu manuellement au catalogue).
+
+L'investigation chemin-par-chemin (drift / phantom au niveau fichier) se fait
+avec le script sœur [`scripts/audit/check_denominators.py --strict`](../../scripts/audit/check_denominators.py)
+(issue `#8050`), qui compare disque / forensic / catalogue et liste les paths
+en défaut. `--check` est le **seuil minimal** (alerte sur l'écart de total) ;
+`check_denominators.py` est le **diagnostic** (localise les fichiers).
+
+---
+
+## Source canonique pour les affirmations publiques
+
+**Le marqueur `CATALOG-STATUS` par série** (maintenu quotidiennement par
+`catalog-cron.yml` dans chaque `README.md` de série) est la source canonique
+pour tout chiffre cité en prose (README racine, release notes, vitrine Pages).
+
+**Règle** ([`catalog-pr-hygiene`](../../.claude/rules/catalog-pr-hygiene.md)) :
+aucun nombre de notebooks n'est **codé en dur** dans la prose d'une PR. On
+cite le marqueur `CATALOG-STATUS` (qui dérive du catalogue 863), jamais un
+compte mesuré à la main — le compte dérive avec chaque merge, le marqueur est
+régénéré.
+
+---
+
+## Pourquoi catalogue et outil convergent (et quand ils divergeraient)
+
+Depuis `#9851` (correctif `bin`/`CombinatorialGames`), catalogue et outil
+donnent le même total **863**. Cette convergence est **accidentelle sur le
+total** mais **structurelle sur la définition** : les deux appliquent le même
+ensemble `EXCLUDE_PEDAGOGICAL` (`research`/`archive`/`_output`/`partner-course`/
+`examples`).
+
+**Ils divergeraient légitimement si** :
+
+- le catalogue **cure** manuellement un notebook que l'outil exclut par chemin
+  (ex. un notebook `examples/` promu au catalogue) → catalogue > outil ;
+- le catalogue **n'a pas encore curé** un notebook fraîchement ajouté que
+  l'outil compte déjà → outil > catalogue (drift de curation, résolu par le
+  cron quotidien).
+
+Un check d'écart catalogue/outil hors des catégories documentées est prévu
+par le détecteur [`scripts/audit/check_denominators.py`](../../scripts/audit/check_denominators.py)
+(cf doc sœur [`notebook-counts-reconciliation.md`](notebook-counts-reconciliation.md),
+périmètre 2026-07-23, chiffres alors périmés — la présente doc la supersede
+pour les chiffres courants).
+
+---
+
+## Voir aussi
+
+- [`notebook-counts-reconciliation.md`](notebook-counts-reconciliation.md) — doc sœur (2026-07-23, `#8050`) : 4 dénominateurs (forensic/catalogue/disque/snapshot) au SHA `be59980`. **Chiffres périmés** (946/944/830) ; la présente doc la supersede pour l'état courant et les 3 sources de `#9857`.
+- [`catalog-pr-hygiene.md`](../../.claude/rules/catalog-pr-hygiene.md) — le marqueur `CATALOG-STATUS` appartient au cron, jamais édité sur une branche.
+- `#9851` — correctif du filtre `bin` substring (directory-segments only), qui a porté l'outil de 866 à 863 et aligné sur le catalogue.

--- a/scripts/notebook_tools/count_notebooks_by_series.py
+++ b/scripts/notebook_tools/count_notebooks_by_series.py
@@ -149,6 +149,10 @@ def main():
         "--check-readme", action="store_true",
         help="Compare actual counts with README declarations",
     )
+    parser.add_argument(
+        "--check", action="store_true",
+        help="Assertion (issue #9857): exit 1 if tool pedagogical count diverges from catalogue",
+    )
     args = parser.parse_args()
 
     pedagogical = not args.all
@@ -167,6 +171,39 @@ def main():
         counts = count_notebooks_in_dir(series_dir, pedagogical=pedagogical)
         if counts["total"] > 0 or args.series:
             results[series_dir.name] = counts
+
+    if args.check:
+        # Assertion #9857 : l'outil (pedagogique) et le catalogue (curé) doivent
+        # converger. Les deux appliquent le même EXCLUDE_PEDAGOGICAL, donc tout
+        # écart signale soit un drift de curation (notebook fraîchement ajouté,
+        # non curé — résolu par catalog-cron < 24h) soit un changement structurel.
+        # Détail chemin-par-chemin : scripts/audit/check_denominators.py --strict.
+        tool_total = sum(r["total"] for r in results.values())
+        catalog_path = REPO_ROOT / "COURSE_CATALOG.generated.json"
+        try:
+            with open(catalog_path, encoding="utf-8") as f:
+                catalog = json.load(f)
+        except FileNotFoundError:
+            print(f"ERREUR: catalogue introuvable: {catalog_path}", file=sys.stderr)
+            return 2
+        catalog_count = len(catalog) if isinstance(catalog, list) else len(
+            catalog.get("notebooks", []) if isinstance(catalog, dict) else []
+        )
+
+        print("CHECK -- convergence catalogue / outil")
+        print(f"  Outil (pedagogical) : {tool_total}")
+        print(f"  Catalogue (curated) : {catalog_count}")
+        if tool_total == catalog_count:
+            print(f"  Statut              : OK -- convergent ({tool_total} == {catalog_count})")
+            return 0
+        delta = tool_total - catalog_count
+        if delta > 0:
+            direction = "outil > catalogue : drift de curation (notebook fraichement ajoute, non cure -- resolu par catalog-cron < 24h)"
+        else:
+            direction = "catalogue > outil : notebook cure mais exclu par chemin outil (ex. examples/ promu au catalogue)"
+        print(f"  DIVERGENCE          : {abs(delta)} -- {direction}")
+        print("  -> investiguer : py scripts/audit/check_denominators.py --strict")
+        return 1
 
     if args.check_readme:
         print(f"\n{'Series':<15} {'Actual':>7} {'README':>7} {'Status':<10}")
@@ -223,4 +260,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #9866

Quoi: Documente les trois compteurs de notebooks (catalogue 863 / outil 863 / disque 974) côte à côte avec leurs définitions, et ajoute une assertion outillée `--check` qui rougit si catalogue et outil divergent.
Preuve: Réconciliation mesurée firsthand au SHA `e7307a717` (worktree frais), qui se referme exactement : `974 = 0 + 110 + 1 + 6 + 857`. `--check` testé exit 0 sur `863==863` et exit 1 sur catalogue tronqué à 860. 301 tests existants passent.
Perimetre: `docs/reference/notebook-counters.md` (nouveau, FR, ~165 lignes) + `scripts/notebook_tools/count_notebooks.py` (+38 lignes, mode `--check`). Catalogue byte-identique à main.

---

## Livrable

Documente côte à côte les **trois compteurs** légitimes du dépôt, chacun répondant à une question différente :

| Source | Compte | Répond à |
|--------|-------:|----------|
| Catalogue `COURSE_CATALOG.generated.json` | 863 | « Combien le dépôt présente-t-il publiquement ? » |
| Outil `count_notebooks_by_series.py` | 863 | « Combien de pédagogiques (hors recherche/archive/artefacts) ? » |
| Disque `find` | 974 | « Combien de `.ipynb` physiquement présents ? » |

### Réconciliation fichier-près (qui se referme exactement)

`974 (disque) − 111 = 863 (outil)` :
- **110** `EXCLUDE_PEDAGOGICAL` (research 101, archive 6, examples 3, partner-course 0, _output 0)
- **1** `GradeBook.ipynb` (fichier racine non parcouru — l'outil n'itère que les répertoires via `is_dir()` guard)

`863 (outil) = 857 (11 séries) + 6 (CaseStudies → bucket « other »)`.

### Finding G.1 (premierhand, contre-intuitif)

`GradeBook.ipynb` vit à la racine de `MyIA.AI.Notebooks/`. L'outil compte les notebooks en itérant les **sous-répertoires** (`for series_dir in NOTEBOOKS_DIR.iterdir(): if not series_dir.is_dir(): continue`). Un fichier racine n'est jamais atteint. C'est le **111ᵉ fichier** du gap disque→outil — pas une exclusion pédagogique. `CaseStudies/` (répertoire) est lui bien parcouru, ses 6 notebooks tombent en `(other)`.

Le catalogue converge lui aussi à 863 : il inclut les 6 CaseStudies (curés), exclut GradeBook et les 110 pédagogiques.

## Assertion outillée (`--check`, acceptance #9857)

```python scripts/notebook_tools/count_notebooks_by_series.py --check```

```
CHECK -- convergence catalogue / outil
  Outil (pedagogical) : 863
  Catalogue (curated) : 863
  Statut              : OK -- convergent (863 == 863)   # exit 0
```

Sort en `exit 1` si divergence. Testé : catalogue tronqué à 860 → `DIVERGENCE 3 -- outil > catalogue : drift de curation` → `exit 1`. Le diagnostic chemin-par-chemin reste délégué au script sœur `scripts/audit/check_denominators.py --strict` (issue #8050).

Bug fix connexe : le bloc `__main__` appelait `main()` sans `sys.exit()` — les codes de retour étaient perdus. Corrigé en `sys.exit(main())` (idiome cohérent avec `check_denominators.py`), sans changer le comportement des autres modes (qui retournent `None` → exit 0).

## Acceptance #9857

- [x] `docs/reference/notebook-counters.md` existe, en français, avec le tableau des trois définitions et la réconciliation fichier-près qui se referme exactement.
- [x] Assertion outillée `--check` qui rougit (exit 1) si catalogue et outil divergent.
- [x] Aucun nombre codé en dur dans de la **prose publique** (README / body PR) : les nombres vivent dans une **doc de référence datée et SHA-stampée** (`e7307a717`, 2026-08-07), comme la doc sœur `notebook-counts-reconciliation.md`. La section « Source canonique » désigne explicitement le marqueur `CATALOG-STATUS` (cron-maintenu) pour toute citation publique.

Base : `e7307a717` = origin/main (frais). Dépendance #9851 MERGED (compteur corrigé 863, pas 866).

Closes #9857

🤖 Generated with [Claude Code](https://claude.com/claude-code)