### PR TITLE
docs(repo-size,#9860): §5.1 submodules — usage réel (8) + angle mort du check advisory

### DIFF
--- a/docs/reference/repo-size-policy.md
+++ b/docs/reference/repo-size-policy.md
@@ -79,6 +79,32 @@ désignée au-dessus du seuil advisory (§6) :
 Le seuil advisory (§6) est là pour **déclencher la conversation** : un blob > seuil dans une
 PR ouvre la question « LFS ou justification pédagogique ? », sans bloquer le merge.
 
+### 5.1 Submodules : usage réel et angle mort du check §6
+
+Le dépôt utilise **8 submodules** (inscrits dans `.gitmodules`), répartis en deux familles :
+
+- **Libs vendored externes** : `foundry-lib/lib/{forge-std, openzeppelin-contracts,
+  account-abstraction}` (SmartContracts Solidity), `Argumentum` (ArgumentumGames) —
+  dépendances externes pointées par commit, non recopiées comme blobs.
+- **Dépôts propres** : `MetaGeneticSharp` (jsboige), `Z3.Linq`, `Automata`, `semantic-fleet`
+  (MyIntelligenceAgency) — sous-projets factorisés hors du monorepo.
+
+Les submodules sont l'**alternative structurelle** à LFS pour externaliser le poids hors de
+l'arbre : un gitlink pèse quelques octets, quel que soit le poids du dépôt référencé. C'est
+précisément ce qui crée leur angle mort.
+
+- **Angle mort du check §6** : un submodule n'est **pas** un blob du dépôt parent — c'est une
+  référence de commit (`gitlink`). Le scan `git diff --diff-filter=A` de `repo-size-advisory.yml`
+  ne le voit donc **jamais**, quel que soit le poids du dépôt référencé. L'introduction d'un
+  submodule pointant vers un dépôt de plusieurs GiB ne déclencherait aucun warning advisory.
+- **Décision** : les 8 submodules actuels sont des dépendances stables (libs vendored + sous-
+  projets propres), légitimes au même titre que les blobs vendored de §3. L'ajout d'un
+  **nouveau** submodule doit être **documenté dans la PR** avec le poids du dépôt référencé et
+  la raison (vendored légitime vs sous-projet propre vs déplacement LFS-like) — le check §6 ne
+  peut pas le mesurer, donc c'est la revue humaine qui porte la garde. Critère de refus : un
+  submodule dont l'unique motivation est « cacher du poids » plutôt qu'une réelle factorisation
+  ou dépendance externe stable.
+
 ## 6. Check advisory (jamais bloquant)
 
 Un workflow CI (`.github/workflows/repo-size-advisory.yml`) signale, sur chaque PR, les blobs


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: DEEP/lean #9883

Quoi: Ajoute §5.1 « Submodules : usage réel et angle mort du check advisory » à `docs/reference/repo-size-policy.md` — le résiduel d'#9860 après #9869 (ai-01 l'a pinpointé : `submodule = 0 occurrence` dans la policy).

Preuve: `git ls-tree -r origin/main | awk '$2=="commit"'` = **8 gitlinks** sur main (forge-std, openzeppelin-contracts, account-abstraction, Argumentum, MetaGeneticSharp, Z3.Linq, Automata, semantic-fleet), tous inscrits dans `.gitmodules` (8 entrées, `grep -c '^\[submodule' = 8`). Le check advisory §6 (`repo-size-advisory.yml`) scanne `git diff --diff-filter=A` sur les blobs — un submodule est un gitlink (référence de commit), pas un blob, donc il échappe au gate par construction, quel que soit le poids du dépôt référencé.

Perimetre: `docs/reference/repo-size-policy.md` UNIQUEMENT (+26 lignes, §5.1 après §5 LFS). Catalogue byte-identique (R1), README non touché, marqueur CATALOG-STATUS préservé.

## Substance de la section ajoutée

La section documente 3 points, tous fondés firsthand :
1. **Usage réel** : 8 submodules en 2 familles — 3 libs vendored externes (foundry Solidity + Argumentum) + 5 sous-projets propres (MetaGeneticSharp/jsboige, Z3.Linq + Automata + semantic-fleet/MyIntelligenceAgency). Le dépôt n'est PAS « sans submodule » comme le suggérait l'absence de mention.
2. **Angle mort structurel du check §6** : gitlink ≠ blob → le scan `--diff-filter=A` ne le voit jamais. Un submodule pointant vers un dépôt de plusieurs GiB passerait le gate advisory sans warning.
3. **Décision** : les 8 actuels sont légitimes (vendored stable + factorisation propre). L'ajout d'un NOUVEAU submodule doit être documenté dans la PR (poids référencé + raison), la revue humaine porte la garde. Critère de refus : submodule dont l'unique motivation est « cacher du poids ».

## G.1 self-correction notée

Mon premier brouillon affirmait faussement « aucun submodule, pas de .gitmodules » — basé sur `git ls-tree origin/main` (racine seule), qui rate les gitlinks en sous-répertoires. Corrigé par `git ls-tree -r` (récursif). Leçon : `ls-tree` racine ≠ inventaire complet ; `-r` obligatoire. Cette dérive G.1 a été attrapée AVANT commit, pas après.

## Acceptance #9860

- `docs/reference/repo-size-policy.md` porte explicitement les deux refus (nbstripout §2.1, filter-repo §2.2) — déjà livré par #9869, préservé ici.
- Check advisory en place avec seuil justifié par mesure réelle (§3/§6) — déjà livré par #9869.
- **Résiduel comblé** : la policy mentionne désormais les submodules (catégorie de poids évitant le check §6), avec décision et critère de refus.

See #9860 (résiduel post-#9869, politique de taille).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
