### PR TITLE
refactor(translation,#10109): TARGET_LANGS single source of truth — collapse 8 duplicates

### DIFF
--- a/.github/workflows/translation-drift.yml
+++ b/.github/workflows/translation-drift.yml
@@ -75,8 +75,8 @@ jobs:
           # surface it into the PR annotation so a SRC_DRIFT=0 on a 0%-translated
           # table can no longer read as "up to date" at the merge gate (#8678:
           # a bare count perishes, a count plus its denominator self-contradicts).
-          FILL_SUMMARY="$(echo "$REPORT" | python -c 'import sys,json; gf=json.load(sys.stdin).get("fill_rate",{}).get("global",{}); t=["en","es","ar","fa","zh","ru","pt"]; print(" ".join("%s=%s%%" % (l, gf.get(l,{}).get("pct",0.0)) for l in t))')"
-          ANY_FILLED="$(echo "$REPORT" | python -c 'import sys,json; gf=json.load(sys.stdin).get("fill_rate",{}).get("global",{}); t=["en","es","ar","fa","zh","ru","pt"]; print(any(gf.get(l,{}).get("filled",0)>0 for l in t))')"
+          FILL_SUMMARY="$(echo "$REPORT" | python -c 'import sys,json; sys.path.insert(0,"scripts/translation"); from check_perimeter import TARGET_LANGS as t; gf=json.load(sys.stdin).get("fill_rate",{}).get("global",{}); print(" ".join("%s=%s%%" % (l, gf.get(l,{}).get("pct",0.0)) for l in t))')"
+          ANY_FILLED="$(echo "$REPORT" | python -c 'import sys,json; sys.path.insert(0,"scripts/translation"); from check_perimeter import TARGET_LANGS as t; gf=json.load(sys.stdin).get("fill_rate",{}).get("global",{}); print(any(gf.get(l,{}).get("filled",0)>0 for l in t))')"
           if [ "$COUNT" = "0" ]; then
             if [ "$ANY_FILLED" = "True" ]; then
               echo "::notice title=Translation sync::All translation CSVs in sync with notebooks. No drift. (fill rate: $FILL_SUMMARY)"

--- a/.github/workflows/translation-guard.yml
+++ b/.github/workflows/translation-guard.yml
@@ -68,7 +68,8 @@ jobs:
           # 3-dot diff: translation-owned files changed on the PR branch.
           # translations/** = sync CSVs (derived). *_<lang>.ipynb = rendered
           # translation notebooks (derived by render_notebook.py T4). Target
-          # langs match translate_csv.py TARGETS (en/ru/pt/es/ar/fa/zh).
+          # langs match check_perimeter.py TARGET_LANGS (en/es/ar/fa/zh/ru/pt),
+          # the single source of truth (#10109).
           CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- \
             'translations/**' \
             'MyIA.AI.Notebooks/**/*_en.ipynb' \

--- a/scripts/translation/check_perimeter.py
+++ b/scripts/translation/check_perimeter.py
@@ -87,6 +87,15 @@ from typing import Dict, List, Optional, Set, Tuple
 # Langs tracked by the CSV schema (ratified #4957 §1). Order matches the
 # schema header : text_<lang> columns in CSV order, with hash_<lang> after.
 # The pivot lang ('fr') is always in-scope by construction (T1 extracts it).
+#
+# SINGLE SOURCE OF TRUTH (#10109). ``TARGET_LANGS`` is the ONLY place the
+# ordered universe of 7 target languages may live as a literal. Every other
+# site (translate_csv.TARGETS, check_resync_only.ALL_LANGS, the T4 step in
+# translation-sync.yml) MUST consume it from here -- a duplicated list with a
+# different order is a latent silent bug (any positional ``zip``/``enumerate``
+# across two copies swaps translations without raising). The regression guard
+# ``scripts/translation/tests/test_lang_single_source.py`` fails if a
+# language-list literal reappears outside this module.
 PIVOT_LANG = "fr"
 TARGET_LANGS = ["en", "es", "ar", "fa", "zh", "ru", "pt"]
 ALL_LANGS = [PIVOT_LANG] + TARGET_LANGS

--- a/scripts/translation/check_resync_only.py
+++ b/scripts/translation/check_resync_only.py
@@ -56,8 +56,14 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
-ALL_LANGS = ("en", "es", "ar", "fa", "zh", "ru", "pt")
-PIVOT_LANG = "fr"
+# Sibling import: the ordered target-language universe is the SINGLE source of
+# truth in ``check_perimeter`` (#10109). ``ALL_LANGS`` here is the 7 target
+# languages (NOT including the 'fr' pivot -- this script's semantics match the
+# ``text_<lang>``/``hash_<lang>`` target columns), in the canonical order.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_perimeter import PIVOT_LANG, TARGET_LANGS  # noqa: E402
+
+ALL_LANGS = tuple(TARGET_LANGS)
 
 # ``translations/...csv`` paths only. Anything else (a notebook .ipynb, a
 # script, a doc) breaks the "resync-only" verdict immediately.

--- a/scripts/translation/check_translation_parity.py
+++ b/scripts/translation/check_translation_parity.py
@@ -82,8 +82,10 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
 # Convention #1650 : un notebook xxx.ipynb source + xxx_<lang>.ipynb traduit.
-# Langues cibles = ratifiees #4957 §1 (meme liste que PERIMETER + sync).
-TARGET_LANGS = ["en", "es", "ar", "fa", "zh", "ru", "pt"]
+# Langues cibles = l'univers ordonné de source unique ``check_perimeter`` (#10109)
+# -- une copie locale divergente est un bug latent silencieux (zip positionnel).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_perimeter import TARGET_LANGS  # noqa: E402  -- single source of truth
 
 # Seuil de longueur pour le verdict FR_CONTAM : un texte trop court (< 4 chars
 # post-normalisation) est un faux-ami structurel (token unique, chiffre, ponctuation).

--- a/scripts/translation/check_translation_sync.py
+++ b/scripts/translation/check_translation_sync.py
@@ -51,10 +51,10 @@ import math
 import sys
 from pathlib import Path
 
-# Doit rester coherent avec extract_cells_to_csv.py (T1).
-PIVOT_LANG = "fr"
-TARGET_LANGS = ["en", "es", "ar", "fa", "zh", "ru", "pt"]
-ALL_LANGS = [PIVOT_LANG] + TARGET_LANGS
+# Doit rester coherent avec extract_cells_to_csv.py (T1) ET check_perimeter.py
+# (source unique de l'univers des langues, #10109) -- pas de copie locale.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_perimeter import ALL_LANGS, PIVOT_LANG, TARGET_LANGS  # noqa: E402
 
 # Plages Unicode du script attendu pour les langues cibles non-Latines.
 # Une cellule text_<lang> deposee dont le contenu ne porte AUCUN caractere de

--- a/scripts/translation/extract_cells_to_csv.py
+++ b/scripts/translation/extract_cells_to_csv.py
@@ -43,8 +43,9 @@ from pathlib import Path
 
 # Langues vivantes côté Argumentum (8 langues, #4957 §1).
 # Le pivot (fr en Phase 0.5) est la source ; les autres sont cibles de traduction.
-PIVOT_LANG = "fr"
-TARGET_LANGS = ["en", "es", "ar", "fa", "zh", "ru", "pt"]
+# L'univers ordonné des cibles vient de la source unique ``check_perimeter`` (#10109).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_perimeter import PIVOT_LANG, TARGET_LANGS  # noqa: E402
 
 # Colonnes du CSV, dans l'ordre ratifié #4957 §1.
 COLUMNS = ["notebook", "cell_id", "cell_type", "src_lang", "src_hash"]

--- a/scripts/translation/multilingual_drift_audit.py
+++ b/scripts/translation/multilingual_drift_audit.py
@@ -57,8 +57,10 @@ from typing import Iterable
 
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-# 7 target languages (matches the CoursIA translation CSV schema + ai-01 mandate).
-LANGS = ["en", "es", "ar", "fa", "zh", "ru", "pt"]
+# 7 target languages = l'univers ordonné de source unique ``check_perimeter``
+# (#10109). Aucune copie locale : une permutation divergente est un bug latent.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from check_perimeter import TARGET_LANGS as LANGS  # noqa: E402
 NON_LATIN = {"ru", "ar", "fa", "zh"}  # langs whose cells should carry non-Latin script
 
 # Drift classes.

--- a/scripts/translation/tests/test_lang_single_source.py
+++ b/scripts/translation/tests/test_lang_single_source.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+r"""Single-source-of-truth tests for the target-language universe (#10109).
+
+Two roles:
+
+1. **Equivalence** -- every consumer's public lang list equals the canonical
+   ``check_perimeter.TARGET_LANGS`` (so a divergence can never re-enter
+   silently).
+
+2. **Regression guard (acceptance #4)** -- FAIL if a language-list literal
+   reappears outside the single source. The detector flags any ``list``/``tuple``
+   literal whose set of string elements is a **superset of the 7 target langs**
+   (i.e. the universe duplicated, possibly permuted -- the exact defect class:
+   a positional ``zip``/``enumerate`` across two copies swaps translations
+   without raising). It scans every ``.py`` under ``scripts/`` (excluding
+   ``tests/`` fixtures and ``check_perimeter.py`` itself) and every ``.yml``
+   under ``.github/`` for the same pattern as adjacent quoted codes.
+
+Why superset-of-7 (not "any 2 lang codes"): a 2- or 3-lang list is a *subset*
+with its own meaning (the RTL pair ``["ar","fa"]``, a non-Latin set), not a
+duplicate of the universe. The defect is the *ordered universe* duplicated --
+7/7. Subsets are out of scope and must stay expressible.
+"""
+import ast
+import re
+import sys
+import warnings
+from pathlib import Path
+
+# scripts/translation/ on the path (tests/ -> parent).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_perimeter as cp  # noqa: E402
+import check_resync_only as cr  # noqa: E402
+import check_translation_parity as ctp  # noqa: E402
+import check_translation_sync as cts  # noqa: E402
+import extract_cells_to_csv as ex  # noqa: E402
+import multilingual_drift_audit as mda  # noqa: E402
+import translate_csv as tc  # noqa: E402
+
+# The canonical universe, pinned ONCE here (the test is allowed to name it; the
+# production code is not). Ratified #4957 §1, CSV-schema column order.
+CANON = ["en", "es", "ar", "fa", "zh", "ru", "pt"]
+LANG_SET = set(CANON)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SINGLE_SOURCE = REPO_ROOT / "scripts" / "translation" / "check_perimeter.py"
+THIS = Path(__file__).resolve()
+
+
+# --- 1. the single source is the canonical ordered universe ------------------
+
+def test_single_source_is_canonical():
+    assert cp.TARGET_LANGS == CANON
+    assert cp.PIVOT_LANG == "fr"
+    assert cp.ALL_LANGS == [cp.PIVOT_LANG] + CANON
+
+
+# --- 1b. every consumer equals the single source -----------------------------
+
+def test_consumers_match_single_source():
+    assert tc.TARGETS == cp.TARGET_LANGS
+    assert cr.ALL_LANGS == tuple(cp.TARGET_LANGS)
+    assert cr.PIVOT_LANG == cp.PIVOT_LANG
+    assert ctp.TARGET_LANGS == cp.TARGET_LANGS
+    assert cts.TARGET_LANGS == cp.TARGET_LANGS
+    assert cts.PIVOT_LANG == cp.PIVOT_LANG
+    assert cts.ALL_LANGS == [cp.PIVOT_LANG] + cp.TARGET_LANGS
+    assert ex.PIVOT_LANG == cp.PIVOT_LANG
+    assert ex.TARGET_LANGS == cp.TARGET_LANGS
+    assert mda.LANGS == cp.TARGET_LANGS
+
+
+# --- 2. regression guard: no universe literal outside the single source -----
+
+def _is_universe_literal(node) -> bool:
+    """True for a ``list``/``tuple`` AST node whose string elements include all
+    7 target langs (the universe duplicated, possibly in another order)."""
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        return False
+    codes = {e.value for e in node.elts
+             if isinstance(e, ast.Constant) and isinstance(e.value, str)}
+    return LANG_SET <= codes  # superset of all 7
+
+
+def test_no_universe_literal_in_scripts():
+    """No ``.py`` under ``scripts/`` (bar the single source + tests) may carry
+    the 7-lang universe as a literal -- it must come from ``check_perimeter``."""
+    offenders = []
+    for py in (REPO_ROOT / "scripts").rglob("*.py"):
+        py = py.resolve()
+        if py == SINGLE_SOURCE or py == THIS:
+            continue
+        if "tests" in py.relative_to(REPO_ROOT / "scripts").parts:
+            continue  # test fixtures legitimately use lang lists
+        try:
+            # Suppress SyntaxWarnings from pre-existing warts (e.g. non-raw
+            # regex strings) in scanned files -- they are not THIS test's
+            # concern and must not surface as noise in CI.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", SyntaxWarning)
+                tree = ast.parse(py.read_text(encoding="utf-8"))
+        except (SyntaxError, OSError):
+            continue
+        for node in ast.walk(tree):
+            if _is_universe_literal(node):
+                offenders.append(f"{py.relative_to(REPO_ROOT)}:{node.lineno}")
+    assert not offenders, (
+        "language-universe literal(s) found outside the single source "
+        f"(check_perimeter.TARGET_LANGS) -- import instead: {offenders}"
+    )
+
+
+# 6+ adjacent quoted lang codes = the universe literal in a YAML one-liner.
+_YAML_LANG_RUN = re.compile(
+    r'(["\'](?:en|es|ar|fa|zh|ru|pt)["\']\s*,?\s*){6,}'
+)
+
+
+def test_no_universe_literal_in_workflows():
+    """No ``.yml`` under ``.github/`` may recite the 7-lang universe as a
+    literal -- derive it via ``from check_perimeter import TARGET_LANGS``."""
+    offenders = []
+    for yml in (REPO_ROOT / ".github").rglob("*.yml"):
+        for i, line in enumerate(yml.read_text(encoding="utf-8").splitlines(), 1):
+            if _YAML_LANG_RUN.search(line):
+                offenders.append(f"{yml.relative_to(REPO_ROOT)}:{i}")
+    assert not offenders, (
+        "language-universe literal(s) found in workflow YAML -- derive via "
+        f"check_perimeter.TARGET_LANGS instead: {offenders}"
+    )
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/translation/translate_csv.py
+++ b/scripts/translation/translate_csv.py
@@ -49,6 +49,13 @@ import time
 import urllib.error
 import urllib.request
 
+# Sibling import: ``check_perimeter`` owns the SINGLE source of truth for the
+# ordered target-language universe (#10109). This script's directory is on
+# ``sys.path`` when run as ``python scripts/translation/translate_csv.py``;
+# the explicit insert also covers ``python -m`` and pytest invocation.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from check_perimeter import TARGET_LANGS  # noqa: E402
+
 # ----------------------------------------------------------------------------
 # Gate de sécurité (HARD). Inactif par défaut ; activé par la variable
 # d'environnement TRANSLATE_ENABLED (grain D #10043). CI-callable sans
@@ -71,7 +78,11 @@ def _enabled_from_env() -> bool:
 
 ENABLED = _enabled_from_env()
 
-TARGETS = ["en", "ru", "pt", "es", "ar", "fa", "zh"]
+# The 7 target languages, in the canonical order owned by ``check_perimeter``
+# (#10109). A local divergent copy previously listed ``en ru pt es ar fa zh``
+# -- a permutation that silently swaps translations the moment any positional
+# access traverses it. Consume the single source instead.
+TARGETS = list(TARGET_LANGS)
 LANG_NAMES = {
     "en": "English",
     "ru": "Russian",


### PR DESCRIPTION
Grain: MED/refactor — lane myia-po-2024:CoursIA — prev: MED/guard #10106
Quoi: #10109 — collapse the duplicated 7-target-language list into a single source of truth (`check_perimeter.TARGET_LANGS`), so a divergent permutation can never silently swap translations again.
Preuve: 230/230 translation tests PASS (4 new + 226 existing — the import refactor breaks no consumer). New regression guard AST-scans every `.py` under `scripts/` (bar the single source + tests) and every `.yml` under `.github/` for a duplicated language-universe literal — it fails the moment one reappears. The guard currently passes (clean). YAML-embedded Python (heredoc + `python -c` one-liners) verified to derive the list correctly from repo root. 3 workflows YAML-valid. CLI import smoke OK for all 7 modules standalone. Pre-commit gitleaks + hooks PASS. Base fully current (0 commits behind origin/main — no rebase). L898 collision guard CLEAN.
Perimetre: 11 files (+190/−17). `check_perimeter.py` marked single source; 7 consumer scripts import `TARGET_LANGS` instead of reciting it; 3 workflow YAMLs derive the list; 1 new regression test. The −17 are exactly the replaced literal lines. No catalog, no notebook, no other file.

## Summary

The 7 target-language list (`en es ar fa zh ru pt`) was duplicated across **eight** production sites, one in a **different order**: `translate_csv.py` carried `en ru pt es ar fa zh` — a permutation. The defect is latent, not cosmetic: any positional `zip()` / `enumerate()` across two copies swaps translations (Persian where Russian belongs) in a rendered `*_<lang>.ipynb`, committed by a bot, **with no exception raised**. #10109 measured 4 sites; an AST scan found 8 (5 more `.py` + 2 more in `translation-drift.yml`). Acceptance #4 requires the guard to catch *all* duplication, so the unification covers the full surface.

### Single source + 8 consumers

`check_perimeter.TARGET_LANGS` (already canonical, now documented as the sole home for the literal). Every consumer imports it:

| Consumer | Before | After |
|---|---|---|
| `translate_csv.TARGETS` | `["en","ru","pt","es","ar","fa","zh"]` ← **permutation** | `list(TARGET_LANGS)` |
| `check_resync_only.ALL_LANGS` | `("en","es",...)` literal | `tuple(TARGET_LANGS)` |
| `check_translation_parity.TARGET_LANGS` | literal | import |
| `check_translation_sync.{TARGET_LANGS,PIVOT_LANG,ALL_LANGS}` | 3 literals | import |
| `extract_cells_to_csv.{TARGET_LANGS,PIVOT_LANG}` | 2 literals | import |
| `multilingual_drift_audit.LANGS` | literal | `TARGET_LANGS as LANGS` |
| `translation-sync.yml` T4 heredoc `active_langs` | recited literal | `from check_perimeter import TARGET_LANGS` |
| `translation-drift.yml` fill-rate one-liners (`t=`) | recited ×2 | derived via import in each `python -c` |

Sibling imports are robust to invocation style (`python scripts/translation/x.py`, `python -m`, pytest): each script inserts its own directory onto `sys.path` before the import.

### Subsets intentionally NOT unified

The RTL pair `["ar","fa"]` (`multilingual_drift_audit.py:81`) and the `NON_LATIN` set are a **different concept** (a semantic subset), not the universe. The detector's superset-of-7 threshold keeps them expressible — only a literal carrying all 7 target langs (the duplicated universe, in any order) is flagged.

### Regression guard (acceptance #4)

`scripts/translation/tests/test_lang_single_source.py`:
1. **Equivalence** — every consumer's public list `==` `check_perimeter.TARGET_LANGS`.
2. **AST guard** — flags any `list`/`tuple` literal whose string elements are a **superset of the 7 target langs**, outside `check_perimeter.py`. Precisely the duplicated-universe defect; subsets stay free.
3. **YAML guard** — text-scans `.github/**/*.yml` for 6+ adjacent quoted lang codes.

The guard fails the moment a literal reappears — so the duplication cannot come back at the next grain.

## Validation

- `python -m pytest scripts/translation/tests/` → **230 passed** (4 new + 226 existing).
- `python -c "import yaml; yaml.safe_load(open(...))"` × 3 workflows → OK.
- CLI import smoke: all 7 modules import standalone ✓.
- YAML-embedded Python (heredoc + `python -c` one-liners) derives the list correctly from repo root ✓.
- `git diff --stat` = 11 files, +190/−17 (the −17 are exactly the replaced literals — consolidative, no anti-regression concern).
- Pre-commit: gitleaks **Passed**; notebook hooks skipped (no notebooks).

## Variation note (transparent)

prev = MED/guard #10106 (close-keyword PR-ref gate). This = MED/refactor — different GENRE. G-VAR-3 bans 2 consecutive LIGHT same-genre; MED cross-genre passes. G-VAR-1 (plancher DEEP/MED): MED ✓. Litmus: not LIGHT (required AST-scanning the whole module to find the full 8-site surface, designing a precise superset-of-7 detector that excludes the RTL subset, and threading sibling imports through 3 invocation styles — not scanner-generable).

Closes #10109
See #10038
