### PR TITLE
Refine(check_machine_dep_timing): per-notebook propagation + protocol constants + git-root --all (#10169)

### DIFF
--- a/scripts/notebook_tools/check_machine_dep_timing.py
+++ b/scripts/notebook_tools/check_machine_dep_timing.py
@@ -57,11 +57,25 @@ Acceptance (cf. CHANGES_REQUESTED #10162, c.1331+59)
 - [x] Inventaire re-mesure : 256 wallclock + 40 distribution_param +
       35 domain_quantity + 0 ambiguous = 331 total (vs 978 avant).
 
+Acceptance (cf. #10169, frontiere residuelle)
+- [x] Residu 1 : propagation per-NOTEBOOK ``domain_quantity`` -- si le notebook
+      porte >=1 ``distribution_param``, l'unite de temps est son sujet et tous
+      les ``wallclock`` residuels basculent (6 findings Infer-2-Gaussian-Mixtures
+      dont les moyennes ajustees 15.07 / 26.69 min).
+- [x] Residu 2 : ``PROTOCOL_KEYWORDS`` (settle_delay, temps de bloc, finality)
+      route les constantes de consensus en ``domain_quantity`` ; tilde detache
+      ``~ 2 min`` reconnu comme ordre de grandeur (SC-19, SC-23).
+- [x] Residu 3 : ``--all`` resolu depuis la racine git (``git rev-parse
+      --show-toplevel``), resultat vide = erreur explicite (exit 1).
+- [x] Controle positif `Sudoku-13` preserve (Z3 wall-clock strict reste detecte).
+
 Note : `ambiguous=0` est structural (defaut conservateur = wallclock). Aucun
 finding ne reste ambigue apres la passe 1 -- le defaut de `_categorize`
 classe toute ligne sans mot-cle en wallclock. La categorie `ambiguous`
 reste dans la taxonomie pour compatibilite (cf. migrations futures) mais
-n'est pas emise en pratique avec l'heuristique courante.
+n'est pas emise en pratique avec l'heuristique courante. Decision #10169 :
+on garde la categorie documentee plutot que de la retirer, pour stabilite
+du schema ``--json`` consomme par l'inventaire #9434.
 """
 
 from __future__ import annotations
@@ -69,6 +83,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -117,6 +132,20 @@ DISTRIBUTION_KEYWORDS = re.compile(
     r"moyenne|mean|std|sigma|sigma[_\s]?2|variance|precision|"
     r"distribution|mu_|sigma_|mixture|Dirichlet|Gamma|Beta|"
     r"intervalle?\s+de\s+confiance|IC\s+\d|probabilit[ée]?)\b",
+    re.IGNORECASE,
+)
+
+# Mot-cle qui signale une CONSTANTE DE PROTOCOLE (consensus blockchain, canal
+# de paiement) -- le chiffre est un parametre du domaine modifie, pas une
+# duree machine. Exempt en tant que ``domain_quantity`` (cf. residu 2 #10169) :
+# un ``settle_delay`` de canal XRP (3600 s) ou un temps de bloc Ethereum
+# (12 blocs ~ 2 min) ne derivent pas d'une machine a l'autre -- ils ne derivent
+# pas du tout, ce sont des parametres de consensus.
+PROTOCOL_KEYWORDS = re.compile(
+    r"\b(?:settle[\s\-_]?delay|settlement|temps\s+de\s+bloc|block[\s\-]?time|"
+    r"blocs?(?:\s+(?:d['Ee]thereum|ethereum|de\s+bitcoin|bitcoin))?|"
+    r"finalit[ée]|epoch|slot|confirmation|consensus|"
+    r"canal\s+de\s+paiement|payment\s+channel)\b",
     re.IGNORECASE,
 )
 
@@ -175,6 +204,22 @@ def _is_range_bound(line: str, match_start: int, match_end: int) -> bool:
     return False
 
 
+def _is_detached_approximate(line: str, match_start: int) -> bool:
+    """Detecte un marqueur d'ordre de grandeur DETACHE : ``~ 2 min`` (espace).
+
+    Le ``MACHINE_RE`` accolé ``~2 min`` est deja gere (le ``~?`` optionnel
+    inclus dans le match -> ``snippet.startswith('~')`` -> skip). Ce helper
+    couvre la forme avec espace, ou le ``~`` (ou ``≈``) precede le chiffre
+    d'une espace -- cas reel SC-23-Cross-Chain : « 12 blocs Ethereum ~ 2 min »
+    (residu 2 #10169). Conforme au mandat #9434 : ordre de grandeur, pas
+    mesure precise -> on ne signale pas.
+    """
+    # Fenetre de 3 chars avant le match : le marqueur + eventuelle espace.
+    lo = max(0, match_start - 3)
+    window = line[lo:match_start]
+    return bool(re.search(r"[~≈]\s*$", window))
+
+
 # --------------------------------------------------------------------------- #
 #  Taxonomie de sortie
 # --------------------------------------------------------------------------- #
@@ -208,6 +253,10 @@ def _categorize(line: str, snippet: str) -> str:
     """
     if DISTRIBUTION_KEYWORDS.search(line):
         return CATEGORY_DISTRIBUTION
+    # Constante de protocole (consensus blockchain / canal de paiement) :
+    # parametre du domaine, pas une duree machine. Residu 2 #10169.
+    if PROTOCOL_KEYWORDS.search(line):
+        return CATEGORY_DOMAIN_QUANTITY
     if WALLCLOCK_KEYWORDS.search(line):
         return CATEGORY_WALLCLOCK
     # Pas de mot-cle de contexte : on considere que la presence de la regex
@@ -237,15 +286,21 @@ def _scan_notebook(nb_path: Path) -> list[dict]:
     -- cf. #10158 acceptance : "les cellules de code et les outputs (une
     sortie doit porter la valeur reelle mesuree -- c'est sa fonction)".
 
-    Strategie en 2 passes (CHANGES_REQUESTED #10162 c.1331+59) :
+    Strategie en 3 passes (FP-2 #10162 + residu 1 #10169) :
 
     1. **Passe ligne** : pour chaque ligne markdown, on applique les exemptions
-       (pacing pedagogique, tilde, fourchette/borne) et on classifie selon le
-       contexte de la ligne (wallclock / distribution_param / ambiguous).
+       (pacing pedagogique, tilde colle/detache, fourchette/borne, constante de
+       protocole) et on classifie selon le contexte de la ligne (wallclock /
+       distribution_param / domain_quantity / ambiguous).
     2. **Passe cellule** : si une cellule porte >=1 finding ``distribution_param``,
        tous les autres findings ``wallclock`` de la meme cellule basculent en
        ``domain_quantity`` -- l'unite de temps est le sujet du modele, pas une
        mesure d'execution (cf. FP-2 sur Infer-2-Gaussian-Mixtures).
+    3. **Passe notebook** : si le notebook ENTIER porte >=1 ``distribution_param``,
+       les ``wallclock`` residuels (cellules sans mot-cle stat) basculent aussi
+       en ``domain_quantity`` (residu 1 #10169 : les 6 findings Infer-2 dont les
+       moyennes ajustees 15.07 / 26.69 min). La granularite per-cell etait trop
+       etroite -- l'unite de temps est le sujet du notebook, pas d'une cellule.
     """
     try:
         data = json.loads(nb_path.read_text(encoding="utf-8"))
@@ -272,6 +327,10 @@ def _scan_notebook(nb_path: Path) -> list[dict]:
                 # pour le tilde.
                 if _is_range_bound(line, m.start(), m.end()):
                     continue
+                # Residu 2 #10169 : tilde DETACHE (`~ 2 min`, marqueur + espace).
+                # Ordre de grandeur, comme le tilde colle et la fourchette.
+                if _is_detached_approximate(line, m.start()):
+                    continue
                 category = _categorize(line, snippet)
                 findings.append({
                     "cell_index": ci,
@@ -297,12 +356,50 @@ def _scan_notebook(nb_path: Path) -> list[dict]:
             if f["category"] == CATEGORY_WALLCLOCK:
                 f["category"] = CATEGORY_DOMAIN_QUANTITY
 
+    # Passe 3 : propagation per-NOTEBOOK domain_quantity (residu 1 #10169).
+    # La propagation per-cell (passe 2) est trop etroite : 6 findings Infer-2
+    # restent wallclock parce que leur cellule ne porte aucun mot-cle statistique,
+    # alors que le notebook entier modelise un temps de trajet. Si le notebook
+    # porte >=1 finding distribution_param, l'unite de temps est le SUJET du
+    # modele -> tous les wallclock residuels basculent en domain_quantity.
+    nb_has_distribution = any(
+        f["category"] == CATEGORY_DISTRIBUTION for f in findings
+    )
+    if nb_has_distribution:
+        for f in findings:
+            if f["category"] == CATEGORY_WALLCLOCK:
+                f["category"] = CATEGORY_DOMAIN_QUANTITY
+
     return findings
+
+
+def _repo_root() -> Path:
+    """Racine du depot : ``git rev-parse --show-toplevel`` (authoritatif),
+    fallback ``parents[2]`` du script.
+
+    Residu 3 #10169 : ``parents[2]`` resolu depuis l'emplacement du script
+    fonctionne seulement tant que le script vit a ``<root>/scripts/...``. Un
+    outil invoque hors du repertoire (le cas d'usage canonique ``--all``)
+    doit trouver ses cibles depuis la racine git reelle, pas depuis un
+    chemin calcule par hypothese.
+    """
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(Path(__file__).resolve().parent),
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        if out:
+            return Path(out).resolve()
+    except (OSError, subprocess.CalledProcessError, subprocess.SubprocessError):
+        pass
+    return Path(__file__).resolve().parents[2]
 
 
 def _collect_targets(args: argparse.Namespace) -> list[Path]:
     """Resout la liste des notebooks a scanner depuis la CLI."""
-    root = Path(__file__).resolve().parents[2]
+    root = _repo_root()
     if args.all or args.json or args.check:
         # Cible canonique : notebooks pedagogiques. Les READMEs et `assets/`
         # sont exclus -- le scope de #10158 est uniquement les ``.ipynb``.
@@ -371,9 +468,22 @@ def main(argv: list[str] | None = None) -> int:
 
     targets = _collect_targets(args)
     if not targets:
-        print("Aucun notebook a scanner.", file=sys.stderr)
-        return 0
+        # Residu 3 #10169 : un resultat vide sur une invocation explicite
+        # (--all/--json/--check ou paths nommes) est une ERREUR bruyante, pas
+        # un succes silencieux. Sinon la lane suivante apprend qu'il n'y a
+        # rien a faire alors que l'outil a juste rate la racine git.
+        explicit_scan = bool(args.all or args.json or args.check or args.paths)
+        if explicit_scan:
+            print(
+                "Aucun notebook a scanner sous la racine git. "
+                "Invoque depuis le depot, ou passe des chemins explicites.",
+                file=sys.stderr,
+            )
+            return 1
+        parser.print_help(sys.stderr)
+        return 1
 
+    repo_root = _repo_root()
     all_findings: dict[str, list[dict]] = {}
     wallclock_count = 0
     distribution_count = 0
@@ -383,7 +493,7 @@ def main(argv: list[str] | None = None) -> int:
         rel = str(nb_path)
         # Afficher le chemin relatif a la racine du depot si possible.
         try:
-            rel = str(nb_path.resolve().relative_to(Path(__file__).resolve().parents[2]))
+            rel = str(nb_path.resolve().relative_to(repo_root))
         except ValueError:
             pass
         findings = _scan_notebook(nb_path)

--- a/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
+++ b/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
@@ -24,6 +24,9 @@ from check_machine_dep_timing import (  # noqa: E402
     _categorize,
     _scan_notebook,
     _is_range_bound,
+    _is_detached_approximate,
+    _repo_root,
+    PROTOCOL_KEYWORDS,
     CATEGORY_WALLCLOCK,
     CATEGORY_DISTRIBUTION,
     CATEGORY_AMBIGUOUS,
@@ -557,6 +560,188 @@ def test_main_advisory_mode_exits_zero() -> None:
     # Sur CI (avec MyIA.AI.Notebooks/ present), --all peut renvoyer 0 ou 1
     # selon --check, mais sans --check, c'est TOUJOURS 0 (mode advisory).
     assert rc == 0
+
+
+# --------------------------------------------------------------------------- #
+#  Residus #10169 : duree modelisee per-notebook + constante de protocole
+#                   + --all resolu hors racine
+# --------------------------------------------------------------------------- #
+def test_silence_per_notebook_propagation_residu1() -> None:
+    """Residu 1 #10169 : propagation per-NOTEBOOK domain_quantity.
+
+    Rationnel : la propagation per-cell (passe 2) est trop etroite. Quand le
+    notebook ENTIER porte >=1 ``distribution_param`` (une cellule Gaussienne),
+    les wallclock des AUTRES cellules (sans mot-cle stat) basculent en
+    ``domain_quantity`` -- l'unite de temps est le sujet du notebook, pas
+    d'une cellule. Cas reel Infer-2-Gaussian-Mixtures : les moyennes ajustees
+    ``| Ordinaire | 15.07 min |`` / ``| Extraordinaire | 26.69 min |`` sont la
+    SORTIE du modele (obtenue par inference), pas une mesure d'execution.
+    """
+    nb = _make_nb([
+        # Cellule 1 : declare les parametres de la distribution (distribution_param).
+        _md_cell(
+            "## Modele\n"
+            "Le melange suit une Gaussian de moyenne 15.33 min et sigma 1.32 min."
+        ),
+        # Cellule 2 : SEPARATE, sans mot-cle stat. Sans la passe per-notebook,
+        # les 15.07 / 26.69 resteraient wallclock (la cellule 2 n'a pas de
+        # mot-cle distribution pour declencher la passe per-cell).
+        _md_cell(
+            "## Resultats ajustes\n"
+            "| Ordinaire | 15.07 min | Trajets normaux : {13, 17, 16} |\n"
+            "| Extraordinaire | 26.69 min | Trajets longs : {20, 25, 25, 30} |"
+        ),
+    ])
+    try:
+        findings = _scan_notebook(nb)
+        wallclock = [f for f in findings if f["category"] == CATEGORY_WALLCLOCK]
+        assert wallclock == [], (
+            f"Propagation per-notebook rate : wallclock residuel = {wallclock}"
+        )
+        domain = {f["snippet"]: f["category"] for f in findings
+                  if f["category"] == CATEGORY_DOMAIN_QUANTITY}
+        assert "15.07 min" in domain, (
+            f"15.07 min (moyenne ajustee) attendue en domain_quantity: {domain}"
+        )
+        assert "26.69 min" in domain, (
+            f"26.69 min (moyenne ajustee) attendue en domain_quantity: {domain}"
+        )
+    finally:
+        nb.unlink()
+
+
+def test_silence_protocol_constant_settle_delay_residu2() -> None:
+    """Residu 2 #10169 : constante de protocole = domain_quantity, pas wallclock.
+
+    Un ``settle_delay`` de canal de paiement (consensus) ne derive pas d'une
+    machine a l'autre -- c'est un parametre du domaine. Cas reel SC-19-Ripple-XRP
+    cell[30] : « Le ``settle_delay`` est crucial... attendre 3600 secondes ».
+    """
+    nb = _make_nb([
+        _md_cell(
+            "**Note technique** : Le `settle_delay` est crucial pour la securite. "
+            "Si Alice veut fermer le canal, elle doit attendre 3600 secondes "
+            "pendant lesquelles Bob peut contester."
+        ),
+    ])
+    try:
+        findings = _scan_notebook(nb)
+        wallclock = [f for f in findings if f["category"] == CATEGORY_WALLCLOCK]
+        assert wallclock == [], (
+            f"settle_delay 3600 secondes ne doit pas etre wallclock : {wallclock}"
+        )
+        assert any(f["category"] == CATEGORY_DOMAIN_QUANTITY for f in findings), (
+            f"3600 secondes attendu en domain_quantity : {findings}"
+        )
+    finally:
+        nb.unlink()
+
+
+def test_silence_protocol_block_time_residu2() -> None:
+    """Residu 2 #10169 : temps de bloc Ethereum = constante de protocole.
+
+    Cas reel SC-23-Cross-Chain : « 12 blocs Ethereum ... ». Le temps de bloc
+    est un parametre de consensus, pas une duree machine.
+    """
+    nb = _make_nb([
+        _md_cell("Finalite : 12 blocs Ethereum correspondent a environ 3 min."),
+    ])
+    try:
+        findings = _scan_notebook(nb)
+        wallclock = [f for f in findings if f["category"] == CATEGORY_WALLCLOCK]
+        assert wallclock == [], (
+            f"temps de bloc Ethereum ne doit pas etre wallclock : {wallclock}"
+        )
+        assert any(f["category"] == CATEGORY_DOMAIN_QUANTITY for f in findings)
+    finally:
+        nb.unlink()
+
+
+def test_silence_detached_tilde_residu2() -> None:
+    """Residu 2 #10169 : tilde detache ``~ 2 min`` = ordre de grandeur, on skip.
+
+    Le ``MACHINE_RE`` colle ``~2 min`` est deja gere (snippet commence par ``~``).
+    Ce test couvre la forme DETACHEE (espace entre marqueur et chiffre). La ligne
+    est choisie SANS mot-cle protocole/distribution, pour isoler le comportement
+    du tilde detache (sinon un mot-cle sauverait le finding par ailleurs).
+    """
+    nb = _make_nb([
+        _md_cell("Estimation de convergence : ~ 2 min par appel."),
+    ])
+    try:
+        findings = _scan_notebook(nb)
+        snippets = [f["snippet"] for f in findings]
+        assert "2 min" not in snippets, (
+            f"Le tilde detache '~ 2 min' doit etre skip (ordre de grandeur) : "
+            f"trouve {findings}"
+        )
+    finally:
+        nb.unlink()
+
+
+def test_is_detached_approximate_helper() -> None:
+    """Le helper _is_detached_approximate couvre ~ et ≈, avec ou sans espace."""
+    # `~ 2 min` : tilde + espace avant le chiffre.
+    assert _is_detached_approximate("foo ~ 2 min", 6) is True   # '~ ' avant idx 6
+    # `~2 min` : tilde colle (deja gere par MACHINE_RE, mais le helper le couvre).
+    assert _is_detached_approximate("foo ~2 min", 5) is True
+    # `≈ 2 min` : variante unicode.
+    assert _is_detached_approximate("≈ 2 min", 2) is True
+    # Sans tilde : pas un ordre de grandeur.
+    assert _is_detached_approximate("duree 2 min", 6) is False
+
+
+def test_bare_wallclock_still_detected_negative_control() -> None:
+    """Controle negatif : sans tilde ni protocole ni distribution, un ``2 min``
+    reste wallclock. Garantie que le detecteur n'est pas muet (cf. controle
+    positif Sudoku-13 + celui-ci isole le comportement par defaut)."""
+    nb = _make_nb([
+        _md_cell("La duree d'execution est 2 min pour 1000 iterations."),
+    ])
+    try:
+        findings = _scan_notebook(nb)
+        assert any(f["category"] == CATEGORY_WALLCLOCK and f["snippet"] == "2 min"
+                   for f in findings), (
+            f"Un bare '2 min' sans marqueur doit rester wallclock : {findings}"
+        )
+    finally:
+        nb.unlink()
+
+
+def test_all_resolves_from_other_dir_residu3(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Residu 3 #10169 : ``--all`` resolu depuis la racine git, pas depuis le cwd.
+
+    Invoque depuis un repertoire externe (tmp_path). ``_repo_root()`` utilise
+    ``git rev-parse --show-toplevel`` (authoritatif), donc ``--all`` trouve les
+    notebooks meme hors du repertoire du script. Advisory -> exit 0.
+    """
+    from check_machine_dep_timing import main
+    if not (_repo_root() / "MyIA.AI.Notebooks").exists():
+        pytest.skip("Hors env repo (MyIA.AI.Notebooks absent sous la racine git)")
+    monkeypatch.chdir(tmp_path)
+    rc = main(["--all"])
+    assert rc == 0, (
+        "--all invoque hors racine doit trouver les notebooks via git toplevel "
+        "et sortir en advisory (exit 0)"
+    )
+
+
+def test_empty_explicit_scan_is_error_residu3(tmp_path: Path) -> None:
+    """Residu 3 #10169 : un scan explicite vide = erreur bruyante (exit 1).
+
+    Un path explicite inexistant ne doit PAS retourner un silent 0 (« Aucun
+    notebook ») -- c'est exactement le piege qui apprend a la lane suivante
+    qu'il n'y a rien a faire alors que l'outil a juste rate sa cible.
+    """
+    from check_machine_dep_timing import main
+    bogus = tmp_path / "n'existe-pas.ipynb"
+    rc = main([str(bogus)])
+    assert rc == 1, (
+        "Un path explicite inexistant doit echouer bruyamment (exit 1), "
+        "pas retourner un silent 0"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA — prev: MED/notebook-dotnet #10148

## Quoi

Ferme les 3 classes de faux positifs résiduelles mesurées sur le détecteur mergé (#10162), avec contrôle positif Sudoku-13 préservé. Organe-only : aucun notebook modifié, le drain vient après.

## Les 3 résidus (mesurés firsthand avant/après)

**R1 — durée = résultat du notebook (propagation per-notebook).** La propagation per-cell (passe 2) était trop étroite : 6 findings Infer-2-Gaussian-Mixtures restaient `wallclock` parce que leur cellule ne porte aucun mot-clé statistique — alors que les `15.07 min` / `26.69 min` sont les **moyennes ajustées du mélange gaussien** (sortie du modèle par inférence). Ajout d'une **passe 3 per-notebook** : si le notebook entier porte ≥1 `distribution_param`, l'unité de temps est son sujet → les `wallclock` résiduels basculent en `domain_quantity`.
- Avant : `Infer-2 wallclock=6` · Après : `wallclock=0` (15.07/26.69 → domain_quantity)

**R2 — constante de protocole (classe nouvelle).** Un `settle_delay` de canal XRP (3600 s) et un temps de bloc Ethereum (12 blocs ~ 2 min) sont des **paramètres de consensus** — ils ne dérivent pas d'une machine à l'autre, ils ne dérivent pas du tout. Ajout de `PROTOCOL_KEYWORDS` routé vers `domain_quantity` (`settle_delay` matché avec underscore `settle[\s\-_]?delay`). Second cas : le tilde **détaché** `~ 2 min` (espace entre marqueur et chiffre) n'était pas reconnu — ajout de `_is_detached_approximate` (le tilde collé `~2 min` était déjà géré).
- Avant : `SC-19/SC-23 wallclock=2` · Après : `wallclock=0` (3600 → domain_quantity ; ~2 min skip)

**R3 — `--all` résolu depuis la racine git.** `--all` résolvait `MyIA.AI.Notebooks/**` relativement au script (`parents[2]`), et retournait silencieusement `Aucun notebook` (exit 0) quand invoqué hors du dépôt — apprenant à la lane suivante qu'il n'y a rien à faire. Maintenant résolu via `git rev-parse --show-toplevel` (helper `_repo_root`, authoritatif, fallback `parents[2]`), et un scan explicite vide = **erreur bruyante** (exit 1).
- Avant : `--all` depuis /tmp → `Aucun notebook` (exit 0) · Après : `scanned=979` (exit 0)

## `ambiguous` — décision

La catégorie est à 0 sur 331 findings (structurel : défaut conservateur = wallclock). L'issue offrait « la faire vivre OU documenter et retirer ». Choix : **garder la catégorie documentée** plutôt que la retirer, pour stabilité du schéma `--json` consommé par l'inventaire #9434. La docstring l'explique.

## Preuve d'exécution (G.1, firsthand)

```
Infer-2-Gaussian-Mixtures:  wallclock=0  (was 6)   15.07/26.69 min -> domain_quantity
SC-19-Ripple-XRP + SC-23:   wallclock=0  (was 2)   3600s -> domain_quantity ; ~2 min skip
Sudoku-13 positive control: wallclock=28 (cell[43]/[44] Z3 timings)  INTACT
--all from /tmp:            scanned=979 via git rev-parse --show-toplevel
```

Tests : **35 passent** (27 existants + 8 nouveaux : per-notebook propagation, settle_delay, block-time, detached-tilde, helper, negative-control, --all cross-dir, empty-explicit-error). **4388 tests sibling-tool passent** (no regression, suite `scripts/notebook_tools/tests/`). CRLF clean (numstat byte-level).

## Inventaire re-mesuré (référence #9434)

`--all` sur 979 notebooks : **232 wallclock** (was 256) + 36 distribution_param + 49 domain_quantity + 0 ambiguous = 317 total. Le compteur de référence de l'epic bouge (256 → 232) ; **re-posté sur #9434** en commentaire accompagnant cette PR.

## Acceptance #10169

- [x] Résidu 1 : 6 findings Infer-2 ne sont plus `wallclock` (test silence `| Ordinaire | 15.07 min |`).
- [x] Résidu 2 : 2 findings SmartContracts ne sont plus `wallclock` ; `~` détaché reconnu.
- [x] Résidu 3 : `--all` résolu depuis la racine git, ou erreur explicite (test cross-dir).
- [x] Contrôle positif `Sudoku-13` intact (Z3 wall-clock strict reste détecté).
- [x] Inventaire re-mesuré et re-posté sur #9434.
- [x] `ambiguous` : catégorie gardée documentée (décision ci-dessus).
- [x] Aucune modification de notebook — l'organe se raffine, le drain vient après.

## Résiduel (hors scope, suivi séparé)

- Latent footgun pré-existant : `--json` (et `--check`) déclenchent la branche `--all` même si des chemins sont passés (le path est ignoré). Non touché ici (hors scope #10169 « le temps d'horloge d'abord ») — à tracker par issue dédiée si pertinent.

Closes #10169 · See #9434 (epic parente — son chiffre de référence bouge) · See #10162 (organe initial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
