### PR TITLE
docs(timetabling,#9434): drain absolute runtime values from CP-SAT comparison prose

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb
@@ -1309,7 +1309,7 @@
     "| Aspect | Glouton | CP-SAT | Commentaire |\n",
     "|--------|---------|--------|-------------|\n",
     "| Faisabilite | Oui | Oui (garanti si solution existe) | CP-SAT est complet |\n",
-    "| Temps de calcul | < 1 ms | ≈ 30 ms | Les deux sont rapides ici |\n",
+    "| Temps de calcul | quasi-instantane (cf. mesure) | fraction de seconde (cf. mesure ci-dessus) | Les deux sont rapides ici |\n",
     "| Optimisation souples | Non | Oui | Différence majeure |\n",
     "| Equilibre des jours | Mediocre | Bien meilleur | Grace a l'objectif |\n",
     "| Trous enseignants | Non minimises | Minimises | Grace aux penalites |\n",

--- a/scripts/notebook_tools/twin_pairs.d/app-5-timetabling.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-5-timetabling.yaml
@@ -8,7 +8,14 @@
       by: myia-po-2023:CoursIA
       python_sha: a80035cb146ea49ef5901ddb940cf573e600017f
       csharp_sha: 1df664fbb228832fec6d05c12efe390465bd65c0
+    - date: "2026-08-08"
+      by: myia-po-2024:CoursIA
+      python_sha: f86c512657965de508bfef73f94fd81adf13a3a8
+      csharp_sha: 1df664fbb228832fec6d05c12efe390465bd65c0
+      content_python_sha: e3138b0bbcc57898cb78a3e3be17edefd3b13501a30f3bd6ef20ce9b943a1e6e
+      content_csharp_sha: 1cdbcf8ff9091c8d28496ae42c40f6a6a9b2bc9afd0be44388f7ae9de3497191
   known_differences:
+    - "Edition 2026-08-08 (myia-po-2024:CoursIA, #9434 item 3) : drainage markdown-only d'une ligne de tableau dans la prose d'interpretation du twin Python (cell[22]) : les valeurs runtime absolues '< 1 ms' (Glouton) et '≈ 30 ms' (CP-SAT) remplacees par des descripteurs qualitatifs pointant vers les cellules de mesure live (cell[12] greedy 'Temps : 0.07 ms', cell[19] CP-SAT 'Temps de calcul : 32.5 ms'). Le twin C# (App-5-Timetabling-CSharp) n'est PAS touche (asymetrie pedagogique deja documentee ci-dessous : le C# demontre l'implementation from-scratch, ses propres valeurs de timing sont distinctes). Parite semantique preservee : socle theorique et concepts cibles inchanges ; seul le notebook Python a bouge, d'ou le re-baseline de son python_sha. Verifie firsthand : les cellules code de mesure au-dessus impriment toujours les runtimes live, la prose pointe desormais qualitativement vers elles (#9434)."
     - "Socle pedagogique commun : Emploi du temps / Timetabling (CSP : creneaux, salles, conflits) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = OR-Tools CP-SAT + itertools combinations + search_helpers ; C# = BCL pure (System.*), 0 NuGet."
     - "Asymetrie pedagogique : Python met l'accent sur le solveur SOTA (OR-Tools CP-SAT / library specialisee) + visualisation matplotlib + experimentation comparative ; le C# demontre l'implementation from-scratch en BCL pure (ou binding NuGet du meme solver pour App-8/10/15), presentation compacte. Meme socle theorique, leviers de demonstration differents."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #10091
Quoi: drain #9434 item 3 (absolute runtime values in interpretation prose) from App-5-Timetabling — remove the hardcoded `< 1 ms` (Glouton) + `≈ 30 ms` (CP-SAT) from the cell[22] comparison table whose measure cells (cell[12] greedy, cell[19] CP-SAT) print the values live above; replace with qualitative descriptors pointing to the live measures. 2nd per-notebook grain of the #9434 item-3 drainage, atomic (1 notebook = 1 PR, terrain actif).
Preuve: prose-vs-output drift measured firsthand — cell[12] output prints `Temps : 0.07 ms` (Glouton) but cell[22] prose table hardcoded `< 1 ms`; cell[19] output prints `Temps de calcul : 32.5 ms` (CP-SAT) but cell[22] prose table hardcoded `≈ 30 ms` (32.5 != 30, already drifted, re-drifts per machine). cell[19] `time_limit_s=10.0` = solver INPUT PARAMETER (in code cell), NOT a measure → not in scope. cell[25] interpretation already qualitative ('Quasi-instantane', 'Quelques ms') → untouched. Diff = 1 file, +1/-1 (1 table row), 0 code cell touched (markdown-only = C.2 exception, no re-exec). notebook JSON valid (47 cells, nbformat 4.5); twin parity rebaselined (App-5 Timetabling pair, csharp_sha UNCHANGED).
Perimetre: `MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb` cell[22] table row only + twin registry `scripts/notebook_tools/twin_pairs.d/app-5-timetabling.yaml` rebaseline. No catalog, no other file.

See #9434

## Summary

2nd per-notebook grain of the **#9434 item-3 drainage** (the active campaign I own on lane po-2024). Same mandate as #10091 (App-11-Picross): **no absolute runtime in ms/s in an interpretation markdown cell when the measure cell just above already prints it live** — because the hardcoded value drifts across machines/envs and lies.

### Content-based triage (G.1, not pattern-based)

cell[22] is the CP-SAT interpretation cell with a Glouton-vs-CP-SAT comparison table. Each ms match classified by reading the cell + its measure-cell neighbors firsthand:

| Match | Cell | Live measure cell | Verdict |
|---|---|---|---|
| `< 1 ms` (Glouton) | [22] table | cell[12] prints `Temps : 0.07 ms` | **REMOVED** — drifted (0.07 vs <1 hardcoded) |
| `≈ 30 ms` (CP-SAT) | [22] table | cell[19] prints `Temps de calcul : 32.5 ms` | **REMOVED** — drifted (32.5 != 30) |

| Match | Cell | Type | Verdict |
|---|---|---|---|
| `time_limit_s=10.0` | [19] code | **INPUT PARAMETER** | **KEPT** — solver timeout config (in code cell, not prose), not a measure |
| `Quasi-instantane`, `Quelques ms` | [25] prose | already qualitative | **KEPT** — no absolute value, already conforms |

Only **measured runtimes** in the interpretation table were drained. The `time_limit_s=10.0` is the solver's timeout input (a config), not a measured value — removing it would corrupt meaning.

### Prose-vs-output drift (the defect, measured firsthand)

```
cell[12] output:  "Temps             : 0.07 ms"   <- Glouton, what the code produced
cell[19] output:  "Temps de calcul   : 32.5 ms"   <- CP-SAT, what the code produced
cell[22] prose:   "| Temps de calcul | < 1 ms | ≈ 30 ms |"  <- hardcoded (DRIFTED both)
```
The 32.5 vs ≈30 mismatch is exactly the class of defect item 3 targets. Fix: the table now points to the measure cells qualitatively (`quasi-instantane (cf. mesure)` / `fraction de seconde (cf. mesure ci-dessus)`), never hardcoding the number.

### Why markdown-only (no re-exec)

Per C.2 exception: only markdown cell[22] source changed; 0 code cells touched. ALL code cells execution_count + outputs byte-identical (verified programmatically: changed CODE cells = [], changed MD cells = [(22,'markdown')]). No kernel run needed — the live measure cells are unchanged, so their committed outputs remain valid references for the qualitative prose pointers.

### Twin parity (#8057)

App-5-Timetabling is a FR/C# twin pair. My markdown-only edit moved the Python blob SHA → DRIFT. Rebaselined via `check_twin_parity.py --update --pair "App-5 Timetabling" --by "myia-po-2024:CoursIA"` (run AFTER the notebook commit, per #8957): python_sha `a80035cb14 → f86c512657`, csharp_sha `1df664fbb2` **UNCHANGED** (C# twin untouched, semantic parity preserved). Added a known_differences header line documenting the edition. Verified locally: 157/157 pairs OK, DRIFT=0.

The C# twin (App-5-Timetabling-CSharp) has its own distinct timing values (documented pedagogical asymmetry: C# demonstrates from-scratch implementation) — separate concern, not edited here.

## Validation

- `git diff --stat` = 1 file, +1/-1 (tightest possible — 1 table row).
- `python -c json.load` = valid JSON, 47 cells, nbformat 4.5.
- Markdown-only: ALL code cells execution_count + outputs byte-identical (no re-exec, C.2 exception).
- Prose ms scan: cell[22] now has 0 absolute ms matches; cell[19] `time_limit_s` kept (parameter); cell[25] already qualitative.
- Twin parity: 157/157 OK, DRIFT=0 (rebaselined, csharp_sha unchanged).
- Pre-commit hooks: gitleaks + H.3 + markdown-rendering + strip hooks all PASS (H.3 confirms markdown-only — no un-executed-cell issue).

## De-conflict (L898 + #9434 comments read firsthand)

L898 collision guard CLEAN: all PRs touching App-5-Timetabling are MERGED (#9009 fixed stale 61.6 ms timing for #8052 — a DIFFERENT value/cell, already landed; #3588 aligned timing interpretation). 0 OPEN PR on this notebook. Verified the ms matches firsthand on CURRENT origin/main (not a stale base): the cell[22] table values were still hardcoded and drifting. #9434 latest comment (po-2024 2026-08-08T03:51): "items 2/3 restent libres". Item 1 = CLAIMED po-2024:CoursIA-2 (census). This PR = item 3 per-notebook drainage, 1 notebook atomically — no collision. Per-notebook granularity (1 PR per notebook) is the safe pattern on active terrain.

## Variation note (transparent)

prev = MED/notebook-python #10091 (App-11-Picross). This = MED/notebook-python (App-5-Timetabling) — 2nd consecutive same-genre. G-VAR-3: the absolute ban is on 2 consecutive **LIGHT** same-genre; for MED in a lane's domain, 2 consecutive are allowed **if each is genuinely distinct substance**. App-5 (Timetabling CSP, Glouton-vs-CP-SAT comparison table) ≠ App-11 (Nonogram CSP, single-solver runtime prose) — different CSP problem, different prose structure, different drift pattern measured firsthand. Both are MED (content-based triage + prose-vs-output drift measured firsthand, not scanner-generable), not LIGHT. Variation protocol §5 self-detection: not LIGHT, so the generating-in-series test doesn't apply. R6/R7 variety: the realistic executable MED pool is the #9434 residual notebooks (pool scan c.31 confirmed DRAINED of other unclaimed CPU DEEP/MED — rest is resolved-on-main-but-still-open / active campaigns / GPU-vision-gated / user-blocker).

See #9434 (item 3, 2nd per-notebook grain). See #9434 PR #10091 (App-11-Picross, grain 1). See #8052, #9377 (the mandate: quantitative held by CI/prose-points-to-live, not hardcoded).
