### PR TITLE
fix(scan-md,#10097): bind MATH_SPAN_RE to KaTeX delimiters — kill currency-price COL_MISMATCH FP (-41 fleet)

### DIFF
--- a/scripts/notebook_tools/scan_md_table_syntax.py
+++ b/scripts/notebook_tools/scan_md_table_syntax.py
@@ -99,7 +99,15 @@ HEADING_RE = re.compile(r'^\s{0,3}#{1,6}\s')
 #      is non-actionable noise; current GitHub renders ``$|x|$`` correctly in
 #      tables. Excluded by deliberate conservative choice.
 CODE_SPAN_RE = re.compile(r'(`+)[^`]*\1')
-MATH_SPAN_RE = re.compile(r'\$[^$\n]*\$')
+# KaTeX-faithful inline-math span. The bare ``\$[^$\n]*\$`` treated two
+# currency amounts in a cost table (``$15.00 | ~$0.75``) as ONE math span,
+# swallowing the cell-delimiter pipe and false-positive-ing COL_MISMATCH on
+# every price column fleet-wide. The real delimiter rule (KaTeX / GFM math):
+# the opening ``$`` is NOT preceded by an alnum, and the closing ``$`` is NOT
+# followed by an alnum. ``$0.75`` has the ``$`` followed by ``0`` so it cannot
+# close a span, while ``$|x|$`` and ``$P(z_t|z_{t-1})$`` keep clean boundaries
+# and stay protected. See #10097 (currency-price COL_MISMATCH FP class).
+MATH_SPAN_RE = re.compile(r'(?<![A-Za-z0-9])\$[^$\n]*\$(?![A-Za-z0-9])')
 ESCAPED_PIPE_RE = re.compile(r'\\\|')
 
 # Conditional-probability / function-call notation: ``P(x|y)``, ``O(|A|*|S|)``,

--- a/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
+++ b/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
@@ -65,6 +65,16 @@ class TestColumnCount:
         # breaking the math, so it is excluded (non-actionable).
         assert _column_count("| $|x|$ | description |") == 2
 
+    def test_currency_price_columns_not_col_mismatch(self):
+        # Cost tables with $amount values are NOT inline math: the bare
+        # `$[^$\n]*$` regex bridged `$15.00 | ~$` across the cell-delimiter
+        # pipe, false-positive-ing every price column as COL_MISMATCH
+        # (fleet-wide currency FP class, #10097). A KaTeX-faithful boundary
+        # (closing $ not followed by an alnum) refuses to close at `$0.75`,
+        # so the pipe counts normally -> 3 columns.
+        assert _column_count("| OpenAI tts-1 | $15.00 | ~$0.75 |") == 3
+        assert _column_count("| a | $1 | $2 | $3 |") == 4
+
     def test_multiple_backtick_spans(self):
         assert _column_count("| a | `b|c` | `d|e` |") == 3
 
@@ -172,6 +182,21 @@ class TestDetectColMismatch:
             "| a | b | c |",
             "|---|---|---|",
             "1 | 2 | 3",
+        ]
+        f = detect_md_table_syntax(lines)
+        assert [x for x in f if x["pathology"] == "COL_MISMATCH"] == []
+
+    def test_currency_price_table_not_flagged(self):
+        # A real cost/comparison table whose cells hold $amount values must
+        # NOT be flagged COL_MISMATCH. The bare `$[^$\n]*$` math regex used to
+        # bridge two currency cells across the delimiter pipe (fleet-wide FP
+        # on every price column, #10097). After the KaTeX-boundary fix the
+        # pipes count normally and the table is clean.
+        lines = [
+            "| Modele | Cout / 1M caracteres | Cout / 1 heure narration |",
+            "|--------|---------------------|-------------------------|",
+            "| OpenAI tts-1 | $15.00 | ~$0.75 |",
+            "| OpenAI tts-1-hd | $30.00 | ~$1.50 |",
         ]
         f = detect_md_table_syntax(lines)
         assert [x for x in f if x["pathology"] == "COL_MISMATCH"] == []


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/readme #10185

See #10097 (GFM markdown table-syntax defect detector — currency-price COL_MISMATCH false-positive class).

## What changed

