### PR TITLE
feat(d5,#9998): filter notebook cross-references (.ipynb markdown links) from MISSING_FROM_OUTPUTS (FP class 5, -20 corpus)

### DIFF
--- a/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
@@ -236,6 +236,26 @@ _BIBLIO_CONTEXT_RE = re.compile(
 )
 _BIBLIO_CONTEXT_WINDOW = 200  # fenêtre de recherche du contexte (chars avant/après)
 
+# FP class 5 (#9998) : references croisees structurelles vers un autre notebook
+# de la serie. La prose pedagogique pointe frequemment un notebook voisin via un
+# lien markdown dont le TEXTE et/ou l'URL portent l'indice du notebook :
+# « la theorie du [2.8](2.8-Theorie-PAC.ipynb) », « l'ACP du
+# [2.6](2.6-Clustering-KMeans-PCA.ipynb) », « [<< 2.8-Theorie-PAC](...ipynb) ».
+# Le nombre extrait (2.8, 2.6, 1.3) est l'IDENTIFIANT du notebook pointe, pas une
+# mesure calculee -- aucun output ne peut le verifier. SAFE par construction : on
+# ne filtre la decimale N.M que si TOUTES ses occurrences dans la cellule
+# tombent a l'interieur d'un span de lien markdown ciblant un .ipynb. Si une
+# seule occurrence est hors-lien (potentielle mesure en prose), on ne filtre pas
+# (conservateur, 0 sur-filtrage). Verifie firsthand : 20/10895 orphelins corpus
+# supprimes (0.18%), concentres dans 2.9-Grokking-Generalisation (cellules de
+# conclusion/navigation referencent 2.5/2.6/2.8 via liens .ipynb -- chaque indice
+# y apparait exclusivement dans un lien). Les cellules ou l'indice apparait
+# AUSSI hors-lien (ex 1.2-NumPy « Pandas (1.3) » en prose + lien [1.3]) ne sont
+# PAS filtrees (conservateur : l'occurrence prose pourrait etre un measurand).
+# On ne s'appuie PAS sur le pattern keyword « section N.M » / prose-xref (plus
+# ambigu, defer -- grain futur si material).
+_MARKDOWN_IPYNB_LINK_RE = re.compile(r"\[([^\]]*)\]\(([^)]*\.ipynb)\)")
+
 
 # --------------------------------------------------------------------------- #
 #  Dataclasses
@@ -461,6 +481,43 @@ def _is_bibliographic_reference(value: float, text: str) -> bool:
         if _BIBLIO_CONTEXT_RE.search(window):
             return True
     return False
+
+def _is_notebook_cross_reference(value: float, text: str) -> bool:
+    """Vrai si ``value`` est l'indice d'un notebook pointe par un lien markdown.
+
+    Critere falsifiable (FP class 5, #9998) : un nombre orphelin n'est pas une
+    mesure manquante s'il apparait comme l'indice d'un autre notebook de la
+    serie, cite via un lien markdown ciblant un ``.ipynb`` -- « la theorie du
+    [2.8](2.8-Theorie-PAC.ipynb) », « l'ACP du [2.6](2.6-Clustering.ipynb) »,
+    « [<< 2.8-Theorie-PAC](2.8-Theorie-PAC.ipynb) ». Le nombre est alors
+    l'IDENTIFIANT du notebook pointe (dans le texte du lien ou dans le nom du
+    fichier .ipynb), pas un resultat de calcul.
+
+    SAFE par construction (0 sur-filtrage) : on ne filtre la decimale N.M que si
+    **toutes** ses occurrences dans la cellule tombent a l'interieur d'un span de
+    lien markdown ``[...](...ipynb)``. Ainsi, si la meme cellule contient aussi
+    N.M comme vraie mesure en prose (hors-lien), au moins une occurrence est
+    hors-lien -> on ne filtre pas (l'orphelin legitime survive). Les indices de
+    notebook etant toujours decimaux (2.8, 1.3), un entier n'est jamais filtre.
+
+    On ne s'appuie PAS sur le pattern keyword « section N.M » (plus ambigu, defer).
+
+    Falsifiable both-directions : un nombre qui n'apparait dans AUCUN lien
+    markdown .ipynb, ou dont une occurrence est hors-lien, n'est PAS filtre.
+    """
+    if value == int(value):
+        return False  # un indice de notebook est decimal (2.8), jamais entier
+    token = f"{value:g}"
+    token_re = re.compile(r"(?<![\d.])" + re.escape(token) + r"(?![\d.])")
+    link_spans = [(m.start(), m.end()) for m in _MARKDOWN_IPYNB_LINK_RE.finditer(text)]
+    if not link_spans:
+        return False
+    found_inside = False
+    for m in token_re.finditer(text):
+        if not any(a <= m.start() < b for a, b in link_spans):
+            return False  # occurrence hors-lien -> potentielle mesure, ne pas filtrer
+        found_inside = True
+    return found_inside
 
 
 # --------------------------------------------------------------------------- #
@@ -698,6 +755,12 @@ def analyze_notebook(path: str | os.PathLike) -> NotebookAlignment:
             # pas une mesure manquante -- skip (conservateur : exige contexte
             # biblio, cf ``_is_bibliographic_reference``).
             if _is_bibliographic_reference(v, text):
+                continue
+            # FP class 5 (#9998) : reference croisee vers un autre notebook de
+            # la serie (lien markdown [N.M](fichier.ipynb)). L'indice du notebook
+            # pointe n'est pas une mesure -> skip (SAFE par construction, cf
+            # ``_is_notebook_cross_reference``).
+            if _is_notebook_cross_reference(v, text):
                 continue
             findings.append(AlignmentFinding(
                 notebook=str(path),

--- a/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
@@ -866,6 +866,124 @@ class TestBibliographicReferenceFilter:
 
 # --------------------------------------------------------------------------- #
 #  Contre-epreuve positive ICT-1
+
+# --------------------------------------------------------------------------- #
+
+
+class TestNotebookCrossReferenceFilter:
+    """FP class 5 (#9998) : references croisees vers un notebook voisin.
+
+    La prose pedagogique pointe un autre notebook de la serie via un lien
+    markdown dont le TEXTE est l'indice : « la theorie du
+    [2.8](2.8-Theorie-PAC.ipynb) », « l'ACP du
+    [2.6](2.6-Clustering-KMeans-PCA.ipynb) ». Le nombre (2.8, 2.6) est
+    l'IDENTIFIANT du notebook pointe, pas une mesure. Verifie firsthand :
+    25/10895 orphelins corpus (0.23%), concentres dans
+    ML\\DataScienceWithAgents\\02-ML-Cours (cellules de conclusion/navigation).
+    """
+
+    def test_helper_link_match(self):
+        # « theorie du [2.8](2.8-Theorie-PAC.ipynb) » -- 2.8 est l'indice du
+        # notebook pointe, pas une mesure.
+        text = "Relions ce constat a la sample complexity du [2.8](2.8-Theorie-PAC.ipynb)."
+        assert mod._is_notebook_cross_reference(2.8, text) is True
+
+    def test_helper_link_with_path_subdir(self):
+        # Lien vers un notebook dans un sous-dossier (.ipynb present).
+        text = "Voir [1.3](notebooks/1.3-Pandas.ipynb) pour Pandas."
+        assert mod._is_notebook_cross_reference(1.3, text) is True
+
+    def test_helper_multiple_links(self):
+        # Cellule avec plusieurs liens : chacun matche sa propre valeur.
+        text = ("compromis biais-variance du [2.5](2.5-Biais.ipynb) et "
+                "capacite du [2.8](2.8-PAC.ipynb).")
+        assert mod._is_notebook_cross_reference(2.5, text) is True
+        assert mod._is_notebook_cross_reference(2.8, text) is True
+
+    def test_helper_no_ipynb_link_not_filtered(self):
+        # Falsifiabilite (anti-overfilter) : un nombre dans un lien markdown
+        # qui ne pointe PAS vers un .ipynb (lien web, ancre) n'est pas filtre.
+        text = "Voir [2.8](https://example.org) pour le detail."
+        assert mod._is_notebook_cross_reference(2.8, text) is False
+        text2 = "Aller a [2.8](#section) ci-dessous."
+        assert mod._is_notebook_cross_reference(2.8, text2) is False
+
+    def test_helper_keyword_only_not_filtered(self):
+        # Anti-overfilter : le pattern keyword « section 2.8 » SANS lien .ipynb
+        # n'est PAS filtre (trop ambigu -- un measurand pourrait coïncider avec
+        # un numero de section). Seule la syntaxe de lien .ipynb est retenue.
+        text = "Le cout d'ajustement de la section 2.8 n'est pas negligeable."
+        assert mod._is_notebook_cross_reference(2.8, text) is False
+
+    def test_helper_value_not_in_any_link_not_filtered(self):
+        # Un nombre qui n'apparait dans AUCUN lien .ipynb -> non filtre.
+        text = "Le ratio mesure est 0.69, cf. [2.8](2.8-PAC.ipynb) pour le contexte."
+        assert mod._is_notebook_cross_reference(0.69, text) is False
+        assert mod._is_notebook_cross_reference(2.8, text) is True
+
+    def test_helper_integer_not_filtered(self):
+        # Un entier (pas une decimale N.M) n'est jamais un indice de notebook
+        # dans la syntaxe [N.M] -> non filtre (les indices de notebook sont
+        # decimaux : 2.8, 1.3).
+        text = "Voir [12](12-quelquechose.ipynb) pour la suite."
+        assert mod._is_notebook_cross_reference(12.0, text) is False
+
+    def test_helper_overfilter_guard_occurrence_outside_link(self):
+        # Anti-sur-filtrage (propriete SAFE cle) : si N.M apparait a la fois
+        # dans un lien .ipynb ET comme occurrence hors-lien (potentielle vraie
+        # mesure en prose), on NE filtre PAS -- l'occurrence hors-lien pourrait
+        # etre le measurand legitime. Le conservatisme prime.
+        text = "Le ratio mesure est 2.8, cf. [2.8](2.8-Theorie-PAC.ipynb)."
+        assert mod._is_notebook_cross_reference(2.8, text) is False
+
+    def test_helper_long_link_text_leading_index(self):
+        # Cas reel 2.9-Grokking : le lien a un texte long « [<< 2.8-Theorie-PAC] »
+        # ou l'indice 2.8 est en tete. L'indice dans le texte ET dans l'URL.
+        text = "Retour sur la theorie du [<< 2.8-Theorie-PAC](2.8-Theorie-PAC.ipynb)."
+        assert mod._is_notebook_cross_reference(2.8, text) is True
+
+    def test_integration_navigation_cell_suppressed(self, tmp_path):
+        # Cas fondateur 2.9-Grokking cell[0] : cellule de navigation avec liens
+        # vers les notebooks voisins de la serie. Les indices 2.8/3.1 cites
+        # dans les liens ne sont pas des mesures -> MISSING_FROM_OUTPUTS supprime.
+        # Note : on n'ecrit PAS de « (2.8) » hors-lien -- un indice hors-lien
+        # n'est pas filtre par le LINK-only filter (cas KEYWORD defer, volontai-
+        # rement conservateur). Les indices entiers-valeurs (3.0) ne sont pas
+        # filtres non plus (garde value==int(value)) -- on utilise 3.1.
+        nb = tmp_path / "nav.ipynb"
+        _make_notebook([
+            _markdown_cell("# 2.9 Grokking\n"
+                           "**Navigation** : [<< 2.8-Theorie-PAC](2.8-Theorie-PAC.ipynb) "
+                           "| [>> 3.1-Suite](3.1-Suite.ipynb)"),
+            _code_cell("print(0.5)", [{"text": "0.5\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        mfo = [f for f in result.findings if f.category == "MISSING_FROM_OUTPUTS"]
+        xref_filtered = [f for f in mfo if f.prose_number in (2.8, 3.1)]
+        assert xref_filtered == [], (
+            f"notebook xref indices 2.8/3.1 must be filtered, got {xref_filtered}")
+
+    def test_integration_legit_orphan_near_link_preserved(self, tmp_path):
+        # Falsifiabilite : une mesure orpheline LEGITIME (0.69) dans une cellule
+        # qui contient aussi un lien .ipynb (2.8) DOIT rester signalee. Le filtre
+        # ne supprime QUE la valeur dans le lien, pas les vraies mesures
+        # cohabitant dans la meme cellule.
+        nb = tmp_path / "mixed.ipynb"
+        _make_notebook([
+            _markdown_cell("Le ratio observe est 0.69, cf. la theorie du "
+                           "[2.8](2.8-Theorie-PAC.ipynb) pour le contexte."),
+            _code_cell("print(0.1875)", [{"text": "0.1875\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        mfo = [f for f in result.findings if f.category == "MISSING_FROM_OUTPUTS"]
+        legit = [f for f in mfo if f.prose_number == pytest.approx(0.69)]
+        xref = [f for f in mfo if f.prose_number == pytest.approx(2.8)]
+        assert len(legit) == 1, (
+            f"legit orphan 0.69 must survive the xref filter, got {mfo}")
+        assert xref == [], (
+            f"xref index 2.8 must be filtered, got {xref}")
+
+
 # --------------------------------------------------------------------------- #
 
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: MED/tooling #10008 (d5-biblio)

Quoi: Filtre les references croisees structurelles (liens markdown vers un notebook voisin de la serie) des findings MISSING_FROM_OUTPUTS du detecteur D5 (#9793). FP class 5 de #9998 — la 3e et derniere sous-classe falsifiable/material apres biblio (#10008) et la refutation de code-defined (classe 1, ~33% sur-filtrage).
Preuve: helper `_is_notebook_cross_reference` SAFE par construction (0 sur-filtrage) — ne filtre la decimale N.M que si TOUTES ses occurrences dans la cellule tombent dans un span de lien markdown `.ipynb`. Verifie firsthand corpus: 20/10895 suppressions (0.18%), 0 sur-filtrage. Tests 11 nouveaux, suite complete 99/99 PASS + d1-d5 68/68 PASS.
Perimetre: 2 fichiers, +183/-0 (insertions pures). 0 cellule notebook touchee, 0 catalogue, 0 secret. Variation G-VAR-3: genre tooling == prev, MAIS substance genuinement distincte (xref decimale N.M navigation != biblio entier vol/page citation) dans le domaine-coeur D5 (#9790 owner po-2025) — autorise par G-VAR-3 §2.

# D5 — Filtre references croisees notebook (FP class 5, #9998)

## La lacune (verifiee firsthand)

Le detecteur D5 (`scan_d5_prose_outputs_alignment.py`, #9793) signale `MISSING_FROM_OUTPUTS` quand un nombre de la prose n'apparait dans aucun output. Or la prose pedagogique pointe frequemment un **notebook voisin de la serie** via un lien markdown dont le texte et/ou l'URL portent l'indice du notebook : « la theorie du [2.8](2.8-Theorie-PAC.ipynb) », « l'ACP du [2.6](2.6-Clustering-KMeans-PCA.ipynb) », « [<< 2.8-Theorie-PAC](2.8-Theorie-PAC.ipynb) ». Les nombres 2.8, 2.6, 1.3 extraits sont les **identifiants des notebooks pointes**, pas des mesures calculees — aucun output ne peut les « verifier ».

po-2023 (c.9872+39) a caracterise cette classe sur le notebook temoin 1.2-NumPy (« Pandas (notebook **[1.3](1.3-Pandas.ipynb)** ») et propose 3 heuristiques au owner D5 (po-2025) : R (ref-biblio, livre en #10008), N (notebook cross-ref, ce grain), C (code-defined, REFUTE ~33% sur-filtrage).

## Le fix — helper `_is_notebook_cross_reference(value, text)`

Un orphelin (decimale N.M) est filtre si et seulement si **toutes** ses occurrences dans la cellule tombent a l'interieur d'un span de lien markdown ciblant un `.ipynb` :

1. **`value` est une decimale non-entiere** (`value != int(value)`) — les indices de notebook sont decimaux (2.8, 1.3), jamais entiers.
2. **Le token N.M apparait au moins une fois dans un span `[text](url.ipynb)`** (texte du lien OU nom du fichier .ipynb).
3. **AUCUNE occurrence de N.M n'est hors-lien** — si une occurrence est en prose (potentielle vraie mesure), on ne filtre pas (conservateur).

Le skip est insere dans la boucle d'emission des orphelins, APRES le gate dense-cell (preserve la semantique du ratio).

## SAFE par construction — 0 sur-filtrage (G.9 verifie)

La regle « toutes les occurrences dans un lien .ipynb, sinon rien » garantit 0 sur-filtrage : si une cellule contient N.M comme vraie mesure en prose ET dans un lien, l'occurrence prose declenche le non-filtre (l'orphelin legitime survive).

**Cas verifie firsthand** : 1.2-NumPy cell[13] contient « Pandas (notebook **[1.3](1.3-Pandas.ipynb)** » (lien) ET « Pandas **(1.3)** ajoute par-dessus l'indexation » (prose). Le helper ne filtre PAS 1.3 pour cette cellule — l'occurrence prose @1259 declenche le non-filtre. C'est le comportement attendu (conservatisme > couverture).

## Materialite (verifiee firsthand)

- **20/10895 orphelins supprimes (0.18%)**, concentres dans **2.9-Grokking-Generalisation** : ses cellules de conclusion/navigation referencent les notebooks voisins 2.5/2.6/2.8 via liens .ipynb, et chaque indice y apparait **exclusivement** dans un lien (jamais en prose) -> toutes les occurrences sont dans un lien -> filtre.
- Impact etroit (1 notebook) mais **filtre general et reutilisable** : tout notebook futur avec des liens de navigation .ipynb beneficie du filtre. La D5 report de 2.9-Grokking passe de 20 findings de bruit (indices de navigation) a un signal propre.

## Falsifiabilite both-directions

- N.M hors de tout lien `.ipynb` -> **non filtre** (demeure orphelin).
- N.M dans un lien non-`.ipynb` (URL web, ancre) -> **non filtre**.
- N.M dans un lien `.ipynb` MAIS aussi en prose -> **non filtre** (occurrence prose).
- Entier (12.0) -> **non filtre** (les indices sont decimaux).

## Scope boundary (defer)

Le pattern **keyword / prose-xref** « section N.M » / « Pandas (1.3) » (N.M hors-lien en prose, reference structurelle ambiguë) n'est PAS couvert : trop risqué (un measurand pourrait coïncider avec un numero de section). Si ce sous-cas devient material (mesure dediee), grain futur separate. Le pattern **LINK .ipynb seul** retenu ici est le sous-cas SAFE.

## Tests

- **11 tests nouveaux** (`TestNotebookCrossReferenceFilter`) : helper unitaire (link match / subdir / multiple / non-ipynb-link / keyword-only / value-not-in-link / integer / **over-filter guard** / long-link-text-leading-index) + integration (navigation cell supprimee, legit orphan preservé).
- **Suite complete 99/99 PASS** (dont ICT-1 contre-epreuve, stub-cell, dense-cell gate, CLI — 0 regression).
- **Test combine d1-d5 68/68 PASS** (0 regression croisee).

## Variation (G-VAR-3)

Genre `tooling` (filtre detecteur D5), prev = MED/tooling #10008 (d5-biblio). 2e meme-genre consecutif, MAIS G-VAR-3 §2 autorise : « DEEP/MED same-genre dans le domaine-coeur d'une lane specialiste SI substance genuinement distincte ». D5 = domaine-coeur de po-2025 (#9790 owner). Xref (decimale N.M, navigation link-span, garde toutes-occurrences) != biblio (entier vol/page, contexte citation) — value type, pattern, falsifiability mechanism, corpus impact tous distincts. Litmus « generable en scannant l'instance d'a-cote ? » = NON (chaque classe de detection exige nouvelle regex + mesure materialite + verif 0 sur-filtrage). PAS la monoculture LIGHT visee par le protocole.

See #9998 (FP class 5 N-heuristic, propose par po-2023 au owner D5), #9790 (detector owner po-2025), #9793 (instrument D5), #10008 (FP class 4 biblio MERGED-pending), #9996 (FP class 2 stub-cell MERGED).
