### PR TITLE
fix(qc-py): renumber duplicate exercise headers in QC-Py-26/27/34 via sub-numbering (1.1/1.2)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
@@ -344,7 +344,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "### Exercice 1 : Estimation des couts API pour le trading\n",
+    "### Exercice 1.1 : Estimation des couts API pour le trading\n",
     "\n",
     "Chaque appel LLM a un cout. En trading haute frequence, les couts API peuvent manger les profits.\n",
     "\n",
@@ -368,7 +368,7 @@
    "id": "cell-f3ce82c0",
    "metadata": {},
    "source": [
-    "# Exercice 1 : Estimation couts API\n",
+    "# Exercice 1.1 : Estimation couts API\n",
     "# TODO etudiant : Calculer le cout quotidien d'un systeme LLM\n",
     "# Indice : tokens * prix + marge de 20%\n",
     "# Etape 1 : Definir les prix et parametres\n",
@@ -386,7 +386,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercice 1 : Estimation du cout mensuel d'une stratégie multi-actifs\n\nEstimez le **cout mensuel** d'une stratégie LLM analysant 10 actifs avec 3 appels API par jour. L'objectif est de determiner si l'approche est economiquement viable.\n\n**Indices** :\n- `# Indice` : Calculez `nb_appels = 10 actifs * 3 appels/jour * 22 jours/mois`\n- `# Étape 1` : Définir le cout par appel API (ex: $0.01 pour GPT-4o-mini)\n- `# Étape 2` : Calculer le nombre d'appels mensuel\n- `# Étape 3` : Calculer le cout total mensuel"
+    "### Exercice 1.2 : Estimation du cout mensuel d'une stratégie multi-actifs\n\nEstimez le **cout mensuel** d'une stratégie LLM analysant 10 actifs avec 3 appels API par jour. L'objectif est de determiner si l'approche est economiquement viable.\n\n**Indices** :\n- `# Indice` : Calculez `nb_appels = 10 actifs * 3 appels/jour * 22 jours/mois`\n- `# Étape 1` : Définir le cout par appel API (ex: $0.01 pour GPT-4o-mini)\n- `# Étape 2` : Calculer le nombre d'appels mensuel\n- `# Étape 3` : Calculer le cout total mensuel"
    ],
    "id": "cell-d3193b5d"
   },
@@ -404,7 +404,7 @@
     }
    ],
    "source": [
-    "# Exercice 1 : Cout mensuel API multi-actifs\n# TODO etudiant : Estimer le cout mensuel d'une strategie LLM sur 10 actifs\n# Etape 1 : cout_par_appel = 0.01  # USD (GPT-4o-mini estimate)\n# Etape 2 : appels_mensuel = 10 * 3 * 22\n# Etape 3 : cout_total = appels_mensuel * cout_par_appel\ncout_mensuel = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Cout mensuel API multi-actifs\")"
+    "# Exercice 1.2 : Cout mensuel API multi-actifs\n# TODO etudiant : Estimer le cout mensuel d'une strategie LLM sur 10 actifs\n# Etape 1 : cout_par_appel = 0.01  # USD (GPT-4o-mini estimate)\n# Etape 2 : appels_mensuel = 10 * 3 * 22\n# Etape 3 : cout_total = appels_mensuel * cout_par_appel\ncout_mensuel = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Cout mensuel API multi-actifs\")"
    ],
    "id": "cell-135ccd50"
   },
@@ -988,7 +988,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "### Exercice 2 : Prompt engineering pour le sentiment financier\n",
+    "### Exercice 2.1 : Prompt engineering pour le sentiment financier\n",
     "\n",
     "La qualite du prompt impacte directement la qualite du signal. Comparez 3 styles de prompts.\n",
     "\n",
