### PR TITLE
fix(ci,#10143): positive control synthetique + invariant de discipline de revocation (debloque Scripts Tests CPU)

### DIFF
--- a/scripts/tests/test_gitleaks_allowlist.py
+++ b/scripts/tests/test_gitleaks_allowlist.py
@@ -12,10 +12,23 @@ Three invariants locked, one per direction:
 * **suppression** — each FP entry actually suppresses its target literal.
 * **positive control** — real-shaped keys of the same provider prefix stay
   DETECTED: no allowlist regex/stopword may match them. Includes the JWT HS256
-  real-formed token (kept armed by #10201's choice NOT to allowlist the header),
-  and the **Civitai token** ``c39ba121…34`` — a real committed secret (#10202)
-  whose rotation is tracked by #10205; a future allowlist entry that swallowed it
-  is exactly the disarm this test must catch.
+  real-formed token (kept armed by #10201's choice NOT to allowlist the header)
+  and a bare 32-hex shape (the Civitai/generic-api-key class).
+
+  The positive-control fixtures are **synthetic by construction**: a shape, never
+  a historical value. That is what makes the invariant un-gameable — a synthetic
+  value can never legitimately appear in the allowlist, so a collision is *always*
+  a disarm. Pinning an actual credential here instead couples the control to that
+  credential's lifecycle, and the control then fires on the day the value is
+  legitimately retired (which is precisely what happened, see below).
+
+* **revocation discipline** (``REVOKED_ALLOWLISTED``) — a value may be allowlisted
+  once it is DEAD, and only with its rotation evidence written in
+  ``.gitleaks.toml``. Rotation is the primary remediation (secrets-hygiene rule
+  5); the allowlist entry only silences the corpse in CI. This invariant checks
+  the paperwork, not the value: entry present + rotation documented. A **live**
+  credential swallowed by the allowlist remains caught by the positive control
+  above, which no longer has any exemption to hide behind.
 
 The tests parse ``.gitleaks.toml`` as text and compile the regexes themselves,
 so they run without the gitleaks binary (CI only has gitleaks-action).
@@ -107,14 +120,27 @@ REAL_KEYS = [
     ("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
      + "." + "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkphbmUgRG9lIn0"
      + "." + "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"),
-    # CIVITAI_TOKEN — a REAL committed secret (32-hex), 6 occurrences in archived
-    # docker-configs/docs (#10202). NOT allowlisted by design (rotation tracked
-    # by #10205). A future allowlist entry (regex or stopword) that swallowed it
-    # would disarm the scanner exactly where it caught something real — the
-    # #9888 failure mode. This control catches that regression. Built from
-    # concatenation so the literal never sits contiguously in the test source.
-    "c39ba121" + "e12e5b40ac67a87836431e34",
+    # Bare 32-hex shape (Civitai / generic-api-key class, #10202). SYNTHETIC:
+    # this value has never been a credential anywhere, so it can never acquire a
+    # legitimate reason to sit in the allowlist — any collision is a real disarm.
+    # It replaces the historical Civitai token, which was pinned here until
+    # #10255: once that token was rotated and legitimately allowlisted as a dead
+    # value, the control fired on the *correct* allowlisting instead of on a
+    # disarm. A positive control must outlive the lifecycle of any one secret.
+    "a7f3c91d" + "4e82b56097fd3a1c8b64e250",
 ]
+
+# Values that ARE allowed to sit in the allowlist because they are dead: rotated
+# at the provider, revocation verified firsthand, evidence written next to the
+# entry in .gitleaks.toml. Allowlisting a *live* credential stays forbidden
+# (#9888) — and stays caught, because the positive control above is synthetic and
+# therefore has no exemption. Key = the 8-char prefix (the full literal has no
+# business in this file); value = the evidence required in the toml comment.
+REVOKED_ALLOWLISTED = {
+    "c39ba121": "Civitai token, 6 occurrences in archive dirs (#10202); rotated "
+                "at provider (#10205), revocation verified firsthand (401 on "
+                "GET /api/v1/users/self); allowlisted by #10255 (see #10141).",
+}
 
 
 class TestAllowlistEntriesPresent:
@@ -234,28 +260,63 @@ class TestJWTDetectorArmed:
         )
 
 
-class TestCivitaiTokenStaysDetected:
-    """The Civitai token ``c39ba121e12e5b40ac67a87836431e34`` is a real committed
-    secret (6 occurrences in archived docker-configs/docs, #10202). It is
-    deliberately NOT allowlisted — the fix is ROTATION at the provider (tracked
-    by #10205), not a suppression entry. This test guards that no future
-    allowlist widening (regex or stopword) silently swallows it, which would
-    disarm the scanner exactly where it caught something real."""
+class TestRevocationDiscipline:
+    """A secret may be allowlisted only once it is DEAD, and only with its
+    rotation evidence written beside the entry.
 
-    CIVITAI_TOKEN = "c39ba121" + "e12e5b40ac67a87836431e34"
+    This class replaces ``TestCivitaiTokenStaysDetected``, whose premise —
+    "deliberately NOT allowlisted, the fix is ROTATION (#10205)" — was correct
+    while the token was live and became false the moment the rotation it demanded
+    was actually performed (#10255: 401 verified firsthand). The old test encoded
+    a *temporal* state as a permanent invariant, so completing the remediation it
+    asked for turned it red and blocked every PR touching ``scripts/``.
 
-    def test_not_matched_by_any_regex(self):
-        compiled = _compiled_regexes()
-        hits = [r.pattern for r in compiled if r.search(self.CIVITAI_TOKEN)]
-        assert not hits, (
-            f"allowlist regex(es) match the Civitai token -> scanner disarmed where "
-            f"it caught a real secret (#9888): {hits} (see #10202/#10205)"
-        )
+    What is durable is not "this value stays out" but "nothing enters alive". So
+    the checks below verify the **paperwork** for each retired value, while the
+    positive control (synthetic fixtures) keeps guarding live credentials."""
 
-    def test_not_a_stopword_substring(self):
+    def test_revoked_entries_are_actually_in_the_allowlist(self):
+        """No stale exemption: an entry removed from the toml must lose its row
+        here too, otherwise the dict silently grants cover to nothing."""
         stopwords = _load_allowlist_stopwords()
-        hits = [s for s in stopwords if s in self.CIVITAI_TOKEN]
-        assert not hits, (
-            f"a stopword is a substring of the Civitai token -> scanner disarmed "
-            f"where it caught a real secret: {hits} (see #10202/#10205)"
-        )
+        for prefix in REVOKED_ALLOWLISTED:
+            matches = [s for s in stopwords if s.startswith(prefix)]
+            assert matches, (
+                f"{prefix}... is listed in REVOKED_ALLOWLISTED but is no longer a "
+                f"stopword in .gitleaks.toml -> stale exemption, drop the row"
+            )
+            assert len(matches) == 1, (
+                f"{prefix}... matches {len(matches)} stopwords -> ambiguous "
+                f"exemption, make the prefix discriminating"
+            )
+
+    def test_revoked_entries_document_their_rotation(self):
+        """The entry must carry its evidence in the toml, next to the value.
+
+        Rotation is the remediation (secrets-hygiene rule 5); the allowlist line
+        only silences the dead value in CI. Without the evidence written down, a
+        future reader cannot tell this apart from allowlisting a live secret."""
+        text = GITLEAKS_TOML.read_text(encoding="utf-8")
+        for prefix in REVOKED_ALLOWLISTED:
+            idx = text.find(prefix)
+            assert idx != -1, f"{prefix}... not found in .gitleaks.toml"
+            # The documenting comment block precedes the value; 1200 chars back
+            # covers a verbose block without reaching the previous entry's.
+            window = text[max(0, idx - 1200):idx].lower()
+            assert "revok" in window or "rotat" in window, (
+                f"the .gitleaks.toml entry for {prefix}... does not document a "
+                f"rotation/revocation -> indistinguishable from allowlisting a "
+                f"live credential (#9888)"
+            )
+
+    def test_revoked_values_are_not_positive_controls(self):
+        """A retired value must never also be a positive-control fixture.
+
+        Otherwise an exemption could be laundered into the control set, and the
+        collision that should turn this suite red would read as authorised."""
+        for prefix in REVOKED_ALLOWLISTED:
+            collides = [k[:12] + "..." for k in REAL_KEYS if prefix in k]
+            assert not collides, (
+                f"{prefix}... is both REVOKED_ALLOWLISTED and inside a positive "
+                f"control {collides} -> the control can no longer detect a disarm"
+            )


### PR DESCRIPTION
Grain: MED/test — lane myia-ai-01:CoursIA — prev: MED/docs #10248

## Le blocage

`main` `74111fe79` **échoue 2 tests bloquants** de `scripts/tests/test_gitleaks_allowlist.py`, vérifié firsthand :

```
FAILED TestPositiveControlRealKeysStayDetected::test_real_keys_contain_no_stopword
FAILED TestCivitaiTokenStaysDetected::test_not_a_stopword_substring
2 failed, 9 passed
```

Ces tests tournent dans `Scripts Tests (CPU)`, qui se déclenche sur **toute PR touchant `scripts/`**. Conséquence : chaque PR de cette classe part `BLOCKED` pour une cause qui n'est pas la sienne. Constaté sur #10141 (run `31369402221`), dont le diff ne touche ni `.gitleaks.toml` ni ce test.

C'est une **collision sémantique de merge** : les deux moitiés étaient vertes séparément, `main` est rouge combiné. Le batch est le mien, la réparation aussi.

## La cause — deux gates tous les deux justes

- `TestCivitaiTokenStaysDetected` (#10143/#10202) épinglait le token Civitai en contrôle positif, avec pour prémisse écrite dans sa docstring : *« deliberately NOT allowlisted — the fix is ROTATION at the provider (tracked by #10205) »*. Juste, **tant que le token était vivant**.
- #10255 (commit `8c651beb5`) a allowlisté ce même token — et son commentaire dans `.gitleaks.toml` est correct de bout en bout : rotation faite chez le provider, révocation vérifiée firsthand (`GET /api/v1/users/self` → **401**), 6 occurrences en dirs d'archive, et l'avertissement explicite *« NEVER allowlist a live credential (#9888) — this entry is legitimate precisely because the value is dead »*.

Aucun des deux n'a tort. Le test a encodé un **état temporel** (« pas encore rotaté ») comme **invariant permanent** : accomplir la remédiation qu'il réclamait l'a fait rougir. Son invariant — « aucun stopword ne doit être sous-chaîne d'une clé réelle » — ne sait pas distinguer *morte* de *vivante*.

Ce n'est donc ni un revert de #10255 ni une suppression du test.

## Le correctif

Ce qui est durable n'est pas « cette valeur reste dehors », c'est **« rien n'entre vivant »**.

1. **Le contrôle positif devient synthétique.** L'entrée 32-hex de `REAL_KEYS` n'est plus le token historique mais une valeur qui n'a jamais été un credential nulle part — elle ne peut donc jamais acquérir de raison légitime de figurer dans l'allowlist, et **toute collision est un vrai désarmement**. Un contrôle positif doit survivre au cycle de vie de n'importe quel secret ; épingler une valeur réelle couple le contrôle à ce secret et le fait tirer le jour de sa retraite légitime. La classe de forme (bare 32-hex / generic-api-key) reste couverte à l'identique.

2. **`REVOKED_ALLOWLISTED` : la discipline de révocation devient un invariant.** Une valeur peut être allowlistée **une fois morte**, et seulement avec sa preuve de rotation écrite à côté de l'entrée. Trois checks, qui vérifient la **paperasse**, jamais la valeur :
   - l'entrée est bien encore un stopword du toml (pas d'exemption périmée qui survivrait à son entrée — et unicité du préfixe, pour qu'elle reste discriminante) ;
   - le toml documente la rotation à proximité de la valeur (`revok`/`rotat`) — sans ça, un lecteur futur ne peut pas distinguer ce cas d'un allowlisting de secret vivant ;
   - une valeur retirée n'est **jamais aussi** un contrôle positif, sinon une exemption pourrait se blanchir dans le jeu de contrôles.

   La clé du dict est le **préfixe 8 caractères** : le littéral entier n'a rien à faire dans ce fichier, il ne subsiste que dans `.gitleaks.toml` où il est l'entrée elle-même. `grep -c` du littéral contigu dans le test : **0** (contre 3 avant).

3. `.gitleaks.toml` est **inchangé** (`git diff --stat` : un seul fichier touché). L'entrée de #10255 est légitime ; c'est le contrôle qui devait bouger.

## Preuve

```
$ python -m pytest scripts/tests/test_gitleaks_allowlist.py -q
12 passed in 0.05s          # avant : 2 failed, 9 passed
```

Et — parce qu'un gate qui passe au vert n'a rien prouvé s'il ne peut plus rougir — **mutation test** : injection d'un stopword égal à la valeur de contrôle synthétique (= simuler l'allowlisting d'un credential vivant), suite relancée, puis toml restauré :

```
mutation  -> FAILED TestPositiveControlRealKeysStayDetected::test_real_keys_contain_no_stopword
             1 failed, 11 passed
restauré  -> 12 passed
```

Le cliquet mord toujours dans la direction qui compte : allowlister une valeur vivante rougit. C'est le seul sens dans lequel ce fichier a de la valeur.

## Portée

- 1 fichier, +93/−32, aucune logique de production touchée — `.gitleaks.toml`, les workflows et le binaire gitleaks sont hors diff.
- Débloque `Scripts Tests (CPU)` pour toute la flotte : #10141, #10275, #10277 et toute PR ultérieure touchant `scripts/`.
- Pas de secret nouveau introduit ; un littéral de credential mort **retiré** du source de test.

## Ce que ça n'est pas

Ce n'est pas un jugement sur #10255, qui a fait la bonne chose (rotation d'abord, allowlist du cadavre ensuite, preuve écrite). C'est la moitié manquante de ce travail : le contrôle positif n'avait pas été mis à jour pour refléter que la rotation demandée avait eu lieu.

See #10143, #10202, #10205, #10255. Débloque #10141.
