### PR TITLE
docs(search,App-10b,#10022): clarify N=12 title -- efficiency value not optimality + EXEC_PROVED via GeneticSharp cache repair

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
@@ -1267,7 +1267,7 @@
     "tags": []
    },
    "source": [
-    "## Instance durcie N=12 : quand le GA devient indispensable (correlation, contraintes)\n",
+    "## Instance durcie N=12 : quand le GA montre sa valeur d'efficacité (correlation, contraintes)\n",
     "\n",
     "L'instance de la section precedente (5 actifs, rendements monotones, covariance\n",
     "diagonale-dominante) souffre d'un defaut pedagogique qu'on appelle **paysage\n",
@@ -1275,7 +1275,7 @@
     "Prong B) : la grille exhaustive bat le GA, le GA n'a rien de discriminant a\n",
     "apporter. C'est precisement le cas degeneré que le twin Python enseigne a eviter.\n",
     "\n",
-    "Pour demontrer la **valeur distinctive** du GA, on construit maintenant une\n",
+    "Pour demontrer la **valeur d'efficacité** du GA (Sharpe eleve a budget d'evaluations reduit, pas optimum absolu), on construit maintenant une\n",
     "instance **non-rectangulaire** ou la grille devient infrarisable :\n",
     "\n",
     "- **N = 12 actifs** organises en 3 clusters (Defensif / Tech / Industrial),\n",

--- a/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
@@ -4,6 +4,12 @@
   csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
   parity_level: semantic
   audits:
+    - date: "2026-08-10"
+      by: myia-po-2024:CoursIA
+      python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+      csharp_sha: 8413a08b13a3f1d3350ca2fa61c5115200f11058
+      content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+      content_csharp_sha: 2208eba59d6d7d0e5a7361811372e1627e7fbd6afe03524dfc1eb338d1374acd
   - date: '2026-08-04'
     by: myia-po-2023:CoursIA
     python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0

--- a/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
@@ -1,79 +1,58 @@
-- name: App-10 Portfolio
-  family: Search/Applications
-  python: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb
-  csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
-  parity_level: semantic
-  audits:
-    - date: "2026-08-10"
-      by: myia-po-2024:CoursIA
-      python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-      csharp_sha: 8413a08b13a3f1d3350ca2fa61c5115200f11058
-      content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
-      content_csharp_sha: 2208eba59d6d7d0e5a7361811372e1627e7fbd6afe03524dfc1eb338d1374acd
-  - date: '2026-08-04'
-    by: myia-po-2023:CoursIA
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: dad13c7fac88520807664b25ab6b95095f608677
-  - date: '2026-08-08'
-    by: myia-po-2024:CoursIA
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: 0e679cb6c2a1b3ea821e9a0e72db238e39ebcef8
-    content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
-    content_csharp_sha: d65d9189296d1821c2e871ed3d2968488cdbb693c831729755d9b7fcccab9084
-  - date: '2026-08-08'
-    by: myia-po-2024:CoursIA-2
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: 443cb79d128f63e03a41ae99400f5da630084db2
-    content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
-    content_csharp_sha: 2b4046cb859f06d956bc016cac81878b798c0ff8622d659c1ec76882a80d1121
-  - date: '2026-08-08'
-    by: myia-po-2024:CoursIA-2
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: 0855da6aca816a8dcec54ff4f62088655ce54cb2
-    content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
-    content_csharp_sha: f3309247124d8c6f0541f2da2624c997d48d86b81e617dbcceed2145af641809
-  - date: '2026-08-09'
-    by: myia-po-2024:CoursIA-2
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: d06e92c8e9186a9023e080f96c4a78fae8ded399
-    content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
-    content_csharp_sha: 6a5e1fc75d8e3794e6a90836c5286e9c4ca701e87d62dc450f3d713b20012dd0
-  - date: '2026-08-09'
-    by: myia-po-2024:CoursIA-2
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: e500ca2f9b63dd59109c875237d097fd203467c7
-    content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
-    content_csharp_sha: 2d3c0c815ffe6cf7440cfd160cf84920798081dd9aa97376a5a6386b8b5078a6
-  - date: "2026-08-10"
-    by: myia-po-2024:CoursIA-2
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: 01db0d7a49a4ac97aad3d33a978cba6bb1269eb4
-    content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
-    content_csharp_sha: 0b8dbd86ed46149c87a3aa55d8c9c165e664168c83ed71986ca2b30ea4b56abb
-
-  known_differences:
-  - 'Socle pedagogique commun : Optimisation de portefeuille (convex opt cvxpy + GeneticSharp
-    C#) comme application canonique. Les deux twins couvrent le meme socle theorique
-    (formulation variables/domaines/contraintes, resolution, experimentation) avec
-    parite semantique sur les concepts cibles.'
-  - 'Idiomes framework : Python = cvxpy convex optimization + math.comb ; C# = GeneticSharp
-    NuGet (GA).'
-  - 'Asymetrie pedagogique : Python met l''accent sur le solveur SOTA (OR-Tools CP-SAT
-    / library specialisee) + visualisation matplotlib + experimentation comparative
-    ; le C# demontre l''implementation from-scratch en BCL pure (ou binding NuGet
-    du meme solver pour App-8/10/15), presentation compacte. Meme socle theorique,
-    leviers de demonstration differents.'
-  - 'Extension cardinalite K : les deux twins demontrent l''inefficacite d''un solveur
-    convexe (Markowitz long-only) face a une contrainte non-convexe (||w||₀ ≤ K).
-    Cote Python : la section 7 du notebook enonce d''abord le discriminant (convexe
-    → cvxpy), puis enumere les C(5,2)=10 paires en resolvant un QP convexe (cvxpy/CLARABEL)
-    sur chacune via `itertools.combinations` (rf=0.02, K=2 → Actions US + Emergents,
-    Sharpe 1.3060), compare au PyGAD GA avec projection top-K dans la fitness (200
-    generations) — verdict : le GA retrouve l''optimum exact. Cote C# : BCL pure enumeration
-    exhaustive C(5,2)=10 paires avec tangence Tobin analytique par paire (formule
-    fermee w ∝ Σ⁻¹(μ-rf) sur sous-matrice 2x2, rf=0.0 simplifie pedagogiquement, meme
-    instance d''actifs), plus metaheuristique GA (GeneticSharp) avec projection top-K
-    dans le decodeur du chromosome (TopKFitness : IFitness). Verdict croise attendu
-    : Concordance OUI entre enumeration et GA (meme paire trouvee, ecart Sharpe ≈
-    0.0000). Demonstration du discriminant ''convexe → solveur exact, non-convexe
-    → enumeration ou metaheuristique''.'
+-   name: App-10 Portfolio
+    family: Search/Applications
+    python: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb
+    csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
+    parity_level: semantic
+    audits:
+    -   date: '2026-08-04'
+        by: myia-po-2023:CoursIA
+        python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+        csharp_sha: dad13c7fac88520807664b25ab6b95095f608677
+    -   date: '2026-08-08'
+        by: myia-po-2024:CoursIA
+        python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+        csharp_sha: 0e679cb6c2a1b3ea821e9a0e72db238e39ebcef8
+        content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+        content_csharp_sha: d65d9189296d1821c2e871ed3d2968488cdbb693c831729755d9b7fcccab9084
+    -   date: '2026-08-08'
+        by: myia-po-2024:CoursIA-2
+        python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+        csharp_sha: 443cb79d128f63e03a41ae99400f5da630084db2
+        content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+        content_csharp_sha: 2b4046cb859f06d956bc016cac81878b798c0ff8622d659c1ec76882a80d1121
+    -   date: '2026-08-08'
+        by: myia-po-2024:CoursIA-2
+        python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+        csharp_sha: 0855da6aca816a8dcec54ff4f62088655ce54cb2
+        content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+        content_csharp_sha: f3309247124d8c6f0541f2da2624c997d48d86b81e617dbcceed2145af641809
+    -   date: '2026-08-09'
+        by: myia-po-2024:CoursIA-2
+        python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+        csharp_sha: d06e92c8e9186a9023e080f96c4a78fae8ded399
+        content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+        content_csharp_sha: 6a5e1fc75d8e3794e6a90836c5286e9c4ca701e87d62dc450f3d713b20012dd0
+    -   date: '2026-08-09'
+        by: myia-po-2024:CoursIA-2
+        python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+        csharp_sha: e500ca2f9b63dd59109c875237d097fd203467c7
+        content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+        content_csharp_sha: 2d3c0c815ffe6cf7440cfd160cf84920798081dd9aa97376a5a6386b8b5078a6
+    -   date: '2026-08-10'
+        by: myia-po-2024:CoursIA-2
+        python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+        csharp_sha: 01db0d7a49a4ac97aad3d33a978cba6bb1269eb4
+        content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+        content_csharp_sha: 0b8dbd86ed46149c87a3aa55d8c9c165e664168c83ed71986ca2b30ea4b56abb
+    -   date: '2026-08-10'
+        by: myia-po-2024:CoursIA
+        python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+        csharp_sha: 8413a08b13a3f1d3350ca2fa61c5115200f11058
+        content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+        content_csharp_sha: 2208eba59d6d7d0e5a7361811372e1627e7fbd6afe03524dfc1eb338d1374acd
+    known_differences:
+    - 'Socle pedagogique commun : Optimisation de portefeuille (convex opt cvxpy + GeneticSharp C#) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles.'
+    - 'Idiomes framework : Python = cvxpy convex optimization + math.comb ; C# = GeneticSharp NuGet (GA).'
+    - 'Asymetrie pedagogique : Python met l''accent sur le solveur SOTA (OR-Tools CP-SAT / library specialisee) + visualisation matplotlib + experimentation comparative ; le C# demontre l''implementation from-scratch en BCL pure (ou binding NuGet du meme solver pour App-8/10/15), presentation compacte. Meme socle theorique, leviers de demonstration differents.'
+    - 'Extension cardinalite K : les deux twins demontrent l''inefficacite d''un solveur convexe (Markowitz long-only) face a une contrainte non-convexe (||w||₀ ≤ K). Cote Python : la section 7 du notebook enonce d''abord le discriminant (convexe → cvxpy), puis enumere les C(5,2)=10 paires en resolvant un QP convexe (cvxpy/CLARABEL) sur chacune via `itertools.combinations` (rf=0.02, K=2 → Actions US + Emergents, Sharpe 1.3060), compare au PyGAD GA avec projection top-K dans la fitness (200 generations) — verdict : le GA retrouve l''optimum exact. Cote C# : BCL pure enumeration exhaustive C(5,2)=10 paires avec tangence Tobin analytique par paire (formule fermee w ∝ Σ⁻¹(μ-rf) sur sous-matrice 2x2, rf=0.0 simplifie pedagogiquement, meme instance d''actifs), plus metaheuristique GA (GeneticSharp) avec projection top-K dans le decodeur du chromosome (TopKFitness : IFitness). Verdict croise attendu : Concordance OUI entre enumeration et GA (meme paire trouvee, ecart Sharpe ≈ 0.0000). Demonstration
+        du discriminant ''convexe → solveur exact, non-convexe → enumeration ou metaheuristique''.'


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #10026

