### PR TITLE
feat(guard,#10323): closingIssuesReferences authoritative for PR-body closing refs

### DIFF
--- a/.github/workflows/lane-claim-guard.yml
+++ b/.github/workflows/lane-claim-guard.yml
@@ -86,12 +86,30 @@ jobs:
           # ajoute, pas d'interpretation des backslash).
           printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
 
+          # #10323: GitHub-authoritative closing refs. closingIssuesReferences
+          # est ce que GitHub fermera REELLEMENT au merge ; le finder regex
+          # seul false-positivait sur un mot-cle fermant dans un code span /
+          # une negation ("NOT closing #N") que le parser de GitHub ignore. On
+          # fetch une fois et on passe au helper. Sur ECHEC du fetch, on omet
+          # l'arg -> le helper retombe sur le regex + warn (ne desarme pas le
+          # gate sur un blip reseau). `gh ... --jq` sort 0 sur un set vide
+          # (chaine vide), non-zero sur auth/erreur -> le `if` discrimine.
+          if PR_CLOSING_REFS=$(gh pr view "$PR_NUMBER" \
+              --json closingIssuesReferences \
+              --jq '[.closingIssuesReferences[].number] | join(",")' 2>/dev/null); then
+            PR_CREFS_ARG=(--pr-closing-refs "$PR_CLOSING_REFS")
+          else
+            PR_CREFS_ARG=()
+            echo "::warning::closingIssuesReferences fetch failed; falling back to regex finder (#10323)."
+          fi
+
           # Le helper fetch chaque issue referencee par mot-cle fermant via
           # `gh issue view`, reduit l'etat des claims, et sort 0 (pass /
           # fail-open) ou 1 (block sur un claim frais d'une autre lane).
           # stderr exempte pour debug.
           python3 scripts/ci/lane_claim_required.py \
-            --body-file /tmp/pr_body.txt > /tmp/verdict.json 2>/tmp/verdict.err
+            --body-file /tmp/pr_body.txt "${PR_CREFS_ARG[@]}" \
+            > /tmp/verdict.json 2>/tmp/verdict.err
           RC=$?
 
           if [ -s /tmp/verdict.err ]; then
@@ -171,12 +189,24 @@ jobs:
 
           printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
 
+          # #10323: meme cross-check closingIssuesReferences que le job required,
+          # pour que lane-claim-absent ne se declenche pas sur un mot-cle fermant
+          # dans un code span/negation que GitHub ignore.
+          if PR_CLOSING_REFS=$(gh pr view "$PR_NUMBER" \
+              --json closingIssuesReferences \
+              --jq '[.closingIssuesReferences[].number] | join(",")' 2>/dev/null); then
+            PR_CREFS_ARG=(--pr-closing-refs "$PR_CLOSING_REFS")
+          else
+            PR_CREFS_ARG=()
+          fi
+
           # Le helper sort 0/1/2 ; ici on ignore le code (advisory) et on ne
           # lit que advisory_labels. `|| true` garde le job vert meme sur un
           # block du sibling required (le verdict JSON est ecrit sur stdout
           # avant l'exit 1 du block path).
           python3 scripts/ci/lane_claim_required.py \
-            --body-file /tmp/pr_body.txt > /tmp/verdict.json 2>/tmp/verdict.err || true
+            --body-file /tmp/pr_body.txt "${PR_CREFS_ARG[@]}" \
+            > /tmp/verdict.json 2>/tmp/verdict.err || true
 
           # Creation idempotente des deux labels.
           mk_label() {

--- a/scripts/ci/lane_claim_required.py
+++ b/scripts/ci/lane_claim_required.py
@@ -104,6 +104,7 @@ def _compute_advisory_labels(
     pr_body: str | None,
     issue_fetcher: IssueFetcher,
     pr_lane: str,
+    pr_closing_refs: set[int] | None = None,
 ) -> list[str]:
     r"""Advisory labels for adoption telemetry (#10223 Task 4) -- never block.
 
@@ -123,10 +124,20 @@ def _compute_advisory_labels(
     SAME scanners (``grain_tag.find_close_keyword_pr_refs`` /
     ``find_non_closing_refs``) -- no competing logic. Fetch failures are
     skipped: an advisory label must not crash the job on a network blip.
+
+    ``pr_closing_refs`` (#10323): the issue numbers GitHub resolved as closing
+    refs for this PR (``closingIssuesReferences``). A closing keyword inside a
+    code span / negation is matched by the regex finder but IGNORED by GitHub --
+    it must not fire ``lane-claim-absent`` either, since GitHub will not close
+    it. ``None`` = cross-check unavailable -> keep the regex-only behaviour
+    (backward compatible).
     """
     labels: set[str] = set()
     # lane-claim-absent: a closing-referenced issue with no active claim at all.
     for h in gt.find_close_keyword_pr_refs(pr_body):
+        # #10323: skip closing keywords GitHub ignores (code span / negation).
+        if pr_closing_refs is not None and h["number"] not in pr_closing_refs:
+            continue
         payload = issue_fetcher(h["number"])
         if payload is None:
             continue
@@ -151,6 +162,7 @@ def check(
     issue_fetcher: IssueFetcher,
     stale_threshold: float = 48.0,
     now: datetime | None = None,
+    pr_closing_refs: set[int] | None = None,
 ) -> dict:
     r"""Pure decision function: blocking verdict for a PR body (#10223).
 
@@ -204,30 +216,58 @@ def check(
     # Advisory labels (#10223 Task 4): computed across BOTH closing and
     # non-closing refs -- the blocking path below only looks at closing refs,
     # but a `See #N` conflict or a no-claim closing issue is still worth a
-    # label. Never blocks.
-    advisory = _compute_advisory_labels(pr_body, issue_fetcher, pr_lane)
-
-    # Closing references ONLY (Closes|Fixes|Resolves). See/Part of are excluded
-    # by construction by find_close_keyword_pr_refs -- that is the discriminant.
-    closing = gt.find_close_keyword_pr_refs(pr_body)
-    issue_nums = sorted({h["number"] for h in closing})
-    if not issue_nums:
-        return {
-            "guard_pass": True,
-            "reason": "no closing-keyword reference -> advisory only (See/Part of do not block)",
-            "pr_lane": pr_lane,
-            "blocking_lane": None,
-            "blocking_issue": None,
-            "blocking_claim_at": None,
-            "closing_issues": [],
-            "advisory_labels": advisory,
-            "warnings": [],
-        }
+    # label. Never blocks. The same closingIssuesReferences cross-check (#10323)
+    # applies so a code-span/negated closing keyword does not fire lane-claim-absent.
+    advisory = _compute_advisory_labels(pr_body, issue_fetcher, pr_lane, pr_closing_refs)
 
     now = now or datetime.now(timezone.utc)
     warnings: list[str] = []
 
-    for num in issue_nums:
+    # Closing references ONLY (Closes|Fixes|Resolves). See/Part of are excluded
+    # by construction by find_close_keyword_pr_refs -- that is the discriminant.
+    closing = gt.find_close_keyword_pr_refs(pr_body)
+    regex_nums = sorted({h["number"] for h in closing})
+
+    # #10323: for a PR BODY, GitHub's closingIssuesReferences is authoritative.
+    # The regex finder matches closing keywords even inside code spans, fenced
+    # blocks, or negations ("NOT closing #N") that GitHub's parser ignores. Only
+    # numbers GitHub actually resolved as closing refs can block; regex-only
+    # matches are logged IGNORED_BY_GITHUB and do not block. The regex stays the
+    # source of truth for COMMIT messages (scanned by pr_close_keyword_guard.py),
+    # which GitHub does not pre-resolve and where the squash trap is real.
+    if pr_closing_refs is None:
+        # Cross-check unavailable (fetch failed / older caller) -> fall back to
+        # the regex finder. Do NOT disarm the gate on a network blip: a real
+        # closing ref still blocks; only the code-span FP resurfaces, and it is
+        # warned so the gap is visible.
+        warnings.append(
+            "closingIssuesReferences unavailable -- using regex finder only; a "
+            "closing keyword in a code span/negation may false-positive (#10323)"
+        )
+        confirmed_nums = regex_nums
+    else:
+        confirmed_nums = sorted(n for n in regex_nums if n in pr_closing_refs)
+        for n in regex_nums:
+            if n not in pr_closing_refs:
+                warnings.append(
+                    f"#{n}: closing-keyword matched by regex but IGNORED_BY_GITHUB "
+                    f"(code span or negation) -- not treated as a closing ref (#10323)"
+                )
+
+    if not confirmed_nums:
+        return {
+            "guard_pass": True,
+            "reason": "no GitHub-confirmed closing-keyword reference -> advisory only (See/Part of do not block)",
+            "pr_lane": pr_lane,
+            "blocking_lane": None,
+            "blocking_issue": None,
+            "blocking_claim_at": None,
+            "closing_issues": confirmed_nums,
+            "advisory_labels": advisory,
+            "warnings": warnings,
+        }
+
+    for num in confirmed_nums:
         payload = issue_fetcher(num)
         if payload is None:
             # Fail-open: a fetch failure (network, missing issue) must not
@@ -269,7 +309,7 @@ def check(
                 "blocking_lane": blocking,
                 "blocking_issue": num,
                 "blocking_claim_at": ev.created_at,
-                "closing_issues": issue_nums,
+                "closing_issues": confirmed_nums,
                 "advisory_labels": advisory,
                 "warnings": warnings,
             }
@@ -281,7 +321,7 @@ def check(
         "blocking_lane": None,
         "blocking_issue": None,
         "blocking_claim_at": None,
-        "closing_issues": issue_nums,
+        "closing_issues": confirmed_nums,
         "advisory_labels": advisory,
         "warnings": warnings,
     }
@@ -295,6 +335,13 @@ def main(argv: list[str] | None = None) -> int:
                    default=48.0,
                    help="other lanes' claims older than HOURS do not block "
                         "(default 48; age from server createdAt).")
+    p.add_argument("--pr-closing-refs", metavar="NUMS", default=None,
+                   help="comma-separated issue numbers GitHub resolved as closing "
+                        "refs for this PR (from `gh pr view --json "
+                        "closingIssuesReferences`). The PR BODY is cross-checked "
+                        "against this set so a closing keyword in a code span/"
+                        "negation cannot block alone (#10323). Omit to fall back "
+                        "to the regex finder (used when the fetch failed).")
     args = p.parse_args(argv)
 
     try:
@@ -307,9 +354,30 @@ def main(argv: list[str] | None = None) -> int:
         ), file=sys.stderr)
         return 2
 
-    verdict = check(body, gh_issue_fetcher, stale_threshold=args.stale_threshold)
+    pr_closing_refs = _parse_closing_refs(args.pr_closing_refs)
+    verdict = check(
+        body, gh_issue_fetcher,
+        stale_threshold=args.stale_threshold,
+        pr_closing_refs=pr_closing_refs,
+    )
     print(json.dumps(verdict, ensure_ascii=False))
     return 0 if verdict["guard_pass"] else 1
+
+
+def _parse_closing_refs(spec: str | None) -> set[int] | None:
+    """Parse the ``--pr-closing-refs`` CLI value into a set, or ``None``.
+
+    ``None`` (arg omitted) signals "cross-check unavailable" -> the gate falls
+    back to the regex finder. An empty string means "GitHub fetched, the PR
+    closes nothing" -> an empty set (every regex hit is IGNORED_BY_GITHUB).
+    Non-numeric tokens are skipped rather than crashing the job.
+    """
+    if spec is None:
+        return None
+    spec = spec.strip()
+    if spec == "":
+        return set()
+    return {int(t) for t in spec.split(",") if t.strip().isdigit()}
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_lane_claim_required.py
+++ b/scripts/tests/test_lane_claim_required.py
@@ -324,3 +324,111 @@ def test_cli_missing_body_file_exit_two(tmp_path):
         capture_output=True, text=True, check=False,
     )
     assert proc.returncode == 2
+
+
+# --- #10323: closingIssuesReferences is authoritative for a PR body -----------
+#
+# The regex finder matches a closing keyword even inside a code span, a fenced
+# block, or a negation ("NOT closing #N") -- contexts GitHub's parser ignores.
+# closingIssuesReferences (passed as pr_closing_refs) is what GitHub will
+# ACTUALLY close on merge. A regex hit absent from that set must NOT block.
+# A real closing ref still does (the ratchet does not disarm).
+
+
+def _body_with(line, lane="myia-po-2026:CoursIA"):
+    return (
+        f"Grain: DEEP/guard -- lane {lane} -- prev: MED/guard #10151\n\n"
+        f"## Summary\n\n{line}\n"
+    )
+
+
+def _claimed_by_other_issue(num=6724):
+    return fetcher_from({num: issue_payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- working here",
+                "2026-08-09T11:41:43Z"),
+        number=num,
+    )})
+
+
+def test_10323_closing_keyword_in_negation_does_not_block():
+    # The #10307 incident shape: the body carries a closing keyword in a context
+    # GitHub's parser ignores (here a negated prose clause). The regex finder
+    # matches `Closes #6724` regardless of the surrounding "NOT" -- but GitHub
+    # resolves nothing (pr_closing_refs=set()), so the gate must NOT block even
+    # though another lane claims #6724. The word "closing" itself is NOT a
+    # GitHub keyword and does not match `close[ds]?`; the FP trigger is the
+    # canonical `Closes`/`Fixes`/`Resolves` token in a GitHub-ignored context.
+    body = _body_with("- OUT of scope: NOT actually Closes #6724 (epic sub-delivery).")
+    fetch = _claimed_by_other_issue(6724)
+    v = lcr.check(body, fetch, now=NOW, pr_closing_refs=set())
+    assert v["guard_pass"] is True
+    assert v["closing_issues"] == []
+    assert any("IGNORED_BY_GITHUB" in w for w in v["warnings"])
+
+
+def test_10323_closing_keyword_in_inline_code_span_does_not_block():
+    # `` `Closes #6724` `` inside backticks -- GitHub ignores closing keywords
+    # in inline code. Regex matches, GitHub doesn't -> no block.
+    body = _body_with("Avoid the form `Closes #6724`; use `See #6724` instead.")
+    fetch = _claimed_by_other_issue(6724)
+    v = lcr.check(body, fetch, now=NOW, pr_closing_refs=set())
+    assert v["guard_pass"] is True
+    assert any("IGNORED_BY_GITHUB" in w for w in v["warnings"])
+
+
+def test_10323_closing_keyword_in_fenced_block_does_not_block():
+    # A closing keyword inside a ``` fenced code block is ignored by GitHub.
+    body = _body_with("Example of what NOT to write:\n```\nCloses #6724\n```\n")
+    fetch = _claimed_by_other_issue(6724)
+    v = lcr.check(body, fetch, now=NOW, pr_closing_refs=set())
+    assert v["guard_pass"] is True
+    assert any("IGNORED_BY_GITHUB" in w for w in v["warnings"])
+
+
+def test_10323_real_closing_ref_still_blocks_when_other_lane_claims():
+    # Ratchet (acceptance #4): a REAL `Closes #N` that GitHub resolves (it is
+    # in pr_closing_refs) still blocks when another lane holds a fresh claim.
+    # The fix must make the gate MORE correct, not more permissive.
+    body = _body_with("Closes #6724")
+    fetch = _claimed_by_other_issue(6724)
+    v = lcr.check(body, fetch, now=NOW, pr_closing_refs={6724})
+    assert v["guard_pass"] is False
+    assert v["blocking_issue"] == 6724
+    assert v["blocking_lane"] == "myia-po-2025:CoursIA-2"
+    assert v["closing_issues"] == [6724]
+
+
+def test_10323_none_pr_closing_refs_falls_back_to_regex_with_warning():
+    # Backward compat / fail-open: when closingIssuesReferences is unavailable
+    # (older caller or fetch failure), pr_closing_refs=None -> the gate keeps
+    # the regex-only behaviour (does not disarm) and warns about the gap.
+    body = _body_with("Closes #6724")
+    fetch = _claimed_by_other_issue(6724)
+    v = lcr.check(body, fetch, now=NOW, pr_closing_refs=None)
+    assert v["guard_pass"] is False  # regex still blocks the real ref
+    assert any("unavailable" in w for w in v["warnings"])
+
+
+def test_10323_advisory_absent_not_fired_on_ignored_closing_ref():
+    # lane-claim-absent must not fire on a closing keyword GitHub ignores (code
+    # span) -- consistent with the blocking path.
+    body = _body_with("Avoid `Closes #6724`; use `See #6724`.")
+    fetch = fetcher_from({6724: issue_payload(number=6724)})  # no claim
+    v = lcr.check(body, fetch, now=NOW, pr_closing_refs=set())
+    assert v["guard_pass"] is True
+    assert "lane-claim-absent" not in v["advisory_labels"]
+
+
+def test_10323_cli_pr_closing_refs_arg_parsed(tmp_path):
+    # The CLI accepts --pr-closing-refs and the verdict reflects the cross-check.
+    body_file = tmp_path / "body.md"
+    body_file.write_text(_body_with("Closes #6724"), encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, "scripts/ci/lane_claim_required.py",
+         "--body-file", str(body_file), "--pr-closing-refs", ""],
+        capture_output=True, text=True, check=False,
+    )
+    v = json.loads(proc.stdout)
+    assert v["guard_pass"] is True  # GitHub closes nothing -> no block
+    assert v["closing_issues"] == []
+    assert any("IGNORED_BY_GITHUB" in w for w in v["warnings"])


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA — prev: MED/tooling #10324

Closes #10323

## Summary

For a PR **body**, `closingIssuesReferences` is now authoritative: the regex finder in `lane_claim_required.py` matches a closing keyword even inside contexts GitHub's parser ignores (inline code span, fenced block, prose negation like "NOT actually Closes #N"), which falsely armed the lane-claim gate. The gate now cross-checks regex hits against `closingIssuesReferences` so such a match cannot block alone.

The regex stays authoritative for **commit messages** (scanned by the separate `pr_close_keyword_guard.py` / #10101 gate) where GitHub does not pre-resolve and the squash auto-close trap is real.

## Motivation (#10323)

The lane-claim guard (#10223) reused `grain_tag.find_close_keyword_pr_refs` on the PR body, treating every regex match as a closing reference. That finder matches `close[ds]?|fix(es|ed)?|resolv(e|es|ed) #N` regardless of surrounding context. A PR body explaining "avoid the form `Closes #N`; use `See #N`" or quoting a fenced example with a closing keyword would have armed the gate against an issue GitHub never closes.

## Changes

**`scripts/ci/lane_claim_required.py`** (+96/-16 net additive)
- `check()` gains `pr_closing_refs: set[int] | None`:
  - `None` (arg omitted / fetch failed) -> fall back to the regex finder (backward compatible, does NOT disarm on a network blip), with a warning.
  - a set -> only numbers present in it can block; regex-only hits are logged `IGNORED_BY_GITHUB` and never reach the blocking path.
- `_compute_advisory_labels()` applies the same cross-check so `lane-claim-absent` does not fire on a closing keyword GitHub ignores.
- CLI gains `--pr-closing-refs`; `_parse_closing_refs()` parses it (`None` = unavailable, `""` = empty set).

**`.github/workflows/lane-claim-guard.yml`** (+34): both the `required` and `advisory` jobs fetch `closingIssuesReferences` via `gh pr view` and pass it; on fetch failure they omit the arg (regex fallback + `::warning::`).

**`scripts/tests/test_lane_claim_required.py`** (+108, +7 tests)

## Acceptance grid vs #10323

| Criterion (#10323) | Test | Result |
|---|---|---|
| closing keyword in negation does not block | `test_10323_closing_keyword_in_negation_does_not_block` | pass, `closing_issues==[]`, `IGNORED_BY_GITHUB` warning |
| closing keyword in inline code span does not block | `test_10323_closing_keyword_in_inline_code_span_does_not_block` | pass, warning |
| closing keyword in fenced block does not block | `test_10323_closing_keyword_in_fenced_block_does_not_block` | pass, warning |
| real closing ref still blocks (ratchet not disarmed) | `test_10323_real_closing_ref_still_blocks_when_other_lane_claims` | block, `blocking_issue==6724` |
| fallback warns when closingIssuesReferences unavailable | `test_10323_none_pr_closing_refs_falls_back_to_regex_with_warning` | block (real ref), "unavailable" warning |
| log names the motif when finder and GitHub diverge | `IGNORED_BY_GITHUB` warning emitted per divergent ref | verified |
| regex stays authoritative for commit messages | unchanged `pr_close_keyword_guard.py` (#10101) | out of scope, untouched |

## Tests

- `26 passed` in `test_lane_claim_required.py` (19 existing + 7 new).
- `96 passed` sibling suite (`test_grain_tag.py`, `test_check_lane_claim.py`, `test_pr_close_keyword_guard.py`) -- zero regression.
- CLI smoke: `--pr-closing-refs "6724"` parsed; real ref confirmed and produces a real verdict.
- YAML parsed valid (`yaml.safe_load`).

## Anti-regression check

- Diff is additive (0 real deletions of existing logic; the only `−` lines are 2 field-value renames `issue_nums` -> `confirmed_nums` and the now-redundant `closing_issues: issue_nums`).
- `#8634`/`#8650` symbols in the sibling figure-detector are untouched (different file, different worktree).
- The blocking ratchet holds: a real closing ref that GitHub resolves still blocks when another lane holds a fresh claim.

## Variation note (G-VAR-3)

prev = MED/tooling #10324 (figure-detector per-tile sparse-grid). This is MED/tooling too, but a genuinely distinct subsystem (lane-claim closing-ref cross-check vs figure per-tile metric), each requiring domain reasoning, not a scan-generated variant. Litmus: could the next be generated by scanning the adjacent instance? No.

## Out of scope

Commit-message scanning (`pr_close_keyword_guard.py`) deliberately keeps the regex authoritative -- GitHub does not pre-resolve closing refs in commits, and the squash auto-close trap (#10101) is real there.
