### PR TITLE
docs(reference,#9976): inscription cluster LAN topology + endpoint reachability matrix

### DIFF
--- a/docs/reference/cluster-agents.md
+++ b/docs/reference/cluster-agents.md
@@ -4,15 +4,77 @@ Reference perenne sur la structure du cluster : machines, GPUs, workspaces RooSy
 
 ## Machines du cluster
 
-| Machine | Role principal | GPUs | VRAM totale |
-|---------|----------------|------|-------------|
-| `myia-ai-01` | **Coordinateur** + tests universels + vLLM hosting + training BG GPU 2 + prover BG forensic | 3x RTX 4090 | 72 GB (3x 24) |
-| `myia-po-2023` | Hote services GenAI Image/Audio/Video (8 Docker services) | RTX 3080 + eGPU RTX 3090 | 40 GB (16 + 24) |
-| `myia-po-2024` | QC backtest + ML training (modèles <= 10M params) | RTX 3070 | 8 GB |
-| `myia-po-2025` | Tracks intensives ML/audits + workspace EPITA (3 agents) | RTX 3080 Ti laptop | 16 GB |
-| `myia-po-2026` | Lean prover + QC MCP + service embedding + reverse proxy `xx.myia.io` | RTX 3080 | 16 GB |
+| Machine | Role principal | LAN plage / IP | GPUs | VRAM totale |
+|---------|----------------|----------------|------|-------------|
+| `myia-ai-01` | **Coordinateur** + tests universels + vLLM hosting + training BG GPU 2 + prover BG forensic | `192.168.0.x` (LAN prive, profile Private, interface `vEthernet (MyIA-AI-Gigabit)`). vLLM sur `192.168.0.47:5002` (`0.0.0.0:5002` via Docker Desktop, `remote=Any` sur profil Private + Public, controle d'acces = `VLLM_API_KEY`). WSL/Hyper-V internes : `172.28.0.1`, `172.28.16.1` (mesure ai-01, [#9976](https://github.com/jsboige/CoursIA/issues/9976) §3.1) | 3x RTX 4090 | 72 GB (3x 24) |
+| `myia-po-2023` | Hote services GenAI Image/Audio/Video (8 Docker services) | LAN a mesurer sur place (plage non inventoriee sur ce doc — confirmer sur la machine elle-meme via `Get-NetIPAddress -AddressFamily IPv4`). GenAI containers sur `localhost:<port>` (ex musicgen 8192) ; voir [docs/genai/genai-services.md](../genai/genai-services.md) pour le registre | RTX 3080 + eGPU RTX 3090 | 40 GB (16 + 24) |
+| `myia-po-2024` | QC backtest + ML training (modèles <= 10M params) | LAN a mesurer sur place (plage non inventoriee). QC MCP Docker `quantconnect/mcp-server` → QC Cloud | RTX 3070 | 8 GB |
+| `myia-po-2025` | Tracks intensives ML/audits + workspace EPITA (3 agents) | `172.24.44.172` (cité dans [#9976](https://github.com/jsboige/CoursIA/issues/9976) §Le fait) — **probable WSL/Hyper-V interne**, pas un LAN physiquement distinct ; confirmation en attente par mesure depuis l'hote Windows (cf §"Regle de routage" ci-dessous) | RTX 3080 Ti laptop | 16 GB |
+| `myia-po-2026` | Lean prover + QC MCP + service embedding + reverse proxy `xx.myia.io` | LAN a mesurer sur place. Service embedding : port non inventorié dans ce doc. Reverse proxy `xx.myia.io` : sous-domaines publics, joignable depuis n'importe quel hote internet | RTX 3080 | 16 GB |
 
 **Note po-2024/po-2025 swap previsionnel** : user prevoit de mettre la 3080 16GB en utilisation perenne (po-2025 mobile recoit la 3070 8GB, po-2024 fixe garde la 3080 16GB).
+
+**Note LAN (cf [#9976](https://github.com/jsboige/CoursIA/issues/9976))** : la topologie complete des plages LAN par machine n'est **pas mesuree sur place** pour po-2023 / po-2024 / po-2026 dans cette revision. La cellule "LAN a mesurer sur place" reflete cet etat — ne PAS substituer une adresse devinette. Toute nouvelle mesure doit etre sourcee firsthand via `Get-NetIPAddress` sur la machine concernee, et ajoutee a ce tableau a ce moment-la.
+
+## Topologie LAN et reachabilite endpoint
+
+Section de reference pour le routage inter-machines des endpoints partages. La precedente absence de cette table est ce qui a rendu l'incident [#9976](https://github.com/jsboige/CoursIA/issues/9976) possible : "endpoint vivant" etait vrai *depuis ai-01*, lu comme un etat du cluster, et `master.env` etait confondu avec "cle de cluster" alors qu'il est per-machine.
+
+### Endpoints partages (port → hote → joignable depuis)
+
+| Endpoint | Port | Hote qui heberge | LAN address | Joignable depuis |
+|----------|------|------------------|-------------|------------------|
+| vLLM `medium` (Qwen3.5-35B-A3B-GPTQ-Int4, TP=2 GPU 0+1) | `5002` | `myia-ai-01` | `192.168.0.47:5002` (`0.0.0.0:5002` via Docker Desktop, `remote=Any` Private + Public, cle = `VLLM_API_KEY`) | **ai-01** (mesure : `401` en 0.0026 s depuis `127.0.0.1` et `192.168.0.47`). **po-2023 / po-2024 / po-2026** : a mesurer sur place (LAN `192.168.0.x` partage probable). **po-2025** : LAN disjoint (`172.24.x`), **NON joignable** par defaut — voir §Regle de routage |
+| vLLM `mini` (OmniCoder-9B-AWQ-4bit) | `5001` | `myia-ai-01` | `192.168.0.47:5001` (deprecated, meme interface que `5002`) | idem `5002` ; port a verifier avant tout test (deprecated, peut etre ferme) |
+| GenAI `musicgen` (service local) | `8192` | `myia-po-2023` | `localhost:8192` (conteneur Docker, wake-on-demand via [genai-service.py](../../MyIA.AI.Notebooks/GenAI/shared/helpers/genai_service.py)) | **po-2023** uniquement (validation reverse-proxy publique via `xx.myia.io` par po-2026, cf [docs/genai/genai-services.md](../genai/genai-services.md)) |
+| GenAI autres services Image/Audio/Video (8 conteneurs) | `8188`-`8196` (cf [genai-services.md](../genai/genai-services.md)) | `myia-po-2023` | `localhost:<port>` + reverse-proxy `xx.myia.io` | **po-2023** localhost ; tout agent via `xx.myia.io` (auth bearer) |
+| QC MCP (`quantconnect/mcp-server`) | n/a (HTTPS sortant vers `quantconnect.com`) | `myia-po-2024` + `myia-po-2026` | n/a (API Cloud) | **po-2024** et **po-2026** (tokens MCP configures sur les 2 machines). Contrainte : MAX 10 appels API QC / minute entre **tous** les agents (cf §"QuantConnect MCP" plus bas) |
+| Lean 4 / Lake build | local (`elan toolchain`) | `myia-po-2026` (specialisation principale) | local uniquement (build sur place) | **po-2026** specialise ; **ai-01** = secours (env Lean a installer si manquant) |
+| Service embedding | non inventorié dans ce doc | `myia-po-2026` | a mesurer sur place | a mesurer ; endpoint supposé joignable cross-LAN si meme plage que po-2026 |
+| Reverse proxy `xx.myia.io` (sous-domaines GenAI publics) | `443` (HTTPS) | `myia-po-2026` (hebergement) | sous-domaines DNS publics | **tout agent** du cluster (auth bearer par sous-domaine) + internet |
+| RooSync GDrive (dashboard + messages) | n/a (HTTPS sortant) | `myia-*` (toutes les machines) | n/a | cross-machine par design |
+
+### Repere de diagnostic endpoint — ne JAMAIS agreger
+
+| Symptome depuis l'hote X | Signification | Action |
+|--------------------------|---------------|--------|
+| `HTTP 401` en < 50 ms | **Vivant** + cle requise (ou token manquant/expiré). Le service repond, il refuse l'authentification. | Verifier la cle (`master.env` de la machine X, pas une autre), PAS l'adresse |
+| `HTTP 200` (avec cle valide) | **Vivant** + authentifie. Service operationnel. | OK |
+| `connection refused` | **Mort** localement : port ferme, service eteint, ou pas de listener. Le paquet arrive au TCP layer, aucun daemon ne repond. | Demarrer le service / verifier que le port est bien bound |
+| `HTTP 000` / `timeout` / `100% packet loss` (ping) | **Non joignable depuis cet hote** : route absente, pare-feu inter-LAN, ou LAN disjoint. Le paquet ne sort pas / n'arrive pas. | **NE PAS classer comme "service mort"**. Tester depuis l'hote qui heberge l'endpoint (pas l'hote X). Si LAN disjoint, c'est une propriete de routage, pas un incident service |
+
+**Regle de routage** (decision [#9976](https://github.com/jsboige/CoursIA/issues/9976) option (a), adoptee 2026-08-08) : **aucun grain necessitant l'inference locale (`192.168.0.47:5002`) n'est dispatche vers une lane hors-LAN**. Ces lanes (`po-2025` notoirement, et toute autre confirmee non-joignable) recoivent soit des grains sans inference, soit des grains a fournisseur externe (OpenRouter, greenlight sur [#6949](https://github.com/jsboige/CoursIA/issues/6949)). Une lane qui recoit un grain d'inference locale et mesure `HTTP 000` doit le signaler comme **erreur de dispatch du coordinateur**, pas le contourner.
+
+**Securite de l'exposition `0.0.0.0:5002`** (mesure ai-01, [#9976](https://github.com/jsboige/CoursIA/issues/9976) §"La portee de securite") : la regle Docker Desktop est `remote=Any` sur les profils **Private ET Public**. Si `myia-ai-01` se retrouve un jour sur un reseau classe `Public` (partage de connexion, reseau invite, hot-spot), le port **5002 y serait joignable aussi**, protege par la seule `VLLM_API_KEY`. Pas un incident aujourd'hui (interface active `Private`, LAN de confiance), mais propriete a connaitre : **la marge d'exposition est deja consommee par defaut**, ce qui est un argument de plus contre toute re-exposition (l'option (b) est **vide cote ai-01** — rien a exposer qui ne le soit deja, mesure du [#9976](https://github.com/jsboige/CoursIA/issues/9976) §3.1).
+
+### Comment mesurer la reachabilite (template reutilisable)
+
+Depuis l'hote **X** (pas depuis l'hote qui heberge l'endpoint) :
+
+```bash
+# 1. Identifier la plage LAN de X (hote Windows)
+Get-NetIPAddress -AddressFamily IPv4 | Where-Object {$_.IPAddress -notlike '127.*'} | Select-Object IPAddress,InterfaceAlias
+
+# 2. Tester l'endpoint avec timeout court (eviter les hangs)
+curl.exe -s -o NUL -w "%{http_code}`n" --max-time 6 http://<LAN-IP>:<port>/v1/models
+```
+
+**Lecture du résultat** :
+- `200` : service vivant + cle valide (ou pas de cle requise).
+- `401` en < 50 ms : service vivant + cle requise. Verifier `master.env` sur la machine X.
+- `000` ou `timeout` : non joignable depuis X (route / pare-feu / LAN disjoint). **Re-tester depuis l'hote qui heberge l'endpoint** pour confirmer que le service est vivant — si `401` depuis l'hote hebergeur, le service marche et le probleme est strictement sur X.
+
+Documenter toute nouvelle mesure dans une sous-section "Mesures recentes" plus bas, avec horodatage, machine source, et resultat verbatim.
+
+### Mesures recentes (audit)
+
+| Date | Source | Cible | Mesure | Conclusion |
+|------|--------|-------|--------|------------|
+| 2026-08-08 | `myia-ai-01` | `192.168.0.47:5002` (vLLM self) | `HTTP 401` en 0.0026 s sur `127.0.0.1:5002` ; `HTTP 401` en 0.0027 s sur `192.168.0.47:5002` (issue [#9976](https://github.com/jsboige/CoursIA/issues/9976), mesure jsboige) | Endpoint vivant sur les 2 interfaces, `0.0.0.0:5002`, `remote=Any` Private + Public, cle requise |
+| 2026-08-08 | `myia-po-2025` | `192.168.0.47:5002` (vLLM) | `HTTP 000`, ping 100 % perte (issue [#9976](https://github.com/jsboige/CoursIA/issues/9976), constat firsthand po-2025) | **LAN disjoint** entre `192.168.0.x` et `172.24.44.172` (a confirmer si WSL interne ou LAN physique distinct — mesure depuis hote Windows requise, cf issue body §"Ce qui reste, et qui n'est pas un blocage") |
+| (a completer) | `myia-po-2023` | `192.168.0.47:5002` (vLLM) | a mesurer | |
+| (a completer) | `myia-po-2024` | `192.168.0.47:5002` (vLLM) | a mesurer | |
+| (a completer) | `myia-po-2026` | `192.168.0.47:5002` (vLLM) | a mesurer | |
 
 ## Workspaces RooSync (cluster CoursIA)
 


### PR DESCRIPTION
## docs(reference,#9976): inscription cluster LAN topology + endpoint reachability matrix

Grain: MED/docs — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #10058

Quoi:       Inscrire dans `docs/reference/cluster-agents.md` la **topologie LAN du cluster** (plage par machine) + une **matrice de reachabilite endpoint** (qui heberge quoi, joignable d'ou) + un **reperage de diagnostic** distinguant `HTTP 401` (alive+auth) / `connection refused` (mort local) / `HTTP 000`/`timeout` (non joignable inter-LAN), conformement a l'acceptance #9976 §3.
Preuve:     Lignes ajoutees 76, fichier +69/-7 (1 fichier modifie). Mesures sourcees firsthand citees en clair : `192.168.0.47:5002` → `401` en 0.0026-0.0027 s (mesure ai-01 sur #9976), `172.24.44.172` cite dans le body issue, WSL/Hyper-V `172.28.0.1`/`172.28.16.1` (mesure ai-01). 4 cellules "LAN a mesurer sur place" explicites pour po-2023/po-2024/po-2026 (donnees non-inventoriees).
Perimetre:  `docs/reference/cluster-agents.md` uniquement. Hors scope : le code de routage, le vLLM hosting, l'option (b) exposition (vide cote ai-01, cf issue), l'option (c) VPN (non retenue par ai-01 option (a)).

## Contexte (issue #9976)

L'incident fondateur : po-2025 (LAN `172.24.44.172`) tente d'atteindre le vLLM d'ai-01 (`192.168.0.47:5002`) → `HTTP 000`, ping 100 % perte. ai-01 mesure `401` en 2.6 ms depuis son propre LAN → l'endpoint **est vivant**, mais **injoignable depuis le LAN de po-2025**. Cause : les deux machines ne sont **pas sur le meme LAN physique** (a confirmer si WSL interne ou LAN distinct — mesure depuis l'hote Windows requise, non realisee a ce cycle).

Trois decisions initialement posees par l'issue : (a) externe (OpenRouter, greenlight #6949) / (b) exposition `0.0.0.0` (deja le cas sur Private + Public, mesure #9976) / (c) VPN. ai-01 a tranche **(a)** (verbatim : *"ne rien faire — lanes hors-LAN passent par fournisseur externe OpenRouter"*) ; le sub-travail doc est le seul livrable restant de l'acceptance.

## Le fix — 3 ajouts a `cluster-agents.md`

### 1. Colonne "LAN plage / IP" au tableau "Machines du cluster"

Pour chaque machine, ajoutee la cellule LAN :
- `myia-ai-01` → `192.168.0.x` + WSL/Hyper-V `172.28.0.1`/`172.28.16.1` (mesure ai-01) + vLLM `192.168.0.47:5002` (Docker Desktop `0.0.0.0:5002`, `remote=Any` Private+Public, `VLLM_API_KEY`).
- `myia-po-2025` → `172.24.44.172` (cité dans le body #9976) avec note "probable WSL/Hyper-V interne, confirmation par mesure depuis l'hote Windows requise".
- `myia-po-2023` / `myia-po-2024` / `myia-po-2026` → "LAN a mesurer sur place (plage non inventoriee)". **Pas d'adresse devinette**, c'est explicite.

### 2. Nouvelle section "Topologie LAN et reachabilite endpoint"

Quatre sous-sections :

**Endpoints partages (port → hote → joignable depuis)** — tableau croise liant chaque service partage (vLLM 5002/5001, GenAI 8188-8196, QC MCP, Lean 4, embedding, reverse proxy `xx.myia.io`, RooSync GDrive) a son hote, son port, son LAN address, et **qui peut l'atteindre**. La cellule "joignable depuis" est explicite : `ai-01` OK partout ou presque ; `po-2025` **non joignable** sur `192.168.0.47:5002` (LAN disjoint) ; `po-2023` localhost pour GenAI.

**Repere de diagnostic endpoint — ne JAMAIS agreger** — tableau a 4 lignes qui distingue les 4 symptomes distincts :

| Symptome | Signification | Action |
|----------|---------------|--------|
| `HTTP 401` < 50 ms | Vivant + cle requise | Verifier `master.env` (machine source, pas autre) |
| `HTTP 200` | Vivant + authentifie | OK |
| `connection refused` | Mort localement | Demarrer le service |
| `HTTP 000` / `timeout` / `100% packet loss` | **Non joignable depuis cet hote** | NE PAS classer "service mort" ; re-tester depuis l'hote hebergeur |

C'est le coeur du fix documentaire : la confusion `401` (alive+auth) vs `HTTP 000` (non joignable) **est** l'incident #9976 (po-2025 a vu `000` et a diagnostique "service mort", alors que le service repondait `401` depuis sa propre machine).

**Regle de routage** (decision (a)) : aucun grain necessitant inference locale n'est dispatche vers une lane hors-LAN ; lanes non-joignables → grains sans inference ou fournisseur externe (OpenRouter, greenlight #6949).

**Securite de l'exposition `0.0.0.0:5002`** (mesure ai-01) : la regle Docker Desktop est `remote=Any` sur Private **et** Public — la marge d'exposition est **deja consommee par defaut**, ce qui est un argument de plus contre toute re-exposition (option (b) vide cote ai-01).

### 3. Template reutilisable "Comment mesurer la reachabilite"

Deux commandes PowerShell + curl.exe, avec timeout court (6 s), plus une lecture du resultat qui renvoie explicitement aux 3 categories du tableau precedent. Le but : un agent qui voit un nouveau symptome ne le confond plus avec un autre.

### 4. Section "Mesures recentes (audit)" — table des mesures sourcees

5 lignes, dont 2 deja filled (ai-01 self-measure + po-2025 firsthand sur #9976) et 3 marquees "(a completer)" pour po-2023/po-2024/po-2026.

## Verification

- `git diff --stat docs/reference/cluster-agents.md` → `+69/-7` (1 fichier)
- **Audit fichier-entier** (cf [pr-review-discipline.md](../../.claude/rules/pr-review-discipline.md) §E) : le tableau "Machines du cluster" a ete verifie ligne-a-ligne contre les 5 lignes existantes (toutes presentes dans la version maj, colonnes GPU/VRAM preservees) ; les sections adjacentes ("Workspaces RooSync", "GPUs", etc.) sont **non touchees** — pas de regression sur le scope adjacent.
- **catalog-pr-hygiene R1** : aucun fichier `COURSE_CATALOG.generated.{json,md}` modifie (docs-only, hors-scope catalogue).
- **Pas de notebook touche** : 0 modification de `.ipynb`.
- **Pas de frontmatter / pas de metadata modifie** : juste prose de reference.

## Conformite

- **L898 ★★★ PRE-PR-CREATE** triple check (commande 1 : `git worktree list` → ma branche unique ; commande 2 : `gh pr list --search "9976 OR LAN topology OR cluster-agents"` → 0 PR touchat le meme chemin ; commande 3 : `gh pr list --state all --json files --jq '.files[] | select(.path == "docs/reference/cluster-agents.md")'` → 0 resultat sur le repo `jsboige/CoursIA`).
- **C9872+45-L1 ★★** fresh `origin/main` worktree (cree depuis SHA `e157904056fe4a7d65e5048b291455bf44afb77a`, pas depuis l'arbre partage).
- **L284** : pas de force push (single-lane branch, premiere pousse, pas besoin).
- **L677-L4 ★★** body genere en `<scratchpad>/c9976_pr_body.md`, **HORS worktree**. Verifie `git status` du worktree : 1 fichier modifie, aucun `.md` orphelin dans la zone stagee.
- **catalog-pr-hygiene R1** : 0 drift sur `COURSE_CATALOG.generated.{json,md}`.
- **catalog-pr-hygiene R2** : branche basee sur `origin/main@e15790405` (commit frais 2026-08-08).
- **catalog-pr-hygiene R3** : 1 fichier = 1 sujet (inscription LAN topology), pas composite.
- **code-style E** : pas d'emojis, prose en francais, pas de prefixes marketing.
- **G-VAR-1** MED plancher : la PR ajoute une section qui n'existait pas (reorganise l'info cluster par une dimension LAN, complete avec matrice de reachabilite et diagnostic distinction) — substance genuine, pas un alignement cosmétique.
- **G-VAR-3** distinct de `MED/tooling #10058` (precedent de la lane) par genre (`docs` vs `tooling`) — pas de monoculture.
- **CLAIM lane** : `gh issue comment 9976 --body "[CLAIMED] lane myia-po-2023:CoursIA-2 ..."` poste avant edit (comment `5226387552`, horodatage serveur).

## Voir aussi

- Issue **#9976** (acceptance source) — contient les mesures firsthand ai-01 + po-2025.
- Issue **#6949** (OpenRouter greenlight, decision (a)).
- PR **#10058** (precedent MED/tooling de la lane, grain different).
- `docs/genai/genai-services.md` (registre des ports 8188-8196 GenAI).
- `docs/genai/service-security-audit.md` (pattern healthcheck `/v1/models` + `401 = secured`).
- `docs/lean/llm-endpoints.md` (mapping 5001/5002 mini/medium).
- [pr-review-discipline.md](../../.claude/rules/pr-review-discipline.md) §E (audit fichier-entier README/docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)