### PR TITLE
fix(genai,#10000): stop machine-path leaks in Cross-Stitch Legacy outputs (Stop & Repair)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb
@@ -61,10 +61,10 @@
    "id": "aa3aa989",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T16:44:37.468581Z",
-     "iopub.status.busy": "2026-07-27T16:44:37.468391Z",
-     "iopub.status.idle": "2026-07-27T16:44:37.472176Z",
-     "shell.execute_reply": "2026-07-27T16:44:37.471780Z"
+     "iopub.execute_input": "2026-08-08T05:37:35.546759Z",
+     "iopub.status.busy": "2026-08-08T05:37:35.545649Z",
+     "iopub.status.idle": "2026-08-08T05:37:35.554943Z",
+     "shell.execute_reply": "2026-08-08T05:37:35.554295Z"
     },
     "papermill": {
      "duration": 0.007234,
@@ -89,10 +89,10 @@
    "id": "dbed0095",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T16:44:37.477526Z",
-     "iopub.status.busy": "2026-07-27T16:44:37.477372Z",
-     "iopub.status.idle": "2026-07-27T16:44:37.480326Z",
-     "shell.execute_reply": "2026-07-27T16:44:37.479709Z"
+     "iopub.execute_input": "2026-08-08T05:37:35.558714Z",
+     "iopub.status.busy": "2026-08-08T05:37:35.558045Z",
+     "iopub.status.idle": "2026-08-08T05:37:35.567333Z",
+     "shell.execute_reply": "2026-08-08T05:37:35.565099Z"
     },
     "papermill": {
      "duration": 0.006827,
@@ -136,10 +136,10 @@
    "id": "1c07097f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T16:44:37.491133Z",
-     "iopub.status.busy": "2026-07-27T16:44:37.490913Z",
-     "iopub.status.idle": "2026-07-27T16:44:37.739851Z",
-     "shell.execute_reply": "2026-07-27T16:44:37.739260Z"
+     "iopub.execute_input": "2026-08-08T05:37:35.571122Z",
+     "iopub.status.busy": "2026-08-08T05:37:35.570912Z",
+     "iopub.status.idle": "2026-08-08T05:37:35.793533Z",
+     "shell.execute_reply": "2026-08-08T05:37:35.792998Z"
     },
     "papermill": {
      "duration": 0.252347,
@@ -156,7 +156,7 @@
      "output_type": "stream",
      "text": [
       "Toutes les dependances sont disponibles\n",
-      "Nombre de references DMC chargees : 454 (depuis D:\\Dev\\CoursIA-2-c915-genai-image-prongb\\MyIA.AI.Notebooks\\GenAI\\Image\\..\\assets\\models\\DMC_colors.json)\n"
+      "Nombre de references DMC chargees : 454 (depuis DMC_colors.json)\n"
      ]
     }
    ],
@@ -237,7 +237,7 @@
     "    try:\n",
     "        with open(dmc_path, \"r\", encoding=\"utf-8\") as f:\n",
     "            DMC_COLORS = json.load(f)\n",
-    "        print(f\"Nombre de references DMC chargees : {len(DMC_COLORS)} (depuis {dmc_path})\")\n",
+    "        print(f\"Nombre de references DMC chargees : {len(DMC_COLORS)} (depuis {os.path.basename(dmc_path)})\")\n",
     "        break\n",
     "    except FileNotFoundError:\n",
     "        continue\n",
@@ -277,10 +277,10 @@
    "id": "2a3da1fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T16:44:37.749861Z",
