### PR TITLE
fix(sk9,#9922): resolve CLR namespace bug + restore assembly build (partial)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
@@ -115,10 +115,10 @@
    "id": "95fec443",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T23:04:03.809950Z",
-     "iopub.status.busy": "2026-05-09T23:04:03.809415Z",
-     "iopub.status.idle": "2026-05-09T23:04:07.187008Z",
-     "shell.execute_reply": "2026-05-09T23:04:07.185477Z"
+     "iopub.execute_input": "2026-08-07T19:41:50.149382Z",
+     "iopub.status.busy": "2026-08-07T19:41:50.149382Z",
+     "iopub.status.idle": "2026-08-07T19:41:50.154729Z",
+     "shell.execute_reply": "2026-08-07T19:41:50.153401Z"
     },
     "papermill": {
      "duration": 3.384082,
@@ -140,10 +140,10 @@
    "id": "d9026247",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T23:04:07.198638Z",
-     "iopub.status.busy": "2026-05-09T23:04:07.198191Z",
-     "iopub.status.idle": "2026-05-09T23:04:07.448969Z",
-     "shell.execute_reply": "2026-05-09T23:04:07.447873Z"
+     "iopub.execute_input": "2026-08-07T19:41:50.157731Z",
+     "iopub.status.busy": "2026-08-07T19:41:50.156731Z",
+     "iopub.status.idle": "2026-08-07T19:41:50.166686Z",
+     "shell.execute_reply": "2026-08-07T19:41:50.165676Z"
     },
     "papermill": {
      "duration": 0.257777,
@@ -177,23 +177,59 @@
   {
    "cell_type": "markdown",
    "id": "a4ac5e51",
-   "source": "### Exercice 1 : Diagnostic de l'environnement CLR\n\nAvant d'utiliser pythonnet en production, il est important de verifier la compatibilite des versions et la configuration du runtime.\n\n**Objectif** : Implementer une fonction `diagnose_clr_env()` qui collecte les informations cles de l'environnement CLR.\n\n**Indices** :\n- # Étape 1 : Verifier la version de pythonnet via `import clr` et le module `importlib.metadata`\n- # Étape 2 : Acceder au runtime .NET via `System.Environment` pour obtenir la version du framework\n- # Étape 3 : Lister les assemblies déjà chargees dans `AppDomain.CurrentDomain`\n- # Indice : `System.Environment.Version` donne la version du runtime .NET, `System.Environment.OSVersion` donne l'OS",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : Diagnostic de l'environnement CLR\n",
+    "\n",
+    "Avant d'utiliser pythonnet en production, il est important de verifier la compatibilite des versions et la configuration du runtime.\n",
+    "\n",
+    "**Objectif** : Implementer une fonction `diagnose_clr_env()` qui collecte les informations cles de l'environnement CLR.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Étape 1 : Verifier la version de pythonnet via `import clr` et le module `importlib.metadata`\n",
+    "- # Étape 2 : Acceder au runtime .NET via `System.Environment` pour obtenir la version du framework\n",
+    "- # Étape 3 : Lister les assemblies déjà chargees dans `AppDomain.CurrentDomain`\n",
+    "- # Indice : `System.Environment.Version` donne la version du runtime .NET, `System.Environment.OSVersion` donne l'OS"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "id": "74a574d5",
-   "source": "def diagnose_clr_env() -> dict:\n    \"\"\"\n    TODO etudiant : Collecter les informations de l'environnement CLR.\n    \n    Returns:\n        dict avec les cles: pythonnet_version, dotnet_version, os_version,\n        loaded_assembly_count, is_runtime_loaded (bool)\n    \"\"\"\n    # TODO etudiant : utiliser System.Environment et AppDomain.CurrentDomain\n    return None\n\n# Test :\n# diag = diagnose_clr_env()\n# print(f\"pythonnet {diag['pythonnet_version']}, .NET {diag['dotnet_version']}\")\n# print(f\"  Assemblies charges: {diag['loaded_assembly_count']}\")\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T19:41:50.168686Z",
+     "iopub.status.busy": "2026-08-07T19:41:50.168686Z",
+     "iopub.status.idle": "2026-08-07T19:41:50.173737Z",
+     "shell.execute_reply": "2026-08-07T19:41:50.172726Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer\n"
      ]
     }
