### PR TITLE
docs(smt,#9434): drain machine-dependent wallclock estimate from Einstein's Riddle Prong-B cell

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb
@@ -276,7 +276,7 @@
     "\n",
     "Pour **mesurer** l'ecart (plutot que l'affirmer), comparons la taille de l'espace de recherche a ce que fait Z3 :\n",
     "\n",
-    "- **Brute force** : enumerer toutes les permutations de chaque attribut, soit `(5!)^5 = 120^5 = 24 883 200 000` combinaisons, puis tester les 15 indices pour chacune. A raison de ~100 millions de tests par seconde en C# natif, cela represente de l'ordre de **4 minutes** de calcul - et le test des 15 indices rend chaque candidat nettement plus lent en pratique.\n",
+    "- **Brute force** : enumerer toutes les permutations de chaque attribut, soit `(5!)^5 = 120^5 = 24 883 200 000` combinaisons, puis tester les 15 indices pour chacune. Cet espace de **~25 milliards** de candidats est inatteignable par enumeration exhaustive - et le test des 15 indices rend chaque candidat nettement plus lent. C'est precisement cet ecart de complexite que Z3 evite : il propage les contraintes au lieu d'enumerer.\n",
     "- **Z3** : formuler les 25 variables + domaine + 5 `Distinct` + 15 indices, et laisser le solveur propager. La propagation fixe `Norwegian = 0` et `Milk = 2` sans aucun essai, puis reduit les domaines jusqu'a la solution unique.\n",
     "\n",
     "Mesurons également si la solution est **unique** : ajoutons une contrainte niant la solution trouvee (au moins un attribut différent) et re-solvons. Si Z3 repond UNSAT, la solution est prouvee unique."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #10268

#9434 precision-drain : retirer l'estimation wallclock machine-dépendante de `18_Einsteins_Riddle` (SymbolicAI/SMT). **Famille fraîche** (SymbolicAI — SMT/Z3, jamais touchée ce window) sur l'épic #9434 en cours (drain des valeurs machine-dépendantes, distinct de l'enrichissement).

## La dérive mesurée firsthand

La cellule `cell[5]` (« Approche naïve vs solveur : mesurer l'écart », Prong-B) portait une **estimation de temps dérivée d'un débit machine-dépendant** :

> « A raison de **~100 millions de tests par seconde en C# natif**, cela represente de l'ordre de **4 minutes** de calcul »

Le débit « ~100 millions de tests/seconde » **dérive d'une machine à l'autre** (fréquence CPU, cache, JIT) → le « 4 minutes » dérive avec lui. C'est exactement la classe de valeur que #9434 veut tenue par le déterministe, pas par la prose. Le détecteur `check_machine_dep_timing.py` flaggait `cell[5]` (« 4 minutes », wallclock).

## Principe appliqué : garder le comptage déterministe, drainer le temps machine

Le notebook produit **deux** sortes de quantités dans cette cellule :

| Quantité | Exemple | Machine-dépendant ? | Décision |
|---|---|---|---|
| **Taille de l'espace de recherche** | `(5!)^5 = 120^5 = 24 883 200 000` combinaisons | **Non** (combinatoire exacte) | **GARDÉ** |
| **Structure du problème** | 25 variables + 5 `Distinct` + 15 indices | **Non** | **GARDÉ** |
| **Débit CPU** | « ~100 millions de tests/seconde en C# natif » | **Oui** (wallclock) | **DRAINÉ** |
| **Temps dérivé** | « ~4 minutes de calcul » | **Oui** (wallclock dérivé) | **DRAINÉ** |

## Changement (cell[5] markdown, 1 point de drain)

La phrase machine-dépendante est remplacée par un **ancrage sur le comptage déterministe** :
- Avant : « ~100 millions de tests/seconde... ~4 minutes de calcul »
- Après : « Cet espace de **~25 milliards** de candidats est inatteignable par énumération exhaustive [...]. C'est précisément cet écart de complexité que Z3 évite : il propage les contraintes au lieu d'énumérer. »

Le message pédagogique (Prong-B « mesurer l'écart ») est **renforcé** : l'écart se lit désormais sur le **comptage** (25 milliards de candidats bruts vs ~0 essais pour Z3 qui propage `Norwegian = 0`, `Milk = 2`), pas sur une estimation de minutes qui glisse.

## G.1 — preuve du livrable

- **Markdown-only** : 0 cellule code touchée, 0 output modifié. Exception C.2 (modifs uniquement markdown) → **0 re-exécution due**.
- Raw-text replace (pas de json round-trip) → 0 churn sur les 15 autres cellules. LF préservé (0 CRLF des deux côtés). JSON valide, H.3 0 violation.
- **Déterministe préservé** : `(5!)^5 = 120^5 = 24 883 200 000`, `~25 milliards`, « 25 variables + 5 Distinct + 15 indices », « le test des 15 indices rend chaque candidat plus lent » — tous intacts. La mécanique de l'écart (propagation vs énumération) est explicitée.
- Le **temps réel de Z3** reste mesuré par le `Stopwatch` de `cell[6]` (output = mesure vivante) et resté qualitatif en `cell[4]` (« quelques millisecondes » — déjà dé-précisionné, non touché).

## Non-twin — pas de rebaseline

Ce notebook **n'est pas un twin** (pas d'entrée dans `scripts/notebook_tools/twin_pairs.d/`). Aucun rebaseline requis.

## Scope (un sujet par PR)

Une PR = un notebook, drain #9434 de l'estimation wallclock de la cellule Prong-B. Ne touche PAS : le code, les outputs, le catalogue (byte-identique à main), les notebooks frères.

## Variation

prev = MED/notebook-dotnet #10268 (c.82, Sudoku backtracking drain). Ce grain = MED/notebook-dotnet sur **SymbolicAI/SMT** (Einstein's Riddle, Z3). **Même genre** (notebook-dotnet) + **même work-type** (drain #9434) — adjacence assumée et transparente. **Substance genuinement distincte** : le drain Sudoku portait sur une **mesure de runtime** (timings en output, restitués en prose) ; celui-ci porte sur une **estimation théorique dérivée d'un débit CPU** (pas une mesure, un calcul de coin de table). Le litmus LIGHT « générable en scannant l'instance suivante » ne mord pas : chaque drain exige de juger déterministe vs machine-dépendant dans son domaine (backtracking runtime vs complexité combinatoire estimée). **Famille fraîche** (SymbolicAI — 5ᵉ famille distincte ce window après Search/GameTheory/GenAI-Texte/Sudoku).
