### PR TITLE
Refactor(lean,#8696): Reidemeister2 surgery = field-equalities (window 4/4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
@@ -378,8 +378,8 @@ def Reidemeister2 (d₁ d₂ : KnotDiagram) : Prop :=
   d₁.wf = true ∧ d₂.wf = true ∧
   (∃ c₁ c₂ : PDCrossing,
      ∃ ρ : Fin (min d₁.numEdges d₂.numEdges) ↪ Fin (max d₁.numEdges d₂.numEdges),
-       d₂ = { d₁ with crossings := d₁.crossings ++ [c₁, c₂], numEdges := d₁.numEdges + 4 } ∨
-       d₁ = { d₂ with crossings := d₂.crossings ++ [c₁, c₂], numEdges := d₂.numEdges + 4 })
+       (d₂.crossings = d₁.crossings ++ [c₁, c₂] ∧ d₂.numEdges = d₁.numEdges + 4) ∨
+       (d₁.crossings = d₂.crossings ++ [c₁, c₂] ∧ d₁.numEdges = d₂.numEdges + 4))
 
 /-- R2 est symétrique : même construction que R1 (transport le long de
 `Nat.min_comm`/`Nat.max_comm`). -/

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister_en.lean
@@ -357,8 +357,8 @@ def Reidemeister2 (d₁ d₂ : KnotDiagram) : Prop :=
   d₁.wf = true ∧ d₂.wf = true ∧
   (∃ c₁ c₂ : PDCrossing,
      ∃ ρ : Fin (min d₁.numEdges d₂.numEdges) ↪ Fin (max d₁.numEdges d₂.numEdges),
-       d₂ = { d₁ with crossings := d₁.crossings ++ [c₁, c₂], numEdges := d₁.numEdges + 4 } ∨
-       d₁ = { d₂ with crossings := d₂.crossings ++ [c₁, c₂], numEdges := d₂.numEdges + 4 })
+       (d₂.crossings = d₁.crossings ++ [c₁, c₂] ∧ d₂.numEdges = d₁.numEdges + 4) ∨
+       (d₁.crossings = d₂.crossings ++ [c₁, c₂] ∧ d₁.numEdges = d₂.numEdges + 4))
 
 /-- R2 is symmetric: same construction as R1 (transport along `Nat.min_comm`/
 `Nat.max_comm`). -/


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA-2 — prev: DEEP/lean #9873

