### PR TITLE
fix(security): scrub absolute papermill metadata paths from 3 notebooks (PII-lite leak)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb
@@ -2261,8 +2261,8 @@
    "end_time": "2026-07-25T17:12:58.451725",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA-musicgen-02-3-reexec\\MyIA.AI.Notebooks\\GenAI\\Audio\\02-Advanced\\02-3-MusicGen-Generation.ipynb",
-   "output_path": "D:\\Dev\\CoursIA-musicgen-02-3-reexec\\MyIA.AI.Notebooks\\GenAI\\Audio\\02-Advanced\\02-3-MusicGen-Generation_output.ipynb",
+   "input_path": "02-3-MusicGen-Generation.ipynb",
+   "output_path": "02-3-MusicGen-Generation.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15c-MetaProxyObstruction.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15c-MetaProxyObstruction.ipynb
@@ -898,8 +898,8 @@
    "end_time": "2026-07-20T10:04:45.083098+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:\\dev\\CoursIA-2-c752-ict-meta-proxy-obstruction\\MyIA.AI.Notebooks\\IIT\\ICT-Series\\ICT-15c-MetaProxyObstruction.ipynb",
-   "output_path": "d:/dev/CoursIA-2-c752-ict-meta-proxy-obstruction/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15c-MetaProxyObstruction-executed.ipynb",
+   "input_path": "ICT-15c-MetaProxyObstruction.ipynb",
+   "output_path": "ICT-15c-MetaProxyObstruction.ipynb",
    "parameters": {},
    "start_time": "2026-07-20T10:04:42.227248+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
@@ -3672,8 +3672,8 @@
    "end_time": "2026-07-25T10:13:44.538705+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-sw13-consolidation\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-13-Python-Reasoners.ipynb",
-   "output_path": "D:\\dev\\CoursIA-sw13-consolidation\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-13-Python-Reasoners_output.ipynb",
+   "input_path": "SW-13-Python-Reasoners.ipynb",
+   "output_path": "SW-13-Python-Reasoners.ipynb",
    "parameters": {},
    "start_time": "2026-07-25T10:13:25.897649+00:00",
    "version": "2.6.0"


### PR DESCRIPTION
fix(security): scrub absolute papermill metadata paths from 3 notebooks (PII-lite leak)

Grain: MED/security — lane myia-po-2023:CoursIA-2 — prev: LIGHT/notebook-dotnet #10052 (CSP-9 .nuget, c.9872+51, mergeable)

## Quoi
3 notebooks carried absolute machine-local paths in `metadata.papermill.{input,output}_path` — a PII-lite leak (username `jsboi` + working-dir topology, exposing worktree names like `CoursIA-2-c752-ict-meta-proxy-obstruction`):
- `ICT-15c-MetaProxyObstruction.ipynb` — `d:\dev\CoursIA-2-c752-ict-meta-proxy-obstruction\...`
- `SW-13-Python-Reasoners.ipynb` — `D:\dev\CoursIA-sw13-consolidation\...`
- `02-3-MusicGen-Generation.ipynb` — (absolute path in papermill metadata)

Fix = `scrub_papermill_paths.py --apply` (official hook) → normalize to basename. This is the accepted **metadata exception** (secrets-hygiene rule 6): `ExecutePreprocessor`/`nbconvert` does NOT touch `metadata.papermill`, so re-exec cannot fix it; the scrub-to-basename IS the accepted fix (cf [[env-metadata-stable-vs-volatile-8052]]). Source byte-identical (0 source lines changed) — pure `metadata.papermill` normalization.

## Preuve
- **Defect class scan** (`scrub_papermill_paths.py --scan-all` from a FRESH `origin/main` worktree): exactly **3 notebooks / 6 absolute paths** on origin/main.
- **Before** (origin/main): each notebook's `metadata.papermill.input_path`/`output_path` = absolute machine path. Verified via `git show origin/main:<nb>` (git blobs, not filesystem).
- **After** (this branch): each = basename only (`ICT-15c-MetaProxyObstruction.ipynb`, etc.).
- G.1 verify: source byte-identical (0 `"source"` lines changed across all 3), `execution_count` + all cell outputs preserved, diff = 6 insertions / 6 deletions (only the 6 `metadata.papermill` path lines).
- **Twin parity (#8057)**: 157/157 OK, DRIFT=0. SW-13 is a twin pair but uses volet-b auto-track (#9399), so the metadata strip (which moved the blob SHA) did NOT create DRIFT — rebaseline was a no-op. ICT-15c + MusicGen are not twin pairs.

## Périmètre
- **3 files**: ICT-15c-MetaProxyObstruction (IIT), SW-13-Python-Reasoners (SemanticWeb), 02-3-MusicGen-Generation (GenAI/Audio). All metadata-only (`metadata.papermill` path normalization), source byte-identical.
- **Honest investigation note (transparency)**: an initial scan from the **shared tree** (`po2023-main-sync` branch, 7583 commits diverged from origin/main) reported "20 notebooks / 27 paths" — that was **stale-tree pollution** (local WIP/worktrees leaked paths into the shared working tree). A fresh `origin/main` worktree revealed only 3 real defects. The SymbolicLearning SL-1/2/4/5 notebooks initially targeted are CLEAN on origin/main. Lesson reinforces [[staleness-check-against-origin-main-not-shared-tree]]: always scan defect classes from a fresh `origin/main` worktree or via `git show origin/main:`, never from the dirty shared tree.
- **Ephemeral nature acknowledged**: `metadata.papermill` paths are re-introduced by every Papermill re-exec (the runtime writes `input_path`/`output_path`). The durable fix is a stricter pre-commit hook (currently the hook modifies-but-doesn't-abort, cf C10000-L2) — a separate harness grain. This PR cleans the 3 currently-leaking notebooks on origin/main.
- Hors scope: the other 17 "defects" from the shared tree (all clean on origin/main); the hook-strictness improvement.

See #7422 (doc-archive/cleanup family) · See #8057 (twin parity) · See #9399 (volet-b auto-track) · See [[env-metadata-stable-vs-volatile-8052]] (metadata exception) · See #6529 (sibling category-A path-leak, .nuget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)