### PR TITLE
fix(csp5,#8052): regenerate stale FFD-vs-optimal output (1 bin -> 3 bins)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
@@ -1349,12 +1349,12 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "CP-SAT optimal: 2 bins\n",
-      "FFD heuristic:  1 bins\n",
-      "Gap: -50.0%\n"
+      "FFD heuristic:  3 bins\n",
+      "Gap: 50.0%\n"
      ]
     }
    ],

--- a/scripts/notebook_tools/twin_pairs.d/csp-5-optimization.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-5-optimization.yaml
@@ -8,6 +8,12 @@
       by: myia-po-2023:CoursIA
       python_sha: 4c6ddd792c6842627cb4029718d378b3b2337381
       csharp_sha: cd0d73e8fee0fe5c17b2a5df10554a32f2d9498e
+    - date: "2026-08-07"
+      by: myia-po-2024:CoursIA
+      python_sha: cf04e71d022cfb777825037e941f80adf01cb295
+      csharp_sha: cd0d73e8fee0fe5c17b2a5df10554a32f2d9498e
+      content_python_sha: 6563b2715a604c74b61ec57af8eea6f1c85324dcb5e8a36d5f96add0b913b8a4
+      content_csharp_sha: 842524dae2c561df22a19efde82c8fcd0583b66367fec5ede557160eb2dc019d
   known_differences:
     - "Socle pedagogique commun (parity semantic) : les deux cotes couvrent les 4 problemes classiques d'optimisation combinatoire -- Bin Packing (BPP), Knapsack 0/1, Cutting Stock, Optimisation de Portefeuille -- avec la meme progression pedagogique (formulation variables/constraints/objectif -> exemple resolu -> interpretation). Meme theorie sous-jacente (minimisation bins, maximisation valeur sous capacite, patterns de coupe optimaux, allocation lineaire sous contraintes de risque)."
     - "Idiomes framework : Python = **OR-Tools CP-SAT** (`ortools.sat.python.cp_model`) + `numpy` + `matplotlib` (visualisation du bin packing, benchmark de passage a l'echelle). C# = **Choco-solver via IKVM** (`org.chocosolver.solver.dll`, recette #4711) sur runtime .NET -- le solveur Java est invoque depuis C# via l'assembleur IKVM."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #9925

## Quoi / Preuve

**Correctness fix** dans `CSP-5-Optimization.ipynb` (Search/Part2-CSP). La cellule `64f599ff` (« Benchmark: Heuristique First Fit Decreasing pour Bin Packing ») portait en sortie committée un résultat **factuellement impossible** :

```
CP-SAT optimal: 2 bins
FFD heuristic:  1 bins
Gap: -50.0%
```

FFD (heuristique gloutonne) ne peut **jamais** utiliser strictement moins de bins que l'optimum **prouvé** par CP-SAT (ici 2 bins, `OPTIMAL`, cellule `b67b84bc`). Un gap négatif heuristique-vs-optimal est mathématiquement impossible. La cellule d'interprétation markdown `ae6d9851` (immédiatement après) dit elle-même « FFD utilise **3 bins** ... un gap de **50 %** », et la cellule de scaling-benchmark (`scaling-benchmark`) confirme `FFD 3 / CP-SAT 2 / gap 50.0%`. Seule la cellule `64f599ff` portait la valeur fausse (1 bin) — **auto-contradiction interne** au notebook.

### Preuve du fix (firsthand, 3 sources G.1)

1. **Re-exécution réelle** du code source de la cellule `64f599ff` (la fonction `bin_packing_ffd` est du pur Python, pas de `#r nuget`/`#!import`/GPU) sur l'instance en scope `items=[2,2,2,3,5,6], capacity=10, bpp_result num_bins=2` → trace FFD : tri décroissant `[6,5,3,2,2,2]`, placements `6→bin0, 5→bin1, 3→bin0, 2→bin1, 2→bin1, 2→bin2` → charges `[9,9,2]` = **3 bins**, gap `(3-2)/2*100 = +50.0%`.
2. **Concordance interne** : markdown `ae6d9851` + scaling-benchmark disent tous deux 3 bins / +50 %.
3. **Main actuel confirmé fautif** : re-lecture de la cellule sur `origin/main` (`7d0af94343`) → toujours « 1 bins / -50.0 % ».

