### PR TITLE
fix(variation,#10102): genre-mismatch heuristic abstains on code PRs (stop flagging 12/14 honest genres)

### DIFF
--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -721,10 +721,12 @@ def test_signal_genre_mismatch_from_paths(tmp_path, capsys):
         "--replay", str(mpath), "--genre-signals",
         "--lane", "myia-po-2023:CoursIA",
         "--body-file", str(bpath),
-        "--files", "README.md,docs/README.md",
+        "--files", "README.md,ML/README.md",
     ])
     out = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
     assert rc == 0
+    # Pure-readme diff (both README*, neither under docs/ nor .claude/) ->
+    # inferred `readme`; declared `tooling` -> MISMATCH.
     assert out["signals"]["GENRE-MISMATCH"] is True
     assert out["inferred_genre_from_paths"] == "readme"
     assert out["candidate_genre_canonical"] == "tooling"
@@ -781,14 +783,53 @@ def test_signal_genre_mismatch_active_for_docs_paths(tmp_path, capsys):
     assert out["inferred_genre_from_paths"] == "docs"
 
 
-def test_genre_from_paths_mixed_non_md_is_tooling():
-    # A diff that touches BOTH a markdown file and a code file is
-    # `tooling` (code-change-dominant). The corroboration is conservative:
-    # the GENRE-MISMATCH signal only fires when ALL paths are md-only.
-    assert vlc._genre_from_paths(["README.md", "scripts/foo.py"]) == "tooling"
-    assert vlc._genre_from_paths(["scripts/foo.py"]) == "tooling"
+def test_genre_from_paths_non_md_abstains_and_md_classification():
+    # #10102: a diff that touches a non-md file is a CODE PR. The heuristic
+    # cannot distinguish code genres (lean/notebook-python/qc/...), so it
+    # ABSTAINS (None) -- the old `tooling` inference MISMATCHED 12 of 14
+    # honest code declarations. A code PR sees no GENRE-MISMATCH signal.
+    assert vlc._genre_from_paths(["README.md", "scripts/foo.py"]) is None
+    assert vlc._genre_from_paths(["scripts/foo.py"]) is None
     assert vlc._genre_from_paths([]) is None
     assert vlc._genre_from_paths(None) is None
