### PR TITLE
feat(hooks,#9888): setup_hooks --self-test verifies gitleaks detection (structure vs function)

### DIFF
--- a/scripts/setup_hooks.py
+++ b/scripts/setup_hooks.py
@@ -15,6 +15,7 @@ Usage:
     python scripts/setup_hooks.py              # install (idempotent)
     python scripts/setup_hooks.py --check      # machine state relevé (no changes)
     python scripts/setup_hooks.py --check-parity  # declared hooks vs executable
+    python scripts/setup_hooks.py --self-test  # functional: stage fake secret, verify gitleaks detects
 
 Design notes:
   - Invokes pre-commit as ``python -m pre_commit`` (no PATH dependency: pip
@@ -23,6 +24,14 @@ Design notes:
     NOT placed on the system PATH (pre-commit's design). The hook works
     regardless -- the proof is that a fake secret is refused at commit, not
     that ``command -v gitleaks`` resolves. See acceptance #2 of #9888.
+  - ``--check`` verifies STRUCTURE (hook file present, module installed);
+    ``--self-test`` verifies FUNCTION (gitleaks actually detects a staged
+    secret). The two differ: the config once shipped without
+    ``[extend] useDefault = true``, so gitleaks matched NOTHING -- structurally
+    "installed", functionally a silent no-op (the root defect of #9888).
+    ``--self-test`` stages a probe, runs gitleaks on the staged content, expects
+    a nonzero exit (leaks found), then cleans up. It is the regression guard
+    for that exact bug class.
 """
 
 from __future__ import annotations
@@ -249,6 +258,75 @@ def cmd_check_parity(repo: Path, python: str) -> int:
     return 0 if rc == 0 else 1
 
 
+# Probe secret for --self-test. Assembled from parts so NO contiguous literal
+# appears in source -- GitHub push protection blocks commits carrying a literal
+# Stripe key pattern even when the value is fake (it cannot tell). The assembled
+# value IS a valid stripe-key pattern that gitleaks flags once written to the
+# probe file. NOT a canonical EXAMPLE key: those are allowlisted by gitleaks'
+# defaults and would mask a silent no-op (the root defect of #9888).
+_SELFTEST_SECRET = "sk_live_" + "51Hqk2l3f4g5h6j7k" + "8l9n0mN1o2pQ3r4s"
+
+
+def cmd_self_test(repo: Path, python: str) -> int:
+    """Functional verification: does gitleaks actually DETECT a staged secret?
+
+    ``--check`` verifies STRUCTURE (hook file present, pre-commit installed)
+    but not FUNCTION. The gitleaks config once shipped without
+    ``[extend] useDefault = true``, so gitleaks matched NOTHING -- structurally
+    "installed", functionally a silent no-op (the root defect of #9888). This
+    mode stages a known-detectable secret, runs gitleaks against the staged
+    content, and expects a nonzero exit (leaks found = detection works). It then
+    cleans up (unstage + delete the probe). No commit is ever made.
+
+    Exit 0 if gitleaks detected the staged secret (harness FUNCTIONAL); exit 1
+    if it did not (silent no-op -- check ``.gitleaks.toml`` ``[extend]
+    useDefault = true``).
+    """
+    if not _pre_commit_available(python):
+        print("setup_hooks: pre-commit not available -- run `setup_hooks.py` first.",
+              file=sys.stderr)
+        return 1
+
+    probe = repo / "_gitleaks_selftest_probe.py"
+    secret = _SELFTEST_SECRET  # assembled at runtime (no literal in source)
+    probe.write_text(
+        f"# setup_hooks --self-test probe (auto-deleted, never committed)\n"
+        f'token = "{secret}"\n',
+        encoding="utf-8",
+    )
+    try:
+        # gitleaks runs as `protect --staged` with pass_filenames:false, so it
+        # scans STAGED content only. `pre-commit run gitleaks --files <x>` is
+        # IGNORED (--files never reaches the hook) -- staging is the only path.
+        _run(["git", "add", "--", str(probe)], repo)
+        rc, out = _run([python, "-m", "pre_commit", "run", "gitleaks"], repo)
+        leaks = out.count("RuleID:")
+        if rc != 0 and leaks > 0:
+            print(f"setup_hooks: SELF-TEST PASS -- gitleaks detected {leaks} staged leak(s).")
+            print("  Harness is FUNCTIONAL (detection works, not just structure).")
+            return 0
+        print(
+            f"setup_hooks: SELF-TEST FAIL -- gitleaks rc={rc}, {leaks} leak(s) reported.",
+            file=sys.stderr,
+        )
+        print(
+            "  A staged secret was NOT detected. Check .gitleaks.toml carries "
+            "`[extend] useDefault = true` (without it gitleaks is a silent no-op, "
+            "the root defect of #9888).",
+            file=sys.stderr,
+        )
+        if out:
+            print(f"  gitleaks output (truncated):\n{out[:400]}", file=sys.stderr)
+        return 1
+    finally:
+        # Cleanup: unstage + delete probe. Never leave the secret staged/on disk.
+        _run(["git", "reset", "-q", "--", str(probe)], repo)
+        try:
+            probe.unlink()
+        except OSError:
+            pass
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(
         description="Idempotent installer for the CoursIA pre-commit harness (#9888)."
@@ -259,12 +337,16 @@ def main(argv: list[str] | None = None) -> int:
                    help="Print machine-state relevé (no changes). Exit 1 if harness inactive.")
     p.add_argument("--check-parity", action="store_true",
                    help="Compare declared hooks vs executable state.")
-    # Allow a plain `--check`/`--check-parity` without implying install.
+    p.add_argument("--self-test", action="store_true",
+                   help="Functional check: stage a fake secret, verify gitleaks detects it, clean up.")
+    # Allow a plain `--check`/`--check-parity`/`--self-test` without implying install.
     args = p.parse_args(argv)
 
     repo = find_repo_root()
     python = sys.executable
 
+    if args.self_test:
+        return cmd_self_test(repo, python)
     if args.check_parity:
         return cmd_check_parity(repo, python)
     if args.check:

--- a/scripts/tests/test_setup_hooks_selftest.py
+++ b/scripts/tests/test_setup_hooks_selftest.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Regression tests for setup_hooks.py --self-test (#9888 functional check).
+
+--self-test stages a probe secret and verifies gitleaks detects it. The
+critical regression guard is the CLEANUP guarantee: even if gitleaks crashes
+or returns a silent no-op, the probe (which contains a fake secret) MUST be
+unstaged and deleted -- never left on disk or in the index. These tests also
+lock the probe-choice rationale: the secret is a stripe key, NOT the canonical
+AWS EXAMPLE key (gitleaks' default ruleset allowlists the latter, so using it
+would make --self-test silently pass even with a broken config -- the exact
+no-op #9888 fights).
+
+Verified live on myia-po-2023 before encoding: gitleaks detected 1 staged
+leak, probe cleaned, exit 0. These unit tests cover the exit logic + cleanup
+guarantee with a mocked gitleaks (CI-portable, no live binary needed).
+
+Executable two ways:
+    py scripts/tests/test_setup_hooks_selftest.py
+    npx pytest scripts/tests/test_setup_hooks_selftest.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SETUP_HOOKS = Path(__file__).resolve().parent.parent / "setup_hooks.py"
+
+GIT = shutil.which("git")
+pytestmark = pytest.mark.skipif(
+    GIT is None,
+    reason="--self-test cleanup tests need git to stage/unstage the probe",
+)
+
+PROBE_SECRET = "sk_live_" + "51Hqk2l3f4g5h6j7k" + "8l9n0mN1o2pQ3r4s"  # assembled; mirrors setup_hooks._SELFTEST_SECRET
+PROBE_NAME = "_gitleaks_selftest_probe.py"
+
+
+@pytest.fixture
+def hooks_module():
+    """Import setup_hooks.py as a module (it lives in scripts/, not a package)."""
+    spec = importlib.util.spec_from_file_location("setup_hooks_under_test", SETUP_HOOKS)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    """A real git repo in tmp_path with one empty commit (so `git reset` resolves
+    HEAD cleanly); cwd switched into it."""
+    subprocess.run(["git", "init", "-q"], cwd=str(tmp_path), check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "--allow-empty", "-m", "init"],
+        cwd=str(tmp_path), check=True,
+        env={**__import__("os").environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
+    )
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _fake_run_factory(simulated_gitleaks):
+    """Build a fake _run that delegates git ops (real) but returns canned output
+    for the pre_commit/gitleaks invocation."""
+
+    def _fake_run(cmd, cwd):
+        # The gitleaks invocation is the only call whose argv contains pre_commit.
+        if any("pre_commit" in c for c in cmd):
+            return simulated_gitleaks
+        # git add / git reset: run for real so staging reflects reality.
+        proc = subprocess.run(
+            cmd, cwd=str(cwd), capture_output=True, text=True, shell=False,
+        )
+        return proc.returncode, (proc.stdout + proc.stderr).strip()
+
+    return _fake_run
+
+
+def _probe_clean(repo):
+    """True if the probe is neither on disk nor in the index."""
+    on_disk = (repo / PROBE_NAME).exists()
+    status = subprocess.run(
+        ["git", "status", "--short"], cwd=str(repo),
+        capture_output=True, text=True,
+    ).stdout
+    in_index = PROBE_NAME in status
+    return not on_disk and not in_index
+
+
+def test_probe_secret_is_real_stripe_key(hooks_module):
+    """The probe must assemble to a key gitleaks actually flags, not an EXAMPLE key.
+
+    The canonical AWS example access key is allowlisted by gitleaks' defaults
+    (AWS documents it) -- using it would mask a silent no-op. The assembled probe
+    must be a realistic stripe key (sk_live_ prefix, plausible length) so the
+    default ruleset flags it. Guard against a future edit switching to an
+    allowlisted/example value.
+    """
+    secret = hooks_module._SELFTEST_SECRET
+    assert secret == PROBE_SECRET, "test PROBE_SECRET drifted from setup_hooks._SELFTEST_SECRET"
+    assert secret.startswith("sk_live_"), "probe must be a stripe key (sk_live_ prefix)"
+    assert len(secret) >= 30, "probe stripe key too short to be realistic"
+    assert not secret.startswith("AKIA"), "AWS example keys are gitleaks-allowlisted"
+
+
+def test_pass_when_leaks_detected(repo, hooks_module, monkeypatch):
+    """gitleaks detects (rc!=0, RuleID in output) -> exit 0 + probe cleaned."""
+    fake_out = (
+        'Finding: token = "REDACTED"\n'
+        "RuleID: stripe-access-token\n"
+        "leaks found: 1\n"
+    )
+    monkeypatch.setattr(hooks_module, "_run", _fake_run_factory((1, fake_out)))
+    monkeypatch.setattr(hooks_module, "_pre_commit_available", lambda python: True)
+
+    rc = hooks_module.cmd_self_test(repo, sys.executable)
+    assert rc == 0
+    assert _probe_clean(repo), "probe leaked (on disk or staged) after a PASS run"
+
+
+def test_fail_and_cleanup_on_silent_noop(repo, hooks_module, monkeypatch, capsys):
+    """Silent no-op (rc=0, no RuleID) -> exit 1, probe cleaned, useDefault hint.
+
+    This is the useDefault-missing regression: gitleaks runs but detects
+    nothing. --self-test must FAIL (exit 1), hint the root cause, and leave no
+    probe behind.
+    """
+    monkeypatch.setattr(hooks_module, "_run", _fake_run_factory((0, "")))
+    monkeypatch.setattr(hooks_module, "_pre_commit_available", lambda python: True)
+
+    rc = hooks_module.cmd_self_test(repo, sys.executable)
+    assert rc == 1, "silent no-op must FAIL the self-test"
+    assert _probe_clean(repo)
+    assert "useDefault" in capsys.readouterr().err, (
+        "FAIL message must hint the [extend] useDefault root cause"
+    )
+
+
+def test_cleanup_when_gitleaks_crashes(repo, hooks_module, monkeypatch):
+    """A gitleaks crash (rc != 0, zero RuleID) must still not leak the probe."""
+    monkeypatch.setattr(
+        hooks_module, "_run", _fake_run_factory((2, "fatal: gitleaks crashed")),
+    )
+    monkeypatch.setattr(hooks_module, "_pre_commit_available", lambda python: True)
+
+    rc = hooks_module.cmd_self_test(repo, sys.executable)
+    assert rc == 1
+    assert _probe_clean(repo), "probe leaked after a gitleaks crash"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #9903

Quoi: Ajoute `setup_hooks.py --self-test` — vérification FONCTIONNELLE que gitleaks détecte réellement un secret staged (vs `--check` qui ne vérifie que la STRUCTURE : hook présent + module installé).

Preuve:
- `python scripts/setup_hooks.py --self-test` sur po-2023 -> `SELF-TEST PASS -- gitleaks detected 1 staged leak(s).` exit 0
- 4/4 tests PASS (`pytest scripts/tests/test_setup_hooks_selftest.py`)
- Suite complete scripts/tests/ : 2044 passed, 0 failed (aucune regression)
- gitleaks Passe sur les 2 fichiers (aucun literal contigu dans la source)

Perimetre: `scripts/setup_hooks.py` (+79 : constante `_SELFTEST_SECRET` assemblee + `cmd_self_test()` + flag) + `scripts/tests/test_setup_hooks_selftest.py` (NEW, 4 tests). 2 fichiers, +234/-1. Catalogue byte-identique a main.

## Pourquoi (le gap structure-vs-fonction)

`--check` verifie la STRUCTURE (fichier hook present, module installe). Mais `.gitleaks.toml` a un jour shippe SANS `[extend] useDefault = true` -> gitleaks matchait NOTHING : structurellement installe, fonctionnellement silent no-op (le defaut racine de #9888). `--self-test` aurait attrape cette regression : il stage un probe, lance gitleaks sur le contenu staged, attend un exit nonzero (leaks found), puis cleanup. Exit 0 si detection OK, 1 si no-op silencieux (message pointe la cause `useDefault`).

## Decisions de design

1. **Probe secret assemble au runtime** (`"sk_live_" + "..." + "..."`) : aucun literal contigu dans la source -> GitHub Push Protection ne bloque pas le commit (un literal Stripe key, meme fake, est bloque server-side ; Push Protection est plus agressif que gitleaks local et ne respecte PAS `# gitleaks:allow`). La valeur assemblee EST un pattern stripe-key valide que gitleaks flag une fois ecrite dans le probe.
2. **Stripe key, PAS cle AWS EXAMPLE** : la cle AWS example canonique est allowlistee par les defaults gitleaks (AWS la documente) -> l'utiliser masquerait un no-op silencieux. Test `test_probe_secret_is_real_stripe_key` verrouille ce choix.
3. **Cleanup garanti** : le probe (fake secret) est unstaged + supprime dans un `finally`, meme si gitleaks crashe. 2 tests verrouillent cela.

## Methodologie notee (lecons de test #9888 acceptance #2)

En verifiant acceptance #2 firsthand, 2 erreurs de methode (pas des bugs) :
- `--files <path>` hors-mount (C: vs D:) -> `ValueError: path is on mount` (artifact de test, fichier hors-repo)
- `--files` est IGNORE par le hook gitleaks (`pass_filenames:false` + `protect --staged`) -> il faut `git add` puis scanner le staged

`--self-test` encode la bonne methode (stage -> scan -> cleanup) pour les futurs workers.

See #9888 (acceptance #2 : mecanisme de verification fonctionnelle reproductible).

Generated with Claude Code
