### PR TITLE
docs(sudoku,#3975,#9805): reconcile Sudoku feuille README + index.qmd post-18b

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -7,19 +7,19 @@ breakdown: root=37
 maturity: BETA=37
 -->
 
-> **Note éditoriale (counts)** : Le marqueur `CATALOG-STATUS` ci-dessus est autoritatif pour le compte agrégé (36 notebooks canoniques). Pour la **décomposition langagière par kernel** (`metadata.kernelspec.language`), ce README reste autoritatif car la granularité kernel n'est pas dans le marqueur agrégé ; elle est documentée ici par lecture directe des kernelspecs au 10/07/2026 :
+> **Note éditoriale (counts)** : Le marqueur `CATALOG-STATUS` ci-dessus est autoritatif pour le compte agrégé (37 notebooks canoniques). Pour la **décomposition langagière par kernel** (`metadata.kernelspec.language`), ce README reste autoritatif car la granularité kernel n'est pas dans le marqueur agrégé ; elle est documentée ici par lecture directe des kernelspecs au 08/08/2026 :
 >
-> **17 C# + 18 Python + 1 Lean 4 = 36 notebooks canoniques ✓** (36 fichiers `*.ipynb` canoniques au total dans le dépôt — les artefacts Papermill `_output.ipynb` sont gitignored, locaux à la machine d'exécution et non commités).
+> **17 C# + 19 Python + 1 Lean 4 = 37 notebooks canoniques ✓** (37 fichiers `*.ipynb` canoniques au total dans le dépôt — les artefacts Papermill `_output.ipynb` sont gitignored, locaux à la machine d'exécution et non commités).
 >
 > Sudoku est un cas de **mixité JUMEAUX C#/Python dominante** (14 paires strictes 1-14 + 1 paradigme-comparable 15 Infer.NET/NumPyro + 1 benchmark 18, soit 16 entrées à 2 langages) avec **1 companion Lean natif intra-hub** (`Sudoku-19-Lean-Propagation.ipynb`, lake `sudoku_lean` 0-sorry). C'est une **variante L392 #4** : contrairement à QC (#5917) où Lean est isolé dans une sous-série dédiée `kelly_lean/`, et contrairement à ML (#5915) / Probas (#5916) où la mixité kernel est intra-série, ici la mixité jumeaux domine largement et le notebook tiers (Lean) est intra-hub sans sous-série dédiée.
 >
-> Les counts obsolètes `16 notebooks Python` (L605) et `16 solveurs` (L770) ont été réconciliés sur la valeur disk-truth de **18 notebooks Python canoniques** dans cette PR.
+> Les counts obsolètes `16 notebooks Python` (L605) et `16 solveurs` (L770) ont été réconciliés sur la valeur disk-truth de **19 notebooks Python canoniques** dans cette PR.
 >
 > **Régénération du marqueur** : `catalog-cron.yml` (cron quotidien 03:37 UTC sur `main`, commit `[skip ci]` par `github-actions[bot]`) — le bloc ci-dessus est régénéré automatiquement, ne pas le modifier manuellement sur une branche feature (catalog-pr-hygiene R1).
 
 [← Notebooks](../README.md) | [→ Search](../Search/README.md)
 
-Comment résoudre un Sudoku ? Cette série explore les techniques de résolution, des algorithmes classiques (backtracking, contraintes) aux approches symboliques, probabilistes et neuronales. La série couvre **16 paires miroir C#/Python** (notebooks 1 à 15 et le benchmark comparatif 18 — mêmes algorithmes dans les deux langages), **1 notebook C# uniquement** (0-Environment, classes de base), **2 notebooks Python uniquement** (16-NeuralNetwork, 17-LLM) et **1 companion Lean natif** ([Sudoku-19](Sudoku-19-Lean-Propagation.ipynb), preuve formelle de la propagation de contraintes). Cette structure laisse à chaque étudiant le choix de son langage sur la quasi-totalité des algorithmes.
+Comment résoudre un Sudoku ? Cette série explore les techniques de résolution, des algorithmes classiques (backtracking, contraintes) aux approches symboliques, probabilistes et neuronales. La série couvre **16 paires miroir C#/Python** (notebooks 1 à 15 et le benchmark comparatif 18 — mêmes algorithmes dans les deux langages), **1 notebook C# uniquement** (0-Environment, classes de base), **3 notebooks Python uniquement** (16-NeuralNetwork, 17-LLM, 18b-Statistical-Comparison) et **1 companion Lean natif** ([Sudoku-19](Sudoku-19-Lean-Propagation.ipynb), preuve formelle de la propagation de contraintes). Cette structure laisse à chaque étudiant le choix de son langage sur la quasi-totalité des algorithmes.
 
 **À qui s'adresse cette série** : étudiants en informatique (L2-M2) découvrant les paradigmes algorithmiques, candidats à des entretiens techniques, et enseignants cherchant un fil rouge pédagogique. Les notebooks Python ne nécessitent que Python 3.10+. Les notebooks C# requièrent .NET 9.0 + dotnet-interactive. Aucun prérequis en IA : les concepts sont introduits depuis le backtracking.
 
@@ -328,7 +328,7 @@ Les solveurs CP et SMT modernes ne se limitent pas à **trouver une solution fai
 - **[#7589](https://github.com/jsboige/CoursIA/issues/7589) `feat(sudoku,#3801): demonstrate Z3 SMT optimization (Optimize/maximize)` — `Sudoku-12-Z3-Python.ipynb`** : ajoute la contrepartie SMT avec `Optimize()` + `maximize(...)` (MaxSMT). Cohérence cross-moteur vérifiée : la même instance de carré latin 5×5 pondéré donne une récompense optimale identique (178) entre CP-SAT et Z3, ce qui valide la transcription entre paradigmes.
 - **[#7622](https://github.com/jsboige/CoursIA/pull/7622) `feat(sudoku,#7589): Z3 SMT optimization (Optimize/MkMaximize) port to C# twin — `Sudoku-12-Z3-Csharp.ipynb`** : port C# du même exemple côté `Microsoft.Z3` (`Context.MkOptimize()` + `MkMaximize(rewardTotal)`), `SATISFIABLE (optimum)` avec récompense 192 (variante du problème, source C# identique au twin Python modulo API binding). Reviewer structural (`NanoClaw`) : LGTM, 19/19 cellules exécutées, latin-square vérifié à la main colonne par colonne.
 
-**Pourquoi cette section manquait avant** : EPIC [#3801](https://github.com/jsboige/CoursIA/issues/3801) Prong-B (« problème non-trivial qui met le moteur en valeur ») a diagnostiqué que — **sur l'ensemble de la série (36 notebooks canoniques : 17 C# + 18 Python + 1 Lean, cf CATALOG-STATUS) [G.1 vérifié 2026-07-22]** — les solveurs CP/SMT étaient présentés uniquement en mode satisfaction (`Solver.check()` / `cp_model.Add(...)`), sans jamais exercer leur capacité d'optimisation — alors que c'est précisément ce qui distingue OR-Tools et Z3 d'un simple solveur SAT dans la pratique industrielle (MaxSMT, configuration sous contraintes, allocation). Les trois PRs ci-dessus rééquilibrent ce curseur pour le Sudoku.
+**Pourquoi cette section manquait avant** : EPIC [#3801](https://github.com/jsboige/CoursIA/issues/3801) Prong-B (« problème non-trivial qui met le moteur en valeur ») a diagnostiqué que — **sur l'ensemble de la série (37 notebooks canoniques : 17 C# + 19 Python + 1 Lean, cf CATALOG-STATUS) [G.1 vérifié 2026-08-08]** — les solveurs CP/SMT étaient présentés uniquement en mode satisfaction (`Solver.check()` / `cp_model.Add(...)`), sans jamais exercer leur capacité d'optimisation — alors que c'est précisément ce qui distingue OR-Tools et Z3 d'un simple solveur SAT dans la pratique industrielle (MaxSMT, configuration sous contraintes, allocation). Les trois PRs ci-dessus rééquilibrent ce curseur pour le Sudoku.
 
 **À retenir** :
 - Un solveur CP/SMT qui répond `FEASIBLE` / `SAT` ne donne qu'un point dans l'espace des solutions ; `OPTIMAL` / `SATISFIABLE (optimum)` prouve qu'aucune meilleure solution n'existe pour le critère.
@@ -394,6 +394,7 @@ Chaque notebook introduit une technique de résolution spécifique. Le tableau c
 | 16 | Neural Network | CNN PyTorch : apprentissage de patterns visuels sur grilles |
 | 17 | LLM | LLM Solver : prompt engineering pour résolution logique, limites |
 | 18 | Comparison | Benchmark comparatif : toutes les approches sur Easy/Medium/Hard/Expert |
+| 18b | [Sudoku-18b-Statistical-Comparison](Sudoku-18b-Statistical-Comparison-Python.ipynb) | **Companion statistique** (Python uniquement) : méthodologie formelle pour les benchmarks solveurs — variance inter-puzzles, IC bootstrap 95%, Mann-Whitney U, taille d'effet (rank-biserial), correction de Bonferroni. Ajouté en [#9805](https://github.com/jsboige/CoursIA/pull/9805) pour combler le gap méthodologique de Sudoku-18 (qui utilise « significatif » au sens courant, pas statistique). |
 | 19 | [Sudoku-19-Lean-Propagation](Sudoku-19-Lean-Propagation.ipynb) | **Companion natif** (kernel Lean) : preuve formelle 0-sorry de la soundness de la propagation (naked/hidden single, clé de voûte `peer_excludes_value`) dans le lake `sudoku_lean`, `#check` + `#print axioms` in-kernel — voir [#4055](https://github.com/jsboige/CoursIA/issues/4055) (création du lake) et `LEAN_INVENTORY.md` du dossier |
 
 ---
@@ -627,7 +628,7 @@ Sudoku/
 ├── README.md                              # Ce fichier
 ├── LEAN_INVENTORY.md                      # Inventaire transverse des lakes Lean de la série
 ├── index.qmd                              # Listing Quarto (sous-ensembles C# / Python)
-├── requirements.txt                       # Dépendances Python (18 notebooks Python canoniques, dont 16 paires miroir C#/Python + 2 only-Python : NN 16 + LLM 17)
+├── requirements.txt                       # Dépendances Python (19 notebooks Python canoniques, dont 16 paires miroir C#/Python + 3 only-Python : NN 16 + LLM 17 + Statistical-Comparison 18b)
 ├── choco-solver-4.10.17-jar-with-dependencies.jar  # JAR Choco (utilisé par nb-11 Python via JPype)
 ├── org.chocosolver.solver.dll             # DLL Choco précompilée (utilisée par nb-11 C# via IKVM)
 ├── Sudoku-0-Environment-Csharp.ipynb      # Classes de base C#
@@ -665,6 +666,7 @@ Sudoku/
 ├── Sudoku-17-LLM-Python.ipynb             # LLM Solver Python
 ├── Sudoku-18-Comparison-Csharp.ipynb      # Benchmark comparatif C#
 ├── Sudoku-18-Comparison-Python.ipynb      # Benchmark comparatif Python
+├── Sudoku-18b-Statistical-Comparison-Python.ipynb  # Companion statistique Python (variance, bootstrap, Mann-Whitney) — méthodologie formelle pour les benchmarks
 ├── Sudoku-19-Lean-Propagation.ipynb       # Companion Lean natif (preuve de soundness)
 ├── Puzzles/                               # Fichiers de puzzles
 │   ├── Sudoku_Easy51.txt
@@ -788,7 +790,7 @@ Commencez par **Sudoku-0 (Environment)** pour comprendre les structures de donn�
 
 ### Si vous voulez comparer les paradigmes
 
-Suivez l'ordre numérique : 0-5 (exhaustif et métaheuristiques), puis 6-12 (CSP et symbolique), puis 13-15 (automates symboliques, BDD, inférence probabiliste), puis 16-18 (data-driven). Le notebook **18 (Comparison)** synthétise toutes les approches en un benchmark comparatif.
+Suivez l'ordre numérique : 0-5 (exhaustif et métaheuristiques), puis 6-12 (CSP et symbolique), puis 13-15 (automates symboliques, BDD, inférence probabiliste), puis 16-18 (data-driven). Le notebook **18 (Comparison)** synthétise toutes les approches en un benchmark comparatif ; **18b (Statistical-Comparison)** formalise la méthodologie statistique de ce benchmark.
 
 ### Si vous venez du C# / .NET
 
@@ -796,7 +798,7 @@ Les notebooks C# (suffixe `-Csharp`) utilisent GeneticSharp, OR-Tools .NET, Z3 .
 
 ### Si vous venez du Python / data science
 
-Les notebooks Python (suffixe `-Python`) couvrent 18 solveurs avec PyGAD, OR-Tools Python, Z3 Python, NumPyro et PyTorch. Commencez par **Sudoku-1-Backtracking-Python**, puis montez en complexité. Le notebook **18-Comparison-Python** synthétise tout.
+Les notebooks Python (suffixe `-Python`) couvrent 19 solveurs avec PyGAD, OR-Tools Python, Z3 Python, NumPyro et PyTorch. Commencez par **Sudoku-1-Backtracking-Python**, puis montez en complexité. Le notebook **18-Comparison-Python** synthétise les solveurs ; **18b-Statistical-Comparison-Python** ajoute la méthodologie statistique formelle (variance, bootstrap, Mann-Whitney, Bonferroni).
 
 ## Conclusion / Prochaines étapes
 

--- a/MyIA.AI.Notebooks/Sudoku/index.qmd
+++ b/MyIA.AI.Notebooks/Sudoku/index.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Sudoku — Le laboratoire multi-paradigmes de résolution de contraintes"
-subtitle: "Série pédagogique — 19 approches du même problème, en C# .NET, Python et Lean 4"
+subtitle: "Série pédagogique — 19 approches + 1 companion statistique, en C# .NET, Python et Lean 4 (37 notebooks)"
 description: "La série Sudoku de CoursIA : un seul problème (la grille 9×9) résolu par 19 paradigmes complémentaires — backtracking, dancing links, métaheuristiques, CSP, solveurs (OR-Tools, Choco, Z3), automates symboliques, BDD, Infer.NET, réseaux de neurones, LLM, et une preuve Lean 4 de propagation. Dual-track C# .NET Interactive + Python."
 listing:
   - id: dotnet
@@ -16,14 +16,14 @@ listing:
 ---
 
 ::: {.series-banner}
-# Sudoku — Un problème, dix-neuf paradigmes
+# Sudoku — Un problème, dix-neuf paradigmes + un compagnon statistique
 
-**Le Sudoku comme fil rouge pédagogique.** La grille 9×9 est un écrin assez riche pour exercer chaque famille d'algorithmes d'IA, assez contraint pour que chaque solveur produise une solution, et assez emblématique pour qu'on reconnaisse immédiatement le problème. Cette série résout **le même Sudoku** par **19 approches complémentaires**, présentées en **double track C# .NET Interactive et Python**, jusqu'à une **preuve formelle Lean 4** de la propagation de contraintes.
+**Le Sudoku comme fil rouge pédagogique.** La grille 9×9 est un écrin assez riche pour exercer chaque famille d'algorithmes d'IA, assez contraint pour que chaque solveur produise une solution, et assez emblématique pour qu'on reconnaisse immédiatement le problème. Cette série résout **le même Sudoku** par **19 approches complémentaires** (16 paires miroir C#/Python + 1 NN + 1 LLM + 1 Lean) plus **un companion statistique** (Sudoku-18b, méthodologie formelle pour les benchmarks), présentés en **double track C# .NET Interactive et Python**, jusqu'à une **preuve formelle Lean 4** de la propagation de contraintes.
 :::
 
 ## Vue d'ensemble
 
-La série compte **33 notebooks** : 16 méthodes déclinées en C# .NET et Python (dual-track), plus `Sudoku-19` en Lean 4. Chaque notebook est exécuté et commité avec ses sorties (règle C.2), avec entrées/sorties réelles.
+La série compte **37 notebooks canoniques** : 16 méthodes déclinées en C# .NET et Python (dual-track, notebooks 1 à 15 et le benchmark 18), **1 notebook C# uniquement** (0-Environment), **3 notebooks Python uniquement** (16-NeuralNetwork, 17-LLM, 18b-Statistical-Comparison), et **`Sudoku-19` en Lean 4**. Chaque notebook est exécuté et commité avec ses sorties (règle C.2), avec entrées/sorties réelles.
 
 | Axe pédagogique | Numéros | Méthodes |
 |-----------------|---------|----------|
@@ -32,7 +32,7 @@ La série compte **33 notebooks** : 16 méthodes déclinées en C# .NET et Pytho
 | **CSP classique** | 6–9 | AIMA-CSP (backtracking + AC3), Norvig, Stratégies humaines, Coloration de graphe |
 | **Solveurs déclaratifs** | 10–15 | OR-Tools, Choco, Z3 (SMT), Automates symboliques, BDD, Infer.NET (probabiliste) |
 | **Apprentissage** | 16–17 | Réseau de neurones (solveur appris), LLM (prompting) |
-| **Synthèse & preuve** | 18–19 | Comparaison cross-moteurs, Propagation Lean 4 (prouvée) |
+| **Synthèse & preuve** | 18–19 | Comparaison cross-moteurs, Companion statistique (18b, variance/IC/Mann-Whitney), Propagation Lean 4 (prouvée) |
 
 **Kernels** : `.net-csharp` (track C#) · `python3` (track Python) · `lean4-wsl` (Sudoku-19) · **GPU** : non · **Prérequis** : la série Search (algorithmes de recherche) aide, mais le Sudoku-0 remet tout à plat.
 
@@ -79,7 +79,7 @@ jupyter kernelspec list             # vérifier la présence de .net-csharp
 
 ## Pour aller plus loin
 
-Une fois les 19 approches comparées, les prolongements naturels sont :
+Une fois les 19 approches comparées (et la méthodologie statistique de 18b acquise), les prolongements naturels sont :
 
 1. **Vers la preuve formelle** : Sudoku-19 (Lean 4) ouvre la série SymbolicAI/Lean — la propagation devient un théorème.
 2. **Vers les solveurs SMT** : [SMT/Z3 (README)](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/README.md) — Z3, le moteur du Sudoku-12, appliqué à l'ordonnancement, la cryptarithmétique, les bit-vectors.


### PR DESCRIPTION
## Sweep-ready — PR docs Sudoku feuille README + index.qmd post-#9805 reconcile (c.1294)

Grain: MED/readme — lane myia-po-2025:CoursIA-2 — prev: DEEP/tooling #9943

### Diagnostic G.1

Sudoku feuille README + index.qmd had stale counts based on pre-#9805 state (`36 = 17 C# + 18 Python + 1 Lean`). PR #9805 (lane `myia-po-2024:CoursIA`, MERGED 2026-08-07T05:10:01Z) added `Sudoku-18b-Statistical-Comparison-Python.ipynb` (Statistical Comparison companion to Sudoku-18) — bringing disk-truth to **37 = 17 C# + 19 Python + 1 Lean**.

Le `CATALOG-STATUS` marker était déjà correct (`pedagogical_count: 37`, auto-regénéré par `catalog-cron.yml`) MAIS la prose README n'avait pas suivi :

- L10 : "36 notebooks canoniques" → **37**
- L12 : "17 C# + 18 Python + 1 Lean 4 = 36" → **17 C# + 19 Python + 1 Lean 4 = 37**
- L16 : "18 notebooks Python canoniques" → **19**
- L22 : "2 notebooks Python uniquement (16-NN, 17-LLM)" → **3 notebooks Python uniquement (16-NN, 17-LLM, 18b-Statistical-Comparison)**
- L331 : "36 notebooks canoniques : 17 C# + 18 Python + 1 Lean" → **37 notebooks canoniques : 17 C# + 19 Python + 1 Lean** (+ G.1 verify-date 2026-07-22 → 2026-08-08)
- L397 : ajout nouvelle ligne `18b | Sudoku-18b-Statistical-Comparison | Companion statistique (Python uniquement)` dans la table principale
- L630 (requirements.txt comment) : "18 notebooks Python canoniques, dont 16 paires + 2 only-Python" → **19 notebooks Python canoniques, dont 16 paires + 3 only-Python (NN 16 + LLM 17 + Statistical-Comparison 18b)**
- L668 (tree) : insertion de `Sudoku-18b-Statistical-Comparison-Python.ipynb` entre `Sudoku-18-Comparison-Python.ipynb` et `Sudoku-19-Lean-Propagation.ipynb`
- L791 : "puis 16-18 (data-driven)" → ajout **18b (Statistical-Comparison)** dans la phrase de conclusion
- L799 : "18 solveurs" → **19 solveurs** + mention de 18b

Et `index.qmd` avait un count **encore plus ancien** (« 33 notebooks »), jamais réconcilié quand 16/17/18/18b ont été ajoutés :

- L3 subtitle : "19 approches" → **"19 approches + 1 companion statistique, en C# .NET, Python et Lean 4 (37 notebooks)"**
- L19 banner : "dix-neuf paradigmes" → **"dix-neuf paradigmes + un compagnon statistique"**
- L21 : "19 approches complémentaires" → **"19 approches complémentaires (...) plus un companion statistique"**
- L26 : "**33 notebooks**" → **"37 notebooks canoniques"**
- L35 : "Comparaison cross-moteurs, Propagation Lean 4 (prouvée)" → ajout **Companion statistique (18b)**
- L82 : "Une fois les 19 approches comparées" → "Une fois les 19 approches comparées (et la méthodologie statistique de 18b acquise)"

### Vérification G.1 disk-truth

```
$ python3 -c "..."
CS: 17, Python: 19, Lean: 1, Total: 37
```

17 paires miroir (1-15, 18) + 1 CS only (0-Environment) + 4 PY only (16-NN, 17-LLM, 18b-Statistical-Comparison, 19-Lean-Propagation) = 37.

### Substance LIVRÉE (2 fichiers)

**`MyIA.AI.Notebooks/Sudoku/README.md`** (+12/-8) :
- 7 réconciliations de count (36→37, 17+18+1→17+19+1, "18 notebooks Python"→19, "16 solveurs"→19, date stamp 10/07/2026→08/08/2026, G.1 verify-date 2026-07-22→2026-08-08)
- 1 ajout de row `18b` dans la table principale des notebooks
- 1 entrée tree (entre 18-Comparison-Python et 19-Lean-Propagation)
- 3 mentions 18b dans la prose (série overview, parcours "comparer paradigmes", parcours "Python")

**`MyIA.AI.Notebooks/Sudoku/index.qmd`** (+6/-6) :
- 5 réconciliations (subtitle, banner, vue d'ensemble 33→37, "Synthèse & preuve" col, "Pour aller plus loin")
- L26 "33 notebooks" était le count le plus ancien (avant que 16/17/18/18b soient ajoutés)

**Diff net vs origin/main = +16/-14 sur 2 fichiers** (c.187 UNIQUE)

### Conformité règles

| Règle | Statut | Preuve |
|---|---|---|
| **G.1 verify-before-claiming** | ✅ | `python3 -c "json.loads(...)"` direct read kernelspecs AVANT rédaction — confirmé 37/17/19/1 |
| **catalog-pr-hygiene R1** | ✅ | `CATALOG-STATUS` byte-identique (`sed -n '3,7p'` = `series: Sudoku / pedagogical_count: 37 / breakdown: root=37 / maturity: BETA=37`) — laissé à l'automatisation cron |
| **catalog-pr-hygiene R3** | ✅ | 1 PR atomique : 2 fichiers doc, 0 notebook, 0 catalogue |
| **§E audit fichier-entier** | ✅ | grep -nE exhaustif sur les 2 fichiers, AUCUNE autre occurrence de "33" / "36" / "18 notebooks" / "18 solveurs" post-réconciliation |
| **L898 ★★★ collision guard** | ✅ | `gh pr list --search "Sudoku.*README"` + `--state open --search "Sudoku"` → seule #9957 (D5 inline-math filter, autre lane, hors-scope Sudoku README) |
| **L281 rebase origin/main** | ✅ | HEAD = `eeb6b8395` rebasé sur `db903bfc2` (= origin/main frais, post-#9956 merge) |
| **L284 amend légitime** | N/A | Pas d'amend (grain one-shot) |
| **L282 mirror-lanes** | ✅ | Claim #3975 vérifié cross-lane via `check_lane_claim.py --lane "myia-po-2025:CoursIA-2"` AVANT edit → 0 active_claim, 0 blocking |
| **lane-claim-protocol** | ✅ | `[CLAIMED]` posé sur #3975 avec intention concise ("Sudoku feuille README: reconcile 18b post-#9805 (disk-truth 37 = 17 C# + 19 Python + 1 Lean)") |
| **L278/L279** | ✅ | Worker ne merge PAS, sweep-ready = DM ai-01 |
| **L677-L4 ★★** | ✅ | Body PR généré HORS worktree (`scratchpad/c1294_pr_3975_sudoku_18b_reconcile.md`, forward-slash path) |
| **c.187 UNIQUE-COMMIT HARD** | ✅ | 1 commit unique `eeb6b8395` |
| **variation-protocol G-VAR-1** | ✅ | Plat MED (substance = 2 docs réconciliés sur disk-truth post-#9805, change la prose du série-Sudoku) |
| **variation-protocol G-VAR-2** | ✅ | 0 LIGHT ce cycle (MED) |
| **variation-protocol G-VAR-3** | ✅ | Sub-genre `readme-disk-truth-reconcile` ≠ c.1293 (rebase-frais tooling) ≠ c.1292 (RELEASE motivée) ≠ c.1291 (audit gates) |
| **harness-hygiene** | ✅ | Pas de rapport commité — body de PR = scratchpad |
| **readme-french-first** | ✅ | Toute la prose ajoutée/réconciliée reste en français |

### Pourquoi ce n'est PAS un grain LIGHT

Litmus LIGHT : « Pourrais-je en générer une douzaine en scannant l'instance suivante ? » — **NON** ici :

- Le count stale 33 (dans index.qmd) datait d'avant 16/17/18/18b — c'est un **gap structurel** du série, pas un nettoyage monotone
- La table principale des notebooks (L396-397) manquait une row entière — pas un ajout cosmétique
- La décomposition langagière ("17+18+1") était fausse sur **2 fichiers indépendants** + 1 mention dans le parcours Python — pas un seul endroit à patcher
- PR #9805 (lane `po-2024`) a délibérément reporté cette réconciliation à la lane `po-2025:CoursIA-2` (ownership #3975) — c'est un **grain de fond d'EPIC**, pas une lubie

### Leçon durable (NEW L987)

**★ L987 NEW (c.1294)** : **Notebook companion (e.g., 18b) = disque/ +1 mais prose/ inchangée = drift obligatoire à détecter**. Quand un PR substantiel livre un notebook **délibérément sans toucher la prose de série** (pattern observé #9805 = *"README-série non touché (catalog-drift gérera l'inscription)"*), la prose devient stale par construction. Tell : `git log --oneline --all -- <new-notebook.ipynb>` pour trouver le PR créateur → `gh pr view <N>` confirme le report explicite → vérifier que la réconciliation est dans le scope d'une issue tracker (ici #3975). Coût vérif = 30s (1 grep + 1 gh pr view). Coût omission = la prose du série dérive de +1 sur le count canonique pendant des semaines (vu : #7800 + #6627 + #6496 + #6512 ont tous été des PRs de réconciliation séparées sur Sudoku, chacune réconciliant 1 à 2 counts). **Idempotent batch** = scanner TOUS les counts du série d'un coup (ici README.md + index.qmd), pas livrer une tranche par PR.

### État final PR

- `headRefOid`: `eeb6b8395` (1 commit unique sur origin/main `db903bfc2`)
- `baseRefOid`: `db903bfc2` (= origin/main frais, post-#9956 kernels-criteria merge)
- Diff net vs `origin/main` = **+16/-14 sur 2 fichiers**
- 0 notebook touché, 0 catalogue touché
- CATALOG-STATUS byte-identique

## Liens

- **#3975** : READMEs feuilles — SymbolicAI non-Lean + Sudoku + GameTheory + CaseStudies (lane `po-2025:CoursIA-2`)
- **#9805** : feat Sudoku-18b Statistical-Comparison (MERGED 2026-08-07, lane `po-2024`) — auteur de la substance qui a dérivé la prose
- **#3801** : EPIC Prong-B (mentionnée dans la prose réconciliée)
- **#4956** : EPIC marathon twin parity (hors-scope ici mais contexte série)
- **PR #9943** : c.1293 grain précédent (DEEP/tooling `rebase-frais`), sweep-ready pour ai-01
- **PR #9945** : c.1292 RELEASE motivée — MERGED 23:12:46Z (commit `4b863469a`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
