### PR TITLE
docs(rl): interpret rl_10 reward-shaping convergence table (central result was unread)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb
@@ -381,6 +381,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b5e10n01",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Lecture du compromis : vitesse de convergence vs garantie theorique\n",
+    "\n",
+    "La table ci-dessus tranche la question empirique avant que la section suivante ne formalise la garantie. Trois constats :\n",
+    "\n",
+    "- **Le shaping accelere massivement la convergence.** Potential-based et Heuristic atteignent le seuil (return MA-50 >= -30) en ~50 episodes, contre **190** pour la Baseline sans guidance -- un facteur ~4.\n",
+    "- **Le Curriculum est intermediaire (122 episodes).** Contrairement a l'intuition, il n'est pas le plus rapide ici : en diluant l'apprentissage sur cinq positions de depart successives, il retarde l'apprentissage depuis la position reelle `env.start`, qui n'intervient qu'en derniere phase.\n",
+    "- **Potential-based et Heuristic sont ex aequo en vitesse (50)** -- mais cette egalite masque la difference essentielle que la section suivante formalise : seul le shaping **potential-based** preserve la politique optimale (theoreme de Ng, Harada & Russell, 1999). L'heuristique, tout aussi rapide sur ce graphe, n'offre aucune garantie de ne pas biaiser la solution trouvee.\n",
+    "\n",
+    "Le seuil **MA-50 = -30** fixe le critere de convergence retenu : un return moyen acceptable sur les 50 derniers episodes. C'est lui qui definit le << episode de convergence >> de la table, et non un critere de politique optimale (traite par la cellule suivante, qui verifie `Q' = Q* - Phi`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a4717ba9",
    "metadata": {
     "tags": []


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: MED/guard (#10197)

## Ce que fait cette PR

Ajoute UNE cellule markdown d'interpretation au notebook `rl_10_reward_shaping.ipynb`, immediatement apres la cellule de code qui produit le resultat central (le plot de comparaison 4-methodes + la speed table), et avant la section theorem. Le notebook livrait sa payload empirique principale puis sautait au theoreme de Ng-Harada-Russell sans que personne ne lise ce que le plot et la table montraient.

## Le gap (verifie firsthand, G.1)

- **cell 7** (markdown) : annonce le graphique ("Le graphique ci-dessous compare...").
- **cell 8** (code) : produit LE resultat central --
  - plot `Vitesse d'apprentissage : Reward Shaping vs Curriculum` (display_data, image presente),
  - STDOUT speed table :
    ```
    Episodes pour atteindre un return moyen >= -30 (MA-50) :
      Baseline             -> episode 190
      Potential-based      -> episode 50
      Heuristic            -> episode 50
      Curriculum           -> episode 122
    ```
- **cell 9** (markdown, maintenant cell 10) : sautait DIRECTEMENT a `## 5. Pourquoi le Potential-Based Shaping fonctionne / Theoreme (Ng, Harada & Russell, 1999)` -- ZERO interpretation du plot ni de la table.

C'etait la payload pedagogique du notebook entier qui passait non-lue : le classement empirique des 4 methodes n'etait jamais enonce, alors qu'il conditionne toute la suite.

## Le fix

1 cellule markdown (FR, style ASCII-fr du notebook environnant -- `Theoreme`, `episodes`, pas d'accents -- pour matcher cell 7/cell 9 existantes). Lit la VRAIE table (pas un classement imagine) :

- **Shaping accelere x4** : Potential-based & Heuristic = 50 episodes vs Baseline = 190.
- **Curriculum intermediaire (122)** : contre-intuitif, pas le plus rapide -- dilution sur 5 positions de depart, `env.start` qu'en derniere phase.
- **Potential-based = Heuristic en vitesse, mais seule potential-based a la garantie** : pont vers le theoreme suivant.

## Honnetete (G.1)

Un scan prealable avait classe "Curriculum > Potential-based > Heuristic > Baseline qui plafonne". **FAUX** : la table reelle (lue firsthand) donne Potential-based = Heuristic = 50 < Curriculum = 122 < Baseline = 190. Le curriculum n'est PAS le plus rapide. L'interpretation livree est fidele au STDOUT commite, pas au pitch du scan.

## Validation

- Markdown-only : **0 cellule code modifiee** (regle C.3 : pas de re-exec). Outputs existants (plot image + speed table stdout) preserves intacts (C.2 exception markdown-only).
- Insertion **raw-text chirurgicale** (1 cellule ajoutee, +18/-0, `git diff --stat` = 1 file +18) -- pas de round-trip nbformat (lecon : `load-modify-dump` = destruction). JSON valide post-insertion, 21 cells (etait 20).
- H.3 / C.1 / exec_count : 8 code cells, **0 violation C.1** (NotImplementedError/assert False), **0 violation H.3** (exec_count None + no outputs), toutes `execution_count` set.
- L898 collision guard : 0 PR open/merged sur `rl_10_reward_shaping`.

## Perimetre

1 fichier, +18/-0. 1 cellule markdown d'interpretation. 0 catalogue, 0 code, 0 re-exec.
