### PR TITLE
fix(machine-dep,#10169): per-notebook propagation + protocol constants + detached tilde + git-root

### DIFF
--- a/scripts/notebook_tools/check_machine_dep_timing.py
+++ b/scripts/notebook_tools/check_machine_dep_timing.py
@@ -120,6 +120,22 @@ DISTRIBUTION_KEYWORDS = re.compile(
     re.IGNORECASE,
 )
 
+# Constante de protocole / consensus : le chiffre est un parametre du domaine
+# modelise (blockchain, reseau), pas une duree machine. Il ne derive pas d'une
+# machine a l'autre, il ne derive pas du tout -- c'est une constante du protocole
+# (settle_delay d'un canal de paiement XRP, temps de bloc Ethereum). Meme famille
+# conceptuelle que domain_quantity, dans un domaine que les mots-clés statistiques
+# ne couvrent pas. Cf #10169 residu 2.
+PROTOCOL_KEYWORDS = re.compile(
+    r"\b(?:settle_?delay|settlement|settle\b|"
+    r"blocs?\s+(?:d['’]\s*)?(?:Ethereum|Bitcoin|eth|btc)|block\s*time|"
+    r"temps\s+de\s+bloc|"
+    r"consensus|finalit[ée]|finality|"
+    r"d[ée]lai\s+de\s+(?:settlement|consensus|finalit)|"
+    r"confir(?:mation|mer).*\bblocs?)\b",
+    re.IGNORECASE,
+)
+
 # Pacing pedagogique : la cellule H1/H2/H3 documente l'effort demande a
 # l'etudiant. Ligne entiere exoneree (cf. arbitrage jsboige 14:05:37Z #9434).
 # Le motif "**Notebook** : ... 30-60 min selon niveau" est aussi couvert --
@@ -208,6 +224,10 @@ def _categorize(line: str, snippet: str) -> str:
     """
     if DISTRIBUTION_KEYWORDS.search(line):
         return CATEGORY_DISTRIBUTION
+    # Constante de protocole/consensus (settle_delay, temps de bloc) : la duree
+    # est un parametre du domaine modelise, pas une mesure machine. Cf #10169.
+    if PROTOCOL_KEYWORDS.search(line):
+        return CATEGORY_DOMAIN_QUANTITY
     if WALLCLOCK_KEYWORDS.search(line):
         return CATEGORY_WALLCLOCK
     # Pas de mot-cle de contexte : on considere que la presence de la regex
@@ -267,6 +287,13 @@ def _scan_notebook(nb_path: Path) -> list[dict]:
                 # mandat #9434. On ne signale pas (cf. acceptance #10158).
                 if snippet.startswith("~"):
                     continue
+                # Tilde detache : `~ 2 min` (espace entre `~` et le nombre) est
+                # aussi un marqueur d'ordre de grandeur conforme. Le tilde n'est
+                # pas colle au nombre, donc MACHINE_RE ne le capture pas dans le
+                # snippet -- on verifie son presence juste avant le match.
+                # Cf #10169 residu 2.
+                if re.search(r"~\s*$", line[: m.start()]):
+                    continue
                 # CHANGES_REQUESTED #10162 : fourchette/borne = soft signal
                 # (`N-M min`, `< N sec`, `N+ min`). On ne signale pas, comme
                 # pour le tilde.
@@ -281,28 +308,54 @@ def _scan_notebook(nb_path: Path) -> list[dict]:
                     "category": category,
                 })
 
-    # Passe 2 : propagation per-cell domain_quantity. Si une cellule porte
-    # >=1 finding distribution_param, tous les findings wallclock de cette
-    # cellule basculent en domain_quantity (FP-2 #10162).
-    by_cell: dict[int, list[dict]] = {}
-    for f in findings:
-        by_cell.setdefault(f["cell_index"], []).append(f)
-    for ci, cell_findings in by_cell.items():
-        has_distribution = any(
-            f["category"] == CATEGORY_DISTRIBUTION for f in cell_findings
-        )
-        if not has_distribution:
-            continue
-        for f in cell_findings:
+    # Passe 2 : propagation per-NOTEBOOK domain_quantity (#10169 residu 1).
+    # La propagation per-cell (#10162 FP-2) etait trop etroite : sur Infer-2
+    # (Gaussian Mixture), 6 findings restaient en wallclock bien que l'unite
+    # de temps (le temps de trajet) soit le sujet meme du notebook -- leurs
+    # cellules ne portaient pas de mot-cle statistique, mais d'autres cellules
+    # du meme notebook oui. Logique correcte a la bonne granularite : si le
+    # notebook porte >=1 finding distribution_param, l'unite de temps est le
+    # sujet du modele, et TOUS ses findings wallclock basculent en
+    # domain_quantity. Le controle positif (Sudoku-13, 0 distribution_param)
+    # est preserve -- aucune propagation ne s'y applique.
+    has_distribution = any(
+        f["category"] == CATEGORY_DISTRIBUTION for f in findings
+    )
+    if has_distribution:
+        for f in findings:
             if f["category"] == CATEGORY_WALLCLOCK:
                 f["category"] = CATEGORY_DOMAIN_QUANTITY
 
     return findings
 
 
+def _repo_root() -> Path:
+    """Resout la racine du depot.
+
+    Priorite : ``git rev-parse --show-toplevel`` (robuste et cwd-independant),
+    fallback sur ``parents[2]`` du script (``<root>/scripts/notebook_tools/``).
+    Cf #10169 residu 3 : la resolution precedente (``parents[2]`` seul)
+    supposait une profondeur fixe et echouait silencieusement (0 cibles) si
+    l'arborescence diferait. La racine git est l'ancre canonique.
+    """
+    try:
+        import subprocess
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).resolve().parent),
+            timeout=5,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            return Path(out.stdout.strip()).resolve()
+    except Exception:
+        pass
+    return Path(__file__).resolve().parents[2]
+
+
 def _collect_targets(args: argparse.Namespace) -> list[Path]:
     """Resout la liste des notebooks a scanner depuis la CLI."""
-    root = Path(__file__).resolve().parents[2]
+    root = _repo_root()
     if args.all or args.json or args.check:
         # Cible canonique : notebooks pedagogiques. Les READMEs et `assets/`
         # sont exclus -- le scope de #10158 est uniquement les ``.ipynb``.
@@ -371,6 +424,19 @@ def main(argv: list[str] | None = None) -> int:
 
     targets = _collect_targets(args)
     if not targets:
+        # Vacuous-zero guard (#10169 residu 3) : un ``--all`` qui ne trouve
+        # AUCUN notebook est presque toujours une resolution de racine cassee
+        # (cwd errone, _repo_root() qui echoue), pas un depôt vide. On echoue
+        # explicitement (exit 2) plutot que d'emettre un faux "0 findings" qui
+        # apprend a la lane suivante qu'il n'y a rien a faire. Mirror
+        # scan_md_table_syntax.py / scan_md_hierarchy.py (#3968).
+        if args.all or args.json or args.check:
+            print(
+                "Aucun notebook a scanner pour --all : la resolution de la "
+                "racine du depot a echoue (verifier _repo_root / git toplevel).",
+                file=sys.stderr,
+            )
+            return 2
         print("Aucun notebook a scanner.", file=sys.stderr)
         return 0
 

--- a/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
+++ b/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
@@ -24,6 +24,7 @@ from check_machine_dep_timing import (  # noqa: E402
     _categorize,
     _scan_notebook,
     _is_range_bound,
+    _repo_root,
     CATEGORY_WALLCLOCK,
     CATEGORY_DISTRIBUTION,
     CATEGORY_AMBIGUOUS,
@@ -31,6 +32,7 @@ from check_machine_dep_timing import (  # noqa: E402
     STUDENT_PACING_RE,
     WALLCLOCK_KEYWORDS,
     DISTRIBUTION_KEYWORDS,
+    PROTOCOL_KEYWORDS,
 )
 
 import pytest
@@ -536,8 +538,152 @@ def test_pii_governed_notebook_skipped(tmp_path: Path) -> None:
 
 
 # --------------------------------------------------------------------------- #
-#  Main entry point : smoke test que l'argparse tient
+#  Extensions #10169 (c.1301+40) : propagation per-notebook + constante de
+#  protocole + tilde detache + resolution git-root
 # --------------------------------------------------------------------------- #
+def test_per_notebook_propagation_flips_cross_cell() -> None:
+    """#10169 residu 1 : la propagation domain_quantity est per-NOTEBOOK.
+
+    Rationnel : la propagation per-cell (#10162 FP-2) etait trop etroite.
+    Sur Infer-2-Gaussian-Mixtures, 6 findings restaient en wallclock bien que
+    l'unite de temps (temps de trajet) soit le sujet du notebook -- leurs
+    cellules ne portaient pas de mot-cle statistique, mais d'autres cellules
+    du meme notebook oui. La propagation per-notebook : si le notebook porte
+    >=1 distribution_param, TOUS ses wallclock basculent en domain_quantity.
+
+    Ce test met la distribution_param dans la cellule A et un wallclock pur
+    (aucun mot-cle) dans la cellule B -- un cas que la propagation per-cell
+    ne couvrait PAS (cellules differentes).
+    """
+    nb = _make_nb([
+        _md_cell("Le modele est une Gaussian de moyenne 15.33 min (sigma 1.32 min)."),
+        _md_cell(
+            "| Classe | Moyenne ajustee |\n"
+            "| --- | --- |\n"
+            "| Ordinaire | 15.07 min | Trajets normaux |\n"
+            "| Extraordinaire | 26.69 min | Trajets longs |"
+        ),
+    ])
+    try:
+        findings = _scan_notebook(nb)
+        # La cellule B (tableau, aucun mot-cle distribution) contient les
+        # '15.07 min' et '26.69 min' qui sont les MOYENNES AJUSTEES du
+        # melange -- le resultat du modele. Apres propagation per-notebook,
+        # ils basculent en domain_quantity, pas wallclock.
+        wallclock = [f for f in findings if f["category"] == CATEGORY_WALLCLOCK]
+        domain = [f for f in findings if f["category"] == CATEGORY_DOMAIN_QUANTITY]
+        assert wallclock == [], (
+            f"Aucun wallclock attendu (propagation per-notebook), trouve {wallclock}"
+        )
+        assert len(domain) >= 2, (
+            f"Attendu >=2 domain_quantity (15.07/26.69 min), categories="
+            f"{[f['category'] for f in findings]}"
+        )
+    finally:
+        nb.unlink()
+
+
+def test_protocol_constant_classified_as_domain_quantity() -> None:
+    """#10169 residu 2 : une constante de protocole n'est PAS un wallclock.
+
+    Rationnel : un `settle_delay` de canal de paiement XRP (3600 secondes) ou
+    un temps de bloc Ethereum (~2 min) sont des PARAMETRES DU DOMAINE modelise
+    (consensus blockchain), pas des durees machine. Ils ne derivent pas d'une
+    machine a l'autre -- ce sont des constantes du protocole. Meme famille que
+    domain_quantity, dans un domaine que les mots-cles statistiques ne couvrent
+    pas.
+    """
+    nb = _make_nb([
+        _md_cell(
+            "Le `settle_delay` est crucial pour la securite. Pour fermer le "
+            "canal, il faut attendre 3600 secondes (le delai de consensus)."
+        ),
+    ])
+    try:
+        findings = _scan_notebook(nb)
+        wallclock = [f for f in findings if f["category"] == CATEGORY_WALLCLOCK]
+        assert wallclock == [], (
+            f"'settle_delay 3600 secondes' ne doit PAS etre wallclock, trouve {wallclock}"
+        )
+    finally:
+        nb.unlink()
+
+
+def test_protocol_keyword_detects_blockchain_domain() -> None:
+    """PROTOCOL_KEYWORDS detecte settle_delay, blocs Ethereum, consensus."""
+    assert PROTOCOL_KEYWORDS.search("Le `settle_delay` du canal XRP")
+    assert PROTOCOL_KEYWORDS.search("12 blocs Ethereum ~ 2 min")
+    assert PROTOCOL_KEYWORDS.search("temps de bloc Bitcoin = 10 min")
+    assert PROTOCOL_KEYWORDS.search("finalite du consensus")
+    # Negatif : un 'block' hors-contexte blockchain n'est pas un protocole.
+    assert not PROTOCOL_KEYWORDS.search("un block de code de 50 lignes")
+
+
+def test_silence_on_detached_tilde() -> None:
+    """#10169 residu 2 : '~ 2 min' (tilde detache, espace) est conforme.
+
+    Rationnel : '~ 2 min' (avec un espace entre le tilde et le nombre) est un
+    ordre de grandeur, tout comme '~2 min' (attache). MACHINE_RE ne capture pas
+    le tilde dans le snippet (il est trop loin du chiffre), donc le check
+    `snippet.startswith('~')` le manquait. On verifie maintenant le tilde dans
+    le prefixe juste avant le match.
+
+    Extrait reel : SC-23-Cross-Chain cell[24] 'Confirmation source (12 blocs
+    Ethereum ~ 2 min)'.
+    """
+    nb = _make_nb([
+        _md_cell("Confirmation source (12 blocs Ethereum ~ 2 min)."),
+        _md_cell("Le scan prend ~ 30 sec habituellement."),
+    ])
+    try:
+        findings = _scan_notebook(nb)
+        assert findings == [], (
+            f"'~ 2 min' et '~ 30 sec' sont des ordres de grandeur conformes, "
+            f"trouve {findings}"
+        )
+    finally:
+        nb.unlink()
+
+
+def test_repo_root_resolves_git_toplevel() -> None:
+    """#10169 residu 3 : _repo_root() resout la racine via git (cwd-independant).
+
+    Rationnel : la resolution precedente (parents[2]) supposait une profondeur
+    fixe. _repo_root() utilise git rev-parse --show-toplevel (ancre canonique),
+    fallback parents[2]. Dans l'env de test (dans le repo), le resultat doit
+    contenir MyIA.AI.Notebooks (la racine du depot).
+    """
+    repo = _repo_root()
+    # Dans l'env de test on est dans le repo CoursIA.
+    if not (Path(__file__).resolve().parents[3] / "MyIA.AI.Notebooks").exists():
+        pytest.skip("Hors env repo (MyIA.AI.Notebooks absent)")
+    assert (repo / "MyIA.AI.Notebooks").exists(), (
+        f"_repo_root()={repo} ne contient pas MyIA.AI.Notebooks/"
+    )
+
+
+def test_all_vacuous_zero_guard_returns_two(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#10169 residu 3 : --all qui trouve 0 notebooks = exit 2 (pas faux 0).
+
+    Rationnel : un --all qui renvoie silencieusement '0 findings' apprend a la
+    lane suivante qu'il n'y a rien a faire -- alors que c'est presque toujours
+    une resolution de racine cassee. On echoue explicitement (exit 2), mirror
+    scan_md_table_syntax.py / scan_md_hierarchy.py (#3968).
+    """
+    from check_machine_dep_timing import main, _collect_targets
+    import argparse
+
+    # Simuler une racine cassee : _collect_targets ne trouve rien.
+    def _bogus_targets(args):
+        return []
+    monkeypatch.setattr(
+        "check_machine_dep_timing._collect_targets", _bogus_targets
+    )
+    rc = main(["--all"])
+    assert rc == 2, f"--all avec 0 cibles doit retourner 2, pas {rc}"
+
+
+
 def test_main_runs_with_help(capsys: pytest.CaptureFixture) -> None:
     """Le main peut etre appele avec --help sans crash."""
     from check_machine_dep_timing import main


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: MED/tooling #10172

## Ce que fait cette PR

Raffine le détecteur `check_machine_dep_timing` (#10162 merged) sur les **3 classes de FP résiduelles** mesurées firsthand par ai-01 dans #10169. Aucune modification de notebook (l'organe se raffine, le drain vient après — acceptance respectée).

## Résidu 1 — propagation per-notebook (FP-2 non fermé)

La propagation per-cell (#10162) était trop étroite : sur Infer-2-Gaussian-Mixtures, 6 findings restaient en `wallclock` bien que l'unité de temps (le temps de trajet) soit le **sujet même du notebook** — leurs cellules ne portaient pas de mot-clé statistique, mais d'autres cellules du même notebook oui (17 `distribution_param`).

**Fix** : la propagation devient **per-notebook**. Si le notebook porte ≥1 `distribution_param`, l'unité de temps est le sujet du modèle, et TOUS ses `wallclock` basculent en `domain_quantity`. C'est la logique per-cell appliquée à la bonne granularité.

**Vérifié firsthand** : Infer-2 wallclock **6 → 0** (les 6 en cell[27,33,48,57,62×2] basculent en domain_quantity). **Contrôle positif Sudoku-13 préservé** : 0 `distribution_param` → aucune propagation ne s'y applique → cell[43] (10 timings Z3/C# : 1,1 ms, 0,1 ms, 2,4 ms, 16,3 ms, 1,7 ms, 43,8 ms, 106 ms, 311 ms, 3,2 ms, 10 s) reste intégralement détecté.

## Résidu 2 — constante de protocole + tilde détaché

Deux sous-classes :

**(a) Nouvelle classe `PROTOCOL_KEYWORDS`** : un `settle_delay` de canal XRP (3600 secondes) ou un temps de bloc Ethereum (~2 min) sont des **paramètres du domaine modélisé** (consensus blockchain), pas des durées machine — ils ne dérivent pas d'une machine à l'autre. Même famille conceptuelle que `domain_quantity`, dans un domaine que les mots-clés statistiques ne couvrent pas. → classé `domain_quantity`, pas `wallclock`.

**(b) Tilde détaché** : `~ 2 min` (espace entre `~` et le nombre) est un ordre de grandeur conforme (#9434), mais `MACHINE_RE` ne capturait pas le `~` dans le snippet (trop loin du chiffre) → le check `snippet.startswith("~")` le manquait. Ajout d'un check sur le préfixe `~\s*$` juste avant le match.

**Vérifié firsthand** : SC-19 cell[30] `3600 secondes` (settle_delay) → 0 wallclock ; SC-23 cell[24] `~ 2 min` (blocs Ethereum) → 0 wallclock.

## Résidu 3 — résolution git-root + garde vacuous-zero

`_collect_targets` résolvait la racine via `parents[2]` du script (supposait une profondeur fixe). `_repo_root()` utilise maintenant `git rev-parse --show-toplevel` (ancre canonique, cwd-indépendant), fallback `parents[2]`. Un `--all` qui trouverait 0 notebooks échoue désormais explicitement (**exit 2**, pas un faux « 0 findings » qui apprendrait à la lane suivante qu'il n'y a rien à faire) — mirror `scan_md_table_syntax.py` / `scan_md_hierarchy.py` (#3968).

## Inventaire re-mesuré (acceptance : re-posté sur #9434)

| Catégorie | Avant (#10162) | Après (#10169) | Delta |
|---|---|---|---|
| wallclock | 256 | **238** | −18 |
| distribution_param | 40 | 38 | −2 |
| domain_quantity | 35 | **49** | +14 |
| ambiguous | 0 | 0 | 0 |
| **total** | **331** | **325** | **−6** |

Le `wallclock` (cible de drainage #9434) baisse de 18. `ambiguous=0` reste structurel (défaut conservateur = wallclock, déjà documenté dans la docstring lignes 60-64 — acceptance « documenter et retirer » satisfaite : la catégorie reste dans la taxonomie pour compat mais le défaut conservateur est explicite).

## Sudoku-13 contrôle positif — note sur le 29→28

Le contrôle positif passe de 29 à 28 wallclock. **Ce n'est PAS une régression** : le finding perdu est `~ 1 s` en cell[39] (`RESOLU (~ 1 s)`), correctement exempté par le fix tilde détaché — c'était un FP du contrôle positif lui-même (un estimateur d'ordre de grandeur, conforme #9434). Les **vrais** timings Z3 de cell[43] (le contrôle nommé dans l'acceptance) restent intégralement détectés.

## Tests

- **27 tests existants PASS** (0 régression) : 5 familles FP, pacing, range-bound, propagation per-cell (toujours couverte par per-notebook), contrôle positif, heuristiques contexte, PII, CLI.
- **6 nouveaux tests** : `test_per_notebook_propagation_flips_cross_cell` (distribution cellule A flippe wallclock cellule B), `test_protocol_constant_classified_as_domain_quantity` (settle_delay), `test_protocol_keyword_detects_blockchain_domain`, `test_silence_on_detached_tilde` (`~ 2 min`), `test_repo_root_resolves_git_toplevel`, `test_all_vacuous_zero_guard_returns_two` (monkeypatch 0 cibles → exit 2).

Total : **33 PASS**.

## Périmètre

Seulement le détecteur + ses tests (2 fichiers, +227/−15). 0 notebook, 0 catalogue, 0 autre script. Pas d'extension aux autres classes de dérive (accuracy/coût/mémoire) — le temps d'horloge d'abord. Pas de `--fix` (la reformulation demande du jugement).

See #10169 · See #9434 (epic parente — chiffre de référence re-posté) · See #10162 (organe initial)
