### PR TITLE
Refactor(lean,#8696): Reidemeister1Connected surgery = field-equalities (window 3/4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -624,7 +624,7 @@ theorem pr1_counterexample_excluded_under_connected :
   -- Reidemeister1Connected unfolds as wf₁ ∧ wf₂ ∧ (∃ i a Y' ρ, bounds ∧ edges ∧
   -- proper-arc ∧ isRenameOf ∧ surgery). The surgery is single-arm (twist only):
   -- d₂ = { d₁ with crossings := d₁.crossings.set i.val Y' ++ [⟨a,3,4,4⟩], numEdges := 4 }.
-  rintro ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, _ha1, ha2, _ha_edges, _hproper, _hren, hsurg⟩
+  rintro ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, _ha1, ha2, _ha_edges, _hproper, _hren, h_cross, _h_num⟩
   -- `i : Fin d₁.crossings.length = Fin 1`, so `i.val = 0`. omega cannot reduce the
   -- structure literal's `.crossings.length` on its own, so discharge the length by
   -- `rfl` (separate hyp — `rw` into `i.isLt` fails: `i`'s type depends on it) and
@@ -640,7 +640,7 @@ theorem pr1_counterexample_excluded_under_connected :
         : KnotDiagram).crossings =
       (({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
         : KnotDiagram).crossings.set i.val Y') ++ [⟨a, 3, 4, 4⟩] :=
-    congrArg (·.crossings) hsurg
+    h_cross
   rw [hi] at hfield
   -- RHS reduces to [⟨1,2,1,2⟩].set 0 Y' ++ [⟨a,3,4,4⟩] = [Y', ⟨a,3,4,4⟩].
   -- The second element gives ⟨3,4,3,4⟩ = ⟨a,3,4,4⟩ (cons injectivity).
@@ -834,14 +834,12 @@ private theorem mem_set_self {α : Type*} : ∀ (n : Nat) (l : List α) (v : α)
 theorem Reidemeister1Connected.tricolorable_forward {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1Connected d₁ d₂) (htri : IsTricolorable d₁) :
     IsTricolorable d₂ := by
-  obtain ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, ha1, ha2, _hamem, _hproper, hrename, hsurg⟩ := h
+  obtain ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, ha1, ha2, _hamem, _hproper, hrename, h_cross, h_num⟩ := h
   -- Edge-count and crossing-list consequences of the surgery equation.
-  have hd₂num : d₂.numEdges = d₁.numEdges + 2 := by
-    simpa using congrArg (·.numEdges) hsurg
+  have hd₂num : d₂.numEdges = d₁.numEdges + 2 := h_num
   have hd₂cross : d₂.crossings =
       d₁.crossings.set i.val Y' ++
-        [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩] := by
-    simpa using congrArg (·.crossings) hsurg
+        [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩] := h_cross
   obtain ⟨col₁, hfox₁, hge2, h2col⟩ := htri
   -- Extension colouring: preserved edges keep their colour, the two new edges
   -- (indices `d₁.numEdges` and `d₁.numEdges+1`, i.e. labels `b`, `c`) carry
@@ -1287,8 +1285,8 @@ borner l'arithmetique des indices de couleur. -/
 theorem Reidemeister1Connected.numEdges_eq {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1Connected d₁ d₂) :
     d₂.numEdges = d₁.numEdges + 2 := by
-  obtain ⟨_, _, _, _, _, _, _, _, _, _, _, hsurg⟩ := h
-  simpa using congrArg (·.numEdges) hsurg
+  obtain ⟨_, _, _, _, _, _, _, _, _, _, _, _h_cross, h_num⟩ := h
+  exact h_num
 
 /-! ## 9. Transfer arriere — analyse de decomposition (Epic #2874, Phase 5)
 
@@ -1554,14 +1552,12 @@ placeholder §2 `tricolorable_invariant`. Voir #2874.
 theorem Reidemeister1Connected.tricolorable_backward {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1Connected d₁ d₂) (htri₂ : IsTricolorable d₂) :
     IsTricolorable d₁ := by
-  obtain ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, ha1, ha2, _hamem, _hproper, hrename, hsurg⟩ := h
+  obtain ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, ha1, ha2, _hamem, _hproper, hrename, h_cross, h_num⟩ := h
   -- Surgery shape (mirrors `tricolorable_forward`).
-  have hd₂num : d₂.numEdges = d₁.numEdges + 2 := by
-    simpa using congrArg (·.numEdges) hsurg
+  have hd₂num : d₂.numEdges = d₁.numEdges + 2 := h_num
   have hd₂cross : d₂.crossings =
       d₁.crossings.set i.val Y' ++
-        [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩] := by
-    simpa using congrArg (·.crossings) hsurg
+        [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩] := h_cross
   obtain ⟨col₂, hfox₂, hge2₂, h2col₂⟩ := htri₂
   -- Naïve restriction: `col₁` embeds `d₁`'s edge indices into `d₂` (the +2
   -- fresh edges sit above `Fin d₁.numEdges`). Mirrors `tricolorable_forward`'s

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
@@ -571,7 +571,7 @@ theorem pr1_counterexample_excluded_under_connected :
   -- Reidemeister1Connected unfolds as wf₁ ∧ wf₂ ∧ (∃ i a Y' ρ, bounds ∧ edges ∧
   -- proper-arc ∧ isRenameOf ∧ surgery). The surgery is single-arm (twist only):
   -- d₂ = { d₁ with crossings := d₁.crossings.set i.val Y' ++ [⟨a,3,4,4⟩], numEdges := 4 }.
-  rintro ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, _ha1, ha2, _ha_edges, _hproper, _hren, hsurg⟩
+  rintro ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, _ha1, ha2, _ha_edges, _hproper, _hren, h_cross, _h_num⟩
   -- `i : Fin d₁.crossings.length = Fin 1`, so `i.val = 0`. omega cannot reduce the
   -- structure literal's `.crossings.length` on its own, so discharge the length by
   -- `rfl` (separate hyp — `rw` into `i.isLt` fails: `i`'s type depends on it) and
@@ -587,7 +587,7 @@ theorem pr1_counterexample_excluded_under_connected :
         : KnotDiagram).crossings =
       (({ crossings := [⟨1, 2, 1, 2⟩], numEdges := 2 }
         : KnotDiagram).crossings.set i.val Y') ++ [⟨a, 3, 4, 4⟩] :=
-    congrArg (·.crossings) hsurg
+    h_cross
   rw [hi] at hfield
   -- RHS reduces to [⟨1,2,1,2⟩].set 0 Y' ++ [⟨a,3,4,4⟩] = [Y', ⟨a,3,4,4⟩].
   -- The second element gives ⟨3,4,3,4⟩ = ⟨a,3,4,4⟩ (cons injectivity).
@@ -774,14 +774,12 @@ private theorem mem_set_self {α : Type*} : ∀ (n : Nat) (l : List α) (v : α)
 theorem Reidemeister1Connected.tricolorable_forward {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1Connected d₁ d₂) (htri : IsTricolorable d₁) :
     IsTricolorable d₂ := by
-  obtain ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, ha1, ha2, _hamem, _hproper, hrename, hsurg⟩ := h
+  obtain ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, ha1, ha2, _hamem, _hproper, hrename, h_cross, h_num⟩ := h
   -- Edge-count and crossing-list consequences of the surgery equation.
-  have hd₂num : d₂.numEdges = d₁.numEdges + 2 := by
-    simpa using congrArg (·.numEdges) hsurg
+  have hd₂num : d₂.numEdges = d₁.numEdges + 2 := h_num
   have hd₂cross : d₂.crossings =
       d₁.crossings.set i.val Y' ++
-        [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩] := by
-    simpa using congrArg (·.crossings) hsurg
+        [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩] := h_cross
   obtain ⟨col₁, hfox₁, hge2, h2col⟩ := htri
   -- Extension colouring: preserved edges keep their colour, the two new edges
   -- (indices `d₁.numEdges` and `d₁.numEdges+1`, i.e. labels `b`, `c`) carry
@@ -1219,8 +1217,8 @@ forthcoming `tricolorable_backward` to bound colour-index arithmetic. -/
 theorem Reidemeister1Connected.numEdges_eq {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1Connected d₁ d₂) :
     d₂.numEdges = d₁.numEdges + 2 := by
-  obtain ⟨_, _, _, _, _, _, _, _, _, _, _, hsurg⟩ := h
-  simpa using congrArg (·.numEdges) hsurg
+  obtain ⟨_, _, _, _, _, _, _, _, _, _, _, _h_cross, h_num⟩ := h
+  exact h_num
 
 /-! ## 9. Backward transfer — decomposition analysis (Epic #2874, Phase 5)
 
@@ -1470,14 +1468,12 @@ to unblock the §2 placeholder `tricolorable_invariant`. See #2874.
 theorem Reidemeister1Connected.tricolorable_backward {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1Connected d₁ d₂) (htri₂ : IsTricolorable d₂) :
     IsTricolorable d₁ := by
-  obtain ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, ha1, ha2, _hamem, _hproper, hrename, hsurg⟩ := h
+  obtain ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, ha1, ha2, _hamem, _hproper, hrename, h_cross, h_num⟩ := h
   -- Surgery shape (mirrors `tricolorable_forward`).
-  have hd₂num : d₂.numEdges = d₁.numEdges + 2 := by
-    simpa using congrArg (·.numEdges) hsurg
+  have hd₂num : d₂.numEdges = d₁.numEdges + 2 := h_num
   have hd₂cross : d₂.crossings =
       d₁.crossings.set i.val Y' ++
-        [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩] := by
-    simpa using congrArg (·.crossings) hsurg
+        [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩] := h_cross
   obtain ⟨col₂, hfox₂, hge2₂, h2col₂⟩ := htri₂
   -- Naïve restriction: `col₁` embeds `d₁`'s edge indices into `d₂` (the +2
   -- fresh edges sit above `Fin d₁.numEdges`). Mirrors `tricolorable_forward`'s

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
@@ -267,9 +267,9 @@ def Reidemeister1Connected (d₁ d₂ : KnotDiagram) : Prop :=
      a ∈ d₁.edges ∧
      (∃ (j : Fin d₁.crossings.length), j ≠ i ∧ (d₁.crossings.get j).hasEdge a) ∧
      Y'.isRenameOf (d₁.crossings.get i) a (d₁.numEdges + 1) ∧
-     d₂ = { d₁ with crossings := d₁.crossings.set i.val Y' ++
-                       [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩],
-                    numEdges := d₁.numEdges + 2 })
+     d₂.crossings = d₁.crossings.set i.val Y' ++
+       [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩] ∧
+     d₂.numEdges = d₁.numEdges + 2)
 
 /-- `Reidemeister1Connected` n'est PAS vide (contrairement à
     `Reidemeister1'`) : une torsion connectée concrète `d₁ → d₂` avec
