### PR TITLE
enrich(semanticweb,#3240): per-exercise markdown context for SW-9-CSharp-JSONLD (twin parity)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb
@@ -1213,6 +1213,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "3b8fbe0b",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercices à compléter\n",
+    "\n",
+    "*Ces exercices prolongent les 6 piliers ci-dessus avec dotNetRDF. Les stubs utilisent des marqueurs `// TODO etudiant` — à compléter. Chaque exercice est précédé de son contexte (objectif + notion JSON-LD + API dotNetRDF).*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e90e997b",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Compaction avec un `@context` personnalisé\n",
+    "\n",
+    "**Objectif.** Écrire un `@context` qui *compacte* un graphe de livres : remplacer les IRIs verbeux (`http://schema.org/title`, `.../author`, `.../datePublished`) par des termes courts français (`titre`, `auteur`, `publie`), puis l'utiliser pour construire un document JSON-LD compact lisible par un humain.\n",
+    "\n",
+    "**Notion JSON-LD — la compaction.** La *compaction* est l'inverse de l'expansion : partant d'un graphe RDF (ou d'un JSON-LD expansé), elle applique un `@context` pour produire le document JSON le plus court et lisible possible, où chaque propriété porte un terme court au lieu de son IRI complet. C'est ce que publie un site web dans sa balise `<script type=\"application/ld+json\">` : le terme `\"name\"` plutôt que `\"http://schema.org/name\"`.\n",
+    "\n",
+    "**API dotNetRDF.** Ici on construit manuellement le `@context` comme un `JObject` (`{\"@context\": {\"titre\": \"http://schema.org/title\", ...}}`) — la même structure qu'à la **Partie 1**. Le `JsonLdProcessor` de dotNetRDF sait compacter un graphe, mais l'exercice se concentre sur la *définition du contexte*, qui est le cœur pédagogique.\n",
+    "\n",
+    "**Indices.** Étape 1 : mapper chaque terme court (`titre`/`auteur`/`publie`) vers son IRI Schema.org. Étape 2 : vérifier qu'un document construit avec ce contexte se parse bien en graphe RDF (round-trip)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "bcf67b26-a4c1-45a9-81ec-9fcf45dd1082",
@@ -1260,6 +1288,22 @@
     "    return new JObject();\n",
     "}\n",
     "Show(\"Contexte biblio (a completer)\", BuildBiblioContext().ToString());\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5df03f9f",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Framing : extraire un sous-graphe typé\n",
+    "\n",
+    "**Objectif.** Extraire d'un graphe RDF tous les nœuds de type `schema:Person` et retourner pour chacun son `@id` et son `schema:name`. C'est l'opération de *framing* — sélectionner un sous-graphe par sa forme (type, propriétés).\n",
+    "\n",
+    "**Notion JSON-LD — le framing.** Le *framing* (mot-clé `@frame`) sélectionne dans un graphe la partie qui matche un patron (« tous les nœuds de type Person avec leur nom »). En pratique, on l'émule souvent en énumérant les triples et en filtrant — c'est l'approche légère de cet exercice, qui évite d'introduire toute la mécanique du `JsonLdFrame`.\n",
+    "\n",
+    "**API dotNetRDF.** Le graphe `g4` (construit en **Partie 5**, dataset multi-ressources via `@graph`) expose `.Triples` : énumérez-le, filtrez les triples de prédicat `rdf:type` dont l'objet est `http://schema.org/Person`, puis pour chaque sujet trouvé récupérez son `schema:name`. Lien direct avec la **Partie 4** (vocabulaire Schema.org) et la **Partie 5** (`@graph`).\n",
+    "\n",
+    "**Indices.** Étape 1 : identifier les sujets `?s rdf:type schema:Person`. Étape 2 : pour chacun, lire le triple `?s schema:name ?nom`."
    ]
   },
   {
@@ -1321,6 +1365,22 @@
     "}\n",
     "var persons = ExtractPersons(g4);\n",
     "Show(\"Personnes extraites (a completer)\", persons.Count == 0 ? \"0 (a completer)\" : string.Join(\"; \", persons.Select(p => p.ToString())));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86debbc4",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Valider un JSON-LD mal formé\n",
+    "\n",
+    "**Objectif.** Écrire une fonction `IsValidJsonLd(string json)` qui retourne `true` si la chaîne est du JSON-LD *parsable en graphe RDF*, `false` sinon.\n",
+    "\n",
+    "**Notion JSON-LD — qu'est-ce qu'un JSON-LD « valide » ?** « Valide » ici signifie *parsable* : la chaîne est du JSON bien formé ET son contenu se traduit en triples RDF. **Ce n'est pas** une garantie de justesse sémantique — un document peut être syntaxiquement valide mais décrire des données absurdes. La distinction *parsabilité* (mécanique) vs *correction* (sémantique) est exactement celle qu'on rencontre en XML (well-formed vs valid).\n",
+    "\n",
+    "**API dotNetRDF.** Le `JsonLdParser` lève une exception (`RdfParseException` ou `JsonReaderException`) si le JSON est cassé ou n'est pas du JSON-LD exploitable. D'où le pattern `try { parser.Load(...); return true; } catch { return false; }`. Lien avec la **Partie 2** (parser JSON-LD → graphe).\n",
+    "\n",
+    "**Indices.** Encapsulez l'appel `LoadJsonLd` (qui invoque `JsonLdParser.Load`) dans un `try/catch`. Testez avec un cas correct (`{\"@id\":...}`) et un cas cassé (`{ce n'est pas du json}`)."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/sw-9-json-ld.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-9-json-ld.yaml
@@ -8,6 +8,12 @@
       by: myia-po-2023:CoursIA
       python_sha: 3c4a93bbf202cea7b12de79ff69d36291c49fc0b
       csharp_sha: 3caa1ec0ce4787f1c7b8a222a370c0cca24e8dbe
+    - date: "2026-08-11"
+      by: myia-po-2024:CoursIA
+      python_sha: 3c4a93bbf202cea7b12de79ff69d36291c49fc0b
+      csharp_sha: cebabdcadc7ff30a695dd7cc780b1b0e0d6929c7
+      content_python_sha: 0f6206639ecbb79a2c4dd7411309972e7e73545f9a7469f54b6a48efbc513ee9
+      content_csharp_sha: a8760e6e1ca7234c6a557248c2fd6fd71db7d391c6e643d475ed61709833661a
   known_differences:
     - "Socle commun : serialisation JSON-LD (Linked Data en JSON, W3C) d'un graphe RDF."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Writing` JsonLdWriter). Python = `rdflib` (plugin JSON-LD via `rdflib-jsonld` integre, `graph.serialize(format='json-ld')`)."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: DEEP/training #10317

## Quoi

`SW-9-CSharp-JSONLD.ipynb` (SymbolicAI/SemanticWeb, twin C# de `SW-9-Python-JSONLD`) avait **3 stubs d'exercice consécutifs** (cells 18/19/20 : Compaction / Framing / Validation) **sans aucun markdown de contexte entre eux** — deux défauts réels :

1. **Epic #3240 (enchaînement canonique)** — trois cellules code consécutives sans markdown d'interprétation/contexte.
2. **Règle three-exercises (#2161)** — « chaque exercice PRÉCÉDÉ d'un markdown : contexte + objectif + indices » non satisfaite.

Le twin Python (`SW-9-Python-JSONLD`) a lui un contexte riche par exercice (cells 76-88) — le twin C# était en retard de parité.

## Livrable

4 cellules markdown ajoutées :

| Cell | Contenu |
|---|---|
| Section header | `## Exercices à compléter` + intro (sépare la Conclusion des exercices) |
| Exercice 1 | **Compaction** — notion JSON-LD (compaction = inverse d'expansion, terme court vs IRI), API dotNetRDF (JObject `@context`), lien Partie 1, indices |
| Exercice 2 | **Framing** — notion (sélectionner un sous-graphe par type/forme), approche légère (énumération `g4.Triples` + filtre `rdf:type`), lien Partie 4/5, indices |
| Exercice 3 | **Validation** — notion (« valide » = parsable en graphe RDF, ≠ justesse sémantique ; distinction well-formed vs valid), pattern `try/catch JsonLdParser`, lien Partie 2, indices |

Le contenu est **domaine-spécifique** (sémantique JSON-LD + API dotNetRDF), pas du texte de transition générique — chaque exercice explique *pourquoi* la notion compte et *comment* elle se relie au matériel précédent.

## Vérifié firsthand

- **Diff markdown-only** : +60/-0, 11 cellules code **inchangées** (sources + outputs identiques, `exec_count` 1-11 préservé). C.2 exception (modif uniquement markdown → outputs précédents valides, pas de re-exec).
- **0 paire d'exercices consécutive** après insertion (chaque exercice à présent séparé par son markdown de contexte).
- **C.1 clean** : aucun `throw new NotImplemented` (stubs existants en `// TODO etudiant` + `return new JObject()` / `return new List<JObject>()` / `return true`).
- **Pre-commit 4/4 PASS** : strip .NET username leak, scrub papermill, block-oversized-md, **H.3 PASS** (0 null-exec).
- **nbformat 4.5** valide.
- **Catalogue byte-identique** à `origin/main`.

## Scope atomique

1 fichier, +60/-0 (enrichissement markdown pur). Pas de re-exec .NET nécessaire (nuget-headless blocker non pertinent — aucune cellule code touchée).

## Voir aussi

- See #3240 (enchaînement canonique des cellules — interprétation/contexte APRES et AVANT le code)
- See #2161 (three-exercises placement — chaque exercice précédé d'un markdown)
- Twin Python : `SW-9-Python-JSONLD.ipynb` (cells 76-88, contexte riche par exercice — source de parité)