@@ -1011,7 +1011,7 @@
    "id": "cell-5f783234",
    "metadata": {},
    "source": [
-    "# Exercice 2 : Prompt engineering compare\n",
+    "# Exercice 2.1 : Prompt engineering compare\n",
     "# TODO etudiant : Comparer zero-shot, few-shot et chain-of-thought\n",
     "# Indice : 3 templates de prompt, evaluer sur 10 headlines\n",
     "# Etape 1 : Definir les 3 templates de prompt\n",
@@ -1029,7 +1029,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercice 2 : Prompt personnalise pour l'analyse de results d'entreprise\n\nCréez un **prompt spécifique** pour analyser les results d'entreprise (earnings). Le prompt doit demander au LLM d'evaluer le sentiment et la confiance.\n\n**Indices** :\n- `# Indice` : Utilisez un template avec des placeholders `{company}`, `{quarter}`, `{eps_actual}`, `{eps_estimate}`\n- `# Étape 1` : Définir le template de prompt\n- `# Étape 2` : Inclure les consignes : sentiment (bullish/bearish/neutral), confiance (0-1), raison principale\n- `# Étape 3` : Tester le template avec des valeurs exemples"
+    "### Exercice 2.2 : Prompt personnalise pour l'analyse de results d'entreprise\n\nCréez un **prompt spécifique** pour analyser les results d'entreprise (earnings). Le prompt doit demander au LLM d'evaluer le sentiment et la confiance.\n\n**Indices** :\n- `# Indice` : Utilisez un template avec des placeholders `{company}`, `{quarter}`, `{eps_actual}`, `{eps_estimate}`\n- `# Étape 1` : Définir le template de prompt\n- `# Étape 2` : Inclure les consignes : sentiment (bullish/bearish/neutral), confiance (0-1), raison principale\n- `# Étape 3` : Tester le template avec des valeurs exemples"
    ],
    "id": "cell-e84bb559"
   },
@@ -1047,7 +1047,7 @@
     }
    ],
    "source": [
-    "# Exercice 2 : Prompt d'analyse de results d'entreprise\n# TODO etudiant : Creer un prompt pour analyser les earnings\n# Etape 1 : Definir le template avec placeholders\n# Etape 2 : Inclure consignes (sentiment, confiance, raison)\n# Etape 3 : Tester avec des valeurs exemples\nearnings_prompt = None  # TODO etudiant : remplacer par le template\nprint(\"Exercice a completer : Prompt d'analyse de results d'entreprise\")"
+    "# Exercice 2.2 : Prompt d'analyse de results d'entreprise\n# TODO etudiant : Creer un prompt pour analyser les earnings\n# Etape 1 : Definir le template avec placeholders\n# Etape 2 : Inclure consignes (sentiment, confiance, raison)\n# Etape 3 : Tester avec des valeurs exemples\nearnings_prompt = None  # TODO etudiant : remplacer par le template\nprint(\"Exercice a completer : Prompt d'analyse de results d'entreprise\")"
    ],
    "id": "cell-f10d87fa"
   },
@@ -1525,7 +1525,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercice 3 : Impact du desaccord entre signaux LLM et techniques\n\nAnalysez l'impact sur le **position sizing** quand le signal LLM et le signal technique sont en desaccord (ex: LLM bullish mais RSI en surachat).\n\n**Indices** :\n- `# Indice` : Simulez 10 scénarios de desaccord avec différentes combinaisons de signaux\n- `# Étape 1` : Créer une liste de scénarios (LLM bullish/bearish) x (technique bullish/bearish)\n- `# Étape 2` : Définir une règle de position sizing pour chaque cas\n- `# Étape 3` : Afficher un tableau recapitulatif des tailles de position"
+    "### Exercice 3.1 : Impact du desaccord entre signaux LLM et techniques\n\nAnalysez l'impact sur le **position sizing** quand le signal LLM et le signal technique sont en desaccord (ex: LLM bullish mais RSI en surachat).\n\n**Indices** :\n- `# Indice` : Simulez 10 scénarios de desaccord avec différentes combinaisons de signaux\n- `# Étape 1` : Créer une liste de scénarios (LLM bullish/bearish) x (technique bullish/bearish)\n- `# Étape 2` : Définir une règle de position sizing pour chaque cas\n- `# Étape 3` : Afficher un tableau recapitulatif des tailles de position"
    ],
    "id": "cell-f75769bc"
   },
