### PR TITLE
Grain: MED/tooling — normalize per-execution ipykernel PIDs in re-exec path (#10061)

### DIFF
--- a/scripts/notebook_tools/batch_reexecute.py
+++ b/scripts/notebook_tools/batch_reexecute.py
@@ -41,6 +41,33 @@ def needs_reexecution(entry: dict) -> bool:
     return False
 
 
+def _normalize_kernel_paths(nb_path: Path) -> int:
+    """Redact kernel-injected username paths and normalize per-execution PIDs
+    on a freshly re-executed notebook.
+
+    Wires ``strip_machine_paths.strip_in_place`` into the re-exec path
+    (#10061) so that the two churn sources that change on every run — the
+    username absolute path and the ``ipykernel_<N>`` PID — are normalized in
+    a single place. This makes two re-executions of the same notebook
+    redact to byte-identical output (no spurious ``git diff``), removing the
+    need for a manual post-hoc scrub per notebook. Returns the number of
+    leak lines normalized (0 when the re-exec produced no kernel-injected
+    paths, or when the normalizer is unavailable).
+    """
+    try:
+        here = str(Path(__file__).resolve().parent)
+        if here not in sys.path:
+            sys.path.insert(0, here)
+        from strip_machine_paths import strip_in_place
+    except ImportError:
+        return 0
+    try:
+        _outputs_with_leak, lines_fixed = strip_in_place(nb_path)
+    except Exception:
+        return 0
+    return lines_fixed
+
+
 def get_kernel_name(entry: dict) -> str:
     """Map catalog kernel to papermill kernel name."""
     kernel = entry.get("kernel", "").lower()
@@ -75,8 +102,10 @@ def execute_notebook(nb_path: Path, kernel: str, timeout: int) -> dict:
         )
 
         if result.returncode == 0:
+            normalized = _normalize_kernel_paths(nb_path)
             backup_path.unlink(missing_ok=True)
-            return {"path": str(nb_path), "status": "SUCCESS"}
+            return {"path": str(nb_path), "status": "SUCCESS",
+                    "normalized": normalized}
         else:
             # Restore backup on failure
             shutil.copy2(backup_path, nb_path)

--- a/scripts/notebook_tools/strip_machine_paths.py
+++ b/scripts/notebook_tools/strip_machine_paths.py
@@ -227,6 +227,35 @@ def _normalize_bs(text):
 # as **not** a leak on the next scan — making ``--apply-all`` idempotent.
 REDACTED_PATH = "<USER_PATH>"
 
+# Numeric process IDs that change on every kernel launch. Unlike the
+# username prefix (a stable per-worker leak) a PID is **per-execution**:
+# the same notebook re-executed twice emits two different
+# ``ipykernel_<N>`` temp paths, producing a spurious ``git diff`` even
+# after the username has been redacted. Normalizing the PID to a stable
+# placeholder makes the redacted output byte-identical across re-execs
+# (motivation: #10061 — the 10 notebooks sharing an ``ipykernel_<N>``
+# numeric churn). The PID carries no pedagogy, unlike the trailing
+# per-cell source hash (``<hash>.py``), which is stable per cell and is
+# left untouched. Currently scoped to the ipykernel family (the proven
+# churn source); ``/proc/<N>`` / ``pid=<N>`` are deferred to a follow-up
+# — they are rarer in notebook outputs and broader matching risks
+# normalizing legitimate numeric literals.
+_IPYKERNEL_PID_PATTERN = re.compile(r"ipykernel_\d+")
+
+
+def _normalize_runtime_pids(text):
+    """Replace per-execution numeric PIDs with stable placeholders.
+
+    Covers the ipykernel per-cell temp directory (``ipykernel_<N>``) so that
+    two re-executions of the same notebook redact to the same
+    ``ipykernel_<pid>`` form instead of differing on the PID. Applied after
+    the username-redaction loop in :func:`_redact_line`, so every caller of
+    the strip pipeline benefits from a single normalization site.
+    """
+    if not isinstance(text, str):
+        return text
+    return _IPYKERNEL_PID_PATTERN.sub("ipykernel_<pid>", text)
+
 # Output fields that can carry the leak:
 # - ``data["text/plain"]`` / ``data["text/html"]`` for ``display_data`` /
 #   ``execute_result`` outputs.
@@ -366,7 +395,10 @@ def _redact_line(text):
         # may be mid-line; bytes before it carry the first runtime prefix
         # that we want to keep in the output).
         out = out[:drive_start] + REDACTED_PATH + "\\" + out[after_marker:]
-    return out
+    # Normalize per-execution PIDs (e.g. ``ipykernel_30104`` -> ``ipykernel_<pid>``)
+    # so two re-execs redact to the same form (no spurious diff). Applied after the
+    # username loop so the redacted trailing path is normalized too.
+    return _normalize_runtime_pids(out)
 
 
 def _field_value(out, key):

--- a/scripts/notebook_tools/tests/test_batch_reexecute.py
+++ b/scripts/notebook_tools/tests/test_batch_reexecute.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from batch_reexecute import get_kernel_name, needs_reexecution
+from batch_reexecute import get_kernel_name, needs_reexecution, _normalize_kernel_paths
 
 
 # ---------------------------------------------------------------------------
