### PR TITLE
fix(genai,#9929): stop machine-path leaks in 09-Building-CLR outputs (re-exec)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
@@ -115,10 +115,10 @@
    "id": "95fec443",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T22:34:51.774882Z",
-     "iopub.status.busy": "2026-08-07T22:34:51.774882Z",
-     "iopub.status.idle": "2026-08-07T22:34:51.781942Z",
-     "shell.execute_reply": "2026-08-07T22:34:51.780410Z"
+     "iopub.execute_input": "2026-08-08T04:37:18.361018Z",
+     "iopub.status.busy": "2026-08-08T04:37:18.360785Z",
+     "iopub.status.idle": "2026-08-08T04:37:18.364597Z",
+     "shell.execute_reply": "2026-08-08T04:37:18.363890Z"
     },
     "papermill": {
      "duration": 3.384082,
@@ -140,10 +140,10 @@
    "id": "d9026247",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T22:34:51.784944Z",
-     "iopub.status.busy": "2026-08-07T22:34:51.784944Z",
-     "iopub.status.idle": "2026-08-07T22:34:51.797183Z",
-     "shell.execute_reply": "2026-08-07T22:34:51.796163Z"
+     "iopub.execute_input": "2026-08-08T04:37:18.366700Z",
+     "iopub.status.busy": "2026-08-08T04:37:18.366206Z",
+     "iopub.status.idle": "2026-08-08T04:37:18.375050Z",
+     "shell.execute_reply": "2026-08-08T04:37:18.374399Z"
     },
     "papermill": {
      "duration": 0.257777,
@@ -198,10 +198,10 @@
    "id": "74a574d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T22:34:51.800701Z",
-     "iopub.status.busy": "2026-08-07T22:34:51.800701Z",
-     "iopub.status.idle": "2026-08-07T22:34:51.806238Z",
-     "shell.execute_reply": "2026-08-07T22:34:51.805721Z"
+     "iopub.execute_input": "2026-08-08T04:37:18.376985Z",
+     "iopub.status.busy": "2026-08-08T04:37:18.376712Z",
+     "iopub.status.idle": "2026-08-08T04:37:18.380139Z",
+     "shell.execute_reply": "2026-08-08T04:37:18.379671Z"
     }
    },
    "outputs": [
@@ -262,10 +262,10 @@
    "id": "1aa67c3f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T22:34:51.810250Z",
-     "iopub.status.busy": "2026-08-07T22:34:51.810250Z",
-     "iopub.status.idle": "2026-08-07T22:34:52.204184Z",
-     "shell.execute_reply": "2026-08-07T22:34:52.202988Z"
+     "iopub.execute_input": "2026-08-08T04:37:18.381749Z",
+     "iopub.status.busy": "2026-08-08T04:37:18.381578Z",
+     "iopub.status.idle": "2026-08-08T04:37:19.165668Z",
+     "shell.execute_reply": "2026-08-08T04:37:19.164952Z"
     },
     "papermill": {
      "duration": 0.895969,
@@ -281,7 +281,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Chemin DLL calculé : C:\\dev\\CoursIA-sk9-clr-fix\\MyIA.AI.Notebooks\\bin\\Release\\net9.0\n"
+      "Chemin DLL calculé : bin/Release/net9.0\n"
      ]
     },
     {
@@ -289,7 +289,7 @@
      "output_type": "stream",
      "text": [
       "✅ Runtime CoreCLR démarré (config : MyIA.AI.Notebooks.runtimeconfig.json)\n",
-      "✅ Chemin ajouté au sys.path : C:\\dev\\CoursIA-sk9-clr-fix\\MyIA.AI.Notebooks\\bin\\Release\\net9.0\n"
+      "✅ Chemin ajouté au sys.path : bin/Release/net9.0\n"
      ]
     }
    ],
@@ -297,9 +297,16 @@
     "import sys\n",
     "import os\n",
     "\n",
+    "\n",
+    "def _rel_dll(chemin):\n",
+    "    # N'affiche que le suffixe relatif (ex. bin/Release/net9.0) afin de\n",
+    "    # ne pas exposer le chemin absolu de la machine dans les sorties.\n",
+    "    parts = chemin.replace(\"\\\\\", \"/\").split(\"/\")\n",
+    "    return \"/\".join(parts[-3:]) if len(parts) >= 3 else os.path.basename(chemin)\n",
+    "\n",
     "# CORRECTION : Chemin absolu vers la DLL compilée\n",
     "dll_path = os.path.abspath(os.path.join(os.getcwd(), \"..\", \"..\", \"bin\", \"Release\", \"net9.0\"))\n",