@@ -1543,7 +1543,7 @@
     }
    ],
    "source": [
-    "# Exercice 3 : Desaccord signaux LLM vs techniques\n# TODO etudiant : Analyser l'impact du desaccord LLM/technique sur le position sizing\n# Etape 1 : Creer 4 scenarios (LLM+/Tech+, LLM+/Tech-, LLM-/Tech+, LLM-/Tech-)\n# Etape 2 : Attribuer une taille de position a chaque scenario\n# Etape 3 : Afficher le tableau recapitulatif\nposition_sizing_table = None  # TODO etudiant : remplacer par le tableau\nprint(\"Exercice a completer : Desaccord signaux LLM vs techniques\")"
+    "# Exercice 3.1 : Desaccord signaux LLM vs techniques\n# TODO etudiant : Analyser l'impact du desaccord LLM/technique sur le position sizing\n# Etape 1 : Creer 4 scenarios (LLM+/Tech+, LLM+/Tech-, LLM-/Tech+, LLM-/Tech-)\n# Etape 2 : Attribuer une taille de position a chaque scenario\n# Etape 3 : Afficher le tableau recapitulatif\nposition_sizing_table = None  # TODO etudiant : remplacer par le tableau\nprint(\"Exercice a completer : Desaccord signaux LLM vs techniques\")"
    ],
    "id": "cell-b7d8e4e7"
   },
@@ -1693,7 +1693,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "### Exercice 3 : Système de vote LLM multi-modèles\n",
+    "### Exercice 3.2 : Système de vote LLM multi-modèles\n",
     "\n",
     "Combinez les signaux de plusieurs LLM (simules) via un système de vote majoritaire.\n",
     "\n",
@@ -1716,7 +1716,7 @@
    "id": "cell-19a79b4c",
    "metadata": {},
    "source": [
-    "# Exercice 3 : Systeme de vote LLM\n",
+    "# Exercice 3.2 : Systeme de vote LLM\n",
     "# TODO etudiant : Implementer un ensemble multi-LLM avec vote pondere\n",
     "# Indice : 3 LLM simules, vote pondere, signal final = sign(somme)\n",
     "# Etape 1 : Definir les 3 LLM simules avec biais differents\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
@@ -396,7 +396,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "### Exercice 1 : Pipeline de validation pre-deploiement\n",
+    "### Exercice 1.1 : Pipeline de validation pre-deploiement\n",
     "\n",
     "Avant de deployer une stratégie en production, un pipeline automatise verifie les pre-requis.\n",
     "\n",
@@ -419,7 +419,7 @@
    "id": "cell-10b1aa7f",
    "metadata": {},
    "source": [
-    "# Exercice 1 : Pipeline validation pre-deploiement\n",
+    "# Exercice 1.1 : Pipeline validation pre-deploiement\n",
     "# TODO etudiant : Implementer 4 etapes de validation\n",
     "# Indice : Chaque etape = fonction retournant (PASS/FAIL, metriques)\n",
     "# Etape 1 : Verifier backtest 2 ans + Sharpe > 0.5\n",
@@ -437,7 +437,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercice 1 : Critères de transition personnalises\n\nAjoutez un critere de transition entre paper trading et live trading : le **backtest return** doit depasser 15% ET le **Max Drawdown** doit rester sous 20%.\n\n**Indices** :\n- `# Indice` : Utilisez les metriques `backtest_return` et `max_drawdown` du LifecycleManager\n- `# Étape 1` : Définir les seuils (return > 15%, drawdown < 20%)\n- `# Étape 2` : Ajouter les conditions dans la méthode de transition\n- `# Étape 3` : Logger le résultat de chaque condition"
+    "### Exercice 1.2 : Critères de transition personnalises\n\nAjoutez un critere de transition entre paper trading et live trading : le **backtest return** doit depasser 15% ET le **Max Drawdown** doit rester sous 20%.\n\n**Indices** :\n- `# Indice` : Utilisez les metriques `backtest_return` et `max_drawdown` du LifecycleManager\n- `# Étape 1` : Définir les seuils (return > 15%, drawdown < 20%)\n- `# Étape 2` : Ajouter les conditions dans la méthode de transition\n- `# Étape 3` : Logger le résultat de chaque condition"
    ],
    "id": "cell-a58c0a99"
   },
