### PR TITLE
fix(csp): strip .nuget machine-path leak from CSP-2 cell[24] ext-load output (#6529 category-A)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
@@ -1481,7 +1481,7 @@
     {
      "data": {
       "text/plain": [
-       "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\skiasharp\\2.88.9\\interactive-extensions\\dotnet\\SkiaSharp.DotNet.Interactive.dll`"
+       
       ]
      },
      "metadata": {},

--- a/scripts/notebook_tools/twin_pairs.d/csp-2-consistency.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-2-consistency.yaml
@@ -14,6 +14,12 @@
       csharp_sha: 6d5e97dcecf99e4e5a9ae1881ba520072808d4d1
       content_python_sha: f804bda0e8779cecd9234bef5ebdfe1bde4f1c5ff07f4db572579a3fafdc642d
       content_csharp_sha: 15254f5d996c1c1b5ec961b8c1e9e1daaa88a500ee1ada38aca8eaf0696db073
+    - date: "2026-08-08"
+      by: myia-po-2023:CoursIA-2
+      python_sha: e4bcb98f9b804b32f5116fdb79e253b7488cd030
+      csharp_sha: 296d6a8b9f2112a20e2cf89c2b0db518f630b50f
+      content_python_sha: f804bda0e8779cecd9234bef5ebdfe1bde4f1c5ff07f4db572579a3fafdc642d
+      content_csharp_sha: 8f43ffa2051318b6eb8448ae3258d905503363d3dfdf1e4ed38a1ad55f26ba81
   known_differences:
     - "Socle pedagogique commun : node consistency + AC-3 + Forward Checking + MAC, implementes from-scratch des deux cotes."
     - "Cote C# : extension Choco-solver 4.10.17 via IKVM 8.15.0 (memes recettes infrastructure que CSP-1) pour comparer les algorithmes custom avec la propagation native de Choco (variable x, contrainte arithmetique, model.getSolver().propagate())."


### PR DESCRIPTION
fix(csp): strip .nuget machine-path leak from CSP-2 cell[24] ext-load output (#6529 category-A)

Grain: LIGHT/notebook-dotnet — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-dotnet #10046 (c.9872+51, 0 fail twin PASS, mergeable)

## Quoi
`CSP-2-Consistency-Csharp.ipynb` cell[24] carried 1 machine-path leak (`Loading extensions from \`C:\Users\jsboi\.nuget\packages\skiasharp\2.88.9\...\``) in the dotnet-interactive runtime ext-load output. **Kernel-injection category-A** (#6529): emitted by the runtime at `#r "nuget:"`, NOT printed by notebook source. Fix = `strip_machine_paths.py --apply` (#6574) → 1 path stripped, 0 source change. Same defect class + same fix as #10046 (ML-3).

## Preuve
- **Before** (origin/main): cell[24] `UsersLeak=1`, 1 `display_data` output with `Loading extensions from \`C:\Users\jsboi\.nuget\packages\skiasharp\...\``.
- **After** (this branch): cell[24] `UsersLeak=0`.
- **Repo-wide scan (origin/main, fixed extractor)** confirmed exactly 3 leaky notebooks: ML-3 (#10046), CSP-2 (this PR), CSP-9 (separate). Scan bug found+fixed: `json.dumps` double-escapes backslashes, so `.nuget\packages` pattern must match against the real `text/plain` (joined list), not the serialized blob — otherwise the scan silently reports 0.
- G.1 verify: source byte-identical (0 `"source"` lines changed), `execution_count` preserved, diff = 1 insertion / 1 deletion (only the `text/plain` ext-load line).

## Périmètre
- **2 files**: (1) `CSP-2-Consistency-Csharp.ipynb` — 1 `display_data` output in cell[24]; source byte-identical (pure output strip via the official hook). (2) `twin_pairs.d/csp-2-consistency.yaml` — twin-parity rebaseline EN DERNIER (after strip, per #8957): csharp_sha `6d5e97dc` → `296d6a8b` (post-strip blob SHA). Python twin unchanged (`e4bcb98f`, not .NET → no equivalent kernel-injection; re-audited firsthand: `CSP-2-Consistency.ipynb` .nuget leak = 0). Parité sémantique préservée: strip retire du bruit kernel-injecté, ne change ni code ni pédagogie.
- Verdict: **category-A kernel-injection strip** (#6529 exception), NOT a re-exec (re-exec re-injects the resolved home path — established by the ML-3 diagnosis in #10046: both `notebook_tools execute` and Papermill reproduced the leak).
- Hors scope (separate PR): CSP-9 (same defect, same family — next grain if window allows).

See #6529 (category-A kernel-injection, resolved by #6536/#6567/#6563/#6578) · See #6574 (strip_machine_paths.py) · See #8057 (twin parity) · See #8957 (rebaseline après strip) · See #10046 (template ML-3, same defect class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)