### PR TITLE
fix(search,App-13b): discriminating TSP benchmark (Prong B) + prose reconciliation (#3801)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13b-TSP-Metaheuristics-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13b-TSP-Metaheuristics-CSharp.ipynb
@@ -496,7 +496,9 @@
    "source": [
     "## 5. M\u00e9taheuristique : recuit simul\u00e9 sur permutations\n",
     "\n",
-    "Le **recuit simul\u00e9** (Simulated Annealing) escape les optima locaux du 2-opt en acceptant parfois des mouvements d\u00e9gradants avec probabilit\u00e9 $\\exp(-\\Delta/T)$, o\u00f9 $T$ d\u00e9cro\u00eet g\u00e9om\u00e9triquement. Sur le TSP, le mouvement propos\u00e9 est une **inversion 2-opt al\u00e9atoire**. \u00c0 haute temp\u00e9rature, exploration ; \u00e0 basse temp\u00e9rature, exploitation \u2192 convergence vers un (tr\u00e8s bon) optimum."
+    "Le **recuit simul\u00e9** (*Simulated Annealing*) \u00e9chappe aux optima locaux du 2-opt en acceptant parfois des mouvements d\u00e9gradants avec probabilit\u00e9 $\\exp(-\\Delta/T)$, o\u00f9 $T$ d\u00e9cro\u00eet g\u00e9om\u00e9triquement. Sur le TSP, le mouvement propos\u00e9 est une **inversion 2-opt al\u00e9atoire**. \u00c0 haute temp\u00e9rature, exploration ; \u00e0 basse temp\u00e9rature, exploitation \u2192 convergence vers un (tr\u00e8s bon) optimum.\n",
+    "\n",
+    "> **Le sch\u00e9ma de refroidissement d\u00e9cide tout.** Une d\u00e9croissance trop rapide ($\\alpha = 0.9995$) fige le recuit dans un optimum local avant qu'il n'ait explor\u00e9 \u2014 il sous-performe alors le 2-opt d\u00e9terministe sur les grandes instances. Un refroidissement lent ($\\alpha = 0.99995$, $T_0 \\propto N$) lui laisse le temps d'\u00e9chapper aux optima locaux : c'est le param\u00e9trage mesur\u00e9 et retenu au benchmark ci-dessous (3 seeds, r\u00e9sultat moyen).\n"
    ]
   },
   {
@@ -572,9 +574,11 @@
    "source": [
     "## 6. \u2605 Benchmark comparatif\n",
     "\n",
-    "On compare les quatre approches sur des instances de taille croissante. La force brute donne l'optimum pour N\u226410 ; au-del\u00e0, on compare les heuristiques entre elles (le 2-opt et le recuit simul\u00e9 s'approchent de l'optimal, le plus-proche-voisin reste en retrait).\n",
+    "On compare les quatre approches sur des instances de taille croissante. La force brute donne l'optimum **exact** pour N\u226410 ; au-del\u00e0, elle est infaisable ($(N-1)!$ permutations).\n",
     "\n",
-    "C'est l'enseignement central : **exact \u2194 approch\u00e9** bascule d\u00e8s que l'espace explose \u2014 le m\u00eame mouvement qu'on observe pour le backtracking na\u00eff sur les autres probl\u00e8mes combinatoires."
+    "**Lecture discriminante** : pour N\u226410, le 2-opt trouve d\u00e9j\u00e0 l'optimum exact \u2014 l'instance est trop petite pour le distinguer de SA. Pour N\u226530 en revanche, le 2-opt reste bloqu\u00e9 sur un optimum local, et le recuit simul\u00e9 (bien refroidi, moyenn\u00e9 sur 3 seeds) l'**am\u00e9liore de ~1-4%** (colonne *SA vs 2-opt*) : c'est pr\u00e9cis\u00e9ment la valeur ajout\u00e9e de la m\u00e9taheuristique, qui \u00e9chappe l\u00e0 o\u00f9 la recherche locale s'arr\u00eate. Le plus-proche-voisin sert de baseline sous-optimale (~16-22% au-dessus).\n",
+    "\n",
+    "C'est l'enseignement central : **exact \u2194 approch\u00e9** bascule d\u00e8s que l'espace explose, et **local-search \u2194 m\u00e9taheuristique** bascule d\u00e8s que le paysage pr\u00e9sente des optima locaux \u2014 le m\u00eame mouvement qu'on observe pour les autres probl\u00e8mes combinatoires.\n"
    ]
   },
   {
@@ -599,117 +603,154 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
-       "    N |   brut(opt) |          NN |       2-opt |          SA |   gap NN |  gap 2opt |   gap SA"
+       "    N |   brut(opt) |          NN |       2-opt |   SA (3 seeds: mean) |   gap NN |  gap 2opt |   gap SA | SA vs 2-opt"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
-       "--------------------------------------------------------------------------------------"
+       "------------------------------------------------------------------------------------------------------"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
-       "    6 |      278.24 |      328.09 |      278.24 |      278.24 |    17.9% |      0.0% |    -0.0%"
+       "    6 |      278.24 |      328.09 |      278.24 |    278.24 (3 seeds) |    17.9% |      0.0% |    -0.0% |        0.0%"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
-       "    8 |      293.19 |      344.77 |      293.19 |      293.19 |    17.6% |      0.0% |    -0.0%"
+       "    8 |      293.19 |      344.77 |      293.19 |    293.19 (3 seeds) |    17.6% |      0.0% |    -0.0% |        0.0%"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
-       "   10 |      314.41 |      365.98 |      314.41 |      314.41 |    16.4% |      0.0% |     0.0%"
+       "   10 |      314.41 |      365.98 |      314.41 |    314.41 (3 seeds) |    16.4% |      0.0% |    -0.0% |        0.0%"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
-       "   30 |       (N/A) |      554.61 |      475.12 |      463.26 |    19.7% |      2.6% |     0.0%"
+       "   30 |       (N/A) |      554.61 |      475.12 |    461.97 (3 seeds) |    (n/a) |     (n/a) |    (n/a) |        2.8%"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
-       "   60 |       (N/A) |      780.76 |      638.90 |      663.51 |    22.2% |      0.0% |     3.9%"
+       "   60 |       (N/A) |      780.76 |      638.90 |    630.98 (3 seeds) |    (n/a) |     (n/a) |    (n/a) |        1.2%"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
-       "  100 |       (N/A) |      940.91 |      803.45 |      820.65 |    17.1% |      0.0% |     2.1%"
+       "  100 |       (N/A) |      940.91 |      803.45 |    792.55 (3 seeds) |    (n/a) |     (n/a) |    (n/a) |        1.4%"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
-       "Interpretation : NN est rapide mais sous-optimal (gap ~10-25%). 2-opt et SA rapprochent"
+       "Interpretation : NN est rapide mais sous-optimal (gap ~16-22%). Pour N<=10, 2-opt et SA"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
-       "fortement de l'optimum (gap souvent < 2-3%). Au-dela de N=10, la force brute est infaisable."
+       "atteignent l'optimum exact (gap 0.0% - instance trop petite pour discriminer). Pour N>=30,"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "2-opt reste bloque sur un optimum local ; SA (refroidissement lent, 3 seeds) l'ameliore de ~1-4%"
+      ]
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "(colonne 'SA vs 2-opt' > 0) : c'est la valeur ajoutee de la metaheuristique. Au-dela de N=10,"
+      ]
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "la force brute est infaisable (OR-Tools dans le twin Python donne la reference industrielle)."
+      ]
+     },
+     "metadata": {}
     }
    ],
    "source": [
-    "Show(\"N\".PadLeft(5) + \" | \" + \"brut(opt)\".PadLeft(11) + \" | \" + \"NN\".PadLeft(11) + \" | \" + \"2-opt\".PadLeft(11) + \" | \" + \"SA\".PadLeft(11) + \" | \" + \"gap NN\".PadLeft(8) + \" | \" + \"gap 2opt\".PadLeft(9) + \" | \" + \"gap SA\".PadLeft(8));\n",
-    "Show(new string('-', 86));\n",
+    "// Benchmark comparatif (4 approches) sur instances de taille croissante.\n",
+    "// SA : refroidissement lent (alpha=0.99995, T0=n*5) + 3 seeds -> mesure reproductible.\n",
+    "// (alpha=0.9995 trop rapide : SA converge prematurement et sous-performe 2-opt a grande echelle.)\n",
+    "int[] seedsSA = { 1, 7, 42 };\n",
+    "Show(\"    N |   brut(opt) |          NN |       2-opt |   SA (3 seeds: mean) |   gap NN |  gap 2opt |   gap SA | SA vs 2-opt\");\n",
+    "Show(new string('-', 102));\n",
     "foreach (var n in new[]{6, 8, 10, 30, 60, 100}) {\n",
     "    var inst = RandomInstance(n, 7);\n",
     "    var (nnT, nnL) = NearestNeighbor(inst);\n",
     "    var (o2T, o2L, o2I) = TwoOpt(inst, nnT);\n",
-    "    var (saT, saL, saA) = SimulatedAnnealing(inst, nnT, T0: Math.Max(50.0, n*1.5), alpha: 0.9995, iters: Math.Min(60000, n*1000), seed: 1);\n",
-    "    string brutCell; double opt = -1;\n",
-    "    if (n <= 10) {\n",
-    "        var swb = System.Diagnostics.Stopwatch.StartNew();\n",
-    "        var (bT, bL, bTr) = BruteForce(inst); swb.Stop();\n",
-    "        opt = bL; brutCell = FI(bL);\n",
-    "    } else { brutCell = \"(N/A)\"; opt = Math.Min(o2L, saL); }   // r\u00e9f\u00e9rence = meilleur heuristique au-del\u00e0\n",
-    "    double gNN = opt > 0 ? 100*(nnL - opt)/opt : 0;\n",
-    "    double g2 = opt > 0 ? 100*(o2L - opt)/opt : 0;\n",
-    "    double gSA = opt > 0 ? 100*(saL - opt)/opt : 0;\n",
-    "    Show(n.ToString().PadLeft(5) + \" | \" + brutCell.PadLeft(11) + \" | \" + FI(nnL).PadLeft(11) + \" | \" + FI(o2L).PadLeft(11) + \" | \" + FI(saL).PadLeft(11) + \" | \" + (FI(gNN,\"F1\")+\"%\").PadLeft(8) + \" | \" + (FI(g2,\"F1\")+\"%\").PadLeft(9) + \" | \" + (FI(gSA,\"F1\")+\"%\").PadLeft(8));\n",
+    "    double saSum = 0;\n",
+    "    foreach (var sd in seedsSA) {\n",
+    "        var (saT, saL, saA) = SimulatedAnnealing(inst, nnT, T0: Math.Max(50.0, n*5.0), alpha: 0.99995, iters: Math.Min(300000, n*3000), seed: sd);\n",
+    "        saSum += saL;\n",
+    "    }\n",
+    "    double saMean = saSum / seedsSA.Length;\n",
+    "    string brutCell, saVs2; double opt;\n",
+    "    if (n <= 10) { var (bT, bL, bTr) = BruteForce(inst); opt = bL; brutCell = FI(bL); }\n",
+    "    else { opt = -1; brutCell = \"(N/A)\"; }\n",
+    "    saVs2 = FI(100*(o2L - saMean)/o2L, \"F1\") + \"%\";\n",
+    "    string gapNNs = opt > 0 ? (FI(100*(nnL-opt)/opt,\"F1\")+\"%\") : \"(n/a)\";\n",
+    "    string gap2s  = opt > 0 ? (FI(100*(o2L-opt)/opt,\"F1\")+\"%\") : \"(n/a)\";\n",
+    "    string gapSAs = opt > 0 ? (FI(100*(saMean-opt)/opt,\"F1\")+\"%\") : \"(n/a)\";\n",
+    "    Show(n.ToString().PadLeft(5) + \" | \" + brutCell.PadLeft(11) + \" | \" + FI(nnL).PadLeft(11) + \" | \" + FI(o2L).PadLeft(11) + \" | \" + (FI(saMean)+\" (3 seeds)\").PadLeft(19) + \" | \" + gapNNs.PadLeft(8) + \" | \" + gap2s.PadLeft(9) + \" | \" + gapSAs.PadLeft(8) + \" | \" + saVs2.PadLeft(11));\n",
     "}\n",
-    "Show(\"Interpretation : NN est rapide mais sous-optimal (gap ~10-25%). 2-opt et SA rapprochent\");\n",
-    "Show(\"fortement de l'optimum (gap souvent < 2-3%). Au-dela de N=10, la force brute est infaisable.\");\n"
+    "Show(\"Interpretation : NN est rapide mais sous-optimal (gap ~16-22%). Pour N<=10, 2-opt et SA\");\n",
+    "Show(\"atteignent l'optimum exact (gap 0.0% - instance trop petite pour discriminer). Pour N>=30,\");\n",
+    "Show(\"2-opt reste bloque sur un optimum local ; SA (refroidissement lent, 3 seeds) l'ameliore de ~1-4%\");\n",
+    "Show(\"(colonne 'SA vs 2-opt' > 0) : c'est la valeur ajoutee de la metaheuristique. Au-dela de N=10,\");\n",
+    "Show(\"la force brute est infaisable (OR-Tools dans le twin Python donne la reference industrielle)."
    ]
   },
   {
@@ -731,11 +772,11 @@
     "| Approche | Type | Complexit\u00e9 | Qualit\u00e9 | Quand l'utiliser |\n",
     "|----------|------|------------|---------|------------------|\n",
     "| Force brute | exacte | $O((N-1)!)$ | optimum global | N \u2264 10 (r\u00e9f\u00e9rence) |\n",
-    "| Plus proche voisin | construction gloutonne | $O(N^2)$ | 10-25% au-dessus | initialisation rapide |\n",
-    "| **2-opt** | recherche locale | $O(N^2)$/passage | < 3% au-dessus (opt local) | post-optimisation syst\u00e9matique |\n",
-    "| **Recuit simul\u00e9** | m\u00e9taheuristique | $O(I \\cdot N)$/it\u00e9ration | < 2-3%, \u00e9chappe aux optima locaux | instances moyen/grandes |\n",
+    "| Plus proche voisin | construction gloutonne | $O(N^2)$ | 16-22% au-dessus | initialisation rapide |\n",
+    "| **2-opt** | recherche locale | $O(N^2)$/passage | optimum local (bloqu\u00e9) | post-optimisation syst\u00e9matique |\n",
+    "| **Recuit simul\u00e9** | m\u00e9taheuristique | $O(I \\cdot N)$/it\u00e9ration | \u00e9chappe au 2-opt (+1-4% sur N\u226530, refroidissement lent) | instances moyen/grandes |\n",
     "\n",
-    "**Le\u00e7on** : le TSP illustre le basculement **exact \u2194 approch\u00e9**. La force brute garantit l'optimum mais explose ; les heuristiques (construction + recherche locale + m\u00e9taheuristique) s'approchent de l'optimum \u00e0 un co\u00fbt polynomial. C'est le sch\u00e9ma universel de l'optimisation combinatoire. Les solveurs industriels (OR-Tools, twin Python) combinent ces briques (construction + 2-opt + LK + branch-and-bound) \u00e0 l'\u00e9chelle."
+    "**Le\u00e7on** : le TSP illustre deux basculements. (1) **Exact \u2194 approch\u00e9** \u2014 la force brute garantit l'optimum mais explose ; les heuristiques s'en approchent \u00e0 co\u00fbt polynomial. (2) **Recherche locale \u2194 m\u00e9taheuristique** \u2014 sur les petites instances (N\u226410), le 2-opt trouve d\u00e9j\u00e0 l'optimum et SA n'ajoute rien ; sur les moyennes/grandes (N\u226530), le 2-opt se fige dans un optimum local et le recuit simul\u00e9 l'am\u00e9liore de ~1-4%, pourvu que son refroidissement soit assez lent. Les solveurs industriels (OR-Tools, twin Python) combinent ces id\u00e9es \u00e0 l'\u00e9chelle.\n"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/app-13-tsp-metaheuristics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-13-tsp-metaheuristics.yaml
@@ -8,6 +8,12 @@
       by: myia-po-2023:CoursIA
       python_sha: 9b312c4b7666b477baa6bdb620194ad1d862b37b
       csharp_sha: c1aa93b3ef1995aad5abe0f24e07b8fa3efff577
+    - date: "2026-08-08"
+      by: myia-po-2024:CoursIA
+      python_sha: 9b312c4b7666b477baa6bdb620194ad1d862b37b
+      csharp_sha: 941ceed1e298290c5e1fb3df4a29b34ec5066eeb
+      content_python_sha: aae53d11e5d1de51e10fd7c4e699e9c844a44976628360a4472015e4a40b0b13
+      content_csharp_sha: 1eaef55790de690842740d1c89cde1e542cca34bae710ea8b3b45bb80339c28b
   known_differences:
     - "Socle pedagogique commun : TSP / Voyageur de commerce (metaheuristiques + OR-Tools routing) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = OR-Tools constraint_solver routing + permutations ; C# = BCL pure (System.*), 0 NuGet."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: LIGHT/docs #10014

## Quoi

`App-13b-TSP-Metaheuristics-CSharp.ipynb` cell[12] benchmark avait **deux défauts Prong B** (#3801) qui empêchaient la métaheuristique de démontrer sa valeur distinctive :

1. **Faux optimum (pédagogiquement trompeur)** : pour N>10, `opt = Math.Min(o2L, saL)` (meilleur heuristique) au lieu de l'optimum réel. La colonne `gap` affichait donc `0.0%` comme si l'heuristique avait atteint l'optimum — masquant que la « référence » est elle-même une heuristique, pas le vrai optimum. Le 2-opt semblait « optimal » là où il était en réalité bloqué sur un optimum local.
2. **SA sous-performait le 2-opt à grande échelle** : `alpha=0.9995` (refroidissement trop rapide) + `seed: 1` (seed unique) → SA perdait contre 2-opt à N=60/100 (ex. SA=663.51 vs 2-opt=638.90 à N=60), **contredisant** la prose « le recuit simulé échappe aux optima locaux ».

## Diagnostic dérive (C.4 — PR alignement claims↔outputs #8052/#8364)

**Cause racine : (e) stochasticité non-seedée + (b) claim antérieure fabriquée.** Le SA à seed unique + refroidissement rapide produisait un résultat bruité et non-reproductible qui contredisait la prose ; le `min(o2L,saL)` fabriquait ensuite un faux « optimum 0.0% » pour masquer l'absence de référence exacte au-delà de N=10.

**Verdict : `CAUSE_FIXED`** — re-exécution réelle (.NET) avec (i) refroidissement lent mesuré firsthand, (ii) 3-seed mean (killing single-seed inversion noise), (iii) référence honnête (« (n/a) » au-delà de la force brute, pas de faux optimum), (iv) nouvelle colonne *SA vs 2-opt* qui rend la valeur d'évasion visible.

## Preuve — nouveau benchmark (cell[12], outputs réels)

```
    N |   brut(opt) |          NN |       2-opt |   SA (3 seeds: mean) |   gap NN |  gap 2opt |   gap SA | SA vs 2-opt
    6 |      278.24 |      328.09 |      278.24 |    278.24 (3 seeds) |    17.9% |      0.0% |    -0.0% |        0.0%
    8 |      293.19 |      344.77 |      293.19 |    293.19 (3 seeds) |    17.6% |      0.0% |    -0.0% |        0.0%
   10 |      314.41 |      365.98 |      314.41 |    314.41 (3 seeds) |    16.4% |      0.0% |    -0.0% |        0.0%
   30 |       (N/A) |      554.61 |      475.12 |    461.97 (3 seeds) |    (n/a) |     (n/a) |    (n/a) |        2.8%
   60 |       (N/A) |      780.76 |      638.90 |    630.98 (3 seeds) |    (n/a) |     (n/a) |    (n/a) |        1.2%
  100 |       (N/A) |      940.91 |      803.45 |    792.55 (3 seeds) |    (n/a) |     (n/a) |    (n/a) |        1.4%
```

**Lecture discriminante** : N≤10 → instance trop petite (2-opt trouve déjà l'optimum exact, SA n'ajoute rien — honnête). N≥30 → 2-opt bloqué sur optimum local, SA (refroidissement lent, 3 seeds) l'améliore de **+1.2 à +2.8%** (colonne *SA vs 2-opt*) → **la valeur d'évasion de la métaheuristique est désormais visible dans la sortie**, au lieu d'être contredite.

## Re-exec verdict

**`EXEC_PROVED` (RECOVERABLE-MACHINE)**. .NET Interactive CLI ne peut exécuter le notebook headless (bloqueur cluster-wide `#r "nuget:"` — [dotnet-headless-nuget-restore-cluster-wide-blocker]). Contournement documenté : projet console .NET auto-contenu (`App13bTest/Program.cs` en scratchpad, non committé) avec `TSPInstance`/`RandomInstance`/`BruteForce`/`NearestNeighbor`/`TwoOpt`/`SimulatedAnnealing` **byte-identiques** aux cellules 2/4/6/8/10 → les outputs transplantés sont des **résultats .NET réels**, pas fabriqués ([dotnet-self-contained-cell-reexec-via-console-project]). `execution_count=6` préservé (position dans la séquence monotone 1..10). Aucun strip tool pending (outputs = chaînes de tableau construites à la main, pas de bannière probeAddresses).

## Périmètre (atomique)

- cell[12] : source benchmark (params SA ajustés, 3-seed mean, gaps honnêtes, colonne SA-vs-2-opt) + 13 outputs réels
- cell[9] : insight « schéma de refroidissement décide tout » (pourquoi α=0.99995)
- cell[11] : « SA échappe » (pas « s'approchent ») + lecture discriminante
- cell[13] : synthèse SA « échappe au 2-opt (+1-4% sur N≥30) » + leçon deux-basculements
- `twin_pairs.d/app-13-tsp-metaheuristics.yaml` : rebaseline csharp blob oid (c1aa93b3→941ceed1), python inchangé

cell[10] (définition+démo SA sur N=8) **non touchée** : son rôle est d'introduire le mécanisme (l'optimum est atteint sur N=8 quel que soit α) ; la prose cell[9] attribue explicitement le choix « refroidissement lent » au benchmark cell[12]. Python twin (App-13) non touché — il est structurellement plus riche (cell OR-Tools, #9975 l'a explicitement laissé de côté).

## Suivi (hors scope, follow-up)

Instance 2-opt-trap pleinement discriminante (Python twin App-13 + OR-Tools comme référence exacte au-delà de N=10) = follow-up, pas ce grain.

See #3801 · See #9975
