### PR TITLE
ci(#10101): prose close-keyword gate with PR/issue discrimination

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -661,3 +661,141 @@ jobs:
           )" 2>/dev/null || true
 
           exit 1
+
+  # #10101 -- extend the prev-close-keyword gate (#10093) to free prose.
+  # The prev: gate scans the `prev: TIER/genre #N` slot of a `Grain:` tag
+  # for a closing keyword in the genre position; this gate scans the FULL
+  # body + commit messages for `<mot-cle> #N` (closes #100, fixes #200,
+  # ...) and discriminates PR vs issue via `gh api repos/<repo>/issues/N`.
+  # A PR hit is blocking (would auto-close the PR at squash-merge); an
+  # issue hit is silent (intended close -- catalog-pr-hygiene HARD 4).
+  # Same shape as the prev: gate next to it: the discriminator is the
+  # nature of the N, not the surface syntax.
+  check-prose-close-keyword-required:
+    name: 'Require prose non-closing-PR (block on close-keyword + PR ref, #10101)'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the prose-guard helper (sparse)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/ci/variation_prose_close_guard.py
+            scripts/grain_tag.py
+      - name: 'Scan body + commit messages for close-keyword + PR reference'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          set -uo pipefail
+
+          # Same bot/fork gating as the other jobs (cf. student-pr-reviews.md).
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issue d'un fork : hors scope (PR etudiante)."
+            exit 0
+          fi
+
+          # Body to a file -- printf '%s' preserves it verbatim.
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          # Commit messages as a JSON array of strings (same shape as the
+          # prev: gate; the helper tolerates empty/missing).
+          gh pr view "$PR_NUMBER" --json commits --jq '[.[].messageBody]' \
+            > /tmp/commits.json 2>/dev/null || printf '[]' > /tmp/commits.json
+
+          # First pass: inert resolver (every N = "issue") to enumerate the
+          # unique Ns the scan produced. The helper always exits 0 in this
+          # mode (issues + unknowns are silent), so we just read the JSON.
+          python3 scripts/ci/variation_prose_close_guard.py \
+            --body-file /tmp/pr_body.txt \
+            --commits-file /tmp/commits.json > /tmp/scan.json 2>/tmp/scan.err
+          if [ -s /tmp/scan.err ]; then
+            echo "--- scan stderr ---"
+            cat /tmp/scan.err
+          fi
+
+          # Build the resolver table {"<N>": "pr"|"issue"} for every N the
+          # scan produced. `gh api repos/<repo>/issues/N --jq .pull_request`
+          # returns `null` for issues (no `pull_request` key) and an object
+          # `{url: ...}` for PRs. A failing call yields "unknown" (the gate
+          # fails OPEN on unknown -- never block on an API blip, which would
+          # be a DoS on its own; see #10101 acceptance #4).
+          TABLE='{}'
+          NS=$(python3 -c "
+          import json
+          v = json.load(open('/tmp/scan.json'))
+          hits = v.get('hits', {})
+          seen = set()
+          for bucket in ('issues_allowed', 'unknowns'):
+              for h in hits.get(bucket, []):
+                  seen.add(str(h['number']))
+          # Also include PR hits (in case a future change fails open on
+          # PRs too, we want them resolved on the second pass).
+          for h in hits.get('pr', []):
+              seen.add(str(h['number']))
+          print(' '.join(sorted(seen)))
+          ")
+          echo "Scan produced Ns: ${NS:-<none>}"
+
+          for N in $NS; do
+            if [ -z "$N" ]; then continue; fi
+            # 10s timeout per call; the JSON `.pull_request` is `null`/`{}`.
+            RES=$(gh api "repos/${GH_REPO}/issues/${N}" --jq '.pull_request' 2>/dev/null || echo "")
+            case "$RES" in
+              "null"|"") KIND="issue" ;;
+              "{")       KIND="pr" ;;
+              *)         KIND="unknown" ;;
+            esac
+            TABLE=$(python3 -c "
+          import json, sys
+          t = json.loads('''$TABLE''')
+          t['$N'] = '$KIND'
+          print(json.dumps(t))
+          ")
+            echo "  N=$N -> $KIND"
+          done
+          echo "Resolver table: $TABLE"
+
+          # Second pass: real resolver table. The helper now discriminates
+          # PR vs issue per hit; PR hits block, issue hits are silent.
+          python3 scripts/ci/variation_prose_close_guard.py \
+            --body-file /tmp/pr_body.txt \
+            --commits-file /tmp/commits.json \
+            --resolver-table "$TABLE" > /tmp/verdict.json 2>/tmp/verdict.err
+          RC=$?
+
+          if [ -s /tmp/verdict.err ]; then
+            echo "--- helper stderr ---"
+            cat /tmp/verdict.err
+          fi
+          echo "--- verdict ---"
+          cat /tmp/verdict.json
+
+          if [ "$RC" -eq 0 ]; then
+            echo "No close-keyword prose targets a PR -- job passes."
+            exit 0
+          fi
+
+          # Block path. Idempotent comment via the HTML marker.
+          REASON=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('reason','unknown'))" 2>/dev/null || echo "unknown")
+          echo "::error::prose close-keyword targets a PR: $REASON"
+
+          gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          <!-- vtr-prose-close-keyword -->
+          **\`close-keyword prose + PR ref\` -- bloquant (#10101).**
+
+          ${REASON}
+
+          Une phrase comme \`Closes #100\` ou \`Fixed #200\` dans le body OU un commit message est interprétée par GitHub comme un ordre de fermeture automatique à la fusion -- **mais seulement si N référence une PR**. Un N qui référence une issue est l'auto-fermeture voulue par la discipline (catalog-pr-hygiene HARD 4) et le gate la laisse passer en silence. C'est le N, pas la syntaxe de surface, qui discrimine.
+
+          Pour passer ce gate, retirez le mot-clé fermant (\`Closes\`/\`Fixes\`/\`Resolves\`/...) ou écrivez le numéro sans \`#\` (GitHub ne le reconnaîtra pas comme référence, donc pas d'auto-fermeture). Le PR visé reste ouvert, intact.
+          EOF
+          )" 2>/dev/null || true
+
+          exit 1

--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -671,6 +671,15 @@ jobs:
   # issue hit is silent (intended close -- catalog-pr-hygiene HARD 4).
   # Same shape as the prev: gate next to it: the discriminator is the
   # nature of the N, not the surface syntax.
+  #
+  # NOTE (c.1331+15): a body that QUOTES the offending `prev: TIER/fix #N`
+  # pattern in prose (e.g. describing the #10093 incident) trips this gate
+  # via the same `_PREV_RE` regex. The guard fires on the literal text
+  # inside code spans; backticks are stripped before matching. Mitigations
+  # for prose quoting the bug: paraphrase the pattern out of existence
+  # (e.g. "a `prev:` tag whose genre was a closing keyword" rather than
+  # `prev: MED/fix #10067`). A future hardening could strip code-fenced
+  # blocks before the scan; out of scope here.
   check-prose-close-keyword-required:
     name: 'Require prose non-closing-PR (block on close-keyword + PR ref, #10101)'
     runs-on: ubuntu-latest

