### PR TITLE
feat(genai,#9734): banc d'evaluation de modele reproductible pour le dossier AI-Engine

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/01-AI-Engine-WordPress/.env.example
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/01-AI-Engine-WordPress/.env.example
@@ -1,0 +1,56 @@
+# ============================================================================
+# Banc d'evaluation de modele - eval-choisir-son-modele.ipynb
+# ============================================================================
+#
+# INSTRUCTIONS :
+# 1. Copier ce fichier vers .env : cp .env.example .env
+# 2. Renseigner les valeurs ci-dessous
+# 3. Le fichier .env est automatiquement ignore par Git (securite)
+#
+# Le notebook lit ce .env s'il est present dans le repertoire courant du
+# kernel. A defaut, il lit les variables d'environnement du processus.
+#
+# ============================================================================
+# SECTION 1 : Endpoint compatible OpenAI
+# ============================================================================
+# N'IMPORTE QUEL endpoint parlant le protocole OpenAI convient : vLLM,
+# Ollama, LM Studio, llama.cpp, une passerelle interne, ou l'API d'un
+# fournisseur cloud. Le banc n'appelle que /v1/models et
+# /v1/chat/completions.
+#
+# Le chemin doit se terminer par /v1.
+#
+# Exemples :
+#   EVAL_BASE_URL=http://localhost:8000/v1              (vLLM local)
+#   EVAL_BASE_URL=http://localhost:11434/v1             (Ollama)
+#   EVAL_BASE_URL=https://openrouter.ai/api/v1          (OpenRouter)
+#   EVAL_BASE_URL=https://api.openai.com/v1             (OpenAI)
+EVAL_BASE_URL=http://localhost:8000/v1
+
+# Cle d'API. Les serveurs locaux acceptent souvent n'importe quelle valeur
+# non vide (mettre "sk-local" par exemple) ; les fournisseurs cloud
+# exigent une vraie cle.
+EVAL_API_KEY=your_api_key_here
+
+# ============================================================================
+# SECTION 2 : Modele evalue
+# ============================================================================
+# Identifiant EXACT du modele, tel que /v1/models le renvoie.
+#
+# Laisser VIDE pour que le notebook prenne automatiquement le premier
+# modele annonce par l'endpoint. Pratique sur un serveur local qui n'en
+# sert qu'un seul ; a renseigner des qu'il y en a plusieurs.
+#
+# Exemples : qwen3-30b-a3b, llama3.1:8b, openai/gpt-5.1
+EVAL_MODEL=
+
+# ============================================================================
+# NOTE SUR LE BUDGET DE TOKENS
+# ============================================================================
+# Le notebook fixe max_tokens=3000, ce qui est genereux pour des reponses
+# de deux phrases. C'est delibere : un modele "a raisonnement" emet une
+# trace de reflexion facturee sur le MEME budget que la reponse. Un budget
+# trop court tronque la reponse avant qu'elle existe, et le banc rend un
+# verdict d'echec qui ne mesure que sa propre configuration.
+#
+# Sur un modele sans raisonnement, 500 suffisent et le banc va plus vite.

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/01-AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/01-AI-Engine-WordPress/README.md
@@ -61,6 +61,15 @@ synthétise les différences fonctionnelles en tableau ; un fichier
 [`livresagites-parcours.md`](livresagites-parcours.md) détaille le cas
 d'usage livresagités bout-en-bout (sans contenu privé).
 
+Un notebook exécutable [`eval-choisir-son-modele.ipynb`](eval-choisir-son-modele.ipynb)
+complète le parcours par la question qu'il laisse ouverte : **quel modèle
+brancher derrière un chatbot public ?** Il teste cinq propriétés
+discriminantes contre n'importe quel endpoint compatible OpenAI — ancrage,
+refus hors-contexte, respect du format, stabilité de langue, discipline
+d'appel d'outil — et remplace « je l'ai essayé, il répond bien » par un
+tableau reproductible. Configuration : copier [`.env.example`](.env.example)
+vers `.env`.
+
 ---
 
 ## Sections
@@ -167,6 +176,8 @@ attendues.
   — tableau structuré
 - [`livresagites-parcours.md`](livresagites-parcours.md) — cas
   d'usage concret
+- [`eval-choisir-son-modele.ipynb`](eval-choisir-son-modele.ipynb) —
+  banc d'évaluation reproductible, cinq propriétés discriminantes
 - Epic [#4433](https://github.com/jsboige/CoursIA/issues/4433) —
   refonte pédagogique GenAI (ce parcours en est une extension)
 - Issue [#9734](https://github.com/jsboige/CoursIA/issues/9734) —

--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/01-AI-Engine-WordPress/eval-choisir-son-modele.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/01-AI-Engine-WordPress/eval-choisir-son-modele.ipynb
@@ -1,0 +1,1019 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6364ca4a",
+   "metadata": {},
+   "source": [
+    "# Choisir le modèle derrière son chatbot — une mini-évaluation reproductible\n",
+    "\n",
+    "[← README AI-Engine-WordPress](README.md) | [Parcours livresagités](livresagites-parcours.md) | [Comparatif OWUI vs AI-Engine](comparatif-owui-vs-ai-engine.md)\n",
+    "\n",
+    "AI-Engine, comme Open WebUI, laisse **choisir le modèle par chatbot**. C'est la\n",
+    "décision la plus structurante d'un déploiement, et c'est presque toujours celle\n",
+    "qu'on prend au feeling : on ouvre le playground, on pose trois questions, la\n",
+    "réponse est jolie, on garde le modèle.\n",
+    "\n",
+    "Trois questions ne sont pas une mesure. Ce notebook remplace l'impression par un\n",
+    "**protocole minimal** : un jeu de scénarios dont chacun porte une **assertion\n",
+    "vérifiable par code**, exécuté en **plusieurs répétitions** pour faire apparaître\n",
+    "la variance, puis un tableau de verdict.\n",
+    "\n",
+    "L'objectif n'est pas de désigner un vainqueur universel — il n'y en a pas. C'est\n",
+    "de rendre le choix **argumentable et rejouable** : quand le modèle change, quand\n",
+    "le fournisseur modifie ses prix, quand une régression apparaît, on relance le\n",
+    "même banc au lieu de rediscuter d'intuitions.\n",
+    "\n",
+    "> **Ce que ce notebook n'est pas.** Ni un benchmark académique, ni une mesure de\n",
+    "> performance (latence, coût, débit). C'est un **banc de conformité\n",
+    "> fonctionnelle** : le modèle fait-il ce qu'un chatbot de site exige de lui ?\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f792452",
+   "metadata": {},
+   "source": [
+    "## Les quatre propriétés qu'on mesure, et pourquoi celles-là\n",
+    "\n",
+    "Un chatbot de site de contenu échoue rarement parce qu'il écrit mal. Il échoue\n",
+    "sur quelques points précis, tous invisibles en démonstration et tous vérifiables\n",
+    "par code.\n",
+    "\n",
+    "| Propriété | Question posée | Pourquoi c'est critique |\n",
+    "|---|---|---|\n",
+    "| **Ancrage / refus** | Face à une question dont la réponse n'est **pas** dans le contexte fourni, le modèle refuse-t-il ? | C'est **la** propriété du RAG. Un modèle qui comble les trous produit des affirmations fausses au nom du site. Une hallucination polie est pire qu'un « je ne sais pas ». |\n",
+    "| **Respect du format** | Rend-il un JSON strict aux clés demandées ? | Dès que la sortie alimente un traitement (formulaire, champ, appel suivant), la prose libre casse la chaîne. |\n",
+    "| **Stabilité de langue** | Répond-il en français à une question en français ? | Les petits modèles dérivent vers l'anglais sous consigne système anglophone. Sur un site francophone, c'est rédhibitoire. |\n",
+    "| **Discipline d'appel d'outil** | Face à un outil disponible, émet-il un **appel** structuré plutôt que d'en parler en prose ? | C'est le prérequis de MCP. Un modèle qui répond « je vais appeler `get_horaires` » au lieu de l'appeler ne pilotera jamais un serveur d'outils. |\n",
+    "\n",
+    "Chaque scénario est rejoué **plusieurs fois**. Un modèle qui passe une fois sur\n",
+    "trois n'a pas la propriété : il a eu de la chance, et la différence ne se voit\n",
+    "qu'en répétant.\n",
+    "\n",
+    "Le corpus utilisé est **entièrement fictif** (une médiathèque inventée). Aucun\n",
+    "contenu réel, aucun site tiers, aucune donnée personnelle.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f384b65",
+   "metadata": {},
+   "source": [
+    "## Configuration\n",
+    "\n",
+    "Le banc parle à n'importe quel endpoint **compatible OpenAI** : vLLM, Ollama,\n",
+    "LM Studio, llama.cpp, LocalAI, ou l'API OpenAI elle-même. Rien n'est codé en\n",
+    "dur — ni adresse, ni clé. Copiez [`.env.example`](.env.example) en `.env` et\n",
+    "renseignez vos valeurs.\n",
+    "\n",
+    "```bash\n",
+    "EVAL_BASE_URL=http://VOTRE-ENDPOINT:PORT/v1\n",
+    "EVAL_API_KEY=votre-cle\n",
+    "EVAL_MODEL=nom-du-modele        # optionnel : sinon, le premier modèle servi\n",
+    "```\n",
+    "\n",
+    "La cellule suivante n'affiche **jamais** la clé ni l'adresse : seulement de quoi\n",
+    "vérifier qu'elles sont chargées. Une sortie de notebook est commitée dans un\n",
+    "dépôt public ; elle ne doit révéler ni secret ni topologie réseau."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0b95b463",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T13:50:03.746264Z",
+     "iopub.status.busy": "2026-08-07T13:50:03.746264Z",
+     "iopub.status.idle": "2026-08-07T13:50:03.762774Z",
+     "shell.execute_reply": "2026-08-07T13:50:03.761708Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BASE_URL : http://<adresse-IP-privee><:port>/v1\n",
+      "API_KEY  : chargee (32 caracteres)\n",
+      "MODEL    : <sera deduit de /v1/models>\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import re\n",
+    "import json\n",
+    "import time\n",
+    "import statistics\n",
+    "import unicodedata\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Chargement optionnel d'un .env local (aucune dependance requise).\n",
+    "env_path = Path(\".env\")\n",
+    "if env_path.is_file():\n",
+    "    for line in env_path.read_text(encoding=\"utf-8\").splitlines():\n",
+    "        line = line.strip()\n",
+    "        if line and not line.startswith(\"#\") and \"=\" in line:\n",
+    "            k, v = line.split(\"=\", 1)\n",
+    "            os.environ.setdefault(k.strip(), v.strip().strip('\"').strip(\"'\"))\n",
+    "\n",
+    "BASE_URL = os.environ.get(\"EVAL_BASE_URL\", \"\")\n",
+    "API_KEY = os.environ.get(\"EVAL_API_KEY\", \"\")\n",
+    "MODEL = os.environ.get(\"EVAL_MODEL\", \"\")\n",
+    "\n",
+    "\n",
+    "def redact_url(url: str) -> str:\n",
+    "    \"\"\"Confirme la forme d'une URL sans reveler l'hote ni le port.\"\"\"\n",
+    "    m = re.match(r\"^(https?)://([^/:]+)(:\\d+)?(/.*)?$\", url or \"\")\n",
+    "    if not m:\n",
+    "        return \"<non defini>\"\n",
+    "    scheme, host, port, path = m.groups()\n",
+    "    kind = \"adresse-IP-privee\" if re.match(r\"^\\d+\\.\\d+\\.\\d+\\.\\d+$\", host) else \"nom-d-hote\"\n",
+    "    return f\"{scheme}://<{kind}>{'<:port>' if port else ''}{path or ''}\"\n",
+    "\n",
+    "\n",
+    "print(\"BASE_URL :\", redact_url(BASE_URL))\n",
+    "print(\"API_KEY  :\", f\"chargee ({len(API_KEY)} caracteres)\" if API_KEY else \"ABSENTE\")\n",
+    "print(\"MODEL    :\", MODEL or \"<sera deduit de /v1/models>\")\n",
+    "assert BASE_URL and API_KEY, \"Renseignez EVAL_BASE_URL et EVAL_API_KEY (voir .env.example).\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f795d8b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T13:50:03.765411Z",
+     "iopub.status.busy": "2026-08-07T13:50:03.764893Z",
+     "iopub.status.idle": "2026-08-07T13:50:08.883133Z",
+     "shell.execute_reply": "2026-08-07T13:50:08.882606Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "modele        : qwen3.6-35b-a3b\n",
+      "contenu       : '2+2 font 4.'\n",
+      "finish_reason : stop\n",
+      "tokens generes: 307\n",
+      "raisonnement  : OUI (956 caracteres caches)\n",
+      "aller-retour  : 3.62 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "from openai import OpenAI\n",
+    "\n",
+    "client = OpenAI(base_url=BASE_URL, api_key=API_KEY, timeout=180.0)\n",
+    "\n",
+    "if not MODEL:\n",
+    "    MODEL = client.models.list().data[0].id\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
+    "probe = client.chat.completions.create(\n",
+    "    model=MODEL,\n",
+    "    messages=[{\"role\": \"user\", \"content\": \"Combien font 2+2 ? Reponds en une phrase.\"}],\n",
+    "    max_tokens=512,\n",
+    "    temperature=0.0,\n",
+    ")\n",
+    "elapsed = time.perf_counter() - t0\n",
+    "msg = probe.choices[0].message\n",
+    "\n",
+    "# Un modele \"a raisonnement\" emet des tokens de reflexion AVANT sa reponse.\n",
+    "# Ils sont factures sur le meme budget max_tokens, et exposes a part.\n",
+    "raisonnement = getattr(msg, \"reasoning\", None) or getattr(msg, \"reasoning_content\", None)\n",
+    "RAISONNEUR = bool(raisonnement)\n",
+    "\n",
+    "print(f\"modele        : {MODEL}\")\n",
+    "print(f\"contenu       : {(msg.content or '').strip()[:60]!r}\")\n",
+    "print(f\"finish_reason : {probe.choices[0].finish_reason}\")\n",
+    "print(f\"tokens generes: {probe.usage.completion_tokens}\")\n",
+    "print(f\"raisonnement  : {'OUI (' + str(len(raisonnement)) + ' caracteres caches)' if RAISONNEUR else 'non'}\")\n",
+    "print(f\"aller-retour  : {elapsed:.2f} s\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0384815",
+   "metadata": {},
+   "source": [
+    "## Le corpus fictif et les scénarios\n",
+    "\n",
+    "Le contexte ci-dessous joue le rôle du passage que le RAG aurait retrouvé. Il est\n",
+    "volontairement **court et lacunaire** : c'est précisément ce qu'il ne dit pas qui\n",
+    "permet de tester le refus.\n",
+    "\n",
+    "Notez le scénario `ancrage_absent` : le tarif d'abonnement n'apparaît **nulle\n",
+    "part** dans le contexte. Un modèle honnête le signale ; un modèle complaisant\n",
+    "invente un montant plausible. C'est le test le plus révélateur du lot, et le seul\n",
+    "qu'une démonstration ne fait jamais — en démonstration, on pose des questions\n",
+    "dont on connaît la réponse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ed741bdf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T13:50:08.886817Z",
+     "iopub.status.busy": "2026-08-07T13:50:08.886299Z",
+     "iopub.status.idle": "2026-08-07T13:50:08.897524Z",
+     "shell.execute_reply": "2026-08-07T13:50:08.896456Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "contexte : 366 caracteres | 62 mots\n",
+      "outils   : ['get_horaires']\n"
+     ]
+    }
+   ],
+   "source": [
+    "CONTEXTE = \"\"\"Mediatheque de Valmont -- informations pratiques.\n",
+    "La mediatheque est ouverte du mardi au samedi, de 10h a 18h30.\n",
+    "Elle est fermee les jours feries et la premiere semaine d'aout.\n",
+    "Le fonds compte 42 000 ouvrages, dont 3 500 bandes dessinees.\n",
+    "L'inscription est gratuite pour les habitants de la commune.\n",
+    "Le pret est limite a 8 documents pour une duree de trois semaines.\"\"\"\n",
+    "\n",
+    "MOTS_FR = {\"le\", \"la\", \"les\", \"des\", \"est\", \"sont\", \"pas\", \"dans\", \"pour\", \"une\",\n",
+    "           \"vous\", \"nous\", \"ce\", \"cette\", \"aux\", \"avec\", \"sur\", \"il\", \"elle\", \"que\"}\n",
+    "MOTS_EN = {\"the\", \"is\", \"are\", \"not\", \"in\", \"for\", \"you\", \"we\", \"this\", \"with\",\n",
+    "           \"and\", \"of\", \"to\", \"it\", \"that\", \"there\", \"here\", \"please\"}\n",
+    "\n",
+    "\n",
+    "def sans_accents(txt: str) -> str:\n",
+    "    \"\"\"Compare a l'identique 'mentionne' et 'mentionne' accentue.\"\"\"\n",
+    "    decompose = unicodedata.normalize(\"NFD\", txt.lower())\n",
+    "    return \"\".join(c for c in decompose if unicodedata.category(c) != \"Mn\")\n",
+    "\n",
+    "\n",
+    "# Une negation et un marqueur d'absence, dans un sens ou dans l'autre, a moins de\n",
+    "# 60 caracteres l'un de l'autre. La proximite remplace la liste de tournures\n",
+    "# figees : \"il ne mentionne aucun tarif\" et \"il n'est donc pas mentionne\" sont\n",
+    "# deux refus corrects que toute liste finit par manquer.\n",
+    "NEGATION = r\"(?:\\bpas\\b|\\baucun\\w*\\b|\\bnulle part\\b|\\brien\\b)\"\n",
+    "ABSENCE = (r\"(?:mentionn\\w*|indiqu\\w*|precis\\w*|figur\\w*|information\\w*|\"\n",
+    "           r\"apparai\\w*|contient|disponible|donnee\\w*|element\\w*)\")\n",
+    "MONTANT = r\"\\d+(?:[.,]\\d+)?\\s*(?:eur|euro|\\u20ac|\\$)\"\n",
+    "\n",
+    "\n",
+    "def dit_ne_sait_pas(txt: str) -> bool:\n",
+    "    \"\"\"Detecte un refus explicite plutot qu'une reponse inventee.\"\"\"\n",
+    "    t = sans_accents(txt)\n",
+    "    return bool(re.search(NEGATION + r\".{0,60}?\" + ABSENCE, t)\n",
+    "                or re.search(ABSENCE + r\".{0,60}?\" + NEGATION, t))\n",
+    "\n",
+    "\n",
+    "def est_francais(txt: str) -> bool:\n",
+    "    mots = re.findall(r\"[^\\W\\d_]+\", txt.lower(), re.UNICODE)\n",
+    "    if len(mots) < 5:\n",
+    "        return False\n",
+    "    fr = sum(1 for m in mots if m in MOTS_FR)\n",
+    "    en = sum(1 for m in mots if m in MOTS_EN)\n",
+    "    return fr > en\n",
+    "\n",
+    "\n",
+    "OUTILS = [{\n",
+    "    \"type\": \"function\",\n",
+    "    \"function\": {\n",
+    "        \"name\": \"get_horaires\",\n",
+    "        \"description\": \"Retourne les horaires d'ouverture de la mediatheque pour un jour donne.\",\n",
+    "        \"parameters\": {\n",
+    "            \"type\": \"object\",\n",
+    "            \"properties\": {\"jour\": {\"type\": \"string\",\n",
+    "                                    \"description\": \"Jour de la semaine en minuscules, ex: mardi\"}},\n",
+    "            \"required\": [\"jour\"],\n",
+    "        },\n",
+    "    },\n",
+    "}]\n",
+    "\n",
+    "print(\"contexte :\", len(CONTEXTE), \"caracteres |\", len(CONTEXTE.split()), \"mots\")\n",
+    "print(\"outils   :\", [o[\"function\"][\"name\"] for o in OUTILS])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fe91780d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T13:50:08.900724Z",
+     "iopub.status.busy": "2026-08-07T13:50:08.900200Z",
+     "iopub.status.idle": "2026-08-07T13:50:08.911257Z",
+     "shell.execute_reply": "2026-08-07T13:50:08.910208Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5 scenarios definis :\n",
+      "  - ancrage_present  [Ancrage] -> cite 42 000 (l'information EST dans le contexte)\n",
+      "  - ancrage_absent   [Refus hors-contexte] -> signale l'absence, sans inventer de montant\n",
+      "  - format_json      [Respect du format] -> JSON parsable, aux deux cles exactes\n",
+      "  - langue_fr        [Stabilite de langue] -> repond en francais malgre une consigne systeme anglophone\n",
+      "  - appel_outil      [Discipline d'appel d'outil] -> emet un tool_call get_horaires(jour) valide, pas de la prose\n"
+     ]
+    }
+   ],
+   "source": [
+    "def v_ancrage_present(rep, _tc):\n",
+    "    return \"42000\" in rep.replace(\" \", \"\").replace(\"\\u202f\", \"\").replace(\"\\u00a0\", \"\")\n",
+    "\n",
+    "\n",
+    "def v_ancrage_absent(rep, _tc):\n",
+    "    # Deux conditions : signaler l'absence ET ne pas avancer de montant.\n",
+    "    return dit_ne_sait_pas(rep) and not re.search(MONTANT, sans_accents(rep))\n",
+    "\n",
+    "\n",
+    "def v_format_json(rep, _tc):\n",
+    "    m = re.search(r\"\\{.*\\}\", rep, re.S)\n",
+    "    if not m:\n",
+    "        return False\n",
+    "    try:\n",
+    "        d = json.loads(m.group(0))\n",
+    "    except json.JSONDecodeError:\n",
+    "        return False\n",
+    "    return isinstance(d, dict) and set(d.keys()) == {\"jours_ouverture\", \"nombre_ouvrages\"}\n",
+    "\n",
+    "\n",
+    "def v_langue(rep, _tc):\n",
+    "    return est_francais(rep)\n",
+    "\n",
+    "\n",
+    "def v_outil(_rep, tool_calls):\n",
+    "    if not tool_calls:\n",
+    "        return False\n",
+    "    tc = tool_calls[0]\n",
+    "    if tc.function.name != \"get_horaires\":\n",
+    "        return False\n",
+    "    try:\n",
+    "        args = json.loads(tc.function.arguments)\n",
+    "    except (json.JSONDecodeError, TypeError):\n",
+    "        return False\n",
+    "    return \"jour\" in args\n",
+    "\n",
+    "\n",
+    "SCENARIOS = [\n",
+    "    dict(cle=\"ancrage_present\", propriete=\"Ancrage\",\n",
+    "         systeme=\"Tu reponds uniquement a partir du CONTEXTE fourni.\",\n",
+    "         user=f\"CONTEXTE:\\n{CONTEXTE}\\n\\nQUESTION: Combien d'ouvrages compte le fonds ?\",\n",
+    "         verif=v_ancrage_present, outils=None,\n",
+    "         attendu=\"cite 42 000 (l'information EST dans le contexte)\"),\n",
+    "    dict(cle=\"ancrage_absent\", propriete=\"Refus hors-contexte\",\n",
+    "         systeme=(\"Tu reponds uniquement a partir du CONTEXTE fourni. \"\n",
+    "                  \"Si l'information n'y figure pas, dis-le explicitement et n'invente rien.\"),\n",
+    "         user=f\"CONTEXTE:\\n{CONTEXTE}\\n\\nQUESTION: Quel est le tarif annuel de l'abonnement ?\",\n",
+    "         verif=v_ancrage_absent, outils=None,\n",
+    "         attendu=\"signale l'absence, sans inventer de montant\"),\n",
+    "    dict(cle=\"format_json\", propriete=\"Respect du format\",\n",
+    "         systeme=\"Tu reponds par un objet JSON valide et rien d'autre. Aucun texte hors du JSON.\",\n",
+    "         user=(f\"CONTEXTE:\\n{CONTEXTE}\\n\\nRends un JSON avec exactement deux cles : \"\n",
+    "               '\"jours_ouverture\" (chaine) et \"nombre_ouvrages\" (entier).'),\n",
+    "         verif=v_format_json, outils=None,\n",
+    "         attendu=\"JSON parsable, aux deux cles exactes\"),\n",
+    "    dict(cle=\"langue_fr\", propriete=\"Stabilite de langue\",\n",
+    "         systeme=\"You are a helpful assistant. Always answer in the language of the user's question.\",\n",
+    "         user=\"En deux phrases, quels sont les jours d'ouverture de la mediatheque de Valmont ?\",\n",
+    "         verif=v_langue, outils=None,\n",
+    "         attendu=\"repond en francais malgre une consigne systeme anglophone\"),\n",
+    "    dict(cle=\"appel_outil\", propriete=\"Discipline d'appel d'outil\",\n",
+    "         systeme=\"Tu disposes d'outils. Utilise-les quand la question l'exige.\",\n",
+    "         user=\"Quels sont les horaires du mardi ?\",\n",
+    "         verif=v_outil, outils=OUTILS,\n",
+    "         attendu=\"emet un tool_call get_horaires(jour) valide, pas de la prose\"),\n",
+    "]\n",
+    "\n",
+    "print(f\"{len(SCENARIOS)} scenarios definis :\")\n",
+    "for s in SCENARIOS:\n",
+    "    print(f\"  - {s['cle']:<16} [{s['propriete']}] -> {s['attendu']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e74ebe08",
+   "metadata": {},
+   "source": [
+    "## Deux pièges rencontrés en écrivant ce notebook\n",
+    "\n",
+    "Ce banc a rendu **deux verdicts faux avant d'en rendre un vrai**. Les deux\n",
+    "accusaient le modèle ; les deux venaient du harnais. Ils sont racontés ici parce\n",
+    "qu'ils sont plus instructifs que le tableau final : personne ne se méfie d'un\n",
+    "résultat qui va dans le sens attendu.\n",
+    "\n",
+    "### Piège 1 — le budget de tokens partagé avec le raisonnement\n",
+    "\n",
+    "La première version donnait un verdict accablant : trois propriétés\n",
+    "sur cinq en `ECHEC`, avec des réponses **vides**. Le modèle paraissait incapable\n",
+    "de répondre.\n",
+    "\n",
+    "Il n'y avait aucun problème de modèle. Le modèle évalué **raisonne avant de\n",
+    "répondre** : il émet d'abord une longue trace de réflexion, exposée séparément\n",
+    "du contenu, mais **facturée sur le même budget `max_tokens`**. Avec un budget de\n",
+    "400 tokens, la réflexion consommait tout, la réponse était tronquée avant\n",
+    "d'exister, et `content` revenait vide. Mes assertions voyaient une chaîne vide et\n",
+    "concluaient sagement à l'échec.\n",
+    "\n",
+    "Un banc mal calibré ne renvoie pas « je ne sais pas » : il renvoie un **verdict\n",
+    "faux, précis et crédible**. C'est le principal risque de ce genre d'outil, et il\n",
+    "est plus dangereux que l'absence de mesure — un tableau chiffré inspire une\n",
+    "confiance qu'une intuition n'obtiendrait pas.\n",
+    "\n",
+    "Trois corrections en découlent, appliquées ci-dessous :\n",
+    "\n",
+    "1. **Budget de tokens généreux** (`3000`), pour que la réflexion ne mange pas la\n",
+    "   réponse.\n",
+    "2. **Distinguer l'échec de la mesure invalide.** Une réponse coupée par la limite\n",
+    "   (`finish_reason == \"length\"`) n'est pas une propriété manquée : c'est une\n",
+    "   mesure inutilisable. Elle est comptée `INVALIDE` et **exclue du verdict**,\n",
+    "   au lieu d'être maquillée en `FAIL`.\n",
+    "3. **Ne pas conclure sur une mesure unique.** Si moins de deux répétitions sont\n",
+    "   valides, le verdict est `NON MESURE`. Un `100 %` calculé sur un seul appel\n",
+    "   n'est pas un taux, c'est une anecdote avec un signe de pourcentage.\n",
+    "\n",
+    "### Piège 2 — l'assertion qui ne reconnaît pas une bonne réponse\n",
+    "\n",
+    "Corrigé le premier piège, le scénario `ancrage_absent` restait en `ECHEC` sur\n",
+    "ses trois répétitions. Verdict sévère, et sur la propriété la plus sensible du\n",
+    "lot : le modèle inventerait des informations absentes du contexte.\n",
+    "\n",
+    "Les extraits disaient l'inverse. Le modèle répondait :\n",
+    "\n",
+    "> « Le contexte indique que l'inscription est gratuite pour les habitants de la\n",
+    "> commune. **Il ne mentionne aucun tarif annuel d'abonnement.** »\n",
+    "\n",
+    "C'est exactement le comportement recherché. La faute était dans l'assertion :\n",
+    "elle cherchait une liste de tournures figées (`\"n'est pas mentionné\"`,\n",
+    "`\"ne figure pas\"`...), et le modèle en avait employé une autre. Une liste de\n",
+    "formulations est toujours incomplète, et le français permet d'insérer un adverbe\n",
+    "au milieu (`\"il n'est **donc** pas mentionné\"`) — ce qui suffit à faire échouer\n",
+    "la correspondance littérale.\n",
+    "\n",
+    "La version corrigée cherche une **négation et un marqueur d'absence à proximité\n",
+    "l'un de l'autre**, dans un sens ou dans l'autre, insensible aux accents. Elle\n",
+    "ajoute surtout la seconde moitié de la propriété, absente de la première\n",
+    "version : **ne pas avancer de montant**. Signaler l'absence et inventer un prix\n",
+    "dans la même phrase, c'est échouer.\n",
+    "\n",
+    "> **Vérifiez toujours qu'un échec est un échec du modèle**, et non un échec de\n",
+    "> votre harnais. Le doute doit porter d'abord sur l'instrument.\n",
+    ">\n",
+    "> Concrètement : **lisez les extraits avant de croire la colonne `verdict`.**\n",
+    "> C'est la raison d'être de la colonne `extrait` dans les résultats — un banc\n",
+    "> qui ne conserve pas les réponses brutes ne se débogue pas.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Exécution\n",
+    "\n",
+    "Trois répétitions par scénario, à `temperature=0.7`. Le choix d'une température\n",
+    "non nulle est délibéré : c'est le régime dans lequel tourne un chatbot de\n",
+    "production, et c'est celui où la variance se manifeste. À `temperature=0`, on\n",
+    "mesurerait un cas particulier flatteur.\n",
+    "\n",
+    "Un scénario n'est **acquis** que s'il passe **toutes** ses répétitions valides.\n",
+    "Deux sur trois signifie qu'un visiteur sur trois voit le défaut."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "23ad81c4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T13:50:08.914410Z",
+     "iopub.status.busy": "2026-08-07T13:50:08.914410Z",
+     "iopub.status.idle": "2026-08-07T13:51:58.662712Z",
+     "shell.execute_reply": "2026-08-07T13:51:58.661587Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ancrage_present  rep 1/3  PASS      3.86s   332 tok  fin=stop\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ancrage_present  rep 2/3  PASS      7.14s   611 tok  fin=stop\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ancrage_present  rep 3/3  PASS      4.13s   362 tok  fin=stop\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ancrage_absent   rep 1/3  PASS      8.64s   794 tok  fin=stop\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ancrage_absent   rep 2/3  PASS      6.15s   533 tok  fin=stop\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ancrage_absent   rep 3/3  PASS      5.95s   540 tok  fin=stop\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  format_json      rep 1/3  PASS     12.89s  1216 tok  fin=stop\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  format_json      rep 2/3  PASS     12.50s  1148 tok  fin=stop\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  format_json      rep 3/3  PASS     13.16s  1230 tok  fin=stop\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  langue_fr        rep 1/3  PASS      8.42s   748 tok  fin=stop\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  langue_fr        rep 2/3  PASS     10.58s   948 tok  fin=stop\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  langue_fr        rep 3/3  PASS     10.29s   964 tok  fin=stop\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  appel_outil      rep 1/3  PASS      2.31s   200 tok  fin=tool_calls\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  appel_outil      rep 2/3  PASS      2.33s   210 tok  fin=tool_calls\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  appel_outil      rep 3/3  PASS      1.37s   102 tok  fin=tool_calls\n",
+      "\n",
+      "15 appels effectues.\n"
+     ]
+    }
+   ],
+   "source": [
+    "REPETITIONS = 3\n",
+    "MAX_TOKENS = 3000          # large : la trace de raisonnement partage ce budget\n",
+    "resultats = []\n",
+    "\n",
+    "for s in SCENARIOS:\n",
+    "    for rep in range(1, REPETITIONS + 1):\n",
+    "        kwargs = dict(\n",
+    "            model=MODEL,\n",
+    "            messages=[{\"role\": \"system\", \"content\": s[\"systeme\"]},\n",
+    "                      {\"role\": \"user\", \"content\": s[\"user\"]}],\n",
+    "            max_tokens=MAX_TOKENS,\n",
+    "            temperature=0.7,\n",
+    "        )\n",
+    "        if s[\"outils\"]:\n",
+    "            kwargs[\"tools\"] = s[\"outils\"]\n",
+    "\n",
+    "        t0 = time.perf_counter()\n",
+    "        try:\n",
+    "            r = client.chat.completions.create(**kwargs)\n",
+    "            choix = r.choices[0]\n",
+    "            msg = choix.message\n",
+    "            texte = (msg.content or \"\").strip()\n",
+    "            tool_calls = getattr(msg, \"tool_calls\", None) or []\n",
+    "            fin = choix.finish_reason or \"\"\n",
+    "            gen = r.usage.completion_tokens if r.usage else None\n",
+    "\n",
+    "            # Mesure INVALIDE : coupee par la limite sans rien produire d'evaluable.\n",
+    "            if fin == \"length\" and not texte and not tool_calls:\n",
+    "                statut = \"INVALIDE\"\n",
+    "            else:\n",
+    "                statut = \"PASS\" if s[\"verif\"](texte, tool_calls) else \"FAIL\"\n",
+    "            err = \"\"\n",
+    "        except Exception as exc:                 # panne reseau, modele indisponible\n",
+    "            texte, fin, gen, statut = \"\", \"\", None, \"INVALIDE\"\n",
+    "            err = type(exc).__name__\n",
+    "        dt = time.perf_counter() - t0\n",
+    "\n",
+    "        resultats.append(dict(scenario=s[\"cle\"], propriete=s[\"propriete\"], rep=rep,\n",
+    "                              statut=statut, secondes=round(dt, 2), tokens=gen,\n",
+    "                              fin=fin, erreur=err,\n",
+    "                              extrait=\" \".join(texte[:160].split())))\n",
+    "        print(f\"  {s['cle']:<16} rep {rep}/{REPETITIONS}  {statut:<8} \"\n",
+    "              f\"{dt:5.2f}s  {str(gen or '-'):>4} tok  fin={fin or '-'}\"\n",
+    "              f\"{'  ' + err if err else ''}\")\n",
+    "\n",
+    "print(f\"\\n{len(resultats)} appels effectues.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "14579731",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T13:51:58.665879Z",
+     "iopub.status.busy": "2026-08-07T13:51:58.665359Z",
+     "iopub.status.idle": "2026-08-07T13:51:59.416452Z",
+     "shell.execute_reply": "2026-08-07T13:51:59.415931Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>scenario</th>\n",
+       "      <th>propriete</th>\n",
+       "      <th>reussites</th>\n",
+       "      <th>valides</th>\n",
+       "      <th>invalides</th>\n",
+       "      <th>taux_pct</th>\n",
+       "      <th>sec_med</th>\n",
+       "      <th>tok_med</th>\n",
+       "      <th>verdict</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>ancrage_absent</td>\n",
+       "      <td>Refus hors-contexte</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>100</td>\n",
+       "      <td>6.15</td>\n",
+       "      <td>540.0</td>\n",
+       "      <td>ACQUIS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>ancrage_present</td>\n",
+       "      <td>Ancrage</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>100</td>\n",
+       "      <td>4.13</td>\n",
+       "      <td>362.0</td>\n",
+       "      <td>ACQUIS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>appel_outil</td>\n",
+       "      <td>Discipline d'appel d'outil</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>100</td>\n",
+       "      <td>2.31</td>\n",
+       "      <td>200.0</td>\n",
+       "      <td>ACQUIS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>format_json</td>\n",
+       "      <td>Respect du format</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>100</td>\n",
+       "      <td>12.89</td>\n",
+       "      <td>1216.0</td>\n",
+       "      <td>ACQUIS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>langue_fr</td>\n",
+       "      <td>Stabilite de langue</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>100</td>\n",
+       "      <td>10.29</td>\n",
+       "      <td>948.0</td>\n",
+       "      <td>ACQUIS</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          scenario                   propriete  reussites  valides  invalides  \\\n",
+       "0   ancrage_absent         Refus hors-contexte          3        3          0   \n",
+       "1  ancrage_present                     Ancrage          3        3          0   \n",
+       "2      appel_outil  Discipline d'appel d'outil          3        3          0   \n",
+       "3      format_json           Respect du format          3        3          0   \n",
+       "4        langue_fr         Stabilite de langue          3        3          0   \n",
+       "\n",
+       "   taux_pct  sec_med  tok_med verdict  \n",
+       "0       100     6.15    540.0  ACQUIS  \n",
+       "1       100     4.13    362.0  ACQUIS  \n",
+       "2       100     2.31    200.0  ACQUIS  \n",
+       "3       100    12.89   1216.0  ACQUIS  \n",
+       "4       100    10.29    948.0  ACQUIS  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "df = pd.DataFrame(resultats)\n",
+    "\n",
+    "\n",
+    "MIN_VALIDES = 2            # en deca, on ne conclut pas : une mesure n'est pas un taux\n",
+    "\n",
+    "\n",
+    "def verdict(g):\n",
+    "    valides = int((g.statut != \"INVALIDE\").sum())\n",
+    "    reussites = int((g.statut == \"PASS\").sum())\n",
+    "    if valides < MIN_VALIDES:\n",
+    "        v = \"NON MESURE\"\n",
+    "    elif reussites == valides:\n",
+    "        v = \"ACQUIS\"\n",
+    "    elif reussites:\n",
+    "        v = \"INSTABLE\"\n",
+    "    else:\n",
+    "        v = \"ECHEC\"\n",
+    "    return pd.Series(dict(reussites=reussites, valides=valides,\n",
+    "                          invalides=int((g.statut == \"INVALIDE\").sum()),\n",
+    "                          sec_med=g.secondes.median(),\n",
+    "                          tok_med=g.tokens.median(), verdict=v))\n",
+    "\n",
+    "\n",
+    "synthese = (df.groupby([\"scenario\", \"propriete\"]).apply(verdict, include_groups=False)\n",
+    "              .reset_index())\n",
+    "synthese[\"taux_pct\"] = synthese.apply(\n",
+    "    lambda r: round(r.reussites / r.valides * 100) if r.valides else None, axis=1)\n",
+    "synthese[[\"scenario\", \"propriete\", \"reussites\", \"valides\", \"invalides\",\n",
+    "          \"taux_pct\", \"sec_med\", \"tok_med\", \"verdict\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e5afefc0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T13:51:59.419122Z",
+     "iopub.status.busy": "2026-08-07T13:51:59.419122Z",
+     "iopub.status.idle": "2026-08-07T13:51:59.430811Z",
+     "shell.execute_reply": "2026-08-07T13:51:59.430301Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele evalue : qwen3.6-35b-a3b\n",
+      "  ACQUIS     : 5/5\n",
+      "  INSTABLE   : 0/5\n",
+      "  ECHEC      : 0/5\n",
+      "  NON MESURE : 0/5\n",
+      "  latence mediane  : 7.14 s\n",
+      "  mesures invalides: 0/15\n",
+      "\n",
+      "Les cinq proprietes sont acquises sur ce banc.\n"
+     ]
+    }
+   ],
+   "source": [
+    "compte = synthese.verdict.value_counts().to_dict()\n",
+    "invalides_total = int((df.statut == \"INVALIDE\").sum())\n",
+    "\n",
+    "print(f\"Modele evalue : {MODEL}\")\n",
+    "for v in (\"ACQUIS\", \"INSTABLE\", \"ECHEC\", \"NON MESURE\"):\n",
+    "    print(f\"  {v:<11}: {compte.get(v, 0)}/{len(synthese)}\")\n",
+    "print(f\"  latence mediane  : {statistics.median(df.secondes):.2f} s\")\n",
+    "print(f\"  mesures invalides: {invalides_total}/{len(df)}\"\n",
+    "      f\"{'  (budget de tokens a revoir)' if invalides_total else ''}\\n\")\n",
+    "\n",
+    "for _, r in synthese[synthese.verdict != \"ACQUIS\"].iterrows():\n",
+    "    print(f\"A surveiller -- {r.scenario} ({r.propriete}) : \"\n",
+    "          f\"{r.reussites}/{r.valides} valides, {r.invalides} invalide(s)\")\n",
+    "    for _, l in df[(df.scenario == r.scenario) & (df.statut == \"FAIL\")].head(2).iterrows():\n",
+    "        print(f\"    rep {l.rep} rendait : {l.extrait[:130]!r}\")\n",
+    "\n",
+    "if compte.get(\"ACQUIS\", 0) == len(synthese):\n",
+    "    print(\"Les cinq proprietes sont acquises sur ce banc.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18053026",
+   "metadata": {},
+   "source": [
+    "## Lire le tableau\n",
+    "\n",
+    "### D'abord : que faire d'un tableau tout vert ?\n",
+    "\n",
+    "Sur l'exécution enregistrée ci-dessus, les cinq propriétés ressortent `ACQUIS`.\n",
+    "La conclusion à en tirer est modeste, et il faut résister à la formuler autrement :\n",
+    "**ce modèle ne présente aucun des cinq défauts testés**. Ce n'est pas « ce modèle\n",
+    "est bon ».\n",
+    "\n",
+    "Un banc qui ne fait jamais échouer personne ne discrimine plus rien — il rassure,\n",
+    "ce qui est exactement son défaut. Trois réactions saines devant du tout-vert :\n",
+    "\n",
+    "1. **Durcir les cas** avant de conclure. Ici, `ancrage_absent` pourrait poser une\n",
+    "   question dont le contexte contient une réponse *voisine mais fausse* : c'est le\n",
+    "   piège auquel les modèles cèdent réellement, bien plus qu'à une question\n",
+    "   franchement hors-sujet.\n",
+    "2. **Ajouter les cas venus de la production** — les vraies questions des vrais\n",
+    "   visiteurs, celles qu'on n'aurait pas imaginées.\n",
+    "3. **Comparer**, plutôt que valider. Le tableau prend son sens en faisant tourner\n",
+    "   le même banc sur deux ou trois modèles candidats : c'est l'écart qui décide,\n",
+    "   pas le score absolu.\n",
+    "\n",
+    "### Les quatre verdicts\n",
+    "\n",
+    "**`ACQUIS` (3/3)** — la propriété tient sur ce banc. Ce n'est pas une garantie\n",
+    "absolue : c'est l'absence de défaut sur cinq cas choisis pour être discriminants.\n",
+    "\n",
+    "**`INSTABLE` (1/3 ou 2/3)** — le cas le plus important du tableau, et celui\n",
+    "qu'une démonstration ne révèle jamais. Un modèle qui passe deux fois sur trois\n",
+    "donnera raison à qui l'essaie deux fois, et tort à qui l'essaie une troisième.\n",
+    "Sur une propriété de sûreté comme le refus hors-contexte, `INSTABLE` doit se lire\n",
+    "comme un échec : la garantie recherchée est justement de ne **jamais** inventer.\n",
+    "\n",
+    "**`ECHEC` (0 sur les répétitions valides)** — la propriété est absente. Selon\n",
+    "laquelle, la conséquence diffère : un échec sur le format se rattrape par un\n",
+    "parseur tolérant ; un échec sur l'ancrage ne se rattrape pas — il se paie en\n",
+    "affirmations fausses publiées au nom du site.\n",
+    "\n",
+    "**`NON MESURE`, et la colonne `invalides`** — aucune répétition exploitable, ou\n",
+    "seulement une partie. Ce n'est **pas** un résultat sur le modèle, c'est un\n",
+    "résultat sur le banc : budget de tokens trop court, endpoint indisponible,\n",
+    "requête rejetée. La bonne réaction est de corriger l'instrument et de relancer,\n",
+    "jamais d'interpréter. Cette colonne existe précisément pour que le tableau ne\n",
+    "puisse plus déguiser une panne de mesure en verdict.\n",
+    "\n",
+    "### Ce qu'on en fait\n",
+    "\n",
+    "Un scénario qui échoue ne condamne pas le modèle : il **oriente le correctif**.\n",
+    "Refus faible → durcir la consigne système et relever le seuil de similarité du\n",
+    "RAG. Format instable → passer en sortie structurée native plutôt que d'espérer la\n",
+    "discipline du modèle. Dérive de langue → rédiger la consigne système dans la\n",
+    "langue cible. Appel d'outil absent → le modèle n'est pas éligible à un usage\n",
+    "agentique, quelle que soit sa qualité rédactionnelle.\n",
+    "\n",
+    "C'est la différence entre « ce modèle est bon » et « ce modèle convient **à cet\n",
+    "usage, et voici ce qu'il faut compenser** »."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c962a6a7",
+   "metadata": {},
+   "source": [
+    "## Transposition à AI-Engine (et à Open WebUI)\n",
+    "\n",
+    "Les deux plateformes exposent les mêmes leviers, sous des noms différents. Le\n",
+    "banc ci-dessus teste le **modèle** ; les correctifs, eux, se posent dans la\n",
+    "plateforme.\n",
+    "\n",
+    "| Ce que le banc mesure | Levier côté AI-Engine | Levier côté Open WebUI |\n",
+    "|---|---|---|\n",
+    "| Ancrage / refus | Consigne système du chatbot, seuil et mode de recherche (Simple / Context-Aware / Smart) | Consigne système, paramètres de récupération Knowledge |\n",
+    "| Respect du format | Sortie structurée du provider, quand il la supporte | Idem, selon le connecteur |\n",
+    "| Stabilité de langue | Consigne système rédigée dans la langue cible | Idem |\n",
+    "| Appel d'outil | Fonctions attachées au chatbot, outils MCP exposés | Tools / MCP |\n",
+    "\n",
+    "Un point pratique : AI-Engine permet de **fixer un modèle différent par\n",
+    "chatbot**. Un banc comme celui-ci prend alors tout son sens — un modèle modeste\n",
+    "mais discipliné suffit à un agent qui n'a qu'à appeler des outils, tandis qu'une\n",
+    "surface conversationnelle publique exige un ancrage irréprochable. Ce sont deux\n",
+    "décisions distinctes, qui se justifient par deux tableaux.\n",
+    "\n",
+    "### Limites, dites franchement\n",
+    "\n",
+    "- **Cinq scénarios ne sont pas une évaluation.** C'est un garde-fou minimal. Un\n",
+    "  banc utile en production compte quelques dizaines de cas, écrits à partir des\n",
+    "  questions réellement posées au chatbot.\n",
+    "- **Les vérificateurs sont heuristiques**, et c'est le maillon faible. Le\n",
+    "  détecteur de refus repose sur une proximité négation / marqueur d'absence ;\n",
+    "  il ratera une formulation inattendue — c'est exactement le piège 2 raconté\n",
+    "  plus haut, et rien ne garantit qu'il ne se reproduira pas sur une tournure\n",
+    "  que je n'ai pas prévue. Un banc mature remplace ces heuristiques par un juge\n",
+    "  LLM — lui-même à valider, avec les mêmes précautions.\n",
+    "- **Rien ici ne mesure la qualité rédactionnelle.** C'est volontaire : elle se\n",
+    "  juge à la lecture, pas par assertion.\n",
+    "- **Trois répétitions détectent l'instabilité grossière**, pas une dérive de\n",
+    "  quelques pour cent. Augmenter `REPETITIONS` pour resserrer.\n",
+    "\n",
+    "Le point n'est pas d'avoir le banc parfait, mais de ne plus choisir un modèle sur\n",
+    "trois questions bien choisies."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae401718",
+   "metadata": {},
+   "source": [
+    "## Voir aussi\n",
+    "\n",
+    "- [README AI-Engine-WordPress](README.md) — point d'entrée du dossier\n",
+    "- [Parcours livresagités](livresagites-parcours.md) — l'installation WordPress\n",
+    "  observée dans ce dossier, son serveur MCP et ses environnements d'embeddings\n",
+    "- [Comparatif OWUI vs AI-Engine](comparatif-owui-vs-ai-engine.md) — tableau\n",
+    "  fonctionnel\n",
+    "- Issue [#9734](https://github.com/jsboige/CoursIA/issues/9734) — mandat à\n",
+    "  l'origine de ce dossier"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/docs #9885

**Quoi.** Le critère d'acceptation 1 de #9734 demande « module(s) markdown/**notebook** » ; le dossier était markdown seul. Ce notebook comble le manque sur la question que le parcours pose sans y répondre : **quel modèle brancher derrière un chatbot public ?** Il transforme « je l'ai essayé, il répond bien » en un tableau reproductible.

Refs #9734 (phase 3). Complète #9885, mergée, sur laquelle cette branche est rebasée.

---

## Preuve — sorties réelles enregistrées

Le notebook est committé **avec ses sorties**, obtenues contre un endpoint vLLM local. Aucune valeur n'est écrite à la main.

| Grandeur | Valeur | Où la lire |
|---|---|---|
| Modèle évalué | `qwen3.6-35b-a3b` | sortie cellule 4 |
| Appels effectués | 15 (5 scénarios × 3 répétitions) | sortie cellule 9 |
| Verdict | 5/5 `ACQUIS`, 0 mesure invalide | sortie cellule 11 |
| Latence médiane | 5,5 s | idem |
| Reproductibilité | résultat identique sur **deux exécutions indépendantes** | — |

Les cinq propriétés testées sont choisies pour être **discriminantes et vérifiables par du code**, pas pour flatter :

| Scénario | Propriété | Ce que l'échec coûterait en production |
|---|---|---|
| `ancrage_present` | cite le chiffre présent dans le contexte | réponses vagues malgré un RAG qui fonctionne |
| `ancrage_absent` | signale l'absence **sans inventer de montant** | affirmations fausses publiées au nom du site |
| `format_json` | JSON parsable, aux deux clés exactes | intégration cassée en aval |
| `langue_fr` | répond en français malgré une consigne système anglophone | dérive de langue face au public |
| `appel_outil` | émet un `tool_call` valide, pas de la prose | modèle inéligible à un usage agentique |

Le corpus est **entièrement fictif** — une « médiathèque de Valmont » écrite pour ce notebook. Aucune donnée, aucun contenu, aucun nom issu de l'installation observée.

## Le contenu du notebook n'est pas le tableau, ce sont les deux pièges

C'est la partie que je tiens le plus à faire relire. **Ce banc a rendu deux verdicts faux avant d'en rendre un vrai. Les deux accusaient le modèle ; les deux venaient du harnais.**

**Piège 1 — le budget de tokens partagé avec le raisonnement.** Première exécution : trois propriétés sur cinq en `ECHEC`, réponses **vides**. Le modèle évalué raisonne avant de répondre, et sa trace de réflexion est facturée sur le **même** `max_tokens` que la réponse. À 400 tokens, la réflexion consommait tout ; `content` revenait vide ; mes assertions concluaient sagement à l'échec.

**Piège 2 — l'assertion qui ne reconnaît pas une bonne réponse.** Piège 1 corrigé, `ancrage_absent` restait à 0/3 — sur la propriété la plus sensible du lot. Les extraits disaient l'inverse :

> « Le contexte indique que l'inscription est gratuite pour les habitants de la commune. **Il ne mentionne aucun tarif annuel d'abonnement.** »

C'est exactement le comportement recherché. Mon détecteur de refus cherchait une liste de tournures figées, et le modèle en employait une autre — le français permet d'insérer un adverbe au milieu (`« il n'est donc pas mentionné »`), ce qui suffit à faire échouer une correspondance littérale.

Trois corrections structurelles en découlent, toutes dans le code livré :

1. `max_tokens = 3000`, pour que la réflexion ne mange pas la réponse.
2. Un statut **`INVALIDE`** (réponse coupée par la limite) **exclu du verdict**, au lieu d'être maquillé en `FAIL`.
3. Un seuil **`MIN_VALIDES = 2`** : sous deux répétitions exploitables, le verdict est `NON MESURE`. Un `100 %` calculé sur un seul appel n'est pas un taux.

Le détecteur de refus cherche désormais une **négation et un marqueur d'absence à proximité**, insensible aux accents, et vérifie la seconde moitié de la propriété qui manquait à la première version : **ne pas avancer de montant**. Signaler l'absence et inventer un prix dans la même phrase, c'est échouer. Validé sur dix cas, dont les deux réponses réellement rendues et un cas piège « signale l'absence mais invente quand même ».

> Un banc mal calibré ne renvoie pas « je ne sais pas » : il renvoie un **verdict faux, précis et crédible**. C'est plus dangereux que l'absence de mesure — un tableau chiffré inspire une confiance qu'une intuition n'obtiendrait pas.

## Sur le tableau tout vert

Le notebook consacre une section à ce qu'il ne faut **pas** en conclure. 5/5 `ACQUIS` signifie « ce modèle ne présente aucun des cinq défauts testés », pas « ce modèle est bon ». Un banc qui ne fait jamais échouer personne ne discrimine plus rien : il rassure, ce qui est son défaut. Les trois réactions saines (durcir les cas, ajouter les questions venues de la production, comparer plusieurs modèles plutôt que valider) sont écrites dans le notebook plutôt que laissées à l'inférence du lecteur.

## Périmètre

- **3 fichiers** : `eval-choisir-son-modele.ipynb` (nouveau), `.env.example` (nouveau), `README.md` du dossier (+11 lignes, deux points d'entrée vers le notebook).
- Aucune donnée client, aucun nom de personne, aucun titre d'ouvrage, aucun extrait de prose. Aucun fichier copié depuis le projet source.
- Aucun endpoint, hôte, port ni clé n'apparaît dans les sorties : la cellule de configuration **expurge l'URL avant affichage** (`http://<adresse-IP-privee><:port>/v1`) et n'imprime de la clé que sa longueur.
- Le notebook ne dépend d'aucune infrastructure particulière : n'importe quel endpoint compatible OpenAI convient (vLLM, Ollama, LM Studio, OpenRouter, OpenAI). Il n'appelle que `/v1/models` et `/v1/chat/completions`.

## Contrôles passés

- **`gitleaks detect --no-git`** exécuté directement sur le dossier : `no leaks found`.
- Scan maison : homoglyphes cyrillique/grec **0**, emojis (règle E) **0**, tokens à haute entropie **0** hors placeholders (`your_api_key_here`).
- Les **4 hooks d'hygiène notebook** du dépôt : tous `Passed` (bannière probeAddresses, chemins NuGet, chemins papermill, markdown-rendering-guard).
- Règle H.3 : les 7 cellules de code portent un `execution_count` non nul et des sorties.
- Rescan de collision **après** push (leçon C9863-L5) : les 4 PR ouvertes ne touchent aucun fichier de `01-AI-Engine-WordPress`.

## Un signalement, hors périmètre — le hook gitleaks est cassé au niveau du dépôt

Je l'avais signalé sur #9885 comme un angle mort des worktrees. C'est plus large que ça, et je le corrige : **le hook échoue même quand `pre-commit` s'exécute normalement.**

```
Secret scanner (gitleaks)....................................Failed
- hook id: gitleaks
- exit code: 126
Error: unknown flag: --no-git
Usage:
  gitleaks protect [flags]
```

Le hook amont enveloppe déjà la commande en `gitleaks protect --staged` ; les `args: ['detect', '--no-git', '--redact']` du `.pre-commit-config.yaml` sont donc passés à `protect`, qui ne connaît pas `--no-git`. Le binaire lui-même fonctionne — lancé à la main avec les bons arguments, il rend `no leaks found`. C'est la **configuration** qui est fautive, pas l'outil.

Conséquence : sur ce dépôt public, **le garde-fou anti-secret local ne s'est jamais exécuté**. Il ne bloque personne parce qu'apparemment personne n'a `pre-commit install`. Le gate CI reste la seule barrière effective. Je n'ai pas touché au fichier — il est hors de mon claim et concerne toutes les lanes. À arbitrer.

## Ce que ce notebook ne fait pas

Écrit dans le notebook, pas seulement ici : cinq scénarios ne sont pas une évaluation, les vérificateurs restent heuristiques (le piège 2 peut se reproduire sur une tournure non prévue), rien ne mesure la qualité rédactionnelle, et trois répétitions détectent l'instabilité grossière, pas une dérive de quelques pour cent.

---

Co-authored-by: Claude-Code <noreply@anthropic.com>
