### PR TITLE
feat(notebook-tools,#9434): scan_quant_classify FP guard v7 — count-nouns ext + module-slug (fleet -646 drainable)

### DIFF
--- a/scripts/notebook_tools/scan_quant_classify.py
+++ b/scripts/notebook_tools/scan_quant_classify.py
@@ -389,10 +389,29 @@ def _classify_quant_value(
     #     N est la cardinalité d'un ensemble fini du domaine, pas une mesure
     #     stochastique (le tirage porte SUR les N, N lui-même est fixe). Mesuré :
     #     GT-1-Setup cell[60] "3 actions" → STOCHASTIQUE via kw 'random'.
+    #     v7 (c.1331+19, #9434) étend la liste de count-nouns aux entités
+    #     pédagogiques/documentaires mesurées sur la flotte (164 FP ENV-DEP) :
+    #     "21 notebooks", "3 modules", "5 sections", "12 fichiers", "8 puzzles",
+    #     "3 exercices" — cardinalités de structure, pas des versions/mesures.
     if re.match(r"(?:actions?|choix|strat[eé]gies?|candidats?|joueurs?|players?|"
                 r"[eé]tats?|[eé]tapes?|coups?|moves?|dimensions?|attributs?|"
-                r"features?|classes?)\b", s_l, re.I):
-        return ("STRUCTUREL", "compteur structurel v6 (N <count-noun>: cardinalité)")
+                r"features?|classes?|notebooks?|modules?|sections?|cellules?|"
+                r"cells?|chapitres?|fichiers?|files?|puzzles?|exercices?|"
+                r"th[eé]or[eè]mes?|theorems?|probl[eè]mes?|exemples?)\b",
+                s_l, re.I):
+        return ("STRUCTUREL", "compteur structurel v6/v7 (N <count-noun>: cardinalité)")
+    # (G) Slug de module/section : "module 01-5", "modules [01]-05", "notebooks
+    #     02-1 a 02-5", "parts 7-23" = le chiffre est dans le slug hiérarchique
+    #     d'un module pédagogique (préfixe = count-noun structurel), pas une version.
+    #     Même asymétrie que le slug-B (cross-ref notebook). Mesuré : GenAI/Audio
+    #     "module 01-5" → ENV-DEP via kw env adjacent. TIGHTENED : exige (a) un
+    #     count-noun structurel en préfixe (module/modules/notebooks/parts — PAS
+    #     "module p" mathématique ni "2^127-1" qui a un caret) ET (b) un slug -N
+    #     en suffixe (le raw matche le 1er chiffre, le suffixe porte le -N). Exclut
+    #     les expressions mathématiques (" - 1" avec espace).
+    if re.search(r"\b(?:modules?|notebooks?|parts?)\b\s*\[?$", p_r, re.I) and \
+       re.match(r"-\d", s_l):
+        return ("STRUCTUREL", "slug module v7 (module N-M: hiérarchie pédagogique)")
 
     # -1 (c.1301+12): anti-FP ML/DfA + Search/Part1 — guard structurel v4
     #     (4 classes : editorial-duration / biblio / section-number /

--- a/scripts/notebook_tools/tests/test_scan_quant_classify.py
+++ b/scripts/notebook_tools/tests/test_scan_quant_classify.py
@@ -824,6 +824,68 @@ class TestFpGuardV6:
             f"'3' sans count-noun ne doit pas declencher le guard (F), rationale={rat!r}"
         )
 
+    # -- v7: extended count-nouns + module-slug (c.1331+19, #9434) ------------- #
+
+    def test_v7_structural_count_notebooks(self):
+        """GT-15b: "cette serie de **21 notebooks**" = cardinalite de la serie.
+
+        21 = nb de notebooks dans la serie (structurel), rattrape par kw 'python'
+        adjacent (+3 compagnons python). Mesure firsthand : 1426 FP ENV-DEP de
+        cette classe sur la flotte avant v7.
+        """
+        cls, _ = _classify_quant_value("21", 21.0,
+                                       "cette serie de **", " notebooks** (+3")
+        assert cls == "STRUCTUREL", (
+            f"compteur structurel (N notebooks) doit etre STRUCTUREL, got {cls}"
+        )
+
+    def test_v7_structural_count_modules(self):
+        """"on importe les 3 modules" = cardinalite des modules importes."""
+        cls, _ = _classify_quant_value("3", 3.0,
+                                       "n est structure en ", " modules (`zerosum`")
+        assert cls == "STRUCTUREL", (
+            f"compteur structurel (N modules) doit etre STRUCTUREL, got {cls}"
+        )
+
+    def test_v7_module_slug_range(self):
+        """GenAI/Audio: "module 01-5" = slug hierarchique d'un module pedagogique.
+
+        Le 01 est le numero du module (raw match), le suffixe -5 est la sous-partie.
+        Rattrape par kw env adjacent. Meme asymetrie que le slug-B notebook.
+        """
+        cls, _ = _classify_quant_value("01", 1.0,
+                                       "kokoro (module ", "-5) ou des services")
+        assert cls == "STRUCTUREL", (
+            f"slug module (module NN-N) doit etre STRUCTUREL, got {cls}"
+        )
+
+    def test_v7_notebooks_range(self):
+        """GT/GameTheory: "notebooks 7-15" = plage de notebooks de la serie.
+
+        7 = debut de plage (raw match), -15 = fin. Structurel (organisation serie),
+        pas une version ni une mesure.
+        """
+        cls, _ = _classify_quant_value("7", 7.0,
+                                       "les notebooks ", "-15 utiliseront")
+        assert cls == "STRUCTUREL", (
+            f"plage notebooks (NN-NN) doit etre STRUCTUREL, got {cls}"
+        )
+
+    def test_v7_mersenne_prime_NOT_absorbed(self):
+        """Falsification CRITIQUE : "2^127-1" (nombre premier de Mersenne) reste drainable.
+
+        Le context "module p | 2^127 - 1 | premier de mersenne" contient le mot
+        "module" mais c'est un nom mathematique (module-Mersenne), pas un module
+        pedagogique. L'exposant `^` et l'expression `- 1` (avec espace) doivent
+        EMPECHER le guard (G) de l'absorber. 2^127-1 = vrai nombre, pas un slug.
+        """
+        cls, rat = _classify_quant_value("127", 127.0,
+                                         "| module p | 2^", " - 1 | premier")
+        assert "slug module" not in rat, (
+            f"nombre premier de Mersenne 2^127-1 ne doit PAS etre absorbe par le "
+            f"guard module-slug (faux 'module' mathematique), rationale={rat!r}"
+        )
+
 
 # --------------------------------------------------------------------------- #
 #  Tests _extract_context


