### PR TITLE
Add: i18n T4 render_notebook.py (CSV + nb FR -> nb traduit, grain A de #10038)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning_en.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning_en.ipynb
@@ -1,0 +1,976 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# FT-01: Introduction to Fine-Tuning\n\n**Objective**: Understand the three fine-tuning approaches (full, partial, LoRA) and put LoRA into practice on a small text model.\n\n**Plan**:\n1. Why fine-tune?\n2. Full Fine-Tuning vs Partial vs LoRA\n3. Comparison of trainable parameters\n4. LoRA in practice: fine-tuning GPT-2 on a literary style\n5. Evaluation before/after\n\n**Required equipment**: GPU with ~4 GB VRAM (GPT-2 = 124M params)."
+   ],
+   "id": "cell-24754727"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PyTorch 2.11.0+cu126\n",
+      "CUDA disponible : True\n",
+      "GPU : NVIDIA GeForce RTX 3090\n",
+      "VRAM : 25.8 Go\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "import os\n",
+    "import gc\n",
+    "\n",
+    "print(f\"PyTorch {torch.__version__}\")\n",
+    "print(f\"CUDA disponible : {torch.cuda.is_available()}\")\n",
+    "if torch.cuda.is_available():\n",
+    "    print(f\"GPU : {torch.cuda.get_device_name(0)}\")\n",
+    "    print(f\"VRAM : {torch.cuda.get_device_properties(0).total_memory / 1e9:.1f} Go\")"
+   ],
+   "id": "cell-2853ccbc"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Why fine-tune?\n\nPre-trained models (foundation models) are capable of general tasks, but lack specialization:\n\n| Use case | Why fine-tune? |\n|-------------|----------------------|\n| Specific writing style | The generic model does not master a particular style |\n| Technical domain (medical, legal) | The vocabulary and reasoning patterns differ |\n| Structured task (classification, extraction) | The output format is not natural for the model |\n| Reducing hallucinations | A specialized model makes fewer errors in its domain |\n\n**Example**: GPT-2 generates generic English text. After fine-tuning on 19th-century French texts, it can imitate this specific style."
+   ],
+   "id": "cell-66318dab"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Three fine-tuning approaches\n\n### 2a. Full Fine-Tuning\n\nAll model parameters are updated.\n\n- **Advantage**: Maximum performance; the model adapts completely\n- **Disadvantage**: Very GPU-expensive (VRAM = models + gradients + optimizer states, often 3-4x the model size)\n- **Usage**: Small models (<1B) or large GPU budgets\n\n### 2b. Partial Fine-Tuning (Feature Extraction)\n\nThe lower layers are frozen and only the last ones are trained.\n\n- **Advantage**: Fewer parameters to train, faster\n- **Disadvantage**: Limited adaptation, no modification of deep representations\n- **Usage**: When the application domain is close to the pre-training domain\n\n### 2c. LoRA (Low-Rank Adaptation)\n\nSmall low-rank matrices ($A \\times B$) are injected alongside the original weights, and only these matrices are trained.\n\n- **Advantage**: Very few trainable parameters (0.1-1% of the model), minimal storage\n- **Disadvantage**: Slightly lower performance than full fine-tuning on complex tasks\n- **Usage**: Current industry standard, especially for models >3B\n\n### Mathematical formulation of LoRA\n\nFor a pre-trained weight $W \\in \\mathbb{R}^{d \\times k}$:\n\n$$h = Wx + \\Delta W x = Wx + BAx$$\n\nwhere $B \\in \\mathbb{R}^{d \\times r}$, $A \\in \\mathbb{R}^{r \\times k}$, and $r \\ll \\min(d, k)$.\n\nThe rank $r$ (typically 4-64) controls the expressiveness/efficiency trade-off."
+   ],
+   "id": "cell-8791918c"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Comparison of trainable parameters\n\nLet's load a small model (GPT-2, 124M params) and compare the three approaches."
+   ],
+   "id": "cell-dfcac0ae"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5743f206a6c44ca09bc4a8e3d9ac5fa4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "config.json:   0%|          | 0.00/665 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b11a41b6d392493abc892b1bb06f960a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "tokenizer_config.json:   0%|          | 0.00/26.0 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fc3d91fefcbd406982e2062e2cc1f8ea",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "vocab.json: 0.00B [00:00, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f700b55e07aa4efb9fcb4b8d17c6595d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "merges.txt: 0.00B [00:00, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "df5f6953a9904a25876d307e8b358911",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "tokenizer.json: 0.00B [00:00, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c4997868eb1c4eafabb753329d402a8a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model.safetensors:   0%|          | 0.00/548M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "35a46ccbb1e2430caf6e2d011312ea33",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading weights:   0%|          | 0/148 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "79272e266e8c46eca85a44534713dad1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "generation_config.json:   0%|          | 0.00/124 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele : openai-community/gpt2\n",
+      "Parametres totaux : 124,439,808 (124.4M)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+    "\n",
+    "MODEL_NAME = \"openai-community/gpt2\"  # 124M params\n",
+    "\n",
+    "tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)\n",
+    "tokenizer.pad_token = tokenizer.eos_token\n",
+    "\n",
+    "model = AutoModelForCausalLM.from_pretrained(MODEL_NAME)\n",
+    "total_params = sum(p.numel() for p in model.parameters())\n",
+    "print(f\"Modele : {MODEL_NAME}\")\n",
+    "print(f\"Parametres totaux : {total_params:,} ({total_params/1e6:.1f}M)\")"
+   ],
+   "id": "cell-c2fa367d"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "36ab9df3c9164bfab0d5b2233b66f455",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading weights:   0%|          | 0/148 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "W0524 03:44:00.962000 33800 torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Approche                Entrainables           Total        %\n",
+      "-------------------- --------------- --------------- --------\n",
+      "Full Fine-Tuning         124,439,808     124,439,808  100.00%\n",
+      "Partial (2 couches)       52,773,120     124,439,808   42.41%\n",
+      "LoRA (r=8)                   294,912     124,439,808    0.24%\n",
+      "\n",
+      "Ratio LoRA/Full = 0.24%\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\peft\\tuners\\lora\\layer.py:2504: UserWarning: fan_in_fan_out is set to False but the target module is `Conv1D`. Setting fan_in_fan_out to True.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "def count_trainable(model):\n",
+    "    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)\n",
+    "    total = sum(p.numel() for p in model.parameters())\n",
+    "    return trainable, total\n",
+    "\n",
+    "def freeze_all(model):\n",
+    "    for p in model.parameters():\n",
+    "        p.requires_grad = False\n",
+    "\n",
+    "def unfreeze_last_n_layers(model, n):\n",
+    "    freeze_all(model)\n",
+    "    for block in model.transformer.h[-n:]:\n",
+    "        for p in block.parameters():\n",
+    "            p.requires_grad = True\n",
+    "    for p in model.lm_head.parameters():\n",
+    "        p.requires_grad = True\n",
+    "\n",
+    "# Approche 1 : Full fine-tuning\n",
+    "for p in model.parameters():\n",
+    "    p.requires_grad = True\n",
+    "full_trainable, total = count_trainable(model)\n",
+    "\n",
+    "# Approche 2 : Partial (2 dernieres couches + lm_head)\n",
+    "unfreeze_last_n_layers(model, 2)\n",
+    "partial_trainable, _ = count_trainable(model)\n",
+    "\n",
+    "# Approche 3 : LoRA\n",
+    "from peft import LoraConfig, get_peft_model\n",
+    "\n",
+    "lora_config = LoraConfig(\n",
+    "    r=8,\n",
+    "    lora_alpha=16,\n",
+    "    target_modules=[\"c_attn\"],  # Attention projections dans GPT-2\n",
+    "    lora_dropout=0.05,\n",
+    "    bias=\"none\",\n",
+    "    task_type=\"CAUSAL_LM\",\n",
+    ")\n",
+    "\n",
+    "# Recharger le modele propre pour LoRA\n",
+    "model_lora = AutoModelForCausalLM.from_pretrained(MODEL_NAME)\n",
+    "model_lora = get_peft_model(model_lora, lora_config)\n",
+    "lora_trainable, _ = count_trainable(model_lora)\n",
+    "\n",
+    "print(f\"{'Approche':<20} {'Entrainables':>15} {'Total':>15} {'%':>8}\")\n",
+    "print(f\"{'-'*20} {'-'*15} {'-'*15} {'-'*8}\")\n",
+    "print(f\"{'Full Fine-Tuning':<20} {full_trainable:>15,} {total:>15,} {100.0:>7.2f}%\")\n",
+    "print(f\"{'Partial (2 couches)':<20} {partial_trainable:>15,} {total:>15,} {partial_trainable/total*100:>7.2f}%\")\n",
+    "print(f\"{'LoRA (r=8)':<20} {lora_trainable:>15,} {total:>15,} {lora_trainable/total*100:>7.2f}%\")\n",
+    "print(f\"\\nRatio LoRA/Full = {lora_trainable/full_trainable*100:.2f}%\")"
+   ],
+   "id": "cell-de59f036"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. LoRA in practice: Fine-tuning on a literary style\n\nWe will fine-tune GPT-2 to generate text in the style of Victor Hugo.\nThe dataset is an excerpt from *Les Miserables* (public domain)."
+   ],
+   "id": "cell-2c50759f"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Segments d'entrainement : 7\n",
+      "Exemple : Cosette, enentrant dans la vieille maison de la rue de l'Homme-Arme, \n",
+      "n'avait pas pu quitter la main...\n",
+      "Dataset : 7 exemples\n"
+     ]
+    }
+   ],
+   "source": [
+    "from datasets import Dataset\n",
+    "\n",
+    "# Extrait des Miserables (Victor Hugo, domaine public)\n",
+    "miserables_text = \"\"\"Cosette, enentrant dans la vieille maison de la rue de l'Homme-Arme, \n",
+    "n'avait pas pu quitter la main du vieuxhomme. Cosette regardait la chambre \n",
+    "obscure, et la figure ridée de son bienfaiteur, et cette figure ridée était \n",
+    "l'immense figure de la misere humaine.\n",
+    "\n",
+    "Jean Valjean etait devenu le bonhomme de la maison. Il avait pris l'habitude \n",
+    "de descendre a la cave pour rapporter du vin, et de monter au grenier pour \n",
+    "rapporter du bois. Cosette trouvait que monsieur Jean avait les mains pleines \n",
+    "de bienfaits.\n",
+    "\n",
+    "La nuit, quand tout dormait dans la maison, Jean Valjean restait eveille. \n",
+    "Il songeait aux annees de bagne, aux chaines, aux coups de fouet, a cette \n",
+    "longue montee vers la lumiere. Cosette dormait, et il la regardait dormir.\n",
+    "\n",
+    "Les rues de Paris etaient sombres en ce temps-la. Les reverberes jetaient \n",
+    "des taches de lumiere jaune sur les pavés mouilles. Jean Valjean marchait \n",
+    "vite, comme un homme qui fuit quelque chose, ou qui cherche quelqu'un.\n",
+    "\n",
+    "Marius l'observait de loin. Ce jeune homme pale, aux yeux brillants de \n",
+    "passion, voyait Cosette chaque soir au Luxembourg. Il n'osait lui parler. \n",
+    "L'amour est timide, meme pour les coeurs les plus courageux.\n",
+    "\n",
+    "La barricade s'elevait dans la rue de la Grange-aux-Belles. Les jeunes \n",
+    "hommes avaient pris les pavés et construit un mur de pierres. Enjolras, \n",
+    "beau comme un dieu, commandait avec une autorite naturelle. Grantaire, \n",
+    "ivre et fidele, le suivait partout.\n",
+    "\n",
+    "Gavroche passait entre les balles comme un oiseau. Ce gamin de Paris, \n",
+    "nenfant abandonne devenu enfant de la patrie, ramassait les cartouches \n",
+    "des soldats morts pour les rapporter aux insurgés. Son chant retentissait \n",
+    "dans la nuit, clair et courageux.\"\"\"\n",
+    "\n",
+    "# Decouper en segments d'entrainement\n",
+    "segments = [s.strip() for s in miserables_text.split(\"\\n\\n\") if s.strip()]\n",
+    "print(f\"Segments d'entrainement : {len(segments)}\")\n",
+    "print(f\"Exemple : {segments[0][:100]}...\")\n",
+    "\n",
+    "# Creer le dataset\n",
+    "train_data = Dataset.from_dict({\"text\": segments})\n",
+    "print(f\"Dataset : {len(train_data)} exemples\")"
+   ],
+   "id": "cell-09a20769"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "60c862733cf546568cf7c1b7ab6d8a5f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/7 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tokens par exemple : 256\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Tokenisation\n",
+    "def tokenize_function(examples):\n",
+    "    result = tokenizer(\n",
+    "        examples[\"text\"],\n",
+    "        truncation=True,\n",
+    "        max_length=256,\n",
+    "        padding=\"max_length\",\n",
+    "    )\n",
+    "    result[\"labels\"] = result[\"input_ids\"].copy()\n",
+    "    return result\n",
+    "\n",
+    "tokenized_dataset = train_data.map(tokenize_function, batched=True, remove_columns=[\"text\"])\n",
+    "print(f\"Tokens par exemple : {len(tokenized_dataset[0]['input_ids'])}\")"
+   ],
+   "id": "cell-8cf30c19"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "The dataset is tokenized with uniform padding to 256 tokens. Each example contains the `input_ids` and the `labels` (a copy of the input_ids for causal language modeling). We will now configure the LoRA adapter and start training."
+   ],
+   "metadata": {},
+   "id": "cell-5eae637f"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c6e7e14998644599b9cbc5ff36ad6d60",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading weights:   0%|          | 0/148 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\peft\\tuners\\lora\\layer.py:2504: UserWarning: fan_in_fan_out is set to False but the target module is `Conv1D`. Setting fan_in_fan_out to True.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "trainable params: 294,912 || all params: 124,734,720 || trainable%: 0.2364\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Entrainement en cours...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\torch\\nn\\parallel\\data_parallel.py:45: UserWarning: \n",
+      "    There is an imbalance between your GPUs. You may want to exclude GPU 1 which\n",
+      "    has less than 75% of the memory or cores of GPU 0. You can do so by setting\n",
+      "    the device_ids argument to DataParallel, or by setting the CUDA_VISIBLE_DEVICES\n",
+      "    environment variable.\n",
+      "  if warn_imbalance(lambda props: props.total_memory):\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[transformers] `loss_type=None` was set in the config but it is unrecognized. Using the default loss: `ForCausalLMLoss`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\torch\\nn\\parallel\\comm.py:109: UserWarning: PyTorch is not compiled with NCCL support\n",
+      "  if nccl.is_available(inputs):\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "      \n",
+       "      <progress value='20' max='20' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      [20/20 00:11, Epoch 10/10]\n",
+       "    </div>\n",
+       "    <table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       " <tr style=\"text-align: left;\">\n",
+       "      <th>Step</th>\n",
+       "      <th>Training Loss</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>5</td>\n",
+       "      <td>5.168762</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>10</td>\n",
+       "      <td>5.062768</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>15</td>\n",
+       "      <td>4.959981</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>20</td>\n",
+       "      <td>4.850943</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table><p>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Perte finale : 5.0106\n",
+      "Temps : 13.3s\n"
+     ]
+    }
+   ],
+   "source": [
+    "from transformers import TrainingArguments, Trainer, DataCollatorForLanguageModeling\n",
+    "\n",
+    "# Configuration LoRA\n",
+    "lora_config = LoraConfig(\n",
+    "    r=8,\n",
+    "    lora_alpha=16,\n",
+    "    target_modules=[\"c_attn\"],\n",
+    "    lora_dropout=0.05,\n",
+    "    bias=\"none\",\n",
+    "    task_type=\"CAUSAL_LM\",\n",
+    ")\n",
+    "\n",
+    "model_to_train = AutoModelForCausalLM.from_pretrained(MODEL_NAME)\n",
+    "model_to_train = get_peft_model(model_to_train, lora_config)\n",
+    "model_to_train.print_trainable_parameters()\n",
+    "\n",
+    "# Arguments d'entrainement\n",
+    "training_args = TrainingArguments(\n",
+    "    output_dir=\"./temp_ft01_output\",\n",
+    "    num_train_epochs=10,\n",
+    "    per_device_train_batch_size=2,\n",
+    "    learning_rate=5e-4,\n",
+    "    weight_decay=0.01,\n",
+    "    logging_steps=5,\n",
+    "    save_strategy=\"no\",\n",
+    "    report_to=\"none\",\n",
+    "    fp16=torch.cuda.is_available(),\n",
+    "    seed=42,\n",
+    ")\n",
+    "\n",
+    "data_collator = DataCollatorForLanguageModeling(\n",
+    "    tokenizer=tokenizer,\n",
+    "    mlm=False,\n",
+    ")\n",
+    "\n",
+    "trainer = Trainer(\n",
+    "    model=model_to_train,\n",
+    "    args=training_args,\n",
+    "    train_dataset=tokenized_dataset,\n",
+    "    data_collator=data_collator,\n",
+    ")\n",
+    "\n",
+    "print(f\"\\nEntrainement en cours...\")\n",
+    "train_result = trainer.train()\n",
+    "print(f\"\\nPerte finale : {train_result.training_loss:.4f}\")\n",
+    "print(f\"Temps : {train_result.metrics['train_runtime']:.1f}s\")"
+   ],
+   "id": "cell-565b5293"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Evaluation before / after\n\nLet's compare the generation of the original model vs. the fine-tuned model."
+   ],
+   "id": "cell-2fe06360"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8da17d18cd99461a8cb0d979a621f85b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading weights:   0%|          | 0/148 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "GENERATION ORIGINALE (GPT-2 pre-entraine)\n",
+      "============================================================\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dans les rues sombres de Paris, l'amour d'un seul et de l'accérieur en France, l'un peut-être la monde en France, l'ambassador sombre, l'équipage, l'éclaration des consommateurs en France, l'équipage, l'équipage d'une développ\n",
+      "\n",
+      "============================================================\n",
+      "GENERATION APRES LoRA (fine-tune style Hugo)\n",
+      "============================================================\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dans les rues sombres de Paris, les rues à la nouvelle à la lune.\n",
+      "\n",
+      "(1) Le rue de Paris.\n",
+      "\n",
+      "(2) Le rue de Paris.\n",
+      "\n",
+      "(3) Les rues dans les lèves.\n",
+      "\n",
+      "(4) Le rue de Paris.\n",
+      "\n",
+      "(5) Le rue de Paris.\n",
+      "\n",
+      "(6) Les r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Modele original (recharger)\n",
+    "model_original = AutoModelForCausalLM.from_pretrained(MODEL_NAME)\n",
+    "model_original.eval()\n",
+    "\n",
+    "def generate_text(model, prompt, max_new_tokens=80, temperature=0.8):\n",
+    "    inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
+    "    if torch.cuda.is_available():\n",
+    "        inputs = {k: v.to(model.device) for k, v in inputs.items()}\n",
+    "    with torch.no_grad():\n",
+    "        outputs = model.generate(\n",
+    "            **inputs,\n",
+    "            max_new_tokens=max_new_tokens,\n",
+    "            temperature=temperature,\n",
+    "            do_sample=True,\n",
+    "            top_p=0.9,\n",
+    "            pad_token_id=tokenizer.eos_token_id,\n",
+    "        )\n",
+    "    return tokenizer.decode(outputs[0], skip_special_tokens=True)\n",
+    "\n",
+    "prompt = \"Dans les rues sombres de Paris,\"\n",
+    "\n",
+    "print(\"=\" * 60)\n",
+    "print(\"GENERATION ORIGINALE (GPT-2 pre-entraine)\")\n",
+    "print(\"=\" * 60)\n",
+    "original_output = generate_text(model_original, prompt)\n",
+    "print(original_output)\n",
+    "\n",
+    "print(\"\\n\" + \"=\" * 60)\n",
+    "print(\"GENERATION APRES LoRA (fine-tune style Hugo)\")\n",
+    "print(\"=\" * 60)\n",
+    "model_to_train.eval()\n",
+    "finetuned_output = generate_text(model_to_train, prompt)\n",
+    "print(finetuned_output)"
+   ],
+   "id": "cell-e44b2476"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "Prompt : \"Jean Valjean marchait dans la nuit\"\n",
+      "============================================================\n",
+      "\n",
+      "ORIGINAL :\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jean Valjean marchait dans la nuit (I want you to see)\n",
+      "\n",
+      "It's the moment when the truth is revealed.\n",
+      "\n",
+      "(A) Vigour de vivre, je vous répondent qu'on avait, avec le journée à ce soir à l'hôtel, je vous vous avez pas avait.\n",
+      "\n",
+      "(B) Vig\n",
+      "\n",
+      "FINE-TUNE :\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jean Valjean marchait dans la nuit à la vie est réponse une réputation des fois ne pas de la voiture, il vie en vie.\n",
+      "\n",
+      "Jusqu'il avait selon à la même de la plus d'une faire qui seulement un sommes la plus d'une faire.\n",
+      "\n",
+      "Je vous les présentants dans la\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Second prompt pour comparer\n",
+    "prompt2 = \"Jean Valjean marchait dans la nuit\"\n",
+    "\n",
+    "print(\"=\" * 60)\n",
+    "print(f\"Prompt : \\\"{prompt2}\\\"\")\n",
+    "print(\"=\" * 60)\n",
+    "\n",
+    "print(\"\\nORIGINAL :\")\n",
+    "print(generate_text(model_original, prompt2))\n",
+    "\n",
+    "print(\"\\nFINE-TUNE :\")\n",
+    "print(generate_text(model_to_train, prompt2))"
+   ],
+   "id": "cell-14e59cfb"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Size of LoRA Adapters\n\nOne of the major advantages of LoRA: the learned weights are tiny."
+   ],
+   "id": "cell-dc70a9c6"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele complet (GPT-2) : 497.8 Mo\n",
+      "Adaptateur LoRA seul  : 1.18 Mo\n",
+      "Ratio adaptateur/modele : 0.24%\n",
+      "\n",
+      "Pour deployer : il suffit du modele de base + adaptateur (1.2 Mo)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "# Sauvegarder l'adaptateur LoRA\n",
+    "adapter_dir = os.path.join(tempfile.gettempdir(), \"ft01_lora_adapter\")\n",
+    "model_to_train.save_pretrained(adapter_dir)\n",
+    "\n",
+    "# Taille totale du modele original vs adaptateur\n",
+    "adapter_size = sum(\n",
+    "    os.path.getsize(os.path.join(adapter_dir, f))\n",
+    "    for f in os.listdir(adapter_dir)\n",
+    "    if f.endswith(\".safetensors\") or f.endswith(\".bin\")\n",
+    ")\n",
+    "\n",
+    "model_size_mb = total_params * 4 / 1e6  # float32\n",
+    "adapter_size_mb = adapter_size / 1e6\n",
+    "\n",
+    "print(f\"Modele complet (GPT-2) : {model_size_mb:.1f} Mo\")\n",
+    "print(f\"Adaptateur LoRA seul  : {adapter_size_mb:.2f} Mo\")\n",
+    "print(f\"Ratio adaptateur/modele : {adapter_size_mb/model_size_mb*100:.2f}%\")\n",
+    "print(f\"\\nPour deployer : il suffit du modele de base + adaptateur ({adapter_size_mb:.1f} Mo)\")"
+   ],
+   "id": "cell-c7cfd896"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. GPU memory cleanup"
+   ],
+   "id": "cell-fd8f3de4"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "VRAM libre : 24.4 Go\n"
+     ]
+    }
+   ],
+   "source": [
+    "del model_original, model_to_train, trainer\n",
+    "gc.collect()\n",
+    "if torch.cuda.is_available():\n",
+    "    torch.cuda.empty_cache()\n",
+    "    print(f\"VRAM libre : {torch.cuda.mem_get_info()[0] / 1e9:.1f} Go\")\n",
+    "else:\n",
+    "    print(\"Nettoyage termine\")"
+   ],
+   "id": "cell-94c0915a"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Exercises\n\nApply the concepts from this notebook."
+   ],
+   "id": "cell-f59529da"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : comparez les rangs LoRA r=2, 8, 32\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : Exploration du rang LoRA\n",
+    "# TODO etudiant : Creez 3 configurations LoRA avec r=2, r=8, r=32\n",
+    "# et comparez le nombre de parametres entrainables pour chacune.\n",
+    "# Quel rang donne le meilleur ratio performance/taille ?\n",
+    "\n",
+    "print(\"Exercice a completer : comparez les rangs LoRA r=2, 8, 32\")"
+   ],
+   "id": "cell-4102f87c"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : fine-tunez sur un style different\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : Fine-tuning sur un autre style\n",
+    "# TODO etudiant : Remplacez le dataset des Miserables par un extrait\n",
+    "# d'un autre auteur (ex: Baudelaire, Verlaine) et relancez l'entrainement.\n",
+    "# Observez comment le style de generation change.\n",
+    "\n",
+    "print(\"Exercice a completer : fine-tunez sur un style different\")"
+   ],
+   "id": "cell-f42dac6b"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Exercise 3: Training Hyperparameters\n\nThe *learning rate* is the most sensitive hyperparameter in fine-tuning. An LR that is too low = slow convergence, an LR that is too high = divergence and degradation of the model. Test different values to find the optimal point."
+   ],
+   "metadata": {},
+   "id": "cell-70d4b526"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : comparez les learning rates\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : Impact du learning rate\n",
+    "# TODO etudiant : Entrainnez avec learning_rate = 1e-5, 5e-4, 1e-3.\n",
+    "# Observez la perte finale et la qualite de generation.\n",
+    "# Que se passe-t-il avec un learning rate trop eleve ?\n",
+    "\n",
+    "print(\"Exercice a completer : comparez les learning rates\")"
+   ],
+   "id": "cell-fc5cb509"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n\n| Approach | Trainable params | Required VRAM | Adapter storage |\n|----------|--------------------:|-------------:|--------------------:|\n| Full Fine-Tuning | 100% | 3-4x model size | Full model |\n| Partial (2 layers) | ~5-15% | ~1.5x model size | Modified layers |\n| **LoRA (r=8)** | **~0.5%** | **~1.1x model size** | **~2-5 MB** |\n\n**Key points**:\n- LoRA decomposes the update into low-rank matrices $B \\times A$ where $r \\ll d, k$\n- Only ~0.5% of the parameters are trained, but the quality remains close to full fine-tuning\n- Adapters are portable: a single base model + N adapters for N tasks\n- The rank $r$ controls the expressiveness/efficiency trade-off\n\n**Next steps** (FT-02): LoRA on a larger model with 4-bit quantization (QLoRA)."
+   ],
+   "id": "cell-ebb412ad"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.13.3"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "local",
+   "cpu_min": 0,
+   "gpu_min": 4,
+   "gpu_required": true,
+   "vram_gb": 4,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "none",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "metadata_written": "2026-07-24",
+   "validator": "manual",
+   "notes": "LoRA sur openai-community/gpt2 (124M params). Modele scolaire volontairement petit :\nfine-tuning rapide (~4 min). VRAM ~4 GB FP16. Cout estime depuis la config modele\n(lecture G.1 firsthand), execution GPU non relancee ce cycle."
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/translation/render_notebook.py
+++ b/scripts/translation/render_notebook.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Render a notebook into a target language from a translation CSV.
+
+Companion to :file:`scripts/translation/extract_cells_to_csv.py` (T1 extraction)
+and :file:`scripts/translation/translate_csv.py` (T3 fill). This is **T4 — the
+re-import**: take a notebook source + the per-cell CSV, and produce a translated
+``<notebook>_<lang>.ipynb`` where markdown cells are substituted from the CSV
+and code cells are copied byte-for-byte (source, outputs, execution_count).
+
+CLI usage
+---------
+    python render_notebook.py \\
+        --csv translations/genai/finetuning.csv \\
+        --notebook MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb \\
+        --lang en --out /tmp/FT-01_en.ipynb [--dry-run] [--verbose]
+
+The output language's column in the CSV (``text_<lang>``) supplies the
+translated prose. Empty cells fall back to the FR source (never a blank cell,
+never a placeholder). Cells in the CSV that are absent from the notebook
+(orphan ``cell_id``) raise a warning and are kept in a sidecar ``.stale`` file
+rather than silently dropped. Conversely, cells in the notebook that are absent
+from the CSV keep their FR text (with a debug-level note when ``--verbose``).
+
+The three invariants (issue #10039, also mandated by #10038 §3) :
+
+1. **Markdown cells** : substituted from ``text_<lang>`` with FR fallback.
+2. **Code cells** : copied byte-for-byte (``source``, ``outputs``,
+   ``execution_count``). The CSV has no code-output column (cf. schema #4957
+   §1) and won't get one — outputs come from real execution of the source,
+   which is identical to the bit, so the proven-same applies. This is what
+   avoids re-executing 703 notebooks × N languages (some of which are
+   GPU-only or QC Cloud, i.e. partially impossible).
+3. **Structure preserved** : count, order and ``cell_id`` of cells identical
+   to the source. A rendered notebook that gains or loses a cell is a bug,
+   not a variant.
+
+Corollary (CLAUDE.md §E) : comments and printed literals in code remain in
+French. This is part of the convention and is the price of honest outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import difflib
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+
+@dataclass
+class RenderStats:
+    """Counters emitted by :func:`render` for diagnostics + tests."""
+
+    n_md_cells: int = 0  # markdown cells in source
+    n_code_cells: int = 0  # code cells in source
+    n_translated: int = 0  # markdown cells translated (CSV had non-empty text_<lang>)
+    n_fallback: int = 0  # markdown cells fell back to FR (CSV text_<lang> empty)
+    n_orphan_keys: int = 0  # CSV rows whose cell_id is not in the notebook
+    n_id_mismatch: int = 0  # cells in notebook whose id is not in CSV (kept as-is)
+    n_byte_identical: int = 0  # rendered cells whose text is identical to source
+
+
+@dataclass
+class RenderResult:
+    """Result of a single render."""
+
+    out_path: Optional[Path]  # None when --dry-run
+    nb_cells_out: int  # cell count in output notebook
+    stats: RenderStats
+    orphan_keys: List[str] = field(default_factory=list)
+
+
+def read_csv_for_lang(csv_path: Path, notebook_keys: List[str], lang: str) -> Tuple[List[str], Dict[str, str]]:
+    """Read the CSV and extract rows for a single notebook + language.
+
+    ``notebook_keys`` is a list of path forms to match against the CSV's
+    ``notebook`` column. The first form to yield any hit wins; the others are
+    silently ignored. This forgives path-style mismatches : ``extract_cells_to_csv.py``
+    writes the repo-relative POSIX path (``MyIA.AI.Notebooks/.../nb.ipynb``) but
+    callers may pass a Windows absolute path (``C:/.../nb.ipynb``) or the bare
+    basename (``nb.ipynb``).
+
+    Returns ``(ordered_cell_ids, text_map)`` where ``text_map[cell_id]`` is the
+    translated text in the target language, or empty string if absent. The
+    ordered list preserves the CSV row order (which is the canonical order
+    used by ``extract_cells_to_csv.py``).
+    """
+    if not csv_path.exists():
+        raise FileNotFoundError(f"CSV introuvable : {csv_path}")
+    with csv_path.open(encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        if reader.fieldnames is None:
+            raise ValueError(f"CSV vide ou illisible : {csv_path}")
+        text_col = f"text_{lang}"
+        if text_col not in reader.fieldnames:
+            raise ValueError(
+                f"Colonne {text_col!r} absente du CSV. Colonnes disponibles : "
+                f"{reader.fieldnames}"
+            )
+        # First pass : collect all rows keyed by notebook. We then pick the form
+        # that yields the largest matching subset (most rows = canonical form).
+        by_key: Dict[str, List[dict]] = {}
+        for row in reader:
+            nb_key = row.get("notebook", "")
+            by_key.setdefault(nb_key, []).append(row)
+        # Choose the form whose row count is highest (most specific match).
+        chosen_key = None
+        chosen_rows: List[dict] = []
+        for key in notebook_keys:
+            if key in by_key and len(by_key[key]) > len(chosen_rows):
+                chosen_key = key
+                chosen_rows = by_key[key]
+        if chosen_key is None:
+            return [], {}
+        ordered_ids: List[str] = []
+        text_map: Dict[str, str] = {}
+        for row in chosen_rows:
+            cid = row.get("cell_id", "")
+            if not cid:
+                continue
+            ordered_ids.append(cid)
+            text_map[cid] = row.get(text_col, "") or ""
+        return ordered_ids, text_map
+
+
+def render(
+    nb_path: Path,
+    csv_path: Path,
+    lang: str,
+    out_path: Optional[Path],
+    *,
+    dry_run: bool = False,
+    verbose: bool = False,
+) -> RenderResult:
+    """Render the notebook at ``nb_path`` to ``out_path`` in language ``lang``.
+
+    Returns a :class:`RenderResult` with stats + orphan keys (cells in the CSV
+    that were not found in the notebook). When ``dry_run`` is set, no file is
+    written; the function still computes everything to surface stats.
+
+    The output language's column in the CSV (``text_<lang>``) supplies the
+    translated prose. Empty cells fall back to the FR source. Structure is
+    preserved bit-for-bit : ``nbformat``, ``metadata`` (sans
+    ``metadata.papermill``), cell order, ``cell_id``, and code cells' ``source``
+    + ``outputs`` + ``execution_count``.
+    """
+    if not nb_path.exists():
+        raise FileNotFoundError(f"Notebook introuvable : {nb_path}")
+    if dry_run and out_path is None:
+        raise ValueError("--dry-run nécessite --out (chemin où il aurait écrit)")
+    if not dry_run and out_path is None:
+        raise ValueError("--out est requis sauf avec --dry-run")
+
+    try:
+        nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError(f"Notebook illisible : {nb_path} ({exc})") from exc
+
+    # Build candidate notebook-key forms : the renderer must match whatever the
+    # CSV carries (full Windows path, full POSIX path, repo-relative POSIX,
+    # or bare basename). ``read_csv_for_lang`` picks the form with the most rows.
+    notebook_keys = [nb_path.as_posix(), str(nb_path), nb_path.name]
+    # Repo-relative POSIX path (forward slashes from repo root) — what
+    # ``extract_cells_to_csv.py`` writes.
+    try:
+        # Walk up to find the first parent that contains ``MyIA.AI.Notebooks``
+        # (the canonical repo root marker). If we don't find it, skip.
+        for parent in [nb_path.parent, *nb_path.parents]:
+            if (parent / "MyIA.AI.Notebooks").is_dir():
+                rel = nb_path.relative_to(parent).as_posix()
+                if rel not in notebook_keys:
+                    notebook_keys.append(rel)
+                break
+    except Exception:
+        pass
+    ordered_csv_ids, text_map = read_csv_for_lang(csv_path, notebook_keys, lang)
+    csv_ids_set: Set[str] = set(ordered_csv_ids)
+
+    stats = RenderStats()
+    orphan_keys: List[str] = []
+    out_nb = dict(nb)  # shallow copy — preserves nbformat, metadata, etc.
+    new_cells: List[dict] = []
+
+    for cell in nb.get("cells", []):
+        cell_id = cell.get("id", "")
+        cell_type = cell.get("cell_type", "unknown")
+        if cell_type == "markdown":
+            stats.n_md_cells += 1
+            new_cell = dict(cell)
+            original_source = "".join(cell.get("source", []))
+            translated = text_map.get(cell_id, "") if cell_id else ""
+            if translated.strip():
+                stats.n_translated += 1
+                new_cell["source"] = [translated]
+                if translated == original_source:
+                    stats.n_byte_identical += 1
+            else:
+                stats.n_fallback += 1
+                # FR fallback = keep original source verbatim, do not modify.
+            new_cells.append(new_cell)
+            continue
+        if cell_type == "code":
+            stats.n_code_cells += 1
+            # Invariant #2 : code cells copied byte-for-byte (source, outputs,
+            # execution_count). We don't even check the CSV for code cells —
+            # the CSV doesn't carry outputs by design.
+            new_cells.append(dict(cell))
+            continue
+        # Unknown cell_type — preserve as-is, do not touch.
+        new_cells.append(dict(cell))
+
+    # Orphan CSV keys (in CSV but not in notebook) : preserved in sidecar
+    # .stale (CSV keys whose cell_id was not present in the source notebook).
+    nb_ids_set: Set[str] = {c.get("id", "") for c in nb.get("cells", []) if c.get("id")}
+    orphan_keys = [cid for cid in ordered_csv_ids if cid not in nb_ids_set]
+    stats.n_orphan_keys = len(orphan_keys)
+    stats.n_id_mismatch = len(nb_ids_set - csv_ids_set - {""})  # cells in nb but not in CSV
+
+    out_nb["cells"] = new_cells
+
+    if not dry_run and out_path is not None:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic write : write to a sibling .tmp then rename. This prevents
+        # leaving a partial notebook on disk if the process is killed mid-write.
+        tmp_path = out_path.with_suffix(out_path.suffix + ".tmp")
+        tmp_path.write_text(json.dumps(out_nb, ensure_ascii=False, indent=1), encoding="utf-8")
+        tmp_path.replace(out_path)
+
+    if orphan_keys and not dry_run and out_path is not None:
+        stale_path = out_path.with_suffix(out_path.suffix + ".stale")
+        stale_path.write_text(
+            "\n".join(orphan_keys) + "\n", encoding="utf-8"
+        )
+        if verbose:
+            print(f"  WARN: {len(orphan_keys)} orphan CSV key(s) -> {stale_path.name}")
+
+    return RenderResult(
+        out_path=out_path if not dry_run else None,
+        nb_cells_out=len(new_cells),
+        stats=stats,
+        orphan_keys=orphan_keys,
+    )
+
+
+# --- Falsification helpers (used by tests) --------------------------------- #
+
+
+def diff_summary(src_path: Path, out_path: Path, lang: str) -> str:
+    """Return a unified-diff-style summary of markdown-cell substitutions.
+
+    Used by tests and by humans via ``--verbose``. Walks both notebooks'
+    markdown cells in order, prints the before/after for cells whose text
+    differs. Useful to spot-check that no French slipped through.
+    """
+    src = json.loads(src_path.read_text(encoding="utf-8"))
+    out = json.loads(out_path.read_text(encoding="utf-8"))
+    src_md = ["".join(c.get("source", [])) for c in src.get("cells", []) if c.get("cell_type") == "markdown"]
+    out_md = ["".join(c.get("source", [])) for c in out.get("cells", []) if c.get("cell_type") == "markdown"]
+    if len(src_md) != len(out_md):
+        return f"## CELL COUNT MISMATCH src={len(src_md)} out={len(out_md)}"
+    diffs = []
+    for i, (a, b) in enumerate(zip(src_md, out_md)):
+        if a == b:
+            continue
+        diff_lines = list(difflib.unified_diff(
+            a.splitlines(keepends=True),
+            b.splitlines(keepends=True),
+            fromfile=f"cell[{i}].fr",
+            tofile=f"cell[{i}].{lang}",
+            n=2,
+        ))
+        diffs.append("".join(diff_lines))
+    return "\n".join(diffs) if diffs else "(no markdown diffs)"
+
+
+# --- CLI ------------------------------------------------------------------- #
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Render a notebook into a target language from a translation CSV."
+    )
+    p.add_argument("--csv", required=True, type=Path, help="Translation CSV (schema #4957 §1)")
+    p.add_argument("--notebook", required=True, type=Path, help="Source notebook (FR)")
+    p.add_argument("--lang", required=True, help="Target language code (e.g. en, es, ar)")
+    p.add_argument("--out", type=Path, help="Output notebook path (e.g. X_en.ipynb)")
+    p.add_argument("--dry-run", action="store_true", help="Compute diff/stats, do not write")
+    p.add_argument("--verbose", action="store_true", help="Print per-cell diagnostics")
+    args = p.parse_args(argv)
+
+    dry_run = args.dry_run or args.out is None
+    if not dry_run and args.out is None:
+        p.error("--out is required unless --dry-run")
+
+    try:
+        result = render(
+            nb_path=args.notebook,
+            csv_path=args.csv,
+            lang=args.lang,
+            out_path=args.out,
+            dry_run=dry_run,
+            verbose=args.verbose,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    s = result.stats
+    mode = "(dry-run)" if dry_run else f"-> {result.out_path}"
+    print(
+        f"[render] {args.notebook} ({args.lang}) {mode}\n"
+        f"  cells out: {result.nb_cells_out}\n"
+        f"  markdown:  {s.n_md_cells} (translated={s.n_translated}, "
+        f"fallback={s.n_fallback}, byte-identical={s.n_byte_identical})\n"
+        f"  code:      {s.n_code_cells} (copied verbatim)\n"
+        f"  orphans:   {s.n_orphan_keys} (CSV keys absent from notebook)\n"
+        f"  unmatched: {s.n_id_mismatch} (notebook cells without CSV row)"
+    )
+    if args.verbose and not dry_run:
+        diff = diff_summary(args.notebook, args.out, args.lang)
+        if diff and diff != "(no markdown diffs)":
+            print("\n--- markdown diff ---")
+            print(diff[:2000])
+            if len(diff) > 2000:
+                print(f"... ({len(diff) - 2000} more chars)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/translation/tests/test_render_notebook.py
+++ b/scripts/translation/tests/test_render_notebook.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Tests pour ``scripts/translation/render_notebook.py`` — T4 du pipeline i18n
+(Epic #4957 / #10038 / #10039). Re-importe un notebook traduit à partir d'un
+CSV par-cellule : markdown substitué, code byte-pour-byte, structure préservée.
+
+Couvre les 6 critères d'acceptance du ticket #10039 :
+
+1. Round-trip nominal : CSV rempli + nb FR → *_en.ipynb avec substitutions
+   effectives et compte de cellules inchangé.
+2. Falsification 1 : si le CSV modifie le source d'une cellule code (ce qui ne
+   devrait jamais arriver), la cellule code reste byte-identique à la source.
+3. Falsification 2 : CSV vide (aucune traduction) → *_en.ipynb identique à
+   la source pour les champs traduisibles, structure préservée.
+4. Orphelines : cellule dans le CSV mais pas dans le notebook → capturée dans
+   la sidecar ``.stale``, ne fait PAS crasher le rendu.
+5. ``--dry-run`` : aucun fichier écrit ; stats et diagnostics calculés.
+6. Déterminisme : deux exécutions successives produisent un output byte-
+   identique (json.dumps + indent=1 stable).
+
+Helpers : notebooks synthétiques via ``_nb`` (mêmes conventions que
+``test_extract_cells_to_csv.py``).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+TRANSLATION_DIR = HERE.parent
+sys.path.insert(0, str(TRANSLATION_DIR))
+
+import render_notebook as r  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Helpers — synthetic notebooks + CSV
+# --------------------------------------------------------------------------
+
+def _nb(cells, **meta):
+    """Construit un notebook minimal. cells = liste de dicts {id,type,source,...}."""
+    out_cells = []
+    for c in cells:
+        cell = {"id": c["id"], "cell_type": c["type"],
+                "source": c["source"], "metadata": {}}
+        if c["type"] == "code":
+            cell["outputs"] = c.get("outputs", [])
+            cell["execution_count"] = c.get("execution_count", None)
+        out_cells.append(cell)
+    return {
+        "cells": out_cells,
+        "metadata": meta,
+        "nbformat": 4, "nbformat_minor": 5,
+    }
+
+
+def _write_nb(tmp_path, name, cells, **meta):
+    p = tmp_path / name
+    p.write_text(json.dumps(_nb(cells, **meta)), encoding="utf-8")
+    return p
+
+
+def _write_csv(tmp_path, name, rows):
+    """CSV minimal avec colonnes : notebook, cell_id, cell_type, src_lang,
+    src_hash, text_fr, text_en. rows = liste de dicts."""
+    p = tmp_path / name
+    fieldnames = ["notebook", "cell_id", "cell_type", "src_lang", "src_hash",
+                  "text_fr", "text_en"]
+    with p.open("w", encoding="utf-8", newline="") as fh:
+        w = csv_DictWriter(fh, fieldnames=fieldnames)
+        w.writeheader()
+        for row in rows:
+            w.writerow(row)
+    return p
+
+
+# Petit wrapper pour éviter l'import csv en haut (juste pour les tests).
+import csv as _csv
+
+
+def csv_DictWriter(fh, fieldnames):
+    return _csv.DictWriter(fh, fieldnames=fieldnames, quoting=_csv.QUOTE_MINIMAL,
+                           lineterminator="\n")
+
+
+# --------------------------------------------------------------------------
+# Gate 1 — Round-trip nominal : substitutions effectives + structure préservée
+# --------------------------------------------------------------------------
+
+def test_render_substitutes_markdown_cells(tmp_path):
+    """Round-trip nominal : 2 cellules markdown substituées depuis text_en."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["# Titre FR"]},
+        {"id": "c1", "type": "code",
+         "source": ["import torch"], "execution_count": 1,
+         "outputs": [{"output_type": "stream", "name": "stdout", "text": ["ok"]}]},
+        {"id": "m2", "type": "markdown", "source": ["## Section FR"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        {"notebook": str(nb), "cell_id": "m1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "aaa", "text_fr": "# Titre FR",
+         "text_en": "# Title EN"},
+        {"notebook": str(nb), "cell_id": "m2", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "bbb", "text_fr": "## Section FR",
+         "text_en": "## Section EN"},
+    ])
+    out = tmp_path / "out_en.ipynb"
+    result = r.render(nb, csv_p, "en", out)
+    # Invariant 3 (structure préservée) : nb de cellules identique.
+    assert result.nb_cells_out == 3
+    assert result.stats.n_md_cells == 2
+    assert result.stats.n_code_cells == 1
+    assert result.stats.n_translated == 2
+    assert result.stats.n_fallback == 0
+    # Sortie : vérifier les substitutions.
+    out_nb = json.loads(out.read_text(encoding="utf-8"))
+    src_md = ["".join(c["source"]) for c in out_nb["cells"]
+              if c["cell_type"] == "markdown"]
+    assert src_md[0] == "# Title EN"
+    assert src_md[1] == "## Section EN"
+
+
+def test_render_preserves_code_byte_for_byte(tmp_path):
+    """Round-trip : cellule code reste byte-identique (source + outputs + exec_count)."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "c1", "type": "code",
+         "source": ["import torch\n", "x = 42\n"],
+         "execution_count": 7,
+         "outputs": [{"output_type": "stream", "name": "stdout",
+                      "text": ["42"]}]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [])  # CSV vide
+    out = tmp_path / "out_en.ipynb"
+    r.render(nb, csv_p, "en", out)
+    out_nb = json.loads(out.read_text(encoding="utf-8"))
+    code = out_nb["cells"][0]
+    assert code["source"] == ["import torch\n", "x = 42\n"]
+    assert code["execution_count"] == 7
+    assert code["outputs"] == [{"output_type": "stream", "name": "stdout",
+                                "text": ["42"]}]
+
+
+def test_render_preserves_cell_count_and_order(tmp_path):
+    """Invariant 3 : count et ordre identiques à la source."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["a"]},
+        {"id": "c1", "type": "code", "source": ["x"], "execution_count": None},
+        {"id": "m2", "type": "markdown", "source": ["b"]},
+        {"id": "c2", "type": "code", "source": ["y"], "execution_count": None},
+        {"id": "m3", "type": "markdown", "source": ["c"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        {"notebook": str(nb), "cell_id": "m1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "1", "text_fr": "a", "text_en": "A"},
+        {"notebook": str(nb), "cell_id": "m2", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "2", "text_fr": "b", "text_en": "B"},
+        {"notebook": str(nb), "cell_id": "m3", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "3", "text_fr": "c", "text_en": "C"},
+    ])
+    out = tmp_path / "out_en.ipynb"
+    result = r.render(nb, csv_p, "en", out)
+    assert result.nb_cells_out == 5
+    out_nb = json.loads(out.read_text(encoding="utf-8"))
+    ids = [c["id"] for c in out_nb["cells"]]
+    assert ids == ["m1", "c1", "m2", "c2", "m3"]
+
+
+# --------------------------------------------------------------------------
+# Gate 2 — Falsification 1 : CSV modifie le source code → cellule code intouchée
+# --------------------------------------------------------------------------
+
+def test_render_csv_text_en_for_code_cell_does_not_affect_code(tmp_path):
+    """Le CSV ne peut pas modifier une cellule code (invariant #2 dur)."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "c1", "type": "code", "source": ["print(1)"],
+         "execution_count": 5,
+         "outputs": [{"output_type": "stream", "name": "stdout",
+                      "text": ["1"]}]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        # Tentation : le CSV contient une "traduction" pour la cellule code.
+        {"notebook": str(nb), "cell_id": "c1", "cell_type": "code",
+         "src_lang": "fr", "src_hash": "x", "text_fr": "print(1)",
+         "text_en": "print(2)  # SHOULD NOT BE USED"},
+    ])
+    out = tmp_path / "out_en.ipynb"
+    r.render(nb, csv_p, "en", out)
+    out_nb = json.loads(out.read_text(encoding="utf-8"))
+    code = out_nb["cells"][0]
+    # Source byte-identique au FR, JAMAIS le contenu de text_en.
+    assert code["source"] == ["print(1)"]
+    assert "SHOULD NOT BE USED" not in "".join(code["source"])
+    # Outputs et execution_count byte-identiques aussi.
+    assert code["outputs"] == [{"output_type": "stream", "name": "stdout",
+                                "text": ["1"]}]
+    assert code["execution_count"] == 5
+
+
+# --------------------------------------------------------------------------
+# Gate 3 — Falsification 2 : CSV vide → tout en fallback FR, structure préservée
+# --------------------------------------------------------------------------
+
+def test_render_empty_csv_falls_back_to_fr(tmp_path):
+    """Aucun texte_en dans le CSV → tous les markdown en fallback FR."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["# Titre"]},
+        {"id": "c1", "type": "code", "source": ["x"], "execution_count": None},
+        {"id": "m2", "type": "markdown", "source": ["para"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [])  # 0 lignes (pas de row, header seul)
+    out = tmp_path / "out_en.ipynb"
+    result = r.render(nb, csv_p, "en", out)
+    assert result.stats.n_md_cells == 2
+    assert result.stats.n_translated == 0
+    assert result.stats.n_fallback == 2
+    # Markdown conserve le texte FR exact.
+    out_nb = json.loads(out.read_text(encoding="utf-8"))
+    md = [c for c in out_nb["cells"] if c["cell_type"] == "markdown"]
+    assert md[0]["source"] == ["# Titre"]
+    assert md[1]["source"] == ["para"]
+
+
+def test_render_partial_csv_translates_only_present_cells(tmp_path):
+    """Cellule absente du CSV → fallback FR (jamais blank, jamais placeholder)."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["# Titre FR"]},
+        {"id": "m2", "type": "markdown", "source": ["## Section FR"]},
+    ])
+    # CSV : SEUL m1 est traduit. m2 absent.
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        {"notebook": str(nb), "cell_id": "m1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "a", "text_fr": "# Titre FR",
+         "text_en": "# Title EN"},
+    ])
+    out = tmp_path / "out_en.ipynb"
+    result = r.render(nb, csv_p, "en", out)
+    assert result.stats.n_translated == 1
+    assert result.stats.n_fallback == 1
+    out_nb = json.loads(out.read_text(encoding="utf-8"))
+    md = [c for c in out_nb["cells"] if c["cell_type"] == "markdown"]
+    assert md[0]["source"] == ["# Title EN"]
+    assert md[1]["source"] == ["## Section FR"]  # fallback, pas blanc
+
+
+# --------------------------------------------------------------------------
+# Gate 4 — Orphelines : CSV a une clé absente du notebook → capturée + non-crash
+# --------------------------------------------------------------------------
+
+def test_render_orphans_collected_in_stale_sidecar(tmp_path):
+    """Clé CSV sans cellule correspondante → capturée, pas d'erreur."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["# A"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        {"notebook": str(nb), "cell_id": "m1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "1", "text_fr": "# A", "text_en": "# A EN"},
+        # Orpheline : pas dans le notebook.
+        {"notebook": str(nb), "cell_id": "ORPHAN", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "x", "text_fr": "fantôme",
+         "text_en": "ghost"},
+    ])
+    out = tmp_path / "out_en.ipynb"
+    result = r.render(nb, csv_p, "en", out)
+    assert "ORPHAN" in result.orphan_keys
+    assert result.stats.n_orphan_keys == 1
+    # Sidecar écrit à côté de l'output (1 clé par ligne).
+    stale = out.with_suffix(out.suffix + ".stale")
+    assert stale.exists()
+    assert stale.read_text(encoding="utf-8").strip() == "ORPHAN"
+
+
+def test_render_orphan_does_not_crash_render(tmp_path):
+    """3 orphelines, 1 cellule valide → rendu OK, sidecar contient 3 clés."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["ok"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        {"notebook": str(nb), "cell_id": "m1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "1", "text_fr": "ok", "text_en": "OK"},
+        {"notebook": str(nb), "cell_id": "ghost1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "x", "text_fr": "g1", "text_en": "G1"},
+        {"notebook": str(nb), "cell_id": "ghost2", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "y", "text_fr": "g2", "text_en": "G2"},
+        {"notebook": str(nb), "cell_id": "ghost3", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "z", "text_fr": "g3", "text_en": "G3"},
+    ])
+    out = tmp_path / "out_en.ipynb"
+    result = r.render(nb, csv_p, "en", out)
+    assert result.stats.n_orphan_keys == 3
+    assert sorted(result.orphan_keys) == ["ghost1", "ghost2", "ghost3"]
+
+
+# --------------------------------------------------------------------------
+# Gate 5 — --dry-run : aucun fichier écrit, stats toujours calculées
+# --------------------------------------------------------------------------
+
+def test_render_dry_run_writes_nothing(tmp_path):
+    """--dry-run : pas de fichier, mais stats cohérentes."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["# Titre"]},
+        {"id": "c1", "type": "code", "source": ["x"], "execution_count": None},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        {"notebook": str(nb), "cell_id": "m1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "1", "text_fr": "# Titre",
+         "text_en": "# Title"},
+    ])
+    out = tmp_path / "out_en.ipynb"
+    # Le caller passe dry_run=True mais le path est fourni pour les stats.
+    result = r.render(nb, csv_p, "en", out, dry_run=True)
+    assert result.out_path is None  # pas d'écriture
+    assert not out.exists()  # preuve disque
+    # Mais les stats sont calculées quand même.
+    assert result.stats.n_md_cells == 1
+    assert result.stats.n_translated == 1
+    assert result.stats.n_code_cells == 1
+
+
+def test_render_dry_run_orphan_sidecar_not_written(tmp_path):
+    """--dry-run : pas de sidecar .stale non plus (on n'écrit rien)."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["a"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        {"notebook": str(nb), "cell_id": "ORPHAN", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "x", "text_fr": "g",
+         "text_en": "G"},
+    ])
+    out = tmp_path / "out_en.ipynb"
+    r.render(nb, csv_p, "en", out, dry_run=True)
+    assert not out.with_suffix(out.suffix + ".stale").exists()
+
+
+# --------------------------------------------------------------------------
+# Gate 6 — Déterminisme : deux exécutions successives → output byte-identique
+# --------------------------------------------------------------------------
+
+def test_render_deterministic_byte_identical_output(tmp_path):
+    """Deux appels avec mêmes inputs → outputs byte-identiques."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["# H"]},
+        {"id": "c1", "type": "code",
+         "source": ["print('ok')"], "execution_count": 1,
+         "outputs": [{"output_type": "stream", "name": "stdout",
+                      "text": ["ok"]}]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        {"notebook": str(nb), "cell_id": "m1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "1", "text_fr": "# H", "text_en": "# H EN"},
+    ])
+    out_a = tmp_path / "a_en.ipynb"
+    out_b = tmp_path / "b_en.ipynb"
+    r.render(nb, csv_p, "en", out_a)
+    r.render(nb, csv_p, "en", out_b)
+    assert out_a.read_bytes() == out_b.read_bytes()
+
+
+def test_render_atomic_write_no_tmp_leftover(tmp_path):
+    """Écriture atomique : pas de .tmp restant après succès."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["x"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        {"notebook": str(nb), "cell_id": "m1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "1", "text_fr": "x", "text_en": "X"},
+    ])
+    out = tmp_path / "out_en.ipynb"
+    r.render(nb, csv_p, "en", out)
+    tmp = out.with_suffix(out.suffix + ".tmp")
+    assert out.exists()
+    assert not tmp.exists()
+
+
+# --------------------------------------------------------------------------
+# Tests d'erreur explicites (FileNotFoundError, ValueError)
+# --------------------------------------------------------------------------
+
+def test_render_missing_notebook_raises(tmp_path):
+    csv_p = _write_csv(tmp_path, "tr.csv", [])
+    with pytest.raises(FileNotFoundError):
+        r.render(tmp_path / "absent.ipynb", csv_p, "en", tmp_path / "out.ipynb")
+
+
+def test_render_missing_csv_raises(tmp_path):
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["x"]},
+    ])
+    with pytest.raises(FileNotFoundError):
+        r.render(nb, tmp_path / "absent.csv", "en", tmp_path / "out.ipynb")
+
+
+def test_render_csv_without_lang_col_raises(tmp_path):
+    """CSV sans colonne text_<lang> → ValueError explicite."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["x"]},
+    ])
+    csv_p = tmp_path / "no_en_col.csv"
+    csv_p.write_text("notebook,cell_id,text_fr\nnb.ipynb,m1,fr only\n",
+                     encoding="utf-8")
+    with pytest.raises(ValueError, match="text_en"):
+        r.render(nb, csv_p, "en", tmp_path / "out.ipynb")
+
+
+def test_render_dry_run_requires_out_path(tmp_path):
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["x"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [])
+    with pytest.raises(ValueError, match="--dry-run"):
+        r.render(nb, csv_p, "en", None, dry_run=True)
+
+
+# --------------------------------------------------------------------------
+# Bonus : n_byte_identical comptabilise les traductions identiques au FR
+# --------------------------------------------------------------------------
+
+def test_render_counts_byte_identical_translations(tmp_path):
+    """Si text_en == text_fr (ex. nom propre, nombre), compteur ++."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["FT-01"]},
+        {"id": "m2", "type": "markdown", "source": ["# Titre FR"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        {"notebook": str(nb), "cell_id": "m1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "1", "text_fr": "FT-01", "text_en": "FT-01"},
+        {"notebook": str(nb), "cell_id": "m2", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "2", "text_fr": "# Titre FR",
+         "text_en": "# Title EN"},
+    ])
+    out = tmp_path / "out_en.ipynb"
+    result = r.render(nb, csv_p, "en", out)
+    assert result.stats.n_translated == 2
+    assert result.stats.n_byte_identical == 1  # m1 : FT-01 == FT-01
+
+
+# --------------------------------------------------------------------------
+# diff_summary — utilitaire de spot-check
+# --------------------------------------------------------------------------
+
+def test_diff_summary_returns_no_diff_when_all_fallback(tmp_path):
+    """CSV vide → output = source → diff_summary dit 'no markdown diffs'."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["# A"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [])
+    out = tmp_path / "out_en.ipynb"
+    r.render(nb, csv_p, "en", out)
+    diff = r.diff_summary(nb, out, "en")
+    assert diff == "(no markdown diffs)"
+
+
+def test_diff_summary_returns_diff_when_substituted(tmp_path):
+    """Avec substitutions effectives → diff_summary non vide."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["# Titre FR"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        {"notebook": str(nb), "cell_id": "m1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "1", "text_fr": "# Titre FR",
+         "text_en": "# Title EN"},
+    ])
+    out = tmp_path / "out_en.ipynb"
+    r.render(nb, csv_p, "en", out)
+    diff = r.diff_summary(nb, out, "en")
+    assert "Titre FR" in diff and "Title EN" in diff


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2025:CoursIA-2 — prev: DEEP/research-code #9995

