### PR TITLE
docs(conway-lean): mark P4 inductive-step docstring as discharged (stale verrou-sorry gone)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness/Foundation.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness/Foundation.lean
@@ -1991,17 +1991,25 @@ theorem hashlifeResult_central_correct_base (c : MacroCell)
 
 /-! ## P4 inductive step — scaffolding for the double-nine decomposition
 
-The sorry at `p4_ext_bridge c (k+1) (fun p => by sorry)` is the **research-level
-verrou** of the whole module. It demands the pointwise membership biconditional:
+The P4 inductive step is **discharged** in the current source. The pointwise
+membership biconditional it demanded —
 
     ∀ p, p ∈ (hashlifeResultAux (k+2) c).toGrid (2^k, 2^k)
          ↔ p ∈ restrictGridTo (evolve (2^k) (c.toGrid (0,0))) (2^k) (2^(k+1))
 
-`p4_ext_bridge` (proven) reduces list-equality to this biconditional, so once
-the biconditional is discharged, `hashlifeResult_central_correct` closes by
-induction. The function `p4_succ_membership` below is the **single named
-entry point** that gathers the four sub-lemmas; each sub-lemma is an
-independent, difficulty-ranked prover target (grignotable one-per-session).
+— is proven by `p4_succ_membership` (aggregator `HashlifeCorrectness.lean`,
+sorry-free body), which gathers the four sub-lemmas below. The aggregator's
+`hashlifeResult_central_correct` consumes it via `p4_ext_bridge` (proven here):
+its `k → k+1` case applies `p4_ext_bridge` to the `p4_succ_membership`
+biconditional to close. The **live open target** is now the P5 large-`n` jump
+`p5_large_n_jumpN` (aggregator, `:= by sorry`), which is P4-gated on exactly
+this inductive step being closed.
+
+NOTE for readers/provers: earlier drafts carried the biconditional as
+`p4_ext_bridge c (k+1) (fun p => by sorry)` — that sorry is gone (the call-site
+now passes the proven `p4_succ_membership`). Do not hunt for it; the
+`p4_ext_bridge`/`p4_succ_membership`/`hashlifeResult_central_correct` chain is
+the closed P4 step.
 
 ### Proof plan (the double-nine, two half-steps)
 


### PR DESCRIPTION
## docs(conway-lean): mark P4 inductive-step docstring as discharged (stale "research-level verrou" sorry is gone)

**Grain:** LIGHT/lean-docstring — lane `myia-po-2026:CoursIA`. This completes the **verification-half of #9863** (ai-01 steer msg-20260808T141643: "cette vérification EST la première moitié du grain"). The verdict — **P4 inductive step closed, `p5_large_n_jumpN` is the live P4-gated target** — was delivered c.1003 via DM+dashboard; this PR makes it durable in-source by correcting the docstring that contradicted it. R6: lean-track cleanup (continues lean→guard→.NET→audit→docs→lean-forensic→lean-docstring).

## Quoi

`Foundation.lean`'s P4 scaffolding module-doc-comment (around the `## P4 inductive step` section) described the pointwise-membership biconditional as an open "research-level verrou", citing a sorry that **no longer exists**:

> The sorry at `p4_ext_bridge c (k+1) (fun p => by sorry)` is the **research-level verrou** of the whole module. [...] `p4_ext_bridge` (proven) reduces list-equality to this biconditional, so **once the biconditional is discharged**, `hashlifeResult_central_correct` closes by induction.

The docstring was **self-contradictory** ("p4_ext_bridge proven" two lines after "the sorry ... research-level verrou") and **stale**: the biconditional is now proven by `p4_succ_membership`, and `hashlifeResult_central_correct` consumes it via `p4_ext_bridge`. This PR rewrites the intro paragraph to state the step is discharged and points to the real live target, and adds a NOTE pre-empting the trap.

## Preuve (G.1 — firsthand, not keywords)

Read directly in a worktree off `origin/main 403f139be`. **Code-level sorry (robust strip of docstrings + line comments), aggregator `HashlifeCorrectness.lean`:**

| declaration | line | status |
|---|---|---|
| `p4_double_nine_shape` / `p4_wave1_ih` / `p4_wave2_ih` / `p4_ext_bridge` | Foundation.lean | sorry-free (P4 split module = 0 real sorry) |
| `p4_succ_membership` (noncomputable def) | aggregator L107 | sorry-free body (calls the 4 sub-lemmas above) |
| `hashlifeResult_central_correct` | aggregator L666 | **proven** — `k→k+1` case applies `p4_ext_bridge c (k+1) (p4_succ_membership c (k+1) …)` (call-site L691; argument is the *proven* biconditional, not sorry) |
| `p5_large_n_jumpN` | aggregator L1156 | `:= by sorry` (L1159) — **the sole remaining code-level sorry in conway_lean** |

So `BLOCKED ⟺ p5_large_n_jumpN` (P5 large-`n` jump, P4-gated on exactly this inductive step being closed). The P4 step is closed.

**G.9 honesty caveat (grep ≠ compilation):** the sorry-free bodies are read directly, but `lake build` was not run here (WSL contention + fleet-wide GitHub Actions queue stall). The claim is "the source carries no other code-level sorry and the P4 chain bodies are sorry-free as read", not "lake build SUCCESS verified". ai-01's steer flagged exactly this gap as acceptable for the verification-half ("un verdict mesuré est un livrable acceptable").

## Périmètre

**Comment-only** (inside the `/-! … -/` module doc comment at Foundation.lean L1992). No theorem statement, tactic, or proof body touched. The "Proof plan" + sub-lemmas table below the intro are preserved (still accurate architecture). `/-!`(L1992) … `-/`(L2040) delimiters intact. Anti-régression §D does not apply (no proof/impl replaced).

**Trap-safe:** `.lean` edit, not `.ipynb` → `translation-sync.yml` paths filter (`MyIA.AI.Notebooks/**/*.ipynb`) does not match → no bot-commit → CLEAN (not subject to the #10114 trap).

## PR hygiene

- **catalog-pr-hygiene R1** ✓ (catalogue byte-identical — 1 .lean file, no markers).
- **R2** fresh off `origin/main 403f139be` ✓ (isolated worktree).
- **R3** atomic (1 subject: P4 docstring discharge note) ✓.
- **R4** `See #9863` (not `Closes` — live target `p5_large_n_jumpN` remains to be proven).
- **i18n** ✓ (Foundation.lean has no `_en` twin — no byte-identity constraint).

## Follow-up noted (out of scope)

`conway_lean/README.md` + `README.en.md` still cite **pre-split monolith line numbers** and an **"8 sorry" count** that no longer matches post-split code (now **1** code-level sorry). Separate grain (the README has detailed per-declaration tables — bigger, riskier edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
