### PR TITLE
fix(scan-md,#10097): exclude P(X|Y) math conditional pipes from table block grouping

### DIFF
--- a/scripts/notebook_tools/scan_md_table_syntax.py
+++ b/scripts/notebook_tools/scan_md_table_syntax.py
@@ -102,6 +102,32 @@ CODE_SPAN_RE = re.compile(r'(`+)[^`]*\1')
 MATH_SPAN_RE = re.compile(r'\$[^$\n]*\$')
 ESCAPED_PIPE_RE = re.compile(r'\\\|')
 
+# Conditional-probability / function-call notation: ``P(x|y)``, ``O(|A|*|S|)``,
+# ``Cov(a|b)`` -- a ``|`` inside such a ``Letter(...)`` span is a math conditional
+# bar, NOT a table column delimiter. Excluding these lines from block grouping
+# prevents two consecutive ``P(X|Y)`` prose lines (e.g. an exercise enumerating
+# conditional probabilities) from being mistaken for a 2-row table block, which
+# was the dominant false-positive source on the Probas family (~71% of the
+# NO_BLANK findings were ``P(X|Y)`` math pipes). See #10097.
+COND_NOTATION_RE = re.compile(r'[A-Za-z]\([^)]*\|[^)]*\)')
+
+
+def _has_delimiter_pipe(line):
+    """True if ``line`` has a pipe that could be a GFM table column delimiter.
+
+    A pipe that survives removal of inline code, inline math, escaped pipes, and
+    ``Letter(...|...)`` conditional notation is a candidate delimiter; a line
+    whose only pipes live inside those spans is math/prose, not a table row.
+    Mirrors the protection already applied by ``_column_count`` (which handles
+    code/math/escaped) and extends it to bare ``P(X|Y)`` plain-text conditional
+    notation that ``$...$`` stripping does not reach.
+    """
+    t = CODE_SPAN_RE.sub('', line)
+    t = MATH_SPAN_RE.sub('', t)
+    t = ESCAPED_PIPE_RE.sub('', t)
+    t = COND_NOTATION_RE.sub('', t)
+    return '|' in t
+
 
 # ---------------------------------------------------------------------------
 # Core: find table blocks in a list of (1-indexed) source lines
@@ -135,8 +161,8 @@ def _find_table_blocks(lines):
             fence_marker = m.group(1)[0]
             i += 1
             continue
-        # Not in a fence: is this a pipe-line?
-        if not stripped or not PIPE_LINE_RE.search(line):
+        # Not in a fence: is this a pipe-line? (math/conditional pipes excluded)
+        if not stripped or not _has_delimiter_pipe(line):
             i += 1
             continue
         # Start of a potential pipe-line run
@@ -145,7 +171,7 @@ def _find_table_blocks(lines):
         while i < n:
             l = lines[i]
             ls = l.strip()
-            if not ls or not PIPE_LINE_RE.search(l):
+            if not ls or not _has_delimiter_pipe(l):
                 break
             # stop if a fence opens mid-run
             if FENCE_OPEN_RE.match(l):

--- a/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
+++ b/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
@@ -25,6 +25,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from scan_md_table_syntax import (  # noqa: E402
     _column_count,
     _find_table_blocks,
+    _has_delimiter_pipe,
     detect_md_table_syntax,
     main,
     scan_markdown,
@@ -66,6 +67,65 @@ class TestColumnCount:
 
     def test_multiple_backtick_spans(self):
         assert _column_count("| a | `b|c` | `d|e` |") == 3
+
+
+# ---------------------------------------------------------------------------
+# _has_delimiter_pipe / math-pipe exclusion -- the P(X|Y) false-positive guard
+# ---------------------------------------------------------------------------
+
+class TestHasDelimiterPipe:
+    def test_real_table_row_has_delimiter_pipe(self):
+        assert _has_delimiter_pipe("| a | b |") is True
+        assert _has_delimiter_pipe("a | b | c") is True
+
+    def test_conditional_probability_pipe_excluded(self):
+        # ``P(X|Y)`` plain-text conditional notation: the pipe is a math bar,
+        # not a delimiter. The dominant Probas false-positive source (#10097).
+        assert _has_delimiter_pipe("- P(Cloudy | Rain=True) = **0.800**") is False
+        assert _has_delimiter_pipe("calculez P(Sprinkler | Rain=True)") is False
+
+    def test_big_o_set_notation_excluded(self):
+        # ``O(|A| x |S|)`` complexity notation -- pipes are abs/norm bars.
+        assert _has_delimiter_pipe("complexite O(|A| x |S|)") is False
+
+    def test_inline_math_pipe_excluded(self):
+        assert _has_delimiter_pipe("- $P(z_t | z_{t-1})$ transition") is False
+
+    def test_table_row_with_conditional_in_cell_still_detected(self):
+        # A real table cell may legitimately contain P(A|B); the OUTER cell
+        # delimiters remain, so it is still a table row.
+        assert _has_delimiter_pipe("| Var | P(A|B) | note |") is True
+
+    def test_english_aside_still_has_delimiter_pipe(self):
+        # "a | b" flowing prose is unchanged (still a candidate; the >=2-row
+        # block rule handles it, not this guard).
+        assert _has_delimiter_pipe("text a | text b") is True
+
+
+class TestMathPipeBlockExclusion:
+    def test_consecutive_conditional_probs_not_a_table(self):
+        # Two consecutive ``P(X|Y)`` exercise lines must NOT be mistaken for a
+        # 2-row table block (was the #10097 Probas NO_BLANK false positive).
+        lines = [
+            "**Resultats** :",
+            "- P(Cloudy | Rain=True) = **0.800** -- observationnel",
+            "- P(Cloudy | do(Rain=True)) = **0.500** -- interventionnel",
+        ]
+        assert detect_md_table_syntax(lines) == []
+
+    def test_conditional_probs_above_real_table_not_flagged(self):
+        # A ``P(X|Y)`` line directly before a real table must not be treated as
+        # the table's first row (no NO_BLANK_BEFORE on the real table's account,
+        # and no spurious block merging).
+        lines = [
+            "",
+            "| Algorithme | Usage |",
+            "|---|---|",
+            "| naive | P(C|X) bayesien |",
+        ]
+        f = detect_md_table_syntax(lines)
+        # The table is clean (blank before, has sep); no finding expected.
+        assert [x for x in f if x["pathology"] == "NO_BLANK_BEFORE"] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: MED/docs (#10170)

## Ce que fait cette PR

Améliore le détecteur `scan_md_table_syntax` (#10100) pour ne plus confondre la notation mathématique conditionnelle `P(X|Y)` (et `O(|A|x|S|)`, `$...|...$`) avec la syntaxe table GFM. Élimine la source dominante de faux positifs constatée firsthand sur Probas lors du burn-down #10170.

## Le défaut (constaté firsthand)

Le détecteur groupait toute ligne contenant un `|` en candidat table-row. Deux lignes `P(X|Y)` consécutives (exercices énumérant des probas conditionnelles, résumés de résultats) formaient un bloc 2-lignes spurieux -> faux NO_BLANK/NO_SEP. Sur Probas : **22/31 findings NO_BLANK étaient des FP math-pipe (71%)**.

## Le fix

`_has_delimiter_pipe(line)` : une ligne n'est candidate table-row que si elle a un `|` qui SURVIT à la suppression des spans inline-code, inline-math, `\|` escaped, et `Letter(...|...)` (P/O/Cov...). Le block-grouper `_find_table_blocks` utilise cette fonction (2 callsites) au lieu du `PIPE_LINE_RE.search` brut.

Une vraie cellule de table contenant `P(A|B)` reste détectée (les délimiteurs externes de cellule survivent).

## Impact mesuré (Probas, firsthand)

| Pathologie | Avant | Après | Delta |
|---|---|---|---|
| NO_BLANK_BEFORE | 24 | 9 | -15 (FPs math) |
| NO_BLANK_AFTER | 7 | 0 | -7 (FPs math) |
| NO_SEP | 4 | 1 | -3 (FPs math) |
| COL_MISMATCH | 17 | 17 | 0 (gap connu) |
| **Total** | **52** | **27** | **-25 FPs** |

Le résiduel NO_BLANK_BEFORE = 9 = **exactement les 9 vraies tables** (le set du burn-down #10170). Le burn-down NO_BLANK est désormais safe à automatiser : le détecteur ne signale plus QUE de vraies tables.

## Tests

- **33 tests existants PASS** (0 régression) : `_column_count`, les 4 pathologies, fence-aware grouping, walkers notebook/markdown, CLI (`--json`, `--check`, exit codes).
- **8 nouveaux tests** : `TestHasDelimiterPipe` (6 cas : vraie table, `P(X|Y)`, `O(|A|x|S|)`, `$...$`, table-avec-P(A|B)-en-cellule, aside anglais) + `TestMathPipeBlockExclusion` (2 cas : 2 lignes `P(X|Y)` consécutives ne forment pas un bloc ; `P(X|Y)` avant une vraie table ne déclenche pas de NO_BLANK spurious).

## Gap résiduel (hors scope, documenté)

17 COL_MISMATCH `|A|` standalone set-notation (DecisionTheory) restent : pathologie différente (drift de colonnes dans une vraie table), et le filtre `Letter(...|...)` ne capture pas le `|A|` non-wrappé. Futur grain.

## Complémentarité avec #10170

#10170 (same cycle) a livré les 9 vraies tables Probas via triage FP manuel. Cette PR-ci rend ce triage obsolète en amont (le détecteur ne produit plus les FPs). Les deux PR sont indépendantes (fichiers disjoints : notebooks Probas vs script detector + tests).

See #10097 #10100 #3966