+    # md-only classification branches (#10102 acceptance 2-3):
+    # docs/ AND .claude/ prose/rule work -> `docs`.
+    assert vlc._genre_from_paths(["docs/reference/x.md"]) == "docs"
+    assert vlc._genre_from_paths([".claude/rules/git-workflow.md"]) == "docs"
+    # a .claude/ rule mixed with another md still reads as `docs`.
+    assert vlc._genre_from_paths([".claude/rules/foo.md", "ML/README.md"]) == "docs"
+    # README* files -> `readme`.
+    assert vlc._genre_from_paths(["README.md"]) == "readme"
+    # md-only elsewhere, non-readme -> abstain (cannot classify confidently).
+    assert vlc._genre_from_paths(["MyIA.AI.Notebooks/ML/notes.md"]) is None
+
+
+def test_signal_genre_mismatch_no_mismatch_10090_harness_rules(tmp_path, capsys):
+    # #10090 non-regression: a diff of 3 *.md files, 2 under .claude/ (rule
+    # prose) + 1 other, declared `docs`. Per #10102 acceptance, .claude/
+    # rule prose classifies as `docs`, so inferred == declared == `docs` ->
+    # NO MISMATCH (the old code returned `readme` -> spurious mismatch).
+    merged_obj = [
+        {"number": 1, "body": "Grain: MED/docs -- lane myia-po-2023:CoursIA",
+         "mergedAt": "2026-08-08T01:00:00Z"},
+    ]
+    mpath = tmp_path / "merged.json"
+    mpath.write_text(json.dumps(merged_obj), encoding="utf-8")
+    bpath = tmp_path / "body.txt"
+    bpath.write_text(
+        "Grain: MED/docs -- lane myia-po-2023:CoursIA", encoding="utf-8"
+    )
+    rc = vlc.main([
+        "--replay", str(mpath), "--genre-signals",
+        "--lane", "myia-po-2023:CoursIA",
+        "--body-file", str(bpath),
+        "--files", ".claude/rules/foo.md,.claude/rules/bar.md,ML/notes.md",
+    ])
+    out = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert rc == 0
+    assert out["inferred_genre_from_paths"] == "docs"
+    assert out["candidate_genre_canonical"] == "docs"
+    assert out["signals"]["GENRE-MISMATCH"] is False
 
 
 def test_signal_genre_mismatch_inactive_when_no_body(tmp_path, capsys):

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -579,39 +579,46 @@ def genre_runs(merged_prs: list[dict], target_lane: str) -> list[dict]:
 def _genre_from_paths(files: list[str] | None) -> str | None:
     """Best-effort GENRE inferred from a PR's diff file paths.
 
-    Issue #10020 §Corroboration: "si tous les fichiers du diff sont des
-    `*.md` (hors `docs/**` de fond), le genre effectif est `readme`/`docs`
-    quel que soit le genre declare". Implemented as:
+    Issue #10020 §Corroboration, refined by #10102: the heuristic can only
+    arbitrate the `docs`/`readme` axis, and ONLY for diffs that are 100%
+    `*.md`. Implemented as:
 
-      * all paths absent or empty   -> None (no signal)
-      * any non-`*.md` path present -> `tooling` (code change dominant)
-      * all paths under `docs/`     -> `docs`
-      * all paths `*.md` (but NOT under `docs/`) -> `readme`
+      * paths absent or empty                    -> None (no signal)
+      * any non-`*.md` path present              -> None (a code PR; the
+        heuristic cannot distinguish `lean`/`notebook-python`/`qc`/...,
+        so it abstains -- forcing `tooling` here would MISMATCH 12 of 14
+        honest code declarations, #10102)
+      * any `*.md` under `docs/` or `.claude/`   -> `docs` (prose/rule work)
+      * all `*.md` named `README*`               -> `readme`
+      * other `*.md`-only diffs                  -> None (cannot classify
+        confidently, e.g. a lone series .md; abstain)
 
-    The function is conservative on the partial-evidence case (a diff that
-    touches BOTH a `*.md` and a `*.py` is `tooling`, NOT `readme`): the
-    GENRE-MISMATCH signal is only raised when ALL paths are
-    `*.md`-equivalent. A PR with no diff paths at all returns `None`
-    (no claim possible), which means GENRE-MISMATCH is INACTIVE for that
-    PR -- not silently `readme`. CI workflows that do not pass `--files`
-    see no GENRE-MISMATCH signal: a missing input is a missing signal,
-    never a false positive.
+    The signal therefore fires ONLY in the case the heuristic can decide: a
+    100%-`*.md` diff whose paths pin the genre to `docs` or `readme`,
+    contrasted with a declared genre that disagrees. A code PR (any
+    non-`*.md` file) sees NO GENRE-MISMATCH -- the previous `tooling`
+    inference flagged every honest code declaration (#10102 measured 6 of 7
+    open PRs). A missing `--files` is INACTIVE: a missing input is a missing
+    signal, never a false positive.
     """
     if not files:
         return None
     # Normalise Windows backslashes to forward slashes for the prefix test.
     norm = [f.replace("\\", "/") for f in files]
-    md_only = all(f.endswith(".md") for f in norm)
-    if not md_only:
-        # Any non-md file present -> this is a code-change PR, not a
-        # doc-only PR. The `tooling` call is what `GENRE-MISMATCH` would
-        # contrast a `readme` declaration against; it is a coarse
-        # distinction (not `lean`/`notebook-python`/...), which is the
-        # point of the corroboration heuristic.
-        return "tooling"
-    if all(f.startswith("docs/") for f in norm):
+    if not all(f.endswith(".md") for f in norm):
+        # Any non-md file -> a code-change PR. The heuristic cannot
+        # distinguish code genres (`lean`/`notebook-python`/`qc`/...), so it
+        # abstains (None) rather than force a `tooling` inference that would
+        # MISMATCH 12 of 14 honest code declarations (#10102).
+        return None
+    # md-only diff: classify the prose work.
+    if any(f.startswith("docs/") or f.startswith(".claude/") for f in norm):
         return "docs"
