### PR TITLE
docs(gametheory): enrich NormalForm-Part2 support-enumeration flow

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp-Part2.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp-Part2.ipynb
@@ -553,6 +553,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "gt2en01",
+   "metadata": {},
+   "source": [
+       "### De l'enumération combinatoire au test d'équilibre\n",
+       "\n",
+       "La fonction `SubsetsOfSize` ci-dessus est le **moteur combinatoire** : elle engendre tous les sous-ensembles de taille $k$ d'un ensemble de $n$ actions — il y en a $\\binom{n}{k}$. Sur Pierre-Feuille-Ciseaux ($n=3$), cela ne fait que $\\binom{3}{1}+\\binom{3}{2}+\\binom{3}{3} = 7$ supports à examiner par joueur.\n",
+       "\n",
+       "Le principe de **l'énumération des supports** (Mangasarian–Stone, 1964 ; Stengel 2002) est de transformer la recherche d'un équilibre de Nash en une **énumération finie** : pour chaque paire de supports candidats $(S_1, S_2)$ de même taille, on résout le **système d'indifférence** (la stratégie adverse rend le joueur indifférent entre les actions de son support) puis on **vérifie la positivité** et la condition de **best-response hors-support**. Chaque support donne au plus un équilibre candidat — c'est un algorithme complet qui trouve **tous** les équilibres, au prix d'une complexité combinatoire.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "id": "gt2b11",
@@ -654,6 +666,18 @@
     "}\n",
     "\n",
     "\"Support enumeration prêt (Gauss + indifference + best-response check).\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt2en02",
+   "metadata": {},
+   "source": [
+       "### Application : Pierre-Feuille-Ciseaux, l'équilibre uniforme attendu\n",
+       "\n",
+       "Appliquons l'algorithme au jeu symétrique $3 \\times 3$ Pierre-Feuille-Ciseaux. L'antisymétrie de la matrice de gain ($u_i = -u_j$) impose qu'aucun joueur n'ait d'avantage systématisque : la théorie prédit l'**équilibre uniforme** $\\sigma = (1/3, 1/3, 1/3)$ pour les deux joueurs, qui rend chaque action indifférente (espérance nulle) et est l'unique best-response à lui-même.\n",
+       "\n",
+       "C'est précisément ce que l'énumération des supports doit retrouver : le support complet $\\{R, P, S\\}$ produit, via le système d'indifférence $3 \\times 3$, la solution uniforme — et les supports de taille 1 et 2 sont rejetés (pas d'équilibre en stratégies pures, ni en support réduit). La cellule suivante exécute cette résolution et affiche le vecteur de probabilité trouvé.\n"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform-part-2-support-enumeration.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform-part-2-support-enumeration.yaml
@@ -17,6 +17,12 @@
       csharp_sha: 7114fe6997be2bbd13cad0ef5a6a76652811ebb2
       content_python_sha: b60792d2c1b041113ef870cf04c6eb17c1e31230115354571d25c7007a5cb2a9
       content_csharp_sha: ef8e3d603ee1cc1b0879dfcadff0c685d48b2020133258ed130f3d1bc07e3c8f
+    - date: "2026-08-10"
+      by: myia-po-2024:CoursIA
+      python_sha: 13c27d9afd12ca9f9f5dc96c00aa761d8d5bb87c
+      csharp_sha: 0803644967201646eb00beb62327da4059e9bb29
+      content_python_sha: b60792d2c1b041113ef870cf04c6eb17c1e31230115354571d25c7007a5cb2a9
+      content_csharp_sha: f3431f222a16b4b4161785d0cf953b79f2670cb7bd27d8d821b56760ff760952
   known_differences:
     - "Socle pedagogique commun : support enumeration des equilibres de Nash mixtes NxN (indifference + Gauss pivot partiel + best-response), sur 4 jeux canoniques (RPS, RPS biaise, Prisonnier, Matching Pennies) + 3 exercices (BoS, RPSLS, complexite)."
     - "Idiomes framework : Python = `numpy` pur pour le from-scratch (meme algorithme que le C#), PLUS `nashpy` comme verification independante (pont SOTA, cell 8). C# = pur BCL .NET (System.*, pas de lib tiers), nashpy n'existe pas en .NET."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #10254

Enrichissement markdown de `GameTheory-2-NormalForm-Csharp-Part2.ipynb` (GameTheory, support enumeration). Self-found MED, rotation de famille (Search → GameTheory).

## Lacune narrative réelle (pas une section d'exercices)

Le notebook enchaînait 3 cellules code consécutives — le cœur algorithmique de l'énumération des supports — sans transition conceptuelle :
- cell 9 : `SubsetsOfSize` (helper combinatoire),
- cell 10 : `SupportEnumeration` (algorithme principal : système d'indifférence + positivité + best-response),
- cell 11 : résolution Pierre-Feuille-Ciseaux.

Contrairement aux sections d'exercices (qui ont des descriptions inline TODO + Étapes), ce trio est un **flot algorithmique** qui mérite du bridge narratif.

## Livrable : 2 cellules de transition FR-first

1. **« De l'énumération combinatoire au test d'équilibre »** — avant l'algorithme : explique le principe de l'énumération des supports (Mangasarian–Stone 1964, Stengel 2002) — transformer la recherche d'un équilibre de Nash en énumération finie de paires de supports, résoudre le système d'indifférence, vérifier positivité + best-response hors-support. Pont helper combinatoire → test d'équilibre.
2. **« Application : Pierre-Feuille-Ciseaux, l'équilibre uniforme attendu »** — avant la résolution RPS : prédit l'équilibre uniforme (1/3,1/3,1/3) depuis l'antisymétrie de la matrice de gain, explique pourquoi les supports de taille 1 et 2 seront rejetés.

## G.1 — preuve du livrable

- `git diff --numstat` : **+24/-0** sur le notebook (addition pure, zéro churn sur les 12 cellules code existantes — execution_count + outputs Choco-solver byte-identiques).
- **Raw-string splice** (pas de json round-trip) → préserve byte-identity de toutes les cellules non touchées ([[nbformat-write-churns-untouched-cells-use-raw-json]]).
- 2 nouvelles cellules = markdown uniquement, FR-first, LaTeX propre ($\binom{n}{k}$, $\sigma = (1/3,1/3,1/3)$).

## C.2 exception — pas de re-exécution

Édition **markdown-only** (aucune cellule code source modifiée, aucun output touché). Règle C.2 : « Exception : modifs uniquement markdown. » → aucune re-exécution due. Pre-commit H.3 PASS.

## Twin parity — rebaseline (commit 2)

Le notebook est un twin (jumeau C#/Python, `gametheory-2-normalform-part-2-support-enumeration.yaml`). L'édition markdown déplace le content_csharp_sha (ef8e3d60 → f3431f22) → DRIFT. Rebaseline via `check_twin_parity.py --update` APRÈS le commit contenu ([[twin-parity-update-after-commit-not-before]]). Vérifié : **157/157 paires OK, drift 0**.

## Scope (un sujet par PR)

Une PR = un notebook, 2 transitions cohérentes (flot algorithmique de l'énumération des supports). Ne touche PAS : le catalogue (byte-identique à main), les notebooks frères, le README de série, l'env.

## Variation

prev = MED/notebook-dotnet #10254 (c.79, CSP-1 enrichment). Ce grain = MED/notebook-dotnet sur **GameTheory** (support enumeration). G-VAR-3 : 2e notebook-dotnet MED consécutif, **substance genuinement distincte** (CSP backtracking heuristics vs Nash equilibrium support-enumeration algorithm — pas scan-générable). Rotation famille (Search → GameTheory). G-VAR-1 OK (MED + classe CONTENU).