+   ],
+   "source": [
+    "def diagnose_clr_env() -> dict:\n",
+    "    \"\"\"\n",
+    "    TODO etudiant : Collecter les informations de l'environnement CLR.\n",
+    "    \n",
+    "    Returns:\n",
+    "        dict avec les cles: pythonnet_version, dotnet_version, os_version,\n",
+    "        loaded_assembly_count, is_runtime_loaded (bool)\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : utiliser System.Environment et AppDomain.CurrentDomain\n",
+    "    return None\n",
+    "\n",
+    "# Test :\n",
+    "# diag = diagnose_clr_env()\n",
+    "# print(f\"pythonnet {diag['pythonnet_version']}, .NET {diag['dotnet_version']}\")\n",
+    "# print(f\"  Assemblies charges: {diag['loaded_assembly_count']}\")\n",
+    "print(\"Exercice a completer\")"
    ]
   },
   {
@@ -222,14 +258,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "1aa67c3f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T23:04:07.464821Z",
-     "iopub.status.busy": "2026-05-09T23:04:07.464466Z",
-     "iopub.status.idle": "2026-05-09T23:04:08.354055Z",
-     "shell.execute_reply": "2026-05-09T23:04:08.353190Z"
+     "iopub.execute_input": "2026-08-07T19:41:50.177347Z",
+     "iopub.status.busy": "2026-08-07T19:41:50.176335Z",
+     "iopub.status.idle": "2026-08-07T19:41:50.517388Z",
+     "shell.execute_reply": "2026-08-07T19:41:50.516300Z"
     },
     "papermill": {
      "duration": 0.895969,
@@ -245,9 +281,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Chemin DLL calculé : D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\bin\\Release\\net9.0\n",
-      "Utilisation du chemin Debug : D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\bin\\Debug\\net9.0\n",
-      "✅ Chemin ajouté au sys.path : D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\bin\\Debug\\net9.0\n"
+      "Chemin DLL calculé : C:\\dev\\CoursIA-sk9-clr-fix\\MyIA.AI.Notebooks\\bin\\Release\\net9.0\n",
+      "✅ Chemin ajouté au sys.path : C:\\dev\\CoursIA-sk9-clr-fix\\MyIA.AI.Notebooks\\bin\\Release\\net9.0\n"
      ]
     }
    ],
@@ -282,14 +317,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "c507d01c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T23:04:08.364109Z",
-     "iopub.status.busy": "2026-05-09T23:04:08.363713Z",
-     "iopub.status.idle": "2026-05-09T23:04:08.919642Z",
-     "shell.execute_reply": "2026-05-09T23:04:08.918541Z"
+     "iopub.execute_input": "2026-08-07T19:41:50.522286Z",
+     "iopub.status.busy": "2026-08-07T19:41:50.521737Z",
+     "iopub.status.idle": "2026-08-07T19:41:50.671255Z",
+     "shell.execute_reply": "2026-08-07T19:41:50.670740Z"
     },
     "papermill": {
      "duration": 0.562144,
@@ -354,14 +389,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "35b15035",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T23:04:08.932286Z",
-     "iopub.status.busy": "2026-05-09T23:04:08.931893Z",
-     "iopub.status.idle": "2026-05-09T23:04:09.188711Z",
-     "shell.execute_reply": "2026-05-09T23:04:09.187771Z"
+     "iopub.execute_input": "2026-08-07T19:41:50.676324Z",
+     "iopub.status.busy": "2026-08-07T19:41:50.675260Z",
+     "iopub.status.idle": "2026-08-07T19:41:50.887140Z",
+     "shell.execute_reply": "2026-08-07T19:41:50.886125Z"
     },
     "papermill": {
      "duration": 0.262218,
@@ -380,6 +415,11 @@
       "\n",
       "✅ Assembly trouvé: MyIA.AI.Notebooks\n",
       "  -> SkiaUtils\n",
+      "  -> FactorGraphHelper\n",
+      "  -> SvgChart\n",
+      "  -> TraceStyle\n",
+      "  -> SvgSeries\n",
+      "  -> SvgChartHelper\n",
       "  -> MyNotebookLib.AutoGenNotebookUpdater\n",
       "  -> MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater\n",
       "  -> MyNotebookLib.DisplayLogger\n",
@@ -416,14 +456,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "aa86a37a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T23:04:09.200892Z",
-     "iopub.status.busy": "2026-05-09T23:04:09.200435Z",
-     "iopub.status.idle": "2026-05-09T23:04:09.498904Z",
-     "shell.execute_reply": "2026-05-09T23:04:09.497887Z"
+     "iopub.execute_input": "2026-08-07T19:41:50.891137Z",
+     "iopub.status.busy": "2026-08-07T19:41:50.890139Z",
+     "iopub.status.idle": "2026-08-07T19:41:51.043437Z",
+     "shell.execute_reply": "2026-08-07T19:41:51.041420Z"
     },
     "papermill": {
      "duration": 0.306075,
@@ -440,25 +480,21 @@
      "output_type": "stream",
      "text": [
       "✅ Assembly trouvé: MyIA.AI.Notebooks\n",
-      "Types disponibles dans l'assembly:\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Types disponibles dans l'assembly:\n",
       "  ⚠️ Erreur lors de l'énumération des types: Impossible de charger un ou plusieurs des types requis. Extrayez la propriété LoaderExceptions pour plus d'informations.\r\n",
       "   à System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)\r\n",
       "   à System.Reflection.RuntimeModule.GetTypes()\r\n",
       "   à System.Reflection.Assembly.GetTypes()\n",
       "  ⚠️ Cela peut indiquer des dépendances .NET manquantes\n",
       "  → Continuons avec la recherche de classes spécifiques...\n",
-      "❌ Aucun type trouvé avec les noms testés\n",
+      "✅ Classe importée: MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater\n",
+      "   - Type: MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater\n",
+      "   - Nom complet: MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater\n",
       "\n",
       "=== RÉSUMÉ IMPORT ===\n",
-      "AutoInvokeSKAgentsNotebookUpdater = None\n",
-      "Type: <class 'NoneType'>\n",
-      "❌ Import .NET échoué - variable = None\n"
+      "AutoInvokeSKAgentsNotebookUpdater = MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater\n",
+      "Type: <class 'System.RuntimeType'>\n",
+      "🎉 IMPORT .NET RÉUSSI !\n"
      ]
     }
    ],
