### PR TITLE
fix(tooling,#9971): variation_light_cap --labels-file double-wrapped gh pr view object form

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -272,7 +272,9 @@ jobs:
           # sur la PR ouverte (cas down-qualification, ou up-qualification
           # anticipee). On les passe au detecteur pour que son verdict soit
           # symetrique a celui porte sur les mergees. `gh pr view --json labels`
-          # renvoie [{name,...}] -- le script l'aplatit.
+          # renvoie l'objet {"labels":[{name,...}]} (et non un tableau nu --
+          # c'est `gh pr list` qui renvoie un tableau de PRs) ; le script
+          # l'aplatit, et accepte aussi les formes tableau nu / [str] (#9971).
           gh pr view "$PR_NUMBER" --json labels > /tmp/pr_labels.json 2>/dev/null || \
             printf '[]' > /tmp/pr_labels.json
 

--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -5,6 +5,7 @@ Acceptance replay over a live `gh pr list` wave is pasted in the PR body; these
 tests pin the PARSING and CAP LOGIC with synthetic cases so the organ does not
 silently rot. Run: `python -m pytest scripts/tests/test_variation_light_cap.py`.
 """
+import json
 import sys
 from pathlib import Path
 
@@ -258,6 +259,103 @@ def test_high_output_lane_still_capped_past_budget():
             _pr(9, lane, "LIGHT", "2026-07-31T09:00:00Z")]
     rows = vlc.replay(prs)
     assert {r["number"] for r in rows if r["cap_reached"]} == {9}
+
+
+# --- labels-file loading (#9971): gh pr view object form vs bare arrays -----
+
+def test_load_labels_file_object_form_gh_pr_view(tmp_path):
+    # `gh pr view --json labels` returns the OBJECT {"labels":[{name,...}]}.
+    # This is the shape the CI workflow actually writes; the double-wrap bug
+    # silently dropped every label, so a requalification was invisible.
+    p = tmp_path / "labels.json"
+    p.write_text(
+        '{"labels": [{"name": "grain-requalified:LIGHT", "color": "fff"}]}',
+        encoding="utf-8",
+    )
+    assert vlc.load_labels_file(p) == ["grain-requalified:LIGHT"]
+
+
+def test_load_labels_file_bare_array_of_objects(tmp_path):
+    # A bare [{name,...}] array -- the shape the old false comment assumed.
+    p = tmp_path / "labels.json"
+    p.write_text('[{"name": "a"}, {"name": "b"}]', encoding="utf-8")
+    assert vlc.load_labels_file(p) == ["a", "b"]
+
+
+def test_load_labels_file_bare_strings(tmp_path):
+    # A bare ["str"] array (a hand-written file).
+    p = tmp_path / "labels.json"
+    p.write_text('["a", "b"]', encoding="utf-8")
+    assert vlc.load_labels_file(p) == ["a", "b"]
+
+
+def test_load_labels_file_missing_empty_invalid(tmp_path):
+    # Missing / empty / invalid-JSON file -> no labels, no crash. The CI
+    # workflow always writes valid JSON, but a manual invocation must not fail.
+    assert vlc.load_labels_file(tmp_path / "absent.json") == []
+    empty = tmp_path / "empty.json"
+    empty.write_text("", encoding="utf-8")
+    assert vlc.load_labels_file(empty) == []
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    assert vlc.load_labels_file(bad) == []
+
+
+def test_check_pr_labels_file_object_downqualifies_to_light(tmp_path, capsys):
+    # Regression for #9971: body declares MED, the CI labels-file is in the
+    # OBJECT form `gh pr view` produces and carries grain-requalified:LIGHT.
+    # The effective tier must be LIGHT, so the verdict carries lane/budget/spent
+    # -- NOT the "reason: not LIGHT (effective MED)" verdict the double-wrap bug
+    # produced. Fails on the pre-fix code: the output had no "lane" key.
+    lpath = tmp_path / "pr_labels.json"
+    lpath.write_text(
+        json.dumps({"labels": [{"name": "grain-requalified:LIGHT"}]}),
+        encoding="utf-8",
+    )
+    bpath = tmp_path / "pr_body.txt"
+    bpath.write_text(
+        "Grain: MED/tooling -- lane myia-po-2023:CoursIA-2\n\nbody",
+        encoding="utf-8",
+    )
+    rpath = tmp_path / "merged.json"
+    rpath.write_text("[]", encoding="utf-8")  # no prior merged LIGHT in this lane
+    rc = vlc.main([
+        "--replay", str(rpath), "--check-pr", "1234",
+        "--body-file", str(bpath), "--labels-file", str(lpath),
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    # Pre-fix verdict was {"cap_reached": false, "reason": "not LIGHT ..."} with
+    # NO "lane" key -> this assertion is what fails before the fix.
+    assert out["lane"] == "myia-po-2023:CoursIA-2"
+    assert out["cap_reached"] is False  # 1st LIGHT of the lane, within budget
+
+
+def test_check_pr_requal_deep_exits_light_cap(tmp_path, capsys):
+    # Symmetry (#8970): a grain-requalified:DEEP on a body declaring LIGHT
+    # lifts it OUT of the LIGHT cap -- the override works both ways. The
+    # object-form labels-file must carry that label (would be invisible pre-fix).
+    lpath = tmp_path / "pr_labels.json"
+    lpath.write_text(
+        json.dumps({"labels": [{"name": "grain-requalified:DEEP"}]}),
+        encoding="utf-8",
+    )
+    bpath = tmp_path / "pr_body.txt"
+    bpath.write_text(
+        "Grain: LIGHT/tooling -- lane myia-po-2023:CoursIA-2",
+        encoding="utf-8",
+    )
+    rpath = tmp_path / "merged.json"
+    rpath.write_text("[]", encoding="utf-8")
+    rc = vlc.main([
+        "--replay", str(rpath), "--check-pr", "1235",
+        "--body-file", str(bpath), "--labels-file", str(lpath),
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    # Effective DEEP -> never spends the LIGHT budget.
+    assert out["reason"].startswith("not LIGHT")
+    assert "DEEP" in out["reason"]
 
 
 def test_denominator_counts_all_tiers_not_just_lights():

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -122,6 +122,33 @@ def label_names(pr: dict) -> list[str]:
     return out
 
 
+def load_labels_file(path: Path) -> list[str]:
+    """Load the current PR's labels from a JSON file written by the CI workflow.
+
+    The workflow writes ``gh pr view --json labels`` output, which is the
+    OBJECT ``{"labels": [{name,...}]}`` -- not a bare array (#9971). ``gh pr
+    list`` returns a bare array of PR objects (each carrying ``.labels``), and
+    a hand-written file may hold a bare ``[{...}]`` or ``["str"]``. Accept all
+    three shapes so the verdict never depends on which ``gh`` subcommand fed
+    the file: previously the object form was double-wrapped into
+    ``{"labels": {"labels": [...]}}`` and ``label_names`` iterated only the key
+    string ``"labels"``, silently dropping every real label.
+    """
+    if path.exists() and path.read_text(encoding="utf-8").strip():
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            raw = []
+    else:
+        # Tolerate a missing/empty file (treat as no labels) rather than crash:
+        # the CI workflow always writes valid JSON (`gh pr view` or a `printf
+        # '[]'` fallback), but a manual invocation should not hard-fail.
+        raw = []
+    if isinstance(raw, dict):
+        raw = raw.get("labels") or []
+    return label_names({"labels": raw})
+
+
 def effective_tier(body: str | None, labels: list[str]) -> str | None:
     """The TIER that counts for G-VAR-2.
 
@@ -347,19 +374,7 @@ def main(argv: list[str] | None = None) -> int:
             p.error("--check-pr requires --body or --body-file")
         cur_labels: list[str] = []
         if args.labels_file:
-            # Tolerate a missing/empty file (treat as no labels) rather than
-            # crash: the CI workflow always writes valid JSON (`gh pr view` or
-            # a `printf '[]'` fallback), but a manual invocation should not
-            # hard-fail on an absent file.
-            lpath = Path(args.labels_file)
-            raw = []
-            if lpath.exists() and lpath.read_text(encoding="utf-8").strip():
-                try:
-                    raw = json.loads(lpath.read_text(encoding="utf-8"))
-                except json.JSONDecodeError:
-                    raw = []
-            # accept [str] or [{name}] (label_names handles objects via a dict)
-            cur_labels = label_names({"labels": raw})
+            cur_labels = load_labels_file(Path(args.labels_file))
         # Effective tier (#8970): a requalification label overrides the declared
         # one. Only an EFFECTIVE LIGHT is assessed against the cap.
         eff = effective_tier(body, cur_labels)


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: LIGHT/fix #9963

# Fix : variation_light_cap --labels-file double-emballe la forme objet de gh pr view

Quoi: `scripts/variation_light_cap.py` (branche `--labels-file`) re-emballe `raw` dans `{"labels": raw}`, puis `label_names({"labels": raw})` itère. Or le workflow CI alimente ce fichier via `gh pr view --json labels`, qui renvoie l'**objet** `{"labels":[{name,...}]}` (pas un tableau nu — c'est `gh pr list` qui renvoie un tableau). Le script construisait donc `{"labels": {"labels": [...]}}`, l'itération ne rendait que la clé `"labels"`, et **aucun label n'atteignait la regex** `grain-requalified:`. Conséquence : toute down/up-qualification posée sur une PR **ouverte** était invisible au détecteur — mes requals récentes (#9942, #9953, #9956, #9958) ont été évaluées à leur tier **déclaré**. Le guard étant advisory (exit 0), aucun comportement CI n'a changé, mais le verdict/label/comptage affichés étaient faux sur ces PR.

Preuve:
- **Bug confirmé firsthand** : ligne 362 `cur_labels = label_names({"labels": raw})` avec `raw = {"labels":[...]}` → double-wrap.
- **Fix** : helper testable `load_labels_file(path)` qui accepte les **3 formes** (objet `{"labels":...}` / tableau nu `[{name}]` / tableau de strings `["str"]`) — `if isinstance(raw, dict): raw = raw.get("labels") or []` avant `label_names`. Tolérance absent/vide/JSON-invalide préservée.
- **Empirique (3 formes, même verdict correct)** : body MED + `grain-requalified:LIGHT` en forme objet/tableau-objets/tableau-strings → tous rendent `{"pr":..., "lane":"myia-po-2023:CoursIA-2", "cap_reached":false, "budget":1, "spent":0, ...}` (tier EFFECTIF LIGHT). Sans labels-file (MED déclaré, pas de requal) → `reason: not LIGHT (effective MED)` (comportement attendu).
- **Test fail-before-pass-after** : `test_check_pr_labels_file_object_downqualifies_to_light` → sur code buggy = `KeyError: 'lane'` (verdict `reason: not LIGHT` sans clé lane) ; sur code fixé = pass. Vérifié en réintroduisant le bug.
- **Suite** : 41 passed (35 pre-existing + 6 nouveaux).

Périmètre: 3 fichiers, +129/-14. `scripts/variation_light_cap.py` (helper `load_labels_file` + appel CLI), `scripts/tests/test_variation_light_cap.py` (6 tests : 3 formes + tolérance + régression down-qualif + symétrie DEEP), `.github/workflows/variation-tag-guard.yml` (commentaire corrigé : `gh pr view` = objet, pas tableau). Pas de notebook, pas de catalogue touché.

Acceptance #9971 (4/4) :
- [x] `--labels-file` honore `{"labels":[...]}` (objet) ET `[{...}]` (tableau) ET `["str"]`
- [x] Test qui rejoue le cas (body MED + labels-file objet `grain-requalified:LIGHT` → tier effectif LIGHT, verdict portant lane/budget/spent) — échoue sur code actuel (KeyError), passe après fix
- [x] Symétrie : `grain-requalified:DEEP` sur PR déclarant LIGHT sort du cap (override bidirectionnel #8970)
- [x] Commentaire workflow corrigé

Closes #9971.

🤖 Generated with [Claude Code](https://claude.com/claude-code)