### PR TITLE
docs(iit,#10246): pont narratif IIT ⇄ docs/ict — 3 notebooks orphelins du fil

### DIFF
--- a/MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb
@@ -89,6 +89,18 @@
     "Sélectionner l'environnement nouvellement créé comme noyau."
    ]
   },
+    {
+   "cell_type": "markdown",
+   "id": "ict-bridge-cadrage",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Cadre.** Ce notebook établit le calcul opérationnel de $\\Phi$ (petite *phi*) sur un réseau *toy* avec PyPhi : construction du sous-système, mécanisme d'information minimale irréductible (MIP), puis cause-effect structure (CES). C'est le socle mécanique de toute la série IIT.\n",
+    "\n",
+    "**Du côté ICT.** L'Epic [#4588](https://github.com/jsboige/CoursIA/issues/4588) demande : *qu'est-ce qu'une « strate » mesure quand on parle d'information intégrée ?* Le $\\Phi$ calculé ici en est l'instrument. Le fil ICT qui prolonge cette mécanique — la [dissolution des scalaires](../../docs/ict/dissolution-scalaires.md) — suit ce qui arrive à $\\Phi$, F, K quand on les pousse hors de leur substrat d'origine (ICT-1 → ICT-22)."
+   ]
+  },
   {
    "cell_type": "code",
    "execution_count": 1,
@@ -1729,6 +1741,16 @@
     "Le calcul de $\\Phi$ est **combinatoirement explosif** (toutes les partitions, tous les mécanismes), ce qui confine PyPhi a de petits systèmes (quelques noeuds) -- une contrainte pratique a garder en tete avant toute ambition d'echelle. Les raffinements de la théorie (IIT 4.0, calcul du $\\varphi$ au niveau des distinctions et relations) et les stratégies de passage a l'echelle sont approfondis dans le notebook [IIT-2 : Sujets avances](./IIT-2-AdvancedTopics.ipynb).\n",
     "\n",
     "> **A retenir** : l'IIT propose de mesurer la conscience comme l'**integration causale irreductible** d'un système sur lui-même. PyPhi rend cette definition operationnelle : on declare une dynamique (TPM), on choisit un decoupage (Subsystem), et le moteur calcule a la fois *combien* ($\\Phi$) et *quoi* (CES) le système integre.\n"
+   ]
+  },
+    {
+   "cell_type": "markdown",
+   "id": "ict-bridge-transition",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Où va la suite.** [IIT-2](IIT-2-AdvancedTopics.ipynb) approfondit le partitionnement (MIP/SIA), les répertoires cause-effet et la comparaison Big $\\Phi$ / Small $\\Phi$ ; [IIT-3](IIT-3-CoarseGrainingMacroPhi.ipynb) traite le coarse-graining et l'échelle du $\\Phi$. Pour relier cette mécanique à la question ICT plus large de la représentation interne et des dissociations : [`synthese-invariants-dissociations-obstructions.md`](../../docs/ict/synthese-invariants-dissociations-obstructions.md)."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb
@@ -41,6 +41,18 @@
     "8. **Vers IIT 4.0** - Apercu des evolutions recentes de la théorie"
    ]
   },
+    {
+   "cell_type": "markdown",
+   "id": "ict-bridge-cadrage",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Cadre.** Ce notebook approfondit l'analyse : partitionnement du sous-système (MIP, SIA — system irreducibility analysis), répertoires cause-effet d'un mécanisme, construction des concepts (MICE/CES), et comparaison Big $\\Phi$ vs Small $\\Phi$.\n",
+    "\n",
+    "**Du côté ICT.** Le partitionnement est précisément l'outil qui *dissocie* un mécanisme de ses purviews. La [matrice des dissociations](../../docs/ict/dissociations-matrix.md) de l'ICT s'appuie sur cette gymnastique cause-effet pour croiser chaque notebook, claim et proxy — comprendre MIP et répertoires ici rend la matrice ICT lisible."
+   ]
+  },
   {
    "cell_type": "markdown",
    "id": "bb121255",
@@ -1792,6 +1804,16 @@
     "- **Article fondateur** : Oizumi, Albantakis, Tononi (2014). *From the Phenomenology to the Mechanisms of Consciousness*\n",
     "- **IIT 4.0** : Albantakis et al. (2023). *Integrated information theory (IIT) 4.0*\n",
     "- **Series connexes** : [Probas](../Probas/README.md), [GameTheory](../GameTheory/README.md)"
+   ]
+  },
+    {
+   "cell_type": "markdown",
+   "id": "ict-bridge-transition",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Où va la suite.** [IIT-3](IIT-3-CoarseGrainingMacroPhi.ipynb) passe à l'échelle : coarse-graining, blackboxing, et la question de savoir si $\\Phi$ survit au changement de résolution. Côté ICT, la [cartographie en tresse](../../docs/ict/tresse-cartographie.md) articule Thom / Grothendieck / Schmidhuber / Friston — les quatre lentilles entre lesquelles le partitionnement navigue."
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb
@@ -20,6 +20,18 @@
     "**Avertissement honnête (Prong-B).** L'IIT prédit que le $\\Phi$ macro peut *dépasser* le $\\Phi$ micro (c'est la *causal emergence* de Hoel 2013, Albantakis & Tononi). Cette prédiction est **réelle et documentée** sur des réseaux probabilistes spécifiques. Mais elle n'est **pas automatique** : sur des réseaux déterministes simples, le coarse-grain ne crée pas d'emergence (le $\\Phi$ macro $\\approx$ le $\\Phi$ micro). Ce notebook démontre donc la **méthode** (comment coarse-grainer, comment comparer les échelles) de manière fidèle, sans prétendre exhiber une emergence positive que le toy ne produit pas."
    ]
   },
