### PR TITLE
feat(shared,#10161): Socle-MetadataDriven-Csharp notebook — exercise low-code Flee rule-engine

### DIFF
--- a/MyIA.AI.Notebooks/cross-series/socle-metadata-driven/Socle-MetadataDriven-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/cross-series/socle-metadata-driven/Socle-MetadataDriven-Csharp.ipynb
@@ -1,0 +1,1226 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6a1d681e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002498,
+     "end_time": "2026-08-09T10:15:31.102927+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:31.100429+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Socle métadonnées-driven — découverte, sérialisation, règles métier\n",
+    "\n",
+    "Ce notebook démontre le socle transverse **`MyIA.AI.Shared`** (.NET 9.0) sur les trois\n",
+    "moments qui le fondent, en partant d'un domaine factice (facturation / catalogue) :\n",
+    "\n",
+    "1. **Décoration → introspection.** Des attributs (`[MainCategory]`, `[AttributeContainer]`)\n",
+    "   rendent des types découvrables *sans aucun appel d'enregistrement* — un\n",
+    "   `ReflectedProviderContainer.FromAssembly<T>()` les regroupe par catégorie et par rôle.\n",
+    "2. **Sérialisation round-trip.** Le même graphe d'entités (hiérarchie `IChildEntity`\n",
+    "   sur plusieurs niveaux) part et revient intact en JSON **et** en XML, parent re-lié.\n",
+    "3. **Prédicat universel métier (Flee).** Une règle métier est une **chaîne** — venue\n",
+    "   d'un fichier, d'un CSV, d'un utilisateur non-développeur — compilée une fois puis\n",
+    "   appliquée à N instances. C'est la différence entre coder N branches `if` et piloter\n",
+    "   la logique métier par les données.\n",
+    "\n",
+    "> **Prérequis.** Le socle doit être compilé en Release à la racine du dépôt :\n",
+    "> `dotnet build MyIA.AI.Shared/MyIA.AI.Shared.csproj -c Release`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a43683e9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:15:31.114488Z",
+     "iopub.status.busy": "2026-08-09T10:15:31.110009Z",
+     "iopub.status.idle": "2026-08-09T10:15:34.367377Z",
+     "shell.execute_reply": "2026-08-09T10:15:34.365126Z"
+    },
+    "papermill": {
+     "duration": 3.262388,
+     "end_time": "2026-08-09T10:15:34.367489+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:31.105101+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-24220.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '24220.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Flee, 2.0.0</span></li><li><span>Newtonsoft.Json, 13.0.4</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "socle    : 1.0.0.0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Flee     : 1.0.0.0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Newtonsoft: 13.0.0.0\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Setup : on charge le socle (DLL Release locale) + Flee (moteur de règles) + Newtonsoft.\n",
+    "#r \"../../../MyIA.AI.Shared/bin/Release/net9.0/MyIA.AI.Shared.dll\"\n",
+    "#r \"nuget:Flee\"\n",
+    "#r \"nuget:Newtonsoft.Json\"\n",
+    "\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "using MyIA.AI.ComponentModel.Attributes;\n",
+    "using MyIA.AI.ComponentModel.Entities;\n",
+    "using MyIA.AI.ComponentModel.Providers;\n",
+    "using MyIA.AI.ComponentModel.Serialization;\n",
+    "using Flee.PublicTypes;\n",
+    "using Newtonsoft.Json;\n",
+    "\n",
+    "// Sanity check : les trois références sont résolues.\n",
+    "Console.WriteLine($\"socle    : {typeof(ReflectedProviderContainer).Assembly.GetName().Version}\");\n",
+    "Console.WriteLine($\"Flee     : {typeof(ExpressionContext).Assembly.GetName().Version}\");\n",
+    "Console.WriteLine($\"Newtonsoft: {typeof(JsonConvert).Assembly.GetName().Version}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b5c8cd5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002328,
+     "end_time": "2026-08-09T10:15:34.372730+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:34.370402+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Moment 1 — Décoration → introspection\n",
+    "\n",
+    "La décoration est le socle d'une architecture *métadonnées-driven* : on **déclare** ce\n",
+    "qu'une classe est (sa catégorie, son rôle hiérarchique) via des attributs, puis un\n",
+    "conteneur de réflexion **découvre** ces déclarations sans qu'aucun code métier n'ait à\n",
+    "appeler un `Register(...)`.\n",
+    "\n",
+    "Définissons un domaine factice : un abonnement facturable (feuille plate `ISimpleEntity`)\n",
+    "et un catalogue `Catalog > Product > Variant` (hiérarchie `IChildEntity` sur **3 niveaux**).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "61e5f14d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:15:34.378886Z",
+     "iopub.status.busy": "2026-08-09T10:15:34.378694Z",
+     "iopub.status.idle": "2026-08-09T10:15:34.650601Z",
+     "shell.execute_reply": "2026-08-09T10:15:34.650727Z"
+    },
+    "papermill": {
+     "duration": 0.27563,
+     "end_time": "2026-08-09T10:15:34.650815+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:34.375185+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 entites definies : Subscription (feuille), Catalog/Product/Variant (hiérarchie).\r\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "(17,24): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n",
+      "(29,24): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n",
+      "(40,24): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Domaine : 4 entités decorées. Aucun Register() — tout passe par les attributs.\n",
+    "\n",
+    "[MainCategory(\"Billing\")]\n",
+    "public sealed class Subscription : ISimpleEntity\n",
+    "{\n",
+    "    public string Name { get; set; } = \"\";\n",
+    "    public double Montant { get; set; }       // en euros\n",
+    "    public string Pays { get; set; } = \"\";    // code pays ISO 2\n",
+    "    public bool Actif { get; set; }\n",
+    "}\n",
+    "\n",
+    "[MainCategory(\"Catalog\")]\n",
+    "[AttributeContainer(ChildType = typeof(Product))]\n",
+    "public sealed class Catalog : IChildEntity\n",
+    "{\n",
+    "    public string Nom { get; set; } = \"\";\n",
+    "    public IChildEntity? Parent { get; set; }\n",
+    "    private readonly List<IChildEntity> _children = new();\n",
+    "    public IReadOnlyList<IChildEntity> Children => _children;\n",
+    "    public void AddChild(IChildEntity child) { child.Parent = this; _children.Add(child); }\n",
+    "}\n",
+    "\n",
+    "[MainCategory(\"Catalog\")]\n",
+    "[AttributeContainer(ChildType = typeof(Variant))]\n",
+    "public sealed class Product : IChildEntity\n",
+    "{\n",
+    "    public string Nom { get; set; } = \"\";\n",
+    "    public double Prix { get; set; }\n",
+    "    public IChildEntity? Parent { get; set; }\n",
+    "    private readonly List<IChildEntity> _children = new();\n",
+    "    public IReadOnlyList<IChildEntity> Children => _children;\n",
+    "    public void AddChild(IChildEntity child) { child.Parent = this; _children.Add(child); }\n",
+    "}\n",
+    "\n",
+    "[MainCategory(\"Catalog\")]\n",
+    "public sealed class Variant : IChildEntity, IMergeable\n",
+    "{\n",
+    "    public string Nom { get; set; } = \"\";\n",
+    "    public double Prix { get; set; }\n",
+    "    public IChildEntity? Parent { get; set; }\n",
+    "    public IReadOnlyList<IChildEntity> Children => Array.Empty<IChildEntity>();\n",
+    "    public bool Merge(IMergeable other)\n",
+    "    {\n",
+    "        if (other is Variant v && string.IsNullOrEmpty(Nom)) { Nom = v.Nom; return true; }\n",
+    "        return false;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"4 entites definies : Subscription (feuille), Catalog/Product/Variant (hiérarchie).\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "533727c3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:15:34.657367Z",
+     "iopub.status.busy": "2026-08-09T10:15:34.657165Z",
+     "iopub.status.idle": "2026-08-09T10:15:34.843492Z",
+     "shell.execute_reply": "2026-08-09T10:15:34.843187Z"
+    },
+    "papermill": {
+     "duration": 0.189909,
+     "end_time": "2026-08-09T10:15:34.843611+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:34.653702+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Catégories découvertes (sans aucun Register) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [Billing]  ->  Subscription\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [Catalog]  ->  Catalog, Product, Variant\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conteneurs (racines légitimes) : Catalog, Product\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Entités hiérarchiques IChildEntity : Catalog, Product, Variant\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Entités plates ISimpleEntity : Subscription\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fusibles IMergeable : Variant\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Decouverte : FromAssembly<Subscription>() scanne l'assembly courant et regroupe.\n",
+    "\n",
+    "var container = ReflectedProviderContainer.FromAssembly<Subscription>();\n",
+    "\n",
+    "Console.WriteLine(\"Catégories découvertes (sans aucun Register) :\");\n",
+    "foreach (var cat in container.Categories)\n",
+    "    Console.WriteLine($\"  [{cat}]  ->  {string.Join(\", \", container[cat].Select(t => t.Name))}\");\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"Conteneurs (racines légitimes) : {string.Join(\", \", container.Containers.Select(t => t.Name))}\");\n",
+    "Console.WriteLine($\"Entités hiérarchiques IChildEntity : {string.Join(\", \", container.ChildEntities.Select(t => t.Name))}\");\n",
+    "Console.WriteLine($\"Entités plates ISimpleEntity : {string.Join(\", \", container.SimpleEntities.Select(t => t.Name))}\");\n",
+    "Console.WriteLine($\"Fusibles IMergeable : {string.Join(\", \", container.Mergeables.Select(t => t.Name))}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fda8e90",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002897,
+     "end_time": "2026-08-09T10:15:34.849929+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:34.847032+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — Enregistrement explicite\n",
+    "\n",
+    "`ReflectedProviderContainer` découvre par **décoration**. Le socle expose aussi\n",
+    "`SimpleProviderContainer`, symétrique par **enregistrement explicite** : on déclare\n",
+    "soi-même quel type va dans quelle catégorie, sans aucun attribut.\n",
+    "\n",
+    "**Objectif.** Compléter la fonction `ConstruireConteneur()` pour qu'elle renvoie un\n",
+    "`SimpleProviderContainer` où `Subscription` est enregistré sous la catégorie `\"Billing\"`\n",
+    "et `Catalog` + `Product` sous `\"Catalog\"`. Les deux stratégies étant interchangeables via\n",
+    "`IProviderContainer`, le conteneur retourné doit exposer les mêmes `Categories` que le\n",
+    "conteneur par réflexion.\n",
+    "\n",
+    "*Indice.* Le chaînage est fluent : `new SimpleProviderContainer().Register<T>(\"cat\")...`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1dc22a53",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:15:34.857124Z",
+     "iopub.status.busy": "2026-08-09T10:15:34.856901Z",
+     "iopub.status.idle": "2026-08-09T10:15:34.931425Z",
+     "shell.execute_reply": "2026-08-09T10:15:34.931540Z"
+    },
+    "papermill": {
+     "duration": 0.0788,
+     "end_time": "2026-08-09T10:15:34.931618+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:34.852818+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 : non complété (renvoie null).\r\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "(2,26): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 (a completer) : enregistrement explicite, même lecture que par réflexion.\n",
+    "public IProviderContainer? ConstruireConteneur()\n",
+    "{\n",
+    "    // TODO etudiant : renvoyer un SimpleProviderContainer enregistrant\n",
+    "    //   Subscription  -> \"Billing\"\n",
+    "    //   Catalog       -> \"Catalog\"\n",
+    "    //   Product       -> \"Catalog\"\n",
+    "    return null;  // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "// --- zone de validation (ne pas modifier) ---\n",
+    "var explicite = ConstruireConteneur();\n",
+    "if (explicite is null)\n",
+    "{\n",
+    "    Console.WriteLine(\"Exercice 1 : non complété (renvoie null).\");\n",
+    "}\n",
+    "else\n",
+    "{\n",
+    "    var cats = string.Join(\", \", explicite.Categories);\n",
+    "    Console.WriteLine($\"Catégories (enregistrement explicite) : {cats}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "220a0218",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00268,
+     "end_time": "2026-08-09T10:15:34.937495+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:34.934815+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Moment 2 — Sérialisation round-trip (JSON + XML)\n",
+    "\n",
+    "Le même graphe d'entités doit pouvoir être **persisté** puis **reconstitué** sans perte\n",
+    "— c'est la promesse d'un socle. On construit une hiérarchie `Catalog > Product > Variant`\n",
+    "sur 3 niveaux, on la sérialise dans les deux formats, puis on désérialise et on vérifie\n",
+    "que (a) la structure est identique et (b) les références `Parent` sont re-liées.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "fc10a4f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:15:34.944000Z",
+     "iopub.status.busy": "2026-08-09T10:15:34.943814Z",
+     "iopub.status.idle": "2026-08-09T10:15:35.048124Z",
+     "shell.execute_reply": "2026-08-09T10:15:35.047990Z"
+    },
+    "papermill": {
+     "duration": 0.10817,
+     "end_time": "2026-08-09T10:15:35.048192+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:34.940022+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Graphe original :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- Catalog:Boutique  [parent: (racine)]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - Product:Logiciel  [parent: Catalog]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    - Variant:Licence Pro  [parent: Product]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    - Variant:Licence Basic  [parent: Product]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - Product:Matériel  [parent: Catalog]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    - Variant:Clé USB  [parent: Product]\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Construction du graphe : Catalog > Product > Variant (3 niveaux).\n",
+    "var catalogue = new Catalog { Nom = \"Boutique\" };\n",
+    "\n",
+    "var logiciel = new Product { Nom = \"Logiciel\", Prix = 199 };\n",
+    "var matos    = new Product { Nom = \"Matériel\", Prix = 0 };\n",
+    "catalogue.AddChild(logiciel);\n",
+    "catalogue.AddChild(matos);\n",
+    "\n",
+    "logiciel.AddChild(new Variant { Nom = \"Licence Pro\",  Prix = 299 });\n",
+    "logiciel.AddChild(new Variant { Nom = \"Licence Basic\", Prix = 99 });\n",
+    "matos.AddChild(new Variant { Nom = \"Clé USB\", Prix = 25 });\n",
+    "\n",
+    "void Afficher(IChildEntity noeud, int prof = 0)\n",
+    "{\n",
+    "    var nom = noeud switch { Catalog c => $\"Catalog:{c.Nom}\", Product p => $\"Product:{p.Nom}\",\n",
+    "                             Variant v => $\"Variant:{v.Nom}\", _ => noeud.GetType().Name };\n",
+    "    var parent = noeud.Parent is null ? \"(racine)\" : noeud.Parent.GetType().Name;\n",
+    "    Console.WriteLine($\"{new string(' ', prof * 2)}- {nom}  [parent: {parent}]\");\n",
+    "    foreach (var enfant in noeud.Children) Afficher(enfant, prof + 1);\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Graphe original :\");\n",
+    "Afficher(catalogue);\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "98acf45e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:15:35.054941Z",
+     "iopub.status.busy": "2026-08-09T10:15:35.054770Z",
+     "iopub.status.idle": "2026-08-09T10:15:35.234885Z",
+     "shell.execute_reply": "2026-08-09T10:15:35.234736Z"
+    },
+    "papermill": {
+     "duration": 0.18373,
+     "end_time": "2026-08-09T10:15:35.234961+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:35.051231+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JSON (extrait) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\r\n",
+      "  \"Nom\": \"Boutique\",\r\n",
+      "  \"Children\": {\r\n",
+      "    \"$type\": \"System.Collections.Generic.List`1[[MyIA.AI.ComponentModel.Entities.IChildEntity, MyIA.AI.Shared]], System.Private.CoreLib\",\r\n",
+      "    \"$values\": [\r\n",
+      "      {\r\n",
+      "        \"$type\": \"Submission#3+P  ...\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Graphe rechargé depuis JSON :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- Catalog:Boutique  [parent: (racine)]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - Product:Logiciel  [parent: Catalog]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    - Variant:Licence Pro  [parent: Product]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    - Variant:Licence Basic  [parent: Product]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - Product:Matériel  [parent: Catalog]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    - Variant:Clé USB  [parent: Product]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Parent du 1er produit re-lié ? True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Round-trip JSON : sérialise -> désérialise -> compare la structure.\n",
+    "string json = MetadataJsonSerializer.Serialize(catalogue);\n",
+    "Console.WriteLine(\"JSON (extrait) :\");\n",
+    "Console.WriteLine(json.Substring(0, Math.Min(240, json.Length)) + (json.Length > 240 ? \"  ...\" : \"\"));\n",
+    "\n",
+    "var depuisJson = MetadataJsonSerializer.Deserialize<Catalog>(json);\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Graphe rechargé depuis JSON :\");\n",
+    "Afficher(depuisJson);\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"Parent du 1er produit re-lié ? {depuisJson.Children[0].Parent?.GetType().Name == \"Catalog\"}\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ce8ad6f3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:15:35.243289Z",
+     "iopub.status.busy": "2026-08-09T10:15:35.243104Z",
+     "iopub.status.idle": "2026-08-09T10:15:35.329811Z",
+     "shell.execute_reply": "2026-08-09T10:15:35.329677Z"
+    },
+    "papermill": {
+     "duration": 0.09098,
+     "end_time": "2026-08-09T10:15:35.329877+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:35.238897+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XML (extrait) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n",
+      "<NodeSurrogate xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" type=\"Catalog\">\r\n",
+      "  <property name=\"Nom\" value=\"Boutique\" />\r\n",
+      "  <child type=\"Product\">\r\n",
+      "    <property name  ...\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nombre de produits rechargés depuis XML : 2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Variantes du 1er produit : 2\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Round-trip XML : même graphe, autre format, même résultat.\n",
+    "// Le serializer XML a besoin du résolveur décoré avec les types concrets connus du graphe\n",
+    "// (la moitié A2 du socle : DynamicSurrogate + re-lien Parent via AddChild au rechargement).\n",
+    "var xmlSerializer = new MetadataXmlSerializer(\n",
+    "    new XmlAwareContractResolver(new[] { typeof(Catalog), typeof(Product), typeof(Variant) }));\n",
+    "string xml = xmlSerializer.Serialize(catalogue);\n",
+    "Console.WriteLine(\"XML (extrait) :\");\n",
+    "Console.WriteLine(xml.Substring(0, Math.Min(260, xml.Length)) + (xml.Length > 260 ? \"  ...\" : \"\"));\n",
+    "\n",
+    "var depuisXml = xmlSerializer.Deserialize<Catalog>(xml);\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"Nombre de produits rechargés depuis XML : {depuisXml.Children.Count}\");\n",
+    "var premierProduit = depuisXml.Children.OfType<Product>().First();\n",
+    "Console.WriteLine($\"Variantes du 1er produit : {premierProduit.Children.Count}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42473079",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003227,
+     "end_time": "2026-08-09T10:15:35.336543+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:35.333316+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Sérialiser une hiérarchie personnalisée\n",
+    "\n",
+    "**Objectif.** Construire un second catalogue contenant un seul produit `Formation` avec\n",
+    "deux variantes (`Présentiel`, `Distanciel`), le sérialiser en JSON, puis désérialiser et\n",
+    "renvoyer le **nom de la première variante** du premier produit.\n",
+    "\n",
+    "*Indice.* Utilise `MetadataJsonSerializer.Serialize` puis `Deserialize<Catalog>`, et\n",
+    "accède à `.Children.OfType<Product>().First().Children` pour atteindre les variantes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "0357c8ec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:15:35.343916Z",
+     "iopub.status.busy": "2026-08-09T10:15:35.343737Z",
+     "iopub.status.idle": "2026-08-09T10:15:35.393567Z",
+     "shell.execute_reply": "2026-08-09T10:15:35.393672Z"
+    },
+    "papermill": {
+     "duration": 0.053898,
+     "end_time": "2026-08-09T10:15:35.393743+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:35.339845+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 : non complété (renvoie null).\r\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "(2,14): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 (a completer) : construire, sérialiser, recharger, extraire.\n",
+    "public string? NomPremiereVariante()\n",
+    "{\n",
+    "    // TODO etudiant : construire Catalog > Product(\"Formation\") >\n",
+    "    //                  Variant(\"Présentiel\"), Variant(\"Distanciel\"),\n",
+    "    //                  sérialiser en JSON, désérialiser, renvoyer le nom\n",
+    "    //                  de la première variante du premier produit.\n",
+    "    return null;  // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "// --- zone de validation (ne pas modifier) ---\n",
+    "var rep2 = NomPremiereVariante();\n",
+    "Console.WriteLine(rep2 is null\n",
+    "    ? \"Exercice 2 : non complété (renvoie null).\"\n",
+    "    : $\"Exercice 2 -> première variante : {rep2}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c61eba8f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0034,
+     "end_time": "2026-08-09T10:15:35.400535+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:35.397135+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Moment 3 — Prédicat universel métier (Flee)\n",
+    "\n",
+    "C'est le moment où la logique métier **cesse d'être codée**. Une règle\n",
+    "métier (quels abonnements sont éligibles à un traitement) est une **chaîne** :\n",
+    "\n",
+    "```\n",
+    "Montant > 1000 And Pays = \"FR\" And Actif = true\n",
+    "```\n",
+    "\n",
+    "Cette chaîne peut venir d'un fichier de configuration, d'une ligne de CSV, ou être saisie\n",
+    "par un utilisateur non-développeur dans une console d'administration. On la **compile une\n",
+    "fois** en un délégué réutilisable, puis on l'évalue sur N instances en changeant\n",
+    "simplement les variables — **sans recompiler l'hôte**.\n",
+    "\n",
+    "> **Syntaxe Flee.** Le moteur est d'inspiration VB : `And` / `Or` / `=`, **pas**\n",
+    "> `&&` / `||` / `==`. La comparaison de chaînes utilise `=`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6f85bec7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:15:35.408032Z",
+     "iopub.status.busy": "2026-08-09T10:15:35.407834Z",
+     "iopub.status.idle": "2026-08-09T10:15:35.535358Z",
+     "shell.execute_reply": "2026-08-09T10:15:35.535220Z"
+    },
+    "papermill": {
+     "duration": 0.131688,
+     "end_time": "2026-08-09T10:15:35.535427+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:35.403739+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Règle appliquée : Montant > 1000 And Pays = \"FR\" And Actif = true\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Eligibles :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ENT-001  Montant=  1500 Pays=FR Actif=True  -> True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ENT-002  Montant=   500 Pays=FR Actif=True  -> False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ENT-003  Montant=  3000 Pays=US Actif=True  -> False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ENT-004  Montant=  2000 Pays=FR Actif=False -> False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Règle 2 : Montant > 2000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Gros abonnements (>2000) : ENT-003\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Des abonnements factices sur lesquels appliquer la règle.\n",
+    "var abonnements = new List<Subscription>\n",
+    "{\n",
+    "    new() { Name = \"ENT-001\", Montant = 1500, Pays = \"FR\", Actif = true   },\n",
+    "    new() { Name = \"ENT-002\", Montant =  500, Pays = \"FR\", Actif = true   },\n",
+    "    new() { Name = \"ENT-003\", Montant = 3000, Pays = \"US\", Actif = true   },\n",
+    "    new() { Name = \"ENT-004\", Montant = 2000, Pays = \"FR\", Actif = false  },\n",
+    "};\n",
+    "\n",
+    "// La règle est une CHAENE — elle aurait aussi bien pu être lue dans un fichier.\n",
+    "string regle = \"Montant > 1000 And Pays = \\\"FR\\\" And Actif = true\";\n",
+    "Console.WriteLine($\"Règle appliquée : {regle}\");\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "// Compilation unique : on lie le délégué une fois.\n",
+    "var ctx = new ExpressionContext();\n",
+    "ctx.Variables.Add(\"Montant\", 0.0);\n",
+    "ctx.Variables.Add(\"Pays\", \"\");\n",
+    "ctx.Variables.Add(\"Actif\", false);\n",
+    "var predicat = ctx.CompileGeneric<bool>(regle);\n",
+    "\n",
+    "Console.WriteLine(\"Eligibles :\");\n",
+    "foreach (var ab in abonnements)\n",
+    "{\n",
+    "    ctx.Variables[\"Montant\"] = ab.Montant;\n",
+    "    ctx.Variables[\"Pays\"]    = ab.Pays;\n",
+    "    ctx.Variables[\"Actif\"]   = ab.Actif;\n",
+    "    Console.WriteLine($\"  {ab.Name,-8} Montant={ab.Montant,6} Pays={ab.Pays} Actif={ab.Actif,-5} -> {predicat.Evaluate()}\");\n",
+    "}\n",
+    "\n",
+    "// On change la règle (les données pilotent), toujours sans recompiler l'hôte.\n",
+    "string regle2 = \"Montant > 2000\";\n",
+    "var predicat2 = ctx.CompileGeneric<bool>(regle2);\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"Règle 2 : {regle2}\");\n",
+    "var gros = abonnements.Where(a => { ctx.Variables[\"Montant\"] = a.Montant; return predicat2.Evaluate(); });\n",
+    "Console.WriteLine($\"Gros abonnements (>2000) : {string.Join(\", \", gros.Select(a => a.Name))}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "454aeb36",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003469,
+     "end_time": "2026-08-09T10:15:35.542696+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:35.539227+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Une règle à seuil variable\n",
+    "\n",
+    "**Objectif.** Compléter `FiltrerParMontant(min)` pour qu'elle renvoie les noms des\n",
+    "abonnements dont le `Montant` est **supérieur ou égal** au seuil passé en paramètre.\n",
+    "La règle doit être **construite comme une chaîne** à partir du seuil (`$\"Montant >= {min}\"`),\n",
+    "compilée via Flee, puis appliquée.\n",
+    "\n",
+    "*Indice.* `CompileGeneric<bool>` sur le contexte, puis bouclez en assignant\n",
+    "`ctx.Variables[\"Montant\"]` avant chaque `.Evaluate()`. Syntaxe Flee : `>=` pour\n",
+    "«supérieur ou égal».\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cdfc128a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:15:35.551175Z",
+     "iopub.status.busy": "2026-08-09T10:15:35.550992Z",
+     "iopub.status.idle": "2026-08-09T10:15:35.596006Z",
+     "shell.execute_reply": "2026-08-09T10:15:35.595872Z"
+    },
+    "papermill": {
+     "duration": 0.04951,
+     "end_time": "2026-08-09T10:15:35.596073+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:35.546563+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 : non complété (renvoie une liste vide).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 (a completer) : règle de seuil variable, compilée depuis une chaîne.\n",
+    "public IEnumerable<string> FiltrerParMontant(IEnumerable<Subscription> abonnements, double min)\n",
+    "{\n",
+    "    // TODO etudiant : construire la règle \"$\"Montant >= {min}\"\", la compiler via Flee,\n",
+    "    //                  et renvoyer les noms des abonnements au-dessus du seuil.\n",
+    "    return Enumerable.Empty<string>();  // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "// --- zone de validation (ne pas modifier) ---\n",
+    "var retenus = FiltrerParMontant(abonnements, 1500);\n",
+    "Console.WriteLine(retenus.Any()\n",
+    "    ? $\"Exercice 3 -> abonnements >= 1500 : {string.Join(\", \", retenus)}\"\n",
+    "    : \"Exercice 3 : non complété (renvoie une liste vide).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fb1dc79",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003437,
+     "end_time": "2026-08-09T10:15:35.603307+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T10:15:35.599870+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Trois moments, un même fil rouge : **séparer la structure de l'utilisation**.\n",
+    "\n",
+    "| Moment | Ce qui change | Bénéfice |\n",
+    "|---|---|---|\n",
+    "| **Décoration → introspection** | On déclare le rôle d'un type par attribut | Un nouveau type est découvrable **sans toucher au code qui le consomme** |\n",
+    "| **Sérialisation round-trip** | Le graphe persiste et se reconstitue | La configuration peut être **un fichier**, pas du code |\n",
+    "| **Prédicat universel (Flee)** | La règle métier est une chaîne | La logique est pilotée par les **données**, éditable sans redéploiement |\n",
+    "\n",
+    "Le socle `MyIA.AI.Shared` factorise ces trois besoins transverses (découverte, persistance,\n",
+    "logique déclarative) afin que les modules métier se concentrent sur leur domaine propre.\n",
+    "C'est le sens d'un *socle* : ce qui était ré-écrit dans chaque projet devient une\n",
+    "convention partagée, testée une fois pour toutes (48 tests unitaires au passage).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 6.922133,
+   "end_time": "2026-08-09T10:15:35.734365+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Socle-MetadataDriven-Csharp.ipynb",
+   "output_path": "Socle-MetadataDriven-Csharp.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-09T10:15:28.812232+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #10154

Closes #10161 · See #7265 (Aricie.Shared socle epic).

## What changed

New cross-series notebook `MyIA.AI.Notebooks/cross-series/socle-metadata-driven/Socle-MetadataDriven-Csharp.ipynb` — the **first** notebook referencing the `MyIA.AI.Shared` socle (#10161 measured 0 reference; socle lives at 48 green tests). The issue title flags the gap precisely: *"Flee declare, jamais exerce"* — the low-code rule-engine pattern existed in the socle's dependencies but no notebook exercised it. This PR closes that gap.

The notebook demonstrates the socle across **three moments**, on a single billing/catalog domain:

| Moment | Demonstrated socle API | Substance |
|---|---|---|
| **1. Décoration → introspection** | `[MainCategory]` + `[AttributeContainer]` → `ReflectedProviderContainer.FromAssembly<T>()` | A 4-entity domain (`Subscription`, `Catalog`, `Product`, `Variant`) is discovered **with zero `Register()` calls** — grouped by category (Billing/Catalog) and by role (Containers / IChildEntity / ISimpleEntity / IMergeable) |
| **2. Sérialisation round-trip** | `MetadataJsonSerializer` + `MetadataXmlSerializer(new XmlAwareContractResolver(knownTypes))` | A **3-level** `IChildEntity` hierarchy (`Catalog > Product > Variant`) serializes and reloads intact in **both** JSON and XML, with the `Parent` reference re-linked |
| **3. Prédicat universel métier (Flee)** | `ExpressionContext` + `CompileGeneric<bool>(ruleString)` + `.Evaluate()` | The Prong-B substance: a business rule is a **string** (`Montant > 1000 And Pays = "FR" And Actif = true`), **compiled once** then evaluated over N subscription instances by changing variables — and a second rule (`Montant > 2000`) is applied **without recompiling the host**. This is the difference between coding N `if` branches and driving business logic from data. |

### 3 stubbed exercises (rule C.1: no `throw`, no voluntary error)
- **Ex. 1** — `SimpleProviderContainer` explicit registration, same `Categories` read as reflection.
- **Ex. 2** — build + JSON round-trip a `Catalog > Product("Formation") > Variant` tree, return the first variant's name.
- **Ex. 3** — `FiltrerParMontant(min)`: build the rule string `$"Montant >= {min}"`, compile via Flee, return matching subscription names.

## Validation (firsthand, this cycle)

- **Executed cell-by-cell** via `notebook_tools.py execute --kernel .net-csharp`: `execution_count` = 1→10 sequential, **0 error outputs**. Flee predicate verified: `(1500,FR,True)→True`, `(500,FR,True)→False`, `(3000,US,True)→False`, `(2000,FR,False)→False`; rule 2 `Montant>2000` → `ENT-003`.
- **Round-trip verified firsthand**: XML `Deserialize<Catalog>` rebuilds 1 product with 2 variants, `Parent` re-linked to `Catalog`, value property `Prix=199` round-trips. JSON `Parent du 1er produit re-lié ? True`.
- **Notebook validator**: OK=1, Warnings=0, Errors=0.
- **probeAddresses banner stripped** post-re-exec (`strip_probe_banner.py --apply`, 9 lines fixed → re-scan 0); papermill input/output paths normalized to basename by pre-commit hook (secrets-hygiene rule 6 — metadata, not output).
- **check_twin_parity --check**: 157 pairs, OK=157 DRIFT=0 MISSING=0 (new notebook is not in any twin pair).
- **Catalog byte-identique to main**: only the new notebook dir is untracked; zero `COURSE_CATALOG.generated.*` churn.
- **Socle code untouched**: this PR adds a notebook only; the Release DLL it `#r`-references is the artifact whose execution above proves it functional. `dotnet test` for the socle was 48/48 at #10161 measurement and is unaffected (no `.cs` modified).

## SOTA note (Prong A + B)

- **Prong A — vrai outil.** The notebook `#r`-references the real compiled socle DLL (`MyIA.AI.Shared/bin/Release/net9.0/MyIA.AI.Shared.dll`) and the real **Flee 2.0.0** rule engine (`#r "nuget:Flee"`). Verdict: **SOTA-OK** — committed outputs are genuine Flee + socle outputs, no workaround.
- **Prong B — problème non-trivial.** The Flee moment is deliberately **not** a degenerate single-condition rule: it exercises a 3-term conjunctive predicate over a typed variable set, plus a second rule showing host-independent re-compilation — exercising Flee's distinctive compile-once/evaluate-N + data-driven-rule capability rather than a capability a single `if` would match.

## L898 collision guard

`gh pr list --state all --search "socle-metadata-driven"` returns 4 PRs (#7653 A1, #7661 A2 JSON, #7677 A2+ XML, #8041 README) — all MERGED socle **code** PRs (token-based FPOS, the socle's domain name). Authoritative files-based query (`gh pr list --json files` filtering `cross-series/socle-metadata-driven/`): **0 PRs** touch this path. Clean.

## Variation note

prev = MED/notebook-dotnet #10154 (Sudoku-9 machine-dep drain). This grain = DEEP/notebook-dotnet (new notebook creation — `main` gains a capability that did not exist, produced by domain reasoning over the socle contracts + Flee API, verified firsthand: litmus DEEP). Same-genre as prev (notebook-dotnet) but **genuinely distinct substance**: DEEP creation vs MED drain, completely different domain (cross-series socle pedagogy vs Sudoku wall-clock drain). G-VAR-3 permits two consecutive MED/DEEP same-genre when each is distinct substance — satisfied. This also breaks the 3-PR drain streak (#10149/#10152/#10154, all #9434) with a creation grain.