@@ -455,7 +455,7 @@
     }
    ],
    "source": [
-    "# Exercice 1 : Criteres de transition paper-to-live\n# TODO etudiant : Ajouter des criteres de transition (return>15%, MaxDD<20%)\n# Etape 1 : Definir les seuils\n# Etape 2 : Verifier chaque condition\n# Etape 3 : Logger le resultat\ntransition_result = None  # TODO etudiant : remplacer par le resultat\nprint(\"Exercice a completer : Criteres de transition paper-to-live\")"
+    "# Exercice 1.2 : Criteres de transition paper-to-live\n# TODO etudiant : Ajouter des criteres de transition (return>15%, MaxDD<20%)\n# Etape 1 : Definir les seuils\n# Etape 2 : Verifier chaque condition\n# Etape 3 : Logger le resultat\ntransition_result = None  # TODO etudiant : remplacer par le resultat\nprint(\"Exercice a completer : Criteres de transition paper-to-live\")"
    ],
    "id": "cell-c2a44cbb"
   },
@@ -872,7 +872,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "### Exercice 2 : Configuration live trading\n",
+    "### Exercice 2.1 : Configuration live trading\n",
     "\n",
     "Le passage du paper au live trading exige une configuration rigoureuse. Un seul paramètre oublie peut causer des pertes.\n",
     "\n",
@@ -894,7 +894,7 @@
    "id": "cell-10f9f8eb",
    "metadata": {},
    "source": [
-    "# Exercice 2 : Validateur de configuration live\n",
+    "# Exercice 2.1 : Validateur de configuration live\n",
     "# TODO etudiant : Creer une checklist + validateur automatique\n",
     "# Indice : Dict config + bornes + rapport PASS/FAIL\n",
     "# Etape 1 : Definir la configuration live\n",
@@ -912,7 +912,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercice 2 : Ratio Sharpe paper vs backtest\n\nCalculez le **ratio de Sharpe** entre le paper trading et le backtest. Un ratio proche de 1.0 indique une bonne coherence. Un ratio < 0.5 signale un problème de deploiement.\n\n**Indices** :\n- `# Indice` : Ratio = `paper_sharpe / backtest_sharpe`\n- `# Étape 1` : Extraire le Sharpe du paper trading\n- `# Étape 2` : Extraire le Sharpe du backtest\n- `# Étape 3` : Calculer le ratio et interpreter"
+    "### Exercice 2.2 : Ratio Sharpe paper vs backtest\n\nCalculez le **ratio de Sharpe** entre le paper trading et le backtest. Un ratio proche de 1.0 indique une bonne coherence. Un ratio < 0.5 signale un problème de deploiement.\n\n**Indices** :\n- `# Indice` : Ratio = `paper_sharpe / backtest_sharpe`\n- `# Étape 1` : Extraire le Sharpe du paper trading\n- `# Étape 2` : Extraire le Sharpe du backtest\n- `# Étape 3` : Calculer le ratio et interpreter"
    ],
    "id": "cell-e0e38754"
   },
@@ -930,7 +930,7 @@
     }
    ],
    "source": [
-    "# Exercice 2 : Ratio Sharpe paper vs backtest\n# TODO etudiant : Calculer le ratio paper_sharpe / backtest_sharpe\n# Etape 1 : paper_sharpe = extraire des metriques paper\n# Etape 2 : backtest_sharpe = extraire des metriques backtest\n# Etape 3 : ratio = paper_sharpe / backtest_sharpe\nsharpe_ratio = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Ratio Sharpe paper vs backtest\")"
+    "# Exercice 2.2 : Ratio Sharpe paper vs backtest\n# TODO etudiant : Calculer le ratio paper_sharpe / backtest_sharpe\n# Etape 1 : paper_sharpe = extraire des metriques paper\n# Etape 2 : backtest_sharpe = extraire des metriques backtest\n# Etape 3 : ratio = paper_sharpe / backtest_sharpe\nsharpe_ratio = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Ratio Sharpe paper vs backtest\")"
    ],
    "id": "cell-af05a88b"
   },
