### PR TITLE
Refine(check_machine_dep_timing): pacing-extension (lecture qualifier) + planning-domain plan-cost arithmetic (#10178)

### DIFF
--- a/scripts/notebook_tools/check_machine_dep_timing.py
+++ b/scripts/notebook_tools/check_machine_dep_timing.py
@@ -166,7 +166,18 @@ STUDENT_PACING_RE = re.compile(
     # Extensions #10162 : parenhese "(15 min)" / "(1-2 min)"
     r"\(\d+\s*(?:-\s*\d+)?\s*(?:min(?:utes?)?|sec(?:ondes?)?|h(?:eures?)?)\)|"
     # Extensions #10162 : cellule de tableau "| 15 min |"
-    r"\|\s*\d+\s*(?:-\s*\d+)?\s*(?:min(?:utes?)?|sec(?:ondes?)?|h(?:eures?)?)\s*\|)",
+    r"\|\s*\d+\s*(?:-\s*\d+)?\s*(?:min(?:utes?)?|sec(?:ondes?)?|h(?:eures?)?)\s*\|"
+    # Frontiere FP (frontier issue) : duree suivi d'un qualificatif d'effort
+    # humain entre parentheses -- « 45 min (lecture + execution sequentielle) ».
+    # C'est le meme signal que le pacing ci-dessus (effort demande a l'etudiant,
+    # arbitrage jsboige 14:05:37Z #9434), mais la duree PRECEDE la parenthese au
+    # lieu de s'y trouver (ex ICT-19-EnjeuBattery cell[0], ICT-19b cell[0]).
+    # NB : on cible le qualificatif d'effort (lecture/cours/tp) precisement -- la
+    # forme « moins de N » / « plus de N » est un signal de borne runtime OU de
+    # probabilite de domaine (P(trajet < 18 min)), PAS de pacing, et ne doit PAS
+    # etre exemptee (cf. brainstorm G.1 : sur-exemption cassait la propagation
+    # per-cell #10162 et flagait des wallclock reels « plus de 4 secondes »).
+    r"|\d+\s*(?:min(?:utes?)?|sec(?:ondes?)?|h(?:eures)?)\s*\(\s*(?:lecture|cours|travaux\s+pratiques|tp\b))",
     re.IGNORECASE,
 )
 
@@ -256,6 +267,15 @@ def _categorize(line: str, snippet: str) -> str:
     # Constante de protocole (consensus blockchain / canal de paiement) :
     # parametre du domaine, pas une duree machine. Residu 2 #10169.
     if PROTOCOL_KEYWORDS.search(line):
+        return CATEGORY_DOMAIN_QUANTITY
+    # Frontiere FP (frontier issue) : cout d'action dans une table de plan.
+    # La duree est le RESULTAT d'une arithmetique « N + M = K unit » (ex
+    # Planners-8-Temporal cell[37] « 5 + 4 = 9 min » = duree d'une livraison
+    # drone). C'est un parametre DETERMINISTE du domaine planifie, pas une
+    # duree machine. Le motif est precis (un vrai wallclock ne se rend presque
+    # jamais comme une somme explicite `a + b = c unit`) -- Sudoku-13 (controle
+    # positif) n'a aucune ligne de cette forme, donc reste detecte.
+    if re.search(r"\d+\s*\+\s*\d+\s*=\s*\d+\s*(?:min(?:utes?)?|sec(?:ondes?)?|s\b|h(?:eures)?)", line):
         return CATEGORY_DOMAIN_QUANTITY
     if WALLCLOCK_KEYWORDS.search(line):
         return CATEGORY_WALLCLOCK

--- a/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
+++ b/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
@@ -744,5 +744,60 @@ def test_empty_explicit_scan_is_error_residu3(tmp_path: Path) -> None:
     )
 
 
+# --------------------------------------------------------------------------- #
+#  Frontiere FP (frontier issue) : pacing-extension + planning-domain
+# --------------------------------------------------------------------------- #
+def test_silence_pacing_duration_with_lecture_qualifier() -> None:
+    """Frontiere : « N min (lecture + execution) » = pacing (effort humain).
+
+    Cas reel ICT-19-EnjeuBattery cell[0] : « 45 min (lecture + execution
+    sequentielle) ». C'est l'estimation d'effort demande a l'etudiant, pas une
+    duree machine -- meme rationale que le pacing deja exempte (arbitrage
+    jsboige 14:05:37Z #9434). La duree PRECEDE la parenthese (inhabituel), ce
+    que le STUDENT_PACING_RE historique ratait.
+
+    NB : on cible le qualificatif d'effort (lecture/cours/tp) precisement. La
+    forme « moins de N » / « plus de N » n'est PAS exemptee -- c'est un signal
+    de borne runtime ou de probabilite de domaine (ex P(trajet < 18 min)), pas
+    de pacing (cf. brainstorm G.1 : sur-exemption cassait la propagation #10162).
+    """
+    assert STUDENT_PACING_RE.search("45 min (lecture + execution sequentielle). GPU-free.")
+    assert STUDENT_PACING_RE.search("90 min (cours magistral + TP)")
+    # Sans qualificatif d'effort : reste un finding (pas pacing).
+    assert not STUDENT_PACING_RE.search("La duree d'execution est 45 min.")
+    # « moins de N » / « plus de N » n'est PAS pacing (borne runtime/domaine).
+    assert not STUDENT_PACING_RE.search("converge en plus de 10 min sur les gros cas")
+
+
+def test_plan_table_cost_routed_to_domain_quantity() -> None:
+    """Frontiere : « N + M = K min » = cout d'action dans une table de plan.
+
+    Cas reel Planners-8-Temporal cell[37] : « | D1 | A -> B | 5 + 4 = 9 min | ».
+    Le « 9 min » est la duree DETERMINISTE d'une livraison drone (somme acces +
+    vol), pas une duree machine. Routed vers domain_quantity (compte, visible),
+    pas wallclock.
+
+    On verifie via _categorize : la ligne porte l'arithmetique de cout -> le
+    snippet « 9 min » est classe domain_quantity.
+    """
+    line = "| D1 | A -> B | 5 + 4 = 9 min | Drone 0 ou 1 |"
+    assert _categorize(line, "9 min") == CATEGORY_DOMAIN_QUANTITY
+    line2 = "Duree totale : 0 + 6 = 6 min pour la livraison D2."
+    assert _categorize(line2, "6 min") == CATEGORY_DOMAIN_QUANTITY
+
+
+def test_plan_cost_regex_does_not_overreach_real_wallclock() -> None:
+    """Controle negatif : un vrai wallclock sans arithmetique de cout reste wallclock.
+
+    Garantie que le motif « N + M = K unit » est precis. Sudoku-13 (controle
+    positif canonique) rapporte « 2.4 s pour 1000 iterations » -- aucune somme
+    explicite `a + b = c unit` -> reste wallclock. Ce test isole le comportement.
+    """
+    line = "La duree d'execution est 2.4 s pour 1000 iterations."
+    # Pas d'arithmetique de cout -> _categorize ne bascule pas en domain_quantity
+    # via la branche plan-cost (WALLCLOCK_KEYWORDS 'execution' -> wallclock).
+    assert _categorize(line, "2.4 s") == CATEGORY_WALLCLOCK
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA — prev: MED/guard #10176 (Closes #10169). Compose avec #10176 (pré-merge).

