### PR TITLE
enrich(search,#3801): Search-15 §9.1/§9.2 interpretation markdown — grounded in committed outputs

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX.ipynb
@@ -1353,6 +1353,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d12b8d12",
+   "source": "### Lecture du résultat — pourquoi A* « gagne » sans tricher\n\nLa sortie ci-dessus tranche la question posée en début de section : A* explore **17 nœuds** contre **25 pour Dijkstra** (32 % d'économie), tout en retournant **exactement le même chemin** (coût `5.905`, longueur `6` pour les deux). Ce « Identiques : True » est la propriété qui fait toute la valeur de l'heuristique.\n\n**Pourquoi les deux chemins coïncident.** L'heuristique euclidienne `heuristique_eucl` est *admissible* : la distance à vol d'oiseau entre deux nœuds de la grille ne surestime jamais le coût réel d'un chemin pondéré qui les relie (la ligne droite est le plus court possible). Sous cette condition, A* conserve la **garantie d'optimalité** de Dijkstra — il ne sacrifie jamais l'exactitude pour aller plus vite. Une heuristique *non* admissible (par exemple en multipliant la distance euclidienne par 10) explorerait encore moins de nœuds, mais pourrait renvoyer un chemin sous-optimal : c'est précisément le piège que le sanity-check `Identiques : True` surveille.\n\n**D'où vient l'économie de 8 nœuds.** Dijkstra est un algorithme *single-source* : il étiquette tous les nœuds du graphe par distance croissante à la source, y compris ceux situés « derrière » la destination ou dans la direction opposée. A* n'étend que les nœuds pour lesquels `coût_déjà_payé + heuristique(estimé_restant)` promet un chemin compétitif : les nœuds qui s'éloignent de la cible voient leur évaluation `f = g + h` grimper et sont repoussés dans la file de priorité. Sur une grille 5×5 parcourue coin à coin, les 8 nœuds économisés sont ceux du quadrant inférieur gauche — inutiles à la recherche, mais que Dijkstra visite quand même.\n\n**Pourquoi ce banc est non trivial (Prong B, #3801).** Sur un graphe à coût uniforme (toutes arêtes de poids 1), l'heuristique euclidienne n'a presque rien à orienter et A* dégénère vers Dijkstra — le cas dégénéré dénoncé dans l'EPIC. Ici, les poids proportionnels à la distance euclidienne **plus** un bruit de ±30 % **plus** 10 % d'arêtes retirées créent un terrain où l'heuristique discrimine réellement : la réduction de 32 % est mesurable et reproductible, pas un artefact. À contraster avec le petit graphe routier de 6 villes de la section 4, où l'économie restait « modeste » (6 nœuds seulement) : c'est sur la grille 5×5 que le bénéfice de l'heuristique devient lisible.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "1808320a",
    "metadata": {
     "papermill": {
@@ -1529,6 +1535,12 @@
     "plt.tight_layout()\n",
     "plt.show()\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c0e7d04",
+   "source": "### Lecture du résultat — popularité et pontage sont orthogonaux\n\nLe tableau trahit l'enseignement central de cette section : **PageRank et betweenness ne récompensent pas les mêmes chercheurs**. Sur les 10 places des deux top 5, seules deux sont occupées par le même sommet — `Bio_00` (PageRank #5, betweenness #2) et `IA_05` (PageRank #2, betweenness #3). Les huit autres places vont à des chercheurs absents de l'autre classement.\n\n**Le cas `Phys_08`.** Il domine la betweenness (`0.2185`, loin devant le #2 à `0.2133`) mais est **absent du top 5 PageRank**. C'est l'archétype du *chercheur-passerelle* : sa liaison inter-communautaire (`Bio_00 — Phys_08`) porte une fraction massive des plus courts chemins entre les communautés Bio et Physique, donc tout le trafic qui franchit ce pont transite par lui. Mais comme il n'a pas plus de co-auteurs intra-Physique que ses collègues, le flux de PageRank — qui récompense le *voisinage* et non le *rôle de routeur* — ne le distingue pas. Betweenness le voit ; PageRank le rate.\n\n**Le cas inverse `Bio_06`.** En tête du PageRank (`0.0454`) mais absent du top betweenness : un hub très cité à l'intérieur de la communauté Bio, mais qui n'est sur le chemin d'aucun plus court chemin inter-communautaire. PageRank le voit ; betweenness le rate.\n\n**Pourquoi les passerelles dominent la betweenness.** Les sommets marqués d'un contour noir dans la visualisation sont les 12 extrémités des 6 liaisons inter-communautaires (`liens_inter`). Or **les 5 sommets du top betweenness (`Phys_08`, `Bio_00`, `IA_05`, `Phys_02`, `IA_09`) sont tous des passerelles** : la centralité de pontage détecte mécaniquement la structure communautaire que PageRank, mesure de flux global, lisse. C'est pourquoi une analyse de réseau réaliste **rapporte plusieurs centralités conjointement** plutôt qu'une seule : elles répondent à des questions différentes (« qui est cité ? » contre « qui est irremplaçable au routage ? »). À contraster avec le petit graphe routier de 6 villes de la section 5, où Paris dominait *les quatre* centralités à la fois (Degree, Betweenness, Closeness, PageRank) : sur un graphe petit et dense, les centralités concordent ; sur un graphe réaliste structuré en communautés, elles divergent — et c'est précisément cette divergence qui rend chacune informative.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",

--- a/scripts/notebook_tools/twin_pairs.d/search-15-networkx.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-15-networkx.yaml
@@ -8,6 +8,12 @@
       by: myia-po-2023:CoursIA
       python_sha: 0c683cf6e0555230549c7fc0cea61995c876eb3e
       csharp_sha: eb47af5f9ac0e8a1dab26989671bfd0b6baad2c4
+    - date: "2026-08-07"
+      by: myia-po-2024:CoursIA
+      python_sha: 248ef9388438ac9084b64aac70db01492c6f31c5
+      csharp_sha: eb47af5f9ac0e8a1dab26989671bfd0b6baad2c4
+      content_python_sha: 3e24a480f8e53f39fd6a0b83e2336142e72058e3b6b07d4b8f53bc1929a89e80
+      content_csharp_sha: 2cbbb56683a8d47fb5ced20b221651eefca4c5ce04d2b6ee7ea77f6b4eeffc80
   known_differences:
     - "Bibliotheque vs from-scratch : Python invoque NetworkX (librairie mature, algorithmes de graphes prets a l'emploi : plus courts chemins, centralites, flot max, Louvain, matching) ; C# implemente les algorithmes from-scratch sur une adjacency list maison (BFS, DFS, Dijkstra, Ford-Fulkerson). parity_level=surface (meme plan pedagogique, implementations independantes)."
     - "Asymetrie de couverture : Python (42 cellules, 21 code) couvre §1-10 (construction, visualisation matplotlib, plus courts chemins, centralites, flot maximum, detection de communautes Louvain, matching pondere, Prong-B #3801) ; C# (20 cellules, 9 code) couvre §1-6 (graphe pondere, BFS/DFS, Dijkstra, centralites, flot maximum Ford-Fulkerson, visualisation ASCII). Louvain, matching pondere et Prong-B sont absents du C#."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/test #9900

## Quoi / Preuve

Enrichissement pédagogique de `Search-15-NetworkX.ipynb` (Part1-Foundations, Prong-B #3801) : les deux bancs d'essai non-triviaux (§9.1 Dijkstra vs A* et §9.2 PageRank vs Betweenness) produisaient des **sorties comparatives riches** mais **sans aucune cellule markdown d'interprétation** — l'insight pédagogique de chaque comparaison (le point Prong-B) n'était pas explicité pour le lecteur.

Ajout de **2 cellules d'interprétation** (markdown), une après chaque banc, **grounded dans les sorties committées** (règle C.4 : seules des valeurs présentes dans les outputs adjacents sont citées).

### §9.1 — Lecture du résultat Dijkstra vs A*

Sortie committée : Dijkstra coût `5.905` / chemin `6` / **25 nœuds explorés** ; A* coût `5.905` / chemin `6` / **17 nœuds** ; `Identiques : True` ; **32 % d'économie**.

L'interprétation ajoutée explicite les 3 points que les chiffres seuls ne disent pas :
1. **Admissibilité → optimalité préservée** : l'heuristique euclidienne ne surestime jamais le coût réel, donc A* conserve la garantie d'optimalité de Dijkstra (« Identiques : True » n'est pas un hasard, c'est le sanity-check d'admissibilité).
2. **D'où viennent les 8 nœuds économisés** : Dijkstra est single-source (étiquette tout le graphe), A* ne suit que `f = g + h` compétitif → les nœuds du quadrant opposé sont repoussés.
3. **Pourquoi le banc est non-trivial** (Prong B) : sur coût uniforme, A* dégénère en Dijkstra ; ici les poids euclidiens + bruit ±30 % + 10 % d'arêtes retirées créent un terrain où l'heuristique discrimine réellement (32 % mesurable et reproductible). Contraste avec le graphe 6-villes de §4 où l'économie restait « modeste ».

### §9.2 — Lecture du résultat PageRank vs Betweenness

Sortie committée : top-5 PageRank (`Bio_06 0.0454`, `IA_05`, `IA_04`, `IA_03`, `Bio_00`) ≠ top-5 Betweenness (`Phys_08 0.2185`, `Bio_00`, `IA_05`, `Phys_02`, `IA_09`) — intersection = `Bio_00` + `IA_05` seulement.

L'interprétation ajoutée explicite :
1. **Orthogonalité** : popularité (PageRank) et pontage (Betweenness) récompensent des chercheurs différents — 2 chercheurs communs sur 10 places.
2. **`Phys_08`** : domine la betweenness (`0.2185`) mais absent du top PageRank → le chercheur-passerelle type (liaison `Bio_00–Phys_08` porte le trafic inter-communautés, mais pas un hub de citations).
3. **`Bio_06`** (cas inverse) : top PageRank mais absent betweenness → hub intra-Bio cité, pas sur les plus courts chemins inter-communautés.
4. **Les 5 sommets du top betweenness sont tous des passerelles** (contour noir) → la centralité de pontage détecte la structure communautaire que PageRank lisse. Contraste avec §5 (graphe 6-villes où Paris dominait les 4 centralités → petit graphe dense = métriques concordantes).

## Périmètre / ce que la PR fait

- **2 cellules markdown ajoutées** (`d12b8d12`, `0c0e7d04`), zéro modification de cellule code ou output.
- `git diff --numstat` : **13 insertions, 1 déletion** (la déletion = restructuration JSON boundary à l'insertion, pas du contenu supprimé).
- **Exception C.3** : modifs uniquement markdown → outputs précédents valides, **pas de re-exécution** nécessaire.
- **18 cellules code avec outputs inchangées** (vérifié : `code cells WITH outputs: 18` avant = après).

## Méthode (firsthand, `origin/main` a535936250)

1. **Scan ciblé** d'un gap pédagogique réel (cellules code à sortie significative sans markdown d'interprétation entre elles) sur les familles Python CPU (Probas/PyMC, GenAI/Texte, Search/Part1+Part3, ML/ML.Net).
2. **G.9 ground-truth avant action** : 5 autres candidats rejetés firsthand comme faux positifs du scanner (Search-13, LocalLlama, Agentic_Orchestration, SK-Plugins, PyMC-5 — tous avaient paires class-def→demo légitimes ou étaient déjà enrichis). Search-15 était le seul avec un gap RÉEL (comparaison Prong-B substantive sans interprétation).
3. **C.4 grounded** : chaque valeur citée (`5.905`, `25`, `17`, `32 %`, `0.0454`, `0.2185`, les top-5) provient des outputs committés adjacents, vérifiée par lecture directe.

## Acceptance

- [x] 2 cellules d'interprétation ajoutées, positionnées APRÈS le code+visualisation qu'elles commentent (règle « Interpretation APRES le code », [notebook-conventions.md](.claude/rules/notebook-conventions.md)).
- [x] Markdown-only : zéro re-exécution (exception C.3), outputs inchangés.
- [x] C.4 grounded : aucune valeur citée absente des outputs.
- [x] Zéro emoji, français (readme-french-first / code-style).
- [x] JSON valide, structure notebook préservée.

## Périmètre — ce que la PR ne fait pas

- Ne touche ni au code, ni aux outputs, ni aux autres sections du notebook.
- Pas de `Closes #N` : enrichissement pédagogique auto-initié (R5 backlog pickup), pas d'issue dédiée.

See #3801 (Prong-B problem-richness), [notebook-conventions.md](.claude/rules/notebook-conventions.md) (interpretation APRES le code, C.4 grounded).