@@ -1336,7 +1336,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "### Exercice 3 : Orchestrateur multi-stratégies\n",
+    "### Exercice 3.1 : Orchestrateur multi-stratégies\n",
     "\n",
     "Un système de production combine plusieurs stratégies. L'orchestrateur gere l'allocation inter-stratégies.\n",
     "\n",
@@ -1359,7 +1359,7 @@
    "id": "cell-a5c6cbfb",
    "metadata": {},
    "source": [
-    "# Exercice 3 : Allocateur multi-strategies\n",
+    "# Exercice 3.1 : Allocateur multi-strategies\n",
     "# TODO etudiant : Implementer un allocateur dynamique\n",
     "# Indice : Sharpe glissant + normalisation + contraintes min/max\n",
     "# Etape 1 : Simuler les rendements des 3 strategies\n",
@@ -1609,7 +1609,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercice 3 : Allocation avec contrainte de correlation\n\nAjoutez une **contrainte de correlation** a l'orchestrateur multi-stratégies : si deux stratégies ont une correlation > 0.7, reduisez l'allocation de la moins performante.\n\n**Indices** :\n- `# Indice` : Calculez la correlation entre les returns des stratégies\n- `# Étape 1` : Simuler les returns de 3 stratégies\n- `# Étape 2` : Calculer la matrice de correlation\n- `# Étape 3` : Reduire l'allocation des stratégies correllees"
+    "### Exercice 3.2 : Allocation avec contrainte de correlation\n\nAjoutez une **contrainte de correlation** a l'orchestrateur multi-stratégies : si deux stratégies ont une correlation > 0.7, reduisez l'allocation de la moins performante.\n\n**Indices** :\n- `# Indice` : Calculez la correlation entre les returns des stratégies\n- `# Étape 1` : Simuler les returns de 3 stratégies\n- `# Étape 2` : Calculer la matrice de correlation\n- `# Étape 3` : Reduire l'allocation des stratégies correllees"
    ],
    "id": "cell-467d75f2"
   },
@@ -1627,7 +1627,7 @@
     }
    ],
    "source": [
-    "# Exercice 3 : Allocation avec contrainte de correlation\n# TODO etudiant : Reduire l'allocation des strategies trop correllees (>0.7)\n# Etape 1 : Simuler les returns de 3 strategies\n# Etape 2 : Calculer la matrice de correlation\n# Etape 3 : Reduire l'allocation si corr > 0.7\nadjusted_allocations = None  # TODO etudiant : remplacer par les allocations\nprint(\"Exercice a completer : Allocation avec contrainte de correlation\")"
+    "# Exercice 3.2 : Allocation avec contrainte de correlation\n# TODO etudiant : Reduire l'allocation des strategies trop correllees (>0.7)\n# Etape 1 : Simuler les returns de 3 strategies\n# Etape 2 : Calculer la matrice de correlation\n# Etape 3 : Reduire l'allocation si corr > 0.7\nadjusted_allocations = None  # TODO etudiant : remplacer par les allocations\nprint(\"Exercice a completer : Allocation avec contrainte de correlation\")"
    ],
    "id": "cell-fbde7235"
   },

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-34-RL-SAC-A2C-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-34-RL-SAC-A2C-Trading.ipynb
@@ -459,7 +459,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "### Exercice 1 : Environnement avec couts de transaction pour RL\n",
+    "### Exercice 1.1 : Environnement avec couts de transaction pour RL\n",
     "\n",
     "Les environnements RL de trading omettent souvent les couts de transaction, ce qui surestime la performance.\n",
     "\n",