## Quoi

`App-10b-Portfolio-CSharp.ipynb` cell[15] titre « quand le GA **devient indispensable** » sur-glossait le verdict Prong B de l'instance N=12. Sur cette instance convexe (clusters + contraintes min/max), le GA ne bat le random Dirichlet projeté que de **+1,0 %** de Sharpe (1,3264 vs 1,3126 — dans le bruit). Le **corps** de cell[15] disait déjà honnêtement « le discriminant est la qualité/coût, pas l'optimum absolu » ; seul le **titre** éludait.

Deux corrections markdown (2 lignes, zéro code, zéro re-exec) :

| Ligne | Avant | Après |
|---|---|---|
| Titre cell[15] | « quand le GA **devient indispensable** » | « quand le GA **montre sa valeur d'efficacité** » |
| Intro cell[15] | « Pour démontrer la **valeur distinctive** du GA » | « Pour démontrer la **valeur d'efficacité** du GA (Sharpe élevé à budget d'évaluations réduit, pas optimum absolu) » |

## Pourquoi (G.1 relecture honnête)

En relisant #10026 (mon propre grain merged), j'ai d'abord soupçonné un overclaim flagrant. Lecture attentive : les claims du **corps** sont défendables (cell[15] cite explicitement « qualité/coût, pas optimum absolu » ; cell[17] dit « différence faible +0,5 à +1 %, systématique sur 5 seeds » ; verdict SOTA-OK basé sur grille infrarisable + coût d'évaluation). Le seul point qui sur-glossait était le **titre** « indispensable » — corrigé.

