### PR TITLE
fix(lean,#6724): re-sign p5_large_n_jumpN + hashlife_correctN to consume jumpCaptured (non-tautological)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1141,6 +1141,38 @@ theorem boxAssezGrandN_block_8 : BoxAssezGrandN block 8 := by native_decide
     (propositional form). -/
 theorem boxAssezGrandN_glider_8 : BoxAssezGrandN glider 8 := by native_decide
 
+/-- **Confinement authentique du jump** (re-signed, inlined from
+    `Conway.Life.JumpCapture` to avoid the A↔B import cycle that exists because
+    `JumpCapture.lean` imports `HashlifeCorrectness`). Byte-identical term to
+    `Conway.Life.JumpCapture.jumpCaptured`; `private` prevents name-resolution
+    ambiguity in the downstream module. -/
+private def jumpCaptured (c : MacroCell) : Bool :=
+  (evolve (2 ^ c.level) ((padCenter2 c).toGrid (0, 0))).all fun p =>
+    decide ((2 ^ c.level : Int) ≤ p.1) &&
+    decide (p.1 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int)) &&
+    decide ((2 ^ c.level : Int) ≤ p.2) &&
+    decide (p.2 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int))
+
+/-- Dépliage propositionnel de `jumpCaptured` (inlined). -/
+private theorem jumpCaptured_iff (c : MacroCell) :
+    jumpCaptured c = true ↔
+      ∀ p ∈ evolve (2 ^ c.level) ((padCenter2 c).toGrid (0, 0)),
+        (2 ^ c.level : Int) ≤ p.1 ∧
+          p.1 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int) ∧
+          (2 ^ c.level : Int) ≤ p.2 ∧
+          p.2 < (2 ^ c.level : Int) + ((2 ^ (c.level + 1) : Nat) : Int) := by
+  unfold jumpCaptured
+  rw [List.all_eq_true]
+  constructor
+  · intro h p hp
+    have hb := h p hp
+    simp only [Bool.and_eq_true, decide_eq_true_eq] at hb
+    tauto
+  · intro h p hp
+    have hb := h p hp
+    simp only [Bool.and_eq_true, decide_eq_true_eq]
+    tauto
+
 /-- **P5.2 genuine large-`n` jump (N2, P4-gated) — the sole remaining open
     target of the P5 layer.** When `n ≥ jumpSize lvl` (the MacroCell level)
     on the n-aware frame, `evolveHashlifeFast` makes one Hashlife jump of
@@ -1152,39 +1184,71 @@ theorem boxAssezGrandN_glider_8 : BoxAssezGrandN glider 8 := by native_decide
     the real P5.2 target — **open named sorry, P4-gated** (`p4_succ_membership`,
     ai-01 turf), NOT closed by vacuity.
 
+    **Re-signed (c.1035, finding #6724 — voie (a)).** The hypothesis was
+    `BoxAssezGrandN g n`, which is **tautological** (proved by
+    `box_assez_grandN_trivial` in `JumpCapture.lean`) — so the old
+    `p5_large_n_jumpN_iff_unconditional` showed the original statement carried
+    zero information. Re-signed to consume `jumpCaptured
+    (gridToMacroCellWithOffset g).2 = true` (inlined above to avoid the import
+    cycle that would arise from `import Conway.Life.JumpCapture`, since
+    `JumpCapture.lean` itself imports `HashlifeCorrectness`). The new
+    hypothesis is **non-tautological** (witnessed by `jumpCaptured_block`,
+    `jumpCaptured_glider`, `jumpCaptured_not_trivial` in `JumpCapture.lean`),
+    so this restatement carries real geometric content. Body remains `sorry`
+    (P4-gated); `restrictGridTo_eq_self` lives in `JumpCapture.lean` (not
+    Foundation), tracked as a known constraint for the eventual sorry discharge.
+
     **Moved above `hashlife_correctN` (c.95)** so the latter can consume it: the
     N-frame statement is now *derived* from this jump plus the padding-free
     small-`n` fallback, instead of carrying an independent sorry of its own. -/
-theorem p5_large_n_jumpN (n : Nat) (g : Grid) (h : BoxAssezGrandN g n)
+theorem p5_large_n_jumpN (n : Nat) (g : Grid)
+    (hcap : jumpCaptured (gridToMacroCellWithOffset g).2 = true)
     (hbig : n ≥ jumpSize (gridToMacroCellWithOffset g).2.level) :
     evolveHashlifeFast n g = evolve n g := by
   sorry
 
 /-- **N2 restatement — the genuine large-`n` correctness statement (EPIC #3846,
-    gate W2).** Under the n-aware padding hypothesis `BoxAssezGrandN g n`
-    (satisfiable for *every* `n`, unlike `BoxAssezGrand g n` capped at `n ≤ 2`),
-    `evolveHashlifeFast n g` agrees with `evolve n g`.
+    gate W2).** Under the **geometric capture hypothesis** `jumpCaptured
+    (gridToMacroCellWithOffset g).2 = true` (i.e., the final generation of the
+    Hashlife jump on the MacroCell representation of `g` stays inside the
+    central window that P4 clips), `evolveHashlifeFast n g` agrees with
+    `evolve n g`.
 
