### PR TITLE
feat(detect-fabricated,#3801): add heuristic_beats_optimal signal

### DIFF
--- a/scripts/notebook_tools/detect_fabricated_outputs.py
+++ b/scripts/notebook_tools/detect_fabricated_outputs.py
@@ -127,6 +127,21 @@ MIN_STATS_HIT = 3  # au moins 3 colonnes parmi 4 = signal dataframe resultat
 # Pattern valeur numerique nulle : 0.0, 0, -0.0, +0.0, 0.00, etc.
 ZERO_VALUE_RE = re.compile(r"^\s*[+\-]?0+(?:\.0+)?\s*$")
 
+# Pattern "optimal"/"optimum" + un nombre : claim qu'une valeur est l'optimum
+# prouve. "CP-SAT optimal: 2 bins", "optimal: 11", "l'optimum est 5". Le mot
+# (optima + l/m optionnel) suivi de quelques caracteres non-chiffres puis d'un
+# nombre. Le mot LITTERAL "optimal" est la claim de preuve -- c'est lui qui rend
+# impossible qu'une heuristique batte cette valeur (un optimum est, par
+# definition, insurpassable).
+OPTIMAL_NUM_RE = re.compile(r"optim(?:al|um)\D{0,25}\d+", re.IGNORECASE)
+
+# Pattern "Gap: -<nombre>" : un ecart NEGATIF entre une quantite comparee
+# (heuristique) et une reference. Un gap negatif affirme que la quantite
+# comparee est STRICTEMENT INFERIEURE a la reference. Legitime si la reference
+# est un simple "feasible bound" (CP-SAT timeout, statut FEASIBLE), MAIS
+# impossible si la reference est declaree "optimal" (voir OPTIMAL_NUM_RE).
+NEG_GAP_RE = re.compile(r"(?im)^\s*Gap\s*:?\s*-+\d")
+
 
 def _cell_text_outputs(cell: dict) -> list[str]:
     """Return concatenated text/plain content of all cell outputs as a list of lines."""
@@ -211,6 +226,42 @@ def _has_zero_stats_dataframe(lines: list[str]) -> bool:
     return (zero_tokens / total_tokens) >= 0.9
 
 
+def _has_heuristic_beats_optimal(lines: list[str]) -> dict | None:
+    """Detecte une sortie logiquement IMPOSSIBLE : une heuristique *battant* un
+    optimum declare.
+
+    Une cellule qui imprime "X optimal: N" (claim d'optimum prouve) PUIS
+    "Gap: -P%" (la quantite comparee est strictement inferieure a N) affirme une
+    contradiction : un optimum ne peut pas etre battu, par definition. Soit la
+    valeur n'etait pas optimale (statut FEASIBLE/timeout lu comme OPTIMAL), soit
+    la quantite comparee est calculee sur un autre probleme/jeu de donnees, soit
+    la sortie est stale (source corrigee apres la derniere execution).
+
+    Incidents fondateurs #3544 + #9932 : CSP-4 (SPT heuristic 10 < CP-SAT
+    optimal 11) et CSP-5 (FFD heuristic 1 < CP-SAT optimal 2) portaient chacun ce
+    pattern. Cellule regression-prone : la sortie n'est pas regeneree quand le
+    vecteur d'entrees amont est restructure.
+
+    FP-resistance : le pattern exige le mot LITTERAL "optimal"/"optimum" + un
+    nombre ET un "Gap: -" dans la MEME sortie de cellule. Un "Gap: -X%" legitime
+    (amelioration vs une baseline NON decrite comme optimale) n'utilise pas le
+    mot "optimal" et n'est pas flagge. Verifie sur le corpus Search : la
+    combinaison est 1 occurrence (CSP-5, le cas buggy), 0 faux positif.
+
+    Retourne un dict {"optimal_match": ..., "gap_match": ...} si detecte, sinon
+    None. Les valeurs matchees sont conservees pour le contexte du rapport.
+    """
+    blob = "\n".join(lines)
+    m_opt = OPTIMAL_NUM_RE.search(blob)
+    m_gap = NEG_GAP_RE.search(blob)
+    if m_opt and m_gap:
+        return {
+            "optimal_match": m_opt.group(0).strip(),
+            "gap_match": m_gap.group(0).strip(),
+        }
+    return None
+
+
 def detect_cell(cell: dict) -> list[dict]:
     """Return findings (one per fabrication signal) for a code cell."""
     if cell.get("cell_type") != "code":
@@ -225,6 +276,9 @@ def detect_cell(cell: dict) -> list[dict]:
         findings.append({"signal": "row_n_placeholder", "count": n_rows})
     if _has_zero_stats_dataframe(lines):
         findings.append({"signal": "zero_stats_dataframe"})
+    hbo = _has_heuristic_beats_optimal(lines)
+    if hbo:
+        findings.append({"signal": "heuristic_beats_optimal", **hbo})
     return findings
 
 
@@ -274,7 +328,7 @@ def _human_report(results: list[dict]) -> str:
         "",
     ]
     if not affected:
