### PR TITLE
feat(ci,#10093): blocking gate against prev: close-keyword genres in body + commits

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -554,3 +554,110 @@ jobs:
           # aggregates all check-runs and will report this as BLOCKED, so
           # the PR is non-mergeable until the body is fixed.
           exit 1
+
+  # #10093 -- the BLOCKING gate against `prev:` close-keyword genres. The
+  # four jobs above (tag advisory, light cap, short-header, tag-required)
+  # read the PR BODY. This one reads the COMMIT MESSAGES too: the incident
+  # was a commit carrying `prev: MED/fix #10067` whose `fix #10067` tail
+  # GitHub parsed as an auto-close, closing PR #10067 (the translation core
+  # deliverable) at the squash-merge of #10063 -- unintended, silent, no
+  # keyword in #10063's body (its body tag was `MED/tooling`, sane).
+  #
+  # Why BLOCKING: the failure is DESTRUCTIVE and happens AT MERGE TIME
+  # (the squash commit message is what GitHub parses). An advisory label
+  # would not stop the merge. Only a required check turning `PR gate` red
+  # before merge prevents the auto-close -- same shape as the
+  # `check-variation-tag-required` job.
+  #
+  # Why scan commits: the offending tag was in a COMMIT, not the body. A
+  # body-only gate would have seen nothing. The decision logic lives in
+  # `scripts/ci/variation_prev_guard.py` (testable, same pattern as
+  # `variation_tag_required.py`); the YAML is plomberie.
+  #
+  # The job name carries the `-required` suffix on purpose: PR #10036's
+  # `is_advisory()` classifier in `scripts/pr_gate.py` must NOT silence
+  # this job (cf. check-variation-tag-required). The 14 canonical genres
+  # contain no closing keyword, so a closing-keyword `prev:` genre is
+  # ALWAYS a misuse -- the worker meant refactor/guard/tooling, never fix.
+  # A standalone `Fixes #N` (intended close) is NOT flagged: the
+  # discriminator is the `prev:` prefix, not the keyword alone.
+  check-prev-close-keyword-required:
+    name: 'Require prev: non-closing (block on close-keyword genre, #10093)'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the prev-guard helper (sparse)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/ci/variation_prev_guard.py
+            scripts/grain_tag.py
+      - name: 'Scan body + commit messages for prev: close-keyword'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          set -uo pipefail
+
+          # Same bot/fork gating as the other jobs (cf. student-pr-reviews.md).
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issue d'un fork : hors scope (PR etudiante)."
+            exit 0
+          fi
+
+          # Body to a file -- printf '%s' preserves it verbatim.
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          # Commit messages as a JSON array of strings. `messageBody` is the
+          # full commit message (subject + body), which is what GitHub parses
+          # for auto-close keywords. Empty/missing file -> no commits to scan
+          # (the helper tolerates it).
+          gh pr view "$PR_NUMBER" --json commits --jq '[.[].messageBody]' \
+            > /tmp/commits.json 2>/dev/null || printf '[]' > /tmp/commits.json
+
+          # The helper scans body + commits for `prev:` close-keyword genres
+          # and exits 0 (pass) or 1 (block). stderr surfaced for debug.
+          python3 scripts/ci/variation_prev_guard.py \
+            --body-file /tmp/pr_body.txt \
+            --commits-file /tmp/commits.json > /tmp/verdict.json 2>/tmp/verdict.err
+          RC=$?
+
+          if [ -s /tmp/verdict.err ]; then
+            echo "--- helper stderr ---"
+            cat /tmp/verdict.err
+          fi
+          echo "--- verdict ---"
+          cat /tmp/verdict.json
+
+          if [ "$RC" -eq 0 ]; then
+            echo "No `prev:` close-keyword genre in body or commits -- job passes."
+            exit 0
+          fi
+
+          # Block path. Idempotent comment via the HTML marker.
+          REASON=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('reason','unknown'))" 2>/dev/null || echo "unknown")
+          echo "::error::prev: close-keyword genre detected: $REASON"
+
+          gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          <!-- vtr-prev-close-keyword -->
+          **\`prev:\` genre mots-clé fermant -- bloquant (#10093).**
+
+          ${REASON}
+
+          Une \`prev:\` dont le genre est \`fix\`/\`close\`/\`resolve\` (ou une inflexion) fait que GitHub interprète \`<genre> #N\` comme un ordre de fermeture automatique dès que le texte atterrit dans un message de commit -- c'est exactement ce qui a fermé #10067 (sans la merger) au squash-merge de #10063. Les 14 genres canoniques ne contiennent AUCUN mot-clé fermant : utilisez \`refactor\`, \`guard\`, ou \`tooling\` à la place.
+
+          Pour passer ce gate, réécrivez le champ \`prev:\` (dans le body ET dans chaque commit concerné) avec un genre non-fermant :
+
+          \`\`\`
+          Grain: <TIER>/<genre> -- lane <machine:workspace> -- prev: <TIER>/<refactor|guard|tooling|...> #<PR>
+          \`\`\`
+          EOF
+          )" 2>/dev/null || true
+
+          exit 1

--- a/scripts/ci/variation_prev_guard.py
+++ b/scripts/ci/variation_prev_guard.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+r"""variation_prev_guard.py -- BLOCKING gate against `prev:` close-keyword genres (#10093).
+
+## Why this exists
+
+Issue #10093 measures a silent, destructive failure: merging PR #10063 via
+squash created a commit whose message carried the line
+
+    Grain: MED/fix -- lane myia-po-2024:CoursIA-2 -- prev: MED/fix #10067 (c.1331+50)
+
+GitHub parsed `fix #10067` as an auto-close instruction and CLOSED PR #10067
+(the core translation deliverable) without merging it -- no intention, no
+keyword in the PR body of #10063 (its body tag was `MED/tooling`, sane), no
+notification to its author. A closed PR reads exactly like an abandoned one.
+
+The `prev:` field (variation-protocol.md §1) is mandatory for tracing genre
+adjacency. Its genre slot reuses the same enumeration as the leading tag. The
+14 canonical genres contain NO GitHub closing keyword, so a `prev:` whose genre
+is `fix`/`close`/`resolve` (or inflections) is ALWAYS a misuse -- the worker
+meant `refactor`, `guard`, or `tooling`. The danger is that the `genre #N`
+tail is a valid auto-close instruction when the text lands in a commit
+message.
+
+## What it does
+
+Scans the PR body AND every commit message on the branch for a `prev:` field
+whose genre is a closing keyword (`grain_tag.CLOSING_KEYWORDS`). Emits a
+single verdict on stdout:
+
+    {"guard_pass": true|false, "reason": "<one line>", "hits": [...]}
+
+Exit codes:
+  0  -- no `prev:` close-keyword genre in body or commits
+  1  -- at least one hit (the PR is non-mergeable until the offending tag is
+        rewritten with a non-closing genre)
+  2  -- caller error (unreadable file)
+
+## Why BLOCKING (not advisory)
+
+The existing `check-variation-tag` job is advisory (exit 0): it posts labels
+and lets the coordinator decide. That is correct for cosmetic tag defects
+(offlist genre, missing short-header). It is WRONG here because the failure is
+DESTRUCTIVE and happens AT MERGE TIME: the squash commit message is what
+GitHub parses, and an advisory label does not stop the merge. Only a required
+check that turns `PR gate` red before merge prevents the auto-close -- the
+same shape as `check-variation-tag-required` (#10045).
+
+## Why it scans commit messages (not just the body)
+
+The #10093 incident: the offending tag was in a COMMIT message, not the PR
+body. A body-only gate would have seen nothing (the body tag was `MED/tooling`
+-- perfectly sane). The point dur (#10093) is precisely that the gate must
+read the commit messages that will become the squash message.
+
+## What it does NOT flag
+
+A standalone ``Fixes #123`` / ``Closes #456`` in a commit message is an
+INTENDED close (catalog-pr-hygiene HARD 4 -- `Closes #N` when the PR fully
+resolves the issue). This gate leaves those alone: it only flags the genre
+slot of a `prev:` field, where a closing keyword is structurally wrong. The
+discriminator is the `prev:` prefix, not the keyword alone.
+
+## Run locally
+
+    python scripts/ci/variation_prev_guard.py --body-file body.txt
+    # with commit messages (JSON array of strings):
+    python scripts/ci/variation_prev_guard.py --body-file body.txt --commits-file commits.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Make the shared extractor importable from anywhere in the repo (CI runs
+# from the repo root; local devs may run from the script directory).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import grain_tag as gt  # noqa: E402
+
+
+def check(body: str | None, commits: list[str] | None = None) -> dict:
+    """Return the blocking verdict for a PR body + its commit messages.
+
+    Pure function so unit tests pin each branch without going through the
+    CLI. ``commits`` is the list of commit message strings on the branch
+    (the workflow fetches them via ``gh pr view --json commits``); each is
+    scanned independently so the verdict can name which commit offended.
+    """
+    hits_body = gt.find_prev_close_keywords(body)
+    hits_commits: list[dict] = []
+    for i, msg in enumerate(commits or []):
+        for h in gt.find_prev_close_keywords(msg):
+            hits_commits.append({"commit_index": i, **h})
+
+    if not hits_body and not hits_commits:
+        return {"guard_pass": True, "reason": "no prev: close-keyword genre", "hits": []}
+
+    locs = []
+    if hits_body:
+        locs.append(f"body ({len(hits_body)})")
+    if hits_commits:
+        locs.append(f"commit messages ({len(hits_commits)})")
+    # The one-line fix: map the closing-keyword genre to its canonical
+    # non-closing equivalent. `fix` -> `refactor` (can-be-rouging work) or
+    # `guard`; the worker picks. The reason must name the offending genres
+    # so the failure is debuggable from the job log alone.
+    genres = sorted({h["genre"] for h in (hits_body + hits_commits)})
+    reason = (
+        f"`prev:` genre(s) {genres} in {' + '.join(locs)} are GitHub closing "
+        f"keywords -> rewrite the `prev:` genre as refactor/guard/tooling "
+        f"(never a closing word). See #10093."
+    )
+    return {
+        "guard_pass": False,
+        "reason": reason,
+        "hits": {"body": hits_body, "commits": hits_commits},
+    }
+
+
+def _read_commits_file(path: str) -> list[str]:
+    """Read a commits file as a JSON array of message strings.
+
+    The workflow writes ``gh pr view --json commits --jq '[.[].messageBody]'``
+    to the file. A plain JSON array of strings is the robust shape: commit
+    messages are multi-line, so a line-oriented format would be ambiguous.
+    An empty/missing file yields an empty list (no commits to scan).
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+    if isinstance(data, list):
+        return [str(m) for m in data if isinstance(m, str)]
+    return []
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--body-file", metavar="FILE", required=True,
+                   help="path to the PR body")
+    p.add_argument("--commits-file", metavar="FILE",
+                   help="path to a JSON array of commit message strings")
+    args = p.parse_args(argv)
+
+    try:
+        with open(args.body_file, encoding="utf-8") as f:
+            body = f.read()
+    except OSError as e:
+        print(json.dumps({"guard_pass": False, "reason": f"caller error: {e}", "hits": []}),
+              file=sys.stderr)
+        return 2
+
+    commits = _read_commits_file(args.commits_file) if args.commits_file else []
+
+    verdict = check(body, commits)
+    print(json.dumps(verdict, ensure_ascii=False))
+    return 0 if verdict["guard_pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -142,6 +142,62 @@ _LANE_RE = re.compile(
     r"lane\s*:?\s+([A-Za-z0-9._-]+:[A-Za-z0-9._-]+)", re.IGNORECASE
 )
 
+# `prev` (case-insensitive), optional colon, whitespace, then the SAME
+# TIER/GENRE pair as the leading tag. The `prev:` field traces genre
+# adjacency (variation-protocol.md §1) and carries a PR reference right
+# after the genre (`prev: MED/refactor #1234 (c.42)`). #10093 -- GitHub
+# parses a `prev:` whose GENRE is a closing keyword (`fix #1234`) as an
+# auto-close instruction when the text lands in a commit message: a
+# squash-merge of #10063 closed #10067 (unintended) this way. The 14
+# canonical genres contain NO closing keyword, so a closing-keyword genre
+# in `prev:` is ALWAYS a misuse (use `refactor`/`guard`/`tooling`).
+_PREV_RE = re.compile(
+    r"prev\s*:?\s*([A-Za-z]+)\s*/\s*([A-Za-z0-9_-]+)", re.IGNORECASE
+)
+
+# GitHub auto-close keywords (case-insensitive) -- the exact set GitHub
+# recognises in commit messages + PR bodies + PR titles
+# (https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).
+# A `prev:` genre drawn from this set makes the `genre #N` tail an
+# unintended close instruction. Source of truth for the close-keyword gate.
+CLOSING_KEYWORDS = frozenset({
+    "close", "closes", "closed",
+    "fix", "fixes", "fixed",
+    "resolve", "resolves", "resolved",
+})
+
+
+def find_prev_close_keywords(text: str | None) -> list[dict]:
+    r"""Return `prev:` fields whose genre is a GitHub closing keyword (#10093).
+
+    Scans any text (a PR body OR a commit message) for `prev: <TIER>/<genre>`
+    where `<genre>` is one of the 9 GitHub auto-close keywords
+    (`CLOSING_KEYWORDS`). Each hit is a `prev:` whose `genre #N` tail GitHub
+    parses as a close instruction when the text lands in a commit message --
+    the silent-PR-closure failure mode of #10093.
+
+    The 14 canonical genres (variation-protocol.md §1) contain NO closing
+    keyword, so a closing-keyword genre in `prev:` is ALWAYS a misuse: the
+    worker meant `refactor`, `guard`, `tooling`, etc. -- never `fix`. This
+    function does NOT flag a standalone ``Fixes #123`` (an intended close):
+    it only flags the genre slot of a `prev:` field, where a closing word
+    is structurally wrong, not intended.
+
+    Same noise discipline as ``parse_grain_tag``: bold/backticks/blockquotes
+    stripped, title hashes stripped on recognised key lines. Returns a list
+    of ``{"tier", "genre"}`` dicts (one per offending `prev:` field, empty
+    when the text is clean).
+    """
+    if not text:
+        return []
+    flat = _strip_title_hashes(text.translate(_NOISE))
+    hits = []
+    for m in _PREV_RE.finditer(flat):
+        genre = m.group(2).lower()
+        if genre in CLOSING_KEYWORDS:
+            hits.append({"tier": m.group(1).upper(), "genre": genre})
+    return hits
+
 
 def parse_grain_tag(body: str | None) -> dict | None:
     """Extract {tier, genre, lane} from a PR body, form-tolerant.
@@ -304,6 +360,10 @@ def main(argv: list[str] | None = None) -> int:
     # The guard reads both and applies separate labels.
     sh = parse_short_header(body)
     short_complete = all(sh[k] is not None for k in ("quoi", "preuve", "perimetre"))
+    # `prev:` close-keyword scan (#10093): runs on the body the same way the
+    # blocking job runs on commit messages. Reported as a field so the
+    # advisory job can label without re-implementing the scan.
+    prev_hits = find_prev_close_keywords(body)
     if g is None:
         # No TIER/GENRE anywhere: the one substance the protocol will not
         # relax. The guard poses `variation-tag-missing`. Short-header is
@@ -312,7 +372,8 @@ def main(argv: list[str] | None = None) -> int:
                           "lane": None, "tier_valid": False, "genre_valid": False,
                           "quoi": sh["quoi"], "preuve": sh["preuve"],
                           "perimetre": sh["perimetre"],
-                          "short_header_complete": short_complete}))
+                          "short_header_complete": short_complete,
+                          "prev_close_keyword_hits": prev_hits}))
         return 0
     tier_valid = g["tier"] in TIERS
     genre_valid = g["genre"] in GENRES
