### PR TITLE
feat(gitleaks,#10143): suppress truncated-example JWT FP (header+ellipsis), keep real-JWT detection armed

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -50,13 +50,20 @@ regexes = [
     # Positive control (#10143): a real sk-or-v1-<lowercase-hex> key in the same file
     # is STILL flagged (uppercase-only class cannot match hex) — detector stays armed.
     '''sk-or-v1-[A-Z][A-Z_]+''',
-    # NOTE: the standard JWT header `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9` is a non-secret
-    # protocol constant, but it CANNOT be allowlisted: it is a prefix of EVERY real JWT,
-    # and gitleaks allowlist matching is substring-based, so suppressing it disarms the
-    # jwt detector entirely (verified — a full jwt header.payload.signature vanished from
-    # the scan when this was listed). The 2 bare-header FP findings in Roo-Code docs
-    # (exemple-api.md, guide-agent.md) are left visible by design: keeping the jwt
-    # detector armed is worth 2 pedagogical-doc FPs. See #10143.
+    # --- Truncated-example JWT (Roo-Code docs, #10143 residual) ---
+    # The BARE header `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9` still CANNOT be allowlisted
+    # (it is a prefix of every real JWT; gitleaks allowlist matching is substring-based,
+    # so the bare header disarms the jwt detector — verified, #10201). BUT the 2 FP findings
+    # in Roo-Code docs (exemple-api.md L38, guide-agent.md L124) are TRUNCATED pedagogical
+    # examples: the literal string is the header followed by an ellipsis `...` (no payload,
+    # no signature) — e.g. `"token": "eyJ...XVCJ9..."`. A real JWT is `header.payload.signature`
+    # (single dots, base64 segments), NEVER header+`...`. Anchoring the allowlist regex on
+    # the trailing literal `\.\.\.` therefore matches ONLY the truncated teaching example,
+    # never a real JWT. Positive control (gitleaks 8.24.3, this PR): a synthetic file with a
+    # real full JWT (header.eyJzdWIi…payload.signature) + the truncated example side by side
+    # → the real JWT stays FLAGGED, the truncated example is SUPPRESSED. Detector armed.
+    # Covers 2 findings (×7 under translation-sync #10133 if these docs are translated).
+    '''eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.\.\.''',
 ]
 
 # Teaching placeholders and model identifiers that `generic-api-key` reads as


### PR DESCRIPTION
Grain: DEEP/guard -- lane myia-po-2026:CoursIA

## What

Add one allowlist regex to `.gitleaks.toml` that suppresses the 2 residual truncated-example JWT FPs from #10143, **without disarming real-JWT detection** (c.1022 positive control verified).

## The defect (2 FPs, post #10201 + #10146)

Two Roo-Code doc files contain a truncated pedagogical JWT — the standard HS256 header followed by a literal ellipsis `...` (no payload, no signature):

- `GenAI/Vibe-Coding/Roo-Code/03-assistant-pro/documentation/exemple-api.md:38` — `"token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."`
- `GenAI/Vibe-Coding/Roo-Code/05-projets-avances/demo-2-documentation/docs/guide-agent.md:124` — `"access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."`

`generic-api-key` flags these. Under translation-sync (#10133) each source derives into 7 target-language files, so 2 FPs can block up to 14 PRs.

## Why #10201 left them, and why this PR can suppress them safely

#10201 verified the **bare** header `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9` CANNOT be allowlisted — it is a prefix of every real JWT, and gitleaks allowlist matching is substring-based, so listing it disarmed the jwt detector (a full `header.payload.signature` vanished from the scan). #10201 correctly left the 2 FPs visible as the lesser evil.

**This PR's insight**: anchor the allowlist regex on the **trailing literal ellipsis** `\.\.\.`. A real JWT is `header.payload.signature` — single dots separating base64 segments — NEVER `header...`. So `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.\.\.` matches ONLY the truncated teaching example, never a real JWT.

## Positive control (the part that makes this safe — c.1022)

Verified with **gitleaks 8.24.3** (exact CI version; winget offers 8.30.1 so I downloaded the release binary to match #10142's version-pin discipline):

Synthetic test file with both tokens side by side:
```
{"token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4iLCJpYXQiOjE1MTYyMzkwMjJ9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"}
{"access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."}
```
Result with the new allowlist: **real full JWT FLAGGED, truncated example SUPPRESSED.** Detector armed. ✅

## Full-repo verification (before → after, origin/main worktree)

| | truncated-JWT FP | CIVITAI real token | total |
|---|---|---|---|
| before | 2 | 6 | 8 |
| **after** | **0** | **6** | **6** |

The 6 `CIVITAI_TOKEN=c39ba121e12e5b40ac67a87836431e34` findings are a **REAL leaked credential** (intentionally not allowlisted per #10201 — sits next to a redacted `HF_TOKEN` in archived docker configs). They remain fully detected, awaiting user rotation (#10205/#10202). Suppressing them would be the exact #9888 no-op failure — this PR does not touch them.

## Scope

- 1 file changed (`.gitleaks.toml`), 14 insertions / 7 deletions — the regex + a comment block documenting the bare-vs-ellipsis reasoning and the positive control.
- Version pins (`GITLEAKS_VERSION` in secret-scan.yml, `rev` in .pre-commit-config.yaml) **unchanged** — hooks parity unaffected (this only adds an allowlist entry, doesn't change gitleaks version).
- No BOM, LF-only line endings (verified byte-level).

See #10143 (follows #10201 + #10146).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
