### PR TITLE
fix(secrets,#10085): render_envs bootstrap_missing_envs hermeticity — inert-patch fix + autouse guard

### DIFF
--- a/scripts/secrets/render_envs.py
+++ b/scripts/secrets/render_envs.py
@@ -369,14 +369,17 @@ def _service_compose_paths(service_dir: Path) -> list[Path]:
 
 
 def bootstrap_missing_envs(
-    services_root: Path = SERVICES_ROOT,
-    master_path: Path = MASTER_ENV,
-    secret_keys: frozenset[str] = SECRET_KEYS,
-) -> list[str]:
+    services_root: Path | None = None,
+    master_path: Path | None = None,
+    secret_keys: frozenset[str] | None = None,
+) -> list[str] | None:
     """Auto-create .env for services whose compose file references a SECRET_KEY
     but who lack a .env. Returns the list of service-dir names that were
-    newly written. Dry-run path for tests: caller can monkeypatch
-    ``services_root`` / ``master_path`` / ``secret_keys``.
+    newly written. Hermetic test paths: (a) caller passes ``services_root`` /
+    ``master_path`` / ``secret_keys`` explicitly, OR (b) caller monkeypatches
+    the module globals (``render_envs.MASTER_ENV`` / ``SERVICES_ROOT``) and
+    invokes via ``main()`` — the ``None`` defaults below defer to the LIVE
+    module globals at call time, so such monkeypatches bite.
 
     Precedence: if the service already has an .env, it is left untouched
     (sync() handles updates). If the service has NO .env but has at least one
@@ -389,6 +392,22 @@ def bootstrap_missing_envs(
     need filling), so the CLI can distinguish "no-op success" from "cannot
     run" via different exit codes.
     """
+    # Resolve module globals at CALL TIME, not import time. Binding these as
+    # default args (= SERVICES_ROOT / MASTER_ENV / SECRET_KEYS) would freeze
+    # them to their import-time values, making a test's
+    # ``monkeypatch.setattr(render_envs, "MASTER_ENV", tmp_path/...)`` INERT --
+    # the #10085 hermeticity defect: the function read the REAL master.env on
+    # every cluster machine (writing real service .env files with live key
+    # material) while CI stayed spuriously green only because it owns no
+    # master.env. The None-sentinel defers to the live module global so test
+    # monkeypatches bite; explicit callers (tests passing tmp_path) override
+    # exactly as before.
+    if services_root is None:
+        services_root = SERVICES_ROOT
+    if master_path is None:
+        master_path = MASTER_ENV
+    if secret_keys is None:
+        secret_keys = SECRET_KEYS
     if not master_path.exists():
         print(f"[X] {master_path} not found. Run with --bootstrap first.")
         return None

--- a/scripts/secrets/tests/test_render_envs.py
+++ b/scripts/secrets/tests/test_render_envs.py
@@ -52,6 +52,55 @@ def _svc_dir(tree: Path, svc: str) -> Path:
     return tree / "docker-configurations" / "services" / svc
 
 