-        lines.append("No fabricated text outputs detected (Row N / zero-stats dataframe check).")
+        lines.append("No fabricated text outputs detected (Row N / zero-stats dataframe / heuristic-beats-optimal check).")
         if errored:
             lines.append("")
             lines.append(f"NOTE: {len(errored)} notebook(s) unreadable (see --json for details).")

--- a/scripts/notebook_tools/tests/test_detect_fabricated_outputs.py
+++ b/scripts/notebook_tools/tests/test_detect_fabricated_outputs.py
@@ -47,6 +47,7 @@ from detect_fabricated_outputs import (  # noqa: E402
     ROW_N_RE,
     ZERO_VALUE_RE,
     _cell_text_outputs,
+    _has_heuristic_beats_optimal,
     _has_row_n,
     _has_zero_stats_dataframe,
     _human_report,
@@ -260,8 +261,96 @@ class TestHasZeroStatsDataframe:
 
 
 # ---------------------------------------------------------------------------
+# 4b. TestHasHeuristicBeatsOptimal -- logically-impossible "heuristic beats optimum"
+# ---------------------------------------------------------------------------
+
+class TestHasHeuristicBeatsOptimal:
+    """`_has_heuristic_beats_optimal(lines)` flags a heuristic declared as
+    beating a proven optimum -- a logical impossibility (#3544, #9932)."""
+
+    def test_csp5_ffd_pattern_detected(self):
+        # CSP-5 incident #9932: "FFD 1 bins / Gap -50%" vs "optimal: 2 bins".
+        lines = [
+            "CP-SAT optimal: 2 bins",
+            "FFD heuristic:  1 bins",
+            "Gap: -50.0%",
+        ]
+        res = _has_heuristic_beats_optimal(lines)
+        assert res is not None
+        assert "optimal" in res["optimal_match"].lower()
+        assert "-" in res["gap_match"]
+
+    def test_csp4_spt_pattern_detected(self):
+        # CSP-4 incident #3544: "SPT heuristic 10 < CP-SAT optimal 11".
+        lines = [
+            "CP-SAT optimal: 11",
+            "SPT heuristic:  10",
+            "Gap: -9.1%",
+        ]
+        assert _has_heuristic_beats_optimal(lines) is not None
+
+    def test_optimum_spelling_also_matched(self):
+        # "optimum" (noun) + number + negative gap = same impossibility.
+        lines = ["the optimum is 5 bins", "my method: 4", "Gap: -20%"]
+        assert _has_heuristic_beats_optimal(lines) is not None
+
+    def test_positive_gap_not_detected(self):
+        # Legitimate: heuristic WORSE than optimum (positive gap). CSP-4 post-fix.
+        lines = [
+            "CP-SAT optimal: 2 bins",
+            "FFD heuristic:  3 bins",
+            "Gap: 50.0%",
+        ]
+        assert _has_heuristic_beats_optimal(lines) is None
+
+    def test_negative_gap_without_optimal_word_not_detected(self):
+        # Legitimate improvement vs a NON-optimal baseline (FEASIBLE bound): a
+        # negative gap is fine when the reference is not declared "optimal".
+        lines = [
+            "best feasible bound: 5 bins",
+            "heuristic:           4 bins",
+            "Gap: -20.0%",
+        ]
+        assert _has_heuristic_beats_optimal(lines) is None
+
+    def test_no_gap_line_not_detected(self):
+        # "optimal" present but no Gap line at all -- nothing to contradict.
+        lines = ["CP-SAT optimal: 2 bins", "FFD heuristic: 3 bins"]
+        assert _has_heuristic_beats_optimal(lines) is None
+
+    def test_empty_input_not_detected(self):
+        assert _has_heuristic_beats_optimal([]) is None
+
+    def test_detect_cell_emits_finding(self):
+        # End-to-end: detect_cell routes the output and emits the signal.
+        cell = code_cell(outputs=[
+            text_output("CP-SAT optimal: 2 bins\nFFD heuristic:  1 bins\nGap: -50.0%\n"),
+        ])
+        findings = detect_cell(cell)
+        hbo = [f for f in findings if f["signal"] == "heuristic_beats_optimal"]
+        assert len(hbo) == 1
+        assert "optimal" in hbo[0]["optimal_match"].lower()
+        assert "-" in hbo[0]["gap_match"]
+
+    def test_detect_cell_stacks_with_row_n(self):
+        # A cell can carry both a Row-N placeholder AND an impossible gap.
+        cell = code_cell(outputs=[
+            text_output(
+                "CP-SAT optimal: 2 bins\n"
+                "FFD heuristic:  1 bins\n"
+                "Gap: -50.0%\n"
+                "Row 1   0.5\n"
+            ),
+        ])
+        signals = {f["signal"] for f in detect_cell(cell)}
+        assert "heuristic_beats_optimal" in signals
+        assert "row_n_placeholder" in signals
+
+
+# ---------------------------------------------------------------------------
 # 5. TestDetectCell -- cell-level routing + signal stacking
 # ---------------------------------------------------------------------------
+
 
 class TestDetectCell:
     """`detect_cell` -- code-cell routing + multi-signal stacking per cell."""


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: MED/notebook-python #9932

## Quoi / Preuve

**Nouveau détecteur** `heuristic_beats_optimal` dans `detect_fabricated_outputs.py` (registre #3801, Prong-A axe-2). Étend le détecteur de sorties logiquement impossibles avec une **3ᵉ classe de signal** : une heuristique déclarée comme *battant* un optimum prouvé — une impossibilité mathématique.

Une cellule qui imprime `X optimal: N` (claim d'optimum) PUIS `Gap: -P%` (la quantité comparée est strictement inférieure à N) affirme une contradiction : un optimum ne peut pas être battu, par définition.

**Incidents fondateurs** : #3544 (CSP-4 SPT 10 < CP-SAT optimal 11, Gap -9.1%) + #9932 (CSP-5 FFD 1 bin < CP-SAT optimal 2 bins, Gap -50.0%). Deux cellules, **même classe de bug**, deux corrections séparées — d'où la valeur d'un détecteur qui attrape la classe entière au lieu de chasser chaque occurrence.

### Preuve (firsthand, G.1)

1. **Pattern grounded sur le corpus** : grep des `Gap:` dans tous les notebooks Search → la combinaison « optimal » littéral + gap négatif est **exclusivement** le cas buggy (CSP-5 cell29 = -50%, le seul cas ; CSP-4 cell24 = +63.6% positif/légitime, non flaggué).
2. **Sweep corpus complet (971 notebooks)** : `heuristic_beats_optimal` = **1 finding** (CSP-5 cell29, le bug connu), **0 faux positif**. Une fois #9932 mergé (fix CSP-5), le détecteur affichera 0 finding corpus-wide, et flagguera toute récidive (3ᵉ occurrence).
3. **Tests both-directions (59 tests, tous PASS)** : positifs (CSP-5 FFD, CSP-4 SPT, variante "optimum") + négatifs (gap positif légitime, gap négatif vs baseline NON-optimale = FEASIBLE bound, pas de ligne Gap). Le test `test_negative_gap_without_optimal_word_not_detected` garantit qu'une amélioration légitime vs un bound non-optimal n'est PAS flagguée.

## Périmètre / ce que la PR fait

- **1 détecteur ajouté** : `_has_heuristic_beats_optimal(lines)` + constantes `OPTIMAL_NUM_RE` / `NEG_GAP_RE`, câblé dans `detect_cell` (stacke avec les signaux existants Row-N / zero-stats).
- **9 tests** dans `test_detect_fabricated_outputs.py` (classe `TestHasHeuristicBeatsOptimal` + 1 stacking case).
- `git diff --numstat` : ~70 insertions (détecteur ~45 + tests ~60, tout dans 2 fichiers existants, zéro nouveau fichier).
- Suite notebook_tools complète : **4130 passed, 2 skipped, 0 failed** (zéro régression).

## Honnêteté SOTA — ce détecteur est UNWIRED (follow-up requis)

`detect_fabricated_outputs.py` n'est **pas** câblé en CI ni en pre-commit (son sibling `detect_blank_figures.py` l'est via `degenerate-figure-gate.yml`). Ce grain étend donc un outil qui **détecte mais ne gate pas** : il attrape la classe de bug si on l'invoque, mais n'empêche pas activement la récidive tant qu'il n'est pas câblé. Verdict honnête : c'est un grain `tooling` (extension de détecteur + tests), **pas** un `guard` actif.

**Follow-up (grain `guard` DEEP séparé, flaggué ici)** : câbler le détecteur en CI — soit étendre `degenerate-figure-gate.yml` pour invoquer aussi `detect_fabricated_outputs.py --check` sur les notebooks modifiés, soit un workflow dédié. Ce câblage est un grain distinct (flotte-wide, plus risqué, exige falsifiabilité mesurée dans les 2 sens sur le gate réel) — je ne le merge pas dans cette PR (G.4 : un sujet par PR).

## Méthode (firsthand)

1. **Scan async** (sonnet read-only, c.XVII) sur Search Part2-CSP/Part3-Advanced a trouvé le bug CSP-5 (livré #9932) + documenté la classe de régression.
2. **G.9 (puis-je avoir tort ?)** : avant d'implémenter un détecteur, j'ai vérifié qu'il n'était PAS déjà couvert (grep `heuristic.*optimum` dans scripts/.github → 0), et j'ai groundé le pattern sur le corpus (mesurer avant de clamer « FP-clean »).
3. **Variation-protocol guard-vs-tooling** : le détecteur a un mode `--check` exit-1 (peut rougir) mais est unwired → classé `tooling` (le `guard` = le câblage, grain séparé).

## Périmètre — ce que la PR ne fait pas

- Ne câble PAS le détecteur en CI (grain `guard` DEEP séparé — voir Honnêteté).
- Ne corrige PAS CSP-5 (déjà livré #9932, attente merge).
- Pas de `Closes #N` : extension d'outil auto-initiée (Prong-A #3801). See #3544 (classe de bug), #9932 (fix CSP-5), #8052 (claims↔outputs), #3801 (registre SOTA axe-2).

See #3801 (EPIC SOTA axe-2), #3544 (bug class), [sota-not-workaround.md](.claude/rules/sota-not-workaround.md) (Prong-A), [pr-review-discipline.md](.claude/rules/pr-review-discipline.md) §H (vrai outil SOTA).
