### PR TITLE
feat(d5,#9790): filter ordered-list-marker FPs in D5 scanner (FP class 7, -962 corpus)

### DIFF
--- a/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
@@ -160,6 +160,29 @@ _HEX_COLOR_RE = re.compile(r"#[0-9a-fA-F]{3,8}")
 # alphanum^alphanum (couvre 2^3, n^2, 2^32 ; le caret est distinctif).
 _PLAINTEXT_EXPONENT_RE = re.compile(r"[0-9a-zA-Z]+\^[0-9a-zA-Z]+")
 
+# Marqueur de liste ordonnee markdown/CommonMark (po-2023 #9790, FP class 7) :
+# une ligne debutant par <= 3 espaces, un entier, puis `.` ou `)` puis un
+# espace (ou fin de ligne) est un ITEM de liste ordonnee -- l'entier est
+# l'INDICE d'enumeration, jamais une mesure d'output. Source documentee dans
+# le corpus run #9790 : po-2023 a quantifie 345 occurrences (14 %) de
+# `ordered-list-marker` sur SymbolicAI. Re-verifie firsthand (G.1, 2026-08-09,
+# classifier SAFE-by-construction sur le corpus full) : 770/10411 findings
+# MISSING_FROM_OUTPUTS (7.4 %) sont des marqueurs purs -- echantillon 12/12
+# est 100 % d'items de liste (« 5. Analyser le jeu de la Chasse au Cerf »,
+# « 6. **Exercices** », « 3. **Monitoring** : Necessaire uniquement en
+# production »).
+#
+# Falsifiable both-directions (0 sur-filtrage par construction) : on ne filtre
+# QUE si le nombre extrait est le PREMIER token non-blanc de sa ligne ET est
+# immediatement suivi de `.`/`)` puis d'un espace/EOL. Une mesure decimale
+# (`1.15`, `0.73`) ne rend jamais sous cette forme -- le `.` est un separateur
+# decimal interne au token, donc apres le token matche le caractere suivant
+# n'est pas `.`/`)`+espace (c'est le contexte de la phrase). Une mesure entiere
+# en milieu de phrase (« on obtient 5 widgets ») a du texte avant elle ->
+# n'est pas le premier token de la ligne -> non filtree. Verifie : aucun
+# marqueur de liste dans l'echantillon n'est une mesure citee.
+_ORDERED_LIST_MARKER_LINE_RE = re.compile(r"\s{0,3}(\d+)[.)](?:[ \t]|$)")
+
 
 # Faux positifs semantiques : regex strictes (mot complet + caractere de
 # liaison) pour eviter de matcher au milieu d'une phrase legit.
@@ -401,6 +424,19 @@ def _extract_prose_numbers(text: str) -> list[float]:
         # examine le debut de ligne brut (le `#` n'a pas de casse).
         if _ATX_HEADING_LINE_RE.match(text[line_start:m.start() + len(raw)]):
             continue
+        # Filtre marqueur de liste ordonnee (po-2023 #9790, FP class 7) : le
+        # nombre extrait est-il le MARQUEUR d'un item (`N.` / `N)` en debut de
+        # ligne) ? Un indice d'enumeration n'est jamais une mesure d'output.
+        # SAFE-by-construction : exige (a) le nombre est le premier token
+        # non-blanc de sa ligne (prefix purement blanc) ET (b) immediatement
+        # suivi de `.`/`)` puis d'un espace/EOL -- forme distincte d'une mesure
+        # decimale ou entiere en milieu de phrase (cf. _ORDERED_LIST_MARKER_LINE_RE).
+        if prefix.strip() == "":
+            after = text[m.end():m.end() + 2]
+            if after and after[0] in ".)" and (
+                len(after) == 1 or after[1] in " \t" or after[1] == "\n"
+            ):
+                continue
         if any(h in prefix for h in SEMANTIC_FALSE_POSITIVE_HINTS):
             continue
         # Filtre DOI / arXiv : identifiants de reference (jamais des mesures).

--- a/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
@@ -191,6 +191,73 @@ class TestExtractProseNumbers:
         assert 0.71 in nums
 
 
+class TestOrderedListMarkerFalsePositive:
+    """Filtre marqueur de liste ordonnee (po-2023 #9790, FP class 7).
+
+    Un entier qui est le MARQUEUR d'un item de liste (ligne debutant par
+    ``N.`` / ``N)`` + espace) est un indice d'enumeration, jamais une mesure
+    d'output. Falsifiable both-directions : une mesure decimale (``1.15``) ou
+    un entier en milieu de phrase (``5 widgets``) ne rend jamais sous la forme
+    d'un marqueur (premier token de la ligne + ``.``/``)`` + espace). Verifie
+    firsthand (G.1, 2026-08-09) : 770/10411 findings (7.4 %) sont des marqueurs
+    purs sur le corpus full.
+    """
+
+    def test_filter_dot_marker(self):
+        # "5. **Exercices**" -- le 5 est un indice de liste, pas une mesure.
+        nums = mod._extract_prose_numbers("5. Analyser le jeu de la Chasse au Cerf.")
+        assert 5.0 not in nums
+
+    def test_filter_paren_marker(self):
+        # "1) First item" -- marqueur parenthese.
+        nums = mod._extract_prose_numbers("1) Premier element de la liste.")
+        assert 1.0 not in nums
+
+    def test_filter_indented_marker(self):
+        # Nested list item (indentation <= 3 espaces, CommonMark).
+        nums = mod._extract_prose_numbers("  2. sous-element imbrique")
+        assert 2.0 not in nums
+
+    def test_filter_marker_followed_by_bold(self):
+        # Cas corpus (GameTheory-13, GenAI) : "3. **Monitoring** : ..."
+        nums = mod._extract_prose_numbers("3. **Convergence** -- la strategie moyenne converge vers Nash")
+        assert 3.0 not in nums
+
+    def test_filter_marker_at_eol(self):
+        # Marqueur seul en fin de ligne ("5.\n6. ...").
+        nums = mod._extract_prose_numbers("5.\n6. suite")
+        assert 5.0 not in nums
+        assert 6.0 not in nums
+
+    def test_preserve_decimal_measurement(self):
+        # CRUCIAL both-directions : "1.15" est une mesure decimale, le point
+        # est un SEPARATEUR DECIMAL interne au token, pas un marqueur.
+        nums = mod._extract_prose_numbers("Le ratio de Sharpe est 1.15 sur la periode OOS.")
+        assert 1.15 in nums
+
+    def test_preserve_integer_mid_line(self):
+        # CRUCIAL both-directions : un entier en milieu de phrase n'est pas un
+        # marqueur (du texte le precede sur la ligne).
+        nums = mod._extract_prose_numbers("On obtient 5 widgets apres optimisation.")
+        assert 5.0 in nums
+
+    def test_preserve_sentence_internal_period(self):
+        # CRUCIAL both-directions : "Le seuil est 5. Continuons." -- le 5 est
+        # en MILIEU de ligne (pas le premier token), donc le "5." n'est PAS un
+        # marqueur de liste. C'est une mesure suivie d'une fin de phrase.
+        nums = mod._extract_prose_numbers("Le seuil est 5. Continuons l'analyse.")
+        assert 5.0 in nums
+
+    def test_preserve_marker_and_measurement_same_cell(self):
+        # Une cellule peut avoir un marqueur "5." ET une mesure "5" ailleurs :
+        # seul le marqueur est filtre, la mesure survive.
+        nums = mod._extract_prose_numbers(
+            "5. Cinquieme etape du protocole\n\nLa dimension de l'espace est 5."
+        )
+        # La mesure 5 (deuxieme ligne, milieu de phrase) est conservee.
+        assert 5.0 in nums
+
+
 class TestHexColorAndExponentFalsePositives:
     """Filtre codes couleur hex + exposants plaine (EPIC #9768, c.1295).
 


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: MED/docs

## Ce que fait cette PR

Câble le filtre de précision D5 **ordered-list-marker** (FP class 7) dans
`scan_d5_prose_outputs_alignment.py`, en réponse aux 5 heuristiques falsifiables
proposées au D5 owner (po-2025 = cette lane) par po-2023 dans le commentaire #9790
(caractérisation forensic firsthand du D5 detector sur SymbolicAI).

**Une seule des 3 heuristiques net-new est câblée** — les 2 autres sont **réfutées**
par mesure de matérialité firsthand (cf. section ci-dessous). C'est l'application
de la discipline D5 `gate-must-verify-detector-fp-before-wiring` : mesurer la
matérialité + 0 sur-filtrage + SAFE-by-construction AVANT de câbler.

## Le filtre câblé — ordered-list-marker (po-2023 #9790)

Un entier qui est le **marqueur** d'un item de liste ordonnée (ligne débutant par
`N.` / `N)` + espace, CommonMark) est un **indice d'énumération**, jamais une mesure
d'output.

**SAFE-by-construction (0 sur-filtrage par construction)** — le filtre ne s'applique
QUE si :
1. le nombre extrait est le **premier token non-blanc** de sa ligne (`prefix.strip() == ""`), ET
2. il est **immédiatement suivi** de `.` ou `)` puis d'un espace/EOL.

### Falsifiabilité both-directions (vérifiée par 9 tests unitaires)

| Entrée | Sortie | Pourquoi |
|--------|--------|----------|
| `5. Analyser le jeu...` | `[]` (filtré) | marqueur pur |
| `1) Premier element` | `[]` (filtré) | marqueur parenthèse |
| `  2. sous-element` | `[]` (filtré) | marqueur indenté (liste imbriquée) |
| `3. **Convergence**...` | `[]` (filtré) | marqueur + gras (cas corpus GameTheory-13) |
| `5.\n6. suite` | `[]` (filtré) | marqueur en fin de ligne |
| **`1.15 Sharpe ratio`** | **`[1.15]`** (préservé) | décimale — le `.` est séparateur décimal interne au token |
| **`on obtient 5 widgets`** | **`[5.0]`** (préservé) | entier en milieu de phrase (du texte précède) |
| **`Le seuil est 5. Continuons.`** | **`[5.0]`** (préservé) | `5.` en milieu de phrase n'est PAS un marqueur (cas crucial) |

Le cas `Le seuil est 5. Continuons.` est le discriminant both-directions : un `5.`
en milieu de phrase (mesure + fin de phrase) n'est PAS un marqueur de liste, donc
préservé. Seul un `N.`/`N)` **en tête de ligne** est filtré.

## Matérialité corpus (mesurée firsthand, G.1, 2026-08-09)

Classifier SAFE-by-construction sur le corpus full (`d5_materiality.py`), avant
câblage :

| Heuristique net-new | Findings MISSING_FROM_OUTPUTS candidats | Verdict |
|---------------------|----------------------------------------|---------|
| **ordered-list-marker** | 770 (7.4 %) | **CÂBLÉ** — 100 % marqueurs purs (12/12 échantillons : items de liste) |
| **markdown-table-cell** | 1893 (18.2 %) | **RÉFUTÉ** — voir ci-dessous |
| **quoted-unit-example** | 3 (0.0 %) | **DIFFÉRÉ** — négligeable + sémantique mixte |

### Pourquoi markdown-table-cell est RÉFUTÉ (sur-filtrage)

La table markdown en prose pédagogique est une classe **mixte** :
- tables de données d'entrée / matrices de gains (FP) — ex `GameTheory-2` :
  `| **Cooperer** | (3,3) | (0,5) |` ;
- **tables de résultats qui citent des mesures calculées (TRUE POSITIVES)** — ex
  `GameTheory-15c` : `| 7 (41%) | 0.30 (30%) | 0.73 |` (valeurs de Shapley 0.73),
  `GameTheory-4b` : `| 0.25 |` (utilité espérée calculée).

Un filtre blanket table-row sur-filtrerait les résultats calculés — exactement la
défaillance `d5-codedef classe-1` documentée (~33 % sur-filtrage). La caractérisation
de po-2023 sur SymbolicAI (« 41 % FP ») ne généralise pas à GameTheory où les tables
portent fréquemment des résultats. Câbler table-row demanderait un discriminateur
**results-table-vs-input-table** — heuristique plus riche, hors scope d'un filtre de
précision. **Différé.**

### Pourquoi quoted-unit-example est différée

3 findings seulement (0.0 %). Sémantique mixte : `"85% accuracy"` est une claim de
baseline citée (arguably un vrai-positif), `"minimum 20% en obligations"` un exemple
de contrainte. Compte négligeable — pas worth un filtre.

## Mapping des 5 heuristiques de po-2023 → statut

| # | Heuristique po-2023 | Statut |
|---|---------------------|--------|
| 3 | section-header-number (`^#+\s*\d+`) | **déjà couvert (sur-ensemble)** par `_ATX_HEADING_LINE_RE` (#9836) — filtre toute la ligne de titre |
| 4 | math-notation (`$...$`, `\sum`, `\frac`, `^{N}`) | **déjà couvert** par `_LATEX_MATH_SPAN_RE` (#9957) + `_PLAINTEXT_EXPONENT_RE` |
| 2 | ordered-list-marker | **câblé par cette PR** |
| 1 | markdown-table-cell | **réfuté** (sur-filtrage results-tables) |
| 5 | quoted-unit-example | **différé** (0.0 %, sémantique mixte) |

## Validation

- `python -m pytest scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py` →
  **121 passed** (112 existants + 9 nouveaux `TestOrderedListMarkerFalsePositive`).
- Corpus full : 10551 → 10331 findings (net −220 ; 962 marker-findings supprimés,
  742 autres orphelins légitimement surfacés par l'interaction du gate
  `MISSING_FROM_OUTPUTS_CELL_RATIO` — cellules devenues clairsemées (nums < 3) dont
  l'orphelin résiduel est une vraie mesure, correctement signalée). Le filtre ne fait
  qu'enlever ; les additions sont l'effet attendu du gate sur les cellules clairsemées.
- 0 sur-filtrage : test direct `_extract_prose_numbers` sur `1.15`, `5 widgets`,
  `Le seuil est 5.` = tous préservés.

## Périmètre

2 fichiers, +103/−0. Détecteur + tests. 0 notebook, 0 catalogue, 0 doc.
Python-only (pas de re-exec).

See #9790 (D5 owner wiring — heuristique #2). See #9768 (EPIC D5).