+    {
+   "cell_type": "markdown",
+   "id": "ict-bridge-cadrage",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Cadre.** Ce notebook est le pont vers l'échelle : coarse-graining (regroupement de nœuds micro en macro-nœuds), blackboxing, et la question décisive — *$\\Phi$ survive-t-il au changement de résolution ?* On mesure l'information efficace et $\\Phi$ au niveau micro, puis on compare à la macro après regroupement.\n",
+    "\n",
+    "**Du côté ICT — le cas le plus net.** Le coarse-graining est *la* mécanique de changement d'échelle dont l'ICT se sert pour parler de [dissolution des scalaires](../../docs/ict/dissolution-scalaires.md) : ce qui arrive à $\\Phi$, F, K quand on change de strate. La [cartographie en tresse](../../docs/ict/tresse-cartographie.md) situe ce geste parmi les quatre lentilles (Thom / Grothendieck / Schmidhuber / Friston)."
+   ]
+  },
   {
    "cell_type": "markdown",
    "id": "setup-md",
@@ -516,6 +528,16 @@
     "C'est précisément cette nuance — l'existence d'une dimension d'échelle dans l'IIT, sans prétendre que tout coarse-grain crée de l'emergence — qui distingue une démo méthodologique honnête d'une démonstration forcée.\n",
     "\n",
     "**Suite** : revoir [IIT-1-IntroToPyPhi](IIT-1-IntroToPyPhi.ipynb) §6 (macro-subsystems) et [IIT-2-AdvancedTopics](IIT-2-AdvancedTopics.ipynb) §7 (performance et coarse-graining comme stratégie de gestion de complexité)."
+   ]
+  },
+    {
+   "cell_type": "markdown",
+   "id": "ict-bridge-transition",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Où va la suite côté ICT.** Les calculs PyPhi s'arrêtent ici ; le fil ICT continue dans la documentation. Entrée recommandée : l'[index ICT](../../docs/ict/README.md) et ses distillations, en partant de [`dissolution-scalaires.md`](../../docs/ict/dissolution-scalaires.md) (le fil qui prolonge directement ce notebook) puis [`tresse-cartographie.md`](../../docs/ict/tresse-cartographie.md) (la carte des quatre lentilles)."
    ]
   },
   {

--- a/docs/ict/README.md
+++ b/docs/ict/README.md
@@ -50,6 +50,16 @@ Lectures *horizontales* : où les fils se rejoignent, s'éloignent, se mélangen
 - **Entrée par les jambes** (cadrage formel) : [`strate7-cadres-libres.md`](strate7-cadres-libres.md) (D1) → [`jambe-c4-propagation.md`](jambe-c4-propagation.md) (C4) → [`d1-c4-rencontre-meta.md`](d1-c4-rencontre-meta.md) (leur articulation).
 - **Entrée par la carte** (vue d'ensemble) : [`tresse-cartographie.md`](tresse-cartographie.md) (la tresse) + [`dissociations-matrix.md`](dissociations-matrix.md) (la matrice 4-objets).
 
+## Entrée exécutable — la série IIT (PyPhi)
+
+Les documents ci-dessus sont au **grade C-documentaire** : ils *cadrent* et *cartographient*, ils ne calculent pas. Le pendant **exécutable** de cette mécanique vit dans la série **IIT** ([`MyIA.AI.Notebooks/IIT/`](../../MyIA.AI.Notebooks/IIT/)), où les instruments dont parlent les fils se calculent réellement avec PyPhi :
+
+- [`IIT-1-IntroToPyPhi.ipynb`](../../MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb) — le socle mécanique : Φ (petite *phi*) sur un réseau *toy*, mécanisme d'information minimale irréductible (MIP), cause-effect structure. Le Φ dont parle le [5ᵉ fil (dissolution des scalaires)](dissolution-scalaires.md) s'y calcule.
+- [`IIT-2-AdvancedTopics.ipynb`](../../MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb) — partitionnement (MIP/SIA), répertoires cause-effet d'un mécanisme, concepts (MICE/CES). La gymnastique qui rend la [matrice des dissociations](dissociations-matrix.md) lisible.
+- [`IIT-3-CoarseGrainingMacroPhi.ipynb`](../../MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb) — coarse-graining et survie de Φ au changement de résolution. **Le cas le plus net** : la mécanique de changement d'échelle dont relèvent directement la [dissolution des scalaires](dissolution-scalaires.md) et la [cartographie en tresse](tresse-cartographie.md).
+
+Entrer par **IIT-3** quand on vient du 5ᵉ fil ; par **IIT-1 / IIT-2** quand on cherche l'instrument avant la carte.
+
 ## État et provenance
 
 Tous les documents consolident un travail mené sur la série de notebooks ICT et les conversations de référence (cadrage stratégique 2026-07-19, tour 523 audit #4, tour 755 jambe C4 2026-07-20). Ils sont *postérieurs* aux livrables expérimentaux qu'ilscadrent — c'est ce timing (synthèse *après* les jambes) qui les rend lisibles. Aucun ne crée de nouvelle dépendance expérimentale ; ils ne dispatchent pas de nouveau notebook.


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: MED/lean

# docs(iit,#10246): pont narratif IIT ⇄ docs/ict — 3 notebooks orphelins du fil

## Quoi

Les 3 notebooks IIT ([IIT-1], [IIT-2], [IIT-3]) étaient orphelins du fil ICT : 2/1/0 mentions ICT respectivement, aucun lien vers les distillations `docs/ict/` qui pourtant parlent des mêmes instruments (Φ, partitionnement, coarse-graining). Cette PR pose le **pont bidirectionnel** :

- **amont** (cellule de *cadrage* après le titre) : ce que calcule ce notebook + le lien ICT correspondant ;
- **aval** (cellule de *transition* avant/après la conclusion) : où va la suite, avec lien relatif résolvant vers `docs/ict/*.md` ;
- **retour** : `docs/ict/README.md` cite les 3 notebooks comme **entrée exécutable** (pendant mécanique des 10 documents de grade C-documentaire).

[IIT-1]: ../../MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb
[IIT-2]: ../../MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb
[IIT-3]: ../../MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb

## Acceptance #10246 — vérifié firsthand

| Critère | Avant | Après | Verdict |
|---------|-------|-------|---------|
| Mentions ICT/notebook (≥4) | 2 / 1 / 0 | **7 / 4 / 5** | OK |
| ≥1 lien relatif `docs/ict/*.md` résolvant/notebook | 0/0/0 | 2/2/5 (5 cibles uniques existent) | OK |
| `docs/ict/README.md` cite les 3 notebooks | 0 mention IIT | section « Entrée exécutable » + 3 liens | OK |
| Prose FR spécifique au voisin (pas générique) | — | IIT-3 = coarse-graining ⇄ dissolution des scalaires (cas le plus net) | OK |
| **Aucune cellule code touchée** → 0 ré-exécution | — | code cells 15/19/8 inchangés | OK |

## Détail du ciblage (IIT-3 = le cas le plus net, cf. acceptance)

IIT-3 (coarse-graining ⇄ changement d'échelle) est explicitement relié à [`dissolution-scalaires.md`](../../docs/ict/dissolution-scalaires.md) (5ᵉ fil : ce qui arrive à Φ, F, K quand on change de strate) + [`tresse-cartographie.md`](../../docs/ict/tresse-cartographie.md) (les 4 lentilles). IIT-1 → `dissolution-scalaires.md` + `synthese-invariants-dissociations-obstructions.md` ; IIT-2 → `dissociations-matrix.md` + `tresse-cartographie.md`.

## Méthode — raw-text surgical splice (pas de json round-trip)

Insertion de cellules markdown **sans** `json.load → modify → dump` (règle `nbformat-reserialization-destroys-content`) : splice d'un fragment de cellule JSON dans le texte brut à une borne identifiée par le champ `id` unique. Validation post-splice par re-parse JSON (`json.loads`) → les 3 notebooks restent valides.

## Anti-régression & validation

- `git diff --stat` : **4 fichiers, +76 / −0** (additif pur, 0 suppression).
- Code cells par notebook **inchangés** (15 / 19 / 8) → diff markdown-only → **aucune ré-exécution due** (acceptance explicite de #10246).
- `check_docs_links.py --check` : exit 0, aucune de mes cibles cassée ; résolution on-disk des liens notebook→docs vérifiée.
- Catalogue **byte-identique à main** (cette PR ne touche que prose markdown).

## Variation

MED/notebook-python (pont narratif markdown-only, 0 ré-exec, mais change le sens de 3 notebooks en les ancrant dans leur fil théorique). prev MED/lean (#10243). G-VAR-1 (plancher MED tenu), G-VAR-3 OK (lean → notebook-python = genre distinct).

See #10246, #4588 (Epic ICT).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
