### PR TITLE
fix(knot_lean,#8696): R1 forward-transfer sub-case 3/3 wrapper + EN mirror (post-#9967 orphan)

### DIFF
--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -40,10 +40,11 @@ name: Lean Knot CI
 #   - Reidemeister.lean:        2 (reidemeister_theorem x2 — PL topology, OOS)
 #   - Basic.lean:               0 (the "1" under prose-header was a TODO prose comment)
 #   - MathlibPrerequisites.lean:0 (the "2" were the prose roadmap index)
-# Total real tactic sorry = 17 (raised from 16 by #9966: +1 wrapper front
-# tricolorable_forward_r1, characterized ∀c∈d₂.crossings wall, 2/3 sub-cases proven;
-# was 16 after #8766 discharged trefoil_not_unknot; re-verified 2026-07-29 at 16 by
-# canonical count_real_sorries replica + CI run 30465509621).
+# Total real tactic sorry = 16 (lowered from 17: the tricolorable_forward_r1
+# wrapper ∀c∈d₂.crossings wall is now DISCHARGED — append decomposition +
+# Lean core lemma List.mem_or_eq_of_mem_set + 3 proven sub-lemmas (_renamed,
+# _unchanged, _newKink) + nomatch on the singleton tail; was 17 raised by
+# #9966 which fronted the wall; 16 after #8766 discharged trefoil_not_unknot).
 # Raising this baseline requires a documented
 # justification in the PR body (a NEW real tactic sorry, not prose).
 
@@ -99,7 +100,7 @@ jobs:
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean
       display-name: knot_lean
-      sorry-baseline: "17"
+      sorry-baseline: "16"
       sorry-filter-mode: real
 
   # Level 3 proof-integrity gate (criterion B.3 of pr-review-discipline).

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -747,8 +747,10 @@ theorem triColorConditionAt_renamed {d₁ d₂ : KnotDiagram}
   omega
 
 /-- **Direction avant** de l'invariance de tricolorabilité par torsion R1
-    connectée. Témoin = extension triviale. Voir la note de blocage ci-dessus
-    pour le mur actuel (la conjonction `∀ c ∈ d₂.crossings`). -/
+    connectée. Témoin = extension triviale. Le mur `∀ c ∈ d₂.crossings` est
+    résolu (c.995) : décomposition append + lemme core
+    `List.mem_or_eq_of_mem_set` (`a ∈ l.set i b → a ∈ l ∨ a = b`) +
+    3 sous-lemmas (`_renamed`, `_unchanged`, `_newKink`). -/
 theorem tricolorable_forward_r1 {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1Connected d₁ d₂) (htc : IsTricolorable d₁) :
     IsTricolorable d₂ := by
@@ -759,18 +761,43 @@ theorem tricolorable_forward_r1 {d₁ d₂ : KnotDiagram}
   -- réglé en c.982, cf. `tricolorForwardExtension`).
   refine' ⟨tricolorForwardExtension hnum2 a ha1 ha2 coloring₁, ?_, ?_, ?_⟩
   · -- (1) `∀ c ∈ d₂.crossings, triColorConditionAt d₂ coloring₂ c`.
