### PR TITLE
docs(harness,#7423): remove 2 dead ~/.claude/projects/ machine-path links (sub-grain)

### DIFF
--- a/.claude/rules/catalog-pr-hygiene.md
+++ b/.claude/rules/catalog-pr-hygiene.md
@@ -41,4 +41,3 @@ Cette discipline est ce qui fait **baisser le compte d'issues** sans interventio
 - [.claude/rules/git-workflow.md](git-workflow.md) — branches `feature/`, no force push, no direct main push
 - [.claude/rules/proactive-coordination.md](proactive-coordination.md) — 1 PR/wakeup, atomique
 - [.claude/rules/pr-review-discipline.md](pr-review-discipline.md) — §A composites trop larges
-- `~/.claude/projects/d--CoursIA/memory/stale-catalog-silent-revert.md` — incident fondateur

--- a/.claude/rules/model-delegation.md
+++ b/.claude/rules/model-delegation.md
@@ -1,6 +1,6 @@
 # Delegation a des sous-agents — modele explicite obligatoire (sonnet/haiku par defaut)
 
-S'applique a **tout agent qui delegue du travail a un sous-agent** (`Agent()` tool), quel que soit le role (coordinateur ai-01 ou worker po-*). Source : mandat user 2026-06-09 (« tout sous-agent doit avoir un modele explicite, sonnet ou haiku typiquement, et uniquement Opus dans des cas exceptionnels qui le justifient »), consolide avec le mandat 2026-06-07 sur la delegation read-heavy. 7 tests confirmants (HAUTE qualite) — detail des angles morts par classe de tache : `~/.claude/projects/d--CoursIA/memory/delegation-glm-haiku-quality.md`.
+S'applique a **tout agent qui delegue du travail a un sous-agent** (`Agent()` tool), quel que soit le role (coordinateur ai-01 ou worker po-*). Source : mandat user 2026-06-09 (« tout sous-agent doit avoir un modele explicite, sonnet ou haiku typiquement, et uniquement Opus dans des cas exceptionnels qui le justifient »), consolide avec le mandat 2026-06-07 sur la delegation read-heavy. Les angles morts observes par classe de tache sont synthetises ci-dessous (section « Angles morts connus »).
 
 ## Regle HARD — modele explicite obligatoire
 
@@ -23,7 +23,7 @@ S'applique a **tout agent qui delegue du travail a un sous-agent** (`Agent()` to
 
 6. **Local-git-only quand l'appelant tient une fenetre `gh auth`.** Un sous-agent qui appellerait `gh` pendant que l'appelant a bascule `gh auth switch -u jsboige` corromprait l'etat d'auth global (race). Donner au sous-agent des ops **`git` locales uniquement** (`git diff origin/main...origin/<branch>`, `git show`, `sha1sum`, `grep`, `Read`), pas de `gh`. L'appelant fait les ops `gh` lui-meme, hors fenetre sous-agent.
 
-7. **Evaluer la qualite et la memoriser.** Apres chaque delegation, noter dans `delegation-glm-haiku-quality.md` : type de tache, qualite (HAUTE/MOYENNE/FAIBLE), ce qui a ete exact, et l'**angle mort** observe. Les angles morts connus par classe de tache orientent quoi re-verifier soi-meme.
+7. **Evaluer la qualite et la memoriser.** Apres chaque delegation, noter dans le journal de delegation local per-machine (`<projet>/.claude/agent-memory-local/delegation-quality.md`, gitignore) : type de tache, qualite (HAUTE/MOYENNE/FAIBLE), ce qui a ete exact, et l'**angle mort** observe. Les angles morts connus par classe de tache orientent quoi re-verifier soi-meme.
 
 ## Angles morts connus (re-verifier soi-meme)
 


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2024:CoursIA — prev: MED/audit (forensic-floor) #10012

## Quoi

Deux règles du harnais pointaient vers une mémoire **per-machine** sous `~/.claude/projects/d--CoursIA/memory/` — un chemin (a) gitignored (scope local par machine) et (b) **machine-hash-spécifique** (`d--CoursIA` sur une machine, `c--dev-CoursIA` sur une autre), donc **mort cross-machine par construction**. Même défaut que celui déjà corrigé en `git-workflow.md:83` (sub-grain L576) : « la doc pérenne vit dans `docs/`, pas dans `~/.claude/projects/` ».

- `catalog-pr-hygiene.md:44` → `stale-catalog-silent-revert.md` « incident fondateur »
- `model-delegation.md:3` → `delegation-glm-haiku-quality.md` « angles morts par classe de tâche »

## Preuve

**Anti-pendule (subtract first) — la substance pointée est déjà préservée inline, le retrait ne laisse aucun trou :**

- `catalog-pr-hygiene.md` : l'incident `stale-catalog-silent-revert` est **déjà encodé** à la ligne 3 (« Codifie la leçon `stale-catalog-silent-revert` (incidents #2376 / #2383 / #2385) »). Le lien L44 était un doublon mort.
- `model-delegation.md` : les angles morts par classe de tâche sont **déjà synthétisés** dans la table inline « Angles morts connus » (lignes 28-37) + le point 7. Le lien L3 a été remplacé par un forward-ref inline vers cette section ; le point 7 (instruction de processus « où noter ») a été clarifié vers le chemin gitignored `agent-memory-local` (sans hypothèse de hash machine).

Vérifié post-fix : `grep "projects/d--CoursIA/memory"` sur les 2 fichiers → 0 occurrence restante.

## Périmètre

Diff chirurgical : 2 insertions, 3 suppressions, 2 fichiers. **PAS la revue globale #7423** (owner `ai-01`, « passe coordinateur-owned, prudente, pas dispatchée à la légère ») — uniquement un fix de cohérence atomique sur des dead-links pointés par le harnais lui-même. Sub-grain de #7423 (le même pattern que L576 a refermé).

## Voir

See #7423 (revue globale harnais, reste owner ai-01) · git-workflow.md:83 (pattern L576 de référence).
