### PR TITLE
fix(sudoku-18,#8052): prose '10 puzzles chacun' vs Expert:1 (D5 twin fix)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
@@ -1121,7 +1121,7 @@
    "source": [
     "## 4. Benchmark\n",
     "\n",
-    "Nous testons les 4 solveurs sur **4 niveaux de difficulte** avec 10 puzzles chacun. Tous les puzzles sont codes en dur ci-dessous pour garantir la reproductibilite (pas de dépendance a des fichiers externes).\n",
+    "Nous testons les 4 solveurs sur **4 niveaux de difficulte** : 10 puzzles pour Easy/Medium/Hard, et 1 puzzle Expert (regime 17-24 indices, ou un seul suffit a illustrer les timeout). Tous les puzzles sont codes en dur ci-dessous pour garantir la reproductibilite (pas de dépendance a des fichiers externes).\n",
     "\n",
     "### Jeux de test\n",
     "\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
@@ -1240,7 +1240,7 @@
    "source": [
     "## 4. Benchmark\n",
     "\n",
-    "Nous testons les 4 solveurs sur **4 niveaux de difficulté** avec 10 puzzles chacun. Tous les puzzles sont codes en dur ci-dessous pour garantir la reproductibilite (pas de dépendance a des fichiers externes).\n",
+    "Nous testons les 4 solveurs sur **4 niveaux de difficulté** : 10 puzzles pour Easy/Medium/Hard, et 1 puzzle Expert (régime 17-24 indices, où un seul suffit à illustrer les timeout). Tous les puzzles sont codes en dur ci-dessous pour garantir la reproductibilite (pas de dépendance a des fichiers externes).\n",
     "\n",
     "### Jeux de test\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-18-comparison.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-18-comparison.yaml
@@ -22,6 +22,12 @@
       csharp_sha: c56831ed09f83e2780d74f265412674b12861dad
       content_python_sha: 089d67e706104ba025aab3198eea12853ee328a341ef3285c384c8ab700c2ee6
       content_csharp_sha: faf8913e82d7880e76d8b9c5f2912e634d7fedca50f1e60f89a6f7e158621915
+    - date: "2026-08-08"
+      by: myia-po-2025:CoursIA
+      python_sha: 8421084259817fa3e8e31689e17c48f63a2ded8d
+      csharp_sha: e2930154a7fb9e89d03a184fff98e21de29cf10b
+      content_python_sha: 5ddf99abf166728218bc7125d2e01782b0d0b2484713c0e2c408b8e7abcda38b
+      content_csharp_sha: aefc3116c2efdf15ea3f514fbbb477e9a183b798257d67ca245796631fb0b496
   known_differences:
     - "Rebaseline 2026-08-05 : cote Python deplace par de-hardcodage de la version numpy depuis le markdown (classe ENV #9434, edition markdown-only). Parite semantique inchangee (aucune cellule code, aucune sortie, aucun exec_count touche) ; cote C# non modifie. Attestation = nouveau blob SHA du cote Python."
     - "Socle pedagogique commun : comparaison synthese de TOUS les solveurs de la serie Sudoku (backtracking, dancing links, genetic, OR-Tools, Z3, BDD, probabiliste), meme concept (tableau de benchmark croise : temps de resolution / robustesse / complexite), meme arc conclusif (Fin de serie)."


### PR DESCRIPTION
Grain: MED/notebook-correctness — lane myia-po-2025:CoursIA — prev: MED/ci-fix (#9949)

## Bug D5 trouvé via le détecteur v3 (Sudoku-18-Comparison, twin Python+C#)

`cell[24]` des **deux** jumeaux Sudoku-18-Comparison affirmait :

> Nous testons les 4 solveurs sur **4 niveaux de difficulté** avec **10 puzzles chacun**.

Mais `cell[25]` output montre (vérifié firsthand, Python ET C#) :

```
Easy:   10 puzzles
Medium: 10 puzzles
Hard:   10 puzzles
Expert: 1 puzzles     <-- la prose ment
```

Le niveau Expert a **1 puzzle**, pas 10. C'est une dérive D5 authentique (prose↔outputs intra-révision) — exactement la classe `MISSING_FROM_PROSE_ENUMERATION` du détecteur v3 (#9793/#9790), celle qui attrape le cas fondateur #9416.

## Méthode (firsthand, G.1)

- Lancé `scan_d5_prose_outputs_alignment.py --root Sudoku` (mon instrument, #9790). 318 findings bruts, dont 16 `MISSING_FROM_PROSE_ENUMERATION` — classe documentée haute-FP.
- **Pas de confiance aveugle dans le détecteur** : les findings étaient majoritairement des FPs (numéros de section `## 4. Benchmark` parsés comme nombres de prose). Vérification **manuelle** cell-par-cell pour distinguer le signal réel du bruit.
- Le bug "10 puzzles chacun vs Expert:1" est sorti : non-ambigu (l'output compte `Expert: 1 puzzles`), vérifié sur les deux jumeaux.
- Le tableau "Nombre de cases vides" (cell[24]) montre aussi un écart (Easy prose ~35-45 vs output 45-57), mais il est **ambigu** (définition générale de la difficulté vs stats des puzzles chargés) → **non touché** (G.9 : puis-je avoir tort ? oui, c'est peut-être une définition de tier, pas un mismatch).

## Fix (markdown-only, C.2 exception)

Prose corrigée dans les **deux** jumeaux, en respectant le style d'accents de chacun :

- **Python** (accents préservés) : « 10 puzzles pour Easy/Medium/Hard, et 1 puzzle Expert (régime 17-24 indices, où un seul suffit à illustrer les timeout) »
- **C#** (style sans accents) : « 10 puzzles pour Easy/Medium/Hard, et 1 puzzle Expert (regime 17-24 indices, ou un seul suffit a illustrer les timeout) »

**Output inchangé** (déjà correct) → exception C.2 markdown-only, **pas de re-exécution** (re-exécuter risquerait du drift output, leçon reexec-multiple-runs).

## Twin parity (leçons #9926/#9930)

Sudoku-18 est une paire jumelle enregistrée (`sudoku-18-comparison.yaml`). Edit des deux notebooks → rebaseline obligatoire :

```
check_twin_parity.py --pair "Sudoku-18 Comparison" --update --by "myia-po-2025:CoursIA"
# 1 paire mise à jour, nouvel audit entry appendé
```

Vérifié : `[OK] Sudoku-18 Comparison`, registre OK=157 DRIFT=0.

## Preuves

- Diff : 3 fichiers (2 notebooks + 1 yaml), +8/-2 (chirurgical, 1 ligne prose par notebook + 6 lignes audit).
- `nbformat.validate()` OK sur les deux.
- Twin check firsthand : OK=157 DRIFT=0.
- Sortie cell[25] (preuve output non-touché) : `Expert: 1 puzzles` inchangé.

See #9790 (détecteur v3 D5), #8052 (audit claims↔outputs), EPIC #9768.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
