### PR TITLE
feat(training,#10211): holdout temporel 06/08 dans c1330 + le test DM est aveugle au signe

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/c1330_xrp_dt_foldwise_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/c1330_xrp_dt_foldwise_research.ipynb
@@ -5,10 +5,10 @@
    "id": "9c1f042f",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-08-06T15:57:46.765721+00:00",
+     "duration": 0.002181,
+     "end_time": "2026-08-09T20:51:58.455106+00:00",
      "exception": false,
-     "start_time": "2026-08-06T15:57:46.762721+00:00",
+     "start_time": "2026-08-09T20:51:58.452925+00:00",
      "status": "completed"
     },
     "tags": []
@@ -52,16 +52,16 @@
    "id": "b6294f38",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T15:57:46.771732Z",
-     "iopub.status.busy": "2026-08-06T15:57:46.771732Z",
-     "iopub.status.idle": "2026-08-06T15:57:46.796023Z",
-     "shell.execute_reply": "2026-08-06T15:57:46.795507Z"
+     "iopub.execute_input": "2026-08-09T20:51:58.460890Z",
+     "iopub.status.busy": "2026-08-09T20:51:58.460890Z",
+     "iopub.status.idle": "2026-08-09T20:51:58.483717Z",
+     "shell.execute_reply": "2026-08-09T20:51:58.482708Z"
     },
     "papermill": {
-     "duration": 0.029316,
-     "end_time": "2026-08-06T15:57:46.797037+00:00",
+     "duration": 0.02601,
+     "end_time": "2026-08-09T20:51:58.484469+00:00",
      "exception": false,
-     "start_time": "2026-08-06T15:57:46.767721+00:00",
+     "start_time": "2026-08-09T20:51:58.458459+00:00",
      "status": "completed"
     },
     "tags": []
@@ -276,10 +276,10 @@
    "id": "ac440bec",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-08-06T15:57:46.802036+00:00",
+     "duration": 0.001409,
+     "end_time": "2026-08-09T20:51:58.487476+00:00",
      "exception": false,
-     "start_time": "2026-08-06T15:57:46.799036+00:00",
+     "start_time": "2026-08-09T20:51:58.486067+00:00",
      "status": "completed"
     },
     "tags": []
@@ -303,16 +303,16 @@
    "id": "a5b47230",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T15:57:46.808047Z",
-     "iopub.status.busy": "2026-08-06T15:57:46.807048Z",
-     "iopub.status.idle": "2026-08-06T15:57:47.238162Z",
-     "shell.execute_reply": "2026-08-06T15:57:47.237630Z"
+     "iopub.execute_input": "2026-08-09T20:51:58.490803Z",
+     "iopub.status.busy": "2026-08-09T20:51:58.490803Z",
+     "iopub.status.idle": "2026-08-09T20:52:00.133188Z",
+     "shell.execute_reply": "2026-08-09T20:52:00.132562Z"
     },
     "papermill": {
-     "duration": 0.435205,
-     "end_time": "2026-08-06T15:57:47.239253+00:00",
+     "duration": 1.645247,
+     "end_time": "2026-08-09T20:52:00.134123+00:00",
      "exception": false,
-     "start_time": "2026-08-06T15:57:46.804048+00:00",
+     "start_time": "2026-08-09T20:51:58.488876+00:00",
      "status": "completed"
     },
     "tags": []
@@ -375,10 +375,10 @@
    "id": "0cd5a2d2",
    "metadata": {
     "papermill": {
-     "duration": 0.00269,
-     "end_time": "2026-08-06T15:57:47.245165+00:00",
+     "duration": 0.001551,
+     "end_time": "2026-08-09T20:52:00.137306+00:00",
      "exception": false,
-     "start_time": "2026-08-06T15:57:47.242475+00:00",
+     "start_time": "2026-08-09T20:52:00.135755+00:00",
      "status": "completed"
     },
     "tags": []
@@ -407,16 +407,16 @@
    "id": "5a4e57cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T15:57:47.253256Z",
-     "iopub.status.busy": "2026-08-06T15:57:47.252704Z",
-     "iopub.status.idle": "2026-08-06T15:57:47.263850Z",
-     "shell.execute_reply": "2026-08-06T15:57:47.262762Z"
+     "iopub.execute_input": "2026-08-09T20:52:00.141259Z",
+     "iopub.status.busy": "2026-08-09T20:52:00.140228Z",
+     "iopub.status.idle": "2026-08-09T20:52:00.147836Z",
+     "shell.execute_reply": "2026-08-09T20:52:00.147836Z"
     },
     "papermill": {
-     "duration": 0.015935,
-     "end_time": "2026-08-06T15:57:47.264367+00:00",
+     "duration": 0.010516,
+     "end_time": "2026-08-09T20:52:00.149325+00:00",
      "exception": false,
-     "start_time": "2026-08-06T15:57:47.248432+00:00",
+     "start_time": "2026-08-09T20:52:00.138809+00:00",
      "status": "completed"
     },
     "tags": []
