### PR TITLE
feat(translation,#10326): translate_policy column -- T3 honors verbatim

### DIFF
--- a/scripts/translation/extract_cells_to_csv.py
+++ b/scripts/translation/extract_cells_to_csv.py
@@ -51,6 +51,14 @@ from check_perimeter import PIVOT_LANG, TARGET_LANGS  # noqa: E402
 COLUMNS = ["notebook", "cell_id", "cell_type", "src_lang", "src_hash"]
 COLUMNS += [f"text_{lang}" for lang in [PIVOT_LANG] + TARGET_LANGS]
 COLUMNS += [f"hash_{lang}" for lang in [PIVOT_LANG] + TARGET_LANGS]
+# translate_policy (#10326): per-row translation policy declared on the source
+# notebook cell (metadata) and carried through the pipeline. Empty = default
+# (translate if target empty or drifted); ``verbatim`` = never translate (the
+# source FR is the deliverable for every lang -- literary citation, idiomatic
+# example, prompt to reproduce). T3 reads/honors it; T1 only carries it (not a
+# PIVOT_COL, so --update preserves a hand-set value on existing rows). See
+# translate_csv.py VERBATIM_POLICY for the honoring contract.
+COLUMNS += ["translate_policy"]
 
 
 def normalize(text: str) -> str:

--- a/scripts/translation/tests/test_extract_cells_to_csv.py
+++ b/scripts/translation/tests/test_extract_cells_to_csv.py
@@ -357,10 +357,12 @@ def test_target_langs_seven():
 
 def test_columns_order_and_completeness():
     # Schéma ratifié : notebook, cell_id, cell_type, src_lang, src_hash, puis
-    # text_<lang> pour [fr]+TARGET, puis hash_<lang> pour [fr]+TARGET.
+    # text_<lang> pour [fr]+TARGET, puis hash_<lang> pour [fr]+TARGET, puis
+    # translate_policy (#10326 : politique per-row, portée par T1, honorée par T3).
     expected = ["notebook", "cell_id", "cell_type", "src_lang", "src_hash"]
     expected += [f"text_{l}" for l in ["fr"] + e.TARGET_LANGS]
     expected += [f"hash_{l}" for l in ["fr"] + e.TARGET_LANGS]
+    expected += ["translate_policy"]
     assert e.COLUMNS == expected
 
 

--- a/scripts/translation/tests/test_translate_csv.py
+++ b/scripts/translation/tests/test_translate_csv.py
@@ -734,3 +734,244 @@ def test_run_translations_preserves_obsolete_text_on_run_interruption(tmp_path, 
     assert rows[0]["hash_en"] == "oldhash"
     # Sécurité : aucun copier-coller du FR dans la colonne cible.
     assert rows[0]["text_en"] != rows[0]["text_fr"]
+
+
+# =========================================================================== #
+# #10326 — translate_policy: T3 preserve-verbatim (pipeline-honors-policy slice)
+#
+# Problème : T3 (translate_csv.py) traduit toute cellule dont la cible est vide
+# ou dérivée. Aucun moyen de déclarer qu'une cellule NE DOIT PAS être traduite
+# (verbatim) -- or c'est pédagogiquement critique pour les citations littéraires
+# (vers de Hugo dans FT-02-QLoRA-Quantization), les exemples idiomatiques, les
+# prompt/completion à reproduire à l'identique.
+#
+# Fix : colonne ``translate_policy`` dans le schéma CSV (T1 + T3), lue par T3,
+# honorée AVANT le test d'éligibilité. ``verbatim`` => ``text_<lang> := text_fr``
+# (le FR source EST le livrable), aucun appel LLM.
+#
+# Acceptance #10326 couverte par CETTE tranche (1/2/5) :
+#   1. une cellule verbatim traverse T1->T3->T4 sans traduction ni appel LLM ;
+#   2. la politique survit a un ``extract_cells_to_csv.py --update`` (test) ;
+#   5. le log nomme chaque cellule préservée.
+#   Critères 3/4 (déclaration metadata dans le notebook source + 2 cellules Hugo
+#   FT-02 marquées) = follow-up PR (hors scope de cette tranche pipeline).
+# =========================================================================== #
+
+
+# --------------------------------------------------------------------------
+# translation_plan — éligibilité : verbatim court-circuîte AVANT cible-vide
+# --------------------------------------------------------------------------
+def test_translation_plan_excludes_verbatim_row():
+    """Acceptance #10326 critère 1 (côté plan) : une cellule ``verbatim`` n'est
+    JAMAIS éligible, même si toutes ses cibles sont vides. Le court-circuit
+    intervient AVANT le test cible-vide/dérivée pour qu'une cible verbatim vide
+    ne soit jamais envoyée au LLM au premier passage."""
+    rows = [_row("c1", text_fr="Demain, dès l'aube, à l'heure où blanchit la campagne",
+                 translate_policy="verbatim")]
+    # Toutes les cibles vides MAIS verbatim => plan vide.
+    assert list(t3.translation_plan(rows, t3.TARGETS)) == []
+
+
+def test_translation_plan_verbatim_short_circuits_before_drift():
+    """Le court-circuit verbatim domine même un drift déclaré : une cellule
+    verbatim dont la source FR a dérivé n'est PAS retraduite (la politique est
+    explicite, elle prime sur la dérive). On vérifie l'orthogonalité."""
+    rows = [_row("c1", text_fr="citation littéraire", translate_policy="verbatim")]
+    drifted = {(0, lang) for lang in t3.TARGETS}  # drift sur toutes les langues
+    assert list(t3.translation_plan(rows, t3.TARGETS, drifted=drifted)) == []
+
+
+def test_translation_plan_legacy_row_without_policy_key_is_eligible():
+    """Rétrocompat : un CSV SANS la colonne ``translate_policy`` (extraction
+    legacy pré-#10326) est lu par DictReader sans la clé. ``row.get(..., "")``
+    => "" != "verbatim" => comportement par défaut (éligible). Aucune
+    régression sur les lots existants."""
+    rows = [_row("c1", text_fr="bonjour")]
+    del rows[0]["translate_policy"]  # simule un CSV legacy sans la colonne
+    plan = list(t3.translation_plan(rows, ["en"]))
+    assert (0, "en") in plan  # éligible par défaut
+
+
+def test_translation_plan_unknown_policy_value_falls_back_to_default():
+    """Une valeur de politique non reconnue (ex. ``verbatim-with-gloss``,
+    follow-up non implémenté) retombe sur le comportement par défaut
+    (éligible) -- elle n'est PAS traitée comme verbatim."""
+    rows = [_row("c1", text_fr="x", translate_policy="verbatim-with-gloss")]
+    assert (0, "en") in list(t3.translation_plan(rows, ["en"]))
+
+
+def test_translation_plan_policy_whitespace_tolerant():
+    """``' verbatim '`` (espaces accidentels) est quand même honoré -- le
+    ``.strip()`` dans le test évite un faux négatif sur une déclaration
+    éditée à la main."""
+    rows = [_row("c1", text_fr="x", translate_policy="  verbatim  ")]
+    assert list(t3.translation_plan(rows, ["en"])) == []
+
+
+# --------------------------------------------------------------------------
+# run_translations — contrat verbatim : text_<lang> := text_fr, AUCUN appel LLM
+# --------------------------------------------------------------------------
+def test_run_translations_verbatim_copies_fr_to_all_langs_no_llm(tmp_path, monkeypatch):
+    """Acceptance #10326 critère 1 (côté exécution) : une cellule verbatim
+    reçoit ``text_<lang> := text_fr`` ET ``hash_<lang> := hash_fr`` pour CHAQUE
+    langue cible, sans AUCUN appel provider (le compteur d'appels reste à 0).
+    Le FR source EST le livrable pour toutes les langues."""
+    calls = []
+    monkeypatch.setattr(t3, "_provider_keys", lambda: [("stub-model", "k", "http://x")])
+    monkeypatch.setattr(t3, "translate_markdown", _stub_translator(calls))
+
+    fr_text = "Demain, dès l'aube, à l'heure où blanchit la campagne"
+    rows = [_row("hugo1", text_fr=fr_text, translate_policy="verbatim")]
+    out = str(tmp_path / "out.csv")
+    done, fails = t3.run_translations(rows, ["en", "es", "ar"], False, out, False)
+
+    assert done == 0 and fails == 0  # aucune traduction (plan vide)
+    assert calls == []  # AUCUN appel LLM -- critère 1
+    expected_hash = t3.cell_hash(fr_text)
+    for lang in ("en", "es", "ar"):
+        assert rows[0][f"text_{lang}"] == fr_text  # text_<lang> := text_fr
+        assert rows[0][f"hash_{lang}"] == expected_hash  # hash cohérent
+
+
+def test_run_translations_verbatim_mixed_with_normal_rows(tmp_path, monkeypatch):
+    """Un lot mixte (1 verbatim + 1 normale) : seule la normale est traduite
+    (1 appel LLM), la verbatim est préservée. Prouve que verbatim et traduction
+    coexistent sans interférence."""
+    calls = []
+    monkeypatch.setattr(t3, "_provider_keys", lambda: [("stub-model", "k", "http://x")])
+    monkeypatch.setattr(t3, "translate_markdown", _stub_translator(calls))
+
+    fr_citation = "Ô temps, suspends ton vol"
+    rows = [
+        _row("c1", text_fr=fr_citation, translate_policy="verbatim"),
+        _row("c2", text_fr="paragraphe normal à traduire"),
+    ]
+    out = str(tmp_path / "out.csv")
+    done, fails = t3.run_translations(rows, ["en"], False, out, False)
+
+    assert done == 1 and fails == 0  # seule c2 traduite
+    assert len(calls) == 1  # 1 appel LLM (c2), pas 2
+    assert rows[0]["text_en"] == fr_citation  # c1 verbatim préservée
+    assert rows[1]["text_en"].startswith("[en]")  # c2 traduite par le stub
+
+
+def test_run_translations_verbatim_logs_each_preserved_cell(tmp_path, monkeypatch, capsys):
+    """Acceptance #10326 critère 5 : le log nomme CHAQUE cellule préservée
+    (notebook + cell_id + politique), jamais silencieux. Un compteur final
+    récapitule."""
+    monkeypatch.setattr(t3, "_provider_keys", lambda: [("stub-model", "k", "http://x")])
+    monkeypatch.setattr(t3, "translate_markdown", _stub_translator([]))
+
+    rows = [
+        _row("c1", text_fr="citation un", translate_policy="verbatim",
+             notebook="FT-02-QLoRA-Quantization.ipynb"),
+        _row("c2", text_fr="citation deux", translate_policy="verbatim",
+             notebook="FT-02-QLoRA-Quantization.ipynb"),
+    ]
+    out = str(tmp_path / "out.csv")
+    t3.run_translations(rows, ["en"], False, out, False)
+    err = capsys.readouterr().err
+    # Chaque cellule est nommée individuellement (critère 5 : pas silencieux).
+    assert "[verbatim] FT-02-QLoRA-Quantization.ipynb c1 preserved" in err
+    assert "[verbatim] FT-02-QLoRA-Quantization.ipynb c2 preserved" in err
+    # Compteur récapitulatif.
+    assert "2 cellule(s) préservée(s)" in err
+
+
+def test_run_translations_verbatim_persisted_when_plan_empty(tmp_path, monkeypatch):
+    """Edge case (#10326) : si TOUTES les cellules sont verbatim, le plan est
+    vide et la write_csv incrémentale (dans la boucle plan) ne s'exécute jamais.
+    Le bloc verbatim persiste les copies au CSV lui-même dans ce cas, sinon les
+    copies resteraient en mémoire (et le CSV de sortie serait vide)."""
+    monkeypatch.setattr(t3, "_provider_keys", lambda: [("stub-model", "k", "http://x")])
+    monkeypatch.setattr(t3, "translate_markdown", _stub_translator([]))
+
+    fr_text = "citation verbatim unique"
+    rows = [_row("c1", text_fr=fr_text, translate_policy="verbatim")]
+    out = tmp_path / "out.csv"
+    t3.run_translations(rows, ["en", "es"], False, str(out), False)
+
+    # Le CSV de sortie DOIT contenir les copies verbatim persistées.
+    reloaded = t3.load_csv(str(out))
+    assert len(reloaded) == 1
+    assert reloaded[0]["text_en"] == fr_text
+    assert reloaded[0]["text_es"] == fr_text
+    assert reloaded[0]["translate_policy"] == "verbatim"
+
+
+# --------------------------------------------------------------------------
+# Schéma pipeline — translate_policy dans T1 ET T3 (contrat #10326)
+# --------------------------------------------------------------------------
+def test_translate_policy_in_both_t1_and_t3_schema():
+    """Acceptance #10326 (schéma) : ``translate_policy`` est une colonne
+    canonique du pipeline, présente dans T1 (extraction/write) ET T3 (honorer).
+    Verrouille le contrat de schéma pour empêcher une divergence silencieuse."""
+    import extract_cells_to_csv as t1
+    assert "translate_policy" in t1.COLUMNS
+    assert "translate_policy" in t3.CSV_COLUMNS
+
+
+def test_translate_policy_not_in_t1_pivot_cols():
+    """Acceptance #10326 critère 2 (précondition) : ``translate_policy`` n'est
+    PAS dans ``PIVOT_COLS``, donc T1 ``--update`` ne l'écrase PAS sur une ligne
+    existante -- une valeur posée à la main survive. (Le test fonctionnel de
+    survie est ``test_t1_update_preserves_translate_policy`` ci-dessous.)"""
+    import extract_cells_to_csv as t1
+    import inspect
+    src = inspect.getsource(t1.update_existing_csv)
+    # On extrait PIVOT_COLS du source (défini localement dans la fonction).
+    import re
+    m = re.search(r'PIVOT_COLS\s*=\s*\(([^)]*)\)', src)
+    assert m, "PIVOT_COLS introuvable dans update_existing_csv"
+    pivot = m.group(1)
+    assert "translate_policy" not in pivot
+
+
+def test_t1_update_preserves_translate_policy(tmp_path):
+    """Acceptance #10326 critère 2 (fonctionnel) : la politique survit à un
+    ``extract_cells_to_csv.py --update``. On part d'une ligne existante avec
+    ``translate_policy=verbatim``, on passe un fresh_row (re-extraction, qui
+    amène ``translate_policy=""`` par défaut), et on vérifie que la valeur
+    verbatim posée à la main EST PRÉSERVÉE (non écrasée)."""
+    import extract_cells_to_csv as t1
+
+    citation = "Ô Civile ! ô Baptistine !"
+    existing = [_row_t1("c1", citation, translate_policy="verbatim")]
+    # fresh_rows : re-extraction simulée, translate_policy="" par défaut.
+    fresh = [_row_t1("c1", citation, translate_policy="")]
+
+    updated, stats = t1.update_existing_csv(
+        existing, fresh, target_notebooks={"nb.ipynb"})
+
+    assert stats["updated"] == 0  # PIVOT_COLS inchangés (même source)
+    assert updated[0]["translate_policy"] == "verbatim"  # PRÉSERVÉ, pas écrasé
+    assert updated[0]["text_fr"] == citation  # contenu intact
+
+
+def test_t1_update_preserves_default_empty_policy_on_unchanged_source(tmp_path):
+    """Cas nominal : une ligne normale (translate_policy="") reste "" après
+    update -- pas de side-effect du guard. Confirme que la préservation n'est
+    pas spécifique à ``verbatim`` mais à toute valeur non-PIVOT."""
+    import extract_cells_to_csv as t1
+    existing = [_row_t1("c1", "texte normal", translate_policy="")]
+    fresh = [_row_t1("c1", "texte normal", translate_policy="")]
+    updated, _ = t1.update_existing_csv(
+        existing, fresh, target_notebooks={"nb.ipynb"})
+    assert updated[0]["translate_policy"] == ""
+
+
+# --------------------------------------------------------------------------
+# Helper local #10326 — ligne CSV au schéma T1 (COLUMNS ordre canonique)
+# --------------------------------------------------------------------------
+def _row_t1(cell_id, text_fr, translate_policy="", notebook="nb.ipynb"):
+    """Ligne CSV au schéma ``extract_cells_to_csv.COLUMNS`` (et non t3.CSV_COLUMNS)
+    pour les tests T1 ``--update``. On importe T1 dans le test, pas ici, pour
+    éviter un import au niveau module (T1 n'est pas sur sys.path par défaut)."""
+    import extract_cells_to_csv as t1
+    r = {col: "" for col in t1.COLUMNS}
+    r.update(notebook=notebook, cell_id=cell_id, cell_type="markdown",
+             src_lang="fr", text_fr=text_fr)
+    r["src_hash"] = t1.cell_hash(text_fr)
+    r["hash_fr"] = r["src_hash"]
+    r["translate_policy"] = translate_policy
+    return r

--- a/scripts/translation/translate_csv.py
+++ b/scripts/translation/translate_csv.py
@@ -128,7 +128,22 @@ CSV_COLUMNS = [
     "notebook", "cell_id", "cell_type", "src_lang", "src_hash",
     "text_fr", "text_en", "text_es", "text_ar", "text_fa", "text_zh", "text_ru", "text_pt",
     "hash_fr", "hash_en", "hash_es", "hash_ar", "hash_fa", "hash_zh", "hash_ru", "hash_pt",
+    # translate_policy (#10326): per-row translation policy. Empty = default
+    # (translate if target empty or drifted). ``verbatim`` = never translate,
+    # ``text_<lang> := text_fr`` is preserved as-is (no LLM call) -- for cells
+    # whose pedagogical value is the source text itself (literary citation,
+    # idiomatic example, prompt/completion to reproduce verbatim). Declared on
+    # the source notebook cell (metadata) and carried through T1 --update; T3
+    # short-circuits before the eligibility test so an empty target on a
+    # verbatim row is never sent to the LLM. Backward compatible: a CSV without
+    # the column reads as empty (DictReader) = default translate.
+    "translate_policy",
 ]
+
+# Recognised translate_policy values (#10326). ``verbatim`` is honored by T3 in
+# this slice; ``verbatim-with-gloss`` (preserve FR + add a translated note) is a
+# follow-up (needs T4 renderer changes) and currently falls back to default.
+VERBATIM_POLICY = "verbatim"
 
 
 def load_csv(path: str) -> list[dict]:
@@ -259,6 +274,13 @@ def translation_plan(rows, langs, include_code=False, drifted=None):
         fr = row.get("text_fr", "")
         if not fr.strip():
             continue
+        # #10326 preserve-verbatim: a row marked ``verbatim`` is never eligible,
+        # even if its target is empty -- the source FR IS the deliverable for
+        # every lang (literary citation, idiomatic example, prompt to reproduce).
+        # Short-circuit BEFORE the target_empty/drifted test so an empty verbatim
+        # target is not sent to the LLM on the first pass.
+        if row.get("translate_policy", "").strip() == VERBATIM_POLICY:
+            continue
         for lang in langs:
             target_empty = not row.get(f"text_{lang}", "").strip()
             if target_empty:
@@ -384,6 +406,32 @@ def run_translations(rows, langs, include_code, out_path, smoke, limit=None, dri
         plan = plan[:limit]
     total = len(plan)
     print(f"[plan] {total} traductions à produire ({len(langs)} langue(s))", file=sys.stderr)
+
+    # #10326 preserve-verbatim (acceptance crit 1 + 5): a row marked ``verbatim``
+    # is never sent to the LLM. T3's contract for it is ``text_<lang> := text_fr``
+    # -- the source FR IS the deliverable for every lang (literary citation,
+    # idiomatic example, prompt to reproduce). We copy FR into each target here
+    # (no LLM call) and log every preserved cell so the count is visible, never
+    # silent. Safe at the CSV layer: parity (FR_CONTAM) runs on RENDERED _en
+    # notebooks (T4 pipeline, follow-up) not on the raw CSV, and sync drift is
+    # keyed on src_hash (unchanged). The rows were excluded from the plan above.
+    verbatim = [r for r in rows if r.get("translate_policy", "").strip() == VERBATIM_POLICY]
+    for r in verbatim:
+        fr_text = r.get("text_fr", "")
+        fr_hash = r.get("hash_fr") or cell_hash(fr_text)
+        for lang in langs:
+            r[f"text_{lang}"] = fr_text
+            r[f"hash_{lang}"] = fr_hash
+        print(f"[verbatim] {r.get('notebook','').split('/')[-1]} "
+              f"{r.get('cell_id','')[:8]} preserved (translate_policy=verbatim, "
+              f"text_<lang> := text_fr, no LLM call)", file=sys.stderr)
+    if verbatim:
+        print(f"[verbatim] {len(verbatim)} cellule(s) préservée(s) — "
+              f"aucune traduction (#10326)", file=sys.stderr)
+        # Persist the text_<lang> := text_fr copies even when the plan is empty
+        # (all cells verbatim): the resume-safe write_csv inside the plan loop
+        # never runs in that case, so the copies would stay in memory only.
+        write_csv(out_path, rows)
 
     done = fails = 0
     for idx, lang in plan:


### PR DESCRIPTION
Grain: MED/convention — lane myia-po-2025:CoursIA-2 — prev: MED/tooling #10327

See #10326

## Summary

Adds a per-row `translate_policy` column to the translation CSV schema (T1 `extract_cells_to_csv.COLUMNS` + T3 `translate_csv.CSV_COLUMNS`). The `verbatim` value is honored by T3 **before** the eligibility test: a verbatim row is never sent to the LLM, and `text_<lang> := text_fr` (the source FR is the deliverable for every lang) is copied with a coherent `hash_<lang> := hash_fr`. Until now T3 translated any cell whose target was empty or drifted — there was no way to declare that a cell must **not** be translated.

## Motivation (#10326)

Pedagogically, some cells lose their value if translated:
- **literary citations** — Hugo's verses in `FT-02-QLoRA-Quantization` must read in the original French;
- **idiomatic examples** — the example IS the French idiom;
- **prompt / completion strings** to reproduce verbatim — translating them breaks the reproduction contract.

T3 (`translate_csv.py`) had no opt-out: every markdown/code cell with an empty or drifted target was sent to the LLM. This adds an explicit, per-row policy.

## Changes (4 files, +300/-1, single subsystem)

**`scripts/translation/translate_csv.py`** (T3 — honors the policy)
- `CSV_COLUMNS` gains `translate_policy`; new constant `VERBATIM_POLICY = "verbatim"`.
- `translation_plan()` short-circuits a verbatim row **before** the target-empty/drifted test, so an empty verbatim target is never sent to the LLM on the first pass. The short-circuit also dominates a declared drift (the policy is explicit).
- `run_translations()` copies `text_fr`/`hash_fr` into every `text_<lang>`/`hash_<lang>` for verbatim rows (no LLM call) and logs each preserved cell (`[verbatim] <notebook> <cell_id> preserved`) plus a final count. When the plan is empty (all cells verbatim), the copies are persisted to the CSV directly — otherwise the resume-safe `write_csv` inside the plan loop never runs.

**`scripts/translation/extract_cells_to_csv.py`** (T1 — carries the column)
- `COLUMNS` gains `translate_policy`. New extractions write it empty (default = translate). It is **not** a `PIVOT_COL`, so `--update` preserves a hand-set value on existing rows (acceptance crit 2, proven by `test_t1_update_preserves_translate_policy`).

**`scripts/translation/tests/test_translate_csv.py`** (+13 tests)
- Plan eligibility: verbatim excluded even with empty target / even with declared drift; legacy CSV without the column stays eligible (backward compat); unknown value (`verbatim-with-gloss`) falls back to default; whitespace-tolerant.
- Execution contract: verbatim copies FR to all langs with **zero** provider calls; mixed lot (1 verbatim + 1 normal) translates only the normal row; each preserved cell is logged by name + count; copies persisted when plan empty.
- Schema: `translate_policy` in both T1 and T3; not in T1 `PIVOT_COLS`; survives `--update`.

**`scripts/translation/tests/test_extract_cells_to_csv.py`** (+1 line)
- `test_columns_order_and_completeness` schema assertion updated to include the new trailing column.

## Backward compatibility

A CSV without the `translate_policy` column (legacy extraction pre-#10326) is read by `DictReader` without the key; `row.get("translate_policy", "")` returns `"" != "verbatim"` → default behavior (eligible). Proven by `test_translation_plan_legacy_row_without_policy_key_is_eligible`. No migration needed.

## Acceptance grid vs #10326

| Criterion (#10326) | This slice | Status |
|---|---|---|
| verbatim cell traverses T1->T3->T4 without translation/LLM call | T3 short-circuit + copy, 0 provider calls (`test_run_translations_verbatim_copies_fr_to_all_langs_no_llm`) | delivered |
| policy survives `extract_cells_to_csv.py --update` (test) | `test_t1_update_preserves_translate_policy` — verbatim value preserved, not overwritten | delivered |
| policy declared in source notebook (metadata), not just CSV | metadata-in-notebook reader | **follow-up PR** |
| 2 FT-02 Hugo cells marked + _en render preserves FR | needs metadata reader + T4 render check | **follow-up PR** |
| log names each preserved cell | `[verbatim] <nb> <cell_id> preserved` per cell + count (`test_run_translations_verbatim_logs_each_preserved_cell`) | delivered |

## Tests

- `267 passed` full translation suite (`scripts/translation/tests/`) — 254 existing + 13 new, zero regression.
- New tests cover all 5 pipeline-honors-policy behaviors + backward compat + the plan-empty persistence edge case.
- Hermetic: stdlib-only, no network (gate `ENABLED=False`, providers stubbed, `translate_markdown` stubbed).

## Why not `Closes #10326`

Criteria 3 and 4 (metadata-in-notebook declaration + the 2 FT-02 Hugo cells marked and rendered) are explicitly a **follow-up PR**: they need a metadata reader in T1 (read `cell.metadata.translate_policy` into the CSV) and a T4 render check that the `_en` notebook preserves the FR for those cells. This slice is the pipeline-honors-policy foundation they build on. Using `See #10326` to keep the issue open.

## Variation note (G-VAR-3)

prev = MED/tooling #10327 (lane-claim closing-ref cross-check). This is MED/convention too, but a genuinely distinct subsystem (translation-pipeline per-row policy vs CI lane-claim gate), each requiring domain reasoning, not a scan-generated variant. Litmus: could the next be generated by scanning the adjacent instance? No — designing a translation opt-out contract is not derivable from a CI guard fix.

## Heads-up

po-2023 owns the i18n/translation turf. `[CLAIMED]` posted on dashboard with a courtesy heads-up before starting; no open PR touched `translate_csv.py`/`extract_cells_to_csv.py` at claim time (L898 clean). If po-2023 flags a different design for the verbatim policy (e.g. policy encoded in `cell_id` prefix vs a column), I'll defer.
