### PR TITLE
fix(planners,#10000): suppress unified_planning path leaks in Planners-11 (Stop & Repair)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
@@ -134,10 +134,10 @@
    "id": "cell-install",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:20.627416Z",
-     "iopub.status.busy": "2026-06-09T05:15:20.627226Z",
-     "iopub.status.idle": "2026-06-09T05:15:22.078107Z",
-     "shell.execute_reply": "2026-06-09T05:15:22.077360Z"
+     "iopub.execute_input": "2026-08-08T12:12:37.432590Z",
+     "iopub.status.busy": "2026-08-08T12:12:37.431130Z",
+     "iopub.status.idle": "2026-08-08T12:12:40.793746Z",
+     "shell.execute_reply": "2026-08-08T12:12:40.792715Z"
     },
     "papermill": {
      "duration": 1.457377,
@@ -169,9 +169,20 @@
     "# Imports principaux\n",
     "import sys\n",
     "import time\n",
+    "import warnings\n",
     "from typing import List, Dict, Optional, Any\n",
     "\n",
     "from unified_planning.shortcuts import *\n",
+    "# La banniere \"Credits\" affichee au premier appel d'un solveur unified_planning\n",
+    "# contient le chemin absolu de la source de la bibliotheque (fuite de chemin\n",
+    "# machine, #9997/#10000). On la supprime globalement une fois pour toutes,\n",
+    "# comme le suggere la banniere elle-meme (cf. aussi la cellule d'optimisation).\n",
+    "get_environment().credits_stream = None\n",
+    "# unified_planning emet un UserWarning \"We cannot establish whether ... can solve\"\n",
+    "# dont le traceback inclut le chemin absolu de la bibliotheque (meme fuite, #9997).\n",
+    "# Ce warning est purement informatif : le statut de resolution (ex. INTERNAL_ERROR\n",
+    "# pour les fluents numeriques) est deja gere explicitement dans les cellules.\n",
+    "warnings.filterwarnings(\"ignore\", message=r\"We cannot establish whether\")\n",
     "# Note: En unified-planning 1.3.0+, toutes les classes sont importees via shortcuts\n",
     "# UserType, BoolType, IntType viennent de shortcuts, pas de model.types\n",
     "from unified_planning.engines import Engine\n",
@@ -206,10 +217,10 @@
    "id": "cell-check-engines",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:22.130749Z",
-     "iopub.status.busy": "2026-06-09T05:15:22.130265Z",
-     "iopub.status.idle": "2026-06-09T05:15:22.958212Z",
-     "shell.execute_reply": "2026-06-09T05:15:22.956692Z"
+     "iopub.execute_input": "2026-08-08T12:12:40.797733Z",
+     "iopub.status.busy": "2026-08-08T12:12:40.796742Z",
+     "iopub.status.idle": "2026-08-08T12:12:40.828021Z",
+     "shell.execute_reply": "2026-08-08T12:12:40.825981Z"
     },
     "papermill": {
      "duration": 0.843474,
@@ -228,10 +239,14 @@
       "Planificateurs disponibles:\n",
       "==================================================\n",
       "  - fast-downward\n",
+      "  - pyperplan\n",
+      "  - replanner[aries]\n",
       "  - replanner[fast-downward-opt]\n",
       "  - replanner[fast-downward]\n",
+      "  - replanner[pyperplan-opt]\n",
+      "  - replanner[pyperplan]\n",
       "\n",
-      "Total: 21 moteurs detectes\n"
+      "Total: 29 moteurs detectes\n"
      ]
     }
    ],
@@ -309,10 +324,10 @@
    "id": "cell-types-fluents-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:23.077459Z",