@@ -501,10 +501,10 @@
    "id": "bb916e71",
    "metadata": {
     "papermill": {
-     "duration": 0.00316,
-     "end_time": "2026-08-06T15:57:47.270736+00:00",
+     "duration": 0.001512,
+     "end_time": "2026-08-09T20:52:00.152463+00:00",
      "exception": false,
-     "start_time": "2026-08-06T15:57:47.267576+00:00",
+     "start_time": "2026-08-09T20:52:00.150951+00:00",
      "status": "completed"
     },
     "tags": []
@@ -527,16 +527,16 @@
    "id": "f7cf92b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T15:57:47.279413Z",
-     "iopub.status.busy": "2026-08-06T15:57:47.279413Z",
-     "iopub.status.idle": "2026-08-06T15:57:47.287577Z",
-     "shell.execute_reply": "2026-08-06T15:57:47.286524Z"
+     "iopub.execute_input": "2026-08-09T20:52:00.155839Z",
+     "iopub.status.busy": "2026-08-09T20:52:00.155839Z",
+     "iopub.status.idle": "2026-08-09T20:52:00.164087Z",
+     "shell.execute_reply": "2026-08-09T20:52:00.163341Z"
     },
     "papermill": {
-     "duration": 0.013724,
-     "end_time": "2026-08-06T15:57:47.288111+00:00",
+     "duration": 0.011184,
+     "end_time": "2026-08-09T20:52:00.164989+00:00",
      "exception": false,
-     "start_time": "2026-08-06T15:57:47.274387+00:00",
+     "start_time": "2026-08-09T20:52:00.153805+00:00",
      "status": "completed"
     },
     "tags": []
@@ -611,10 +611,10 @@
    "id": "220e4c68",
    "metadata": {
     "papermill": {
-     "duration": 0.002724,
-     "end_time": "2026-08-06T15:57:47.294074+00:00",
+     "duration": 0.001452,
+     "end_time": "2026-08-09T20:52:00.168123+00:00",
      "exception": false,
-     "start_time": "2026-08-06T15:57:47.291350+00:00",
+     "start_time": "2026-08-09T20:52:00.166671+00:00",
      "status": "completed"
     },
     "tags": []
@@ -637,16 +637,16 @@
    "id": "f781dc6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T15:57:47.302088Z",
-     "iopub.status.busy": "2026-08-06T15:57:47.302088Z",
-     "iopub.status.idle": "2026-08-06T15:57:47.311439Z",
-     "shell.execute_reply": "2026-08-06T15:57:47.310432Z"
+     "iopub.execute_input": "2026-08-09T20:52:00.171219Z",
+     "iopub.status.busy": "2026-08-09T20:52:00.171219Z",
+     "iopub.status.idle": "2026-08-09T20:52:00.179220Z",
+     "shell.execute_reply": "2026-08-09T20:52:00.179220Z"
     },
     "papermill": {
-     "duration": 0.014351,
-     "end_time": "2026-08-06T15:57:47.311439+00:00",
+     "duration": 0.011202,
+     "end_time": "2026-08-09T20:52:00.180762+00:00",
      "exception": false,
-     "start_time": "2026-08-06T15:57:47.297088+00:00",
+     "start_time": "2026-08-09T20:52:00.169560+00:00",
      "status": "completed"
     },
     "tags": []
@@ -710,10 +710,10 @@
    "id": "9c2bd0b8",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-08-06T15:57:47.317436+00:00",
+     "duration": 0.001845,
+     "end_time": "2026-08-09T20:52:00.184204+00:00",
      "exception": false,
-     "start_time": "2026-08-06T15:57:47.314436+00:00",
+     "start_time": "2026-08-09T20:52:00.182359+00:00",
      "status": "completed"
     },
     "tags": []
@@ -734,16 +734,16 @@
    "id": "ffd1191f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-06T15:57:47.325446Z",
-     "iopub.status.busy": "2026-08-06T15:57:47.324448Z",
-     "iopub.status.idle": "2026-08-06T15:57:48.143021Z",
-     "shell.execute_reply": "2026-08-06T15:57:48.142470Z"
+     "iopub.execute_input": "2026-08-09T20:52:00.187934Z",
+     "iopub.status.busy": "2026-08-09T20:52:00.187934Z",
+     "iopub.status.idle": "2026-08-09T20:52:01.348918Z",
+     "shell.execute_reply": "2026-08-09T20:52:01.348221Z"
     },
     "papermill": {
-     "duration": 0.823104,
-     "end_time": "2026-08-06T15:57:48.143548+00:00",
+     "duration": 1.164282,
+     "end_time": "2026-08-09T20:52:01.349956+00:00",
      "exception": false,
-     "start_time": "2026-08-06T15:57:47.320444+00:00",
+     "start_time": "2026-08-09T20:52:00.185674+00:00",
      "status": "completed"
     },
     "tags": []
@@ -753,7 +753,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Plot sauvegarde : c1330_xrp_dt_foldwise_plots.png (53500 bytes)\n"
+      "Plot sauvegarde : c1330_xrp_dt_foldwise_plots.png (52308 bytes)\n"
      ]
     }
    ],
