### PR TITLE
feat(translation,#10349): opt-in --require-translated guardrail (T4 render)

### DIFF
--- a/scripts/translation/render_notebook.py
+++ b/scripts/translation/render_notebook.py
@@ -134,6 +134,7 @@ def render(
     *,
     dry_run: bool = False,
     verbose: bool = False,
+    require_translated: bool = False,
 ) -> RenderResult:
     """Render the notebook at ``nb_path`` to ``out_path`` in language ``lang``.
 
@@ -221,6 +222,20 @@ def render(
 
     out_nb["cells"] = new_cells
 
+    # Guardrail (#10349) : refuse to write a language render whose CSV carried
+    # ZERO translated markdown cells. Such a render is a verbatim FR clone (every
+    # cell fell back to source) — a garbage file, not a translation. Opt-in via
+    # ``require_translated`` : the default (False) preserves the idempotent
+    # re-render contract where an untranslated in-scope lang renders as a FR
+    # placeholder (#10039 criterion 3). The check sits BEFORE the atomic write so
+    # no partial/clone file reaches disk.
+    if require_translated and stats.n_md_cells > 0 and stats.n_translated == 0:
+        raise ValueError(
+            f"--require-translated : 0 cellule markdown traduite sur "
+            f"{stats.n_md_cells} (lang={lang}, {csv_path.name}). "
+            f"Refus d'ecrire un clone FR verbatim."
+        )
+
     if not dry_run and out_path is not None:
         out_path.parent.mkdir(parents=True, exist_ok=True)
         # Atomic write : write to a sibling .tmp then rename. This prevents
@@ -289,6 +304,12 @@ def main(argv: Optional[List[str]] = None) -> int:
     p.add_argument("--out", type=Path, help="Output notebook path (e.g. X_en.ipynb)")
     p.add_argument("--dry-run", action="store_true", help="Compute diff/stats, do not write")
     p.add_argument("--verbose", action="store_true", help="Print per-cell diagnostics")
+    p.add_argument(
+        "--require-translated", action="store_true",
+        help="Refuse a render whose CSV carried 0 translated markdown cells "
+             "(guardrail against FR-clone files, #10349). Default off: preserves "
+             "the FR-placeholder re-render contract (#10039 criterion 3).",
+    )
     args = p.parse_args(argv)
 
     dry_run = args.dry_run or args.out is None
@@ -303,6 +324,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             out_path=args.out,
             dry_run=dry_run,
             verbose=args.verbose,
+            require_translated=args.require_translated,
         )
     except (FileNotFoundError, ValueError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/scripts/translation/tests/test_render_notebook.py
+++ b/scripts/translation/tests/test_render_notebook.py
@@ -221,6 +221,93 @@ def test_render_empty_csv_falls_back_to_fr(tmp_path):
     assert md[1]["source"] == ["para"]
 
 
+# --------------------------------------------------------------------------
+# Gate 3b — --require-translated guardrail (#10349) : refuse FR-clone renders
+# --------------------------------------------------------------------------
+
+def test_require_translated_raises_on_zero_translated(tmp_path):
+    """require_translated=True + CSV vide (0 traduit) → ValueError (refus clone FR)."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["# Titre"]},
+        {"id": "c1", "type": "code", "source": ["x"], "execution_count": None},
+        {"id": "m2", "type": "markdown", "source": ["para"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [])  # 0 traduction
+    out = tmp_path / "out_en.ipynb"
+    with pytest.raises(ValueError, match="0 cellule markdown traduite"):
+        r.render(nb, csv_p, "en", out, require_translated=True)
+
+
+def test_require_translated_writes_no_file_on_refusal(tmp_path):
+    """Le guardrail leve AVANT l'ecriture atomique : aucun fichier clone sur disque."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["# Titre"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [])
+    out = tmp_path / "out_en.ipynb"
+    with pytest.raises(ValueError):
+        r.render(nb, csv_p, "en", out, require_translated=True)
+    assert not out.exists()  # aucun clone FR ecrit
+
+
+def test_require_translated_passes_when_cells_translated(tmp_path):
+    """require_translated=True + CSV rempli (>=1 traduit) → rendu normal, pas d'erreur."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["# Titre FR"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [
+        {"notebook": str(nb), "cell_id": "m1", "cell_type": "markdown",
+         "src_lang": "fr", "src_hash": "a", "text_fr": "# Titre FR",
+         "text_en": "# Title EN"},
+    ])
+    out = tmp_path / "out_en.ipynb"
+    result = r.render(nb, csv_p, "en", out, require_translated=True)
+    assert result.stats.n_translated == 1
+    assert out.exists()  # rendu normal ecrit
+
+
+def test_require_translated_noop_when_no_markdown_cells(tmp_path):
+    """Notebook sans markdown (0 cellule traduisible) → guardrail se tait (pas de clone possible)."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "c1", "type": "code", "source": ["print(1)"], "execution_count": None},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [])
+    out = tmp_path / "out_en.ipynb"
+    # Pas de raise : n_md_cells == 0, le guardrail ne s'applique pas.
+    result = r.render(nb, csv_p, "en", out, require_translated=True)
+    assert result.stats.n_md_cells == 0
+    assert out.exists()
+
+
+def test_default_render_preserves_criterion3_fr_placeholder(tmp_path):
+    """Sans require_translated (defaut) → 0 traduit produit un clone FR (critere 3 #10039),
+    le guardrail opt-in ne casse PAS le contrat de re-render idempotent."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["# Titre FR"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [])  # 0 traduction
+    out = tmp_path / "out_en.ipynb"
+    result = r.render(nb, csv_p, "en", out)  # defaut require_translated=False
+    assert result.stats.n_translated == 0
+    out_nb = json.loads(out.read_text(encoding="utf-8"))
+    assert out_nb["cells"][0]["source"] == ["# Titre FR"]  # placeholder FR, pas d'erreur
+
+
+def test_main_require_translated_returns_exit_2(tmp_path):
+    """main() avec --require-translated + CSV vide → exit code 2 (ValueError catche)."""
+    nb = _write_nb(tmp_path, "nb.ipynb", [
+        {"id": "m1", "type": "markdown", "source": ["# Titre"]},
+    ])
+    csv_p = _write_csv(tmp_path, "tr.csv", [])
+    out = tmp_path / "out_en.ipynb"
+    rc = r.main([
+        "--csv", str(csv_p), "--notebook", str(nb),
+        "--lang", "en", "--out", str(out), "--require-translated",
+    ])
+    assert rc == 2
+    assert not out.exists()  # aucun clone FR ecrit
+
+
 def test_render_partial_csv_translates_only_present_cells(tmp_path):
     """Cellule absente du CSV → fallback FR (jamais blank, jamais placeholder)."""
     nb = _write_nb(tmp_path, "nb.ipynb", [


### PR DESCRIPTION
Grain: MED/convention — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-dotnet #10353

See #10349 (partial), See #10044, See #10039

## Summary

Adds an **opt-in `--require-translated` guardrail** to `render_notebook.py` (T4): when set, a render whose CSV carried **ZERO translated markdown cells** raises `ValueError` (CLI exit 2) **before** the atomic write — so no verbatim FR-clone file ever reaches disk.

This is **guardrail 1's mechanism** from #10349. The **default behavior is unchanged** (`require_translated=False`): a 0-translated render still produces a source-identical FR placeholder — that is the **accepted idempotent re-render contract** (#10039 criterion 3, see tension below). The flag is opt-in so the guardrail can be wired where it matters (out-of-scope language renders) without breaking the legitimate pending-in-scope placeholder.

## The defect (#10349)

`translation-sync.yml` T4 step (line 280) renders **all 7** `TARGET_LANGS` for every notebook (`active_langs = list(mod.TARGET_LANGS)`), regardless of PERIMETER.md scope. For the 6 out-of-scope languages (`es/ar/fa/zh/ru/pt`), the CSV has 0 translations → `render_notebook.py` silently writes a **FR-clone** (every markdown cell falls back to source). The workflow swallows it (`non-zero (may have 0 translated cells)`, line 305). Net: the bot's branch carries **4170 garbage files** (695 notebooks × 6 langs) that are FR copies masquerading as translations.

The `--require-translated` flag is the **render-side guardrail**: wired into the workflow's render call, it makes the tool **refuse** the FR-clone write for out-of-scope langs (exit 2, no file).

## Why opt-in (the criterion-3 tension, G.1 firsthand)

#10349's body says "Un rendu a 0 cellule traduite est un echec." But test criterion 3 of #10039 codifies the **opposite** as accepted:

> 3. Falsification 2 : CSV vide (aucune traduction) → *_en.ipynb identique à la source pour les champs traduisibles, structure préservée.

This is **intentional**: T4 *idempotently re-renders* all notebooks from CSVs. An in-scope language (`en`) whose CSV isn't translated yet renders as a FR **placeholder** (to be translated by T3 later). So "0 translated → fail" is **too aggressive** for the legitimate pending-in-scope case — it would break the re-render contract.

**Resolution**: the guardrail is **opt-in** (`--require-translated`). Default off = criterion 3 preserved (verified by `test_default_render_preserves_criterion3_fr_placeholder`). Opt-in = the tool refuses FR clones where the caller *knows* 0-translated is a defect (out-of-scope langs, CI gates, manual verification). The caller (workflow) decides; the tool provides the mechanism.

## The fix (3 surgical edits, additive)

**`scripts/translation/render_notebook.py`** (+22)
- `render()` gains `require_translated: bool = False`.
- After the cell loop, **before** the atomic write: if `require_translated and n_md_cells > 0 and n_translated == 0` → `raise ValueError`. Sits before `out_path.write` so **no clone reaches disk**.
- `main()` gains `--require-translated` argparse flag, threaded into `render()`. `ValueError` caught → exit 2 (existing `except (FileNotFoundError, ValueError)` path).

**`scripts/translation/tests/test_render_notebook.py`** (+87, +6 tests)
- `test_require_translated_raises_on_zero_translated` — flag + empty CSV → `ValueError`.
- `test_require_translated_writes_no_file_on_refusal` — refusal happens **before** write (no file on disk).
- `test_require_translated_passes_when_cells_translated` — flag + filled CSV → normal render.
- `test_require_translated_noop_when_no_markdown_cells` — notebook with 0 md cells → guardrail silent (no clone possible).
- `test_default_render_preserves_criterion3_fr_placeholder` — default (flag off) + empty CSV → FR placeholder, **no error** (criterion 3 preserved).
- `test_main_require_translated_returns_exit_2` — `main()` + flag + empty CSV → exit 2, no file.

## Why this is partial (See #10349, not Closes)

This PR delivers **guardrail 1's mechanism only**. Two parts of #10349 remain:

1. **Workflow wiring** — adding `--require-translated` to the `translation-sync.yml` T4 render call (line ~300) so the guardrail is actually exercised in CI. **Deferred**: wiring it unconditionally would also refuse the legitimate `en`-pending placeholders (criterion 3) until the scope fix (below) lands. The clean wiring order is: scope fix first (only render in-scope langs), then `--require-translated` as a safety net on in-scope renders (which are translated → flag never trips).
2. **Scope fix** — `translation-sync.yml` line 280: replace `active_langs = list(mod.TARGET_LANGS)` with per-CSV in-scope scope from `parse_perimeter()`. **Deferred to po-2023** (owns the translation workflow + PERIMETER.md): it depends on PERIMETER.md completeness (only 4 CSVs currently declare `**en**` vs the bot's 686 files) and needs end-to-end workflow testing I can't run from a worker. po-2023 is already measuring translation debt (#10347) and is best positioned to verify PERIMETER.md + wire the scope fix + the flag together.

This PR is **orthogonal** to po-2023's workflow fix (different file: `render_notebook.py` + tests vs `translation-sync.yml`), so no collision.

## Tests

- `260 passed` full translation suite (`scripts/translation/tests/`) — 254 existing + 6 new, **zero regression**.
- Criterion 3 explicitly re-verified: `test_default_render_preserves_criterion3_fr_placeholder` (default off = FR placeholder, no error).
- CLI smoke test firsthand: no-flag → rc=0 + FR clone written (criterion 3); flag → rc=2 + no file.
- Hermetic: stdlib-only, no network, synthetic notebooks.

## Variation note (G-VAR-3)

prev = MED/notebook-dotnet #10353 (this lane). This is MED/convention (translation-pipeline guardrail mechanism), a genuinely distinct subsystem + defect class (FR-clone prevention vs per-exercise pedagogical context). Litmus: could the next be generated by scanning the adjacent instance? No — designing a render-side guardrail that preserves an accepted behavior (criterion 3) while enabling refusal is not scan-derivable. Not the monoculture G-VAR-3 bans.

## Heads-up

po-2023 owns the i18n/translation turf. `[CLAIMED]` posted on dashboard before editing. If po-2023 flags a different design for the guardrail (e.g. default-on with an explicit `--allow-fr-placeholder` opt-out instead of opt-in), I'll defer — the mechanism is what matters; the polarity is po-2023's call.