+# --------------------------------------------------------------------------- #
+# Anti-recidive hermeticity guard (#10085)
+#
+# The #10085 defect: ``test_bootstrap_missing_flag_no_master_returns_1`` had an
+# INERT monkeypatch (the impl's default args were bound at import time, so
+# patching ``render_envs.MASTER_ENV`` did nothing). On every cluster machine
+# (which owns a real ``.secrets/master.env``) the test silently bootstrapped
+# the REAL ``docker-configurations/services`` tree, writing genuine key
+# material to real service ``.env`` files; CI stayed green only because it has
+# no master.env. "Vert sincere et sans valeur."
+#
+# This autouse organ makes a future inert-patch regression RED everywhere --
+# not just on machines that happen to own a master.env. It snapshots the real
+# services tree's ``*/. env`` (existence + mtime) before each test and asserts
+# no test created or rewrote a real service .env. A regression self-cleans
+# (created files are unlinked) then fails loudly with the offending paths.
+# --------------------------------------------------------------------------- #
+@pytest.fixture(autouse=True)
+def _guard_real_service_envs():
+    services_root = render_envs.REPO_ROOT / "docker-configurations" / "services"
+    if not services_root.is_dir():
+        yield
+        return
+
+    def _snapshot() -> dict[Path, int]:
+        return {p: p.stat().st_mtime_ns for p in services_root.glob("*/.env")}
+
+    before = _snapshot()
+    yield
+    after = _snapshot()
+    created = sorted(set(after) - set(before))
+    modified = {p for p in set(before) & set(after) if before[p] != after[p]}
+    # Self-clean created files so a regression leaves no polluted .env on disk;
+    # the assertion below still fails loudly with the paths.
+    for p in created:
+        try:
+            p.unlink()
+        except OSError:
+            pass
+    assert not created, (
+        "#10085 hermeticity guard: test created real service .env "
+        f"(monkeypatch was inert?); cleaned up: {created}"
+    )
+    assert not modified, (
+        "#10085 hermeticity guard: test rewrote real service .env "
+        f"(monkeypatch was inert?): {sorted(modified)}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # parse_kv
 # ---------------------------------------------------------------------------
@@ -470,12 +519,46 @@ class TestMain:
             render_envs.main()
         assert exc.value.code == 2
 
-    def test_bootstrap_missing_flag_no_master_returns_1(self, tmp_path, monkeypatch):
+    def test_bootstrap_missing_master_absent_returns_1(self, tmp_path, monkeypatch):
+        # #10085: master absent -> bootstrap_missing_envs returns None -> exit 1.
+        # The monkeypatch of MASTER_ENV / SERVICES_ROOT MUST bite (deferred
+        # resolution at call time); on an unfixed build the patch was inert and
+        # the function read the REAL master.env, so this passed in CI (no master)
+        # yet wrote real service .env files on every cluster machine -- caught
+        # by the autouse _guard_real_service_envs fixture.
         monkeypatch.setattr(render_envs, "MASTER_ENV", tmp_path / "absent.env")
         monkeypatch.setattr(render_envs, "SERVICES_ROOT", tmp_path / "svc")
         monkeypatch.setattr(sys, "argv", ["render_envs.py", "--bootstrap-missing"])
-        # master missing -> bootstrap_missing_envs returns None -> exit 1.
         assert render_envs.main() == 1
+
+    def test_bootstrap_missing_master_present_writes_tmp_returns_0(
+        self, tmp_path, monkeypatch
+    ):
+        # #10085 hermeticity proof: master PRESENT + a service gap -> the .env
+        # must be written UNDER the patched tmp SERVICES_ROOT, proving the
+        # monkeypatch bites. On an unfixed build the patch was inert: the
+        # function read the real master, iterated the real SERVICES_ROOT, and
+        # wrote a REAL service .env (caught by the autouse guard), while CI
+        # (no real master) returned 1 and failed the == 0 assertion. Either
+        # way the unfixed build is RED; the fixed build writes to tmp and is GREEN.
+        services_root = tmp_path / "svc"
+        services_root.mkdir()
+        master = tmp_path / "master.env"
+        master.write_text("WHISPER_API_KEY=canonical-wsk\n", encoding="utf-8")
+        svc = services_root / "whisper-api"
+        svc.mkdir()
+        (svc / "docker-compose.yml").write_text(
+            "services:\n  w:\n    environment:\n      - API_KEY=${WHISPER_API_KEY:-}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(render_envs, "MASTER_ENV", master)
+        monkeypatch.setattr(render_envs, "SERVICES_ROOT", services_root)
+        monkeypatch.setattr(sys, "argv", ["render_envs.py", "--bootstrap-missing"])
+        assert render_envs.main() == 0
+        # Hermeticity: the .env landed under the PATCHED tmp services_root.
+        written = svc / ".env"
+        assert written.exists(), "bootstrap should have created the missing .env"
+        assert "WHISPER_API_KEY=canonical-wsk" in written.read_text(encoding="utf-8")
 
     def test_bootstrap_missing_exclusive_with_check(self, tmp_path, monkeypatch):
         monkeypatch.setattr(render_envs, "MASTER_ENV", tmp_path / "absent.env")


### PR DESCRIPTION
Grain: MED/test — lane myia-po-2024:CoursIA — prev: MED/refactor #10084
Quoi: fix `bootstrap_missing_envs()` non-hermeticity (#10085) — its monkeypatch was INERT (default args bound at import), so on every cluster machine it read the REAL master.env and wrote REAL service `.env` files with live key material, while CI stayed spuriously green (no master.env). Fix the impl to resolve module globals at call time (None-sentinel), replace the one inert test with both-states coverage + a hermeticity proof, and add an autouse anti-recidive guard.
Preuve: `python -m pytest scripts/secrets/tests/test_render_envs.py -q` -> 71 passed; falsifiability PROVEN — stashing the impl fix (test file kept) makes `test_bootstrap_missing_master_present_writes_tmp_returns_0` FAIL with `assert 1 == 0` + captured stdout `[X] ...\.secrets\master.env not found` (the unfixed code ignored the patched-present tmp master and read the absent real master); no real `.env` written by the suite (hermeticity confirmed); CLI `--help` + `--bootstrap-missing` smoke OK; diff = 2 files +110/-8.
Perimetre: `scripts/secrets/render_envs.py` (signature None-sentinel + 12-line resolve block + return annotation `list[str] | None`) + `scripts/secrets/tests/test_render_envs.py` (autouse `_guard_real_service_envs` fixture + replace 1 test with 2 both-states tests). No catalog, no other file.

Closes #10085

## Summary

Fixes the non-hermetic test defect filed in #10085 — a direct consequence of the #10066 consolidation campaign (PR #10077, merged). The render_envs canon test file was DEAD in CI (module collision, documented in [pytest-module-name-collision-dead-tests]). Resurrecting it exposed that one transported test had an **inert monkeypatch**: `bootstrap_missing_envs()` used default args bound at import time, so patching `render_envs.MASTER_ENV` / `render_envs.SERVICES_ROOT` did nothing. On every cluster machine (which owns a real `.secrets/master.env`) the test silently bootstrapped the **real** `docker-configurations/services` tree, writing genuine key material to real service `.env` files. CI stayed green only because it has no master.env. As the issue puts it: *"le vert etait sincere et sans valeur."*

### Root cause confirmed firsthand

`bootstrap_missing_envs()` (impl L371) had:
```python
def bootstrap_missing_envs(
    services_root: Path = SERVICES_ROOT,   # bound at IMPORT time
    master_path: Path = MASTER_ENV,        # bound at IMPORT time
    secret_keys: frozenset[str] = SECRET_KEYS,
) -> list[str]:
```
Python default args are evaluated once at function-definition. A test's `monkeypatch.setattr(render_envs, "MASTER_ENV", tmp_path/...)` changes the module global, but the function's default already captured the original real `Path` -> the patch is **inert**. `main()` calls `bootstrap_missing_envs()` with no args (L467), so it always used the import-bound real paths.

Note: `bootstrap()` and `sync()` reference `MASTER_ENV` / `TARGET_ENVS` **directly** (not via default args), so their monkeypatches already bit — only `bootstrap_missing_envs()` had this defect (confirmed by the issue's per-test isolation).

### The fix (issue's 3 acceptance criteria)

**1. Make the patch effective.** Convert the defaults to `None`-sentinels, resolve the module globals at **call time**:
```python
def bootstrap_missing_envs(
    services_root: Path | None = None,
    master_path: Path | None = None,
    secret_keys: frozenset[str] | None = None,
) -> list[str] | None:
    ...
    if services_root is None:
        services_root = SERVICES_ROOT      # reads the LIVE module global
    if master_path is None:
        master_path = MASTER_ENV
    if secret_keys is None:
        secret_keys = SECRET_KEYS
```
Now when `main()` calls `bootstrap_missing_envs()` after a test patches `render_envs.MASTER_ENV`, the function reads the patched global at call time -> the patch **bites**. Explicit callers (the `TestBootstrapMissing` tests passing `services_root=tmp_path`) override as before (backward-compatible). Return annotation corrected to `list[str] | None` (the docstring already documented the `None` return).

**2. Anti-recidive organ (autouse fixture).** `_guard_real_service_envs` snapshots the real `docker-configurations/services/*/.env` (existence + mtime) before each test and asserts no test created or rewrote a real service `.env`. A regression self-cleans (unlinks created files) then fails loudly with the offending paths. This makes a future inert-patch regression **RED everywhere**, not just on machines that happen to own a master.env — the organ the issue demands ([[rule-needs-an-organ-not-more-vigilance]]).

**3. Both states.** Replaced the single `test_bootstrap_missing_flag_no_master_returns_1` with:
- `test_bootstrap_missing_master_absent_returns_1` — master absent -> exit 1.
- `test_bootstrap_missing_master_present_writes_tmp_returns_0` — master PRESENT + a service gap -> the `.env` is written UNDER the patched tmp SERVICES_ROOT (hermeticity proof), exit 0.

### Falsifiability PROVEN (not assumed)

Stashing the impl fix (keeping the test file with guard + new tests) and running the master-present test on the UNFIXED code:
```
FAILED TestMain::test_bootstrap_missing_master_present_writes_tmp_returns_0
  assert render_envs.main() == 0
E assert 1 == 0
  Captured stdout: [X] C:\...\CoursIA-render-envs-hermetic-10085\.secrets\master.env not found.
```
The captured stdout is the smoking gun: the unfixed code **ignored the patched-present tmp master** and read the **absent real master** -> returned 1, not 0. On a cluster machine (real master present) the same inertness would write a REAL service `.env` -> the autouse guard trips. Both environments catch the regression; CI green now means something.

## Validation

- `python -m pytest scripts/secrets/tests/test_render_envs.py -q` -> **71 passed** (was 70; net +1: replaced 1 inert test with 2 both-states tests).
- Falsifiability: stashing the impl fix -> the new master-present test FAILS (`assert 1 == 0` + inert-master stdout); restoring -> green.
- Hermeticity: `find docker-configurations/services -name '.env'` after the suite -> empty (no real `.env` written).
- CLI smoke: `--help` works; `--bootstrap-missing` routes correctly (exit 1 on absent master, no crash).
- Backward-compat: `TestBootstrapMissing` (6 tests passing explicit `services_root=tmp_path`) unchanged — None-sentinel honors explicit args.
- Other callers: only `main()` (L467) routes to `bootstrap_missing_envs`; no external caller impacted.
- L898 collision guard CLEAN pre-push: all PRs touching `render_envs` are MERGED, none OPEN.

## Provenance & ownership

This defect is the follow-through of my own merged PR #10077 (#10066 tranche 3). The consolidation itself was sound (no coverage loss, measured canon-by-canon); the defect was in a transported test, revealed by the move from a collision-shadowed context where the patch happened to bite. Filing + fixing my own merge's fallout — anti-regression ownership, not someone else's turf.

See #10085 (the forensic that diagnosed this, with stdout proof). See #10066 (the consolidation campaign whose collision discovery surfaced this). See #10055 (still OPEN — the translate_csv blocker, unrelated to this fix).

## Variation note (transparent)

First non-refactor grain after 6 consecutive MED/refactor tranches (the #10066 campaign, now DRAINED except the #10055-blocked translate_csv). This is MED/test — a genuine bug fix (impl change to honor call-time globals + hermeticity proof + anti-recidive organ), not a scan-generated LIGHT. G-VAR-3 ban is LIGHT-genres-only and on *consecutive same genre*; `test` != `refactor` (genre rotated), and this is MED (the litmus: not generable-by-scanning-the-next-instance). The cluster merge queue unstuck (6 of my consolidation PRs merged this cycle), and #10085 was filed against my own merged work — taking ownership of merge fallout is exactly right.
