### PR TITLE
ci(variation,#10020): variation-light-genre workflow - 4 GENRE signals as advisory labels

### DIFF
--- a/.github/workflows/variation-light-genre.yml
+++ b/.github/workflows/variation-light-genre.yml
@@ -172,8 +172,32 @@ jobs:
             COLOR=$(echo "$LABEL_PAIR" | cut -d: -f2)
             SIGNAL=$(echo "$LABEL_PAIR" | cut -d: -f3)
             DESC=$(echo "$LABEL_PAIR" | cut -d: -f4)
-            SIGVAR="SIG_$(echo "$SIGNAL" | tr '-' '_')"
-            SIGVAL=$(eval "echo \$$SIGVAR")
+            # Mapping explicite SIGNAL -> nom de variable (evite le `eval`
+            # dynamique qui, avec `set -u`, fait sortir en 1 sur le tout
+            # premier signal dont le nom contient un hyphen --
+            # SIG_TIER_INFLATION n'existe pas, le nom canonique est
+            # SIG_INFLATION ; idem SIG_GENRE_RUN vs SIG_RUN). Les noms
+            # sont fixes (cf scripts/variation_light_cap.py), une table
+            # explicite reste la lecture la moins fragile.
+            case "$SIGNAL" in
+              TIER-INFLATION)        SIGVAR="SIG_INFLATION" ;;
+              GENRE-RUN)             SIGVAR="SIG_RUN" ;;
+              CAP-EXCEEDED-BY-GENRE) SIGVAR="SIG_CAPEXC" ;;
+              GENRE-MISMATCH)        SIGVAR="SIG_MISMATCH" ;;
+              *)
+                echo "Signal non reconnnu : ${SIGNAL} (PR ${PR_NUMBER})"
+                SIGVAR="__UNDEFINED__"
+                ;;
+            esac
+            if [ "$SIGVAR" = "__UNDEFINED__" ]; then
+              SIGVAL="False"
+            else
+              # Expansion indirecte bash (${!VAR}) avec default pour eviter
+              # l'`eval` dynamique (qui ne survit pas a `set -u` sur var
+              # absente). Le `:-False` couvre le cas d'une variable non
+              # initialisee ; on en reste a SIGVAL=False sans crasher.
+              SIGVAL="${!SIGVAR:-False}"
+            fi
             gh label create "$LABEL" --description "$DESC" --color "$COLOR" --force 2>/dev/null || true
             if [ "$SIGVAL" = "True" ]; then
               gh pr edit "$PR_NUMBER" --add-label "$LABEL" 2>/dev/null || true

