### PR TITLE
feat(ci,#9819): CI check-runs aggregator with verdict replay of #9762 + outage #9858 coverage

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -64,6 +64,13 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install canary dependency
+        # PyYAML drives the rule-8 delivery canary (derive_always_on_jobs reads
+        # .github/workflows to find jobs that run on every pull_request). If this
+        # install failed, the script's import guard self-disables the canary --
+        # safe (no block) but the #9858 hole would stay open, so install it.
+        run: pip install pyyaml
+
       - name: Aggregate check verdicts
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -66,10 +66,21 @@ now and later, with no per-workflow wiring to maintain.
    then skips polling entirely and reports PASS. The "verdict on every PR"
    invariant is preserved (GitHub sees a real success line) without ever
    deciding the student's CI.
+8. **Delivery canary.** A settled check set containing NONE of the always-on
+   workflows means CI was never created for the PR -- the 2026-08-06 (#9858)
+   partial-delivery failure mode, where `pr-gate` ran and stabilised on a near-
+   empty bouquet while the rest of CI sat uncreated. The always-on roster is
+   DERIVED from `.github/workflows` (jobs whose workflow fires on `pull_request`
+   with no `paths:` filter), never hardcoded; the canary fires only at settle
+   time and judges on observed NAMES so advisory always-on jobs (diverted out of
+   `ok` by rule 6) still count as delivered. An empty set is no longer a pass:
+   it is indistinguishable from a partial delivery, and rule 1 says refuse.
 
-Exit codes: 0 = every settled check is non-failing (or there are none),
-            or the PR is from a fork (out-of-scope per #10072).
-            1 = at least one failure, or the state could not be established.
+Exit codes: 0 = every settled check is non-failing AND the platform delivered
+            its always-on bouquet (or the PR is from a fork, out-of-scope per
+            #10072).
+            1 = at least one failure, the state could not be established, or the
+            platform never delivered the PR (#9858 canary).
 
 Run locally against any PR head:
 
@@ -83,7 +94,13 @@ import json
 import subprocess
 import sys
 import time
+from pathlib import Path
 from typing import Iterable, Sequence
+
+try:  # Used only by the rule-8 delivery canary (derive_always_on_jobs).
+    import yaml  # type: ignore
+except ImportError:  # pragma: no cover - environment problem, canary self-disables
+    yaml = None  # type: ignore
 
 # A check that reached one of these has produced a verdict we accept.
 CONCLUSION_OK = frozenset({"success", "neutral", "skipped"})
@@ -112,6 +129,158 @@ ADVISORY_MARKER = "advisory"
 def is_advisory(name: str) -> bool:
     """True when the check declares itself non-blocking by name (rule 6)."""
     return ADVISORY_MARKER in (name or "").lower()
+
+
+# Where the always-on workflow jobs are derived from (rule 8 canary). Resolved
+# relative to the repo root: this script lives in scripts/, so its parent is the
+# repository root that holds .github/workflows.
+DEFAULT_WORKFLOWS_DIR = str(Path(__file__).resolve().parent.parent / ".github" / "workflows")
+
+
+def _norm(name: str) -> str:
+    """Normalise a check/job name for the delivery canary: lowercase, collapse
+    whitespace. Matching is on observed NAMES (the input to `classify`), never on
+    the bucket a check landed in, because some always-on jobs are themselves
+    advisory (rule 6) and would be diverted out of `ok`.
+    """
+    return " ".join((name or "").lower().split())
+
+
+def derive_always_on_jobs(
+    workflows_dir: str = DEFAULT_WORKFLOWS_DIR, self_name: str = DEFAULT_SELF_NAME
+) -> frozenset[str]:
+    """Job names produced by workflows that run on EVERY pull_request (no
+    `paths:` filter), excluding this gate's own job.
+
+    These are the canary: a healthy PR always surfaces at least one of them, so
+    a settled check set containing NONE means the platform never delivered the
+    PR -- the 2026-08-06 (#9858) partial-delivery failure mode, where `pr-gate`
+    ran and stabilised while the rest of CI was never created.
+
+    The list is DERIVED, never hardcoded (rule 8 / acceptance criterion 1): a
+    baked-in list rots the moment a workflow is added, and a rotten canary is
+    worse than none because it blocks with false confidence. Reading the trigger
+    from the workflows themselves is what keeps it honest.
+
+    Returns an empty set when the directory is missing, YAML is unavailable, or a
+    file fails to parse -- the caller treats an empty set as "canary disabled"
+    rather than "nothing is ever-on", because weaponising an unreadable state
+    against every PR would deadlock the repository (rule 1's bias-to-fail applies
+    to an unreadable VERDICT, not to an unreadable canary roster).
+    """
+    if yaml is None:
+        return frozenset()
+    root = Path(workflows_dir)
+    if not root.is_dir():
+        return frozenset()
+
+    self_norm = _norm(self_name)
+    jobs: set[str] = set()
+    for yml in sorted(root.glob("*.yml")):
+        try:
+            data = yaml.safe_load(yml.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError):
+            continue
+        if not isinstance(data, dict):
+            continue
+
+        triggers = data.get("on", data.get(True))  # PyYAML may parse `on:` as True
+        pr = _pull_request_trigger(triggers)
+        if pr is None:
+            continue
+        # `pr` is truthy when pull_request fires; a dict with `paths`/`paths-ignore`
+        # means the workflow is path-filtered and does NOT run on every PR.
+        if isinstance(pr, dict) and ("paths" in pr or "paths-ignore" in pr):
+            continue
+
+        for jname in _workflow_job_names(data):
+            if _norm(jname) == self_norm:
+                continue  # never let the gate canary itself
+            jobs.add(jname)
+
+    return frozenset(jobs)
+
+
+def _pull_request_trigger(triggers: object) -> object:
+    """Extract the `pull_request` trigger value from a workflow `on:` field.
+
+    Returns None when pull_request is absent, otherwise the trigger's value
+    (True/a list/a dict). Shields `derive_always_on_jobs` from the three YAML
+    shapes `on:` can take (scalar, sequence, mapping).
+    """
+    if isinstance(triggers, str):
+        return True if triggers == "pull_request" else None
+    if isinstance(triggers, list):
+        return "pull_request" if "pull_request" in triggers else None
+    if isinstance(triggers, dict):
+        return triggers.get("pull_request")
+    return None
+
+
+def _workflow_job_names(data: dict) -> list[str]:
+    """The check-run names a workflow produces: each job's `name:` or its key.
+
+    GitHub renders an Actions job's check-run `name` as the job's own `name`
+    field (or the job key when `name:` is absent). Workflows with a top-level
+    `name:` and a single job render as that job name; matrix/reusable jobs keep
+    the job name verbatim. Matching on these derived names is therefore faithful
+    to what the API returns under `check-runs[].name`.
+    """
+    names: list[str] = []
+    for jkey, jval in (data.get("jobs") or {}).items():
+        if isinstance(jval, dict):
+            names.append(jval.get("name") or jkey)
+    return names
+
+
+def platform_delivered(checks: Sequence[dict], always_on_jobs: frozenset[str]) -> bool:
+    """True when at least one always-on job is represented among observed checks.
+
+    The delivery canary (rule 8). Judges on observed NAMES -- the raw input to
+    `classify` -- and deliberately NOT on the `ok` bucket: at least two
+    always-on jobs are themselves advisory (e.g. the repo-size advisory, the
+    short-header advisory trio) and `classify` diverts a non-green advisory out
+    of `ok` into `advisory`. Judging `ok` would therefore flag a healthy PR whose
+    only always-on happened to be a red advisory. Judging names sidesteps the
+    trap: a delivered advisory job is still present by name.
+
+    A check matches an always-on job when the normalised names are equal, or when
+    the observed name ends with " / <job>" (GitHub's "<workflow> / <job>"
+    rendering for multi-job workflows).
+    """
+    observed = {_norm(c.get("name") or "") for c in checks}
+    for job in always_on_jobs:
+        target = _norm(job)
+        if not target:
+            continue
+        for name in observed:
+            if name == target or name.endswith(" / " + target):
+                return True
+    return False
+
+
+def _canary_verdict(
+    checks: Sequence[dict], always_on_jobs: frozenset[str]
+) -> tuple[int, str] | None:
+    """Rule 8: refuse to PASS when the platform did not deliver.
+
+    Returns (1, message) when the canary fires, None when it is disabled (empty
+    roster) or satisfied (delivery observed). Only consulted at settle time by
+    `wait_and_decide`, so it inherits the `settle_polls` grace period -- a
+    freshly-opened PR has that many consecutive quiet polls worth of runway for
+    Actions to create its check-runs before the canary draws a conclusion.
+    """
+    if not always_on_jobs:
+        return None
+    if platform_delivered(checks, always_on_jobs):
+        return None
+    sample = ", ".join(sorted(always_on_jobs)[:3])
+    tail = " ..." if len(always_on_jobs) > 3 else ""
+    return 1, (
+        "FAIL -- platform did not deliver: no always-on check observed "
+        f"(expected one of: {sample}{tail}). A settled set with none of the "
+        "always-on workflows means CI was never created for this PR (#9858)."
+    )
 
 
 class GateError(RuntimeError):
@@ -286,6 +455,7 @@ def wait_and_decide(
     timeout_min: float,
     poll_sec: float,
     settle_polls: int,
+    always_on_jobs: "frozenset[str] | None" = None,
     sleep=time.sleep,
     fetch=fetch_checks,
     now=time.monotonic,
@@ -295,6 +465,11 @@ def wait_and_decide(
     Stability is `settle_polls` consecutive polls with nothing pending -- a
     single quiet poll is not enough, because a workflow queued milliseconds ago
     has not surfaced yet and would be invisible.
+
+    `always_on_jobs` arms the delivery canary (rule 8). None or empty disables
+    it (the gate then behaves exactly as before this rule). Only consulted at
+    settle time, so a freshly-opened PR keeps the `settle_polls` grace period for
+    Actions to create its check-runs.
     """
     deadline = now() + timeout_min * 60.0
     quiet_streak = 0
@@ -315,6 +490,15 @@ def wait_and_decide(
         else:
             quiet_streak += 1
             if quiet_streak >= settle_polls:
+                # Rule 8 canary: refuse to pass when the platform never
+                # delivered the always-on bouquet (#9858 partial-delivery hole).
+                # `checks` is the raw observation (names, pre-bucket) so advisory
+                # always-on jobs still count as delivered.
+                canary = _canary_verdict(checks, always_on_jobs or frozenset())
+                if canary is not None:
+                    _report_advisory(advisory)
+                    print(f"[pr-gate] {canary[1]}", flush=True)
+                    return canary
                 _report_advisory(advisory)
                 print(f"[pr-gate] settled: {len(ok)} check(s) green", flush=True)
                 return verdict(pending, bad, settled=True)
@@ -351,6 +535,16 @@ def main(argv: Iterable[str] | None = None) -> int:
         action="store_true",
         help="PR comes from a fork (student work). Short-circuit to PASS.",
     )
+    parser.add_argument(
+        "--workflows-dir",
+        default=DEFAULT_WORKFLOWS_DIR,
+        help="Directory of GitHub workflow YAMLs for the rule-8 delivery canary.",
+    )
+    parser.add_argument(
+        "--no-canary",
+        action="store_true",
+        help="Disable the rule-8 delivery canary (escape hatch only).",
+    )
     args = parser.parse_args(list(argv) if argv is not None else None)
 
     if args.is_fork:
@@ -364,6 +558,18 @@ def main(argv: Iterable[str] | None = None) -> int:
         )
         return 0
 
+    always_on_jobs: "frozenset[str] | None" = None
+    if not args.no_canary:
+        always_on_jobs = derive_always_on_jobs(args.workflows_dir, args.self_name)
+        if not always_on_jobs:
+            # Disabled, not fatal (see derive_always_on_jobs): an unreadable
+            # canary roster must not block every PR.
+            print(
+                f"[pr-gate] delivery canary disabled: no always-on jobs derived "
+                f"from {args.workflows_dir}",
+                flush=True,
+            )
+
     try:
         code, message = wait_and_decide(
             args.repo,
@@ -372,6 +578,7 @@ def main(argv: Iterable[str] | None = None) -> int:
             args.timeout_min,
             args.poll_sec,
             args.settle_polls,
+            always_on_jobs,
         )
     except GateError as exc:
         # Rule 1: an unreadable state is a failure, never a pass.

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -139,9 +139,9 @@ def test_self_exclusion_is_not_a_loose_prefix():
 # --- decision table ----------------------------------------------------------
 
 
-def test_no_checks_at_all_passes():
-    """A PR that triggers no other CI has nothing to gate."""
-    assert decide([])[0] == 0
+def test_skipped_and_neutral_are_green():
+    checks = [run("A", "skipped", rid=1), run("B", "neutral", rid=2)]
+    assert decide(checks)[0] == 0
 
 
 def test_skipped_and_neutral_are_green():
@@ -166,6 +166,37 @@ def test_the_9762_shape_fails():
     code, msg = decide(checks)
     assert code == 1
     assert "Lean CI" in msg and "Proof integrity" in msg
+
+
+def test_the_9858_outage_shape_fails():
+    """Replay of the #9858 outage (Actions 2026-08-06): 175 PRs merged while
+    the per-PR gates never ran -- check-runs sat at `queued`/`in_progress` with
+    no conclusion, or reported `completed` with a null conclusion (runner died).
+
+    A gate that verdicts PASS on this shape is the exact failure mode that let
+    175 PRs through unpoliced. Both sub-cases must land in `pending` (classify:
+    `status in STATUS_PENDING or not conclusion`) and the verdict must FAIL --
+    the bias-to-fail rule (rule 1) applied to the outage, parallel to the #9762
+    replay above (which pins the failure-side, this pins the no-verdict-side).
+    """
+    # Sub-case 1: runner never picked the check up (queued / in_progress, null).
+    queued = [
+        run("ci / Lean CI (grothendieck_lean)", None, status="queued", rid=1),
+        run("proof-integrity / Proof integrity", None, status="in_progress", rid=2),
+        run("CodeQL", "success", rid=3),
+    ]
+    code, msg = decide(queued)
+    assert code == 1, "queued/null checks (outage) must block, not pass"
+    assert "Lean CI" in msg
+
+    # Sub-case 2: runner died mid-run -- `completed` with a null conclusion.
+    died = [
+        run("ci / Lean CI (grothendieck_lean)", None, status="completed", rid=4),
+        run("proof-integrity / Proof integrity", "success", rid=5),
+    ]
+    code, msg = decide(died)
+    assert code == 1, "completed/null-conclusion (runner died) must block"
+    assert "Lean CI" in msg
 
 
 # --- wait loop ---------------------------------------------------------------
@@ -384,3 +415,134 @@ def test_advisory_failure_alone_settles_green_end_to_end():
         now=lambda: 0.0,
     )
     assert code == 0, msg
+
+
+# --- delivery canary (rule 8, PR #10036 / #9858) -----------------------------
+#
+# A settled set containing NONE of the always-on workflows means CI was never
+# created for the PR -- the 2026-08-06 (#9858) partial-delivery failure mode,
+# where pr-gate ran and stabilised on a near-empty bouquet while the rest of CI
+# sat uncreated (175 PRs merged unpoliced). The canary refuses to pass on that
+# shape. The always-on roster is DERIVED from .github/workflows (jobs whose
+# workflow fires on pull_request with no paths: filter); judging on observed
+# NAMES (not the ok bucket) so advisory always-on jobs still count as delivered.
+
+# A small, stable roster for the pure-logic tests (independent of the live
+# workflows dir, which drifts as workflows are added -- exactly why the real
+# gate derives it rather than baking it in).
+_CANARY = frozenset(
+    {"No catalog changes on feature branch", "Gitleaks secret scanner"}
+)
+
+
+def test_empty_set_means_platform_did_not_deliver():
+    """Replaces the old `test_no_checks_at_all_passes`.
+
+    An empty settled set is indistinguishable from a partial delivery, so rule 1
+    (bias to fail) says refuse rather than pass. The pure `verdict`/`decide`
+    layer still returns PASS on empty (delivery is a wait-loop concern), but the
+    armed canary makes the *gate* exit 1 -- which is what closes the #9858 hole.
+    """
+    code, msg = pr_gate.wait_and_decide(
+        "o/r", "sha", "PR gate", timeout_min=1, poll_sec=0, settle_polls=1,
+        always_on_jobs=_CANARY,
+        sleep=lambda _s: None, fetch=lambda _r, _s: [], now=lambda: 0.0,
+    )
+    assert code == 1, msg
+    assert "did not deliver" in msg
+
+
+def test_canary_passes_when_an_always_on_is_present():
+    """A healthy PR surfaces at least one always-on check -> delivered."""
+    checks = [
+        run("No catalog changes on feature branch", "success", rid=1),
+        run("Lean CI", "success", rid=2),
+    ]
+    code, msg = pr_gate.wait_and_decide(
+        "o/r", "sha", "PR gate", timeout_min=1, poll_sec=0, settle_polls=1,
+        always_on_jobs=_CANARY,
+        sleep=lambda _s: None, fetch=lambda _r, _s: checks, now=lambda: 0.0,
+    )
+    assert code == 0, msg
+
+
+def test_canary_counts_a_red_advisory_always_on_as_delivered():
+    """The trap (acceptance criterion 2): an advisory always-on diverted out of
+    `ok` by rule 6 must STILL count as delivered. Judging on `ok` would falsely
+    flag a healthy PR whose only always-on happened to be a red advisory.
+    """
+    assert pr_gate.platform_delivered(
+        [run("Gitleaks secret scanner", "success")], _CANARY
+    ) is True
+    # Same job, failing -- still present by NAME, so still delivered.
+    assert pr_gate.platform_delivered(
+        [run("Gitleaks secret scanner", "failure")], _CANARY
+    ) is True
+
+
+def test_canary_fires_on_partial_delivery_pr_gate_only():
+    """The #9858 partial-delivery hole: pr-gate ran, nothing else did.
+
+    pr-gate is excluded from the roster (the gate never canaries itself), so a
+    bouquet of only the gate's own check is an undelivered PR.
+    """
+    checks = [run("PR gate", "success", rid=1)]
+    assert pr_gate.platform_delivered(checks, _CANARY) is False
+    code, msg = pr_gate.wait_and_decide(
+        "o/r", "sha", "PR gate", timeout_min=1, poll_sec=0, settle_polls=1,
+        always_on_jobs=_CANARY,
+        sleep=lambda _s: None, fetch=lambda _r, _s: checks, now=lambda: 0.0,
+    )
+    assert code == 1 and "did not deliver" in msg
+
+
+def test_canary_fires_when_only_non_always_on_checks_ran():
+    """Path-filtered checks ran but no always-on did -> platform degraded."""
+    checks = [run("ci / Lean CI (grothendieck_lean)", "success", rid=1)]
+    assert pr_gate.platform_delivered(checks, _CANARY) is False
+
+
+def test_canary_is_disabled_when_roster_is_empty():
+    """An unreadable/empty roster must not block every PR (safe-open).
+
+    derive_always_on_jobs returns empty when the dir is missing or YAML fails;
+    the gate then behaves exactly as before rule 8. Confirming that contract
+    here, against the real repo so the derivation itself is exercised.
+    """
+    jobs = pr_gate.derive_always_on_jobs(
+        "this/does/not/exist", pr_gate.DEFAULT_SELF_NAME
+    )
+    assert jobs == frozenset()
+    code, msg = pr_gate.wait_and_decide(
+        "o/r", "sha", "PR gate", timeout_min=1, poll_sec=0, settle_polls=1,
+        always_on_jobs=None,
+        sleep=lambda _s: None, fetch=lambda _r, _s: [], now=lambda: 0.0,
+    )
+    assert code == 0, "disabled canary must not turn an empty set into a failure"
+
+
+def test_derive_always_on_reads_real_workflows_and_excludes_self():
+    """Acceptance criterion 1: the roster is derived, not hardcoded, and never
+    includes the gate's own job. Run against the live .github/workflows.
+    """
+    jobs = pr_gate.derive_always_on_jobs()
+    assert len(jobs) >= 6, "expected at least the catalog/secret/regression/" \
+        "stale-base/variation always-on jobs from the real repo"
+    assert all(pr_gate.DEFAULT_SELF_NAME not in j for j in jobs), \
+        "the gate must never canary itself"
+    # A job known to be always-on (catalog-guard, no paths filter) is present.
+    assert "No catalog changes on feature branch" in jobs
+
+
+def test_fork_short_circuit_skips_the_canary(monkeypatch):
+    """Acceptance criterion 4: a fork PR never reaches the canary.
+
+    Forks short-circuit in main() before wait_and_decide is ever called, so even
+    a would-be-firing canary cannot touch a student PR.
+    """
+    def explode(*_a, **_kw):
+        raise AssertionError("fork path must not poll or canary")
+    monkeypatch.setattr(pr_gate, "wait_and_decide", explode)
+    monkeypatch.setattr(pr_gate, "derive_always_on_jobs", explode)
+    code = pr_gate.main(["--repo", "o/r", "--sha", "deadbeef", "--is-fork"])
+    assert code == 0


### PR DESCRIPTION
Grain: DEEP/guard — lane myia-po-2025:CoursIA-2 — prev: MED/docs #9991

## Quoi

Per ai-01's design-gate tranche: drop the duplicate 2nd aggregator and fold the **one** remaining real contribution — a **delivery canary** — into the single required gate (`scripts/pr_gate.py`). The canary closes the hole that requiredness alone cannot: during a degraded Actions outage (#9858), `pr-gate.yml` runs and stabilises while the rest of CI is never created, so the gate verdicts PASS on a near-empty bouquet — exactly what let 175 PRs merge unpoliced on 2026-08-06.

## G.1 — the world moved under this branch

Re-measured firsthand after rebase: `pr_gate.py` on main **already has** what the original review framing called the value to fold — folded by #10087 + follow-ups AFTER the review:
- **advisory classification** (rule 6, `is_advisory()`, 4-tuple `classify()`) — landed in #10087 (`afd436c2d`)
- **#9762 replay** — `test_the_9762_shape_fails`
- **fork short-circuit** (#10072) — `--is-fork`

So the duplicate 2nd aggregator (1001 lines) this branch added is **pure duplication**, removed entirely. The `pytest.ini` lines it needed are reverted to main.

## Le canari (rule 8)

The hole the requiredness does **not** close: requiredness guarantees the `PR gate` context reports, but it cannot tell the bouquet is suspiciously thin. The canary:

- `derive_always_on_jobs()` — reads `.github/workflows`, collects job names whose workflow fires on `pull_request` with **no `paths:` filter** (the always-on bouquet every healthy PR shows), excludes the gate's own job. **DERIVED, never hardcoded** (acceptance 1) — a baked list rots the moment a workflow is added. Measured firsthand now: 10 always-on jobs across 7 workflows (catalog-guard, regression-guard, repo-size-advisory, secret-scan, stale-base-warning, variation-tag-guard, variation-light-genre).
- `platform_delivered()` — True if ≥1 always-on job is among the **observed check names**. Judges on **names** (the input to `classify`), **not** the `ok` bucket (acceptance 2) — because some always-on jobs are themselves advisory and get diverted out of `ok` by rule 6; judging `ok` would falsely flag a healthy PR whose only always-on was a red advisory.
- Fires only **at settle time** (inherits the `settle_polls` grace for Actions to create check-runs). An empty set is **no longer a pass** — indistinguishable from a partial delivery, rule 1 says refuse (acceptance 3).
- **Safe-open**: an unreadable/empty roster (missing dir, YAML unavailable) **disables** the canary rather than blocking every PR — rule 1's bias-to-fail applies to an unreadable *verdict*, not an unreadable canary roster.

## Preuve

```
$ python -m pytest scripts/tests/test_pr_gate.py -q
......................................   [100%]
38 passed in 0.77s   (30 original + #9858 replay + 7 canary tests)
```

Canary against the real repo's workflows (firsthand):
```
derived always-on jobs (10): No catalog changes on feature branch, Gitleaks secret
  scanner, Large blob advisory (>= 10 MiB), Check base branch staleness, ...
delivered (healthy PR, incl a RED advisory always-on): True   # trap handled
delivered (empty set):                                   False  # canary fires
delivered (pr-gate only = #9858 partial delivery):       False  # the hole
```

`pr-gate.yml`: `pip install pyyaml` (the canary's only dependency; without it the import guard self-disables the canary and the #9858 hole stays open).

## Acceptance (5 criteria from the review)

- [x] **1. Canary DERIVED** from `.github/workflows` (pull_request, no paths), not hardcoded
- [x] **2. Settled set with no always-on => exit 1**, judges on observed **names** (advisory-always-on trap handled)
- [x] **3. `test_no_checks_at_all_passes` REPLACED** by `test_empty_set_means_platform_did_not_deliver` (empty → canary fail)
- [x] **4. Fork short-circuit intact** — `--is-fork` returns before `wait_and_decide`; `test_fork_short_circuit_skips_the_canary` pins it
- [x] **5. #9762 + #9858 replays** in `test_pr_gate.py`, green with the 30 existing (38 total)

## Perimetre

3 files, +383/-7 vs main:
- `scripts/pr_gate.py` — rule 8 (`derive_always_on_jobs`, `platform_delivered`, `_canary_verdict`), canary at settle in `wait_and_decide`, `--workflows-dir`/`--no-canary` flags.
- `scripts/tests/test_pr_gate.py` — 7 canary tests + the #9858 replay; `test_no_checks_at_all_passes` replaced.
- `.github/workflows/pr-gate.yml` — `pip install pyyaml`.

The deleted `ci-required-aggregator.yml` + `aggregate_checks.py` + its tests + `pytest.ini` lines were never on main; removing them returns to main.

See #9819, #9858, #9762, #10087, #10072
