### PR TITLE
docs(reference,#7422): fix phantom GradeBookApp path in common-commands.md

### DIFF
--- a/docs/reference/common-commands.md
+++ b/docs/reference/common-commands.md
@@ -72,8 +72,8 @@ Cf [claude-code-config.md](./claude-code-config.md) pour le detail agents/skills
 ## GradeBookApp
 
 ```bash
-python GradeBookApp/gradebook.py               # Python grading pipeline
-python GradeBookApp/run_epf_mis_2026.py         # EPF MIS multi-epreuves
+python GradeBookApp/gradebook.py               # Python grading pipeline (module core)
+python GradeBookApp/run_grading.py              # Runner generique (CLI argparse)
 ```
 
 Notation par cohorte (ECE, ESGF, ...) = privee sur GDrive `G:\Mon Drive\MyIA\Formation\<ecole>\<annee>\grading\` ; cf [GradeBookApp/configs/README.md](../../GradeBookApp/configs/README.md) pour le moteur generique.


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2023:CoursIA-2 — prev: MED/guard c.9872+36 (audit #9858)

## docs(reference,#7422): fix phantom GradeBookApp path in common-commands.md

> **Re-issuance of closed #9980.** PR #9980 was closed by the parallel
> session c.9872+36 as a perceived "duplicate of #9981" under G-VAR-3
> (2ᵉ MED/docs consecutive). The close was **incorrect**: this PR
> carries a distinct, minimal 1-file 2-line fix that **#9981 did not
> absorb**. Main still ships with the phantom path. This PR is the
> re-delivery of the same substance, on a fresh branch rebased on
> `origin/main` (`18607091e`).

## Le faux chemin

`docs/reference/common-commands.md` ligne 76 (main actuel) :
```
python GradeBookApp/run_epf_mis_2026.py         # EPF MIS multi-epreuves
```

**`run_epf_mis_2026.py` n'a jamais existé dans l'historique git** —
`git log --all -- GradeBookApp/run_epf_mis_2026.py` retourne 0 commit.
Les seuls scripts `GradeBookApp/*.py` présents sur le repo :
- `GradeBookApp/gradebook.py` — module core (functions, classes)
- `GradeBookApp/run_grading.py` — runner generique (CLI argparse)

Un user qui copierait la commande `python GradeBookApp/run_epf_mis_2026.py`
depuis la doc tomberait sur `ModuleNotFoundError`. C'est le **type exact
de phantom-path** que la vague de fix #8052 + l'audit #7422 ont éradiqué
du notebooks ; le docs/reference/ avait été oublié.

## La correction

```diff
 ```bash
 python GradeBookApp/gradebook.py               # Python grading pipeline
-python GradeBookApp/run_epf_mis_2026.py         # EPF MIS multi-epreuves
+python GradeBookApp/run_grading.py              # Runner generique (CLI argparse)
 ```
```

`run_grading.py` est le runner CLI réel (vérifié par lecture du fichier :
`argparse` + imports de `gradebook`). Le commentaire reflète son rôle
(runner generique) et non l'EPF MIS qui n'existe pas comme cohorte
publique — la pipeline par cohorte est sur GDrive (cf ligne 79).

## Pourquoi cette PR n'est PAS une doublon de #9981

| Aspect | PR #9981 | PR #9980 (cette ré-émission) |
|---|---|---|
| **Fichier touché** | `docs/reference/teaching-context.md` (accents) | `docs/reference/common-commands.md` (path GradeBookApp) |
| **Substance** | Restauration diacritiques (écoles, donné, etc.) | Phantom-path detection → correction |
| **Issue source** | Sub-issue #9984 (calendar freshness 2026-2027) | EPIC #7422 (docs/reference/ triage, item 1) |
| **Genre** | docs-restoration FR | docs-phantom-correction |
| **Caractère mergeable** | OPEN, en attente ai-01 | Cette PR |

Les deux PRs vivent sur **deux fichiers distincts** du même dossier
`docs/reference/`. Aucune ligne commune, aucun overlap de substance.
La fermeture de #9980 a supposé — sans vérification `git diff` ni `gh
pr diff` — que #9981 absorbait la correction ; ce n'était pas le cas.

## Périmètre

| Métrique | Valeur |
|---|---|
| Fichier modifié | 1 (`docs/reference/common-commands.md`) |
| Insertions / suppressions | +2 / −2 |
| Branche | `fix/c9980-gradebook-phantom-path` (fresh from `origin/main`) |
| Base | `18607091e feat(ict-25,#5105)...` (fresh, 0 jours retard) |
| Force push | NON (L284 respecté — première push sur branche nouvelle) |
| Catalogue | byte-identique à `origin/main` (catalog-pr-hygiene R1 ✓) |
| Marqueurs CATALOG-STATUS | inchangés (0 README racine/curriculum/docs touché) |

## Conformité rules

- **L898 ★★★ PRE-WRITE** : `gh pr list --search "run_epf|run_grading|GradeBookApp|phantom"` × `gh pr list --search "7422"` × `git worktree list` → 0 PR ouvert ne couvre ce path (CLOSED #9980 = même substance close à tort).
- **G.1 firsthand** : `git log --all -- GradeBookApp/run_epf_mis_2026.py` = 0 commit. Phantom confirmé.
- **L989 ★★★** : push via `GH_TOKEN=$(gh auth token --user jsboige) git -c credential.helper="!gh auth git-credential" push`.
- **L677-L4 ★★** : PR body généré HORS worktree (scratchpad).
- **L284** : pas de force push (première push).
- **catalog-pr-hygiene R1** : branche fresh from main, 0 drift catalogue (cf `git diff origin/main --stat`).
- **G.4 atomique** : 1 fichier, 1 sujet, 1 path-correction.
- **variation-protocol** : `MED/docs` (substance distincte : path-correction vérifiable vs garde précédente `MED/guard` = audit #9858).
- **G-VAR-3** : MED/docs **consécutif** à c.9872+36 (MED/guard), pas 2ᵉ MED/docs consécutif. Garde tenue.

## Voir aussi

- PR #9980 (CLOSED — substance close à tort par parallel session)
- PR #9981 (OPEN — teaching-context.md accents, scope disjoint)
- Issue #7422 (EPIC triage docs/reference/)
- Issue #8052 (vague anti-phantom antérieure sur notebooks)
- `git log --all -- GradeBookApp/run_epf_mis_2026.py` → 0 result (preuve phantom)
- `GradeBookApp/run_grading.py` — runner réel (argparse CLI)

See #7422.