### PR TITLE
enrich(probas): interpret MAUT sensitivity curves (DecPyMC-3, C.4)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-3-Multi-Attribute.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-3-Multi-Attribute.ipynb
@@ -1632,6 +1632,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a3f4c5d6",
+   "metadata": {},
+   "source": [
+    "### Interpretation : la robustesse d'une recommandation MAUT\n",
+    "\n",
+    "Les courbes de sensibilité transforment la recommandation MAUT — un **point** (un classement pour des poids fixés) — en une **fonction** : comment le classement évolue quand on perturbe les poids. C'est le complément indispensable du calcul de valeur, et sa lecture se fait sur deux plans.\n",
+    "\n",
+    "**Les croisements sont des points de bascule.** Là où deux courbes se croisent, l'option optimale **change**. Ici, le Freelance domine tant que le poids du salaire dépasse ~25 %, et la Recherche domine en dessous de ~15 %. Entre les deux, plusieurs carrières restent compétitives : la recommandation n'est plus tranchée. Un classement MAUT donné sans cette analyse de sensibilité laisse croire que le vainqueur est robuste alors qu'il peut ne tenir qu'à un poids mal élucidé.\n",
+    "\n",
+    "**Implication pour la décision.** Si le poids du salaire est bien élucidé (loin de la bande ambiguë 15–25 %), la recommandation est **stable** et on peut décider en confiance. S'il tombe dans la bande de bascule, deux attitudes cohérentes : (a) **élucider plus finement** la prérence sur le salaire (swing weight, trade-off direct) pour quitter la zone d'ambiguïté ; (b) **accepter que la décision est sensible au poids** et introduire un critère discriminant supplémentaire ou un principe de précaution (privilégier l'option la plus robuste, pas la mieux classée en moyenne).\n",
+    "\n",
+    "C'est la leçon méthodologique : l'analyse de sensibilité ne raffine pas la recommandation, elle **quantifie la confiance** qu'on peut lui accorder. Une recommandation MAUT sans sensibilité est un avis ; avec, c'est un avis accompagné de son domaine de validité.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ec90c721",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
Grain: MED/notebook-python CONTENT — lane myia-po-2023:CoursIA-2 — prev: MED/CONTENT #10375 (Lean knot representations)

## Quoi

`DecPyMC-3-Multi-Attribute.ipynb` : ajout d'1 cellule markdown d'interprétation **APRÈS** les courbes de sensibilité de la §8 (cell `25bcd772`) et **AVANT** la §9 (cell `ec90c721`). La §8 « Analyse de Sensibilité » n'avait **AUCUNE** interprétation markdown — alors que chaque autre section analytique du notebook en a une (« ### Interpretation : Arbitrage » cell 39, « ### Interpretation : Diagnostics et correlations » cell 45). La §8 se terminait abruptement sur les courbes + un stream one-liner.

## Preuve

- **G.1 firsthand** : les 3 candidats de l'heuristique code→code ont été triés individuellement (leçon c.1041 : l'heuristique over-compte car l'interprétation peut venir 1-3 cells plus loin).
  - cell 16 (bar chart décomposition) = **borderline/FAUX** — le stream porte une one-liner (« Meilleur choix : Hybride D »).
  - cell 43 (prior vs posterior) = **FAUX GAP** — l'interprétation à cell 42 **PRÉCÈDE** le plot + le stream annote les deltas.
  - cell 36 (courbes de sensibilité) = **GENUINE** — la §8 se termine sans lecture pédagogique ; le stream one-liner (« croisements = bascule ») ne fait pas la lecture de la sensibilité comme test de robustesse de la recommandation MAUT.
- **Valeurs citées exactes** des outputs commités : Freelance domine >25%, Recherche <15%, bande ambiguë 15–25%. Pas de valeur inventée.
- **Markdown-only** : 0 cellule code touchée, 0 re-exec (C.2 exception — outputs précédents valides).
- **Anti-régression** : `git diff --stat` = **+16/-0** (insertion pure, 0 délétion).
- **nbformat.validate** : OK. **H.3** : 0 violation. **Catalogue** : byte-identique à main.

## Contenu pédagogique

Le markdown couvre : (1) les croisements comme points de bascule où l'optimum change, (2) la bande ambiguë 15–25% où plusieurs carrières restent compétitives, (3) l'implication décisionnelle (élucider plus finement vs accepter la sensibilité), (4) la leçon méthodologique — l'analyse de sensibilité ne raffine pas la recommandation, elle quantifie la confiance qu'on peut lui accorder.

## Perimetre

- `MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-3-Multi-Attribute.ipynb` (+1 markdown interprétation).
- Hors scope : DecPyMC-2/7 (candidats au scan non vérifiés ce cycle — DecPyMC-2 cell 10 Arrow-Pratt et DecPyMC-7 potentiel, à confirmer genuine dans des grains séparés). Contribution ponctuelle.
- R6 : Probas (DecisionTheory/PyMC). Note honnête : 3e grain Probas en ~4 cycles MAIS DecPyMC-3 (Multi-Attribute) ≠ DecPyMC-5 (Value of Information), et alternatives blocked/drained (voir commit).

See #2161 (famille Probas, convention interprétation — contribution partielle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
