### PR TITLE
docs(pymc,#4588): fix Infer-8 -> Infer-10 citation in PyMC-10 cell[12]

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Model-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Model-Selection.ipynb
@@ -739,7 +739,7 @@
     "Maintenant, testons avec des données bimodales. Le modèle a 2 gaussiennes devrait\n",
     "nettement preferer car les données proviennent effectivement de 2 distributions.\n",
     "\n",
-    "Cela correspond a l'exemple Infer-8 ou :\n",
+    "Cela correspond a l'exemple Infer-10 ou :\n",
     "- 1 composante : log evidence = -45.89\n",
     "- 2 composantes : log evidence = -31.35\n",
     "- Différence : 14.54 (decisif pour 2 composantes)"

--- a/scripts/notebook_tools/twin_pairs.d/probas-10-model-selection.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-10-model-selection.yaml
@@ -8,6 +8,11 @@
       by: myia-po-2023:CoursIA
       python_sha: 4aef3828fcb8976eabcfbc56000d50487dc619e2
       csharp_sha: 00c3d935ea7b4573c2a3dd6950bf955a39fe793c
+    - date: "2026-08-07"
+      by: myia-po-2025:CoursIA
+      python_sha: 4481dfa722eff68e157a8beaf4287ad3bf1bd1c4
+      csharp_sha: 00c3d935ea7b4573c2a3dd6950bf955a39fe793c
+      note: "Rebaseline apres correctif markdown cell[12] (citation croisee Infer-8 -> Infer-10 : les valeurs d'evidence -45.89/-31.35/14.54 proviennent d'Infer-10-Model-Selection, pas d'Infer-8=TrueSkill). Infer-10 est par ailleurs le jumeau C# declare de PyMC-10. Parite semantic preservee : markdown-only, 0 cellule code modifiee, cote C# inchange."
   known_differences:
   - 'Socle pedagogique commun : selection de modele (WAIC/LOO, evidence) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-dotnet (#9934)

## Ce que fait cette PR

**Correctif markdown-only d'une citation croisée cassée** dans PyMC-10-Model-Selection.ipynb (cell[12]) : la cellule renvoyait à **« l'exemple Infer-8 »** pour les valeurs d'evidence de la sélection bimodale (1 composante = −45.89, 2 composantes = −31.35, delta décisif 14.54). Or **Infer-8 = TrueSkill** (un système de classement) — ces nombres d'evidence **n'apparaissent nulle part** dans Infer-8. La source réelle est **Infer-10-Model-Selection**.

**Le double tort** : Infer-10 est en outre le **jumeau C# déclaré** de PyMC-10 (`probas-10-model-selection.yaml`). La citation devait pointer vers son propre jumeau, pas vers TrueSkill. Un étudiant suivant le renvoi ouvrait le mauvais notebook.

Genre **distinct** de la PR plancher du cycle (#9934, MED/notebook-dotnet : correctif de dérivation Infer-4) : celle-ci est **LIGHT/notebook-python**, une citation croisée, trouvée via l'audit PyMC (sonnet scan + vérification firsthand). Les **nombres eux-mêmes sont corrects** (vérifiés firsthand contre les outputs committés d'Infer-10) — seul le **cible du renvoi** était fausse.

## La correction (grounded firsthand)

**Infer-10-Model-Selection** (source canonique, vérifiée par grep + lecture) :
- cell code output : `1 composante : log evidence = -45,89`
- cell code output : `2 composantes : log evidence = -31,35`
- table markdown de synthèse : `| 1 composante | -45.89 | Mal adapté ... | | 2 composantes | -31.35 | Bien adapté ... |`
- verdict : modèle 2 composantes préféré.

**PyMC-10 cell[12]** (avant) : `Cela correspond a l'exemple Infer-8 ou :` (+ les 3 nombres).
**PyMC-10 cell[12]** (après) : `Cela correspond a l'exemple Infer-10 ou :` (+ les 3 nombres inchangés).

## Preuves

- **Diff chirurgical** : `git diff --shortstat` = **1 file (notebook), 1 insertion(+), 1 deletion(-)**, **1 seule ligne** (`@@ -739,7 +739,7 @@`). + twin yaml 5 lignes (rebaseline).
- **C.3 (markdown-only, dur)** : **0 cellule code source/output/execution_count modifiée** (vérifié par comparaison parsed cell-by-cell). Seul cell[12] (markdown) diffère.
- **C.1** : markdown-only, 0 erreur volontaire.
- **nbformat valide** (`nbformat.validate`).
- **Méthode d'édition** : **substitution byte-level textuelle** d'une chaîne unique (`l'exemple Infer-8 ou` → `l'exemple Infer-10 ou`) à l'intérieur de la source de cell[12]. Le notebook n'est pas json-round-tripé : tous les autres bytes préservés, fins de ligne LF préservées (CRLF count = 0).
- **Unicité vérifiée** : `grep -c "l'exemple Infer-8"` = 1 dans tout le fichier PyMC-10 (aucune autre occurrence légitime d'Infer-8 à préserver).
- **Twin registre** : `probas-10-model-selection.yaml` lu firsthand — PyMC-10 ↔ Infer-10 parité semantic. Rebaseline `python_sha` (4aef3828 → 4481dfa7, **git blob hash** via `git hash-object`), csharp inchange (00c3d935). Validé : `audits[-1].python_sha == git hash-object PyMC-10` ET `audits[-1].csharp_sha == git hash-object Infer-10` (les deux MATCH). La nuance « citation pointait vers le mauvais jumeau » est un bug markdown C#-side-irrelevant (les deux notebooks restent sémantiquement parallèles).
- **G.9** : j'ai corrigé une erreur de méthode en cours de route. J'ai d'abord calculé le SHA via `hashlib.sha1(content)` (raw content hash) — méthode FAUSSE. Le checker twin utilise le **git blob hash** (`sha1("blob <size>\0<content>")`). Re-computé via `git hash-object` : la baseline existante (po-2023, 2026-08-04) était correcte (pas stale). Le SHA Infer-4 de #9934 a aussi été vérifié via cette méthode (match confirme la correction).

## Contexte honnete (variation-protocol)

Ceci est un grain **LIGHT** (citation croisée, markdown-only). Le litmus « pourrais-je en générer une douzaine en scannant l'instance suivante ? » s'applique partiellement (les checks de cross-reference sont mécanisables), bien que celle-ci ait exigé l'audit + la vérification cross-notebook pour être révélée. **La PR plancher du cycle est #9934 (MED)** : celle-ci est un grain **secondaire** qui **clôt la boucle de l'audit** (R7 : un scan qui trouve un défaut doit le fixer, pas juste le signaler). Cap G-VAR-2 (1 LIGHT/lane/jour) : c'est ma 1re LIGHT du jour. G-VAR-3 : genre précédent = MED/notebook-dotnet → pas 2× même genre LIGHT.

See #4588 (EPIC fiabilité des notebooks) / See #8081.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
