### PR TITLE
fix(csp): strip .nuget machine-path leak from CSP-9 ext-load output (#6529 category-A, closes notebook defect class 3/3)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed-Csharp.ipynb
@@ -785,7 +785,7 @@
     {
      "data": {
       "text/plain": [
-       "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\skiasharp\\2.88.9\\interactive-extensions\\dotnet\\SkiaSharp.DotNet.Interactive.dll`"
+       
       ]
      },
      "metadata": {},

--- a/scripts/notebook_tools/twin_pairs.d/csp-9-distributed.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-9-distributed.yaml
@@ -9,6 +9,12 @@
       python_sha: adee0d476742b82cc2efb931e778f4fba271be35
       reason: "c.1125 #8052 Python c44 stale pre-rename self-label Search-18->CSP-9-Distributed (C# twin already correct); print-literal src+out atomic"
       csharp_sha: 8324939a7b714bb232440bac11de6c84c0981a70
+    - date: "2026-08-08"
+      by: myia-po-2023:CoursIA-2
+      python_sha: adee0d476742b82cc2efb931e778f4fba271be35
+      csharp_sha: dea842f708b472a1c43238942489ed247714618a
+      content_python_sha: 8875c36b493aa80600dda58e11d9742d0fcdcb60328924cc7cd2b8eb992126a3
+      content_csharp_sha: ae7aea765ad272c6e84b24d2b4a926623a630f67d3a4c495f0a81459e3a0b875
   known_differences:
     - "Socle commun : CSP distribue (DisCSP) -- formalisation, ABT (Asynchronous Backtracking, Yokoo 1992), AWC (Asynchronous Weak-Commitment, Yokoo 1995), Privacy-Preserving CSP, application multi-hopital, benchmark synthetique ABT vs AWC. Le C# se declare explicitement 'binome .NET du CSP-9-Distributed.ipynb' (H1) et cite Yokoo 1992."
     - "PARITE CELLULAIRE EXACTE : 47 cellules des deux cotes (19 code, 28 markdown) -- le twin le plus proche cellule-a-cellule des 5 residuels. Sections logiques 1-7 identiques ; le C# concentre parfois plusieurs H2 logiques dans une meme cellule markdown (surcomptage brut d'en-tetes a 34) mais la couverture structurelle reelle matche le Python."


### PR DESCRIPTION
fix(csp): strip .nuget machine-path leak from CSP-9 ext-load output — closes .nuget notebook defect class (#6529 3/3)

Grain: LIGHT/notebook-dotnet — lane myia-po-2023:CoursIA-2 — prev: LIGHT/notebook-dotnet #10051 (CSP-2, mergeable)

## Quoi
`CSP-9-Distributed-Csharp.ipynb` carried 1 machine-path leak (`Loading extensions from \`C:\Users\jsboi\.nuget\packages\...\``) in the dotnet-interactive runtime ext-load output. **Kernel-injection category-A** (#6529): emitted by the runtime, NOT source-printed. Fix = `strip_machine_paths.py --apply` (#6574) → 1 path stripped, 0 source change. **This closes the .nuget notebook defect class** — after this PR, `strip_machine_paths.py --scan-all` reports 0 leaky notebooks on origin/main (3/3 fixed: ML-3 #10046, CSP-2 #10051, CSP-9 this).

## Preuve
- **Before** (origin/main): `UsersLeak=1`, 1 `display_data` output with the machine path.
- **After** (this branch): `UsersLeak=0`.
- G.1 verify: source byte-identical (0 `"source"` lines changed), `execution_count` preserved, diff = 1 insertion / 1 deletion.
- **Defect-class closure**: repo-wide scan (fixed extractor, see #10051 body) confirmed exactly 3 leaky notebooks — all 3 now fixed.

## Périmètre
- **2 files**: (1) `CSP-9-Distributed-Csharp.ipynb` — 1 `display_data` output; source byte-identical (pure output strip via the official hook). (2) `twin_pairs.d/csp-9-distributed.yaml` — twin-parity rebaseline EN DERNIER (after strip, per #8957). Python twin unchanged (not .NET → no equivalent kernel-injection; re-audited firsthand: `CSP-9-Distributed.ipynb` .nuget leak = 0). Parité sémantique préservée.
- Verdict: **category-A kernel-injection strip** (#6529 exception), NOT a re-exec.

See #6529 (category-A kernel-injection) · See #6574 (strip_machine_paths.py) · See #8057 (twin parity) · See #8957 (rebaseline après strip) · See #10046 #10051 (ML-3, CSP-2 — same defect class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)