### PR TITLE
docs(ict): index 10 orphaned strate-7 reference docs into README + docs portal

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -102,6 +102,24 @@ Iteration history prover, intractable diagnosis, LLM endpoints.
 
 > Note : `lean/stable_marriage_intractable_diagnosis.md` a été déplacé vers [archive/lean-intractable-diagnosis/stable-marriage.md](archive/lean-intractable-diagnosis/stable-marriage.md) (archivé c.696).
 
+## ICT (docs/ict/)
+
+Documentation de cadrage et de synthèse de la série ICT (strate 7) — tous **grade C-documentaire** (positionnement/consolidation/cartographie, aucun résultat démontré). Index thématique et parcours suggéré dans [`ict/README.md`](ict/README.md). Epic umbrella [#4588](https://github.com/jsboige/CoursIA/issues/4588), méta-proxy [#7395](https://github.com/jsboige/CoursIA/issues/7395).
+
+| Fichier | Rôle |
+|---------|------|
+| [ict/README.md](ict/README.md) | **Index** — cartographie des 10 docs par mode (vertical / horizontal / méta) + parcours suggéré |
+| [ict/synthese-invariants-dissociations-obstructions.md](ict/synthese-invariants-dissociations-obstructions.md) | Fils 1–3 : trois régimes de lecture (invariants / dissociations / obstructions) |
+| [ict/genealogy-representation-interne.md](ict/genealogy-representation-interne.md) | 4e fil : généalogie de `p̂` (représentation interne, ICT-10 → ICT-17) |
+| [ict/dissolution-scalaires.md](ict/dissolution-scalaires.md) | 5e fil : dissolution successive des scalaires Φ / F / K |
+| [ict/strate7-boussole-myth.md](ict/strate7-boussole-myth.md) | 6e fil : boussole narrative de la strate 7 |
+| [ict/strate7-cadres-libres.md](ict/strate7-cadres-libres.md) | Jambe D1 : formalisme (variables libres, jeu évolutif `G_t`) |
+| [ict/jambe-c4-propagation.md](ict/jambe-c4-propagation.md) | Jambe C4 : grammaire de propagation & seuil de bascule `(π, W, causalité)` |
+| [ict/cadrage-trajectoires-representations.md](ict/cadrage-trajectoires-representations.md) | Pivot N2 : états → représentations |
+| [ict/tresse-cartographie.md](ict/tresse-cartographie.md) | Cartographie horizontale : la tresse (Thom / Grothendieck / Schmidhuber / Friston) |
+| [ict/dissociations-matrix.md](ict/dissociations-matrix.md) | Matrice de dissociations 4-objets `(s, q, π, W)` |
+| [ict/d1-c4-rencontre-meta.md](ict/d1-c4-rencontre-meta.md) | Méta-cadrage : rencontre D1 ↔ C4 (le formel et l'opérationnel) |
+
 ## Curriculum (docs/curriculum/)
 
 Guides pédagogiques et parcours d'apprentissage.

--- a/docs/ict/README.md
+++ b/docs/ict/README.md
@@ -1,0 +1,55 @@
+# ICT — Index de la documentation de cadrage et de synthèse
+
+> **Portée.** Index thématique des 10 documents de cadrage et de synthèse de la série ICT (Integrated / Integrated-Coordination Theory de la strate 7). Tous sont au **grade C-documentaire** : positionnement, consolidation, cartographie — *aucun ne revendique un résultat démontré* ; ils nomment, articulent ou cartographient ce que les notebooks ICT expérimentent.
+>
+> **Épics de rattachement.** [#4588](https://github.com/jsboige/CoursIA/issues/4588) (Epic umbrella ICT) · [#7395](https://github.com/jsboige/CoursIA/issues/7395) (méta-proxy ICT). Les issues-sources de chaque jambe sont citées dans le document correspondant.
+
+## Cartographie des 10 documents
+
+Les documents se répartissent en **trois modes d'écriture** explicitement distingués dans [`d1-c4-rencontre-meta.md`](d1-c4-rencontre-meta.md) §0 — *vertical* (un fil de lecture), *horizontal* (une cartographie), *méta* (une articulation entre deux livrables).
+
+### Mode vertical — les fils de lecture (synthèses transversales)
+
+Chaque fil est un angle d'attaque distinct sur le même objet (la strate 7 / ICT) ; les fils ne se réduisent pas les uns aux autres.
+
+| Document | Rôle |
+|----------|------|
+| [`synthese-invariants-dissociations-obstructions.md`](synthese-invariants-dissociations-obstructions.md) | **Fils 1–3** (Grothendieck / Schmidhuber / Thom + Grothendieck) : trois régimes de lecture d'une trajectoire — invariants, dissociations, obstructions. Point d'entrée des fils. |
+| [`genealogy-representation-interne.md`](genealogy-representation-interne.md) | **4e fil** — le problème de la représentation interne : généalogie successive de `p̂` à travers les notebooks ICT-10 → ICT-17. |
+| [`dissolution-scalaires.md`](dissolution-scalaires.md) | **5e fil** — la dissolution successive des scalaires : ce qui arrive à Φ, F, K quand on les pousse hors de leur substrat d'origine (ICT-1 → ICT-22). |
+| [`strate7-boussole-myth.md`](strate7-boussole-myth.md) | **6e fil** — la boussole de la strate 7 : un mythe fondateur (auto-référence performative fractale) qui fixe la direction sans se déguiser en hypothèse scientifique. |
+
+### Cadrages formels — les jambes (D1 / D3 / C4 / N2)
+
+Les « jambes » sont des cadrages autonomes et complémentaires (pas redondants) : chacune porte une face que les autres ne portent pas.
+
+| Document | Rôle |
+|----------|------|
+| [`strate7-cadres-libres.md`](strate7-cadres-libres.md) | **Jambe D1** — le formalisme : variables libres bien choisies, free coordinates de 2e ordre, jeu évolutif `G_t`, mécanisme `M`, 6 proxys, dette d'irréversibilité. Issue [#7745](https://github.com/jsboige/CoursIA/issues/7745). |
+| [`jambe-c4-propagation.md`](jambe-c4-propagation.md) | **Jambe C4** — la grammaire de propagation & seuil de bascule `(π, W, causalité)` : quand une représentation locale transforme le tout. Jambe *inter-jambes* centrale (Thom / Grothendieck / Luhmann / Friston). Issue [#7743](https://github.com/jsboige/CoursIA/issues/7743). |
+| [`cadrage-trajectoires-representations.md`](cadrage-trajectoires-representations.md) | **Pivot N2** — le pivot états → représentations : passage du « où est-on » au « comment est-ce représenté ». |
+
+### Mode horizontal — cartographies
+
+Lectures *horizontales* : où les fils se rejoignent, s'éloignent, se mélangent ou s'affrontent — et ce qui empêche de monter trop vite de dissociation à obstruction.
+
+| Document | Rôle |
+|----------|------|
+| [`tresse-cartographie.md`](tresse-cartographie.md) | Cartographie de la **tresse** (Thom / Grothendieck / Schmidhuber / Friston) + hiérarchie de sobriété + deux ponts Conway. Issue [#7738](https://github.com/jsboige/CoursIA/issues/7738). |
+| [`dissociations-matrix.md`](dissociations-matrix.md) | **Matrice de dissociations** (notebook × claim × proxy × contrôle × réplicats × type × verdict × portée) — ossaturée par la factorisation 4-objets `(s, q, π, W)` dégagée par l'audit #4. |
+
+### Mode méta — articulation
+
+| Document | Rôle |
+|----------|------|
+| [`d1-c4-rencontre-meta.md`](d1-c4-rencontre-meta.md) | **Méta-cadrage D1 ↔ C4** — la rencontre du formel et de l'opérationnel. Reformule l'isomorphisme `ρ_c = (π_c, W_c, P_c)` en termes symétriques (D1 *nomme*, C4 *mesure* — et réciproquement), borne ce que le pont permet et interdit. N'écrivable qu'après que D1 et C4 eurent chacun leur cadrage autonome. |
+
+## Parcours suggéré
+
+- **Entrée par les fils** (lecture verticale) : [`synthese-invariants-dissociations-obstructions.md`](synthese-invariants-dissociations-obstructions.md) → [`genealogy-representation-interne.md`](genealogy-representation-interne.md) → [`dissolution-scalaires.md`](dissolution-scalaires.md) → [`strate7-boussole-myth.md`](strate7-boussole-myth.md).
+- **Entrée par les jambes** (cadrage formel) : [`strate7-cadres-libres.md`](strate7-cadres-libres.md) (D1) → [`jambe-c4-propagation.md`](jambe-c4-propagation.md) (C4) → [`d1-c4-rencontre-meta.md`](d1-c4-rencontre-meta.md) (leur articulation).
+- **Entrée par la carte** (vue d'ensemble) : [`tresse-cartographie.md`](tresse-cartographie.md) (la tresse) + [`dissociations-matrix.md`](dissociations-matrix.md) (la matrice 4-objets).
+
+## État et provenance
+
+Tous les documents consolident un travail mené sur la série de notebooks ICT et les conversations de référence (cadrage stratégique 2026-07-19, tour 523 audit #4, tour 755 jambe C4 2026-07-20). Ils sont *postérieurs* aux livrables expérimentaux qu'ilscadrent — c'est ce timing (synthèse *après* les jambes) qui les rend lisibles. Aucun ne crée de nouvelle dépendance expérimentale ; ils ne dispatchent pas de nouveau notebook.


### PR DESCRIPTION
## docs(ict): index 10 orphaned strate-7 reference docs into README + docs portal

**Grain:** LIGHT/docs — lane `myia-po-2026:CoursIA`. Prev: MED/guard #10123 (C.2 detector). Method = **tooling-as-discovery** (c.9715-bis ★★, applied by po-2024 c.46 for docs/lean/ in #10132 — different family, no collision). R6 rotation: lean → Python guard → .NET verdict → CI-audit → trap-forensic → docs-index (new genre). Docs-only = not subject to the #10114 trap.

## Quoi

`docs/ict/` held **10 substantive C-documentaire reference docs** (cadres formels D1/D3/C4, fils de lecture 1–6, cartographie de la tresse, matrice 4-objets `(s,q,π,W)`, méta-cadrage D1↔C4), totalling ~1915 lines, but had **NO index** and was linked only as a bare folder mention from `docs/README.md`. The whole family was under-discoverable; `check_docs_links.py --orphans` flagged `d1-c4-rencontre-meta.md` as a genuine orphan (referenced nowhere tracked).

This PR:

1. **New `docs/ict/README.md`** — thematic index grouping the 10 docs by their **three explicit writing modes** (vertical *fils* / horizontal *cartographie* / *méta* articulation), as distinguished in `d1-c4-rencontre-meta.md` §0. Each row restates the doc's **own stated purpose** verbatim from its `Statut` block — no invented claims. Adds a suggested reading order per mode. FR-first (readme-french-first rule).
2. **New `## ICT (docs/ict/)` section in `docs/README.md`** mirroring the existing Lean section — header + 1-line description + 11-row table (README index + 10 docs), so the family is discoverable from the docs portal. `d1-c4-rencontre-meta.md` is now linked → no longer orphaned.

## Preuve (G.1 — firsthand, not keywords)

**Firsthand tooling** (`scripts/check_docs_links.py`, run in worktree off `origin/main d16af441a`):
- Before: 9 orphan docs (`d1-c4-rencontre-meta.md` among them).
- After: **580 files, 4593 links, 0 broken**. All **20 `.md` links in the new README resolve** (verified by script: `missing: none`).

**Scope verified** (catalog-pr-hygiene R1):
```
$ git status --short
 M docs/README.md
?? docs/ict/README.md
$ git diff --stat
 docs/README.md | 18 ++++++++++++++++++
 1 file changed, 18 insertions(+)
```
Only 2 files (new README + 18-line portal section). No `COURSE_CATALOG.generated.*`, no README `<!-- CATALOG-STATUS -->` markers touched.

**Trap-safe**: docs-only, **no `.ipynb` touched** → `translation-sync.yml` paths filter (`MyIA.AI.Notebooks/**/*.ipynb`) does not match → no bot-commit → CLEAN (discriminator settled firsthand, c.1000).

## Périmètre

Discoverability only — an index. The 10 docs' prose is **untouched**. The grouping follows each doc's own self-description (vertical/horizontal/méta modes are explicitly named in `d1-c4-rencontre-meta.md` §0). `See #4588` (Epic umbrella ICT) + `#7395` (méta-proxy ICT) for context — **not** `Closes` (this is docs indexing; the epics remain open).

## PR hygiene

- **catalog-pr-hygiene R1** ✓ (catalogue byte-identical to main — 2 docs files only, no markers).
- **R2** fresh rebase from `origin/main d16af441a` ✓ (isolated worktree `CoursIA-docindex`).
- **R3** atomic (1 subject: ICT docs index) ✓.
- **R4** `See #4588` (not `Closes` — docs indexing, epic open).
- **readme-french-first** ✓ (new doc FR-first).
- **Verify-before-claiming (G.1)** ✓ — orphans measured firsthand via `check_docs_links.py`; 20/20 links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