`scan_md_table_syntax.py`'s inline-math span regex `MATH_SPAN_RE` was `\$[^$\n]*\$` — it matched **two currency cells across the cell-delimiter pipe**. On a cost-table row like ``| OpenAI tts-1 | $15.00 | ~$0.75 |``, the regex saw `$15.00 | ~$` (from the first `$` to the next `$`) as ONE inline-math span, swallowing the `|` between the two price columns. `_column_count` then under-counted the row (3 cols → 2), flagging every price/cost column in the corpus as `COL_MISMATCH` ("colonne fantôme").

| File | Change |
|---|---|
| `scripts/notebook_tools/scan_md_table_syntax.py` | +9/-1 — `MATH_SPAN_RE` now `(?<![A-Za-z0-9])\$[^$\n]*\$(?![A-Za-z0-9])`: opening `$` not preceded by an alnum, closing `$` not followed by an alnum (KaTeX / GFM-math delimiter rule). `$0.75` cannot close a span (the `$` is followed by `0`), so the pipe counts normally. |
| `scripts/notebook_tools/tests/test_scan_md_table_syntax.py` | +25 — 2 regression tests: `_column_count` on currency rows (3-col price row → 3, not 2); `detect_md_table_syntax` on a full 4-line cost table → 0 COL_MISMATCH. |

## Finding (firsthand root cause, not scanner-output)

The "287 GenAI md-table defects" dashboard figure was investigated cell-by-cell. Two phantom-inflating classes found:

| Class | Count | Nature |
|---|---|---|
| **NO_SEP on `roo_task_*.md`** | 208 / 287 (72%) | Roo-Code atelier **conversation transcripts** ("table de 770 lignes sans séparateur") — not tables, not pedagogical prose. FP by construction. |
| **COL_MISMATCH currency-price** | ~26 (the delta) | **The bug fixed here.** Cost/comparison tables with `$amount` cells, every one a FP. |

Firsthand reproduction on `03-1-Multi-Model-Audio-Comparison` cell[21]: the scanner flagged ``| OpenAI tts-1 | $15.00 | ~$0.75 |`` (a correct 3-column row) as "2 colonnes vs 3" — traced via `_column_count` to the math-span bridging. The scanner's own detail ("un `|` nu non-échappé ?") was a hypothesis, not the cause; the cause was the regex spanning cells.

## Validation (measured, not asserted)

- **Fleet-wide COL_MISMATCH**: **154 → 113** (−41 FPs, −27%). Measured by `git stash` (before) vs fix applied (after) on the full `MyIA.AI.Notebooks` corpus.
- **GenAI family**: 287 → 263 total; COL_MISMATCH **41 → 15** (−63%). The 15 residual are `roo_task` transcripts + genuine phantom-column cases, not the currency class.
- **43 tests pass** (41 existing + 2 new), 0.22s. No regression.
- **Math protection preserved** (the whole point of `MATH_SPAN_RE`): `$|x|$` → 2 cols ✓, `$P(z_t | z_{t-1})$` → `has_delimiter_pipe` False ✓, `$\theta$`-style spans → still stripped.
- **Catalog byte-identique**: 0 catalog files touched (scanner + test only, +34/-1).
- **L898 collision guard**: `gh pr list --state open` filtered to files matching `scan_md_table_syntax` = 0 open PRs. #10189 (OPEN) touches a different scanner (D5 ordered-list).

## Why no false-negative

The fix restricts the math-span close to a `$` NOT followed by an alnum. The only newly-unstripped `$…$` are those whose close `$` abuts a digit/letter — which KaTeX itself does NOT recognize as a math delimiter (the currency case). Real inline math in this corpus (`$|x|$`, `$P(z_t|z_{t-1})$`, `$\theta$`) has whitespace/punctuation/pipe boundaries and stays matched. The 41 existing tests (incl. `test_inline_math_pipe_not_counted`, `test_inline_math_pipe_excluded`) corroborate — all still green.

## Variation note

prev = MED/readme #10185 (Z3-API §E doc-sync). This grain = MED/guard (md-table detector precision fix). Different GENRE (guard ≠ readme; G-VAR-3 satisfied — not 2 consecutive same-GENRE-LIGHT). Both MED. The substance is the firsthand FP-class discovery (currency-price bridging) + measured fleet delta + KaTeX-faithful fix + regression tests, not scanner-generatable.