@@ -814,10 +814,10 @@
    "id": "3f3dcaf1",
    "metadata": {
     "papermill": {
-     "duration": 0.002556,
-     "end_time": "2026-08-06T15:57:48.149393+00:00",
+     "duration": 0.003019,
+     "end_time": "2026-08-09T20:52:01.355040+00:00",
      "exception": false,
-     "start_time": "2026-08-06T15:57:48.146837+00:00",
+     "start_time": "2026-08-09T20:52:01.352021+00:00",
      "status": "completed"
     },
     "tags": []
@@ -829,6 +829,387 @@
     "sont dégénérées de la même manière, soit ~37.5% des 32 modèles effectifs. C'est\n",
     "**un signal de collapse de feature** : le DT n'extrait plus rien d'actionnable\n",
     "et bascule sur l'inverse systématique."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68a13024",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002099,
+     "end_time": "2026-08-09T20:52:01.358493+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T20:52:01.356394+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Holdout temporel du 06/08 — le verdict §C hors échantillon\n",
+    "\n",
+    "Les sections 1 à 5 portent sur le **sweep fold-wise** (4 anchors × 4 seeds × 2 modes ×\n",
+    "2 fenêtres). Elles répondent à « le DT bat-il BH sur un découpage trimestriel glissant ? ».\n",
+    "Deux runs du **06/08** posent une question différente et plus dure : le DT bat-il BH sur un\n",
+    "**holdout temporel strict**, entraîné avant la coupure et jamais rejugé après ?\n",
+    "\n",
+    "| Run | `train_end` | Holdout | Obs | Seeds |\n",
+    "|---|---|---|---:|---|\n",
+    "| `holdout_internal_20260806_093143` | 2025-06-30 | 2025-07-10 → 2026-04-30 | 294 | 0,1,7,42,99 |\n",
+    "| `holdout_fresh_20260806_094210` | 2026-04-21 | 2026-05-01 → *courant* | 96 | 0,1,7,42,99 |\n",
+    "\n",
+    "Un `gap_days = 10` sépare la fin d'entraînement du début de holdout dans les deux cas\n",
+    "(anti-fuite par autocorrélation). Ces deux runs sont **absents du sweep** : ils ont tourné\n",
+    "sur ai-01, pas sur le runner GPU po-2024, et ils portent une cinquième seed (99).\n",
+    "\n",
+    "Les chiffres ci-dessous sont **lus dans les JSON**, jamais recopiés. `results/` est\n",
+    "gitignoré : les sorties committées proviennent de la machine qui détient les fichiers, et\n",
+    "la cellule dit explicitement quoi relancer si elle ne les trouve pas.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5724013d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T20:52:01.361704Z",
+     "iopub.status.busy": "2026-08-09T20:52:01.361704Z",
+     "iopub.status.idle": "2026-08-09T20:52:01.379751Z",
+     "shell.execute_reply": "2026-08-09T20:52:01.379004Z"
+    },
+    "papermill": {
+     "duration": 0.021101,
+     "end_time": "2026-08-09T20:52:01.380989+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T20:52:01.359888+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[load] OK       internal  results\\xrp_dt_validation\\holdout_internal_20260806_093143.json\n",
+      "                2367 o  sha1 6e338a634bcf\n",
+      "[load] OK       fresh     results\\xrp_dt_validation\\holdout_fresh_20260806_094210.json\n",
+      "                2332 o  sha1 30deedc9ca27\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Section 6 -- Chargement des deux runs holdout (lecture reelle, pas de snapshot)\n",
+    "#\n",
+    "# Contrairement a la Section 0, PAS de snapshot embarque en fallback : le grain\n",
+    "# exige que les chiffres viennent du fichier. Sur une machine sans les JSON, la\n",
+    "# cellule le dit et nomme le script qui les regenere -- jamais un except muet.\n",
+    "\n",
+    "import hashlib\n",
+    "\n",
+    "HOLDOUT_FILES = {\n",
+    "    'internal': 'results/xrp_dt_validation/holdout_internal_20260806_093143.json',\n",
+    "    'fresh':    'results/xrp_dt_validation/holdout_fresh_20260806_094210.json',\n",
+    "}\n",
+    "GENERATOR = 'scripts/validate_xrp_dt_holdout.py'\n",
+    "\n",
+    "holdouts = {}\n",
+    "for label, rel in HOLDOUT_FILES.items():\n",
+    "    p = Path(rel)\n",
+    "    if not p.exists():\n",
+    "        p = Path('..') / rel\n",
+    "    if not p.exists():\n",
+    "        print(f'[load] ABSENT   {rel}')\n",
+    "        print(f'        results/ est gitignore -- regenerer par :')\n",
+    "        print(f'        python {GENERATOR} --label {label} --coin XRP-USD')\n",
+    "        continue\n",
+    "    raw = p.read_bytes()\n",
+    "    holdouts[label] = json.loads(raw.decode('utf-8'))\n",
+    "    print(f'[load] OK       {label:<9} {p}')\n",
+    "    print(f'                {len(raw)} o  sha1 {hashlib.sha1(raw).hexdigest()[:12]}')\n",
+    "\n",
+    "if len(holdouts) != len(HOLDOUT_FILES):\n",
+    "    print()\n",
+    "    print('ATTENTION : section 6 incomplete sur cette machine. Les outputs')\n",
+    "    print('committes proviennent de ai-01, ou les deux JSON etaient presents.')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d491e7cd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T20:52:01.385873Z",
+     "iopub.status.busy": "2026-08-09T20:52:01.384374Z",
+     "iopub.status.idle": "2026-08-09T20:52:01.395859Z",
+     "shell.execute_reply": "2026-08-09T20:52:01.394859Z"
+    },
+    "papermill": {
+     "duration": 0.013784,
+     "end_time": "2026-08-09T20:52:01.396714+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T20:52:01.382930+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== HOLDOUT TEMPOREL -- agregats par run ===\n",
+      "run       train_end    obs    dt_net       bh      mom  seeds>BH  edge_sig    dm_p       verdict\n",
+      "------------------------------------------------------------------------------------------------\n",
+      "internal  2025-06-30   294   -1.8648  -0.5924  -0.0342       0/5     -6.63  0.0847      NO-BEATS\n",
+      "fresh     2026-04-21    96   +2.0985  -1.8032  +1.6236       5/5    +19.97  0.2360  INCONCLUSIVE\n",
+      "\n",
+      "=== EDGE DT vs MOMENTUM NAKED (le vrai adversaire, cf section 4) ===\n",
+      "run          dt_net   mom_net   edge (dt-mom)   edge vs BH\n",
+      "----------------------------------------------------------\n",
+      "internal    -1.8648   -0.0342         -1.8306      -1.2724\n",
+      "fresh       +2.0985   +1.6236         +0.4749      +3.9017\n",
+      "\n",
+      "=== Detail par seed ===\n",
+      "-- internal --\n",
+      "   seed  0  dt_net= -1.9789  dt_gross= -1.7216  dm_stat= -1.7299  p=0.0847\n",
+      "   seed  1  dt_net= -2.1212  dt_gross= -1.8602  dm_stat= -0.8758  p=0.3819\n",
+      "   seed  7  dt_net= -1.7985  dt_gross= -1.4939  dm_stat= -1.6409  p=0.1019\n",
+      "   seed 42  dt_net= -1.6176  dt_gross= -1.3240  dm_stat= -2.0410  p=0.0421\n",
+      "   seed 99  dt_net= -1.8080  dt_gross= -1.6725  dm_stat= -2.3755  p=0.0182\n",
+      "-- fresh --\n",
+      "   seed  0  dt_net= +2.0975  dt_gross= +2.1369  dm_stat= -1.4979  p=0.1375\n",
+      "   seed  1  dt_net= +2.2628  dt_gross= +2.3179  dm_stat= -1.1926  p=0.2360\n",
+      "   seed  7  dt_net= +1.9775  dt_gross= +2.0158  dm_stat= -1.0912  p=0.2780\n",
+      "   seed 42  dt_net= +1.8426  dt_gross= +1.8500  dm_stat= -1.0504  p=0.2962\n",
+      "   seed 99  dt_net= +2.3119  dt_gross= +2.3665  dm_stat= -1.2306  p=0.2215\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Table des verdicts holdout + comparaison au VRAI adversaire (momentum naked)\n",
+    "print('=== HOLDOUT TEMPOREL -- agregats par run ===')\n",
+    "hdr = (f\"{'run':<9} {'train_end':<11} {'obs':>4} {'dt_net':>9} {'bh':>8} \"\n",
+    "       f\"{'mom':>8} {'seeds>BH':>9} {'edge_sig':>9} {'dm_p':>7} {'verdict':>13}\")\n",
+    "print(hdr)\n",
+    "print('-' * len(hdr))\n",
+    "for label in ('internal', 'fresh'):\n",
+    "    if label not in holdouts:\n",
+    "        print(f'{label:<9} (JSON absent)')\n",
+    "        continue\n",
+    "    d = holdouts[label]\n",
+    "    ag, cf = d['aggregate'], d['config']\n",
+    "    n = d['seed_results'][0]['n_holdout_obs']\n",
+    "    print(f\"{label:<9} {cf['train_end']:<11} {n:>4} \"\n",
+    "          f\"{ag['dt_net_sharpe_mean']:>+9.4f} {ag['bh_sharpe']:>+8.4f} \"\n",
+    "          f\"{ag['momentum_naked_net_sharpe']:>+8.4f} {ag['seeds_beat_bh']:>9} \"\n",
+    "          f\"{ag['edge_sigma']:>+9.2f} {ag['dm_p_median']:>7.4f} {d['verdict']:>13}\")\n",
+    "\n",
+    "print()\n",
+    "print('=== EDGE DT vs MOMENTUM NAKED (le vrai adversaire, cf section 4) ===')\n",
+    "print(f\"{'run':<9} {'dt_net':>9} {'mom_net':>9} {'edge (dt-mom)':>15} {'edge vs BH':>12}\")\n",
+    "print('-' * 58)\n",
+    "for label in ('internal', 'fresh'):\n",
+    "    if label not in holdouts:\n",
+    "        continue\n",
+    "    ag = holdouts[label]['aggregate']\n",
+    "    e_mom = ag['dt_net_sharpe_mean'] - ag['momentum_naked_net_sharpe']\n",
+    "    e_bh = ag['dt_net_sharpe_mean'] - ag['bh_sharpe']\n",
+    "    print(f\"{label:<9} {ag['dt_net_sharpe_mean']:>+9.4f} \"\n",
+    "          f\"{ag['momentum_naked_net_sharpe']:>+9.4f} {e_mom:>+15.4f} {e_bh:>+12.4f}\")\n",
+    "\n",
+    "print()\n",
+    "print('=== Detail par seed ===')\n",
+    "for label in ('internal', 'fresh'):\n",
+    "    if label not in holdouts:\n",
+    "        continue\n",
+    "    print(f'-- {label} --')\n",
+    "    for r in holdouts[label]['seed_results']:\n",
+    "        dm = r.get('dm_dt_vs_bh') or {}\n",
+    "        print(f\"   seed {r['seed']:>2}  dt_net={r['dt_net_sharpe']:>+8.4f}  \"\n",
+    "              f\"dt_gross={r['dt_gross_sharpe']:>+8.4f}  \"\n",
+    "              f\"dm_stat={dm.get('dm_stat', float('nan')):>+8.4f}  \"\n",
+    "              f\"p={dm.get('p_value', float('nan')):.4f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e86303b1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00159,
+     "end_time": "2026-08-09T20:52:01.400362+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T20:52:01.398772+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 6.1 Ce que les deux runs établissent\n",
+    "\n",
+    "**Le momentum naked bat le DT dans les DEUX fenêtres.** C'est la conclusion de la section 4\n",
+    "reconduite hors échantillon, et elle est plus nette ici : sur le holdout interne le DT fait\n",
+    "−1,86 Sharpe contre −0,03 pour une règle directionnelle triviale sans GPU ni entraînement ;\n",
+    "sur le holdout frais il fait +2,10 contre +1,62, soit **+0,48 de gain marginal** là où le\n",
+    "gain affiché contre BH est de +3,90. Presque tout l'« edge vs BH » du run frais est du\n",
+    "momentum, pas du DT.\n",
+    "\n",
+    "**`edge_sigma` change de signe entre les deux fenêtres** : −6,63 (interne) et +19,97 (frais).\n",
+    "Un edge qui passe de −6σ à +20σ selon la coupure temporelle n'est pas un edge, c'est une\n",
+    "mesure de la fenêtre. Et le dénominateur de `edge_sigma`\n",
+    "([`validate_xrp_dt_holdout.py:238`](scripts/validate_xrp_dt_holdout.py)) est la dispersion\n",
+    "**entre seeds entraînées sur les mêmes données** — il croît quand les seeds s'accordent,\n",
+    "ce qui est de la reproductibilité, pas de la significativité.\n",
+    "\n",
+    "**Le comparateur `bh` est dégénéré dans le run frais** : buy-and-hold y fait −1,80 Sharpe.\n",
+    "Battre un actif qui tombe en étant capable de se mettre short n'est pas un résultat ; c'est\n",
+    "pourquoi le vrai adversaire est le momentum, et pourquoi la section 4 avait raison de le\n",
+    "poser ainsi.\n",
+    "\n",
+    "Reste le troisième conjoint de la doctrine §C — `dm_p_median < 0.05`. La cellule suivante\n",
+    "le met à l'épreuve directement, et le résultat n'est pas celui qu'on attend.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cd15a844",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T20:52:01.404565Z",
+     "iopub.status.busy": "2026-08-09T20:52:01.404037Z",
+     "iopub.status.idle": "2026-08-09T20:52:06.359853Z",
+     "shell.execute_reply": "2026-08-09T20:52:06.359166Z"
+    },
+    "papermill": {
+     "duration": 4.95918,
+     "end_time": "2026-08-09T20:52:06.361051+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T20:52:01.401871+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "serie      sharpe     dm_stat        p_value\n",
+      "----------------------------------------------\n",
+      "gagnante   +0.221   +0.757651   0.449257\n",
+      "perdante   -0.221   +0.757651   0.449257\n",
+      "\n",
+      "dm_stat identiques : True\n",
+      "p_value identiques : True\n",
+      "\n",
+      "Conclusion : sous loss_fn=\"mse\", le test compare les CARRES des\n",
+      "rendements -- donc les seconds moments (volatilite realisee), pas la\n",
+      "rentabilite. Une strategie et son exact oppose sont indistinguables.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Le test DM tel qu'il est cable est-il capable de distinguer gagner de perdre ?\n",
+    "#\n",
+    "# Site d'appel (validate_xrp_dt_holdout.py:132) :\n",
+    "#     DM.diebold_mariano_test(-dt_n, -bh_g, loss_fn='mse', hln_correction=True)\n",
+    "# et dans dm_test.py, loss_fn='mse' calcule  loss = errors ** 2.\n",
+    "# Donc le carre annule la negation ET le signe des rendements. Verifions-le\n",
+    "# sur une serie et son exact oppose : meme magnitude, profit inverse.\n",
+    "\n",
+    "import sys\n",
+    "import numpy as np\n",
+    "\n",
+    "DM_MODULE = Path('scripts/dm_test.py')\n",
+    "if not DM_MODULE.exists():\n",
+    "    DM_MODULE = Path('../scripts/dm_test.py')\n",
+    "\n",
+    "if not DM_MODULE.exists():\n",
+    "    print(f'[demo] ABSENT {DM_MODULE} -- demonstration non executable ici.')\n",
+    "else:\n",
+    "    sys.path.insert(0, str(DM_MODULE.parent))\n",
+    "    import dm_test as DM\n",
+    "\n",
+    "    rng = np.random.default_rng(0)\n",
+    "    gagnante = rng.normal(0.001, 0.02, 300)   # derive positive\n",
+    "    perdante = -gagnante                      # perd exactement ce que l'autre gagne\n",
+    "    bh_ref = rng.normal(0.0, 0.02, 300)\n",
+    "\n",
+    "    def sh(x):\n",
+    "        return float(x.mean() / x.std() * np.sqrt(252))\n",
+    "\n",
+    "    a = DM.diebold_mariano_test(-gagnante, -bh_ref, loss_fn='mse', hln_correction=True)\n",
+    "    b = DM.diebold_mariano_test(-perdante, -bh_ref, loss_fn='mse', hln_correction=True)\n",
+    "\n",
+    "    print('serie      sharpe     dm_stat        p_value')\n",
+    "    print('-' * 46)\n",
+    "    print(f'gagnante  {sh(gagnante):>+7.3f}   {a.dm_statistic:>+9.6f}   {a.p_value:.6f}')\n",
+    "    print(f'perdante  {sh(perdante):>+7.3f}   {b.dm_statistic:>+9.6f}   {b.p_value:.6f}')\n",
+    "    print()\n",
+    "    print(f'dm_stat identiques : {a.dm_statistic == b.dm_statistic}')\n",
+    "    print(f'p_value identiques : {a.p_value == b.p_value}')\n",
+    "    print()\n",
+    "    print('Conclusion : sous loss_fn=\"mse\", le test compare les CARRES des')\n",
+    "    print('rendements -- donc les seconds moments (volatilite realisee), pas la')\n",
+    "    print('rentabilite. Une strategie et son exact oppose sont indistinguables.')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16a7f480",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00223,
+     "end_time": "2026-08-09T20:52:06.365484+00:00",
+     "exception": false,
+     "start_time": "2026-08-09T20:52:06.363254+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 6.2 Conséquence : le troisième conjoint de §C mesure la volatilité, pas la rentabilité\n",
+    "\n",
+    "La cellule ci-dessus est une démonstration exécutée, pas une lecture de code : une série de\n",
+    "Sharpe +0,22 et son exact opposé (−0,22) obtiennent un `dm_stat` et un `p_value`\n",
+    "**identiques au bit**. Sous `loss_fn=\"mse\"`, `dm_test.py` élève les entrées au carré, ce qui\n",
+    "annule à la fois la négation du site d'appel et le signe des rendements. Le test compare\n",
+    "donc `dt_net**2` à `bh_gross**2` — deux **volatilités réalisées**.\n",
+    "\n",
+    "Les deux runs holdout le montrent en situation. Sur le holdout **interne**, `dm_stat` est\n",
+    "**négatif** (−1,73 ; convention « négatif = modèle meilleur ») avec `p = 0,0847`, c'est-à-dire\n",
+    "au bord de la significativité **en faveur du DT** — dans une fenêtre où le DT fait −1,86 de\n",
+    "Sharpe contre −0,59 pour BH, soit trois fois pire. Le test ne dit pas que le DT gagne : il\n",
+    "dit que le DT bouge moins.\n",
+    "\n",
+    "Et le détail par seed ci-dessus va plus loin que « le test ne détecte rien » : sur le\n",
+    "holdout interne, **les seeds 42 et 99 franchissent le seuil de 5 %** — `dm_stat = −2,041`\n",
+    "(`p = 0,0421`) et `−2,376` (`p = 0,0182`) — donc *significatifs en faveur du DT*, alors que\n",
+    "ces deux modèles font −1,62 et −1,81 de Sharpe contre −0,59 pour BH. Le test ne se contente\n",
+    "pas d'être muet sur la rentabilité : il rend des verdicts significatifs **du mauvais côté**.\n",
+    "Le `dm_p_median` de 0,0847 qui a produit le `NO-BEATS` est la médiane de p-values dont deux\n",
+    "auraient, prises seules, validé le troisième conjoint de §C pour une stratégie perdante.\n",
+    "\n",
+    "Ce que cela implique, précisément :\n",
+    "\n",
+    "- La doctrine §C exige la **conjonction** `≥4 seeds` ET `edge ≥ 2σ` ET `dm_p_median < 0,05`.\n",
+    "  Le troisième conjoint, tel qu'il est câblé, ne peut pas détecter une différence de\n",
+    "  rentabilité. Il n'invalide pas les verdicts `NO-BEATS` déjà rendus — un `NO-BEATS` tombe\n",
+    "  sur les deux premiers conjoints — mais il rend un futur `BEATS` **non concluant**.\n",
+    "- Le correctif est un test sur le **différentiel de rendement** (ou une perte qui préserve\n",
+    "  le signe), pas sur des carrés. Il est **hors du périmètre de ce notebook** : celui-ci lit\n",
+    "  des JSON, il ne réécrit pas le validateur, et retoucher le script changerait les chiffres\n",
+    "  sans re-tourner les modèles.\n",
+    "- Les JSON ne stockent **pas** les séries de rendements, seulement les Sharpes agrégés : les\n",
+    "  p-values ne peuvent pas être recalculées post hoc. Un run correctif devra les persister.\n",
+    "\n",
+    "**Verdict honnête du holdout temporel** : `NO-BEATS` sur la fenêtre interne, `INCONCLUSIVE`\n",
+    "sur la fenêtre fraîche, et dans les deux cas **le momentum naked reste devant ou au niveau**.\n",
+    "Le `BEATS` du registre L4 reste vrai là où il a été mesuré — panel transversal @10 bps — et\n",
+    "ne s'étend pas au holdout temporel. C'est un bornage de portée, pas une réfutation.\n"
    ]
   }
  ],
