### PR TITLE
docs(variation,#10020): le cap G-VAR-2 est un ratio — aligner les 4 prose qui l'annoncent plat

### DIFF
--- a/.github/workflows/variation-light-genre.yml
+++ b/.github/workflows/variation-light-genre.yml
@@ -226,7 +226,7 @@ jobs:
           **G-VAR-2/3 GENRE signals** (advisory, non bloquant, #10020).
           La lane \\\`${LANE}\\\` voit ces signaux actifs sur les mergees du jour (UTC ${TODAY}) :${ACTIVE_LINES}
 
-          G-VAR-2 plafonne a **une LIGHT par lane et par jour, toutes categories LIGHT confondues** ; G-VAR-3 interdit deux genres LIGHT consecutifs. Les signaux ci-dessus rendent le fait VISIBLE (labels \`variation-tier-inflation\`, \\\`variation-genre-run\\\`, \\\`variation-genre-cap-exceeded\\\`, \\\`variation-genre-mismatch\\\`) -- la decision de merge reste au coordinateur."
+          G-VAR-2 plafonne a **max(1, grains_mergees_du_jour // 3) LIGHT par lane et par jour, toutes categories LIGHT confondues** -- un RATIO, pas un plafond plat ; le cap calcule du jour est dans le tally ci-dessus. G-VAR-3 interdit deux genres LIGHT consecutifs. Les signaux ci-dessus rendent le fait VISIBLE (labels \`variation-tier-inflation\`, \\\`variation-genre-run\\\`, \\\`variation-genre-cap-exceeded\\\`, \\\`variation-genre-mismatch\\\`) -- la decision de merge reste au coordinateur."
             EXISTING_ID=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments[] | select(.body | startswith("'"$MARK"'")) | .id' 2>/dev/null | head -1 || echo "")
             if [ -n "$EXISTING_ID" ]; then
               gh api -X PATCH "repos/${GH_REPO}/issues/comments/${EXISTING_ID}" \

--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -200,8 +200,9 @@ jobs:
           exit 0
 
   # G-VAR-2 est le seul gate du protocole qui ne se decide pas DANS la PR : il
-  # demande de savoir ce que la lane a DEJA merge aujourd'hui (au plus une LIGHT
-  # par lane et par jour, toutes categories LIGHT confondues). Compte a la main
+  # demande de savoir ce que la lane a DEJA merge aujourd'hui (au plus
+  # max(1, grains_mergees_du_jour // 3) LIGHT par lane et par jour, toutes
+  # categories LIGHT confondues -- un RATIO, pas un plafond plat). Compte a la main
   # par le coordinateur jusqu'ici, qui a merge une 2e LIGHT deux fois en un
   # cycle (#8964). Ce job rend le fait VISIBLE (advisory, exit 0).
   #
@@ -311,9 +312,10 @@ jobs:
             if ! gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' 2>/dev/null | grep -qF "$MARK"; then
               BODY="${MARK}
           **G-VAR-2 light cap reached** (advisory, non bloquant).
-          La lane \`${LANE}\` a deja merge une LIGHT aujourd'hui (${CB}).
-          G-VAR-2 plafonne a **une LIGHT par lane et par jour, toutes categories LIGHT confondees**
-          (guard, doc, refs, ... partagent un seul budget). La decision de merge reste au coordinateur."
+          La lane \`${LANE}\` a deja consomme son budget LIGHT du jour (${CB}).
+          G-VAR-2 plafonne a **max(1, grains_mergees_du_jour // 3) LIGHT par lane et par jour,
+          toutes categories LIGHT confondues** (guard, doc, refs, ... partagent un seul budget) :
+          c'est un RATIO, pas un plafond plat. La decision de merge reste au coordinateur."
               gh pr comment "$PR_NUMBER" --body "$BODY" 2>/dev/null || true
             fi
             echo "::notice::G-VAR-2 cap reached pour la lane ${LANE} (consomme par ${CB})."

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""Detect G-VAR-2 cap-reached: a 2nd+ LIGHT PR merged the same day for a lane.
+"""Detect G-VAR-2 cap-reached: a LIGHT PR merged past the lane's daily budget.
 
-G-VAR-2 (variation-protocol.md) caps the protocol at **one LIGHT PR per lane
-per day, all LIGHT sub-categories confounded** (guard, doc, refs, ... share a
-single budget). It is the only gate of the protocol that is **cross-PR** -- it
+G-VAR-2 (variation-protocol.md) caps the protocol at **max(1, lane grains
+merged today // 3) LIGHT PRs per lane per day, all LIGHT sub-categories
+confounded** (guard, doc, refs, ... share a single budget). The cap is a
+RATIO, not a flat one-per-day: see `light_budget()` below and the rationale
+block above it. It is the only gate of the protocol that is **cross-PR** -- it
 needs to know what the lane has ALREADY merged today -- so until now it was
 counted by hand by the coordinator, who merged a 2nd LIGHT twice in one cycle
 (issue #8964: measured firsthand on the 2026-07-30 wave). This tool makes the


### PR DESCRIPTION
Grain: LIGHT/docs -- lane myia-ai-01:myia-open-webui -- prev: aucun grain tague sur cette lane (#9752 et #9854 sont sans tag)

```
Quoi:       Aligner sur `max(1, n // 3)` les 4 prose qui annoncent encore le cap G-VAR-2 comme un plafond plat de 1.
Preuve:     82/82 tests verts + `yaml.safe_load` sur les 2 workflows + `py_compile` ; diff +14/-10 sans une ligne executable.
Perimetre:  variation_light_cap.py (docstring), variation-tag-guard.yml, variation-light-genre.yml. HORS-SCOPE : le bloc L170-184, qui historicise l'ancien cap et est juste.
```

Prend le grain laisse ouvert sur #10020 (commentaire du 2026-08-10T08:28Z : « grain disponible, a prendre par une lane qui a du budget LIGHT »). L'acceptance principale de l'issue est deja livree par #10031 ; il ne restait que la prose du cap.

**Lane-claim** : repris sur claim STALE de `myia-po-2024:CoursIA-2` (47,3 h > seuil 24 h ; son scope, #10031, est livre et merge). `[CLAIMED]` poste sur l'issue — **apres coup, ce qui est ma faute** : je n'avais pas lance `check_lane_claim.py` avant d'editer. Je le signale plutot que de le passer sous silence, c'est le label `lane-claim-conflict` qui l'a rattrape.

## Le defaut

`light_budget()` (`variation_light_cap.py:187-193`) implemente `max(1, n // 3)` depuis le sign-off user du 2026-07-31. **Quatre prose continuent d'annoncer l'ancien plafond plat de 1**, et deux d'entre elles sont postees en commentaire **sur la PR du worker** — donc le canal par lequel la regle atteint effectivement les lanes.

| # | Site | Qui le lit |
|---|---|---|
| 1 | `scripts/variation_light_cap.py:2` | resume du module, `--help` |
| 2 | `scripts/variation_light_cap.py:4-6` | docstring de tete |
| 3 | `.github/workflows/variation-tag-guard.yml:203` | commentaire du job |
| 4 | `.github/workflows/variation-tag-guard.yml:315` | **commentaire poste sur la PR** |
| 5 | `.github/workflows/variation-light-genre.yml:229` | **commentaire poste sur la PR** |

Une lane qui lit l'un de ces textes se plafonne a 1 LIGHT alors qu'a 6 grains mergees elle en a droit a 2, et a 19 elle en a six. C'est exactement le defaut que le passage au ratio visait a fermer, reproduit dans le paragraphe d'ouverture du fichier qui le corrige.

## Deux ecarts avec le perimetre annonce sur l'issue

**1. `variation-tag-guard.yml` n'etait pas dans le perimetre.** Il porte deux occurrences, dont celle postee au worker. Meme defaut, meme phrase, aucun claim dessus.

**2. Le dernier commentaire indique que `variation-light-genre.yml` est correct « sans chiffrer ».** Verifie firsthand : sa **ligne 220** l'est (`cap partage G-VAR-2`), mais sa **ligne 229**, neuf lignes plus bas, enonce le plafond plat. Les deux coexistent dans le meme fichier — la ligne correcte est celle qu'on rencontre en premier en lisant, ce qui explique la lecture.

## Non touche, volontairement

Le bloc `variation_light_cap.py:170-184` **historicise** l'ancien cap (« The old `1 LIGHT/lane/day` scored a 1-PR lane and a 19-merge/13-DEEP lane identically ») : il est juste et reste la seule occurrence du motif dans le depot, par construction.

## Verifications

- **82/82 tests verts** — `test_variation_light_cap.py` (60), `test_variation_prev_guard.py` (8), `test_variation_tag_required.py` (14)
- `python -m py_compile scripts/variation_light_cap.py` OK
- Les deux workflows parses par `yaml.safe_load` (la ligne 229 porte des backticks echappes `\\\`` : seul le prefixe de prose a ete touche, aucun echappement modifie)
- `--help` affiche le resume corrige
- **Diff +14/-10 sur 3 fichiers, zero ligne executable** — `git diff` ne contient que des commentaires et des litteraux de chaine

## Verdict SOTA

`SOTA-OK` — prose alignee sur l'implementation, aucun contournement.

Part of #10020 — **je ne ferme pas** (la fermeture est un acte coordinateur, #1502). Avec ceci merge, le residuel de l'issue est vide : l'acceptance GENRE est livree par #10031 (`[RESOLVED-on-main]` du 2026-08-08) et la prose du cap est alignee ici. Elle peut etre close sur ces deux elements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
