### PR TITLE
fix(leaks-scanner): capture sub-numbered exercises (8.1/8.2/8.3) as distinct, not duplicate

### DIFF
--- a/scripts/notebook_tools/detect_solution_leaks.py
+++ b/scripts/notebook_tools/detect_solution_leaks.py
@@ -48,7 +48,7 @@ STUB_PATTERNS = [
 ]
 
 EXERCISE_HEADER_RE = re.compile(
-    r'^#+\s*(?:\d+[.:]\s*)?(?:Exercice|Exercise)\s*(\d*)\s*[:.]?\s*(.*)',
+    r'^#+\s*(?:\d+[.:]\s*)?(?:Exercice|Exercise)\s*(\d*(?:\.\d+)*)\s*[:.]?\s*(.*)',
     re.MULTILINE | re.IGNORECASE,
 )
 

--- a/scripts/notebook_tools/tests/test_detect_solution_leaks.py
+++ b/scripts/notebook_tools/tests/test_detect_solution_leaks.py
@@ -213,6 +213,28 @@ class TestExerciseHeaderRe:
         assert m is not None
         assert m.group(1) == "5"
 
+    def test_subnumbered_exercice_captures_full_dotted(self):
+        # Regression: "Exercice 8.1" must capture "8.1" (not just "8"), so
+        # sub-numbered exercises (8.1 / 8.2 / 8.3) are distinct and not
+        # reported as duplicate "Exercice 8" findings. Real-world case:
+        # Planners-2-PDDL-Basics cells (Exercice 8.1/8.2/8.3).
+        m = EXERCISE_HEADER_RE.search("### Exercice 8.1 : Gripper a 3 balles")
+        assert m is not None
+        assert m.group(1) == "8.1"
+
+    def test_plain_number_unchanged_under_dotted_fix(self):
+        # Recall guard: a plain "Exercice 8" still captures "8" (the dotted
+        # fix must not alter single-number matching).
+        m = EXERCISE_HEADER_RE.search("### Exercice 8 : Foo")
+        assert m is not None
+        assert m.group(1) == "8"
+
+    def test_deeply_subnumbered(self):
+        # Multi-level sub-numbering (9.2.1) is captured in full.
+        m = EXERCISE_HEADER_RE.search("### Exercice 9.2.1 : Foo")
+        assert m is not None
+        assert m.group(1) == "9.2.1"
+
 
 # ---------------------------------------------------------------------------
 # SOUMIS_PAR_RE
@@ -290,6 +312,37 @@ class TestScanNotebook:
             _md("## Exercice 1 : First"),
             _code("pass"),
             _md("## Exercice 1 : Second"),
+            _code("pass"),
+        ])
+        findings = scan_notebook(str(nb_path))
+        assert any(f["severity"] == "MEDIUM" for f in findings)
+
+    def test_subnumbered_exercises_not_duplicates(self, tmp_path):
+        # Regression: sub-numbered exercises (8.1 / 8.2 / 8.3) are DISTINCT
+        # progressive exercises, not duplicates of "Exercice 8". Before the
+        # dotted-number fix, all three captured num="8" and the scanner
+        # reported 2 spurious MEDIUM "Duplicate Exercice 8" findings.
+        # Real-world case: Planners-2-PDDL-Basics (8.1/8.2/8.3) and
+        # Planners-2 Python (9.1/9.2/9.3).
+        nb_path = _write_nb(tmp_path / "subnum.ipynb", [
+            _md("### Exercice 8.1 : Gripper a 3 balles"),
+            _code("pass"),
+            _md("### Exercice 8.2 : Robot-Cuisine"),
+            _code("pass"),
+            _md("### Exercice 8.3 : Logistics fly"),
+            _code("pass"),
+        ])
+        findings = scan_notebook(str(nb_path))
+        assert not any(f["severity"] == "MEDIUM" for f in findings)
+
+    def test_identical_subnumber_still_duplicate(self, tmp_path):
+        # Recall guard: two cells with the SAME full dotted number (e.g. two
+        # "Exercice 8.1") are still a genuine duplicate — the dotted fix only
+        # stops flagging DIFFERENT sub-numbers, never identical ones.
+        nb_path = _write_nb(tmp_path / "dupsub.ipynb", [
+            _md("### Exercice 8.1 : First"),
+            _code("pass"),
+            _md("### Exercice 8.1 : Second"),
             _code("pass"),
         ])
         findings = scan_notebook(str(nb_path))


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: LIGHT/coordination c.9872+15

# Fix : le scanner de solution-leaks confondait "Exercice 8.1/8.2/8.3" avec des doublons de "Exercice 8"

Quoi: `EXERCISE_HEADER_RE` ne capturait que le premier chiffre (`\d*`), donc les exercices sous-numérotés "Exercice 8.1", "8.2", "8.3" collapseaient tous vers `num="8"` et étaient rapportés comme des faux MEDIUM "Duplicate Exercice 8". Cas réels : Planners-2-PDDL-Basics (8.1/8.2/8.3 C# + 9.1/9.2/9.3 Python). Fix : `\d*` → `\d*(?:\.\d+)*` capture l'identifiant pointé complet.

Preuve:
- Baseline repo-wide MEDIUM "Duplicate" : **31 → 27** (-4 FPs sous-numérotés éliminés).
- E2E sur le cas initial `Planners-2-PDDL-Basics-Csharp.ipynb` : pré-fixe 2 MEDIUM "Duplicate Exercice 8" → post-fixe **0 HIGH, 0 MEDIUM, 0 errors**.
- Test suite `test_detect_solution_leaks.py` : **112 passed** (5 nouveaux tests + 0 régression).
- Le fix est **precision-only** (zéro recall loss) : deux numéros pointés *différents* (8.1 vs 8.2) ne sont plus flaggés ; deux numéros pointés *identiques* (deux "Exercice 8.1") le restent (recall guard `test_identical_subnumber_still_duplicate`). Comportement empty/unnumberé inchangé (`\d*` matche toujours vide).

Périmètre: 2 fichiers, +54/-1. `detect_solution_leaks.py` (1 regex, ligne 38) + 5 tests de régression dans `test_detect_solution_leaks.py` (3 regex-level dotted capture + 2 integration avec recall guards). Scanner référencé en CI (`notebook-validation.yml`). Aucun notebook touché, aucun catalogue touché (byte-identique à main).

## Les 27 MEDIUM restants (HORS scope, problème séparé)

Ce sont le pattern "two-sections" : un notebook avec DEUX sections d'exercices légitimes (ex Lean-6 "Exercices — corrigés" + "Exercices à compléter") qui renumérotent indépendamment "Exercice 1/2/3" chacune. Le scanner ne peut pas distinguer cela d'un vrai doublon sans analyse structurelle plus profonde. C'est un FP distinct (renumérotation légitime entre sections), plus difficile, délibérément hors scope de ce fix focalisé.

See #9858 (side-finding #2 de l'audit des invariants panne-window — j'ai vérifié firsthand que les ~20 "Duplicate Exercice" rapportés par ce scanner étaient des FPs : sous-numérotation pour Planners-2/Z3-06, two-sections pour Lean-6/App-15/Search-7/QC-Py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