## EXEC_PROVED — ré-exec fraîche via réparation rule F (cache GeneticSharp)

Le bloquéur headless-nuget cluster-wide (`dotnet-headless-nuget-restore-cluster-wide-blocker`, confirmé c.595) est **réparable** : peupler le cache NuGet avec la version exacte via `dotnet add package GeneticSharp` (restore réseau via la CLI dotnet, qui marche), puis le kernel headless trouve le package en cache.

```
dotnet add package GeneticSharp   # → cache ~/.nuget/packages/geneticsharp/3.1.4 (234 ms)
jupyter nbconvert --execute App-10b-Portfolio-CSharp.ipynb  # → exit 0, 93987 bytes, 0 erreur
```

Ré-exec complète du notebook (28 cellules, kernel `.net-csharp`, GeneticSharp 3.1.4) : **exit 0, 0 erreur**. Les outputs frais sont **identiques** aux outputs committés (déterministe, seed=42) → reproductibilité confirmée, pas de drift C.4.

**Portée** : débloque la ré-exec headless de tous les notebooks `#r "nuget:"` dont la version exacte est en cache — GeneticSharp (App-10b, App-13b), et potentiellement #6596 (Sudoku Plotly), ML-5 (Microsoft.ML). Leçon à consigner.

## Acceptance #10022

