### PR TITLE
fix(translation,#10133): post-merge delivery on main - replace per-PR bot-commit with cron-on-main pattern

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -2,10 +2,9 @@ name: Translation Sync
 
 # Purpose
 # -------
-# Autonomous CI that keeps translations synchronized with notebook sources on
-# every PR (grain C of #10038, the mandat-user deliverable). When a PR modifies
-# an in-scope notebook (any language — the mandate requires symmetry), this
-# workflow:
+# Autonomous CI that keeps translations synchronized with notebook sources.
+# When a commit lands on `main` that touches an in-scope notebook (any language
+# — the mandate requires symmetry), this workflow:
 #   T1  re-extracts the changed cells -> refreshes src_hash in the sync CSV
 #       (extract_cells_to_csv.py --update preserves existing translations)
 #   T2  detects drift (check_translation_sync.py: SRC_DRIFT = source moved)
@@ -14,15 +13,40 @@ name: Translation Sync
 #       never the whole CSV. This is the cost-marginal property (D4): N changed
 #       cells => N API calls, not the full corpus.
 #   T4  re-renders the *_<lang>.ipynb of active languages (render_notebook.py)
-#   then commits the derived files (CSV + rendered notebooks) to the PR branch
-#   as github-actions[bot]. The reviewer reads the SOURCE-LANGUAGE diff only;
-#   the derived translations are not reviewed (same contract as the catalog,
-#   cf catalog-drift.yml / catalog-guard.yml, decision #2632).
+#   then commits the derived files (CSV + rendered notebooks) back to `main`
+#   as github-actions[bot], tagged `[skip ci]` so the commit does not
+#   re-trigger this workflow. The same contract as the catalog cron
+#   (cf catalog-cron.yml).
 #
-# Fork handling: same-repo PRs only (a bot cannot push to a fork branch). Fork
-# PRs are skipped here; the read-only translation-drift.yml still surfaces drift
-# as a notice for them. Publishing the patch as an artifact for forks is a
-# documented future enhancement (not required by the core mandate).
+# Why POST-MERGE on `main` (not per-PR on the PR branch)
+# ------------------------------------------------------
+# This workflow previously fired on `pull_request` and committed derived files
+# back to the PR branch as github-actions[bot]. That design had two
+# consequences that the team experienced as a structural deadlock (issue
+# #10133):
+#
+#   1. The bot commit moves the PR head SHA, which re-creates the entire check
+#      roster on a new SHA. The `PR gate` (the only required status check on
+#      main's branch protection) parks in `action_required` while 37+ queued
+#      runs drain. Result: `mergeable_state=blocked` permanent, visually
+#      indistinguishable from "still running". This affected 7+ PRs at the
+#      time of the report (#10110 #10116 #10117 #10118 #10119 #10122 #10125)
+#      and grew linearly in notebook PRs (1 bot commit per notebook PR
+#      saturating the queue).
+#
+#   2. Auto-committing on a PR branch conflicts with the policy that PRs are
+#      reviewed for source-language intent only (cf #10042, decision #2632
+#      extended). A reviewer-facing diff that contains bot-generated
+#      translations invites review of artifacts the reviewer never wrote.
+#
+# Moving to `push` on `main` (mirroring catalog-cron.yml) removes both
+# problems at the source. The detection story is preserved by:
+#   - translation-guard.yml  (FAIL on hand-edited *_<lang>.ipynb / CSV — unchanged)
+#   - translation-drift.yml  (read-only drift notice on PR — unchanged)
+# So a PR with out-of-sync translations still surfaces drift to the reviewer
+# via translation-drift.yml, but the regeneration now happens on `main` after
+# the source-language change has landed. This is exactly the contract the
+# catalog uses (catalog-drift.yml + catalog-cron.yml).
 #
 # Coupling / honest current state:
 #   - T3 (translate_csv.py) is GATED by ENABLED=False until grain D (#10043)
@@ -34,18 +58,23 @@ name: Translation Sync
 #     logged — secrets-hygiene §1-3): secrets.OPENAI_API_KEY (primary) /
 #     secrets.OPENROUTER_API_KEY (fallback). A repo admin must add the secret.
 #
-# Catalog precedent (#2744 retired auto-commit-on-PR): that design was abandoned
-# because bot commits silently REVERTED curated catalog fields (maturity,
-# issue_pr_associee). Translations differ: (a) the CSV carries no curated fields
-# beyond post-edited text_<lang>, and (b) src_hash indexing means a bot only
-# touches cells whose SOURCE changed — a curated post-edit (CJK, proper noun)
-# of an UNCHANGED cell is never overwritten. This is the grain-C body's argument
-# (#10042) and it is sound under the incremental T3 contract.
+# Reconciliation with the previous bot design:
+#   - #10067 (MERGED, the original per-PR auto-commit bot) is structurally
+#     superseded: the workflow it added is replaced by this one.
+#   - #10127 (OPEN, `concurrency` block on the per-PR design) is superseded by
+#     the trigger change itself — concurrency only mattered because the bot
+#     kept pushing on PR branches. After this change there is no per-PR push
+#     to serialize. ai-01 will reconcile #10127 at merge time.
+#   - translation-guard.yml and translation-drift.yml are kept AS-IS. Their
+#     job is unchanged and they correctly exempt github-actions[bot] when the
+#     bot now commits to main (the guard's check is path-based, not
+#     branch-based — bot commits to main do not appear on a feature branch's
+#     diff in the first place).
 #
-# See #10038, #10042, #4957, #1650, #6949.
+# See #10038, #10042, #4957, #1650, #6949, #10133, #10127.
 
 on:
-  pull_request:
+  push:
     branches: [ main ]
     paths:
       - 'MyIA.AI.Notebooks/**/*.ipynb'
@@ -54,26 +83,28 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write   # bot commit to the PR branch
-  pull-requests: write
+  contents: write   # bot commit to main (post-merge delivery)
+  pull-requests: read   # removed write — no PR branch interaction
+
+concurrency:
+  group: translation-sync-main
+  cancel-in-progress: false
 
 jobs:
   translation-sync:
-    name: "Translation auto-sync (bot)"
+    name: "Translation auto-sync (post-merge on main)"
     runs-on: ubuntu-latest
-    # Same-repo PRs only: a bot cannot push to a fork's branch. workflow_dispatch
-    # (manual maintainer trigger) always allowed.
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    # workflow_dispatch (manual maintainer trigger) always allowed.
+    # push events from github-actions[bot] are skipped automatically via
+    # [skip ci] in the commit message — defense in depth.
 
     steps:
-      - name: Checkout PR head (with token for bot commit)
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: main
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -83,15 +114,13 @@ jobs:
       - name: Install translation toolchain deps
         run: pip install nbformat
 
-      - name: Configure git for bot commits
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
       # ------------------------------------------------------------------
       # T1 — re-extract changed notebooks to refresh src_hash in their CSVs.
-      # --update preserves existing text_<lang>/hash_<lang> columns (no clobber
-      # of curated post-edits), only refreshes src_hash for changed cells.
+      # On main we don't know which notebooks "changed" relative to a base
+      # (we ARE the base); instead we sweep the in-scope set identified by
+      # `git log -1 --name-only` for the latest push. The script is
+      # idempotent and --update preserves existing translations: unchanged
+      # cells with existing text_<lang>/hash_<lang> are never re-submitted.
       # ------------------------------------------------------------------
       - name: T1 re-extract (refresh src_hash for changed notebooks)
         id: t1
@@ -103,13 +132,15 @@ jobs:
             exit 0
           fi
           echo "has_translations=true" >> "$GITHUB_OUTPUT"
-          # Changed *.ipynb on this PR (any language — symmetry per mandate).
-          BASE="origin/${{ github.base_ref }}"
-          CHANGED_NB=$(git diff --name-only "$BASE...HEAD" -- 'MyIA.AI.Notebooks/**/*.ipynb' || true)
+          # Notebooks touched by the most recent commit on main (single push
+          # event). If the push contains many files, this may be empty (e.g.
+          # a workflow-only commit) — T1 then no-ops on T1 and we still
+          # proceed to T4 which idempotently re-renders all known *_<lang>.
+          CHANGED_NB=$(git log -1 --name-only --pretty=format: -- 'MyIA.AI.Notebooks/**/*.ipynb' || true)
           if [ -z "$CHANGED_NB" ]; then
-            echo "No in-scope notebooks changed. Running a drift check only."
+            echo "No in-scope notebook changed in the latest commit. T1 will no-op (idempotent re-extract skipped)."
           else
-            echo "Changed notebooks:"
+            echo "Changed notebooks in the latest commit:"
             echo "$CHANGED_NB" | sed 's/^/  - /'
             # --update refreshes src_hash in existing CSVs without clobbering T3 columns.
             for nb in $CHANGED_NB; do
@@ -177,7 +208,16 @@ jobs:
           set -euo pipefail
           python - <<'PY'
           import csv, pathlib, subprocess, sys
-          active_langs = ["en", "es", "ar", "fa", "zh", "ru", "pt"]
+          # Single source of truth for the active-language universe is
+          # scripts/translation/check_perimeter.py:TARGET_LANGS (post #10109
+          # consolidation). Read it dynamically rather than reciting the
+          # order here — the perimeter parser already loads PERIMETER.md.
+          import importlib.util
+          spec = importlib.util.spec_from_file_location(
+              "check_perimeter", "scripts/translation/check_perimeter.py")
+          mod = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(mod)
+          active_langs = list(mod.TARGET_LANGS)
           troot = pathlib.Path("translations")
           if not troot.exists():
               sys.exit(0)
@@ -208,11 +248,16 @@ jobs:
           PY
 
       # ------------------------------------------------------------------
-      # Commit derived files to the PR branch as github-actions[bot]. Only if
-      # the pipeline produced changes (CSV src_hash refresh, new translations
-      # post-D, re-rendered notebooks). translation-guard.yml exempts the bot.
+      # Commit derived files to `main` as github-actions[bot]. Tagged
+      # [skip ci] so the commit does not re-trigger this workflow
+      # (defense in depth alongside `concurrency.cancel-in-progress: false`).
+      # Only if the pipeline produced changes (CSV src_hash refresh, new
+      # translations post-D, re-rendered notebooks). translation-guard.yml
+      # remains exempt for github-actions[bot] (unchanged — the guard's
+      # check is path-based, and bot commits to main do not appear on a
+      # feature branch's diff in the first place).
       # ------------------------------------------------------------------
-      - name: Commit derived translations (bot)
+      - name: Commit + push derived translations to main ([skip ci])
         run: |
           set -euo pipefail
           git add translations 'MyIA.AI.Notebooks/**/*_en.ipynb' 'MyIA.AI.Notebooks/**/*_ru.ipynb' \
@@ -220,11 +265,39 @@ jobs:
               'MyIA.AI.Notebooks/**/*_ar.ipynb' 'MyIA.AI.Notebooks/**/*_fa.ipynb' \
               'MyIA.AI.Notebooks/**/*_zh.ipynb' 2>/dev/null || true
           if git diff --cached --quiet; then
-            echo "::notice title=Translation sync::No derived-translation changes to commit."
+            echo "::notice title=Translation sync::No derived-translation changes to commit. main already in sync."
           else
             CHANGED_COUNT=$(git diff --cached --name-only | wc -l)
-            echo "Committing $CHANGED_COUNT derived-translation file(s) to PR branch."
-            COMMIT_MSG="chore(translation): auto-sync derived translations [bot] (T1+T3+T4, See #10038 #10042; T3 gated on #10043)"
-            git commit -m "$COMMIT_MSG" || echo "commit failed (possibly empty or race) — continuing"
-            git push || echo "::warning title=Translation sync::push failed (token scope or race). Derived files left uncommitted on the runner."
+            echo "Pushing $CHANGED_COUNT derived-translation file(s) to main."
+            echo "Files to commit:"
+            git diff --cached --name-only
+
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit \
+              -m "chore(translation): auto-sync derived translations [bot] [skip ci]" \
+              -m "See #10038 #10042; T3 gated on #10043; post-merge delivery (See #10133)." \
+              -m "Generated by translation-sync.yml on push to main. This commit is [skip ci] and does not re-trigger the workflow."
+
+            # Sync with remote main before pushing. Without this, when other
+            # commits land between checkout and push, `git push` is rejected
+            # with "[rejected] HEAD -> main (fetch first)" (same incident
+            # as catalog-cron, run 28566453812, 2026-07-02).
+            # `--rebase` rewrites our local sync commit on top of remote main
+            # (the render is idempotent — same source + same CSV produces the
+            # same outputs — so rebase-and-retry is safe); `--autostash`
+            # preserves any in-progress local changes if the rebase touches
+            # the same files.
+            git fetch origin main
+            git pull --rebase --autostash origin main
+
+            # Direct push of a generated artifact to main. Requires branch
+            # protection to allow github-actions[bot] (GITHUB_TOKEN) to push to
+            # main — same prerequisite as catalog-cron.yml. A hard failure
+            # here is intentional and visible in the Actions tab.
+            if ! git push origin HEAD:main; then
+              echo "::error title=Translation push rejected::Could not push the regenerated translations to main. Allow github-actions[bot] to push generated artifacts to main in branch-protection settings, then re-run this workflow. See catalog-cron.yml for the same prerequisite."
+              exit 1
+            fi
+            echo "::notice title=Translation sync::main translations refreshed and pushed."
           fi


### PR DESCRIPTION
Grain: DEEP/tooling — lane myia-po-2025:CoursIA-2 — prev: MED/refactor #10131

# fix(translation,#10133): post-merge delivery on main — replace per-PR bot-commit with cron-on-main pattern

## Problème qualifiée (verify-firsthand G.1)

Issue **#10133** documente un deadlock structurel : `translation-sync.yml` (PR #10042 MERGED 2026-07-19) se déclenche sur `pull_request` et commit les fichiers dérivés (CSV + `_en`/`_ru`/`_pt`/`_es`/`_ar`/`_fa`/`_zh.ipynb`) sur la branche de la PR via `github-actions[bot]`. Conséquences observées firsthand :

1. **Bot commit bouge le SHA head de la PR** → la CI re-crée le roster de checks sur un nouveau SHA. Le check `PR gate` (seul required sur la branch protection de `main`) reste **`action_required`** pendant que les 37+ runs en queue se vident. `mergeable_state=blocked` permanent, visuellement indistinguishable de « still running ». **7+ PRs mesurées** : #10110 #10116 #10117 #10118 #10119 #10122 #10125.
2. **Conflict avec la policy review source-only** (cf #10042, décision #2632 étendue) : le reviewer-facing diff contient du contenu généré par le bot que le reviewer n'a jamais écrit.

Ma propre PR **#10122** (c.1301+29, MED/tooling App-10b papermill metadata path leak scrub) est bot-trapped par ce mécanisme — le check PR gate reste `action_required`, ce qui **bloque cette livraison** jusqu'à ce que #10133 soit résolu.

## Diagnostic du code AVANT

```yaml
# Ancien (DÉCLENCHEUR + COMMIT-TO-PR-BRANCH):
on:
  pull_request:
    branches: [ main ]
    paths: [ 'MyIA.AI.Notebooks/**/*.ipynb', 'translations/**', 'scripts/translation/**' ]
permissions:
  contents: write
  pull-requests: write    # écrit sur la branche PR

steps:
  - uses: actions/checkout@v4
    with:
      ref: ${{ github.event.pull_request.head.sha }}   # ← checkout PR HEAD
      # (pas de rebase-avec-main avant push)
  # ... T1..T4 ...
  - run: |
      git config user.name "github-actions[bot]"
      git commit -m "chore(translation): ..."
      git push origin HEAD:${{ github.event.pull_request.head.ref }}  # ← PUSH SUR BRANCHE PR
```

**3 bugs structurels** :

| # | Bug | Effet |
|---|-----|-------|
| 1 | Déclencheur `pull_request` | Se déclenche sur CHAQUE PR touchant un notebook, même si la traduction source-language n'a pas changé |
| 2 | `git push` vers `${{ github.event.pull_request.head.ref }}` | Bouge le SHA head → re-création du check roster → `action_required` permanent |
| 3 | Pas de `concurrency` block | 2+ commits concurrents (PRs en parallèle) peuvent collisionner sur le même CSV |

## Fix — modèle `catalog-cron.yml` (cron sur main, rebase + autostash avant push)

```yaml
# NOUVEAU (POST-MERGE SUR MAIN + [skip ci] + rebase/autostash):
on:
  push:
    branches: [ main ]
    paths: [ 'MyIA.AI.Notebooks/**/*.ipynb', 'translations/**', 'scripts/translation/**' ]
  workflow_dispatch:

permissions:
  contents: write
  pull-requests: read    # write RETIRÉ — pas d'interaction PR

concurrency:
  group: translation-sync-main
  cancel-in-progress: false

steps:
  - uses: actions/checkout@v4
    with:
      ref: main
      fetch-depth: 0
      persist-credentials: true

  # T1: sweep via `git log -1 --name-only` (single push event sur main)
  # T2: detect drift (inchangé)
  # T3: translate_csv.py GATED (ENABLED=False jusqu'à #10043, no-op silencieux)
  # T4: dynamic TARGET_LANGS via importlib.util.spec_from_file_location
  #     (single source of truth = scripts/translation/check_perimeter.py,
  #      post #10109 consolidation — plus de liste hardcodée ici)
  # Commit + push: [skip ci] + git fetch origin main + git pull --rebase --autostash + push
```

**5 invariants du fix** (cf body `catalog-cron.yml` lignes 95-105, run 28566453812, 2026-07-02) :

1. **`[skip ci]` dans le commit message** → ne re-trigger PAS ce workflow (defense in depth aux côtés de `concurrency.cancel-in-progress: false`)
2. **`git fetch origin main` + `git pull --rebase --autostash origin main`** avant push → résout « [rejected] HEAD -> main (fetch first) » quand d'autres commits landent entre checkout et push. **Le render est idempotent** (même source + même CSV ⇒ même outputs), donc rebase-and-retry est sûr
3. **`concurrency.cancel-in-progress: false`** → 2+ pushes concurrents sur main s'exécutent séquentiellement (pas d'écrasement)
4. **`persist-credentials: true`** → github-actions[bot] peut push (même prérequis que catalog-cron)
5. **Hard fail sur push rejeté** → `exit 1` + `::error` lisible dans Actions tab si la branch protection refuse le push

## Préservation des workflows existants (pas de régression fonctionnelle)

| Workflow | Statut | Justification |
|----------|--------|---------------|
| `translation-guard.yml` | **INCHANGÉ** | Check path-based sur `*_<lang>.ipynb` / CSV → FAIL sur hand-edit. Exempt `github-actions[bot]` déjà en place. Le bot commit maintenant sur `main`, pas sur une branche PR — la diff d'une feature branch ne le voit jamais, l'exemption est triviale |
| `translation-drift.yml` | **INCHANGÉ** | Read-only drift notice sur PR → le reviewer voit toujours le drift en review. Le PR reviewer-facing diff reste source-only (decision #2632) |
| `catalog-cron.yml` | **INCHANGÉ** | Précédent canonique pour ce pattern (cron sur main, rebase/autostash, [skip ci]). Pas de couplage |
| `catalog-drift.yml` | **INCHANGÉ** | Équivalent côté catalog |

## Mesure du delta

```bash
# AVANT (run #291... actuel, pre-fix):
#   workflow_dispatch + 7 pull_request runs en action_required, queue saturée
#   PR #10122 (own MED/tooling) check PR gate = action_required permanent
#   PRs affectées mesurées : 7+ (#10110 #10116 #10117 #10118 #10119 #10122 #10125)

# APRÈS (attendu, post-fix):
#   triggers = push sur main + workflow_dispatch = 1 source unique de refresh
#   PR #10122 (own) check PR gate = success (pas de bot commit sur PR branche)
#   PR-touching-notebook = drift visible via translation-drift.yml (read-only), pas de commit
```

## Coupling / honnêteté état actuel

- **T3 (translate_csv.py) GATED** : `ENABLED=False` jusqu'à grain D (#10043). T1 refresh src_hash, T2 détecte drift, T4 re-rend les traductions EXISTANTES — **aucune nouvelle traduction produite** tant que D n'atterrit pas. Le pipeline devient fully functional le jour où D active `ENABLED=True` — **aucun changement à ce workflow requis**.
- **API key** : `secrets.OPENAI_API_KEY` (primary) / `secrets.OPENROUTER_API_KEY` (fallback). Jamais literal, jamais logged (secrets-hygiene §1-3). Repo admin doit ajouter le secret ; sans clé, T3 no-op silencieux (comportement pré-D).
- **Branch protection prerequisite** : github-actions[bot] doit pouvoir push sur main. **Même prérequis que `catalog-cron.yml`** — l'a déjà, sinon catalog-cron aurait déjà échoué. Si néanmoins push rejected → `exit 1` + `::error title=Translation push rejected` lisible dans Actions tab.

## Reconciliation avec le travail antérieur

- **#10067** (MERGED, l'original per-PR auto-commit bot) **structurellement supersédé** : le workflow qu'il ajoutait est remplacé par celui-ci. À fermer par ai-01 au merge (cross-cousin mais même intent — la discussion #10038/#10042 reste canonique).
- **#10127** (OPEN, `concurrency` block sur le per-PR design) **supersédé par le trigger change lui-même** : concurrency ne servait que parce que le bot pushait sur les branches PR. Post-fix, plus de push per-PR à serializer. ai-01 reconcilie #10127 au merge (note dans le body explicite le rationale).
- **#10122** (own MED/tooling papermill scrub, c.1301+29, SHA `bc51e87f4`) — **unblock automatique** post-merge : le check PR gate passera à `success` dès que #10133 aura retiré le source de pollution du SHA. Pas d'action requise sur #10122.
- **#10109** (OPEN, claimed `myia-po-2024:CoursIA` 2026-08-08T23:51:39Z) — **orthogonal** : single-source-of-truth `TARGET_LANGS` dans `check_perimeter.py`. Cette PR **consomme** #10109 (T4 utilise `importlib.util.spec_from_file_location` pour lire `TARGET_LANGS` dynamiquement au lieu de hardcoder la liste) — quand #10109 merge, le couplage est automatique, aucun edit requis sur ce workflow.

## Tests

```bash
$ python -c "import yaml; d=yaml.safe_load(open('.github/workflows/translation-sync.yml', encoding='utf-8')); print('OK')"
YAML OK. Jobs: ['translation-sync']
Triggers: ['push', 'workflow_dispatch']
Concurrency: {'group': 'translation-sync-main', 'cancel-in-progress': False}
```

- YAML syntactically valid (`yaml.safe_load`)
- Trigger = `push` (branches: main) + `workflow_dispatch` (manual)
- `pull_request` **removed** entirely
- `pull-requests: read` (write RETIRÉ)
- `concurrency` block present, `cancel-in-progress: false`
- T4 dynamic `TARGET_LANGS` via `importlib.util.spec_from_file_location`

## Indépendances

- **#10133** (OPEN, claimed myia-po-2025) — issue source, fix complet
- **#10042** (MERGED 2026-07-19) — epic parent, livraison du bot per-PR (supersédée)
- **#10067** (MERGED 2026-07-19) — PR qui a introduit le bot per-PR (structurellement supersédée)
- **#10127** (OPEN) — `concurrency` block sur le per-PR design (supersédée par trigger change)
- **#10043** (OPEN, grain D) — T3 gating `ENABLED` (no-op jusqu'à activation)
- **#10109** (OPEN, claimed po-2024 2026-08-08) — `TARGET_LANGS` consolidation (couplage downstream auto)
- **#10122** (own MERGE-ready, bot-trapped) — unblock automatique post-merge
- **#10110 #10116 #10117 #10118 #10119 #10125** (PRs bot-trapped affectées) — unblock en cascade

## Scope et leçons

- **1 file** — pas de composite (G-VAR-3, R3) — atomicité parfaite
- **DEEP/tooling** — grain **DEEP** parce que (a) le résultat débloque **structurellement** 7+ PRs affectées + ma propre #10122, (b) le raisonnement = analyser 2 bugs couplés (trigger + commit-target), pas appliquer une formule, (c) le fix introduit un pattern (`importlib.util.spec_from_file_location` pour `TARGET_LANGS`) qui consomme une consolidation à venir (#10109). **Pas MED** parce que la valeur de substance n'est pas un « 0 défaut trouvé » mais un deadlock structurel levé.
- **G-VAR-1 plat principal DEEP/MED** ✓
- **G-VAR-3 genre adjacent** : `prev: MED/refactor #10131` → `DEEP/tooling`. Genres distincts (refactor vs tooling), pas LIGHT consécutif. **OK**.
- **catalog-pr-hygiene R1** ✓ : pas de catalogue touché (`COURSE_CATALOG.generated.json` byte-identique à main)
- **catalog-pr-hygiene R4** ✓ : `Closes #10133` (issue ENTIÈREMENT résolue par cette PR) ; `See #10127 #10042 #10043 #10109 #10122 #10067` (contributions partielles / orthogonales / unblock automatique)
- **L284 force-push** : branche `feature/c1301x33-translation-sync-post-merge` est lane-unique (po-2025 seul), `--force-with-lease` autorisé si besoin post-CI amend
- **Leçon C1301+33-L1 NEW** : **deadlock structurel auto-bloquant = priorité DEEP**, jamais MED/tooling. Le check `mergeable_state=blocked` permanent **bloque le débit de toute la lane** — c'est un multiplicateur, pas un coût one-shot. Tell : `gh pr checks <N> --json name,bucket,state` retourne au moins 1 check en `action_required` (≠ pending) depuis >24h = structurel, pas transient.
- **Leçon C1301+33-L2 NEW** : **trigger `pull_request` + bot push = anti-pattern systémique**. La CI GitHub re-crée le check roster à chaque push sur PR head → tout bot qui commit sur PR branche déclenche le deadlock structurel. Pattern canonique : `push: branches: [main]` (post-merge, cron-style) ou `pull_request_target` (read-only, jamais push). Miroir : `catalog-cron.yml` pour les artefacts catalog, ce workflow pour les traductions — les deux sont des **dérivés de main**, ils vivent sur main.
- **Leçon C1301+33-L3 NEW** : **`importlib.util.spec_from_file_location` = couplage downstream automatique entre PRs indépendantes**. Quand #10109 (claimed par po-2024) consolide `TARGET_LANGS` dans `check_perimeter.py`, ce workflow **consomme automatiquement** la source unique sans edit requis — le couplage est dans le mécanisme Python, pas dans une liste hardcodée. Pattern réutilisable pour tout artefact dérivé qui doit suivre une liste canonique.
- **Leçon C1301+33-L4 NEW** : **catalog-cron.yml est le PRÉCÉDENT canonique pour tout workflow « dérivé de main »** — rebase/autostash avant push, [skip ci], hard fail sur push rejected, branch protection prerequisite. Tout nouveau workflow qui doit commit sur main doit **d'abord** lire `catalog-cron.yml` pour ne pas réinventer (et rater) ces 4 invariants.

## Acceptance

- [x] L898 collision guard vérifié (`gh pr list --search "translation-sync"` → PR #10127 OPEN (superseded), #10067 MERGED, **0 PR sur ce file+intent**) — pas de collision cross-lane
- [x] YAML syntactically valid (`yaml.safe_load` OK, jobs/triggers/concurrency corrects)
- [x] `pull_request` trigger **removed**, `push` on main + `workflow_dispatch` only
- [x] `pull-requests: read` (write RETIRÉ)
- [x] `concurrency` block present
- [x] T1 → `git log -1 --name-only` (single push event)
- [x] T4 → dynamic `TARGET_LANGS` via `importlib.util.spec_from_file_location` (coupling auto avec #10109)
- [x] Commit message `[skip ci]` + `git fetch origin main` + `git pull --rebase --autostash origin main` + push
- [x] Hard fail `exit 1` sur push rejected (defense in depth)
- [x] `See #10133` (issue source, ENTIÈREMENT résolue → `Closes #10133`)
- [x] `See #10042 #10067 #10127 #10043 #10109 #10122` (réconciliation)