### PR TITLE
fix(lean,#4980): register PetersTour_en as build target (orphan-trap #6749)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/lakefile.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/lakefile.lean
@@ -34,3 +34,7 @@ require SocialChoiceLean from git
 @[default_target]
 lean_lib «PetersTour» where
   -- Tour of DominikPeters/SocialChoiceLean results
+  -- globs incluent le sibling EN (i18n #4980) pour que `lake build` le compile
+  -- aussi : sans cela, PetersTour_en.lean n'est jamais élaboré et un Lean CI
+  -- vert est un faux pass (orphan-trap #6749). Même pattern que sudoku_lean.
+  globs := #[`PetersTour, `PetersTour_en]


### PR DESCRIPTION
fix(lean,#4980): register PetersTour_en as build target (orphan-trap #6749)

Grain: MED/fix — lane myia-po-2023:CoursIA-2 — prev: LIGHT/coord cycle-6

## Quoi

`social_choice_lean_peters/PetersTour_en.lean` (sibling EN i18n de `PetersTour.lean`)
n'était pas inscrit comme cible `lean_lib` dans le lakefile → `lake build` ne
l'élaborait jamais. Détecté par `scripts/lean/check_i18n_siblings.py --all` :
« module `PetersTour_en` absent from lakefile.lean roots/globs -> never compiled
by `lake build` (a green Lean CI is a false pass) ». C'est l'orphan-trap #6749 :
une erreur de syntaxe ou un drift dans le sibling EN passerait inaperçu en CI.

Fix (+4 lignes) : ajouter `globs := #[`PetersTour, `PetersTour_en]` au
`lean_lib «PetersTour»` existant, pour que `lake build` compile les deux modules.
Même pattern que `sudoku_lean/lakefile.lean` (`globs := #[.submodules `Sudoku,
`Sudoku_en]`), qui est le lac de référence 0-unbuilt pour un fichier plat + sibling _en.

## Preuve

- **Checker firsthand** : avant « 1 unbuilt », après « 0 unbuilt | 0 drift | 0 orphan
  | 1/1 pairs byte-identical ». Le checker parse le lakefile (extrait roots/globs) et
  confirme la cible est désormais reconnue.
- **Byte-identity 1/1** : le code body (signatures, imports, tactiques, énoncés) de
  `PetersTour_en.lean` est byte-identique à `PetersTour.lean` (FR canonique) — seules
  les docstrings/commentaires diffèrent (convention #4980). Donc si le FR build
  (default_target, buildé en CI aujourd'hui), l'EN build identiquement (mêmes imports
  SocialChoice.*, mêmes tactiques Mathlib).
- **Anti-regression** : 0 suppression, +4 lignes (3 commentaires + 1 globs). Aucune
  preuve/tactique touchée. Aucun `sorry` ajouté/retiré.
- **Variété R6.6** : famille Lean (orphan-trap remediation), distincte de mes récents
  cycles tooling/scanner/security/coord.

## Périmètre

- **1 fichier** (+4 lignes, 0 suppression) : `lakefile.lean` du lake
  `social_choice_lean_peters`. 1 sujet (orphan-trap #6749 sur un sibling i18n).
- **Collision-guard** : 0 PR OPEN sur PetersTour / social_choice_lean_peters ; base
  fraîche (issue de origin/main `d16af441a`), 0 divergence. Catalogue byte-identique.
- **Scope i18n** : `social_choice_lean_peters/` est NOTRE lake (dépend de
  DominikPeters/SocialChoiceLean externe, mais lakefile + PetersTour*.lean sont à
  nous). Le checker l'a flaggé IN-scope (non skippé), contrairement aux vendored
  `.lake/packages/`. Le `_peters` du code-style.md hors-scope désigne un chemin
  différent, pas ce lake.

See #4980 (i18n sibling convention) · See #6749 (orphan-trap guard) · Pattern ref : sudoku_lean/lakefile.lean

Co-Authored-By: Claude-Code <noreply@anthropic.com>