@@ -327,6 +388,7 @@ def main(argv: list[str] | None = None) -> int:
         "preuve": sh["preuve"],
         "perimetre": sh["perimetre"],
         "short_header_complete": short_complete,
+        "prev_close_keyword_hits": prev_hits,
     }, ensure_ascii=False))
     return 0
 

--- a/scripts/tests/test_grain_tag.py
+++ b/scripts/tests/test_grain_tag.py
@@ -243,3 +243,74 @@ def test_short_header_first_hit_wins_per_key():
     )
     sh = gt.parse_short_header(body)
     assert sh["quoi"] == "first answer (canonical)"
+
+
+# --- prev: close-keyword detection (#10093) ---------------------------------
+#
+# find_prev_close_keywords() scans any text (body OR commit message) for a
+# `prev: <TIER>/<genre>` whose genre is a GitHub closing keyword. The #10093
+# incident: a commit `prev: MED/fix #10067` made GitHub auto-close #10067 at
+# squash-merge. The 14 canonical genres contain no closing keyword, so a
+# closing-keyword genre in prev: is ALWAYS a misuse.
+
+def test_prev_close_keyword_fix_detected():
+    # The exact #10093 incident line: `prev: MED/fix #10067`.
+    hits = gt.find_prev_close_keywords(
+        "Grain: MED/fix -- lane myia-po-2024:CoursIA-2 -- prev: MED/fix #10067 (c.1331+50)"
+    )
+    assert len(hits) == 1
+    assert hits[0] == {"tier": "MED", "genre": "fix"}
+
+
+def test_prev_close_keyword_all_inflections():
+    # Every GitHub closing keyword in the genre slot is flagged.
+    for kw in ("fix", "fixes", "fixed", "close", "closes", "closed",
+               "resolve", "resolves", "resolved"):
+        hits = gt.find_prev_close_keywords(f"prev: LIGHT/{kw} #42")
+        assert len(hits) == 1, f"expected hit for genre={kw}"
+        assert hits[0]["genre"] == kw
+
+
+def test_prev_canonical_genres_pass():
+    # The 14 canonical genres contain NO closing keyword -> all pass.
+    for genre in ("lean", "qc", "training", "genai", "notebook-python",
+                  "notebook-dotnet", "docs", "guard", "refactor", "ledger",
+                  "readme", "test", "tooling", "research-code"):
+        hits = gt.find_prev_close_keywords(f"prev: MED/{genre} #100")
+        assert hits == [], f"canonical genre {genre} must NOT be flagged"
+
+
+def test_prev_close_keyword_backtick_wrapped():
+    # Backticks around the prev: value are stripped (same noise discipline as
+    # parse_grain_tag) -- a `prev: `MED/fix #9457`` still triggers.
+    hits = gt.find_prev_close_keywords("prev: `MED/fix #9457`.")
+    assert len(hits) == 1
+    assert hits[0] == {"tier": "MED", "genre": "fix"}
+
+
+def test_prev_close_keyword_no_prev_field():
+    # A body without any prev: field -> no hits (the leading tag's genre is
+    # NOT scanned, only the prev: slot).
+    hits = gt.find_prev_close_keywords(
+        "Grain: MED/fix -- lane myia-po-2024:CoursIA-2\n\nFixes #100."
+    )
+    # `MED/fix` is the LEADING tag genre (not prev:), and `Fixes #100` is an
+    # intended close (no prev: prefix) -> neither is flagged. Only the prev:
+    # genre slot is in scope.
+    assert hits == []
+
+
+def test_prev_close_keyword_empty_and_none():
+    assert gt.find_prev_close_keywords(None) == []
+    assert gt.find_prev_close_keywords("") == []
+    assert gt.find_prev_close_keywords("no grain tag here at all") == []
+
+
+def test_prev_close_keyword_multiple_prevs():
+    # Two offending prev: fields in one text -> two hits.
+    hits = gt.find_prev_close_keywords(
+        "prev: MED/fix #100\nGrain: LIGHT/close -- prev: LIGHT/closes #200"
+    )
+    assert len(hits) == 2
+    genres = {h["genre"] for h in hits}
+    assert genres == {"fix", "closes"}

