### PR TITLE
fix(quantconnect,#10097): add blank lines before 2 glued GFM tables in LongShortHarvest research (math-pipe FPs excluded)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/LongShortHarvest-QC/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/LongShortHarvest-QC/research.ipynb
@@ -1167,6 +1167,7 @@
    "source": [
     "## Analyse Walk-Forward\n",
     "Decoupage en 3 sous-periodes pour evaluer la stabilite temporelle.\n",
+    "\n",
     "| Periode | Description |\n",
     "|---|---|\n",
     "| 2007-2012 | Crise financiere, rebond |\n",
@@ -1315,6 +1316,7 @@
    "source": [
     "## Analyse par Regime VIX\n",
     "Segmentation des performances en fonction du niveau de VIX.\n",
+    "\n",
     "| Regime | VIX | Description |\n",
     "|---|---|---|\n",
     "| Calme | < 15 | Marche trendant |\n",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: DEEP/lean #10220

See #10097. GFM table-rendering fix in the **QuantConnect research-projects** corner (`projects/`, distinct from the QC-Python pedagogical series).

## What changed

`QuantConnect/projects/LongShortHarvest-QC/research.ipynb` had **2 real GFM tables glued to the preceding prose line** (no blank line before the table block). GitHub fuses a table into the preceding paragraph when it is not preceded by a blank line, so these 2 tables (Walk-Forward periods + VIX-regime segmentation) did **not render as tables**. Insert one blank line before each.

| Cell | Preceding line (glued) | Table |
|---|---|---|
| [23] | `Decoupage en 3 sous-periodes pour evaluer la stabilite temporelle.` | Periode / Description (3 data rows) |
| [26] | `Segmentation des performances en fonction du niveau de VIX.` | Regime / VIX / Description (3 data rows) |

Both already had their `|---|` separator row — the defect was purely the missing blank line above. +2 insertions / 0 deletions, markdown-only.

## G.1 firsthand — 4 of the 6 "QC quantbook" defects are math-pipe FALSE POSITIVES (NOT touched)

I scanned all 4 QC research-project quantbooks firsthand. The detector flagged 6 defects; **only 2 are real**. The other 4 are the **math-pipe FP class** (`|x|` absolute-value ≠ `|` table separator) — z-score notation in pairs-trading prose, which is legitimate math, not a table:

| Quantbook | Cell | Detector flag | Firsthand verdict |
|---|---|---|---|
| ETF-Pairs | cell[9] | NO_BLANK_BEFORE/AFTER | **FALSE POSITIVE** — `- Entrée quand \|z-score\| > threshold` = z-score abs-value in a bullet list, NO table exists |
| ML-EnhancedPairs | cell[0] | NO_BLANK_BEFORE | **FALSE POSITIVE** — `\|Z\| > 2`, `\|Z\| < 0.5` = abs-value in list, NO table |
| PairsTrading | cell[13] | NO_BLANK_BEFORE | **FALSE POSITIVE** — `Entry: \|z\| > seuil` = abs-value, NO table |
| **LongShortHarvest** | cell[23] | NO_BLANK_BEFORE | **REAL** — `\| Periode \| Description \|` table glued to prose ✓ fixed |
| **LongShortHarvest** | cell[26] | NO_BLANK_BEFORE | **REAL** — `\| Regime \| VIX \| Description \|` table glued to prose ✓ fixed |

Blindly "fixing" the 4 FPs by inserting blank lines would have done nothing useful (there is no table to render) and risks corrupting the legitimate z-score math notation. This is the same math-pipe FP class I excluded firsthand in #10218 (`|r|` correlation, `|$...$|` LaTeX). The detector over-matches `|x|` abs-value as a table pipe — a refinement candidate for the detector owner.

## §E — bounded to the QC research-projects corner

This is NOT po-2026's QC-Python pedagogical partition (#10198 covered `QuantConnect/Python/QC-Py-*`). `QuantConnect/projects/*/quantbook.ipynb` and `research.ipynb` are **research notebooks** (local-only Lean Research, per their own `## Prérequis`), a distinct un-partitioned corner. The 2 real defects are both in `LongShortHarvest-QC/research.ipynb`; the other 3 research quantbooks' "defects" are the math-pipe FPs above.

## Validation (measured, not asserted)

- **Detector before/after**: `scan_md_table_syntax.py LongShortHarvest-QC/research.ipynb` → **2 NO_BLANK_BEFORE → 0**.
- **Markdown-only edit** (C.2 exception): +2 insertions / 0 deletions, both blank-line array elements in markdown cells. No code cell, no output, no `execution_count` touched. H.3 pre-commit N/A (markdown-only in a quantbook — pre-commit is un-executed-code-cell-scoped).
- **JSON validity**: `json.load` OK post-edit; raw string-level insertion (no nbformat re-serialization churn, original 4-space indent preserved).
- **NOT a twin pair**: `grep -rl LongShortHarvest twin_pairs.d/` → 0 (no rebaseline, no twin-parity gate).
- **Catalogue byte-identique**: 0 catalog files touched (1 quantbook only).

## Scope boundary (one subject per PR)

This PR fixes the 2 real NO_BLANK_BEFORE defects in `LongShortHarvest-QC/research.ipynb` only. It does NOT touch: the 4 math-pipe FP cells (ETF-Pairs/ML-EnhancedPairs/PairsTrading — legitimate z-score math, not bugs), the QC-Python pedagogical series (po-2026 tranche), the Probas DecPyMC defects (jsboige #10170 math-pipe exclusion class — `P(malade|obs)`, `|A|x|S|`), or the detector itself.

## Variation note

prev = DEEP/lean #10220 (StableMarriage vacuous requalification). This grain = MED/notebook-python (QC research-quantbook GFM table-rendering). Different GENRE (lean → notebook-python; G-VAR-3 satisfied — not 2 consecutive same). Different family (GameTheory Lean → QuantConnect research-projects). The substance is the G.1 firsthand FP-exclusion (4 math-pipe `|z-score|`/`|Z|`/`|z|` FPs distinguished from 2 real table defects) — not scanner-generatable blind blank-line insertion (which would have corrupted the 4 FP cells).

## Note on cycle saturation

This is a small, honest grain. I exhaustively measured this cycle that the verified-substance veins are drained: Lean vacuous (all 5 #10188 targets done — my #10220 + po-2026 #10214/#10216 + #10195), Lean sorry (conway frozen until 10/08, knot INTRINSIC, all others code-sorry=0 verified via count_code_sorry), GFM real defects (all remaining are math-pipe FPs in partitioned families — Probas/jsboige, QC-Py/po-2026), machine-dep drains (entangled with detector FPs, #10178 owner territory, class 3 gated), docs (capped for po-2024). Conway unfreeze **tomorrow 10/08** = the DEEP/lean provision ai-01 identified; this grain is a bounded real fix while that gate holds.