@@ -481,7 +481,7 @@
    "id": "cell-c5363160",
    "metadata": {},
    "source": [
-    "# Exercice 1 : Environnement avec couts de transaction\n",
+    "# Exercice 1.1 : Environnement avec couts de transaction\n",
     "# TODO etudiant : Ajouter 5 bps par trade et comparer\n",
     "# Indice : Modifier step() pour deduire les couts, comparer avec/sans\n",
     "# Etape 1 : Modifier l'environnement\n",
@@ -714,7 +714,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercice 1 : Analyser l'impact de la taille du buffer SAC\n\nLe **replay buffer** du SAC stocke les expériences passees. Testez deux tailles : 25K (petit) vs 100K (grand) et observez l'impact sur la stabilite.\n\n**Indices** :\n- `# Indice` : La taille est le paramètre `capacity` du ReplayBuffer\n- `# Étape 1` : Modifier capacity=25000 et executer\n- `# Étape 2` : Modifier capacity=100000 et executer\n- `# Étape 3` : Comparer les courbes d'eval Sharpe"
+    "### Exercice 1.2 : Analyser l'impact de la taille du buffer SAC\n\nLe **replay buffer** du SAC stocke les expériences passees. Testez deux tailles : 25K (petit) vs 100K (grand) et observez l'impact sur la stabilite.\n\n**Indices** :\n- `# Indice` : La taille est le paramètre `capacity` du ReplayBuffer\n- `# Étape 1` : Modifier capacity=25000 et executer\n- `# Étape 2` : Modifier capacity=100000 et executer\n- `# Étape 3` : Comparer les courbes d'eval Sharpe"
    ],
    "id": "cell-810a68e1"
   },
@@ -732,7 +732,7 @@
     }
    ],
    "source": [
-    "# Exercice 1 : Impact de la taille du replay buffer SAC\n# TODO etudiant : Tester capacity=25000 vs 100000\n# Etape 1 : Entrainer avec petit buffer\n# Etape 2 : Entrainer avec grand buffer\n# Etape 3 : Comparer les Sharpe ratios\nbuffer_comparison = None  # TODO etudiant : remplacer par les resultats\nprint(\"Exercice a completer : Impact de la taille du replay buffer SAC\")"
+    "# Exercice 1.2 : Impact de la taille du replay buffer SAC\n# TODO etudiant : Tester capacity=25000 vs 100000\n# Etape 1 : Entrainer avec petit buffer\n# Etape 2 : Entrainer avec grand buffer\n# Etape 3 : Comparer les Sharpe ratios\nbuffer_comparison = None  # TODO etudiant : remplacer par les resultats\nprint(\"Exercice a completer : Impact de la taille du replay buffer SAC\")"
    ],
    "id": "cell-cc6d5659"
   },
@@ -880,7 +880,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "### Exercice 2 : A2C avec entropy bonus\n",
+    "### Exercice 2.1 : A2C avec entropy bonus\n",
     "\n",
     "L'entropy bonus dans A2C encourage l'exploration. Un coefficient trop eleve empeche la convergence.\n",
     "\n",
@@ -902,7 +902,7 @@
    "id": "cell-1d01d08c",
    "metadata": {},
    "source": [
-    "# Exercice 2 : A2C entropy bonus\n",
+    "# Exercice 2.1 : A2C entropy bonus\n",
     "# TODO etudiant : Tuner le coefficient d'entropy\n",
     "# Indice : loss = policy_loss - coef * entropy, comparer 4 valeurs\n",
     "# Etape 1 : Ajouter le terme d'entropy dans la loss\n",
@@ -920,7 +920,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercice 2 : Modifier le facteur de discount gamma\n\nLe **facteur de discount gamma** determine l'horizon temporel de l'agent. Testez gamma=0.9 (court terme) vs gamma=0.995 (long terme).\n\n**Indices** :\n- `# Indice` : `gamma` est utilise dans le calcul des returns dans A2C\n- `# Étape 1` : Localiser le paramètre gamma dans A2CAgent\n- `# Étape 2` : Tester gamma=0.9 et gamma=0.995\n- `# Étape 3` : Comparer les performances"
+    "### Exercice 2.2 : Modifier le facteur de discount gamma\n\nLe **facteur de discount gamma** determine l'horizon temporel de l'agent. Testez gamma=0.9 (court terme) vs gamma=0.995 (long terme).\n\n**Indices** :\n- `# Indice` : `gamma` est utilise dans le calcul des returns dans A2C\n- `# Étape 1` : Localiser le paramètre gamma dans A2CAgent\n- `# Étape 2` : Tester gamma=0.9 et gamma=0.995\n- `# Étape 3` : Comparer les performances"
    ],
    "id": "cell-d357580b"
   },
