### PR TITLE
fix(exercises,#2161): family dir scanned as root no longer empties corpus

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -241,13 +241,26 @@ def _classify(
     # A notebook sitting directly at the top of MyIA.AI.Notebooks/ belongs to no
     # series; every taught series lives in a family directory. `GradeBook.ipynb`
     # (the grading engine) is the only such file today. Gate on the NORMALIZED
-    # `parts` (form-invariant), NOT on `path.is_absolute()`: a relative path --
+    # path (form-invariant), NOT on `path.is_absolute()`: a relative path --
     # exactly what `check_pr_exercises.py --stdin` receives from
     # `git diff --name-only` -- silently skipped the rule, so the PR gate and the
     # fleet scan returned different verdicts for the same file, and the liar was
-    # the one posing labels (#8835). `parts` (= `_scope_parts`) already resolves
-    # both forms to the identical tuple, so every directory rule must consume it.
-    if len(parts) == 1:
+    # the one posing labels (#8835).
+    #
+    # Anchor this check on NOTEBOOKS_DIR specifically, NOT on the scan `root`
+    # consumed by `_scope_parts`: that helper relativizes to the scan tree, so
+    # when a family directory is itself the scan target, EVERY notebook in it
+    # becomes relative-depth-1 and the whole family is false-classified as
+    # tooling. The corpus then empties silently and `--check` passes trivially
+    # (false green) -- observed on `Sudoku/`, `IIT/`, etc. scanned alone (#2161
+    # false-negative). The other directory rules (archive / `_` / legacy /
+    # `groupe-`) correctly key off `parts` because they reason about the path
+    # INSIDE the scan tree; this one alone reasons about NOTEBOOKS_DIR topology.
+    try:
+        notebooks_parts = path.resolve().relative_to(NOTEBOOKS_DIR.resolve()).parts
+    except (ValueError, OSError):
+        notebooks_parts = ()  # outside NOTEBOOKS_DIR entirely -> not top-level
+    if len(notebooks_parts) == 1:
         return ("tooling", None)
 
     if SETUP_STEM_RE.search(stem) or any(SETUP_DIR_RE.search(p) for p in parts[:-1]):

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -1200,3 +1200,48 @@ class TestPathFormInvariance:
         absolute = (root / "GradeBook.ipynb").resolve()
         assert _classify(rel, standard_threshold=3, root=root) == ("tooling", None)
         assert _classify(absolute, standard_threshold=3, root=root) == ("tooling", None)
+
+    def test_family_dir_scanned_as_root_is_not_emptied(self, tmp_path, monkeypatch):
+        """#2161 false-negative: scanning a FAMILY directory as the scan root
+        silently emptied the corpus.
+
+        The top-of-tree ``tooling`` rule (catching ``GradeBook.ipynb`` directly
+        under ``NOTEBOOKS_DIR``) was gated on ``len(_scope_parts(path, root)) == 1``.
+        ``_scope_parts`` relativizes to the scan ``root``, so when a family dir
+        was the scan target, EVERY notebook in it sat at relative-depth-1 and
+        was false-classified ``tooling`` -- the whole family dropped out of the
+        corpus, ``--check`` saw nothing, and returned a trivially-green exit 0.
+        Observed on ``Sudoku/``, ``IIT/``, ``ML/`` scanned alone. The fix anchors
+        the top-of-tree check on ``NOTEBOOKS_DIR`` specifically (not the scan
+        root), mirroring how the other directory rules already key off ``parts``.
+        """
+        root = tmp_path / "nb_root"
+        family = root / "Sudoku"
+        family.mkdir(parents=True)
+        _write_nb(family / "Sudoku-1-Backtracking-Csharp.ipynb", [])
+        _write_nb(family / "Sudoku-0-Environment-Csharp.ipynb", [])
+        _write_nb(root / "GradeBook.ipynb", [])  # the only TRUE top-of-tree file
+        monkeypatch.setattr(count_exercises, "NOTEBOOKS_DIR", root)
+
+        # Scanning the FAMILY dir as root must still see its notebooks -- they
+        # are NOT top-of-tree (GradeBook is). On buggy code both returned
+        # ("tooling", None) and corpus_scope(family) yielded an empty list.
+        assert _classify(
+            family / "Sudoku-1-Backtracking-Csharp.ipynb",
+            standard_threshold=3, root=family,
+        ) == ("standard", 3)
+        assert _classify(
+            family / "Sudoku-0-Environment-Csharp.ipynb",
+            standard_threshold=3, root=family,
+        ) == ("setup", 0)
+        corpus, removed = corpus_scope(family)
+        assert len(corpus) == 2, (
+            f"family scanned as root was emptied (corpus={len(corpus)}, "
+            f"removed={removed}) -- the #2161 false-negative"
+        )
+
+        # The genuine top-of-tree file is still tooling (regression guard on
+        # the fix itself -- anchoring on NOTEBOOKS_DIR must not over-correct).
+        assert _classify(
+            root / "GradeBook.ipynb", standard_threshold=3, root=root,
+        ) == ("tooling", None)


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA — prev: DEEP/lean #9897

## Summary

`count_exercises.py` returned a **silent false-negative** when a family directory was the scan target: `count_exercises.py MyIA.AI.Notebooks/Sudoku` printed `No notebooks matched` and `--check` exited 0 — not because the family conformed, but because the corpus was emptied. The same applied to `IIT/`, `ML/`, `Probas/`, etc. scanned alone.

## Root cause

The top-of-tree `tooling` rule in `_classify` (catching `GradeBook.ipynb`, the only notebook directly under `MyIA.AI.Notebooks/`) was gated on:

```python
if len(parts) == 1:          # parts = _scope_parts(path, root)
    return ("tooling", None)
```

`_scope_parts` relativizes to the scan `root`. When a family dir is the scan target, **every notebook in it sits at relative-depth-1** → all false-classified `tooling` → all filtered as out-of-corpus → empty corpus → `--check` passes trivially.

The rule's own comment states its intent ("directly at the top of `MyIA.AI.Notebooks/`"), i.e. **NOTEBOOKS_DIR topology**, not scan-root depth. The `_scope_parts` refactor (landed for #8858/#8835) silently broke that assumption.

## Fix

Anchor the top-of-tree check on `NOTEBOOKS_DIR` explicitly instead of the generic `parts`:

```python
try:
    notebooks_parts = path.resolve().relative_to(NOTEBOOKS_DIR.resolve()).parts
except (ValueError, OSError):
    notebooks_parts = ()
if len(notebooks_parts) == 1:
    return ("tooling", None)
```

The other directory rules (archive / `_`-prefix / legacy / `groupe-`) still consume `parts` — they reason about the path INSIDE the scan tree, which is correct. Only this one rule reasons about NOTEBOOKS_DIR topology.

This is the **dual of #8835**: same top-of-tree rule misfiring, #8835 was form-variant (relative vs absolute path), this one is root-variant (scan-root vs NOTEBOOKS_DIR). Both are "the GradeBook rule catches more than GradeBook."

## Validation

**Bug reproduction (firsthand, pre-fix):**
```
$ python count_exercises.py MyIA.AI.Notebooks/Sudoku
No notebooks matched the given targets.     # <- 37 notebooks silently dropped
```

**Post-fix:**
```
$ python count_exercises.py MyIA.AI.Notebooks/Sudoku
Notebooks in corpus : 37
Total exercises     : 176
Conforming          : 37
Sub-threshold       : 0
```
Other families scanned alone now also work (IIT 53, ML 48, Probas 58).

**No regression on intended target / full scan:**
- `GradeBook.ipynb` still classifies `tooling` (corpus 0 — correct, it's excluded).
- Full `MyIA.AI.Notebooks` scan unchanged: the fix is a no-op when `root == NOTEBOOKS_DIR` (old and new both compute relative to NOTEBOOKS_DIR in that case).

**Test suite:**
- New regression test `test_family_dir_scanned_as_root_is_not_emptied` in `TestPathFormInvariance`. Verified it **FAILS on old code** (`'tooling' != 'standard'`) and **PASSES on the fix** — a true regression guard.
- Full `notebook_tools` suite: **398 passed, 0 failed** (was 397 + my new test).
- Existing #8858/#8835 tests (path-form invariance, ancestor-named checkout) all still pass — the fix preserves them.

## Anti-régression §D

Pure bug fix to a CI/PR-gate scanner. No proof/notebook touched. The fix makes the scanner STRICTER (sees more notebooks), never looser — a family that was silently un-audited is now correctly scanned.

See #2161 (3-exercises convention + scanner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)