### PR TITLE
docs(genai,#9734): corriger le parcours AI-Engine par observation directe

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/01-AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/01-AI-Engine-WordPress/README.md
@@ -5,7 +5,7 @@
 > **Parcours découverte.** Ce dossier présente **AI-Engine**, l'extension
 > WordPress de Jordy Meow, comme **presqu'équivalent d'Open WebUI** côté
 > *site de contenu*. La question n'est pas « quel produit choisir en
-> абсолю » — les deux ciblent des usages différents — mais « quand l'un
+> absolu » — les deux ciblent des usages différents — mais « quand l'un
 > est plus adapté que l'autre » pour un projet donné.
 
 ---
@@ -22,10 +22,13 @@ installé. Plutôt que de poser Open WebUI *à côté* de WordPress, on peut
 comme point de comparaison pour les fonctionnalités communes (chat,
 RAG, outils MCP, personas).
 
-Le projet **livresagités** (WordPress user) sert de **terrain de démo**
-concret pour illustrer les cas d'usage. Aucune donnée privée de ce site
-n'est reproduite ici : les parcours sont décrits à un niveau
-architectural, jamais avec des contenus réels.
+Le projet **livresagités** — une installation WordPress de maison
+d'édition, avec workflow de manuscrits, comité de lecture et catalogue
+WooCommerce — sert de **terrain d'observation** concret. Aucune donnée
+de ce site n'est reproduite ici : ce dossier ne transmet que des
+structures et des comptages, sans contenu, sans nom, et sans capture
+d'écran (voir la note de méthode du
+[parcours détaillé](livresagites-parcours.md#note-de-méthode--pourquoi-il-ny-a-aucune-capture)).
 
 ---
 
@@ -107,12 +110,21 @@ MCP** d'Open WebUI.
 
 ### 6. [Cas d'usage livresagités](livresagites-parcours.md)
 
-Le projet WordPress **livresagités** (user) sert de **terrain
-concret** : blog éditorial autour du livre, avec usage réel d'AI-Engine
-pour assistance éditoriale (résumé, traduction), RAG sur corpus de
-livres (recommandations), MCP pour automatiser la modération. Aucun
-contenu privé n'est reproduit — uniquement l'architecture du
-parcours et les types d'appels effectués.
+Le projet WordPress **livresagités** sert de **terrain d'observation
+réel** : une maison d'édition, et non un blog — dépôt de manuscrits,
+comité de lecture, catalogue e-commerce. Le parcours détaille
+l'architecture en modules d'AI-Engine, la séparation du RAG en
+**six environnements d'embeddings** distincts (un contrôle d'accès,
+pas une commodité), et surtout le catalogue MCP réellement exposé :
+**88 outils**, dont 64 natifs génériques et **24 outils métier**. Cet
+écart porte la leçon d'architecture la plus transposable du dossier —
+*un serveur MCP utile expose les verbes du métier, pas les tables de
+la base*.
+
+Aucun contenu du site n'est reproduit, et le dossier ne contient
+aucune capture d'écran : la
+[note de méthode](livresagites-parcours.md#note-de-méthode--pourquoi-il-ny-a-aucune-capture)
+explique pourquoi une capture de `wp-admin` n'est pas assainissable.
 
 ---
 
@@ -121,13 +133,18 @@ parcours et les types d'appels effectués.
 Comme pour les autres parcours de la série Open-WebUI :
 
 - **Aucun secret exposé** : pas d'URL d'admin, pas de clé d'API, pas
-  de token MCP, pas de credentials WordPress. Toutes les captures
-  reposent sur un **tenant de démonstration dédié**, des comptes
-  non-administrateur, des données fictives, et le masquage des
-  champs sensibles.
+  de token MCP, pas de credentials WordPress.
+- **Aucune capture d'écran**, ce qui est le moyen le plus sûr de
+  tenir la ligne précédente. Un écran de `wp-admin` expose son
+  contexte — compte connecté, domaines, extensions installées —
+  indépendamment de la page affichée, et une capture retouchée n'est
+  pas vérifiable par le lecteur. La
+  [note de méthode](livresagites-parcours.md#note-de-méthode--pourquoi-il-ny-a-aucune-capture)
+  détaille l'arbitrage et ce qu'illustrer proprement supposerait.
 - **Aucun contenu privé livresagités** : le cas d'usage est décrit à
-  un niveau architectural (types d'appels, schémas de données), pas
-  avec les contenus réels du site.
+  un niveau architectural (structures, comptages, familles d'outils),
+  jamais avec les contenus réels du site — ni texte de manuscrit, ni
+  nom de personne, ni titre d'ouvrage.
 - **Documentation de patterns, pas de credentials** : les exemples
   PHP dans ce dossier utilisent des *constantes de substitution*
   (`YOUR_OPENAI_API_KEY`, `YOUR_VECTOR_STORE_ID`), jamais des

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/01-AI-Engine-WordPress/livresagites-parcours.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/01-AI-Engine-WordPress/livresagites-parcours.md
@@ -2,35 +2,76 @@
 
 [← README AI-Engine-WordPress](README.md) | [← Comparatif OWUI vs AI-Engine](comparatif-owui-vs-ai-engine.md)
 
-> Le projet **livresagités** est un **site WordPress éditorial**
-> personnel (user) autour du livre — critiques, notes de lecture,
-> recommandations. Il sert ici de **terrain de démo réel** pour
-> illustrer AI-Engine en contexte, à un niveau architectural et
-> fonctionnel. Aucun contenu privé (texte de critique, URL
-> nominative, identifiants) n'est reproduit — uniquement les
-> *types d'usages* et les *schémas d'intégration*.
+> Le projet **livresagités** est une installation WordPress de
+> **maison d'édition** : soumission de manuscrits, comité de lecture,
+> catalogue de livres vendus, et une couche GenAI (chatbots + RAG +
+> serveur MCP) posée par-dessus. Il sert ici de **terrain
+> d'observation réel** pour AI-Engine, à un niveau architectural et
+> fonctionnel.
+>
+> **Aucune donnée du site n'est reproduite** : ni contenu de
+> manuscrit, ni nom de personne, ni titre d'ouvrage, ni identifiant,
+> ni capture d'écran. Ce qui est transmis ici, ce sont les *formes
+> d'intégration* et les *chiffres de structure* — voir la
+> [note de méthode](#note-de-méthode--pourquoi-il-ny-a-aucune-capture)
+> qui explique pourquoi il n'y a pas d'illustration.
 
 ---
 
 ## Contexte
 
-**livresagités** = blog WordPress personnel, avec :
+L'erreur d'intuition la plus commune sur AI-Engine est de le ranger
+au rayon « plugin de blog ». L'installation observée ici est
+l'inverse d'un blog personnel : c'est un **système multi-rôles avec
+un workflow métier**.
 
-- Plusieurs **catégories éditoriales** (par genre, par période,
-  par auteur).
-- Des **articles longs** (critiques ~2-5k mots).
-- Du **contenu catégorisé** (tags + Polylang FR/EN).
-- Pas d'équipe — auteur unique + lecteurs.commentaires occasionnels.
+- Plusieurs **rôles distincts** : autrices qui déposent un
+  manuscrit, comité de lecture qui l'évalue, éditrices qui
+  arbitrent, clients qui achètent.
+- Un **pipeline documentaire** : dépôt d'un fichier, extraction du
+  texte, découpage en chunks, indexation vectorielle, pré-lecture
+  assistée par LLM, notification.
+- Un **catalogue e-commerce** (WooCommerce) adossé au même
+  WordPress, donc des produits, des commandes, des stocks.
+- Des **agents conversationnels** différenciés selon la surface du
+  site où ils apparaissent.
 
-L'enjeu GenAI pour ce site = **assistance éditoriale** + **RAG sur
-le corpus** (recommandations) + **modération** (commentaires).
+L'enjeu GenAI n'est donc pas « assister un auteur qui rédige » mais
+**outiller une chaîne de production éditoriale** — ce qui déplace
+complètement le centre de gravité du parcours. C'est pour cette
+raison que le cas est intéressant pédagogiquement : il montre
+AI-Engine là où on ne l'attend pas.
 
-> **Note pédagogique.** Ce site sert d'*exemple pédagogique* dans
-> ce parcours. Toutes les captures et tous les extraits montrés
-> sont produits sur **un tenant de démonstration dédié** (compte
-> non-admin, articles fictifs, masquage des champs sensibles),
-> jamais sur l'instance réelle du site. La règle « aucun contenu
-> privé dans le repo » s'applique strictement.
+**Ordres de grandeur mesurés sur l'installation** (relevés
+directement sur l'instance, voir [Métriques](#métriques-relevées)) :
+AI-Engine Pro 3.4.1, **88 outils MCP exposés**, **6 environnements
+d'embeddings** coexistants, ~1600 vecteurs indexés.
+
+---
+
+## Parcours 0 — L'architecture en modules
+
+Avant les parcours fonctionnels, un point de structure qui n'est
+documenté nulle part clairement et qui conditionne la lecture du
+reste : **AI-Engine n'est pas un bloc**. Son tableau de bord
+présente trois familles de modules activables indépendamment.
+
+| Famille | Modules | Ce qu'elle décide |
+|---------|---------|-------------------|
+| **Client** | Chatbot, Forms, Search | Ce que voit le **visiteur** du site |
+| **Server** | Insights, Knowledge, Orchestration, Finetunes, Moderation, Assistants | Ce que le **serveur** sait faire (RAG, MCP sortant, logs, modération) |
+| **Admin** | Advisor, AI Assistant, Generators (texte / image / vidéo), Playground, Utilities, Transcription | Ce que voit l'**administrateur** dans `wp-admin` |
+
+Deux conséquences pratiques :
+
+1. Un déploiement minimal (chatbot public seul) n'active qu'un
+   module Client — l'empreinte du plugin est modulable, contrairement
+   à ce que suggère la longue liste de fonctionnalités commerciales.
+2. Le module **Orchestration** est la face *cliente* de MCP :
+   c'est lui qui permet à AI-Engine de **consommer** des serveurs MCP
+   externes. Le serveur MCP *exposé* par WordPress est une mécanique
+   distincte (voir Parcours 3). Les deux sens du protocole ne se
+   configurent pas au même endroit — confusion fréquente.
 
 ---
 
@@ -39,212 +80,291 @@ le corpus** (recommandations) + **modération** (commentaires).
 ### Ce que c'est
 
 AI-Engine ajoute un panneau **Copilot** dans l'éditeur Gutenberg de
-WordPress. L'auteur écrit un brouillon ; le Copilot propose :
+WordPress. Le rédacteur écrit un brouillon ; le Copilot propose :
 
-- **Résumé** d'un article long en 1 paragraphe (pour les meta
-  descriptions, Open Graph, etc.).
+- **Résumé** d'un texte long en un paragraphe (meta description,
+  Open Graph).
 - **Enhancement** stylistique (clarifier, reformuler, ton).
-- **Traduction** FR ↔ EN avec préservation du ton éditorial.
-- **Rewriting** d'un paragraphe en plusieurs variantes (sans
-  remplacer l'original).
+- **Traduction** avec préservation du registre.
+- **Rewriting** d'un paragraphe en plusieurs variantes, sans
+  remplacer l'original.
 - **Génération d'image d'en-tête** à partir d'un prompt court.
 - **Alt text automatique** pour les images insérées.
 
 ### Comment ça marche
 
-L'auteur écrit dans Gutenberg comme d'habitude ; le panneau Copilot
-appelle AI-Engine qui route vers le provider sélectionné (par
-exemple Anthropic pour les résumés, OpenAI pour les images). Le
-résultat apparaît dans une zone de prévisualisation ; l'auteur
-*valide* ou *rejette* l'insertion dans le texte. Aucune réécriture
+Le rédacteur écrit dans Gutenberg comme d'habitude ; le panneau
+Copilot appelle AI-Engine qui route vers le provider sélectionné.
+Le résultat apparaît dans une zone de prévisualisation ; le
+rédacteur *valide* ou *rejette* l'insertion. Aucune réécriture
 automatique — le brouillon reste sous contrôle humain.
 
 ### Comparaison OWUI
 
-Open WebUI **n'a pas d'équivalent** : il n'intègre aucun CMS. Pour
-un parcours équivalent côté OWUI, il faudrait exporter l'article
-depuis WordPress, le coller dans OWUI, faire l'opération, réimporter
-le résultat manuellement. AI-Engine est plus efficace sur ce
-*type d'usage*.
+Open WebUI **n'a pas d'équivalent** : il n'intègre aucun CMS. Le
+parcours équivalent supposerait d'exporter le texte, de le coller
+dans OWUI, puis de réimporter le résultat à la main. Sur ce *type
+d'usage précis*, l'intégration au CMS est l'avantage décisif.
 
-### Cas d'usage livresagités (illustratif)
+### Ce que l'installation observée en fait
 
-Pour un article long de ~3k mots, l'auteur utilise le Copilot pour
-générer la meta description (1 phrase), proposer 2 variantes de
-titres courts pour partage social, et générer l'image d'en-tête à
-partir d'un prompt court (« abstract photo of an open book on a
-wooden desk, morning light, soft focus »). Temps gagné : ~30 min
-par article.
+Peu de choses, et c'est un enseignement en soi. Dans une maison
+d'édition, le texte de valeur est le **manuscrit**, qui n'entre pas
+par Gutenberg mais par un formulaire de dépôt, et qui n'a pas
+vocation à être réécrit par un LLM. Le Copilot y sert pour les
+contenus *périphériques* (pages de présentation, descriptions de
+catalogue), pas pour le cœur éditorial.
 
-> **Aucune URL réelle, aucun titre réel d'article n'est cité.**
-> Le tenant de démo utilise des articles fictifs (`Lorem ipsum
-> editorial post #N`) avec des images placeholder.
+> **Leçon transposable.** La fonctionnalité la plus mise en avant
+> par un éditeur de plugin n'est pas nécessairement celle qui porte
+> la valeur dans un déploiement donné. Cartographier les *flux de
+> texte réels* avant de choisir les modules à activer.
 
 ---
 
-## Parcours 2 — RAG sur le corpus éditorial
+## Parcours 2 — RAG sur corpus, et le piège du multi-environnement
 
 ### Ce que c'est
 
-Le site contient **N articles** ; AI-Engine les ingère dans un
-vector store (ici : **Internal WordPress DB** — option gratuite,
-pas de service externe requis), puis permet à un chatbot public de
-répondre à des questions en s'appuyant sur le corpus.
-
-Exemple d'usage : un lecteur demande « *Quel est l'avis du site sur
-les polars scandinaves ?* » ; le chatbot répond avec un résumé
-agrégeant 3-5 critiques pertinentes.
+AI-Engine ingère du contenu dans un vector store, puis permet à un
+chatbot de répondre en s'appuyant sur ce corpus. Cinq backends sont
+supportés (Chroma, Qdrant, Pinecone, OpenAI Vector Store, **base
+WordPress interne**).
 
 ### Comment ça marche
 
-**Ingestion** (one-shot, déclenchée par un bouton admin ou un cron
-quotidien) :
+**Ingestion** (déclenchée par bouton admin, par cron, ou par un hook
+sur la sauvegarde d'un contenu) :
 
-1. Pour chaque article publié, on extrait le contenu principal
-   (hors menus, sidebars, footer).
-2. On chunk (AI-Engine applique un chunking par défaut).
-3. Pour chaque chunk, on génère un embedding (provider
-   sélectionné — ex. OpenAI `text-embedding-3-small`).
-4. On stocke l'embedding + métadonnées (article_id, titre,
-   catégorie, langue) dans le vector store.
+1. Extraction du contenu principal (hors menus, sidebars, footer).
+2. Découpage en chunks.
+3. Génération d'un embedding par chunk.
+4. Stockage embedding + métadonnées dans le vector store.
 
 **Requête** (à chaque message du chatbot) :
 
 1. La question est embedée avec le même modèle.
-2. Top-K chunks les plus proches (K = paramètre du chatbot, par
-   défaut 5).
-3. Mode de recherche sélectionné (Smart = combine embedding +
-   BM25 sur les métadonnées).
-4. Le contexte enrichi est envoyé au LLM avec un prompt système
-   « *Tu réponds en t'appuyant sur les critiques du site
-   livresagités. Si l'information n'est pas dans le contexte,
-   dis-le.* ».
+2. Top-K chunks les plus proches (K paramétrable par chatbot).
+3. Mode de recherche sélectionné (Simple, Context-Aware, Smart).
+4. Le contexte enrichi part au LLM avec une consigne de type
+   « réponds à partir du contexte ; si l'information n'y est pas,
+   dis-le ».
+
+### Le point non documenté : plusieurs environnements coexistent
+
+Sur l'installation observée, les vecteurs ne forment **pas** un
+corpus unique. Ils sont répartis en **six environnements
+d'embeddings** distincts, séparés par une colonne d'identifiant
+d'environnement en base. Chaque chatbot pointe vers l'environnement
+qui le concerne.
+
+C'est la bonne façon de faire, et elle est contre-intuitive : le
+réflexe est d'indexer « tout le site » dans un seul index. Or les
+corpus n'ont ni le même public ni le même régime de confidentialité
+— du contenu catalogue destiné aux visiteurs ne doit pas cohabiter
+dans le même espace de recherche que du contenu réservé à un comité
+interne. **La séparation par environnement est un contrôle d'accès,
+pas une commodité d'organisation.**
+
+Corollaire opérationnel, appris à ses dépens : une réindexation
+lancée sans préciser l'environnement cible écrase un corpus voisin.
+Sur une instance servant du contenu en ligne, la perte est immédiate
+et silencieuse.
 
 ### Comparaison OWUI
 
 Open WebUI a une pile RAG équivalente (**Knowledge** : upload de
-documents, hybrid search, retrieval dans le prompt système). La
-différence est l'**intégration native** au contenu du site : AI-Engine
-*sync automatiquement* ses chunks à chaque mise à jour d'article,
-tandis qu'OWUI demanderait un re-upload manuel après chaque
-modification.
+documents, hybrid search, injection dans le prompt système). La
+différence est l'**intégration native au contenu** : AI-Engine
+resynchronise ses chunks quand un contenu est modifié, via les hooks
+WordPress ; OWUI demanderait un re-upload.
 
-### Cas d'usage livresagités (illustratif)
-
-Le chatbot public « *Recommandations livresagités* » s'appuie sur
-le RAG pour répondre à des questions visiteurs ; les chunks sont
-re-synchés une fois par jour (cron) pour rester à jour du corpus.
-La métrique clé est le taux de « réponse basée sur le corpus »
-vs « réponse générée indépendamment » — évalué sur un golden set
-de questions fictives.
-
-> **Le chatbot de démo utilise un corpus de 5 articles fictifs**
-> (`placeholder editorial corpus`) pour démontrer le pipeline
-> bout-en-bout sans exposer les articles réels.
+En revanche, la notion d'**environnements multiples** au sein d'une
+même instance est plus explicite côté AI-Engine, où elle est un
+champ de configuration de premier niveau.
 
 ---
 
-## Parcours 3 — WordPress comme serveur MCP
+## Parcours 3 — WordPress comme serveur MCP métier
+
+C'est le parcours le plus intéressant du dossier, et celui qu'on
+sous-estime le plus.
 
 ### Ce que c'est
 
-AI-Engine transforme l'installation WordPress en **serveur MCP** :
-elle expose des **outils permission-aware** (post, comment, media,
-theme, plugin, WooCommerce, Polylang, requêtes SQL, SEO) à des
-agents externes comme Claude, Claude Code, ChatGPT ou OpenClaw.
-L'agent peut alors **piloter le site** par conversation, sans
-glue code custom.
+AI-Engine expose l'installation WordPress comme **serveur MCP**, sur
+un endpoint REST authentifié par jeton Bearer. Un agent externe
+(Claude Code, Claude Desktop, ChatGPT, OpenClaw) reçoit le catalogue
+d'outils et pilote le site par conversation, sans glue code.
 
-### Comment ça marche
+### Le catalogue réellement exposé
 
-Côté serveur MCP (dans WordPress) :
+Relevé sur l'installation, l'endpoint retourne **88 outils**, qui se
+répartissent en deux couches très différentes :
 
-1. AI-Engine enregistre des *tools* MCP (ex. `wp_create_post`,
-   `wp_list_comments`, `wp_query_db`) avec un schéma JSON d'entrée.
-2. Chaque tool a une **capability** WP_CAP_ requise (ex.
-   `wp_create_post` requiert `edit_posts`).
-3. Lors d'une connexion d'un agent, OAuth côté serveur vérifie
-   la capability avant d'exposer l'outil.
+| Couche | Nombre | Préfixe | Nature |
+|--------|--------|---------|--------|
+| Natifs WordPress | 37 | `wp_*` | Posts, users, comments, media, taxonomies, options |
+| Natifs WooCommerce | 25 | `wc_*` | Produits, commandes, stocks, clients, avis, rapports de vente |
+| Natifs AI-Engine | 2 | `mwai_*` | Vision, génération d'image |
+| **Métier, développés pour le site** | **24** | `livresagites_*` | **Verbes du domaine éditorial** |
 
-Côté client (par exemple Claude Code en local) :
+Les 64 outils natifs sont du **CRUD générique** : ils décrivent
+WordPress, pas le métier. Un agent qui n'aurait qu'eux devrait
+reconstituer la logique éditoriale à coups de requêtes sur des
+tables et des métadonnées — fragile, verbeux, et dangereux.
 
-1. L'agent reçoit le catalogue d'outils disponibles.
-2. Pour une tâche (ex. « *modère les 5 derniers commentaires
-   signalés* »), il choisit les outils pertinents.
-3. Il les appelle via le protocole MCP, en respectant le schéma
-   JSON.
-4. Le résultat remonte dans la conversation.
+Les 24 outils métier sont d'une autre nature. Ils portent des
+**verbes du domaine**, dont voici des représentants :
+
+```
+<domaine>_get_manuscripts            <domaine>_submit_manuscript
+<domaine>_update_manuscript_status   <domaine>_assign_manuscript
+<domaine>_submit_reading_report      <domaine>_get_pending_decisions
+<domaine>_get_processing_status      <domaine>_query_rag_manuscripts
+```
+
+Chacun encapsule une règle métier : quels statuts sont atteignables
+depuis quel statut, qui a le droit d'assigner, quel corpus une
+recherche a le droit d'interroger. L'agent n'a pas à connaître le
+schéma de la base ; il n'a même pas la possibilité de le contourner.
+
+### La leçon d'architecture
+
+> **Un serveur MCP utile expose les verbes du métier, pas les tables
+> de la base.**
+>
+> Le CRUD générique donne à l'agent un pouvoir maximal et une
+> compréhension minimale. Les outils métier font l'inverse : ils
+> restreignent le geste possible et y attachent le sens. Le
+> deuxième régime est à la fois plus sûr *et* plus performant en
+> pratique, parce que l'agent choisit mieux quand le catalogue parle
+> sa langue.
+
+C'est le point transposable à n'importe quel projet MCP, quel que
+soit le CMS ou le langage : la valeur d'un serveur MCP se mesure à
+la distance entre ses outils et le schéma de persistance.
 
 ### Comparaison OWUI
 
-C'est ici qu'AI-Engine se distingue le plus franchement d'Open WebUI.
-OWUI peut *consommer* des outils MCP (externe), il n'en *expose pas*.
-AI-Engine joue **dans les deux sens** : il consomme des serveurs
-MCP externes (LLM tool use) et expose WordPress comme serveur MCP
-(côté agent). C'est un terrain pédagogique idéal pour comprendre
-le Model Context Protocol *des deux côtés du fil*.
+C'est ici qu'AI-Engine se distingue le plus franchement. Open WebUI
+peut *consommer* des outils MCP ; il n'en *expose* pas. AI-Engine
+joue **dans les deux sens** : il consomme des serveurs MCP externes
+(module Orchestration, Parcours 0) et expose WordPress comme serveur
+MCP. C'est un terrain pédagogique de choix pour comprendre le
+protocole des deux côtés du fil, sur une seule installation.
 
-### Cas d'usage livresagités (illustratif)
+### Sécurité de l'endpoint
 
-Un agent Claude Code en local est autorisé à se connecter au
-serveur MCP livresagités (compte dédié de rôle `editor`, **PAS
-admin**). Pour une opération de modération :
+Deux remarques valables pour tout déploiement :
 
-1. L'agent appelle `wp_list_comments({status: 'pending'})` pour
-   récupérer les commentaires à modérer.
-2. Pour chaque commentaire, l'agent appelle un LLM (configuré
-   dans AI-Engine) pour classifier « *spam / à garder / à
-   supprimer* ».
-3. L'agent appelle `wp_update_comment({id, status})` pour
-   appliquer la décision.
-4. L'audit log WP conserve la trace (qui a modéré, quand).
-
-> **Le serveur MCP de démo expose uniquement les outils de
-> modération** (`wp_list_comments`, `wp_update_comment`), avec un
-> compte `editor` fictif et 5 commentaires fictifs. Aucun outil
-> admin n'est exposé.
+- L'authentification par **jeton Bearer** unique donne à son
+  porteur l'intégralité du catalogue. Il n'y a pas de granularité
+  par outil au niveau du jeton — la granularité vient des
+  *capabilities* WordPress de l'utilisateur auquel le jeton est
+  rattaché. Choisir cet utilisateur avec soin ; ne pas le prendre
+  administrateur par défaut.
+- Un jeton MCP est un **secret d'infrastructure** : il ne va ni dans
+  un dépôt, ni dans une capture d'écran, ni dans un fichier de
+  configuration versionné. Voir la note de méthode ci-dessous.
 
 ---
 
-## Sécurité — ce que ce parcours montre **sans le faire**
+## Note de méthode — pourquoi il n'y a aucune capture
 
-Ce parcours livresagités illustre **architecturalement** les
-capacités d'AI-Engine, mais :
+Ce dossier ne contient **aucune capture d'écran**, et c'est un choix
+documenté, pas un manque.
 
-- **Aucune instance réelle n'est accédée.** Toutes les captures
-  et tous les exemples viennent d'un **tenant de démonstration
-  dédié** monté par l'auteur sur un sous-domaine privé, sans
-  lien avec le site public.
-- **Aucun identifiant réel** n'apparaît nulle part (URL, e-mail,
-  clé d'API, mot de passe).
-- **Aucune URL admin n'est citée** : les chemins d'API MCP sont
-  présentés sous forme générique (`https://YOUR-WP-INSTALL/wp-json/...`).
-- **Les comptes utilisés** ont le **strict minimum de privilèges**
-  nécessaires à la démonstration : `editor` pour la modération,
-  `subscriber` pour le chatbot public.
-- **Les logs sont anonymisés** dans les exemples : pas d'adresse
-  IP, pas d'horodatage précis (uniquement des ordres de grandeur
-  comme « *moins de 50 ms par appel LLM* »).
+La posture du dépôt ([`PRIVACY.md`](../../../../PRIVACY.md) §1)
+exclut déjà « aucune capture d'écran, aucun log, aucune sortie nommant
+une personne ». Elle y est formulée pour les données d'étudiants ; ce
+dossier l'applique à un cas voisin — l'**environnement de travail d'un
+tiers** — et le retour d'expérience ci-dessous explique pourquoi la
+règle y est encore plus difficile à tenir qu'il n'y paraît.
+
+La tentation initiale était d'illustrer les parcours avec des écrans
+de l'administration AI-Engine de l'installation observée. La
+première capture a suffi à trancher : un écran de `wp-admin` affiche
+simultanément le **nom du compte connecté** dans la barre
+d'administration, le **titre du site**, ses **noms de domaine**, et
+la **liste complète des extensions installées** dans le menu latéral.
+Ces éléments ne sont pas dans le contenu de la page : ils sont dans
+son cadre, et le cadre est présent sur *toutes* les pages.
+
+Deux issues seulement, et les deux sont fermées :
+
+- **Retoucher la capture** (flouter, masquer) est proscrit. Une
+  retouche est invérifiable par le lecteur, elle rate régulièrement
+  une occurrence, et elle donne une fausse assurance. La règle
+  d'hygiène applicable ici impose de corriger la *cause* — le
+  contenu affiché — puis de recapturer.
+- **Modifier l'installation** pour neutraliser le cadre (renommer le
+  site, créer un compte au nom neutre) reviendrait à altérer un
+  environnement de travail réel pour les besoins d'une illustration.
+  Hors de question.
+
+La conclusion vaut au-delà de ce dossier :
+
+> **Une capture d'écran n'est pas un extrait de contenu, c'est un
+> extrait de contexte.** On ne l'assainit pas en cachant ce qu'on y
+> a repéré ; on la produit sur une instance dédiée, ou on ne la
+> produit pas.
+
+Illustrer correctement ces parcours suppose donc de monter une
+**instance jetable** — WordPress neuf, nom neutre, compte
+d'administration neutre, corpus synthétique, extensions réduites au
+nécessaire — et de n'y capturer que des écrans construits pour être
+publiés. C'est un travail à part entière, sans lien avec le site
+observé ; il n'est pas fait ici.
+
+En attendant, ce dossier privilégie une contrainte simple : **tout
+ce qu'il affirme est vérifiable par le lecteur sur sa propre
+installation**, puisqu'il ne s'agit que de structures et de
+comptages, pas de contenus.
 
 ---
 
