### PR TITLE
feat(qc,#10230): scan_window_drift.py — D2 window-form detector (DRIFT/PINNED/INDÉTERMINÉ/N-A)

### DIFF
--- a/scripts/notebook_tools/scan_window_drift.py
+++ b/scripts/notebook_tools/scan_window_drift.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Detecteur advisory de la derive de fenetre QC (forme de la borne, D2 #9768).
+
+Classe un notebook (ou un arbre) en ``DRIFT`` / ``PINNED`` / ``INDÉTERMINÉ``
+/ ``N-A`` :
+
+  N-A          : aucune API QC dans le code (``set_end_date`` non-applicable).
+  DRIFT        : la fenetre de donnees bouge avec l'horloge murale.
+  PINNED       : bornes litterales ou ``set_end_date`` present -> fenetre figee.
+  INDÉTERMINÉ  : API QC presente mais forme de la borne ambigue.
+
+Quatre formes distinctes produisent le drift, et **une seule** se corrige par
+``set_end_date`` (cf #10230) :
+
+  T  ``history(sym, timedelta(...), ...)``   fenetre relative depuis NOW
+  L  ``history(sym, N, Resolution)``         N barres depuis NOW
+  N  ``datetime.now()`` / ``date.today()``   borne ancrée sur l'horloge
+  S  ``set_start_date`` sans ``set_end_date`` fenetre ouverte à droite
+
+Le detecteur cherche la **forme de la borne**, jamais la presence d'un nom de
+methode : une borne litterale (``datetime(2015, 1, 1)``) passee a ``history``
+est figee meme sans ``set_end_date``. Lit les cellules **code** uniquement
+(une date en prose ne fige rien).
+
+Pourquoi les snippets de reference ``class Foo(QCAlgorithm)`` sont ecartes :
+dans un ``QCAlgorithm``, ``self.History(symbol, N)`` s'ancre sur ``self.Time``,
+l'heure COURANTE de la boucle de backtest -- le lookback glissant y est l'effet
+voulu. Seul le ``QuantBook`` de recherche derive. Compter le
+``self.SetStartDate(...)`` d'un snippet a copier dans ``main.py`` contaminerait
+le verdict des cellules ``QuantBook`` voisines (cas mesure : QC-Py-04, #8765).
+
+Advisory : ``exit 0`` toujours, le signal est le rapport. ``--json`` pour la
+CI ulterieure, ``--check`` pour un echec bloquant.
+
+See #10230 (grain), #9772 (probe precedant), #9768 (EPIC D2), #1621.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_ROOT = REPO_ROOT / "MyIA.AI.Notebooks"
+
+# --- Marqueurs d'API QC --------------------------------------------------
+# Presence d'AU MOINS UN => le notebook parle a QuantConnect => set_end_date est
+# applicable. L'absence de tous => N-A (ajouter set_end_date serait un no-op ou
+# un NameError). Cohérent avec le grep de cadrage de #10230.
+RE_QC_API = re.compile(
+    r"\bQuantBook\b"
+    r"|\bQCAlgorithm\b"
+    r"|\bset_start_date\b"
+    r"|\bset_end_date\b"
+    r"|\bSetStartDate\b"
+    r"|\bSetEndDate\b"
+    r"|\badd_(?:equity|crypto|forex|security|option|future|cfd)s?\b",
+    re.IGNORECASE,
+)
+
+# set_start_date / set_end_date, tolerants a la casse et au separateur
+# (SetStartDate, set_start_date, SETENDDATE). Reutilise l'idiome de
+# scan_d2_window_openness.py.
+RE_SET_START = re.compile(
+    r"[Ss][Ee][Tt][_]?[Ss][Tt][Aa][Rr][Tt][_]?[Dd][Aa][Tt][Ee]\s*\("
+)
+RE_SET_END = re.compile(
+    r"[Ss][Ee][Tt][_]?[Ee][Nn][Dd][_]?[Dd][Aa][Tt][Ee]\s*\("
+)
+
+# Borne ancrée sur l'horloge murale : datetime.now(), date.today(),
+# datetime.utcnow(), pd.Timestamp.now(). Forme N = la borne de la fenetre de
+# DONNEES derive avec l'horloge. Discrimine par CONTEXTE (pas le pattern seul) :
+# ne compte que ``now()/today()`` qui est (a) assigne a une variable-borne, ou
+# (b) passe en argument a history()/set_*date(). Un ``now()`` dans un en-tete
+# de log ``print(f"...{datetime.now().strftime()}")`` n'est PAS une borne -> FP
+# evite (QC-Py-40/41, #10230). Une variable-borne = nom de date de fin/right.
+RE_NOW = re.compile(
+    r"\b(?:datetime|date|pd\.Timestamp|pd\.DatetimeIndex)\s*\.\s*"
+    r"(?:now|utcnow|today)\s*\("
+)
+# ``<var> = ... datetime.now()/today()`` ou var est un nom de borne (end/stop/
+# to/right/finish). Le ``=`` distingue l'affectation d'une borne d'un print.
+RE_NOW_ASSIGN = re.compile(
+    r"^[ \t]*(?:end|end_date|enddate|to|to_date|todate|stop|stop_date|"
+    r"finish|right|right_edge|back_end|date_end|final)\w*\s*=\s*=?"
+    r"[^\n]*\b(?:datetime|date|pd\.Timestamp)\s*\.\s*(?:now|utcnow|today)\s*\(",
+    re.MULTILINE,
+)
+
+# Argument entier (lookback en barres) : 2520, 365*5, 252 * 12, etc.
+# Reutilise RE_INT_ARG de detect_quantbook_window_divergence.py (#8772).
+RE_INT_ARG = re.compile(r"^(?=.*\d)[\d\s*+/()-]+$")
+
+# Borne litterale concrete : datetime(2015, 1, 1), date(2020, 6, 30). Une telle
+# borne passee a history FIGE la fenetre (PINNED) meme sans set_end_date.
+RE_LITERAL_DATE = re.compile(r"\b(?:datetime|date)\s*\(\s*\d{4}\s*,")
+
+# Affectation d'une variable a une date litterale concrete : ``start = datetime(
+# 2015, 1, 1)``, ``end_date = date(2020, 6, 30)``. Permet de resoudre le data-
+# flow elementaire : ``qb.History(sym, start, end)`` ou ``start``/``end`` sont
+# des variables-borne litterales -> fenetre FIGEE (PINNED), pas INDÉTERMINÉ.
+RE_DATE_VAR_ASSIGN = re.compile(
+    r"^[ \t]*(\w+)\s*=\s*(?:datetime|date)\s*\(\s*\d{4}\s*,",
+    re.MULTILINE,
+)
+
+
+def _split_call_args(text: str, open_paren: int) -> tuple[list[str], int] | None:
+    """Decoupe les arguments d'un appel dont la parenthese ouvrante est a
+    ``open_paren``, en respectant l'imbrication des ``()[]{}`` et les chaines.
+
+    Retourne ``(args, index_de_la_parenthese_fermante)`` ou ``None`` si l'appel
+    n'est pas clos (source tronquee). Ecrit a la main plutot qu'en regex : une
+    classe ``[^)]`` casse sur ``list(symbols.values())`` (#8772). Reutilise tel
+    quel depuis detect_quantbook_window_divergence.py.
+    """
+    depth = 0
+    quote: str | None = None
+    args: list[str] = []
+    current: list[str] = []
+    i = open_paren
+    while i < len(text):
+        ch = text[i]
+        if quote is not None:
+            current.append(ch)
+            if ch == "\\":
+                if i + 1 < len(text):
+                    current.append(text[i + 1])
+                    i += 2
+                    continue
+            elif ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in "\"'":
+            quote = ch
+            current.append(ch)
+        elif ch in "([{":
+            depth += 1
+            if depth > 1:
+                current.append(ch)
+        elif ch in ")]}":
+            depth -= 1
+            if depth == 0:
+                args.append("".join(current))
+                return [a.strip() for a in args], i
+            current.append(ch)
+        elif ch == "," and depth == 1:
+            args.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+        i += 1
+    return None
+
+
+def _history_calls(source: str) -> list[dict]:
+    """Retourne les appels ``<receiver>.History(...)`` / ``.history(...)`` dont
+    le receiver n'est pas ``self`` (sémantique QCAlgorithm, non-defaut), avec le
+    2e argument positionnel et l'expression de l'appel.
+    """
+    hits: list[dict] = []
+    for m in re.finditer(r"(\w+)\s*\.\s*[Hh]istory\s*\(", source):
+        if m.group(1) == "self":
+            continue
+        open_paren = m.end() - 1
+        parsed = _split_call_args(source, open_paren)
+        if parsed is None:
+            continue
+        args, close = parsed
+        # expression complete de l'appel (receiver.history(...))
+        expr = source[m.start():close + 1]
+        hits.append({
+            "receiver": m.group(1),
+            "args": args,
+            "expr": expr,
+            "start": m.start(),
+        })
+    return hits
+
+
+def _line_no(source: str, offset: int) -> int:
+    """Numero de ligne (1-indexe) d'un offset dans une source multi-lignes."""
+    return source.count("\n", 0, offset) + 1
+
+
+def _snippet_of(src: str, line: int) -> str:
+    lines = src.splitlines()
+    return lines[line - 1].strip() if 0 < line <= len(lines) else src.strip()
+
+
+def classify_notebook(path: Path) -> dict[str, Any]:
+    """Classifie un notebook selon le verdict D2 de forme de fenetre.
+
+    Lit les cellules **code** uniquement (une date en prose ne fige rien). Les
+    formes de drift se detectent sur TOUT le code :
+
+    - Forme S (``set_start_date`` sans ``set_end_date``) s'applique y compris au
+      code ``QCAlgorithm`` : un backtest d'algorithme dont la fin n'est pas
+      figee derive comme une fenetre de recherche (cas QC-Py-Cloud-03, #10230).
+    - Formes L/T (``history(..., N/timedelta, ...)``) : le ``self.History`` d'un
+      ``QCAlgorithm`` s'ancre sur l'heure COURANTE de la boucle de backtest
+      (effet voulu) -> exclu via le receiver ``self``, pas via la cellule.
+    """
+    rec: dict[str, Any] = {
+        "path": _rel(path),
+        "verdict": None,
+        "forms": [],
+        "markers": [],
+        "has_qc_api": False,
+        "has_set_end": False,
+        "error": None,
+    }
+    try:
+        nb = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        rec["error"] = f"{type(exc).__name__}: {exc}"
+        rec["verdict"] = "ERREUR"
+        return rec
+
+    cells = nb.get("cells", []) or []
+    code_cells = [
+        (i, "".join(c.get("source", [])))
+        for i, c in enumerate(cells)
+        if c.get("cell_type") == "code"
+    ]
+    full_code = "\n".join(src for _, src in code_cells)
+
+    has_qc_api = bool(RE_QC_API.search(full_code))
+    rec["has_qc_api"] = has_qc_api
+    if not has_qc_api:
+        rec["verdict"] = "N-A"
+        return rec
+
+    has_set_start = bool(RE_SET_START.search(full_code))
+    has_set_end = bool(RE_SET_END.search(full_code))
+    rec["has_set_end"] = has_set_end
+
+    forms: dict[str, list[dict]] = {}
+
+    # Forme S : set_start_date sans set_end_date (fenetre ouverte a droite).
+    # C'est la SEULE forme que set_end_date corrige. Evaluee sur tout le code,
+    # QCAlgorithm inclus (backtest a fin ouverte = drift).
+    if has_set_start and not has_set_end:
+        for idx, src in code_cells:
+            m = RE_SET_START.search(src)
+            if m:
+                ln = _line_no(src, m.start())
+                forms.setdefault("S", []).append(
+                    {"cell_index": idx, "line": ln, "snippet": _snippet_of(src, ln)}
+                )
+                break
+
+    # Forme N : now()/today() assigne a une variable-borne (end/stop/to/...).
+    # Le ``=`` distingue l'affectation d'une borne d'un simple print de log
+    # (QC-Py-40/41 impriment ``datetime.now()`` dans un en-tete -> pas une borne).
+    for m in RE_NOW_ASSIGN.finditer(full_code):
+        # retrouve la cellule + ligne de l'offset dans full_code.
+        offset = m.start()
+        idx, ln = _locate(code_cells, offset)
+        forms.setdefault("N", []).append(
+            {"cell_index": idx, "line": ln, "snippet": _snippet_of(_cell_src(code_cells, idx), ln)}
+        )
+
+    # Variables-borne litterales : ``start = datetime(2015,1,1)`` etc. Permet de
+    # resoudre ``qb.History(sym, start, end)`` (args nus) vers PINNED.
+    literal_date_vars: set[str] = set()
+    for m in RE_DATE_VAR_ASSIGN.finditer(full_code):
+        literal_date_vars.add(m.group(1))
+
+    # Formes T / L / N-arg : arguments de <receiver>.history(...), receiver != self.
+    history_literal_pinned = False
+    history_calls_seen = False
+    for idx, src in code_cells:
+        for call in _history_calls(src):
+            history_calls_seen = True
+            args = call["args"]
+            if len(args) < 2:
+                continue
+            second = args[1]
+            line = _line_no(src, call["start"])
+            snippet = _snippet_of(src, line)
+            # Forme N directe : now()/today() passe en argument a history(...).
+            if RE_NOW.search(second):
+                forms.setdefault("N", []).append(
+                    {"cell_index": idx, "line": line, "snippet": snippet}
+                )
+            elif "timedelta" in second:
+                forms.setdefault("T", []).append(
+                    {"cell_index": idx, "line": line, "snippet": snippet}
+                )
+            elif RE_INT_ARG.match(second):
+                forms.setdefault("L", []).append(
+                    {"cell_index": idx, "line": line, "snippet": snippet, "lookback": second}
+                )
+            elif RE_LITERAL_DATE.search(second) or second.split("[")[0].strip() in literal_date_vars:
+                # borne litterale concrete (ou variable litterale resolue) ->
+                # fenetre FIGEE, pas du drift.
+                history_literal_pinned = True
+
+    rec["forms"] = sorted(forms.keys())
+    for f in sorted(forms.keys()):
+        rec["markers"].append({"form": f, "hits": forms[f]})
+
+    if forms:
+        rec["verdict"] = "DRIFT"
+    elif has_set_end:
+        rec["verdict"] = "PINNED"
+    elif history_literal_pinned:
+        rec["verdict"] = "PINNED"
+    else:
+        rec["verdict"] = "INDÉTERMINÉ"
+    return rec
+
+
+def _locate(code_cells: list[tuple[int, str]], offset: int) -> tuple[int, int]:
+    """Mappe un offset dans full_code vers (cell_index, ligne_dans_la_cellule)."""
+    running = 0
+    for idx, src in code_cells:
+        cell_len = len(src) + 1  # +1 pour le '\n' de jonction
+        if offset < running + cell_len:
+            return idx, full_code_offset_to_line(src, offset - running)
+        running += cell_len
+    return code_cells[-1][0], 1
+
+
+def full_code_offset_to_line(src: str, offset: int) -> int:
+    if offset < 0:
+        offset = 0
+    return src.count("\n", 0, min(offset, len(src))) + 1
+
+
+def _cell_src(code_cells: list[tuple[int, str]], idx: int) -> str:
+    for i, src in code_cells:
+        if i == idx:
+            return src
+    return ""
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _iter_notebooks(root: Path, family: str | None):
+    base = root / "MyIA.AI.Notebooks" if (root / "MyIA.AI.Notebooks").is_dir() else root
+    top = base / family if family else base
+    if not top.is_dir():
+        return
+    for p in sorted(top.rglob("*.ipynb")):
+        if ".ipynb_checkpoints" in p.parts:
+            continue
+        yield p
+
+
+def _human_report(records: list[dict]) -> str:
+    by_verdict: dict[str, list[dict]] = {}
+    for r in records:
+        by_verdict.setdefault(r["verdict"], []).append(r)
+    total = len(records)
+    lines = [f"=== scan_window_drift : {total} notebook(s) ==="]
+    order = ["DRIFT", "PINNED", "INDÉTERMINÉ", "N-A", "ERREUR"]
+    for v in order:
+        bucket = by_verdict.get(v, [])
+        if not bucket:
+            continue
+        lines.append(f"\n--- {v} : {len(bucket)} ---")
+        for r in bucket:
+            lines.append(f"  {_rel(Path(r['path']))}")
+            for marker in r.get("markers", []):
+                for hit in marker["hits"]:
+                    lines.append(
+                        f"      [{marker['form']}] c{hit['cell_index']} L{hit['line']}: {hit['snippet'][:90]}"
+                    )
+    # cross-tab
+    lines.append("\n=== Répartition ===")
+    for v in order:
+        c = len(by_verdict.get(v, []))
+        if c:
+            lines.append(f"  {v:<13}: {c}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0] if __doc__ else None,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("notebook", nargs="?", help="Notebook à classer (défaut: arbre QC entier)")
+    parser.add_argument("--family", default="QuantConnect", help="Famille sous MyIA.AI.Notebooks/ (défaut: QuantConnect)")
+    parser.add_argument("--root", default=str(REPO_ROOT), help="Racine du dépôt")
+    parser.add_argument("--json", action="store_true", help="Sortie JSON machine-readable")
+    parser.add_argument("--check", action="store_true", help="Exit 1 si au moins un DRIFT (CI-ready)")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root)
+
+    if args.notebook:
+        nb_path = Path(args.notebook)
+        if not nb_path.is_absolute():
+            nb_path = root / args.notebook
+        records = [classify_notebook(nb_path)]
+    else:
+        paths = list(_iter_notebooks(root, args.family))
+        if not paths:
+            print(f"[scan_window_drift] aucun notebook sous {root}/{args.family}", file=sys.stderr)
+            return 2
+        records = [classify_notebook(p) for p in paths]
+
+    if args.json:
+        payload = {"records": records}
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(_human_report(records))
+
+    if args.check and any(r["verdict"] == "DRIFT" for r in records):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_scan_window_drift.py
+++ b/scripts/notebook_tools/tests/test_scan_window_drift.py
@@ -1,0 +1,227 @@
+"""Tests pour scripts/notebook_tools/scan_window_drift.py -- detecteur advisory
+de derive de fenetre QC (forme de la borne, D2 #9768/#10230).
+
+Couvre les 4 verdicts (DRIFT/PINNED/INDÉTERMINÉ/N-A), les 4 formes de drift
+(T=timedelta, L=lookback, N=now, S=set_start_sans_end), les discriminations
+anti-FP (now() dans un print n'est pas une borne ; self.History d'un backtest
+n'est pas du drift ; variable litterale resolue -> PINNED), et le CLI
+(advisory exit 0 ; --check exit 1 sur DRIFT ; --json shape).
+
+Fragments synthetiques (pas de couplage a un vrai notebook) pour l'isolation.
+See #10230, #9772, #9768.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scan_window_drift import classify_notebook  # noqa: E402
+
+
+def _nb(cells: list[tuple[str, str]]) -> dict:
+    """Construit un notebook minimal depuis une liste (cell_type, source)."""
+    return {
+        "cells": [
+            {"cell_type": ct, "source": src.splitlines(keepends=True), "metadata": {},
+             "outputs": [] if ct == "code" else None}
+            for ct, src in cells
+        ],
+        "metadata": {}, "nbformat": 4, "nbformat_minor": 5,
+    }
+
+
+def _write(tmp_path: Path, cells: list[tuple[str, str]]) -> Path:
+    p = tmp_path / "nb.ipynb"
+    p.write_text(json.dumps(_nb(cells)), encoding="utf-8")
+    return p
+
+
+# --- N-A : aucune API QC -------------------------------------------------
+
+def test_na_no_qc_api(tmp_path):
+    """Un notebook sans aucune API QC -> N-A (set_end_date non-applicable)."""
+    p = _write(tmp_path, [
+        ("markdown", "# Recherche ML"),
+        ("code", "import pandas as pd\ndf = pd.read_parquet('data.pq')\nprint(df.shape)"),
+    ])
+    r = classify_notebook(p)
+    assert r["verdict"] == "N-A"
+    assert r["forms"] == []
+
+
+# --- DRIFT forme T : timedelta ------------------------------------------
+
+def test_drift_form_timedelta(tmp_path):
+    """qb.History(sym, timedelta(252*12), ...) -> DRIFT forme T (#10230 c3)."""
+    p = _write(tmp_path, [
+        ("code", "qb = QuantBook()\nsym = qb.add_equity('SPY').symbol"),
+        ("code", "h = qb.History(sym, timedelta(252 * 12), Resolution.Daily)"),
+    ])
+    r = classify_notebook(p)
+    assert r["verdict"] == "DRIFT"
+    assert "T" in r["forms"]
+
+
+# --- DRIFT forme L : lookback entier ------------------------------------
+
+def test_drift_form_lookback(tmp_path):
+    """qb.history(syms, 2520, Resolution) -> DRIFT forme L (N barres depuis now)."""
+    p = _write(tmp_path, [
+        ("code", "qb = QuantBook()\nsymbols = {'SPY': qb.add_equity('SPY').symbol}"),
+        ("code", "history = qb.history(list(symbols.values()), 2520, Resolution.DAILY)"),
+    ])
+    r = classify_notebook(p)
+    assert r["verdict"] == "DRIFT"
+    assert "L" in r["forms"]
+
+
+# --- DRIFT forme N : now() borne ----------------------------------------
+
+def test_drift_form_now_assignment(tmp_path):
+    """end_date = datetime.now() -> DRIFT forme N (borne ancrée sur l'horloge)."""
+    p = _write(tmp_path, [
+        ("code", "qb = QuantBook()\nstart = datetime(2020, 1, 1)"),
+        ("code", "end_date = datetime.now()\nh = qb.History('SPY', start, end_date)"),
+    ])
+    r = classify_notebook(p)
+    assert r["verdict"] == "DRIFT"
+    assert "N" in r["forms"]
+
+
+def test_now_in_print_is_not_a_bound(tmp_path):
+    """now() dans un en-tete de log print() n'est PAS une borne -> pas forme N.
+
+    FP guard (QC-Py-40/41, #10230) : la forme N discrimine par CONTEXTE
+    (affectation d'une borne ou arg de history), pas par le pattern now() seul.
+    """
+    p = _write(tmp_path, [
+        ("code", "qb = QuantBook()\nprint(f\"Run - {datetime.now().strftime('%Y-%m-%d')}\")"),
+        ("code", "h = qb.History('SPY', datetime(2020,1,1), datetime(2024,1,1))"),
+    ])
+    r = classify_notebook(p)
+    assert r["verdict"] == "PINNED"
+    assert "N" not in r["forms"]
+
+
+# --- DRIFT forme S : set_start_date sans set_end_date -------------------
+
+def test_drift_form_set_start_no_end_qcalgorithm(tmp_path):
+    """self.set_start_date(...) sans set_end_date dans un QCAlgorithm -> DRIFT S.
+
+    Cas QC-Py-Cloud-03 (#10230) : un backtest d'algorithme à fin ouverte dérive.
+    Forme S évaluée sur TOUT le code, QCAlgorithm inclus.
+    """
+    p = _write(tmp_path, [
+        ("code", "class Algo(QCAlgorithm):\n    def initialize(self):\n        self.set_start_date(2015, 1, 1)\n        self.add_equity('SPY')"),
+    ])
+    r = classify_notebook(p)
+    assert r["verdict"] == "DRIFT"
+    assert "S" in r["forms"]
+
+
+# --- PINNED --------------------------------------------------------------
+
+def test_pinned_set_end_date(tmp_path):
+    """set_end_date présent + bornes litterales (pas de forme de drift) -> PINNED.
+
+    NB : set_end_date NE neutralise PAS un appel ``history(..., timedelta(...))``
+    qui dérive par ailleurs (forme T dominante). Ce test isole le pin pur.
+    """
+    p = _write(tmp_path, [
+        ("code", "qb = QuantBook()\nqb.set_start_date(2020, 1, 1)\nqb.set_end_date(2024, 1, 1)"),
+        ("code", "h = qb.History('SPY', datetime(2020, 1, 1), datetime(2024, 1, 1), Resolution.Daily)"),
+    ])
+    r = classify_notebook(p)
+    assert r["verdict"] == "PINNED"
+
+
+def test_set_end_date_does_not_neutralize_timedelta(tmp_path):
+    """Falsifiabilité : set_end_date présent MAIS history(timedelta) -> DRIFT.
+
+    La forme T dérive indépendamment de set_end_date : il faut passer start/end
+    explicites à history(), pas compter sur set_end_date pour figer (#10230).
+    """
+    p = _write(tmp_path, [
+        ("code", "qb = QuantBook()\nqb.set_start_date(2020, 1, 1)\nqb.set_end_date(2024, 1, 1)"),
+        ("code", "h = qb.History('SPY', timedelta(365), Resolution.Daily)"),
+    ])
+    r = classify_notebook(p)
+    assert r["verdict"] == "DRIFT"
+    assert "T" in r["forms"]
+
+
+def test_pinned_literal_date_args(tmp_path):
+    """qb.History(sym, datetime(2015,1,1), datetime(2020,1,1)) -> PINNED
+    (bornes litterales, fenetre figee meme sans set_end_date)."""
+    p = _write(tmp_path, [
+        ("code", "qb = QuantBook()"),
+        ("code", "h = qb.History('SPY', datetime(2015, 1, 1), datetime(2020, 1, 1), Resolution.Daily)"),
+    ])
+    r = classify_notebook(p)
+    assert r["verdict"] == "PINNED"
+
+
+def test_pinned_literal_date_variables(tmp_path):
+    """start=datetime(2015,1,1); end=date(2020,1,1); qb.History(sym,start,end)
+    -> PINNED par resolution de variable-borne litterale (Crypto-MultiCanal)."""
+    p = _write(tmp_path, [
+        ("code", "qb = QuantBook()\nstart_date = datetime(2022, 1, 1)\nend_date = datetime(2025, 4, 21)"),
+        ("code", "h = qb.History('BTC', start_date, end_date, Resolution.Hour)"),
+    ])
+    r = classify_notebook(p)
+    assert r["verdict"] == "PINNED"
+
+
+# --- Falsifiabilité : self.History d'un backtest n'est PAS du drift ------
+
+def test_self_history_in_qcalgorithm_not_drift(tmp_path):
+    """self.History(sym, N) dans un QCAlgorithm s'ancre sur self.Time (backtest
+    loop) -> lookback glissant INTENDU, pas du drift. Receiver 'self' exclu."""
+    p = _write(tmp_path, [
+        ("code", "class Algo(QCAlgorithm):\n    def initialize(self):\n        self.set_start_date(2015, 1, 1)\n        self.set_end_date(2024, 1, 1)\n    def on_data(self, data):\n        h = self.History('SPY', 252, Resolution.Daily)"),
+    ])
+    r = classify_notebook(p)
+    assert r["verdict"] == "PINNED"
+    assert "L" not in r["forms"]
+
+
+# --- INDÉTERMINÉ ---------------------------------------------------------
+
+def test_indetermine_qc_api_no_form(tmp_path):
+    """API QC présente mais aucune forme résolue et pas de set_end -> INDÉTERMINÉ."""
+    p = _write(tmp_path, [
+        ("code", "qb = QuantBook()"),
+        ("code", "# configure les données plus loin, fenêtre non résolue statiquement\npass"),
+    ])
+    r = classify_notebook(p)
+    assert r["verdict"] == "INDÉTERMINÉ"
+
+
+# --- CLI -----------------------------------------------------------------
+
+def test_cli_advisory_exit_zero(tmp_path):
+    """Sans --check, le detecteur advisory exit 0 meme avec du drift."""
+    import subprocess
+    nb = _write(tmp_path, [("code", "qb = QuantBook()\nh = qb.History('SPY', timedelta(365), Resolution.Daily)")])
+    r = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parent.parent / "scan_window_drift.py"),
+         str(nb)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0
+
+
+def test_cli_check_exit_one_on_drift(tmp_path):
+    """--check exit 1 si au moins un DRIFT (CI-ready)."""
+    import subprocess
+    nb = _write(tmp_path, [("code", "qb = QuantBook()\nh = qb.History('SPY', timedelta(365), Resolution.Daily)")])
+    r = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parent.parent / "scan_window_drift.py"),
+         str(nb), "--check", "--json"],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 1
+    payload = json.loads(r.stdout)
+    assert payload["records"][0]["verdict"] == "DRIFT"


### PR DESCRIPTION
Grain: DEEP/qc — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #10231 (c.200, GFM NO_BLANK_BEFORE)

## Quoi

`scripts/notebook_tools/scan_window_drift.py` — détecteur advisory de la dérive de fenêtre QC (mécanisme D2 de #9768). Classe un notebook selon la **forme de la borne** (jamais la présence d'un nom de méthode) en 4 verdicts :

| Verdict | Signification |
|---|---|
| **DRIFT** | la fenêtre bouge avec l'horloge murale (4 formes ci-dessous) |
| **PINNED** | bornes littérales ou `set_end_date` présent → fenêtre figée |
| **INDÉTERMINÉ** | API QC présente mais forme non résolue statiquement |
| **N-A** | aucune API QC (`set_end_date` non-applicable, **plein droit**) |

Les 4 formes de drift (une seule, `S`, se corrige par `set_end_date`) :

| Forme | Code | `set_end_date` corrige ? |
|---|---|---|
| **T** | `qb.History(sym, timedelta(252*12), ...)` | non — passer start/end explicites |
| **L** | `qb.history(syms, 2520, Resolution)` | non — N barres depuis maintenant |
| **N** | `end_date = datetime.now()` | non — figer la borne |
| **S** | `set_start_date` sans `set_end_date` | **oui** |

Lit les cellules **code** uniquement. Advisory : `exit 0` toujours, `--check` pour CI (exit 1 si DRIFT), `--json` pour la CI ultérieure. 14 tests de falsifiabilité.

## Preuve

**Acceptance #1 — 8 ML-Training-Pipeline → N-A (pas DRIFT) :**
```
NAMED-8 verdicts: ['N-A' × 8]   ALL N-A? True
```
Ces notebooks lisent parquet/yfinance, ne parlent jamais à QuantConnect.

**Acceptance #2 — research_long_short_harvest → DRIFT, forme T (timedelta), c3 :**
```
verdict: DRIFT   forms: ['T']
  c3 L5: spy_hist = qb.History(spy_sym, timedelta(252 * 12), Resolution.Daily)
  c3 L6: gld_hist = qb.History(gld_sym, timedelta(252 * 12), Resolution.Daily)
```

**Acceptance #3 — distribution sur l'arbre QC entier (origin/main `023b542bb`) :**

| Verdict | Moi | ai-01 (#10230) |
|---|---:|---:|
| DRIFT | **31** | 21 |
| PINNED | **86** | 106 |
| INDÉTERMINÉ | **6** | 5 |
| N-A | **84** | 87 |
| **TOTAL** | **207** | 220 |

**Réconciliation (j'explique l'écart, je ne m'y aligne pas).** Mes 6 INDÉTERMINÉ vs 5 d'ai-01 : accord excellent (la résolution de variable-borne littérale `start=datetime(2015,1,1)` a collapsé 57→6). Mon DRIFT=31 vs 21 : **19 des 21 d'ai-01 confirmés** + **12 drifts supplémentaires confirmés réels** (famille `projects/ML-*/quantbook.ipynb` en `qb.History(..., 365*5, ...)` = fenêtre glissante 5 ans, plus Alpha-Correlation, ETF-Pairs, Research-Executor/research.ipynb, QC-Py-04, research_lstm, Sector-Momentum). **1 réfuté** (Crypto-MultiCanal — voir Task 2). **1 absent** (research_robustness_output.ipynb n'existe pas sur origin/main). Le dénominateur 207 vs 220 = un point de mesure plus récent (notebooks archivés/renommés entre-temps).

**Mon PINNED=86 vs 106** : ai-01 compte PINNED = « QC-API, pas de drift » (near-default). Moi je PROVE le pin (set_end_date OU borne littérale OU variable-borne résolue). Mon seuil est plus strict mais prouvé ; le résidu atterrit dans INDÉTERMINÉ (6, vs 5 d'ai-01 — quasi-égal).

**Discriminations anti-FP firsthand (chacune mesurée contre un vrai notebook) :**
- `now()` dans un en-tête `print(f"...{datetime.now().strftime()}")` n'est PAS une borne → forme N exclue par contexte (QC-Py-40/41, #10230).
- `self.History(sym, N)` dans un `QCAlgorithm` = lookback glissant INTENDU (s'ancre sur `self.Time` de la boucle de backtest) → receiver `self` exclu, pas la cellule.
- Forme **S** évaluée sur TOUT le code, `QCAlgorithm` inclus : un backtest d'algorithme à fin ouverte dérive (cas QC-Py-Cloud-03, #10230).

**Tâche 2 — confirmation firsthand des 21 d'ai-01 :**

| Notebook | ai-01 | moi | statut |
|---|---|---|---|
| kit-transitoire/01-02-03-ML research.ipynb (×3) | L | DRIFT/L | CONFIRMÉ |
| projects/Crypto-MultiCanal/research.ipynb | L | DRIFT/L | CONFIRMÉ |
| CSharp-BTC-EMA-Cross/research_robustness | NSL | DRIFT/NS | CONFIRMÉ (L=diff : self.History exclu) |
| CSharp-CTG-Momentum/research_robustness | NSL | DRIFT/NS | CONFIRMÉ (idem) |
| Research-Executor/research_*.ipynb (×7) | T | DRIFT/T | CONFIRMÉ |
| QC-Py-27-Production-Deployment | N | DRIFT/N | CONFIRMÉ |
| QC-Py-Cloud-03-Risk-Parity | S | DRIFT/S | CONFIRMÉ |
| research_classification | LS | DRIFT/LS | CONFIRMÉ |
| research_m11ef_ensemble, m12_har_rv_j, m12_har_rv_j_minute (×3) | T | DRIFT/T | CONFIRMÉ |
| **examples/Crypto-MultiCanal/research.ipynb** | NL | **PINNED** | **RÉFUTÉ** : ai-01 a attrapé `pd.Timestamp.now()` qui est un fallback de *simulation-timer* (`sim_start_time_run1 = ...iloc[0] if ...else pd.Timestamp.now()`), pas une borne de données. La fenêtre réelle est `qb.History(btc, datetime(2022,1,1), datetime(2025,4,21))` = figée. |
| **CSharp-CTG-Momentum/research_robustness_output.ipynb** | NSL | — | **ABSENT** de origin/main |

→ **19 CONFIRMÉ / 1 RÉFUTÉ (FP d'ai-01) / 1 ABSENT.**

**Tâche 3** : commentaire correctif posté sur #9772 (sans la fermer) — voir commentaire.

## Perimetre

2 nouveaux fichiers, +656/−0, **0 notebook modifié** (détecteur + tests + inventaire seulement — critère d'acceptation). `scripts/notebook_tools/scan_window_drift.py` + `tests/test_scan_window_drift.py`. Tâche 4 (épingler les fenêtres + ré-exécuter via QC Cloud) est **gated QC Cloud, hors grain** — ne pas attendre. 0 `outputs` édité à la main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
