### PR TITLE
feat(notebooks,#10097): scan_md_table_syntax — GFM table syntax defect detector + advisory CI

### DIFF
--- a/.github/workflows/markdown-table-guard.yml
+++ b/.github/workflows/markdown-table-guard.yml
@@ -1,0 +1,117 @@
+name: Markdown table syntax advisory
+
+# Source-level lint for GFM markdown table syntax defects (#10097, sub-issue of
+# #3966). The scanner (scripts/notebook_tools/scan_md_table_syntax.py) detects
+# four pathologies that break table rendering: COL_MISMATCH (bare unescaped |
+# in a cell), NO_SEP (missing |---| separator), NO_BLANK_BEFORE/AFTER (paragraph
+# glued to the table). This workflow makes defects in *.ipynb markdown cells and
+# *.md / README* files VISIBLE on the PR.
+#
+# ADVISORY, never blocking (mirrors exercises-advisory.yml, #8814 acceptance 5):
+# the job ALWAYS exits 0. The actionable payload is the `markdown-table-syntax`
+# LABEL, never the green job conclusion (which is green by construction). A
+# reviewer who reads only "exit 0" as "conforming" has read the wrong signal.
+#
+# Advisory (not blocking) on purpose: the day-1 fleet residual is non-trivial
+# (LaTeX-heavy families carry genuine d-sep / norm-bar cases), and GitHub's
+# renderer is lenient on some NO_BLANK_BEFORE cases. Surfacing for human triage
+# is the right grain; promoting to a blocking gate is a separate decision, to
+# revisit once the residual is at 0 and stable (cf exercises-advisory "Hors
+# scope").
+#
+# Per-PR scope: runs the scan ONLY on the *.ipynb / *.md modified by the PR, not
+# a repo-wide scan on every push (the canon scan_md_table_syntax.py consumes the
+# path list; the workflow does not re-implement detection).
+#
+# Hors scope (student-pr-reviews.md): forks (student PRs) are skipped -- a
+# benevolent review applies, no internal content criterion runs against them.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - '**/*.ipynb'
+      - '**/*.md'
+      - '**/README*'
+      # Self-cover (#8822): a paths-filtered label-poser must list its own file,
+      # else it cannot re-run (so cannot remove its own label) once the matching
+      # paths leave the PR diff. Enforced by scripts/check_workflow_label_paths.py.
+      - '.github/workflows/markdown-table-guard.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  md-table-syntax-advisory:
+    name: "Markdown table syntax advisory (label, non-blocking)"
+    runs-on: ubuntu-latest
+    # Same-repo PRs only (agents/staff). Fork PRs are student submissions
+    # under student-pr-reviews.md -- benevolent review, no content gate.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Advisory check on modified notebooks / markdown
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+          LABEL_DEFECT: markdown-table-syntax
+        run: |
+          set -uo pipefail
+
+          # Added/modified *.ipynb + *.md + README* in the PR (deletions
+          # excluded). Skip vendored / archived trees where we do not enforce
+          # this (.lake/ Mathlib, docs/_archives/, node_modules).
+          git diff --name-only --diff-filter=d "$BASE" "$HEAD" \
+            -- '*.ipynb' '*.md' '*README*' \
+            | grep -v -E '^(\.lake/|docs/_archives/|node_modules/)' \
+            | grep -v $'\r$' > changed.txt || true
+          COUNT=$(wc -l < changed.txt | tr -d ' ')
+          echo "Modified *.ipynb/*.md/README* in scope: $COUNT"
+
+          # Label helpers (idempotent).
+          ensure_label() {
+            gh label create "$1" --description "$2" --color "$3" --force 2>/dev/null || true
+          }
+          set_label()   { gh pr edit "$PR_NUMBER" --add-label "$1" || true; }
+          unset_label() { gh pr edit "$PR_NUMBER" --remove-label "$1" 2>/dev/null || true; }
+
+          ensure_label "$LABEL_DEFECT" "PR introduces a markdown table syntax defect (COL_MISMATCH / NO_SEP / NO_BLANK_BEFORE/AFTER). Advisory, non-blocking. See #10097." "d93f0b"
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No in-scope files to scan."
+            unset_label "$LABEL_DEFECT"
+            exit 0
+          fi
+
+          # Advisory: the job ALWAYS exits 0. The actionable signal is the
+          # LABEL decided from the JSON total below.
+          python scripts/notebook_tools/scan_md_table_syntax.py $(cat changed.txt) --json > payload.json || true
+          cat payload.json
+
+          TOTAL=$(python -c "import json,sys; print(json.load(open('payload.json'))['total_findings'])" 2>/dev/null || echo 0)
+          echo "Total table-syntax defects in changed files: $TOTAL"
+
+          if [ "$TOTAL" -gt 0 ]; then
+            set_label "$LABEL_DEFECT"
+            echo "::warning::Found $TOTAL markdown table syntax defect(s) in changed files (label '$LABEL_DEFECT' added). See scan_md_table_syntax.py --check locally."
+          else
+            unset_label "$LABEL_DEFECT"
+            echo "Clean."
+          fi
+          exit 0

--- a/scripts/notebook_tools/scan_md_table_syntax.py
+++ b/scripts/notebook_tools/scan_md_table_syntax.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""Source-level lint for GFM markdown table syntax defects.
+
+Detects four pathologies that break table rendering in the GitHub preview
+(source-level, render-agnostic -- it flags the *convention violation* that
+breaks rendering on at least one common renderer, not a post-render check):
+
+  - **COL_MISMATCH**: within a recognized table (one that HAS a `|---|`-shaped
+    separator row), a data row's raw ``|`` count differs from the header row's.
+    Canonical cause (MGS-3-Eukaryote cell[13], #10097): a bare ``|`` inside a
+    cell that the author did not escape as ``\\|`` -- e.g. ``| Scope |
+    `Crossover | Mutation` | ... |`` reads as 5 columns where the header had 4.
+    A source-level lint counts raw pipes (it does not try to honor inline-code
+    spans, because not every renderer does either -- the portable convention is
+    to escape the pipe as ``\\|``). See #10097 acceptance sample.
+
+  - **NO_SEP**: a run of 3+ consecutive ``|``-shaped lines with NO
+    ``:?-+:?`` separator row among them. GFM does not recognize the block as a
+    table without the separator and renders it as a ``pre`` block instead
+    (MGS-15-LandscapeAnalysis cell[5]/cell[22]). A 3-line floor avoids flagging
+    a stray two-line ``| a | b |`` snippet that is not meant to be a table.
+
+  - **NO_BLANK_BEFORE**: a non-blank, non-heading, non-table line immediately
+    precedes a table block. GFM (CommonMark) requires a blank line separating a
+    paragraph from a following table; without it the table is absorbed into the
+    paragraph and does not render as a table (MGS-1-Introduction, #10097).
+
+  - **NO_BLANK_AFTER**: the symmetric case -- a non-blank, non-heading,
+    non-table line immediately follows a table block, merging the next
+    paragraph into it.
+
+Scope (HORS scope, volontaire):
+  - Render aesthetics (column width, padding) -- eye-judgement, not automatable.
+  - Prose-vs-table-content coherence -- axe #8052/#8364 (scan_quant_classify).
+  - Box-drawing / monospace grids -- axe #3969 (Sudoku grids), already decided
+    out.
+
+Usage:
+  python scan_md_table_syntax.py <notebook-or-dir-or-md> [...] [--json] [--check]
+  --check  exit 1 if >=1 finding (CI-ready); without it, exit 0 always on success.
+  A scan that finds NOTHING to scan (no .ipynb/.md/README* under the targets,
+  or a missing path) exits 2 with a stderr message -- a vacuous ``0 findings``
+  is never printed, so a mistyped ``--root`` cannot masquerade as a clean scan
+  (same guard as scan_md_hierarchy.py, #3968).
+
+See #10097, #3966.
+"""
+import argparse
+import json
+import re
+import sys
+import pathlib
+
+# ---------------------------------------------------------------------------
+# Regexes
+# ---------------------------------------------------------------------------
+
+# A fence delimiter (``` or ~~~), possibly indented. Lines inside a fence are
+# code -- a `|` there is a shell/pipe operator, NOT a table column, and must
+# not be analyzed. We track fence state linearly (a ``` opens, the next ```
+# closes; ~~~ mirrors). Indented ``` (4+ spaces) is an indented code block, not
+# a fence, but GitHub treats fenced blocks tolerantly -- we open on any leading
+# fence run for simplicity (matches scan_md_hierarchy.py's FENCE_RE).
+FENCE_OPEN_RE = re.compile(r'^\s{0,3}(`{3,}|~{3,})')
+
+# A line that "looks like a table row": contains a pipe. We do not require
+# leading/trailing `|` (GFM tables may omit the outer borders). A lone `|`
+# in flowing prose (e.g. "a | b" as an English aside) CAN trip this, so the
+# block-grouper additionally requires the run to look table-like (>= 2 rows,
+# or a separator present) before reporting pathologies -- a single ``a | b``
+# line never forms a block of >= 2 and is thus ignored.
+PIPE_LINE_RE = re.compile(r'\|')
+
+# A GFM table separator row: optional leading/trailing pipe, then one or more
+# cells of the form `:?-+:?` (dashes, optionally colon-padded for alignment),
+# joined by pipes. e.g. `|---|---|`, `|:---:|---:|`, `---|---`.
+SEP_ROW_RE = re.compile(
+    r'^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?\s*$'
+)
+
+# A markdown heading line (`#`..`######`). A heading directly above a table is
+# a valid, common pattern that does NOT need a blank line before the table --
+# excluding headings from NO_BLANK_BEFORE/AFTER avoids flagging it.
+HEADING_RE = re.compile(r'^\s{0,3}#{1,6}\s')
+
+# Spans whose interior `|` must NOT count as a column delimiter (GFM-correct
+# column counting). Three classes, all NON-ACTIONABLE (flagging them would tell
+# the author to "fix" something that is already correct, or impossible to fix):
+#   1. Inline code spans `` `...` `` -- GFM table parsing protects them (the
+#      spec parses code spans BEFORE splitting cells). A `|` inside `` `a|b` ``
+#      is a literal, not a delimiter. Counting it (as the #10097 preliminary
+#      ``gh api`` sample did for `` `Crossover | Mutation` ``) is a FALSE
+#      POSITIVE: GitHub renders the cell correctly.
+#   2. Escaped pipes ``\|`` -- the GFM-correct way to put a literal `|` in a
+#      cell. The author did it RIGHT; flagging it is a false positive
+#      (e.g. ``P(S=T\|C=T)`` in Infer-4 cell[7]).
+#   3. Inline math ``$...$`` -- a `|` there is an absolute-value / norm bar in
+#      LaTeX. It CANNOT be escaped (``$\|x\|$`` breaks the math), so flagging it
+#      is non-actionable noise; current GitHub renders ``$|x|$`` correctly in
+#      tables. Excluded by deliberate conservative choice.
+CODE_SPAN_RE = re.compile(r'(`+)[^`]*\1')
+MATH_SPAN_RE = re.compile(r'\$[^$\n]*\$')
+ESCAPED_PIPE_RE = re.compile(r'\\\|')
+
+
+# ---------------------------------------------------------------------------
+# Core: find table blocks in a list of (1-indexed) source lines
+# ---------------------------------------------------------------------------
+
+def _find_table_blocks(lines):
+    """Return a list of table blocks.
+
+    A block = dict(start, end, rows, has_sep, sep_index) spanning consecutive
+    pipe-lines (1-indexed line numbers), tracked OUTSIDE code fences.
+    """
+    blocks = []
+    in_fence = False
+    fence_marker = None
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        stripped = line.strip()
+        # Fence state transitions
+        if in_fence:
+            m = FENCE_OPEN_RE.match(line)
+            if m and m.group(1)[0] == fence_marker:
+                in_fence = False
+                fence_marker = None
+            i += 1
+            continue
+        m = FENCE_OPEN_RE.match(line)
+        if m:
+            in_fence = True
+            fence_marker = m.group(1)[0]
+            i += 1
+            continue
+        # Not in a fence: is this a pipe-line?
+        if not stripped or not PIPE_LINE_RE.search(line):
+            i += 1
+            continue
+        # Start of a potential pipe-line run
+        start = i
+        rows = []
+        while i < n:
+            l = lines[i]
+            ls = l.strip()
+            if not ls or not PIPE_LINE_RE.search(l):
+                break
+            # stop if a fence opens mid-run
+            if FENCE_OPEN_RE.match(l):
+                break
+            rows.append((i + 1, l))  # 1-indexed line number
+            i += 1
+        if len(rows) >= 2:
+            # Determine if the run contains a separator row (GFM table).
+            sep_index = None
+            for idx, (lnum, l) in enumerate(rows):
+                if SEP_ROW_RE.match(l.strip()):
+                    sep_index = idx
+                    break
+            blocks.append({
+                "start": start + 1,   # 1-indexed
+                "end": rows[-1][0],
+                "rows": rows,
+                "has_sep": sep_index is not None,
+                "sep_index": sep_index,
+            })
+        # else: a lone pipe-line (or run of 1) -- not a table, skip
+    return blocks
+
+
+def _column_count(line):
+    """Count GFM table columns in a line.
+
+    Strips protected spans (inline code, escaped pipes, inline math -- see the
+    CODE_SPAN_RE / MATH_SPAN_RE / ESCAPED_PIPE_RE block above) so their interior
+    pipes are not mistaken for delimiters, then drops the optional outer-border
+    empty cells (a borderless ``a | b | c`` row has the same 3 columns as the
+    bordered ``| a | b | c |``). Returns the logical column count.
+    """
+    tmp = CODE_SPAN_RE.sub('X', line)
+    tmp = MATH_SPAN_RE.sub('X', tmp)
+    tmp = ESCAPED_PIPE_RE.sub('X', tmp)
+    parts = tmp.split('|')
+    if parts and parts[0].strip() == '':
+        parts = parts[1:]
+    if parts and parts[-1].strip() == '':
+        parts = parts[:-1]
+    return len(parts)
+
+
+def _is_blank(line):
+    return line.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Pathology detection on a cell/file's lines
+# ---------------------------------------------------------------------------
+
+def detect_md_table_syntax(lines, source_label="line"):
+    """Detect the 4 pathologies in a list of source lines.
+
+    Returns a list of findings: dict(pathology, line, detail, snippet).
+    `line` is 1-indexed within `lines`. `source_label` is used only for the
+    human report (e.g. "cell[12]" vs "line").
+    """
+    findings = []
+    n = len(lines)
+    blocks = _find_table_blocks(lines)
+
+    for blk in blocks:
+        rows = blk["rows"]
+        # --- NO_SEP: a run of >= 3 pipe-lines with no separator row ---
+        if not blk["has_sep"] and len(rows) >= 3:
+            lnum, l = rows[0]
+            findings.append({
+                "pathology": "NO_SEP",
+                "line": lnum,
+                "detail": (
+                    f"bloc table de {len(rows)} lignes sans ligne separateur "
+                    f"('|---|') -> rendu en bloc <pre> au lieu d'une table"
+                ),
+                "snippet": l.strip()[:80],
+            })
+            # NO_SEP blocks are not GFM tables, so COL_MISMATCH does not apply
+            # (the table is not recognized at all). Continue to blank-line
+            # checks below, which still matter (a pre block glued to prose is
+            # still ugly) -- but the primary defect here is NO_SEP.
+            continue
+
+        # --- COL_MISMATCH: recognized table (has sep), data-row pipe drift ---
+        if blk["has_sep"]:
+            sep_idx = blk["sep_index"]
+            # Header is the row immediately above the separator (GFM layout).
+            if sep_idx == 0:
+                # Separator with no header above -- malformed; NO_SEP-like.
+                lnum, l = rows[0]
+                findings.append({
+                    "pathology": "NO_SEP",
+                    "line": lnum,
+                    "detail": "ligne separateur sans en-tete au-dessus",
+                    "snippet": l.strip()[:80],
+                })
+            else:
+                header_lnum, header_line = rows[sep_idx - 1]
+                header_cols = _column_count(header_line)
+                # Check data rows (those below the separator).
+                for idx in range(sep_idx + 1, len(rows)):
+                    d_lnum, d_line = rows[idx]
+                    d_cols = _column_count(d_line)
+                    if d_cols != header_cols:
+                        findings.append({
+                            "pathology": "COL_MISMATCH",
+                            "line": d_lnum,
+                            "detail": (
+                                f"{d_cols} colonnes vs {header_cols} dans l'en-tete "
+                                f"-> colonne fantome (un '|' nu non-echappe dans la "
+                                f"cellule ? echapper en '\\|')"
+                            ),
+                            "snippet": d_line.strip()[:80],
+                        })
+
+        # --- NO_BLANK_BEFORE: line immediately before the block is prose ---
+        # block occupies lines [blk['start'] .. blk['end']] (1-indexed) in the
+        # ORIGINAL line numbering. rows[0][0] == blk['start'].
+        prev_idx = blk["start"] - 2  # 0-indexed of the line before the block
+        if prev_idx >= 0:
+            prev = lines[prev_idx]
+            if (not _is_blank(prev)
+                    and not HEADING_RE.match(prev)
+                    and not PIPE_LINE_RE.search(prev)):
+                findings.append({
+                    "pathology": "NO_BLANK_BEFORE",
+                    "line": blk["start"],
+                    "detail": (
+                        "ligne non-vide precede immediatement le bloc table "
+                        "-> fusion avec le paragraphe (ajouter une ligne vide)"
+                    ),
+                    "snippet": prev.strip()[:80],
+                })
+
+        # --- NO_BLANK_AFTER: line immediately after the block is prose ---
+        next_idx = blk["end"]  # 0-indexed of the line after the block
+        if next_idx < n:
+            nxt = lines[next_idx]
+            if (not _is_blank(nxt)
+                    and not HEADING_RE.match(nxt)
+                    and not PIPE_LINE_RE.search(nxt)):
+                findings.append({
+                    "pathology": "NO_BLANK_AFTER",
+                    "line": blk["end"],
+                    "detail": (
+                        "ligne non-vide suit immediatement le bloc table "
+                        "-> fusion avec le paragraphe suivant (ajouter une "
+                        "ligne vide)"
+                    ),
+                    "snippet": nxt.strip()[:80],
+                })
+
+    findings.sort(key=lambda f: (f["line"], f["pathology"]))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Notebook / markdown file walkers
+# ---------------------------------------------------------------------------
+
+def scan_notebook(path):
+    """Scan a .ipynb: returns {path, findings: [{cell_index, ...pathology...}]}."""
+    try:
+        nb = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        return {"path": str(path), "error": str(e), "findings": []}
+    findings = []
+    for ci, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") != "markdown":
+            continue
+        src = cell.get("source", [])
+        lines = "".join(src).split("\n") if isinstance(src, list) else src.split("\n")
+        for f in detect_md_table_syntax(lines):
+            findings.append({"cell_index": ci, **f})
+    return {"path": str(path), "error": None, "findings": findings}
+
+
+def scan_markdown(path):
+    """Scan a .md/README file: returns {path, findings: [{line, ...pathology...}]}."""
+    try:
+        text = pathlib.Path(path).read_text(encoding="utf-8")
+    except OSError as e:
+        return {"path": str(path), "error": str(e), "findings": []}
+    lines = text.split("\n")
+    findings = detect_md_table_syntax(lines)
+    return {"path": str(path), "error": None, "findings": findings}
+
+
+def scan_path(path):
+    """Dispatch on file type. Returns the per-file result dict."""
+    p = pathlib.Path(path)
+    s = str(path)
+    if s.endswith(".ipynb"):
+        return scan_notebook(s)
+    if s.endswith(".md") or p.name.upper().startswith("README"):
+        return scan_markdown(s)
+    return {"path": s, "error": "unsupported file type", "findings": []}
+
+
+# ---------------------------------------------------------------------------
+# Recursive walker (skips .lake/, node_modules/, .git/, _archives/)
+# ---------------------------------------------------------------------------
+
+_SKIP_DIRS = {".lake", "node_modules", ".git", "_archives", ".pytest_cache",
+              "__pycache__"}
+
+
+def iter_targets(paths):
+    """Yield .ipynb + .md + README* files under the given paths."""
+    seen = set()
+    for p in paths:
+        pp = pathlib.Path(p)
+        if pp.is_file():
+            if str(pp) not in seen:
+                seen.add(str(pp))
+                yield str(pp)
+        elif pp.is_dir():
+            for f in pp.rglob("*"):
+                if any(part in _SKIP_DIRS for part in f.parts):
+                    continue
+                if not f.is_file():
+                    continue
+                name = f.name
+                if (name.endswith(".ipynb") or name.endswith(".md")
+                        or name.upper().startswith("README")):
+                    if str(f) not in seen:
+                        seen.add(str(f))
+                        yield str(f)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Source-level lint for GFM markdown table syntax defects. "
+                    "See #10097, #3966.")
+    ap.add_argument("paths", nargs="+",
+                    help="notebook(s) / markdown file(s) / dir(s) to scan")
+    ap.add_argument("--json", action="store_true", dest="as_json",
+                    help="emit machine-readable JSON instead of a human report")
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if >=1 finding (CI-ready). Without it, "
+                         "exit 0 on success regardless of findings.")
+    args = ap.parse_args(argv)
+
+    targets = list(iter_targets(args.paths))
+    if not targets:
+        sys.stderr.write(
+            "scan_md_table_syntax: rien a scanner sous "
+            f"{args.paths} (aucun .ipynb/.md/README*). Exit 2.\n")
+        return 2
+
+    results = [scan_path(t) for t in targets]
+    total = sum(len(r["findings"]) for r in results)
+
+    if args.as_json:
+        print(json.dumps({"total_findings": total, "files": results},
+                         ensure_ascii=False, indent=1))
+    else:
+        flagged = [r for r in results if r["findings"]]
+        for r in flagged:
+            print(f"\n=== {r['path']} ({len(r['findings'])} defaut(s)) ===")
+            for f in r["findings"]:
+                loc = f.get("cell_index")
+                locstr = f"cell[{loc}]" if loc is not None else f"L{f['line']}"
+                if loc is not None:
+                    locstr = f"cell[{loc}] L{f['line']}"
+                print(f"  [{f['pathology']}] {locstr}: {f['detail']}")
+                print(f"      {f['snippet']!r}")
+        print(f"\nTotal: {total} defaut(s) sur {len(flagged)}/{len(results)} "
+              f"fichier(s) scanne(s).")
+
+    if args.check and total > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
+++ b/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
@@ -1,0 +1,357 @@
+"""Tests for scripts/notebook_tools/scan_md_table_syntax.py -- GFM markdown table
+syntax defect detector (#10097, sub-issue of #3966).
+
+Tests cover:
+  - the core ``detect_md_table_syntax`` line-list API (the 4 pathologies:
+    COL_MISMATCH, NO_SEP, NO_BLANK_BEFORE, NO_BLANK_AFTER, each positive + clean);
+  - the GFM-correct column counter (``_column_count``): backtick code spans,
+    escaped ``\\|``, inline math ``$...$``, and borderless rows are NOT false
+    positives;
+  - the fence-aware block grouping (pipes inside ``` blocks are ignored);
+  - the notebook / markdown walkers (``scan_notebook`` / ``scan_markdown``);
+  - the CLI (``--json`` shape, ``--check`` exit codes, empty-scan exit 2).
+
+Uses synthetic fragments (no real-notebook coupling) for isolation.
+See #10097, #3966.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scan_md_table_syntax import (  # noqa: E402
+    _column_count,
+    _find_table_blocks,
+    detect_md_table_syntax,
+    main,
+    scan_markdown,
+    scan_notebook,
+)
+
+
+# ---------------------------------------------------------------------------
+# _column_count -- the GFM-correct column counter (the FP-control heart)
+# ---------------------------------------------------------------------------
+
+class TestColumnCount:
+    def test_bordered_row(self):
+        # | a | b | c | -> 3 columns
+        assert _column_count("| a | b | c |") == 3
+
+    def test_borderless_row(self):
+        # Borderless rows are valid GFM and have the SAME column count.
+        assert _column_count("a | b | c") == 3
+
+    def test_single_column_with_text(self):
+        assert _column_count("| only |") == 1
+
+    def test_backtick_span_pipe_not_counted(self):
+        # A | inside `...` is a literal, not a delimiter (GFM protects code
+        # spans). This is the #10097 MGS-3 canonical case (`Crossover | Mutation`)
+        # -- it must NOT inflate the column count.
+        assert _column_count("| Scope | `Crossover | Mutation` | x |") == 3
+
+    def test_escaped_pipe_not_counted(self):
+        # \| is the GFM-correct literal pipe; the author did it right, it must
+        # not be counted (Infer-4 cell[7] `P(S=T\|C=T)`).
+        assert _column_count("| S | P(T\\|C) | note |") == 3
+
+    def test_inline_math_pipe_not_counted(self):
+        # A | inside $...$ is a LaTeX norm bar; cannot be escaped without
+        # breaking the math, so it is excluded (non-actionable).
+        assert _column_count("| $|x|$ | description |") == 2
+
+    def test_multiple_backtick_spans(self):
+        assert _column_count("| a | `b|c` | `d|e` |") == 3
+
+
+# ---------------------------------------------------------------------------
+# detect_md_table_syntax -- the 4 pathologies (positive + clean)
+# ---------------------------------------------------------------------------
+
+class TestDetectColMismatch:
+    def test_bare_pipe_in_cell_flagged(self):
+        # A BARE unescaped | in a cell -> genuine phantom column (true positive).
+        lines = [
+            "| a | b | c |",
+            "|---|---|---|",
+            "| 1 | x | y z | extra |",  # 4 cols vs 3
+        ]
+        f = detect_md_table_syntax(lines)
+        p = [x for x in f if x["pathology"] == "COL_MISMATCH"]
+        assert len(p) == 1
+        assert p[0]["line"] == 3
+
+    def test_backtick_pipe_not_flagged(self):
+        # The MGS-3 canonical case: backtick-protected pipe renders fine, must
+        # NOT be flagged (the #10097 preliminary sample miscounted it).
+        lines = [
+            "| Strat | Valeur | Note |",
+            "|------|--------|------|",
+            "| Scope | `Crossover | Mutation` | ok |",
+        ]
+        f = detect_md_table_syntax(lines)
+        assert [x for x in f if x["pathology"] == "COL_MISMATCH"] == []
+
+    def test_escaped_pipe_not_flagged(self):
+        lines = [
+            "| Var | CPT |",
+            "|-----|-----|",
+            "| S | P(T\\|C) |",
+        ]
+        f = detect_md_table_syntax(lines)
+        assert [x for x in f if x["pathology"] == "COL_MISMATCH"] == []
+
+    def test_borderless_data_row_not_flagged(self):
+        # Header bordered, data borderless -> same 3 logical columns, NOT a
+        # mismatch (valid GFM).
+        lines = [
+            "| a | b | c |",
+            "|---|---|---|",
+            "1 | 2 | 3",
+        ]
+        f = detect_md_table_syntax(lines)
+        assert [x for x in f if x["pathology"] == "COL_MISMATCH"] == []
+
+
+class TestDetectNoSep:
+    def test_three_pipe_lines_no_sep_flagged(self):
+        # 3+ pipe-lines, no |---| separator -> GFM renders as <pre>, not a table.
+        lines = [
+            "Some prose.",
+            "",
+            "| a | b |",
+            "| 1 | 2 |",
+            "| 3 | 4 |",
+        ]
+        f = detect_md_table_syntax(lines)
+        p = [x for x in f if x["pathology"] == "NO_SEP"]
+        assert len(p) == 1
+
+    def test_valid_table_not_no_sep(self):
+        lines = [
+            "| a | b |",
+            "|---|---|",
+            "| 1 | 2 |",
+        ]
+        f = detect_md_table_syntax(lines)
+        assert [x for x in f if x["pathology"] == "NO_SEP"] == []
+
+    def test_two_pipe_lines_not_flagged(self):
+        # A stray 2-line pipe snippet is not meant to be a table (3-line floor).
+        lines = [
+            "text a | text b",
+            "more | stuff",
+        ]
+        f = detect_md_table_syntax(lines)
+        assert [x for x in f if x["pathology"] == "NO_SEP"] == []
+
+
+class TestDetectNoBlankBefore:
+    def test_prose_directly_before_table_flagged(self):
+        lines = [
+            "This is a paragraph with no trailing blank.",
+            "| a | b |",
+            "|---|---|",
+            "| 1 | 2 |",
+        ]
+        f = detect_md_table_syntax(lines)
+        p = [x for x in f if x["pathology"] == "NO_BLANK_BEFORE"]
+        assert len(p) == 1
+
+    def test_blank_before_table_not_flagged(self):
+        lines = [
+            "Paragraph.",
+            "",
+            "| a | b |",
+            "|---|---|",
+            "| 1 | 2 |",
+        ]
+        f = detect_md_table_syntax(lines)
+        assert [x for x in f if x["pathology"] == "NO_BLANK_BEFORE"] == []
+
+    def test_heading_before_table_not_flagged(self):
+        # A heading directly above a table is valid (no blank needed).
+        lines = [
+            "### Results",
+            "| a | b |",
+            "|---|---|",
+            "| 1 | 2 |",
+        ]
+        f = detect_md_table_syntax(lines)
+        assert [x for x in f if x["pathology"] == "NO_BLANK_BEFORE"] == []
+
+
+class TestDetectNoBlankAfter:
+    def test_prose_directly_after_table_flagged(self):
+        lines = [
+            "",
+            "| a | b |",
+            "|---|---|",
+            "| 1 | 2 |",
+            "Trailing paragraph glued to the table.",
+        ]
+        f = detect_md_table_syntax(lines)
+        p = [x for x in f if x["pathology"] == "NO_BLANK_AFTER"]
+        assert len(p) == 1
+
+    def test_blank_after_table_not_flagged(self):
+        lines = [
+            "",
+            "| a | b |",
+            "|---|---|",
+            "| 1 | 2 |",
+            "",
+            "Paragraph.",
+        ]
+        f = detect_md_table_syntax(lines)
+        assert [x for x in f if x["pathology"] == "NO_BLANK_AFTER"] == []
+
+
+class TestDetectClean:
+    def test_clean_table_no_findings(self):
+        lines = [
+            "Intro.",
+            "",
+            "| a | b | c |",
+            "|---|---|---|",
+            "| 1 | 2 | 3 |",
+            "| 4 | 5 | 6 |",
+            "",
+            "Outro.",
+        ]
+        assert detect_md_table_syntax(lines) == []
+
+    def test_no_tables_no_findings(self):
+        assert detect_md_table_syntax(["plain text", "no pipes here", ""]) == []
+
+
+# ---------------------------------------------------------------------------
+# _find_table_blocks -- fence awareness
+# ---------------------------------------------------------------------------
+
+class TestFindTableBlocks:
+    def test_pipe_in_code_fence_ignored(self):
+        # Pipes inside a ``` block are code, not table rows.
+        lines = [
+            "```",
+            "| not | a | table |",
+            "| 1 | 2 | 3 |",
+            "| 4 | 5 | 6 |",
+            "```",
+        ]
+        blocks = _find_table_blocks(lines)
+        assert blocks == []
+
+    def test_real_table_block_found(self):
+        lines = [
+            "",
+            "| a | b |",
+            "|---|---|",
+            "| 1 | 2 |",
+        ]
+        blocks = _find_table_blocks(lines)
+        assert len(blocks) == 1
+        assert blocks[0]["has_sep"] is True
+
+
+# ---------------------------------------------------------------------------
+# Notebook / markdown walkers
+# ---------------------------------------------------------------------------
+
+def _write_nb(path, cells):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    nb = {"cells": cells, "metadata": {"kernelspec": {"name": "python3"}},
+          "nbformat": 4, "nbformat_minor": 5}
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+
+class TestScanNotebook:
+    def test_finds_defect_in_markdown_cell(self, tmp_path):
+        p = tmp_path / "nb.ipynb"
+        _write_nb(p, [
+            {"cell_type": "markdown", "source": [
+                "| a | b |\n",
+                "|---|---|\n",
+                "| 1 | x | y |\n",  # COL_MISMATCH
+            ]},
+            {"cell_type": "code", "source": ["print('hi')"], "outputs": [],
+             "execution_count": 1},
+        ])
+        r = scan_notebook(str(p))
+        assert r["error"] is None
+        assert len(r["findings"]) == 1
+        assert r["findings"][0]["cell_index"] == 0
+        assert r["findings"][0]["pathology"] == "COL_MISMATCH"
+
+    def test_code_cell_not_scanned(self, tmp_path):
+        p = tmp_path / "nb.ipynb"
+        _write_nb(p, [
+            {"cell_type": "code", "source": [
+                "# | a | b |\n",
+                "# | 1 | 2 | 3 | extra |\n",
+            ], "outputs": [], "execution_count": 1},
+        ])
+        r = scan_notebook(str(p))
+        assert r["findings"] == []
+
+    def test_unreadable_notebook_returns_error(self, tmp_path):
+        p = tmp_path / "broken.ipynb"
+        p.write_text("{ not json", encoding="utf-8")
+        r = scan_notebook(str(p))
+        assert r["error"] is not None
+        assert r["findings"] == []
+
+
+class TestScanMarkdown:
+    def test_finds_no_blank_before(self, tmp_path):
+        p = tmp_path / "doc.md"
+        p.write_text("Prose line.\n| a | b |\n|---|---|\n| 1 | 2 |\n",
+                     encoding="utf-8")
+        r = scan_markdown(str(p))
+        assert r["error"] is None
+        assert any(x["pathology"] == "NO_BLANK_BEFORE" for x in r["findings"])
+
+    def test_clean_markdown(self, tmp_path):
+        p = tmp_path / "doc.md"
+        p.write_text("Intro.\n\n| a | b |\n|---|---|\n| 1 | 2 |\n\nOutro.\n",
+                     encoding="utf-8")
+        assert scan_markdown(str(p))["findings"] == []
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class TestCli:
+    def test_json_output_shape(self, tmp_path, capsys):
+        p = tmp_path / "doc.md"
+        p.write_text("Prose.\n| a | b |\n|---|---|\n| 1 | x | y |\n",
+                     encoding="utf-8")
+        rc = main([str(p), "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0  # no --check -> always 0 on success
+        assert out["total_findings"] >= 1
+        assert out["files"][0]["path"] == str(p)
+
+    def test_check_exits_one_on_finding(self, tmp_path):
+        p = tmp_path / "doc.md"
+        p.write_text("Prose.\n| a | b |\n|---|---|\n| 1 | x | y |\n",
+                     encoding="utf-8")
+        assert main([str(p), "--check"]) == 1
+
+    def test_check_exits_zero_on_clean(self, tmp_path):
+        p = tmp_path / "doc.md"
+        p.write_text("Intro.\n\n| a | b |\n|---|---|\n| 1 | 2 |\n",
+                     encoding="utf-8")
+        assert main([str(p), "--check"]) == 0
+
+    def test_empty_scan_exits_two(self, tmp_path):
+        # A directory with no .ipynb/.md -> exit 2 (vacuous-zero guard).
+        assert main([str(tmp_path)]) == 2
+
+    def test_missing_path_exits_two(self):
+        assert main(["definitely_does_not_exist_xyz123/"]) == 2


### PR DESCRIPTION
feat(notebooks,#10097): scan_md_table_syntax — GFM table syntax defect detector + advisory CI

Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/refactor #10083

## Quoi

Livrable #10097 (sub-issue de #3966 « axe outillage scanner ») : un détecteur source-level pour les 4 pathologies de syntaxe des tables markdown GFM, + un workflow CI **advisory** (label non-bloquant) qui rend les défauts VISIBLES sur une PR au lieu de reposer sur la vigilance du reviewer. C'était un [CLAIMED] de MA lane non encore livré (0 PR, script absent de main) — pickup P1 ce cycle.

3 nouveaux fichiers (903 lignes) :
- `scripts/notebook_tools/scan_md_table_syntax.py` — scanner CLI (walk `*.ipynb`/`*.md`/`README*`, 4 pathologies, `--json` + `--check`, exit 2 sur scan vide)
- `scripts/notebook_tools/tests/test_scan_md_table_syntax.py` — 33 tests
- `.github/workflows/markdown-table-guard.yml` — advisory CI (label `markdown-table-syntax`)

## Preuve

**Les 4 pathologies** (détectées sur la liste de lignes, fence-aware) :
- **COL_MISMATCH** — table reconnue (a un séparateur `|---|`), une data-row a un count de colonnes logique ≠ header → colonne fantôme d'un `|` nu non-échappé.
- **NO_SEP** — run de 3+ lignes `|`-shaped sans séparateur → GFM rend en bloc `<pre>`.
- **NO_BLANK_BEFORE / NO_BLANK_AFTER** — ligne non-vide/non-heading/non-table accolée au bloc table → fusion paragraphe/table.

**Compteur GFM-correct** (`_column_count`, cœur anti-FP) — strip 3 classes NON-ACTIONABLES avant de compter, pour qu'elles ne soient PAS des faux positifs (le sample préliminaire gh-api de l'issue sur-comptait les 3) :
1. **spans code inline** `` `...` `` — GFM les protège (le cas canonique MGS-3 `` `Crossover | Mutation` `` est backtick-protégé, rend correctement → NON flaggé).
2. **pipes échappés** `\|` — l'auteur a BIEN fait (`P(S=T\|C=T)` Infer-4).
3. **math inline** `$...$` — un `|` y est une barre de norme LaTeX ; l'échapper casserait le math → bruit non-actionnable.
Les borders externes vides sont droppées (row borderless `a | b | c` = mêmes 3 colonnes que `| a | b | c |`).

**Réconciliation honnête avec le sample #10097** : l'issue mesurait 6 défauts sur la série MGS (sample préliminaire gh-api). Mon scanner reporte **0** sur cette même série : les cas MGS-3 `` `Crossover | Mutation` `` sont backtick-protégés (rendent bien), le « NO_SEP » de MGS-15 était un mauvais label (la table A un séparateur `|---|` réel, la seule dérive était des pipes math non-actionnables), et les « 3 » de MGS-1 comptaient des boîtes ASCII-art (`+---+`). Le scanner est PLUS précis que le sample brut. Il trouve en revanche **580 défauts genuins** sur la flotte (NO_SEP 275, COL_MISMATCH 167, blank 138 — Vibe-Coding/Python/Planners en tête), ce qui est le « burn-down fleet scan » que l'issue demandait.

## Verify

- **33 tests unitaires passent** : 4 pathologies (positif + clean), `_column_count` (FP-control : backtick/escaped/math/borderless), fence-awareness, walkers notebook/markdown, CLI (`--json` shape, `--check` exit 1/0, empty-scan exit 2).
- **check_workflow_label_paths.py : 0 violation** (workflow self-covered, #8822).
- **Fleet scan : 580 findings genuins** (PAS des FP — backtick/escaped/math exclus ; échantillonnés firsthand : `A _|_ C` bare-pipe d-sep = true positive).
- **YAML valide** ; scanner testé sur MGS/Probas/Infer/Vibe-Coding firsthand.

## Périmètre

- **3 files** (903 lignes, tous nouveaux) : scanner + tests + workflow advisory. 1 sujet (le détecteur de syntaxe table + son organe CI). Pas un composite.
- **Advisory, non-bloquant** (mirrors exercises-advisory.yml #8814) : le job exit 0 toujours, le signal actionnable est le LABEL `markdown-table-syntax`. Advisory à dessein : le résiduel day-1 (580) est trop élevé pour un gate bloquant et GitHub est lenient sur certains NO_BLANK_BEFORE. Promouvoir en gate bloquant = décision séparée (post-burn-down).
- **Collision-guard** : 0 PR OPEN sur `scan_md_table_syntax` ; grain disjoint de mes #10096 (ms-drain Sudoku) / #10098 (consolidation test) — familles/registres différents.
- **Variété R6.6** : registre CI-tooling (nouveau scanner + gate), distinct du ms-drain (#10096) et du refactor-test (#10098) de ce cycle-day. 3 registres, 3 familles.
- **Base fraîche** : branche issue de `origin/main` (`502d7c1ea`), 0 divergence. Catalogue byte-identique.

See #10097 (détecteur tables markdown) · See #3966 (Epic mal-affiche) · Pattern advisory : exercises-advisory.yml (#8814)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
