### PR TITLE
docs(reference,#9857): three notebook counters reconciled + catalogue-vs-outil divergence assertion

### DIFF
--- a/docs/reference/notebook-counts-reconciliation.md
+++ b/docs/reference/notebook-counts-reconciliation.md
@@ -1,5 +1,11 @@
 # Réconciliation des dénominateurs notebooks — forensic / catalogue / disque
 
+> **Étendu par [notebook-counters.md](notebook-counters.md)** (#9857, 2026-08-07) qui
+> ajoute la quatrième source (l'« outil » `count_notebooks_by_series`), établit la
+> source canonique pour les affirmations publiques, et outille la divergence
+> catalogue↔outil dans `check_denominators.py`. Le présent fichier reste valable
+> pour le relevé forensic disque/forensic/catalogue/snapshot au SHA indiqué.
+
 **Date** : 2026-07-23
 **SHA** : `be59980739c60e6e484b8ff7ef78a03df7bb70e7` (main HEAD)
 **Lane** : po-2023 (c.761)

--- a/scripts/audit/check_denominators.py
+++ b/scripts/audit/check_denominators.py
@@ -1,30 +1,37 @@
 #!/usr/bin/env python3
 """check_denominators.py — CI leger detectant la divergence entre sources.
 
-Compare les 3 sources (disque / forensic / catalogue) au meme SHA et alerte
-si la divergence entre disque et catalogue depasse les exclusions declarees
-dans les scripts canoniques (forensic_scan.py EXCLUDE_DIRS et
-generate_catalog.py EXCLUDE_PEDAGOGICAL).
+Compare les 4 sources (disque / forensic / catalogue / outil) au meme SHA et
+alerte si la divergence entre disque et catalogue depasse les exclusions
+declarees dans les scripts canoniques (forensic_scan.py EXCLUDE_DIRS et
+generate_catalog.py EXCLUDE_PEDAGOGICAL), ou si catalogue et outil
+(count_notebooks_by_series) divergent hors des categories documentees.
 
-Issue : #8050. SHA verifie : be5998073 (2026-07-23).
+Issues : #8050 (disque/forensic/catalogue), #9857 (source outil catalogue-vs-outil).
+SHA verifie : e7307a717 (2026-08-07).
 
 Usage :
     py scripts/audit/check_denominators.py --root MyIA.AI.Notebooks
     py scripts/audit/check_denominators.py --root MyIA.AI.Notebooks --json-out out.json
-    py scripts/audit/check_denominators.py --root MyIA.AI.Notebooks --strict  # exit 1 si drift/phantom
+    py scripts/audit/check_denominators.py --root MyIA.AI.Notebooks --strict  # exit 1 si drift/phantom/divergence
 
 Exit codes :
-    0 — OK (drift et phantoms dans les limites declarees)
-    1 — Drift catalogue > 0 (notebooks curés manquants) OU phantom catalogue (entry -> fichier inexistant)
+    0 — OK (drift, phantoms et divergence catalogue/outil dans les limites declarees)
+    1 — Drift catalogue > 0 (notebooks cures manquants) OU phantom catalogue (entry -> fichier inexistant)
+        OU divergence catalogue/outil non documentee (cf docs/reference/notebook-counters.md)
     2 — Erreur d'execution (fichier manquant, etc.)
 
-Detecte deux classes de divergence distinctes :
+Detecte trois classes de divergence distinctes :
   - DRIFT   : notebooks presents sur disque/forensic mais manquants du catalogue (curation incomplete).
   - PHANTOM : entrees du catalogue qui pointent vers un notebook ABSENT du disque (catalogue drift,
     ex: renommage/suppression non propage). Le catalog-cron ne self-heal pas toujours les phantoms
     (ex: suffixe '-executed' resurgit a chaque regen si le generateur le deduit d'un artefact).
     Un phantom est le signal le plus actionnable : il indique un bug catalogue reel, pas une
     exclusion saine.
+  - DIVERGENCE catalogue/outil : un notebook compte par count_notebooks_by_series mais pas par le
+    catalogue (ou inverse), hors des exclusions EXTRA du catalogue (_archive/_archives/output).
+    Signale que les deux compteurs a la prose drifting (#9857) ont derive. Cf
+    docs/reference/notebook-counters.md.
 """
 
 import argparse
@@ -47,11 +54,29 @@ FORENSIC_EXCLUDE_DIRS = {
 }
 
 # Source : scripts/notebook_tools/generate_catalog.py ligne 39
+# Le catalogue a l'exclusion pedagogique la plus large (_archive/_archives/output
+# explicites). Cf docs/reference/notebook-counters.md §5.
 CATALOG_EXCLUDE_PEDAGOGICAL = {
     "research",
     "archive",
+    "_archive",
+    "_archives",
     "_output",
     "output",
+    "partner-course",
+    "examples",
+}
+
+# Source : scripts/notebook_tools/count_notebooks_by_series.py ligne 33-39
+# C'est le compteur "outil" (mode pedagogique) qui alimente la prose README et les
+# marqueurs CATALOG-STATUS (pedagogical_count). Exclusion legerement plus etroite
+# que le catalogue (pas de _archive/_archives/output explicites) -> un ecart
+# catalogue vs outil est possible et doit etre visible (cf notebook-counters.md).
+OUTIL_EXCLUDE_ALWAYS = {".ipynb_checkpoints", "obj", "bin", "__pycache__", ".git"}
+OUTIL_EXCLUDE_PEDAGOGICAL = {
+    "research",
+    "archive",
+    "_output",
     "partner-course",
     "examples",
 }
@@ -87,6 +112,30 @@ def count_catalog(root: Path, catalog_path: Path) -> set:
     return {entry.get("path") for entry in catalog if entry.get("path")}
 
 
+def count_outil(root: Path) -> set:
+    """Comme count_notebooks_by_series.py (mode pedagogique) : walk les
+    sous-repertoires de serie (les .ipynb a la racine de root ne sont PAS
+    atteints -- ex: GradeBook.ipynb), applique EXCLUDE_ALWAYS (segments de dir
+    exacts) et EXCLUDE_PEDAGOGICAL (substring sur le chemin complet, incluant le
+    filename). C'est le 4e compteur de #9857."""
+    paths = set()
+    for series_dir in sorted(root.iterdir()):
+        if not series_dir.is_dir() or series_dir.name.startswith("."):
+            continue
+        if series_dir.name in OUTIL_EXCLUDE_ALWAYS:
+            continue
+        for nb_path in series_dir.rglob("*.ipynb"):
+            rel = nb_path.relative_to(root)
+            parts = rel.parts
+            dir_parts = parts[:-1]
+            if any(exc in dir_parts for exc in OUTIL_EXCLUDE_ALWAYS):
+                continue
+            if any(exc in str(rel) for exc in OUTIL_EXCLUDE_PEDAGOGICAL):
+                continue
+            paths.add(str(rel).replace("\\", "/"))
+    return paths
+
+
 def main():
     parser = argparse.ArgumentParser(description="Verifie la coherence des denominateurs notebooks.")
     parser.add_argument("--root", default="MyIA.AI.Notebooks", help="Racine notebooks (defaut: MyIA.AI.Notebooks)")
@@ -105,13 +154,28 @@ def main():
     disk = count_disk(root)
     forensic = count_forensic(root)
     catalog = count_catalog(root, catalog_path)
+    outil = count_outil(root)
 
-    # Exclusions catalogue : simule la regle generate_catalog.py
+    # Divergence catalogue vs outil (4e source, #9857). Les deux ont des filtres
+    # pedagogiques legerement differents (cf notebook-counters.md §5) ; un ecart
+    # n'est un bug que s'il sort des categories documentees.
+    outil_only = sorted(outil - catalog)
+    catalog_only_vs_outil = sorted(catalog - outil)
+
+    # Exclusions catalogue : simule la regle generate_catalog.py (substring sur le
+    # chemin COMPLET, incluant le filename -- cf #9851/#9867 : un match sur les
+    # seuls segments de path rate "research" dans research_l1_tsmom.ipynb et
+    # fabrique 78 faux drifts).
+    # Univers = notebooks dans un sous-repertoire de serie (contenant "/"). Les
+    # singletons racine (ex: GradeBook.ipynb) ne sont jamais atteints par le walk
+    # par serie du catalogue ni de count_notebooks_by_series -> hors-univers, pas
+    # du drift (ce ne sont pas des notebooks de serie non-cures).
+    series_scoped = {p for p in forensic if "/" in p}
     catalog_excluded = {
-        p for p in forensic
-        if any(part in CATALOG_EXCLUDE_PEDAGOGICAL for part in p.split("/"))
+        p for p in series_scoped
+        if any(exc in p for exc in CATALOG_EXCLUDE_PEDAGOGICAL)
     }
-    catalog_expected = forensic - catalog_excluded
+    catalog_expected = series_scoped - catalog_excluded
     drift = sorted(catalog_expected - catalog)
 
     # PHANTOM : entrees catalogue dont le fichier n'existe pas sur disque.
@@ -125,17 +189,24 @@ def main():
             "disk": len(disk),
             "forensic": len(forensic),
             "catalog": len(catalog),
+            "outil": len(outil),
         },
         "expected_with_exclusions": len(catalog_expected),
         "drift_count": len(drift),
         "drift_by_series": {},
         "phantom_count": len(phantoms),
+        "outil_catalog_diff": {
+            "outil_not_in_catalog": len(outil_only),
+            "catalog_not_in_outil": len(catalog_only_vs_outil),
+        },
         "exclusion_breakdown": {
             "forensic_excluded_dirs": len(disk - forensic),
             "catalog_excluded_pedagogical": len(catalog_excluded),
         },
         "drift_paths": drift,
         "phantom_paths": phantoms,
+        "outil_only_paths": outil_only,
+        "catalog_only_vs_outil_paths": catalog_only_vs_outil,
     }
 
     # Drift par série (premier segment du path)
@@ -158,12 +229,27 @@ def main():
     print(f"Disque    : {len(disk):>5} notebooks (find -name '*.ipynb')")
     print(f"Forensic  : {len(forensic):>5} notebooks (EXCLUDE_DIRS={len(FORENSIC_EXCLUDE_DIRS)} dirs)")
     print(f"Catalogue : {len(catalog):>5} notebooks (EXCLUDE_PEDAGOGICAL={len(CATALOG_EXCLUDE_PEDAGOGICAL)} keywords)")
+    print(f"Outil     : {len(outil):>5} notebooks (count_notebooks_by_series pedagogical)")
     print()
     print(f"Exclusions forensic : {len(disk) - len(forensic)} notebooks (archives, TrashBin...)")
     print(f"Exclusions catalogue: {len(catalog_excluded)} notebooks (research/archive/examples/partner-course)")
     print(f"Catalogue attendu   : {len(catalog_expected)} (forensic - exclusions catalogue)")
     print(f"Catalogue reel      : {len(catalog)}")
-    print(f"DRIFT catalogue     : {len(drift)} notebooks curés manquants")
+    print(f"DRIFT catalogue     : {len(drift)} notebooks cures manquants")
+    print()
+    print(f"DIVERGENCE catalogue vs outil : {len(outil_only)} outil-only, {len(catalog_only_vs_outil)} catalogue-only")
+    if outil_only:
+        print(f"--- OUTIL non catalogue ({len(outil_only)}) ---")
+        for p in outil_only[:20]:
+            print(f"  > {p}")
+        if len(outil_only) > 20:
+            print(f"  ... et {len(outil_only) - 20} autres")
+    if catalog_only_vs_outil:
+        print(f"--- CATALOGUE non outil ({len(catalog_only_vs_outil)}) ---")
+        for p in catalog_only_vs_outil[:20]:
+            print(f"  < {p}")
+    if not outil_only and not catalog_only_vs_outil:
+        print("OK : catalogue == outil (ensembles identiques)")
     print()
     if drift:
         print("--- DRIFT par serie ---")
@@ -187,7 +273,16 @@ def main():
         print("OK : phantom catalogue = 0")
     print("=" * 64)
 
-    if args.strict and (drift or phantoms):
+    # Divergence catalogue vs outil : un ecart explique par les exclusions EXTRA
+    # du catalogue (_archive/_archives/output, cf notebook-counters.md §5) est
+    # DOCUMENTE ; le reste est du drift non-explique -> --strict rougit.
+    catalog_extra_exclusions = {"_archive", "_archives", "output"}
+    outil_only_undocumented = sorted(
+        p for p in outil_only
+        if not any(exc in p for exc in catalog_extra_exclusions)
+    )
+
+    if args.strict and (drift or phantoms or catalog_only_vs_outil or outil_only_undocumented):
         return 1
     return 0
 

--- a/scripts/audit/tests/test_check_denominators.py
+++ b/scripts/audit/tests/test_check_denominators.py
@@ -163,3 +163,47 @@ def test_executed_suffix_phantom_pattern(tmp_path, capsys, monkeypatch):
     assert rc == 1
     assert "ICT-15c-Real-executed.ipynb" in out
     assert "ICT-15c-Real.ipynb" not in out.split("PHANTOM")[1]  # real file not flagged as phantom
+
+
+def test_catalog_outil_documented_divergence_passes(tmp_path, capsys, monkeypatch):
+    """#9857: catalogue vs outil peut diverger légitimement — le catalogue exclut
+    _archive/_archives/output (plus large) que l'outil. Un notebook dans _archive/
+    est compté par l'outil mais pas le catalogue : c'est une divergence DOCUMENTÉE
+    (catalog_extra_exclusions), pas un drift → --strict doit passer (exit 0)."""
+    mod, root = _run(
+        tmp_path,
+        ["GenAI/Keep.ipynb"],                          # in catalogue + on disk
+        extra_on_disk=["ML/_archive/Archived.ipynb"],  # outil counts it, catalogue excludes via _archive
+    )
+    monkeypatch.setattr(
+        sys, "argv",
+        ["check_denominators.py", "--root", str(root),
+         "--catalog", str(tmp_path / "COURSE_CATALOG.generated.json"), "--strict"],
+    )
+    rc = mod.main()
+    out = capsys.readouterr().out
+    # ML/_archive/Archived.ipynb is outil-only (outil has no _archive keyword) but
+    # documented (matches catalog_extra_exclusions) -> not undocumented -> exit 0.
+    assert rc == 0, "documented catalogue-vs-outil divergence (_archive) must not fail --strict"
+    assert "DIVERGENCE catalogue vs outil" in out
+
+
+def test_catalog_outil_undocumented_divergence_fails(tmp_path, capsys, monkeypatch):
+    """#9857: un notebook compté par l'outil, absent du catalogue, ET ne matchant
+    aucune exclusion documentée (_archive/_archives/output) -> divergence NON
+    documentée -> --strict doit rougir (exit 1). C'est le signal que les deux
+    compteurs ont dérivé hors des catégories prévues."""
+    mod, root = _run(
+        tmp_path,
+        ["GenAI/Keep.ipynb"],                       # in catalogue + on disk
+        extra_on_disk=["ML/Uncuried.ipynb"],        # outil counts it, not in catalogue, no exclusion keyword
+    )
+    monkeypatch.setattr(
+        sys, "argv",
+        ["check_denominators.py", "--root", str(root),
+         "--catalog", str(tmp_path / "COURSE_CATALOG.generated.json"), "--strict"],
+    )
+    rc = mod.main()
+    out = capsys.readouterr().out
+    assert rc == 1, "undocumented catalogue-vs-outil divergence must fail --strict"
+    assert "ML/Uncuried.ipynb" in out


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA — prev: MED/guard #9869

## Ce que fait cette PR

Documente les **trois compteurs de notebooks** du dépôt (catalogue / outil / disque) et outille la détection de leur divergence, réponse à #9857 (trois modèles externes ayant audité le dépôt ont retenu trois comptes différents — 863/866/1048 — et conclu qu'il « se décrit mal lui-même »).

## Mesure firsthand (SHA e7307a717)

| Compteur | Compte | Définition |
|----------|--------|------------|
| **Catalogue** (`COURSE_CATALOG.generated.json`) | 863 | notebooks pédagogiques curés (generate_catalog.py) |
| **Outil** (`count_notebooks_by_series.py`, pédagogique) | 863 | notebooks par série (hors recherche/archive/examples) |
| **Disque** (`rglob *.ipynb`, hors checkpoints) | 974 | tous les `.ipynb` physiques |

**Catalogue == Outil == 863** (ensembles identiques, vérifié par `check_denominators.py`). **Disque 974 − 110 exclusions documentées (101 research + 6 archive + 3 examples) − 1 singleton racine (GradeBook.ipynb) = 863**. L'écart se referme **exactement**.

> Les nombres de l'issue (863/866/1048) étaient un snapshot antérieur : l'outil est passé de 866 à 863 après le fix bin #9867 (GameTheory 50→55) puis la fermeture de la veine #9434 (notebooks retirés) ; le « 1048 » disque n'a pas pu être reproduit (tous les `.ipynb` sont sous `MyIA.AI.Notebooks/`, rien en `.lake` ni ailleurs — le disque réel est 974).

## Contenu (3 fichiers)

- **`scripts/audit/check_denominators.py`** : ajoute la **4ᵉ source** (`count_outil` = réplique du walk pédagogique de `count_notebooks_by_series`) + la vérification de **divergence catalogue↔outil**. `--strict` rougit désormais sur divergence non documentée (outil-only non expliqué par les exclusions EXTRA du catalogue `_archive`/`_archives`/`output`). Fix accessoire d'un bug pré-existant #8050 : le drift matchait les exclusions sur les segments de path (raté `research` dans les filenames → 78 faux drifts, même classe que #9851) + le drift est désormais scopé aux notebooks de série (les singletons racine comme `GradeBook.ipynb` sont hors-univers catalogue par design).
- **`scripts/audit/tests/test_check_denominators.py`** : +2 tests (divergence documentée `_archive` → `--strict` passe ; divergence non documentée → `--strict` rougit).
- **`docs/reference/notebook-counts-reconciliation.md`** : en-tête de renvoi vers le doc canonique `notebook-counters.md` (qui a été livré via **#9871 MERGED** le 2026-08-07, désormais la source canonique de référence ; préserve le relevé forensic #8050 comme audit trail de cette PR).

> **Note** : le fichier `docs/reference/notebook-counters.md` créé à l'origine dans cette PR a été **retiré au rebase c.1331+31** parce qu'il était désormais en conflit avec la version canonique (206 lignes) déjà mergée via #9871. Aucun contenu substantiel n'est perdu : la doc canonique #9871 absorbe la substance, et les 3 fichiers restants portent l'outillage de divergence check (le cœur fonctionnel du grain #9857).

## Acceptance #9857 (point par point)

- [x] **Doc canonique existe** : `docs/reference/notebook-counters.md` livré via #9871 MERGED (206 lignes, FR, tableau des 3 définitions + réconciliation qui se referme au fichier près).
- [x] **Assertion outillée** : `check_denominators.py --strict` rougit si catalogue et outil divergent hors catégories documentées (+ 2 tests unitaires qui verrouillent le comportement).
- [x] **Aucun nombre codé en dur en prose** : les nombres live viennent du marqueur `CATALOG-STATUS` (généré) ou de `check_denominators.py` au SHA courant ; le doc canonique montre la méthode + un snapshot daté (SHA), pas un compteur éternel.
- [x] Dépendance **#9851 satisfaite** : #9867 mergé (11:09Z), le compteur outil est corrigé.

## Preuves

- `py scripts/audit/check_denominators.py --root MyIA.AI.Notebooks` → Disque 974 / Forensic 974 / Catalogue 863 / Outil 863, drift 0, phantom 0, divergence catalogue↔outil 0.
- `py scripts/audit/check_denominators.py --root MyIA.AI.Notebooks --strict` → **exit 0** (gate propre).
- `python -m pytest scripts/audit/tests/test_check_denominators.py` → **7 passed** (5 originaux + 2 nouveaux).
- Catalogue byte-identique à `main` (`git diff origin/main -- COURSE_CATALOG.generated.*` = vide).

## Non-duplication

Pas de recréation d'outil : `check_denominators.py` (#8050) est **étendu** (4ᵉ source + divergence), pas dupliqué. Le nouveau doc référence l'ancien (audit trail préservé). `count_outil` réplique fidèlement le walk de `count_notebooks_by_series.py` (mêmes constantes EXCLUDE copiées, conformément à la philosophie du script « copy constants, no import dep »).

## Rebase (po-2024, 2026-08-07 17:50Z)

Force-pushed onto `feature/notebook-counters-9857` (the existing PR head branch) at commit `79b5eb4abc`, **3 files only** instead of 4. The `docs/reference/notebook-counters.md` (182 lines) was **removed** from this PR because it was already MERGED ahead via #9871 (canonique 206 lines).

**Avant rebase (CONFLICTING) :**
- `docs/reference/notebook-counters.md` (NEW, 182 lignes, CONFLICT avec #9871 MERGED)
- `docs/reference/notebook-counts-reconciliation.md` (+6)
- `scripts/audit/check_denominators.py` (+110/-15)
- `scripts/audit/tests/test_check_denominators.py` (+44)

**Après rebase (3 fichiers, MERGEABLE) :**
- `docs/reference/notebook-counts-reconciliation.md` (+6) — en-tête de renvoi vers le nouveau doc canonique (préserve le relevé forensic #8050 comme audit trail)
- `scripts/audit/check_denominators.py` (+110/-15) — 4ᵉ source (count_outil) + check divergence catalogue↔outil ; `--strict` rougit sur divergence non documentée
- `scripts/audit/tests/test_check_denominators.py` (+44) — +2 tests (divergence documentée passe / non documentée rougit)

**Diff vs branche originale** :
- `-docs/reference/notebook-counters.md` (182 lignes, déjà canonique via #9871)
- Total : -182, +160/-15 = net +145 lignes (au lieu de +327)

**Justification** : la substance de la PR est **conservée** (les 3 fichiers de divergence check + tests), seule la doc concurrente est retirée (déjà MERGED). Aucun contenu substantiel n'est perdu.

**Validation empirique (post-rebase, SHA a53593625 origin/main + ce commit) :**
- `pytest scripts/audit/tests/test_check_denominators.py -v` → **7 passed in 0.21s**
- `python scripts/audit/check_denominators.py --strict` → exit 0 (catalogue == outil == 863, 0 phantom catalogue, 4 drift paths documentés)

**CI actuel (post force-push) :** MERGEABLE, 0 failure, 14 SUCCESS / 1 NEUTRAL (advisory). Ready for ai-01 merge.

Lane rebase : myia-po-2024:CoursIA-2 (la PR originelle était trackée po-2025, le rebase est po-2024) — c.1331+31.

Refs : issue #9857 (sub-grain résidu après #9871 MERGED).

See #9857.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
