### PR TITLE
test(lean,#8782): convert Hashlife blind-spot witness to regression guard (unblocks red main)

### DIFF
--- a/scripts/lean/tests/test_check_public_anchor.py
+++ b/scripts/lean/tests/test_check_public_anchor.py
@@ -297,27 +297,41 @@ def hashlife_modules() -> list[Path]:
 
 
 @pytest.mark.skipif(not HASHLIFE.is_file(), reason="conway_lean absent de cet arbre")
-def test_hashlife_exhibits_the_blind_spot():
-    """Temoin #8782 : les modules cibles par la CI portent des sorry sans ancrage.
+def test_hashlife_blind_spot_stays_reabsorbed():
+    """Garde-regression #8782 : l'angle mort Hashlife, reabsorbe par #9897, ne doit pas revenir.
 
-    Non fige sur un compte exact (le module evolue, cf #8981) : ce qui est
-    verifie, c'est que la classe de defaut est instanciee ET qu'une partie des
-    sorry est bien visible du gate -- l'angle mort est partiel, pas total.
+    Ce test etait un *temoin* du defaut #8782 (chaines sorry privees non ancrees) :
+    il assertait que la classe de defaut etait instanciee dans Hashlife pour exercer
+    le gate ``check_public_anchor`` sur un cas reel. La fusion #9897 (-9 sorry) a
+    reabsorbe cet angle mort : un scan de tous les modules own (198 fichiers, cf
+    le corps de ce PR) ne trouve plus aucun site ``UNANCHORED`` dans tout le depot,
+    pas seulement Hashlife.
+    Sans cible, le temoin est converti en garde-regression, conformement a son propre
+    docstring originel (<< mettre a jour le temoin >>).
 
     Porte sur l'**union** de l'agregateur et de ses sous-modules (cf
     ``hashlife_modules``) : c'est la meme union que ``target-modules`` cote CI.
+
+    Deux proprietes gardees :
+
+      - **regression** : aucun site ``UNANCHORED`` ne reaparait dans Hashlife (sinon
+        le -9 sorry de #9897 est defait -> rouge, signalement d'une regression reelle).
+      - **temoin d'integration** : le gate tourne toujours sur du vrai Lean et
+        classifie le sorry residuel (au moins un site ``ANCHORED_PUBLIC`` visible),
+        pour que l'outil reste exerce sur le depot reel, pas seulement sur des fixtures.
+
+    Cf #8782, #9897, #9863 (split Hashlife).
     """
     sites = [s for p in hashlife_modules() for s in analyze_module(p)["sites"]]
     if not sites:
-        pytest.skip("modules assainis depuis la mesure de reference")
+        pytest.skip("Hashlife totalement assaini : aucun sorry residuel a surveiller")
     unanchored = [s for s in sites if s["verdict"] == UNANCHORED]
-    assert unanchored, "l'angle mort a disparu : mettre a jour le temoin"
-    assert any(s["verdict"] == ANCHORED_PUBLIC for s in sites), (
-        "aucun sorry public : les modules auraient change de nature"
+    assert not unanchored, (
+        "regression #8782 : un sorry prive non ancre a reaparu dans Hashlife -- "
+        f"porteurs={sorted({s['owner'] for s in unanchored})}"
     )
-    assert all(s["owner_private"] for s in unanchored)
-    assert {s["owner"] for s in unanchored}, (
-        "les sorry sans ancrage doivent nommer leur porteur"
+    assert any(s["verdict"] == ANCHORED_PUBLIC for s in sites), (
+        "aucun sorry public visible : le gate ne s'exerce plus sur un cas reel"
     )
 
 


### PR DESCRIPTION
Grain: LIGHT/test — lane myia-ai-01:CoursIA — prev: MED/lean #9818

## Constat

`main` est rouge sur `Scripts Tests (CPU)` depuis mon merge #9897 (−9 sorry sur Hashlife). Le témoin `test_hashlife_exhibits_the_blind_spot` assertait que la **classe de défaut #8782** (chaînes `sorry` privées non ancrées) était instanciée dans Hashlife — #9897 l'a réabsorbée, donc `assert unanchored` échoue avec `[]`. Toute PR ouverte touchant `scripts/**` hérite du rouge.

Le docstring du témoin disait explicitement : « l'angle mort a disparu : **mettre a jour le temoin** ».

## Vérification firsthand (avant tout fix)

- **État Hashlife** : `analyze_module` sur l'union agrégateur + sous-modules (la même union que `target-modules` côté CI) → **1 site total**, verdict `anchored_public`. `unanchored == []`.
- **Scan depot-wide** : parse statique de tous les modules own (198 fichiers `.lean`, hors `.lake`/`_peters`) → **0 site `UNANCHORED`** nulle part dans le dépôt, pas seulement Hashlife. Le défaut #8782 n'a plus de cible → le retargeting n'est pas une option.

## Fix

Conversion du témoin en **garde-régression** (conforme à « mettre à jour le témoin ») :

- `assert not unanchored` → rouge si le −9 sorry de #9897 est défait (régression réelle).
- Conservation du sanity-check `any(anchored_public)` → le gate tourne toujours sur du vrai Lean et classifie le sorry résiduel (**témoin d'intégration**, pas seulement des fixtures).

Le test est renommé `test_hashlife_blind_spot_stays_reabsorbed` car l'ancien intitulé (`exhibits_the_blind_spot`) serait devenu mensonger. Aucune référence au nom n'existe hors du fichier (CI/workflows vérifiés).

## Preuve

- `python -m pytest scripts/lean/tests/test_check_public_anchor.py` → **26/26 green** localement (Python 3.14, Windows).
- `scripts/notebook_tools/tests` → 4121 passed (territoire du fix relpath #9917, non affecté).
- Les erreurs de collection `scripts/tests/` (genai/sudoku-training) sont des manques de deps optionnels (torch/arch) locaux — la CI installe tout, elles n'apparaissent pas là-bas.

## Ce que cette PR débloque

`Scripts Tests (CPU)` repasse au vert sur `main` → débloque #9917 (relpath, rouge uniquement pour cette cause racine) et toutes les PRs `scripts/**` en attente.

See #8782, #9897, #9863.
