### PR TITLE
fix(ci,#10063): decouple advisory checks from the required PR gate

### DIFF
--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -46,7 +46,20 @@ now and later, with no per-workflow wiring to maintain.
 4. **Self-exclusion.** The gate never waits for itself.
 5. **Legacy commit statuses count too.** Some integrations post statuses, not
    check runs; both are unioned.
-6. **Fork PRs short-circuit to PASS.** Issue #10072 -- student PRs from a
+6. **Advisory checks are reported, never blocking.** A job whose name says
+   `advisory` is by construction a signal-carrier: its verdict belongs in a
+   label, not in a merge decision (7 of the 53 jobs in `.github/workflows`
+   are named that way, 5 of them spelling out "label, non-blocking"). Because
+   this gate aggregates *whatever CI exists*, letting an advisory failure
+   through would silently promote every advisory guard into a hard gate --
+   the exact opposite of what its author declared. Measured on 2026-08-08:
+   #10063 and #10080 were both `BLOCKED` with `PR gate -> FAILURE`, and in
+   #10063's case the advisory job had merely crashed on an unbound shell
+   variable before emitting any verdict at all. An advisory check therefore
+   never enters `pending` (a hung one must not hold the repo) nor `bad`; it
+   is listed separately and printed, so the signal stays visible in the log
+   while the decision stays clean.
+7. **Fork PRs short-circuit to PASS.** Issue #10072 -- student PRs from a
    fork have no internal convention to police, and `.claude/rules/student-pr-
    reviews.md` explicitly allows admin merges on red CI for that class of PR.
    The workflow passes `--is-fork` for `head.repo.fork == true`; the script
@@ -87,6 +100,19 @@ STATUS_PENDING = frozenset({"queued", "in_progress", "waiting", "pending", "requ
 
 DEFAULT_SELF_NAME = "PR gate"
 
+# Substring that marks a check as advisory (see rule 6). Matched
+# case-insensitively anywhere in the check name, because GitHub renders a job as
+# "<workflow> / <job>" and the marker sits in the job half. This is the
+# convention already in use across `.github/workflows` -- e.g. "CJK residue
+# advisory (label, non-blocking)" -- so no separate registry has to be kept in
+# sync with the workflows.
+ADVISORY_MARKER = "advisory"
+
+
+def is_advisory(name: str) -> bool:
+    """True when the check declares itself non-blocking by name (rule 6)."""
+    return ADVISORY_MARKER in (name or "").lower()
+
 
 class GateError(RuntimeError):
     """Raised when the check state cannot be established. Always fatal."""
@@ -115,16 +141,22 @@ def dedupe_latest(checks: Sequence[dict]) -> list[dict]:
 
 def classify(
     checks: Sequence[dict], self_name: str = DEFAULT_SELF_NAME
-) -> tuple[list[str], list[str], list[str]]:
-    """Split settled checks into (pending, bad, ok) name lists.
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    """Split settled checks into (pending, bad, ok, advisory) name lists.
 
     `self_name` is excluded so the gate never waits on itself. Matching is a
     prefix test because GitHub renders a job inside a workflow as
     "<workflow> / <job>", and the gate is required under its workflow name.
+
+    Advisory checks (rule 6) are diverted into their own list -- annotated with
+    what they actually reported -- and never reach `pending` or `bad`. They are
+    kept separate rather than merged into `ok` so a caller can print "advisory
+    X failed" instead of silently rewriting a failure into a pass.
     """
     pending: list[str] = []
     bad: list[str] = []
     ok: list[str] = []
+    advisory: list[str] = []
 
     for check in dedupe_latest(checks):
         name = check.get("name") or "<unnamed>"
@@ -133,6 +165,14 @@ def classify(
 
         status = (check.get("status") or "").lower()
         conclusion = (check.get("conclusion") or "").lower()
+
+        if is_advisory(name):
+            if conclusion not in CONCLUSION_OK:
+                state = conclusion or status or "no verdict"
+                advisory.append(f"{name} ({state})")
+            else:
+                ok.append(name)
+            continue
 
         if status in STATUS_PENDING or not conclusion:
             pending.append(name)
@@ -145,7 +185,18 @@ def classify(
             # adds later must not silently become a pass.
             bad.append(f"{name} (unknown conclusion '{conclusion}')")
 
-    return sorted(pending), sorted(bad), sorted(ok)
+    return sorted(pending), sorted(bad), sorted(ok), sorted(advisory)
+
+
+def _report_advisory(advisory: Sequence[str]) -> None:
+    """Print non-green advisory checks. Never affects the exit code (rule 6).
+
+    Printing is the whole point: the gate must not be the reason an advisory
+    signal disappears. The label posted by the advisory workflow itself remains
+    the durable carrier -- this line only keeps it visible in the gate's own log.
+    """
+    for entry in advisory:
+        print(f"[pr-gate] advisory (not blocking): {entry}", flush=True)
 
 
 def verdict(pending: Sequence[str], bad: Sequence[str], settled: bool) -> tuple[int, str]:
@@ -252,10 +303,11 @@ def wait_and_decide(
 
     while True:
         checks = fetch(repo, sha)
-        pending, bad, ok = classify(checks, self_name)
+        pending, bad, ok, advisory = classify(checks, self_name)
 
         if bad:
             # Fail fast: a failure cannot be undone by waiting longer.
+            _report_advisory(advisory)
             return verdict(pending, bad, settled=True)
 
         if pending:
@@ -263,10 +315,12 @@ def wait_and_decide(
         else:
             quiet_streak += 1
             if quiet_streak >= settle_polls:
+                _report_advisory(advisory)
                 print(f"[pr-gate] settled: {len(ok)} check(s) green", flush=True)
                 return verdict(pending, bad, settled=True)
 
         if now() >= deadline:
+            _report_advisory(advisory)
             return verdict(pending, bad, settled=False)
 
         print(

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -40,7 +40,7 @@ def run(name, conclusion, status="completed", started_at="2026-08-07T00:00:00Z",
 
 
 def decide(checks, self_name=pr_gate.DEFAULT_SELF_NAME, settled=True):
-    pending, bad, _ok = pr_gate.classify(checks, self_name)
+    pending, bad, _ok, _adv = pr_gate.classify(checks, self_name)
     return pr_gate.verdict(pending, bad, settled=settled)
 
 
@@ -72,7 +72,7 @@ def test_unreadable_api_exits_one(monkeypatch):
 
 def test_completed_without_conclusion_is_pending_not_pass():
     """`status=completed, conclusion=null` is a transient GitHub state."""
-    pending, bad, ok = pr_gate.classify([run("Odd", None)])
+    pending, bad, ok, _adv = pr_gate.classify([run("Odd", None)])
     assert pending == ["Odd"] and not bad and not ok
 
 
@@ -119,20 +119,20 @@ def test_distinct_names_are_never_merged():
 
 def test_gate_does_not_wait_for_itself():
     checks = [run("PR gate", None, status="in_progress"), run("Lean CI", "success")]
-    pending, bad, ok = pr_gate.classify(checks, "PR gate")
+    pending, bad, ok, _adv = pr_gate.classify(checks, "PR gate")
     assert pending == [] and bad == [] and ok == ["Lean CI"]
 
 
 def test_self_exclusion_matches_workflow_slash_job_rendering():
     checks = [run("PR gate / gate", None, status="queued")]
-    pending, _bad, _ok = pr_gate.classify(checks, "PR gate")
+    pending, _bad, _ok, _adv = pr_gate.classify(checks, "PR gate")
     assert pending == []
 
 
 def test_self_exclusion_is_not_a_loose_prefix():
     """"PR gateway" is a different check and must still be judged."""
     checks = [run("PR gateway", "failure")]
-    _pending, bad, _ok = pr_gate.classify(checks, "PR gate")
+    _pending, bad, _ok, _adv = pr_gate.classify(checks, "PR gate")
     assert bad == ["PR gateway"]
 
 
@@ -238,7 +238,7 @@ def test_pending_legacy_status_blocks_settling():
         {"name": "legacy/lint", "status": "in_progress", "conclusion": "",
          "started_at": "2026-08-07T00:00:00Z", "id": 9},
     ]
-    pending, _bad, _ok = pr_gate.classify(checks)
+    pending, _bad, _ok, _adv = pr_gate.classify(checks)
     assert pending == ["legacy/lint"]
 
 
@@ -298,3 +298,89 @@ def test_non_fork_path_is_unchanged(monkeypatch):
     code = pr_gate.main(["--repo", "o/r", "--sha", "deadbeef"])
     assert code == 0
     assert len(calls) == 1, "non-fork path must still call wait_and_decide"
+
+
+# --- advisory decoupling (rule 6, PRs #10063 / #10080) ----------------------
+
+
+def test_advisory_failure_does_not_block():
+    """The regression this file exists for: a red advisory left the gate red.
+
+    Shape taken from #10063 measured on 2026-08-08 -- the advisory job crashed
+    on an unbound shell variable, and `PR gate` went FAILURE with it.
+    """
+    checks = [
+        run("G-VAR-2/3 GENRE signals (advisory, non-blocking)", "failure"),
+        run("Lean CI", "success"),
+    ]
+    pending, bad, ok, advisory = pr_gate.classify(checks, "PR gate")
+    assert bad == [], "an advisory failure must never reach the blocking list"
+    assert pending == []
+    assert ok == ["Lean CI"]
+    assert advisory == ["G-VAR-2/3 GENRE signals (advisory, non-blocking) (failure)"]
+    assert pr_gate.verdict(pending, bad, settled=True)[0] == 0
+
+
+def test_advisory_pending_does_not_hold_the_gate():
+    """A hung advisory must not keep the repository waiting."""
+    checks = [
+        run("CJK residue advisory (label, non-blocking)", None, status="in_progress"),
+        run("Lean CI", "success"),
+    ]
+    pending, bad, _ok, advisory = pr_gate.classify(checks, "PR gate")
+    assert pending == [] and bad == []
+    assert advisory == ["CJK residue advisory (label, non-blocking) (in_progress)"]
+
+
+def test_advisory_marker_is_case_insensitive():
+    checks = [run("Slidev Build ADVISORY", "failure")]
+    _pending, bad, _ok, advisory = pr_gate.classify(checks, "PR gate")
+    assert bad == [] and len(advisory) == 1
+
+
+def test_green_advisory_counts_as_a_normal_pass():
+    """Only non-green advisory checks are singled out for reporting."""
+    checks = [run("Large blob advisory (>= 10 MiB)", "success")]
+    _pending, bad, ok, advisory = pr_gate.classify(checks, "PR gate")
+    assert bad == [] and advisory == []
+    assert ok == ["Large blob advisory (>= 10 MiB)"]
+
+
+def test_non_advisory_failure_still_blocks():
+    """Guard against the fix becoming a blanket amnesty."""
+    checks = [
+        run("Lean CI (grothendieck_lean)", "failure"),
+        run("Exercises >= 3 advisory (label, non-blocking)", "failure"),
+    ]
+    _pending, bad, _ok, advisory = pr_gate.classify(checks, "PR gate")
+    assert bad == ["Lean CI (grothendieck_lean)"]
+    assert len(advisory) == 1
+    assert pr_gate.verdict([], bad, settled=True)[0] == 1
+
+
+def test_advisory_is_printed_not_swallowed(capsys):
+    """The gate must not be the reason an advisory signal disappears."""
+    pr_gate._report_advisory(["Twin parity SHA mismatch (advisory) (failure)"])
+    out = capsys.readouterr().out
+    assert "not blocking" in out
+    assert "Twin parity SHA mismatch (advisory) (failure)" in out
+
+
+def test_advisory_failure_alone_settles_green_end_to_end():
+    """Whole-loop check: the #10063 shape now reaches exit 0."""
+    checks = [
+        run("G-VAR-2/3 GENRE signals (advisory, non-blocking)", "failure"),
+        run("Lean CI", "success"),
+    ]
+    code, msg = pr_gate.wait_and_decide(
+        repo="o/r",
+        sha="deadbeef",
+        timeout_min=1,
+        poll_sec=0,
+        self_name=pr_gate.DEFAULT_SELF_NAME,
+        settle_polls=2,
+        sleep=lambda _s: None,
+        fetch=lambda _r, _s: checks,
+        now=lambda: 0.0,
+    )
+    assert code == 0, msg


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/docs #10037

## Le defaut

`PR gate` (#9819, requis sur `main` depuis hier) agrege **tous** les checks du head SHA. Il n'a aucune notion d'`advisory` :

```python
CONCLUSION_OK = frozenset({"success", "neutral", "skipped"})
```

Consequence non voulue : **tout garde advisory qui rougit devient un gate dur**. Exactement le contraire de ce que son auteur a declare — 7 des 53 jobs de `.github/workflows` se nomment `advisory`, dont 5 precisent « label, non-blocking ».

## Mesure (pas lecture d'intention)

Constate ce matin sur les deux seules PRs `BLOCKED` du depot :

| PR | checks non-verts | cause reelle |
|---|---|---|
| #10063 | `G-VAR-2/3 GENRE signals (advisory,` + `PR gate` | le job advisory a **plante** (`line 112: SIG_TIER_INFLATION: unbound variable`) **avant d'emettre le moindre verdict** ; `PR gate` a rougi avec lui |
| #10080 | `Require Grain tag (block on absent,` + `PR gate` | tag `Grain:` reellement absent — blocage **legitime** |

Le cas #10063 est le pire de la classe : le garde n'a rien detecte, il s'est **casse**, et un garde advisory casse arretait le depot.

## Le correctif

Regle 6 ajoutee au docstring. Un check dont le nom contient `advisory` (insensible a la casse, sous-chaine — la convention deja en place, pas de registre a maintenir en parallele des workflows) :

- n'entre **jamais** dans `bad` (ne bloque pas) ;
- n'entre **jamais** dans `pending` (un advisory *pendu* ne doit pas retenir le depot) ;
- est **imprime** — `[pr-gate] advisory (not blocking): <nom> (<etat>)`.

Le 4e bucket est explicite plutot que replie dans `ok` : un gate qui reecrit silencieusement un echec en succes est precisement le defaut corrige. Contrat `classify()` passe de 3 a 4 valeurs, 7 sites de test et 4 sites du module mis a jour.

## Preuve par execution, sur les vrais checks

Pas une fixture — `fetch_checks` sur les head SHA reels de #10063 et #10080 :

```
#10063  verdict=0  ok=14 bad=0 pending=0 advisory=1
    advisory (non bloquant): G-VAR-2/3 GENRE signals (advisory, (failure)
#10080  verdict=1  ok=41 bad=1 pending=0 advisory=0
    BLOQUANT: Require Grain tag (block on absent,
```

Les deux moities se comportent comme voulu : #10063 cesse d'etre bloque **par le gate** (il reste bloque par ma review, ce qui est le bon endroit pour une decision de politique), et #10080 **reste bloque** — son garde est nomme pour bloquer, le correctif ne le maquille pas.

`30 passed` (23 existants + 7 nouveaux), dont deux garde-fous anti-derive :

- `test_non_advisory_failure_still_blocks` — le correctif ne devient pas une amnistie generale (`Lean CI (grothendieck_lean) -> failure` bloque toujours, cote a cote avec un advisory rouge) ;
- `test_advisory_is_printed_not_swallowed` — le gate ne doit pas etre la raison pour laquelle un signal advisory disparait.

## Ce que ce correctif ne fait pas

Il **ne repare pas** le bug de #10063. La table de noms de ce workflow est incoherente avec elle-meme : L154-157 declarent `SIG_INFLATION` / `SIG_RUN` / `SIG_CAPEXC` / `SIG_MISMATCH`, tandis que L175 derive dynamiquement `SIG_$(echo "$SIGNAL" | tr '-' '_')`, soit `SIG_TIER_INFLATION` — jamais defini, et `set -uo pipefail` (L65) tue le job. Les quatre noms divergent ; la boucle meurt sur le premier. Cela reste a corriger dans #10063 (review posee), et l'intention de son auteur etait bien advisory : le fichier finit par `exit 0` (L225).

La division est deliberee : la **politique** appartient a la review, la **mecanique** au gate. Un garde advisory pouvant toujours planter, le depot ne doit pas s'arreter quand il plante — [[rule-needs-an-organ-not-more-vigilance]].

See #10063, #10080, #9819, #10072.
