### PR TITLE
fix(csp5,#8052): resolve conflicts-cell KeyError (stale index 7 -> 4) [stacked on #9932]

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
@@ -1987,9 +1987,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Bin packing sans conflits : None bins\n",
-      "Bin packing avec conflits : None bins (conflits=[(0, 2), (3, 7), (1, 4)])\n",
-      "Tous les conflits sont respectes.\n"
+      "Bin packing sans conflits : 2 bins\n",
+      "Bin packing avec conflits : 3 bins (conflits=[(0, 2), (3, 4), (1, 4)])\n",
+      "  Bin 0 (10/10) : objets [0, 1, 5] tailles [2, 2, 6]\n",
+      "  Bin 1 (7/10) : objets [2, 4] tailles [2, 5]\n",
+      "  Bin 2 (3/10) : objets [3] tailles [3]\n"
      ]
     }
    ],
@@ -2044,8 +2046,8 @@
     "    return {\"num_bins\": None, \"bins\": {}, \"status\": \"INFEASIBLE\"}\n",
     "\n",
     "\n",
-    "# Avec conflits : (0, 2), (3, 7) ne peuvent pas etre ensemble\n",
-    "conflicts = [(0, 2), (3, 7), (1, 4)]\n",
+    "# Avec conflits : (0, 2), (3, 4) ne peuvent pas etre ensemble\n",
+    "conflicts = [(0, 2), (3, 4), (1, 4)]\n",
     "res_base  = solve_bin_packing_cp(items, capacity)\n",
     "res_conf  = solve_bin_packing_conflicts(items, capacity, conflicts)\n",
     "print(f\"Bin packing sans conflits : {res_base['num_bins']} bins\")\n",

--- a/scripts/notebook_tools/twin_pairs.d/csp-5-optimization.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-5-optimization.yaml
@@ -14,6 +14,12 @@
       csharp_sha: cd0d73e8fee0fe5c17b2a5df10554a32f2d9498e
       content_python_sha: 6563b2715a604c74b61ec57af8eea6f1c85324dcb5e8a36d5f96add0b913b8a4
       content_csharp_sha: 842524dae2c561df22a19efde82c8fcd0583b66367fec5ede557160eb2dc019d
+    - date: "2026-08-07"
+      by: myia-po-2024:CoursIA
+      python_sha: d27169c3774d2a6a4bb35623f899e8471a7fec49
+      csharp_sha: cd0d73e8fee0fe5c17b2a5df10554a32f2d9498e
+      content_python_sha: 73ea8ab67732803ec72eeed8eb2e0183eb48c5e48d6be6bdf062fd406e250be6
+      content_csharp_sha: 842524dae2c561df22a19efde82c8fcd0583b66367fec5ede557160eb2dc019d
   known_differences:
     - "Socle pedagogique commun (parity semantic) : les deux cotes couvrent les 4 problemes classiques d'optimisation combinatoire -- Bin Packing (BPP), Knapsack 0/1, Cutting Stock, Optimisation de Portefeuille -- avec la meme progression pedagogique (formulation variables/constraints/objectif -> exemple resolu -> interpretation). Meme theorie sous-jacente (minimisation bins, maximisation valeur sous capacite, patterns de coupe optimaux, allocation lineaire sous contraintes de risque)."
     - "Idiomes framework : Python = **OR-Tools CP-SAT** (`ortools.sat.python.cp_model`) + `numpy` + `matplotlib` (visualisation du bin packing, benchmark de passage a l'echelle). C# = **Choco-solver via IKVM** (`org.chocosolver.solver.dll`, recette #4711) sur runtime .NET -- le solveur Java est invoque depuis C# via l'assembleur IKVM."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/guard #9935

## Quoi / Preuve

**Correctness bugfix** `CSP-5-Optimization.ipynb` cellule `f827a0561e2b` (Bin Packing avec conflits) — la cellule levait un **KeyError** à l'exécution (`x[(7, j)]` pour un dict dont les clés vont de 0 à 5). La source était cassée : `conflicts = [(0, 2), (3, 7), (1, 4)]` référence l'index **7**, mais `items = [2, 2, 2, 3, 5, 6]` n'a que 6 éléments (indices valides 0-5).

