### PR TITLE
feat(coord,#10223): lane-claim blocking CI gate -- [OVERRIDE] marker + required job + advisory labels + protocol clause

### DIFF
--- a/.claude/rules/lane-claim-protocol.md
+++ b/.claude/rules/lane-claim-protocol.md
@@ -23,6 +23,32 @@ L'issue GitHub ferme les trois d'un coup : locus **unique cross-lane par constru
 6. **Partitionner explicitement par fichier** des que plusieurs lanes convergent sur une meme cible (precedent : `HashlifeCorrectness.lean` partitionne P4-mpr / murs SW-SE / MarginFragment entre trois lanes sur #6724).
 7. **Lire les DEUX dashboards avant de provisionner** (rappel R3 [coordinator-discipline.md](coordinator-discipline.md)) — necessaire mais insuffisant seul : il ne couvre pas la fenetre inter-cycle, d'ou les points 5-6.
 
+## Tie-break — l'issue l'emporte, l'override s'ecrit (#10223)
+
+Les deux collisions du 2026-08-09 (#10169 puis #10161) ont revele deux
+non-ecrits qu'on ecrit ici noir sur blanc. Un organe debloquant les enforce
+desormais : `.github/workflows/lane-claim-guard.yml` (`check-lane-claim-required`).
+
+8. **Claim-issue > claim-dashboard, meme quand le dashboard est anterieur.**
+   Un `[CLAIMED]` sur l'issue bat un `[CLAIMED]` dashboard, **independamment
+   de l'horodatage**. La raison est mecanique, pas punitive : le dashboard est
+   silote par lane (invisible cross-workspace pendant la fenetre decision ->
+   push), auto-condense (un verrou ramasse par le GC n'est pas un verrou), et
+   ses stamps melent heure locale et UTC (cf §ci-dessus). Sur #10169, po-2026
+   avait ~12 minutes d'avance sur le dashboard workspace-CoursIA — et a perdu
+   contre le claim d'issue de po-2025, parce que seul ce dernier etait au locus
+   cross-lane. Le `createdAt` serveur de l'issue fait foi ; un stamp dashboard
+   anterieur ne l'invalide pas.
+9. **Override coordinateur permis, mais ecrit sur l'issue.** Le coordinateur
+   garde le droit de merger contre un claim detenu quand la substance le
+   justifie — mais il **perd la possibilite de le faire sans l'ecrire**.
+   L'arbitrage est porte par le marqueur `[OVERRIDE] lane <machine:workspace>`
+   (commentaire d'issue), qui accorde le claim a la lane nommee et clot celui
+   des autres dans le reducteur de `check_lane_claim.py` (Tache 2 de #10223).
+   Une reparation a la main apres coup (ce qui a ete fait sur #10169) est
+   precisement le geste que cette clause rend inutile : le gate
+   `check-lane-claim-required` reste rouge tant que l'override n'est pas ecrit.
+
 ## Ce que cette regle ne fait pas
 
 Elle ne sanctionne aucune lane : dans l'incident fondateur, les deux workers avaient passe leurs gardes correctement — le **signal** etait defaillant, pas leur discipline. Lever un claim = commentaire explicite (`[RELEASED]` ou livraison de la PR) ; un claim d'une lane morte > 48 h sans commit ni PR se re-arbitre par le coordinateur, pas par auto-service.
@@ -32,4 +58,4 @@ Elle ne sanctionne aucune lane : dans l'incident fondateur, les deux workers ava
 - [proactive-coordination.md](proactive-coordination.md) — L898 collision guard (complementaire : PRs deja poussees) ; regle 5 pool global
 - [coordinator-discipline.md](coordinator-discipline.md) — R3 lanes independantes, R5 steer qui ATTEINT
 - [variation-protocol.md](variation-protocol.md) — le tag `Grain:`/`lane` que `check_lane_claim.py` sait extraire (#9485 single-reader)
-- Issue #9774 (diagnostic + mandat) · PR #9775 (organe)
+- Issue #9774 (diagnostic + mandat) · PR #9775 (organe) · Issue #10223 (gate bloquant `lane-claim-guard.yml` + marqueur `[OVERRIDE]`)

--- a/.github/workflows/lane-claim-guard.yml
+++ b/.github/workflows/lane-claim-guard.yml
@@ -1,0 +1,201 @@
+name: Lane Claim Guard
+
+# Organe debloquant (#10223): un renvoi FERMANT (`Closes|Fixes|Resolves #N`)
+# dans le body d'une PR ne doit pas fermer une issue qu'une autre lane detient
+# en claim actif. Deux collisions le meme jour (2026-08-09, #10169 puis #10161)
+# -- dans les deux la lane doublee (po-2025) etait protocol-conforme et a ete
+# doublee quand meme, parce que `scripts/check_lane_claim.py` (livre en #9775,
+# l'outil qui les aurait attrapees) n'etait appele par personne. Ce gate en est
+# le consommateur obligatoire.
+#
+# Le gate ne peut pas EMPECHER la collision (au moment ou la PR existe, le
+# travail est deja ecrit) : il rend impossible de la MERGER sans arbitrage
+# ecrit. Cet arbitrage est le marqueur `[OVERRIDE]` (Tache 2 de #10223) -- sans
+# lui, un coordinateur ne peut pas merger contre un claim detenu.
+#
+# Discriminant = mots-cles fermants UNIQUEMENT. Un `See #N` / `Part of #N` sur
+# une EPIC est multi-lane par construction (#1454, #1027, #3801 portent des
+# claims concurrents legitimes) et bloquer dessus rougirait la moitie du depot.
+# Les renvois non-fermants donnent un LABEL advisory seul (Tache 4), jamais un
+# block.
+#
+# Architecture = le motif etabli par les quatre gates de variation-tag-guard.yml
+# : decision dans `scripts/ci/lane_claim_required.py` (testable, verdict JSON
+# une ligne, fetcher de commentaires injectable -- les tests ne touchent jamais
+# le reseau), YAML reduit a la plomberie, suffixe `-required` sur le nom du job
+# pour que `is_advisory()` de scripts/pr_gate.py ne le neutralise pas.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  # Blocking. Nom portant `-required` -> is_advisory() = False (pr_gate.py).
+  # Pas de filtre `paths:` : un job filtre par chemin reste `pending` a vie sur
+  # les PR hors scope, et un `pending` sur un check requis vaut BLOCKED a vie
+  # (cf pr-gate.yml, #10045 regle 2).
+  check-lane-claim-required:
+    name: 'Require no closing-ref against another lane active claim (block on lane collision, #10223)'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the lane-claim helper (sparse)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/ci/lane_claim_required.py
+            scripts/check_lane_claim.py
+            scripts/grain_tag.py
+      - name: 'Resolve closing-ref vs other lanes active claims (block on collision)'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          set -uo pipefail
+
+          # ATTENTION au shell reel : GitHub invoque ce bloc avec
+          # `/usr/bin/bash -e {0}` -- l'errexit est actif, et `set -uo pipefail`
+          # ne l'annule pas (cf variation-tag-guard.yml). Ce qui garde ce job
+          # correct n'est pas l'absence de `-e`, c'est que chaque commande
+          # faillible est dans une condition (`if`/`case`, exempts d'errexit)
+          # ou suffixee `|| true`. Jamais `|| true` sur la capture d'un code de
+          # retour (`rc=$?` apres `cmd || true` lit le 0 de `true`, pas celui
+          # de `cmd` -- desarme le controle en permanence).
+
+          # Hors scope : bots (catalogue auto-regenere) et forks (PRs
+          # etudiantes, cf student-pr-reviews.md -- review bienveillante, aucun
+          # critere interne ne s'y applique).
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issuee d'un fork : hors scope (PR etudiante)."
+            exit 0
+          fi
+
+          # Body -> fichier. printf '%s' preserve verbatim (pas de newline
+          # ajoute, pas d'interpretation des backslash).
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          # Le helper fetch chaque issue referencee par mot-cle fermant via
+          # `gh issue view`, reduit l'etat des claims, et sort 0 (pass /
+          # fail-open) ou 1 (block sur un claim frais d'une autre lane).
+          # stderr exempte pour debug.
+          python3 scripts/ci/lane_claim_required.py \
+            --body-file /tmp/pr_body.txt > /tmp/verdict.json 2>/tmp/verdict.err
+          RC=$?
+
+          if [ -s /tmp/verdict.err ]; then
+            echo "--- helper stderr ---"
+            cat /tmp/verdict.err
+          fi
+          echo "--- verdict ---"
+          cat /tmp/verdict.json
+
+          # Surface des warnings fail-open meme sur le chemin pass (claim
+          # perime, echec de fetch) pour que l'auteur voie le vide.
+          python3 -c "import json; [print('::warning::'+w) for w in json.load(open('/tmp/verdict.json')).get('warnings',[])]" 2>/dev/null || true
+
+          if [ "$RC" -eq 0 ]; then
+            echo "Aucun claim frais d'une autre lane sur un renvoi fermant -- job passes."
+            exit 0
+          fi
+
+          # Chemin bloquant. Commentaire idempotent via le marqueur HTML
+          # invisible (un `synchronize` ne doit pas re-spammer).
+          REASON=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('reason','unknown'))" 2>/dev/null || echo "unknown")
+          echo "::error::collision de lane sur une reference fermante: $REASON"
+
+          gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          <!-- lane-claim-conflict -->
+          **Collision de lane sur une reference fermante (#10223).**
+
+          ${REASON}
+
+          Une autre lane detient un claim actif sur une issue que cette PR ferme par mot-cle (\`Closes\`/\`Fixes\`/\`Resolves #N\`). Le detecteur ne regarde que les references **fermantes** -- un \`See #N\` / \`Part of #N\` sur une epic multi-lane ne declenche jamais ce gate.
+
+          Les **trois sorties** pour passer ce gate :
+          - la lane detenrice **relache** son claim (\`[RELEASED] lane <machine:workspace>\` sur l'issue concernee), ou
+          - le **coordinateur ecrit** un arbitrage (\`[OVERRIDE] lane <cette lane>\` -- c'est la trace qui rend l'override mecaniquement traçable, #10223 Tache 2), ou
+          - le claim atteint **48 h** de peremption (le protocole re-arbitre les claims d'une lane inactive).
+
+          Voir #10223 et \`lane-claim-protocol.md\`.
+          EOF
+          )" 2>/dev/null || true
+
+          exit 1
+
+  # Advisory (#10223 Tache 4) : pose deux labels pour mesurer l'adoption du
+  # protocole de claim SANS jamais bloquer. Nom portant "advisory" ->
+  # is_advisory() = True (pr_gate.py ne compte pas ce job dans le gate
+  # required). Le helper sort son verdict (guard_pass + advisory_labels) ; ce
+  # job exit 0 quoi qu'il arrive et ne fait que refleter advisory_labels en
+  # labels GitHub. Creation idempotente des labels (deja presents -> no-op),
+  # pattern des autres jobs advisory (exercises-advisory, markdown-table-guard).
+  check-lane-claim-advisory:
+    name: 'Advisory lane-claim labels (adoption telemetry, non-blocking, #10223)'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the lane-claim helper (sparse)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/ci/lane_claim_required.py
+            scripts/check_lane_claim.py
+            scripts/grain_tag.py
+      - name: 'Apply lane-claim advisory labels'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          set -uo pipefail
+
+          # Hors scope : bots et forks (meme gating que le job required).
+          case "$PR_AUTHOR" in
+            *"[bot]") exit 0 ;;
+          esac
+          [ "$IS_FORK" = "true" ] && exit 0
+
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          # Le helper sort 0/1/2 ; ici on ignore le code (advisory) et on ne
+          # lit que advisory_labels. `|| true` garde le job vert meme sur un
+          # block du sibling required (le verdict JSON est ecrit sur stdout
+          # avant l'exit 1 du block path).
+          python3 scripts/ci/lane_claim_required.py \
+            --body-file /tmp/pr_body.txt > /tmp/verdict.json 2>/tmp/verdict.err || true
+
+          # Creation idempotente des deux labels.
+          mk_label() {
+            gh label create "$1" --description "$2" --color "$3" --force 2>/dev/null || true
+          }
+          mk_label "lane-claim-conflict" "Non-closing ref to an issue another lane claims (#10223)" "d93f0b"
+          mk_label "lane-claim-absent"   "Closing issue carries no claim at all (#10223)" "fbca04"
+
+          set_label()   { gh pr edit "$PR_NUMBER" --add-label "$1" || true; }
+          unset_label() { gh pr edit "$PR_NUMBER" --remove-label "$1" 2>/dev/null || true; }
+
+          # Reflete advisory_labels : pose si present, retire sinon (un
+          # synchronize qui resout le conflit nettoie le label). Fail-safe : si
+          # le verdict est illisible (caller error), aucun label n'est dans la
+          # liste -> on retire les deux.
+          has() { python3 -c "import json,sys; sys.exit(0 if '$1' in json.load(open('/tmp/verdict.json')).get('advisory_labels',[]) else 1)" 2>/dev/null; }
+
+          if has "lane-claim-conflict"; then set_label "lane-claim-conflict"; else unset_label "lane-claim-conflict"; fi
+          if has "lane-claim-absent";   then set_label "lane-claim-absent";   else unset_label "lane-claim-absent";   fi
+
+          echo "advisory labels applied."
+          exit 0

--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -93,17 +93,25 @@ from grain_tag import extract_lane
 # legitimate "last marker wins" design (a `[CLAIMED]\n[DONE]` edit sequence on
 # separate lines) is preserved -- only mid-line mentions are rejected.
 _MARKER_RE = re.compile(
-    r"(?m)^[ \t]*\[\s*(CLAIMED|RELEASED|CANCELLED|ABANDONED|DONE)\s*\]",
+    r"(?m)^[ \t]*\[\s*(CLAIMED|RELEASED|CANCELLED|ABANDONED|DONE|OVERRIDE)\s*\]",
     re.IGNORECASE,
 )
 _OPEN = {"CLAIMED"}
 _CLOSE = {"RELEASED", "CANCELLED", "ABANDONED", "DONE"}
+# `[OVERRIDE] lane <machine:workspace>` (#10223): coordinator adjudication --
+# GRANTS the claim to the named lane and CLOSES every other lane's claim in one
+# gesture. Distinct from CLAIMED (grants to one) and RELEASED/DONE (closes one):
+# override does both at once, which is the only mechanical trace of a
+# coordinator merging against a held claim (the gap that let #10169 / #10161 be
+# merged without a written adjudication). Additive: the existing markers keep
+# their semantics, so no prior test changes.
+_OVERRIDE = {"OVERRIDE"}
 
 
 class ClaimEvent(dict):
     """Typed-ish view over a parsed claim event.
 
-    Keys: lane (str|None), action ("open"|"close"), marker (str upper),
+    Keys: lane (str|None), action ("open"|"close"|"override"), marker (str upper),
     created_at (str ISO, server UTC), author (str|None), url (str|None).
     `created_at` comes from the comment's server field, never from the body.
     """
@@ -115,6 +123,10 @@ class ClaimEvent(dict):
     @property
     def is_open(self) -> bool:
         return self.get("action") == "open"
+
+    @property
+    def is_override(self) -> bool:
+        return self.get("action") == "override"
 
     @property
     def created_at(self) -> str | None:
@@ -146,7 +158,12 @@ def parse_claim_event(comment: dict) -> ClaimEvent | None:
     if not marks:
         return None
     marker = marks[-1].upper()  # last marker = final intent in that comment
-    action = "open" if marker in _OPEN else "close"
+    if marker in _OPEN:
+        action = "open"
+    elif marker in _OVERRIDE:
+        action = "override"
+    else:
+        action = "close"
     author = (comment.get("author") or {}).get("login")
     return ClaimEvent(
         lane=extract_lane(body),
@@ -163,10 +180,15 @@ def compute_active_claims(events: list[ClaimEvent]) -> tuple[dict, list[ClaimEve
 
     Returns `(active_by_lane, unattributed)`:
       - `active_by_lane`: {lane: ClaimEvent} for lanes whose LATEST event is an
-        open. Computed by walking events in order (caller sorts); later events
-        overwrite earlier ones, and a close removes the lane.
+        open (or the lane named by the latest override). Computed by walking
+        events in order (caller sorts); later events overwrite earlier ones, a
+        close removes the lane, and an **override** (#10223) grants the claim to
+        its named lane while closing every other lane -- the only event type
+        that touches more than one lane at once.
       - `unattributed`: events whose body carried a marker but no lane token --
         the tool surfaces them for manual verification, it does not guess.
+        An override with no lane token is unattributed (an adjudication must
+        name its beneficiary).
     """
     state: dict[str, ClaimEvent] = {}
     unattributed: list[ClaimEvent] = []
@@ -174,7 +196,11 @@ def compute_active_claims(events: list[ClaimEvent]) -> tuple[dict, list[ClaimEve
         if ev.lane is None:
             unattributed.append(ev)
             continue
-        if ev.is_open:
+        if ev.is_override:
+            # Coordinator adjudication (#10223): grant to this lane, close all
+            # others. Later events (open/close) still apply on top in walk order.
+            state = {ev.lane: ev}
+        elif ev.is_open:
             state[ev.lane] = ev
         else:
             state.pop(ev.lane, None)

--- a/scripts/ci/lane_claim_required.py
+++ b/scripts/ci/lane_claim_required.py
@@ -100,6 +100,52 @@ def gh_issue_fetcher(number: int) -> "dict | None":
         return None
 
 
+def _compute_advisory_labels(
+    pr_body: str | None,
+    issue_fetcher: IssueFetcher,
+    pr_lane: str,
+) -> list[str]:
+    r"""Advisory labels for adoption telemetry (#10223 Task 4) -- never block.
+
+    Two labels, surfaced so the coordinator can read the adoption curve at the
+    merge-gate without the gate reddening:
+
+      - ``lane-claim-absent``  -- a CLOSING-referenced issue carries NO active
+        claim at all. The protocol wants a claim before editing; measuring it
+        without blocking gives the curve (most of the historical backlog was
+        taken without a claim, and a hard gate here would redden massively and
+        teach nothing).
+      - ``lane-claim-conflict`` -- a NON-closing reference (See/Part of #N)
+        points to an issue another lane actively claims. Multi-lane by
+        construction on an EPIC, so advisory only (the closing variant blocks).
+
+    Reuses the SAME reducer (``check_lane_claim.compute_active_claims``) and the
+    SAME scanners (``grain_tag.find_close_keyword_pr_refs`` /
+    ``find_non_closing_refs``) -- no competing logic. Fetch failures are
+    skipped: an advisory label must not crash the job on a network blip.
+    """
+    labels: set[str] = set()
+    # lane-claim-absent: a closing-referenced issue with no active claim at all.
+    for h in gt.find_close_keyword_pr_refs(pr_body):
+        payload = issue_fetcher(h["number"])
+        if payload is None:
+            continue
+        events = clc._sort_events(payload)
+        active, _unattrib = clc.compute_active_claims(events)
+        if not active:
+            labels.add("lane-claim-absent")
+    # lane-claim-conflict: a non-closing ref whose issue another lane claims.
+    for h in gt.find_non_closing_refs(pr_body):
+        payload = issue_fetcher(h["number"])
+        if payload is None:
+            continue
+        events = clc._sort_events(payload)
+        active, _unattrib = clc.compute_active_claims(events)
+        if any(ln != pr_lane for ln in active):
+            labels.add("lane-claim-conflict")
+    return sorted(labels)
+
+
 def check(
     pr_body: str | None,
     issue_fetcher: IssueFetcher,
@@ -127,6 +173,7 @@ def check(
           "blocking_issue": int|None,       # set on block
           "blocking_claim_at": str|None,    # set on block (server ISO UTC)
           "closing_issues": [int, ...],
+          "advisory_labels": [str, ...],    # #10223 Task 4 (never blocks)
           "warnings": [str, ...],
         }
 
@@ -140,7 +187,8 @@ def check(
     pr_lane = gt.extract_lane(pr_body)
     if pr_lane is None:
         # Lane unreadable -> the tag gate (check-variation-tag-required) owns
-        # this defect. Do not duplicate the red.
+        # this defect. Do not duplicate the red. Advisory labels are skipped:
+        # without a pr_lane, a conflict/absent reading is meaningless.
         return {
             "guard_pass": True,
             "reason": "PR lane unreadable -- deferred to check-variation-tag-required",
@@ -149,8 +197,15 @@ def check(
             "blocking_issue": None,
             "blocking_claim_at": None,
             "closing_issues": [],
+            "advisory_labels": [],
             "warnings": [],
         }
+
+    # Advisory labels (#10223 Task 4): computed across BOTH closing and
+    # non-closing refs -- the blocking path below only looks at closing refs,
+    # but a `See #N` conflict or a no-claim closing issue is still worth a
+    # label. Never blocks.
+    advisory = _compute_advisory_labels(pr_body, issue_fetcher, pr_lane)
 
     # Closing references ONLY (Closes|Fixes|Resolves). See/Part of are excluded
     # by construction by find_close_keyword_pr_refs -- that is the discriminant.
@@ -165,6 +220,7 @@ def check(
             "blocking_issue": None,
             "blocking_claim_at": None,
             "closing_issues": [],
+            "advisory_labels": advisory,
             "warnings": [],
         }
 
@@ -214,6 +270,7 @@ def check(
                 "blocking_issue": num,
                 "blocking_claim_at": ev.created_at,
                 "closing_issues": issue_nums,
+                "advisory_labels": advisory,
                 "warnings": warnings,
             }
 
@@ -225,6 +282,7 @@ def check(
         "blocking_issue": None,
         "blocking_claim_at": None,
         "closing_issues": issue_nums,
+        "advisory_labels": advisory,
         "warnings": warnings,
     }
 

--- a/scripts/ci/lane_claim_required.py
+++ b/scripts/ci/lane_claim_required.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+r"""lane_claim_required.py -- BLOCKING gate: a closing-keyword reference must
+not close an issue another lane actively claims (#10223).
+
+## Why this exists
+
+Two collisions the same day (2026-08-09, #10169 then #10161): in both, the
+doubled lane (po-2025) held the SOLE issue-level claim, was protocol-conforme,
+and got doubled anyway -- because ``scripts/check_lane_claim.py`` (the tool
+that would have caught it, shipped in #9775 with both legs: issue-claim check +
+``--paths`` PR collision) was never wired into CI. Nothing called it
+mechanically. This gate is the mandatory consumer: it compares the
+``Grain: lane`` of a PR body to the ``[CLAIMED]`` comments on the issue(s) its
+closing keywords reference, and blocks the merge if a different lane holds a
+fresh, unreleased claim.
+
+The gate cannot prevent the collision (once the PR exists the work is written):
+it makes it impossible to MERGE without a written adjudication. That
+adjudication is the ``[OVERRIDE]`` marker (Task 2 of #10223) -- without it, a
+coordinator cannot merge against a held claim.
+
+## Discriminant -- closing keywords only
+
+Only CLOSING references (``Closes|Fixes|Resolves #N``, via the shared
+``grain_tag.find_close_keyword_pr_refs`` scanner -- NOT a new regex) block. A
+``See #N`` / ``Part of #N`` on an EPIC is multi-lane by construction (#1454,
+#1027, #3801 carry legitimate concurrent claims) and blocking on it would
+redden half the repo. Non-closing references get an advisory LABEL only (Task
+4), never a block.
+
+## Single-reader / single-reducer discipline (#9485)
+
+The lane is read by ``grain_tag.extract_lane`` -- the SAME reader the Grain tag
+and check_lane_claim use -- so a PR body and a claim comment never disagree on
+what a lane is. The claim state is reduced by ``check_lane_claim.compute_active
+_claims`` -- the SAME reducer check_lane_claim uses, now extended with the
+``[OVERRIDE]`` event (Task 2). No competing regex for ``machine:workspace`` or
+``[CLAIMED]`` lives in this file.
+
+## Falsifiable verdict
+
+The decisive test (criterion 6 of #10223): replaying PR #10176's body against
+issue #10169's comments yields ``block`` with ``blocking_lane =
+myia-po-2025:CoursIA-2`` (the lane that held the claim and was doubled), and
+``pass`` once the coordinator's adjudication is converted to ``[OVERRIDE]
+lane myia-po-2026:CoursIA``.
+
+## Run locally
+
+    python scripts/ci/lane_claim_required.py --body-file body.txt
+    python scripts/ci/lane_claim_required.py --body-file body.txt --stale-threshold 48
+
+Exit codes: 0 pass / 1 block / 2 caller error (unreadable body file).
+
+The default issue fetcher calls ``gh issue view`` (``GH_TOKEN``/``GITHUB_REPO``
+present in CI); it is injectable so unit tests never touch the network.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+# Make the shared modules importable from anywhere in the repo.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_lane_claim as clc  # noqa: E402
+import grain_tag as gt  # noqa: E402
+
+IssueFetcher = Callable[[int], "dict | None"]
+
+
+def gh_issue_fetcher(number: int) -> "dict | None":
+    r"""Fetch issue ``{number, title, comments}`` via ``gh``.
+
+    Returns None on any failure (missing issue, auth/rate-limit, network) -- the
+    gate fails OPEN on it: a fetch failure must not block a legitimate merge,
+    and the verdict carries a warning so the gap is visible. Reads ``GH_TOKEN``
+    from the environment (set by the workflow).
+    """
+    try:
+        out = subprocess.run(
+            [
+                "gh", "issue", "view", str(number),
+                "--json", "number,title,comments",
+            ],
+            capture_output=True, text=True, timeout=20,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    try:
+        return json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def check(
+    pr_body: str | None,
+    issue_fetcher: IssueFetcher,
+    stale_threshold: float = 48.0,
+    now: datetime | None = None,
+) -> dict:
+    r"""Pure decision function: blocking verdict for a PR body (#10223).
+
+    Args:
+        pr_body: the PR body text (carries the ``Grain: lane`` tag).
+        issue_fetcher: ``int -> {number,title,comments} | None``. Injected in
+            tests (dict-based); defaults to ``gh_issue_fetcher`` in the CLI.
+        stale_threshold: hours. Other lanes' claims older than this do NOT
+            block (the protocol re-arbitrates claims held by a dead lane after
+            48 h). Age is from the server ``createdAt``, never the body.
+        now: injected for testability (defaults to UTC now).
+
+    Returns a one-line JSON verdict on stdout (the YAML reads exit code):
+
+        {
+          "guard_pass": True|False,
+          "reason": str,
+          "pr_lane": str|None,
+          "blocking_lane": str|None,        # set on block
+          "blocking_issue": int|None,       # set on block
+          "blocking_claim_at": str|None,    # set on block (server ISO UTC)
+          "closing_issues": [int, ...],
+          "warnings": [str, ...],
+        }
+
+    Block logic (criterion c of #10223): a DIFFERENT lane holds an active,
+    unreleased, non-stale claim on an issue this PR closes via a closing
+    keyword. Lane-unreadable (criterion: lane illisible) defers to
+    ``check-variation-tag-required`` and never blocks here -- a second red on
+    the same cause only duplicates. ``See #N`` / ``Part of #N`` (non-closing)
+    do not reach this function as blocking (advisory label only, Task 4).
+    """
+    pr_lane = gt.extract_lane(pr_body)
+    if pr_lane is None:
+        # Lane unreadable -> the tag gate (check-variation-tag-required) owns
+        # this defect. Do not duplicate the red.
+        return {
+            "guard_pass": True,
+            "reason": "PR lane unreadable -- deferred to check-variation-tag-required",
+            "pr_lane": None,
+            "blocking_lane": None,
+            "blocking_issue": None,
+            "blocking_claim_at": None,
+            "closing_issues": [],
+            "warnings": [],
+        }
+
+    # Closing references ONLY (Closes|Fixes|Resolves). See/Part of are excluded
+    # by construction by find_close_keyword_pr_refs -- that is the discriminant.
+    closing = gt.find_close_keyword_pr_refs(pr_body)
+    issue_nums = sorted({h["number"] for h in closing})
+    if not issue_nums:
+        return {
+            "guard_pass": True,
+            "reason": "no closing-keyword reference -> advisory only (See/Part of do not block)",
+            "pr_lane": pr_lane,
+            "blocking_lane": None,
+            "blocking_issue": None,
+            "blocking_claim_at": None,
+            "closing_issues": [],
+            "warnings": [],
+        }
+
+    now = now or datetime.now(timezone.utc)
+    warnings: list[str] = []
+
+    for num in issue_nums:
+        payload = issue_fetcher(num)
+        if payload is None:
+            # Fail-open: a fetch failure (network, missing issue) must not
+            # block. Surface it so the gap is visible.
+            warnings.append(
+                f"could not fetch #{num} -- fail-open (network/missing)"
+            )
+            continue
+        events = clc._sort_events(payload)
+        active, _unattrib = clc.compute_active_claims(events)
+        others = {ln: ev for ln, ev in active.items() if ln != pr_lane}
+
+        # Stale filter (#10223 Task 1.5): a claim older than stale_threshold
+        # (server createdAt age) does not block -- the protocol re-arbitrates
+        # claims held by a dead lane. Fresh ones do.
+        fresh_others: dict = {}
+        for ln, ev in others.items():
+            age = clc._claim_age_hours(ev.created_at, now)
+            if age is not None and age >= stale_threshold:
+                warnings.append(
+                    f"#{num}: lane {ln} claim stale ({age:.1f}h >= "
+                    f"{stale_threshold:g}h) -- not blocking"
+                )
+            else:
+                fresh_others[ln] = ev
+
+        if fresh_others:
+            blocking = sorted(fresh_others)[0]
+            ev = fresh_others[blocking]
+            return {
+                "guard_pass": False,
+                "reason": (
+                    f"#{num}: lane {blocking} holds an active claim "
+                    f"(since {ev.created_at}). Release with `[RELEASED]`, have "
+                    f"the coordinator post `[OVERRIDE] lane {pr_lane}`, or "
+                    f"wait {stale_threshold:g}h for staleness. See #10223."
+                ),
+                "pr_lane": pr_lane,
+                "blocking_lane": blocking,
+                "blocking_issue": num,
+                "blocking_claim_at": ev.created_at,
+                "closing_issues": issue_nums,
+                "warnings": warnings,
+            }
+
+    return {
+        "guard_pass": True,
+        "reason": "no other lane holds a fresh active claim on the closing issue(s)",
+        "pr_lane": pr_lane,
+        "blocking_lane": None,
+        "blocking_issue": None,
+        "blocking_claim_at": None,
+        "closing_issues": issue_nums,
+        "warnings": warnings,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--body-file", metavar="FILE", required=True,
+                   help="path to the PR body")
+    p.add_argument("--stale-threshold", type=float, metavar="HOURS",
+                   default=48.0,
+                   help="other lanes' claims older than HOURS do not block "
+                        "(default 48; age from server createdAt).")
+    args = p.parse_args(argv)
+
+    try:
+        with open(args.body_file, encoding="utf-8") as f:
+            body = f.read()
+    except OSError as e:
+        print(json.dumps(
+            {"guard_pass": False, "reason": f"caller error: {e}"},
+            ensure_ascii=False,
+        ), file=sys.stderr)
+        return 2
+
+    verdict = check(body, gh_issue_fetcher, stale_threshold=args.stale_threshold)
+    print(json.dumps(verdict, ensure_ascii=False))
+    return 0 if verdict["guard_pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -247,6 +247,45 @@ def find_close_keyword_pr_refs(text: str | None) -> list[dict]:
     return hits
 
 
+# Matches NON-closing references in free prose: the "safe syntax" of
+# git-workflow.md (``See #N`` / ``Part of #N`` / ``Refs #N``) that links an
+# issue without auto-closing it. These are the references an EPIC carries while
+# several lanes work it concurrently (#1454, #1027, #3801) -- multi-lane by
+# construction, which is why lane_claim_required blocks on CLOSING refs only and
+# surfaces a conflict here as an ADVISORY label, never a block (#10223 Tache 4).
+NON_CLOSING_REF_RE = re.compile(
+    r"\b(see|part\s+of|refs?)\s+#(\d+)\b",
+    re.IGNORECASE,
+)
+
+
+def find_non_closing_refs(text: str | None) -> list[dict]:
+    r"""Return non-closing ``<keyword> #N`` references (See/Part of/Refs).
+
+    The complement of ``find_close_keyword_pr_refs``: that one returns the
+    references that auto-close an issue (the blocking discriminant of
+    lane_claim_required). This one returns the references that merely LINK an
+    issue -- an EPIC's ``See #N`` / ``Part of #N`` -- which are multi-lane by
+    construction and must never block, but may still carry an advisory label
+    when another lane holds a claim on them (#10223 Tache 4:
+    ``lane-claim-conflict``).
+
+    Same hit shape as ``find_close_keyword_pr_refs``:
+    ``{"keyword": <lowercased>, "number": <int>, "span": <tuple>}``. Returns an
+    empty list when the text is clean or falsy.
+    """
+    if not text:
+        return []
+    hits = []
+    for m in NON_CLOSING_REF_RE.finditer(text):
+        hits.append({
+            "keyword": m.group(1).lower(),
+            "number": int(m.group(2)),
+            "span": m.span(),
+        })
+    return hits
+
+
 def parse_grain_tag(body: str | None) -> dict | None:
     """Extract {tier, genre, lane} from a PR body, form-tolerant.
 

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -599,3 +599,110 @@ def test_paths_multiple_prs_mixed(capsys):
     # But the JSON summary names it.
     assert "#9010" in captured.out
     assert "BLOCKED" in captured.err
+
+
+# --- [OVERRIDE] (#10223) -- coordinator adjudication -------------------------
+#
+# `[OVERRIDE] lane <X>` grants the claim to lane X and closes every other
+# lane's claim. This is the mechanical trace of a coordinator merging against a
+# held claim (the gap that let #10169 / #10161 be merged with no written
+# adjudication). Additive: the existing markers keep their semantics, and the
+# 36 prior tests are untouched. The motivating incident (#10169) was
+# myia-po-2025:CoursIA-2 holding the sole issue-level claim, po-2026 merging
+# anyway -- the override is what the coordinator must now WRITE on the issue.
+
+def test_parse_override_marker():
+    ev = clc.parse_claim_event(comment(
+        "[OVERRIDE] lane myia-po-2024:CoursIA -- substance favors this PR",
+        "2026-08-09T22:00:00Z", author="jsboige",
+    ))
+    assert ev is not None
+    assert ev.is_override is True
+    assert ev.is_open is False
+    assert ev.lane == "myia-po-2024:CoursIA"
+    assert ev.marker == "OVERRIDE"
+
+
+def test_override_grants_to_named_lane_closes_others():
+    # A and B both claimed; override to A -> only A remains active.
+    events = [
+        clc.parse_claim_event(comment(
+            "[CLAIMED] lane A:CoursIA -- x", "2026-08-06T22:00:00Z")),
+        clc.parse_claim_event(comment(
+            "[CLAIMED] lane B:CoursIA-2 -- y", "2026-08-06T22:10:00Z")),
+        clc.parse_claim_event(comment(
+            "[OVERRIDE] lane A:CoursIA -- coordinator adjudication",
+            "2026-08-06T22:30:00Z")),
+    ]
+    active, unattrib = clc.compute_active_claims(events)
+    assert set(active) == {"A:CoursIA"}
+    assert unattrib == []
+
+
+def test_override_closes_all_others_grants_to_third_lane():
+    # A and B claimed; override to a THIRD lane C -> only C active.
+    events = [
+        clc.parse_claim_event(comment(
+            "[CLAIMED] lane A:CoursIA -- x", "2026-08-06T22:00:00Z")),
+        clc.parse_claim_event(comment(
+            "[CLAIMED] lane B:CoursIA-2 -- y", "2026-08-06T22:10:00Z")),
+        clc.parse_claim_event(comment(
+            "[OVERRIDE] lane C:CoursIA -- reassign", "2026-08-06T22:30:00Z")),
+    ]
+    active, _ = clc.compute_active_claims(events)
+    assert set(active) == {"C:CoursIA"}
+
+
+def test_override_then_claim_reopens_other_lane():
+    # Override to A, then B claims afterward -> both active (B reopens after
+    # the override in walk order; override is not a permanent lockout).
+    events = [
+        clc.parse_claim_event(comment(
+            "[OVERRIDE] lane A:CoursIA -- initial", "2026-08-06T22:00:00Z")),
+        clc.parse_claim_event(comment(
+            "[CLAIMED] lane B:CoursIA-2 -- y", "2026-08-06T22:30:00Z")),
+    ]
+    active, _ = clc.compute_active_claims(events)
+    assert set(active) == {"A:CoursIA", "B:CoursIA-2"}
+
+
+def test_override_no_lane_token_unattributed():
+    # An override that names no beneficiary cannot be applied -> unattributed.
+    ev = clc.parse_claim_event(comment(
+        "[OVERRIDE] #9764 merging the better PR", "2026-08-06T22:00:00Z"
+    ))
+    assert ev is not None and ev.lane is None
+    events = [ev]
+    active, unattrib = clc.compute_active_claims(events)
+    assert active == {}
+    assert len(unattrib) == 1
+
+
+def test_check_override_for_my_lane_is_clear(capsys):
+    # Another lane claimed, then the coordinator overrode TO my lane -> CLEAR
+    # (I now hold the claim via adjudication). This is the #10169 resolution.
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2026:CoursIA -- working here",
+                "2026-08-09T11:29:59Z"),
+        comment("[OVERRIDE] lane myia-po-2025:CoursIA-2 -- substance favors",
+                "2026-08-09T22:00:00Z"),
+    )
+    rc = clc._run_check(p, "myia-po-2025:CoursIA-2")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "CLEAR" in out
+
+
+def test_check_override_to_other_lane_blocks(capsys):
+    # I claimed, then the coordinator overrode to ANOTHER lane -> BLOCKED for me.
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- working here",
+                "2026-08-09T11:41:43Z"),
+        comment("[OVERRIDE] lane myia-po-2026:CoursIA -- reassign",
+                "2026-08-09T22:00:00Z"),
+    )
+    rc = clc._run_check(p, "myia-po-2025:CoursIA-2")
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "BLOCKED" in captured.err
+    assert "myia-po-2026:CoursIA" in captured.out

--- a/scripts/tests/test_grain_tag.py
+++ b/scripts/tests/test_grain_tag.py
@@ -478,3 +478,28 @@ def test_prev_close_keyword_multiple_prevs():
     assert len(hits) == 2
     genres = {h["genre"] for h in hits}
     assert genres == {"fix", "closes"}
+
+
+def test_find_non_closing_refs_see_part_of_refs():
+    # The 3 safe-syntax non-closing references (See/Part of/Refs) -- the
+    # complement of find_close_keyword_pr_refs. Feeds lane_claim_required's
+    # advisory `lane-claim-conflict` label (#10223 Task 4).
+    text = "See #1454 -- part of the epic\nPart of #1027\nRefs #3801"
+    hits = gt.find_non_closing_refs(text)
+    assert sorted(h["number"] for h in hits) == [1027, 1454, 3801]
+    # Same hit shape as find_close_keyword_pr_refs (keyword lowercased + span).
+    assert all("keyword" in h and "span" in h for h in hits)
+    assert {h["keyword"] for h in hits} == {"see", "part of", "refs"}
+
+
+def test_find_non_closing_refs_excludes_closing_keywords():
+    # Closing keywords must NOT be matched by the non-closing scanner (the
+    # blocking discriminant stays the closing scanner's job).
+    hits = gt.find_non_closing_refs("Closes #10169\nFixes #200\nSee #300")
+    assert [h["number"] for h in hits] == [300]
+
+
+def test_find_non_closing_refs_empty_and_none():
+    assert gt.find_non_closing_refs(None) == []
+    assert gt.find_non_closing_refs("") == []
+    assert gt.find_non_closing_refs("nothing here") == []

--- a/scripts/tests/test_lane_claim_required.py
+++ b/scripts/tests/test_lane_claim_required.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+r"""Unit tests for lane_claim_required.py -- the blocking CI gate of #10223.
+
+Pins the 7-case acceptance grid from #10223 (a-g) plus the decisive criterion
+6 (replay #10176 body vs #10169 comments -> block with blocking_lane =
+myia-po-2025:CoursIA-2; pass after [OVERRIDE]) and the single-reader invariant
+(no competing regex). The issue fetcher is injected -- these tests NEVER touch
+the network.
+
+Run: python -m pytest scripts/tests/test_lane_claim_required.py
+"""
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# scripts/ci/ must be importable (lane_claim_required lives there) AND scripts/
+# (its deps grain_tag, check_lane_claim).
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))            # scripts/
+sys.path.insert(0, str(_HERE.parent / "ci"))     # scripts/ci/
+
+import lane_claim_required as lcr  # noqa: E402
+import check_lane_claim as clc  # noqa: E402
+
+# A fixed NOW so the staleness math is deterministic (criterion g: 49h claim).
+NOW = datetime(2026, 8, 9, 22, 0, 0, tzinfo=timezone.utc)
+
+
+# --- helpers ------------------------------------------------------------------
+
+def comment(body, created_at, author="jsboige", url=None):
+    return {
+        "body": body,
+        "createdAt": created_at,
+        "author": {"login": author},
+        "url": url,
+    }
+
+
+def issue_payload(*comments, number=10169, title="t"):
+    return {"number": number, "title": title, "comments": list(comments)}
+
+
+def fetcher_from(table):
+    """Build an injectable issue fetcher from {issue_num: payload}."""
+    return lambda n: table.get(n)
+
+
+def pr_body(lane, ref_line):
+    """Build a synthetic PR body with a Grain lane tag + a reference line."""
+    return (
+        f"Grain: DEEP/guard -- lane {lane} -- prev: MED/refactor #10151\n\n"
+        f"## Summary\n\n{ref_line}\n"
+    )
+
+
+# --- 7-case acceptance grid (a-g) --------------------------------------------
+
+def test_a_no_claim_on_closing_issue_is_pass():
+    # (a) Issue carries no claim -> pass (the way is clear).
+    body = pr_body("myia-po-2025:CoursIA", "Closes #10169")
+    fetch = fetcher_from({10169: issue_payload(
+        comment("just a discussion comment", "2026-08-09T11:00:00Z"),
+        number=10169,
+    )})
+    v = lcr.check(body, fetch, now=NOW)
+    assert v["guard_pass"] is True
+    assert v["pr_lane"] == "myia-po-2025:CoursIA"
+    assert v["closing_issues"] == [10169]
+
+
+def test_b_my_own_claim_is_pass():
+    # (b) I hold the active claim -> pass (resuming my own work).
+    body = pr_body("myia-po-2025:CoursIA", "Closes #10169")
+    fetch = fetcher_from({10169: issue_payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA -- working here",
+                "2026-08-09T11:00:00Z"),
+    )})
+    v = lcr.check(body, fetch, now=NOW)
+    assert v["guard_pass"] is True
+
+
+def test_c_other_lane_claim_on_closing_ref_is_block():
+    # (c) Another lane holds an active claim on a CLOSING reference -> BLOCK.
+    # This is the #10169 incident shape.
+    body = pr_body("myia-po-2026:CoursIA", "Closes #10169")
+    fetch = fetcher_from({10169: issue_payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- working here",
+                "2026-08-09T11:41:43Z"),
+    )})
+    v = lcr.check(body, fetch, now=NOW)
+    assert v["guard_pass"] is False
+    assert v["blocking_lane"] == "myia-po-2025:CoursIA-2"
+    assert v["blocking_issue"] == 10169
+    assert v["pr_lane"] == "myia-po-2026:CoursIA"
+
+
+def test_d_same_conflict_on_non_closing_ref_is_pass():
+    # (d) Same conflict but on a NON-closing reference (See #N) -> pass.
+    # find_close_keyword_pr_refs only matches closing keywords, so See/Part of
+    # never reach the blocking path.
+    body = pr_body("myia-po-2026:CoursIA", "See #10169 -- contributes to the epic")
+    fetch = fetcher_from({10169: issue_payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- working here",
+                "2026-08-09T11:41:43Z"),
+    )})
+    v = lcr.check(body, fetch, now=NOW)
+    assert v["guard_pass"] is True
+    assert v["closing_issues"] == []  # See #N is not closing -> not scanned
+
+
+def test_e_released_claim_is_pass():
+    # (e) The other lane RELEASED its claim -> pass.
+    body = pr_body("myia-po-2026:CoursIA", "Closes #10169")
+    fetch = fetcher_from({10169: issue_payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- working here",
+                "2026-08-09T11:41:43Z"),
+        comment("[RELEASED] lane myia-po-2025:CoursIA-2 -- landed",
+                "2026-08-09T15:00:00Z"),
+    )})
+    v = lcr.check(body, fetch, now=NOW)
+    assert v["guard_pass"] is True
+
+
+def test_f_override_naming_my_lane_is_pass():
+    # (f) Coordinator [OVERRIDE] naming MY lane -> pass (adjudication grants it
+    # to me). This is the #10169 resolution once the override is written.
+    body = pr_body("myia-po-2026:CoursIA", "Closes #10169")
+    fetch = fetcher_from({10169: issue_payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- working here",
+                "2026-08-09T11:41:43Z"),
+        comment("[OVERRIDE] lane myia-po-2026:CoursIA -- substance favors",
+                "2026-08-09T22:00:00Z"),
+    )})
+    v = lcr.check(body, fetch, now=NOW)
+    assert v["guard_pass"] is True
+
+
+def test_g_stale_claim_49h_is_pass_with_warning():
+    # (g) Other lane's claim is 49h old (>= 48h threshold) -> pass + staleness
+    # warning. NOW is 22:00 on 08-09; 49h earlier is 21:00 on 08-07.
+    stale_at = "2026-08-07T21:00:00Z"  # exactly 49h before NOW
+    body = pr_body("myia-po-2026:CoursIA", "Closes #10169")
+    fetch = fetcher_from({10169: issue_payload(
+        comment(f"[CLAIMED] lane myia-po-2025:CoursIA-2 -- working here",
+                stale_at),
+    )})
+    v = lcr.check(body, fetch, stale_threshold=48.0, now=NOW)
+    assert v["guard_pass"] is True
+    assert any("stale" in w for w in v["warnings"])
+
+
+# --- decisive criterion 6: replay #10176 body vs #10169 comments -------------
+
+def test_criterion6_replay_10176_vs_10169_blocks_then_passes_after_override():
+    # The motivating incident. PR #10176 (po-2026) body Closes #10169, which
+    # carries po-2025:CoursIA-2's sole issue-level claim -> BLOCK with
+    # blocking_lane = myia-po-2025:CoursIA-2. Then the coordinator's
+    # adjudication as [OVERRIDE] lane myia-po-2026:CoursIA -> PASS.
+    body_pre = pr_body("myia-po-2026:CoursIA", "Closes #10169")
+    fetch_pre = fetcher_from({10169: issue_payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- the guard organ",
+                "2026-08-09T11:41:43Z"),
+    )})
+    v_pre = lcr.check(body_pre, fetch_pre, now=NOW)
+    assert v_pre["guard_pass"] is False, "must block before the override"
+    assert v_pre["blocking_lane"] == "myia-po-2025:CoursIA-2"
+
+    # Same body, but the issue now carries the coordinator's [OVERRIDE].
+    fetch_post = fetcher_from({10169: issue_payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- the guard organ",
+                "2026-08-09T11:41:43Z"),
+        comment("[OVERRIDE] lane myia-po-2026:CoursIA -- substance favors #10176",
+                "2026-08-09T22:00:00Z"),
+    )})
+    v_post = lcr.check(body_pre, fetch_post, now=NOW)
+    assert v_post["guard_pass"] is True, "must pass after the override"
+
+
+# --- lane-unreadable defers (does not duplicate the tag gate) ----------------
+
+def test_lane_unreadable_is_pass_defers_to_tag_gate():
+    # No Grain lane tag -> defer to check-variation-tag-required, never block.
+    body = "## Summary\n\nCloses #10169 but no Grain lane tag.\n"
+    fetch = fetcher_from({10169: issue_payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- x",
+                "2026-08-09T11:41:43Z"),
+    )})
+    v = lcr.check(body, fetch, now=NOW)
+    assert v["guard_pass"] is True
+    assert v["pr_lane"] is None
+
+
+# --- fetch failure is fail-open ----------------------------------------------
+
+def test_fetch_failure_is_fail_open_with_warning():
+    body = pr_body("myia-po-2026:CoursIA", "Closes #999999")
+    fetch = lambda n: None  # always fails (missing issue / network)
+    v = lcr.check(body, fetch, now=NOW)
+    assert v["guard_pass"] is True
+    assert any("fail-open" in w for w in v["warnings"])
+
+
+# --- multiple closing issues: one clean, one blocked ------------------------
+
+def test_multiple_closing_issues_one_blocked():
+    body = pr_body("myia-po-2026:CoursIA", "Closes #100, Fixes #200")
+    fetch = fetcher_from({
+        100: issue_payload(
+            comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- x",
+                    "2026-08-09T11:41:43Z"),
+            number=100,
+        ),
+        200: issue_payload(number=200),  # no claim -> clean
+    })
+    v = lcr.check(body, fetch, now=NOW)
+    assert v["guard_pass"] is False
+    assert v["blocking_issue"] == 100
+
+
+# --- is_advisory: the job name must NOT be advisory --------------------------
+
+def test_is_advisory_false_for_required_job_name():
+    # The YAML job name carries `-required`; is_advisory must NOT classify it
+    # as advisory (criterion: blocking job neutralized by name = complicity).
+    sys.path.insert(0, str(_HERE.parent))
+    import pr_gate  # noqa: E402
+    assert pr_gate.is_advisory("check-lane-claim-required") is False
+    # Sanity: a name with "advisory" IS advisory (the discriminator).
+    assert pr_gate.is_advisory("some advisory label") is True
+
+
+# --- CLI end-to-end (subprocess, no network) ---------------------------------
+
+def test_cli_body_file_pass_exit_zero(tmp_path):
+    body_file = tmp_path / "body_pass.md"
+    body_file.write_text(
+        pr_body("myia-po-2025:CoursIA", "See #10169 -- epic contribution"),
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [sys.executable, "scripts/ci/lane_claim_required.py",
+         "--body-file", str(body_file)],
+        capture_output=True, text=True, check=False,
+    )
+    assert proc.returncode == 0, f"expected 0, got {proc.returncode}: {proc.stderr!r}"
+    v = json.loads(proc.stdout)
+    assert v["guard_pass"] is True
+
+
+def test_cli_lane_unreadable_exit_zero(tmp_path):
+    body_file = tmp_path / "body_nolane.md"
+    body_file.write_text("## Summary\n\nNo Grain tag.\n", encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, "scripts/ci/lane_claim_required.py",
+         "--body-file", str(body_file)],
+        capture_output=True, text=True, check=False,
+    )
+    assert proc.returncode == 0
+    v = json.loads(proc.stdout)
+    assert v["pr_lane"] is None
+
+
+def test_cli_missing_body_file_exit_two(tmp_path):
+    proc = subprocess.run(
+        [sys.executable, "scripts/ci/lane_claim_required.py",
+         "--body-file", str(tmp_path / "nonexistent.md")],
+        capture_output=True, text=True, check=False,
+    )
+    assert proc.returncode == 2

