### PR TITLE
ci(translation-sync): add concurrency block to prevent stale-run drift on force-push

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -57,6 +57,19 @@ permissions:
   contents: write   # bot commit to the PR branch
   pull-requests: write
 
+# Cancel a superseded in-flight run when a new push lands on the same PR/ref.
+# A translation-sync run re-extracts CSVs + re-renders derived notebooks off
+# the PR HEAD; if the HEAD moves mid-run (force-push, or a second push during
+# the ~2-min T1-T4 pipeline), the stale run can commit derived state that no
+# longer matches the new HEAD -- a silent drift source. Serialising per-PR
+# (cancel-in-progress) matches the convention used by pr-gate / pip-leak-guard
+# / banner-guard / catalog-cron / exercise-leak-ci / markdown-rendering-guard.
+# NOTE (#10114): this does NOT fix the action_required bot-trap -- that needs
+# the Option B/C mandate decision. It only prevents the within-PR race.
+concurrency:
+  group: translation-sync-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   translation-sync:
     name: "Translation auto-sync (bot)"


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/docs PR-10118 (Infer-4 md tables)

## Quoi

`translation-sync.yml` (#10042 grain C, the T1+T3+T4 auto-sync bot) is the **only** notebook-touching workflow WITHOUT a top-level `concurrency:` block. A run re-extracts CSVs + re-renders derived `*_<lang>.ipynb` off the PR HEAD; if the HEAD moves mid-run (force-push, or a second push during the ~2-min T1-T4 pipeline), the stale run can commit derived state that no longer matches the new HEAD — a silent drift source. Adding `concurrency:` with `cancel-in-progress` (keyed per-PR) cancels the superseded stale run, matching the convention used by **6 other workflows** in the repo.

Convention alignment (measured firsthand — these all have `concurrency:`): `pr-gate.yml`, `pip-leak-guard.yml`, `banner-guard.yml`, `catalog-cron.yml`, `exercise-leak-ci.yml`, `markdown-rendering-guard.yml`. `translation-sync.yml` was the outlier.

## Preuve

- **YAML valide** (`yaml.safe_load` OK). Diff = **13 insertions, 0 suppression** (8 lignes commentaire + bloc concurrency de 3 lignes + ligne vide). Purement additif, aucun step T1-T4 touché.
- **Reproduction firsthand du race** : cycle 10, PR #10118 — j'ai force-pushé (`2241a098a` amend) pendant que des runs translation-sync étaient in-flight ; sans `concurrency:`, l'ancien run aurait pu committer du state dérivé basé sur le HEAD pré-amend. Le bot a d'ailleurs committé `a8039491a3` (T1+T3+T4) — le race est réel, pas théorique.
- **Pattern de keying** : `group: translation-sync-${{ github.event.pull_request.number || github.ref }}` — exactement le modèle `pr-gate.yml` (PR-number quand dispo, ref sinon), qui gère correctement `workflow_dispatch` (où `pull_request.number` est absent → fallback `github.ref`).
- **Recommendation po-2024** : lane `myia-po-2024:CoursIA` a investigué le bot-trap #10114 firsthand et explicitement recommandé ce block (« A `concurrency:` block is still independently worthwhile (prevents overlapping human-triggered runs racing on the same CSV) and I recommend folding it into whichever Option-B/C PR lands »).

## Périmètre

- **1 fichier** (+13, 0 suppression) : `.github/workflows/translation-sync.yml`. 1 sujet (concurrency hardening). Pas un composite.
- **Collision-guard** : `gh search prs "translation-sync.yml"` → 1 PR OPEN (#10110 po-2024, TARGET_LANGS single-source). #10110 modifie la **logique des steps T1/T3** (source des 7 langues), PAS le top-level `concurrency:`/`permissions` → sections disjointes, pas de conflit de merge. Base fraîche origin/main `d16af441a`. Catalogue byte-identique.
- **Honnêteté — ce que cette PR NE fait PAS** : elle ne fixe PAS le bot-trap `action_required` #10114. po-2024 a vérifié firsthand que l'Option A (job-level actor guard) ne marche pas (le bot run ne crée jamais le job → le guard ne fire jamais). Le vrai fix (Option B : pas de branch commit / Option C : workflow_dispatch manual) **inverse le mandat #10042** → décision user/coordinateur, pas worker. Ce block prévient uniquement le **race within-PR** (stale-run drift sur force-push). Le commentaire in-file le documente explicitement pour prévenir mésinterprétation.
- **Variété R6.6** : MED/guard (CI workflow hardening), non-notebook (évite le bot-trap translation-sync lui-même), distinct du MED/docs notebook (#10118) et MED/guard pr_gate (#10115) des cycles précédents.

See #10114 (bot-trap — cette PR prévient le race, pas le trap) · See #10042 (grain C — le workflow durci) · Convention ref : pr-gate.yml / pip-leak-guard.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)
