### PR TITLE
fix(check-c2,#10120): wire dead-code is_assignment + papermill/C#/stub FP heuristics

### DIFF
--- a/scripts/notebook_tools/check_c2_compliance.py
+++ b/scripts/notebook_tools/check_c2_compliance.py
@@ -109,8 +109,13 @@ def check_notebook(nb_path: Path) -> dict:
                 "source_preview": source[:80].replace("\n", " "),
             })
         elif not outputs and source.strip():
-            # Code cell with execution_count but no outputs
-            # Only flag if the cell should produce output (print, return, expression)
+            # Code cell with execution_count but no outputs.
+            # Only flag if the cell SHOULD produce output. The prior heuristic
+            # listed "=" among the output-keyword triggers, so every pure
+            # assignment (`x = 5`, papermill parameter cells `BATCH_MODE = "true"`)
+            # was flagged as "should produce output". `is_assignment` was computed
+            # precisely to exclude those, but never wired into the condition (dead
+            # code, #10120) — the half-finished refactor is completed here.
             has_output_statement = any(
                 kw in source for kw in
                 ["print(", "display(", "plt.", "fig", "return ", "="]
@@ -121,8 +126,52 @@ def check_notebook(nb_path: Path) -> dict:
                 "=" in source
                 and not any(kw in source for kw in ["print(", "display(", "plt."])
             )
+            # Papermill parameter cells are intentionally no-output: papermill
+            # injects values via API at execution time, so the cell body (a set
+            # of assignments) produces nothing visible. Recognised by the GenAI
+            # convention header `# Parametres Papermill` or the QC-strategies
+            # convention `# Parameters`. Covers the case where such a cell also
+            # holds a stray non-assignment expression that would trip
+            # has_output_statement despite being a config cell (#10120).
+            stripped_lower = source.lstrip().lower()
+            is_papermill_param = (
+                stripped_lower.startswith("# parametres papermill")
+                or stripped_lower.startswith("# parameters")
+            )
+            # C#/.NET top-of-file `using` declarations are import boilerplate
+            # (the C# analogue of Python `import`) and produce no output. Guard
+            # the rare cell where a class-declaration initializer (`=`) or the
+            # substring `fig` would otherwise trip has_output_statement (#10120).
+            first_code_line = next(
+                (l for l in lines if not l.startswith(("#", "//"))), "")
+            is_csharp_using = (
+                first_code_line.startswith("using ")
+                and first_code_line.endswith(";")
+            )
+            # A pedagogical stub cell whose top-level statements are ALL
+            # definitions (`def`/`class`), imports, or assignments produces no
+            # top-level output: defining a function/class does not echo, and
+            # assignments don't display. This is the common exercise-stub case
+            # (`def fib(n):\n    return None`) flagged by the `return ` trigger.
+            # A top-level EXPRESSION statement (a bare call like `foo()` or
+            # `df.head()`) DOES echo, so such a cell is NOT definition-only and
+            # is still checked. Conservative: only skips when every unindented,
+            # non-comment line is a definition/import/assignment (#10120).
+            top_level_stmts = [
+                l for l in source.split("\n")
+                if l.strip()
+                and not l[0].isspace()
+                and not l.strip().startswith(("#", "//"))
+            ]
+            is_definition_only = bool(top_level_stmts) and all(
+                l.strip().startswith(("def ", "class ", "import ", "from "))
+                or "=" in l
+                for l in top_level_stmts
+            )
 