## Diagnostic dérive (C.4 — obligatoire #8052 / #8364)

**POURQUOI l'output était faux** : la **source** `bin_packing_ffd` est **correcte** (FFD standard, produit bien 3 bins vérifié par re-run). Le défaut est une **sortie stale** : la cellule avait été re-exécutée dans le passé dans un état où `bin_packing_ffd` était boguée (retournait 1) ou `bpp_result` était incohérent ; la source a ensuite été corrigée **mais la sortie n'a jamais été régénérée** (violation C.2). Aucun hand-edit — Stop & Repair : la cause (sortie stale) est corrigée par **re-exécution réelle**, sortie transplantée byte-identique au run.

**Historique de régression (honnêteté)** : cette cellule a **déjà été corrigée** par #3550 (2026-06-19, « re-align stale FFD output »), puis a **dérivé à nouveau** (le vecteur `items` a été restructuré — optimal est passé de 5 à 2 bins — et une re-exécution partielle/incohérente a réintroduit une sortie fausse). C'est une cellule **régression-prone** : la sortie FFD n'est pas régénérée quand `items`/`bpp_result` changent en amont. Le présent fix ré-aligne sur la vraie sortie du run, mais **la récidive est possible** tant qu'aucun invariant CI ne verrouille « heuristique ≥ optimum prouvé ». Suivi suggéré : invariant CI (grain `guard` séparé).

**Verdict C.4** : `CAUSE_FIXED` — la cause (sortie stale après correction de source) est corrigée par re-exécution réelle ; la valeur ré-alignée (3 bins / +50.0 %) vient d'un **run frais**, pas d'un byte-surgical markdown-align.

## Périmètre / ce que la PR fait

- **Sortie cellule `64f599ff` régénérée** depuis le run réel (transplant : `1 bins / -50.0%` → `3 bins / +50.0%`). `git diff --numstat` : 3 insertions, 3 déletions (output-only).
- **Source inchangée** (la fonction `bin_packing_ffd` était déjà correcte) — vérifié : `def bin_packing_ffd` + print « FFD heuristic: » intacts.
- `execution_count` préservé (11) — la position de la cellule est inchangée par un transplant output-only.
- **Twin pair** « CSP-5 Optimization » : rebaseline effectuée (`--update` APRÈS commit, MEMORY twin-parity-update-after-commit) — le benchmark FFD est un **known_difference Python-only** (le twin C# utilise Choco-solver), donc le twin C# est non-affecté ; `--per-pair --base origin/main` → `drift_introduced == 0` reproduit (157 paires, 0 drift).
- Pre-commit hooks TOUS PASSÉS (gitleaks, probe-strip, machine-path-scrub, papermill-paths, H.3).

## Périmètre — ce que la PR ne fait pas

- **Bug #2 secondaire** (cellule `f827a0561e2b`, « Bin Packing avec conflits ») : source **cassée** — la liste de conflits `[(0,2),(3,7),(1,4)]` référence l'index 7 mais `items` n'a que 6 éléments → `KeyError` sur re-exécution ; la sortie committée « None bins » est stale. Cause différente (source cassée + décision de design sur les conflits valides), fix différent → **grain séparé** pour éviter un composite (G.4). Flaggué ici pour traçabilité.
- Aucun invariant CI « heuristique ≥ optimum » (grain `guard` séparé, voir Diagnostic).
- Pas de `Closes #N` : fix auto-initié (scan Prong-B #3801), rattaché à l'EPIC claims↔outputs `#8052` (contribution partielle). Voir `#8052`, `#8364`.

See #8052 (claims↔outputs audit), #8364 (diagnostiquer avant de ré-aligner), [notebook-conventions.md](.claude/rules/notebook-conventions.md) (C.2 outputs, C.4 diagnostic), [secrets-hygiene.md](.claude/rules/secrets-hygiene.md) règle 6 (Stop & Repair), #3801 (Prong-B / axe-2 SOTA).
