### PR TITLE
ci(lean,i18n): cable check_i18n_siblings as per-PR drift gate (#10007)

### DIFF
--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -87,8 +87,10 @@ jobs:
         # are DUPLICATES of the FR file's, not new debt. Counting both double-inflates
         # the total above baseline (e.g. knot_lean: Reidemeister.lean(2) +
         # Reidemeister_en.lean(2) => 19 > baseline 17, a false FAIL — C513-L1, #6429).
-        # FR<->EN divergence is caught separately by the i18n drift CI, so nothing is
-        # hidden. This exclusion only ever LOWERS a count, never breaks a green lake.
+        # FR<->EN divergence is caught separately by the i18n sibling-drift CI
+        # (.github/workflows/lean-i18n-drift.yml, cables check_i18n_siblings.py
+        # #6711 as a per-PR gate -- See #10007), so nothing is hidden. This
+        # exclusion only ever LOWERS a count, never breaks a green lake.
         for f in $(find . -name '*.lean' ! -name '*_en.lean' -not -path './.lake/*'); do
           if [ -f "$f" ]; then
             case "$MODE" in

--- a/.github/workflows/lean-game-theory.yml
+++ b/.github/workflows/lean-game-theory.yml
@@ -41,7 +41,8 @@ name: Lean Game Theory CI
 # convention (code-style.md, signatures and proofs byte-identical, only
 # docstrings differ) Folk_en.lean's sorry is the SAME obligation as Folk.lean's,
 # not new debt -- counting both double-inflates past baseline (C513-L1, #6429).
-# FR<->EN divergence is caught separately by the i18n drift CI, so nothing hides.
+# FR<->EN divergence is caught separately by the i18n sibling-drift CI
+# (.github/workflows/lean-i18n-drift.yml, cables check_i18n_siblings.py -- See #10007), so nothing hides.
 #
 # Lake build: the reusable runs `lake exe cache get || true` then `lake -R build`,
 # which builds every @[default_target] of the lakefile -- SocialChoice,

--- a/.github/workflows/lean-i18n-drift.yml
+++ b/.github/workflows/lean-i18n-drift.yml
@@ -1,0 +1,86 @@
+name: Lean i18n Sibling Drift
+
+# CI gate for the Lean i18n byte-identity invariant (EPIC #4980).
+#
+# Convention #4980 (ratified 2026-07-04, cf .claude/rules/code-style.md §Lean
+# i18n): a French-canonical ``Foo.lean`` may carry an English mirror
+# ``Foo_en.lean``. Only the docstrings (``/- ... -/``) and comments (``-- ...``)
+# differ between the two; the code body -- signatures, theorem statements,
+# proofs, tactics -- stays BYTE-IDENTICAL, modulo the lines that legitimately
+# differ (``import`` / ``open`` / ``namespace`` / ``end``).
+#
+# This workflow cables the canonical checker ``check_i18n_siblings.py``
+# (#6711/#6718) as a per-PR gate. The checker EXISTS but, before this workflow,
+# was invoked by NOTHING in automation -- the invariant (184 pairs, 0 drift on
+# main) held by reviewer vigilance alone. The per-project ``lean-build.yml``
+# sorry-scan EXCLUDES ``*_en.lean`` (counting FR+EN double-inflates, C513-L1
+# #6429) and justified that exclusion by "the i18n drift CI", which did not
+# exist -- See #10007. This workflow makes that justification true.
+#
+# Pass/fail semantics (DECIDED, not deferred -- See #10007 design points):
+#
+#  - DRIFT  -> FAIL. A sibling pair whose code body diverges beyond the allowed
+#              import/open/namespace lines. This is the real regression signal:
+#              the byte-identity invariant is broken. A DRIFT line is a STARTING
+#              POINT for investigation (the checker knows three legitimate pair
+#              forms), not a verdict to execute verbatim -- line-verify the diff
+#              + ``lake build <target>_en`` before deciding a drift is
+#              intentional. docs/lean/i18n-sibling-patterns.md has the taxonomy.
+#  - ORPHAN -> FAIL. An ``_en`` file with no FR counterpart. Either add the FR
+#              sibling or remove the stray ``_en`` file.
+#  - UNBUILT -> advisory (PRINTED, never fails). A module absent from its
+#              lakefile roots/globs is a Lake-BUILD concern (a green Lake CI
+#              would be a false pass), not an i18n-drift concern. The one
+#              current case (social_choice_lean_peters PetersTour_en, INTRINSIC
+#              Peters v4.27 vendored library, #7081) must stay GREEN -- a gate
+#              that reddens on it on day one gets disarmed. The checker reports
+#              it so a reviewer SEES it; Lake build catches the compilation gap.
+#  - OK / OK-CONSUMER -> pass silently (the two validated pair forms).
+#
+# The checker's OWN exit code conflates UNBUILT with DRIFT/ORPHAN (any -> 1),
+# so this workflow re-derives pass/fail from the output lines rather than
+# trusting the exit code. The checker is NOT softened (its default stays strict
+# for manual ``python check_i18n_siblings.py --all`` use); the CI layer makes a
+# deliberate, named, single-category exemption that is readable right here.
+
+on:
+  pull_request:
+    paths:
+      - '**/*.lean'
+      - 'scripts/lean/check_i18n_siblings.py'
+      - '.github/workflows/lean-i18n-drift.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  i18n-drift:
+    name: i18n sibling byte-identity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check i18n sibling drift
+        run: |
+          set +e
+          # Run the canonical checker across every Lean project. Its exit code
+          # is 1 on ANY DRIFT/ORPHAN/UNBUILT; we do NOT trust that code, we
+          # re-derive the verdict from the output lines so UNBUILT (advisory)
+          # does not redden the gate. Full output is echoed so every status --
+          # including the advisory UNBUILT line and the summary -- is visible.
+          output="$(python scripts/lean/check_i18n_siblings.py --all 2>&1)"
+          echo "$output"
+          echo "---"
+          if echo "$output" | grep -qE '^(DRIFT|ORPHAN) '; then
+            echo "FAIL: Lean i18n sibling drift detected (DRIFT/ORPHAN above)."
+            echo "The FR/EN code body must stay byte-identical -- only docstrings"
+            echo "and comments differ (EPIC #4980). A DRIFT line is a starting"
+            echo "point for investigation: line-verify the diff and"
+            echo "\`lake build <target>_en\` before concluding the drift is"
+            echo "intentional. See docs/lean/i18n-sibling-patterns.md."
+            exit 1
+          fi
+          echo "OK: 0 DRIFT, 0 ORPHAN. i18n byte-identity invariant holds."
+          echo "(any UNBUILT line above is advisory -- a Lake-build concern,"
+          echo "not an i18n-drift concern; See #10007, #7081.)"


### PR DESCRIPTION
## Grain: DEEP/ci-infra — lane myia-po-2023:CoursIA-2 — prev: LIGHT/verification c.9872+40

## Quoi
Cable le checker canonique d'i18n byte-identity `check_i18n_siblings.py` (#6711) comme gate CI per-PR sur `**/*.lean`. Le checker **existait mais n'etait invoque par rien** en automatique : l'invariant 184 paires / 0 drift tenait par la seule vigilance des relecteurs, et `lean-build.yml` justifiait son exclusion des `*_en.lean` du sorry-scan par « the i18n drift CI » — une CI **qui n'existait pas** (#10007). Révélé par #9967 : un DRIFT de 5 blocs FR-only sur `Knots/Invariant.lean` a passé tous les checks verts et n'a été trouvé qu'en lançant le checker à la main.

## Preuve (firsthand, origin/main @ 6e494c57d)
```
$ python scripts/lean/check_i18n_siblings.py --all
... 182 OK + 2 OK-CONSUMER ...
UNBUILT .../social_choice_lean_peters/PetersTour_en.lean  (Peters v4.27 #7081)
182/184 pairs byte-identical | 2 consumer-pattern | 0 drift | 0 orphan | 1 unbuilt
$ echo $?  -> exit 1 (cause: UNBUILT)
```
Simulation **exacte** de l'étape CI (capture output + `grep -E '^(DRIFT|ORPHAN) '`): **PASS** — gate né vert, comme l'exige #10007.
- YAML validé (`yaml.safe_load` OK).
- 0 référence « i18n drift CI » non qualifiée restante après fix des 2 commentaires.

## Decisions design (#10007, tranchées pas différées)
1. **Bloquant sur DRIFT/ORPHAN** (le vrai signal de régression), pas pure advisory — l'invariant est à 0 drift donc un gate bloquant est tenable **maintenant** ; une ligne DRIFT est un **point de départ d'investigation** (3 formes de paire légitimes), surfaçée pour un humain, jamais auto-résolue.
2. **UNBUILT reste vert** : le code de sortie du checker confond UNBUILT avec DRIFT/ORPHAN (any → 1), donc le gate **re-déduit** le verdict des lignes de sortie (`grep ^DRIFT|^ORPHAN`) plutôt que du exit code. Le checker **n'est pas assoupli** (son défaut reste strict pour l'usage manuel) ; la couche CI pose **une seule exemption nommée et lisible** dans le workflow.

## Perimetre
3 fichiers, +92/−3, atomique (un sujet : cabler le gate i18n-drift + rendre vrais les commentaires qui le référencent) :
- **`.github/workflows/lean-i18n-drift.yml`** (nouveau) — gate per-PR.
- **`.github/workflows/lean-build.yml:90`** — commentaire corrigé (pointe vers le workflow réel).
- **`.github/workflows/lean-game-theory.yml:44`** — seconde instance de la même fausse référence, corrigée.

Hors scope (respecté) : ne pas assouplir le checker (interdit par #10007) ; ne pas élargir l'exclusion sorry-scan. Le checker n'est pas modifié — son défaut reste strict.

Closes #10007

🤖 Generated with [Claude Code](https://claude.com/claude-code)