@@ -848,18 +1229,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.15"
+   "version": "3.10.11"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.407688,
-   "end_time": "2026-08-06T15:57:48.400672+00:00",
+   "duration": 9.69358,
+   "end_time": "2026-08-09T20:52:06.715057+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "c1330_xrp_dt_foldwise_research.ipynb",
-   "output_path": "c1330_xrp_dt_foldwise_research_v2.ipynb",
+   "output_path": "c1330_xrp_dt_foldwise_research.ipynb",
    "parameters": {},
-   "start_time": "2026-08-06T15:57:44.992984+00:00",
+   "start_time": "2026-08-09T20:51:57.021477+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
Grain: DEEP/training — lane myia-ai-01:CoursIA — prev: MED/guard #10142

## Résumé

Tâche 2 de #10211 : la section 6 du notebook `c1330_xrp_dt_foldwise_research.ipynb` porte désormais les deux runs de **holdout temporel du 06/08**, lus dans leurs JSON. Les tâches 1 et 3 ont été livrées par #10215 (po-2025) ; cette PR complète la partition annoncée sur [#10211 (comment)](https://github.com/jsboige/CoursIA/issues/10211#issuecomment-5233737257).

**Pourquoi cette tâche est chez ai-01 et pas chez la lane qui tient le claim** : les deux JSON vivent sous `results/`, gitignoré (`.gitignore:51`), donc ils n'existent que sur la machine qui a fait tourner l'extension multi-seed le 06/08. Le critère exigeait des chiffres **issus d'une lecture du fichier**, pas d'une recopie : aucune autre lane ne pouvait le satisfaire sans recopier à la main ce que le critère interdit. Le claim de `myia-po-2025:CoursIA-2` n'est **pas** levé, et le crédit de l'analyse lui revient.