-     "iopub.status.busy": "2026-06-09T05:15:23.076921Z",
-     "iopub.status.idle": "2026-06-09T05:15:23.085712Z",
-     "shell.execute_reply": "2026-06-09T05:15:23.084288Z"
+     "iopub.execute_input": "2026-08-08T12:12:40.831008Z",
+     "iopub.status.busy": "2026-08-08T12:12:40.830012Z",
+     "iopub.status.idle": "2026-08-08T12:12:40.837760Z",
+     "shell.execute_reply": "2026-08-08T12:12:40.836724Z"
     },
     "papermill": {
      "duration": 0.020815,
@@ -382,10 +397,10 @@
    "id": "cell-actions-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:23.126792Z",
-     "iopub.status.busy": "2026-06-09T05:15:23.126429Z",
-     "iopub.status.idle": "2026-06-09T05:15:23.136977Z",
-     "shell.execute_reply": "2026-06-09T05:15:23.135758Z"
+     "iopub.execute_input": "2026-08-08T12:12:40.841756Z",
+     "iopub.status.busy": "2026-08-08T12:12:40.840756Z",
+     "iopub.status.idle": "2026-08-08T12:12:40.852349Z",
+     "shell.execute_reply": "2026-08-08T12:12:40.850790Z"
     },
     "papermill": {
      "duration": 0.023064,
@@ -457,10 +472,10 @@
    "id": "cell-problem-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:23.177627Z",
-     "iopub.status.busy": "2026-06-09T05:15:23.177228Z",
-     "iopub.status.idle": "2026-06-09T05:15:23.189738Z",
-     "shell.execute_reply": "2026-06-09T05:15:23.188439Z"
+     "iopub.execute_input": "2026-08-08T12:12:40.855780Z",
+     "iopub.status.busy": "2026-08-08T12:12:40.855780Z",
+     "iopub.status.idle": "2026-08-08T12:12:40.878061Z",
+     "shell.execute_reply": "2026-08-08T12:12:40.876929Z"
     },
     "papermill": {
      "duration": 0.02543,
@@ -660,10 +675,10 @@
    "id": "cell-solve-single",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:23.271602Z",
-     "iopub.status.busy": "2026-06-09T05:15:23.271044Z",
-     "iopub.status.idle": "2026-06-09T05:15:23.282813Z",
-     "shell.execute_reply": "2026-06-09T05:15:23.280675Z"
+     "iopub.execute_input": "2026-08-08T12:12:40.882059Z",
+     "iopub.status.busy": "2026-08-08T12:12:40.881062Z",
+     "iopub.status.idle": "2026-08-08T12:12:40.924062Z",
+     "shell.execute_reply": "2026-08-08T12:12:40.923027Z"
     },
     "papermill": {
      "duration": 0.026618,
@@ -679,19 +694,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[96m\u001b[1mNOTE: To disable printing of planning engine credits, add this line to your code: `up.shortcuts.get_environment().credits_stream = None`\n",
-      "\u001b[0m\u001b[96m  *** Credits ***\n",
-      "\u001b[0m\u001b[96m  * In operation mode `OneshotPlanner` at line 563 of `C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages\\unified_planning\\shortcuts.py`, \u001b[0m\u001b[96myou are using the following planning engine:\n",
-      "\u001b[0m\u001b[96m  * Engine name: pyperplan\n",
-      "  * Developers:  Albert-Ludwigs-Universität Freiburg (Yusra Alkhazraji, Matthias Frorath, Markus Grützner, Malte Helmert, Thomas Liebetraut, Robert Mattmüller, Manuela Ortlieb, Jendrik Seipp, Tobias Springenberg, Philip Stahl, Jan Wülfing)\n",
-      "\u001b[0m\u001b[96m  * Description: \u001b[0m\u001b[96mPyperplan is a lightweight STRIPS planner written in Python.\u001b[0m\u001b[96m\n",
-      "\u001b[0m\u001b[96m\n",
-      "\u001b[0m\n",
+      "\n",
       "==================================================\n",
       "Solveur: pyperplan\n",
       "==================================================\n",
       "Statut: SOLVED_SATISFICING\n",
-      "Temps: 0.082s\n",
+      "Temps: 0.032s\n",
       "\n",
       "Plan trouve (6 actions):\n",
       "  1. move(robot1, L0, L1)\n",
@@ -767,28 +775,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interpretation : Resolution avec un seul solveur\n",
-    "\n",
-    "**Sortie obtenue** : pyperplan resout le labyrinthe. Le moteur affiche ses credits (provenance du code, equipe de developpement) puis renvoie un statut `SOLVED_SATISFICING` avec un plan de **6 actions** menant le robot de L0 (entree) a L11 (sortie).\n",
-    "\n",
-    "**Le plan trouve suit le chemin court** traverse le corridor principal L0 -> L1 -> L2 -> L4 -> L7 -> L10, puis atteint L11. Les 7 impasses (L3, L5, L6, L8, L9, L12, L14) ne sont jamais visitees : l'heuristique h^FF interne a pyperplan les elimine des le depart, car elles eloignent du but au lieu d'en rapprocher. C'est precisement ce qu'un moteur de planification apporte de plus qu'une recherche aveugle (BFS/DFS), qui devrait explorer ces branches sans issue avant de les ecarter.\n",
-    "\n",
-    "**Workflow de resolution** :\n",
-    "1. Creer le solveur (`OneshotPlanner`)\n",
-    "2. Appeler `solve(problem)`\n",
-    "3. Analyser le statut de retour\n",
-    "4. Extraire le plan si succes\n",
-    "\n",
-    "**Statuts possibles** :\n",
-    "- `SOLVED_SATISFICING` : Plan trouve (pas forcement optimal)\n",
-    "- `SOLVED_OPTIMALLY` : Plan optimal trouve\n",
-    "- `UNSATISFIABLE` : Probleme insoluble\n",
-    "- `TIMEOUT` : Timeout atteint\n",
-    "- `ERROR` : Erreur technique (solveur absent, probleme mal defini)\n",
-    "\n",
-    "> **Note technique** : La classe `OneshotPlanner` est un contexte manager qui gere les ressources du solveur. Il est important de l'utiliser dans un bloc `with` pour assurer la liberation des ressources. Le banniere de credits affichee au premier appel est une signature du moteur reellement invoque (ici pyperplan, Universite de Fribourg) : c'est la preuve que unified-planning delegue bien a un moteur externe plutot que d'emuler la planification en Python."
-   ]
+   "source": "### Interpretation : Resolution avec un seul solveur\n\n**Sortie obtenue** : pyperplan resout le labyrinthe et renvoie un statut `SOLVED_SATISFICING` avec un plan de **6 actions** menant le robot de L0 (entree) a L11 (sortie).\n\n**Le plan trouve suit le chemin court** traverse le corridor principal L0 -> L1 -> L2 -> L4 -> L7 -> L10, puis atteint L11. Les 7 impasses (L3, L5, L6, L8, L9, L12, L14) ne sont jamais visitees : l'heuristique h^FF interne a pyperplan les elimine des le depart, car elles eloignent du but au lieu d'en rapprocher. C'est precisement ce qu'un moteur de planification apporte de plus qu'une recherche aveugle (BFS/DFS), qui devrait explorer ces branches sans issue avant de les ecarter.\n\n**Workflow de resolution** :\n1. Creer le solveur (`OneshotPlanner`)\n2. Appeler `solve(problem)`\n3. Analyser le statut de retour\n4. Extraire le plan si succes\n\n**Statuts possibles** :\n- `SOLVED_SATISFICING` : Plan trouve (pas forcement optimal)\n- `SOLVED_OPTIMALLY` : Plan optimal trouve\n- `UNSATISFIABLE` : Probleme insoluble\n- `TIMEOUT` : Timeout atteint\n- `ERROR` : Erreur technique (solveur absent, probleme mal defini)\n\n> **Note technique** : La classe `OneshotPlanner` est un contexte manager qui gere les ressources du solveur. Il est important de l'utiliser dans un bloc `with` pour assurer la liberation des ressources. unified_planning affiche normalement une banniere de credits au premier appel d'un solveur (provenance du moteur, equipe de developpement) ; nous la supprimons globalement dans la cellule d'import, car elle contient le chemin d'installation de la bibliotheque (fuite de chemin machine). Reste que le statut `SOLVED_SATISFICING` et le plan produit sont la preuve que unified-planning delegue bien a un moteur externe (pyperplan, Universite de Fribourg) plutot que d'emuler la planification en Python."
   },
   {
    "cell_type": "markdown",
@@ -815,10 +802,10 @@
    "id": "cell-compare-solvers",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:23.379364Z",
-     "iopub.status.busy": "2026-06-09T05:15:23.378016Z",
-     "iopub.status.idle": "2026-06-09T05:15:23.886434Z",
-     "shell.execute_reply": "2026-06-09T05:15:23.885810Z"
+     "iopub.execute_input": "2026-08-08T12:12:40.928544Z",
+     "iopub.status.busy": "2026-08-08T12:12:40.927537Z",
+     "iopub.status.idle": "2026-08-08T12:12:41.332303Z",
+     "shell.execute_reply": "2026-08-08T12:12:41.331180Z"
     },
     "papermill": {
      "duration": 0.530151,
@@ -841,13 +828,7 @@
       "============================================================\n",
       "\n",
       "Test de pyperplan...\n",
-      "\u001b[96m  *** Credits ***\n",
-      "\u001b[0m\u001b[96m  * In operation mode `OneshotPlanner` at line 563 of `C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages\\unified_planning\\shortcuts.py`, \u001b[0m\u001b[96myou are using the following planning engine:\n",
-      "\u001b[0m\u001b[96m  * Engine name: pyperplan\n",
-      "  * Developers:  Albert-Ludwigs-Universität Freiburg (Yusra Alkhazraji, Matthias Frorath, Markus Grützner, Malte Helmert, Thomas Liebetraut, Robert Mattmüller, Manuela Ortlieb, Jendrik Seipp, Tobias Springenberg, Philip Stahl, Jan Wülfing)\n",
-      "\u001b[0m\u001b[96m  * Description: \u001b[0m\u001b[96mPyperplan is a lightweight STRIPS planner written in Python.\u001b[0m\u001b[96m\n",
-      "\u001b[0m\u001b[96m\n",
-      "\u001b[0m  Statut: SOLVED_SATISFICING, Temps: 0.018s, Plan: 6 actions\n",
+      "  Statut: SOLVED_SATISFICING, Temps: 0.023s, Plan: 6 actions\n",
       "\n",
       "Test de fast-downward...\n"
      ]
@@ -856,20 +837,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[96m  *** Credits ***\n",
-      "\u001b[0m\u001b[96m  * In operation mode `OneshotPlanner` at line 563 of `C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages\\unified_planning\\shortcuts.py`, \u001b[0m\u001b[96myou are using the following planning engine:\n",
-      "\u001b[0m\u001b[96m  * Engine name: Fast Downward\n",
-      "  * Developers:  Uni Basel team and contributors (cf. https://github.com/aibasel/downward/blob/main/README.md)\n",
-      "\u001b[0m\u001b[96m  * Description: \u001b[0m\u001b[96mFast Downward is a domain-independent classical planning system.\u001b[0m\u001b[96m\n",
-      "\u001b[0m\u001b[96m\n",
-      "\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Statut: SOLVED_SATISFICING, Temps: 0.972s, Plan: 6 actions\n"
+      "  Statut: SOLVED_SATISFICING, Temps: 0.373s, Plan: 6 actions\n"
      ]
     }
    ],
