### PR TITLE
feat(translation,#10042): wire T3 activation couture (en, finetuning perimeter)

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -60,11 +60,13 @@ name: Translation Sync
 # PR after the source-language change has landed on main.
 #
 # Coupling / honest current state:
-#   - T3 (translate_csv.py) is GATED by ENABLED=False until grain D (#10043)
-#     activates it. Until then the T3 step is a NO-OP: T1 refreshes src_hash,
-#     T2 detects drift, T4 re-renders EXISTING translations, but no NEW
-#     translations are produced. The pipeline becomes fully functional the
-#     moment D lands (ENABLED=True) — no change to this workflow required.
+#   - T3 (translate_csv.py) is ACTIVATED. Grain D (#10055, MERGED) landed the
+#     TRANSLATE_ENABLED env gate + --max-cells hard cap; this workflow now wires
+#     them. INITIAL ACTIVATION PERIMETER (ai-01 dispatch #10042 items 5-7): en
+#     only, genai/finetuning series (161 cells, 71 text_en still empty). The
+#     hand-rendered FT-01-Introduction-FineTuning_en.ipynb serves as positive
+#     control — the bot must reproduce an equivalent file. Widen the perimeter
+#     (more series, more langs) only after the positive control passes.
 #   - The translation API key comes from GitHub secrets (never a literal, never
 #     logged — secrets-hygiene §1-3): secrets.OPENAI_API_KEY (primary) /
 #     secrets.OPENROUTER_API_KEY (fallback). A repo admin must add the secret.
@@ -218,30 +220,38 @@ jobs:
           echo "$REPORT"
 
       # ------------------------------------------------------------------
-      # T3 — translate CHANGED CELLS ONLY. GATED by ENABLED=False in
-      # translate_csv.py until grain D (#10043) activates it. The env carries
-      # the API key from GitHub secrets (never a literal). Until D lands this is
-      # a no-op (the script prints [GATED] and exits 0); the pipeline structure
-      # is correct and activates unchanged when D lands.
+      # T3 — translate CHANGED CELLS ONLY. ACTIVATED (grain D #10055 landed the
+      # TRANSLATE_ENABLED gate + --max-cells cap; this step wires them). Initial
+      # activation perimeter (ai-01 dispatch #10042 items 5-7): en only,
+      # genai/finetuning series. translate_csv.py only translates MARKDOWN cells
+      # whose text_<lang> is empty (cost-marginal property, D4). The 90 markdown
+      # text_en cells are already filled (#10018) -> T3 plans 0 new translations
+      # on the first run; the 71 code cells stay untranslated (include_code=False).
+      # A future change to a finetuning markdown cell re-activates T3 for THAT
+      # cell only. The env carries the API key from GitHub secrets (never literal).
       # ------------------------------------------------------------------
-      - name: T3 translate changed cells (gated on #10043)
+      - name: T3 translate changed cells (en, finetuning perimeter)
         if: steps.t1.outputs.has_translations == 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          TRANSLATE_ENABLED: "1"
+          TRANSLATE_MAX_CELLS: "100"
         run: |
           set -euo pipefail
-          echo "T3 status: translate_csv.py ENABLED flag = governed by grain D (#10043)."
-          # Apply across all CSVs. translate_csv.py only translates cells whose
-          # text_<lang> is empty (the cost-marginal property): unchanged cells
-          # with existing translations are never re-submitted.
-          find translations -name '*.csv' -print0 | while IFS= read -r -d '' csv; do
-            echo "T3 processing: $csv"
-            python scripts/translation/translate_csv.py --csv "$csv" --apply || {
-              echo "::notice title=T3 translate::GATED or failed for $csv (ENABLED=False until #10043, or missing API key). No-op, continuing.";
+          echo "T3 status: ACTIVATED (TRANSLATE_ENABLED=1). Perimeter = en, genai/finetuning. Hard cap = ${TRANSLATE_MAX_CELLS} cells/run."
+          # Initial activation perimeter (ai-01 #10042): en only, finetuning.csv.
+          # Widen (more CSVs, more langs) only after FT-01_en positive control passes.
+          csv="translations/genai/finetuning.csv"
+          if [ ! -f "$csv" ]; then
+            echo "T3 skip: $csv not on this branch. No-op, continuing."
+          else
+            echo "T3 processing: $csv (--lang en, --max-cells ${TRANSLATE_MAX_CELLS})"
+            python scripts/translation/translate_csv.py --csv "$csv" --apply --lang en --max-cells "${TRANSLATE_MAX_CELLS}" || {
+              echo "::notice title=T3 translate::failed for $csv (missing API key, rate-limited, or cap reached). Derived files unaffected — T4 re-renders existing translations only. Continuing.";
             }
-          done
-          echo "T3 done. If ENABLED=False (pre-D), no new translations were produced — T4 re-renders existing ones only."
+          fi
+          echo "T3 done."
 
       # ------------------------------------------------------------------
       # T4 — re-render the *_<lang>.ipynb of active languages from each CSV.
@@ -320,7 +330,7 @@ jobs:
 
           git commit \
             -m "chore(translation): auto-sync derived translations [bot] [skip ci]" \
-            -m "See #10038 #10042; T3 gated on #10043; long-lived PR delivery (See #10133 #10136)." \
+            -m "See #10038 #10042 #10055; T3 activated (en, finetuning perimeter); long-lived PR delivery (See #10133 #10136)." \
             -m "Generated by translation-sync.yml on push to main. Direct push to main blocked by GH006 (PR gate required); this commit lives on chore/translation-sync-pending until a maintainer merges the long-lived PR."
 
           if ! git push origin "HEAD:$BRANCH"; then


### PR DESCRIPTION
Grain: DEEP/tooling — lane myia-po-2025:CoursIA-2 — prev: DEEP/guard #10236

## La couture T3/T4 manquait — le moteur tournait à vide

Grain D (#10055, MERGED) a livré dans `translate_csv.py` le gate `TRANSLATE_ENABLED` (env) + la cape dure `--max-cells`. Mais `translation-sync.yml` **ne câblait jamais ces flags** : le step T3 appelait `translate_csv.py --apply` **sans** `TRANSLATE_ENABLED=1` → le script lisait l'env (défaut inactif) → affichait `[GATED]` → exit 0 → **0 traduction**, et T4 ne re-renderait que l'existant. ai-01 l'avait diagnostiqué dans son dispatch #10042 : « les deux grains sont corrects séparément, c'est la couture entre eux qui manque ».

## Ce que la PR fait (items 5-7 du dispatch ai-01)

| Item | Avant | Après |
|---|---|---|
| **1. Activation** | T3 env sans `TRANSLATE_ENABLED` → `[GATED]` no-op | `TRANSLATE_ENABLED: "1"` + `TRANSLATE_MAX_CELLS: "100"` (cape dure écrite dans le YAML) |
| **2. Périmètre** | `find translations -name '*.csv'` (tous CSVs, 7 langs) | **en seul, `translations/genai/finetuning.csv`** (D3 de #10038, périmètre initial) |
| **3. Commentaire menteur** | « GATED until grain D (#10043) activates it » (D landed #10055 MERGED) | « ACTIVATED (grain D #10055 landed) » — même classe de défaut que le swap-comment #9863 |

`--lang en --max-cells "${TRANSLATE_MAX_CELLS}"` câblés à l'appel `translate_csv.py`. Le message de commit du bot reflète aussi l'activation (pas « gated on #10043 »).

## Coût marginal démontré (acceptance D4, mesuré firsthand)

`finetuning.csv` : **161 lignes = 90 markdown + 71 code**. Les 90 cellules markdown `text_en` sont **déjà remplies** (#10018). Les 71 vides sont des **cellules code** (`include_code=False`, non traduites par défaut). Vérifié firsthand :

```
$ python translate_csv.py --csv finetuning.csv --apply --lang en --max-cells 5
[load] 161 lignes (90 markdown, 71 code)
[plan] 0 traductions nécessaires (1 langue(s), include_code=False)
[GATED] TRANSLATE_ENABLED inactif... exit 0   ← avec TRANSLATE_ENABLED=1 : plan 0, aucune mutation
```

→ **T3 activé planifie 0 traduction** (rien à traduire : le markdown en est fait). La propriété coût-marginal tient : seules les cellules vides/changées sont soumises. Une future modif d'une cellule markdown finetuning ré-active T3 pour **cette cellule seule**.

## Comment l'acceptance est démontrée (post-merge)

Le trigger `on.push.paths` filtre sur notebooks/translations/scripts — **un PR workflow-only ne trigger pas auto au merge**. ai-01 déclenche via **`workflow_dispatch`** après merge :

1. Bot lance T3 → plan 0 (markdown en fait) → T4 **render `FT-01-Introduction-FineTuning_en.ipynb`** autonomement depuis le CSV.
2. `FT-01_en.ipynb` rendu à la main (présent sur main) = **contrôle positif** : le bot doit produire un fichier équivalent (vérifiable par diff).
3. Bot commit CSV + notebook rendu sur `chore/translation-sync-pending` (long-lived PR, pattern #10145) → merge → acceptance « ≥1 `*_en.ipynb` produit par le bot sans intervention d'agent ».

## Vérifications

- `yaml.safe_load` OK sur le fichier modifié.
- Flags `--lang en --max-cells N` acceptés par `translate_csv.py` argparse (parse OK, `[GATED]` exit 0 sans API = pas de mutation, pas de coût).
- Aucun littéral de secret (`secrets.OPENAI_API_KEY` / `secrets.OPENROUTER_API_KEY` via env GitHub, jamais echo/log).
- Catalogue byte-identique à main (PR touche 1 fichier workflow only).
- L898 : 0 PR ouverte sur translation-sync/guard avant edit ; `chore/translation-sync-pending` n'existe pas encore (le bot la créera au 1er run).

See #10042 (items 5-7) · #10038 (umbrella, mandat user 2026-08-08) · #10055 (grain D landed) · #10145 (long-lived-PR pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
