### PR TITLE
feat(ci,#3801): wire fabricated-output gate + harden row_n vs LLM-prose FP

### DIFF
--- a/.github/workflows/fabricated-output-gate.yml
+++ b/.github/workflows/fabricated-output-gate.yml
@@ -1,0 +1,143 @@
+name: Fabricated text output gate
+
+# Purpose
+# -------
+# Per-PR gate for committed TEXT outputs that are FABRICATED placeholders
+# masquerading as real cell results: a `text/plain` cell output that prints a
+# Pandas default-index dataframe ("Row 0", "Row 1", ...) never filled in, a
+# backtest-stats dataframe with all-zero values, or a heuristic that *beats* a
+# proven optimum. Such outputs are committed where the cell source builds a real
+# result, so the PR's literal pedagogical goal (a number that came out of the
+# real engine) is unmet even though the notebook is well-formed and CI passes.
+# This is the Prong-A axe-2 defect class of registre #3801 (a substitution
+# output committed as if it were the real engine's output).
+#
+# This gate is the textual counterpart of degenerate-figure-gate.yml (#6918,
+# axe 1 = the 1x1 / tiny-payload PNG). The two are complementary and
+# non-overlapping: the figure gate catches degenerate RASTER placeholders; this
+# one catches degenerate TEXT placeholders. A notebook can suffer either or
+# both (incident #6891 quantbooks carried blank-PNG AND "Row N" text).
+#
+# Detector: scripts/notebook_tools/detect_fabricated_outputs.py (#3801, axe 2),
+# run in --check mode (exit 0 clean, exit 1 on defect, exit 2 on read error) on
+# every notebook CHANGED by the PR. Three deterministic signal classes:
+#   - row_n_placeholder      : >= 3 consecutive "Row N" labels (Pandas default
+#                              index of an unfilled dataframe). Hardened against
+#                              LLM-output / prose FP (Sudoku-17 incident): a
+#                              single isolated "Row N" mention is NOT flagged --
+#                              only the consecutive-index sequence is.
+#   - zero_stats_dataframe   : >= 3 of {Sharpe, CAGR, MaxDD, NetProfit} columns
+#                              with all-zero values (a backtest that did not run).
+#   - heuristic_beats_optimal: "optimal: N" + "Gap: -P%" in the same cell output
+#                              (a heuristic cannot beat a proven optimum =
+#                              mathematical impossibility). Bug class of #3544
+#                              (CSP-4 SPT) and #9932 (CSP-5 FFD).
+#
+# Diff-scoped ratchet (not clean-baseline-absolute): the gate only inspects
+# notebooks CHANGED by a PR. As of the gate's introduction (2026-08-07) the full
+# 971-notebook pedagogical tree is CLEAN (0 findings) -- verified firsthand, so
+# the ratchet has ZERO grandfathered debt and blocks any NEW fabricated output
+# immediately, anywhere. Should a fabricated output land on `main` out-of-band
+# (a merge that bypassed this gate), it sits dormant until its notebook is next
+# touched, at which point the gate correctly enforces the fix.
+#
+# FP profile (honest): the row_n signal was hardened in this same change to
+# eliminate a confirmed false positive (Sudoku-17-LLM-Python cell[14]: an LLM
+# zero-shot trace referencing Sudoku rows in prose). Post-hardening the corpus
+# sweep is 0/971. The heuristic_beats_optimal signal is FP-safe by construction
+# (the literal "optimal" + negative-gap combination is exclusively the buggy
+# case). The zero_stats_dataframe signal requires the canonical column set AND
+# all-zero values, a combination rare outside a non-running backtest.
+#
+# See EPIC #3801 (registre axe-2 SOTA / Prong-A), issues #6891 (founding
+# incident: 8 quantbooks blank-PNG + Row N), #3544 + #9932 (heuristic-beats-
+# optimal bug class), and the sibling degenerate-figure-gate.yml (#6918).
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'MyIA.AI.Notebooks/**/*.ipynb'
+      - 'scripts/notebook_tools/detect_fabricated_outputs.py'
+      - '.github/workflows/fabricated-output-gate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fabricated-output:
+    name: "No fabricated text output in changed notebooks"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # No extra dependencies: detect_fabricated_outputs.py is pure stdlib
+      # (argparse, json, re, pathlib) + a same-directory import of notebook_walk.
+      # The script's own dir is on sys.path[0], so the sibling import resolves
+      # exactly as it does for detect_blank_figures.py in the figure gate.
+
+      - name: Gate changed notebooks
+        run: |
+          set -uo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "::notice title=Fabricated output gate::Manual dispatch — nothing to diff."
+            exit 0
+          fi
+
+          BASE="origin/${{ github.base_ref }}"
+          CHANGED=$(git diff --name-only "$BASE"...HEAD -- 'MyIA.AI.Notebooks/**/*.ipynb' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "::notice title=Fabricated output gate::No notebooks changed — clean."
+            exit 0
+          fi
+
+          echo "## Fabricated text output gate" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          fail=0
+          checked=0
+          while IFS= read -r nb; do
+            [ -z "$nb" ] && continue
+            # Skip notebooks deleted by the PR.
+            [ -f "$nb" ] || continue
+            checked=$((checked + 1))
+            # The `&& rc=0 || rc=$?` tail is load-bearing. The step runs under
+            # `bash -e`, where a bare `out=$(cmd)` that exits non-zero aborts
+            # the step IMMEDIATELY -- before `rc=$?` is read -- making the
+            # rc=1 / rc=2 branches unreachable dead code. A real finding then
+            # surfaces as a bare `exit 1` naming no notebook, indistinguishable
+            # from the detector crashing. Membership in an `&&`/`||` list
+            # exempts the assignment from errexit; the explicit `fail` flag
+            # decides the step's outcome instead. NOT `|| true`: that would make
+            # `$?` read 0 from `true` itself, so rc would always be 0 and the
+            # gate could never fire at all. (Same invariant as the figure gate.)
+            out=$(python scripts/notebook_tools/detect_fabricated_outputs.py --check "$nb" 2>&1) && rc=0 || rc=$?
+            if [ "$rc" -eq 1 ]; then
+              echo "::error title=Fabricated output::$nb commits a fabricated text output (Row-N placeholder / zero-stats dataframe / heuristic-beats-optimal) masquerading as a real cell result."
+              echo "<details><summary><code>$nb</code></summary>" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "$out" >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+              fail=1
+            elif [ "$rc" -eq 2 ]; then
+              echo "::warning title=Fabricated output gate::$nb could not be read (rc=2); see detector log."
+            fi
+          done <<< "$CHANGED"
+
+          if [ "$fail" -ne 0 ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "FIX (Stop&Repair): re-execute the cell in the REAL environment (QC Cloud research for QuantBook, local kernel for Python) and commit the real output. Never scrub/delete the output to hide it (secrets-hygiene rule 6). See issue #6891 for the founding incident and EPIC #3801 for the detector register." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "::notice title=Fabricated output gate::Checked $checked changed notebook(s); no fabricated text output."

--- a/scripts/notebook_tools/detect_fabricated_outputs.py
+++ b/scripts/notebook_tools/detect_fabricated_outputs.py
@@ -118,6 +118,21 @@ from pathlib import Path
 # suivi d'espace ou fin de ligne (pour eviter "Row 123" en milieu de phrase).
 ROW_N_RE = re.compile(r"(?m)^\s*Row\s+\d+(?=\s|$)")
 
+# Une occurrence isolee de "Row N" n'est PAS un signal de fabrication : c'est
+# souvent de la prose (sortie LLM "Row 1 remaining:...", texte pedagogique
+# "la Row 2 contient..."). La signature d'un dataframe Pandas NON REMPLI est une
+# SEQUENCE d'indices consecutifs (Row 0, Row 1, Row 2, ...) -- l'index par
+# defaut qu'emet Pandas pour un dataframe sans index nomme. On exige donc une
+# serie d'au moins MIN_ROW_SEQUENCE entiers consecutifs pour flagger.
+#
+# Incident fondateur (FP) : Sudoku-17-LLM-Python cell[14] -- la trace de
+# resolution zero-shot d'un LLM contient "Row 1 remaining: R1C4..." et "Row 2
+# is complete: 1 7 4...". Deux mentions isolees de prose, non un dataframe.
+# Sous l'ancienne regle "any single match", c'etait un faux positif. Exiger une
+# sequence de >= 3 l'elimine (2 mentions isolees < 3, et non consecutives au
+# sens d'un index 0..k-1 remontant).
+MIN_ROW_SEQUENCE = 3
+
 # Noms de colonnes canoniques d'un dataframe "resultat backtest".
 # Si au moins 3 de ces 4 apparaissent dans la sortie ET que les valeurs sont
 # toutes a 0.0 / 0 (dataframe present mais stats nulles = backtest pas tourne).
@@ -155,9 +170,31 @@ def _cell_text_outputs(cell: dict) -> list[str]:
 
 
 def _has_row_n(lines: list[str]) -> bool:
-    """True if any line is a 'Row N' placeholder (litteral row not filled)."""
+    """True if the output contains a SEQUENCE of >= MIN_ROW_SEQUENCE consecutive
+    'Row N' labels -- the Pandas default-index signature of an unfilled dataframe.
+
+    Une occurrence isolee (ou deux) de "Row N" dans la prose n'est PAS un
+    dataframe placeholder : sortie LLM ("Row 1 remaining: ..."), texte
+    pedagogique, reference a une ligne de grille (Sudoku). La signature d'un
+    dataframe NON REMPLI est l'index par defaut de Pandas : Row 0, Row 1, ...,
+    Row k-1 (une suite d'entiers consecutifs). On exige donc >= MIN_ROW_SEQUENCE
+    entiers formant une suite consecutive.
+
+    FP elimine : Sudoku-17-LLM-Python cell[14] (trace LLM, 2 mentions isolees
+    "Row 1 remaining" / "Row 2 is complete") etait un faux positif sous l'ancienne
+    regle "any single match". Corpus-wide post-durcissement : 0 finding (verifie
+    sur les 971 notebooks pedagogiques).
+    """
     blob = "\n".join(lines)
-    return bool(ROW_N_RE.search(blob))
+    nums = sorted({int(m.group(0).split()[-1]) for m in ROW_N_RE.finditer(blob)})
+    if len(nums) < MIN_ROW_SEQUENCE:
+        return False
+    # Plus longue suite d'entiers consecutifs (signature index Pandas 0..k-1).
+    longest = run = 1
+    for prev, cur in zip(nums, nums[1:]):
+        run = run + 1 if cur == prev + 1 else 1
+        longest = max(longest, run)
+    return longest >= MIN_ROW_SEQUENCE
 
 
 def _has_zero_stats_dataframe(lines: list[str]) -> bool:

--- a/scripts/notebook_tools/tests/test_detect_fabricated_outputs.py
+++ b/scripts/notebook_tools/tests/test_detect_fabricated_outputs.py
@@ -164,8 +164,23 @@ class TestZeroValueRegex:
 class TestHasRowN:
     """`_has_row_n(lines)` returns True when Row N placeholders are present."""
 
-    def test_single_row_n_detected(self):
-        assert _has_row_n(["Row 1     0.5   0.1"])
+    def test_single_row_n_not_flagged(self):
+        # A single isolated "Row N" is prose (LLM output, pedagogy, grid
+        # reference), NOT a dataframe placeholder. Hardened post Sudoku-17 FP
+        # (c.XIX): exige >= MIN_ROW_SEQUENCE entiers consecutifs.
+        assert not _has_row_n(["Row 1     0.5   0.1"])
+
+    def test_row_n_llm_prose_not_flagged(self):
+        # Sudoku-17-LLM-Python cell[14] incident : LLM zero-shot trace references
+        # Sudoku rows in prose. Two isolated mentions = NOT a Pandas index sequence.
+        assert not _has_row_n([
+            "Row 1 remaining: R1C4, R1C5 are {1,8}.",
+            "Row 2 is complete: 1 7 4 9 6 3 8 2 5.",
+        ])
+
+    def test_row_n_two_isolated_not_flagged(self):
+        # Two mentions with non-consecutive integers = NOT a sequence.
+        assert not _has_row_n(["Row 1 some prose", "Row 5 other prose"])
 
     def test_multiple_row_n_detected(self):
         assert _has_row_n(
@@ -281,8 +296,13 @@ class TestDetectCell:
         assert detect_cell(cell) == []
 
     def test_code_cell_with_row_n_returns_finding(self):
+        # Hardened (c.XIX): requires >= MIN_ROW_SEQUENCE consecutive Row N.
         cell = code_cell(outputs=[
-            display_data_output("Row 1     0.530    7.2%  -12.7%"),
+            display_data_output("\n".join([
+                "Row 1     0.530    7.2%  -12.7%",
+                "Row 2     0.612    8.1%  -15.3%",
+                "Row 3     0.701    9.0%  -10.1%",
+            ])),
         ])
         findings = detect_cell(cell)
         assert len(findings) == 1
@@ -307,6 +327,7 @@ class TestDetectCell:
             display_data_output("\n".join([
                 "Row 1   0.530    7.2%  -12.7%",
                 "Row 2   0.612    8.1%  -15.3%",
+                "Row 3   0.701    9.0%  -10.1%",
                 "",
                 "       Sharpe  CAGR  MaxDD",
                 "A       0.0    0.0   0.0",
@@ -349,7 +370,11 @@ class TestScanNotebook:
     def test_fabricated_notebook_returns_hits(self, tmp_path):
         nb = {
             "cells": [
-                code_cell(outputs=[display_data_output("Row 1     0.530    7.2%")]),
+                code_cell(outputs=[display_data_output("\n".join([
+                    "Row 1     0.530    7.2%",
+                    "Row 2     0.612    8.1%",
+                    "Row 3     0.701    9.0%",
+                ]))]),
                 code_cell(outputs=[display_data_output("\n".join([
                     "Sharpe  CAGR  MaxDD",
                     "0.0     0.0   0.0",
@@ -400,14 +425,22 @@ class TestMainExitCodes:
         assert result == 0
 
     def test_fabricated_notebook_check_exit_1(self, tmp_path):
-        nb = {"cells": [code_cell(outputs=[display_data_output("Row 1     0.530")])], "metadata": {"kernelspec": {"name": "python3"}}}
+        nb = {"cells": [code_cell(outputs=[display_data_output("\n".join([
+            "Row 1     0.530",
+            "Row 2     0.612",
+            "Row 3     0.701",
+        ]))])], "metadata": {"kernelspec": {"name": "python3"}}}
         nb_path = tmp_path / "fab.ipynb"
         nb_path.write_text(json.dumps(nb), encoding="utf-8")
         result = main(["--root", str(tmp_path), "--check", str(nb_path)])
         assert result == 1
 
     def test_json_output_is_machine_readable(self, tmp_path, capsys):
-        nb = {"cells": [code_cell(outputs=[display_data_output("Row 1     0.530")])], "metadata": {"kernelspec": {"name": "python3"}}}
+        nb = {"cells": [code_cell(outputs=[display_data_output("\n".join([
+            "Row 1     0.530",
+            "Row 2     0.612",
+            "Row 3     0.701",
+        ]))])], "metadata": {"kernelspec": {"name": "python3"}}}
         nb_path = tmp_path / "fab.ipynb"
         nb_path.write_text(json.dumps(nb), encoding="utf-8")
         main(["--root", str(tmp_path), "--json", str(nb_path)])


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/tooling #9933

## Quoi / Preuve

**Nouveau gate CI** `fabricated-output-gate.yml` + **durcissement** du signal `row_n` du détecteur `detect_fabricated_outputs.py` (Prong-A axe-2, registre #3801). Câble le détecteur de sorties textuelles FABRIQUÉES en gate CI **hard** par-PR (diff-scoped), le pendant textuel de `degenerate-figure-gate.yml` (#6918, axe-1 = PNG 1x1).

**Pourquoi durcir AVANT de câbler** : la falsifiabilité mesurée dans les 2 sens (ce que les règles exigent avant un gate fleet-wide) a révélé un **faux positif confirmé** dans le signal `row_n` existant : `Sudoku-17-LLM-Python.ipynb` cell[14] — une trace de résolution zero-shot d'un LLM qui référence légitimement les lignes Sudoku en prose (`Row 1 remaining: R1C4...`, `Row 2 is complete: 1 7 4...`). Sous l'ancienne règle « any single match », c'était flaggué à tort. Un hard gate mirroring le sibling (qui revendique 0 FP) aurait **bloqué toute PR touchant Sudoku-17** sur un FP.

**Durcissement** : `row_n` exige désormais une **séquence de ≥3 entiers consécutifs** (`Row 0, Row 1, Row 2, ...`) — la signature de l'index par défaut Pandas d'un dataframe non rempli. Une mention isolée (ou deux) en prose = pas un placeholder. Ça élimine le FP Sudoku-17 (2 mentions isolées) tout en préservant la détection des cas réels #6891 (tous ≥3 séquentiels : AllWeather 9, FuturesTrend 15, TurnOfMonth 16...).

### Preuve (firsthand, G.1)

1. **FP Sudoku-17 éliminé** : `--check` sur `Sudoku-17-LLM-Python.ipynb` → rc=0 (« No fabricated text outputs ») post-durcissement (était rc=1 avant).
2. **Sweep corpus complet (971 notebooks) : 0 finding, rc=0**. Le durcissement élimine Sudoku-17 SANS introduire aucun nouveau FP. Le ratchet a donc **zéro dette grandfathered** — tout notebook sur `main` est clean, le gate bloque toute NOUVELLE fabrication immédiatement, n'importe où.
3. **Simulation gate both-directions** : POSITIF (notebook fabriqué 3-row Row N) → rc=1, fail=1, annotation error fires ; NÉGATIF (CSP-1 propre) → rc=0. Le pattern bash `&& rc=0 || rc=$?` (load-bearing sous `bash -e`) est copié verbatim du sibling prouvé en production.
4. **Suite complète notebook_tools : 4124 passed, 0 failed** (zéro régression, run depuis repo root).
5. **Tests durcissement both-directions (52 tests)** : positifs (séquence ≥3 Row N → flagged) + négatifs (single Row N, 2 mentions prose isolées, mentions non-consécutives → NOT flagged). 3 tests existants mis à jour pour refléter le comportement durci (single Row N n'est plus flaggué).

## Périmètre / ce que la PR fait

- **Durcissement `_has_row_n`** : `MIN_ROW_SEQUENCE = 3` + extraction des entiers `Row N` + plus longue suite consécutive ≥ 3. Docstring mis à jour (FP Sudoku-17 documenté).
- **Workflow `fabricated-output-gate.yml`** : trigger `pull_request` paths-filtered (notebooks + détecteur + workflow), diff-scoped (`git diff "$BASE"...HEAD`), `--check` par notebook changé, step summary + annotations, ratchet. Mirroring `degenerate-figure-gate.yml`.
- **3 tests mis à jour** (single-Row-N → not-flagged, fixtures 1-row → 3-row sequence, both-signals → 3rd Row N) + **2 nouveaux tests FP** (LLM prose, 2 mentions isolées).
- `git diff --numstat` : 39+/2- détecteur, 39+/6- tests, +1 nouveau workflow. ~80 insertions, 3 fichiers, zéro nouveau fichier hors workflow.

## Honnêteté SOTA

- **Diff-scoped ratchet, pas clean-baseline-absolute** : le gate n'inspecte que les notebooks CHANGÉS par la PR. Au moment de l'introduction, le corpus est 0/971 (zéro dette grandfathered — plus propre que le sibling qui grandfathere 8 PNG QC #6891). Si une fabrication atterrit sur `main` out-of-band (merge contournant le gate), elle reste dormante jusqu'au prochain touch du notebook.
- **Découplage path** : le gate référence `detect_fabricated_outputs.py` par chemin. Le signal `heuristic_beats_optimal` (PR #9933, 0 FP par construction) s'active automatiquement dès que #9932/#9933 mergent — le détecteur mis à jour est invoqué, pas de re-câblage. Les deux PRs touchent le détecteur dans des fonctions distinctes (`_has_row_n` ici vs `_has_heuristic_beats_optimal` dans #9933) → merge auto-résolvable.
- **FP profile documenté** : `heuristic_beats_optimal` = FP-safe par construction (combinaison « optimal » littéral + gap négatif = exclusivement le cas buggy). `zero_stats_dataframe` = exige les colonnes canoniques + valeurs all-zero (rare hors backtest non-tourné). `row_n` = durci (séquence ≥3).

## Méthode (firsthand)

1. **Falsifiabilité AVANT le gate** (ce que les règles imposent) : test du détecteur sur Sudoku-17 → FP révélé. Sans ce test, un hard gate aurait livré un FP bloquant.
2. **G.9 (puis-je avoir tort ?)** : j'avais flaggué ce grain comme `guard DEEP` dans le body #9933. En le réalisant, ré-évaluation contre le litmus variation-protocol : c'est **MED/guard** (étend la substance détecteur #9933 avec vérification CI + enforcement, pas du nouveau raisonnement de domaine). Le « fleet-wide risky » était le scope d'impact, pas la profondeur de raisonnement. Honnêtement corrigé en MED.
3. **Mirror du sibling prouvé** : `degenerate-figure-gate.yml` (#6918) tourne en production depuis 2026-07. Le pattern (paths-filter, diff-scoped, `--check`, rc-handling, step summary) est copié verbatim — seul le détecteur + message diffèrent.

See #3801 (EPIC SOTA axe-2), #6891 (incident fondateur 8 quantbooks), #3544 + #9932 (bug class heuristic-beats-optimal), #9933 (détecteur heuristic_beats_optimal), [degenerate-figure-gate.yml](.github/workflows/degenerate-figure-gate.yml) (sibling axe-1), [sota-not-workaround.md](.claude/rules/sota-not-workaround.md) (Prong-A), [variation-protocol.md](.claude/rules/variation-protocol.md) (litmus MED/guard).
