### PR TITLE
docs(reference,#7422): fix phantom GradeBookApp path in common-commands.md

### DIFF
--- a/docs/reference/common-commands.md
+++ b/docs/reference/common-commands.md
@@ -73,7 +73,7 @@ Cf [claude-code-config.md](./claude-code-config.md) pour le detail agents/skills
 
 ```bash
 python GradeBookApp/gradebook.py               # Python grading pipeline
-python GradeBookApp/run_epf_mis_2026.py         # EPF MIS multi-epreuves
+python GradeBookApp/run_grading.py              # Pipeline de notation (runner)
 ```
 
 Notation par cohorte (ECE, ESGF, ...) = privee sur GDrive `G:\Mon Drive\MyIA\Formation\<ecole>\<annee>\grading\` ; cf [GradeBookApp/configs/README.md](../../GradeBookApp/configs/README.md) pour le moteur generique.


### PR DESCRIPTION
Grain: MED/docs-triage — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #9972

# Fix : common-commands.md référençait un script GradeBookApp qui n'a jamais existé

Quoi: `docs/reference/common-commands.md` §GradeBookApp citait `python GradeBookApp/run_epf_mis_2026.py  # EPF MIS multi-epreuves`. Ce script **n'existe pas et n'a jamais existé** dans l'historique git (`git log --all -- GradeBookApp/run_epf_mis_2026.py` = vide ; GradeBookApp ne contient que `gradebook.py`, `run_grading.py`, `test_fuzzy_match_group.py`). Chemin fantôme — la notation EPF/MIS par cohorte est privée sur GDrive (CLAUDE.md), il n'y a pas d'entrypoint EPF dans le repo. Remplacé par le vrai runner générique `run_grading.py` (vérifié : importe depuis `gradebook`, prend un `DATA_ROOT`, génère les rapports).

Surfacé par la passe de tri complet de `docs/reference/` (40 fichiers) — EPIC #7422 acceptance item 1. Table de tri complète postée sur dashboard workspace CoursIA-2 (acceptance : « sur PR ou dashboard, pas un *_REPORT.md »). Résumé du tri : 35 KEEP, 4 UPDATE (1 chemin fantôme = cette PR ; 1 contradiction interne cluster-agents Qwen3.6 vs Qwen3.5 = nécessite confirmation ai-01 sur la machine ; 1 drift self-healing notebook-counters 863/867 ; 1 cosmétique catalog_markers), 1 ARCHIVE borderline (notebook-counts-reconciliation, décision ai-01/user).

Preuve:
- **Chemin fantôme vérifié firsthand** : `ls GradeBookApp/*.py` → `gradebook.py`, `run_grading.py`, `test_fuzzy_match_group.py` (3 fichiers, aucun `run_epf_mis_2026.py`) ; `git log --all --oneline -- GradeBookApp/run_epf_mis_2026.py` → vide (jamais dans l'historique).
- **Vrai runner vérifié firsthand** : `run_grading.py` existe, `from gradebook import process_grades, ...`, `DATA_ROOT = r"G:\Mon Drive\MyIA\Formation\Epita\2025"`, génère des rapports. Entrypoint générique de notation.
- **Audit fichier-entier** (pr-review-discipline §E) : les 11 autres chemins cités dans common-commands.md vérifiés présents (requirements.txt, MyIA.CoursIA.sln, genai.py, notebook_tools.py, validate_sc_notebooks.py, notebook-validation.yml, gradebook.py, configs/README.md, 2 liens docs). Aucun autre chemin fantôme.
- **Diff minimal** : 1 fichier, +1/-1. **Catalogue byte-identique** à origin/main (catalog-pr-hygiene R1 ✓). Zéro cellule notebook, zéro règle touchée.

Perimètre: 1 fichier, +1/-1. `docs/reference/common-commands.md` §GradeBookApp ligne 76 uniquement. Supprime un chemin fantôme, le remplace par le vrai runner. Ne touche pas la prose GDrive (correcte), ne touche pas aux autres sections. Les 3 autres UPDATE candidates du tri (cluster-agents contradiction = ai-01 confirme le modèle réellement chargé ; notebook-counters drift 863/867 = self-healing cron ; catalog_markers = exemple illustratif cosmétique) et l'ARCHIVE candidate (notebook-counts-reconciliation = décision ai-01/user) sont flaguées sur le dashboard, hors de cette PR — elles nécessitent une décision humaine ou se self-heal.

See #7422 (acceptance item 1 = triage table sur dashboard ; cette PR = action concrète issue du tri). Pas `Closes` : #7422 = EPIC triage docs, reste ouvert (d'autres familles docs/ à trier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
