### PR TITLE
ci(lean, #10007): cable check_i18n_siblings as PR gate (PetersTour_en whitelisted, #7081)

### DIFF
--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -87,8 +87,12 @@ jobs:
         # are DUPLICATES of the FR file's, not new debt. Counting both double-inflates
         # the total above baseline (e.g. knot_lean: Reidemeister.lean(2) +
         # Reidemeister_en.lean(2) => 19 > baseline 17, a false FAIL — C513-L1, #6429).
-        # FR<->EN divergence is caught separately by the i18n drift CI, so nothing is
-        # hidden. This exclusion only ever LOWERS a count, never breaks a green lake.
+        # FR<->EN body divergence is caught separately by the dedicated job
+        # `.github/workflows/lean-i18n-drift.yml` (#10007), which invokes
+        # `scripts/lean/check_i18n_siblings.py --all` and FAILs on real drift /
+        # orphan / non-whitelisted unbuilt. The exemption list lives there,
+        # NAMED (PetersTour_en, #7081 INTRINSIC). This exclusion only ever LOWERS
+        # a count here, never breaks a green lake.
         for f in $(find . -name '*.lean' ! -name '*_en.lean' -not -path './.lake/*'); do
           if [ -f "$f" ]; then
             case "$MODE" in

--- a/.github/workflows/lean-i18n-drift.yml
+++ b/.github/workflows/lean-i18n-drift.yml
@@ -1,0 +1,56 @@
+name: Lean i18n sibling drift
+
+# Cable the FR<->EN sibling body-identity invariant (#4980 convention) on PRs
+# that touch Lean code. Without this job, the sorries scan in lean-build.yml
+# excludes `*_en.lean` mirrors (legitimate — counting FR+EN double-inflates the
+# total above baseline, C513-L1 #6429), but nothing else in CI catches the
+# compensating drift: a French file gains a new `def` or `theorem` whose EN
+# mirror never follows. See #10007.
+#
+# The checker canonical to #4980 lives at `scripts/lean/check_i18n_siblings.py`
+# (#6711 / #6718). It is **NOT** a Lake-build step — it only proves the bodies
+# have not drifted apart (cf `lean-merge-discipline.md` §1: lake build SUCCESS
+# stays mandatory for module compilation). It exits non-zero on:
+#   - drift       — a real divergence between FR canonical and EN mirror;
+#   - orphan      — an `*_en.lean` whose FR sibling is missing;
+#   - unbuilt     — an `_en` mirror Lake never compiles (a green Lean CI is a
+#                   false pass for it — the #6749 orphan-trap, which the body
+#                   comparison alone cannot catch).
+# It runs in **advisory** mode on `HALF-DONE` pairs (FR was probably never
+# localized — #7763); the counter never flips the exit code.
+#
+# Exemptions: NAMED only, never wildcarded — same discipline as `allow-axioms`
+# in `pr-review-discipline.md` §B. The single current exemption is PetersTour_en
+# (Peters v4.27 INTRINSIC, #7081), where `lake build` cannot compile the mirror
+# for an external reason. A new UNBUILT entry must be investigated and added by
+# name; do NOT relax the checker.
+#
+# Trigger: any PR that touches `**/*.lean` or the checker / this workflow.
+# `paths` is a denylist-complement (the inverse filter is `!` lines).
+on:
+  pull_request:
+    paths:
+      - "**/*.lean"
+      - "scripts/lean/check_i18n_siblings.py"
+      - ".github/workflows/lean-i18n-drift.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  i18n-drift:
+    name: "i18n sibling drift"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: "Check FR i18n body byte-identity (allow-list PetersTour_en #7081)"
+        run: |
+          set -eu
+          python scripts/lean/check_i18n_siblings.py --all \
+            --allow-unbuilt MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/PetersTour_en.lean

--- a/scripts/lean/check_i18n_siblings.py
+++ b/scripts/lean/check_i18n_siblings.py
@@ -522,6 +522,21 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("paths", nargs="*", help="files or directories to scan")
     parser.add_argument("--all", action="store_true",
                         help="scan the whole repository")
+    parser.add_argument(
+        "--allow-unbuilt", action="append", default=[],
+        metavar="RELATIVE_PATH",
+        help=(
+            "Whitelist one unbuilt `_en` mirror (path relative to repo root, "
+            "repeatable). The mirror is still scanned and reported as UNBUILT, "
+            "but the exit code does NOT flip on it. Use NAMED exemptions only "
+            "(never a wildcard) — same discipline as `allow-axioms` "
+            "(pr-review-discipline §B): a gate that can never rouge is not a "
+            "gate. Reserved for INTRINSIC exceptions where `lake build` cannot "
+            "compile the mirror for an external reason (e.g. PetersTour_en "
+            "tracks Peters v4.27, #7081). A new UNBUILT entry must be "
+            "investigated and added by name; do NOT relax the checker."
+        ),
+    )
     args = parser.parse_args(argv)
 
     repo_root = Path(__file__).resolve().parents[2]
@@ -532,12 +547,22 @@ def main(argv: list[str] | None = None) -> int:
     else:
         parser.error("provide PATH(s) or --all")
 
+    # Normalize whitelist to POSIX strings relative to repo root; accept either
+    # forward or backslashes (Windows runner + Linux runner share the same file).
+    allow_unbuilt: set[str] = set()
+    for raw in args.allow_unbuilt:
+        # `str(Path)` on Windows yields backslashes; normalize to POSIX so the
+        # whitelist round-trips identically between runner OS.
+        norm = str(Path(raw)).replace("\\", "/")
+        allow_unbuilt.add(norm)
+
     en_files = find_en_files(scan_paths)
     if not en_files:
         print("No *_en.lean sibling files found — nothing to check.")
         return 0
 
     passed = consumer = failed = orphan = unbuilt = half_done = 0
+    unbuilt_whitelisted = 0
     for en in sorted(en_files):
         fr = fr_sibling(en)
         if not fr.exists():
@@ -549,9 +574,16 @@ def main(argv: list[str] | None = None) -> int:
         # sit outside the build, which is exactly the failure CI misses.
         built, why = check_en_built(en, repo_root)
         if built is False:
+            # Compute the same POSIX-normalized path the CLI flag uses, so the
+            # whitelist matches regardless of OS runner.
+            rel = en.resolve().relative_to(repo_root.resolve()).as_posix()
+            whitelisted = rel in allow_unbuilt
             unbuilt += 1
-            print(f"UNBUILT {en}")
+            tag = "  [WHITELISTED]" if whitelisted else ""
+            print(f"UNBUILT {en}{tag}")
             print(f"        {why}")
+            if whitelisted:
+                unbuilt_whitelisted += 1
         status, detail = check_pair(fr, en)
         if status == "OK":
             passed += 1
@@ -576,13 +608,18 @@ def main(argv: list[str] | None = None) -> int:
     total = passed + consumer + failed + orphan
     print(f"\n{passed}/{total} pairs byte-identical"
           f" | {consumer} consumer-pattern | {failed} drift | {orphan} orphan"
-          f" | {unbuilt} unbuilt"
+          f" | {unbuilt} unbuilt ({unbuilt_whitelisted} whitelisted)"
           f" | {half_done} half-done (advisory)")
     # NB: half_done is ADVISORY — it does NOT flip the exit code. Some
     # legitimate scenarios produce identical bodies (shared licence header,
     # verbatim bibliographic citation, etc.) and a human must triage. The
-    # exit code remains a hard fail on real drift / orphan / unbuilt.
-    return 0 if (failed == 0 and orphan == 0 and unbuilt == 0) else 1
+    # exit code remains a hard fail on real drift / orphan / non-whitelisted
+    # unbuilt. Whitelisted unbuilt mirrors are reported as UNBUILT in the log
+    # but excluded from the exit-code computation (cliquet: the exemption is
+    # named at the call site, never wildcarded — same discipline as the
+    # `allow-axioms` whitelist in pr-review-discipline §B).
+    effective_unbuilt = unbuilt - unbuilt_whitelisted
+    return 0 if (failed == 0 and orphan == 0 and effective_unbuilt == 0) else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# ci(lean, #10007): cable `check_i18n_siblings` as PR gate (PetersTour_en whitelisted, #7081)

Grain: MED/lean-ci — lane myia-po-2025:CoursIA-2 — prev: MED/refactor #9989 c.1301+8 (docs-archive-move-coupling, MERGED a53fb1eb)

## TL;DR

`.github/workflows/lean-build.yml` excluait les jumeaux `*_en.lean` du scan sorry en invoquant une *« i18n drift CI »* qui n'existait pas (`grep -r check_i18n_siblings .github/workflows/` → vide). Le filet de compensation est cable :
- **nouveau job** `.github/workflows/lean-i18n-drift.yml` -> FAIL sur `drift | orphan | unbuilt` (cliquet)
- **nouveau flag** `--allow-unbuilt <path>` sur `check_i18n_siblings.py` (exemption **par nom**, jamais wildcard — discipline `allow-axioms`)
- **commentaire `lean-build.yml`** mis a jour : le filet existe desormais

L'invariant est tenu sur `main` : 0 drift, 0 orphan, 1 unbuilt whitelistable (PetersTour_en, Peters v4.27 INTRINSIC #7081). Le job nalt vert.

## Cause (G.1 firsthand)

Issue #10007 documente le constat verbatim :
```
$ grep -rl check_i18n_siblings .github/workflows/          -> (vide)
$ grep -rln 'check_i18n_siblings' --include='*.yml' --include='*.sh' --include='*.ps1' .   -> (vide)
$ grep -niE 'i18n|sibling' .pre-commit-config.yaml         -> aucun hook
```

Incident fondateur : **PR #9967** ajoute 5 blocs (`def tricolorForwardExtension` + 3 theoremes-pivots + 1 theoreme) a `Knots/Invariant.lean` seul. Cliquet sorry rougit pour une raison sans rapport, mais le drift i18n n'a ete trouve qu'en lancant le checker **a la main** :
```
DRIFT   knot_lean/Knots/Invariant_en.lean
5 block(s) only in FR
```

L'exclusion `*_en.lean` est legitime (C513-L1, #6429) — compter FR+EN double-inflate. Le probleme est que le filet invoque pour la compenser est absent.

## Diff (3 fichiers, +103/-6)

```diff
$ git diff --stat
 .github/workflows/lean-build.yml    |  8 +++++--
 scripts/lean/check_i18n_siblings.py | 45 +++++++++++++++++++++++++++++++++----
 .github/workflows/lean-i18n-drift.yml (new, 56 lines)
```

### 1. `scripts/lean/check_i18n_siblings.py` (cœur du fix)

- Nouveau flag `--allow-unbuilt <RELATIVE_PATH>` (repeatable, chemins normalises POSIX pour round-trip Windows/Linux runner)
- Compteur `unbuilt_whitelisted` distinct du compteur `unbuilt`
- Sortie enrichie : `UNBUILT <path>  [WHITELISTED]` + summary line `| N unbuilt (M whitelisted)`
- Exit code : `0 if (failed == 0 and orphan == 0 and effective_unbuilt == 0) else 1` ou `effective_unbuilt = unbuilt - unbuilt_whitelisted`
- Discipline : exemption **par nom explicite uniquement** (cf pr-review-discipline §B : `allow-axioms` utilise la meme regle, un wildcard detruit la propriete « un nouveau unbuilt rougit »)

### 2. `.github/workflows/lean-i18n-drift.yml` (nouveau, parallele)

- Trigger : `pull_request` paths-filter `**/*.lean` + `scripts/lean/check_i18n_siblings.py` + le workflow lui-meme
- `ubuntu-latest` + `actions/setup-python@v5` + checker avec whitelist PetersTour_en
- Commentaire d'en-tete : explique **pourquoi** separe de `lean-build.yml` (single-responsibility : ce job = pas Lake build, juste invariant body byte-identity)

### 3. `.github/workflows/lean-build.yml` (correction commentaire)

Le commentaire « FR<->EN divergence is caught separately by the i18n drift CI, so nothing is hidden » est **mis a jour** : la CI qu'il invoque existe desormais. Laisser le commentaire d'origine apres le cablage serait pire que l'etat actuel (le harnais documenterait un mensonge).

## Validation H.1

```bash
$ cd d:/dev/CoursIA-2-c1301x10-lean-i18n-ci
$ python scripts/lean/check_i18n_siblings.py --all --allow-unbuilt \
    MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/PetersTour_en.lean
...
182/184 pairs byte-identical | 2 consumer-pattern | 0 drift | 0 orphan | 1 unbuilt (1 whitelisted) | 0 half-done (advisory)
EXIT=0
```

Valide sur la branche. **SANS** `--allow-unbuilt`, le checker retourne `EXIT=1` (deux unbuilt sur le main reel via `--all` ; un seul dans le worktree car le submodule `CoursIA-2-c728-prover-mine-lean-guards` est exclu par `EXCLUDE_PARTS`).  

- **AST parse** : `python -c "import ast; ast.parse(open('scripts/lean/check_i18n_siblings.py').read())"` OK
- **YAML parse** : `yaml.safe_load(.github/workflows/lean-i18n-drift.yml)` OK (jobs=`['i18n-drift']`, trigger paths filtres)
- **Quote YAML** : `name:` contient un `:`, d'ou le `"..."` autour de la valeur (lesson apprise ce cycle — note pour ne pas re-mordre)

## Design-gates tranches

| Question | Decision | Justification |
|---|---|---|
| Bloquant ou advisory ? | **Bloquant** | L'invariant est tenu (0 drift / 0 orphan) — un gate bloquant nalt vert et ne rougit que sur une vraie divergence. Cf axiome-allowlist lesson. |
| Whitelist : nom ou wildcard ? | **Nom explicite** | Discipline `allow-axioms` (pr-review-discipline §B). Un wildcard detruit le cliquet. |
| Comment gerer PetersTour_en ? | Whitelist explicite PetersTour_en | Peters v4.27 INTRINSIC, #7081 — `lake build` ne peut pas compiler le miroir pour une raison externe. |
| Reusable dans `lean-build.yml` ou workflow separe ? | **Workflow separe** | Single-responsibility : checker = pas Lake build. Caller de `lean-build.yml` reste 24 workflows inchanges. |
| HALF-DONE pair en advisory ? | **Advisory (unchanged)** | Cf le checker original : legitimes (shared licence header, verbatim citation) ; un humain doit trier. |

## Conformite regles

| Regle | Statut | Preuve |
|---|---|---|
| **G.1 verify-before-claiming** | ✓ | grep 1ᶜ main confirme l'absence de la CI invoquee (pas claim non-verifie) |
| **lean-merge-discipline §1** | N/A | pas de fichier `*.lean` touche dans cette PR — pas de `lake build` requis |
| **pr-review-discipline §B** | ✓ | exemption par nom (PetersTour_en), pas de wildcard — disclipline `allow-axioms` |
| **catalog-pr-hygiene R1** | ✓ | catalogue non touche (pas de `COURSE_CATALOG.generated.json`) |
| **catalog-pr-hygiene R3** | ✓ | 1 PR = 1 sujet (cabler LE checker i18n, pas un composite) |
| **c.187 UNIQUE commit HARD** | ✓ | 1 commit, 3 fichiers, +103/-6 |
| **H.1 validation exec** | ✓ | checker exit=0 sur la branche, AST parse OK, YAML parse OK |
| **variation-protocol G-VAR-1** | ✓ | MED/lean-ci (substance + re-execution + change quelque chose) |
| **variation-protocol G-VAR-3** | ✓ | prev=MED/refactor #9989 (genre distinct lean-ci) |
| **L284** | N/A | pas de push force, premier push |
| **L677-L4 ★★ body HORS worktree** | ✓ | body = scratchpad `<scratchpad-dir>/c1301x10_pr_body_10007.md` |
| **L898 ★★★ collision guard** | ✓ | `gh pr list --search "check_i18n_siblings OR lean-build OR 10007"` + `gh pr list --search "10007 OR i18n"` → 0 PR concurrente |
| **L282 mirror-lanes** | ✓ | claim pose sur issue #10007 (`[CLAIMED] lane myia-po-2025:CoursIA-2`) avant commencer |
| **L983 spirit** | ✓ | 5 PRs jsboige OPEN ce cycle (coherent, pas saturant owner) |
| **L984 workflow** | ✓ | clause #10007 evaluee avant action : 1 design-gate tranche (bloquant + exemption par nom) |
| **C9872+36-L1 G.9** | ✓ | « issue acceptance « rely on existing CI » confrontee a grep = CI n'existe pas, cabler » |

## Anti-patterns evites

- **Pas de wildcard** dans la whitelist (cliquet detruit)
- **Pas de merge dans le checker** (single-responsibility : verifier, pas compiler)
- **Pas de modification du test main** : `EXCLUDE_PARTS` reste inchange, on ajoute juste un flag
- **Pas de commentaire mensonger** post-cablage : `lean-build.yml` update reflette la realite

## Liens

- **#10007** — issue parente (cablage CI manquant)
- **#4980** — Lean i18n convention (FR canonical + EN mirror)
- **#6711 / #6718** — `check_i18n_siblings.py` checker initial
- **#6429** — pourquoi l'exclusion `*_en.lean` existe (C513-L1)
- **#7081** — PetersTour_en Peters v4.27 INTRINSIC
- **#6749** — orphan-trap guard (unbuilt hors build)
- **#7763** — HALF-DONE pair advisory class
- **#9967** — incident fondateur (drift decouvert a la main)
- **PR #9989** — sub-sœur c.1301+8 docs-archive-move-coupling (MERGED a53fb1eb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
