### PR TITLE
feat(notebook-tools,#9768): filter DOI/arXiv reference identifiers in D5 scanner

### DIFF
--- a/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
@@ -79,6 +79,48 @@ EXCLUDE_PATTERNS = (
     re.compile(r"^[A-Z]+\d+$"),            # PRJ42, ABC123 -- discutable, mais limite
 )
 
+
+# Identifiants de reference (DOI / arXiv) : classes dominantes de faux positifs
+# observees firsthand en EPIC #9768 Phase 0 (po-2025, c.1291) sur les familles
+# riches en citations -- Probas/Infer.NET (~40 findings/notebook) et ML.NET labs.
+# Ces identifiants sont parses comme des floats par FR_DECIMAL_RE mais ne sont
+# jamais des mesures calculees.
+#   (a) prefix registrant DOI : 10.1109, 10.1145, 10.1002 ... (10. + >=4 chiffres)
+#   (b) suffixe d'URL DOI     : le nombre suit immediatement un prefixe
+#       registrant sur la meme ligne (10.1145/564376.564421 -> 564376.564421)
+#   (c) arXiv ID              : YYMM.NNNNN (annee plausible 19-30) ou contexte
+#       explicite « arXiv: » (2402.0103, 2309.07864)
+_DOI_PREFIX_RE = re.compile(r"^10\.\d{4,}$")          # (a) 10.1109 / 10.1145
+_DOI_SUFFIX_RE = re.compile(r"10\.\d{4,}/\S*$")        # (b) prefix-line = URL DOI
+_ARXIV_ID_RE = re.compile(r"^\d{4}\.\d{4,5}$")         # (c) 2402.0103 (4-5 decimales)
+_ARXIV_HINT_RE = re.compile(r"arxiv", re.IGNORECASE)   # (c) contexte explicite
+
+
+def _is_reference_identifier(raw: str, line_prefix: str) -> bool:
+    """Vrai si `raw` est un identifiant de reference (DOI / arXiv), pas une mesure.
+
+    `line_prefix` = texte de la meme ligne precedant le token (lowercase),
+    deja calcule par l'appelant pour les autres filtres semantiques.
+    """
+    # (a) prefix registrant DOI (10.1109, 10.1145) -- impossible comme mesure.
+    if _DOI_PREFIX_RE.match(raw):
+        return True
+    # (c) arXiv ID YYMM.NNNNN : on n'exclut qu'a annee plausible (19-30) ou si
+    # le contexte cite explicitement arXiv, pour ne pas tuer un resultat legit
+    # type 1234.56789 (annee 12 hors plage).
+    if _ARXIV_ID_RE.match(raw):
+        yy = int(raw[:2])
+        if 19 <= yy <= 30 or _ARXIV_HINT_RE.search(line_prefix):
+            return True
+    # (b) suffixe d'URL DOI : le prefix contient un registrant suivi de `/` puis
+    # de non-whitespace jusqu'a ce token (ex. « ...10.1145/ » avant 564376...).
+    # Un nombre legit apres un DOI separes par une espace n'est pas atteint
+    # (la regex exige \S* jusqu'a la fin du prefix, sans espace intercalaire).
+    if _DOI_SUFFIX_RE.search(line_prefix):
+        return True
+    return False
+
+
 # Ligne de titre markdown ATX (CommonMark) : 0-3 espaces puis 1-6 `#` puis un
 # espace ou fin de ligne. Les hints `## `/`### `/`#### ` ci-dessous couvraient
 # H2-H6 mais laissaient fuiter les titres H1 (`# SC-8-...`, `# MGS-9`,
@@ -218,6 +260,11 @@ def _extract_prose_numbers(text: str) -> list[float]:
         if _ATX_HEADING_LINE_RE.match(text[line_start:m.start() + len(raw)]):
             continue
         if any(h in prefix for h in SEMANTIC_FALSE_POSITIVE_HINTS):
+            continue
+        # Filtre DOI / arXiv : identifiants de reference (jamais des mesures).
+        # EPIC #9768 Phase 0 (c.1291) -- classe dominante de FP sur les familles
+        # riches en citations (Probas/Infer.NET, ML.NET labs).
+        if _is_reference_identifier(raw, prefix):
             continue
         v = _parse_fr_number(raw)
         if v is None:

--- a/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
@@ -163,6 +163,60 @@ class TestExtractProseNumbers:
         assert 2.31 in nums
 
 
+class TestReferenceIdentifiers:
+    """Filtre DOI / arXiv (EPIC #9768 Phase 0, c.1291).
+
+    Les identifiants de reference (DOI 10.XXXX/..., arXiv YYMM.NNNNN) sont la
+    classe dominante de FP firsthand sur Probas/Infer.NET (~40 findings/notebook)
+    et les labs ML.NET. Ils doivent etre filtres ; un vrai resultat doit passer.
+    """
+
+    def test_doi_registrant_prefix_filtered(self):
+        # 10.1145 / 10.1109 : prefix registrant DOI, jamais une mesure.
+        nums = mod._extract_prose_numbers("Voir DOI 10.1145 pour le detail.")
+        assert 10.1145 not in nums
+        nums = mod._extract_prose_numbers("Reference IEEE 10.1109 du papier.")
+        assert 10.1109 not in nums
+
+    def test_doi_url_suffix_filtered(self):
+        # Le suffixe 564376.564421 suit immediatement le registrant (URL DOI).
+        nums = mod._extract_prose_numbers("Paper : 10.1145/564376.564421 (ACM).")
+        assert 564376.564421 not in nums
+        assert 10.1145 not in nums
+
+    def test_arxiv_id_filtered(self):
+        # arXiv:2402.0103 -- annee plausible 24.
+        nums = mod._extract_prose_numbers("Decrit dans arXiv:2402.0103.")
+        assert 2402.0103 not in nums
+
+    def test_arxiv_bare_year_plausible_filtered(self):
+        # Bare YYMM.NNNNN avec annee plausible (23) meme sans prefixe « arXiv ».
+        nums = mod._extract_prose_numbers("Methode de 2309.07864 appliquee ici.")
+        assert 2309.07864 not in nums
+
+    def test_legit_decimal_preserved(self):
+        # Un rating 1923.7 (1 decimale) n'est PAS un arXiv ID -> preserve.
+        nums = mod._extract_prose_numbers("Elo estime : 1923.7 points.")
+        assert 1923.7 in nums
+
+    def test_legit_4digit_decimal_outside_arxiv_range_preserved(self):
+        # 1234.56789 : annee 12 hors plage arXiv (19-30) -> preserve.
+        nums = mod._extract_prose_numbers("Mesure precise : 1234.56789 unite.")
+        assert 1234.56789 in nums
+
+    def test_legit_number_after_doi_with_space_preserved(self):
+        # Un vrai resultat apres un DOI, separe par une espace, n'est pas un
+        # suffixe d'URL -> preserve (anti-regression du filtre suffixe).
+        nums = mod._extract_prose_numbers("DOI 10.1145/564376.564421 ; ratio 0.82.")
+        assert 0.82 in nums
+        assert 564376.564421 not in nums
+
+    def test_real_marginal_preserved(self):
+        # 0.647 (la marginale exacte P(W=T) d'Infer-4) doit rester extraite.
+        nums = mod._extract_prose_numbers("La proba exacte est P(W=T) = 0.647.")
+        assert 0.647 in nums
+
+
 # --------------------------------------------------------------------------- #
 #  Extraction outputs
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA — prev: LIGHT/notebook-python (#9937)

## Ce que fait cette PR

**Durcit le détecteur D5** (`scan_d5_prose_outputs_alignment.py`, EPIC #9768 Phase 1 outillage) en filtrant les **identifiants de référence (DOI / arXiv)** — la classe dominante de faux positifs observée firsthand lors de la triage Phase 0 sur les familles riches en citations.

Le détecteur comparait les nombres de la prose markdown aux outputs de code, mais parseait les DOI (`10.1145/564376.564421`) et les arXiv IDs (`2402.0103`) comme des floats — d'où un déluge de findings qui n'étaient que des citations bibliographiques.

## Comment le défaut a été trouvé (audit Phase 0 firsthand, c.1291)

J'ai lancé le détecteur D5 sur **5 familles non couvertes** par la Phase 0 initiale (IIT/ICT) : ML.NET, Probas/Infer.NET, GameTheory, Sudoku, Planning. Triage firsthand des findings :

- **Probas/Infer.NET — Infer-15-Recommenders** : 40 findings/notebook, ~17 étaient des DOI (`10.1109`, `10.1145/564376.564421`, `10.1145/1526709.1526711`, `10.1145/1390156.1390267`).
- **ML.NET labs** (Lab9/Lab11/Lab16) : findings = arXiv IDs (`2402.0103`, `2309.07864`, `2210.03629`, `1809.08887`, `2107.03374`).
- **Verdict honnête** : **0 bug réel** de cohérence prose↔output dans ces 5 familles (conforme au verdict IIT/ICT « 8/8 SAIN »). Le détecteur était noyé dans le bruit, pas riche en signal.

Plutôt que de manufacturer un fix sur un finding FP, j'ai **corrigé la cause** (le détecteur) pour rendre les futures Phase 0 réellement exploitables.

## La correction

Ajoute `_is_reference_identifier(raw, line_prefix)` filtrant 3 formes d'identifiants :

| # | Forme | Exemple | Logique |
|---|-------|---------|---------|
| (a) | Prefix registrant DOI | `10.1109`, `10.1145` | `^10\.\d{4,}$` — impossible comme mesure |
| (b) | Suffixe d'URL DOI | `564376.564421` (dans `10.1145/564376.564421`) | prefix de ligne = `10\.\d{4,}/\S*$` — un nombre légitime après un DOI séparé par une espace est **préservé** (la regex exige `\S*` jusqu'à la fin du prefix) |
| (c) | arXiv ID | `2402.0103`, `2309.07864` | `^\d{4}\.\d{4,5}$` + année plausible (19-30) OU contexte `arXiv:` — préserve un résultat légitime `1234.56789` (année 12 hors plage) |

**Scope** : nombres de prose uniquement (là où vivent les références) ; outputs de code inchangés. Les findings résiduels (comptes de prose type « 42 utilisateurs », numéros de section) sont d'autres classes FP gérées par le dense-cell gate existant (`MISSING_FROM_OUTPUTS_CELL_RATIO`).

## Preuves (firsthand, G.1)

- **Infer-15-Recommenders** : findings **40 → 23** (les ~17 DOI/arXiv retirés).
- **Lab9-First-ADK-Agent** : findings **→ 0** (n'était composé que d'arXiv IDs).
- **Full corpus `--check`** : **EXIT 0** (aucun gate-triggering dense-cell finding — le filtre empêche les cellules denses en DOI de faux-déclencher le gate).
- **Nouvelle classe `TestReferenceIdentifiers`** : 8 tests — prefix/suffixe DOI, arXiv bare/explicite, décimale légitime préservée, nombre légitime après DOI+espace préservé, marginale réelle 0.647 préservée.
- **Suite complète : 68 passed, 0 failed** (zéro régression — le contre-exemple fondateur ICT-1 #9416, le dense-cell gate, la détection d'énumération intacts).
- **diff** : `+101` (47 module + 54 tests), **0 deletion** — changement purement additif.

## Contexte honnête (variation-protocol)

Grain **MED/tooling** — genre **distinct** de mes 2 derniers grains (`MED/notebook-dotnet` #9934, `LIGHT/notebook-python` #9937) → G-VAR-3 OK. C'est le pattern po-2024 #9933/#9935 (durcissement de détecteur groundé sur un FP observé firsthand). Substance : corrige la cause d'une classe FP dominante qui rendait le détecteur inutilisable pour les Phase 0 fleet-wide — exactement le travail qui débloque EPIC #9768.

**Queue merge saturée** (22 PRs, main frozen #9927, ai-01 OOM-recovery) : cette PR s'ajoute à la queue. Mais c'est du tooling (durcit le harnais anti-dégénérescence), pas un N-ième enrichment — valeur indépendante du timing de merge. R7 outcome-test satisfait : un grain de substance (EPIC #9768) transformé en PR.

**Pivot genre du steer ai-01** (« rotate off monoculture, pas de turf ») : honoré — passage de notebook-correctness (Probas) à tooling (détecteur), famille différente (notebook_tools), contribution à l'EPIC degenerescence.

See #9768 (degenerescence EPIC) / See #9790 (detector v3) / See #4588.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