@@ -90,3 +90,83 @@ class TestGetKernelName:
     def test_dotnet_in_name(self):
         """Any '.net' substring maps to .net-interactive."""
         assert get_kernel_name({"kernel": ".NET Interactive"}) == ".net-interactive"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_kernel_paths — strip_machine_paths wired into the re-exec path (#10061)
+# ---------------------------------------------------------------------------
+
+def _nb_with_ipykernel_leak(pid: int):
+    """Build a minimal nbformat-4 notebook whose single code cell carries a
+    stream output with a username + ipykernel_<pid> kernel-injected path."""
+    return {
+        "cells": [
+            {
+                "cell_type": "code",
+                "execution_count": 1,
+                "source": ["print('hi')\n"],
+                "outputs": [
+                    {
+                        "output_type": "stream",
+                        "name": "stderr",
+                        "text": [
+                            f"C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_{pid}"
+                            f"\\1424116259.py:8: DeprecationWarning\n"
+                        ],
+                    }
+                ],
+                "metadata": {},
+            }
+        ],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+class TestNormalizeKernelPaths:
+    """#10061 — re-exec must auto-normalize username paths AND per-execution
+    PIDs so two runs produce byte-identical output (no spurious diff)."""
+
+    def test_normalizes_username_and_pid(self, tmp_path):
+        import json
+
+        nb_path = tmp_path / "nb.ipynb"
+        nb_path.write_text(json.dumps(_nb_with_ipykernel_leak(30104)), encoding="utf-8")
+
+        fixed = _normalize_kernel_paths(nb_path)
+        # The leak line was detected and normalized.
+        assert fixed >= 1
+        out = json.loads(nb_path.read_text(encoding="utf-8"))
+        text = out["cells"][0]["outputs"][0]["text"][0]
+        # Username is redacted, PID is normalized to the stable placeholder.
+        assert "jsboi" not in text
+        assert "30104" not in text
+        assert "ipykernel_<pid>" in text
+        assert "<USER_PATH>" in text
+        # The per-cell source hash (stable, pedagogy) survives.
+        assert "1424116259.py" in text
+
+    def test_two_reexecs_produce_identical_output(self, tmp_path):
+        """Acceptance (a): two re-execs differing only in the PID redact to the
+        same byte-identical output → empty git diff on the PID motif."""
+        import json
+
+        a = tmp_path / "a.ipynb"
+        b = tmp_path / "b.ipynb"
+        a.write_text(json.dumps(_nb_with_ipykernel_leak(30104)), encoding="utf-8")
+        b.write_text(json.dumps(_nb_with_ipykernel_leak(55982)), encoding="utf-8")
+        _normalize_kernel_paths(a)
+        _normalize_kernel_paths(b)
+        assert a.read_text(encoding="utf-8") == b.read_text(encoding="utf-8")
+
+    def test_idempotent(self, tmp_path):
+        """Re-normalizing an already-clean notebook is a no-op (no leak → 0)."""
+        import json
+
+        nb_path = tmp_path / "nb.ipynb"
+        nb_path.write_text(json.dumps(_nb_with_ipykernel_leak(30104)), encoding="utf-8")
+        first = _normalize_kernel_paths(nb_path)
+        assert first >= 1
+        second = _normalize_kernel_paths(nb_path)
+        assert second == 0

--- a/scripts/notebook_tools/tests/test_strip_machine_paths.py
+++ b/scripts/notebook_tools/tests/test_strip_machine_paths.py
@@ -41,6 +41,7 @@ from strip_machine_paths import (
     _redact_line,
     _first_matching_label,
     _normalize_bs,
+    _normalize_runtime_pids,
 )
 
 
@@ -557,7 +558,7 @@ def test_redact_line_per_category():
     """
     cases = [
         (_PIP_LINE, "AppData\\Roaming\\Python"),
-        (_IPYKERNEL_LINE, "AppData\\Local\\Temp\\ipykernel_30104"),
+        (_IPYKERNEL_LINE, "AppData\\Local\\Temp\\ipykernel_<pid>"),
         (_CONDA_LINE, ".conda\\envs\\mcp-jupyter-py310"),
         (_HF_LINE, ".cache\\huggingface"),
         (_OTHER_LINE, "AppData\\Local\\Temp\\test_audio.mp3"),
@@ -570,6 +571,32 @@ def test_redact_line_per_category():
         # The stable placeholder MUST appear at least once (the username
         # was successfully redacted to the placeholder form).
         assert "<USER_PATH>" in redacted, (line, redacted)
+
+
+def test_normalize_runtime_pids_stable_across_reexec():
+    """#10061 — the ipykernel per-execution PID must normalize to a stable
+    placeholder so two re-execs of the same notebook redact byte-identically
+    (no spurious ``git diff``). The PID carries no pedagogy; the trailing
+    per-cell source hash (``<hash>.py``) is stable per cell and MUST survive.
+    """
+    # Two raw kernel lines differing ONLY in the PID (as a fresh re-exec would).
+    a = r"C:\Users\jsboi\AppData\Local\Temp\ipykernel_30104\1424116259.py:8: DeprecationWarning"
+    b = r"C:\Users\jsboi\AppData\Local\Temp\ipykernel_55982\1424116259.py:8: DeprecationWarning"
+    red_a = _redact_line(a)
+    red_b = _redact_line(b)
+    # The PIDs are gone, replaced by the stable placeholder...
+    assert "30104" not in red_a and "55982" not in red_b, (red_a, red_b)
+    assert "ipykernel_<pid>" in red_a and "ipykernel_<pid>" in red_b
+    # ...so the two redactions are byte-identical (acceptance: empty diff on
+    # the PID motif across two re-execs).
+    assert red_a == red_b, (red_a, red_b)
+    # The per-cell source hash (stable, carries pedagogy) is preserved verbatim.
+    assert "1424116259.py" in red_a
+    # The unit normalizer is idempotent (re-applying is a no-op).
+    assert _normalize_runtime_pids(red_a) == red_a
+    # Non-ipykernel numerics are NOT touched (conservative scope: only the
+    # ipykernel family, not arbitrary digits).
+    assert _normalize_runtime_pids("version 3.10.2 pid=99") == "version 3.10.2 pid=99"
 
 
 def test_redact_line_per_category_audit_extension_3_tokens():


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/docs #10130

Normalise le PID ipykernel par-exécution dans le chemin de re-exec, pour tarir à la source le churn de diff que ces PID provoquent à chaque re-exec (dispatch ai-01, grains #10061 / #10066).

## Quoi

Le chemin temporaire `ipykernel_<N>` change à **chaque** lancement de kernel. Deux re-exécutions du même notebook diffèrent donc sur le PID **même après** que le préfixe username a été redacté → faux `git diff` sur ~10 notebooks, et un scrub manuel post-hoc obligatoire à chaque fois.

La correction se fait **à la source** (l'outil de re-exec), pas notebook-par-notebook :

- `strip_machine_paths._normalize_runtime_pids()` remplace `ipykernel_<N>` par le placeholder stable `ipykernel_<pid>`, appliqué dans `_redact_line()` **après** la boucle de redaction username → tous les callers du pipeline strip en bénéficient. Scope : famille ipykernel uniquement (source de churn prouvée) ; le hash de source par-cellule `<hash>.py` (pédagogie, stable par cellule) est **préservé**.
- `batch_reexecute._normalize_kernel_paths()` câble `strip_in_place()` dans le chemin SUCCESS de `execute_notebook`, donc une re-exec auto-redacte username **ET** normalise les PID en un seul endroit. Retourne le nombre de lignes normalisées.

## Preuve

Acceptance #10061 (3 critères de ai-01) :

- **(a) re-exec → diff vide deux fois sur le PID** : `test_two_reexecs_produce_identical_output` — deux notebooks ne différant que par le PID (30104 vs 55982) redactent en output **byte-identical**.
- **(b) test qui mord** : `test_normalize_runtime_pids_stable_across_reexec` (PID présent avant, absent après, hash de cellule préservé) + `test_normalizes_username_and_pid` (username redacté PID normalisé).
- **(c) aucun output hand-édité** : la PR ne touche **aucun notebook** (4 fichiers `.py` uniquement) — c'est l'outil qui normalise, pas l'humain qui scrubbe.

Suite complète : **4355 tests passés** (`scripts/notebook_tools/tests/`, 0 régression, 111.7s). Bite-test avant/après :

```
a = C:\Users\jsboi\...\ipykernel_30104\1424116259.py:8: DeprecationWarning
b = C:\Users\jsboi\...\ipykernel_55982\1424116259.py:8: DeprecationWarning
_redact_line(a) == _redact_line(b) == <USER_PATH>\...\ipykernel_<pid>\1424116259.py:8: DeprecationWarning
```

## Perimetre

- `scripts/notebook_tools/strip_machine_paths.py` (+34) : pattern `_IPYKERNEL_PID_PATTERN` + `_normalize_runtime_pids()`, appliqué dans `_redact_line`.
- `scripts/notebook_tools/batch_reexecute.py` (+31) : helper `_normalize_kernel_paths()` câblé dans `execute_notebook` SUCCESS path.
- `scripts/notebook_tools/tests/test_strip_machine_paths.py` (+29) : import, assertion ligne 560 mise à jour, nouveau biting test.
- `scripts/notebook_tools/tests/test_batch_reexecute.py` (+82) : import + fixture `_nb_with_ipykernel_leak(pid)` + 3 tests `TestNormalizeKernelPaths`.

Hors scope (explicit) : `/proc/<N>` / `pid=<N>` (plus rares, matching trop large risquerait de normaliser des littéraux numériques légitimes) — follow-up le cas échéant. Aucun notebook touché. Catalogue byte-identique à `main` (`diff -q` OK).

See #10061
See #10066

🤖 Generated with [Claude Code](https://claude.com/claude-code)
