### PR TITLE
fix(ml): strip .nuget machine-path leak from ML-3 cell[1] ext-load output (#6529 category-A)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
@@ -96,28 +96,28 @@
     {
      "output_type": "display_data",
      "data": {
-      "text/plain": "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\plotly.net.interactive\\3.0.2\\lib\\netstandard2.1\\Plotly.NET.Interactive.dll`"
+      "text/plain": ""
      },
      "metadata": {}
     },
     {
      "output_type": "display_data",
      "data": {
-      "text/plain": "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\microsoft.data.analysis\\0.23.0\\interactive-extensions\\dotnet\\Microsoft.Data.Analysis.Interactive.dll`"
+      "text/plain": ""
      },
      "metadata": {}
     },
     {
      "output_type": "display_data",
      "data": {
-      "text/plain": "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\microsoft.ml.automl\\0.23.0\\interactive-extensions\\dotnet\\Microsoft.ML.AutoML.Interactive.dll`"
+      "text/plain": ""
      },
      "metadata": {}
     },
     {
      "output_type": "display_data",
      "data": {
-      "text/plain": "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\skiasharp\\2.88.8\\interactive-extensions\\dotnet\\SkiaSharp.DotNet.Interactive.dll`"
+      "text/plain": ""
      },
      "metadata": {}
     }

--- a/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
@@ -15,6 +15,12 @@
       csharp_sha: cc944d052d3f64d4d72e0c0a833a0a637746a62b
       content_python_sha: 58d05932f373d8570f763fca6d9cdccd997959fd75a2509513c74dbec893cccc
       content_csharp_sha: 2c593b51f0144ed0a7b21cbd230719916fca3744e9ef9cfba0b6ca2fadf9041b
+    - date: "2026-08-08"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 695da4960a0c19888c1e5917040ed84d5ee520be
+      csharp_sha: c5be5734167b73aa31abb84da4d00165a3612552
+      content_python_sha: 58d05932f373d8570f763fca6d9cdccd997959fd75a2509513c74dbec893cccc
+      content_csharp_sha: 86f24846bc1a8aec98d49b592ea36d0ec471eb0e065eb44bb3f48cfe1a8649cb
   known_differences:
     - "Socle pedagogique commun : comparaison de trainers de regression (lineaire vs boosting) + evaluation RMSE train/test."
     - "Zoos de modeles distincts : C# = `Regression.Trainers.Sdca` (Stochastic Dual Coord Ascent) + `LightGbm` (binding ML.NET LightGBM natif). Python = `LinearRegression` + `GradientBoostingRegressor, RandomForestRegressor, DecisionTreeRegressor, SVR` (ensemble sklearn)."


### PR DESCRIPTION
fix(ml): strip .nuget machine-path leak from ML-3 cell[1] ext-load output (#6529 category-A)

Grain: MED/notebook-dotnet — lane myia-po-2023:CoursIA-2 — prev: (drained) c.9872+50

## Quoi
`ML-3-Entrainement&AutoML.ipynb` cell[1] carried 4 machine-path leaks (`C:\Users\jsboi\.nuget\packages\plotly.net.interactive\3.0.2\...` + 3 similar) in the dotnet-interactive runtime's "Loading extensions from ..." outputs. These are **kernel-injection category-A** paths (secrets-hygiene rule 6, #6529): emitted by the `dotnet-interactive` runtime at `#r "nuget:"`, NOT printed by notebook source code. ML-3 had slipped past the `strip_machine_paths.py` hook (#6574) — 60+ other notebooks were already stripped via #6578. Re-applied the hook → 4 paths stripped, 0 source change.

## Preuve
- **Before** (origin/main): cell[1] `UsersLeak=4`, 4 `display_data` outputs with `Loading extensions from \`C:\Users\jsboi\.nuget\packages\...\``.
- **After** (this branch): cell[1] `UsersLeak=0`, notebook-wide `Users\ = 0`.
- **Diagnosis path (honest, 3 attempts)**:
  1. ❌ `notebook_tools execute --kernel .net-csharp` → **reproduced the leak** (4 paths, same `C:\Users\jsboi`). Re-exec does NOT fix category-A kernel-injection (the runtime always emits the resolved home path).
  2. ❌ Papermill `.net-csharp` → **also reproduced the leak**. So the `~\.nuget` form in ML-4/ML-7 is NOT a kernel rendering mode — it is produced by the **strip hook**, not the kernel.
  3. ✅ `strip_machine_paths.py --scan` → detected 4 leaks; `--apply` → 4 fixed, 0 source change. **This is the #6529 category-A exception** (output-side strip of kernel-injected PII-lite = prof's GitHub handle, not a proof-of-exec scrub).
- G.1 verify: `UsersLeak=0` notebook-wide, source byte-identical (0 `"source"` lines changed), `execution_count` preserved (ec=1), diff = 4 insertions / 4 deletions (only the 4 `text/plain` ext-load lines).

## Périmètre
- **2 files**: (1) `ML-3-Entrainement&AutoML.ipynb` — 4 `display_data` outputs in cell[1]; source byte-identical (pure output strip via the official hook). (2) `twin_pairs.d/ml-3-entrainement-automl.yaml` — twin-parity rebaseline EN DERNIER (after strip, per #8957): csharp_sha `2c593b51` → `c5be5734` (post-strip blob SHA). Python twin unchanged (`695da496`, not .NET → no equivalent kernel-injection; re-audited firsthand: `ML-3-Python` Users\ leak = 0). Parité sémantique préservée: strip retire du bruit kernel-injecté, ne change ni code ni pédagogie.
- Verdict: **category-A kernel-injection strip** (#6529 exception), NOT a re-exec. The re-exec attempts confirmed the leak is runtime-injected (irreproducible-to-fix via exec).
- **Inconsistency noted (transparency)**: the hook produces **empty `text/plain`** for the 4 stripped outputs, whereas ML-4/ML-7 carry the tilde form (`~\.nuget\packages\...`). The ext-load messages are not pedagogically essential (kernel diagnostics, not results), so the empty form is acceptable — but a hook-improvement to emit `~` (matching ML-4) would be cleaner. Tracked as a separate harness grain, not in this PR's scope.
- Hors scope (separate PRs): CSP-2, CSP-9 (same defect, Search family = po-2024/po-2026 active turf on App-13/App-18, avoid same-family collision); hook-improvement `~`-form.

See #6529 (category-A kernel-injection, resolved by #6536/#6567/#6563/#6578) · See #6574 (strip_machine_paths.py) · See #8057 (twin parity) · See #8957 (rebaseline après strip) · See #10000 (GenAI-only scope, does not cover ML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)