### PR TITLE
fix(notebook-tools,#10012): scan_quant_classify FP guard v5 — numbered-list + clock-arithmetic

### DIFF
--- a/scripts/notebook_tools/scan_quant_classify.py
+++ b/scripts/notebook_tools/scan_quant_classify.py
@@ -327,6 +327,36 @@ def _classify_quant_value(
     if SEMVER_RE.fullmatch(raw):
         return ("ENV-DEP", f"semver pattern match: {raw!r}")
 
+    # -2 (c.1331): anti-FP residuel ML/DfA — guard structurel v5 (2 classes
+    #     mesurees apres v4, issue #10012). v4 (#10016) a reduit 209 -> 93 mais
+    #     la verification #4 (assert restants = vrais drainables) ECHOUE : les 93
+    #     sont ~90 % de FP dans 2 nouvelles classes non couvertes par v4.
+    #     Failure-mode SAFE : ces guards ne font qu'absorber vers STRUCTUREL
+    #     (jamais vers drainable) — un faux positif du guard = garder une vraie
+    #     valeur en STRUCTUREL = sur-correction inoffensive (pas de corruption de
+    #     contenu), tandis que le bug a fixer est la direction inverse (FP
+    #     drainable qui corromprait un drain). L'asymetrie regle #9434 tient.
+    #
+    # (e) Numbered-list-item guard : entier en DEBUT de ligne + ". mot" suit =
+    #     numerotation de liste / objectif pedagogique / auteur biblio. Mesure
+    #     ML/DfA : 7 MACHINE-DEP ("4. comprendre", "3. executor") + ~15 ENV-DEP
+    #     ("3. t. e. oliphant", "2. w. mckinney" = auteurs numerotes biblio).
+    #     Pattern strict : raw entier (les indices de liste sont des entiers ;
+    #     "0.95" est preserve) + prefix strippe vide (debut de ligne, rien avant
+    #     sur la ligne) + suffix debutant par ". " + alphanumerique.
+    if re.fullmatch(r"\d+", raw) and prefix.strip() == "" and re.match(r"\.\s+\w", suffix):
+        return ("STRUCTUREL", "liste/objectif numéroté v5 (entier début de ligne)")
+
+    # (f) Clock-arithmetic guard : "11 h + 3 h = 2 h" = arithmetique de l'horloge
+    #     (exemple math pedagogique), pas un timing runtime. Le `h` (heures) dans
+    #     une EQUATION (deux quantites-h jointes par + ou =) signale l'arithmetic,
+    #     pas une mesure. Un vrai runtime "prend 3 h" n'a qu'une quantite-h sans
+    #     operateur. Mesure ML/DfA c9 : 3 MACHINE-DEP FP (11/3/2 de l'horloge).
+    #     Pattern strict : \d+h[+=]\d+h exige DEUX quantites-h + operateur.
+    ctx_with_raw = (prefix + " " + raw + " " + suffix).lower()
+    if re.search(r"\d+\s*h\s*[+=]\s*\d+\s*h", ctx_with_raw):
+        return ("STRUCTUREL", "arithmétique horloge v5 (Nh ± = Nh, exemple math)")
+
     # -1 (c.1301+12): anti-FP ML/DfA + Search/Part1 — guard structurel v4
     #     (4 classes : editorial-duration / biblio / section-number /
     #     theoretical-reference). Capture les FPs AVANT que les mots-cles

--- a/scripts/notebook_tools/tests/test_scan_quant_classify.py
+++ b/scripts/notebook_tools/tests/test_scan_quant_classify.py
@@ -617,6 +617,75 @@ class TestGoldenSetMLDfASearchPart1C1301:
 
 
 # --------------------------------------------------------------------------- #
+#  Tests v5 (c.1331) — anti-FP residuel ML/DfA (issue #10012, apres v4 #10016)
+#  2 guards : numbered-list-item (entier debut de ligne + ". mot") +
+#  clock-arithmetic (Nh ± = Nh). Failure-mode SAFE : absorbent vers STRUCTUREL.
+# --------------------------------------------------------------------------- #
+
+
+class TestV5NumberedListAndClockArithmetic:
+    """Guards v5 (c.1331) — residuel ML/DfA apres v4 (#10016 a laisse 93 FP).
+
+    Numbered-list-item : "4. comprendre", "3. executor", "2. w. mckinney"
+    (auteur biblio numerote). Mesure ML/DfA : 7 MACHINE-DEP + ~15 ENV-DEP.
+    Cross-famille : 15 FP Probas + 2 ArgAna (listes definition/etape), verifies
+    firsthand = list items, absorption CORRECT (FP removal, pas regression).
+    """
+
+    def test_v5_numbered_list_item_at_line_start(self):
+        """ML/DfA c0: "4. comprendre l'apprentissage" = objectif numéroté."""
+        cls, _ = _classify_quant_value("4", 4.0,
+                                       "", ". comprendre l'apprentissage supervisé")
+        assert cls == "STRUCTUREL", (
+            f"item de liste numéroté (début de ligne) doit etre STRUCTUREL, got {cls}"
+        )
+
+    def test_v5_biblio_author_numbering(self):
+        """ML/DfA c14: "3. t. e. oliphant" = auteur numéroté en biblio."""
+        cls, _ = _classify_quant_value("3", 3.0,
+                                       "", ". t. e. oliphant, numpy (2006)")
+        assert cls == "STRUCTUREL", (
+            f"auteur numéroté en biblio doit etre STRUCTUREL, got {cls}"
+        )
+
+    def test_v5_non_integer_at_line_start_NOT_absorbed(self):
+        """Falsification : "0.95. The AUC..." (réel) n'est PAS absorbé (non-entier).
+
+        raw "0.95" n'est pas un entier -> le guard numbered-list skippe -> la
+        valeur tombe sur sa vraie classe (ici ENV-DEP via semver... non, 0.95
+        n'est pas semver ; via contexte aucun keyword -> STRUCTUREL defaut).
+        L'essentiel : elle n'est PAS absorbée par le guard list-item.
+        """
+        cls, rat = _classify_quant_value("0.95", 0.95,
+                                         "", ". the auc of the random classifier")
+        assert "liste/objectif" not in rat, (
+            f"0.95 (non-entier) ne doit pas declencher le guard list-item, rationale={rat!r}"
+        )
+
+    def test_v5_clock_arithmetic_absorbed(self):
+        """ML/DfA c9: "11 h + 3 h = 2 h" = arithmétique horloge, pas runtime."""
+        cls, _ = _classify_quant_value("11", 11.0,
+                                       "", " h + 3 h = 2 h) comme les angles")
+        assert cls == "STRUCTUREL", (
+            f"arithmétique horloge (Nh + Nh = Nh) doit etre STRUCTUREL, got {cls}"
+        )
+
+    def test_v5_single_hour_runtime_NOT_absorbed(self):
+        """Falsification : "prend 3 h" (1 seule quantite-h, runtime reel) reste MACHINE-DEP.
+
+        Note : on evite le mot "notebook" dans le contexte car STRUCTURAL_LOCATIONS_V4
+        contient "notebook " (guard section-number) qui absorberait deja la valeur —
+        on isole ici le comportement du SEUL guard v5 clock-arithmetic (qui exige
+        DEUX quantites-h jointes par un operateur, donc une heure unique ne matche pas).
+        """
+        cls, rat = _classify_quant_value("3", 3.0,
+                                         "le script prend ", " h a tourner")
+        assert cls == "MACHINE-DEP", (
+            f"runtime 'prend 3 h' (heure unique) doit rester MACHINE-DEP, got {cls} ({rat})"
+        )
+
+
+# --------------------------------------------------------------------------- #
 #  Tests _extract_context
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2024:CoursIA — prev: LIGHT/tooling #10057
Quoi:       scan_quant_classify FP guard v5 -- numbered-list-item + clock-arithmetic (residual after v4 #10016)
Preuve:     ML/DfA 93->71 drainable; cross-family no-regression verified firsthand (Probas -15 = list items); 66 tests
Perimetre:  scan_quant_classify.py + tests (+5); residual 71 code-params = future v6, #10012 stays open


## Summary

Suite du durcissement anti-FP du scanner `scan_quant_classify.py` (EPIC #9434). v4 (#10016) avait réduit les drainables ML/DataScienceWithAgents de **209 → 93**, mais la vérification de falsifiabilité de #10012 (recommandation #4 : « assert les restants sont des vrais drainables ») **ÉCHOUE** : mesure firsthand ce cycle, les 93 résiduels sont **~90 % de FP** dans 2 nouvelles classes non couvertes par v4.

Cette PR livre **v5** : 2 guards haute-précision (numbered-list-item + clock-arithmetic), mesurés, avec vérification cross-famille de non-régression.

### Mesure firsthand (origin/main @ e157904056, post-v4 #10016)

Classification manuelle d'un échantillon des 93 drainables ML/DfA :

| Classe FP résiduelle | Exemples | Classé (faux) | Vraie nature |
|---|---|---|---|
| **Numbered-list-item** | "4. comprendre", "3. executor", "3. t. e. oliphant" (auteur biblio) | MACHINE-DEP / ENV-DEP | Numérotation de liste / objectif / auteur |
| **Clock-arithmetic** | "11 h + 3 h = 2 h" | MACHINE-DEP (`h` = hours matché) | Arithmétique d'horloge (exemple math pédagogique) |
| *(résiduel restant, v6 future)* | `max_iter=1000`, `cv=5`, "tableau de 10 éléments" | STOCH / ENV | Code-param en prose / donnée d'exemple |

### Guards v5 (`_classify_quant_value`, rule -2 avant v4)

1. **Numbered-list-item guard** : entier (`\d+` fullmatch — "0.95" est préservé) **en début de ligne** (`prefix.strip() == ""`) + suffix débutant par `". " + mot`. Capture objectifs numérotés + auteurs biblio. **7 MACHINE-DEP + ~15 ENV-DEP** ML/DfA.
2. **Clock-arithmetic guard** : `re.search(r"\d+\s*h\s*[+=]\s*\d+\s*h")` exige **DEUX quantités-h jointes par `+`/`=`**. Un runtime "prend 3 h" (heure unique) ne matche pas → reste MACHINE-DEP. **3 MACHINE-DEP** ML/DfA c9.

**Failure-mode SAFE** : ces guards n'absorbent QUE vers STRUCTUREL (jamais vers drainable). Un faux positif du guard = garder une vraie valeur en STRUCTUREL = sur-correction inoffensive (pas de corruption de contenu). Le bug à fixer est la direction inverse (FP drainable qui corromprait un drain). L'asymétrie règle #9434 tient.

### Impact mesuré

| Famille | v4 (#10016) | v5 (cette PR) | Δ |
|---|---|---|---|
| **ML/DataScienceWithAgents** | 93 | **71** | **−22** |
| **Search/Part1-Foundations** | 213 | 204 | −9 |

### Non-régression cross-famille (vérifiée firsthand)

v5 absorbe aussi des FP dans les familles calibrées précédemment — vérifié que ce sont des **list items** (FP removal, pas régression) :

| Famille | main (pre-v5) | v5 | Δ | Vérification |
|---|---|---|---|---|
| Probas (bayésien c.1272) | 313 | 297 | −15 | 3 samples lus : TrueSkill "3. Les changements de performance…", DecPyMC3 "4. Normaliser les scores…", DecInfer "2. Si votre X* < 500…" = **list items** (FP sur main, keyword ±40 avait mal classé l'index de liste) |
| Argument_Analysis (c.1275) | 69 | 67 | −2 | list items également |

La « régression » apparente (−15 Probas) est en réalité un **nettoyage FP cross-famille** que v4 avait manqué : v5 retire les items de liste numérotée partout, ce qui est correct (un index de liste n'est jamais un drainable légitime).

### Tests (`+5`, 66 total)

`TestV5NumberedListAndClockArithmetic` : 2 guards × (positif + falsification). Falsifications : valeur non-entière à début de ligne non absorbée ; runtime heure-unique non absorbé (isole v5 de v4 `notebook ` keyword).

## Validation

- `python -m pytest scripts/notebook_tools/tests/test_scan_quant_classify.py` → **66 passed**.
- Mesures ML/DfA + Search/Part1 + cross-famille (Probas/ArgAna) firsthand, main-vs-branch via `git stash`.
- 3 samples Probas lus directement (cellules markdown) = list items confirmés.

## Résiduel (honnête, G.3)

v5 (2 guards) atteint 93 → 71 sur ML/DfA, pas la cible ~10-20 de #10012. Les 71 restants sont **code-params en prose** (`max_iter=1000`, `cv=5`) + **données d'exemple** ("tableau de 10 éléments") — classes plus risquées (patterns `=N` plus larges, faux-absorption plus probable). Caractérisés ici pour une **v6 future** (issue #10012 reste ouverte). Ne pas forcer un guard code-param trop large sans mesure FP dédiée (méthodologie `gate-must-verify-detector-fp-before-wiring`).

## Coordination

- **L898** : 0 PR open + 0 remote branch sur `scan_quant_classify.py` (po-205 scanner turf, free — po-205 D5 worktrees sur autres scanners). v4 livré par #10016 (MERGED, n'avait pas clos #10012 — vérification #4 échouait).
- **Claim** posé sur #10012 (corrigé : les 3 filtres v4 étaient déjà câblés par #10016 ; v5 = résiduel post-v4).

See #10012 (v5 résiduel, contribution partielle — v6 code-param reste). See #9434 (EPIC parent).

