### PR TITLE
fix(gametheory,#8052): GT-15 cooperative_games path leak (re-exec) + SC-03 voting prose precision

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames.ipynb
@@ -86,7 +86,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Module cooperative_games charge depuis: D:\\Dev\\CoursIA-gt15-shapley-exo\\MyIA.AI.Notebooks\\GameTheory\n",
+      "Module cooperative_games charge depuis: GameTheory/cooperative_games/\n",
       "Import reussi!\n"
      ]
     }
@@ -145,7 +145,7 @@
     "        FrenchLeftCoalition2024, analyze_coalition_dynamics\n",
     "    )\n",
     "    \n",
-    "    print(f\"Module cooperative_games charge depuis: {_gametheory_dir}\")\n",
+    "    print(f\"Module cooperative_games charge depuis: {_gametheory_dir.name}/cooperative_games/\")\n",
     "    print(\"Import reussi!\")\n",
     "    \n",
     "except ImportError as e:\n",

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb
@@ -765,7 +765,7 @@
    "source": [
     "### Interpretation : Divergence des règles de vote\n",
     "\n",
-    "**Résultat sur le profil divergent** : les trois règles donnent des classements différents.\n",
+    "**Résultat sur le profil divergent** : Borda et Copeland donnent le même classement (B > C > A, gagnant B) ; seule la Pluralité s'en écarte (A > C > B, gagnant A). Le choix de la règle change donc le vainqueur.\n",
     "\n",
     "| Règle | Classement (sortie) | Gagnant | Explication |\n",
     "|-------|---------------------|---------|-------------|\n",

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-15-cooperativegames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-15-cooperativegames.yaml
@@ -8,7 +8,14 @@
       by: myia-po-2023:CoursIA
       python_sha: 9e82048c4ad2393af7e012c036ce714b590380e8
       csharp_sha: 7d0fca43674a5478f7a96de1af75ffe165005a2f
+    - date: "2026-08-08"
+      by: myia-po-2025:CoursIA
+      python_sha: e536cc4c95af84a5131a97c55b693ee2d5c4f37d
+      csharp_sha: 7d0fca43674a5478f7a96de1af75ffe165005a2f
+      content_python_sha: abc64ad748b456153cff4fe6af3a4b8017a11f1a053dec9f4c0fd3655f409de2
+      content_csharp_sha: beb9eb6d1f081e52a33cbe880ae0659ac31a65ef2468a4439f4113f0c77a65cd
   known_differences:
+    - "2026-08-08 (po-2025) #8052 secrets-hygiene : cell[1] import imprimait le chemin absolu resolu du module (_gametheory_dir) dans l'output committé -> leak de worktree machine (D:\\Dev\\CoursIA-gt15-shapley-exo\\...). Fix source {_gametheory_dir.name}/cooperative_games/ + re-exec genuine (Stop&Repair, pas de scrub). csharp_sha inchange (twin C# non touche). python_sha rebaseline suite a ce changement de blob."
     - "Socle pedagogique commun : jeux cooperatifs a utilite transferable, fonction caracteristique et coalitions, valeur de Shapley (Shapley 1953) et ses axiomes (efficacite, symetrie, joueur nul, additivite), glove game (jeu des gants) comme exemple canonique."
     - "Idiomes framework : Python = `numpy` + `matplotlib` + module local `cooperative_games` + `itertools` (enumeration des coalitions/permutations). C# = BCL .NET 9 pur (`System.Linq`, `System.Collections.Generic`, 0 NuGet), calcul de Shapley from-scratch via permutations Linq."
     - "Asymetrie de couverture : Python (54 cellules, 25 code) plus etendu (module local dedie, visualisations matplotlib, proprietes additionnelles des jeux cooperatifs) ; C# (34 cellules, 13 code) se concentre sur le glove game et le calcul de Shapley from-scratch. Meme theorie centrale (Shapley 1953), couverture Python plus large."

--- a/scripts/notebook_tools/twin_pairs.d/socialchoice-3-voting-methods.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/socialchoice-3-voting-methods.yaml
@@ -8,7 +8,14 @@
       by: myia-po-2023:CoursIA
       python_sha: 7d3ea48c681d137b25725c50e9c4d78678fd6ba8
       csharp_sha: 0d127926ec65642b24c16d7ca24cfa88cae11830
+    - date: "2026-08-08"
+      by: myia-po-2025:CoursIA
+      python_sha: 0b4e212a66f03f2eec2247e17f55db061bd2b247
+      csharp_sha: 0d127926ec65642b24c16d7ca24cfa88cae11830
+      content_python_sha: 44b742b5f9cb1974b925f64a5b7f8ee3de1ead02a9d9095c857e4d27e620aa36
+      content_csharp_sha: 45c07615f01f1b52fc259c38d930acb8b8745186adcf93cbaa09eae2e1b281fd
   known_differences:
+    - "2026-08-08 (po-2025) #8052 prose precision : md[16] disait 'les trois regles donnent des classements differents' mais l'output (cell#12) montre Borda = Copeland (B>C>A), seule la Pluralite s'ecarte (A>C>B). Reworded au split 2-vs-1 reel. Markdown-only (C.2 exception). csharp_sha inchange (twin C# non touche). python_sha rebaseline suite a ce changement de blob."
     - "2026-07-25 (po-2024) #8052 case-A : median-voter preference order -- cell#29 (devenu #29 apres #8566) table disait pic=5 => '4 > 6 > 2 > 0 > 8 > 10' mais l'output code (Electeur 4 pic=5: [4,6,2,8,0,10]) prouve '4 > 6 > 2 > 8 > 0 > 10' (single_peaked_preference sort stable par |x-5|). Markdown-only 1-line swap, no re-exec. csharp_sha inchange. python_sha rebaseline suite a ce changement de blob."
     - "2026-07-25 (po-2024) #8564 : IIA verdict honnetete + contre-exemple Copeland -- cell#23 imprimait `=> respecte IIA` des que le compteur Monte-Carlo tombait a 0, mais Copeland (Condorcet-consistante) VIOLE IIA (theoreme). Fix : verdict existentiel seul (0/100 => 'aucune violation observee, n'etablit pas respecte IIA' ; >0 => 'VIOLE IIA (N contre-exemples)'). Ajout cellule contre-exemple constructif (profil cyclique 4 alts A>B>C>D / B>C>D>A / C>D>A>B : A bat B pairwise, Copeland classe B>A avec C,D vs A>B sans -- inversion = IIA violée prouvee). markdown cell#24 (devenu #26) corrigé ('Copeland respecte IIA car pairwise' etait faux). csharp_sha inchange (twin C# non touche). python_sha rebaseline suite a ce changement de blob."
     - "2026-07-25 (po-2024) #8559 : determinism rebaseline -- plurality/borda/copeland tie-break etait `sorted(set(...), key=lambda x:-score)` (stable-sort + hash-dependent set iteration = PYTHONHASHSEED non-determinisme, 4 outcome buckets sur 41 seeds). Fix : tuple tiebreak `key=lambda x:(-score, x)` (lexicographique). Outputs regeneres (cell#12 rules -> A>B>C deterministe ; cell#23 Arrow MC -> 12/3/0 deterministe). markdown cell#13/#14/#16 aligne a la nouvelle verite (symmetric profile donne meme classement A>B>C ; departage alphabétique). csharp_sha inchange (twin C# non touche). python_sha rebaseline suite a ce changement de blob."


### PR DESCRIPTION
Grain: MED/notebook-correctness — lane myia-po-2025:CoursIA — prev: MED/tooling (#9968)

# GameTheory / SocialChoice claims↔outputs audit (#8052)

Audit claims-vs-outputs (prose vs committed execution) of the quantitative GameTheory / SocialChoice notebooks. Two actionable findings; the rest are faithful (re-derived arithmetic matches outputs).

## Finding 1 — GT-15 cooperative_games import prints an absolute machine path (secrets-hygiene §6, category C)

`GameTheory-15-CooperativeGames.ipynb` cell[1] did a robust multi-platform import of the local `cooperative_games` module and **printed the resolved absolute directory**:

```
print(f"Module cooperative_games charge depuis: {_gametheory_dir}")
```

The committed output leaked a previous worktree path:

```
Module cooperative_games charge depuis: D:\Dev\CoursIA-gt15-shapley-exo\MyIA.AI.Notebooks\GameTheory
```

**Fix (Stop & Repair — not a hand-scrub of the output):** the source now prints only the directory name (non-leaking, still confirms where the module was found):

```python
print(f"Module cooperative_games charge depuis: {_gametheory_dir.name}/cooperative_games/")
```

…then cell[1] was **genuinely re-executed** (cwd = GameTheory dir, `MPLBACKEND=Agg`, deterministic — path resolution + import only, no randomness). New committed output:

```
Module cooperative_games charge depuis: GameTheory/cooperative_games/
Import reussi!
```

No hand-edit of the output: the committed text is exactly what the corrected code produced. (secrets-hygiene rule 6 / [[feedback-no-cell-output-scrubbing]].)

## Finding 2 — SC-03 voting-methods divergence prose overstates (markdown-only)

`SocialChoice/03-Voting-Methods.ipynb` md cell said *"les trois règles donnent des classements différents"*, but the committed output of the comparison cell is:

```
Pluralite: A > C > B
Borda:     B > C > A
Copeland:  B > C > A
```

Borda and Copeland **coincide** (both `B > C > A`, winner B); only Pluralité diverges. The notebook's own table already lists B as the Borda *and* Copeland winner, so only the lead sentence was imprecise. Reworded to state the actual 2-vs-1 split. Markdown-only (C.2 exception: no re-execution needed).

## Audit scope (claims↔outputs, re-derived)

Notebooks checked firsthand against their committed outputs — arithmetic re-derived, tables cross-checked:

| Notebook | Status |
|---|---|
| GT-3 Topology2x2 | faithful (ordinal matrices, 24×24=576 games, swap paths) |
| GT-4 NashEquilibrium | faithful (PD (D,D)→(1,1); Matching Pennies (0.5,0.5); RPS (1/3,1/3,1/3)) |
| GT-5 ZeroSum-Minimax | faithful (gap 2.0; saddle 2.0; LP dualité forte True; Blotto 15 strategies/3 played) |
| GT-6 EvolutionTrust | faithful (tournament tables 520.06/518.69/498.25 ≈ prose 520/519/500; noise-shuffle evolutions #4→#2/#2→#3/#6→#4/#3→#5 all exact; "104 vs 99"; Moran 7/25 Defector) |
| SC-03 Voting | 1 finding (above) |
| GT-15 Cooperative | 1 finding (above); Shapley/Banzhaf/Core claims faithful |

This corroborates the notebook-correctness convergence reported by po-2024 (6 families) and the D5 frontier being drained.

## Verification
- `nbformat validate` OK on both notebooks.
- 0 `raise NotImplementedError` / `assert False` / `1/0` (C.1).
- GT-15 committed output contains no drive-letter / absolute path.
- Diff surgical: **2 files, +3/−3**, no metadata/execution_count churn, no source-repr reformatting.
- GT-15 cell[1] re-executed (H.1: exec_count non-null, real outputs); SC-03 markdown-only (C.2 exception).

See #8052 (claims↔outputs epic, partial — GameTheory/SocialChoice family), #8364 (prose-drift understanding).
