### PR TITLE
fix(guard,#9774): line-anchor check_lane_claim marker regex — FN on #10228 (mid-prose [RELEASED] neutralised real [CLAIMED])

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -82,8 +82,19 @@ from grain_tag import extract_lane
 # `[DONE]`/`[RELEASED]`/`[CANCELLED]`/`[ABANDONED]` close a claim; `[CLAIMED]`
 # opens one. Read on ISSUE comments (the claim registry per #9774), not on the
 # dashboard. Case-insensitive, tolerates inner spaces.
+# Line-anchored (`(?m)^[ \t]*\[...`): a marker only enacts a state change when
+# it STARTS a line -- the convention of every `--claim`/`--release` post and every
+# coordinator dispatch. A marker MENTIONED mid-sentence in prose is not an event.
+# Closes the #10228 false-negative: ai-01's claim comment ended with the
+# instructional sentence "Release with `[RELEASED]` when your PR lands" -- the
+# unanchored regex took that mid-prose `[RELEASED]` as the final-intent close,
+# neutralising the real `[CLAIMED]` and reporting the issue CLEAR while another
+# lane held an active claim. `findall` still returns markers in order, so the
+# legitimate "last marker wins" design (a `[CLAIMED]\n[DONE]` edit sequence on
+# separate lines) is preserved -- only mid-line mentions are rejected.
 _MARKER_RE = re.compile(
-    r"\[\s*(CLAIMED|RELEASED|CANCELLED|ABANDONED|DONE)\s*\]", re.IGNORECASE
+    r"(?m)^[ \t]*\[\s*(CLAIMED|RELEASED|CANCELLED|ABANDONED|DONE)\s*\]",
+    re.IGNORECASE,
 )
 _OPEN = {"CLAIMED"}
 _CLOSE = {"RELEASED", "CANCELLED", "ABANDONED", "DONE"}

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -94,6 +94,42 @@ def test_parse_last_marker_wins():
     assert ev is not None and ev.is_open is False
 
 
+def test_parse_instructional_marker_in_prose_ignored():
+    # The #10228 false-negative (c.74). ai-01's claim comment carried a real
+    # line-start `[CLAIMED]` then an instructional sentence MENTIONING
+    # `[RELEASED]` mid-prose ("Release with `[RELEASED]` when your PR lands").
+    # The unanchored regex took that mid-prose `[RELEASED]` as the final-intent
+    # close, neutralising the claim -- the tool reported CLEAR while po-2025
+    # held an active claim, a near-collision. Line-anchoring rejects the
+    # mid-prose mention; only the real line-start `[CLAIMED]` counts.
+    body = (
+        "[CLAIMED] lane myia-po-2025:CoursIA-2 -- Taches 1-2 (CPU).\r\n\r\n"
+        "(check_lane_claim #9774; Release with `[RELEASED]` when your PR lands.)"
+    )
+    ev = clc.parse_claim_event(
+        comment(body, "2026-08-09T21:19:00Z", author="myia-ai-01"))
+    assert ev is not None
+    assert ev.is_open is True              # NOT closed by the mid-prose mention
+    assert ev.marker == "CLAIMED"
+    assert ev.lane == "myia-po-2025:CoursIA-2"
+
+
+def test_check_blocked_when_claim_comment_mentions_marker_in_prose(capsys):
+    # Full-flow regression for the #10228 FN: a claim comment that ALSO mentions
+    # a close marker in instructional prose must still BLOCK another lane. This
+    # is the exact shape of ai-01's dispatch comments (claim + release instructions).
+    body = (
+        "[CLAIMED] lane myia-po-2025:CoursIA-2 -- Taches 1-2 (CPU).\r\n\r\n"
+        "(Release with `[RELEASED]` when your PR lands.)"
+    )
+    p = payload(comment(body, "2026-08-09T21:19:00Z", author="myia-ai-01"))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    assert rc == 1                          # BLOCKED, not CLEAR (the FN returned 0)
+    captured = capsys.readouterr()
+    assert "BLOCKED" in captured.err
+    assert "myia-po-2025:CoursIA-2" in captured.out
+
+
 def test_parse_unattributed_marker():
     # Marker present but no `lane` keyword -> lane None (surfaced, not guessed).
     ev = clc.parse_claim_event(comment(


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/notebook-python #10224

See #9774 (the tool's originating mandat). Complementary to #10223 (po-205's CI claim-locus gate — a different layer: this fixes the EXISTING manual CLI, #10223 wires a NEW PR-time CI gate that will likely reuse `parse_claim_event`).

## The defect — a false negative that nearly caused a collision

`check_lane_claim.py` is the manual pre-edit guard that surfaces `[CLAIMED]` signals living on ISSUE comments (cross-lane, server-timestamped). This cycle (c.74) I ran it on **#10228** before considering the Diebold-Mariano grain:

```
$ python scripts/check_lane_claim.py 10228 --lane myia-po-2024:CoursIA
CLEAR: no other lane claims #10228.   (active_claims: {}, unattributed_markers: 0)
```

But #10228 WAS claimed — ai-01's comment carries `[CLAIMED] lane myia-po-2025:CoursIA-2`. The tool reported CLEAR and would have let me start a duplicated grain.

## Root cause (read firsthand, not a guess)

`parse_claim_event` takes the **last** bracketed marker in the body as the "final intent" (`marker = marks[-1]`). ai-01's dispatch comment is:

```
[CLAIMED] lane myia-po-2025:CoursIA-2 -- Taches 1-2 (CPU) : ...

(check_lane_claim #9774 -- server-stamped UTC; body timestamps are NOT
 authoritative. Release with `[RELEASED]` when your PR lands.)
```

The unanchored `_MARKER_RE` matched **both** `[CLAIMED]` (real, line-start) **and** `[RELEASED]` (an instructional MENTION in prose — "Release with `[RELEASED]`"). `marks[-1]` = `RELEASED` → the event was classified `action="close"` → `compute_active_claims` did `state.pop(lane)` → `active_claims` empty → CLEAR. The lane (`myia-po-2025:CoursIA-2`) was extracted correctly; only the marker classification was wrong.

This is the same root class as the c.72 incident (#10161): a claim-on-issue that the detection surface misses. ai-01 dispatched #10223 (the CI gate) this very cycle citing "les trois collisions de ce cycle ont la même cause mécanique." This fix closes the gap in the EXISTING manual CLI that complements that future CI gate.

## The fix — line-anchor the marker regex

A marker only enacts a state change when it STARTS a line — the convention of every `--claim`/`--release` post and every coordinator dispatch. A marker MENTIONED mid-sentence in prose is not an event.

```python
# BEFORE (unanchored — mid-prose mentions count)
_MARKER_RE = re.compile(
    r"\[\s*(CLAIMED|RELEASED|CANCELLED|ABANDONED|DONE)\s*\]", re.IGNORECASE
)
# AFTER (line-anchored — only line-start markers count)
_MARKER_RE = re.compile(
    r"(?m)^[ \t]*\[\s*(CLAIMED|RELEASED|CANCELLED|ABANDONED|DONE)\s*\]",
    re.IGNORECASE,
)
```

`findall` still returns markers in order, so the legitimate **"last marker wins"** design (a `[CLAIMED]\n[DONE]` edit sequence on separate lines) is preserved — only mid-line mentions are rejected. `test_parse_last_marker_wins` still passes.

## Validation (measured, not asserted)

- **Unit tests**: `python -m pytest scripts/tests/test_check_lane_claim.py` → **38 passed** (36 existing + 2 new). No regression. `test_parse_last_marker_wins` (the design invariant) still green.
- **Dependency**: `scripts/tests/test_grain_tag.py` → **36 passed** (`extract_lane` reader unchanged).
- **End-to-end positive control — the real #10228**: with the FIXED tool, the CLI now reports:
  ```
  BLOCKED: another lane holds an active claim on #10228: myia-po-2025:CoursIA-2
           (@myia-ai-01, 2026-08-09 21:03:07 UTC).
  active_claims: {"myia-po-2025:CoursIA-2": {"marker": "CLAIMED", "by": "myia-ai-01", ...}}
  ```
  Before the fix: `CLEAR / active_claims: {}`. The exact FN that nearly caused my collision this cycle is now caught.
- **New regression tests**: `test_parse_instructional_marker_in_prose_ignored` (the parser rejects mid-prose `[RELEASED]`, keeps the real `[CLAIMED]`) + `test_check_blocked_when_claim_comment_mentions_marker_in_prose` (full `_run_check` flow returns BLOCKED rc=1, not CLEAR rc=0).

## Scope boundary (one subject per PR)

This PR fixes ONLY the `_MARKER_RE` line-anchoring in `scripts/check_lane_claim.py`. It does NOT touch: #10223 (the new CI claim-locus gate — po-205's grain, complementary layer), `grain_tag.py` (`extract_lane` unchanged), the `--stale-threshold` / `--paths` modes (their tests pass untouched), or any other script. 2 files, +48/-1.

## Why MED/guard, not LIGHT

This is not a scanner-generatable blank-line/accent/resync fix. It required: reproducing a real false negative firsthand (the `[RELEASED]`-in-prose trap is not obvious — the lane was extracted correctly, only the marker classification was wrong), understanding the "last marker wins" design interaction, and crafting a line-anchor fix that preserves that design while rejecting mid-prose mentions. The value is concrete: it prevents the duplicated-cycle collisions that cost the coordinator arbitration this very cycle (3 incidents, ai-01's [DONE] 21:19Z). The tool CAN rougir (exit 1 BLOCKED) → `guard` genre.

prev = MED/notebook-python #10224 (c.72). This grain = MED/guard. GENRE CHANGE (notebook-python → guard), G-VAR-3 satisfied (not 2 consecutive same). Self-found grain (no coordinator dispatch this cycle — ai-01 provisioned po-2025 + po-2023, acknowledged po-2024 unprovisioned as their debt; pool-global R5 applied).
