### PR TITLE
docs(rules,#9434): codify data-unit TN class in C.5 quantitative line-of-parting (acceptance item 4)

### DIFF
--- a/.claude/rules/notebook-conventions.md
+++ b/.claude/rules/notebook-conventions.md
@@ -101,10 +101,13 @@ Ré-aligner sans diagnostic = consacrer la dégénérescence : le notebook re-d�
 |--------|---------|----------|
 | **Structurel** | `2^225` combinaisons → speedup `~2.8e24x` ; nombre de contraintes ; complexité | **GARDER** — stable d'une machine à l'autre, c'est du contenu pédagogique réel |
 | **Machine-dépendant** | temps absolus (`~21 s`, `24-127 ms`) | **RETIRER** — renvoi à la cellule de mesure ; si le coût relatif porte le propos, l'écrire en **rapport** (cf ci-dessous) |
+| **Donnée en unité de temps (data-unit)** | moyenne de trajet `15.33 min` (Infer-101) ; durée de contenu `30 sec` ; estimation pédagogique `Durée : ~2 h` | **GARDER** — c'est une *donnée* déterministe (statistique, longueur de contenu, estimation humaine), pas un runtime ; ne dérive pas à la re-exécution |
 | **Env-dépendant (observé)** | table de versions `NumPy 2.4.2` écrite à la main | **RETIRER** quand une cellule imprime déjà la version (source unique = l'output) |
 | **Env-dépendant (exigé)** | `Python 3.10+`, `.NET 9.0` | **GARDER** — c'est une **décision de projet**, pas une observation ; ne dérive pas |
 | **Stochastique seedé** | fitness d'un GA à `seed=42` | **GARDER** — reproductible, donc stable |
 | **Stochastique non seedé** | utilité CFR après une itération unique | **RETIRER** ou **seeder** — jamais citer une valeur d'instance |
+
+**La frontière est la machine-dépendance, pas « nombre + unité »** (arbitrage #9434, 2026-08-06). Une valeur en `ms`/`sec`/`min` n'est pas toujours un runtime à retirer : la classe **Donnée en unité de temps** regroupe les valeurs qui portent une unité de temps mais qui sont **déterministes** — moyenne statistique de données (postérieur bayésien, moyenne de trajets), longueur d'un contenu (durée d'un clip), estimation pédagogique humaine (`Durée estimée`). Elles ne dérivent ni avec la machine ni au re-run ; les retirer détruit du contenu pédagogique réel. Le critère discriminateur : *« cette valeur changerait-elle si je ré-exécutais le notebook sur une autre machine ? »* — non pour un data-unit, oui pour un runtime. C'est cette frontière (et non la présence d'une unité de temps) que le classifieur [`scan_quant_classify.py`](../../scripts/notebook_tools/scan_quant_classify.py) + son [golden set](../../scripts/tests/golden_quantitative_claims.json) instrumentent.
 
 ### L'arbitrage §D.5 ↔ #9377 : retirer gagne
 
@@ -133,5 +136,5 @@ La prose honnête dit ce qui est réellement vrai : la valeur théorique **et** 
 
 Une seule question sur la prose modifiée : **cite-t-elle encore un nombre qui rebougera au prochain passage kernel ?** Si oui, la PR ré-épingle et §D.5 s'applique dans toute sa rigueur (re-exécution fraîche exigée). Si non, la boucle est fermée.
 
-See #9377, #8052.
+See #9377, #8052, #9434.
 


### PR DESCRIPTION
Grain: MED/rule — lane myia-po-2023:CoursIA-2 — prev: LIGHT/cleanup #9944

# Fix : la règle C.5 confondait "runtime" et "donnée en unité de temps" — codification de l'arbitrage #9434 (data-unit TN)

Quoi: Rule C.5 ([notebook-conventions.md](.claude/rules/notebook-conventions.md) §C.5 « Valeurs quantitatives en prose ») regroupait **toutes** les valeurs en unité de temps sous « Machine-dépendant = RETIRER ». L'arbitrage #9434 (ai-01, 2026-08-06 + corollaire po-2023) a créé une classe TN pour les **data-units** : valeurs en `ms`/`sec`/`min` qui sont **déterministes** (statistique de données, longueur de contenu, estimation pédagogique), pas des runtimes. Le golden set les codifie déjà (cas `m9` Infer-101 « 15.33 min » trajet, `m10` « 30 sec » clip) ; **la règle qui gouverne les futures PR #8052 ne les mentionnait pas** → un worker lisant C.5 aurait retiré la moyenne de trajet Infer-101 (faux — c'est une donnée, pas un runtime).

Fix : ajout d'une ligne **« Donnée en unité de temps (data-unit) » = GARDER** au tableau C.5 + le paragraphe discriminateur (« la frontière est la machine-dépendance, pas nombre+unité ») avec la question-test (« cette valeur changerait-elle si je ré-exécutais sur une autre machine ? ») + pointeur vers le classifieur instrumenté `scan_quant_classify.py` et son golden set.

Preuve:
- Gap vérifié firsthand : `grep` sur `notebook-conventions.md` → C.5 citait `~21 s`, `24-127 ms` (runtime = RETIRER) mais **0 mention** du cas data-unit / Durée-estimée / posterior-déterministe avant ce fix.
- Arbitrage source : commentaire #9434 (ai-01 2026-08-06) « le classifieur #9476 + golden set doivent classer Durée estimée + unités-données en TN » + corollaire po-2023 « postérieurs bayésiens en minutes (Infer-101) = données pédagogiques déterministes, PAS des runtimes → à garder ».
- Audit des drains merged (task a, même dispatch) : tous (#9426/#9427/#9428/#9497/#9507/#9574/#9684/#9685/#9716) n'ont retiré que des runtimes machine-dépendants, en préservant speedups structurels + Durée-estimée — **0 over-removal** → pas de PR de restauration. Les 7 PR fermées sans merge (#9668, #9673, #9674, #9698, #9701, #9705, #9712) ont correctement attrapé les over-removals Durée-estimée **avant** merge.
- Diff minimal : 1 fichier, +4/-1 (1 ligne de table + 1 paragraphe + 1 ref See-also). Zéro cellule notebook touchée, zéro catalogue touché.

Périmètre: 1 fichier, +4/-1. `.claude/rules/notebook-conventions.md` §C.5 uniquement. Acceptance item 4 de #9434 (« Une note dans notebook-conventions.md énonce la ligne de partage »). Transcription d'un arbitrage déjà décidé (ai-01 + mandat user Beausoleil) — pas une décision nouvelle.

## [ASK USER] — sign-off wording (règle §A)

C'est un changement de **règle** auto-loaded (modifie le comportement des futurs cycles #8052). L'acceptance item 4 exige « PR + sign-off user (cf règle §A) ». Le **contenu** (4 classes + data-unit TN) est déjà décidé par l'arbitrage ; le sign-off porte sur la **formulation**. @jsboige : la formulation de la ligne data-unit + du paragraphe frontière te va ? Si oui, mergeable ; si tu veux reformuler, amend.

See #9434 (acceptance item 4 + audit task a verdict). Pas `Closes` : l'epic se ferme sur commentaire de statut final ai-01 après constat que task a (audit = clean) + task b (golden set, déjà fait m9/m10) + item 4 (cette PR) sont tous satisfaits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