-    return "readme"
+    if all(f.rsplit("/", 1)[-1].upper().startswith("README") for f in norm):
+        return "readme"
+    # md-only but neither docs/.claude/ nor all-README (e.g. a lone series
+    # .md): the heuristic cannot confidently classify -> abstain.
+    return None
 
 
 def compute_signals(


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/guard #10127 (translation-sync concurrency)

## Quoi

`_genre_from_paths()` (`scripts/variation_light_cap.py:579`, the GENRE-MISMATCH corroboration heuristic from #10020) returned `"tooling"` for any diff containing a non-`.md` file. Since GENRE-MISMATCH fires whenever `declared != inferred`, **every honest code PR** (declaring `lean`/`notebook-python`/`qc`/`refactor`/...) was inferred `tooling` and mismatched. #10102 measured **6 of 7 open PRs** mis-signaled — the label flagged almost everything, so it distinguished nothing, and it rewarded precisely the mis-tagging that `variation-protocol.md` §1 proscribes (to kill the signal on a code PR you had to declare `tooling`).

## Preuve

- **Fix** = align the code with its own docstring (which already claimed the conservative behavior): `_genre_from_paths` now returns `None` for non-`.md` diffs (abstain — the heuristic cannot distinguish code genres), classifies `.claude/**/*.md` as `docs` (was `readme`; rule prose is docs work), reserves `readme` for `README*` files, and returns `None` for other md-only non-readme diffs (cannot classify confidently).
- **Tests**: the unit test encoding the old `tooling` behavior (`test_genre_from_paths_mixed_non_md_is_tooling`) is replaced by `test_genre_from_paths_non_md_abstains_and_md_classification` (non-md → None, .claude/ → docs, README* → readme, md-only ailleurs → None). `test_signal_genre_mismatch_from_paths` adjusted to a pure-readme diff (its old `README.md,docs/README.md` would now infer `docs`). New `test_signal_genre_mismatch_no_mismatch_10090_harness_rules` reproduces the #10090 non-regression (3 md, 2 under .claude/, declared docs → NO mismatch).
- **Acceptance 4 firsthand demo** (run against the 7 PRs cited in #10102): all 7 show **no false MISMATCH** — code PRs (#10036/#10067/#10098/#10100) infer None → no signal; md/doc PRs (#9991/#10095/#10096) infer `docs` matching their declaration.
- **Test suite**: 60 variation_light_cap + 28 grain_tag = **88 passed, 0 regressions**. No other test depended on the old `tooling` inference (grep-verified: the other `== "tooling"` assertions are `canonicalize_genre` alias tests + declared-genre parsing, not `_genre_from_paths`).

## Perimetre

- **2 files** (+82/-34): `scripts/variation_light_cap.py` (the `_genre_from_paths` function + docstring) + `scripts/tests/test_variation_light_cap.py` (tests). 1 subject (the GENRE-MISMATCH heuristic). **No workflow YAML change** — `variation-light-genre.yml` only consumes `signals.json` (GENRE-MISMATCH now `False` for code PRs → the workflow stops labeling them).
- **Self-consistent**: this PR's diff is 2 non-`.md` files → inferred `None` → no GENRE-MISMATCH, so it is not flagged by the very heuristic it fixes.
- **Collision-guard**: `gh pr list --state open` + grep → 0 open PR touching `_genre_from_paths` / #10102. Base fresh origin/main `d16af441a`. Catalog byte-identical (0 diff lines).
- **Advisory stays advisory**: the objective is not to block (the signal never blocked — it only labels), it is that the label becomes informative again — firing only when the heuristic can actually decide: a 100%-md diff whose paths pin the genre to docs/readme, against a disagreeing declaration.
- **Honesty — what this does NOT do**: it does not touch GENRE-RUN / TIER-INFLATION / CAP-EXCEEDED (those signals are unaffected — they use `canonicalize_genre` of the declared tag, not path inference). It does not change the declared-genre taxonomy. The `tooling` genre still exists as a valid declaration; it just no longer appears as a *path-inferred* override.

See #10102 (the bug) · See #10020 (the corroboration heuristic this refines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
