### PR TITLE
fix(hooks): strip hooks accept multiple staged notebooks (pre-commit >=2-file failure)

### DIFF
--- a/scripts/notebook_tools/strip_machine_paths.py
+++ b/scripts/notebook_tools/strip_machine_paths.py
@@ -751,8 +751,10 @@ def main():
                        help="dry-run scan a file or dir; list leak outputs")
     group.add_argument("--scan-all", action="store_true",
                        help="dry-run scan repo-wide")
-    group.add_argument("--apply", metavar="PATH",
-                       help="fix a file in place (strip leaks)")
+    group.add_argument("--apply", metavar="PATH", nargs="+",
+                       help="fix file(s) in place (strip leaks); accepts one or more "
+                            "paths so the pre-commit hook (which appends every staged "
+                            ".ipynb) does not hit argparse on >=2 files")
     group.add_argument("--apply-all", action="store_true",
                        help="fix repo-wide in place")
     parser.add_argument("--check", action="store_true",
@@ -773,17 +775,22 @@ def main():
     nb_root = os.path.join(repo_root, "MyIA.AI.Notebooks")
 
     do_apply = args.apply is not None or args.apply_all
-    target = args.apply if args.apply else (args.scan if args.scan else nb_root)
 
     paths = []
     if args.scan_all or args.apply_all:
         paths = list(iter_notebooks(nb_root))
-    elif os.path.isdir(target):
-        paths = list(iter_notebooks(target))
-    elif os.path.isfile(target):
-        paths = [target]
     else:
-        parser.error("path not found: %s" % target)
+        # --apply is nargs="+" (a list; a pre-commit hook appends the staged
+        # notebooks here). --scan is a single path. Default to the notebook root.
+        targets = args.apply if args.apply else ([args.scan] if args.scan else [nb_root])
+        for target in targets:
+            if os.path.isdir(target):
+                paths.extend(iter_notebooks(target))
+            elif os.path.isfile(target):
+                paths.append(target)
+            else:
+                parser.error("path not found: %s" % target)
+        paths = list(dict.fromkeys(paths))  # de-dup while preserving order
 
     total_files = 0
     total_found = 0

--- a/scripts/notebook_tools/strip_probe_banner.py
+++ b/scripts/notebook_tools/strip_probe_banner.py
@@ -416,8 +416,10 @@ def main():
                        help="dry-run scan a file or dir; list banner outputs")
     group.add_argument("--scan-all", action="store_true",
                        help="dry-run scan repo-wide")
-    group.add_argument("--apply", metavar="PATH",
-                       help="fix a file in place (strip banners)")
+    group.add_argument("--apply", metavar="PATH", nargs="+",
+                       help="fix file(s) in place (strip banners); accepts one or "
+                            "more paths so the pre-commit hook (which appends every "
+                            "staged .ipynb) does not hit argparse on >=2 files")
     group.add_argument("--apply-all", action="store_true",
                        help="fix repo-wide in place")
     parser.add_argument("--check", action="store_true",
@@ -432,17 +434,22 @@ def main():
     nb_root = os.path.join(repo_root, "MyIA.AI.Notebooks")
 
     do_apply = args.apply is not None or args.apply_all
-    target = args.apply if args.apply else (args.scan if args.scan else nb_root)
 
     paths = []
     if args.scan_all or args.apply_all:
         paths = list(iter_notebooks(nb_root))
-    elif os.path.isdir(target):
-        paths = list(iter_notebooks(target))
-    elif os.path.isfile(target):
-        paths = [target]
     else:
-        parser.error("path not found: %s" % target)
+        # --apply is nargs="+" (a list; a pre-commit hook appends the staged
+        # notebooks here). --scan is a single path. Default to the notebook root.
+        targets = args.apply if args.apply else ([args.scan] if args.scan else [nb_root])
+        for target in targets:
+            if os.path.isdir(target):
+                paths.extend(iter_notebooks(target))
+            elif os.path.isfile(target):
+                paths.append(target)
+            else:
+                parser.error("path not found: %s" % target)
+        paths = list(dict.fromkeys(paths))  # de-dup while preserving order
 
     if args.exclude_submodules:
         subs = submodule_dirs(repo_root)


### PR DESCRIPTION
## What

Fixes the two strip hooks that crashed pre-commit on any commit touching >=2 staged `.ipynb` files. Flagged by po-2024 (c.XXIII dashboard) as a separate infra subject; no prior issue (distinct from #9888 hooks-inert, already fixed).

## The defect (root cause, proven firsthand)

`strip-probeaddresses-banner` and `strip-dotnet-nuget-ext` declared `--apply` with a **single-PATH metavar** while `pass_filenames: true`. pre-commit appends **every** staged `.ipynb` to a single hook invocation, so a commit touching >=2 notebooks produced:

```
strip_probe_banner.py: error: unrecognized arguments: <second notebook>
```

Workers worked around it by committing one notebook at a time. The sibling `scrub-papermill-paths` hook was already correct (its `--apply` uses `nargs="+"`).

## Fix

Mirror the proven `scrub-papermill-paths` pattern in the two broken scripts:
- `--apply` now takes `nargs="+"` (a list).
- `main()` loops over the targets (dir → `iter_notebooks`, file → append, else `parser.error`), then de-dups.

No change to the strip logic itself (`strip_banner_in_place`, `count_banner_lines`, machine-path scrub) — only the path-collection in `main()`. `--scan` stays single-PATH (CLI single-file scan unchanged).

## Closed-loop proof (real pre-commit 4.6.1 harness, installed per Rule F)

**BEFORE the fix** — `pre-commit run strip-probeaddresses-banner --files nb1 nb2`:
```
Failed - hook id: strip-probeaddresses-banner - exit code: 2
strip_probe_banner.py: error: unrecognized arguments: <nb2>
```
Same for `strip-dotnet-nuget-ext` (exit 1). Control: `scrub-papermill-paths` on the same 2 files → **Passed** (already correct).

**AFTER the fix** — same command on the same 2 files:
- `strip-probeaddresses-banner` → **Passed (exit 0)**
- `strip-dotnet-nuget-ext` → **Passed (exit 0)**

**Functional strip test** (synthetic notebook with a real probeAddresses banner, 2-file batch): `--apply a.ipynb b.ipynb` → "apply summary: 2 notebook(s) carrying 2 banner line(s), fixed: 2"; rescan → 0 banners. The multi-path loop feeds the strip logic correctly.

**No regression**: single-file run → Passed; `--scan <path>` CLI → works.

## Scope

2 files, +30/-16 (additive-dominant; only the path-collection block in `main()` of each script, mirrored from the existing correct sibling). No `.pre-commit-config.yaml` change, no hook added/removed (hooks-parity unaffected). Rule F honored (pre-commit installed locally to run the closed-loop proof, not bypassed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
