### PR TITLE
docs(csp): enrich CSP-1 with 4 transition markdown cells

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
@@ -714,6 +714,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Du brute force au backtracking\n",
+    "\n",
+    "Le brute force ci-dessus est **correct mais exhaustif** : il énumère tout le produit cartésien des domaines, puis filtre les combinaisons valides. Sur la coloration de l'Australie (7 territoires, 3 couleurs), cela fait $3^7 = 2187$ combinaisons — gérable. Mais sur un graphe à 30 variables et 5 couleurs, on passe à $5^{30} \\approx 9{,}3 \\times 10^{20}$ : l'explosion combinatoire rend le brute force inutilisable en pratique.\n",
+    "\n",
+    "Le **backtracking** est la première amélioration fondamentale : au lieu d'énumérer puis de filtrer, on **assigne les variables une par une** et on **vérifie les contraintes dès qu'une variable est fixée**. Dès qu'une assignation viole une contrainte, on remonte (*backtrack*) sans explorer les sous-arbres invalides — on élague ainsi l'immense majorité de l'espace de recherche."
+   ],
+   "id": "fa31c9c5"
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "48e72ae3",
@@ -886,6 +898,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pourquoi MRV réduit l'arbre de recherche\n",
+    "\n",
+    "L'heuristique **MRV (Minimum Remaining Values)** choisit, à chaque étape, la variable non encore assignée qui a le **moins de valeurs viables** dans son domaine. L'intuition : la variable la plus contrainte est celle qui risque le plus d'échouer — l'assigner en premier fait remonter les échecs plus tôt et élague l'arbre.\n",
+    "\n",
+    "La cellule suivante montre comment, après quelques assignations sur l'Australie, MRV sélectionne automatiquement le territoire le plus contraint (celui dont les voisins déjà colorés réduisent le plus son domaine), plutôt que de suivre l'ordre naturel de déclaration des variables."
+   ],
+   "id": "68deec77"
+  },
+  {
    "cell_type": "code",
    "execution_count": 10,
    "id": "4e434bcb",
@@ -1026,6 +1050,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Combiner les heuristiques : MRV + LCV\n",
+    "\n",
+    "Nous avons jusqu'ici deux heuristiques **orthogonales** :\n",
+    "- **MRV** décide *quelle* variable assigner ensuite — la plus contrainte,\n",
+    "- **LCV (Least Constraining Value)** décide *quelle valeur* tester en premier — celle qui élimine le moins d'options pour les voisins.\n",
+    "\n",
+    "Un backtracking efficace les **combine** : MRV pour le choix de variable, LCV pour l'ordre des valeurs. Les deux réduisent l'arbre de façon complémentaire — MRV en accélérant les échecs, LCV en privilégiant les branches qui aboutissent. La cellule suivante implémente cette combinaison."
+   ],
+   "id": "c0258755"
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "id": "858509d3",
@@ -1095,6 +1133,21 @@
     "\n",
     "Console.WriteLine(\"Backtracking ameliore defini (variantes controlees par useMRV/useLCV booleens).\");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Comparaison empirique des variantes\n",
