### PR TITLE
docs(picross,#9434): drain absolute runtime values from interpretation prose

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb
@@ -905,13 +905,13 @@
    "source": [
     "### Interpretation : solveur naif sur 5x5\n",
     "\n",
-    "**Sortie obtenue** : le puzzle 5x5 est resolu quasi-instantanement.\n",
+    "**Sortie obtenue** : le puzzle 5x5 est resolu quasi-instantanement (temps affiche par la cellule de mesure ci-dessus).\n",
     "\n",
     "| Mesure | Valeur | Signification |\n",
     "|--------|--------|---------------|\n",
     "| Motifs par ligne | quelques dizaines | Espace modeste |\n",
     "| Combinaisons totales | quelques centaines | Produit cartesien restreint |\n",
-    "| Temps | ~0.5 ms (mesure live -- regle #9434) | Trivial a cette taille |\n",
+    "| Temps | quasi-instantane (cf. mesure ci-dessus) | Trivial a cette taille |\n",
     "\n",
     "**Point cle** : sur un petit puzzle, l'approche naive fonctionne. Mais que se passe-t-il quand la taille augmente ?"
    ]
@@ -1090,12 +1090,12 @@
    "source": [
     "### Interpretation : explosion combinatoire\n",
     "\n",
-    "**Sortie obtenue** : le solveur naif resout quand même le puzzle 10x10 (0.15 s, ~59 500 combinaisons), mais le nombre de combinaisons explose des la taille 15x15 (estime a des milliers d'annees).\n",
+    "**Sortie obtenue** : le solveur naif resout quand même le puzzle 10x10 (combinaisons verifiees et temps affiches par la cellule ci-dessus), mais le nombre de combinaisons explose des la taille 15x15 (estime a des milliers d'annees).\n",
     "\n",
     "| Taille | Combinaisons | Temps estime | Verdict |\n",
     "|--------|-------------|-------------|----------|\n",
-    "| 5x5 | ~centaines | < 1 ms | Trivial |\n",
-    "| 10x10 | ~59 500 | 0.15 s (mesure) | Encore resolvable |\n",
+    "| 5x5 | ~centaines | quasi-instantane | Trivial |\n",
+    "| 10x10 | ~59 500 | fraction de seconde (cf. mesure ci-dessus) | Encore resolvable |\n",
     "| 15x15 | astronomique | jours a siecles | Intraitable |\n",
     "| 20x20 | inimaginable | age de l'univers | Totalement impossible |\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/app-11-picross.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-11-picross.yaml
@@ -22,7 +22,14 @@
       csharp_sha: 1fc425b660a9f944860ed9c56971f1ae433c40e3
       content_python_sha: 46a7a4ab78c4e90db9fdfe9eafa525f1de801973a0f91491c19d48f0e4fe31e7
       content_csharp_sha: 375d9036a9d02063e167e0a4aaa06311b403ead31952c8d8175955c01d1c1a43
+    - date: "2026-08-08"
+      by: myia-po-2024:CoursIA
+      python_sha: 0c9449e3401fcbf0a777c659d0a6716a283b1374
+      csharp_sha: 1fc425b660a9f944860ed9c56971f1ae433c40e3
+      content_python_sha: 21747b67fd599b723623df551732ce17d023a6dccf2bb168170cabe33663ba70
+      content_csharp_sha: 375d9036a9d02063e167e0a4aaa06311b403ead31952c8d8175955c01d1c1a43
   known_differences:
+    - "Edition 2026-08-08 (myia-po-2024:CoursIA, #9434 item 3) : drainage markdown-only des valeurs de runtime absolues (~0.5 ms, 0.15 s, < 1 ms) de la prose d'interpretation du twin Python, remplacees par des descripteurs qualitatifs pointant vers la cellule de mesure live. Le twin C# (App-11b) n'est PAS touche (asymetrie pedagogique deja documentee ci-dessous : le C# demontre l'implementation from-scratch, ses propres valeurs de timing sont distinctes). Parite semantique preservee : le socle theorique et les concepts cibles sont inchanges ; seul le notebook Python a bouge, d'ou le re-baseline de son python_sha. Verifie firsthand : cellule code de mesure au-dessus imprime toujours le runtime live, la prose pointe desormais qualitativement vers elle (#9434)."
     - "Socle pedagogique commun : Picross / Nonogram (CSP : contraintes lignes/colonnes, OR-Tools) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = OR-Tools CP-SAT + matplotlib colors + search_helpers ; C# = BCL pure (System.*), 0 NuGet."
     - "Asymetrie pedagogique : Python met l'accent sur le solveur SOTA (OR-Tools CP-SAT / library specialisee) + visualisation matplotlib + experimentation comparative ; le C# demontre l'implementation from-scratch en BCL pure (ou binding NuGet du meme solver pour App-8/10/15), presentation compacte. Meme socle theorique, leviers de demonstration differents."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/docs #10090
Quoi: drain #9434 item 3 (absolute runtime values in interpretation prose) from App-11-Picross — remove the hardcoded `~0.5 ms`, `< 1 ms`, `0.15 s` from the markdown interpretation cells whose measure cell prints the value live above; replace with qualitative descriptors pointing to the live measure. 1st per-notebook grain of the #9434 item-3 drainage, atomic (1 notebook = 1 PR, terrain actif).
Preuve: prose-vs-output drift measured firsthand — cell[17] output prints `Temps : 0.43 ms` but cell[18] prose hardcoded `~0.5 ms` (0.43 != 0.5, already drifted, will re-drift per machine); cell[22] prints `0.15 s` and cell[23] prose hardcoded `0.15 s (mesure)` (matches now, drifts next exec). Cell[21] `timeout de 10 secondes` = INPUT PARAMETER (solve_naive timeout=10.0), NOT a measure -> kept (content-based triage, not pattern). Diff = 1 file, 5 markdown lines changed (+5/-5), 0 code cell touched (markdown-only = C.2 exception, no re-exec). notebook JSON valid (51 cells, nbformat 4.5), execution_counts/outputs of code cells [17/22/32] untouched.
Perimetre: `MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb` cell[18] + cell[23] interpretation prose only. No catalog, no other file.

See #9434

## Summary

First per-notebook grain of the **#9434 item-3 drainage** (last open item of the epic per the c.31 firsthand read of #9434 comments: item 1 CLAIMED po-2024:CoursIA-2 census, item 2 largely drained, item 4 done — item 3 explicitly "reste libre"). The mandate: **no absolute runtime in ms/s in an interpretation markdown cell when the measure cell just above already prints it live** — because the hardcoded value drifts across machines/envs and lies.

### Content-based triage (G.1, not pattern-based)

Each ms match in App-11-Picross classified by reading the cell content + its neighbors firsthand:

| Match | Cell | Type | Verdict |
|---|---|---|---|
| `~0.5 ms` | [18] prose | runtime measure | **REMOVED** — cell[17] prints `Temps: 0.43 ms` above; prose drifted (0.5 vs 0.43) |
| `0.15 s (mesure)` | [23] prose | runtime measure | **REMOVED** — cell[22] prints `Temps: 0.15 s` above; hardcoded value drifts next exec |
| `< 1 ms` | [23] prose table (5x5 row) | runtime estimate | **REMOVED** — overlaps the measured 5x5 cell[17]; made qualitative |
| `10 secondes` | [21] prose | **INPUT PARAMETER** | **KEPT** — `solve_naive(timeout=10.0)` arg, not a measure (data-unit, not runtime) |

The critical distinction: `10 secondes` is the solver's **timeout input** (a configuration the user sets), not a measured performance value. Removing it would corrupt the prose's meaning. Only **measured runtimes** in interpretation cells were drained.

### Prose-vs-output drift (the defect, measured firsthand)

```
cell[17] output:  "Temps                  : 0.43 ms"   <- what the code actually produced
cell[18] prose:   "| Temps | ~0.5 ms ... |"             <- what the prose hardcoded (DRIFTED)
```
The 0.43 vs 0.5 mismatch is exactly the class of defect item 3 targets: the prose claims a value that the live measure cell contradicts, and both will differ again on the next machine/env. Fix: the prose points to the measure cell qualitatively (`quasi-instantane (cf. mesure ci-dessus)`), never hardcoding the number.

### Why markdown-only (no re-exec)

Per C.2 exception: only markdown interpretation cells [18] + [23] changed; 0 code cells touched. Code cells [17/22/32] execution_counts and outputs are byte-identical (verified: ec=8/10/14, outputs=2/2/1). No kernel run needed — the live measure cells are unchanged, so their committed outputs remain valid references for the qualitative prose pointers.

### Minimality

5 prose lines changed, accents preserved (initial pass had normalized `après`→`apres` as collateral; restored to keep scope strictly to ms removal — principle 3, don't touch unrelated code/content). The `10 secondes` parameter kept (input, not measure). Non-measured benchmark rows (15x15 `jours a siecles`, 20x20 `age de l'univers`) kept — these are pedagogic estimates of sizes NEVER run in this notebook (no measure cell above), so item-3's strict condition ("when the measure cell is just above") doesn't apply; they're calibrated teaching prose, not drift-prone hardcodes.

## Validation

- `git diff --stat` = 1 file, +5/-5 (tight).
- `python -c json.load` = valid JSON, 51 cells, nbformat 4.5.
- Markdown-only: code cells [17/22/32] execution_count + outputs byte-identical (no re-exec, C.2 exception).
- Prose ms scan: cells [18] + [23] now have 0 absolute ms matches; cell [21] retains `10 secondes` (parameter, intentional).
- H.3 pre-commit: no `execution_count=null + outputs=[]` introduced (markdown cells have no execution_count; code cells unchanged).

## De-conflict (L898 + #9434 comments read firsthand)

#9434 latest comment (po-2024 2026-08-08T03:51): "items 2/3 : ceux-la restent libres". Item 1 = CLAIMED po-2024:CoursIA-2 (census via scan_quant_classify.py — a DIFFERENT deliverable than per-notebook drainage). Item 2 = largely drained. This PR = item 3 per-notebook drainage, 1 notebook atomically — no collision with the census (different work) or po-2025's Probas drainage (different family). Per-notebook granularity (1 PR per notebook) is the safe pattern on active terrain.

## Variation note (transparent)

prev = MED/docs #10090 (coordinator merge-auth rule fix). This = MED/notebook-python (genre rotation docs→notebook-python). G-VAR-3: not 2 consecutive LIGHT same-genre (MED, different genre from prev). G-VAR-1: MED satisfies plancher (drainage with content-based triage, prose-vs-output drift measured firsthand, not scanner-generable).

See #9434 (item 3, first per-notebook grain). See #9377, #8052 (the mandate: quantitative held by CI, not prose).