@@ -302,7 +302,7 @@ theorem reidemeister1Connected_satisfiable :
     --   j=0 ≠ i=1, witnessed explicitly; `hasEdge` unfolded + `decide`.
     exact ⟨by decide, by decide, by decide,
            ⟨⟨0, by decide⟩, by decide, by unfold PDCrossing.hasEdge; decide⟩,
-           by unfold PDCrossing.isRenameOf; decide, rfl⟩
+           by unfold PDCrossing.isRenameOf; decide, ⟨rfl, rfl⟩⟩
 
 /-! ### Lemmes d'API pour `Reidemeister1Connected` (infrastructure option C pour PR2)
 
@@ -319,18 +319,16 @@ mitent le style d'API de projection `trefoil_wf` / `unknot_wf` de `Basic.lean`.
     disjoint mais via une insertion connectée. -/
 theorem Reidemeister1Connected.numEdges_succ {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1Connected d₁ d₂) : d₂.numEdges = d₁.numEdges + 2 := by
-  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, _hproper, _hrename, hsurg⟩ := h
-  have hne := congrArg (·.numEdges) hsurg
-  simpa using hne
+  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, _hproper, _hrename, _h_cross, h_num⟩ := h
+  exact h_num
 
 /-- Une torsion R1 connectée ajoute exactement un croisement (la boucle `C`) ;
     le croisement d'extrémité existant `Y` est renuméroté sur place (`List.set`
     préserve la longueur), non dupliqué. -/
 theorem Reidemeister1Connected.numCrossings_succ {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1Connected d₁ d₂) : d₂.crossings.length = d₁.crossings.length + 1 := by
