### PR TITLE
i18n(#4980): add basic_logic_en + tactics_demo_en + llm_assisted_proof_en siblings — examples folder 5/5 bilingual

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/basic_logic_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/basic_logic_en.lean
@@ -1,0 +1,104 @@
+/-
+  Lean Examples - Basic Logic (EN sibling)
+
+  This file contains basic propositional logic examples
+  corresponding to the Lean-2 and Lean-3 notebooks.
+
+  English sibling of basic_logic.lean (i18n #4980): docstrings and
+  comments translated to English; theorems, definitions, tactics, and
+  variables are byte-identical to the French original.
+-/
+
+-- Propositional variables
+variable (p q r : Prop)
+
+-- ============================================================
+-- Implication
+-- ============================================================
+
+-- Reflexivity of implication
+theorem impl_refl : p -> p :=
+  fun hp => hp
+
+-- Transitivity of implication
+theorem impl_trans (hpq : p -> q) (hqr : q -> r) : p -> r :=
+  fun hp => hqr (hpq hp)
+
+-- K combinator
+theorem impl_intro : p -> q -> p :=
+  fun hp _ => hp
+
+-- ============================================================
+-- Conjunction (And)
+-- ============================================================
+
+-- And introduction
+theorem and_intro (hp : p) (hq : q) : p /\ q :=
+  And.intro hp hq
+
+-- Commutativity of And
+theorem and_comm : p /\ q -> q /\ p :=
+  fun hpq => And.intro hpq.right hpq.left
+
+-- Associativity of And
+theorem and_assoc : (p /\ q) /\ r <-> p /\ (q /\ r) :=
+  Iff.intro
+    (fun h => And.intro h.left.left (And.intro h.left.right h.right))
+    (fun h => And.intro (And.intro h.left h.right.left) h.right.right)
+
+-- ============================================================
+-- Disjunction (Or)
+-- ============================================================
+
+-- Commutativity of Or
+theorem or_comm : p \/ q -> q \/ p :=
+  fun hpq => Or.elim hpq Or.inr Or.inl
+
+-- Or elimination
+theorem or_elim_example (hpq : p \/ q) (hpr : p -> r) (hqr : q -> r) : r :=
+  Or.elim hpq hpr hqr
+
+-- ============================================================
+-- Negation
+-- ============================================================
+
+-- Modus tollens
+theorem modus_tollens (hpq : p -> q) (hnq : Not q) : Not p :=
+  fun hp => hnq (hpq hp)
+
+-- Non-contradiction
+theorem non_contradiction : Not (p /\ Not p) :=
+  fun h => h.right h.left
+
+-- ============================================================
+-- Equivalence (Iff)
+-- ============================================================
+
+-- Reflexivity of Iff
+theorem iff_refl : p <-> p :=
+  Iff.intro (fun hp => hp) (fun hp => hp)
+
+-- Symmetry of Iff
+theorem iff_symm (h : p <-> q) : q <-> p :=
+  Iff.intro h.mpr h.mp
+
+-- ============================================================
+-- De Morgan's laws
+-- ============================================================
+
+-- De Morgan 1 (constructive)
+theorem de_morgan_1 : Not (p \/ q) <-> Not p /\ Not q :=
+  Iff.intro
+    (fun h => And.intro (fun hp => h (Or.inl hp)) (fun hq => h (Or.inr hq)))
+    (fun h hpq => Or.elim hpq h.left h.right)
+
+-- De Morgan 2 (requires classical logic)
+open Classical in
+theorem de_morgan_2 : Not (p /\ q) <-> Not p \/ Not q :=
+  Iff.intro
+    (fun h => Or.elim (em p)
+      (fun hp => Or.inr (fun hq => h (And.intro hp hq)))
+      (fun hnp => Or.inl hnp))
+    (fun h hpq => Or.elim h
+      (fun hnp => hnp hpq.left)
+      (fun hnq => hnq hpq.right))

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/llm_assisted_proof_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/llm_assisted_proof_en.lean
@@ -1,0 +1,163 @@
+/-
+  Lean Examples - LLM Assisted Proofs (EN sibling)
+
+  This file contains examples of proofs that could be
+  generated or assisted by LLMs.
+  Corresponding to the Lean-7 and Lean-8 notebooks.
+
+  English sibling of llm_assisted_proof.lean (i18n #4980): docstrings and
+  comments translated to English; theorems, definitions, tactics, and
+  variables are byte-identical to the French original.
+-/
+
+-- ============================================================
+-- "LLM-style" proofs - clear and well-structured
+-- ============================================================
+
+/-
+  LLMs often generate proofs with:
+  1. Explanatory comments
+  2. Intermediate steps with 'have'
+  3. Explicit type annotations
+  4. A pedagogical style
+-/
+
+-- Example 1: Commutativity in LLM style
+theorem add_comm_llm_style (a b : Nat) : a + b = b + a := by
+  -- Use the commutativity lemma from the standard library
+  exact Nat.add_comm a b
+
+-- Example 2: Associativity with decomposition
+theorem add_assoc_llm_style (x y z : Nat) : (x + y) + z = x + (y + z) := by
+  -- This property is fundamental for arithmetic
+  -- It allows grouping additions in any order
+  exact Nat.add_assoc x y z
+
+-- Example 3: More detailed proof
+theorem distributivity_llm_style (a b c : Nat) : a * (b + c) = a * b + a * c := by
+  -- Distributivity of multiplication over addition
+  -- This is a characteristic property of rings
+  exact Nat.mul_add a b c
+
+-- ============================================================
+-- Step-by-step proofs (LeanCopilot style)
+-- ============================================================
+
+theorem step_by_step_proof (p q r : Prop)
+  (hpq : p -> q) (hqr : q -> r) (hp : p) : r := by
+  -- Step 1: Obtain q from p
+  have hq : q := hpq hp
+  -- Step 2: Obtain r from q
+  have hr : r := hqr hq
+  -- Step 3: Conclude
+  exact hr
+
+-- ============================================================
+-- Proofs with automatic tactics
+-- ============================================================
+
+-- LLMs often suggest using automatic tactics
+-- when they are appropriate
+
+theorem auto_omega (n m : Nat) (h : n < m) : n + 1 <= m := by
+  -- omega automatically solves linear arithmetic
+  omega
+
+theorem auto_simp (n : Nat) : n + 0 + 0 = n := by
+  -- simp automatically simplifies expressions
+  simp
+
+-- ============================================================
+-- Iteratively generated proofs
+-- ============================================================
+
+/-
+  Systems like AlphaProof and APOLLO generate proofs
+  by iteration:
+  1. Generate an attempt
+  2. Verify with Lean
+  3. If it fails, fix and retry
+-/
+
+-- Iteration 1 (potential failure) : sorry
+-- theorem iter1 (n : Nat) : n + 0 = n := by sorry
+
+-- Iteration 2 (correction) : rfl
+theorem iter2 (n : Nat) : n + 0 = n := by rfl
+
+-- Iteration 3 (alternative) : exact
+theorem iter3 (n : Nat) : n + 0 = n := by exact Nat.add_zero n
+
+-- ============================================================
+-- Decomposed proofs (Aristotle style)
+-- ============================================================
+
+-- Decomposing an equivalence into two implications
+theorem iff_decomposed (p q : Prop)
+  (hpq : p -> q) (hqp : q -> p) : p <-> q := by
+  -- Part 1: Direction p -> q
+  constructor
+  . -- Prove p -> q
+    exact hpq
+  . -- Part 2: Direction q -> p
+    exact hqp
+
+-- Decomposing a conjunction
+theorem and_decomposed (p q : Prop) (hp : p) (hq : q) : p /\ q := by
+  -- Build the conjunction from its parts
+  constructor
+  . -- Left part: p
+    exact hp
+  . -- Right part: q
+    exact hq
+
+-- ============================================================
+-- Examples of typical prompts and responses
+-- ============================================================
+
+/-
+  Prompt: "Prove that addition is commutative over Nat"
+  LLM response:
+-/
+theorem llm_response_example (a b : Nat) : a + b = b + a :=
+  Nat.add_comm a b
+
+/-
+  Prompt: "Prove that if p implies q and q implies r, then p implies r"
+  LLM response:
+-/
+theorem llm_transitivity (p q r : Prop) : (p -> q) -> (q -> r) -> (p -> r) :=
+  fun hpq hqr hp => hqr (hpq hp)
+
+/-
+  Prompt: "Prove that there exists a natural number greater than 100"
+  LLM response:
+-/
+theorem llm_exists_large : exists n : Nat, n > 100 :=
+  Exists.intro 101 (by decide)
+
+-- ============================================================
+-- Patterns for proof generation
+-- ============================================================
+
+-- Pattern 1: Direct proof with a lemma
+-- "Use lemma X to prove Y"
+theorem pattern_direct (n : Nat) : n * 1 = n := Nat.mul_one n
+
+-- Pattern 2: Proof by induction
+-- "Prove by induction on n"
+theorem pattern_induction (n : Nat) : 0 + n = n := by
+  induction n with
+  | zero => rfl
+  | succ k ih => simp [Nat.add_succ, ih]
+
+-- Pattern 3: Proof by cases
+-- "Case analysis on the disjunction"
+theorem pattern_cases (p q : Prop) (hpq : p \/ q) : q \/ p := by
+  cases hpq with
+  | inl hp => right; exact hp
+  | inr hq => left; exact hq
+
+-- Pattern 4: Proof by simplification
+-- "Simplify and conclude"
+theorem pattern_simp (n : Nat) : n + 0 = n := by simp

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/tactics_demo_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/tactics_demo_en.lean
@@ -1,0 +1,134 @@
+/-
+  Lean Examples - Tactics Mode (EN sibling)
+
+  This file demonstrates Lean's tactic mode
+  corresponding to the Lean-5 notebook.
+
+  English sibling of tactics_demo.lean (i18n #4980): docstrings and
+  comments translated to English; theorems, definitions, tactics, and
+  variables are byte-identical to the French original.
+-/
+
+-- ============================================================
+-- Basic tactics
+-- ============================================================
+
+-- exact : provide the exact term
+theorem exact_demo (p : Prop) (hp : p) : p := by
+  exact hp
+
+-- intro : introduce hypotheses
+theorem intro_demo (p q : Prop) : p -> q -> p := by
+  intro hp hq
+  exact hp
+
+-- apply : apply a lemma
+theorem apply_demo (p q r : Prop) (hpq : p -> q) (hqr : q -> r) (hp : p) : r := by
+  apply hqr
+  apply hpq
+  exact hp
+
+-- assumption : search the context
+theorem assumption_demo (p q : Prop) (hp : p) (hq : q) : p := by
+  assumption
+
+-- ============================================================
+-- Context management
+-- ============================================================
+
+-- have : intermediate lemma
+theorem have_demo (p q r : Prop) (hpq : p -> q) (hqr : q -> r) (hp : p) : r := by
+  have hq : q := hpq hp
+  have hr : r := hqr hq
+  exact hr
+
+-- show : annotate the goal
+theorem show_demo (p q : Prop) (hp : p) (hq : q) : q /\ p := by
+  constructor
+  show q
+  exact hq
+  show p
+  exact hp
+
+-- ============================================================
+-- Tactics for logic
+-- ============================================================
+
+-- constructor for And
+theorem and_tactic (p q : Prop) (hp : p) (hq : q) : p /\ q := by
+  constructor
+  . exact hp
+  . exact hq
+
+-- cases for Or
+theorem or_tactic (p q r : Prop) (hpq : p \/ q) (hpr : p -> r) (hqr : q -> r) : r := by
+  cases hpq with
+  | inl hp => exact hpr hp
+  | inr hq => exact hqr hq
+
+-- left and right for Or
+theorem left_right_demo (p q : Prop) (hp : p) : p \/ q := by
+  left
+  exact hp
+
+-- contradiction
+theorem contradiction_demo (p q : Prop) (hp : p) (hnp : Not p) : q := by
+  contradiction
+
+-- ============================================================
+-- Rewriting and simplification
+-- ============================================================
+
+-- rw : rewriting
+theorem rw_demo (a b c : Nat) (h : a = b) : a + c = b + c := by
+  rw [h]
+
+-- rw with multiple lemmas
+theorem rw_chain (a b c d : Nat) (h1 : a = b) (h2 : b = c) (h3 : c = d) : a = d := by
+  rw [h1, h2, h3]
+
+-- simp : automatic simplification
+theorem simp_demo (n : Nat) : n + 0 = n := by
+  simp
+
+-- simp with additional lemmas
+theorem simp_with (a b : Nat) (h : a = b) : a + 1 = b + 1 := by
+  simp [h]
+
+-- ============================================================
+-- Automatic tactics
+-- ============================================================
+
+-- omega : Presburger arithmetic
+theorem omega_demo (n m : Nat) (h : n < m) : n + 1 <= m := by
+  omega
+
+-- decide : decidable propositions
+theorem decide_demo : 3 < 5 := by
+  decide
+
+-- ============================================================
+-- Structuring proofs
+-- ============================================================
+
+-- Bullets for focusing
+theorem bullets_demo (p q r : Prop) (hp : p) (hq : q) (hr : r) : p /\ q /\ r := by
+  constructor
+  . exact hp
+  . constructor
+    . exact hq
+    . exact hr
+
+-- <;> to apply to all goals
+theorem all_goals_demo (p : Prop) (hp : p) : p /\ p := by
+  constructor <;> exact hp
+
+-- ============================================================
+-- Induction
+-- ============================================================
+
+-- Recurrence over Nat
+theorem induction_demo (n : Nat) : 0 + n = n := by
+  induction n with
+  | zero => rfl
+  | succ k ih => simp [Nat.add_succ, ih]


### PR DESCRIPTION
Grain: MED/content(i18n) — lane myia-po-2026:CoursIA — prev: MED/guard #10179. **R6 pivot** : après 2 cycles guard/detector (c.1015 #10176, c.1016 #10179), passage au genre Lean+i18n.

## Quoi

Trois siblings anglais dans `SymbolicAI/Lean/examples/` : `basic_logic_en.lean`, `tactics_demo_en.lean`, `llm_assisted_proof_en.lean`. Le dossier suivait déjà la convention sibling #4980 (`mathlib_examples_en`, `quantifiers_en` existaient) — ces 3 fichiers portent le dossier à **5/5 bilingue** (couverture complète).

## Convention

Docstrings et commentaires traduits en anglais ; théorèmes, définitions, tactiques, variables et termes de preuve **byte-identiques** à l'original français. Pas de suffixe de namespace (fichiers autonomes exécutés cellule par cellule via le kernel `lean4-wsl`, pas des modules lake).

## Preuve (firsthand, 2 axes par fichier)

**Axe 1 — invariant structurel** : contenu non-commentaire (docstrings + commentaires full-line ET trailing stripping) byte-identical FR↔EN.
```
basic_logic ↔ basic_logic_en       : 40 lignes de code identiques ✓
tactics_demo ↔ tactics_demo_en     : 58 lignes de code identiques ✓
llm_assisted_proof ↔ ..._en        : 46 lignes de code identiques ✓
```

**Axe 2 — comportement compilateur** : `lean <file>` produit des diagnostics **identiques** FR↔EN modulo l'offset de +4 lignes (header notice). Les erreurs standalone-compile (`and_comm already declared`, `simp failed`, etc.) sont des propriétés des originaux (design cellule-par-cellule kernel), fidèlement reproduites.

**llm_assisted_proof — note sorry** : le README annonçait « sorry count: 2 » mais firsthand, les 2 tokens `sorry` sont sur des lignes COMMENTÉES (L78 prose + L79 théorème commenté). **0 sorry actif** dans le FR comme dans l'EN. Le `sorry` du code commenté (L79) est gardé verbatim — c'est le mot-clé tactique Lean illustré, pas de la prose à traduire.

**EOL** : LF-only (git attr `text eol=lf`), UTF-8 no-BOM. Vérifié byte-level (Python `count(b'\r')=0`).

## Non inclus

Pas de toucher README : les siblings `_en` sont des miroirs transparents, non listés dans la table README (cohérent avec `quantifiers_en`/`mathlib_examples_en` non référencés).

See #4980 (epic i18n Lean, partial : dossier examples 2/5 → 5/5 bilingue, complet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
