### PR TITLE
feat(d5,#9998): filter code-parameter values in backtick spans (FP class 1, -65 corpus)

### DIFF
--- a/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
@@ -623,6 +623,101 @@ def _is_notebook_cross_reference(value: float, text: str) -> bool:
     return found_inside
 
 
+def _is_code_defined_value(value, prose_text) -> bool:
+    r"""Vrai si la prose cite ``value`` comme parametre de code dans un span backtick.
+
+    Critere falsifiable (FP class 1, #9998) : un nombre orphelin n'est pas une
+    mesure manquante si la prose le cite explicitement comme un PARAMETRE de code,
+    entre backticks -- « K-Means avec `n_clusters=3`, `random_state=42`,
+    `n_init=10` », « les hyperparametres (`learning_rate=0.001`) ». Le nombre est
+    alors un INPUT configure, pas une mesure a verifier.
+
+    SAFE par construction (0 sur-filtrage, mesure corpus firsthand) : on exige
+    QUATRE gardes cumulatifs, chacun issu d'un mode de sur-filtrage mesure et
+    rejete (consigne ci-dessous pour prevenir les retentes) :
+
+      1. L'assignment ``identifiant = valeur`` figure DANS UN SPAN BACKTICK
+         `` `...` ``. L'auteur qui backtick un fragment cite explicitement du
+         CODE (un parametre de config). Une METRIQUE RESTITUEE en prose
+         narrative (« **MAE = 0,41**, **RMSE = 2,33** », « score = 0.95 »)
+         n'est JAMAIS backtickee (elle est en gras/dans un tableau) -> n'est pas
+         filtree : c'est un resultat que l'output doit confirmer. C'est ce gate
+         qui distingue un INPUT (param) d'un OUTPUT (metrique restituee).
+
+      2. ``=`` simple isole (pas ``==``, ``>=``, ``<=``, ``!=``, ``+=`` ...) et
+         bornes numeriques strictes ``(?<![\d.,_])`` / ``(?![\d._])`` : ``5`` ne
+         matche pas dans ``n = 50`` ni dans le prefixe de ``QUORUM = 4_000_000``.
+         Decimale francaise toleree (la prose FR ecrit `` `alpha=0,5` ``).
+
+      3. Exclut les VARIABLES DE RESULTAT de solveur (``x_1 = 0.5``,
+         ``x_2 = ...``) : une valeur de solution restituee en prose est un
+         output a verifier, pas un parametre de config (cas OR-tools c[13]).
+
+      4. La valeur doit etre le RHS COMPLET, pas le debut d'une expression
+         mathematique : on bloque si le caractere suivant est un operateur
+         formel (ASCII ``* + - / ^ %`` et variantes Unicode ``· − × ÷ ∗``).
+         Exclut les formules (``MONEY = 10000·M``, ``RSI = 100 - ...``,
+         ``Cosine Distance = 1 −``) et les pourcentages illustratifs
+         (``heat = 18%``).
+
+    Deux heuristiques anterieures ont ete mesurees firsthand et REJETEES comme
+    sur-filtrantes (consignees ici pour prevenir les retentes) :
+      - cross-cell « var = value dans une cellule code voisine » : un ``value = 1``
+        de code generic collide avec un « 1 » de table (Sudoku-2 c[8]) ;
+      - intra-prose « identifiant = valeur » hors backtick : filtre les METRIQUES
+        restituees en gras (MAE/RMSE dans ML-4 c[36]) -> supprime un vrai drift.
+
+    Falsifiable both-directions : un nombre qui ne franchit pas les 4 gardes
+    n'est PAS filtre -- il demeure un orphelin a signaler.
+    """
+    token = f"{value:g}"
+    variants = [token]
+    if "." in token:
+        variants.append(token.replace(".", ","))  # decimale FR « 0,5 »
+    # Spans backtick de la cellule prose.
+    bk_spans = [(m.start(), m.end())
+                for m in re.finditer(r"`[^`]*`", prose_text)]
+    if not bk_spans:
+        return False
+    for tok in variants:
+        pat = re.compile(
+            r"\b([A-Za-z_]\w{1,})\s*=\s*(?<![\d.,_])"
+            + re.escape(tok)
+            + r"(?![\d._])"
+        )
+        for m in pat.finditer(prose_text):
+            var = m.group(1)
+            # Condition 1 : l'assignment doit etre dans un span backtick.
+            if not any(a < m.start() and m.end() <= b for a, b in bk_spans):
+                continue
+            # Condition 2 : '=' simple isole (remonte les blancs avant le '=').
+            k = prose_text.find("=", m.start() + len(m.group(1)),
+                                m.start() + len(m.group(1)) + 12)
+            if k < 0:
+                continue
+            p = k - 1
+            while p >= 0 and prose_text[p] in " \t":
+                p -= 1
+            if p >= 0 and prose_text[p] in "=!<>+-*/%&|^~":
+                continue
+            # Condition 3 : exclut les VARIABLES DE RESULTAT de solveur
+            # (x_1 = 0.5, x_2 = ...) -- une valeur de solution restituee en prose
+            # est un output a verifier, pas un parametre de config.
+            if re.match(r"^[a-z]_\d+$", var):
+                continue
+            # Condition 4 : la valeur doit etre le RHS COMPLET, pas le debut d'une
+            # expression mathematique. On bloque si le caractere suivant (apres
+            # blancs optionnels) est un operateur formel (ASCII * + - / ^ % et
+            # variantes Unicode · − × ÷ ∗) -> exclut les formules
+            # (MONEY = 10000·M, RSI = 100 - ..., Cosine Distance = 1 −) et les
+            # pourcentages illustratifs (heat = 18%).
+            tail = prose_text[m.end():m.end() + 3].lstrip()
+            if tail[:1] in "*+-/^·%−×÷∗":
+                continue
+            return True
+    return False
+
+
 # --------------------------------------------------------------------------- #
 #  Alignement prose <-> outputs
 # --------------------------------------------------------------------------- #
@@ -864,6 +959,12 @@ def analyze_notebook(path: str | os.PathLike) -> NotebookAlignment:
             # pointe n'est pas une mesure -> skip (SAFE par construction, cf
             # ``_is_notebook_cross_reference``).
             if _is_notebook_cross_reference(v, text):
+                continue
+            # FP class 1 (#9998) : parametre d'entree restitue dans la prose sous
+            # la forme ``identifiant = valeur`` (n_init=10, Size = 2,5). La valeur
+            # est un INPUT nomme, pas une mesure a verifier -> skip (SAFE par
+            # construction, cf ``_is_code_defined_value``).
+            if _is_code_defined_value(v, text):
                 continue
             findings.append(AlignmentFinding(
                 notebook=str(path),

--- a/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
@@ -1232,6 +1232,127 @@ class TestNotebookCrossReferenceFilter:
 
 
 # --------------------------------------------------------------------------- #
+#  FP class 1 (#9998) : parametres de code restitues dans la prose (backtick)
+# --------------------------------------------------------------------------- #
+
+
+class TestCodeDefinedValueFilter:
+    """FP class 1 (#9998) : parametres de code restitues dans la prose en span backtick.
+
+    Un nombre orphelin n'est pas une mesure manquante si la prose le cite comme
+    un PARAMETRE de code, entre backticks : « `n_init=10` », « `random_state=42` »,
+    « `alpha=0,5` ». La valeur pilote le calcul, elle n'en est pas un output.
+
+    SAFE par construction (mesure corpus firsthand, 4 gardes cumulatifs) :
+      1. assignment ``identifiant = valeur`` DANS un span backtick (l'auteur cite
+         du CODE). Une METRIQUE RESTITUEE en prose narrative (« **MAE = 0,41** »)
+         n'est jamais backtickee -> non filtree : c'est un output a verifier.
+      2. identifiant non-resultat-de-solveur (exclut ``x_1 = 0.5``).
+      3. valeur = RHS complet (pas une formule ``MONEY = 10000·M`` ni un % ``heat = 18%``).
+      4. bornes numeriques + ``_`` (exclut le prefixe 4 de ``QUORUM = 4_000_000``).
+
+    Verifie firsthand ML.NET : 2/184 (ML-1 Size=2.5, ML-8 n_init=10) ; full corpus
+    65 orphelins filtres. Aucune metrique restituee (MAE/RMSE/score) filtree.
+    """
+
+    def test_helper_backtick_param_int(self):
+        # "`n_init=10`" -- 10 est un parametre de KMeans, cite en backtick.
+        text = "K-Means avec `n_clusters=3`, `random_state=42`, `n_init=10`."
+        assert mod._is_code_defined_value(10.0, text) is True
+        assert mod._is_code_defined_value(42.0, text) is True
+
+    def test_helper_backtick_param_decimal(self):
+        # "`alpha=0.5`" -- decimale en backtick.
+        text = "Regression ridge avec `alpha=0.5`."
+        assert mod._is_code_defined_value(0.5, text) is True
+
+    def test_helper_backtick_param_fr_decimal(self):
+        # "`alpha=0,5`" -- decimale francaise en backtick (prose pedagogique FR).
+        text = "Regression ridge avec `alpha=0,5` (seuil FR)."
+        assert mod._is_code_defined_value(0.5, text) is True
+
+    def test_helper_no_backtick_not_filtered(self):
+        # Anti-sur-filtrage : une valeur en prose SANS backtick n'est pas filtree
+        # (peut etre une metrique narrative). "Sharpe = 0.69" non backticke.
+        text = "Le ratio de Sharpe est 0.69 sur la periode OOS."
+        assert mod._is_code_defined_value(0.69, text) is False
+
+    def test_helper_reported_metric_bold_not_filtered(self):
+        # Anti-sur-filtrage (cas ML-4 c[36]) : une METRIQUE RESTITUEE en prose
+        # narrative (MAE, RMSE) en gras n'est PAS un parametre de code -> non
+        # filtree. C'est un output que le detecteur doit pouvoir verifier.
+        text = "Les metriques sont **R^2 = 0,941**, **MAE = 0,41**, **RMSE = 2,33**."
+        assert mod._is_code_defined_value(0.41, text) is False
+        assert mod._is_code_defined_value(2.33, text) is False
+
+    def test_helper_solver_result_backtick_not_filtered(self):
+        # Anti-sur-filtrage (cas OR-tools-Stiegler c[13]) : une VALEUR DE SOLUTION
+        # de solveur restituee en backtick (`x_1 = 0.5`) est un OUTPUT, pas un
+        # parametre de config -> non filtree.
+        text = "La solution optimale est `x_1 = 0.5` et `x_2 = 0.3`."
+        assert mod._is_code_defined_value(0.5, text) is False
+
+    def test_helper_formula_expression_not_filtered(self):
+        # Anti-sur-filtrage (cas 13_Cryptarithmetic c[2]) : une formule en
+        # backtick (`MONEY = 10000·M + ...`) -- 10000 est un coefficient de
+        # place-value, RHS incomplet -> non filtre.
+        text = "Decomposition : `MONEY = 10000·M + 1000·O + 100·N + 10·E + Y`."
+        assert mod._is_code_defined_value(10000.0, text) is False
+
+    def test_helper_unicode_minus_formula_not_filtered(self):
+        # Anti-sur-filtrage (cas 05-SemanticKernel c[19]) : identite mathematique
+        # avec moins Unicode U+2212 « Cosine Distance = 1 − ... » -> 1 non filtre.
+        text = "Rappel : `Cosine Distance = 1 − Cosine Similarity`."
+        assert mod._is_code_defined_value(1.0, text) is False
+
+    def test_helper_underscore_grouping_not_filtered(self):
+        # Anti-sur-filtrage (cas SC-9 c[5]) : le separateur underscore `4_000_000`
+        # ne doit pas faire matcher le prefixe 4 comme parametre.
+        text = "Seuil de gouvernance `QUORUM = 4_000_000` tokens."
+        assert mod._is_code_defined_value(4.0, text) is False
+
+    def test_helper_comparison_not_filtered(self):
+        # Anti-sur-filtrage : un comparateur (`count >= 5`, `ratio == 0.9`) n'est
+        # pas un assignment de parametre.
+        text = "On garde si `count >= 5` et `ratio == 0.9`."
+        assert mod._is_code_defined_value(5.0, text) is False
+        assert mod._is_code_defined_value(0.9, text) is False
+
+    def test_helper_value_not_in_any_assignment_not_filtered(self):
+        # Un nombre hors de tout assignment backtick -> orphelin normal.
+        text = "Le code `model.fit(X)` produit un score. Valeur cible 0.69."
+        assert mod._is_code_defined_value(0.69, text) is False
+
+    def test_integration_param_suppressed(self, tmp_path):
+        # Cas fondateur ML-8 c[5] : prose cite `n_init=10` -> 10 orphelin filtre.
+        nb = tmp_path / "param.ipynb"
+        _make_notebook([
+            _markdown_cell("## Pipeline\nK-Means avec `n_clusters=3`, `n_init=10` "
+                           "(10 redemarrages)."),
+            _code_cell("print(0.42)", [{"text": "0.42\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        mfo = [f for f in result.findings if f.category == "MISSING_FROM_OUTPUTS"]
+        filtered = [f for f in mfo if f.prose_number == pytest.approx(10.0)]
+        assert filtered == [], f"param n_init=10 must be filtered, got {filtered}"
+
+    def test_integration_legit_orphan_alongside_param_preserved(self, tmp_path):
+        # Falsifiabilite : une vraie mesure orpheline (0.69) coexistant avec un
+        # parametre backtick (n_init=10) DOIT rester signalee.
+        nb = tmp_path / "mixed.ipynb"
+        _make_notebook([
+            _markdown_cell("Sharpe observe = 0.69 ; K-Means `n_init=10`."),
+            _code_cell("print(0.42)", [{"text": "0.42\n"}]),
+        ], nb)
+        result = mod.analyze_notebook(nb)
+        mfo = [f for f in result.findings if f.category == "MISSING_FROM_OUTPUTS"]
+        legit = [f for f in mfo if f.prose_number == pytest.approx(0.69)]
+        param = [f for f in mfo if f.prose_number == pytest.approx(10.0)]
+        assert len(legit) == 1, f"legit orphan 0.69 must survive, got {mfo}"
+        assert param == [], f"param n_init=10 must be filtered, got {param}"
+
+
+# --------------------------------------------------------------------------- #
 
 
 class TestICT1CounterEvidence:


### PR DESCRIPTION
Grain: DEEP/tooling — lane myia-po-2025:CoursIA-2 — prev: MED/tooling

## What

Adds the **FP class 1** filter to the D5 prose↔outputs detector (`scan_d5_prose_outputs_alignment.py`, EPIC #9768 / #9998): a prose orphan is a **false positive** when the prose cites it as a **code parameter inside a backtick span** — « K-Means avec `n_init=10`, `random_state=42` », « `alpha=0,5` », « `learning_rate=0.001` ». The value drives the computation; it is not an output to verify.

Closes the last un-addressed class of the #9998 FP characterization (classes 2/4/5/6/7 landed in prior PRs #10008/#10011/#10033/#10189/#10196).

## Why SAFE-by-construction (4 cumulative guards, each from a *measured* over-filtration mode)

The naive heuristic from the issue body ("value is RHS of `var = value` in a neighboring code cell") was implemented and **measured firsthand to over-filter**. Three formulations were rejected before reaching the SAFE one:

| Formulation | Measured over-filtration (firsthand) | Verdict |
|---|---|---|
| cross-cell numeric equality (radius ±2) | `value = 1` (Sudoku-2 c[8]) collides with a table "1" whose prose also says "value" | REJECTED |
| intra-prose `ident = value` (no backtick) | filters reported metrics **MAE = 0,41**, **RMSE = 2,33** (ML-4 c[36]) → suppresses real drift | REJECTED |
| intra-prose `ident = value` **in backtick span** | filters solver results `x_1 = 0.5` (OR-tools c[13]), formulas `MONEY = 10000·M` (13_Cryptarithmetic), `4` from `QUORUM = 4_000_000` (SC-9) | needs the 4 guards below |

The shipped filter keeps the backtick signal (the author explicitly quotes *code* — a param, not a bold/table reported metric) and adds 4 guards:

1. **Backtick span** — the `ident = value` must lie inside `` `...` ``. Reported metrics in narrative (« **MAE = 0,41** ») are never backticked → not filtered.
2. **Isolated `=`** + numeric bounds incl. `_` — excludes comparators (`==`/`>=`), and the `4` prefix of `QUORUM = 4_000_000`.
3. **Non-solver-var** — excludes `x_1 = 0.5` (regex `^[a-z]_\d+$`), a reported solution value.
4. **Complete RHS** — blocks a trailing arithmetic operator (ASCII + Unicode `· − × ÷`), excluding formulas (`MONEY = 10000·M`, `RSI = 100 -`, `Cosine = 1 −`) and illustrative `%` (`heat = 18%`).

French decimal tolerated (`` `alpha=0,5` ``).

## Verification (gate-must-verify-detector-fp-before-wiring)

- **Materiality**: full corpus baseline 6754 orphelins → 65 filtered (**0.96 %**). ML.NET: 184 → 182.
- **0 over-filtration (firsthand, the gate)**: enumerated all 65 survivors + their exact matched backtick span. The clear over-filtration modes (Sudoku table-1, ML-4 MAE/RMSE, OR-tools x_1=0.5, 13_Cryptarithmetic formulas, SC-9 underscore, QC-Py-13 RSI formula, QC-Py-10 illustrative %) are all excluded by construction. The 65 survivors are unambiguous code params (`random_state=42`, `n_init=10`, `learning_rate`, `target_accept=0.95`, `epsilon=0.1`, `beta=0.01`, `n_steps=600`, `seed=42`, …) plus a handful of illustrative example values in code spans (`SPY=100`, `Beta=1.2`) which the author presented as code artifacts, not empirical claims.
- **No regression**: 141 tests pass (128 existing + 13 new for class 1).

## Tests added (`TestCodeDefinedValueFilter`, 13 tests)

TRUE positives (backtick params, int/decimal/FR-decimal) + 8 anti-over-filtrage guards (no-backtick, bold-metric, solver-result, formula, Unicode-minus-formula, underscore-grouping, comparator, no-assignment) + 2 integration (param suppressed, legit orphan alongside preserved).

## Scope

Detector + its tests only (+210 lines). No notebooks, no catalogue touched.

See #9998
