### PR TITLE
feat(guard,#10024): advisory detector for .NET exec-block without #r nuget (Livrable 2)

### DIFF
--- a/.github/workflows/dotnet-nuget-block-advisory.yml
+++ b/.github/workflows/dotnet-nuget-block-advisory.yml
@@ -1,0 +1,125 @@
+name: dotnet-nuget-block-advisory
+
+# Advisory organ for issue #10024 Livrable 2.
+#
+# The .NET headless `#r "nuget:"` block is REAL but BOUNDED
+# ([dotnet-headless-nuget-restore-cluster-wide-blocker]): it applies only to
+# notebooks that actually contain a `#r "nuget:"` cell. The block was repeatedly
+# invoked as a BLANKET excuse to skip re-execution or transplant outputs from
+# outside the repo -- on notebooks with ZERO `#r "nuget:"`. PR #10021 is the
+# canonical case (App-13b, 0 nuget, RECOVERABLE-MACHINE + transplanted outputs).
+#
+# This makes the anti-pattern VISIBLE on the PR.
+#
+# ADVISORY, never blocking (issue #10024 acceptance): the job ALWAYS exits 0.
+# The actionable payload is the `dotnet-block-without-nuget` LABEL, NEVER the
+# green conclusion of the job (which is green by construction). A reviewer who
+# reads only "exit 0" as "conforming" has read the wrong signal -- the same trap
+# documented in exercises-advisory.yml (PR #8820).
+#
+# Per-PR scope: runs check_pr_dotnet_nuget_block.py on the *.ipynb modified by
+# the PR + the PR body (fetched via gh). It does NOT re-implement detection
+# (acceptance: the label and the canonical tool must not diverge).
+#
+# Hors scope (student-pr-reviews.md): forks (student PRs) are skipped.
+#
+# Falsifiability ([gate-must-verify-detector-fp-before-wiring]):
+#   - .NET notebook WITH `#r nuget` + body block -> SILENT (block may be legit)
+#   - .NET notebook WITHOUT nuget + body no block -> SILENT
+#   - non-.NET notebook -> out of scope, SILENT
+# Reference RED case: PR #10021 body on App-13b (0 nuget).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - '**/*.ipynb'
+      # Self-cover (#8822): a paths-filtered label-poser must list its own file,
+      # else it cannot re-run (so cannot remove its own label) once the matching
+      # paths leave the PR diff. Enforced by scripts/check_workflow_label_paths.py.
+      - '.github/workflows/dotnet-nuget-block-advisory.yml'
+      - 'scripts/notebook_tools/check_pr_dotnet_nuget_block.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dotnet-nuget-block-advisory:
+    name: ".NET exec-block-without-nuget advisory (label, non-blocking)"
+    runs-on: ubuntu-latest
+    # Same-repo PRs only (agents/staff). Fork PRs are student submissions
+    # under student-pr-reviews.md -- benevolent review, no content gate.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          # Need base..head history for `git diff` of changed notebooks.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Advisory check on modified notebooks
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Without GH_REPO, `gh pr edit` / `gh pr view` cannot infer the target
+          # repo and fail silently (variation-tag-guard documented this trap).
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+          LABEL_NAME: dotnet-block-without-nuget
+        run: |
+          set -uo pipefail
+
+          # Added/modified *.ipynb in the PR (deletions excluded).
+          git diff --name-only --diff-filter=d "$BASE" "$HEAD" -- '*.ipynb' \
+            | grep -v $'\r$' > changed_ipynb.txt || true
+          COUNT=$(wc -l < changed_ipynb.txt | tr -d ' ')
+          echo "Modified *.ipynb in this PR: $COUNT"
+
+          # Fetch the PR body (the block keywords are detected here).
+          gh pr view "$PR_NUMBER" --json body --jq '.body' > pr_body.md 2>/dev/null || true
+
+          # Helper: ensure a label exists (idempotent), then add/remove it.
+          ensure_label() {
+            gh label create "$1" --description "$2" --color "$3" --force 2>/dev/null || true
+          }
+          set_label() { gh pr edit "$PR_NUMBER" --add-label "$1" || true; }
+          unset_label() { gh pr edit "$PR_NUMBER" --remove-label "$1" 2>/dev/null || true; }
+
+          ensure_label "$LABEL_NAME" \
+            "Body invokes a .NET exec block on a notebook with 0 #r nuget -- likely RECOVERABLE-LOCAL (#10024)" "F47373"
+
+          # Advisory: ALWAYS exit 0. The job never fails; the signal is the LABEL.
+          python scripts/notebook_tools/check_pr_dotnet_nuget_block.py \
+            --json --stdin --pr-body-file pr_body.md < changed_ipynb.txt > payload.json
+          cat payload.json
+
+          FLAGGED=$(python -c "import json; print(json.load(open('payload.json'))['summary']['dotnet_block_without_nuget'])")
+
+          # Illisible payload -> measure NOTHING, do not claim conformity (cf
+          # exercises-advisory.yml Blocage 3, #8819): stay silent (no label),
+          # emit a loud ::error::, exit 0.
+          if ! [ "${FLAGGED:-}" -eq "${FLAGGED:-}" ] 2>/dev/null; then
+            echo "::error::dotnet-nuget-block payload illisible -- the gate measured NOTHING; neither claimed nor denied."
+            unset_label "$LABEL_NAME"
+            exit 0
+          fi
+
+          if [ "${FLAGGED:-0}" -gt 0 ]; then
+            echo "::warning::$FLAGGED modified .NET notebook(s) with 0 #r nuget but a body invoking a .NET exec block (#10024). See the '$LABEL_NAME' label."
+            set_label "$LABEL_NAME"
+            echo "RESULT: $FLAGGED notebook(s) flagged -- labelled."
+          else
+            unset_label "$LABEL_NAME"
+            echo "RESULT: no .NET exec-block-without-nuget anti-pattern detected (verified)."
+          fi
+          exit 0

--- a/scripts/notebook_tools/check_pr_dotnet_nuget_block.py
+++ b/scripts/notebook_tools/check_pr_dotnet_nuget_block.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Per-PR advisory detector: a body invoking a .NET execution-block dispense
+on a notebook that contains zero ``#r "nuget:"`` references.
+
+Why this exists -- issue #10024 Livrable 2 (the organ).
+``docs/reference/kernels-runtime.md`` documents that the headless ``#r "nuget:"``
+restore is blocked cluster-wide ([dotnet-headless-nuget-restore-cluster-wide-blocker]).
+That blocker is REAL but BOUNDED: it applies only to notebooks that actually
+contain a ``#r "nuget:"`` cell. The dispense was repeatedly invoked as a blanket
+excuse to skip re-execution or to transplant outputs from outside the repo -- on
+notebooks that contained NO ``#r "nuget:"`` at all. PR #10021 is the canonical
+case: ``RECOVERABLE-MACHINE`` verdict + outputs transplanted from an uncommitted
+console project, for ``App-13b`` (0 ``#r "nuget:"``) -- the form of a falsified
+execution proof.
+
+This detector makes that anti-pattern VISIBLE. It is **advisory** (always exits
+0): the actionable signal is the ``dotnet-block-without-nuget`` LABEL posed by
+the workflow, never the exit code. A reviewer reading "exit 0" as "conforming"
+reads the wrong signal -- the same trap documented in exercises-advisory.yml.
+
+Falsifiability (acceptance: >=2 silence tests, [gate-must-verify-detector-fp-before-wiring]):
+  - a .NET notebook WITH ``#r "nuget:"`` + body invoking the block -> SILENT
+    (the block may be legitimate: nuget restore genuinely can hang headless).
+  - a .NET notebook WITHOUT nuget and a body NOT invoking the block -> SILENT.
+  - a non-.NET notebook -> out of scope, SILENT.
+The reference case that must ROUGE: PR #10021 body on App-13b (0 nuget).
+
+Usage (mirrors check_pr_exercises.py):
+
+    python check_pr_dotnet_nuget_block.py --paths App-13b.ipynb --pr-body-file body.md --json
+    git diff --name-only BASE HEAD -- '*.ipynb' | python check_pr_dotnet_nuget_block.py --stdin --pr-body-file body.md --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+LABEL_NAME = "dotnet-block-without-nuget"
+
+# Keywords that signal a .NET execution-block dispense in a PR body. The flag
+# fires only when the modified notebook has 0 ``#r "nuget:"``, so listing
+# "nuget" here is self-consistent (a body mentioning nuget + a notebook with no
+# nuget reference = the suspicious combination). Case-insensitive.
+BLOCK_KEYWORDS: tuple[str, ...] = (
+    "recoverable-machine",
+    "headless",
+    "non-executable",
+    "non-exec",
+    "pas executable",
+    "pas execut",
+    "transplant",
+    "nuget",
+)
+
+# Matches ``#r "nuget:...`` in cell source (after JSON parse, quotes are real).
+# Tolerates whitespace variants: ``#r "nuget:...``, ``#r  "nuget: ...``.
+NUGET_REF_RE = re.compile(r'#r\s+"nuget\s*:', re.IGNORECASE)
+
+
+def _is_dotnet_kernel(nb: dict) -> bool:
+    """True if the notebook's kernelspec name starts with ``.net``."""
+    name = (
+        nb.get("metadata", {})
+        .get("kernelspec", {})
+        .get("name", "")
+        .strip()
+        .lower()
+    )
+    return name.startswith(".net")
+
+
+def _count_nuget_refs(nb: dict) -> int:
+    """Count ``#r "nuget:"`` occurrences across ALL cell sources."""
+    total = 0
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        source = cell.get("source", [])
+        text = "".join(source) if isinstance(source, list) else str(source)
+        total += len(NUGET_REF_RE.findall(text))
+    return total
+
+
+def _find_block_keywords(body: str) -> list[str]:
+    """Return the (lowercased, de-duplicated, order-preserving) block keywords
+    found in the PR body. Empty list if the body does not invoke a block."""
+    if not body:
+        return []
+    low = body.lower()
+    found: list[str] = []
+    seen: set[str] = set()
+    for kw in BLOCK_KEYWORDS:
+        if kw in low and kw not in seen:
+            seen.add(kw)
+            found.append(kw)
+    return found
+
+
+def check_pr(paths: list[str], body: str) -> dict:
+    """Inspect each notebook path + the PR body. Return the JSON payload.
+
+    A notebook is FLAGGED iff ALL hold:
+      1. it parses as a valid .ipynb with a ``.net*`` kernelspec,
+      2. it contains 0 ``#r "nuget:"`` references,
+      3. the PR body invokes >=1 block keyword.
+    """
+    body_keywords = _find_block_keywords(body)
+    body_invokes_block = len(body_keywords) > 0
+
+    notebooks_out: list[dict] = []
+    dotnet_checked = 0
+    dotnet_with_nuget = 0
+    flagged = 0
+
+    for raw_path in paths:
+        raw_path = raw_path.strip()
+        if not raw_path or not raw_path.endswith(".ipynb"):
+            continue
+        p = Path(raw_path)
+        entry: dict = {"path": raw_path}
+        if not p.is_file():
+            entry.update({"status": "missing", "flagged": False})
+            notebooks_out.append(entry)
+            continue
+        try:
+            nb = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            entry.update({"status": f"unparseable: {exc}", "flagged": False})
+            notebooks_out.append(entry)
+            continue
+        if not _is_dotnet_kernel(nb):
+            entry.update(
+                {
+                    "status": "non-dotnet",
+                    "kernel": nb.get("metadata", {})
+                    .get("kernelspec", {})
+                    .get("name", "?"),
+                    "flagged": False,
+                }
+            )
+            notebooks_out.append(entry)
+            continue
+
+        dotnet_checked += 1
+        nuget_count = _count_nuget_refs(nb)
+        entry.update(
+            {
+                "status": "ok",
+                "kernel": nb.get("metadata", {})
+                .get("kernelspec", {})
+                .get("name", "?"),
+                "nuget_count": nuget_count,
+                "flagged": False,
+            }
+        )
+        if nuget_count > 0:
+            dotnet_with_nuget += 1
+            # Legitimate block context: the nuget blocker genuinely can apply.
+            entry["reason"] = "has #r nuget -- block may be legitimate (SILENT)"
+        elif not body_invokes_block:
+            entry["reason"] = "no nuget but body does not invoke a block (SILENT)"
+        else:
+            # The anti-pattern: 0 nuget + body invokes a blocker dispense.
+            entry["flagged"] = True
+            entry["body_block_keywords"] = body_keywords
+            entry[
+                "reason"
+            ] = "0 #r nuget but body invokes a .NET exec block -- likely RECOVERABLE-LOCAL, re-exec for real"
+            flagged += 1
+        notebooks_out.append(entry)
+
+    return {
+        "summary": {
+            "dotnet_block_without_nuget": flagged,
+            "dotnet_notebooks_checked": dotnet_checked,
+            "dotnet_notebooks_with_nuget": dotnet_with_nuget,
+            "body_invokes_block": body_invokes_block,
+            "body_keywords_found": body_keywords,
+        },
+        "notebooks": notebooks_out,
+    }
+
+
+def _collect_paths(path_args: list[str], from_stdin: bool) -> list[str]:
+    paths = list(path_args or [])
+    if from_stdin:
+        for line in sys.stdin:
+            line = line.strip()
+            if line:
+                paths.append(line)
+    # De-duplicate while preserving order.
+    seen: set[str] = set()
+    out: list[str] = []
+    for p in paths:
+        if p not in seen:
+            seen.add(p)
+            out.append(p)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Advisory detector for the .NET exec-block-without-nuget anti-pattern "
+            "(#10024 Livrable 2). Always exits 0 (advisory): the signal is the "
+            f"'{LABEL_NAME}' label, not this exit code."
+        ),
+    )
+    parser.add_argument(
+        "--paths", nargs="*", default=[],
+        help="Notebook paths modified by the PR.",
+    )
+    parser.add_argument(
+        "--stdin", action="store_true",
+        help="Also read paths from stdin (one per line; e.g. git diff output).",
+    )
+    parser.add_argument(
+        "--pr-body-file", dest="pr_body_file", default=None,
+        help="Path to a file containing the PR body text.",
+    )
+    parser.add_argument(
+        "--pr-body", dest="pr_body", default=None,
+        help="PR body text directly (alternative to --pr-body-file).",
+    )
+    parser.add_argument(
+        "--json", dest="json_out", action="store_true",
+        help="Emit machine-readable JSON (the workflow parses this for the label).",
+    )
+    args = parser.parse_args(argv)
+
+    paths = _collect_paths(args.paths, args.stdin)
+    body = args.pr_body or ""
+    if args.pr_body_file:
+        try:
+            body += Path(args.pr_body_file).read_text(encoding="utf-8")
+        except OSError:
+            pass
+
+    payload = check_pr(paths, body)
+
+    if args.json_out:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        s = payload["summary"]
+        print(f".NET notebooks checked: {s['dotnet_notebooks_checked']}")
+        print(f"  with #r nuget: {s['dotnet_notebooks_with_nuget']}")
+        print(f"  flagged (0 nuget + body block): {s['dotnet_block_without_nuget']}")
+        if s["body_keywords_found"]:
+            print(f"body block keywords: {s['body_keywords_found']}")
+        for nb in payload["notebooks"]:
+            tag = "FLAG" if nb.get("flagged") else "ok"
+            print(f"  [{tag}] {nb['path']} -- {nb.get('reason', nb.get('status'))}")
+
+    # Advisory: NEVER exit non-zero (#10024 acceptance).
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_check_pr_dotnet_nuget_block.py
+++ b/scripts/notebook_tools/tests/test_check_pr_dotnet_nuget_block.py
@@ -1,0 +1,172 @@
+"""Tests for scripts/notebook_tools/check_pr_dotnet_nuget_block.py
+
+Issue #10024 Livrable 2 acceptance -- >=2 falsification tests proving silence
+([gate-must-verify-detector-fp-before-wiring]) PLUS a CONTROLE POSITIF
+OBLIGATOIRE: a gate that never fires is silent for the wrong reason (#8680).
+These tests prove the advisory can actually fire (reference RED case: PR #10021
+on App-13b) AND that it stays silent on the legitimate combinations.
+
+Falsification cases that MUST be silent:
+  1. .NET notebook WITH `#r "nuget:"` + body invoking RECOVERABLE-MACHINE -> SILENT
+     (the nuget blocker genuinely can apply headless -> block may be legitimate).
+  2. .NET notebook WITHOUT nuget + body NOT invoking any block -> SILENT.
+  3. non-.NET notebook + body invoking a block -> SILENT (out of scope).
+
+Pure functions on tmp_path notebooks -- no I/O on the real repo.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+_tools_dir = str(Path(__file__).resolve().parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+import check_pr_dotnet_nuget_block as mod  # noqa: E402
+
+
+def _write_nb(path: Path, cells: list[dict], kernel: str = ".net-csharp") -> Path:
+    nb = {
+        "cells": cells,
+        "metadata": {"kernelspec": {"name": kernel, "display_name": kernel}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(nb), encoding="utf-8")
+    return path
+
+
+def _code(source: str) -> dict:
+    return {
+        "cell_type": "code",
+        "source": [source],
+        "metadata": {},
+        "execution_count": 1,
+        "outputs": [],
+    }
+
+
+# Reference RED case body -- mirrors PR #10021 (the canonical anti-pattern):
+# RECOVERABLE-MACHINE verdict + transplant, on App-13b which has 0 #r nuget.
+BODY_10021 = (
+    "## Re-exec verdict\n\n"
+    "**RECOVERABLE-MACHINE (real kernel unavailable headless)**. "
+    "Le notebook n'est pas executable localement (blocage nuget #r headless). "
+    "Outputs produits via un projet console .NET auto-contenu (transplant), "
+    "non committé dans le depot."
+)
+
+
+def test_reference_red_case_app13b_0_nuget_body_invokes_block(tmp_path: Path):
+    """CONTROLE POSITIF: the reference case (PR #10021) MUST be flagged.
+    App-13b contains 0 `#r "nuget:"`; the body invokes RECOVERABLE-MACHINE +
+    headless + nuget + transplant -> the exact anti-pattern."""
+    nb = tmp_path / "App-13b.ipynb"
+    _write_nb(
+        nb,
+        [
+            _code('var x = 1;'),
+            _code('Console.WriteLine("hello");'),
+        ],
+        kernel=".net-csharp",
+    )
+    payload = mod.check_pr([str(nb)], BODY_10021)
+    assert payload["summary"]["dotnet_block_without_nuget"] == 1
+    assert payload["summary"]["dotnet_notebooks_checked"] == 1
+    assert payload["summary"]["dotnet_notebooks_with_nuget"] == 0
+    assert payload["summary"]["body_invokes_block"] is True
+    entry = payload["notebooks"][0]
+    assert entry["flagged"] is True
+    assert entry["nuget_count"] == 0
+    assert "recoverable-machine" in entry["body_block_keywords"]
+
+
+def test_silence_dotnet_WITH_nuget_and_body_invokes_block(tmp_path: Path):
+    """FALSIFICATION 1: a .NET notebook WITH `#r "nuget:"` + body invoking the
+    block -> SILENT. The nuget blocker genuinely can apply headless, so the
+    RECOVERABLE-MACHINE verdict may be legitimate. Flagging here = FP."""
+    nb = tmp_path / "WithNuget.ipynb"
+    _write_nb(
+        nb,
+        [
+            _code('#r "nuget: GeneticSharp, 3.1.4"'),
+            _code('using GeneticSharp;\nvar ga = new GeneticAlgorithm();'),
+        ],
+        kernel=".net-csharp",
+    )
+    payload = mod.check_pr([str(nb)], BODY_10021)
+    assert payload["summary"]["dotnet_block_without_nuget"] == 0
+    assert payload["summary"]["dotnet_notebooks_with_nuget"] == 1
+    entry = payload["notebooks"][0]
+    assert entry["flagged"] is False
+    assert entry["nuget_count"] == 1
+
+
+def test_silence_dotnet_WITHOUT_nuget_and_body_does_not_invoke_block(tmp_path: Path):
+    """FALSIFICATION 2: a .NET notebook WITHOUT nuget + body that does NOT
+    invoke any block -> SILENT. No dispense claimed -> nothing to flag."""
+    nb = tmp_path / "PlainDotnet.ipynb"
+    _write_nb(
+        nb,
+        [_code('Console.WriteLine("no nuget here");')],
+        kernel=".net-csharp",
+    )
+    body = "Routine re-exec via notebook_tools.py execute --kernel .net-csharp. All cells green."
+    payload = mod.check_pr([str(nb)], body)
+    assert payload["summary"]["dotnet_block_without_nuget"] == 0
+    assert payload["summary"]["body_invokes_block"] is False
+    entry = payload["notebooks"][0]
+    assert entry["flagged"] is False
+
+
+def test_silence_non_dotnet_notebook_out_of_scope(tmp_path: Path):
+    """FALSIFICATION 3: a non-.NET notebook (python3) + body invoking the block
+    -> SILENT. The .NET blocker does not apply to python3 notebooks."""
+    nb = tmp_path / "Python.ipynb"
+    _write_nb(
+        nb,
+        [_code('print("python notebook")')],
+        kernel="python3",
+    )
+    payload = mod.check_pr([str(nb)], BODY_10021)
+    assert payload["summary"]["dotnet_block_without_nuget"] == 0
+    assert payload["summary"]["dotnet_notebooks_checked"] == 0
+    entry = payload["notebooks"][0]
+    assert entry["flagged"] is False
+    assert entry["status"] == "non-dotnet"
+
+
+def test_nuget_ref_regex_matches_variants():
+    """The `#r "nuget:"` regex must catch the real-world variants (versioned,
+    spaced) so a notebook with a genuine nuget ref is not mis-flagged."""
+    assert mod.NUGET_REF_RE.findall('#r "nuget: GeneticSharp"')
+    assert mod.NUGET_REF_RE.findall('#r "nuget:GeneticSharp, 3.1.4"')
+    assert mod.NUGET_REF_RE.findall('#r  "nuget: Google.OrTools"')
+    # Must NOT match a plain DLL load or a comment.
+    assert not mod.NUGET_REF_RE.findall('#r "System.Console"')
+    assert not mod.NUGET_REF_RE.findall('// nuget is mentioned in a comment')
+
+
+def test_stdio_variant_kernel_names_caught(tmp_path: Path):
+    """All `.net*` kernel variants are in scope (.net-csharp, .net-fsharp,
+    .net-powershell, .net-csharp-stdio). A non-.net name is not."""
+    for kernel in (".net-csharp", ".net-fsharp", ".net-powershell", ".net-csharp-stdio"):
+        nb = tmp_path / f"{kernel}.ipynb"
+        _write_nb(nb, [_code('var x = 1;')], kernel=kernel)
+        payload = mod.check_pr([str(nb)], BODY_10021)
+        assert payload["summary"]["dotnet_notebooks_checked"] == 1, kernel
+        assert payload["summary"]["dotnet_block_without_nuget"] == 1, kernel
+
+
+def test_cli_always_exits_zero(tmp_path: Path, capsys):
+    """Advisory contract (#10024 acceptance): the CLI NEVER exits non-zero,
+    even when it flags. The signal is the label, not the exit code."""
+    nb = tmp_path / "App.ipynb"
+    _write_nb(nb, [_code('var x = 1;')], kernel=".net-csharp")
+    body_file = tmp_path / "body.md"
+    body_file.write_text(BODY_10021, encoding="utf-8")
+    rc = mod.main(["--paths", str(nb), "--pr-body-file", str(body_file)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "FLAG" in out  # flagged but still exit 0


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #10026 (c.12, all-CI-green, pending ai-01 merge)

## Quoi

Livrable 2 of #10024 — l'organe advisory qui rend visible l'anti-pattern du bloc d'exécution .NET invoqué sur un notebook qui **ne contient aucun `#r "nuget:"`**. PR #10021 est le cas canonique : verdict `RECOVERABLE-MACHINE` + outputs transplantés depuis un projet console non committé, pour `App-13b` qui contient **0 `#r "nuget:"`** — la forme même d'une preuve d'exécution falsifiée.

**PR SÉPARÉE de #10027** (po-2026, Livrable 1+1bis, doc `kernels-runtime.md`) — **aucun chevauchement de fichier** : cette PR = `.github/workflows/` + script + tests ; #10027 = `docs/`. L'issue #10024 stipule explicitement « Livrable 2 — PR SÉPARÉE, ne pas composer ».

## Le défaut organique que ça corrige

Le blocage `#r "nuget:"` headless est **réel mais borné** ([dotnet-headless-nuget-restore-cluster-wide-blocker]) : il s'applique **uniquement** aux notebooks qui contiennent une cellule `#r "nuget:"`. Il a été invoqué de façon répétée comme dispense **générale** pour skipper la ré-exécution ou transplanter des outputs — sur des notebooks qui n'en contenaient **aucun**. Une règle reposant sur la vigilance d'un reviewer à chaque passe n'est pas un organe (le constat qui a produit #10010 et #10020). Ce check câble la vigilance.

## Le détecteur — `scripts/notebook_tools/check_pr_dotnet_nuget_block.py`

Un notebook est **flaggé** ssi les 3 conditions tiennent :
1. il parse comme un `.ipynb` avec un kernelspec `.net*` (`.net-csharp`, `.net-fsharp`, `.net-powershell`, `.net-csharp-stdio`),
2. il contient **0** `#r "nuget:"` (regex `#r\s+"nuget\s*:`, toutes cellules code),
3. le **body de la PR** invoque ≥1 mot-clé de bloc (`RECOVERABLE-MACHINE`, `headless`, `nuget`, `non-executable`/`pas exécutable`, `transplant`).

Interface miroir de `check_pr_exercises.py` (`--paths` / `--stdin` / `--json` / `--pr-body-file`), **always exit 0** (advisory).

## Le workflow — `.github/workflows/dotnet-nuget-block-advisory.yml`

Pattern `exercises-advisory.yml` (advisory canonique) : per-PR scope, **same-repo only** (forks/student PRs skippés via `student-pr-reviews.md`), **self-cover** dans `paths:` (enforced par `check_workflow_label_paths.py` — vérifié, 0 violation), `permissions: pull-requests: write`, `GH_REPO` env. Récupère le body via `gh pr view --json body`, délègue la détection au script → JSON → décision label. Pose `dotnet-block-without-nuget` si flagged, retire sinon. **Always exit 0.**

## Falsification (acceptance ≥2 + contrôle positif) — 7 tests verts

| Test | Attendu | Statut |
|---|---|---|
| **Cas de référence #10021** (App-13b, 0 nuget, body RECOVERABLE-MACHINE+transplant+headless+nuget) | **FLAG** | PASS |
| .NET **WITH** `#r nuget` + body invoque le bloc | SILENT (le bloc peut être légitime) | PASS |
| .NET **WITHOUT** nuget + body **n'invoque pas** de bloc | SILENT | PASS |
| non-.NET (python3) + body invoque le bloc | SILENT (hors scope) | PASS |
| regex `#r "nuget:"` matche les variantes (versionné, espacé) ; rejette DLL load + commentaire | — | PASS |
| kernel variants `.net-{csharp,fsharp,powershell,csharp-stdio}` tous in-scope | — | PASS |
| CLI **always exit 0** même quand flagged | advisory contract | PASS |

**Suite complète `notebook_tools` : 4197 passed, 2 skipped** — aucune régression.

## FP measurement firsthand ([gate-must-verify-detector-fp-before-wiring])

Détecteur exécuté sur le corpus réel `origin/main` :
- **Real App-13b** (référence) : 0 nuget → **flagged correctement** quand le body invoque un bloc ✓
- **Real App-10b** (GeneticSharp) : `nuget_count=1` → **SILENT** même avec body invoquant le bloc ✓ (le blocage nuget peut légitimement s'appliquer)
- **Corpus** : 231 notebooks .NET, 103 avec `#r nuget`, 128 sans. Le « 128 » = population **sous scrutin** (notebooks où une claim de bloc SERAIT examinée), **pas 128 FP** : le détecteur ne flagge que dans le contexte d'un body qui invoque un bloc.

**FP caractérisé honnêtement** : `headless` matche aussi les bodies de **ré-exec headless réussie** (« re-exec headless via notebook_tools → success »). C'est un FP **advisory** — le reviewer lit le label « 0 nuget + body mentionne headless », voit que le body dit SUCCÈS (pas bloc), et le dismiss. Le coût du FP (1 label à dismiss) ≪ coût d'un FN (preuve d'exécution falsifiée qui passe). La nature advisory tolère ce tradeoff. La discrimination reste nette sur le signal fort : **RECOVERABLE-MACHINE + transplant sur 0-nuget** = le pattern de #10021.

## Acceptance #10024 (Livrable 2)

- [x] advisory (`exit 0`, signal dans le label), jamais bloquant
- [x] code de sortie préservé (pas de `tee | grep`)
- [x] ≥2 tests de falsification prouvant le silence (3 cas SILENT ci-dessus)
- [x] aucune exemption wildcard
- [x] cas de référence #10021 rougit (vérifié firsthand + test dédié)

See #10024 (Livrable 2) · See #10027 (Livrable 1+1bis, po-2026, sans chevauchement) · See #10021 (cas de référence) · See #3801