## Quoi

Deux classes de FP du détecteur, découvertes en **tentant un drain #9434** : les 3 candidats drain examinés (ICT-19, Planners-8, ML-1) étaient tous des FP du détecteur, pas des drains réels. Cette PR ferme 2 des 4 classes de la frontière documentée dans #10178 (les 2 autres sont des design-questions, non implémentées ce cycle).

## Les 2 classes (forensic diff PRE↔POST vérifié clean)

**Classe 1 — pacing-extension.** `STUDENT_PACING_RE` ratait « N min (lecture + exécution) » où la durée PRÉCÈDE la parenthèse (ICT-19 cell[0] « 45 min (lecture + exécution séquentielle) », ICT-19b cell[0] « 20 min (...) »). Ajout d'une alternation ciblée sur le **qualificatif d'effort** (`lecture|cours|tp`).

> **Rejet G.1 (brainstorm)** : la forme large `\b(moins|plus)\s+de\s+\d+` a été rejetée. Elle sur-exemptait (a) du vrai wallclock (« plus de 4 secondes » Sudoku-1 = lent, « plus de 15 minutes » Lean-10 = warning tracing) ET (b) des probabilités de domaine (« P(trajet < 18 min) » Infer-2) — ce qui **défait la propagation per-cell #10162** (régression en cascade : distribution_param exempté → pass-2 annulé → domain_quantity revert en wallclock). Le diff PRE↔POST l'a attrapé avant commit. On cible donc le qualificatif d'effort précisément.

**Classe 2 — planning-domain plan-cost.** « 5 + 4 = 9 min » dans une table de plan (Planners-8-Temporal cell[37]) = coût d'action DÉTERMINISTE (durée de livraison drone), pas une durée machine. Regex précise `\d+\s*\+\s*\d+\s*=\s*\d+\s*unit` dans `_categorize` → `domain_quantity`.

## Preuve (forensic diff, firsthand)

```
PRE:  wallclock=256  distribution_param=40  domain_quantity=35  total=331
POST: wallclock=251  distribution_param=40  domain_quantity=38  total=329

DISAPPEARED (2):   ICT-19 '45 min (lecture)' / ICT-19b '20 min (lecture)' -> pacing ✓
RE-CATEGORIZED (3): Planners-8 9/6/12 min -> wallclock to domain_quantity (plan-cost) ✓
distribution_param UNCHANGED (40->40): NO cascade regression on Infer-2 ✓
Sudoku-1 '4 secondes' / Lean-10 '15 minutes': real wallclock PRESERVED (no over-exemption) ✓
Sudoku-13 positive control: wallclock=29 INTACT ✓
```

ICT-19 cell[8] « moins de 5 minutes » (runtime estimate « exécutable end-to-end ») **reste wallclock** — c'est honnête : c'est une estimation de runtime machine-dépendante, pas du pacing. La distinction est documentée dans #10178.

## Tests

30 detector tests passent (27 + 3 nouveaux : pacing-lecture-qualifier, plan-cost-routing, plan-cost-negative-control). **4383 sibling-tool tests passent** (0 régression). CRLF clean.

## Compose avec #10176

Sections de code disjointes : cette PR touche `STUDENT_PACING_RE` + `_categorize` (plan-cost) ; #10176 touche `PROTOCOL_KEYWORDS` + `_repo_root` + `_is_detached_approximate` + pass-3. Les deux PR se composent (rebase trivial si #10176 merge en premier — `_categorize` ajoute des checks sur lignes adjacentes).

## Non implémenté ce cycle (design-question, voir #10178)

- **Classe 3** : annotation `*runtime *machine-dep* : N unit` déjà-drainée que le détecteur re-flag (~10 findings/6 notebooks). Décision coordinateur/user requise : exempter (forme conforme) vs drainer (retrait complet).
- **Classe 4** : contraintes durée-vidéo GenAI/Video (« 5 minutes » = longueur max vidéo = domaine). Faible volume.

See #10178 (issue frontière, partial : classes 1-2 sur 4) · See #10176 (composes) · See #9434 (epic parente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
