### PR TITLE
feat(ci,#9858): add workflow_dispatch to docs-link-check (last PR-only gate without re-run)

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -10,6 +10,10 @@ on:
       - 'docs/**'
       - '**/README.md'
       - 'scripts/check_docs_links.py'
+  # Manual re-run on `main` after a CI outage (e.g. 2026-08-06 Actions window),
+  # so this PR-only gate is not silently skipped on merges that land without a
+  # clean per-PR run. See #9858. Matches the 6 sibling gates that already carry it.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Grain: MED/ci — lane myia-po-2026:CoursIA — prev: MED/tooling #9868
Quoi: ajoute `workflow_dispatch:` à `docs-link-check.yml` — le seul des 7 gates par-PR qui ne pouvait PAS être relancé sur `main` après une panne CI.
Preuve: `grep -c workflow_dispatch` sur les 7 gates → 6 l'ont (regression-guard, catalog-guard, cell-order-gate, notebook-execution-required, pip-leak-guard, translation-drift), seul docs-link-check manquait ; YAML validé `yaml.safe_load` OK ; diff +4/−0, 0 CRLF.
Périmètre: `.github/workflows/docs-link-check.yml` uniquement (trigger `workflow_dispatch:` purement additif + commentaire `See #9858`). Aucun changement au script `check_docs_links.py`, aucun comportement d'auto-run modifié (manuel seulement). Hors scope : la décision « ajouter `push: [main]` pour auto-rejouer » est un arbitrage coût/robustesse qui appartient au coordinateur (posture CI), pas à ce fix minimal.

---

## Contexte — #9858

La fenêtre panne GitHub Actions du 2026-08-06 a vu **175 PRs mergées** sans que les gates par-PR jouent proprement. #9858 demande d'auditer si une régression est passée. **Verdict po-2025 : AUCUNE_RÉGRESSION** (invariants vérifiés firsthand sur `main` : Twin parity 156/156 DRIFT=0, regression_scan 20 drapeaux TOUS TOOL_MISSING/GPU-gated, 0 régression code source).

Le complément structurel (ce que cette PR adresse) : identifier quels gates par-PR ne peuvent **jamais** être rejoués sur `main`. Audit robuste des 7 gates par-PR (correctif de mon finding initial c.958 qui sous-comptait) :

| Gate | `pull_request` | `workflow_dispatch` | `push` | Re-runnable sur main ? |
|------|:---:|:---:|:---:|:---:|
| regression-guard.yml | ✓ | ✓ | ✗ | ✓ (manuel) |
| catalog-guard.yml | ✓ | ✓ | ✗ | ✓ (manuel) |
| cell-order-gate.yml | ✓ | ✓ | ✗ | ✓ (manuel) |
| notebook-execution-required.yml | ✓ | ✓ | ✓ | ✓ (auto + manuel) |
| pip-leak-guard.yml | ✓ | ✓ | ✗ | ✓ (manuel) |
| translation-drift.yml | ✓ | ✓ | ✗ | ✓ (manuel) |
| **docs-link-check.yml** | ✓ | **✗** | **✗** | **✗ — corrigé par cette PR** |

**6 des 7 gates** peuvent déjà être relancées manuellement sur `main` via `workflow_dispatch` (ai-01 peut faire `gh workflow run <gate>.yml`). Seul `docs-link-check.yml` ne le pouvait pas — cette PR ferme ce dernier aveugle.

## Auto-correctif G.1

Mon finding posté en c.958 (issuecomment-5216789948) affirmait « 5 gates manquent workflow_dispatch » — c'était **faux** : la lecture des blocs `on:` montrait que 6/7 l'avaient déjà. Cette PR corrige le point de départ (1 gate, pas 5) et documente le tableau exact ci-dessus. Leçon : relire le bloc `on:` complet, pas un grep partiel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
