### PR TITLE
feat(notebook-tools,#10319): per-tile advisory detector for partially-blank grid figures

### DIFF
--- a/scripts/notebook_tools/detect_blank_figures.py
+++ b/scripts/notebook_tools/detect_blank_figures.py
@@ -98,6 +98,28 @@ MIN_BYTES = 1024    # o  : un PNG decode < 1 Ko ne porte pas de vraie figure
 MIN_DISTINCT_COLORS = 4  # nb de couleurs RGB distinctes en dessous duquel une
                          # petite image est consideree sans contenu reel
 
+# Metrique per-tile advisory (#10319) : une figure-grille dont une fraction des
+# tuiles est quasi-uniforme (vide/blanc) tandis que d'autres sont riches (vrai
+# contenu) est une "grille partiellement vide" que les trois metriques globales
+# (dimensions, payload, couleurs de toute l'image) ne peuvent pas voir -- le
+# contenu des tuiles pleines dilue le vide des autres dans l'agregat. Cas revele
+# par 02-7 CogVideoX : grille 4x4 dont 2 rangees sur 4 etaient vides (pomme
+# absente), 955 Ko, passee au vert par les metriques globales. Phase advisory
+# (label) : signale sans bloquer --check ; le durcissement vient apres mesure
+# du taux de faux positifs sur les assets existants.
+MIN_DISTINCT_COLORS_PER_TILE = 16    # tuile "uniforme" si < 16 couleurs RGB distinctes
+RICH_DISTINCT_COLORS_PER_TILE = 100  # tuile "riche" si >= 100 couleurs (vrai contenu)
+PARTIAL_BLANK_UNIFORM_FRAC = 0.25    # >= 25 % de tuiles uniformes ...
+PARTIAL_BLANK_RICH_FRAC = 0.25       # ... ET >= 25 % de tuiles riches = contraste intra-image
+MIN_UNIFORM_RUN = 2                  # >= 2 rangees (ou colonnes) completes contigues de
+                                      # tuiles uniformes : la signature d'un BLOC de panneaux
+                                      # vides (rangees de subplots absents). Discrimine le
+                                      # vrai defaut (panneaux contigus) des marges blanches
+                                      # d'une figure simple (tuiles uniformes eparpillees aux
+                                      # coins) -> 0 FP sur 981 notebooks (scan #10319).
+DEFAULT_TILES = (4, 4)               # grille par defaut (lignes, colonnes)
+_TILE_SAMPLE_PX = 64                 # sous-echantillonnage des tuiles pour le denombrement
+
 _IMAGE_MIMES = ("image/png", "image/jpeg")
 _PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
@@ -174,6 +196,130 @@ def _has_real_content(raw: bytes, min_colors: int = MIN_DISTINCT_COLORS) -> bool
         return None
 
 
+def _tile_distinct_colors(im, rows: int, cols: int) -> list[int]:
+    """Return the distinct-RGB-color count of each tile in a rows x cols grid.
+
+    Tiles larger than _TILE_SAMPLE_PX on either side are downsampled before
+    counting, bounding the work on big figures. Downsampling preserves the
+    uniform/rich distinction (a blank tile stays ~1 color, a content tile stays
+    many) while capping per-tile cost at _TILE_SAMPLE_PX**2 pixels.
+    """
+    from PIL import Image  # noqa: F401  (resize available on the crop instance)
+    w, h = im.size
+    tw, th = w // cols, h // rows
+    counts = []
+    for r in range(rows):
+        for c in range(cols):
+            tile = im.crop((c * tw, r * th, (c + 1) * tw, (r + 1) * th))
+            if tile.size[0] > _TILE_SAMPLE_PX or tile.size[1] > _TILE_SAMPLE_PX:
+                tile = tile.resize((_TILE_SAMPLE_PX, _TILE_SAMPLE_PX))
+            counts.append(len(set(_flattened_pixels(tile))))
+    return counts
+
+
+def _max_uniform_run(counts: list[int], rows: int, cols: int, axis: int) -> int:
+    """Longest run of fully-uniform tiles along ``axis`` (0=rows, 1=cols).
+
+    A "fully-uniform row" = every tile in that row is below
+    MIN_DISTINCT_COLORS_PER_TILE. Returns the longest streak of such rows
+    (resp. columns) -- 0 if none. This is the contiguity signal that separates
+    a block of blank subplot panels (contiguous) from the scattered uniform
+    tiles of a single figure's whitespace margins.
+    """
+    best = cur = 0
+    outer, inner = (rows, cols) if axis == 0 else (cols, rows)
+    for o in range(outer):
+        full = True
+        for i in range(inner):
+            idx = o * inner + i if axis == 0 else i * outer + o
+            if counts[idx] >= MIN_DISTINCT_COLORS_PER_TILE:
+                full = False
+                break
+        if full:
+            cur += 1
+            best = max(best, cur)
+        else:
+            cur = 0
+    return best
+
+
+def partial_blank_fraction(raw: bytes, rows: int, cols: int) -> dict | None:
+    """Per-tile uniform/rich fractions + contiguity for a grid figure, or None.
+
+    Detects a *partially blank* grid (#10319): a figure where a significant
+    fraction of tiles is quasi-uniform (blank/near-blank) while others are rich.
+    The signal is the intra-image contrast -- both uniform AND rich tiles must be
+    present. A fully blank figure (caught by the global metrics) and a fully
+    filled one do not qualify.
+
+    Returns ``{uniform_frac, rich_frac, n_uniform, n_rich, n_tiles,
+    max_uniform_row_run, max_uniform_col_run}`` or None if the image cannot be
+    decoded or is too small to tile meaningfully (< 8 px per tile side).
+    """
+    try:
+        from PIL import Image
+        import io
+        im = Image.open(io.BytesIO(raw)).convert("RGB")
+    except Exception:
+        return None
+    w, h = im.size
+    if w < cols * 8 or h < rows * 8:
+        return None
+    counts = _tile_distinct_colors(im, rows, cols)
+    n_tiles = len(counts)
+    n_uniform = sum(1 for c in counts if c < MIN_DISTINCT_COLORS_PER_TILE)
+    n_rich = sum(1 for c in counts if c >= RICH_DISTINCT_COLORS_PER_TILE)
+    return {
+        "uniform_frac": n_uniform / n_tiles,
+        "rich_frac": n_rich / n_tiles,
+        "n_uniform": n_uniform,
+        "n_rich": n_rich,
+        "n_tiles": n_tiles,
+        "max_uniform_row_run": _max_uniform_run(counts, rows, cols, 0),
+        "max_uniform_col_run": _max_uniform_run(counts, rows, cols, 1),
+    }
+
+
+def _classify_partial_blank(mime: str, raw: bytes, rows: int, cols: int) -> dict | None:
+    """Return an *advisory* finding if the image is a partially-blank grid.
+
+    Advisory findings carry ``"level": "advisory"`` and do NOT fail ``--check``
+    (phase advisory, #10319). They are reported separately from hard degenerate
+    findings so the exit code of existing CI gates is unchanged.
+
+    Three conjuncts must hold: (1) enough uniform tiles, (2) enough rich tiles
+    (intra-image contrast), and (3) a contiguous block of >= MIN_UNIFORM_RUN
+    fully-uniform rows or columns -- the signature of missing subplot panels.
+    Conjunct (3) is the precision gate: it rejects single figures whose
+    whitespace margins scatter uniform tiles at the corners (0 FP on 981
+    notebooks, scan #10319) while keeping the real defect (>= 2 blank rows of a
+    subplot grid).
+    """
+    stats = partial_blank_fraction(raw, rows, cols)
+    if stats is None:
+        return None
+    has_contrast = (stats["uniform_frac"] >= PARTIAL_BLANK_UNIFORM_FRAC
+                    and stats["rich_frac"] >= PARTIAL_BLANK_RICH_FRAC)
+    has_block = (stats["max_uniform_row_run"] >= MIN_UNIFORM_RUN
+                 or stats["max_uniform_col_run"] >= MIN_UNIFORM_RUN)
+    if has_contrast and has_block:
+        dims = _png_dimensions(raw) if mime == "image/png" else None
+        return {
+            "mime": mime,
+            "bytes": len(raw),
+            "dimensions": list(dims) if dims else None,
+            "reasons": [
+                f"partial_blank_grid("
+                f"uniform={stats['n_uniform']}/{stats['n_tiles']},"
+                f"rich={stats['n_rich']}/{stats['n_tiles']},"
+                f"run={max(stats['max_uniform_row_run'], stats['max_uniform_col_run'])},"
+                f"tiles={rows}x{cols})"
+            ],
+            "level": "advisory",
+        }
+    return None
+
+
 def _classify_image(mime: str, raw: bytes, min_dim: int, min_bytes: int) -> dict | None:
     """Return a finding dict if the image is degenerate, else None."""
     reasons = []
@@ -203,8 +349,14 @@ def _classify_image(mime: str, raw: bytes, min_dim: int, min_bytes: int) -> dict
     }
 
 