### PR DESCRIPTION
feat(notebook-tools,#9434): scan_quant_classify FP guard v7 — count-nouns ext + module-slug (fleet -646 drainable)

Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/fix PR-10111 (Lean orphan-trap)

## Quoi

4e passe anti-FP sur le scanner canon de l'Epic #9434. v4 (#10016) + v5 (#10062) +
v6 (#10108) laissaient 5173 valeurs drainables sur 754 notebooks. En scannant la
flotte AVEC v6 (cycle 8, tooling-as-discovery), j'ai mesure firsthand 2 nouvelles
classes de FP residuels NON couvertes : (F-ext) count-nouns pedagogiques/documentaires
manquants, (G) slug de module pedagogique. +21 lignes scanner, +62 lignes tests
(5 nouveaux).

Les 2 extensions v7 (failure-mode-safe, meme asymetrie que v4/v5/v6 — absorbent
UNIQUEMENT vers STRUCTUREL) :
- **(F) count-nouns etendus** : "21 notebooks", "3 modules", "5 sections",
  "12 fichiers", "8 puzzles", "3 exercices", "5 theoremes" = cardinalites de
  structure pedagogique/documentaire (mesure firsthand : 1426 FP ENV-DEP de cette
  classe). Etend la liste v6 (actions/joueurs/dimensions...) aux entites du
  domaine pedagogique.
- **(G) slug de module** : "module 01-5", "notebooks 7-15", "parts 7-23" = le
  chiffre est dans le slug hierarchique d'un module pedagogique (134 FP absorbes).
  Meme asymetrie que le slug-B (cross-ref notebook) de v6.

## Preuve

- **86 tests passent** (81 v6 + 5 nouveaux v7), 0 echec, 0 SyntaxWarning. Les 5
  nouveaux = 4 positifs (notebooks/modules/module-slug/notebooks-range → STRUCTUREL)
  + **1 falsification CRITIQUE** : `test_v7_mersenne_prime_NOT_absorbed` —
  "2^127-1" (nombre premier de Mersenne, contexte "module p | 2^127 - 1") NE doit
  PAS etre absorbe par le guard (G) car "module p" est un nom mathematique, pas
  un module pedagogique, et l'exposant `^` + l'espace dans "- 1" l'excluent.
- **G.9 self-correction documentee** : 1ere iteration du guard (G) absorbait le
  Mersenne prime (contexte "module p |" matchait `\bmodules?\b`). Identifie
  firsthand via echantillon de l'ensemble absorbe (1/8 etait le Mersenne = faux).
  TIGHTENED : exige un count-noun structurel en prefixe (module/notebooks/parts,
  PAS "module p") ET un slug -N en suffixe (PAS "- 1" avec espace). Le test de
  falsification PREVIENT la regression future.
- **Fleet delta firsthand** : ENV-DEP 2155→1602 (−553), MACHINE-DEP 1798→1740
  (−58), STOCH 1220→1185 (−35), STRUCTUREL +646. Aucun genuine ENV supprime
  (Mersenne preserve, 4 falsifications anti-FN existantes conservees).
- **0 suppression sur le scanner** (+21 lignes guard, 0 retrait). Les 2 deletions
  sont dans le test (remplacement d'un bloc marqueur).

## Périmètre

- **2 fichiers** (+83 lignes, −2) : scanner + tests. 1 sujet (anti-FP residuel du
  canon #9434). Pas un composite.
- **Stacked PR** : cette branche est issue de `feature/scan-quant-fp-v6` (PR #10108
  OPEN, non encore mergee). Le merge de #10111 + #10108 doit preceder. Le
  coordinateur rebasera v7 sur main apres merge v6 (PR stacked, meme pattern que
  po-2024 cycle).
- **Collision-guard** : 0 PR OPEN sur scan_quant_classify autre que #10108 (ma v6,
  sur laquelle je m'appuie). Catalogue byte-identique a main.
- **Variété R6.6** : MED/tooling (scanner FP-reduction), distinct du MED/fix Lean
  orphan-trap (#10111) du cycle precedent. Memme veine #9434 mais registre
  coherent (scanner anti-FP) — l'alternative etait forensic-floor.

See #9434 (quantitatif tenu par le CI) · Builds on v4 #10016 + v5 #10062 + v6 #10108 · Tracker #10012

Co-Authored-By: Claude-Code <noreply@anthropic.com>