-  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, _hproper, _hrename, hsurg⟩ := h
-  have hcl := congrArg (fun d => d.crossings.length) hsurg
-  simpa [List.length_set, List.length_append] using hcl
+  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, _hproper, _hrename, h_cross, _h_num⟩ := h
+  rw [h_cross]; simp [List.length_set, List.length_append]
 
 /-- L'arc `a` recevant la torsion est une arête authentique de `d₁` (hypothèse
     de connectivité) : le nouveau croisement `C = ⟨a, b, c, c⟩` partage l'arête
@@ -355,9 +353,8 @@ theorem Reidemeister1Connected.crossings_eq {d₁ d₂ : KnotDiagram}
       i < d₁.crossings.length ∧
       d₂.crossings = d₁.crossings.set i Y' ++
         [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩] := by
-  obtain ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, _hr1, _hr2, _hmem, _hproper, _hrename, hsurg⟩ := h
-  refine ⟨i.val, Y', a, i.isLt, ?_⟩
-  simpa using congrArg (·.crossings) hsurg
+  obtain ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, _hr1, _hr2, _hmem, _hproper, _hrename, h_cross, _h_num⟩ := h
+  exact ⟨i.val, Y', a, i.isLt, h_cross⟩
 
 /-- R2 (Pique/Dépiqué) : ajout ou suppression de deux croisements consécutifs
 de signe opposé.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister_en.lean
