### PR TITLE
feat(genai,#2161): eval-choisir-son-modele — 3 exercise stubs (validator/scenario/lever)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/eval-choisir-son-modele.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/eval-choisir-son-modele.ipynb
@@ -402,6 +402,54 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex1-md-2161",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Écrire un validateur pour une propriété non couverte\n",
+    "\n",
+    "Le banc mesure quatre propriétés au moyen de cinq validateurs ayant tous la\n",
+    "même signature, `(rep, _tc) -> bool` (où `_tc` est la liste des *tool calls*,\n",
+    "ignorée par les validateurs qui n'en ont pas besoin). C'est ce squelette\n",
+    "uniforme qui rend le banc extensible : ajouter une propriété, c'est ajouter un\n",
+    "validateur de cette forme, puis un scénario qui l'utilise.\n",
+    "\n",
+    "Une propriété utile et **absente** du banc ci-dessus est la **concision** : un\n",
+    "chatbot de site qui délaye sa réponse dilue l'information et lasse le visiteur\n",
+    "qui cherchait un fait. Complétez `v_concision`, qui doit renvoyer `True` quand\n",
+    "la réponse fait **au plus 80 mots**.\n",
+    "\n",
+    "- **Objectif** — renvoyer `True` si `rep` contient ≤ 80 mots, `False` sinon.\n",
+    "- **Indice** — découpez `rep` sur les espaces (`str.split()` ignore les\n",
+    "  blancs surnuméraires) et comparez la longueur au seuil.\n",
+    "- **Étape 1** — compter les mots de `rep`.\n",
+    "- **Étape 2** — comparer au seuil de 80 et renvoyer le booléen.\n",
+    "\n",
+    "> Une fois votre validateur écrit, ajoutez-lui un scénario dans `SCENARIOS`\n",
+    "> (une question simple, par exemple « résume les horaires ») et relancez le\n",
+    "> banc : la nouvelle ligne apparaît dans le tableau de synthèse.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "ex1-code-2161",
+   "metadata": {},
+   "execution_count": 8,
+   "outputs": [],
+   "source": [
+    "def v_concision(rep, _tc):\n",
+    "    # Exercice 1 -- un validateur pour la concision.\n",
+    "    #\n",
+    "    # Renvoie True si la reponse fait au plus 80 mots, False sinon.\n",
+    "    # La signature (rep, _tc) est celle des autres validateurs ; _tc (les\n",
+    "    # tool_calls) est ignore ici.\n",
+    "    #\n",
+    "    # Indice : rep.split() decoupe sur les espaces en ignorant les blancs\n",
+    "    # surnumeraires. Comparez len(...) au seuil 80.\n",
+    "    return None  # TODO etudiant\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e74ebe08",
    "metadata": {},
    "source": [
@@ -936,6 +984,57 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex2-md-2161",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Durcir un cas : une réponse voisine mais fausse\n",
+    "\n",
+    "La section « Lire le tableau » recommande, devant un tableau tout vert, de\n",
+    "**durdir les cas** avant de conclure. Le scénario `ancrage_absent` teste un\n",
+    "refus franc : la réponse n'est nulle part dans le contexte. Mais c'est **le\n",
+    "piège auquel les modèles cèdent réellement** qui manque ici : un contexte\n",
+    "contenant une réponse *voisine mais fausse*, que le modèle peut confondre avec\n",
+    "la vraie.\n",
+    "\n",
+    "Construisez un tel scénario, au format des dicts de `SCENARIOS`.\n",
+    "\n",
+    "- **Objectif** — définir `scenario_voisin`, un dict avec les clés `cle`,\n",
+    "  `propriete`, `systeme`, `user`, `verif`, `outils`, `attendu`.\n",
+    "- **Indice** — ajoutez au `CONTEXTE` un montant plausible mais inexact (par\n",
+    "  exemple « frais de retard : 1,50 € par semaine »), puis posez une question\n",
+    "  dont la **vraie** réponse (le tarif d'abonnement) reste absente. Un modèle\n",
+    "  complaisant confondra le leurre avec la réponse.\n",
+    "- **Étape 1** — définir un `CONTEXTE_DURCI` incluant le leurre.\n",
+    "- **Étape 2** — remplir `scenario_voisin` en réutilisant `v_ancrage_absent`\n",
+    "  comme `verif` (le validateur exige à la fois le signalement d'absence **et**\n",
+    "  l'absence de montant — le leurre est un montant, donc il doit aussi être\n",
+    "  refusé).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "ex2-code-2161",
+   "metadata": {},
+   "execution_count": 9,
+   "outputs": [],
+   "source": [
+    "# Exercice 2 -- un scenario \"voisin mais faux\".\n",
+    "#\n",
+    "# Objectif : un dict au format de SCENARIOS ou le contexte contient un montant\n",
+    "# proche mais inexact, pour piéger un modele complaisant.\n",
+    "#\n",
+    "# Indice : ajoutez un leurre au contexte (ex. des frais de retard), puis posez\n",
+    "# la question du tarif d'abonnement (toujours absent). Reutilisez\n",
+    "# v_ancrage_absent comme verif : il exige le signalement d'absence ET l'absence\n",
+    "# de tout montant -- le leurre compris.\n",
+    "\n",
+    "CONTEXTE_DURCI = None  # TODO etudiant : CONTEXTE + un leurre (montant inexact)\n",
+    "\n",
+    "scenario_voisin = None  # TODO etudiant : dict(cle=..., propriete=..., ...)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c962a6a7",
    "metadata": {},
    "source": [
@@ -976,6 +1075,54 @@
     "\n",
     "Le point n'est pas d'avoir le banc parfait, mais de ne plus choisir un modèle sur\n",
     "trois questions bien choisies."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ex3-md-2161",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Du verdict au levier de plateforme\n",
+    "\n",
+    "Le tableau de transposition ci-dessus mappe « ce que le banc mesure » au levier\n",
+    "à actionner côté plateforme (AI-Engine ou Open WebUI). Mais c'est le **verdict**\n",
+    "(ACQUIS / INSTABLE / ÉCHEC) qui déclenche l'action : un `ACQUIS` ne demande\n",
+    "rien, un `ÉCHEC` sur l'ancrage appelle un durcissement immédiat.\n",
+    "\n",
+    "Écrivez une fonction qui, étant donné une propriété et son verdict, renvoie le\n",
+    "levier recommandé et l'action correctrice.\n",
+    "\n",
+    "- **Objectif** — `levier_pour(propriete, verdict)` renvoie une chaîne\n",
+    "  décrivant le levier + l'action (ou `None` si `ACQUIS`).\n",
+    "- **Indice** — appuyez-vous sur le tableau de transposition. Pour l'ancrage :\n",
+    "  consigne système + seuil/mode de recherche. Pour le format : sortie\n",
+    "  structurée native. Pour la langue : consigne système dans la langue cible.\n",
+    "  Pour l'outil : fonctions/MCP attachés au chatbot.\n",
+    "- **Étape 1** — choisir le levier selon la `propriete`.\n",
+    "- **Étape 2** — formuler l'action selon le `verdict` (rien si `ACQUIS`,\n",
+    "  surveillance si `INSTABLE`, correctif si `ÉCHEC`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "ex3-code-2161",
+   "metadata": {},
+   "execution_count": 10,
+   "outputs": [],
+   "source": [
+    "def levier_pour(propriete, verdict):\n",
+    "    # Exercice 3 -- du verdict au levier de plateforme.\n",
+    "    #\n",
+    "    # Renvoie le levier + l'action correctrice selon la propriete et son\n",
+    "    # verdict (ACQUIS / INSTABLE / ECHEC), ou None si rien a faire.\n",
+    "    #\n",
+    "    # Indice : table de transposition ci-dessus.\n",
+    "    #   Ancrage      -> consigne systeme + seuil/mode de recherche\n",
+    "    #   Format       -> sortie structuree native\n",
+    "    #   Langue       -> consigne systeme redigee dans la langue cible\n",
+    "    #   Appel d'outil-> fonctions/MCP attaches au chatbot\n",
+    "    # Et le verdict : ACQUIS = rien, INSTABLE = surveiller, ECHEC = corriger.\n",
+    "    return None  # TODO etudiant\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/enrichment — lane myia-po-2023:CoursIA-2 — prev: DEEP/secrets #9997

## Quoi

`eval-choisir-son-modele.ipynb` (AI-Engine-WordPress, #9734 livresagités) était à **0 exercice** — sous le seuil **>=3** de #2161. Ajout de **3 stubs d'exercice** (conformes C.1 : `return None` / assignment à `None`, jamais `raise NotImplementedError`), chacun précédé d'une cellule markdown (objectif + indice + étapes), répartis dans le notebook à la suite des exemples guidés :

| # | Exercice | Suit l'exemple | Étend |
|---|----------|----------------|-------|
| 1 | `v_concision(rep, _tc)` — validateur pour une nouvelle propriété (concision) | les 5 validateurs `v_*` de signature uniforme | ajoute une 5e propriété au banc |
| 2 | `scenario_voisin` — un cas « voisin mais faux » | les dicts `SCENARIOS` | durcit `ancrage_absent` (leurre dans le contexte) |
| 3 | `levier_pour(propriete, verdict)` — du verdict au levier plateforme | le tableau de transposition | mappe verdict → action correctrice |

## Preuve

- **Exécution réelle (C.2)** : chaque stub est autonome (aucun appel API) et **exécuté en subprocess isolé** (exit 0 chacun). `execution_count` 8/9/10 (suite logique de la séquence 1-7 du banc principal = « exécutés après le banc »), sorties réelles (vides — un `def`/assignment ne produit rien).
- **H.3 validator** : `validate_pr_notebooks.py` → **10/10 cells PASS**.
- **count_exercises.py --threshold 3** : **3 exercices, 0 sub-threshold** (le notebook passe désormais le seuil #2161).
- **nbformat.validate** : OK (v4.5).
- **C.1** : aucun `raise NotImplementedError` / `assert False` / `1/0` dans les stubs (regex de ban vérifiée).
- **Diff additions-only** : **147 insertions, 0 suppression** — les cellules existantes et leurs outputs (banc sur qwen3.6-35b-a3b) sont préservés byte-identique (C.3 respecté : je ne touche que le notebook modifié).

## Perimetre

- **1 fichier** : `eval-choisir-son-modele.ipynb` (+147, -0).
- **Aucune** modification du catalogue (`COURSE_CATALOG.generated.*` byte-identique à main — laissé au cron/CI).
- **Aucun** changement aux cellules API existantes (cells 3/4/6/7/9/10/11) ni à leurs outputs.
- Rebasé sur `origin/main` frais (`18607091e`) avant push.

`See #2161` (contribution partielle à l'Epic — un notebook de plus au-dessus du seuil ; l'Epic reste ouverte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)