@@ -1000,10 +968,10 @@
    "id": "cell-display-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:24.048715Z",
-     "iopub.status.busy": "2026-06-09T05:15:24.048250Z",
-     "iopub.status.idle": "2026-06-09T05:15:24.058944Z",
-     "shell.execute_reply": "2026-06-09T05:15:24.057804Z"
+     "iopub.execute_input": "2026-08-08T12:12:41.335811Z",
+     "iopub.status.busy": "2026-08-08T12:12:41.335303Z",
+     "iopub.status.idle": "2026-08-08T12:12:41.345799Z",
+     "shell.execute_reply": "2026-08-08T12:12:41.344684Z"
     },
     "papermill": {
      "duration": 0.028075,
@@ -1025,11 +993,11 @@
       "================================================================================\n",
       "Solveur              | Statut          | Temps      | Longueur Plan  \n",
       "--------------------------------------------------------------------------------\n",
-      "pyperplan            | SOLVED_SATISFICING | 0.018s     | 6              \n",
-      "fast-downward        | SOLVED_SATISFICING | 0.972s     | 6              \n",
+      "pyperplan            | SOLVED_SATISFICING | 0.023s     | 6              \n",
+      "fast-downward        | SOLVED_SATISFICING | 0.373s     | 6              \n",
       "================================================================================\n",
       "\n",
-      "Plus rapide: pyperplan (0.018s)\n",
+      "Plus rapide: pyperplan (0.023s)\n",
       "Plan le plus court: pyperplan (6 actions)\n"
      ]
     }
