### PR TITLE
feat(d5,#9790): filter markdown-table-cell FPs in D5 scanner (class 8, -808)

### DIFF
--- a/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
@@ -160,6 +160,28 @@ _HEX_COLOR_RE = re.compile(r"#[0-9a-fA-F]{3,8}")
 # alphanum^alphanum (couvre 2^3, n^2, 2^32 ; le caret est distinctif).
 _PLAINTEXT_EXPONENT_RE = re.compile(r"[0-9a-zA-Z]+\^[0-9a-zA-Z]+")
 
+# Ligne de table GFM (markdown) (po-2023 #9790, FP class 8 -- markdown-table-data) :
+# une ligne debutant par <= 3 espaces/tab, un `|`, du contenu, puis un `|` de fin
+# est une RANGEE de table -- le nombre est une CELLULE de donnees structurale,
+# pas une affirmation de mesure en prose. Source documentee : po-2023 a mesure
+# firsthand (G.1, 2026-08-09, classifier full-corpus SymbolicAI) 1001/2110
+# findings MISSING_FROM_OUTPUTS (47,4 %) tombent dans une rangee de table ;
+# echantillon divers 19/19 notebooks = 100 % tables de REFERENCE/DONNEES/SPEC
+# (dataset input Stigler `| Farine | 4,5 kg | 36 | 44,7 | 1411 |`, tables de
+# versions `RDF 1.2 (2020)`, benchmarks de papier `0.53 | 0.95 | +79 %`, specs
+# d'outils `IKVM 8.15.0`), zero table de resultats-calculés.
+#
+# SAFE-by-construction (exclusion structurelle, cf. deja-exclus : titres ATX
+# `## 4.2`, marqueurs de liste `1.`, math LaTeX `$2^3$` -- tous presentation
+# structurelle, pas affirmation de mesure). Ancre debut-de-ligne `|` : un item
+# de liste (`- x |`) ou une math mid-sentence (`|r| = 0,5`) ne rend jamais sous
+# cette forme (ils ne commencent pas par `|`), donc non filtres. Considération
+# de faux-negatif : une table markdown de RESULTATS serait aussi exclue -- mais
+# un notebook qui calcule un resultat l'echo dans les outputs code (verifies
+# separatement) ; retaper un resultat calcule dans une table markdown est rare
+# dans ce corpus (0/19 echantillon). Le gain (1001 FP, 47 %) domine largement.
+_MARKDOWN_TABLE_ROW_RE = re.compile(r"^[ \t]{0,3}\|.*\|[ \t]*$", re.MULTILINE)
+
 # Marqueur de liste ordonnee markdown/CommonMark (po-2023 #9790, FP class 7) :
 # une ligne debutant par <= 3 espaces, un entier, puis `.` ou `)` puis un
 # espace (ou fin de ligne) est un ITEM de liste ordonnee -- l'entier est
@@ -393,13 +415,15 @@ def _extract_prose_numbers(text: str) -> list[float]:
         return []
     # Precompute les spans a ignorer une fois (evite un finditer par nombre) :
     # math LaTeX ($2^n - 1$), codes couleur hex (#084298), exposants plaine
-    # (2^3). Un nombre tombant dans un de ces spans n'est pas une mesure
-    # d'output (constante de formule / canal de couleur / constituant
-    # d'exposant). c.1293 (LaTeX), c.1295 (hex + exposant).
+    # (2^3), rangees de table GFM (`| ... |`). Un nombre tombant dans un de ces
+    # spans n'est pas une mesure d'output (constante de formule / canal de
+    # couleur / constituant d'exposant / cellule de donnees tabulaire). c.1293
+    # (LaTeX), c.1295 (hex + exposant), c.XXX (table GFM, FP class 8).
     skip_spans = (
         [m.span() for m in _LATEX_MATH_SPAN_RE.finditer(text)]
         + [m.span() for m in _HEX_COLOR_RE.finditer(text)]
         + [m.span() for m in _PLAINTEXT_EXPONENT_RE.finditer(text)]
+        + [m.span() for m in _MARKDOWN_TABLE_ROW_RE.finditer(text)]
     )
     out: list[float] = []
     for m in FR_DECIMAL_RE.finditer(text):

--- a/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
@@ -258,6 +258,89 @@ class TestOrderedListMarkerFalsePositive:
         assert 5.0 in nums
 
 
+class TestMarkdownTableDataFalsePositive:
+    """Filtre cellules de table GFM (po-2023 #9790, FP class 8 -- markdown-table-data).
+
+    Un nombre dans une rangee de table markdown (ligne debutant par ``|`` et
+    finissant par ``|``) est une CELLULE de donnees structurale (dataset input,
+    table de versions, benchmark de papier, spec d'outil), pas une affirmation
+    de mesure en prose. Verifie firsthand (G.1, 2026-08-09, classifier
+    full-corpus SymbolicAI) : 808/2110 findings MISSING_FROM_OUTPUTS (38 %)
+    tombent dans une rangee de table ; echantillon divers 19/19 notebooks =
+    100 % tables de REFERENCE/DONNEES, zero table de resultats calcules.
+    Falsifiable both-directions : un nombre en PROSE (hors table) est conserve,
+    meme si la cellule contient aussi une table ; un item de liste avec un pipe
+    ne commence pas par ``|`` donc n'est pas une table.
+    """
+
+    def test_filter_table_cell_input_data(self):
+        # Cas corpus (OR-tools-Stiegler c8, Stigler diet dataset) : "36" est le
+        # prix nutrient de la farine, donnee d'INPUT du solver, pas une mesure.
+        nums = mod._extract_prose_numbers(
+            "| Ingredient | Quantite | Prix |\n|---|---|---|\n| Farine | 4,5 kg | 36 |\n"
+        )
+        assert 36.0 not in nums
+
+    def test_filter_table_cell_version_reference(self):
+        # Cas corpus (SW-9-JSONLD) : table de versions "1.1 (2020)" = reference.
+        nums = mod._extract_prose_numbers(
+            "| Standard | Version |\n|---|---|\n| RDF-Star | 1.2 (2020) |\n"
+        )
+        assert 1.2 not in nums
+
+    def test_filter_table_cell_paper_benchmark(self):
+        # Cas corpus (Lean-8-Agentic) : "0.53" est un benchmark tire d'un papier.
+        nums = mod._extract_prose_numbers(
+            "| Lemme | Auto | Semantique |\n|---|---|---|\n| Nat.add_comm | 0.53 | 0.95 |\n"
+        )
+        assert 0.53 not in nums
+        assert 0.95 not in nums
+
+    def test_filter_multi_column_table_all_cells(self):
+        # Toutes les cellules numeriques d'une table a plusieurs colonnes.
+        nums = mod._extract_prose_numbers(
+            "| A | B | C |\n|---|---|---|\n| 10 | 20 | 30 |\n| 40 | 50 | 60 |\n"
+        )
+        assert nums == []
+
+    def test_filter_indented_table_row(self):
+        # Table indentee (<= 3 espaces, CommonMark) toujours une rangee.
+        nums = mod._extract_prose_numbers("  | x | 42 |\n")
+        assert 42.0 not in nums
+
+    def test_preserve_measurement_after_table(self):
+        # CRUCIAL both-directions : une mesure en PROSE apres une table est
+        # conservee -- on ne filtre que les nombres DANS les rangees.
+        nums = mod._extract_prose_numbers(
+            "| Data | Val |\n|---|---|\n| a | 99 |\n\nLe score final observe est 0.42."
+        )
+        assert 99.0 not in nums
+        assert 0.42 in nums
+
+    def test_preserve_prose_measurement_with_math_pipe(self):
+        # CRUCIAL both-directions : "|r| = 0,5" mid-sentence n'est PAS une table
+        # (la ligne ne commence pas par `|`) -> la mesure 0.5 est conservee.
+        nums = mod._extract_prose_numbers("La valeur absolue |r| = 0,5 indique correlation.")
+        assert 0.5 in nums
+
+    def test_list_item_with_pipe_not_table(self):
+        # CRUCIAL both-directions : un item de liste "- a | b" ne commence pas
+        # par `|` -> un nombre dedans est conserve (pas une table).
+        nums = mod._extract_prose_numbers("- Ratio gagnant | 7 trades sur 12")
+        assert 7.0 in nums
+        assert 12.0 in nums
+
+    def test_table_and_prose_claim_same_cell(self):
+        # Une cellule avec une table ET une affirmation en prose : seules les
+        # cellules de table sont filtrees, la mesure en prose survive.
+        nums = mod._extract_prose_numbers(
+            "Parametres :\n| Seuil | 0.5 |\n|---|---|\n| K | 3 |\n\nResultat : Phi = 0.69."
+        )
+        assert 0.5 not in nums      # cellule de table
+        assert 3.0 not in nums      # cellule de table
+        assert 0.69 in nums         # affirmation de prose
+
+
 class TestHexColorAndExponentFalsePositives:
     """Filtre codes couleur hex + exposants plaine (EPIC #9768, c.1295).
 


### PR DESCRIPTION
Grain: DEEP/forensic — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #10237 (TTS Task-2)

## Quoi

`scripts/notebook_tools/scan_d5_prose_outputs_alignment.py` — filtre la 8e classe de faux positifs du détecteur D5 : **markdown-table-data**. Un nombre dans une rangée de table GFM (ligne débutant et finissant par `|`) est une cellule de DONNÉES structurelle, pas une affirmation de mesure en prose. Ajout du skip-span `_MARKDOWN_TABLE_ROW_RE` dans `_extract_prose_numbers`, miroir des exclusions structurelles existantes (LaTeX/hex/exposant/titres/marqueurs-de-liste).

## Preuve

**Mesure firsthand (G.1, 2026-08-09, classifier full-corpus SymbolicAI 230 notebooks)** :
- AVANT : 2110 findings MISSING_FROM_OUTPUTS.
- APRÈS : 1302 findings.
- **DELTA : −808 (−38,3 %)** — la plus grande classe de FP résiduelle du détecteur.

**Échantillon divers 19/19 notebooks = 100 % tables de RÉFÉRENCE/DONNÉES/SPEC** (dataset input Stigler `| Farine | 4,5 kg | 36 | 44,7 | 1411 |`, tables de versions `RDF 1.2 (2020)`, benchmarks de papier Lean `| Nat.add_comm | 0.53 | 0.95 |`, specs d'outils `IKVM 8.15.0`) — **zéro table de résultats-calculés**. Les résultats calculés s'echo dans les outputs code (vérifiés séparément), pas retapés en table markdown.

**SAFE-by-construction (exclusion structurelle)** : ancre début-de-ligne `^[ \t]{0,3}\|...\|[ \t]*$`. Un item de liste (`- x |`) ou une math mid-sentence (`|r| = 0,5`) ne commence jamais par `|` → non filtré. Falsifiable both-directions : 9 tests dont (a) cellule de table exclue, (b) mesure en prose APRÈS une table conservée, (c) `|r| = 0,5` mid-sentence conservé, (d) item de liste avec pipe conservé.

**Régression** :
- Suite `test_scan_d5_prose_outputs_alignment.py` : **143/143 PASS** (134 existants + 9 nouveaux, 0 régression).
- **True-positive fondateur ICT-1 (#9416) préservé** : 20 findings dont MISSING_FROM_PROSE_ENUMERATION intact.
- **Probas ENUMERATION true-positives préservées** (24 > 0) — pas d'over-filtering cross-famille.
- Diff **additif** +110/−3 (anti-régression : 0 logique supprimée, les 3 deletions = reformatage du tuple skip-spans).

## Perimetre

2 fichiers, +110/−3. `scan_d5_prose_outputs_alignment.py` (+30, 1 nouveau regex + 1 ligne skip-span) + `tests/test_scan_d5_prose_outputs_alignment.py` (+83, 9 tests). 0 notebook touché, 0 output édité, 0 catalogue. Markdown/Python-only.

**Collision avec #10222 (po-2025, OPEN)** : cette PR ajoute `_is_code_defined_value` après la ligne ~623 ; la mienne touche `_extract_prose_numbers` (~ligne 399) — fonctions différentes, rebase trivial. Documenté pour l'ordonnancement merge ai-01.

See #9790 (EPIC #9768 détecteur v3, contribution partielle — ne ferme pas l'EPIC). See #9768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