@@ -488,11 +524,18 @@
     "        print(f\"  ⚠️ Cela peut indiquer des dépendances .NET manquantes\")\n",
     "        print(f\"  → Continuons avec la recherche de classes spécifiques...\")\n",
     "    \n",
-    "    # 3. Essayer plusieurs variantes du nom de classe\n",
+    "    # 3. Le bon nom : le namespace C# est `MyNotebookLib`, PAS le nom de l'assembly\n",
+    "    # (`MyIA.AI.Notebooks`). `Assembly.GetType(nom)` fait une correspondance exacte\n",
+    "    # sur le nom complet du type : un seul segment erroné -> retourne None\n",
+    "    # SANS lever d'exception (échec silencieux). Les variantes testées ci-dessous\n",
+    "    # sont toutes fausses ; on les conserve commentées comme illustration du piège\n",
+    "    # « assembly ≠ namespace » (cf. cellule d'interprétation suivante).\n",
     "    type_names = [\n",
-    "        \"MyIA.AI.Notebooks.GenAI.SemanticKernel.AutoInvokeSKAgentsNotebookUpdater\",\n",
-    "        \"MyIA.AI.Notebooks.AutoInvokeSKAgentsNotebookUpdater\", \n",
-    "        \"AutoInvokeSKAgentsNotebookUpdater\"\n",
+    "        \"MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater\",\n",
+    "        # variantes historiquement testées, toutes fausses :\n",
+    "        #   \"MyIA.AI.Notebooks.GenAI.SemanticKernel.AutoInvokeSKAgentsNotebookUpdater\",\n",
+    "        #   \"MyIA.AI.Notebooks.AutoInvokeSKAgentsNotebookUpdater\",\n",
+    "        #   \"AutoInvokeSKAgentsNotebookUpdater\",\n",
     "    ]\n",
     "    \n",
     "    AutoInvokeSKAgentsNotebookUpdater = None\n",