- [x] Prose réconciliée (titre aligné sur les outputs réels)
- [x] Verdict Prong B : SOTA-OK confirmé (le GA apporte efficacité sur instance à grille infrarisable, pas optimalité absolue — déjà honnête dans le corps)
- [x] EXEC_PROVED (ré-exec fraîche post cache-repair)
- [x] Twin rebaseline (`app-10-portfolio.yaml`, csharp blob oid, 157/157 OK attendu)

Le critère « instance discriminante stricte (GA bat strictement) » reste partiel : sur instance convexe, random ≈ GA. Une instance à cardinalité dure NP (K-sur-N grand) où le GA bat strictement random reste un grain suivant — non couvert ici.

## Méthode

Raw string-replace sur le JSON brut (zéro churn nbformat, mémoire `nbformat-write-churns-untouched-cells`). Markdown-only → exception C.2 (pas de re-exec requise pour le commit ; la re-exec fraîche est la preuve, non un output commité). H.3 Passed. Catalogue byte-identique.

See #10022, #10026, #3801

---

## YAML re-indent + reorder (commit `f2cbbb16f`, cross-lane by `myia-po-2024:CoursIA-2`)

**Cross-lane work, permission explicite d'ai-01** (DM HIGH msg-20260810T111622-lvrhzp : « oui fonce » sur la re-indentation YAML).

