### PR TITLE
fix(notebook-tools): scrub lowercase pip home paths case-insensitively (Users|home)

### DIFF
--- a/scripts/notebook_tools/scrub_papermill_paths.py
+++ b/scripts/notebook_tools/scrub_papermill_paths.py
@@ -156,11 +156,20 @@ def scrub_notebook(nb_path, apply=False):
 # 'C:\Users\<user>'. A single-separator regex misses those entirely (regression:
 # archive Fast-Downward-Legacy #3891, where traceback frames scrubbed but the
 # final exception line did not).
+#
+# Both patterns are case-insensitive (re.IGNORECASE) on `Users|home` because pip
+# prints its install roots in lowercase: 'Requirement already satisfied: openai
+# in c:\users\jsboi\appdata\roaming\python\...'. A case-sensitive 'Users' left
+# such lowercase pip roots in place (regression: 1_OpenAI_Intro cell[4], 14
+# leaks silently missed). The drive-letter class [A-Za-z] plus the segment
+# boundary (a separator before Users/home) keep the FP surface unchanged: a bare
+# 'users' word elsewhere still does not match (e.g. 'C:\SomeUsers' has no
+# separator before 'Users'), so IGNORECASE only widens coverage, not the FP set.
 _HOME_RES = [
     # Windows drive home: C:\Users\<user> or C:/Users/<user>  (single capture -> ~)
-    re.compile(r"[A-Za-z]:[\\/]+(?:Users|home)[\\/]+[^\\/]+"),
+    re.compile(r"[A-Za-z]:[\\/]+(?:Users|home)[\\/]+[^\\/]+", re.IGNORECASE),
     # POSIX-style home root as written by some MSYS/git-bash tools: /c/Users/<user>
-    re.compile(r"/[a-zA-Z]/(?:Users|home)/[^/]+"),
+    re.compile(r"/[a-zA-Z]/(?:Users|home)/[^/]+", re.IGNORECASE),
 ]
 
 # Checkout-root prefixes: a drive-absolute path into the repo checkout (any

--- a/scripts/notebook_tools/tests/test_scrub_papermill_paths.py
+++ b/scripts/notebook_tools/tests/test_scrub_papermill_paths.py
@@ -275,6 +275,41 @@ def test_scrub_outputs_anonymizes_home_and_preserves_rest(tmp_path):
     assert before.replace("C:\\\\Users\\\\jsboi", "~") == after
 
 
