### PR TITLE
fix(security): scrub non-deterministic ipykernel PID from QC-Py-04 stderr outputs

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb
@@ -437,7 +437,7 @@
     {
      "output_type": "stream",
      "name": "stderr",
-     "text": "/tmp/ipykernel_71/875978701.py:2: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['returns'] = df_spy['close'].pct_change()\n/tmp/ipykernel_71/875978701.py:5: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['cumulative_returns'] = (1 + df_spy['returns']).cumprod()\n"
+     "text": "/tmp/ipykernel_<pid>/875978701.py:2: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['returns'] = df_spy['close'].pct_change()\n/tmp/ipykernel_<pid>/875978701.py:5: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['cumulative_returns'] = (1 + df_spy['returns']).cumprod()\n"
     }
    ],
    "source": [
@@ -540,7 +540,7 @@
     {
      "output_type": "stream",
      "name": "stderr",
-     "text": "/tmp/ipykernel_71/2338322283.py:2: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['volatility_30d'] = df_spy['returns'].rolling(30).std() * np.sqrt(252)\n"
+     "text": "/tmp/ipykernel_<pid>/2338322283.py:2: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['volatility_30d'] = df_spy['returns'].rolling(30).std() * np.sqrt(252)\n"
     },
     {
      "output_type": "display_data",
@@ -715,7 +715,7 @@
     {
      "output_type": "stream",
      "name": "stderr",
-     "text": "/tmp/ipykernel_71/2737840623.py:2: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['sma_50'] = df_spy['close'].rolling(50).mean()\n/tmp/ipykernel_71/2737840623.py:3: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['sma_200'] = df_spy['close'].rolling(200).mean()\n"
+     "text": "/tmp/ipykernel_<pid>/2737840623.py:2: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['sma_50'] = df_spy['close'].rolling(50).mean()\n/tmp/ipykernel_<pid>/2737840623.py:3: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['sma_200'] = df_spy['close'].rolling(200).mean()\n"
     }
    ],
    "source": [
@@ -756,7 +756,7 @@
     {
      "output_type": "stream",
      "name": "stderr",
-     "text": "/tmp/ipykernel_71/2273594491.py:2: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['signal'] = 0\n/tmp/ipykernel_71/2273594491.py:7: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['position'] = df_spy['signal'].shift(1)\n"
+     "text": "/tmp/ipykernel_<pid>/2273594491.py:2: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['signal'] = 0\n/tmp/ipykernel_<pid>/2273594491.py:7: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['position'] = df_spy['signal'].shift(1)\n"
     }
    ],
    "source": [
@@ -808,7 +808,7 @@
     {
      "output_type": "stream",
      "name": "stderr",
-     "text": "/tmp/ipykernel_71/2881660513.py:2: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['strategy_returns'] = df_spy['position'] * df_spy['returns']\n/tmp/ipykernel_71/2881660513.py:5: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['strategy_cumulative'] = (1 + df_spy['strategy_returns']).cumprod()\n"
+     "text": "/tmp/ipykernel_<pid>/2881660513.py:2: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['strategy_returns'] = df_spy['position'] * df_spy['returns']\n/tmp/ipykernel_<pid>/2881660513.py:5: SettingWithCopyWarning: \nA value is trying to be set on a copy of a slice from a DataFrame.\nTry using .loc[row_indexer,col_indexer] = value instead\n\nSee the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n  df_spy['strategy_cumulative'] = (1 + df_spy['strategy_returns']).cumprod()\n"
     }
    ],
    "source": [


### PR DESCRIPTION
fix(security): scrub non-deterministic ipykernel PID from QC-Py-04 stderr outputs

Grain: LIGHT/security — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #10058 (c.9872+53, hook case-sensitive fix, CI all PASS, mergeable)

## Quoi

`QC-Py-04-Research-Workflow.ipynb` carried a non-deterministic kernel PID in 5 pandas `SettingWithCopyWarning` stderr outputs: `/tmp/ipykernel_71/875978701.py:2: ...`. The PID `71` is process-specific (changes every kernel restart), which made the committed output churn at every re-exec and exposed a process fingerprint. Fix = `scrub_papermill_paths.py --outputs --apply` (official hook) → anonymize `ipykernel_71` → `ipykernel_<pid>`. This is the accepted hook for non-deterministic environment noise (PID/temp/regenerated-each-run): re-exec cannot cure it because a fresh PID leaks each run (cf the hook's docstring + the `test_scrub_outputs_anonymizes_ipykernel_pid` regression test).

## Preuve

- **Defect scan** (`detect_papermill_path_leak.py --scan-all --outputs` on fresh `origin/main`): QC-Py-04 = 9 occurrences `/tmp/ipykernel_71/` across 5 stderr output-blobs (the 2nd-worst class-B file after 1_OpenAI_Intro's 14).
- **Apply** (`scrub_papermill_paths.py --apply --outputs`): 5 output leak(s), 1 notebook fixed. Diff = **5 insertions / 5 deletions**, perfectly symmetric.
- **Surgical**: the ONLY change is the substring `ipykernel_71` → `ipykernel_<pid>` in the 5 stderr texts. Everything else is byte-identical: `/tmp/` (generic, not PII), the cell-hash filenames `875978701.py`/`2338322283.py`/etc (diagnostic value), the full `SettingWithCopyWarning` message + pandas docs link (pedagogical), line numbers `:2:`/`:5:`/`:7:`, and **all `"source"` cells** (0 source lines changed, C.3 scope respected).
- **C.2 verify**: 28 code cells, `execution_count=None` = 0, JSON valid, 5 outputs now carry `ipykernel_<pid>` / 0 still leaking a raw PID.

## Périmètre

- **1 file**: `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb` (QuantConnect Python family — distinct from the ML/Search/GenAI families of prior cycles). Output-only PID anonymization, source byte-identical.
- **Not a twin pair** (no entry in `twin_pairs.d/`) → no rebaseline needed.
- **INDEPENDENT of #10058**: the leaks here are POSIX `/tmp/ipykernel_71/` (kernel PID), anonymized by the `_IPYKERNEL_PID` regex which is already on `origin/main`. #10058 fixed the lowercase pip-home case-sensitivity (a different mechanism). This PR branches fresh from `origin/main` and is **not stacked** on #10058 — either can merge first.
- **Not Stop-&-Repair-banned**: this is the official hook for non-deterministic PID noise (regenerated each run), not a hand-edit masking a fixable leak. The source of the warnings (pandas `SettingWithCopyWarning`) is legitimate pedagogical content, preserved as-is.
- Hors scope: the other class-B files (1_OpenAI_Intro pip-home lowercase = needs #10058 merged first; ML-3/CSP-2/CSP-9 = pending in #10046/#10051/#10052, file-collision if touched now; ICT-15c/SW-13/MusicGen = pending in #10054).

See #10000 (path-leak family) · See #8052 (claims-vs-outputs / output-path-leak defect class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)