-## Métriques observables (illustratives)
+## Ce que ce parcours ne montre pas
 
-Sur le tenant de démo (5 articles fictifs, ~150 chunks, LLM
-Anthropic Claude Sonnet) :
+- **Aucun contenu du site** : ni texte de manuscrit (sous droits
+  d'auteur), ni nom de personne, ni titre d'ouvrage, ni extrait de
+  corpus indexé.
+- **Aucun identifiant** : ni URL d'administration, ni adresse
+  e-mail, ni clé d'API, ni jeton MCP, ni mot de passe. Les chemins
+  d'API sont donnés sous forme générique
+  (`https://VOTRE-INSTALL/wp-json/...`).
+- **Aucun nom d'outil métier réel** : les huit exemples du
+  Parcours 3 sont donnés avec un préfixe substitué `<domaine>_`.
+  Ce qui compte pédagogiquement est le *verbe*, pas le préfixe.
+- **Aucune capture d'écran**, pour la raison exposée ci-dessus.
 
-| Métrique | Valeur observée (tenant démo) |
-|----------|-------------------------------|
-| Latence bot public (RAG) p50 | ~700 ms |
-| Latence bot public (RAG) p95 | ~2.4 s |
-| Taux « basé sur corpus » vs « LLM seul » (golden set 50 questions) | ~80% chunks trouvés dans le top-K |
-| Coût API moyen / question | ~$0.003 (embedding + 1 appel LLM) |
-| Throughput modération MCP (5 commentaires) | ~12 secondes bout-en-bout |
+---
 
-> **Ces chiffres sont *illustratifs* et propres au tenant de
-> démo.** Les chiffres réels dépendent du modèle utilisé, du
-> volume du corpus, et du provider sélectionné. Aucun benchmark
-> formel n'est publié ici.
+## Métriques relevées
+
+Relevés directement sur l'installation observée. Ce sont des
+**chiffres de structure** (comptages de configuration), pas des
+mesures de performance : aucun benchmark n'a été conduit, et aucune
+latence n'est publiée ici.
+
+| Grandeur | Valeur relevée |
+|----------|----------------|
+| Version AI-Engine | Pro 3.4.1 |
+| Outils MCP exposés au total | 88 |
+| dont natifs WordPress (`wp_*`) | 37 |
+| dont natifs WooCommerce (`wc_*`) | 25 |
+| dont natifs AI-Engine (`mwai_*`) | 2 |
+| dont **outils métier** développés pour le site | **24** |
+| Environnements d'embeddings coexistants | 6 |
+| Vecteurs indexés, tous environnements confondus | ~1600 |
+| Familles de modules AI-Engine | 3 (Client, Server, Admin) |
+
+> **Ce que ces chiffres ne disent pas.** Ni la latence, ni le coût
+> par requête, ni la qualité du retrieval. Ces grandeurs-là dépendent
+> du modèle choisi, du volume du corpus et du provider ; les publier
+> depuis une seule installation, sans protocole de mesure, n'aurait
+> aucune valeur. Elles feront l'objet d'un travail séparé s'il est
+> mené.
 
 ---
 


### PR DESCRIPTION
Grain: MED/docs — lane myia-ai-01:LivresAgités — prev: n/a (première livraison de la lane)

**Quoi.** Le dossier `01-AI-Engine-WordPress` décrivait livresagités comme un « site WordPress éditorial **personnel** », un « blog » à « **auteur unique** », et affirmait que ses illustrations provenaient d'un « **tenant de démonstration dédié** ». Ces trois énoncés sont faux. Cette PR réécrit le parcours à partir d'un relevé direct sur l'installation, et remplace le tableau de métriques inventées par des comptages vérifiables.

Refs #9734 (phase 2).

---

## Preuve — relevés directs sur l'installation

| Grandeur | Valeur relevée | Source du relevé |
|---|---|---|
| Version AI-Engine | Pro 3.4.1 | `wp plugin get ai-engine-pro --field=version` |
| Outils MCP exposés | **88** | `GET /wp-json/mcp/v1/tools` (Bearer) |
| dont `wp_*` / `wc_*` / `mwai_*` | 37 / 25 / 2 | idem, décompte par préfixe |
| dont **outils métier** | **24** | idem |
| Environnements d'embeddings | 6 | `GROUP BY envId` sur la table de vecteurs |
| Vecteurs indexés | ~1600 | idem |
| Familles de modules | 3 (Client / Server / Admin) | tableau de bord AI-Engine |

## Ce qui change sur le fond

- **Cadrage.** Maison d'édition multi-rôles — dépôt de manuscrits, comité de lecture, catalogue WooCommerce — et non blog personnel. Le centre de gravité du parcours se déplace de « assister un auteur qui rédige » vers « outiller une chaîne de production ».
- **Nouveau Parcours 0** : l'architecture en trois familles de modules, et la distinction entre le module *Orchestration* (AI-Engine **consomme** du MCP) et le serveur MCP **exposé** par WordPress. Les deux sens du protocole ne se configurent pas au même endroit ; la confusion est fréquente.
- **Parcours 2** : les vecteurs ne forment pas un corpus unique mais six environnements séparés. Le point n'est pas cosmétique — **c'est un contrôle d'accès**, et une réindexation sans environnement cible écrase silencieusement un corpus voisin.
- **Parcours 3 réécrit.** L'ancienne version ne décrivait que des outils génériques (`wp_create_post`, `wp_list_comments`) autour d'un cas de modération inventé. Le fait intéressant était ailleurs : l'écart entre **64 outils natifs CRUD** et **24 outils métier**. C'est la leçon la plus transposable du dossier, indépendante de WordPress :

  > Un serveur MCP utile expose les **verbes du métier**, pas les tables de la base. Le CRUD générique donne à l'agent un pouvoir maximal et une compréhension minimale ; les outils métier font l'inverse.

- **Métriques.** Le tableau de latences, coûts et taux de retrieval était fabriqué. Remplacé par des comptages de structure, avec une mention explicite de ce qui **n'est pas** mesuré (aucun benchmark n'a été conduit).
- **README** : typo `en абсолю` → `en absolu` (caractères cyrilliques), plus l'alignement du cadrage et de la section sécurité.

