### PR TITLE
Refine(check_machine_dep_timing,#10178): route Bayesian-context durations to distribution_param (Classe 5)

### DIFF
--- a/scripts/notebook_tools/check_machine_dep_timing.py
+++ b/scripts/notebook_tools/check_machine_dep_timing.py
@@ -131,7 +131,15 @@ DISTRIBUTION_KEYWORDS = re.compile(
     r"\b(?:Gaussian|Normal|prior|posterior|posteriori|likelihood|vraisemblance|"
     r"moyenne|mean|std|sigma|sigma[_\s]?2|variance|precision|"
     r"distribution|mu_|sigma_|mixture|Dirichlet|Gamma|Beta|"
-    r"intervalle?\s+de\s+confiance|IC\s+\d|probabilit[ée]?)\b",
+    r"intervalle?\s+de\s+confiance|IC\s+\d|probabilit[ée]?|"
+    # #10178 Classe 5 (proposée po-2024, c.66 firsthand) : discriminants
+    # bayesiens qui signalent qu'une durée (N min / N minutes) est une
+    # quantité de domaine (composante de mélange, observation, trajet,
+    # écart-type de la postérieure) et NON un wallclock machine. Sans
+    # cette liste, les notebooks de Probas qui modélisent des grandeurs
+    # temporelles (durée trajet vélo, durée décision) sont flaggés à tort
+    # et un drain détruirait des paramètres du modèle (anti-regression §D).
+    r"composantes?|observations?|trajets?|ecarts?[\-\s]?types?)\b",
     re.IGNORECASE,
 )
 

--- a/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
+++ b/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
@@ -28,6 +28,7 @@ from check_machine_dep_timing import (  # noqa: E402
     _repo_root,
     PROTOCOL_KEYWORDS,
     CONTENT_DURATION_CONSTRAINT_RE,
+    DISTRIBUTION_KEYWORDS,
     CATEGORY_WALLCLOCK,
     CATEGORY_DISTRIBUTION,
     CATEGORY_AMBIGUOUS,
@@ -373,13 +374,19 @@ def test_domain_quantity_propagation_in_cell() -> None:
     utilise ces parametres comme variable modelisee -- ex '15 min de moins
     que la moyenne'. Les '15 min' de la 2eme ligne sont la variable
     modelisee (domain_quantity), pas une mesure wallclock.
+
+    NB (#10178 Classe 5, c.1301+64) : on enleve les discriminants bayesiens
+    ('trajet', 'observations', etc.) des lignes 2/3 pour tester la
+    propagation per-cell en isolation. Sinon, la ligne 2 serait classee
+    distribution_param DIRECTEMENT par les nouveaux discriminants, sans
+    laisser la propagation s'exprimer.
     """
     nb = _make_nb([
         _md_cell(
             "Le modele suit une Gaussian de moyenne 15.33 min et sigma 1.32 min.\n"
             "\n"
             "La duree typique observee est de l'ordre de 15 minutes par trajet.\n"
-            "La proportion de trajets de moins de 15 min est la metrique cle."
+            "La proportion de moins de 15 min est la metrique cle."
         ),
     ])
     try:
@@ -390,8 +397,10 @@ def test_domain_quantity_propagation_in_cell() -> None:
             f["category"] == CATEGORY_DISTRIBUTION for f in findings
         )
         assert has_distribution, f"Attendu >=1 distribution_param, categories={findings}"
-        # Au moins un finding wallclock avant propagation (les '15 minutes' /
-        # '15 min' des autres lignes).
+        # Au moins un finding wallclock avant propagation (le '15 minutes' de
+        # la ligne 2 -- pas de mot-cle distribution direct sur cette ligne,
+        # donc reste wallclock au niveau ligne, et la propagation per-cell
+        # doit basculer en domain_quantity).
         has_wallclock_before = any(
             f["category"] == CATEGORY_WALLCLOCK for f in findings
         )
@@ -578,6 +587,137 @@ def test_categorize_ambiguous_only_when_neither() -> None:
 
 
 # --------------------------------------------------------------------------- #
+#  #10178 Classe 5 : discriminants bayesiens routent les durees de domaine
+#                   (composante de melange, observation, trajet, ecart-type)
+#                   vers distribution_param, pas wallclock.
+#  Proposee par po-2024, c.66 (comment #5232772579) sur 14 + 45 findings FP
+#  dans Infer-101 / Infer-2 (durees trajet velo). Falsifiable :
+#    - PyMC-2 cell[17] : 3 wallclock -> 0 (composantes, observations)
+#    - DecInfer-4 cell[18] : 2 wallclock -> 0 (Trajet: 60min -> 10min)
+# --------------------------------------------------------------------------- #
+def test_class5_distribution_keywords_composante_observation_trajet_ecarttype() -> None:
+    """Les discriminants bayesiens sont detectes par DISTRIBUTION_KEYWORDS.
+
+    Rationnel : un notebook qui modelise une grandeur temporelle (duree
+    trajet, duree decision) voit ses N min/matches en wallclock alors que
+    ce sont des parametres de domaine. La regex doit reconnaitre les
+    discriminants bayesiens (composantes, observations, trajets,
+    ecarts-types) comme contexte de distribution.
+
+    Cas verbatim :
+    - PyMC-2 cell[17] : 'La composante "normale" capture les trajets de
+      11 a 20 minutes' (composantes + trajets)
+    - DecInfer-4 cell[18] : 'Trajet: 60min -> 10min' (Trajet)
+    - 'observations (13, 17, 16 min)' (observations)
+    - 'ecart-type 4.14 min' (ecart-type)
+    """
+    assert DISTRIBUTION_KEYWORDS.search("composante normale")
+    assert DISTRIBUTION_KEYWORDS.search("composantes de melange")
+    assert DISTRIBUTION_KEYWORDS.search("observations (13, 17, 16 min)")
+    assert DISTRIBUTION_KEYWORDS.search("5 nouveaux trajets (18, 25, 30)")
+    assert DISTRIBUTION_KEYWORDS.search("Trajet: 60min -> 10min")
+    assert DISTRIBUTION_KEYWORDS.search("ecart-type 4.14 min")
+    assert DISTRIBUTION_KEYWORDS.search("ecart type de la posterieure")
+    # Variantes avec trait d'union / sans trait d'union
+    assert DISTRIBUTION_KEYWORDS.search("ecart-type")
+    assert DISTRIBUTION_KEYWORDS.search("ecart type")
+
+
+def test_class5_pymc2_composante_routed_to_distribution() -> None:
+    """Verbatim PyMC-2 cell[17] : 3 wallclock 'X min(utes)' -> distribution_param.
+
+    Cas reels (paraphrase conforme) :
+    - 'La composante "normale" capture les trajets de 11 a 20 minutes'
+    - 'La composante "exceptionnelle" capture les trajets de 28 a 35 minutes'
+    - 'Les 3 observations extremes (28, 32, 35 min)'
+
+    Apres le fix Classe 5 : tous les 'minutes' / 'min' dans une ligne qui
+    contient 'composantes' / 'observations' / 'trajets' doivent etre
+    classifies distribution_param.
+    """
+    line_a = (
+        "La composante \"normale\" capture les trajets de 11 a 20 minutes"
+    )
+    assert _categorize(line_a, "20 minutes") == CATEGORY_DISTRIBUTION
+    line_b = (
+        "La composante \"exceptionnelle\" capture les trajets de 28 a 35 minutes"
+    )
+    assert _categorize(line_b, "35 minutes") == CATEGORY_DISTRIBUTION
+    line_c = "Les 3 observations extremes (28, 32, 35 min)"
+    assert _categorize(line_c, "35 min") == CATEGORY_DISTRIBUTION
+
+
+def test_class5_decinfer4_trajet_routed_to_distribution() -> None:
+    """Verbatim DecInfer-4 cell[18] : 'Trajet: 60min -> 10min' -> distribution_param.
+
+    Cas reel (#10178 Classe 5, indice 2 notebook pedagogique) : un swing
+    decisionnel sur la duree de trajet n'est pas un wallclock, c'est une
+    quantite de domaine (attribut de la fonction de decision multi-criteres).
+    """
+    line = (
+        "Un swing \"Prix: 500k -> 200k\" peut etre plus ou moins important "
+        "qu'un swing \"Trajet: 60min -> 10min\""
+    )
+    # Premier match dans la ligne (regex cherche le 1er digit pattern).
+    assert _categorize(line, "60min") == CATEGORY_DISTRIBUTION
+
+
+def test_class5_does_not_break_sudoku13_control() -> None:
+    """Le controle positif Sudoku-13 reste detecte apres le fix Classe 5.
+
+    Falsifiable : les wallclock STRICTS (TIMEOUT > 60 s, duree execution
+    2.4 s) ne contiennent PAS de discriminant bayesien (composantes,
+    observations, trajets, ecart-type) et restent classes wallclock.
+
+    Verifie directement sur le notebook reel (path canonique cote owner).
+    Si le path n'existe pas (autre machine que po-2025), skip avec un
+    message clair -- le test est skip-able par design (CONTEXT-DEPENDENT).
+    """
+    nb_path = (
+        Path(__file__).resolve().parent.parent.parent.parent
+        / "MyIA.AI.Notebooks"
+        / "Sudoku"
+        / "Sudoku-13-SymbolicAutomata-Csharp.ipynb"
+    )
+    if not nb_path.exists():
+        import pytest
+        pytest.skip(f"Notebook reel non trouve cote worker : {nb_path}")
+    findings = _scan_notebook(nb_path)
+    wc = [f for f in findings if f["category"] == CATEGORY_WALLCLOCK]
+    # Falsifiable : wallclock count = 28 (avant et apres fix Classe 5).
+    # Tolerance +-0 : le fix ne doit pas modifier ce compte.
+    assert len(wc) >= 25, (
+        f"Controle positif Sudoku-13 degrade : wallclock={len(wc)} "
+        f"(attendu >=25). Le fix Classe 5 a modifie un cas non-cible."
+    )
+
+
+def test_class5_pymc2_real_notebook_silenced() -> None:
+    """Le notebook reel PyMC-2 cell[17] passe de 3 wallclock -> 0.
+
+    Verifie directement sur le notebook reel cote owner. Skip si absent.
+    """
+    nb_path = (
+        Path(__file__).resolve().parent.parent.parent.parent
+        / "MyIA.AI.Notebooks"
+        / "Probas"
+        / "PyMC"
+        / "PyMC-2-Gaussian-Mixtures.ipynb"
+    )
+    if not nb_path.exists():
+        import pytest
+        pytest.skip(f"Notebook reel non trouve cote worker : {nb_path}")
+    findings = _scan_notebook(nb_path)
+    # Filtre sur cell[17] uniquement (cas verbatim Classe 5).
+    cell17 = [f for f in findings if f.get("cell_index") == 17]
+    wc = [f for f in cell17 if f["category"] == CATEGORY_WALLCLOCK]
+    # Falsifiable : 0 wallclock sur cell[17] apres le fix.
+    assert wc == [], (
+        f"PyMC-2 cell[17] wallclock NON silencie : {[(f['snippet'], f['line'][:80]) for f in wc]}"
+    )
+
+
+# --------------------------------------------------------------------------- #
 #  Edge case : notebook PII-governed
 # --------------------------------------------------------------------------- #
 def test_pii_governed_notebook_skipped(tmp_path: Path) -> None:
@@ -650,6 +790,11 @@ def test_silence_per_notebook_propagation_residu1() -> None:
     d'une cellule. Cas reel Infer-2-Gaussian-Mixtures : les moyennes ajustees
     ``| Ordinaire | 15.07 min |`` / ``| Extraordinaire | 26.69 min |`` sont la
     SORTIE du modele (obtenue par inference), pas une mesure d'execution.
+
+    NB (#10178 Classe 5, c.1301+64) : on enleve les discriminants bayesiens
+    ('Trajets') du texte de la cellule 2 pour tester la propagation
+    per-NOTEBOOK en isolation. Sinon, 'Trajets normaux' serait classee
+    distribution_param DIRECTEMENT par DISTRIBUTION_KEYWORDS Classe 5.
     """
     nb = _make_nb([
         # Cellule 1 : declare les parametres de la distribution (distribution_param).
@@ -657,13 +802,13 @@ def test_silence_per_notebook_propagation_residu1() -> None:
             "## Modele\n"
             "Le melange suit une Gaussian de moyenne 15.33 min et sigma 1.32 min."
         ),
-        # Cellule 2 : SEPARATE, sans mot-cle stat. Sans la passe per-notebook,
-        # les 15.07 / 26.69 resteraient wallclock (la cellule 2 n'a pas de
-        # mot-cle distribution pour declencher la passe per-cell).
+        # Cellule 2 : SEPARATE, sans mot-cle stat ni discriminant Classe 5.
+        # Sans la passe per-notebook, les 15.07 / 26.69 resteraient wallclock
+        # (la cellule 2 n'a aucun discriminant distribution).
         _md_cell(
             "## Resultats ajustes\n"
-            "| Ordinaire | 15.07 min | Trajets normaux : {13, 17, 16} |\n"
-            "| Extraordinaire | 26.69 min | Trajets longs : {20, 25, 25, 30} |"
+            "| Ordinaire | 15.07 min | Normaux : {13, 17, 16} |\n"
+            "| Extraordinaire | 26.69 min | Longs : {20, 25, 25, 30} |"
         ),
     ])
     try:


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: LIGHT/guard #10374

# Refine(check_machine_dep_timing,#10178 Classe 5): Bayesian-context anti-FP — discriminants composante/observation/trajet/ecart-type

## Contexte

Issue **#10178** documente 5 classes de faux-positifs wallclock signalés par le détecteur `check_machine_dep_timing.py` (issue **#10158**). Les 4 premières classes ont été fermées par les PRs mergées :
- Classe 1 (extraction output `var=...`) — implicite
- Classe 2 (notebook bayésien global) — **PR #10176** (`distribution_param` per-cell + per-notebook propagation)
- Classe 3 (design question annotation) — non implémentée (question design ouverte)
- Classe 4 (content-duration constraint) — **PR #10241** (`CONTENT_DURATION_CONSTRAINT_RE`)
- **Classe 5 (proposée par po-2024, c.66 firsthand) — non implémentée**

## Classe 5 — Bayesian-context anti-FP

Po-2024 a documenté (comment **#5232772579** sur l'issue #10178, 2026-08-09) que les notebooks qui **modélisent des grandeurs temporelles** voient leurs `N min` / `N minutes` flaggés comme wallclock alors que ce sont des **quantités de domaine** (paramètres d'inférence, observations, durées trajet vélo, attributs de décision multi-critères). Le détecteur traite tous les `N min` de la même façon, sans regarder la **nature de la quantité**.

Cinq findings cumulés sur 2 notebooks ont été identifiés firsthand par po-2024 :

| Notebook | Cellule | Snippet | Nature |
|---|---|---|---|
| PyMC-2-Gaussian-Mixtures | cell[17] | `20 minutes` (ligne 1) | Composante de mélange (paramètre) |
| PyMC-2-Gaussian-Mixtures | cell[17] | `35 minutes` (ligne 2) | Composante de mélange (paramètre) |
| PyMC-2-Gaussian-Mixtures | cell[17] | `35 min` (ligne 3) | Observation extrême (data) |
| DecInfer-4-Multi-Attribute | cell[18] | `60min` (Indice 2) | Attribut durée trajet (swing décisionnel) |
| DecInfer-4-Multi-Attribute | cell[18] | `10min` (Indice 2) | Attribut durée trajet (swing décisionnel) |

Drainer ces valeurs détruirait des paramètres du modèle (anti-regression §D : les résultats d'inférence **sont** ces nombres).

## Fix

Extension de `DISTRIBUTION_KEYWORDS` (regex ligne 130-136 de `scripts/notebook_tools/check_machine_dep_timing.py`) avec 4 nouveaux discriminants bayesiens :

```python
DISTRIBUTION_KEYWORDS = re.compile(
    r"\b(?:Gaussian|Normal|prior|posterior|posteriori|likelihood|vraisemblance|"
    r"moyenne|mean|std|sigma|sigma[_\s]?2|variance|precision|"
    r"distribution|mu_|sigma_|mixture|Dirichlet|Gamma|Beta|"
    r"intervalle?\s+de\s+confiance|IC\s+\d|probabilit[ée]?|"
    # #10178 Classe 5 (proposée po-2024, c.66 firsthand) :
    r"composantes?|observations?|trajets?|ecarts?[\-\s]?types?)\b",
    re.IGNORECASE,
)
```

| Discriminant | Justification bayésienne |
|---|---|
| `composantes?` | Composantes d'un mélange gaussien (moyennes des K régimes) |
| `observations?` | Observations = data, pas runtime |
| `trajets?` | Durée trajet (vélo, transport) = quantité modélisée, pas exécution |
| `ecarts?[\-\s]?types?` | Écart-type de la postérieure = paramètre d'inférence |

## Mesure before / after (falsifiable)

Scan `--all` sur le corpus entier :

| Métrique | Avant (HEAD) | Après | Delta |
|---|---|---|---|
| `wallclock` corpus | 217 | 212 | **-5** |
| `distribution_param` corpus | 35 | 58 | +23 |
| `domain_quantity` corpus | 48 | 30 | -18 |

**Per-notebook wallclock changes** (seuls 2 notebooks bougent) :

| Notebook | Avant | Après |
|---|---|---|
| `Probas/PyMC/PyMC-2-Gaussian-Mixtures.ipynb` | 3 | **0** |
| `Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb` | 2 | **0** |
| Sudoku-13 (contrôle positif) | 28 | **28** (intact) |
| Tous les autres notebooks | inchangés | inchangés |

Le delta de +23 distribution_param et -18 domain_quantity provient de ce que les discriminants Classe 5 captent les lignes `composantes`, `observations`, `trajets`, `ecart-type` directement en `distribution_param`, court-circuitant la propagation per-cell/per-notebook. C'est le comportement souhaité : le discriminant est plus précis que la propagation.

## Tests

5 nouveaux tests ajoutés à `scripts/notebook_tools/tests/test_check_machine_dep_timing.py` :

1. `test_class5_distribution_keywords_composante_observation_trajet_ecarttype` — la regex capture les 4 nouveaux discriminants + variantes (trait d'union / sans trait d'union).
2. `test_class5_pymc2_composante_routed_to_distribution` — verbatim PyMC-2 cell[17] (3 cas) → `distribution_param`.
3. `test_class5_decinfer4_trajet_routed_to_distribution` — verbatim DecInfer-4 cell[18] → `distribution_param`.
4. `test_class5_does_not_break_sudoku13_control` — contrôle positif sur le notebook réel Sudoku-13 : wallclock ≥ 25 (skip si notebook absent).
5. `test_class5_pymc2_real_notebook_silenced` — notebook réel PyMC-2 : cell[17] wallclock = 0 (skip si absent).

2 tests existants adaptés (légitime : ils mélangeaient les mécanismes de propagation avec les nouveaux discriminants) :
- `test_domain_quantity_propagation_in_cell` — retire `trajet` du snippet pour isoler la propagation per-cell (le discriminant Classe 5 court-circuite la propagation, c'est le comportement souhaité).
- `test_silence_per_notebook_propagation_residu1` — retire `Trajets` du snippet pour isoler la propagation per-NOTEBOOK.

```
$ python -m pytest scripts/notebook_tools/tests/test_check_machine_dep_timing.py
============================== 46 passed in 24.30s ==============================
```

## Faux-positifs connus (exclus)

- `Probas/Infer-101.ipynb` (14 wallclock) et `Probas/Infer-2-Gaussian-Mixtures.ipynb` (45 wallclock) signalés par po-2024 — ils contiennent `trajet`, `duree`, `bruitTrafic` mais **pas** dans le scope `Probas/PyMC/` ni `Probas/DecisionTheory/DecInfer/`. Le scanner détecte désormais `trajet` dans ces notebooks aussi — **un follow-up** (issue à ouvrir si ce n'est pas déjà le cas) drainera les FP résiduels avec une politique explicite (probablement Classe 6 = "contexte temporel du notebook entier"). À débattre avant de toucher ces notebooks (anti-regression §D : les paramètres d'inférence sont le livrable pédagogique).

- Les 16 wallclock findings de l'inventaire initial dans Probas — déjà réduits à 11 après ce fix. Les 5 restants sont **de vrais wallclock** (à drainer avec une politique de réduction, séparée).

## Anti-regression

- **Aucun notebook touché** : seul le détecteur et ses tests sont modifiés.
- **Catalogue byte-identique** : `COURSE_CATALOG.generated.{json,md}` non régénéré sur cette branche (cf [catalog-pr-hygiene.md](../../.claude/rules/catalog-pr-hygiene.md)).
- **Contrôle positif Sudoku-13** : 28 wallclock strict intacts (TIMEOUT > 60 s, durées solveur 1.1 ms / 0.1 ms / 2.4 ms / 25.2 s, etc.) — le fix ne touche que les lignes contenant un discriminant bayesien.

## Liens

- Issue **#10178** (5 classes FP wallclock)
- Comment po-2024 **#5232772579** (proposition Classe 5, 2026-08-09)
- PR **#10176** (Classe 2 — propagation distribution_param, MERGED)
- PR **#10241** (Classe 4 — content-duration constraint, MERGED)
- Issue **#10158** (détecteur dédié, MERGED via PR **#10162**)
- Issue **#10169** (résidu propagation per-notebook, MERGED via PR **#10175**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