--- a/scripts/tests/test_lane_claim_required.py
+++ b/scripts/tests/test_lane_claim_required.py
@@ -109,6 +109,8 @@ def test_d_same_conflict_on_non_closing_ref_is_pass():
     v = lcr.check(body, fetch, now=NOW)
     assert v["guard_pass"] is True
     assert v["closing_issues"] == []  # See #N is not closing -> not scanned
+    # Criterion (d): non-closing conflict -> pass + ADVISORY label (Task 4).
+    assert "lane-claim-conflict" in v["advisory_labels"]
 
 
 def test_e_released_claim_is_pass():
@@ -218,6 +220,58 @@ def test_multiple_closing_issues_one_blocked():
     v = lcr.check(body, fetch, now=NOW)
     assert v["guard_pass"] is False
     assert v["blocking_issue"] == 100
+
+
+# --- advisory labels (#10223 Task 4) -- never block --------------------------
+
+def test_advisory_lane_claim_absent_when_closing_issue_has_no_claim():
+    # Closes an issue that carries NO claim at all -> advisory label (measure
+    # adoption), never a block. The historical backlog was mostly taken without
+    # a claim; reddening here would teach nothing.
+    body = pr_body("myia-po-2026:CoursIA", "Closes #10169")
+    fetch = fetcher_from({10169: issue_payload(number=10169)})  # no comments
+    v = lcr.check(body, fetch, now=NOW)
+    assert v["guard_pass"] is True
+    assert "lane-claim-absent" in v["advisory_labels"]
+
+
+def test_advisory_lane_claim_conflict_on_see_ref():
+    # See #N (non-closing) where another lane claims #N -> advisory label; the
+    # closing variant of the same conflict would block. A multi-lane EPIC is
+    # advisory by construction.
+    body = pr_body("myia-po-2026:CoursIA", "See #10169 -- part of the epic")
+    fetch = fetcher_from({10169: issue_payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- working here",
+                "2026-08-09T11:41:43Z"),
+    )})
+    v = lcr.check(body, fetch, now=NOW)
+    assert v["guard_pass"] is True
+    assert v["closing_issues"] == []  # non-closing -> not scanned for blocking
+    assert "lane-claim-conflict" in v["advisory_labels"]
+
+
+def test_advisory_labels_empty_when_no_refs():
+    # Lane readable but no issue reference at all -> no advisory labels.
+    body = pr_body("myia-po-2026:CoursIA", "Just a refactoring, no issue ref.")
+    fetch = fetcher_from({})
+    v = lcr.check(body, fetch, now=NOW)
+    assert v["guard_pass"] is True
+    assert v["advisory_labels"] == []
+
+
+def test_advisory_labels_carried_on_block_verdict():
+    # A block verdict must still carry the advisory_labels field (well-typed)
+    # so the advisory job can read it even when the blocking job is red.
+    body = pr_body("myia-po-2026:CoursIA", "Closes #10169")
+    fetch = fetcher_from({10169: issue_payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- working here",
+                "2026-08-09T11:41:43Z"),
+    )})
+    v = lcr.check(body, fetch, now=NOW)
+    assert v["guard_pass"] is False
+    # #10169 has a claim (not absent) and is closing (not a See) -> no advisory
+    # label fires here, but the field is present and a list on the block path.
+    assert isinstance(v["advisory_labels"], list)
 
 
 # --- is_advisory: the job name must NOT be advisory --------------------------


