### PR TITLE
docs(git-workflow): force-push scope — interdit sur main, autorise sur branche de PR a lane unique

### DIFF
--- a/.claude/PROJECT_MEMORY.md
+++ b/.claude/PROJECT_MEMORY.md
@@ -83,7 +83,7 @@ python scripts/series_progress_manager.py report search-part1-foundations
 - JAMAIS lancer papermill ou ipython directement sans passer par les scripts
 
 ### Git / Workflow
-- Jamais `git push --force` sans approbation explicite
+- `git push --force` : jamais sur `main` ; autorise sur une branche de PR qu'une seule lane manipule (`--force-with-lease`, alternative merge d'abord) — cf `.claude/rules/git-workflow.md`
 - Committer les enrichissements separement des outputs d'execution
 - Preferer `git add <fichiers specifiques>` a `git add -A`
 

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -28,13 +28,22 @@ GitHub auto-closes issues on `Refs #N`, `Fixes #N`, `Closes #N`. Use safe syntax
 
 ## Safety Rules
 
-### 🚨 CRITICAL - NEVER FORCE PUSH
+### Force push — interdit sur `main`, autorisé sur une branche de PR à lane unique
 
-**INCIDENT 2026-03-13** : Force push sur main a potentiellement écrasé des commits
-- **Règle** : `git push --force` et `--force-with-lease` sont INTERDITS
-- **Exception** : Uniquement urgence extrême avec validation explicite du user AU PRÉALABLE
-- **Alternative** : Créer feature branch, cherry-pick, revert, ou nouveaux commits
-- **Si PR nécessaire** : Créer feature branch FROM main, ne JAMAIS reset main
+**Décision user 2026-08-08** (verbatim) : « *Je ne suis pas fan des force-pushs, on a déjà perdu pas mal de contenu dans le passé à cause de ça, et il existe généralement une alternative à base de merge. Mais pour une branche de feature qui n'est pas manipulée par plusieurs agents de front, ça n'est pas la même histoire. Donc en gros si on interdit sur main et on permet sur des branches de PRs, ça me va.* »
+
+L'ancienne rédaction interdisait `--force` **partout**, urgence-user comprise. Elle est remplacée par un **périmètre**, parce que les deux cas n'ont pas la même conséquence : sur `main` un force-push écrase du contenu partagé et déjà consommé par ~95 forks étudiants (incident **2026-03-13**, commits potentiellement perdus) ; sur une branche de feature qu'une seule lane manipule, il ne réécrit que le travail non mergé de cette lane.
+
+| Cible | Règle | Ce qui la porte |
+|---|---|---|
+| **`main`** | **INTERDIT**, sans exception d'urgence | `allow_force_pushes: false` dans la protection de branche — GitHub **refuse** le push. Ce n'est pas qu'une consigne (vérifiable : `gh api repos/jsboige/CoursIA/branches/main/protection -q .allow_force_pushes`) |
+| **Branche de PR (`feature/*`, `fix/*`, `docs/*`) à lane unique** | **AUTORISÉ**, `--force-with-lease` préféré | aucune protection côté plateforme : c'est la discipline de lane qui répond |
+| **Branche manipulée par plusieurs agents de front** | **INTERDIT** | un `[CLAIMED]` d'une autre lane sur l'issue vaut « plusieurs agents » → [lane-claim-protocol.md](lane-claim-protocol.md) |
+
+- **L'alternative merge d'abord, quand elle existe** : `git merge origin/main`, `gh pr update-branch`, cherry-pick, revert, nouveaux commits. Le force-push est le dernier recours, jamais le réflexe de rebase par défaut.
+- **`--force-with-lease` plutôt que `--force`** : il échoue si le remote a bougé depuis ta dernière lecture — précisément le cas « une autre lane a poussé sans que je le sache ». C'est le garde-fou qui rend le périmètre ci-dessus sûr.
+- **Jamais de `reset --hard`** sur `main` ni sur une branche partagée.
+- **Un secret déjà commité ne se répare PAS par réécriture d'historique** : branche propre + cherry-pick, et **rotation de la clé** (cf [secrets-hygiene.md](secrets-hygiene.md) règle 5).
 
 ---
 

