### PR TITLE
docs(reference,#7422): restore French accents in teaching-context.md (clean rescope of #9981)

### DIFF
--- a/docs/reference/teaching-context.md
+++ b/docs/reference/teaching-context.md
@@ -1,100 +1,100 @@
-# Contexte enseignement - calendrier, ecoles, agents
+# Contexte enseignement - calendrier, écoles, agents
 
-Documentation transversale sur l'organisation de l'enseignement annuel : calendrier, scope par ecole, mapping agents cluster. Pour le **moteur de notation** : cf [GradeBookApp/configs/README.md](../../GradeBookApp/configs/README.md) (pipelines + donnees par cohorte = prives sur GDrive). Pour le **mapping cluster machines** (au-dela des roles enseignement) : cf [docs/cluster-agents.md](cluster-agents.md).
+Documentation transversale sur l'organisation de l'enseignement annuel : calendrier, scope par école, mapping agents cluster. Pour le **moteur de notation** : cf [GradeBookApp/configs/README.md](../../GradeBookApp/configs/README.md) (pipelines + données par cohorte = privés sur GDrive). Pour le **mapping cluster machines** (au-delà des rôles enseignement) : cf [docs/cluster-agents.md](cluster-agents.md).
 
-## Date de fraicheur
+## Date de fraîcheur
 
-Derniere actualisation : **2026-08-08** (cycle c.1331+39, sub-issue #9984 tranche 2 du triage `docs/reference/` #7422). Cycle en cours : **2026 → 2027** (rentree septembre 2026). Les statuts session 2026 sont les statuts **de cloture** (memoires des livrables passes) ; les sessions 2027 demarrent a la rentree et seront documentees au fil de l'eau (dashboard workspace CoursIA, pas ce fichier). Conventions de dates : verifiez `[last_updated]` en tete du sous-dossier GDrive `Formation/<ecole>/<annee>/` pour la version nominative.
+Dernière actualisation : **2026-08-08** (cycle c.1331+39, sub-issue #9984 tranche 2 du triage `docs/reference/` #7422). Cycle en cours : **2026 → 2027** (rentrée septembre 2026). Les statuts session 2026 sont les statuts **de clôture** (mémoires des livrables passés) ; les sessions 2027 démarrent à la rentrée et seront documentées au fil de l'eau (dashboard workspace CoursIA, pas ce fichier). Conventions de dates : vérifiez `[last_updated]` en tête du sous-dossier GDrive `Formation/<école>/<année>/` pour la version nominative.
 
-## Ecoles partenaires 2027
+## Écoles partenaires 2027
 
-| Ecole | Cours | Statut session 2026 (cloture) | Statut session 2027 |
+| École | Cours | Statut session 2026 (clôture) | Statut session 2027 |
 |-------|-------|------------------------------|---------------------|
-| EPF | GenAI Bachelor 3A (MSBNS3IN03), classes MIN1/MIN2/MIS | Termine, notes transmises | A pourvoir (rentree septembre 2026) |
-| ECE | IA Finance Ing4 (Gr01/02/03) | Termine, notes rendues debut mai | A pourvoir (planning en cours, dashboard workspace CoursIA) |
-| Partner | Algo Trading QuantConnect | Soutenances finales fin mai, **grading debut juin** termine | A pourvoir (cohort 2026-2027 sponsor QC) |
-| EPITA | Programmation par Contraintes | Soutenances 2 batchs **terminees**, suivi TP bonus rempli, notes projet faites | A pourvoir (cohort 2026-2027, dispatches `myia-po-2025:2026-Epita-Programmation-par-Contraintes` vers `2027-...` au Q3 2026) |
-| EPITA | IA Symbolique | Cours en cours (cycle printemps 2026 termine) ; TPs notebooks rendus sur CoursIA = points bonus des projets EPITA-IS | A pourvoir (cohort 2026-2027, dispatches `myia-po-2025:2026-Epita-Intelligence-Symbolique` vers `2027-...` au Q3 2026) |
+| EPF | GenAI Bachelor 3A (MSBNS3IN03), classes MIN1/MIN2/MIS | Terminé, notes transmises | À pourvoir (rentrée septembre 2026) |
+| ECE | IA Finance Ing4 (Gr01/02/03) | Terminé, notes rendues début mai | À pourvoir (planning en cours, dashboard workspace CoursIA) |
+| Partner | Algo Trading QuantConnect | Soutenances finales fin mai, **grading début juin** terminé | À pourvoir (cohort 2026-2027 sponsor QC) |
+| EPITA | Programmation par Contraintes | Soutenances 2 batchs **terminées**, suivi TP bonus rempli, notes projet faites | À pourvoir (cohort 2026-2027, dispatches `myia-po-2025:2026-Epita-Programmation-par-Contraintes` vers `2027-...` au Q3 2026) |
+| EPITA | IA Symbolique | Cours en cours (cycle printemps 2026 terminé) ; TPs notebooks rendus sur CoursIA = points bonus des projets EPITA-IS | À pourvoir (cohort 2026-2027, dispatches `myia-po-2025:2026-Epita-Intelligence-Symbolique` vers `2027-...` au Q3 2026) |
 
-## Calendrier general 2027 (printemps)
+## Calendrier général 2027 (printemps)
 
-Le calendrier nominatif (dates precises de soutenance par groupe etudiant) est dans `G:/Mon Drive/MyIA/Formation/<ecole>/2027/` et sur le **dashboard RooSync workspace CoursIA**, pas dans le repo public.
+Le calendrier nominatif (dates précises de soutenance par groupe étudiant) est dans `G:/Mon Drive/MyIA/Formation/<école>/2027/` et sur le **dashboard RooSync workspace CoursIA**, pas dans le repo public.
 
-Les jalons annuels recurrents (le cycle **2026** est en cloture au 2026-08-08 ; le cycle **2027** ouvre a la rentree septembre 2026) :
+Les jalons annuels récurrents (le cycle **2026** est en clôture au 2026-08-08 ; le cycle **2027** ouvre à la rentrée septembre 2026) :
 
-| Periode | Activite type |
+| Période | Activité type |
 |---------|---------------|
-| Janvier-Fevrier | Cours EPF GenAI + cours EPITA-PrCon (slides + notebooks) |
+| Janvier-Février | Cours EPF GenAI + cours EPITA-PrCon (slides + notebooks) |
 | Mars-Avril | Cours ECE IA Finance Ing4 (Gr01/02/03 successifs) + soutenances P1 |
-| Mai | Soutenances ECE P2, soutenances EPITA-PrCon (batch 1 presentiel + batch 2 visio), debut cours EPITA-IA-Symbolique, soutenances finales partenaire |
-| Juin | **Grading partenaire (debut juin)**, fin cours EPITA-IA-Symbolique + soutenances projet final |
-| Juillet-Aout | **Preparation cycle suivant** (mise a jour notebooks, validation cohortes, dispatches coordinateur) |
-| Septembre | Rentree (QC League pour anciens ECE, nouvelle promo EPF) |
+| Mai | Soutenances ECE P2, soutenances EPITA-PrCon (batch 1 présentiel + batch 2 visio), début cours EPITA-IA-Symbolique, soutenances finales partenaire |
+| Juin | **Grading partenaire (début juin)**, fin cours EPITA-IA-Symbolique + soutenances projet final |
+| Juillet-Août | **Préparation cycle suivant** (mise à jour notebooks, validation cohortes, dispatches coordinateur) |
+| Septembre | Rentrée (QC League pour anciens ECE, nouvelle promo EPF) |
 
 ## EPITA - IA Symbolique : scope 2027
 
-5 cours, 18h totales (cycle 2026 invariant - en attente confirmation coordinateur pour 2027, cf dashboard workspace CoursIA `myia-po-2025:2026-Epita-Intelligence-Symbolique` des septembre 2026), focus exclusif sur le repertoire `MyIA.AI.Notebooks/SymbolicAI/`.
+5 cours, 18h totales (cycle 2026 invariant - en attente confirmation coordinateur pour 2027, cf dashboard workspace CoursIA `myia-po-2025:2026-Epita-Intelligence-Symbolique` dès septembre 2026), focus exclusif sur le répertoire `MyIA.AI.Notebooks/SymbolicAI/`.
 
-### Series DANS le scope (6)
+### Séries DANS le scope (6)
 
-| # | Serie | Contenu |
+| # | Série | Contenu |
 |---|-------|---------|
-| 1 | `SymbolicAI/Argument_Analysis` | **Priorite** (Epic dedie). Submodule Argumentum + materiel importable 2025 |
-| 2 | `SymbolicAI/Tweety` | Argumentation formelle, transition naturelle apres Argumentum |
+| 1 | `SymbolicAI/Argument_Analysis` | **Priorité** (Epic dédié). Submodule Argumentum + matériel importable 2025 |
+| 2 | `SymbolicAI/Tweety` | Argumentation formelle, transition naturelle après Argumentum |
 | 3 | `SymbolicAI/Lean` | Preuves formelles (incluant GameTheory `social_choice_lean/` port Arrow/Sen) |
 | 4 | `SymbolicAI/SemanticWeb` | RDF / OWL / SHACL |
 | 5 | `SymbolicAI/Planning` | PDDL / GraphPlan / HTN |
 | 6 | `SymbolicAI/SmartContract` | Solidity / ZKP / multi-chain |
 
-### Series HORS scope (referencables pour les projets, pas de cours dedie)
+### Séries HORS scope (référençables pour les projets, pas de cours dédié)
 
 - `Search/` : couvert dans Programmation par Contraintes
-- `Probas/` : mentionne en passant
-- `GameTheory/` (serie complete) : mentionne dans sujets et sous-partie Lean
+- `Probas/` : mentionné en passant
+- `GameTheory/` (série complète) : mentionné dans sujets et sous-partie Lean
 - `IIT/` : non couvert
 
 ### Format TP final EPITA-IS
 
-- **1 serie au minimum** choisie par l'etudiant parmi les 6 du scope
-- **Livrable principal** : 1 exercice final de notebook complete dans cette serie
-- **Workflow** : PR sur **fork du depot `jsboige/CoursIA`** (pattern PrCon : fork + PR sur notebooks)
-- **Le depot `2026-Epita-Intelligence-Symbolique`** = projets/sujets de soutenance du cycle 2026 (clos) ; le cycle 2027 heritera d'un depot `2027-Epita-Intelligence-Symbolique` (creation coordonnee par ai-01 au Q3 2026), distinct des TPs notebooks
-- **Bonus** : +0.5 / exercice supplementaire meme serie (cap +1), +1 / exercice autre serie (cap +2), +0.5 redaction 1p markdown explicative (demarche, choix techniques, limites)
-- **Application du bonus** : c'est l'**inscription des groupes dans les fichiers de suivi adequats qui fait foi** (G drive `Notation/`), pas la PR mergee ni le keying gradebook sur la chaine sujet
-- **Collisions de TP** (2 groupes, meme exercice) : merger le **meilleur rendu** ou **cherry-pick entre les meilleurs**, puis **close les autres** avec un message expliquant qu'un seul peut etre merge (meme protocole que les TPs PrCon ; cf SW-10 #1429/#1416 -> #1499)
-- **Soutenance** : 10 min presentation + 5 min Q&A, batch presentiel sur creneau cours + batch visio si depassement
+- **1 série au minimum** choisie par l'étudiant parmi les 6 du scope
+- **Livrable principal** : 1 exercice final de notebook complété dans cette série
+- **Workflow** : PR sur **fork du dépôt `jsboige/CoursIA`** (pattern PrCon : fork + PR sur notebooks)
+- **Le dépôt `2026-Epita-Intelligence-Symbolique`** = projets/sujets de soutenance du cycle 2026 (clos) ; le cycle 2027 héritera d'un dépôt `2027-Epita-Intelligence-Symbolique` (création coordonnée par ai-01 au Q3 2026), distinct des TPs notebooks
+- **Bonus** : +0.5 / exercice supplémentaire même série (cap +1), +1 / exercice autre série (cap +2), +0.5 rédaction 1p markdown explicative (démarche, choix techniques, limites)
+- **Application du bonus** : c'est l'**inscription des groupes dans les fichiers de suivi adéquats qui fait foi** (G drive `Notation/`), pas la PR mergée ni le keying gradebook sur la chaîne sujet
+- **Collisions de TP** (2 groupes, même exercice) : merger le **meilleur rendu** ou **cherry-pick entre les meilleurs**, puis **close les autres** avec un message expliquant qu'un seul peut être mergé (même protocole que les TPs PrCon ; cf SW-10 #1429/#1416 -> #1499)
+- **Soutenance** : 10 min présentation + 5 min Q&A, batch présentiel sur créneau cours + batch visio si dépassement
 
-## Agents cluster par ecole
+## Agents cluster par école
 
-Le cluster CoursIA dispatche les missions par workspace dedie. **Les workspaces EPITA ne sont PAS dispatchables depuis `myia-ai-01:CoursIA`** : chaque workspace EPITA a son propre flow, son propre depot, ses propres tracks.
+Le cluster CoursIA dispatche les missions par workspace dédié. **Les workspaces EPITA ne sont PAS dispatchables depuis `myia-ai-01:CoursIA`** : chaque workspace EPITA a son propre flow, son propre dépôt, ses propres tracks.
 
-| Ecole / role | Workspace RooSync | Limites |
+| École / rôle | Workspace RooSync | Limites |
 |--------------|-------------------|---------|
 | ECE - notation P1+P2, bonus CC, compilation | `myia-ai-01:CoursIA` + `myia-po-2024:CoursIA` | - |
 | Partner QC - ML kit + soutenances + suivi | `myia-ai-01:CoursIA` + `myia-po-2024:CoursIA` | Sponsor QC, prudence sur la communication publique (tiers research org) |
-| EPITA-PrCon - review/merge PRs etudiants | `myia-po-2025:2026-Epita-Programmation-par-Contraintes` (cycle 2026 clos) → `myia-po-2025:2027-Epita-Programmation-par-Contraintes` (cycle 2027, creation a coordonner ai-01 au Q3 2026) | Ne **pas** envoyer de mission CoursIA via ce workspace |
-| EPITA-IS - veille + enrichissement sujets | `myia-po-2025:2026-Epita-Intelligence-Symbolique` (cycle 2026 clos) → `myia-po-2025:2027-Epita-Intelligence-Symbolique` (cycle 2027, creation a coordonner ai-01 au Q3 2026) | Ne **pas** envoyer de mission CoursIA via ce workspace |
-| EPF - notation, archive | (workspace dedie myia-po-2025) | Cycle annuel termine |
+| EPITA-PrCon - review/merge PRs étudiants | `myia-po-2025:2026-Epita-Programmation-par-Contraintes` (cycle 2026 clos) → `myia-po-2025:2027-Epita-Programmation-par-Contraintes` (cycle 2027, création à coordonner ai-01 au Q3 2026) | Ne **pas** envoyer de mission CoursIA via ce workspace |
+| EPITA-IS - veille + enrichissement sujets | `myia-po-2025:2026-Epita-Intelligence-Symbolique` (cycle 2026 clos) → `myia-po-2025:2027-Epita-Intelligence-Symbolique` (cycle 2027, création à coordonner ai-01 au Q3 2026) | Ne **pas** envoyer de mission CoursIA via ce workspace |
+| EPF - notation, archive | (workspace dédié myia-po-2025) | Cycle annuel terminé |
 
-**Specificite po-2025** : 3 workspaces distincts sur la meme machine RTX 3080 Ti (backoff thermal partage). Dispatcher en precisant le workspace explicitement dans `to:`, jamais `myia-po-2025` seul.
+**Spécificité po-2025** : 3 workspaces distincts sur la même machine RTX 3080 Ti (backoff thermique partagé). Dispatcher en précisant le workspace explicitement dans `to:`, jamais `myia-po-2025` seul.
 
 ## Conventions Google Drive
 
-Base path commune : `G:\Mon Drive\MyIA\Formation\<ecole>\<annee>\` (cf `gdrive_teaching_paths.md` non public pour le detail par fichier).
+Base path commune : `G:\Mon Drive\MyIA\Formation\<école>\<année>\` (cf `gdrive_teaching_paths.md` non public pour le détail par fichier).
 
 Sous-dossiers types :
-- `participants/` ou `Groupe<N>_participants.xlsx` : rosters etudiants
-- `grading/` : configs GradeBookApp + outputs Excel (resolus via `COURSIA_ROOT` env var)
-- `Notation/` : briefings jury, questions de soutenance, grilles d'evaluation **(internes - ne JAMAIS publier sur PR/issue)**
-- `Projet1-Gr<N>-Presentations/` : presentations etudiantes
+- `participants/` ou `Groupe<N>_participants.xlsx` : rosters étudiants
+- `grading/` : configs GradeBookApp + outputs Excel (résolus via `COURSIA_ROOT` env var)
+- `Notation/` : briefings jury, questions de soutenance, grilles d'évaluation **(internes - ne JAMAIS publier sur PR/issue)**
+- `Projet1-Gr<N>-Presentations/` : présentations étudiantes
 
-## Reviews PR etudiantes - regle critique
+## Reviews PR étudiantes - règle critique
 
-Voir [.claude/rules/student-pr-reviews.md](../../.claude/rules/student-pr-reviews.md). Rappel : les commentaires de PR sur depot etudiant sont **visibles par les etudiants**, donc jamais de questions de soutenance / grille / briefing jury en commentaire public avant l'epreuve. Incident 2026-05-17 documente.
+Voir [.claude/rules/student-pr-reviews.md](../../.claude/rules/student-pr-reviews.md). Rappel : les commentaires de PR sur dépôt étudiant sont **visibles par les étudiants**, donc jamais de questions de soutenance / grille / briefing jury en commentaire public avant l'épreuve. Incident 2026-05-17 documenté.
 
 ## Pointeurs cross-doc
 
-- Pipeline notation et bonus CC : moteur [GradeBookApp/configs/README.md](../../GradeBookApp/configs/README.md) ; detail par cohorte prive sur GDrive `Formation\<ecole>\2027\grading\` (cycle courant 2026-2027)
-- Mapping cluster machines (au-dela enseignement) : [docs/cluster-agents.md](cluster-agents.md)
-- Slides Slidev EPITA : `MyIA.AI.Notebooks/SymbolicAI/<serie>/slides/` (workflow Slidev verify, cf [.claude/rules/](../../.claude/rules/))
+- Pipeline notation et bonus CC : moteur [GradeBookApp/configs/README.md](../../GradeBookApp/configs/README.md) ; détail par cohorte privé sur GDrive `Formation\<école>\2027\grading\` (cycle courant 2026-2027)
+- Mapping cluster machines (au-delà enseignement) : [docs/cluster-agents.md](cluster-agents.md)
+- Slides Slidev EPITA : `MyIA.AI.Notebooks/SymbolicAI/<série>/slides/` (workflow Slidev verify, cf [.claude/rules/](../../.claude/rules/))
 - QuantConnect (partenaire) : [docs/qc/quantconnect.md](../qc/quantconnect.md)


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #10049

## TL;DR

Clean rescope of the CONFLICTING #9981: `docs/reference/teaching-context.md` had **0 accented characters** (~37 unaccented French words — "ecoles", "rentree", "Termine", "recurrents", etc.). This PR restores the accents on a **fresh base from current `main`** (which carries the 2027 calendar content from #9988 that the old #9981 branch would have regressed). See #7422, See #9981.

## Why #9981 was closed (the rescope)

#9981 was a broad stale-base *triage* (11 files) created **before** sibling #9988 (calendar freshness) merged. On rebase it would:
1. **Regress** the 2027 calendar content back to 2026 (the conflict root cause), and
2. carry **+852 lines of catalogue churn** (catalog-pr-hygiene HARD 1 violation) + a `HEALTH_DASHBOARD.md` edit that #9989 has since relocated to `docs/archive/reference/`.

Rather than force-rebase the messy branch (risk of silently undoing #9988/#9989), this PR starts clean from `origin/main` and applies **only** the accent cure to `teaching-context.md`. One file, one purpose.

## Verification (firsthand, post-cure)

| Check | Result |
|-------|--------|
| Files changed | **1** (`docs/reference/teaching-context.md`) |
| Diff symmetry | 53 insertions(+) / 53 deletions(-) = line replacements, no net add/remove |
| Nature of every changed line | **accent characters only** (é è à ê ç É À) + 1 `des`→`dès` (French "since") |
| 2027 calendar content (#9988) preserved | YES — "Écoles partenaires 2027", "Calendrier général 2027", "cycle 2027 ouvre à la rentrée" intact, NOT reverted to 2026 |
| Accented chars (was → now) | 0 → 51 |
| Residual unaccented prose words | **0** (only `Presentations` left — a literal GDrive directory name in a code span, correctly unaccented) |
| Catalogue files | byte-identical to main (untouched) |

## Scope

- 1 file, 1 domain (docs), accents only.
- No notebook re-exec needed (pure `.md`, rule C.2 exception: markdown-only edit).
- Canonical cure tool `restore_accents_canonical.py` (#7186) is **notebook-only** (`.ipynb` cell-source) and does not apply to standalone `.md`; cure done by careful transcription + full-diff verification (every line audited above).
- `#2876` scope (markdown-only STRICT, tranche 17/07) — standalone `.md` doc IS markdown, in scope.

See #7422 (docs/reference/ triage epic), See #9981 (superseded messy branch, closed).
