### PR TITLE
fix(genai-docs,#9906): align comparatif OWUI-vs-AI-Engine Position row with lifted taxonomy

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/comparatif-owui-vs-ai-engine.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/comparatif-owui-vs-ai-engine.md
@@ -38,7 +38,7 @@ version 3.7.0), de son code source GPL (distribué via le dépôt SVN
 | **Modèle économique** | Open source pur | Freemium (gratuit + Pro) |
 | **License** | Open source (BSD-3 conforme au dépôt GitHub `open-webui/open-webui`) | GPL (conforme au dépôt WordPress plugins) |
 | **Statistiques publiques** | Écosystème open-source mature (image officielle OCI multi-tags, déploiement massif auto-hébergé) | **100K+ installations actives**, 4.9/5 étoiles (854 avis), 14 traductions, cadence hebdomadaire |
-| **Position dans le dépôt** | `MyIA.AI.Notebooks/GenAI/Open-WebUI/` (série dédiée) | Sibling `01-AI-Engine-WordPress/` (extension du parcours OWUI) |
+| **Position dans le dépôt** | `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/Open-WebUI/` (sous-série dédiée) | Sibling `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/` (sous-série homologue) |
 
 ---
 


### PR DESCRIPTION
## fix(genai-docs): align comparatif-owui-vs-ai-engine.md "Position dans le dépôt" row with the lifted taxonomy (#9906)

Grain: MED/docs — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #10117

## Quoi

La ligne `| Position dans le dépôt |` (L41) de `comparatif-owui-vs-ai-engine.md` décrivait encore l'**ancienne arborescence** que #9906 a corrigée. Le fichier a été lifté au niveau catégorie (`GenAI/Plateformes-Conversationnelles/`) par #9916, mais cette ligne de prose décrivait toujours :

1. l'ancien chemin `MyIA.AI.Notebooks/GenAI/Open-WebUI/` (la série a été renommée+déplacée),
2. l'ancien préfixe `01-AI-Engine-WordPress/` (le `01-` a été supprimé),
3. AI-Engine comme *« extension du parcours OWUI »* — l'inversion exacte que #9906 corrige (les deux sont siblings homologues sous `Plateformes-Conversationnelles/`, ni l'un ni l'autre n'est l'extension de l'autre).

## Preuve — audit §E fichier-entier (pr-review-discipline §E, readme-french-first)

Le critère §E impose l'audit du **fichier entier**, pas seulement de la ligne signalée. Balayage exhaustif firsthand dans un worktree frais depuis `origin/main` (`84d3d0b6f`) :

| Classe d'erreur | Occurrences | Verdict |
|---|---|---|
| `GenAI/Open-WebUI` (ancien chemin absolu) | L41 seule | **FIXED** (→ `Plateformes-Conversationnelles/Open-WebUI/`) |
| `Open-WebUI/...` (liens relatifs L10, L11, L236) | 3 | **CORRECTS** — résolvent dans la nouvelle arborescence (`Plateformes-Conversationnelles/Open-WebUI/00-Tour-Plateforme/README.md`, `…/Playwright-OWUI/README.md` : `test -f` OK firsthand). Pas touchés. |
| `01-AI-Engine` (ancien préfixe) | L41 seule | **FIXED** (→ `AI-Engine-WordPress/`) |
| `extension du parcours OWUI` (inversion subordonnée) | L41 seule | **FIXED** (→ `sous-série homologue`, parité sibling) |
| `extension WordPress` (L26, description AI-Engine) | 1 | **CORRECT** — AI-Engine EST une extension WordPress (un autre *plan d'intégration*), correspond à la décision statu-quo du commentaire #9906. Pas touché. |
| ancre interne `#coût` (référencée L35) | 1 | **CORRECT** — résout vers `## Coût` L146. |
| `GenAI/Open-WebUI` résiduel ailleurs | 0 | clean (les 5 occ dans des `MANIFEST.md` générés sont hors-périmètre, régénérées par cron — cf commentaire #9906) |

**Diff** : `1 file changed, 1 insertion(+), 1 deletion(-)` — chirurgical, prose-only. Aucun code, aucun notebook, aucune régression possible.

**Décisions de périmètre préservées** (ne pas re-soulever, cf commentaire #9906) : `eval-choisir-son-modele.ipynb` RESTE dans `AI-Engine-WordPress/` (statu quo tranché sur pièces), nom `Plateformes-Conversationnelles` ratifié.

## Perimetre

- `.md` (1 fichier) : `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/comparatif-owui-vs-ai-engine.md` — L41 (ligne `Position dans le dépôt` du tableau Positionnement).

Hors scope : les `MANIFEST.md` générés (cron régénère), les liens relatifs `Open-WebUI/` corrects, la description L26 (extension WordPress = exacte). Cette ligne était le **seul résidu** empêchant la fermeture de #9906 (cf son dernier commentaire : « Reste à faire, borné : cette ligne … Puis fermeture »).

Closes #9906

🤖 Generated with [Claude Code](https://claude.com/claude-code)