-    "print(f\"Chemin DLL calculé : {dll_path}\")\n",
+    "print(f\"Chemin DLL calculé : {_rel_dll(dll_path)}\")\n",
     "\n",
     "# Vérification de l'existence du chemin\n",
     "if not os.path.exists(dll_path):\n",
@@ -307,11 +314,11 @@
     "    dll_path_debug = os.path.abspath(os.path.join(os.getcwd(), \"..\", \"..\", \"bin\", \"Debug\", \"net9.0\"))\n",
     "    if os.path.exists(dll_path_debug):\n",
     "        dll_path = dll_path_debug\n",
-    "        print(f\"Utilisation du chemin Debug : {dll_path}\")\n",
+    "        print(f\"Utilisation du chemin Debug : {_rel_dll(dll_path)}\")\n",
     "    else:\n",
     "        print(f\"❌ Erreur : Aucun chemin DLL trouvé!\")\n",
-    "        print(f\"   - Testé Release : {dll_path}\")\n",
-    "        print(f\"   - Testé Debug : {dll_path_debug}\")\n",
+    "        print(f\"   - Testé Release : {_rel_dll(dll_path)}\")\n",
+    "        print(f\"   - Testé Debug : {_rel_dll(dll_path_debug)}\")\n",
     "        raise FileNotFoundError(\"DLL MyIA.AI.Notebooks.dll introuvable\")\n",
     "\n",
     "# Sélection du runtime .NET AVANT tout `import clr`.\n",
@@ -334,7 +341,7 @@
     "if dll_path not in sys.path:\n",
     "    sys.path.append(dll_path)\n",
     "\n",
-    "print(f\"✅ Chemin ajouté au sys.path : {dll_path}\")"
+    "print(f\"✅ Chemin ajouté au sys.path : {_rel_dll(dll_path)}\")"
    ]
   },
   {
@@ -343,10 +350,10 @@
    "id": "c507d01c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T22:34:52.207183Z",
-     "iopub.status.busy": "2026-08-07T22:34:52.206182Z",
-     "iopub.status.idle": "2026-08-07T22:34:52.385289Z",
-     "shell.execute_reply": "2026-08-07T22:34:52.385289Z"
+     "iopub.execute_input": "2026-08-08T04:37:19.167822Z",
+     "iopub.status.busy": "2026-08-08T04:37:19.167496Z",
+     "iopub.status.idle": "2026-08-08T04:37:21.124292Z",
+     "shell.execute_reply": "2026-08-08T04:37:21.123343Z"
     },
     "papermill": {
      "duration": 0.562144,
@@ -362,14 +369,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ Référence à 'MyIA.AI.Notebooks.dll' ajoutée avec succès."
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "✅ Référence à 'MyIA.AI.Notebooks.dll' ajoutée avec succès.\n"
      ]
     }
    ],
@@ -422,10 +422,10 @@
    "id": "35b15035",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T22:34:52.389808Z",
