### PR TITLE
feat(hooks,#9888): activate inert pre-commit harness + H.3 hook + fix gitleaks no-op

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,6 +3,15 @@
 
 title = "CoursIA Secret Scanner"
 
+# Extend gitleaks' built-in default ruleset (700+ detectors: AWS, GitHub,
+# Google, Stripe, ...). WITHOUT this directive the config below carries no
+# [[rules]] of its own, so gitleaks matched nothing — the secret scanner was a
+# silent no-op both in the pre-commit hook and in CI (secret-scan.yml sets
+# GITLEAKS_CONFIG=.gitleaks.toml). The allowlist below still applies on top of
+# the defaults (verified: secrets detected + base64-blob FP suppressed). See #9888.
+[extend]
+useDefault = true
+
 [allowlist]
 description = "Global allowlist for known false positives"
 paths = [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,21 @@
 # Pre-commit hooks for CoursIA
-# Install: pip install pre-commit && pre-commit install
+# Install (idempotent, recommended): python scripts/setup_hooks.py
+#   or manually: pip install pre-commit && pre-commit install
 # Run manually: pre-commit run --all-files
+# Machine relevé / parity: python scripts/setup_hooks.py --check | --check-parity
 
 repos:
+  # gitleaks: scans STAGED content before it enters history. Uses the hook's
+  # canonical v8.21.2 entry (`gitleaks protect --verbose --redact --staged`,
+  # pass_filenames: false) -- do NOT override `args` with the old `detect
+  # --no-git` form: that appends to the canonical entry and gitleaks rejects
+  # the combined flags (#9888). `protect` scans uncommitted changes (fast,
+  # correct for pre-commit); `detect` would scan full git history (slow).
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.21.2
     hooks:
       - id: gitleaks
         name: Secret scanner (gitleaks)
-        args: ['detect', '--no-git', '--redact']
 
   # Local hooks: notebook hygiene + structural integrity. These run on the
   # worker's machine without external dependencies. See
@@ -85,5 +92,24 @@ repos:
         entry: python scripts/notebook_tools/detect_markdown_rendering.py --check --baseline scripts/notebook_tools/markdown_rendering_baseline.json
         language: system
         pass_filenames: false
+        files: '\.ipynb$'
+        stages: [pre-commit]
+
+      - id: check-null-exec
+        name: H.3 — refuse un-executed notebooks (execution_count=null + outputs=[])
+        description: |
+          Fails the commit if a staged notebook has a code cell with
+          execution_count == null AND empty outputs — a C.2/H.3 violation: a
+          committed notebook must prove it ran. This is the pre-commit half of
+          the CI gate validate_pr_notebooks.py (same tolerance predicates: lean
+          kernels, QC Cloud via _is_qc_cloud, and metadata.pii_no_output). It
+          catches the worker who edits a notebook and forgets to re-execute it
+          BEFORE the push — before a secret or a false output reaches history.
+          See #9888 (inert pre-commit) and regles-validation-detail.md H.3
+          ("verification pre-commit obligatoire"). Repo-wide --check exit 0 on
+          current main (all null-exec notebooks are legitimately tolerated).
+        entry: python scripts/notebook_tools/check_null_exec.py
+        language: system
+        pass_filenames: true
         files: '\.ipynb$'
         stages: [pre-commit]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,39 @@ python scripts/notebook_tools/notebook_tools.py execute <path>
 python scripts/notebook_tools/notebook_tools.py analyze <path>
 ```
 
+### Hooks pre-commit (securite + H.3)
+
+Le depot embarque un harnais `pre-commit` (`.pre-commit-config.yaml`) qui
+intercepte les problemes **au commit**, avant qu'un secret ou un notebook
+non-execute n'entre dans l'historique :
+
+- **gitleaks** (scanner de secrets) — un secret est arrete localement (edition,
+  zero trace) plutot qu'apres le push (ou sa rotation devient obligatoire).
+- **H.3 `check-null-exec`** — refuse un notebook dont une cellule code a
+  `execution_count: null` + `outputs: []` (re-utilise les memes tolerances que
+  le gate CI : kernels lean, QC Cloud, `metadata.pii_no_output`).
+- hooks de strip (banniere probeAddresses, chemin cache NuGet, chemins
+  papermill) + garde de rendu markdown.
+
+Ces hooks sont **declare mais inactifs** tant que `pre-commit` n'est pas
+installe. Activation idempotente (a faire une fois par machine) :
+
+```bash
+python scripts/setup_hooks.py            # installe pre-commit + wire le hook + warm gitleaks
+python scripts/setup_hooks.py --check    # releve d'etat de la machine (harnais actif ?)
+python scripts/setup_hooks.py --check-parity  # hooks declares vs executables
+```
+
+Verifier que le harnais arrete bien un faux secret :
+
+```bash
+echo 'AKIA000TEST000KEY000A' > /tmp/fake_secret.txt && git add /tmp/fake_secret.txt
+git commit -m "test"   # doit echouer : gitleaks detecte le faux secret
+git reset /tmp/fake_secret.txt && rm /tmp/fake_secret.txt
+```
+
+Execution manuelle sur tout le depot : `python -m pre_commit run --all-files`.
+
 ### Conventions notebooks
 
 - **Pas d'erreur volontaire** : `raise NotImplementedError`, `assert False`, `1/0` sont interdits. Les cellules d'exercice utilisent `pass`, `print("Exercice a completer")`, ou `return None`

--- a/scripts/notebook_tools/check_null_exec.py
+++ b/scripts/notebook_tools/check_null_exec.py
@@ -17,6 +17,10 @@ execution is also impossible or unsafe, reusing the canonical predicates from
     GradeBook.ipynb, where empty outputs are the compliant state; running it
     locally would leak student PII, #8830).
 
+A code cell whose source is empty or only comments (Python ``#`` / C-family
+``//``) is also skipped: it is a transition/explanation cell, not an
+executable one -- flagging it would be a false positive.
+
 .NET Interactive is deliberately NOT tolerated: ``dotnet-interactive`` runs on
 every worker, so a committed .NET cell MUST carry a real execution_count (cf.
 the Tweety-3 incident, PRs #5194/#5199/#5202 merged at null+empty).
@@ -25,8 +29,10 @@ Usage -- pre-commit (``pass_filenames: true``):
     python scripts/notebook_tools/check_null_exec.py <staged.ipynb> [...]
 
 Standalone:
-    python scripts/notebook_tools/check_null_exec.py --all     # whole-repo scan
-    python scripts/notebook_tools/check_null_exec.py --check   # CI parity (exit 1)
+    python scripts/notebook_tools/check_null_exec.py --all      # whole-repo scan
+    python scripts/notebook_tools/check_null_exec.py --check    # CI parity (exit 1)
+    python scripts/notebook_tools/check_null_exec.py --explain  # rule summary
+    python scripts/notebook_tools/check_null_exec.py --verbose <nb.ipynb>  # per-nb
 
 See #9888 (inert pre-commit harness) and
 docs/reference/regles-validation-detail.md (H.3 -- "verification pre-commit
@@ -75,6 +81,35 @@ def _is_null_unexecuted(cell: dict) -> bool:
     return not outputs
 
 
+def _cell_source_str(cell: dict) -> str:
+    """Normalize a cell's ``source`` (list or str, per nbformat) to a string."""
+    src = cell.get("source", "")
+    if isinstance(src, list):
+        return "".join(src)
+    return src or ""
+
+
+def _is_skippable_comment_only(source: str) -> bool:
+    """True if cell ``source`` is empty or only Python ``#`` / C-family ``//``
+    comment lines.
+
+    Such a cell is a transition/explanation cell mis-authored as code, not an
+    executable one -- flagging its null execution would be a false positive
+    (mirrors ``check_c2_compliance.py``'s tolerance).
+    """
+    stripped = source.strip()
+    if not stripped:
+        return True
+    for line in stripped.splitlines():
+        s = line.strip()
+        if not s:
+            continue
+        if s.startswith("#") or s.startswith("//"):
+            continue
+        return False
+    return True
+
+
 def scan_notebook(nb_path: Path) -> list[str]:
     """Return a list of violation messages for ``nb_path`` (empty if clean).
 
@@ -111,6 +146,8 @@ def scan_notebook(nb_path: Path) -> list[str]:
 
     violations: list[str] = []
     for idx, cell in _code_cells(data):
+        if _is_skippable_comment_only(_cell_source_str(cell)):
+            continue
         if _is_null_unexecuted(cell):
             violations.append(
                 f"{rel_path}: cell {idx} code "
@@ -149,24 +186,51 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="CI parity mode: whole-repo scan, exit 1 if any violation.",
     )
+    parser.add_argument(
+        "--explain",
+        action="store_true",
+        help="Print the rule summary and exit (no scan).",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Emit a per-notebook OK/FAIL line on stderr.",
+    )
     args = parser.parse_args(argv)
+
+    if args.explain:
+        print(__doc__)
+        return 0
 
     targets = _collect_targets(args)
     if not targets:
         return 0
 
-    all_violations: list[str] = []
+    # Scan each notebook, keeping per-notebook results for --verbose.
+    per_notebook: list[tuple[Path, list[str]]] = []
     for nb_path in targets:
-        all_violations.extend(scan_notebook(nb_path))
+        per_notebook.append((nb_path, scan_notebook(nb_path)))
+    all_violations = [v for _, vs in per_notebook for v in vs]
+
+    if args.verbose:
+        for nb_path, vs in per_notebook:
+            if vs:
+                print(f"FAIL {nb_path}", file=sys.stderr)
+                for v in vs:
+                    print(f"  - {v}", file=sys.stderr)
+            else:
+                print(f"OK   {nb_path}", file=sys.stderr)
 
     if all_violations:
-        print(
-            f"H.3 pre-commit: {len(all_violations)} un-executed cell(s) "
-            f"refused (execution_count=null + outputs=[]):",
-            file=sys.stderr,
-        )
-        for v in all_violations:
-            print(f"  - {v}", file=sys.stderr)
+        if not args.verbose:
+            print(
+                f"H.3 pre-commit: {len(all_violations)} un-executed cell(s) "
+                f"refused (execution_count=null + outputs=[]):",
+                file=sys.stderr,
+            )
+            for v in all_violations:
+                print(f"  - {v}", file=sys.stderr)
         print(
             "Re-execute the notebook locally and re-stage, or (QC Cloud / "
             "lean) the notebook is auto-tolerated -- check the kernel.",
@@ -174,8 +238,9 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    scanned = len(targets)
-    print(f"H.3 pre-commit: {scanned} notebook(s) OK (no null+empty code cell).")
+    if not args.verbose:
+        scanned = len(targets)
+        print(f"H.3 pre-commit: {scanned} notebook(s) OK (no null+empty code cell).")
     return 0
 
 

--- a/scripts/notebook_tools/check_null_exec.py
+++ b/scripts/notebook_tools/check_null_exec.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""H.3 pre-commit hook: refuse un-executed notebooks at commit time.
+
+Scans .ipynb files for code cells with ``execution_count == null`` AND empty
+``outputs`` -- a C.2/H.3 violation (a committed notebook must prove it ran).
+Exits 1 if any such cell is found, 0 otherwise.
+
+A null ``execution_count`` is TOLERATED (not a violation) exactly where local
+execution is also impossible or unsafe, reusing the canonical predicates from
+``validate_pr_notebooks.py`` (single source of truth -- no divergence):
+
+  - lean kernels (``ALLOW_NULL_EXEC_COUNT_KERNELS``: lean4 / lean4-wsl / lean),
+  - QC Cloud notebooks (``_is_qc_cloud``: QC path fast-path, ``qc_reference``
+    metadata flag, or a cell instantiating ``QuantBook()`` -- the QuantBook
+    runtime exists on no worker machine),
+  - PII-governed notebooks (``metadata.pii_no_output: true`` -- e.g.
+    GradeBook.ipynb, where empty outputs are the compliant state; running it
+    locally would leak student PII, #8830).
+
+.NET Interactive is deliberately NOT tolerated: ``dotnet-interactive`` runs on
+every worker, so a committed .NET cell MUST carry a real execution_count (cf.
+the Tweety-3 incident, PRs #5194/#5199/#5202 merged at null+empty).
+
+Usage -- pre-commit (``pass_filenames: true``):
+    python scripts/notebook_tools/check_null_exec.py <staged.ipynb> [...]
+
+Standalone:
+    python scripts/notebook_tools/check_null_exec.py --all     # whole-repo scan
+    python scripts/notebook_tools/check_null_exec.py --check   # CI parity (exit 1)
+
+See #9888 (inert pre-commit harness) and
+docs/reference/regles-validation-detail.md (H.3 -- "verification pre-commit
+obligatoire").
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Reuse the canonical predicates so this hook never diverges from the CI/PR
+# gate (validate_pr_notebooks.py). Same package -> direct import.
+from validate_pr_notebooks import (  # noqa: E402
+    ALLOW_NULL_EXEC_COUNT_KERNELS,
+    PII_NO_OUTPUT_KEY,
+    REPO_ROOT,
+    _is_qc_cloud,
+    get_kernel_name,
+)
+
+__all__ = ["scan_notebook", "main"]
+
+
+def _code_cells(data: dict) -> list[tuple[int, dict]]:
+    """Yield (index, cell) for code cells in notebook JSON ``data``."""
+    out = []
+    for i, cell in enumerate(data.get("cells", [])):
+        if cell.get("cell_type") == "code":
+            out.append((i, cell))
+    return out
+
+
+def _is_null_unexecuted(cell: dict) -> bool:
+    """True if a code cell has execution_count == null AND empty outputs.
+
+    This is the precise C.2/H.3 violation: the cell never ran (no count) and
+    produced nothing (no outputs). A cell with outputs but a null count, or a
+    count but empty outputs, is not this violation (handled elsewhere).
+    """
+    if cell.get("execution_count") is not None:
+        return False
+    outputs = cell.get("outputs", [])
+    return not outputs
+
+
+def scan_notebook(nb_path: Path) -> list[str]:
+    """Return a list of violation messages for ``nb_path`` (empty if clean).
+
+    A notebook is clean if every code cell has a non-null execution_count, OR
+    its kernel/runtime makes local execution impossible (lean / QC Cloud).
+    """
+    try:
+        data = json.loads(nb_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError) as exc:
+        # Unparseable notebook: report as a violation (the worker should see it
+        # before commit), but do not crash the hook.
+        return [f"{nb_path}: cannot parse ({exc.__class__.__name__})"]
+
+    kernel = get_kernel_name(nb_path)
+    try:
+        rel_path = str(nb_path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        rel_path = str(nb_path)
+
+    # Tolerated-null runtimes: local execution is also impossible or unsafe, so
+    # a null count is not worker negligence. Three declared carve-outs, matching
+    # validate_pr_notebooks.py exactly (allow_null_exec_count predicate):
+    #   - lean kernels (rendering subtleties, local install not universal),
+    #   - QC Cloud notebooks (QuantBook runtime on no worker machine),
+    #   - PII-governed notebooks (metadata.pii_no_output: true -- e.g.
+    #     GradeBook.ipynb, whose empty outputs are the COMPLIANT state: running
+    #     it locally would leak student PII to a public repo, #8830).
+    if any(k in kernel for k in ALLOW_NULL_EXEC_COUNT_KERNELS):
+        return []
+    if _is_qc_cloud(rel_path, data):
+        return []
+    if data.get("metadata", {}).get(PII_NO_OUTPUT_KEY) is True:
+        return []
+
+    violations: list[str] = []
+    for idx, cell in _code_cells(data):
+        if _is_null_unexecuted(cell):
+            violations.append(
+                f"{rel_path}: cell {idx} code "
+                f"(kernel={kernel}) execution_count=null + outputs=[] "
+                f"-- H.3 violation (execute the cell before commit)"
+            )
+    return violations
+
+
+def _collect_targets(args: argparse.Namespace) -> list[Path]:
+    """Resolve the list of notebooks to scan from CLI args."""
+    if args.all or args.check:
+        root = Path(__file__).resolve().parents[2]
+        return sorted(root.rglob("*.ipynb"))
+    paths = [Path(p) for p in args.files]
+    # Filter to .ipynb that exist (pre-commit may pass deleted files).
+    return [p for p in paths if p.suffix == ".ipynb" and p.exists()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="H.3 pre-commit hook: refuse un-executed notebooks."
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Notebook paths to check (pre-commit passes staged files).",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Scan every .ipynb in the repo (standalone audit).",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="CI parity mode: whole-repo scan, exit 1 if any violation.",
+    )
+    args = parser.parse_args(argv)
+
+    targets = _collect_targets(args)
+    if not targets:
+        return 0
+
+    all_violations: list[str] = []
+    for nb_path in targets:
+        all_violations.extend(scan_notebook(nb_path))
+
+    if all_violations:
+        print(
+            f"H.3 pre-commit: {len(all_violations)} un-executed cell(s) "
+            f"refused (execution_count=null + outputs=[]):",
+            file=sys.stderr,
+        )
+        for v in all_violations:
+            print(f"  - {v}", file=sys.stderr)
+        print(
+            "Re-execute the notebook locally and re-stage, or (QC Cloud / "
+            "lean) the notebook is auto-tolerated -- check the kernel.",
+            file=sys.stderr,
+        )
+        return 1
+
+    scanned = len(targets)
+    print(f"H.3 pre-commit: {scanned} notebook(s) OK (no null+empty code cell).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Idempotent installer for the CoursIA pre-commit harness.
+
+The repo ships a ``.pre-commit-config.yaml`` (gitleaks secret scanner +
+notebook hygiene/strip hooks + the H.3 null-exec guard), but nothing installs
+it: on every worker machine measured (myia-ai-01, myia-po-2024) ``pre-commit``
+is absent and ``.git/hooks/pre-commit`` does not exist, so the declared hooks
+are **decorative** -- they never run. See #9888.
+
+This script is the *organe d'installation* the issue asks for ("pas une
+consigne"): it installs pre-commit, wires the hook into ``.git/hooks/``, warms
+the gitleaks cache, and verifies -- idempotently (a second run is a no-op).
+
+Usage:
+    python scripts/setup_hooks.py              # install (idempotent)
+    python scripts/setup_hooks.py --check      # machine state relevé (no changes)
+    python scripts/setup_hooks.py --check-parity  # declared hooks vs executable
+
+Design notes:
+  - Invokes pre-commit as ``python -m pre_commit`` (no PATH dependency: pip
+    installs the module, the -m flag finds it without refreshing the shell).
+  - gitleaks is fetched by pre-commit into its own cache on first run; it is
+    NOT placed on the system PATH (pre-commit's design). The hook works
+    regardless -- the proof is that a fake secret is refused at commit, not
+    that ``command -v gitleaks`` resolves. See acceptance #2 of #9888.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def find_repo_root(start: Path | None = None) -> Path:
+    """Walk upward from ``start`` (default: this file's parents) to the repo
+    root -- the first directory containing a ``.git`` entry."""
+    cwd = (start or Path(__file__).resolve()).resolve()
+    for candidate in [cwd, *cwd.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    raise SystemExit(
+        "setup_hooks: could not locate repo root (.git not found upward "
+        f"from {cwd}). Run from inside the CoursIA checkout."
+    )
+
+
+def _run(cmd: list[str], cwd: Path) -> tuple[int, str]:
+    """Run ``cmd`` in ``cwd``, return (returncode, combined trimmed output)."""
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        shell=False,
+    )
+    out = (proc.stdout + proc.stderr).strip()
+    return proc.returncode, out
+
+
+def _hooks_dir(repo: Path) -> Path:
+    """Resolve the hooks directory git actually uses.
+
+    Honors ``core.hooksPath`` if set (this repo sets it, shared across all 38
+    worktrees); otherwise falls back to ``git rev-parse --git-path hooks`` (which
+    correctly resolves through a worktree's ``.git`` file to the main gitdir).
+    Avoids the naive ``repo/.git/hooks`` that breaks under worktrees.
+    """
+    hp = subprocess.run(
+        ["git", "config", "core.hooksPath"], cwd=str(repo),
+        capture_output=True, text=True,
+    ).stdout.strip()
+    if hp:
+        p = Path(hp)
+        return p if p.is_absolute() else (repo / p)
+    g = subprocess.run(
+        ["git", "rev-parse", "--git-path", "hooks"], cwd=str(repo),
+        capture_output=True, text=True,
+    ).stdout.strip()
+    return (repo / g).resolve() if g else repo / ".git" / "hooks"
+
+
+def _pre_commit_available(python: str) -> bool:
+    rc, _ = _run([python, "-m", "pre_commit", "--version"], Path.cwd())
+    return rc == 0
+
+
+def _install_pre_commit(python: str) -> bool:
+    """pip install pre-commit (user site). Returns True on success."""
+    print("setup_hooks: installing pre-commit (pip install --user) ...")
+    rc, out = _run(
+        [python, "-m", "pip", "install", "--user", "--quiet", "pre-commit"],
+        Path.cwd(),
+    )
+    if rc != 0:
+        print(f"setup_hooks: pip install failed (rc={rc}):\n{out}", file=sys.stderr)
+        return False
+    return _pre_commit_available(python)
+
+
+def cmd_install(repo: Path, python: str) -> int:
+    """Idempotent: ensure pre-commit installed, hook wired, gitleaks warmed."""
+    steps_ok = True
+
+    # Step 1: pre-commit module available.
+    if _pre_commit_available(python):
+        rc, ver = _run([python, "-m", "pre_commit", "--version"], repo)
+        print(f"setup_hooks: pre-commit already available ({ver}).")
+    else:
+        if not _install_pre_commit(python):
+            steps_ok = False
+        else:
+            rc, ver = _run([python, "-m", "pre_commit", "--version"], repo)
+            print(f"setup_hooks: pre-commit installed ({ver}).")
+
+    if not steps_ok:
+        return 1
+
+    # Step 2: wire the hook into the git hooks directory.
+    # pre-commit refuses to install when core.hooksPath is set (a safety guard).
+    # This repo sets core.hooksPath (redundantly == gitdir/hooks, shared across
+    # worktrees). Handle it: capture where git LOOKS for hooks, temporarily
+    # unset hooksPath so pre-commit cooperates, then ensure the generated hook
+    # lands where git actually reads it. Restore hooksPath afterwards.
+    target_hooks = _hooks_dir(repo)  # where git reads hooks (honors core.hooksPath)
+    saved_hookspath = subprocess.run(
+        ["git", "config", "core.hooksPath"], cwd=str(repo),
+        capture_output=True, text=True,
+    ).stdout.strip()
+    hook_path = target_hooks / "pre-commit"
+    if saved_hookspath:
+        subprocess.run(
+            ["git", "config", "--unset-all", "core.hooksPath"], cwd=str(repo),
+            capture_output=True, text=True,
+        )
+    try:
+        rc, out = _run([python, "-m", "pre_commit", "install"], repo)
+    finally:
+        if saved_hookspath:
+            subprocess.run(
+                ["git", "config", "core.hooksPath", saved_hookspath], cwd=str(repo),
+                capture_output=True, text=True,
+            )
+    # pre-commit writes to gitdir/hooks (its resolved git-path hooks). If git
+    # reads hooks from a different dir (core.hooksPath), mirror it there.
+    gitdir_hooks_rel = subprocess.run(
+        ["git", "rev-parse", "--git-path", "hooks"], cwd=str(repo),
+        capture_output=True, text=True,
+    ).stdout.strip()
+    gitdir_precommit = (repo / gitdir_hooks_rel).resolve() / "pre-commit"
+    if rc == 0:
+        # If pre-commit wrote to gitdir/hooks but git reads target_hooks, copy.
+        if gitdir_precommit != hook_path and gitdir_precommit.exists():
+            target_hooks.mkdir(parents=True, exist_ok=True)
+            hook_path.write_bytes(gitdir_precommit.read_bytes())
+        if hook_path.exists():
+            print(f"setup_hooks: hook wired -> {hook_path}")
+        else:
+            print(f"setup_hooks: pre-commit install rc=0 but {hook_path} missing")
+            steps_ok = False
+    else:
+        if hook_path.exists():
+            print(f"setup_hooks: hook already wired -> {hook_path}")
+        else:
+            print(f"setup_hooks: pre-commit install failed:\n{out}", file=sys.stderr)
+            steps_ok = False
+
+    # Step 3: warm the gitleaks cache (download the binary on a harmless file).
+    rc, out = _run(
+        [python, "-m", "pre_commit", "run", "gitleaks",
+         "--files", ".pre-commit-config.yaml"],
+        repo,
+    )
+    # gitleaks returns 0 when no secrets found; a nonzero here after a fresh
+    # fetch usually means the binary downloaded fine but the probe file tripped
+    # something unexpected -- surface it but do not fail install.
+    if rc == 0:
+        print("setup_hooks: gitleaks warmed (cache populated, probe clean).")
+    else:
+        print(
+            f"setup_hooks: gitleaks warm-up rc={rc} (cache may still populate "
+            f"on first real run):\n{out[:300]}",
+            file=sys.stderr,
+        )
+
+    # Step 4: verify.
+    if hook_path.exists() and _pre_commit_available(python):
+        print("\nsetup_hooks: OK. pre-commit harness is active.")
+        print("  Next: `git commit` now runs gitleaks + notebook hygiene + H.3.")
+        print("  Manual: python -m pre_commit run --all-files")
+        return 0
+    return 1
+
+
+def cmd_check(repo: Path, python: str) -> int:
+    """Print machine-state relevé (no changes). For the per-lane report #9888."""
+    print(f"# Pre-commit harness relevé — {repo.name}")
+    pc = shutil.which("pre-commit")
+    gl = shutil.which("gitleaks")
+    pc_mod = _pre_commit_available(python)
+    rc, ver = (None, None)
+    if pc_mod:
+        rc, ver = _run([python, "-m", "pre_commit", "--version"], repo)
+    hook = _hooks_dir(repo) / "pre-commit"
+    hooks_dir = _hooks_dir(repo)
+    installed_hooks = (
+        sorted(p.name for p in hooks_dir.iterdir() if not p.name.endswith(".sample"))
+        if hooks_dir.exists() else []
+    )
+    print(f"pre-commit on PATH      : {pc or 'ABSENT'}")
+    print(f"pre-commit module (-m)  : {'available' if pc_mod else 'ABSENT'}" + (f" ({ver})" if ver else ""))
+    print(f"gitleaks on PATH        : {gl or 'ABSENT (pre-commit manages it in its cache)'}")
+    print(f"core.hooksPath          : {subprocess.run(['git','config','core.hooksPath'], capture_output=True, text=True).stdout.strip() or '(unset → default .git/hooks)'}")
+    print(f"git hooks/pre-commit    : {'EXISTS' if hook.exists() else 'MISSING (run setup_hooks.py)'}")
+    print(f"hooks dir installed     : {', '.join(installed_hooks) or '(only samples)'}")
+    # Exit 0 if harness active, 1 otherwise (useful for fleet audit scripting).
+    return 0 if (pc_mod and hook.exists()) else 1
+
+
+def cmd_check_parity(repo: Path, python: str) -> int:
+    """Compare declared hooks (.pre-commit-config.yaml) vs executable state."""
+    cfg = repo / ".pre-commit-config.yaml"
+    if not cfg.exists():
+        print(f"setup_hooks: {cfg} not found", file=sys.stderr)
+        return 1
+    text = cfg.read_text(encoding="utf-8")
+    declared = re.findall(r"^\s*-\s+id:\s*(\S+)", text, re.MULTILINE)
+    print(f"Declared hooks ({len(declared)}): {', '.join(declared)}")
+
+    # validate-config: confirms the YAML parses and external repos fetch.
+    rc, out = _run([python, "-m", "pre_commit", "validate-config", str(cfg)], repo)
+    print(f"validate-config         : {'PASS (all declared hooks fetch/parse)' if rc == 0 else f'FAIL rc={rc}'}")
+    if rc != 0:
+        print(out[:500], file=sys.stderr)
+
+    # Which local-hook entry scripts exist on disk?
+    print("Local hook entry scripts:")
+    for m in re.finditer(r"-\s+id:\s*(\S+).*?entry:\s*([^\n]+)", text, re.S):
+        hid, entry = m.group(1), m.group(2).strip()
+        # entry like "python scripts/notebook_tools/strip_probe_banner.py --apply"
+        parts = entry.split()
+        script = next((p for p in parts if p.endswith(".py")), None)
+        if script:
+            exists = (repo / script).exists()
+            print(f"  {hid:32} -> {script} [{'EXISTS' if exists else 'MISSING'}]")
+    return 0 if rc == 0 else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Idempotent installer for the CoursIA pre-commit harness (#9888)."
+    )
+    p.add_argument("--install", action="store_true", default=True,
+                   help="Install pre-commit + wire hook + warm gitleaks (default; idempotent).")
+    p.add_argument("--check", action="store_true",
+                   help="Print machine-state relevé (no changes). Exit 1 if harness inactive.")
+    p.add_argument("--check-parity", action="store_true",
+                   help="Compare declared hooks vs executable state.")
+    # Allow a plain `--check`/`--check-parity` without implying install.
+    args = p.parse_args(argv)
+
+    repo = find_repo_root()
+    python = sys.executable
+
+    if args.check_parity:
+        return cmd_check_parity(repo, python)
+    if args.check:
+        return cmd_check(repo, python)
+    return cmd_install(repo, python)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_null_exec.py
+++ b/scripts/tests/test_check_null_exec.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Tests for the H.3 null-exec pre-commit hook (notebook_tools/check_null_exec.py).
+
+Adapted from the CoursIA-2 lane sub-grain (#9894) to the canonical
+implementation in #9895: that impl reuses the ``validate_pr_notebooks.py``
+predicates (lean / QC Cloud / PII carve-outs) and exposes positional files
+(how pre-commit passes them) plus ``--all`` / ``--check`` / ``--explain`` /
+``--verbose``. These tests drive it the way pre-commit does -- with positional
+notebook paths -- and assert its actual messages.
+
+Covers:
+  - clean notebook (executed cells) -> exit 0
+  - one H.3 violation (execution_count=null + outputs=[]) -> exit 1
+  - comment-only / empty code cell skipped (NOT a violation)
+  - PII carve-out (metadata.pii_no_output=true) absorbs null+empty cells
+  - a cell with null count BUT outputs present is out of H.3 scope -> exit 0
+  - unparseable notebook reported (cannot parse) -> exit 1
+  - mixed clean + violation across two files -> exit 1
+  - --explain prints the rule summary -> exit 0
+  - --verbose emits a per-notebook OK/FAIL line -> exit 1, both tags present
+
+Run:
+    python -m pytest scripts/tests/test_check_null_exec.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Script under test (scripts/notebook_tools/check_null_exec.py).
+SCRIPT = Path(__file__).resolve().parent.parent / "notebook_tools" / "check_null_exec.py"
+
+
+def _mk_nb(tmp_path: Path, name: str, cells: list[dict], metadata: dict | None = None) -> Path:
+    p = tmp_path / name
+    payload = {"cells": cells, "metadata": metadata or {}}
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+def _code_cell(source: str, execution_count=None, outputs=None) -> dict:
+    return {
+        "cell_type": "code",
+        "source": source,
+        "metadata": {},
+        "execution_count": execution_count,
+        "outputs": outputs if outputs is not None else [],
+    }
+
+
+def _md_cell(source: str) -> dict:
+    return {"cell_type": "markdown", "source": source, "metadata": {}}
+
+
+def _run(*extra: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *extra],
+        capture_output=True,
+        text=True,
+    )
+
+
+# --- the strict H.3 rule ---
+
+
+def test_clean_notebook(tmp_path: Path):
+    nb = _mk_nb(
+        tmp_path,
+        "ok.ipynb",
+        [
+            _md_cell("# title"),
+            _code_cell("x = 1", execution_count=1, outputs=[{"text": "ok"}]),
+            _code_cell("y = 2", execution_count=2, outputs=[{"text": "ok"}]),
+        ],
+    )
+    res = _run(str(nb))
+    assert res.returncode == 0, f"unexpected fail: {res.stderr}"
+
+
+def test_h3_violation(tmp_path: Path):
+    nb = _mk_nb(
+        tmp_path,
+        "bad.ipynb",
+        [_code_cell("x = 1", execution_count=None, outputs=[])],
+    )
+    res = _run(str(nb))
+    assert res.returncode == 1
+    # Canonical message (#9895): "N un-executed cell(s) refused".
+    assert "un-executed cell(s)" in res.stderr
+    assert "execution_count=null + outputs=[]" in res.stderr
+
+
+def test_mixed_clean_and_violation(tmp_path: Path):
+    ok = _mk_nb(tmp_path, "ok.ipynb", [_code_cell("x = 1", execution_count=1, outputs=[{"t": 1}])])
+    bad = _mk_nb(tmp_path, "bad.ipynb", [_code_cell("y = 2", execution_count=None, outputs=[])])
+    res = _run(str(ok), str(bad))
+    assert res.returncode == 1
+    assert "1 un-executed cell(s)" in res.stderr
+
+
+# --- the carve-outs / tolerances ---
+
+
+def test_comment_only_cell_skipped(tmp_path: Path):
+    """A code cell whose source is only comments is not executable -> skipped."""
+    nb = _mk_nb(
+        tmp_path,
+        "comments.ipynb",
+        [
+            _code_cell("# TODO: explanation only", execution_count=None, outputs=[]),
+            _code_cell("// C# comment-only", execution_count=None, outputs=[]),
+            _code_cell("x = 1", execution_count=1, outputs=[{"text": "ok"}]),
+        ],
+    )
+    res = _run(str(nb))
+    assert res.returncode == 0, f"comment-only cells must be skipped: {res.stderr}"
+
+
+def test_empty_code_cell_skipped(tmp_path: Path):
+    """An empty source code cell is not executable -> skipped."""
+    nb = _mk_nb(
+        tmp_path,
+        "empty.ipynb",
+        [_code_cell("", execution_count=None, outputs=[])],
+    )
+    res = _run(str(nb))
+    assert res.returncode == 0, f"empty cell must be skipped: {res.stderr}"
+
+
+def test_pii_carve_out_absorbs_violations(tmp_path: Path):
+    """metadata.pii_no_output=true: empty outputs are the compliant state."""
+    nb = _mk_nb(
+        tmp_path,
+        "pii.ipynb",
+        [
+            _code_cell("x = 1", execution_count=None, outputs=[]),
+            _code_cell("y = 2", execution_count=None, outputs=[]),
+        ],
+        metadata={"pii_no_output": True},
+    )
+    res = _run(str(nb))
+    assert res.returncode == 0, f"PII carve-out must absorb: {res.stderr}"
+
+
+def test_violation_with_outputs_is_not_flagged(tmp_path: Path):
+    """execution_count=null BUT outputs != [] is OUT OF H.3 SCOPE.
+
+    H.3 mandates BOTH conditions (null count AND empty outputs). A cell with
+    cleared outputs on a real run is unusual but distinct from null-exec.
+    """
+    nb = _mk_nb(
+        tmp_path,
+        "weird.ipynb",
+        [_code_cell("x = 1", execution_count=None, outputs=[{"text": "ok"}])],
+    )
+    res = _run(str(nb))
+    assert res.returncode == 0, f"outputs-present must be out of scope: {res.stderr}"
+
+
+def test_dotnet_comment_cell_skipped(tmp_path: Path):
+    """C#/.NET-Interactive-shaped comment cell is skipped; a real cell must run."""
+    nb = _mk_nb(
+        tmp_path,
+        "csharp.ipynb",
+        [
+            _code_cell("// TODO: real C# later", execution_count=None, outputs=[]),
+            _code_cell('Console.WriteLine("ok");', execution_count=1, outputs=[{"text": "ok"}]),
+        ],
+    )
+    res = _run(str(nb))
+    assert res.returncode == 0, f"dotnet comment cell must be skipped: {res.stderr}"
+
+
+# --- operational robustness ---
+
+
+def test_parse_error_reported(tmp_path: Path):
+    """A non-JSON notebook is reported (cannot parse), refusing the commit."""
+    nb = tmp_path / "broken.ipynb"
+    nb.write_text("not-a-json", encoding="utf-8")
+    res = _run(str(nb))
+    assert res.returncode == 1
+    assert "cannot parse" in res.stderr
+
+
+def test_no_targets_is_clean():
+    """No files passed -> exit 0 (pre-commit with no staged notebooks)."""
+    res = _run()
+    assert res.returncode == 0
+
+
+# --- CLI ergonomics ---
+
+
+def test_explain_prints_rule(tmp_path: Path):
+    res = _run("--explain")
+    assert res.returncode == 0
+    assert "H.3" in res.stdout
+
+
+def test_verbose_emits_per_notebook(tmp_path: Path):
+    ok = _mk_nb(tmp_path, "ok.ipynb", [_code_cell("x = 1", execution_count=1, outputs=[{"t": 1}])])
+    bad = _mk_nb(tmp_path, "bad.ipynb", [_code_cell("y = 2", execution_count=None, outputs=[])])
+    res = _run("--verbose", str(ok), str(bad))
+    assert res.returncode == 1, f"unexpected pass: {res.stderr}"
+    assert "OK" in res.stderr and "FAIL" in res.stderr, (
+        f"expected OK + FAIL on stderr, got: {res.stderr}"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: DEEP/training #9881

## Ce que fait cette PR

Le dépôt **déclarait** un harnais pre-commit (`.pre-commit-config.yaml` : gitleaks + 4 hooks notebook strip/render) mais **rien ne l'installait** : sur chaque machine mesurée (myia-ai-01, myia-po-2024) `pre-commit` était absent et `.git/hooks/pre-commit` n'existait pas — les hooks étaient **décoratifs**, jamais exécutés.

Pire : `.gitleaks.toml` ne portait qu'un `[allowlist]`, **aucune `[[rules]]` ni `[extend]`** → gitleaks ne matchait **rien**. Le scanner de secrets était un **no-op silencieux** à la fois dans le hook pre-commit **ET** dans la CI (`secret-scan.yml` set `GITLEAKS_CONFIG=.gitleaks.toml`). Voir #9888.

## 5 livrables

1. **`scripts/setup_hooks.py`** — organe d'installation idempotent (mandat #9888 « pas une consigne ») : `pip install pre-commit`, wire le hook en honorant `core.hooksPath`/worktrees (pré-commit refuse d'installer quand hooksPath est set — géré), warm le cache gitleaks. + `--check` (relevé machine) + `--check-parity` (hooks déclarés vs exécutables).
2. **`scripts/notebook_tools/check_null_exec.py`** — le hook H.3 que `regles-validation-detail.md` L40 mandate (« vérification pre-commit obligatoire ») mais que le config n'avait pas : refuse les cellules code `execution_count: null` + `outputs: []`. **Réutilise les prédicats canoniques** de `validate_pr_notebooks.py` (source unique, pas de divergence : kernels lean, QC Cloud via `_is_qc_cloud`, `metadata.pii_no_output`). Ne bloque jamais un notebook légitimement toléré.
3. **`.gitleaks.toml`** — `[extend] useDefault = true` (**une ligne**) restaure les 700+ détecteurs built-in (AWS/GitHub/Google/…) tout en gardant l'allowlist custom. **Corrige le no-op fleet-wide** (pre-commit **ET** CI).
4. **`.pre-commit-config.yaml`** — câble `check-null-exec` ; retire les `args:['detect','--no-git','--redact']` stale qui s'appendaient à l'entry canonique `gitleaks protect --staged` et faisaient crasher (« unknown flag »).
5. **`CONTRIBUTING.md`** — section dev-setup (activation idempotente + probe secret).

## Acceptance vérifiée firsthand sur myia-po-2024

| # | Acceptance | Preuve |
|---|---|---|
| 1 | `command -v pre-commit` renvoie un chemin | `pre-commit 4.6.1` installé (`python -m pre_commit --version`). NB : non sur le shell PATH (pip `--user` Scripts), mais le module marche via `python -m` — c'est ce que `setup_hooks.py` utilise partout. |
| 2 | `.git/hooks/pre-commit` existe + faux secret refusé au commit | `setup_hooks.py` wire le hook → `C:\dev\CoursIA\.git\hooks\pre-commit`. **Commit d'un faux token `ghp_9KqM3jR7...` = BLOCKED** (`Secret scanner (gitleaks)…Failed`, exit 1). |
| 3 | notebook `execution_count:null`+`outputs:[]` refusé au commit | Probe notebook créé → **REFUSED** (`H.3 pre-commit: 1 un-executed cell(s) refused`, exit 1). |
| 4 | script idempotent | 2ᵉ `--install` = no-op (`pre-commit already available`, hook déjà wired). |
| 5 | relevé posté par lane | [DONE] po-2024 c.V sur dashboard (relevé `--check` inclus). |

**Bonus découverte (no-op gitleaks)** : la correction `[extend] useDefault = true` rend le scanner fonctionnel **partout** (pre-commit + CI) — sans ça, n'importe quel secret (`ghp_…`, `AKIA…`) passait inaperçu depuis toujours. C'est précisément le genre de latent bug que #9888 visait à révéler.

## Périmètre / ce que la PR ne fait pas

- **Ne force pas l'installation** sur les autres machines (rôle worker = livrer l'organe, chaque lane installe via `setup_hooks.py` et poste son relevé `--check`). La sécu s'améliore machine par machine.
- **Ne set pas `push: [main]` auto-rejouer les gates par-PR** = arbitrage coût-CI/robustesse = rôle coordinateur (cf po-2026 c.958 sur #9858). Scope #9888 = rendre l'organe fonctionnel, pas le durcissement CI.
- **`detect --no-git` retiré** : l'entry canonique v8.21.2 (`protect --staged`) scanne le staged (correct pour pre-commit) ; `detect` scannerait l'historique complet (lent). Le fallback `--no-git` direct ne détectait pas de façon fiable en worktree partagé.

## Notes transparence

- Le commit initial a eu un `@` parasite en début de sujet (fuite here-string PowerShell) → **amendé** avant push (commit `b2a5d7b5cb`). Pas de force push.
- Les 5 fichiers sont nouveaux/edités chirurgicalement. Diff `+529/−2` cohérent (2 nouveaux scripts + 3 edits de config/doc).
- Aucune sortie de cellule hand-éditée (aucun notebook touché).

See #9888.
