### PR TITLE
fix(qc,#9772): freeze D2 window on 3 Tier1 deployment templates (SetEndDate 2025-01-01)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
@@ -1854,6 +1854,7 @@
     "class DQNTradingAlgorithm(QCAlgorithm):\n",
     "    def Initialize(self):\n",
     "        self.SetStartDate(2023, 1, 1)\n",
+    "        self.SetEndDate(2025, 1, 1)\n",
     "        self.SetCash(100000)\n",
     "        self.n_actions = 4\n",
     "        self.threshold = 0.05\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-33-RL-PPO-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-33-RL-PPO-Trading.ipynb
@@ -1889,7 +1889,7 @@
      "output_type": "stream",
      "text": [
       "Template QC Algorithm PPO genere.\n",
-      "  Taille: 3393 caracteres\n",
+      "  Taille: 3529 caracteres\n",
       "  Methodes: Initialize, Rebalance, _ppo_predict, OnEndOfAlgorithm\n",
       "\n",
       "Pour deployer sur QuantConnect :\n",
@@ -1916,6 +1916,7 @@
     "\n",
     "    def Initialize(self):\n",
     "        self.SetStartDate(2022, 1, 1)\n",
+    "        self.SetEndDate(2025, 1, 1)\n",
     "        self.SetCash(100000)\n",
     "        \n",
     "        # Chargement du modele depuis ObjectStore\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-02-ML-Classification.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-02-ML-Classification.ipynb
@@ -330,6 +330,7 @@
     "\n",
     "    def Initialize(self):\n",
     "        self.SetStartDate(2020, 1, 1)\n",
+    "        self.SetEndDate(2025, 1, 1)\n",
     "        self.SetCash(100000)\n",
     "\n",
     "        # Assets\n",


### PR DESCRIPTION
Grain: MED/qc — lane myia-po-2024:CoursIA — prev: MED/notebook-python #9940

## Quoi / Preuve

**D2 window-freeze (correctness)** sur 3 notebooks QC Tier1 (deployment `qc_code` string avec `SetStartDate` SANS `SetEndDate`), identifiés par l'audit Phase 0 #9772 (classification 166 SANS → 121 defect réparables, 3 Tier1 safe).

| Notebook | SetStartDate | Ajout | Output commité |
|---|---|---|---|
| `QC-Py-32-RL-DQN-Trading.ipynb` | 2023-01-01 | `self.SetEndDate(2025, 1, 1)` | inchangé (instructions déploiement statiques — ne dépend pas du template) |
| `QC-Py-33-RL-PPO-Trading.ipynb` | 2022-01-01 | `self.SetEndDate(2025, 1, 1)` | **re-exécuté** : `Taille: 3393 -> 3529 caracteres` (cell c34 = pure string ops, self-contained, re-exec réelle) |
| `QC-Py-Cloud-02-ML-Classification.ipynb` | 2020-01-01 | `self.SetEndDate(2025, 1, 1)` | inchangé (cell c10 n'a aucun output) |

**Pourquoi safe (pas de re-exec massif)** : la sortie commitée des 3 notebooks vient des données locales **déjà figées** (32/33: `END_DATE = datetime(2025,1,1)` hardcoded ; Cloud-02: section NLP, pas de backtest local). La `qc_code` string de déploiement n'est PAS ce que la sortie commitée exécute — c'est un template pour QC Cloud. Ajouter `SetEndDate` fige la fenêtre du backtest déployé sans invalider la sortie locale (vérifié : 0 cellule output dépend de la string, sauf c34 qui imprime `len()` → re-exec).

### Preuve (firsthand, G.1)

1. **D2 root cause** : un `QCAlgorithm.Initialize()` avec `SetStartDate` mais pas `SetEndDate` → backtest déployé court jusqu'à "aujourd'hui" → dérive à chaque exécution (mécanisme D2 fenêtre non figée, EPIC #9768).
2. **Fix minimal faithful** : `self.SetEndDate(2025, 1, 1)` (mirrors la convention locale `END_DATE=2025-01-01`). Diff chirurgical : 4 insertions / 1 deletion.
3. **C.2/Stop-&-Repair honoré** : QC-Py-33 c34 re-exécutée en standalone (pure string ops, 0 dépendance externe vérifiée) → output réel `3529 caracteres` (3393 était stale, déjà dérivé vs template main). QC-Py-32/Cloud-02 outputs inchangés (ne dépendent pas du template).
4. **validate_pr_notebooks.py : 3/3 PASS** (H.3 enforcer, 0 cellule null-ec-no-output introduite).

## Diagnostic dérive (C.4 obligatoire, #8364)

**Cause** : **(d)** régression dépendance partielle — les templates de déploiement `qc_code` furent écrits avec `SetStartDate` mais le `SetEndDate` fut omis (4 notebooks sur 5 dans la recherche QC, cf #9772 : 80% du corpus). La sortie commitée n'a pas dérivé (elle vient des données locales figées), mais le **template déployable** dérive à chaque déploiement QC Cloud.

**Verdict** : `CAUSE_FIXED` — source corrigée (3 templates figés à `SetEndDate(2025,1,1)`) ET la sortie de c34 (QC-Py-33) vient d'une **re-exécution réelle** du code exact de la cellule (pas d'un byte-surgical markdown-align). Les 2 autres notebooks n'ont pas de sortie dépendante du template (inchangées = fidèles).

## Périmètre

- **3 notebooks** `Python/QC-Py-{32-RL-DQN, 33-RL-PPO, Cloud-02-ML-Classification}.ipynb` : 1 ligne source chacun (`self.SetEndDate(2025,1,1)` après `SetStartDate`) + 1 output transplanté (QC-Py-33 c34 re-exec).
- **Pas de re-exec RL/GPU** : la sortie locale vient des données déjà figées (`END_DATE` hardcoded) ; le fix cible le template de déploiement. Les 118 Tier3 (recherche/projets avec perf commité) restent gated QC Cloud batch (follow-up).
- Collision guard L898 : 0 PR ouverte sur QC-Py-32/33/Cloud-02 au départ (vérifié).

## Variété R6

qc après notebook-python #9940 → genre distinct (G-VAR-3 OK). Substance : fix de correctness D2 groundé firsthand (audit #9772 Phase 0 classification complète + re-exec réelle c34), pas un scan-and-insert mécanique (la sélection safe-vs-gated a exigé l'audit des 166).

See #9772 (Phase 0 audit, classification complète + ce fix Tier1), #9768 (EPIC dégénérescence D2), #3801 (registre SOTA), #8052 (claims↔outputs — la sortie c34 re-exécutée).
