### PR TITLE
fix(d5,#9790): exclude domain-range descriptions from prose enumeration (FP -4 Sudoku)

### DIFF
--- a/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
@@ -480,6 +480,15 @@ def _detect_prose_enumeration(text: str) -> list[float] | None:
     after = latex_clean[m.end():m.end()+200]
     # Cas (a)/(b) : on prend la PHRASE courante a partir du mot-cle.
     sentence = after.split("\n", 1)[0]
+    # Domain-range descriptions (« 81 valeurs (1-9) », « valeurs 1–9 ») ne sont
+    # PAS des enumerations de niveaux output : la paire `lo-hi` denote les
+    # bornes de l'espace de valeurs (domaine), pas des niveaux distincts
+    # observes. Une vraie enumeration #9416 liste des valeurs mesurees separees
+    # par des virgules/conjonctions, jamais un intervalle entier. On retire ces
+    # ranges avant extraction, sinon « 81 valeurs (1-9) » etait lu comme une
+    # enumeration de 2 niveaux (1 et 9) puis comparee aux outputs globaux ->
+    # FP systematique (confirme firsthand Sudoku-5-PSO cell[9], GameTheory).
+    sentence = re.sub(r"\b\d{1,4}\s*[-–—]\s*\d{1,4}\b", " ", sentence)
     nums = _extract_prose_numbers(sentence)
     return nums if len(nums) >= 2 else None
 

--- a/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
@@ -366,6 +366,20 @@ class TestDetectProseEnumeration:
         assert mod._detect_prose_enumeration("Plusieurs pics apparaissent.") is None
         assert mod._detect_prose_enumeration("") is None
 
+    def test_domain_range_not_enumeration(self):
+        # A domain/range description (« 81 valeurs (1-9) ») is NOT an output-
+        # level enumeration: the hyphenated pair denotes value-space bounds,
+        # not distinct observed levels. Confirmed FP firsthand Sudoku-5-PSO
+        # cell[9] (« Chaque particule contient 81 valeurs (1-9) » was read as
+        # a 2-level enumeration of {1, 9} then compared to global outputs).
+        # ASCII hyphen, en-dash and em-dash variants must all be excluded.
+        assert mod._detect_prose_enumeration(
+            "Chaque particule contient 81 valeurs (1-9) pour chaque cellule.") is None
+        assert mod._detect_prose_enumeration(
+            "Chaque particule contient 81 valeurs (1–9) pour chaque cellule.") is None
+        assert mod._detect_prose_enumeration(
+            "Chaque bloc contient 81 valeurs 1—9 initialisees.") is None
+
     def test_latex_decimal_span_preserved(self):
         # $2{,}31$ is a LaTeX decimal == 2.31 -- a real value, must be kept.
         nums = mod._detect_prose_enumeration("2 niveaux : $0{,}19$ et $2{,}31$.")


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: MED/translation #9987

Quoi: D5 detector `_detect_prose_enumeration` — exclusion des domain-range descriptions ("81 valeurs (1-9)") qui étaient lues comme des énumérations de 2 niveaux output → FP systématique.
Preuve: firsthand — `_extract_prose_numbers` sur Sudoku-5-PSO cell[9] retourne [81,1,9] (les "2" des headings BIEN filtrés), mais le `prose_number:2.0` du finding venait de "81 valeurs (1-9)" lu comme énumération {1,9}. Fix strip les ranges `lo-hi` (ASCII/en/em-dash) avant extraction. 81/81 tests PASS (3 nouvelles assertions régression), 5 TPs réels retenus (ICT-1 "un pic à 2,31"), corpus Sudoku PROSE_ENUM 16→12 (−4 FPs), MISSING_FROM_OUTPUTS intact (301).
Perimetre: `scan_d5_prose_outputs_alignment.py` (+9 lignes) + son test (+14). 2 fichiers, +23/-0. Pas de notebook touché, pas de secret.

# D5 detector — exclure les domain-range descriptions de l'énumération prose (#9790)

## Cause racine — vérifiée firsthand (G.9), pas une intuition

Le détecteur D5 v3 (`scan_d5_prose_outputs_alignment.py`, PR #9793, mon instrument de lane) signale la classe #9416 — « la prose énumère N niveaux mais les outputs en exhibent strictement plus ». `_detect_prose_enumeration` cherche un mot-clé d'annonce (`\d+\s+(?:niveaux|valeurs|phases|...)`) puis extrait les nombres qui suivent comme niveaux énumérés.

**Le FP** : une description de domaine comme « Chaque particule contient **81 valeurs (1-9)** pour chaque cellule » (Sudoku-5-PSO cell[9]) déclenche l'annonce (`81 valeurs`), puis extrait `(1-9)` → `[1.0, 9.0]` = **2 niveaux énumérés**, comparés aux outputs globaux du notebook (qui en ont plus) → finding `MISSING_FROM_PROSE_ENUMERATION, prose_levels=2, orphan=49`. Vérifié firsthand :

```
_extract_prose_numbers(cell[9]) -> [81.0, 1.0, 9.0]   # les "2" des headings "## 2." / "### Approche 2" sont BIEN filtrés par _ATX_HEADING_LINE_RE
# mais le "2" du finding = distinct_levels([1,9]) = 2, venu du range "(1-9)"
```

La sémantique est claire : une **paire entière `lo-hi`** denotes les bornes de l'espace de valeurs (domaine), pas des niveaux distincts observés. Une vraie énumération #9416 liste des valeurs mesurées séparées par virgules/conjonctions (« 2 niveaux : 0,19 et 2,31 »), jamais un intervalle entier.

## Le fix (chirurgical, +9 lignes)

Dans `_detect_prose_enumeration`, après isolation de la phrase post-annonce, on retire les ranges numériques nus avant extraction :

```python
sentence = re.sub(r"\b\d{1,4}\s*[-–—]\s*\d{1,4}\b", " ", sentence)
nums = _extract_prose_numbers(sentence)
```

Couvre ASCII hyphen `-`, en-dash `–`, em-dash `—`. Portée limitée à la phrase post-annonce (pas le paragraphe entier) — ne touche pas `_extract_prose_numbers` (utilisé par MISSING_FROM_OUTPUTS, inchangé).

## Validation — réelle (règle F, anti-regression)

- **Suite tests** : `pytest test_scan_d5_prose_outputs_alignment.py` → **81/81 PASS** (incl. 3 nouvelles assertions `test_domain_range_not_enumeration` : hyphen, en-dash, em-dash).
- **TPs réels retenus** (5 cas #9416) : « On observe 2 niveaux : 0,19 et 2,31 » → [0.19, 2.31] ✓ ; « les 3 valeurs sont 0.19, 0.69 et 2.31 » ✓ ; « 4 phases : 0.1, 0.3, 0.5, 0.7 » ✓ ; **cas fondateur ICT-1 « un pic à 2,31, le reste à 0,19 »** → [2.31, 0.19] ✓ ; LaTeX `$0{,}19$ et $2{,}31$` ✓.
- **Contre-épreuve #9790** : le cas fondateur ICT-1 (l'épreuve d'intégrité du détecteur) reste détecté — le fix ne masque pas les vrais findings.
- **Corpus réel (Sudoku)** : `MISSING_FROM_PROSE_ENUMERATION` 16 → **12** (−4 FPs range-description : Sudoku-5-PSO, -8, -9 et un 4e). `MISSING_FROM_OUTPUTS` **301 → 301** (inchangé, le fix ne touche pas cette voie). Aucune régression.

## Résiduel (hors scope, documenté)

D'autres classes de FP D5 subsistent (confirmées firsthand, **non adressées** par cette PR pour garder le scope atomique) :
- **Nombres structurels** dans MISSING_FROM_OUTPUTS : dimensions de jeu (« 2×2 » → 2.0), compteurs de soldats/champs (« 2 champs sur 3 »), numéros de section (« ## 2. » via headings non-ATX ou tableaux). GameTheory particulièrement bruité.
- **MISSING_FROM_PROSE_ENUMERATION restants (12)** : comparaison prose-cell vs outputs globaux (devrait être vs output-cell précédente), headings numérotés dans tableaux.

Ces classes méritent des grains séparés (chacun son diagnostic + fix + tests) — cette PR ne traite que la classe range-description, la mieux isolée et la plus clairement FP.

## Scope (HARD)

- 2 fichiers, +23/-0. Pas de notebook touché, pas de catalogue, pas de secret.
- `variation-protocol` : MED/tooling (instrument ma lane #9793), genre ≠ prev (translation). G-VAR-1 ✓ (plancher MED), G-VAR-3 ✓ (tooling ≠ translation).

See #9790 (D5 detector), #9768 (EPIC forensic), #9416 (cas fondateur ICT-1), #9793 (détecteur v3).
