### PR TITLE
fix(search,#10121): scrub App-10b papermill metadata path leak to basename

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
@@ -1942,8 +1942,8 @@
    "end_time": "2026-08-09T09:26:04.793512+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\c1331x56-app10b-prongb\\MyIA.AI.Notebooks\\Search\\Applications\\Hybrid\\App-10b-Portfolio-CSharp.ipynb",
-   "output_path": "C:\\dev\\c1331x56-app10b-prongb\\MyIA.AI.Notebooks\\Search\\Applications\\Hybrid\\App-10b-Portfolio-CSharp_output.ipynb",
+   "input_path": "App-10b-Portfolio-CSharp.ipynb",
+   "output_path": "App-10b-Portfolio-CSharp_output.ipynb",
    "parameters": {},
    "start_time": "2026-08-09T09:25:56.379096+00:00",
    "version": "2.7.0"


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA

Quoi: Scrub the 2 absolute worktree paths in App-10b's metadata.papermill.{input,output}_path to basename.
Preuve: detect_papermill_path_leak.py --scan reports [] (2 -> 0 high-severity defects, exit 0); JSON valid; CR=0.
Perimetre: 1 file, 2 lines (metadata only, no cells/outputs touched). No re-exec (secrets-hygiene rule 6 metadata exception).

---

## Summary

`detect_papermill_path_leak.py --scan-all` reported 2 high-severity defects on `Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb`: `metadata.papermill.input_path` and `output_path` carried the absolute worktree path (`C:\dev\c1331x56-app10b-prongb\...`) from a papermill run during PR #10048 / the App-10b Prong-B re-exec. A machine-local path leak (secrets-hygiene rule 6, metadata variant).

## Fix

Normalize the 2 fields to their basename — the explicitly-allowed manual normalization for `metadata.papermill.{input,output}_path` (secrets-hygiene rule 6: these are **metadata**, not cell outputs, so no re-execution is required; the C.2 markdown-style exception applies). Byte-level replacement preserves every other byte (including existing trailing whitespace) → minimal 2-line diff.

## Verification

- `detect_papermill_path_leak.py --scan <nb>` → `[]` (2 → 0 defects, exit 0).
- JSON valid; LF-only (`CR=0` via Python `count(b'\r')`, c.965).
- Diff = exactly 2 lines (numstat `2 2`), no cell source/outputs touched.
- Firsthand confirmed on `origin/main` before editing: both paths were the `c1331x56-app10b-prongb` absolute worktree path.

Closes #10121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)