### PR TITLE
Fix(parse_short_header,#10163): recognise section form (key + next paragraph)

### DIFF
--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -335,44 +335,96 @@ def parse_short_header(body: str | None) -> dict:
     when **all three are absent**, by design (existing PRs have none of the
     three and must not suddenly turn red).
 
-    Each value is stripped of leading/trailing whitespace. The keys themselves
-    are case-insensitive (matched after the noise strip, which lower-cases
-    nothing but removes decoration). Returns {quoi, preuve, perimetre} with
-    each entry `None` when the key is absent and the captured text otherwise.
+    Two presentation forms are recognised (#10163 acceptance):
 
-    The body is treated as already-presented markdown: leading/trailing
-    whitespace and the noise (bold, backticks, hashes, blockquotes) are
-    handled by translating through `_NOISE` first, exactly like
-    `parse_grain_tag`.
+    - **Inline form** (#9861 reference) -- key + value on the SAME line:
+        ``Quoi: fix the parser for #10163``
+    - **Section form** (#10163 extension) -- key on its own line (optionally
+      titled with `#`, optionally wrapped in `**`), value is the NEXT
+      paragraph (lines until next blank-line break):
+        ``## Quoi\\n\\nfix the parser for #10163\\n\\n## Context\\n...``
+
+    Both forms tolerate the same noise discipline as `parse_grain_tag`: bold
+    (``**``), backticks, title hashes (`#`), blockquotes (`>`) are stripped
+    before matching. Each value is stripped of leading/trailing whitespace.
+    Keys are case-insensitive. Returns {quoi, preuve, perimetre} with each
+    entry `None` when the key is absent and the captured text otherwise.
+
+    Mid-paragraph mentions like ``We discuss Quoi: the convention here`` are
+    still rejected -- the key MUST be at the start of the line (after the
+    noise strip), and in section form the value is the next PARAGRAPH, not
+    the rest of the line.
     """
     out: dict[str, str | None] = {k.lower(): None for k in _SHORT_HEADER_KEYS}
     if not body:
         return out
     flat = _strip_title_hashes(body.translate(_NOISE))
-    # Scan line-by-line. A trio key on the same line as the Grain tag would
-    # be a structural oddity; the convention in #9861 puts each on its own
-    # line just after the Grain tag, and that is what we match. Multi-line
-    # values are explicitly excluded by the spec ("une ligne -- ...").
-    for line in flat.splitlines():
-        line = line.strip()
+
+    # Two-pass scan: first, the inline form (a key on a line that also has a
+    # value -- captured by the same regex as #9861). Second, the section
+    # form (key on its own line, value in the NEXT non-empty paragraph).
+    # Pass 1 -- inline form.
+    # The inline trio puts Quoi/Preuve/Perimetre on three CONSECUTIVE lines
+    # inside ONE paragraph (joined by '\n', no blank line between them); we
+    # iterate line-by-line and capture any key whose line yields an inline
+    # match. The section-form pass 2 runs on paragraphs, not lines.
+    for raw_line in flat.splitlines():
+        line = raw_line.strip()
         if not line:
             continue
-        # Each key MUST be at the start of the line (after strip). Anchored
-        # to prevent false positives where a body says e.g. "We discuss Quoi:
-        # the convention here" mid-paragraph -- that is commentary, not a
-        # canonical answer. The convention #9861 is "juste apres le tag Grain:
-        # un en-tete court normalise" -- three lines, one key per line.
         for k in _SHORT_HEADER_KEYS:
-            # Cheap prefix check before the regex: skips the regex engine
-            # on every line that does not start with the key word.
+            if out[k.lower()] is not None:
+                continue
             if not line.lower().startswith(k.lower()):
                 continue
             m = _SHORT_HEADER_RES[k].search(line)
             if m:
-                # First hit wins per key. If a body carries the key twice, the
-                # first is the canonical answer; later mentions are commentary.
-                if out[k.lower()] is None:
-                    out[k.lower()] = m.group(1).strip()
+                out[k.lower()] = m.group(1).strip()
+
+    # Pass 2 -- section form. Walk paragraphs in order. A paragraph whose
+    # FIRST line is a key (anchored, no inline value) takes the NEXT
+    # non-empty paragraph as its value. We only fall back here for keys
+    # still unfilled after pass 1 -- so a body that uses inline for Quoi
+    # and section for Preuve still works (see
+    # `test_short_header_section_form_mixed_inline_and_section`).
+    paragraphs = flat.split("\n\n")
+    for pi, para in enumerate(paragraphs):
+        if not para.strip():
+            continue
+        first = para.splitlines()[0].strip()
+        if not first:
+            continue
+        for k in _SHORT_HEADER_KEYS:
+            if out[k.lower()] is not None:
+                continue
+            if not first.lower().startswith(k.lower()):
+                continue
+            # Already have inline value? pass 1 won.
+            m = _SHORT_HEADER_RES[k].search(first)
+            if m:
+                continue
+            # Section form: key alone on the line, value is the next
+            # non-empty paragraph (any number of subsequent paragraphs,
+            # skipping blanks -- matches the documented #10163 form where
+            # the body has `## Key\n\nAnswer paragraph\n\n## NextKey\n...`).
+            value_lines: list[str] = []
+            for next_para in paragraphs[pi + 1:]:
+                pstripped = next_para.strip()
+                if not pstripped:
+                    continue
+                # Stop at a paragraph that itself starts with a known key
+                # -- that paragraph belongs to the next key, not to ours.
+                pfirst = pstripped.splitlines()[0].strip().lower()
+                if any(pfirst.startswith(other.lower()) for other in _SHORT_HEADER_KEYS):
+                    break
+                value_lines.append(pstripped)
+                # Take the first non-empty answer paragraph only.
+                break
+            if value_lines:
+                out[k.lower()] = " ".join(
+                    ln.strip() for ln in value_lines[0].splitlines() if ln.strip()
+                )
+
     return out
 
 

--- a/scripts/tests/test_grain_tag.py
+++ b/scripts/tests/test_grain_tag.py
@@ -245,6 +245,170 @@ def test_short_header_first_hit_wins_per_key():
     assert sh["quoi"] == "first answer (canonical)"
 
 
+# --- short-header section form (#10163) -------------------------------------
+#
+# #10163 extends the trio: key on its own line (optionally with title hashes or
+# `**` wrapper), value in the NEXT paragraph (until blank-line break). The
+# inline form (#9861) must continue to work unchanged -- non-regression.
+
+def test_short_header_section_form_h2():
+    """`## Quoi` then the answer in the next paragraph (#10163 reference form)."""
+    body = (
+        "Grain: MED/guard -- lane myia-po-2024:CoursIA-2 -- prev: MED/guard #10162\n"
+        "\n"
+        "## Quoi\n"
+        "\n"
+        "Extend parse_short_header to recognise the section form (#10163) --\n"
+        "key on its own line, value in the next paragraph.\n"
+        "\n"
+        "## Preuve\n"
+        "\n"
+        "pytest scripts/tests/test_grain_tag.py -v (30/30 PASS expected)\n"
+        "\n"
+        "## Perimetre\n"
+        "\n"
+        "scripts/grain_tag.py + scripts/tests/test_grain_tag.py. Out of scope:\n"
+        "variation-tag-guard.yml (no API change, the guard consumes parse_short_header\n"
+        "identically).\n"
+        "\n"
+        "## Context\n"
+        "..."
+    )
+    sh = gt.parse_short_header(body)
+    assert sh["quoi"].startswith("Extend parse_short_header")
+    assert "next paragraph" in sh["quoi"]
+    assert sh["preuve"].startswith("pytest scripts/tests/test_grain_tag.py")
+    assert "(30/30 PASS expected)" in sh["preuve"]
+    assert sh["perimetre"].startswith("scripts/grain_tag.py +")
+    assert "variation-tag-guard.yml" in sh["perimetre"]
+
+
+def test_short_header_section_form_bold_alone():
+    """`**Quoi**` (bold wrapper, NO colon, NO value on the line) -- section form."""
+    body = (
+        "Grain: MED/guard -- lane myia-po-2024:CoursIA-2\n"
+        "\n"
+        "**Quoi**\n"
+        "\n"
+        "split the parser into two phases (#10163)\n"
+        "\n"
+        "**Preuve** : lake build conway_lean (exit 0)\n"
+        "\n"
+        "**Perimetre** : conway_lean/Conway/Life/HashlifeCorrectness.lean\n"
+    )
+    sh = gt.parse_short_header(body)
+    # Section form (Quoi): value is the next paragraph.
+    assert sh["quoi"] == "split the parser into two phases (#10163)"
+    # Inline form (Preuve/Perimetre) coexists -- non-regression check.
+    assert sh["preuve"] == "lake build conway_lean (exit 0)"
+    assert sh["perimetre"] == "conway_lean/Conway/Life/HashlifeCorrectness.lean"
+
+
+def test_short_header_section_form_h3():
+    """`### Quoi` -- three hashes, same mechanism as `## Quoi`."""
+    body = (
+        "Grain: LIGHT/guard -- lane myia-po-2024:CoursIA-2\n"
+        "\n"
+        "### Quoi\n"
+        "\n"
+        "doc-resync for #9756 (h3 form, same as h2)\n"
+    )
+    sh = gt.parse_short_header(body)
+    assert sh["quoi"] == "doc-resync for #9756 (h3 form, same as h2)"
+    assert sh["preuve"] is None
+    assert sh["perimetre"] is None
+
+
+def test_short_header_section_form_paragraph_boundary():
+    """Section form: value spans MULTIPLE lines, joined into one capture."""
+    body = (
+        "## Quoi\n"
+        "\n"
+        "First line of the answer.\n"
+        "Second line, same paragraph (no blank between).\n"
+        "Third line, still the same paragraph.\n"
+        "\n"
+        "## Preuve\n"
+        "\n"
+        "single-line preuve\n"
+    )
+    sh = gt.parse_short_header(body)
+    assert sh["quoi"] == "First line of the answer. Second line, same paragraph (no blank between). Third line, still the same paragraph."
+    assert sh["preuve"] == "single-line preuve"
+    assert sh["perimetre"] is None
+
+
+def test_short_header_inline_form_no_regression():
+    """The reference body from #9861 -- inline form, still captured (non-regression)."""
+    body = (
+        "Quoi: fix the parser\n"
+        "Preuve: pytest -v\n"
+        "Perimetre: scripts/x.py\n"
+    )
+    sh = gt.parse_short_header(body)
+    assert sh["quoi"] == "fix the parser"
+    assert sh["preuve"] == "pytest -v"
+    assert sh["perimetre"] == "scripts/x.py"
+
+
+def test_short_header_mid_paragraph_silence():
+    """A key mid-paragraph (after commentary) is NOT captured -- the anchor
+    is at the START of the line, and section form keys must lead their
+    paragraph too. This is the test that proves we didn't widen too much."""
+    body = (
+        "## Context\n"
+        "\n"
+        "We discuss the trio convention here. Note that Quoi: the convention\n"
+        "is anchored at start of line, NOT inside running prose -- this body\n"
+        "has no canonical answer, only commentary.\n"
+        "\n"
+        "## Preuve\n"
+        "\n"
+        "actual proof line\n"
+    )
+    sh = gt.parse_short_header(body)
+    # The first paragraph starts with "We discuss..." -- not a key line.
+    # The mid-paragraph "Quoi: the convention" must NOT be captured.
+    assert sh["quoi"] is None
+    assert sh["preuve"] == "actual proof line"
+
+
+def test_short_header_section_form_mixed_inline_and_section():
+    """A body mixing the two forms: Quoi inline, Preuve/Perimetre section."""
+    body = (
+        "Grain: MED/guard -- lane myia-po-2024:CoursIA-2\n"
+        "\n"
+        "Quoi: fix the parser\n"
+        "\n"
+        "## Preuve\n"
+        "\n"
+        "pytest scripts/tests/test_grain_tag.py -v\n"
+        "\n"
+        "## Perimetre\n"
+        "\n"
+        "scripts/grain_tag.py only\n"
+    )
+    sh = gt.parse_short_header(body)
+    assert sh["quoi"] == "fix the parser"
+    assert sh["preuve"] == "pytest scripts/tests/test_grain_tag.py -v"
+    assert sh["perimetre"] == "scripts/grain_tag.py only"
+
+
+def test_short_header_section_form_first_paragraph_no_value():
+    """Section form: key leads, but next paragraph is empty -> still None."""
+    body = (
+        "## Quoi\n"
+        "\n"
+        "## Preuve\n"
+        "\n"
+        "actual proof\n"
+    )
+    sh = gt.parse_short_header(body)
+    # Quoi: key alone, no following non-empty paragraph -> None.
+    assert sh["quoi"] is None
+    assert sh["preuve"] == "actual proof"
+
+
 # --- prev: close-keyword detection (#10093) ---------------------------------
 #
 # find_prev_close_keywords() scans any text (body OR commit message) for a


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: MED/guard #10162

## What this changes

Extend `parse_short_header` (#9861) to recognise the **section form** in addition to the inline form:

- **Inline form** (existing, #9861 reference) — key + value on the same line:
  `Quoi: fix the parser for #10163`
- **Section form** (new, #10163 extension) — key on its own line (optionally titled with `##`, optionally wrapped in `**`), value in the NEXT non-empty paragraph:
  ```markdown
  ## Quoi

  Extend parse_short_header to recognise the section form (#10163).

  ## Preuve

  pytest scripts/tests/test_grain_tag.py -v
  ```

The guard (`check-short-header` job in `variation-tag-guard.yml`) consumes `parse_short_header`'s return value unchanged — so the convention now admits more presentation forms without churn on the guard side.

## Why

#10163 reports that several contributors were writing the trio as `## Quoi` + paragraph (the natural markdown pattern), and the inline-only parser returned `None` for those keys. The trio then appeared missing to the guard even though the body carried the right substance in the right shape — false positives on the `variation-short-header-missing` label, and a treadmill of edits where authors had to flatten their markdown to satisfy the regex.

The fix widens the parser's reading surface to the **form** the body actually carries, while keeping the substance guard intact: a key is still anchored at the start of a line (no mid-paragraph match), and section form requires the key to lead its own paragraph with the value in the next non-empty paragraph.

## Scope

- `scripts/grain_tag.py` — `parse_short_header` now does a 2-pass scan:
  1. **Pass 1 (inline form)** — line-by-line, same regex as before, captures keys whose line already carries a value.
  2. **Pass 2 (section form)** — paragraph-by-paragraph, captures keys whose first line is just the key (no inline value) by taking the next non-empty paragraph as the value, stopping if the next paragraph is itself a key.
  Both passes share the same noise discipline (`_strip_title_hashes` + `_NOISE` translation). Mid-paragraph `Quoi: commentary` mentions stay rejected (anchor at line start, section form keys must lead a paragraph).

- `scripts/tests/test_grain_tag.py` — +8 tests covering:
  - `## Quoi` + paragraph (the canonical #10163 form)
  - `**Quoi**` bold wrapper alone (no colon, no value on the line)
  - `### Quoi` (three hashes)
  - Section form spanning multiple lines in the value paragraph
  - Inline form non-regression (the reference body from #9861)
  - Mid-paragraph silence (commentary doesn't capture)
  - Mixed body: Quoi inline + Preuve/Perimetre section (proves the 2-pass design)
  - Section form: key alone, no following paragraph → still `None` (no fabrication)

## Verification

- **Test suite**: `python -m pytest scripts/tests/test_grain_tag.py -v` → 36/36 PASS (28 existing + 8 new).
- **Live demo on #10162 body**: the body that shipped with #10162 was already in section form (`## Quoi`, `## Preuve`, `## Perimetre` + paragraphs). Before this fix, `parse_short_header` would have returned all three as `None`; after, it returns the canonical answers. Non-regression on existing inline bodies confirmed by the inline-form test.

Refs #10163
See #9861 (the original inline-form convention, now extended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
