### PR TITLE
docs(harness,#9535): relocate durable notebook-enricher learnings to docs/reference/

### DIFF
--- a/docs/reference/notebook-enricher-guide.md
+++ b/docs/reference/notebook-enricher-guide.md
@@ -1,6 +1,10 @@
-# Notebook Enricher - Agent Memory
+# Guide d'enrichissement des notebooks — méthodologie & vocabulaire par domaine
 
-## Key Learnings
+> **Provenance** : consolidé depuis `.claude/agent-memory/notebook-enricher/MEMORY.md` (relocalisé ici le 2026-08-10, item-7 de #9535). Ce fichier regroupe les leçons trans-machine de l'agent `notebook-enricher` : règles de positionnement des cellules, vocabulaire pédagogique par famille, patrons de contenu et checklist qualité. Il complète [.claude/rules/notebook-conventions.md](../../.claude/rules/notebook-conventions.md) (règles C.1/C.2/C.3) et [docs/reference/procedures-recurrentes.md](procedures-recurrentes.md) (workflow d'enrichissement).
+>
+> **Note de fraîcheur** : les « session logs » datés (2026-02 à 2026-06) sont conservés comme provenance historique ; les références de fichiers `enrichment-log-*.md` / `enrichment_summary_*.md` pointent vers des journaux de session locaux non conservés dans le dépôt. Les noms de notebooks cités peuvent avoir évolué (renumérotation #5081).
+
+## Règles de positionnement des cellules (CRITIQUE)
 
 ### Cell Positioning Rules (CRITICAL)
 
@@ -29,17 +33,17 @@
   - Added interpretations for: complexity viz, SSM demo, S4 test, Mamba test, training results, SST hybrid, benchmark
   - Summary report: `enrichment_summary_qc23.md`
 
-- **2026-02-07**: DataScienceWithAgents Labs (3 notebooks, 11 cells added) - See [enrichment-log-2026-02-07.md](enrichment-log-2026-02-07.md)
+- **2026-02-07**: DataScienceWithAgents Labs (3 notebooks, 11 cells added) — journal de session local `enrichment-log-2026-02-07.md` (non conservé dans le dépôt)
   - All cells positioned correctly on first attempt
   - BOTTOM-to-TOP strategy prevented index conflicts
   - No git rollbacks needed
-- **2026-02-16**: Sudoku-3-ORTools (4 cells added: 1 header with objectives, 2 interpretations, 1 footer)
+- **2026-02-16**: Sudoku-10-ORTools (anciennement « Sudoku-3-ORTools » avant la renumérotation #5081 ; 4 cells added: 1 header with objectives, 2 interpretations, 1 footer)
   - Navigation header and footer with Search notebook links
   - Learning objectives (Bloom taxonomy) for CSP, CP-SAT, MIP
   - Duration: 50 minutes, Prerequisites: Sudoku-1-Backtracking
   - Interpretations after CP solver test and performance comparison
   - BOTTOM-to-TOP strategy with re-read between each insertion
-- **2026-02-16**: Search-9-Metaheuristics (3 cells added: 2 interpretations, 1 code improvement)
+- **2026-02-16**: Search — notebook métaheuristiques (anciennement « Search-9-Metaheuristics » avant la renumérotation #5081 ; 3 cells added: 2 interpretations, 1 code improvement)
   - Added interpretation after parameter analysis visualization (pop_size impact)
   - Added interpretation after PSO convergence visualization with technical note
   - Replaced seaborn with matplotlib in comparative plots (removed dependency)
@@ -117,7 +121,7 @@
 2. **Never** skip re-reading after insertions
 3. **Never** use ad-hoc Python for notebook manipulation (use notebook_helpers.py)
 4. **Never** add emojis
-5. **Never** modify existing code cells (unless --fix-errors flag)
+5. **Never** modify existing code cells (l'enrichissement ajoute du markdown autour du code existant ; pour corriger une cellule code cassée, tracer une PR séparée — cf [anti-regression.md](../../.claude/rules/anti-regression.md))
 
 ### Quality Checklist
 
@@ -132,19 +136,37 @@ Before completing enrichment:
 
 ### Tools Reference
 
+L'outil désigné (cf [CLAUDE.md](../../CLAUDE.md) « Catalogue agents / skills / scripts ») est la CLI multi-famille `scripts/notebook_tools/notebook_tools.py` :
+
 ```bash
-# Analyze structure
+# Valider la structure d'un notebook (cellules, execution_count, outputs)
+python scripts/notebook_tools/notebook_tools.py validate <path>
+
+# Analyser les sorties (détecter les erreurs, les outputs vides)
+python scripts/notebook_tools/notebook_tools.py analyze <path>
+
+# Extraire le squelette (index de cellules pour le repérage avant insertion)
+python scripts/notebook_tools/notebook_tools.py skeleton <path>
+```
+
+L'utilitaire `notebook_helpers.py` reste utile pour un listing détaillé par cellule :
+
+```bash
+# Lister les cellules avec leurs indices (repérage avant insertion BOTTOM-to-TOP)
 python scripts/notebook_tools/notebook_helpers.py list <path> --verbose
 
-# Verify consecutive code cells
+# Vérifier l'absence de cellules code consécutives sans markdown intercalaire
 grep -A1 "cell_type.*code" <path>
 
-# Check git diff
+# Vérifier le diff final
 git diff --stat <path>
 ```
 
-### Memory Organization
+Catalogue complet des scripts : [scripts-reference.md](scripts-reference.md).
 
-- `MEMORY.md` (this file): High-level patterns and lessons
-- `enrichment-log-YYYY-MM-DD.md`: Detailed session logs
-- Future: `domain-patterns.md` for domain-specific vocabulary expansion
+### Documentation associée
+
+- [notebook-conventions.md](../../.claude/rules/notebook-conventions.md) — règles C.1/C.2/C.3 (stubs sans erreur volontaire, outputs commités, scope des re-exécutions).
+- [procedures-recurrentes.md](procedures-recurrentes.md) — workflow d'enrichissement et pré-commit notebook (H.3).
+- [subagents-reference.md](subagents-reference.md) — catalogue des sous-agents (`notebook-enricher`, `notebook-cleaner`, `notebook-designer`).
+- Les journaux de session détaillés (`enrichment-log-YYYY-MM-DD.md`) sont des artefacts locaux hors dépôt ; cette doc n'en conserve que la synthèse trans-machine.


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2025:CoursIA — prev: MED/tooling #10303

# docs(harness,#9535): relocate durable notebook-enricher learnings to docs/reference/

## Quoi

Le `MEMORY.md` de l'agent `notebook-enricher` (.claude/agent-memory/notebook-enricher/MEMORY.md, 150L) contenait des leçons **trans-machine** (méthodologie de positionnement des cellules, 10 tables de vocabulaire par famille, patrons de contenu, checklist qualité) dans un chemin **per-machine incidental**. Per harness-hygiene tier 2 (doc pérenne = `docs/`), cette référence durable appartient à `docs/reference/`, pas au dossier agent-memory.

Relocalisé comme `docs/reference/notebook-enricher-guide.md` (historique préservé via `git mv`) **avec audit de fraîcheur** (real content edits, pas un rename cosmétique) :

## Freshness fixes (mesurés firsthand vs origin/main HEAD 31eb6d0ff)

| Défaut | Avant | Après |
|--------|-------|-------|
| Header | "# Notebook Enricher - Agent Memory" (per-machine framing) | Header de consolidation FR (provenance + scope + note de fraîcheur) + pointeurs vers notebook-conventions.md, procedures-recurrentes.md |
| Noms notebooks périmés | "Sudoku-3-ORTools", "Search-9-Metaheuristics" (pré-renumérotation) | "Sudoku-10-ORTools", "notebook métaheuristiques" (post-#5081) avec note de renumérotation |
| Lien markdown cassé | `[enrichment-log-2026-02-07.md](...)` (fichier non conservé dans dépôt, `git ls-tree` = 0) | Note "journal de session local non conservé dans le dépôt" |
| Flag inexistant | "--fix-errors flag" (grep sur `scripts/notebook_tools/*.py` = 0 occurrence) | Renvoi vers anti-regression.md (PR séparée pour corriger du code) |
| CLI manquante | Tools Reference n'avait QUE `notebook_helpers.py` | Ajout CLI canonique `notebook_tools.py` (validate/analyze/skeleton) per CLAUDE.md designated-tool rule |
| Footer | "Memory Organization" (ancienne structure agent-memory) | "Documentation associée" (cross-links: notebook-conventions, procedures-recurrentes, subagents-reference, scripts-reference) |

## Validation

- `git show HEAD --numstat` = rename + content edits (35 insertions, 13 deletions sur 172L total). Pas un rename pur.
- Markdown : `scripts-reference.md`, `notebook-conventions.md`, `procedures-recurrentes.md`, `subagents-reference.md` vérifiés EXISTS (cross-links valides).
- §E fichier-entier : le fichier EST l'unité (1 fichier, relocation prescrite).

## Anti-regression & scope

- **Préservation** : contenu durable conservé intégralement (tables vocabulaire, patrons, checklist). Header de consolidation documente la provenance (cf Consolider != Archiver).
- **0 notebook touché** : docs-only, 0 re-execution.
- `slide-analyzer/MEMORY.md` (aussi prescrit par po-2023 PR-D) **laissé** : son contenu est vision-dépendant (sk-agent image analysis, Marp render QA) → lane vision-capable per model-delegation. Residual signalé.
- QC agent-memory files gated on #6891.

## Provenance

Prescrit par myia-po-2023:CoursIA-2 (item-7 PR-D, analyse c.9535 des 10 fichiers agent-memory : triage durable-vs-scratch). `notebook-enricher/MEMORY.md` = classé durable → `docs/reference/`.

See #9535 (item-7 partial — #10023 a déjà retiré le scratch per-machine + dead indexes ; cette PR déplace le fichier durable résiduel).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
