### PR TITLE
fix(guard,#10020): --limit 500 sur le jeu de comptage G-VAR-2 — la page gh tronquee a 30 attaquait le denominateur du cap

### DIFF
--- a/.github/workflows/variation-light-genre.yml
+++ b/.github/workflows/variation-light-genre.yml
@@ -81,7 +81,14 @@ jobs:
           # donc elle n'est PAS dans le set -- c'est ce qui rend la detection
           # du 2e grain consecutif possible.
           TODAY=$(date -u +%Y-%m-%d)
-          gh pr list --state merged --search "merged:$TODAY" \
+          # --limit 500 est OBLIGATOIRE : `gh pr list` pagine a 30 par defaut
+          # et ne signale pas la troncature. Le set tronque attaque le
+          # DENOMINATEUR du ratio G-VAR-2 (`max(1, lane_grains // 3)`) : la
+          # lane sous-compte, le cap retombe a 1, et l'organe accuse de
+          # CAP-EXCEEDED la lane la plus productive du jour -- l'inverse exact
+          # de ce que le ratio protege. Constate le 2026-08-10 sur #10328
+          # (60 mergees, 30 vues, lane po-2024:CoursIA a 11 grains lue <=2).
+          gh pr list --state merged --search "merged:$TODAY" --limit 500 \
             --json number,body,mergedAt,labels > /tmp/merged.json 2>/dev/null || \
             printf '[]' > /tmp/merged.json
 

--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -262,7 +262,12 @@ jobs:
           # honorer la requalification #8970 (grain-requalified:<TIER> qui
           # override le tier declare) : ajouter le champ `labels` a la MEME
           # requete ne consomme pas de quota supplementaire.
-          gh pr list --state merged --search "merged:$TODAY" \
+          # --limit 500 OBLIGATOIRE : la page par defaut de `gh pr list` est 30,
+          # silencieusement. Le set tronque attaque le DENOMINATEUR du ratio
+          # G-VAR-2 -- le cap retombe a son plancher de 1 et le label devient un
+          # faux positif contre les lanes productives (cf #10328, 2026-08-10 :
+          # 60 mergees pour 30 vues). Meme correctif dans variation-light-genre.yml.
+          gh pr list --state merged --search "merged:$TODAY" --limit 500 \
             --json number,body,mergedAt,labels > /tmp/merged.json 2>/dev/null || true
 
           # Le body circule par fichier : printf '%s' ne reinterprete rien

--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -904,3 +904,54 @@ def test_po2025_replay_signals_genre_run_via_cli(tmp_path, capsys):
     # The long_run carries the 5 readme numbers from the issue acceptance.
     assert out["long_runs"][0]["count"] == 5
     assert out["long_runs"][0]["numbers"] == [9960, 9965, 9966, 9969, 9977]
+
+
+# --- troncature du dataset (#10328, 2026-08-10) ----------------------------
+# `gh pr list` pagine a 30 sans le dire. La troncature attaque le DENOMINATEUR
+# du ratio G-VAR-2 : le cap retombe a son plancher de 1 et l'organe accuse de
+# CAP-EXCEEDED la lane la plus productive. Les deux tests ci-dessous encadrent
+# le tell : il tire a exactement 30 (page par defaut) et se tait sinon.
+
+def _grain(n: int, tier: str, genre: str, lane: str) -> dict:
+    return {"number": n, "mergedAt": f"2026-08-10T{n % 24:02d}:00:00Z",
+            "body": f"Grain: {tier}/{genre} - lane {lane} - prev: MED/guard #1\n",
+            "labels": []}
+
+
+def test_load_warns_when_dataset_is_exactly_the_gh_default_page(tmp_path, capsys):
+    lane = "myia-po-2024:CoursIA"
+    data = [_grain(9000 + i, "MED", "notebook-python", lane) for i in range(30)]
+    p = tmp_path / "merged.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    assert len(vlc._load(str(p))) == 30
+    err = capsys.readouterr().err
+    assert "TRONQUE" in err and "30" in err
+
+
+def test_load_silent_when_dataset_is_not_a_full_default_page(tmp_path, capsys):
+    lane = "myia-po-2024:CoursIA"
+    for n in (29, 31, 60):
+        p = tmp_path / f"m{n}.json"
+        p.write_text(json.dumps([_grain(9000 + i, "MED", "notebook-python", lane)
+                                 for i in range(n)]), encoding="utf-8")
+        vlc._load(str(p))
+        assert "TRONQUE" not in capsys.readouterr().err, n
+
+
+def test_truncation_flips_cap_verdict_on_the_10328_shape(tmp_path, capsys):
+    # Forme reelle du 2026-08-10 : la lane po-2024:CoursIA a merge 11 grains
+    # dont 2 LIGHT. Cap correct = max(1, 11 // 3) = 3 -> les 2 LIGHT passent.
+    # Vue tronquee ou seuls les 2 LIGHT survivent : cap = max(1, 2 // 3) = 1
+    # -> le 2e LIGHT est declare cap-reached. C'est le faux positif observe.
+    lane = "myia-po-2024:CoursIA"
+    lights = [_grain(10291, "LIGHT", "guard", lane), _grain(10279, "LIGHT", "docs", lane)]
+    full = lights + [_grain(10250 + i, "MED", "notebook-python", lane) for i in range(9)]
+
+    def cap_of(dataset):
+        p = tmp_path / f"d{len(dataset)}.json"
+        p.write_text(json.dumps(dataset), encoding="utf-8")
+        vlc.main(["--replay", str(p), "--genre-signals", "--lane", lane])
+        return json.loads(capsys.readouterr().out.strip().splitlines()[-1])["tally"]
+
+    assert cap_of(full)["cap"] == 3
+    assert cap_of(lights)["cap"] == 1

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -714,10 +714,32 @@ def compute_signals(
 
 # --- CLI -------------------------------------------------------------------
 
+# `gh pr list` pagine a 30 par defaut et ne le dit pas. Un dataset de
+# *exactement* 30 PRs est donc presque toujours une page tronquee, pas une
+# journee a 30 merges -- et la troncature attaque le DENOMINATEUR du ratio
+# G-VAR-2 : lane_grains sous-compte, `max(1, n // 3)` retombe sur son plancher
+# de 1, et l'organe accuse de CAP-EXCEEDED la lane la plus productive du jour
+# (exactement l'inverse de ce que le ratio existe pour proteger). Constate le
+# 2026-08-10 sur #10328 : 60 PRs mergees, l'organe en voyait 30, la lane
+# `myia-po-2024:CoursIA` comptait 11 grains vus comme <=2 -> cap=1, faux
+# positif. Le correctif est le `--limit` cote workflow ; ce tell existe pour
+# que la PROCHAINE copie de l'idiome ne puisse pas le reintroduire en silence.
+_GH_DEFAULT_PAGE = 30
+
+
 def _load(path: str) -> list[dict]:
     data = json.loads(Path(path).read_text(encoding="utf-8"))
     if not isinstance(data, list):
         sys.exit(f"--replay/--check-pr expects a JSON array, got {type(data).__name__}")
+    if len(data) == _GH_DEFAULT_PAGE:
+        print(
+            f"AVERTISSEMENT: le jeu de comptage fait exactement {_GH_DEFAULT_PAGE} "
+            "entrees = la taille de page par defaut de `gh pr list`. Si le "
+            "producteur du dataset n'a pas passe --limit, le set est TRONQUE : "
+            "le denominateur de G-VAR-2 sous-compte et le cap retombe a son "
+            "plancher de 1 (faux CAP-EXCEEDED sur les lanes productives).",
+            file=sys.stderr,
+        )
     return data
 
 


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/notebook-python #10337

## Le defaut

Les deux organes de variation construisent leur **jeu de comptage** du jour ainsi :

```bash
gh pr list --state merged --search "merged:$TODAY" --json number,body,mergedAt,labels
```

`gh pr list` **pagine a 30 par defaut, sans le signaler**. Le set tronque n'attaque pas un detail cosmetique : il attaque le **denominateur** du ratio G-VAR-2, `cap = max(1, lane_grains // 3)`. La lane sous-compte ses grains, le cap retombe sur son **plancher de 1**, et l'organe accuse de `CAP-EXCEEDED-BY-GENRE` **la lane la plus productive du jour** — l'inverse exact de ce que le ratio proportionnel existe pour proteger.

## La mesure

Constate firsthand le 2026-08-10 en instruisant les labels de #10328 : **60 PRs mergees** ce jour-la, l'organe en voyait **30**. Pour `myia-po-2024:CoursIA` :

| jeu de comptage | `lane_grains` | `cap` | verdict |
|---|---|---|---|
| tronque (30, defaut `gh`) | ≤ 2 | **1** | `CAP-EXCEEDED` — faux positif |
| complet (`--limit 500`) | **11** | **3** | conforme |

Le meme test a **exonere** un cas et **confirme** l'autre, ce qui est le point : le correctif ne blanchit pas une lane par principe, il rend le compteur juste. Sur `myia-po-2023:CoursIA-2` le jeu complet donne `lane_grains=17 cap=5 light_genre=9` (guard 6 + docs 3) — depassement **reel**, qui sort True dans les deux vues. Un organe qui se trompe dans un sens se trompe aussi dans l'autre ; ici il fallait mesurer les deux.

## Le correctif

1. **`--limit 500`** sur les deux — et seuls — call sites qui construisent le dataset : [`variation-light-genre.yml:84`](.github/workflows/variation-light-genre.yml) et [`variation-tag-guard.yml:265`](.github/workflows/variation-tag-guard.yml). Les sept autres occurrences de `gh pr list` dans ces fichiers sont des **commentaires**, verifie par grep — le correctif est donc exhaustif, il n'y a pas de troisieme instance a suivre.

2. **Un tell dans le detecteur partage** (`scripts/variation_light_cap.py`), parce qu'un `--limit` dans un YAML se perd des que l'idiome est recopie ailleurs : `_load()` avertit sur stderr quand le dataset fait **exactement 30** entrees — la taille de page par defaut. Une journee a exactement 30 merges est presque toujours une page tronquee, et le doute doit etre visible **la ou le calcul se fait**, pas seulement dans le workflow d'origine. C'est le garde-fou qui empeche la prochaine copie de reintroduire le defaut en silence.

3. **Trois tests** (`scripts/tests/test_variation_light_cap.py`, +51) :
   - `test_load_warns_when_dataset_is_exactly_the_gh_default_page` — le tell se declenche a 30 ;
   - `test_load_silent_when_dataset_is_not_a_full_default_page` — silencieux hors de 30, et le chargement **reussit** dans les deux cas : le tell est un avertissement, jamais un rejet, un dataset legitimement a 30 continue de passer ;
   - `test_truncation_flips_cap_verdict_on_the_10328_shape` — rejoue la forme de #10328 et epingle le **basculement du verdict** entre jeu tronque et jeu complet, c'est-a-dire le defaut lui-meme et non seulement son symptome.

```
collected 63 items
63 passed in 0.53s
```

## Ce que ce correctif ne fait pas

Il ne corrige **pas** le second defaut de la meme famille, decouvert en instruisant #10312 : un label de variation est calcule sur la **trainee-jour de la lane** mais se **pose sur la PR ouverte du moment**, qui peut etre le seul grain de CONTENU remediant au motif. Le merge-gate lit alors `--json labels` et peut HOLD la mauvaise PR. Meme classe — l'organe egare le merge-gate — mais autre cause et autre correctif : issue separee, pas de composite ici.

## Rattachement et non-collision

L'organe repare a ete provisionne par **#10020**. Cette PR **ne reclame pas** cette issue et n'y pose aucun claim : les deux `[CLAIMED]` qui y sont detenus (dont `myia-po-2024:CoursIA-2`, 2026-08-08) couvrent la **construction** de l'organe, qui est livree et sur `main` — c'est precisement ce qui rend un defaut post-livraison observable. Reference descriptive, non fermante.

Garde L898 mesuree avant la premiere edition : **aucune PR ouverte** ne touche l'un des quatre chemins de ce diff (`gh pr list --state open --json files`, les quatre interroges un par un). Le correctif ne pietine le travail d'aucune lane.

