### PR TITLE
Refactor(lean,#8696): Reidemeister3 surgery = field-equalities (window 5/9)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister.lean
@@ -407,8 +407,8 @@ ici comme une injection `Fin d₁.numEdges ↪ Fin d₂.numEdges` (avec dimensio
 def Reidemeister3 (d₁ d₂ : KnotDiagram) : Prop :=
   d₁.crossings.length = d₂.crossings.length ∧ d₁.numEdges = d₂.numEdges ∧
   ∃ i c, ∃ ρ : Fin d₁.numEdges ↪ Fin d₂.numEdges,
-    (d₂ = { d₁ with crossings := d₁.crossings.set i c } ∨
-     d₁ = { d₂ with crossings := d₂.crossings.set i c }) ∧
+    (d₂.crossings = d₁.crossings.set i c ∨
+     d₁.crossings = d₂.crossings.set i c) ∧
     d₁.wf = true ∧ d₂.wf = true
 
 /-- R3 est symétrique par construction : la disjonction de chirurgie est
@@ -490,8 +490,17 @@ def Reidemeister3Determined (d₁ d₂ : KnotDiagram) : Prop :=
 theorem Reidemeister3Determined.implies_reidemeister3 {d₁ d₂ : KnotDiagram}
     (h : Reidemeister3Determined d₁ d₂) : Reidemeister3 d₁ d₂ := by
   obtain ⟨hl, he, i, c, ρ, _hperm, hsurg | hsurg, hwf₁, hwf₂⟩ := h
-  · exact ⟨hl, he, i.val, c, ρ, Or.inl hsurg, hwf₁, hwf₂⟩
-  · exact ⟨hl, he, i.val, c, ρ, Or.inr hsurg, hwf₁, hwf₂⟩
+  · -- `hsurg : d₂ = {d₁ with crossings := d₁.crossings.set i.val c}` est
+    -- une égalité de record `with`-surgery. Pour l'injecter dans R3 (qui
+    -- attend une égalité de champ `d₂.crossings = d₁.crossings.set i.val c`
+    -- post-migration field-eq), on extrait la composante `crossings` via
+    -- `congrArg` sur le foncteur d'accès au champ. Le témoin `numEdges`
+    -- de R3D est déjà garanti par `he : d₁.numEdges = d₂.numEdges` du
+    -- destructuring, donc le seul champ à projeter est `crossings`.
+    exact ⟨hl, he, i.val, c, ρ, Or.inl (congrArg (fun d => d.crossings) hsurg),
+           hwf₁, hwf₂⟩
+  · exact ⟨hl, he, i.val, c, ρ, Or.inr (congrArg (fun d => d.crossings) hsurg),
+           hwf₁, hwf₂⟩
 
 /-- `Reidemeister3Determined` n'est PAS vide : un glissement slot-déterminé
     concret `d₁ → d₂` avec `wf = true` des deux côtés. Témoin : `d₁` a deux

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Reidemeister_en.lean
@@ -385,8 +385,8 @@ injection `Fin d₁.numEdges ↪ Fin d₂.numEdges` (with equal dimensions).
 def Reidemeister3 (d₁ d₂ : KnotDiagram) : Prop :=
   d₁.crossings.length = d₂.crossings.length ∧ d₁.numEdges = d₂.numEdges ∧
   ∃ i c, ∃ ρ : Fin d₁.numEdges ↪ Fin d₂.numEdges,
-    (d₂ = { d₁ with crossings := d₁.crossings.set i c } ∨
-     d₁ = { d₂ with crossings := d₂.crossings.set i c }) ∧
+    (d₂.crossings = d₁.crossings.set i c ∨
+     d₁.crossings = d₂.crossings.set i c) ∧
     d₁.wf = true ∧ d₂.wf = true
 
 /-- R3 is symmetric by construction: the surgery disjunction is symmetric, the
@@ -461,8 +461,17 @@ def Reidemeister3Determined (d₁ d₂ : KnotDiagram) : Prop :=
 theorem Reidemeister3Determined.implies_reidemeister3 {d₁ d₂ : KnotDiagram}
     (h : Reidemeister3Determined d₁ d₂) : Reidemeister3 d₁ d₂ := by
   obtain ⟨hl, he, i, c, ρ, _hperm, hsurg | hsurg, hwf₁, hwf₂⟩ := h
-  · exact ⟨hl, he, i.val, c, ρ, Or.inl hsurg, hwf₁, hwf₂⟩
-  · exact ⟨hl, he, i.val, c, ρ, Or.inr hsurg, hwf₁, hwf₂⟩
+  · -- `hsurg : d₂ = {d₁ with crossings := d₁.crossings.set i.val c}` is a
+    -- `with`-surgery record equality. To inject it into R3 (which now expects a
+    -- field equality `d₂.crossings = d₁.crossings.set i.val c` after the
+    -- field-eqs migration), we project the `crossings` component via
+    -- `congrArg` on the field-access functor. The `numEdges` witness of R3D
+    -- is already guaranteed by `he : d₁.numEdges = d₂.numEdges` from the
+    -- destructuring, so the only field to project is `crossings`.
+    exact ⟨hl, he, i.val, c, ρ, Or.inl (congrArg (fun d => d.crossings) hsurg),
+           hwf₁, hwf₂⟩
+  · exact ⟨hl, he, i.val, c, ρ, Or.inr (congrArg (fun d => d.crossings) hsurg),
+           hwf₁, hwf₂⟩
 
 /-- `Reidemeister3Determined` is NOT vacuous: a concrete slot-determined slide
     `d₁ → d₂` with `wf = true` on both sides. Witness: `d₁` has two identical


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA-2 — prev: DEEP/lean #9901

Quoi: Migration Reidemeister3 (L407-412 FR + L385-390 EN) depuis `with`-surgery vers field-equalities single-field (window 5/9 #8696, AVANT-DERNIER site corridor)
Preuve: Lake build 4/4 EXIT=0 (warm cache post-c.8167 + R3D consumer fix), sorry 2/2/14/9 baseline c.8167 inchange, 0 axiome ajoute, 1 consumer intra-file R3D.implies_reidemeister3 mis a jour (projection `congrArg (fun d => d.crossings) hsurg`)
Perimetre: 2 fichiers modifies, +26/-8 lignes (def R3 single-field + projection R3D consumer), Reidemeister3.symm survit tel quel (pattern Or.inl/inr preserve)

## Refactor(lean,#8696): Reidemeister3 surgery = field-equalities (window 5/9)

Suite du chantier multi-cycle **#8696** (Reidemeister corridor field-eqs migration).
Apres Reidemeister1 (L91/92, **PR #9807 MERGED**), Reidemeister1' (L143/145, **PR #9807 MERGED**),
Reidemeister1Connected (L262-272, **PR #9873 OPEN**), et Reidemeister2 (L377-382, **PR #9901 OPEN**),
la chirurgie `with`-update de **`Reidemeister3`** est remplacee par une **egalite de champ unique**
sur `d2.crossings (set i c)` dans chaque branche de la disjonction symetrique, sans modification
de `d2.numEdges` (R3 preserve le nombre d'aretes par construction, donc un seul champ suffit).

## Pattern A single-field applique

```lean
-- AVANT (record `with` surgery, par branche de la disjonction)
def Reidemeister3 (d1 d2 : KnotDiagram) : Prop :=
  d1.crossings.length = d2.crossings.length and d1.numEdges = d2.numEdges and
  exists i c, exists rho : Fin d1.numEdges <~> Fin d2.numEdges,
    (d2 = { d1 with crossings := d1.crossings.set i c } or
     d1 = { d2 with crossings := d2.crossings.set i c }) and
    d1.wf = true and d2.wf = true

-- APRES (field equality single-field, par branche de la disjonction)
def Reidemeister3 (d1 d2 : KnotDiagram) : Prop :=
  d1.crossings.length = d2.crossings.length and d1.numEdges = d2.numEdges and
  exists i c, exists rho : Fin d1.numEdges <~> Fin d2.numEdges,
    (d2.crossings = d1.crossings.set i c or
     d1.crossings = d2.crossings.set i c) and
    d1.wf = true and d2.wf = true
```

Pattern **plus simple** que les fenetres precedentes : un seul champ concerne (`crossings`), pas de modification de `numEdges` (a la difference de R2 qui ajoutait +4 edges). Donc Pattern A single-field au lieu du 2-conj `(h_cross, h_num)` de R2.

## Benefices

1. **`Reidemeister3.symm` survit tel quel** (L418-427 FR / L395-404 EN) :
   `Or.inl h` / `Or.inr h` consomme directement l'egalite de champ
   `h : d2.crossings = d1.crossings.set i c` comme type `alpha` dans
   `Or.inl/inr : alpha -> alpha or beta`. Le destructuring
   `obtain ... h | h` reste valide : la disjonction est preservee,
   chaque arm devient l'egalite single-field.

2. **`Reidemeister3Determined.implies_reidemeister3` mis a jour**
   (L490-498 FR / L461-465 EN) : R3D reste `with`-surgery (hors scope
   #8696, planifie pour c.8169+), donc `hsurg : d2 = {d1 with crossings := d1.crossings.set i.val c}`
   doit etre **projete** sur le champ `crossings` avant injection dans
   R3. Solution : `congrArg (fun d => d.crossings) hsurg`. Le
   destructuring `obtain ... hsurg | hsurg` reste valide (meme type
   `alpha or beta` dans R3D), seul le type du cinquieme composant
   du `Exists.intro` change (record-eq -> field-eq). 1 ligne modifiee
   par arm (la conversion est inline).

3. **Aucun consumer cross-file a mettre a jour** : `Reidemeister3` n'est
   pas reference dans `Invariant.lean` / `Invariant_en.lean` (sweep L891 ★★
   pre-edit l'a confirme). Identique a c.8167 (R2) : 0 cross-file consumer.

4. **i18n sibling-pair #4980** : la def FR (L407-412) est byte-identique
   a la def EN (L385-390 dans `Reidemeister_en.lean`), hors docstrings
   (critere verifie par diff direct, comme c.8164 + c.8166 + c.8167).

5. **Pattern duplique** : meme mecanique `with`-surgery -> field-eqs,
   meme semantique preservee (proof-irrelevant, meme `Prop`, memes
   temoins `i, c, rho`).

## Scope reel #8696 = 5 fenetres (post-c.8168)

| Fenetre | Site | PR | Statut |
|---|---|---|---|
| 1/9 | Reidemeister1 L91/92 | #9807 | MERGED |
| 1/9 (meme PR) | Reidemeister1' L143/145 | #9807 | MERGED |
| 2/9 | (NO-OP decouverte c.8165) | #9816 | CLOSED |
| 3/9 | Reidemeister1Connected L262-272 | #9873 | OPEN |
| 4/9 | Reidemeister2 L377-382 | #9901 | OPEN |
| **5/9** | **Reidemeister3 L407-412** | **#????** | **cette PR** |

Apres merge de c.8168 (cette PR) + c.8167 (#9901) + c.8166 (#9873), le scope #8696 = **5/9 complete**.

Reste **R3D L484-485** = **NOUVEAU chantier** `with`-surgery single-element avec **2 consumers** a mettre a jour :
- `implies_reidemeister3` (L490-498 FR / L461-465 EN, deja mis a jour c.8168 par projection)
- potentiel autre consumer non encore identifie (sweep L891 ★★ obligatoire sur c.8169)

PR livree = `See #8696` (L883 ★, pas `Closes` : contribution finale d'un chantier multi-cycle, la fermeture complete est le merge de c.8167 + c.8168).

## Perimetre c.8168

| Fichier | Lignes touchees | Statut |
|---|---|---|
| `Knots/Reidemeister.lean` | def R3 L407-412 + R3D consumer L490-498 (12 lignes modifiees) | modifie |
| `Knots/Reidemeister_en.lean` | mirror EN def R3 L385-390 + R3D consumer L461-465 (12 lignes modifiees) | modifie (byte-identity FR) |

**Total** : 2 fichiers, **+26 insertions / -8 deletions**. **Aucun** consumer cross-file.

## Validation

- **Lake build** (warm cache post-c.8167 + R3D consumer fix post-c.8168) : `lake build Knots.Reidemeister`,
  `Knots.Reidemeister_en`, `Knots.Invariant`, `Knots.Invariant_en` -- **4/4 EXIT=0**.
- **Axiomes** :
  - `grep -c sorry` par fichier : **2/2/14/9** (unchange depuis baseline c.8167).
  - `grep -c native_decide` par fichier : **0/0/4/4** -- les 4+4 mentions dans `Invariant*`
    sont **toutes dans des docstrings `/-- ... -/`** (descriptions historiques). Aucun
    `native_decide` actif introduit.
  - `grep -c sorryAx` par fichier : **0**.
  - `grep -c Classical.choice` par fichier : **0/0/1/1** (pre-existants, inchanges).
- **proof-integrity SUCCESS** : `lean-axiom.yml` non cable sur le lake `knot_lean`
  (cf triage par lake `docs/reference/lean-axiom-coverage.md`). **B.3 non applicable pour ce module** --
  a ecrire explicitement, le job advisory `target-coverage` rend l'ecart lisible dans le log.
- **L891 ★★ pre-edit sweep** : `grep -rn "congrArg.*hsurg|hsurg\\b|simpa using congrArg.*hsurg"`
  exhaustif avant edition. **Aucun consumer cross-file de R3** dans `Invariant.lean`
  / `Invariant_en.lean` (seul le type `inductive ReidemeisterStep.r3` est reference,
  inchange car le type de `Reidemeister3` reste `Prop`).
- **L898 ★★★ pre-claim collision guard** : `gh pr list --search head:feature/c8168-...`
  = `[]` (pas de collision cross-lane).

## Hors-scope (decouplage multi-cycle)

1 site `with`-surgery restant dans `Reidemeister.lean` / `Reidemeister_en.lean`
(programme pour le cycle suivant) :

- **c.8169** : R3D L484/485 / L484/485 (single-element `set i.val c` + 0 edges).
  **NOUVEAU chantier** car **migration de R3D elle-meme** doit etre faite, plus
  verification que `implies_reidemeister3` reste correcte apres migration des deux cotes.

## Lecons appliquees

- **L891 ★★** (c.8166) : Exhaustive cross-file consumer sweep OBLIGATOIRE avant
  migration `with`-surgery → field-eqs. Ici = sweep exhaustif, **0 cross-file consumer R3**.
- **L891 ★★ extended** : **intra-file consumer** (R3D.implies_reidemeister3) **peut aussi
  casser** si le consumer a une disjonction symetrique d'un cote (R3D) qui doit etre
  injectee dans une autre disjonction symetrique (R3) avec une signature differente
  (record-eq vs field-eq). Le sweep L891 ★★ etait cross-file ; c.8168 etend la
  portee a **intra-file consumer qui partage la structure `obtain ... h | h`**.
- **L887 ★★** (c.8164) : Pattern A `with`-surgery → field-eqs duplique sur
  5 sites en 5 PRs.
- **L890 ★★** (c.8165) : `git diff origin/main..HEAD -- <paths>` obligatoire avant push ;
  ici = +26/-8, **pas un no-op**.
- **L892 ★★** (c.8167) : Compound triple-gate (merge-base + REST + `gh pr list`) sur
  la branche orpheline-par-creation `feature/c8168-8696-reidemeister3-eqch`
  → ORPHELINE CONFIRMEE, self-pick OK.
- **L893 ★★** (c.8167) : Lake build REPLAY != silent failure : exit=0 + Replayed downstream
  = OK si upstream silent.
- **L883 ★** : `See #8696` (pas `Closes`, contribution finale d'un chantier multi-cycle).
- **L677-L4 ★★** : PR body HORS worktree (scratchpad pattern).
- **L888 ★** : `git commit -F <file>` (pas de heredoc bash avec backticks).
- **L898 ★★★** : `gh pr list --search head:<branch>` = `[]` (pas de collision cross-lane).
- **L576 ★★ + L843 ★** : Compound gate (merge-base + REST + `gh pr list`) sur la branche
  orpheline-par-creation.
- **L9774** : claim posee sur issue #8696 (`[CLAIMED] lane myia-po-2026:CoursIA-2 ... 2026-08-07T17:??Z`).
- **L885 ★★** (c.8162) : Mathlib cache recovery via `cp -r <sibling-worktree>/.lake/packages/mathlib`
  (~3.9 GB, ~5 min 9P). c.8168 = premiere application directe de cette lecon.

## Anti-regression §D

Aucun `sorry` ajoute. Aucune regression d'axiome. Aucune suppression de code metier.
Seul le **pattern mecanique** `with`-surgery (L407-412 / L385-390) est remplace par des
egalites de champs, et le **consumer R3D.implies_reidemeister3** est adapte par projection
`congrArg (fun d => d.crossings) hsurg`, ce qui **preserve la semantique** (proof-irrelevant,
meme `Prop`, memes temoins `i, c, rho`) et **uniformise** la signature avec R1/R1'/R1Connected/R2.

## Voir aussi

- PR #9807 (window 1/9 #8696, c.8164) -- Reidemeister1 + Reidemeister1' field-eqs.
- PR #9873 (window 3/9 #8696, c.8166) -- Reidemeister1Connected field-eqs.
- PR #9901 (window 4/9 #8696, c.8167) -- Reidemeister2 field-eqs.
- Issue **#8696** -- corridor Reidemeister (9 sites `with`-surgery, **5 fenetres completes post-c.8168**, NO-OP c.8165).
- Topic [cycles-c8162-c8166-reidemeister-corridor](MEMORY.md#cycles-c8162-c8166--reidemeister-corridor-refactor-8696-multi-cycle-chantier).
- L887 ★★, L890 ★★, L891 ★★, L883 ★, L898 ★★★, L677-L4 ★★, L888 ★, L576 ★★, L843 ★, L892 ★★, L893 ★★, L885 ★★.