### PR TITLE
feat(lean,#10188): remove redundant gale_shapley_produces_matching vacuous shadow (FR+EN)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GaleShapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GaleShapley.lean
@@ -69,16 +69,6 @@ theorem gale_shapley_terminates (prof : PrefProfile n) :
   exact gsTerminated_runSteps_bound prof
 
 /--
-L'algorithme de Gale-Shapley produit un matching (bijection) valide.
-
-Le matching identité sert de témoin (toute bijection sur `Fin n` suffit pour
-l'existentiel ; on utilise ici `id`).
--/
-theorem gale_shapley_produces_matching (prof : PrefProfile n) :
-    ∃ μ : Matching n, True := by
-  exact ⟨{ spouse := id, bijective := Function.bijective_id }, trivial⟩
-
-/--
 L'algorithme de Gale-Shapley produit un mariage stable.
 
 Aucune paire bloquante n'existe dans le matching en sortie.

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GaleShapley_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GaleShapley_en.lean
@@ -64,15 +64,6 @@ theorem gale_shapley_terminates (prof : PrefProfile n) :
   exact gsTerminated_runSteps_bound prof
 
 /--
-The Gale-Shapley algorithm produces a valid matching (bijection).
-The identity matching is a witness (any bijection on Fin n suffices for the
-existential statement; here we use `id`).
--/
-theorem gale_shapley_produces_matching (prof : PrefProfile n) :
-    ∃ μ : Matching n, True := by
-  exact ⟨{ spouse := id, bijective := Function.bijective_id }, trivial⟩
-
-/--
 The Gale-Shapley algorithm produces a stable matching.
 No blocking pair exists in the output matching.
 


### PR DESCRIPTION
Grain: MED/lean -- lane myia-po-2026:CoursIA

## What

Delete the redundant vacuous shadow `gale_shapley_produces_matching` (`StableMarriage/GaleShapley.lean` + `_en` sibling). Instance 1 residual of #10188 (ai-01 design-gate).

## Why delete (ai-01 prescription, not a weaken/strengthen)

The theorem stated `∃ μ : Matching n, True := by exact ⟨{spouse := id, ...}, trivial⟩` — a hollow statement proven by *any* bijection, saying nothing about Gale–Shapley. ai-01's design-gate analysis (Issue #10188 comment) gave two honest options; this PR takes the second:

> *« l'honnête est soit un énoncé sur la sortie réelle (`gsFinalMatching` est un matching valide), soit sa **suppression** comme ombre redondante. »*

Deletion is the correct choice because **both alternatives collapse into triviality or duplication**:

| Option | Why not |
|---|---|
| Strengthen to `∃ μ, IsStable μ` | **Duplicates** `gale_shapley_stable` (L95), which constructively proves `∃ μ : Matching n, IsStable prof μ` via `gsRunSteps` + `gsFinalMatching` + `gsNoBlockingPairs` (~1000 lines of ported lemmas). po-2024 confirmed this firsthand in #10195. |
| Statement on real output `gsFinalMatching` is a valid matching | **Trivially true by type** — `gsFinalMatching ... : Matching n` and its `bijective` field carries the proof (`Lemmas.lean:794`). A theorem restating "the term of type `Matching n` is of type `Matching n`" is `rfl`, no content. |
| **Delete the shadow** ✅ | The existence is **fully covered** by `gale_shapley_stable` (L95) **and** restated by `stable_matching_exists` (L128). The hollow theorem adds nothing. |

## Credit po-2024 #10195 (MERGED)

po-2024's PR #10195 fixed the **other** GaleShapley vacuous site — `gale_shapley_terminates` (L68: `True := by trivial` → real `gsTerminated prof (gsRunSteps prof (gsProposalBound n))` statement, proof `exact gsTerminated_runSteps_bound prof`). That PR **explicitly scoped OUT this line-78 instance** (body: *"strengthening line 79 would duplicate line 95"*). This PR closes the gap po-2024 deliberately left open — the two PRs are complementary halves of GaleShapley's vacuous cleanup.

## Not anti-regression (§D)

Removes a hollow *statement* (`True`), **adds no `sorry`**. The sorry count is unchanged (0 → 0 for GaleShapley); the *meaning* improves by deleting a theorem that said nothing. The substantive results remain: `gale_shapley_terminates` (proven, #10195) and `gale_shapley_stable` (proven, constructively).

## Verification (firsthand)

- **`lake build StableMarriage.GaleShapley StableMarriage.GaleShapley_en` SUCCESS** — native `lake.exe` on NTFS (Lean `v4.31.0-rc1`), fresh worktree off `origin/main`. (c.1024: native lake, WSL stalls on drvfs.)
- **0 external references** to `gale_shapley_produces_matching` across the whole `game_theory_lean` lake (`grep -rn` confirmed) — safe deletion.
- **`count_code_sorry` game_theory_lean**: `gale_shapley_produces_matching` no longer appears in the vacuous list (2 sites gone: FR L78 + EN L71). `code_sorry` unchanged (the 2 remaining are the intentional `folk_theorem_discounted` sorries in `RepeatedGames/Folk`, out of scope — PR #10216).
- **FR/`_en` parity** — symmetric deletion (10 lines FR / 9 lines EN, the EN docstring was 1 line shorter); `gale_shapley_terminates` (proven) and `gale_shapley_stable` (proven) byte-identical between siblings (#4980).
- **Diff**: 2 files, 19 deletions / 0 insertions (pure removal of the hollow theorem + its docstring). Catalogue byte-identical to `main`.

See #10188 (Gittins half = #10214, Folk half = #10216, this = GaleShapley Instance 1 — together complete the vacuous-statement requalification of the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
