### PR TITLE
chore(variation-tag): retire check-short-header + variation-short-header-missing label (#10330)

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -325,126 +325,14 @@ jobs:
           fi
           exit 0
 
-  # #9861 -- short-header trio (Quoi / Preuve / Perimetre) -- "rougit sur une
-  # PR dont le body n'a pas les trois cles, et passe sur les PRs conformes
-  # existantes" (acceptance #9861). The convention spreads by ADVISORY, not
-  # gate: a body that has none of the three keys gets
-  # `variation-short-header-missing`, but only on PRs that are NEW relative
-  # to the rollout. Existing PRs that just never adopted the trio do NOT
-  # turn red -- they pass as-is. The detector is the same `grain_tag.py`
-  # extractor: `parse_short_header` returns {quoi, preuve, perimetre}, each
-  # None when the key is absent; `short_header_complete` is True only when
-  # all three are present (the only case the flag does NOT pose).
-  #
-  # The flag is advisory, exit 0 by design (the whole workflow is advisory:
-  # #9485 lesson -- "un garde dont l'echec est muet n'est pas un garde",
-  # but a guard that BLOCKS on rollout would redden every PR in the repo
-  # the day the convention is rolled out, which is the failure mode the
-  # issue rejects).
-  check-short-header:
-    # Job name carries the `advisory` marker so pr_gate.is_advisory() diverts
-    # it out of `pending` (incident #10104: the job posts a check-run that can
-    # linger in_progress, and a name without the marker made pr_gate.py wait on
-    # it until the 90-min gate timeout -> every PR lacking the trio BLOCKED).
-    # Same convention as "CJK residue advisory (label, non-blocking)" etc.
-    name: Check short-header trio (advisory, label, non-blocking, #9861)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the shared tag extractor (sparse)
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            scripts/grain_tag.py
-      - name: Inspect PR body for short-header trio (#9861)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
-        run: |
-          set -uo pipefail
-
-          # Meme garde-fou que les deux jobs precedents : bots et forks hors
-          # scope (les PRs etudiantes n'ont pas de convention interne,
-          # .claude/rules/student-pr-reviews.md).
-          case "$PR_AUTHOR" in
-            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
-          esac
-          if [ "$IS_FORK" = "true" ]; then
-            echo "PR issue d'un fork : hors scope (PR etudiante)."
-            exit 0
-          fi
-
-          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
-          python3 scripts/grain_tag.py --body-file /tmp/pr_body.txt > /tmp/tag.json 2>/dev/null || true
-
-          # Champs courts (cf parse_short_header). `_field` est tolerant a un
-          # /tmp/tag.json absent ou vide -- fallback = defauts surs qui
-          # declenchent le label (un parseur en panne n'efface JAMAIS un
-          # defaut, c'est l'inverse qui serait suspect).
-          _field() { python3 -c "import json; print(json.load(open('/tmp/tag.json')).get('$1'))" 2>/dev/null || echo "None"; }
-          QUOI=$(_field quoi)
-          PREUVE=$(_field preuve)
-          PERIMETRE=$(_field perimetre)
-          COMPLETE=$(_field short_header_complete)
-
-          DEFECTS=""
-          note_defect() { DEFECTS="$DEFECTS $1"; }
-
-          # Les trois cles : si AUCUNE n'est la, on flag. Un partiel (1 ou
-          # 2 presentes) NE flag PAS -- l'objectif au rollout est de
-          # signaler les PRs qui n'ont meme pas commence a adopter la
-          # convention, pas de penaliser les adoptions partielles. Le
-          # durcissement progressif ("1 absente = flag") est une decision
-          # separee, prise apres que la flotte a adopte le pattern.
-          if [ "$COMPLETE" = "True" ]; then
-            echo "Short-header trio complet : Quoi + Preuve + Perimetre presents."
-            echo "::notice::Short-header conforme (3/3 cles presentes)."
-          elif [ "$QUOI" = "None" ] && [ "$PREUVE" = "None" ] && [ "$PERIMETRE" = "None" ]; then
-            echo "::warning::Short-header trio totalement absent (ni Quoi, ni Preuve, ni Perimetre). Issue #9861 demande 'Quoi: <une ligne>, Preuve: <une ligne>, Perimetre: <une ligne>' juste apres le tag Grain:. Advisory, non bloquant -- la convention se rollout progressivement."
-            note_defect variation-short-header-missing
-          else
-            echo "Short-header trio partiel (1 ou 2 cles presentes) -- pas flagge au rollout (adoption partielle toleree)."
-          fi
-
-          # Traduction en label distinct (lisible dans gh pr list --json labels).
-          # `create` tolere l'echec (|| true), `add` aussi. `remove` sur label
-          # absent est l'issue attendue au cas nominal (cf variation-tag-guard
-          # -- la justification vit dans le commentaire du workflow, pas dans
-          # une nouvelle regle de harnais).
-          LABEL="variation-short-header-missing"
-          COLOR="FEF2C0"
-          DESC="PR sans short-header trio (Quoi/Preuve/Perimetre, #9861) -- convention en rollout progressif"
-          case " $DEFECTS " in
-            *" $LABEL "*)
-              gh label create "$LABEL" --description "$DESC" --color "$COLOR" --force || true
-              gh pr edit "$PR_NUMBER" --add-label "$LABEL" || true
-              # Commentaire idempotent. On NE le pose que si la PR ne le
-              # porte pas deja -- un push ulterieur ne re-spam pas. Meme
-              # marqueur HTML invisible que G-VAR-2, par souci de coherence.
-              MARK="<!-- short-header-rollout -->"
-              if ! gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' 2>/dev/null | grep -qF "$MARK"; then
-                BODY="${MARK}
-          **Short-header trio absent** (advisory, non bloquant, #9861).
-          La convention issue de #9861 demande trois cles en tete du body, juste apres le tag \`Grain:\` :
-
-          \`\`\`
-          Quoi:       <une ligne -- ce que la PR change>
-          Preuve:     <une ligne -- commande ou run qui l'atteste>
-          Perimetre:  <une ligne -- fichiers/domaine touches, hors-scope explicite>
-          \`\`\`
-
-          Les trois reponses permettent a un reviewer de trouver l'essentiel en tete, sans lire dix ecrans. Le detail reste autorise plus bas (valeur d'audit). Convention en rollout progressif : les PRs adoptees passent, les PRs sans aucune des trois cles sont signalees ici -- un adoption partielle (1 ou 2 cles) NE flag PAS, par design."
-                gh pr comment "$PR_NUMBER" --body "$BODY" 2>/dev/null || true
-              fi
-              ;;
-            *)
-              gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
-              ;;
-          esac
-          exit 0
+  # c.10330 / PR retire le job `check-short-header` et le label
+  # `variation-short-header-missing`. La convention #9861 (Quoi/Preuve/Perimetre)
+  # etait volontairement non-promulguee (cf. titre de l'issue : "pas une
+  # nouvelle regle"), mais l'organe etait cable quand meme et labellisait
+  # 69 % du flux (207/300 PR) -- un signal qui se leve sur 7 PR sur 10 ne
+  # discrimine plus rien. `parse_short_header` reste dans `scripts/grain_tag.py`
+  # (code teste, sans cout quand personne ne l'appelle), disponible si la
+  # convention est un jour promulguee avec une regle dans le harnais.
 
   # #10045 -- the BLOCKING half of the variation-tag guard. The job above
   # (check-variation-tag) is advisory (exit 0) -- it posts labels but never

--- a/scripts/ci/variation_prev_guard.py
+++ b/scripts/ci/variation_prev_guard.py
@@ -39,11 +39,11 @@ Exit codes:
 
 The existing `check-variation-tag` job is advisory (exit 0): it posts labels
 and lets the coordinator decide. That is correct for cosmetic tag defects
-(offlist genre, missing short-header). It is WRONG here because the failure is
-DESTRUCTIVE and happens AT MERGE TIME: the squash commit message is what
-GitHub parses, and an advisory label does not stop the merge. Only a required
-check that turns `PR gate` red before merge prevents the auto-close -- the
-same shape as `check-variation-tag-required` (#10045).
+(offlist genre). It is WRONG here because the failure is DESTRUCTIVE and
+happens AT MERGE TIME: the squash commit message is what GitHub parses,
+and an advisory label does not stop the merge. Only a required check that
+turns `PR gate` red before merge prevents the auto-close -- the same shape
+as `check-variation-tag-required` (#10045).
 
 ## Why it scans commit messages (not just the body)
 

--- a/scripts/ci/variation_tag_required.py
+++ b/scripts/ci/variation_tag_required.py
@@ -28,10 +28,9 @@ Exit codes:
 ## Design rules that matter
 
 1. **The blocking decision is a one-line guard**: `present AND lane`. Nothing
-   else. The advisory job has the full nuance (GENRE offlist, short-header
-   trio, malformed TIER) -- this one only blocks the two cases that make the
-   grain STRUCTURALLY UNACCOUNTABLE (#9485 -- "incomptable" = a cap that cannot
-   be computed).
+   else. The advisory job has the full nuance (GENRE offlist, malformed TIER)
+   -- this one only blocks the two cases that make the grain STRUCTURALLY
+   UNACCOUNTABLE (#9485 -- "incomptable" = a cap that cannot be computed).
 2. **The check is run by the existing `scripts/grain_tag.py` extractor** (the
    single source of truth, #9485). A separate regex is a divergence waiting
    to happen; if the toleration surface moves (e.g. a new form survives),
@@ -68,11 +67,11 @@ at review time.
   decides whether the tag is REQUIRED to be present. The advisory job
   stays advisory even if this one is removed.
 - Workflow YAML stays thin: the bash block calls one Python script. The
-  same shape as the existing `check-short-header` job.
+  same shape as the remaining always-on jobs.
 - Testability: a CLI with a stdout JSON contract is trivial to assert on.
   Workflow-only logic (paths-filter check, fork exclusion) is YAML and
-  relies on the same harness-hygiene review that landed the existing
-  three jobs.
+  relies on the same harness-hygiene review that landed the remaining
+  always-on jobs.
 
 ## Run locally
 

--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -36,11 +36,12 @@ discipline). Each key is a single line, anywhere after the Grain tag:
     Perimetre:  <one-line -- files/domain touched, and what is explicitly
                          out of scope>
 
-Tolerant to bold (`**Quoi** :`), case, and extra whitespace. The trio is
-**advisory** at first: the guard flags `variation-short-header-missing` only
-when ALL THREE are absent (so existing PRs do not suddenly turn red the day
-the convention is rolled out). Hardening to "1 absent = flag" is a separate
-gate, after the convention has spread.
+Tolerant to bold (`**Quoi** :`), case, and extra whitespace. c.10330 / PR
+retired the `check-short-header` CI job that labelled `variation-short-header-missing`
+on 69 % of PRs without the convention ever being promulgated in the harness
+(#10330). The parser stays in place (pure function, no cost when no caller
+invokes it); a future convention rollout would re-cable a job and pair it
+with a harnais rule.
 
 `parse_short_header` returns {quoi, preuve, perimetre} (each | None).
 `parse_grain_tag` is unchanged (back-compat for the variation_light_cap organ).
@@ -340,12 +341,13 @@ def extract_lane(body: str | None) -> str | None:
 #
 # The detailed body below stays authorised and welcome (audit value) -- the
 # goal is NOT to censor the argument, it is to guarantee the reviewer finds
-# those three answers AT THE TOP, in three lines. The trio is advisory at
-# rollout (issue spec: "rougit sur une PR dont le body n'a pas les trois
-# cles"), so we flag `variation-short-header-missing` only when ALL THREE
-# are absent -- existing PRs that have none of the three keys still pass,
-# so the convention spreads without churn. Hardening to "1 absent = flag"
-# is a separate decision, taken when the fleet has adopted the convention.
+# those three answers AT THE TOP, in three lines.
+#
+# c.10330 / PR retired the `check-short-header` CI job: the convention was
+# voluntarily not promulgated (cf. issue title "pas une nouvelle regle") but
+# the organ was cabled and labelled 69 % of PRs without ever discriminating
+# anything. The function `parse_short_header` below stays in place as a pure
+# parser -- available if a future harness rule ever adopts the convention.
 #
 # Same noise discipline as `_GRAIN_FULL_RE` / `_LANE_RE`: bold (`**`), backticks
 # (`` ` ``), title hashes (`#`), blockquotes (`>`) are stripped BEFORE matching.
@@ -369,10 +371,12 @@ def parse_short_header(body: str | None) -> dict:
     """Extract the {Quoi, Preuve, Perimetre} short-header trio (#9861).
 
     Each key is independent: a body can carry one, two, or all three -- the
-    caller decides what to do with the partial coverage. The CI guard
-    (`check-short-header` job in `variation-tag-guard.yml`) flags a PR only
-    when **all three are absent**, by design (existing PRs have none of the
-    three and must not suddenly turn red).
+    caller decides what to do with the partial coverage. c.10330 / PR retired
+    the `check-short-header` CI job (#10330): the convention was not
+    promulgated in the harness, so the label `variation-short-header-missing`
+    flagged 69 % of PRs without ever discriminating anything. The function
+    stays in place -- pure parser, no cost when no caller invokes it,
+    available if the convention is one day promulgated.
 
     Two presentation forms are recognised (#10163 acceptance):
 

--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -238,11 +238,13 @@ def platform_delivered(checks: Sequence[dict], always_on_jobs: frozenset[str]) -
 
     The delivery canary (rule 8). Judges on observed NAMES -- the raw input to
     `classify` -- and deliberately NOT on the `ok` bucket: at least two
-    always-on jobs are themselves advisory (e.g. the repo-size advisory, the
-    short-header advisory trio) and `classify` diverts a non-green advisory out
-    of `ok` into `advisory`. Judging `ok` would therefore flag a healthy PR whose
-    only always-on happened to be a red advisory. Judging names sidesteps the
-    trap: a delivered advisory job is still present by name.
+    always-on jobs are themselves advisory (e.g. the repo-size advisory and
+    former short-header trio, both advisory-diverted) and `classify` diverts a
+    non-green advisory out of `ok` into `advisory`. Judging `ok` would therefore
+    flag a healthy PR whose only always-on happened to be a red advisory.
+    Judging names sidesteps the trap: a delivered advisory job is still present
+    by name. The short-header job was retired by c.10330 / PR and is no longer
+    part of the always-on set; this comment is kept as a trace for reviewers.
 
     A check matches an always-on job when the normalised names are equal, or when
     the observed name ends with " / <job>" (GitHub's "<workflow> / <job>"

--- a/scripts/tests/test_grain_tag.py
+++ b/scripts/tests/test_grain_tag.py
@@ -178,9 +178,10 @@ def test_short_header_partial_two_of_three():
     assert sh["quoi"] == "doc-resync for #9756"
     assert sh["preuve"] == "diff --stat on README.md"
     assert sh["perimetre"] is None
-    # The guard checks `all three absent`: partial coverage does NOT trip the
-    # `variation-short-header-missing` label. (Hardening to "1 absent = flag"
-    # is a separate decision; see issue body.)
+    # The trio is partial: c.10330 / PR retired the `check-short-header` job
+    # that labelled `variation-short-header-missing` on PRs with all three keys
+    # absent. The parser here is still used (kept for a future convention
+    # rollout); what changed is the gating decision -- no job, no flag.
     assert not all(sh[k] is not None for k in ("quoi", "preuve", "perimetre"))
 
 

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -369,18 +369,29 @@ def test_advisory_marker_is_case_insensitive():
     assert bad == [] and len(advisory) == 1
 
 
-def test_short_header_trio_job_name_is_advisory_diverted():
-    """Incident #10104 -- the short-header trio job is advisory by design
+def test_short_header_trio_job_was_retired_by_c10330():
+    """Incident #10104 -- the short-header trio job was advisory by design
     (exit 0, label-only, see variation-tag-guard.yml comment) but its job name
     originally lacked the `advisory` marker. A lingering in_progress check-run
     then made pr_gate.py wait on it until the 90-min timeout, blocking every PR
     whose body lacked the Quoi/Preuve/Perimetre trio (e.g. #10104 itself).
 
-    The job name now carries the marker; this test pins the invariant so a
-    future rename that drops `advisory` is caught here, not by a stuck gate.
+    c.10330 / PR retired the job entirely: the convention was voluntarily not
+    promulgated (cf. issue title "pas une nouvelle regle"), so the label
+    `variation-short-header-missing` flagged 69 % of PRs without ever
+    discriminating anything. The marker invariant from #10104 is no longer
+    load-bearing (no job means no risk of a stuck gate), but the contract on
+    `is_advisory` is preserved: if someone re-cables a job with the same name
+    pattern, the marker MUST come back with it, otherwise #10104 resurrects.
     """
+    # The retired job name still routes through is_advisory() if ever seen on a
+    # check-run (e.g. from a stale in-progress hung-run). Pin the marker:
     job_name = "Check short-header trio (advisory, label, non-blocking, #9861)"
-    assert pr_gate.is_advisory(job_name), "short-header job name must carry the advisory marker"
+    assert pr_gate.is_advisory(job_name), (
+        "if the short-header job is ever re-cabled, its name MUST carry the "
+        "advisory marker to prevent a recurrence of the #10104 stuck-gate"
+    )
+    # And the resulting pending check must not hold the gate:
     checks = [run(job_name, None, status="in_progress"), run("Lean CI", "success")]
     pending, bad, _ok, advisory = pr_gate.classify(checks, "PR gate")
     assert pending == [] and bad == [], "a hung short-header advisory must not hold the gate"


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #10340

# PR c.10330 — Retire `check-short-header` + `variation-short-header-missing` (label non discriminant, 69% du flux)

## Contexte — issue #10330 (under-quota noise au merge-gate)

Le job `check-short-header` du workflow `variation-tag-guard.yml` appliquait le label `variation-short-header-missing` sur les PRs dont le body ne portait pas les trois cles `Quoi: / Preuve: / Perimetre:` (convention `#9861`).

Diagnostic premiere main :
1. **La convention n'a jamais ete promulguée dans le harnais** (cf. titre de l'issue `#9861` : « pas une nouvelle regle », juste une proposition de convention facultative).
2. **L'organe a ete cable quand meme** — sortie de `scripts/grain_tag.py` + job CI + label.
3. **207/300 PRs (≈ 69 %) sont labellisees** par ce seul guard — un signal qui se leve sur 7 PRs sur 10 **ne discrimine plus rien** (les PRs labellisees ne sont pas distinguables des PRs non-labellisees).
4. **Aucun autre organe ne depend de ce label** (pas de reviewer auto, pas de merge-gate, pas de coordination).

Conclusion c.10330 : **delete first** (mandat user no-pendulum : « quand une ligne de prompt/regle cause un mauvais comportement, la supprimer ; n'ajouter un remplacant que si sa suppression laisse un vide que les autres directives ne couvrent pas »). Le vide ici n'existe pas — la convention n'a jamais ete promulguée, donc ne pas la promulguer ne casse rien.

## Fix — retirer l'organe, garder le parser

| Fichier | Changement |
|---|---|
| `.github/workflows/variation-tag-guard.yml` | Supprime le job `check-short-header` (~110 lignes) et son bloc de commentaires qui justifiaient l'advisory roll-out. Remplace par un commentaire bref (7 lignes) documentant la retraita + reference `c.10330`. |
| `scripts/grain_tag.py` | Docstring + commentaire de section de `parse_short_header` re-ecrits pour refleter la retraita (le parser reste comme pure function). Commentaire d'introduction du module egalement mis a jour. |
| `scripts/ci/variation_tag_required.py` | 1 reference `short-header trio` dans la justification design retiree. |
| `scripts/ci/variation_prev_guard.py` | 1 reference « missing short-header » dans la justification BLOCKING retiree. |
| `scripts/pr_gate.py` | Commentaire `platform_delivered` mis a jour (cite desormais le job « former » comme trace pour reviewers). |
| `scripts/tests/test_pr_gate.py` | `test_short_header_trio_job_was_retired_by_c10330` (renomme, docstring etabli, intention preservee : si le job est re-cable un jour, le marker `advisory` DOIT revenir avec, sinon la stuck-gate de #10104 ressucite). |
| `scripts/tests/test_grain_tag.py` | 1 commentaire historique sur le label mis a jour (les tests du parser en eux-memes restent, puisque le parser reste). |

**Le parser `parse_short_header` reste dans `scripts/grain_tag.py`** — pure function, sans cout quand aucun caller ne l'invoque, **disponible** si la convention `#9861` est un jour promulguée avec une regle dans le harnais (laquelle, le cas echeant, meritera une nouvelle CI job et un nouveau label — a decider le moment venu, pas en pre-rollout).

**Aucun appelant actif de `parse_short_header` dans le code actuel.** Une recherche `grep -rn parse_short_header scripts/` ne trouve que des references dans `scripts/grain_tag.py` (la definition + 1 usage interne pour `short_header_complete`) + les tests. Aucun consommateur productif → retrait inoffensif.

## Verification

1. **Tests unitaires : `pytest scripts/tests/`** → **1950 passed, 18 skipped, 5 xfailed** en 83.27s. Zero regressions. Les tests de `parse_short_header` dans `test_grain_tag.py` continuent de passer (la fonction n'est pas modifiee).
2. **Tests specifiques : `pytest scripts/tests/test_grain_tag.py scripts/tests/test_pr_gate.py scripts/tests/test_variation_tag_required.py scripts/tests/test_variation_prev_guard.py`** → **100 passed** en 1.28s.
3. **YAML parse** : `python -c "import yaml; yaml.safe_load(open('.github/workflows/variation-tag-guard.yml'))"` → OK. Jobs presents : `['check-variation-tag', 'check-light-cap', 'check-variation-tag-required', 'check-prev-close-keyword-required', 'check-close-keyword-pr-ref-required']` — `check-short-header` est bien absent.
4. **`is_advisory` invariant preservee** : `test_short_header_trio_job_was_retired_by_c10330` valide que le nom historique du job porte toujours le marker `advisory` dans `pr_gate.is_advisory()` — si quelqu'un re-cable un job avec ce nom sans le marker, le test rouge immediatement.

## Diff stat

```
 .github/workflows/variation-tag-guard.yml | 128 ++----------------------------
 scripts/ci/variation_prev_guard.py        |  10 +--
 scripts/ci/variation_tag_required.py      |  13 ++-
 scripts/grain_tag.py                      |  34 ++++----
 scripts/pr_gate.py                        |  12 +--
 scripts/tests/test_grain_tag.py           |   7 +-
 scripts/tests/test_pr_gate.py             |  21 +++--
 7 files changed, 65 insertions(+), 160 deletions(-)
```

**Net −95 lignes** (deletions > insertions, mais c'est du **retrait d'un organe + cleanup de references obsoletes**, pas une regression sur du code metier — l'anti-regression red-flag ne s'applique pas ici, cf `anti-regression.md` red-flag « remplace une preuve/impl par un stub » : rien n'est remplace, juste deserte).

## Scope & hygiene

- **Un seul livrable par PR** (cf [catalog-pr-hygiene.md](catalog-pr-hygiene.md) R3) : un sujet = retirer un job de garde devenu non-discriminant.
- **Pas de regen catalogue** : `COURSE_CATALOG.generated.json`/`.md` byte-identique a `origin/main` (cf R1).
- **Branch from origin/main a jour** : HEAD `32e383e47` (cf R2 rebase frais).

## Liens

- Closes #10330 (le seul + l'unique issue que cette PR resout entierement — la convention `#9861` reste non-promulguée par design, aucune action complementaire requise).
- See #9861 (la convention source — reste ouverte, la retraita ne la clot pas, juste elle cesse d'etre cablee par accident).
- See #10104 (l'incident fondateur du marker `advisory` dans le nom du job — la convention `is_advisory` reste pinned par le test renomme, gate anti-resurrection preservee).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
