### PR TITLE
feat(translation,#10043): T3 activation via env TRANSLATE_ENABLED + --max-cells cap (grain D)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,7 @@ testpaths =
     scripts/tests
     scripts/audit/tests
     scripts/quantconnect/tests
+    scripts/translation/tests
     MyIA.AI.Notebooks/QuantConnect/scripts/tests
     GradeBookApp
 pythonpath =

--- a/scripts/tests/test_translate_csv.py
+++ b/scripts/tests/test_translate_csv.py
@@ -190,7 +190,8 @@ def test_run_translations_no_env_keys_raises(monkeypatch, tmp_path):
 # 5. Safety gates via main() CLI.
 # ---------------------------------------------------------------------------
 def test_main_apply_gated_when_disabled(monkeypatch, tmp_path, capsys):
-    # ENABLED=False (module default). --apply must be a no-op.
+    # Gate closed (ENABLED=False, env-controlled via TRANSLATE_ENABLED, grain D
+    # #10043). --apply must be a no-op.
     monkeypatch.setattr(tc, "ENABLED", False)
     monkeypatch.setenv("OPENAI_API_KEY", "fake-key-for-testing")
     p = tmp_path / "x.csv"
@@ -202,7 +203,7 @@ def test_main_apply_gated_when_disabled(monkeypatch, tmp_path, capsys):
     # No mutation, no API: text_en still empty.
     assert tc.load_csv(str(p))[0]["text_en"] == ""
     err = capsys.readouterr().err
-    assert "GATED" in err and "ENABLED=False" in err
+    assert "GATED" in err and "TRANSLATE_ENABLED inactif" in err
 
 
 def test_main_dry_run_default_no_mutation(monkeypatch, tmp_path, capsys):

--- a/scripts/translation/README.md
+++ b/scripts/translation/README.md
@@ -8,7 +8,7 @@ Infrastructure de synchronisation multilingue pour les notebooks pédagogiques. 
 |--------|--------|------|--------|
 | **T1** | `extract_cells_to_csv.py` | Extrait les cellules des notebooks vers le CSV (langue pivot `fr`) | Livré |
 | **T2** | `check_translation_sync.py` | Détecte le drift (source modifiée / trad éditée / cellule supprimée) | Livré (non-bloquant, CI) |
-| **T3** | `translate_csv.py` | Traduit les cellules `text_fr` vers les 7 langues cibles (`text_<lang>` + `hash_<lang>`) | Starter livré ([#6976](https://github.com/jsboige/CoursIA/pull/6976)), gated `ENABLED=False` + `--dry-run` défaut — activation après GO user, [#6949](https://github.com/jsboige/CoursIA/issues/6949)) |
+| **T3** | `translate_csv.py` | Traduit les cellules `text_fr` vers les 7 langues cibles (`text_<lang>` + `hash_<lang>`) | Moteur livré ([#6976](https://github.com/jsboige/CoursIA/pull/6976)) + activation **env-controlled** (grain D [#10043](https://github.com/jsboige/CoursIA/issues/10043), umbrella [#10038](https://github.com/jsboige/CoursIA/issues/10038)) : gate `TRANSLATE_ENABLED` (off par défaut) + `--dry-run` défaut + cap `--max-cells`. Premier `--apply` réel = mandat user (clé API env, [#6949](https://github.com/jsboige/CoursIA/issues/6949)) |
 
 ## Issue #6949 — Status de clôture (2026-07-22, c.757)
 
@@ -28,7 +28,7 @@ Travaux d'harmonisation shipped post-issue (PRs additionnelles non-comptées dan
 - [#7731](https://github.com/jsboige/CoursIA/pull/7731) — verdict `FR_CONTAM` (4e classe Argumentum alignée, c.738).
 
 **Hors-scope explicite** (gated) :
-- **Activation T3** (`ENABLED=True` + premier run `--apply`) — mandat user requis, déclencheur Phase 1 de l'épic [#1650](https://github.com/jsboige/CoursIA/issues/1650). Le moteur reste **gated** intentionnellement : la pre-flight account/mandat (coût API, choix LLM en prod, stratégie de quota) sort du périmètre d'une PR de code.
+- **Activation T3** — le **mécanisme** (gate `TRANSLATE_ENABLED` env, cap `--max-cells`, dégradation propre, cache `src_hash`) est livré par le grain D [#10043](https://github.com/jsboige/CoursIA/issues/10043) de l'umbrella [#10038](https://github.com/jsboige/CoursIA/issues/10038) ; le moteur reste **gated** (off par défaut). Le **premier run `--apply` réel** = mandat user (clé `OPENAI_API_KEY` env + GO), déclencheur Phase 1 de l'épic [#1650](https://github.com/jsboige/CoursIA/issues/1650) : la pre-flight account (coût API prod, choix LLM prod, stratégie de quota) sort du périmètre d'une PR de code.
 - **T4 — re-import CSV → notebooks traduits** (papermill `--language <lang>`) — travail post-activation, dépendant du retour d'expérience du premier run T3 réel.
 
 Cible de revue cross-doc (à matérialiser au merge de la PR de clôture c.757) : `docs/translation/argumentum-fork-mapping.md` porte la même déclaration de clôture.

--- a/scripts/translation/tests/test_translate_csv.py
+++ b/scripts/translation/tests/test_translate_csv.py
@@ -15,6 +15,7 @@ exercée). stdlib-only (csv/hashlib/os/json/sys/argparse/urllib), hermétique.
 import csv
 import os
 import sys
+import urllib.error
 from pathlib import Path
 
 import pytest
@@ -47,6 +48,18 @@ def _write_csv(path, rows):
         for row in rows:
             w.writerow({c: row.get(c, "") for c in t3.CSV_COLUMNS})
     return path
+
+
+def _stub_translator(records):
+    """Remplaçant de translate_markdown qui enregistre (lang, texte) sans appeler l'API.
+
+    Sert aux tests du cap (--max-cells), du cache (0 appels sur lot inchangé) et de
+    la dégradation propre (échec simulé) — grain D #10043. Aucun réseau.
+    """
+    def _fake(fr_text, target_lang, model, key, base_url, **kw):
+        records.append((target_lang, fr_text))
+        return f"[{target_lang}] {fr_text[:12]}", 0.01, 0
+    return _fake
 
 
 # --------------------------------------------------------------------------
@@ -256,16 +269,22 @@ def test_main_dry_run_returns_0_no_mutation(tmp_path, monkeypatch, capsys):
 
 
 def test_main_apply_gated_noop_when_disabled(tmp_path, monkeypatch, capsys):
-    """--apply + ENABLED=False = GATED no-op (aucun appel API, aucune mutation)."""
+    """--apply + TRANSLATE_ENABLED inactif = GATED no-op (aucun appel API, aucune mutation).
+
+    Grain D #10043 : la gate est désormais env-controlled (TRANSLATE_ENABLED),
+    CI-callable sans monkeypatch source. On force la gate fermée pour un test
+    déterministe quel que soit l'environnement d'exécution.
+    """
     csv_path = _write_csv(tmp_path / "in.csv", [_row("c1", text_fr="bonjour")])
     original = csv_path.read_bytes()
+    monkeypatch.setattr(t3, "ENABLED", False)  # gate fermée, déterministe
     monkeypatch.setattr(sys, "argv", ["translate_csv.py", "--csv", str(csv_path), "--apply"])
     rc = t3.main()
     assert rc == 0
     assert csv_path.read_bytes() == original  # gated = aucune mutation
     err = capsys.readouterr().err
     assert "GATED" in err
-    assert "ENABLED=False" in err
+    assert "TRANSLATE_ENABLED inactif" in err
 
 
 def test_main_smoke_restricts_to_first_cell(tmp_path, monkeypatch, capsys):
@@ -281,7 +300,9 @@ def test_main_smoke_restricts_to_first_cell(tmp_path, monkeypatch, capsys):
 
 
 def test_main_limit_bounds_plan(tmp_path, monkeypatch, capsys):
-    # 5 cells markdown x 1 langue = 5 traductions ; --limit 2 borne a 2 (#6949).
+    # 5 cells markdown x 1 langue = 5 traductions. --limit 2 (alias de --max-cells,
+    # grain D #10043) borne l'EXÉCUTION --apply à 2 ; le dry-run affiche le plan
+    # complet (5) + signale le cap.
     csv_path = _write_csv(tmp_path / "in.csv", [
         _row(f"c{i}", text_fr=f"cellule {i}") for i in range(5)
     ])
@@ -290,7 +311,8 @@ def test_main_limit_bounds_plan(tmp_path, monkeypatch, capsys):
     rc = t3.main()
     assert rc == 0
     err = capsys.readouterr().err
-    assert "2 traductions nécessaires" in err  # borne par --limit, pas 5
+    assert "5 traductions nécessaires" in err  # dry-run = plan complet (informatif)
+    assert "borné à 2" in err  # cap --limit=2 signalé pour --apply
 
 
 def test_main_single_lang(tmp_path, monkeypatch, capsys):
@@ -349,3 +371,80 @@ def test_csv_columns_match_pipeline_schema():
     # T3 CSV_COLUMNS doit être un sous-ensemble cohérent du schéma ratifié T1.
     for col in t3.CSV_COLUMNS:
         assert col in t1.COLUMNS, f"T3 column {col} not in T1 schema"
+
+
+# --------------------------------------------------------------------------
+# Grain D #10043 — activation env + cap + dégradation propre + cache
+# --------------------------------------------------------------------------
+
+def test_activation_env_flag(monkeypatch):
+    """TRANSLATE_ENABLED contrôle la gate (CI-callable, sans monkeypatch source).
+
+    Grain D #10043 acceptance #1 : T3 activable sans éditer la source. La CI
+    positionne TRANSLATE_ENABLED=1 dans son env au lieu du workaround importlib
+    de #10032.
+    """
+    monkeypatch.delenv("TRANSLATE_ENABLED", raising=False)
+    assert t3._enabled_from_env() is False
+    for v in ("1", "true", "TRUE", "Yes", "on"):
+        monkeypatch.setenv("TRANSLATE_ENABLED", v)
+        assert t3._enabled_from_env() is True, f"{v!r} should enable"
+    for v in ("0", "false", "no", "off", "", "random", "2"):
+        monkeypatch.setenv("TRANSLATE_ENABLED", v)
+        assert t3._enabled_from_env() is False, f"{v!r} should NOT enable"
+
+
+def test_max_cells_caps_api_calls(tmp_path, monkeypatch):
+    """--max-cells borne le nombre d'appels API (grain D #10043 acceptance #3).
+
+    5 cellules éligibles, cap=2 => exactement 2 appels provider (pas 5). Protège
+    contre un bug de hash qui déclencherait une passe complète.
+    """
+    rows = [_row(f"c{i}", text_fr=f"cellule {i}") for i in range(5)]
+    monkeypatch.setattr(t3, "_provider_keys", lambda: [("stub-model", "k", "http://x")])
+    calls = []
+    monkeypatch.setattr(t3, "translate_markdown", _stub_translator(calls))
+    done, fails = t3.run_translations(rows, ["es"], False, str(tmp_path / "out.csv"), False, limit=2)
+    assert done == 2 and fails == 0
+    assert len(calls) == 2  # cap respecté : 2 appels, pas 5
+
+
+def test_graceful_degradation_no_source_copy(tmp_path, monkeypatch):
+    """Échec provider => text_<lang> RESTE VIDE (jamais recopiée depuis text_fr).
+
+    Grain D #10043 acceptance #4 : pas de falsification (récopie du source dans la
+    colonne cible = même faute que la règle 6 sur les sorties de cellules).
+    """
+
+    def _fail(fr_text, target_lang, model, key, base_url, **kw):
+        raise urllib.error.HTTPError("http://x", 500, "server err", {}, None)
+
+    rows = [_row("c1", text_fr="contenu source français secret")]
+    monkeypatch.setattr(t3, "_provider_keys", lambda: [("stub", "k", "http://x")])
+    monkeypatch.setattr(t3, "translate_markdown", _fail)
+    done, fails = t3.run_translations(rows, ["es"], False, str(tmp_path / "out.csv"), False, limit=5)
+    assert done == 0 and fails == 1
+    assert rows[0]["text_es"] == ""  # resté vide, pas recopié depuis text_fr
+    assert "secret" not in rows[0]["text_es"]
+    assert rows[0]["hash_es"] == ""
+
+
+def test_cache_zero_calls_on_unchanged_lot(tmp_path, monkeypatch):
+    """Cache (text_<lang> rempli) : 2e passe sur lot inchangé = 0 appel provider.
+
+    Grain D #10043 acceptance #2 : la propriété qui rend l'automatisation (grain C)
+    soutenable — les cellules déjà traduites ne sont jamais re-soumises.
+    """
+    rows = [_row(f"c{i}", text_fr=f"cellule {i}") for i in range(3)]
+    monkeypatch.setattr(t3, "_provider_keys", lambda: [("stub", "k", "http://x")])
+    calls1 = []
+    monkeypatch.setattr(t3, "translate_markdown", _stub_translator(calls1))
+    out = str(tmp_path / "out.csv")
+    t3.run_translations(rows, ["es"], False, out, False, limit=10)  # 1re passe
+    assert len(calls1) == 3  # 3 cellules traduites
+    # 2e passe : text_es rempli pour les 3 => plan vide => 0 appel (cache)
+    calls2 = []
+    monkeypatch.setattr(t3, "translate_markdown", _stub_translator(calls2))
+    done2, fails2 = t3.run_translations(rows, ["es"], False, out, False, limit=10)
+    assert done2 == 0 and fails2 == 0
+    assert len(calls2) == 0  # cache : 0 appel provider sur lot inchangé

--- a/scripts/translation/translate_csv.py
+++ b/scripts/translation/translate_csv.py
@@ -14,9 +14,11 @@ livrées ; ce script est la couche T3 (gated). Il lit un CSV `translations/<fami
 avec T2 (hash_<lang> = cell_hash(text_<lang>), même normalize que T1/T2).
 
 Sécurité (HARD) :
-  - `ENABLED = False` par défaut. Même avec `--apply`, le moteur refuse d'appeler
-    l'API tant que `ENABLED` n'est pas passé à `True` dans la source (GO user,
-    #6949 moyen terme). Triple gate : edit source + --apply + clé env.
+  - `ENABLED` contrôlé par la variable d'environnement `TRANSLATE_ENABLED`
+    (`1`/`true`/`yes`/`on`). Défaut : inactif. Même avec `--apply`, le moteur
+    refuse d'appeler l'API tant que `TRANSLATE_ENABLED` n'est pas activé. Triple
+    gate : `TRANSLATE_ENABLED=1` (env, CI-callable sans monkeypatch — grain D
+    #10043) + --apply + clé env. Fini l'activation in-memory par importlib (#10032).
   - `--dry-run` est le mode défaut (no API, no mutation) : imprime le plan de
     traduction (cellules markdown x langues = N appels).
   - Les clés API viennent UNIQUEMENT de l'environnement (`OPENAI_API_KEY`,
@@ -33,8 +35,9 @@ Usage :
   python translate_csv.py --csv translations/iit/iit.csv                  # dry-run plan
   python translate_csv.py --csv x.csv --smoke                              # dry-run 1 cell x 7 langs
   python translate_csv.py --csv x.csv --lang en                            # dry-run 1 langue
-  python translate_csv.py --csv x.csv --apply                              # GATED (ENABLED=False) -> no-op
-  # (activation : éditer ENABLED=True + OPENAI_API_KEY env + --apply)
+  python translate_csv.py --csv x.csv --apply                              # GATED (TRANSLATE_ENABLED inactif) -> no-op
+  # (activation : TRANSLATE_ENABLED=1 + OPENAI_API_KEY env + --apply ; CI-callable)
+  python translate_csv.py --csv x.csv --apply --max-cells 50               # cap dur : 50 traductions max/passe
 """
 import argparse
 import csv
@@ -47,10 +50,26 @@ import urllib.error
 import urllib.request
 
 # ----------------------------------------------------------------------------
-# Gate de sécurité (HARD). `False` = le moteur est inactif même avec --apply.
-# Passer à `True` uniquement après GO user (#6949 moyen terme, #1650 Phase 1).
+# Gate de sécurité (HARD). Inactif par défaut ; activé par la variable
+# d'environnement TRANSLATE_ENABLED (grain D #10043). CI-callable sans
+# monkeypatch : `TRANSLATE_ENABLED=1 python translate_csv.py --csv x --apply`.
+# Triple gate : env flag + --apply + clé API env. GO user = umbrella #10038.
 # ----------------------------------------------------------------------------
-ENABLED = False
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def _enabled_from_env() -> bool:
+    """Lit la gate d'activation depuis l'env (TRANSLATE_ENABLED). Défaut : off.
+
+    Résout le cran de sûreté posé pendant le développement (ENABLED=False en
+    source) en une activation CI-callable sans monkeypatch : la CI positionne
+    ``TRANSLATE_ENABLED=1`` dans son env, au lieu d'éditer la source en mémoire
+    via ``importlib`` (workaround de #10032, désormais inutile).
+    """
+    return os.getenv("TRANSLATE_ENABLED", "").strip().lower() in _TRUTHY
+
+
+ENABLED = _enabled_from_env()
 
 TARGETS = ["en", "ru", "pt", "es", "ar", "fa", "zh"]
 LANG_NAMES = {
@@ -290,10 +309,17 @@ def main() -> int:
                          "la traduction des commentaires de code est un refinement T3)")
     ap.add_argument("--model", default=DEFAULT_MODEL, help=f"modèle primaire (défaut {DEFAULT_MODEL})")
     ap.add_argument("--base-url", default=DEFAULT_BASE_URL, help="endpoint primaire")
+    ap.add_argument("--max-cells", type=int, default=300,
+                    help="cap dur du nombre de traductions par exécution (défaut 300, grain D "
+                         "#10043) : borne le coût d'une passe et protège contre un bug de hash "
+                         "qui déclencherait une passe complète (24 470 cellules). Neutre sur la gate.")
     ap.add_argument("--limit", type=int, default=None,
-                    help="borne le plan aux N premières traductions (tranche/test bornée, #6949). "
-                         "Neutre sur la gate de sécurité (borne le plan seulement).")
+                    help="[deprecated, alias de --max-cells] surcharge le cap si donné (backward "
+                         "compat #10032). Préférer --max-cells.")
     args = ap.parse_args()
+
+    # Cap effectif : --limit (deprecated alias) surcharge --max-cells sinon (grain D #10043).
+    effective_cap = args.limit if args.limit is not None else args.max_cells
 
     out_path = args.out or args.csv
     rows = load_csv(args.csv)
@@ -312,11 +338,13 @@ def main() -> int:
     if args.smoke:
         first_idx = next((i for i, _ in plan), None)
         plan = [(i, lang) for i, lang in plan if i == first_idx] if first_idx is not None else []
-    if args.limit:
-        plan = plan[:args.limit]
 
+    # dry-run : plan COMPLET (informatif) + cap appliqué en --apply (grain D #10043).
     print(f"[plan] {len(plan)} traductions nécessaires "
           f"({len(langs)} langue(s), include_code={args.include_code})", file=sys.stderr)
+    if len(plan) > effective_cap and not args.smoke:
+        print(f"[cap] --apply sera borné à {effective_cap} traductions (--max-cells) ; "
+              f"{len(plan) - effective_cap} attendront une passe ultérieure.", file=sys.stderr)
 
     if not args.apply:
         print("[dry-run] aucune mutation, aucun appel API. Passe --apply pour exécuter "
@@ -331,15 +359,15 @@ def main() -> int:
             print(f"  ... +{len(plan) - 5} autres", file=sys.stderr)
         return 0
 
-    # --apply : gate de sécurité ENABLED.
+    # --apply : gate de sécurité ENABLED (env TRANSLATE_ENABLED, grain D #10043).
     if not ENABLED:
-        print("[GATED] ENABLED=False dans translate_csv.py. Le moteur T3 est inactif : "
-              "aucun appel API, aucune mutation. Pour activer (après GO user, #6949 "
-              "moyen terme / #1650 Phase 1) : éditer ENABLED=True + définir "
-              "OPENAI_API_KEY env + re-passer --apply.", file=sys.stderr)
+        print("[GATED] TRANSLATE_ENABLED inactif. Le moteur T3 n'appelle pas l'API, "
+              "ne mute rien. Activation CI-callable (sans monkeypatch) : "
+              "`TRANSLATE_ENABLED=1 python translate_csv.py --csv x --apply` + clé "
+              "OPENAI_API_KEY env. GO user = umbrella #10038.", file=sys.stderr)
         return 0
 
-    return 0 if run_translations(rows, langs, args.include_code, out_path, args.smoke, args.limit)[1] == 0 else 1
+    return 0 if run_translations(rows, langs, args.include_code, out_path, args.smoke, effective_cap)[1] == 0 else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: MED/guard #10035
Quoi:       T3 engine activation via env TRANSLATE_ENABLED + --max-cells cap (grain D, umbrella #10038)
Preuve:     35 pytest passed (4 new) + cost measured 217 tok/cell FR->en gpt-5.5; stale-assertion fix 58 pass both test files
Perimetre:  translate_csv.py + 2 test files + pytest.ini + README; mechanism only, first real --apply = user mandate


## Summary

Grain D de l'umbrella #10038 (i18n notebooks : T4 renderer + CI autonome). Active le moteur T3 (`translate_csv.py`) — prérequis du grain C (bot CI auto-commit). Voir #10043 pour le scope grain.

Le moteur T3 était livré (#6976) mais **figé** : `ENABLED = False` hardcodé en source, activable uniquement par monkeypatch importlib (#10032). Cette PR résout le cran de sûreté de développement en une **activation env-controlled, CI-callable sans monkeypatch**.

### Changements (`scripts/translation/translate_csv.py`, +64/-22)

- **Gate env-controlled** : `ENABLED = _enabled_from_env()` lit `TRANSLATE_ENABLED` (`1`/`true`/`yes`/`on`). Off par défaut. Résout le workaround importlib de #10032. Triple gate conservée : `TRANSLATE_ENABLED=1` + `--apply` + `OPENAI_API_KEY` env.
- **Cap `--max-cells`** (défaut 300) borne le nombre de traductions par exécution — protège contre un bug de hash qui déclencherait une passe complète (14 853 cellules markdown). `--limit` conservé comme **alias déprécié** (backward compat #10032).
- **Dégradation propre** : échec provider ⇒ `text_<lang>` reste **vide** + `hash_<lang>` vide (déjà en place, désormais **testé**). Jamais de recopie `text_fr → text_<lang>` (pas de falsification, esprit secrets-hygiene règle 6).

### Tests (`scripts/translation/tests/test_translate_csv.py`, +107)

4 nouveaux tests (35 total) :
- `test_activation_env_flag` — `TRANSLATE_ENABLED` truthy/falsy exhaustif (`1`/`true`/`Yes`/`on` activent ; `0`/`false`/`random`/`2` non).
- `test_max_cells_caps_api_calls` — 5 cellules éligibles, cap=2 ⇒ **exactement 2 appels** provider (stub).
- `test_graceful_degradation_no_source_copy` — HTTPError 500 simulé ⇒ `text_es` **reste vide**, `hash_es` vide, `"secret"` (contenu source) **absent** de la cible.
- `test_cache_zero_calls_on_unchanged_lot` — 2e passe sur lot `text_es` rempli ⇒ **0 appel** provider (cache).

### pytest.ini (+1)

`scripts/translation/tests` ajouté aux `testpaths`. **Les 31 tests pré-existants étaient SILENTS en CI** (testpath absent) — désormais collectés (35 exécutés).

### README (`scripts/translation/README.md`, +2/-2)

Deux mentions stale alignées sur D (le README documentait exactement le mécanisme modifié — laisser stale = drift §E-esprit) :
- l.11 (statut T3) : `gated ENABLED=False` → **gate env-controlled** + lien grain D/umbrella.
- l.30-31 (hors-scope) : « Activation T3 sort du périmètre d'une PR de code » → le **mécanisme** est livré par D ; seul le **premier run réel** reste mandat user.

**Audit fichier-entier** (§E) : 4 mentions de l'activation passées en revue. 2 MAJ (contrat courant), 2 laissées (l.15/21 = relevé **historique** de ce que #6976/#6980 ont livré à leur date — `ENABLED=False` était alors exact).

## Acceptance (#10043)

- [x] **T3 activable sans monkeypatch ; clé par env, aucun littéral** — `_enabled_from_env()` + `TRANSLATE_ENABLED` ; clé via `_provider_keys()` (env-only, `os.getenv("OPENAI_API_KEY")` sans défaut). Vérifié off-by-default + on-with-env.
- [x] **cache src_hash : 0 appel provider sur lot inchangé** — `test_cache_zero_calls_on_unchanged_lot` (2e passe = 0 appels). Observé en pratique : dry-run sur `casestudies.csv --lang en` → `0 traductions nécessaires` (déjà traduit).
- [x] **`--max-cells` respecté, testé** — `test_max_cells_caps_api_calls` (cap=2 ⇒ 2 appels exacts). Défaut 300.
- [x] **échec provider ⇒ cellule non traduite et signalée ; aucune recopie source** — `test_graceful_degradation_no_source_copy`.
- [x] **coût mesuré sur lot réel + extrapolation périmètre grain E** — voir ci-dessous.
- [x] **aucune clé dans un log de CI** — clé uniquement via env, jamais imprimée. `call_chat` loggue `model`/`nb`/`cid`/`lang`/`dt`/`rt`, jamais la clé.
- [x] **tag `Grain:` avec `lane`** — première ligne de ce body.

## Coût mesuré (acceptance #5) — 1 cellule FR→en réelle, gpt-5.5

```
input chars      : 390
output chars     : 365
latency          : 3.0s
prompt_tokens    : 139
completion_tokens: 78
reasoning_tokens : 0   (reasoning_effort=low)
total_tokens     : 217
```

Cellule source : premier markdown FR de `translations/genai/casestudies.csv`. Traduction correcte (preview : `# Verbal Duel: Barbie vs. Shrek's Donkey`). **SOTA-OK** : vrai appel API, vrai gpt-5.5, vraie cellule — pas une estimation.

**Extrapolation périmètre grain E** (umbrella #10038 : 24 470 lignes cellules = 14 853 markdown + 9 617 code ; T3 traduit **markdown uniquement**, code byte-identical per design-gate D2) :
- **EN-only** (langue active par grain E) : 14 853 × 217 ≈ **3,2M tokens** (2,06M prompt + 1,16M completion).
- **--max-cells 300** borne chaque run CI à ~65K tokens (≈ cents).
- Coût $ = tokens × tarif gpt-5.5 (provider-dépendant — non fabriqué ici, G.9). Ordre de grandeur : un run full-EN est dans la fourchette dizaine de $ selon tarif ; le cap rend chaque passe CI négligeable.

## Validation

- `python -m pytest scripts/translation/tests/test_translate_csv.py` → **35 passed** (6.2s).
- Dry-run sanity : `--lang en` sur casestudies → plan 0 (cache) ; `--apply --max-cells 1` sans env → `[GATED] TRANSLATE_ENABLED inactif` (no-op, no mutation).
- `git diff --stat` : 4 fichiers, +152/-24 (scope grain D uniquement).
- Secrets scan diff : CLEAN (seul match = `os.getenv("TRANSLATE_ENABLED", "")` = flag env vide, pas un littéral).

## Coordination

- **L898 pre-push collision guard** : path-gate (`gh pr list --json files | test("translation")`) → PRs open sur `scripts/translation/` = #10050 (grain B, po-2025) + #10047 (grain E, po-2025). **Aucune ne touche `translate_csv.py` ni l'activation** (D est isolé). Pas de collision.
- **DM courtoisie** envoyé à po-2025 (lane CoursIA-2) avant claim : signal de travail sur grain D (po-2025 tient B+E). Backstop ; le path-gate est l'ancre autoritative.

See #10043 (grain D). See #10038 (umbrella — contribution partielle, l'umbrella reste ouverte tant que C n'est pas livré).

