### PR TITLE
i18n(parity,#10041): parity gate for xxx_<lang>.ipynb provenance vs source (grain B)

### DIFF
--- a/.github/workflows/translation-parity.yml
+++ b/.github/workflows/translation-parity.yml
@@ -1,0 +1,102 @@
+name: Translation parity gate (advisory)
+
+# Epic #10038 grain B — parity gate for xxx_<lang>.ipynb provenance.
+# Cf. issue #10041 acceptance : workflow advisory (label, exit 0 phase 1).
+# Phase 1 promotion criterion (B -> A) : 0 false-positif in 14 j sur PR touchant
+# xxx_<lang>.ipynb. Tant que non promu, ce workflow est advisory et ne bloque
+# PAS la PR (continue-on-error: true, no fail-fast).
+#
+# Reads:
+#   - scripts/translation/check_translation_parity.py
+#   - xxx_<lang>.ipynb pairs on disk
+# Writes:
+#   - workflow run annotations (label-only, exit 0)
+# Promotes to required when the 14-day advisory period reports 0 defects.
+
+on:
+  pull_request:
+    paths:
+      - "*.ipynb"
+      - "scripts/translation/check_translation_parity.py"
+      - ".github/workflows/translation-parity.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Python setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Compute parity on native pairs (advisory)
+        id: parity
+        continue-on-error: true
+        run: |
+          python scripts/translation/check_translation_parity.py --json-only > parity-report.json
+          cat parity-report.json
+
+      - name: Annote verdict on PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let report = null;
+            try {
+              report = JSON.parse(fs.readFileSync('parity-report.json', 'utf8'));
+            } catch (e) {
+              core.warning('parity-report.json absent ou illisible : ' + e.message);
+              return;
+            }
+            if (!report) return;
+            const verdict = report.verdict;
+            const blocking = report.blocking_count;
+            const advisory = report.advisory_count;
+            const pairs = report.pair_count;
+            const label = verdict === 'OK' ? 'parity-ok'
+              : verdict === 'OK_WITH_ADVISORIES' ? 'parity-advisory'
+              : 'parity-violation';
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: [label],
+              });
+            } catch (e) {
+              core.warning('Label add failed : ' + e.message);
+            }
+            if (verdict !== 'OK') {
+              const lines = report.pairs
+                .filter(p => p.verdict !== 'OK')
+                .slice(0, 10)
+                .map(p => `- \`${p.translation}\` (lang=${p.lang}) — ${p.verdict} (${(p.anomalies || []).length} anomalies)`);
+              const body = [
+                `**Translation parity gate (advisory, grain B Epic #10038)**`,
+                ``,
+                `- verdict: \`${verdict}\``,
+                `- pairs scanned: ${pairs}`,
+                `- blocking: ${blocking}`,
+                `- advisory: ${advisory}`,
+                ``,
+                ...lines,
+                ``,
+                `Re-run with \`python scripts/translation/check_translation_parity.py\` locally.`,
+                `Promotion to blocking planned after 14j advisory post-merge.`,
+              ].join('\n');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/scripts/translation/check_translation_parity.py
+++ b/scripts/translation/check_translation_parity.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""Parity gate — verify ``xxx_<lang>.ipynb`` provenance vs source ``xxx.ipynb``.
+
+Companion to :file:`check_perimeter.py` (grain E) and :file:`check_translation_sync.py`
+(T2 hash-based drift) : this is the **structural parity gate** — for every pair
+``(xxx.ipynb, xxx_<lang>.ipynb)`` on disk, it enforces the four invariants that
+a T4-rendered translation **must** satisfy (#10041 grain B / Epic #10038).
+
+Why this matters (Epic #10038 §4 D3, grain B acceptance)
+=======================================================
+
+T4 (``render_notebook.py``, grain A MERGED #10040) produces ``xxx_<lang>.ipynb``
+by replacing markdown cells with translations from the CSV and copying code cells
+byte-for-byte. A rendered translation is therefore a **derived artifact** : its
+relationship to the source must be machine-verifiable, otherwise a future re-render
+or a manual edit can silently degrade the catalog (drifted code, swapped cell order,
+FR leaked through, fabricated output).
+
+This script enforces four invariants per pair (cf #10041 §2) :
+
+| # | Invariant                                       | Verdict if violated  |
+|---|-------------------------------------------------|----------------------|
+| 1 | Code cells byte-identical (source + outputs + execution_count) | ``CODE_DRIFT``         |
+| 2 | Cell count + order + ``cell_id`` sequence match | ``STRUCTURE_DRIFT``  |
+| 3 | No markdown cell identical to FR without declared reason | ``FR_CONTAM`` (advisory) |
+| 4 | No output in translation absent from the source | ``OUTPUT_FABRICATED`` |
+
+Invariant 3 (``FR_CONTAM``) is **advisory by default** : a translated notebook
+may legitimately keep an FR string in a code comment or in a string literal —
+the gate flags the cell but does not exit 1 unless ``--strict-fr`` is passed.
+
+Invariant 4 (``OUTPUT_FABRICATED``) catches the silent regression where a
+notebook is hand-edited to inject outputs the source never produced — the
+``outputs`` array is part of the T4 byte-identity invariant for code cells.
+
+Usage
+-----
+
+::
+
+    # Default: scan repo for xxx_<lang>.ipynb pairs, verify against xxx.ipynb
+    python scripts/translation/check_translation_parity.py
+
+    # Custom paths (CI)
+    python scripts/translation/check_translation_parity.py \\
+        --repo-root . \\
+        --langs en,ru
+
+    # Machine-readable
+    python scripts/translation/check_translation_parity.py --json-only
+
+Exit codes
+----------
+
+- ``0``  all invariants satisfied (or only FR_CONTAM advisories)
+- ``1``  one or more CODE_DRIFT / STRUCTURE_DRIFT / OUTPUT_FABRICATED found
+- ``2``  filesystem error (repo root absent, notebook unreadable)
+
+Verdicts
+--------
+
+- ``OK``                  — pair satisfies all four invariants
+- ``CODE_DRIFT``          — code cell bytes / outputs / execution_count differ
+- ``STRUCTURE_DRIFT``     — cell count, order, or ``cell_id`` differs
+- ``FR_CONTAM``           — markdown cell text identical to FR without
+  declared reason (advisory, exit 0 by default; use ``--strict-fr`` to
+  promote to blocking)
+- ``OUTPUT_FABRICATED``   — translation has an ``outputs`` array on a code
+  cell that is absent from the source
+
+See :file:`tests/test_check_translation_parity.py` for the full coverage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+# Convention #1650 : un notebook xxx.ipynb source + xxx_<lang>.ipynb traduit.
+# Langues cibles = ratifiees #4957 §1 (meme liste que PERIMETER + sync).
+TARGET_LANGS = ["en", "es", "ar", "fa", "zh", "ru", "pt"]
+
+# Seuil de longueur pour le verdict FR_CONTAM : un texte trop court (< 4 chars
+# post-normalisation) est un faux-ami structurel (token unique, chiffre, ponctuation).
+# Meme garde que check_translation_sync._is_fr_contam (cohérence inter-scripts).
+FR_CONTAM_MIN_LEN = 4
+
+
+# ---------------------------------------------------------------------------
+# Notebook loading
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CellRecord:
+    """Canonical record of one cell from a notebook, normalized for comparison."""
+
+    cell_id: str
+    cell_type: str  # "code" | "markdown"
+    source: str  # joined source list (may be empty)
+    outputs: List[dict]  # verbatim (deep-copied) — only relevant for code cells
+    execution_count: Optional[int]  # only relevant for code cells
+    metadata: Dict[str, object] = field(default_factory=dict)
+
+
+def load_cells(nb_path: Path) -> Tuple[List[CellRecord], Optional[str]]:
+    """Load cells from a notebook. Returns ``(cells, error)`` — error is non-None
+    iff the file is missing or malformed JSON.
+
+    The cells list preserves notebook order, suitable for STRUCTURE_DRIFT
+    comparison via list equality.
+    """
+    if not nb_path.exists():
+        return [], f"notebook absent : {nb_path}"
+    try:
+        nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return [], f"notebook illisible : {nb_path} ({exc})"
+    records: List[CellRecord] = []
+    for cell in nb.get("cells", []):
+        cid = cell.get("id", "")
+        ctype = cell.get("cell_type", "")
+        if ctype not in ("code", "markdown"):
+            continue
+        if not cid:
+            # Skip un-id'd cells (nbformat < 4.5) — they break STRUCTURE_DRIFT.
+            return [], f"cellule sans id dans {nb_path} (nbformat < 4.5 ?)"
+        records.append(
+            CellRecord(
+                cell_id=cid,
+                cell_type=ctype,
+                source="".join(cell.get("source", [])),
+                outputs=list(cell.get("outputs", [])) if ctype == "code" else [],
+                execution_count=cell.get("execution_count") if ctype == "code" else None,
+                metadata=dict(cell.get("metadata", {})),
+            )
+        )
+    return records, None
+
+
+# ---------------------------------------------------------------------------
+# Pair enumeration
+# ---------------------------------------------------------------------------
+
+
+_SUFFIX_RE = re.compile(r"^(?P<stem>.+)_(?P<lang>" + "|".join(TARGET_LANGS) + r")$")
+
+
+def discover_pairs(
+    repo_root: Path, langs: List[str]
+) -> List[Tuple[Path, Path, str, str]]:
+    """Find every ``(xxx.ipynb, xxx_<lang>.ipynb)`` pair on disk.
+
+    Returns a list of ``(source_path, translation_path, stem, lang)`` tuples.
+    ``stem`` is the source's bare name (e.g. ``FT-01-Introduction-FineTuning``) —
+    callers use it for human-readable reporting. Each pair is reported ONCE,
+    identified by ``(resolved_src_path, lang)``.
+
+    Two branches:
+    - **source-present** (the typical case): walk finds ``X.ipynb``, derives
+      ``X_en.ipynb``; pair emitted with src=X.ipynb.
+    - **orphan** (translation lost its source): walk finds ``X_en.ipynb``
+      but no ``X.ipynb``; pair emitted with src_path=X_en.ipynb (the
+      translation acts as its own source stub), so downstream STRUCTURE_DRIFT
+      + READ_ERROR flag it. Orphans surface without scanning a separate index.
+
+    Pattern note: we iterate every ``*.ipynb`` once and use a ``seen`` set
+    keyed by ``(resolved_path, lang)`` to avoid the double-emit trap (the
+    source branch emits a pair, the translation branch would also see the
+    translation and re-derive the source). On Windows the resolve() call
+    normalizes the case + the path separators; on POSIX it canonicalizes
+    symlinks, which is what we want for both.
+    """
+    pairs: List[Tuple[Path, Path, str, str]] = []
+    seen: Set[Tuple[str, str]] = set()
+    for nb_path in sorted(repo_root.rglob("*.ipynb")):
+        stem = nb_path.stem
+        suffix_match = _SUFFIX_RE.match(stem)
+        if suffix_match and suffix_match.group("lang") in langs:
+            # Translation file — derive the (possibly-missing) source.
+            src_stem = suffix_match.group("stem")
+            lang = suffix_match.group("lang")
+            src_path = nb_path.with_name(src_stem + ".ipynb")
+            key = (str(src_path.resolve()), lang)
+            if key in seen:
+                continue
+            seen.add(key)
+            # Orphan tolerated : if the source is missing, src_path is the
+            # translation path itself; downstream check_invariants + READ_ERROR
+            # path in main() will flag it.
+            pairs.append((src_path, nb_path, src_stem, lang))
+            continue
+        # Source file — look for translations.
+        for lang in langs:
+            trd_path = nb_path.with_name(stem + f"_{lang}.ipynb")
+            if trd_path.exists():
+                key = (str(nb_path.resolve()), lang)
+                if key in seen:
+                    continue
+                seen.add(key)
+                pairs.append((nb_path, trd_path, stem, lang))
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Invariant computation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Anomaly:
+    verdict: str
+    cell_id: str = ""
+    detail: Dict[str, object] = field(default_factory=dict)
+
+
+def check_invariants(
+    src_cells: List[CellRecord],
+    trd_cells: List[CellRecord],
+    *,
+    strict_fr: bool = False,
+) -> List[Anomaly]:
+    """Apply the four invariants from issue #10041. Returns the list of anomalies.
+
+    Parameters
+    ----------
+    src_cells
+        Cells of the source ``xxx.ipynb`` (already loaded).
+    trd_cells
+        Cells of the translation ``xxx_<lang>.ipynb`` (already loaded).
+    strict_fr
+        If True, ``FR_CONTAM`` violations are added to the verdict list that
+        gates exit code 1. By default, FR_CONTAM is advisory only (exit 0).
+    """
+    anomalies: List[Anomaly] = []
+
+    # --- Invariant 2 : STRUCTURE_DRIFT (count + ordre + cell_id) -----------
+    src_ids = [c.cell_id for c in src_cells]
+    trd_ids = [c.cell_id for c in trd_cells]
+    if src_ids != trd_ids:
+        # Build a structured diff : set(src) - set(trd) = cells deleted,
+        # set(trd) - set(src) = cells added, zip-mismatch = reorder.
+        added = sorted(set(trd_ids) - set(src_ids))
+        deleted = sorted(set(src_ids) - set(trd_ids))
+        anomalies.append(
+            Anomaly(
+                verdict="STRUCTURE_DRIFT",
+                detail={
+                    "src_count": len(src_ids),
+                    "trd_count": len(trd_ids),
+                    "added_cells": added[:10],
+                    "deleted_cells": deleted[:10],
+                    "reorder_detected": len(added) == 0
+                    and len(deleted) == 0
+                    and src_ids != trd_ids,
+                },
+            )
+        )
+        # If structure is broken, the per-cell invariants (CODE_DRIFT, FR_CONTAM)
+        # cannot be evaluated safely — we return early after the structure verdict.
+        return anomalies
+
+    # --- Per-cell invariants ----------------------------------------------
+    for src, trd in zip(src_cells, trd_cells):
+        # Invariant 1 : CODE_DRIFT (code cell bytes + outputs + execution_count)
+        if src.cell_type == "code" and trd.cell_type == "code":
+            if src.source != trd.source:
+                anomalies.append(
+                    Anomaly(
+                        verdict="CODE_DRIFT",
+                        cell_id=src.cell_id,
+                        detail={
+                            "field": "source",
+                            "src_sha": _sha(src.source)[:16],
+                            "trd_sha": _sha(trd.source)[:16],
+                            "src_len": len(src.source),
+                            "trd_len": len(trd.source),
+                        },
+                    )
+                )
+            if src.outputs != trd.outputs:
+                anomalies.append(
+                    Anomaly(
+                        verdict="CODE_DRIFT",
+                        cell_id=src.cell_id,
+                        detail={
+                            "field": "outputs",
+                            "src_n_outputs": len(src.outputs),
+                            "trd_n_outputs": len(trd.outputs),
+                            "src_execution_count": src.execution_count,
+                            "trd_execution_count": trd.execution_count,
+                        },
+                    )
+                )
+            if src.execution_count != trd.execution_count:
+                anomalies.append(
+                    Anomaly(
+                        verdict="CODE_DRIFT",
+                        cell_id=src.cell_id,
+                        detail={
+                            "field": "execution_count",
+                            "src": src.execution_count,
+                            "trd": trd.execution_count,
+                        },
+                    )
+                )
+
+        # Invariant 4 : OUTPUT_FABRICATED — translation has outputs the
+        # source lacks. Catches hand-edited translations that inject fake
+        # outputs. (The reverse case is covered by CODE_DRIFT above.)
+        if src.cell_type == "code" and trd.cell_type == "code":
+            if not src.outputs and trd.outputs:
+                anomalies.append(
+                    Anomaly(
+                        verdict="OUTPUT_FABRICATED",
+                        cell_id=src.cell_id,
+                        detail={
+                            "trd_n_outputs": len(trd.outputs),
+                            "trd_execution_count": trd.execution_count,
+                        },
+                    )
+                )
+
+        # Invariant 3 : FR_CONTAM — markdown cell text identical to source FR.
+        # Advisory by default; promoted to blocking under --strict-fr.
+        if (
+            src.cell_type == "markdown"
+            and trd.cell_type == "markdown"
+            and strict_fr
+        ):
+            if (
+                _normalize(src.source) == _normalize(trd.source)
+                and len(_normalize(src.source)) >= FR_CONTAM_MIN_LEN
+            ):
+                anomalies.append(
+                    Anomaly(
+                        verdict="FR_CONTAM",
+                        cell_id=src.cell_id,
+                        detail={
+                            "src_len": len(src.source),
+                            "trd_len": len(trd.source),
+                        },
+                    )
+                )
+        elif (
+            src.cell_type == "markdown"
+            and trd.cell_type == "markdown"
+            and not strict_fr
+        ):
+            # Advisory path : emit but flag as non-blocking.
+            if (
+                _normalize(src.source) == _normalize(trd.source)
+                and len(_normalize(src.source)) >= FR_CONTAM_MIN_LEN
+            ):
+                anomalies.append(
+                    Anomaly(
+                        verdict="FR_CONTAM",
+                        cell_id=src.cell_id,
+                        detail={
+                            "advisory": True,
+                            "src_len": len(src.source),
+                            "trd_len": len(trd.source),
+                        },
+                    )
+                )
+
+    return anomalies
+
+
+def _normalize(text: str) -> str:
+    """Meme garde que check_translation_sync.normalize — anti faux-drift cosmétique."""
+    lines = [line.rstrip() for line in text.splitlines()]
+    return "\n".join(lines).strip("\n")
+
+
+def _sha(text: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Reporting + CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description=(
+            "Parity gate — verify xxx_<lang>.ipynb provenance vs xxx.ipynb "
+            "(Epic #10038 grain B)."
+        )
+    )
+    p.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path("."),
+        help="Root of the repo to scan (default: cwd).",
+    )
+    p.add_argument(
+        "--langs",
+        type=str,
+        default=",".join(TARGET_LANGS),
+        help=f"Comma-separated list of target langs (default: {','.join(TARGET_LANGS)}).",
+    )
+    p.add_argument(
+        "--strict-fr",
+        action="store_true",
+        help="Promote FR_CONTAM from advisory (exit 0) to blocking (exit 1).",
+    )
+    p.add_argument(
+        "--json-only",
+        action="store_true",
+        help="Emit JSON only (no human-readable summary).",
+    )
+    p.add_argument(
+        "--ignore-dir",
+        action="append",
+        default=[".git", ".github", "_archives", ".claude", "__pycache__"],
+        help="Directory name to skip during the walk (repeatable).",
+    )
+    args = p.parse_args(argv)
+
+    repo_root: Path = args.repo_root.resolve()
+    if not repo_root.is_dir():
+        print(f"ERROR: --repo-root introuvable : {repo_root}", file=sys.stderr)
+        return 2
+
+    langs = [lang.strip() for lang in args.langs.split(",") if lang.strip()]
+    bad = [lang for lang in langs if lang not in TARGET_LANGS]
+    if bad:
+        print(f"ERROR: langues inconnues : {bad}", file=sys.stderr)
+        return 2
+
+    # Walk : skip ignore-dir.
+    pairs = discover_pairs(repo_root, langs)
+
+    report_pairs: List[Dict[str, object]] = []
+    blocking_count = 0
+    advisory_count = 0
+
+    for src_path, trd_path, stem, lang in pairs:
+        src_cells, src_err = load_cells(src_path)
+        trd_cells, trd_err = load_cells(trd_path)
+        if src_err or trd_err:
+            report_pairs.append(
+                {
+                    "source": str(src_path.relative_to(repo_root)),
+                    "translation": str(trd_path.relative_to(repo_root)),
+                    "lang": lang,
+                    "verdict": "READ_ERROR",
+                    "error": src_err or trd_err,
+                }
+            )
+            blocking_count += 1
+            continue
+        anomalies = check_invariants(
+            src_cells, trd_cells, strict_fr=args.strict_fr
+        )
+        # Classify : CODE_DRIFT / STRUCTURE_DRIFT / OUTPUT_FABRICATED are always
+        # blocking; FR_CONTAM is blocking only under strict-fr. The strict_fr
+        # flag is already applied inside check_invariants (the anomaly's
+        # detail.advisory=False under strict-fr). So we only need to test
+        # verdict membership in a blocking-list that ORs strict path.
+        blocking_verdicts = {"CODE_DRIFT", "STRUCTURE_DRIFT", "OUTPUT_FABRICATED"}
+        if args.strict_fr:
+            blocking_verdicts.add("FR_CONTAM")
+        blocking = [a for a in anomalies if a.verdict in blocking_verdicts]
+        advisories = [
+            a
+            for a in anomalies
+            if a.verdict == "FR_CONTAM" and a.detail.get("advisory")
+        ]
+        if blocking:
+            blocking_count += 1
+            verdict = "BLOCKED"
+        elif advisories:
+            verdict = "OK_WITH_ADVISORIES"
+        else:
+            verdict = "OK"
+        advisory_count += len(advisories)
+        report_pairs.append(
+            {
+                "source": str(src_path.relative_to(repo_root)),
+                "translation": str(trd_path.relative_to(repo_root)),
+                "lang": lang,
+                "verdict": verdict,
+                "anomalies": [
+                    {
+                        "verdict": a.verdict,
+                        "cell_id": a.cell_id,
+                        "detail": a.detail,
+                    }
+                    for a in anomalies
+                ],
+            }
+        )
+
+    overall = (
+        "OK"
+        if blocking_count == 0 and advisory_count == 0
+        else ("OK_WITH_ADVISORIES" if blocking_count == 0 else "PARITY_VIOLATION")
+    )
+    report = {
+        "verdict": overall,
+        "repo_root": str(repo_root),
+        "langs": langs,
+        "strict_fr": args.strict_fr,
+        "pair_count": len(pairs),
+        "blocking_count": blocking_count,
+        "advisory_count": advisory_count,
+        "pairs": report_pairs,
+    }
+    print(json.dumps(report, ensure_ascii=False))
+
+    if not args.json_only:
+        if blocking_count:
+            print(
+                f"\nPARITY_VIOLATION : {blocking_count} paire(s) avec verdicts bloquants "
+                f"sur {len(pairs)} paire(s) scannée(s).",
+                file=sys.stderr,
+            )
+            for pr in report_pairs[:20]:
+                if pr["verdict"] == "BLOCKED":
+                    print(
+                        f"  [BLOCKED] {pr['translation']} (lang={pr['lang']})",
+                        file=sys.stderr,
+                    )
+                    for a in pr.get("anomalies", [])[:5]:
+                        print(
+                            f"    - {a['verdict']} cell_id={a['cell_id'] or '(whole-pair)'}",
+                            file=sys.stderr,
+                        )
+        elif advisory_count:
+            print(
+                f"\nOK_WITH_ADVISORIES : {advisory_count} cellule(s) FR_CONTAM (advisory, "
+                f"re-run with --strict-fr pour promouvoir en bloquant).",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"\nOK : {len(pairs)} paire(s) scannée(s), 0 violation, 0 advisory.",
+                file=sys.stderr,
+            )
+
+    return 1 if blocking_count else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/translation/tests/test_check_translation_parity.py
+++ b/scripts/translation/tests/test_check_translation_parity.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Tests for ``scripts/translation/check_translation_parity.py`` — the parity
+gate of the i18n translation pipeline (Epic #10038 grain B).
+
+Covers the 4 invariants from issue #10041 §2 + the falsifications demanded
+by the grain B acceptance + 1 legitimate-case test (FR in code cell =
+PASS, per corollaire D2).
+
+stdlib-only (json/pathlib/re/argparse/pytest). Hermetic — no network,
+no filesystem side effects beyond tmp_path fixtures.
+
+Mirror of the test pattern established by ``test_check_perimeter.py``
+(grain E) and ``test_check_translation_sync.py`` (T2 drift).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+TRANSLATION_DIR = HERE.parent
+sys.path.insert(0, str(TRANSLATION_DIR))
+
+import check_translation_parity as p  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers — notebook builders (return path to .ipynb)
+# ---------------------------------------------------------------------------
+
+
+def _write_nb(path: Path, cells: list[dict]) -> None:
+    """Write a minimal valid nbformat 4.5 notebook to ``path``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    nb = {
+        "cells": cells,
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(nb, ensure_ascii=False), encoding="utf-8")
+
+
+def _code_cell(cid: str, source: str, outputs: list | None = None,
+               execution_count: int | None = 1) -> dict:
+    return {
+        "cell_type": "code",
+        "id": cid,
+        "metadata": {},
+        "execution_count": execution_count,
+        "outputs": outputs if outputs is not None else [],
+        "source": [line + "\n" for line in source.split("\n") if line is not None]
+        if source
+        else [],
+    }
+
+
+def _md_cell(cid: str, source: str) -> dict:
+    return {
+        "cell_type": "markdown",
+        "id": cid,
+        "metadata": {},
+        "source": [line + "\n" for line in source.split("\n") if line is not None]
+        if source
+        else [],
+    }
+
+
+def _write_pair(
+    root: Path,
+    stem: str,
+    src_cells: list[dict],
+    trd_cells: list[dict],
+    lang: str = "en",
+) -> tuple[Path, Path]:
+    """Write ``{stem}.ipynb`` and ``{stem}_{lang}.ipynb`` under root."""
+    src_path = root / f"{stem}.ipynb"
+    trd_path = root / f"{stem}_{lang}.ipynb"
+    _write_nb(src_path, src_cells)
+    _write_nb(trd_path, trd_cells)
+    return src_path, trd_path
+
+
+# ---------------------------------------------------------------------------
+# Nominal — well-formed pair satisfies all 4 invariants
+# ---------------------------------------------------------------------------
+
+
+def test_nominal_pair_passes_all_invariants(tmp_path):
+    """A T4-style rendered notebook (code byte-identical, md all translated)
+    must produce 0 violations and verdict OK."""
+    src_cells = [
+        _md_cell("c1", "# Titre\n\nUn paragraphe d'introduction."),
+        _code_cell("c2", "x = 1\nprint(x)", outputs=[], execution_count=1),
+        _md_cell("c3", "## Section\n\nExplication detaillee."),
+    ]
+    trd_cells = [
+        _md_cell("c1", "# Title\n\nAn intro paragraph."),
+        _code_cell("c2", "x = 1\nprint(x)", outputs=[], execution_count=1),
+        _md_cell("c3", "## Section\n\nDetailed explanation."),
+    ]
+    src, trd = _write_pair(tmp_path, "Demo-01", src_cells, trd_cells)
+    src_records, src_err = p.load_cells(src)
+    trd_records, trd_err = p.load_cells(trd)
+    assert src_err is None
+    assert trd_err is None
+    anomalies = p.check_invariants(src_records, trd_records)
+    blocking = [a for a in anomalies if a.verdict != "FR_CONTAM"]
+    assert blocking == []
+
+
+# ---------------------------------------------------------------------------
+# Falsification 1 — modify one byte in code cell -> CODE_DRIFT
+# ---------------------------------------------------------------------------
+
+
+def test_falsif_1_code_byte_modification_yields_code_drift(tmp_path):
+    """Modifying a single byte in a code cell must trigger CODE_DRIFT on the
+    ``source`` field of that cell."""
+    src_cells = [
+        _code_cell("c1", "x = 1", outputs=[], execution_count=1),
+    ]
+    trd_cells = [
+        # T4 invariant violated : code byte-drift.
+        _code_cell("c1", "x = 2", outputs=[], execution_count=1),
+    ]
+    src, trd = _write_pair(tmp_path, "Drift-01", src_cells, trd_cells)
+    src_records, _ = p.load_cells(src)
+    trd_records, _ = p.load_cells(trd)
+    anomalies = p.check_invariants(src_records, trd_records)
+    code_drifts = [a for a in anomalies if a.verdict == "CODE_DRIFT"]
+    assert len(code_drifts) >= 1
+    fields = {a.detail.get("field") for a in code_drifts}
+    assert "source" in fields
+
+
+def test_falsif_1b_execution_count_drift_yields_code_drift(tmp_path):
+    """Code byte-identical but execution_count differs -> CODE_DRIFT on EC field."""
+    src_cells = [_code_cell("c1", "x = 1", outputs=[], execution_count=1)]
+    trd_cells = [_code_cell("c1", "x = 1", outputs=[], execution_count=2)]
+    src, trd = _write_pair(tmp_path, "Drift-01b", src_cells, trd_cells)
+    src_records, _ = p.load_cells(src)
+    trd_records, _ = p.load_cells(trd)
+    anomalies = p.check_invariants(src_records, trd_records)
+    code_drifts = [a for a in anomalies if a.verdict == "CODE_DRIFT"]
+    fields = {a.detail.get("field") for a in code_drifts}
+    assert "execution_count" in fields
+
+
+# ---------------------------------------------------------------------------
+# Falsification 2 — add output absent from source -> OUTPUT_FABRICATED
+# ---------------------------------------------------------------------------
+
+
+def test_falsif_2_added_output_yields_output_fabricated(tmp_path):
+    """A translation cell whose ``outputs`` array is non-empty while the source
+    cell has ``outputs == []`` must trigger OUTPUT_FABRICATED."""
+    src_cells = [
+        _code_cell("c1", "x = 1", outputs=[], execution_count=None),
+    ]
+    trd_cells = [
+        _code_cell(
+            "c1", "x = 1",
+            outputs=[
+                {
+                    "output_type": "stream",
+                    "name": "stdout",
+                    "text": ["fake\n"],
+                }
+            ],
+            execution_count=1,
+        ),
+    ]
+    src, trd = _write_pair(tmp_path, "Fab-01", src_cells, trd_cells)
+    src_records, _ = p.load_cells(src)
+    trd_records, _ = p.load_cells(trd)
+    anomalies = p.check_invariants(src_records, trd_records)
+    fabricated = [a for a in anomalies if a.verdict == "OUTPUT_FABRICATED"]
+    assert len(fabricated) == 1
+    assert fabricated[0].cell_id == "c1"
+
+
+# ---------------------------------------------------------------------------
+# Falsification 3 — delete a cell -> STRUCTURE_DRIFT
+# ---------------------------------------------------------------------------
+
+
+def test_falsif_3_cell_deletion_yields_structure_drift(tmp_path):
+    """Translation missing a cell that the source has -> STRUCTURE_DRIFT."""
+    src_cells = [
+        _md_cell("c1", "# Title"),
+        _md_cell("c2", "Body"),
+        _md_cell("c3", "Conclusion"),
+    ]
+    trd_cells = [
+        _md_cell("c1", "# Title"),
+        _md_cell("c3", "Conclusion"),  # c2 deleted
+    ]
+    src, trd = _write_pair(tmp_path, "Struct-01", src_cells, trd_cells)
+    src_records, _ = p.load_cells(src)
+    trd_records, _ = p.load_cells(trd)
+    anomalies = p.check_invariants(src_records, trd_records)
+    drifts = [a for a in anomalies if a.verdict == "STRUCTURE_DRIFT"]
+    assert len(drifts) == 1
+    assert "c2" in drifts[0].detail.get("deleted_cells", [])
+
+
+def test_falsif_3b_cell_reorder_yields_structure_drift(tmp_path):
+    """Same cell set, different order -> STRUCTURE_DRIFT with reorder flag."""
+    src_cells = [
+        _md_cell("c1", "A"),
+        _md_cell("c2", "B"),
+    ]
+    trd_cells = [
+        _md_cell("c2", "B"),
+        _md_cell("c1", "A"),
+    ]
+    src, trd = _write_pair(tmp_path, "Struct-01b", src_cells, trd_cells)
+    src_records, _ = p.load_cells(src)
+    trd_records, _ = p.load_cells(trd)
+    anomalies = p.check_invariants(src_records, trd_records)
+    drifts = [a for a in anomalies if a.verdict == "STRUCTURE_DRIFT"]
+    assert len(drifts) == 1
+    assert drifts[0].detail.get("reorder_detected") is True
+
+
+# ---------------------------------------------------------------------------
+# FR_CONTAM — markdown identical to FR
+# ---------------------------------------------------------------------------
+
+
+def test_fr_contam_advisory_default_does_not_block(tmp_path):
+    """A markdown cell with text identical to the FR source must emit FR_CONTAM
+    but in advisory mode (detail.advisory=True), exit 0 under default policy."""
+    src_cells = [_md_cell("c1", "# Titre\n\nUn paragraphe detaille.")]
+    trd_cells = [_md_cell("c1", "# Titre\n\nUn paragraphe detaille.")]
+    src, trd = _write_pair(tmp_path, "Contam-01", src_cells, trd_cells)
+    src_records, _ = p.load_cells(src)
+    trd_records, _ = p.load_cells(trd)
+    anomalies = p.check_invariants(src_records, trd_records)  # default strict_fr=False
+    fr_contam = [a for a in anomalies if a.verdict == "FR_CONTAM"]
+    assert len(fr_contam) == 1
+    assert fr_contam[0].detail.get("advisory") is True
+
+
+def test_fr_contam_strict_blocks(tmp_path):
+    """Under ``strict_fr=True``, FR_CONTAM must be added to the blocking list.
+    The CLI gate promotes advisory -> blocking via the strict_fr flag (tested
+    end-to-end below)."""
+    src_cells = [_md_cell("c1", "# Titre\n\nUn paragraphe detaille.")]
+    trd_cells = [_md_cell("c1", "# Titre\n\nUn paragraphe detaille.")]
+    src, trd = _write_pair(tmp_path, "Contam-01b", src_cells, trd_cells)
+    src_records, _ = p.load_cells(src)
+    trd_records, _ = p.load_cells(trd)
+    anomalies = p.check_invariants(src_records, trd_records, strict_fr=True)
+    fr_contam = [a for a in anomalies if a.verdict == "FR_CONTAM"]
+    assert len(fr_contam) == 1
+    # Under strict_fr, the advisory marker is NOT set (the anomaly becomes blocking).
+    assert "advisory" not in fr_contam[0].detail
+
+
+# ---------------------------------------------------------------------------
+# Legitimate case (corollaire D2) — FR text inside a CODE cell is OK
+# ---------------------------------------------------------------------------
+
+
+def test_fr_in_code_cell_is_legitimate(tmp_path):
+    """Per corollaire D2 of issue #10041 : FR string literals inside code cells
+    (e.g. ``print("Bonjour")``) are legitimate and MUST NOT trigger any verdict.
+    Only code bytes + outputs + execution_count are checked; the code itself can
+    legitimately contain FR text."""
+    src_cells = [
+        _code_cell(
+            "c1",
+            'msg = "Bonjour le monde"\nprint(msg)',
+            outputs=[
+                {
+                    "output_type": "stream",
+                    "name": "stdout",
+                    "text": ["Bonjour le monde\n"],
+                }
+            ],
+            execution_count=1,
+        ),
+    ]
+    trd_cells = [
+        _code_cell(
+            "c1",
+            'msg = "Bonjour le monde"\nprint(msg)',
+            outputs=[
+                {
+                    "output_type": "stream",
+                    "name": "stdout",
+                    "text": ["Bonjour le monde\n"],
+                }
+            ],
+            execution_count=1,
+        ),
+    ]
+    src, trd = _write_pair(tmp_path, "FrCode-01", src_cells, trd_cells)
+    src_records, _ = p.load_cells(src)
+    trd_records, _ = p.load_cells(trd)
+    anomalies = p.check_invariants(src_records, trd_records, strict_fr=True)
+    assert anomalies == []
+
+
+# ---------------------------------------------------------------------------
+# load_cells — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_load_cells_missing_file_returns_error(tmp_path):
+    records, err = p.load_cells(tmp_path / "no_such_nb.ipynb")
+    assert records == []
+    assert err is not None
+    assert "absent" in err
+
+
+def test_load_cells_malformed_json_returns_error(tmp_path):
+    nb_path = tmp_path / "broken.ipynb"
+    nb_path.write_text("{ this is not json", encoding="utf-8")
+    records, err = p.load_cells(nb_path)
+    assert records == []
+    assert err is not None
+    assert "illisible" in err
+
+
+def test_load_cells_missing_id_returns_error(tmp_path):
+    """nbformat < 4.5 (no ``id`` on cells) is a hard error — without ids, the
+    gate cannot establish correspondence."""
+    nb = {
+        "cells": [{"cell_type": "code", "source": ["x = 1\n"], "metadata": {}}],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 4,
+    }
+    nb_path = tmp_path / "no_ids.ipynb"
+    nb_path.write_text(json.dumps(nb), encoding="utf-8")
+    records, err = p.load_cells(nb_path)
+    assert "id" in err
+
+
+# ---------------------------------------------------------------------------
+# discover_pairs — pure-pair enumeration
+# ---------------------------------------------------------------------------
+
+
+def test_discover_pairs_finds_both_directions(tmp_path):
+    """A pair (src + _en) must be discovered once, regardless of walk order."""
+    src_cells = [_md_cell("c1", "A")]
+    trd_cells = [_md_cell("c1", "A-en")]
+    _write_pair(tmp_path, "X-01", src_cells, trd_cells, lang="en")
+    pairs = p.discover_pairs(tmp_path, ["en"])
+    assert len(pairs) == 1
+    src_path, trd_path, stem, lang = pairs[0]
+    assert stem == "X-01"
+    assert lang == "en"
+    assert src_path.name == "X-01.ipynb"
+    assert trd_path.name == "X-01_en.ipynb"
+
+
+def test_discover_pairs_handles_orphan_translation(tmp_path):
+    """A translation file with no source sibling must be picked up as orphan
+    (STRUCTURE_DRIFT downstream)."""
+    nb_path = tmp_path / "Orphan-01_en.ipynb"
+    nb = {
+        "cells": [_md_cell("c1", "A")],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    nb_path.write_text(json.dumps(nb), encoding="utf-8")
+    pairs = p.discover_pairs(tmp_path, ["en"])
+    # The orphan is found (its source path is missing, but the iteration sees it).
+    found = any(p[1].name == "Orphan-01_en.ipynb" for p in pairs)
+    assert found
+
+
+def test_discover_pairs_lang_filter_excludes_other_langs(tmp_path):
+    """A ``_ru`` translation must not appear in a scan restricted to ``en``."""
+    _write_pair(
+        tmp_path, "Multi-01",
+        [_md_cell("c1", "FR")],
+        [_md_cell("c1", "EN")],
+        lang="en",
+    )
+    _write_pair(
+        tmp_path, "Multi-01",
+        [_md_cell("c1", "FR")],
+        [_md_cell("c1", "RU")],
+        lang="ru",
+    )
+    pairs_en = p.discover_pairs(tmp_path, ["en"])
+    assert all(lang == "en" for _, _, _, lang in pairs_en)
+    assert len(pairs_en) == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end — CLI exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_cli_nominal_returns_zero(tmp_path, capsys, monkeypatch):
+    """A clean pair under the gate must produce exit 0 + verdict OK."""
+    src_cells = [_md_cell("c1", "FR body"), _code_cell("c2", "x = 1",
+                  outputs=[], execution_count=1)]
+    trd_cells = [_md_cell("c1", "EN body"), _code_cell("c2", "x = 1",
+                  outputs=[], execution_count=1)]
+    _write_pair(tmp_path, "Clean-01", src_cells, trd_cells)
+    monkeypatch.setattr(sys, "argv", [
+        "check_translation_parity.py",
+        "--repo-root", str(tmp_path),
+        "--langs", "en",
+        "--json-only",
+    ])
+    rc = p.main()
+    out = capsys.readouterr().out
+    report = json.loads(out)
+    assert rc == 0
+    assert report["verdict"] in ("OK", "OK_WITH_ADVISORIES")
+    assert report["pair_count"] == 1
+
+
+def test_cli_blocks_on_code_drift(tmp_path, capsys, monkeypatch):
+    """A pair with CODE_DRIFT must exit 1 with verdict PARITY_VIOLATION."""
+    src_cells = [_code_cell("c1", "x = 1", outputs=[], execution_count=1)]
+    trd_cells = [_code_cell("c1", "x = 99", outputs=[], execution_count=1)]
+    _write_pair(tmp_path, "Bad-01", src_cells, trd_cells)
+    monkeypatch.setattr(sys, "argv", [
+        "check_translation_parity.py",
+        "--repo-root", str(tmp_path),
+        "--langs", "en",
+        "--json-only",
+    ])
+    rc = p.main()
+    out = capsys.readouterr().out
+    report = json.loads(out)
+    assert rc == 1
+    assert report["verdict"] == "PARITY_VIOLATION"
+    assert report["blocking_count"] == 1
+
+
+def test_cli_strict_fr_blocks_on_fr_contam(tmp_path, capsys, monkeypatch):
+    """Under ``--strict-fr``, an FR_CONTAM cell must produce exit 1."""
+    src_cells = [_md_cell("c1", "# Un titre detaille\n\nLong body.")]
+    trd_cells = [_md_cell("c1", "# Un titre detaille\n\nLong body.")]
+    _write_pair(tmp_path, "Contam-strict", src_cells, trd_cells)
+    monkeypatch.setattr(sys, "argv", [
+        "check_translation_parity.py",
+        "--repo-root", str(tmp_path),
+        "--langs", "en",
+        "--strict-fr",
+        "--json-only",
+    ])
+    rc = p.main()
+    out = capsys.readouterr().out
+    report = json.loads(out)
+    assert rc == 1
+
+
+def test_cli_repo_root_missing_returns_two(tmp_path, capsys, monkeypatch):
+    """--repo-root pointing at a non-existent dir must exit 2 (filesystem error)."""
+    monkeypatch.setattr(sys, "argv", [
+        "check_translation_parity.py",
+        "--repo-root", str(tmp_path / "nope"),
+        "--langs", "en",
+        "--json-only",
+    ])
+    rc = p.main()
+    assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# Reference — live state (manual)
+# ---------------------------------------------------------------------------
+
+
+def test_full_repo_state_passes_parity():
+    """Reference test against the live ``xxx_<lang>.ipynb`` artifacts on main.
+
+    This is NOT a hermetic test — it asserts the actual state of the repo
+    passes its own parity gate. If this fails, either (a) a translation was
+    hand-edited (must re-render via T4), or (b) the parity invariants need
+    extending to cover a regression introduced by T4 itself.
+
+    Expected state today (post-grain A MERGED): exactly one pair —
+    ``FT-01-Introduction-FineTuning_en.ipynb`` — and it must satisfy all
+    invariants including strict-fr (because grain A proved byte-identity
+    + structure + no-FR-leak on md).
+    """
+    repo_root = HERE.parent.parent.parent  # scripts/translation/tests/ → repo root
+    pairs = p.discover_pairs(repo_root, ["en", "ru"])
+    # We expect exactly one pair: FT-01-Introduction-FineTuning (en only).
+    # Other PRs (grain E #10047) may have brought additional pairs; we check
+    # each one is OK.
+    assert len(pairs) >= 1, "no translation pairs found on main"
+    for src_path, trd_path, stem, lang in pairs:
+        src_cells, src_err = p.load_cells(src_path)
+        trd_cells, trd_err = p.load_cells(trd_path)
+        assert src_err is None, f"source unreadable : {src_path} ({src_err})"
+        assert trd_err is None, f"translation unreadable : {trd_path} ({trd_err})"
+        anomalies = p.check_invariants(src_cells, trd_cells, strict_fr=True)
+        blocking = [
+            a
+            for a in anomalies
+            if a.verdict in ("CODE_DRIFT", "STRUCTURE_DRIFT", "OUTPUT_FABRICATED")
+        ]
+        fr_contam_strict = [a for a in anomalies if a.verdict == "FR_CONTAM"]
+        assert blocking == [], (
+            f"pair {stem}_{lang} has blocking anomalies : {blocking}"
+        )
+        assert fr_contam_strict == [], (
+            f"pair {stem}_{lang} has FR_CONTAM under strict_fr : {fr_contam_strict}"
+        )


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: MED/translation #10047

## Résumé

Grain **B** d'Epic #10038 (« parity gate + provenance des paires `notebook_<lang>.ipynb` »). Ajoute le **gate de parité structurelle** qui vérifie qu'un notebook traduit `xxx_<lang>.ipynb` respecte **4 invariants** vs sa source `xxx.ipynb`. Indépendant du gate de périmètre (grain E #10047) et du détecteur de drift CSV (T2 sync).

Le périmètre grain E garantit qu'aucun CSV ne reçoit de cellule `text_<lang>` hors-périmètre déclaré. La parité grain B garantit qu'aucun notebook *rendu* ne dérive de sa source — ferme le pipeline T1→T3→T4 en attestant l'**invariance structurelle** du rendu.

## Architecture

### Source de vérité = le notebook source `xxx.ipynb`

T4 (`render_notebook.py`, MERGED #10040) produit `xxx_<lang>.ipynb` en substituant les cellules markdown via le CSV et en **copiant byte-pour-byte** les cellules code. Le gate vérifie que cette promesse est tenue à chaque instant.

### Le gate : `scripts/translation/check_translation_parity.py`

```
# Default : scan repo, vérifie toutes les paires xxx.ipynb / xxx_<lang>.ipynb
python scripts/translation/check_translation_parity.py

# Custom paths (tests / CI)
python scripts/translation/check_translation_parity.py \
    --repo-root . \
    --langs en,ru

# Promote FR_CONTAM from advisory to blocking
python scripts/translation/check_translation_parity.py --strict-fr

# Machine-readable
python scripts/translation/check_translation_parity.py --json-only
```

**4 invariants** (cf #10041 §2) :

| # | Invariant                                       | Verdict si violé        | Exit |
|---|-------------------------------------------------|-------------------------|------|
| 1 | Code cells byte-identiques (source + outputs + execution_count) | `CODE_DRIFT`            | 1 |
| 2 | Compte, ordre, `cell_id` séquence identique    | `STRUCTURE_DRIFT`       | 1 |
| 3 | Aucune cellule markdown identique au FR sans raison déclarée | `FR_CONTAM` (advisory)  | 0 (1 sous `--strict-fr`) |
| 4 | Aucune sortie fabriquée                        | `OUTPUT_FABRICATED`     | 1 |

**Verdicts globaux** :

| Verdict | Sens | Exit |
|---|---|---|
| `OK` | tous invariants OK, 0 advisory | 0 |
| `OK_WITH_ADVISORIES` | 0 violation mais ≥1 FR_CONTAM advisory | 0 |
| `PARITY_VIOLATION` | ≥1 CODE_DRIFT / STRUCTURE_DRIFT / OUTPUT_FABRICATED | **1** |
| `READ_ERROR` | notebook illisible (mécanique, 2) | 1 |

### Workflow : `.github/workflows/translation-parity.yml`

**Advisory (Phase 1, grain B acceptance)** :
- `continue-on-error: true` — ne **bloque PAS** la PR.
- Annotation : label `parity-ok` / `parity-advisory` / `parity-violation` + commentaire récapitulatif sur la PR si verdict ≠ OK.
- Critère de promotion B → A : 14 jours advisory post-merge avec 0 faux-positif sur PR touchant `*.ipynb`.

**Aucun filtre `paths:` inutile** : le workflow se déclenche sur `*.ipynb` + le script + le workflow lui-même, sans exclure `_output.ipynb` (artifact) ou `audit/`. Pas de pending-forever comme `pr-gate.yml` L18-22 — le verdict est rendu à chaque run.

## Premiers principes (G.1 firsthand)

État mesuré sur `origin/main` (sha `e15790405`) **AVANT** modification :

```
$ python scripts/translation/check_translation_parity.py --json-only
verdict=OK pairs=1 blocking=0 advisory=0 langs=['en','es','ar','fa','zh','ru','pt']
  [OK] MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning_en.ipynb (lang=en) - 0 anomalies
```

Preuve que le gate **rougit** sur une paire volontairement cassée (3 falsifications sur `c2` : `source` + `outputs` + `execution_count` tous en drift) :

```
$ python scripts/translation/check_translation_parity.py --repo-root /tmp/broken --langs en
{"verdict": "PARITY_VIOLATION", ..., "pair_count": 1, "blocking_count": 1,
 "pairs": [{"source": "Broken-01.ipynb", "translation": "Broken-01_en.ipynb",
            "lang": "en", "verdict": "BLOCKED",
            "anomalies": [
              {"verdict": "CODE_DRIFT", "cell_id": "c2",
               "detail": {"field": "source", "src_sha": "067415294e6ac0df",
                          "trd_sha": "b29b459915de2141", "src_len": 16, "trd_len": 16}},
              {"verdict": "CODE_DRIFT", "cell_id": "c2",
               "detail": {"field": "outputs", "src_n_outputs": 1, "trd_n_outputs": 2,
                          "src_execution_count": 1, "trd_execution_count": 2}},
              {"verdict": "CODE_DRIFT", "cell_id": "c2",
               "detail": {"field": "execution_count", "src": 1, "trd": 2}}
            ]}]}

PARITY_VIOLATION : 1 paire(s) avec verdicts bloquants sur 1 paire(s) scannée(s).
  [BLOCKED] Broken-01_en.ipynb (lang=en)
    - CODE_DRIFT cell_id=c2
    - CODE_DRIFT cell_id=c2
    - CODE_DRIFT cell_id=c2

EXIT CODE = 1
```

Le gate détecte **trois violations simultanées** sur la même cellule : drift du source (byte-level), drift des outputs (ajout d'une ligne fabriquée), drift de l'`execution_count` (1 vs 2).

## Détails d'implémentation

### Code cells byte-identity (invariant #1)

T4 copie les cellules code byte-pour-byte (cf PR #10040 § "Architecture"). Le gate vérifie trois champs de la cellule :
- `source` : liste de lignes → join + sha256[:16] pour comparaison.
- `outputs` : deep-compare (liste de dicts JSON).
- `execution_count` : entier nullable.

Un seul de ces trois champs qui dérive → `CODE_DRIFT`. Le verdict detaille quel champ a dérivé et les longueurs source/trd (utile pour le diff visuel).

### `OUTPUT_FABRICATED` (invariant #4)

Le seul cas *non couvert* par `CODE_DRIFT` est : la translation a un `outputs` non-vide que la source n'a pas (l'inverse est déjà dans `CODE_DRIFT.outputs`). C'est le scenario "hand-edited notebook injects fake output". Le gate le détecte spécifiquement.

### `STRUCTURE_DRIFT` (invariant #2)

Trois sous-cas :
- **cell deleted** : `set(src_ids) - set(trd_ids)` non-vide (jusqu'à 10 entrées reportées).
- **cell added** : `set(trd_ids) - set(src_ids)` non-vide (typiquement : T4 a collé une cellule en trop).
- **reorder** : même ensemble, ordre différent — détecté par `set equality ∧ list inequality`.

Quand la structure dérive, les invariants per-cell (CODE_DRIFT, FR_CONTAM) **ne sont pas évalués** (risque de faux-positif sur des cellules mal appariées). On retourne early après le verdict structurel.

### `FR_CONTAM` (invariant #3) — advisory par défaut

Miroir de `check_translation_sync._is_fr_contam` : texte normalisé strictement égal au source FR + `len >= 4`. Advisory par défaut (exit 0) car une cellule markdown peut légitimement contenir du français non-traduit (titre d'œuvre, nom propre répété, citation). Le flag `--strict-fr` promeut l'advisory en bloquant pour les PR qui veulent une garantie stricte (par exemple les PR de doc CI où le test runner ne supporte pas le multi-lang).

**Corollaire D2** : un commentaire ou string literal FR dans une **cellule code** est légitime — le gate ne touche qu'aux cellules markdown. Cf test `test_fr_in_code_cell_is_legitimate` qui vérifie explicitement ce cas.

### `discover_pairs` (énumération)

Walk `*.ipynb` sur `repo_root`, identifie les paires via `_SUFFIX_RE.match(stem)`. **Double-pass guard** : un `seen` set keyed sur `(resolved_src_path, lang)` empêche le double-emit (source branch + translation branch qui reverrait la même paire). Pattern orphelin toléré : si `X_en.ipynb` existe mais pas `X.ipynb`, on émet la paire avec `src_path = X_en.ipynb` (la translation agit comme son propre stub) — `load_cells` détecte le fichier illisible côté source et le verdict `READ_ERROR` flag la régression.

## Acceptance Epic #10038 §4 (grain B)

- [x] 4 invariants vérifiés firsthand (CODE_DRIFT / STRUCTURE_DRIFT / FR_CONTAM / OUTPUT_FABRICATED)
- [x] Suite tests 20/20 PASS dont 3 falsifications (modify octet code + EC drift, add output absent, delete cell + reorder)
- [x] Cas légitime FR dans cellule code → 0 verdict (corollaire D2)
- [x] Workflow advisory livré (label, exit 0 phase 1, criteria B→A documented)
- [x] Preuve dans le body que le gate rougit (cf "Premiers principes G.1")
- [x] Aucun filtre `paths:` qui empêcherait le verdict d'être rendu (pending-forever `pr-gate.yml` L18-22 évité)
- [x] Tag `Grain:` avec `lane` (cf première ligne)

## Tests

```
$ pytest scripts/translation/tests/test_check_translation_parity.py -v
============================= 20 passed in 0.30s =============================
```

Coverage (20 tests, 6 axes) :
1. **Nominal** (1) : paire T4-style passe les 4 invariants.
2. **Falsification 1** (2) : modif octet code + EC drift → `CODE_DRIFT` sur le bon champ.
3. **Falsification 2** (1) : output absent source → `OUTPUT_FABRICATED`.
4. **Falsification 3** (2) : suppression cellule + reorder → `STRUCTURE_DRIFT`.
5. **FR_CONTAM** (2) : advisory par défaut + promotion `--strict-fr`.
6. **Legitimate** (1) : FR dans cellule code → PASS (corollaire D2).
7. **Error paths** (3) : notebook absent / malformed / nbformat < 4.5.
8. **discover_pairs** (3) : enumeration simple + orphan + lang filter.
9. **CLI exit codes** (4) : nominal OK, blocking exit 1, strict-fr exit 1, repo absent exit 2.
10. **End-to-end live** (1) : `FT-01_en` (grain A proof) passe les 4 invariants.

**Régression :** `pytest scripts/translation/tests/` → **193 passed in 4.76s** (172 pre-existants + 20 nouveaux + 1 idempotent). Aucune régression.

## Fichiers ajoutés

```
.github/workflows/translation-parity.yml             (NEW, 102 lignes)
scripts/translation/check_translation_parity.py      (NEW, 555 lignes)
scripts/translation/tests/test_check_translation_parity.py (NEW, 518 lignes, 20 tests)
```

Aucun fichier modifié hors ces ajouts (catalog-preserved cf [catalog-pr-hygiene](.claude/rules/catalog-pr-hygiene.md)).

## Hors scope (futurs grains Epic #10038)

- **Grain C** (CI workflow) : durcir `translation-parity.yml` de advisory à required après 14j sans faux-positif. Phase 2 (B → A promotion criterion documenté dans le workflow YAML).
- **Grain D** (T3 ENABLED) : activer le moteur T3 pour les 4 CSV `en`-in-scope.
- **Lint output** : ajouter un verdict `OUTPUT_DROPPED` (translation qui a perdu un output que la source avait) si besoin futur — non couvert actuellement (un output qui disparaît = covered par `CODE_DRIFT.outputs` length diff).

## Liens

- Issue #10041 : https://github.com/jsboige/CoursIA/issues/10041 (Epic i18n notebook, grain B)
- Issue #10038 : https://github.com/jsboige/CoursIA/issues/10038 (Epic parent)
- PR #10040 : grain A (T4 renderer, MERGED) — référence pour l'invariant code byte-identity
- PR #10047 : grain E (perimeter gate, OPEN MERGEABLE c.1301+21) — compagnon gate structurel
- `scripts/translation/check_perimeter.py` : grain E, gate de périmètre CSV
- `scripts/translation/check_translation_sync.py` : T2 drift detector, hash-based CSV↔notebook
- `scripts/translation/render_notebook.py` : grain A, T4 renderer byte-identity