### PR TITLE
feat(lean,#10188): count_code_sorry organ — real sorry count + vacuous detector (Task 3)

### DIFF
--- a/scripts/lean/README.md
+++ b/scripts/lean/README.md
@@ -10,6 +10,7 @@ Outils pour le cycle de vie des projets Lean 4 du dépôt.
 | `lean_kernel_check.py` | Diagnostic kernel Lean (toolchain, oleans, env Python) |
 | `smoke_test_epita_is.py` | Smoke tests du parcours EPITA-IS (notebooks + preuves) |
 | `check_public_anchor.py` | Detecte les `sorry` qu'aucune declaration publique n'atteint — l'angle mort residuel du gate `proof-integrity` (voir ci-dessous) |
+| `count_code_sorry.py` | Compte les `sorry` **hors commentaires** (la vraie dette) et liste les theoremes vacuous (`: True`) — ce que `grep -c sorry` surestime de ~11x (voir ci-dessous) |
 
 Tests unitaires dans `tests/`.
 
@@ -82,6 +83,66 @@ n'a rien regarde (meme raison d'etre que les classifications `EMPTY_*` de #8940)
 | `unanchored` | porteur prive qu'aucune declaration publique ne rejoint — **invisible du gate** |
 | `anonymous` | `example` : sans nom, jamais enumerable |
 | `orphan_sorry` | `sorry` hors de toute declaration |
+
+---
+
+## `count_code_sorry.py` — la vraie dette de preuve vs `grep`, et les theoremes vides (issue #10188)
+
+### Problème : deux angles morts composes
+
+**1. `grep -c sorry` surevalue la dette d'un facteur ~11x a l'echelle du depot.**
+Le compteur naif inclut le mot `sorry` dans les docstrings (`/- ... sorry ... -/`),
+les commentaires ligne (`-- ... sorry`) et les chaines. Un body de PR qui cite un
+avant/apres tire de `grep` cite donc un nombre sans rapport avec la dette reelle,
+et un coordinateur qui dispatch du travail « fermer le sorry #N » depuis ce compte
+envoie un worker sur une veine tarie (cas conway_lean : `grep` = 152, code reel = 2
+distincts).
+
+**2. Les theoremes vacuous passent TOUS nos gates.** Un enonce dont la conclusion
+est `True` (`theorem foo : True := by trivial`, ou `∃ μ, True`) est entierement
+verifie et entierement vide : `grep` ne le voit pas (pas de `sorry`, ou un `sorry`
+sur un but trivial), `lake build` est vert, `#print axioms` est vert, et les scans
+`sorryAx` / `Classical.choice` sont verts car `trivial` n'utilise aucun axiome
+interdit. Fermer un tel `sorry` en une ligne produit un « sorry 41 -> 40 »
+parfaitement authentique au compteur — avec **zero mathematique**. C'est la fausse
+progression que G.2 interdit, sauf qu'ici toutes les preuves demandees par le
+harnais seraient fournies.
+
+### Solution : un organe d'analyse statique (sans Lean ni Mathlib)
+
+Comme `check_public_anchor.py`, l'analyse est **mono-fichier et complete** pour la
+question posee : on stripe les commentaires (blocs `/- -/` **imbriques** + lignes
+`--`, en preservant les positions pour les rapports `file:line`), puis on compte
+les tokens `sorry` reels et on les attribue a la declaration englobante. Les
+siblings i18n `_en` (miroirs byte-identiques, convention #4980) sont rapportes
+separement pour ne pas gonfler le compte *distinct*.
+
+La detection vacuous cible la **fin du type** avant `:=`, avec un motif ancre :
+`:\s*True$` (type = `True`) ou `,\s*True$` (conclusion d'un existentiel/universel).
+Cela ne flaggue **pas** `a = True` (equation, le caractere avant `True` est `=`) ni
+`True -> True` (fonction) — ces enonces sont triviaux mais disent quelque chose.
+
+### Usage
+
+```bash
+# Depot entier : table par lake + liste advisory des vacuous (exit 0)
+python scripts/lean/count_code_sorry.py
+
+# Un seul lake
+python scripts/lean/count_code_sorry.py --lake MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
+
+# JSON machine (CI / generation de body PR)
+python scripts/lean/count_code_sorry.py --json
+
+# Strict : exit 1 si un theoreme vacuous NON-marker reste (gate post-triage)
+python scripts/lean/count_code_sorry.py --strict
+```
+
+Advisory (exit 0) par defaut : l'outil rend visible, il ne decide pas. Les
+marqueurs assumes (`theorem *_prerequisites` du `MathlibPrerequisites.lean` de
+knot_lean) sont taggues `is_marker` et ignores par `--strict` — ils sont la
+dette explicite d'un port, pas des faux verts. Hors perimetre (statu quo i18n
+#4980) : `.lake/packages/`, `_peters/`, `reference_docs/`, libs vendored.
 
 ---
 

--- a/scripts/lean/count_code_sorry.py
+++ b/scripts/lean/count_code_sorry.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+"""Count real ``sorry`` tokens and detect vacuous theorems in own Lean sources.
+
+Why this organ exists
+---------------------
+
+``grep -c sorry`` overstates the open-proof debt by ~11x at repo scale: it
+counts the word ``sorry`` inside docstrings (``/- ... sorry ... -/``), line
+comments (``-- ... sorry``), and string literals. A PR body that cites a
+before/after ``sorry`` count drawn from ``grep`` therefore cites a number that
+has nothing to do with the actual proof debt, and a coordinator dispatching
+"close sorry #N" work from such a count sends a worker to a dry vein (cf the
+conway_lean case: ``grep -c sorry`` = 152, real code ``sorry`` = 2 distinct).
+
+Conversely, an *empty* theorem -- one whose conclusion is ``True`` -- sails
+through every gate we have: ``grep`` does not see it (no sorry, or a sorry on a
+trivial goal), ``lake build`` is green, ``#print axioms`` is green, and the
+``sorryAx`` / ``Classical.choice`` scans are green because ``True := trivial``
+uses no forbidden axiom. The theorem is fully verified and entirely empty. This
+is the worst blind spot we have: closing such a ``sorry`` in one line produces
+an authentic-looking "sorry 41 -> 40" with zero mathematics.
+
+This module is the organ (cf [[rule-needs-an-organ-not-more-vigilance]]): a rule
+without an organ does not apply. It provides, per own lake:
+
+  1. the real ``sorry`` count -- comment-stripped, attributed to the enclosing
+     declaration, with ``_en`` i18n mirrors reported separately so the distinct
+     count is not inflated by translation siblings;
+  2. an advisory list of vacuous conclusions (``: True``, ``∃ ..., True``) so a
+     human can triage the markers that are legit (``*_prerequisites``) from the
+     theorems that say nothing.
+
+It runs WITHOUT Lean or Mathlib -- pure text analysis -- so it can be cited in
+a PR body or wired into CI as a measurement-only advisory (exit 0 by default;
+``--strict`` exits 1 if any vacuous non-marker theorem is found, for the day
+the triage is complete).
+
+Out of scope (matching the i18n #4980 convention): ``.lake/packages/`` (Mathlib
+vendored), ``_peters/``, ``agent_tests/prover/session_state/reference_docs/``
+(third-party fixtures), vendored libs (``foundry-lib/lib/**``). Only own lakes
+are measured.
+
+Usage
+-----
+
+    # Full repo scan, per-lake table + advisory vacuous list (exit 0):
+    python scripts/lean/count_code_sorry.py
+
+    # Single lake:
+    python scripts/lean/count_code_sorry.py --lake MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
+
+    # Machine-readable JSON (for CI / PR-body generation):
+    python scripts/lean/count_code_sorry.py --json
+
+    # Strict: exit 1 if a vacuous non-marker theorem remains (post-triage gate):
+    python scripts/lean/count_code_sorry.py --strict
+
+Module usage:
+    from count_code_sorry import scan_lake, strip_lean_comments
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# Configuration
+# --------------------------------------------------------------------------- #
+
+# Directories that are NOT own lakes -- third-party / vendored / fixtures.
+# Must match the i18n #4980 out-of-scope list (code-style.md).
+EXCLUDE_DIR_PARTS = (
+    ".lake",            # Mathlib + build artifacts
+    "_peters",          # external lake
+    "reference_docs",   # agent_tests/prover/session_state/reference_docs/
+    "foundry-lib",      # vendored lib
+)
+
+# Declaration keywords whose header opens a new named scope.
+DECL_KEYWORDS = (
+    "theorem", "lemma", "def", "opaque", "axiom",
+    "structure", "inductive", "class", "abbrev",
+)
+
+# A declaration header: optional leading modifiers/attributes/whitespace, then a
+# keyword, then the name. ``instance`` is anonymous-allowed (name optional).
+_DECL_MODIFIERS = r"(?:@\[[^\]]*\]\s*|protected\s+|private\s+|noncomputable\s+|partial\s+|unsafe\s+|rec\s+)*"
+_DECL_RE = re.compile(
+    rf"^(?P<indent>\s*){_DECL_MODIFIERS}"
+    rf"(?P<kw>{'|'.join(DECL_KEYWORDS)}|instance)\s+"
+    rf"(?P<name>[A-Za-z_][A-Za-z0-9_']*)?"
+)
+_INSTANCE_ANON_RE = re.compile(rf"^(?P<indent>\s*){_DECL_MODIFIERS}instance\b")
+
+# sorry as a real tactic token (word-boundary, not inside an identifier).
+_SORRY_RE = re.compile(r"\bsorry\b")
+
+# A declaration marker whose ``True`` conclusion is assumed-legit (knot_lean
+# MathlibPrerequisites ports). Advisory only -- surfaced, not silenced, so the
+# human sees the count but the strict gate does not fire on them.
+_MARKER_NAME_RE = re.compile(r".*_prerequisites$")
+
+# Vacuous: the type tail (statement text up to ``:=``) concludes with ``True``
+# preceded by ``:`` (return type) or ``,`` (existential/forall conclusion).
+# Anchored at the end of the type tail so ``a = True`` (equation) and
+# ``True -> True`` (function) are NOT flagged.
+_VACUOUS_RE = re.compile(r"(?::|,)\s*True\s*$")
+
+
+# --------------------------------------------------------------------------- #
+# Comment stripping (position-preserving)
+# --------------------------------------------------------------------------- #
+
+def strip_lean_comments(text: str) -> str:
+    """Return ``text`` with Lean comments blanked (spaces), positions preserved.
+
+    Handles nested block comments ``/- ... -/`` (Lean nests them, unlike C) and
+    line comments ``--``. String literals ``"..."`` are skipped so a ``--`` or
+    ``/-`` inside a string is not treated as a comment (best-effort: no char is
+    perfectly lexed here, but the heuristic is sound for the sorry/True tokens).
+
+    Newlines are preserved so line numbers stay valid for reporting.
+    """
+    out = []
+    i = 0
+    n = len(text)
+    in_string = False
+    block_depth = 0
+    while i < n:
+        c = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+
+        # Inside a block comment: blank everything except newlines, track depth.
+        if block_depth > 0:
+            if c == "/" and nxt == "-":
+                block_depth += 1
+                out.extend("  ")
+                i += 2
+                continue
+            if c == "-" and nxt == "/":
+                block_depth -= 1
+                out.extend("  ")
+                i += 2
+                continue
+            out.append("\n" if c == "\n" else " ")
+            i += 1
+            continue
+
+        # Not in a block comment.
+        if in_string:
+            if c == "\\" and nxt:  # escaped char (e.g. \", \\, \n)
+                out.append(c)
+                out.append(nxt)
+                i += 2
+                continue
+            if c == '"':
+                in_string = False
+            out.append(c)
+            i += 1
+            continue
+
+        if c == '"':
+            in_string = True
+            out.append(c)
+            i += 1
+            continue
+        if c == "/" and nxt == "-":
+            block_depth = 1
+            out.extend("  ")
+            i += 2
+            continue
+        if c == "-" and nxt == "-":
+            # Line comment: blank to end of line (preserve the newline).
+            while i < n and text[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+# --------------------------------------------------------------------------- #
+# Declaration model + scanning
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class Declaration:
+    kind: str               # theorem / lemma / def / instance / ...
+    name: str               # declaration name ("" for anonymous instance)
+    line: int               # 1-based line of the header
+    file: str               # source file path (relative)
+    sorry_count: int = 0    # real sorry tokens in this declaration's body
+    is_vacuous: bool = False  # conclusion is True (empty theorem)
+    is_marker: bool = False   # name matches *_prerequisites (assumed-legit)
+
+
+@dataclass
+class LakeResult:
+    lake: str                       # lake name (relative root)
+    files: int = 0
+    naive_sorry: int = 0            # grep -c sorry (comments included)
+    code_sorry: int = 0             # real sorry (comment-stripped)
+    code_sorry_en_mirrors: int = 0  # subset of code_sorry inside _en siblings
+    declarations: list[Declaration] = field(default_factory=list)
+
+    @property
+    def distinct_code_sorry(self) -> int:
+        """code_sorry minus the _en i18n mirror tokens (translation siblings)."""
+        return self.code_sorry - self.code_sorry_en_mirrors
+
+    @property
+    def vacuous(self) -> list[Declaration]:
+        return [d for d in self.declarations if d.is_vacuous]
+
+
+def _is_excluded(path: Path) -> bool:
+    return any(part in EXCLUDE_DIR_PARTS for part in path.parts)
+
+
+def _is_en_mirror(path: Path) -> bool:
+    return path.stem.endswith("_en")
+
+
+def discover_lakes(root: Path) -> list[Path]:
+    """Return own lake roots (dirs containing a ``lakefile.lean``), sorted.
+
+    Falls back to ``*_lean`` directories without a lakefile (legacy lakes whose
+    lakefile was removed when absorbed, e.g. absorbed into game_theory_lean).
+    """
+    lakes: list[Path] = []
+    for lakefile in root.rglob("lakefile.lean"):
+        lake_root = lakefile.parent
+        if _is_excluded(lake_root):
+            continue
+        lakes.append(lake_root)
+    # Legacy absorbed lakes: directories named *_lean without a lakefile but
+    # containing own .lean files. Surfaced so dead-path references stay visible.
+    for candidate in root.rglob("*_lean"):
+        if not candidate.is_dir() or _is_excluded(candidate):
+            continue
+        if candidate in lakes:
+            continue
+        if any(candidate.samefile(l) for l in lakes):
+            continue
+        if not any(candidate.rglob("*.lean")):
+            continue
+        lakes.append(candidate)
+    # Deduplicate by resolved path, keep deterministic order.
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for l in lakes:
+        key = str(l.resolve())
+        if key not in seen:
+            seen.add(key)
+            unique.append(l)
+    unique.sort(key=lambda p: str(p))
+    return unique
+
+
+def scan_file(path: Path, root: Path) -> tuple[list[Declaration], int, int]:
+    """Scan one .lean file.
+
+    Returns ``(declarations, naive_sorry, code_sorry)``.
+    """
+    rel = str(path.relative_to(root))
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+
+    naive = len(_SORRY_RE.findall(raw))
+    code = strip_lean_comments(raw)
+    code_sorry = len(_SORRY_RE.findall(code))
+
+    lines = code.splitlines()
+    declarations: list[Declaration] = []
+    current: Declaration | None = None
+    statement_buf: list[str] = []   # lines accumulated until ``:=`` for vacuous check
+    seen_assign = False             # whether the current decl passed its ``:=``
+    paren_depth = 0                 # brace/paren/bracket depth on the header line region
+
+    def _flush_vacuous() -> None:
+        nonlocal current, statement_buf, seen_assign
+        # Evaluate on the accumulated statement regardless of whether ``:=``
+        # was reached: we truncate at the first ``:=`` so the proof body cannot
+        # pollute the type tail. (Gating on ``not seen_assign`` was the bug that
+        # skipped every single-line ``theorem foo : True := by trivial``.)
+        if current is not None and statement_buf:
+            type_tail = "\n".join(statement_buf)
+            # Truncate at the first ``:=`` if present on the tail.
+            am = re.search(r":=", type_tail)
+            if am:
+                type_tail = type_tail[:am.start()]
+            type_tail = type_tail.rstrip()
+            if type_tail and _VACUOUS_RE.search(type_tail):
+                current.is_vacuous = True
+        statement_buf = []
+        seen_assign = False
+
+    for idx, line in enumerate(lines, start=1):
+        # New declaration header? (at column 0 or close -- Lean allows indented
+        # instances inside a namespace, so we allow leading whitespace.)
+        hdr = _DECL_RE.match(line) or _INSTANCE_ANON_RE.match(line)
+        if hdr:
+            _flush_vacuous()
+            kw = hdr.group("kw")
+            name = hdr.groupdict().get("name") or ""
+            current = Declaration(kind=kw, name=name, line=idx, file=rel,
+                                  is_marker=bool(name and _MARKER_NAME_RE.match(name)))
+            declarations.append(current)
+            paren_depth = 0
+            seen_assign = False
+            statement_buf = [line]
+        elif current is not None:
+            if not seen_assign:
+                statement_buf.append(line)
+
+        # Track sorry in this line, attributed to the current declaration.
+        line_sorry = len(_SORRY_RE.findall(line))
+        if line_sorry and current is not None:
+            current.sorry_count += line_sorry
+
+        # Track when we cross the ``:=`` that ends the statement.
+        if current is not None and not seen_assign:
+            # cheap depth tracking on the raw line to avoid matching ``:=``
+            # inside a binder type annotation (rare, but keeps FP down)
+            if ":=" in line:
+                seen_assign = True
+
+    _flush_vacuous()
+    return declarations, naive, code_sorry
+
+
+def scan_lake(lake_root: Path, repo_root: Path) -> LakeResult:
+    result = LakeResult(lake=str(lake_root.relative_to(repo_root)))
+    # Scan own .lean files; exclude .lake and vendored subdirs at walk time.
+    lean_files = [p for p in lake_root.rglob("*.lean") if not _is_excluded(p)]
+    lean_files.sort()
+    result.files = len(lean_files)
+    for path in lean_files:
+        # ``d.file`` is stored lake-relative so display can prepend the lake name
+        # without doubling the path prefix.
+        decls, naive, code = scan_file(path, lake_root)
+        result.naive_sorry += naive
+        result.code_sorry += code
+        if _is_en_mirror(path):
+            result.code_sorry_en_mirrors += code
+        result.declarations.extend(decls)
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Output formatting
+# --------------------------------------------------------------------------- #
+
+def _fmt_ratio(code: int, naive: int) -> str:
+    if code == 0:
+        return "inf" if naive > 0 else "-"
+    return f"{naive / code:.0f}x"
+
+
+def render_table(results: list[LakeResult]) -> str:
+    total_naive = sum(r.naive_sorry for r in results)
+    total_code = sum(r.code_sorry for r in results)
+    total_distinct = sum(r.distinct_code_sorry for r in results)
+    rows = []
+    header = f"{'Lake':<48} {'code':>6} {'distinct':>9} {'grep':>6} {'ratio':>6}"
+    rows.append(header)
+    rows.append("-" * len(header))
+    for r in sorted(results, key=lambda x: -x.code_sorry):
+        lake_short = _norm(r.lake.replace("MyIA.AI.Notebooks/", ""))
+        rows.append(
+            f"{lake_short:<48} {r.code_sorry:>6} {r.distinct_code_sorry:>9} "
+            f"{r.naive_sorry:>6} {_fmt_ratio(r.code_sorry, r.naive_sorry):>6}"
+        )
+    rows.append("-" * len(header))
+    rows.append(
+        f"{'TOTAL':<48} {total_code:>6} {total_distinct:>9} {total_naive:>6} "
+        f"{_fmt_ratio(total_code, total_naive):>6}"
+    )
+    body = "\n".join(rows)
+    note = (
+        "\n\n"
+        "code      = sorry tokens OUTSIDE comments (real proof debt)\n"
+        "distinct  = code minus _en i18n mirror tokens (translation siblings)\n"
+        "grep      = naive `grep -c sorry` (comments included) -- the misleading number\n"
+        "ratio     = grep / code (how much grep overstates the debt)"
+    )
+    return body + note
+
+
+def _norm(p: str) -> str:
+    """Normalize path separators to forward slashes for repo-consistent display."""
+    return p.replace("\\", "/")
+
+
+def render_vacuous(results: list[LakeResult]) -> str:
+    lines = ["", "ADVISORY -- vacuous conclusions (`: True` / `∃ ..., True`)", "=" * 60]
+    any_vac = False
+    for r in sorted(results, key=lambda x: x.lake):
+        for d in r.vacuous:
+            any_vac = True
+            lake_short = _norm(r.lake.replace("MyIA.AI.Notebooks/", ""))
+            tag = " [marker -- assumed legit]" if d.is_marker else ""
+            lines.append(f"  {lake_short}/{_norm(d.file)}:{d.line}  {d.kind} {d.name}{tag}")
+            if d.sorry_count:
+                lines.append(f"      sorry on trivial goal: {d.sorry_count}")
+    if not any_vac:
+        lines.append("  (none)")
+    lines.append("")
+    lines.append("These pass lake build + axiom checks but state nothing. Closing a")
+    lines.append("`sorry` here yields an authentic-looking count delta with zero math.")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    repo = Path(__file__).resolve().parents[2]
+    p.add_argument("--repo", default=str(repo), help="repo root (default: autodetect)")
+    p.add_argument("--lake", action="append", default=[],
+                   help="scan a single lake root (repeatable); default = all own lakes")
+    p.add_argument("--json", action="store_true",
+                   help="emit machine-readable JSON instead of the table")
+    p.add_argument("--strict", action="store_true",
+                   help="exit 1 if any vacuous NON-marker theorem is found")
+    p.add_argument("--no-vacuous", action="store_true",
+                   help="skip the vacuous-conclusion advisory (sorry count only)")
+    args = p.parse_args(argv)
+
+    repo_root = Path(args.repo).resolve()
+    if args.lake:
+        lake_roots = [repo_root / lk if not Path(lk).is_absolute() else Path(lk)
+                      for lk in args.lake]
+        # normalize: keep only existing own lakes
+        lake_roots = [lk.resolve() for lk in lake_roots if lk.exists()]
+    else:
+        nb_root = repo_root / "MyIA.AI.Notebooks"
+        lake_roots = discover_lakes(nb_root)
+
+    results = [scan_lake(lk, repo_root) for lk in lake_roots]
+    results = [r for r in results if r.files > 0]
+    results.sort(key=lambda x: x.lake)
+
+    if args.json:
+        payload = {
+            "lakes": [
+                {
+                    "lake": _norm(r.lake),
+                    "files": r.files,
+                    "naive_sorry": r.naive_sorry,
+                    "code_sorry": r.code_sorry,
+                    "distinct_code_sorry": r.distinct_code_sorry,
+                    "vacuous": [
+                        {"file": _norm(d.file), "line": d.line, "kind": d.kind,
+                         "name": d.name, "is_marker": d.is_marker,
+                         "sorry_count": d.sorry_count}
+                        for d in r.vacuous
+                    ],
+                }
+                for r in results
+            ],
+        }
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        print(render_table(results))
+        if not args.no_vacuous:
+            print(render_vacuous(results))
+
+    if args.strict:
+        offenders = [d for r in results for d in r.vacuous if not d.is_marker]
+        if offenders:
+            print(f"\nSTRICT FAIL: {len(offenders)} vacuous non-marker theorem(s).",
+                  file=sys.stderr)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lean/tests/test_count_code_sorry.py
+++ b/scripts/lean/tests/test_count_code_sorry.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Tests for count_code_sorry.py -- the real-sorry counter + vacuous detector.
+
+Dual-mode: runnable directly or under pytest (auto-collected by scripts-tests.yml).
+Covers the two organ responsibilities cited in #10188:
+
+1. ``sorry`` in comments/prose is NOT counted; ``sorry`` in code IS counted and
+   attributed to its enclosing declaration.
+2. vacuous conclusions (``: True``, ``∃ ..., True``) are flagged; legit
+   ``a = True`` and ``True -> True`` are NOT (low false-positive by design).
+3. ``_en`` i18n mirrors are excluded from the *distinct* count.
+4. ``*_prerequisites`` markers are tagged so the strict gate ignores them.
+"""
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from count_code_sorry import (  # noqa: E402
+    _VACUOUS_RE,
+    main,
+    scan_file,
+    strip_lean_comments,
+)
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    """Write a .lean snippet to the test's tmp_path and return its path."""
+    f = tmp_path / name
+    f.write_text(body, encoding="utf-8")
+    return f
+
+
+# --------------------------------------------------------------------------- #
+# strip_lean_comments
+# --------------------------------------------------------------------------- #
+
+def test_strip_line_comment(tmp_path: Path) -> None:
+    src = "theorem foo : True := by\n  -- sorry in comment\n  trivial"
+    assert "sorry" not in strip_lean_comments(src)
+
+
+def test_strip_block_comment_nested() -> None:
+    # Lean nests block comments: /- outer -/ ... -/ is NOT a close inside outer.
+    src = "/- outer /- inner sorry -/ still outer sorry -/\ntheorem foo : True := by trivial"
+    stripped = strip_lean_comments(src)
+    assert "sorry" not in stripped
+    # The theorem line survives (only comment chars blanked).
+    assert "theorem foo" in stripped
+
+
+def test_strip_preserves_newlines_for_line_numbers() -> None:
+    src = "a\n-- comment line\nb"
+    stripped = strip_lean_comments(src)
+    assert stripped.count("\n") == src.count("\n")
+
+
+def test_dash_dash_inside_string_is_not_a_comment() -> None:
+    src = 'def s := "-- not a comment sorry"\n-- real comment sorry'
+    stripped = strip_lean_comments(src)
+    # The string sorry survives; the comment sorry is blanked.
+    assert stripped.count("sorry") == 1
+
+
+# --------------------------------------------------------------------------- #
+# sorry counting + attribution
+# --------------------------------------------------------------------------- #
+
+def test_sorry_in_docstring_not_counted(tmp_path: Path) -> None:
+    f = _write(tmp_path, "Foo.lean", textwrap.dedent("""\
+        /- Docstring mentions sorry twice: sorry sorry -/
+        theorem real_one (n : Nat) : n = n := by sorry
+        -- prose: sorry in a line comment
+        theorem no_sorry (n : Nat) : n + 0 = n := by rfl
+        """))
+    decls, naive, code = scan_file(f, f.parent)
+    assert code == 1, f"only the code sorry should count: naive={naive} code={code}"
+    assert naive >= 3, "naive grep counts the docstring + comment sorries"
+    by_name = {d.name: d.sorry_count for d in decls}
+    assert by_name.get("real_one") == 1
+    assert by_name.get("no_sorry") == 0
+
+
+# --------------------------------------------------------------------------- #
+# vacuous detection -- the core low-FP heuristic
+# --------------------------------------------------------------------------- #
+
+def test_vacuous_single_line_true(tmp_path: Path) -> None:
+    f = _write(tmp_path, "T.lean", "theorem t : True := by trivial\n")
+    decls, _, _ = scan_file(f, f.parent)
+    assert decls[0].is_vacuous
+
+
+def test_vacuous_existential_true(tmp_path: Path) -> None:
+    f = _write(tmp_path, "T.lean",
+               "theorem t (n : Nat) : ∃ μ : Nat, True := by exact ⟨0, trivial⟩\n")
+    decls, _, _ = scan_file(f, f.parent)
+    assert decls[0].is_vacuous
+
+
+def test_vacuous_multiline_existential_true(tmp_path: Path) -> None:
+    f = _write(tmp_path, "T.lean", textwrap.dedent("""\
+        theorem folk (g : Nat) :
+            ∃ (d : Nat), d < 1 ∧
+              ∃ (s : Nat), True := by
+          sorry
+        """))
+    decls, _, _ = scan_file(f, f.parent)
+    assert decls[0].is_vacuous, "multiline ∃ ..., True must be flagged"
+    assert decls[0].sorry_count == 1
+
+
+def test_NOT_vacuous_equality_with_true(tmp_path: Path) -> None:
+    # ``a = True`` is an equation, not an empty conclusion: char before True is '='.
+    f = _write(tmp_path, "T.lean", "theorem t (a : Prop) [Decidable a] : a = True := by sorry\n")
+    decls, _, _ = scan_file(f, f.parent)
+    assert not decls[0].is_vacuous
+
+
+def test_NOT_vacuous_true_arrow_true(tmp_path: Path) -> None:
+    # ``True -> True`` is trivial-but-meaningful as a function type.
+    f = _write(tmp_path, "T.lean", "theorem t : True -> True := by intro h; exact h\n")
+    decls, _, _ = scan_file(f, f.parent)
+    assert not decls[0].is_vacuous
+
+
+def test_marker_prerequisites_tagged(tmp_path: Path) -> None:
+    f = _write(tmp_path, "T.lean", "theorem foo_prerequisites : True := by trivial\n")
+    decls, _, _ = scan_file(f, f.parent)
+    assert decls[0].is_vacuous is True        # still detected (advisory)
+    assert decls[0].is_marker is True          # but tagged -- strict gate skips it
+
+
+def test_regex_unit_directly() -> None:
+    # Direct regex contract: anchored at end, preceded by ':' or ','.
+    assert _VACUOUS_RE.search("theorem t : True")
+    assert _VACUOUS_RE.search("∃ μ, True")
+    assert not _VACUOUS_RE.search("a = True")
+    assert not _VACUOUS_RE.search("True -> True")
+
+
+# --------------------------------------------------------------------------- #
+# _en mirror distinct-count
+# --------------------------------------------------------------------------- #
+
+def test_en_mirrors_excluded_from_distinct(tmp_path: Path) -> None:
+    lake = tmp_path / "fake_lean"
+    lake.mkdir()
+    (lake / "lakefile.lean").write_text("", encoding="utf-8")
+    (lake / "Foo.lean").write_text("theorem a : True := by sorry\n", encoding="utf-8")
+    (lake / "Foo_en.lean").write_text("theorem a : True := by sorry\n", encoding="utf-8")
+    from count_code_sorry import scan_lake
+    r = scan_lake(lake, tmp_path)
+    assert r.code_sorry == 2          # both files have one code sorry
+    assert r.code_sorry_en_mirrors == 1
+    assert r.distinct_code_sorry == 1  # the _en mirror is a translation sibling
+
+
+# --------------------------------------------------------------------------- #
+# CLI smoke (default exit 0; --strict exit 1 on vacuous non-marker)
+# --------------------------------------------------------------------------- #
+
+def _make_demo_lake(tmp_path: Path, decl: str) -> Path:
+    repo = tmp_path / "repo"
+    lake = repo / "MyIA.AI.Notebooks" / "demo_lean"
+    lake.mkdir(parents=True)
+    (lake / "lakefile.lean").write_text("", encoding="utf-8")
+    (lake / "D.lean").write_text(decl, encoding="utf-8")
+    return repo
+
+
+def test_cli_smoke_default_exit_zero(tmp_path: Path) -> None:
+    repo = _make_demo_lake(tmp_path, "theorem a : True := by trivial\n")
+    rc = main(["--repo", str(repo)])
+    assert rc == 0, "default mode is advisory -> exit 0 even with a vacuous theorem"
+
+
+def test_cli_strict_exit_one_on_vacuous_non_marker(tmp_path: Path) -> None:
+    repo = _make_demo_lake(tmp_path, "theorem a : True := by trivial\n")
+    rc = main(["--repo", str(repo), "--strict"])
+    assert rc == 1, "strict mode fires on a vacuous non-marker theorem"
+
+
+def test_cli_strict_exit_zero_when_only_markers(tmp_path: Path) -> None:
+    repo = _make_demo_lake(tmp_path, "theorem foo_prerequisites : True := by trivial\n")
+    rc = main(["--repo", str(repo), "--strict"])
+    assert rc == 0, "markers are assumed-legit -> strict does not fire"
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Grain: DEEP/lean -- lane myia-po-2026:CoursIA

Quoi: count_code_sorry organ -- real sorry count (strips comments, attributes per-declaration) + vacuous-conclusion (`: True` / `∃ ..., True`) advisory.
Preuve: 16/16 unit tests pass (CI Scripts Tests CPU); reproduces #10188 table exactly (code=41, distinct=21, grep=465, ratio=11x); 5 non-marker vacuous verified firsthand on origin/main.
Perimetre: scripts/lean/count_code_sorry.py + tests + README only. Out of scope: .lake/_peters/reference_docs/vendored. T1 GaleShapley + T2 Folk-Gittins Lean requalification are the follow-up PR (needs WSL lake build + FR/EN parity).

---
## Summary

Delivers **Task 3 (the organ)** of #10188 — the measurement tool that the Lean requalification PRs (T1 GaleShapley `IsStable`, T2 Folk/Gittins) must cite for their before/after code-only sorry count. Pure text analysis: **no Lean or Mathlib needed** to run it.

Two responsibilities, each closing a gate blind spot documented in #10188:

1. **Real sorry count.** `grep -c sorry` overstates repo-scale debt ~11x (counts `sorry` in docstrings, line comments, strings). This script strips comments (nested `/- -/` blocks + `--` lines, string-aware, position-preserving for `file:line` reporting), counts code-only sorry, attributes each to its enclosing declaration. `_en` i18n mirrors (#4980, byte-identical translation siblings) reported separately so the *distinct* count is not inflated.

2. **Vacuous-conclusion advisory.** A theorem whose conclusion is `True` (`: True` or `∃ ..., True`) passes grep / `lake build` / `#print axioms` / `sorryAx` scans — fully verified, entirely empty. Closing its sorry yields an authentic-looking count delta with zero math. The detector anchors at the type tail before `:=`, so `a = True` (equation) and `True -> True` (function) are **not** flagged — low FP by design. Advisory (exit 0 default); `--strict` exits 1 on a vacuous non-marker theorem (opt-in post-triage gate). `*_prerequisites` markers (knot `MathlibPrerequisites` port) are tagged `is_marker` and skipped by `--strict`.

## Acceptance criterion 4 — per-lake table reproduced by the script

```
Lake                                               code  distinct   grep  ratio
-------------------------------------------------------------------------------
SymbolicAI/Lean/knot_lean                            32        16     75     2x
Probas/decision_theory_lean                           4         2     45    11x
SymbolicAI/Lean/conway_lean                           3         2    159    53x
GameTheory/game_theory_lean                           2         1     30    15x
...
-------------------------------------------------------------------------------
TOTAL                                                41        21    465    11x
```

Matches #10188 exactly: code=41, distinct=21, ratio=11x. (The `grep` column drifts with prose across commits; the **code** count — the real debt — is the stable, exact figure.)

## Advisory output — the 5 non-marker vacuous theorems (+ their `_en` mirrors)

```
game_theory_lean/RepeatedGames/Folk.lean:86      theorem folk_theorem_discounted   [sorry on trivial goal: 1]
game_theory_lean/RepeatedGames/Folk.lean:102     theorem folk_theorem_boundary
game_theory_lean/StableMarriage/GaleShapley.lean:68  theorem gale_shapley_terminates
game_theory_lean/StableMarriage/GaleShapley.lean:78  theorem gale_shapley_produces_matching
Probas/decision_theory_lean/Gittins/GittinsTheorem.lean:149  theorem gittins_beats_greedy
```
All 5 verified firsthand at the cited locations before writing the detector. Plus 11 `theorem *_prerequisites` in knot `MathlibPrerequisites.lean` correctly tagged `[marker -- assumed legit]`.

## Verification

- **16/16 unit tests pass** (`scripts/lean/tests/test_count_code_sorry.py`): comment stripping (nested block, line, string-protection, newline-preservation), sorry attribution, the vacuous FP threshold (`: True` / `∃ ..., True` flagged; `a = True` / `True -> True` NOT), `_en` distinct-count, marker tagging, CLI exit codes (default 0, `--strict` 1 on non-marker / 0 on marker-only).
- **Reproduces the #10188 table** (above) — exact code/distinct/ratio.
- **5 non-marker vacuous** all firsthand-confirmed on `origin/main` (G.1): Folk.lean L86/L102, GaleShapley.lean L68/L78, GittinsTheorem.lean L149.
- LF-only (`CR=0` via Python `count(b'\r')`, not `od|grep` per c.965), UTF-8 no-BOM.
- Out of scope (#4980 status quo): `.lake/packages/`, `_peters/`, `reference_docs/`, vendored libs.
- `scripts/lean/README.md` documents the organ (FR-first, grouped with `check_public_anchor.py` — both sorry-integrity advisors).

## Scope — partial (Task 3 of 3)

This PR delivers **only the organ** (acceptance criterion 4 + the measurement foundation for criterion 5's before/after count). The Lean requalifications (criterion 1 GaleShapley `∃ μ, IsStable μ`, criterion 2 Folk/Gittins debt reclassification) are the **follow-up Lean PR** — they need WSL `lake build SUCCESS` on 3 lakes + FR/EN parity on the `_en` files, and are tracked separately. Splitting organ-from-proof keeps each PR atomically verifiable (catalog-pr-hygiene HARD 3).

See #10188 (Task 3/3, partial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
