### PR TITLE
feat(ci,#10101): blocking gate against close-keyword + PR-number (extends #10093)

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -661,3 +661,113 @@ jobs:
           )" 2>/dev/null || true
 
           exit 1
+
+  # #10101 -- the BLOCKING gate against `<closing-keyword> #N` in FREE PROSE
+  # (body + commit messages) where N resolves to a PR. The #10093 gate above
+  # blocks the SAME keyword but ONLY in the `prev:` genre slot (structurally
+  # always wrong). #10101 closes the second, measured vector: PR #10094's own
+  # commit message claimed it had CLOSED a PR (the translation core deliverable)
+  # "without merging it" -- a naive squash would have re-closed that PR because
+  # GitHub parses `<closing-keyword> #N` in a squash message as an auto-close
+  # whenever N is a PR.
+  #
+  # The discriminator is the NUMBER's nature, not the keyword's context:
+  #   - N is an ISSUE -> silence (intended close, catalog-pr-hygiene HARD 4:
+  #     `Closes #N` is what shrinks the backlog on its own)
+  #   - N is a PR      -> BLOCK (one does not "resolve" a PR by keyword)
+  #   - N missing/API error -> fail-open warn (a stale ref or a network blip
+  #     must not block a legitimate merge)
+  # The PR-vs-issue resolution uses `gh api repos/:owner/:repo/issues/N` (a
+  # non-null `.pull_request` field is a PR). The resolver is INJECTABLE in the
+  # helper (`scripts/ci/pr_close_keyword_guard.py`), so the unit tests pass a
+  # table and never touch the network. The YAML is plomberie, same shape as
+  # `check-prev-close-keyword-required` above.
+  #
+  # The job name carries the `-required` suffix so PR #10036's `is_advisory()`
+  # classifier in `scripts/pr_gate.py` does NOT silence it -- same reason as
+  # the tag-required and prev-close-keyword-required jobs.
+  check-close-keyword-pr-ref-required:
+    name: 'Require no close-keyword + PR-number (block on auto-close of a PR, #10101)'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the close-keyword-pr-ref helper (sparse)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/ci/pr_close_keyword_guard.py
+            scripts/grain_tag.py
+      - name: 'Resolve body + commit close-keyword refs (PR -> block, issue -> silence)'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          set -uo pipefail
+
+          # Same bot/fork gating as the other jobs (cf. student-pr-reviews.md).
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issue d'un fork : hors scope (PR etudiante)."
+            exit 0
+          fi
+
+          # Body to a file -- printf '%s' preserves it verbatim.
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          # Commit messages as a JSON array of strings. `messageBody` is the
+          # full commit message (subject + body), which is what GitHub parses
+          # for auto-close keywords. Empty/missing file -> no commits to scan
+          # (the helper tolerates it).
+          gh pr view "$PR_NUMBER" --json commits --jq '[.[].messageBody]' \
+            > /tmp/commits.json 2>/dev/null || printf '[]' > /tmp/commits.json
+
+          # The helper resolves each `<closing-keyword> #N` via `gh api` and
+          # exits 0 (pass / fail-open) or 1 (block on a PR). stderr surfaced
+          # for debug.
+          python3 scripts/ci/pr_close_keyword_guard.py \
+            --body-file /tmp/pr_body.txt \
+            --commits-file /tmp/commits.json > /tmp/verdict.json 2>/tmp/verdict.err
+          RC=$?
+
+          if [ -s /tmp/verdict.err ]; then
+            echo "--- helper stderr ---"
+            cat /tmp/verdict.err
+          fi
+          echo "--- verdict ---"
+          cat /tmp/verdict.json
+
+          # Surface fail-open warnings even on the pass path (stale refs, API
+          # blips) so the author can fix the ref without the gate blocking.
+          python3 -c "import json; [print('::warning::'+w) for w in json.load(open('/tmp/verdict.json')).get('warnings',[])]" 2>/dev/null || true
+
+          if [ "$RC" -eq 0 ]; then
+            echo "No closing-keyword + PR-number reference in body or commits -- job passes."
+            exit 0
+          fi
+
+          # Block path. Idempotent comment via the HTML marker.
+          REASON=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('reason','unknown'))" 2>/dev/null || echo "unknown")
+          echo "::error::closing-keyword + PR-number reference detected: $REASON"
+
+          gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          <!-- vtr-close-keyword-pr-ref -->
+          **\`<mot-clé fermant> #N\` où N est une PR -- bloquant (#10101).**
+
+          ${REASON}
+
+          GitHub interprète \`close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved #N\` comme un ordre de fermeture automatique dès que le texte atterrit dans le message de squash -- et fermer une **PR** par mot-clé n'est jamais intentionnel (une PR se merge ou se ferme explicitement, elle ne se « résout » pas). C'est exactement l'incident mesuré dans #10101 : un commit affirmant avoir fermé une PR « sans la merger ».
+
+          Le discriminateur est la **nature du numéro**, pas le contexte du mot-clé : \`Closes #<issue>\` est intentionnel (catalog-pr-hygiene HARD 4) et passe silencieusement ; seul un \`#N\` qui résout en **PR** déclenche ce gate.
+
+          Pour passer ce gate :
+          - **retirez le mot-clé fermant** devant le numéro, ou
+          - **écrivez le numéro SANS le \`#\`** (un nombre nu n'est pas un auto-close).
+          EOF
+          )" 2>/dev/null || true
+
+          exit 1

--- a/scripts/ci/pr_close_keyword_guard.py
+++ b/scripts/ci/pr_close_keyword_guard.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+r"""pr_close_keyword_guard.py -- BLOCKING gate against ``<closing-keyword> #N``
+that closes a PR (#10101).
+
+## Why this exists
+
+The #10093 gate (``variation_prev_guard.py``) blocks a closing keyword in the
+*genre slot of a ``prev:`` field* -- structurally always wrong. But the same
+auto-close danger lives in **free prose followed by a PR number**. Issue #10101
+measures it firsthand: PR #10094's own commit message carried a line saying it
+had CLOSED a PR (the translation core deliverable) without merging it. A naive
+squash of #10094 would have re-closed that PR -- the exact victim #10093
+protects -- because GitHub parses ``<closing-keyword> #N`` in a commit message
+as an auto-close instruction whenever N resolves to a PR.
+
+## The discriminator -- the NUMBER's nature, not the keyword's context
+
+Closing an **issue** by keyword is intended (catalog-pr-hygiene HARD 4 --
+``Closes #N`` is what makes the backlog shrink on its own). Closing a **PR** by
+keyword never is: one does not "resolve" a PR -- one merges it or closes it
+explicitly. So the gate resolves each referenced N:
+
+  - N is an ISSUE -> silence (intended close)
+  - N is a PR      -> BLOCKING failure
+  - N missing / API error -> fail-open (warn, do not crash the job)
+
+The resolver is **injectable** so unit tests never touch the network: the
+caller passes a callable ``int -> "pr"|"issue"|"missing"|"error"``, or leaves
+it None for the default ``gh``-based resolver (used by CI).
+
+## What it scans
+
+The PR body AND every commit message on the branch (the offending text in
+#10101 was a COMMIT, and the squash message is what GitHub parses -- the same
+reason ``variation_prev_guard.py`` scans commits).
+
+## Why BLOCKING (not advisory)
+
+Same reason as #10093: the failure is DESTRUCTIVE and happens AT MERGE TIME.
+An advisory label does not stop the squash. Only a required check turning
+``PR gate`` red before merge prevents the auto-close.
+
+## Run locally
+
+    python scripts/ci/pr_close_keyword_guard.py --body-file body.txt
+    # with commit messages (JSON array of strings):
+    python scripts/ci/pr_close_keyword_guard.py --body-file body.txt --commits-file commits.json
+
+The GH-based resolver needs ``GH_REPO`` and ``GH_TOKEN`` in the environment
+(both are present in CI).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+# Make the shared extractor importable from anywhere in the repo.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import grain_tag as gt  # noqa: E402
+
+# The four kinds a referenced number can resolve to.
+#   "pr"      -> N is a Pull Request  -> BLOCKING (closing a PR by keyword is never intended)
+#   "issue"   -> N is an Issue        -> silence (catalog-pr-hygiene HARD 4 intended close)
+#   "missing" -> N does not exist     -> fail-open warn (stale ref, not a crash)
+#   "error"   -> the API call failed  -> fail-open warn (do not fail-closed on a network blip)
+NumberKind = str
+Resolver = Callable[[int], NumberKind]
+
+
+def gh_resolver(number: int) -> NumberKind:
+    """Resolve ``number`` to "pr"/"issue"/"missing"/"error" via the ``gh`` CLI.
+
+    Uses ``gh api repos/:owner/:repo/issues/<n>``: a response with a non-null
+    ``pull_request`` field is a PR; null is an issue; a 404 is "missing".
+    Any other failure (auth, rate limit, network) is "error" -- the gate
+    fails OPEN on it (a network blip must not block legitimate merges).
+    Reads ``GH_REPO``/``GH_TOKEN`` from the environment (set by the workflow).
+    """
+    repo = os.environ.get("GH_REPO") or os.environ.get("GITHUB_REPOSITORY")
+    if not repo:
+        return "error"
+    try:
+        # ``gh api`` prints the JSON object; we only need whether
+        # ``.pull_request`` is null. ``--jq`` exits non-zero on a 404, which
+        # we catch as "missing".
+        out = subprocess.run(
+            ["gh", "api", f"repos/{repo}/issues/{number}", "--jq", ".pull_request"],
+            capture_output=True, text=True, timeout=20,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "error"
+    if out.returncode != 0:
+        # gh exits non-zero on 404 (and on auth/rate-limit). Distinguish by
+        # the stderr: a "not found"/404 line -> "missing"; anything else ->
+        # "error" (fail-open). The body of the 404 response carries no PR.
+        stderr = (out.stderr or "").lower()
+        if "not found" in stderr or "404" in stderr:
+            return "missing"
+        return "error"
+    # ``.pull_request`` is a dict for a PR, null/empty for an issue.
+    body = (out.stdout or "").strip()
+    return "pr" if body and body != "null" else "issue"
+
+
+def check(body: str | None, commits: list[str] | None = None,
+          resolver: Resolver | None = None) -> dict:
+    """Return the blocking verdict for a PR body + commit messages (#10101).
+
+    Pure function: ``resolver`` is injected (default ``gh_resolver``), so unit
+    tests pass a table-based resolver and never touch the network. Finds every
+    ``<closing-keyword> #N`` in the body and each commit, resolves N, and
+    BLOCKS iff any resolved N is a PR. Issues pass (intended close); missing /
+    error numbers pass with a warning (fail-open).
+    """
+    resolve: Resolver = resolver or gh_resolver
+    warnings: list[str] = []
+    pr_hits: list[dict] = []
+
+    def _resolve_hits(text: str, location: str) -> None:
+        for h in gt.find_close_keyword_pr_refs(text):
+            kind = resolve(h["number"])
+            entry = {**h, "kind": kind, "location": location}
+            if kind == "pr":
+                pr_hits.append(entry)
+            elif kind == "issue":
+                pass  # intended close (catalog-pr-hygiene HARD 4) -> silence
+            else:  # missing / error
+                warnings.append(
+                    f"referenced #{h['number']} resolved as '{kind}' at {location} "
+                    f"-- fail-open (not blocking), but the ref may be stale."
+                )
+
+    _resolve_hits(body or "", "body")
+    for i, msg in enumerate(commits or []):
+        _resolve_hits(msg, f"commit[{i}]")
+
+    if not pr_hits:
+        return {
+            "guard_pass": True,
+            "reason": "no closing-keyword + PR-number reference found",
+            "hits": [],
+            "warnings": warnings,
+        }
+
+    # Cite each offending line + tell the author what to do (acceptance #5):
+    # drop the keyword, or write the number without the `#`.
+    cite = [
+        f"`{h['keyword']} #{h['number']}` ({h['location']}, resolves to a PR)"
+        for h in pr_hits
+    ]
+    reason = (
+        f"closing-keyword + PR-number reference(s) that would auto-close a PR on "
+        f"squash: {cite}. Remove the closing keyword, or write the number "
+        f"WITHOUT the leading `#` (a bare number is not an auto-close). See #10101."
+    )
+    return {
+        "guard_pass": False,
+        "reason": reason,
+        "hits": pr_hits,
+        "warnings": warnings,
+    }
+
+
+def _read_commits_file(path: str) -> list[str]:
+    """Read a commits file as a JSON array of message strings (same shape as
+    ``variation_prev_guard.py``: ``gh pr view --json commits --jq '[.[].messageBody]'``).
+    Empty/missing -> no commits to scan.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+    if isinstance(data, list):
+        return [str(m) for m in data if isinstance(m, str)]
+    return []
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--body-file", metavar="FILE", required=True,
+                   help="path to the PR body")
+    p.add_argument("--commits-file", metavar="FILE",
+                   help="path to a JSON array of commit message strings")
+    args = p.parse_args(argv)
+
+    try:
+        with open(args.body_file, encoding="utf-8") as f:
+            body = f.read()
+    except OSError as e:
+        print(json.dumps({"guard_pass": False, "reason": f"caller error: {e}",
+                          "hits": [], "warnings": []}), file=sys.stderr)
+        return 2
+
+    commits = _read_commits_file(args.commits_file) if args.commits_file else []
+    verdict = check(body, commits)
+    print(json.dumps(verdict, ensure_ascii=False))
+    return 0 if verdict["guard_pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -199,6 +199,54 @@ def find_prev_close_keywords(text: str | None) -> list[dict]:
     return hits
 
 
+# Matches `<closing-keyword> #N` in free prose (#10101). The keyword set is
+# exactly `CLOSING_KEYWORDS` (the 9 GitHub auto-close words); the `#N` tail is
+# what GitHub parses as an auto-close instruction when the text lands in a
+# PR description or a commit message. The 9 flexions are anchored with a
+# word boundary so `fixed` does not match inside `affixed`, and `\s+` allows
+# any whitespace between the keyword and the `#`. The number is captured so
+# the caller can resolve it: closing an ISSUE is intended
+# (catalog-pr-hygiene HARD 4), closing a PR by keyword never is (one does not
+# "resolve" a PR -- one merges or closes it explicitly). #10101.
+CLOSE_KW_REF_RE = re.compile(
+    r"\b(close[ds]?|fix(?:es|ed)?|resolv(?:e|es|ed))\s+#(\d+)\b",
+    re.IGNORECASE,
+)
+
+
+def find_close_keyword_pr_refs(text: str | None) -> list[dict]:
+    r"""Return ``<closing-keyword> #N`` references found in free prose (#10101).
+
+    The complement of ``find_prev_close_keywords``: that one flags a closing
+    keyword in the *genre slot of a `prev:` field* (structurally always wrong).
+    This one flags a closing keyword followed by a number **anywhere in the
+    text** -- the failure mode #10101 measures: PR #10094's own commit message
+    carried a ``CLOSED <PR-number>`` line in prose, which a naive squash would
+    have re-closed that PR (the same translation deliverable #10093 protects).
+
+    Each hit is ``{"keyword": <lowercased>, "number": <int>, "span": <tuple>}``:
+    the keyword (lowercased for the 9-flexion test), the referenced number
+    (the caller resolves it PR-vs-issue), and the match span (so the verdict
+    can cite the offending line). Returns an empty list when the text is clean
+    or falsy.
+
+    This function is a *finder*, not a *decider*: it does not know whether N is
+    a PR or an issue (that needs an API call). The decision lives in the gate
+    that calls it (`scripts/ci/pr_close_keyword_guard.py`), with the resolver
+    injected so unit tests never touch the network.
+    """
+    if not text:
+        return []
+    hits = []
+    for m in CLOSE_KW_REF_RE.finditer(text):
+        hits.append({
+            "keyword": m.group(1).lower(),
+            "number": int(m.group(2)),
+            "span": m.span(),
+        })
+    return hits
+
+
 def parse_grain_tag(body: str | None) -> dict | None:
     """Extract {tier, genre, lane} from a PR body, form-tolerant.
 

--- a/scripts/tests/test_pr_close_keyword_guard.py
+++ b/scripts/tests/test_pr_close_keyword_guard.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+r"""Unit tests for ``pr_close_keyword_guard.py`` (#10101).
+
+Acceptance point 4 (no network): the resolver is **injected** as a table,
+so these tests never call ``gh``. They cover the seven mandated cases from
+#10101:
+
+  - ``Closes #<issue>``         -> PASS  (intended close, catalog-pr-hygiene HARD 4)
+  - ``Closes #<PR>``            -> BLOCK (closing a PR by keyword is never intended)
+  - specimen ``CLOSED <PR> ... without merging it`` -> BLOCK (the #10094 incident)
+  - the nine keyword flexions  -> each blocks when N is a PR
+  - ``#N`` without a keyword    -> PASS  (bare reference is not an auto-close)
+  - non-existent number         -> PASS + WARN (fail-open, not a crash)
+  - API error                   -> PASS + WARN (fail-open on a network blip)
+"""
+import json
+import sys
+from pathlib import Path
+
+# Make ``scripts/ci`` importable (sibling of ``scripts/tests``).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
+
+import pr_close_keyword_guard as pkg  # noqa: E402
+
+
+def _table_resolver(table: dict):
+    """Build an injectable resolver from ``{number: kind}``; unmapped -> 'missing'."""
+    return lambda n: table.get(n, "missing")
+
+
+# --- acceptance #4: Closes #<issue> PASSES (intended close) -----------------
+
+def test_closes_issue_passes():
+    body = "This PR refactors the search module. Closes #42"
+    verdict = pkg.check(body, resolver=_table_resolver({42: "issue"}))
+    assert verdict["guard_pass"] is True
+    assert verdict["hits"] == []
+    assert verdict["warnings"] == []  # silence, not even a warning
+
+
+# --- acceptance #4: Closes #<PR> BLOCKS -------------------------------------
+
+def test_closes_pr_blocks():
+    body = "Refactor the search module. Closes #10067"
+    verdict = pkg.check(body, resolver=_table_resolver({10067: "pr"}))
+    assert verdict["guard_pass"] is False
+    assert len(verdict["hits"]) == 1
+    assert verdict["hits"][0]["number"] == 10067
+    assert verdict["hits"][0]["kind"] == "pr"
+    assert verdict["hits"][0]["location"] == "body"
+    # acceptance #5: failure message cites the offender AND the remediation
+    assert "10067" in verdict["reason"]
+    assert "remov" in verdict["reason"].lower() or "without the leading" in verdict["reason"].lower()
+
+
+# --- acceptance #4: the #10094 specimen BLOCKS ------------------------------
+# The exact incident from #10101: a commit claiming it CLOSED a PR "without
+# merging it". The number resolves to a PR -> BLOCK. (We scan a commit message,
+# matching where #10094's offending text actually lived.)
+
+def test_specimen_closed_pr_without_merging_blocks():
+    commit_msg = (
+        "chore: drain translation work\n\n"
+        "CLOSED #10067 without merging it -- the translation core deliverable."
+    )
+    verdict = pkg.check(None, commits=[commit_msg],
+                        resolver=_table_resolver({10067: "pr"}))
+    assert verdict["guard_pass"] is False
+    assert verdict["hits"][0]["number"] == 10067
+    assert verdict["hits"][0]["keyword"] == "closed"
+    assert verdict["hits"][0]["location"] == "commit[0]"
+
+
+# --- acceptance #4: the NINE flexions each BLOCK when N is a PR -------------
+
+def test_nine_flexions_block():
+    flexions = ["close", "closes", "closed", "fix", "fixes", "fixed",
+                "resolve", "resolves", "resolved"]
+    for kw in flexions:
+        body = f"Work done. {kw} #10067 -- done."
+        verdict = pkg.check(body, resolver=_table_resolver({10067: "pr"}))
+        assert verdict["guard_pass"] is False, f"flexion '{kw}' should block"
+        assert verdict["hits"][0]["keyword"] == kw
+
+
+# --- acceptance #4: #N WITHOUT a keyword PASSES -----------------------------
+
+def test_bare_number_without_keyword_passes():
+    body = "Follow-up to PR 10067 and issue #42 for context."
+    verdict = pkg.check(body, resolver=_table_resolver({10067: "pr", 42: "issue"}))
+    # No closing keyword precedes either number -> nothing to resolve as a hit.
+    assert verdict["guard_pass"] is True
+    assert verdict["hits"] == []
+
+
+# --- acceptance #4: non-existent number FAILS-OPEN (warn, not crash) --------
+
+def test_nonexistent_number_fails_open():
+    body = "Cleanup. Closes #99999 (old ref)."
+    verdict = pkg.check(body, resolver=_table_resolver({}))  # 99999 -> missing
+    assert verdict["guard_pass"] is True  # fail-open, not blocking
+    assert len(verdict["warnings"]) == 1
+    assert "99999" in verdict["warnings"][0]
+    assert "missing" in verdict["warnings"][0]
+
+
+# --- acceptance #4: API error FAILS-OPEN (warn, not crash) ------------------
+
+def test_api_error_fails_open():
+    def error_resolver(_n):
+        return "error"
+    body = "Cleanup. Closes #10067."
+    verdict = pkg.check(body, resolver=error_resolver)
+    assert verdict["guard_pass"] is True  # fail-open on network blip
+    assert len(verdict["warnings"]) == 1
+    assert "error" in verdict["warnings"][0]
+
+
+# --- extra: body empty / no refs -> PASS ------------------------------------
+
+def test_empty_body_passes():
+    assert pkg.check("", resolver=_table_resolver({}))["guard_pass"] is True
+    assert pkg.check(None, resolver=_table_resolver({}))["guard_pass"] is True
+
+
+# --- extra: an ISSUE and a PR in the same body -> BLOCKS on the PR ----------
+
+def test_mixed_issue_and_pr_blocks_on_pr():
+    body = "Refactor. Closes #42 (issue) and closes #10067 (pr)."
+    verdict = pkg.check(body, resolver=_table_resolver({42: "issue", 10067: "pr"}))
+    assert verdict["guard_pass"] is False
+    assert len(verdict["hits"]) == 1
+    assert verdict["hits"][0]["number"] == 10067  # only the PR blocks
+
+
+# --- extra: commit-message-only block (the #10094 path) ---------------------
+
+def test_commit_message_only_blocks():
+    commits = ["fix: thing", "Docs done. fixed #10067"]
+    verdict = pkg.check(None, commits=commits,
+                        resolver=_table_resolver({10067: "pr"}))
+    assert verdict["guard_pass"] is False
+    assert verdict["hits"][0]["location"] == "commit[1]"
+
+
+# --- extra: CLI end-to-end with a table resolver monkeypatch ----------------
+
+def test_cli_blocks_on_pr(tmp_path, monkeypatch):
+    body_file = tmp_path / "body.txt"
+    body_file.write_text("Done. closes #10067", encoding="utf-8")
+    # Inject the table resolver so the CLI path needs no network.
+    monkeypatch.setattr(pkg, "gh_resolver", _table_resolver({10067: "pr"}))
+    rc = pkg.main(["--body-file", str(body_file)])
+    assert rc == 1  # BLOCKING exit
+
+
+def test_cli_passes_on_issue(tmp_path, monkeypatch):
+    body_file = tmp_path / "body.txt"
+    body_file.write_text("Done. closes #42", encoding="utf-8")
+    monkeypatch.setattr(pkg, "gh_resolver", _table_resolver({42: "issue"}))
+    rc = pkg.main(["--body-file", str(body_file)])
+    assert rc == 0
+
+
+if __name__ == "__main__":
+    # Allow ``python test_pr_close_keyword_guard.py`` to run directly.
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/notebook-python #10092
Quoi: implement #10101 — extend the #10093 close-keyword gate to BLOCK a `<closing-keyword> #N` in free prose (PR body) AND commit messages when N resolves to a PR. The discriminator is the NUMBER's nature: closing an ISSUE by keyword is intended (catalog-pr-hygiene HARD 4 — passes silently); closing a PR by keyword never is (BLOCKS). A missing number or an API blip fails OPEN with a warning, not closed/fail-closed. Resolution is injectable so unit tests touch no network.
Preuve: 12 new unit tests PASS (pytest 9.1.1, 0.19s) covering all 7 #10101 acceptance cases + 5 extras; 48/48 PASS including the shared `grain_tag` + `variation_prev_guard` suites (no regression in the shared module the #10093 gate also uses). YAML validated (`yaml.safe_load` OK). Pre-commit gitleaks + hooks PASS. Base rebased onto fresh `origin/main` (`be5469dd2d`); `origin/main` did not touch any of my 4 files → clean replay. Collision guard CLEAN (L898): no open PR on `scripts/grain_tag.py`, the new guard, or the workflow; no PR on the branch head.
Perimetre: `scripts/grain_tag.py` (+48: `find_close_keyword_pr_refs` + `CLOSE_KW_REF_RE`, additive after `find_prev_close_keywords`, existing parsing untouched) · `scripts/ci/pr_close_keyword_guard.py` (new, 208 lines: pure `check()` + injectable `gh_resolver` + CLI, same shape as `variation_prev_guard.py`) · `scripts/tests/test_pr_close_keyword_guard.py` (new, 12 tests) · `.github/workflows/variation-tag-guard.yml` (+110: `check-close-keyword-pr-ref-required` job). 534 insertions, 0 deletions. No catalog, no notebook, no other file.

## Summary

The #10093 gate (`variation_prev_guard.py`) blocks a closing keyword ONLY in the `prev:` genre slot — structurally always wrong. #10101 measures a **second, live vector** for the same auto-close danger: a `<closing-keyword> #N` in **free prose** (PR body) or a **commit message**. GitHub parses such text in the **squash message** as an auto-close instruction whenever N resolves to a PR.

### The incident (measured firsthand in #10101)

PR 10094's own commit message carried a line saying it had CLOSED a PR (the translation core deliverable) "without merging it". A naive squash of that PR would have re-closed the victim PR — the exact victim the #10093 gate protects — because GitHub parses a closing keyword followed by `#N` in a commit message as an auto-close whenever N is a PR. (Numbers written bare here, without `#`, so this very body does not reproduce the pattern the gate detects — cf. the #10101 rédaction note.)

### The discriminator — the NUMBER's nature, not the keyword's context

Closing an **issue** by keyword is **intended**: `Closes #N` is what makes the backlog shrink on its own (catalog-pr-hygiene HARD 4). Closing a **PR** by keyword **never is** — one does not "resolve" a PR; one merges it or closes it explicitly. So the gate resolves each referenced N:

| N resolves to | Action |
|---|---|
| **ISSUE** | silence (intended close) |
| **PR** | **BLOCKING** failure |
| missing (404) | fail-open warn (stale ref, not a crash) |
| API error | fail-open warn (network blip, not fail-closed) |

### Injectable resolver — 0 network in tests

`Resolver = Callable[[int], NumberKind]` where `NumberKind ∈ {"pr","issue","missing","error"}`. The default `gh_resolver` calls `gh api repos/:owner/:repo/issues/<n> --jq .pull_request` (non-null → PR; 404 → missing; else error). Unit tests inject a table-based resolver (`{number: kind}.get(n, "missing")`) — **they never call `gh`**. CI uses the default resolver (GH_TOKEN/GH_REPO are in the workflow env).

### Why BLOCKING (not advisory)

Same reason as #10093: the failure is **destructive** and happens **at merge time** (the squash message is what GitHub parses). An advisory label does not stop the squash. Only a required check turning `PR gate` red before merge prevents the auto-close. The job name carries the `-required` suffix so PR 10036's `is_advisory()` classifier in `scripts/pr_gate.py` does NOT silence it — same reason as the tag-required and prev-close-keyword-required jobs.

## Acceptance (#10101 — all 5 points met)

| # | Criterion | Met how |
|---|---|---|
| 1 | Scan body AND commits; block `<closing-keyword> #N` in both | `check(body, commits)` scans both; the offending text in the incident was a COMMIT |
| 2 | Resolve N: PR → block, issue → silence | `gh_resolver` (non-null `.pull_request` → PR); issue → `pass` with no warning |
| 3 | Injectable resolver, tests provide a table | `Resolver` callable; tests inject `{n: kind}` dict |
| 4 | Tests: issue passes, PR blocks, specimen blocks, 9 flexions, `#N` without keyword passes, non-existent fail-open | `test_pr_close_keyword_guard.py` — 7 mandated cases + 5 extras (mixed, commit-only, empty, CLI both ways) |
| 5 | Failure message cites the line + remediation | `"remove the closing keyword, or write the number WITHOUT the leading #"` + per-hit citation with location |

The **9 flexions** (`close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved`) are covered by the regex `\b(close[ds]?|fix(?:es|ed)?|resolv(?:e|es|ed))\s+#(\d+)\b` and the `test_nine_flexions_block` parametrized test.

## Validation

- `python -m pytest scripts/tests/test_pr_close_keyword_guard.py -v` → **12 passed**.
- `python -m pytest scripts/tests/test_variation_prev_guard.py scripts/tests/test_pr_close_keyword_guard.py scripts/tests/test_grain_tag.py -q` → **48 passed** (no regression in the shared `grain_tag` module).
- YAML: `python -c "import yaml; yaml.safe_load(open(...))"` → OK.
- `git diff --stat` vs `origin/main` = 4 files, +534/−0 (pure additive — no anti-regression concern).
- Pre-commit: gitleaks **Passed**; notebook hooks skipped (no notebooks).
- Base: rebased onto fresh `origin/main` (`be5469dd2d`); the 3 commits main gained did not touch my files.

## Variation note (transparent)

prev = MED/notebook-python #10092 (App-5-Timetabling). This = MED/guard — different GENRE (guard vs notebook-python). G-VAR-3 bans 2 consecutive **LIGHT** same-genre; this is MED cross-genre, so the ban does not apply. G-VAR-1 (plancher DEEP/MED): MED ✓. Litmus: this is not LIGHT ("could I generate a dozen by scanning the next instance?" — no: it required designing the injectable-resolver architecture + the PR-vs-issue discriminator + the fail-open policy), so the generating-in-series test does not apply.

Closes #10101
See #10093