### Symptôme (Scripts Tests CPU : 18 failed / 7310 passed + App-10 DRIFT)

TWO défauts introduits par le commit `179a5beea` (PR #10291) :

**Défaut #1 — indentation mixte YAML.**

L'entrée d'audit ajoutée au commit `179a5beea` (PR #10291) était à l'indentation canonique 4 espaces (`    - date:` + `      by:`), mais les 7 entrées existantes de la séquence `audits:` restaient à 2 espaces (`  - date:` + `    by:`). PyYAML refuse ce mélange :

```
expected <block end>, but found '-'
  in "scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml", line 13, column 3:
      - date: '2026-08-04'
      ^
```

Ce parse-fail bloquait `validators.validate_twin_registry` (charge tous les YAML sous `scripts/notebook_tools/twin_pairs.d/`), qui cascadait sur 18 tests dans Scripts Tests (CPU).

**Défaut #2 — entrée PRÉPENDÉE causant DRIFT.**

L'entrée d'audit de PR #10291 a été **prépendée en haut** de la liste `audits:`. Mais `check_twin_parity.py::_latest_audit` retourne `audits[-1]` (la dernière entrée = la plus récente en position de fichier). Avec deux entrées sur date `2026-08-10`, le script choisit la plus **ancienne** chronologiquement (en queue de liste) → DRIFT sur App-10 :

```
[DRIFT] App-10 Portfolio (Search/Applications, semantic)
       - C# a drift (content) : 0b8dbd86 -> 2208eba5
```

`content_csharp_sha` recorded = `0b8dbd86...` (depuis l'ancienne entrée en queue) vs `content_csharp_sha` calculated = `2208eba5...` (état actuel du C# notebook). Le twin parity gate `--check` retourne exit 1 sur cette dérive.

### Fix (2 axes, vérifiés localement)

**Axe 1 — Re-indentation canonique.**

Normaliser **toutes** les 8 entrées à l'indentation canonique 4 espaces (qui matche le reste du repo : `app-1-nqueens.yaml` et 100+ fichiers déjà en 4+6). Aucun changement de contenu, indentation pure.

**Axe 2 — Reorder : « latest at bottom ».**

Déplacer l'entrée de PR #10291 (date `2026-08-10`, by `myia-po-2024:CoursIA`, `csharp_sha 8413a08b...`) **de la tête vers la queue** de la liste `audits:`. Conséquence : `_latest_audit` résout maintenant vers la nouvelle entrée (fraiche), pas vers `0b8dbd86...` (stale).

Référence : commit `6c2fa6597` « fix(twin): correct App-10 audit entry indent + order (move latest to bottom) » a appliqué le même fix sur le style 2-espaces le 2026-08-10. Cette PR-ci applique le fix sur le style 4-espaces canonique (matchant le reste du repo).

### Vérification

```
$ python -c "import yaml; print(len(yaml.safe_load(open('app-10-portfolio.yaml'))[0]['audits']))"
8

$ python scripts/notebook_tools/check_twin_parity.py --check
Total : 157 paire(s) | OK=157 DRIFT=0 MISSING=0
```

Référence croisée : `app-1-nqueens.yaml` utilise déjà le style 4+6 — la convention du repo est désormais uniforme.

### Hors-scope

- Pas de rebase sur `main` (PR est MERGEABLE, fix incrémental)
- Pas de modification du contenu des audits (mêmes `date`/`by`/`*_sha`)
- Pas de modif du notebook `App-10b-Portfolio-CSharp.ipynb` lui-même

### Suivi attendu

Après ce fix, le workflow `Scripts Tests (CPU)` doit passer de **18 failed / 7310 passed** à **0 failed / 7328 passed** (la perte de 18 tests valides était exactement le bruit que PyYAML générait). Le twin parity audit doit reprendre sa sortie nominale (157 OK, 0 DRIFT).