-     "iopub.status.busy": "2026-07-27T16:44:37.749595Z",
-     "iopub.status.idle": "2026-07-27T16:44:37.754780Z",
-     "shell.execute_reply": "2026-07-27T16:44:37.754353Z"
+     "iopub.execute_input": "2026-08-08T05:37:35.795539Z",
+     "iopub.status.busy": "2026-08-08T05:37:35.795306Z",
+     "iopub.status.idle": "2026-08-08T05:37:35.800291Z",
+     "shell.execute_reply": "2026-08-08T05:37:35.799739Z"
     },
     "papermill": {
      "duration": 0.008671,
@@ -400,10 +400,10 @@
    "id": "4ccd0538",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T16:44:37.769282Z",
-     "iopub.status.busy": "2026-07-27T16:44:37.768993Z",
-     "iopub.status.idle": "2026-07-27T16:44:37.781632Z",
-     "shell.execute_reply": "2026-07-27T16:44:37.781218Z"
+     "iopub.execute_input": "2026-08-08T05:37:35.801973Z",
+     "iopub.status.busy": "2026-08-08T05:37:35.801828Z",
+     "iopub.status.idle": "2026-08-08T05:37:35.812908Z",
+     "shell.execute_reply": "2026-08-08T05:37:35.812380Z"
     },
     "papermill": {
      "duration": 0.016171,
@@ -649,10 +649,10 @@
    "id": "cf535356",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T16:44:37.793250Z",
-     "iopub.status.busy": "2026-07-27T16:44:37.792952Z",
-     "iopub.status.idle": "2026-07-27T16:44:37.839546Z",
-     "shell.execute_reply": "2026-07-27T16:44:37.839043Z"
+     "iopub.execute_input": "2026-08-08T05:37:35.814751Z",
+     "iopub.status.busy": "2026-08-08T05:37:35.814558Z",
+     "iopub.status.idle": "2026-08-08T05:37:35.832562Z",
+     "shell.execute_reply": "2026-08-08T05:37:35.832061Z"
     },
     "papermill": {
      "duration": 0.050284,
@@ -664,14 +664,6 @@
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_23832\\647826323.py:24: DeprecationWarning: 'mode' parameter is deprecated and will be removed in Pillow 13 (2026-10-15)\n",
-      "  return Image.fromarray(small_arr, mode=\"RGB\")\n"
-     ]
-    },
     {
      "data": {
       "image/jpeg": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAAQABgDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDvKjhmSdCyEkA45rzymRuzqS7FjuYZJz/Ear+0n/L+J8+pQ5Hda9D0/wDc/Z+/m5orzOis6eP5L6N3d9Xt5LTYJ1Oa2iVlbT+tz//Z",
@@ -715,7 +707,7 @@
     "    arr_reshaped = arr.reshape(new_h, block_size, new_w, block_size, 3)\n",
     "    small_arr = arr_reshaped.mean(axis=(1, 3)).astype(np.uint8)\n",
     "    \n",
-    "    return Image.fromarray(small_arr, mode=\"RGB\")\n",
+    "    return Image.fromarray(small_arr)\n",
     "\n",
     "if 'generated_image' in globals():\n",
     "    reduced_image = reduce_by_blocks(generated_image, block_size=BLOCK_SIZE)\n",
@@ -760,10 +752,10 @@
    "id": "8c187a3a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T16:44:37.850464Z",
-     "iopub.status.busy": "2026-07-27T16:44:37.850101Z",
-     "iopub.status.idle": "2026-07-27T16:44:37.853571Z",
-     "shell.execute_reply": "2026-07-27T16:44:37.853002Z"
+     "iopub.execute_input": "2026-08-08T05:37:35.834194Z",
+     "iopub.status.busy": "2026-08-08T05:37:35.834006Z",
+     "iopub.status.idle": "2026-08-08T05:37:35.838199Z",
+     "shell.execute_reply": "2026-08-08T05:37:35.837516Z"
     },
     "papermill": {
      "duration": 0.007084,
@@ -857,10 +849,10 @@
    "id": "de627f6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T16:44:37.870174Z",
-     "iopub.status.busy": "2026-07-27T16:44:37.869812Z",
-     "iopub.status.idle": "2026-07-27T16:44:37.884056Z",
-     "shell.execute_reply": "2026-07-27T16:44:37.883384Z"
+     "iopub.execute_input": "2026-08-08T05:37:35.839810Z",
+     "iopub.status.busy": "2026-08-08T05:37:35.839673Z",
+     "iopub.status.idle": "2026-08-08T05:37:35.849559Z",
+     "shell.execute_reply": "2026-08-08T05:37:35.849131Z"
     },
     "papermill": {
      "duration": 0.018242,
@@ -877,14 +869,6 @@
      "output_type": "stream",
      "text": [
       "Matching des couleurs DMC pour une image 24x16...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_23832\\749145445.py:57: DeprecationWarning: 'mode' parameter is deprecated and will be removed in Pillow 13 (2026-10-15)\n",
-      "  new_img = Image.fromarray(dmc_arr, mode=\"RGB\")\n"
      ]
     },
     {
@@ -963,7 +947,7 @@
     "    dmc_arr = dmc_colors[best_indices].reshape(h, w, 3).astype(np.uint8)\n",
     "    dmc_codes = np.array([dmc_code_list[i] for i in best_indices], dtype=object).reshape(h, w)\n",
     "\n",
-    "    new_img = Image.fromarray(dmc_arr, mode=\"RGB\")\n",
+    "    new_img = Image.fromarray(dmc_arr)\n",
     "    return new_img, dmc_codes\n",
     "\n",
     "\n",
@@ -1013,10 +997,10 @@
    "id": "b900050c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T16:44:37.898991Z",
-     "iopub.status.busy": "2026-07-27T16:44:37.898617Z",
-     "iopub.status.idle": "2026-07-27T16:44:37.902532Z",
-     "shell.execute_reply": "2026-07-27T16:44:37.901917Z"
+     "iopub.execute_input": "2026-08-08T05:37:35.850973Z",
+     "iopub.status.busy": "2026-08-08T05:37:35.850800Z",
+     "iopub.status.idle": "2026-08-08T05:37:35.854143Z",
+     "shell.execute_reply": "2026-08-08T05:37:35.853604Z"
     },
     "papermill": {
      "duration": 0.010188,
@@ -1288,10 +1272,10 @@
    "id": "cedaabe5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T16:44:37.925380Z",
-     "iopub.status.busy": "2026-07-27T16:44:37.925020Z",
-     "iopub.status.idle": "2026-07-27T16:44:37.928701Z",
-     "shell.execute_reply": "2026-07-27T16:44:37.928228Z"
+     "iopub.execute_input": "2026-08-08T05:37:35.855857Z",
+     "iopub.status.busy": "2026-08-08T05:37:35.855726Z",
+     "iopub.status.idle": "2026-08-08T05:37:35.859108Z",
+     "shell.execute_reply": "2026-08-08T05:37:35.858537Z"
     },
     "papermill": {
      "duration": 0.008906,
@@ -1333,6 +1317,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "stability",
+   "api_usd_est": 0.2,
+   "cpu_min": 2,
+   "external_account": "stability",
+   "free_alternative": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-23T08:45Z",
+   "network": true,
+   "notes": "Notebook LEGACY : transformation image vers patron de point de croix.\nPipeline : upload image → Stable Diffusion API (pixel art) → reduction palette DMC → grille.\nPalette DMC : fichier JSON local (pas d'API).\nCout reel depend du nombre d'iterations Stable Diffusion (~5-10 par demo).\nAlternative gratuite : Forge SD XL Turbo local (pas de cle API).",
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb",
+   "reproducibility": "LOW",
+   "validator": "papermill",
+   "vram_gb": 0,
+   "vram_tier": "LITE"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -1348,7 +1349,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.14"
   },
   "papermill": {
    "default_parameters": {},
@@ -1356,8 +1357,8 @@
    "end_time": "2026-07-27T16:44:38.179006",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA-2-c915-genai-image-prongb\\MyIA.AI.Notebooks\\GenAI\\Image\\04-Applications\\04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb",
-   "output_path": "D:\\Dev\\CoursIA-2-c915-genai-image-prongb\\MyIA.AI.Notebooks\\GenAI\\Image\\04-Applications\\04-4-Cross-Stitch-Pattern-Maker-Legacy_output.ipynb",
+   "input_path": "04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb",
+   "output_path": "04-4-Cross-Stitch-Pattern-Maker-Legacy_output.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },
@@ -1377,24 +1378,7 @@
   },
   "tags": [
    "NEEDS_INFRA"
-  ],
-  "cost": {
-   "api_usd_est": 0.2,
-   "api_provider": "stability",
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "LITE",
-   "network": true,
-   "external_account": "stability",
-   "free_alternative": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
-   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb",
-   "reproducibility": "LOW",
-   "metadata_written": "2026-07-23T08:45Z",
-   "validator": "papermill",
-   "notes": "Notebook LEGACY : transformation image vers patron de point de croix.\nPipeline : upload image → Stable Diffusion API (pixel art) → reduction palette DMC → grille.\nPalette DMC : fichier JSON local (pas d'API).\nCout reel depend du nombre d'iterations Stable Diffusion (~5-10 par demo).\nAlternative gratuite : Forge SD XL Turbo local (pas de cle API)."
-  }
+  ]
  },
  "nbformat": 4,
  "nbformat_minor": 5


