### PR TITLE
fix(ci): update row_n stack test for MIN_ROW_SEQUENCE hardening (red main)

### DIFF
--- a/scripts/notebook_tools/tests/test_detect_fabricated_outputs.py
+++ b/scripts/notebook_tools/tests/test_detect_fabricated_outputs.py
@@ -349,12 +349,17 @@ class TestHasHeuristicBeatsOptimal:
 
     def test_detect_cell_stacks_with_row_n(self):
         # A cell can carry both a Row-N placeholder AND an impossible gap.
+        # The Row-N detector was hardened (c.XIX, MIN_ROW_SEQUENCE=3): a single
+        # isolated "Row N" is not a Pandas-default-index signature, so the stack
+        # test must feed >= MIN_ROW_SEQUENCE consecutive rows to fire both signals.
         cell = code_cell(outputs=[
             text_output(
                 "CP-SAT optimal: 2 bins\n"
                 "FFD heuristic:  1 bins\n"
                 "Gap: -50.0%\n"
                 "Row 1   0.5\n"
+                "Row 2   0.6\n"
+                "Row 3   0.7\n"
             ),
         ])
         signals = {f["signal"] for f in detect_cell(cell)}


### PR DESCRIPTION
Grain: MED/ci-fix — lane myia-po-2025:CoursIA — prev: DEEP/tooling (#9945)

## Red main — 1 stale test bloquait toute la merge queue

`Scripts Tests (CPU)` échouait sur **chaque** PR (dont les miennes #9943/#9945/#9926) avec `exit code 1` : `7012 passed, 1 failed`. Le `PR gate` (agrégateur) tombait rouge en cascade → main effectivement rouge pour la queue de merge.

## Root cause (firsthand, G.1)

`test_detect_fabricated_outputs.py::TestHasHeuristicBeatsOptimal::test_detect_cell_stacks_with_row_n` fournissait **une seule** ligne `Row 1   0.5` et assertait que le signal `row_n_placeholder` se déclenche. Or le détecteur `_has_row_n` a été **durci en c.XIX** (#9933/#9935, po-2024) : `MIN_ROW_SEQUENCE = 3` exige désormais **≥3 labels "Row N" consécutifs** (signature de l'index par défaut Pandas d'un dataframe non rempli). Une occurrence isolée ne se déclenche **correctement** pas — FP éliminé documenté : Sudoku-17-LLM-Python cell[14] (2 mentions isolées "Row 1 remaining" / "Row 2 is complete"). Corpus-wide post-durcissement : 0 finding sur 971 notebooks.

**Le test était stale (pre-hardening), pas mis à jour quand le détecteur a été durci.** Ce n'est pas une régression du détecteur — le hardening est intentionnel et documenté (`test_code_cell_with_row_n_returns_finding` ligne 374 documente déjà le `>= MIN_ROW_SEQUENCE`).

## Fix

Compléter le test stack avec une séquence Row-N **valide** (≥3 consécutifs) pour exercer le stacking des deux signaux dans une même cellule (c'était le but du test) :

```python
"Row 1   0.5\n"
"Row 2   0.6\n"
"Row 3   0.7\n"
```

**Aucun changement de code de production** — le hardening intentionnel est préservé. Le test vérifie désormais ce qu'il est censé vérifier : qu'une cell peut porter simultanément `heuristic_beats_optimal` (gap -50%) ET `row_n_placeholder` (séquence index Pandas).

## Preuves (G.1, firsthand)

- Local : `pytest test_detect_fabricated_outputs.py` → **61 passed** (était 1 failed / 60 passed).
- Test ciblé : `test_detect_cell_stacks_with_row_n` → PASSED.
- Diff : `+5/-0` (additif, 0 deletion, 0 fichier production touché).
- CI run rouge de référence : `31222790323` — `FAILED ... assert 'row_n_placeholder' in {'heuristic_beats_optimal'} ... 1 failed, 7012 passed`.

## Impact

Débloque la merge queue cluster-wide (main redevient vert sur `Scripts Tests (CPU)`). Mes 3 PRs en attente (#9943, #9945, #9926) + toutes les PRs des autres lanes passent ce check après merge.

See #9935 (row_n gate), #9933 (heuristic_beats_optimal detector), EPIC #3801.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
