### PR TITLE
fix(security): scrub bare POSIX /home/jesse leak from Lean-1-Setup kernel-wrapper stderr

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
@@ -1488,7 +1488,7 @@
       "      [OK] Kernel enregistre: ~\\AppData\\Roaming\\jupyter\\kernels\\lean4-wsl\n",
       "      [*] Mise a jour du wrapper robuste...\n",
       "[*] Installation du kernel Lean4-WSL...\n",
-      "[+] Wrapper robuste deploye: /home/jesse/.lean4-kernel-wrapper.py\n",
+      "[+] Wrapper robuste deploye: ~/.lean4-kernel-wrapper.py\n",
       "[+] Kernel cree: ~\\AppData\\Roaming\\jupyter\\kernels\\lean4-wsl\\kernel.json\n",
       "\n",
       "[4/4] Test du kernel WSL...\n",


### PR DESCRIPTION
fix(security): scrub bare POSIX /home/jesse leak from Lean-1-Setup kernel-wrapper stderr

Grain: LIGHT/security — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #10073 (scrubber POSIX /home/ pattern, MERGEABLE)

**Stacks on #10073** (the scrubber `_HOME_RES` bare-`/home/` pattern lives there). Base = `fix/scrub-posix-home-bare`; merge #10073 first, this auto-rebases to `main`. Review diff = **1 line** (the notebook output below).

## Quoi

`Lean-1-Setup.ipynb` portait le home d'un contributeur dans le stderr du deploiement du kernel Lean4-WSL (cell[16] output[2] stream) : `[+] Wrapper robuste deploye: /home/jesse/.lean4-kernel-wrapper.py`. Username `jesse` (un autre contributeur, pas `jsboi`) = PII-lite. C'est l'instance reelle qui motivait #10073 : le home Windows a cote (`~\AppData\Roaming\jupyter\kernels\lean4-wsl`) etait deja anonymise, mais le POSIX `/home/jesse` restait — l'asymetrie detect-vs-scrub que #10073 a ferme cote tooling, ici cote instance. Fix = `scrub_papermill_paths.py --apply <nb> --outputs` (hook officiel, pattern POSIX de #10073) → `~`.

## Preuve

- **Defect scan** firsthand (`git show origin/main:...Lean-1-Setup.ipynb`) : `cell[16] output[2]` = `...deploye: /home/jesse/.lean4-kernel-wrapper.py`.
- **Apply** : `[FIXED] Lean-1-Setup.ipynb (1 output leak(s), 1 fixed)`.
- **Surgical** : diff vs `origin/main` = **1 insertion / 1 deletion**. La SEULE modification est le substr `/home/jesse` → `~`. Tout le reste byte-identique : le prefixe `[+] Wrapper robuste deploye: `, le tail `/.lean4-kernel-wrapper.py` (nom du wrapper = diagnostic preserve), les lignes voisines (`[OK] Kernel enregistre: ~\AppData\...`, `[*] Installation du kernel Lean4-WSL...`, `[+] Kernel cree: ~\AppData\...\kernel.json`), le format ANSI. **0 ligne `"source"` changee** (C.3 scope respecte). JSON valide (23 cells).
- **Verify post-fix** : `/home/jesse` present = False, `~/.lean4-kernel-wrapper.py` present = True.
- **Non-regression G.1** : le deploiement du wrapper Lean4-WSL est un contenu pedagogique legitime (comment le kernel s'installe), preserve as-is. Seul le chemin machine du contributeur est anonymise.

## Périmètre

- **1 file** : `MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb` (SymbolicAI/Lean family). Output-only anonymization, source byte-identique.
- **Not a twin pair** (Lean notebooks n'ont pas d'entree `twin_pairs.d/`) → pas de rebaseline.
- **Depend sur #10073** : le pattern `_HOME_RES` bare-`/home/` est dans #10073 (pas encore sur main). Branche stackee sur `fix/scrub-posix-home-bare` → diff review = 1 ligne. Si #10073 merge en premier, celle-ci auto-rebase vers main proprement.
- **Not Stop-&-Repair-banned** : le home root `/home/jesse` est un chemin de deploiement non-deterministique (topologie machine du contributeur), et le hook est l'outil accepte pour l'anonymiser en preservant le tail diagnostique (cf [[feedback-no-cell-output-scrubbing]] triage A : env/cwd path → anonymize, pas source-leak ni outil-manquant).

See #10000 (path-leak family) · See #8052 (claims-vs-outputs / output-path-leak defect class) · Stacks on #10073

🤖 Generated with [Claude Code](https://claude.com/claude-code)
