### PR TITLE
feat(socle,#10161): add FleePredicateBuilder — B4 universal predicate (tests 56/56)

### DIFF
--- a/MyIA.AI.Shared.Tests/FleePredicateBuilderTests.cs
+++ b/MyIA.AI.Shared.Tests/FleePredicateBuilderTests.cs
@@ -1,0 +1,106 @@
+using MyIA.AI.ComponentModel.Rules;
+using Xunit;
+
+namespace MyIA.AI.Shared.Tests;
+
+// Exercises the FleePredicateBuilder (EPIC #7265, nugget B4 "le liant universel"): a string
+// rule compiled once into a reusable predicate over an entity type. These tests are the
+// substance Prong-B proof — the rule engine that #10161's notebook demonstrates live.
+
+/// <summary>Fixture entity with scalar properties bound as rule variables.</summary>
+internal sealed class Invoice
+{
+    public string Country { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public int Quantity { get; set; }
+    public bool Vip { get; set; }
+}
+
+public class FleePredicateBuilderTests
+{
+    private static readonly Invoice[] Sample =
+    {
+        new() { Country = "FR", Amount = 1500m, Quantity = 2, Vip = false },
+        new() { Country = "US", Amount = 2000m, Quantity = 1, Vip = false },
+        new() { Country = "FR", Amount = 500m, Quantity = 5, Vip = false },
+        new() { Country = "DE", Amount = 300m, Quantity = 1, Vip = true },
+    };
+
+    [Fact]
+    public void Create_compiles_a_numeric_comparison_predicate()
+    {
+        var predicate = FleePredicateBuilder.Create<Invoice>("Amount > 1000");
+
+        var matches = Sample.Where(predicate).ToArray();
+
+        Assert.Equal(2, matches.Length);
+        Assert.All(matches, i => Assert.True(i.Amount > 1000m));
+    }
+
+    [Fact]
+    public void Create_compiles_a_combined_and_rule_with_string_equality()
+    {
+        // Flee syntax: `and` (word) + `=` (single equals), not && / ==.
+        var predicate = FleePredicateBuilder.Create<Invoice>("Amount > 1000 and Country = \"FR\"");
+
+        var matches = Sample.Where(predicate).ToArray();
+
+        var single = Assert.Single(matches);
+        Assert.Equal("FR", single.Country);
+        Assert.Equal(1500m, single.Amount);
+    }
+
+    [Fact]
+    public void Create_compiles_an_or_rule_with_a_boolean_property()
+    {
+        var predicate = FleePredicateBuilder.Create<Invoice>("Vip or Amount > 1000");
+
+        var matches = Sample.Where(predicate).ToArray();
+
+        Assert.Equal(3, matches.Length); // FR/1500, US/2000, DE/300 (Vip)
+    }
+
+    [Fact]
+    public void Create_evaluates_many_entities_with_one_compiled_rule()
+    {
+        // The predicate is compiled once and evaluated per entity (variable mutation + eval).
+        var predicate = FleePredicateBuilder.Create<Invoice>("Quantity >= 3");
+
+        Assert.True(predicate(Sample[2]));   // FR/500/5
+        Assert.False(predicate(Sample[0]));  // FR/1500/2
+        Assert.False(predicate(Sample[3]));  // DE/300/1
+    }
+
+    [Fact]
+    public void Create_supports_arithmetic_in_the_rule()
+    {
+        var predicate = FleePredicateBuilder.Create<Invoice>("Amount / Quantity > 600");
+
+        var matches = Sample.Where(predicate).ToArray();
+
+        // FR/1500/2 = 750 > 600 (match); US/2000/1 = 2000 (match); FR/500/5 = 100 (no); DE/300/1 (no)
+        Assert.Equal(2, matches.Length);
+    }
+
+    [Fact]
+    public void Create_throws_on_a_null_or_empty_rule()
+    {
+        Assert.Throws<ArgumentNullException>(() => FleePredicateBuilder.Create<Invoice>(""));
+        Assert.Throws<ArgumentNullException>(() => FleePredicateBuilder.Create<Invoice>(null!));
+    }
+
+    [Fact]
+    public void Create_throws_on_a_syntactically_invalid_rule()
+    {
+        // == is not Flee syntax (equality is a single =).
+        var ex = Assert.ThrowsAny<Exception>(() => FleePredicateBuilder.Create<Invoice>("Amount == 1000"));
+        Assert.Contains("Compile", ex.GetType().Name);
+    }
+
+    [Fact]
+    public void Create_throws_on_a_rule_referencing_an_unknown_variable()
+    {
+        // "Total" is not a property of Invoice.
+        Assert.ThrowsAny<Exception>(() => FleePredicateBuilder.Create<Invoice>("Total > 1000"));
+    }
+}

--- a/MyIA.AI.Shared/ComponentModel/Rules/FleePredicateBuilder.cs
+++ b/MyIA.AI.Shared/ComponentModel/Rules/FleePredicateBuilder.cs
@@ -1,0 +1,93 @@
+using System.Reflection;
+using Flee.PublicTypes;
+
+namespace MyIA.AI.ComponentModel.Rules;
+
+/// <summary>
+/// Compiles a business rule written as a string (Flee expression syntax) into a reusable
+/// predicate over an entity type. This is the "universal predicate" of the socle
+/// (EPIC #7265, nugget B4 "le liant universel"): a non-developper writes a rule as text,
+/// the builder compiles it once, and it filters any collection of entities discovered by
+/// reflection (cf. <see cref="Providers.ReflectedProviderContainer"/>). The rule changes
+/// without recompiling the host — the low-code bridge between data and code.
+/// </summary>
+/// <remarks>
+/// <para><b>Expression syntax.</b> Flee uses a VB-like operator set: <c>and</c> / <c>or</c>
+/// / <c>not</c> (words, <b>not</b> <c>&amp;&amp;</c>/<c>||</c>) and <c>=</c> for equality
+/// (<b>not</b> <c>==</c>). Comparisons (<c>&gt;</c>, <c>&lt;</c>, <c>&gt;=</c>, <c>&lt;&gt;</c>)
+/// and arithmetic are as expected. Example: <c>"Montant &gt; 1000 and Pays = \"FR\""</c>.</para>
+/// <para><b>How it binds.</b> Public instance properties of <typeparamref name="T"/> become
+/// the rule's variables, by name. The expression is compiled once against the property
+/// types (a non-null sentinel of each type is set before compile so Flee can infer them),
+/// then evaluated per entity by reflecting its current property values. Compile cost is
+/// paid once; evaluation is a variable-mutation + native delegate call.</para>
+/// </remarks>
+public static class FleePredicateBuilder
+{
+    /// <summary>
+    /// Compiles <paramref name="rule"/> into a predicate over <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">Entity type whose public properties are the rule variables.</typeparam>
+    /// <param name="rule">Flee expression evaluating to a boolean, e.g.
+    /// <c>"Montant &gt; 1000 and Pays = \"FR\""</c>.</param>
+    /// <returns>A predicate that, given a <typeparamref name="T"/> instance, reflects its
+    /// properties into the compiled expression and returns the boolean verdict.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="rule"/> is null/empty.</exception>
+    /// <exception cref="Flee.PublicTypes.ExpressionCompileException">The rule is syntactically
+    /// invalid or references a property that does not exist on <typeparamref name="T"/>.</exception>
+    public static Func<T, bool> Create<T>(string rule)
+    {
+        if (string.IsNullOrWhiteSpace(rule))
+        {
+            throw new ArgumentNullException(nameof(rule));
+        }
+
+        // Reflect the public instance properties once: they become the rule's variables.
+        var props = typeof(T)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            // Indexers are not scalar variables — exclude them (Flee binds names to values).
+            .Where(p => p.GetIndexParameters().Length == 0)
+            .ToArray();
+
+        var context = new ExpressionContext();
+        context.Options.CaseSensitive = true;
+
+        // A non-null sentinel of each property type lets Flee infer variable types at
+        // compile time. Flee rejects null values, so string => "" and reference types
+        // without a parameterless ctor fall back to "" (they bind by name, not by value).
+        foreach (var prop in props)
+        {
+            context.Variables[prop.Name] = NonNullDefault(prop.PropertyType);
+        }
+
+        var compiled = context.CompileGeneric<bool>(rule);
+
+        return entity =>
+        {
+            foreach (var prop in props)
+            {
+                var value = prop.GetValue(entity);
+                context.Variables[prop.Name] = value ?? NonNullDefault(prop.PropertyType);
+            }
+
+            return compiled.Evaluate();
+        };
+    }
+
+    private static object NonNullDefault(Type type)
+    {
+        if (type == typeof(string))
+        {
+            return string.Empty;
+        }
+
+        if (type.IsValueType)
+        {
+            return Activator.CreateInstance(type)!;
+        }
+
+        // Reference type: prefer a parameterless ctor, else an empty string sentinel
+        // (the variable binds by name; the placeholder is replaced per-entity at eval time).
+        return Activator.CreateInstance(type) ?? (object)string.Empty;
+    }
+}


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2025:CoursIA-2 — prev: validation (no PR)

## Ce que fait cette PR

Ajoute **`FleePredicateBuilder`** au socle `MyIA.AI.Shared` — le **premier consommateur Flee** du socle (EPIC [#7265](https://github.com/jsboige/CoursIA/issues/7265), ancrage **B4 « le liant universel » »).

Une règle métier écrite en **chaîne de caractères** (syntaxe Flee) est compilée **une fois** en un `Func<T, bool>` réutilisable sur n'importe quel type d'entité découvert par réflexion : les propriétés publiques de `T` deviennent les variables de la règle. Le coût de compilation est payé une fois ; l'évaluation est une mutation de variable + appel de délégué natif.

C'est le pont **low-code** entre données et code : un non-développeur écrit une règle dans un fichier de config, le socle la compile au démarrage et l'applique — **aucune ligne de C# modifiée** pour changer la règle métier.

## Fichiers

| Fichier | Rôle |
|---------|------|
| `MyIA.AI.Shared/ComponentModel/Rules/FleePredicateBuilder.cs` | Le builder (compile-once, eval-many). Réfléchit les propriétés publiques de `T`, pose des sentinelles non-null avant compilation (Flee rejette `null`), évalue par mutation de variable. |
| `MyIA.AI.Shared.Tests/FleePredicateBuilderTests.cs` | 8 tests : comparaison numérique, `and` + égalité de chaîne, `or` + booléen, multi-entités, arithmétique dans la règle, rejets (règle vide/nulle, `==` invalide, variable inconnue). |

## Validation

- `dotnet test` = **56/56 vert** (48 préexistants + 8 nouveaux) — firsthand, net9.0.
- `dotnet build -c Release` = 0 warning, 0 erreur.
- Aucune régression : addition pure (199 lignes, 0 suppression).

## Note : règle F appliquée

L'exécution locale du notebook (qui référence la DLL `net9.0` du socle) révélait que le pin `dotnet-interactive` installé était `1.0.552801` (**hôte net8.0-only**, « ne plus viser » per `docs/reference/kernels-runtime.md`) — incapable de charger un assembly `net9.0` (hang au chargement). Upgradé vers le pin canonique **`1.0.617701`** (`dotnet tool update --global Microsoft.dotnet-interactive --version 1.0.617701` + `dotnet interactive jupyter install`). C'est la réparation, pas un contournement.

## Scope — pourquoi le notebook est deferred

Le notebook de démonstration live (3 moments A1/A2/B4, exécuté `.net-csharp`, 10/10 cellules, `execution_count` 1-10, bannière `probeAddresses` strippée) **n'est pas dans cette PR** : collision détectée avec **PR #10165** (notebook-only `Socle-MetadataDriven-Csharp.ipynb`, Flee inline, même issue #10161, ouverte aujourd'hui 10:19Z). Per le protocole collision : on livre le surplus non-collidant (le builder — substance B4 du socle), on deferre le notebook à l'adjudication d'ai-01. Le notebook + README sont conservés (worktree) en attendant.

See #10161, #7265, #3801
