### PR TITLE
docs(cluster,#9976): po-2025 lane-table routing note — off-LAN, not CPU-only

### DIFF
--- a/docs/reference/cluster-agents.md
+++ b/docs/reference/cluster-agents.md
@@ -101,7 +101,7 @@ Depuis ~juin 2026, chaque machine worker porte **deux lanes** (un `lane` = machi
 | Machine | Lane `CoursIA` (dashboard `workspace-CoursIA`) | Lane `CoursIA-2` (dashboard `workspace-CoursIA-2`) |
 |---------|-----------------------------------------------|---------------------------------------------------|
 | `myia-po-2024` | QC backtest + ML (RTX 3070) | MetaGeneticSharp / metaheuristiques .NET (#1203) |
-| `myia-po-2025` | Python / ML CPU-only (exec OpenRouter) | .NET / Argumentum (#2137) |
+| `myia-po-2025` | Python / ML (off-LAN — OpenRouter pour LLM, vLLM local non-joignable, cf [#9976](https://github.com/jsboige/CoursIA/issues/9976)) | .NET / Argumentum (#2137) |
 | `myia-po-2026` | Lean Conway/Knot + embeddings GenAI | Grothendieck (#2159) |
 
 `po-2023` (hote GenAI) et `ai-01` (coord) n'ont qu'une lane `CoursIA`. po-2025 ajoute par ailleurs ses 2 workspaces EPITA (cf section "po-2025 - 3 agents distincts").


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #10267

## Quoi

**Correction d'une prémisse de routage fausse** dans la lane-specialization table de `docs/reference/cluster-agents.md` (L104). La ligne portait `Python / ML CPU-only (exec OpenRouter)` — or la raison pour laquelle po-2025 route l'inférence LLM vers OpenRouter est **off-LAN** (vLLM local `192.168.0.47:5002` non-joignable, `172.24.44.x` disjoint du `192.168.0.x`), **pas** le fait d'être CPU-only. Signalé par ai-01 (PART 2/2 intercom) : « dont la note de routage est fausse (la contrainte réelle est off-LAN, pas "CPU-only") ».

## Preuve

Le corps du doc documentait **déjà** off-LAN correctement en 4 endroits :
- L12 (topologie) : po-2025 = `172.24.44.172`, LAN disjoint
- L27 (vLLM medium) : po-2025 = LAN disjoint, NON joignable par défaut
- L46 (règle de routage #9976 option (a)) : aucun grain nécessitant l'inférence locale dispatché vers une lane hors-LAN
- L74 (mesures) : 2026-08-08 po-2025 `HTTP 000` + 100 % ping loss firsthand

La lane-table L104 était la **seule** ligne avec le label stale « CPU-only ». `grep -rn "CPU-only" docs/` → résidu uniquement dans des contextes DIFFÉRENTS et exacts (kernels-runtime.md L114/L126 : « CPU-only strict » thermal = policy de ML training local, exact et séparé ; dissociations-matrix.md ICT CPU-only ; cost-matrix.md métadonnées étudiant).

**Note de réconciliation G.1** : po-2025 EST « CPU-only strict » pour le **ML training local** (thermal, 11 crashes GPU — documenté kernels-runtime.md L114). Cette PR ne touche PAS ce fait. Elle corrige uniquement l'**explication de routage LLM** (pourquoi OpenRouter) : off-LAN, pas CPU-only.

## Perimetre

1 fichier, +1/−1.
- `docs/reference/cluster-agents.md` : 1 ligne (L104 lane-table). 0 autre ligne modifiée.

0 notebook, 0 catalogue, 0 output, 0 code métier.

**Stacking avec #10258** (OPEN, même issue #9976) : #10258 touche L12+L27 (mesure LAN firsthand po-2025, LAN physiquement disjoint non-artefact-WSL). Cette PR touche L104 (lane-table label). **Hunks disjoints, 0 conflit** — l'un ou l'autre merge en premier, l'autre rebase proprement. #10258 ne corrigeait PAS le label L104 « CPU-only » — d'où cette PR complémentaire.

**Résiduel out-of-scope** : inventaire kernels po-2023 (12 kernels, mesuré firsthand ce cycle) livré à ai-01 via DM (msg-20260810T024646-o479jm) — ai-01 inscrira lui-même (turfe).

See #9976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