@@ -1183,10 +1151,10 @@
    "id": "cell-durative-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:24.169969Z",
-     "iopub.status.busy": "2026-06-09T05:15:24.169594Z",
-     "iopub.status.idle": "2026-06-09T05:15:24.180061Z",
-     "shell.execute_reply": "2026-06-09T05:15:24.178485Z"
+     "iopub.execute_input": "2026-08-08T12:12:41.348808Z",
+     "iopub.status.busy": "2026-08-08T12:12:41.348808Z",
+     "iopub.status.idle": "2026-08-08T12:12:41.362064Z",
+     "shell.execute_reply": "2026-08-08T12:12:41.360949Z"
     },
     "papermill": {
      "duration": 0.021494,
@@ -1274,10 +1242,10 @@
    "id": "cell-numeric-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:24.220801Z",
-     "iopub.status.busy": "2026-06-09T05:15:24.220535Z",
-     "iopub.status.idle": "2026-06-09T05:15:24.227765Z",
-     "shell.execute_reply": "2026-06-09T05:15:24.226843Z"
+     "iopub.execute_input": "2026-08-08T12:12:41.365079Z",
+     "iopub.status.busy": "2026-08-08T12:12:41.365079Z",
+     "iopub.status.idle": "2026-08-08T12:12:41.374727Z",
+     "shell.execute_reply": "2026-08-08T12:12:41.373593Z"
     },
     "papermill": {
      "duration": 0.019714,
@@ -1355,10 +1323,10 @@
    "id": "cell-numeric-problem",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:24.318078Z",
-     "iopub.status.busy": "2026-06-09T05:15:24.317346Z",
-     "iopub.status.idle": "2026-06-09T05:15:24.326172Z",
-     "shell.execute_reply": "2026-06-09T05:15:24.325096Z"
+     "iopub.execute_input": "2026-08-08T12:12:41.377852Z",
+     "iopub.status.busy": "2026-08-08T12:12:41.377852Z",
+     "iopub.status.idle": "2026-08-08T12:12:41.387388Z",
+     "shell.execute_reply": "2026-08-08T12:12:41.386254Z"
     },
     "papermill": {
      "duration": 0.057425,
@@ -1440,10 +1408,10 @@
    "id": "95be6a9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:24.374659Z",
-     "iopub.status.busy": "2026-06-09T05:15:24.374184Z",
-     "iopub.status.idle": "2026-06-09T05:15:24.821368Z",
-     "shell.execute_reply": "2026-06-09T05:15:24.817654Z"
+     "iopub.execute_input": "2026-08-08T12:12:41.390737Z",
+     "iopub.status.busy": "2026-08-08T12:12:41.390397Z",
+     "iopub.status.idle": "2026-08-08T12:12:41.728828Z",
+     "shell.execute_reply": "2026-08-08T12:12:41.727821Z"
     },
     "papermill": {
      "duration": 0.460537,
@@ -1476,22 +1444,7 @@
       "  :effect (and (not (at ?l_from))\n",
       "...\n",
       "\n",
-      "Resolution avec fast-downward...\n",
-      "\u001b[96m  *** Credits ***\n",
-      "\u001b[0m\u001b[96m  * In operation mode `OneshotPlanner` at line 563 of `~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages\\unified_planning\\shortcuts.py`, \u001b[0m\u001b[96myou are using the following planning engine:\n",
-      "\u001b[0m\u001b[96m  * Engine name: Fast Downward\n",
-      "  * Developers:  Uni Basel team and contributors (cf. https://github.com/aibasel/downward/blob/main/README.md)\n",
-      "\u001b[0m\u001b[96m  * Description: \u001b[0m\u001b[96mFast Downward is a domain-independent classical planning system.\u001b[0m\u001b[96m\n",
-      "\u001b[0m\u001b[96m\n",
-      "\u001b[0m"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages\\unified_planning\\engines\\mixins\\oneshot_planner.py:83: UserWarning: We cannot establish whether Fast Downward can solve this problem!\n",
-      "  warn(msg)\n"
+      "Resolution avec fast-downward...\n"
      ]
     },
     {
@@ -1646,10 +1599,10 @@
    "id": "c4669d87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:24.939451Z",
-     "iopub.status.busy": "2026-06-09T05:15:24.939146Z",
-     "iopub.status.idle": "2026-06-09T05:15:24.944740Z",
-     "shell.execute_reply": "2026-06-09T05:15:24.943584Z"
+     "iopub.execute_input": "2026-08-08T12:12:41.731830Z",
+     "iopub.status.busy": "2026-08-08T12:12:41.731830Z",
+     "iopub.status.idle": "2026-08-08T12:12:41.737888Z",
+     "shell.execute_reply": "2026-08-08T12:12:41.736830Z"
     },
     "papermill": {
      "duration": 0.018567,
@@ -1720,14 +1673,54 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 14,
    "id": "planners-optimization-demo",
-   "execution_count": 20,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-08T12:12:41.740886Z",
+     "iopub.status.busy": "2026-08-08T12:12:41.740886Z",
+     "iopub.status.idle": "2026-08-08T12:12:42.597440Z",
+     "shell.execute_reply": "2026-08-08T12:12:42.596325Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Probleme : livraison A -> D, couts heterogenes par trajet.\n  Direct A->D       : 1 action, cout 10\n  Detour A->B->C->D : 3 actions, cout 1+1+1 = 3\n  => plan le plus court != plan le moins cher.\n\n=== fast-downward-opt (OPTIMAL : minimise le cout total) ===\n  Plan optimal    : SequentialPlan:\n    move(A, B)\n    move(B, C)\n    move(C, D)\n  Cout minimal    : 3\n  Nombre d'actions: 3\n\n=== fast-downward (SATISFICING : un plan, sans garantie de cout) ===\n  Plan satisficing : SequentialPlan:\n    move(A, D)\n  Cout obtenu      : 10\n  Nombre d'actions : 1\n\n>>> L'optimal (cout 3) bat le satisficing (cout 10) : l'optimization trouve un plan 7 unites moins cher -- avec PLUS d'actions.\n"
+     "output_type": "stream",
+     "text": [
+      "Probleme : livraison A -> D, couts heterogenes par trajet.\n",
+      "  Direct A->D       : 1 action, cout 10\n",
+      "  Detour A->B->C->D : 3 actions, cout 1+1+1 = 3\n",
+      "  => plan le plus court != plan le moins cher.\n",
+      "\n",
+      "=== fast-downward-opt (OPTIMAL : minimise le cout total) ===\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Plan optimal    : SequentialPlan:\n",
+      "    move(A, B)\n",
+      "    move(B, C)\n",
+      "    move(C, D)\n",
+      "  Cout minimal    : 3\n",
+      "  Nombre d'actions: 3\n",
+      "\n",
+      "=== fast-downward (SATISFICING : un plan, sans garantie de cout) ===\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Plan satisficing : SequentialPlan:\n",
+      "    move(A, D)\n",
+      "  Cout obtenu      : 10\n",
+      "  Nombre d'actions : 1\n",
+      "\n",
+      ">>> L'optimal (cout 3) bat le satisficing (cout 10) : l'optimization trouve un plan 7 unites moins cher -- avec PLUS d'actions.\n"
+     ]
     }
    ],
    "source": [
@@ -1813,8 +1806,7 @@
     "gap = plan_cost(sat_plan) - plan_cost(opt_plan)\n",
     "print(f\">>> L'optimal (cout {plan_cost(opt_plan)}) bat le satisficing \"\n",
     "      f\"(cout {plan_cost(sat_plan)}) : l'optimization trouve un plan \"\n",
-    "      f\"{gap} unites moins cher -- avec PLUS d'actions.\")\n",
-    ""
+    "      f\"{gap} unites moins cher -- avec PLUS d'actions.\")\n"
    ]
   },
   {
@@ -1896,14 +1888,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "cell-pddl-export",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:25.013248Z",
-     "iopub.status.busy": "2026-06-09T05:15:25.012855Z",
-     "iopub.status.idle": "2026-06-09T05:15:25.026337Z",
-     "shell.execute_reply": "2026-06-09T05:15:25.025309Z"
+     "iopub.execute_input": "2026-08-08T12:12:42.600567Z",
+     "iopub.status.busy": "2026-08-08T12:12:42.600567Z",
+     "iopub.status.idle": "2026-08-08T12:12:42.613275Z",
+     "shell.execute_reply": "2026-08-08T12:12:42.612139Z"
     },
     "papermill": {
      "duration": 0.031664,
@@ -1971,14 +1963,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "cell-pddl-problem",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:25.068744Z",
-     "iopub.status.busy": "2026-06-09T05:15:25.068364Z",
-     "iopub.status.idle": "2026-06-09T05:15:25.076567Z",
-     "shell.execute_reply": "2026-06-09T05:15:25.075625Z"
+     "iopub.execute_input": "2026-08-08T12:12:42.617399Z",
+     "iopub.status.busy": "2026-08-08T12:12:42.616416Z",
+     "iopub.status.idle": "2026-08-08T12:12:42.631671Z",
+     "shell.execute_reply": "2026-08-08T12:12:42.630471Z"
     },
     "papermill": {
      "duration": 0.020968,
@@ -2000,24 +1992,44 @@
       " (:domain robot_navigation-domain)\n",
       " (:objects\n",
       "   robot1 - robot\n",
-      "   l0 l1 l2 l3 l4 - location\n",
+      "   l0 l1 l2 l3 l4 l5 l6 l7 l8 l9 l10 l11 l12 l13 l14 - location\n",
       " )\n",
       " (:init\n",
       "              (connected l0 l1)\n",
       "              (connected l1 l0)\n",
       "              (connected l1 l2)\n",
       "              (connected l2 l1)\n",
-      "              (connected l0 l3)\n",
-      "              (connected l3 l0)\n",
       "              (connected l2 l4)\n",
       "              (connected l4 l2)\n",
-      "              (connected l3 l4)\n",
-      "              (connected l4 l3)\n",
+      "              (connected l4 l7)\n",
+      "              (connected l7 l4)\n",
+      "              (connected l7 l10)\n",
+      "              (connected l10 l7)\n",
+      "              (connected l10 l13)\n",
+      "              (connected l13 l10)\n",
+      "              (connected l10 l11)\n",
+      "              (connected l11 l10)\n",
+      "              (connected l13 l11)\n",
+      "              (connected l11 l13)\n",
+      "              (connected l1 l3)\n",
+      "              (connected l3 l1)\n",
+      "              (connected l4 l5)\n",
+      "              (connected l5 l4)\n",
+      "              (connected l2 l6)\n",
+      "              (connected l6 l2)\n",
+      "              (connected l7 l8)\n",
+      "              (connected l8 l7)\n",
+      "              (connected l2 l9)\n",
+      "              (connected l9 l2)\n",
+      "              (connected l10 l12)\n",
+      "              (connected l12 l10)\n",
+      "              (connected l13 l14)\n",
+      "              (connected l14 l13)\n",
       "              (robot_at robot1 l0)\n",
       "              (visited l0)\n",
       " )\n",
       " (:goal (and \n",
-      "           (robot_at robot1 l4)\n",
+      "           (robot_at robot1 l11)\n",
       "        )\n",
       " )\n",
       ")\n",
@@ -2054,14 +2066,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "cell-pddl-import",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:25.120964Z",
-     "iopub.status.busy": "2026-06-09T05:15:25.120427Z",
-     "iopub.status.idle": "2026-06-09T05:15:25.196032Z",
-     "shell.execute_reply": "2026-06-09T05:15:25.194699Z"
+     "iopub.execute_input": "2026-08-08T12:12:42.635218Z",
+     "iopub.status.busy": "2026-08-08T12:12:42.635218Z",
+     "iopub.status.idle": "2026-08-08T12:12:42.738912Z",
+     "shell.execute_reply": "2026-08-08T12:12:42.738275Z"
     },
     "papermill": {
      "duration": 0.089801,
@@ -2079,7 +2091,7 @@
      "text": [
       "Probleme recharge: robot_navigation-problem\n",
       "  Actions: 1\n",
-      "  Objets: 6\n",
+      "  Objets: 16\n",
       "  Buts: 1\n",
       "\n",
       "Verification: probleme original vs recharge\n",
@@ -2217,14 +2229,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "cell-best-practices-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:25.281185Z",
-     "iopub.status.busy": "2026-06-09T05:15:25.280878Z",
-     "iopub.status.idle": "2026-06-09T05:15:25.724335Z",
-     "shell.execute_reply": "2026-06-09T05:15:25.722817Z"
+     "iopub.execute_input": "2026-08-08T12:12:42.742039Z",
+     "iopub.status.busy": "2026-08-08T12:12:42.742039Z",
+     "iopub.status.idle": "2026-08-08T12:12:42.771799Z",
+     "shell.execute_reply": "2026-08-08T12:12:42.770650Z"
     },
     "papermill": {
      "duration": 0.464503,
@@ -2242,24 +2254,8 @@
      "text": [
       "\n",
       "Essai avec pyperplan...\n",
-      "  ERREUR: \n",
-      "\n",
-      "Essai avec fast-downward...\n",
-      "\u001b[96m  *** Credits ***\n",
-      "\u001b[0m\u001b[96m  * In operation mode `OneshotPlanner` at line 563 of `~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages\\unified_planning\\shortcuts.py`, \u001b[0m\u001b[96myou are using the following planning engine:\n",
-      "\u001b[0m\u001b[96m  * Engine name: Fast Downward\n",
-      "  * Developers:  Uni Basel team and contributors (cf. https://github.com/aibasel/downward/blob/main/README.md)\n",
-      "\u001b[0m\u001b[96m  * Description: \u001b[0m\u001b[96mFast Downward is a domain-independent classical planning system.\u001b[0m\u001b[96m\n",
-      "\u001b[0m\u001b[96m\n",
-      "\u001b[0m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "  SUCCES: Plan trouve!\n",
-      "  Longueur: 2 actions\n"
+      "  Longueur: 6 actions\n"
      ]
     }
    ],
