### PR TITLE
fix(lean,#9863): le temoin d'angle mort suit les sous-modules du split (main rouge)

### DIFF
--- a/scripts/lean/tests/test_check_public_anchor.py
+++ b/scripts/lean/tests/test_check_public_anchor.py
@@ -280,24 +280,45 @@ def test_cli_json_is_parseable(tmp_path, capsys):
 # --------------------------------------------------------------------------
 
 
+def hashlife_modules() -> list[Path]:
+    """L'agregateur **et** ses sous-modules.
+
+    Le temoin ne peut pas viser un fichier : au split #9863 la substance a quitte
+    ``HashlifeCorrectness.lean``, devenu un agregateur d'imports, pour descendre
+    dans ``HashlifeCorrectness/{Foundation,Walls/*}.lean``. Viser le seul fichier
+    d'origine faisait tomber le temoin a ``unanchored == 0`` -- soit precisement
+    l'angle mort #8782 qu'il existe pour attraper, reproduit sur lui-meme.
+    """
+    mods = [HASHLIFE] if HASHLIFE.is_file() else []
+    tree = HASHLIFE.with_suffix("")
+    if tree.is_dir():
+        mods += sorted(tree.rglob("*.lean"))
+    return mods
+
+
 @pytest.mark.skipif(not HASHLIFE.is_file(), reason="conway_lean absent de cet arbre")
 def test_hashlife_exhibits_the_blind_spot():
-    """Temoin #8782 : le module cible par la CI porte des sorry sans ancrage.
+    """Temoin #8782 : les modules cibles par la CI portent des sorry sans ancrage.
 
     Non fige sur un compte exact (le module evolue, cf #8981) : ce qui est
     verifie, c'est que la classe de defaut est instanciee ET qu'une partie des
     sorry est bien visible du gate -- l'angle mort est partiel, pas total.
+
+    Porte sur l'**union** de l'agregateur et de ses sous-modules (cf
+    ``hashlife_modules``) : c'est la meme union que ``target-modules`` cote CI.
     """
-    r = analyze_module(HASHLIFE)
-    if r["sorry_sites"] == 0:
-        pytest.skip("module assaini depuis la mesure de reference")
-    assert r["unanchored"] > 0, "l'angle mort a disparu : mettre a jour le temoin"
-    assert any(s["verdict"] == ANCHORED_PUBLIC for s in r["sites"]), (
-        "aucun sorry public : le module aurait change de nature"
+    sites = [s for p in hashlife_modules() for s in analyze_module(p)["sites"]]
+    if not sites:
+        pytest.skip("modules assainis depuis la mesure de reference")
+    unanchored = [s for s in sites if s["verdict"] == UNANCHORED]
+    assert unanchored, "l'angle mort a disparu : mettre a jour le temoin"
+    assert any(s["verdict"] == ANCHORED_PUBLIC for s in sites), (
+        "aucun sorry public : les modules auraient change de nature"
     )
-    owners = {s["owner"] for s in r["sites"] if s["verdict"] == UNANCHORED}
-    assert all(s["owner_private"] for s in r["sites"] if s["verdict"] == UNANCHORED)
-    assert owners, "les sorry sans ancrage doivent nommer leur porteur"
+    assert all(s["owner_private"] for s in unanchored)
+    assert {s["owner"] for s in unanchored}, (
+        "les sorry sans ancrage doivent nommer leur porteur"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: LIGHT/test — lane myia-ai-01:CoursIA — prev: DEEP/lean #9883 (merge, pas auteur)

## Ce que ca repare

`main` est **rouge** depuis `2a9593526` (merge du split #9883) :

```
FAILED scripts/lean/tests/test_check_public_anchor.py::test_hashlife_exhibits_the_blind_spot
E   AssertionError: l'angle mort a disparu : mettre a jour le temoin
E   assert 0 > 0
```

Ce n'est pas discretionnaire : c'est une reparation de `main` rouge, causee par un merge que j'ai fait. Le plat principal de mon cycle est ailleurs (PR B de #9863, `DEEP/lean`).

## Pourquoi le temoin est tombe — l'angle mort reproduit sur lui-meme

`test_hashlife_exhibits_the_blind_spot` est un **temoin** : il verifie que `HashlifeCorrectness` instancie encore la classe de defaut #8782 (un `sorry` porte par une declaration privee qu'aucun public ne rejoint), pour que le gate `check_public_anchor.py` garde un cas vivant sous les yeux.

Le split a fait de `HashlifeCorrectness.lean` un **agregateur d'imports**. Le temoin visait ce **fichier** ; la substance est descendue dans `HashlifeCorrectness/{Foundation,Walls/*}.lean`. Il mesurait donc `unanchored == 0` et concluait — correctement, selon sa propre logique — que l'angle mort avait disparu.

C'est litteralement **#8782 reproduit sur son propre temoin** : « les gates nomment le module, pas le fichier ». J'avais ecrit cet ecueil dans le brief de dispatch pour `target-modules`, et je ne l'ai pas vu pour le temoin qui surveille le meme angle mort. Il portait pourtant son propre mode d'emploi dans son message d'echec.

## Le split n'a rien deplace — mesure firsthand

Avant de corriger le temoin, j'ai verifie qu'il ne signalait pas un vrai probleme, en comparant les verdicts d'ancrage de part et d'autre du split :

| | sites | unanchored | transitive | public |
|---|---|---|---|---|
| `89664de51` (monolithe, 7 082 l.) | 4 | **1** | 2 | 1 |
| `2a9593526` (agregateur + 5 sous-modules) | 4 | **1** | 2 | 1 |

Porteur `unanchored` **inchange** : `Conway.Life.p4_sw_overlap_wall`, desormais dans `Walls/SW.lean`. Repartition post-split : agregateur 1 site, `Walls/SE` 1, `Walls/SW` 2.

**Distribution strictement conservee.** Cela ajoute une preuve au dossier du split : le retrait de `private` sur 26 declarations (le seul delta de contenu, cf ma revue de #9883) n'a **pas** fait basculer de verdict d'ancrage — aucun `sorry` n'a change de nature au passage.

## Le correctif

Le temoin porte desormais sur l'**union** agregateur + sous-modules, via un helper `hashlife_modules()` — la meme union que `target-modules` cote CI. Un futur re-decoupage a l'interieur de `HashlifeCorrectness/` n'aura donc pas a le retoucher : `rglob` suit.

```
python -m pytest scripts/lean/tests/ -q   ->  156 passed, 1 skipped
```

Le `skipif` sur `HASHLIFE.is_file()` et le `skip` « modules assainis » sont conserves : le temoin reste un temoin, pas un oracle fige.

## Note pour la suite

Un point que ce split rend reel et que le gate ne traite pas : `public_closure_reaches` cherche l'ancrage **dans le module**. Une declaration privee d'un sous-module ancree par un public d'un **autre** module se lirait desormais `unanchored` a tort. Ce n'est pas le cas ici (distribution conservee, verifie ci-dessus), donc je ne l'elargis pas dans cette PR — mais c'est un grain distinct qui merite son issue si un futur split rend le cas frequent.

`See #9863`