@@ -938,7 +938,7 @@
     }
    ],
    "source": [
-    "# Exercice 2 : Impact du facteur de discount gamma\n# TODO etudiant : Tester gamma=0.9 vs gamma=0.995 sur A2C\n# Etape 1 : Localiser gamma dans A2CAgent\n# Etape 2 : Tester les deux valeurs\n# Etape 3 : Comparer les courbes de reward\ngamma_comparison = None  # TODO etudiant : remplacer par les resultats\nprint(\"Exercice a completer : Impact du facteur de discount gamma\")"
+    "# Exercice 2.2 : Impact du facteur de discount gamma\n# TODO etudiant : Tester gamma=0.9 vs gamma=0.995 sur A2C\n# Etape 1 : Localiser gamma dans A2CAgent\n# Etape 2 : Tester les deux valeurs\n# Etape 3 : Comparer les courbes de reward\ngamma_comparison = None  # TODO etudiant : remplacer par les resultats\nprint(\"Exercice a completer : Impact du facteur de discount gamma\")"
    ],
    "id": "cell-82eb8d0e"
   },
@@ -1019,7 +1019,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercice 3 : Tableau comparatif SAC vs A2C vs DQN vs PPO\n\nCréez un **tableau comparatif** des 4 algorithmes RL (DQN, PPO, SAC, A2C) avec les metriques : Sharpe, Return total, Max Drawdown, Nombre de trades.\n\n**Indices** :\n- `# Indice` : Reutilisez les résultats des notebooks QC-Py-32 et QC-Py-33 si disponibles\n- `# Indice` : Utilisez `pd.DataFrame()` pour construire le tableau\n- `# Étape 1` : Collecter les metriques de chaque algorithme\n- `# Étape 2` : Construire le DataFrame\n- `# Étape 3` : Afficher le tableau formatte"
+    "### Exercice 3.1 : Tableau comparatif SAC vs A2C vs DQN vs PPO\n\nCréez un **tableau comparatif** des 4 algorithmes RL (DQN, PPO, SAC, A2C) avec les metriques : Sharpe, Return total, Max Drawdown, Nombre de trades.\n\n**Indices** :\n- `# Indice` : Reutilisez les résultats des notebooks QC-Py-32 et QC-Py-33 si disponibles\n- `# Indice` : Utilisez `pd.DataFrame()` pour construire le tableau\n- `# Étape 1` : Collecter les metriques de chaque algorithme\n- `# Étape 2` : Construire le DataFrame\n- `# Étape 3` : Afficher le tableau formatte"
    ],
    "id": "cell-ead4003d"
   },
@@ -1037,7 +1037,7 @@
     }
    ],
    "source": [
-    "# Exercice 3 : Tableau comparatif des 4 algorithmes RL\n# TODO etudiant : Construire un tableau comparatif SAC vs A2C vs DQN vs PPO\n# Etape 1 : Collecter les metriques (Sharpe, Return, MaxDD, Trades)\n# Etape 2 : Construire un DataFrame\n# Etape 3 : Afficher le tableau formatte\ncomparison_table = None  # TODO etudiant : remplacer par le tableau\nprint(\"Exercice a completer : Tableau comparatif des algorithmes RL\")"
+    "# Exercice 3.1 : Tableau comparatif des 4 algorithmes RL\n# TODO etudiant : Construire un tableau comparatif SAC vs A2C vs DQN vs PPO\n# Etape 1 : Collecter les metriques (Sharpe, Return, MaxDD, Trades)\n# Etape 2 : Construire un DataFrame\n# Etape 3 : Afficher le tableau formatte\ncomparison_table = None  # TODO etudiant : remplacer par le tableau\nprint(\"Exercice a completer : Tableau comparatif des algorithmes RL\")"
    ],
    "id": "cell-da4e1451"
   },
