### PR TITLE
refactor(socle,#10161): consume FleePredicateBuilder in Socle-MetadataDriven Moment 3

### DIFF
--- a/MyIA.AI.Notebooks/cross-series/socle-metadata-driven/Socle-MetadataDriven-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/cross-series/socle-metadata-driven/Socle-MetadataDriven-Csharp.ipynb
@@ -39,10 +39,10 @@
    "id": "a43683e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T10:15:31.114488Z",
-     "iopub.status.busy": "2026-08-09T10:15:31.110009Z",
-     "iopub.status.idle": "2026-08-09T10:15:34.367377Z",
-     "shell.execute_reply": "2026-08-09T10:15:34.365126Z"
+     "iopub.execute_input": "2026-08-09T21:01:22.381462Z",
+     "iopub.status.busy": "2026-08-09T21:01:22.374424Z",
+     "iopub.status.idle": "2026-08-09T21:01:29.470098Z",
+     "shell.execute_reply": "2026-08-09T21:01:29.465065Z"
     },
     "papermill": {
      "duration": 3.262388,
@@ -59,7 +59,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-24220.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-96908.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -109,7 +109,7 @@
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '24220.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '96908.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -213,13 +213,15 @@
     "using MyIA.AI.ComponentModel.Entities;\n",
     "using MyIA.AI.ComponentModel.Providers;\n",
     "using MyIA.AI.ComponentModel.Serialization;\n",
+    "using MyIA.AI.ComponentModel.Rules;\n",
     "using Flee.PublicTypes;\n",
     "using Newtonsoft.Json;\n",
     "\n",
-    "// Sanity check : les trois références sont résolues.\n",
+    "// Sanity check : les trois références sont résolues. Flee reste chargé car\n",
+    "// FleePredicateBuilder (Moment 3) s'appuie sur ce moteur en interne.\n",
     "Console.WriteLine($\"socle    : {typeof(ReflectedProviderContainer).Assembly.GetName().Version}\");\n",
     "Console.WriteLine($\"Flee     : {typeof(ExpressionContext).Assembly.GetName().Version}\");\n",
-    "Console.WriteLine($\"Newtonsoft: {typeof(JsonConvert).Assembly.GetName().Version}\");\n"
+    "Console.WriteLine($\"Newtonsoft: {typeof(JsonConvert).Assembly.GetName().Version}\");"
    ]
   },
   {
@@ -253,10 +255,10 @@
    "id": "61e5f14d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T10:15:34.378886Z",
-     "iopub.status.busy": "2026-08-09T10:15:34.378694Z",
-     "iopub.status.idle": "2026-08-09T10:15:34.650601Z",
-     "shell.execute_reply": "2026-08-09T10:15:34.650727Z"
+     "iopub.execute_input": "2026-08-09T21:01:29.473004Z",
+     "iopub.status.busy": "2026-08-09T21:01:29.472444Z",
+     "iopub.status.idle": "2026-08-09T21:01:30.101240Z",
+     "shell.execute_reply": "2026-08-09T21:01:30.101623Z"
     },
     "papermill": {
      "duration": 0.27563,
@@ -347,10 +349,10 @@
    "id": "533727c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T10:15:34.657367Z",
-     "iopub.status.busy": "2026-08-09T10:15:34.657165Z",
-     "iopub.status.idle": "2026-08-09T10:15:34.843492Z",
-     "shell.execute_reply": "2026-08-09T10:15:34.843187Z"
+     "iopub.execute_input": "2026-08-09T21:01:30.104258Z",
+     "iopub.status.busy": "2026-08-09T21:01:30.103754Z",
+     "iopub.status.idle": "2026-08-09T21:01:30.468045Z",
+     "shell.execute_reply": "2026-08-09T21:01:30.467593Z"
     },
     "papermill": {
      "duration": 0.189909,
@@ -470,10 +472,10 @@
    "id": "1dc22a53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T10:15:34.857124Z",
-     "iopub.status.busy": "2026-08-09T10:15:34.856901Z",
-     "iopub.status.idle": "2026-08-09T10:15:34.931425Z",
-     "shell.execute_reply": "2026-08-09T10:15:34.931540Z"
+     "iopub.execute_input": "2026-08-09T21:01:30.470846Z",
+     "iopub.status.busy": "2026-08-09T21:01:30.470303Z",
+     "iopub.status.idle": "2026-08-09T21:01:30.616096Z",
+     "shell.execute_reply": "2026-08-09T21:01:30.616403Z"
     },
     "papermill": {
      "duration": 0.0788,
@@ -554,10 +556,10 @@
    "id": "fc10a4f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T10:15:34.944000Z",
-     "iopub.status.busy": "2026-08-09T10:15:34.943814Z",
-     "iopub.status.idle": "2026-08-09T10:15:35.048124Z",
-     "shell.execute_reply": "2026-08-09T10:15:35.047990Z"
+     "iopub.execute_input": "2026-08-09T21:01:30.619238Z",
+     "iopub.status.busy": "2026-08-09T21:01:30.618571Z",
+     "iopub.status.idle": "2026-08-09T21:01:30.841949Z",
+     "shell.execute_reply": "2026-08-09T21:01:30.841458Z"
     },
     "papermill": {
      "duration": 0.10817,
@@ -651,10 +653,10 @@
    "id": "98acf45e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T10:15:35.054941Z",
-     "iopub.status.busy": "2026-08-09T10:15:35.054770Z",
-     "iopub.status.idle": "2026-08-09T10:15:35.234885Z",
-     "shell.execute_reply": "2026-08-09T10:15:35.234736Z"
+     "iopub.execute_input": "2026-08-09T21:01:30.845047Z",
+     "iopub.status.busy": "2026-08-09T21:01:30.844535Z",
+     "iopub.status.idle": "2026-08-09T21:01:31.233305Z",
+     "shell.execute_reply": "2026-08-09T21:01:31.232851Z"
     },
     "papermill": {
      "duration": 0.18373,
@@ -777,10 +779,10 @@
    "id": "ce8ad6f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T10:15:35.243289Z",
-     "iopub.status.busy": "2026-08-09T10:15:35.243104Z",
-     "iopub.status.idle": "2026-08-09T10:15:35.329811Z",
-     "shell.execute_reply": "2026-08-09T10:15:35.329677Z"
+     "iopub.execute_input": "2026-08-09T21:01:31.235711Z",
+     "iopub.status.busy": "2026-08-09T21:01:31.235227Z",
+     "iopub.status.idle": "2026-08-09T21:01:31.427412Z",
+     "shell.execute_reply": "2026-08-09T21:01:31.426946Z"
     },
     "papermill": {
      "duration": 0.09098,
@@ -879,10 +881,10 @@
    "id": "0357c8ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T10:15:35.343916Z",
-     "iopub.status.busy": "2026-08-09T10:15:35.343737Z",
-     "iopub.status.idle": "2026-08-09T10:15:35.393567Z",
-     "shell.execute_reply": "2026-08-09T10:15:35.393672Z"
+     "iopub.execute_input": "2026-08-09T21:01:31.429987Z",
+     "iopub.status.busy": "2026-08-09T21:01:31.429506Z",
+     "iopub.status.idle": "2026-08-09T21:01:31.535007Z",
+     "shell.execute_reply": "2026-08-09T21:01:31.534611Z"
     },
     "papermill": {
      "duration": 0.053898,
@@ -953,12 +955,19 @@
     "```\n",
     "\n",
     "Cette chaîne peut venir d'un fichier de configuration, d'une ligne de CSV, ou être saisie\n",
-    "par un utilisateur non-développeur dans une console d'administration. On la **compile une\n",
-    "fois** en un délégué réutilisable, puis on l'évalue sur N instances en changeant\n",
+    "par un utilisateur non-développeur dans une console d'administration. On la **compile une fois**\n",
+    "en un délégué réutilisable, puis on l'évalue sur N instances en changeant\n",
     "simplement les variables — **sans recompiler l'hôte**.\n",
     "\n",
+    "> **Le socle industrialise ce moment.** Plutôt que d'enregistrer chaque variable\n",
+    "> à la main (`ctx.Variables.Add(...)`), le socle expose\n",
+    "> [`FleePredicateBuilder.Create<T>(regle)`](../../../MyIA.AI.Shared/ComponentModel/Rules/FleePredicateBuilder.cs) :\n",
+    "> il reflète les propriétés publiques de `T` comme variables de la règle et renvoie\n",
+    "> un `Func<T, bool>` directement utilisable dans LINQ. La signature du type fait\n",
+    "> office de contrat de variables — l'erreur « variable non déclarée » disparaît.\n",
+    "\n",
     "> **Syntaxe Flee.** Le moteur est d'inspiration VB : `And` / `Or` / `=`, **pas**\n",
-    "> `&&` / `||` / `==`. La comparaison de chaînes utilise `=`.\n"
+    "> `&&` / `||` / `==`. La comparaison de chaînes utilise `=`."
    ]
   },
   {
@@ -967,10 +976,10 @@
    "id": "6f85bec7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T10:15:35.408032Z",
-     "iopub.status.busy": "2026-08-09T10:15:35.407834Z",
-     "iopub.status.idle": "2026-08-09T10:15:35.535358Z",
-     "shell.execute_reply": "2026-08-09T10:15:35.535220Z"
+     "iopub.execute_input": "2026-08-09T21:01:31.537900Z",
+     "iopub.status.busy": "2026-08-09T21:01:31.537300Z",
+     "iopub.status.idle": "2026-08-09T21:01:31.837121Z",
+     "shell.execute_reply": "2026-08-09T21:01:31.836659Z"
     },
     "papermill": {
      "duration": 0.131688,
@@ -1063,34 +1072,31 @@
     "    new() { Name = \"ENT-004\", Montant = 2000, Pays = \"FR\", Actif = false  },\n",
     "};\n",
     "\n",
-    "// La règle est une CHAENE — elle aurait aussi bien pu être lue dans un fichier.\n",
+    "// La règle est une CHAÎNE — elle aurait aussi bien pu être lue dans un fichier.\n",
     "string regle = \"Montant > 1000 And Pays = \\\"FR\\\" And Actif = true\";\n",
     "Console.WriteLine($\"Règle appliquée : {regle}\");\n",
     "Console.WriteLine();\n",
     "\n",
-    "// Compilation unique : on lie le délégué une fois.\n",
-    "var ctx = new ExpressionContext();\n",
-    "ctx.Variables.Add(\"Montant\", 0.0);\n",
-    "ctx.Variables.Add(\"Pays\", \"\");\n",
-    "ctx.Variables.Add(\"Actif\", false);\n",
-    "var predicat = ctx.CompileGeneric<bool>(regle);\n",
+    "// Compilation unique : le socle (FleePredicateBuilder) reflète automatiquement\n",
+    "// les propriétés publiques de Subscription (Montant, Pays, Actif) et les expose\n",
+    "// comme variables de la règle. Fini l'enregistrement manuel ctx.Variables.Add :\n",
+    "// la signature du type fait office de contrat de variables.\n",
+    "var predicat = FleePredicateBuilder.Create<Subscription>(regle);\n",
     "\n",
     "Console.WriteLine(\"Eligibles :\");\n",
     "foreach (var ab in abonnements)\n",
     "{\n",
-    "    ctx.Variables[\"Montant\"] = ab.Montant;\n",
-    "    ctx.Variables[\"Pays\"]    = ab.Pays;\n",
-    "    ctx.Variables[\"Actif\"]   = ab.Actif;\n",
-    "    Console.WriteLine($\"  {ab.Name,-8} Montant={ab.Montant,6} Pays={ab.Pays} Actif={ab.Actif,-5} -> {predicat.Evaluate()}\");\n",
+    "    Console.WriteLine($\"  {ab.Name,-8} Montant={ab.Montant,6} Pays={ab.Pays} Actif={ab.Actif,-5} -> {predicat(ab)}\");\n",
     "}\n",
     "\n",
-    "// On change la règle (les données pilotent), toujours sans recompiler l'hôte.\n",
+    "// On change la règle (les données pilotent), toujours sans recompiler l'hôte :\n",
+    "// un nouveau Create<T> recompile un délégué indépendant. Les deux règles coexistent.\n",
     "string regle2 = \"Montant > 2000\";\n",
-    "var predicat2 = ctx.CompileGeneric<bool>(regle2);\n",
+    "var predicat2 = FleePredicateBuilder.Create<Subscription>(regle2);\n",
     "Console.WriteLine();\n",
     "Console.WriteLine($\"Règle 2 : {regle2}\");\n",
-    "var gros = abonnements.Where(a => { ctx.Variables[\"Montant\"] = a.Montant; return predicat2.Evaluate(); });\n",
-    "Console.WriteLine($\"Gros abonnements (>2000) : {string.Join(\", \", gros.Select(a => a.Name))}\");\n"
+    "var gros = abonnements.Where(predicat2);\n",
+    "Console.WriteLine($\"Gros abonnements (>2000) : {string.Join(\", \", gros.Select(a => a.Name))}\");"
    ]
   },
   {
@@ -1112,11 +1118,11 @@
     "**Objectif.** Compléter `FiltrerParMontant(min)` pour qu'elle renvoie les noms des\n",
     "abonnements dont le `Montant` est **supérieur ou égal** au seuil passé en paramètre.\n",
     "La règle doit être **construite comme une chaîne** à partir du seuil (`$\"Montant >= {min}\"`),\n",
-    "compilée via Flee, puis appliquée.\n",
+    "compilée via le socle, puis appliquée.\n",
     "\n",
-    "*Indice.* `CompileGeneric<bool>` sur le contexte, puis bouclez en assignant\n",
-    "`ctx.Variables[\"Montant\"]` avant chaque `.Evaluate()`. Syntaxe Flee : `>=` pour\n",
-    "«supérieur ou égal».\n"
+    "*Indice.* `FleePredicateBuilder.Create<Subscription>($\"Montant >= {min}\")` renvoie\n",
+    "un `Func<Subscription, bool>` : passez-le directement à `.Where(...)` puis sélectionnez\n",
+    "les `Name`. Syntaxe Flee : `>=` pour « supérieur ou égal »."
    ]
   },
   {
@@ -1125,10 +1131,10 @@
    "id": "cdfc128a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T10:15:35.551175Z",
-     "iopub.status.busy": "2026-08-09T10:15:35.550992Z",
-     "iopub.status.idle": "2026-08-09T10:15:35.596006Z",
-     "shell.execute_reply": "2026-08-09T10:15:35.595872Z"
+     "iopub.execute_input": "2026-08-09T21:01:31.840159Z",
+     "iopub.status.busy": "2026-08-09T21:01:31.839508Z",
+     "iopub.status.idle": "2026-08-09T21:01:31.944103Z",
+     "shell.execute_reply": "2026-08-09T21:01:31.942721Z"
     },
     "papermill": {
      "duration": 0.04951,


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA-2 — prev: DEEP/tooling (#10222)

## Summary

Moment 3 ("Prédicat universel métier") of `Socle-MetadataDriven-Csharp.ipynb` now consumes the library builder [`FleePredicateBuilder`](../../MyIA.AI.Shared/ComponentModel/Rules/FleePredicateBuilder.cs) (ancre B4, MERGED via #10167) instead of writing Flee inline. This is the "missing seam": the cross-series README already documents the builder as the industrialized form of Moment 3, but the notebook itself still used the low-level `ExpressionContext` + manual `ctx.Variables.Add(...)`.

### What changed (4 cells, +73/-67, 1 file)

| Cell | Before | After |
|------|--------|-------|
| **1 (setup)** | `using Flee.PublicTypes;` only | **adds `using MyIA.AI.ComponentModel.Rules;`** (builder namespace) |
| **13 (markdown Moment 3)** | generic Flee prose | **documents `FleePredicateBuilder.Create<T>(regle)`** — auto-reflects public props as rule variables, returns `Func<T,bool>` |
| **14 (Moment 3 code)** | `new ExpressionContext()` + `ctx.Variables.Add("Montant",0.0)` x3 + `CompileGeneric<bool>` + per-entity `ctx.Variables["Montant"]=ab.Montant` | **`FleePredicateBuilder.Create<Subscription>(regle)`** — one line, auto-binding; `abonnements.Where(predicat2)` directly in LINQ |
| **15 (Exercice 3 indice)** | indice via `CompileGeneric<bool>` + `ctx.Variables` | indice redirected to `Create<Subscription>($"Montant >= {min}")` + `.Where(...)` |

**Exercice 3 (cell 16) is NOT resolved** — it remains a stub (`return Enumerable.Empty<string>();`). Only the *indice* was updated to point at the builder API. Per exercise-example-labeling, a stub stays a stub.

## Proof of execution (re-exec .net-csharp, C.2)

Re-executed via `jupyter nbconvert --execute --inplace` (kernel `.net-csharp`):

- **All 10 code cells: `execution_count` 1-10 (non-null), 0 error.**
- Moment 3 outputs are **identical** to the inline version — pedagogical coherence preserved:
  - `Montant > 1000 And Pays = "FR" And Actif = true`: ENT-001→True, ENT-002→False, ENT-003→False, ENT-004→False
  - `Montant > 2000`: ENT-003
- Sanity check cell 1: `socle 1.0.0.0`, `Flee 1.0.0.0`, `Newtonsoft 13.0.0.0`

## Validation

| Check | Result |
|-------|--------|
| C.1 (no intentional error) | 0 violation |
| Path-leak scan (`C:\`,`D:\`,`/Users/`) | 0 hit |
| Exercice 3 still stub (not solved) | confirmed (`Enumerable.Empty`, no `FleePredicateBuilder` in stub) |
| `nbformat validate` | VALID |
| `strip_probe_banner.py --apply` | 9 probeAddresses lines stripped post-exec |
| Catalogue | byte-identical to main (untouched) |
| Twin parity | notebook NOT in any twin pair (grep `twin_pairs.d/` empty) — safe |

## Firsthand viability check (before editing)

Before editing, verified on a live `.net-csharp` kernel that `FleePredicateBuilder.Create<T>` accepts the notebook's exact rule syntax (`And` capitalized, `=` string comparison). The builder sets `CaseSensitive=true` for identifier matching but Flee's VB-style keywords (`And`/`Or`/`=`) work regardless of casing — confirmed: ENT-001→True. Rule 2 `Montant > 2000` → ENT-003.

## Scope

One notebook, one concern (consume the merged builder). No catalogue churn, no twin-parity rebaseline needed (not a twin member). `See #10161` (the builder's epic; the builder itself landed via #10167).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
