### PR TITLE
feat(notebook-tools,#10319): per-region degenerate-figure detector (advisory)

### DIFF
--- a/scripts/notebook_tools/detect_blank_figures.py
+++ b/scripts/notebook_tools/detect_blank_figures.py
@@ -37,15 +37,31 @@ Une sortie `image/png` (ou `image/jpeg`) d'une cellule code est DEGENERECE si :
     fait 70 o ; un vrai plot fait des dizaines de Ko).
 Les deux signaux concordent sur le cas #6891 ; chacun est rapporte separement
 pour que l'humain juge (une image JPEG dont on ne parse pas les dimensions n'est
-retenue que sur la taille).
+retenue que sur la taille). Ces deux signaux sont BLOQUANTS (--check exit 1).
+
+Signaux ADVISORY par region (#10319, NON bloquants)
+---------------------------------------------------
+Un grand PNG riche en couleurs peut quand meme avoir la moitie de son contenu
+absent : une grille matplotlib dont certaines rangées de sous-graphes sont vides
+(cas #10319 : 4x4 dont 2 rangees uniformes). Les trois signaux ci-dessus
+raisonnent sur l'image ENTIERE et ne voient pas le trou. Une 4e métrique, par
+TUILE, ajoute le contraste INTRA-image : on decoupe l'image en grille (adaptive
+~64 px par tuile, ou `--tiles RxC`), on calcule par tuile l'ecart-type max par
+canal, et on signale (advisory) quand une fraction significative des tuiles est
+quasi-uniforme (>= MIN_UNIFORM_FRACTION) COEXISTANT avec une fraction
+significative de tuiles riches (>= MIN_CONTENT_FRACTION). Le signal est le
+CONTRASTE, pas le niveau absolu : une image entierement uniforme ou entierement
+riche n'est PAS flaggee. Advisory = rapporte mais ne fait PAS rougir --check
+(phase 1 : on mesure le taux de FP avant tout blocage, #10319 critere 4).
 
 Known blind spots (hors scope par design)
 -----------------------------------------
 - FIGURE PLEINE MAIS VIDE : un PNG full-size (ex 690x590) entierement blanc /
-  transparent (un plot qui a trace des axes vides). Detecter ca demande une
-  analyse pixel (variance de couleur) -- plus lourd et bruite. Hors scope : cet
-  outil cible la degenerescence de dimension/taille (le cas #6891 verifie), pas
-  le contenu semantique de l'image.
+  transparent (un plot qui a trace des axes vides, SANS region riche). La
+  métrique par tuile (#10319) ne le voit PAS : elle exige du contraste intra-
+  image (uniforme + riche). Le cas « tout vide » reste hors scope (variance
+  globale faible -- bruité, couvert partiellement par _has_real_content quand
+  l'image a < MIN_DISTINCT_COLORS).
 - IMAGE LEGITIMEMENT PETITE : une icone / un sprite / un QR code volontairement
   petit. Rare en notebook pedagogique (les sorties image sont des figures). Si
   rencontre, l'exclure au cas par cas -- l'outil est read-only.
@@ -58,12 +74,14 @@ Usage
     python detect_blank_figures.py NB.ipynb --json          # sortie machine
     python detect_blank_figures.py NB.ipynb --check         # exit 1 si figures degenerees (CI-ready)
     python detect_blank_figures.py NB.ipynb --min-dim 8 --min-bytes 1024   # seuils explicites
+    python detect_blank_figures.py NB.ipynb --tiles 4x4    # grille par-region advisory explicite
 
 Exit codes
 ----------
-    0 -- aucune figure degenerece (ou mode non --check)
-    1 -- une ou plusieurs figures degenerees (--check seulement)
-    2 -- erreur (notebook illisible, famille introuvable)
+    0 -- aucune figure degeneree bloquante (ou mode non --check). Les findings
+         advisory (#10319) ne font JAMAIS remonter exit 1.
+    1 -- une ou plusieurs figures degenerees BLOQUANTES (--check seulement)
+    2 -- erreur (notebook illisible, famille introuvable, --tiles mal forme)
 
 Voir aussi
 ----------
@@ -71,6 +89,7 @@ Voir aussi
 - `.claude/rules/sota-not-workaround.md` -- Prong-A : vrai outil, pas workaround/fabrication
 - `.claude/rules/secrets-hygiene.md` regle 6 -- Stop&Repair : re-executer, jamais scrubber
 - #6891 -- incident fondateur (8 quantbook.ipynb QC blank-PNG)
+- #10319 -- grille partiellement vide (advisory par-region, non bloquant)
 
 Part of #3801 (EPIC SOTA axe-2).
 """
@@ -97,6 +116,45 @@ MIN_BYTES = 1024    # o  : un PNG decode < 1 Ko ne porte pas de vraie figure
 # taille pour ne pas regresser la couverture de #6891).
 MIN_DISTINCT_COLORS = 4  # nb de couleurs RGB distinctes en dessous duquel une
                          # petite image est consideree sans contenu reel
+
+# Detection par region (#10319) -- grille partiellement vide.
+# Les trois seuils ci-dessus (dim / bytes / couleurs) raisonnent sur des agrégats
+# de l'image ENTIÈRE : une grille matplotlib dont seule une partie des sous-graphes
+# est vide est un grand PNG riche en couleurs -- elle passe les trois au vert alors
+# que la moitie de son contenu pedagogique est absent (cas #10319 : 4x4 dont 2
+# rangées vides). La métrique par tuile ci-dessous ajoute le contraste INTRA-image
+# comme 4e signal (advisory, non bloquant -- phase 1).
+TILE_TARGET_PX = 64          # cote de tuile vise en mode adaptatif (grille choisie
+                             # pour que chaque tuile fasse ~>= 64 px, min 2x2). Une
+                             # tuile plus fine qu'un sous-graphe marche aussi bien :
+                             # un sous-graphe vide de 172x147 couvre ~3x3 tuiles, qui
+                             # contribuent toutes au compte "uniforme".
+MIN_TILES_AXIS = 2           # ne pas subdivider en dessous de 2x2 (une tuile unique
+                             # = l'image entiere = le cas global deja couvert).
+UNIFORM_TILE_STD = 10.0      # ecart-type max (0-255) par canal en dessous duquel une
+                             # tuile est "quasi-uniforme" (fond uni, cadre vide).
+CONTENT_TILE_STD = 25.0      # ecart-type min au-dessus duquel une tuile porte un
+                             # vrai contenu. La bande [10, 25] = ambigue, exclue des
+                             # deux comptes (conservateur : ne gonfle ni uniforme ni
+                             # riche, donc ne fabrique pas de contraste artificiel).
+LARGE_UNIFORM_REGION = 0.40  # Une GRANDE region uniforme CONNEXE couvrant >= 40 % des
+                             # tuiles est la signature d'un sous-graphe vide (cas
+                             # #10319 : la moitie superieure de la grille est vide ->
+                             # une composante 4-connexe de tuiles uniformes couvre ~50 %
+                             # de l'image). Un plot matplotlib normal a son blanc de
+                             # fond EPARPILLE entre les tuiles de contenu -> ses
+                             # composantes uniformes connexes sont petites (marges,
+                             # interstices) -> non flaggue. Seuil phase 1 calibre sur
+                             # le corpus (1100 figures candidates) : p50=0.11, p90=0.33,
+                             # p95=0.43 -> 0.40 est juste au-dela de p90 et laisse 94 %
+                             # des figures muettes, ne surfacent que la queue ~6 % pour
+                             # tri visuel. Taux advisory mesure a d'autres seuils :
+                             # 0.20->27 %, 0.30->13 %, 0.40->6 %, 0.50->2 %. A retuner
+                             # apres tri visuel des candidats par les lanes qui voient
+                             # (MiniMax/ai-01) -- #10319 critere 4.
+MIN_CONTENT_FRACTION = 0.15  # ... ET >= 15 % de tuiles riches => il y a BIEN du
+                             # contenu quelque part (sinon c'est le cas "figure pleine
+                             # mais vide", hors scope).
 
 _IMAGE_MIMES = ("image/png", "image/jpeg")
 _PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
@@ -174,8 +232,165 @@ def _has_real_content(raw: bytes, min_colors: int = MIN_DISTINCT_COLORS) -> bool
         return None
 
 
-def _classify_image(mime: str, raw: bytes, min_dim: int, min_bytes: int) -> dict | None:
-    """Return a finding dict if the image is degenerate, else None."""
+def _partially_empty_metric(
+    raw: bytes,
+    tiles: tuple[int, int] | None = None,
+) -> dict | None:
+    """Detect a grid figure that is PARTIALLY empty (#10319).
+
+    Returns a detail dict when the image carries intra-image contrast -- a
+    significant fraction of near-uniform tiles coexisting with a significant
+    fraction of rich tiles -- which is the signature of a matplotlib subplot
+    grid where some rows rendered empty (uniform canvas) while others carry
+    real content. Returns None otherwise (fully-rich real plot, fully-uniform
+    white canvas, PIL/numpy absent, or undecodable image).
+
+    Why per-tile and not whole-image: the three blocking metrics above reason
+    on aggregates of the ENTIRE image. A 4x4 grid whose top half is empty is a
+    large, byte-heavy, many-colored PNG -- it passes dimension, payload AND
+    distinct-color checks, because the rich bottom half supplies enough colors.
+    Only a per-region statistic can see that half the content is missing.
+
+    The signal is CONTRAST, not absolute level: a fully-empty image (all tiles
+    uniform, none rich) is NOT flagged here -- that is the separate, already
+    documented "figure pleine mais vide" blind spot, out of this metric's
+    scope. Only the *partially*-empty case (both uniform AND rich fractions
+    above threshold) produces an advisory.
+
+    numpy is used for the per-tile std-dev (fast vectorised). It is optional:
+    if numpy or PIL is unavailable, or the image is undecodable, returns None
+    and the caller keeps the blocking size/dimension behaviour (no coverage
+    regression -- same degrade-gracefully contract as `_has_real_content`).
+
+    `tiles` overrides the adaptive grid as (rows, cols); None = adaptive
+    (grid chosen so each tile ~= TILE_TARGET_PX, floored at MIN_TILES_AXIS).
+    """
+    try:
+        import io
+        import numpy as np
+        from PIL import Image
+    except Exception:
+        return None
+    try:
+        im = Image.open(io.BytesIO(raw)).convert("RGB")
+        arr = np.asarray(im)  # (H, W, 3) uint8
+    except Exception:
+        return None
+    if arr.ndim != 3 or arr.shape[2] < 3:
+        return None
+    h, w = int(arr.shape[0]), int(arr.shape[1])
+    if h < MIN_TILES_AXIS or w < MIN_TILES_AXIS:
+        return None  # too small to subdivide meaningfully
+
+    if tiles is None:
+        cols = max(MIN_TILES_AXIS, round(w / TILE_TARGET_PX))
+        rows = max(MIN_TILES_AXIS, round(h / TILE_TARGET_PX))
+    else:
+        rows, cols = tiles
+    rows = max(MIN_TILES_AXIS, int(rows))
+    cols = max(MIN_TILES_AXIS, int(cols))
+
+    row_edges = np.linspace(0, h, rows + 1, dtype=int)
+    col_edges = np.linspace(0, w, cols + 1, dtype=int)
+
+    # Carte par tuile : 0 = uniforme, 1 = contenu, -1 = ambigue.
+    tile_map = [[-1] * cols for _ in range(rows)]
+    uniform = 0
+    content = 0
+    total = 0
+    for ri in range(rows):
+        for ci in range(cols):
+            tile = arr[row_edges[ri]:row_edges[ri + 1], col_edges[ci]:col_edges[ci + 1]]
+            if tile.size == 0:
+                continue
+            total += 1
+            # max-channel std across all pixels of the tile (0-255 scale)
+            std = float(tile.reshape(-1, tile.shape[-1]).std(axis=0).max())
+            if std < UNIFORM_TILE_STD:
+                uniform += 1
+                tile_map[ri][ci] = 0
+            elif std >= CONTENT_TILE_STD:
+                content += 1
+                tile_map[ri][ci] = 1
+    if total == 0:
+        return None
+
+    c_frac = content / total
+    # Le signal discriminant est la CONTIGUITE, pas la fraction. Un plot normal
+    # a ses tuiles uniformes (blanc de fond) EPARPILLEES entre les tuiles de
+    # contenu -> la plus grande region uniforme connexe est petite. Une grille
+    # dont des sous-graphes entiers sont vides a une GRANDE region uniforme
+    # connexe (ex. la moitie superieure de l'image). On mesure donc la plus
+    # grande composante 4-connexe de tuiles uniformes (#10319). Sans ce test,
+    # 64 % des notebooks pedagogiques (plot matplotlib clairsemes sur fond
+    # blanc) etaient flaggues advisory -- bruit inutilisable.
+    largest_region = _largest_uniform_region(tile_map, rows, cols)
+    region_frac = largest_region / total if total else 0.0
+    if region_frac >= LARGE_UNIFORM_REGION and c_frac >= MIN_CONTENT_FRACTION:
+        return {
+            "uniform_fraction": round(uniform / total, 3),
+            "content_fraction": round(c_frac, 3),
+            "largest_uniform_region": round(region_frac, 3),
+            "tiles": f"{rows}x{cols}",
+            "uniform_tiles": uniform,
+            "content_tiles": content,
+            "total_tiles": total,
+        }
+    return None
+
+
+def _largest_uniform_region(tile_map: list[list[int]], rows: int, cols: int) -> int:
+    """Size of the largest 4-connected component of uniform (0) tiles.
+
+    Pure-Python flood fill on the (small) tile grid -- the grid is at most a few
+    hundred tiles, so no scipy dependency is warranted. Used by
+    `_partially_empty_metric` to distinguish a contiguous empty subplot block
+    (large region) from scattered background-white tiles of a normal plot
+    (small regions).
+    """
+    visited = [[False] * cols for _ in range(rows)]
+    largest = 0
+    for sr in range(rows):
+        for sc in range(cols):
+            if tile_map[sr][sc] != 0 or visited[sr][sc]:
+                continue
+            # BFS over uniform tiles
+            size = 0
+            stack = [(sr, sc)]
+            visited[sr][sc] = True
+            while stack:
+                r, c = stack.pop()
+                size += 1
+                for dr, dc in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+                    nr, nc = r + dr, c + dc
+                    if (
+                        0 <= nr < rows
+                        and 0 <= nc < cols
+                        and not visited[nr][nc]
+                        and tile_map[nr][nc] == 0
+                    ):
+                        visited[nr][nc] = True
+                        stack.append((nr, nc))
+            if size > largest:
+                largest = size
+    return largest
+
+
+def _classify_image(
+    mime: str,
+    raw: bytes,
+    min_dim: int,
+    min_bytes: int,
+    tiles: tuple[int, int] | None = None,
+) -> dict | None:
+    """Return a finding dict if the image is degenerate or partially empty, else None.
+
+    Findings carry a ``severity`` field: ``"blocking"`` for the deterministic
+    dimension/payload defects (#6891), ``"advisory"`` for the per-region
+    partially-empty signal (#10319). A ``"blocking"`` finding trips ``--check``;
+    an ``"advisory"`` finding never does (phase 1: measure the FP rate before
+    any blocking, per #10319 acceptance criterion 4).
+    """
     reasons = []
     size = len(raw)
     dims = _png_dimensions(raw) if mime == "image/png" else None
@@ -193,18 +408,41 @@ def _classify_image(mime: str, raw: bytes, min_dim: int, min_bytes: int) -> dict
         if _has_real_content(raw) is not True:
             reasons.append(f"tiny_payload({size}B)")
 
-    if not reasons:
+    if reasons:
+        # Defaut deterministe (dim/taille) -> bloquant.
+        return {
+            "mime": mime,
+            "bytes": size,
+            "dimensions": list(dims) if dims else None,
+            "reasons": reasons,
+            "severity": "blocking",
+        }
+
+    # L'image a passe les seuils bloquants : examiner le contraste intra-image
+    # (#10319). Advisory seulement -- ne fait pas rougir le gate.
+    region = _partially_empty_metric(raw, tiles)
+    if region is None:
         return None
     return {
         "mime": mime,
         "bytes": size,
         "dimensions": list(dims) if dims else None,
-        "reasons": reasons,
+        "reasons": [
+            f"partially_empty_grid(largest_empty_region={region['largest_uniform_region']}, "
+            f"content={region['content_fraction']}, tiles={region['tiles']})"
+        ],
+        "severity": "advisory",
+        "region_detail": region,
     }
 
 
-def detect_cell(cell: dict, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES) -> list[dict]:
-    """Return findings (one per degenerate image output) for a code cell."""
+def detect_cell(
+    cell: dict,
+    min_dim: int = MIN_DIM,
+    min_bytes: int = MIN_BYTES,
+    tiles: tuple[int, int] | None = None,
+) -> list[dict]:
+    """Return findings (one per degenerate/partially-empty image output) for a code cell."""
     findings = []
     for oi, out in enumerate(_cell_outputs(cell)):
         data = out.get("data", {}) if isinstance(out, dict) else {}
@@ -214,13 +452,18 @@ def detect_cell(cell: dict, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES) 
             raw = _decode_image(data[mime])
             if raw is None:
                 continue
-            finding = _classify_image(mime, raw, min_dim, min_bytes)
+            finding = _classify_image(mime, raw, min_dim, min_bytes, tiles)
             if finding:
                 findings.append({"output_index": oi, **finding})
     return findings
 
 
-def scan_notebook(path: Path, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES) -> dict:
+def scan_notebook(
+    path: Path,
+    min_dim: int = MIN_DIM,
+    min_bytes: int = MIN_BYTES,
+    tiles: tuple[int, int] | None = None,
+) -> dict:
     """Return a result dict for one notebook: path, hits[], error."""
     try:
         with open(path, encoding="utf-8") as f:
@@ -232,7 +475,7 @@ def scan_notebook(path: Path, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES
     for ci, cell in enumerate(nb.get("cells", [])):
         if cell.get("cell_type") != "code":
             continue
-        for finding in detect_cell(cell, min_dim, min_bytes):
+        for finding in detect_cell(cell, min_dim, min_bytes, tiles):
             hits.append({"cell_index": ci, **finding})
     return {"path": str(path), "kernel": _kernel(nb), "hits": hits, "error": None}
 
@@ -261,34 +504,76 @@ def _iter_notebooks(root: Path, family: str | None):
 
 
 def _human_report(results: list[dict]) -> str:
-    total_hits = sum(len(r["hits"]) for r in results)
-    affected = [r for r in results if r["hits"]]
+    # Les findings advisory (#10319, par-region) ne sont pas des degenerescences
+    # deterministes : on les rapporte dans une section dediee, sans faire monter le
+    # compteur "Degenerate figures" (qui pilote historiquement le gate --check).
+    blocking: list[tuple[dict, dict]] = []
+    advisory: list[tuple[dict, dict]] = []
+    for r in results:
+        for h in r["hits"]:
+            (advisory if h.get("severity") == "advisory" else blocking).append((r, h))
+    nb_blocking = len({id(r) for r, _ in blocking})
     errored = [r for r in results if r.get("error")]
     lines = [
         f"Notebooks scanned  : {len(results)}",
-        f"Degenerate figures : {total_hits}",
-        f"Affected notebooks : {len(affected)}",
+        f"Degenerate figures : {len(blocking)}",
+        f"Affected notebooks : {nb_blocking}",
         "",
     ]
-    if not affected:
+    if not blocking and not advisory:
         lines.append("No degenerate figures detected (deterministic dimension/size check).")
         if errored:
             lines.append("")
             lines.append(f"NOTE: {len(errored)} notebook(s) unreadable (see --json for details).")
         return "\n".join(lines)
-    for r in affected:
+    # Findings bloquants (deterministes dim/taille -- #6891).
+    for r, h in blocking:
         short = r["path"].split("MyIA.AI.Notebooks")[-1].lstrip("\\/")
         lines.append(f"## {short}  [{r['kernel']}]")
-        for h in r["hits"]:
-            reasons = ", ".join(h["reasons"])
-            lines.append(f"  - cell [{h['cell_index']}] output[{h['output_index']}] {h['mime']}: {reasons}")
+        lines.append(f"  - cell [{h['cell_index']}] output[{h['output_index']}] {h['mime']}: {', '.join(h['reasons'])}")
+    if blocking:
         lines.append("")
-    lines.append(
-        "FIX: re-execute the cell in the real environment (QC Cloud research for "
-        "QuantBook, local kernel for matplotlib) and commit the real figure -- "
-        "Stop&Repair, never scrub/delete to hide (secrets-hygiene rule 6)."
-    )
+        lines.append(
+            "FIX: re-execute the cell in the real environment (QC Cloud research for "
+            "QuantBook, local kernel for matplotlib) and commit the real figure -- "
+            "Stop&Repair, never scrub/delete to hide (secrets-hygiene rule 6)."
+        )
+    # Findings advisory (par-region, #10319, NON bloquants).
+    if advisory:
+        lines.append("")
+        lines.append(f"## Advisory -- partially-empty grids (#10319, non-blocking): {len(advisory)}")
+        for r, h in advisory:
+            short = r["path"].split("MyIA.AI.Notebooks")[-1].lstrip("\\/")
+            lines.append(f"  - {short} cell [{h['cell_index']}] output[{h['output_index']}]: {', '.join(h['reasons'])}")
+        lines.append(
+            "NOTE: advisory only -- a region of the figure is near-uniform while another "
+            "carries content. Verify by eye (vision lanes); --check does not fail on this "
+            "(FP-rate measure phase, #10319 acceptance criterion 4)."
+        )
+    if errored:
+        lines.append("")
+        lines.append(f"NOTE: {len(errored)} notebook(s) unreadable (see --json for details).")
     return "\n".join(lines)
+
+
+def _parse_tiles(spec: str | None) -> tuple[int, int] | None:
+    """Parse a ``--tiles RxC`` spec (e.g. ``"4x4"``) into a (rows, cols) tuple.
+
+    Accepts ``x`` or ``X`` as the separator. Returns None for an empty/None
+    spec (adaptive grid). Raises ValueError on a malformed spec so argparse
+    surfaces it as a usage error.
+    """
+    if not spec:
+        return None
+    parts = spec.lower().replace("x", "X").split("X")
+    if len(parts) != 2:
+        raise ValueError(f"--tiles expects RxC (e.g. 4x4), got {spec!r}")
+    rows, cols = int(parts[0]), int(parts[1])
+    if rows < MIN_TILES_AXIS or cols < MIN_TILES_AXIS:
+        raise ValueError(
+            f"--tiles rows and cols must be >= {MIN_TILES_AXIS} (got {spec!r})"
+        )
+    return (rows, cols)
 
 
 def main(argv=None) -> int:
@@ -303,7 +588,22 @@ def main(argv=None) -> int:
     parser.add_argument("--check", action="store_true", help="Exit 1 if any degenerate figure (CI-ready)")
     parser.add_argument("--min-dim", type=int, default=MIN_DIM, help=f"Min figure side px (default {MIN_DIM})")
     parser.add_argument("--min-bytes", type=int, default=MIN_BYTES, help=f"Min decoded bytes (default {MIN_BYTES})")
+    parser.add_argument(
+        "--tiles",
+        default=None,
+        help=(
+            "Per-region grid for the partially-empty advisory (#10319), as RxC "
+            "(e.g. 4x4). Default: adaptive (~64px tiles). Advisory only, never "
+            "trips --check."
+        ),
+    )
     args = parser.parse_args(argv)
+
+    try:
+        tiles = _parse_tiles(args.tiles)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
 
     root = Path(args.root).resolve()
     if args.notebook:
@@ -319,16 +619,31 @@ def main(argv=None) -> int:
             print(f"error: family not found: {args.family}", file=sys.stderr)
             return 2
 
-    results = [scan_notebook(p, args.min_dim, args.min_bytes) for p in paths]
-    total_hits = sum(len(r["hits"]) for r in results)
+    results = [scan_notebook(p, args.min_dim, args.min_bytes, tiles) for p in paths]
+    # --check ne rougit QUE sur les findings bloquants (dim/taille, #6891). Les
+    # advisory partially_empty_grid (#10319) sont rapportes mais non bloquants
+    # (phase 1 : mesure du taux de FP avant tout blocage).
+    blocking_hits = sum(
+        1 for r in results for h in r["hits"] if h.get("severity") != "advisory"
+    )
+    advisory_hits = sum(
+        1 for r in results for h in r["hits"] if h.get("severity") == "advisory"
+    )
+    total_hits = blocking_hits + advisory_hits
 
     if args.json:
-        payload = {"notebooks_scanned": len(results), "total_hits": total_hits, "results": results}
+        payload = {
+            "notebooks_scanned": len(results),
+            "total_hits": total_hits,
+            "blocking_hits": blocking_hits,
+            "advisory_hits": advisory_hits,
+            "results": results,
+        }
         print(json.dumps(payload, ensure_ascii=False, indent=2))
     else:
         print(_human_report(results))
 
-    if args.check and total_hits > 0:
+    if args.check and blocking_hits > 0:
         return 1
     return 0
 

--- a/scripts/notebook_tools/tests/test_detect_blank_figures.py
+++ b/scripts/notebook_tools/tests/test_detect_blank_figures.py
@@ -40,16 +40,25 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from detect_blank_figures import (  # noqa: E402
+    LARGE_UNIFORM_REGION,
     MIN_BYTES,
+    MIN_CONTENT_FRACTION,
     MIN_DIM,
     MIN_DISTINCT_COLORS,
+    MIN_TILES_AXIS,
     SKIP_DIRS,
+    TILE_TARGET_PX,
+    UNIFORM_TILE_STD,
+    CONTENT_TILE_STD,
     _OUTPUT_SUFFIX,
     _PNG_SIGNATURE,
     _classify_image,
     _decode_image,
     _flattened_pixels,
     _has_real_content,
+    _largest_uniform_region,
+    _parse_tiles,
+    _partially_empty_metric,
     detect_cell,
     _human_report,
     _iter_notebooks,
@@ -876,3 +885,248 @@ class TestGateWorkflowContract:
             "`|| true` makes rc always 0 and permanently disarms the gate; "
             "use `&& rc=0 || rc=$?`"
         )
+
+
+# ---------------------------------------------------------------------------
+# 12. Per-region partially-empty grid (#10319) -- advisory, non-blocking
+# ---------------------------------------------------------------------------
+# The #6891 founding class was an EMPTY figure (1x1, 70 B): the size/dimension
+# gate catches it. #10319 is the OTHER half: a figure that is LARGE and RICH
+# overall but has WHOLE SUBPLOTS empty (a 4x4 grid whose top 2 rows rendered
+# nothing). The three whole-image metrics (dim / bytes / distinct-colors) all
+# pass -- the rich half supplies enough colors. Only a per-tile statistic can
+# see the hole, and only a CONTIGUITY test (largest connected uniform region,
+# not scattered fraction) separates a real missing subplot from a normal sparse
+# matplotlib plot. These tests pin both the detection and the phase-1 contract:
+# advisory surfaces, but --check does NOT fail on it.
+
+def _make_grid_png_bytes(row_kinds, cell=120, cols=4):
+    """Synthesize a grid PNG: row_kinds[i] in {'rich','uniform'}.
+
+    A 'rich' cell is filled with uniform random noise (per-channel std ~73,
+    well above CONTENT_TILE_STD=25 -- a real-plot analog). A 'uniform' cell is a
+    solid beige (std 0 < UNIFORM_TILE_STD=10 -- the empty-render case). Each
+    row spans `cols` cells of `cell` px. Needs numpy + PIL (both transitive
+    matplotlib deps; importorskip'd at the class level below).
+    """
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("PIL")
+    from PIL import Image
+    import io
+
+    rows = len(row_kinds)
+    arr = np.zeros((rows * cell, cols * cell, 3), dtype=np.uint8)
+    for ri, kind in enumerate(row_kinds):
+        for ci in range(cols):
+            if kind == "rich":
+                rng = np.random.default_rng(ri * 1000 + ci)
+                block = rng.integers(0, 256, size=(cell, cell, 3), dtype=np.uint8)
+            else:
+                block = np.empty((cell, cell, 3), dtype=np.uint8)
+                block[:, :, 0] = 235
+                block[:, :, 1] = 220
+                block[:, :, 2] = 190
+            arr[ri * cell:(ri + 1) * cell, ci * cell:(ci + 1) * cell] = block
+    buf = io.BytesIO()
+    Image.fromarray(arr).save(buf, format="PNG")  # no positional mode (Pillow 13)
+    return buf.getvalue()
+
+
+# The canonical #10319 grid: 4 rows x 4 cols, top 2 rows empty, bottom 2 rich.
+# ~50 % of its area is one contiguous uniform block -> advisory at threshold 0.40.
+GRID_HALF_EMPTY = _make_grid_png_bytes(["uniform", "uniform", "rich", "rich"])
+# A grid where only the rich rows exist -> fully rich -> clean.
+GRID_FULL_RICH = _make_grid_png_bytes(["rich", "rich", "rich", "rich"])
+
+
+class TestPartiallyEmptyConstants:
+    def test_large_uniform_region_threshold(self):
+        # Phase-1 default calibrated on the corpus (p90 of largest-region = 0.33;
+        # the canonical 2/4-empty case = ~0.50 -> 0.40 catches it with margin).
+        assert LARGE_UNIFORM_REGION == 0.40
+
+    def test_min_content_fraction(self):
+        # Must have SOME content, else it's the out-of-scope "fully empty" case.
+        assert MIN_CONTENT_FRACTION == 0.15
+
+    def test_tile_std_thresholds(self):
+        # A tile is uniform below 10, content above 25; the [10,25] band is
+        # ambiguous (excluded from both counts so neither inflates artificially).
+        assert UNIFORM_TILE_STD == 10.0
+        assert CONTENT_TILE_STD == 25.0
+
+    def test_adaptive_tile_target(self):
+        # Adaptive grid aims at ~64px tiles, floored at 2x2.
+        assert TILE_TARGET_PX == 64
+        assert MIN_TILES_AXIS == 2
+
+
+class TestParseTiles:
+    def test_rxc_lowercase(self):
+        assert _parse_tiles("4x4") == (4, 4)
+
+    def test_rxc_uppercase_separator(self):
+        assert _parse_tiles("3X2") == (3, 2)
+
+    def test_none_means_adaptive(self):
+        assert _parse_tiles(None) is None
+        assert _parse_tiles("") is None
+
+    def test_non_rectangular_raises(self):
+        with pytest.raises(ValueError):
+            _parse_tiles("4")
+        with pytest.raises(ValueError):
+            _parse_tiles("4x4x4")
+
+    def test_below_min_axis_raises(self):
+        with pytest.raises(ValueError):
+            _parse_tiles("1x4")  # rows < MIN_TILES_AXIS
+
+
+class TestLargestUniformRegion:
+    def test_contiguous_block_size(self):
+        # A 4x4 tile map with the top 2 rows uniform -> largest component = 8.
+        tile_map = [[0] * 4 for _ in range(2)] + [[1] * 4 for _ in range(2)]
+        assert _largest_uniform_region(tile_map, 4, 4) == 8
+
+    def test_scattered_uniform_small_largest(self):
+        # 4 uniform tiles scattered (checkerboard) -> each is its own component of 1.
+        tile_map = [
+            [0, 1, 0, 1],
+            [1, 0, 1, 0],
+            [0, 1, 0, 1],
+            [1, 0, 1, 0],
+        ]
+        assert _largest_uniform_region(tile_map, 4, 4) == 1
+
+    def test_no_uniform_tiles(self):
+        tile_map = [[1, 1], [1, 1]]
+        assert _largest_uniform_region(tile_map, 2, 2) == 0
+
+    def test_diagonal_not_connected(self):
+        # 4-connectivity: diagonal tiles are NOT connected -> two components of 1.
+        tile_map = [
+            [0, 1],
+            [1, 0],
+        ]
+        assert _largest_uniform_region(tile_map, 2, 2) == 1
+
+
+class TestPartiallyEmptyMetric:
+    def test_half_empty_grid_flagged(self):
+        # THE #10319 case: 4x4 grid, top half empty -> advisory.
+        region = _partially_empty_metric(GRID_HALF_EMPTY)
+        assert region is not None
+        assert region["largest_uniform_region"] >= LARGE_UNIFORM_REGION
+        assert region["content_fraction"] >= MIN_CONTENT_FRACTION
+
+    def test_fully_rich_grid_not_flagged(self):
+        # A grid with no empty rows -> no large contiguous uniform region.
+        region = _partially_empty_metric(GRID_FULL_RICH)
+        assert region is None
+
+    def test_fully_uniform_not_flagged(self):
+        # Fully uniform (all empty) -> content_fraction = 0 < MIN_CONTENT_FRACTION.
+        # This is the out-of-scope "figure pleine mais vide" case: the signal is
+        # CONTRAST (uniform + content), and there is no content here.
+        fully_empty = _make_grid_png_bytes(["uniform", "uniform", "uniform", "uniform"])
+        region = _partially_empty_metric(fully_empty)
+        assert region is None
+
+    def test_tiles_override_propagates(self):
+        # An explicit --tiles 4x4 still flags the half-empty grid.
+        region = _partially_empty_metric(GRID_HALF_EMPTY, tiles=(4, 4))
+        assert region is not None
+        assert region["tiles"] == "4x4"
+
+    def test_returns_none_when_numpy_absent(self, monkeypatch):
+        # Degrade-gracefully: no numpy -> None (caller keeps blocking behaviour,
+        # no coverage regression). Same contract as _has_real_content.
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *a, **k):
+            if name == "numpy":
+                raise ImportError("simulated absent numpy")
+            return real_import(name, *a, **k)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        assert _partially_empty_metric(GRID_HALF_EMPTY) is None
+
+
+class TestClassifyImageAdvisory:
+    def test_half_empty_returns_advisory_finding(self):
+        result = _classify_image("image/png", GRID_HALF_EMPTY, MIN_DIM, MIN_BYTES)
+        assert result is not None
+        assert result["severity"] == "advisory"
+        assert any("partially_empty_grid" in r for r in result["reasons"])
+        assert "region_detail" in result
+
+    def test_fully_rich_returns_none(self):
+        # A fully-rich large image scans clean (no blocking, no advisory).
+        result = _classify_image("image/png", GRID_FULL_RICH, MIN_DIM, MIN_BYTES)
+        assert result is None
+
+    def test_blocking_takes_precedence_over_advisory(self):
+        # A degenerate (1x1) image is blocking regardless of region logic.
+        raw = _make_png(1, 1)
+        result = _classify_image("image/png", raw, MIN_DIM, MIN_BYTES)
+        assert result is not None
+        assert result["severity"] == "blocking"
+
+
+class TestAdvisoryDoesNotBlock:
+    """The phase-1 contract (#10319 acceptance criterion 4): advisory findings
+    appear in the report/JSON but NEVER trip --check (the CI gate stays green).
+    Blocking is deferred until the FP rate is measured by vision triage."""
+
+    def test_advisory_only_notebook_check_exits_zero(self, tmp_path):
+        # A notebook whose only figure is a partially-empty grid: --check must
+        # NOT fail (advisory is non-blocking).
+        b64 = base64.b64encode(GRID_HALF_EMPTY).decode("ascii")
+        nb_path = _write_nb(tmp_path / "grid.ipynb", [_code_cell_with_png(b64)])
+        rc = main([str(nb_path), "--check"])
+        assert rc == 0
+
+    def test_advisory_appears_in_json_payload(self, tmp_path, capsys):
+        b64 = base64.b64encode(GRID_HALF_EMPTY).decode("ascii")
+        nb_path = _write_nb(tmp_path / "grid.ipynb", [_code_cell_with_png(b64)])
+        rc = main([str(nb_path), "--json"])
+        assert rc == 0
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["blocking_hits"] == 0
+        assert parsed["advisory_hits"] == 1
+        assert parsed["total_hits"] == 1
+
+    def test_blocking_still_trips_check(self, tmp_path):
+        # Regression guard: a blocking 1x1 figure still fails --check.
+        nb_path = _write_nb(tmp_path / "bad.ipynb", [_code_cell_with_png(PNG_1x1_B64)])
+        assert main([str(nb_path), "--check"]) == 1
+
+    def test_advisory_in_human_report_under_advisory_heading(self, tmp_path):
+        b64 = base64.b64encode(GRID_HALF_EMPTY).decode("ascii")
+        nb_path = _write_nb(tmp_path / "grid.ipynb", [_code_cell_with_png(b64)])
+        result = scan_notebook(nb_path)
+        report = _human_report([result])
+        assert "Degenerate figures : 0" in report  # blocking count unchanged
+        assert "Advisory" in report  # surfaced in its own section
+        assert "partially_empty_grid" in report
+        assert "non-blocking" in report  # the phase-1 caveat is stated
+
+    def test_tiles_flag_threaded_to_scan(self, tmp_path, capsys):
+        # --tiles 4x4 reaches _classify_image via scan_notebook.
+        b64 = base64.b64encode(GRID_HALF_EMPTY).decode("ascii")
+        nb_path = _write_nb(tmp_path / "grid.ipynb", [_code_cell_with_png(b64)])
+        rc = main([str(nb_path), "--json", "--tiles", "4x4"])
+        assert rc == 0
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["advisory_hits"] == 1
+        # the region_detail.tiles reflects the override
+        hit = parsed["results"][0]["hits"][0]
+        assert hit["region_detail"]["tiles"] == "4x4"
+
+    def test_malformed_tiles_exits_2(self, tmp_path, capsys):
+        nb_path = _write_nb(tmp_path / "ok.ipynb", [_code("x = 1")])
+        rc = main([str(nb_path), "--tiles", "garbage"])
+        assert rc == 2
+        assert "tiles" in capsys.readouterr().err.lower()


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: DEEP/genai #10334 (MERGED)

## Quoi

Une métrique par tuile `partially_empty_grid` ajoutée à `detect_blank_figures.py` (#10319). Les trois métriques existantes (dimension / payload / couleurs distinctes) raisonnent sur des agrégats de l'image ENTIÈRE : une grille matplotlib dont seules certaines rangées de sous-graphes sont vides est un grand PNG riche en couleurs — elle passe les trois au vert alors que la moitié du contenu pédagogique est absent (cas #10319 : grille 4×4 dont la moitié supérieure est uniforme). La nouvelle métrique découpe l'image en tuiles (adaptive ~64 px, ou `--tiles RxC`), classe chaque tuile uniforme/contenu par écart-type par canal, et signale (advisory) quand une GRANDE région uniforme CONNEXE (>= 0.40 des tuiles) coexiste avec du contenu (>= 0.15). La connexité — pas la fraction éparpillée — est le discriminateur : un plot matplotlib normal a ses tuiles blanches EPARPILLÉES (petites composantes connexes de marges/interstices), un sous-graphe manquant est un seul grand bloc connexe.

## Preuve

- `python -m pytest scripts/notebook_tools/tests/test_detect_blank_figures.py -q` → **104 passed** (77 existing + 27 new), non-regression verte.
- `-W error::DeprecationWarning` → 104 passed (nouveau code numpy/PIL sans warning ; contrat Pillow-13 tenu).
- Cas synthétisé canonique (grille 4×4, 2 rangées vides sur 4) → flagged advisory `largest_empty_region=0.5` ; grille entièrement remplie → `None` ; grille entièrement uniforme → `None` (hors scope « figure pleine mais vide », correct : le signal est le contraste intra-image).
- Contrat CLI `--check` : advisory-only → **exit 0** (le gate ne rougit PAS) ; blocking 1×1 → exit 1 (préservé) ; `--tiles` malformé → exit 2. JSON scindé `blocking_hits` / `advisory_hits` + `region_detail`.
- Calibration sur le corpus (1100 figures candidates sur `origin/main`) : distribution `largest_uniform_region` p50=0.11, p90=0.33, p95=0.43 ; cas canonique 2/4-empty = 0.50. Sweep de seuils : 0.20→27 %, 0.30→13 %, **0.40→6.7 % (67/994 notebooks)**, 0.50→2 %. Seuil 0.40 choisi : capte le cas canonique (0.50) avec marge, laisse 94 % des figures muettes, ne surfacent que la queue top ~6 % pour tri visuel. Sweep complet cité dans la docstring du module.
- Aucun consommateur n'appelle `_classify_image` directement (grep repo-wide) ; le pipeline quantbook invoque le CLI `--family QuantConnect --check` (contrat exit-1-sur-blocking préservé — l'advisory était non-détecté avant, reste exit-0 maintenant). Shape du finding préservée : `mime`/`bytes`/`dimensions`/`reasons` inchangés, `severity` + `region_detail` ajoutés.

## Perimetre

- `scripts/notebook_tools/detect_blank_figures.py` (+385) : constantes `LARGE_UNIFORM_REGION=0.40`, `MIN_CONTENT_FRACTION=0.15`, `UNIFORM_TILE_STD`, `CONTENT_TILE_STD`, `TILE_TARGET_PX`, `MIN_TILES_AXIS` ; `_partially_empty_metric()` (tuilage adaptatif + std par canal par tuile) ; `_largest_uniform_region()` (flood-fill 4-connexe pur Python, pas de scipy) ; `_parse_tiles()` (RxC) ; CLI `--tiles` ; séparation blocking/advisory dans `_classify_image` / `_human_report` / `main` (`--check` exit 1 sur blocking seulement ; advisory dans sa propre section de rapport).
- `scripts/notebook_tools/tests/test_detect_blank_figures.py` (+256) : 27 tests (constantes, `_parse_tiles` cas valides/invalides, `_largest_uniform_region` connexité/diagonal/scattered, métrique advisory half-empty/fully-rich/fully-uniform, `--tiles` propagé, advisory-ne-tripe-pas-`--check`, advisory-dans-JSON, malformé→exit 2, degrade-gracefully sans numpy).
- Hors scope : phase 2 (blocage) différée après tri visuel des 67 candidats par les lanes qui voient (MiniMax/ai-01) — #10319 critère 4. Le ré-tuning du seuil 0.40 post-triage serait un suivi séparé.
- Note honnêteté : 1 test unrelated échoue dans le dir complet (`test_twin_registry_integrity::test_audit_shas_exist_in_file_history`, derive de SHA `Sudoku-14-BDD-Python`) — pré-existant, indépendant de cette branche (aucun fichier twin/sudoku/registry touché ; la branche ne modifie QUE les 2 fichiers ci-dessus).

Closes #10319

🤖 Generated with [Claude Code](https://claude.com/claude-code)
