### PR TITLE
docs(gametheory4): enrich Nash equilibrium multiplicity taxonomy interpretation cell

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
@@ -1155,6 +1155,38 @@
     "Analyze(bos);\n"
    ]
   },
+    {
+   "cell_type": "markdown",
+   "id": "gt4-multeq-interpretation",
+   "metadata": {},
+   "source": [
+    "Les cinq jeux canoniques se partitionnent en **deux régimes** selon le nombre\n",
+    "d'équilibres. D'un côté, le **Dilemme du Prisonnier** (1 équilibre pur,\n",
+    "$(D,D)$) et **Matching Pennies** (1 équilibre mixte, $p=0{,}5$) : chacun admet\n",
+    "un équilibre **unique**. De l'autre, **Stag Hunt**, **Coordination** et\n",
+    "**Battle of the Sexes** en comptent **trois** (deux purs + un mixte). La\n",
+    "différence n'est pas accidentelle : quand les intérêts sont **totalement\n",
+    "opposés** (Matching Pennies, strictement compétitif) ou qu'une stratégie en\n",
+    "**domine strictement** une autre (Dilemme), la tension se résout en un point\n",
+    "unique. Quand les intérêts ne sont que **partiellement alignés** — chaque\n",
+    "joueur préfère sa propre coordination mais tous veulent se coordonner *sur\n",
+    "quelque chose* — plusieurs équilibres émergent.\n",
+    "\n",
+    "L'équilibre **mixte** des jeux de coordination mérite une lecture : il est\n",
+    "**Pareto-dominé**. En Coordination, $\\text{EQ3} = (L=0{,}33, R=0{,}67)$\n",
+    "rapporte $0{,}667$ à chaque joueur, contre $(2,2)$ pour le pur $(L,L)$. La\n",
+    "randomisation provoque une **décoordination** dans ~44 % des rencontres —\n",
+    "les joueurs tires un revenu *inférieur* à tout équilibre pur. La théorie le\n",
+    "prédit (chaque joueur rend l'autre *indifférent* entre ses stratégies), mais\n",
+    "il soulève la question centrale de la **sélection d'équilibre** : sur lequel\n",
+    "des deux purs les joueurs vont-ils tomber ? Stag Hunt l'illustre sous l'angle\n",
+    "**risque-vs-gain** ($(S,S)\\to(4,4)$ domine en gain, mais $(H,H)\\to(3,3)$\n",
+    "est plus « sûr » si l'autre dévie) ; Battle of the Sexes sous l'angle\n",
+    "**conflit de préférence** (Opera vs Foot). Aucun critère ne tranche seul :\n",
+    "c'est précisément ce que les raffinements (Harsanyi-Selten : dominance de\n",
+    "gain vs dominance de risque) tentent de formuler."
+   ]
+  },
   {
    "cell_type": "markdown",
    "id": "ba75e955-9d7b-402b-8f6c-6882a2a2f44d",

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
@@ -21,6 +21,12 @@
       csharp_sha: 1c90b37ab7d6098dcf07d5d141875b752b315afd
       content_python_sha: 969f44d1f55a24c59159c97f0f28864264f46c865a08efae379ad67a270b6e26
       content_csharp_sha: 4021a70b18b0be17cf3cc9302549df5de68a6c1f5fecedf62517af96e45b6214
+    - date: "2026-08-10"
+      by: myia-po-2025:CoursIA-2
+      python_sha: c74eabd61cd743f4247dd1e29cc9a4f813859e74
+      csharp_sha: dc0c6381a77c3b5efd488de2e0f57ce400300d7f
+      content_python_sha: 969f44d1f55a24c59159c97f0f28864264f46c865a08efae379ad67a270b6e26
+      content_csharp_sha: c88fd3c06bdb5b2d9688475998c6f03d763e4d06e64bdd0f43ec8514ee3feba2
   known_differences:
     - "Socle pedagogique commun : calcul des equilibres de Nash (purs + mixtes), meilleure reponse, support des equilibres mixtes."
     - "Idiomes framework : Python = `nashpy` + `scipy.optimize.linprog` (resolution des mixtes via programmation lineaire). C# = `BestResponseRow` from-scratch (enumeration des meilleures reponses en pur Linq, pas de solveur LP externe)."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-dotnet #10257 (GameTheory-4 vs App-8 MiniZinc: distinct series, distinct domain — equilibrium theory vs CSP paradigm-jump)

# docs(gametheory4): enrich Nash equilibrium multiplicity taxonomy interpretation cell

## Quoi

`GameTheory-4-NashEquilibrium-Csharp.ipynb` (GameTheory, twin C# .NET Interactive) avait une lacune narrative au point culminant du notebook : les cellules **[14]→[15]→[16]** enchaînaient l'analyse complète des 5 jeux canoniques (Dilemme du Prisonnier, Stag Hunt, Coordination, Matching Pennies, Battle of the Sexes) puis sautaient directement à `## 6. Pierre-Feuille-Ciseaux` **sans markdown interprétant les résultats**. Les cellules impriment `Nombre d'équilibres : 1` (PD, Matching Pennies) et `Nombre d'équilibres : 3` (Stag Hunt, Coordination, BoS) avec **zéro explication** du pattern.

Cette PR ajoute **1 cellule markdown d'interprétation** (`gt4-multeq-interpretation`, après la cellule 15 / sortie Battle of the Sexes, avant la section 6 RPS) :

| Phénomène interprété | Sortie réelle citée (cellules 14+15) |
|----------------------|--------------------------------------|
| **Taxonomie deux-régimes** | PD=1 éq, Matching Pennies=1 éq (intérêts opposés / dominance stricte) vs Stag Hunt / Coordination / BoS = 3 éq (intérêts partiellement alignés) |
| **Équilibre mixte Pareto-dominé** | Coordination EQ3 `(L=0.33, R=0.67)` → gain `0.667` vs pur `(L,L)→(2,2)` ; ~44 % décoordination |
| **Sélection d'équilibre** | Stag Hunt risque-vs-gain `(S,S)→(4,4)` vs `(H,H)→(3,3)` ; BoS conflit de préférence Opera/Foot ; Harsanyi-Selten |

Le contenu est **spécifique aux sorties réelles** (estimandes, comptes exacts, probabilités de décoordination), pas générique.

## #9434 — comptes d'équilibre = déterministes, sûrs à citer

Les outputs contiennent des **comptes d'équilibres** (1, 3) et des **probabilités mixtes** (0.33, 0.667). Ce sont des valeurs **structurelles** produites par support-énumération déterministe, **PAS** des timings machine-dépendants. Le mandat #9434 (« quantitatif tenu par le CI, pas par la prose ») vise les valeurs qui **drift à la ré-exécution** (ms de timing, états stochastiques non-seedés) — les comptes d'équilibre sont invariants par construction. Citer `EQ3 → 0.667` est donc conforme.

## Méthode — raw-text surgical splice (pas de json round-trip)

Insertion sans `json.load → modify → dump` (règle `nbformat-reserialization-destroys-content`). Splice d'un fragment de cellule JSON à une borne identifiée par le champ `id` unique (`d6e925d4`, cell 15). Validation par re-parse JSON.

## Anti-régression & validation

- `git diff --stat` : **2 fichiers, +38 / −0** (additif pur, 0 suppression).
- **0 cellule code touchée** : `git diff | grep -c '^\-\s*"source"'` = 0 → markdown-only → **0 ré-exécution** (exception C.2 ; les 15 outputs + execution_counts existants restent byte-identiques).
- **Twin-parity** : `gametheory-4-nashequilibrium.yaml` rebaseliné après édition (`--update --by myia-po-2025:CoursIA-2`), nouvelle entrée `csharp_sha: dc0c6381...`, DRIFT=0 fleet-wide (157/157 OK).
- `nbformat.validate` : **VALID**.
- H.3 pre-commit : **0 violation** (aucune cellule code avec `execution_count: null` et pas d'outputs).
- 0 `sorry` / `raise NotImplementedError` / `assert False`.
- Catalogue **byte-identique à main** (cette PR ne touche que prose markdown + registry yaml).

## Variation

MED/notebook-dotnet. prev MED/notebook-dotnet (#10257 App-8 MiniZinc). G-VAR-3 ✓ : même genre **mais substance genuinely distincte** — #10257 = saut de paradigme MiniZinc↔CP-SAT (CSP, `alldifferent` déclaratif vs variables de diagonale procédurales) ; ce grain = taxonomie de multiplicité d'équilibre (théorie des jeux, intérêts-alignés-vs-opposés, sélection d'équilibre Harsanyi-Selten). Le litmus LIGHT (« générable en scannant le carnet suivant ? ») = **non** : déduire pourquoi PD=1 et StagHunt=3 depuis les matrices de gain, et relier l'équilibre mixte de Coordination à sa Pareto-dégradation, exige du raisonnement de domaine de théorie des jeux, pas un scan.

See #9434 (mandat prose-qui-interprète dans les notebooks).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
