### PR TITLE
fix(gitleaks,#10143): class-based FP suppression + positive control (29 FPs gone, scanner armed)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -43,6 +43,20 @@ regexes = [
     '''os\.getenv\(['\"][A-Z_]+['\"]\)''',  # env var reads without defaults
     '''data:image/[a-z]+;base64,''',  # Inline base64 images in outputs
     '''^[A-Za-z0-9+/]{100,}={0,2}$''',  # Base64 blobs (long lines typical of image outputs)
+    # --- #10143 class-based FP suppression (each read at source + positive control) ---
+    # OpenRouter pedagogical placeholder: real keys are `sk-or-v1-` + 64 hex chars;
+    # the uppercase-only suffix (VOTRE_CLE, VOTRE_CLE_ICI) is the FR teaching form and
+    # can never be a real key. Covers ~15 findings across GenAI/Vibe-Coding/Claude-Code.
+    # Positive control (#10143): a real sk-or-v1-<lowercase-hex> key in the same file
+    # is STILL flagged (uppercase-only class cannot match hex) — detector stays armed.
+    '''sk-or-v1-[A-Z][A-Z_]+''',
+    # NOTE: the standard JWT header `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9` is a non-secret
+    # protocol constant, but it CANNOT be allowlisted: it is a prefix of EVERY real JWT,
+    # and gitleaks allowlist matching is substring-based, so suppressing it disarms the
+    # jwt detector entirely (verified — a full jwt header.payload.signature vanished from
+    # the scan when this was listed). The 2 bare-header FP findings in Roo-Code docs
+    # (exemple-api.md, guide-agent.md) are left visible by design: keeping the jwt
+    # detector armed is worth 2 pedagogical-doc FPs. See #10143.
 ]
 
 # Teaching placeholders and model identifiers that `generic-api-key` reads as
@@ -65,4 +79,30 @@ stopwords = [
     "dummy_key",
     "no-key-needed",
     "GPT-4o-Transcribe",
+    # --- #10143 distinct pedagogical/test literals (each re-read at its source) ---
+    # None is a secret; none is rotatable. Kept as stopwords (substring on the finding)
+    # so a REAL key in the same file still fails the scan.
+    "sk-secret-12345",            # pedagogical key placeholder, Claude-Code commit-review README
+    "sk_live_1234567890abcdef",   # canonical Stripe TEST key, bonnes-pratiques.md (stripe-access-token)
+    "rt-67890abcdef",             # pedagogical refresh-token placeholder, Roo-Code exemple-api/guide-agent
+    "v4_officier_german",         # voice-clone sample name (character->voice map), p1_voice_cloning.py
+    "_getDistanceToBezierEdge2",  # vendored vis.js Bezier-edge function, movie_kg_interactive.html
+    "votre_token_ici",            # FR placeholder "your token here", archived README-ETUDIANTS-AUTH
+    "INVALID_TOKEN",              # error-string literal, archived ComfyUI auth-archaeology report
+    "b2NWTdQ/zSFsWQ/JwCHyK/egVV6jpIssX0htD16",  # throwaway ComfyUI-Login local test token, archived 2025-11 failed-auth report
+    "wrongkey",                   # pedagogical placeholder, auth-flip-runbook.md
+    "fixture-whisper-XXXX-1234",  # test fixture, scripts/secrets/tests/test_verify_running_containers.py
+    "hf_fixtureABCDEF1234567890", # test fixture (HF-token-shaped), same test file
+    "val2=with=equals",           # parser test fixture (value with embedded '='), test_notebook_tools_pure.py
+    "ghp_IMfYN5...NCsd",          # redacted GitHub-token example (the `...` is literal), symbolicai-lean translation CSV
 ]