@@ -532,29 +575,76 @@
   {
    "cell_type": "markdown",
    "id": "46549ac6",
-   "source": "### Lecture du résultat — deux API de réflexion, deux pièges CLR\n\nLes deux cellules précédentes comparent `GetExportedTypes()` et `GetTypes()`, les deux API .NET pour énumérer les types d'un assembly. Leurs sorties divergent radicalement, et cette divergence est la leçon centrale de l'interop par réflexion.\n\n**`GetExportedTypes()` vs `GetTypes()`.** La première n'énumère que les types **publics** de l'assembly et retourne ici, proprement, 14 types. La seconde énumère **tous** les types (y compris internes et imbriqués) et, en tentant de résoudre chaque type référencé, bute sur une dépendance qu'elle ne peut charger : elle lève alors `ReflectionTypeLoadException`, dont la propriété `LoaderExceptions` est précisément le **diagnostic** — un tableau nommant, pour chaque type fautif, l'assembly manquant. La stack trace committée (`RuntimeModule.GetTypes` → `Assembly.GetTypes`) est la signature exacte de ce cas. **Quand `GetTypes` échoue, lire `.LoaderExceptions`** : c'est l'outil qui transforme une exception opaque en liste actionnable de dépendances manquantes.\n\n**Pourquoi l'import échoue (`= None`) — le piège assembly ≠ namespace.** La cause n'est pas le `LoaderException` ci-dessus (il est attrapé par le `try/except`, l'exécution continue). Elle est dans les trois noms testés par `GetType` : `MyIA.AI.Notebooks.*` et `AutoInvokeSKAgentsNotebookUpdater`. Or la sortie de `GetExportedTypes` montre que les types vivent dans le namespace **`MyNotebookLib`** (`MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater`, etc.). `Assembly.GetType(nom)` fait une recherche **exacte** sur le nom complet : un seul segment diffère, et elle retourne `None` **sans lever d'exception** — silencieusement. L'appel correct eût été `assembly.GetType(\"MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater\")`. C'est le piège rappelé en tête de bloc : **le nom de l'assembly** (`MyIA.AI.Notebooks`) **n'est pas le namespace C#** (`MyNotebookLib`). La conséquence est directement lisible dans la sortie de cette même cellule : `AutoInvokeSKAgentsNotebookUpdater = None`, « Import .NET échoué » — l'agent ne pourra pas s'instancier tant que le namespace ciblé n'est pas le bon.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat — deux API de réflexion, deux pièges CLR\n",
+    "\n",
+    "Les deux cellules précédentes comparent `GetExportedTypes()` et `GetTypes()`, les deux API .NET pour énumérer les types d'un assembly. Leurs sorties divergent radicalement, et cette divergence est la leçon centrale de l'interop par réflexion.\n",
+    "\n",
+    "**`GetExportedTypes()` vs `GetTypes()`.** La première n'énumère que les types **publics** de l'assembly et retourne ici, proprement, 14 types. La seconde énumère **tous** les types (y compris internes et imbriqués) et, en tentant de résoudre chaque type référencé, bute sur une dépendance qu'elle ne peut charger : elle lève alors `ReflectionTypeLoadException`, dont la propriété `LoaderExceptions` est précisément le **diagnostic** — un tableau nommant, pour chaque type fautif, l'assembly manquant. La stack trace committée (`RuntimeModule.GetTypes` → `Assembly.GetTypes`) est la signature exacte de ce cas. **Quand `GetTypes` échoue, lire `.LoaderExceptions`** : c'est l'outil qui transforme une exception opaque en liste actionnable de dépendances manquantes.\n",
+    "\n",
+    "**Le piège assembly ≠ namespace — désormais corrigé.** La cause de l'échec d'import observé précédemment (`AutoInvokeSKAgentsNotebookUpdater = None`) n'était pas le `LoaderException` ci-dessus (attrapé par le `try/except`, l'exécution continue). Elle venait des noms testés par `GetType` : `MyIA.AI.Notebooks.*` et `AutoInvokeSKAgentsNotebookUpdater`. Or la sortie de `GetExportedTypes` montre que les types vivent dans le namespace **`MyNotebookLib`** (`MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater`, etc.). `Assembly.GetType(nom)` fait une recherche **exacte** sur le nom complet : un seul segment diffère, et elle retourne `None` **sans lever d'exception** — silencieusement. C'est le piège rappelé en tête de bloc : **le nom de l'assembly** (`MyIA.AI.Notebooks`) **n'est pas le namespace C#** (`MyNotebookLib`). La cellule précédente teste désormais le bon nom complet (`MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater` en tête de liste) : `GetType` trouve le type, l'import réussit (« 🎉 IMPORT .NET RÉUSSI ») et la classe est prête à être instanciée. Les trois variantes historiquement fausses sont conservées commentées dans le code, pour rendre le piège visible et reproductible."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "8f765129",
-   "source": "### Exercice 2 : Exploration reflexive des types .NET\n\nLa reflexion .NET permet d'explorer dynamiquement les méthodes et proprietes d'un type charge depuis Python.\n\n**Objectif** : Implementer une fonction `inspect_clr_type()` qui liste les méthodes publiques d'un type .NET avec leurs signatures.\n\n**Indices** :\n- # Étape 1 : Utiliser `assembly.GetType()` pour recuperer un type CLR par son nom\n- # Étape 2 : Iterer sur `type.GetMethods()` pour lister les méthodes publiques\n- # Étape 3 : Extraire le nom de la méthode, le type de retour et les paramètres pour chaque méthode\n- # Indice : Utiliser `System.Reflection.MethodInfo` pour acceder aux informations detaillees de chaque méthode",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Exploration reflexive des types .NET\n",
+    "\n",
+    "La reflexion .NET permet d'explorer dynamiquement les méthodes et proprietes d'un type charge depuis Python.\n",
+    "\n",
+    "**Objectif** : Implementer une fonction `inspect_clr_type()` qui liste les méthodes publiques d'un type .NET avec leurs signatures.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Étape 1 : Utiliser `assembly.GetType()` pour recuperer un type CLR par son nom\n",
+    "- # Étape 2 : Iterer sur `type.GetMethods()` pour lister les méthodes publiques\n",
+    "- # Étape 3 : Extraire le nom de la méthode, le type de retour et les paramètres pour chaque méthode\n",
+    "- # Indice : Utiliser `System.Reflection.MethodInfo` pour acceder aux informations detaillees de chaque méthode"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
    "id": "b895a913",
-   "source": "def inspect_clr_type(assembly, type_name: str) -> list:\n    \"\"\"\n    TODO etudiant : Lister les methodes publiques d'un type .NET via reflexion.\n    \n    Args:\n        assembly: L'assembly .NET charge via clr\n        type_name: Nom complet du type (ex: \"MyNotebookLib.GuessingGame\")\n    \n    Returns:\n        Liste de dicts avec les cles: name, return_type, parameters (list de str)\n    \"\"\"\n    # TODO etudiant : utiliser assembly.GetType() et GetMethods()\n    return None\n\n# Test :\n# methods = inspect_clr_type(assembly, \"MyNotebookLib.GuessingGame\")\n# for m in methods[:5]:\n#     print(f\"  {m['return_type']} {m['name']}({', '.join(m['parameters'])})\")\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T19:41:51.048442Z",
+     "iopub.status.busy": "2026-08-07T19:41:51.048442Z",
+     "iopub.status.idle": "2026-08-07T19:41:51.055728Z",
+     "shell.execute_reply": "2026-08-07T19:41:51.054713Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer\n"
      ]
     }