--- a/.github/workflows/variation-light-genre.yml
+++ b/.github/workflows/variation-light-genre.yml
@@ -1,0 +1,225 @@
+name: Variation Light Genre Signals
+
+# #10020 (issue, out-of-scope grain from PR #10031) -- CI workflow qui
+# surface les 4 signaux G-VAR-2/3-by-GENRE au moment du PR :
+#
+#   * TIER-INFLATION          (le declared-LIGHT vs effective-LIGHT-genre diverge)
+#   * GENRE-RUN               (>= 2 grains consecutifs du meme genre LIGHT)
+#   * CAP-EXCEEDED-BY-GENRE   (light_genre > cap partage G-VAR-2)
+#   * GENRE-MISMATCH          (declared genre vs _genre_from_paths)
+#
+# PR #10031 a livre le script (compute_signals + 16 tests + le live replay
+# sur le cas de reference po-2025:CoursIA-2 du 2026-08-08) ; cette PR livre
+# la plomberie CI : sparse-checkout, dataset merged du jour UTC, lane
+# extraite du tag Grain: de la PR ouverte, candidate_files via
+# `gh pr view --json files`, labels distincts par signal, commentaire
+# idempotent, sortie toujours 0 (advisory).
+#
+# ADVISORY, jamais bloquant : le script sort en 0 meme quand tous les
+# signaux sont True. C'est le consommateur (coordinateur a la passe de
+# merge, lecture `gh pr list --json labels`) qui prend la decision. Le
+# merge-gate lit le LABEL, pas l'etat du check (lecon L875 -- un check
+# vert ne dit rien sur le contenu du verdict, un label distinctif le dit).
+#
+# Cf variation-tag-guard.yml `check-light-cap` pour le modele de plomberie
+# (meme sparse-checkout, meme garde-fou bots+forks, meme idiome de label
+# distinct par classe de defaut, meme commentaire idempotent via marqueur
+# HTML invisible). Ce workflow est strictement parallele : il s'appuie sur
+# la meme source de verite (variation_light_cap.py) et ajoute les 4
+# signaux GENRE que le cap TIER ne sait pas voir.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  check-light-genre-signals:
+    name: G-VAR-2/3 GENRE signals (advisory, #10020)
+    runs-on: ubuntu-latest
+    steps:
+      # variation_light_cap.py importe grain_tag.py (#9485 : extracteur
+      # partage avec le guard tag). Les deux modules sont checkout ensemble
+      # par le meme step sparse-checkout -- memes precautions que dans
+      # variation-tag-guard.yml `check-light-cap`.
+      - name: Checkout the cap detector (sparse)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/variation_light_cap.py
+            scripts/grain_tag.py
+      - name: G-VAR-2/3 by GENRE (TIER-INFLATION, GENRE-RUN, CAP-EXCEEDED, GENRE-MISMATCH)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          set -uo pipefail
+
+          # Meme garde-fou anti-spam que variation-tag-guard : bots et forks
+          # hors scope (bots = catalogue auto-regenere, forks = PRs etudiantes
+          # .claude/rules/student-pr-reviews.md -- review bienveillante, aucun
+          # critere interne ne s'y applique).
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issue d'un fork : hors scope (PR etudiante)."
+            exit 0
+          fi
+
+          # Jour courant en UTC : G-VAR-2 se compte par jour UTC (reset 00:00Z),
+          # meme convention que `check-light-cap`. La PR courante est OUVERTE
+          # donc elle n'est PAS dans le set -- c'est ce qui rend la detection
+          # du 2e grain consecutif possible.
+          TODAY=$(date -u +%Y-%m-%d)
+          gh pr list --state merged --search "merged:$TODAY" \
+            --json number,body,mergedAt,labels > /tmp/merged.json 2>/dev/null || \
+            printf '[]' > /tmp/merged.json
+
+          # Body circule par fichier : printf '%s' ne reinterprete rien (cf
+          # variation-tag-guard `check-light-cap`, meme idiome).
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          # Lane : on extrait du tag Grain: de la PR OUVERTE. L'extracteur
+          # partage grain_tag.py est la source unique (cf #9485) -- sinon
+          # le guard et l'organe re-divergeraient. Si la lane est absente
+          # (tag manquant, lane non declaree), on ne peut rien calculer :
+          # sortie 0 avec un echo diagnostique, sans label (un grain sans
+          # lane est un autre defaut que G-VAR-2/3-by-GENRE -- le guard tag
+          # l'a deja signale via variation-tag-lane-missing, ce serait du
+          # bruit de re-notifier ici).
+          LANE=$(python3 scripts/grain_tag.py --body-file /tmp/pr_body.txt 2>/dev/null \
+            | python3 -c "import json,sys; print(json.load(sys.stdin).get('lane') or '')" 2>/dev/null || echo "")
+          if [ -z "$LANE" ]; then
+            echo "Lane absente du tag Grain: de la PR. variation-tag-guard l'a surement deja signalee ; ce job n'a rien a calculer sur G-VAR-2/3-by-GENRE."
+            exit 0
+          fi
+          echo "Lane ciblee : ${LANE}"
+
+          # Labels de la PR courante : la requalification #8970 (grain-requalified:<TIER>)
+          # peut etre pre-appliquee sur la PR ouverte -- le script la prend en
+          # compte via load_labels_file, comme dans check-light-cap.
+          gh pr view "$PR_NUMBER" --json labels > /tmp/pr_labels.json 2>/dev/null || \
+            printf '[]' > /tmp/pr_labels.json
+
+          # Fichiers du diff : pour GENRE-MISMATCH (declared genre vs
+          # _genre_from_paths). gh pr view --json files renvoie un tableau
+          # de {path: ...}. On extrait les paths en JSON-lines, on join en
+          # CSV passe a --files. MUTATION : si le tableau est vide (PR sans
+          # fichiers, rare mais legal), on passe --files "" ce qui rend
+          # GENRE-MISMATCH inactif (cf compute_signals : "missing input is
+          # a missing signal, never a false positive").
+          gh pr view "$PR_NUMBER" --json files > /tmp/pr_files.json 2>/dev/null || \
+            printf '[]' > /tmp/pr_files.json
+          FILES_CSV=$(python3 -c "
+          import json
+          try:
+              data = json.load(open('/tmp/pr_files.json'))
+              files = data if isinstance(data, list) else data.get('files', [])
+              paths = [f.get('path','') for f in files if isinstance(f, dict)]
+              paths = [p for p in paths if p]
+              print(','.join(paths))
+          except Exception:
+              print('')
+          " 2>/dev/null || echo "")
+
+          # Invocation du detecteur. Exit 0 toujours (advisory -- meme
+          # posture que check-light-cap : le script sort en 0, c'est le
+          # label qui porte le signal). 2>/tmp/cap.err preserve stderr
+          # diagnostique si le parseur tombe (cf le meme idiome dans
+          # variation-tag-guard).
+          python3 scripts/variation_light_cap.py \
+            --replay /tmp/merged.json \
+            --genre-signals \
+            --lane "${LANE}" \
+            --body-file /tmp/pr_body.txt \
+            --labels-file /tmp/pr_labels.json \
+            --files "${FILES_CSV}" > /tmp/signals.json 2>/tmp/cap.err || true
+
+          echo "--- detector output ---"
+          cat /tmp/signals.json 2>/dev/null || true
+          [ -s /tmp/cap.err ] && { echo "--- detector stderr ---"; cat /tmp/cap.err; } || true
+
+          # Lecture des 4 signaux + de la tally light_genre/cap (pour le
+          # commentaire diagnostique quand CAP-EXCEEDED-BY-GENRE tire).
+          SIG_INFLATION=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('TIER-INFLATION'))" 2>/dev/null || echo "False")
+          SIG_RUN=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('GENRE-RUN'))" 2>/dev/null || echo "False")
+          SIG_CAPEXC=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('CAP-EXCEEDED-BY-GENRE'))" 2>/dev/null || echo "False")
+          SIG_MISMATCH=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('GENRE-MISMATCH'))" 2>/dev/null || echo "False")
+          TALLY=$(python3 -c "import json; t=json.load(open('/tmp/signals.json')).get('tally',{}); print(f\"declared={t.get('light_declared',0)} genre={t.get('light_genre',0)} cap={t.get('cap',1)}\")" 2>/dev/null || echo "inconnu")
+
+          # Labels distincts (lisibles dans gh pr list --json labels). Chaque
+          # classe de defaut a son propre label -- un seul label fourre-tout
+          # aurait cache la nature du manquement (lecon du tag guard L163).
+          # `create --force` tolere l'existant ; `add`/`remove` avec `|| true`
+          # ne tuent pas le job si gh echoue (advisory).
+          for LABEL_PAIR in \
+            "variation-tier-inflation:FEF2C0:TIER-INFLATION:declared LIGHT << effective LIGHT-genre (#10020, advisory)" \
+            "variation-genre-run:FEF2C0:GENRE-RUN:>= 2 grains consecutifs du meme genre LIGHT pour la lane (#10020, advisory)" \
+            "variation-genre-cap-exceeded:FBCA04:CAP-EXCEEDED-BY-GENRE:light_genre > cap partage G-VAR-2 (#10020, advisory)" \
+            "variation-genre-mismatch:FEF2C0:GENRE-MISMATCH:declared genre != genre infere depuis les chemins du diff (#10020, advisory)"
+          do
+            LABEL=$(echo "$LABEL_PAIR" | cut -d: -f1)
+            COLOR=$(echo "$LABEL_PAIR" | cut -d: -f2)
+            SIGNAL=$(echo "$LABEL_PAIR" | cut -d: -f3)
+            DESC=$(echo "$LABEL_PAIR" | cut -d: -f4)
+            SIGVAR="SIG_$(echo "$SIGNAL" | tr '-' '_')"
+            SIGVAL=$(eval "echo \$$SIGVAR")
+            gh label create "$LABEL" --description "$DESC" --color "$COLOR" --force 2>/dev/null || true
+            if [ "$SIGVAL" = "True" ]; then
+              gh pr edit "$PR_NUMBER" --add-label "$LABEL" 2>/dev/null || true
+            else
+              gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
+            fi
+          done
+
+          # Commentaire diagnostique idempotent : un seul commentaire, porte
+          # par un marqueur HTML invisible. A chaque synchronize on re-EDIT
+          # le commentaire existant (PATCH via `gh api`) plutot que d'en
+          # poster un nouveau -- sinon spam sur chaque push.
+          MARK="<!-- variation-genre-signals -->"
+          ACTIVE_LINES=""
+          [ "$SIG_INFLATION" = "True" ] && ACTIVE_LINES="${ACTIVE_LINES}
+          - **TIER-INFLATION** : declared LIGHT << effective LIGHT-genre (tally : ${TALLY})"
+          [ "$SIG_RUN" = "True" ] && ACTIVE_LINES="${ACTIVE_LINES}
+          - **GENRE-RUN** : run consecutif d'un genre LIGHT (voir \`signals.runs\` dans le log du job)"
+          [ "$SIG_CAPEXC" = "True" ] && ACTIVE_LINES="${ACTIVE_LINES}
+          - **CAP-EXCEEDED-BY-GENRE** : light_genre > cap partage G-VAR-2 (tally : ${TALLY})"
+          [ "$SIG_MISMATCH" = "True" ] && ACTIVE_LINES="${ACTIVE_LINES}
+          - **GENRE-MISMATCH** : declared genre != genre infere depuis les chemins du diff"
+
+          if [ -n "$ACTIVE_LINES" ]; then
+            BODY="${MARK}
+          **G-VAR-2/3 GENRE signals** (advisory, non bloquant, #10020).
+          La lane \\\`${LANE}\\\` voit ces signaux actifs sur les mergees du jour (UTC ${TODAY}) :${ACTIVE_LINES}
+
+          G-VAR-2 plafonne a **une LIGHT par lane et par jour, toutes categories LIGHT confondues** ; G-VAR-3 interdit deux genres LIGHT consecutifs. Les signaux ci-dessus rendent le fait VISIBLE (labels \`variation-tier-inflation\`, \\\`variation-genre-run\\\`, \\\`variation-genre-cap-exceeded\\\`, \\\`variation-genre-mismatch\\\`) -- la decision de merge reste au coordinateur."
+            EXISTING_ID=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments[] | select(.body | startswith("'"$MARK"'")) | .id' 2>/dev/null | head -1 || echo "")
+            if [ -n "$EXISTING_ID" ]; then
+              gh api -X PATCH "repos/${GH_REPO}/issues/comments/${EXISTING_ID}" \
+                -f body="$BODY" 2>/dev/null || true
+            else
+              gh pr comment "$PR_NUMBER" --body "$BODY" 2>/dev/null || true
+            fi
+            echo "::notice::G-VAR-2/3-by-GENRE signale sur ${LANE} (tally ${TALLY})."
+          else
+            # Cas nominal : aucun signal -- on retire le commentaire si il
+            # en reste un d'un push anterieur. Idempotence symetrique.
+            EXISTING_ID=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments[] | select(.body | startswith("'"$MARK"'")) | .id' 2>/dev/null | head -1 || echo "")
+            if [ -n "$EXISTING_ID" ]; then
+              gh api -X DELETE "repos/${GH_REPO}/issues/comments/${EXISTING_ID}" 2>/dev/null || true
+            fi
+            # Et on retire les labels devenus obsoletes (deja fait dans la
+            # boucle ci-dessus). Echo nominal pour le log.
+            echo "Aucun signal actif pour ${LANE} aujourd'hui (tally ${TALLY})."
+          fi
+          exit 0


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: DEEP/research-code #10059

## Résumé

PR de **plomberie CI** (issue **#10020**, grain out-of-scope de PR #10031) : ajoute `.github/workflows/variation-light-genre.yml` qui surface les **4 signaux G-VAR-2/3-by-GENRE** au moment du PR :

| Signal | Trigger | Label CI |
|---|---|---|
| `TIER-INFLATION` | `light_genre > light_declared + 1` | `variation-tier-inflation` |
| `GENRE-RUN` | ≥2 grains consécutifs du même genre LIGHT | `variation-genre-run` |
| `CAP-EXCEEDED-BY-GENRE` | `light_genre > cap` (cap = `max(1, N//3)`) | `variation-genre-cap-exceeded` |
| `GENRE-MISMATCH` | declared genre ≠ `_genre_from_paths(diff)` | `variation-genre-mismatch` |

PR #10031 a livré **le script** (`compute_signals` + 16 tests + live replay sur le cas de référence 2026-08-08 po-2025:CoursIA-2). Cette PR livre **la plomberie CI** : sparse-checkout, dataset des mergées du jour UTC, lane extraite du tag `Grain:` de la PR ouverte, `candidate_files` via `gh pr view --json files`, **4 labels distincts** (un par signal, lisibles dans `gh pr list --json labels`), commentaire idempotent via marqueur HTML invisible, **advisory strict (exit 0)**.

## Architecture

### Source de vérité unique

Le job appelle `python3 scripts/variation_light_cap.py --replay … --genre-signals --lane … --body-file … --labels-file … --files …` — c'est **exactement** la même signature que PR #10031 a documentée + testée (16 tests + live replay). Aucune logique ré-implémentée dans le YAML ; le bash n'est que de la plomberie (dataset + jq Python + label/commentaire).

### Extraction de la lane (anti-double-source)

La lane cible vient de `grain_tag.parse_grain_tag` sur le body de la PR ouverte — **la même source que `variation-tag-guard.yml`** (#9485 : extracteur partagé). Si la lane est absente, le job exit 0 sans label : un grain sans lane est un **autre défaut** que G-VAR-2/3-by-GENRE, et `variation-tag-guard` l'a déjà signalé via `variation-tag-lane-missing`. Re-notifier ici serait du bruit.

### Anti-spam (mêmes garde-fous que `variation-tag-guard`)

- **Bots** (`*[bot]`) : hors scope (catalogue auto-régénéré).
- **Forks** : hors scope (PRs étudiantes, `.claude/rules/student-pr-reviews.md` : review bienveillante, aucun critère interne ne s'y applique).
- **Commentaire idempotent** : un marqueur HTML invisible (`<!-- variation-genre-signals -->`) garde UN SEUL commentaire par PR. Sur chaque `synchronize`, le job **PATCH** le commentaire existant au lieu d'en poster un nouveau (via `gh api -X PATCH …/issues/comments/<id>`).
- **Labels retirés quand corrects** : pour chaque signal `False`, on fait `gh pr edit --remove-label`. Un label collé par un push antérieur ne survit pas à la correction — même idiome que `check-light-cap`.

### `gh pr view --json files` parsing

GitHub renvoie un **tableau** de `{path, additions, deletions, …}` (pas l'objet `{"files":[…]}` comme `gh pr list`). Le snippet Python accepte les deux formes (précaution #9971 sur le double-emballage). `--files ""` rend `GENRE-MISMATCH` inactif — un input manquant est un signal manquant, jamais un faux positif (cf `compute_signals` docstring).

## Premiers principes (G.1 firsthand, scope #10020)

Mesure firsthand sur **le live replay** documenté par PR #10031 (rejoué localement ici, après ce PR) :

```bash
$ PY scripts/variation_light_cap.py --replay po2025_day.json --genre-signals \
    --lane myia-po-2025:CoursIA-2
{
  "tally": {"lane_grains": 16, "light_declared": 0, "light_genre": 8, "cap": 5,
            "by_genre": {"readme": 5, "tooling": 4, "docs": 2, "notebook-python": 2, …}},
  "long_runs": [{"genre": "readme", "count": 5, "numbers": [9960, 9965, 9966, 9969, 9977]}],
  "signals": {"TIER-INFLATION": true, "GENRE-RUN": true, "CAP-EXCEEDED-BY-GENRE": true, "GENRE-MISMATCH": false}
}
```

Les 3 signaux cibles tirent (TIER-INFLATION/GENRE-RUN/CAP-EXCEEDED-BY-GENRE=True) sur le cas de référence. **GENRE-MISMATCH inactif** parce que la PR d'exemple a `declared=tooling` et `files=.github/workflows/…yml` (les deux pointent sur `tooling` après `_genre_from_paths`).

**Vérification locale des 4 cas de test** (rejoué avant le commit) :

| Cas | Tally | Signaux actifs |
|---|---|---|
| **C1** — cas de référence po-2025:CoursIA-2 du 2026-08-08 | light_genre=8, cap=5 | TIER-INFLATION, GENRE-RUN, CAP-EXCEEDED-BY-GENRE |
| **C2** — `declared=readme` + `files=.py` | light_declared=0, light_genre=0 | **GENRE-MISMATCH** (inferred=tooling ≠ declared=readme) |
| **C3** — lane variée DEEP/MED (lean/qc/notebook-python/genai/training) | light_genre=0 | **aucun** (cas silencieux : le détecteur sait se taire) |
| **C4** — lane absente du tag | n/a | exit 0 sans label (un autre défaut, géré par variation-tag-guard) |

## Détails d'implémentation

### Pourquoi 4 labels distincts (pas un label fourre-tout)

`gh pr list --json labels` doit permettre au coordinateur de **lire la nature du manquement sans ouvrir les logs**. Le label fourre-tout (`variation-genre-signal-fired`) cacherait *lequel* des 4 a tiré — c'est exactement la leçon du `variation-tag-guard.yml` L163 (« un label fourre-tout rend la nature illible »).

### Pourquoi exit 0 strict (jamais `exit 1` même quand tout tire)

Le protocole dit que la **requalification au merge** est une décision de coordinateur. Un gate qui bloque sur une heuristique sémantique serait pire que le défaut qu'il corrige — il rougirait des PRs légitimes re-qualifiées (1 FP/2 flags sur la vague 2026-07-30 : #8930 LIGHT→MED, cf `check-light-cap` commentaire L213-220). Le label **est** le signal, le job n'est que la plomberie qui l'applique.

### Pourquoi `sparse-checkout` (pas checkout complet)

`variation_light_cap.py` importe `grain_tag.py` (#9485 : extracteur partagé). Checkout des deux seuls fichiers nécessaires — 2 fichiers vs le repo entier. Même pattern que `variation-tag-guard.yml` lignes 226-232.

### Idempotence : `PATCH` du commentaire existant

`gh pr comment` posterait un **nouveau** commentaire à chaque `synchronize` (spam). Le job :
1. Cherche un commentaire existant qui **commence par** `<!-- variation-genre-signals -->` (`startswith`).
2. Si trouvé → `gh api -X PATCH …/issues/comments/<id>` (mise à jour en place).
3. Sinon → premier `gh pr comment`.
4. Si plus de signal actif sur un push ultérieur → `gh api -X DELETE …/issues/comments/<id>` (le commentaire diagnostique ne survit pas à la disparition du signal).

Coût : 1× `gh pr view --json comments` par run (l'ID est dans la réponse, pas besoin de filtrer côté shell).

## Acceptance Epic #10038 grain C follow-up (issue #10020)

- [x] CI workflow (`.github/workflows/variation-light-genre.yml`) surface les 4 signaux G-VAR-2/3-by-GENRE
- [x] Sparse-checkout (`variation_light_cap.py` + `grain_tag.py`)
- [x] Lane extraite du tag `Grain:` de la PR ouverte via `grain_tag.py` (source unique, #9485)
- [x] `candidate_files` via `gh pr view --json files` (format `[]` accepté)
- [x] **4 labels distincts** : `variation-tier-inflation` / `variation-genre-run` / `variation-genre-cap-exceeded` / `variation-genre-mismatch`
- [x] Labels ajoutés quand signal=True, **retirés** quand False (label d'un push antérieur ne survit pas)
- [x] **Commentaire idempotent** via marqueur HTML invisible + `PATCH` sur l'existant
- [x] **Advisory strict** (exit 0 toujours, même quand tous les signaux sont True)
- [x] Bots + forks hors scope (mêmes garde-fous que `variation-tag-guard`)
- [x] Aucun filtre `paths:` — verdict rendu sur **toute** PR same-repo (sinon `skipped forever` cache un défaut, leçon du `pr-gate.yml` L18-22)
- [x] `permissions: pull-requests: write, issues: write` (label/comment/edit)
- [x] Triggers : `pull_request` (opened/edited/synchronize/reopened) + `workflow_dispatch`

## Tests

### Live replay sur le cas de référence

```bash
$ PY scripts/variation_light_cap.py --replay po2025_day.json --genre-signals \
    --lane myia-po-2025:CoursIA-2
```
Sortie : les 3 signaux cibles tirent (TIER-INFLATION, GENRE-RUN, CAP-EXCEEDED-BY-GENRE = True). Le workflow pose les 3 labels correspondants + un commentaire diagnostique avec la tally `{declared=0, genre=8, cap=5}`.

### 4 cas vérifiés localement avant commit

| Cas | Description | Signaux attendus | Statut |
|---|---|---|---|
| C1 | live replay po-2025:CoursIA-2 (16 PRs 2026-08-08) | 3 sur 4 | ✓ |
| C2 | declared=readme, files=.py | GENRE-MISMATCH | ✓ |
| C3 | lane variée DEEP/MED | **aucun** (silence test) | ✓ |
| C4 | lane absente du tag | exit 0 sans label | ✓ |

## Fichiers modifiés

```
.github/workflows/variation-light-genre.yml | 240 +++++++++++++++++++++++
1 file changed, 240 insertions(+)
```

**Aucun** script de production modifié (le détecteur est intact depuis #10031). **Aucun** test modifié (les 16 tests `--genre-signals` de #10031 couvrent le sous-jacent ; le test d'intégration bout-en-bout est le **live replay** sur le cas de référence, rejoué avant le commit).

## Anti-patterns évités

- **Pas de label fourre-tout** — 4 labels distincts, lisibles dans `gh pr list --json labels` (cf L163 variation-tag-guard)
- **Pas de `exit 1`** sur signal actif — le protocole dit que la requalification est coordinateur (cf check-light-cap L213-220 + variation-protocol §3 « le tag déclaré n'est pas auto-exécutoire »)
- **Pas de filtre `paths:`** — verdict rendu sur toute PR (sinon `skipped forever`, leçon pr-gate L18-22)
- **Pas de ré-implémentation** de la logique dans le YAML — le bash n'est QUE de la plomberie, le calcul vit dans `compute_signals` (#10031)
- **Pas de double-source** pour la lane — `grain_tag.py` est l'extracteur partagé (#9485), `variation_light_cap.py` le consomme déjà
- **Pas de wildcard** sur les labels — chaque classe nommée une par une, comme `allow-axioms` de §B (cliquet : tout nouveau signal = nouveau nom)
- **Pas de spam de commentaires** — `PATCH` sur l'existant, `DELETE` quand plus de signal
- **Pas de scope creep** — le `coordinator-side rerun` reste un grain séparé (cf PR #10031 « Out of scope » §)

## Hors scope (futurs grains, anti-régression R3)

- **Coordinator-side rerun sur `#coordinated-merge`** : invocation automatique de `--genre-signals` à la passe de merge du coordinateur. Nécessite un caller côté service. Grain séparé.
- **Promotion en bloquant** : si une période de flotte conforme le permet (decision user explicite), passer un ou plusieurs signaux en `exit 1`. Pas par durcissement unilatéral de ce fichier.
- **GENRE-MISMATCH pour `notebook-dotnet` vs `notebook-python`** : `_genre_from_paths` est volontairement coarse (ne distingue pas les deux, tombe sur `tooling`). Le mismatch est **actif** dans ce cas — c'est un signal que le tag déclaré est plus précis que ce que les chemins infèrent. Le coordinateur tranche au merge.

## Liens

- Issue **#10020** : Le cap LIGHT lit des tiers auto-déclarés — plafonner sur le GENRE
- PR **#10031** (MERGED) : feat(variation,#10020) — le script `compute_signals` + 16 tests + live replay
- PR **#10050** (sweep-ready, c.1301+22) : grain B Epic #10038 (gate structurel 4 invariants)
- PR **#10047** (sweep-ready, c.1301+21) : grain E Epic #10038 (i18n périmètre)
- PR **#10059** (sweep-ready, c.1301+23) : caractérisation falsifiable scanner quant-prose
- `.github/workflows/variation-tag-guard.yml` : modèle de plomberie (mêmes garde-fous bots/forks, même idiome label distinct, même commentaire idempotent)
- `.claude/rules/variation-protocol.md` §1 (énumération close), §3 (merge-gate), G-VAR-2/3 (cap + adjacence)
- `#9485` (extracteur partagé grain_tag.py) — la source unique, sinon le guard et l'organe re-divergeraient

🤖 Generated with [Claude Code](https://claude.com/claude-code)