### PR TITLE
feat(genai,#10260): 3rd exercise (metadata filtering) for RAG notebook

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/ingestion-corpus-long-rag.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/ingestion-corpus-long-rag.ipynb
@@ -53,10 +53,10 @@
    "id": "f525fac0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T13:23:31.071981Z",
-     "iopub.status.busy": "2026-08-09T13:23:31.070474Z",
-     "iopub.status.idle": "2026-08-09T13:23:31.759317Z",
-     "shell.execute_reply": "2026-08-09T13:23:31.758185Z"
+     "iopub.execute_input": "2026-08-10T01:15:23.974091Z",
+     "iopub.status.busy": "2026-08-10T01:15:23.974091Z",
+     "iopub.status.idle": "2026-08-10T01:15:30.147362Z",
+     "shell.execute_reply": "2026-08-10T01:15:30.146358Z"
     }
    },
    "outputs": [
@@ -103,10 +103,10 @@
    "id": "282c7287",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T13:23:31.761377Z",
-     "iopub.status.busy": "2026-08-09T13:23:31.760856Z",
-     "iopub.status.idle": "2026-08-09T13:23:31.773960Z",
-     "shell.execute_reply": "2026-08-09T13:23:31.772844Z"
+     "iopub.execute_input": "2026-08-10T01:15:30.148809Z",
+     "iopub.status.busy": "2026-08-10T01:15:30.148809Z",
+     "iopub.status.idle": "2026-08-10T01:15:30.162911Z",
+     "shell.execute_reply": "2026-08-10T01:15:30.161632Z"
     }
    },
    "outputs": [
@@ -217,10 +217,10 @@
    "id": "567350c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T13:23:31.775540Z",
-     "iopub.status.busy": "2026-08-09T13:23:31.775540Z",
-     "iopub.status.idle": "2026-08-09T13:23:31.789109Z",
-     "shell.execute_reply": "2026-08-09T13:23:31.787993Z"
+     "iopub.execute_input": "2026-08-10T01:15:30.165006Z",
+     "iopub.status.busy": "2026-08-10T01:15:30.165006Z",
+     "iopub.status.idle": "2026-08-10T01:15:30.178212Z",
+     "shell.execute_reply": "2026-08-10T01:15:30.176997Z"
     }
    },
    "outputs": [
@@ -291,10 +291,10 @@
    "id": "ffa8c24e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T13:23:31.791216Z",
-     "iopub.status.busy": "2026-08-09T13:23:31.791216Z",
-     "iopub.status.idle": "2026-08-09T13:23:31.804154Z",
-     "shell.execute_reply": "2026-08-09T13:23:31.803147Z"
+     "iopub.execute_input": "2026-08-10T01:15:30.180306Z",
+     "iopub.status.busy": "2026-08-10T01:15:30.179783Z",
+     "iopub.status.idle": "2026-08-10T01:15:30.192367Z",
+     "shell.execute_reply": "2026-08-10T01:15:30.191775Z"
     }
    },
    "outputs": [
@@ -361,10 +361,10 @@
    "id": "77812c46",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T13:23:31.806728Z",
-     "iopub.status.busy": "2026-08-09T13:23:31.806728Z",
-     "iopub.status.idle": "2026-08-09T13:23:31.819451Z",
-     "shell.execute_reply": "2026-08-09T13:23:31.818319Z"
+     "iopub.execute_input": "2026-08-10T01:15:30.194471Z",
+     "iopub.status.busy": "2026-08-10T01:15:30.194471Z",
+     "iopub.status.idle": "2026-08-10T01:15:30.208147Z",
+     "shell.execute_reply": "2026-08-10T01:15:30.207009Z"
     }
    },
    "outputs": [
@@ -413,10 +413,10 @@
    "id": "1a7fe687",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T13:23:31.821016Z",
-     "iopub.status.busy": "2026-08-09T13:23:31.820499Z",
-     "iopub.status.idle": "2026-08-09T13:23:31.834695Z",
-     "shell.execute_reply": "2026-08-09T13:23:31.833583Z"
+     "iopub.execute_input": "2026-08-10T01:15:30.209714Z",
+     "iopub.status.busy": "2026-08-10T01:15:30.209194Z",
+     "iopub.status.idle": "2026-08-10T01:15:30.222874Z",
+     "shell.execute_reply": "2026-08-10T01:15:30.222286Z"
     }
    },
    "outputs": [
@@ -529,10 +529,10 @@
    "id": "85ce3018",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T13:23:31.836815Z",
-     "iopub.status.busy": "2026-08-09T13:23:31.836292Z",
-     "iopub.status.idle": "2026-08-09T13:23:31.850165Z",
-     "shell.execute_reply": "2026-08-09T13:23:31.849020Z"
+     "iopub.execute_input": "2026-08-10T01:15:30.224956Z",
+     "iopub.status.busy": "2026-08-10T01:15:30.224437Z",
+     "iopub.status.idle": "2026-08-10T01:15:30.238639Z",
+     "shell.execute_reply": "2026-08-10T01:15:30.237503Z"
     }
    },
    "outputs": [
@@ -636,10 +636,10 @@
    "id": "b32584c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T13:23:31.852295Z",
-     "iopub.status.busy": "2026-08-09T13:23:31.851772Z",
-     "iopub.status.idle": "2026-08-09T13:23:31.865412Z",
-     "shell.execute_reply": "2026-08-09T13:23:31.864786Z"
+     "iopub.execute_input": "2026-08-10T01:15:30.240199Z",
+     "iopub.status.busy": "2026-08-10T01:15:30.239678Z",
+     "iopub.status.idle": "2026-08-10T01:15:30.253933Z",
+     "shell.execute_reply": "2026-08-10T01:15:30.252679Z"
     }
    },
    "outputs": [
@@ -686,10 +686,10 @@
    "id": "3db8ee47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-09T13:23:31.867906Z",
-     "iopub.status.busy": "2026-08-09T13:23:31.867906Z",
-     "iopub.status.idle": "2026-08-09T13:23:31.880964Z",
-     "shell.execute_reply": "2026-08-09T13:23:31.880393Z"
+     "iopub.execute_input": "2026-08-10T01:15:30.256530Z",
+     "iopub.status.busy": "2026-08-10T01:15:30.256530Z",
+     "iopub.status.idle": "2026-08-10T01:15:30.269054Z",
+     "shell.execute_reply": "2026-08-10T01:15:30.267924Z"
     }
    },
    "outputs": [
@@ -712,6 +712,74 @@
     "# retrouves = sum(1 for c in naif if retrouver_origine(c, CORPUS) is not None)\n",
     "# print(f\"Chunks naifs etiquetables a posteriori : {retrouves}/{len(naif)}\")\n",
     "print(\"Exercice 2 -- a implementer.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1746ed71",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 -- Le filtrage par metadonnee, que le chunking naif ne permet pas\n",
+    "\n",
+    "Les sections 6 et 7 comparent les deux strategies a *candidats egaux* : toute la\n",
+    "collection est en lice a chaque requete. Or l'etiquette `livre` du chunking\n",
+    "structure autorise une chose que le naif ne pourra jamais faire -- **restreindre\n",
+    "les candidats avant de classer**.\n",
+    "\n",
+    "Implementez `top_k_filtre(requete, livre=None, k=1)` qui ne classe que les chunks\n",
+    "du livre demande, puis mesurez sur `REQUETES` la precision chapitre exact avec et\n",
+    "sans filtre. Deux points a justifier dans votre conclusion :\n",
+    "\n",
+    "1. Le filtre **ne doit pas** re-entrainer le vectoriseur : on selectionne des\n",
+    "   **lignes** de `mat_struct`, l'espace de termes reste celui du corpus complet.\n",
+    "   Pourquoi cette distinction change-t-elle le score obtenu ?\n",
+    "2. Sur quelles requetes le filtre est-il *inutile* (le top-1 etait deja bon) ?\n",
+    "   Une precision moyenne qui monte cache-t-elle ici un gain reel ?\n",
+    "\n",
+    "(Indice : une matrice creuse s'indexe par liste -- `mat_struct[idx]` ou `idx` est\n",
+    "la liste des positions telles que `structure[i][\"livre\"] == livre`.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "693798b8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T01:15:30.270623Z",
+     "iopub.status.busy": "2026-08-10T01:15:30.270098Z",
+     "iopub.status.idle": "2026-08-10T01:15:30.284297Z",
+     "shell.execute_reply": "2026-08-10T01:15:30.283155Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 -- a implementer (decommenter la boucle ci-dessus).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 -- recherche filtree par metadonnee (impossible en chunking naif).\n",
+    "def top_k_filtre(requete, livre=None, k=1):\n",
+    "    # TODO etudiant :\n",
+    "    #   1. rv = vec.transform([requete])  -- ne PAS refaire fit_transform\n",
+    "    #   2. idx = [i for i, c in enumerate(structure)\n",
+    "    #             if livre is None or c[\"livre\"] == livre]\n",
+    "    #   3. classer cosine_similarity(rv, mat_struct[idx]) et remonter les k\n",
+    "    #      meilleurs en reprojetant sur les indices d'origine (idx[j], pas j).\n",
+    "    # Renvoie [(indice_dans_structure, score), ...].\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "# for req, livre_attendu, ch_attendu in REQUETES:\n",
+    "#     sans = top_k_filtre(req)[0]\n",
+    "#     avec = top_k_filtre(req, livre=livre_attendu)[0]\n",
+    "#     print(f\"{req[:40]:<40} ch.{structure[sans[0]]['chapitre']} -> \"\n",
+    "#           f\"ch.{structure[avec[0]]['chapitre']} (attendu ch.{ch_attendu})\")\n",
+    "print(\"Exercice 3 -- a implementer (decommenter la boucle ci-dessus).\")"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/notebook-python #10184

**Quoi:** ajoute le 3e exercice manquant au notebook `ingestion-corpus-long-rag.ipynb` (PR #10184 mergée en `4fa18773b` avec seulement 2 exercices, sous le seuil HARD de `three-exercises-per-notebook.md`). Suit la spec du coordinateur (DM `msg-20260809T201835-tm434m`) : `top_k_filtre(requete, livre=None, k=1)` — le filtrage pré-classement par le payload `livre`, actif que le notebook défend sur 10 sections mais qu'aucun exercice n'exerçait. Piège technique réel : on filtre des **lignes** de `mat_struct`, on ne refait pas `fit_transform` (l'espace de termes reste celui du corpus complet).

**Preuve:** édition chirurgicale (insert 2 cellules après Exo 2), re-exécution complète. `exec_count` séquentiel `1..10`. **Zéro régression** sur les 9 cellules existantes — source + outputs **byte-identiques** à la version mergée (diff automatique : 0 divergence ; le notebook est déterministe). Nouveau stub : `exec_count=10`, output stream réel (`return None` conforme C.1, `print(...)` garantit la sortie). gitleaks **Passed** au commit, scan Unicode clean (zéro homoglyphe cyrillique/grec, zéro emoji, code 100 % ASCII). H.3 **Passed**. Claim posé avant édition (`issuecomment-5234870318`).

**Périmètre:** 1 fichier, +104/−36 (les −36 = churn des timestamps d'exécution `iopub.*` dans `metadata.execution`, actualisés par la re-exécution — aucun contenu supprimé). Aucune prose client, aucun secret. Ex3 complète la série sans doublonner (Ex1 = recouvrement du naïf, Ex2 = étiquetage a posteriori, Ex3 = filtrage par métadonnée par construction).

**G-VAR-3:** `MED/notebook-python` après `MED/notebook-python` (#10184) — 2e consécutif, substance distincte (filtrage pré-classement, concept non couvert par Ex1/Ex2), dans la limite autorisée. Coordinateur : « Le Grain: reste MED/notebook-python », « je merge sans autre gate ».

Closes #10260
