### PR TITLE
fix(gametheory,#4365): point 15b/15c prose at live game_theory_lean path (cooperative_games_lean absorbed)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15b-Lean-CooperativeGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15b-Lean-CooperativeGames.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "## Configuration du projet Lake avec Mathlib\n",
     "\n",
-    "Ce notebook utilise **Mathlib** pour les types mathématiques (`Finset`, `Fintype`, `R`) et les tactiques avancées. Un projet Lake a ete configure dans `cooperative_games_lean/`.\n",
+    "Ce notebook utilise **Mathlib** pour les types mathématiques (`Finset`, `Fintype`, `R`) et les tactiques avancées. Un projet Lake a ete configure dans `game_theory_lean/`.\n",
     "\n",
     "### Option 1 : Executer avec le projet Lake (recommande)\n",
     "\n",
@@ -36,7 +36,7 @@
     "\n",
     "```bash\n",
     "# 1. Aller dans le repertoire du projet Lake\n",
-    "cd MyIA.AI.Notebooks/GameTheory/cooperative_games_lean\n",
+    "cd MyIA.AI.Notebooks/GameTheory/game_theory_lean\n",
     "\n",
     "# 2. Telecharger le cache Mathlib pre-compile (~100 MB, 1-2 min)\n",
     "lake exe cache get\n",
@@ -56,9 +56,9 @@
     "\n",
     "| Fichier | Contenu | Sorry |\n",
     "|---------|---------|-------|\n",
-    "| `cooperative_games_lean/CooperativeGames/Basic.lean` | TUGame, Core, convexite, Bondareva-Shapley | 0 |\n",
-    "| `cooperative_games_lean/CooperativeGames/ConeKernel.lean` | Farkas / separation de cone (direction backward) | 0 |\n",
-    "| `cooperative_games_lean/CooperativeGames/Shapley.lean` | Axiomes, valeur, unicite | 0 |\n",
+    "| `game_theory_lean/CooperativeGames/Basic.lean` | TUGame, Core, convexite, Bondareva-Shapley | 0 |\n",
+    "| `game_theory_lean/CooperativeGames/ConeKernel.lean` | Farkas / separation de cone (direction backward) | 0 |\n",
+    "| `game_theory_lean/CooperativeGames/Shapley.lean` | Axiomes, valeur, unicite | 0 |\n",
     "| `game_theory_lean/StableMarriage/Definitions.lean` | Préférences, matching, stabilite | 0 |\n",
     "| `game_theory_lean/StableMarriage/GSState.lean` | Etat intermediaire Gale-Shapley | 0 |\n",
     "| `game_theory_lean/StableMarriage/Lemmas.lean` | Invariants et lemmes | 0 |\n",
@@ -321,7 +321,7 @@
     "\n",
     "La convexite joue un rôle cle : pour les jeux convexes, la valeur de Shapley est **toujours dans le Core** (section 4), garantissant la stabilite de l'allocation.\n",
     "\n",
-    "> **Note Lean** : Les définitions ci-dessous utilisent des `List N` pour représenter les coalitions, avec des predicats pour exprimer la disjonction et l'inclusion. Le port Mathlib (`cooperative_games_lean/CooperativeGames/Basic.lean`) utilise `Finset N` a la place."
+    "> **Note Lean** : Les définitions ci-dessous utilisent des `List N` pour représenter les coalitions, avec des predicats pour exprimer la disjonction et l'inclusion. Le port Mathlib (`game_theory_lean/CooperativeGames/Basic.lean`) utilise `Finset N` a la place."
    ]
   },
   {
@@ -1359,7 +1359,7 @@
     "\n",
     "La stratégie de preuve repose sur la **decomposition en jeux d'unanimite** : on montre que tout jeu cooperatif est combinaison lineaire de jeux $u_S$, puis on vérifie que la valeur de Shapley est l'unique solution satisfaisant les quatre axiomes sur chaque $u_S$.\n",
     "\n",
-    "La cellule ci-dessous enonce formellement ce theoreme. La preuve complète est dans `cooperative_games_lean/CooperativeGames/Shapley.lean`."
+    "La cellule ci-dessous enonce formellement ce theoreme. La preuve complète est dans `game_theory_lean/CooperativeGames/Shapley.lean`."
    ]
   },
   {
@@ -1496,7 +1496,7 @@
     "\n",
     "Le code ci-dessous formalise ces deux résultats. Le predicat `inCore` est declare en forward pour rendre les enonces typables.\n",
     "\n",
-    "> **Note technique** : Les deux theoremes utilisent `sorry` car leur preuve complète necessite l'enumeration des sous-ensembles (`List.powerset`) et des permutations, indisponibles en Lean 4 pur sans Mathlib. Le projet Lake `cooperative_games_lean/` contient des versions plus complètes."
+    "> **Note technique** : Les deux theoremes utilisent `sorry` car leur preuve complète necessite l'enumeration des sous-ensembles (`List.powerset`) et des permutations, indisponibles en Lean 4 pur sans Mathlib. Le projet Lake `game_theory_lean/` contient des versions plus complètes."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
@@ -1807,7 +1807,7 @@
     "tags": []
    },
    "source": [
-    "> **Lien avec la formalisation Lean** : Les concepts de ce notebook — jeux cooperatifs TU, valeur de Shapley, Core, convexite — sont construits formellement dans le notebook compagnon [GT-15b-Lean-CooperativeGames](GameTheory-15b-Lean-CooperativeGames.ipynb) et la librairie [`cooperative_games_lean/`](cooperative_games_lean/). Le module `Basic.lean` (1 sorry) définit `TUGame`, les coalitions, le Core et la convexite, et prouve le theoreme de Bondareva-Shapley (condition necessaire et suffisante pour le Core non-vide). Le module `Shapley.lean` (0 sorry) formalise les 4 axiomes de Shapley (efficacite, symetrie, joueur nul, additivite) et prouve l'unicite de la valeur. Le jeu de gants (Glove Game) et le jeu de majorite illustres numeriquement ci-dessus y sont également traites."
+    "> **Lien avec la formalisation Lean** : Les concepts de ce notebook — jeux cooperatifs TU, valeur de Shapley, Core, convexite — sont construits formellement dans le notebook compagnon [GT-15b-Lean-CooperativeGames](GameTheory-15b-Lean-CooperativeGames.ipynb) et la librairie [`game_theory_lean/`](game_theory_lean/). Le module `Basic.lean` (0 sorry) définit `TUGame`, les coalitions, le Core et la convexite, et prouve le theoreme de Bondareva-Shapley (condition necessaire et suffisante pour le Core non-vide). Le module `Shapley.lean` (0 sorry) formalise les 4 axiomes de Shapley (efficacite, symetrie, joueur nul, additivite) et prouve l'unicite de la valeur. Le jeu de gants (Glove Game) et le jeu de majorite illustres numeriquement ci-dessus y sont également traites."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-15c-cooperativegames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-15c-cooperativegames.yaml
@@ -8,7 +8,14 @@
       by: myia-po-2023:CoursIA
       python_sha: 6a0f9876a9e7b2563a4a451da57f5722408b5245
       csharp_sha: 2b5ecf27a189d00765e6f80edf7c48eb10372cfe
+    - date: "2026-08-09"
+      by: myia-po-2026:CoursIA
+      python_sha: 25459ad7ac385087eb15c07e41121dd3ac8e51a5
+      csharp_sha: 2b5ecf27a189d00765e6f80edf7c48eb10372cfe
+      content_python_sha: 94c4c3e1f27d44c46e530295487eedc9871c7d2582b872180502f7a9c39936ff
+      content_csharp_sha: e51c9c8531ea016c263de00b7a5aaef5815002fa0306a825091399d04403cd35
   known_differences:
+    - "[2026-08-09 re-audit myia-po-2026:CoursIA] Edition prose-truth du jumeau Python uniquement (cellule markdown compagnon, pas de cellule code) : chemin mort cooperative_games_lean/ remplace par le chemin vivant game_theory_lean/ (lake absorbe per #6040/#4365) + compte sorry Basic.lean 1->0 corrige (accuracy, 0 sorry actif verifie). Aucun changement au contenu mathematique cooperatif (Shapley / core / coalitions), le jumeau C# n'est pas touche : la parite Python<->C# tient, seul le blob SHA du jumeau Python a deplace."
     - "Socle pedagogique commun : jeux cooperatifs a utilite transferable (TU) -- valeur de Shapley (formule axiomatique, calcul sur permutations), le core (stabilite, imputations), coalitions. Meme concept mathematique (Shapley value phi_i = somme sur permutations, core comme polytope des imputations stables), meme cas d'application (repartition de gains cooperatifs). Les deux couvrent Shapley, core, Coalition."
     - "Divergence d'implementation : le Python (numpy + scipy + matplotlib, 18 cellules code) calcule les valeurs de Shapley et visualise le core (polytope, extremites) ; le C# (pur System.* stdlib, 0 NuGet, 15 cellules code) implemente le calcul de Shapley (iteration sur permutations) et la verification d'appartenance au core sans libs numeriques. Meme theoreme, deux angles : numerique+visualisation cote Python vs implementation constructive cote C#."
     - "Idiomes framework : Python = numpy + scipy + matplotlib, 18 cellules code ; C# = pur System.* (System / System.Linq), 0 NuGet, 15 cellules code. Asymetrie attendue (le C# evite les libs numeriques/scientifiques), meme enseignement sous-jacent (Shapley axiomatique + core)."


### PR DESCRIPTION
Grain: MED/content(prose-truth) — lane myia-po-2026:CoursIA — prev: MED/content-i18n #10180. **R6 ✓** : content prose-truth, famille GameTheory, ≠ detector/i18n (rotation après c.1015 guard / c.1016 guard / c.1017 i18n).

## Quoi

Les notebooks **GameTheory-15b** (8 refs) et **GameTheory-15c** (2 refs) pointaient vers `cooperative_games_lean/` — chemin **MORT** sur main (0 fichier tracké, lakefile supprimé quand le lake a été absorbé dans `game_theory_lean/CooperativeGames/` per #6040, cf #4365). Le chemin vivant correct `game_theory_lean/CooperativeGames/` contient Basic.lean, ConeKernel.lean, Shapley.lean (vérifiés présents + lakefile vivant).

Les refs morts incluaient :
- une instruction bash `cd MyIA.AI.Notebooks/GameTheory/cooperative_games_lean` (cell[0], dans un fence markdown) qui **échouerait au copy-paste** par un étudiant ;
- une table de 3 chemins (`cooperative_games_lean/CooperativeGames/{Basic,ConeKernel,Shapley}.lean`) ;
- de la prose « la preuve complète est dans `cooperative_games_lean/...` » pointant vers rien.

## Correctif secondaire (accuracy sorry)

15c cell[39] disait « `Basic.lean` (1 sorry) » → corrigé en « (0 sorry) ». Vérifié firsthand : `game_theory_lean/CooperativeGames/Basic.lean` a **0 occurrence du mot sorry** (des 3 fichiers, ConeKernel.lean et Shapley.lean ont le mot « sorry » uniquement dans des COMMENTAIRES — « 0 sorry » / « bullet-sorry stub » — soit 0 sorry actif). La table 15b (Basic=0, ConeKernel=0, Shapley=0) était déjà correcte.

## Preuve (firsthand)

```
cooperative_games_lean/ tracké sur origin/main : 0 fichier (lakefile absent, lake absorbé)
game_theory_lean/CooperativeGames/{Basic,ConeKernel,Shapley}.lean : présents + lakefile vivant ✓
burn-down complet : 0 autre notebook ne référence cooperative_games_lean (scan complet .ipynb)
```
- **Markdown-only** : 0 cellule code ou output touchée → exception C.2 markdown (pas de re-exec).
- **H.3** : 15b a 20 code cells, 0 unexecuted-no-output (pas de régression H.3 introduite).
- **JSON** : round-trip byte-identical confirmé AVANT édition (formatting préservé) ; diff = 8/8 (15b) + 1/1 (15c) lignes de remplacement uniquement ; nbformat 4 valide.
- **EOL** : LF-only (`count(\r)=0`).

## Distinct de #10157

#10157 = sorties (outputs) `social_choice_lean` dans 02-Lean-SocialChoice + GT16, fixé par #10159 (re-exec). Ici = prose markdown `cooperative_games_lean` dans 15b/15c (module différent, notebooks différents, markdown pas outputs). Collision pre-flight 3-signaux clean (0 PR open sur 15b/15c).

See #4365 (lake absorption epic) · See #10157 (même classe de défaut, social_choice_lean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
