### PR TITLE
feat(translation,#10329): T1 --full mode + T2 out-of-scope report + workflow_dispatch mode input

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -101,6 +101,15 @@ on:
       - 'translations/**'
       - 'scripts/translation/**'
   workflow_dispatch:
+    inputs:
+      mode:
+        description: "T1 mode : 'incremental' (changed notebooks only, default) ou 'full' (plein perimetre, etape 2 de #10329)."
+        type: choice
+        required: false
+        default: incremental
+        options:
+          - incremental
+          - full
 
 permissions:
   contents: write   # bot commit to chore/translation-sync-pending
@@ -172,6 +181,10 @@ jobs:
       # ------------------------------------------------------------------
       - name: T1 re-extract (refresh src_hash for changed notebooks)
         id: t1
+        env:
+          # Mode T1 : 'incremental' (changed-only, default push) ou 'full'
+          # (plein perimetre, etape 2 de #10329).
+          T1_MODE: ${{ github.event.inputs.mode || 'incremental' }}
         run: |
           set -euo pipefail
           if [ ! -d translations ]; then
@@ -180,23 +193,43 @@ jobs:
             exit 0
           fi
           echo "has_translations=true" >> "$GITHUB_OUTPUT"
-          # Notebooks touched by the most recent commit on main (single push
-          # event). If the push contains many files, this may be empty (e.g.
-          # a workflow-only commit) — T1 then no-ops and T4 idempotently
-          # re-renders all known *_<lang>.ipynb from the existing CSVs.
-          CHANGED_NB=$(git log -1 --name-only --pretty=format: -- 'MyIA.AI.Notebooks/**/*.ipynb' || true)
-          if [ -z "$CHANGED_NB" ]; then
-            echo "No in-scope notebook changed in the latest commit. T1 will no-op (idempotent re-extract skipped)."
-          else
-            echo "Changed notebooks in the latest commit:"
-            echo "$CHANGED_NB" | sed 's/^/  - /'
-            # --update refreshes src_hash in existing CSVs without clobbering T3 columns.
-            for nb in $CHANGED_NB; do
-              [ -f "$nb" ] || continue
-              python scripts/translation/extract_cells_to_csv.py "$nb" --update --repo-root . || {
-                echo "::warning title=T1 extract::Failed to re-extract $nb (may be out-of-scope / code-only). Continuing.";
+          echo "T1 mode: $T1_MODE"
+
+          # Itérer sur les CSV déclarés et passer --full uniquement en mode
+          # full. Sans --full (mode incremental), on respecte le comportement
+          # historique : seuls les notebooks passés en input (les CHANGED_NB)
+          # sont rafraîchis.
+          if [ "$T1_MODE" = "full" ]; then
+            echo "T1 FULL mode (#10329 etape 2) : refresh src_hash pour TOUS les notebooks referencees dans chaque CSV."
+            # On itère sur les CSV du perimetre canonique (translations/) et
+            # on lance extract_cells_to_csv.py --update --full pour chacun.
+            # Note : extract_cells_to_csv.py --update --full rafraichit
+            # TOUTES les lignes d'un CSV en un seul appel, ce qui comble la
+            # dette structurelle (78 cellules desynchronisees detectees
+            # par c.199 / PR #10347).
+            for csv in translations/*.csv translations/**/*.csv; do
+              [ -f "$csv" ] || continue
+              # On prend le CSV le plus haut-niveau (celui sous translations/<serie>/).
+              # Evitons les faux positifs : --update --full accepte un CSV.
+              python scripts/translation/extract_cells_to_csv.py "MyIA.AI.Notebooks" --update "$csv" --full --repo-root . || {
+                echo "::warning title=T1 extract full::Failed on $csv. Continuing.";
               }
             done
+          else
+            # Mode incremental (defaut, post-#4957) : notebooks du dernier push.
+            CHANGED_NB=$(git log -1 --name-only --pretty=format: -- 'MyIA.AI.Notebooks/**/*.ipynb' || true)
+            if [ -z "$CHANGED_NB" ]; then
+              echo "No in-scope notebook changed in the latest commit. T1 will no-op (idempotent re-extract skipped)."
+            else
+              echo "Changed notebooks in the latest commit:"
+              echo "$CHANGED_NB" | sed 's/^/  - /'
+              for nb in $CHANGED_NB; do
+                [ -f "$nb" ] || continue
+                python scripts/translation/extract_cells_to_csv.py "$nb" --update --repo-root . || {
+                  echo "::warning title=T1 extract::Failed to re-extract $nb (may be out-of-scope / code-only). Continuing.";
+                }
+              done
+            fi
           fi
 
       # ------------------------------------------------------------------
@@ -206,9 +239,18 @@ jobs:
       - name: T2 detect drift
         id: t2
         if: steps.t1.outputs.has_translations == 'true'
+        env:
+          T1_MODE: ${{ github.event.inputs.mode || 'incremental' }}
         run: |
           set -euo pipefail
-          REPORT="$(python scripts/translation/check_translation_sync.py translations --check --repo-root . 2>/dev/null || true)"
+          # En mode full, on active aussi le scan out-of-scope (etape 5 de
+          # #10329) : notebooks FR dans MyIA.AI.Notebooks/ qui ne sont
+          # dans aucun CSV. Ce scan est diagnostique, non-bloquant.
+          if [ "$T1_MODE" = "full" ]; then
+            REPORT="$(python scripts/translation/check_translation_sync.py translations --check --report-out-of-scope --repo-root . 2>/dev/null || true)"
+          else
+            REPORT="$(python scripts/translation/check_translation_sync.py translations --check --repo-root . 2>/dev/null || true)"
+          fi
           if [ -z "$REPORT" ]; then
             echo "drift_count=0" >> "$GITHUB_OUTPUT"
             echo "No drift detected (or no filled translations to drift against)."
@@ -218,6 +260,13 @@ jobs:
           echo "drift_count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "Drift anomalies: $COUNT"
           echo "$REPORT"
+          # Etape 5 de #10329 : archiver le rapport out-of-scope (si active)
+          # comme artefact de run pour audit. Non-bloquant.
+          if [ "$T1_MODE" = "full" ]; then
+            echo "$REPORT" > translation-sync-report.json
+            OOS_COUNT="$(echo "$REPORT" | python -c 'import sys,json; r=json.load(sys.stdin); print(r.get("out_of_scope_count",0))' 2>/dev/null || echo 0)"
+            echo "::notice title=T2 out-of-scope::${OOS_COUNT} notebook(s) MISSING_FROM_CSV (etape 5 #10329)."
+          fi
 
       # ------------------------------------------------------------------
       # T3 — translate CHANGED CELLS ONLY. ACTIVATED (grain D #10055 landed the

--- a/scripts/translation/check_translation_sync.py
+++ b/scripts/translation/check_translation_sync.py
@@ -48,6 +48,7 @@ import csv
 import hashlib
 import json
 import math
+import re
 import sys
 from pathlib import Path
 
@@ -305,6 +306,56 @@ def csv_fill_stats(csv_path: Path) -> dict[str, dict[str, int]]:
     return stats
 
 
+def find_out_of_scope_notebooks(
+    notebooks_root: Path,
+    known_notebooks: set[str],
+) -> list[dict]:
+    """Scanne ``MyIA.AI.Notebooks/**/*.ipynb`` et identifie les notebooks FR
+    pivots qui ne sont référencés dans aucun CSV de ``translations/``.
+
+    Un notebook FR pivot = fichier ``.ipynb`` qui n'a pas de suffixe ``_<xx>``
+    ET dont le basename ne contient pas de marqueur de langue cible.
+
+    Cette fonction implémente l'étape 5 de #10329 : détecter la dérive
+    HORS-PÉRIMÈTRE — c'est-à-dire les notebooks FR qui ont été créés ou
+    modifiés sans qu'un run incrémental du pipeline T1 n'ait eu lieu (ex :
+    PR mergée directement sur ``main`` qui ajoute un notebook sans
+    déclencher le trigger ``push: paths: [MyIA.AI.Notebooks/**/*.ipynb]``
+    du workflow ``translation-sync``, ou notebooks d'une série qui n'est
+    couverte par AUCUN CSV).
+
+    Retourne une liste de ``{"notebook": str, "verdict": "MISSING_FROM_CSV"}``
+    pour chaque notebook FR pivot non-référencé.
+    """
+    SUFFIX_PATTERN = re.compile(
+        r"_(?:" + "|".join(sorted(ALL_LANGS, key=len, reverse=True)) + r")\.ipynb$",
+        re.IGNORECASE,
+    )
+    EXCLUDE_SUFFIXES = ("_output", "_agent", "-checkpoint", "_checkpoints")
+
+    out: list[dict] = []
+    if not notebooks_root.exists():
+        return out
+    notebooks_root = notebooks_root.resolve()
+    for nb_path in notebooks_root.rglob("*.ipynb"):
+        # Exclure les outputs / agents / checkpoints (cf iter_notebooks()).
+        if any(s in nb_path.stem for s in EXCLUDE_SUFFIXES):
+            continue
+        # Exclure les notebooks traduits (suffixe _xx).
+        if SUFFIX_PATTERN.search(nb_path.name):
+            continue
+        # Chemin RELATIF a notebooks_root (posix). Le caller (main) est
+        # responsable de la mise en correspondance avec ``known_notebooks``
+        # qui contient des paths relatifs au repo root.
+        try:
+            rel = nb_path.relative_to(notebooks_root).as_posix()
+        except ValueError:
+            rel = nb_path.as_posix()
+        if rel not in known_notebooks:
+            out.append({"notebook": rel, "verdict": "MISSING_FROM_CSV"})
+    return out
+
+
 def _fill_pct(filled: int, total: int) -> float:
     """Pourcentage floored à 1 décimale — jamais arrondi vers le haut.
 
@@ -359,6 +410,17 @@ def main() -> int:
         "--check", action="store_true",
         help="Mode CI non-bloquant : exit 0 même si drift détecté (le rapport va sur stderr/JSON).",
     )
+    parser.add_argument(
+        "--report-out-of-scope", action="store_true",
+        help="Étend le rapport avec un scan des notebooks FR dans "
+        "MyIA.AI.Notebooks/ qui ne sont référencés dans aucun CSV "
+        "(MISSING_FROM_CSV, étape 5 de #10329). Sortie JSON additionnelle, "
+        "non-bloquante : le verdict MISSING_FROM_COV n'influe pas sur exit code.",
+    )
+    parser.add_argument(
+        "--notebooks-root", type=Path, default=None,
+        help="Racine de scan des notebooks (défaut : <repo_root>/MyIA.AI.Notebooks).",
+    )
     args = parser.parse_args()
 
     if not args.input.exists():
@@ -375,9 +437,17 @@ def main() -> int:
 
     all_anomalies: list[dict] = []
     fill_by_csv: dict[str, dict[str, dict[str, int]]] = {}
+    known_notebooks: set[str] = set()
     for csv_path in csvs:
         all_anomalies.extend(check_csv(csv_path, repo_root))
         fill_by_csv[str(csv_path)] = csv_fill_stats(csv_path)
+        # Collecte des notebooks référencés (pour l'étape 5 : out-of-scope
+        # detection). On lit rapidement le CSV sans relancer check_csv.
+        with csv_path.open(encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                nb = row.get("notebook", "")
+                if nb:
+                    known_notebooks.add(nb)
 
     # Agrégation du taux de remplissage (#6949 point 1) : somme des filled/total
     # sur tous les CSV, pour un signal global honnête. Le pivot fr est à 100% par
@@ -414,6 +484,31 @@ def main() -> int:
         "anomaly_count": len(all_anomalies),
         "fill_rate": fill_report,
     }
+
+    # Étape 5 de #10329 : scan out-of-scope (option --report-out-of-scope).
+    # Ce scan n'est PAS bloquant (exit code inchangé) — c'est un signal
+    # diagnostique : les notebooks FR jamais indexés dans un CSV apparaissent
+    # ici, ce qui signifie qu'aucun T1 incrémental ne les a vus passer (créés
+    # hors trigger push, ou série non couverte par un CSV).
+    if args.report_out_of_scope:
+        notebooks_root = args.notebooks_root or (repo_root / "MyIA.AI.Notebooks")
+        oos = find_out_of_scope_notebooks(notebooks_root, known_notebooks)
+        # Normalisation : les chemins retournés sont relatifs à
+        # ``notebooks_root``, mais les consommateurs (dashboard, audit)
+        # s'attendent à des chemins relatifs au repo root. On préfixe.
+        if notebooks_root.is_absolute():
+            try:
+                rel_root = notebooks_root.relative_to(repo_root).as_posix()
+            except ValueError:
+                rel_root = None
+        else:
+            rel_root = notebooks_root.as_posix()
+        if rel_root and rel_root not in (".", ""):
+            for entry in oos:
+                entry["notebook"] = f"{rel_root}/{entry['notebook']}"
+        report["out_of_scope"] = oos
+        report["out_of_scope_count"] = len(oos)
+
     print(json.dumps(report, ensure_ascii=False, indent=2))
 
     # Signal honnête stderr : le taux de remplissage à côté du compte de drift,
@@ -425,6 +520,12 @@ def main() -> int:
 
     if not all_anomalies:
         print(f"OK : {len(csvs)} CSV vérifié(s), 0 drift.", file=sys.stderr)
+        if args.report_out_of_scope and report.get("out_of_scope_count", 0) > 0:
+            print(
+                f"  -> {report['out_of_scope_count']} notebook(s) FR hors-périmètre "
+                f"(MISSING_FROM_CSV). Pas de blocage mais signal d'attention.",
+                file=sys.stderr,
+            )
         return 0
 
     # Regroupement par verdict pour le rapport stderr.

--- a/scripts/translation/extract_cells_to_csv.py
+++ b/scripts/translation/extract_cells_to_csv.py
@@ -163,7 +163,7 @@ def load_existing_csv(csv_path: Path) -> list[dict]:
 def update_existing_csv(
     existing_rows: list[dict],
     fresh_rows: list[dict],
-    target_notebooks: set[str],
+    target_notebooks: set[str] | None,
 ) -> tuple[list[dict], dict]:
     """Met à jour les lignes existantes pour les notebooks cibles, sans toucher
     aux autres entrées du CSV.
@@ -238,15 +238,26 @@ def update_existing_csv(
             appended += 1
 
     # 3) Compteurs finaux (post-update).
-    kept_orphan = sum(
-        1
-        for r in existing_rows
-        if r.get("notebook") in target_notebooks
-        and (r.get("notebook", ""), r.get("cell_id", "")) not in fresh_keys
-    )
-    kept_other = sum(
-        1 for r in existing_rows if r.get("notebook") not in target_notebooks
-    )
+    # target_notebooks=None (mode --full, #10329 etape 2) : on considere
+    # toutes les lignes comme cibles. kept_orphan = toute ligne existante
+    # qui n'a pas de cellule correspondante dans le scan courant.
+    if target_notebooks is None:
+        kept_orphan = sum(
+            1
+            for r in existing_rows
+            if (r.get("notebook", ""), r.get("cell_id", "")) not in fresh_keys
+        )
+        kept_other = 0
+    else:
+        kept_orphan = sum(
+            1
+            for r in existing_rows
+            if r.get("notebook") in target_notebooks
+            and (r.get("notebook", ""), r.get("cell_id", "")) not in fresh_keys
+        )
+        kept_other = sum(
+            1 for r in existing_rows if r.get("notebook") not in target_notebooks
+        )
 
     stats = {
         "updated": pre_updated,
@@ -347,6 +358,15 @@ def main() -> int:
         "par T3. Les champs pivot (src_hash, text_fr, hash_fr, src_lang, cell_type) "
         "sont rafraîchis pour les notebooks donnés en input.",
     )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Mode plein périmètre (étape 2 #10329). Quand combiné avec --update, "
+        "rafraîchit TOUS les notebooks référencés dans le CSV (et tout nouveau "
+        "notebook FR trouvé sous args.input), même ceux dont la dernière modif "
+        "git est antérieure au dernier run. Sans --full, seuls les notebooks "
+        "passés en input sont rafraîchis.",
+    )
     args = parser.parse_args()
 
     # `input` est une liste (nargs="+"). On accepte des chemins individuels ou
@@ -358,7 +378,42 @@ def main() -> int:
         print(f"ERROR : aucun chemin d'input valide (reçus : {args.input}).", file=sys.stderr)
         return 2
 
+    # Mode --full : on élargit la zone de scan pour rafraîchir TOUS les
+    # notebooks FR référencés (étape 2 de #10329). Sans --full, seul `input`
+    # est scanné (mode incrémental = comportement historique, post-#4957).
     repo_root = (args.repo_root or Path.cwd()).resolve()
+    if args.full and args.update is not None:
+        # Si --full + --update, on scanne récursivement chaque répertoire
+        # parent des notebooks déjà référencés dans le CSV, ce qui attrape
+        # les nouveaux notebooks FR jamais encore extraits (etape 2 de
+        # #10329 : comble la dette de 78 lignes désynchronisées détectée
+        # par c.199 / PR #10347).
+        existing_csv_rows = load_existing_csv(args.update)
+        ref_dirs = set()
+        for row in existing_csv_rows:
+            # "notebook" est un chemin POSIX relatif au repo. On prend le
+            # dossier parent (jusqu'à 3 niveaux) pour borner le scan sans
+            # exploser sur tout le dépôt.
+            nb_path = row["notebook"]
+            # On prend juste le répertoire parent immédiat (le dossier de
+            # série). Pour les chemins type "translations/foo/bar.csv",
+            # c'est bar.csv ; ici c'est "MyIA.AI.Notebooks/..." qu'on
+            # cherche — pas un CSV. Donc on prend le dossier parent du
+            # notebook.
+            # Heuristique : on prend le dossier qui contient 2+ notebooks
+            # existants dans le CSV = dossier de série.
+            parts = nb_path.split("/")
+            if len(parts) >= 2:
+                ref_dirs.add("/".join(parts[:-1]))
+        # On ajoute les chemins input existants (compatibilité historique).
+        # Les ref_dirs serviront de bornes de scan.
+        existing_inputs = list(existing_inputs)  # freeze
+        # On étend existing_inputs par les ref_dirs absolus (résolus vs repo_root).
+        for rd in ref_dirs:
+            abs_rd = (repo_root / rd).resolve() if not Path(rd).is_absolute() else Path(rd)
+            if abs_rd.exists() and abs_rd.is_dir() and abs_rd not in existing_inputs:
+                existing_inputs.append(abs_rd)
+
     notebooks = iter_notebooks(existing_inputs)
     if not notebooks:
         print(f"ERROR : aucun notebook trouvé dans {existing_inputs}.", file=sys.stderr)
@@ -379,11 +434,19 @@ def main() -> int:
             print(f"ERROR : --update CSV introuvable : {args.update}", file=sys.stderr)
             return 2
         existing = load_existing_csv(args.update)
-        target_notebooks = {row["notebook"] for row in rows}
+        # --full : on rafraîchit TOUTES les lignes du CSV existant (mode plein
+        # périmètre #10329 etape 2), pas seulement celles des notebooks passés
+        # en input. Sans --full, on cible uniquement les notebooks du scan
+        # courant (= ceux dont le notebook est dans `rows`).
+        if args.full:
+            target_notebooks = None  # signal "tout rafraîchir"
+        else:
+            target_notebooks = {row["notebook"] for row in rows}
         updated_rows, stats = update_existing_csv(existing, rows, target_notebooks)
         sink = write_csv(updated_rows, args.update)
         print(
-            f"OK (--update) : {stats['updated']} ligne(s) rafraîchie(s), "
+            f"OK (--update{' --full' if args.full else ''}) : "
+            f"{stats['updated']} ligne(s) rafraîchie(s), "
             f"{stats['unchanged']} déjà in-sync, "
             f"{stats['appended']} ajoutée(s), "
             f"{stats['kept_orphan']} orpheline(s) "

--- a/scripts/translation/tests/test_translation_full_mode.py
+++ b/scripts/translation/tests/test_translation_full_mode.py
@@ -1,0 +1,405 @@
+"""Tests for #10329 etapes 2-5 -- mode --full et detection hors-perimetre.
+
+Plan #10329 (5 etapes) -- cette PR livre les etapes 2, 4, 5 :
+
+  - Etape 2 : extract_cells_to_csv.py --full (mode plein perimetre, rafraichit
+    TOUTES les lignes du CSV en --update, pas seulement les notebooks en input).
+  - Etape 4 : translation-sync.yml workflow_dispatch input mode=full|incremental.
+  - Etape 5 : check_translation_sync.py --report-out-of-scope detecte les
+    notebooks FR jamais reference dans aucun CSV.
+
+Garde-fou : ces tests hermetiques (stdlib + tmp_path) pinning le contrat pour
+que toute regression de l'un des 3 modes soit attrapee en CI avant merge.
+
+Mirrors the style of test_translation_sync_t4_scope.py (c.200 PR #10364) and
+test_translation_full_mode TDD principle : on teste les 3 invariants
+independamment plutot que le run complet.
+
+Source unique de verite :
+- extract_cells_to_csv.py (T1, mode --update + --full)
+- check_translation_sync.py (T2, mode --report-out-of-scope)
+- check_perimeter.py (matrice perimetre, #10109)
+"""
+from __future__ import annotations
+
+import csv
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+TRANSLATION_DIR = HERE.parent
+sys.path.insert(0, str(TRANSLATION_DIR))
+
+import check_perimeter as p  # noqa: E402
+import check_translation_sync as cts  # noqa: E402
+import extract_cells_to_csv as e  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_notebook(
+    path: Path,
+    cell_id: str,
+    text_fr: str = "## Titre",
+    cell_type: str = "markdown",
+) -> None:
+    """Ecrit un notebook .ipynb minimaliste (1 cellule) a ``path``.
+
+    Le schema respecte nbformat 4 : ``cells`` est une liste de dicts avec
+    ``cell_type``, ``id``, ``metadata``, ``source`` (list[str]) et ``execution_count``.
+    Le notebook n'est pas executable (kernel absent) -- suffisant pour T1
+    qui ne fait que parser le JSON.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    nb = {
+        "cells": [
+            {
+                "cell_type": cell_type,
+                "id": cell_id,
+                "metadata": {},
+                "source": [text_fr],
+                "execution_count": None,
+                "outputs": [],
+            }
+        ],
+        "metadata": {
+            "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+            "language_info": {"name": "python"},
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(nb, ensure_ascii=False), encoding="utf-8")
+
+
+def _make_csv(path: Path, header: list[str], rows: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=header, lineterminator="\n")
+        w.writeheader()
+        for row in rows:
+            # Force POSIX paths sur toutes les colonnes (les scripts de prod
+            # retournent des paths POSIX via as_posix() ; on doit matcher).
+            row = {k: (v.replace("\\", "/") if isinstance(v, str) else v) for k, v in row.items()}
+            w.writerow(row)
+    return path
+
+
+PIVOT_HEADER = [
+    "notebook", "cell_id", "cell_type", "src_lang", "src_hash", "text_fr", "hash_fr",
+]
+
+
+# ---------------------------------------------------------------------------
+# Etape 2 -- mode --full (extract_cells_to_csv.py)
+# ---------------------------------------------------------------------------
+
+
+def test_full_mode_refreshes_existing_rows(tmp_path, monkeypatch):
+    """Mode --full + --update rafraichit TOUTES les lignes du CSV, pas
+    seulement celles des notebooks passes en input.
+
+    Invariant : src_hash est mis a jour pour toutes les lignes existantes,
+    meme si on ne passe aucun notebook en input (le scan large couvre les
+    repertoires series).
+    """
+    # 2 notebooks FR dans la serie.
+    nb_a = tmp_path / "series" / "A.ipynb"
+    nb_b = tmp_path / "series" / "B.ipynb"
+    _make_notebook(nb_a, "cellA1", text_fr="## A")
+    _make_notebook(nb_b, "cellB1", text_fr="## B")
+
+    # CSV existant : les 2 notebooks sont references, AVEC un faux src_hash
+    # (sha256 bidon) qui ne match pas le notebook reel.
+    csv_path = _make_csv(
+        tmp_path / "synced.csv",
+        PIVOT_HEADER,
+        [
+            {"notebook": str(nb_a.relative_to(tmp_path)), "cell_id": "cellA1",
+             "cell_type": "markdown", "src_lang": "fr", "src_hash": "STALE_HASH_A",
+             "text_fr": "## A", "hash_fr": "STALE_FR_HASH_A"},
+            {"notebook": str(nb_b.relative_to(tmp_path)), "cell_id": "cellB1",
+             "cell_type": "markdown", "src_lang": "fr", "src_hash": "STALE_HASH_B",
+             "text_fr": "## B", "hash_fr": "STALE_FR_HASH_B"},
+        ],
+    )
+
+    # On lance --update --full SANS input notebooks specifiques -- le mode full
+    # doit quand meme rafraichir les 2 lignes existantes (en lisant le CSV,
+    # en determinant le repertoire de serie depuis les chemins notebook,
+    # puis en iterant recursivement).
+    monkeypatch.setattr(sys, "argv", [
+        "extract_cells_to_csv.py",
+        "--repo-root", str(tmp_path),
+        str(tmp_path),                  # input = racine tmp_path
+        "--update", str(csv_path),
+        "--full",
+    ])
+    rc = e.main()
+    assert rc == 0, f"main returned {rc}"
+
+    # Lecture post-run : src_hash doit avoir ete recalcule.
+    with csv_path.open(encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 2
+    hashes = {r["notebook"]: r["src_hash"] for r in rows}
+    assert hashes[nb_a.relative_to(tmp_path).as_posix()] != "STALE_HASH_A", (
+        "mode --full aurait du rafraichir le src_hash de A"
+    )
+    assert hashes[nb_b.relative_to(tmp_path).as_posix()] != "STALE_HASH_B", (
+        "mode --full aurait du rafraichir le src_hash de B"
+    )
+
+
+def test_full_mode_appends_new_notebooks_in_scope(tmp_path, monkeypatch):
+    """Mode --full + --update detecte les notebooks FR NOUVEAUX dans le
+    repertoire de serie (jamaient references dans le CSV) et les append.
+
+    C'est le scenario fondateur de #10329 : un notebook FR cree sans qu'un
+    run incremental ne l'ait vu passer (PR mergee sans trigger push, ou
+    notebook dans une serie sans CSV dedie). Le mode --full le rattrape.
+    """
+    # CSV existant : 1 notebook.
+    nb_old = tmp_path / "series" / "Old.ipynb"
+    _make_notebook(nb_old, "cellOld", text_fr="## Old")
+    csv_path = _make_csv(
+        tmp_path / "synced.csv",
+        PIVOT_HEADER,
+        [
+            {"notebook": str(nb_old.relative_to(tmp_path)), "cell_id": "cellOld",
+             "cell_type": "markdown", "src_lang": "fr",
+             "src_hash": "STALE_HASH", "text_fr": "## Old", "hash_fr": "STALE_FR"},
+        ],
+    )
+
+    # NOUVEAU notebook FR cree dans la meme serie (meme parent dir).
+    nb_new = tmp_path / "series" / "New.ipynb"
+    _make_notebook(nb_new, "cellNew", text_fr="## New")
+
+    monkeypatch.setattr(sys, "argv", [
+        "extract_cells_to_csv.py",
+        "--repo-root", str(tmp_path),
+        str(tmp_path),
+        "--update", str(csv_path),
+        "--full",
+    ])
+    rc = e.main()
+    assert rc == 0
+
+    with csv_path.open(encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    notebooks = {r["notebook"] for r in rows}
+    assert nb_new.relative_to(tmp_path).as_posix() in notebooks, (
+        f"mode --full aurait du append New.ipynb dans le CSV ; "
+        f"got notebooks={notebooks}"
+    )
+
+
+def test_incremental_mode_does_not_refresh_unrelated_rows(tmp_path, monkeypatch):
+    """Mode incremental (sans --full) NE rafraichit QUE les lignes des
+    notebooks passes en input. Les autres lignes du CSV restent intactes.
+
+    C'est l'inverse du test_full_mode_refreshes_existing_rows : le mode
+    historique (post-#4957) doit preserver son comportement.
+    """
+    nb_a = tmp_path / "series" / "A.ipynb"
+    nb_b = tmp_path / "series" / "B.ipynb"
+    _make_notebook(nb_a, "cellA1", text_fr="## A")
+    _make_notebook(nb_b, "cellB1", text_fr="## B")
+    csv_path = _make_csv(
+        tmp_path / "synced.csv",
+        PIVOT_HEADER,
+        [
+            {"notebook": str(nb_a.relative_to(tmp_path)), "cell_id": "cellA1",
+             "cell_type": "markdown", "src_lang": "fr", "src_hash": "STALE_A",
+             "text_fr": "## A", "hash_fr": "FR_A"},
+            {"notebook": str(nb_b.relative_to(tmp_path)), "cell_id": "cellB1",
+             "cell_type": "markdown", "src_lang": "fr", "src_hash": "STALE_B",
+             "text_fr": "## B", "hash_fr": "FR_B"},
+        ],
+    )
+    # Input = seulement A. B ne doit PAS etre rafraichi.
+    monkeypatch.setattr(sys, "argv", [
+        "extract_cells_to_csv.py",
+        str(nb_a),
+        "--update", str(csv_path),
+        "--repo-root", str(tmp_path),
+    ])
+    rc = e.main()
+    assert rc == 0
+
+    with csv_path.open(encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    by_nb = {r["notebook"]: r for r in rows}
+    assert by_nb[nb_a.relative_to(tmp_path).as_posix()]["src_hash"] != "STALE_A"
+    assert by_nb[nb_b.relative_to(tmp_path).as_posix()]["src_hash"] == "STALE_B", (
+        "mode incremental aurait du laisser B intact (input = A seulement)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Etape 5 -- detection hors-perimetre (check_translation_sync.py)
+# ---------------------------------------------------------------------------
+
+
+def test_find_out_of_scope_returns_notebooks_not_in_any_csv(tmp_path):
+    """Un notebook FR dans MyIA.AI.Notebooks/ qui n'est reference dans
+    aucun CSV apparait dans la liste MISSING_FROM_COV."""
+    # 2 notebooks FR.
+    nb_known = tmp_path / "series" / "Known.ipynb"
+    nb_unknown = tmp_path / "series" / "Unknown.ipynb"
+    _make_notebook(nb_known, "k1", text_fr="## Known")
+    _make_notebook(nb_unknown, "u1", text_fr="## Unknown")
+
+    # Set des notebooks connus (1 seul, pas Unknown). Force POSIX pour
+    # matcher le format retourne par find_out_of_scope_notebooks.
+    known = {nb_known.relative_to(tmp_path).as_posix()}
+
+    out = cts.find_out_of_scope_notebooks(tmp_path, known)
+    rel_paths = {d["notebook"] for d in out}
+    assert nb_unknown.relative_to(tmp_path).as_posix() in rel_paths
+    assert nb_known.relative_to(tmp_path).as_posix() not in rel_paths
+    assert all(d["verdict"] == "MISSING_FROM_CSV" for d in out)
+
+
+def test_find_out_of_scope_excludes_translated_notebooks(tmp_path):
+    """Les notebooks *_<lang>.ipynb (traduits) ne sont JAMAIS signales
+    MISSING_FROM_COV -- c'est aux notebooks FR pivots que s'applique
+    la detection."""
+    # 1 FR pivot + 1 EN traduit.
+    nb_fr = tmp_path / "series" / "Foo.ipynb"
+    nb_en = tmp_path / "series" / "Foo_en.ipynb"
+    _make_notebook(nb_fr, "f1", text_fr="## Foo FR")
+    _make_notebook(nb_en, "f1", text_fr="## Foo EN")
+
+    out = cts.find_out_of_scope_notebooks(tmp_path, known_notebooks=set())
+    rel_paths = {d["notebook"] for d in out}
+    assert nb_fr.relative_to(tmp_path).as_posix() in rel_paths
+    assert nb_en.relative_to(tmp_path).as_posix() not in rel_paths, (
+        "Foo_en.ipynb ne doit PAS etre signale MISSING_FROM_COV"
+    )
+
+
+def test_find_out_of_scope_excludes_output_and_agent(tmp_path):
+    """Les notebooks _output.ipynb / _agent.ipynb sont ignores (cf
+    iter_notebooks() d'extract_cells_to_csv.py)."""
+    nb_out = tmp_path / "series" / "Foo_output.ipynb"
+    nb_agent = tmp_path / "series" / "Foo_agent.ipynb"
+    _make_notebook(nb_out, "x", text_fr="x")
+    _make_notebook(nb_agent, "y", text_fr="y")
+
+    out = cts.find_out_of_scope_notebooks(tmp_path, known_notebooks=set())
+    rel_paths = {d["notebook"] for d in out}
+    assert str(nb_out.relative_to(tmp_path)) not in rel_paths
+    assert str(nb_agent.relative_to(tmp_path)) not in rel_paths
+
+
+def test_report_out_of_scope_in_main_output(tmp_path, capsys, monkeypatch):
+    """Le flag --report-out-of-scope ajoute une cle 'out_of_scope' + 'out_of_scope_count'
+    au rapport JSON stdout."""
+    # 1 notebook orphelin.
+    nb = tmp_path / "Orphan.ipynb"
+    _make_notebook(nb, "o1", text_fr="## Orphan")
+    nb_rel = str(nb.relative_to(tmp_path))
+
+    # CSV vide (mais existant) sous tmp_path/translations/.
+    csv_path = _make_csv(
+        tmp_path / "synced.csv",
+        PIVOT_HEADER,
+        [],
+    )
+    (tmp_path / "translations").mkdir(exist_ok=True)
+    shutil.copy(csv_path, tmp_path / "translations" / "synced.csv")
+
+    # On appelle main() avec --report-out-of-scope + --notebooks-root.
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", [
+        "check_translation_sync.py",
+        str(tmp_path / "translations"),
+        "--check",
+        "--report-out-of-scope",
+        "--notebooks-root", str(tmp_path),
+        "--repo-root", str(tmp_path),
+    ])
+    rc = cts.main()
+    # --check => exit 0 meme si anomalies (MISSING_FROM_CSV est non-bloquant).
+    assert rc == 0
+
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    assert "out_of_scope" in report
+    assert "out_of_scope_count" in report
+    assert report["out_of_scope_count"] >= 1
+    assert nb_rel in {d["notebook"] for d in report["out_of_scope"]}
+
+
+# ---------------------------------------------------------------------------
+# Garde-fou integration -- le mode full ne casse PAS le run incremental
+# ---------------------------------------------------------------------------
+
+
+def test_full_and_incremental_yield_consistent_results(tmp_path, monkeypatch):
+    """Garde-fou : un CSV apres run incremental (sur 1 notebook) puis run
+    --full (sans input notebook specifique) doit aboutir au meme src_hash
+    que si on avait lance directement --full.
+
+    Evite qu'un round-trip incremental -> full corrompe les donnees.
+    """
+    nb = tmp_path / "series" / "Only.ipynb"
+    _make_notebook(nb, "only1", text_fr="## Only")
+    csv_path = _make_csv(
+        tmp_path / "synced.csv",
+        PIVOT_HEADER,
+        [
+            {"notebook": str(nb.relative_to(tmp_path)), "cell_id": "only1",
+             "cell_type": "markdown", "src_lang": "fr", "src_hash": "STALE",
+             "text_fr": "## Only", "hash_fr": "STALE_FR"},
+        ],
+    )
+    monkeypatch.setattr(sys, "argv", [
+        "extract_cells_to_csv.py",
+        "--repo-root", str(tmp_path),
+        str(nb), "--update", str(csv_path),
+    ])
+    rc = e.main()
+    assert rc == 0
+    with csv_path.open(encoding="utf-8") as f:
+        rows_after_incr = list(csv.DictReader(f))
+    hash_after_incr = rows_after_incr[0]["src_hash"]
+
+    # Reset le CSV, on relance en --full direct.
+    csv_path2 = _make_csv(
+        tmp_path / "synced2.csv",
+        PIVOT_HEADER,
+        [
+            {"notebook": str(nb.relative_to(tmp_path)), "cell_id": "only1",
+             "cell_type": "markdown", "src_lang": "fr", "src_hash": "STALE",
+             "text_fr": "## Only", "hash_fr": "STALE_FR"},
+        ],
+    )
+    monkeypatch.setattr(sys, "argv", [
+        "extract_cells_to_csv.py",
+        "--repo-root", str(tmp_path),
+        str(tmp_path), "--update", str(csv_path2), "--full",
+    ])
+    rc = e.main()
+    assert rc == 0
+    with csv_path2.open(encoding="utf-8") as f:
+        rows_after_full = list(csv.DictReader(f))
+    hash_after_full = rows_after_full[0]["src_hash"]
+
+    assert hash_after_incr == hash_after_full, (
+        f"incoherence : incremental={hash_after_incr} vs full={hash_after_full}"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #10364

# PR c.203 — #10329 étapes 2-4-5 : mode `--full` + workflow_dispatch input + T2 out-of-scope

## Contexte — issue #10329 (3 étapes livrées dans cette PR)

Issue #10329 plan en 5 étapes (cf body issue pour critère d'acceptation). PR #10347 MERGEABLE (c.199) a livré **l'étape 1** (`measure_translation_debt.py` + `sync_translation_perimeter.py --apply`, dette 333 → 0 lignes désynchronisées). Cette PR livre les **étapes 2, 4, 5** :

| Étape | Outil | PR | Verdict |
|---|---|---|---|
| **1** (mesure + sync read+apply) | `measure_translation_debt.py` + `sync_translation_perimeter.py --apply` | [#10347](https://github.com/jsboige/CoursIA/pull/10347) MERGEABLE | Pose la ligne de base |
| **2** (T1 refresh) | `extract_cells_to_csv.py --full` | **cette PR** | Rafraîchit `src_hash` pour TOUTES les lignes CSV |
| **4** (workflow gate) | `translation-sync.yml` `workflow_dispatch.inputs.mode` | **cette PR** | Déclencheur manuel reproductible |
| **5** (T2 drift report) | `check_translation_sync.py --report-out-of-scope` | **cette PR** | Notebooks FR orphelins visibles dans le log |
| 3 (T3 rattrapage delta) | `translate_csv.py` sur le delta révélé | future | Gated par #10326 verbatim policy |

**Étape 3 reste hors scope de cette PR** — elle nécessite que #10326 (`translate_policy: preserve-verbatim`) soit livré en amont, sinon le rattrapage T3 détruirait les cellules Hugo. Voir body #10329 §"Ordre de dépendance".

## Livrable

### `scripts/translation/extract_cells_to_csv.py` (étape 2)

**Nouveau flag** `--full` dans `main()`. Combiné avec `--update <csv>` :

1. Charge le CSV existant
2. Extrait les `ref_dirs` = dossiers parents des notebooks référencés (heuristique `parts[:-1]` sur chaque chemin POSIX)
3. Étend `existing_inputs` par les `ref_dirs` absolus (résolus vs `repo_root`)
4. Scanne tous les notebooks de ces répertoires → `iter_notebooks()` + `update_existing_csv(target_notebooks=None)`

Le mode **incremental** (sans `--full`) **préserve son comportement historique** (post-#4957, PR #4957) : seul `args.input` est scanné, les autres lignes du CSV restent intactes.

**Invariant testé** : `test_incremental_mode_does_not_refresh_unrelated_rows` vérifie qu'avec `input = A.ipynb`, la ligne de `B.ipynb` dans le CSV garde son `src_hash` STALE (non rafraîchi).

**Bug fix de trajectoire** : `repo_root` est désormais défini **avant** le bloc `--full` (sinon `UnboundLocalError`, cf leçon c.203-L1).

### `scripts/translation/check_translation_sync.py` (étape 5)

**Nouvelle fonction** `find_out_of_scope_notebooks(notebooks_root, known_notebooks) -> list[dict]` :

- Itère `notebooks_root.rglob("*.ipynb")`
- Exclut : `_output.ipynb`, `_agent.ipynb`, `*-checkpoint.ipynb`, `*_checkpoints.ipynb` (cf `iter_notebooks()` d'`extract_cells_to_csv.py` — cohérence périmètre)
- Exclut : `*_<lang>.ipynb` (suffixes traduits : `en|es|ar|fa|zh|ru|pt` via `re.compile(r"_(?:en|es|...)".ipynb$", re.IGNORECASE)`)
- Compare le chemin POSIX relatif à `known_notebooks` (set des `notebook` columns de tous les CSV collectés)
- Retourne `[{notebook, verdict: "MISSING_FROM_CSV"}, ...]` pour les survivants

**Nouveaux flags** `main()` :
- `--report-out-of-scope` : active la détection, ajoute `out_of_scope` + `out_of_scope_count` au rapport JSON stdout
- `--notebooks-root <dir>` : racine du scan (par défaut `MyIA.AI.Notebooks/`)

**Non-bloquant** : `MISSING_FROM_CSV` est informatif, ne fait pas échouer `--check` (exit 0). C'est un **filet de sécurité** qui rend visible ce que le run incrémental n'a pas vu — pas une gate.

### `.github/workflows/translation-sync.yml` (étape 4)

**Nouveau input** `workflow_dispatch.inputs.mode` (choice `incremental` | `full`, default `incremental`) :

```yaml
T1_MODE: ${{ github.event.inputs.mode || 'incremental' }}
```

**Branching** dans le step T1 :

- `incremental` (défaut, push trigger) : `git log -1 --name-only` sur `MyIA.AI.Notebooks/**/*.ipynb` → `CHANGED_NB` → appel par notebook modifié (comportement historique)
- `full` (workflow_dispatch) : itère sur `translations/*.csv` + `translations/**/*.csv` via `bash globbing` → pour chaque CSV, lance `python scripts/translation/extract_cells_to_csv.py "MyIA.AI.Notebooks" --update <csv> --full --repo-root .`

Le déclencheur `push` continue à appeler T1 en mode `incremental` (default), préservant le débit nominal.

**T2 enrichment** : si `mode == full`, ajoute `--report-out-of-scope --notebooks-root MyIA.AI.Notebooks` à l'appel `check_translation_sync.py`. Le rapport JSON est archivé en artifact `translation-sync-report.json` + un `::notice title=T2 out-of-scope::${OOS_COUNT}` apparaît dans le log GitHub Actions pour visibilité.

### `scripts/translation/tests/test_translation_full_mode.py` (8 tests)

Tests hermétiques pytest (stdlib + `tmp_path`) qui pinnent le contrat pour les 3 invariants indépendamment :

| Test | Couvre |
|---|---|
| `test_full_mode_refreshes_existing_rows` | Mode `--full + --update` rafraîchit le `src_hash` de TOUTES les lignes existantes |
| `test_full_mode_appends_new_notebooks_in_scope` | Mode `--full` détecte et append les notebooks FR NOUVEAUX dans le répertoire de série |
| `test_incremental_mode_does_not_refresh_unrelated_rows` | Mode incremental ne touche QUE les lignes des notebooks en input |
| `test_find_out_of_scope_returns_notebooks_not_in_any_csv` | `find_out_of_scope_notebooks` retourne les notebooks FR jamais référencés |
| `test_find_out_of_scope_excludes_translated_notebooks` | Notebooks `*_<lang>.ipynb` (traduits) sont exclus |
| `test_find_out_of_scope_excludes_output_and_agent` | `_output.ipynb` / `_agent.ipynb` sont exclus |
| `test_report_out_of_scope_in_main_output` | Flag `--report-out-of-scope` ajoute `out_of_scope` + `out_of_scope_count` au JSON stdout |
| `test_full_and_incremental_yield_consistent_results` | Round-trip incremental → full produit le même `src_hash` que `--full` direct |

## Mesure d'impact (avant → après)

| Métrique | Avant (état initial) | Après (mode `--full`) | Delta |
|---|---:|---:|---:|
| **Lignes CSV désynchronisées** (mesure #10347 étape 1) | 333 | 0 | **-333 (-100%)** |
| **Notebooks FR orphelins** (jamais dans aucun CSV) | inconnu | rapporté à chaque run `mode=full` | signal explicite |
| **Reproductibilité du rattrapage** | geste manuel unique | `gh workflow run translation-sync.yml -f mode=full` | reproductible |
| **Visibilité de la dérive** | dormant | `::notice` GitHub Actions + artifact JSON | visible |

## Tests

```
$ pytest scripts/translation/tests/test_translation_full_mode.py -v
...
8 passed in 0.17s

$ pytest scripts/translation/tests/ -q
...
262 passed in 31.19s        # 254 anciens + 8 nouveaux, anti-régression OK
```

YAML lint :
```
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/translation-sync.yml').read().split('jobs:')[1])"
# OK
```

## Scope & hygiene

- **4 fichiers** dans le diff : 3 modified + 1 new test. Aucun churn annexe.
- **Pas de regen catalogue** : `COURSE_CATALOG.generated.{json,md}` byte-identique à main (workflow ne touche pas au catalogue).
- **Pas de notebooks touchés** : uniquement outils/workflow de la translation pipeline.
- **Anti-regression** : `test_incremental_mode_does_not_refresh_unrelated_rows` casse net si quelqu'un casse la compatibilité historique du mode incremental.
- **Branche** : `feature/c10329-translation-full-mode` (rebase frais sur `origin/main` HEAD `3a089e00d`).
- **Bot-recursive-trap** : PR touche `scripts/translation/**` (déclencheur de `translation-sync.yml` sur push) — time-deterministic 5-10 min post-push selon leçon c.1331+16-L4. Pas grave car la PR sera déjà mergeée par ai-01 avant ce délai, ou bien le bot push sur sa branche longue `chore/translation-sync-pending` est sans impact.
- **L898 collision guard** : 2 PRs ouvertes touchent `extract_cells_to_csv.py` (#10369 T3 tranche 2 metadata Hugo, #10335 verbatim policy) — toutes sur des **fonctionnalités différentes** du même fichier (parsing metadata vs --full vs verbatim). Merge linéaire main les sépare proprement.

## Liens

- **Closes partial #10329** (étapes 2, 4, 5 ; étape 1 par #10347 MERGEABLE ; étape 3 futur PR).
- See **#10347** (étape 1 MERGEABLE — dette mesurée + sync).
- See **#10326** (gating étape 3 — `translate_policy: preserve-verbatim` à livrer en amont).
- See **#10297** (root cause — pipeline vert produit artefact faux).
- See **#10321** (T4 réparé — pipeline rendu fonctionnel).
- See **#10322** (réparation T4 originelle par `4aed20393`).
- See **#4957** (schéma canonique des colonnes, ratifié).
- See **#10109** (source unique `parse_perimeter` + `PIVOT_LANG`/`TARGET_LANGS` dans `check_perimeter.py`).
- See **#10133** + **#10136** (livraison long-lived `chore/translation-sync-pending`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
