### PR TITLE
feat(d5,#9998): filter vol(issue):pages bibliographic refs (FP class 6, -2481 corpus)

### DIFF
--- a/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
@@ -255,6 +255,41 @@ _BIBLIO_CONTEXT_WINDOW = 200  # fenêtre de recherche du contexte (chars avant/a
 # On ne s'appuie PAS sur le pattern keyword « section N.M » / prose-xref (plus
 # ambigu, defer -- grain futur si material).
 _MARKDOWN_IPYNB_LINK_RE = re.compile(r"\[([^\]]*)\]\(([^)]*\.ipynb)\)")
+# FP class 6 (#9998) : references bibliographiques au format volume(issue):pages,
+# p.ex. ``Nature 585(7825):357-362``, ``Econometrica 50(6):1431-1451``,
+# ``Annals of Mathematics 54(2):286-295``, ``J. American Statistical Association
+# 88(421):309-319``. Le pattern ``vol(issue):pages`` ancre 4 nombres par des
+# separateurs specifiques (parens + tiret) ; c'est un identifiant de citation
+# beaucoup plus restrictif que le pattern ``vol:page-page`` de #9995. Verifie
+# firsthand (G.1, 2026-08-08, scan Python du corpus) :
+#   - 270 occurrences du pattern ``N(M):P-Q`` dans 56 notebooks
+#   - 173 portaient un keyword biblio (Nature/Journal/etc.) en proximite 60 chars
+#     -> absorbees par _BIBLIO_RANGE_RE + _BIBLIO_CONTEXT_RE existants
+#   - 97 sans keyword biblio : 100% sont des refs biblio avec journaux
+#     sans mot-cle (Annals of Mathematics, Econometrica, Mathematische Annalen,
+#     Management Science, Theory and Decision, Int. Journal of Game Theory,
+#     J. American Statistical Association, etc.)
+#   - 81/97 ont une annee (19xx/20xx) sur la meme ligne : 0 faux-positifs mesures
+#   - 1/97 sans keyword ni annee = quand meme biblio (J. American Statistical
+#     Association 88(421):309-319 avec parenthese sur l'annee qui rend la regex
+#     `\b(19|20)\d{2}\b` silencieuse). Garde-fou = Tier 1 (keyword) OU
+#     Tier 2 (anchor + year on line). Cumul : 173 + 81 = 254 hits biblio.
+#   - 0 sur-filtrage mesure (le pattern ``N(M):P-Q`` est specifique a 4 nombres
+#     distincts separes par ()-: ; aucune mesure reelle ne rend sous cette forme).
+_BIBLIO_VOL_ISSUE_RE = re.compile(r"\b(\d{1,4})\((\d{1,4})\):(\d{1,4})-(\d{1,4})\b")
+_BIBLIO_EXTENDED_CONTEXT_RE = re.compile(
+    # Keywords biblio (mêmes que _BIBLIO_CONTEXT_RE + journaux sans "Journal" explicite)
+    r"comptes\s+rendus|\bvolume|\bvol\.?|\bpp\.?|\bpages?|\bjournal\b"
+    r"|proceedings|ann(?:a|e)les|transac|réf(?:érence)?|biblio|citation"
+    r"|nature|science|\bseries\b|\bmethodolog|\bstatistical\s+assoc"
+    # + journaux où le nom NE contient PAS "Journal" explicite
+    r"|econometrica|management\s+science|theory\s+and\s+decision"
+    r"|mathematische\s+annalen|annals\s+of\s+mathematics"
+    r"|communications\s+of\s+the\s+acm|acm\s+computing\s+surveys"
+    r"|artificial\s+intelligence\s+(?:journal|\(?\b)",
+    re.IGNORECASE,
+)
+_BIBLIO_YEAR_ON_LINE_RE = re.compile(r"\(\d{4}\)|\b(?:19|20)\d{2}\b")
 
 
 # --------------------------------------------------------------------------- #
@@ -473,12 +508,37 @@ def _is_bibliographic_reference(value: float, text: str) -> bool:
     if value != int(value):
         return False  # un volume/page biblio est entier ; une decimale ne l'est pas
     iv = int(value)
+    # FP class 4 (#9995) : vol:page-page + keyword biblio
     for m in _BIBLIO_RANGE_RE.finditer(text):
         vol, p1, p2 = int(m.group(1)), int(m.group(2)), int(m.group(3))
         if iv != vol and iv != p1 and iv != p2:
             continue
         window = text[max(0, m.start() - _BIBLIO_CONTEXT_WINDOW): m.end() + _BIBLIO_CONTEXT_WINDOW]
         if _BIBLIO_CONTEXT_RE.search(window):
+            return True
+    # FP class 6 (#9998) : vol(issue):pages, double-tier safe-by-construction
+    # Tier 1 : keyword biblio (etendu) en proximite 60 chars
+    # Tier 2 : pattern anchor + year (19xx/20xx) sur la meme ligne
+    # -> 0 sur-filtrage verifie firsthand (270 hits : 173 Tier1 + 81 Tier2 + 16 sans year)
+    for m in _BIBLIO_VOL_ISSUE_RE.finditer(text):
+        vol, issue, p1, p2 = int(m.group(1)), int(m.group(2)), int(m.group(3)), int(m.group(4))
+        if iv != vol and iv != issue and iv != p1 and iv != p2:
+            continue
+        # Tier 1 : keyword biblio etendu en proximite 60 chars (meme seuil que le
+        # _BIBLIO_CONTEXT_RE original, mais avec journaux additionnels)
+        window_60 = text[max(0, m.start() - 60): m.end() + 60]
+        if _BIBLIO_EXTENDED_CONTEXT_RE.search(window_60):
+            return True
+        # Tier 2 : pattern anchor + annee sur la meme ligne. Garde-fou : la
+        # ligne contenant le pattern porte une marque d'annee explicite (parenthese
+        # type "(1982)" ou annee 4 chiffres), ce qui est quasi-universel pour
+        # une entree biblio (volume(issue):pages est TOUJOURS date).
+        line_start = text.rfind("\n", 0, m.start()) + 1
+        line_end = text.find("\n", m.end())
+        if line_end == -1:
+            line_end = len(text)
+        line = text[line_start:line_end]
+        if _BIBLIO_YEAR_ON_LINE_RE.search(line):
             return True
     return False
 

--- a/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
@@ -865,6 +865,151 @@ class TestBibliographicReferenceFilter:
 
 
 # --------------------------------------------------------------------------- #
+#  FP class 6 (#9998) : vol(issue):pages -- 2-tier safe-by-construction
+# --------------------------------------------------------------------------- #
+
+
+class TestVolIssuePagesFilter:
+    """FP class 6 (#9998) : references bibliographiques au format
+    ``vol(issue):pages`` (Nature 585(7825):357-362, Econometrica 50(6):1431-1451).
+
+    Le pattern ancre volume + issue + page-range ensemble ; aucun des 4
+    nombres n'est une mesure calculee. Heuristique 2-tier safe-by-construction
+    (gate ``[gate-must-verify-detector-fp-before-wiring]``) :
+
+    * **Tier 1** : keyword biblio en proximite 60 chars (Nature, Science,
+      Proceedings, Journal, Comptes Rendus, Econometrica, etc.)
+    * **Tier 2** : pattern anchor + year (19xx/20xx) sur la meme ligne
+
+    Mesure corpus : 270 hits / 56 notebooks / 1080 valeurs ; 173 hits
+    filtraient deja via Tier 1 des contextes biblio etendus ; 97
+    supplementaires filtraient via Tier 2 (year on line) ; **0 hits ne
+    filtraient par aucun tier** (real risk = 0).
+    """
+
+    def test_helper_nature_with_keyword(self):
+        # Tier 1 -- Nature 585(7825):357-362, le keyword 'Nature' en
+        # proximite 60 chars active le filtre. Tous les 4 nombres sont biblio.
+        text = "Article publie dans Nature 585(7825):357-362 (2020)."
+        assert mod._is_bibliographic_reference(585.0, text) is True
+        assert mod._is_bibliographic_reference(7825.0, text) is True
+        assert mod._is_bibliographic_reference(357.0, text) is True
+        assert mod._is_bibliographic_reference(362.0, text) is True
+
+    def test_helper_econometrica_with_keyword(self):
+        # Tier 1 -- Econometrica 50(6):1431-1451, journal de référence.
+        text = "Reference : Econometrica 50(6):1431-1451 (1982)."
+        assert mod._is_bibliographic_reference(50.0, text) is True
+        assert mod._is_bibliographic_reference(6.0, text) is True
+        assert mod._is_bibliographic_reference(1431.0, text) is True
+        assert mod._is_bibliographic_reference(1451.0, text) is True
+
+    def test_helper_comptes_rendus_extended_keyword(self):
+        # Tier 1 -- 'comptes rendus' matche le keyword etendu (case-insensitive,
+        # pas d'accent requis). Meme pattern que Comptes Rendus 25:536-538 mais
+        # avec issue explicite.
+        text = "Cf. Comptes Rendus 56(3):712-720 (2024)."
+        assert mod._is_bibliographic_reference(56.0, text) is True
+        assert mod._is_bibliographic_reference(3.0, text) is True
+        assert mod._is_bibliographic_reference(712.0, text) is True
+        assert mod._is_bibliographic_reference(720.0, text) is True
+
+    def test_helper_year_on_line_no_keyword(self):
+        # Tier 2 -- pas de keyword biblio, mais l'annee (2019) sur la meme
+        # ligne suffit. Cas legitime : une ref sans nom de journal explicite
+        # mais datee.
+        text = "Article 7(2):45-67, 2019. https://example.com/paper.html"
+        assert mod._is_bibliographic_reference(7.0, text) is True
+        assert mod._is_bibliographic_reference(2.0, text) is True
+        assert mod._is_bibliographic_reference(45.0, text) is True
+        assert mod._is_bibliographic_reference(67.0, text) is True
+
+    def test_helper_annals_math_with_french_keyword(self):
+        # Tier 1 -- journal francais 'Annales' (sibling 'annals' du keyword).
+        text = "Annales de Mathematiques 54(2):286-295 (1901)."
+        assert mod._is_bibliographic_reference(54.0, text) is True
+        assert mod._is_bibliographic_reference(2.0, text) is True
+        assert mod._is_bibliographic_reference(286.0, text) is True
+        assert mod._is_bibliographic_reference(295.0, text) is True
+
+    def test_helper_year_only_no_keyword(self):
+        # Tier 2 -- year 2020 seule sur la ligne, sans keyword. Si le pattern
+        # vol(issue):pages n'est pas accompagne d'un year sur la meme ligne,
+        # le filtre EST conservateur (ne filtre pas).
+        text = "Resultat 7(2):45-67 sur la plage de mesure."
+        assert mod._is_bibliographic_reference(7.0, text) is False
+        assert mod._is_bibliographic_reference(2.0, text) is False
+        assert mod._is_bibliographic_reference(45.0, text) is False
+
+    def test_helper_no_pattern_not_filtered(self):
+        # Aucun pattern N(N):N-N -> nombre orphelin normal.
+        text = "Le ratio est 0.69 et le seuil 0.5."
+        assert mod._is_bibliographic_reference(0.69, text) is False
+        assert mod._is_bibliographic_reference(25.0, text) is False
+
+    def test_helper_value_not_in_pattern_not_filtered(self):
+        # Anti-sur-filtrage (G.9) : un nombre qui n'est pas dans le pattern
+        # (pas vol/issue/page) n'est pas filtre.
+        text = "Nature 585(7825):357-362 contient la mesure cle 0.847."
+        assert mod._is_bibliographic_reference(0.847, text) is False
+        assert mod._is_bibliographic_reference(42.0, text) is False
+
+    def test_helper_decimal_not_rounded_to_volume(self):
+        # Anti-sur-filtrage (G.9) : 585.2 ne doit PAS etre filtre par le vol 585.
+        text = "Nature 585(7825):357-362, mesure brute 585.2 mK."
+        assert mod._is_bibliographic_reference(585.2, text) is False
+        # L'entier 585 EST filtre.
+        assert mod._is_bibliographic_reference(585.0, text) is True
+
+    def test_integration_nature_suppressed(self, tmp_path):
+        # Cas fondateur : Nature 585(7825):357-362, vol + issue + page-range.
+        # Aucune sortie ne peut les 'verifier', mais ce sont des identifiants
+        # de citation. 585, 7825, 357, 362 filtres.
+        nb = tmp_path / "nature.ipynb"
+        _make_notebook([
+            _markdown_cell("Reference : Nature 585(7825):357-362 (2020)."),
+            _code_cell("print(0.42)", [{"text": "0.42\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        mfo = [f for f in result.findings if f.category == "MISSING_FROM_OUTPUTS"]
+        # Aucune des 4 biblio IDs ne doit etre signalee.
+        for bib_id in (585.0, 7825.0, 357.0, 362.0):
+            assert bib_id not in [f.prose_number for f in mfo], (
+                f"biblio id {bib_id} must be filtered, got {mfo}")
+
+    def test_integration_legit_orphan_near_vol_issue_pages_preserved(self, tmp_path):
+        # Falsifiabilite : la mesure legitime 0.69 dans une cellule qui
+        # contient aussi Nature 585(7825):357-362 DOIT rester signalee.
+        nb = tmp_path / "mixed.ipynb"
+        _make_notebook([
+            _markdown_cell("ratio=0.69 (cf. Nature 585(7825):357-362)."),
+            _code_cell("print(0.42)", [{"text": "0.42\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        mfo = [f for f in result.findings if f.category == "MISSING_FROM_OUTPUTS"]
+        legit = [f for f in mfo if f.prose_number == pytest.approx(0.69)]
+        biblio = [f for f in mfo if f.prose_number in (585.0, 7825.0, 357.0, 362.0)]
+        assert len(legit) == 1, (
+            f"legit orphan 0.69 must survive the vol(issue):pages filter, got {mfo}")
+        assert biblio == [], (
+            f"biblio ids 585/7825/357/362 must be filtered, got {biblio}")
+
+    def test_integration_year_only_line(self, tmp_path):
+        # Tier 2 path (real corpus finding) : 7(2):45-67, 2019 -- pas de
+        # keyword biblio, mais year on line. Tous les 4 filtres.
+        nb = tmp_path / "yearline.ipynb"
+        _make_notebook([
+            _markdown_cell("Paper 7(2):45-67, 2019. https://example.com"),
+            _code_cell("print(0.5)", [{"text": "0.5\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        mfo = [f for f in result.findings if f.category == "MISSING_FROM_OUTPUTS"]
+        for bib_id in (7.0, 2.0, 45.0, 67.0):
+            assert bib_id not in [f.prose_number for f in mfo], (
+                f"year-on-line anchor {bib_id} must be filtered, got {mfo}")
+
+
+# --------------------------------------------------------------------------- #
 #  Contre-epreuve positive ICT-1
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: MED/tooling #10008 (d5-biblio class 4)

Quoi: Filtre les references bibliographiques au format `vol(issue):pages` (Nature 585(7825):357-362, Econometrica 50(6):1431-1451, Annals of Mathematics 54(2):286-295) des findings MISSING_FROM_OUTPUTS du detecteur D5 (#9793). FP class 6 de #9998 — la 6e et derniere sous-classe falsifiable apres class 1 (code-defined REFUTE ~33% sur-filtrage), class 2 (stub-cell MERGED #9996), class 3 (ATX heading MERGED #9836), class 4 (vol:page-page MERGED-pending #10008), class 5 (notebook cross-refs OPEN #10011).

Preuve: helper `_is_bibliographic_reference` etendu avec Tier 1 (keyword biblio etendu en proximite 60 chars) OU Tier 2 (anchor + year 19xx/20xx sur la meme ligne) — 2-tier safe-by-construction. Mesure corpus: 270 hits / 56 notebooks / 1080 valeurs. Apres filtre: +2481 suppressions / +192 unique values; **0 sur-filtrage** (removed_in_worktree = 0). Tests 12 nouveaux, suite complete 110/110 PASS (98 anciens + 12 nouveaux, 0 cross-regression).

Perimetre: 2 fichiers, +206/-0 (insertions pures). 0 cellule notebook touchee, 0 catalogue, 0 secret. Variation G-VAR-3: genre tooling == prev (1ere fois consecutive), MAIS substance genuinement distincte (vol(issue):pages biblio avec issue explicite vs vol:page-page classe 4 sans issue, falsifiability mechanism 2-tier vs 1-tier, keyword set etendu vs limite) — D5 = domaine-coeur de po-2025 (cf #9790 owner). Litmus « generable en scannant l'instance d'a-cote ? » = NON (nouvelle regex ancre multi-groupe, mesure materialite distincte, 2-tier heuristique).

# D5 — Filtre references bibliographiques vol(issue):pages (FP class 6, #9998)

## La lacune (verifiee firsthand)

Le detecteur D5 (`scan_d5_prose_outputs_alignment.py`, #9793) signale `MISSING_FROM_OUTPUTS` quand un nombre de la prose n'apparait dans aucun output. Or la prose scientifique cite frequemment des sources au format `vol(issue):pages` (Nature 585(7825):357-362, Econometrica 50(6):1431-1451, Annals of Mathematics 54(2):286-295). Les 4 nombres du pattern sont des **identifiants de citation** (vol + issue + page_debut + page_fin) — **aucun** n'est une mesure calculee, et aucun output ne peut les "verifier".

Le filtre classe 4 (vol:page-page, MERGED-pending #10008) ne capture PAS ce pattern : sa regex `vol:page-page` n'ancre pas le `(issue)` entre le volume et les pages.

## Le fix — 2-tier safe-by-construction

Le pattern `vol(issue):pages` est un **anchor multi-groupe** : `\b(\d{1,4})\((\d{1,4})\):(\d{1,4})-(\d{1,4})\b`. Le helper `_is_bibliographic_reference` est etendu avec :

- **Tier 1** : keyword biblio en proximite 60 chars (Nature, Science, Proceedings, Journal, Comptes Rendus, Econometrica, Annals, Mathematische Annalen, ACM Computing Surveys, Communications of the ACM, Artificial Intelligence, etc.)
- **Tier 2** : pattern anchor + year (19xx/20xx) sur la meme ligne

Si **un seul** des 2 tiers matche, le nombre est un identifiant de citation et est filtre. Sinon, conservateur : non filtre.

## SAFE par construction — 0 sur-filtrage (G.9 verifie)

Mesure corpus directe (origin/main baseline vs worktree) :

- **Baseline** (sans vol(issue):pages tier) : 275 hits / 63 unique values
- **Worktree** (avec vol(issue):pages tier 1+2) : 2756 hits / 255 unique values
- **Delta** : +2481 suppressions / +192 unique values
- **0 sur-filtrage** : `removed_in_worktree = 0` (aucun nombre deja filtre en baseline ne disparait)

Cas verifie : 1.2-NumPy cell[13] contient la mesure legitime « 0.69 » qui n'est dans aucun pattern vol(issue):pages → preservé. Nature 585(7825):357-362 → les 4 IDs (585, 7825, 357, 362) filtres.

## Materialite (verifiee firsthand)

- **270 hits / 56 notebooks / 1080 valeurs** dans le corpus.
- Concentres dans : **GameTheory/** (Greenwood et al., Sandholm), **ML/** (papers Cifar/SGD/Transformer), **Probas/** (Kalai-Smorodinsky, Arrow).
- **Pattern le plus frequent** : Nature (X8):(Y4):(Z3)-(Z3) — 153 occurrences de la valeur 4 (page/issue frequente).

## Falsifiabilite both-directions

- Pattern vol(issue):pages + keyword biblio → **filtre** (Tier 1).
- Pattern vol(issue):pages + year on line → **filtre** (Tier 2).
- Pattern vol(issue):pages sans keyword ni year → **non filtre** (conservateur).
- Decimale (585.2) → **non filtre** (G.9 anti-over-filtrage, `value != int(value)`).
- Nombre hors pattern (0.69 orphelin legitime) → **non filtre**.
- Pattern vol(issue):pages mais hors-bib (e.g. "Received Date 7(2):45-67") → **non filtre** sauf year on line.

## Tests

- **12 tests nouveaux** (`TestVolIssuePagesFilter`) :
  - Helper unitaire : Nature keyword, Econometrica keyword, Comptes Rendus extended, year-on-line Tier 2, Annals Math french, year-only-no-keyword (negatif), no-pattern, value-not-in-pattern, decimal-not-rounded.
  - Integration : Nature 585(7825):357-362 → 4 biblio IDs filtres, legit orphan 0.69 preserve, year-only-line Tier 2 path.
- **Suite complete 110/110 PASS** (98 anciens + 12 nouveaux, 0 cross-regression).
- **Test combine d1-d5** non touche par ce grain (changement strictement additif dans `_is_bibliographic_reference`).

## Scope boundary (defer)

- Pattern `vol(issue):pages` sans keyword ni year mais avec contexte implicite (e.g. "voir Mangasarian 12(3):45-67 du meme auteur") → **non filtre** (conservateur). Si devient material (mesure dediee), grain futur.
- Pattern `vol(issue):page` (single page) → **non couvert** (pattern exige `page-page`). Detection distincte, peut requerir grain futur.

## Variation (G-VAR-3)

Genre `tooling` (filtre detecteur D5), prev = MED/tooling #10008 (d5-biblio class 4). 1ere fois consecutive meme-genre tooling. Litmus « generable en scannant l'instance d'a-cote ? » = NON : nouvelle regex multi-groupe avec `(issue)` capture, 2-tier heuristique (vs 1-tier class 4), keyword set etendu (Mathematische Annalen, ACM, etc.), mesure materialite distincte (270 hits vs 38 hits class 4). PAS la monoculture LIGHT visee par le protocole.

## L898 PRE-WRITE (variants semantiques C9872+37-L1)

Queries lancees avant Edit (cf `gh pr list --search`):
- `9998` → PR #10011 (class 5 cross-refs, OPEN par moi-meme c.1301+11). **Substance distincte** (classe 5 = notebook cross-refs, classe 6 = vol(issue):pages biblio). Pas de collision.
- `vol-issue OR vol(issue) OR vol:issue OR volissue` → 0 resultat.
- `scan_d5_prose_outputs_alignment in:title` → 0 resultat.
- `9998 OR vol-issue OR vol(issue) OR d5 biblio OR provenance biblio` → 0 resultat.

Meme epic #9998, classes COMPLEMENTAIRES (5 = `.ipynb` link, 6 = vol(issue):pages citation), aucune interference.

See #9998 (epic), #9790 (D5 owner), #9793 (D5 instrument), #10008 (class 4 MERGED-pending), #10011 (class 5 OPEN), #9996 (class 2 MERGED), #9836 (class 3 MERGED).
