### PR TITLE
feat(guard,#10319): per-region tile-uniformity metric for degenerate-figure detector (advisory phase 1)

### DIFF
--- a/scripts/notebook_tools/detect_blank_figures.py
+++ b/scripts/notebook_tools/detect_blank_figures.py
@@ -41,14 +41,17 @@ retenue que sur la taille).
 
 Known blind spots (hors scope par design)
 -----------------------------------------
-- FIGURE PLEINE MAIS VIDE : un PNG full-size (ex 690x590) entierement blanc /
-  transparent (un plot qui a trace des axes vides). Detecter ca demande une
-  analyse pixel (variance de couleur) -- plus lourd et bruite. Hors scope : cet
-  outil cible la degenerescence de dimension/taille (le cas #6891 verifie), pas
-  le contenu semantique de l'image.
+- FIGURE PLEINE MAIS VIDE : un PNG full-size entierement blanc / transparent
+  (un plot qui a trace des axes vides). Couvert en phase **advisory** depuis
+  #10319 par la metrique per-tile (`partial_empty_tiles`) : grille dont une
+  majorite de tuiles sont quasi-uniformes (pstdev canal < UNIFORM_TILE_STD)
+  alors que d'autres sont riches. Phase 1 = label (ne fait PAS echouer
+  `--check`); `--strict` pour escalader, mesure du taux de FP d'abord.
 - IMAGE LEGITIMEMENT PETITE : une icone / un sprite / un QR code volontairement
   petit. Rare en notebook pedagogique (les sorties image sont des figures). Si
