### PR TITLE
docs(genai,#9434): drain machine-dependent '18 secondes' wallclock from Forge-SD-XL-Turbo intro note

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb
@@ -630,7 +630,7 @@
     "\n",
     "Testons la fonction avec un prompt simple pour générer un paysage de montagne au coucher du soleil.\n",
     "\n",
-    "**Note**: La génération prend environ **18 secondes** avec les paramètres Turbo optimaux (4 steps)."
+    "**Note**: SD XL Turbo est conçu pour la vitesse — seulement 4 steps de débruitage contre ~30 pour SD XL standard. Le temps exact dépend du GPU (RTX 3090, cloud T4…) et varie d'une exécution à l'autre : il s'observe à l'exécution de la cellule suivante, pas dans un nombre figé."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #10271

#9434 precision-drain : retirer le wallclock machine-dépendant « 18 secondes » de `01-4-Forge-SD-XL-Turbo` (GenAI/Image). **Famille GenAI** (6ᵉ famille distincte ce window), **notebook-python** — exactement le rebalancement de genre assigné au dashboard po-2024 (« provisionner genai / notebook-python substantiels »).

## La dérive mesurée firsthand

La cellule d'intro `cell[9]` portait une **estimation de temps de génération précise en prose** :

> **Note**: La génération prend environ **18 secondes** avec les paramètres Turbo optimaux (4 steps).

Le temps de génération SD XL Turbo **dépend du GPU** (RTX 3090 vs cloud T4 vs autre) et dérive d'une exécution à l'autre. C'est la classe de valeur machine-dépendante que #9434 veut tenue par l'exécution, pas par la prose. Le détecteur `check_machine_dep_timing.py` flaggait `cell[9]` (« 18 secondes », wallclock).

**Aggrave le cas** : la valeur n'apparaît dans **aucun output** — `cell[10]` (le code de génération) imprime seulement « 🎨 Génération en cours » / « ✅ Image générée (512×512) », pas le wallclock. C'est la pire forme de dérive : un nombre de runtime en prose **sans aucune mesure vivante qui le sous-tende**.

## Principe appliqué : garder le déterministe, drainer le temps machine

| Quantité | Exemple | Machine-dépendant ? | Décision |
|---|---|---|---|
| **Steps de débruitage** | 4 (Turbo) vs ~30 (standard) | **Non** (paramètre d'entrée) | **GARDÉ** |
| **Temps de génération** | « ~18 secondes » | **Oui** (wallclock GPU) | **DRAINÉ** |

## Changement (cell[9] markdown, 1 point de drain)

- Avant : « La génération prend environ **18 secondes** avec les paramètres Turbo optimaux (4 steps). »
- Après : « SD XL Turbo est conçu pour la vitesse — seulement 4 steps de débruitage contre ~30 pour SD XL standard. Le temps exact dépend du GPU (RTX 3090, cloud T4…) et varie d'une exécution à l'autre : il s'observe à l'exécution de la cellule suivante, pas dans un nombre figé. »

Le message pédagogique (« Turbo = rapide ») est **renforcé** : il repose désormais sur le **contraste déterministe** (4 vs ~30 steps) plutôt que sur un nombre de secondes qui glisse d'un GPU à l'autre.

## G.1 — preuve du livrable

- **Markdown-only** : 0 cellule code touchée, 0 output modifié. Exception C.2 (modifs uniquement markdown) → **0 re-exécution due** (la cellule de génération elle-même, GPU-dépendante, n'est PAS touchée).
- Raw-text replace (pas de json round-trip) → 0 churn sur les 27 autres cellules. Les 6 escapes `\u00` du fichier (autres cellules) **intacts**. LF préservé (0 CRLF). JSON valide, H.3 0 violation.
- **Déterministe préservé** : « 4 steps », le contraste « ~30 pour SD XL standard », « 4 steps de débruitage » — tous intacts.

## Non-twin — pas de rebaseline

Ce notebook **n'est pas un twin**. Aucun rebaseline requis.

## Scope (un sujet par PR)

Une PR = un notebook, drain #9434 du wallclock de la cellule d'intro. Ne touche PAS : le code de génération, les outputs (images), le catalogue (byte-identique à main), les notebooks frères.

## Variation

prev = MED/notebook-dotnet #10271 (c.83, SMT Einstein drain). Ce grain = MED/notebook-python sur **GenAI/Image** (SD XL Turbo). **Genre python** (rotation dotnet→python) + **famille GenAI** (6ᵉ distincte ce window). Work-type = drain #9434 (3ᵉ drain consécutif, mais **substance genuinement distincte** à chaque fois : Sudoku runtime-output-restated → Einstein theoretical-throughput-derived → GenAI GPU-generation-time-pinned). Le litmus LIGHT « générable en scannant l'instance suivante » ne mord pas : chaque drain exige de juger déterministe-vs-machine-dépendant dans un domaine différent (backtracking combinatoire vs complexité combinatoire estimée vs temps de génération GPU). Aligné avec le mandat rebalancement dashboard (genai notebook-python).