-def detect_cell(cell: dict, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES) -> list[dict]:
-    """Return findings (one per degenerate image output) for a code cell."""
+def detect_cell(cell: dict, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES,
+                tiles: tuple[int, int] | None = None) -> list[dict]:
+    """Return findings (one per degenerate OR advisory image output) for a code cell.
+
+    Advisory findings (#10319, ``level == "advisory"``) flag partially-blank grids
+    and are only emitted for images that passed the hard degenerate checks (a hard
+    finding already covers a fully-blank image). They do NOT fail ``--check``.
+    """
     findings = []
     for oi, out in enumerate(_cell_outputs(cell)):
         data = out.get("data", {}) if isinstance(out, dict) else {}
@@ -217,10 +369,16 @@ def detect_cell(cell: dict, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES) 
             finding = _classify_image(mime, raw, min_dim, min_bytes)
             if finding:
                 findings.append({"output_index": oi, **finding})
+                continue  # hard finding couvre deja cette image
+            if tiles is not None:
+                adv = _classify_partial_blank(mime, raw, *tiles)
+                if adv:
+                    findings.append({"output_index": oi, **adv})
     return findings
 
 
-def scan_notebook(path: Path, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES) -> dict:
+def scan_notebook(path: Path, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES,
+                  tiles: tuple[int, int] | None = None) -> dict:
     """Return a result dict for one notebook: path, hits[], error."""
     try:
         with open(path, encoding="utf-8") as f:
@@ -232,7 +390,7 @@ def scan_notebook(path: Path, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES
     for ci, cell in enumerate(nb.get("cells", [])):
         if cell.get("cell_type") != "code":
             continue
-        for finding in detect_cell(cell, min_dim, min_bytes):
+        for finding in detect_cell(cell, min_dim, min_bytes, tiles):
             hits.append({"cell_index": ci, **finding})
     return {"path": str(path), "kernel": _kernel(nb), "hits": hits, "error": None}
 
@@ -261,12 +419,14 @@ def _iter_notebooks(root: Path, family: str | None):
 
 
 def _human_report(results: list[dict]) -> str:
-    total_hits = sum(len(r["hits"]) for r in results)
+    total_hits = sum(len([h for h in r["hits"] if h.get("level") != "advisory"]) for r in results)
+    total_adv = sum(len([h for h in r["hits"] if h.get("level") == "advisory"]) for r in results)
     affected = [r for r in results if r["hits"]]
     errored = [r for r in results if r.get("error")]
     lines = [
         f"Notebooks scanned  : {len(results)}",
         f"Degenerate figures : {total_hits}",
+        f"Advisory (partial) : {total_adv}",
         f"Affected notebooks : {len(affected)}",
         "",
     ]
@@ -281,13 +441,20 @@ def _human_report(results: list[dict]) -> str:
         lines.append(f"## {short}  [{r['kernel']}]")
         for h in r["hits"]:
             reasons = ", ".join(h["reasons"])
-            lines.append(f"  - cell [{h['cell_index']}] output[{h['output_index']}] {h['mime']}: {reasons}")
+            tag = "  [advisory]" if h.get("level") == "advisory" else ""
+            lines.append(f"  - cell [{h['cell_index']}] output[{h['output_index']}] {h['mime']}: {reasons}{tag}")
         lines.append("")
     lines.append(
-        "FIX: re-execute the cell in the real environment (QC Cloud research for "
-        "QuantBook, local kernel for matplotlib) and commit the real figure -- "
-        "Stop&Repair, never scrub/delete to hide (secrets-hygiene rule 6)."
+        "FIX: re-execute the cell in the real environment (QC Cloud "
+        "research for QuantBook, local kernel for matplotlib) and commit the real "
+        "figure -- Stop&Repair, never scrub/delete to hide (secrets-hygiene rule 6)."
     )
+    if total_adv:
+        lines.append(
+            "NOTE (advisory, #10319): a partially-blank grid is signalled, not blocked. "
+            "Inspect by eye (a lane that sees) before acting -- it may be a legitimate "
+            "sparse layout or a real missing-content defect."
+        )
     return "\n".join(lines)
 
 
@@ -303,7 +470,24 @@ def main(argv=None) -> int:
     parser.add_argument("--check", action="store_true", help="Exit 1 if any degenerate figure (CI-ready)")
     parser.add_argument("--min-dim", type=int, default=MIN_DIM, help=f"Min figure side px (default {MIN_DIM})")
     parser.add_argument("--min-bytes", type=int, default=MIN_BYTES, help=f"Min decoded bytes (default {MIN_BYTES})")
+    parser.add_argument("--tiles", default="4x4",
+                        help="Per-tile advisory grid RxC for partially-blank detection "
+                        f"(#10319, default {DEFAULT_TILES[0]}x{DEFAULT_TILES[1]}); "
+                        "pass 'off' to disable.")
+    parser.add_argument("--strict", action="store_true",
+                        help="Also exit 1 on advisory findings (default: advisories do not fail --check)")
     args = parser.parse_args(argv)
+
+    tiles = None
+    if args.tiles and args.tiles.lower() != "off":
+        try:
+            r_s, c_s = args.tiles.lower().split("x")
+            tiles = (int(r_s), int(c_s))
+            if tiles[0] < 1 or tiles[1] < 1:
+                raise ValueError
+        except ValueError:
+            print(f"error: --tiles expects RxC (e.g. 4x4), got {args.tiles!r}", file=sys.stderr)
+            return 2
 
     root = Path(args.root).resolve()
     if args.notebook:
@@ -319,16 +503,25 @@ def main(argv=None) -> int:
             print(f"error: family not found: {args.family}", file=sys.stderr)
             return 2
 
-    results = [scan_notebook(p, args.min_dim, args.min_bytes) for p in paths]
-    total_hits = sum(len(r["hits"]) for r in results)
+    results = [scan_notebook(p, args.min_dim, args.min_bytes, tiles) for p in paths]
+    # Hard hits only for --check exit code (advisories do not block, unless --strict).
+    hard_hits = sum(len([h for h in r["hits"] if h.get("level") != "advisory"]) for r in results)
+    adv_hits = sum(len([h for h in r["hits"] if h.get("level") == "advisory"]) for r in results)
 
     if args.json:
-        payload = {"notebooks_scanned": len(results), "total_hits": total_hits, "results": results}
+        payload = {
+            "notebooks_scanned": len(results),
+            "total_hits": hard_hits,
+            "advisory_hits": adv_hits,
+            "results": results,
+        }
         print(json.dumps(payload, ensure_ascii=False, indent=2))
     else:
         print(_human_report(results))
 
-    if args.check and total_hits > 0:
+    if args.check and hard_hits > 0:
+        return 1
+    if args.check and args.strict and adv_hits > 0:
         return 1
     return 0
 

--- a/scripts/notebook_tools/tests/test_detect_blank_figures.py
+++ b/scripts/notebook_tools/tests/test_detect_blank_figures.py
@@ -46,7 +46,14 @@ from detect_blank_figures import (  # noqa: E402
     SKIP_DIRS,
     _OUTPUT_SUFFIX,
     _PNG_SIGNATURE,
+    RICH_DISTINCT_COLORS_PER_TILE,
+    MIN_DISTINCT_COLORS_PER_TILE,
+    PARTIAL_BLANK_RICH_FRAC,
+    PARTIAL_BLANK_UNIFORM_FRAC,
+    MIN_UNIFORM_RUN,
+    _max_uniform_run,
     _classify_image,
+    _classify_partial_blank,
     _decode_image,
     _flattened_pixels,
     _has_real_content,
@@ -57,6 +64,7 @@ from detect_blank_figures import (  # noqa: E402
     _png_dimensions,
     _should_skip,
     main,
+    partial_blank_fraction,
     scan_notebook,
 )
 
@@ -876,3 +884,193 @@ class TestGateWorkflowContract:
             "`|| true` makes rc always 0 and permanently disarms the gate; "
             "use `&& rc=0 || rc=$?`"
         )
+
+# ---------------------------------------------------------------------------
+# 8. TestPartialBlankGrid -- per-tile advisory metric (#10319)
+# ---------------------------------------------------------------------------
+# A grid figure (e.g. a 4x4 panel of subplots) whose tiles are PARTIALLY empty
+# passes all three global metrics (dimensions, payload, whole-image color count):
+# the rich tiles carry enough colors for the whole image. The per-tile advisory
+# catches the intra-image contrast (uniform tiles + rich tiles coexisting).
+# Phase advisory: emitted with level="advisory", does NOT fail --check.
+
+def _grid_png_bytes(rows: int, cols: int, tile: int,
+                    uniform_cells: set[tuple[int, int]],
+                    seed: int = 42) -> bytes:
+    """Build a (cols*tile)x(rows*tile) RGB PNG grid.
+
+    Cells in ``uniform_cells`` are solid beige (1 distinct color); the rest are
+    seeded random noise (>= 100 distinct colors = "rich"). Returns raw PNG bytes.
+    """
+    import io
+    import random
+    from PIL import Image
+    rng = random.Random(seed)
+    w, h = cols * tile, rows * tile
+    im = Image.new("RGB", (w, h))
+    px = im.load()
+    for r in range(rows):
+        for c in range(cols):
+            if (r, c) in uniform_cells:
+                color = (245, 240, 230)  # beige quasi-uniforme
+                for y in range(r * tile, (r + 1) * tile):
+                    for x in range(c * tile, (c + 1) * tile):
+                        px[x, y] = color
+            else:
+                for y in range(r * tile, (r + 1) * tile):
+                    for x in range(c * tile, (c + 1) * tile):
+                        px[x, y] = (rng.randint(0, 255), rng.randint(0, 255), rng.randint(0, 255))
+    buf = io.BytesIO()
+    im.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _grid_b64(rows: int, cols: int, tile: int,
+              uniform_cells: set[tuple[int, int]]) -> str:
+    return base64.b64encode(_grid_png_bytes(rows, cols, tile, uniform_cells)).decode("ascii")
+
+
+# 4x4 grid, rows 0-1 uniform (8 cells), rows 2-3 rich (8 cells) -- the #10319 case.
+_UNIFORM_HALF = {(r, c) for r in range(2) for c in range(4)}
+PNG_PARTIAL_GRID_B64 = _grid_b64(4, 4, 40, _UNIFORM_HALF)
+# 4x4 grid, fully rich (no uniform cells).
+PNG_FULL_GRID_B64 = _grid_b64(4, 4, 40, set())
+# 4x4 grid, only the 4 CORNERS uniform -- scattered (no full row/col). Models the
+# whitespace-margin false positive (a single matplotlib figure whose 4 corner
+# tiles are pure background). Has the frac contrast but NO contiguity -> the
+# precision gate (#10319 contiguity) must reject it.
+_UNIFORM_CORNERS = {(0, 0), (0, 3), (3, 0), (3, 3)}
+PNG_SCATTERED_CORNERS_B64 = _grid_b64(4, 4, 40, _UNIFORM_CORNERS)
+
+
+class TestPartialBlankGrid:
+    """Per-tile advisory metric (#10319): partially-blank grid detection."""
+
+    def test_partial_blank_fraction_half_empty(self):
+        """The #10319 case: 4x4 grid, half uniform -> uniform_frac=0.5, rich_frac=0.5,
+        and a contiguous block of 2 fully-uniform rows (rows 0-1)."""
+        raw = base64.b64decode(PNG_PARTIAL_GRID_B64)
+        stats = partial_blank_fraction(raw, 4, 4)
+        assert stats is not None
+        assert stats["n_tiles"] == 16
+        assert stats["n_uniform"] == 8
+        assert stats["uniform_frac"] >= PARTIAL_BLANK_UNIFORM_FRAC
+        assert stats["rich_frac"] >= PARTIAL_BLANK_RICH_FRAC
+        assert stats["max_uniform_row_run"] == 2  # rows 0-1 fully uniform (contiguous)
+        assert stats["max_uniform_col_run"] == 0  # no full uniform column
+
+    def test_max_uniform_run_helper(self):
+        """_max_uniform_run returns the longest streak of fully-uniform rows/cols."""
+        # row-major counts: 16 tiles. Make rows 2-3 fully uniform (values < threshold).
+        counts = [200, 200, 200, 200,   # row 0 rich
+                  200, 200, 200, 200,   # row 1 rich
+                  1, 1, 1, 1,           # row 2 uniform
+                  1, 1, 1, 1]           # row 3 uniform
+        assert _max_uniform_run(counts, 4, 4, axis=0) == 2
+        assert _max_uniform_run(counts, 4, 4, axis=1) == 0
+        # column contiguity: cols 0-1 uniform, cols 2-3 rich
+        counts_c = [1, 1, 200, 200] * 4
+        assert _max_uniform_run(counts_c, 4, 4, axis=1) == 2
+        assert _max_uniform_run(counts_c, 4, 4, axis=0) == 0
+
+    def test_scattered_corners_not_flagged(self):
+        """Precision gate (#10319): 4 scattered uniform corner tiles have the frac
+        contrast but NO contiguous full row -> NOT flagged (the FP that would flood
+        a whitespace-margin single figure). This is the regression that keeps the
+        advisory at 0 FP on the existing notebook base."""
+        raw = base64.b64decode(PNG_SCATTERED_CORNERS_B64)
+        stats = partial_blank_fraction(raw, 4, 4)
+        assert stats is not None
+        assert stats["n_uniform"] == 4                      # has the frac (4/16 = 25%)
+        assert stats["uniform_frac"] >= PARTIAL_BLANK_UNIFORM_FRAC
+        assert stats["rich_frac"] >= PARTIAL_BLANK_RICH_FRAC
+        assert stats["max_uniform_row_run"] == 0            # but no contiguous full row
+        assert stats["max_uniform_col_run"] == 0
+        assert _classify_partial_blank("image/png", raw, 4, 4) is None  # precision gate rejects
+
+    def test_full_grid_no_partial_blank(self):
+        """A fully-rich grid has no uniform tiles -> not flagged."""
+        raw = base64.b64decode(PNG_FULL_GRID_B64)
+        stats = partial_blank_fraction(raw, 4, 4)
+        assert stats is not None
+        assert stats["n_uniform"] == 0
+        assert stats["uniform_frac"] < PARTIAL_BLANK_UNIFORM_FRAC
+        assert _classify_partial_blank("image/png", raw, 4, 4) is None
+
+    def test_classify_partial_blank_emits_advisory(self):
+        """The half-empty grid yields an advisory finding with level='advisory'."""
+        raw = base64.b64decode(PNG_PARTIAL_GRID_B64)
+        finding = _classify_partial_blank("image/png", raw, 4, 4)
+        assert finding is not None
+        assert finding["level"] == "advisory"
+        assert any("partial_blank_grid" in r for r in finding["reasons"])
+
+    def test_detect_cell_advisory_on_partial_grid(self):
+        """detect_cell emits an advisory finding for a partial-grid image output,
+        and it carries level='advisory' (distinct from a hard degenerate finding)."""
+        cell = _code("# plot\n")
+        cell["outputs"] = [{
+            "output_type": "display_data",
+            "data": {"image/png": PNG_PARTIAL_GRID_B64},
+            "metadata": {},
+        }]
+        findings = detect_cell(cell, tiles=(4, 4))
+        adv = [f for f in findings if f.get("level") == "advisory"]
+        assert len(adv) == 1
+        assert "partial_blank_grid" in adv[0]["reasons"][0]
+
+    def test_detect_cell_no_advisory_on_full_grid(self):
+        """A fully-rich grid image yields no advisory finding (no false positive)."""
+        cell = _code("# plot\n")
+        cell["outputs"] = [{
+            "output_type": "display_data",
+            "data": {"image/png": PNG_FULL_GRID_B64},
+            "metadata": {},
+        }]
+        findings = detect_cell(cell, tiles=(4, 4))
+        adv = [f for f in findings if f.get("level") == "advisory"]
+        assert adv == []
+
+    def test_advisory_does_not_fail_check(self):
+        """--check on a notebook whose only finding is advisory exits 0 (phase advisory)."""
+        nb = _nb([_code("# plot\n")])
+        nb["cells"][0]["outputs"] = [{
+            "output_type": "display_data",
+            "data": {"image/png": PNG_PARTIAL_GRID_B64},
+            "metadata": {},
+        }]
+        with open(_NB_TMP := Path(__file__).parent / "_tmp_partial_grid.ipynb", "w", encoding="utf-8") as f:
+            json.dump(nb, f)
+        try:
+            rc = main([str(_NB_TMP), "--check", "--root", str(Path(__file__).resolve().parents[3])])
+        finally:
+            _NB_TMP.unlink(missing_ok=True)
+        assert rc == 0, "advisory-only notebook must NOT fail --check (phase advisory)"
+
+    def test_advisory_fails_check_strict(self):
+        """--check --strict exits 1 on an advisory finding (opt-in hardening)."""
+        nb = _nb([_code("# plot\n")])
+        nb["cells"][0]["outputs"] = [{
+            "output_type": "display_data",
+            "data": {"image/png": PNG_PARTIAL_GRID_B64},
+            "metadata": {},
+        }]
+        with open(_NB_TMP := Path(__file__).parent / "_tmp_partial_grid_strict.ipynb", "w", encoding="utf-8") as f:
+            json.dump(nb, f)
+        try:
+            rc = main([str(_NB_TMP), "--check", "--strict", "--root", str(Path(__file__).resolve().parents[3])])
+        finally:
+            _NB_TMP.unlink(missing_ok=True)
+        assert rc == 1, "--strict must fail --check on advisory findings"
+
+    def test_no_tiles_disables_advisory(self):
+        """tiles=None (or --tiles off) preserves the pre-#10319 behavior: no advisory."""
+        cell = _code("# plot\n")
+        cell["outputs"] = [{
+            "output_type": "display_data",
+            "data": {"image/png": PNG_PARTIAL_GRID_B64},
+            "metadata": {},
+        }]
+        findings = detect_cell(cell, tiles=None)
+        adv = [f for f in findings if f.get("level") == "advisory"]
+        assert adv == [], "tiles=None must not run the per-tile advisory"


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #10313

Quoi:      Detecteur advisory per-tile (#10319) pour les figures-grilles partiellement vides que les 3 metriques globales de `detect_blank_figures` (dimensions, payload, couleurs de toute l'image) ne peuvent pas voir. Cas revelateur 02-7 CogVideoX cell 12 (PR #10305) : grille 4x4 dont 2 rangees sont vides (frames absentes), 955 Ko, passee au vert par les metriques globales car les tuiles pleines diluent le vide des tuiles vides dans l'agregat. Phase advisory (label, ne bloque PAS --check).
Preuve:    `pytest scripts/notebook_tools/tests/test_detect_blank_figures.py` = 87/87 PASS (77 existants + 10 nouveaux TestPartialBlankGrid). Sweep FP sur les assets existants : `detect_blank_figures --root . --json --tiles 4x4` = **981 notebooks, 0 hard hit (pas de regression sur la detection existante), 0 advisory FP**. La precision vient de la contiguite (3e conjonct) : sans elle, la regle frac-only produit 85 FP (figures matplotlib simples dont les marges blanches eparpillent des tuiles uniformes aux 4 coins) ; exiger un bloc contigu de >= 2 rangees/colonnes uniformes = la signature de panneaux de subplots absents -> 0 FP tout en gardant le cas #10319 synthetique (2 rangees uniformes signale). Le cas revelateur reel (02-7 cell 12) vit sur #10305, pas encore sur main ; le detecteur l'attrapera au merge de #10305. Test de non-regression synthetique : grille 4x4 dont 2 rangees uniformes -> signalee ; la meme grille entierement remplie -> non signalee ; tuiles uniformes eparpillees (4 coins) -> non signalee (le FP-killer). Pre-existing unrelated failure confirmee sur origin/main sans mes changements (git stash) : `test_twin_registry_integrity::test_audit_shas_exist_in_file_history` (drift SHA audit Sudoku-14 BDD, orthogonal).
Perimetre: `scripts/notebook_tools/detect_blank_figures.py` (+219/-14 : constantes per-tile, `_tile_distinct_colors`, `partial_blank_fraction`, `_classify_partial_blank` advisory, `_max_uniform_run`, params `tiles` sur `detect_cell`/`scan_notebook`, CLI `--tiles`/`--strict`, JSON `advisory_hits`) + `scripts/notebook_tools/tests/test_detect_blank_figures.py` (+200 : fixture `_grid_png_bytes`, `TestPartialBlankGrid` 10 tests). Hors-scope : le tri visuel des candidats signales (lane qui voit, ai-01/MiniMax) ; le durcissement eventuel advisory->hard (gated par le taux de FP mesure, ici 0) ; la mise a jour du test avec l'image reelle 02-7 (apres merge #10305).

## Disciplines respectees

- **Advisory, pas blocage** : `--check` exit 0 sur advisory-only (phase advisory). `--strict` opt-in pour faire echouer.
- **Pas de regression** : 0 hard hit sur 981 notebooks ; les 77 tests existants PASS intacts.
- **Catalogue byte-identique a main** (catalog-pr-hygiene) : ma PR ne touche que `detect_blank_figures.py` + son test, 0 toucher catalogue/marqueurs.
- **secret-hygiene** : N/A (aucun secret, aucun getenv).
- **Tests centralises** `scripts/notebook_tools/tests/` (hermeticite).

## See #10319. Related: #10305 (Tache 3 CogVideoX, contient le cas revelateur 02-7), EPIC #3801 (registre SOTA axe-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF 2>&1 | tail -5
