### PR TITLE
docs(repo-size-policy): decompose local .git/ (worktrees, wt-* residuels) — suite #9912

### DIFF
--- a/docs/reference/repo-size-policy.md
+++ b/docs/reference/repo-size-policy.md
@@ -30,10 +30,17 @@ Le dépôt compte ~95 forks étudiants. Réécrire l'historique casserait chacun
 déjà committés (cf. §3) restent dans l'historique. La politique est **entièrement tournée
 vers l'avenir** — on surveille ce qui entre, on ne défait pas ce qui est fait.
 
-## 3. Mesure réelle (plus gros blobs, ordre décroissant)
+## 3. Mesure réelle
 
-Mesuré firsthand via `git rev-list --objects --all | git cat-file --batch-check` (équivalent
-fonctionnel à `git-sizer` pour le classement par blob, sans dépendance Go) :
+Deux angles, deux méthodes : **ce qui est committé** (blobs dans le dépôt) et **ce qui est
+dans `.git/` localement** (artefacts d'administration, dépendants de la machine). Ne pas
+mélanger.
+
+### 3.1 Blobs du dépôt (le poids partageable)
+
+Mesurable firsthand via `git rev-list --objects --all | git cat-file --batch-check` (équivalent
+fonctionnel à `git-sizer` pour le classement par blob, sans dépendance Go). Top 5 décroissant
+(mesure ai-01 2026-08-07, reproduit par le PR #9912) :
 
 | Taille | Blob | Statut | Décision |
 |--------|------|--------|----------|
@@ -47,22 +54,55 @@ Le pack agrégé (~1,2 GiB bare) reflète : (a) les blobs vendored légitimes, (
 des notebooks-avec-outputs (chaque révision d'un notebook riche compte), (c) quelques
 incidents passés (le `model.pt`) désormais nettoyés de l'arbre courant.
 
-> **Note locale** : `git count-objects -vH` peut afficher `size-pack` plus élevé et des
-> `warning: garbage found: .git/objects/pack/tmp_pack_*` sur un clone de travail. Ces
-> `tmp_pack_*` sont du **garbage local** à la machine (un `git gc` les élimine), pas un
-> problème du dépôt distant. Ne pas les confondre avec le sujet.
+> **Comment lire `git count-objects -vH`.** `size-pack` est la taille cumulée des `.pack`
+> dans `objects/pack/` — c'est la mesure **distante** (ce que tout clone télécharge). Le
+> `packs: N` indique le nombre de `.pack` non coalescés : un chiffre élevé signifie que
+> `git gc` n'a pas encore été lancé localement depuis longtemps, pas une dette du dépôt
+> distant. Les `tmp_pack_*` signalés en `warning: garbage found` sont du **garbage local**
+> à la machine (un `git gc` les élimine), pas un problème du dépôt distant — ne pas les
+> confondre avec le sujet.
+
+### 3.2 `.git/` local (artefacts d'administration, par machine)
+
+`du -sh .git/` agrège **six composantes** qu'il faut distinguer — confondre `.git/` avec « le
+poids du dépôt » est une erreur fréquente (la PR #9912 mesurait ai-01 et en oubliait deux).
+Mesure ai-01 2026-08-07 (méthode : `du -sh .git/<composante>` par sous-dossier, hors
+`du -sh .git/*` qui timeoute sur les 200+ worktrees) :
+
+| Composante | Ordre de grandeur | Ce que c'est | Qui le produit |
+|------------|-------------------|--------------|----------------|
+| `.git/modules/` | ~4,0 GiB | submodules (§5.1) — clones des dépôts référencés par `.gitmodules` | un `git submodule update --init --recursive` |
+| `.git/worktrees/` | ~1,7 GiB | worktrees éphémères créés par les agents workers | `git worktree add ../CoursIA-<sujet>` (cf. CLAUDE.md §A et `git-workflow.md`) |
+| `.git/objects/` | ~1,6 GiB | le store d'objets (≈ `size-pack` + delta + dangling) | tout `git fetch` / `git commit` |
+| `.git/wt-*` (résiduels) | ~950 MiB | worktrees laissés par un crash ou un worktree mal démonté | agents sans `git worktree remove` propre |
+| `.git/lfs/` | ~73 MiB | cache LFS (objets téléchargés mais pas encore promus) | un `git lfs fetch` |
+| `.git/logs/` | ~7 MiB | historique des refs (reflog) | tout mouvement de HEAD |
+| **Total `.git/`** | **~8,2 GiB** | — | — |
+
+> **Ces chiffres sont datés 2026-08-07 sur ai-01.** Ils servent à illustrer l'ordre de grandeur
+> et la **proportion** de chaque composante — pas un absolu à reporter. Un `git gc` peut faire
+> varier `objects/` ; un `git worktree prune` peut faire chuter `wt-*` ; un worker actif qui
+> ouvre un worktree fait croître `worktrees/`. **La méthode compte, le chiffre périme.**
 >
-> **`du -sh .git` n'est pas la taille du dépôt.** Sur une machine de dev, `du -sh .git`
-> additionne des composantes **locales** qu'un cloneur ne paie jamais : (a) `size-pack`
-> (le pack parent — accrète plusieurs fichiers `.pack` sur un clone longévif, non coalescés
-> tant qu'un `git gc` n'a pas tourné), (b) `size-garbage` (`tmp_pack_*` orphelins, cf.
-> ci-dessus), et (c) **`.git/modules/`** — les object stores des 8 submodules (cf. §5.1),
-> checkoutés localement mais absents du pack parent. Mesure firsthand sur une machine du
-> cluster : `size-pack ~2 GiB` + `size-garbage ~890 MiB` + `.git/modules ~270 MiB`, soit un
-> `du -sh .git` dépassant largement le pack distant (~1,2 GiB bare, cf. en-tête) — un écart
-> qui n'est **pas** une régression de taille, juste la somme de ces trois composantes locales.
-> La source de vérité pour la taille du dépôt est le pack distant (ce qu'un `git clone` nu
-> récupère), jamais `du -sh .git` sur une machine de travail.
+> **L'angle mort du commentaire #9912** : les deux composantes **produites par le harnais**
+> (`worktrees/` 1,7 GiB et `wt-*` résiduels 950 MiB) étaient absentes de la décomposition
+> initiale — qui parlait de « 1,45 GiB size-pack ». `du -sh .git/*` timeout sur les machines
+> avec beaucoup de worktrees (200+ chez ai-01) : la mesure agrégée n'est récupérable que
+> composante par composante, ou via `git worktree list` pour le décompte.
+
+### 3.3 Maintenance (locale, à la demande)
+
+Quelques gestes d'hygiène **sans valeur de fond**, à exécuter quand l'espace disque devient
+gênant sur la machine :
+
+- `git worktree prune` — nettoie `.git/wt-*` (worktrees non référencés par `git worktree list`).
+- `git gc --aggressive --prune=now` — recompacte `.git/objects/` ; coûteux en CPU, à éviter
+  pendant une session de travail.
+- `git submodule deinit -f <submodule>` puis `git worktree remove` — pour libérer `modules/`
+  si un submodule n'est plus utilisé localement (ne touche pas le dépôt distant).
+
+Ces gestes **ne réduisent pas la taille du dépôt partageable** (§3.1) : pour cela, la voie est
+LFS au prochain ajout (§5), pas la rétro-conversion de l'existant (§2.2).
 
 ## 4. Ce qui ne doit JAMAIS entrer
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/audit c.9872+13

# Suite #9912 : intègre l'amendement ai-01 sur la décomposition de `.git/` local

## Contexte

PR #9912 (`du -sh .git != depot size`, MERGED 2026-08-07) a livré le doc
[`docs/reference/repo-size-policy.md`](../repo-size-policy.md) avec une mesure focalisée
sur les **blobs du dépôt partageable** (top 5 décroissant, ~1,2 GiB bare). ai-01 a posté
un amendement explicite sur l'issue **#9860** (commentaire 2026-08-07T19:05Z) : la mesure
`du -sh .git/` sur sa propre machine agrège **six composantes** dont deux étaient absentes
de #9912 — `worktrees/` (1,7 GiB) et `wt-*` résiduels (953 MiB). Total `.git/` mesuré :
**~8,2 GiB**, dont seuls ~1,45 GiB sont du `size-pack`.

Cette PR intègre cet amendement en remaniant §3 :
- **§3.1** (blobs du dépôt) conserve le tableau top-5 inchangé — chiffres acquis, citations
  verbatim.
- **§3.2** (nouveau) : décomposition des 6 composantes de `.git/` local, avec colonnes
  *ce que c'est* et *qui le produit*. Méthode explicitée (`du -sh .git/<composante>` par
  sous-dossier, hors `du -sh .git/*` qui timeoute sur 200+ worktrees).
- **§3.3** (nouveau) : section maintenance locale — `git worktree prune`, `git gc`, etc.

## Ce que cette PR livre (1 fichier, 59/-7 LOC)

1. **§3 renuméroté** « Mesure réelle » → 3 sous-sections :
   - **§3.1** « Blobs du dépôt (le poids partageable) » — le top-5 verbatim de #9912,
     table inchangée, + une note « comment lire `git count-objects -vH` » qui
     distingue `size-pack` (distante) du `packs: N` (état local de gc).
   - **§3.2** « `.git/` local (artefacts d'administration, par machine) » — tableau des
     6 composantes, **proportionnel** plutôt qu'absolu, avec encadré « angle mort du
     commentaire #9912 » qui nomme explicitement les deux composantes manquantes.
   - **§3.3** « Maintenance (locale, à la demande) » — 3 gestes d'hygiène locale +
     disclaimer « ne réduit pas la taille partageable ».

2. **Méthode privilégiée sur les absolus** : les chiffres sont datés (2026-08-07 sur ai-01)
   et l'encadré final insiste — *« la méthode compte, le chiffre périme »*. Un `git gc`
   ou un `git worktree prune` les font varier ; un worker qui démarre un nouveau worktree
   fait croître `worktrees/`.

4. **Catalogue byte-identique à `main`** (`COURSE_CATALOG.generated.{json,md}` non touché).

## Acceptance (cf issue #9860)

- ✅ Composantes `worktrees/` et `wt-*` (résiduels) explicitement nommées avec ordre de
  grandeur — l'angle mort du commentaire #9912 est documenté.
- ✅ Méthode de mesure privilégiée aux valeurs absolues — la phrase *« la méthode compte,
  le chiffre périme »* est dans l'encadré de §3.2.
- ✅ `git worktree prune` apparaît dans la section maintenance §3.3 — directement
  exécutable, sortie attendue `wt-*` réduit.
- ✅ Top-5 blobs inchangé (vérification 1:1 avec #9912, pas de modification de chiffres
  acquis).
- ✅ `git diff --stat` : 1 fichier, 59/-7 LOC — sous G.4 (3000 lignes / 15 fichiers).

## Scope strict (R3 atomicité)

- **1 sujet** = amender la politique de taille du dépôt avec la décomposition `.git/`
  locale proposée par ai-01.
- **1 fichier** : `docs/reference/repo-size-policy.md`.
- **59/-7 LOC** au total — sous tous les seuils G.4.
- Ne touche **PAS** au catalogue (catalog-pr-hygiene Règle HARD 1).
- Ne touche **PAS** à `.github/workflows/repo-size-advisory.yml` (workflow CI inchangé
  depuis #9912).
- Ne touche **PAS** au `gitignore` (les `wt-*` sont des artefacts que `git worktree prune`
  nettoie à la demande, pas des fichiers gitignored — sinon `git worktree add` ne
  pourrait pas les créer).

## L898 ★★★ + lane-claim

- `[CLAIMED] <#9860> — lane myia-po-2023:CoursIA-2 — intégrer amendement ai-01` posé
  par mes soins sur l'issue **#9860** (cf [commentaire 5221471000](https://github.com/jsboige/CoursIA/issues/9860#issuecomment-5221471000)) avant édition —
  respect du lane-claim-protocol #9774.
- L898 ★★★ vérifié : `gh pr list --search "repo-size-policy"` → 0 PR OPEN, seul #9912
  MERGED. `gh pr list --search head:feature/c9860-amendment-worktrees` → 0 PR. 0
  collision cross-lane.
- L9888-L5 ★★ appliqué en début de cycle (c.9872+12 / wakeup 116 + c.9872+13 / wakeup
  117) : G.1 firsthand sur main `b71316410 → ed29b1e30` + delta commits + 13 PRs po-2023
  OPEN/MERGEABLE. Main `ed29b1e30` à 20:55Z confirmée avant `git worktree add`.
- Pas de DM ai-01 à acquitter (amendement posté en commentaire d'issue, pas en DM).
  Commentaire d'amendement 2026-08-07T19:05:10Z lu sur l'#9860 avant édition.

## Voir aussi

- Issue **#9860** — *« Repo size / GC enforcement policy »* (reste OPEN pour suivi H.3)
- PR **#9912** (`02a7b1f8c`, MERGED 2026-08-07) — porte le doc initial ; cette PR en est
  l'amendement sur §3
- Commentaire ai-01 sur #9860, 2026-08-07T19:05:10Z — source verbatim des chiffres §3.2
- `topic-c9872-102-pool-saturation.md` — leçons pool-saturation-honnête c.9872-L7/L8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

See #9860