### PR TITLE
feat(genai,#10244): MiniMax H3 architecture+licensing notebook (descriptive, UE license gate)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-6-MiniMax-H3-Architecture-Licensing.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-6-MiniMax-H3-Architecture-Licensing.ipynb
@@ -1,0 +1,503 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "068dcdf2",
+   "metadata": {},
+   "source": [
+    "# MiniMax H3 (Hailuo 3.0) — Architecture, capacités… et licence géo-restreinte\n",
+    "\n",
+    "> **Verdict SOTA : INTRINSIC.** Ce notebook **n'exécute pas** le modèle MiniMax H3 et **n'affiche aucun Output généré**. La licence *MiniMax H3 Community License* interdit explicitement l'usage, l'hébergement **et l'affichage des Outputs** du modèle dans l'Union Européenne (territoire exclu). Nous étudions donc l'architecture du modèle et — surtout — la **décision de conformité** qu'impose une telle licence. Cette transparence est elle-même une compétence d'ingénierie ML.\n",
+    "\n",
+    "**Source officielle** : `MiniMax H3 COMMUNITY LICENSE AGREEMENT` (date de licence : 2 août 2026), déposée sur [HuggingFace `MiniMaxAI/MiniMax-H3`](https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/LICENSE). Code modèle : [GitHub `MiniMax-AI/MiniMax-H3`](https://github.com/MiniMax-AI/MiniMax-H3).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66d2480b",
+   "metadata": {},
+   "source": [
+    "## Le contexte : un « Sora at home » qui fait vibrer la communauté\n",
+    "\n",
+    "MiniMax H3 (aussi *Hailuo 3.0* / 海螺3), open-sourcé fin juillet / début août 2026, est arrivé **#1 du benchmark *Artificial Analysis* video editing** (Elo ~1130) au lancement. Sa promesse séduit : un modèle **omni-modal unifié** (texte, image, vidéo, audio en entrée) produisant de la vidéo jusqu'à **2K / 15 s / 24 fps** avec **audio stéréo natif** (32 kHz, 11 langues) — le tout en *open-weights*, donc en principe auto-hébergeable. C'est le « Sora at home » : la même ambition qu'OpenAI Sora, mais en poids téléchargeables plutôt qu'en API fermée.\n",
+    "\n",
+    "Ce notebook examine pourquoi, **pour notre contexte (France / UE, dépôt public, écoles partenaires)**, cette promesse se heurte à un obstacle qui n'est pas technique mais **juridique** — et comment raisonner sobrement cette décision de déploiement.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ebb793c9",
+   "metadata": {},
+   "source": [
+    "## Section 1 — La licence *MiniMax H3 Community License* : une restriction territoriale explicite\n",
+    "\n",
+    "Lisons les clauses pivots (verbatim, numérotation originale) :\n",
+    "\n",
+    "> **Art. I.5 — « Excluded Territories »** : *means the European Union, the United Kingdom, the Republic of Korea and the United States of America.*\n",
+    ">\n",
+    "> **Art. I.3 — « Applicable Territory »** : *means worldwide, excluding the Excluded Territories.*\n",
+    ">\n",
+    "> **Art. II — Grant of Rights** : *Solely within the Applicable Territory, we grant you a non-exclusive, non-transferable, royalty-free, limited license to use, reproduce, distribute, create derivative works […] and modify the Materials […].* **Aucune exception pour l'éducation, la recherche ou un usage non-commercial** n'est prévue.\n",
+    ">\n",
+    "> **Art. V.4 — Use Restrictions** : *You may not use, reproduce, modify, distribute, or display the MiniMax H3 Works **or any of their Outputs or results** outside the Applicable Territory. Any such use outside the Applicable Territory is not authorized by this Agreement.*\n",
+    ">\n",
+    "> **Exhibit A.1** (Acceptable Use Policy, première utilisation interdite) : *Use outside the Applicable Territory.*\n",
+    "\n",
+    "Deux points sont souvent mal compris et méritent d'être soulignés :\n",
+    "\n",
+    "1. **Les *Outputs* sont couverts, pas seulement les poids.** Même en appelant l'API cloud MiniMax depuis l'UE (un *Hosted Service* au sens de l'Art. I.8), afficher ou redistribuer la vidéo générée dans l'UE est un usage *outside the Applicable Territory* → non autorisé. L'argument « on n'héberge pas les poids, on appelle juste l'API » **ne tient pas**.\n",
+    "2. **L'« open-weights » n'est pas le « open source ».** Les poids sont téléchargeables, mais sous une licence propriétaire à restriction territoriale — l'opposé d'une licence OSI. Confondre les deux est une erreur classique de mise en production.\n",
+    "\n",
+    "La seule voie vers un usage UE est une **licence commerciale séparée** (Art. II, dernier § : *« you are welcome to contact us about obtaining a license »*) — une démarche *provider-side* qui dépend de MiniMax (Nanonoble Pte. Ltd.), pas de l'utilisateur.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "342fb707",
+   "metadata": {},
+   "source": [
+    "## Section 2 — Vérificateur de juridiction : coder la conformité\n",
+    "\n",
+    "Plutôt qu'un discours, codons le raisonnement. La fonction suivante **parse la clause *Excluded Territories*** et décide, pour une localisation de déploiement donnée, si l'usage de MiniMax H3 y est autorisé. Ce code tourne localement (aucun appel au modèle) — il analyse le texte de licence, pas le modèle.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4521098c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T23:54:46.669315Z",
+     "iopub.status.busy": "2026-08-09T23:54:46.669149Z",
+     "iopub.status.idle": "2026-08-09T23:54:46.677257Z",
+     "shell.execute_reply": "2026-08-09T23:54:46.676725Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "France (user + ecoles EPITA/ECE/ESGF/EPF) (FR) : EXCLUDED (European Union) — usage NON autorise, licence commerciale requise\n",
+      "Allemagne (DE) : EXCLUDED (European Union) — usage NON autorise, licence commerciale requise\n",
+      "Royaume-Uni (GB) : EXCLUDED (United Kingdom) — usage NON autorise, licence commerciale requise\n",
+      "Etats-Unis (US) : EXCLUDED (United States of America) — usage NON autorise, licence commerciale requise\n",
+      "Coree du Sud (KR) : EXCLUDED (Republic of Korea) — usage NON autorise, licence commerciale requise\n",
+      "Chine (CN) : Applicable Territory — usage autorise sous la Community License\n",
+      "Japon (JP) : Applicable Territory — usage autorise sous la Community License\n",
+      "Bresil (BR) : Applicable Territory — usage autorise sous la Community License\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Excluded Territories au sens de l'Art. I.5 (verbatim license).\n",
+    "# Couverture par code pays / région ISO, pour le raisonnement de conformité.\n",
+    "EXCLUDED_TERRITORIES = {\n",
+    "    \"European Union\": {\n",
+    "        \"AT\", \"BE\", \"BG\", \"HR\", \"CY\", \"CZ\", \"DK\", \"EE\", \"FI\", \"FR\", \"DE\", \"GR\",\n",
+    "        \"HU\", \"IE\", \"IT\", \"LV\", \"LT\", \"LU\", \"MT\", \"NL\", \"PL\", \"PT\", \"RO\", \"SK\",\n",
+    "        \"SI\", \"ES\", \"SE\",\n",
+    "    },\n",
+    "    \"United Kingdom\": {\"GB\"},\n",
+    "    \"Republic of Korea\": {\"KR\"},\n",
+    "    \"United States of America\": {\"US\"},\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def is_applicable_territory(country_code: str) -> bool:\n",
+    "    \"\"\"True si country_code (ISO-3166 alpha-2) est dans l'Applicable Territory.\n",
+    "\n",
+    "    L'Applicable Territory = monde entier hors Excluded Territories (Art. I.3).\n",
+    "    \"\"\"\n",
+    "    cc = country_code.upper()\n",
+    "    for states in EXCLUDED_TERRITORIES.values():\n",
+    "        if cc in states:\n",
+    "            return False\n",
+    "    return True\n",
+    "\n",
+    "\n",
+    "def deployment_verdict(country_code: str, label: str = \"\") -> str:\n",
+    "    \"\"\"Rend un verdict lisible pour un déploiement envisagé dans country_code.\"\"\"\n",
+    "    ok = is_applicable_territory(country_code)\n",
+    "    where = label or country_code\n",
+    "    if ok:\n",
+    "        return f\"{where} ({country_code}) : Applicable Territory — usage autorise sous la Community License\"\n",
+    "    # identifier quel territoire exclu\n",
+    "    for name, states in EXCLUDED_TERRITORIES.items():\n",
+    "        if country_code.upper() in states:\n",
+    "            return f\"{where} ({country_code}) : EXCLUDED ({name}) — usage NON autorise, licence commerciale requise\"\n",
+    "    return f\"{where} ({country_code}) : indetermine\"\n",
+    "\n",
+    "\n",
+    "# --- Verdicts pour nos contextes reels ---\n",
+    "contextes = [\n",
+    "    (\"FR\", \"France (user + ecoles EPITA/ECE/ESGF/EPF)\"),\n",
+    "    (\"DE\", \"Allemagne\"),\n",
+    "    (\"GB\", \"Royaume-Uni\"),\n",
+    "    (\"US\", \"Etats-Unis\"),\n",
+    "    (\"KR\", \"Coree du Sud\"),\n",
+    "    (\"CN\", \"Chine\"),\n",
+    "    (\"JP\", \"Japon\"),\n",
+    "    (\"BR\", \"Bresil\"),\n",
+    "]\n",
+    "for cc, label in contextes:\n",
+    "    print(deployment_verdict(cc, label))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d82b7ad5",
+   "metadata": {},
+   "source": [
+    "## Section 3 — Architecture : ce qui fait la force du modèle (et que nous ne pouvons pas exercer ici)\n",
+    "\n",
+    "Bien que nous ne puissions pas exécuter H3, comprendre son architecture est légitime et précieux. Le dépôt [`MiniMax-AI/MiniMax-H3`](https://github.com/MiniMax-AI/MiniMax-H3) révèle les composants clés :\n",
+    "\n",
+    "| Composant (dépôt) | Rôle | Détail technique |\n",
+    "|---|---|---|\n",
+    "| **`FL2VA`** | *Flow-Language-to-Video-Audio* — le cœur omni-modal | Encode unifie texte/image/vidéo/audio en entrée vers une représentation latente partagée |\n",
+    "| **`Ref2VA`** | *Reference-to-Video-Audio* | Gère les références multiples (first+last frame, omni-reference) pour l'édition instructionnelle |\n",
+    "| **`transformer`** / **`transformer_ref`** | Backbone de débruitage diffusif | Le transformeur principal + la branche de conditionnement par référence |\n",
+    "| **`vae`** | *Variational Autoencoder* vidéo | Compresse les pixels vidéo vers l'espace latent (jusqu'à 2K) |\n",
+    "| **`audio_vae`** + **`audio_scheduler`** | **Audio stéréo natif** | La différence distinctive : génère l'audio synchronisé (32 kHz, 11 langues) *en même temps* que la vidéo, pas en pass séparé |\n",
+    "| **`text_encoder`** + **`tokenizer`** | Encodage du prompt | Le `processor` orchestre l'entrée omni-modale |\n",
+    "| **`scheduler`** | Planificateur de diffusion | Contrôle le nombre de pas de débruitage |\n",
+    "\n",
+    "**Point de licence notable** (Additional Note du LICENSE) : l'encodeur de H3 utilise **Qwen3-VL-32B**, lui-même sous **Apache 2.0** (une licence réellement ouverte, sans restriction territoriale). Mais cet encodeur est un *constituant* de H3 — l'assemblage complet reste sous la Community License géo-restreinte. On ne peut pas « récupérer juste l'encodeur Apache » pour contourner la restriction : le modèle intégré est un *Material* couvert par l'Accord.\n",
+    "\n",
+    "**Pourquoi c'est un excellent cas pédagogique** : H3 combine une capacité absente de nos autres notebooks (vidéo 2K **+ audio natif synchronisé** dans un seul modèle omni-modal) — exactement le genre de prouesse technique qu'un cours SOTA voudrait montrer. La licence nous oblige à le faire *différemment* : par l'analyse, pas l'exécution.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "610790bf",
+   "metadata": {},
+   "source": [
+    "## Section 4 — Matrice de décision : H3 vs ses alternatives\n",
+    "\n",
+    "Face à une licence géo-restreinte, la compétence clé est de **raisonner en alternatives**. Le code suivant construit une matrice comparant MiniMax H3 aux autres modèles vidéo de la série (et à Sora), pour aider à décider quoi utiliser selon la juridiction.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3a5172c7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T23:54:46.679371Z",
+     "iopub.status.busy": "2026-08-09T23:54:46.679190Z",
+     "iopub.status.idle": "2026-08-09T23:54:46.684997Z",
+     "shell.execute_reply": "2026-08-09T23:54:46.684398Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Modeles utilisables en UE (pas de restriction territoriale UE) ===\n",
+      "  - Wan 2.1/2.2      | Apache 2.0 (permissive)\n",
+      "  - HunyuanVideo     | Tencent Community License (permissive UE)\n",
+      "  - LTX-2            | LTX-2 Community License (permissive UE)\n",
+      "  - OpenAI Sora      | API fermee (ToS OpenAI)\n",
+      "\n",
+      "=== Modeles avec audio natif synchronise ===\n",
+      "  MiniMax H3, LTX-2, OpenAI Sora\n",
+      "\n",
+      "=== Alternatives UE a H3 pour le cas 'video + audio natif' ===\n",
+      "  - LTX-2            | res 1080p | notebook 02-5 (executable, audiovisuel conjoint)\n",
+      "  - OpenAI Sora      | res 1080p | notebook 04-3 (API cloud, sous quota/cout)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Matrice de decision : modeles video de la serie + Sora, selon 5 axes de conformite/usage.\n",
+    "# 'geo_restricted' = True si la licence exclut des territoires (UE en particulier).\n",
+    "MODELES = [\n",
+    "    {\n",
+    "        \"nom\": \"MiniMax H3\",\n",
+    "        \"open_weights\": True,\n",
+    "        \"geo_restricted_ue\": True,\n",
+    "        \"audio_natif\": True,\n",
+    "        \"resolution_max\": \"2K\",\n",
+    "        \"notebook_series\": \"02-6 (ce notebook, descriptif)\",\n",
+    "        \"licence\": \"MiniMax H3 Community License (UE exclue)\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"nom\": \"Wan 2.1/2.2\",\n",
+    "        \"open_weights\": True,\n",
+    "        \"geo_restricted_ue\": False,\n",
+    "        \"audio_natif\": False,\n",
+    "        \"resolution_max\": \"1080p\",\n",
+    "        \"notebook_series\": \"02-3 (executable localement)\",\n",
+    "        \"licence\": \"Apache 2.0 (permissive)\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"nom\": \"HunyuanVideo\",\n",
+    "        \"open_weights\": True,\n",
+    "        \"geo_restricted_ue\": False,\n",
+    "        \"audio_natif\": False,\n",
+    "        \"resolution_max\": \"1080p\",\n",
+    "        \"notebook_series\": \"02-1 (executable localement)\",\n",
+    "        \"licence\": \"Tencent Community License (permissive UE)\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"nom\": \"LTX-2\",\n",
+    "        \"open_weights\": True,\n",
+    "        \"geo_restricted_ue\": False,\n",
+    "        \"audio_natif\": True,\n",
+    "        \"resolution_max\": \"1080p\",\n",
+    "        \"notebook_series\": \"02-5 (executable, audiovisuel conjoint)\",\n",
+    "        \"licence\": \"LTX-2 Community License (permissive UE)\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"nom\": \"OpenAI Sora\",\n",
+    "        \"open_weights\": False,\n",
+    "        \"geo_restricted_ue\": False,\n",
+    "        \"audio_natif\": True,\n",
+    "        \"resolution_max\": \"1080p\",\n",
+    "        \"notebook_series\": \"04-3 (API cloud, sous quota/cout)\",\n",
+    "        \"licence\": \"API fermee (ToS OpenAI)\",\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "\n",
+    "def utilisables_en_ue(modeles):\n",
+    "    \"\"\"Filtre les models utilisables en UE (non geo-restreints UE).\"\"\"\n",
+    "    return [m for m in modeles if not m[\"geo_restricted_ue\"]]\n",
+    "\n",
+    "\n",
+    "def avec_audio_natif(modeles):\n",
+    "    \"\"\"Modeles offrant l'audio natif synchronise.\"\"\"\n",
+    "    return [m[\"nom\"] for m in modeles if m[\"audio_natif\"]]\n",
+    "\n",
+    "\n",
+    "print(\"=== Modeles utilisables en UE (pas de restriction territoriale UE) ===\")\n",
+    "for m in utilisables_en_ue(MODELES):\n",
+    "    print(f\"  - {m['nom']:<16} | {m['licence']}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"=== Modeles avec audio natif synchronise ===\")\n",
+    "print(\"  \" + \", \".join(avec_audio_natif(MODELES)))\n",
+    "\n",
+    "print()\n",
+    "print(\"=== Alternatives UE a H3 pour le cas 'video + audio natif' ===\")\n",
+    "# H3 est exclus: on cherche les modeles utilisables en UE AVEC audio natif.\n",
+    "alt = [m for m in utilisables_en_ue(MODELES) if m[\"audio_natif\"]]\n",
+    "for m in alt:\n",
+    "    print(f\"  - {m['nom']:<16} | res {m['resolution_max']} | notebook {m['notebook_series']}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b5e561c",
+   "metadata": {},
+   "source": [
+    "## Section 5 — Cadre de décision : « puis-je légalement déployer ce modèle ici ? »\n",
+    "\n",
+    "MiniMax H3 illustre un cadre de raisonnement général, utile pour **tout** modèle qu'on envisage d'intégrer en production ou en enseignement :\n",
+    "\n",
+    "1. **Lire la licence à la source** (pas un résumé secondaire). Ici, le `LICENSE` brut HuggingFace — pas un article de blog.\n",
+    "2. **Identifier les restrictions structurelles** : territoriales (H3), de revenu commercial (H3 Art. IV : seuil 20 M$), d'usage (Exhibit A : pas de military, pas de désinformation, etc.).\n",
+    "3. **Vérifier la portée** : la restriction couvre-t-elle seulement les poids, ou aussi les *Outputs* et les *Hosted Services* ? (H3 : les trois.)\n",
+    "4. **Croiser avec son contexte** : juridiction (France = UE), public (ici : dépôt public + écoles = large diffusion), usage (commercial vs éducatif — mais H3 n'exempte pas l'éducatif).\n",
+    "5. **Décider entre** : (a) obtenir une licence commerciale, (b) usage descriptif/analytique sans exécuter ni afficher d'Outputs, (c) choisir une alternative permissive.\n",
+    "\n",
+    "Ce notebook incarne l'option **(b)** appliquée à l'enseignement : étudier le modèle sans l'exécuter. C'est honnête (verdict INTRINSIC documenté, pas de contournement) et pédagogiquement riche (la décision de conformité *est* la leçon).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15991a46",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les trois exercices suivants s'exercent sur la **décision de conformité** — la compétence distinctive de ce notebook. Aucun n'exécute le modèle (la licence l'interdit). Complétez les stubs.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0eab69f7",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Étendre le vérificateur aux *Hosted Services* (API)\n",
+    "\n",
+    "La licence couvre aussi l'usage via API (Art. I.8 *Hosted Services*). Écrivez `can_call_api(country_code, provider_region)` qui renvoie `False` si **soit** le pays de l'appelant, **soit** la région du provider est un territoire exclu — car l'Output serait consommé/affiché dans un territoire exclu.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9e7f9d75",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T23:54:46.687375Z",
+     "iopub.status.busy": "2026-08-09T23:54:46.687121Z",
+     "iopub.status.idle": "2026-08-09T23:54:46.690582Z",
+     "shell.execute_reply": "2026-08-09T23:54:46.689969Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def can_call_api(country_code: str, provider_region: str) -> bool:\n",
+    "    \"\"\"True si un appel API MiniMax H3 est autorise pour cet appelant + ce provider.\n",
+    "\n",
+    "    Rappel (Art. V.4) : les Outputs ne peuvent etre ni utilises ni affiches hors\n",
+    "    Applicable Territory. Donc l'appel est bloque des que l'appelant OU le provider\n",
+    "    est en territoire exclu.\n",
+    "    \"\"\"\n",
+    "    # Indice : reutilisez is_applicable_territory(country_code) definie plus haut.\n",
+    "    # Etape 1 : verifier country_code (ou l'appelant consomme l'Output).\n",
+    "    # Etape 2 : verifier provider_region (ou l'Output est produit/affiche).\n",
+    "    # Etape 3 : retourner True seulement si les DEUX sont dans l'Applicable Territory.\n",
+    "    return None  # TODO etudiant\n",
+    "\n",
+    "\n",
+    "# Test rapide (a decommenter) :\n",
+    "# print(can_call_api(\"FR\", \"CN\"))   # attendu : False (FR = UE exclue)\n",
+    "# print(can_call_api(\"JP\", \"CN\"))   # attendu : True (les deux applicables)\n",
+    "# print(can_call_api(\"JP\", \"US\"))   # attendu : False (US exclue)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d86b702",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Sélectionneur de modèle conforme\n",
+    "\n",
+    "Écrivez `choisir_modele_conforme(exigences)` qui, étant donné un dictionnaire d'exigences (pays, `audio_natif` booléen, `open_weights` booléen), renvoie la **liste** des modèles de `MODELES` qui satisfont **toutes** les contraintes — typiquement pour recommander une alternative UE à H3.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a79619eb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T23:54:46.692858Z",
+     "iopub.status.busy": "2026-08-09T23:54:46.692407Z",
+     "iopub.status.idle": "2026-08-09T23:54:46.696095Z",
+     "shell.execute_reply": "2026-08-09T23:54:46.695440Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def choisir_modele_conforme(exigences: dict) -> list:\n",
+    "    \"\"\"Renvoie les modeles de MODELES satisfaisant toutes les exigences.\n",
+    "\n",
+    "    exigences cles possibles :\n",
+    "      - 'pays' (ISO alpha-2) : le modele doit etre utilisable dans ce pays\n",
+    "      - 'audio_natif' (bool) : le modele doit (ou non) offrir l'audio natif\n",
+    "      - 'open_weights' (bool) : le modele doit (ou non) etre open-weights\n",
+    "    \"\"\"\n",
+    "    # Indice : filtrez MODELES en cumulatif. Pour 'pays', ecartez les\n",
+    "    # geo-restreints UE si le pays est dans l'UE (is_applicable_territory == False).\n",
+    "    resultats = []\n",
+    "    # TODO etudiant\n",
+    "    return resultats\n",
+    "\n",
+    "\n",
+    "# Test rapide (a decommenter) :\n",
+    "# besoin = {\"pays\": \"FR\", \"audio_natif\": True, \"open_weights\": True}\n",
+    "# for m in choisir_modele_conforme(besoin):\n",
+    "#     print(f\"  conforme : {m['nom']}\")\n",
+    "# # attendu : LTX-2 (UE-ok, audio natif, open-weights). H3 exclu (UE), Sora exclu (pas open-weights).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e7b339a",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Détecteur de clause de territorialité dans une licence arbitraire\n",
+    "\n",
+    "Écrivez `detecte_restriction_territoriale(texte_licence)` qui prend le texte brut d'une licence et renvoie la liste des noms de pays/régions mentionnés dans une clause d'exclusion géographique (regardez les motifs comme *« excluding »*, *« Excluded Territories »*, *« not permitted in »*). Ceci généralise le raisonnement au-delà de H3.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "361f977c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-09T23:54:46.697961Z",
+     "iopub.status.busy": "2026-08-09T23:54:46.697778Z",
+     "iopub.status.idle": "2026-08-09T23:54:46.701131Z",
+     "shell.execute_reply": "2026-08-09T23:54:46.700613Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def detecte_restriction_territoriale(texte_licence: str) -> list:\n",
+    "    \"\"\"Renvoie les entites geographiques citees dans une clause d'exclusion.\n",
+    "\n",
+    "    Recherche des amorces de clause ('excluding', 'Excluded Territories',\n",
+    "    'not permitted in', 'not authorized in') puis extrait les noms de pays/regions\n",
+    "    connus qui suivent.\n",
+    "    \"\"\"\n",
+    "    entites_connues = [\n",
+    "        \"European Union\", \"United Kingdom\", \"United States\", \"United States of America\",\n",
+    "        \"Republic of Korea\", \"China\", \"Japan\", \"France\", \"Germany\", \"Brazil\",\n",
+    "    ]\n",
+    "    trouvees = []\n",
+    "    # Indice : pour chaque entite connue, verifier si elle apparait dans le texte\n",
+    "    # A PROXIMITE d'une amorce de clause d'exclusion (pas n'importe ou : une licence\n",
+    "    # peut citer un pays pour d'autres raisons). Une approche simple : chercher\n",
+    "    # l'amorce, puis scanner les N caracteres qui suivent.\n",
+    "    # TODO etudiant\n",
+    "    return trouvees\n",
+    "\n",
+    "\n",
+    "# Test rapide (a decommenter) avec un extrait de la licence H3 :\n",
+    "# extrait = '''\"Excluded Territories\" means the European Union, the United Kingdom,\n",
+    "# the Republic of Korea and the United States of America.'''\n",
+    "# print(detecte_restriction_territoriale(extrait))\n",
+    "# # attendu : les 4 territoires exclus\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d861ba1",
+   "metadata": {},
+   "source": [
+    "## Conclusion — transparence et conformité comme compétences\n",
+    "\n",
+    "MiniMax H3 est techniquement remarquable (#1 video editing, omni-modal, audio natif). Mais **sa licence l'exclut de notre juridiction** (UE), et cette exclusion couvre les poids **comme les Outputs**. Ce notebook a choisi la voie honnête : **documenter et raisonner, pas exécuter ni contourner** (verdict INTRINSIC, [sota-not-workaround](https://github.com/jsboige/CoursIA/blob/main/.claude/rules/sota-not-workaround.md)).\n",
+    "\n",
+    "Trois leçons à retenir :\n",
+    "\n",
+    "1. **Open-weights ≠ open-source ≠ libre d'usage partout.** Toujours lire la licence à la source et identifier les restrictions structurelles (territoriales, commerciales, d'usage).\n",
+    "2. **La portée compte autant que l'octroi.** Une licence peut autoriser un usage mais en restreindre l'affichage, la redistribution, ou les Outputs — comme H3.\n",
+    "3. **La conformité est une décision de conception, pas une après-pensée.** Choisir tôt entre (a) licence commerciale, (b) usage descriptif, (c) alternative permissive — c'est ce qu'on fait ici avec (b).\n",
+    "\n",
+    "**État réversible** : si une licence commerciale UE est obtenue auprès de MiniMax (option A), ce notebook évoluera vers une exécution locale réelle (ComfyUI workflow + VRAM mesurée, comme `02-3-Wan`). En attendant, l'alternative UE pédagogiquement équivalente pour « vidéo + audio natif » est **LTX-2** (`02-5-LTX2-Audiovisual`, licence permissive, exécutable).\n",
+    "\n",
+    "---\n",
+    "*Note : ce notebook n'embarque aucun poids, n'appelle aucune API MiniMax, et n'affiche aucun Output généré par H3 — conformément à l'Art. V.4 de la licence. Le code présent analyse le texte de licence et raisonne sur la conformité ; ses sorties sont produites localement par ce raisonnement, pas par le modèle.*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/Video/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/README.md
@@ -71,7 +71,7 @@ On ne peut pas créer ce qu'on ne comprend pas. Ce niveau pose les bases techniq
 
 ### 02-Advanced - Générer du mouvement à partir de texte ou d'images
 
-Ce niveau explore les modèles génératifs vidéo : HunyuanVideo pour la qualité cinématographique (malgré ses 24 GB de VRAM), LTX-Video pour la génération rapide sur des configurations modestes, Wan pour les prompts multilingues, et Stable Video Diffusion pour animer une image existante. Chaque modèle a ses forces et ses limites — le but est de les connaître pour choisir le bon outil au bon moment. Le notebook 02-5 introduit en outre LTX-2 (Lightricks 22B), le seul modèle de la série qui génère vidéo **et audio synchronisés** en une seule passe de diffusion (quantization obligatoire : `fp8-cast` via ltx-pipelines — borderline sur 24 GB — ou GGUF Q4 via ComfyUI en production, ~14-24 GB VRAM).
+Ce niveau explore les modèles génératifs vidéo : HunyuanVideo pour la qualité cinématographique (malgré ses 24 GB de VRAM), LTX-Video pour la génération rapide sur des configurations modestes, Wan pour les prompts multilingues, et Stable Video Diffusion pour animer une image existante. Chaque modèle a ses forces et ses limites — le but est de les connaître pour choisir le bon outil au bon moment. Le notebook 02-5 introduit en outre LTX-2 (Lightricks 22B), le seul modèle de la série qui génère vidéo **et audio synchronisés** en une seule passe de diffusion (quantization obligatoire : `fp8-cast` via ltx-pipelines — borderline sur 24 GB — ou GGUF Q4 via ComfyUI en production, ~14-24 GB VRAM). Le notebook 02-6 traite **MiniMax H3 (Hailuo 3.0)**, modèle omni-modal #1 au benchmark *Artificial Analysis* — mais dont la licence communautaire **exclut l'UE** (territoires exclus : UE, Royaume-Uni, Corée du Sud, États-Unis). Ce notebook est **descriptif** : il n'exécute pas le modèle (interdit par licence) mais enseigne l'architecture et, surtout, le **raisonnement de conformité** (vérificateur de juridiction, matrice de décision, alternatives UE). La licence géo-restreinte comme angle pédagogique.
 
 <p align="center">
   <a href="02-Advanced/02-4-SVD-Image-to-Video.ipynb"><img src="assets/readme/video-svd.png" width="540" alt="« Images de test pour SVD » — 3 vignettes côte-à-côte servant d'inputs pour Stable Video Diffusion (Paysage avec montagnes / Silhouette portrait / Coucher de soleil sur l'eau), pas une sortie SVD."></a><br>
@@ -85,6 +85,7 @@ Ce niveau explore les modèles génératifs vidéo : HunyuanVideo pour la qualit
 | [02-3-Wan-Video-Generation](02-Advanced/02-3-Wan-Video-Generation.ipynb) | Wan 2.1/2.2, prompts FR/EN | Local GPU | ~10 GB |
 | [02-4-SVD-Image-to-Video](02-Advanced/02-4-SVD-Image-to-Video.ipynb) | Stable Video Diffusion, animation | Local GPU | ~10 GB |
 | [02-5-LTX2-Audiovisual](02-Advanced/02-5-LTX2-Audiovisual.ipynb) | LTX-2 (Lightricks 22B), vidéo + audio conjoint | Local GPU | ~16-24 GB |
+| [02-6-MiniMax-H3-Architecture-Licensing](02-Advanced/02-6-MiniMax-H3-Architecture-Licensing.ipynb) | MiniMax H3 (descriptif), licence + conformité UE | Local (analyse) | 0 |
 
 ### 03-Orchestration - Combiner les modèles dans des pipelines
 
@@ -123,7 +124,7 @@ Le fil rouge de cette série est la création d'un pipeline de vidéo pédagogiq
 
 1. **01-Foundation** (compréhension vidéo) : [01-1](01-Foundation/01-1-Video-Operations-Basics.ipynb) donne les bases techniques (ffmpeg, moviepy). [01-2](01-Foundation/01-2-GPT-5-Video-Understanding.ipynb) et [01-3](01-Foundation/01-3-Qwen-VL-Video-Analysis.ipynb) couvrent la compréhension vidéo (décomposition en scènes, Q&A). [01-4](01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb) améliore la qualité. À la fin, vous savez analyser et manipuler une vidéo existante.
 
-2. **02-Advanced** (génération vidéo) : [02-1](02-Advanced/02-1-HunyuanVideo-Generation.ipynb) génère des vidéos haute qualité. [02-3](02-Advanced/02-3-Wan-Video-Generation.ipynb) offre une alternative rapide avec support multilingue. [02-4](02-Advanced/02-4-SVD-Image-to-Video.ipynb) anime une image existante (utile pour transformer un diagramme en animation). [02-5](02-Advanced/02-5-LTX2-Audiovisual.ipynb) est le seul à produire vidéo **et audio synchronisés** en une passe (LTX-2 22B, le plus exigeant en VRAM).
+2. **02-Advanced** (génération vidéo) : [02-1](02-Advanced/02-1-HunyuanVideo-Generation.ipynb) génère des vidéos haute qualité. [02-3](02-Advanced/02-3-Wan-Video-Generation.ipynb) offre une alternative rapide avec support multilingue. [02-4](02-Advanced/02-4-SVD-Image-to-Video.ipynb) anime une image existante (utile pour transformer un diagramme en animation). [02-5](02-Advanced/02-5-LTX2-Audiovisual.ipynb) est le seul à produire vidéo **et audio synchronisés** en une passe (LTX-2 22B, le plus exigeant en VRAM). [02-6](02-Advanced/02-6-MiniMax-H3-Architecture-Licensing.ipynb) étudie MiniMax H3 (modèle omni-modal #1) sous l'angle de sa **licence géo-restreinte** — un cas d'école de conformité : pourquoi ce modèle ne peut pas être exécuté en UE et comment raisonner la décision de déploiement.
 
 3. **03-Orchestration** (assemblage) : [03-1](03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb) compare les modèles pour choisir le bon. [03-2](03-Orchestration/03-2-Video-Workflow-Orchestration.ipynb) construit le pipeline text-to-image-to-video. [03-3](03-Orchestration/03-3-ComfyUI-Video-Workflows.ipynb) utilise ComfyUI pour des workflows natifs.
 
@@ -143,6 +144,7 @@ flowchart TD
         B2["02-3 Wan : rapide, multilingue"]
         B3["02-4 SVD : animer une image"]
         B4["02-5 LTX-2 : vidéo + audio conjoints"]
+        B5["02-6 MiniMax H3 : licence + conformité UE"]
     end
     subgraph N3["3 · Orchestrer — 03-Orchestration"]
         C1["03-1 : comparer les modèles"]
@@ -180,6 +182,7 @@ flowchart TD
 | **Wan 2.1/2.2** | 02-3 | GPU ~10 GB VRAM |
 | **SVD** | 02-4 | GPU ~10 GB VRAM |
 | **LTX-2 (Lightricks)** | 02-5 | GPU ~14-24 GB VRAM (GGUF Q4 / fp8-cast) |
+| **MiniMax H3 (Hailuo 3.0)** | 02-6 | Descriptif — licence exclut l'UE (pas d'exécution) |
 | **ComfyUI Video** | 03-3 | Docker, nodes vidéo |
 | **OpenAI Sora 2** | 04-3 | `OPENAI_API_KEY` |
 
@@ -188,7 +191,7 @@ flowchart TD
 | Objectif | Notebooks |
 |----------|-----------|
 | Découverte rapide | 01-1, 01-2, 01-5 |
-| Génération vidéo | 01-5, 02-1 à 02-5 |
+| Génération vidéo | 01-5, 02-1 à 02-6 |
 | Compréhension vidéo | 01-2, 01-3 |
 | Production complète | Tous + Audio/04-4 (sync A/V) |
 
@@ -233,6 +236,10 @@ ffmpeg_path = imageio_ffmpeg.get_ffmpeg_exe()
 | **Latence** | 30s-2min | 1-5min | 30s-2min | 10-30s |
 
 Pour du prototypage ou des résultats rapides, Sora 2 (notebook [04-3](04-Applications/04-3-Sora-API-Cloud-Video.ipynb)) est idéal. Pour un contrôle fin, une production répétitive, ou des données sensibles, les modèles locaux sont indispensables.
+
+### Pourquoi le notebook MiniMax H3 (02-6) n'exécute-t-il pas le modèle ?
+
+MiniMax H3 (Hailuo 3.0) est techniquement excellent (#1 video editing au benchmark *Artificial Analysis*, omni-modal, audio natif), mais sa **licence communautaire exclut l'UE, le Royaume-Uni, la Corée du Sud et les États-Unis** des territoires autorisés. Cette restriction couvre les poids **et les Outputs** générés (y compris via l'API cloud). Aucune exception éducation/recherche n'est prévue. Le notebook [02-6](02-Advanced/02-6-MiniMax-H3-Architecture-Licensing.ipynb) choisit donc la voie conforme : **étude descriptive** de l'architecture + raisonnement de conformité (vérificateur de juridiction, matrice de décision, alternatives UE), sans exécuter ni afficher d'Outputs. L'alternative UE pédagogiquement équivalente pour « vidéo + audio natif » est **LTX-2** (notebook [02-5](02-Advanced/02-5-LTX2-Audiovisual.ipynb), licence permissive, exécutable).
 
 ### Les vidéos générées manquent de cohérence temporelle
 


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: DEEP/forensic #10242

## Quoi

Nouveau notebook `02-6-MiniMax-H3-Architecture-Licensing.ipynb` dans `MyIA.AI.Notebooks/GenAI/Video/02-Advanced/`. P0 dispatch #10244 (po-2024, demande user : intégrer MiniMax H3 au cursus GenAI/Video), **option (B) appliquée par défaut réversible** sur recommandation **po-2024** (commentaire #10244 2026-08-09T23:22Z, sous le compte GitHub partagé `jsboige`) — **le user n'a PAS explicitement tranché (A)/(B)/(C)** ; (B) = interprétation raisonnable en mode non-supervisé (CLAUDE.md principe 1, réversible/conservateur, 0 violation de licence), **en attente de décision user explicite**. Notebook **descriptif pédagogique** qui n'exécute pas le modèle.

> **Correction d'attribution (po-2024 review c.78, G.9)** : une version antérieure de ce §Quoi attribuait à tort le commentaire 23:22Z au « user ». Ce commentaire est de po-2024 (compte GitHub partagé), pas du user humain. La substance du notebook et le verdict INTRINSIC ne sont pas contestés ; seule la provenance de la décision (B) est corrigée ici. See commentaire merge-gate ci-dessous.

**Pourquoi pas d'exécution — verdict SOTA INTRINSIC** (documenté honnêtement, [sota-not-workaround](https://github.com/jsboige/CoursIA/blob/main/.claude/rules/sota-not-workaround.md)) : la *MiniMax H3 Community License* exclut l'UE/UK/Corée/USA des territoires autorisés (Art. I.5 *Excluded Territories*, Art. I.3 *Applicable Territory*, Art. II grant *Solely within the Applicable Territory*). L'Art. V.4 couvre **explicitement les Outputs** (« *You may not use, reproduce, modify, distribute, or display the MiniMax H3 Works or any of their Outputs or results outside the Applicable Territory* ») — donc même un appel API cloud puis affichage en UE est interdit. **Aucune exception éducation/recherche/NC**. Vérifié verbatim via la LICENSE source HuggingFace (`MiniMaxAI/MiniMax-H3/blob/main/LICENSE`).

L'angle pédagogique retenu : **la conformité licence comme compétence**. Le notebook étudie l'architecture (FL2VA/Ref2VA/transformer/audio_vae + encodeur Qwen3-VL-32B Apache) et raisonne la décision de déploiement.

## Preuve

**C.1 (pas d'erreur volontaire)** : 5 cellules code, 0 `raise NotImplementedError`/`assert False`/`1/0` (vérifié grep). 3 exercices = stubs conformes (`return None`, listes vides, TODO étudiant).

**C.2 (outputs réels)** : notebook exécuté localement kernel `python3` via `jupyter nbconvert --execute`. Les cellules non-exercice produisent des sorties réelles :
- Vérificateur de juridiction : FR/DE/GB/US/KR → `EXCLUDED`, CN/JP/BR → `Applicable Territory`.
- Matrice de décision : alternatives UE à H3 pour « vidéo + audio natif » → LTX-2 (02-5) est l'alternative exécutable.
- `execution_count` 1-5 sur les 5 cellules.

**Conformité licence** : le notebook n'embarque aucun poids, n'appelle aucune API MiniMax, n'affiche aucun Output H3 — vérifié (0 `diffusers`/`from_pretrained`/`requests.post`/`minimax.io` dans le code). Le code présent analyse le **texte de licence** et raisonne sur la conformité ; ses sorties sont produites par ce raisonnement local, pas par le modèle.

**README §E (audit fichier-entier)** : prose reconciliée disque ↔ prose — tables listent désormais 18 notebooks (5+6+3+4) = disque (18). Intro 02-Advanced, table 02-Advanced, table Technologies, schéma mermaid N2 (B5), section recette, parcours recommandé, et nouvelle entrée FAQ « Pourquoi le notebook MiniMax H3 n'exécute-t-il pas le modèle ? » tous mis à jour. **`<!-- CATALOG-STATUS -->` laissé byte-identique** (catalog-pr-hygiene HARD 1 : artefact d'automatisation ; self-registers à 18 via CI `catalog-drift.yml` / cron `catalog-cron.yml`).

## Perimetre

2 fichiers, +513/−3. `02-6-MiniMax-H3-Architecture-Licensing.ipynb` (nouveau, 17 cellules : 12 markdown + 5 code) + `Video/README.md` (+10/−3). 0 poids, 0 output modèle, 0 catalogue regenerated.

**Réversible** : si user tranche (A) licence commerciale → on ajoute l'exécution locale (workflow ComfyUI + VRAM mesurée, miroir 02-3-Wan) ; si (C) abandon → on retire le notebook. En attendant, alternative UE pédagogiquement équivalente = LTX-2 (02-5).

See #10244 (contribution au dispatch, **gated sur décision user explicite A/B/C — ne ferme pas l'issue** ; (B) appliqué par défaut réversible en attente de tranche user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
