### PR TITLE
fix(ci,#10373): reset (not rebase) chore/<name>-pending on origin/main unconditionally

### DIFF
--- a/.github/workflows/catalog-cron.yml
+++ b/.github/workflows/catalog-cron.yml
@@ -80,27 +80,23 @@ jobs:
           fetch-depth: 0          # full history so git-derived fields are exact
           persist-credentials: true
 
-      # Prepare the long-lived branch from origin/main. We checkout it directly
-      # when it exists; otherwise we create it from main. This step NEVER
-      # touches main -- it only operates on chore/catalog-refresh-pending.
+      # Prepare the long-lived branch from origin/main. We reset (not rebase)
+      # onto origin/main unconditionally. Catalog regen is fully idempotent and
+      # the previous bot commit holds no curated state worth preserving -- the
+      # --merge-curated-fields logic runs against origin/main at regeneration
+      # time, not against the prior bot commit. Rebasing instead yields the
+      # same structural add/add conflict pattern observed on translation-sync
+      # (issue #10373): any human PR that touches a catalog-derived file will
+      # block the cron until the bot commit is manually dropped.
+      # --force-with-lease is safe here: branch is mono-writer bot-owned
+      # (git-workflow.md allows it on lane-unique feature branches; main is
+      # untouched either way).
       - name: Prepare chore/catalog-refresh-pending branch
         run: |
           set -euo pipefail
           BRANCH="chore/catalog-refresh-pending"
-          if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
-            echo "Branch $BRANCH already exists on origin; checking it out."
-            git fetch origin "$BRANCH"
-            git checkout -B "$BRANCH" "origin/$BRANCH"
-            # Rebase on top of origin/main so the regen always starts from
-            # the freshest main (catalog regen is idempotent -- same main
-            # produces the same catalog, so rebase-and-retry is safe).
-            git fetch origin main
-            git rebase origin/main
-          else
-            echo "Branch $BRANCH does not exist on origin yet; creating it from origin/main."
-            git fetch origin main
-            git checkout -b "$BRANCH" origin/main
-          fi
+          git fetch origin main
+          git checkout -B "$BRANCH" origin/main
           echo "Working on branch: $(git rev-parse --abbrev-ref HEAD) at $(git rev-parse --short HEAD)"
 
       - name: Set up Python

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -132,21 +132,17 @@ jobs:
         run: |
           set -euo pipefail
           BRANCH="chore/translation-sync-pending"
-          if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
-            echo "Branch $BRANCH already exists on origin; checking it out."
-            git fetch origin "$BRANCH"
-            git checkout -B "$BRANCH" "origin/$BRANCH"
-            # Rebase on top of origin/main so T1 sees the freshest set of
-            # changed notebooks. Translation re-render is idempotent -- same
-            # main + same source produces the same output, so rebase-and-retry
-            # is safe.
-            git fetch origin main
-            git rebase origin/main
-          else
-            echo "Branch $BRANCH does not exist on origin yet; creating it from origin/main."
-            git fetch origin main
-            git checkout -b "$BRANCH" origin/main
-          fi
+          git fetch origin main
+          # Reset (not rebase) onto origin/main unconditionally. T1->T4
+          # regenerate the entire derived set on every run, so the previous
+          # bot commit holds no information worth preserving -- rebasing it
+          # instead yields structural add/add conflicts as soon as any human
+          # PR lands a rendered notebook or CSV (see issue #10373: 12 runs
+          # failed 2026-08-10 on add/add for FT-02_en + finetuning.csv).
+          # --force-with-lease is safe here: branch is mono-writer bot-owned
+          # (git-workflow.md allows it on lane-unique feature branches; main
+          # is untouched either way).
+          git checkout -B "$BRANCH" origin/main
           echo "Working on branch: $(git rev-parse --abbrev-ref HEAD) at $(git rev-parse --short HEAD)"
 
       - name: Set up Python

--- a/scripts/tests/test_workflow_branch_pattern.py
+++ b/scripts/tests/test_workflow_branch_pattern.py
@@ -283,3 +283,61 @@ def test_skip_ci_in_commit_message(
         f"{workflow_label}: bot commit message must contain `[skip ci]` to "
         f"prevent the workflow from re-firing on its own push."
     )
+
+
+# ---------------------------------------------------------------------------
+# (7) The `Prepare` step does NOT rebase on origin/main.
+#     Issue #10373 (12 failed runs 2026-08-10): rebasing the previous bot
+#     commit on a fresh main produces structural add/add conflicts as soon as
+#     any human PR lands a derived file (rendered notebook or CSV). The fix
+#     is an unconditional reset (`git checkout -B <branch> origin/main`) -- the
+#     bot commit holds no curated state worth preserving because T1->T4
+#     regenerate the full derived set, and the cron workflows regenerate the
+#     catalog from origin/main directly. This test pins that invariant.
+# ---------------------------------------------------------------------------
+
+PREPARE_STEP_RE = re.compile(
+    # `- name: Prepare ...` step, capture the run block following it
+    r"(?P<header>- name: Prepare [^\n]*\n\s+run:\s*\|\s*\n)"
+    r"(?P<body>(?:\s+.*\n?)+)"
+)
+
+
+def _prepare_run_block(yaml_text: str) -> str:
+    """Return the run block of the `Prepare chore/...-pending branch` step."""
+    match = PREPARE_STEP_RE.search(yaml_text)
+    assert match is not None, "no `Prepare ...-pending branch` step found"
+    return match.group("body")
+
+
+@pytest.mark.parametrize(
+    "workflow_path,workflow_label",
+    [(CATALOG_CRON, "catalog-cron.yml"), (TRANSLATION_SYNC, "translation-sync.yml")],
+)
+def test_prepare_step_does_not_rebase(
+    workflow_path: Path, workflow_label: str
+) -> None:
+    """The `Prepare` step must reset onto origin/main, never rebase.
+
+    Rebasing the previous bot commit onto a fresh main causes structural
+    add/add conflicts (issue #10373, 12 runs failed 2026-08-10). The bot
+    commit holds no curated state worth preserving -- the catalog workflows
+    regenerate from origin/main directly, and the translation workflow
+    regenerates derived files via T1->T4 on every run.
+    """
+    text = _yaml_text(workflow_path)
+    prepare_block = _prepare_run_block(text)
+    # Forbidden: `git rebase origin/main` -- the previous failure mode.
+    assert "git rebase origin/main" not in prepare_block, (
+        f"{workflow_label}: `Prepare` step uses `git rebase origin/main`. "
+        f"Issue #10373 shows this fails structurally as soon as any human PR "
+        f"touches a derived file. Use `git checkout -B <branch> origin/main` "
+        f"instead (unconditional reset). Found:\n{prepare_block}"
+    )
+    # Required: an unconditional reset to origin/main. Accept `checkout -B`
+    # (in-place branch reset) as the canonical form.
+    assert "git checkout -B" in prepare_block and "origin/main" in prepare_block, (
+        f"{workflow_label}: `Prepare` step must unconditionally reset the "
+        f"branch onto origin/main via `git checkout -B <branch> origin/main`. "
+        f"Found:\n{prepare_block}"
+    )


### PR DESCRIPTION
# PR body — #10373 (translation-sync Prepare rebase -> reset)

Grain: LIGHT/guard META — lane myia-po-2025:CoursIA-2 — prev: MED/code #10369

## Contexte

Issue **#10373** (lane `myia-po-2025:CoursIA-2`, owner de la famille traduction) : `translation-sync.yml` étape `Prepare` **rebase** le commit bot précédent sur `origin/main` au lieu de réinitialiser la branche longue. Conséquence : dès qu'une PR humaine touche un `*_<lang>.ipynb` ou un `translations/*.csv` dérivé, le rebase bute sur un `CONFLICT (add/add)` — les deux côtés ont régénéré les mêmes chemins.

**Mesure firsthand (issue body)** : 12 runs échoués le 2026-08-10, premier à 13:56Z, dernier [run 31437202452](https://github.com/jsboige/CoursIA/actions/runs/31437202452) à 22:11Z. Branche à 22 commits derrière main, 1 commit d'avance (= une régénération intégrale de 4857 fichiers / 10 346 403 insertions). La cascade de 15 merges 21:55-22:11Z a ré-déclenché le défaut (~8 h de latence), elle ne l'a pas causé.

## Cause : la prémisse du commentaire est juste, la conclusion ne suit pas

> *Translation re-render is idempotent — same main + same source produces the same output, so rebase-and-retry is safe.*

L'idempotence de la **sortie** est vraie. Elle ne dit rien de la **rebasabilité du commit précédent**. Le commit bot porte les dérivés tels qu'il les a calculés la dernière fois — pas d'état curé, pas de curation à préserver. T1→T4 recalculent tout depuis le main frais. Préserver un commit entièrement recalculable n'est rien préserver.

Le même raisonnement vaut pour `catalog-cron.yml` : `scripts/notebook_tools/generate_catalog.py` lit `origin/main` via `_load_main_catalog` + `_merge_curated_fields` (#2433), donc le commit bot précédent n'est pas non plus une source de vérité curée.

## Réparation

Avant (les 2 workflows) :
```bash
if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
  git fetch origin "$BRANCH"
  git checkout -B "$BRANCH" "origin/$BRANCH"
  git fetch origin main
  git rebase origin/main          # <- structurellement CONFLICT dès qu'une PR humaine touche un dérivé
else
  git fetch origin main
  git checkout -b "$BRANCH" origin/main
fi
```

Après :
```bash
git fetch origin main
git checkout -B "$BRANCH" origin/main   # inconditionnel : pas de préservation d'un commit entièrement recalculable
```

Push reste en `--force-with-lease` (branche mono-écrivain propriété du bot ; l'interdit force-push porte sur `main`, cf `.claude/rules/git-workflow.md`).

## Fichiers touchés (3)

| Fichier | Δ | Nature |
|---|---|---|
| `.github/workflows/translation-sync.yml` | +11/-15 | Bloc `Prepare chore/translation-sync-pending branch` : `if/rebase` → reset inconditionnel, commentaire enrichi avec issue #10373 +12 runs et add/add mesuré |
| `.github/workflows/catalog-cron.yml` | +13/-17 | Idem sur `Prepare chore/catalog-refresh-pending branch` — même défaut, fixé en parallèle (cf. exigence #10373 critère 3 « auditer l'autre workflow ») |
| `scripts/tests/test_workflow_branch_pattern.py` | +58/-0 | **Nouveau test `test_prepare_step_does_not_rebase`** — pin l'invariant : la `Prepare` step ne doit **pas** contenir `git rebase origin/main` et doit contenir `git checkout -B … origin/main`. Empêche une régression future silencieuse. |

## Vérification

- `pytest scripts/tests/test_workflow_branch_pattern.py -v` → **14 passed in 0.16s** (12 existants + 2 nouveaux pour le pin reset-vs-rebase, paramétrés sur les 2 workflows).
- Le test rouge si on réintroduit `git rebase origin/main` ou si on retire le reset : vérifié à la main sur une copie éphémère avant commit.
- Aucune autre modification dans le diff (`git diff --stat` = 3 fichiers, +82/-32).

## Acceptance criteria (#10373, 4 critères)

| # | Critère | Statut | Note |
|---|---|---|---|
| 1 | `Prepare` step resets onto `origin/main` (au lieu de rebase) ; push en `--force-with-lease` | **OK** | Modifs minimales, commentaire enrichi avec lien issue + symptôme mesuré |
| 2 | Un run sur push `main` atteint T4 en `success` (étape 12 reste en échec tant que #10331 n'est pas tranchée — écrit explicitement dans le log, pas silencieusement) | **NON APPLICABLE cette PR** | Le fix restaure la moitié *calcul*. La moitié *livraison* (étape 12) reste fermée par le 403 de réglage (#10331, décision user, non levée). À **écrire explicitement dans le log du prochain run**, pas à passer en silence — le commentaire du workflow le rappelle déjà |
| 3 | `catalog-cron.yml` audité pour le même motif : corrigé ou déclaré non concerné avec ligne à l'appui | **OK** | Défaut identique détecté (l. 90-99, `git rebase origin/main`) et corrigé identiquement. Commentaire du fix cite explicitement la symétrie avec translation-sync et l'issue #10373 |
| 4 | Aucun `*_<lang>.ipynb` non traduit livré sur `main` ; garde-fou de #10349 effectif avant ouverture PR branche longue | **OK** | Cette PR n'ouvre PAS la PR de la branche longue (cf. dernier paragraphe). Le garde-fou `--require-translated` de #10359 reste opt-in ; tant qu'il n'est pas effectif, ouvrir la PR livrerait ~4170 copies FR (vérifié firsthand `Tweety-9-Preferences_ru.ipynb`, 17 cellules md, 0 cyrillique, 1ère cellule « # Préférences et Théorie du Vote ») |

## Constraints rappelées (NOT in this PR)

1. **Indépendant de #10331.** Le fix restaure la moitié *calcul*. La moitié *livraison* reste fermée par le 403 de réglage (décision user, non levée). L'étape 12 est **attendue** en échec ; à écrire dans le log du prochain run, pas à laisser passer.
2. **N'ouvre PAS la PR de `chore/translation-sync-pending`** tant que `--require-translated` (#10349, #10359) n'est pas effectif. Le rouge actuel est, de fait, protecteur — cette PR ne lève pas ce rouge. La régression a été postée sur #10331 par ai-01 ce soir : « rien n'est perdu en attendant la décision » n'est plus vrai, le pipeline échoue désormais *avant* de calculer.

## Note G-VAR-1 (plancher / honnêteté)

Ce grain est **LIGHT/guard META** — il ne tient pas le plancher G-VAR-1 et ne remplace pas le plat principal CONTENU (cf. DM `msg-20260810T220347-0omr5r` Epic #10355 : `#10367` requalification + grain d'import `argumentation_lib` = préalable Epic Phase 2).

Il est livré maintenant parce qu'il est court (~10 lignes YAML par workflow) et qu'il répare un défaut qui rend `main` rouge à chaque push depuis 8 h — coût du report : main continue à échouer sur chaque merge. Le proviseur (ai-01) a explicitement écrit « *Fais-le d'abord* ».

`prev: MED/code #10369` (G-VAR-3) : le précédent est resté sur la **famille** traduction mais en genre `code` ; ce grain est `guard` META (lumière). Le META-budget G-VAR-2 (`max(1, N//3)`) reste sous plafond pour le cycle : 0 LIGHT livré précédemment ce cycle worker, donc budget ≥ 1.

## Voir aussi

- Issue #10373 (lane owner)
- Issue #10331 (étape 12, 403 de réglage, user-gated)
- Issue #10349 (--require-translated, opt-in via #10359 MERGED)
- Issue #10136 (pattern de branche longue, GH006 blocker systémique)
- Issue #10369 (tranche 2 #10326, MED/code précédent sur la même famille traduction)
- `.claude/rules/git-workflow.md` (--force-with-lease sur branche lane-unique)

🤖 Generated with [Claude Code](https://claude.com/claude-code)