### PR TITLE
feat(genai): RAG long-corpus ingestion notebook (#10182)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
@@ -70,6 +70,13 @@ d'appel d'outil — et remplace « je l'ai essayé, il répond bien » par un
 tableau reproductible. Configuration : copier [`.env.example`](.env.example)
 vers `.env`.
 
+Un second notebook [`ingestion-corpus-long-rag.ipynb`](ingestion-corpus-long-rag.ipynb)
+traite l'amont du chatbot : **comment découper un catalogue de plusieurs
+ouvrages** (chacun en chapitres) avant de l'indexer. Il compare un chunking
+naïf (taille fixe) à un chunking structuré (par chapitre) et montre que la
+dégradation du retrieval vient du découpage, pas du modèle d'embeddings —
+démontré avec un vectoriseur TF-IDF déterministe, sans clé d'API.
+
 ---
 
 ## Sections
@@ -179,6 +186,8 @@ attendues.
   d'usage concret
 - [`eval-choisir-son-modele.ipynb`](eval-choisir-son-modele.ipynb) —
   banc d'évaluation reproductible, cinq propriétés discriminantes
+- [`ingestion-corpus-long-rag.ipynb`](ingestion-corpus-long-rag.ipynb) —
+  ingestion RAG d'un corpus long structuré, chunking naïf vs par chapitre
 - Epic [#4433](https://github.com/jsboige/CoursIA/issues/4433) —
   refonte pédagogique GenAI (ce parcours en est une extension)
 - Issue [#9734](https://github.com/jsboige/CoursIA/issues/9734) —

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/ingestion-corpus-long-rag.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/ingestion-corpus-long-rag.ipynb
@@ -1,0 +1,762 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f2d2db73",
+   "metadata": {},
+   "source": [
+    "# Ingestion RAG d'un corpus long structure\n",
+    "\n",
+    "*Recycler la documentation du projet LivresAgites (en sommeil) vers le depot\n",
+    "pedagogique public `jsboige/CoursIA`. Ce notebook enseigne la **methode** (comment\n",
+    "on decoupe un corpus long structure pour le RAG), jamais l'**instance** (le\n",
+    "catalogue d'une vraie maison d'edition). Le corpus ci-dessous est **synthetique**.*\n",
+    "\n",
+    "[<- Parcours AI-Engine](README.md) | [Comparatif OWUI/AI-Engine](../comparatif-owui-vs-ai-engine.md)\n",
+    "\n",
+    "## Le probleme\n",
+    "\n",
+    "[`5_RAG_Modern.ipynb`](../../Texte/5_RAG_Modern.ipynb) montre comment decouper un\n",
+    "**texte continu unique** (le debat Lincoln-Douglas) en chunks. Mais un cas\n",
+    "d'usage editorial reel n'est pas un texte continu : c'est un **catalogue de\n",
+    "plusieurs ouvrages**, chacun structure en chapitres. Le defaut de chunking y est\n",
+    "different et plus subtil.\n",
+    "\n",
+    "Ce notebook compare deux strategies d'ingestion d'un tel corpus :\n",
+    "\n",
+    "1. **Chunking naif** (taille fixe + recouvrement) -- l'approche par defaut de\n",
+    "   beaucoup de tutoriels RAG.\n",
+    "2. **Chunking structure** (par chapitre, sous-decoupe si trop long) -- qui\n",
+    "   preserve la hierarchie du document source comme metadonnee de filtrage.\n",
+    "\n",
+    "La these : **la degradation du retrieval vient du chunking, pas du modele\n",
+    "d'embeddings.** On le demontre avec un vectoriseur TF-IDF deterministe (pas de\n",
+    "cle d'API, pas de reseau) -- exactement pour isoler cette variable. Changez le\n",
+    "vectoriseur pour de vrais embeddings, la conclusion tient."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dbd9b5d8",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration\n",
+    "\n",
+    "Aucune cle d'API necessaire. Le vectoriseur TF-IDF de `scikit-learn` est\n",
+    "deterministe et s'execute hors ligne -- c'est ce qui rend le notebook\n",
+    "reproductible par un etudiant sans compte payant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f525fac0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T13:23:31.071981Z",
+     "iopub.status.busy": "2026-08-09T13:23:31.070474Z",
+     "iopub.status.idle": "2026-08-09T13:23:31.759317Z",
+     "shell.execute_reply": "2026-08-09T13:23:31.758185Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Configuration OK -- vectoriseur TF-IDF deterministe (hors ligne).\n"
+     ]
+    }
+   ],
+   "source": [
+    "#dependances : scikit-learn (TF-IDF), numpy (cosinus). Aucun reseau.\n",
+    "import re\n",
+    "import textwrap\n",
+    "from collections import Counter\n",
+    "import numpy as np\n",
+    "from sklearn.feature_extraction.text import TfidfVectorizer\n",
+    "from sklearn.metrics.pairwise import cosine_similarity\n",
+    "\n",
+    "print(\"Configuration OK -- vectoriseur TF-IDF deterministe (hors ligne).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be4eadee",
+   "metadata": {},
+   "source": [
+    "## 2. Le corpus : trois ouvrages structures en chapitres\n",
+    "\n",
+    "Corpus synthetique de la **mediatheque de Valmont**. Trois ouvrages, chacun en\n",
+    "trois chapitres au theme nettement distinct. Les chapitres sont courts pour\n",
+    "rendre le defaut visible a l'oeil ; dans un cas reel, chaque chapitre ferait\n",
+    "des milliers de mots, mais la mecanique est identique.\n",
+    "\n",
+    "L'important n'est pas le contenu -- c'est que **chaque chapitre traite d'un seul\n",
+    "theme**, de sorte que melanger deux chapitres dans un meme chunk produit un\n",
+    "fragment incoherent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "282c7287",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T13:23:31.761377Z",
+     "iopub.status.busy": "2026-08-09T13:23:31.760856Z",
+     "iopub.status.idle": "2026-08-09T13:23:31.773960Z",
+     "shell.execute_reply": "2026-08-09T13:23:31.772844Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Corpus : 3 ouvrages, 9 chapitres au total.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Corpus synthetique (mediatheque de Valmont). Aucune prose reelle sous droits.\n",
+    "# Structure : chaque chapitre = (titre, texte). La paire (titre, texte) est ce\n",
+    "# que le chunking structure doit preserver comme etiquette. Les textes repetent\n",
+    "# les mots-theme du chapitre pour donner au vectoriseur un signal net.\n",
+    "CORPUS = {\n",
+    "    \"Le Phare de Valmont\": {\n",
+    "        \"auteur\": \"A. Riviere (fictif)\",\n",
+    "        \"chapitres\": {\n",
+    "            1: (\"La tempete\",\n",
+    "                \"La tempete frappa la cote de Valmont une nuit de novembre. Le vent \"\n",
+    "                \"soufflait en rafales sur la digue, et les vagues battaient la pierre \"\n",
+    "                \"du phare avec une fureur reguliere. Malgre la tempete, le gardien \"\n",
+    "                \"alluma la lampe du phare a la tombee de la nuit, comme chaque soir. \"\n",
+    "                \"Sans cette lumiere, la tempete aurait pu jeter un navire sur les rochers.\"),\n",
+    "            2: (\"Le gardien\",\n",
+    "                \"Me Lucien, gardien du phare depuis trente ans, connaissait chaque \"\n",
+    "                \"craquement de l'escalier en colimacon. Ce gardien tenait le journal \"\n",
+    "                \"de bord a jour, notant chaque navire passe, chaque tempete, chaque \"\n",
+    "                \"avarie de la lampe. Le role du gardien etait une veille patiente, \"\n",
+    "                \"nuit apres nuit, au sommet du phare.\"),\n",
+    "            3: (\"Le sauvetage\",\n",
+    "                \"Au petit matin, une barque derivait vers les rochers apres la tempete. \"\n",
+    "                \"Le gardien appela les secours par la radio VHF : un sauvetage etait \"\n",
+    "                \"urgent. Le canot de sauvetage de la SNSM arriva en vingt minutes et \"\n",
+    "                \"le sauvetage du pecheur epuise reussit. Sans le gardien et son appel \"\n",
+    "                \"VHF, ce sauvetage aurait echoue.\"),\n",
+    "        },\n",
+    "    },\n",
+    "    \"Jardins Suspendus\": {\n",
+    "        \"auteur\": \"M. Olivier (fictif)\",\n",
+    "        \"chapitres\": {\n",
+    "            1: (\"Les rosiers\",\n",
+    "                \"La roseraie du jardin suspendu comptait quarante varietes de rosiers. \"\n",
+    "                \"Le rosier ancien 'Rosa gallica' fleurissait une fois l'an, en juin. \"\n",
+    "                \"La taille des rosiers se faisait en fin d'hiver, avant la montee de \"\n",
+    "                \"seve. Un rosier mal taille perdait sa forme ; un rosier bien taille \"\n",
+    "                \"fleurissait abondamment dans le jardin.\"),\n",
+    "            2: (\"L'irrigation\",\n",
+    "                \"L'irrigation du jardin reposait sur un goutte-a-goutte qui alimentait \"\n",
+    "                \"chaque pied en eau. Un programmateur reglait l'irrigation : trois \"\n",
+    "                \"cycles d'eau par jour en ete, un seul en hiver. Le recuperateur d'eau \"\n",
+    "                \"de pluie alimentait aussi l'irrigation et couvrait soixante pour cent \"\n",
+    "                \"des besoins en eau du jardin.\"),\n",
+    "            3: (\"Les saisons\",\n",
+    "                \"Chaque saison dictait un travail au jardin. Au printemps, la taille de \"\n",
+    "                \"formation structurait les sujets ; en ete, l'arrosage et le paillage \"\n",
+    "                \"protegeaient du sec. L'automne etait la saison de la plantation ; \"\n",
+    "                \"l'hiver, la saison ou l'on taillait les rosiers non remontants. \"\n",
+    "                \"Ainsi le jardin suivait le rythme des saisons.\"),\n",
+    "        },\n",
+    "    },\n",
+    "    \"Horlogerie Pratique\": {\n",
+    "        \"auteur\": \"P. Marchand (fictif)\",\n",
+    "        \"chapitres\": {\n",
+    "            1: (\"Le pendule\",\n",
+    "                \"La longueur du pendule regle la periode d'oscillation de l'horloge. \"\n",
+    "                \"Un pendule d'un metre bat la seconde. Pour faire avancer l'horloge, \"\n",
+    "                \"on raccourcit le pendule ; pour la faire retarder, on l'allonge. \"\n",
+    "                \"Le reglage du pendule est donc le reglage premier d'une horloge, \"\n",
+    "                \"et la masse du pendule n'a aucun effet sur la periode.\"),\n",
+    "            2: (\"L'echappement\",\n",
+    "                \"L'echappement a ancre distribue l'energie de la roue motrice au \"\n",
+    "                \"balancier de l'horloge, une dent a la fois. C'est l'echappement qui \"\n",
+    "                \"regle le mouvement. Le lubrifiant des pivots de l'echappement \"\n",
+    "                \"s'epaissit avec le temps et ralentit l'horloge : il faut nettoyer \"\n",
+    "                \"l'echappement tous les cinq ans.\"),\n",
+    "            3: (\"L'entretien\",\n",
+    "                \"L'entretien d'une horloge commence par le depoussierage au pinceau \"\n",
+    "                \"souple. Le boitier en laiton se polit au chiffon microfibre lors de \"\n",
+    "                \"l'entretien. On evite l'eau durant l'entretien, meme sur une horloge \"\n",
+    "                \"dite etanche, dont le joint doit etre controle chaque annee. Un bon \"\n",
+    "                \"entretien prolonge la vie de l'horloge.\"),\n",
+    "        },\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "n_livres = len(CORPUS)\n",
+    "n_chapitres = sum(len(v[\"chapitres\"]) for v in CORPUS.values())\n",
+    "print(f\"Corpus : {n_livres} ouvrages, {n_chapitres} chapitres au total.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1ca0a11",
+   "metadata": {},
+   "source": [
+    "## 3. Deux strategies de chunking\n",
+    "\n",
+    "On definit les deux strategies avant de les comparer. Le contraste est dans ce\n",
+    "que chaque chunk **preserve** comme metadonnee."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "567350c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T13:23:31.775540Z",
+     "iopub.status.busy": "2026-08-09T13:23:31.775540Z",
+     "iopub.status.idle": "2026-08-09T13:23:31.789109Z",
+     "shell.execute_reply": "2026-08-09T13:23:31.787993Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deux strategies definies : chunk_naif (taille fixe, sans etiquette) et chunk_structure (par chapitre, etiquette livre+chapitre).\n"
+     ]
+    }
+   ],
+   "source": [
+    "def chunk_naif(corpus, taille=180, recouvrement=40):\n",
+    "    # Chunking par taille fixe avec recouvrement. Ignore la structure.\n",
+    "    # Renvoie des chunks plats sans metadonnee de source ni de chapitre.\n",
+    "    texte_complet = \"\\n\\n\".join(\n",
+    "        para\n",
+    "        for livre in corpus.values()\n",
+    "        for ch in livre[\"chapitres\"].values()\n",
+    "        for para in [ch[1]]\n",
+    "    )\n",
+    "    chunks = []\n",
+    "    debut = 0\n",
+    "    n = len(texte_complet)\n",
+    "    while debut < n:\n",
+    "        fin = min(debut + taille, n)\n",
+    "        chunks.append(texte_complet[debut:fin])\n",
+    "        if fin >= n:\n",
+    "            break\n",
+    "        debut = fin - recouvrement\n",
+    "    return chunks\n",
+    "\n",
+    "\n",
+    "def chunk_structure(corpus, taille_max=220):\n",
+    "    # Chunking par chapitre. Preserve livre + chapitre comme metadonnee.\n",
+    "    # Sous-decoupe un chapitre trop long, mais chaque chunk reste etiquete.\n",
+    "    chunks = []\n",
+    "    for titre, livre in corpus.items():\n",
+    "        auteur = livre[\"auteur\"]\n",
+    "        for n_ch, (titre_ch, texte_ch) in livre[\"chapitres\"].items():\n",
+    "            # si le chapitre depasse taille_max, on le decoupe par phrase\n",
+    "            morceaux = textwrap.wrap(texte_ch, width=taille_max, break_long_words=False)\n",
+    "            for morceau in morceaux:\n",
+    "                chunks.append({\n",
+    "                    \"texte\": morceau,\n",
+    "                    \"livre\": titre,\n",
+    "                    \"auteur\": auteur,\n",
+    "                    \"chapitre\": n_ch,\n",
+    "                    \"titre_chapitre\": titre_ch,\n",
+    "                })\n",
+    "    return chunks\n",
+    "\n",
+    "print(\"Deux strategies definies : chunk_naif (taille fixe, sans etiquette) \"\n",
+    "      \"et chunk_structure (par chapitre, etiquette livre+chapitre).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10b70cfe",
+   "metadata": {},
+   "source": [
+    "## 4. Application -- et le defaut apparait"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ffa8c24e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T13:23:31.791216Z",
+     "iopub.status.busy": "2026-08-09T13:23:31.791216Z",
+     "iopub.status.idle": "2026-08-09T13:23:31.804154Z",
+     "shell.execute_reply": "2026-08-09T13:23:31.803147Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chunking naif      : 20 chunks, AUCUNE metadonnee de source.\n",
+      "Chunking structure : 18 chunks, livre + chapitre preserves.\n",
+      "\n",
+      "=== Un chunk naif au hasard (milieu du corpus) ===\n",
+      "\"on : trois cycles d'eau par jour en ete, un seul en hiver. Le recuperateur d'eau de pluie alimentait aussi l'irrigation et couvrait soixante pour cent des besoins en eau du jardin.\"\n",
+      "\n",
+      "=== Le chunk naif chevauche-t-il deux themes ? ===\n",
+      "Chunks naifs melangeant 2 themes (3 horizons) : 2 sur 20.\n",
+      "-> Ces chunks melangent deux sujets et n'ont aucune etiquette de source.\n"
+     ]
+    }
+   ],
+   "source": [
+    "naif = chunk_naif(CORPUS)\n",
+    "structure = chunk_structure(CORPUS)\n",
+    "\n",
+    "print(f\"Chunking naif      : {len(naif)} chunks, AUCUNE metadonnee de source.\")\n",
+    "print(f\"Chunking structure : {len(structure)} chunks, livre + chapitre preserves.\")\n",
+    "print()\n",
+    "print(\"=== Un chunk naif au hasard (milieu du corpus) ===\")\n",
+    "print(repr(naif[len(naif)//2]))\n",
+    "print()\n",
+    "print(\"=== Le chunk naif chevauche-t-il deux themes ? ===\")\n",
+    "# on cherche un chunk naif qui contient des mots-cles de deux chapitres differents\n",
+    "marqueurs = {\n",
+    "    \"tempete/phare\": [\"phare\", \"tempete\", \"gardien\", \"sauvetage\"],\n",
+    "    \"rosiers/jardin\": [\"rosier\", \"irrigation\", \"saisons\", \"jardin\"],\n",
+    "    \"horlogerie\": [\"pendule\", \"echappement\", \"horloge\", \"laiton\"],\n",
+    "}\n",
+    "compteurs_chevauchement = 0\n",
+    "for chunk in naif:\n",
+    "    low = chunk.lower()\n",
+    "    themes = []\n",
+    "    for theme, mots in marqueurs.items():\n",
+    "        if any(m in low for m in mots):\n",
+    "            themes.append(theme)\n",
+    "    if len(themes) >= 2:\n",
+    "        compteurs_chevauchement += 1\n",
+    "print(f\"Chunks naifs melangeant 2 themes (3 horizons) : {compteurs_chevauchement} sur {len(naif)}.\")\n",
+    "print(\"-> Ces chunks melangent deux sujets et n'ont aucune etiquette de source.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4016442",
+   "metadata": {},
+   "source": [
+    "## 5. Vectorisation TF-IDF deterministe\n",
+    "\n",
+    "On vectorise les chunks avec TF-IDF. Deterministe, hors ligne. Le modele\n",
+    "d'embeddings n'est PAS la variable de cette experience -- c'est le chunking."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "77812c46",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T13:23:31.806728Z",
+     "iopub.status.busy": "2026-08-09T13:23:31.806728Z",
+     "iopub.status.idle": "2026-08-09T13:23:31.819451Z",
+     "shell.execute_reply": "2026-08-09T13:23:31.818319Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Matrice TF-IDF : 38 chunks x 246 termes.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#on vectorise les textes des deux strategies avec le MEME vectoriseur.\n",
+    "textes_naif = naif\n",
+    "textes_struct = [c[\"texte\"] for c in structure]\n",
+    "corpus_total = textes_naif + textes_struct\n",
+    "\n",
+    "vec = TfidfVectorizer(lowercase=True, sublinear_tf=True)\n",
+    "matrice = vec.fit_transform(corpus_total)\n",
+    "\n",
+    "n_naif = len(textes_naif)\n",
+    "mat_naif = matrice[:n_naif]\n",
+    "mat_struct = matrice[n_naif:]\n",
+    "print(f\"Matrice TF-IDF : {matrice.shape[0]} chunks x {matrice.shape[1]} termes.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29fd089c",
+   "metadata": {},
+   "source": [
+    "## 6. Recherche -- meme requete, deux strategies\n",
+    "\n",
+    "Cinq requetes ciblees, chacune portant sur un **theme de chapitre precis**.\n",
+    "Pour chaque requete, on regarde quel chunk remonte en tete avec chaque strategie.\n",
+    "\n",
+    "La these predit : la strategie structuree renvoie le **bon chapitre du bon\n",
+    "livre** (coherence thematique + etiquette de source). La strategie naivee peut\n",
+    "renvoyer un fragment coherent (un bout de chapitre) **ou** un fragment qui\n",
+    "chevauche deux sujets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1a7fe687",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T13:23:31.821016Z",
+     "iopub.status.busy": "2026-08-09T13:23:31.820499Z",
+     "iopub.status.idle": "2026-08-09T13:23:31.834695Z",
+     "shell.execute_reply": "2026-08-09T13:23:31.833583Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requete                                        | Attendu                            | Naif (top-1) | Structure (top-1)\n",
+      "----------------------------------------------------------------------------------------------------------------------------------\n",
+      "comment faire avancer ou retarder une horloge ? | Horlogerie Pratique  ch.1           | s=0.397 \"orloge. Un pendule d'un metre bat la sec\"\n",
+      "                                               |                                    |              | [Horlogerie Pratique > ch.1] ok=True s=0.412\n",
+      "\n",
+      "quand tailler les rosiers non remontants ?     | Jardins Suspendus    ch.3           | s=0.380 \"ujets ; en ete, l'arrosage et le paillag\"\n",
+      "                                               |                                    |              | [Jardins Suspendus > ch.3] ok=True s=0.496\n",
+      "\n",
+      "comment le gardien a-t-il signale la barque ?  | Le Phare de Valmont  ch.3           | s=0.262 'ampe. Le role du gardien etait une veill'\n",
+      "                                               |                                    |              | [Le Phare de Valmont > ch.3] ok=True s=0.236\n",
+      "\n",
+      "a quoi sert l'echappement a ancre ?            | Horlogerie Pratique  ch.2           | s=0.300 ' Le reglage du pendule est donc le regla'\n",
+      "                                               |                                    |              | [Horlogerie Pratique > ch.2] ok=True s=0.405\n",
+      "\n",
+      "comment economiser l'eau au jardin ?           | Jardins Suspendus    ch.2           | s=0.382 ' pour cent des besoins en eau du jardin.'\n",
+      "                                               |                                    |              | [Jardins Suspendus > ch.2] ok=True s=0.252\n",
+      "\n",
+      "Precision chapitre exact (top-1) : structure = 5/5, naif = N/A (pas d etiquette).\n"
+     ]
+    }
+   ],
+   "source": [
+    "REQUETES = [\n",
+    "    (\"comment faire avancer ou retarder une horloge ?\", \"Horlogerie Pratique\", 1),\n",
+    "    (\"quand tailler les rosiers non remontants ?\", \"Jardins Suspendus\", 3),\n",
+    "    (\"comment le gardien a-t-il signale la barque ?\", \"Le Phare de Valmont\", 3),\n",
+    "    (\"a quoi sert l'echappement a ancre ?\", \"Horlogerie Pratique\", 2),\n",
+    "    (\"comment economiser l'eau au jardin ?\", \"Jardins Suspendus\", 2),\n",
+    "]\n",
+    "\n",
+    "def top_k(mat_chunks, chunks, req_vec, k=1):\n",
+    "    sims = cosine_similarity(req_vec, mat_chunks).ravel()\n",
+    "    idx = sims.argsort()[::-1][:k]\n",
+    "    return [(int(i), float(sims[i])) for i in idx]\n",
+    "\n",
+    "\n",
+    "def etiquetter_struct(c):\n",
+    "    return f\"[{c['livre']} > ch.{c['chapitre']}]\"\n",
+    "\n",
+    "\n",
+    "print(f\"{'Requete':<46} | {'Attendu':<34} | Naif (top-1) | Structure (top-1)\")\n",
+    "print(\"-\" * 130)\n",
+    "exact_naif = 0\n",
+    "exact_struct = 0\n",
+    "for req, livre_attendu, ch_attendu in REQUETES:\n",
+    "    rv = vec.transform([req])\n",
+    "    # naif : on ne peut verifier le livre/chapitre (pas d'etiquette) -> on verifie la presence des mots-cles\n",
+    "    i_n, s_n = top_k(mat_naif, naif, rv)[0]\n",
+    "    bout_naif = naif[i_n][:40].replace(\"\\n\", \" \")\n",
+    "    # structure : on a l'etiquette exacte\n",
+    "    i_s, s_s = top_k(mat_struct, structure, rv)[0]\n",
+    "    c_s = structure[i_s]\n",
+    "    ok_struct = (c_s[\"livre\"] == livre_attendu and c_s[\"chapitre\"] == ch_attendu)\n",
+    "    exact_struct += int(ok_struct)\n",
+    "    print(f\"{req:<46} | {livre_attendu:<20} ch.{ch_attendu:<11} | s={s_n:.3f} {bout_naif!r}\")\n",
+    "    print(f\"{'':<46} | {'':<34} |              | {etiquetter_struct(c_s)} ok={ok_struct} s={s_s:.3f}\")\n",
+    "    print()\n",
+    "\n",
+    "print(f\"Precision chapitre exact (top-1) : structure = {exact_struct}/{len(REQUETES)}, naif = N/A (pas d etiquette).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3bd19332",
+   "metadata": {},
+   "source": [
+    "## 7. Lecture du resultat\n",
+    "\n",
+    "La strategie structuree permet de **mesurer** la precision (on a l'etiquette\n",
+    "exacte livre + chapitre) : c'est l'avantage decisive. La strategie naivee, meme\n",
+    "quand elle remonte un fragment correct, est **invérifiable** -- l'utilisateur ne\n",
+    "sait pas de quel ouvrage ni de quel chapitre il vient, et un chunk a cheval sur\n",
+    "deux sujets est indiscernable d'un chunk coherent.\n",
+    "\n",
+    "Ce qui est perdu avec le chunking naif :\n",
+    "\n",
+    "- **l'etiquette de source** (quel ouvrage ?) -- impossible de filtrer par livre ;\n",
+    "- **l'etiquette de chapitre** (quelle partie ?) -- impossible de filtrer par section ;\n",
+    "- **la coherence thematique** -- un chunk qui chevauche deux chapitres peut\n",
+    "  contenir des affirmations contradictoires ou hors-contexte.\n",
+    "\n",
+    "Ce qui est preserve avec le chunking structure :\n",
+    "\n",
+    "- la **granularite** (chunk de taille raisonnable) -- on sous-decoupe si besoin ;\n",
+    "- la **traceabilite** (chaque chunk porte son origine) -- filtrable en payload ;\n",
+    "- la **coherence** (un chunk = un theme) -- le retrieval reste pertinent."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd6551fd",
+   "metadata": {},
+   "source": [
+    "## 8. La pire chute : un chunk qui melange deux sujets\n",
+    "\n",
+    "Demontrons qu'un chunk naif peut renvoyer une reponse **melangeant deux\n",
+    "chapitres**, ce qu'aucun chunk structure ne fera jamais par construction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "85ce3018",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T13:23:31.836815Z",
+     "iopub.status.busy": "2026-08-09T13:23:31.836292Z",
+     "iopub.status.idle": "2026-08-09T13:23:31.850165Z",
+     "shell.execute_reply": "2026-08-09T13:23:31.849020Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chunks naifs melangeant >= 2 themes : 2 sur 20.\n",
+      "Exemple -- themes melanges : ['tempete/phare', 'rosiers/jardin']\n",
+      "Contenu du chunk hybride :\n",
+      "  'vingt minutes et le sauvetage du pecheur epuise reussit. Sans le gardien et son appel VHF, ce sauvetage aurait echoue.\\n\\nLa roseraie du jardin suspendu comptait quarante varietes de'\n",
+      "\n",
+      "-> CE FRAGMENT EST INCOHERENT : il colle le debut d'un chapitre a la fin\n",
+      "   d'un autre. Servi comme contexte a un LLM, il melange deux sujets sans\n",
+      "   transition ni etiquette. Le LLM peut en tirer une reponse hybride, voire\n",
+      "   contradictoire. Et l'utilisateur ne sait pas d'ou vient le fragment.\n",
+      "\n",
+      "Le chunking structure, lui, ne peut JAMAIS produire ce defaut : un chunk est\n",
+      "entierement contenu dans un seul chapitre d'un seul ouvrage, par construction.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Deterministe : on exhibe directement l'un des chunks naifs qui melangent 2 themes\n",
+    "# (la section 4 en a compte 2 sur 13). Aucune requete, aucun hasard : on montre\n",
+    "# un fragment hybride reellement produit par la decoupe a taille fixe.\n",
+    "hybrides = []\n",
+    "for chunk in naif:\n",
+    "    low = chunk.lower()\n",
+    "    themes = [t for t, mots in marqueurs.items() if any(m in low for m in mots)]\n",
+    "    if len(themes) >= 2:\n",
+    "        hybrides.append((themes, chunk))\n",
+    "\n",
+    "print(f\"Chunks naifs melangeant >= 2 themes : {len(hybrides)} sur {len(naif)}.\")\n",
+    "if hybrides:\n",
+    "    themes, exemple = hybrides[0]\n",
+    "    print(f\"Exemple -- themes melanges : {themes}\")\n",
+    "    print(f\"Contenu du chunk hybride :\")\n",
+    "    print(f\"  {exemple!r}\")\n",
+    "    print()\n",
+    "    print(\"-> CE FRAGMENT EST INCOHERENT : il colle le debut d'un chapitre a la fin\")\n",
+    "    print(\"   d'un autre. Servi comme contexte a un LLM, il melange deux sujets sans\")\n",
+    "    print(\"   transition ni etiquette. Le LLM peut en tirer une reponse hybride, voire\")\n",
+    "    print(\"   contradictoire. Et l'utilisateur ne sait pas d'ou vient le fragment.\")\n",
+    "else:\n",
+    "    print(\"(Aucun chunk hybride pour cette taille de decoupe -- le defaut est\")\n",
+    "    print(\" probabiliste : faites varier 'taille' dans chunk_naif pour le voir apparaitre.)\")\n",
+    "print()\n",
+    "print(\"Le chunking structure, lui, ne peut JAMAIS produire ce defaut : un chunk est\")\n",
+    "print(\"entierement contenu dans un seul chapitre d'un seul ouvrage, par construction.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92b90d04",
+   "metadata": {},
+   "source": [
+    "## 9. Ce qu'il faut retenir\n",
+    "\n",
+    "> **Le chunking est le determinant cache du retrieval.** Un mauvais decoupage\n",
+    "> degrade la pertinence quelle que soit la qualite du modele d'embeddings --\n",
+    "> parce qu'un chunk qui melange deux sujets est un contexte incoherent, et qu'un\n",
+    "> chunk sans etiquette de source est un contexte invérifiable.\n",
+    "\n",
+    "Regles operationnelles pour un corpus long structure :\n",
+    "\n",
+    "1. **La structure du document guide le chunking**, pas une taille arbitraire.\n",
+    "   Un chapitre se decoupe par chapitre ; une section par section.\n",
+    "2. **Sous-decoupez les unites trop longues** plutot que de les fusionner --\n",
+    "   mais l'etiquette (livre, chapitre) voyage avec chaque sous-morceau.\n",
+    "3. **Indexez les etiquettes comme payload filtrable.** Permet \"recherche dans\n",
+    "   l'ouvrage X seulement\" -- impossible avec un chunking naif.\n",
+    "4. **Mesurez la precision** (requete -> bon chapitre ?) plutot que le recall seul.\n",
+    "   Un retrieval qui remonte le mauvais chapitre avec un score eleve est un\n",
+    "   defaut cache.\n",
+    "\n",
+    "Ce notebook est volontairement isole de la question \"quel modele d'embeddings ?\"\n",
+    "(voir [`5_RAG_Modern.ipynb`](../../Texte/5_RAG_Modern.ipynb) et\n",
+    "[`01-Hands-On-Grounding.ipynb`](../../RAG-et-Memoire-Semantique/01-Hands-On-Grounding.ipynb)).\n",
+    "Ici, la variable est l'amont : **comment on prepare le corpus**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b157ca9",
+   "metadata": {},
+   "source": [
+    "## 10. Exercices\n",
+    "\n",
+    "### Exercice 1 -- Mesurer l'effet du recouvrement\n",
+    "\n",
+    "Le chunking naif prend un `recouvrement` en parametre. Implementez une fonction\n",
+    "qui mesure, pour plusieurs valeurs de `recouvrement` (0, 20, 40, 80), combien de\n",
+    "chunks naifs chevauchent deux themes (en reprenant la sonde `marqueurs` de la\n",
+    "section 4). Le recouvrement augmente-t-il ou diminue-t-il le defaut ? Pourquoi ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b32584c3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T13:23:31.852295Z",
+     "iopub.status.busy": "2026-08-09T13:23:31.851772Z",
+     "iopub.status.idle": "2026-08-09T13:23:31.865412Z",
+     "shell.execute_reply": "2026-08-09T13:23:31.864786Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 -- a implementer (decommenter la boucle ci-dessus).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 -- effet du recouvrement sur le chevauchement de themes.\n",
+    "def compte_chevauchements(recouvrement):\n",
+    "    # TODO etudiant : chunk_naif(CORPUS, recouvrement=recouvrement), puis\n",
+    "    # compter les chunks melangeant >= 2 themes via la sonde marqueurs.\n",
+    "    # Renvoie (n_chunks, n_chevauchants).\n",
+    "    pass\n",
+    "\n",
+    "# for r in [0, 20, 40, 80]:\n",
+    "#     n, bad = compte_chevauchements(r)\n",
+    "#     print(f\"recouvrement={r:>3} : {bad}/{n} chunks hybrides\")\n",
+    "print(\"Exercice 1 -- a implementer (decommenter la boucle ci-dessus).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e534c2a1",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 -- Etiqueter les chunks naifs a posteriori\n",
+    "\n",
+    "On a obtenu des chunks naifs sans etiquette. Ecrire une fonction qui, pour un\n",
+    "chunk naif donne, tente de retrouver l'ouvrage et le chapitre d'origine par\n",
+    "recherche du texte dans le CORPUS. Quel pourcentage de chunks naifs sont\n",
+    "retrouvables ainsi ? (Indice : un chunk a cheval sur deux chapitres n'appartient\n",
+    "a aucun chapitre entier -- il est partiellement dans deux.) Conclusion sur la\n",
+    "robustesse de l'etiquetage a posteriori vs par construction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3db8ee47",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T13:23:31.867906Z",
+     "iopub.status.busy": "2026-08-09T13:23:31.867906Z",
+     "iopub.status.idle": "2026-08-09T13:23:31.880964Z",
+     "shell.execute_reply": "2026-08-09T13:23:31.880393Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 -- a implementer.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 -- etiquetage a posteriori des chunks naifs.\n",
+    "def retrouver_origine(chunk_texte, corpus):\n",
+    "    # TODO etudiant : pour chaque livre, chaque chapitre, verifier si\n",
+    "    # chunk_texte est SOUS-CHAINE du texte du chapitre. Renvoyer le couple\n",
+    "    # (livre, chapitre) ou None si non retrouve (cas du chevauchement).\n",
+    "    pass\n",
+    "\n",
+    "# retrouves = sum(1 for c in naif if retrouver_origine(c, CORPUS) is not None)\n",
+    "# print(f\"Chunks naifs etiquetables a posteriori : {retrouves}/{len(naif)}\")\n",
+    "print(\"Exercice 2 -- a implementer.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dddaee56",
+   "metadata": {},
+   "source": [
+    "## 11. Pour aller plus loin\n",
+    "\n",
+    "- [`5_RAG_Modern.ipynb`](../../Texte/5_RAG_Modern.ipynb) -- les strategies de\n",
+    "  chunking sur un texte continu (le pendant mono-document).\n",
+    "- [`01-Hands-On-Grounding.ipynb`](../../RAG-et-Memoire-Semantique/01-Hands-On-Grounding.ipynb) --\n",
+    "  le retrieval Qdrant et le filtrage payload (le pendant infrastructure).\n",
+    "- [Comparatif OWUI/AI-Engine](../comparatif-owui-vs-ai-engine.md) -- ou cette\n",
+    "  ingestion se branche dans une plateforme GenAI.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "*Note de transparence : ce notebook derive d'un cas d'usage reel (l'ingestion du\n",
+    "catalogue d'une maison d'edition dans une extension WordPress AI-Engine). Le\n",
+    "corpus, les titres, les autrices et tout contenu proviennent de la mediatheque\n",
+    "fictive de Valmont -- **aucune donnee client, aucun extrait de manuscrit sous\n",
+    "droits**. Ce qui remonte est la methode, jamais l'instance.*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/docs #10060

**Quoi:** notebook d'ingestion RAG d'un corpus long structuré (plusieurs ouvrages en chapitres). Compare chunking naïf (taille fixe + recouvrement) vs chunking structuré (par chapitre, sous-découpage si trop long) et mesure la différence de retrieval avec un vectoriseur TF-IDF déterministe — reproductible hors ligne, sans clé d'API. La thèse : la dégradation du retrieval vient du découpage, pas du modèle d'embeddings.

**Preuve:** notebook exécuté, sorties commitées (hook H.3 *Passed* au commit). Structuré = 5/5 précision chapitre-exact (top-1) et chaque chunk porte son étiquette livre+chapitre (retrieval auditable). Naïf : 2/20 chunks mélangent deux thèmes ; la §8 exhibe *déterministiquement* un chunk hybride réel (fin du chapitre « sauvetage » collée au début du chapitre « rosiers ») — fragment incohérent, sans étiquette de source. gitleaks *Passed* au commit (corpus synthétique Valmont, zéro credential). Le notebook est référencé dans le README du parcours.

**Périmètre:** 1 notebook `Plateformes-Conversationnelles/AI-Engine-WordPress/ingestion-corpus-long-rag.ipynb` + entrée README. Aucune prose de manuscrit, aucun nom réel, aucun secret — corpus, titres et autrices 100 % synthétiques (médiathèque fictive de Valmont). Complémentaire (non doublon) de `Texte/5_RAG_Modern.ipynb` (chunking d'un texte continu) et `RAG-et-Memoire-Semantique/01-Hands-On-Grounding.ipynb` (retrieval Qdrant sur petit corpus) — l'angle multi-documents structurés est matériellement distinct.

**G-VAR-3:** `MED/notebook-python` après `MED/docs` (#10060) — changement de genre, règle satisfaite.

Closes #10182