@@ -250,9 +250,9 @@ def Reidemeister1Connected (d₁ d₂ : KnotDiagram) : Prop :=
      a ∈ d₁.edges ∧
      (∃ (j : Fin d₁.crossings.length), j ≠ i ∧ (d₁.crossings.get j).hasEdge a) ∧
      Y'.isRenameOf (d₁.crossings.get i) a (d₁.numEdges + 1) ∧
-     d₂ = { d₁ with crossings := d₁.crossings.set i.val Y' ++
-                       [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩],
-                    numEdges := d₁.numEdges + 2 })
+     d₂.crossings = d₁.crossings.set i.val Y' ++
+       [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩] ∧
+     d₂.numEdges = d₁.numEdges + 2)
 
 /-- `Reidemeister1Connected` is NOT vacuous (contrast with `Reidemeister1'`):
     a concrete connected twist `d₁ → d₂` with `wf = true` on both sides.
@@ -283,7 +283,7 @@ theorem reidemeister1Connected_satisfiable :
     --   j=0 ≠ i=1, witnessed explicitly; `hasEdge` unfolded + `decide`.
     exact ⟨by decide, by decide, by decide,
            ⟨⟨0, by decide⟩, by decide, by unfold PDCrossing.hasEdge; decide⟩,
-           by unfold PDCrossing.isRenameOf; decide, rfl⟩
+           by unfold PDCrossing.isRenameOf; decide, ⟨rfl, rfl⟩⟩
 
 /-! ### API lemmas for `Reidemeister1Connected` (option C infrastructure for PR2)
 
@@ -300,18 +300,16 @@ by exactly 1. They mirror the `trefoil_wf` / `unknot_wf` projection-API style of
     a connected splice. -/
 theorem Reidemeister1Connected.numEdges_succ {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1Connected d₁ d₂) : d₂.numEdges = d₁.numEdges + 2 := by
-  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, _hproper, _hrename, hsurg⟩ := h
-  have hne := congrArg (·.numEdges) hsurg
-  simpa using hne
+  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, _hproper, _hrename, _h_cross, h_num⟩ := h
+  exact h_num
 
 /-- A connected R1 twist adds exactly one crossing (the curl `C`); the existing
     endpoint crossing `Y` is relabelled in place (`List.set` preserves length),
     not duplicated. -/
 theorem Reidemeister1Connected.numCrossings_succ {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1Connected d₁ d₂) : d₂.crossings.length = d₁.crossings.length + 1 := by
-  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, _hproper, _hrename, hsurg⟩ := h
-  have hcl := congrArg (fun d => d.crossings.length) hsurg
-  simpa [List.length_set, List.length_append] using hcl
+  obtain ⟨_hwf₁, _hwf₂, _i, _a, _Y', _ρ, _hr1, _hr2, _hmem, _hproper, _hrename, h_cross, _h_num⟩ := h
+  rw [h_cross]; simp [List.length_set, List.length_append]
 
 /-- The arc `a` receiving the twist is a genuine edge of `d₁` (connectivity
     hypothesis): the new crossing `C = ⟨a, b, c, c⟩` shares edge `a` with `d₁`,
