### PR TITLE
feat(d5,#9790): filter integer nav-link cross-references in D5 scanner (-753 corpus)

### DIFF
--- a/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
@@ -553,20 +553,27 @@ def _is_notebook_cross_reference(value: float, text: str) -> bool:
     l'IDENTIFIANT du notebook pointe (dans le texte du lien ou dans le nom du
     fichier .ipynb), pas un resultat de calcul.
 
-    SAFE par construction (0 sur-filtrage) : on ne filtre la decimale N.M que si
-    **toutes** ses occurrences dans la cellule tombent a l'interieur d'un span de
-    lien markdown ``[...](...ipynb)``. Ainsi, si la meme cellule contient aussi
-    N.M comme vraie mesure en prose (hors-lien), au moins une occurrence est
-    hors-lien -> on ne filtre pas (l'orphelin legitime survive). Les indices de
-    notebook etant toujours decimaux (2.8, 1.3), un entier n'est jamais filtre.
+    SAFE par construction (0 sur-filtrage) : on ne filtre la valeur (decimale N.M
+    OU entier) que si **toutes** ses occurrences dans la cellule tombent a
+    l'interieur d'un span de lien markdown ``[...](...ipynb)``. Ainsi, si la meme
+    cellule contient aussi la valeur comme vraie mesure en prose (hors-lien), au
+    moins une occurrence est hors-lien -> on ne filtre pas (l'orphelin legitime
+    survive).
+
+    Entiers ET decimaux : certaines series nomment leurs notebooks par un INDICE
+    DECIMAL (ML/DataScience : 2.8, 1.3), d'autres par un INDICE ENTIER (GameTheory,
+    SymbolicAI : « [GameTheory-7](GameTheory-7-ExtensiveForm.ipynb) »,
+    « [<< 12-Reputation](12-ReputationGames.ipynb) »). L'exclusion prematuree des
+    entiers (historique : « un indice est toujours decimal ») a ete refutee par le
+    forensic po-2023 c.188 sur SymbolicAI (375/2458 = 15%) et GameTheory (34%) --
+    la majorite des FPs nav-link sont des entiers. L'identite SAFE (toutes les
+    occurrences dans un span lien) couvre les deux formes.
 
     On ne s'appuie PAS sur le pattern keyword « section N.M » (plus ambigu, defer).
 
     Falsifiable both-directions : un nombre qui n'apparait dans AUCUN lien
     markdown .ipynb, ou dont une occurrence est hors-lien, n'est PAS filtre.
     """
-    if value == int(value):
-        return False  # un indice de notebook est decimal (2.8), jamais entier
     token = f"{value:g}"
     token_re = re.compile(r"(?<![\d.])" + re.escape(token) + r"(?![\d.])")
     link_spans = [(m.start(), m.end()) for m in _MARKDOWN_IPYNB_LINK_RE.finditer(text)]

--- a/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
@@ -1066,12 +1066,47 @@ class TestNotebookCrossReferenceFilter:
         assert mod._is_notebook_cross_reference(0.69, text) is False
         assert mod._is_notebook_cross_reference(2.8, text) is True
 
-    def test_helper_integer_not_filtered(self):
-        # Un entier (pas une decimale N.M) n'est jamais un indice de notebook
-        # dans la syntaxe [N.M] -> non filtre (les indices de notebook sont
-        # decimaux : 2.8, 1.3).
+    def test_helper_integer_link_filtered(self):
+        # Cas reel GameTheory/SymbolicAI : certaines series nomment leurs
+        # notebooks par un INDICE ENTIER. « [12](12-quelquechose.ipynb) » ->
+        # 12 est l'indice du notebook pointe, pas une mesure. L'exclusion
+        # historique des entiers (refutee par forensic po-2023 c.188) est levee.
         text = "Voir [12](12-quelquechose.ipynb) pour la suite."
-        assert mod._is_notebook_cross_reference(12.0, text) is False
+        assert mod._is_notebook_cross_reference(12.0, text) is True
+
+    def test_helper_integer_gameyseries_nav_link(self):
+        # Cas fondateur (forensic po-2023 c.188, SymbolicAI 15% / GameTheory 34%
+        # des MISSING_FROM_OUTPUTS) : barre de navigation entre notebooks d'une
+        # serie a indice entier. Le « 7 » de « GameTheory-7 » est l'indice du
+        # notebook pointe, dans le texte ET dans l'URL du lien .ipynb.
+        text = ("**Navigation** : [GameTheory-7](GameTheory-7-ExtensiveForm-Csharp.ipynb) "
+                "| [GameTheory-11 (Bayesien)](GameTheory-11-BayesianGames.ipynb)")
+        assert mod._is_notebook_cross_reference(7.0, text) is True
+        assert mod._is_notebook_cross_reference(11.0, text) is True
+
+    def test_helper_integer_prevnext_bar(self):
+        # Barre prev/next « [<< 12-Reputation] » : l'indice 12 est en tete du
+        # texte du lien, objet navigationnel, pas une mesure.
+        text = "**Transition** : [<< 12-ReputationGames](12-ReputationGames.ipynb)"
+        assert mod._is_notebook_cross_reference(12.0, text) is True
+
+    def test_helper_integer_overfilter_guard_occurrence_outside_link(self):
+        # Anti-sur-filtrage (propriete SAFE cle, entiers) : si un entier apparait
+        # a la fois dans un lien .ipynb ET comme occurrence hors-lien (potentielle
+        # vraie mesure en prose, ex. « 2 joueurs »), on NE filtre PAS. Le
+        # conservatisme prime -- l'occurrence hors-lien peut etre le measurand.
+        text = "Ce jeu a 2 joueurs, cf. [2-Coordination](2-Coordination.ipynb)."
+        assert mod._is_notebook_cross_reference(2.0, text) is False
+
+    def test_helper_integer_measurement_cell_not_overfiltered(self):
+        # La cellule peut cohabiter indices-entiers (filtres) ET vraies mesures
+        # decimales (preservees) -- le filtre est par-valeur, SAFE. Ici 0.73 est
+        # une vraie valeur de Shapley en prose hors-lien -> non filtre, tandis
+        # que 15 (indice du notebook pointe) est filtre.
+        text = ("La valeur de Shapley calculee est 0.73 ; "
+                "suite : [GameTheory-15-Cooperatif](GameTheory-15-CooperativeGames.ipynb)")
+        assert mod._is_notebook_cross_reference(15.0, text) is True
+        assert mod._is_notebook_cross_reference(0.73, text) is False
 
     def test_helper_overfilter_guard_occurrence_outside_link(self):
         # Anti-sur-filtrage (propriete SAFE cle) : si N.M apparait a la fois
@@ -1093,8 +1128,8 @@ class TestNotebookCrossReferenceFilter:
         # dans les liens ne sont pas des mesures -> MISSING_FROM_OUTPUTS supprime.
         # Note : on n'ecrit PAS de « (2.8) » hors-lien -- un indice hors-lien
         # n'est pas filtre par le LINK-only filter (cas KEYWORD defer, volontai-
-        # rement conservateur). Les indices entiers-valeurs (3.0) ne sont pas
-        # filtres non plus (garde value==int(value)) -- on utilise 3.1.
+        # rement conservateur). Les indices decimaux (2.8, 3.1) et entiers
+        # sont desormais tous deux filtres (forensic po-2023 c.188).
         nb = tmp_path / "nav.ipynb"
         _make_notebook([
             _markdown_cell("# 2.9 Grokking\n"


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: MED/docs

## Ce que fait cette PR

Etend le filtre `_is_notebook_cross_reference` du detecteur D5 (FP class 5,
#9998/#10011) aux **indices de notebook ENTIFIERS** dans les liens markdown de
navigation. Suite directe du forensic po-2023 c.188 (SymbolicAI 375/2458 = 15%,
GameTheory 67/199 = 34% des MISSING_FROM_OUTPUTS) qui a réfuté la prémisse
historique « un indice de notebook est toujours décimal (2.8, 1.3), jamais
entier ».

## Le défaut (trouvé par po-2023 c.188, mesuré firsthand par le D5 owner)

`_is_notebook_cross_reference` (#10011) filtrait les **décimales** N.M dans les
liens `[N.M](fichier.ipynb)`, mais excluait prématurément les entiers :

```python
if value == int(value):
    return False  # un indice de notebook est decimal (2.8), jamais entier
```

Cette prémisse est **fausse** : les series GameTheory et SymbolicAI nomment leurs
notebooks par un **INDICE ENTIER**. Les barres de navigation pointent les
notebooks voisins via `[GameTheory-7](GameTheory-7-ExtensiveForm-Csharp.ipynb)`,
`[<< 12-Reputation](12-ReputationGames.ipynb)`, `[11-BayesianGames](...ipynb)`.
L'entier (7, 11, 12) est l'IDENTIFIANT du notebook pointé, pas une mesure —
exactement la classe de FP que le filtre devait capturer, mais qu'il laissait
passer à cause de l'exclusion prématurée.

Mesure firsthand (D5 owner, script `d5_navlink.py` sur le corpus 10192 findings
MISSING_FROM_OUTPUTS post-filtres) :
- **844 findings entiers** (.ipynb links, regex exacte du détecteur) = 8.3% du
  corpus — PLUS material que le list-marker (#10189, 770/7.4%).
- 805 dans liens `.ipynb` + 14 http + 13 other.
- Tous les 844 sont des entiers (les décimales .ipynb sont déjà filtrées).

## Le fix

**2 lignes supprimées** : retire le early-return `if value == int(value): return
False`. L'identité SAFE-by-construction (toutes les occurrences de la valeur
tombent dans un span lien `[...](...ipynb)`) s'étend naturellement aux entiers —
le token regex `(?<![\d.]){token}(?![\d.])` matche « 7 » dans « GameTheory-7 »
(le « - » n'est pas un digit). Le reste est correction de docstring.

## SAFE-by-construction (0 sur-filtrage, vérifié firsthand)

Un entier n'est filtré QUE si **toutes** ses occurrences dans la cellule sont
dans un span lien `.ipynb`. Vérifié firsthand sur un cas alarme (GameTheory-13
cellule 21) : la cellule contient 2 occurrences de « 13 », TOUTES deux dans
`[GameTheory-13-ImperfectInfo-CFR.ipynb](...ipynb)`. La cellule cohabite aussi
des mots de mesure (« valeur », « regret ») mais ceux-ci qualifient des nombres
DIFFÉRENTS (valeurs de regret décimales), pas le littéral « 13 ». L'alarme
cell-level (210) est un faux positif : la garantie SAFE tient au niveau
occurrence.

Anti-sur-filtrage (test `test_helper_integer_overfilter_guard`) : « Ce jeu a 2
joueurs, cf. [2-Coordination](2-Coordination.ipynb) » → « 2 » a une occurrence
hors-lien (« 2 joueurs ») → NON filtré (le measurand légitime survive).

## Validation

- `pytest scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py`
  → **125 passed** (121 existants conservés + 4 nouveaux tests entiers nets ; le
  test stale `test_helper_integer_not_filtered` qui enshrinit la prémisse fausse
  est remplacé par 5 tests corrects).
- Nouveaux tests : `test_helper_integer_link_filtered`,
  `test_helper_integer_gameyseries_nav_link` (cas fondateur GameTheory),
  `test_helper_integer_prevnext_bar` (`[<< 12-Reputation]`),
  `test_helper_integer_overfilter_guard_occurrence_outside_link` (SAFE clé),
  `test_helper_integer_measurement_cell_not_overfiltered` (cohabitation 0.73
  Shapley préservée + 15 indice filtré).
- Full-corpus before/after : **10411 → 9658 MISSING_FROM_OUTPUTS (-753, -7.2%)**.
  (Le delta net 753 < 844 projeté : la baseline ici est pure origin/main sans
  list-marker #10189, + interactions du ratio-gate de cellule.)

## Note de frontière

Ce grain raffine la conclusion « frontière SAFE line-level atteinte » du cycle 44
(issuecomment-5232230654) : la classe nav-link-entier était DISTINCTE des 3
classes réfutées (table-row / LaTeX-outside-$ / identifier-bound) — c'est un
span-mask au même titre que `_LATEX_MATH_SPAN_RE` et le cross-ref décimal #10011,
pas une heuristique line-level sémantique. po-2023 l'avait correctement isolée
comme sous-classe propre ; ma réfutation cycle 44 ne l'avait pas mesurée
séparément. Bonne illustration du pattern #9998 : characterization (po-2023) →
wiring owner (po-2025).

## Périmètre

2 fichiers, +57/-15. 1 fonction modifiée (logic: -2 lignes, docstring corrigée).
0 catalogue, 0 notebook, 0 re-exec.

See #9768 (EPIC). See #9790 (po-2023 heuristics source, c.188 nav-link). cc @po-2023 (forensic source).