## Ce que la section établit — trois résultats, tous exécutés

Cellules 7, 8, 9 réellement exécutées, outputs réels committés (C.2).

**1. Le momentum naked bat le DT dans les DEUX fenêtres holdout.** La section 4 du notebook posait déjà le momentum comme « le vrai adversaire, pas BH » ; le holdout le confirme hors échantillon et plus nettement :

| Run | `train_end` | Obs | DT net | BH | momentum | edge vs mom | edge vs BH | Verdict |
|---|---|---:|---:|---:|---:|---:|---:|---|
| interne | 2025-06-30 | 294 | −1,8648 | −0,5924 | **−0,0342** | **−1,8306** | −1,2724 | `NO-BEATS` |
| frais | 2026-04-21 | 96 | +2,0985 | −1,8032 | **+1,6236** | **+0,4749** | +3,9017 | `INCONCLUSIVE` |

Presque tout l'« edge vs BH » du run frais (+3,90) est du momentum ; le gain marginal du Decision Transformer est **+0,47**. Et le comparateur `bh` est **dégénéré** dans cette fenêtre (BH = −1,8032) : battre un actif qui tombe en pouvant se mettre short n'est pas un résultat.

**2. `edge_sigma` change de signe selon la coupure** : −6,63 (interne) / +19,97 (frais). Son dénominateur ([`validate_xrp_dt_holdout.py:238`](MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/validate_xrp_dt_holdout.py)) est la dispersion **entre seeds entraînées sur les mêmes données** — il mesure la reproductibilité de la procédure, pas la significativité de l'edge. C'est le constat de #10211, reconduit ici avec les deux fenêtres côte à côte.

