### PR TITLE
docs(ci,lean,#9863): correct stale swap comment — split resolved the single-module OOM

### DIFF
--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -184,23 +184,30 @@ jobs:
 
     - name: Add swap space
       # Hosted ubuntu-latest runners have 16 GB RAM. Full (cache-miss) elaboration
-      # of a large local module — conway_lean HashlifeCorrectness.lean, 7300+ lines —
-      # exceeds that: the VM OOMs and the provisioner tears the runner down mid-build
-      # ("The runner has received a shutdown signal", exit 143, ~4 min after the
-      # Mathlib cache download completes). Observed 3x on PR #9798 (runs 31139*,
-      # 31141*, 31147588612, 2026-08-07) while the sibling PR #9806 — same lake,
-      # cache HIT on the big module — passed in ~6 min: the discriminant is the
-      # actions/cache miss, not the code. Swap absorbs the elaboration peak; on
-      # incremental (cache-hit) runs this step costs ~5 s and the swap is idle.
+      # of a large local module can exceed that: the VM OOMs and the provisioner
+      # tears the runner down mid-build ("The runner has received a shutdown
+      # signal", exit 143, ~4 min after the Mathlib cache download completes).
+      # Observed 3x on PR #9798 (runs 31139*, 31141*, 31147588612, 2026-08-07)
+      # while the sibling PR #9806 — same lake, cache HIT on the big module —
+      # passed in ~6 min: the discriminant is the actions/cache miss, not the
+      # code. Swap absorbs the elaboration peak; on incremental (cache-hit) runs
+      # this step costs ~5 s and the swap is idle.
       #
-      # 16 G -> 32 G (2026-08-07, PR #9840): the same exit-143 teardown recurred
-      # twice WITH this step green (run 31161731891, jobs 92824690001 et al.) —
-      # `Add swap space` = success, `Lake build` killed ~4 min 50 s after
-      # `Decompressed 8477 file(s)`, zero `.lean:L:C: error:` line. #9840 adds
-      # +756 lines of heartbeat-heavy P4 wall proofs (16 M cap on the SE mp arm)
-      # to HashlifeCorrectness.lean, so the peak sits in ONE module: lowering
-      # `lake -j` cannot split it, only more swap can absorb it. The same commit
-      # elaborates clean on WSL (`lake build` exit 0, 8556 jobs) — the ceiling is
+      # History (2026-08-07): PR #9840 (+756 lines of heartbeat-heavy P4 wall
+      # proofs) pushed the monolithic HashlifeCorrectness.lean past the 16 GB
+      # ceiling — `Add swap space` green but `Lake build` killed ~4 min 50 s after
+      # `Decompressed 8477 file(s)` (run 31161731891), zero error line. At the
+      # time the elaboration peak sat in ONE module, so lowering `lake -j` could
+      # not split it and more swap was the only lever.
+      #
+      # RESOLVED by the split (#9863, PR #9897 + follow-ups, 2026-08-07):
+      # HashlifeCorrectness.lean is now an aggregator (1285 lines) over
+      # Foundation.lean + Walls/{NE,NW,SE,SW}.lean. The peak is distributed across
+      # modules that `lake -j` elaborates in SEPARATE processes, so the runner no
+      # longer OOMs a single address space — conway_lean CI is green on main
+      # (runs of 2026-08-09). This swap step stays as cheap insurance against a
+      # future cache-miss peak; it is no longer the only mitigation. The same
+      # commit elaborates clean on WSL (`lake build` exit 0) — the ceiling was
       # the runner's 16 GB RAM, not the proof. /mnt on ubuntu-latest carries
       # ~70 GB free, so 32 G is affordable; `df -h /mnt` keeps that auditable.
       run: |


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2025:CoursIA-2 — prev: MED/tooling

# docs(ci,lean,#9863) : corriger le commentaire swap stale — le split a résolu l'OOM single-module

## Quoi

Le commentaire « Add swap space » de `lean-build.yml` (posé par #9850) affirmait : « the peak sits in ONE module: lowering `lake -j` cannot split it, only more swap can absorb it. » C'était **vrai le 2026-08-07** contre le `HashlifeCorrectness.lean` monolithique de 7082 lignes — mais **#9863** (PR #9897 + follow-ups, 2026-08-07) l'a découpé en un agrégateur (1285 lignes) sur `Foundation.lean` + `Walls/{NE,NW,SE,SW}.lean`, donc le pic d'élaboration est désormais **réparti sur des modules que `lake -j` élabore dans des processus séparés**.

## Vérifié firsthand

- **conway_lean CI vert sur main** (post-split) — runs du 2026-08-09 (success) :
  ```
  success 2026-08-09T14:07  docs(conway-lean): align p5_large_n_jumpN docstring
  success 2026-08-09T06:42  docs(conway-lean): mark P4 inductive-step docstring
  success 2026-08-07T18:35  feat(lean,#9863): port SW+SE wall proofs to split
  success 2026-08-07T13:50  feat(lean,#9863): split HashlifeCorrectness into Foundation
  ```
  Le runner n'OOM-plus un seul espace d'adressage. La narration historique (pourquoi le swap existe) est préservée ; le swap reste une assurance bon marché, **ce n'est plus la seule mitigation**.

## Anti-régression (règle B pr-review-discipline)

- `git diff --name-only` : **0 fichier `.lean` touché** → 0 sorry ajouté garanti (trivial).
- Byte-identity des énoncés : préservée par #9897 (ce PR ne touche que le YAML).
- `lake build` vert en CI : **vérifié sur main post-split** (critère d'acceptance décisif de #9863).
- proof-integrity vert : CI conway_lean green.
- YAML re-validé (`yaml.safe_load` OK, bloc `run: |` intact).

## Ce qui ferme #9863

#9863 (4 items d'acceptance) — cet PR complète l'**item 4** (« Corriger le commentaire de lean-build.yml ajouté par #9850 »), le dernier non-coché :

| Item | Statut |
|------|--------|
| `wc -l` par module + seuil justifié | ✓ (Foundation 3609 = le plus lourd, sous le seuil OOM — CI vert le justifie, pas un chiffre rond) |
| `lake build` vert en CI post-split | ✓ (conway_lean green 2026-08-09) |
| Aucun `sorry` ajouté | ✓ (0 `.lean` touché dans ce PR ; #9897 a préservé la byte-identity) |
| Byte-identity des énoncés déplacés | ✓ (#9897) |
| proof-integrity vert | ✓ (CI green) |
| **Corriger le commentaire #9850** | ✓ **ce PR** |

## Variation

MED/lean (vérification CI firsthand + correction d'un claim diagnostique faux + fermeture d'issue DEEP). Le commentaire n'est pas cosmétique : il documentait une décision d'infrastructure (swap 32G) sur la base d'un claim (« lake -j cannot split it ») que le split a rendu faux — le corriger aligne la doc CI sur la réalité vérifiée. prev MED/tooling (#10241). G-VAR-1 (plancher MED tenu), G-VAR-3 OK (lean ≠ tooling).

## Finding annexe (re-mapping #6724 post-split)

En vérifiant #9863, j'ai constaté que les numéros de ligne du tracker **#6724** (L2839/L3168/L3317/L3346 pour les 4 sorries canoniques dans `HashlifeCorrectness.lean`) sont **stale post-split** : le fichier monolithique de 7082 lignes est désormais l'agrégateur de 1285 lignes. Les 4 théorèmes nommés (`p4_succ_membership`, `p5_large_n_jump`, `hashlife_correctN`, `p5_large_n_jumpN`) vivent maintenant entre l'agrégateur et `Foundation.lean`, et les modules murs portent **0 sorry code-level** (les 25/23/6/6/1 du grep-brut = prose de docstrings, sur-compte documenté dans #6724). Commentaire correctif posté sur #6724 avec la carte post-split, pour re-grounder le tracker avant tout travail prover.

See #9863, #9850 (commentaire stale), #9897 (split), #9840 (trigger OOM), #6724 (tracker sorry — re-mappé).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