### PR DESCRIPTION
Grain: MED/secrets — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #9999

Quoi: GenAI Cross-Stitch Pattern Maker Legacy — 2 cellules (cell[12], cell[17]) committaient un chemin machine `C:\Users\jsboi\AppData\Local\Temp\ipykernel_<PID>\<NN>.py` via une DeprecationWarning Pillow, + cell[5] commitait le worktree path absolu du fichier DMC_colors.json. Stop & Repair (secrets-hygiene regle 6) : corriger la cause source + re-executer, jamais hand-editer la sortie.
Preuve: re-exec BATCH_MODE reelle (nbconvert --execute, Pillow 12.2.0 + numpy 2.4.4, CPU-only). Verifie firsthand : 0 chemin machine (grep -F fiable sur Users\/C:\dev/D:\Dev/CoursIA-/ipykernel_/C:\Program = 0 chacun), 0 DeprecationWarning, 10/10 cells exec_count!=null, 0 erreur, 0 probeAddresses. H.3 validator 1/1 PASS. nbformat VALID. Catalogue byte-identique a main.
Perimetre: 1 notebook, +65/-81 (1 fichier). Pas de catalogue, pas de secret, pas de code metier touche (3 lignes source : 2x fromarray mode= retire, 1x basename pour DMC path). Variation G-VAR-3: genre secrets != prev notebook-python, famille GenAI (fraiche).

