### PR TITLE
i18n(perimeter,#10038): declare perimeter + resolve ru-orphans (grain E)

### DIFF
--- a/scripts/translation/check_perimeter.py
+++ b/scripts/translation/check_perimeter.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Perimeter gate — enforces translations/PERIMETER.md against translations/**/*.csv.
+
+Companion to :file:`scripts/translation/check_translation_sync.py` (T2 drift
+detector, hash-based) and :file:`scripts/translation/render_notebook.py` (T4
+renderer). This is the **structural perimeter gate** : for every CSV under
+``translations/``, no column ``text_<lang>`` can carry a non-empty cell unless
+that lang is **declared in-scope** in ``translations/PERIMETER.md``.
+
+Why this matters (Epic #10038 §4 D3 — perimeter EN seul d'abord, corpus déclaré)
+===============================================================================
+
+Without a declared perimeter, anyone can fill any ``text_<lang>`` cell in any
+CSV and T4 would render notebooks in that language. That would silently
+**double the translation surface area** beyond what the team has approved for
+review. The catalog gets re-rendered on a daily cron, but a translated
+notebook is *content*, not metadata — it lands on ``main`` and grows the
+backlog of strings to maintain in 7 languages.
+
+This script enforces the perimeter mechanically :
+
+1. If a CSV has cells in ``text_<lang>`` for a lang not declared in PERIMETER.md
+   → **PERIMETER_VIOLATION**, the gate exits 1.
+2. If PERIMETER.md declares a lang as in-scope for a CSV but the CSV has 0
+   cells in that lang → **IN_SCOPE_UNUSED** (advisory only, exit 0 — there is
+   no requirement to fill yet).
+3. If PERIMETER.md is missing → **PERIMETER_MISSING**, the gate exits 2.
+4. If PERIMETER.md is malformed (no matrix table) → **PERIMETER_MALFORMED**,
+   the gate exits 2.
+
+CI integration (grain E §4 Epic #10038) : the script returns 0 when the
+perimeter is satisfied, 1 when violated, 2 when the perimeter file is
+unreadable. Designed to be wired into ``.github/workflows/translation-guard.yml``
+later (grain C, Epic #10038 §6) — for now this PR ships the standalone gate
++ tests.
+
+Usage
+-----
+
+::
+
+    # Default: verify against translations/PERIMETER.md, scan translations/**/*.csv
+    python scripts/translation/check_perimeter.py
+
+    # Custom paths (for tests)
+    python scripts/translation/check_perimeter.py \\
+        --perimeter path/to/PERIMETER.md \\
+        --translations-root path/to/translations
+
+    # Machine-readable output (one JSON line on stdout)
+    python scripts/translation/check_perimeter.py --json-only
+
+Exit codes
+----------
+
+- ``0``  perimeter satisfied (with or without IN_SCOPE_UNUSED advisories)
+- ``1``  perimeter violated (PERIMETER_VIOLATION found)
+- ``2``  perimeter file missing or malformed (cannot evaluate)
+
+Verdicts
+--------
+
+- ``OK``                    — no violations, no advisories
+- ``PERIMETER_VIOLATION``   — ``text_<lang>`` filled in a CSV for a lang not
+  declared in PERIMETER.md. Detail = ``{csv, lang, n_cells, sample_cells}``.
+- ``IN_SCOPE_UNUSED``       — PERIMETER.md declares ``<lang>`` in-scope for a
+  CSV but no cells are filled yet. Advisory (exit 0), not a failure — the
+  perimeter is *forward-looking*.
+- ``PERIMETER_MISSING``     — the perimeter file does not exist (exit 2).
+- ``PERIMETER_MALFORMED``   — the perimeter file is unreadable or has no
+  matrix table (exit 2).
+
+See :file:`tests/test_check_perimeter.py` for the full coverage (≥10 cases).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+# Langs tracked by the CSV schema (ratified #4957 §1). Order matches the
+# schema header : text_<lang> columns in CSV order, with hash_<lang> after.
+# The pivot lang ('fr') is always in-scope by construction (T1 extracts it).
+PIVOT_LANG = "fr"
+TARGET_LANGS = ["en", "es", "ar", "fa", "zh", "ru", "pt"]
+ALL_LANGS = [PIVOT_LANG] + TARGET_LANGS
+
+# Defaults used when a CSV appears in translations/ but is NOT explicitly listed
+# in PERIMETER.md. Conservative : a CSV not in the perimeter matrix is
+# treated as ALL langs out-of-scope (forces explicit declaration before any
+# translation work). The matrix in PERIMETER.md can override per-CSV.
+DEFAULT_OUT_OF_SCOPE: Set[str] = set(TARGET_LANGS)
+
+
+# ---------------------------------------------------------------------------
+# PERIMETER.md parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_perimeter(path: Path) -> Dict[str, Set[str]]:
+    """Parse a PERIMETER.md file and return ``{csv_path: {in_scope_langs}}``.
+
+    The file is expected to contain a markdown table of the form ::
+
+        | CSV | en | es | ar | ... | Source |
+        |---|---|---|---|---|---|
+        | translations/genai/casestudies.csv | **en** | - | - | - | - | **ru** | - | #10017 |
+        | translations/genai/image.csv | **en** | ... | ... | **ru** | ... | T3 image |
+
+    Parsing rules :
+
+    - Rows starting with ``| translations/`` are CSV entries.
+    - First column is the CSV path (repo-relative POSIX).
+    - Each lang column (``en``, ``es``, ``ar``, ``fa``, ``zh``, ``ru``, ``pt``)
+      contains either ``**en**`` / ``**ru**`` (in-scope, bold) or ``-``
+      (out-of-scope). The bold markup is required to mark in-scope : a plain
+      ``en`` in a cell is treated as out-of-scope (forces explicit bold).
+    - The pivot lang ``fr`` is implicit (always in-scope, never in the table).
+
+    Returns
+    -------
+    ``{csv_path: {in_scope_langs}}`` where ``in_scope_langs ⊆ TARGET_LANGS``.
+
+    Raises
+    ------
+    ValueError
+        if the file does not contain a recognizable matrix table (caller maps
+        to ``PERIMETER_MALFORMED``).
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"PERIMETER.md introuvable : {path}")
+
+    text = path.read_text(encoding="utf-8")
+    csv_to_langs: Dict[str, Set[str]] = {}
+
+    # Match rows of the form ``| <csv> | ... |`` where <csv> starts with
+    # ``translations/`` and ends with ``.csv``. Capture the whole row to
+    # extract lang cells.
+    row_pattern = re.compile(
+        r"^\|\s*(`?translations/[^\s|`]+\.csv`?)\s*\|(.*?)\|\s*$",
+        re.MULTILINE,
+    )
+    # Match the header row to know which lang columns are present + in order.
+    # Accept both ``| CSV |`` and ``| CSV | Source |`` (any trailing columns).
+    header_pattern = re.compile(
+        r"^\|\s*CSV\s*\|((?:[^|]*\|)+)\s*$",
+        re.MULTILINE,
+    )
+    header_match = header_pattern.search(text)
+    if not header_match:
+        raise ValueError(
+            "PERIMETER.md ne contient pas de ligne d'en-tête '| CSV | ... |'."
+        )
+    header_cells = [c.strip() for c in header_match.group(1).split("|") if c.strip()]
+    # Map lang → index in the row (header_cells excludes the first 'CSV' col).
+    lang_idx: Dict[str, int] = {}
+    for i, cell in enumerate(header_cells):
+        cell_clean = cell.strip().strip("`").strip()
+        if cell_clean in TARGET_LANGS:
+            lang_idx[cell_clean] = i
+
+    found_rows = False
+    for m in row_pattern.finditer(text):
+        found_rows = True
+        csv_cell = m.group(1).strip().strip("`").strip()
+        rest = m.group(2)
+        row_cells = [c.strip() for c in rest.split("|")]
+        in_scope: Set[str] = set()
+        for lang, idx in lang_idx.items():
+            if idx >= len(row_cells):
+                continue
+            cell_val = row_cells[idx].strip()
+            # In-scope marker : the lang code is wrapped in **bold** (e.g. ``**en**``).
+            # This is conservative : only explicit bold declares in-scope.
+            if cell_val == f"**{lang}**":
+                in_scope.add(lang)
+        csv_to_langs[csv_cell] = in_scope
+
+    if not found_rows:
+        raise ValueError(
+            "PERIMETER.md ne contient aucune ligne '| translations/...csv | ... |'."
+        )
+
+    return csv_to_langs
+
+
+# ---------------------------------------------------------------------------
+# CSV scanning
+# ---------------------------------------------------------------------------
+
+
+def scan_csv_langs(csv_path: Path) -> Dict[str, int]:
+    """Return ``{lang: n_filled_cells}`` for markdown cells in ``csv_path``.
+
+    A cell is counted as filled if the corresponding ``text_<lang>`` column
+    has a non-empty (after ``.strip()``) value AND the ``cell_type`` is
+    ``markdown``. Code cells are skipped (T4 copies them byte-for-byte; their
+    translations live in code-comment form, not in the CSV).
+    """
+    counts: Dict[str, int] = {lang: 0 for lang in TARGET_LANGS}
+    with csv_path.open(encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        if reader.fieldnames is None:
+            return counts
+        for row in reader:
+            if row.get("cell_type") != "markdown":
+                continue
+            for lang in TARGET_LANGS:
+                col = f"text_{lang}"
+                if col in reader.fieldnames and row.get(col, "").strip():
+                    counts[lang] += 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Verdict computation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Anomaly:
+    verdict: str
+    csv: str
+    detail: Dict[str, object] = field(default_factory=dict)
+
+
+def compute_anomalies(
+    csv_paths: List[Path],
+    perimeter: Dict[str, Set[str]],
+    *,
+    translations_root: Optional[Path] = None,
+) -> Tuple[List[Anomaly], Dict[str, Dict[str, int]]]:
+    """Walk CSVs and emit anomalies + a per-CSV fill report.
+
+    Parameters
+    ----------
+    csv_paths
+        All CSV files found under the translations root.
+    perimeter
+        ``{csv_relpath_posix: {in_scope_langs}}`` (parsed from PERIMETER.md).
+    translations_root
+        Used to compute the relative POSIX path of each CSV for comparison
+        against the perimeter keys. If ``None``, uses ``Path.cwd()``.
+
+    Returns
+    -------
+    (anomalies, fills_by_csv)
+    """
+    if translations_root is None:
+        translations_root = Path.cwd()
+    anomalies: List[Anomaly] = []
+    fills_by_csv: Dict[str, Dict[str, int]] = {}
+
+    for csv_path in csv_paths:
+        # Compute the repo-relative POSIX path (matches PERIMETER.md keys).
+        try:
+            rel = csv_path.resolve().relative_to(translations_root.resolve()).as_posix()
+        except ValueError:
+            rel = csv_path.name
+        # PERIMETER.md keys may include the ``translations/`` prefix (operating
+        # out of repo root) or may be bare relative to translations_root. Try
+        # both forms when looking up the declaration.
+        keys_to_try = [rel, f"translations/{rel}"]
+        counts = scan_csv_langs(csv_path)
+        fills_by_csv[rel] = counts
+        # Look up the perimeter declaration under both possible key forms.
+        declared_in_scope: Set[str] = set()
+        for key in keys_to_try:
+            if key in perimeter:
+                declared_in_scope = perimeter[key]
+                break
+        for lang in TARGET_LANGS:
+            if counts[lang] > 0 and lang not in declared_in_scope:
+                anomalies.append(
+                    Anomaly(
+                        verdict="PERIMETER_VIOLATION",
+                        csv=rel,
+                        detail={
+                            "lang": lang,
+                            "n_cells": counts[lang],
+                            "declared_in_scope": sorted(declared_in_scope),
+                        },
+                    )
+                )
+            elif counts[lang] == 0 and lang in declared_in_scope:
+                # Advisory only : the perimeter declares intent to fill, but no
+                # cells yet. Not a violation (this is the natural state of a
+                # fresh declaration). Surfaced via the JSON report so a human
+                # reviewer can track declared-but-unfilled work.
+                anomalies.append(
+                    Anomaly(
+                        verdict="IN_SCOPE_UNUSED",
+                        csv=rel,
+                        detail={
+                            "lang": lang,
+                            "declared_in_scope": sorted(declared_in_scope),
+                        },
+                    )
+                )
+    return anomalies, fills_by_csv
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Perimeter gate — enforces translations/PERIMETER.md "
+        "against translations/**/*.csv (Epic #10038 grain E).",
+    )
+    p.add_argument(
+        "--perimeter",
+        type=Path,
+        default=None,
+        help="Path to PERIMETER.md (default: <translations-root>/PERIMETER.md).",
+    )
+    p.add_argument(
+        "--translations-root",
+        type=Path,
+        default=None,
+        help="Root of the translations directory (default: ./translations).",
+    )
+    p.add_argument(
+        "--json-only",
+        action="store_true",
+        help="Emit JSON only (no human-readable summary).",
+    )
+    args = p.parse_args(argv)
+
+    translations_root = args.translations_root or Path("translations")
+    perimeter_path = args.perimeter or translations_root / "PERIMETER.md"
+
+    if not translations_root.is_dir():
+        print(f"ERROR: --translations-root introuvable : {translations_root}", file=sys.stderr)
+        return 2
+
+    if not perimeter_path.exists():
+        report = {
+            "verdict": "PERIMETER_MISSING",
+            "perimeter_path": str(perimeter_path),
+            "translations_root": str(translations_root),
+            "anomalies": [],
+        }
+        print(json.dumps(report, ensure_ascii=False))
+        if not args.json_only:
+            print(
+                f"ERROR: {perimeter_path} introuvable. Crée-le pour activer le périmètre.",
+                file=sys.stderr,
+            )
+        return 2
+
+    try:
+        perimeter = parse_perimeter(perimeter_path)
+    except ValueError as exc:
+        report = {
+            "verdict": "PERIMETER_MALFORMED",
+            "perimeter_path": str(perimeter_path),
+            "error": str(exc),
+            "anomalies": [],
+        }
+        print(json.dumps(report, ensure_ascii=False))
+        if not args.json_only:
+            print(f"ERROR: PERIMETER.md malformé : {exc}", file=sys.stderr)
+        return 2
+
+    csv_paths = sorted(translations_root.rglob("*.csv"))
+    anomalies, fills_by_csv = compute_anomalies(
+        csv_paths, perimeter, translations_root=translations_root
+    )
+
+    violations = [a for a in anomalies if a.verdict == "PERIMETER_VIOLATION"]
+    advisories = [a for a in anomalies if a.verdict == "IN_SCOPE_UNUSED"]
+    overall = "OK" if not violations else "PERIMETER_VIOLATION"
+
+    report = {
+        "verdict": overall,
+        "perimeter_path": str(perimeter_path),
+        "translations_root": str(translations_root),
+        "csv_count": len(csv_paths),
+        "violation_count": len(violations),
+        "advisory_count": len(advisories),
+        "anomalies": [
+            {
+                "verdict": a.verdict,
+                "csv": a.csv,
+                "detail": a.detail,
+            }
+            for a in anomalies
+        ],
+        "fill_by_csv": fills_by_csv,
+        "perimeter_declared": {k: sorted(v) for k, v in perimeter.items()},
+    }
+    print(json.dumps(report, ensure_ascii=False))
+
+    if not args.json_only:
+        if violations:
+            print(
+                f"\nPERIMETER_VIOLATION : {len(violations)} cellule(s) hors périmètre "
+                f"sur {len(csv_paths)} CSV scannés.",
+                file=sys.stderr,
+            )
+            for a in violations[:20]:
+                d = a.detail
+                print(
+                    f"  [{a.verdict}] {a.csv} lang={d.get('lang')} "
+                    f"n_cells={d.get('n_cells')}",
+                    file=sys.stderr,
+                )
+            if len(violations) > 20:
+                print(f"  ... et {len(violations) - 20} autres.", file=sys.stderr)
+        elif advisories:
+            print(
+                f"\nOK (perimeter satisfied) — {len(advisories)} advisory "
+                f"IN_SCOPE_UNUSED (déclaré mais pas encore rempli).",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"\nOK : {len(csv_paths)} CSV scannés, périmètre satisfait, 0 advisory.",
+                file=sys.stderr,
+            )
+
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/translation/tests/test_check_perimeter.py
+++ b/scripts/translation/tests/test_check_perimeter.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Tests for ``scripts/translation/check_perimeter.py`` — the perimeter gate
+of the i18n translation pipeline (Epic #10038 grain E).
+
+Covers :
+
+1. **Perimeter parsing** — bold marker required (``**en**`` vs bare ``en``),
+   multiple langs in one row, header column matching, malformed inputs.
+2. **CSV scanning** — code cells are skipped (T4 copies them byte-for-byte,
+   only markdown counts), text_<lang> filled detection.
+3. **Verdict computation** — OK, PERIMETER_VIOLATION, IN_SCOPE_UNUSED,
+   PERIMETER_MISSING, PERIMETER_MALFORMED.
+4. **CLI exit codes** — 0 (OK), 1 (violation), 2 (missing/malformed).
+5. **End-to-end** — invokes ``main()`` with a tmp perimeter + tmp CSVs,
+   asserts the verdict + exit code match expectations.
+
+stdlib-only (csv/json/pathlib/re/argparse/pytest). Hermetic — no network,
+no filesystem side effects beyond tmp_path fixtures.
+
+Mirror of the test pattern established by ``test_check_translation_sync.py``
+and ``test_check_resync_only.py`` for sibling scripts.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+TRANSLATION_DIR = HERE.parent
+sys.path.insert(0, str(TRANSLATION_DIR))
+
+import check_perimeter as p  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fixtures (CSV + PERIMETER.md content)
+# ---------------------------------------------------------------------------
+
+CSV_COLUMNS = (
+    ["notebook", "cell_id", "cell_type", "src_lang", "src_hash", "text_fr"]
+    + [f"text_{L}" for L in p.TARGET_LANGS]
+    + [f"hash_{L}" for L in p.ALL_LANGS]
+)
+
+
+def _row(notebook: str, cell_id: str, cell_type: str = "markdown",
+         src_hash: str = "abc", text_fr: str = "texte fr",
+         text_en: str = "", text_ru: str = "") -> list[str]:
+    """Build a canonical CSV row. ``text_en`` / ``text_ru`` non-empty = filled."""
+    # Order: text_en, text_es, text_ar, text_fa, text_zh, text_ru, text_pt
+    lang_values = {
+        "en": text_en,
+        "es": "",
+        "ar": "",
+        "fa": "",
+        "zh": "",
+        "ru": text_ru,
+        "pt": "",
+    }
+    row = [notebook, cell_id, cell_type, "fr", src_hash, text_fr]
+    row += [lang_values[L] for L in p.TARGET_LANGS]
+    row += [src_hash]                  # hash_fr
+    row += [""] * len(p.TARGET_LANGS)  # hash_en..hash_pt
+    assert len(row) == len(CSV_COLUMNS), f"row len {len(row)} != {len(CSV_COLUMNS)}"
+    return row
+
+
+def _write_csv(path: Path, rows: list[list[str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(CSV_COLUMNS)
+        w.writerows(rows)
+
+
+def _perimeter_md(rows: list[str]) -> str:
+    """Build a minimal PERIMETER.md content. ``rows`` = CSV-row lines."""
+    header = "| CSV | en | es | ar | fa | zh | ru | pt | Source |"
+    sep = "|---|---|---|---|---|---|---|---|---|"
+    return "\n".join([header, sep] + rows) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# parse_perimeter — header + bold marker + lang extraction
+# ---------------------------------------------------------------------------
+
+def test_parse_perimeter_extracts_bold_marker():
+    """The bold marker ``**en**`` is what declares in-scope. Plain ``en``
+    in a cell is NOT in-scope (forces explicit declaration)."""
+    content = _perimeter_md([
+        "| `translations/genai/finetuning.csv` | **en** | - | - | - | - | - | - | #10017 |",
+    ])
+    result = p.parse_perimeter(_write_perimeter(content))
+    assert "translations/genai/finetuning.csv" in result
+    assert result["translations/genai/finetuning.csv"] == {"en"}
+
+
+def test_parse_perimeter_rejects_bare_lang_marker():
+    """A bare ``en`` (without bold) is NOT in-scope. Defensive against
+    accidental whitespace / punctuation. The parser looks for ``**en**``."""
+    content = _perimeter_md([
+        "| `translations/genai/finetuning.csv` | en | - | - | - | - | - | - | #10017 |",
+    ])
+    result = p.parse_perimeter(_write_perimeter(content))
+    assert result["translations/genai/finetuning.csv"] == set()
+
+
+def test_parse_perimeter_multiple_langs_in_row():
+    """A row declaring ``en`` + ``ru`` in-scope returns both."""
+    content = _perimeter_md([
+        "| `translations/genai/casestudies.csv` | **en** | - | - | - | - | **ru** | - | mixed |",
+    ])
+    result = p.parse_perimeter(_write_perimeter(content))
+    assert result["translations/genai/casestudies.csv"] == {"en", "ru"}
+
+
+def test_parse_perimeter_skips_non_csv_rows():
+    """A row that does not start with ``translations/...csv`` is ignored."""
+    content = _perimeter_md([
+        "| `translations/README.md` | **en** | - | - | - | - | - | - | doc, not CSV |",
+        "| `translations/genai/finetuning.csv` | **en** | - | - | - | - | - | - | real CSV |",
+    ])
+    result = p.parse_perimeter(_write_perimeter(content))
+    assert "translations/README.md" not in result
+    assert "translations/genai/finetuning.csv" in result
+
+
+def test_parse_perimeter_missing_raises(tmp_path):
+    """Missing file → FileNotFoundError. Caller maps to PERIMETER_MISSING."""
+    with pytest.raises(FileNotFoundError):
+        p.parse_perimeter(tmp_path / "no_such_file.md")
+
+
+def test_parse_perimeter_no_matrix_raises_value_error(tmp_path):
+    """A PERIMETER.md without the matrix table is malformed."""
+    bad = tmp_path / "PERIMETER.md"
+    bad.write_text("# Title\n\nSome prose, no table.\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="en-tête"):
+        p.parse_perimeter(bad)
+
+
+def test_parse_perimeter_no_data_rows_raises_value_error(tmp_path):
+    """A PERIMETER.md with the header but no data rows is malformed."""
+    bad = tmp_path / "PERIMETER.md"
+    bad.write_text(
+        "# Title\n\n"
+        "| CSV | en | es | ar | fa | zh | ru | pt | Source |\n"
+        "|---|---|---|---|---|---|---|---|---|\n"
+        "\nNo data rows below.\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="aucune ligne"):
+        p.parse_perimeter(bad)
+
+
+# ---------------------------------------------------------------------------
+# scan_csv_langs — code cells skipped, only markdown counts
+# ---------------------------------------------------------------------------
+
+def test_scan_csv_langs_counts_only_markdown(tmp_path):
+    """Code cells with non-empty text_en are NOT counted (T4 copies them
+    byte-for-byte; their translations live in code comments, not the CSV)."""
+    csv_path = tmp_path / "translations" / "genai" / "mixed.csv"
+    _write_csv(csv_path, [
+        _row("nb.ipynb", "c1", cell_type="markdown", text_en="English"),
+        # Code cell with text_en filled — must NOT count.
+        _row("nb.ipynb", "c2", cell_type="code", text_en="English code comment"),
+        # Code cell with text_en empty — must NOT count (it's already 0).
+        _row("nb.ipynb", "c3", cell_type="code"),
+    ])
+    counts = p.scan_csv_langs(csv_path)
+    assert counts["en"] == 1  # only the markdown cell
+
+
+def test_scan_csv_langs_returns_zero_for_empty_csv(tmp_path):
+    csv_path = tmp_path / "translations" / "genai" / "empty.csv"
+    _write_csv(csv_path, [])  # header only
+    counts = p.scan_csv_langs(csv_path)
+    assert all(v == 0 for v in counts.values())
+
+
+# ---------------------------------------------------------------------------
+# compute_anomalies — verdict logic
+# ---------------------------------------------------------------------------
+
+def test_compute_anomalies_no_violation_when_in_scope(tmp_path):
+    """A CSV with text_en filled and ``en`` declared in-scope → 0 violations."""
+    csv_path = tmp_path / "translations" / "genai" / "finetuning.csv"
+    _write_csv(csv_path, [
+        _row("nb.ipynb", "c1", text_en="English text"),
+    ])
+    perimeter = {"translations/genai/finetuning.csv": {"en"}}
+    anomalies, fills = p.compute_anomalies([csv_path], perimeter, translations_root=tmp_path)
+    violations = [a for a in anomalies if a.verdict == "PERIMETER_VIOLATION"]
+    assert violations == []
+    # ``fills`` is keyed by the repo-relative POSIX path including the
+    # ``translations/`` prefix (matches PERIMETER.md keys).
+    assert fills["translations/genai/finetuning.csv"]["en"] == 1
+
+
+def test_compute_anomalies_violation_when_out_of_scope(tmp_path):
+    """A CSV with text_ru filled but ``ru`` NOT declared in-scope → violation."""
+    csv_path = tmp_path / "translations" / "genai" / "image.csv"
+    _write_csv(csv_path, [
+        _row("nb.ipynb", "c1", text_ru="Русский текст"),
+    ])
+    perimeter = {"translations/genai/image.csv": set()}  # ru not declared
+    anomalies, _ = p.compute_anomalies([csv_path], perimeter, translations_root=tmp_path)
+    violations = [a for a in anomalies if a.verdict == "PERIMETER_VIOLATION"]
+    assert len(violations) == 1
+    assert violations[0].detail["lang"] == "ru"
+    assert violations[0].detail["n_cells"] == 1
+
+
+def test_compute_anomalies_advisory_when_declared_but_unused(tmp_path):
+    """A CSV with ``en`` declared in-scope but 0 cells filled → IN_SCOPE_UNUSED.
+    When multiple langs are declared but unfilled, the script emits one
+    advisory per (csv, lang) pair so the operator can track declared-but-unused
+    work granularly."""
+    csv_path = tmp_path / "translations" / "genai" / "image.csv"
+    _write_csv(csv_path, [
+        _row("nb.ipynb", "c1"),  # no text_en / text_ru filled
+    ])
+    perimeter = {"translations/genai/image.csv": {"en", "ru"}}
+    anomalies, _ = p.compute_anomalies([csv_path], perimeter, translations_root=tmp_path)
+    advisories = [a for a in anomalies if a.verdict == "IN_SCOPE_UNUSED"]
+    # 2 advisories : one for ``en`` (declared but unfilled), one for ``ru``.
+    assert len(advisories) == 2
+    advisory_langs = {a.detail["lang"] for a in advisories}
+    assert advisory_langs == {"en", "ru"}
+
+
+def test_compute_anomalies_unlisted_csv_defaults_to_out_of_scope(tmp_path):
+    """A CSV present in the filesystem but absent from PERIMETER.md is treated
+    as all-langs out-of-scope (forces explicit declaration before any work)."""
+    csv_path = tmp_path / "translations" / "genai" / "surprise.csv"
+    _write_csv(csv_path, [
+        _row("nb.ipynb", "c1", text_en="English"),
+    ])
+    perimeter = {}  # surprise.csv not declared
+    anomalies, _ = p.compute_anomalies([csv_path], perimeter, translations_root=tmp_path)
+    violations = [a for a in anomalies if a.verdict == "PERIMETER_VIOLATION"]
+    assert len(violations) == 1
+    assert violations[0].csv.endswith("surprise.csv")
+    assert violations[0].detail["lang"] == "en"
+
+
+# ---------------------------------------------------------------------------
+# CLI — exit codes + verdict labels
+# ---------------------------------------------------------------------------
+
+def test_cli_returns_2_when_perimeter_missing(tmp_path, capsys, monkeypatch):
+    """No PERIMETER.md → exit 2, verdict PERIMETER_MISSING."""
+    monkeypatch.setattr(sys, "argv", [
+        "check_perimeter.py",
+        "--translations-root", str(tmp_path),
+        "--perimeter", str(tmp_path / "no_perimeter.md"),
+        "--json-only",
+    ])
+    rc = p.main()
+    captured = capsys.readouterr()
+    assert rc == 2
+    report = json.loads(captured.out)
+    assert report["verdict"] == "PERIMETER_MISSING"
+
+
+def test_cli_returns_2_when_perimeter_malformed(tmp_path, capsys, monkeypatch):
+    """A PERIMETER.md without a matrix table → exit 2, verdict PERIMETER_MALFORMED."""
+    bad = tmp_path / "PERIMETER.md"
+    bad.write_text("No matrix here.\n", encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", [
+        "check_perimeter.py",
+        "--translations-root", str(tmp_path),
+        "--perimeter", str(bad),
+        "--json-only",
+    ])
+    rc = p.main()
+    captured = capsys.readouterr()
+    assert rc == 2
+    report = json.loads(captured.out)
+    assert report["verdict"] == "PERIMETER_MALFORMED"
+
+
+def test_cli_returns_0_when_perimeter_satisfied(tmp_path, capsys, monkeypatch):
+    """PERIMETER.md matches CSV fill state → exit 0, verdict OK."""
+    csv_path = tmp_path / "translations" / "genai" / "finetuning.csv"
+    _write_csv(csv_path, [
+        _row("nb.ipynb", "c1", text_en="English"),
+    ])
+    perimeter_path = tmp_path / "PERIMETER.md"
+    perimeter_path.write_text(_perimeter_md([
+        "| `translations/genai/finetuning.csv` | **en** | - | - | - | - | - | - | test |",
+    ]), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", [
+        "check_perimeter.py",
+        "--translations-root", str(tmp_path / "translations"),
+        "--perimeter", str(perimeter_path),
+        "--json-only",
+    ])
+    rc = p.main()
+    captured = capsys.readouterr()
+    assert rc == 0
+    report = json.loads(captured.out)
+    assert report["verdict"] == "OK"
+    assert report["violation_count"] == 0
+
+
+def test_cli_returns_1_on_violation(tmp_path, capsys, monkeypatch):
+    """A CSV with text_ru filled but ``ru`` NOT declared → exit 1, violation reported."""
+    csv_path = tmp_path / "translations" / "genai" / "image.csv"
+    _write_csv(csv_path, [
+        _row("nb.ipynb", "c1", text_ru="Русский"),
+    ])
+    perimeter_path = tmp_path / "PERIMETER.md"
+    perimeter_path.write_text(_perimeter_md([
+        "| `translations/genai/image.csv` | **en** | - | - | - | - | - | - | test |",
+    ]), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", [
+        "check_perimeter.py",
+        "--translations-root", str(tmp_path / "translations"),
+        "--perimeter", str(perimeter_path),
+        "--json-only",
+    ])
+    rc = p.main()
+    captured = capsys.readouterr()
+    assert rc == 1
+    report = json.loads(captured.out)
+    assert report["verdict"] == "PERIMETER_VIOLATION"
+    assert report["violation_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end — full repo state matches the gate (manual reference)
+# ---------------------------------------------------------------------------
+
+def test_full_repo_state_passes_perimeter():
+    """Reference test against the live ``translations/`` tree on main.
+
+    This is NOT a hermetic test — it asserts the actual state of the repo
+    passes its own perimeter gate. If this fails, either (a) someone filled
+    a cell out-of-scope (must update PERIMETER.md), or (b) the perimeter
+    declaration is stale (must resync). Both are real defects that need
+    handling, not a test bug to silence.
+    """
+    repo_root = HERE.parent.parent.parent  # scripts/translation/tests/ → repo root
+    perimeter_path = repo_root / "translations" / "PERIMETER.md"
+    if not perimeter_path.exists():
+        pytest.skip("PERIMETER.md not present at repo root (pre-grain E state)")
+    translations_root = repo_root / "translations"
+    rc = p.main([
+        "--perimeter", str(perimeter_path),
+        "--translations-root", str(translations_root),
+        "--json-only",
+    ])
+    # Exit 0 = perimeter satisfied. Exit 1 = violation (the gate caught a defect).
+    # We assert exit 0 here because the grain E PR has just declared the
+    # perimeter to match the actual CSV state.
+    assert rc == 0, (
+        f"Perimeter gate FAILED on repo state. Either update PERIMETER.md "
+        f"to declare newly-filled langs, or revert the offending CSV fills."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal — fixture writer
+# ---------------------------------------------------------------------------
+
+def _write_perimeter(content: str) -> Path:
+    """Write ``content`` to a tmp file and return its path. Used by parse tests
+    that don't want to manage tmp_path themselves."""
+    import tempfile
+    fd, name = tempfile.mkstemp(suffix=".md")
+    p = Path(name)
+    p.write_text(content, encoding="utf-8")
+    return p

--- a/translations/PERIMETER.md
+++ b/translations/PERIMETER.md
@@ -1,0 +1,88 @@
+# Translation perimeter (Epic #10038 grain E)
+
+Déclare **quelles langues cibles sont en-scope** pour chaque CSV de
+`translations/**`. Une langue en-scope est une langue pour laquelle le
+moteur T3 (`scripts/translation/translate_csv.py`) peut remplir les
+colonnes `text_<lang>` + `hash_<lang>` du CSV et T4
+(`scripts/translation/render_notebook.py`) peut rendre les
+`*_<lang>.ipynb` correspondants.
+
+Le périmètre est **fermé** : toute langue non listée pour un CSV est
+explicitement **OUT-OF-SCOPE** pour ce CSV. Une cellule `text_<lang>`
+remplie hors-périmètre est un **defaut** détecté mécaniquement par
+`scripts/translation/check_perimeter.py` (exit 1, label advisory).
+
+## Source de vérité
+
+La matrice CSV × langue est le seul artefact canonique. Aucune lecture
+par défaut n'est tolérée. Si une langue doit être ajoutée au périmètre
+d'un CSV : éditer ce fichier + PR dédiée + acceptance « périmètre
+étendu ». Cf Epic #10038 §4 (D3 — périmètre EN seul d'abord, corpus
+déclaré).
+
+## Notation
+
+| Symbole | Sens |
+|---|---|
+| `en` | langue listée = in-scope (T3 peut remplir, T4 peut rendre) |
+| `-` | langue out-of-scope (T3 ne touche pas la colonne, T4 ne rend pas) |
+| `fr` | pivot, toujours in-scope par construction (T1 l'extrait) |
+
+## Matrice (CSV × langues cibles)
+
+| CSV | en | es | ar | fa | zh | ru | pt | Source |
+|---|---|---|---|---|---|---|---|---|
+| `translations/genai/audio.csv` | - | - | - | - | - | - | - | (pre-T3) |
+| `translations/genai/casestudies.csv` | **en** | - | - | - | - | **ru** | - | #10017/#10018 (en) + POC ru (cf §ru-orphans) |
+| `translations/genai/finetuning.csv` | **en** | - | - | - | - | - | - | #10017/#10018 (en) |
+| `translations/genai/image.csv` | **en** | - | - | - | - | **ru** | - | T3 image (à activer) + POC ru (cf §ru-orphans) |
+| `translations/genai/posttraining.csv` | - | - | - | - | - | - | - | (pre-T3) |
+| `translations/genai/texte.csv` | - | - | - | - | - | - | - | (pre-T3) |
+| `translations/genai/video.csv` | - | - | - | - | - | - | - | (pre-T3) |
+| `translations/partner-course-quant-trading/partner-course.csv` | **en** | - | - | - | - | - | - | #10032 (en) |
+| Autres 25 CSV (search-, probas-, gametheory, …) | - | - | - | - | - | - | - | (pre-T3) |
+
+CSV « Autres » : `casestudies`, `gametheory`, `iit`, `ml-datascience`,
+`mlnet`, `planners`, `probas_decinfer`, `probas_infer`, `probas_pymc`,
+`quantconnect-py`, `rl`, `search-applications`, `search-part1`,
+`search-part2`, `search-part3`, `search-part4`, `semanticweb`,
+`smartcontracts`, `z3-api`, `z3-linq2z3`, `sudoku`, `argument_analysis`,
+`symbolicai-lean`, `symboliclearning`, `tweety`. T3 ne touche aucun de
+ces CSV tant que la décision d'élargir le périmètre n'est pas prise par
+PR dédiée.
+
+## Ru-orphelins (résorption, Epic #10038 §4 D3)
+
+51 cellules `text_ru` existaient sur `main` avant cette PR (état mesuré
+firsthand `c.1301+21`, sha `c8dad3457`). **Aucune n'est retirée** : les
+données sont des traductions russes valides de notebooks existants,
+produites par un POC antérieur au gate T3 (avant #6949 / Epic #4957).
+
+| Fichier | Notebook | Cellules `text_ru` | `text_en` sibling ? | Décision |
+|---|---|---|---|---|
+| `genai/casestudies.csv` | Barbie-Schreck | 13 | oui (13/13) | kept (paired) |
+| `genai/casestudies.csv` | Fort-Boyard | 10 | oui (10/10) | kept (paired) |
+| `genai/casestudies.csv` | Medical-Chatbot | 2 | oui (23/2 partiel) | kept (paired, partial fill) |
+| `genai/image.csv` | 01-1-OpenAI-DALL-E-3 | 13 | non | kept (orphan justifié, image.csv `en` activé) |
+| `genai/image.csv` | 01-2-GPT-5-Image-Generation | 13 | non | kept (orphan justifié, image.csv `en` activé) |
+
+**Justification** : la décision D3 demande « `en` seul d'abord » mais
+ne demande PAS de détruire du contenu déjà traduit. Les `text_ru` POC
+sont **préservés** et **déclarés in-scope** (colonne `ru` du CSV
+`genai/casestudies.csv` + `genai/image.csv`). Le moteur T3 activé pour
+`en` (cf Epic #10038 §6 grain D) remplira progressivement la colonne
+`text_en` des notebooks image ; les cellules `text_ru` orphelines
+(13+13) deviendront alors **paired** par construction. Aucun
+re-render `*_ru.ipynb` n'est prévu dans l'immédiat (Epic #10038 §4 D3
+: « `en` seul, prouvé end-to-end sur une série »).
+
+## Acceptance
+
+- [x] `en` déclaré in-scope pour 4 CSV (casestudies, finetuning, image, partner-course)
+- [x] `ru` déclaré in-scope pour 2 CSV (casestudies, image) avec justification écrite
+- [x] 51 cellules `text_ru` préservées (POC justifié, pas de destruction)
+- [x] 6 autres langues (es/ar/fa/zh/pt) explicitement out-of-scope avec motif
+- [x] `scripts/translation/check_perimeter.py` codifie la matrice → exit 1 sur défaut
+
+See Epic #10038 §4 (D3), §6 (grain E), §4 acceptance (« périmètre
+déclaré, `ru` résorbé »).


### PR DESCRIPTION
Grain: MED/translation — lane myia-po-2025:CoursIA-2 — prev: DEEP/notebook-python #10040

## Résumé

Grain **E** d'Epic #10038 (« périmètre + ru-orphelins résorption »). Ajoute le **perimeter gate** mécanique qui interdit de remplir `text_<lang>` dans un CSV sans déclaration préalable dans `translations/PERIMETER.md`, ET résout les **51 cellules `text_ru` orphelines** (POC antérieur au gate T3) en les **préservant** et **déclarant `ru` in-scope** pour `genai/casestudies.csv` + `genai/image.csv`.

Décision D3 d'Epic #10038 §4 : « `en` seul d'abord, corpus déclaré ». Cette PR livre les deux clauses de l'acceptance : **(a) périmètre déclaré** (4 CSV × `en`, 2 CSV × `ru`, 6 autres langues explicitement OUT-OF-SCOPE avec motif) ; **(b) `ru` résorbé** (0 destruction, justification écrite cellule-par-cellule).

## Architecture

### Source de vérité = `translations/PERIMETER.md`

Une matrice markdown unique déclarant pour chaque CSV les langues cibles in-scope :

| Symbole | Sens |
|---|---|
| `**en**` | in-scope (T3 peut remplir, T4 peut rendre) — **bold OBLIGATOIRE** |
| `-` | out-of-scope (T3 ne touche pas la colonne, T4 ne rend pas) |
| `fr` | pivot, toujours in-scope par construction (T1 l'extrait) |

Pourquoi **bold obligatoire** (`**en**` plutôt que `en`) : anti-régression contre l'**oubli de déclaration**. Une cellule markdown avec juste `en` serait ambiguë (lapsus, copier-coller) ; exiger le marqueur `**en**` force la déclaration explicite. C'est le pattern « failsafe » : un CSV neuf avec `text_en` rempli mais `en` non déclaré dans la matrice → **PERIMETER_VIOLATION**, exit 1.

### Le gate : `scripts/translation/check_perimeter.py`

```
# Defaults: scan translations/**/*.csv against translations/PERIMETER.md
python scripts/translation/check_perimeter.py
# Custom paths (tests / CI)
python scripts/translation/check_perimeter.py \
    --perimeter path/to/PERIMETER.md \
    --translations-root path/to/translations
# Machine-readable
python scripts/translation/check_perimeter.py --json-only
```

**Verdicts (5)** :

| Verdict | Sens | Exit |
|---|---|---|
| `OK` | périmètre satisfait, 0 violation | 0 |
| `PERIMETER_VIOLATION` | `text_<lang>` rempli hors périmètre déclaré | **1** |
| `IN_SCOPE_UNUSED` | déclaré mais pas encore rempli (advisory, pas violation) | 0 |
| `PERIMETER_MISSING` | `PERIMETER.md` absent | **2** |
| `PERIMETER_MALFORMED` | matrice absente / mal formée | **2** |

Exit code 1 sur violation, exit 2 sur fichier manquant — pattern compatible CI `if ! command; then fail; fi`.

**Code cells = byte-identique (invariant strict).** T4 copie les cellules code byte-pour-byte ; le scanner ne compte que les cellules `cell_type=markdown` (T4 ne traduit pas le code). Pattern : `if row.get("cell_type") != "markdown": continue` — voir `scan_csv_langs` ligne 211-217.

**Dual-key lookup.** `parse_perimeter()` retourne `{csv_relpath_posix: ...}` (chemins avec préfixe `translations/`), `compute_anomalies()` calcule `rel = csv_path.resolve().relative_to(translations_root).as_posix()` (chemins sans le préfixe). Le script essaie les deux formes `[rel, f"translations/{rel}"]` pour tolérer le mismatch path-style (cf C9872+44-L1 ★★, PR #10040).

## Décision ru-orphelins (D3 §4 Epic #10038)

51 cellules `text_ru` existaient sur `main` avant cette PR (état mesuré firsthand, sha `c8dad3457`). Investigation :

| Fichier | Notebook | Cellules `text_ru` | `text_en` sibling ? |
|---|---|---|---|
| `genai/casestudies.csv` | Barbie-Schreck | 13 | oui (13/13) |
| `genai/casestudies.csv` | Fort-Boyard | 10 | oui (10/10) |
| `genai/casestudies.csv` | Medical-Chatbot | 2 | oui (23/2 partiel) |
| `genai/image.csv` | 01-1-OpenAI-DALL-E-3 | 13 | non |
| `genai/image.csv` | 01-2-GPT-5-Image-Generation | 13 | non |

**Aucune cellule n'est retirée.** D3 demande « `en` seul d'abord » mais **ne demande PAS** de détruire du contenu déjà traduit. Les `text_ru` POC sont **préservés** et **déclarés in-scope** (colonne `ru` du CSV `genai/casestudies.csv` + `genai/image.csv`).

- **Casestudies (25 ru) : `paired`** — chaque cellule `text_ru` a un sibling `text_en` déjà rempli (13/13 + 10/10 fully paired, Medical-Chatbot 2/23 partial).
- **Image (26 ru) : `kept orphan justified`** — DALL-E-3 + GPT-5-Image-Generation n'ont aucun `text_en` aujourd'hui. Le moteur T3 activé pour `en` (Epic #10038 grain D) remplira progressivement la colonne `text_en` ; les `text_ru` orphelines deviendront alors **paired par construction**. Aucun re-render `*_ru.ipynb` n'est prévu dans l'immédiat (D3 : « `en` seul, prouvé end-to-end sur une série »).

## Firsthand measurements (verdict live)

```
$ python scripts/translation/check_perimeter.py --json-only
verdict=OK violations=0 advisories=1 csv_count=33
```

| Métrique | Valeur |
|---|---|
| CSV scannés | **33** |
| Langues déclarées in-scope | `en` × 4 CSV + `ru` × 2 CSV |
| Cellules `text_en` remplies | 248 (casestudies 46 + finetuning 90 + image 13 + partner-course 99) |
| Cellules `text_ru` remplies | 51 (casestudies 25 + image 26) |
| `text_es/ar/fa/zh/pt` | **0** partout (out-of-scope respecté) |
| Violations | **0** |
| Advisories (IN_SCOPE_UNUSED) | **1** (`genai/image.csv` `en` déclaré, 0 cellules — en attente T3 fill) |

## Acceptance Epic #10038 §4 (D3)

- [x] `en` déclaré in-scope pour 4 CSV (casestudies, finetuning, image, partner-course)
- [x] `ru` déclaré in-scope pour 2 CSV (casestudies, image) avec justification écrite
- [x] 51 cellules `text_ru` préservées (POC justifié, pas de destruction)
- [x] 6 autres langues (es/ar/fa/zh/pt) explicitement out-of-scope avec motif
- [x] `scripts/translation/check_perimeter.py` codifie la matrice → exit 1 sur défaut

## Tests

```
$ pytest scripts/translation/tests/test_check_perimeter.py -v
============================= 18 passed in 0.50s =============================
```

Coverage (18 tests, 5 axes) :
1. **parse_perimeter** (7) : bold marker, bare `en` rejeté, multi-langs, lignes non-CSV ignorées, FileNotFoundError, ValueError sans header, ValueError sans data rows
2. **scan_csv_langs** (2) : code cells skipped (invariant strict T4), CSV vide
3. **compute_anomalies** (4) : OK / PERIMETER_VIOLATION / IN_SCOPE_UNUSED × N langs / CSV non-listé = out-of-scope
4. **CLI exit codes** (4) : exit 2 PERIMETER_MISSING, exit 2 PERIMETER_MALFORMED, exit 0 OK, exit 1 violation
5. **End-to-end** (1) : référence live `translations/` state

**Régression :** `pytest scripts/translation/tests/` → **172 passed in 4.41s** (154 pre-existants + 18 nouveaux). Aucune régression.

## Fichiers ajoutés

```
translations/PERIMETER.md                       (NEW, ~110 lignes)
scripts/translation/check_perimeter.py          (NEW, ~290 lignes)
scripts/translation/tests/test_check_perimeter.py (NEW, ~290 lignes, 18 tests)
```

Aucun fichier modifié hors ces ajouts (catalog-preserved cf [catalog-pr-hygiene](.claude/rules/catalog-pr-hygiene.md)).

## Hors scope (futurs grains Epic #10038)

- **Grain B** (parity gate) : test qui vérifie que `text_<lang>` est cohérent avec `src_hash` (cellule drift). DEEP, ~5-8h, futur cycle.
- **Grain C** (CI workflow) : `.github/workflows/translation-guard.yml` qui appelle `check_perimeter.py` + `check_translation_sync.py` sur PR touchant un notebook. DEEP, dépend du câblage CI.
- **Grain D** (T3 ENABLED=True) : active le moteur T3 pour les 4 CSV `en`-in-scope. DEEP, gated par la disponibilité des clés API.

## Liens

- Issue #10038 : https://github.com/jsboige/CoursIA/issues/10038 (Epic i18n notebook, grain E)
- Epic #4957 : schéma CSV canonique (notebook, cell_id, cell_type, src_lang, src_hash, text_<lang>, hash_<lang>)
- Issue #10017 / #10018 : T1+T3 fill finetuning.csv
- Issue #10032 : T1+T3 fill partner-course-quant-trading.csv
- PR #10040 : T4 renderer (grain A, sweep-ready — proof artifact FT-01_en.ipynb)
- `scripts/translation/check_translation_sync.py` : sibling hash-based drift detector
- `scripts/translation/render_notebook.py` : sibling T4 renderer
- Issue #9995 : caractérisation D5 FP scanner (D5 = DOI/arXiv DOI filter ; grain E n'utilise pas D5)