### PR TITLE
fix(translation,#10298): check_translation_parity strict_fr FP on native-English source cells

### DIFF
--- a/scripts/translation/check_translation_parity.py
+++ b/scripts/translation/check_translation_parity.py
@@ -330,6 +330,11 @@ def check_invariants(
 
         # Invariant 3 : FR_CONTAM — markdown cell text identical to source FR.
         # Advisory by default; promoted to blocking under --strict-fr.
+        # Exception (#10298 Option A): when the SOURCE cell is itself native
+        # English, trd==src is a legitimate same-language pass-through (the
+        # cell needed no translation), not French contamination. Without this,
+        # deep_research notebooks whose FR source was copy-pasted from an
+        # English paper are false-flagged under --strict-fr.
         if (
             src.cell_type == "markdown"
             and trd.cell_type == "markdown"
@@ -338,6 +343,7 @@ def check_invariants(
             if (
                 _normalize(src.source) == _normalize(trd.source)
                 and len(_normalize(src.source)) >= FR_CONTAM_MIN_LEN
+                and not _is_native_english(src.source)
             ):
                 anomalies.append(
                     Anomaly(
@@ -358,6 +364,7 @@ def check_invariants(
             if (
                 _normalize(src.source) == _normalize(trd.source)
                 and len(_normalize(src.source)) >= FR_CONTAM_MIN_LEN
+                and not _is_native_english(src.source)
             ):
                 anomalies.append(
                     Anomaly(
@@ -378,6 +385,49 @@ def _normalize(text: str) -> str:
     """Meme garde que check_translation_sync.normalize — anti faux-drift cosmétique."""
     lines = [line.rstrip() for line in text.splitlines()]
     return "\n".join(lines).strip("\n")
+
+
+# Caractères signalant du prose français (accents, cédille, ligatures) par
+# opposition à de l'anglais ASCII. Utilisé par ``_is_native_english`` (#10298).
+_FRENCH_DIACRITIC_CHARS = set(
+    "àâäçéèêëîïôöùûüÿœæÀÂÄÇÉÈÊËÎÏÔÖÙÛÜŸŒÆñÑ"
+)
+
+# Longueur minimale (post-normalisation) pour qu'une cellule soit candidate au
+# whitelist ``_is_native_english``. Les cellules courtes (« ## Introduction »)
+# sont ambiguës : un header français sans diacritiques ne doit pas être
+# silencieusement whitelisté. Les cas visés (#10298) sont du prose de recherche
+# substantielle (600-800 chars).
+_NATIVE_EN_MIN_LEN = 40
+
+
+def _is_native_english(source: str) -> bool:
+    """Heuristique : la source markdown est-elle déjà en anglais ?
+
+    Une cellule traduite dont la **source** (FR) est elle-même en anglais, et
+    dont le rendu égal la source, n'est **pas** une contamination française —
+    c'est un pass-through légitime (la cellule n'avait rien à traduire). Ceci
+    attrape les notebooks deep_research dont la source FR a été copiée d'un
+    papier de recherche anglophone (#10298).
+
+    Heuristique (#10298 Option A) : **>80 % de caractères ASCII imprimables** +
+    **<5 % de diacritiques français**, sur une cellule assez longue (≥ 40 chars
+    normalisés) pour que le ratio soit significatif. Les cellules courtes
+    retombent dans le chemin FR_CONTAM normal (un header ambigu ne se whiteliste
+    pas silencieusement).
+    """
+    norm = _normalize(source)
+    if len(norm) < _NATIVE_EN_MIN_LEN:
+        return False
+    non_ws = [c for c in norm if not c.isspace()]
+    if not non_ws:
+        return False
+    ascii_printable = sum(1 for c in non_ws if 0x20 <= ord(c) <= 0x7E)
+    alpha = sum(1 for c in non_ws if c.isalpha())
+    diacritics = sum(1 for c in non_ws if c in _FRENCH_DIACRITIC_CHARS)
+    ascii_ratio = ascii_printable / len(non_ws)
+    diacritic_ratio = (diacritics / alpha) if alpha else 0.0
+    return ascii_ratio > 0.80 and diacritic_ratio < 0.05
 
 
 def _sha(text: str) -> str:

--- a/scripts/translation/tests/test_check_translation_parity.py
+++ b/scripts/translation/tests/test_check_translation_parity.py
@@ -264,6 +264,71 @@ def test_fr_contam_strict_blocks(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# FR_CONTAM native-English exception (#10298 Option A)
+# ---------------------------------------------------------------------------
+# A markdown cell whose SOURCE (FR) is itself English, and whose rendered text
+# equals the source, is NOT contamination -- it is a legitimate same-language
+# pass-through (the cell needed no translation). This catches deep_research
+# notebooks whose FR source was copy-pasted from an English research paper.
+
+_NATIVE_EN_PROSE = (
+    "## Research Findings\n\n"
+    "Based on the grid search, the optimal lookback window for the momentum "
+    "strategy balances signal stability against responsiveness. The VIX "
+    "threshold reduces drawdown at the cost of forgone upside."
+)
+
+
+def test_is_native_english_detects_english_prose():
+    """Long English prose with no French diacritics is native English."""
+    assert p._is_native_english(_NATIVE_EN_PROSE) is True
+
+
+def test_is_native_english_rejects_french_prose():
+    """Genuine French prose (with diacritics) is not native English."""
+    french = (
+        "## Résultats de recherche\n\n"
+        "D'après la recherche par grille, la fenêtre optimale pour la stratégie "
+        "équilibrre la stabilité du signal et la réactivité. Le seuil VIX réduit "
+        "le drawdown au coût d'un rendement sacrifié."
+    )
+    assert p._is_native_english(french) is False
+
+
+def test_is_native_english_rejects_short_ambiguous_cell():
+    """A short header like '## Introduction' is too ambiguous to whitelist
+    silently -- it stays in the normal FR_CONTAM path (could be French)."""
+    assert p._is_native_english("## Introduction") is False
+
+
+def test_fr_contam_native_english_not_flagged_strict(tmp_path):
+    """Under strict_fr, a markdown cell identical to its source where the
+    source is native English must NOT be flagged FR_CONTAM (#10298)."""
+    src_cells = [_md_cell("c1", _NATIVE_EN_PROSE)]
+    trd_cells = [_md_cell("c1", _NATIVE_EN_PROSE)]  # trd == src (same-language pass-through)
+    src, trd = _write_pair(tmp_path, "NativeEn-01", src_cells, trd_cells)
+    src_records, _ = p.load_cells(src)
+    trd_records, _ = p.load_cells(trd)
+    anomalies = p.check_invariants(src_records, trd_records, strict_fr=True)
+    fr_contam = [a for a in anomalies if a.verdict == "FR_CONTAM"]
+    assert fr_contam == [], (
+        f"native-English same-language cell must not be FR_CONTAM : {fr_contam}"
+    )
+
+
+def test_fr_contam_native_english_not_flagged_advisory(tmp_path):
+    """Same exception holds in advisory (default) mode."""
+    src_cells = [_md_cell("c1", _NATIVE_EN_PROSE)]
+    trd_cells = [_md_cell("c1", _NATIVE_EN_PROSE)]
+    src, trd = _write_pair(tmp_path, "NativeEn-01b", src_cells, trd_cells)
+    src_records, _ = p.load_cells(src)
+    trd_records, _ = p.load_cells(trd)
+    anomalies = p.check_invariants(src_records, trd_records)  # default strict_fr=False
+    fr_contam = [a for a in anomalies if a.verdict == "FR_CONTAM"]
+    assert fr_contam == []
+
+
+# ---------------------------------------------------------------------------
 # Legitimate case (corollaire D2) — FR text inside a CODE cell is OK
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA — prev: MED/notebook-python #10300

# fix(translation,#10298): check_translation_parity strict_fr FP on native-English source cells

## Quoi

`scripts/translation/check_translation_parity.py` flaguait en **FR_CONTAM** (sous `--strict-fr`) les cellules markdown dont la **source FR est elle-même en anglais**. Cas réel : `deep_research_optimization.ipynb` (partner-course) contient 2 cellules copiées verbatim d'un papier de recherche anglophone (« Objective », « Strategy Overview », ETFs). Le moteur de rendu applique `text_en` (identique au FR car déjà en anglais) → `trd == src` → le checker strict_fr conclut « contamination française » alors qu'aucun français n'a fui (la source était anglaise).

**FP firsthand** (ce cycle, diagnostic de la livraison #10039) : 2 anomalies `FR_CONTAM` sur `deep_research_optimization_en` (`66fac460` src_len=819, `9ac7cfa8` src_len=605), bloquant `test_full_repo_state_passes_parity`.

## Fix — Option A (heuristique native-English whitelist)

Nouvelle fonction `_is_native_english(source)` (issue #10298 Option A) : whiteliste une cellule source dont le prose est déjà en anglais — **>80 % ASCII imprimable + <5 % diacritiques français**, sur une cellule assez longue (≥ 40 chars normalisés) pour que le ratio soit significatif. Les cellules courtes (« ## Introduction ») restent dans le chemin FR_CONTAM normal (un header ambigu ne se whiteliste pas silencieusement).

La garde `and not _is_native_english(src.source)` est ajoutée aux **deux** chemins FR_CONTAM (strict-blocking ligne 343 + advisory ligne 367).

## Preuve firsthand (post-fix)

```
render deep_research_optimization -> /tmp/dr_test/deep_research_optimization_en.ipynb (13 cells)
_is_native_english('66fac460') = True   (len 819, English research prose)
_is_native_english('9ac7cfa8') = True   (len 605)
check_invariants(strict_fr=True) -> NONE  (was 2 FR_CONTAM, FP FIXED)
```

**Negative control** (pas d'over-whitelist) : une cellule française inchangée (« ## Introduction aux réseaux de neurones et à leur apprentissage supervisé... ») reste flaguée FR_CONTAM (`_is_native_english = False`). Le fix n'aveugle pas le détecteur pour le vrai français.

## Validation

- `python -m pytest scripts/translation/tests/ -q` → **249 passed** (244 + 5 nouveaux tests), **0 failed**, **0 régression**.
- 5 nouveaux tests `test_check_translation_parity.py` :
  1. `test_is_native_english_detects_english_prose` — prose anglais longue → True
  2. `test_is_native_english_rejects_french_prose` — prose français avec diacritiques → False
  3. `test_is_native_english_rejects_short_ambiguous_cell` — « ## Introduction » → False (ambigu, reste chemin normal)
  4. `test_fr_contam_native_english_not_flagged_strict` — exception en mode strict
  5. `test_fr_contam_native_english_not_flagged_advisory` — exception en mode advisory
- Les 20 tests existants (FR_CONTAM français, CODE_DRIFT, STRUCTURE_DRIFT, OUTPUT_FABRICATED) inchangés.

## Anti-regression & scope

- `git diff --stat` : **2 fichiers** (`check_translation_parity.py` +50, `test_check_translation_parity.py` +71), additif pur.
- **0 notebook touché** : scripts-only → **0 re-execution** (exception C.2), **0** cellule de sortie affectée.
- **Pas un twin** : `twin_pairs.d/` ne couvre pas les scripts de translation → pas de rebaseline.
- Ne touche **pas** `*_<lang>.ipynb` → **translation-guard.yml ne s'applique pas** (ce grain est le fix du checker, pas un rendu).
- Le checker reste **strict sur le vrai français** (negative control prouvé) : seules les cellules source native-anglaises sont whitelistées.

## Variation

MED/tooling. prev MED/notebook-python (#10300 render _en). G-VAR-3 ✓ : genre rotate (tooling vs notebook-python). Le litmus LIGHT (« générable en scannant l'instance suivante ? ») = **non** : ce fix exigeait (a) diagnostiquer le FP firsthand (distinction « trd==src par fuite FR » vs « trd==src car source déjà anglaise »), (b) concevoir une heuristique qui whiteliste l'anglais sans aveugler le français (le piège : « pas de diacritiques » whitelistait aussi « ## Nettoyage »), (c) la garde longueur-min pour les cellules ambiguës, (d) negative control prouvant pas d'over-whitelist — pas un +regex mécanique.

Closes #10298 (acceptance tenue : pytest vert, cellules by-design-anglaises acceptées, fix référencé). See #10038 (EPIC i18n), #10039 (le render qui a exposé le FP).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