--- a/scripts/ci/variation_prose_close_guard.py
+++ b/scripts/ci/variation_prose_close_guard.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+r"""variation_prose_close_guard.py -- BLOCKING gate against close-keyword
+prose that targets a PR (not an issue) (#10101).
+
+## Why this exists
+
+Issue #10101 measures a hole in the #10093 gate (variation_prev_guard.py):
+the existing gate only scans the `prev:` field of a `Grain:` tag, so a
+close-keyword followed by `#<N>` in free prose is invisible to it.
+
+The spec:
+- A standalone `Closes #<issue>` or `Fixes #<issue>` in a commit message or
+  PR body is an INTENDED close (catalog-pr-hygiene HARD 4 -- `Closes #N`
+  when the PR fully resolves the issue). The discipline **wants** it.
+- A standalone `Closes #<PR>` or `Fixes #<PR>` is NEVER intended: PRs are
+  not "resolved" by another PR (they are merged or explicitly closed). The
+  #10093 incident started from `prev: MED/fix #10067` (genre-slot misuse),
+  but the wider hazard is the same shape in prose: the message body or
+  commit message of #10094 itself contained a `Closes #10067`-shaped
+  fragment when the worker transcribed the incident for the audit, and a
+  naive squash of #10094 would have re-closed #10067. The discriminator
+  that catches both shapes is **the nature of the N**, not the surface
+  syntax.
+
+## What it does
+
+Scans the PR body AND every commit message on the branch for the GitHub
+auto-close keywords (`grain_tag.CLOSING_KEYWORDS`) followed by `#<N>`. For
+each hit, resolves N via the injectable `resolver(n) -> "pr" | "issue" |
+"unknown"`. A hit whose N is a PR is a hard failure (exit 1). A hit whose
+N is an issue is silence (the gate leaves intended closes alone). A hit
+whose N cannot be resolved fails OPEN with an audit warning (the worker
+already pushed the prose, so the gate's job is not to invent a
+disambiguation that is not there -- but it must NOT block on a transient
+API failure, which would be a DoS on its own).
+
+Emits a single verdict on stdout:
+
+    {"guard_pass": true|false, "reason": "<one line>", "hits": [...]}
+
+Exit codes:
+  0  -- no offending prose (issues are allowed, PRs are absent, unknowns
+        are absent)
+  1  -- at least one close-keyword + PR hit (the PR is non-mergeable until
+        the offending line is rewritten -- remove the keyword, or drop the
+        `#` so GitHub does not parse it as a reference)
+  2  -- caller error (unreadable file)
+
+## Why BLOCKING (not advisory)
+
+The failure mode is identical to #10093: a destructive auto-close at merge
+time. The existing `check-prev-close-keyword-required` job is the same
+shape. This gate lives next to it.
+
+## Run locally
+
+    python scripts/ci/variation_prose_close_guard.py --body-file body.txt \
+        --commits-file commits.json --resolver-table '{"10067": "pr", "10093": "issue"}'
+
+Without `--resolver-table`, the gate runs an INERT resolver that classifies
+every N as `issue` (i.e. PASS everywhere). This is the safe default for
+offline local runs: no real-world PR is auto-closed, and tests inject their
+own resolver. The CI workflow supplies a resolver populated by
+`gh api repos/:owner/:repo/issues/N --jq '.pull_request'` for the Ns the
+scan produced.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Make the shared extractor importable from anywhere in the repo (CI runs
+# from the repo root; local devs may run from the script directory).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import grain_tag as gt  # noqa: E402
+
+
+# A close-keyword word boundary that does not match when the keyword is part
+# of an identifier (e.g. `prefix` should not match `fix`). GitHub's own
+# keyword matcher is whitespace-and-punctuation sensitive; we mirror it
+# loosely with `\b` so we catch the headline `Closes #N` form and the
+# `CLOSED #N` form (the #10101 spec specimen) without false positives on
+# words that contain a keyword as a substring.
+_CLOSE_KW_RE = re.compile(
+    r"\b(" + "|".join(re.escape(k) for k in sorted(gt.CLOSING_KEYWORDS, key=len, reverse=True)) + r")\b",
+    re.IGNORECASE,
+)
+
+# `#<N>` reference -- only what GitHub parses as an issue/PR link. Strips
+# the hash, captures the digits. A trailing `,` / `.` / `)` is NOT in the
+# capture because GitHub's parser is permissive there but the prose scan
+# wants the integer for the resolver.
+_HASH_REF_RE = re.compile(r"#(\d+)\b")
+
+
+# --- resolver --------------------------------------------------------------
+
+# Default resolver: inert. Classifies every N as `issue` so the gate is
+# PASS-by-default offline. Tests inject their own resolver. CI replaces it
+# with one populated by `gh api` for the Ns the scan produced. The inert
+# default is a deliberate safety choice: a misconfigured offline run must
+# NOT block every PR (it would be a DoS); the worker can also use it to
+# dry-run the scan and see the hits without resolving them.
+def inert_resolver(n: int) -> str:
+    """Default resolver: every N is treated as an issue (gate stays silent)."""
+    return "issue"
+
+
+def gh_resolver_factory(repo: str):
+    """Build a resolver backed by `gh api repos/<repo>/issues/<N>`.
+
+    Caches per-N to bound the network budget. The CI workflow passes this
+    resolver only when GITHUB_TOKEN + GH_REPO are available. A failing call
+    yields `"unknown"` -- the gate fails OPEN on unknown, never blocks on
+    an API blip.
+    """
+    cache: dict[int, str] = {}
+
+    def resolve(n: int) -> str:
+        if n in cache:
+            return cache[n]
+        try:
+            import subprocess  # local import: the gh-resolver is CI-only
+            r = subprocess.run(
+                ["gh", "api", f"repos/{repo}/issues/{n}", "--jq", ".pull_request"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if r.returncode != 0:
+                cache[n] = "unknown"
+                return "unknown"
+            # `gh api --jq .pull_request` prints `null` for issues (no
+            # `pull_request` key) and an object `{url: ...}` for PRs.
+            v = r.stdout.strip()
+            if v == "null" or v == "":
+                cache[n] = "issue"
+                return "issue"
+            if v.startswith("{"):
+                cache[n] = "pr"
+                return "pr"
+            cache[n] = "unknown"
+            return "unknown"
+        except Exception:
+            cache[n] = "unknown"
+            return "unknown"
+
+    return resolve
+
+
+# --- scan ------------------------------------------------------------------
+
+def find_prose_close_refs(text: str | None) -> list[dict]:
+    """Return all `<keyword> #N` occurrences in `text` (body or commit).
+
+    Each hit is a `{"keyword": "close", "number": 10067, "span": (start, end)}`
+    dict -- the `span` is the slice of the input that contains the keyword,
+    so the failure message can quote the offending fragment. The order
+    matches the input (the gate does not deduplicate; the same `Closes #100`
+    twice is two hits).
+    """
+    if not text:
+        return []
+    hits: list[dict] = []
+    for kw_m in _CLOSE_KW_RE.finditer(text):
+        # Look ahead from the keyword's END for a `#N` reference within a
+        # reasonable window (a closing paragraph can run hundreds of chars
+        # before the `#N`; we cap at 200 to avoid matching a much later
+        # `#N` that is not associated with this keyword -- e.g. a body that
+        # mentions `Closes #100` then later `See #200` should NOT pair the
+        # two). The cap is generous: GitHub's auto-close parser pairs them
+        # on the same paragraph / commit message anyway, and 200 chars
+        # covers the realistic shapes seen in the corpus.
+        start = kw_m.end()
+        window = text[start:start + 200]
+        ref_m = _HASH_REF_RE.search(window)
+        if not ref_m:
+            continue
+        hits.append({
+            "keyword": kw_m.group(1).lower(),
+            "number": int(ref_m.group(1)),
+            "span_start": kw_m.start(),
+            "span_end": start + ref_m.end(),
+        })
+    return hits
+
+
+def classify_hits(hits: list[dict], resolver) -> tuple[list[dict], list[dict], list[dict]]:
+    """Partition hits into (pr_hits, issue_hits, unknown_hits) by resolver.
+
+    `resolver` is a callable `int -> "pr"|"issue"|"unknown"`. Same N twice
+    hits the resolver twice (no caching at this layer -- the gh resolver
+    caches internally, and the offline resolver is free). The verdict is
+    the PR bucket that matters; the others are reported for transparency.
+    """
+    pr, issue, unknown = [], [], []
+    for h in hits:
+        kind = resolver(h["number"])
+        if kind == "pr":
+            pr.append(h)
+        elif kind == "issue":
+            issue.append(h)
+        else:
+            unknown.append(h)
+    return pr, issue, unknown
+
+
+def check(
+    body: str | None,
+    commits: list[str] | None = None,
+    *,
+    resolver=None,
+) -> dict:
+    """Return the blocking verdict for a PR body + its commit messages.
+
+    `resolver` is injectable so tests can pin PR vs issue without going
+    through the network. The default is the inert resolver -- see
+    `inert_resolver` docstring.
+    """
+    if resolver is None:
+        resolver = inert_resolver
+
+    hits_body = find_prose_close_refs(body)
+    hits_commits: list[dict] = []
+    for i, msg in enumerate(commits or []):
+        for h in find_prose_close_refs(msg):
+            hits_commits.append({"commit_index": i, **h})
+
+    pr_body, issue_body, unk_body = classify_hits(hits_body, resolver)
+    pr_commits, issue_commits, unk_commits = classify_hits(hits_commits, resolver)
+
+    pr_total = pr_body + pr_commits
+    if not pr_total:
+        # No PR-targeted close-keyword prose: pass. Issues + unknowns are
+        # reported in the verdict for transparency but never block.
+        return {
+            "guard_pass": True,
+            "reason": "no close-keyword prose targets a PR",
+            "hits": {
+                "pr": [],
+                "issues_allowed": issue_body + issue_commits,
+                "unknowns": unk_body + unk_commits,
+            },
+        }
+
+    locs = []
+    if pr_body:
+        locs.append(f"body ({len(pr_body)})")
+    if pr_commits:
+        locs.append(f"commit messages ({len(pr_commits)})")
+    numbers = sorted({h["number"] for h in pr_total})
+    reason = (
+        f"close-keyword prose targets a PR (#{', #'.join(str(n) for n in numbers)}) "
+        f"in {' + '.join(locs)} -- PRs are not 'resolved' by prose. Remove the "
+        f"keyword (or drop the `#`) so GitHub does not auto-close. See #10101."
+    )
+    return {
+        "guard_pass": False,
+        "reason": reason,
+        "hits": {
+            "pr": pr_body + pr_commits,
+            "issues_allowed": issue_body + issue_commits,
+            "unknowns": unk_body + unk_commits,
+        },
+    }
+
+
+# --- I/O helpers ------------------------------------------------------------
+
+def _read_commits_file(path: str) -> list[str]:
+    """Read a commits file as a JSON array of message strings.
+
+    The workflow writes `gh pr view --json commits --jq '[.[].messageBody]'`
+    to the file. A plain JSON array of strings is the robust shape: commit
+    messages are multi-line, so a line-oriented format would be ambiguous.
+    An empty/missing file yields an empty list (no commits to scan).
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+    if isinstance(data, list):
+        return [str(m) for m in data if isinstance(m, str)]
+    return []
+
+
+def _resolver_from_table(table_json: str | None):
+    """Build a resolver from a JSON `{"<N>": "pr"|"issue"}` table.
+
+    Tests use this to pin classification without mocking. Unknown Ns in
+    the table fall through to the inert_resolver default (issue).
+    """
+    if not table_json:
+        return inert_resolver
+    try:
+        table = json.loads(table_json)
+    except json.JSONDecodeError:
+        return inert_resolver
+    if not isinstance(table, dict):
+        return inert_resolver
+
+    def from_table(n: int) -> str:
+        v = table.get(str(n))
+        if v in ("pr", "issue"):
+            return v
+        return "issue"  # default safe
+
+    return from_table
+
+
+# --- CLI --------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--body-file", metavar="FILE", required=True,
+                   help="path to the PR body")
+    p.add_argument("--commits-file", metavar="FILE",
+                   help="path to a JSON array of commit message strings")
+    p.add_argument("--resolver-table", metavar="JSON",
+                   help='JSON object {"<N>": "pr"|"issue"} for offline resolution; '
+                        'unknown Ns default to "issue". Without this flag the gate '
+                        'uses the inert resolver and always passes.')
+    p.add_argument("--resolver-gh-repo", metavar="OWNER/REPO",
+                   help="if set, resolve via `gh api repos/<repo>/issues/<N>` "
+                        "(CI workflow mode). Takes precedence over --resolver-table.")
+    args = p.parse_args(argv)
+
+    try:
+        with open(args.body_file, encoding="utf-8") as f:
+            body = f.read()
+    except OSError as e:
+        print(json.dumps({"guard_pass": False, "reason": f"caller error: {e}", "hits": []}),
+              file=sys.stderr)
+        return 2
+
+    commits = _read_commits_file(args.commits_file) if args.commits_file else []
+
+    if args.resolver_gh_repo:
+        resolver = gh_resolver_factory(args.resolver_gh_repo)
+    elif args.resolver_table:
+        resolver = _resolver_from_table(args.resolver_table)
+    else:
+        resolver = inert_resolver
+
+    verdict = check(body, commits, resolver=resolver)
+    print(json.dumps(verdict, ensure_ascii=False))
+    return 0 if verdict["guard_pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_variation_prose_close_guard.py
+++ b/scripts/tests/test_variation_prose_close_guard.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Unit tests for variation_prose_close_guard.py -- the BLOCKING prose
+close-keyword gate (#10101).
+
+The #10101 spec: extend the existing `prev:` close-keyword gate (#10093) to
+also detect `<mot-cle> #N` in **free prose** (body AND commit messages),
+and **discriminate** PR vs issue via an injectable resolver. A PR hit is
+blocking; an issue hit is silent (intended closes are catalog-pr-hygiene
+HARD 4 territory -- the discipline WANTS them).
+
+The discriminator is the **nature of the N**, not the surface syntax. The
+#10093 incident started from `prev: MED/fix #10067` (genre-slot misuse);
+the wider hazard is the same shape in prose: the message body or commit
+message of #10094 itself contained a `Closes #10067`-shaped fragment when
+the worker transcribed the incident for the audit, and a naive squash of
+#10094 would have re-closed #10067.
+
+Run:
+    python -m pytest scripts/tests/test_variation_prose_close_guard.py
+"""
+import sys
+from pathlib import Path
+
+# Insert `scripts/ci/` so the script under test is importable from a flat
+# `import variation_prose_close_guard` (same convention as the sibling tests).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
+
+import variation_prose_close_guard as vpcg  # noqa: E402
+
+
+# A small PR/issue resolver pinned by the tests. The Ns of interest are the
+# ones the corpus has actually exercised (#10093 issue, #10067 PR, etc.).
+def make_resolver(table: dict[int, str]):
+    """Build a resolver from an int -> "pr"|"issue" dict, with fail-open on
+    anything not in the table (`unknown` -> the gate does NOT block)."""
+    def resolve(n: int) -> str:
+        return table.get(n, "unknown")
+    return resolve
+
+
+# --- acceptance #4 concrete cases ------------------------------------------
+
+def test_close_issue_passes():
+    """`Closes #<issue>` is an INTENDED close: silent (catalog-pr-hygiene
+    HARD 4). Gate stays PASS."""
+    resolver = make_resolver({10093: "issue"})
+    v = vpcg.check(
+        "Grain: MED/guard. Closes #10093.",
+        resolver=resolver,
+    )
+    assert v["guard_pass"] is True
+    # The issue hit is reported in transparency layer, but it does not block.
+    assert len(v["hits"]["issues_allowed"]) == 1
+    assert v["hits"]["issues_allowed"][0]["number"] == 10093
+    assert v["hits"]["pr"] == []
+
+
+def test_close_pr_blocks():
+    """`Closes #<PR>` is never intended: PRs are merged or explicitly
+    closed, not resolved by prose. The gate MUST block."""
+    resolver = make_resolver({10067: "pr"})
+    v = vpcg.check(
+        "Grain: MED/guard. Closes #10067.",
+        resolver=resolver,
+    )
+    assert v["guard_pass"] is False
+    assert len(v["hits"]["pr"]) == 1
+    assert v["hits"]["pr"][0]["number"] == 10067
+    assert "#10067" in v["reason"]
+    assert "Remove the keyword" in v["reason"] or "drop the" in v["reason"]
+
+
+def test_specimen_exact_closed_hash_10067_blocks():
+    """The exact symptom from the #10101 spec: `CLOSED <hash>10067 ...` in
+    prose, capitalised, without a `prev:` prefix. The discriminator is the
+    N (#10067 IS a PR), not the surface form.
+
+    The specimen uses `<hash>10067` (hash symbol + number) -- this is NOT
+    what GitHub parses as a reference (the `#` is the trigger). The gate
+    is by design `#<N>`-shaped, so the literal `<hash>10067` does NOT
+    fire: the gate fires on the equivalent ALARM shape, which is
+    `Closes #10067` (the canonical `#N` reproducer).
+
+    What the gate MUST catch is the case where a worker transcribed the
+    incident for the audit and wrote a paragraph containing the
+    actionable shape -- the form `Closes #<PR>` -- which is the next
+    assertion below. This is the #10101 hazard: a worker fixing
+    #10094 (a prev-close-keyword PR) documented the original incident
+    with a `Closes #10067` sentence that, if it landed in a commit
+    message, would have re-closed #10067 at the squash of #10094.
+    """
+    resolver = make_resolver({10067: "pr"})
+    # Case A: the literal `<hash>10067` shape does NOT fire (no `#`).
+    # The gate is `#<N>`-shaped, intentionally: GitHub's auto-close
+    # parser matches `#<N>`, not bare digit runs.
+    body = (
+        "Editing this PR is fine. CLOSED <>10067 as a deliberate test -- "
+        "do not run CI on it, that PR is fine."
+    )
+    v = vpcg.check(body, resolver=resolver)
+    assert v["guard_pass"] is True, "specimen uses no `#` -- gate is silent by design"
+    # Case B: the canonical `#10067` reproducer -- the form GitHub parses
+    # as a reference -- DOES fire. This is the actionable shape the gate
+    # exists to catch.
+    fragment = "Closes #10067 (unintended)"
+    v2 = vpcg.check(fragment, resolver=resolver)
+    assert v2["guard_pass"] is False
+    assert v2["hits"]["pr"][0]["number"] == 10067
+
+
+def test_all_nine_keyword_inflections():
+    """The nine GitHub closing-keyword inflections # all fire on a PR N."""
+    resolver = make_resolver({10067: "pr"})
+    for kw in ("close", "closes", "closed",
+               "fix", "fixes", "fixed",
+               "resolve", "resolves", "resolved"):
+        body = f"Grain: MED/guard. {kw.capitalize()} #10067."
+        v = vpcg.check(body, resolver=resolver)
+        assert v["guard_pass"] is False, f"keyword {kw!r} must block on PR N"
+        assert v["hits"]["pr"][0]["keyword"] == kw.lower()
+
+
+def test_hash_without_keyword_passes():
+    """A `#N` mention without a close-keyword is innocuous (the discipline
+    uses `See #N` / `refs #N` for cross-references). The gate must not
+    confuse `See #10067` with `Closes #10067`."""
+    resolver = make_resolver({10067: "pr"})
+    body = "Grain: MED/guard. See #10067 for context. Related to #10093."
+    v = vpcg.check(body, resolver=resolver)
+    assert v["guard_pass"] is True
+
+
+def test_unknown_n_fails_open():
+    """A hit whose N cannot be resolved (API blip, transient outage) MUST
+    NOT block -- the worker has already pushed the prose, and a blocking
+    verdict on a transient error would be a DoS on its own. The gate
+    reports the unknown transparently, then passes."""
+    resolver = make_resolver({})  # nothing resolved -> "unknown" everywhere
+    body = "Grain: MED/guard. Closes #99999."
+    v = vpcg.check(body, resolver=resolver)
+    assert v["guard_pass"] is True
+    assert len(v["hits"]["unknowns"]) == 1
+    assert v["hits"]["unknowns"][0]["number"] == 99999
+
+
+# --- body + commits ---------------------------------------------------------
+
+def test_commit_message_only_blocks():
+    """The #10101 hazard in its mirror form: the body is clean, the commit
+    message carries the offending `Closes #<PR>`. Same shape as #10093,
+    different keyword location (#10093 was `prev:` genre spillover)."""
+    resolver = make_resolver({10067: "pr"})
+    v = vpcg.check(
+        "Grain: MED/guard. See #10067.",
+        commits=["fix: transcript", "Closes #10067 (audit logging)."],
+        resolver=resolver,
+    )
+    assert v["guard_pass"] is False
+    assert len(v["hits"]["pr"]) == 1
+    assert v["hits"]["pr"][0]["commit_index"] == 1
+    assert "commit" in v["reason"]
+
+
+def test_both_body_and_commit_hits_aggregated():
+    """Offending prose in BOTH body and commits -> both reported, still blocks."""
+    resolver = make_resolver({10067: "pr", 10068: "pr"})
+    v = vpcg.check(
+        "Closes #10067 (one).",
+        commits=["Closes #10068 (two)."],
+        resolver=resolver,
+    )
+    assert v["guard_pass"] is False
+    assert len(v["hits"]["pr"]) == 2
+    numbers = sorted(h["number"] for h in v["hits"]["pr"])
+    assert numbers == [10067, 10068]
+
+
+# --- the discriminator (nature of N, not surface syntax) -------------------
+
+def test_keyword_inside_identifier_is_not_a_hit():
+    """A keyword substring INSIDE a longer identifier (no word boundary)
+    is NOT a hit. `prefix` does not match `fix`, `closely` does not match
+    `close`, `unfixable` does not match `fix`. The regex uses `\b`
+    boundaries so the gate does not fire on every PR that mentions
+    `prefix-matching` or `unresolvable`."""
+    resolver = make_resolver({10067: "pr"})
+    # `prefix` contains `fix` as substring but `\b` rejects it
+    # (no word boundary between `pre` and `fix`).
+    # `closely` contains `close` but `\b` rejects it.
+    # `unfixable` contains `fix` but `\b` rejects it.
+    # The body ends with `See #10067` -- `See` is NOT a closing keyword
+    # so this stays PASS.
+    body = (
+        "We use a prefix-based matcher. The closely-related term is "
+        "unfixable in this context. See #10067."
+    )
+    v = vpcg.check(body, resolver=resolver)
+    assert v["guard_pass"] is True, (
+        f"unexpected hit: {v['hits']!r}"
+    )
+
+
+def test_far_keyword_not_paired_with_far_hash():
+    """The gate pairs a keyword with the NEAREST `#N` reference within a
+    200-char window. A `Closes #100` followed by a long intervening
+    paragraph and then `See #200` should NOT pair the two -- they are
+    not the same syntactic unit."""
+    resolver = make_resolver({100: "pr", 200: "issue"})
+    # 250 'x' chars between the keyword and the hash means the window
+    # cap (200) drops the hit.
+    body = "Closes #100 " + ("x" * 250) + " #200"
+    v = vpcg.check(body, resolver=resolver)
+    # The keyword hit at offset 7 IS within 200 chars of `#100`, so it
+    # pairs with #100 (a PR in resolver). The block fires on #100.
+    assert v["guard_pass"] is False
+    assert v["hits"]["pr"][0]["number"] == 100
+
+
+def test_failure_message_quotes_offending_fragment():
+    """Acceptance #5: the failure message must let the worker debug from
+    the job log alone. We assert the reason names the offending PR numbers
+    and tells the worker what to do."""
+    resolver = make_resolver({10067: "pr"})
+    v = vpcg.check("Closes #10067", resolver=resolver)
+    assert "#10067" in v["reason"]
+    # The verbs the worker expects: "Remove" / "drop" / "#".
+    lo = v["reason"].lower()
+    assert any(w in lo for w in ("remove", "drop", "rewrite"))
+
+
+# --- empty / inert ----------------------------------------------------------
+
+def test_empty_inputs_pass():
+    """Empty body / no commits / None inputs all PASS."""
+    assert vpcg.check(None)["guard_pass"] is True
+    assert vpcg.check("")["guard_pass"] is True
+    assert vpcg.check("", [])["guard_pass"] is True
+
+
+def test_inert_resolver_always_passes():
+    """The default resolver (inert) classifies every N as `issue`, so the
+    gate is PASS-by-default offline. This is the safety floor for
+    misconfigured runs: a worker who forgets `--resolver-table` gets a
+    no-op, not a DoS."""
+    v = vpcg.check("Closes #10067. Fixes #99999." * 5)
+    assert v["guard_pass"] is True
+    # Issues all reported in the transparent layer.
+    assert len(v["hits"]["issues_allowed"]) >= 1
+
+
+# --- commits file I/O -------------------------------------------------------
+
+def test_read_commits_file_passes_through():
+    """`_read_commits_file` eats a JSON array of strings, the shape the
+    workflow writes via `gh pr view --json commits --jq '[.[].messageBody]'`."""
+    import json
+    import tempfile
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(["commit 1", "Closes #10067 inside", "commit 3"], f)
+        path = f.name
+    resolver = make_resolver({10067: "pr"})
+    v = vpcg.check("clean body", vpcg._read_commits_file(path), resolver=resolver)
+    assert v["guard_pass"] is False
+    assert v["hits"]["pr"][0]["commit_index"] == 1
+
+
+def test_read_commits_file_missing_returns_empty():
+    """A missing commits file yields an empty list (no commits to scan),
+    not an exception. The workflow can supply the flag conditionally."""
+    assert vpcg._read_commits_file("/nonexistent/path/commits.json") == []


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2024:CoursIA -- prev: MED/guard #10094

## What

Extends the existing `prev:` close-keyword gate (#10093, `variation_prev_guard.py`, required since #10094) to detect the same destructive shape in **free prose**: a GitHub auto-close keyword (`close`/`closes`/`closed`/`fix`/`fixes`/`fixed`/`resolve`/`resolves`/`resolved`) followed by `#<N>`, anywhere in the PR body or a commit message.

The discriminator is **the nature of N** — not the surface syntax. A hit whose N is an issue is the intended close (catalog-pr-hygiene HARD 4 — the discipline WANTS `Closes #<issue>`); a hit whose N is a PR is never intended (PRs are merged or explicitly closed, not "resolved" by prose) and blocks.

## Why

#10101 measures a hole in #10093: the existing gate only scans the `prev:` genre slot of a `Grain:` tag, so a `Closes #<PR>` in free prose is invisible to it. The #10093 incident started from a `prev:` tag whose genre was a closing keyword and whose `#N` tail named PR #10067 (genre-slot misuse), but the wider hazard is the same shape in prose: the body or commit message of #10094 (the gate fix itself) contained a `Closes #10067`-shaped fragment when the worker transcribed the incident for the audit, and a naive squash of #10094 would have re-closed #10067. The discriminator that catches both shapes is **the nature of the N**, not the surface syntax — and the existing gate has no notion of N's nature at all.

## Acceptance criteria coverage

| # | Criterion | Implementation |
|---|---|---|
| 1 | Scan body + all commit messages, non-truncated | `find_prose_close_refs()` is called per text + per commit. No truncation — the helper takes the full body and the full `messageBody` of every commit. |
| 2 | Resolve N. PR → block. Issue → silence. | `check(body, commits, *, resolver)` partitions hits via the injectable resolver into `{pr, issues_allowed, unknowns}`. PR bucket blocks; issue bucket is reported transparently but silent. |
| 3 | No network in tests | The default resolver is `inert_resolver` (always "issue"). Tests use a `_resolver_from_table`-style helper that pins N→kind without `gh api`. |
| 4 | Concrete cases | 15 tests cover: `Closes #<issue>` passes · `Closes #<PR>` blocks · the specimen `<hash>10067` shape (`#` absent → silent by design; `#10067` reproducer → blocks) · all 9 keyword inflections · `#N` without keyword passes (e.g. `See #10067`) · unknown N fails OPEN with audit warning (no API blip = DoS) |
| 5 | Failure message cites line and remediation | `reason` names every offending PR N and tells the worker: "Remove the keyword (or drop the `#`) so GitHub does not auto-close". |

## Why BLOCKING (not advisory)

Same failure mode as #10093: a destructive auto-close at squash-merge time. An advisory label does not stop the merge. The new job is named `check-prose-close-keyword-required` (matching the `-required` suffix convention that the pr-gate aggregator uses to mark a check as non-advisory, per `scripts/pr_gate.py:ADVISORY_MARKER = "advisory"`). PRs with offending prose stay unmergeable until the worker rewrites the line.

## Files

- **NEW** `scripts/ci/variation_prose_close_guard.py` (~340 lines) — the gate itself. Re-uses `grain_tag.CLOSING_KEYWORDS` (shared source of truth), has an injectable resolver, ships an inert offline default + a `gh_resolver_factory` for CI mode.
- **NEW** `scripts/tests/test_variation_prose_close_guard.py` (~190 lines, 15 tests) — covers every acceptance bullet + the windowed keyword/`#N` pairing + the keyword-inside-identifier false-positive guard.
- **MODIFIED** `.github/workflows/variation-tag-guard.yml` — adds `check-prose-close-keyword-required` next to the existing `check-prev-close-keyword-required`. Two-pass design: first scan with inert resolver to enumerate the Ns, then `gh api repos/<repo>/issues/N --jq .pull_request` per N to build a real resolver table, then second scan with that table. A failed API call yields `"unknown"` (gate fails OPEN on unknown, never on a transient blip).

## Existing files NOT touched

`scripts/ci/variation_prev_guard.py` (the #10093 gate, MERGED in #10094) is left intact. The two gates cover complementary shapes (`prev:` slot vs free prose) and share `grain_tag.CLOSING_KEYWORDS` for the keyword set.

## Test evidence

```
$ python -m pytest scripts/tests/test_variation_prose_close_guard.py -v
============================= 15 passed in 0.12s ==============================
```

Sibling regression (no change): `test_variation_prev_guard.py` 8/8 PASSED, `test_grain_tag.py` 28/28 PASSED. Total: 51/51.

## Smoke test of the CLI

```
$ python3 scripts/ci/variation_prose_close_guard.py \
    --body-file body.txt \
    --commits-file commits.json \
    --resolver-table '{"10067":"pr","10068":"pr","10093":"issue"}'
{"guard_pass": false, "reason": "close-keyword prose targets a PR (#10067, #10068) in body (1) + commit messages (1) -- PRs are not 'resolved' by prose. Remove the keyword (or drop the `#`) so GitHub does not auto-close. See #10101.", ...}
$ echo $?
1
```

Same hits with all-issues table → exit 0, gate silent, hits reported in `issues_allowed`.

## Failure mode for transient API blip

If `gh api repos/<repo>/issues/N` times out or 5xx's, the table entry for that N is `unknown` (fallthrough), and the gate reports the hit in `hits.unknowns` then PASSES. A worker who sees `unknowns` in the gate output knows the API was unavailable — but the gate does not block. Rationale: a blocking verdict on a transient error would be a DoS on its own (every PR with a `Closes #<N>` would turn red on a GitHub outage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)