### PR TITLE
fix(qc,#10230): correct D2 probe docstring -- measure 82% (227/276) of #9772 was over-counted

### DIFF
--- a/scripts/notebook_tools/scan_d2_window_openness.py
+++ b/scripts/notebook_tools/scan_d2_window_openness.py
@@ -15,10 +15,28 @@ produire un Sharpe 0.225 le 2026-04-27 et un Sharpe 0.123 le 2026-08-06,
 soit une degradation de ~46 % en 3,4 mois sur les memes parametres
 committes. La barre de mesure etait `SetEndDate(2024, 12, 31)` absente.
 
-L'audit Phase 0 (issue #9772, c.1331+13) a mesure le phenomene sur le depot
-reel : 0 % des `main.py` QuantConnect sont D2+, mais **82 % des notebooks
-QC (227/276)** le sont. ML-Training-Pipeline concentre 8/8 D2+ -- c'est un
-cluster-specifique qui meriterait un audit dedie.
+Historique de la mesure (IMPORTANT -- ne pas propager la mesure #9772) :
+
+  - L'audit Phase 0 (issue #9772, c.1331+13) avait rapporte **82 % de D2+
+    (227/276)** via un grep manuel `set_end_date`. Cette mesure SUR-COMPTAIT :
+    elle incluait ~87 notebooks **sans aucune API QC** (ni QuantBook, ni
+    QCAlgorithm, ni add_equity/set_start_date) sur lesquels `set_end_date` est
+    un no-op ou un NameError. Les 8 notebooks `ML-Training-Pipeline/` cibles
+    du correctif propose etaient tous dans ces 87 -- les ajouter aurait ete
+    "satisfaire le grep sans corriger le defaut" (motif #1214).
+  - Refute firsthand (issue #10230, re-mesure G.1) : ce probe deterministe
+    rapporte **3/207 (1.4 %)** car il ne capte que la **forme S** (SetStartDate
+    sans SetEndDate). Les 3 autres formes de drift -- N (`datetime.now()`),
+    L (`qb.History(sym, N)` lookback-count), T (`timedelta`) -- qui constituent
+    la majorite des drift reels, ECHAPPENT a ce probe.
+  - Le detecteur canonique des 4 formes est ``scan_window_drift.py`` (#10235),
+    qui rapporte ~31/207 DRIFT (verdicts DRIFT/PINNED/INDETERMINE/N-A).
+    **Pour mesurer le D2 reel, utiliser scan_window_drift.py, pas ce probe.**
+
+Ce probe reste utile comme **filtre forme-S** rapide (SetStartDate explicite
+sans SetEndDate, le sous-ensemble le plus facile a corriger) et pour le scope
+Phase 2 des sources deployables (``main.py`` / ``Main.cs``) non couvert par
+scan_window_drift.py.
 
 Cet outil transforme l'audit manuel (forensic au cas par cas) en un
 **detecteur deterministe** utilisable en CI :
@@ -93,9 +111,14 @@ Usage
 
 Sortie type (--format text)
 ---------------------------
-  QC-Notebooks D2+ (fenetre non figee) : 227/276 (82 %)
-  QC-Notebooks conformes (EndDate OK)   : 49/276 (18 %)
-  QC-Notebooks sans SetStartDate (N/A)  : 0/276 (0 %)
+  Total D2+ (fenetre non figee)       : 3/207 (1.4 %)   <- forme S seule
+  Total CONFORME (EndDate OK)         : 43/207
+  Total NEUTRE (sans SetStartDate)    : 161/207
+
+  NOTE : ce probe ne capte que la forme S (SetStartDate sans SetEndDate).
+  Les formes N/L/T (datetime.now / lookback-count / timedelta) echappent ;
+  elles sont mesurees par scan_window_drift.py (~31/207 DRIFT, 4 formes).
+  Voir issue #10230 (refutation firsthand de la mesure 82 % de #9772).
   ---
   Echantillon D2+ (10 premiers) :
     MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly_companion.ipynb
@@ -105,6 +128,13 @@ Sortie type (--format text)
 Voir aussi
 ----------
 - Issue #9772 (Phase 0 audit, c.1331+13) -- mesure empirique 227/276 D2+
+  **SUR-COMPTEE** (grep manuel incluant ~87 notebooks sans API QC = no-op).
+  Refutee firsthand par issue #10230 (re-mesure G.1) : vrai D2 multi-forme
+  ~9.5 %, ce probe forme-S = 1.4 %. NE PAS reprendre la mesure 82 %/#9772.
+- Issue #10230 -- refutation de la mesure #9772 + diagnostic des 4 formes.
+- ``scan_window_drift.py`` (#10235) -- detecteur CANONIQUE D2 (4 formes
+  N/L/T/S, verdicts DRIFT/PINNED/INDETERMINE/N-A). A utiliser pour la mesure
+  reelle ; ce probe est le filtre forme-S + scope sources deployables.
 - EPIC #9768 -- cadre methodologique (D1-D6)
 - .claude/rules/audit-cross-source-distillation.md -- regle HARD 1 :
   aucun rapport committe (sorties de l'audit = dashboard + issues filles)
@@ -507,6 +537,19 @@ def _format_text(report: dict[str, Any]) -> str:
     if report["errors"]:
         lines.append("Erreurs de lecture :")
         lines.extend(f"  {e['path']}: {e['error']}" for e in report["errors"])
+    # Advisory : ce probe ne capte que la forme S (SetStartDate sans SetEndDate).
+    # Les formes N/L/T (datetime.now / lookback-count / timedelta) echappent et
+    # sont mesurees par scan_window_drift.py. Voir #10230 (refutation 82 %/#9772).
+    lines.append("---")
+    lines.append(
+        "NOTE : ce probe capte la forme S (SetStartDate sans SetEndDate) "
+        "uniquement."
+    )
+    lines.append(
+        "      Formes N/L/T (datetime.now / qb.History(N) / timedelta) -> "
+        "scan_window_drift.py (#10235, 4 formes, ~31 DRIFT)."
+    )
+    lines.append("      La mesure 82 % de #9772 etait SUR-COMPTEE (refutee #10230).")
     return "\n".join(lines)
 
 

--- a/scripts/notebook_tools/tests/test_scan_d2_window_openness.py
+++ b/scripts/notebook_tools/tests/test_scan_d2_window_openness.py
@@ -8,6 +8,14 @@ un faux negatif absout un notebook D2+ et le signal perd toute credibilite
 des la premiere declaration usurpee. Un faux positif accuse un notebook
 conforme et bloque une PR legitime.
 
+PORTEE -- ce probe capte la **forme S** seule (SetStartDate sans SetEndDate).
+Les formes N (datetime.now()), L (qb.History(sym, N)), T (timedelta)
+echappent et sont mesurees par scan_window_drift.py (#10235, 4 formes).
+La mesure 82 % (227/276) de #9772 etait un grep manuel SUR-COMPTE (incluait
+~87 notebooks sans API QC = no-op), refusee firsthand par #10230. Ce probe
+deterministe rapporte ~1.4 % (forme S) ; le vrai D2 multi-forme est ~15 %
+(scan_window_drift, ~31/207). Voir #10230 pour le diagnostic complet.
+
 Les tests ci-dessous couvrent les 4 axes :
 
   1. **Vrais positifs** -- un notebook avec SetStartDate mais sans SetEndDate
@@ -32,9 +40,11 @@ fixture. Le detecteur est du Python pur operant sur des dicts `cells[]` ;
 on synthetise exactement les structures que Jupyter produit.
 
 References :
-  - Issue #9772 : Phase 0 audit (mesure empirique 227/276 D2+)
+  - Issue #9772 : Phase 0 audit (mesure 227/276 D2+ -- SUR-COMPTEE, voir #10230)
+  - Issue #10230 : refutation firsthand de la mesure #9772 + diagnostic 4 formes
+  - scan_window_drift.py (#10235) : detecteur CANONIQUE D2 (4 formes N/L/T/S)
   - EPIC #9768 : cadre methodologique (D1-D6)
-  - c.1331+13-L1 ★★ : `grep -L` MSYS non fiable (immune ici, on utilise pathlib)
+  - c.1331+13-L1 : `grep -L` MSYS non fiable (immune ici, on utilise pathlib)
 """
 
 from __future__ import annotations
@@ -795,3 +805,75 @@ class TestScanMergedPopulations:
         # by_type doit contenir 'cs'
         assert "cs" in report["by_type"]
         assert report["by_type"]["cs"]["D2+"] >= 1
+
+
+class TestFormSScopeLimitation:
+    """Portee du probe : forme S (SetStartDate sans SetEndDate) SEULE.
+
+    Ce probe NE capte PAS les formes N/L/T de drift (datetime.now, lookback-count,
+    timedelta) -- qui constituent la majorite des drift reels sur le corpus QC.
+    Ces formes sont mesurees par scan_window_drift.py (#10235). Les tests
+    ci-dessous ANCRENT cette limitation dans le code : si un futur contributeur
+    ajoutait par megarde une detection des formes N/L/T ici, il dupliquerait
+    scan_window_drift.py ; si on retirait la forme S, on perdrait le filtre S.
+
+    Refs : #10230 (refutation de la mesure 82 %/#9772), #10235 (scan_window_drift).
+    """
+
+    def test_form_lookback_count_L_not_detected(self, tmp_path):
+        """Forme L : qb.History(sym, 2520, Resolution.DAILY) drift (N barres
+        depuis maintenant) MAIS ce probe ne le capte pas (pas de SetStartDate).
+        C'est attendu : scan_window_drift.py couvre cette forme. On verifie ici
+        que le probe rend NEUTRE (pas de faux D2+ sur un pattern qu'il ne mesure
+        pas honnetement)."""
+        nb_path = tmp_path / "lookback.ipynb"
+        nb_path.write_text(json.dumps({
+            "cells": [
+                {"cell_type": "code", "source": [
+                    "from QuantConnect.Research import QuantBook",
+                    "qb = QuantBook()",
+                    "history = qb.history(['SPY'], 2520, Resolution.DAILY)",
+                ], "outputs": []},
+            ],
+            "metadata": {}, "nbformat": 4, "nbformat_minor": 5,
+        }), encoding="utf-8")
+        rec = classify_notebook(nb_path)
+        assert rec["verdict"] == "NEUTRE"
+        assert rec["has_qc_context"] is True
+        assert rec["has_set_start"] is False
+
+    def test_form_datetime_now_N_not_detected(self, tmp_path):
+        """Forme N : end = datetime.now() drift avec l'horloge murale, mais
+        ce probe ne le capte pas. Verifie que le probe ne pretend PAS mesurer
+        cette forme (honetete de portee, anti-claim-trompeur)."""
+        nb_path = tmp_path / "nownb.ipynb"
+        nb_path.write_text(json.dumps({
+            "cells": [
+                {"cell_type": "code", "source": [
+                    "from QuantConnect.Research import QuantBook",
+                    "from datetime import datetime",
+                    "qb = QuantBook()",
+                    "end = datetime.now().strftime('%Y-%m-%d')",
+                ], "outputs": []},
+            ],
+            "metadata": {}, "nbformat": 4, "nbformat_minor": 5,
+        }), encoding="utf-8")
+        rec = classify_notebook(nb_path)
+        assert rec["verdict"] == "NEUTRE"
+
+    def test_form_S_set_start_without_end_IS_detected(self, tmp_path):
+        """Forme S (la seule que ce probe couvre) : SetStartDate sans SetEndDate
+        + contexte QC -> D2+. C'est le sous-ensemble honnetement mesure."""
+        nb_path = tmp_path / "formS.ipynb"
+        nb_path.write_text(json.dumps({
+            "cells": [
+                {"cell_type": "code", "source": [
+                    "from QuantConnect.Research import QuantBook",
+                    "qb = QuantBook()",
+                    "qb.SetStartDate(2015, 1, 1)",
+                ], "outputs": []},
+            ],
+            "metadata": {}, "nbformat": 4, "nbformat_minor": 5,
+        }), encoding="utf-8")
+        rec = classify_notebook(nb_path)
+        assert rec["verdict"] == "D2+"


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/feature #10264

## Quoi

**Tâche 3 de #10230** (mon claim P1 QC) : correction du probe `scan_d2_window_openness.py` qui perpétuait la **mesure fausse 82 % (227/276)** de l'audit Phase 0 #9772 comme si c'était son résultat — alors que mesuré firsthand ce cycle, le probe déterministe rapporte **3/207 (1,4 %)**.

Le diagnostic #10230 avait établi que la mesure 82 % de #9772 (grep manuel) **sur-comptait** : elle incluait ~87 notebooks **sans aucune API QC** (ni QuantBook, ni QCAlgorithm, ni add_equity/set_start_date) sur lesquels `set_end_date` est un no-op ou un NameError. Les 8 notebooks `ML-Training-Pipeline/` cibles du correctif proposé étaient tous dans ces 87 — les ajouter aurait été « satisfaire le grep sans corriger le défaut » (motif #1214). Le probe déterministe #9783, lui, exclut déjà ces notebooks via `RE_QC_CONTEXT` (→ NEUTRE), d'où son 1,4 %.

**Le sur-comptage résiduel réel = le docstring du probe propageait la mesure fausse** (3 endroits : docstring principal L18-21, exemple de sortie L96-98, Voir aussi L107) + le test file (docstrings L6, L35). Un lecteur du code pensait que le probe rapportait 82 % — c'était trompeur.

## Preuve

**Mesuré firsthand (G.1, worktree frais `D:/Dev/CoursIA-qc10230-probe` sur origin/main `3640450f2`)** :

| Détecteur | Verdict D2+/DRIFT | Portée | Source |
|---|---|---|---|
| `scan_d2_window_openness.py` (ce probe) | **3/207 (1,4 %)** D2+ | forme S seule (SetStartDate sans SetEndDate) | #9783 |
| `scan_window_drift.py` (canonique, #10235 MERGED) | **~31/207** DRIFT | 4 formes N/L/T/S | #10235 |
| Mesure manuelle #9772 (grep) | ~~227/276 (82 %)~~ **SUR-COMPTE** | incl. 87 notebooks no-API | réfuté #10230 |

**Tâche 2 (confirmation des drift)** : `scan_window_drift.py` rapporte **31 DRIFT** aujourd'hui (le corpus QC a grandi depuis le diagnostic 21/220 de #10230 — ordre de grandeur cohérent). Le probe D2+ (3) sous-compte massivement les formes N/L/T — qui sont la majorité des drift réels.

**Correction appliquée** (additif, 0 logique de verdict changée — le probe faisait déjà correctement son travail forme-S) :
1. **Docstring principal** : remplace l'affirmation « 82 % (227/276) » par l'historique honnête (mesure #9772 sur-comptée, réfutation #10230, ce probe = forme S 1,4 %, scan_window_drift = canonique 4 formes ~31).
2. **Exemple de sortie** : corrigé `227/276 (82 %)` → exemple réel `3/207 (1,4 %)` + note advisory.
3. **Voir aussi** : ajoute réfutation #10230 + cross-ref `scan_window_drift.py` comme détecteur canonique.
4. **Sortie `_format_text`** : ajoute 3 lignes advisory **visibles à l'usage** (pas seulement dans le docstring) pointant vers scan_window_drift.py pour les formes N/L/T.
5. **Test file** : corrige les docstrings L6/L35 (portaient « 227/276 D2+ ») + nouvelle classe `TestFormSScopeLimitation` (3 tests) ancrant la limitation forme-S dans le code — un notebook forme-L (`qb.History(sym, 2520)`) et forme-N (`datetime.now()`) rendent NEUTRE (honnête : ce probe ne les mesure pas), tandis que la forme S (`SetStartDate` sans `SetEndDate`) rend bien D2+.

**Tests** : `test_scan_d2_window_openness.py` → **58 passed** (55 existants + 3 nouveaux). `test_scan_window_drift.py` → **14 passed** (voisin, no regression). `grep` résiduel 82 %/227 dans `scripts/` `docs/` `.github/` hors fichiers édités → **0 référence**.

## Perimetre

2 fichiers, +134/−9.
- `scripts/notebook_tools/scan_d2_window_openness.py` : docstring corrigé (3 blocs) + sortie advisory + Voir aussi. 0 ligne de logique de verdict modifiée.
- `scripts/notebook_tools/tests/test_scan_d2_window_openness.py` : docstrings corrigés (2) + classe `TestFormSScopeLimitation` (3 tests).

0 notebook, 0 catalogue, 0 output, 0 code métier. **Scope = correction de claim factuel faux (mesure 82 %) propagé dans le code du détecteur + documentation honnête de la portée forme-S.**

**Résiduel out-of-scope (signalé — principe 3)** :
1. #10230 reste OPEN : tâche 4 (correction des 21+ notebooks DRIFT) est gated QC Cloud (MCP qc-mcp / Playwright, `set_end_date` réel), hors grain CPU. Les 8 notebooks `ML-Training-Pipeline/` (qcapi=0) ne sont PAS à corriger — ils n'ont pas d'API QC.
2. La mesure fausse 82 %/227 peut subsister dans des issues/commentaires GitHub (non-corrigible depuis le code) — le docstring corrigé est désormais la source de vérité.

See #10230 (tâches 2-3), #10235 (détecteur canonique), #9772 (mesure sur-comptée réfutée), #9768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
