### PR TITLE
fix(variation,#10020): align G-VAR-2 docstring + workflow prose on ratio formula

### DIFF
--- a/.github/workflows/variation-light-genre.yml
+++ b/.github/workflows/variation-light-genre.yml
@@ -226,7 +226,7 @@ jobs:
           **G-VAR-2/3 GENRE signals** (advisory, non bloquant, #10020).
           La lane \\\`${LANE}\\\` voit ces signaux actifs sur les mergees du jour (UTC ${TODAY}) :${ACTIVE_LINES}
 
-          G-VAR-2 plafonne a **une LIGHT par lane et par jour, toutes categories LIGHT confondues** ; G-VAR-3 interdit deux genres LIGHT consecutifs. Les signaux ci-dessus rendent le fait VISIBLE (labels \`variation-tier-inflation\`, \\\`variation-genre-run\\\`, \\\`variation-genre-cap-exceeded\\\`, \\\`variation-genre-mismatch\\\`) -- la decision de merge reste au coordinateur."
+          G-VAR-2 plafonne a un **ratio**, pas un plafond plat : budget LIGHT = \`max(1, grains_mergees_du_jour // 3)\` (sign-off user 2026-07-31, incident #8961). Valeur concrete : \`tally.cap\` (cf \`${TALLY}\` ci-dessus). Toutes categories LIGHT restent confondues (guard, docs, readme, ledger, test partagent la meme enveloppe). G-VAR-3 interdit deux genres LIGHT consecutifs. Les signaux ci-dessus rendent le fait VISIBLE (labels \`variation-tier-inflation\`, \\\`variation-genre-run\\\`, \\\`variation-genre-cap-exceeded\\\`, \\\`variation-genre-mismatch\\\`) -- la decision de merge reste au coordinateur."
             EXISTING_ID=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments[] | select(.body | startswith("'"$MARK"'")) | .id' 2>/dev/null | head -1 || echo "")
             if [ -n "$EXISTING_ID" ]; then
               gh api -X PATCH "repos/${GH_REPO}/issues/comments/${EXISTING_ID}" \

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
 """Detect G-VAR-2 cap-reached: a 2nd+ LIGHT PR merged the same day for a lane.
 
-G-VAR-2 (variation-protocol.md) caps the protocol at **one LIGHT PR per lane
-per day, all LIGHT sub-categories confounded** (guard, doc, refs, ... share a
-single budget). It is the only gate of the protocol that is **cross-PR** -- it
-needs to know what the lane has ALREADY merged today -- so until now it was
-counted by hand by the coordinator, who merged a 2nd LIGHT twice in one cycle
-(issue #8964: measured firsthand on the 2026-07-30 wave). This tool makes the
-fact VISIBLE (advisory, exit 0), it does not block.
+G-VAR-2 (variation-protocol.md) caps the protocol at a **ratio**, not a flat
+ceiling: the LIGHT allowance is `max(1, lane_grains_merged_today // 3)` (sign-off
+user 2026-07-31, incident #8961), with **all LIGHT sub-categories confounded**
+(guard, doc, refs, ... share a single budget). The flat `1 LIGHT/lane/day` it
+replaced scored a 1-PR lane and a 19-merge/13-DEEP lane identically -- a cap
+blind to throughput does not measure monoculture, it caps throughput. See
+`light_budget` below for the implementation and the L165-184 historicizing
+block for the rationale. It is the only gate of the protocol that is **cross-PR**
+-- it needs to know what the lane has ALREADY merged today -- so until it was
+automated the coordinator merged a 2nd LIGHT twice in one cycle (issue #8964:
+measured firsthand on the 2026-07-30 wave). This tool makes the fact VISIBLE
+(advisory, exit 0), it does not block.
 
 Input: a JSON array of the day's merged PRs, each `{number, body, mergedAt}`,
 produced by:


### PR DESCRIPTION
## Scope

Grain: LIGHT/docs -- lane myia-po-2026:CoursIA

Two prose locations still announced the obsolete flat G-VAR-2 cap (`1 LIGHT/lane/day`) while `light_budget` already implements the correct ratio `max(1, lane_grains_merged_today // 3)` (sign-off user 2026-07-31, incident #8961).

| File | Before | After |
|------|--------|-------|
| `scripts/variation_light_cap.py:4-6` | "caps the protocol at **one LIGHT PR per lane per day**" | "caps the protocol at a **ratio**, not a flat ceiling: `max(1, lane_grains_merged_today // 3)`" + cites sign-off + incident |
| `.github/workflows/variation-light-genre.yml:229` | "plafonne a **une LIGHT par lane et par jour**" | "plafonne a un **ratio**, pas un plafond plat : budget LIGHT = `max(1, grains_mergees_du_jour // 3)`" + cite `tally.cap` |

## Ce qui n'a PAS été touché (périmètre strict)

- `light_budget` (L193) — la logique du ratio est correcte depuis le sign-off
- Le bloc historicizing L165-184 — déjÃ  jour, déjÃ  historique, déjÃ  correct
- Aucune autre prose (pas de scope creep)

## Pourquoi

L'incohérence interne du fichier était un anti-pattern dangereux : un worker ouvrant `variation_light_cap.py` lisait la docstring, voyait "1 LIGHT/lane/day", et s'auto-bridait alors que `tally.cap > 1`. La même prose circule dans le commentaire que le workflow poste sur la PR, donc c'est le canal de décision qui véhiculait l'erreur.

C'est exactement le mécanisme de duplication que le passage au ratio visait à fermer : le plafond aveugle au débit ne mesure pas la monoculture, il plafonne le débit — et le répéter en prose le manufacturait à nouveau.

## Vérifications (G.1 firsthand)

- **G.1 docstring** : `git show origin/main:scripts/variation_light_cap.py` confirmé L4-6 obsolète
- **G.1 yml** : `git show origin/main:.github/workflows/variation-light-genre.yml` confirmé L229 obsolète
- **G.1 ratio** : L193 `max(1, lane_grain_count // LIGHT_RATIO_DIVISOR)` confirmé correct, ne touche pas
- **Tests** : `pytest scripts/tests/test_variation_light_cap.py` = **60/60 passed**
- **Catalog-pr-hygiene** : aucun marqueur `CATALOG-STATUS` touché, fichiers hors périmètre cron catalogue
- **Gate L898** : `gh pr list --state open --json files | grep variation_light_cap` = 0 PR ouverte touchante

## Périmètre

- 4 lignes docstring module (avant → 11 lignes plus précises)
- 1 ligne yml PR-comment prose
- Aucun autre fichier, aucune logique, aucun test ajouté

See #10020, #8961

🤖 Generated with [Claude Code](https://claude.com/claude-code)