## Résumé

Ajoute le **T4 renderer** du pipeline i18n notebook (Epic #4957 / #10038 / #10039). Re-importe un notebook traduit à partir du CSV par-cellule produit par T1 (`extract_cells_to_csv.py`) + rempli par T3 (`translate_csv.py`). Garantit les **3 invariants** du ticket #10039 :

1. **Markdown cells** : substitué depuis `text_<lang>` avec fallback FR quand vide (jamais blank, jamais placeholder).
2. **Code cells** : copié byte-pour-byte (`source`, `outputs`, `execution_count`) — invariant strict, le CSV ne peut pas modifier du code.
3. **Structure préservée** : count, ordre et `cell_id` des cellules identiques à la source.

Le tout évite de re-exécuter 703 notebooks × 7 langues pour générer les `*_en.ipynb` — certains GPU-only ou QC Cloud, partiellement impossibles (cf #10038 §3).

## Acceptance criteria (#10039)

| # | Critère | Preuve |
|---|---------|--------|
| 1 | Round-trip nominal : substitutions effectives, structure préservée | `test_render_substitutes_markdown_cells`, `test_render_preserves_cell_count_and_order` |
| 2 | Falsification code : CSV modifie code → cellule code byte-identique | `test_render_csv_text_en_for_code_cell_does_not_affect_code` |
| 3 | Falsification CSV vide : tout en fallback FR, structure préservée | `test_render_empty_csv_falls_back_to_fr`, `test_render_partial_csv_translates_only_present_cells` |
| 4 | Orphelines CSV : capturées en `.stale`, pas de crash | `test_render_orphans_collected_in_stale_sidecar`, `test_render_orphan_does_not_crash_render` |
| 5 | `--dry-run` : aucun fichier écrit, stats cohérentes | `test_render_dry_run_writes_nothing`, `test_render_dry_run_orphan_sidecar_not_written` |
| 6 | Déterminisme : deux exécutions successives → outputs byte-identiques | `test_render_deterministic_byte_identical_output` |

**Tests** : 19/19 PASS, dont helpers, tests d'erreur, `diff_summary` utilitaire. `pytest scripts/translation/tests/test_render_notebook.py -v` :
```
============================= 19 passed in 0.52s =============================
```

**Régression** : la suite `scripts/translation/tests/` complète reste verte :
```
============================= 173 passed in 5.60s =============================
```

## Preuve end-to-end (FT-01 — `MyIA.AI.Notebooks/GenAI/FineTuning/`)

`python scripts/translation/render_notebook.py --csv translations/genai/finetuning.csv --notebook MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb --lang en --out MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning_en.ipynb --verbose` :

```
[render] .../FT-01-Introduction-FineTuning.ipynb (en) -> .../FT-01-Introduction-FineTuning_en.ipynb
  cells out: 25
  markdown:  12 (translated=12, fallback=0, byte-identical=0)
  code:      13 (copied verbatim)
  orphans:   0 (CSV keys absent from notebook)
  unmatched: 0 (notebook cells without CSV row)
```

Vérifications additives via script ad-hoc :
```
OK: 13 code cells byte-identical (source + outputs + execution_count)
OK: 12/12 markdown cells substituted (rest = identical to FR)
OK: 25 cells, same count/order/ids
```

Le `*_en.ipynb` rendu est commité dans cette PR comme **preuve d'exécution end-to-end**. Le pattern de re-rendu CI (Epic #10038 grain B/C) re-générera tous les fichiers `*_<lang>.ipynb` à partir des CSV T1+T3 — celui-ci est l'instance témoin.

## Architecture & décisions

### Modèle de matching CSV↔notebook (3 formes tolérées)

Le CSV T1 écrit le path relatif POSIX depuis la racine du repo (`MyIA.AI.Notebooks/.../nb.ipynb`) — extrait via `extract_cells_to_csv.extract_notebook()` ligne `notebook = nb_path.resolve().relative_to(repo_root).as_posix()`. Mais le renderer peut être appelé :

- **En CLI depuis la racine repo** : `nb_path = "MyIA.AI.Notebooks/.../nb.ipynb"` → match direct.
- **En test avec Path absolutisé** : `nb_path = Path("C:/.../nb.ipynb")` (forward slashes via `.as_posix()`).
- **En test avec Path str** : `str(nb_path)` sur Windows = backslashes (`C:\...\nb.ipynb`).
- **Avec basename seul** : pour un usage ad-hoc rapide.

`read_csv_for_lang()` accepte une **liste de candidats** et choisit la forme qui maximise le nombre de lignes matchées (le path le plus spécifique gagne). Évite la fragilité d'un lookup exact-match et reste compatible avec le format T1 canonique.

### Atomicité de l'écriture

Écriture en 2 temps : `tmp_path.write_text(...)` puis `tmp_path.replace(out_path)`. Évite qu'un crash de processus laisse un notebook partiellement écrit sur disque (le kernel et l'agent pourraient sinon lire un fichier corrompu). Le `.tmp` est sur le même volume → `replace()` est atomique (POSIX rename + Windows MoveFileEx).

### Code byte-identique (invariant #2 — le plus strict)

Le CSV ne porte **aucune** colonne `text_<lang>` pour les cellules code par design (cf schéma #4957 §1). Si un CSV contient quand même une ligne `cell_type=code` avec `text_en`, le renderer **l'ignore complètement** : la cellule code reste byte-identique au source FR, sans aucun warning. C'est le comportement le plus safe — l'invariant #2 est garanti par construction, pas par warning.

### Orphelines CSV → sidecar `.stale`

Cellule dans le CSV mais pas dans le notebook (signe de drift entre T1 et T4 — code ajouté au notebook sans re-extraction, ou cellule supprimée du notebook mais traduite) :
- Capturée dans `<out>.stale` (1 ligne par `cell_id` orphelin).
- Ne fait PAS crasher le rendu.
- Le contenu du `.stale` est exploitable par T2 (`check_translation_sync.py`) pour détecter le drift.

## Fichiers ajoutés

```
scripts/translation/render_notebook.py            (NEW, ~290 lignes)
scripts/translation/tests/test_render_notebook.py (NEW, ~430 lignes, 19 tests)
MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning_en.ipynb (NEW, proof artifact)
```

Aucun fichier modifié hors ces ajouts (catalog-preserved cf catalog-pr-hygiene R1).

## Liens

- Issue #10039 : https://github.com/jsboige/CoursIA/issues/10039
- Epic #10038 : https://github.com/jsboige/CoursIA/issues/10038 (grain B = CI workflow, grain C = 30+ CSVs × 6 langs re-render)
- Epic #4957 : schéma CSV canonique (notebook, cell_id, cell_type, src_lang, src_hash, text_<lang>, hash_<lang>)
- Issue #10017/#10018 : T1+T3 fill finetuning.csv (90 cellules markdown en anglais)
- `scripts/i18n/render.py` : modèle pour le renderer markdown (utilisé pour les README .en.md)

## Hors scope

- **CI autonome** (#10038 grain B) : un workflow qui re-render automatiquement sur PR touchant un notebook. À faire dans un PR séparé (grain B/C/D #10038).
- **Re-render batch 30+ CSVs × 6 langues** (#10038 grain C/D) : out-of-scope cette PR-ci — c'est un rollout, pas un renderer.
- **`.ipynb` rendus pour les 32 autres familles** : uniquement FT-01 rendu ici (preuve d'exécution). Le rollout se fera en série via le grain B (CI).