## Pourquoi il n'y a toujours aucune capture

C'était la demande initiale, et je l'ai instruite avant de renoncer — le compte rendu est dans le fichier, section *Note de méthode*.

La première capture d'administration a suffi à trancher : un écran de `wp-admin` affiche le **compte connecté**, le **titre du site**, ses **noms de domaine** et la **liste des extensions installées** — non pas dans le contenu de la page, mais dans son **cadre**, donc sur *toutes* les pages. Les deux issues sont fermées :

- **retoucher** est proscrit par l'hygiène du dépôt (une retouche est invérifiable par le lecteur et rate régulièrement une occurrence) ;
- **modifier l'installation** pour neutraliser le cadre reviendrait à altérer l'environnement de travail d'un tiers pour les besoins d'une illustration.

D'où la formulation retenue, qui étend [`PRIVACY.md`](../blob/main/PRIVACY.md) §1 au cas de l'environnement d'un tiers :

> Une capture d'écran n'est pas un extrait de contenu, c'est un **extrait de contexte**. On ne l'assainit pas en cachant ce qu'on y a repéré ; on la produit sur une instance dédiée, ou on ne la produit pas.

Illustrer proprement suppose une **instance jetable** (WordPress neuf, nom neutre, corpus synthétique). C'est un grain à part entière, sans lien avec le site observé ; je peux le prendre s'il est jugé utile.

