### PR TITLE
fix(ci,#10139): pin gitleaks 8.24.3 sur les DEUX gates + 5 placeholders pedagogiques en allowlist

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -24,3 +24,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml
+          # PINNED, and it must stay in lockstep with `rev` in
+          # .pre-commit-config.yaml -- gated by scripts/check_hooks_parity.py.
+          # Left unset, the action falls back to a version hard-coded in its own
+          # source (`GITLEAKS_VERSION || "8.24.3"`, src/index.js), i.e. an
+          # implicit pin owned by a third party and revisable by any @v2 release
+          # without a commit here. Version choice is NOT cosmetic: on identical
+          # content this repo measures 8.21.2 -> 0 findings, 8.24.3 -> 2. The
+          # hook used to pin 8.21.2 while CI ran 8.24.3, so a clean pre-commit
+          # pass did not predict CI. See #10139.
+          GITLEAKS_VERSION: 8.24.3

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -9,6 +9,17 @@ title = "CoursIA Secret Scanner"
 # silent no-op both in the pre-commit hook and in CI (secret-scan.yml sets
 # GITLEAKS_CONFIG=.gitleaks.toml). The allowlist below still applies on top of
 # the defaults (verified: secrets detected + base64-blob FP suppressed). See #9888.
+#
+# WARNING — this directive's behaviour is VERSION-DEPENDENT, so both gates MUST
+# pin the SAME gitleaks version: GITLEAKS_VERSION in secret-scan.yml (CI) and
+# `rev` in .pre-commit-config.yaml (local). Parity is gated by
+# scripts/check_hooks_parity.py; do not change one without the other.
+# Measured on this repo, same files and same config, three binaries:
+#     8.21.2 -> 0 findings   |   8.24.3 -> 2   |   8.30.1 -> 2
+# `useDefault = true` is therefore NOT equivalent to running with no config at
+# all: the implicit default suppresses what the *extended* default reports. Left
+# unpinned, the hook (8.21.2) silently disagreed with CI (8.24.3) — a clean
+# local commit was rejected in CI with no way to see it coming. See #10139.
 [extend]
 useDefault = true
 
@@ -32,4 +43,26 @@ regexes = [
     '''os\.getenv\(['\"][A-Z_]+['\"]\)''',  # env var reads without defaults
     '''data:image/[a-z]+;base64,''',  # Inline base64 images in outputs
     '''^[A-Za-z0-9+/]{100,}={0,2}$''',  # Base64 blobs (long lines typical of image outputs)
+]
+
+# Teaching placeholders and model identifiers that `generic-api-key` reads as
+# assignments. Each entry was read at its source before being listed here — all
+# are non-secrets, so no rotation applies. Kept as stopwords (substring match on
+# the finding) rather than paths, so a REAL secret in the same file still fails.
+#   abcd1234           sample .env block in a MARKDOWN cell of
+#                      GenAI/Texte/10_LocalLlama.ipynb ("sk-abcd1234ABCD1423")
+#   SECRET-KEY         same cell: "sk-MINI-SECRET-KEY", "sk-MEDIUM-SECRET-KEY"
+#   dummy_key          "dummy_key_for_validation" in
+#                      GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb
+#   no-key-needed      conventional value for a keyless local vLLM endpoint
+#   GPT-4o-Transcribe  a MODEL NAME, flagged because it follows "API," in a
+#                      "**Technologies :**" bullet
+# These surface x7 once translation-sync derives each source into every target
+# language (#10133), so one unlisted FP blocks up to 7 PRs. See #10139.
+stopwords = [
+    "abcd1234",
+    "SECRET-KEY",
+    "dummy_key",
+    "no-key-needed",
+    "GPT-4o-Transcribe",
 ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,13 +6,21 @@
 
 repos:
   # gitleaks: scans STAGED content before it enters history. Uses the hook's
-  # canonical v8.21.2 entry (`gitleaks protect --verbose --redact --staged`,
-  # pass_filenames: false) -- do NOT override `args` with the old `detect
-  # --no-git` form: that appends to the canonical entry and gitleaks rejects
-  # the combined flags (#9888). `protect` scans uncommitted changes (fast,
-  # correct for pre-commit); `detect` would scan full git history (slow).
+  # canonical upstream entry -- since v8.22 that is
+  # `gitleaks git --pre-commit --redact --staged --verbose` (it was
+  # `gitleaks protect ...` at v8.21.2; `protect` still resolves but is no longer
+  # listed as a command). Do NOT override `args` with the old `detect --no-git`
+  # form: that appends to the canonical entry and gitleaks rejects the combined
+  # flags (#9888). `git --staged` scans uncommitted changes (fast, correct for
+  # pre-commit); `detect` would scan full git history (slow).
+  #
+  # `rev` MUST match GITLEAKS_VERSION in .github/workflows/secret-scan.yml --
+  # gated by scripts/check_hooks_parity.py, do not bump one alone. The versions
+  # disagree on real content: on the files that blocked 5 PRs, 8.21.2 reported 0
+  # findings and 8.24.3 reported 2, so pinning 8.21.2 here while CI ran 8.24.3
+  # meant a green pre-commit did not predict CI. See #10139.
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.21.2
+    rev: v8.24.3
     hooks:
       - id: gitleaks
         name: Secret scanner (gitleaks)

--- a/scripts/check_hooks_parity.py
+++ b/scripts/check_hooks_parity.py
@@ -32,11 +32,17 @@ What it checks
 --------------
 1. ``.pre-commit-config.yaml`` exists and parses as YAML.
 2. ``pre-commit`` binary is on PATH.
-3. ``gitleaks`` binary is on PATH (since the config declares v8.21.2).
+3. *(removed -- see "Gate 3" note in ``_run_checks``: gitleaks lives in
+   pre-commit's own cache and never has to be on the system PATH.)*
 4. ``.git/hooks/pre-commit`` is installed (produced by ``pre-commit install``).
 5. The id of each hook declared in the config matches an id the framework
    will execute (best-effort: relies on ``pre-commit validate-config``).
-6. **NEW**: each local hook's ``entry`` script exists on disk (PyYAML pair).
+6. each local hook's ``entry`` script exists on disk (PyYAML pair).
+7. **NEW** (#10139): the gitleaks version pinned by the hook's ``rev`` equals
+   the one pinned by ``GITLEAKS_VERSION`` in ``secret-scan.yml``. Measured
+   need: on identical content, 8.21.2 reported 0 findings where 8.24.3
+   reported 2, so a hook pinned to 8.21.2 could not reproduce -- nor warn
+   about -- what CI rejected.
 
 Why advisory only
 -----------------
@@ -68,6 +74,7 @@ except ImportError:
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CONFIG_PATH = REPO_ROOT / ".pre-commit-config.yaml"
 HOOK_PATH = REPO_ROOT / ".git" / "hooks" / "pre-commit"
+SECRET_SCAN_PATH = REPO_ROOT / ".github" / "workflows" / "secret-scan.yml"
 
 
 def _declared_hook_ids() -> list[str]:
@@ -187,6 +194,52 @@ def _entry_script(entry: str) -> str | None:
     return next((p for p in parts if p.endswith(".py")), None)
 
 
+def _hook_gitleaks_version() -> str | None:
+    """Version pinned by the gitleaks hook's ``rev``, ``v`` prefix stripped.
+
+    Returns ``None`` when no gitleaks repo is declared at all.
+    """
+    if yaml is None:
+        raise RuntimeError("PyYAML not installed; install with `pip install pyyaml`")
+    data = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{CONFIG_PATH}: top-level must be a mapping")
+    for repo in data.get("repos", []) or []:
+        if not isinstance(repo, dict):
+            continue
+        url = str(repo.get("repo", ""))
+        if "gitleaks" in url and repo.get("rev"):
+            return str(repo["rev"]).lstrip("v")
+    return None
+
+
+def _ci_gitleaks_version() -> str | None:
+    """Version pinned by ``GITLEAKS_VERSION`` in the Secret Scan workflow.
+
+    Returns ``None`` when the workflow exists but pins nothing -- which is a
+    real finding, not an absence of information: unset, the action falls back
+    to a version hard-coded in its own source, i.e. an implicit pin owned by a
+    third party that any ``@v2`` release can revise without a commit here.
+    """
+    if yaml is None:
+        raise RuntimeError("PyYAML not installed; install with `pip install pyyaml`")
+    if not SECRET_SCAN_PATH.exists():
+        raise FileNotFoundError(f"{SECRET_SCAN_PATH} missing")
+    data = yaml.safe_load(SECRET_SCAN_PATH.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{SECRET_SCAN_PATH}: top-level must be a mapping")
+    for job in (data.get("jobs") or {}).values():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps", []) or []:
+            if not isinstance(step, dict):
+                continue
+            env = step.get("env")
+            if isinstance(env, dict) and env.get("GITLEAKS_VERSION"):
+                return str(env["GITLEAKS_VERSION"]).lstrip("v")
+    return None
+
+
 def _run_checks() -> list[tuple[str, str, str]]:
     """Return list of (gate, status, detail). status in {"OK", "KO", "ERR"}."""
     out: list[tuple[str, str, str]] = []
@@ -269,6 +322,42 @@ def _run_checks() -> list[tuple[str, str, str]]:
             out.append(("local hook entry scripts", "OK", f"{len(local)} local hooks wired"))
     except (ValueError, RuntimeError) as e:
         out.append(("local hook entry scripts", "ERR", str(e)))
+
+    # Gate 7: gitleaks version parity between the hook and CI (#10139).
+    #
+    # Unlike every gate above, this one does not depend on the worker's machine
+    # state -- it compares two files in the repo, so it reads the same on every
+    # checkout. It is here for discoverability (a worker running this script
+    # sees it), but the ENFORCING copy is the unit test in
+    # scripts/tests/test_check_hooks_parity.py, which runs on PRs. This script
+    # stays advisory by design (see "Why advisory only" above) and a divergence
+    # must fail something blocking.
+    #
+    # Why it matters concretely: on the files that blocked 5 PRs, gitleaks
+    # 8.21.2 reported 0 findings and 8.24.3 reported 2. While the hook pinned
+    # 8.21.2 and CI resolved 8.24.3, a clean `git commit` was rejected in CI
+    # with nothing in the repo to explain it.
+    try:
+        hook_v = _hook_gitleaks_version()
+        ci_v = _ci_gitleaks_version()
+        if hook_v is None:
+            out.append(("gitleaks version parity", "KO", "no gitleaks repo in pre-commit config"))
+        elif ci_v is None:
+            out.append((
+                "gitleaks version parity", "KO",
+                f"hook pins {hook_v} but {SECRET_SCAN_PATH.name} sets no GITLEAKS_VERSION "
+                "(CI would use the action's own hard-coded default)",
+            ))
+        elif hook_v != ci_v:
+            out.append((
+                "gitleaks version parity", "KO",
+                f"hook rev v{hook_v} != CI GITLEAKS_VERSION {ci_v} -- "
+                "a green pre-commit does not predict CI",
+            ))
+        else:
+            out.append(("gitleaks version parity", "OK", f"hook and CI both pin {hook_v}"))
+    except (FileNotFoundError, ValueError, RuntimeError) as e:
+        out.append(("gitleaks version parity", "ERR", str(e)))
 
     return out
 

--- a/scripts/tests/test_check_hooks_parity.py
+++ b/scripts/tests/test_check_hooks_parity.py
@@ -331,10 +331,20 @@ def test_main_returns_1_on_ko(tmp_path, monkeypatch, capsys):
 
 
 def test_main_returns_0_when_all_green(tmp_path, monkeypatch, capsys):
-    """main() returns 0 when every gate is green."""
+    """main() returns 0 when every gate is green.
+
+    Gate 7 (#10139) needs BOTH pinned versions to exist and agree, so the
+    fake repo declares a gitleaks hook and a matching workflow. Feeding the
+    new gate its inputs is deliberate: exempting it here would make
+    "every gate green" quietly mean "every gate but one".
+    """
     mod = _load(CHECK_HOOKS_PARITY)
     config_text = (
         "repos:\n"
+        "  - repo: https://github.com/gitleaks/gitleaks\n"
+        "    rev: v9.9.9\n"
+        "    hooks:\n"
+        "      - id: gitleaks\n"
         "  - repo: local\n"
         "    hooks:\n"
         "      - id: local-a\n"
@@ -344,9 +354,21 @@ def test_main_returns_0_when_all_green(tmp_path, monkeypatch, capsys):
     (repo / ".git" / "hooks" / "pre-commit").write_text("#!/bin/sh\nexit 0\n")
     (repo / "scripts").mkdir(parents=True)
     (repo / "scripts" / "a.py").write_text("# stub\n")
+    workflow = repo / ".github" / "workflows" / "secret-scan.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        "jobs:\n"
+        "  gitleaks:\n"
+        "    steps:\n"
+        "      - uses: gitleaks/gitleaks-action@v2\n"
+        "        env:\n"
+        "          GITLEAKS_VERSION: 9.9.9\n",
+        encoding="utf-8",
+    )
     monkeypatch.setattr(mod, "REPO_ROOT", repo)
     monkeypatch.setattr(mod, "CONFIG_PATH", repo / ".pre-commit-config.yaml")
     monkeypatch.setattr(mod, "HOOK_PATH", repo / ".git" / "hooks" / "pre-commit")
+    monkeypatch.setattr(mod, "SECRET_SCAN_PATH", workflow)
     monkeypatch.setattr(shutil, "which", lambda name: f"/usr/bin/{name}")
 
     # Mock subprocess.run for BOTH the --version probe (Gate 2) and the
@@ -364,3 +386,124 @@ def test_main_returns_0_when_all_green(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert rc == 0, f"expected rc=0, got rc={rc}, output={out!r}"
     assert "OK" in out
+
+
+# --- Gate 7: gitleaks version parity (hook rev vs CI GITLEAKS_VERSION) -------
+#
+# This is the ENFORCING copy of the gate. check_hooks_parity.py is advisory in
+# CI by design (a missing local hook is the worker's state to repair), but a
+# version divergence is not machine state: it is two files in the repo
+# disagreeing, identical on every checkout. It must fail something blocking,
+# and that is this test.
+#
+# What it guards, measured on this repo (#10139): gitleaks 8.21.2 reported 0
+# findings on the very files where 8.24.3 reported 2. While the hook pinned
+# 8.21.2 and CI resolved 8.24.3, a clean `git commit` was rejected in CI with
+# nothing in the repo to explain it.
+
+
+def _write_pair(tmp_path: Path, hook_rev: str | None, ci_version: str | None):
+    """Fake repo pinning ``hook_rev`` locally and ``ci_version`` in CI.
+
+    ``None`` means "pin absent" -- for the hook, no gitleaks repo at all; for
+    CI, a workflow step carrying no GITLEAKS_VERSION.
+    """
+    repos = "repos:\n"
+    if hook_rev is not None:
+        repos += (
+            "  - repo: https://github.com/gitleaks/gitleaks\n"
+            f"    rev: {hook_rev}\n"
+            "    hooks:\n"
+            "      - id: gitleaks\n"
+        )
+    repos += (
+        "  - repo: local\n"
+        "    hooks:\n"
+        "      - id: local-a\n"
+        "        entry: python scripts/a.py\n"
+    )
+    repo = _make_repo(tmp_path, repos)
+    workflow = repo / ".github" / "workflows" / "secret-scan.yml"
+    workflow.parent.mkdir(parents=True)
+    env_block = f"        env:\n          GITLEAKS_VERSION: {ci_version}\n" if ci_version else ""
+    workflow.write_text(
+        "jobs:\n  gitleaks:\n    steps:\n"
+        "      - uses: gitleaks/gitleaks-action@v2\n" + env_block,
+        encoding="utf-8",
+    )
+    return repo, workflow
+
+
+def _parity_row(mod, tmp_path, monkeypatch, hook_rev, ci_version):
+    repo, workflow = _write_pair(tmp_path, hook_rev, ci_version)
+    monkeypatch.setattr(mod, "REPO_ROOT", repo)
+    monkeypatch.setattr(mod, "CONFIG_PATH", repo / ".pre-commit-config.yaml")
+    monkeypatch.setattr(mod, "SECRET_SCAN_PATH", workflow)
+    rows = [r for r in mod._run_checks() if r[0] == "gitleaks version parity"]
+    assert rows, "gate 'gitleaks version parity' absent from _run_checks()"
+    return rows[0]
+
+
+def test_parity_ok_when_versions_agree(tmp_path, monkeypatch):
+    mod = _load(CHECK_HOOKS_PARITY)
+    gate, status, detail = _parity_row(mod, tmp_path, monkeypatch, "v8.24.3", "8.24.3")
+    assert status == "OK", f"{gate}: {detail}"
+
+
+def test_parity_ko_when_versions_diverge(tmp_path, monkeypatch):
+    """The exact shape of the #10139 defect: hook 8.21.2 vs CI 8.24.3."""
+    mod = _load(CHECK_HOOKS_PARITY)
+    _gate, status, detail = _parity_row(mod, tmp_path, monkeypatch, "v8.21.2", "8.24.3")
+    assert status == "KO", f"expected KO on divergence, got {status}: {detail}"
+    assert "8.21.2" in detail and "8.24.3" in detail, detail
+
+
+def test_parity_ko_when_ci_pins_nothing(tmp_path, monkeypatch):
+    """No GITLEAKS_VERSION is a finding, not an absence of information.
+
+    Unset, the action falls back to a version hard-coded in its own source
+    (``GITLEAKS_VERSION || "8.24.3"``, src/index.js) -- an implicit pin owned
+    by a third party that any ``@v2`` release can revise with no commit here.
+    """
+    mod = _load(CHECK_HOOKS_PARITY)
+    _gate, status, detail = _parity_row(mod, tmp_path, monkeypatch, "v8.24.3", None)
+    assert status == "KO", f"expected KO when CI pins nothing, got {status}: {detail}"
+    assert "GITLEAKS_VERSION" in detail, detail
+
+
+def test_parity_v_prefix_is_not_a_divergence(tmp_path, monkeypatch):
+    """``rev: v8.24.3`` vs ``GITLEAKS_VERSION: 8.24.3`` is the CORRECT form.
+
+    The hook tag carries the ``v``; the action's env var must not (its README
+    is explicit: "no ``v`` prefix"). A gate that flagged this would push
+    someone to "fix" it into a genuinely broken download URL.
+    """
+    mod = _load(CHECK_HOOKS_PARITY)
+    _gate, status, _detail = _parity_row(mod, tmp_path, monkeypatch, "v8.24.3", "8.24.3")
+    assert status == "OK"
+
+
+def test_parity_holds_on_the_real_repo_files(monkeypatch):
+    """The live gate: the versions actually shipped in this repo must agree.
+
+    Unlike the fixtures above, this reads the real ``.pre-commit-config.yaml``
+    and ``.github/workflows/secret-scan.yml``. It is what turns the rule into
+    an organ: bump one file alone and this test goes red.
+    """
+    mod = _load(CHECK_HOOKS_PARITY)
+    if not (mod.CONFIG_PATH.exists() and mod.SECRET_SCAN_PATH.exists()):
+        import pytest
+        pytest.skip("real config/workflow not present in this environment")
+    try:
+        hook_v = mod._hook_gitleaks_version()
+        ci_v = mod._ci_gitleaks_version()
+    except RuntimeError as e:
+        import pytest
+        pytest.skip(f"PyYAML missing in test environment: {e}")
+    assert hook_v is not None, ".pre-commit-config.yaml declares no gitleaks rev"
+    assert ci_v is not None, "secret-scan.yml sets no GITLEAKS_VERSION (unpinned CI gate)"
+    assert hook_v == ci_v, (
+        f"gitleaks version drift: hook pins v{hook_v}, CI pins {ci_v}. "
+        "These must be bumped together -- they disagree on real content "
+        "(see #10139), so a green pre-commit would stop predicting CI."
+    )


### PR DESCRIPTION
`Grain: MED/guard — lane myia-ai-01:CoursIA — prev: LIGHT/guard #10115`

> **Note G-VAR-3** — deuxième `guard` consécutif de la lane, assumé et déclaré : #10115 était un flag advisory d'une ligne (LIGHT), celui-ci mesure un mécanisme, corrige une affirmation publiée et ajoute un gate testé (MED). Substances genuinement distinctes, pas la veine facile rejouée.

## Correction d'une affirmation que j'avais écrite dans #10139

J'avais écrit dans #10139 que `gitleaks-action@v2` « télécharge la dernière version publiée ». **C'est faux.** L'action porte un pin **codé en dur dans sa propre source** :

```js
// gitleaks-action, src/index.js:138
let gitleaksVersion = process.env.GITLEAKS_VERSION || "8.24.3";
```

Confirmé par le log de run : `Version to install: 8.24.3`. (Le commentaire de `src/gitleaks.js` qui parle de « latest » est périmé.) C'est donc un **pin implicite détenu par un tiers**, révisable par n'importe quelle release `@v2` sans aucun commit chez nous — pire qu'un flottement, parce qu'invisible.

Conséquence directe : mon encadrement initial (8.21.2 vs 8.30.1) **n'avait jamais couvert la version que la CI exécute réellement**.

## Le vrai défaut : un écart de version hook-vs-CI

Mêmes fichiers, même config, trois binaires mesurés sur ce dépôt :

| binaire | findings |
|---|---|
| 8.21.2 (ce que le hook épinglait) | **0** |
| 8.24.3 (ce que la CI exécute) | **2** |
| 8.30.1 (dernière publiée) | **2** |

Le hook épinglait 8.21.2 pendant que la CI résolvait 8.24.3 : un `git commit` **propre en local** était rejeté en CI, sans que rien dans le dépôt permette de le voir venir. C'est la forme exacte que décrit #10139.

Corollaire mesuré : **`[extend] useDefault = true` n'est PAS équivalent à tourner sans config.** Sous 8.24.3/8.30.1, le défaut *étendu* rapporte ce que le défaut *implicite* supprime.

## Pourquoi ces FP surgissent maintenant (le pipeline est un révélateur, pas le défaut)

`gitleaks-action` sur une PR ne scanne **que les commits de cette PR**, et #9888 n'a armé le scanner que pour les commits *à venir* — le corpus pré-existant n'a jamais été scanné. `translation-sync` ré-émet chaque source FR en **7 fichiers dérivés** dans de nouveaux commits, ce qui tire du contenu jamais scanné dans le périmètre **×7** : un seul FP non listé bloque jusqu'à 7 PRs sans rapport entre elles.

## Correctif

1. **`secret-scan.yml`** épingle `GITLEAKS_VERSION: 8.24.3` — ce que la CI exécutait déjà, donc **le verdict CI ne change pas**.
2. **`.pre-commit-config.yaml`** : `v8.21.2` → `v8.24.3`. Le hook **avance** vers le détecteur de la CI, plutôt que d'épingler la CI en arrière vers un détecteur plus ancien qui se contente de masquer des findings.
3. **5 stopwords**, chacun **relu à sa source** avant d'être listé (annoté dans `.gitleaks.toml`) : `abcd1234` et `SECRET-KEY` (bloc `.env` d'exemple dans une cellule **markdown** de `GenAI/Texte/10_LocalLlama.ipynb`), `dummy_key` (`dummy_key_for_validation`, Whisper-STT), `no-key-needed` (valeur conventionnelle d'un endpoint vLLM local sans clé), `GPT-4o-Transcribe` (**un nom de modèle**, signalé parce qu'il suit `API,` dans une puce « **Technologies :** »). Stopwords et non `paths` : un **vrai** secret dans le même fichier échoue toujours.
4. **Gate 7 sur l'organe de parité existant** (`scripts/check_hooks_parity.py`, issu de #9888/#9895) plutôt qu'un fichier concurrent — j'avais prévu un `test_gitleaks_version_parity.py`, l'organe existait déjà.

Le hook a **changé d'entrée amont à v8.22** (`gitleaks protect --verbose --redact --staged` → `gitleaks git --pre-commit --redact --staged --verbose`, vérifié sur les trois `.pre-commit-hooks.yaml`). On n'override pas `args`, donc le bump adopte la nouvelle entrée automatiquement — et le commentaire qui nommait `protect` est corrigé avec.

## Vérifications

- **Self-test du hook bumpé : PASS** — `gitleaks detected 1 staged leak(s)`. C'était le gate sur le fait de committer : un hook qui ne détecte plus livrerait le no-op silencieux de #9888.
- **Contrôle positif** : une sonde `ghp_` reste détectée (**1 finding**) sous la config candidate → l'allowlist **ne désarme pas** le scanner.
- 8.24.3 + config `main` sur les fichiers dérivés → **2 findings** (reproduit la CI à l'identique) ; + config candidate → **0**, sous 8.24.3 **et** sous 8.30.1.
- **Le gate 7 est prouvé capable de rougir** : en forçant artificiellement la CI à 8.30.1, le test sur les fichiers réels échoue —
  `gitleaks version drift: hook pins v8.24.3, CI pins 8.30.1` — puis repasse au vert une fois restauré. **19/19 tests.**
- Advisory vs enforçant : `check_hooks_parity.py` reste **advisory** en CI par construction (un hook local manquant est l'état du *worker*, pas celui de la PR). Un écart de version n'est **pas** de l'état machine — deux fichiers du dépôt qui se contredisent, identiques à chaque checkout — donc la copie **enforçante** est le test pytest, qui tourne sous `scripts-tests.yml` sur les PRs.

## Ce que cette PR NE fait PAS

Corpus notebooks entier sous 8.24.3 : **164 findings avant, 162 après**. Ce patch retire donc **exactement les 2 qui bloquent** et laisse la **classe latente intacte** : 162 findings / 69 littéraux distincts, dont **152 de `generic-api-key`**, dominés par des identifiants d'erreurs personnalisées Solidity (`ERC1155InvalidReceiver` ×12, `ERC20InsufficientBalance` ×10, `ERC721InvalidReceiver` ×10, …) plus `sk-or-v1-VOTRE_CLE` ×12. Une PR touchant la famille SmartContract serait bloquée par ~100 findings.

C'est un **second sujet**, suivi dans une issue dédiée avec **contrôles positifs par classe** exigés — pas un élargissement de cette PR. Le triage des 6 findings de détecteurs *spécifiques* (non `generic-api-key`) y est joint : il a fait apparaître un vrai credential non protégé, lui aussi porté par sa propre issue.

## Acceptation

- [x] Les deux gates épinglent la même version, et un gate testé le vérifie **et peut rougir**
- [x] Self-test PASS (le hook détecte encore) + contrôle positif `ghp_` (l'allowlist ne désarme pas)
- [x] Chaque stopword relu à sa source et annoté ; aucun n'est un secret, donc aucune rotation
- [ ] **À confirmer par le log de run de cette PR** : `Version to install: 8.24.3` et 0 finding sur les fichiers dérivés

Closes #10139
