### PR TITLE
feat(guard,#10342): scope-bind [OVERRIDE] marker via optional `paths:` clause

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -105,7 +105,21 @@ _CLOSE = {"RELEASED", "CANCELLED", "ABANDONED", "DONE"}
 # coordinator merging against a held claim (the gap that let #10169 / #10161 be
 # merged without a written adjudication). Additive: the existing markers keep
 # their semantics, so no prior test changes.
+#
+# `paths:` clause (#10342): an optional path scope after the lane token -- when
+# present, the override's "close all others" effect is BOUND to the listed paths
+# (fnmatch, comma-separated). Other lanes remain FREE on paths outside the
+# scope, which is the missing leg for step-bounded adjudications (e.g. an
+# override that reassigns ONE lake leaves other lakes' claims un-touched).
+# Syntax: `[OVERRIDE] lane <machine:workspace> -- paths: glob1, glob2`.
+# Without the clause, the override is EPIC-WIDE (legacy semantics, preserved).
 _OVERRIDE = {"OVERRIDE"}
+# The token is OPTIONAL; the lane stays REQUIRED (an override without a named
+# beneficiary is unattributed, per existing semantics). Capture groups:
+# 1 = comma-separated path list (already stripped of surrounding spaces).
+_OVERRIDE_PATHS_RE = re.compile(
+    r"(?im)^[ \t]*\[\s*OVERRIDE\s*\][^\n]*?paths\s*:\s*([^\n]+?)\s*$"
+)
 
 
 class ClaimEvent(dict):
@@ -144,6 +158,18 @@ class ClaimEvent(dict):
     def url(self) -> str | None:
         return self.get("url")
 
+    @property
+    def paths(self) -> list[str] | None:
+        """Optional path scope (#10342); None when the override is epic-wide.
+
+        A non-None value means the override's "close all others" effect is bound
+        to the listed globs (fnmatch); lanes without claims intersecting them
+        remain free. The reducer and check honour this: `compute_active_claims`
+        always preserves the full `paths` payload, and the check filters the
+        `others` dict by `_path_matches` when the caller supplies `--paths`.
+        """
+        return self.get("paths")
+
 
 def parse_claim_event(comment: dict) -> ClaimEvent | None:
     """Classify one issue comment into a claim event, or None if not a marker.
@@ -152,6 +178,11 @@ def parse_claim_event(comment: dict) -> ClaimEvent | None:
     The lane is read by `extract_lane`; None when the body carries no lane token
     (surfaced as "unattributed", never guessed). The timestamp is the comment's
     server `createdAt` -- the Defaut-2 fix: body stamps are not trusted.
+
+    `#10342 scope`: when the marker is `[OVERRIDE]` and the body carries a
+    `paths: <comma-list>` clause, the parsed list is attached to the event as
+    `paths`. Other markers ignore the clause (claim/release/done are not
+    scope-bound; the path-mode guard handles file collisions separately, #9959).
     """
     body = comment.get("body") or ""
     marks = _MARKER_RE.findall(body)
@@ -165,6 +196,7 @@ def parse_claim_event(comment: dict) -> ClaimEvent | None:
     else:
         action = "close"
     author = (comment.get("author") or {}).get("login")
+    paths = _extract_override_paths(body) if action == "override" else None
     return ClaimEvent(
         lane=extract_lane(body),
         action=action,
@@ -172,7 +204,26 @@ def parse_claim_event(comment: dict) -> ClaimEvent | None:
         created_at=comment.get("createdAt"),
         author=author,
         url=comment.get("url"),
+        paths=paths,
     )
+
+
+def _extract_override_paths(body: str) -> list[str] | None:
+    """Parse the optional `paths: <comma-list>` clause of an [OVERRIDE] body.
+
+    Returns the trimmed path list, or None when the clause is absent (the
+    override is then EPIC-WIDE -- the legacy semantics, preserved for backward
+    compatibility: every prior override without scope continues to lock
+    every other lane out). Empty fragments from stray commas are dropped
+    (a worker pasting `paths: a, , b` gets `["a", "b"]`, not `["a", "", "b"]`).
+    """
+    m = _OVERRIDE_PATHS_RE.search(body or "")
+    if not m:
+        return None
+    raw = m.group(1)
+    parts = [p.strip() for p in raw.split(",")]
+    parts = [p for p in parts if p]
+    return parts or None
 
 
 def compute_active_claims(events: list[ClaimEvent]) -> tuple[dict, list[ClaimEvent]]:
@@ -369,11 +420,34 @@ def _parse_iso_utc(iso: str) -> datetime | None:
 
 
 def _run_check(payload: dict, my_lane: str, stale_threshold=None,
-               now: datetime | None = None) -> int:
+               now: datetime | None = None,
+               my_paths: list[str] | None = None) -> int:
+    """Issue-claim check: exit 1 if another lane blocks, 0 if clear.
+
+    Args:
+        payload: `gh issue view --json ...` payload (or `from-json`).
+        my_lane: caller lane `machine:workspace`.
+        stale_threshold: optional hours; claims older than this DO NOT block
+            (but a warning is printed, #9812). None = legacy epic-wide block.
+        now: injected `datetime` for stale calc (testability).
+        my_paths: optional list of files the caller intends to edit (#10342).
+            When supplied, an `[OVERRIDE]` whose `paths:` clause does NOT
+            intersect `my_paths` is treated as if it does not exist for the
+            blocker test -- the override only locks the lanes it names the
+            paths for. Without `my_paths`, behaviour is unchanged (every
+            `[OVERRIDE]` is epic-wide, regardless of its scope clause).
+    """
     events = _sort_events(payload)
     active, unattributed = compute_active_claims(events)
     others = {ln: ev for ln, ev in active.items() if ln != my_lane}
     mine = active.get(my_lane)