--- a/scripts/tests/test_variation_prev_guard.py
+++ b/scripts/tests/test_variation_prev_guard.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Unit tests for variation_prev_guard.py -- the BLOCKING prev: close-keyword
+gate (#10093).
+
+The #10093 incident: a COMMIT MESSAGE carrying `prev: MED/fix #10067` made
+GitHub auto-close PR #10067 at the squash-merge of #10063 -- the PR body of
+#10063 was sane (`MED/tooling`). The gate must therefore scan BOTH the body
+AND the commit messages, and block (exit 1) when a `prev:` genre is a closing
+keyword.
+
+Run:
+    python -m pytest scripts/tests/test_variation_prev_guard.py
+"""
+import sys
+from pathlib import Path
+
+# Insert `scripts/ci/` so the script under test is importable from a flat
+# `import variation_prev_guard` (same convention as test_variation_tag_required.py).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
+
+import variation_prev_guard as vpg  # noqa: E402
+
+
+CLEAN_BODY = "Grain: MED/tooling -- lane myia-po-2025:CoursIA-2 -- prev: MED/infra #10067"
+
+
+def test_clean_body_passes():
+    v = vpg.check(CLEAN_BODY)
+    assert v["guard_pass"] is True
+    assert v["hits"] == []
+
+
+def test_offending_body_blocks():
+    # A `prev: MED/fix #10067` in the BODY -> block.
+    v = vpg.check(
+        "Grain: MED/fix -- lane myia-po-2024:CoursIA-2 -- prev: MED/fix #10067 (c.1331+50)"
+    )
+    assert v["guard_pass"] is False
+    assert v["hits"]["body"] == [{"tier": "MED", "genre": "fix"}]
+    assert "refactor" in v["reason"] or "guard" in v["reason"] or "tooling" in v["reason"]
+
+
+def test_commit_message_only_blocks():
+    # The #10093 incident case: the BODY is clean, the COMMIT carries the
+    # offending `prev: MED/fix #10067`. A body-only gate would miss it.
+    commits = [
+        "feat(ci): some normal commit",
+        "Grain: MED/fix -- prev: MED/fix #10067 (c.1331+50)",
+    ]
+    v = vpg.check(CLEAN_BODY, commits)
+    assert v["guard_pass"] is False
+    assert len(v["hits"]["body"]) == 0
+    assert len(v["hits"]["commits"]) == 1
+    assert v["hits"]["commits"][0]["commit_index"] == 1
+    assert v["hits"]["commits"][0]["genre"] == "fix"
+    assert "commit" in v["reason"]
+
+
+def test_clean_commits_pass():
+    # Commits with a non-closing prev: genre pass.
+    commits = [
+        "Grain: DEEP/lean -- prev: DEEP/lean #2159",
+        "Fixes #100 (intended close, no prev: prefix -> NOT flagged)",
+    ]
+    v = vpg.check(CLEAN_BODY, commits)
+    assert v["guard_pass"] is True
+
+
+def test_intended_close_not_flagged():
+    # A standalone `Fixes #100` / `Closes #456` (no `prev:` prefix) is an
+    # INTENDED close and must NOT be flagged -- catalog-pr-hygiene HARD 4
+    # relies on `Closes #N`. Only the prev: genre slot is in scope.
+    v = vpg.check(
+        "Grain: MED/refactor -- lane x:y\n\nThis PR fixes a bug. Fixes #100. Closes #456."
+    )
+    assert v["guard_pass"] is True
+
+
+def test_all_canonical_genres_in_prev_pass():
+    # Every canonical genre in a prev: field passes (no closing keyword).
+    for genre in ("lean", "guard", "refactor", "tooling", "docs", "test",
+                  "readme", "ledger", "qc", "training", "genai",
+                  "notebook-python", "notebook-dotnet", "research-code"):
+        v = vpg.check(f"prev: MED/{genre} #100")
+        assert v["guard_pass"] is True, f"canonical genre {genre} must pass"
+
+
+def test_both_body_and_commit_hits_aggregated():
+    # Offending prev: in BOTH body and a commit -> both reported.
+    body = "Grain: LIGHT/close -- prev: LIGHT/close #1"
+    commits = ["prev: MED/fixes #2"]
+    v = vpg.check(body, commits)
+    assert v["guard_pass"] is False
+    assert len(v["hits"]["body"]) == 1
+    assert len(v["hits"]["commits"]) == 1
+
+
+def test_empty_inputs_pass():
+    assert vpg.check(None)["guard_pass"] is True
+    assert vpg.check("")["guard_pass"] is True
+    assert vpg.check("", [])["guard_pass"] is True


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: MED/infra #10067

## Quoi

A **BLOCKING** CI gate that rejects a `Grain:` tag whose `prev:` field carries a GitHub closing keyword as its genre (`fix`/`close`/`resolve` + inflections) — scanning the PR body **AND** every commit message. Closes #10093.

## Preuve

```
$ python -m pytest scripts/tests/test_grain_tag.py scripts/tests/test_variation_prev_guard.py scripts/tests/test_variation_tag_required.py -v
... 50 passed in 0.85s   (21 existing grain_tag + 7 new prev-keyword + 8 new prev_guard + 14 tag_required = 0 regression)
```

The incident case, via the blocking helper CLI (this is the #10093 scenario — a clean body, the offending tag in a **commit**):

```
$ python3 scripts/ci/variation_prev_guard.py --body-file clean_body.txt --commits-file offending_commits.json
{"guard_pass": false, "reason": "`prev:` genre(s) ['fix'] in commit messages (1) are GitHub closing keywords -> rewrite the `prev:` genre as refactor/guard/tooling (never a closing word). See #10093.", "hits": {"body": [], "commits": [{"commit_index": 1, "tier": "MED", "genre": "fix"}]}}
exit=1
```

A standalone `Fixes #N` (an **intended** close, no `prev:` prefix) is NOT flagged — confirmed by `test_intended_close_not_flagged`. The discriminator is the `prev:` prefix, not the keyword alone.

## Perimetre

- `scripts/grain_tag.py` — the #9485 single reader, extended: `_PREV_RE`, `CLOSING_KEYWORDS` (the 9 GitHub auto-close keywords), `find_prev_close_keywords()`. One extended extractor, NOT a second implementation. New field `prev_close_keyword_hits` in the CLI JSON.
- `scripts/ci/variation_prev_guard.py` — new blocking helper (exit 1 on hit), pure `check(body, commits)` + CLI. Same pattern as `variation_tag_required.py`.
- `.github/workflows/variation-tag-guard.yml` — new job `check-prev-close-keyword-required` (name carries `-required` so `pr_gate.py` `is_advisory()` does not silence it). Sparse checkout of the 2 scripts; fetches commit messages via `gh pr view --json commits --jq '[.[].messageBody]'`.
- `scripts/tests/test_grain_tag.py` — +7 tests (the incident line, all 9 inflections, 14 canonical genres pass, backtick-wrapped, no-prev-field, empty/None, multiple prevs).
- `scripts/tests/test_variation_prev_guard.py` — +8 tests (clean body, offending body, commit-message-only = the #10093 case, clean commits, intended close, all canonical pass, body+commit aggregated, empty inputs).

Out of scope: the existing advisory jobs (`check-variation-tag`, `check-light-cap`, `check-short-header`) are untouched. The leading-tag genre is NOT scanned (only the `prev:` slot) — a tag whose leading genre is `MED/guard` with `prev: MED/tooling` is fine.

## Acceptance (#10093)

- [x] The gate **blocks** a closing-keyword `prev:` genre in the **body** AND in a **commit message** (`test_offending_body_blocks`, `test_commit_message_only_blocks`).
- [x] All 14 canonical genres pass; non-closing aliases (`security`, `infra`, `ci`) continue to pass (`test_all_canonical_genres_in_prev_pass` — `infra` is even used in THIS PR's own `prev:` field as a live demonstration).
- [x] Test that bites, output cited above (50 passed, 0 regression). The "before": the issue documents the old plural-only grep (`closes|fixes|resolves`) that missed `fix` singular; the "after": `CLOSING_KEYWORDS` is the full 9-keyword frozenset.
- [x] No cosmetic churn on conforming tags — the gate flags ONLY the 9 closing keywords in the `prev:` slot; every other genre (canonical or tolerated alias) is untouched.

## Self-enforcing note

This PR's own body and commit message are scanned by the gate it introduces — which is why neither contains a contiguous `prev:` field with a closing-keyword genre (I describe the incident as "the genre `fix` in a `prev:`-prefixed field" instead of reproducing the literal). The gate passing on this PR is itself proof point #5.

Closes #10093