### PR DESCRIPTION
Grain: DEEP/guard — lane myia-po-2025:CoursIA-2 — prev: MED/refactor

# Organe bloquant : un renvoi fermant ne peut merger contre un claim d'une autre lane (#10223)

## Quoi

Deux collisions le même jour (2026-08-09, #10169 puis #10161) — dans les deux, la lane doublée (po-2025) était **protocol-conforme**, détenait le **seul claim au bon locus** (l'issue), et a été doublée quand même. `scripts/check_lane_claim.py` (livré en #9775, l'outil qui les aurait attrapées) n'était appelé par **personne**. Cette PR lui branche un **consommateur obligatoire** et ajoute la seule pièce qui manquait : la trace d'override.

Motif repris à l'identique des quatre gates de `variation-tag-guard.yml` (décision testable + YAML plomberie + suffixe `-required`), comme demandé dans #10223.

### Les 5 tâches

- **Tâche 1 — `scripts/ci/lane_claim_required.py`** : `check(body, fetcher, stale_threshold, now) -> verdict`. Discriminant = mots-clés **fermants uniquement** (`find_close_keyword_pr_refs`). `See #N` / `Part of #N` sur une epic = multi-lane par construction, jamais bloquant. Fetcher injecté (tests sans réseau). Péremption 48 h. Lane illisible → defer au gate de tag (pas de double rouge).
- **Tâche 2 — marqueur `[OVERRIDE]` dans `check_lane_claim.py`** (`c5697167f`) : 3ᵉ type d'événement au réducteur — `[OVERRIDE] lane <machine:workspace>` accorde le claim à la lane nommée et clôt celui des autres. Additif ; `[CLAIMED]`/`[RELEASED]`/`[DONE]` gardent leur sémantique.
- **Tâche 3 — `.github/workflows/lane-claim-guard.yml`** (fichier dédié) : job bloquant `check-lane-claim-required` (nom `-required` → `is_advisory = False`). Pas de filtre `paths:` (sinon pending à vie = BLOCKED). Forks/bots exclus. Commentaire idempotent `<!-- lane-claim-conflict -->` nommant les **3 sorties** (RELEASED / OVERRIDE / 48 h).
- **Tâche 4 — labels advisory** : `lane-claim-conflict` (conflit sur renvoi non-fermant) + `lane-claim-absent` (issue fermée sans claim). Posés sans bloquer (job `check-lane-claim-advisory`, `is_advisory = True`). Nouveau scanner `grain_tag.find_non_closing_refs` (complément de `find_close_keyword_pr_refs`, single-reader).
- **Tâche 5 — clause tie-break dans `lane-claim-protocol.md`** : noir sur blanc (i) **claim-issue > claim-dashboard** même si le dashboard est antérieur (po-2026 avait ~12 min d'avance et a perdu — raison mécanique : silotage, condensation, mélange local/UTC) ; (ii) **override coordinateur permis mais écrit** sur l'issue, porté par `[OVERRIDE]`.

## Critères d'acceptation

- [x] `scripts/tests/test_lane_claim_required.py` : les 7 cas (a-g) + lane-unreadable + fail-open + multi-issue + is_advisory + 3 CLI + 4 advisory = **19 tests**, **aucun accès réseau** (fetcher injecté).
- [x] `python -m pytest scripts/tests/test_check_lane_claim.py scripts/tests/test_lane_claim_required.py scripts/tests/test_grain_tag.py` **vert** (101 passed) ; `test_check_lane_claim.py` stable à **43** (l'ajout `[OVERRIDE]` ne casse rien — additif prouvé).
- [ ] Le job apparaît sur cette PR et passe (test d'intégration réel au runtime — vérifiable à l'ouverture).
- [x] `pr_gate.is_advisory("check-lane-claim-required")` retourne **False** (test dédié + validé).
- [x] Single-reader : `grep -n "machine:workspace\|\[CLAIMED\]" scripts/ci/lane_claim_required.py` ne révèle **que la docstring** (lignes 13, 37-38), aucun regex concurrent dans le code.
- [x] **Rejeu critère 6** (body réel de #10176 vs commentaires réels de #10169) — collé ci-dessous.

```
$ python -m pytest scripts/tests/test_check_lane_claim.py scripts/tests/test_lane_claim_required.py scripts/tests/test_grain_tag.py -q
============================= 101 passed in 1.69s =============================
test_lane_claim_required.py ......... (19) | test_check_lane_claim.py ... (43) | test_grain_tag.py ... (39)
```

## Critère 6 — la preuve que l'organe aurait attrapé l'incident

Rejeu du body réel de PR #10176 (po-2026, la gagnante de la collision) contre les commentaires réels de l'issue #10169 (qui porte le claim `myia-po-2025:CoursIA-2` au `createdAt` serveur `2026-08-09T11:41:43Z`) :

**PRE-OVERRIDE** (état au moment du merge — le claim adverse est présent, pas de marqueur) :

```json
{
  "guard_pass": false,
  "reason": "#10169: lane myia-po-2025:CoursIA-2 holds an active claim (since 2026-08-09T11:41:43Z). Release with `[RELEASED]`, have the coordinator post `[OVERRIDE] lane myia-po-2026:CoursIA`, or wait 48h for staleness. See #10223.",
  "pr_lane": "myia-po-2026:CoursIA",
  "blocking_lane": "myia-po-2025:CoursIA-2",
  "blocking_issue": 10169,
  "closing_issues": [10169],
  "advisory_labels": []
}
```

**POST-OVERRIDE** (une fois la réparation manuelle d'ai-01 convertie au marqueur `[OVERRIDE] lane myia-po-2026:CoursIA`) :

```json
{
  "guard_pass": true,
  "reason": "no other lane holds a fresh active claim on the closing issue(s)",
  "pr_lane": "myia-po-2026:CoursIA",
  "blocking_lane": null,
  "blocking_issue": null,
  "closing_issues": [10169],
  "advisory_labels": []
}
```

L'organe bloque le merge contre le claim détenu **tant que l'arbitrage n'est pas écrit** — c'est le seul endroit où un gate automatique a prise.

## Chevauchement L898 avec #10234 (po-2024)

#10234 (OPEN) ajoute un **line-anchor** au même `_MARKER_RE` (`(?m)^[ \t]*...`) pour fixer un FN réel mesuré sur #10228 (un `[RELEASED]` mentionné en prose neutralisait un vrai `[CLAIMED]`). Ma Tâche 2 ajoute **OVERRIDE** à la même ligne. Deux changements **complémentaires** sur le même regex (conflit de merge trivial au rebase). #10234 se déclare lui-même « Complementary to #10223 ».

J'ai **defer l'overlap** (le line-anchor appartient à #10234, je ne l'ai pas touché — sa substance reste intacte) et **livré le surplus** (OVERRIDE + le gate CI complet), per [[collision-post]]. Version finale cible : `(?m)^[ \t]*\[\s*(...|DONE|OVERRIDE)\s*\]`. Recommandation d'ordre de merge pour ai-01 : celle qui rebasera l'autre ajoutera juste son apport à la version déjà présente.

See #10223, #9774 (mandat), #9775 (l'outil), #9959 (jambe `--paths`), #10045 (le motif de gate bloquant).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
