### PR TITLE
docs(variation-protocol,#9859): §4.1 cross-lane view + coordination_budget.py pointer

### DIFF
--- a/docs/reference/variation-protocol-detail.md
+++ b/docs/reference/variation-protocol-detail.md
@@ -32,6 +32,39 @@ Le ratio `max(1, grains_mergés // 3)` garde l'intention (une lane ne peut pas �
 
 Organe : [`scripts/variation_light_cap.py`](../../scripts/variation_light_cap.py) — le budget est **calculé** (`--replay <merged.json>`), et c'est cette sortie qu'on cite dans un HOLD, jamais une estimation à l'œil.
 
+### 4.1 Vue agrégée cross-lane (per-lane, 7j)
+
+`scripts/variation_light_cap.py` répond à « *combien de LIGHT cette lane peut-elle encore merger aujourd'hui ?* » — utile au merge-gate, aveugle au cluster. La **vue d'ensemble** (où le provisionnement manque, quelles lanes en monoculture, combien de PRs sans tag) est dans [`scripts/coordination_budget.py`](../../scripts/coordination_budget.py) — sorti par #9868, vérifié sur main par #9859. Deux modes :
+
+- `--days N` (défaut 7) : live via `gh pr list --state merged --search "merged:>=YYYY-MM-DD" --json number,title,body,mergedAt,labels`.
+- `--replay <file>` : offline (test, audit historique post-mortem).
+- `--json` : sortie machine-readable (CI, post-traitement).
+- `--known-lanes a,b,c` : signale les lanes connues **idle** (sans la liste canonique, le script ne sait pas).
+
+Le script **réutilise** `parse_grain_tag` (parsing tolerant casse/décoration, voir #9485) et `effective_tier` + `light_budget` + `label_names` (voir #8970 / #8964) — pas de duplication, les bugs historiques (divergence guard/organ, requalification invisible) sont hérités gratuits. Les nombres sont **calculés**, jamais déclarés, et un tag malformé (genre `WTF/bogus`, casse mixte `gRaIn: deEp/LeAn`) **ne crashe pas** — il est signalé en anomalie avec sa PR. Le tableau par lane (DEEP / MED / LIGHT / budget / consommé / genres) est suivi d'un bloc d'anomalies : 32 sans tag, 8 sans lane, monoculture smells G-VAR-3 par lane.
+
+Sortie réelle (live, 7j, après #9734 merge) — capturée par ce PR :
+
+```
+| Lane | DEEP | MED | LIGHT | total | budget | consumed | genres |
+|------|-----:|----:|------:|------:|-------:|---------:|--------|
+| myia-po-2024:CoursIA-2 | 5 | 39 | 6 | 57 | 19 | 6 | ... |
+| myia-po-2023:CoursIA-2 | 2 | 27 | 6 | 35 | 11 | 6 | ... |
+| myia-po-2025:CoursIA | 15 | 17 | 2 | 34 | 11 | 2 | ... |
+| myia-po-2023:CoursIA | 3 | 11 | 13 | 30 | 10 | 13  (+3 over) | ... |
+| myia-po-2025:CoursIA-2 | 8 | 19 | 0 | 27 | 9 | 0 | ... |
+| myia-ai-01:CoursIA | 9 | 11 | 6 | 26 | 8 | 6 | ... |
+| myia-po-2024:CoursIA | 11 | 12 | 1 | 24 | 8 | 1 | ... |
+| myia-po-2026:CoursIA | 3 | 15 | 1 | 19 | 6 | 1 | ... |
+| myia-po-2026:CoursIA-2 | 1 | 3 | 0 | 4 | 1 | 0 | ... |
+| myia-ai-01:LivresAgit | 0 | 2 | 0 | 2 | 1 | 0 | ... |
+| myia-po-2026:CoursIA. | 0 | 2 | 0 | 2 | 1 | 0 | ... |
+```
+
+300 PRs mergés, 40 unattributed (32 sans tag + 8 sans lane). Le tag typo `myia-po-2026:CoursIA.` (point final) — le script le sépare en lane fantôme, signal de **qualité des tags** au-delà du compteur.
+
+**Pourquoi c'est utile au-delà de la conformité** : une lane à 4 LIGHT / 0 DEEP dit « *coordinateur qui n'a pas stocké de substance pour cette lane* » (variation-protocol §4 obligation de provisionnement), pas « worker paresseux ». Le compteur rend ce diagnostic **lisible** au lieu de dépendre de la mémoire du coordinateur. C'est aussi ce qui permet la §4 règle « passer 24 h ou nommer le remplaçant » — un hold prolongé se voit en agrégat avant de devenir un doublon.
+
 ## 5. Incident fondateur du GENRE — rollout `metadata.cost` #8056 (2026-07-28)
 
 Quatre tranches d'un **seul** rollout scan-générable ont porté **trois étiquettes différentes** :


### PR DESCRIPTION
# c.9859 — coord closes: doc pointer to coordination_budget.py + live snapshot

## What this PR does

`scripts/coordination_budget.py` was shipped by PR #9868 (commit `4674f8978`), but with `See #9859` (not `Closes #9859`) — so the issue stayed OPEN. This PR closes the loop:

1. **Adds a `§4.1 Vue agrégée cross-lane`** section in `docs/reference/variation-protocol-detail.md` documenting the new organ: live mode (`--days N`), replay (`--replay`), JSON (`--json`), `--known-lanes` for idle detection. References both the script and the #9868 [#9485, #8970, #8964] lineage.
2. **Captures the live output** (7-day window, 300 merged PRs, 40 unattributed) as a frozen example in the doc — the script's value is showing real numbers, not just advertising an API.
3. **`Closes #9859`** triggers GitHub auto-close.

## Acceptance gates verified firsthand

| # | Criterion from #9859 | Status |
|---|----------------------|--------|
| 1 | `python scripts/coordination_budget.py --days 7` runs on real PRs without crash on malformed tags | **OK** — run on main `ae9720c1f`, 300 PRs scanned, 32 sans tag + 8 sans lane signalés comme anomalies, exit 0. Malformed `WTF/bogus` genre + casse `gRaIn: deEp/LeAn` testés sans crash |
| 2 | Tests with synthetic bodies covering: tag conforme, alias genre (`lean-ci`), lane absente, aucun tag | **OK** — 16/16 tests in `scripts/tests/test_coordination_budget.py` PASS in 0.13s (tag-conforme, alias-genre-aggregate, lane-missing-anomaly, no-tag-anomaly, requalification up/down, budget ratio G-VAR-2, idle-gated, replay file, JSON mode) |
| 3 | Numbers **calculated**, never declared | **OK** — every cell in the table comes from `aggregate(prs) → row[DEEP/MED/LIGHT/total/budget/consumed/genres]`, never hardcoded. Test `test_aggregate_light_budget_ratio` proves this (6 grains → budget 2) |

## Live output (run on main, 7-day window)

```
## Coordination budget -- last 7 day(s)

_300 merged PR(s), 40 unattributed._

| Lane | DEEP | MED | LIGHT | total | budget | consumed | genres |
|------|-----:|----:|------:|------:|-------:|---------:|--------|
| myia-po-2024:CoursIA-2 | 5 | 39 | 6 | 57 | 19 | 6 | docs, notebook-dotnet, notebook-python, qc, qc-tooling, readme, refactor, tooling, training |
| myia-po-2023:CoursIA-2 | 2 | 27 | 6 | 35 | 11 | 6 | docs, guard, lean, ledger, readme, research-code, tooling |
| myia-po-2025:CoursIA | 15 | 17 | 2 | 34 | 11 | 2 | code, docs, guard, ict-code, lean, notebook-python, notebook-tools, qc, readme, refactor, research, test, tooling |
| myia-po-2023:CoursIA | 3 | 11 | 13 | 30 | 10 | 13  (+3 over) | 9434-timing, anti-regression-restore, docs, drainage, notebook-csharp, notebook-markdown, notebook-python, repo-hygiene, research, script-python, tooling |
| myia-po-2025:CoursIA-2 | 8 | 19 | 0 | 27 | 9 | 0 | chore, docs, docs-ict-resync, docs-investigation, test, tooling, ... |
| myia-ai-01:CoursIA | 9 | 11 | 6 | 26 | 8 | 6 | docs, guard, lean, notebook-python, test, tooling, training |
| myia-po-2024:CoursIA | 11 | 12 | 1 | 24 | 8 | 1 | code, docs, lean, notebook-python, qc, qc-backtest, readme, refactor, test, tooling, training |
| myia-po-2026:CoursIA | 3 | 15 | 1 | 19 | 6 | 1 | chore, ci, docs, guard, lean, notebook-python, notebook-tools, test, tooling |
| myia-po-2026:CoursIA-2 | 1 | 3 | 0 | 4 | 1 | 0 | guard, lean |
| myia-ai-01:LivresAgit | 0 | 2 | 0 | 2 | 1 | 0 | docs, notebook-python |
| myia-po-2026:CoursIA. | 0 | 2 | 0 | 2 | 1 | 0 | readme |
```

Anomalies (excerpt):
- 32 PRs `variation-tag-missing` (no tag at all)
- 8 PRs `variation-tag-lane-missing` (tag but no lane)
- 3 monoculture smells G-VAR-3 (2 LIGHT same-genre consécutifs)
- Tag typo `myia-po-2026:CoursIA.` (point final) — lane fantôme, signal de qualité des tags

## Tests (16/16 green)

```
scripts/tests/test_coordination_budget.py::test_aggregate_counts_by_effective_tier PASSED
scripts/tests/test_coordination_budget.py::test_aggregate_light_budget_ratio PASSED
scripts/tests/test_coordination_budget.py::test_aggregate_budget_floor_one_for_small_lane PASSED
scripts/tests/test_coordination_budget.py::test_aggregate_consumed_tracks_effective_tier PASSED
scripts/tests/test_coordination_budget.py::test_aggregate_separates_lanes PASSED
scripts/tests/test_coordination_budget.py::test_aggregate_skips_untagged_and_no_lane PASSED
scripts/tests/test_coordination_budget.py::test_aggregate_collects_genres PASSED
scripts/tests/test_coordination_budget.py::test_anomaly_no_tag_reported PASSED
scripts/tests/test_coordination_budget.py::test_anomaly_lane_missing_reported PASSED
scripts/tests/test_coordination_budget.py::test_anomaly_same_genre_light_adjacency PASSED
scripts/tests/test_coordination_budget.py::test_anomaly_distinct_genres_no_adjacency PASSED
scripts/tests/test_coordination_budget.py::test_anomaly_idle_lane_only_with_known_list PASSED
scripts/tests/test_coordination_budget.py::test_no_anomaly_on_clean_window PASSED
scripts/tests/test_coordination_budget.py::test_load_prs_replay_reads_json_array PASSED
scripts/tests/test_coordination_budget.py::test_replay_end_to_end_via_main PASSED
scripts/tests/test_coordination_budget.py::test_json_mode_emits_machine_readable PASSED
============================= 16 passed in 0.13s ==============================
```

## Why a doc-only PR

The script is **already on main** (PR #9868). What's missing is the **doc reference** that wires `scripts/coordination_budget.py` into the variation-protocol tooling hierarchy (`scripts/variation_light_cap.py` was already documented in §4). The PR is intentionally small (1 file, +30 lines) because:

- Code is shipped — adding a second script would be needless duplication
- Doc pointer serves the **same** purpose as a `Closes #9859` keyword without violating `one-subject-per-PR` (G.4)
- The frozen example in the doc outlives the next re-run, so the doc is **evidence** at the time of merge, not an aspirational description

## L898 ★★★ collision guard (verified before any PR work)

- `gh pr list --search "coordination_budget" --state all` → PR #9868 MERGED (po-2026, script itself), no other PRs open
- `gh pr list --search "9859 in:body" --state open` → 0 PRs
- `gh issue view 9859` → OPEN, no prior `closedByPullRequestsReferences`
- Confirmed no other lane is currently shipping #9859 closure

## Cross-lane claim

`[CLAIMED] <#9859> — lane myia-po-2023:CoursIA` (comment 5218503141, server UTC, unambiguous — per `lane-claim-protocol` rule #9774).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
