### PR TITLE
fix(gitleaks,#10141): allowlist revoked Civitai token for scanner hygiene

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -102,14 +102,15 @@ stopwords = [
     "hf_fixtureABCDEF1234567890", # test fixture (HF-token-shaped), same test file
     "val2=with=equals",           # parser test fixture (value with embedded '='), test_notebook_tools_pure.py
     "ghp_IMfYN5...NCsd",          # redacted GitHub-token example (the `...` is literal), symbolicai-lean translation CSV
+    # --- #10141 revoked Civitai token (allowlist for scanner hygiene) ---
+    # c39ba121e12e5b40ac67a87836431e34 = CIVITAI_TOKEN, 6 occurrences in archive dirs
+    # (docker-configurations/_archive-20251125/, docs/archive/suivis/genai-image/phase-30-*/,
+    # scripts/genai-stack/_archive/). Rotation performed at Civitai (user action 2026-08);
+    # revoked confirmed firsthand: GET /api/v1/users/self with this token -> 401 Unauthorized
+    # (same as a fake token; a live key returns 200). Allowlister une valeur REVOQUEE est de
+    # l'hygiene de scanner (secrets-hygiene rule 5: rotation is the PRIMARY remediation and is
+    # DONE; this entry only silences the dead value in CI). NEVER allowlist a live credential
+    # (#9888) — this entry is legitimate precisely because the value is dead. The 6 archive
+    # files are redacted in a SEPARATE PR (replace with ROTATED placeholder). See #10141.
+    "c39ba121e12e5b40ac67a87836431e34",
 ]
-
-# NOTE (#10143) — INTENTIONALLY NOT ALLOWLISTED:
-#   c39ba121e12e5b40ac67a87836431e34  (CIVITAI_TOKEN, 6 occurrences)
-# Read at source: docker-configurations/_archive-20251125/docker-compose-no-auth.yml,
-# scripts/genai-stack/_archive/utils/reconstruct_env.py (default_config), + 3 archived
-# genai-image reports. Sits next to `HF_TOKEN=HF_TOKEN_REDACTED` (redacted) while this
-# value is NOT redacted, and is absent from .secrets/master.env — consistent with a REAL
-# committed token, not a fixture. Suppressing it would disarm the scanner exactly where
-# it caught something real. Left visible on purpose: if confirmed real, the fix is
-# ROTATION at Civitai (secrets-hygiene rule 5), not an allowlist entry.


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #10237

## Quoi

`#10141` Option 1 (décision ai-01 msg-y97blk) — allowliste la valeur du jeton Civitai **révoqué** (`c39ba121e12e5b40ac67a87836431e34`) dans `.gitleaks.toml`, pour l'hygiène du scanner CI. Ajout dans `stopwords` (named value, pas motif générique) + réécriture de la NOTE #10143 qui laissait le token non-allowlisté en attente de rotation.

## Preuve

**Révoqué confirmé firsthand (G.1, 2026-08-10)** : rotation faite par user (action provider-side). Vérification propre : `GET https://civitai.com/api/v1/users/self` avec ce token → **401 Unauthorized** (identique à un token fake ; une clé vivante retournerait 200 + profil). Corrobore le claim firsthand d'ai-01 (« c39ba121... renvoie mort »). Allowlister une valeur **révoquée** est de l'hygiène de scanner (secrets-hygiene règle 5 : la rotation est la remédiation PRIMAIRE et est FAITE ; cette entrée ne fait que taire la valeur morte en CI). **JAMAIS** d'allowlist sur une valeur vivante (#9888) — légitime ici précisément parce que la valeur est morte.

**Correction G.9 de mon diagnostic c.201** (sur lequel ai-01 s'appuyait) : firsthand maintenant, **6 instances d'1 token en dirs d'archive**, PAS « 5 faux positifs distincts ». Les FPs authentiques étaient déjà traités par les PR merged `#10225` (JWT tronqué) + `#10201` (suppression class-based). Localisation exacte des 6 :
- `docker-configurations/_archive-20251125/docker-compose-no-auth.yml`
- `docs/archive/suivis/genai-image/phase-30-*/configurations-docker/docker-compose-no-auth.yml`
- `docs/archive/suivis/genai-image/phase-30-*/rapports-validation/CONFIGURATION-DOCKER-QWEN-SANCTUAIRE-20251114.md` (×2)
- `docs/archive/suivis/genai-image/phase-30-*/rapports-validation/RAPPORT-RESOLUTION-FINALE-AUTHENTIFICATION-COMFYUI-QWEN-20251114.md`
- `scripts/genai-stack/_archive/utils/reconstruct_env.py`

**Falsifiabilité both-directions (gitleaks 8.24.3, --no-git, CI-matching docker image)** :
- AVANT allowlist : **6 leaks** (toutes `c39ba121...`, règle `generic-api-key`)
- APRÈS allowlist : **0 leaks**
- **Contrôle positif** (detector armé, pas désarmé) : injection d'un fake GitHub PAT réaliste haute-entropie (`ghp_9f8a7b...`) → **2 leaks** trouvés (règle `github-pat`). Un gate qui ne peut plus rougir n'est pas un gate — celui-ci rougit toujours pour un vrai secret.

## Perimetre

1 fichier, +11/−10. `.gitleaks.toml` (1 stopword ajouté + NOTE #10143 réécrite pour refléter révocation-confirmée + allowlist). 0 notebook, 0 catalogue, 0 output. La **rédaction des 6 fichiers d'archive** (remplacement du token par placeholder `ROTATED`) part en **PR séparée** (ai-01 Option 1 : « deux objets, deux PR »).

See #10141 (allowlist part d'Option 1 ; ne ferme pas — la rédaction `_archive/` reste). See #9888, #10143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
