### PR TITLE
enrich(gametheory): interpret pure + mixed Nash equilibria (GameTheory-4-Csharp, C.4)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
@@ -426,6 +426,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b623f1ae",
+   "source": "**Lecture.** Les trois jeux exhibent trois régimes d'équilibres purs distincts :\n\n- **Dilemme du Prisonnier** — un seul équilibre $(D,D)$, qui rapporte $(1,1)$. Il s'explique par la **dominance stricte** : $D$ bat $C$ pour chaque joueur quelle que soit la colonne ($5>3$ contre $C$, $1>0$ contre $D$). Le paradoxe : $(C,C)=(3,3)$ serait collectivement meilleur, mais chaque joueur a individuellement intérêt à dévier. L'équilibre unique est **Pareto-dominé** — cas d'école de la tension entre rationalité individuelle et optimum social.\n- **Stag Hunt** — deux équilibres purs $(S,S)=(4,4)$ et $(H,H)=(3,3)$. $(S,S)$ est Pareto-supérieur mais **risqué** : si l'autre dévie vers $H$, le chasseur de cerf prend $0$. $(H,H)$ est **sûr** (gain garanti $3$ même en cas de déviation). C'est le **dilemme risque-vs-gain** : lequel les joueurs vont-ils coordonner ?\n- **Coordination** — deux équilibres purs $(L,L)=(2,2)$ et $(R,R)=(1,1)$, mais aucun critère ne dit lequel choisir : c'est le **problème de sélection d'équilibre** (le pur $(L,L)$ est Pareto-supérieur, mais rien ne force la convergence vers lui).\n\nCes trois cas motivent la suite : quand aucun équilibre pur n'existe (Matching Pennies) ou quand le critère de sélection reste ouvert, l'équilibre **mixte** entre en scène.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "a9445262-2568-4d3a-a59b-89c205b619fd",
    "metadata": {},
    "source": [
@@ -623,6 +629,12 @@
     "var (ssr, ssc) = stagMix.Value;\n",
     "$\"Stag Hunt mixte : p(S) = {FI(ssr[0])} (0.75), q(S) = {FI(ssc[0])} (0.75)\".Display();\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8320dbfc",
+   "source": "**Lecture.** La condition d'indifférence produit des équilibres mixtes aux lectures contrastées :\n\n- **Matching Pennies** — aucun équilibre pur (chaque joueur veut *contredire* l'autre). Le mixte $(0{,}5, 0{,}5)$ est l'**unique** équilibre : pure randomisation, gain nul. C'est la **valeur du jeu** zero-sum — aucun joueur ne peut faire mieux que $0$ en espérance si l'autre randomise uniformément.\n- **Battle of the Sexes** — l'équilibre mixte $(p^*_{\\text{Opera}}=2/3,\\ q^*_{\\text{Opera}}=1/3)$ **égalise l'espérance** de chaque joueur entre ses actions : Row est indifférent entre Opera et Foot face à $q^*=1/3$, Col de même face à $p^*=2/3$. Il rapporte $(0{,}667, 0{,}667)$ — **Pareto-dominé** par les deux purs $(2,1)$ et $(1,2)$. La randomisation est ici « défensive » : elle garantit un gain minimal face à un adversaire imprévisible, au prix d'une décoordination fréquente.\n- **Stag Hunt** — l'équilibre mixte $(p^*_S=0{,}75,\\ q^*_S=0{,}75)$ est le **seuil critique** : si l'autre joue Stag avec probabilité $0{,}75$, je suis exactement indifférent. En dessous, $H$ devient rationnel ; au-dessus, $S$. Ce seuil quantifie la **frontière du dilemme risque-vs-gain** entrevue sur les équilibres purs.\n\nLa formule fermée $q^* = (a_{11}-a_{01})/(a_{00}-a_{01}-a_{10}+a_{11})$ donne directement ces valeurs sans énumération. Mais elle ne suffit qu'en $2\\times 2$ : le cas général exige la **support enumeration** (section suivante).",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -1155,7 +1167,7 @@
     "Analyze(bos);\n"
    ]
   },
