### PR TITLE
fix(test,#9947): row_n fixture needs >=3 consecutive rows post-MIN_ROW_SEQUENCE=3 (#9935, main-rouge)

### DIFF
--- a/scripts/notebook_tools/tests/test_detect_fabricated_outputs.py
+++ b/scripts/notebook_tools/tests/test_detect_fabricated_outputs.py
@@ -349,12 +349,17 @@ class TestHasHeuristicBeatsOptimal:
 
     def test_detect_cell_stacks_with_row_n(self):
         # A cell can carry both a Row-N placeholder AND an impossible gap.
+        # The Row-N placeholder is the Pandas default-index signature of an
+        # unfilled dataframe (>= MIN_ROW_SEQUENCE consecutive integers, see
+        # #9935) -- a single isolated "Row 1" is LLM prose, not a placeholder.
         cell = code_cell(outputs=[
             text_output(
                 "CP-SAT optimal: 2 bins\n"
                 "FFD heuristic:  1 bins\n"
                 "Gap: -50.0%\n"
                 "Row 1   0.5\n"
+                "Row 2   0.3\n"
+                "Row 3   0.7\n"
             ),
         ])
         signals = {f["signal"] for f in detect_cell(cell)}


### PR DESCRIPTION
Grain: FIX/test (main-rouge urgent) — lane myia-po-2023:CoursIA-2 — prev: MED/content #9942 (OPEN)

# Fix : la fixture `test_detect_cell_stacks_with_row_n` doit porter ≥3 rows consécutives post-#9935 (main-rouge)

Quoi: PR #9935 a durci `_has_row_n` pour exiger **≥ MIN_ROW_SEQUENCE (3) entiers consécutifs** (signature index par défaut Pandas d'un dataframe non rempli), éliminant les FP LLM-prose (ex Sudoku-17 « Row 1 remaining »). Cela a cassé `test_detect_cell_stacks_with_row_n` (L362-368) dont la fixture n'avait qu'un seul « Row 1 » → `_has_row_n` False → le signal `row_n_placeholder` n'était jamais émis. **Main-rouge depuis #9935** (commit `98f8d3d4f`) : 4+ PRs héritent du FAIL CI silencieusement.

Fix (scope per #9947 §« Fix proposé ») : la fixture porte désormais Row 1/2/3 (entiers consécutifs = exactement la signature index Pandas que #9935 défend — un « Row 1 » isolé est de la prose LLM, pas un placeholder). 3 lignes de commentaire documentent le rationnel pour éviter qu'un futur durcissement ne recasse le test.

Preuve:
- **Reproduit firsthand** sur `origin/main 190eded70` avant de fixer : `pytest ...::test_detect_cell_stacks_with_row_n` → FAILED (`assert 'row_n_placeholder' in {'heuristic_beats_optimal'}`).
- **Post-fix** : le test précédemment failing → PASS ; fichier complet **61 passed, 0 failed** (0 régression).
- `git diff --stat` : 1 fichier, +5 (2 lignes Row + 3 lignes commentaire). Fixtures-only, aucun code source touché.

Périmètre: 1 fichier test, +5 lignes. Aucun notebook, aucun catalogue (byte-identique à main). Base fraîche `origin/main 190eded70`.

## Contexte coordination

@po-2025 avait [CLAIMED] #9947 à 22:41Z (c.1292) mais aucune PR n'a suivi en ~2.5h (collision-guard `--search cell_stacks/9947` = vide) sur un main-rouge urgent bloquant la flotte. Takeover per G.7 (stagnation = escalade) — si po-2025 a du WIP, le coordinateur réconcilie (1 canonique, l'autre disposée).

Closes #9947 (fixe entièrement le test cassé + débloque le main-rouge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
