### PR TITLE
feat(training,#10228): sign-sensitive linear loss for DM test + persist return series

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/dm_test.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/dm_test.py
@@ -84,7 +84,13 @@ def diebold_mariano_test(
     errors_b : np.ndarray
         Forecast errors from model B (1-D), same length as errors_a.
     loss_fn : str
-        "mse" for squared-error loss, "mae" for absolute-error loss.
+        "mse" for squared-error loss, "mae" for absolute-error loss,
+        "linear" for signed linear loss L(e) = e. Only "linear" is
+        sign-sensitive: mse and mae are symmetric ((-r)**2 == r**2 and
+        |-r| == |r|), so a forecast and its exact opposite are
+        bit-identical under mse/mae. Use "linear" when the sign of the
+        error carries information (e.g. forecasting returns rather than
+        volatility) -- see #10228.
     hln_correction : bool
         Apply Harvey-Leybourne-Newbold (1997) small-sample correction.
     max_lag : int | None
@@ -114,8 +120,14 @@ def diebold_mariano_test(
     elif loss_fn == "mae":
         loss_a = np.abs(errors_a)
         loss_b = np.abs(errors_b)
+    elif loss_fn == "linear":
+        # Signed linear loss L(e) = e. Unlike mse/mae (symmetric), linear
+        # preserves the sign of the error: it is the only option that lets the
+        # DM test tell a winning forecast from its exact opposite (#10228).
+        loss_a = errors_a
+        loss_b = errors_b
     else:
-        raise ValueError(f"loss_fn must be 'mse' or 'mae', got '{loss_fn}'")
+        raise ValueError(f"loss_fn must be 'mse', 'mae' or 'linear', got '{loss_fn}'")
 
     d = loss_a - loss_b
     d_mean = float(np.mean(d))

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/test_dm.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/test_dm.py
@@ -94,6 +94,27 @@ class TestDieboldMarianoTest:
         with pytest.raises(ValueError, match="loss_fn"):
             diebold_mariano_test(np.ones(50), np.ones(50), loss_fn="rmse")
 
+    def test_linear_loss_distinguishes_opposite_series(self):
+        """Regression #10228: mse loss is sign-blind.
+
+        A forecast-error series and its exact opposite are bit-identical
+        under mse (squaring cancels the sign), so the DM test cannot tell a
+        winning forecast from a losing one. Only the signed linear loss
+        L(e) = e restores sign-sensitivity.
+        """
+        rng2 = np.random.default_rng(7)
+        e = rng2.normal(0.5, 1.0, 500)  # nonzero mean so d_mean != 0
+        zero = np.zeros_like(e)
+        # mse is symmetric: e and -e give the same statistic.
+        r_mse_pos = diebold_mariano_test(e, zero, loss_fn="mse")
+        r_mse_neg = diebold_mariano_test(-e, zero, loss_fn="mse")
+        assert r_mse_pos.dm_statistic == pytest.approx(r_mse_neg.dm_statistic)
+        # linear preserves the sign: e and -e give opposite-sign statistics.
+        r_lin_pos = diebold_mariano_test(e, zero, loss_fn="linear")
+        r_lin_neg = diebold_mariano_test(-e, zero, loss_fn="linear")
+        assert r_lin_pos.dm_statistic != pytest.approx(r_lin_neg.dm_statistic)
+        assert r_lin_pos.dm_statistic * r_lin_neg.dm_statistic < 0
+
 
 class TestDmVerdict:
     def test_model_wins(self):

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/validate_xrp_dt_holdout.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/validate_xrp_dt_holdout.py
@@ -127,18 +127,36 @@ def run_one_seed_holdout(seed: int, raw: pd.DataFrame, train_end: str,
     bh_g = gross_returns(bh_pos, test_returns_full)
 
     dm = None
+    dm_mom = None
     if len(dt_n) > 30:
+        # loss_fn="linear" (#10228): mse/mae are symmetric ((-r)**2 == r**2)
+        # and made the test sign-blind -- a winning and a losing return series
+        # got bit-identical dm_stat. Linear loss L(e) = e preserves the sign,
+        # so d = (-bh_g) - (-dt_n) = dt_n - bh_g and E[d] < 0 <=> DT beats BH.
         try:
-            r = DM.diebold_mariano_test(-dt_n, -bh_g, loss_fn="mse", hln_correction=True)
+            r = DM.diebold_mariano_test(-dt_n, -bh_g, loss_fn="linear", hln_correction=True)
             dm = {"dm_stat": round(r.dm_statistic, 4), "p_value": round(r.p_value, 4),
                   "n_obs": int(r.n_observations)}
         except Exception as e:
             dm = {"error": str(e)}
+        # Momentum is the real adversary: BH is degenerate when the asset falls
+        # (fresh-window BH sharpe was -1.80). A DM vs naked momentum is what
+        # makes the third conjunct of pr-review-discipline section C informative.
+        try:
+            r_mom = DM.diebold_mariano_test(-dt_n, -mom_n, loss_fn="linear", hln_correction=True)
+            dm_mom = {"dm_stat": round(r_mom.dm_statistic, 4), "p_value": round(r_mom.p_value, 4),
+                      "n_obs": int(r_mom.n_observations)}
+        except Exception as e:
+            dm_mom = {"error": str(e)}
 
     del model, result
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
 
+    # Persist the per-seed return series so the DM p-values stay recalculable
+    # post hoc: today only aggregated Sharpes are saved, which froze the p-value
+    # at the buggy mse value and prevented correcting it without a rerun.
+    # ~300 obs x 3 series x 5 seeds stays small.
     return {
         "seed": seed,
         "n_holdout_obs": int(len(dt_n)),
@@ -147,6 +165,10 @@ def run_one_seed_holdout(seed: int, raw: pd.DataFrame, train_end: str,
         "momentum_naked_net_sharpe": round(sharpe(mom_n), 4),
         "bh_sharpe": round(sharpe(bh_g), 4),
         "dm_dt_vs_bh": dm,
+        "dm_dt_vs_momentum": dm_mom,
+        "dt_net": [round(float(x), 6) for x in dt_n],
+        "bh_gross": [round(float(x), 6) for x in bh_g],
+        "momentum_net": [round(float(x), 6) for x in mom_n],
     }
 
 


### PR DESCRIPTION
Grain: DEEP/training — lane myia-po-2025:CoursIA-2 — prev: DEEP/training #10215

## Le test Diebold-Mariano était aveugle au signe

Le site d'appel `validate_xrp_dt_holdout.py` passait `-dt_n, -bh_g` (rendements -> pertes, pour la convention « dm_stat negatif = modele meilleur ») MAIS avec `loss_fn="mse"`. Or `(-r)**2 == r**2` : le carre annule la negation ET le signe du rendement. Le test comparait donc deux volatilites realisees, pas des rentabilites — une serie gagnante et son exact opposee obtenaient un `dm_stat` **bit-identique**.

Demonstration d'integration (miroir de la cellule commitee #10211/#10226) :

| serie | mse dm_stat | mse p_value | linear dm_stat | linear p_value |
|---|---|---|---|---|
| gagnante | 10.0754 | 0.0 | -0.1771 | 0.860 |
| perdante (-gagnante) | 10.0754 | 0.0 | +0.1771 | 0.860 |

Sous mse, gagnante et perdante sont **indistinguables** ; sous linear, **signes opposes**.

## Tache 1 — `loss_fn="linear"` dans `dm_test.py`

Ajout d'une perte lineaire signee `L(e) = e` (`loss_a = errors_a`, `loss_b = errors_b`). Additif : `mse` et `mae` gardent leur semantique. Le reste du chemin (differentiel `d`, variance HAC Newey-West, correction HLN, `_optimal_lag`) est **inchange** — il est correct et gere deja l'autocorrelation serielle.

Avec `linear`, le site d'appel `(-dt_n, -bh_g)` donne `d = bh_g - dt_n`, donc `E[d] < 0` <=> DT de rendement moyen superieur — exactement la convention que la docstring promet deja.

## Tache 2 — site d'appel + persistance des series

Dans `validate_xrp_dt_holdout.py` :
- `loss_fn="mse"` -> `loss_fn="linear"`.
- Ajout de `dm_dt_vs_momentum` (DM du DT contre le momentum naked) a cote de `dm_dt_vs_bh`. Le momentum est le vrai adversaire ; BH est **degenere** des que l'actif tombe (fenetre fraiche BH sharpe -1.80). Un DM vs momentum rend le 3e conjoint de pr-review-discipline section C informatif.
- Persistance des series de rendements par seed : `dt_net`, `bh_gross`, `momentum_net` (floats arrondis a 6 decimales). Aujourd'hui seuls les Sharpes agreges sont sauves -> les p-values n'etaient **pas recalculables post hoc** (ce qui a fige la p-value au niveau buggue). ~300 obs x 3 series x 5 seeds reste petit.

## Acceptance

- **Tests dm_test existants inchanges et verts** : 18/18 PASS (17 existants + 1 nouveau), 0 FAIL. `test_invalid_loss_fn` toujours vert (`"rmse"` -> ValueError matchant "loss_fn").
- **Nouveau test de regression** `test_linear_loss_distinguishes_opposite_series` : pin le bug (mse rend `e` et `-e` bit-identiques) et la correction (linear -> signes opposes). Falsifiable both-directions.
- `py_compile` OK sur les 3 fichiers ; integration demo ci-dessus.
- Tache 3 (GPU) routee separement par ai-01 — hors scope de cette PR.

See #10228 (Taches 1+2, CPU). See #10211 (grain parent : amendement section C + qualification du verdict L4). Suite de #10215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