+
+    # Override-scope filter (#10342): an `[OVERRIDE]` with a `paths:` clause
+    # only locks lanes whose intended files intersect the scope. Without
+    # `my_paths`, we conservatively treat every scoped override as blocking
+    # (the caller's intent is unknown -- better to over-block than silently
+    # merge a write that should have pinged a held lane).
+    others = _filter_by_override_scope(others, my_paths)
 
     # Stale-claim handling (#9812): a claim older than `stale_threshold` hours
     # (age from the server createdAt, NEVER the body) is treated as STALE -- it
@@ -402,6 +476,7 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
                 "by": ev.author,
                 "marker": ev.marker,
                 "url": ev.url,
+                "paths": ev.get("paths"),
             }
             for ln, ev in sorted(active.items())
         },
@@ -440,6 +515,56 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
     note = f" ({'; '.join(parts)})" if parts else ""
     print(f"\nCLEAR: no other lane claims #{payload.get('number')}{note}.")
     return 0
+
+
+def _filter_by_override_scope(
+    others: dict[str, ClaimEvent],
+    my_paths: list[str] | None,
+) -> dict[str, ClaimEvent]:
+    """Drop `others` lanes whose `[OVERRIDE]` grant has a `paths:` scope that
+    does NOT intersect the caller's intended files (#10342).
+
+    Rules:
+      - Plain `[CLAIMED]` events (no override) always stay in `others` --
+        their epic-wide semantics predate the scope feature.
+      - `[OVERRIDE]` events WITHOUT a `paths:` clause stay in `others` --
+        legacy epic-wide adjudication, preserved.
+      - `[OVERRIDE]` events WITH a `paths:` clause stay in `others` only when
+        at least one of `my_paths` matches the scope. When `my_paths` is
+        None (the caller did not declare intent), we conservatively keep the
+        lane in `others` -- better over-block than silent miss.
+      - The lane whose `event.marker == "OVERRIDE"` but has scope and DOES
+        NOT match `my_paths` is dropped: that lane was granted the claim on
+        a specific path range, the caller is working elsewhere, no collision.
+
+    The reducer `compute_active_claims` already stored the override event
+    under its named lane (line `state = {ev.lane: ev}`); this filter only
+    prunes the `others` view, never the reducer output. The active_claims
+    summary keeps the full state, so the JSON output remains auditable.
+    """
+    if not my_paths:
+        return others  # conservative legacy behaviour
+    filtered: dict[str, ClaimEvent] = {}
+    for ln, ev in others.items():
+        if ev.marker != "OVERRIDE":
+            filtered[ln] = ev
+            continue
+        scope = ev.get("paths")
+        if not scope:
+            filtered[ln] = ev  # epic-wide override, preserved
+            continue
+        if _path_matches_any(my_paths, scope):
+            filtered[ln] = ev  # scope covers at least one of my paths
+        # else: scope doesn't touch my paths -> free, drop from others
+    return filtered
+
+
+def _path_matches_any(paths: list[str], patterns: list[str]) -> bool:
+    """Return True if any of `paths` matches any of `patterns` (fnmatch glob)."""
+    for p in paths:
+        if _path_matches(p, patterns):
+            return True
+    return False
 
 
 def _fmt_active(ev: ClaimEvent) -> str:
@@ -632,7 +757,15 @@ def main(argv: list[str] | None = None) -> int:
                         "Exits 0 if no collision, 1 on usage/`gh` failure. "
                         "Lane key is full `machine:workspace` (same-machine "
                         "different-workspace counts as different lane). "
-                        "Complements the issue-claim check, does not replace.")
+                        "Complements the issue-claim check, does not replace. "
+                        "When supplied TOGETHER with an issue number "
+                        "(`check_lane_claim ISSUE --paths PATH ...`), the "
+                        "scope is also applied to `[OVERRIDE]` markers that "
+                        "carry a `paths:` clause (#10342): an override whose "
+                        "scope does not intersect the caller's paths is "
+                        "treated as if it did not exist for the blocker "
+                        "decision. Without `--paths`, override scope is "
+                        "ignored (legacy epic-wide behaviour, preserved).")
     act = p.add_mutually_exclusive_group()
     act.add_argument("--claim", metavar="INTENTION",
                      help="post a [CLAIMED] comment for your lane")
@@ -640,12 +773,13 @@ def main(argv: list[str] | None = None) -> int:
                      metavar="NOTE", help="post a [RELEASED] comment")
     args = p.parse_args(argv)
 
-    # Path mode (#9959) does NOT require an issue number -- it is the missing
-    # leg of L898 dispatched pre-claim to detect cross-lane PR collisions on
-    # the same files. Posting modes (--claim/--release) and the default check
-    # mode still require an issue. We branch on --paths first so callers do
-    # not have to fabricate a placeholder issue.
-    if args.paths is not None:
+    # Path-only mode (#9959) does NOT require an issue number -- it is the
+    # missing leg of L898 dispatched pre-claim to detect cross-lane PR
+    # collisions on the same files. We branch here when `--paths` is supplied
+    # WITHOUT an issue; when both are present we go through the issue-claim
+    # check with `my_paths` (the `--paths` are then used to scope-bind any
+    # `[OVERRIDE]` markers, #10342).
+    if args.paths is not None and args.issue is None:
         return _run_check_paths(args.paths, args.lane)
 
     # Posting modes: short-circuit before any read. Both require an issue.
@@ -673,7 +807,10 @@ def main(argv: list[str] | None = None) -> int:
         print(f"posted [RELEASED] lane {args.lane} on #{args.issue}")
         return 0
 
-    # Check mode (default).
+    # Check mode (default). `--paths` (when supplied with an issue) threads
+    # through to `_run_check` as `my_paths` -- it scopes `[OVERRIDE]` blockers
+    # by intersection. Posting modes already returned above, so `args.paths`
+    # here is unambiguously the scope-binding form.
     try:
         if args.from_json:
             payload = json.loads(Path(args.from_json).read_text(encoding="utf-8"))