+
+# NOTE (#10143) — INTENTIONALLY NOT ALLOWLISTED:
+#   c39ba121e12e5b40ac67a87836431e34  (CIVITAI_TOKEN, 6 occurrences)
+# Read at source: docker-configurations/_archive-20251125/docker-compose-no-auth.yml,
+# scripts/genai-stack/_archive/utils/reconstruct_env.py (default_config), + 3 archived
+# genai-image reports. Sits next to `HF_TOKEN=HF_TOKEN_REDACTED` (redacted) while this
+# value is NOT redacted, and is absent from .secrets/master.env — consistent with a REAL
+# committed token, not a fixture. Suppressing it would disarm the scanner exactly where
+# it caught something real. Left visible on purpose: if confirmed real, the fix is
+# ROTATION at Civitai (secrets-hygiene rule 5), not an allowlist entry.


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/guard #10179 (twin-parity rebaseline was c.1021 tooling). R6 ✓: security/gitleaks tooling, distinct from lean-organ/content/search-guard recent.

## Quoi
The gitleaks scanner (8.24.3, the CI pin) carried 37 dormant findings in tracked content that translation-sync multiplies ×7 (#10133) — blocking unrelated PRs on the SmartContract/GenAI families. Suppress by CLASS (not literal-by-literal), with the positive-control rigor the issue mandates.

## Preuve
Reproduced with the exact CI binary (`gitleaks_8.24.3_windows_x64`, downloaded fresh — Rule F: install the tool, don't bypass). Baseline `--no-git` scan on a fresh origin/main worktree: **37 findings**.

**After this config (37 → 8, 29 FPs suppressed):**
| class | mechanism | findings |
|-------|-----------|----------|
| OpenRouter placeholder `sk-or-v1-VOTRE_CLE[_ICI]` | regex `sk-or-v1-[A-Z][A-Z_]+` | 15 |
| 13 distinct pedagogical/test literals | stopwords (each re-read at source) | 14 |
| **total suppressed** | | **29** |

**Positive control (issue mandatory — prove a real key of the same form stays detected):**
```
baseline probe (no allowlist):  4 findings  (2 FP forms + 2 real-form keys)
with this allowlist:            2 findings  (real sk-or-v1-<hex> + full JWT — BOTH still flagged)
```
The FP forms (VOTRE_CLE, bare JWT header) are suppressed; real keys stay detected. Verdict: **ARMED — 0 detectors disarmed.**

## Perimetre
1 file: `.gitleaks.toml` (+40 lines: 1 regex + 13 stopwords + documentation). No version-pin change (CI/pre-commit parity unaffected). No code, no notebooks, no catalogue churn.

## Intentionally NOT suppressed (8 findings remain — scanner stays armed)
- **`c39ba121e12e5b40ac67a87836431e34` (CIVITAI_TOKEN, ×6)** — read at source: `docker-configurations/_archive/docker-compose-no-auth.yml`, `scripts/genai-stack/_archive/utils/reconstruct_env.py` (default_config), + 3 archived genai-image reports. Sits next to `HF_TOKEN=HF_TOKEN_REDACTED` (redacted) while this value is NOT; absent from `.secrets/master.env`. Consistent with a REAL committed token, not a fixture. **[ASK USER]** if confirmed real, the fix is rotation at Civitai (secrets-hygiene rule 5), not an allowlist entry. Suppressing it would disarm the scanner exactly where it caught something real.
- **bare JWT header `eyJhbGci...KpXVCJ9` (×2, Roo-Code docs)** — a non-secret protocol constant, but a PREFIX of every real JWT; gitleaks allowlist is substring-based, so suppressing it disarms the jwt detector (verified: a full `header.payload.signature` vanished when listed). 2 pedagogical-doc FPs are worth keeping the jwt detector armed.

## Scope note
A fresh worktree shows 37 tracked-content findings; the issue's 162 figure includes untracked `.lake/packages/` vendored content (gitignored — never in gitleaks-action's commit-diff CI scope). This PR addresses the tracked-content CI risk (the real ×7 translation-sync blocker). Vendored-path allowlisting (`.lake/packages/`, `DNNPlatform/`, `dist/*.min.js`) is left as follow-up since those findings can't surface in CI commit-diff scans.

See #10143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

