### PR TITLE
feat(d5,#9998): filter Nature/Science/Econometrica simple vol:pages biblio refs (FP class 4 extended)

### DIFF
--- a/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/scan_d5_prose_outputs_alignment.py
@@ -576,6 +576,18 @@ def _is_bibliographic_reference(value: float, text: str) -> bool:
         window = text[max(0, m.start() - _BIBLIO_CONTEXT_WINDOW): m.end() + _BIBLIO_CONTEXT_WINDOW]
         if _BIBLIO_CONTEXT_RE.search(window):
             return True
+        # FP class 4 extended (#9998) : journaux sans mot-cle generique (Nature,
+        # Science, Econometrica, Annals of Mathematics, ...) au format SIMPLE
+        # vol:pages (sans parenthese d'issue). _BIBLIO_EXTENDED_CONTEXT_RE est un
+        # sur-ensemble de _BIBLIO_CONTEXT_RE ; on l'applique sur une fenetre etroite
+        # (60 chars, identique au Tier 1 de class 6) -- et NON sur la fenetre 200 du
+        # base -- car "nature"/"science" y figurent SANS frontiere de mot : une
+        # fenetre large risquerait de sur-filtrer une plage de donnees proche d'une
+        # prose "la nature de". La fenetre etroite ancre le mot-cle au pattern
+        # (le nom du journal precede immediatement vol:pages, ex "Nature 518:529-533").
+        window_60 = text[max(0, m.start() - 60): m.end() + 60]
+        if _BIBLIO_EXTENDED_CONTEXT_RE.search(window_60):
+            return True
     # FP class 6 (#9998) : vol(issue):pages, double-tier safe-by-construction
     # Tier 1 : keyword biblio (etendu) en proximite 60 chars
     # Tier 2 : pattern anchor + year (19xx/20xx) sur la meme ligne

--- a/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
+++ b/scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py
@@ -956,6 +956,35 @@ class TestBibliographicReferenceFilter:
         assert mod._is_bibliographic_reference(5.7, text2) is False
         assert mod._is_bibliographic_reference(6.0, text2) is True
 
+    def test_helper_extended_journal_nature_simple_volpages(self):
+        # FP class 4 extended (#9998) : journal SANS mot-cle generique (Nature,
+        # Econometrica, Annals of Mathematics) au format SIMPLE vol:pages. Le nom
+        # du journal precede immediatement le pattern (fenetre etroite 60 chars).
+        # Cas fondateur : rl_6_dqn_policy_gradient cell[27] "Nature 518:529-533".
+        text = "Mnih et al., Nature 518:529-533 (2015)."
+        assert mod._is_bibliographic_reference(518.0, text) is True
+        assert mod._is_bibliographic_reference(529.0, text) is True
+        assert mod._is_bibliographic_reference(533.0, text) is True
+
+    def test_helper_extended_journal_econometrica(self):
+        # Econometrica est dans _BIBLIO_EXTENDED_CONTEXT_RE sans "Journal" dans
+        # le nom. DecPyMC-2 corpus : "Econometrica 32:122-136".
+        text = "Theorie de l'utilite, Econometrica 32:122-136 (1964)."
+        assert mod._is_bibliographic_reference(32.0, text) is True
+        assert mod._is_bibliographic_reference(122.0, text) is True
+        assert mod._is_bibliographic_reference(136.0, text) is True
+
+    def test_helper_extended_keyword_far_from_pattern_not_filtered(self):
+        # Anti-sur-filtrage (fenetre etroite 60 chars) : "nature" mot courant en
+        # prose LOIN (>60 chars) d'un pattern N:N-N qui est un range de donnees.
+        # Si la fenetre etait 200 chars (comme le base), "nature" collerait et
+        # sur-filtrerait la plage de donnees. La fenetre etroite protege.
+        filler = ("x" * 80)  # 80 chars > 60 : "nature" hors fenetre etroite
+        text = "On etudie la nature du phenomene " + filler + " sur la plage 5:10-15 des indices."
+        assert mod._is_bibliographic_reference(5.0, text) is False
+        assert mod._is_bibliographic_reference(10.0, text) is False
+        assert mod._is_bibliographic_reference(15.0, text) is False
+
     def test_integration_comptes_rendus_suppressed(self, tmp_path):
         # Cas fondateur DecPyMC-2 cell[23] : prose cite "Comptes Rendus
         # 25:536-538" -- 25, 536, 538 sont des identifiants de citation,


### PR DESCRIPTION
Grain: MED/feature — lane myia-po-2023:CoursIA-2 — prev: MED/guard #10259

## Quoi

**D5 détecteur FP class 4 étendu (#9998).** La classe 4 (`_is_bibliographic_reference`, forme simple `vol:page-page`) ne reconnaissait que les mots-clés bibliographiques **génériques** (`Comptes Rendus`, `volume`, `vol.`, `pp.`, `journal`, `proceedings`, `annales`, `transac`, `réf`, `biblio`, `citation`). Les **noms de revues sans mot-clé générique** au format simple `vol:pages` — `Nature 518:529-533`, `Econometrica 32:122-136`, `Annals of Mathematics` — échappaient à la porte de contexte et restaient des faux positifs `MISSING_FROM_OUTPUTS`.

C'est l'exemple **headline** de #9998 : « les 585/357/362 répétés dans `1.2-Manipulation_de_Donnees_avec_NumPy` sont "Nature, 585:357-362, 2020" — mon regex ref-biblio a **manqué** `Nature`/`Science` ».

## Preuve

**Fix minimal additif** (`scan_d5_prose_outputs_alignment.py`, fonction `_is_bibliographic_reference`) : ajout d'un check de contexte étendu sur une **fenêtre étroite de 60 chars** (mirroring class 6 Tier 1) utilisant `_BIBLIO_EXTENDED_CONTEXT_RE` — sur-ensemble strict de `_BIBLIO_CONTEXT_RE` qui ajoute `nature|science|econometrica|annals of mathematics|management science|theory and decision|...`. Le check base 200 chars est **inchangé** (pas de régression de couverture) ; la fenêtre étroite protège du sur-filtrage car `nature`/`science` sont **sans frontière de mot** (`\b`) — une fenêtre large rattraperait « la nature de » en prose loin du pattern.

**Mesuré firsthand (G.1, worktree frais `D:/Dev/CoursIA-d5-refbiblio` sur origin/main `40384ae11`)** :

| Notebook / corpus | Avant fix | Après fix | Delta | Régression |
|---|---|---|---|---|
| `rl_6_dqn_policy_gradient` cell[27] | 7 | 4 | **−3** (Nature 518:529-533 vol+pages) | 0 (9/13/8 structurels + 321 hors-scope conservés) |
| **RL corpus** (famille entière) | 121 | 118 | **−3** | **0** |
| **ML corpus** (contrôle sur-filtrage) | 324 | 324 | **0** | **0** (le fix ne tire que sur `vol:page-page` + keyword journal étendu ≤60 chars ; aucune coïncidence en ML) |

**Tests** : `scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py` → **159 passed** (156 existants + 3 nouveaux) :
- `test_helper_extended_journal_nature_simple_volpages` — `Nature 518:529-533` → 518/529/533 filtrés (cas fondateur rl_6).
- `test_helper_extended_journal_econometrica` — `Econometrica 32:122-136` → 32/122/136 filtrés.
- `test_helper_extended_keyword_far_from_pattern_not_filtered` — garde-fou fenêtre étroite : « nature » en prose à >60 chars d'un range `5:10-15` → NON filtré (prouve que la fenêtre 60, pas 200, prévient le sur-filtrage).

**Collision check (po-2025 = owner D5 #9790)** : `gh pr list --state all --search "ref-biblio OR d5"` → aucun PR OPEN sur ce gap précis. PRs D5 ref-biblio antérieurs MERGED : #10008 (class 4 base `#9995`), #10011 (class 5 xref `.ipynb`), #10033 (class 6 `vol(issue):pages`), #9943 (DOI/arXiv), #10242 (class 8 table-cell). **Celui-ci est un raffinement de class 4 (keyword journal étendu) — nouveau, pas de chevauchement.**

## Perimetre

2 fichiers, `+29/-1` net.
- `scripts/notebook_tools/scan_d5_prose_outputs_alignment.py` : +1 bloc check additif (7 lignes + commentaire) dans `_is_bibliographic_reference`, entre le check base existant et class 6. Aucune ligne existante modifiée (additif pur).
- `scripts/notebook_tools/tests/test_scan_d5_prose_outputs_alignment.py` : +3 méthodes de test (Nature, Econometrica, garde-fou fenêtre).

0 notebook, 0 catalogue, 0 output, 0 code métier. **Scope = FP class 4 extended (keyword journal `vol:pages` simple-form) uniquement.**

**Résiduel out-of-scope (signalé, ne pas étendre ici — principe 3 CLAUDE.md)** :
1. Le `585` signalé sur `1.2-NumPy` cell[4] n'est PAS la réf Nature (qui est en cell[1]) — c'est un `585` séparé dans la prose de vectorisation, correctement conservé par le fix. À examiner séparément si c'est un vrai defect ou un autre FP.
2. `321` sur rl_6 cell[27] reste signalé — probablement une page biblio hors forme `vol:pages` (ex « pp. 321 ») ; classe de FP distincte, hors scope.
3. #9998 reste OPEN : cette PR est une **contribution partielle** au volet ref-biblio (l'issue couvre aussi la caractérisation ML.NET + la classe 1 code-assignment).

See #9998, #9995, #9768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