+   ],
+   "source": [
+    "def inspect_clr_type(assembly, type_name: str) -> list:\n",
+    "    \"\"\"\n",
+    "    TODO etudiant : Lister les methodes publiques d'un type .NET via reflexion.\n",
+    "    \n",
+    "    Args:\n",
+    "        assembly: L'assembly .NET charge via clr\n",
+    "        type_name: Nom complet du type (ex: \"MyNotebookLib.GuessingGame\")\n",
+    "    \n",
+    "    Returns:\n",
+    "        Liste de dicts avec les cles: name, return_type, parameters (list de str)\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : utiliser assembly.GetType() et GetMethods()\n",
+    "    return None\n",
+    "\n",
+    "# Test :\n",
+    "# methods = inspect_clr_type(assembly, \"MyNotebookLib.GuessingGame\")\n",
+    "# for m in methods[:5]:\n",
+    "#     print(f\"  {m['return_type']} {m['name']}({', '.join(m['parameters'])})\")\n",
+    "print(\"Exercice a completer\")"
    ]
   },
   {
@@ -582,14 +672,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "5065d5f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T23:04:09.521311Z",
-     "iopub.status.busy": "2026-05-09T23:04:09.520734Z",
-     "iopub.status.idle": "2026-05-09T23:04:09.528828Z",
-     "shell.execute_reply": "2026-05-09T23:04:09.527948Z"
+     "iopub.execute_input": "2026-08-07T19:41:51.060731Z",
+     "iopub.status.busy": "2026-08-07T19:41:51.059729Z",
+     "iopub.status.idle": "2026-08-07T19:41:51.106182Z",
+     "shell.execute_reply": "2026-08-07T19:41:51.104777Z"
     },
     "papermill": {
      "duration": 0.01561,
@@ -605,7 +695,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ Impossible de lancer l'agent - classe non disponible\n"
+      "❌ Erreur lors de l'exécution de l'agent : Une exception a été levée par la cible d'un appel. ---> System.TypeLoadException: Impossible de charger le type 'System.ValueTuple`5' à partir de l'assembly 'System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.\r\n",
+      "   à MyNotebookLib.NotebookUpdaterBase.InitSemanticKernel()\r\n",
+      "   à MyNotebookLib.NotebookUpdaterBase..ctor(String notebookPath, ILogger logger)\r\n",
+      "   --- Fin de la trace de la pile d'exception interne ---\r\n",
+      "   à System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)\r\n",
+      "   à System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)\r\n",
+      "   à System.RuntimeType.CreateInstanceImpl(BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes, StackCrawlMark& stackMark)\r\n",
+      "   à System.Activator.CreateInstance(Type type, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes)\r\n",
+      "   à System.Activator.CreateInstance(Type type, Object[] args)\n",
+      "   Note : la classe est bien importée (cellule précédente).\n",
+      "   L'instanciation et l'exécution complète de l'agent nécessitent\n",
+      "   pythonnet configuré en mode CoreCLR (runtime .NET 9) ainsi qu'une\n",
+      "   clé OpenAI valide — voir l'issue de suivi du notebook.\n"
      ]
     }
    ],
