### PR TITLE
fix(translation,#10287): translation_plan() pivote sur src_hash — ferme lacune T3↔T2

### DIFF
--- a/scripts/translation/tests/test_demo_t3_t4_acceptance.py
+++ b/scripts/translation/tests/test_demo_t3_t4_acceptance.py
@@ -6,9 +6,10 @@ Verifies that the end-to-end T3/T4 acceptance demo produces a falsifiable
 report and that the *couture* (gating flags, dry-run discipline, plan
 captioning) is intact.
 
-Litmus (litmus anti-regression, miroir du PR body) :
+Litmus (litmus anti-regression, miroir du PR body) — état après #10287 :
   - couture T3/T4 active (GATED banner present, plan count parseable)
-  - T3 ne capture pas le SRC_DRIFT dans state filled (lacune documentee)
+  - T3 détecte le SRC_DRIFT (translation_plan() pivote sur src_hash) — pivot
+    #10287 critère 1+4 : la lacune documentée par #10282 est FERMÉE.
   - T4 dry-run byte-stable sur le notebook de reference (FT-01)
 """
 from __future__ import annotations
@@ -54,13 +55,21 @@ def test_drift_count_is_consistent():
     assert drift["drift_with_filled_text_en"] == drift["src_drift_in_csv"]
 
 
-def test_t3_does_not_capture_filled_text_en_drift():
-    """Lacune documentee : T3 plan = 0 meme quand drift > 0 sur cellules filled."""
+def test_t3_captures_drift_now():
+    """Pivot #10287 : la lacune documentée par #10282 est fermée — T3 détecte
+    maintenant le SRC_DRIFT même quand text_<lang> est rempli. Critère #10287
+    critère 4 : la démo doit basculer de verdict (t3_detects_drift=False → True).
+
+    Avant #10287 : plan_count=0, drift_with_filled_text_en=78 → t3_detects_drift=False.
+    Après #10287 : plan_count=78, drift_with_filled_text_en=78 → t3_detects_drift=True.
+    """
     report = _run_demo()
     if report["drift"]["drift_with_filled_text_en"] > 0:
-        assert report["t3_plan"]["translations_planned"] == 0
-        assert report["verdict"]["t3_detects_drift"] is False
-        assert report["verdict"]["lacune"] is not None
+        # Le plan couvre toutes les cellules drifted (sur la langue `en` du test).
+        assert report["t3_plan"]["translations_planned"] == report["drift"]["drift_with_filled_text_en"]
+        assert report["verdict"]["t3_detects_drift"] is True
+        # La lacune est résolue — verdict.lacune est null.
+        assert report["verdict"]["lacune"] is None
 
 
 def test_t4_render_byte_stable():

--- a/scripts/translation/tests/test_translate_csv.py
+++ b/scripts/translation/tests/test_translate_csv.py
@@ -556,3 +556,181 @@ def test_provider_keys_have_no_literal_default_in_source():
     src = Path(t3.__file__).read_text(encoding="utf-8")
     assert 'getenv("OPENAI_API_KEY"' in src
     assert 'getenv("OPENAI_API_KEY", "' not in src  # no literal default
+
+
+# =========================================================================== #
+# #10287 — translation_plan() src_hash pivot
+#
+# Bug fondateur (c.1301+48, démo #10282) : translation_plan() filtrait sur
+# ``text_<lang>`` vide (cache/resume) et ignorait src_hash. Conséquence : un
+# notebook modifié FR (src_hash stale) ➜ T2 signale « SRC_DRIFT » mais T3
+# planifie 0 retraduction ➜ traduction périmée reste figée en EN/ES/...
+#
+# Fix : 4e paramètre ``drifted: set[(int, str)] | None`` injecté par l'appelant.
+#      - None (legacy) : comportement cible vide inchangé, rétrocompat.
+#      - set : éligibilité = cible vide OU (i, lang) dans drifted.
+#
+# Acceptance #10287 :
+#   1. translation_plan() rend éligible une cellule dont src_hash diffère,
+#      même si text_<lang> est déjà rempli.
+#   2. translation_plan() reste pure (pas d'I/O notebook).
+#   3. Aucune écriture destructive — un test couvre le cas « run interrompu ».
+#   4. La démo #10282 bascule de verdict (couvert dans test_demo_t3_t4_acceptance).
+#   5. Tests existants (234) restent verts.
+# =========================================================================== #
+
+
+# --------------------------------------------------------------------------
+# Pivot du fix — éligibilité par src_hash (paramètre drifted)
+# --------------------------------------------------------------------------
+def test_translation_plan_picks_up_drift_when_text_already_filled():
+    """Pivot #10287 critère 1 : une cellule dont la source FR a dérivé doit
+    être éligible À RETRADUIRE, même si text_<lang> est déjà rempli (le cache
+    logique est invalidé par la dérive de la source).
+
+    Cas : c1 a text_en="hello" (cache du run précédent), MAIS src_hash stale
+    (la source FR du notebook a changé depuis l'extraction CSV). L'appelant
+    injecte ``{(0, "en")}`` dans drifted → c1->en est yielded.
+    """
+    rows = [_row("c1", text_fr="nouvelle source FR", text_en="hello (obsolète)")]
+    drifted = {(0, "en")}
+    plan = list(t3.translation_plan(rows, ["en"], drifted=drifted))
+    assert (0, "en") in plan, "drift doit réactiver la cellule, même si text_en rempli"
+
+
+def test_translation_plan_legacy_behavior_without_drifted_kwarg():
+    """Rétrocompat #10287 critère 5 : translation_plan(rows, langs) (3 args,
+    sans drifted) reproduit le comportement legacy (cible vide uniquement)."""
+    rows = [_row("c1", text_fr="fr", text_en="hello")]
+    # drifted=None (défaut) → c1->en PAS yielded (text_en rempli = cache valide)
+    assert (0, "en") not in list(t3.translation_plan(rows, ["en"]))
+    # drifted=None explicite → même comportement
+    assert (0, "en") not in list(t3.translation_plan(rows, ["en"], drifted=None))
+
+
+def test_translation_plan_drifted_empty_set_behaves_like_none():
+    """``set()`` ≠ ``None`` : un set vide n'élargit pas l'éligibilité (pas de
+    cellule flagged). C'est la sémantique attendue (l'appelant qui calcule
+    drift=set() dit « aucun drift détecté »)."""
+    rows = [_row("c1", text_fr="fr", text_en="hello")]
+    # drifted=set() → c1->en PAS yielded (idem legacy)
+    assert list(t3.translation_plan(rows, ["en"], drifted=set())) == []
+
+
+def test_translation_plan_drift_does_not_affect_unrelated_cells():
+    """Orthogonalité : drift sur c1 ne réveille pas c2 (drifted ciblé)."""
+    rows = [
+        _row("c1", text_fr="fr1", text_en="en1"),
+        _row("c2", text_fr="fr2", text_en="en2"),
+    ]
+    drifted = {(0, "en")}  # SEUL c1->en drift
+    plan = list(t3.translation_plan(rows, ["en"], drifted=drifted))
+    assert (0, "en") in plan
+    assert (1, "en") not in plan  # c2 intouché
+
+
+def test_translation_plan_drift_scoped_to_lang():
+    """drift ciblé sur 'en' ne drape pas 'es' : (0, 'en') in drifted ⟹ (0, 'es')
+    reste legacy (text_es vide dans ce test → yielded par cible-vide, pas par
+    drift). Cas inverse : text_es rempli + pas de drift es → PAS yielded."""
+    rows = [_row("c1", text_fr="fr", text_en="en", text_es="es")]
+    drifted = {(0, "en")}  # drift EN, pas ES
+    plan = list(t3.translation_plan(rows, ["en", "es"], drifted=drifted))
+    assert (0, "en") in plan  # drift
+    assert (0, "es") not in plan  # text_es rempli + pas drift es
+
+
+# --------------------------------------------------------------------------
+# compute_drift_from_notebooks — détecteur pur (lit le disque via _read_cell_source)
+# --------------------------------------------------------------------------
+def test_compute_drift_from_notebooks_detects_modified_source(tmp_path):
+    """Le détecteur compare cell_hash(source_FR_actuelle) au row["src_hash"]
+    extrait. Si la source FR du notebook diffère du hash d'extraction, la
+    ligne est dans le set retourné."""
+    # Écrit un notebook .ipynb minimaliste avec 1 cellule markdown.
+    import json
+    nb_path = tmp_path / "MyIA.AI.Notebooks" / "demo.ipynb"
+    nb_path.parent.mkdir(parents=True)
+    nb = {
+        "cells": [{"id": "abc123", "cell_type": "markdown",
+                   "source": "source FR actuelle MODIFIÉE"}],
+        "metadata": {}, "nbformat": 4, "nbformat_minor": 5,
+    }
+    nb_path.write_text(json.dumps(nb), encoding="utf-8")
+
+    # src_hash INTENTIELLEMENT faux (≠ hash de la source actuelle).
+    rows = [_row("abc123", text_fr="source FR actuelle MODIFIÉE",
+                 src_hash="deadbeef" * 4)]  # 32 hex bidons
+    rows[0]["notebook"] = "MyIA.AI.Notebooks/demo.ipynb"
+
+    drifted = t3.compute_drift_from_notebooks(rows, repo_root=tmp_path)
+    assert 0 in drifted, "src_hash mismatch doit être détecté"
+
+
+def test_compute_drift_from_notebooks_no_drift_when_match(tmp_path):
+    """Si src_hash == cell_hash(source_actuelle), pas de drift."""
+    import json
+    actual_src = "contenu identique à l'extraction"
+    nb_path = tmp_path / "demo.ipynb"
+    nb = {"cells": [{"id": "c1", "cell_type": "markdown", "source": actual_src}],
+          "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+    nb_path.write_text(json.dumps(nb), encoding="utf-8")
+
+    rows = [_row("c1", text_fr=actual_src, src_hash=t3.cell_hash(actual_src))]
+    rows[0]["notebook"] = "demo.ipynb"
+    drifted = t3.compute_drift_from_notebooks(rows, repo_root=tmp_path)
+    assert drifted == set()
+
+
+def test_compute_drift_from_notebooks_missing_notebook_is_not_drift(tmp_path):
+    """Lecture défensive : notebook introuvable → skip (pas de drift déclaré).
+    L'absence d'info ne déclare pas un drift (cf acceptance #10287)."""
+    rows = [_row("c1", text_fr="x", src_hash="deadbeef" * 4)]
+    rows[0]["notebook"] = "introuvable.ipynb"  # n'existe pas
+    drifted = t3.compute_drift_from_notebooks(rows, repo_root=tmp_path)
+    assert drifted == set()  # skip, pas drift
+
+
+def test_compute_drift_from_notebooks_empty_src_hash_is_not_drift(tmp_path):
+    """Ligne sans src_hash (extraction legacy) → skip, pas drift."""
+    rows = [_row("c1", text_fr="x", src_hash="")]
+    rows[0]["notebook"] = "demo.ipynb"
+    drifted = t3.compute_drift_from_notebooks(rows, repo_root=tmp_path)
+    assert drifted == set()
+
+
+# --------------------------------------------------------------------------
+# Acceptance #10287 #3 — aucune écriture destructrice sur run interrompu
+# --------------------------------------------------------------------------
+def test_run_translations_preserves_obsolete_text_on_run_interruption(tmp_path, monkeypatch):
+    """Test « run interrompu » : tous les providers échouent → text_<lang>
+    RESTE FIGÉ à la valeur périmée (cache observé), pas de wipe ni de recopiage
+    depuis text_fr. La traduction périmée reste lisible dans le CSV jusqu'à
+    ce qu'un run réussi la remplace.
+
+    Acceptance #10287 #3 : « pas d'écriture destructive » + « la traduction
+    périmée reste lisible ».
+    """
+    import urllib.error
+
+    def _fail(fr_text, target_lang, model, key, base_url, **kw):
+        raise urllib.error.HTTPError("http://x", 500, "server err", {}, None)
+
+    out = str(tmp_path / "out.csv")
+    rows = [_row("c1", text_fr="contenu secret FR",
+                 text_en="OLD EN (sera remplacé)", hash_en="oldhash")]
+
+    monkeypatch.setattr(t3, "_provider_keys", lambda: [("stub", "k", "http://x")])
+    monkeypatch.setattr(t3, "translate_markdown", _fail)
+
+    # drifted indique « c1->en est périmé » — le moteur doit RETRADUIRE
+    # (drift + API KO => text_en reste la valeur ENSUITE au fallback).
+    done, fails = t3.run_translations(rows, ["en"], False, out, False,
+                                      limit=5, drifted={(0, "en")})
+    assert done == 0 and fails == 1
+    # text_en INTACT : la dérive déclenche bien la planification, mais l'échec
+    # provider n'efface pas la valeur périmée.
+    assert rows[0]["text_en"] == "OLD EN (sera remplacé)"
+    assert rows[0]["hash_en"] == "oldhash"
+    # Sécurité : aucun copier-coller du FR dans la colonne cible.
+    assert rows[0]["text_en"] != rows[0]["text_fr"]

--- a/scripts/translation/translate_csv.py
+++ b/scripts/translation/translate_csv.py
@@ -48,6 +48,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from pathlib import Path
 
 # Sibling import: ``check_perimeter`` owns the SINGLE source of truth for the
 # ordered target-language universe (#10109). This script's directory is on
@@ -225,11 +226,29 @@ def translate_markdown(fr_text, target_lang, model, key, base_url,
 # ----------------------------------------------------------------------------
 # Plan de traduction — cellules éligibles.
 # ----------------------------------------------------------------------------
-def translation_plan(rows, langs, include_code=False):
-    """Yield (row_index, lang) pour chaque cellule markdown éligible x langue cible vide.
+def translation_plan(rows, langs, include_code=False, drifted=None):
+    """Yield (row_index, lang) pour chaque cellule éligible x langue cible.
 
-    Éligibilité : cell_type == 'markdown' (ou 'code' si include_code), text_fr non
-    vide, text_<lang> vide (non déjà traduit — sert aussi de cache/resume).
+    Éligibilité (filtres cumulatifs) :
+      - cell_type == 'markdown' (ou 'code' si include_code) ;
+      - text_fr non vide ;
+      - **soit** ``text_<lang>`` vide (cible à produire — sert aussi de cache/resume),
+        **soit** ``(row_index, lang) in drifted`` (source FR modifiée depuis
+        l'extraction CSV, le contenu cible existant est périmé et doit être
+        régénéré — goulot d'intégration T3 ↔ T2 #10287).
+
+    Args:
+        rows: lignes CSV chargées (DictReader).
+        langs: liste des langues cibles.
+        include_code: inclure les cellules ``code`` (defaut False).
+        drifted: ``None`` (comportement legacy : cible vide uniquement) ou
+            ``set[(int, str)]`` de paires ``(row_index, lang)`` dont la source
+            FR a dérivé. Computé par l'appelant (qui a accès au disque) via
+            ``compute_drift_from_notebooks()`` — la fonction reste **pure**,
+            pas d'I/O notebook ici (acceptance #10287 critère 2).
+
+    Yields:
+        ``(row_index, lang)`` — tuples éligibles.
     """
     for i, row in enumerate(rows):
         ctype = row.get("cell_type", "")
@@ -241,15 +260,113 @@ def translation_plan(rows, langs, include_code=False):
         if not fr.strip():
             continue
         for lang in langs:
-            if not row.get(f"text_{lang}", "").strip():
+            target_empty = not row.get(f"text_{lang}", "").strip()
+            if target_empty:
+                yield i, lang
+                continue
+            if drifted is not None and (i, lang) in drifted:
                 yield i, lang
 
 
-def run_translations(rows, langs, include_code, out_path, smoke, limit=None):
+def compute_drift_from_notebooks(rows, repo_root=None):
+    """Identifie les row indices dont le ``src_hash`` ne match plus la source FR courante.
+
+    Lit les ``.ipynb`` référencés par les lignes du CSV, compare
+    ``cell_hash(cell_source_fr_actual)`` au ``row["src_hash"]`` extrait. Retourne
+    les indices dont le hash diffère (= « SRC_DRIFT » au sens T2). Une lecture
+    manquante ou un JSON cassé est traitée comme **non-drift** (skip défensif,
+    comme ``check_translation_sync.py`` T2) — la vérité disque prime, l'absence
+    d'info ne déclare pas un drift.
+
+    Args:
+        rows: lignes CSV chargées.
+        repo_root: racine du dépôt. ``None`` → auto-détection via le chemin
+            CSV (le repo contient ``scripts/translation/translate_csv.py``).
+
+    Returns:
+        ``set[int]`` — indices des lignes dont la source FR a dérivé.
+    """
+    if repo_root is None:
+        repo_root = _detect_repo_root(rows)
+    if repo_root is None:
+        return set()
+
+    # Cache (path, cell_id) -> source FR pour éviter de relire N fois le même notebook.
+    notebook_cache: dict[tuple[str, str], str | None] = {}
+
+    drifted_indices: set[int] = set()
+    for i, row in enumerate(rows):
+        csv_src_hash = row.get("src_hash", "").strip()
+        if not csv_src_hash:
+            # Pas de hash d'extraction → T2 ne peut pas conclure, on ne déclare pas drift.
+            continue
+        nb_rel = row.get("notebook", "").strip()
+        cell_id = row.get("cell_id", "").strip()
+        if not nb_rel or not cell_id:
+            continue
+        key = (nb_rel, cell_id)
+        if key not in notebook_cache:
+            notebook_cache[key] = _read_cell_source(nb_rel, cell_id, repo_root)
+        actual = notebook_cache[key]
+        if actual is None:
+            continue  # cellule introuvable → skip défensif, pas drift
+        if cell_hash(actual) != csv_src_hash:
+            drifted_indices.add(i)
+    return drifted_indices
+
+
+def _detect_repo_root(rows) -> Path | None:
+    """Détecte la racine du dépôt (contenant ``scripts/translation/``).
+
+    On cherche d'abord depuis ``cwd``, puis en remontant les ancêtres (cas
+    worktree où ``cwd`` peut être n'importe où). ``rows`` est conservé dans la
+    signature pour permettre un affinement futur (chemin absolu d'un notebook
+    comme heuristique) — aujourd'hui cwd suffit.
+    """
+    del rows  # noqa: F811 - unused parameter kept for future heuristic
+    cwd = Path.cwd()
+    if (cwd / "scripts" / "translation").is_dir():
+        return cwd
+    for ancestor in cwd.parents:
+        if (ancestor / "scripts" / "translation").is_dir():
+            return ancestor
+    return None
+
+
+def _read_cell_source(notebook_rel: str, cell_id: str, repo_root: Path) -> str | None:
+    """Lit le source FR actuel d'une cellule depuis son notebook. None si KO.
+
+    Lecture défensive : notebook introuvable, JSON cassé, cellule absente → None.
+    On **ne lève pas** : T2 a le même comportement et l'absence d'info ne déclare
+    pas un drift (cf acceptance #10287 — pas d'effet de bord silencieux sur
+    ``text_<lang>``).
+    """
+    nb_path = repo_root / notebook_rel
+    try:
+        with open(nb_path, encoding="utf-8") as f:
+            nb = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    for cell in nb.get("cells", []):
+        if cell.get("id") == cell_id:
+            src = cell.get("source", "")
+            if isinstance(src, list):
+                return "".join(src)
+            return src or ""
+    return None
+
+
+def run_translations(rows, langs, include_code, out_path, smoke, limit=None, drifted=None):
     """Exécute les traductions live (ENABLED doit être True). Mutate rows in place.
 
     Écrit le CSV incrémentalement après chaque cellule (resume-safe : un run
     interrompu reprend où il s'est arrêté grâce au cache text_<lang>).
+
+    Args:
+        drifted: ``set[(int, str)]`` — paires éligibles dont la source FR a
+            dérivé. Si ``None``, comportement legacy (cible vide uniquement).
+            Computé upstream dans ``main()`` via ``compute_drift_from_notebooks()``
+            — ``run_translations`` reste pure sur le CSV (acceptance #10287).
     """
     providers = _provider_keys()
     if not providers:
@@ -258,7 +375,7 @@ def run_translations(rows, langs, include_code, out_path, smoke, limit=None):
             "OPENROUTER_API_KEY) dans l'environnement. Jamais de littéral inline "
             "(secrets-hygiene.md).")
 
-    plan = list(translation_plan(rows, langs, include_code))
+    plan = list(translation_plan(rows, langs, include_code, drifted=drifted))
     if smoke:
         # 1 cellule x toutes les langues demandées (premier markdown trouvé).
         first_idx = next((i for i, _ in plan), None)
@@ -345,7 +462,18 @@ def main() -> int:
     else:
         langs = list(TARGETS)  # dry-run default = plan complet sur les 7 langues
 
-    plan = list(translation_plan(rows, langs, args.include_code))
+    # Compute drift depuis les notebooks (cf #10287) — la dérive est injectée
+    # dans translation_plan() pour qu'une cellule ``text_<lang>`` non-vide
+    # dont la source FR a changé devienne éligible à retraduction.
+    # Erreurs de lecture (notebook introuvable, JSON cassé) → skip défensif.
+    drifted_indices = compute_drift_from_notebooks(rows)
+    drifted_pairs = {(i, lang) for i in drifted_indices for lang in langs}
+    if drifted_pairs:
+        print(f"[drift] {len(drifted_indices)} cellule(s) FR modifiée(s) "
+              f"depuis l'extraction CSV ({len(drifted_pairs)} paires "
+              f"cel. x langue éligibles à retraduction) — #10287", file=sys.stderr)
+
+    plan = list(translation_plan(rows, langs, args.include_code, drifted=drifted_pairs))
     if args.smoke:
         first_idx = next((i for i, _ in plan), None)
         plan = [(i, lang) for i, lang in plan if i == first_idx] if first_idx is not None else []
@@ -378,7 +506,7 @@ def main() -> int:
               "OPENAI_API_KEY env. GO user = umbrella #10038.", file=sys.stderr)
         return 0
 
-    return 0 if run_translations(rows, langs, args.include_code, out_path, args.smoke, effective_cap)[1] == 0 else 1
+    return 0 if run_translations(rows, langs, args.include_code, out_path, args.smoke, effective_cap, drifted=drifted_pairs)[1] == 0 else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: DEEP/tooling #10282

# fix(translation,#10287): translation_plan() pivote sur src_hash — fermeture de la lacune T3↔T2

## Mission (DM ai-01 msg-20260810T093123-cl5fe0, dispatch #10287)

> « Goulot d'intégration T3 ↔ T2 : `translation_plan()` ignore `src_hash`.
> Éligibilité = cible vide OU source dérivée, dérive calculée par l'appelant
> et injectée. Aucun effacement préalable. »

**Livré** : 4e paramètre optionnel `drifted: set[(int, str)] | None = None` à
`translation_plan()` dans `scripts/translation/translate_csv.py`, +
`compute_drift_from_notebooks()` qui scanne les `.ipynb` et collecte les
indices dont `src_hash` a dérivé. `main()` injecte le set dans le plan,
`run_translations()` le propage. **10 nouveaux tests, 244 verts
(234 baseline + 10).**

## Mesure falsifiable (acceptance #10287, 5 critères)

| # | Critère | Mesure |
|---|---------|--------|
| 1 | `translation_plan()` rend éligible une cellule dont `src_hash` diffère, **même si `text_<lang>` est non vide** | `test_translation_plan_picks_up_drift_when_text_already_filled` ✓ |
| 2 | `translation_plan()` ne lit aucun notebook — la dérive est injectée | signature `(rows, langs, include_code, drifted)` pure ; `compute_drift_from_notebooks()` est dans le caller ✓ |
| 3 | Aucune écriture destructive ; un test couvre le « run interrompu » | `test_run_translations_preserves_obsolete_text_on_run_interruption` ✓ |
| 4 | La démo d'acceptance de #10282 **bascule de verdict** | `t3_detects_drift: false → true`, `plan_count: 0 → 78`, `lacune: "<msg>" → null` (cf sortie demo ci-dessous) ✓ |
| 5 | `pytest scripts/translation/tests/ -q` reste vert (234 tests) | **244 passed** (10 nouveaux) ✓ |

## Sortie demo (avant/après factuel)

**Avant #10287** (PR #10282 ff3bcc75c) :
```json
{
  "drift": {"src_drift_total": 78, "drift_with_filled_text_en": 78},
  "t3_plan": {"translations_planned": 0},
  "verdict": {"t3_detects_drift": false, "lacune": "T3 ne capture pas les 78 cellules..."}
}
```

**Après #10287** (cette PR) :
```json
{
  "drift": {"src_drift_total": 78, "drift_with_filled_text_en": 78},
  "t3_plan": {"translations_planned": 78, "stderr_summary": [
    "[drift] 78 cellule(s) FR modifiée(s) depuis l'extraction CSV (78 paires cel. x langue éligibles à retraduction) — #10287",
    "[plan] 78 traductions nécessaires (1 langue(s), include_code=False)",
    "[GATED] ..."
  ]},
  "verdict": {"t3_detects_drift": true, "lacune": null}
}
```

## Design (tranché ai-01, respecté)

- **`translation_plan(rows, langs, include_code, drifted=None)`** — fonction
  *pure*, accepte `drifted` (set optionnel de paires `(i, lang)`):
  - `drifted=None` → comportement legacy (cible vide uniquement) → **rétrocompat totale** (les 6 tests existants passent sans modification).
  - `drifted=set(...)` → éligibilité = cible vide `OR (i, lang) in drifted`.
- **`compute_drift_from_notebooks(rows, repo_root=None)`** — *détecteur*,
  lit les `.ipynb` (même `cell_hash` que T1/T2), compare au `row["src_hash"]`,
  retourne `set[int]` de row indices. Lecture défensive : notebook absent /
  JSON cassé / cellule absente → skip (pas de drift déclaré).
- **`main()`** — appelle `compute_drift_from_notebooks(rows)` puis construit
  `drifted_pairs = {(i, lang) for i in drifted_indices for lang in langs}` et
  l'injecte dans `translation_plan()` et `run_translations()`.
- **Aucun effacement préalable** — `run_translations()` n'écrit `text_<lang>`
  qu'après réception d'une nouvelle traduction (ligne 278). Une traduction
  périmée reste lisible dans le CSV jusqu'à l'écrasement effectif. Test
  « run interrompu » : tous les providers KO → `text_<lang>` reste figé à la
  valeur périmée (intacte, pas recopiée depuis text_fr, pas wipe).

## Tests (10 ajoutés, 244 au total)

Section ajoutée en fin de `test_translate_csv.py` sous le bandeau
`#10287 — translation_plan() src_hash pivot` :

| Test | Couvre |
|------|--------|
| `test_translation_plan_picks_up_drift_when_text_already_filled` | critère 1 — pivot |
| `test_translation_plan_legacy_behavior_without_drifted_kwarg` | rétrocompat (critère 5) |
| `test_translation_plan_drifted_empty_set_behaves_like_none` | `set()` ≠ `None` |
| `test_translation_plan_drift_does_not_affect_unrelated_cells` | orthogonalité par row |
| `test_translation_plan_drift_scoped_to_lang` | orthogonalité par langue |
| `test_compute_drift_from_notebooks_detects_modified_source` | détecteur détecte |
| `test_compute_drift_from_notebooks_no_drift_when_match` | pas de faux positif |
| `test_compute_drift_from_notebooks_missing_notebook_is_not_drift` | lecture défensive |
| `test_compute_drift_from_notebooks_empty_src_hash_is_not_drift` | skip src_hash vide |
| `test_run_translations_preserves_obsolete_text_on_run_interruption` | critère 3 — run KO |

Et **`test_demo_t3_t4_acceptance.py`** : `test_t3_does_not_capture_filled_text_en_drift`
**inversé** → `test_t3_captures_drift_now` (le harnais qui mesurait la lacune
mesure maintenant sa fermeture).

## Anti-patterns évités

- **Pas de regen catalogue** (catalog-pr-hygiene R1) — 3 fichiers stricts, diff `+332/-17`.
- **Pas de fix destructif** — la valeur existante `text_<lang>` est préservée
  jusqu'à l'écrasement réussi (critère 3 acceptance #10287).
- **Pas d'auto-promotion du fix en epic** — la lacune est trackée #10042 (umbrella),
  fermée seulement quand le pipeline global (T1+T2+T3+T4) sera lui-même intégré.
- **Pas de modification de notebook pédagogique** (G.3, C.3) — la démo utilise
  l'état drift déjà réel sur main (78 cellules), comme #10282.
- **Pas de I/O notebook dans `translation_plan()`** — la fonction reste pure
  (critère 2 acceptance); l'I/O est dans l'appelant.

## Acceptance pour #10042 (mise-à-jour)

| Avant cette PR | Après cette PR |
|----------------|----------------|
| couture T3/T4 active (DRY-RUN) | inchangé |
| T3 capte cible vide | **T3 capte cible vide OU src_hash mismatch** |
| Lacune T3↔T2 documentée (#10282) | **Lacune fermée pour le pivot planification** |
| Démo mesure la lacune | **Démo bascule verdict** (acceptance #4) |

## Sortie pytest

```
============================ 244 passed in 20.94s =============================
```

(234 baseline + 10 nouveaux)

## Anti-patterns INTERDITS respectés

- `extract_cells_to_csv` (T1) NON touché — le schéma CSV est inchangé.
- `check_translation_sync` (T2) NON touché — c'est le détecteur, déjà correct.
- `render_notebook` (T4) NON touché — la couture aval est inchangée.
- `extract_cells_to_csv` a un candidat naturel comme « owner de la dérive »,
  mais **le pivot est sur T3** : T3 planifie la retraduction, c'est son job.
  T1 reste l'extracteur, T2 reste le détecteur, T3 reste le planificateur.

## Notes coordination

- **ai-01 tranché le design** (DM msg-20260810T093123-cl5fe0) avant le dispatch.
  Pas de retour en arrière sur les choix `drifted` (set / pure / injecté).
- **5 critères acceptance = check-list binaire** vérifiable post-fix. Aucun
  critère subjectif ou « à dire d'expert ».
- **#10287 = PR partielle / `Closes`** (les 5 critères ferment entièrement
  l'issue pivot). `#10042` reste l'epic umbrella (tracké via `See`).

## Liens

- Issue : **#10287** (Closes)
- Epic parente : **#10042** (See, déjà CLOSED en élaboration mais toujours référente)
- PR antérieure : **#10282** (DEEP/tooling — démo falsifiable qui a
  documenté la lacune). Cette PR est la **fermeture falsifiable** de la
  lacune qu'elle a scopée.
- DM coordinateur : msg-20260810T093123-cl5fe0 (dispatch #10287)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