+    "\n",
+    "Nous disposons maintenant de trois stratégies pour le même problème (coloration de l'Australie) :\n",
+    "1. **Brute force** — référence exhaustive (lente mais complète),\n",
+    "2. **Backtracking simple** — assignation séquentielle avec vérification immédiate des contraintes,\n",
+    "3. **Backtracking MRV + LCV** — backtracking enrichi des deux heuristiques.\n",
+    "\n",
+    "La comparaison suivante mesure le **nombre d'assignations testées** par chaque variante. C'est la métrique qui révèle le gain réel des heuristiques : moins d'assignations = moins de nœuds explorés = arbre plus petit. Sur un petit graphe l'écart peut sembler modeste, mais il devient drastique quand le nombre de variables croît."
+   ],
+   "id": "1628d0c4"
   },
   {
    "cell_type": "code",

--- a/scripts/notebook_tools/twin_pairs.d/csp-1-fundamentals.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-1-fundamentals.yaml
@@ -20,6 +20,12 @@
       csharp_sha: d6cd5b2719c40d6aa8670f4212102afae346fdee
       content_python_sha: 0148af8590584a1234e23b1d9599151ffa6e7bf36c3d71fdfc5c6604cd07644a
       content_csharp_sha: 24c3e489cf23df1e832b35c9a1e25d1b531ac6ba588421e3e467d70882208b36
+    - date: "2026-08-10"
+      by: myia-po-2024:CoursIA
+      python_sha: 7013d56a565f9243bbf1b7d7e49529c4048bba24
+      csharp_sha: deb7ec968d40c1fc2f54e3f584f289ce6abc7af0
+      content_python_sha: 0148af8590584a1234e23b1d9599151ffa6e7bf36c3d71fdfc5c6604cd07644a
+      content_csharp_sha: b818eb308915ed0f9b46a131cb928641a7e92df4ef7c14ce73efa45834cb7b0f
   known_differences:
     - "Socle pedagogique commun (parity semantic) : les deux cotes implementent une classe CSP generique + backtracking simple + heuristique MRV + value-ordering LCV, depuis zero (pas de lib externe pour le coeur). Cote Python : classe CSP dict/list pure Python. Cote C# : classe CSP generique C# (Dictionary/List) qui reflete la Python."
     - "Extension solveur ASYMETRIQUE : le cote C# ajoute Choco-solver 4.10.17 (Java solver via IKVM 8.15.0, recette #4711) avec des cellules (coloration Australie par Choco, enumeration de TOUTES les solutions, 8-Reines par Choco) qui n'ont PAS d'equivalent direct cote Python. Le cote Python reste pur from-scratch sur tout le notebook."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: DEEP/genai #10251

Enrichissement markdown de `CSP-1-Fundamentals-Csharp.ipynb` (Search, Part2-CSP). Self-found MED, rotation famille vs le DEEP/genai #10251 du même cycle.

## Livrable : 4 cellules de transition pédagogique

Le notebook enchaînait 4 fois des cellules code consécutives sans transition conceptuelle. Insertion (avant le concept qu'elles introduisent) :

1. **« Du brute force au backtracking »** — avant la cellule backtracking. Motive l'explosion combinatoire ($3^7 = 2187$ vs $5^{30} \approx 9{,}3 \times 10^{20}$) et le passage d'« énumérer puis filtrer » à « assigner et vérifier au fil ».
2. **« Pourquoi MRV réduit l'arbre de recherche »** — avant la démo MRV. Explique l'intuition (variable la plus contrainte = échec plus tôt = élagage).
3. **« Combiner les heuristiques : MRV + LCV »** — avant le backtracking combiné. Cadre les deux heuristiques comme orthogonales (choix de variable vs ordre des valeurs).
4. **« Comparaison empirique des variantes »** — avant le benchmark. Pose la métrique (nombre d'assignations testées) qui révèle le gain des heuristiques.

## G.1 — preuve du livrable

- `git diff --numstat` : **+53 / -0** (addition pure, zéro churn sur les cellules existantes).
- Vérifié firsthand : les 14 cellules code conservent leur `execution_count` (8, 9, 10, 11, 12…) et leurs outputs réels Choco-solver byte-identiques.
- 4 nouvelles cellules = markdown uniquement, FR-first.

## C.2 exception — pas de re-exécution

Édition **markdown-only** (aucune cellule code source modifiée, aucun output touché). Règle C.2 : « Exception : modifs uniquement markdown. » → aucune re-exécution due. Pre-commit H.3 PASS (le guard ne flag que `execution_count=null + outputs=[]`, or les cellules code sont intactes et les nouvelles cellules sont markdown).

## Scope (un sujet par PR)

Une PR = un notebook, 4 transitions cohérentes (même registre pédagogique). Ne touche PAS : le catalogue (`COURSE_CATALOG.generated.*` byte-identique à main, non régénéré), les notebooks frères, le README de série, l'env.

## Variation

prev = DEEP/genai #10251 (c.78, LoRA fine-tuning). Ce grain = **MED/notebook-dotnet** sur la famille **Search/CSP**. Rotation famille (GenAI → Search) ET genre (genai DEEP → notebook-dotnet MED). G-VAR-3 OK (pas deux fois le même genre LIGHT consécutif ; ici MED dans un domaine hors-core de la lane). Substances distinctes.