@@ -614,6 +716,7 @@
     "nest_asyncio.apply()\n",
     "\n",
     "import asyncio\n",
+    "from System import Activator\n",
     "\n",
     "# Facultatif si vous avez un logger C# \n",
     "# from Microsoft.Extensions.Logging import LogLevel\n",
@@ -631,8 +734,11 @@
     "        # Chemin où sera généré le notebook \"cible\" à manipuler\n",
     "        notebook_path = r\".\\Workbook-Template-Python.ipynb\"\n",
     "\n",
-    "        # On crée l'updater\n",
-    "        updater = AutoInvokeSKAgentsNotebookUpdater(notebook_path, logger)\n",
+    "        # On crée l'updater. La classe a été récupérée par RÉFLEXION\n",
+    "        # (`assembly.GetType`) dans la cellule précédente : on l'instancie donc\n",
+    "        # via `Activator.CreateInstance`, car un System.Type n'est pas\n",
+    "        # directement callable comme une classe Python ordinaire.\n",
+    "        updater = Activator.CreateInstance(AutoInvokeSKAgentsNotebookUpdater, notebook_path, logger)\n",
     "\n",
     "        # On définit un template ou une instruction initiale\n",
     "        # (Équivalent de: autoInvokeUpdater.SetStartingNotebookFromTemplate(...))\n",
@@ -652,8 +758,10 @@
     "        \n",
     "    except Exception as e:\n",
     "        print(f\"❌ Erreur lors de l'exécution de l'agent : {e}\")\n",
-    "        import traceback\n",
-    "        traceback.print_exc()\n",
+    "        print(\"   Note : la classe est bien importée (cellule précédente).\")\n",
+    "        print(\"   L'instanciation et l'exécution complète de l'agent nécessitent\")\n",
+    "        print(\"   pythonnet configuré en mode CoreCLR (runtime .NET 9) ainsi qu'une\")\n",
+    "        print(\"   clé OpenAI valide — voir l'issue de suivi du notebook.\")\n",
     "\n",
     "# Lancement\n",
     "if AutoInvokeSKAgentsNotebookUpdater is not None:\n",
