### PR TITLE
feat(lean,#10188): crystallize Gittins≡greedy coincidence (A4), drop 2 vacuous [decision_theory_lean]

### DIFF
--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/GittinsTheorem.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/GittinsTheorem.lean
@@ -145,10 +145,35 @@ theorem gittins_index_monotone_discount (arm : BanditArm) (γ₁ γ₂ : ℝ)
   simp only [gittinsIndex]
   apply le_refl
 
-/-- Pour le bandit à 2 bras, la politique de Gittins surpasse la politique gloutonne. -/
-theorem gittins_beats_greedy (inst : BanditInstance)
-    (h : inst.arms.size = 2) :
-    True := by  -- Placeholder : l'énoncé réel nécessite V(gittins) ≥ V(greedy)
-  trivial
+/-- Politique gloutonne (myope) : toujours jouer le bras de moyenne réelle la plus
+    élevée. C'est le même argmax que `gittinsPolicy` mais lu directement sur
+    `arm.trueMean` plutôt que via l'indice de Gittins. -/
+noncomputable def greedyPolicy (inst : BanditInstance) : Nat :=
+  ((Array.range inst.arms.size).foldl
+    (fun (best : Nat × ℝ) i =>
+      match inst.arms[i]? with
+      | none => best
+      | some arm =>
+        let g := arm.trueMean
+        if g > best.2 then (i, g) else best)
+    (0, 0)).1
+
+/-- Dans le modèle à moyenne connue, la politique de Gittins **coïncide** avec la
+    politique gloutonne, quelle que soit l'historique observé : l'indice de Gittins
+    égale `trueMean` (`gittins_index_known_arm`), donc les deux argmax portent sur la
+    même quantité. La preuve est définitionnelle (réduction à l'identité des deux
+    plis après débrouillage de `gittinsIndex`).
+
+    C'est précisément pourquoi l'ancien énoncé « Gittins bat greedy » était vide ici :
+    la domination de la politique de Gittins sur l'approche gloutonne n'apparaît que
+    dans le régime à croyances incertaines (posterior Beta–Bernoulli, exploration),
+    qui requiert la machinerie arrêt-optimal / Bellman absente de Mathlib (INTRINSIC,
+    `gittins_optimality` ci-dessus, #4039). Dans le modèle à bras connus,
+    Gittins = greedy, point. -/
+theorem gittinsPolicy_eq_greedyPolicy (inst : BanditInstance)
+    (histories : Array RewardHistory) :
+    gittinsPolicy inst histories = greedyPolicy inst := by
+  unfold gittinsPolicy greedyPolicy gittinsIndex
+  rfl
 
 end Gittins

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/GittinsTheorem_en.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/GittinsTheorem_en.lean
@@ -137,10 +137,35 @@ theorem gittins_index_monotone_discount (arm : BanditArm) (γ₁ γ₂ : ℝ)
   simp only [gittinsIndex]
   apply le_refl
 
-/-- For the 2-armed bandit, the Gittins policy outperforms the greedy policy. -/
-theorem gittins_beats_greedy (inst : BanditInstance)
-    (h : inst.arms.size = 2) :
-    True := by  -- Placeholder: the actual statement needs V(gittins) ≥ V(greedy)
-  trivial
+/-- Greedy (myopic) policy: always play the arm with the highest true mean.
+    This is the same argmax as `gittinsPolicy` but read directly off `arm.trueMean`
+    rather than through the Gittins index. -/
+noncomputable def greedyPolicy (inst : BanditInstance) : Nat :=
+  ((Array.range inst.arms.size).foldl
+    (fun (best : Nat × ℝ) i =>
+      match inst.arms[i]? with
+      | none => best
+      | some arm =>
+        let g := arm.trueMean
+        if g > best.2 then (i, g) else best)
+    (0, 0)).1
+
+/-- In the known-mean model, the Gittins policy **coincides** with the greedy
+    policy, regardless of the observed history: the Gittins index equals `trueMean`
+    (`gittins_index_known_arm`), so both argmaxes range over the same quantity. The
+    proof is definitional (reduction to the identity of the two folds after unfolding
+    `gittinsIndex`).
+
+    This is precisely why the former "Gittins beats greedy" statement was vacuous
+    here: the dominance of the Gittins policy over the greedy approach only appears
+    in the uncertain-belief regime (Beta–Bernoulli posterior, exploration), which
+    requires the optimal-stopping / Bellman machinery absent from Mathlib (INTRINSIC,
+    `gittins_optimality` above, #4039). In the known-arm model, Gittins = greedy,
+    full stop. -/
+theorem gittinsPolicy_eq_greedyPolicy (inst : BanditInstance)
+    (histories : Array RewardHistory) :
+    gittinsPolicy inst histories = greedyPolicy inst := by
+  unfold gittinsPolicy greedyPolicy gittinsIndex
+  rfl
 
 end Gittins_en


### PR DESCRIPTION
## What

Crystallize the Gittins ≡ greedy degeneration into a real zero-sorry theorem, replacing the vacuous `gittins_beats_greedy : True := by trivial` (the false-green this grain exists to remove). Task 2 **Gittins half** of #10188, ai-01 design-gate **A4**.

## Why this statement

`BanditArm` carries only `trueMean` (no posterior), so `gittinsIndex arm γ history := arm.trueMean` — the index ignores both `γ` and `history`. Hence `gittinsPolicy` (argmax of the index) is already the argmax of `trueMean`, i.e. **identical to a greedy policy**, for every history. The module said this in prose only; A4 states it in Lean.

ai-01 explicitly rejected the alternative A1 (restate as `V(gittins) ≥ V(greedy)`) because that is a strict special case of `gittins_optimality` ten lines above — it would replace one false-green with a redundant shadow. A4 instead **explains** why "beats greedy" is empty in this model and points to #4039 for the uncertain-belief regime where the question becomes substantive.

## Change (lake source only, FR + `_en` parity)

- **New `greedyPolicy`** (argmax of `trueMean`, same `foldl` shape as `gittinsPolicy`).
- **New `gittinsPolicy_eq_greedyPolicy`** : `gittinsPolicy inst histories = greedyPolicy inst`, proven by `unfold gittinsPolicy greedyPolicy gittinsIndex; rfl` (the two folds are identical once `gittinsIndex` reduces to `trueMean`).
- **Removed** the vacuous `gittins_beats_greedy : True := by trivial`.
- Mirror change in `GittinsTheorem_en.lean` (namespace `Gittins_en`).

Out of scope (separate grains): README/`DecInfer-9` notebook prose describing the old placeholder — doc-sync follow-up, not a lake-proof concern.

## Verification (firsthand)

- **`lake build` SUCCESS** — 1649 jobs, native lake on Lean `v4.31.0-rc1`, no error on the new theorem (only pre-existing `sorry`/unused-var lints on unchanged lines).
- **`count_code_sorry` decision_theory_lean**:
  - `code_sorry = 4` (distinct 2) — **unchanged**: both are the INTRINSIC `gittins_optimality` sorries (FR L104/L108 + EN mirrors), recorded honestly as the MDP/Bellman barrier (#4039).
  - `vacuous = 2 → 0` — the two `gittins_beats_greedy` sites (FR + EN) are gone.
  - **Net: −2 vacuous, 0 new sorry.**
- **FR/`_en` parity** — bare code (signatures + proofs, all block/line comments stripped) is byte-identical after namespace/import normalization; only docstrings differ (#4980 Option A).

Grain: DEEP/lean -- lane myia-po-2026:CoursIA

See #10188. (Folk half of Task 2 follows as a separate grain in `game_theory_lean`, serialized build.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