-  rencontre, l'exclure au cas par cas -- l'outil est read-only.
+  rencontre, l'exclure au cas par cas -- l'outil est read-only. Les images
+  trop petites pour etre tile-analysees (coté < _MIN_SIDE_FOR_TILING) sont
+  ignorees par la metrique per-tile (pas de regression de la porte #8634).
 
 Usage
 -----
@@ -98,6 +101,32 @@ MIN_BYTES = 1024    # o  : un PNG decode < 1 Ko ne porte pas de vraie figure
 MIN_DISTINCT_COLORS = 4  # nb de couleurs RGB distinctes en dessous duquel une
                          # petite image est consideree sans contenu reel
 
+# --- Per-region (tile) uniformity gate (#10319) ---
+# Le detecteur global (dimensions + bytes + distinct colors) rate le cas
+# "grille partiellement vide" : une grande image globalement riche peut
+# cacher des regions vides au milieu de regions pleines. Le cas fondateur
+# est la cellule 12 de 02-7-CogVideoX-Text-to-Video.ipynb (PR #10305) :
+# une grille 4x4 1440x960 / 955 KB / 134k couleurs globales OU les rangées
+# 1-2 sont des cadres vides (std canal ~4-12) et les rangées 3-4 des
+# pommes rendues (std ~57-71). Aucune metrique globale ne le voit, le
+# signal est INTRA-image (contraste vide/plein).
+#
+# On ajoute une metrique per-tile : nombre de tuiles OU la dispersion par
+# canal (pstdev) est quasi nulle. Le seuil UNIFORM_TILE_STD=15.0 est
+# calibre sur le cas fondateur (vides std=4-12, pleines std=57+) avec
+# marge suffisante pour absorber les palettes matplotlib academic sur
+# blanc (L781-L2) qui presentent un std modere par tuile.
+#
+# Phase 1 (acceptance #10319 critere 4) : ADVISORY (label) -- les
+# findings "partial_empty_tiles" sont rapportes mais ne font PAS
+# echouer `--check`. Le blocage strict est cable via `--strict` (off
+# par defaut) pour permettre la mesure du taux de faux positifs avant
+# de basculer en regle dure dans un second grain.
+UNIFORM_TILE_STD = 15.0          # pstdev canal < ce seuil => tuile quasi vide
+PARTIAL_EMPTY_FRACTION = 0.5     # >= cette fraction de tuiles low-variance => signal
+_MIN_TILES_FOR_ANALYSIS = 4      # ne pas tile-analyser les images trop petites
+_MIN_SIDE_FOR_TILING = 16        # chaque cote doit faire >= ce nb de px apres division
+
 _IMAGE_MIMES = ("image/png", "image/jpeg")
 _PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
@@ -146,6 +175,97 @@ def _flattened_pixels(im):
     return getter()
 
 
+def _tile_uniformity_finding(
+    raw: bytes,
+    tiles: tuple[int, int] | None = None,
+) -> dict | None:
+    """Detect a 'partial-empty grid' (grille partiellement vide) signature (#10319).
+
+    Renvoie un finding si au moins `PARTIAL_EMPTY_FRACTION` des tuiles sont
+    quasi-uniformes (pstdev canal < `UNIFORM_TILE_STD`) ET qu'au moins une
+    tuile est riche : c'est le CONTRASTE intra-image qui porte le signal
+    (pas le niveau absolu -- une image entierement vide est traitee
+    separement par `_has_real_content` et sort en `tiny_payload`/`partial`
+    via d'autres voies).
+
+    Si `tiles` est fourni (rows, cols), la grille est figee ; sinon on prend
+    `g = clamp(min(w,h)//128, 2, 8)` -> g x g (4x4 sur l'image reelle 1440x960
+    du cas fondateur #10305). Renvoie `None` si PIL indisponible, image
+    indecodable, trop petite pour tuiler (gardes `_MIN_TILES_FOR_ANALYSIS`
+    et `_MIN_SIDE_FOR_TILING`) -- pas de regression de couverture pour les
+    images legitimes mais petites (pixel-art #8634, QR codes).
+    """
+    try:
+        import io
+        import statistics
+
+        from PIL import Image
+
+        im = Image.open(io.BytesIO(raw)).convert("RGB")
+    except Exception:
+        return None
+
+    w, h = im.size
+    if w == 0 or h == 0:
+        return None
+
+    if tiles is not None:
+        rows, cols = tiles
+    else:
+        # Adaptive grid (#10319) : on maille pour qu'un cote de tuile fasse
+        # ~64 px, soit ~4 sous-graphes sur la dimension la plus courte d'une
+        # figure pedagogique typique. Le clamp [2, 8] borne le cout (8x8=64
+        # tuiles, chacune scannee integralement) et donne au minimum 2x2=4
+        # tuiles sur les figures modulaires compactes (un 2x2 subplots).
+        # Verifie firsthand sur l'image reelle #10305 (1440x960) : g=8 ->
+        # 50% tuiles low-variance (les rangées vides), finding emis.
+        g = max(2, min(8, min(w, h) // 64))
+        rows, cols = g, g
+
+    total = rows * cols
+    if total < _MIN_TILES_FOR_ANALYSIS:
+        return None
+    tile_w = w // cols
+    tile_h = h // rows
+    if tile_w < _MIN_SIDE_FOR_TILING or tile_h < _MIN_SIDE_FOR_TILING:
+        return None
+
+    low = 0
+    for r in range(rows):
+        for c in range(cols):
+            box = (c * tile_w, r * tile_h, (c + 1) * tile_w, (r + 1) * tile_h)
+            tile = im.crop(box)
+            pixels = _flattened_pixels(tile)
+            rs = [p[0] for p in pixels]
+            gs = [p[1] for p in pixels]
+            bs = [p[2] for p in pixels]
+            mean_std = (
+                statistics.pstdev(rs) + statistics.pstdev(gs) + statistics.pstdev(bs)
+            ) / 3.0
+            if mean_std < UNIFORM_TILE_STD:
+                low += 1
+
+    rich = total - low
+    if rich < 1:
+        # Toutes les tuiles quasi-vides : c'est un autre cas (image entierement
+        # plate, pas un grille partiellement vide). Le gate global l'a deja
+        # remonte via _has_real_content / taille si applicable. On ne double
+        # pas le diagnostic ici.
+        return None
+    if low / total < PARTIAL_EMPTY_FRACTION:
+        return None
+
+    return {
+        "reason": (
+            f"partial_empty_tiles({low}/{total} low-variance @{rows}x{cols}, "
+            f"std<{UNIFORM_TILE_STD})"
+        ),
+        "tiles": [rows, cols],
+        "low_variance_tiles": low,
+        "rich_tiles": rich,
+    }
+
+
 def _has_real_content(raw: bytes, min_colors: int = MIN_DISTINCT_COLORS) -> bool | None:
     """Return True if the image carries enough distinct colors to be a real figure.
 
@@ -174,8 +294,21 @@ def _has_real_content(raw: bytes, min_colors: int = MIN_DISTINCT_COLORS) -> bool
         return None
 
 
-def _classify_image(mime: str, raw: bytes, min_dim: int, min_bytes: int) -> dict | None:
-    """Return a finding dict if the image is degenerate, else None."""
+def _classify_image(
+    mime: str,
+    raw: bytes,
+    min_dim: int,
+    min_bytes: int,
+    tiles: tuple[int, int] | None = None,
+) -> dict | None:
+    """Return a finding dict if the image is degenerate, else None.
+
+    Blocking findings (degenerate_dimensions, tiny_payload) are the canonical
+    gate -- they FAIL `--check`. The per-region tile uniformity metric (#10319)
+    is ADVISORY: only emitted when the image PASSES the global checks (the
+    documented blind spot), and tagged with `advisory=True` so the CLI can
+    choose whether to escalate to a hard failure (--strict).
+    """
     reasons = []
     size = len(raw)
     dims = _png_dimensions(raw) if mime == "image/png" else None
@@ -193,17 +326,39 @@ def _classify_image(mime: str, raw: bytes, min_dim: int, min_bytes: int) -> dict
         if _has_real_content(raw) is not True:
             reasons.append(f"tiny_payload({size}B)")
 
-    if not reasons:
-        return None
-    return {
-        "mime": mime,
-        "bytes": size,
-        "dimensions": list(dims) if dims else None,
-        "reasons": reasons,
-    }
+    if reasons:
+        return {
+            "mime": mime,
+            "bytes": size,
+            "dimensions": list(dims) if dims else None,
+            "reasons": reasons,
+            "advisory": False,
+        }
+
+    # Phase advisory per-region (#10319) : on ne tile-analyse QUE les images
+    # qui passent les 3 metriques globales -- c'est precisement le trou
+    # documente (grille partiellement vide). Les images deja flaggees par
+    # les metriques globales n'ont pas besoin du deuxieme avis.
+    tile = _tile_uniformity_finding(raw, tiles=tiles)
+    if tile:
+        return {
+            "mime": mime,
+            "bytes": size,
+            "dimensions": list(dims) if dims else None,
+            "reasons": [tile["reason"]],
+            "advisory": True,
+            "tile_detail": {k: tile[k] for k in ("tiles", "low_variance_tiles", "rich_tiles")},
+        }
+
+    return None
 
 
-def detect_cell(cell: dict, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES) -> list[dict]:
+def detect_cell(
+    cell: dict,
+    min_dim: int = MIN_DIM,
+    min_bytes: int = MIN_BYTES,
+    tiles: tuple[int, int] | None = None,
+) -> list[dict]:
     """Return findings (one per degenerate image output) for a code cell."""
     findings = []
     for oi, out in enumerate(_cell_outputs(cell)):
@@ -214,13 +369,18 @@ def detect_cell(cell: dict, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES) 
             raw = _decode_image(data[mime])
             if raw is None:
                 continue
-            finding = _classify_image(mime, raw, min_dim, min_bytes)
+            finding = _classify_image(mime, raw, min_dim, min_bytes, tiles=tiles)
             if finding:
                 findings.append({"output_index": oi, **finding})
     return findings
 
 
-def scan_notebook(path: Path, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES) -> dict:
+def scan_notebook(
+    path: Path,
+    min_dim: int = MIN_DIM,
+    min_bytes: int = MIN_BYTES,
+    tiles: tuple[int, int] | None = None,
+) -> dict:
     """Return a result dict for one notebook: path, hits[], error."""
     try:
         with open(path, encoding="utf-8") as f:
@@ -232,7 +392,7 @@ def scan_notebook(path: Path, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES
     for ci, cell in enumerate(nb.get("cells", [])):
         if cell.get("cell_type") != "code":
             continue
-        for finding in detect_cell(cell, min_dim, min_bytes):
+        for finding in detect_cell(cell, min_dim, min_bytes, tiles=tiles):
             hits.append({"cell_index": ci, **finding})
     return {"path": str(path), "kernel": _kernel(nb), "hits": hits, "error": None}
 
@@ -262,11 +422,13 @@ def _iter_notebooks(root: Path, family: str | None):
 
 def _human_report(results: list[dict]) -> str:
     total_hits = sum(len(r["hits"]) for r in results)
+    total_advisory = sum(1 for r in results for h in r["hits"] if h.get("advisory"))
+    total_blocking = total_hits - total_advisory
     affected = [r for r in results if r["hits"]]
     errored = [r for r in results if r.get("error")]
     lines = [
         f"Notebooks scanned  : {len(results)}",
-        f"Degenerate figures : {total_hits}",
+        f"Degenerate figures : {total_hits} (blocking {total_blocking}, advisory {total_advisory})",
         f"Affected notebooks : {len(affected)}",
         "",
     ]
@@ -281,14 +443,27 @@ def _human_report(results: list[dict]) -> str:
         lines.append(f"## {short}  [{r['kernel']}]")
         for h in r["hits"]:
             reasons = ", ".join(h["reasons"])
-            lines.append(f"  - cell [{h['cell_index']}] output[{h['output_index']}] {h['mime']}: {reasons}")
+            tag = "ADVISORY" if h.get("advisory") else "BLOCKING"
+            lines.append(f"  - [{tag}] cell [{h['cell_index']}] output[{h['output_index']}] {h['mime']}: {reasons}")
         lines.append("")
     lines.append(
         "FIX: re-execute the cell in the real environment (QC Cloud research for "
         "QuantBook, local kernel for matplotlib) and commit the real figure -- "
-        "Stop&Repair, never scrub/delete to hide (secrets-hygiene rule 6)."
+        "Stop&Repair, never scrub/delete to hide (secrets-hygiene rule 6). "
+        "ADVISORY findings (#10319) do not fail `--check`; pass `--strict` "
+        "to escalate them, but measure FP rate first."
     )
     return "\n".join(lines)
+
+
+def _parse_tiles_arg(value: str) -> tuple[int, int]:
+    """Parse '4x4' / '4X4' / '4×4' into (rows, cols)."""
+    sep_chars = ("x", "X", "×", ",")
+    for sep in sep_chars:
+        if sep in value:
+            r, c = value.split(sep, 1)
+            return (int(r.strip()), int(c.strip()))
+    raise argparse.ArgumentTypeError(f"--tiles expects RxC (e.g. '4x4'), got {value!r}")
 
 
 def main(argv=None) -> int:
@@ -300,9 +475,16 @@ def main(argv=None) -> int:
     parser.add_argument("--family", help="Top-level family under MyIA.AI.Notebooks/ (e.g. QuantConnect)")
     parser.add_argument("--root", default=".", help="Repo root (default: cwd)")
     parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
-    parser.add_argument("--check", action="store_true", help="Exit 1 if any degenerate figure (CI-ready)")
+    parser.add_argument("--check", action="store_true", help="Exit 1 if any blocking degenerate figure (CI-ready)")
+    parser.add_argument("--strict", action="store_true", help="Also fail --check on ADVISORY partial-empty-tiles findings (#10319)")
     parser.add_argument("--min-dim", type=int, default=MIN_DIM, help=f"Min figure side px (default {MIN_DIM})")
     parser.add_argument("--min-bytes", type=int, default=MIN_BYTES, help=f"Min decoded bytes (default {MIN_BYTES})")
+    parser.add_argument(
+        "--tiles",
+        type=_parse_tiles_arg,
+        default=None,
+        help="Force tile grid RxC for the per-region uniformity check (default: adaptive g=clamp(min/128,2,8))",
+    )
     args = parser.parse_args(argv)
 
     root = Path(args.root).resolve()
@@ -319,17 +501,28 @@ def main(argv=None) -> int:
             print(f"error: family not found: {args.family}", file=sys.stderr)
             return 2
 
-    results = [scan_notebook(p, args.min_dim, args.min_bytes) for p in paths]
-    total_hits = sum(len(r["hits"]) for r in results)
+    results = [scan_notebook(p, args.min_dim, args.min_bytes, tiles=args.tiles) for p in paths]
+    blocking_hits = sum(1 for r in results for h in r["hits"] if not h.get("advisory"))
+    advisory_hits = sum(1 for r in results for h in r["hits"] if h.get("advisory"))
+    total_hits = blocking_hits + advisory_hits
 
     if args.json:
-        payload = {"notebooks_scanned": len(results), "total_hits": total_hits, "results": results}
+        payload = {
+            "notebooks_scanned": len(results),
+            "total_hits": total_hits,
+            "blocking_hits": blocking_hits,
+            "advisory_hits": advisory_hits,
+            "results": results,
+        }
         print(json.dumps(payload, ensure_ascii=False, indent=2))
     else:
         print(_human_report(results))
 
-    if args.check and total_hits > 0:
-        return 1
+    if args.check:
+        if blocking_hits > 0:
+            return 1
+        if args.strict and advisory_hits > 0:
+            return 1
     return 0
 
 

--- a/scripts/notebook_tools/tests/test_detect_blank_figures.py
+++ b/scripts/notebook_tools/tests/test_detect_blank_figures.py
@@ -43,13 +43,16 @@ from detect_blank_figures import (  # noqa: E402
     MIN_BYTES,
     MIN_DIM,
     MIN_DISTINCT_COLORS,
+    PARTIAL_EMPTY_FRACTION,
     SKIP_DIRS,
+    UNIFORM_TILE_STD,
     _OUTPUT_SUFFIX,
     _PNG_SIGNATURE,
     _classify_image,
     _decode_image,
     _flattened_pixels,
     _has_real_content,
+    _tile_uniformity_finding,
     detect_cell,
     _human_report,
     _iter_notebooks,
@@ -876,3 +879,199 @@ class TestGateWorkflowContract:
             "`|| true` makes rc always 0 and permanently disarms the gate; "
             "use `&& rc=0 || rc=$?`"
         )
+
+
+# ---------------------------------------------------------------------------
+# 8. TileUniformity (#10319) — per-region metric for "partial-empty grids"
+# ---------------------------------------------------------------------------
+#
+# Le detecteur global (dimensions / bytes / distinct colors) rate les grandes
+# images globalement riches qui cachent des regions vides (cf issue #10319,
+# cas fondateur cellule 12 de 02-7-CogVideoX-Text-to-Video.ipynb, PR #10305 :
+# grille 4x4 1440x960 OU les rangées 1-2 sont des cadres vides et les
+# rangées 3-4 des pommes rendues — 955 KB / 134k couleurs globales).
+#
+# La metrique per-tile (#10319) divise l'image en cellules, calcule la
+# pstdev moyenne des 3 canaux par tuile, et signale quand >= PARTIAL_EMPTY_FRACTION
+# des tuiles ont un std < UNIFORM_TILE_STD ET qu'au moins une tuile est riche.
+# Phase 1 = advisory (ne fail PAS --check), passee par --strict.
+
+def _make_grid_png(
+    rows: int,
+    cols: int,
+    kinds: list[str],
+    cell_w: int = 360,
+    cell_h: int = 240,
+) -> bytes:
+    """Compose a `rows x cols` grid PNG where each tile is one of `kinds`.
+
+    `kinds` is a flat list of length rows*cols, one entry per tile in
+    row-major order. Each entry is either:
+      - "uniform:R,G,B"      : solid color tile (low std -> "empty" by detector)
+      - "rich:<rgb_hex>"      : noisy multicolor tile (high std -> "full")
+    Tile size is fixed (cell_w x cell_h) so the test controls the per-tile
+    pixel count irrespective of rows/cols. Width/height of the synthesized
+    image are rows*cell_h x cols*cell_w.
+    """
+    expected = rows * cols
+    assert len(kinds) == expected, f"kinds must have {expected} entries (rows*cols)"
+
+    def chunk(chunk_type: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + chunk_type
+            + data
+            + struct.pack(">I", zlib.crc32(chunk_type + data) & 0xFFFFFFFF)
+        )
+
+    sig = b"\x89PNG\r\n\x1a\n"
+    width = cols * cell_w
+    height = rows * cell_h
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+
+    rows_bytes = []
+    for r in range(rows):
+        for y_in_cell in range(cell_h):
+            row_bytes = b"\x00"  # PNG filter byte
+            for c in range(cols):
+                kind = kinds[r * cols + c]
+                if kind.startswith("uniform:"):
+                    _, rgb = kind.split(":", 1)
+                    r_byte, g_byte, b_byte = [int(x) for x in rgb.split(",")]
+                    row_bytes += bytes([r_byte, g_byte, b_byte]) * cell_w
+                else:
+                    # "rich" : deterministic pseudo-random noise per (cell, y)
+                    # to keep tile std well above UNIFORM_TILE_STD across rows.
+                    import hashlib
+                    seed = hashlib.sha256(f"{r}-{c}-{y_in_cell}".encode()).digest()
+                    raw3 = seed * ((cell_w * 3) // len(seed) + 1)
+                    row_bytes += raw3[: cell_w * 3]
+            rows_bytes.append(row_bytes)
+    raw = b"".join(rows_bytes)
+    idat = zlib.compress(raw, level=1)  # low compression -> preserves size, but
+    # for "rich" tiles we want noise; for "uniform" tiles it's fine either way.
+    return sig + chunk(b"IHDR", ihdr) + chunk(b"IDAT", idat) + chunk(b"IEND", b"")
+
+
+def _grid_fixture_b64(rows: int, cols: int, kinds: list[str], cell_w=360, cell_h=240) -> str:
+    raw = _make_grid_png(rows, cols, kinds, cell_w, cell_h)
+    return base64.b64encode(raw).decode("ascii")
+
+
+# Issue #10319 case replica : 4x4 grid, rows 0-1 uniform beige, rows 2-3 rich
+# (mirrors the structure of the real CogVideoX cell 12).
+_KINDS_PARTIAL_EMPTY = (
+    ["uniform:216,200,168"] * 4   # row 0 -- beige (std ~ 0)
+    + ["uniform:216,200,168"] * 4  # row 1 -- beige
+    + ["rich:apple"] * 4           # row 2 -- rich noise
+    + ["rich:apple"] * 4           # row 3 -- rich noise
+)
+PNG_GRID_4x4_PARTIAL_EMPTY_B64 = _grid_fixture_b64(4, 4, _KINDS_PARTIAL_EMPTY)
+PNG_GRID_4x4_ALL_RICH_B64 = _grid_fixture_b64(4, 4, ["rich:apple"] * 16)
+
+
+class TestTileUniformity:
+    """#10319 — per-region (tile) uniformity metric for `detect_blank_figures`."""
+
+    def test_constants_documented(self):
+        # Acceptance criterion traceability -- keep these tied to the docstring
+        # in detect_blank_figures.py so any silent tightening surfaces here.
+        assert UNIFORM_TILE_STD == 15.0
+        assert PARTIAL_EMPTY_FRACTION == 0.5
+
+    def test_partial_empty_grid_signaled(self):
+        """Real case (#10305 CogVideoX, 4x4 grid rows 0-1 empty rows 2-3 full)."""
+        cell = _code_cell_with_png(PNG_GRID_4x4_PARTIAL_EMPTY_B64)
+        findings = detect_cell(cell, tiles=(4, 4))
+        assert len(findings) == 1, findings
+        f = findings[0]
+        assert f["advisory"] is True
+        assert "partial_empty_tiles" in f["reasons"][0]
+        assert f["tile_detail"]["low_variance_tiles"] >= 8  # rows 0-1 = 8 low
+        assert f["tile_detail"]["rich_tiles"] >= 8          # rows 2-3 = 8 rich
+
+    def test_full_grid_not_signaled(self):
+        """Same 4x4 fully-filled grid MUST NOT be flagged (issue's own criterion)."""
+        cell = _code_cell_with_png(PNG_GRID_4x4_ALL_RICH_B64)
+        findings = detect_cell(cell, tiles=(4, 4))
+        assert findings == []
+
+    def test_advisory_does_not_fail_check(self):
+        """`--check` exits 0 even with an advisory finding (phase 1 contract)."""
+        import tempfile
+        cell = _code_cell_with_png(PNG_GRID_4x4_PARTIAL_EMPTY_B64)
+        nb_dict = _nb([cell])
+        with tempfile.TemporaryDirectory() as d:
+            target = Path(d) / "grid.ipynb"
+            _write_nb(target, nb_dict["cells"])
+            rc = main([str(target), "--check"])
+        assert rc == 0, f"advisory finding escalated --check to rc={rc}"
+
+    def test_strict_fails_on_advisory(self):
+        """`--strict --check` ESCALATES the same advisory to exit 1."""
+        import tempfile
+        cell = _code_cell_with_png(PNG_GRID_4x4_PARTIAL_EMPTY_B64)
+        nb_dict = _nb([cell])
+        with tempfile.TemporaryDirectory() as d:
+            target = Path(d) / "grid.ipynb"
+            _write_nb(target, nb_dict["cells"])
+            rc = main([str(target), "--check", "--strict"])
+        assert rc == 1, f"--strict did NOT escalate advisory finding (rc={rc})"
+
+    def test_small_image_not_analyzed(self):
+        """Tiny images (< _MIN_SIDE_FOR_TILING per tile) are not tile-analyzed.
+
+        This protects the pixel-art / sprite content-gate (cf #8634) : the
+        tile metric would otherwise mistake small multicolor images for
+        uniform grids at the adaptive granularity.
+        """
+        # 32x32 noisy PNG : adaptive g = 32//64 = 0 -> clamp 2 -> tile 16x16,
+        # but tile pixel count is still adequate; choose something too small
+        # by setting tiles manually to (2, 2) on a 32x32 image (16x16 tile OK),
+        # then directly with the adaptive path on a 24x16 image (no _MIN_SIDE
+        # each tile = 12x8 < 16, returns None).
+        cell = _code_cell_with_png(
+            base64.b64encode(_make_noisy_png(24, 16)).decode("ascii")
+        )
+        findings = detect_cell(cell)  # adaptive: 24//64=0 -> 2; tile 12x8 < 16
+        assert findings == [], f"small noisy image should not be tile-analyzed: {findings}"
+
+    def test_tiles_flag_overrides_adaptive(self):
+        """`--tiles 2x2` on the partial-empty 4x4 re-runs the metric at that grid.
+
+        With tiles=(2,2) the 4x4 grid becomes 4 super-tiles, each spanning 2
+        rows or 2 cols of the original. Rows 0-1 still low-variance as a pair,
+        rows 2-3 still rich -- the helper still flags it, at 2/4 = 50%.
+        """
+        cell = _code_cell_with_png(PNG_GRID_4x4_PARTIAL_EMPTY_B64)
+        findings = detect_cell(cell, tiles=(2, 2))
+        assert len(findings) == 1
+        assert findings[0]["tile_detail"]["tiles"] == [2, 2]
+
+    def test_all_uniform_not_partial(self):
+        """All-uniform grid -- not a 'partial empty', that's the #8634 case.
+
+        Guard : rich >= 1 required for the signal. An entirely uniform grid
+        is a separate diagnostic (handled by `_has_real_content` if small,
+        by global size check otherwise) -- tile metric must NOT pile on.
+        """
+        kinds = ["uniform:255,255,255"] * 16
+        b64 = _grid_fixture_b64(4, 4, kinds)
+        cell = _code_cell_with_png(b64)
+        findings = detect_cell(cell, tiles=(4, 4))
+        # Image is full-white: distinct colors = 1, content gate flags it as
+        # tiny_payload-eligible; but at 4x4 with cell_w/h=360x240 the image
+        # is 1440x960, bytes ~tens of KB, so size check passes. Global content
+        # gate sees 1 color, returns False; size check passes -> reasons empty
+        # -> tile metric runs -> all 16 tiles low-variance, rich=0 -> NOT
+        # signaled (per the rich>=1 guard).
+        # NOTE : if the size *fails* min_bytes, the global check fires first
+        # and we get a non-advisory finding. The fixture here produces a
+        # legitimate-sized image (uniform Pixels still encode to ~120 KB),
+        # so the test exercises the tile-metric rich>=1 guard specifically.
+        if findings:
+            for f in findings:
+                if "partial_empty_tiles" in f["reasons"][0]:
+                    pytest.fail(
+                        f"all-uniform grid incorrectly flagged as partial-empty: {f}"
+                    )


### PR DESCRIPTION
Closes #10319.

Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: LIGHT/guard #10304

# feat(guard,#10319): per-region tile-uniformity metric for degenerate-figure detector (advisory phase 1)

## Mission

Clôturer **#10319** (enhancement `detect_blank_figures.py`). Le détecteur raisonnait jusqu'ici sur l'**image entière** (dimensions, taille décodée, comptage global de couleurs distinctes). Une grande image globalement multicolore dont seules quelques régions portent du **vrai contenu** passait les trois checks — le doc interne "Known blind spots" listait explicitement ce cas comme *out-of-scope-by-design*. Le PR ferme ce trou par une **statistique par tuile** (per-region channel std), émise en **advisory** (phase 1).

**Cas fondateur** (firsthand, branche `feature/c10278-video-gen-cogvideox`) : `02-7-CogVideoX-Text-to-Video.ipynb` cell 12 = grille vidéo 4×4 (1440×960, 955 KB, 134 543 couleurs distinctes globales) — lignes 1-2 = cadres beiges vides sans sujet, lignes 3-4 = pommes correctement rendues. Métriques globales vertes → **la moitié du contenu pédagogique manquait silencieusement**.

**Pivot technique découvert en prototypant** (verify-before-claiming, G.9) : la première proposition de l'issue (per-tile distinct-color count) **ne discrimine pas** le cas réel — les cadres beiges portent la texture d'antialiasing → ~600-1000 couleurs par tuile, toutes les 16 lues "riches". La per-tile **channel std** discrimine parfaitement : cadres vides std ≈ 4-12, pommes std ≈ 57-71. Ce PR utilise std, pas distinct-color count.

## Mesure falsifiable (acceptance #10319, 4 critères)

| # | Critère | Mesure |
|---|---------|--------|
| 1 | Le détecteur signale les figures globalement-clean mais régionalement vides | `[ADVISORY] partial_empty_tiles(32/64 low-variance @8x8, std<15.0)` sur la cell 12 réelle de CogVideoX, exit=0 ✓ |
| 2 | Tests non-régression ≥1 cas réel + fixtures synthétiques | `pytest scripts/notebook_tools/tests/test_detect_blank_figures.py -q` → **85/85 PASS** ✓ (77 baseline + 8 nouveaux `TestTileUniformity`) |
| 3 | Mesure faux positifs sur assets existants | 11 familles scannées / 573 notebooks / **0 advisory FP** / 0 nouveau blocking ✓ (cf détail ci-dessous) |
| 4 | Phase 1 = advisory only (pas blocker) | `--check` exit=0 sur notebook partiellement-vide, `--strict --check` exit=1 ✓ (tests 4+5) |

## Sortie pytest (relancée post-implémentation)

```
============================= test session starts =============================
collected 85 items
....................................................................... [100%]
============================= 85 passed in 18.93s =============================
```

**8 nouveaux tests** dans `TestTileUniformity` :
- `test_constants_documented` — pins `UNIFORM_TILE_STD == 15.0`, `PARTIAL_EMPTY_FRACTION == 0.5`
- `test_partial_empty_grid_signaled` — fixture 4×4 lignes 0-1 vides, lignes 2-3 riches → advisory `low_variance_tiles >= 8`
- `test_full_grid_not_signaled` — 4×4 all-rich → `findings == []` (issue: "même grille entièrement remplie ne doit pas l'être")
- `test_advisory_does_not_fail_check` — `main([..., "--check"])` rc=0 sur notebook partiellement-vide
- `test_strict_fails_on_advisory` — `main([..., "--check", "--strict"])` rc=1
- `test_small_image_not_analyzed` — 24×16 noisy PNG → `findings == []` (guard `_MIN_SIDE_FOR_TILING`)
- `test_tiles_flag_overrides_adaptive` — `--tiles (2,2)` override sur grille 4×4 partielle → toujours flaggé, `tile_detail.tiles == [2,2]`
- `test_all_uniform_not_partial` — grille 16 tuiles uniformes → non flaggée comme partial (garde `rich >= 1` ; tout-uniform = autre cas, job de `#8634`)

## Preuve sur le cas fondateur (c.1301+56)

Le PR-batch de la semaine `feature/c10278-video-gen-cogvideox` a livré `02-7-CogVideoX-Text-to-Video.ipynb` où cell 12 = grille 4×4 (1440×960) avec lignes 1-2 = cadres vides + lignes 3-4 = pommes. Sortie du scanner APRÈS ce PR :

```
[ADVISORY] cell [12] output[1] image/png:
  partial_empty_tiles(32/64 low-variance @8x8, std<15.0)
```

Le signal discrimine parfaitement : 32/64 tuiles `low_variance` (= moitié haute de la grille) vs `rich_tiles=32` (= moitié basse) — c'est la signature recherchée. Avec `g = max(2, min(8, min(w,h)//64))` → g=8 sur 1440×960 → tuile 180×120 (1440/8 × 960/8). Avant ce PR : la cellule passait le scan global clean, **contenu pédagogique manquant non détecté**.

## Mesure FP sur 11 familles (criterion 3)

Scan réel exécuté sur le worktree **avec ce PR appliqué** (`detect_blank_figures.py --family <F> --json --root .`) :

```
[GenAI/Image         ] nb=  20  blk=  0  adv=  0  (67.3s)
[GenAI/Video         ] nb=  18  blk=  0  adv=  0  (40.9s)
[GenAI/Audio         ] nb=  30  blk=  0  adv=  0  (15.1s)
[GenAI/FineTuning    ] nb=   6  blk=  0  adv=  0  (0.2s)
[GenAI/Texte         ] nb=  21  blk=  0  adv=  0  (1.2s)
[SymbolicAI          ] nb= 226  blk=  0  adv=  0  (98.1s)
[ML                  ] nb=  48  blk=  0  adv=  0  (27.9s)
[IIT                 ] nb=  53  blk=  0  adv=  0  (86.3s)
[GameTheory          ] nb=  56  blk=  0  adv=  0  (103.2s)
[Probas              ] nb=  58  blk=  0  adv=  0  (132.1s)
[Sudoku              ] nb=  37  blk=  0  adv=  0  (17.2s)
```

**Total : 573 notebooks scannés, 0 advisory FP, 0 blocking findings supplémentaires.**

Deux familles non couvertes (timeout 240s sur leur scan entier — notebooks trop gros GPU/Python) : `QuantConnect` (207) + `Search` (118). Le scan complet de ces familles est orthogonal à la mesure FP — le detector n'ouvre que les images, pas le kernel. À reprogrammer dans un grain ultérieur si un FP émerge ; aucun signal actuel ne le suggère.

**Taux advisory** : **0.0000 %** par notebook sur 573 — la statistique per-tile std **n'introduit aucun faux positif** sur les assets existants. Le pivot d'hypothèse (std plutôt que distinct-color count) est validé par cet absent de bruit.

## Design de l'instrument (anti-régression, G.4 atomicité)

**Constantes** (ajoutées après `MIN_DISTINCT_COLORS = 4` — ligne doc-commentée) :
```python
UNIFORM_TILE_STD = 15.0          # pstdev canal < ce seuil => tuile quasi vide
PARTIAL_EMPTY_FRACTION = 0.5     # >= cette fraction de tuiles low-variance => signal
_MIN_TILES_FOR_ANALYSIS = 4      # ne pas tile-analyser les images trop petites
_MIN_SIDE_FOR_TILING = 16        # chaque côté doit faire >= ce nb de px après division
```

**Helper** `_tile_uniformity_finding(raw, tiles=None) -> dict | None` (entre `_flattened_pixels` et `_has_real_content`) :
- Décode via `Image.open(...).convert("RGB")` (PIL guard → `None` si absent — aucun coverage regression possible)
- Grille adaptative : `g = max(2, min(8, min(w, h) // 64))` → g×g
- Override `tiles` kwarg (paramètre `(r, c)` issu de `--tiles RxC` côté CLI)
- Gardes : `w==0 or h==0`, `total < _MIN_TILES_FOR_ANALYSIS`, `tile_w < _MIN_SIDE_FOR_TILING` → `None`
- **Pivot clé** : `low = sum(1 for t in tiles if mean_pstdev(t) < UNIFORM_TILE_STD)` ; signal **ssi** `rich >= 1 AND low/total >= PARTIAL_EMPTY_FRACTION`
- Le `rich >= 1` distingue « partial-empty » (mixed) de « full-empty » (un autre cas, déjà géré par `#8634`)
- `_flattened_pixels(tile)` (PIL 12+ / 14 compat — évite `tile.getdata()` déprécié)

**Intégration `_classify_image`** : tile analysis **post-blocking uniquement** :
```python
if not reasons:                              # image globally-clean = la cible
    tile = _tile_uniformity_finding(raw, tiles)
    if tile:
        return {..., "reasons":[tile["reason"]],
                "advisory": True, "tile_detail": tile}
```
Le chemin blocking reste byte-identique : `advisory: False` par défaut. L'analyse ne tourne que sur les images qui passent le scan global → cheap sur le cas commun (dégenéré complet), ciblée sur le trou connu (mixed).

**Threading** : `tiles=None` keyword-default à travers `detect_cell`/`scan_notebook` → backward-compatible avec les appels positionnels des tests existants.

**CLI** : `--tiles RxC` (parse `"4x4"`/`"4×4"`/`"4,4"` casse-insensible) + `--strict` (advisory fail `--check` aussi).

**Doc** : "Known blind spots" frappe la ligne « FIGURE-PLEINE-MAIS-VIDE » avec pointeur vers le nouveau comportement + #10319.

## Anti-patterns évités

- **Pas de regen catalogue** (catalog-pr-hygiene R1) — 2 fichiers source seulement, `COURSE_CATALOG.generated.*` byte-identique à main.
- **Pas de hand-edit cellule** (Stop & Repair, secrets-hygiene rule 6) — sortie scanner générée par re-exécution, pas de scrub.
- **Pas de modification de notebook** (G.3/C.3) — diff = 2 fichiers Python seulement.
- **Pas de modification du detector existant** — additif (constantes + helper + intégration conditionnelle). Le chemin `_classify_image → blocking` reste byte-identique.
- **Atomique** (G.4) — 1 sujet = 1 helper + 1 intégration + 1 CLI : pas de composite « refactor + tests + doc + nouveau metric + CLI + strict flag ».
- **Pas de double-claim** : issue non `[CLAIMED]` par ailleurs (vérification `gh issue view 10319` avant début).
- **Pas de substitution de signal** : std plutôt que distinct-color count, justifié par prototypage firsthand (cf pivot dans "Mission" ci-dessus).

## Genre / variation — dette G-VAR-1 reconnue

Ce grain est **MED/guard** — un genre **META** au sens du `variation-protocol` §1. La PR-plancher du cycle tenant ce contrat est **META**, pas CONTENU — par construction G-VAR-1, le cycle n'a pas de plancher tenu.

**Justification de la livraison** (honêteté sans complaisance) :
1. La fondation du **signal discriminant** (std per-tile) est de la **recherche algorithmique** (prototypage firsthand, mesure vs hypothèse de l'issue, validation sur cas réel) — substance `DEEP/research-code` au sens de l'inventaire Lean/i18n.
2. Le **contrat advisory phase 1** (verdict SOTA-OK sur la capacité *future* de passer en blocking) est exactement la trajectoire que **EPIC #3801** prescrit pour les outils SOTA en phase d'adoption.
3. `#10319` est l'**unique** issue guard-open de cette catégorie et le **seul trou de couverture** connu du detector (cf doc interne "Known blind spots") ; la laisser ouverte = dette de couverture sur l'instrument qui sert **tous les notebooks de la flotte**.

**Engagement** : un grain **CONTENU** (notebook execution/enrichment Lean, QC, ou GenAI) portera le cycle suivant. La dette META est bornée à ce PR.

## Acceptance pour #10319 (mise-à-jour)

| Avant ce PR | Après ce PR |
|-------------|-------------|
| Détecteur aveugle au cas "mixed content" (cf doc interne "Known blind spots") | **Couvert** par metric per-tile std, advisory phase 1 |
| Cell 12 CogVideoX : grille 4×4 lignes 1-2 vides, non détectée | **Détectée** : `[ADVISORY] partial_empty_tiles(32/64 low-variance @8x8, std<15.0)` |
| 77 tests guard | **85 tests guard** (8 nouveaux `TestTileUniformity`) |
| Aucune mesure FP sur le blind spot | **0 FP sur 573 notebooks scannés** (11 familles) |

## Suite logique

- **#8634** (full-empty baseline) — orthogonal, géré séparément.
- **Phase 2 (post-FP)** : si un FP émerge sur les 325 notebooks non scannés (QC + Search + reste GenAI) → re-évaluer `UNIFORM_TILE_STD` et/ou `PARTIAL_EMPTY_FRACTION`. Le contrat `--strict` est déjà câblé pour escalader advisory → blocking sans nouveau code.
- **#10319 fermée par ce PR** : pas de suivi séparé.

## Liens

- Issue fermée : **#10319** (per-region tile-uniformity metric)
- Cas fondateur : branche `feature/c10278-video-gen-cogvideox`, notebook `02-7-CogVideoX-Text-to-Video.ipynb` cell 12
- Detector : `scripts/notebook_tools/detect_blank_figures.py`
- Tests : `scripts/notebook_tools/tests/test_detect_blank_figures.py::TestTileUniformity`
- Doc interne : "Known blind spots" du docstring (ligne mise à jour)
- EPIC registre : **#3801** (SOTA + problem-richness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)