### PR TITLE
docs(vibe-coding,#9735): surface MCP reelle — 15 outils enumeres, 3 noms fabriques retires

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
@@ -119,13 +119,27 @@ Les sections précédentes ([Claude Code](#claude-code---ateliers), [Roo Code](#
 
 [`roo-state-manager`](https://github.com/jsboige/roo-extensions) est un MCP maison qui regroupe **15 outils** d'orchestration inter-agents et de mémoire collective. La doc pérenne détaille le rôle de chacun : [HARNESS-OVERVIEW.md §2](https://github.com/jsboige/roo-extensions/blob/main/docs/harness/HARNESS-OVERVIEW.md) (6 coordination + 4 mémoire/recherche + 5 infrastructure). Pour le cycle de vie et le diagnostic des serveurs MCP eux-mêmes, voir [docs/reference/architecture_mcp_roo.md](../../../docs/reference/architecture_mcp_roo.md).
 
-| Catégorie | Rôle | Quelques outils représentatifs (sur 34) |
-|-----------|------|------------------------------------------|
-| **Dashboards** | Canal principal de coordination entre agents (3 types : `global`, `machine`, `workspace`). | `roosync_dashboard`, `roosync_dashboard_update` |
-| **Messagerie inter-agents** | DM point-à-point qui survit à la condensation du dashboard. | `roosync_messages`, `roosync_messages_inbox` |
-| **Conversation browser** | Navigation dans l'historique des sessions d'agents (liste d'abord, puis view/tree). | `conversation_browser`, `conversation_browser_view` |
-| **Indexation sémantique** | Qdrant — indexation du code, des décisions, des incidents, retrouvables par le sens. | `roosync_search`, `roosync_indexing` |
-| **Recherche codebase** | Recherche sémantique dans le code par concept (pas par mot-clé). | `codebase_search` |
+Les 15 outils, dans les trois catégories de `HARNESS-OVERVIEW.md` :
+
+| Catégorie | Outil | Rôle |
+|-----------|-------|------|
+| **Coordination** (6) | `roosync_dashboard` | Canal principal entre agents — 3 types : `global`, `machine`, `workspace`. |
+| | `roosync_messages` | DM point-à-point ; survit à la condensation du dashboard. |
+| | `roosync_inventory` | Inventaire machines, heartbeats, santé du cluster. |
+| | `roosync_config` | Collecte / publication / application de configuration entre machines. |
+| | `roosync_baseline` | Versionnage et restauration d'une configuration de référence. |
+| | `roosync_compare_config` | Diff de configuration entre deux machines. |
+| **Mémoire & recherche** (4) | `codebase_search` | Recherche sémantique dans le code par concept, pas par mot-clé. |
+| | `roosync_search` | Recherche sémantique ou plein-texte dans l'historique des tâches. |
+| | `conversation_browser` | Navigation dans les sessions d'agents (lister d'abord, puis voir / arborer / résumer). |
+| | `roosync_indexing` | Index Qdrant, cache, archivage — la mémoire collective elle-même. |
+| **Infrastructure** (5) | `roosync_diagnose` | Diagnostic d'environnement, cycle de vie d'agent, santé du harnais. |
+| | `roosync_mcp_management` | Gestion des serveurs MCP (lecture / écriture de config, rebuild, reload). |
+| | `roosync_storage_management` | Inspection du stockage et maintenance (reconstruction de cache, réparation BOM). |
+| | `read_vscode_logs` | Lecture des logs Extension Host / Renderer — le diagnostic de dernier recours. |
+| | `export_data` | Export XML / JSON / CSV / Markdown d'une tâche, conversation ou projet. |
+
+**Un point de modèle mental** qui trompe souvent quand on découvre MCP : dans cet écosystème, **une action n'est pas un outil**. `roosync_dashboard` est *un* outil dont le comportement est piloté par un paramètre (`action: "read" | "append" | "write" | …`) ; il n'existe pas de `roosync_dashboard_update` à côté. C'est un choix de conception délibéré — regrouper une famille d'actions derrière un outil paramétré garde la surface d'outils lisible pour l'agent (15 descriptions à charger, pas 60), au prix d'un schéma d'entrée plus riche. Un agent qui invente `<outil>_<action>` par analogie échoue à l'appel : la liste ci-dessus est exhaustive.
 
 Ces outils sont le **câblage** sans lequel les agents travailleraient en silos : un dashboard workspace, c'est ce qui fait qu'un worker sur une machine sait ce que le coordinateur attend de lui, et inversement. Le détail de l'architecture (processus, cycle de vie, configuration `mcp_settings.json`, redémarrage Python avec nettoyage `.pyc`) est dans [architecture_mcp_roo.md](../../../docs/reference/architecture_mcp_roo.md).
 


### PR DESCRIPTION
Grain: MED/readme — lane myia-ai-01:CoursIA — prev: DEEP/lean #9883

Corrige le résidu réel de #9735 — que **deux** audits firsthand indépendants avaient conclu résolu à tort — et un défaut plus grave trouvé au passage.

## Pourquoi #9735 n'était pas un phantom

po-2024 puis po-2023 ont audité `Vibe-Coding/README.md` et conclu tous deux « résidu résolu par #9832, close ». Leur travail était sérieux ; le motif de vérification était trop étroit :

```
$ git grep "34 outils" -- "*/Vibe-Coding/*"     # 0 résultat -> "c'est propre"
$ grep -n "sur 34"     MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
122:| Catégorie | Rôle | Quelques outils représentatifs (sur 34) |
```

La chaîne survivante était `(sur 34)`, pas `34 outils`. La prose (l.120) annonçait bien « **15 outils** » tandis que l'en-tête de son propre tableau, deux lignes plus bas, en annonçait 34 — un document qui se contredisait sur deux lignes voisines.

Le second audit est arrivé après le premier sur la même issue et a confirmé sa conclusion (`cross-review-priming`) : deux verdicts concordants ne valent pas deux mesures indépendantes.

## Le défaut plus grave : trois outils qui n'existent pas

Sur les dix noms d'outils que listait le tableau, **trois sont fabriqués** :

| Nom publié | Réalité |
|---|---|
| `roosync_dashboard_update` | n'existe pas — `roosync_dashboard` prend `action: "write" \| "append" \| "update"` |
| `roosync_messages_inbox` | n'existe pas — `roosync_messages` prend `action: "inbox"` |
| `conversation_browser_view` | n'existe pas — `conversation_browser` prend `action: "view"` |

Le motif est clair : les trois viennent de suffixer une **action** au nom de l'outil. Or dans `roo-state-manager` l'action est un *paramètre*. Un lecteur — humain ou agent — qui apprend la surface MCP depuis ce README appelle des outils inexistants. Sur une page qui se présente comme « notre harnais réel », c'est le contenu le moins pardonnable.

## Ce que livre la PR

- **Énumération exhaustive des 15 outils**, dans les trois catégories que `HARNESS-OVERVIEW.md §2` annonce déjà (6 coordination + 4 mémoire/recherche + 5 infrastructure) — le compte en prose et le contenu du tableau concordent enfin, et il n'y a plus de « représentatifs » à interpréter.
- **Un paragraphe « une action n'est pas un outil »** : pourquoi ce regroupement est un choix de conception (15 descriptions à charger pour l'agent, pas 60) et pourquoi inventer `<outil>_<action>` échoue à l'appel.

## Vérification

Liste établie **à la source** : ce sont les outils que le coordinateur tient effectivement dans son propre contexte d'exécution, pas une note recopiée. Le compte 6+4+5 = 15 concorde avec la répartition annoncée par `HARNESS-OVERVIEW.md §2`.

```
$ grep -c "sur 34" .../Vibe-Coding/README.md                     -> 0
$ grep -oE '`(roosync_[a-z_]+|codebase_search|conversation_browser|read_vscode_logs|export_data)`' \
    .../Vibe-Coding/README.md | sort -u | wc -l                  -> 16
```

16 et non 15 : la 16ᵉ occurrence est `roosync_dashboard_update` **cité comme contre-exemple explicite** dans le paragraphe de modèle mental (« il n'existe pas de `roosync_dashboard_update` à côté »). Les 15 réels sont tous présents une fois.

## Acceptance de #9735

Les trois critères de l'issue étaient effectivement déjà satisfaits sur le fond (le module « Notre harnais réel » existe, nomme roo-state-manager et ≥3 MCPs maison, décrit le pattern coordinateur/workers anonymisé) — les deux audits avaient raison là-dessus. Ce qui restait n'était pas un manque de couverture mais une **inexactitude de contenu**, invisible aux deux greps. Cette PR la corrige ; `Closes #9735` une fois mergée.

See #9735, #9831
