### PR TITLE
docs(tweety,#4667): add 3 interpretation cells to Tweety-3-Dung-Csharp

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Dung-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Dung-Csharp.ipynb
@@ -400,6 +400,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "i3bb7a9fd",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : pourquoi `{a}` ?\n",
+    "\n",
+    "Sur l'AF `a -> b`, l'extension **fondée** (grounded) est `{a}`. Cette sémantique se construit de façon **sceptique et déterministe**, par point fixe :\n",
+    "\n",
+    "1. On part des arguments **inattaqués** — `a` n'est attaqué par personne, donc `a` entre dans l'extension.\n",
+    "2. Tout argument attaqué par un membre déjà accepté est **battu** — `b`, attaqué par `a`, est exclu.\n",
+    "3. On itère : aucun nouvel argument ne devient inattaqué, donc on s'arrête.\n",
+    "\n",
+    "D'où le verdict de la cellule : `grounded |= a` vrai, `grounded |= b` faux. La force de la fondée est son **unicité** (toujours une seule extension, jamais d'ambiguïté) et sa **complexité polynomiale**. Sa faiblesse est sa **prudence extrême** : dès que deux arguments s'attaquent mutuellement, aucun des deux n'est accepté — c'est précisément ce que la cellule suivante met en évidence.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "m819417",
    "metadata": {},
    "source": [
@@ -533,6 +549,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "icc72fd74",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : la hiérarchie des sémantiques se dévoile\n",
+    "\n",
+    "Sur l'attaque mutuelle `x <-> y`, les quatre sémantiques **divergent** — c'est le moment où leur hiérarchie d'inclusions devient lisible :\n",
+    "\n",
+    "| Sémantique | Extensions | Lecture |\n",
+    "|------------|------------|--------|\n",
+    "| **Fondée** | `{}` | Aucun argument n'est inattaqué, donc rien n'entre. Prudence maximale. |\n",
+    "| **Stable** | `{x}`, `{y}` | Accepter l'un exclut l'autre. `{}` n'est **pas** stable : un stable doit attaquer tout non-membre, or `{}` n'attaque personne. |\n",
+    "| **Préférée** | `{x}`, `{y}` | Maximaux parmi les admissibles. Ici, coïncide avec le stable. |\n",
+    "| **Complète** | `{x}`, `{y}`, `{}` | Comme la préférée **plus `{}`** : l'extension vide est toujours complète (trivialement admissible, elle se défend contre tout… rien). |\n",
+    "\n",
+    "**La cascade d'inclusions canonique** : `fondée ⊆ complète`, et la fondée est la *plus petite* extension complète (ici `{}`). `stable ⊆ complète` quand des stables existent ; `préférée = complète maximale`. C'est cette hiérarchie que les exercices ci-dessous vous demanderont d'explorer sur des AF plus subtils (cycle à trois, auto-attaque).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "m622273",
    "metadata": {},
    "source": [
@@ -630,6 +665,22 @@
     "Console.WriteLine(\"AF3 fondée ⊨ B ? \" + gr.query(af3, B));\n",
     "Console.WriteLine(\"AF3 fondée ⊨ A ? \" + gr.query(af3, A));   // battu par D\n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "i0c6a2416",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : la défense en chaîne\n",
+    "\n",
+    "Sur `AF3 = {A->B, A->C, D->A}`, l'extension fondée est `{B, C, D}`. C'est l'illustration du **mécanisme de défense** qui distingue l'argumentation de la simple élimination :\n",
+    "\n",
+    "- `D` est **inattaqué** → entre (germe du raisonnement).\n",
+    "- `D` attaque `A` → `A` est battu et exclu.\n",
+    "- Une fois `A` exclu, ses attaques sur `B` et `C` **s'évanouissent** → `B` et `C` redeviennent inattaqués et entrent à leur tour.\n",
+    "\n",
+    "`D` **défend** `B` et `C` en neutralisant leur attaquant commun `A`. C'est pourquoi `grounded |= D` et `grounded |= B` sont vrais, mais `grounded |= A` est faux. Un argument peut donc être accepté non parce qu'il est inattaqué, mais parce qu'il est **défendu** par un allié déjà accepté — ce mécanisme itératif est le cœur des systèmes d'argumentation abstraite.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA — prev: MED/docs

## Ce que fait cette PR

Enrichissement pédagogique markdown-only de **Tweety-3-Dung-Csharp.ipynb** : ajoute 3 cellules d'interprétation placées **après** les cellules de code qu'elles interprètent (convention CLAUDE.md « Cellules d'interprétation APRES la cellule de code interprétée »). Rotation de genre sollicitée par ai-01 (DM msg-20260807T183035 : sortir du registre outillage, 5 MED/tooling consécutifs → piocher un autre genre du pool global).

Le notebook calculait les 4 sémantiques de Dung (fondée / stable / préférée / complète) en C#/.NET via IKVM mais n'interprétait **aucun** de ses 12 outputs : un étudiant lisait `{}`, `{x}`, `{y}`, `{}` sans la moindre lecture pédagogique. C'est précisément le gap que ces cellules comblent.

## Les 3 cellules (toutes grounded dans les outputs committés firsthand)

| Position | Après code | Output lu | Interprétation ajoutée |
|----------|-----------|-----------|------------------------|
| `[12]` | exec=7 (`a -> b`) | `fondée = {a}`, `⊨a true`, `⊨b false` | **Pourquoi `{a` ?** — point fixe sceptique : inattaqués entrent, attaqués par acceptés sont battus. Force = unicité + complexité poly ; faiblesse = prudence extrême. |
| `[15]` | exec=8 (`x <-> y`) | `fondée {}`, `stable {x}/{y}`, `préférée {x}/{y}`, `complète {x}/{y}/{}` | **Hiérarchie des sémantiques** — tableau 4-lignes + cascade d'inclusions `fondée ⊆ complète`, `stable ⊆ complète`, `préférée = complète maximale`. Pourquoi `{}` n'est pas stable mais est complète. |
| `[18]` | exec=9 (AF3 `A->B, A->C, D->A`) | `fondée = {B,C,D}`, `⊨D true`, `⊨B true`, `⊨A false` | **Défense en chaîne** — D inattaqué entre, bat A, les attaques de A sur B/C s'évaporent, B/C entrent. Le mécanisme itératif de défense. |

## Preuves

- **Diff chirurgical** : `git diff --shortstat` = **1 file changed, 51 insertions(+), 0 deletions(-)**. Markdown-only (C.3). La cause d'un churn initial (nbformat.read() collapse les `source` list→string) a été diagnostiquée et corrigée : ré-application via `json.load` (préserve les listes source) → diff minimal.
- **C.1** : grep `raise NotImplementedError|assert False|1/0` sur les 12 cellules code = **0 hit**.
- **C.3** : aucune cellule code source/output modifiée (exception markdown-only — outputs précédents valides, pas de re-exec requise).
- **Non-twin** : `git grep` sur `twin_pairs.d/` = aucun match (enrichissement sûr, pas de DRIFT twin).
- **nbformat 4.5 valide** (`nbformat.validate`), 27 cellules (24→27), 12 cellules code avec `execution_count` + `outputs` intacts.
- **L898** : `gh pr list --search "Tweety-3-Dung-Csharp"` = aucune PR ouverte (pas de collision).

## Diff

1 fichier : `Tweety-3-Dung-Csharp.ipynb` (+51, 0). Catalogue byte-identique à main.

See #4667 (EPIC Tweety port C#/.NET natif dont ce notebook relève).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
