### PR TITLE
feat(cross-series,#10161): socle metadata-driven notebook (A1 + A2 + Flee predicate)

### DIFF
--- a/MyIA.AI.Notebooks/cross-series/socle-metadata-driven/README.md
+++ b/MyIA.AI.Notebooks/cross-series/socle-metadata-driven/README.md
@@ -1,0 +1,70 @@
+# Socle .NET metadata-driven
+
+Ce projet est la **première existence pédagogique** du socle transverse
+[`MyIA.AI.Shared`](../../../MyIA.AI.Shared/) (EPIC #7265, tranches A1 + A2). Le socle
+compile, passe 48 tests — et jusqu'ici aucun notebook ne le référençait. Le notebook
+[`Socle-Metadata-Driven.ipynb`](Socle-Metadata-Driven.ipynb) démontre le pattern
+*metadata-driven* en trois moments, du plus mécanique au plus substantiel.
+
+Il se classe dans `cross-series/` parce que le socle se définit lui-même comme un
+**socle .NET transverse partagé** : il mobilise la notation générique (destination
+`GradeBookApp`, #7265 A1) et les contraintes-comme-expressions (proche de
+`Search/Part2-CSP/`, pépite B1 du patrimoine Aricie).
+
+## Les trois moments
+
+1. **Décoration → introspection (A1).** On décore un type avec `[MainCategory(...)]`
+   et/ou `[AttributeContainer]`, on le découvre par réflexion via
+   `ReflectedProviderContainer.FromAssembly<T>()` — sans aucune inscription explicite.
+   Aucun registre à maintenir : la décoration suffit.
+
+2. **Sérialisation pilotée par la décoration (A2).** Le même graphe `IChildEntity`,
+   sérialisé en JSON par `MetadataJsonSerializer`, round-trippé : les types concrets des
+   enfants sont préservés (via `$type`), le back-reference `Parent` (qui formerait un
+   cycle) est droppé à la sérialisation puis reconstruit au chargement.
+
+3. **Le prédicat universel Flee (la substance *low-code*).** Une règle métier écrite
+   **en chaîne de caractères**, compilée à l'exécution par le moteur
+   [Flee](https://github.com/arnonax/Flee) 2.0.0, évaluée comme prédicat sur les entités
+   découvertes en (1). Flee est déclaré en dépendance du socle (`<PackageReference>`)
+   mais **n'était jamais exercé** : ce notebook le met en œuvre. La règle vient de la
+   **donnée** (config, CSV, saisie), pas du code, et change sans recompiler.
+
+   > **Grammaire Flee.** Le moteur utilise une grammaire VB-like : opérateurs
+   > `And` / `Or` / `Not`, `=` pour l'égalité, `<>` pour la différence — et non
+   > `&&` / `==` du C#. Détail mis en évidence par cette première exécution réelle.
+
+## Prérequis
+
+Le notebook référence l'**assembly buildée** du socle (jamais le code n'est copié-collé).
+Buildée une fois le socle, depuis la racine du dépôt :
+
+```bash
+dotnet build MyIA.AI.Shared/MyIA.AI.Shared.csproj
+```
+
+Le notebook charge ensuite l'assembly par un `#r` relatif (kernel `.net-csharp`) :
+
+```csharp
+#r "../../../MyIA.AI.Shared/bin/Debug/net9.0/MyIA.AI.Shared.dll"
+```
+
+Exécuter sur une machine où [.NET Interactive](https://github.com/dotnet/interactive)
+est installé (kernel `.net-csharp`). Cible .NET 9.0.
+
+## Exercices
+
+Le notebook contient **3 exercices** répartis (non groupés en fin), chacun précédé d'un
+markdown contexte + objectif + indice, stubbé sans erreur volontaire (règle C.1) :
+
+1. Découvrir sa propre entité décorée (`[MainCategory("Logistique")]`).
+2. Vérifier le round-trip JSON sur un graphe plus profond (back-references `Parent`).
+3. Écrire une règle Flee compilée (filtrage par montant supérieur à la moyenne).
+
+## Références
+
+- EPIC **#7265** — récupération du patrimoine transverse Aricie (`Aricie.Shared` →
+  `MyIA.AI.Shared`, net9.0). Tranches A1 (décoration), A2 (sérialisation JSON), A2+ (XML).
+- Issue **#10161** — cadrage de ce notebook (le socle « 48 tests verts, 0 notebook »).
+- Socle : [`MyIA.AI.Shared/README.md`](../../../MyIA.AI.Shared/README.md),
+  [`MyIA.AI.Shared/MyIA.AI.Shared.csproj`](../../../MyIA.AI.Shared/MyIA.AI.Shared.csproj).

--- a/MyIA.AI.Notebooks/cross-series/socle-metadata-driven/Socle-Metadata-Driven.ipynb
+++ b/MyIA.AI.Notebooks/cross-series/socle-metadata-driven/Socle-Metadata-Driven.ipynb
@@ -1,0 +1,929 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e6a008df",
+   "metadata": {},
+   "source": [
+    "# Socle .NET metadata-driven : décoration, sérialisation et prédicat universel\n",
+    "\n",
+    "Ce notebook est la **première existence pédagogique** du socle transverse `MyIA.AI.Shared`\n",
+    "(EPIC #7265, tranches A1 + A2). Le socle compile, passe 48 tests — et aucun notebook ne le\n",
+    "référençait. Il démontre le pattern *metadata-driven* en trois moments, du plus mécanique au\n",
+    "plus substantiel :\n",
+    "\n",
+    "1. **Décoration → introspection** (A1). On décore un type, on le découvre par réflexion, sans\n",
+    "   aucune inscription explicite.\n",
+    "2. **Sérialisation pilotée par la décoration** (A2). Le même graphe, deux formats, et la\n",
+    "   *décoration seule* qui décide de ce qui sort — avec aller-retour (round-trip).\n",
+    "3. **Le prédicat universel Flee** (la substance). Une règle métier écrite **en chaîne de\n",
+    "   caractères**, compilée à l'exécution, évaluée comme prédicat sur les entités découvertes.\n",
+    "   C'est le moteur d'expressions déclaré en dépendance (`Flee 2.0.0`) et **jamais exercé**\n",
+    "   jusqu'ici : la démonstration du pattern *low-code*, où la règle vient de la donnée, pas du\n",
+    "   code, et change sans recompiler.\n",
+    "\n",
+    "> **Prérequis** : le socle doit être buildé une fois (`dotnet build MyIA.AI.Shared/MyIA.AI.Shared.csproj`).\n",
+    "> Le notebook référence l'assembly produite, jamais le code du socle n'est copié-collé."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0cfa6632",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:27:46.688860Z",
+     "iopub.status.busy": "2026-08-09T10:27:46.683876Z",
+     "iopub.status.idle": "2026-08-09T10:27:48.098617Z",
+     "shell.execute_reply": "2026-08-09T10:27:48.091868Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '12436.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Flee, 2.0.0</span></li><li><span>Newtonsoft.Json, 13.0.3</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Socle MyIA.AI.Shared + Flee 2.0.0 + Newtonsoft.Json 13.0.3 référencés."
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#r \"nuget: Flee, 2.0.0\"\n",
+    "#r \"nuget: Newtonsoft.Json, 13.0.3\"\n",
+    "#r \"../../../MyIA.AI.Shared/bin/Debug/net9.0/MyIA.AI.Shared.dll\"\n",
+    "using MyIA.AI.ComponentModel.Attributes;\n",
+    "using MyIA.AI.ComponentModel.Entities;\n",
+    "using MyIA.AI.ComponentModel.Providers;\n",
+    "using MyIA.AI.ComponentModel.Serialization;\n",
+    "using Flee.PublicTypes;\n",
+    "using System.Linq;\n",
+    "using System.Collections.Generic;\n",
+    "\"Socle MyIA.AI.Shared + Flee 2.0.0 + Newtonsoft.Json 13.0.3 référencés.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df50bd69",
+   "metadata": {},
+   "source": [
+    "## 1. Décoration → introspection (A1)\n",
+    "\n",
+    "Le contrat tient en une phrase : **décorer un type suffit**. Pas de registre, pas\n",
+    "d'inscription, pas de factory à maintenir. La décoration `[MainCategory(\"...\")]`\n",
+    "suffixe le type d'une catégorie de groupement ; `[AttributeContainer]` marque un type\n",
+    "comme racine d'une hiérarchie d'entités enfants (`IChildEntity`). Le\n",
+    "`ReflectedProviderContainer` parcourt l'assembly et expose ce qui a été décoré.\n",
+    "\n",
+    "On définit trois entités d'un domaine e-commerce : une commande (feuille plate,\n",
+    "`ISimpleEntity`) et un arbre catalogue (`IChildEntity` sur deux niveaux)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a037be75",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:27:48.099697Z",
+     "iopub.status.busy": "2026-08-09T10:27:48.099697Z",
+     "iopub.status.idle": "2026-08-09T10:27:48.494023Z",
+     "shell.execute_reply": "2026-08-09T10:27:48.494023Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Entités définies : Commande (ISimpleEntity), Rayon (IChildEntity + AttributeContainer), Categorie (IChildEntity)."
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#nullable enable\n",
+    "[MainCategory(\"Ventes\")]\n",
+    "public sealed class Commande : ISimpleEntity\n",
+    "{\n",
+    "    public string Reference { get; set; } = \"\";\n",
+    "    public decimal Montant { get; set; }\n",
+    "    public string Pays { get; set; } = \"\";\n",
+    "    public string Name => Reference;\n",
+    "}\n",
+    "\n",
+    "[MainCategory(\"Catalogue\")]\n",
+    "[AttributeContainer]\n",
+    "public sealed class Rayon : IChildEntity\n",
+    "{\n",
+    "    public string Nom { get; set; } = \"\";\n",
+    "    private readonly List<IChildEntity> _enfants = new();\n",
+    "    public IChildEntity? Parent { get; set; }\n",
+    "    public IReadOnlyList<IChildEntity> Enfants => _enfants;\n",
+    "    IReadOnlyList<IChildEntity> IChildEntity.Children => _enfants;\n",
+    "    public void Ajouter(IChildEntity enfant) { enfant.Parent = this; _enfants.Add(enfant); }\n",
+    "}\n",
+    "\n",
+    "[MainCategory(\"Catalogue\")]\n",
+    "public sealed class Categorie : IChildEntity\n",
+    "{\n",
+    "    public string Nom { get; set; } = \"\";\n",
+    "    private readonly List<IChildEntity> _enfants = new();\n",
+    "    public IChildEntity? Parent { get; set; }\n",
+    "    public IReadOnlyList<IChildEntity> Enfants => _enfants;\n",
+    "    IReadOnlyList<IChildEntity> IChildEntity.Children => _enfants;\n",
+    "    public void Ajouter(IChildEntity enfant) { enfant.Parent = this; _enfants.Add(enfant); }\n",
+    "}\n",
+    "\"Entités définies : Commande (ISimpleEntity), Rayon (IChildEntity + AttributeContainer), Categorie (IChildEntity).\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b59faab5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:27:48.496022Z",
+     "iopub.status.busy": "2026-08-09T10:27:48.496022Z",
+     "iopub.status.idle": "2026-08-09T10:27:48.723652Z",
+     "shell.execute_reply": "2026-08-09T10:27:48.723652Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Catégories découvertes : Ventes, Catalogue"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Entités simples (ISimpleEntity) : Commande"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Conteneurs hiérarchiques ([AttributeContainer]) : Rayon"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Entités hiérarchiques (IChildEntity) : Rayon, Categorie"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Types dans la catégorie [Catalogue] : Rayon, Categorie"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Aucune inscription explicite : la décoration suffit.\n",
+    "var provider = ReflectedProviderContainer.FromAssembly<Commande>();\n",
+    "\n",
+    "display(\"Catégories découvertes : \" + string.Join(\", \", provider.Categories));\n",
+    "display(\"Entités simples (ISimpleEntity) : \" + string.Join(\", \", provider.SimpleEntities.Select(t => t.Name)));\n",
+    "display(\"Conteneurs hiérarchiques ([AttributeContainer]) : \" + string.Join(\", \", provider.Containers.Select(t => t.Name)));\n",
+    "display(\"Entités hiérarchiques (IChildEntity) : \" + string.Join(\", \", provider.ChildEntities.Select(t => t.Name)));\n",
+    "display(\"Types dans la catégorie [Catalogue] : \" + string.Join(\", \", provider[\"Catalogue\"].Select(t => t.Name)));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91d3ebd4",
+   "metadata": {},
+   "source": [
+    "**Lecture.** Aucune ligne n'a enregistré `Commande`, `Rayon` ou `Categorie` auprès d'un\n",
+    "service. La décoration seule les a rendus discoverables, groupés par catégorie, et\n",
+    "classés par rôle (feuille, conteneur, nœud hiérarchique). C'est l'ancre A1 : la\n",
+    "réflexion .NET standard, orchestrée par deux attributs, produit un registre vivant\n",
+    "sans maintenance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e60a216c",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Découvrez votre propre entité\n",
+    "\n",
+    "**Objectif.** Ajoutez une entité `Livraison` représentant une expédition, décorez-la\n",
+    "avec `[MainCategory(\"Logistique\")]`, implémentez `ISimpleEntity`, puis reconstruisez\n",
+    "le provider et confirmez qu'elle apparaît dans la catégorie `\"Logistique\"`.\n",
+    "\n",
+    "**Indice.** Suivez le squelette de `Commande` ci-dessus. Le `Name` peut renvoyer un\n",
+    "identifiant de suivi. Recréez `ReflectedProviderContainer.FromAssembly<Livraison>()`\n",
+    "et inspectez `provider[\"Logistique\"]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "92099971",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:27:48.725652Z",
+     "iopub.status.busy": "2026-08-09T10:27:48.724652Z",
+     "iopub.status.idle": "2026-08-09T10:27:48.748132Z",
+     "shell.execute_reply": "2026-08-09T10:27:48.747133Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div><style>\r\n",
+       ".dni-code-hint {\r\n",
+       "    font-style: italic;\r\n",
+       "    overflow: hidden;\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview {\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview td {\r\n",
+       "    vertical-align: top;\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "details.dni-treeview {\r\n",
+       "    padding-left: 1em;\r\n",
+       "}\r\n",
+       "table td {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "table tr { \r\n",
+       "    vertical-align: top; \r\n",
+       "    margin: 0em 0px;\r\n",
+       "}\r\n",
+       "table tr td pre \r\n",
+       "{ \r\n",
+       "    vertical-align: top !important; \r\n",
+       "    margin: 0em 0px !important;\r\n",
+       "} \r\n",
+       "table th {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "</style>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : à compléter.\n",
+    "// TODO etudiant : définir [MainCategory(\"Logistique\")] public sealed class Livraison : ISimpleEntity { ... }\n",
+    "// TODO etudiant : reconstruire le provider et afficher provider[\"Logistique\"].\n",
+    "return null;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd687e85",
+   "metadata": {},
+   "source": [
+    "## 2. Sérialisation pilotée par la décoration (A2)\n",
+    "\n",
+    "Même graphe, format JSON — et c'est encore la **décoration qui décide** de ce qui sort.\n",
+    "Le `MetadataJsonSerializer` round-trippe un arbre `IChildEntity` : le type concret des\n",
+    "enfants est préservé (via `$type`), le back-reference `Parent` — qui formerait un cycle\n",
+    "— est droppé à la sérialisation puis **reconstruit** au chargement. Un graphe sérialisé\n",
+    "puis rechargé reste introspectable exactement comme l'original."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "fb781b57",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:27:48.749133Z",
+     "iopub.status.busy": "2026-08-09T10:27:48.749133Z",
+     "iopub.status.idle": "2026-08-09T10:27:48.866807Z",
+     "shell.execute_reply": "2026-08-09T10:27:48.866807Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{\r\n",
+       "  \"Nom\": \"Multimédia\",\r\n",
+       "  \"Enfants\": {\r\n",
+       "    \"$type\": \"System.Collections.Generic.List`1[[MyIA.AI.ComponentModel.Entities.IChildEntity, MyIA.AI.Shared]], System.Private.CoreLib\",\r\n",
+       "    \"$values\": [\r\n",
+       "      {\r\n",
+       "        \"$type\": \"Submission#3+Categorie, ℛ*4d1c3986-52f5-475e-a58b-d7f066f3d6fd#1-3\",\r\n",
+       "        \"Nom\": \"Vidéo\",\r\n",
+       "        \"Enfants\": {\r\n",
+       "          \"$type\": \"System.Collections.Generic.List`1[[MyIA.AI.ComponentModel.Entities.IChildEntity, MyIA.AI.Shared]], System.Private.CoreLib\",\r\n",
+       "          \"$values\": [\r\n",
+       "            {\r\n",
+       "              \"$type\": \"Submission#3+Categorie, ℛ*4d1c3986-52f5-475e-a58b-d7f066f3d6fd#1-3\",\r\n",
+       "              \"Nom\": \"Caméscopes\",\r\n",
+       "              \"Enfants\": {\r\n",
+       "                \"$type\": \"System.Collections.Generic.List`1[[MyIA.AI.ComponentModel.Entities.IChildEntity, MyIA.AI.Shared]], System.Private.CoreLib\",\r\n",
+       "                \"$values\": []\r\n",
+       "              }\r\n",
+       "            }\r\n",
+       "          ]\r\n",
+       "        }\r\n",
+       "      },\r\n",
+       "      {\r\n",
+       "        \"$type\": \"Submission#3+Categorie, ℛ*4d1c3986-52f5-475e-a58b-d7f066f3d6fd#1-3\",\r\n",
+       "        \"Nom\": \"Audio\",\r\n",
+       "        \"Enfants\": {\r\n",
+       "          \"$type\": \"System.Collections.Generic.List`1[[MyIA.AI.ComponentModel.Entities.IChildEntity, MyIA.AI.Shared]], System.Private.CoreLib\",\r\n",
+       "          \"$values\": []\r\n",
+       "        }\r\n",
+       "      }\r\n",
+       "    ]\r\n",
+       "  }\r\n",
+       "}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Un catalogue sur deux niveaux : Rayon -> Categorie -> Categorie.\n",
+    "var multimedia = new Rayon { Nom = \"Multimédia\" };\n",
+    "var video = new Categorie { Nom = \"Vidéo\" };\n",
+    "var audio = new Categorie { Nom = \"Audio\" };\n",
+    "multimedia.Ajouter(video);\n",
+    "multimedia.Ajouter(audio);\n",
+    "video.Ajouter(new Categorie { Nom = \"Caméscopes\" });\n",
+    "\n",
+    "var json = MetadataJsonSerializer.Serialize(multimedia);\n",
+    "display(json);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "7ffd8ff6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:27:48.867807Z",
+     "iopub.status.busy": "2026-08-09T10:27:48.867807Z",
+     "iopub.status.idle": "2026-08-09T10:27:48.974089Z",
+     "shell.execute_reply": "2026-08-09T10:27:48.974089Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Type concret du 1er enfant reconstruit : Categorie"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Nom du 1er enfant : Vidéo"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Parent du 1er enfant re-linké vers la racine ? True"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Profondeur conservée (Caméscopes sous Vidéo) : Caméscopes"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Round-trip : on recharge le JSON et on vérifie l'intégrité du graphe.\n",
+    "var recharge = MetadataJsonSerializer.Deserialize<Rayon>(json);\n",
+    "var video = (Categorie)recharge.Enfants[0];\n",
+    "var camscopes = (Categorie)video.Enfants[0];\n",
+    "\n",
+    "display(\"Type concret du 1er enfant reconstruit : \" + video.GetType().Name);\n",
+    "display(\"Nom du 1er enfant : \" + video.Nom);\n",
+    "display(\"Parent du 1er enfant re-linké vers la racine ? \" + (video.Parent == recharge));\n",
+    "display(\"Profondeur conservée (Caméscopes sous Vidéo) : \" + camscopes.Nom);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32406371",
+   "metadata": {},
+   "source": [
+    "**Lecture.** Le `Parent` du premier enfant pointe bien vers `recharge` (la racine\n",
+    "rechargée), pas vers l'arbre original : le cycle a été cassé puis rebâti. Le type\n",
+    "concret (`Categorie`, pas `IChildEntity`) est restauré grâce au discriminateur `$type`.\n",
+    "La sérialisation hérite donc du modèle A1 — un graphe rechargé est redécouvrable par\n",
+    "le même `ReflectedProviderContainer`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f7917f3",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Round-trip d'un graphe plus profond\n",
+    "\n",
+    "**Objectif.** Construisez un `Rayon` contenant au moins trois niveaux de `Categorie`,\n",
+    "sérialisez-le, désérialisez-le, puis écrivez une vérification qui descend jusqu'à la\n",
+    "feuille la plus profonde et confirme que chaque nœud a son `Parent` correctement\n",
+    "re-linké.\n",
+    "\n",
+    "**Indice.** Une fonction récursive `ProfondeurMax(IChildEntity n)` peut mesurer la\n",
+    "profondeur ; vérifiez `enfant.Parent == parentAttendu` à chaque niveau."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8b3688b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:27:48.975108Z",
+     "iopub.status.busy": "2026-08-09T10:27:48.975108Z",
+     "iopub.status.idle": "2026-08-09T10:27:48.993825Z",
+     "shell.execute_reply": "2026-08-09T10:27:48.993825Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div><style>\r\n",
+       ".dni-code-hint {\r\n",
+       "    font-style: italic;\r\n",
+       "    overflow: hidden;\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview {\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview td {\r\n",
+       "    vertical-align: top;\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "details.dni-treeview {\r\n",
+       "    padding-left: 1em;\r\n",
+       "}\r\n",
+       "table td {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "table tr { \r\n",
+       "    vertical-align: top; \r\n",
+       "    margin: 0em 0px;\r\n",
+       "}\r\n",
+       "table tr td pre \r\n",
+       "{ \r\n",
+       "    vertical-align: top !important; \r\n",
+       "    margin: 0em 0px !important;\r\n",
+       "} \r\n",
+       "table th {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "</style>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : à compléter.\n",
+    "// TODO etudiant : construire un Rayon à 3+ niveaux, le sérialiser, le désérialiser.\n",
+    "// TODO etudiant : vérifier récursivement les back-references Parent.\n",
+    "return null;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "267d8f97",
+   "metadata": {},
+   "source": [
+    "## 3. Le prédicat universel Flee — la substance *low-code*\n",
+    "\n",
+    "Les deux premiers moments reposent sur de la réflexion .NET standard. Le troisième est\n",
+    "la raison d'être du pattern *metadata-driven* : **une règle métier écrite en chaîne de\n",
+    "caractères**, compilée à l'exécution par le moteur [Flee](https://github.com/arnonax/Flee),\n",
+    "et évaluée comme prédicat sur les entités découvertes en (1).\n",
+    "\n",
+    "Ce que Flee apporte qu'un `if` codé en dur n'apporte pas : la règle vient de la\n",
+    "**donnée** (fichier de config, CSV, saisie d'un utilisateur non-développeur), pas du\n",
+    "code. On la change **sans recompiler** — c'est tout l'enjeu du *low-code*. On compile\n",
+    "l'expression **une fois**, puis on l'évalue contre N entités : c'est un filtre dont la\n",
+    "définition est externe au programme."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b0c58145",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:27:48.995826Z",
+     "iopub.status.busy": "2026-08-09T10:27:48.995826Z",
+     "iopub.status.idle": "2026-08-09T10:27:49.201415Z",
+     "shell.execute_reply": "2026-08-09T10:27:49.201415Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Règle compilée : Montant > 1000 And Pays = \"FR\""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Commandes sélectionnées : C-1001 (1500 FR), C-1004 (1800 FR)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Un jeu de commandes de test, tel que pourrait le fournir une source externe.\n",
+    "var commandes = new List<Commande>\n",
+    "{\n",
+    "    new() { Reference = \"C-1001\", Montant = 1500m, Pays = \"FR\" },\n",
+    "    new() { Reference = \"C-1002\", Montant =  200m, Pays = \"FR\" },\n",
+    "    new() { Reference = \"C-1003\", Montant = 3000m, Pays = \"BE\" },\n",
+    "    new() { Reference = \"C-1004\", Montant = 1800m, Pays = \"FR\" },\n",
+    "    new() { Reference = \"C-1005\", Montant =  900m, Pays = \"ES\" },\n",
+    "};\n",
+    "\n",
+    "// La règle est une CHAÎNE. Elle pourrait venir d'un fichier, d'une DB, d'une UI.\n",
+    "// Grammaire Flee (VB-like) : And/Or/Not, = pour l'égalité, <> pour la différence — pas &&/==.\n",
+    "string regle = \"Montant > 1000 And Pays = \\\"FR\\\"\";\n",
+    "\n",
+    "var ctx = new ExpressionContext();\n",
+    "ctx.Variables[\"Montant\"] = 0m;   // type établi AVANT compilation (Flee résout les identifiants à la compilation)\n",
+    "ctx.Variables[\"Pays\"] = \"\";\n",
+    "var predicat = ctx.CompileDynamic(regle);   // compilé UNE fois\n",
+    "\n",
+    "// On évalue le même prédicat contre chaque commande.\n",
+    "var selectionnees = commandes.Where(c =>\n",
+    "{\n",
+    "    ctx.Variables[\"Montant\"] = c.Montant;\n",
+    "    ctx.Variables[\"Pays\"] = c.Pays;\n",
+    "    return (bool)predicat.Evaluate();\n",
+    "}).ToList();\n",
+    "\n",
+    "display(\"Règle compilée : \" + regle);\n",
+    "display(\"Commandes sélectionnées : \"\n",
+    "        + string.Join(\", \", selectionnees.Select(c => $\"{c.Reference} ({c.Montant} {c.Pays})\")));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "a9c73a99",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:27:49.203414Z",
+     "iopub.status.busy": "2026-08-09T10:27:49.202415Z",
+     "iopub.status.idle": "2026-08-09T10:27:49.260190Z",
+     "shell.execute_reply": "2026-08-09T10:27:49.260190Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Nouvelle règle (sans toucher au code métier) : Montant >= 500 And Montant <= 2000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Sélection : C-1001 (1500), C-1004 (1800), C-1005 (900)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Le point clé : changer la règle NE demande AUCUNE recompilation du programme.\n",
+    "// On remplace la chaîne, on recompile l'expression, le reste du pipeline est intact.\n",
+    "string nouvelleRegle = \"Montant >= 500 And Montant <= 2000\";\n",
+    "var ctx2 = new ExpressionContext();\n",
+    "ctx2.Variables[\"Montant\"] = 0m;\n",
+    "var predicat2 = ctx2.CompileDynamic(nouvelleRegle);\n",
+    "\n",
+    "var plageMontant = commandes.Where(c =>\n",
+    "{\n",
+    "    ctx2.Variables[\"Montant\"] = c.Montant;\n",
+    "    return (bool)predicat2.Evaluate();\n",
+    "}).Select(c => $\"{c.Reference} ({c.Montant})\").ToList();\n",
+    "\n",
+    "display(\"Nouvelle règle (sans toucher au code métier) : \" + nouvelleRegle);\n",
+    "display(\"Sélection : \" + string.Join(\", \", plageMontant));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "898f9998",
+   "metadata": {},
+   "source": [
+    "**Lecture.** La première règle (`Montant > 1000 And Pays = \"FR\"`) sélectionne les\n",
+    "commandes françaises de plus de 1000 ; la seconde (`Montant >= 500 And Montant <= 2000`)\n",
+    "ignore le pays et borne le montant. Aucune des deux n'existe dans le code source au\n",
+    "moment où le programme a été compilé : ce sont des **chaînes**, interprétées à\n",
+    "l'exécution. C'est le *prédicat universel* du patrimoine Aricie (#7265, pépite B4) : le\n",
+    "liant qui transforme une bibliothèque d'introspection en moteur de règles piloté par\n",
+    "la donnée.\n",
+    "\n",
+    "Dans une application réelle, ces chaînes vivraient dans un fichier de configuration ou\n",
+    "une base de règles éditée par un fonctionnel — le déploiement d'une nouvelle règle\n",
+    "métier devient une édition de texte, pas une release logicielle."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47cf059f",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Votre propre règle compilée\n",
+    "\n",
+    "**Objectif.** Écrivez une règle Flee qui sélectionne les commandes dont le montant est\n",
+    "strictement supérieur à la moyenne du jeu de données. Compilez-la, évaluez-la contre\n",
+    "les `commandes`, et affichez les références sélectionnées.\n",
+    "\n",
+    "**Indices.** (1) Calculez d'abord `var moyenne = commandes.Average(c => c.Montant);`.\n",
+    "(2) Injectez-la comme variable Flee : `ctx.Variables[\"Moyenne\"] = moyenne;`.\n",
+    "(3) La règle devient la chaîne `\"Montant > Moyenne\"`. Flee supporte les opérateurs de\n",
+    "comparaison, `&&`, `||`, et les appels à certains membres statiques importés."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "d5eaa774",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T10:27:49.261190Z",
+     "iopub.status.busy": "2026-08-09T10:27:49.261190Z",
+     "iopub.status.idle": "2026-08-09T10:27:49.281897Z",
+     "shell.execute_reply": "2026-08-09T10:27:49.280895Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div><style>\r\n",
+       ".dni-code-hint {\r\n",
+       "    font-style: italic;\r\n",
+       "    overflow: hidden;\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview {\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview td {\r\n",
+       "    vertical-align: top;\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "details.dni-treeview {\r\n",
+       "    padding-left: 1em;\r\n",
+       "}\r\n",
+       "table td {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "table tr { \r\n",
+       "    vertical-align: top; \r\n",
+       "    margin: 0em 0px;\r\n",
+       "}\r\n",
+       "table tr td pre \r\n",
+       "{ \r\n",
+       "    vertical-align: top !important; \r\n",
+       "    margin: 0em 0px !important;\r\n",
+       "} \r\n",
+       "table th {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "</style>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : à compléter.\n",
+    "// TODO etudiant : calculer la moyenne des montants, l'injecter comme variable Flee,\n",
+    "// TODO etudiant : compiler \"Montant > Moyenne\", évaluer, afficher les sélectionnées.\n",
+    "return null;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "011fa7f3",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Trois moments, une même idée : **la décoration porte la sémantique, le socle fait le\n",
+    "reste**. (1) Décorer un type suffit à le rendre discoverable. (2) La sérialisation\n",
+    "round-trip le graphe en préservant types concrets et hiérarchie. (3) Flee compile une\n",
+    "règle-métier-chaîne en un prédicat réutilisable, ouvrant le pattern *low-code* où la\n",
+    "règle vit dans la donnée, pas dans le code.\n",
+    "\n",
+    "Le socle `MyIA.AI.Shared` (EPIC #7265) est désormais visible pédagogiquement. La\n",
+    "prochaine tranche (A2+ XML, `DynamicSurrogate` pour constructeurs non défauts) étendra\n",
+    "le round-trip ; les modules de domaine (Trading : Converter E1, Backtester E2)\n",
+    "s'y brancheront en consommateurs."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2026:CoursIA — prev: MED/notebook-lean #10159

## Quoi

Première existence pédagogique du socle transverse `MyIA.AI.Shared` (EPIC #7265). Le socle compile, passe 48 tests — et `grep -rl "MyIA.AI.Shared" --include=*.ipynb` renvoyait 0. Ce notebook (`cross-series/socle-metadata-driven/`, kernel `.net-csharp`) démontre le pattern *metadata-driven* en trois moments, et **exerce Flee 2.0.0** (déclaré en `<PackageReference>`, utilisé 0 fois dans les `.cs` — le moteur « payé en dépendance, jamais exercé » qui donne sa substance Prong-B au notebook).

## Les trois moments

1. **Décoration → introspection (A1).** `[MainCategory]` / `[AttributeContainer]` + `ReflectedProviderContainer.FromAssembly<T>()` découvre les types décorés, sans inscription. Sortie vérifiée : `Catégories découvertes : Ventes, Catalogue` ; `Conteneurs [AttributeContainer] : Rayon` ; `Types dans [Catalogue] : Rayon, Categorie`.
2. **Sérialisation décoration-driven (A2).** `MetadataJsonSerializer` round-trippe un arbre `IChildEntity` (Rayon → Categorie → Categorie). Sortie vérifiée : `Type concret du 1er enfant reconstruit : Categorie` ; `Parent re-linké vers la racine ? True` ; `Profondeur conservée : Caméscopes` — le cycle `Parent` est cassé à la sérialisation puis rebâti au load.
3. **Prédicat universel Flee (la substance low-code).** Une règle métier en **chaîne**, compilée à l'exécution, évaluée contre les entités. Sortie vérifiée : règle `Montant > 1000 And Pays = "FR"` → sélectionne C-1001 (1500 FR), C-1004 (1800 FR) ; règle changée en `Montant >= 500 And Montant <= 2000` → C-1001, C-1004, C-1005 — **sans recompiler le code métier**. C'est le liant universel (#7265, pépite B4).

> **Grammaire Flee (découverte de cette exécution).** Le moteur utilise une grammaire VB-like : `And` / `Or` / `Not`, `=` pour l'égalité, `<>` pour la différence — **pas** `&&` / `==` du C#. Détail mis en évidence par la première exécution réelle du moteur.

## Preuve d'exécution (C.2, règle H.1)

Exécuté via nbclient + kernel `.net-csharp` (.NET Interactive 1.0.712001) sur worktree frais. 10/10 cellules code `execution_count != null`, **0 error output**. `probeAddresses` banner strippée via `strip_probe_banner.py --apply` (9 lignes ; seule normalisation autorisée, règle 6 Stop & Repair). Aucune fuite de chemin machine (scan `/mnt/`, `/home/`, `C:\dev`, `jsboi`, `c1331x` = 0 hit).

```
code cells=10 exec_count!=null=10 errors=0 exec-but-no-output=0
machine-path leaks: 0   probeAddresses résiduel: 0
```

## Acceptance #10161

- [x] Notebook sous `cross-series/socle-metadata-driven/`, kernel `.net-csharp`, référençant le socle via `#r` (assembly buildée, pas de copier-coller).
- [x] Les trois moments présents, le (3) **exécuté avec une règle Flee compilée** et sa sortie visible.
- [x] **≥ 3 exercices** stubés (cellules 7, 13, 19), répartis, chacun précédé d'un markdown contexte + objectif + indice. Stubs `return null;` / `// TODO etudiant` (pas de `throw`, règle C.1).
- [x] **C.2** : `execution_count != null` + `outputs` cohérents sur toutes les cellules code.
- [x] `strip_probe_banner.py --apply` passé après la ré-exécution.
- [x] `dotnet test MyIA.AI.Shared.Tests` vérifié **firsthand** : `Réussi! échec 0, réussite 48, total 48` (205ms, net9.0). Runtime net9.0 installé sur la machine (règle F : réparer, pas contourner) — le diff ne touche ni le socle ni les tests, donc les 48/48 sont préservés et confirmés.
- [x] Documentation en **français** (README + prose pédagogique) ; identifiants/API en anglais.

## Prérequis documenté

Le notebook référence l'assembly buildée (`#r "../../../MyIA.AI.Shared/bin/Debug/net9.0/MyIA.AI.Shared.dll"`). Il faut buildée le socle une fois (`dotnet build MyIA.AI.Shared/MyIA.AI.Shared.csproj`) — documenté dans le README du projet.

## Résiduel (hors scope, suivi séparé)

- La ligne d'index dans `cross-series/README.md` (table « Projets ») n'est pas ajoutée ici pour garder la PR atomique (1 sujet = le notebook). Suivi possible.
- L'Epic #7265 reste ouverte (tranches A2+ XML, `DynamicSurrogate`, modules domaine Trading) — `Closes #10161` seulement (cette issue = créer le notebook), pas l'Epic.

Closes #10161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