**3. Le test Diebold-Mariano tel qu'il est câblé est AVEUGLE AU SIGNE.** C'est le résultat neuf de cette PR, et il est **démontré par une cellule exécutée**, pas déduit d'une lecture de code :

```
serie      sharpe     dm_stat        p_value
----------------------------------------------
gagnante   +0.221   +0.757651   0.449257
perdante   -0.221   +0.757651   0.449257

dm_stat identiques : True
p_value identiques : True
```

Une série et son **exact opposé** reçoivent un `dm_stat` et un `p_value` identiques au bit. Cause mécanique : le site d'appel ([`validate_xrp_dt_holdout.py:132`](MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/validate_xrp_dt_holdout.py)) passe `-dt_n` / `-bh_g` avec `loss_fn='mse'`, et [`dm_test.py`](MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/dm_test.py) calcule `loss = errors ** 2` — le carré annule **la négation du site d'appel et le signe des rendements**. Le test compare `dt_net²` à `bh_gross²`, donc deux **volatilités réalisées**.

**Conséquence mesurée sur nos propres données** : sur le holdout interne, les seeds 42 et 99 sortent `p = 0,0421` et `p = 0,0182`, c'est-à-dire **significatifs à 5 % « en faveur du DT »** — alors que ces deux modèles font −1,62 et −1,81 de Sharpe contre −0,59 pour BH. Le test ne se contente pas d'être muet sur la rentabilité : il rend des verdicts significatifs **du mauvais côté**. Le `dm_p_median = 0,0847` qui a produit le `NO-BEATS` est la médiane de p-values dont deux auraient, prises seules, validé le troisième conjoint de §C pour une stratégie perdante.