-     "iopub.status.busy": "2026-08-07T22:34:52.388802Z",
-     "iopub.status.idle": "2026-08-07T22:34:52.563260Z",
-     "shell.execute_reply": "2026-08-07T22:34:52.562250Z"
+     "iopub.execute_input": "2026-08-08T04:37:21.126857Z",
+     "iopub.status.busy": "2026-08-08T04:37:21.126612Z",
+     "iopub.status.idle": "2026-08-08T04:37:21.262534Z",
+     "shell.execute_reply": "2026-08-08T04:37:21.261699Z"
     },
     "papermill": {
      "duration": 0.262218,
@@ -489,10 +489,10 @@
    "id": "aa86a37a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T22:34:52.567260Z",
-     "iopub.status.busy": "2026-08-07T22:34:52.567260Z",
-     "iopub.status.idle": "2026-08-07T22:34:52.671028Z",
-     "shell.execute_reply": "2026-08-07T22:34:52.669947Z"
+     "iopub.execute_input": "2026-08-08T04:37:21.265049Z",
+     "iopub.status.busy": "2026-08-08T04:37:21.264780Z",
+     "iopub.status.idle": "2026-08-08T04:37:22.796629Z",
+     "shell.execute_reply": "2026-08-08T04:37:22.796045Z"
     },
     "papermill": {
      "duration": 0.306075,
@@ -509,10 +509,13 @@
      "output_type": "stream",
      "text": [
       "✅ Assembly trouvé: MyIA.AI.Notebooks\n",
-      "Types disponibles dans l'assembly:\n",
-      "  - <>y__InlineArray5`1\n",
-      "  - <>y__InlineArray6`1\n",
-      "  - <>z__ReadOnlyArray`1\n",
+      "Types disponibles dans l'assembly:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  - SkiaUtils\n",
       "  - FactorGraphHelper\n",
       "  - SvgChart\n",
@@ -535,6 +538,9 @@
       "  - MyIA.AI.Notebooks.Config.Settings\n",
       "  - MyIA.AI.Notebooks.Config.Utils\n",
       "  - <PrivateImplementationDetails>\n",
+      "  - <>y__InlineArray5`1\n",
+      "  - <>y__InlineArray6`1\n",
+      "  - <>z__ReadOnlyArray`1\n",
       "  - SkiaUtils+<ShowImage>d__0\n",
       "  - FactorGraphHelper+<>c\n",
       "  - FactorGraphHelper+<>o__12\n",
@@ -719,10 +725,10 @@
    "id": "b895a913",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T22:34:52.674417Z",
-     "iopub.status.busy": "2026-08-07T22:34:52.673856Z",
-     "iopub.status.idle": "2026-08-07T22:34:52.681131Z",
-     "shell.execute_reply": "2026-08-07T22:34:52.679495Z"
+     "iopub.execute_input": "2026-08-08T04:37:22.798561Z",
+     "iopub.status.busy": "2026-08-08T04:37:22.798249Z",
+     "iopub.status.idle": "2026-08-08T04:37:22.801763Z",
+     "shell.execute_reply": "2026-08-08T04:37:22.801117Z"
     }
    },
    "outputs": [
@@ -785,10 +791,10 @@
    "id": "5065d5f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T22:34:52.684885Z",
-     "iopub.status.busy": "2026-08-07T22:34:52.684367Z",
-     "iopub.status.idle": "2026-08-07T22:34:52.772784Z",
-     "shell.execute_reply": "2026-08-07T22:34:52.771552Z"
+     "iopub.execute_input": "2026-08-08T04:37:22.803853Z",
+     "iopub.status.busy": "2026-08-08T04:37:22.803569Z",
+     "iopub.status.idle": "2026-08-08T04:37:25.374840Z",
+     "shell.execute_reply": "2026-08-08T04:37:25.374344Z"
     },
     "papermill": {
      "duration": 0.01561,
@@ -804,29 +810,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ Erreur lors de l'exécution de l'agent : Exception has been thrown by the target of an invocation.\r\n",
-      " ---> System.Exception: Configuration not found, please setup the notebooks first using notebook 0-AI-settings.pynb\r\n",
-      "   at MyIA.AI.Notebooks.Config.Settings.LoadFromFile(String configFile) in C:\\dev\\CoursIA-sk9-clr-fix\\MyIA.AI.Notebooks\\Config\\Settings.cs:line 135\r\n",
-      "   at MyNotebookLib.NotebookUpdaterBase.InitSemanticKernel() in C:\\dev\\CoursIA-sk9-clr-fix\\MyIA.AI.Notebooks\\GenAI\\SemanticKernel\\NotebookUpdaterBase.cs:line 175\r\n",
-      "   at MyNotebookLib.NotebookUpdaterBase..ctor(String notebookPath, ILogger logger) in C:\\dev\\CoursIA-sk9-clr-fix\\MyIA.AI.Notebooks\\GenAI\\SemanticKernel\\NotebookUpdaterBase.cs:line 166\r\n",
-      "   at MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater..ctor(String notebookPath, ILogger logger) in C:\\dev\\CoursIA-sk9-clr-fix\\MyIA.AI.Notebooks\\GenAI\\SemanticKernel\\AutoInvokeSKAgentsNotebookUpdater.cs:line 13\r\n",
-      "   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Constructor(Object obj, IntPtr* args)\r\n",
-      "   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)\r\n",
-      "   --- End of inner exception stack trace ---\r\n",
-      "   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)\r\n",
-      "   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)\r\n",
-      "   at System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)\r\n",
-      "   at System.RuntimeType.CreateInstanceImpl(BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture)\r\n",
-      "   at System.Activator.CreateInstance(Type type, Object[] args)\r\n",
-      "   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)\r\n",
-      "   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "❌ Erreur lors de l'exécution de l'agent : Exception has been thrown by the target of an invocation.\n",
       "   Note : la classe est bien importée et instanciable sur le\n",
       "   runtime CoreCLR. L'erreur résiduelle est la configuration du\n",
       "   backend IA : créez `config/settings.json` (modèle :\n",
@@ -886,7 +870,7 @@
     "        # constructeur). L'erreur résiduelle vient de la configuration du backend\n",
     "        # IA : Settings.LoadFromFile cherche `config/settings.json` (clé OpenAI /\n",
     "        # Azure), fichier à générer via le notebook de setup 0-AI-settings.ipynb.\n",
-    "        print(f\"❌ Erreur lors de l'exécution de l'agent : {e}\")\n",
+    "        print(f\"❌ Erreur lors de l'exécution de l'agent : {getattr(e, \"Message\", str(e))}\")\n",
     "        print(\"   Note : la classe est bien importée et instanciable sur le\")\n",
     "        print(\"   runtime CoreCLR. L'erreur résiduelle est la configuration du\")\n",
     "        print(\"   backend IA : créez `config/settings.json` (modèle :\")\n",
@@ -947,10 +931,10 @@
    "id": "1ca195b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T22:34:52.777758Z",
-     "iopub.status.busy": "2026-08-07T22:34:52.777200Z",
-     "iopub.status.idle": "2026-08-07T22:34:52.784197Z",
-     "shell.execute_reply": "2026-08-07T22:34:52.782692Z"
+     "iopub.execute_input": "2026-08-08T04:37:25.376501Z",
+     "iopub.status.busy": "2026-08-08T04:37:25.376284Z",
+     "iopub.status.idle": "2026-08-08T04:37:25.379983Z",
+     "shell.execute_reply": "2026-08-08T04:37:25.379441Z"
     }
    },
    "outputs": [
@@ -1081,7 +1065,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
Grain: DEEP/secrets — lane myia-po-2023:CoursIA-2 — prev: LIGHT/docs #9980

## Quoi
Fix 5 machine-path leaks in the committed cell outputs of `09-SemanticKernel-Building-CLR.ipynb` (the SemanticKernel .NET-CLR reflection notebook).

- **cell[8]** printed the absolute `dll_path` (`C:\dev\CoursIA-sk9-clr-fix\...`) in 5 places → now shows the relative suffix (`bin/Release/net9.0`).
- **cell[17]** printed the full .NET exception (`{e}`) including the stack trace with `.cs:line` source paths (`Settings.cs:line 135`, `NotebookUpdaterBase.cs:line 175/166`, `AutoInvokeSKAgentsNotebookUpdater.cs:line 13`) → now prints `e.Message` only.

This is **Stop & Repair** (secrets-hygiene rule 6): the committed OUTPUTS leaked absolute machine paths. The CAUSE was the SOURCE printing absolute paths / full stack traces. I fixed the **source** and **re-executed** — never hand-edited the outputs.

## Preuve
- Path-leak scan (absolute-path regex over all committed outputs): **5 → 0**.
- Source diff: cell[8] gains a `_rel_dll()` helper (relative suffix) — note the author already used `os.path.basename(_runtime_config)` one line below, so this extends an established pattern. cell[17] uses `getattr(e, "Message", str(e))`.
- Re-executed end-to-end via the **python3 kernel** (Python313 + pythonnet 3.0.5 + CoreCLR .NET 9): all code cells `execution_count != null`, 0 error-type outputs. cell[17]'s caught exception is the expected USER-HAND blocker (OpenAI key missing — `Configuration not found: config/settings.json`); it now prints only the honest message.
- H.3 validator (`scripts/notebook_tools/validate_pr_notebooks.py`): **9/9 cells PASS**.
- Exercise stubs (cells 6, 15, 20) preserved: "Exercice a completer" intact in source + output.

## Perimetre
1 file, 1 notebook, +68/-84 (net deletion = removed stack trace). Source-only fix + full re-exec. Catalogue byte-identique to origin/main. NB: criterion 1 of #9929 (CoreCLR boot config) was already solved by #9946 (merged); this PR cleans the path-leak evidence that #9946 left behind. Criterion 2 (end-to-end agent run) remains USER-HAND (needs an OpenAI key in `config/settings.json`).

See #9929

🤖 Generated with [Claude Code](https://claude.com/claude-code)