+def test_scrub_outputs_anonymizes_lowercase_pip_home(tmp_path):
+    """A lowercase pip install root (c:\\users\\<user>) must be scrubbed.
+
+    Regression: 1_OpenAI_Intro cell[4]. pip prints its install roots in
+    lowercase ('Requirement already satisfied: openai in
+    c:\\users\\jsboi\\appdata\\roaming\\python\\...'), and the home regex's
+    'Users' alternative was case-SENSITIVE, so all 14 lowercase leaks were
+    silently missed by both --scan and --outputs --apply. Adding re.IGNORECASE
+    makes 'c:\\users' match just like 'C:\\Users'. The FP surface is unchanged
+    because a separator is still required before the Users/home segment.
+    """
+    raw = (
+        "Requirement already satisfied: openai in "
+        "c:\\users\\jsboi\\appdata\\roaming\\python\\site-packages (1.93.0)\n"
+    )
+    p = _write_nb_with_output(tmp_path / "nb.ipynb", "%pip install openai", raw)
+    before = p.read_text(encoding="utf-8")
+
+    found, fixed = scrub_output_paths(str(p), apply=True)
+    assert found == 1
+    assert fixed >= 1
+
+    after = p.read_text(encoding="utf-8")
+    # lowercase home root anonymized (was left in place by the case-sensitive bug)
+    assert "c:\\\\users\\\\jsboi" not in after
+    assert "~" in after
+    # rest of the pip message preserved (package + version + tail)
+    assert "site-packages" in after
+    assert "1.93.0" in after
+    # source cell byte-identical
+    assert json.loads(after)["cells"][0]["source"] == ["%pip install openai"]
+    # the ONLY change is the lowercase home-root substring -> ~
+    assert before.replace("c:\\\\users\\\\jsboi", "~") == after
+
+
 def test_scrub_outputs_anonymizes_ipykernel_pid(tmp_path):
     raw = (
         "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_85268\\3959998143.py:74: "


### PR DESCRIPTION
fix(notebook-tools): scrub lowercase pip home paths case-insensitively (Users|home)

Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-dotnet #10052 (CSP-9 .nuget category-A, mergeable clean)

## Quoi

The `--outputs` scrubber in `scrub_papermill_paths.py` silently missed **lowercase** machine-local home paths. `_HOME_RES` matched the `Users|home` segment **case-sensitively**, but `pip` prints its install roots in lowercase:

```
Requirement already satisfied: openai in c:\users\jsboi\appdata\roaming\python\site-packages (1.93.0)
```

`c:\users\jsboi` never matched the case-sensitive `Users`, so both `--scan` and `--outputs --apply` returned `0 fixed` while the leak stayed in place. The pre-commit hook therefore failed to scrub a whole class of real PII-lite leaks (username in pip install roots — the single most common pip output on Windows user-installs).

Fix = add `re.IGNORECASE` to **both** `_HOME_RES` patterns (Windows drive + POSIX MSYS/git-bash). **Root-cause fix for the class-B output-text defect class** — durable tooling repair, not a per-notebook re-exec.

## Preuve

- **Bug confirmed via regex probe** (case-sensitivity): the current regex returned `False` on `c:\users\jsboi` (lowercase) and `True` on `C:\Users\jsboi` (uppercase) — same path, only case differs. With `re.IGNORECASE` both return `True`, and the FP guard holds: `C:\SomeUsers` (no separator before `Users`) returns `False`.
- **New regression test** `test_scrub_outputs_anonymizes_lowercase_pip_home` (mirrors the exact 1_OpenAI_Intro cell[4] pip pattern): `found == 1`, `fixed >= 1`, `c:\\users\\jsboi` gone, `~` present, `site-packages` + version preserved, source byte-identical, ONLY the home-root substring changed. **PASSES.**
- **No regression**: `130 passed` across `test_scrub_papermill_paths.py` (30) + `test_detect_papermill_path_leak.py` (31) + `test_strip_machine_paths.py` (69). Existing uppercase tests unchanged.
- **End-to-end on the failing notebook** (`1_OpenAI_Intro.ipynb` cell[4], read via `git show origin/main:`):
  - occurrences of `users\jsboi` **BEFORE scrub: 14**
  - occurrences **AFTER scrub with the fixed hook: 0**
  - source cell byte-identical (`True`); `find_output_path_defects found=1 fixed=1`.
  - The case-sensitive (buggy) version returned `0` here — this is the silent miss the fix closes.

## Périmètre

- **2 files** (tooling only): `scripts/notebook_tools/scrub_papermill_paths.py` (+13/-2, the `re.IGNORECASE` flag on both `_HOME_RES` patterns + an explanatory comment) and `scripts/notebook_tools/tests/test_scrub_papermill_paths.py` (+35, the regression test). **No notebook touched** — this is a hook fix, atomic.
- **FP surface unchanged**: a separator (`[\\/]+`) is still required before the `Users|home` segment, so a bare `users` word elsewhere (e.g. prose, `C:\SomeUsers`) does not match. IGNORECASE only widens **coverage**, not the false-positive set. Only `_HOME_RES` needs the flag — `_REPO_RES`/`_REPO_POSIX_RES` match the fixed-case literal `CoursIA`, and the PID/temp-id patterns are numeric.
- **Follow-ups (separate PRs, NOT this one)**: applying the now-corrected hook to the affected notebooks (e.g. `1_OpenAI_Intro`, `QC-Py-04` ipykernel-temp, Planners) comes as per-notebook PRs (same atomic pattern as the .nuget sweep #10046/#10051/#10052), each with its twin-parity rebaseline if applicable. This PR ships the durable tooling repair first so the pre-commit hook catches the class automatically going forward.

See #8052 (claims-vs-outputs / output-path-leak defect class) · See #6529 (category-A kernel-injection, sibling strip hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)