-    --   `hsurg` déplie `d₂.crossings = d₁.crossings.set i.val Y' ++ [newKink]`.
-    --   Les 3 sous-cas sont PROUVÉS (lemmes ci-dessus) :
-    --     • (a) `c = Y'` (renamed)        → `triColorConditionAt_renamed`
-    --     • (b) c inchangé (d₁, index ≠ i) → `triColorConditionAt_unchanged`
-    --     • (c) `c = newKink`              → `triColorConditionAt_newKink`
-    --   MUR NOMMÉ restant (c.986) : la décomposition d'appartenance
-    --   `c ∈ d₁.crossings.set i.val Y' → c = Y' ∨ c ∈ d₁.crossings` n'a pas de
-    --   lemme nommé en Lean 4.11 (`List.get_set`/`mem_set_iff` absents ;
-    --   `simpa using hc` échoue, pas de forme normale simp pour `List.set`).
-    --   Raccourcissement du pont (Fin/getElem/getElem_set_of_ne) = travail
-    --   dédié prochain cycle. Les sous-faits mathématiques sont établis.
-    exact sorry
+    --   `hsurg` : `d₂.crossings = d₁.crossings.set i.val Y' ++ [newKink]`.
+    --   3 sous-cas PROUVÉS + lemme core `List.mem_or_eq_of_mem_set` (c.995).
+    intro c hc
+    rw [hsurg] at hc
+    obtain hc_set | hc_kink := List.mem_append.mp hc
+    · -- (i)+(ii) `c ∈ d₁.crossings.set i.val Y'` : c'est `Y'` (renommé) ou un
+      -- crossing `d₁` inchangé (via `List.mem_or_eq_of_mem_set`).
+      by_cases hY : c = Y'
+      · -- (i) c = Y' : crossing renommé. `hcond` (htc) fournit la condition du
+        -- crossing source `d₁.crossings.get i`, transportée par `_renamed`.
+        subst hY
+        have hget_mem : d₁.crossings.get i ∈ d₁.crossings := List.get_mem d₁.crossings i
+        have hcond_i : triColorConditionAt d₁ coloring₁ (d₁.crossings.get i) :=
+          hcond _ hget_mem
+        exact triColorConditionAt_renamed hnum2 a ha1 ha2 coloring₁ _
+          (d₁.crossings.get i) hrename hcond_i
+      · -- (ii) c ≠ Y' : crossing `d₁` inchangé. `List.mem_or_eq_of_mem_set`
+        -- donne `c ∈ d₁.crossings ∨ c = Y'` ; `hY` écarte `.inr`, d'où `c ∈
+        -- d₁.crossings`, puis `_unchanged` transporte la condition.
+        have hc_in : c ∈ d₁.crossings := by
+          rcases List.mem_or_eq_of_mem_set hc_set with h | h'
+          · exact h
+          · exact absurd h' hY
+        have hcond_c : triColorConditionAt d₁ coloring₁ c := hcond _ hc_in
+        -- Bornes (8) extraites de `hcond_c` (définitionnellement la conjonction).
+        have hc_wf : 1 ≤ c.e1 ∧ c.e1 ≤ d₁.numEdges ∧
+                      1 ≤ c.e2 ∧ c.e2 ≤ d₁.numEdges ∧
+                      1 ≤ c.e3 ∧ c.e3 ≤ d₁.numEdges ∧
+                      1 ≤ c.e4 ∧ c.e4 ≤ d₁.numEdges := by
+          have := hcond_c
+          simp only [triColorConditionAt] at this
+          exact this.1
+        exact triColorConditionAt_unchanged hnum2 a ha1 ha2 coloring₁ c hc_wf hcond_c
+    · -- (iii) `c ∈ [newKink]` : seul le `head`, `c = newKink`.
+      cases hc_kink with
+        | head _ => exact triColorConditionAt_newKink hnum2 a ha1 ha2 coloring₁
+        | tail _ h => nomatch h
   · -- (2) `d₂.numEdges ≥ 2` : `d₂.numEdges = d₁.numEdges + 2 ≥ 2`.
     rw [hnum2]; omega
   · -- (3) ≥ 2 couleurs : héritées de `coloring₁` (le préfixe `[0, d₁.numEdges)` est

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -687,6 +687,65 @@ theorem triColorConditionAt_unchanged {d₁ d₂ : KnotDiagram}
   -- 8 bornes d₂ : c.ek ≤ d₁.numEdges (hcond.1) ≤ d₂.numEdges (hnum2)
   omega
 
+/-- **Cas (a) — slot renommé `Y'`** du dépliage `∀ c ∈ d₂.crossings` du wrapper
+    `tricolorable_forward_r1`. Le croisement `Y'` est la version renommée de `c`
+    par la torsion R1 connectée : un slot `a` (appartenant à `c`) est devenu
+    `b = d₁.numEdges + 1`, matérialisé par l'hypothèse `isRenameOf Y' c a b`.
+    Pour chacun des 4 slots, `isRenameOf` donne la disjonction
+    `(Y'.ek = c.ek) ∨ (Y'.ek = b ∧ c.ek = a)` ; dans les deux branches le
+    transport `d₂.colorAtNat coloring₂ Y'.ek = d₁.colorAtNat coloring₁ c.ek`
+    tient : slot inchangé → `colorAtNat_eq`, slot renommé `b` →
+    `colorAtNat_fresh_eq` (= `coloring₁ a` = `coloring₁ c.ek` via `c.ek = a`).
+    Les 4 couleurs de `Y'` dans `d₂` égalent donc celles de `c` dans `d₁` ;
+    continuité (`c2 = c4`) et Fox sont transportées telles quelles depuis
+    `hcond`. Les bornes `Y'.ek ∈ [1, d₂.numEdges]` suivent de la disjonction
+    (slot inchangé : `c.ek ≤ d₁.numEdges ≤ d₂.numEdges` ; slot `b` :
+    `b = d₁.numEdges + 1 ≤ d₂.numEdges = d₁.numEdges + 2`) par `omega`. -/
+theorem triColorConditionAt_renamed {d₁ d₂ : KnotDiagram}
+    (hnum2 : d₂.numEdges = d₁.numEdges + 2) (a : Nat) (ha1 : 1 ≤ a) (ha2 : a ≤ d₁.numEdges)
+    (coloring₁ : TriColoring d₁) (Y' c : PDCrossing)
+    (hrename : Y'.isRenameOf c a (d₁.numEdges + 1))
+    (hcond : triColorConditionAt d₁ coloring₁ c) :
+    triColorConditionAt d₂ (tricolorForwardExtension hnum2 a ha1 ha2 coloring₁) Y' := by
+  -- Déplie la conjonction 4×disjonction de `isRenameOf` en 4 hypothèses de slot.
+  obtain ⟨hs1, hs2, hs3, hs4⟩ := hrename
+  -- Déplie les bornes de `c` dans `d₁` (servent au `colorAtNat_eq` slot-inchangé).
+  simp only [triColorConditionAt] at hcond
+  obtain ⟨hc11, hc12, hc21, hc22, hc31, hc32, hc41, hc42⟩ := hcond.1
+  -- Transport des 4 couleurs. Chaque `rcases hs_k` vit dans le scope local du
+  -- `have` (n'épuise pas `hs_k`, réutilisé ci-après pour le bornage) :
+  --   slot inchangé (Y'.ek = c.ek) → `colorAtNat_eq` ;
+  --   slot renommé (Y'.ek = b ∧ c.ek = a) → `colorAtNat_fresh_eq` (= coloring₁ a
+  --   = coloring₁ c.ek via `c.ek = a`).
+  have hk1 : d₂.colorAtNat (tricolorForwardExtension hnum2 a ha1 ha2 coloring₁) Y'.e1 =
+      d₁.colorAtNat coloring₁ c.e1 := by
+    rcases hs1 with he | ⟨heb, hec⟩
+    · rw [he]; exact tricolorForwardExtension.colorAtNat_eq hnum2 a ha1 ha2 coloring₁ c.e1 hc11 hc12
+    · rw [heb, hec]; exact tricolorForwardExtension.colorAtNat_fresh_eq hnum2 a ha1 ha2 coloring₁
+  have hk2 : d₂.colorAtNat (tricolorForwardExtension hnum2 a ha1 ha2 coloring₁) Y'.e2 =
+      d₁.colorAtNat coloring₁ c.e2 := by
+    rcases hs2 with he | ⟨heb, hec⟩
+    · rw [he]; exact tricolorForwardExtension.colorAtNat_eq hnum2 a ha1 ha2 coloring₁ c.e2 hc21 hc22
+    · rw [heb, hec]; exact tricolorForwardExtension.colorAtNat_fresh_eq hnum2 a ha1 ha2 coloring₁
+  have hk3 : d₂.colorAtNat (tricolorForwardExtension hnum2 a ha1 ha2 coloring₁) Y'.e3 =
+      d₁.colorAtNat coloring₁ c.e3 := by
+    rcases hs3 with he | ⟨heb, hec⟩
+    · rw [he]; exact tricolorForwardExtension.colorAtNat_eq hnum2 a ha1 ha2 coloring₁ c.e3 hc31 hc32
+    · rw [heb, hec]; exact tricolorForwardExtension.colorAtNat_fresh_eq hnum2 a ha1 ha2 coloring₁
+  have hk4 : d₂.colorAtNat (tricolorForwardExtension hnum2 a ha1 ha2 coloring₁) Y'.e4 =
+      d₁.colorAtNat coloring₁ c.e4 := by
+    rcases hs4 with he | ⟨heb, hec⟩
+    · rw [he]; exact tricolorForwardExtension.colorAtNat_eq hnum2 a ha1 ha2 coloring₁ c.e4 hc41 hc42
+    · rw [heb, hec]; exact tricolorForwardExtension.colorAtNat_fresh_eq hnum2 a ha1 ha2 coloring₁
+  -- But : bornes Y' + (continuité + Fox). Les 4 `hk_k` ramènent les couleurs de
+  -- `Y'` dans `d₂` à celles de `c` dans `d₁` → continuité + Fox = `hcond.2`.
+  simp only [triColorConditionAt]
+  simp only [hk1, hk2, hk3, hk4]
+  refine ⟨?_, hcond.2⟩
+  -- 8 bornes `1 ≤ Y'.ek ≤ d₂.numEdges` : chaque slot est `c.ek` (≤ d₁.numEdges
+  -- ≤ d₂.numEdges) ou `b = d₁.numEdges + 1` (≤ d₂.numEdges = d₁.numEdges + 2).
+  omega
+
 /-- **Direction avant** de l'invariance de tricolorabilité par torsion R1
     connectée. Témoin = extension triviale. Voir la note de blocage ci-dessus
     pour le mur actuel (la conjonction `∀ c ∈ d₂.crossings`). -/
@@ -699,17 +758,18 @@ theorem tricolorable_forward_r1 {d₁ d₂ : KnotDiagram}
   -- Témoin : l'extension triviale. `a`/bornes passés explicites (Prop → Type
   -- réglé en c.982, cf. `tricolorForwardExtension`).
   refine' ⟨tricolorForwardExtension hnum2 a ha1 ha2 coloring₁, ?_, ?_, ?_⟩
-  · -- (1) MUR CARACTÉRISÉ : `∀ c ∈ d₂.crossings, triColorConditionAt d₂ coloring₂ c`.
-    --   Dépliage requis : `d₂.crossings = d₁.crossings.set i Y' ++ [⟨a,n+1,n+2,n+2⟩]`
-    --   (`hsurg`) → 3 sous-cas par membership `List.set`/append :
-    --     • `c = Y'` (slot renommé) : `colorAtNat_fresh_eq` + `colorAtNat_eq` sur
-    --       les slots inchangés + `isRenameOf hrename` → Fox préservée.
-    --     • `c` unchanged (d₁ crossing, index ≠ i) : `colorAtNat_eq` sur les 4 slots.
-    --     • `c = ⟨a,n+1,n+2,n+2⟩` (nouveau kink) : `colorAtNat_eq` (slot a) +
-    --       `colorAtNat_freshEdge_eq` (slots n+1,n+2) → Fox toutes-égales (or.inl).
-    --   3 tactiques tentées : `rw [hsurg]; rintro _ (hc|hc)`, `simp only [List.mem_append,
-    --   List.mem_set]`, dépliage manuel `obtain`. Aucune ne clôt sans un lemme-pont
-    --   nommé portant `isRenameOf` + les 4 réductions colorAtNat (cf. named-hard-wall).
+  · -- (1) `∀ c ∈ d₂.crossings, triColorConditionAt d₂ coloring₂ c`.
+    --   `hsurg` déplie `d₂.crossings = d₁.crossings.set i.val Y' ++ [newKink]`.
+    --   Les 3 sous-cas sont PROUVÉS (lemmes ci-dessus) :
+    --     • (a) `c = Y'` (renamed)        → `triColorConditionAt_renamed`
+    --     • (b) c inchangé (d₁, index ≠ i) → `triColorConditionAt_unchanged`
+    --     • (c) `c = newKink`              → `triColorConditionAt_newKink`
+    --   MUR NOMMÉ restant (c.986) : la décomposition d'appartenance
+    --   `c ∈ d₁.crossings.set i.val Y' → c = Y' ∨ c ∈ d₁.crossings` n'a pas de
+    --   lemme nommé en Lean 4.11 (`List.get_set`/`mem_set_iff` absents ;
+    --   `simpa using hc` échoue, pas de forme normale simp pour `List.set`).
+    --   Raccourcissement du pont (Fin/getElem/getElem_set_of_ne) = travail
+    --   dédié prochain cycle. Les sous-faits mathématiques sont établis.
     exact sorry
   · -- (2) `d₂.numEdges ≥ 2` : `d₂.numEdges = d₁.numEdges + 2 ≥ 2`.
     rw [hnum2]; omega

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
@@ -654,8 +654,10 @@ theorem triColorConditionAt_renamed {d₁ d₂ : KnotDiagram}
   omega
 
 /-- **Forward direction** of tricolorability invariance under connected R1 twist.
-    Witness = trivial extension. See the blocking note above for the current wall
-    (the `∀ c ∈ d₂.crossings` conjunction). -/
+    Witness = trivial extension. The wall `∀ c ∈ d₂.crossings` is resolved
+    (c.995): append decomposition + core lemma `List.mem_or_eq_of_mem_set`
+    (`a ∈ l.set i b → a ∈ l ∨ a = b`) + 3 sub-lemmas (`_renamed`,
+    `_unchanged`, `_newKink`). -/
 theorem tricolorable_forward_r1 {d₁ d₂ : KnotDiagram}
     (h : Reidemeister1Connected d₁ d₂) (htc : IsTricolorable d₁) :
     IsTricolorable d₂ := by
@@ -665,18 +667,44 @@ theorem tricolorable_forward_r1 {d₁ d₂ : KnotDiagram}
   -- Witness: the trivial extension. `a`/bounds passed explicit (Prop → Type
   -- settled in c.982, cf. `tricolorForwardExtension`).
   refine' ⟨tricolorForwardExtension hnum2 a ha1 ha2 coloring₁, ?_, ?_, ?_⟩
-  · -- (1) CHARACTERIZED WALL: `∀ c ∈ d₂.crossings, triColorConditionAt d₂ coloring₂ c`.
-    --   Unfolding required: `d₂.crossings = d₁.crossings.set i Y' ++ [⟨a,n+1,n+2,n+2⟩]`
-    --   (`hsurg`) → 3 sub-cases by `List.set`/append membership:
-    --     • `c = Y'` (renamed slot): `colorAtNat_fresh_eq` + `colorAtNat_eq` on
-    --       the unchanged slots + `isRenameOf hrename` → Fox preserved.
-    --     • `c` unchanged (d₁ crossing, index ≠ i): `colorAtNat_eq` on the 4 slots.
-    --     • `c = ⟨a,n+1,n+2,n+2⟩` (new kink): `colorAtNat_eq` (slot a) +
-    --       `colorAtNat_freshEdge_eq` (slots n+1,n+2) → Fox all-equal (or.inl).
-    --   3 tactics attempted: `rw [hsurg]; rintro _ (hc|hc)`, `simp only [List.mem_append,
-    --   List.mem_set]`, manual `obtain`. None closes without a named bridge lemma
-    --   carrying `isRenameOf` + the 4 colorAtNat reductions (cf. named-hard-wall).
-    exact sorry
+  · -- (1) `∀ c ∈ d₂.crossings, triColorConditionAt d₂ coloring₂ c`.
+    --   `hsurg`: `d₂.crossings = d₁.crossings.set i.val Y' ++ [newKink]`.
+    --   3 sub-cases PROVEN + core lemma `List.mem_or_eq_of_mem_set` (c.995).
+    intro c hc
+    rw [hsurg] at hc
+    obtain hc_set | hc_kink := List.mem_append.mp hc
+    · -- (i)+(ii) `c ∈ d₁.crossings.set i.val Y'`: it's `Y'` (renamed) or an
+      -- unchanged `d₁` crossing (via `List.mem_or_eq_of_mem_set`).
+      by_cases hY : c = Y'
+      · -- (i) c = Y': renamed crossing. `hcond` (htc) provides the source
+        -- crossing condition `d₁.crossings.get i`, transported by `_renamed`.
+        subst hY
+        have hget_mem : d₁.crossings.get i ∈ d₁.crossings := List.get_mem d₁.crossings i
+        have hcond_i : triColorConditionAt d₁ coloring₁ (d₁.crossings.get i) :=
+          hcond _ hget_mem
+        exact triColorConditionAt_renamed hnum2 a ha1 ha2 coloring₁ _
+          (d₁.crossings.get i) hrename hcond_i
+      · -- (ii) c ≠ Y': unchanged `d₁` crossing. `List.mem_or_eq_of_mem_set`
+        -- gives `c ∈ d₁.crossings ∨ c = Y'`; `hY` rules out `.inr`, yielding
+        -- `c ∈ d₁.crossings`, then `_unchanged` transports the condition.
+        have hc_in : c ∈ d₁.crossings := by
+          rcases List.mem_or_eq_of_mem_set hc_set with h | h'
+          · exact h
+          · exact absurd h' hY
+        have hcond_c : triColorConditionAt d₁ coloring₁ c := hcond _ hc_in
+        -- 8 bounds extracted from `hcond_c` (definitionally the conjunction).
+        have hc_wf : 1 ≤ c.e1 ∧ c.e1 ≤ d₁.numEdges ∧
+                      1 ≤ c.e2 ∧ c.e2 ≤ d₁.numEdges ∧
+                      1 ≤ c.e3 ∧ c.e3 ≤ d₁.numEdges ∧
+                      1 ≤ c.e4 ∧ c.e4 ≤ d₁.numEdges := by
+          have := hcond_c
+          simp only [triColorConditionAt] at this
+          exact this.1
+        exact triColorConditionAt_unchanged hnum2 a ha1 ha2 coloring₁ c hc_wf hcond_c
+    · -- (iii) `c ∈ [newKink]`: only the `head`, `c = newKink`.
+      cases hc_kink with
+        | head _ => exact triColorConditionAt_newKink hnum2 a ha1 ha2 coloring₁
+        | tail _ h => nomatch h
   · -- (2) `d₂.numEdges ≥ 2`: `d₂.numEdges = d₁.numEdges + 2 ≥ 2`.
     rw [hnum2]; omega
   · -- (3) ≥ 2 colors: inherited from `coloring₁` (the prefix `[0, d₁.numEdges)` is

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
@@ -595,6 +595,64 @@ theorem triColorConditionAt_unchanged {d₁ d₂ : KnotDiagram}
   -- 8 d₂ bounds: c.ek ≤ d₁.numEdges (hcond.1) ≤ d₂.numEdges (hnum2)
   omega
 
+/-- **Case (a) — renamed slot `Y'`** of the `∀ c ∈ d₂.crossings` case-split in the
+    wrapper `tricolorable_forward_r1`. The crossing `Y'` is the renamed version
+    of `c` under the connected R1 twist: one slot `a` (belonging to `c`) becomes
+    `b = d₁.numEdges + 1`, witnessed by the hypothesis `isRenameOf Y' c a b`.
+    For each of the 4 slots, `isRenameOf` gives the disjunction
+    `(Y'.ek = c.ek) ∨ (Y'.ek = b ∧ c.ek = a)`; in both branches the transport
+    `d₂.colorAtNat coloring₂ Y'.ek = d₁.colorAtNat coloring₁ c.ek` holds:
+    unchanged slot → `colorAtNat_eq`, renamed slot `b` → `colorAtNat_fresh_eq`
+    (= `coloring₁ a` = `coloring₁ c.ek` via `c.ek = a`). The 4 colours of `Y'`
+    in `d₂` thus equal those of `c` in `d₁`; continuity (`c2 = c4`) and Fox are
+    transported as-is from `hcond`. The bounds `Y'.ek ∈ [1, d₂.numEdges]` follow
+    from the disjunction (unchanged slot: `c.ek ≤ d₁.numEdges ≤ d₂.numEdges`;
+    slot `b`: `b = d₁.numEdges + 1 ≤ d₂.numEdges = d₁.numEdges + 2`) by `omega`. -/
+theorem triColorConditionAt_renamed {d₁ d₂ : KnotDiagram}
+    (hnum2 : d₂.numEdges = d₁.numEdges + 2) (a : Nat) (ha1 : 1 ≤ a) (ha2 : a ≤ d₁.numEdges)
+    (coloring₁ : TriColoring d₁) (Y' c : PDCrossing)
+    (hrename : Y'.isRenameOf c a (d₁.numEdges + 1))
+    (hcond : triColorConditionAt d₁ coloring₁ c) :
+    triColorConditionAt d₂ (tricolorForwardExtension hnum2 a ha1 ha2 coloring₁) Y' := by
+  -- Unfold the 4×disjunction conjunction of `isRenameOf` into 4 slot hypotheses.
+  obtain ⟨hs1, hs2, hs3, hs4⟩ := hrename
+  -- Unfold the bounds of `c` in `d₁` (used by `colorAtNat_eq` for the unchanged slot).
+  simp only [triColorConditionAt] at hcond
+  obtain ⟨hc11, hc12, hc21, hc22, hc31, hc32, hc41, hc42⟩ := hcond.1
+  -- Transport the 4 colours. Each `rcases hs_k` lives in the local scope of the
+  -- `have` (does not exhaust `hs_k`, reused below for bounding):
+  --   unchanged slot (Y'.ek = c.ek) → `colorAtNat_eq` ;
+  --   renamed slot (Y'.ek = b ∧ c.ek = a) → `colorAtNat_fresh_eq` (= coloring₁ a
+  --   = coloring₁ c.ek via `c.ek = a`).
+  have hk1 : d₂.colorAtNat (tricolorForwardExtension hnum2 a ha1 ha2 coloring₁) Y'.e1 =
+      d₁.colorAtNat coloring₁ c.e1 := by
+    rcases hs1 with he | ⟨heb, hec⟩
+    · rw [he]; exact tricolorForwardExtension.colorAtNat_eq hnum2 a ha1 ha2 coloring₁ c.e1 hc11 hc12
+    · rw [heb, hec]; exact tricolorForwardExtension.colorAtNat_fresh_eq hnum2 a ha1 ha2 coloring₁
+  have hk2 : d₂.colorAtNat (tricolorForwardExtension hnum2 a ha1 ha2 coloring₁) Y'.e2 =
+      d₁.colorAtNat coloring₁ c.e2 := by
+    rcases hs2 with he | ⟨heb, hec⟩
+    · rw [he]; exact tricolorForwardExtension.colorAtNat_eq hnum2 a ha1 ha2 coloring₁ c.e2 hc21 hc22
+    · rw [heb, hec]; exact tricolorForwardExtension.colorAtNat_fresh_eq hnum2 a ha1 ha2 coloring₁
+  have hk3 : d₂.colorAtNat (tricolorForwardExtension hnum2 a ha1 ha2 coloring₁) Y'.e3 =
+      d₁.colorAtNat coloring₁ c.e3 := by
+    rcases hs3 with he | ⟨heb, hec⟩
+    · rw [he]; exact tricolorForwardExtension.colorAtNat_eq hnum2 a ha1 ha2 coloring₁ c.e3 hc31 hc32
+    · rw [heb, hec]; exact tricolorForwardExtension.colorAtNat_fresh_eq hnum2 a ha1 ha2 coloring₁
+  have hk4 : d₂.colorAtNat (tricolorForwardExtension hnum2 a ha1 ha2 coloring₁) Y'.e4 =
+      d₁.colorAtNat coloring₁ c.e4 := by
+    rcases hs4 with he | ⟨heb, hec⟩
+    · rw [he]; exact tricolorForwardExtension.colorAtNat_eq hnum2 a ha1 ha2 coloring₁ c.e4 hc41 hc42
+    · rw [heb, hec]; exact tricolorForwardExtension.colorAtNat_fresh_eq hnum2 a ha1 ha2 coloring₁
+  -- Goal: bounds Y' + (continuity + Fox). The 4 `hk_k` bring the colours of
+  -- `Y'` in `d₂` back to those of `c` in `d₁` → continuity + Fox = `hcond.2`.
+  simp only [triColorConditionAt]
+  simp only [hk1, hk2, hk3, hk4]
+  refine ⟨?_, hcond.2⟩
+  -- 8 bounds `1 ≤ Y'.ek ≤ d₂.numEdges`: each slot is `c.ek` (≤ d₁.numEdges
+  -- ≤ d₂.numEdges) or `b = d₁.numEdges + 1` (≤ d₂.numEdges = d₁.numEdges + 2).
+  omega
+
 /-- **Forward direction** of tricolorability invariance under connected R1 twist.
     Witness = trivial extension. See the blocking note above for the current wall
     (the `∀ c ∈ d₂.crossings` conjunction). -/


### PR DESCRIPTION
> **UPDATE 2026-08-09 — commit `0a78a7a38` (lane `myia-po-2026:CoursIA`): wrapper wall DISCHARGED.** The `∀ c ∈ d₂.crossings` wall characterized below as "STILL OPEN" is now **PROVEN**. This **supersedes** the pre-discharge claims in the *Honest accounting* / *Anti-régression* sections below ("wall STILL OPEN", "wrapper still has 2 sorries", "baseline UNCHANGED") — those described the state before this commit.
>
> **Discharge summary:** the c.986 absence-claim ("no named lemma for `List.set` membership in Lean 4.11") was **FALSE** — the lemma exists in Lean **CORE** (`Init.Data.List.Lemmas` L718: `List.mem_or_eq_of_mem_set : a ∈ l.set i b → a ∈ l ∨ a = b`). The wrapper `tricolorable_forward_r1`'s `exact sorry` is replaced by: `intro c hc` → `rw [hsurg]` → `List.mem_append` → `List.mem_or_eq_of_mem_set` (rules out `.inr` via `by_cases`) → the 3 proven sub-lemmas (`_renamed` / `_unchanged` / `_newKink`) → `nomatch` on the impossible singleton tail.
>
> **Sorry baseline `17 → 16`** (bidirectional gate c.989; real-mode FR count verified firsthand with the exact CI awk: Conway 8 + Invariant 4 + Lidman 2 + Reidemeister 2 = 16; `_en` siblings excluded as i18n mirrors). **Local `lake build` SUCCESS** (Knots.Invariant + Invariant_en, 2951 jobs, native Windows lake.exe). The `tricolorable_invariant` transfer sorry (L350) remains a **separate** open wall (anti-régression §D — untouched).
>
> Diff stat is now **3 files** (+89/-33): the 2 Lean files above + `.github/workflows/lean-knot.yml` (baseline 17→16 + updated comment). FR↔EN byte-identity preserved (comment-stripped diff identical). Cross-lane contribution: po-2023 delivered the orphan-recovery + 3 sub-lemmas; po-2026 delivered the wrapper composition that closes the wall.

---

## fix(knot_lean,#8696): R1 forward-transfer sub-case 3/3 wrapper (post-#9967 orphan)

**Grain:** DEEP/lean — lane `myia-po-2023:CoursIA-2` — prev: MED/refactor PR-10111

**Issue:** [jsboige/CoursIA#8696](https://github.com/jsboige/CoursIA/issues/8696) — R1 forward-transfer wall characterization + wrapper lemma.

## Context — orphan post-#9967

11 commits landed on `lean/tricolorable-transfer-invariant` (HEAD `4004d4519`) **after** PR #9967 was MERGED (squash `c80f9e5bd`) — i.e., 11 commits on a feature branch with no follow-up PR. The work is real, substantive, and detailed in the commit messages:

| # | Commit | Subject |
|---|--------|---------|
| 1 | `a48c67e6d` | characterize 4th tactic for tricolorable forward-transfer wall |
| 2 | `ecff05e45` | correct 4th-tactic construction — trivial all-equal extension |
| 3 | `9105365e7` | tricolorForwardExtension def — trivial all-equal R1 extension |
| 4 | `32cf47684` | colorAtNat_eq lemma-pivot + defeq-reducible extension refactor |
| 5 | `2609c3803` | colorAtNat_fresh_eq lemma-pivot — fresh edge reads splice-arc color |
| 6 | `7c951da59` | colorAtNat_freshEdge_eq — 3rd pivot, fresh edges read splice color |
| 7 | `c7b525cf9` | tricolorable_forward_r1 wrapper — 2/3 conjonctions, mur caractérisé |
| 8 | `47af7bc0c` | triColorConditionAt_newKink named wall — 3 color reductions |
| 9 | `2c01def0c` | resolve triColorConditionAt_newKink — named wall now proven |
| 10 | `0395844f3` | triColorConditionAt_unchanged — unchanged-casing bridge (sub-case 2/3) |
| 11 | `4004d4519` | prove triColorConditionAt_renamed (R1 sub-case 3/3) + EN mirror |
| 12 | `0427c1920` | raise sorry-baseline 16→17 + mirror forward-transfer (CI green) |

The branch accumulated **158 files of unrelated drift** (catalog churn, tooling tests, translation scripts, etc.) — none of it belonging to a focused PR. I cherry-picked only the **2 Lean proof files** (+129/-11 LOC) onto a fresh branch from `origin/main` (HEAD `d16af441a`).

## What this PR delivers

**`triColorConditionAt_renamed` (named lemma, 60-line proof)** — sub-case (a) of the wrapper `tricolorable_forward_r1`'s `∀ c ∈ d₂.crossings` decomposition. Handles the **renamed slot** `Y'` (where one slot `a` of crossing `c` is renamed to `b = d₁.numEdges + 1` under the R1 twist, witnessed by `isRenameOf`).

Each of the 4 slots `Y'.ek` is dispatched via `rcases` on the `isRenameOf` disjunction:
- `Y'.ek = c.ek` (slot unchanged) → `colorAtNat_eq` — color transports from `d₁.colorAtNat coloring₁ c.ek`
- `Y'.ek = b ∧ c.ek = a` (slot renamed) → `colorAtNat_fresh_eq` — fresh edge reads `coloring₁ a = coloring₁ c.ek`

Continuity (`c2 = c4`) and Fox 3-coloring condition (`mkOctic`) are transported via `hcond.2` (the witness from `d₁`). Bounds `1 ≤ Y'.ek ≤ d₂.numEdges` follow from the slot disjunction + `omega`.

## Honest accounting (G.9 — no inflated DONE)

**Sorry baseline UNCHANGED at 2** in `Invariant.lean` and `Invariant_en.lean` (line 2188/2338 in FR, 2053/2203 in EN — same as `origin/main` baseline `c80f9e5bd`). The new lemma **works around the wall** via a wrapper-and-cases structure, it does **NOT close it**. The wrapper `tricolorable_forward_r1` itself still has 2 sorries.

Per `verify-before-claiming.md` rule 2: this is **"1 sub-case proven via named wrapper, 2/3 wrapper conjonctions resolved, wall characterized but NOT closed — 0 net sorry reduction"** — **not** "DONE".

| Sub-case | Status |
|----------|--------|
| (a) renamed slot `Y'` | **PROVEN** via `triColorConditionAt_renamed` (this PR) |
| (b) unchanged slot (d₁ crossing) | PROVEN via `triColorConditionAt_unchanged` (commit `0395844f3`) |
| (c) new kink `⟨a,n+1,n+2,n+2⟩` | PROVEN via `triColorConditionAt_newKink` (commits `2c01def0c`/`47af7bc0c`) |
| Wall closure (∀ c ∈ d₂.crossings) | **STILL OPEN** — 2 sorries |

## Diff stat (clean — no catalog drift)

```
 .../knot_lean/Knots/Invariant.lean     | 82 +++++++++++++++++++---
 .../knot_lean/Knots/Invariant_en.lean  | 58 +++++++++++++++
 2 files changed, 129 insertions(+), 11 deletions(-)
```

Catalog-pr-hygiene R1 ✓ — `COURSE_CATALOG.generated.{json,md}` byte-identical to `origin/main` (verified `git diff origin/main --stat` returns 0 hits on those files).

## i18n byte-identity (sibling pair FR/EN)

```
$ python scripts/lean/check_i18n_siblings.py MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
OK      MyIA.AI.Notebooks\SymbolicAI\Lean\knot_lean\Knots\Invariant_en.lean
1/1 pairs byte-identical | 0 consumer-pattern | 0 drift | 0 orphan | 0 unbuilt (0 whitelisted) | 0 half-done (advisory)
```

EN mirror's docstring differs (French sibling pattern) but proof bodies are **byte-identical** to FR, per `code-style.md` i18n convention (docstrings FR + sibling-pair `_en`).

## Lake build verification (CI will validate)

Local lake build was **attempted** but failed with network timeout cloning Mathlib into the fresh worktree (`fatal: fetch-pack: invalid index-pack output` / exit 143). CI's `lean-ci.yml` workflow will validate. The orphan commits cite `lake build Knots.Invariant SUCCESS local, exit 0, 2948 jobs` — a CI green run is the canonical gate.

## L898 collision guard ✓

- `gh pr list --search "8696 OR triColorCondition"` → no other lane on this sub-work
- `gh pr list --search "Invariant.lean"` → no follow-up PR
- `gh worktree list` → this is the only worktree on the orphan path
- Branch gates: `lean/tricolorable-transfer-invariant` (VIVANTE per merge-base) + `gh pr list --search head:feature/c8696-r1-forward-subcase3-orphan` = no PR

## Lane claim protocol ✓

- Other lanes on #8696 are claimed for **Reidemeister3 migration** (`myia-po-2026:CoursIA-2` and `myia-po-2026:CoursIA`) — **distinct sub-work** (R3D surgery) from this PR (R1 forward-transfer sub-case 3/3 wrapper).
- Lane claim here is **for the orphan work**, not for the broader #8696 epic — `See #8696` partial framing.

## Anti-régression (D) ✓

- No code replaced by `sorry` / `pass` / stub vide — proof body is **additive**.
- `grep -c sorry` UNCHANGED at 2 (same as main baseline).
- Documented in commit `0427c1920` (the orphan's actual raise: 16→17 baseline was for a different prior state).

## PR hygiene checklist

- **Lane** : `myia-po-2023:CoursIA-2`
- **TIER** : DEEP/lean — litmus = "real new result on main" (60-line Lean proof of a named lemma, lake build SUCCESS documented in commit messages, byte-identical EN mirror).
- **Issue** : `See #8696` (partial — sub-case 3/3 only, wall NOT closed, R3D migration owned by po-2026).
- **Catalog-pr-hygiene R1** ✓ · **R2** fresh rebase from `origin/main` `d16af441a` ✓ · **R3** atomic (2 files, 1 subject) ✓ · **R4** `See` not `Closes` ✓
- **L898 ★★★** ✓ · **L989 ★★★** push via `git -c http.extraHeader=` ✓
- **L677-L4 ★★** PR body in scratchpad `…/scratchpad/c8696_orphan_pr_body.md` ✓
- **C10078-L3 ★★ RECURRENCE** switch `jsboige` upfront for push ✓
- **Stop & Repair (mandat user 2026-06-22)** ✓ — no notebook/output hand-edited
- **Verify-before-claiming (G.1)** ✓ — sorry count + i18n byte-identity + diff stat + merge-base verified firsthand
- **SOTA-OK** ✓ — Lean 4 proof, no workaround degraded, no stub where SOTA solvable

🤖 Generated with [Claude Code](https://claude.com/claude-code)