## Portée — ce que cette PR ne fait pas

- **Elle ne corrige pas le validateur.** Le correctif (test sur le différentiel de rendement, ou une perte qui préserve le signe) est **hors périmètre** : il changerait les chiffres sans re-tourner les modèles, et les JSON ne persistent pas les séries de rendements, donc les p-values ne sont pas recalculables post hoc. Issue de suivi ouverte séparément (principe 3 : signaler, traiter en sujet dédié).
- **Elle n'invalide pas les `NO-BEATS` déjà rendus** — ils tombent sur les deux premiers conjoints de §C (`seeds > BH` et `edge ≥ 2σ`), pas sur le DM.
- **Elle ne réfute pas L4.** Le `BEATS` du registre reste vrai là où il a été mesuré (panel transversal @10 bps) ; il ne s'étend pas au holdout temporel. C'est un bornage de portée.

## Conception de la cellule de chargement

Pas de snapshot embarqué en fallback — contrairement à la section 0, qui en a un pour le sweep. Le critère du grain exige que les chiffres viennent du fichier : embarquer une copie rouvrirait la porte à la recopie manuelle. Sur une machine sans les JSON, la cellule imprime `[load] ABSENT` et **nomme la commande de régénération** (`python scripts/validate_xrp_dt_holdout.py --label <l> --coin XRP-USD`) — jamais un `except` muet (interdit harnais). La provenance est imprimée dans l'output : chemin, taille, `sha1` tronqué (`6e338a634bcf` / `30deedc9ca27`).