## Périmètre

- 2 fichiers markdown, +329 / −192.
- `comparatif-owui-vs-ai-engine.md` **n'est pas touché** (hors périmètre du claim).
- Aucun fichier copié depuis le projet source : tout est réécrit depuis la leçon.

## Contrôles passés

- Fuites : aucun secret, jeton, mot de passe, e-mail, IP, nom d'hôte réel, nom de personne, titre d'ouvrage ni extrait de prose dans les lignes ajoutées (scan motifs + entropie sur le diff). Les seuls motifs détectés sont les substituts délibérés `<domaine>_*` et `https://VOTRE-INSTALL`.
- Aucun nom d'outil métier réel : les huit exemples du Parcours 3 portent un préfixe substitué. Ce qui compte pédagogiquement est le verbe, pas le préfixe.
- Règle E (emojis) : 0 occurrence dans les deux fichiers modifiés.
- Liens relatifs et ancres vérifiés.

## Deux signalements, hors périmètre

1. `comparatif-owui-vs-ai-engine.md` contient **57 emojis** (`✅` `❌` `⚠️`) servant de marqueurs de tableau. Je ne l'ai pas touché — il est hors de mon claim et a été jugé bon. À arbitrer au regard de la règle E.
2. Le hook `pre-commit` **ne s'exécute pas depuis un worktree** : `core.hooksPath` pointe vers l'arbre principal et le `pre-commit` y est absent, `gitleaks` n'est pas dans le `PATH`. Le scan de secrets de cette PR a donc été fait à la main. Toute lane travaillant en worktree est dans le même cas — ce qui mérite peut-être un garde-fou.

---

Co-authored-by: Claude-Code <noreply@anthropic.com>
