### PR TITLE
fix(ci,#10321): T4 de translation-sync — enregistrer le module dans sys.modules avant exec_module

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -271,6 +271,11 @@ jobs:
           spec = importlib.util.spec_from_file_location(
               "check_perimeter", "scripts/translation/check_perimeter.py")
           mod = importlib.util.module_from_spec(spec)
+          # OBLIGATOIRE avant exec_module : check_perimeter.py definit un @dataclass,
+          # et dataclasses._is_type resout sys.modules.get(cls.__module__).__dict__.
+          # Sans cet enregistrement le lookup rend None -> AttributeError, et l'etape
+          # entiere echoue avant tout rendu (cause des 31 runs push / 0 succes, #10321).
+          sys.modules[spec.name] = mod
           spec.loader.exec_module(mod)
           active_langs = list(mod.TARGET_LANGS)
           troot = pathlib.Path("translations")


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: DEEP/training #10226

## Résumé

Une ligne dans `.github/workflows/translation-sync.yml` : `sys.modules[spec.name] = mod` avant `exec_module`. Elle répare un job de CI qui **n'a jamais abouti une seule fois**.

## La mesure qui a déclenché l'enquête

J'ai déclenché un `workflow_dispatch` ce cycle pour tenir une promesse faite sur #10299 (« je vérifie en vrai et je poste le résultat »). Il a échoué. En regardant l'historique **groupé par événement** plutôt qu'en agrégat :

```
{"event":"pull_request",      "n":23, "success":17, "last_success":"2026-08-09T03:34:14Z"}
{"event":"push",              "n":31, "success":0,  "last_success":"JAMAIS"}
{"event":"workflow_dispatch", "n":2,  "success":0,  "last_success":"JAMAIS"}
```

L'agrégat « 17 succès / 19 échecs » avait l'air d'un workflow instable. Groupé par événement, il dit autre chose : les 17 succès appartiennent tous à `pull_request`, qui exécute le **garde-fou de fichiers dérivés**. Le job qui *livre* — celui qui rend les siblings traduits et pousse sur `chore/translation-sync-pending` — est à **0/33**.

## Cause racine

```
File "scripts/translation/check_perimeter.py", line 235, in <module>
    @dataclass
File ".../dataclasses.py", line 712, in _is_type
    ns = sys.modules.get(cls.__module__).__dict__
AttributeError: 'NoneType' object has no attribute '__dict__'
```

T4 charge `check_perimeter.py` dynamiquement pour lire `TARGET_LANGS` (source unique de vérité depuis la consolidation #10109). `module_from_spec` **ne** met pas le module dans `sys.modules` ; or `check_perimeter.py:235` définit un `@dataclass`, et `dataclasses._is_type` résout `sys.modules.get(cls.__module__).__dict__`. Le lookup rend `None`, le décorateur lève à l'import — donc avant la première itération de rendu.

Ce n'est pas une optimisation d'import : pour un module qui définit un `@dataclass`, l'enregistrement dans `sys.modules` est une **précondition**.

## Reproduction locale (falsifiable)

```
=== reproduction locale (python 3.14.3) ===
  sans sys.modules[spec.name] (= etat actuel du T4) : CRASH AttributeError: 'NoneType' object has no attribute '__dict__'
  avec sys.modules[spec.name] (= le fix)            : OK  (module charge, 33 attrs)
```

## Rayon : un seul site, pas de rollout

Le motif « charge dynamique sans `sys.modules` » existe sur une trentaine de sites du dépôt (tests, surtout), mais il ne casse **que** si la cible définit un `@dataclass`. Audit mécanique de l'intersection : **un seul import réel** concerné, celui-ci. (`render_notebook.py` apparaît aussi dans ce workflow mais est appelé en sous-processus, pas importé.) Aucune bombe latente ailleurs.

## Ce que ça invalide — deux de mes propres affirmations

1. **Sur #10299**, j'ai écrit que « l'automatisation couvre déjà les 16 candidats » et que la boucle du runner de po-2025 « est déjà celle du bot ». Le **code** de T4 dit bien cela — il itère `translations/**/*.csv` × langues actives sans condition d'existence du sibling. Mais l'étape plante **avant** d'itérer. Le runner que j'ai qualifié de redondant faisait à la main ce que le bot n'a jamais réussi une seule fois. Ma remarque sur son emplacement (racine au lieu de `scripts/`) tient ; celle sur sa redondance était fausse, et je la corrige sur l'issue.
2. **Le modèle « PR permanente »** (#10136), décrit dans [catalog-pr-hygiene](.claude/rules/catalog-pr-hygiene.md) comme le canal canonique avec pour corollaire qu'un agent ne rend pas les fichiers dérivés à la main : pour le volet **traduction**, cette promesse était non financée — `chore/translation-sync-pending` ne pouvait pas être alimentée. La règle reste juste ; c'est l'organe qui manquait.

## Validation

Le seul critère qui compte est un run **`success` sur `workflow_dispatch`** (pas sur `pull_request`). Je le déclenche dès le merge et je poste la conclusion sur #10321. Tant qu'il n'est pas vert, la cause racine est prouvée mais la réparation ne l'est pas.

Un vert `pull_request` est visuellement indiscernable d'un vert de livraison dans le rollup — c'est exactement ce qui a permis à 33 échecs de passer inaperçus, et c'est pourquoi le critère est écrit par événement.

## Notes de protocole

- **Genre `guard`** plutôt que `tooling` : j'ai requalifié `tooling`→`guard` sur #10313 ce cycle au motif que le script est câblé en CI et peut rougir. Appliquer une lecture plus indulgente à mon propre grain serait l'asymétrie exacte que le protocole existe pour empêcher. `guard` durcit mon adjacence, il ne l'assouplit pas.
- **G-VAR-1 : ce grain ne tient pas mon plancher.** `guard` est un genre META. Aucun de mes livrables de ce cycle n'est du contenu — je le dis plutôt que de laisser le tier `MED` en donner l'illusion. Le grain de contenu qui portera mon plancher est nommé : PT-12 étapes 2-4 (post-training réel sur `Qwen/Qwen3.5-2B`, GPU 2 de ai-01, puis lecture différentielle par les SAE).

See #10321
