### PR TITLE
fix(variation,#9971): --labels-file honors gh pr view --json labels object shape

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -272,7 +272,10 @@ jobs:
           # sur la PR ouverte (cas down-qualification, ou up-qualification
           # anticipee). On les passe au detecteur pour que son verdict soit
           # symetrique a celui porte sur les mergees. `gh pr view --json labels`
-          # renvoie [{name,...}] -- le script l'aplatit.
+          # renvoie un **objet** {"labels":[{name,...}]} (note : PAS un tableau
+          # comme `gh pr list --json labels`) -- variation_light_cap.py (#9971)
+          # extrait le `.labels` avant d'aplatir. Le fallback `[]` couvre le
+          # cas ou la commande echoue (PR fork, token limite).
           gh pr view "$PR_NUMBER" --json labels > /tmp/pr_labels.json 2>/dev/null || \
             printf '[]' > /tmp/pr_labels.json
 

--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -341,6 +341,63 @@ def test_tagged_light_still_assessed_normally(tmp_path, capsys):
     assert res["lane"] == "myia-po-2023:CoursIA"
 
 
+# --- #9971: --labels-file must accept the THREE shapes the workflow can write ---
+
+# The workflow writes `gh pr view --json labels` output to /tmp/pr_labels.json.
+# That command returns an OBJECT {"labels":[{name,...}]} -- not the array `gh pr
+# list --json` produces. The CI comment (variation-tag-guard.yml, lines 273-275)
+# used to claim "le script l'aplatit" but the script never did -- it re-wrapped
+# the dump as {"labels": {"labels": [...]}}, label_names iterated over the
+# OUTER keys, and the re-qualification label was invisible. Acceptance: the
+# three shapes below must all reach the same verdict (#1 already worked, #2/#3
+# did NOT pre-fix).
+def test_labels_file_object_form_honors_requalif(tmp_path, capsys):
+    # #9971 acceptance case: body declares MED, the *object* shape a
+    # `gh pr view --json labels` write to disk carries a `grain-requalified:LIGHT`
+    # label -> effective tier MUST be LIGHT, and the verdict MUST carry
+    # lane/budget/spent (NOT the "not LIGHT (effective MED)" short-circuit).
+    body = "Grain: MED/tooling -- lane myia-po-2023:CoursIA"
+    rc, res = _check_pr(
+        tmp_path, [], body,
+        labels={"labels": [{"name": "grain-requalified:LIGHT"}]},
+        capsys=capsys,
+    )
+    assert rc == 0
+    # Pre-fix: res = {"cap_reached": false, "reason": "not LIGHT (effective MED)"}
+    # Post-fix: the label is honored, the effective tier is LIGHT, the verdict
+    # computes lane/budget/spent.
+    assert "lane" in res and "budget" in res and "spent" in res
+    assert res["cap_reached"] is False  # no merged LIGHT yet, budget 1, spent 0
+
+
+def test_labels_file_array_of_objects_honors_requalif(tmp_path, capsys):
+    # The "gh pr list --json labels" shape (what the script's own `_lane_of`
+    # already flattens): an array of {name,...} objects. Must keep working.
+    body = "Grain: MED/tooling -- lane myia-po-2023:CoursIA"
+    rc, res = _check_pr(
+        tmp_path, [], body,
+        labels=[{"name": "grain-requalified:LIGHT"}],
+        capsys=capsys,
+    )
+    assert rc == 0
+    assert "lane" in res and "budget" in res and "spent" in res
+    assert res["cap_reached"] is False
+
+
+def test_labels_file_array_of_strings_honors_requalif(tmp_path, capsys):
+    # The bare-string shape (the existing `label_names` test already covers this
+    # path through the helper). Confirms it survives the JSON-load change.
+    body = "Grain: MED/tooling -- lane myia-po-2023:CoursIA"
+    rc, res = _check_pr(
+        tmp_path, [], body,
+        labels=["grain-requalified:LIGHT"],
+        capsys=capsys,
+    )
+    assert rc == 0
+    assert "lane" in res and "budget" in res and "spent" in res
+    assert res["cap_reached"] is False
+
+
 def test_unattributed_lists_untagged_prs():
     prs = [
         {"number": 1, "body": BODY_EMDASH, "mergedAt": "2026-08-05T01:00:00Z"},

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -358,7 +358,19 @@ def main(argv: list[str] | None = None) -> int:
                     raw = json.loads(lpath.read_text(encoding="utf-8"))
                 except json.JSONDecodeError:
                     raw = []
-            # accept [str] or [{name}] (label_names handles objects via a dict)
+            # `gh pr view --json labels` writes an **object** {"labels":[...]}
+            # to disk; `gh pr list --json labels` writes an **array** [{...}].
+            # The CI workflow calls the former (variation-tag-guard.yml line 276),
+            # so the object form is the production case. Pre-#9971, the script
+            # re-wrapped `raw` as {"labels": raw} -- which turned the object
+            # into {"labels": {"labels":[...]}}, and `label_names` walked the
+            # OUTER keys instead of the items. The re-qualification label was
+            # invisible, so the advisory gate returned the wrong verdict
+            # (effective=tier_declared, not effective=requalified). Unwrap the
+            # object form first; the three remaining shapes fall through to the
+            # existing array/object/string handling in `label_names`.
+            if isinstance(raw, dict):
+                raw = raw.get("labels", [])
             cur_labels = label_names({"labels": raw})
         # Effective tier (#8970): a requalification label overrides the declared
         # one. Only an EFFECTIVE LIGHT is assessed against the cap.


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: LIGHT/fix #9963

Quoi: 3-shape JSON acceptance on `--labels-file` for `variation_light_cap.py` (#9971): the `gh pr view --json labels` OBJECT form `{"labels":[{...}]}` was re-wrapped into `{"labels": {"labels": [...]}}`, leaving `grain-requalified:<TIER>` invisible — declared MED with this label now correctly overrides to LIGHT and the verdict carries `lane`/`budget`/`spent`.

Preuve: 38/38 tests PASS (35 pre-existing + 3 new). The 3 new tests pin the three shapes the workflow can write:
- `test_labels_file_object_form_honors_requalif` — the bug case. Pre-fix FAILED with `{"cap_reached": false, "reason": "not LIGHT (effective MED)"}`. Post-fix PASSES with `lane=myia-po-2023:CoursIA, budget=1, spent=0, cap_reached=false`.
- `test_labels_file_array_of_objects_honors_requalif` — `gh pr list --json labels` shape (the script's existing `_lane_of` already flattens this; now the `--check-pr` path matches).
- `test_labels_file_array_of_strings_honors_requalif` — bare-string shape (existing `label_names` test already covered this; confirms it survives the JSON-load change).

```
============================= 38 passed in 0.22s ==============================
```

Perimetre: 3 files, 74 insertions / 2 deletions.
- `scripts/variation_light_cap.py` (+12/−2, lines 354-371): unwrap the object form before `label_names`. Three-line logic change + 9-line comment explaining the three shapes and the incident.
- `scripts/tests/test_variation_light_cap.py` (+57/−0): 3 new tests.
- `.github/workflows/variation-tag-guard.yml` (+4/−1, lines 271-277): correct the misleading comment that claimed `gh pr view --json labels` returns an array — it returns an object, and the script now unwraps it. Cite #9971 in the comment.

C.5 Diagnostic dérive: N/A — this is a tooling fix, not a doc-honesty re-alignment. Note in body instead: the bug was identified by **manual budget calculation** (not estimation) against the replay output, which is consistent with the G-VAR-2 rule "compute, not estimate". The defect (\"label declared but ignored\") was a silent cap miscount, not a hard crash — flagged only because the operator cross-checked the verdict. After this fix, the verdict the CI prints is the verdict the operator would compute by hand.

Acceptance #9971 — 5/5:
1. ✅ `{"labels":[…]}` honored (new test fails pre-fix, passes post-fix).
2. ✅ Test fails on current code (verified: `test_labels_file_object_form_honors_requalif` FAILED before the 3-line fix).
3. ✅ Symmetry: `grain-requalified:DEEP` on declared LIGHT exits cap counting (returns `{"cap_reached": false, "reason": "not LIGHT (effective DEEP)"}`); `grain-requalified:LIGHT` on declared DEEP enters it (returns full verdict with lane/budget/spent).
4. ✅ `variation-tag-guard.yml` comment corrected (`[{name,…}]` → `{"labels":[{name,...}]}`, cites #9971).
5. ✅ pytest vert: 38/38 (output cited above).

Out-of-scope (per issue): does NOT change the advisory character of the G-VAR-2 gate (#9819 step 2 still awaits user action).

See #9971 (partial: tooling fix only; the wider \"advisory → blocking\" decision is gated by user sign-off).

Co-Authored-By: Claude <noreply@anthropic.com>
