### PR TITLE
docs(repo-size,#9860): du -sh .git != depot size (submodule stores + garbage)

### DIFF
--- a/docs/reference/repo-size-policy.md
+++ b/docs/reference/repo-size-policy.md
@@ -51,6 +51,18 @@ incidents passés (le `model.pt`) désormais nettoyés de l'arbre courant.
 > `warning: garbage found: .git/objects/pack/tmp_pack_*` sur un clone de travail. Ces
 > `tmp_pack_*` sont du **garbage local** à la machine (un `git gc` les élimine), pas un
 > problème du dépôt distant. Ne pas les confondre avec le sujet.
+>
+> **`du -sh .git` n'est pas la taille du dépôt.** Sur une machine de dev, `du -sh .git`
+> additionne des composantes **locales** qu'un cloneur ne paie jamais : (a) `size-pack`
+> (le pack parent — accrète plusieurs fichiers `.pack` sur un clone longévif, non coalescés
+> tant qu'un `git gc` n'a pas tourné), (b) `size-garbage` (`tmp_pack_*` orphelins, cf.
+> ci-dessus), et (c) **`.git/modules/`** — les object stores des 8 submodules (cf. §5.1),
+> checkoutés localement mais absents du pack parent. Mesure firsthand sur une machine du
+> cluster : `size-pack ~2 GiB` + `size-garbage ~890 MiB` + `.git/modules ~270 MiB`, soit un
+> `du -sh .git` dépassant largement le pack distant (~1,2 GiB bare, cf. en-tête) — un écart
+> qui n'est **pas** une régression de taille, juste la somme de ces trois composantes locales.
+> La source de vérité pour la taille du dépôt est le pack distant (ce qu'un `git clone` nu
+> récupère), jamais `du -sh .git` sur une machine de travail.
 
 ## 4. Ce qui ne doit JAMAIS entrer
 


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2025:CoursIA — prev: DEEP/notebook-python

## Ce que fait cette PR

Comble le **seul gap réel** du `repo-size-policy.md` signalé par ai-01 (DM msg-20260807T142322) : la réconciliation explicite de `du -sh .git` (machine locale) vs la taille réelle du dépôt distant.

## G.1 — la mesure d'ai-01 était stale

ai-01 a mesuré « `submodule` = 0 occurrence et `rewrite|reecriture|fork` = 0 » et conclu que les deux garde-fous manquaient. Vérification firsthand sur `origin/main` (SHA a53593625) : **les deux topics sont déjà couverts** —
- **§2.2** « Réécriture d'historique (`git filter-repo`, BFG) : NON » cite explicitement les **~95 forks étudiants** (« casserait chacun d'eux », « acquis, non négociable »).
- **§5.1** « Submodules » documente les **8 submodules**, l'angle mort du check §6, la décision et le critère de refus.

La mesure « 0 occurrence » s'explique par un grep sans accent (`reecriture` ne matche pas `Réécriture`) sur un arbre périmé (leçon `audit-on-originmain-not-stale-local`). Les garde-fous demandés **existent déjà** — cette PR n'ajoute **pas** de doublon.

## Le gap réel comblé

Le seul contenu genuinely manquant : **`du -sh .git` n'est pas la taille du dépôt**. Mesure firsthand (cluster, ce cycle) :

| Composante locale | Taille | Payée par un cloneur ? |
|-------------------|--------|------------------------|
| `size-pack` (parent) | ~2 GiB | Oui (pack distant) |
| `size-garbage` (`tmp_pack_*`) | ~890 MiB | Non (local, `git gc`) |
| `.git/modules/` (8 submodules) | ~270 MiB | Non (checkout local) |

`du -sh .git` additionne les trois → dépasse largement le pack distant bare (~1,2 GiB). Sans cette distinction écrite, le prochain agent qui lit `du -sh .git` diagnostique une régression de taille qui n'existe pas. La source de vérité = `size-pack` (dépôt distant), jamais `du -sh .git` (machine locale).

## Preuve

- Diff `+12` lignes, doc-only (`docs/reference/repo-size-policy.md`), aucune dépendance, aucun churn catalogue.
- Mesures `git count-objects -vH` + `.git/modules` firsthand (non hardcodées depuis ai-01, mesurées ce cycle).

See #9860.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
