### PR TITLE
chore(gitignore,#10025): ignore Playwright storage-state (session cookies) + test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -755,6 +755,15 @@ videos/
 /.playwright-mcp/
 /calib/
 
+# Playwright test artifacts — storage-state.json holds session cookies/tokens
+# (SECRET) and the rest is regenerable. Prevents credential leak on commit.
+**/storage-state*.json
+**/playwright-report/
+**/test-results/
+**/playwright/.cache/
+**/playwright/.auth/
+**/blob-report/
+
 # Slidev pre-fix vs post-fix screenshot pairs (regenerable via Playwright)
 slides/*/analysis/_*.png
 


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2024:CoursIA — prev: MED/tooling #10055
Quoi:       ignore Playwright storage-state.json (session cookies/SECRET) + test artifacts in .gitignore (#10025)
Preuve:     git check-ignore firsthand: 6 target paths IGNORED, 0 over-match on tracked files
Perimetre:  .gitignore +9 lines; latent gap (storage-state was unprotected), not the stale 827-files premise


## Summary

Ajoute les artifacts standard Playwright au `.gitignore`. Le gap critique : `**/storage-state*.json` — Playwright y persiste **cookies/tokens de session (SECRET)** après login. Le `.gitignore` ne le protégeait pas : un run QA Playwright-OWUI sauvegardant l'état de session aurait pu être committé = **fuite de credentials**.

### Patterns ajoutés (`.gitignore`, +9)

```
**/storage-state*.json     # session cookies/tokens (SECRET)
**/playwright-report/      # HTML report (regenerable)
**/test-results/           # screenshots/videos/traces (regenerable)
**/playwright/.cache/
**/playwright/.auth/
**/blob-report/
```

`.playwright-mcp/` (le dir du MCP server) était déjà couvert (lignes 583/751/856). Le nouveau bloc couvre les **artifacts de test** Playwright standard (non couverts par le pattern VS `[Tt]est[Rr]esult*/` qui ne matche pas `test-results/` avec tiret).

## Validation (verify-before-claiming)

`git check-ignore` sur 6 chemins cibles → **tous IGNORED** :
- `.../Playwright-OWUI/storage-state.json` ✓
- `.../02-navigation-authentification/storage-state.json` ✓ (nested depth)
- `playwright-report/index.html` ✓
- `.../Playwright-OWUI/test-results/.last-run.json` ✓
- `playwright/.auth/user.json` ✓
- `playwright/.cache/...` ✓

**Aucune over-match** : `.gitignore`, `README.md`, `CLAUDE.md`, et `Playwright-OWUI/README.md` restent tracked.

## Note sur la premise de #10025

La premise originale de #10025 (827 fichiers non suivis dont un storage-state de session) est **stale sur origin/main** — corroborated po-2023 (c.9872+46) + po-2025 (c.1301+21) : mesure sur stale-tree, premise LARGELY FALSE. **Cette PR n'attaque pas la premise stale** — elle adresse le **gap latent indépendamment vérifié firsthand** : `storage-state.json` n'était PAS protégé par `.gitignore` (Grep confirmé sur le vrai fichier), indépendamment de la présence ou non des 827 fichiers. La tri du périmètre publiable des 827 fichiers reste un sujet séparé (judgment user) — non couvert ici.

## Scope

1 fichier, +9 lignes. Pas de notebook, pas de code. `fix(gitignore)`.

See #10025 (latent .gitignore gap adressé ; tri périmètre 827 fichiers reste ouvert).