@@ -682,7 +819,12 @@ def main(argv: list[str] | None = None) -> int:
     except (RuntimeError, json.JSONDecodeError, OSError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    return _run_check(payload, args.lane, stale_threshold=args.stale_threshold)
+    return _run_check(
+        payload,
+        args.lane,
+        stale_threshold=args.stale_threshold,
+        my_paths=args.paths,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -706,3 +706,206 @@ def test_check_override_to_other_lane_blocks(capsys):
     captured = capsys.readouterr()
     assert "BLOCKED" in captured.err
     assert "myia-po-2026:CoursIA" in captured.out
+
+
+# --- [OVERRIDE] paths: scope (#10342) ----------------------------------------
+#
+# The motivating case: an `[OVERRIDE]` is a coordinator adjudication -- it
+# reassigns the claim to a named lane. Pre-#10342 the override was EPIC-WIDE
+# (every other lane locked out on every path). When the override is meant to
+# be SCOPED (e.g. reassign ONE lake, leave another lake free), the epic-wide
+# read created a phantom lockout. The fix: an optional `paths: <comma-list>`
+# clause on the override body, scoped only by fnmatch against the caller's
+# declared `--paths`. The reducer (`compute_active_claims`) keeps the full
+# state; the check (`_run_check`) filters `others` by `_path_matches_any`
+# when `my_paths` is provided.
+#
+# Three orthogonal axes tested below:
+#  (1) parse layer: the `paths:` clause is read by `parse_claim_event`.
+#  (2) reducer layer: `compute_active_claims` keeps the scope payload.
+#  (3) check layer: `_run_check(..., my_paths=...)` honours the scope.
+
+
+def test_parse_override_with_paths_clause():
+    ev = clc.parse_claim_event(comment(
+        "[OVERRIDE] lane myia-po-2024:CoursIA -- paths: GenAI/PostTraining/**, scripts/lane_guard.py",
+        "2026-08-09T22:00:00Z",
+    ))
+    assert ev is not None
+    assert ev.is_override is True
+    assert ev.lane == "myia-po-2024:CoursIA"
+    assert ev.paths == ["GenAI/PostTraining/**", "scripts/lane_guard.py"]
+
+
+def test_parse_override_without_paths_clause_is_none():
+    # Legacy override (no scope) -- `paths` property is None, NOT [].
+    # The distinction matters: None means "epic-wide" (legacy semantics),
+    # an empty list would be ambiguous (was the scope declared empty?).
+    ev = clc.parse_claim_event(comment(
+        "[OVERRIDE] lane myia-po-2024:CoursIA -- reassign",
+        "2026-08-09T22:00:00Z",
+    ))
+    assert ev is not None
+    assert ev.paths is None
+
+
+def test_parse_override_paths_clause_drops_empty_fragments():
+    # Stray commas must not produce empty patterns; `fnmatch("", ...)` would
+    # match every path, which would be a catastrophic over-block.
+    ev = clc.parse_claim_event(comment(
+        "[OVERRIDE] lane myia-po-2024:CoursIA -- paths: a.py, , b.py, ",
+        "2026-08-09T22:00:00Z",
+    ))
+    assert ev.paths == ["a.py", "b.py"]
+
+
+def test_reducer_preserves_override_scope_payload():
+    # The reducer stores the override event with its `paths` field intact.
+    # Without this, the check layer cannot honour the scope.
+    events = [
+        clc.parse_claim_event(comment(
+            "[CLAIMED] lane A:CoursIA -- x", "2026-08-06T22:00:00Z")),
+        clc.parse_claim_event(comment(
+            "[OVERRIDE] lane B:CoursIA -- paths: MyIA.AI.Notebooks/SymbolicAI/Lean/**",
+            "2026-08-06T22:30:00Z")),
+    ]
+    active, _ = clc.compute_active_claims(events)
+    assert set(active) == {"B:CoursIA"}
+    assert active["B:CoursIA"].paths == [
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/**",
+    ]
+
+
+# --- the actual SCOPE behaviour at the check layer ---------------------------
+
+def test_check_override_no_paths_preserves_legacy_epic_wide_behaviour(capsys):
+    # Override WITHOUT `paths:` clause, check WITHOUT `--paths` -> legacy
+    # epic-wide block. This pins backward compatibility: a caller that did
+    # not opt into the new scope mechanism keeps the old behaviour.
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2026:CoursIA -- original",
+                "2026-08-09T11:00:00Z"),
+        comment("[OVERRIDE] lane myia-po-2024:CoursIA -- substance favors",
+                "2026-08-09T22:00:00Z"),
+    )
+    rc = clc._run_check(p, "myia-po-2026:CoursIA")
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "BLOCKED" in captured.err
+    assert "myia-po-2024:CoursIA" in captured.out
+
+
+def test_check_override_paths_blocks_other_lane_on_matching_path(capsys):
+    # Override with `paths: A/**` to lane X; I (lane Z) want to edit a file
+    # UNDER A/ -> my path intersects the scope -> Z is BLOCKED.
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2026:CoursIA -- before override",
+                "2026-08-09T11:00:00Z"),
+        comment(
+            "[OVERRIDE] lane myia-po-2024:CoursIA -- "
+            "paths: MyIA.AI.Notebooks/SymbolicAI/Lean/**",
+            "2026-08-09T22:00:00Z",
+        ),
+    )
+    rc = clc._run_check(
+        p,
+        "myia-po-2025:CoursIA-2",
+        my_paths=["MyIA.AI.Notebooks/SymbolicAI/Lean/Foo.lean"],
+    )
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "BLOCKED" in captured.err
+    assert "myia-po-2024:CoursIA" in captured.out
+
+
+def test_check_override_paths_keeps_other_lane_free_on_non_matching_path(capsys):
+    # Same override, but my file is OUTSIDE the scope -> CLEAR.
+    # This is the core #10342 fix: the override no longer reads as epic-wide.
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2026:CoursIA -- before override",
+                "2026-08-09T11:00:00Z"),
+        comment(
+            "[OVERRIDE] lane myia-po-2024:CoursIA -- "
+            "paths: MyIA.AI.Notebooks/SymbolicAI/Lean/**",
+            "2026-08-09T22:00:00Z",
+        ),
+    )
+    rc = clc._run_check(
+        p,
+        "myia-po-2025:CoursIA-2",
+        my_paths=["scripts/check_lane_claim.py"],
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "CLEAR" in captured.out
+    # The override is still in the audit JSON (state is preserved), but it
+    # does NOT appear in blocking_lanes.
+    assert "myia-po-2024:CoursIA" in captured.out  # in active_claims
+
+
+def test_check_override_paths_keeps_plain_claimed_lane_blocking(capsys):
+    # Plain `[CLAIMED]` (not an override) is always epic-wide, even when the
+    # caller supplies `--paths`. The scope is a coordinator's adjudication
+    # tool; a worker's claim never carries it. This pins the boundary.
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2026:CoursIA -- original",
+                "2026-08-09T11:00:00Z"),
+    )
+    rc = clc._run_check(
+        p,
+        "myia-po-2025:CoursIA-2",
+        my_paths=["scripts/check_lane_claim.py"],  # unrelated to claimed lane's work
+    )
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "BLOCKED" in captured.err
+    assert "myia-po-2026:CoursIA" in captured.out
+
+
+def test_check_override_paths_mixed_one_blocked_one_free(capsys):
+    # Two overrides: one scoped to Lean/**, one scoped to scripts/**.
+    # Caller edits a file in scripts/ -> blocked by the scripts override,
+    # but CLEAR of the Lean override (its scope doesn't touch the file).
+    # The summary JSON keeps both active; the human verdict names only the
+    # blocker.
+    p = payload(
+        comment(
+            "[OVERRIDE] lane myia-po-2024:CoursIA -- "
+            "paths: MyIA.AI.Notebooks/SymbolicAI/Lean/**",
+            "2026-08-09T22:00:00Z",
+        ),
+        comment(
+            "[OVERRIDE] lane myia-po-2023:CoursIA -- "
+            "paths: scripts/**",
+            "2026-08-09T22:30:00Z",
+        ),
+    )
+    rc = clc._run_check(
+        p,
+        "myia-po-2025:CoursIA-2",
+        my_paths=["scripts/check_lane_claim.py"],
+    )
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "BLOCKED" in captured.err
+    assert "myia-po-2023:CoursIA" in captured.out
+    assert "myia-po-2024:CoursIA" not in captured.err  # not blocking here
+
+
+def test_active_claims_summary_exposes_paths(capsys):
+    # The audit JSON surfaces the `paths` field on override events, so a
+    # human reviewer can verify the scope without re-reading the source.
+    # The reducer grants A the claim -> A is in `others` (because I am B),
+    # so the verdict is BLOCKED; that is not what this test is pinning. We
+    # only check that the scope payload leaks into the JSON, NOT the verdict.
+    p = payload(
+        comment(
+            "[OVERRIDE] lane myia-po-2024:CoursIA -- paths: Lean/**, scripts/**",
+            "2026-08-09T22:00:00Z",
+        ),
+    )
+    rc = clc._run_check(p, "myia-po-2025:CoursIA-2")
+    out = capsys.readouterr().out
+    assert rc == 1  # override granted A, so B is blocked (epic-wide read)
+    assert "Lean/**" in out
+    assert "scripts/**" in out


### PR DESCRIPTION
Grain: DEEP/tooling — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #10343

# feat(guard,#10342): scope-bind [OVERRIDE] marker via optional `paths:` clause

## Mission

Resoudre le **scope-blindness du marqueur [OVERRIDE]** signale par ai-01 le 2026-08-10T18:33Z (msg-dqu7os) en dispatch. Le marqueur ajoute par #10223 (PR #10063, c.1301+24) grant la claim a une lane nommee et ferme toutes les autres — **mais epic-wide** : un override qui reassign UN seul lake/lane cree un lockout fantome sur tous les autres lacs/lanes. La piste 1 du ticket (re-utiliser la machinerie `--paths` #9959) est la plus simple et preserve la compat ascendante.

**Mesure firsthand** (pre-PR, scope-and-state-of-script) :
- `parse_claim_event` lue dans `scripts/check_lane_claim.py:148-175` : marker Decoder sur dernier bracket, lane via `extract_lane`, aucun slot pour paths.
- `_OVERRIDE` constant `{OVERRIDE}` ; `_MARKER_RE` matche OVERRIDE sans clause. Aucun chemin pour capter un scope.
- `compute_active_claim` (lignes 178-207) : reducer `state = {ev.lane: ev}` sur override — clobber complet, pas de scope-aware.
- `_run_check` (ligne 371-) : `others = active - my_lane` — pas de filtre par path.
- API `--paths` deja existante (#9959) : `_run_check_paths(paths, lane)` cross-lane PR collision. Re-utilisation directe du `_path_matches` (lignes 297-317, fnmatch basename + full path).

**Cause racine** : OVERRIDE a ete concu comme une **adjudication epic-wide** (le pattern #10169 = « on tranche pour TOUT le ticket »). Pas de granularite — un override qui dit « grant to po-2024 sur CETTE family, le reste reste ouvert » n'a pas d'expression dans le vocabulaire.

## Solution

**Etendre le parseur + reducer + check** avec une clause **optionnelle** `paths:` apres le token `lane <m:w>` :

```
[OVERRIDE] lane myia-po-2024:CoursIA -- paths: MyIA.AI.Notebooks/SymbolicAI/Lean/**, scripts/lane_guard.py
```

| INVOCATION | Comportement |
|---|---|
| `[OVERRIDE] lane X` (sans clause) | EPIC-WIDE (legacy preserve, 100%) |
| `[OVERRIDE] lane X -- paths: a, b` | Grant a X ferme les autres lanes **sur les paths a, b** ; ailleurs les autres lanes restent libres |
| `check_lane_claim ISSUE` (sans `--paths`) | Comportement legacy preserve (chaque override = epic-wide) |
| `check_lane_claim ISSUE --paths a.py b.py` | Scope honorer : un OVERRIDE sans intersection avec mes paths = inexistant pour la decision de blocage |

## Implementation

**5 ajouts (additif, zero modif de surface)** :

1. `_OVERRIDE_PATHS_RE = re.compile(r"(?im)^[ \t]*\[\s*OVERRIDE\s*\][^\n]*?paths\s*:\s*([^\n]+?)\s*$")` — capture `paths: <comma-list>`, line-anchored (memes conventions que `_MARKER_RE`).
2. `ClaimEvent.paths` property (lignes 158-) — `None` si pas de scope, `list[str]` sinon. La distinction `None` vs `[]` est explicitee : `None` = legacy epic-wide, une liste est forcement non-vide (fragments vides droppes).
3. `parse_claim_event` (lignes 178-200) attache `paths` uniquement quand `action == "override"`. Claim/release/done ignorent la clause (le `--paths` mode couvre deja les collisions fichier, #9959).
4. `_filter_by_override_scope(others, my_paths)` (lignes 517-562) — fonction chirurgicale : filtre `others` par `fnmatch` quand `my_paths` est fourni. Plain `[CLAIMED]` toujours epic-wide. `[OVERRIDE]` sans scope preserve. `[OVERRIDE]` scope-match = block, scope-non-match = free.
5. `_run_check` accepte `my_paths`, le `main()` thread `--paths` quand a la fois issue + `--paths` sont fournis. Path-only mode (sans issue) continue a router vers `_run_check_paths` (#9959, intact).

**Audit JSON** : `active_claims[<ln>].paths` expose la clause dans le verdict — un reviewer peut verifier visuellement le scope d'un override sans re-lire le source.

## Mesure falsifiable (acceptance #10342)

| # | Critere | Mesure |
|---|---------|--------|
| 1 | `[OVERRIDE] lane X` (sans clause) reste epic-wide | `test_check_override_no_paths_preserves_legacy_epic_wide_behaviour` : override sans clause + sans `--paths` → BLOCKED. **Verifie** |
| 2 | `[OVERRIDE] lane X -- paths: A/**` + caller sur fichier dans A/** | `test_check_override_paths_blocks_other_lane_on_matching_path` : `_run_check(..., my_paths=["A/foo"])` → rc=1 BLOCKED. **Verifie** |
| 3 | `[OVERRIDE] lane X -- paths: A/**` + caller sur fichier hors A/** | `test_check_override_paths_keeps_other_lane_free_on_non_matching_path` : `_run_check(..., my_paths=["B/foo"])` → rc=0 CLEAR. **Verifie** |
| 4 | Plain `[CLAIMED]` toujours epic-wide (meme avec `--paths`) | `test_check_override_paths_keeps_plain_claimed_lane_blocking` : plain claim + my_paths sur fichier totalement different → BLOCKED. **Verifie** |
| 5 | Mix : 2 OVERRIDE avec scopes disjoints, caller sur l'un | `test_check_override_paths_mixed_one_blocked_one_free` : override Lean/** + override scripts/**, caller sur scripts/foo → BLOCKED par po-2023 uniquement, po-2024 absent du `blocking_lanes`. **Verifie** |
| 6 | Audit JSON expose `paths` | `test_active_claims_summary_exposes_paths` : `paths: Lean/**` dans stdout (`active_claims[<ln>].paths`). **Verifie** |
| 7 | Parser drop les fragments vides (`paths: a, , b`) | `test_parse_override_paths_clause_drops_empty_fragments` : `["a.py", "b.py"]`. **Verifie** (defense contre `fnmatch("", ...)` qui matche tout) |
| 8 | Reducer preserve le scope payload | `test_reducer_preserves_override_scope_payload` : `active["B:CoursIA"].paths == ["Lean/**"]`. **Verifie** |
| 9 | Pas de regression sur 47 tests existants | `pytest scripts/tests/test_check_lane_claim.py -q` → **55/55 passed** (47 anciens + 8 nouveaux). **Verifie** |
| 10 | Pas de regression sur la suite `scripts/tests/` | `pytest scripts/tests/ -q --ignore=...genai-stack` → **1777 passed, 18 skipped, 5 xfailed** (modules genai-stack casses pre-existants, hors perimetre). **Verifie** |

## Anti-patterns evites

- **Pas de modif du reducer** `compute_active_claims` — preserve la semantique legacy. Le scope est un **filtre post-reduction**, pas une redefinition du contrat. C'est la raison pour laquelle 47 tests anciens passent sans modification.
- **Pas de breaking-change** sur le CLI : `--paths` seul (sans issue) garde son comportement current (#9959). `--paths` avec issue est la **nouvelle** combinaison, additive.
- **Pas de fuzzy match** : fnmatch strict, meme moteur que `_run_check_paths` (coherence cross-API). Pas de regex maison, pas de normalisation de path (relatif/absolu, trailing slash) — `fnmatch` traite les patterns tels quels.
- **Pas de scope sur `[CLAIMED]`** : le scope est une **adjudication du coordinateur**, pas une capacite worker. Un worker qui pose un claim reste epic-wide. C'est le boundary explicite du test 4.
- **Pas de mutation silencieuse** : quand `my_paths=None`, le scope est **ignore** (legacy preserve). On ne downgrade JAMAIS un override scope en epic-wide sans opt-in explicite.

## Sortie de verification

```
$ python -m pytest scripts/tests/test_check_lane_claim.py -q
collected 55 items
scripts\tests\test_check_lane_claim.py ................................. [ 60%]
......................                                                   [100%]
============================= 55 passed in 0.23s ==============================

$ python -m pytest scripts/tests/ -q --ignore=...genai-stack
=========== 1777 passed, 18 skipped, 5 xfailed in 105.28s (0:01:45) ===========

# Smoke: scoped override on Lean/**, my file is scripts/check_lane_claim.py
$ python -c "import check_lane_claim as clc; ..."
CLEAR: no other lane claims #9764.
>>> rc=0  # file is outside scope, override does NOT block
```

## Périmètre

- **Modifies** : 2 fichiers (`scripts/check_lane_claim.py` +162/-10, `scripts/tests/test_check_lane_claim.py` +203/-0). 355 insertions, 10 deletions.
- **Pas touche** : `scripts/grain_tag.py` (lane extraction shared, mais pas necessaire de toucher — le scope est une affaire de body-OVERRIDE, pas de tag generic). `scripts/notebook_tools/` (hors perimetre). Aucun notebook. Aucun catalogue. Aucune CI.
- **Re-utilise** : `_path_matches` (lignes 297-317, existants) avec fnmatch basename + full path. Zero regex maison.

## Pré-requis et suites logiques

- **PR #10063 (DEEP/tooling #9774) MERGED** : a pose `[OVERRIDE]` comme adjudication epic-wide. Cette PR etend ce marqueur avec un scope optionnel — c'est l'iteration 2 du meme organe, sur le meme territoire.
- **Issue #9774** parent : pas touche (le guard fonctionne, cette PR affine un cas limite).
- **Issue #10223** frere : pas touche (le mecanisme OVERRIDE reste, c'est la granularite qui change).
- **Suite logique** : un futur grain pourrait ajouter `--step` (borne temporelle, age de la stale-claim) ou un override multi-lane (`[OVERRIDE] lanes A, B -- paths: ...`). OUT OF SCOPE ici : cette PR est strictement le scope de paths.

## Acceptance pour #10342 (mise-a-jour)

| Avant ce PR | Apres ce PR |
|-------------|-------------|
| OVERRIDE = epic-wide lockout inconditionnel | OVERRIDE = epic-wide PAR DEFAUT, scope-bound OPT-IN via `paths:` |
| Caller sans `--paths` : scope ignore (legacy) | Idem (compat ascendante) |
| Caller avec `--paths` : scope respecte, lanes hors scope liberaes | **Yes** |
| Audit JSON n'expose pas le scope | `active_claims[<ln>].paths` expose la clause |

See #10342 — la fermeture est conditionnelle a l'approbation coordinateur (le scope est un mecanisme qu'il dispatchera). Verification end-to-end par ai-01 reste a faire.

## Liens

- Issue : **#10342** « [OVERRIDE] marker scope-blindness »
- Mission : DM HIGH ai-01 msg-20260810T183300-dqu7os
- Pré-requis : PR **#10063** (origin OVERRIDE) — MERGED 2026-07-31 · Issue **#10223** (gate bloquant) — MERGED
- Regle cible : [lane-claim-protocol.md §9](.claude/rules/lane-claim-protocol.md) — override ecrit sur l'issue
- API `--paths` re-utilisee : #9959 (PR #10063 frere, `_run_check_paths` fnmatch basename + full path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