-    {
+  {
    "cell_type": "markdown",
    "id": "gt4-multeq-interpretation",
    "metadata": {},
@@ -1548,8 +1560,8 @@
   }
  ],
  "metadata": {
- "cost":{
-   "api_usd_est": 0.0,
+  "cost": {
+   "api_usd_est": 0,
    "api_provider": "none",
    "qcc_tokens_est": 0,
    "cpu_min": 1,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #10347

## Quoi

`GameTheory-4-NashEquilibrium-Csharp.ipynb` : 2 markdowns d'interprétation APRÈS output (C.4), comblant les 2 gaps genuine entre sections 2→3 et 3→4. Le notebook .NET Twin (marathon #4956, axe-2 SOTA #3801 Prong B) déroulait les algorithmes de Nash à la main mais laissait les tables de résultats sans interprétation pédagogique entre les sections.

**Gap 1** (après cell `2d27b18d`, tables équilibres purs PD/Stag Hunt/Coordination → section 3 mixtes) : interprétation des 3 régimes d'équilibres purs — dominance stricte (D bat C : $5>3$ contre C, $1>0$ contre D → équilibre unique (D,D) Pareto-dominé), dilemme risque-vs-gain (Stag Hunt : (S,S)=(4,4) Pareto-supérieur mais risqué vs (H,H)=(3,3) sûr), problème de sélection d'équilibre (Coordination : (L,L) vs (R,R)).

**Gap 2** (après cell `b2f8a6fc`, tables équilibres mixtes MP/BoS/Stag Hunt → section 4 support enumeration) : interprétation des mixtes — valeur du jeu zero-sum (MP : aucun pur, mixte unique 0.5/0.5 = pure randomisation, gain nul), indifférenciation défensive (BoS : 2/3-1/3 égalise l'espérance, Pareto-dominé par les purs), seuil critique 0.75 (Stag Hunt : frontière du dilemme risque-vs-gain).

## Preuve

- **G.1 firsthand** (écart des faux gaps) : la cellule `gt4-multeq-interpretation` interprète DÉJÀ la section 5 (5 jeux canoniques, 2 régimes). Le scan automatique « consecutive-code » over-countait ICT-1 (2 faux gaps — markdowns « Lecture » déjà présents) ET GameTheory-4 (gap section 5 déjà couvert). Lecture directe cell-par-cell : seuls les gaps 1 et 2 ci-dessus sont genuine.
- **Valeurs citées exactes** des outputs commités : $5>3$, $1>0$, $(4,4)$, $(3,3)$, $(0{,}5,0{,}5)$, $2/3$, $1/3$, $0{,}75$ — pas de valeur inventée.
- **Markdown-only** : 0 cellule code touchée (14 code cells intactes), 0 null-exec, pas de re-exec (C.2 : markdown-only → outputs précédents valides).
- **Anti-régression** : `git diff --stat` = +16/-4 ; les -4 délétions = reformatage structurel NotebookEdit (indentation cell `gt4`, metadata `cost` normalisée `0.0→0`, newline final) — AUCUN contenu pédagogique supprimé.
- **H.3 pre-commit** : pas de cellule code à `execution_count: null`, gate OK.
- **Catalogue** : byte-identique à main (aucun `COURSE_CATALOG` touché).

## Perimetre

- `MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb` (+2 markdowns d'interprétation).
- Hors scope : enrichissement des autres notebooks GameTheory (3-NashExistence, 11-Bayesian, 14-DifferentialGames avaient aussi des runs au scan — à confirmer genuine dans des grains séparés). Twin Python `GameTheory-4-NashEquilibrium.ipynb` non touché (ses interprétations sont dans le markdown existant).
- Rotation R6 : CONTENU notebook-python après 2 cycles tooling (#10345, #10347), hors GenAI-video (probe MiniMax en attente d'arbitrage ai-01 — non tunnelisée sur cette famille).

See #3801 (Prong B twin C# — le notebook est déjà tagué dans son intro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)