### PR TITLE
fix(scan-md,#10097): make SEP_ROW_RE blockquote-aware (-42 corpus FP)

### DIFF
--- a/scripts/notebook_tools/scan_md_table_syntax.py
+++ b/scripts/notebook_tools/scan_md_table_syntax.py
@@ -74,8 +74,11 @@ PIPE_LINE_RE = re.compile(r'\|')
 # A GFM table separator row: optional leading/trailing pipe, then one or more
 # cells of the form `:?-+:?` (dashes, optionally colon-padded for alignment),
 # joined by pipes. e.g. `|---|---|`, `|:---:|---:|`, `---|---`.
+# An optional blockquote marker ``>`` is tolerated: a GFM table wrapped in a
+# blockquote keeps its separator as ``> |---|---|``, and ``^\s*`` alone missed
+# the ``>`` and flagged valid blockquote tables as NO_SEP (ICT-0-Annexe, #10097).
 SEP_ROW_RE = re.compile(
-    r'^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?\s*$'
+    r'^\s*>?\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?\s*$'
 )
 
 # A markdown heading line (`#`..`######`). A heading directly above a table is
@@ -217,7 +220,13 @@ def _column_count(line):
 
 
 def _is_blank(line):
-    return line.strip() == ""
+    # A bare blockquote marker ``>`` (optionally followed by whitespace) renders
+    # as a blank separator within a blockquote -- it provides the same visual
+    # separation between a table and surrounding prose as a true blank line, so
+    # for the table-glue checks (NO_BLANK_BEFORE/AFTER) it counts as blank
+    # (a ``>`` line does NOT glue a blockquote table to its neighbors).
+    s = line.strip()
+    return s == "" or s == ">"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
+++ b/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
@@ -23,6 +23,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from scan_md_table_syntax import (  # noqa: E402
+    SEP_ROW_RE,
     _column_count,
     _find_table_blocks,
     _has_delimiter_pipe,
@@ -208,6 +209,66 @@ class TestDetectNoSep:
         ]
         f = detect_md_table_syntax(lines)
         assert [x for x in f if x["pathology"] == "NO_SEP"] == []
+
+
+class TestBlockquoteTableNotFalsePositive:
+    """FP classe #10097 (po-2023 c.189) : table GFM valide enveloppee dans un
+    blockquote. Chaque ligne porte un prefixe ``>`` ; la ligne separateur
+    ``> |---|---|`` est un separateur GFM VALIDE, mais ``SEP_ROW_RE`` (``^\\s*``)
+    ne matchait pas le ``>`` -> faux NO_SEP. Cas fondateur : ICT-0-Annexe."""
+
+    def test_blockquote_table_not_no_sep(self):
+        # Table blockquote complete : header + separateur + 2 data, toutes prefixees `> `.
+        # Le separateur `> |---|---|` doit etre reconnu -> pas de NO_SEP.
+        lines = [
+            "> | Pattern original | Restaure en |",
+            "> |---|---|---|",
+            "> | `\\text{X}*_\\text{Y}` | `\\text{X}_\\text{Y}` | 4 |",
+            "> | `\\min*` | `\\min_*` | 2 |",
+        ]
+        f = detect_md_table_syntax(lines)
+        assert [x for x in f if x["pathology"] == "NO_SEP"] == [], (
+            f"blockquote table with valid `> |---|` separator must not be NO_SEP, "
+            f"got {[x for x in f if x['pathology'] == 'NO_SEP']}")
+
+    def test_blockquote_sep_row_regex_match(self):
+        # Test unitaire du regex : la ligne separateur blockquote matche SEP_ROW_RE.
+        assert SEP_ROW_RE.match("> |---|---|---|")
+        assert SEP_ROW_RE.match("> |:---:|---:|")
+        assert SEP_ROW_RE.match("> ---|---|---")
+        # Un separateur SANS blockquote matche toujours (regression guard).
+        assert SEP_ROW_RE.match("|---|---|---|")
+        assert SEP_ROW_RE.match("  |---|---|")
+
+    def test_blockquote_table_no_col_mismatch(self):
+        # La table blockquote est bien formee (3 colonnes logiques) -> pas de
+        # COL_MISMATCH non plus. (Le prefixe `> ` ajoute une "cellule" fantome a
+        # toutes les lignes de maniere CONSISTANTE, donc la detection de mismatch
+        # header-vs-data reste correcte.)
+        lines = [
+            "> | a | b | c |",
+            "> |---|---|---|",
+            "> | 1 | 2 | 3 |",
+            "> | 4 | 5 | 6 |",
+        ]
+        f = detect_md_table_syntax(lines)
+        assert [x for x in f if x["pathology"] == "NO_SEP"] == []
+        assert [x for x in f if x["pathology"] == "COL_MISMATCH"] == []
+
+    def test_blockquote_table_real_col_mismatch_still_flagged(self):
+        # Falsifiabilite : si une ligne blockquote a un vrai drift de pipes (5 au
+        # lieu de 3), COL_MISMATCH DOIT etre flagge -- le fix blockquote ne masque
+        # pas les vrais defauts.
+        lines = [
+            "> | a | b | c |",
+            "> |---|---|---|",
+            "> | 1 | 2 | 3 | extra | extra2 |",
+        ]
+        f = detect_md_table_syntax(lines)
+        cm = [x for x in f if x["pathology"] == "COL_MISMATCH"]
+        assert len(cm) >= 1, (
+            f"a real pipe-drift row in a blockquote table must still be flagged, "
+            f"got {f}")
 
 
 class TestDetectNoBlankBefore:


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: MED/guard

## Ce que fait cette PR

Rend le detecteur GFM `scan_md_table_syntax.py` (#10097) conscient des **tables
GFM enveloppees dans un blockquote**. Suite directe du forensic po-2023 c.189
(2 classes FP signalees au #10097 owner -- moi-meme).

## Le defaut (trouve par po-2023 c.189, verifie firsthand)

`ICT-0-Annexe-IntegratedComplexityTheory.md` L19-25 contient une table GFM
**parfaitement valide** enveloppee dans un blockquote :

```markdown
> | Pattern original | Restaure en | Occurrences |
> |---|---|---|
> | `\text{X}*\text{Y}` | `\text{X}_\text{Y}` | 4 |
> | `\min*` | `\min_*` | 2 |
```

Le detecteur flaggait cette table comme **NO_SEP** ("bloc table de 6 lignes sans
ligne separateur") -- un FAUX POSITIF. Cause racine : `SEP_ROW_RE` (`^\s*...`)
ne matchait pas le prefixe blockquote `>` de la ligne separateur `> |---|---|---|`.
Le separateur VALIDE n'etait pas reconnu -> `has_sep=False` -> NO_SEP flaggue.

Verifie firsthand : la ligne separateur `> |---|---|---|` (L20) EST presente et
valide. po-2023 a raison.

## Le fix (2 changements chirurgicaux)

1. **`SEP_ROW_RE`** : ajoute un `>?` optionnel apres le `^\s*` ->
   `^\s*>?\s*\|?...`. Reconnait `> |---|---|---|`. Le decalage de compte de
   colonnes (le prefixe `> ` devient une "cellule" fantome) est CONSISTANT sur
   toutes les lignes -> la detection COL_MISMATCH header-vs-data reste correcte
   (verifie par test `test_blockquote_table_real_col_mismatch_still_flagged`).

2. **`_is_blank`** : traite un marqueur blockquote nu `>` (suivi optionnellement
   d'espaces) comme un separateur blank. Sans cela, reconnaitre le separateur
   exposait 2 nouveaux FP NO_BLANK_BEFORE/AFTER (la table blockquote est
   "collee" aux lignes `>` environnantes). Un `>` nu rend bien comme une ligne
   vide de separation dans le blockquote -- semantiquement blank pour le
   table-glue. (Trade 1 NO_SEP FP pour 2 NO_BLANK FP sans ce 2e fix -> net-
   negatif ; le 2e fix rend le tout net-positif, ICT-0-Annexe 1 defaut -> 0.)

## Validation

- `pytest scripts/notebook_tools/tests/test_scan_md_table_syntax.py` ->
  **45 passed** (41 existants + 4 nouveaux). Nouvelle classe
  `TestBlockquoteTableNotFalsePositive` : table blockquote not-NO_SEP, regex
  match `> |---|`, pas de COL_MISMATCH sur table bien formee, ET real col-
  mismatch still flagged (falsifiabilite anti-regression).
- `scan_md_table_syntax.py ICT-0-Annexe-IntegratedComplexityTheory.md` ->
  **0 defaut** apres le fix (1 NO_SEP avant).
- Full-corpus before/after : **493 -> 451 total findings (-42, -8.5%)**. La classe
  blockquote-table FP est plus large que le seul ICT-0-Annexe (~42 tables
  blockquote FPs fleet-wide, principalement .md de synthese ICT/SymbolicAI).

## Note de perimetre (2e FP DEFERRE)

po-2023 c.189 a signale une 2e classe FP : **valeur absolue LaTeX multiline**
(`$|...-...|$` spanning un newline, ICT-7 cell[11]). Verifie firsthand aussi
(vrai FP). MAIS le fix est un mecanisme DIFFERENT (masque math multiline
stateful -- `MATH_SPAN_RE` est single-line `[^$\n]*`), plus risque. Cette PR
traite le blockquote (propre, low-risk) seule -- la 2e classe merite sa propre
PR (atomic-PR : 1 sujet, 2 mecanismes = 2 PRs). DM a po-2023 pour ack le defer.

## Perimetre

2 fichiers, +72/-2. 2 edits chirurgicaux (SEP_ROW_RE + _is_blank) + 4 tests.
0 catalogue, 0 notebook, 0 re-exec.

See #10097 (detecteur source-level GFM). See #3966 (epic parent). cc @po-2023 (c.189 forensic source).
