### PR TITLE
feat(lean,#10188): requalify Folk vacuous — provable boundary + real discounted conclusion [game_theory_lean]

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk.lean
@@ -71,18 +71,37 @@ def Feasible (g : PrisonersDilemma) (u_row u_col : ℝ) : Prop :=
     u_row = pCC * g.R + pCD * g.S + pDC * g.T + pDD * g.P ∧
     u_col = pCC * g.R + pCD * g.T + pDC * g.S + pDD * g.P
 
+/-- Paiement actualisé du joueur de référence (ligne) sous une trajectoire
+    d'actions conjointes `a` et facteur d'escompte `δ`. Généralise
+    `coopValue` / `deviateValue` (cas particuliers stationnaires) à une
+    trajectoire arbitraire : `Σ' n, δⁿ · stagePayoff g (a n).1 (a n).2`.
+    Le paiement du joueur colonne sous la même trajectoire s'obtient en
+    échangeant les composantes de l'action conjointe (voir
+    `folk_theorem_discounted`). -/
+noncomputable def discountedPayoff (g : PrisonersDilemma) (δ : ℝ)
+    (a : ℕ → PDAction × PDAction) : ℝ :=
+  ∑' n : ℕ, δ^n * stagePayoff g (a n).1 (a n).2
+
 /-- Le théorème de Folk ACTUALISÉ (Fudenberg–Maskin 1986, simplifié pour 2x2) :
 
       Pour tout paiement faisable strictement individuellement rationnel
-      `u`, il existe δ* < 1 et un profil de stratégies tels que pour tout
-      δ ≥ δ* le paiement de l'unique équilibre sous-jeu-parfait est `u`.
+      `u = (u_row, u_col)`, il existe δ* < 1 tel que pour tout δ ≥ δ* le
+      vecteur `u` est réalisé comme paiement actualisé d'une trajectoire
+      d'actions conjointes.
 
