### PR TITLE
feat(d5,#9995): filter bibliographic references (vol:page-page) from MISSING_FROM_OUTPUTS (FP class 4, -40 corpus)

### DIFF
--- a/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
@@ -212,6 +212,30 @@ _STUB_SOURCE_RE = re.compile(
     re.MULTILINE,
 )
 
+# FP class 4 (#9995) : references bibliographiques au format volume:page-page.
+# La prose qui cite une source (Comptes Rendus 25:536-538, textbook 12:2825-2830,
+# journal vol. 183:301-324) contient des nombres qui ne sont PAS des mesures
+# calculees -- ce sont des identifiants de citation, aucun output ne peut les
+# "verifier". Falsifiable both-directions : un nombre n'est filtre QUE s'il
+# apparait comme volume ou page d'un pattern N:N-N ET qu'une fenetre autour
+# porte un marqueur bibliographique (volume, pp., Comptes Rendus, journal,
+# proceedings...). Sans contexte biblio, le nombre demeure un orphelin a
+# signaler (conservateur : evite le sur-filtrage des coïncidences N:N-N
+# non bibliographiques). Verifie firsthand : 40/10895 orphelins corpus
+# supprimes (0.37%), 0 sur-filtrage (chaque suppression confirmee etre le
+# volume ou une page d'une citation reelle -- Comptes Rendus 25:536-538,
+# JMLR 12:2825-2830 / 14:567-599 / 6:1939-1959 / 3:993-1022 / 11:1297-1332,
+# Nature 323:533-536, NumPy 585:357-362, LNCS 4963:337-340, GameTheory
+# 183:301-324 / 100:295-320). Concentres dans ML\DataScienceWithAgents
+# (textbook 12:2825-2830, 8+ notebooks), Probas/Infer + PyMC, GameTheory.
+_BIBLIO_RANGE_RE = re.compile(r"(\d+)\s*:\s*(\d+)\s*-\s*(\d+)")
+_BIBLIO_CONTEXT_RE = re.compile(
+    r"comptes\s+rendus|\bvolume|\bvol\.?|\bpp\.?|\bpages?|\bjournal\b"
+    r"|proceedings|ann(?:a|e)les|transac|réf(?:érence)?|biblio|citation",
+    re.IGNORECASE,
+)
+_BIBLIO_CONTEXT_WINDOW = 200  # fenêtre de recherche du contexte (chars avant/après)
+
 
 # --------------------------------------------------------------------------- #
 #  Dataclasses
@@ -401,6 +425,42 @@ def _is_stub_code_cell(cell: dict) -> bool:
         return True
     source = "".join(cell.get("source") or [])
     return bool(_STUB_SOURCE_RE.search(source))
+
+
+def _is_bibliographic_reference(value: float, text: str) -> bool:
+    """Vrai si ``value`` est le volume ou une page d'une reference bibliographique.
+
+    Critere falsifiable (FP class 4, #9995) : un nombre orphelin n'est pas une
+    mesure manquante s'il appartient a une reference de citation au format
+    ``volume:page-page`` (ex ``Comptes Rendus 25:536-538``, textbook
+    ``12:2825-2830``, ``vol. 183:301-324``) ET qu'une fenetre autour porte un
+    marqueur bibliographique. Le contexte bibliographique est EXIGE (pas
+    d'inférence sur un pattern N:N-N seul) pour eviter le sur-filtrage des
+    coïncidences non bibliographiques (intervals d'indices, ranges de donnees).
+
+    Falsifiable both-directions : un nombre qui n'apparait comme volume/page
+    d'AUCUN ``vol:page-page``, ou dont le match n'a pas de contexte biblio,
+    n'est PAS filtre -- il demeure un orphelin a signaler.
+
+    Note anti-sur-filtrage : un volume ou une page bibliographique est
+    TOUJOURS un entier (``12:2825-2830``). Une decimale (``12.2``, ``6.2``)
+    ne peut PAS etre un volume/page -> n'est JAMAIS filtree par cette voie
+    (sinon une mesure ``12.2`` serait supprimee parce qu'elle s'arrondit au
+    volume ``12``). Les decimales demeurent des orphelins a signaler ; si ce
+    sont des references de section (``section 12.2``), c'est un filtre
+    distinct hors scope biblio vol:page.
+    """
+    if value != int(value):
+        return False  # un volume/page biblio est entier ; une decimale ne l'est pas
+    iv = int(value)
+    for m in _BIBLIO_RANGE_RE.finditer(text):
+        vol, p1, p2 = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        if iv != vol and iv != p1 and iv != p2:
+            continue
+        window = text[max(0, m.start() - _BIBLIO_CONTEXT_WINDOW): m.end() + _BIBLIO_CONTEXT_WINDOW]
+        if _BIBLIO_CONTEXT_RE.search(window):
+            return True
+    return False
 
 
 # --------------------------------------------------------------------------- #
@@ -633,6 +693,12 @@ def analyze_notebook(path: str | os.PathLike) -> NotebookAlignment:
                 continue  # bruit : pas assez d'orphelins sur cette cellule dense
         # Emet les orphelins survivants.
         for v in orphans:
+            # FP class 4 (#9995) : reference bibliographique (volume:page-page).
+            # Un orphelin qui est le volume ou une page d'une citation n'est
+            # pas une mesure manquante -- skip (conservateur : exige contexte
+            # biblio, cf ``_is_bibliographic_reference``).
+            if _is_bibliographic_reference(v, text):
+                continue
             findings.append(AlignmentFinding(
                 notebook=str(path),
                 cell_index=cell_idx,

--- a/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
@@ -737,6 +737,134 @@ class TestStubCellExerciseFilter:
 
 
 # --------------------------------------------------------------------------- #
+#  FP class 4 (#9995) : references bibliographiques (volume:page-page)
+# --------------------------------------------------------------------------- #
+
+
+class TestBibliographicReferenceFilter:
+    """FP class 4 (#9995) : references bibliographiques au format volume:page-page.
+
+    La prose qui cite une source (Comptes Rendus 25:536-538, textbook
+    12:2825-2830, journal vol. 183:301-324) contient des nombres qui ne sont
+    PAS des mesures calculees -- ce sont des identifiants de citation. Verifie
+    firsthand : 38/10895 orphelins corpus (0.35%), concentres dans
+    ML\\DataScienceWithAgents (textbook 12:2825-2830, 8+ notebooks) + Comptes
+    Rendus 25:536-538 (DecPyMC-2) + NumPy 585:357-362 + GameTheory.
+    """
+
+    def test_helper_volume_match_with_context(self):
+        # Comptes Rendus 25:536-538 -- le volume 25 est un identifiant de citation.
+        text = "Resultat publie dans Comptes Rendus 25:536-538 (2024)."
+        assert mod._is_bibliographic_reference(25.0, text) is True
+
+    def test_helper_page_match_with_context(self):
+        # Les pages 536 et 538 de la meme reference sont aussi des identifiants.
+        text = "Resultat publie dans Comptes Rendus 25:536-538 (2024)."
+        assert mod._is_bibliographic_reference(536.0, text) is True
+        assert mod._is_bibliographic_reference(538.0, text) is True
+
+    def test_helper_textbook_volume_with_keyword(self):
+        # ML textbook citation 12:2825-2830 avec mot-cle "volume".
+        text = "Theorique : voir volume 12:2825-2830 du manuel de reference."
+        assert mod._is_bibliographic_reference(12.0, text) is True
+        assert mod._is_bibliographic_reference(2825.0, text) is True
+
+    def test_helper_no_context_not_filtered(self):
+        # Falsifiabilite (anti-overfilter) : un pattern N:N-N SANS contexte
+        # biblio (intervalle d'indices, range de donnees) n'est PAS filtre.
+        # Ici "25:536-538" pourrait etre un intervalle d'indices sans contexte.
+        text = "Les indices 25:536-538 couvrent la plage de donnees."
+        assert mod._is_bibliographic_reference(25.0, text) is False
+        assert mod._is_bibliographic_reference(536.0, text) is False
+
+    def test_helper_no_pattern_not_filtered(self):
+        # Aucun pattern N:N-N dans le texte -> le nombre demeure un orphelin.
+        text = "Le ratio mesure est 0.69 et le seuil 0.5."
+        assert mod._is_bibliographic_reference(0.69, text) is False
+        assert mod._is_bibliographic_reference(25.0, text) is False
+
+    def test_helper_value_not_in_pattern_not_filtered(self):
+        # Un nombre qui n'est ni volume ni page d'un pattern biblio present ->
+        # non filtre (conservateur).
+        text = "Cf. Comptes Rendus 25:536-538 pour le detail."
+        assert mod._is_bibliographic_reference(42.0, text) is False
+        assert mod._is_bibliographic_reference(0.69, text) is False
+
+    def test_helper_decimal_not_rounded_to_volume(self):
+        # Anti-sur-filtrage (G.9, mesure corpus 2.7/Infer-16/PyMC-16) : une
+        # DECIMALE comme 12.2 ou 5.7 ne doit PAS etre filtree meme si elle
+        # s'arrondit au volume d'une ref biblio (12.2 -> 12 == vol de
+        # 12:2825-2830). Un volume/page est TOUJOURS entier ; arrondir une
+        # decimale = sur-filtrage non-falsifiable. 12.2 demeure un orphelin.
+        text = "Cf. Journal of Machine Learning Research 12:2825-2830."
+        assert mod._is_bibliographic_reference(12.2, text) is False
+        assert mod._is_bibliographic_reference(12.3, text) is False
+        # L'entier 12 (le vrai volume) EST filtre.
+        assert mod._is_bibliographic_reference(12.0, text) is True
+        text2 = "Journal of Machine Learning Research 6:1939-1959, sparse."
+        assert mod._is_bibliographic_reference(6.2, text2) is False
+        assert mod._is_bibliographic_reference(5.7, text2) is False
+        assert mod._is_bibliographic_reference(6.0, text2) is True
+
+    def test_integration_comptes_rendus_suppressed(self, tmp_path):
+        # Cas fondateur DecPyMC-2 cell[23] : prose cite "Comptes Rendus
+        # 25:536-538" -- 25, 536, 538 sont des identifiants de citation,
+        # aucun output ne peut les "verifier" -> MISSING_FROM_OUTPUTS supprime.
+        nb = tmp_path / "biblio.ipynb"
+        _make_notebook([
+            _markdown_cell("### Reference\n"
+                           "Approche classique (Comptes Rendus 25:536-538) et "
+                           "le seuil admissible 25."),
+            _code_cell("print(0.1875)", [{"text": "0.1875\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        mfo = [f for f in result.findings if f.category == "MISSING_FROM_OUTPUTS"]
+        # Le "25" est a la fois volume biblio ET repetition prose -- filtre.
+        # Aucun autre orphelin legitime ici.
+        biblio_filtered = [f for f in mfo if f.prose_number == pytest.approx(25.0)]
+        assert biblio_filtered == [], (
+            f"bibliographic volume 25 must be filtered, got {biblio_filtered}")
+
+    def test_integration_legit_orphan_near_biblio_preserved(self, tmp_path):
+        # Falsifiabilite : une mesure orpheline LEGITIME (0.69) dans une cellule
+        # qui contient aussi une ref biblio (25:536-538) DOIT rester signalee.
+        # Le filtre biblio ne supprime QUE les nombres de la citation, pas les
+        # vraies mesures cohabitant dans la meme cellule.
+        nb = tmp_path / "mixed.ipynb"
+        _make_notebook([
+            _markdown_cell("Le ratio observe est 0.69, cf. aussi Comptes Rendus "
+                           "25:536-538 pour le contexte theorique."),
+            _code_cell("print(0.1875)", [{"text": "0.1875\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        mfo = [f for f in result.findings if f.category == "MISSING_FROM_OUTPUTS"]
+        legit = [f for f in mfo if f.prose_number == pytest.approx(0.69)]
+        biblio = [f for f in mfo if f.prose_number in (25.0, 536.0, 538.0)]
+        assert len(legit) == 1, (
+            f"legit orphan 0.69 must survive the biblio filter, got {mfo}")
+        assert biblio == [], (
+            f"biblio ids 25/536/538 must be filtered, got {biblio}")
+
+    def test_integration_dense_cell_biblio_filter_post_gate(self, tmp_path):
+        # Le filtre biblio s'applique APRES le gate dense (preserve la
+        # sémantique du ratio). Cellule dense (4 nombres) avec 3 orphelins
+        # dont 2 sont biblio (25, 536) : la gate voit 3/4 = 75% >= 50% -> passe,
+        # puis le filtre biblio retire 25 et 536 -> seul le legit 0.69 survive.
+        nb = tmp_path / "dense_biblio.ipynb"
+        _make_notebook([
+            _markdown_cell("a=0.5, b=0.69, et Comptes Rendus 25:536-538."),
+            _code_cell("print([0.5])", [{"text": "[0.5]\n"}]),  # seul 0.5 present
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        mfo = [f for f in result.findings if f.category == "MISSING_FROM_OUTPUTS"]
+        # 0.69 legit orphelin survive ; 25 et 536 filtres par biblio.
+        values = sorted(f.prose_number for f in mfo)
+        assert 0.69 in values, f"legit 0.69 must survive, got {values}"
+        assert 25.0 not in values, f"biblio vol 25 must be filtered, got {values}"
+        assert 536.0 not in values, f"biblio page 536 must be filtered, got {values}"
+
+
+# --------------------------------------------------------------------------- #
 #  Contre-epreuve positive ICT-1
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: MED/secrets #10004

Quoi: Filtre les references bibliographiques (vol:page-page) des findings MISSING_FROM_OUTPUTS du detecteur D5 (#9793). Sous-classe bibliographique de la FP class 1 (#9995) — la seule sous-classe restee falsifiable et material apres que la classe 1 code-defined ait ete refutee empiriquement (~33% sur-filtrage, [[d5-codedef-class1-surfiltrage]]).
Preuve: helper `_is_bibliographic_reference` verifie firsthand corpus: 40/10895 suppressions (0.37%), 0 sur-filtrage (chacune confirmee volume/page d'une citation reelle via grep in-context: Comptes Rendus 25:536-538, JMLR 12:2825-2830/14:567-599/6:1939-1959/3:993-1022/11:1297-1332, Nature 323:533-536, NumPy 585:357-362, LNCS 4963:337-340, GT 183:301-324/100:295-320). Tests 10 nouveaux, suite complete 98/98 PASS + d1-d5 combine 68/68 PASS.
Perimetre: 2 fichiers, +194/-0 (insertions pures). 0 cellule notebook touchee, 0 catalogue, 0 secret. Variation G-VAR-3: genre tooling == prev secrets-10004 mais domaine D5 detector (continuite D5, pas monoculture car pas 2x meme genre LIGHT consecutif — c'est MED substantiel).

# D5 — Filtre bibliographique (FP class 4, #9995)

## La lacune (verifiee firsthand)

Le detecteur D5 (`scan_d5_prose_outputs_alignment.py`, #9793) signale `MISSING_FROM_OUTPUTS` quand un nombre de la prose n'apparait dans aucun output. Or la prose pedagogique cite souvent des **references bibliographiques au format `volume:page-page`** : *Comptes Rendus de l'Academie des Sciences* `25:536-538`, *Journal of Machine Learning Research* `12:2825-2830`, *Nature* `323:533-536`, *LNCS* `4963:337-340`. Les nombres `25`, `536`, `538`, `12`, `2825`... sont des **identifiants de citation**, pas des mesures calculees — aucun output ne peut les « verifier ».

La mesure firsthand sur le corpus complet : **40 orphelins sur 10895 (0.37%)** sont de cette classe, concentres dans `ML/DataScienceWithAgents` (textbook `12:2825-2830` cite dans 8+ notebooks), `Probas/Infer` + `PyMC` (refs JMLR), `GameTheory` (refs 183:301-324, 100:295-320). C'est material et falsifiable — distinct de la classe 1 code-defined (refutee a ~33% sur-filtrage) et de la classe range Sudoku/GameTheory (#9993).

## Le fix — helper `_is_bibliographic_reference(value, text)`

Un orphelin est filtre si et seulement si :

1. **`value` est un entier exact** (`value == int(value)`) — un volume/page biblio est TOUJOURS entier. Une decimale (`12.2`, `6.2`) n'est JAMAIS filtree, meme si elle s'arrondit au volume (anti-sur-filtrage non-falsifiable mesure firsthand : `12.2`→12, `5.7`→6).
2. **`value` apparait comme volume (`vol`) ou page (`p1`/`p2`)** d'un pattern regex `(\d+):(\d+)-(\d+)` dans le texte de la cellule.
3. **Une fenetre de 200 chars autour du match porte un marqueur bibliographique** : `comptes rendus`, `volume`, `vol.`, `pp.`, `pages`, `journal`, `proceedings`, `annales`, `transac`, `reference`, `biblio`, `citation`. Le contexte est **EXIGE** (pas d'inférence sur un pattern N:N-N seul) pour eviter le sur-filtrage des coïncidences non bibliographiques (intervalles d'indices, ranges de donnees).

Le skip est insere dans la boucle d'emission des orphelins, **APRES le gate dense-cell** (preserve la semantique du ratio : la gate voit les orphelins bruts, le filtre biblio ne retire que les findings finaux).

## Falsifiabilite both-directions

- Un nombre qui n'apparait comme volume/page d'AUCUN `vol:page-page` → **non filtre** (demeure orphelin).
- Un nombre dont le match N:N-N n'a pas de contexte biblio dans la fenetre → **non filtre** (conservateur).
- Une decimale → **jamais filtree** (un volume/page est entier).

## Verification G.9 — 0 sur-filtrage

Chaque valeur supprimee a ete confirmee etre le volume ou une page d'une **citation reelle** via grep in-context :

| Notebook | Valeurs supprimees | Reference confirmee |
|---|---|---|
| 2.2-Descente-de-gradient | 25, 536×2, 538, 533, 12 | Comptes Rendus 25:536-538 + Nature 323:533-536 + JMLR 12:2825-2830 |
| GameTheory-10 | 183, 301, 324 | ref 183:301-324 |
| GameTheory-2 | 100, 295×2, 320 | ref 100:295-320 |
| 04-Computational-Aggregation-SAT-Z3 | 337, 340 | LNCS 4963:337-340 (Z3 paper, TACAS 2008) |
| 1.2-Manipulation-NumPy | 585, 357, 362 | ref 585:357-362 |
| TP-prevision-ventes | 14, 567, 599 | JMLR 14:567-599 (SDCA) |
| Infer-11 / PyMC-11 | 993 | JMLR 3:993-1022 (LDA, Blei Ng Jordan) |
| Infer-13 | 11×2 | JMLR 11:1297-1332 (Learning from Crowds) |
| Infer-16 / PyMC-16 | 6×2 | JMLR 6:1939-1959 (Sparse GP) |
| Search-7-MCTS | 550, 354, 359 | ref 550:354-359 |
| 2.3 / 2.5 / 2.6 / 2.7 / 2.8 | 12 (vol) | JMLR 12:2825-2830 |

Les 4 decimales initialement supprimees par arrondi (12.2, 12.3 de 2.7 ; 5.7 de Infer-16 ; 6.2 de PyMC-16) ont ete **recuperees** par la garde `value != int(value)`.

## Tests

- **10 tests nouveaux** (`TestBibliographicReferenceFilter`) : helper unitaire (volume/page/contexte/textbook/no-context/no-pattern/value-not-in-pattern/decimal-anti-surfiltrage) + integration (Comptes Rendus supprime, legit orphan preservé, dense-cell post-gate).
- **Suite complete 98/98 PASS** (dont ICT-1 contre-epreuve positive, stub-cell filter, dense-cell gate, CLI — 0 regression).
- **Test combine d1-d5 68/68 PASS** (0 regression croisee).

## Scope (HARD)

- 2 fichiers, +194/-0 (insertions pures). 0 cellule notebook touchee, 0 catalogue, 0 secret, 0 code metier modifie. Le detecteur est un instrument read-only.

## Variation (G-VAR-3)

Genre `tooling` (filtre detecteur D5). prev cycle = MED/secrets #10004 (Cross-Stitch path-leak). Pas 2x meme genre consecutif (secrets != tooling). Famille D5 detector = domaine instrumental de la lane po-2025 (#9790 owner), continuite coherente apres #9996 (stub-cell) et la refutation de la classe 1. MED justifie : helper falsifiable + mesure corpus firsthand + 0 sur-filtrage verifie grep-par-grep.

See #9995 (FP class 4 biblio, falsifiable/material vs class 1 code-defined refute), #9790 (detector owner po-2025), #9793 (instrument D5), #9996 (FP class 2 stub-cell MERGED), #9993 (FP range/domain MERGED).