@@ -688,23 +796,61 @@
   {
    "cell_type": "markdown",
    "id": "2cae260f",
-   "source": "### Exercice 3 : Gestionnaire d'erreurs CLR\n\nL'interop Python/.NET peut echouer silencieusement ou lever des exceptions .NET non catchees par Python.\n\n**Objectif** : Implementer une fonction `safe_clr_call()` qui encapsule un appel .NET avec gestion d'erreurs et logging.\n\n**Indices** :\n- # Étape 1 : Accepter une fonction callable et ses arguments en paramètres\n- # Étape 2 : Wraper l'appel dans un try/except qui capture les exceptions CLR et Python\n- # Étape 3 : Retourner un tuple (success: bool, result_or_error: Any) et logger l'opération\n- # Indice : Les exceptions .NET via pythonnet heritent de `System.Exception` ou sont des `Exception` Python classiques",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Gestionnaire d'erreurs CLR\n",
+    "\n",
+    "L'interop Python/.NET peut echouer silencieusement ou lever des exceptions .NET non catchees par Python.\n",
+    "\n",
+    "**Objectif** : Implementer une fonction `safe_clr_call()` qui encapsule un appel .NET avec gestion d'erreurs et logging.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Étape 1 : Accepter une fonction callable et ses arguments en paramètres\n",
+    "- # Étape 2 : Wraper l'appel dans un try/except qui capture les exceptions CLR et Python\n",
+    "- # Étape 3 : Retourner un tuple (success: bool, result_or_error: Any) et logger l'opération\n",
+    "- # Indice : Les exceptions .NET via pythonnet heritent de `System.Exception` ou sont des `Exception` Python classiques"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "id": "1ca195b3",
-   "source": "def safe_clr_call(func, *args, **kwargs):\n    \"\"\"\n    TODO etudiant : Encapsuler un appel .NET avec gestion d'erreurs.\n    \n    Args:\n        func: Fonction callable (methode .NET ou Python)\n        *args, **kwargs: Arguments a passer a la fonction\n    \n    Returns:\n        tuple (success: bool, result_or_error) avec logging de l'operation\n    \"\"\"\n    # TODO etudiant : implementer le wrapper try/except\n    return None\n\n# Test :\n# ok, result = safe_clr_call(lambda: 42)\n# print(f\"Succes: {ok}, Resultat: {result}\")\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T19:41:51.111715Z",
+     "iopub.status.busy": "2026-08-07T19:41:51.110714Z",
+     "iopub.status.idle": "2026-08-07T19:41:51.116634Z",
+     "shell.execute_reply": "2026-08-07T19:41:51.115621Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer\n"
      ]
     }
+   ],
+   "source": [
+    "def safe_clr_call(func, *args, **kwargs):\n",
+    "    \"\"\"\n",
+    "    TODO etudiant : Encapsuler un appel .NET avec gestion d'erreurs.\n",
+    "    \n",
+    "    Args:\n",
+    "        func: Fonction callable (methode .NET ou Python)\n",
+    "        *args, **kwargs: Arguments a passer a la fonction\n",
+    "    \n",
+    "    Returns:\n",
+    "        tuple (success: bool, result_or_error) avec logging de l'operation\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementer le wrapper try/except\n",
+    "    return None\n",
+    "\n",
+    "# Test :\n",
+    "# ok, result = safe_clr_call(lambda: 42)\n",
+    "# print(f\"Succes: {ok}, Resultat: {result}\")\n",
+    "print(\"Exercice a completer\")"
    ]
   },
   {
@@ -772,6 +918,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "openai",
+   "api_usd_est": 0.05,
+   "cpu_min": 2,
+   "external_account": "openai",
+   "free_alternative": null,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-28",
+   "network": true,
+   "notes": "Interoperabilite Python/.NET via pythonnet : appel .NET CLR depuis Python (rare, 1 appel chat gpt-4o pour exemple). Cout faible mais build CLR necessite .NET 9.0 SDK. Provenance: myia-po-2023:CoursIA-2 (c.945).",
+   "qcc_tokens_est": 0,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "validator": "manual",
+   "vram_gb": 0,
+   "vram_tier": "LITE"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -787,7 +951,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},
@@ -800,24 +964,6 @@
    "parameters": {},
    "start_time": "2026-05-09T23:04:01.648273",
    "version": "2.6.0"
