### PR TITLE
fix(genai-audio,#10207): restore orphan TTS timing values in OpenAI-TTS cell35 (Task 2)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb
@@ -2181,7 +2181,7 @@
     "\n",
     "| Aspect | tts-1 | tts-1-hd | Différence |\n",
     "|--------|-------|----------|------------|\n",
-    "| Temps de generation | *runtime machine-dep* : (mesure live) | *runtime machine-dep* : (mesure live) | **~2.3x plus rapide pour tts-1 (ratio structurel)** |\n",
+    "| Temps de generation | *runtime machine-dep* : ~2-3 s (mesure cell. 21) | *runtime machine-dep* : ~4-5 s (mesure cell. 21) | **~1.6x plus rapide pour tts-1 (ratio structurel, mesure cell. 21)** |\n",
     "| Taille fichier | 398.9 KB | 405.5 KB | Negligeable (6.6 KB) |\n",
     "| Cout (texte exemple) | $0.0050 | $0.0099 | **2x moins cher** |\n",
     "| Qualite percue | Bonne | Excellente | Subjectif |\n",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: DEEP/qc #10235 (c.201, scan_window_drift)

## Quoi

**Tâche 2 de #10207** — restaure les valeurs orphelines `(mesure live)` dans `GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb` cell35.

#10212 (merged) a livré la Tâche 1 (159 emphases cassées → forme bien formée `*runtime machine-dep*`) mais a laissé cell35 avec l'unité orpheline `(mesure live)` (pas de nombre) — la valeur perdue lors du drainage #9434.

**Diff (+1/−1, 1 fichier, markdown-only)** :
```
- | Temps de generation | *runtime machine-dep* : (mesure live) | *runtime machine-dep* : (mesure live) | **~2.3x plus rapide pour tts-1 (ratio structurel)** |
+ | Temps de generation | *runtime machine-dep* : ~2-3 s (mesure cell. 21) | *runtime machine-dep* : ~4-5 s (mesure cell. 21) | **~1.6x plus rapide pour tts-1 (ratio structurel, mesure cell. 21)** |
```

## Preuve

**Verdict SOTA : RECOVERABLE-LOCAL (corrigé depuis RECOVERABLE-USER-HAND).** Le verdict précédent invoquait #9929 (clé OpenAI manquante) — **c'était un PHANTOM**, vérifié firsthand : `curl -H "Authorization: Bearer $KEY" https://api.openai.com/v1/models` → **HTTP 200** contre la clé dans `GenAI/.env` (vivante depuis ~20 cycles). Le notebook est **localement ré-exécutable** — ai-01 §D.5 s'applique : le nombre vient du kernel, pas d'un alignement markdown.

**Fresh re-exec firsthand (2026-08-10, papermill headless, clé live)** : 38/38 cellules exécutées, 0 erreur. Cell21 (`Comparaison tts-1 vs tts-1-hd`, mesure `time.time()`) produit le wall-clock réel :
- **fresh** : tts-1 **2.41s**, tts-1-hd **4.00s**, **1.7x plus rapide**
- **committed c21 output** (run antérieur) : tts-1 2.95s, tts-1-hd 4.74s, 1.6x plus rapide

Les deux runs s'accordent sur l'**ordre de grandeur** (~2-3s vs ~4-5s) et le **ratio structurel (~1.6-1.7x)** — la variation absolue confirme la qualification `*runtime machine-dep*` (network/load-dépendant). cell35 cite désormais ces valeurs **kernel-mesurées** (cell. 21), avec le ratio corrigé 2.3x → **~1.6x** (l'ancienne valeur 2.3x était un alignement markdown erroné depuis cell19).

**Kokoro cell37 (2e « valeur perdue » de l'issue) — réfuté firsthand G.1 :** sur origin/main, c37 est de la prose de pipeline (`Le pipeline complet : texte -> front-end G2P ...`), pas une cellule de valeur perdue. Les valeurs de timing Kokoro sont toutes présentes et bien formées (c3 `5-20x temps reel`, c10 `~0.5-1s (GPU)`, c29 `~5.3s observe`, c33 `Ratio temps reel 2.0x`). L'issue admet elle-même ses erreurs de comptage (« mon premier passage en annonçait 24. C'était faux »). **1 cas orphelin (OpenAI-TTS cell35), pas 2 fichiers.**

**Exit criteria #10207 :**
- `grep '\*runtime \*machine-dep\*'` → **0** (Tâche 1, livrée par #10212 sur main) ✓
- `grep '(mesure live)' OpenAI-TTS-Intro.ipynb` → **0** (was 1, cette PR) ✓

**Validation :** markdown-only (C.2 exception), +1/−1, raw-text surgery (byte-identity préservée). 0 `outputs` touchée (les outputs committed de cell21 documentent déjà un run réel ; cell35 s'aligne désormais sur elles au lieu de la prose cell19).

## Perimetre

1 notebook (+1/−1, markdown-only). `GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb` cell35. Fresh re-exec effectuée (preuve firsthand, non commitée pour garder le diff focalisé — les outputs committed sont déjà valides). 0 catalogue (byte-identique), 0 code, 0 output touché. Kokoro cell37 réfuté G.1 (pas touché).

#10213 (ma PR précédente, 23 fichiers, CONFLICTING post-#10212-merge) est **superseded** : Tâche 1 par #10212, Tâche 2 par cette PR minimale sans-conflit. Fermée sans merge (commentaire 21:55:44Z).

Closes #10207. See #9434 (rollout), #10212 (Tâche 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