@@ -1368,7 +1368,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "### Exercice 3 : Comparaison quadri-algorithmes\n",
+    "### Exercice 3.2 : Comparaison quadri-algorithmes\n",
     "\n",
     "DQN, PPO, SAC et A2C ont des forces et faiblesses différentes selon l'environnement.\n",
     "\n",
@@ -1390,7 +1390,7 @@
    "id": "cell-70702d7d",
    "metadata": {},
    "source": [
-    "# Exercice 3 : Benchmark DQN/PPO/SAC/A2C\n",
+    "# Exercice 3.2 : Benchmark DQN/PPO/SAC/A2C\n",
     "# TODO etudiant : Comparer les 4 algorithmes\n",
     "# Indice : Meme env, 50 episodes, tableau + boxplot\n",
     "# Etape 1 : Configurer les 4 agents\n",


### PR DESCRIPTION
Grain: MED/content — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #9938

# Fix : renumérotation des exercices dupliqués dans QC-Py-26/27/34 (sous-numérotation 1.1/1.2)

Quoi: Les 3 notebooks QC-Py-26/27/34 avaient chacun 3 bugs réels de numérotation d'exercices dupliqués — deux exercices distincts partageant le numéro 1, deux le numéro 2, deux le numéro 3 (bug de template, mêmes offsets de cellules dans les 3 notebooks). Chaque paire = header markdown `### Exercice N` + commentaire code adjacent `# Exercice N` avec des titres DIFFÉRENTS (ex QC-Py-26 : "Exercice 1 : Estimation couts API" vs "Exercice 1 : Estimation du cout mensuel multi-actifs"). Renuméroté via sous-numérotation (1.1/1.2, 2.1/2.2, 3.1/3.2), convention déjà utilisée par Planners-2 (8.x/9.x) que le scanner reconnaît désormais correctement après #9938. Le header md ET son commentaire code appairé reçoivent le MÊME sous-numéro (renumérotation par unité, pas par ligne).

Preuve:
- `detect_solution_leaks.py --scan` (avec fix #9938 MERGED) sur chaque notebook : **0 HIGH, 0 MEDIUM, 0 errors** (était 3 MEDIUM "Duplicate Exercice" chacun). Total repo-wide : -9 MEDIUM.
- `git diff --stat` : 3 fichiers, +36/-36 (équilibré = renumérotation pure, zéro churn structurel). Byte-identité préservée via `json.dumps(indent=1, ensure_ascii=False)` (les originaux utilisent des littéraux UTF-8, pas d'échappements \uXXXX).
- Diff chirurgical : SEULS les numéros d'exercice changent dans les headers md + commentaires code. Stubs inchangés (`exec=None`, `result = None  # TODO etudiant`, corps de stub identique).
- JSON valide re-confirmé après édition (json.load OK sur les 3).
- Aucune ré-exécution C.2 requise : édition commentaire/markdown uniquement, le code exécutable (stubs) est byte-identique.

Périmètre: 3 notebooks QC-Py (26/27/34), +36/-36. Aucun scanner touché (le fix scanner #9938 est déjà merged sur main). Aucun catalogue touché (byte-identique à main). Base fraîche (`origin/main 8b3b26cca`, post-merge #9938).

## Contexte

Side-finding de l'audit #9858 (invariants panne-window) : sur les ~27 MEDIUM "Duplicate Exercice" rapportés repo-wide, 9 (3 notebooks × 3 exercices) étaient des duplications RÉELLES dans QC-Py — bugs de template où deux exercices distincts partageaient un numéro. Les 14 restants (Lean-6, App-15, Search-7) sont le pattern "two-sections" plus difficile (renumérotation légitime entre sections), délibérément hors scope.

See #9858 (side-finding) · dépend du scanner fix #9938 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
