### PR TITLE
docs(conway-lean): align p5_large_n_jumpN docstring with theorem precondition + code

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1142,10 +1142,12 @@ theorem boxAssezGrandN_block_8 : BoxAssezGrandN block 8 := by native_decide
 theorem boxAssezGrandN_glider_8 : BoxAssezGrandN glider 8 := by native_decide
 
 /-- **P5.2 genuine large-`n` jump (N2, P4-gated) — the sole remaining open
-    target of the P5 layer.** When `n ≥ jumpSize k` on the n-aware frame,
-    `evolveHashlifeFast` makes one Hashlife jump of `2^(k-2)` generations
-    (certified by P4 `hashlifeResult_central_correct`) then recurses
-    on `n - 2^(k-2)`, with the light cone staying inside the `gridFrameN` margin
+    target of the P5 layer.** When `n ≥ jumpSize lvl` (the MacroCell level)
+    on the n-aware frame, `evolveHashlifeFast` makes one Hashlife jump of
+    `jumpSize lvl = 2^lvl` generations (via `hashlifeJump = hashlifeResult
+    (padCenter2 c)` on the level-`lvl+2` padded cell, certified by P4
+    `hashlifeResult_central_correct`) then recurses on `n - jumpSize lvl`,
+    with the light cone staying inside the `gridFrameN` margin
     (`window_cheb_cone_in_domain`, now in `Conway.Life.ConeGeometry`). This is
     the real P5.2 target — **open named sorry, P4-gated** (`p4_succ_membership`,
     ai-01 turf), NOT closed by vacuity.


### PR DESCRIPTION
## fix(conway-lean): p5_large_n_jumpN docstring said `2^(k-2)`, code + precondition say `2^lvl`

**Grain:** LIGHT/lean-docstring — lane `myia-po-2026:CoursIA`. In-source companion to the README correction delivered in **#10140** (c.1007) and to **#10137** (Foundation.lean docstring, c.1004). See #9863 (verification-half rendered durable in-source).

## The inconsistency (G.1 firsthand)

The docstring of `p5_large_n_jumpN` (HashlifeCorrectness.lean L1144) stated the jump advances `2^(k-2)` generations and recurses on `n - 2^(k-2)`. This contradicts two sources:

1. **The theorem's OWN precondition** (L1156): `hbig : n ≥ jumpSize (gridToMacroCellWithOffset g).2.level` — i.e. `n ≥ jumpSize lvl = 2^lvl`, not `2^(k-2)`.
2. **The code** (`evolveHashlifeFastAux`, Hashlife.lean L332-334): `let js := jumpSize lvl` + comment *« Jump forward by `2^lvl` generations »* + recurse on `n - js`.

## Jump semantics — verified by chaining the definitions

```
hashlifeJump c = hashlifeResult (padCenter2 c)          -- Hashlife.lean L306
padCenter2 adds 2 levels: level-lvl cell -> level (lvl+2)
hashlifeResult on a level-K cell advances 2^(K-2) generations (canonical Hashlife)
=> hashlifeJump on level-lvl advances 2^((lvl+2)-2) = 2^lvl = jumpSize lvl
```

## Why this matters

The docstring's ambiguous `2^(k-2)` misdirected the author of #10140 (this lane, c.1006) into believing the jump was `2^(k-2)` in raw-level terms — a self-corrected error that cost a cycle. Aligning the docstring with its own signature + the code prevents the next p5 attacker from re-chasing the wrong jump amount. Same class of stale-docstring fix as #10137.

## Scope

**1 file, 1 docstring, comment-only.** Diff `--numstat` = 6/4, all ± lines inside the `/-! ... -/` block. **0 code lines touched.** `sorry` count 33 → 33 (anti-régression §D ✓). Delimiters intact. No `_en` twin for HashlifeCorrectness.lean.

## Verification & trap-safe

Comment-only → compilation preserved. Conway lake build (shared tree, Mathlib junction replay) reached `[600/628]` with 0 errors — baseline compiles, comment-only preserves it. `.lean` (not `.ipynb`) → no translation-sync bot-commit → CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)