### PR TITLE
docs(genai): enrich Test-Time-Scaling - 2 FR transitions (dataset->gen_code->baseline)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/12_Test_Time_Scaling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/12_Test_Time_Scaling.ipynb
@@ -377,6 +377,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ttsen01",
+   "metadata": {},
+   "source": [
+       "### La boucle d'évaluation : générer, extraire, exécuter\n",
+       "\n",
+       "La cellule précédente définit le **dataset de benchmark** `PROBLEMES` — 5 exercices de code de difficulté croissante (`diff` 1 à 5), chacun avec une spécification et une liste de tests exécutables qui servent de **vérité objective**.\n",
+       "\n",
+       "La fonction `gen_code` ci-dessous est le **building block** qui transforme un problème en code : elle envoie la spécification au modèle (en demandant uniquement un bloc ```python```), extrait le code de la réponse, et estime le coût en tokens. C'est l'unité atomique du test-time scaling — les moteurs suivants (Best-of-N, self-consistency, tree-search) ne feront que **l'appeler plusieurs fois** et agréger ses sorties. La vérité viendra de l'exécution des tests, pas d'un juge subjectif.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "3788f1b7",
@@ -430,6 +442,18 @@
     "print(f\"[smoke test] {PROBLEMES[0]['id']} : {_pass}/{_tot} tests, ~{_tok} tokens\")\n",
     "print(\"--- code genere ---\")\n",
     "print(_code[:300])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ttsen02",
+   "metadata": {},
+   "source": [
+       "### L'orchestration comparative : la grille modèles × problèmes\n",
+       "\n",
+       "`gen_code` résout **un** problème pour **un** modèle. La fonction `mesure_baseline` ci-dessous orchestre la **grille complète** : elle boucle sur chaque (modèle, problème), appelle `gen_code` puis `executer_tests`, et agrège les résultats `{passes, total, tokens}` dans une table comparative.\n",
+       "\n",
+       "Cette baseline **single-shot** est le point de référence : combien chaque modèle réussit en un seul essai (température 0), sans aucune stratégie de test-time compute. Les sections suivantes (Best-of-N, self-consistency, tree-search) mesureront si **dépenser plus d'inférence** sur le modèle *cheap* rattrape ou dépasse le modèle *big* — c'est tout l'enjeu empirique du test-time scaling.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #10262

Enrichissement markdown de `12_Test_Time_Scaling.ipynb` (GenAI/Texte, test-time scaling / inference-time compute). Rotation de famille (GameTheory C# → GenAI Python), 3e grain du cycle.

## Lacune narrative réelle

Le notebook enchaînait **3 cellules code consécutives** — le cœur du protocole de benchmark — sans transition conceptuelle entre l'intro (« Le benchmark ») et l'interprétation finale :
- cell 7 : `PROBLEMES` (dataset : 5 exercices de code, diff 1→5, avec tests exécutables = vérité objective),
- cell 8 → 9 : `gen_code` (building block LLM : prompt → extraction bloc python → coût tokens),
- cell 9 → 10 : `mesure_baseline` (grille modèles × problèmes, agrégation {passes, total, tokens}).

Ce trio est un **flot de mesure** qui mérite du bridge narratif : le lecteur passe du dataset au générateur puis à la grille comparative sans comprendre l'enchaînement conceptuel ni pourquoi ce substrat (code + tests) est le bon terrain pour mesurer le test-time scaling.

## Livrable : 2 cellules de transition FR-first

1. **« La boucle d'évaluation : générer, extraire, exécuter »** (avant `gen_code`) — pont dataset → générateur : explique que `PROBLEMES` est le benchmark paramétrique (difficulté croissante), que `gen_code` est l'**unité atomique** du test-time scaling (prompt contraint ```python```, extraction, coût), et que les moteurs suivants (Best-of-N, self-consistency, tree-search) ne feront que l'appeler plusieurs fois. La vérité vient de l'exécution des tests, pas d'un juge subjectif.
2. **« L'orchestration comparative : la grille modèles × problèmes »** (avant `mesure_baseline`) — pont générateur → grille : `gen_code` résout UN problème pour UN modèle ; `mesure_baseline` orchestre la grille complète et agrège les résultats. Cette baseline **single-shot** (température 0) est le **point de référence** que les sections suivantes doivent battre en dépensant plus d'inférence.

## G.1 — preuve du livrable

- `git diff --numstat` : **+24/-0** sur le notebook (addition pure, zéro churn sur les 15 cellules code existantes — `execution_count` et outputs byte-identiques).
- **Raw-string splice** (pas de json round-trip) → préserve byte-identity de toutes les cellules non touchées ([[nbformat-write-churns-untouched-cells-use-raw-json]]). Vérifié : 0 backslash-u escapes (UTF-8 raw préservé), 0 CRLF (LF des deux côtés), JSON valide.
- 2 nouvelles cellules = markdown uniquement, FR-first, LaTeX/code propre.

## C.2 exception — pas de re-exécution

Édition **markdown-only** (0 cellule code source modifiée, 0 output touché — vérifié : 0 ligne `execution_count` changée). Règle C.2 : « Exception : modifs uniquement markdown. » → aucune re-exécution due. Pre-commit H.3 PASS (0 violation : aucune cellule code avec `execution_count is None and not outputs`).

## Non-twin — pas de rebaseline

Ce notebook **n'est pas un twin** (pas d'entrée dans `scripts/notebook_tools/twin_pairs.d/`). Aucun rebaseline `check_twin_parity.py --update` requis → minimise la friction CI.

## Scope (un sujet par PR)

Une PR = un notebook, 2 transitions cohérentes (flot de mesure du benchmark test-time scaling). Ne touche PAS : le catalogue (byte-identique à main), les notebooks frères, le README de série, l'env.

## Variation

prev = MED/notebook-dotnet #10262 (c.80, GameTheory support-enumeration). Ce grain = MED/notebook-python sur **GenAI/Texte** (test-time scaling). G-VAR-3 : changement de **famille** (GameTheory → GenAI) ET de **langage** (C# → Python), substance genuinement distincte (Nash equilibrium algorithm vs inference-time compute benchmark). G-VAR-1 OK (MED + genre CONTENU notebook-python, pas LIGHT-banni).
