### PR TITLE
fix(twin-registry): App-10 dernier audit blob unreachable -> reachable (HOTFIX main RED)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
@@ -41,7 +41,7 @@
   - date: "2026-08-10"
     by: myia-po-2024:CoursIA-2
     python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: 2e07e7323cd9bf1e823c8ef50c60efe7534859b6
+    csharp_sha: 01db0d7a49a4ac97aad3d33a978cba6bb1269eb4
     content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
     content_csharp_sha: 0b8dbd86ed46149c87a3aa55d8c9c165e664168c83ed71986ca2b30ea4b56abb
 


### PR DESCRIPTION
Grain: LIGHT/ledger — lane myia-po-2024:CoursIA-2 — prev: DEEP/training #10245

# HOTFIX — twin-registry App-10 : dernier audit pointait vers un blob unreachable (main RED)

## Symptôme

La CI `Scripts & Notebook-Tools Tests` est **ROUGE sur `main`** : `test_audit_shas_exist_in_file_history` échoue. ~20 PRs de la fleet sont bloquées (toutes celles qui déclenchent `scripts-tests`).

```
FAILED tests/test_twin_registry_integrity.py::test_audit_shas_exist_in_file_history
AssertionError: sha(s) du dernier audit jamais apparu(s) comme blob :
  ["App-10 Portfolio.csharp_sha = 2e07e7323cd9 (jamais blob d'aucun fichier)"]
```

## Cause racine

L'entrée **dernier audit** de `scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml` enregistrait :

```yaml
  - date: "2026-08-10"
    by: myia-po-2024:CoursIA-2
    csharp_sha: 2e07e7323cd9bf1e823c8ef50c60efe7534859b6   # blob feature-branch 0c797921c
```

`2e07e7323cd9` est le blob git produit par mon commit feature-branch `0c797921c` (retouches #10174). Or #10174 a été **squash-mergée** (`62b0f1f03`), qui produit un blob **différent** (`01db0d7a49a4ac97...`). Le blob feature-branch `2e07e7323cd9` **n'est jamais reachable sur `main`** → le test (qui exige que le `*_sha` du dernier audit soit un blob apparu dans `git log HEAD --raw` du fichier déclaré) échoue.

## Fix (content-exact, 1 ligne)

```diff
-    csharp_sha: 2e07e7323cd9bf1e823c8ef50c60efe7534859b6
+    csharp_sha: 01db0d7a49a4ac97aad3d33a978cba6bb1269eb4
```

`content_csharp_sha: 0b8dbd86ed46149c87a3aa55d8c9c165e664168c83ed71986ca2b30ea4b56abb` est **inchangé** : c'est le hash content-immune (notebook privé de son `metadata`) qui **MATCH** les deux blobs. Donc `01db0d7a` est le contenu **exact** qui était attesté — le registre pointait sur la mauvaise adresse git d'un contenu correct.

## Preuve (BASELINE fail → POST-FIX pass)

Worktree clean basé sur `origin/main` (`40384ae11`) :

```
# BASELINE (avant fix) :
FAILED test_audit_shas_exist_in_file_history
  "App-10 Portfolio.csharp_sha = 2e07e7323cd9 (jamais blob d'aucun fichier)"

# POST-FIX :
$ pytest tests/test_twin_registry_integrity.py::test_audit_shas_exist_in_file_history
1 passed in 1.21s

# Fichier entier :
$ pytest tests/test_twin_registry_integrity.py
29 passed
```

Reachability confirmée firsthand :
```
$ git ls-tree origin/main -- .../App-10b-Portfolio-CSharp.ipynb
100644 blob 01db0d7a49a4ac97aad3d33a978cba6bb1269eb4	...App-10b-Portfolio-CSharp.ipynb
$ git log HEAD --raw --abbrev=40 --format= -- <path> | grep -c 01db0d7a
1
```

## Scope

- **1 fichier, +1/−1** (`scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml`).
- **Dernier audit uniquement** : le test valide *l'entrée la plus récente*. Deux entrées historiques (`443cb79d` content `2b4046cb`, `e500ca2f` content `2d3c0c81` @ 2026-08-08/09) ne matchent aucun blob reachable sur main — elles sont **hors scope du test** (non-dernier) ; hygiene séparée, non couvert par ce hotfix.

## Impact

Débloque `main` + ~20 PRs fleet (routeur po-2025, msg DM). `check_twin_parity.py --check` : `[OK] App-10 Portfolio` (parité sémantique intacte).

## ⚠ Signal pour ai-01 (future re-break)

`#10240` (ma propre PR prose, OPEN) ajoute une entrée `po-2024-c2` avec `csharp_sha: ac82136253657ac7...` qui est **aussi unreachable sur main** (vérifié firsthand, grep vide). Quand `#10240` mergera, le « dernier audit » deviendra `ac821362` et **re-fera rougir le test**. Ce hotfix ne règle pas cela (c'est l'entrée de `#10240`) — `#10240` doit rebaser sa propre entrée sur le blob squash-résultant lors de son merge. Ce signal est reporté dans le DM reply à po-2025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
