### PR TITLE
Refine(check_machine_dep_timing,#10178): route content-duration constraints to domain_quantity (Classe 4)

### DIFF
--- a/scripts/notebook_tools/check_machine_dep_timing.py
+++ b/scripts/notebook_tools/check_machine_dep_timing.py
@@ -149,6 +149,26 @@ PROTOCOL_KEYWORDS = re.compile(
     re.IGNORECASE,
 )
 
+# Contrainte de duree de CONTENU (longueur cible d'un media produit) : le chiffre
+# est une borne du domaine (longueur max d'une video YouTube Shorts, duree cible
+# d'un module de cours), pas une duree machine. Exempt en tant que
+# ``domain_quantity`` (#10178 Classe 4). Discriminant : un wallclock strict ne
+# s'encadre JAMAIS comme « contrainte de duree » / « duree cible » / « YouTube
+# Shorts » / « module de cours » -- ce sont des descripteurs de CONTENU, pas
+# d'execution. Verifie firsthand : GenAI/Video cell[12] « contraintes de duree
+# (ex: moins de 5 minutes pour YouTube Shorts, ou exactement 10 minutes pour un
+# module de cours) » = 2 FP wallclock -> domain_quantity ; le controle positif
+# GenAI/Texte/10 cell[56] « Temps : 1M / 40 = 25,000 secondes » (vrai throughput
+# compute) ne matche AUCUN de ces signaux et reste wallclock.
+CONTENT_DURATION_CONSTRAINT_RE = re.compile(
+    r"(?:\bcontrainte[s]?\s+(?:de\s+)?dur[ée]e\b"
+    r"|\bdur[ée]e\s+(?:cible|totale|maximale|optimale)\b"
+    r"|\bdur[ée]e\s+de\s+la\s+vid[ée]o\b"
+    r"|\bYouTube\s+Shorts\b"
+    r"|\bmodule\s+de\s+cours\b)",
+    re.IGNORECASE,
+)
+
 # Pacing pedagogique : la cellule H1/H2/H3 documente l'effort demande a
 # l'etudiant. Ligne entiere exoneree (cf. arbitrage jsboige 14:05:37Z #9434).
 # Le motif "**Notebook** : ... 30-60 min selon niveau" est aussi couvert --
@@ -267,6 +287,11 @@ def _categorize(line: str, snippet: str) -> str:
     # Constante de protocole (consensus blockchain / canal de paiement) :
     # parametre du domaine, pas une duree machine. Residu 2 #10169.
     if PROTOCOL_KEYWORDS.search(line):
+        return CATEGORY_DOMAIN_QUANTITY
+    # Contrainte de duree de CONTENU (#10178 Classe 4) : longueur cible d'un
+    # media produit (YouTube Shorts, module de cours, duree cible de video).
+    # Borne du domaine, pas une duree machine -- les 2 FP GenAI/Video cell[12].
+    if CONTENT_DURATION_CONSTRAINT_RE.search(line):
         return CATEGORY_DOMAIN_QUANTITY
     # Frontiere FP (frontier issue) : cout d'action dans une table de plan.
     # La duree est le RESULTAT d'une arithmetique « N + M = K unit » (ex

--- a/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
+++ b/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
@@ -27,6 +27,7 @@ from check_machine_dep_timing import (  # noqa: E402
     _is_detached_approximate,
     _repo_root,
     PROTOCOL_KEYWORDS,
+    CONTENT_DURATION_CONSTRAINT_RE,
     CATEGORY_WALLCLOCK,
     CATEGORY_DISTRIBUTION,
     CATEGORY_AMBIGUOUS,
@@ -450,6 +451,79 @@ def test_sudoku13_positive_control_preserved() -> None:
         wallclock = [f for f in findings if f["category"] == CATEGORY_WALLCLOCK]
         assert wallclock, (
             f"Controle positif perdu : aucun wallclock trouve, "
+            f"categories={[f['category'] for f in findings]}"
+        )
+    finally:
+        nb.unlink()
+
+
+# --------------------------------------------------------------------------- #
+#  #10178 Classe 4 : contrainte de duree de CONTENU (longueur cible d'un media)
+# --------------------------------------------------------------------------- #
+def test_content_duration_constraint_regex_matches() -> None:
+    """Le motif detecte les descripteurs de duree de CONTENU, pas d'execution.
+
+    Rationnel (#10178 Classe 4) : « moins de 5 minutes pour YouTube Shorts » ou
+    « 10 minutes pour un module de cours » sont des bornes du domaine video
+    (longueur max du media produit), pas des durees machine. Le motif vise 5
+    signaux univoques de contenu.
+    """
+    # Signaux positifs (chacun univoque de duree de contenu).
+    assert CONTENT_DURATION_CONSTRAINT_RE.search("respecter des contraintes de duree (ex: 5 minutes)")
+    assert CONTENT_DURATION_CONSTRAINT_RE.search("moins de 5 minutes pour YouTube Shorts")
+    assert CONTENT_DURATION_CONSTRAINT_RE.search("exactement 10 minutes pour un module de cours")
+    assert CONTENT_DURATION_CONSTRAINT_RE.search("la duree cible de la video est 30 secondes")
+    assert CONTENT_DURATION_CONSTRAINT_RE.search("duree totale du clip : 2 minutes")
+    assert CONTENT_DURATION_CONSTRAINT_RE.search("duree maximale autorisee : 60s")
+    # Negatifs -- un vrai wallclock ne s'encadre pas ainsi.
+    assert not CONTENT_DURATION_CONSTRAINT_RE.search("La duree d'execution est 2.4 s")
+    assert not CONTENT_DURATION_CONSTRAINT_RE.search("Temps : 1M / 40 = 25,000 secondes = ~7 heures")
+    assert not CONTENT_DURATION_CONSTRAINT_RE.search("compute took 3.5 sec on the GPU")
+
+
+def test_categorize_content_duration_constraint_is_domain_quantity() -> None:
+    """Une duree de contenu (contrainte de duree / Shorts / module) -> domain_quantity.
+
+    Cas reel GenAI/Video cell[12] (#10178 Classe 4) : le « 5 minutes » est la
+    longueur max d'un YouTube Shorts, pas un runtime. Le controle positif
+    GenAI/Texte/10 cell[56] (throughput compute) reste wallclock.
+    """
+    # Ligne reelle GenAI/Video cell[12] (paraphrase ASCII conforme au notebook).
+    line_video = (
+        "les videos educatives doivent souvent respecter des contraintes de "
+        "duree (ex: moins de 5 minutes pour YouTube Shorts)"
+    )
+    assert _categorize(line_video, "5 minutes") == CATEGORY_DOMAIN_QUANTITY
+    # Controle positif : vrai throughput compute -> reste wallclock.
+    line_throughput = "Temps : 1M / 40 = 25,000 secondes = ~7 heures"
+    assert _categorize(line_throughput, "25,000 secondes") == CATEGORY_WALLCLOCK
+
+
+def test_content_duration_constraint_fp_routed_to_domain_quantity() -> None:
+    """Le FP GenAI/Video cell[12] (wallclock) est silencie en domain_quantity.
+
+    Rationnel : le detecteur ne doit PLUS rapporter « 5 minutes » / « 10 minutes »
+    comme wallclock quand la ligne encadre une contrainte de duree de contenu.
+    Avant le fix : wallclock=2 sur ce notebook ; apres : wallclock=0 (les 2
+    findings basculent en domain_quantity, categorie non-signalee par design).
+    """
+    nb = _make_nb([_md_cell(
+        "**Contexte** : En production, les videos educatives doivent souvent "
+        "respecter des contraintes de duree (ex: moins de 5 minutes pour "
+        "YouTube Shorts, ou exactement 10 minutes pour un module de cours)."
+    )])
+    try:
+        findings = _scan_notebook(nb)
+        # Aucun finding wallclock (les 2 chiffres sont des durees de contenu).
+        wallclock = [f for f in findings if f["category"] == CATEGORY_WALLCLOCK]
+        assert not wallclock, (
+            f"FP Classe 4 non corrige : wallclock trouve, "
+            f"categories={[f['category'] for f in findings]}"
+        )
+        # Et au moins un finding route en domain_quantity (l'exemption agit).
+        domain = [f for f in findings if f["category"] == CATEGORY_DOMAIN_QUANTITY]
+        assert domain, (
+            f"Aucun domain_quantity : l'exemption n'a pas route le finding, "
             f"categories={[f['category'] for f in findings]}"
         )
     finally:


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: DEEP/guard

# check_machine_dep_timing : Classe 4 — contraintes durée-vidéo → domain_quantity

## Quoi

#10178 Classe 4 (acceptance item unchecked) : GenAI/Video/04-1-Educational-Video-Generation cell[12] flaggait `5 minutes` / `10 minutes` comme **wallclock** — ce sont des **contraintes du domaine vidéo** (longueur max d'un YouTube Shorts / durée cible d'un module de cours), pas des runtimes machine. La classe est documentée dans #10178 comme « similaire à `domain_quantity` mais dans un domaine qu'aucun mot-clé ne couvre ».

Fix : `CONTENT_DURATION_CONSTRAINT_RE` (5 signaux univoques de contenu) routé vers `domain_quantity` dans `_categorize`, aux côtés de `PROTOCOL_KEYWORDS` (Classe protocole) et du motif plan-cost (Classe planning).

## Discriminant mesuré firsthand (anti-fabrication Prong-B)

| Notebook | Avant | Après | Verdict |
|----------|-------|-------|---------|
| GenAI/Video cell[12] (le FP documenté) | wallclock=2 | wallclock=0, domain_quantity=2 | **FP corrigé** |
| GenAI/Texte/10 cell[56] `Temps : 1M / 40 = 25,000 secondes` (vrai throughput compute) | wallclock=1 | wallclock=1 | **contrôle positif préservé** |
| Sudoku-13-CSharp (timings réels DLX solver) | wallclock=28 | wallclock=28 | **contrôle positif intact** |

Les 5 signaux (`contrainte de durée` / `durée cible-totale-maximale` / `durée de la vidéo` / `YouTube Shorts` / `module de cours`) sont univoques de **contenu** : un wallclock strict ne s'encadre jamais ainsi. Aucun FN collatéral (le seul drop wallclock repo-wide GenAI = Video cell[12]).

## Tests

```
$ python -m pytest scripts/notebook_tools/tests/test_check_machine_dep_timing.py -q
============================= 41 passed in 31.12s =============================
```

38 existants + 3 nouveaux :
- `test_content_duration_constraint_regex_matches` — signaux positifs + négatifs (durée d'exécution, throughput compute ne matchent pas).
- `test_categorize_content_duration_constraint_is_domain_quantity` — `_categorize` unit (ligne GenAI/Video → domain_quantity ; contrôle throughput → wallclock).
- `test_content_duration_constraint_fp_routed_to_domain_quantity` — intégration (notebook synthétique mirroir cell[12] : 0 wallclock, >=1 domain_quantity).

## Résiduel hors-scope (classes distinctes, PRs séparées)

Audio/Video-Sync `04-4-Audio-Video-Sync` : `durée du segment` (cell[13]/[17]) et `fenêtre glissante 50ms` (cell[22] = DSP window) sont des classes **distinctes** (segment-duration / DSP-window-parameter), non couvertes par ce fix — laissées wallclock, documentées ici pour traçabilité. Classe 3 (`*runtime *machine-dep*` annotation) reste un design-question gated (décision coord/user requise, cf #10178).

## Variation

MED/tooling (détecteur FP + tests, change une décision de classification). prev DEEP/guard (#10236 lane-claim). G-VAR-1 (plancher MED tenu), G-VAR-3 OK (tooling != guard).

See #10178 (Classe 4), #10179 (Classes 1+2 livrées), #10162 (détecteur initial).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