-    `sorry` (STRETCH) — requiert la convexité et la machinerie des points
-    extrêmes ; priorité BG FAIBLE (cf critères de clôture Issue #4880 1,
-    seul `grim_trigger_sustains_iff` est requis). La direction difficile est
-    l'existence du profil de stratégies étant donné les contraintes de
-    polytope ; la preuve de Fudenberg–Maskin 1986 s'étend sur plusieurs
-    pages et n'est pas affaire d'une seule tactique. -/
+    La conclusion est une **équation réelle** (`discountedPayoff … = u_row ∧
+    … = u_col`), pas un `True` : le `sorry` porte donc la dette authentique
+    (existence de la trajectoire réalisant le vecteur cible — construction de
+    Fudenberg–Maskin par alternance action-cible / phase de punition, avec la
+    convexité du polytope des paiements faisables). Ne PAS fermer sur `True` :
+    la conclusion étant alors triviale, le `sorry` produirait un « −1 » sans
+    mathématique (leçon #10188). La couche plus profonde — résistance à la
+    déviation unilatérale en un coup (sustainment comme SPNE) — est le mur
+    Fudenberg–Maskin complet, hors périmètre de ce grain (cf
+    `grim_trigger_sustains_iff` pour le cas particulier grim trigger, prouvé).
+
+    STRETCH authentique : priorité BG FAIBLE (cf critères de clôture Issue
+    #4880 1). -/
 theorem folk_theorem_discounted (g : PrisonersDilemma) :
     ∀ (u_row u_col : ℝ),
       IndividuallyRational g u_row u_col →
@@ -90,16 +109,24 @@ theorem folk_theorem_discounted (g : PrisonersDilemma) :
       u_row > g.P ∧ u_col > g.P →  -- strict IR
       ∃ (δ_star : ℝ), δ_star < 1 ∧
         ∀ (d : ℝ), d ≥ δ_star →
-          ∃ (_stratProfile : List (PDAction × PDAction) → PDAction × PDAction),
-            True := by
+          ∃ (a : ℕ → PDAction × PDAction),
+            discountedPayoff g d a = u_row ∧
+            discountedPayoff g d (fun n => ((a n).2, (a n).1)) = u_col := by
+  -- STRETCH (Fudenberg–Maskin 1986) : existence d'une trajectoire d'actions
+  -- conjointes réalisant le vecteur de paiement cible (u_row, u_col) comme
+  -- paiement actualisé, pour tout δ assez proche de 1. Requiert la convexité
+  -- du polytope des paiements faisables et un argument de point extrême ;
+  -- preuve de plusieurs pages, pas une seule tactique.
   sorry
 
-/-- Un corollaire dégénéré : quand δ = 0, le seul équilibre sous-jeu-parfait
-    de la DP répétée est l'équilibre de Nash en un coup (défection, défection),
-    donnant le paiement (P, P). C'est le cas limite du théorème de Folk et il
-    aide à ancrer la construction (la preuve se réduit à un argument à 1
-    étape). Trivial et prouvé : l'hypothèse est déchargée directement. -/
+/-- Cas limite δ = 0 : sans poids sur le futur, les valeurs actualisées se
+    réduisent aux paiements de stage — le jeu répété collapse au jeu one-shot.
+    C'est le cas frontière du théorème de Folk (le seul équilibre de Nash
+    one-shot est (Défection, Défection) de paiement (P, P)) et il ancre la
+    construction. Prouvé : formes closes de `coopValue` / `deviateValue` en
+    δ = 0 (`coopValue R 0 = R / (1 − 0) = R`, `deviateValue T P 0 = T + 0 = T`). -/
 theorem folk_theorem_boundary (g : PrisonersDilemma) :
-    True := by trivial
+    coopValue g.R 0 = g.R ∧ coopValue g.P 0 = g.P ∧ deviateValue g.T g.P 0 = g.T := by
+  simp [coopValue, deviateValue]
 
 end RepeatedGames

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk_en.lean
@@ -91,18 +91,35 @@ def Feasible (g : PrisonersDilemma) (u_row u_col : ℝ) : Prop :=
     u_row = pCC * g.R + pCD * g.S + pDC * g.T + pDD * g.P ∧
     u_col = pCC * g.R + pCD * g.T + pDC * g.S + pDD * g.P
 
+/-- Discounted payoff of the reference (row) player under a trajectory of
+    joint actions `a` and discount factor `δ`. Generalizes `coopValue` /
+    `deviateValue` (stationary special cases) to an arbitrary trajectory:
+    `Σ' n, δⁿ · stagePayoff g (a n).1 (a n).2`. The column player's payoff
+    under the same trajectory is obtained by swapping the joint-action
+    components (see `folk_theorem_discounted`). -/
+noncomputable def discountedPayoff (g : PrisonersDilemma) (δ : ℝ)
+    (a : ℕ → PDAction × PDAction) : ℝ :=
+  ∑' n : ℕ, δ^n * stagePayoff g (a n).1 (a n).2
+
 /-- The DISCOUNTED Folk theorem (Fudenberg–Maskin 1986, simplified for 2x2):
 
-      For every strictly individually rational feasible payoff `u`,
-      there exists δ* < 1 and a strategy profile such that for all δ ≥ δ*
-      the unique subgame-perfect equilibrium payoff is `u`.
+      For every strictly individually rational feasible payoff
+      `u = (u_row, u_col)`, there exists δ* < 1 such that for all δ ≥ δ* the
+      vector `u` is realized as the discounted payoff of a trajectory of
+      joint actions.
 
-    `sorry` (STRETCH) — requires convexity + extreme-point machinery; BG
-    prover priority LOW (cf Issue #4880 closing criteria 1, only
-    `grim_trigger_sustains_iff` is required). The hard direction is the
-    existence of the strategy profile given the polytope constraints;
-    Fudenberg–Maskin 1986 proof spans several pages and is not a one-tactic
-    matter. -/
+    The conclusion is a **real equation** (`discountedPayoff … = u_row ∧
+    … = u_col`), not `True`: the `sorry` thus carries the genuine debt
+    (existence of a trajectory realizing the target vector — the
+    Fudenberg–Maskin construction alternating target action / punishment
+    phase, using convexity of the feasible-payoff polytope). Do NOT close on
+    `True`: with a trivial conclusion the `sorry` would yield a "−1" with no
+    mathematics (lesson #10188). The deeper layer — resistance to one-shot
+    unilateral deviation (sustainment as SPNE) — is the full
+    Fudenberg–Maskin wall, out of scope of this grain (see
+    `grim_trigger_sustains_iff` for the grim-trigger special case, proven).
+
+    Genuine STRETCH: BG priority LOW (cf Issue #4880 closing criteria 1). -/
 theorem folk_theorem_discounted (g : PrisonersDilemma) :
     ∀ (u_row u_col : ℝ),
       IndividuallyRational g u_row u_col →
@@ -110,16 +127,23 @@ theorem folk_theorem_discounted (g : PrisonersDilemma) :
       u_row > g.P ∧ u_col > g.P →  -- strict IR
       ∃ (δ_star : ℝ), δ_star < 1 ∧
         ∀ (d : ℝ), d ≥ δ_star →
-          ∃ (_stratProfile : List (PDAction × PDAction) → PDAction × PDAction),
-            True := by
+          ∃ (a : ℕ → PDAction × PDAction),
+            discountedPayoff g d a = u_row ∧
+            discountedPayoff g d (fun n => ((a n).2, (a n).1)) = u_col := by
+  -- STRETCH (Fudenberg–Maskin 1986): existence of a joint-action trajectory
+  -- realizing the target payoff vector (u_row, u_col) as a discounted payoff,
+  -- for all δ close enough to 1. Requires convexity of the feasible-payoff
+  -- polytope and an extreme-point argument; a multi-page proof, not one tactic.
   sorry
 
-/-- A degenerate corollary: when δ = 0, the only subgame-perfect equilibrium
-    of the repeated PD is the one-shot Nash equilibrium (defect, defect),
-    yielding payoff (P, P). This is the boundary case of the Folk theorem and
-    helps anchor the construction (the proof elides to a 1-stage argument).
-    Trivial and proven: the hypothesis is discharged directly. -/
+/-- Boundary case δ = 0: with no weight on the future, the discounted values
+    collapse to the stage payoffs — the repeated game reduces to the one-shot
+    game. This is the Folk theorem's boundary case (the only one-shot Nash
+    equilibrium is (Defect, Defect) with payoff (P, P)) and anchors the
+    construction. Proven: closed forms of `coopValue` / `deviateValue` at
+    δ = 0 (`coopValue R 0 = R / (1 − 0) = R`, `deviateValue T P 0 = T + 0 = T`). -/
 theorem folk_theorem_boundary (g : PrisonersDilemma) :
-    True := by trivial
+    coopValue g.R 0 = g.R ∧ coopValue g.P 0 = g.P ∧ deviateValue g.T g.P 0 = g.T := by
+  simp [coopValue, deviateValue]
 
 end RepeatedGames_en


### PR DESCRIPTION
## What

Requalify the two vacuous Folk statements in `RepeatedGames/Folk.lean` (+ `_en` mirror). Task 2 **Folk half** of #10188, ai-01 design-gate **B**.

## Changes

**1. `folk_theorem_boundary`** — was `True := by trivial`. Restated as the **provable** δ=0 collapse of the value operators:
`coopValue g.R 0 = g.R ∧ coopValue g.P 0 = g.P ∧ deviateValue g.T g.P 0 = g.T`, by `simp [coopValue, deviateValue]` (`sub_zero` / `div_one` / `mul_zero` / `add_zero`). Meaning: with no weight on the future (δ=0), the repeated game reduces to the one-shot game, whose unique Nash is (Defect, Defect) with payoff (P, P). Real, non-vacuous, **zero `sorry`**.

**2. `folk_theorem_discounted`** — its conclusion was `∃ stratProfile, True`, trivially closeable (the false "−1" ai-01 explicitly warned against: *"Ne le ferme jamais sur `True` — sa conclusion étant `True`, il se ferme en une ligne et produirait un « −1 » authentique avec zéro mathématique"*).
- Added a sorry-free `discountedPayoff` def (`∑' n, δⁿ · stagePayoff g (a n).1 (a n).2` — generalizes `coopValue`/`deviateValue` to an arbitrary joint-action trajectory).
- Conclusion restated as a **real payoff-realization equation**: `∃ a : ℕ → PDAction × PDAction, discountedPayoff g d a = u_row ∧ discountedPayoff g d (fun n => ((a n).2, (a n).1)) = u_col`.
- The `sorry` now carries genuine Fudenberg–Maskin debt (existence of a realizing trajectory), documented. The deeper SPNE-sustainment layer is flagged as out-of-grain in the docstring.

`grim_trigger_sustains_iff` **untouched** (proven via `coop_ge_deviate_iff`; ai-01 hors-grain).

## Verification (firsthand)

- **`lake build RepeatedGames.Folk RepeatedGames.Folk_en` SUCCESS** — 2952 jobs, native lake on Lean `v4.31.0-rc1`. Only `declaration uses sorry` lints are the **intentional** `folk_theorem_discounted` sites (FR L105 + EN L123).
- **`count_code_sorry` game_theory_lean**: `code_sorry = 2` (distinct 1 = `folk_theorem_discounted` × FR/_en, **unchanged** — the sorry predates this PR; I strengthened its conclusion, did not add debt). `vacuous = 2 → 0` for Folk: the two `folk_theorem_boundary` sites gone. (The 2 remaining `gale_shapley_produces_matching` vacuous in `StableMarriage/` are Task 1 / po-2024 territory, out of scope.)
- **FR/`_en` parity** — bare code byte-identical after docstring/comment strip; only `open RepeatedGames` differs (EN sibling accessing FR Stage types, #4980).

Grain: DEEP/lean -- lane myia-po-2026:CoursIA

See #10188. (Gittins half delivered in #10214; this completes Task 2.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