--- a/.claude/skills/coordinate/SKILL.md
+++ b/.claude/skills/coordinate/SKILL.md
@@ -59,7 +59,7 @@ Regles completes : [coordinator-discipline.md](../../rules/coordinator-disciplin
 
 ## Regles importantes
 
-- **Jamais de force push** — cf [git-workflow.md](../../rules/git-workflow.md)
+- **Force push** : jamais sur `main` ; autorisé sur une branche de PR à lane unique — cf [git-workflow.md](../../rules/git-workflow.md)
 - **Coordination via RooSync uniquement** — aucun fichier de coordination/rapport dans git
 - **Deux dashboards workspace, coordonnes independamment** — `workspace-CoursIA` et `workspace-CoursIA-2` sont co-egaux ; lire et poster un contenu lane-specific sur CHACUN a chaque cycle, jamais de broadcast miroir, jamais "le mien vs celui des workers".
 - **Issues + PRs** — chaque tache = issue, chaque livraison = PR avec review

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Notation étudiants : moteur générique = [GradeBookApp/configs/README.md](Grad
 
 **Reporting dashboard** : poster au minimum début/livraison/fin de session. > 30 min sans post = signe d'isolement. Posts `[INFO]` courts > silence.
 
-**Git** : pas de push direct sur `main`, pas de force push (`--force` / `--force-with-lease`) ni `reset --hard` sans validation user. Branches `feature/<sujet>` ou `fix/<sujet>`, un sujet par PR. Le coordinateur (ai-01) review et merge ; les agents ne mergent pas eux-mêmes. Cf [git-workflow.md](.claude/rules/git-workflow.md).
+**Git** : pas de push direct sur `main`. **Force push** : interdit sur `main` (porté par `allow_force_pushes: false`), autorisé sur une branche de PR qu'une **seule** lane manipule (`--force-with-lease`, l'alternative merge d'abord) — décision user 2026-08-08. Pas de `reset --hard` sur `main` ni sur une branche partagée. Branches `feature/<sujet>` ou `fix/<sujet>`, un sujet par PR. Le coordinateur (ai-01) review et merge ; les agents ne mergent pas eux-mêmes. Cf [git-workflow.md](.claude/rules/git-workflow.md).
 
 ### B. Reviews PR (5 points obligatoires)
 


### PR DESCRIPTION
Grain: MED/docs — lane myia-ai-01:CoursIA — prev: LIGHT/guard #9941

**Quoi** : la règle force-push passe d'un interdit absolu à un **périmètre** signé user — interdit sur `main`, autorisé sur une branche de PR qu'une seule lane manipule.
**Preuve** : l'état de la protection de `main` mesuré firsthand (`allow_force_pushes: false`) montre que la plateforme **implémente déjà** exactement ce périmètre ; c'était le texte du harnais qui était en décalage.
**Périmètre** : 4 fichiers de harnais, +18/−9. Aucun notebook, aucun catalogue, aucun workflow.

## La décision

Verbatim user, 2026-08-08 :

> Je ne suis pas fan des force-pushs, on a déjà perdu pas mal de contenu dans le passé à cause de ça, et il existe généralement une alternative à base de merge. Mais pour une branche de feature qui n'est pas manipulée par plusieurs agents de front, ça n'est pas la même histoire. Donc en gros si on interdit sur main et on permet sur des branches de PRs, ça me va.

## Pourquoi un périmètre et pas un assouplissement

L'ancienne rédaction (`--force` et `--force-with-lease` INTERDITS, exception « urgence extrême avec validation user »)
traitait deux situations sans rapport comme une seule :

| | Conséquence d'un force-push |
|---|---|
| `main` | écrase du contenu **partagé et déjà consommé** — dépôt public forké par ~95 dépôts étudiants. Irrécupérable en pratique (incident 2026-03-13) |
| branche de PR à lane unique | réécrit le travail **non mergé de la lane qui le possède**, et rien d'autre |

Le premier cas justifie un interdit dur ; le second n'a jamais rien mis en danger. L'interdit uniforme
produisait le coût habituel d'une règle trop large : elle se contourne « juste cette fois » au lieu de
se respecter, ce qui érode aussi la moitié qui compte.

## Ce qui porte la règle, mesuré

```
gh api repos/jsboige/CoursIA/branches/main/protection
  allow_force_pushes  = false      <- GitHub REFUSE le push sur main, ce n'est pas qu'une consigne
  allow_deletions     = false
```

Les branches `feature/*` / `fix/*` / `docs/*` n'ont aucune protection : côté plateforme le périmètre
user est **déjà** l'état du dépôt. La règle amendée décrit désormais le mécanisme réel au lieu de le
contredire — et cite la commande de vérification, pour qu'un futur agent puisse la relire contre la
source plutôt que me croire.

## Le garde-fou qui rend le second cas sûr

`--force-with-lease` est **préféré à `--force`**, et pour une raison précise : il échoue si le remote a
bougé depuis la dernière lecture — exactement le cas « une autre lane a poussé sans que je le sache ».
C'est ce qui transforme « branche à lane unique » d'une déclaration d'intention en propriété vérifiée
au moment du push. La condition « manipulée par plusieurs agents de front » est rattachée au signal
qui l'objective : un `[CLAIMED]` d'une autre lane sur l'issue
([lane-claim-protocol.md](.claude/rules/lane-claim-protocol.md)).

Deux points préservés de l'ancienne rédaction, parce qu'ils restent vrais :
`reset --hard` interdit sur `main` et sur toute branche partagée ; un secret déjà commité ne se répare
**pas** par réécriture d'historique (branche propre + cherry-pick + rotation de la clé, cf
[secrets-hygiene.md](.claude/rules/secrets-hygiene.md) règle 5).

## Cohérence — les quatre endroits qui l'affirmaient

Un grep de l'ensemble du dépôt a trouvé quatre assertions, toutes alignées ici :

| Fichier | Avant | Après |
|---|---|---|
| `.claude/rules/git-workflow.md` | « `--force` et `--force-with-lease` sont INTERDITS » | tableau de périmètre + garde-fous |
| `CLAUDE.md` §A | « pas de force push … sans validation user » | périmètre + mécanisme porteur |
| `.claude/skills/coordinate/SKILL.md` | « Jamais de force push » | « jamais sur `main` ; autorisé sur branche de PR à lane unique » |
| `.claude/PROJECT_MEMORY.md` | « Jamais … sans approbation explicite » | périmètre + pointeur vers la rule |

`docs/reference/procedures-recurrentes.md` L172 (« JAMAIS force-push la branche de l'auteur », côté
coordinateur) est **laissé tel quel** : sous le nouveau périmètre il reste exact — la branche d'un
autre auteur est par définition le cas multi-agents.

## Note de tag

`MED` et non `LIGHT` : le litmus LIGHT est « pourrais-je en générer une douzaine en scannant
l'instance suivante ? ». Non — c'est une décision de périmètre signée user, vérifiée contre l'état de
la plateforme, et il n'y a pas de douzaine d'instances. `docs` après `guard` (#9941) : genres
distincts, G-VAR-3 passe.