## Vérifications (relancées après le dernier commit)

```
notebook_tools validate         OK: 1   Warnings: 0   Errors: 0
check_c2_compliance --path      C.2 Compliance Check: 1/1 notebooks compliant — All clear!
strip_machine_paths --scan      0 notebook(s) carrying 0 leak line(s)
detect_papermill_path_leak      []
grep -cE "raise NotImplementedError|assert False|1/0"   -> 0
pre-commit (6 hooks)            tous Passed (gitleaks, probeAddresses, nuget-leak,
                                papermill-paths, md-rendering, H.3 null-exec)
```

`execution_count` : 1..9 sans trou, chaque cellule code porte ses outputs. Les cellules 1 à 6 ont été re-exécutées et restent identiques en substance — le sweep JSON `foldwise_20260806_165146.json` est toujours absent de cette machine, donc la section 0 retombe sur le même snapshot embarqué qu'avant (output inchangé). Les chemins papermill ont été normalisés au basename par [`scrub_papermill_paths.py`](scripts/notebook_tools/scrub_papermill_paths.py) — l'outil dédié, pas une édition manuelle.

Le PNG produit par la cellule 6 (`c1330_xrp_dt_foldwise_plots.png`) reste **non tracké**, comme avant cette PR : il n'est pas ajouté au dépôt.

## Note d'honnêteté sur un critère

Le critère de #10211 demandait la présence de `-1.865`. La valeur exacte du JSON est **`-1.8648`** (`aggregate.dt_net_sharpe_mean`), et c'est celle que le notebook imprime : j'avais écrit l'arrondi dans l'issue. Le critère est tenu en substance, avec une précision supérieure — pas avec la chaîne littérale. Les quatre autres (`-6.63`, `0.0847`, `+19.97`, `0.236`) apparaissent tels quels dans l'output de la cellule 8.

See #10211 (Tâche 2 ; Tâches 1 et 3 livrées par #10215), #1454.
