### PR TITLE
feat(search,#2161): MGS-7b 3rd exercise — Schwefel corner vs Rastrigin center topology

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7b-LandscapeMultidim.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7b-LandscapeMultidim.ipynb
@@ -79,7 +79,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -89,10 +88,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -107,7 +103,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -119,8 +114,6 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -169,13 +162,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -775,6 +766,44 @@
     "Console.WriteLine($\"Pixels qui different entre 2 seeds : {totalDiff}/{80 * 80} = {100.0 * totalDiff / (80 * 80):F1}%\");\n",
     "// Attendu : une proportion significative (>50%) — la projection MAX injecte de la\n",
     "// variabilite qui depend de l'ordre de visite Parallel.For des pixels.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3f1c7e9",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Schwefel — l'optimum au coin vs Rastrigin au centre\n",
+    "\n",
+    "Schwefel est l'exception topologique de la série (cellule Schwefel ci-dessus) : son optimum global se cache dans un **coin** du domaine ($x_i \\approx 420{,}97$ sur $[-500, 500]$), alors que Rastrigin et Ackley ont leur optimum au **centre** (origine). La projection MAX préserve-t-elle cette différence de position ?\n",
+    "\n",
+    "**Mesure à coder** : pour `SchwefelFitness` et `RastriginFitness` en dimension 2, extraire la valeur du canal rouge au **centre** de la heatmap et aux **4 coins**, puis identifier où se trouve le minimum rouge. *Intuition à vérifier* : pour Rastrigin, le centre doit être le point le plus sombre (canal rouge minimal, optimum à l'origine) ; pour Schwefel, c'est l'un des coins. Si la projection efface la distinction, c'est le signe que la dimension cachée brouille la topologie 2-D — exactement le piège qui rend Schwefel difficile pour une métaheuristique myope."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "b7e2d4f1",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice 3 a completer : comparer centre vs coins du canal rouge (Schwefel vs Rastrigin).\r\n"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : Schwefel (optimum au coin) vs Rastrigin (optimum au centre).\n",
+    "// Pour chaque fonction en dimension 2, comparer le canal rouge au centre vs aux 4 coins.\n",
+    "// Squelette : le pipeline RenderHeatmap est documente dans les cellules ci-dessus.\n",
+    "// TODO etudiant :\n",
+    "//   1. using var hS = KnownFunctionLandscape.RenderHeatmap(new SchwefelFitness(),\n",
+    "//        dimension: 2, nbSamples: 50, rng: new Random(2026), width: 80, height: 80);\n",
+    "//   2. idem pour RastriginFitness (hR).\n",
+    "//   3. Pour chaque heatmap : extraire h.Bitmap.GetPixel(40, 40).R (centre) et\n",
+    "//      les 4 coins (0,0),(79,0),(0,79),(79,79).R.\n",
+    "//   4. Afficher ou se trouve le minimum rouge pour Schwefel vs Rastrigin.\n",
+    "Console.WriteLine(\"Exercice 3 a completer : comparer centre vs coins du canal rouge (Schwefel vs Rastrigin).\");"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: DEEP/training #10302

## Quoi

`MGS-7b-LandscapeMultidim.ipynb` (Search/Part4-Metaheuristics) passait de 2 à 3 exercices. La règle HARD [three-exercises-per-notebook](../../MyIA.AI.Notebooks/Search/Part4-Metaheuristics/../../.claude/rules/three-exercises-per-notebook.md) (#2161) exige `>=3` exercices par notebook pédagogique. PR #8152 avait déjà porté la trilogie 7c/7d à 3 exercices ; **7b restait à 2** (Ex1 convergence `nbSamples`, Ex2 variabilité seed).

Ajout d'un **Exercice 3** : Schwefel (optimum au coin `x_i ≈ 420.97`) vs Rastrigin (optimum au centre). L'étudiant compare le canal rouge au **centre** vs aux **4 coins** des heatmaps, et vérifie si la projection MAX préserve la position de l'optimum — distinguant la topologie coin-centre (Schwefel) du centre-seul (Rastrigin).

## Non-trivialité (Prong B, #3801)

L'exercice n'est pas un BFS-vs-A* dégénéré : il teste si la projection MAX (qui cache les dimensions supérieures) préserve ou efface l'information topologique sur la *position* de l'optimum. Schwefel est précisément le cas-piège (optimum trompeur loin du centre). La mesure est falsifiable (le centre est-il le minimum rouge pour les deux fonctions, ou seulement Rastrigin ?). Distinct de Ex1 (effet `nbSamples`) et Ex2 (effet seed).

## Acceptance

- [x] **Genuine stub** — `// TODO étudiant` squelette (4 étapes documentées), `Console.WriteLine` placeholder, **aucun** `raise`/`throw new NotImplemented` (C.1)
- [x] **Cellule markdown de contexte** avant le stub (objectif + intuition à vérifier + indices), per three-exercises règle « chaque exercice précède d'un markdown »
- [x] **Exécutée** — kernel `.net-csharp`, `execution_count: 8`, output stdout réel (`"Exercice 3 a completer : comparer centre vs coins..."`)
- [x] **probeAddresses banner strippée** post-re-exec (`strip_probe_banner.py`, L532) — le banner .NET Interactive qui leak les interfaces réseau du runner est retiré
- [x] **H.3 PASS** (pre-commit) — 0 cellule null-exec sur le notebook entier
- [x] **Catalogue byte-identique** à `origin/main` (non touché)
- [x] **Scope atomique** — 1 fichier, 2 cellules ajoutées (1 markdown + 1 code), 38 ins / 9 del (9 del = whitespace normalization `json.dumps`)

## Exécution

Le stub s'exécute **sans** le binaire MetaGeneticSharp (`Console.WriteLine` only, pas de dépendance). Les cellules existantes (3,5,7,9,11,12) conservent leurs outputs committés (C.3 — seules les cellules modifiées sont ré-exécutées ; ici la nouvelle cellule uniquement). Le binaire MGS n'est pas rebuilt ce cycle (submodule GeneticSharp nested non-init récursivement — déficit env pré-existant, out-of-scope de ce grain d'exercice).

## Voir aussi

- See #2161 (three-exercises rule)
- See #3801 (Prong-B problem-richness)
- PR #8152 (précédent : 3e exercice sur 7c/7d)

En attente review ai-01 (je ne merge pas, leçon #1502).