@@ -2331,26 +2327,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interpretation : Resolution robuste avec gestion d'erreurs\n",
-    "\n",
-    "**Sortie obtenue** : Après echec de pyperplan, **fast-downward a reussi** : `SUCCES: Plan trouve! Longueur: 2 actions`. Le fallback a fonctionne.\n",
-    "\n",
-    "| Solveur | Statut | Temps | Plan |\n",
-    "|---------|--------|-------|------|\n",
-    "| pyperplan | ERROR | 0.000s | N/A |\n",
-    "| fast-downward | **SUCCES** | -- | **2 actions** |\n",
-    "\n",
-    "**Lecon** : c'est précisément l'intérêt du pattern solveur-preferé + fallback. Quand pyperplan n'est pas disponible, on bascule sur fast-downward, qui produit le plan attendu. L'exécution robuste ne signifie pas que tous les solveurs doivent reussir, mais qu'au moins un degrade gracieusement vers une solution.\n",
-    "\n",
-    "**Workflow robuste** :\n",
-    "1. Essayer le solveur preferé (ici pyperplan, leger)\n",
-    "2. En cas d'echec, essayer le solveur de fallback (ici fast-downward)\n",
-    "3. Gerer les différents statuts (SOLVED, UNSOLVABLE, TIMEOUT)\n",
-    "4. Afficher des statistiques detaillees si disponibles\n",
-    "\n",
-    "> **Note technique** : Dans un environnement de production, il est recommande d'installer les solveurs via les packages UP (`up-fast-downward`, `up-pyperplan`) plutot que d'utiliser les installations système, ce qui garantit la compatibilite des versions.\n"
-   ]
+   "source": "### Interpretation : Resolution robuste avec gestion d'erreurs\n\n**Sortie obtenue** : le solveur preferé (pyperplan) reussit du premier coup : `SUCCES: Plan trouve! Longueur: 6 actions`. La fonction `solve_robust` retourne immediatement le plan, sans avoir besoin d'invoquer le solveur de fallback (fast-downward).\n\n| Solveur | Statut | Plan |\n|---------|--------|------|\n| pyperplan (preferé) | **SUCCES** | **6 actions** |\n| fast-downward (fallback) | non invoqué | -- |\n\n**Lecon** : avec les deux solveurs installes (`up-pyperplan`, `up-fast-downward`), pyperplan resout le labyrinthe tout seul. L'interet du pattern solveur-preferé + fallback est precisement de rester robuste **meme quand** le solveur preferé est absent ou echoue : le code essaie pyperplan, et seulement s'il echoue bascule sur fast-downward. L'exécution robuste ne signifie pas que tous les solveurs doivent reussir, mais qu'au moins un degrade gracieusement vers une solution.\n\n**Workflow robuste** :\n1. Essayer le solveur preferé (ici pyperplan, leger)\n2. En cas d'echec, essayer le solveur de fallback (ici fast-downward)\n3. Gerer les différents statuts (SOLVED, UNSOLVABLE, TIMEOUT)\n4. Afficher des statistiques detaillees si disponibles\n\n> **Note technique** : Dans un environnement de production, il est recommande d'installer les solveurs via les packages UP (`up-fast-downward`, `up-pyperplan`) plutot que d'utiliser les installations système, ce qui garantit la compatibilite des versions. Si pyperplan n'etait pas installe, c'est fast-downward qui aurait produit le plan : le code de fallback est pret, simplement non declenche sur cette instance."
   },
   {
    "cell_type": "markdown",
@@ -2467,14 +2444,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "t5fwysijna8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:25.895962Z",
-     "iopub.status.busy": "2026-06-09T05:15:25.895501Z",
-     "iopub.status.idle": "2026-06-09T05:15:25.905769Z",
-     "shell.execute_reply": "2026-06-09T05:15:25.901718Z"
+     "iopub.execute_input": "2026-08-08T12:12:42.775224Z",
+     "iopub.status.busy": "2026-08-08T12:12:42.775224Z",
+     "iopub.status.idle": "2026-08-08T12:12:42.781483Z",
+     "shell.execute_reply": "2026-08-08T12:12:42.780328Z"
     },
     "papermill": {
      "duration": 0.030484,
@@ -2643,14 +2620,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "535e7452",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T05:15:26.057814Z",
-     "iopub.status.busy": "2026-06-09T05:15:26.057402Z",
-     "iopub.status.idle": "2026-06-09T05:15:26.062591Z",
-     "shell.execute_reply": "2026-06-09T05:15:26.061477Z"
+     "iopub.execute_input": "2026-08-08T12:12:42.784483Z",
+     "iopub.status.busy": "2026-08-08T12:12:42.784483Z",
+     "iopub.status.idle": "2026-08-08T12:12:42.796659Z",
+     "shell.execute_reply": "2026-08-08T12:12:42.794538Z"
     },
     "papermill": {
      "duration": 0.018364,
@@ -2666,7 +2643,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Exercice a completer"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -2685,22 +2669,22 @@
  ],
  "metadata": {
   "cost": {
-   "api_usd_est": 0.0,
    "api_provider": "none",
-   "qcc_tokens_est": 0,
+   "api_usd_est": 0,
    "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": true,
    "external_account": "none",
    "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-08-03",
+   "network": true,
+   "notes": "unified-planning + up-fast-downward solver; deterministic PDDL",
+   "qcc_tokens_est": 0,
    "reduced_pedagogical": null,
    "reproducibility": "HIGH",
-   "metadata_written": "2026-08-03",
    "validator": "papermill",
-   "notes": "unified-planning + up-fast-downward solver; deterministic PDDL"
+   "vram_gb": 0,
+   "vram_tier": "NONE"
   },
   "kernelspec": {
    "display_name": "Python 3",
@@ -2717,7 +2701,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.12.13"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: DEEP/docs-translation #10032

## TL;DR

`Planners-11-Unified-Planning.ipynb` leaked machine paths in committed outputs via **two distinct unified_planning mechanisms**. This PR suppresses both at the source (Stop & Repair), installs the real solvers (regle F), re-executes end-to-end, and reconciles the prose that the re-exec made stale. See #10000 / #9997.

## Root cause (two leak mechanisms)

1. **Credits banner**: unified_planning prints a `*** Credits ***` banner at the first solver call, including the absolute source path of the library (`C:\Users\jsboi\AppData\Local\Packages\...\site-packages\unified_planning\shortcuts.py`). Leaked in the pyperplan solve cell + the multi-solver comparison cell (2 banners).
2. **UserWarning filename**: when fast-downward is asked to solve a numeric-fluents problem, unified_planning emits `UserWarning: We cannot establish whether Fast Downward can solve this problem!` — Python prepends the warning's source filename, which under the `coursia-ml-training` conda kernel is the absolute env path `C:\ProgramData\miniconda3\envs\coursia-ml-training\...\oneshot_planner.py`. Leaked in the robot_battery example cell. (Under the previous Store-app kernel this showed as `~\AppData\...` = not a leak; switching to the conda kernel expanded it to a full path.)

## Fix (cause + re-exec, NOT output scrubbing — Stop & Repair secrets-hygiene §6)

In the import cell, once globally:
- `get_environment().credits_stream = None` — suppresses the credits banner (the banner itself prints this exact suggestion; the existing optimization-demo cell in this notebook already uses it).
- `warnings.filterwarnings("ignore", message=r"We cannot establish whether")` — suppresses the benign informational warning (the `INTERNAL_ERROR` status + interpretation already convey "FD can't do numeric fluents"; the warning is redundant AND leaks a path).

Both solvers installed per regle F (`up-pyperplan` 2.1, `up-fast-downward` 0.5.2) so the re-exec runs the REAL engines (SOTA-OK), not workarounds.

## Validation (firsthand, post-fix re-exec)

| Check | Result |
|-------|--------|
| nbconvert end-to-end (kernel `coursia-ml-training`) | EXIT 0 |
| Path leaks — full marker set (drive letters, ipykernel, miniconda, ProgramData, Users\, AppData, .nuget, OneDrive) | **0** |
| Credits banners remaining | **0** |
| Code cells with execution_count=null | 0 / 20 |
| Error outputs | 0 |
| Solve results preserved | pyperplan 6 actions; fast-downward 6 actions; optimization cout 3 (optimal) vs 10 (satisficing) |

## Prose reconciliation (direct consequence of the fix + mandatory re-exec C.2)

The end-to-end re-exec regenerated all outputs honestly; two interpretation cells became stale and are reconciled:
- `ed11f1e2` described the credits banner as visible proof of the external engine -> updated: banner suppressed for path hygiene, the `SOLVED_SATISFICING` result + produced plan are the proof.
- `3d167717` claimed "pyperplan ERROR, fast-downward fallback 2 actions" -> updated: with both solvers installed, pyperplan now succeeds (6 actions); the fallback code is present but not triggered this run.
- Honest side effect: the PDDL export cell now correctly shows 15 locations (l0-l14) matching the source; the committed output was stale (only 5 locations, from an older problem version). Solve times drift slightly across re-execs (non-deterministic); the "~"-qualified comparison prose is left as-is (chasing non-deterministic times is the determinism-gate anti-pattern).

## Scope boundary

- 1 file changed (Planners-11 notebook), 1 domain (Planners), 1 feature (path-leak fix + coherence).
- No exercise stub modified (C.1): the exercise stubs (recharge, chantier temporel, synthese comparaison) untouched.
- No twin registry entry for Planners-11 (entries stop at planners-9).
- Catalogue byte-identical to main.

See #10000, #9997, #3436.