Quoi: Migration Reidemeister2 (L377-382 FR + L356-361 EN) depuis `with`-surgery vers field-equalities (window 4/4 #8696, dernier site corridor)
Preuve: Lake build 4/4 EXIT=0 (warm cache post-c.8166), sorry 2/2/14/9 baseline c.8166 inchangé, 0 axiome ajouté, 0 cross-file consumer (L891 ★★ sweep)
Perimetre: 2 fichiers modifiés, +4/-4 lignes, Reidemeister2.symm survit tel quel (pattern disjonction préservé)

## Refactor(lean,#8696): Reidemeister2 surgery = field-equalities (window 4/4)

Suite du chantier multi-cycle **#8696** (Reidemeister corridor field-eqs migration).
Apr&egrave;s Reidemeister1 (L91/92, **PR #9807 MERGED**), Reidemeister1' (L143/145, **PR #9807 MERGED**),
et Reidemeister1Connected (L262-272, **PR #9873 OPEN**),
la chirurgie `with`-update de **`Reidemeister2`** est remplac&eacute;e par un couple
d'&eacute;galit&eacute;s de champs sur `d&sub2;.crossings` et `d&sub2;.numEdges` dans chaque branche
de la disjonction sym&eacute;trique.

## Pattern A appliqu&eacute;

```lean
-- AVANT (record `with` surgery, par branche de la disjonction)
def Reidemeister2 (d1 d2 : KnotDiagram) : Prop :=
  d1.wf = true and d2.wf = true and
  (exists c1 c2 : PDCrossing,
     exists rho : Fin (min d1.numEdges d2.numEdges) -> Fin (max d1.numEdges d2.numEdges),
       d2 = { d1 with crossings := d1.crossings ++ [c1, c2], numEdges := d1.numEdges + 4 } or
       d1 = { d2 with crossings := d2.crossings ++ [c1, c2], numEdges := d2.numEdges + 4 })

-- APR&Egrave;S (field equalities, par branche de la disjonction)
def Reidemeister2 (d1 d2 : KnotDiagram) : Prop :=
  d1.wf = true and d2.wf = true and
  (exists c1 c2 : PDCrossing,
     exists rho : Fin (min d1.numEdges d2.numEdges) -> Fin (max d1.numEdges d2.numEdges),
       (d2.crossings = d1.crossings ++ [c1, c2] and d2.numEdges = d1.numEdges + 4) or
       (d1.crossings = d2.crossings ++ [c1, c2] and d1.numEdges = d2.numEdges + 4))
```

Pattern identique &agrave; ceux livr&eacute;s en c.8164 (PR #9807, Reidemeister1 + Reidemeister1')
et en c.8166 (PR #9873, Reidemeister1Connected).

## B&eacute;n&eacute;fices

1. **`Reidemeister2.symm` survit tel quel** (L386-393 FR / L365-372 EN) :
   `Or.inl hsurg` / `Or.inr hsurg` consomme directement la conjonction
   `(h_cross, h_num)` comme type `alpha` dans `Or.inl/inr : alpha -> alpha or beta`.
   Le destructuring `obtain ... hsurg | hsurg` reste valide : la disjonction
   est pr&eacute;serv&eacute;e, chaque arm devient un 2-conj.
2. **Aucun consumer cross-file &agrave; mettre &agrave; jour** : `Reidemeister2` n'est
   pas r&eacute;f&eacute;renc&eacute; dans `Invariant.lean` / `Invariant_en.lean` (sweep L891 ★★
   pre-edit l'a confirm&eacute;). Diff&eacute;rent de c.8166 (R1Connected) qui avait
   6 cross-file consumers ; c.8167 est **local** au seul fichier corridor.
3. **i18n sibling-pair #4980** : la d&eacute;f FR (L377-382) est byte-identique
   &agrave; la d&eacute;f EN (L356-361 dans `Reidemeister_en.lean`), hors docstrings
   (crit&egrave;re v&eacute;rifi&eacute; par diff direct, comme c.8164 + c.8166).
4. **Pattern dupliqu&eacute;** : m&ecirc;me m&eacute;canique `with`-surgery &rarr; field-eqs,
   m&ecirc;me s&eacute;mantique pr&eacute;serv&eacute;e (proof-irrelevant, m&ecirc;me `Prop`, m&ecirc;mes
   t&eacute;moins `c1, c2, rho`).

## Scope r&eacute;el #8696 = 4 fen&ecirc;tres (apr&egrave;s c.8165 NO-OP discovery)

| Fen&ecirc;tre | Site | PR | Statut |
|---|---|---|---|
| 1/4 | Reidemeister1 L91/92 | #9807 | MERGED |
| 1/4 (m&ecirc;me PR) | Reidemeister1' L143/145 | #9807 | MERGED |
| 2/4 | (NO-OP d&eacute;couverte c.8165) | #9816 | CLOSED |
| 3/4 | Reidemeister1Connected L262-272 | #9873 | OPEN |
| **4/4** | **Reidemeister2 L377-382** | **#????** | **cette PR** |

Apr&egrave;s merge de c.8167 (cette PR) + c.8166 (#9873), le scope #8696 = **100% complete**.
Reste c.8168/c.8169 (R3 L413/414, R3D L484/485) = **NOUVEAU** chantier `with`-surgery
distinct (single-element `set i c` au lieu de multi-crossing) &mdash; hors scope #8696.

PR livr&eacute;e = `See #8696` (L883 ★, pas `Closes` : contribution finale d'un chantier
multi-cycle, la fermeture compl&egrave;te est le merge de c.8166 + c.8167).

## Perim&egrave;tre c.8167

| Fichier | Lignes touch&eacute;es | Statut |
|---|---|---|
| `Knots/Reidemeister.lean` | def R2 L377-382 (4 lignes modifi&eacute;es) | modifi&eacute; |
| `Knots/Reidemeister_en.lean` | mirror EN def R2 L356-361 (4 lignes modifi&eacute;es) | modifi&eacute; (byte-identity FR) |

**Total** : 2 fichiers, **+4 insertions / -4 deletions**. **Aucun** consumer cross-file.

## Validation

- **&sect;B.1 Lake build** (warm cache post-c.8166) : `lake build Knots.Reidemeister`,
  `Knots.Reidemeister_en`, `Knots.Invariant`, `Knots.Invariant_en` &mdash; **4/4 EXIT=0**.
  Log WSL : `=== REBUILD_OK 2026-08-07T12:??Z`.
- **&sect;B.2 axiomes** :
  - `grep -c sorry` par fichier : **2/2/14/9** (inchang&eacute; depuis baseline c.8166).
  - `grep -c native_decide` par fichier : **0/0/4/4** &mdash; les 4+4 mentions dans `Invariant*`
    sont **toutes dans des docstrings `/-- ... -/`** (descriptions historiques). Aucun
    `native_decide` actif introduit.
  - `grep -c sorryAx` par fichier : **0**.
  - `grep -c Classical.choice` par fichier : **0/0/1/1** (pre-existants, inchang&eacute;s).
- **&sect;B.3 proof-integrity** : `lean-axiom.yml` non c&acirc;bl&eacute; sur le lake `knot_lean`
  (cf triage par lake `docs/reference/lean-axiom-coverage.md`). **B.3 non applicable pour ce module** &mdash;
  &agrave; &eacute;crire explicitement, le job advisory `target-coverage` rend l'&eacute;cart lisible dans le log.
- **&sect;B.5 L891 ★★ pre-edit sweep** : `grep -rn "Reidemeister2\b|hsurg\b|congrArg.*hsurg|simpa using congrArg.*hsurg"`
  exhaustif avant &eacute;dition. **Aucun consumer cross-file de R2** dans `Invariant.lean`
  / `Invariant_en.lean` (seul l'inductive `ReidemeisterStep.r2` est r&eacute;f&eacute;renc&eacute;,
  inchang&eacute; car le type de `Reidemeister2` reste `Prop`).

## Hors-scope (d&eacute;couplage multi-cycle)

2 sites `with`-surgery restants dans `Reidemeister.lean` / `Reidemeister_en.lean`
(programm&eacute;s pour les cycles suivants) :

- **c.8168** : R3 L413/414 (single-element `set i c` + 0 edges) &mdash; **NOUVEAU** chantier
- **c.8169** : R3D L484/485 (single-element `set i.val c` + 0 edges) &mdash; **NOUVEAU** chantier

Ces 2 sites sont des **chirurgies single-element** (vs multi-crossing de c.8167),
donc un pattern diff&eacute;rent : `d&sub2;.crossings = d&sub1;.crossings.set i c` (sans
modification de `numEdges`). Probablement **plus simple** que c.8166/c.8167 (pas
de multi-champ), mais potentiel cross-file sweep L891 ★★ &agrave; refaire.

## Le&ccedil;ons appliqu&eacute;es

- **L891 ★★** (c.8166) : Exhaustive cross-file consumer sweep OBLIGATOIRE avant
  migration `with`-surgery &rarr; field-eqs. Ici = sweep exhaustif, **0 cross-file consumer R2**.
- **L887 ★★** (c.8164) : Pattern A `with`-surgery &rarr; field-eqs dupliqu&eacute; sur
  4 sites en 3 PRs.
- **L890 ★★** (c.8165) : `git diff origin/main..HEAD -- <paths>` obligatoire avant push ;
  ici = +4/-4, **pas un no-op**.
- **L883 ★** : `See #8696` (pas `Closes`, contribution finale d'un chantier multi-cycle).
- **L677-L4 ★★** : PR body HORS worktree (scratchpad pattern).
- **L888 ★** : `git commit -F <file>` (pas de heredoc bash avec backticks).
- **L898 ★★★** : `gh pr list --search head:<branch>` = `[]` (pas de collision cross-lane).
- **L576 ★★ + L843 ★** : Compound gate (merge-base + REST + `gh pr list`) sur la
  branche orpheline-par-cr&eacute;ation `feature/c8167-8696-reidemeister2-eqch`
  &rarr; ORPHELINE CONFIRM&Eacute;E, self-pick OK apr&egrave;s suppression placeholder.
- **L9774** : claim pos&eacute;e sur issue #8696 (`[CLAIMED] lane myia-po-2026:CoursIA-2 ... 2026-08-07T12:??Z`).

## Anti-r&eacute;gression &sect;D

Aucun `sorry` ajout&eacute;. Aucune r&eacute;gression d'axiome. Aucune suppression de code m&eacute;tier.
Seul le **pattern m&eacute;canique** `with`-surgery (L377-382 / L356-361) est remplac&eacute; par des
&eacute;galit&eacute;s de champs, ce qui **pr&eacute;serve la s&eacute;mantique** (proof-irrelevant, m&ecirc;me `Prop`,
m&ecirc;mes t&eacute;moins `c1, c2, rho`) et **uniformise** la signature avec R1/R1'/R1Connected.

## Voir aussi

- PR #9807 (window 1/4 #8696, c.8164) &mdash; Reidemeister1 + Reidemeister1' field-eqs.
- PR #9873 (window 3/4 #8696, c.8166) &mdash; Reidemeister1Connected field-eqs.
- Issue **#8696** &mdash; corridor Reidemeister (4 sites `with`-surgery, **clos d&egrave;s merge c.8167**).
- Topic [cycles-c8162-c8165-reidemeister-corridor](MEMORY.md#cycles-c8162-c8165--reidemeister-corridor-refactor-8696-multi-cycle-chantier).
- L887 ★★, L890 ★★, L891 ★★, L883 ★, L898 ★★★, L677-L4 ★★, L888 ★, L576 ★★, L843 ★.