@@ -336,9 +334,8 @@ theorem Reidemeister1Connected.crossings_eq {d₁ d₂ : KnotDiagram}
       i < d₁.crossings.length ∧
       d₂.crossings = d₁.crossings.set i Y' ++
         [⟨a, d₁.numEdges + 1, d₁.numEdges + 2, d₁.numEdges + 2⟩] := by
-  obtain ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, _hr1, _hr2, _hmem, _hproper, _hrename, hsurg⟩ := h
-  refine ⟨i.val, Y', a, i.isLt, ?_⟩
-  simpa using congrArg (·.crossings) hsurg
+  obtain ⟨_hwf₁, _hwf₂, i, a, Y', _ρ, _hr1, _hr2, _hmem, _hproper, _hrename, h_cross, _h_num⟩ := h
+  exact ⟨i.val, Y', a, i.isLt, h_cross⟩
 
 /-- R2 (Poke/Unpoke): add or remove two consecutive crossings of opposite sign.
 


### PR DESCRIPTION
## Refactor(lean,#8696): Reidemeister1Connected surgery = field-equalities (window 3/4)

Suite du chantier multi-cycle **#8696** (Reidemeister corridor field-eqs migration).
Apr&egrave;s Reidemeister1 (L91/92, **PR #9807 MERGED** c.8164) et Reidemeister1' (L143/145, m&ecirc;me PR),
la chirurgie `with`-update de **`Reidemeister1Connected`** est remplac&eacute;e par un couple
d'&eacute;galit&eacute;s de champs sur `d2.crossings` et `d2.numEdges`.

## Pattern A appliqu&eacute;

```lean
-- AVANT (record `with` surgery)
structure Reidemeister1Connected (d1 d2 : KnotDiagram) : Prop where
  ...
  surg : d2 = d1.with ...   -- 2-champs mut&eacute;s simultan&eacute;ment via `with`

-- APR&Egrave;S (field equalities)
def Reidemeister1Connected (d1 d2 : KnotDiagram) : Prop :=
  ... ∧
  d2.crossings = d1.crossings.set i.val Y' ++
    [&#10216;a, d1.numEdges + 1, d1.numEdges + 2, d1.numEdges + 2&#10217;] ∧
  d2.numEdges = d1.numEdges + 2
```

Pattern identique &agrave; celui livr&eacute; en c.8164 (#9807) sur Reidemeister1 et Reidemeister1'.

## B&eacute;n&eacute;fices

1. **Consumers en aval** (`Invariant.lean` : `tricolorable_forward`, `tricolorable_backward`,
   `numEdges_eq`) acc&egrave;dent directement aux &eacute;galit&eacute;s de champs, plus via
   `congrArg (fun x => x.numEdges) hsurg` (m&eacute;canisme mort post-field-eqs).
2. **i18n sibling-pair #4980** : la d&eacute;f FR (L262-272) est byte-identique &agrave; la d&eacute;f EN
   (L245-255 dans `Reidemeister_en.lean`), hors docstrings (crit&egrave;re v&eacute;rifi&eacute; par diff direct).
3. **Witness theorem** `reidemeister1Connected_satisfiable` se conclut par `&#10216;rfl, rfl&#10217;`
   (2-conj litt&eacute;ral) au lieu de `rfl` (record-equation).
4. **6 consumers cross-file** dans `Invariant.lean` / `Invariant_en.lean` mis &agrave; jour
   destructurant `hsurg` en `h_cross, h_num` (ou `_h_num`).

## Perim&egrave;tre c.8166

| Fichier | Lignes touch&eacute;es | Statut |
|---|---|---|
| `Knots/Reidemeister.lean` | def R1Connected L262-272 + 4 consumers L305-358 | modifi&eacute; |
| `Knots/Reidemeister_en.lean` | mirror EN L245-255 + L284-336 | modifi&eacute; (byte-identity FR) |
| `Knots/Invariant.lean` | 6 sites (L1287-1290, L837, L840, L844, L1555-1564, L627-643) | modifi&eacute; |
| `Knots/Invariant_en.lean` | mirror EN des 6 sites | modifi&eacute; (byte-identity FR) |

**Total** : 4 fichiers, **+40 insertions / -54 deletions**.

## Validation

- **§B.1 Lake build** (warm cache post-c.8164) : `lake build Knots.Reidemeister`,
  `Knots.Reidemeister_en`, `Knots.Invariant`, `Knots.Invariant_en` &mdash; **4/4 EXIT=0**.
  Log WSL : `=== REBUILD_OK 2026-08-07T11:45:10Z`.
- **§B.2 axiomes** :
  - `grep -c sorry` par fichier : **2/2/14/9** (inchang&eacute; depuis baseline c.8165).
  - `grep -c native_decide` par fichier : **0/0/4/4** &mdash; les 4+4 mentions dans `Invariant*`
    sont **toutes dans des docstrings `/-- ... -/`** (descriptions historiques expliquant
    pourquoi on les &eacute;vite). Aucun `native_decide` actif introduit.
  - `grep -c sorryAx` par fichier : **0** (pas de transitivit&eacute; `sorry`).
  - `grep -c Classical.choice` par fichier : **0/0/1/1** (pre-existants, inchang&eacute;s).
- **§B.3 proof-integrity** : `lean-axiom.yml` non c&acirc;bl&eacute; sur le lake `knot_lean`
  (cf triage par lake `docs/reference/lean-axiom-coverage.md`). **B.3 non applicable pour ce module** &mdash;
  &agrave; &eacute;crire explicitement, le job advisory `target-coverage` rend l'&eacute;cart lisible dans le log.

## Hors-scope (d&eacute;couplage multi-cycle)

3 sites `with`-surgery restants dans `Reidemeister.lean` / `Reidemeister_en.lean`
(programm&eacute;s pour les cycles suivants) :

- **c.8167** : R2 L381/382 (multi-crossing `++ [c1, c2]` +4 edges)
- **c.8168** : R3 L413/414 (single-element `set i c`)
- **c.8169** : R3D L484/485 (single-element `set i.val c`)

Le scope r&eacute;el de #8696 = 4 fen&egrave;tres restantes (apr&egrave;s c.8165 NO-OP discovery),
dont c.8166 = celle-ci. PR livr&eacute;e = `See #8696` (L883 ★, pas `Closes`).

## Le&ccedil;ons appliqu&eacute;es

- **L887 ★★** (c.8164) : `obtain rfl := hsurg` (RHS literal `with`) **OU**
  `exact &#10216;rfl, rfl&#10217;` (witness literal 2-conj) &mdash; pattern dupliqu&eacute; ici.
- **L890 ★★** (c.8165) : `git diff origin/main..HEAD -- <paths>` obligatoire avant push ;
  ici = +40/-54, **pas un no-op**.
- **L883 ★** : `See #8696` (pas `Closes`, contribution partielle).
- **L677-L4 ★★** : PR body HORS worktree (scratchpad pattern).
- **L888 ★** : `git commit -F <file>` (pas de heredoc bash avec backticks).
- **L898 ★★★** : `gh pr list --search head:<branch>` = `[]` (pas de collision cross-lane).
- **L9774** : claim pos&eacute;e sur issue #8696 (`[CLAIMED] lane myia-po-2026:CoursIA-2 ... 2026-08-07T06:30Z`).

## Anti-r&eacute;gression §D

Aucun `sorry` ajout&eacute;. Aucune r&eacute;gression d'axiome. Aucune suppression de code m&eacute;tier.
Seul le **pattern m&eacute;canique** `with`-surgery (L262-272) est remplac&eacute; par des &eacute;galit&eacute;s
de champs, ce qui **pr&eacute;serve la s&eacute;mantique** (proof-irrelevant, m&ecirc;me `Prop`,
m&ecirc;mes t&eacute;moins) et **simplifie les consumers**.

## Voir aussi

- PR #9807 (window 1/9, c.8164) &mdash; Reidemeister1 + Reidemeister1' field-eqs.
- Issue **#8696** &mdash; corridor Reidemeister (4 sites `with`-surgery).
- Topic [cycles-c8162-c8165-reidemeister-corridor](MEMORY.md#cycles-c8162-c8165--reidemeister-corridor-refactor-8696-multi-cycle-chantier).
- L887 ★★, L890 ★★, L883 ★, L898 ★★★, L677-L4 ★★, L888 ★.