### PR TITLE
docs(genai,#1385): add 2 interpretation cells to FT-02-QLoRA-Quantization

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb
@@ -1047,6 +1047,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ift02-gen",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : la greffe stylistique du fine-tuning\n",
+    "\n",
+    "La génération `« Dans les rues sombres de Paris, Jean Valjean… »` prouve que le fine-tuning QLoRA a **modifié le comportement** du modèle. L'OPT-1.3B de base, entraîné sur un corpus anglophone générique, produit désormais du français qui réemploie le **lexique des *Misérables*** (`Jean Valjean`, `rues sombres de Paris`) — la greffe du dataset de classiques français a pris. Mais observez aussi les **limites** : `« la sonne du consaveau »`, `« ce qu'il lui aveuglait »` sont des fragments grammaticalement incohérents. C'est le compromis attendu d'un modèle de **1,3 Md paramètres** fine-tuné sur **seulement 10 extraits** : l'imprégnation stylistique prend, la cohérence syntaxique profonde ne suit pas. C'est précisément ce déséquilibre que la cellule de comparaison suivante quantifie (qualité `~97-99%` du full fine-tuning).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "acf6d40f",
    "metadata": {
     "papermill": {
@@ -1296,6 +1306,22 @@
     "print(f\"\\nRecommendation :\\n\"\n",
     "      \"  - Modele < 1B + VRAM suffisante -> LoRA (FP16) : plus simple, plus rapide\\n\"\n",
     "      \"  - Modele > 1B ou VRAM limitee -> QLoRA : Economie memoire 3-4x\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ift02-cmp",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : le triptyque VRAM / qualité / vitesse\n",
+    "\n",
+    "Le tableau récapitulatif condense la **promesse et le coût** de QLoRA sur trois axes :\n",
+    "\n",
+    "- **VRAM (le gain décisif)** : `~0,7 Go` (QLoRA) contre `~2,6 Go` (LoRA FP16), soit **~3,7× d'économie mémoire**. C'est ce qui rend un modèle de 1,3 Md fine-tunable sur une carte *consumer* (8-12 Go) au lieu d'une 24 Go. La clé : seuls les poids **NF4 (4 bits)** résident en VRAM ; les gradients et l'optimiseur ne portent que sur les **adaptateurs LoRA** (FP16), d'où la ligne `Grad + optimizer : FP16 (LoRA seul)` identique des deux côtés.\n",
+    "- **Qualité (le prix à payer)** : `~97-99%` du full fine-tuning. La quantization NF4 préserve l'information car elle **concentre la précision** là où les poids sont denses (distribution gaussienne supposée), mais une dégradation de 1-3 % est intrinsèque à la perte d'information 16→4 bits.\n",
+    "- **Vitesse (le coût caché)** : `~0,8×`, soit ~20 % de ralentissement. La **déquantization** NF4→FP16 à chaque *forward pass* a un surcoût de calcul — QLoRA n'est pas gratuit en temps d'entraînement.\n",
+    "\n",
+    "La **recommandation** qui clôt le tableau encode la règle de décision : LoRA (FP16) si la VRAM le permet (plus simple, plus rapide), QLoRA dès que le modèle dépasse ~1 Md de paramètres ou que la VRAM est contrainte. C'est ce positionnement — *fine-tuner de gros modèles sur du petit matériel* — qui a fait de QLoRA le standard du fine-tuning ouvert sur GPU *consumer*.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-dotnet

## Ce que fait cette PR

Enrichissement pédagogique markdown-only de **FT-02-QLoRA-Quantization.ipynb** : ajoute 2 cellules d'interprétation après les cellules de code qu'elles interprètent (convention CLAUDE.md). Genre notebook-python (rotation vs le notebook-dotnet livré juste avant, #9919).

Le notebook fine-tunait OPT-1.3B en QLoRA et produisait sa **génération de texte** (preuve du fine-tuning) puis un **tableau récapitulatif LoRA vs QLoRA** (le climax pédagogique : VRAM/qualité/vitesse) — **aucun des deux** n'était interprété. La cellule suivant le tableau sautait directement à « Nettoyage mémoire GPU », laissant l'étudiant devant des chiffres sans lecture.

## Les 2 cellules (grounded dans les outputs GPU committés firsthand)

| Position | Après code | Output lu | Interprétation ajoutée |
|----------|-----------|-----------|------------------------|
| `[20]` | exec=10 (génération) | `« Dans les rues sombres de Paris, Jean Valjean… »` + fragments incohérents `« la sonne du consaveau »` | **Greffe stylistique** : OPT-1.3B anglophone produit désormais du français Hugo (lexique *Misérables*). Mais l'incohérence syntaxique révèle les limites 1,3 Md + 10 extraits. |
| `[24]` | exec=12 (tableau LoRA vs QLoRA) | VRAM `~0,7 Go` vs `~2,6 Go`, qualité `~97-99%`, vitesse `~0,8×` | **Triptyque VRAM/qualité/vitesse** : ~3,7× d'économie mémoire (poids NF4 4-bit + LoRA FP16), qualité préservée via NF4 densité-adaptive, coût vitesse ~20% (déquant), + règle de décision. |

## Preuves

- **Diff chirurgical** : `git diff --shortstat` = **1 file changed, 26 insertions(+), 0 deletions(-)**. Markdown-only (C.3). Ré-application via `json.load` (préserve les listes source, évite le churn nbformat appris sur #9919).
- **C.1** : markdown-only, 0 cellule code touchée.
- **C.3** : aucune cellule code source/output modifiée (exception markdown-only — les outputs GPU sont déjà committés, pas de re-exec ; l'enrichissement lit les outputs, n'invoque pas le modèle).
- **Non-twin** : `git grep` sur `twin_pairs.d/` = aucun match (FT-02 n'est pas twinnée).
- **nbformat 4.5 valide** (`nbformat.validate`), 33 cellules (31→33), 16 cellules code avec `execution_count` + `outputs` intacts.
- **L898** : `gh pr list --search "FT-02-QLoRA"` = aucune PR ouverte (historique MERGED uniquement).

## Diff

1 fichier : `FT-02-QLoRA-Quantization.ipynb` (+26, 0). Catalogue byte-identique à main.

See #1385 (EPIC GenAI side-track dont la famille FineTuning relève).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
