### PR TITLE
fix(sk9,#9929): boot CoreCLR runtime for pythonnet interop (net9.0 assembly) [stacked on #9928]

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
@@ -115,10 +115,10 @@
    "id": "95fec443",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T19:41:50.149382Z",
-     "iopub.status.busy": "2026-08-07T19:41:50.149382Z",
-     "iopub.status.idle": "2026-08-07T19:41:50.154729Z",
-     "shell.execute_reply": "2026-08-07T19:41:50.153401Z"
+     "iopub.execute_input": "2026-08-07T21:06:49.885987Z",
+     "iopub.status.busy": "2026-08-07T21:06:49.885987Z",
+     "iopub.status.idle": "2026-08-07T21:06:49.891623Z",
+     "shell.execute_reply": "2026-08-07T21:06:49.890577Z"
     },
     "papermill": {
      "duration": 3.384082,
@@ -140,10 +140,10 @@
    "id": "d9026247",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T19:41:50.157731Z",
-     "iopub.status.busy": "2026-08-07T19:41:50.156731Z",
-     "iopub.status.idle": "2026-08-07T19:41:50.166686Z",
-     "shell.execute_reply": "2026-08-07T19:41:50.165676Z"
+     "iopub.execute_input": "2026-08-07T21:06:49.895227Z",
+     "iopub.status.busy": "2026-08-07T21:06:49.894174Z",
+     "iopub.status.idle": "2026-08-07T21:06:49.904056Z",
+     "shell.execute_reply": "2026-08-07T21:06:49.903508Z"
     },
     "papermill": {
      "duration": 0.257777,
@@ -198,10 +198,10 @@
    "id": "74a574d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T19:41:50.168686Z",
-     "iopub.status.busy": "2026-08-07T19:41:50.168686Z",
-     "iopub.status.idle": "2026-08-07T19:41:50.173737Z",
-     "shell.execute_reply": "2026-08-07T19:41:50.172726Z"
+     "iopub.execute_input": "2026-08-07T21:06:49.908118Z",
+     "iopub.status.busy": "2026-08-07T21:06:49.907109Z",
+     "iopub.status.idle": "2026-08-07T21:06:49.913291Z",
+     "shell.execute_reply": "2026-08-07T21:06:49.912244Z"
     }
    },
    "outputs": [
@@ -262,10 +262,10 @@
    "id": "1aa67c3f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T19:41:50.177347Z",
-     "iopub.status.busy": "2026-08-07T19:41:50.176335Z",
-     "iopub.status.idle": "2026-08-07T19:41:50.517388Z",
-     "shell.execute_reply": "2026-08-07T19:41:50.516300Z"
+     "iopub.execute_input": "2026-08-07T21:06:49.915884Z",
+     "iopub.status.busy": "2026-08-07T21:06:49.915884Z",
+     "iopub.status.idle": "2026-08-07T21:06:50.193523Z",
+     "shell.execute_reply": "2026-08-07T21:06:50.192949Z"
     },
     "papermill": {
      "duration": 0.895969,
@@ -281,14 +281,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Chemin DLL calculé : C:\\dev\\CoursIA-sk9-clr-fix\\MyIA.AI.Notebooks\\bin\\Release\\net9.0\n",
+      "Chemin DLL calculé : C:\\dev\\CoursIA-sk9-clr-fix\\MyIA.AI.Notebooks\\bin\\Release\\net9.0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Runtime CoreCLR démarré (config : MyIA.AI.Notebooks.runtimeconfig.json)\n",
       "✅ Chemin ajouté au sys.path : C:\\dev\\CoursIA-sk9-clr-fix\\MyIA.AI.Notebooks\\bin\\Release\\net9.0\n"
      ]
     }
    ],
    "source": [
     "import sys\n",
-    "import clr\n",
     "import os\n",
     "\n",
     "# CORRECTION : Chemin absolu vers la DLL compilée\n",
@@ -308,6 +314,22 @@
     "        print(f\"   - Testé Debug : {dll_path_debug}\")\n",
     "        raise FileNotFoundError(\"DLL MyIA.AI.Notebooks.dll introuvable\")\n",
     "\n",
+    "# Sélection du runtime .NET AVANT tout `import clr`.\n",
+    "# pythonnet 3.x boote par défaut le CLR du .NET Framework (vieux runtime) :\n",
+    "# incapable de résoudre les types ValueTuple d'un assembly net9.0, il lève une\n",
+    "# `TypeLoadException` au moindre appel à un constructeur modern (cf. leçon de la\n",
+    "# section 3). On force donc le **CoreCLR (.NET 9)** via le `runtimeconfig.json`\n",
+    "# produit par `dotnet build`.\n",
+    "#   DOTNET_ROLL_FORWARD=Major : autorise un runtime 10.x à exécuter un assembly\n",
+    "#   net9.0 si seul le runtime 10 est installé sur la machine.\n",
+    "import pythonnet\n",
+    "os.environ[\"DOTNET_ROLL_FORWARD\"] = \"Major\"\n",
+    "_runtime_config = os.path.join(dll_path, \"MyIA.AI.Notebooks.runtimeconfig.json\")\n",
+    "pythonnet.load(\"coreclr\", runtime_config=_runtime_config)\n",
+    "print(f\"✅ Runtime CoreCLR démarré (config : {os.path.basename(_runtime_config)})\")\n",
+    "\n",
+    "import clr  # doit venir APRÈS pythonnet.load\n",
+    "\n",
     "# On ajoute ce dossier dans sys.path\n",
     "if dll_path not in sys.path:\n",
     "    sys.path.append(dll_path)\n",
@@ -321,10 +343,10 @@
    "id": "c507d01c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T19:41:50.522286Z",
-     "iopub.status.busy": "2026-08-07T19:41:50.521737Z",
-     "iopub.status.idle": "2026-08-07T19:41:50.671255Z",
-     "shell.execute_reply": "2026-08-07T19:41:50.670740Z"
+     "iopub.execute_input": "2026-08-07T21:06:50.195569Z",
+     "iopub.status.busy": "2026-08-07T21:06:50.195569Z",
+     "iopub.status.idle": "2026-08-07T21:06:50.307015Z",
+     "shell.execute_reply": "2026-08-07T21:06:50.306467Z"
     },
     "papermill": {
      "duration": 0.562144,
@@ -393,10 +415,10 @@
    "id": "35b15035",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T19:41:50.676324Z",
-     "iopub.status.busy": "2026-08-07T19:41:50.675260Z",
-     "iopub.status.idle": "2026-08-07T19:41:50.887140Z",
-     "shell.execute_reply": "2026-08-07T19:41:50.886125Z"
+     "iopub.execute_input": "2026-08-07T21:06:50.310066Z",
+     "iopub.status.busy": "2026-08-07T21:06:50.310066Z",
+     "iopub.status.idle": "2026-08-07T21:06:50.447438Z",
+     "shell.execute_reply": "2026-08-07T21:06:50.446392Z"
     },
     "papermill": {
      "duration": 0.262218,
@@ -460,10 +482,10 @@
    "id": "aa86a37a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T19:41:50.891137Z",
-     "iopub.status.busy": "2026-08-07T19:41:50.890139Z",
-     "iopub.status.idle": "2026-08-07T19:41:51.043437Z",
-     "shell.execute_reply": "2026-08-07T19:41:51.041420Z"
+     "iopub.execute_input": "2026-08-07T21:06:50.450445Z",
+     "iopub.status.busy": "2026-08-07T21:06:50.449441Z",
+     "iopub.status.idle": "2026-08-07T21:06:50.519148Z",
+     "shell.execute_reply": "2026-08-07T21:06:50.519148Z"
     },
     "papermill": {
      "duration": 0.306075,
@@ -479,14 +501,99 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ Assembly trouvé: MyIA.AI.Notebooks\n",
+      "✅ Assembly trouvé: MyIA.AI.Notebooks"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "Types disponibles dans l'assembly:\n",
-      "  ⚠️ Erreur lors de l'énumération des types: Impossible de charger un ou plusieurs des types requis. Extrayez la propriété LoaderExceptions pour plus d'informations.\r\n",
-      "   à System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)\r\n",
-      "   à System.Reflection.RuntimeModule.GetTypes()\r\n",
-      "   à System.Reflection.Assembly.GetTypes()\n",
-      "  ⚠️ Cela peut indiquer des dépendances .NET manquantes\n",
-      "  → Continuons avec la recherche de classes spécifiques...\n",
+      "  - <>y__InlineArray5`1\n",
+      "  - <>y__InlineArray6`1\n",
+      "  - <>z__ReadOnlyArray`1\n",
+      "  - SkiaUtils\n",
+      "  - FactorGraphHelper\n",
+      "  - SvgChart\n",
+      "  - TraceStyle\n",
+      "  - SvgSeries\n",
+      "  - SvgChartHelper\n",
+      "  - TweetyShade.Placeholder\n",
+      "  - MyNotebookLib.AutoGenNotebookUpdater\n",
+      "  - MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater\n",
+      "  - MyNotebookLib.DisplayLogger\n",
+      "  - MyNotebookLib.DisplayLoggerProvider\n",
+      "  - MyNotebookLib.GuessingGame\n",
+      "  - MyNotebookLib.NotebookExecutor\n",
+      "  - MyNotebookLib.NotebookPlannerUpdater\n",
+      "  - MyNotebookLib.NotebookUpdaterBase\n",
+      "  - MyNotebookLib.WorkbookInteractionBase\n",
+      "  - MyNotebookLib.WorkbookUpdateInteraction\n",
+      "  - MyNotebookLib.WorkbookValidation\n",
+      "  - MyIA.AI.Notebooks.Program\n",
+      "  - MyIA.AI.Notebooks.Config.Settings\n",
+      "  - MyIA.AI.Notebooks.Config.Utils\n",
+      "  - <PrivateImplementationDetails>\n",
+      "  - SkiaUtils+<ShowImage>d__0\n",
+      "  - FactorGraphHelper+<>c\n",
+      "  - FactorGraphHelper+<>o__12\n",
+      "  - SvgChartHelper+PlotLayout\n",
+      "  - SvgChartHelper+<>c\n",
+      "  - SvgChartHelper+<>c__DisplayClass15_0\n",
+      "  - SvgChartHelper+<>c__DisplayClass16_0\n",
+      "  - SvgChartHelper+<>c__DisplayClass20_0\n",
+      "  - MyNotebookLib.AutoGenNotebookUpdater+<>c__DisplayClass1_0\n",
+      "  - MyNotebookLib.AutoGenNotebookUpdater+<PerformNotebookUpdateAsync>d__1\n",
+      "  - MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater+NotebookTerminationStrategy\n",
+      "  - MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater+NotebookSelectionStrategy\n",
+      "  - MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater+<>c\n",
+      "  - MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater+<PerformNotebookUpdateAsync>d__1\n",
+      "  - MyNotebookLib.GuessingGame+ApprovalTerminationStrategy\n",
+      "  - MyNotebookLib.GuessingGame+<RunGameAsync>d__0\n",
+      "  - MyNotebookLib.NotebookExecutor+<>c\n",
+      "  - MyNotebookLib.NotebookExecutor+<>c__DisplayClass11_0\n",
+      "  - MyNotebookLib.NotebookExecutor+<>c__DisplayClass12_0\n",
+      "  - MyNotebookLib.NotebookExecutor+<RunCell>d__12\n",
+      "  - MyNotebookLib.NotebookExecutor+<RunNotebookAsync>d__11\n",
+      "  - MyNotebookLib.NotebookPlannerUpdater+<>c\n",
+      "  - MyNotebookLib.NotebookPlannerUpdater+<PerformNotebookUpdateAsync>d__2\n",
+      "  - MyNotebookLib.NotebookUpdaterBase+<>c\n",
+      "  - MyNotebookLib.NotebookUpdaterBase+<UpdateNotebookAsync>d__49\n",
+      "  - MyNotebookLib.WorkbookInteractionBase+<>c\n",
+      "  - MyNotebookLib.WorkbookInteractionBase+<>c__DisplayClass20_0\n",
+      "  - MyNotebookLib.WorkbookInteractionBase+<>c__DisplayClass22_0\n",
+      "  - MyNotebookLib.WorkbookInteractionBase+<>c__DisplayClass24_0\n",
+      "  - MyNotebookLib.WorkbookInteractionBase+<ExecuteWithExceptionHandling>d__23\n",
+      "  - MyNotebookLib.WorkbookInteractionBase+<FindAllIndex>d__21`1\n",
+      "  - MyNotebookLib.WorkbookInteractionBase+<InitializeExecutorIfNeeded>d__11\n",
+      "  - MyNotebookLib.WorkbookInteractionBase+<InitializePythonExecutor>d__12\n",
+      "  - MyNotebookLib.WorkbookInteractionBase+<LoadNotebookAsync>d__14\n",
+      "  - MyNotebookLib.WorkbookInteractionBase+<RunNotebook>d__24\n",
+      "  - MyNotebookLib.WorkbookInteractionBase+<RunNotebookAsync>d__22\n",
+      "  - MyNotebookLib.WorkbookInteractionBase+<UpdateCellAsync>d__20\n",
+      "  - MyNotebookLib.WorkbookUpdateInteraction+<>c__DisplayClass4_0\n",
+      "  - MyNotebookLib.WorkbookUpdateInteraction+<>c__DisplayClass5_0\n",
+      "  - MyNotebookLib.WorkbookUpdateInteraction+<>c__DisplayClass6_0\n",
+      "  - MyNotebookLib.WorkbookUpdateInteraction+<InsertInWorkbookCell>d__6\n",
+      "  - MyNotebookLib.WorkbookUpdateInteraction+<ReplaceBlockInWorkbookCell>d__5\n",
+      "  - MyNotebookLib.WorkbookUpdateInteraction+<ReplaceWorkbookCell>d__4\n",
+      "  - MyIA.AI.Notebooks.Program+<Main>d__2\n",
+      "  - MyIA.AI.Notebooks.Program+<TestNotebookUpdater>d__3\n",
+      "  - MyIA.AI.Notebooks.Config.Settings+<AskApiKey>d__9\n",
+      "  - MyIA.AI.Notebooks.Config.Settings+<AskAzureEndpoint>d__7\n",
+      "  - MyIA.AI.Notebooks.Config.Settings+<AskModel>d__8\n",
+      "  - MyIA.AI.Notebooks.Config.Settings+<AskOrg>d__10\n",
+      "  - <PrivateImplementationDetails>+__StaticArrayInitTypeSize=22\n",
+      "  - <PrivateImplementationDetails>+__StaticArrayInitTypeSize=24\n",
+      "  - MyNotebookLib.AutoGenNotebookUpdater+<>c__DisplayClass1_0+<<PerformNotebookUpdateAsync>b__0>d\n",
+      "  - MyNotebookLib.AutoGenNotebookUpdater+<>c__DisplayClass1_0+<<PerformNotebookUpdateAsync>b__1>d\n",
+      "  - MyNotebookLib.AutoGenNotebookUpdater+<>c__DisplayClass1_0+<<PerformNotebookUpdateAsync>b__2>d\n",
+      "  - MyNotebookLib.AutoGenNotebookUpdater+<>c__DisplayClass1_0+<<PerformNotebookUpdateAsync>b__3>d\n",
+      "  - MyNotebookLib.WorkbookInteractionBase+<>c__DisplayClass24_0+<<RunNotebook>b__0>d\n",
+      "  - MyNotebookLib.WorkbookUpdateInteraction+<>c__DisplayClass4_0+<<ReplaceWorkbookCell>b__0>d\n",
+      "  - MyNotebookLib.WorkbookUpdateInteraction+<>c__DisplayClass5_0+<<ReplaceBlockInWorkbookCell>b__0>d\n",
+      "  - MyNotebookLib.WorkbookUpdateInteraction+<>c__DisplayClass6_0+<<InsertInWorkbookCell>b__0>d\n",
       "✅ Classe importée: MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater\n",
       "   - Type: MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater\n",
       "   - Nom complet: MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater\n",
@@ -577,13 +684,15 @@
    "id": "46549ac6",
    "metadata": {},
    "source": [
-    "### Lecture du résultat — deux API de réflexion, deux pièges CLR\n",
+    "### Lecture du résultat — runtime .NET, réflexion et piège de namespace\n",
     "\n",
-    "Les deux cellules précédentes comparent `GetExportedTypes()` et `GetTypes()`, les deux API .NET pour énumérer les types d'un assembly. Leurs sorties divergent radicalement, et cette divergence est la leçon centrale de l'interop par réflexion.\n",
+    "Les cellules précédentes comparent `GetExportedTypes()` et `GetTypes()`, les deux API .NET pour énumérer les types d'un assembly. Sur le **CoreCLR** (le runtime que l'on vient de démarrer explicitement), les deux réussissent, et leur divergence illustre deux notions distinctes : la visibilité des types et la résolution des dépendances.\n",
     "\n",
-    "**`GetExportedTypes()` vs `GetTypes()`.** La première n'énumère que les types **publics** de l'assembly et retourne ici, proprement, 14 types. La seconde énumère **tous** les types (y compris internes et imbriqués) et, en tentant de résoudre chaque type référencé, bute sur une dépendance qu'elle ne peut charger : elle lève alors `ReflectionTypeLoadException`, dont la propriété `LoaderExceptions` est précisément le **diagnostic** — un tableau nommant, pour chaque type fautif, l'assembly manquant. La stack trace committée (`RuntimeModule.GetTypes` → `Assembly.GetTypes`) est la signature exacte de ce cas. **Quand `GetTypes` échoue, lire `.LoaderExceptions`** : c'est l'outil qui transforme une exception opaque en liste actionnable de dépendances manquantes.\n",
+    "**`GetExportedTypes()` vs `GetTypes()`.** La première n'énumère que les types **publics** (19 ici). La seconde énumère **tous** les types — y compris les types internes et les structures générées par le compilateur C# (`<>y__InlineArray5`1`, `<>z__ReadOnlyArray`1`, etc.), d'où un compte plus élevé (84). C'est la même distinction qu'entre `dir()` et `[x for x in dir() if not x.startswith('_')]` en Python : on filtre le bruit interne.\n",
     "\n",
-    "**Le piège assembly ≠ namespace — désormais corrigé.** La cause de l'échec d'import observé précédemment (`AutoInvokeSKAgentsNotebookUpdater = None`) n'était pas le `LoaderException` ci-dessus (attrapé par le `try/except`, l'exécution continue). Elle venait des noms testés par `GetType` : `MyIA.AI.Notebooks.*` et `AutoInvokeSKAgentsNotebookUpdater`. Or la sortie de `GetExportedTypes` montre que les types vivent dans le namespace **`MyNotebookLib`** (`MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater`, etc.). `Assembly.GetType(nom)` fait une recherche **exacte** sur le nom complet : un seul segment diffère, et elle retourne `None` **sans lever d'exception** — silencieusement. C'est le piège rappelé en tête de bloc : **le nom de l'assembly** (`MyIA.AI.Notebooks`) **n'est pas le namespace C#** (`MyNotebookLib`). La cellule précédente teste désormais le bon nom complet (`MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater` en tête de liste) : `GetType` trouve le type, l'import réussit (« 🎉 IMPORT .NET RÉUSSI ») et la classe est prête à être instanciée. Les trois variantes historiquement fausses sont conservées commentées dans le code, pour rendre le piège visible et reproductible."
+    "**Pourquoi le runtime compte — la vraie raison du `pythonnet.load(\"coreclr\", …)` de la cellule précédente.** pythonnet 3.x boote **par défaut** le CLR du .NET Framework, un vieux runtime incapable de résoudre les types modernes (`System.ValueTuple\\`5`) qu'un assembly **net9.0** utilise abondamment dans `NotebookUpdaterBase.InitSemanticKernel()`. Sur ce runtime par défaut, `GetTypes()` lève une `ReflectionTypeLoadException` (dont la propriété `LoaderExceptions` liste les dépendances manquantes) et l'instanciation échoue avec une `TypeLoadException` opaque. En démarrant le **CoreCLR (.NET 9)** via `pythonnet.load(\"coreclr\", runtime_config=…)`, on fournit le runtime capable de résoudre `ValueTuple\\`5` et toutes les dépendances : `GetTypes()` réussit proprement et l'instanciation passe. **Quand on interopère avec un assembly .NET moderne, sélectionner le bon runtime dès le départ** (`DOTNET_ROLL_FORWARD=Major` + CoreCLR) est la correction racine, pas un contournement.\n",
+    "\n",
+    "**Le piège assembly ≠ namespace (corrigé).** Indépendant du runtime : la cause de l'échec d'import observé initialement (`AutoInvokeSKAgentsNotebookUpdater = None`) venait des noms testés par `GetType` — `MyIA.AI.Notebooks.*` et `AutoInvokeSKAgentsNotebookUpdater`. Or les types vivent dans le namespace **`MyNotebookLib`** (`MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater`, visible dans `GetExportedTypes`). `Assembly.GetType(nom)` fait une recherche **exacte** sur le nom complet : un seul segment diffère, et elle retourne `None` **sans lever d'exception** — silencieusement. C'est le piège rappelé en tête de bloc : **le nom de l'assembly** (`MyIA.AI.Notebooks`) **n'est pas le namespace C#** (`MyNotebookLib`). La cellule précédente teste le bon nom complet ; les trois variantes historiquement fausses sont conservées commentées pour rendre le piège reproductible."
    ]
   },
   {
@@ -610,10 +719,10 @@
    "id": "b895a913",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T19:41:51.048442Z",
-     "iopub.status.busy": "2026-08-07T19:41:51.048442Z",
-     "iopub.status.idle": "2026-08-07T19:41:51.055728Z",
-     "shell.execute_reply": "2026-08-07T19:41:51.054713Z"
+     "iopub.execute_input": "2026-08-07T21:06:50.522345Z",
+     "iopub.status.busy": "2026-08-07T21:06:50.522345Z",
+     "iopub.status.idle": "2026-08-07T21:06:50.527080Z",
+     "shell.execute_reply": "2026-08-07T21:06:50.526031Z"
     }
    },
    "outputs": [
@@ -676,10 +785,10 @@
    "id": "5065d5f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T19:41:51.060731Z",
-     "iopub.status.busy": "2026-08-07T19:41:51.059729Z",
-     "iopub.status.idle": "2026-08-07T19:41:51.106182Z",
-     "shell.execute_reply": "2026-08-07T19:41:51.104777Z"
+     "iopub.execute_input": "2026-08-07T21:06:50.531170Z",
+     "iopub.status.busy": "2026-08-07T21:06:50.529638Z",
+     "iopub.status.idle": "2026-08-07T21:06:50.583424Z",
+     "shell.execute_reply": "2026-08-07T21:06:50.582410Z"
     },
     "papermill": {
      "duration": 0.01561,
@@ -695,19 +804,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ Erreur lors de l'exécution de l'agent : Une exception a été levée par la cible d'un appel. ---> System.TypeLoadException: Impossible de charger le type 'System.ValueTuple`5' à partir de l'assembly 'System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.\r\n",
-      "   à MyNotebookLib.NotebookUpdaterBase.InitSemanticKernel()\r\n",
-      "   à MyNotebookLib.NotebookUpdaterBase..ctor(String notebookPath, ILogger logger)\r\n",
-      "   --- Fin de la trace de la pile d'exception interne ---\r\n",
-      "   à System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)\r\n",
-      "   à System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)\r\n",
-      "   à System.RuntimeType.CreateInstanceImpl(BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes, StackCrawlMark& stackMark)\r\n",
-      "   à System.Activator.CreateInstance(Type type, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes)\r\n",
-      "   à System.Activator.CreateInstance(Type type, Object[] args)\n",
-      "   Note : la classe est bien importée (cellule précédente).\n",
-      "   L'instanciation et l'exécution complète de l'agent nécessitent\n",
-      "   pythonnet configuré en mode CoreCLR (runtime .NET 9) ainsi qu'une\n",
-      "   clé OpenAI valide — voir l'issue de suivi du notebook.\n"
+      "❌ Erreur lors de l'exécution de l'agent : Exception has been thrown by the target of an invocation.\r\n",
+      " ---> System.Exception: Configuration not found, please setup the notebooks first using notebook 0-AI-settings.pynb\r\n",
+      "   at MyIA.AI.Notebooks.Config.Settings.LoadFromFile(String configFile) in C:\\dev\\CoursIA-sk9-clr-fix\\MyIA.AI.Notebooks\\Config\\Settings.cs:line 135\r\n",
+      "   at MyNotebookLib.NotebookUpdaterBase.InitSemanticKernel() in C:\\dev\\CoursIA-sk9-clr-fix\\MyIA.AI.Notebooks\\GenAI\\SemanticKernel\\NotebookUpdaterBase.cs:line 175\r\n",
+      "   at MyNotebookLib.NotebookUpdaterBase..ctor(String notebookPath, ILogger logger) in C:\\dev\\CoursIA-sk9-clr-fix\\MyIA.AI.Notebooks\\GenAI\\SemanticKernel\\NotebookUpdaterBase.cs:line 166\r\n",
+      "   at MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater..ctor(String notebookPath, ILogger logger) in C:\\dev\\CoursIA-sk9-clr-fix\\MyIA.AI.Notebooks\\GenAI\\SemanticKernel\\AutoInvokeSKAgentsNotebookUpdater.cs:line 13\r\n",
+      "   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Constructor(Object obj, IntPtr* args)\r\n",
+      "   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)\r\n",
+      "   --- End of inner exception stack trace ---\r\n",
+      "   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)\r\n",
+      "   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)\r\n",
+      "   at System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)\r\n",
+      "   at System.RuntimeType.CreateInstanceImpl(BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture)\r\n",
+      "   at System.Activator.CreateInstance(Type type, Object[] args)\r\n",
+      "   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)\r\n",
+      "   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)\n",
+      "   Note : la classe est bien importée et instanciable sur le\n",
+      "   runtime CoreCLR. L'erreur résiduelle est la configuration du\n",
+      "   backend IA : créez `config/settings.json` (modèle :\n",
+      "   Config/settings.json.openai-example) avec une clé OpenAI\n",
+      "   valide, via le notebook 0-AI-settings.ipynb.\n"
      ]
     }
    ],
@@ -757,11 +874,17 @@
     "        print(\"🎉 Agent SK terminé avec succès !\")\n",
     "        \n",
     "    except Exception as e:\n",
+    "        # À ce stade le runtime (CoreCLR) et la classe sont corrects : la classe\n",
+    "        # est importée ET instanciable (Activator.CreateInstance atteint le\n",
+    "        # constructeur). L'erreur résiduelle vient de la configuration du backend\n",
+    "        # IA : Settings.LoadFromFile cherche `config/settings.json` (clé OpenAI /\n",
+    "        # Azure), fichier à générer via le notebook de setup 0-AI-settings.ipynb.\n",
     "        print(f\"❌ Erreur lors de l'exécution de l'agent : {e}\")\n",
-    "        print(\"   Note : la classe est bien importée (cellule précédente).\")\n",
-    "        print(\"   L'instanciation et l'exécution complète de l'agent nécessitent\")\n",
-    "        print(\"   pythonnet configuré en mode CoreCLR (runtime .NET 9) ainsi qu'une\")\n",
-    "        print(\"   clé OpenAI valide — voir l'issue de suivi du notebook.\")\n",
+    "        print(\"   Note : la classe est bien importée et instanciable sur le\")\n",
+    "        print(\"   runtime CoreCLR. L'erreur résiduelle est la configuration du\")\n",
+    "        print(\"   backend IA : créez `config/settings.json` (modèle :\")\n",
+    "        print(\"   Config/settings.json.openai-example) avec une clé OpenAI\")\n",
+    "        print(\"   valide, via le notebook 0-AI-settings.ipynb.\")\n",
     "\n",
     "# Lancement\n",
     "if AutoInvokeSKAgentsNotebookUpdater is not None:\n",
@@ -817,10 +940,10 @@
    "id": "1ca195b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T19:41:51.111715Z",
-     "iopub.status.busy": "2026-08-07T19:41:51.110714Z",
-     "iopub.status.idle": "2026-08-07T19:41:51.116634Z",
-     "shell.execute_reply": "2026-08-07T19:41:51.115621Z"
+     "iopub.execute_input": "2026-08-07T21:06:50.587424Z",
+     "iopub.status.busy": "2026-08-07T21:06:50.587424Z",
+     "iopub.status.idle": "2026-08-07T21:06:50.594835Z",
+     "shell.execute_reply": "2026-08-07T21:06:50.593610Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
## What

Configures the correct .NET runtime (CoreCLR / .NET 9) for the `09-Building-CLR` pythonnet interop, resolving the `ValueTuple\`5` TypeLoadException that blocked agent instantiation in #9929. **Stacked on #9928** — base is `fix/sk9-09-building-clr-agent-9922`; GitHub auto-retargets to `main` when #9928 merges.

## The root problem (vs #9928)

#9928 fixed the namespace bug (assembly `MyIA.AI.Notebooks` != C# namespace `MyNotebookLib`) and restored the assembly build. But cell[17] instantiation still failed with an opaque `TypeLoadException: System.ValueTuple\`5 from System.Runtime v4.0.0.0`. Root cause: **pythonnet 3.x boots the .NET Framework CLR by default**, which cannot resolve the modern `ValueTuple\`5` types that a **net9.0** assembly uses in `NotebookUpdaterBase.InitSemanticKernel()`. No cell-code change can fix a runtime mismatch.

## The fix (Regle F / sota Prong A — configure the correct runtime)

**cell[8]** now selects the **CoreCLR (.NET 9)** before `import clr`:
```python
import pythonnet
os.environ["DOTNET_ROLL_FORWARD"] = "Major"   # machine has 10.0 runtime; assembly targets net9.0
pythonnet.load("coreclr", runtime_config=os.path.join(dll_path, "MyIA.AI.Notebooks.runtimeconfig.json"))
import clr  # must come AFTER pythonnet.load
```
`DOTNET_ROLL_FORWARD=Major` lets the installed 10.0 runtime execute the net9.0 assembly. The `runtimeconfig.json` is the build artifact produced by `dotnet build`.

**cell[13]** interpretation rewritten: the `GetExportedTypes`-vs-`GetTypes` lesson evolves from "read LoaderExceptions when GetTypes throws" (obsolete on CoreCLR — GetTypes succeeds) to "**runtime selection matters**: CoreCLR resolves deps the .NET Framework default cannot". The assembly != namespace lesson (from #9928) is preserved.

**cell[17]** error message updated: now reflects that runtime + class are correct, with only the backend config (config/settings.json + OpenAI key) remaining.

## Verification (real re-exec on CoreCLR, H.3 PASS)

Re-executed end-to-end in-place (`nbconvert --execute`, exit 0, **0 anomalies** — no null execution_count, no uncaught error):

| cell | before (#9928) | after (this PR, CoreCLR) |
|------|----------------|--------------------------|
| cell[8] | `import clr` (default .NET Framework CLR) | `pythonnet.load("coreclr", ...)` → "Runtime CoreCLR demarre" |
| cell[11] GetExportedTypes | 14 types (.NET Framework) | **19 types** (CoreCLR resolves more) |
| cell[12] GetTypes | ReflectionTypeLoadException + namespace fix | **84 types, NO LoaderException** (CoreCLR resolves all deps) |
| cell[17] CreateInstance | `TypeLoadException ValueTuple\`5` (opaque) | reaches ctor → `Configuration not found: config/settings.json` (clear, RECOVERABLE-USER-HAND) |

H.3 pre-commit: PASS (10 code cells, 0 anomalies).

## Residual — RECOVERABLE-USER-HAND (still #9929 criterion #2/#3)

Full agent `UpdateNotebookAsync()` run needs `config/settings.json` (gitignored, secrets) with a valid OpenAI key. The template is `Config/settings.json.openai-example`; `Settings.LoadFromFile` looks for `config/settings.json`. Without it, cell[17] fails cleanly at the ctor (not an opaque runtime crash) — the only remaining blocker. The CoreCLR runtime + instantiation now work end-to-end; only the backend config (user action) remains.

Hence **`See #9929`** (partial): the runtime mismatch (point 1) is resolved; criterion #2 (agent runs end-to-end) and #3 (0 error) remain gated on the user-provided OpenAI key/config. This PR closes point 1 of #9929.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