**Même cause racine que #9932** : le vecteur `items` fut restructuré (optimal passé de 5 à 2 bins, cf le thread FFD), mais la cellule dépendante (qui référence des indices dans `items`) ne fut pas mise à jour. Le pattern [[stale-output-cell-re-derives-after-upstream-restructure]] se manifeste ici sous forme d'un **KeyError source** (indices périmés), pas seulement d'une sortie stale.

### Preuve (firsthand, G.1)

1. **KeyError reproduit** : `solve_bin_packing_conflicts(items, capacity, [(0,2),(3,7),(1,4)])` → `KeyError: (7, 0)` — l'index 7 n'existe pas dans le dict `x` (n=6).
2. **Sortie committée doublement stale** : la sortie montrait `None bins` (les deux cas) + `Tous les conflits sont respectes.` — un message d'une **version antérieure** de la source (la source actuelle a une boucle `for bid, it in res_conf["bins"].items()` imprimant les détails des bins, pas ce message). La sortie ne correspondait même plus à la source courante.
3. **Fix minimal faithful** : `(3, 7)` → `(3, 4)`. Conserve les paires originales `(0, 2)` + `(1, 4)` ; seul l'index invalide change. Index 4 est valide. **Résultat vérifié firsthand (CP-SAT OPTIMAL)** : les conflits forcent 2→3 bins (démonstration pédagogique significative — c'est tout l'intérêt de l'exemple de contrainte de conflit). Charges : Bin0=[2,2,6]=10, Bin1=[2,5]=7, Bin2=[3]=3, total 20.

## Diagnostic dérive (C.4 obligatoire, #8364)

**Cause** : **(d)** régression dépendance — le vecteur amont `items` fut restructuré (5→6 éléments, optimal 5→2 bins) sans mettre à jour la cellule dépendante qui référence des indices dans `items`. Le KeyError source en est la manifestation (la sortie avait déjà dérivé vers « None bins » + un message obsolète d'une source antérieure).

**Verdict** : `CAUSE_FIXED` — la source est corrigée (index valide) ET la sortie vient d'une **re-exécution réelle** du code exact de la cellule (chaîne de dépendances amont fidèle : `solve_bin_packing_cp` + `items` + `capacity`), pas d'un byte-surgical markdown-align. La sortie transplantée est byte-identique au run CP-SAT.

**Diff chirurgical** : 7 insertions / 5 deletions (2 lignes source : commentaire + `conflicts` ; 5 lignes sortie réelle remplaçant 3 lignes stale). Fichier json-round-trip-faithful (`ensure_ascii=False`, indent=1) — pas de churn. Validation : 0 cellules avec erreur, 0 cellules null-exec (H.3 PASS).

## Périmètre

- **1 cellule** (`f827a0561e2b`, index 43) : source `(3,7)→(3,4)` (commentaire + ligne `conflicts`) + sortie transplantée (re-exec réelle).
- Twin « CSP-5 Optimization » rebaselined (`--update` après commit, `drift_introduced=0`).
- **Stacked sur #9932** (même fichier CSP-5 + même twin yaml → séquentiel). Base = `fix/csp5-ffd-stale-output-8052` ; GitHub auto-retarget vers `main` au merge de #9932.

## Variété R6

notebook-python après guard #9935 → genre distinct (G-VAR-3 OK). Bugfix correctness (KeyError source) ≠ guard CI (rotation nette). Substance : bug d'exactitude réel (la cellule ne s'exécutait pas du tout), fix groundé firsthand (re-run + vérification arithmétique des charges).

See #8052 (EPIC claims↔outputs), #9932 (FFD stale output, même fichier), #3801 (registre SOTA), [[stale-output-cell-re-derives-after-upstream-restructure]] (bug pattern).
