### PR TITLE
feat(notebook-tools,#9434): scan_quant_classify FP guard v6 — slug/citation/count-noun (residual after v5 #10062)

### DIFF
--- a/scripts/notebook_tools/scan_quant_classify.py
+++ b/scripts/notebook_tools/scan_quant_classify.py
@@ -357,6 +357,43 @@ def _classify_quant_value(
     if re.search(r"\d+\s*h\s*[+=]\s*\d+\s*h", ctx_with_raw):
         return ("STRUCTUREL", "arithmétique horloge v5 (Nh ± = Nh, exemple math)")
 
+    # -1b v6 (c.1331+15, #9434): anti-FP résiduel — 3 nouvelles classes mesurées
+    #     firsthand sur GT-1-Setup + PyMC-1-Setup NON couvertes par v4 (#10016) ni
+    #     v5 (#10062). Même asymétrie failure-mode-safe que v4/v5 : ces guards
+    #     absorbent UNIQUEMENT vers STRUCTUREL (jamais vers drainable), donc un
+    #     guard trop large = garder une vraie valeur en STRUCTUREL = sur-correction
+    #     inoffensive (pas de corruption de drain). Falsification tests
+    #     (TestFpGuardV6) prouvent qu'un genuine ENV "NumPy 2.4.4" et un genuine
+    #     STOCH "accuracy 0.87" restent drainables.
+    #
+    #     IMPORTANT — ce que v6 NE touche pas : les version-adjacents ("python
+    #     3.10+", "numpy 2.x") restent ENV-DEP légitimes (test_10012_falsif_python
+    #     _semver_kept : un floor/wildcard de version DÉRIVE quand la lib évolue —
+    #     3.10+ → 3.13+ — donc est env-drift-prone par design). v6 ne cible que les
+    #     valeurs NON-version rattrapées par proximité de mot-clé.
+    s_l = suffix.lstrip()
+    p_r = prefix.rstrip()
+    # (B) Cross-ref nom de notebook : "voir pymc-6-debugging" = le chiffre est le
+    #     slug d'un notebook voisin, pas une version. Mesuré : PyMC-1-Setup
+    #     cell[16] "pymc-6-debugging" → ENV-DEP via kw 'version'.
+    if re.search(r"[a-z0-9]-$", p_r, re.I) and re.match(r"-\s*[a-z]", s_l, re.I):
+        return ("STRUCTUREL", "cross-ref slug v6 (\\w-N-\\w: nom notebook/fichier)")
+    # (A) Citation bibliographique : "Physics Letters B, 195(2), 216-222" = les
+    #     chiffres sont vol/issue/pages d'une réf journal, pas des mesures. Le
+    #     pattern Vol(Issue), pages est non-ambigu. Mesuré : PyMC-1-Setup
+    #     cell[25] "195(2)" → STOCHASTIQUE via kw 'Monte Carlo' (titre du papier).
+    if re.search(r"\d+\s*\(\s*\d+\s*\)\s*,\s*\d+\s*[-–]\s*\d+",
+                 prefix + " " + raw + " " + suffix):
+        return ("STRUCTUREL", "citation biblio v6 (Vol(Issue), pages: réf journal)")
+    # (F) Compteur structurel : "randomiser sur ses 3 actions", "5 candidats" =
+    #     N est la cardinalité d'un ensemble fini du domaine, pas une mesure
+    #     stochastique (le tirage porte SUR les N, N lui-même est fixe). Mesuré :
+    #     GT-1-Setup cell[60] "3 actions" → STOCHASTIQUE via kw 'random'.
+    if re.match(r"(?:actions?|choix|strat[eé]gies?|candidats?|joueurs?|players?|"
+                r"[eé]tats?|[eé]tapes?|coups?|moves?|dimensions?|attributs?|"
+                r"features?|classes?)\b", s_l, re.I):
+        return ("STRUCTUREL", "compteur structurel v6 (N <count-noun>: cardinalité)")
+
     # -1 (c.1301+12): anti-FP ML/DfA + Search/Part1 — guard structurel v4
     #     (4 classes : editorial-duration / biblio / section-number /
     #     theoretical-reference). Capture les FPs AVANT que les mots-cles

--- a/scripts/notebook_tools/tests/test_scan_quant_classify.py
+++ b/scripts/notebook_tools/tests/test_scan_quant_classify.py
@@ -685,6 +685,146 @@ class TestV5NumberedListAndClockArithmetic:
         )
 
 
+class TestFpGuardV6:
+    """Guards v6 (c.1331+15, #9434) — residuel apres v4 (#10016) + v5 (#10062).
+
+    3 classes de FP residuels mesurees firsthand sur GT-1-Setup + PyMC-1-Setup :
+    valeurs NON-version rattrapees par proximite de mot-cle, que v4/v5 ne couvraient
+    pas (elles ciblent les listes numerotees / arithmetique horloge, pas ces cas).
+    Meme asymetrie failure-mode-safe : absorption UNIQUEMENT vers STRUCTUREL.
+
+    IMPORTANT — ce que v6 NE touche PAS : les version-adjacents ("python 3.10+",
+    "numpy 2.x") restent ENV-DEP legitimes (test_10012_falsif_python_semver_kept :
+    un floor/wildcard de version DERIVE quand la lib evolue, donc env-drift-prone).
+    """
+
+    # -- (B) Cross-ref slug de notebook ------------------------------------- #
+
+    def test_v6_notebook_slug_cross_ref(self):
+        """PyMC-1-Setup c16: "pymc-6-debugging" = slug d'un notebook voisin, pas une version.
+
+        Le 6 est le numero du notebook dans le slug (pymc-6-debugging), rattrape
+        par le kw 'version' dans le contexte environnant. Le guard reconnait le
+        pattern <alnum>-<N>-<alnum> (lettre/chiffre - tiret - lettre).
+        """
+        cls, _ = _classify_quant_value("6", 6.0,
+                                       "pymc-", "-debugging pour le debug")
+        assert cls == "STRUCTUREL", (
+            f"slug de notebook (\\w-N-\\w) doit etre STRUCTUREL, got {cls}"
+        )
+
+    def test_v6_file_ref_slug(self):
+        """Cross-ref fichier : "voir data-2-preprocessed.csv" = le 2 est dans un nom de fichier."""
+        cls, _ = _classify_quant_value("2", 2.0,
+                                       "voir data-", "-preprocessed.csv")
+        assert cls == "STRUCTUREL", (
+            f"slug de fichier (\\w-N-\\w) doit etre STRUCTUREL, got {cls}"
+        )
+
+    # -- (A) Citation bibliographique --------------------------------------- #
+
+    def test_v6_journal_citation_vol_issue_pages(self):
+        """PyMC-1-Setup c25: "Physics Letters B, 195(2), 216-222" = ref journal.
+
+        Le pattern Vol(Issue), pages est non-ambigu : 195(2) = vol 195, issue 2 ;
+        216-222 = pages. Les chiffres sont ceux d'une reference, pas des mesures.
+        Rattrape par kw 'Monte Carlo' (titre du papier cite).
+        """
+        cls, _ = _classify_quant_value("195", 195.0,
+                                       "physics letters b, ", "(2), 216-222")
+        assert cls == "STRUCTUREL", (
+            f"citation journal (Vol(Issue), pages) doit etre STRUCTUREL, got {cls}"
+        )
+
+    def test_v6_journal_citation_secondary_page_number(self):
+        """Le 216 dans la meme citation doit aussi etre absorbe (pages)."""
+        cls, _ = _classify_quant_value("216", 216.0,
+                                       "(2), ", "-222 (duane et al. 1987)")
+        assert cls == "STRUCTUREL", (
+            f"numero de page dans citation Vol(Issue),pages doit etre STRUCTUREL, got {cls}"
+        )
+
+    # -- (F) Compteur structurel (cardinalite d'un ensemble fini) ----------- #
+
+    def test_v6_structural_count_actions(self):
+        """GT-1-Setup c60: "randomiser sur ses 3 actions" = N est la cardinalite.
+
+        Le tirage porte SUR les 3 actions ; le 3 lui-meme est fixe (cardinalite de
+        l'ensemble des actions), pas une mesure stochastique. Rattrape par kw 'random'.
+        """
+        cls, _ = _classify_quant_value("3", 3.0,
+                                       "randomiser sur ses ", " actions")
+        assert cls == "STRUCTUREL", (
+            f"compteur structurel (N actions) doit etre STRUCTUREL, got {cls}"
+        )
+
+    def test_v6_structural_count_players(self):
+        """Autre compteur : "5 joueurs participent au jeu" = cardinalite fixe."""
+        cls, _ = _classify_quant_value("5", 5.0,
+                                       "ces ", " joueurs participent")
+        assert cls == "STRUCTUREL", (
+            f"compteur structurel (N joueurs) doit etre STRUCTUREL, got {cls}"
+        )
+
+    def test_v6_structural_count_dimensions(self):
+        """Compteur technique : "vecteur de 10 dimensions" = cardinalite fixe."""
+        cls, _ = _classify_quant_value("10", 10.0,
+                                       "un vecteur de ", " dimensions")
+        assert cls == "STRUCTUREL", (
+            f"compteur structurel (N dimensions) doit etre STRUCTUREL, got {cls}"
+        )
+
+    # -- Falsification : genuine drainables ne sont PAS absorbes (anti-FN) -- #
+
+    def test_v6_genuine_semver_still_env_dep(self):
+        """Falsification : "numpy 2.4.4" (version pincee) reste ENV-DEP.
+
+        Un semver X.Y.Z adjacent a un mot-cle env est env-drift-prone (la lib
+        bouge). v6 ne touche QUE les valeurs NON-version.
+        """
+        cls, _ = _classify_quant_value("2.4.4", 2.44,
+                                       "numpy ", " installe")
+        assert cls == "ENV-DEP", (
+            f"version pincee 'numpy 2.4.4' doit rester ENV-DEP, got {cls}"
+        )
+
+    def test_v6_genuine_version_floor_still_env_dep(self):
+        """Falsification : "python 3.10+" (floor) reste ENV-DEP (deja valide #10012).
+
+        Le floor DERIVE quand Python evolue (3.10+ -> 3.13+). v6 ne l'absorbe PAS.
+        """
+        cls, _ = _classify_quant_value("3.10", 3.10,
+                                       "python ", "+ (jupyter env)")
+        assert cls == "ENV-DEP", (
+            f"floor de version 'python 3.10+' doit rester ENV-DEP, got {cls}"
+        )
+
+    def test_v6_genuine_accuracy_still_stoch(self):
+        """Falsification : "accuracy de 0.87" reste STOCHASTIQUE (mesure reelle).
+
+        0.87 est une mesure de performance stochastique (depend du seed/sample),
+        pas un compteur structurel (n'est pas prefixe d'un count-noun au suffix).
+        """
+        cls, _ = _classify_quant_value("0.87", 0.87,
+                                       "une accuracy de ", " sur le test set")
+        assert cls == "STOCHASTIQUE-NON-SEEDEE", (
+            f"mesure stochastique 'accuracy 0.87' doit rester drainable, got {cls}"
+        )
+
+    def test_v6_count_noun_requires_adjacency(self):
+        """Falsification : "3" sans count-noun adjacent n'est pas auto-absorbe.
+
+        Un "3" isole (ex: "resultat = 3") tombe sur sa vraie classe via le contexte,
+        il n'est pas absorbe juste parce qu'il est entier. Isole le comportement du
+        guard (F) qui exige un count-noun EN SUFFIXE immediat.
+        """
+        cls, rat = _classify_quant_value("3", 3.0,
+                                         "resultat = ", " apres convergence")
+        assert "cardinalité" not in rat and "cardinalit" not in rat.lower(), (
+            f"'3' sans count-noun ne doit pas declencher le guard (F), rationale={rat!r}"
+        )
+
+
 # --------------------------------------------------------------------------- #
 #  Tests _extract_context
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
feat(notebook-tools,#9434): scan_quant_classify FP guard v6 — slug/citation/count-noun (residual after v5 #10062)

Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: LIGHT/security PR-10076

## Quoi

3e passe d'anti-FP sur le scanner canon de l'Epic #9434 (quantitatif tenu par le CI).
v4 (#10016) couvrait listes numérotées + sections ; v5 (#10062) couvrait arithmétique
horloge. v6 cible 3 classes résiduelles mesurées firsthand sur GT-1-Setup +
PyMC-1-Setup : valeurs NON-version rattrapées par proximité de mot-clé, que v4/v5
ne couvraient pas. +37 lignes scanner, +140 lignes tests (11 nouveaux).

Les 3 guards v6 (failure-mode-safe : absorbent UNIQUEMENT vers STRUCTUREL, jamais
vers drainable — donc un guard trop large = sur-correction inoffensive, pas de
corruption du drain) :
- (B) cross-ref slug de notebook : "pymc-6-debugging" → le 6 est le slug d'un
  notebook voisin (pattern <alnum>-<N>-<alnum>), pas une version. Mesuré
  PyMC-1-Setup cell[16].
- (A) citation bibliographique : "195(2), 216-222" = Vol(Issue),pages d'une réf
  journal (pattern non-ambigu), pas des mesures. Mesuré PyMC-1-Setup cell[25]
  (papier Duane et al. HMC), rattrapé par kw 'Monte Carlo'.
- (F) compteur structurel : "randomiser sur ses 3 actions", "5 joueurs" = N est la
  cardinalité d'un ensemble fini (le tirage porte SUR les N, N lui-même est fixe).
  Mesuré GT-1-Setup cell[60].

## Preuve

- **81 tests passent** (70 existants + 11 nouveaux TestFpGuardV6), 0 échec, 0
  SyntaxWarning. Les 11 nouveaux = 7 positifs (3 FPs × variantes → STRUCTUREL) +
  4 falsification anti-FN (genuine "numpy 2.4.4" reste ENV-DEP, genuine "python
  3.10+" reste ENV-DEP #10012, genuine "accuracy 0.87" reste STOCHASTIQUE, "3" sans
  count-noun n'est pas auto-absorbé).
- **G.9 self-correction documentée** : première itération incluait 2 guards
  supplémentaires (C "+" floor, D ".x" wildcard) qui SUPPRIMAIENT du genuine
  ENV-DEP ("python 3.10+"), cassant 2 tests de falsification existants
  (test_10012_falsif_python_semver_kept, test_c1301_23_no_regression_v4_guard_kept).
  Les tests ont PRÉVENU la régression. v6 final NE touche pas aux version-adjacents
  (floor/wildcard/pin dérivent quand la lib évolue = env-drift-prone par design).
- **Re-scan firsthand** : GT-1-Setup ENV-DEP 2→2 (3.9+, 2.x = genuine, préservés) +
  STOCH 2→1 (cell[60] "3 actions" absorbé, 1 résiduel cell[43] "0 et 1" alphabet
  binaire — diminishing returns à guarder) ; PyMC-1-Setup ENV-DEP 2→1 (slug
  absorbé, "5.x" genuine préservé) + STOCH 1→0 (citation absorbée).
- **0 deletion** (purement additif : guard + tests). Pas de risque anti-régression.

## Périmètre

- **2 fichiers** (+177 lignes, 0 suppression) : scanner + tests. 1 sujet
  (anti-FP résiduel du canon #9434). Pas un composite.
- **Collision-guard** : 0 PR OPEN sur scan_quant_classify ; base fraîche (issue de
  origin/main 0f0ac3dc5, dernière modif #10062 v5), 0 divergence. Catalogue
  byte-identique à main.
- **Honnêteté** : 1 résiduel STOCH FP (GT cell[43] "0 et 1", alphabet binaire)
  délibérément non-guardé — un guard "value in (0,1)" serait catastrophique
  (absorberait tout 0/1 du corpus). Rendement marginal, risque élevé = hors scope.
- **Variété R6.6** : registre CI-tooling (scanner FP-reduction), distinct des
  path-leak scrubs du cycle précédent (LIGHT/security PR-10076).

See #9434 (quantitatif tenu par le CI) · Builds on v4 #10016 + v5 #10062 · Tracker #10012

Co-Authored-By: Claude-Code <noreply@anthropic.com>
