### PR TITLE
docs(kernels): inventaire kernels po-2023 (12, firsthand) + ecart de compte po-2025 signale

### DIFF
--- a/docs/reference/kernels-runtime.md
+++ b/docs/reference/kernels-runtime.md
@@ -151,6 +151,8 @@ Incident 2026-05-06 : training MoE tenté directement sur Python 3.14 système :
 | python3-wsl | Python (WSL 3.12) | wsl_papermill.py |
 | smartcontracts | Python | Papermill |
 
+**Écart de compte non résolu** : l'intitulé annonce « 10 registered », la table en liste **9**. Non re-mesurable en l'état — po-2025 est **CONFIRMÉ non joignable** firsthand (#9976 : `HTTP 000` + 100 % de perte ping, LAN physiquement disjoint). Ni le 10 ni le 9 ne sont corrigés ici : un relevé `jupyter kernelspec list` tranchera au retour de la machine. Ne pas citer l'un des deux comme mesuré.
+
 **Note** : la colonne *Executable via* disait « MCP Jupyter cell-by-cell » pour les kernels `.net-*` et `lean4*`. C'etait faux pour `.NET` (Papermill execute `.net-csharp` firsthand, cf L19-21 et la mesure nuget ci-dessus) et **ne s'applique pas** au chemin recommande : le MCP `jupyter-papermill` hang (#835) et ignore `kernel_name` (#5211) — il ne doit **jamais** etre le chemin de re-exec cite dans cette table. Pour `lean4`/`lean4-wsl`, le chemin `notebook_tools.py execute` (Papermill in-process avec translator enregistre, `notebook_tools.py` L1139-1179) est le mecanisme reel ; non re-mesure ce cycle, ne pas affirmer sans mesure.
 
 #### Papermill : env de reference
@@ -222,9 +224,34 @@ Installation : `python SymbolicAI/SmartContracts/setup_env.py`.
 | `SymbolicAI/Lean/scripts/validate_lean_setup.py` | Valide env Lean (elan, lean4-jupyter, kernel, openai) |
 | `SymbolicAI/Lean/scripts/setup_wsl_python.sh` | Setup WSL Python pour lean4-wsl kernel |
 
-### Autres machines (po-2023/24/26)
+### po-2023 (inventaire kernels, 2026-08-10)
 
-Vérifier qu'elles ont aussi un env Conda dédié ou un venv local équivalent. La mémoire est spécifique ai-01 mais le pattern (env dédié ML) est cluster-wide. Inventorier via `conda env list` sur chaque machine.
+**Machine** : hôte des services GenAI Image/Audio/Video (8 services Docker), RTX 3080 + eGPU RTX 3090, 40 GB VRAM (16 + 24) — cf [cluster-agents.md](cluster-agents.md) L10. **po-2023 n'est PAS CPU-only** : la mention « CPU-only strict » de ce fichier (L114) appartient à **po-2025** (MSI GE76 Raider, 11 crashes GPU), et c'est la seule machine du cluster ainsi caractérisée. Ne pas router par famille sur cette base.
+
+#### Jupyter kernels (12 registered)
+
+Relevé `jupyter kernelspec list` firsthand sur po-2023, 2026-08-10.
+
+| Kernel | Type | Usage |
+|--------|------|-------|
+| `.net-csharp` | .NET Interactive | notebooks C# (ML, Sudoku, Probas, SymbolicAI .NET) |
+| `.net-fsharp` | .NET Interactive | notebooks F# |
+| `.net-powershell` | .NET Interactive | notebooks PowerShell |
+| `python3` | Python (Windows) | notebooks Python natifs |
+| `python3-wsl` | Python (WSL) | notebooks Python côté WSL |
+| `lean4-wsl` | Lean 4 (WSL) | `SymbolicAI/Lean` |
+| `gametheory-wsl` | Python (WSL + OpenSpiel) | `GameTheory` |
+| `mcp-jupyter-py310` | Python 3.10 | exécution Papermill (env de référence) |
+| `acestep-venv` | Python (venv) | GenAI Audio — ACE-Step |
+| `dia-tts` | Python (venv) | GenAI Audio — Dia TTS |
+| `bonsai-gpu` | Python (GPU) | notebooks GPU |
+| `cleanenv-k` | Python (env propre) | tests d'isolation de dépendances |
+
+**Couverture des trois kernels installables partout** (règle F / H.2) : .NET Interactive **OK**, Python **OK**, Lean 4 **OK** (via WSL). Aucun contournement « kernel not available locally » n'est recevable sur cette lane.
+
+### Autres machines (po-2024/26)
+
+Inventaire kernels non encore relevé. Vérifier aussi l'env Conda dédié ou son venv équivalent : la mémoire est spécifique ai-01 mais le pattern (env dédié ML) est cluster-wide. Relever via `conda env list` **et** `jupyter kernelspec list` sur chaque machine.
 
 ### GenAI GPU stack : triton-windows + bitsandbytes
 


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-ai-01:CoursIA — prev: MED/test #10280

## D'où vient ce grain

po-2023 a relevé firsthand `jupyter kernelspec list` sur sa machine (12 kernels, 2026-08-10) puis m'a explicitement rendu l'écriture : l'inventaire est du ressort du coordinateur. Cette PR le consigne.

Elle corrige aussi **deux erreurs qui sont les miennes**, pas celles du worker.

## Correction 1 — mon « 18 » n'était pas un compte cluster

po-2023 a demandé si mon « 18 kernels » était (a) un total cluster-wide, (b) kernels + conda envs, ou (c) un autre périmètre. Réponse : **(c)**, et le chiffre ne concernait pas sa machine du tout.

Il correspond exactement à la section **po-2025** de ce fichier : 9 lignes de la table kernels + 9 environnements Conda = 18. C'est-à-dire une somme de **deux unités différentes** attribuée à la mauvaise machine. Rien à corriger côté po-2023 ; le nombre n'aurait jamais dû lui être opposé.

## Correction 2 — po-2023 n'est caractérisée « CPU-only » nulle part

po-2023 a soulevé le point **sous forme d'hypothèse** (« *si* `cluster-agents.md` caractérise po-2023 comme CPU-only, c'est inexact — quelle ligne ? ») plutôt que de l'affirmer. C'était la bonne façon de le poser, et la vérification tranche en sa faveur sur les deux volets :

- `cluster-agents.md:10` la crédite de **RTX 3080 + eGPU RTX 3090 | 40 GB (16 + 24)** ;
- toutes les occurrences **machine-scoped** de « CPU-only » dans `docs/` désignent **po-2025**, jamais po-2023 : `kernels-runtime.md:114` (« MSI GE76 Raider, RTX 3080 Ti Laptop 16GB, **CPU-only strict** (11 crashes GPU) »), `archive/env-audit-cluster-2026-05-10.md` L21/68/98/258, `archive/STABLE_SNAPSHOT.md:9`. Les autres occurrences qualifient des **notebooks ou des services** (`cost-matrix.md`, `docs/ict/**`, `tts-gateway`), pas une machine.

**Signalé, pas corrigé (hors scope)** : `docs/reference/proactive-coordination-detail.md:69` contient un token tronqué — « (CPU-only-po et lecture OK, GPU-only exclu) ». Il ne caractérise aucune machine nommée, mais il est assez ambigu pour être relu comme taguant n'importe quelle lane `po-*`. À traiter dans un grain dédié, pas ici.

Donc : **aucune PR de correction n'était nécessaire**, la doc était déjà juste. La confusion venait de moi. Le nouvel encart le dit explicitement, pour qu'un lecteur futur ne refasse pas l'amalgame en routant par famille.

## Ce que la PR écrit

- Nouvelle section `### po-2023 (inventaire kernels, 2026-08-10)`, sur le modèle de la section po-2025 existante : machine + GPU, table des 12 kernels avec type et usage, et la couverture des **trois kernels installables partout** (règle F / H.2) — .NET Interactive, Python, Lean 4 (WSL) tous présents, donc aucun « kernel not available locally » n'est recevable sur cette lane.
- Le stub `### Autres machines (po-2023/24/26)` devient `### Autres machines (po-2024/26)` : deux machines restent à relever, et la commande à passer est nommée (`conda env list` **et** `jupyter kernelspec list`).

**Cible = `kernels-runtime.md`, pas `cluster-agents.md`.** L'ask initial visait `cluster-agents.md` ; c'était le mauvais fichier. Les inventaires de kernels vivent déjà ici (section po-2025), et `cluster-agents.md` porte le routage (machines, lanes, GPU). Écrire l'inventaire là-bas aurait dupliqué le tier « doc pérenne » — ce que `harness-hygiene` interdit.

## Un écart signalé, pas maquillé

En relisant la section po-2025 pour m'aligner sur son format, l'intitulé annonce « 10 registered » quand la table en liste **9**.

Je ne corrige **ni l'un ni l'autre** : po-2025 est **CONFIRMÉ non joignable** firsthand (#9976, `HTTP 000` + 100 % de perte ping, LAN physiquement disjoint), donc aucun des deux nombres n'est re-mesurable aujourd'hui. Choisir silencieusement le 9 « parce que la table le dit » fabriquerait une mesure. L'écart est donc écrit comme tel, avec la consigne de ne citer aucun des deux comme mesuré tant que la machine n'est pas revenue.

## Tag de variation

`LIGHT/docs`, assumé comme tel : consigner un relevé fourni par autrui est scan-générable (le litmus LIGHT réussit — je pourrais en produire douze en interrogeant les machines suivantes).

- **G-VAR-1** (plancher DEEP/MED) : tenu par **#10280** (`MED/test`, réparation du gate gitleaks qui bloquait toute la flotte). Cette LIGHT est un à-côté, pas le plat principal.
- **G-VAR-2** (budget) : 2 grains mergés aujourd'hui sur la lane (#10280 `MED/test`, #10248 `MED/docs`) → cap `max(1, 2//3)` = **1**, non consommé.
- **G-VAR-3** (adjacence) : `docs` après `test` — genres distincts, pas de répétition.

Répond à l'ask kernels de po-2023 (`msg-20260810T011221-pyo044`). Aucune issue à fermer.