# Cross-Stitch Legacy — Stop & Repair des path leaks (secrets-hygiene regle 6, issue #10000)

## Cause racine — 3 leaks distincts, verifies firsthand

Issue #10000 caracterise ce notebook comme **cause A (env/cwd)** sur 2 outputs contenant `C:\Users\jsboi\...\ipykernel_23832\...`. Le diagnostic firsthand revele 3 causes source distinctes (le grep `Users\` de l'issue n'attrapait que la 1ere famille) :

1. **cell[12] L24 + cell[17] L57** — `Image.fromarray(arr, mode="RGB")`. Pillow a deprecie le kwarg `mode` (redondant : fromarray infere RGB depuis un array (H,W,3) uint8). Le `DeprecationWarning` emis portait le chemin temp du kernel `C:\Users\jsboi\AppData\Local\Temp\ipykernel_<PID>\<NN>.py:24`. **Category A** (chemin dynamique benin) dont la cause racine est un appel PIL deprecie.

2. **cell[5] L77** — `print(f"...(depuis {dmc_path})")` ou le 2e candidat de path (`os.path.join(os.path.dirname(os.path.abspath(".")), ...)`, L68) resout en **chemin absolu** `D:\Dev\<worktree>\...\DMC_colors.json`. **Category C** (source imprime le chemin). Le grep `Users\` de l'issue manquait celui-ci (c'est un chemin `D:\`, pas `C:\Users\`).

3. **metadata.papermill** — `input_path`/`output_path` pointaient vers l'ancien worktree `D:\Dev\CoursIA-2-c915-genai-image-prongb\...`. **Normalisation toleree** (regle 6 : metadata, pas une sortie) au `basename`.

## Le fix — Stop & Repair (jamais scrubber la sortie)

| Cellule | Avant | Apres | Cause |
|---|---|---|---|
| cell[12] L24 | `Image.fromarray(small_arr, mode="RGB")` | `Image.fromarray(small_arr)` | kwarg deprecie -> warning -> chemin temp |
| cell[17] L57 | `Image.fromarray(dmc_arr, mode="RGB")` | `Image.fromarray(dmc_arr)` | idem |
| cell[5] L77 | `(depuis {dmc_path})` | `(depuis {os.path.basename(dmc_path)})` | abspath imprime |
| metadata.papermill | abspath worktree | basename | metadata normalization (toleree) |

**Comportement preserve** : `Image.fromarray` sur un array (H,W,3) uint8 infere "RGB" automatiquement (c'est precisement pourquoi le `mode` explicite est deprecie). Le resultat image est identique. Le message DMC affiche `DMC_colors.json` (basename) au lieu du chemin absolu — l'info pedagogique (quel fichier charge) est preserveree.

## Validation — re-exec reelle (regle F + H.1)

- **Re-exec** : `BATCH_MODE=true nbconvert --to notebook --execute --inplace`. BATCH_MODE = design natif du notebook (cell[10] L26-56 cree une image de test synthetique 192x128, skippe `requests.post` L132 du branch interactif) -> **CPU-only, PIL/numpy, aucun appel a la stack GenAI**. Pillow 12.2.0 + numpy 2.4.4 (regle F : env fonctionne).
- **Leak scan (grep -F fiable, methode #10000)** : `Users\`=0, `C:\dev`=0, `D:\Dev`=0, `CoursIA-`=0, `ipykernel_`=0, `C:\Program`=0.
- **Gates** : 10/10 code cells `exec_count != null` (C.2), 0 `DeprecationWarning`, 0 sortie d'erreur, 0 `probeAddresses`.
- **H.3 validator** `validate_pr_notebooks.py` : 1/1 PASS (10 cells).
- **nbformat** : VALID.
- **Catalogue** : byte-identique a origin/main (R1).

## Verdict SOTA — SOTA-OK

Le vrai pipeline PIL/numpy tourne (reduction par blocs, matching DMC vectorise, generation de la grille). BATCH_MODE est le **design natif** du notebook pour l'execution headless/CI (cell[10] le documente explicitement), pas un workaround degrade. Le mode interactif (qui appellerait l'endpoint Stable Diffusion via `requests.post`) est un sujet distinct (depend de la stack GenAI), hors scope de ce fix de path-leak.

## Scope (HARD)

- 1 notebook, +65/-81. 3 lignes source changees (2 fromarray + 1 basename) + outputs regenerez + metadata normalizee. Pas de catalogue, pas de secret, pas de code metier.

## Variation (G-VAR-3)

Genre `secrets` (Stop & Repair) != prev `notebook-python` #9999 (enrichissement ICT). Famille GenAI (fraiche vs mes grains ICT recents). MED justifie : re-exec reelle + 3 causes source diagnostiquees firsthand (le grep de l'issue en manquait une). Distinct du 2e MED/tooling D5 evite ce cycle.

See #10000 (partial 1/5 — Cross-Stitch Legacy seulement ; les 4 notebooks Video sont RECOVERABLE-MACHINE vers po-2023 = machine GenAI, hors profil CPU po-2025), #3801 (registre SOTA, verdict SOTA-OK), #7422 (triage paths).
