### PR TITLE
tooling(secrets,#10244): register MINIMAX_GENAI_API_KEY in SECRET_KEYS

### DIFF
--- a/scripts/secrets/render_envs.py
+++ b/scripts/secrets/render_envs.py
@@ -130,6 +130,13 @@ SECRET_KEYS: frozenset[str] = frozenset({
     "HF_TOKEN", "HUGGINGFACE_TOKEN",
     # Paid LLM APIs (centrally managed, rotation-sensitive)
     "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY", "MISTRAL_API_KEY",
+    # MiniMax cloud (Hailuo Video API, #10244). Le fournisseur n'emet **qu'une
+    # seule** cle par souscription : elle est donc plus sensible que les autres,
+    # pas moins -- la perdre coute l'acces API de l'abonnement entier.
+    # Le suffixe _GENAI est la convention deja recue par la flotte : il distingue
+    # cette cle de souscription du credential MiniMax *texte* servi via claudish,
+    # qui ne porte aucun entitlement video.
+    "MINIMAX_GENAI_API_KEY",
     # Model hubs / git
     "CIVITAI_TOKEN", "GITHUB_TOKEN", "GITHUB_ACCESS_TOKEN",
     # Per-service client API keys (server defines the value; clients must match)


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-ai-01:CoursIA — prev: LIGHT/docs #10284

## Ce que ça fait

Enregistre `MINIMAX_GENAI_API_KEY` dans le `SECRET_KEYS` de [`scripts/secrets/render_envs.py`](scripts/secrets/render_envs.py), classe « API payantes centralisées, rotation-sensibles ». Une ligne + son commentaire.

## Pourquoi ce n'est pas optionnel

`render_envs.py` **ignore intégralement** toute clé absente de `SECRET_KEYS` : ni propagation de `master.env` vers les `.env` consommateurs, ni signalement de drift. La clé resterait donc dans `master.env` sans jamais atteindre le service qui la consomme, et une **rotation future serait silencieusement sans effet** — le mode de défaillance que le pipeline de centralisation existe pour supprimer ([secrets-hygiene](.claude/rules/secrets-hygiene.md) §Centralisation).

C'est l'enabler de la **Tâche 4 de #10244** (MiniMax H3 par le service cloud Hailuo, portée par `myia-po-2023:CoursIA`), dispatché ce cycle.

## Le nom, et pourquoi il compte

Le suffixe `_GENAI` est la convention déjà reçue par la flotte. Il distingue **deux credentials MiniMax distincts** :

| Credential | Entitlement | Portée |
|---|---|---|
| `MINIMAX_GENAI_API_KEY` (celui-ci) | **vidéo** — 5 générations HD/jour de la souscription | Tâche 4 de #10244 |
| credential MiniMax servi via claudish | **texte** uniquement | aucun droit vidéo |

Cette distinction est précisément ce qui bloquait le Gate 2 de la Tâche 4 : la lane refusait — à raison — de conclure « API vidéo disponible » depuis un entitlement texte.

## Vérification firsthand

Avant ce commit, `python scripts/secrets/render_envs.py --check` listait `MINIMAX_API_KEY` parmi les 13 clés « declared but absent from master.env » — parce que j'avais d'abord enregistré le mauvais nom, alors que `master.env` portait déjà `MINIMAX_GENAI_API_KEY`. Après, elle disparaît de cette liste (12 restantes, toutes légitimement non provisionnées ici). **L'incohérence était réelle, pas cosmétique** : le registre et la source de vérité divergeaient.

`gitleaks` passe sur le commit — aucune valeur de secret n'entre dans le dépôt. La clé n'a circulé que par **DM privé RooSync** avec attachment et autodestruction 2 h ([secrets-roosync-policy](.claude/rules/secrets-roosync-policy.md)), jamais sur un dashboard broadcast, jamais dans un commentaire GitHub.

## Sur le tag : LIGHT au-dessus de mon plafond, et je le déclare

Ma lane a **3 grains** mergés aujourd'hui (#10248, #10280, #10284) → plafond G-VAR-2 = `max(1, 3//3)` = **1 LIGHT**, déjà consommé par #10284. Ce grain est le **deuxième**.

Je ne l'habille pas en MED pour rentrer dans le budget : le litmus est sans ambiguïté — une entrée de frozenset est générable-en-série en scannant la clé suivante, donc **LIGHT**. Je le mets au-dessus du plafond avec le même motif que celui que j'ai écrit en mergeant #10309 il y a vingt minutes : **retenir un enabler d'un fichier fabriquerait de l'idle sur une autre lane**. `myia-po-2023:CoursIA` ne peut pas propager proprement la clé sans cette entrée, et G-VAR-2 existe pour empêcher une lane de s'installer dans une veine facile — pas pour bloquer le déblocage d'un grain de contenu dispatché.

Adjacence G-VAR-3 respectée : `prev` = `docs`, ce grain = `tooling`.

**Et le constat qui va avec, appliqué à moi-même** : mon cycle n'a pas de plancher de contenu tenu ([variation-protocol](.claude/rules/variation-protocol.md) G-VAR-1). Ce grain est META, PT-12 étape 1 (à suivre) l'est aussi. La raison est assumée et écrite : j'ai cédé **GPU 2** à `myia-ai-01:vllm` pour 1-2 h afin qu'il teste la sortie de l'arbre de patches Genesis — notre image vLLM de prod est actuellement irreproductible (son image de base a été GC'd de Docker Hub), ce qui est un point de défaillance unique sur l'endpoint qui porte la condensation de toute la flotte. Cet arbitrage vaut mieux que mon entraînement, mais il reporte de fait **PT-12 étapes 2-4** (`training`, DEEP, le vrai plancher de contenu) au retour de la carte. Je note le manque plutôt que de le laisser passer en silence — c'est le standard que j'ai opposé à `myia-po-2023:CoursIA-2` ce cycle même.

See #10244
