### PR TITLE
docs(genai-texte,#3975): resync README with notebook 21 (QLoRA fine-tuning)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Texte/README.md
@@ -96,6 +96,16 @@ Le notebook 12 introduit en Python pur les quatre moteurs d'inférence au moment
 
 Provenance et poids de chaque figure : [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 
+### Tier 6 : Fine-tuning (Avancé)
+
+Les tiers 1 à 5 exploitent un LLM **tel quel** (prompting, structuration, augmentation, scaling au moment du test). Le notebook 21 franchit le pas suivant : **adapter le modèle lui-même** à une tâche précise sans tout réentraîner. La technique est **LoRA / QLoRA** (Low-Rank Adaptation) : on gèle les poids du modèle de base et on n'entraîne que de petits *adaptateurs* de bas rang — quelques millions de paramètres au lieu de quelques milliards — ce qui tient dans 8 Go de VRAM et évite l'oubli catastrophistique des connaissances pré-entraînées.
+
+Le fil rouge est volontairement discriminant : enseigner au modèle un **format balisé arbitraire** (`[T]Terme[/T][D]Définition[/D][E]Exemple[/E]`) que le modèle de base ne produit **jamais** spontanément. On observe d'abord l'échec du base (prose avec deux-points, balises ignorées), puis on quantifie en 4-bit (NF4 + double quantification, calcul en bf16 via `BitsAndBytesConfig`), on greffe les adaptateurs LoRA avec `peft`, et on entraîne avec `trl` sur un petit jeu d'exemples bien formatés. Le vrai outil SOTA est branché bout en bout (`peft`, `bitsandbytes`, `trl`, `datasets`, `transformers`) — aucun substitut. Ce notebook fait pont avec la série [PostTraining](../PostTraining/README.md) et l'EPIC [#10247](https://github.com/jsboige/CoursIA/issues/10247) (fine-tuning/training). **GPU CUDA requis** (environnement `coursia-ml-training`).
+
+| # | Notebook | Description | Durée |
+|---|----------|-------------|-------|
+| 21 | `21_LoRA_FineTuning.ipynb` | **QLoRA** (NF4 4-bit + double quant, bf16) sur Qwen2.5-0.5B-Instruct : fil rouge = format balisé `[T]/[D]/[E]` que le base échoue à produire ; adaptateurs LoRA via `peft` + `bitsandbytes` + `trl` + `datasets`, GPU CUDA requis (pont PostTraining / #10247) | 75 min |
+
 ## Prérequis
 
 ### Configuration API


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2025:CoursIA-2 — prev: MED/tooling #10288

# docs(genai-texte): resync README with notebook 21 (QLoRA fine-tuning)

## Quoi

`MyIA.AI.Notebooks/GenAI/Texte/README.md` avait un drift structurel §E : le notebook `21_LoRA_FineTuning.ipynb` (ajoute via #10251, MERGED `a0d405293`) etait present sur `origin/main` mais **absent du README** — le tableau s'arretait au notebook 20 (Tier 5 : Test-Time Scaling), et le marker `pedagogical_count: 20` sous-comptait.

Cette PR ajoute un **Tier 6 : Fine-tuning (Avancé)** au README :
- **Prose pedagogique** (paragraphe d'introduction) : explique LoRA/QLoRA (adaptateurs de bas rang, geler les poids de base, quelques millions de params vs quelques milliards, tient dans 8 Go VRAM, evite l'oubli catastrophistique), le fil rouge discriminant (format balise `[T]/[D]/[E]` que le base Qwen2.5-0.5B-Instruct echoue a produire spontanement), et fait pont avec la serie PostTraining + EPIC #10247.
- **Ligne de tableau** pour le notebook 21 avec description fidele au contenu firsthand (QLoRA NF4 4-bit + double quantification, calcul bf16, `BitsAndBytesConfig`, adaptateurs via `peft`+`bitsandbytes`+`trl`+`datasets`, GPU CUDA requis, duree 75 min).

## #9434 / SOTA — description fidele, vrai outil branche

Le notebook 21 execute le **vrai outil SOTA** end-to-end (`peft`, `bitsandbytes`, `trl`, `datasets`, `transformers`) — aucun substitut, verdict **SOTA-OK**. La description README reflete fidelement le fil rouge (format balise que le base echoue) lu firsthand dans le notebook, pas juste le titre.

## §E — audit fichier-entier (pr-review-discipline E)

Une PR README DOIT prouver l'audit du **fichier entier** vs disque, pas seulement la ligne ajoutee :

| Axe | Verifie |
|-----|---------|
| Disque (`git ls-tree origin/main GenAI/Texte/*.ipynb`) | **21** ipynb |
| Citations README (post-edit) | **21** ipynb (`grep -oE` unique) |
| Parite | **21 = 21** drift-0 |
| Claim prose de compte | aucun (`grep '[0-9]+ (notebook|carnet|guide)s?'` = vide) |
| Marker `pedagogical_count` | **non touche** (artefact genere, regen par `catalog-drift.yml` CI / cron quotidien — catalog-pr-hygiene HARD 1) |

Les trois (disque / citations README / prose) s'alignent. Le marker genere sera regenere par l'automatisation a la PR.

## Anti-regression & validation

- `git diff --stat` : **1 fichier, +13 / -0** (additif pur, markdown-only).
- **0 notebook code touche** : README-only → **0 re-execution** (exception C.2 ; aucun output/execution_count affecte).
- **Pas un twin** : `twin_pairs.d/` ne couvre pas GenAI/Texte → pas de rebaseline requis.
- Catalogue : marker genere laisse byte-identique (CI regen) → conforme catalog-pr-hygiene HARD 1.

## Variation

MED/docs. prev MED/notebook-python (#10277 SL-12 interpretation cell). G-VAR-3 ✓ : genre rotate (docs vs notebook-python). Le litmus LIGHT (« generable en scannant l'instance suivante ? ») = **non** : cette PR exigeait (a) detecter le drift 21-vs-20, (b) lire le contenu du notebook firsthand pour ecrire une description fidele du fil rouge QLoRA + format balise, (c) rediger une prose pedagogique Tier 6 (LoRA vs full fine-tuning, oubli catastrophistique, VRAM), (d) audit fichier-entier certifiant drift-0 — pas un +1-row mecanique. G-VAR-1 ✓ : MED plat principal (drift structurel reel corrige).

See #3975 (feuilles README GenAI — contribution partielle, l'epic reste ouverte).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