-  },
-  "cost": {
-   "api_usd_est": 0.05,
-   "api_provider": "openai",
-   "qcc_tokens_est": 0,
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "LITE",
-   "network": true,
-   "external_account": "openai",
-   "free_alternative": null,
-   "reduced_pedagogical": null,
-   "reproducibility": "MED",
-   "metadata_written": "2026-07-28",
-   "validator": "manual",
-   "notes": "Interoperabilite Python/.NET via pythonnet : appel .NET CLR depuis Python (rare, 1 appel chat gpt-4o pour exemple). Cout faible mais build CLR necessite .NET 9.0 SDK. Provenance: myia-po-2023:CoursIA-2 (c.945)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/MyIA.AI.Notebooks.csproj
+++ b/MyIA.AI.Notebooks/MyIA.AI.Notebooks.csproj
@@ -48,6 +48,11 @@
   <ItemGroup>
     <Compile Remove="QuantConnect\**\*.cs" />
     <Compile Remove="ML\ML.Net\Infer.NETCacheHelper.cs" />
+    <!-- Nested standalone sub-projects (own .csproj): excluded from the
+         parent glob so they do not break MyIA.AI.Notebooks.dll (precedent:
+         QuantConnect exclusion above). OwlAdapter/GSheetSync/DatasetUpdater
+         were added in #5167 without this guard. -->
+    <Compile Remove="SymbolicAI\Argument_Analysis\CoursIA-*\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What

Fixes the diagnosed bug in #9922 (the `09-Building-CLR` agent was never instantiated because `Assembly.GetType` was called with wrong namespace variants) and restores the `MyIA.AI.Notebooks.dll` build that the notebook depends on.

## Changes (2 files)

**`MyIA.AI.Notebooks.csproj`** — build fix (Regle F prerequisite). The nested standalone sub-projects `CoursIA-OwlAdapter` / `GSheetSync` / `DatasetUpdater-Prompts` (each with its own `.csproj`, added in #5167) were being globbed by the parent `MyIA.AI.Notebooks.csproj`, breaking the assembly build with **223 errors**. Excluded via `<Compile Remove="SymbolicAI\Argument_Analysis\CoursIA-*\**\*.cs" />` (precedent: `40c5a2a88` QuantConnect/Infer.NET exclusion). `dotnet build` now **SUCCEEDS, 0 errors / 2 warnings**, DLL produced (143360 bytes). This is the prerequisite for re-executing the notebook locally — without it, no criterion of #9922 is verifiable.

**`09-SemanticKernel-Building-CLR.ipynb`**:
- **cell[12]** `type_names` now leads with the correct namespace `MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater`. The assembly is named `MyIA.AI.Notebooks` but its public types live in the `MyNotebookLib` namespace (visible in `GetExportedTypes()`). `Assembly.GetType(name)` does an **exact** full-name match → the wrong segment returned `None` **silently**. The 3 wrong variants are kept commented as an illustration of the assembly != namespace trap.
- **cell[13]** interpretation markdown rewritten: the bug is now in the past tense (the import succeeds), and the assembly != namespace lesson is preserved as a documented warning.
- **cell[17]** instantiates via `Activator.CreateInstance` (the class was retrieved by reflection in cell[12], so it is a `System.Type`, not directly callable). The residual runtime blocker is surfaced cleanly without a Python traceback.

## Verification (real re-exec, H.3 PASS)

Re-executed end-to-end in-place (`nbconvert --execute`, exit 0, 10 code cells, **0 anomalies** — no null execution_count, no uncaught error):

- **criterion #1 MET**: cell[12] output now shows `Classe importee: MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater` + `IMPORT .NET REUSSI`. The `= None` / "Import .NET echoue" is gone.
- **criterion #4 MET**: cell[13] 2nd paragraph rewritten (bug past-tense, lesson preserved).
- **criterion #5 MET**: `GetTypes` `ReflectionTypeLoadException` remains as the documented pedagogical case (LoaderExceptions lesson).

H.3 pre-commit check: PASS (no cell with `execution_count is None and not outputs`).

## Residual — out of scope, tracked separately (#9922 criteria #2/#3)

Full agent instantiation is blocked by a **.NET runtime mismatch** that #9922's diagnostic (#9910) did not cover:

> `Activator.CreateInstance` -> `TargetInvocationException` -> `System.TypeLoadException: Impossible de charger le type 'System.ValueTuple\`5' a partir de l'assembly 'System.Runtime, Version=4.0.0.0'`

pythonnet runs on the **.NET Framework CLR** (`System.Runtime v4.0.0.0`) but the assembly targets **net9.0** and uses `System.ValueTuple\`5` in `NotebookUpdaterBase.InitSemanticKernel()`. No notebook-cell change can fix this — it requires configuring **pythonnet for CoreCLR (.NET 9 runtime)** (`runtimeconfig.json` + hostpolicy), plus a **valid OpenAI key** (the env key is not a real OpenAI key; `Settings.LoadFromFile` needs committed config). Both are substantial env/creds work (Regle F + RECOVERABLE-USER-HAND) — I will open a follow-up issue so the deeper blocker is tracked, not lost.

Hence **`See #9922` (partial)** — not `Closes #9922`: the diagnosed namespace bug is fixed and verified, but criteria #2 (agent runs) and #3 (0 error) are blocked by the runtime mismatch discovered during re-exec.

## Out-of-scope signals (principle 3)

- The csproj build break (223 errors) was pre-existing (since #5167) and affects **every** notebook using `MyIA.AI.Notebooks.dll`, not just SK9. It is included here because it is the build prerequisite for this notebook's re-exec (Regle F). Worth a dedicated cleanup pass if other SK notebooks also fail to build.

See #9922

🤖 Generated with [Claude Code](https://claude.com/claude-code)
