### PR TITLE
enrich(probas): interpret MC convergence EVPI table (DecPyMC-5, C.4)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb
@@ -2618,6 +2618,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b3c4e1f2",
+   "metadata": {},
+   "source": [
+    "### Interpretation : vitesse de convergence Monte Carlo\n",
+    "\n",
+    "La table révèle deux régimes distincts dans l'estimation de l'EVPI par Monte Carlo :\n",
+    "\n",
+    "- **N ≤ 1000 (régime bruité)** : l'intervalle de confiance à 95% est large (±27k à N=100, ±8k à N=1000) et la valeur estimée oscille (90,0k → 92,4k → 86,4k). L'estimateur n'est pas encore fiable : l'EVPI vraie pourrait être n'importe où entre 78k et 117k à N=100.\n",
+    "- **N ≥ 20000 (régime convergé)** : l'IC se resserre sous ±2k (±1,9k à N=20000, ±0,9k à N=100000) et l'estimation se stabilise autour de **~89,7k EUR**. L'erreur tombe sous 0,5k, seuil que la cellule identifie comme « convergence confirmée ».\n",
+    "\n",
+    "**Lecture opérationnelle** : pour un problème de décision unique, **N ≈ 20000** suffit (précision <2k sur un gain de l'ordre de 90k, soit ~2% — largement sous le seuil de décision). Pousser à N=100000 ne gagne qu'un facteur ~2 sur l'IC au prix de 5× plus de tirages : la convergence en $1/\\sqrt{N}$ de Monte Carlo rend les derniers chiffres coûteux. C'est exactement la situation où un échantillonnage MCMC (section suivante) devient pertinent : non pas pour réduire la variance Monte Carlo, mais pour propager l'incertitude d'un **meta-prior** sur $P(\text{pétrole})$ que l'estimateur analytique ne peut pas intégrer."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 21,
    "id": "769bd2e5",


### PR DESCRIPTION
Grain: MED/notebook-python CONTENT — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #10362 (Lean knots)

## Quoi

`DecPyMC-5-Value-Information.ipynb` : 1 markdown d'interprétation APRÈS l'output de convergence Monte Carlo de l'EVPI (C.4), comblant le genuine gap entre la table de convergence (cell `6e9cdd71`) et la section PyMC meta-prior suivante (cell `769bd2e5`).

Le notebook exécutait un estimateur MC de l'EVPI sur N=100→100000 échantillons, produisant une table montrant l'IC à 95% se resserrant de ±27k (N=100) à ±0,9k (N=100000), mais enchaînait directement sur PyMC sans lecture pédagogique du résultat de convergence.

## Preuve

- **G.1 firsthand (genuine gap)** : le notebook suit une convention stricte `### Interpretation : <sujet>` (12 cellules d'interprétation existantes : cells 5/11/14/19/24/27/30/31/35/39/42/45 + 59/63/66 dans la région PyMC). La cellule `2573dea4` « ### Convergence de l'estimateur Monte Carlo » est un **intro** (avant le code), pas une interprétation (après output). Le genuine gap = output de convergence non lu.
- **Écart du faux gap (G.1)** : le 2e hit du scan (cell `72`, forest plot partial pooling) est un **FAUX GAP** = stub d'exercice C.1 (`# --- TODO etudiant ---`, `p_post = None`). Non enrichi — ne jamais résoudre un stub d'exercice (cf exercise-example-labeling).
- **Valeurs citées exactes** des outputs commités : 90,0k / 92,4k / 86,4k (oscillation N≤1000), ±27k (N=100), ±0,9k (N=100000), ~89,7k EUR (convergé). Pas de valeur inventée.
- **Markdown-only** : 0 cellule code touchée, 0 null-exec, pas de re-exec (C.2 : markdown-only → outputs précédents valides).
- **Anti-régression** : `git diff --stat` = +16/-1 ; la -1 délétion = final newline (indent=1 normalization quasi byte-identique, +1/-1 pré-insertion confirmé). Raw-text splice préserve le format source liste (pas de churn list↔string).
- **nbformat.validate** : OK. **H.3** : 0 violation. **Catalogue** : byte-identique à main.

## Perimetre

- `MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb` (+1 markdown interprétation).
- Hors scope : les autres notebooks DecPyMC (DecPyMC-2/3/7 avaient des hits au scan mais non vérifiés ce cycle — à confirmer genuine dans des grains séparés). Le stub d'exercice cell[72] n'est PAS touché (C.1, attend la solution étudiant).
- R6 : Probas (DecisionTheory/PyMC) ≠ Lean knots (#10362) ≠ GameTheory (#10351) — rotation de famille tenue sur 3 cycles.

See #2161 (famille Probas, convention interprétation — contribution partielle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
