### PR TITLE
fix(ci,#9888): move continue-on-error onto the job — root key caused a startup_failure on main

### DIFF
--- a/.github/workflows/hooks-parity.yml
+++ b/.github/workflows/hooks-parity.yml
@@ -22,13 +22,15 @@ on:
       - "scripts/check_hooks_parity.py"
       - "scripts/setup_hooks.py"
 
-# Advisory: surfaces the warning without breaking the rest of the CI run.
-continue-on-error: true
-
 jobs:
   parity:
     name: parity gate
     runs-on: ubuntu-latest
+    # Advisory: surfaces the warning without breaking the rest of the CI run.
+    # `continue-on-error` is only valid on a job or a step -- at the workflow
+    # root it is an unknown key, which Actions rejects with a startup_failure
+    # (0 jobs created, no log to read). See the PR body for the diagnosis.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-ai-01:CoursIA — prev: LIGHT/test #9927

## Constat

`main` est rouge sur `hooks-parity` depuis `8b3b26cca`. Le symptôme est atypique : la run conclut `failure` mais **`total_count: 0` job créé**, aucun log à lire, et `gh run list` rapporte le *chemin* `.github/workflows/hooks-parity.yml` au lieu du `name: hooks-parity` parsé.

Cette combinaison est la signature d'un **`startup_failure`** — Actions a rejeté le fichier au niveau du schéma, avant d'instancier le moindre job. Ce n'est pas un test qui échoue.

## Cause racine

Le fichier portait `continue-on-error: true` **à la racine du workflow** (ligne 26). Cette clé n'est valide que sur un **job** ou une **step** : à la racine c'est une clé inconnue, et Actions refuse le fichier entier.

Le YAML, lui, est syntaxiquement valide — `yaml.safe_load` passe sans broncher. C'est pourquoi le défaut est invisible à toute vérification locale qui se contente de parser : seul le **schéma Actions** le rejette.

## Pourquoi maintenant, et pourquoi ce n'était pas une collision de merge

La clé a été introduite par #9903, et elle est restée **dormante** : le workflow ne se déclenche sur `push` que si l'un de ses quatre paths change. Depuis #9903, exactement deux commits en ont touché un — #9908 puis #9920. Merger #9920 dans la passe de merge de ce cycle est donc ce qui l'a **réveillée**, pas ce qui l'a causée.

Je le note explicitement parce que l'hypothèse par défaut sur un `main` rouge après une cascade de merges est la collision sémantique (deux PRs vertes isolément, rouges combinées). Ici ce n'est pas le cas : c'est un workflow invalide atteint pour la première fois. Le distinguer importe — la collision se corrige en rebasant, celle-ci se corrige en réparant le fichier.

## Fix

Déplacement de la clé sur le job `parity`, là où Actions l'honore. La sémantique voulue — advisory, ne casse pas le reste de la run — est celle du commentaire d'origine, elle est simplement exprimée au bon niveau. Même placement que `validation-matrix.yml:63`, précédent qui fonctionne dans ce dépôt.

À noter : l'étape porte déjà `python scripts/check_hooks_parity.py || echo "PARITY_FAIL_RC=$?"`, donc le gate ne pouvait de toute façon pas rougir par son exit code. Le `continue-on-error` au niveau job est une ceinture de sécurité, pas le mécanisme advisory principal.

## Preuve

Balayage des clés racine sur **tous** les workflows du dépôt (ensemble valide = `name`, `run-name`, `on`, `permissions`, `env`, `defaults`, `concurrency`, `jobs`), en neutralisant la résolution PyYAML de `on:` non quoté en booléen `True` :

```
TOTAL workflows avec cle racine invalide: 0
```

`hooks-parity.yml` était le seul porteur ; il ne l'est plus. `grep -rn '^continue-on-error' .github/workflows/*.yml` ne renvoie plus rien, et l'usage indenté légitime subsiste (`hooks-parity.yml:33`, `validation-matrix.yml:63`).

Diff : 1 fichier, +5/−3. Pre-commit gitleaks `Passed`.

## Ce que cette PR débloque

`main` repasse au vert sur `hooks-parity`, qui est le dernier rouge après la cascade de 21 merges de ce cycle.

See #9888, #9903, #9920.
