### PR TITLE
docs(readme,#9847): document socle-metadata-driven notebook in cross-series README

### DIFF
--- a/MyIA.AI.Notebooks/cross-series/README.md
+++ b/MyIA.AI.Notebooks/cross-series/README.md
@@ -13,6 +13,7 @@ Ces projets servent donc d'**exemples-capstones** : chacun est autonome (son pro
 | Projet | Description | Séries mobilisées |
 |--------|-------------|-------------------|
 | [matching-cv/](matching-cv/) | Application web Flask qui compare trois algorithmes d'appariement CV ↔ fiche de poste : mots-clés (baseline), similarité sémantique par embeddings, et appariement stable de Gale-Shapley. | GameTheory, GenAI, ML |
+| [socle-metadata-driven/](socle-metadata-driven/) | Notebook .NET (C#) démontrant le socle transverse [`MyIA.AI.Shared`](../../MyIA.AI.Shared/) : découverte par décoration, sérialisation JSON/XML, et prédicat métier low-code (Flee). | socle partagé (.NET) |
 
 ## Focus — `matching-cv` : trois lectures d'un même problème
 
@@ -27,6 +28,18 @@ Le projet [`matching-cv/`](matching-cv/) prend un problème unique — apparier 
 La leçon transversale est que **le « meilleur » appariement dépend du critère** : le meilleur score individuel (algorithme 2) n'est pas le même que l'appariement globalement stable au sens de Gale-Shapley (algorithme 3), où aucune paire candidat/poste n'a intérêt à se ré-apparier. Comparer les deux sur les mêmes données rend visible la différence entre *optimisation locale* et *stabilité globale*.
 
 > **Note pédagogique.** `matching-cv` a été produit sous orchestration automatisée comme extension d'un atelier élémentaire ; sa trace d'orchestration n'a pas été conservée. Sa valeur tient à l'**illustration** de l'intégration cross-séries plus qu'à un déroulé pas-à-pas — voir son [README dédié](matching-cv/README.md) et son [introduction](matching-cv/docs/INTRODUCTION.md) pour le détail.
+
+## Focus — `socle-metadata-driven` : le socle partagé démontré
+
+À l'inverse de `matching-cv` qui **combine** plusieurs séries sur une même application, [`socle-metadata-driven/`](socle-metadata-driven/Socle-MetadataDriven-Csharp.ipynb) illustre ce qui est **partagé** par toutes les familles .NET du cursus : le socle transverse [`MyIA.AI.Shared`](../../MyIA.AI.Shared/) (EPIC #7265). Ce socle factorise trois besoins transverses — découverte, persistance, logique déclarative — qu'autrement chaque série ré-écrirait. Le notebook les met en scène sur un domaine factice (facturation / catalogue) en trois moments :
+
+| Moment | Principe démontré | API du socle |
+|--------|-------------------|--------------|
+| **Décoration → introspection** | Des attributs (`[MainCategory]`, `[AttributeContainer]`) rendent les types découvrables *sans aucun appel d'enregistrement* ; un conteneur de réflexion les groupe par catégorie et par rôle. | `ReflectedProviderContainer.FromAssembly<T>()` |
+| **Sérialisation round-trip** | Le même graphe d'entités (hiérarchie `IChildEntity` sur 3 niveaux) part et revient intact en JSON **et** en XML, référence parent re-liée. | `MetadataJsonSerializer`, `MetadataXmlSerializer` |
+| **Prédicat métier low-code (Flee)** | Une règle métier est une **chaîne** — venue d'un fichier, d'un CSV, d'un utilisateur non-développeur — compilée une fois puis appliquée à N instances. C'est la différence entre coder N branches `if` et piloter la logique métier par les données. | `ExpressionContext` + `CompileGeneric<bool>` (Flee 2.0.0) |
+
+La leçon transversale est qu'un **socle** fait basculer ce qui était ré-écrit dans chaque projet (comment découvre-t-on mes types ? comment persiste-t-on ma configuration ? où vit ma règle métier ?) vers une **convention partagée et testée une fois pour toutes**. Le notebook inclut trois exercices stub (enregistrement explicite, sérialisation personnalisée, règle à seuil variable) qui déclinent chacun des moments. Le socle expose par ailleurs un [`FleePredicateBuilder`](../../MyIA.AI.Shared/ComponentModel/Rules/FleePredicateBuilder.cs) (ancre B4) qui industrialise le troisième moment.
 
 ---
 


### PR DESCRIPTION
Grain: MED/readme — lane myia-po-2024:CoursIA — prev: MED/tooling #10168

See #9847 (cross-series README doc-sync) · See #10161 (socle-metadata-driven notebook epic).

## What changed

`socle-metadata-driven/` landed on `main` via #10165 (my prior grain) but the cross-series `README.md` "## Projets" table still listed only `matching-cv/`. Disk = 2 projects, prose = 1 — a §E structural drift **caused by my own merged delivery**, so post-merge doc-sync is my responsibility. This PR documents it.

| File | Change |
|---|---|
| `MyIA.AI.Notebooks/cross-series/README.md` | +13 — one table row + a "## Focus" section for `socle-metadata-driven` |

The new **Focus** section (mirroring the structure of the existing `matching-cv` Focus) frames `socle-metadata-driven` as the *complement* of `matching-cv`: where matching-cv **combines** series on one app, the socle notebook demonstrates what is **shared** across all .NET families — the transverse `MyIA.AI.Shared` socle (EPIC #7265). Three "moments": decoration→introspection (`ReflectedProviderContainer.FromAssembly<T>()`), JSON+XML round-trip (`MetadataJsonSerializer`/`MetadataXmlSerializer`), and low-code Flee predicate (`CompileGeneric<bool>`, ancre B4 `FleePredicateBuilder`).

## §E audit fichier-entier (honest)

Re-read the whole `cross-series/README.md` against disk (not just my insertion point):

- **Disk** (`ls cross-series/`): `README.en.md`, `README.md`, `i18n/`, `matching-cv/`, `socle-metadata-driven/` (5 entries).
- **Prose "## Projets" table** now lists the 2 cross-series **projects**: `matching-cv/`, `socle-metadata-driven/`. **Reconciled.**
- All linked paths resolve: `README.en.md` ✓, `MyIA.AI.Shared/` ✓, `FleePredicateBuilder.cs` ✓ (added by ai-01 #10167), `socle-metadata-driven/Socle-MetadataDriven-Csharp.ipynb` ✓.
- **`i18n/` is deliberately undocumented**: it is Epic #1650 translation **tooling/infrastructure**, not a cross-series *project*. It was already undocumented before this PR and is out of scope for documenting my merged #10165. Surfaced here for transparency, not touched.
- Catalog byte-identique to main: 0 catalog files touched (diff = 1 file, README only).

## Validation

- **0 close-keyword**: body + commit use `See #N` only (partial doc contribution to #9847 epic + #10161; neither is fully resolved by a README edit).
- **FR-first**: new prose is French (per [readme-french-first.md](.claude/rules/readme-french-first.md) HARD 1); original English preserved untouched in `README.en.md`.
- **No catalog churn**: `git diff --name-only | grep CATALOG` = empty.
- **Focus structure mirrors the existing `matching-cv` Focus**: same "leçon transversale" closing-paragraph pattern, consistent pedagogical voice across both capstones.

## Variation note

prev = MED/tooling #10168. This grain = MED/readme — **different GENRE** (docs/readme vs tooling), so G-VAR-3 (no 2 same-genre-LIGHT consecutive) is satisfied a fortiori. Both MED: substance with a verifiable change (this one closes a real disque↔prose drift I caused), not scanner-generatable.