-    Unlike the fixed-frame `hashlife_correct` (vacuously true at large `n`),
-    this statement is **non-vacuous** at `n ≥ 8` (witnessed by
-    `boxAssezGrandN_block_8` / `boxAssezGrandN_glider_8` above).
+    **Re-signed (c.1035, finding #6724).** The previous hypothesis
+    `BoxAssezGrandN g n` was **tautological** (`box_assez_grandN_trivial`,
+    `JumpCapture.lean`) — it held for *every* `(g, n)` and thus carried no
+    information. The new hypothesis `jumpCaptured (gridToMacroCellWithOffset
+    g).2 = true` is **non-tautological** (witnessed by `jumpCaptured_block`,
+    `jumpCaptured_glider`, `jumpCaptured_not_trivial` in `JumpCapture.lean`)
+    and makes this theorem genuinely informative.
 
     **Reduction (c.95, ai-01).** The theorem no longer carries a sorry of its
     own. Splitting on the jump guard discharges it entirely:
     - `n < jumpSize` : `p5_small_n_fallback`, which takes **no padding
       hypothesis whatsoever** — it holds on any frame, the n-aware one included;
-    - `n ≥ jumpSize` : `p5_large_n_jumpN`, the genuine P4-gated jump.
+    - `n ≥ jumpSize` : `p5_large_n_jumpN`, the genuine P4-gated jump, which
+      now also consumes `jumpCaptured` (see its doc above).
 
     This is a structural reduction, **not** a vacuity closure: the whole
     remaining content of the N-frame statement is now localized in the single
     named sorry `p5_large_n_jumpN`. Before this change the two carried
     independent sorries, and a reader could not tell whether `hashlife_correctN`
-    required work *beyond* the jump. It does not. -/
-theorem hashlife_correctN (n : Nat) (g : Grid) (h : BoxAssezGrandN g n) :
+    required work *beyond* the jump. It does not.
+
+    **Note (c.1035).** The non-vacuity witnesses
+    `boxAssezGrandN_block_8` / `boxAssezGrandN_glider_8` (L1138/L1142) are now
+    orphaned relative to this theorem, since the hypothesis they satisfied is
+    gone. They still typecheck standalone and are kept for traceability of
+    the c.95 / c.1035 evolution; their substantive role is superseded by
+    `jumpCaptured_block` / `jumpCaptured_glider` in `JumpCapture.lean`. The
+    `BoxAssezGrandN` predicate itself remains consumed by
+    `hashlife_correctN_le_two` (L1199), which keeps the witnesses honest. -/
+theorem hashlife_correctN (n : Nat) (g : Grid)
+    (hcap : jumpCaptured (gridToMacroCellWithOffset g).2 = true) :
     evolveHashlifeFast n g = evolve n g := by
   by_cases hsmall : n < jumpSize (gridToMacroCellWithOffset g).2.level
   · exact p5_small_n_fallback n g hsmall
-  · exact p5_large_n_jumpN n g h (Nat.not_lt.mp hsmall)
+  · exact p5_large_n_jumpN n g hcap (Nat.not_lt.mp hsmall)
 
 /-- **N3 small-`n` bridge (issue #3846, ai-01 greenlight msg-zx9es2).** On the
     small-`n` regime (`n ≤ 2`), the n-aware spec `BoxAssezGrandN g n` coincides


### PR DESCRIPTION
Grain: DEEP/lean -- lane myia-po-2026:CoursIA-2

Quoi: Re-sign p5_large_n_jumpN + hashlife_correctN to consume the non-tautological `jumpCaptured` predicate instead of the tautological `BoxAssezGrandN` (finding #6724). Inline the predicate as `private` declarations to avoid the A↔B import cycle that would arise from importing Conway.Life.JumpCapture.

Preuve: `lake build Conway.Life.HashlifeCorrectness` SUCCEEDS (8503 jobs, 336s). Single active sorry preserved at line 1208 (`p5_large_n_jumpN` body — unchanged count). No build cycle (cycle was present in the naive `import Conway.Life.JumpCapture` attempt; the inline breaks it by introducing zero new import edges). Verified via forensic agent: import DAG acyclic, all required symbols in scope via existing Foundation.lean imports (MacroCell, padCenter2, level_padCenter2, wf_padCenter2, evolve, Int, decide, List.all, jumpSize, gridToMacroCellWithOffset, evolveHashlifeFast). Inline is byte-identical to JumpCapture.lean:197-222 (proof bodies match JumpCapture.lean:205-222 line-for-line).

Perimetre:
- IN scope: Conway/Life/HashlifeCorrectness.lean only (76 insertions, 12 deletions, 1 file).
- IN scope: doc comments on p5_large_n_jumpN (L1144-1157) and hashlife_correctN (L1163-1182) refreshed to reflect new hypotheses + record c.95 → c.1035 evolution.
- IN scope: inlined `private def jumpCaptured` + `private theorem jumpCaptured_iff` (prevents name-resolution ambiguity with JumpCapture.lean which still exports its own public versions).
- OUT of scope: NOT closing #6724 (this is a sub-delivery within the epic — `See #6724`, not `Closes #6724`). The remaining sorry in p5_large_n_jumpN body is P4-gated (`p4_succ_membership`, ai-01 turf).
- OUT of scope: NOT creating `HashlifeCorrectness_en.lean` i18n sibling (pre-existing gap in the i18n rollout — `JumpCapture.lean` and `HashlifeCorrectness.lean` both lack `_en` siblings; this is a separate PR for the i18n backlog per code-style.md).
- OUT of scope: NOT removing the orphaned `boxAssezGrandN_block_8` / `boxAssezGrandN_glider_8` witnesses (kept for traceability of the c.95 evolution; BoxAssezGrandN predicate remains consumed by `hashlife_correctN_le_two:1199`).
- OUT of scope: NOT closing the `p5_large_n_jumpN` sorry itself — that requires P4-unlock (see "Known constraint" below).

## Context

Finding #6724 (c.8174, 2026-08-07, `p5_large_n_jumpN_iff_unconditional` in JumpCapture.lean):
the old hypothesis `BoxAssezGrandN g n` is a **tautology** (proved by
`box_assez_grandN_trivial`, also in JumpCapture.lean) — it holds for every
`(g, n)`. So the old `p5_large_n_jumpN (n : Nat) (g : Grid) (h : BoxAssezGrandN g n)
(hbig : n ≥ jumpSize ...)` was equivalent to the unconditional statement
`evolveHashlifeFast n g = evolve n g` under `n ≥ jumpSize ...`. The old
hypothesis carried zero geometric content.

This commit re-signs both `p5_large_n_jumpN` and `hashlife_correctN` to consume
the **non-tautological** `jumpCaptured (gridToMacroCellWithOffset g).2 = true`
predicate instead. The new predicate is witnessed true on the 2×2 block and
the glider, and **witnessed false on the width-7 line at level 3**
(`jumpCaptured_not_trivial` in JumpCapture.lean:255) — so it carries real
geometric information about whether the final generation of the Hashlife
jump stays inside the central window that P4 clips.

## Cycle break (and why the inline)

Naive `import Conway.Life.JumpCapture` in HashlifeCorrectness.lean creates an
A↔B cycle: JumpCapture.lean:56 already does `import Conway.Life.HashlifeCorrectness`
(verified dead — grep returns 0 references to any `HashlifeCorrectness.X`
symbol in that file; the import is unused leftover from a previous iteration).
Lake rejects the cycle (`error: build cycle detected`) before even reaching
the Lean type-check.

The inline introduces **zero new import edges**: it relies entirely on
symbols already in scope via `Conway.Life.HashlifeCorrectness.Foundation`.
The `private` keyword prevents name-resolution ambiguity with the public
`jumpCaptured` in JumpCapture.lean, which continues to export its own
version (alongside `jumpCaptured_block`, `jumpCaptured_glider`,
`jumpCaptured_not_trivial`, `hashlifeJump_correct_of_captured`).

## Known constraint for future sorry discharge

`restrictGridTo_eq_self` lives in **JumpCapture.lean:174** (not
Foundation.lean). The eventual P4-unlock that discharges the `p5_large_n_jumpN`
sorry body will need to either:
1. Inline `restrictGridTo_eq_self` (and its dependencies) as well, or
2. Restructure `hashlifeJump_correct_of_captured` upstream to expose the
   lemma through a module that doesn't cycle back into HashlifeCorrectness.

This is tracked as a known design constraint for the P4-unlock work, not
a blocker for this re-signature (the sorry body stays as-is).

## Verification

```
⚠ [8503/8503] Built Conway.Life.HashlifeCorrectness (336s)
warning: Conway/Life/HashlifeCorrectness.lean:1204:8: declaration uses `sorry`
Build completed successfully (8503 jobs).
```

Sorry count: 1 active body in `HashlifeCorrectness.lean:1208`
(`p5_large_n_jumpN`, unchanged from baseline). `JumpCapture.lean`: 0
active sorries. Mention counts went up by 2 (35 vs 33) — both are in
the expanded docstrings documenting the c.95 → c.1035 evolution.

See #6724, #9568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
