### PR TITLE
fix(probas,#10097): escape math pipe in DecPyMC-6 GFM header (source-credibility table)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-6-Expert-Systems.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-6-Expert-Systems.ipynb
@@ -1630,7 +1630,7 @@
     "\n",
     "**Sources et leurs fiabilites** :\n",
     "\n",
-    "| Source | Observation | P(source=correct | pluie) | P(source=correct | pas_pluie) |\n",
+    "| Source | Observation | P(source=correct \\| pluie) | P(source=correct \\| pas_pluie) |\n",
     "|--------|------------|---------------------------|-------------------------------|\n",
     "| Barometre | Basse pression | 0.80 | 0.15 |\n",
     "| Observation nuages | Nuages sombres | 0.75 | 0.20 |\n",


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA

## What

Fix the **real** GFM table defect in `DecPyMC-6-Expert-Systems.ipynb` cell[37] (task 2 of #10097 — per-notebook GFM fixes), flagged by `scan_md_table_syntax.py` as `COL_MISMATCH`.

## The defect

The header of the Bayesian-source-credibility table carried two unescaped math `|` inside conditional-probability notation, which GFM parsed as column separators:

```
| Source | Observation | P(source=correct | pluie) | P(source=correct | pas_pluie) |
```

GFM sees the bare `|` in `P(source=correct | pluie)` and `P(source=correct | pas_pluie)` as column separators → the header becomes **6 columns**, while the data rows have **4**:

```
| Barometre | Basse pression | 0.80 | 0.15 |
```

Result: the table does not render — the header phantom-columns don't line up with the data, so the credibility values shift under the wrong headers.

## Fix

Escape the two math pipes `|` → `\|` so GFM renders the literal pipe:

```
| Source | Observation | P(source=correct \| pluie) | P(source=correct \| pas_pluie) |
```

The header now parses as **4 columns**, matching the data rows. The rendered cell reads `P(source=correct | pluie)` exactly as the author intended (the backslash is invisible in rendered GFM).

## Measured

```
scan_md_table_syntax.py on this file:
  before: 1 REAL defect (cell[37] COL_MISMATCH, header 6 cols vs data 4)
  after:  0 defects  → 1 -> 0
```

Diff = 1 header line (2 escape edits), +1/−1. Separator row and data rows unchanged.

## Same class as my merged #10238

This is the same defect class as `DecPyMC-4-Decision-Networks.ipynb` cell[15]/cell[26] (header with unescaped `P(x|y)` math pipe creating phantom columns), fixed in my #10238 — header-vs-data column mismatch, where escaping is unambiguously correct (the rendered output is identical to author intent).

## The other Probas math-pipe findings are NOT fixed — by design

The scanner reports 3 more notebooks in `Probas/` with math-pipe findings, all in po-204's **#10170 excluded class** (cardinality `|A|`/`|S|` and conditional `P(x|y)` in *data rows* where the convention is established as out-of-scope):

- `DecInfer-5` cell[15]: `O(|A| × |S|)` complexity cardinality
- `DecPyMC-1` cell[17]: `P(test+ | malade)` in data rows
- `Probas/README.md` L420: `P(A|B)` in a data row

Those are left to the scanner-owner's convention decision (#10170 / po-204's refinement candidate), not patched here to avoid creating inconsistency.

## Scope

- **1 file, +1/−1 line** (markdown header cell only).
- **Markdown-only edit** → C.2 exception applies (no re-execution needed; no code cell touched).
- **NOT a twin pair** (absent from `twin_pairs.d/` → no rebaseline).
- JSON verified valid, LF-only, no BOM; `execution_count`/`outputs` of all 22 code cells unchanged.

See #10097 (task 2 — per-notebook GFM fixes; task 1 = scanner exclusion, my #10233).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
