### PR TITLE
docs(discoverability): index 5 orphaned reference docs + lean index into docs portal

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,10 @@ Documentation vivante, active et liée depuis CLAUDE.md / `.claude/rules/`.
 | [archive/reference/notebook-counts-reconciliation.md](archive/reference/notebook-counts-reconciliation.md) | **Archivé 2026-08-08** (était [reference/](reference/)) : réconciliation forensic des 4 sources de comptage notebooks (disque 946 / forensic 944 / catalogue 830 / STABLE_SNAPSHOT 934) — écart catalogue-disque = 116 = 84 drift + 30 exclusions par design, filtre `scripts/audit/check_denominators.py`. SHA daté 2026-07-23. **Record historique** — superseded pour usage live par [`reference/notebook-counters.md`](reference/notebook-counters.md) (#9857). 174 lignes. Linked #8050 |
 | [reference/stale-tree-drift-scan.md](reference/stale-tree-drift-scan.md) | Scan de drift sur worktree frais (anti-phantom) |
 | [reference/orphan-branch-scan-l576.md](reference/orphan-branch-scan-l576.md) | Scan de branche orpheline (L576 ★★) — compound gate 3 ancres (`merge-base` + REST `commits/<sha>/pulls` + `gh pr list --search head:<branch>`) anti-FPOS du REST, decision matrix 5 lignes. Détail de référence pour la section « Orphan-branch scan » de `.claude/rules/git-workflow.md`. 105 lignes. Origine : investigation 5 branches `jsboige/*` attachées à #7086-#7091 (c.576) |
+| [reference/probas-history.md](reference/probas-history.md) | Référence pérenne du portage Infer.NET → Python (`Probas/`) — périmètre intentionnel (combien de notebooks, quelle bibliothèque pour quel concept) + recommandation PyMC/NumPyro/pgmpy/hmmlearn/Pyro. Source canonique issue #297. Le mapping d'API ligne-à-ligne y est explicitement marqué *périssable* (poison si non re-testé). 117 lignes |
+| [reference/quant-prose-census.md](reference/quant-prose-census.md) | Recensement chiffré des valeurs quantitatives écrites en dur dans les cellules markdown des notebooks, classées selon la ligne de partage codifiée par #9434 (acceptance item 4, #9958). Outil `scripts/notebook_tools/scan_quant_classify.py`. 212 lignes |
+| [reference/repo-size-policy.md](reference/repo-size-policy.md) | Politique de taille du dépôt (~1,2 GiB) — pourquoi ce poids est le prix d'une décision délibérée (sorties notebooks committées C.2/H.1), ce qui est acquis (ne sera pas réécrit), ce qui est surveillé. Mesure, pas impression. 177 lignes |
+| [reference/verification-verte-systeme-casse.md](reference/verification-verte-systeme-casse.md) | « Quand la vérification est verte et le système est cassé » — étude de cas 8 incidents datés, un seul motif (un agent déclare un état système sur la foi d'une vérification qui passait alors que cet état était faux). Détail de référence pour la règle G.9 (culture du doute). 170 lignes |
 
 ## GenAI (docs/genai/)
 
@@ -87,7 +91,7 @@ Documentation détaillée de l'infrastructure GenAI (ComfyUI, Docker, modèles l
 
 ## Lean (docs/lean/)
 
-Iteration history prover, intractable diagnosis, LLM endpoints.
+Iteration history prover, intractable diagnosis, LLM endpoints. **Index du sous-répertoire :** [lean/README.md](lean/README.md) — point d'entrée de référence regroupant les sous-docs ci-dessous (coordinator-workflow, llm-endpoints, prover history, SOTA 2026, AB, i18n). Établi par po-2024 (#10132).
 
 | Fichier | Description |
 |---------|-------------|


### PR DESCRIPTION
## fix(docs): make 5 durable orphan docs discoverable from the portal

**Grain:** MED/docs-discoverability — lane `myia-po-2026:CoursIA`.

## Why

`check_docs_links.py --orphans` surfaced **7 orphan docs** (0 broken links across 4579). 5 of them are **durable work invisible from the portal** — strong methodological references that nothing in the harness or docs/README.md pointed to. This is the tooling-as-discovery pattern (c.9715-bis): run a repo script to find CLEAN under-documented work invisible to manual issue enumeration.

| Orphan doc | Status | Action |
|---|---|---|
| `lean/README.md` | po-2024's Lean sub-directory index (#10132), listed nowhere (Lean section enumerated the 7 sub-docs but not the index itself) | **referenced** — Lean section intro |
| `reference/probas-history.md` | Perennial Infer.NET→Python port reference (#297), unreferenced | **referenced** — Outils & méthodologie table |
| `reference/quant-prose-census.md` | Quantitative-prose census (#9434), unreferenced | **referenced** — Outils & méthodologie table |
| `reference/repo-size-policy.md` | Repo-size policy (~1.2 GiB rationale), unreferenced | **referenced** — Outils & méthodologie table |
| `reference/verification-verte-systeme-casse.md` | 'Green check + broken system' case study (G.9), unreferenced | **referenced** — Outils & méthodologie table |
| `harness/global-rules-detail.md` | Deprecated transient pointer to roo-extensions#3036 (its own body says *'rien dans CoursIA ne référençait ce fichier'*) | **excluded** — pointing to it = pointing at a redirect stub |

## Proof (G.1 firsthand)

```
$ python scripts/check_docs_links.py --orphans
before this PR: 7 orphans, 0 broken (4574 links)
after:          2 orphans, 0 broken (4579 links)
  remaining: global-rules-detail.md (excluded — deprecated pointer, see above)
             ict/d1-c4-rencontre-meta.md (resolved by the still-open sibling PR #10134 ICT orphan-recovery)
```

`git diff --numstat` = **5/1** (4 table rows + 1 Lean intro phrasing). No catalogue churn, no `CATALOG-STATUS` marker touched (catalog-pr-hygiene R1).

## Scope

**1 file (docs/README.md), 5 references, same subject** (orphan discoverability via tooling-as-discovery). FR-first per readme-french-first (the portal is FR-canonical). §E whole-file audit: the portal's 11 sections are otherwise coherent — this PR fills the discoverability gap the scanner found, it does not touch stale lists (none found).

## Collision pre-flight (c.818, by content)

Sibling PR #10134 (ICT orphan-recovery) also touches docs/README.md but in the **ICT section** (far from my Lean/Outils edits) → auto-merge compatible. No content overlap.

See #10132 (lean index source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)