### PR TITLE
tooling(ict,#10289): garde-fous cross-echelle des traces SAE (9B/W64K <-> 2B/W32K)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/sae_traces.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/sae_traces.py
@@ -42,6 +42,11 @@ __all__ = [
     "acts_topk_panels",
     "binarize_quantile",
     "states_from_panel",
+    # Garde-fous cross-echelle (9B/W64K <-> 2B/W32K)
+    "resolve_capture_layer",
+    "check_sae_model_match",
+    "assert_bf16_readout",
+    "trace_filename",
 ]
 
 
@@ -165,3 +170,117 @@ def states_from_panel(bits: np.ndarray) -> np.ndarray:
                          "(explosion d'etats vs support statistique)")
     weights = (1 << np.arange(F)).astype(np.int64)
     return bits.astype(np.int64) @ weights
+
+
+# --------------------------------------------------------------------------- #
+# Garde-fous cross-echelle (9B/W64K <-> 2B/W32K) — #5105 / #7396
+#
+# Ces quatre fonctions sont volontairement pures (aucun torch, aucun reseau) :
+# elles decrivent le contrat d'une extraction SAE, donc elles doivent etre
+# testables sans GPU, et le script d'extraction les consomme au lieu de
+# reimplementer les memes verifications en ligne.
+# --------------------------------------------------------------------------- #
+def resolve_capture_layer(n_layers: int,
+                          layer: int | None = None,
+                          layer_frac: float | None = None) -> dict:
+    """Resout la couche de capture et rend sa **profondeur relative**.
+
+    Le piege que cette fonction existe pour fermer : ``--layer 16`` est
+    silencieusement comparable a lui-meme d'une echelle a l'autre alors qu'il
+    ne l'est pas. Sur ``Qwen3.5-9B-Base`` (32 couches) la couche 16 est le
+    mi-reseau ; sur ``Qwen3.5-2B-Base`` (24 couches) c'est **deux tiers** de la
+    profondeur. Un differentiel de features entre les deux melangerait alors
+    l'effet cherche et un simple artefact de profondeur, **sans jamais lever
+    d'erreur** — le mode de defaillance le plus couteux qui soit.
+
+    Passer ``layer_frac`` rend l'intention explicite et transposable :
+    ``0.5`` donne 16 sur le 9B (16/31) et 12 sur le 2B (12/23).
+
+    Exactement un des deux parametres doit etre fourni.
+    """
+    if (layer is None) == (layer_frac is None):
+        raise ValueError("fournir exactement un de layer / layer_frac "
+                         f"(recu layer={layer}, layer_frac={layer_frac})")
+    if n_layers is None or n_layers < 1:
+        raise ValueError(f"n_layers invalide : {n_layers!r} — la config du "
+                         "modele n'expose pas num_hidden_layers")
+    if layer_frac is not None:
+        if not 0.0 <= layer_frac <= 1.0:
+            raise ValueError(f"layer_frac={layer_frac} hors [0, 1]")
+        layer = int(round(layer_frac * (n_layers - 1)))
+    if not 0 <= layer < n_layers:
+        raise ValueError(
+            f"couche {layer} hors bornes : ce modele a {n_layers} couches "
+            f"(indices 0-{n_layers - 1}). Le defaut 16 vise le mi-reseau d'un "
+            "modele 32 couches ; pour une autre echelle, preferer "
+            "--layer-frac 0.5.")
+    return {"layer": int(layer),
+            "n_layers": int(n_layers),
+            "layer_frac": round(layer / (n_layers - 1), 4) if n_layers > 1 else 0.0}
+
+
+def check_sae_model_match(sae_d_model: int, model_d_model: int,
+                          sae_repo: str = "", model: str = "") -> None:
+    """Verifie que le SAE encode bien le residual stream de CE modele.
+
+    Remplace un ``assert`` nu : un ``assert`` disparait sous ``python -O`` et
+    son message n'indiquait pas quoi corriger. La confusion realiste, une fois
+    deux echelles en jeu, est de garder le SAE 9B/W64K (d_model 4096) en
+    changeant le modele pour le 2B (d_model 2048) — le produit ``h @ W_enc.T``
+    echouerait alors sur une erreur de forme torch illisible.
+    """
+    if int(sae_d_model) != int(model_d_model):
+        raise ValueError(
+            f"d_model incompatible : le SAE {sae_repo or '(?)'} encode "
+            f"{sae_d_model} dimensions, le modele {model or '(?)'} en produit "
+            f"{model_d_model}. Apparier les familles : "
+            "Qwen3.5-9B-Base <-> SAE-Res-Qwen3.5-9B-Base-W64K-*, "
+            "Qwen3.5-2B(-Base) <-> SAE-Res-Qwen3.5-2B-Base-W32K-*.")
+
+
+def assert_bf16_readout(quantization_config: object | None,
+                        allow_quantized: bool = False) -> None:
+    """Refuse une lecture SAE sur un modele charge quantifie.
+
+    Les SAE Qwen-Scope ont ete entraines sur le residual stream **pleine
+    precision** du modele *Base*. Lire les features d'un modele post-entraine
+    charge en 4-bit et les comparer a une base bf16 produirait un differentiel
+    indiscernable de l'erreur d'arrondi de la quantification : le resultat
+    aurait l'air d'un effet de post-training alors qu'il mesurerait NF4.
+
+    Le regime correct pour l'arc PT-12 est dissocie : QLoRA (base gelee 4-bit,
+    adapters bf16) pour la **boucle d'entrainement**, puis rechargement en
+    **bf16** — base + adapters fusionnes — pour la **lecture SAE**.
+
+    ``allow_quantized=True`` reste possible pour une exploration assumee, mais
+    doit etre demande explicitement et ecrit dans les metadonnees de la trace.
+    """
+    if quantization_config is not None and not allow_quantized:
+        raise ValueError(
+            "modele charge quantifie (quantization_config present) : la "
+            "lecture SAE exige bf16. Les SAE sont entraines sur le residual "
+            "stream pleine precision, donc un differentiel mesure en 4-bit "
+            "melangerait l'effet du post-training et l'erreur d'arrondi NF4. "
+            "Recharger base+adapters fusionnes en bf16, ou passer "
+            "--allow-quantized-readout pour une exploration assumee.")
+
+
+def trace_filename(variant: str, layer: int, *, model: str = "",
+                   default_model: str = "", n_layers: int | None = None,
+                   n_clamp: int = 0, prefix: str = "ict21_sae") -> str:
+    """Nom de fichier de trace **discriminant par echelle**.
+
+    Defaut historique conserve a l'octet pour le modele de reference (les
+    traces ``ict21_sae_layer16_{trained,control}.npz`` deja committees et les
+    notebooks ICT-21/ICT-24 qui les chargent par chemin explicite continuent de
+    fonctionner). Des que le modele differe, un slug d'echelle est insere :
+    sans lui, un run 2B et un run 9B a la meme couche 16 ecrivent **le meme
+    nom** et le second efface le premier en silence — perte de donnees, pas
+    seulement confusion.
+    """
+    clamp = f"_clamp{n_clamp}" if n_clamp else ""
+    if model and default_model and model != default_model:
+        slug = model.rstrip("/").split("/")[-1].lower().replace(".", "")
+        depth = f"layer{layer}of{n_layers}" if n_layers else f"layer{layer}"
+        return f"{prefix}_{slug}_{depth}_{variant}{clamp}.npz"
+    return f"{prefix}_layer{layer}_{variant}{clamp}.npz"

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/extract_sae_traces.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/extract_sae_traces.py
@@ -22,11 +22,21 @@ Hook de clamp (Gate 24 de #5635, phase 2 — NON exECUTE dans cette issue) :
 `--clamp-ids` force un sous-ensemble de features SAE a zero en soustrayant leur
 contribution decodeur du residual stream (necessite W_dec dans le checkpoint).
 
+Deux echelles (#5105 / #7396) : le couple de reference est 9B-Base x W64K, mais
+l'arc post-training PT-12 lit aussi Qwen3.5-2B(-Base) x W32K. Les deux profondeurs
+different (32 vs 24 couches), donc `--layer 16` ne designe PAS la meme position
+relative : passer `--layer-frac 0.5` pour une intention transposable. Les gardes
+correspondantes vivent dans `ict/sae_traces.py` (pures, testables sans GPU) et
+sont appliquees ici AVANT tout chargement de poids.
+
 Usage (GPU 2 d'ai-01 STRICT — vLLM tient GPU 0-1) :
     CUDA_VISIBLE_DEVICES=2 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
       python extract_sae_traces.py --stage smoke
     ... --stage full --variant trained
     ... --stage full --variant control
+    # echelle 2B, mi-reseau, SAE apparie :
+    ... --model Qwen/Qwen3.5-2B-Base --layer-frac 0.5 \
+        --sae-repo Qwen/SAE-Res-Qwen3.5-2B-Base-W32K-L0_50 --stage full
 """
 from __future__ import annotations
 
@@ -39,6 +49,17 @@ from pathlib import Path
 
 import numpy as np
 import torch
+
+# Le package ``ict/`` reste numpy-only : l'importer ici ne fait PAS entrer torch
+# dans la bibliotheque — c'est ce script qui confine torch (cf docstring). Les
+# garde-fous cross-echelle vivent la-bas precisement pour etre testables sans GPU.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from ict.sae_traces import (  # noqa: E402  (necessairement apres sys.path)
+    assert_bf16_readout,
+    check_sae_model_match,
+    resolve_capture_layer,
+    trace_filename,
+)
 
 # ---------------------------------------------------------------------------
 # Jeux de prompts contrastifs (>=5 jeux = multi-graines du Gate 12, cf #5102).
@@ -278,6 +299,7 @@ PROMPT_SETS: dict[str, list[str]] = {
 
 DEFAULT_MODEL = "Qwen/Qwen3.5-9B-Base"
 DEFAULT_SAE_REPO = "Qwen/SAE-Res-Qwen3.5-9B-Base-W64K-L0_50"
+DEFAULT_LAYER = 16
 
 
 def parse_args() -> argparse.Namespace:
@@ -285,8 +307,20 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--stage", choices=["smoke", "full"], default="smoke")
     p.add_argument("--variant", choices=["trained", "control"], default="trained",
                    help="control = permutation seedee des lignes d'input embeddings")
-    p.add_argument("--layer", type=int, default=16,
-                   help="couche du resid_post capture (defaut 16 = mi-reseau, 0-31)")
+    # --layer et --layer-frac s'excluent : passer les deux serait une intention
+    # ambigue, et la resolution vit dans ict.sae_traces.resolve_capture_layer
+    # (qui refuse aussi le cas, pour l'appel bibliotheque hors CLI).
+    depth = p.add_mutually_exclusive_group()
+    depth.add_argument("--layer", type=int, default=None,
+                      help=f"index absolu du resid_post capture (defaut "
+                           f"{DEFAULT_LAYER}, valide pour un modele 32 couches). "
+                           "Un index n'est PAS comparable d'une echelle a "
+                           "l'autre : preferer --layer-frac pour un modele "
+                           "d'une autre profondeur.")
+    depth.add_argument("--layer-frac", type=float, default=None,
+                      help="profondeur RELATIVE dans [0, 1] (0.5 = mi-reseau). "
+                           "Transposable entre echelles : 0.5 donne 16 sur un "
+                           "32 couches, 12 sur un 24 couches.")
     p.add_argument("--model", default=DEFAULT_MODEL)
     p.add_argument("--sae-repo", default=DEFAULT_SAE_REPO)
     p.add_argument("--out-dir", default=str(Path(__file__).resolve().parent.parent / "traces"))
@@ -296,7 +330,27 @@ def parse_args() -> argparse.Namespace:
                         "(Gate 24 #5635, phase 2) — liste separee par des virgules")
     p.add_argument("--attn", default=None,
                    help="attn_implementation a forcer (ex: eager) si le defaut echoue")
+    p.add_argument("--allow-quantized-readout", action="store_true",
+                   help="autorise la lecture SAE d'un checkpoint quantifie. Par "
+                        "defaut refusee : les SAE sont entraines sur le residual "
+                        "stream pleine precision, donc un differentiel mesure en "
+                        "4-bit melangerait l'effet cherche et l'arrondi NF4.")
+    p.add_argument("--overwrite", action="store_true",
+                   help="autorise l'ecrasement d'une trace existante (refuse par defaut)")
     return p.parse_args()
+
+
+def _guard(fn, *a, **kw):
+    """Traduit une ``ValueError`` de garde-fou en sortie CLI actionnable.
+
+    Les garde-fous d':mod:`ict.sae_traces` levent des exceptions (testables,
+    reutilisables hors CLI) ; en ligne de commande, une trace Python nue est un
+    mauvais message d'erreur. Ce wrapper garde les deux usages.
+    """
+    try:
+        return fn(*a, **kw)
+    except ValueError as exc:
+        sys.exit(f"ERREUR: {exc}")
 
 
 def guard_single_gpu() -> torch.device:
@@ -421,13 +475,43 @@ def main() -> None:
 
     from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
-    print(f"[load] {args.model} (bf16, forward-only) ...")
+    print(f"[load] config {args.model} ...")
     cfg = AutoConfig.from_pretrained(args.model)
     text_cfg = getattr(cfg, "text_config", cfg)
     n_layers = getattr(text_cfg, "num_hidden_layers", None)
     d_model = getattr(text_cfg, "hidden_size", None)
     print(f"[model] model_type={cfg.model_type} n_layers={n_layers} d_model={d_model}")
 
+    # --- Gardes cross-echelle, AVANT tout chargement de poids -------------- #
+    # Toutes echouent sur la seule config (quelques Ko) : un mauvais couple
+    # couche/echelle, un checkpoint quantifie ou une trace deja presente sont
+    # detectes en secondes, pas apres 20 GiB de poids et une passe complete.
+    depth = _guard(resolve_capture_layer, n_layers, args.layer, args.layer_frac) \
+        if (args.layer is not None or args.layer_frac is not None) \
+        else _guard(resolve_capture_layer, n_layers, DEFAULT_LAYER, None)
+    layer = depth["layer"]
+    print(f"[depth] couche {layer}/{n_layers - 1} "
+          f"(profondeur relative {depth['layer_frac']:.3f})")
+
+    _guard(assert_bf16_readout,
+           getattr(cfg, "quantization_config", None),
+           args.allow_quantized_readout)
+
+    out_path: Path | None = None
+    if args.stage == "full":
+        out_dir = Path(args.out_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / trace_filename(
+            args.variant, layer, model=args.model, default_model=DEFAULT_MODEL,
+            n_layers=n_layers, n_clamp=len(clamp_ids))
+        if out_path.exists() and not args.overwrite:
+            sys.exit(f"ERREUR: {out_path} existe deja. Deux runs d'echelles "
+                     "differentes ne doivent jamais partager un nom : verifier "
+                     "que --model/--layer sont ceux voulus, puis --overwrite "
+                     "pour ecraser deliberement.")
+        print(f"[out] cible {out_path.name}")
+
+    print(f"[load] {args.model} (bf16, forward-only) ...")
     tokenizer = AutoTokenizer.from_pretrained(args.model)
     kwargs: dict = {"dtype": torch.bfloat16}
     if args.attn:
@@ -440,13 +524,15 @@ def main() -> None:
     if args.variant == "control":
         apply_control_permutation(model, args.seed)
 
-    sae = load_sae(args.sae_repo, args.layer, device)
-    assert sae["W_enc"].shape[1] == d_model, \
-        f"d_model SAE {sae['W_enc'].shape[1]} != modele {d_model}"
+    sae = load_sae(args.sae_repo, layer, device)
+    # Remplace un ``assert`` nu : il disparaissait sous ``python -O`` et son
+    # message ne disait pas quoi apparier.
+    _guard(check_sae_model_match, int(sae["W_enc"].shape[1]), int(d_model),
+           args.sae_repo, args.model)
 
     layers = find_decoder_layers(model, n_layers)
     capture = ResidCapture(sae=sae, clamp_ids=clamp_ids)
-    handle = layers[args.layer].register_forward_hook(capture)
+    handle = layers[layer].register_forward_hook(capture)
 
     sets = PROMPT_SETS
     if args.stage == "smoke":
@@ -495,13 +581,16 @@ def main() -> None:
     print(f"[sanity] vram pic={torch.cuda.max_memory_allocated() / 2**30:.1f} GiB")
 
     if args.stage == "full":
-        out_dir = Path(args.out_dir)
-        out_dir.mkdir(parents=True, exist_ok=True)
-        suffix = f"_clamp{len(clamp_ids)}" if clamp_ids else ""
-        out = out_dir / f"ict21_sae_layer{args.layer}_{args.variant}{suffix}.npz"
+        out = out_path                       # resolu et verifie avant le chargement
         meta = {
-            "model": args.model, "sae_repo": args.sae_repo, "layer": args.layer,
+            "model": args.model, "sae_repo": args.sae_repo, "layer": layer,
+            # Profondeur RELATIVE : c'est elle, pas l'index absolu, qui rend deux
+            # traces d'echelles differentes comparables (#5105 / #7396).
+            "n_layers": int(n_layers), "layer_frac": depth["layer_frac"],
+            # d_sae EST la largeur du SAE (65536 pour W64K, 32768 pour W32K) :
+            # pas de second champ synonyme, qui divergerait un jour.
             "k": 50, "d_sae": int(sae["W_enc"].shape[0]), "d_model": int(d_model),
+            "quantized_readout": bool(args.allow_quantized_readout),
             "variant": args.variant, "seed": args.seed, "clamp_ids": clamp_ids,
             "encode_convention": "pre = h @ W_enc.T + b_enc ; relu ; topk(50) "
                                  "(app.py officiel Qwen-Scope, pas de b_dec a l'encode)",

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_sae_cross_scale.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_sae_cross_scale.py
@@ -1,0 +1,191 @@
+"""Garde-fous cross-echelle des traces SAE — 9B/W64K <-> 2B/W32K (#5105 / #7396).
+
+Ces tests portent sur le *contrat* d'une extraction SAE, pas sur son execution :
+les quatre fonctions testees sont pures (numpy-only, ni torch ni reseau), ce qui
+est exactement ce qui les rend executables en CI sans GPU. Le script GPU
+`scripts/extract_sae_traces.py` les consomme au lieu de reimplementer les memes
+verifications en ligne.
+
+Les constantes d'echelle sont **mesurees**, pas supposees :
+    Qwen/Qwen3.5-9B-Base   -> 32 couches, d_model 4096, SAE W64K
+    Qwen/Qwen3.5-2B-Base   -> 24 couches, d_model 2048, SAE W32K
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from ict.sae_traces import (  # noqa: E402
+    assert_bf16_readout,
+    check_sae_model_match,
+    resolve_capture_layer,
+    trace_filename,
+)
+
+# Echelles reelles (config.json des depots HF officiels).
+N_LAYERS_9B, D_MODEL_9B, W_9B = 32, 4096, 65536
+N_LAYERS_2B, D_MODEL_2B, W_2B = 24, 2048, 32768
+
+MODEL_9B = "Qwen/Qwen3.5-9B-Base"
+MODEL_2B = "Qwen/Qwen3.5-2B-Base"
+SAE_9B = "Qwen/SAE-Res-Qwen3.5-9B-Base-W64K-L0_50"
+SAE_2B = "Qwen/SAE-Res-Qwen3.5-2B-Base-W32K-L0_50"
+
+
+# --------------------------------------------------------------------------- #
+# resolve_capture_layer
+# --------------------------------------------------------------------------- #
+def test_layer_absolu_conserve_et_annote():
+    """Un index absolu passe tel quel, mais ressort avec sa profondeur relative."""
+    got = resolve_capture_layer(N_LAYERS_9B, layer=16)
+    assert got["layer"] == 16
+    assert got["n_layers"] == 32
+    assert got["layer_frac"] == pytest.approx(16 / 31, abs=1e-4)
+
+
+def test_le_meme_index_designe_deux_profondeurs_differentes():
+    """Le piege que ces gardes existent pour rendre visible.
+
+    `--layer 16` est accepte sur les deux echelles et n'y a pas le meme sens :
+    mi-reseau sur le 9B, ~70 % de la profondeur sur le 2B. Sans la profondeur
+    relative dans les metadonnees, un differentiel entre ces deux traces
+    melangerait l'effet cherche et un artefact de profondeur — sans erreur.
+    """
+    frac_9b = resolve_capture_layer(N_LAYERS_9B, layer=16)["layer_frac"]
+    frac_2b = resolve_capture_layer(N_LAYERS_2B, layer=16)["layer_frac"]
+    assert frac_9b == pytest.approx(0.5161, abs=1e-3)
+    assert frac_2b == pytest.approx(0.6957, abs=1e-3)
+    assert abs(frac_2b - frac_9b) > 0.17, "l'ecart de profondeur doit rester visible"
+
+
+def test_layer_frac_transpose_l_intention_entre_echelles():
+    """0.5 = mi-reseau, quelle que soit la profondeur : 16 sur 32, 12 sur 24."""
+    assert resolve_capture_layer(N_LAYERS_9B, layer_frac=0.5)["layer"] == 16
+    assert resolve_capture_layer(N_LAYERS_2B, layer_frac=0.5)["layer"] == 12
+
+
+@pytest.mark.parametrize("frac,expected_9b", [(0.0, 0), (0.25, 8), (1.0, 31)])
+def test_layer_frac_bornes(frac, expected_9b):
+    assert resolve_capture_layer(N_LAYERS_9B, layer_frac=frac)["layer"] == expected_9b
+
+
+def test_exactement_un_parametre_requis():
+    with pytest.raises(ValueError, match="exactement un"):
+        resolve_capture_layer(N_LAYERS_9B)
+    with pytest.raises(ValueError, match="exactement un"):
+        resolve_capture_layer(N_LAYERS_9B, layer=16, layer_frac=0.5)
+
+
+def test_couche_hors_bornes_refusee_avec_la_profondeur_reelle():
+    """Le defaut 16 est valide sur 32 couches ; 28 ne l'est pas sur 24."""
+    with pytest.raises(ValueError, match=r"24 couches"):
+        resolve_capture_layer(N_LAYERS_2B, layer=28)
+    with pytest.raises(ValueError, match="hors bornes"):
+        resolve_capture_layer(N_LAYERS_2B, layer=N_LAYERS_2B)   # index == n_layers
+    with pytest.raises(ValueError, match="hors bornes"):
+        resolve_capture_layer(N_LAYERS_9B, layer=-1)
+
+
+def test_layer_frac_hors_intervalle_refuse():
+    with pytest.raises(ValueError, match=r"hors \[0, 1\]"):
+        resolve_capture_layer(N_LAYERS_9B, layer_frac=1.5)
+
+
+def test_n_layers_absent_de_la_config_refuse():
+    """`getattr(cfg, "num_hidden_layers", None)` peut rendre None : le dire."""
+    with pytest.raises(ValueError, match="num_hidden_layers"):
+        resolve_capture_layer(None, layer=16)
+
+
+# --------------------------------------------------------------------------- #
+# check_sae_model_match
+# --------------------------------------------------------------------------- #
+def test_appariements_corrects_passent():
+    check_sae_model_match(D_MODEL_9B, D_MODEL_9B, SAE_9B, MODEL_9B)
+    check_sae_model_match(D_MODEL_2B, D_MODEL_2B, SAE_2B, MODEL_2B)
+
+
+def test_sae_9b_sur_modele_2b_refuse_et_nomme_l_appariement():
+    """La confusion realiste : changer --model sans changer --sae-repo."""
+    with pytest.raises(ValueError) as exc:
+        check_sae_model_match(D_MODEL_9B, D_MODEL_2B, SAE_9B, MODEL_2B)
+    msg = str(exc.value)
+    assert "4096" in msg and "2048" in msg
+    assert "W32K" in msg, "le message doit nommer le SAE a utiliser a la place"
+
+
+def test_message_utilisable_sans_les_noms_de_depots():
+    """Appel bibliotheque sans repo/model : le message reste lisible."""
+    with pytest.raises(ValueError, match="d_model incompatible"):
+        check_sae_model_match(D_MODEL_2B, D_MODEL_9B)
+
+
+# --------------------------------------------------------------------------- #
+# assert_bf16_readout
+# --------------------------------------------------------------------------- #
+def test_readout_bf16_accepte():
+    assert_bf16_readout(None)
+
+
+def test_readout_sur_checkpoint_quantifie_refuse():
+    with pytest.raises(ValueError, match="bf16"):
+        assert_bf16_readout({"quant_method": "bitsandbytes", "bits": 4})
+
+
+def test_readout_quantifie_autorise_explicitement():
+    """Exploration assumee : possible, mais elle doit etre demandee."""
+    assert_bf16_readout({"quant_method": "awq"}, allow_quantized=True)
+
+
+def test_le_message_explique_le_regime_correct():
+    """QLoRA pour l'entrainement, bf16 fusionne pour la lecture."""
+    with pytest.raises(ValueError) as exc:
+        assert_bf16_readout({"bits": 4})
+    assert "NF4" in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
+# trace_filename — le defaut le plus couteux : la collision silencieuse
+# --------------------------------------------------------------------------- #
+def test_nom_historique_conserve_a_l_octet():
+    """Les traces committees et les notebooks ICT-21/24 les chargent par chemin."""
+    assert trace_filename("trained", 16, model=MODEL_9B, default_model=MODEL_9B,
+                          n_layers=N_LAYERS_9B) == "ict21_sae_layer16_trained.npz"
+    assert trace_filename("control", 16, model=MODEL_9B, default_model=MODEL_9B,
+                          n_layers=N_LAYERS_9B) == "ict21_sae_layer16_control.npz"
+
+
+def test_clamp_suffixe_conserve():
+    assert trace_filename("trained", 16, model=MODEL_9B, default_model=MODEL_9B,
+                          n_layers=N_LAYERS_9B, n_clamp=3) == \
+        "ict21_sae_layer16_trained_clamp3.npz"
+
+
+def test_deux_echelles_a_la_meme_couche_ne_collisionnent_pas():
+    """Le defaut le plus couteux du lot : un run ecrasant l'autre en silence.
+
+    Sans slug d'echelle, un run 2B et un run 9B a la couche 16 ecrivent le meme
+    nom de fichier — perte de donnees, pas seulement confusion.
+    """
+    name_9b = trace_filename("trained", 16, model=MODEL_9B,
+                             default_model=MODEL_9B, n_layers=N_LAYERS_9B)
+    name_2b = trace_filename("trained", 16, model=MODEL_2B,
+                             default_model=MODEL_9B, n_layers=N_LAYERS_2B)
+    assert name_9b != name_2b
+    assert "qwen35-2b-base" in name_2b
+    assert "layer16of24" in name_2b, "la profondeur totale doit rester lisible"
+
+
+def test_slug_insere_des_que_le_modele_differe_meme_sans_n_layers():
+    name = trace_filename("trained", 12, model=MODEL_2B, default_model=MODEL_9B)
+    assert name.startswith("ict21_sae_qwen35-2b-base_layer12_")
+
+
+def test_sans_modele_le_nom_reste_le_defaut_historique():
+    """Appel sans --model explicite : pas de slug parasite."""
+    assert trace_filename("trained", 16) == "ict21_sae_layer16_trained.npz"


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: LIGHT/tooling #10311

Étape 1 de l'arc **PT-12** (#10289) : rendre l'extraction SAE sûre à **deux échelles** avant d'y faire passer un post-training. Le pipeline `scripts/extract_sae_traces.py` a été écrit pour `Qwen3.5-9B-Base × W64K` ; le mandat y ajoute `Qwen3.5-2B(-Base) × W32K`, qui n'a **ni** la même profondeur **ni** le même `d_model`.

| | couches | `d_model` | SAE |
|---|---|---|---|
| `Qwen3.5-9B-Base` | 32 | 4096 | `SAE-Res-…-9B-Base-W64K-L0_50` |
| `Qwen3.5-2B-Base` | 24 | 2048 | `SAE-Res-…-2B-Base-W32K-L0_50` |

## Les cinq défauts — et ce qu'ils ont en commun

Aucun ne levait d'erreur. C'est ce qui les rend coûteux : un résultat faux ressemble exactement à un résultat.

**1. `--layer 16` est valide aux deux échelles et n'y désigne pas la même chose.** Mi-réseau sur le 9B (16/31 = 0,516), **deux tiers** sur le 2B (16/23 = 0,696). Un différentiel de features entre ces deux traces mélangerait l'effet cherché et un simple artefact de profondeur. → `resolve_capture_layer` + `--layer-frac` (transposable : `0.5` donne 16 sur 32 couches, 12 sur 24), et la profondeur **relative** écrite dans les métadonnées de la trace — c'est elle, pas l'index absolu, qui rend deux traces comparables.

**2. Collision de noms de fichier — le plus coûteux du lot.** Un run 2B et un run 9B à la couche 16 écrivaient `ict21_sae_layer16_trained.npz` **tous les deux** ; le second effaçait le premier en silence. C'est une perte de données, pas seulement une confusion. → `trace_filename` insère un slug d'échelle dès que le modèle diffère (`ict21_sae_qwen35-2b-base_layer16of24_trained.npz`), et le script **refuse d'écraser** une trace existante sans `--overwrite`.

**3. `assert` nu sur `d_model`.** Il disparaît sous `python -O` et son message ne disait pas quoi apparier — la confusion réaliste étant de changer `--model` sans changer `--sae-repo`, ce qui produisait une erreur de forme torch illisible. → `check_sae_model_match` nomme les couples corrects.

**4. Lecture SAE d'un checkpoint quantifié.** Les SAE Qwen-Scope sont entraînés sur le residual stream **pleine précision** du modèle *Base*. Lire un modèle post-entraîné chargé en 4-bit et le comparer à une base bf16 donnerait un différentiel indiscernable de l'arrondi NF4 : le résultat aurait l'air d'un effet de post-training alors qu'il mesurerait la quantification. → `assert_bf16_readout`, contournable seulement par `--allow-quantized-readout`, et le choix est tracé dans les métadonnées.

Le régime correct pour l'arc est donc **dissocié** : QLoRA (base gelée 4-bit + adapters bf16) pour la **boucle d'entraînement** — c'est la réponse à l'addendum du user sur les quants — puis rechargement **bf16** base+adapters fusionnés pour la **lecture SAE**. Les deux contraintes cohabitent au lieu de s'annuler.

**5. Les gardes s'appliquaient après le chargement des poids.** Désormais toutes tournent sur la seule `config` (quelques Ko) : un mauvais couple couche/échelle, un checkpoint quantifié ou une trace déjà présente échouent **en secondes**, pas après 20 GiB de poids et une passe complète.

## Où vit le code, et pourquoi là

Les quatre fonctions sont dans [`ict/sae_traces.py`](MyIA.AI.Notebooks/IIT/ICT-Series/ict/sae_traces.py) et **volontairement pures** — numpy-only, ni torch ni réseau. C'est exactement ce qui les rend exécutables en CI **sans GPU**, et le script GPU les consomme au lieu de réimplémenter les mêmes vérifications en ligne. Elles restent des exceptions (testables, réutilisables hors CLI) ; un wrapper `_guard` les traduit en sortie CLI actionnable côté script, sans les dégrader en `assert`.

## Compatibilité — vérifiée firsthand, pas supposée

Le nom par défaut du modèle de référence reste **byte-identique**. Ce n'est pas une politesse : `grep` compte **12 références en dur** qui chargent ces traces par chemin explicite — les notebooks ICT-21, ICT-22, ICT-24, `ICT-SAE-JLens-TeteATete`, `ICT-Synthese-CrossSubstrat`, plus `tests/test_sae_traces.py`, `tests/test_lens_agreement.py` et `ict/triade.py` — et les deux `.npz` portant ces noms sont réellement committés dans `traces/`. Casser le nom cassait cinq notebooks et deux suites.

## Tests

**22 tests neufs** dans `tests/test_sae_cross_scale.py`, placés à côté du compagnon canonique `tests/test_sae_traces.py`. J'ai d'abord écrit le fichier dans `ict/tests/` avant de vérifier lequel des deux répertoires est le bon : les **deux** tournent en CI (deux entrées de matrice dans `ict-tests.yml`), mais le test canonique de `ict/sae_traces.py` vit dans `tests/`, donc c'est là qu'un lecteur ira le chercher. Déplacé, `sys.path` aligné sur la convention du voisin.

```
tests/test_sae_cross_scale.py + tests/test_sae_traces.py   30 passed
ict/tests/ (suite complète)                              317 passed, 3 skipped
```

Les 3 skips sont pré-existants. Les constantes d'échelle (32/4096, 24/2048) sont **mesurées** sur les `config.json` officiels — un test vérifie explicitement que l'écart de profondeur relative entre les deux échelles reste visible (`> 0.17`), c'est-à-dire que le piège n° 1 ne peut pas se refermer en silence.

## Ce que cette PR ne fait pas

Elle **ne fait pas** de post-training et **ne consomme aucun GPU** : GPU 2 d'ai-01 est réservé cette heure à `ai-01:vllm`, qui teste la sortie de l'arbre de patches Genesis (notre image vLLM de prod est actuellement irreproductible — un point de défaillance unique sur l'endpoint qui porte la condensation de toute la flotte). Cet arbitrage passe devant mon entraînement ; les **étapes 2-4** de PT-12 (vrai post-training sur `Qwen3.5-2B`, puis lecture SAE différentielle bf16 base vs post-entraîné via le `differential_features` existant) suivront au retour de la carte.

## Sur le tag

`MED` : ça étend de la substance existante avec vérification, et ça change le comportement du script (échec rapide, refus de collision) — mais aucune capacité nouvelle n'atterrit sur `main` pour un lecteur, donc pas `DEEP`. Ce n'est pas `LIGHT` non plus : ces cinq défauts sont diagnostiqués contre un plan cross-échelle réel, pas générables en scannant l'instance suivante.

`tooling` deux fois de suite (`prev` = `LIGHT/tooling #10311`) : permis par G-VAR-3, qui ne bannit absolument que les genres LIGHT (`guard`/`ledger`/`docs`/`readme`/`test`) et autorise deux DEEP/MED consécutifs **de substance genuinement distincte** — un registre de secrets et des gardes SAE cross-échelle n'ont rien en commun. Je le déclare plutôt que de maquiller le genre.

**Et le constat qui compte plus que le tag** : mes deux livrables de ce cycle sont META, donc **mon plancher G-VAR-1 n'est pas tenu**. Je le note dans les mêmes termes que ceux que j'ai opposés à une autre lane ce cycle même — c'est un défaut de provisionnement de ma part, et PT-12 étapes 2-4 (`training`, DEEP) est le grain de contenu qui le tiendra.

See #10289
See #5105