-            if has_output_statement and not is_import:
+            if (has_output_statement and not is_import and not is_assignment
+                    and not is_papermill_param and not is_csharp_using
+                    and not is_definition_only):
                 violations.append({
                     "cell_index": i,
                     "code_cell": code_idx,

--- a/scripts/notebook_tools/tests/test_check_c2_compliance.py
+++ b/scripts/notebook_tools/tests/test_check_c2_compliance.py
@@ -153,10 +153,80 @@ class TestMissingOutputs:
         result = check_notebook(nb_path)
         assert result["violations"] == []
 
-    def test_assignment_no_output_flagged(self, tmp_path):
-        """Simple assignment with = but no print/display -> flagged (has '=' keyword)."""
+    def test_assignment_no_output_ok(self, tmp_path):
+        """Simple assignment with = but no print/display -> NOT flagged.
+
+        A pure assignment (`x = compute_value()`) produces no visible output in
+        Jupyter — only the LAST expression-statement of a cell (or an explicit
+        print/display) emits output. The prior heuristic listed "=" among the
+        output-keyword triggers and `is_assignment` (computed to exclude this
+        case) was dead code, so assignment cells were wrongly flagged (#10120).
+        Wiring `is_assignment` into the condition restores the correct verdict.
+        """
         nb_path = _write_nb(tmp_path / "assign.ipynb", [
             _code("x = compute_value()", exec_count=1),
+        ])
+        result = check_notebook(nb_path)
+        assert result["violations"] == []
+
+    def test_papermill_parameter_no_output_ok(self, tmp_path):
+        """Papermill parameter cell (assignments under a header comment) -> OK.
+
+        Papermill injects parameter values via API at execution time, so the
+        cell body (a set of assignments like `BATCH_MODE = "true"`) intentionally
+        produces no visible output. Recognised by the GenAI convention header
+        `# Parametres Papermill` or the QC-strategies convention `# Parameters`
+        (#10120). NB: plain assignments are already exempt via `is_assignment`;
+        this header check adds robustness for config cells holding a stray
+        non-assignment expression.
+        """
+        nb_path = _write_nb(tmp_path / "papermill.ipynb", [
+            _code('# Parametres Papermill - JAMAIS modifier ce commentaire\n'
+                  'BATCH_MODE = "true"\nskip_widgets = "true"',
+                  exec_count=1),
+        ])
+        result = check_notebook(nb_path)
+        assert result["violations"] == []
+
+    def test_csharp_using_decl_no_output_ok(self, tmp_path):
+        """C#/.NET top-of-file `using` declaration -> OK (import boilerplate).
+
+        `using System;` is the C# analogue of Python `import` — import
+        boilerplate that produces no output. Guard the rare case where a class
+        initializer (`=`) or the substring `fig` in the same cell would
+        otherwise trip has_output_statement (#10120).
+        """
+        nb_path = _write_nb(tmp_path / "cs_using.ipynb", [
+            _code("using System;\nusing Microsoft.DotNet.Interactive;",
+                  exec_count=1),
+        ])
+        result = check_notebook(nb_path)
+        assert result["violations"] == []
+
+    def test_function_def_stub_no_output_ok(self, tmp_path):
+        """Pedagogical function-definition stub (`def foo(): return None`) -> OK.
+
+        A cell whose top-level statements are all definitions/imports/
+        assignments produces no top-level output — defining a function does
+        not echo. This is the common exercise-stub case, flagged by the `return `
+        trigger before the `is_definition_only` guard (#10120).
+        """
+        nb_path = _write_nb(tmp_path / "stub.ipynb", [
+            _code("def fibonacci(n):\n    # TODO etudiant\n    return None",
+                  exec_count=1),
+        ])
+        result = check_notebook(nb_path)
+        assert result["violations"] == []
+
+    def test_function_def_with_top_level_call_flagged(self, tmp_path):
+        """Control: a def followed by a top-level CALL -> flagged (call echoes).
+
+        `is_definition_only` must NOT skip a cell whose last top-level statement
+        is an expression-call (produces output), only cells that are purely
+        definitions/imports/assignments. Guards against over-broad skipping.
+        """
+        nb_path = _write_nb(tmp_path / "def_call.ipynb", [
+            _code("def foo():\n    return 1\nfoo()", exec_count=1),
         ])
         result = check_notebook(nb_path)
         assert len(result["violations"]) == 1


### PR DESCRIPTION
## fix(check-c2,#10120): wire dead-code is_assignment + papermill/C#/stub FP heuristics

**Grain:** MED/guard — lane `myia-po-2026:CoursIA` — prev: DEEP/lean #10112 (tricolorable wrapper discharge). Cross-lane: issue body tags `scripts/notebook_tools/` as po-2025 family; R5 pool cross-lane, transparency acked in [CLAIMED] post (2026-08-09T02:32Z). No collision (PR #10116 is a different file/content).

**Issue:** [jsboige/CoursIA#10120](https://github.com/jsboige/CoursIA/issues/10120) — C.2 PR-gate detector `check_c2_compliance.py` reported 671 cells / 202 notebooks as "execution_count set but no outputs"; ~537 were heuristic FP.

## Quoi

The C.2 detector's `has_output_statement` (L116) listed `"="` as an output trigger, and `is_assignment` (L120-123) — computed precisely to exclude pure-assignment cells — was **dead code** (never wired into the L125 conditional). So every assignment cell (`x = 5`, papermill `BATCH_MODE = "true"`) was flagged "should produce output". This PR:

1. **Wires `is_assignment` into the conditional** (the dead-code fix, #10120 core). Pure assignments produce no Jupyter output → no longer flagged.
2. **Papermill parameter cells** (`# Parametres Papermill` GenAI / `# Parameters` QC convention) — intentionally no-output, skipped.
3. **C#/.NET `using` declarations** — import boilerplate (C# analogue of Python `import`), skipped.
4. **Pedagogical definition-only stubs** (`def fib(n): return None`) — top-level statements all def/class/import/assignment → no top-level output, skipped. Conservative: a top-level EXPRESSION statement (`foo()`) still flags.

## Preuve (G.1/G.2 — firsthand, not keywords)

**Firsthand bug verification**: `check_c2_compliance.py` L82-97 (read before edit) — `is_assignment` computed L120-123, condition L125 `if has_output_statement and not is_import:` does NOT reference it. `has_output_statement` L116 includes `"="`. Bug confirmed.

**Tests** (49 PASS, full suite 4317 passed / 2 skipped — no regression):
- Flipped `test_assignment_no_output_flagged` → `test_assignment_no_output_ok` (it encoded the bug).
- +4 new tests: `test_papermill_parameter_no_output_ok`, `test_csharp_using_decl_no_output_ok`, `test_function_def_stub_no_output_ok`, `test_function_def_with_top_level_call_flagged` (control — def+call still flags).
```
$ python -m pytest scripts/notebook_tools/tests/test_check_c2_compliance.py -q
49 passed in 0.24s
$ python -m pytest scripts/notebook_tools/tests/ -q
4317 passed, 2 skipped in 55.87s
```

**Corpus scan** (exact CI detector, run firsthand):
| | notebooks compliant | violating cells |
|---|---|---|
| Before | 665/867 | 671 cells / 202 notebooks |
| After | 729/867 | 338 cells / 81 notebooks |

Breakdown of 338 residual:
- **279 MISSING_EXEC_COUNT** (`execution_count: null`) — a DIFFERENT C.2 violation type (cells never executed), out of scope for this detector-FP fix (the issue targets the "no outputs" branch).
- **59 no-outputs** (down from the no-outputs component of 671).

## True-bug triage (acceptance item 6)

Of the 59 residual no-outputs, **6 are TRUE-BUG candidates** (real display/print/plt cells with no recorded output — need re-execution):

| Notebook | cell | signal |
|----------|------|--------|
| GenAI/SemanticKernel/Semantic-kernel-AutoInteractive.ipynb | #6 | `display(...)` C# call |
| QuantConnect/Python/QC-Py-08-Multi-Asset-Strategies.ipynb | #20 | `print("="*60)` |
| QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb | #27 | `plt.subplots(...)` |
| QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb | #6 | `print("="*60)` |
| QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb | #23 | `plt.subplots(...)` |
| QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb | #3 | `plt.subplots(...)` |

NB: 5/6 are QuantConnect notebooks (outputs require QC Cloud execution, not local) — separate burn-down. The remaining 53 residual are edge-case FP (complex multi-line stubs needing AST to classify: `TOOLS = [...]` + defs, control-flow cells) — refining further would risk false negatives; out of scope.

## Perimetre

**Scope = the detector only** (fix the heuristic, per the issue's "Why not just fix the violators? Because the detector is wrong. Fixing 671 notebook cells to satisfy a buggy detector = enshrining a wrong invariant."). True-bug burn-down (re-executing the 6 notebooks) is **separate follow-up**. The detector is now correct for the main FP categories.

## Acceptance checklist (#10120)

- [x] `is_assignment` used in conditional (dead-code fix)
- [x] Papermill + `# Parameters` cells skip
- [x] C# top-of-file `using` cells skip
- [x] `test_assignment_no_output_flagged` updated (+4 new tests, 49 PASS)
- [x] `pytest test_check_c2_compliance.py` PASS (49/49)
- [x] Corpus scan: 671 → 338 total (no-outputs 59; 279 are out-of-scope missing-exec)
- [x] True-bug list produced + per-bug triage (6 candidates above)

## PR hygiene

- **Catalog-pr-hygiene R1** ✓ (catalogue byte-identical to main — only 2 Python files touched, no catalogue/markers).
- **R2** fresh rebase from `origin/main d16af441a` ✓ (isolated worktree).
- **R3** atomic (2 files, 1 subject) ✓.
- **R4** `See #10120` (not `Closes` — true-bug burn-down + <50 edge-case refinement remain).
- **Verify-before-claiming (G.1)** ✓ — bug read firsthand L82-97 before edit; corpus numbers measured firsthand.
- **SOTA-OK** ✓ — no workaround, real detector fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
