### PR TITLE
docs(causal-bridge): enrich do-calculus backdoor+frontdoor with 4 interpretation transition cells

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb
@@ -197,6 +197,20 @@
     "print(f\"Effet VRAI (connu) : 2.000\")"
    ]
   },
+    {
+   "cell_type": "markdown",
+   "id": "docalc-backdoor-trans1",
+   "metadata": {},
+   "source": [
+    "Le biais est net : l'effet **naïf** (~3,49) surévalue largement l'effet vrai (2,0) —\n",
+    "l'aptitude ouvre un chemin *backdoor* $T \\leftarrow U \\rightarrow Y$. Pour corriger,\n",
+    "il faut indiquer à `dowhy` la **structure causale** du problème. Le graphe ci-dessous\n",
+    "déclare nos connaissances ($U \\to T$, $T \\to Y$, $U \\to Y$) ; à partir de lui, `dowhy`\n",
+    "va **identifier lui-même** l'ensemble des variables à ajuster. C'est l'étape *identify*,\n",
+    "distincte de l'estimation : on ne dit pas *comment* ajuster, on dit *ce que l'on sait*\n",
+    "du mécanisme, et le moteur en déduit la stratégie d'identification."
+   ]
+  },
   {
    "cell_type": "code",
    "execution_count": 3,
@@ -259,6 +273,21 @@
     "model_bd = CausalModel(data=df_backdoor, treatment=\"college\", outcome=\"earnings\", graph=gml_backdoor)\n",
     "estimand_bd = model_bd.identify_effect(proceed_when_unidentifiable=False)\n",
     "print(estimand_bd)"
+   ]
+  },
+    {
+   "cell_type": "markdown",
+   "id": "docalc-backdoor-trans2",
+   "metadata": {},
+   "source": [
+    "`dowhy` a lu le graphe et produit l'**estimande** : la seule stratégie viable est\n",
+    "*backdoor* en ajustant sur `aptitude` (les variables instrumentales et la voie\n",
+    "front-door sont rejetées — il n'y en a pas dans ce graphe). La forme de l'estimande,\n",
+    "$\\frac{d}{d[\\text{college}]} E[\\text{earnings} \\mid \\text{aptitude}]$, est la\n",
+    "**règle 2 du do-calculus** matérialisée : l'intervention $do(\\text{college})$ se ramène\n",
+    "à un ajustement conditionnel. On estime maintenant l'effet en appliquant cet ajustement\n",
+    "(régression linéaire), puis on le soumet à deux **réfutations** : un placebo\n",
+    "(le vrai effet doit disparaître) et un sous-échantillon (l'effet doit rester stable)."
    ]
   },
   {
@@ -360,6 +389,20 @@
     "df_frontdoor = pd.DataFrame({\"smoking\": smoking, \"tar\": tar, \"cancer\": cancer})"
    ]
   },
