### PR TITLE
fix(hooks,#9888): PyYAML-aware parity gate — corrige faux appariement id→entry

### DIFF
--- a/.github/workflows/hooks-parity.yml
+++ b/.github/workflows/hooks-parity.yml
@@ -1,0 +1,48 @@
+# Parity-check for the pre-commit harness (issue #9888, suite).
+# Advisory: surfaces in CI but does not block. The worker is the owner
+# of the missing-local-hook state, not the PR.
+name: hooks-parity
+
+on:
+  # Monthly cron so a long-running worker that drifted since last push
+  # still gets a nudge back into the harness.
+  schedule:
+    # 05:17 UTC on the 1st of each month (avoids the top-of-hour rush).
+    - cron: "17 5 1 * *"
+  push:
+    paths:
+      - ".pre-commit-config.yaml"
+      - ".github/workflows/hooks-parity.yml"
+      - "scripts/check_hooks_parity.py"
+      - "scripts/setup_hooks.py"
+  pull_request:
+    paths:
+      - ".pre-commit-config.yaml"
+      - ".github/workflows/hooks-parity.yml"
+      - "scripts/check_hooks_parity.py"
+      - "scripts/setup_hooks.py"
+
+# Advisory: surfaces the warning without breaking the rest of the CI run.
+continue-on-error: true
+
+jobs:
+  parity:
+    name: parity gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install PyYAML
+        run: python -m pip install --quiet pyyaml
+      - name: Run parity check
+        id: parity
+        # Exit 0 = all gates green, 1 = some gate KO. We surface the
+        # warning either way because the gate is advisory.
+        run: |
+          python scripts/check_hooks_parity.py || echo "PARITY_FAIL_RC=$?"
+      - name: Annotate if any gate KO
+        if: steps.parity.outcome == 'failure'
+        run: |
+          echo "::warning::hooks-parity gate: declared-vs-installable mismatch. Run on the worker: python scripts/setup_hooks.py --install"

--- a/scripts/check_hooks_parity.py
+++ b/scripts/check_hooks_parity.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Parity check: declared vs installed pre-commit hooks (issue #9888, suite).
+
+Compares the hooks named in ``.pre-commit-config.yaml`` against the
+hooks that would actually fire on a commit, then walks the YAML
+structure to pair each declared hook id with its entry script.
+
+Why this script (vs the regex walker in ``scripts/setup_hooks.py``)
+-------------------------------------------------------------------
+The current ``--check-parity`` subcommand uses
+``re.finditer(r"-\\s+id:\\s*(\\S+).*?entry:\\s*([^\\n]+)", text, re.S)``
+to pair ``id -> entry``. The non-greedy ``.*?`` with ``re.S`` (DOTALL)
+makes **each id match the FIRST entry that follows** instead of the
+entry that actually belongs to it. The result, measured first-hand on
+this machine:
+
+    $ python scripts/setup_hooks.py --check-parity | grep gitleaks
+      gitleaks                         -> scripts/notebook_tools/strip_probe_banner.py [EXISTS]
+
+``gitleaks`` is an external hook (no ``entry`` field of its own); the
+regex falsely attaches it to ``strip_probe_banner.py`` (the first
+local entry that follows). The real first local hook (id
+``strip-probeaddresses-banner``) is silently dropped from the pairing
+report. This is the same shape of blind spot as #8782 -- a gate that
+names a target it stopped watching.
+
+The PyYAML-aware walker in this script reads the YAML structure
+instead of line regexes, so the pairing is correct (gitleaks has no
+entry, and the five local hooks are each paired with their own entry).
+
+What it checks
+--------------
+1. ``.pre-commit-config.yaml`` exists and parses as YAML.
+2. ``pre-commit`` binary is on PATH.
+3. ``gitleaks`` binary is on PATH (since the config declares v8.21.2).
+4. ``.git/hooks/pre-commit`` is installed (produced by ``pre-commit install``).
+5. The id of each hook declared in the config matches an id the framework
+   will execute (best-effort: relies on ``pre-commit validate-config``).
+6. **NEW**: each local hook's ``entry`` script exists on disk (PyYAML pair).
+
+Why advisory only
+-----------------
+The same angle-mot that produced #8782 (a gate that names a target it
+stopped watching) is what we are guarding against. We do **not** block
+CI on this parity check, because a missing local hook is the **worker's**
+state to repair, not the PR's. The output is a warning. CI is configured
+with ``continue-on-error: true`` and annotates ``::warning::`` on parity
+fail so the worker can see it without it stopping the rest of the run.
+
+Exit code:
+    0 -- every gate green
+    1 -- at least one gate red (printed in the report)
+    2 -- YAML parse error / config missing
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml  # PyYAML
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_PATH = REPO_ROOT / ".pre-commit-config.yaml"
+HOOK_PATH = REPO_ROOT / ".git" / "hooks" / "pre-commit"
+
+
+def _declared_hook_ids() -> list[str]:
+    if not CONFIG_PATH.exists():
+        raise FileNotFoundError(f"{CONFIG_PATH} missing")
+    if yaml is None:
+        raise RuntimeError("PyYAML not installed; install with `pip install pyyaml`")
+    text = CONFIG_PATH.read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict) or "repos" not in data:
+        raise ValueError(f"{CONFIG_PATH}: top-level must be a mapping with 'repos' key")
+    ids: list[str] = []
+    for repo in data["repos"]:
+        if not isinstance(repo, dict):
+            continue
+        for hook in repo.get("hooks", []) or []:
+            if isinstance(hook, dict) and "id" in hook:
+                ids.append(hook["id"])
+    return ids
+
+
+def _local_hook_pairs() -> list[tuple[str, str | None]]:
+    """PyYAML walk: yield (id, entry_or_None) for each local hook.
+
+    External hooks (e.g. gitleaks) have no ``entry`` -- the entry is
+    inherited from the remote repo's plugin. We yield ``None`` for the
+    entry in that case so the caller can report it cleanly instead of
+    pairing the id with the *next* hook's entry (the regex bug).
+    """
+    if not CONFIG_PATH.exists():
+        raise FileNotFoundError(f"{CONFIG_PATH} missing")
+    if yaml is None:
+        raise RuntimeError("PyYAML not installed; install with `pip install pyyaml`")
+    text = CONFIG_PATH.read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict) or "repos" not in data:
+        raise ValueError(f"{CONFIG_PATH}: top-level must be a mapping with 'repos' key")
+    pairs: list[tuple[str, str | None]] = []
+    for repo in data["repos"]:
+        if not isinstance(repo, dict):
+            continue
+        # Only local hooks have an explicit entry we can verify.
+        if repo.get("repo") != "local":
+            for hook in repo.get("hooks", []) or []:
+                if isinstance(hook, dict) and "id" in hook:
+                    pairs.append((hook["id"], None))
+            continue
+        for hook in repo.get("hooks", []) or []:
+            if not isinstance(hook, dict) or "id" not in hook:
+                continue
+            entry = hook.get("entry")
+            pairs.append((hook["id"], entry))
+    return pairs
+
+
+def _validate_config() -> tuple[bool, str]:
+    """Run ``pre-commit validate-config`` and return (ok, stderr)."""
+    precommit = shutil.which("pre-commit")
+    if precommit is None:
+        return False, "pre-commit not on PATH"
+    try:
+        proc = subprocess.run(
+            [precommit, "validate-config", str(CONFIG_PATH)],
+            capture_output=True, text=True, check=False,
+        )
+    except FileNotFoundError:
+        # shutil.which can succeed on Windows even when CreateProcess can't
+        # actually launch the binary (PATH mismatch in subprocess).
+        return False, "pre-commit not launchable from subprocess"
+    return proc.returncode == 0, (proc.stderr or proc.stdout or "").strip()
+
+
+def _entry_script(entry: str) -> str | None:
+    """Extract the first ``*.py`` path from a hook entry string.
+
+    Entry strings are like:
+        "python scripts/notebook_tools/strip_probe_banner.py --apply"
+        "python scripts/notebook_tools/check_null_exec.py"
+    Returns the path component (or None if no .py found).
+    """
+    parts = entry.split()
+    return next((p for p in parts if p.endswith(".py")), None)
+
+
+def _run_checks() -> list[tuple[str, str, str]]:
+    """Return list of (gate, status, detail). status in {"OK", "KO", "ERR"}."""
+    out: list[tuple[str, str, str]] = []
+
+    # Gate 1: config present and parseable
+    try:
+        ids = _declared_hook_ids()
+        out.append(("config declared", "OK", f"{len(ids)} hooks: {', '.join(ids)}"))
+    except FileNotFoundError as e:
+        out.append(("config declared", "ERR", str(e)))
+        return out  # cannot proceed further meaningfully
+    except (ValueError, RuntimeError) as e:
+        out.append(("config declared", "ERR", str(e)))
+        return out
+
+    # Gate 2: pre-commit on PATH
+    precommit_path = shutil.which("pre-commit")
+    if precommit_path:
+        out.append(("pre-commit on PATH", "OK", precommit_path))
+    else:
+        out.append(("pre-commit on PATH", "KO", "install with: pip install --user pre-commit"))
+
+    # Gate 3: gitleaks on PATH
+    gitleaks_path = shutil.which("gitleaks")
+    if gitleaks_path:
+        out.append(("gitleaks on PATH", "OK", gitleaks_path))
+    else:
+        out.append(("gitleaks on PATH", "KO", "install with: pip install --user gitleaks"))
+
+    # Gate 4: hook installed
+    if HOOK_PATH.exists():
+        out.append((".git/hooks/pre-commit installed", "OK", str(HOOK_PATH)))
+    else:
+        out.append((".git/hooks/pre-commit installed", "KO", "run: pre-commit install"))
+
+    # Gate 5: validate-config
+    if precommit_path:
+        ok, detail = _validate_config()
+        out.append(("pre-commit validate-config", "OK" if ok else "KO", detail or "(silent)"))
+    else:
+        out.append(("pre-commit validate-config", "SKIP", "pre-commit not installed"))
+
+    # Gate 6: local hook entry scripts (NEW, PyYAML-correct pairing)
+    try:
+        pairs = _local_hook_pairs()
+        # Filter to local hooks (entry is not None) for the script check.
+        local = [(hid, entry) for hid, entry in pairs if entry is not None]
+        missing = []
+        for hid, entry in local:
+            script = _entry_script(entry)
+            if script is None:
+                missing.append((hid, "no .py in entry"))
+                continue
+            if not (REPO_ROOT / script).exists():
+                missing.append((hid, script))
+        if missing:
+            details = "; ".join(f"{h} -> {s}" for h, s in missing)
+            out.append(("local hook entry scripts", "KO", details))
+        else:
+            out.append(("local hook entry scripts", "OK", f"{len(local)} local hooks wired"))
+    except (ValueError, RuntimeError) as e:
+        out.append(("local hook entry scripts", "ERR", str(e)))
+
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[1] if __doc__ else "")
+    parser.add_argument("--quiet", action="store_true", help="only print the gate table on KO")
+    args = parser.parse_args()
+
+    rows = _run_checks()
+    any_ko = False
+    for gate, status, detail in rows:
+        if status != "OK":
+            any_ko = True
+        line = f"  [{status:3}] {gate}: {detail}"
+        if not args.quiet or status != "OK":
+            print(line)
+    if any_ko:
+        print("\n  Run `python scripts/setup_hooks.py --install` to repair.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -266,7 +266,17 @@ def main(argv: list[str] | None = None) -> int:
     python = sys.executable
 
     if args.check_parity:
-        return cmd_check_parity(repo, python)
+        # Delegate to scripts/check_hooks_parity.py (PyYAML walker) so the
+        # declared-vs-installable pairing is YAML-aware and not regex-based.
+        # See scripts/check_hooks_parity.py for the rationale; the regex
+        # walker in cmd_check_parity() above pairs each id with the FIRST
+        # entry that follows (gitleaks -> strip_probe_banner.py), which is
+        # the bug this delegation replaces.
+        parity_script = Path(__file__).resolve().parent / "check_hooks_parity.py"
+        rc, out = _run([python, str(parity_script)], repo)
+        if out:
+            print(out, end="" if out.endswith("\n") else "\n")
+        return rc
     if args.check:
         return cmd_check(repo, python)
     return cmd_install(repo, python)

--- a/scripts/tests/test_check_hooks_parity.py
+++ b/scripts/tests/test_check_hooks_parity.py
@@ -1,0 +1,262 @@
+"""Tests for scripts/check_hooks_parity.py (issue #9888, suite of #9895).
+
+These tests cover the PyYAML-aware walker that replaces the regex
+pairing in ``scripts/setup_hooks.py --check-parity`` (regex pairs
+each id with the FIRST entry that follows, producing false pairings
+such as ``gitleaks -> strip_probe_banner.py``).
+
+The previously-shipped test file ``test_setup_hooks.py`` (from my
+superseded #9893) targeted an ``inspect()`` / ``class SetupResult``
+API that lives in the pre-#9895 codebase. Per C9888-bis-L3, tests
+must reflect the API of the target codebase; ``setup_hooks.py`` on
+main no longer exposes those symbols, so the tests here cover only
+``check_hooks_parity.py`` directly.
+"""
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+CHECK_HOOKS_PARITY = HERE.parent / "check_hooks_parity.py"
+
+
+def _load(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_repo(tmp_path: Path, config_text: str) -> Path:
+    """Create a fake repo with a .git/hooks/ directory and a config file."""
+    repo = tmp_path / "fake_repo"
+    (repo / ".git" / "hooks").mkdir(parents=True)
+    (repo / ".pre-commit-config.yaml").write_text(config_text, encoding="utf-8")
+    return repo
+
+
+# --- Gate 1: config declared -------------------------------------------------
+
+def test_declared_hook_ids_real_config():
+    """Smoke test: the real .pre-commit-config.yaml yields >= 5 hook ids."""
+    mod = _load(CHECK_HOOKS_PARITY)
+    if not mod.CONFIG_PATH.exists():
+        import pytest
+        pytest.skip("real config not found in test environment")
+    try:
+        ids = mod._declared_hook_ids()
+    except RuntimeError as e:
+        import pytest
+        pytest.skip(f"PyYAML missing in test environment: {e}")
+    # Real config has 6 hooks (gitleaks + 5 local) as of #9895.
+    assert len(ids) >= 5, f"expected >= 5 hooks in real config, got {len(ids)}: {ids}"
+
+
+def test_declared_hook_ids_missing_config(tmp_path, monkeypatch):
+    """declared_hook_ids() raises FileNotFoundError on missing config."""
+    mod = _load(CHECK_HOOKS_PARITY)
+    repo = tmp_path / "no_config_here"
+    repo.mkdir()
+    monkeypatch.setattr(mod, "CONFIG_PATH", repo / ".pre-commit-config.yaml")
+    try:
+        mod._declared_hook_ids()
+    except FileNotFoundError:
+        return
+    raise AssertionError("expected FileNotFoundError")
+
+
+def test_declared_hook_ids_extract(tmp_path, monkeypatch):
+    """declared_hook_ids() pulls the right number of ids from a fake config."""
+    mod = _load(CHECK_HOOKS_PARITY)
+    config_text = (
+        "repos:\n"
+        "  - repo: local\n"
+        "    hooks:\n"
+        "      - id: fake-hook-a\n"
+        "      - id: fake-hook-b\n"
+    )
+    repo = _make_repo(tmp_path, config_text)
+    monkeypatch.setattr(mod, "CONFIG_PATH", repo / ".pre-commit-config.yaml")
+    ids = mod._declared_hook_ids()
+    assert ids == ["fake-hook-a", "fake-hook-b"]
+
+
+def test_declared_hook_ids_mixed_repos(tmp_path, monkeypatch):
+    """declared_hook_ids() walks both external and local repos."""
+    mod = _load(CHECK_HOOKS_PARITY)
+    config_text = (
+        "repos:\n"
+        "  - repo: https://github.com/gitleaks/gitleaks\n"
+        "    rev: v8.21.2\n"
+        "    hooks:\n"
+        "      - id: gitleaks\n"
+        "  - repo: local\n"
+        "    hooks:\n"
+        "      - id: local-a\n"
+        "      - id: local-b\n"
+    )
+    repo = _make_repo(tmp_path, config_text)
+    monkeypatch.setattr(mod, "CONFIG_PATH", repo / ".pre-commit-config.yaml")
+    ids = mod._declared_hook_ids()
+    assert ids == ["gitleaks", "local-a", "local-b"]
+
+
+# --- Gate 6: local hook entry scripts (PyYAML-correct pairing) ---------------
+
+def test_local_hook_pairs_pyyaml_not_regex(tmp_path, monkeypatch):
+    """_local_hook_pairs() pairs each id with its own entry via PyYAML walk.
+
+    This is the regression test for the regex bug: the OLD regex would
+    pair ``gitleaks`` (external, no entry) with the FIRST entry that
+    follows (``local-a``). The PyYAML walker yields ``(gitleaks, None)``
+    and ``(local-a, "python foo.py")`` separately, so the false pairing
+    cannot occur.
+    """
+    mod = _load(CHECK_HOOKS_PARITY)
+    config_text = (
+        "repos:\n"
+        "  - repo: https://github.com/gitleaks/gitleaks\n"
+        "    rev: v8.21.2\n"
+        "    hooks:\n"
+        "      - id: gitleaks\n"
+        "  - repo: local\n"
+        "    hooks:\n"
+        "      - id: local-a\n"
+        "        entry: python scripts/a.py --apply\n"
+        "      - id: local-b\n"
+        "        entry: python scripts/b.py\n"
+    )
+    repo = _make_repo(tmp_path, config_text)
+    monkeypatch.setattr(mod, "CONFIG_PATH", repo / ".pre-commit-config.yaml")
+    pairs = mod._local_hook_pairs()
+    # gitleaks (external) -> entry is None, NOT the first local entry.
+    assert ("gitleaks", None) in pairs, pairs
+    # local-a and local-b are paired with their own entries.
+    assert ("local-a", "python scripts/a.py --apply") in pairs, pairs
+    assert ("local-b", "python scripts/b.py") in pairs, pairs
+
+
+def test_local_hook_pairs_extracts_script_path(tmp_path, monkeypatch):
+    """_entry_script() extracts the first *.py path from an entry string."""
+    mod = _load(CHECK_HOOKS_PARITY)
+    assert mod._entry_script("python scripts/notebook_tools/strip_probe_banner.py --apply") \
+        == "scripts/notebook_tools/strip_probe_banner.py"
+    assert mod._entry_script("python scripts/x.py") == "scripts/x.py"
+    assert mod._entry_script("python scripts/x.py --opt val") == "scripts/x.py"
+    assert mod._entry_script("python something") is None  # no .py
+
+
+def test_run_checks_local_entry_missing(tmp_path, monkeypatch):
+    """local hook entry scripts gate flips to KO when a script is missing."""
+    mod = _load(CHECK_HOOKS_PARITY)
+    config_text = (
+        "repos:\n"
+        "  - repo: local\n"
+        "    hooks:\n"
+        "      - id: local-a\n"
+        "        entry: python scripts/does_not_exist.py --apply\n"
+    )
+    repo = _make_repo(tmp_path, config_text)
+    monkeypatch.setattr(mod, "REPO_ROOT", repo)
+    monkeypatch.setattr(mod, "CONFIG_PATH", repo / ".pre-commit-config.yaml")
+    monkeypatch.setattr(mod, "HOOK_PATH", repo / ".git" / "hooks" / "pre-commit")
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(sys, "argv", ["check_hooks_parity"])
+
+    rows = mod._run_checks()
+    gate_by_name = {g: (s, d) for g, s, d in rows}
+    status, detail = gate_by_name["local hook entry scripts"]
+    assert status == "KO", f"expected KO, got {status}: {detail}"
+    assert "local-a" in detail and "scripts/does_not_exist.py" in detail
+
+
+def test_run_checks_local_entry_present(tmp_path, monkeypatch):
+    """local hook entry scripts gate is OK when each entry script exists."""
+    mod = _load(CHECK_HOOKS_PARITY)
+    config_text = (
+        "repos:\n"
+        "  - repo: local\n"
+        "    hooks:\n"
+        "      - id: local-a\n"
+        "        entry: python scripts/a.py --apply\n"
+    )
+    repo = _make_repo(tmp_path, config_text)
+    # Create the entry script so it exists.
+    (repo / "scripts").mkdir(parents=True)
+    (repo / "scripts" / "a.py").write_text("# stub\n")
+    monkeypatch.setattr(mod, "REPO_ROOT", repo)
+    monkeypatch.setattr(mod, "CONFIG_PATH", repo / ".pre-commit-config.yaml")
+    monkeypatch.setattr(mod, "HOOK_PATH", repo / ".git" / "hooks" / "pre-commit")
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(sys, "argv", ["check_hooks_parity"])
+
+    rows = mod._run_checks()
+    gate_by_name = {g: (s, d) for g, s, d in rows}
+    status, detail = gate_by_name["local hook entry scripts"]
+    assert status == "OK", f"expected OK, got {status}: {detail}"
+    assert "1 local hooks wired" in detail
+
+
+# --- Main entrypoint exit code ----------------------------------------------
+
+def test_main_returns_1_on_ko(tmp_path, monkeypatch, capsys):
+    """main() returns 1 when at least one gate is KO."""
+    mod = _load(CHECK_HOOKS_PARITY)
+    config_text = (
+        "repos:\n"
+        "  - repo: local\n"
+        "    hooks:\n"
+        "      - id: local-a\n"
+        "        entry: python scripts/nope.py\n"
+    )
+    repo = _make_repo(tmp_path, config_text)
+    monkeypatch.setattr(mod, "REPO_ROOT", repo)
+    monkeypatch.setattr(mod, "CONFIG_PATH", repo / ".pre-commit-config.yaml")
+    monkeypatch.setattr(mod, "HOOK_PATH", repo / ".git" / "hooks" / "pre-commit")
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(sys, "argv", ["check_hooks_parity"])
+
+    rc = mod.main()
+    out = capsys.readouterr().out
+    assert rc == 1, f"expected rc=1, got rc={rc}, output={out!r}"
+    assert "KO" in out
+    assert "pre-commit on PATH" in out
+    assert "gitleaks on PATH" in out
+
+
+def test_main_returns_0_when_all_green(tmp_path, monkeypatch, capsys):
+    """main() returns 0 when every gate is green."""
+    mod = _load(CHECK_HOOKS_PARITY)
+    config_text = (
+        "repos:\n"
+        "  - repo: local\n"
+        "    hooks:\n"
+        "      - id: local-a\n"
+        "        entry: python scripts/a.py --apply\n"
+    )
+    repo = _make_repo(tmp_path, config_text)
+    (repo / ".git" / "hooks" / "pre-commit").write_text("#!/bin/sh\nexit 0\n")
+    (repo / "scripts").mkdir(parents=True)
+    (repo / "scripts" / "a.py").write_text("# stub\n")
+    monkeypatch.setattr(mod, "REPO_ROOT", repo)
+    monkeypatch.setattr(mod, "CONFIG_PATH", repo / ".pre-commit-config.yaml")
+    monkeypatch.setattr(mod, "HOOK_PATH", repo / ".git" / "hooks" / "pre-commit")
+    monkeypatch.setattr(shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    # Mock subprocess.run for validate-config so the gate succeeds even when
+    # pre-commit is not actually launchable from this CI env.
+    class _FakeProc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **kw: _FakeProc())
+    monkeypatch.setattr(sys, "argv", ["check_hooks_parity"])
+
+    rc = mod.main()
+    out = capsys.readouterr().out
+    assert rc == 0, f"expected rc=0, got rc={rc}, output={out!r}"
+    assert "OK" in out


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: LIGHT/coord #9893-close

# Suite de #9895 : parity gate PyYAML-aware (corrige le faux appariement regex du `--check-parity`)

## Contexte

PR #9895 (`04e734337`, MERGED 16:53Z) a livré l'organe d'installation `scripts/setup_hooks.py` + le fix `.pre-commit-config.yaml` + `.gitleaks.toml`. Le subcommand `--check-parity` y est implémenté par `cmd_check_parity()` (`scripts/setup_hooks.py:223`) qui utilise une regex pour apparier `id ↔ entry` :

```python
re.finditer(r"-\s+id:\s*(\S+).*?entry:\s*([^\n]+)", text, re.S)
```

Le `.*?` non-greedy + `re.S` (DOTALL) fait que **chaque id est apparié à la PREMIÈRE `entry:` qui suit**, pas à la sienne. Symptôme mesuré firsthand sur ce worktree :

```text
$ python scripts/setup_hooks.py --check-parity | grep -E 'gitleaks|strip-probeaddresses'
  gitleaks                         -> scripts/notebook_tools/strip_probe_banner.py [EXISTS]
```

`gitleaks` est un hook externe (`repo: https://github.com/gitleaks/gitleaks`, sans `entry:` propre) ; la regex le fausse-appaire au premier entry local suivant (`strip_probe_banner.py`). Pendant ce temps, **le vrai premier hook local** — id `strip-probeaddresses-banner` — est **complètement omis** du rapport de pairing. C'est exactement la classe d'angle mort que #8782 a documentée (un gate qui nomme une cible qu'il a cessé de regarder).

ai-01 a explicitement identifié ce trou de préservation dans son dispatch (msg-20260807T171010-ohdjmt HIGH) : « le gate de parité ne doit pas rester dans un worktree local », et m'a greenlité la re-livraison du delta seul par-dessus #9895.

## Ce que cette PR livre (3 fichiers + 1 diff minimal)

1. **`scripts/check_hooks_parity.py`** (241 LOC) — script autonome, PyYAML-aware, 6 gates :
   - gates 1-5 : config declared / pre-commit on PATH / gitleaks on PATH / hook installed / validate-config (portés depuis #9895)
   - **gate 6 NEW** : `local hook entry scripts` — walker YAML qui itère `repos[*].hooks[*]` et paire chaque id local avec son propre `entry`. Pour les hooks externes (`repo != local`), yield `(id, None)` au lieu d'hériter frauduleusement du premier entry suivant. C'est la correction du faux appariement.
2. **`.github/workflows/hooks-parity.yml`** (48 LOC) — CI advisory `continue-on-error: true` + cron mensuel `17 5 1 * *` + push/PR sur les paths hook. Sur KO, annote `::warning::` sans bloquer le reste du run (le hook cassé est la state de la machine worker, pas du PR).
3. **`scripts/tests/test_check_hooks_parity.py`** (262 LOC, **10 tests**) — réécrits sur la nouvelle API (`C9888-bis-L3 ★★` : les tests de mon ancien #9893 hardcodaient `inspect()` / `class SetupResult` qui n'existent plus sur main après #9895 — dette, pas livrable). Le test central `test_local_hook_pairs_pyyaml_not_regex` est précisément la régression contre le bug regex.
4. **`scripts/setup_hooks.py`** (+11/-1) — **diff minimal ciblé** : `main()` délègue `--check-parity` au nouveau script via `_run([python, parity_script], repo)` au lieu d'invoquer `cmd_check_parity()` regex. La fonction morte `cmd_check_parity()` reste dans le fichier (héritage), mais n'est plus invoquée — pas de risque de casser `--install` qui marche (vérifié : `setup_hooks.py --check` retourne OK sur ce worktree).

## Preuve côte-à-côte — le bug regex vs la correction PyYAML

**Avant** (regex, sur main après #9895, mesuré firsthand 17:18Z) :

```text
$ python scripts/setup_hooks.py --check-parity
Declared hooks (6): gitleaks, strip-probeaddresses-banner, strip-dotnet-nuget-ext, scrub-papermill-paths, markdown-rendering-guard, check-null-exec
validate-config         : PASS (all declared hooks fetch/parse)
Local hook entry scripts:
  gitleaks                         -> scripts/notebook_tools/strip_probe_banner.py [EXISTS]    # FAUX
  strip-dotnet-nuget-ext           -> scripts/notebook_tools/strip_machine_paths.py [EXISTS]
  scrub-papermill-paths            -> scripts/notebook_tools/scrub_papermill_paths.py [EXISTS]
  markdown-rendering-guard         -> scripts/notebook_tools/detect_markdown_rendering.py [EXISTS]
  check-null-exec                  -> scripts/notebook_tools/check_null_exec.py [EXISTS]
# strip-probeaddresses-banner MANQUANT du pairing (id orphelin)
```

**Après** (PyYAML, sur cette branche, mesuré firsthand 17:18Z) :

```text
$ python scripts/setup_hooks.py --check-parity
  [OK ] config declared: 6 hooks: gitleaks, strip-probeaddresses-banner, strip-dotnet-nuget-ext, scrub-papermill-paths, markdown-rendering-guard, check-null-exec
  [KO ] pre-commit on PATH: install with: pip install --user pre-commit
  [KO ] gitleaks on PATH: install with: pip install --user gitleaks
  [KO ] .git/hooks/pre-commit installed: run: pre-commit install
  [SKIP] pre-commit validate-config: pre-commit not installed
  [OK ] local hook entry scripts: 5 local hooks wired
```

5 local hooks wired correctement, `gitleaks` (externe) absent du pairing local (correct, pas d'`entry:`), `strip-probeaddresses-banner` inclus dans le pairing.

## Acceptance (cf #9888 §Acceptance)

- ✅ **« un job advisory qui compare les hooks déclarés dans `.pre-commit-config.yaml` à ce qui est réellement exécutable »** : 6 gates, exit 0/1/2, CI advisory mensuel + push/PR.
- ✅ Preuve côte-à-côte du fix dans ce body (regex vs PyYAML).
- ✅ Tests verts firsthand : `python -m pytest scripts/tests/test_check_hooks_parity.py` → **10/10 PASSED en 0.33s**.
- ✅ Pas de régression sur `--install` / `--check` : `python scripts/setup_hooks.py --check` retourne OK (relevé présent).
- ✅ Catalogue byte-identique à `main` (`COURSE_CATALOG.generated.{json,md}` non touché, [catalog-pr-hygiene.md Règle HARD 1](docs/reference/catalog-pr-hygiene.md)).

## Scope strict (R3 atomicité)

- **1 sujet** = parity gate PyYAML par-dessus #9895.
- **4 fichiers** : 3 NEW + 1 minimal diff (11 lignes) dans `setup_hooks.py`.
- **+562/-1 LOC** au total.
- Sous les seuils G.4 (3000 / 15 / 4 features / 1 domaine).
- Ne touche **PAS** à `setup_hooks.py` `--install` (chemin canonique de #9895, validé en prod).
- Ne touche **PAS** à `.pre-commit-config.yaml` / `.gitleaks.toml` (déjà MERGED dans #9895, fix canonique).
- Ne touche **PAS** au catalogue (catalog-pr-hygiene Règle HARD 1).
- Ne touche **PAS** au pré-commit hook lui-même (déjà fonctionnel post-#9895).

## L898 ★★★ + lane-claim

- `[CLAIMED] lane myia-po-2023:CoursIA-2` posé par ai-01 sur #9888 (msg-20260807T171010-ohdjmt) avant démarrage — respect du lane-claim-protocol.
- L898 ★★★ pre-write vérifié : `gh pr list --search "hooks-parity OR check_hooks_parity OR c9888"` → 0 PR OPEN sur ce scope (seul mon #9893 CLOSED superseded, pas de PR vivante). 0 collision cross-lane.
- L898 ★★★ post-merge discovery (cf `topic-c9888-9888-hooks-install.md` §c.9872+7) : appliqué pour NE PAS re-créer la collision #9893 ↔ #9895 — d'où le scope strict "delta seul" demandé par ai-01.

## Voir aussi

- Issue **#9888** — acceptance criteria
- PR **#9893** (CLOSED superseded by #9895) — ancienne version, organe + regex parity
- PR **#9895** (MERGED `04e734337`) — organe canonique + fix `.gitleaks.toml`/`.pre-commit-config.yaml`
- `topic-c9888-9888-hooks-install.md` §c.9872+7 — leçons C9888-bis-L2/L3 ancrées
- `[CLAIMED] lane myia-po-2023:CoursIA-2` sur #9888 (ai-01 dispatch msg-20260807T171010-ohdjmt)

See #9888