+    {
+   "cell_type": "markdown",
+   "id": "docalc-frontdoor-trans1",
+   "metadata": {},
+   "source": [
+    "Le **génotype** $U$ est *latent* : il a généré les données mais n'apparaît **pas** dans\n",
+    "le `DataFrame`. On déclare néanmoins le graphe à `dowhy` **en incluant $U$ comme nœud**\n",
+    "— c'est décisif. Sans aucune variable observable pour bloquer le chemin backdoor\n",
+    "$X \\leftarrow U \\rightarrow Y$, `dowhy` doit **échouer** à trouver une backdoor et\n",
+    "**basculer** sur la voie *front-door* à travers le médiateur `tar`, que l'on mesure.\n",
+    "C'est toute la situation qui motive le critère front-door : un confondeur inobservable,\n",
+    "un médiateur mesurable."
+   ]
+  },
   {
    "cell_type": "code",
    "execution_count": 6,
@@ -429,6 +472,21 @@
     "model_fd = CausalModel(data=df_frontdoor, treatment=\"smoking\", outcome=\"cancer\", graph=gml_frontdoor)\n",
     "estimand_fd = model_fd.identify_effect(proceed_when_unidentifiable=True)\n",
     "print(estimand_fd)"
+   ]
+  },
+    {
+   "cell_type": "markdown",
+   "id": "docalc-frontdoor-trans2",
+   "metadata": {},
+   "source": [
+    "Comme prévu, `dowhy` rejette la backdoor (*« No such variable(s) found! »* — $U$ est\n",
+    "inobservable) et identifie la **front-door** via `tar`. Trois hypothèses sont posées :\n",
+    "(1) `tar` **médie entièrement** l'effet smoking $\\to$ cancer ; (2) aucun chemin backdoor\n",
+    "de smoking vers `tar` ; (3) tout chemin backdoor de `tar` vers cancer est bloqué par\n",
+    "smoking. L'estimande devient alors\n",
+    "$E\\!\\left[\\frac{\\partial\\,\\text{cancer}}{\\partial\\,\\text{tar}} \\cdot\n",
+    "\\frac{\\partial\\,\\text{tar}}{\\partial\\,\\text{smoking}}\\right]$. On l'estime par la\n",
+    "régression en **deux étapes** — sans jamais avoir observé le génotype."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python (#10250, IIT narrative bridge — distinct substance: causal-inference interpretation vs cross-doc narrative bridge)

# docs(causal-bridge): enrich do-calculus backdoor + frontdoor with 4 interpretation transition cells

## Quoi

`Do-Calculus-Bridge.ipynb` (Probas/DecisionTheory/Causal-Bridges) avait **2 véritables lacunes narratives** : les cellules 7-9 (backdoor) et 12-14 (frontdoor) = **3 cellules code consécutives** sans markdown intermédiaire entre l'init des données, la construction du graphe, et l'estimation. L'étudiant enchaînait `np.random.seed` → `CausalModel(...)` → `estimate_effect(...)` sans aucune lecture interprétative des sorties de `dowhy`.

Cette PR ajoute **4 cellules markdown de transition**, chacune interprétant la **sortie réelle** de la cellule qui précède et cadrant celle qui suit :

| Cell | Après | Interprète |
|------|-------|-----------|
| `docalc-backdoor-trans1` | cell 7 (effet naïf 3,49 vs vrai 2,0) | pourquoi il faut déclarer le graphe causal pour que `dowhy` identifie lui-même l'ensemble d'ajustement (étape *identify* ≠ *estimate*) |
| `docalc-backdoor-trans2` | cell 8 (estimande backdoor sur `aptitude`) | lire la forme de l'estimande comme la **règle 2 du do-calculus** matérialisée ; les réfutations placebo/sous-échantillon comme tests de robustesse |
| `docalc-frontdoor-trans1` | cell 12 (génotype latent) | `U` absent du DataFrame, graphe le déclare → `dowhy` doit échouer la backdoor et basculer sur front-door via `tar` |
| `docalc-frontdoor-trans2` | cell 13 (front-door identifiée via `tar`) | les **3 hypothèses front-door** (médiation complète, non-confusion des deux étages) et la forme de l'estimande en deux étapes |

Le contenu est **spécifique au voisin** (estimandes Pearl, hypothèses nommées de dowhy, forme $E[\partial\,\text{cancer}/\partial\,\text{tar} \cdot \partial\,\text{tar}/\partial\,\text{smoking}]$), pas générique.

## Méthode — raw-text surgical splice (pas de json round-trip)

Insertion de cellules markdown **sans** `json.load → modify → dump` (règle `nbformat-reserialization-destroys-content`) : splice d'un fragment de cellule JSON dans le texte brut à une borne identifiée par le champ `id` unique. Validation post-splice par re-parse JSON (`json.loads`) → notebook reste valide.

## Anti-régression & validation

- `git diff --stat` : **1 fichier, +58 / −0** (additif pur, 0 suppression).
- **0 cellule code touchée** : `git diff | grep -c '^\-\s*"source"'` = 0 ligne source supprimée → diff markdown-only → **aucune ré-exécution due** (exception C.2 pour modifs markdown-only ; les 8 sorties + execution_counts existants restent byte-identiques).
- `nbformat.validate` : **VALID**.
- H.3 pre-commit : **0 violation** (`execution_count is None and not outputs` = 0).
- Aucun `sorry` / `raise NotImplementedError` / `assert False` (grep = 0).
- L898 pre-work : 0 PR open sur le notebook, 0 concurrent mergé sur ces cellules (seuls #4806 création, #5239 path-leak fix, #5860 enrichissement §7 — section différente).

## Variation

MED/notebook-python. prev MED/notebook-python (#10250). G-VAR-1 ✓ (plancher MED + classe CONTENU notebook-python, pas META). G-VAR-3 : même genre **mais substance genuinement distincte** — #10250 = pont narratif IIT↔docs (cross-document linking) ; ce grain = interprétation pédagogique du do-calculus (causal-inference domain reasoning). Le litmus LIGHT (« générable en scannant le carnet suivant ? ») = **non** : lire une estimande Pearl et la relier à la règle 2 du do-calculus exige du raisonnement de domaine, pas un scan.

See #9434 (mandat prose-qui-interprète dans les notebooks).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
