### PR TITLE
feat(search,#10382): App-1 NQueens Tranche 2 via Google.OrTools CP-SAT (lib-vs-lib parity)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-1b-NQueens-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-1b-NQueens-CSharp.ipynb
@@ -5,37 +5,37 @@
    "id": "b6601688-9f2f-4570-bae4-202df6e512ee",
    "metadata": {
     "papermill": {
-     "duration": 0.009502,
-     "end_time": "2026-07-06T10:36:43.480831",
+     "duration": 0.004544,
+     "end_time": "2026-08-11T01:03:41.604578",
      "exception": false,
-     "start_time": "2026-07-06T10:36:43.471329",
+     "start_time": "2026-08-11T01:03:41.600034",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "# App-1b : Le probl\u00e8me des N-Reines \u2014 Jumeau C#\n",
+    "# App-1b : Le problème des N-Reines — Jumeau C#\n",
     "\n",
     "> **Twin C#** de [`App-1-NQueens`](App-1-NQueens.ipynb) (Python + OR-Tools + numpy + matplotlib).\n",
-    "> Suite du marathon **.NET \u21c4 Python** (#4956), volet **Search / Applications / CSP**.\n",
+    "> Suite du marathon **.NET ⇄ Python** (#4956), volet **Search / Applications / CSP**.\n",
     "> BCL .NET seule, **0 NuGet**, **from-scratch** (Prong B #3801).\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
-    "1. Mod\u00e9liser les N-Reines comme un **CSP** (variables, domaines, contraintes).\n",
-    "2. Comparer **trois familles** de r\u00e9solution : *backtracking* (avec heuristiques MRV + Forward Checking), *min-conflicts* (recherche locale), et **\u00e9num\u00e9ration compl\u00e8te** (toutes les solutions + comptage des solutions fondamentales par brisure de sym\u00e9trie).\n",
-    "3. Comprendre **algorithmiquement** le \u00ab miracle \u00bb de Min-Conflicts (passage \u00e0 l'\u00e9chelle jusqu'\u00e0 N = 1000+) et la **brisure de sym\u00e9trie** (8 transformations du carr\u00e9 \u2192 forme canonique).\n",
+    "1. Modéliser les N-Reines comme un **CSP** (variables, domaines, contraintes).\n",
+    "2. Comparer **trois familles** de résolution : *backtracking* (avec heuristiques MRV + Forward Checking), *min-conflicts* (recherche locale), et **énumération complète** (toutes les solutions + comptage des solutions fondamentales par brisure de symétrie).\n",
+    "3. Comprendre **algorithmiquement** le « miracle » de Min-Conflicts (passage à l'échelle jusqu'à N = 1000+) et la **brisure de symétrie** (8 transformations du carré → forme canonique).\n",
     "\n",
-    "## Compl\u00e9mentarit\u00e9 (#3801 Prong B)\n",
+    "## Complémentarité (#3801 Prong B)\n",
     "\n",
     "| Twin | Outil | Valeur |\n",
     "|------|-------|--------|\n",
     "| Python | **OR-Tools CP-SAT** (solveur industriel) + numpy + matplotlib | invoquer un solveur, simulation vectorielle |\n",
-    "| **Ce twin (.NET BCL seule)** | **from-scratch** (r\u00e9cursion, propagation de domaines, marche al\u00e9atoire, transforms D4) | **comprendre la m\u00e9canique** : backtracking, propagation, recherche locale, sym\u00e9tries |\n",
+    "| **Ce twin (.NET BCL seule)** | **from-scratch** (récursion, propagation de domaines, marche aléatoire, transforms D4) | **comprendre la mécanique** : backtracking, propagation, recherche locale, symétries |\n",
     "\n",
-    "Le twin Python **appelle** un solveur ; ce twin **d\u00e9roule** les algorithmes. Les deux se compl\u00e8tent : on voit ici *ce que fait* CP-SAT sous le capot (propagation, \u00e9num\u00e9ration, brisure de sym\u00e9trie).\n",
+    "Le twin Python **appelle** un solveur ; ce twin **déroule** les algorithmes. Les deux se complètent : on voit ici *ce que fait* CP-SAT sous le capot (propagation, énumération, brisure de symétrie).\n",
     "\n",
-    "**Dur\u00e9e estim\u00e9e : 35 min.** Pr\u00e9requis : [`Search-1`](../../Part1-Foundations/Search-1-StateSpace-Csharp.ipynb), [`CSP-1`](../../Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb) (CSP).\n"
+    "**Durée estimée : 35 min.** Prérequis : [`Search-1`](../../Part1-Foundations/Search-1-StateSpace-Csharp.ipynb), [`CSP-1`](../../Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb) (CSP).\n"
    ]
   },
   {
@@ -43,20 +43,20 @@
    "id": "2dbf824b-edff-40bc-b080-e8615eae95ab",
    "metadata": {
     "papermill": {
-     "duration": 0.0019,
-     "end_time": "2026-07-06T10:36:43.486004",
+     "duration": 0.004506,
+     "end_time": "2026-08-11T01:03:41.614097",
      "exception": false,
-     "start_time": "2026-07-06T10:36:43.484104",
+     "start_time": "2026-08-11T01:03:41.609591",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 1. Repr\u00e9sentation du probl\u00e8me\n",
+    "## 1. Représentation du problème\n",
     "\n",
-    "On repr\u00e9sente un plateau par `queens[col] = row` : **une reine par colonne** (la contrainte \u00ab une par colonne \u00bb est donc satisfaite par construction). Il reste \u00e0 v\u00e9rifier les conflits de **ligne** et de **diagonales**.\n",
+    "On représente un plateau par `queens[col] = row` : **une reine par colonne** (la contrainte « une par colonne » est donc satisfaite par construction). Il reste à vérifier les conflits de **ligne** et de **diagonales**.\n",
     "\n",
-    "Cellule d'installation : on d\u00e9finit le helper de formatage invariant (pour \u00e9viter la collision virgule-d\u00e9cimale FR) et les compteurs de n\u0153uds explor\u00e9s.\n"
+    "Cellule d'installation : on définit le helper de formatage invariant (pour éviter la collision virgule-décimale FR) et les compteurs de nœuds explorés.\n"
    ]
   },
   {
@@ -65,16 +65,16 @@
    "id": "3cef7737-deaf-4918-b98d-4e55471fde9e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:36:43.501357Z",
-     "iopub.status.busy": "2026-07-06T10:36:43.495950Z",
-     "iopub.status.idle": "2026-07-06T10:36:45.214986Z",
-     "shell.execute_reply": "2026-07-06T10:36:45.207436Z"
+     "iopub.execute_input": "2026-08-11T01:03:41.635502Z",
+     "iopub.status.busy": "2026-08-11T01:03:41.628038Z",
+     "iopub.status.idle": "2026-08-11T01:03:43.252722Z",
+     "shell.execute_reply": "2026-08-11T01:03:43.250051Z"
     },
     "papermill": {
-     "duration": 1.725147,
-     "end_time": "2026-07-06T10:36:45.215121",
+     "duration": 1.63438,
+     "end_time": "2026-08-11T01:03:43.252863",
      "exception": false,
-     "start_time": "2026-07-06T10:36:43.489974",
+     "start_time": "2026-08-11T01:03:41.618483",
      "status": "completed"
     },
     "tags": []
@@ -82,8 +82,123 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-38644.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '38644.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
       "text/plain": [
-       "Setup OK \u2014 repr\u00e9sentation queens[col]=row, helper IsSafe d\u00e9fini."
+       "Setup OK — représentation queens[col]=row, helper IsSafe défini."
       ]
      },
      "metadata": {},
@@ -97,23 +212,23 @@
     "using System.Globalization;\n",
     "using System.Linq;\n",
     "\n",
-    "// Formatage invariant (r\u00e8gle marathon : la culture FR ne persiste pas entre cellules .NET Interactive)\n",
+    "// Formatage invariant (règle marathon : la culture FR ne persiste pas entre cellules .NET Interactive)\n",
     "static string FI(double x, string fmt = \"F3\") => x.ToString(fmt, CultureInfo.InvariantCulture);\n",
     "static string FI(long x) => x.ToString(\"N0\", CultureInfo.InvariantCulture);\n",
     "static void Show(string s) => display(s);\n",
     "\n",
-    "// conflit entre (col,row) et les reines d\u00e9j\u00e0 plac\u00e9es dans les colonnes marqu\u00e9es `placed`\n",
+    "// conflit entre (col,row) et les reines déjà placées dans les colonnes marquées `placed`\n",
     "static bool IsSafe(int[] queens, int col, int row, bool[] placed) {\n",
     "    for (int c = 0; c < queens.Length; c++) {\n",
     "        if (c == col || !placed[c]) continue;\n",
     "        int r = queens[c];\n",
-    "        if (r == row) return false;                       // m\u00eame ligne\n",
-    "        if (Math.Abs(r - row) == Math.Abs(col - c)) return false;  // m\u00eame diagonale\n",
+    "        if (r == row) return false;                       // même ligne\n",
+    "        if (Math.Abs(r - row) == Math.Abs(col - c)) return false;  // même diagonale\n",
     "    }\n",
     "    return true;\n",
     "}\n",
     "\n",
-    "Show(\"Setup OK \u2014 repr\u00e9sentation queens[col]=row, helper IsSafe d\u00e9fini.\");\n"
+    "Show(\"Setup OK — représentation queens[col]=row, helper IsSafe défini.\");\n"
    ]
   },
   {
@@ -121,10 +236,10 @@
    "id": "b3206d27-1ad7-4b13-8572-7903925e53dc",
    "metadata": {
     "papermill": {
-     "duration": 0.003455,
-     "end_time": "2026-07-06T10:36:45.222195",
+     "duration": 0.004059,
+     "end_time": "2026-08-11T01:03:43.261339",
      "exception": false,
-     "start_time": "2026-07-06T10:36:45.218740",
+     "start_time": "2026-08-11T01:03:43.257280",
      "status": "completed"
     },
     "tags": []
@@ -132,9 +247,9 @@
    "source": [
     "## 2. Approche 1a : Backtracking simple\n",
     "\n",
-    "On remplit les colonnes de gauche \u00e0 droite. Pour chaque colonne, on essaie les lignes de haut en bas ; la premi\u00e8re ligne **s\u00fbre** est accept\u00e9e et on descend. Si aucune ligne ne convient, on **remonte** (backtrack).\n",
+    "On remplit les colonnes de gauche à droite. Pour chaque colonne, on essaie les lignes de haut en bas ; la première ligne **sûre** est acceptée et on descend. Si aucune ligne ne convient, on **remonte** (backtrack).\n",
     "\n",
-    "C'est le DFS sur l'arbre des affectations partielles. On compte les **n\u0153uds explor\u00e9s** pour comparer les variantes."
+    "C'est le DFS sur l'arbre des affectations partielles. On compte les **nœuds explorés** pour comparer les variantes."
    ]
   },
   {
@@ -143,16 +258,16 @@
    "id": "fb89e3b0-29fb-4297-9306-2b9fdf69f80f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:36:45.231670Z",
-     "iopub.status.busy": "2026-07-06T10:36:45.231181Z",
-     "iopub.status.idle": "2026-07-06T10:36:45.454747Z",
-     "shell.execute_reply": "2026-07-06T10:36:45.454581Z"
+     "iopub.execute_input": "2026-08-11T01:03:43.271075Z",
+     "iopub.status.busy": "2026-08-11T01:03:43.270821Z",
+     "iopub.status.idle": "2026-08-11T01:03:43.442461Z",
+     "shell.execute_reply": "2026-08-11T01:03:43.442239Z"
     },
     "papermill": {
-     "duration": 0.229418,
-     "end_time": "2026-07-06T10:36:45.454828",
+     "duration": 0.177163,
+     "end_time": "2026-08-11T01:03:43.442553",
      "exception": false,
-     "start_time": "2026-07-06T10:36:45.225410",
+     "start_time": "2026-08-11T01:03:43.265390",
      "status": "completed"
     },
     "tags": []
@@ -161,7 +276,7 @@
     {
      "data": {
       "text/plain": [
-       "Backtracking simple, N = 8 -> 113 n\u0153uds explor\u00e9s."
+       "Backtracking simple, N = 8 -> 113 nœuds explorés."
       ]
      },
      "metadata": {},
@@ -188,7 +303,7 @@
     "long _btNodes;\n",
     "\n",
     "bool BacktrackSimple(int[] queens, bool[] placed, int col, int n) {\n",
-    "    if (col == n) return true;           // toutes les colonnes plac\u00e9es -> solution\n",
+    "    if (col == n) return true;           // toutes les colonnes placées -> solution\n",
     "    _btNodes++;\n",
     "    for (int row = 0; row < n; row++) {\n",
     "        if (IsSafe(queens, col, row, placed)) {\n",
@@ -218,7 +333,7 @@
     "int n = 8;\n",
     "var q = new int[n]; var p = new bool[n]; _btNodes = 0;\n",
     "BacktrackSimple(q, p, 0, n);\n",
-    "Show(\"Backtracking simple, N = \" + n + \" -> \" + FI(_btNodes) + \" n\u0153uds explor\u00e9s.\");\n",
+    "Show(\"Backtracking simple, N = \" + n + \" -> \" + FI(_btNodes) + \" nœuds explorés.\");\n",
     "Show(BoardString(q));\n"
    ]
   },
@@ -227,10 +342,10 @@
    "id": "aaf2df63-f1f5-453f-88de-5508e50ba2e0",
    "metadata": {
     "papermill": {
-     "duration": 0.003036,
-     "end_time": "2026-07-06T10:36:45.461182",
+     "duration": 0.004678,
+     "end_time": "2026-08-11T01:03:43.451701",
      "exception": false,
-     "start_time": "2026-07-06T10:36:45.458146",
+     "start_time": "2026-08-11T01:03:43.447023",
      "status": "completed"
     },
     "tags": []
@@ -238,9 +353,9 @@
    "source": [
     "### 2.1 Backtracking avec heuristique MRV (Minimum Remaining Values)\n",
     "\n",
-    "Au lieu de fixer l'ordre des colonnes, on choisit \u00e0 chaque pas la colonne **non assign\u00e9e** qui a le **moins** de lignes s\u00fbres possibles. Intuition : \u00e9chouer vite l\u00e0 o\u00f9 on est le plus contraint r\u00e9duit la taille de l'arbre.\n",
+    "Au lieu de fixer l'ordre des colonnes, on choisit à chaque pas la colonne **non assignée** qui a le **moins** de lignes sûres possibles. Intuition : échouer vite là où on est le plus contraint réduit la taille de l'arbre.\n",
     "\n",
-    "> Ici, comme chaque colonne re\u00e7oit exactement une reine, MRV agit sur l'**ordre des variables** (quelle colonne remplir ensuite), et non sur les domaines."
+    "> Ici, comme chaque colonne reçoit exactement une reine, MRV agit sur l'**ordre des variables** (quelle colonne remplir ensuite), et non sur les domaines."
    ]
   },
   {
@@ -249,16 +364,16 @@
    "id": "8d16dcb0-70fc-480c-9e5a-c75e816e9291",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:36:45.468909Z",
-     "iopub.status.busy": "2026-07-06T10:36:45.468664Z",
-     "iopub.status.idle": "2026-07-06T10:36:45.572548Z",
-     "shell.execute_reply": "2026-07-06T10:36:45.572369Z"
+     "iopub.execute_input": "2026-08-11T01:03:43.461527Z",
+     "iopub.status.busy": "2026-08-11T01:03:43.461294Z",
+     "iopub.status.idle": "2026-08-11T01:03:43.547072Z",
+     "shell.execute_reply": "2026-08-11T01:03:43.546813Z"
     },
     "papermill": {
-     "duration": 0.108284,
-     "end_time": "2026-07-06T10:36:45.572626",
+     "duration": 0.091224,
+     "end_time": "2026-08-11T01:03:43.547166",
      "exception": false,
-     "start_time": "2026-07-06T10:36:45.464342",
+     "start_time": "2026-08-11T01:03:43.455942",
      "status": "completed"
     },
     "tags": []
@@ -267,7 +382,7 @@
     {
      "data": {
       "text/plain": [
-       "Backtracking MRV, N = 8 -> 52 n\u0153uds explor\u00e9s (vs simple ci-dessus)."
+       "Backtracking MRV, N = 8 -> 52 nœuds explorés (vs simple ci-dessus)."
       ]
      },
      "metadata": {},
@@ -278,7 +393,7 @@
     "long _mrvNodes;\n",
     "\n",
     "bool BacktrackMRV(int[] queens, bool[] placed, int n) {\n",
-    "    // 1. choisir la colonne non assign\u00e9e avec le moins de lignes s\u00fbres (MRV)\n",
+    "    // 1. choisir la colonne non assignée avec le moins de lignes sûres (MRV)\n",
     "    int bestCol = -1, bestCount = int.MaxValue;\n",
     "    List<int> bestRows = new List<int>();\n",
     "    for (int col = 0; col < n; col++) {\n",
@@ -287,9 +402,9 @@
     "        for (int row = 0; row < n; row++)\n",
     "            if (IsSafe(queens, col, row, placed)) rows.Add(row);\n",
     "        if (rows.Count < bestCount) { bestCount = rows.Count; bestCol = col; bestRows = rows; }\n",
-    "        if (bestCount == 0) return false;            // impasse d\u00e9tect\u00e9e t\u00f4t\n",
+    "        if (bestCount == 0) return false;            // impasse détectée tôt\n",
     "    }\n",
-    "    if (bestCol == -1) return true;                  // tout est assign\u00e9 -> solution\n",
+    "    if (bestCol == -1) return true;                  // tout est assigné -> solution\n",
     "    _mrvNodes++;\n",
     "    placed[bestCol] = true;\n",
     "    foreach (var row in bestRows) {\n",
@@ -303,7 +418,7 @@
     "int n = 8;\n",
     "var q = new int[n]; var p = new bool[n]; _mrvNodes = 0;\n",
     "BacktrackMRV(q, p, n);\n",
-    "Show(\"Backtracking MRV, N = \" + n + \" -> \" + FI(_mrvNodes) + \" n\u0153uds explor\u00e9s (vs simple ci-dessus).\");\n"
+    "Show(\"Backtracking MRV, N = \" + n + \" -> \" + FI(_mrvNodes) + \" nœuds explorés (vs simple ci-dessus).\");\n"
    ]
   },
   {
@@ -311,10 +426,10 @@
    "id": "5ed56bf7-b226-4402-b72c-59290601c103",
    "metadata": {
     "papermill": {
-     "duration": 0.003619,
-     "end_time": "2026-07-06T10:36:45.579505",
+     "duration": 0.004434,
+     "end_time": "2026-08-11T01:03:43.556589",
      "exception": false,
-     "start_time": "2026-07-06T10:36:45.575886",
+     "start_time": "2026-08-11T01:03:43.552155",
      "status": "completed"
     },
     "tags": []
@@ -322,7 +437,7 @@
    "source": [
     "### 2.2 Backtracking avec Forward Checking (FC)\n",
     "\n",
-    "\u00c0 chaque placement, on **propage** : on retire des domaines des colonnes encore vides toutes les lignes devenues conflictuelles. Si un domaine devient vide, on d\u00e9clenche le backtrack **imm\u00e9diatement** (avant m\u00eame de d\u00e9velopper). On restaure les domaines au backtrack (pile des retraits).\n",
+    "À chaque placement, on **propage** : on retire des domaines des colonnes encore vides toutes les lignes devenues conflictuelles. Si un domaine devient vide, on déclenche le backtrack **immédiatement** (avant même de développer). On restaure les domaines au backtrack (pile des retraits).\n",
     "\n",
     "C'est exactement la propagation de contraintes qu'effectue CP-SAT sous le capot."
    ]
@@ -333,16 +448,16 @@
    "id": "39a6ba6c-99e3-41e5-9bb6-b1da00ca7d5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:36:45.587399Z",
-     "iopub.status.busy": "2026-07-06T10:36:45.587097Z",
-     "iopub.status.idle": "2026-07-06T10:36:45.823163Z",
-     "shell.execute_reply": "2026-07-06T10:36:45.822990Z"
+     "iopub.execute_input": "2026-08-11T01:03:43.567186Z",
+     "iopub.status.busy": "2026-08-11T01:03:43.566919Z",
+     "iopub.status.idle": "2026-08-11T01:03:43.775645Z",
+     "shell.execute_reply": "2026-08-11T01:03:43.775472Z"
     },
     "papermill": {
-     "duration": 0.240676,
-     "end_time": "2026-07-06T10:36:45.823244",
+     "duration": 0.214467,
+     "end_time": "2026-08-11T01:03:43.775727",
      "exception": false,
-     "start_time": "2026-07-06T10:36:45.582568",
+     "start_time": "2026-08-11T01:03:43.561260",
      "status": "completed"
     },
     "tags": []
@@ -351,7 +466,7 @@
     {
      "data": {
       "text/plain": [
-       "Backtracking Forward-Checking, N = 8 -> 51 n\u0153uds explor\u00e9s."
+       "Backtracking Forward-Checking, N = 8 -> 51 nœuds explorés."
       ]
      },
      "metadata": {},
@@ -381,14 +496,14 @@
     "bool BacktrackFC(int[] queens, HashSet<int>[] domains, int placedCount, int n) {\n",
     "    if (placedCount == n) return true;\n",
     "    _fcNodes++;\n",
-    "    // choisir la colonne non assign\u00e9e au plus petit domaine (MRV sur domaines filtr\u00e9s)\n",
+    "    // choisir la colonne non assignée au plus petit domaine (MRV sur domaines filtrés)\n",
     "    int bestCol = -1, bestSize = int.MaxValue;\n",
     "    for (int col = 0; col < n; col++) {\n",
     "        if (queens[col] >= 0) continue;\n",
     "        if (domains[col].Count < bestSize) { bestSize = domains[col].Count; bestCol = col; }\n",
     "    }\n",
     "    if (bestSize == 0) return false;                 // domaine vide -> impasse\n",
-    "    // snapshot des lignes candidats (on it\u00e8re sur une copie car on va modifier domains)\n",
+    "    // snapshot des lignes candidats (on itère sur une copie car on va modifier domains)\n",
     "    var candidates = domains[bestCol].ToList();\n",
     "    foreach (var row in candidates) {\n",
     "        // tenter (bestCol, row) : propager\n",
@@ -414,7 +529,7 @@
     "var dom = Enumerable.Range(0, n).Select(_ => new HashSet<int>(Enumerable.Range(0, n))).ToArray();\n",
     "_fcNodes = 0;\n",
     "BacktrackFC(q, dom, 0, n);\n",
-    "Show(\"Backtracking Forward-Checking, N = \" + n + \" -> \" + FI(_fcNodes) + \" n\u0153uds explor\u00e9s.\");\n",
+    "Show(\"Backtracking Forward-Checking, N = \" + n + \" -> \" + FI(_fcNodes) + \" nœuds explorés.\");\n",
     "Show(BoardString(q));\n"
    ]
   },
@@ -423,10 +538,10 @@
    "id": "49229e2b-745b-43f1-a06a-5c00e1dc42f0",
    "metadata": {
     "papermill": {
-     "duration": 0.003396,
-     "end_time": "2026-07-06T10:36:45.830071",
+     "duration": 0.004066,
+     "end_time": "2026-08-11T01:03:43.784376",
      "exception": false,
-     "start_time": "2026-07-06T10:36:45.826675",
+     "start_time": "2026-08-11T01:03:43.780310",
      "status": "completed"
     },
     "tags": []
@@ -434,7 +549,7 @@
    "source": [
     "### 2.3 Benchmark des trois variantes\n",
     "\n",
-    "On compare le **nombre de n\u0153uds explor\u00e9s** et le **temps** pour trouver une premi\u00e8re solution, de N = 8 \u00e0 N = 16. Attendu : FC < MRV < simple (la propagation coupe l'arbre plus t\u00f4t)."
+    "On compare le **nombre de nœuds explorés** et le **temps** pour trouver une première solution, de N = 8 à N = 16. Attendu : FC < MRV < simple (la propagation coupe l'arbre plus tôt)."
    ]
   },
   {
@@ -443,16 +558,16 @@
    "id": "df22ce87-9ace-4fa7-8c4f-c46a11234c80",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:36:45.839570Z",
-     "iopub.status.busy": "2026-07-06T10:36:45.839083Z",
-     "iopub.status.idle": "2026-07-06T10:36:46.026778Z",
-     "shell.execute_reply": "2026-07-06T10:36:46.026629Z"
+     "iopub.execute_input": "2026-08-11T01:03:43.794240Z",
+     "iopub.status.busy": "2026-08-11T01:03:43.793986Z",
+     "iopub.status.idle": "2026-08-11T01:03:43.919590Z",
+     "shell.execute_reply": "2026-08-11T01:03:43.919378Z"
     },
     "papermill": {
-     "duration": 0.192962,
-     "end_time": "2026-07-06T10:36:46.026854",
+     "duration": 0.131054,
+     "end_time": "2026-08-11T01:03:43.919690",
      "exception": false,
-     "start_time": "2026-07-06T10:36:45.833892",
+     "start_time": "2026-08-11T01:03:43.788636",
      "status": "completed"
     },
     "tags": []
@@ -479,7 +594,7 @@
     {
      "data": {
       "text/plain": [
-       "   8 |        113 |         52 |         51 |        0.029 |      0.089 |     0.109"
+       "   8 |        113 |         52 |         51 |        0.053 |      0.155 |     0.255"
       ]
      },
      "metadata": {},
@@ -488,7 +603,7 @@
     {
      "data": {
       "text/plain": [
-       "  10 |        102 |         26 |         26 |        0.032 |      0.067 |     0.051"
+       "  10 |        102 |         26 |         26 |        0.056 |      0.130 |     0.130"
       ]
      },
      "metadata": {},
@@ -497,7 +612,7 @@
     {
      "data": {
       "text/plain": [
-       "  12 |        261 |        107 |         84 |        0.109 |      0.347 |     0.165"
+       "  12 |        261 |        107 |         84 |        0.178 |      0.534 |     0.323"
       ]
      },
      "metadata": {},
@@ -506,7 +621,7 @@
     {
      "data": {
       "text/plain": [
-       "  14 |      1,899 |         91 |        105 |        0.885 |      0.466 |     0.235"
+       "  14 |      1,899 |         91 |        105 |        1.129 |      0.685 |     0.429"
       ]
      },
      "metadata": {},
@@ -515,7 +630,7 @@
     {
      "data": {
       "text/plain": [
-       "  16 |     10,052 |         37 |         37 |        6.113 |      0.246 |     0.097"
+       "  16 |     10,052 |         37 |         37 |        7.333 |      0.337 |     0.153"
       ]
      },
      "metadata": {},
@@ -524,7 +639,7 @@
     {
      "data": {
       "text/plain": [
-       "Interpr\u00e9tation : simple explose (croissance ~factorielle), MRV et FC la divisent par 1-2 ordres de grandeur."
+       "Interprétation : simple explose (croissance ~factorielle), MRV et FC la divisent par 1-2 ordres de grandeur."
       ]
      },
      "metadata": {},
@@ -542,7 +657,7 @@
     {
      "data": {
       "text/plain": [
-       "l'ordonnancement de MRV coupent l'arbre diff\u00e9remment). Le gain dominant vient de l'heuristique vs simple."
+       "l'ordonnancement de MRV coupent l'arbre différemment). Le gain dominant vient de l'heuristique vs simple."
       ]
      },
      "metadata": {},
@@ -577,9 +692,9 @@
     "                + FI(r.fc).PadLeft(10) + \" | \" + FI(r.tSimple, \"F3\").PadLeft(12) + \" | \" + FI(r.tMrv, \"F3\").PadLeft(10) + \" | \" + FI(r.tFc, \"F3\").PadLeft(9);\n",
     "    Show(line);\n",
     "}\n",
-    "Show(\"Interpr\u00e9tation : simple explose (croissance ~factorielle), MRV et FC la divisent par 1-2 ordres de grandeur.\");\n",
+    "Show(\"Interprétation : simple explose (croissance ~factorielle), MRV et FC la divisent par 1-2 ordres de grandeur.\");\n",
     "Show(\"MRV et FC sont comparables : selon l'instance, l'un ou l'autre gagne (la propagation de FC et\");\n",
-    "Show(\"l'ordonnancement de MRV coupent l'arbre diff\u00e9remment). Le gain dominant vient de l'heuristique vs simple.\");\n"
+    "Show(\"l'ordonnancement de MRV coupent l'arbre différemment). Le gain dominant vient de l'heuristique vs simple.\");\n"
    ]
   },
   {
@@ -587,10 +702,10 @@
    "id": "bce02a5c-0337-45ab-a84d-4582816ae6e8",
    "metadata": {
     "papermill": {
-     "duration": 0.003181,
-     "end_time": "2026-07-06T10:36:46.034052",
+     "duration": 0.005462,
+     "end_time": "2026-08-11T01:03:43.931032",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.030871",
+     "start_time": "2026-08-11T01:03:43.925570",
      "status": "completed"
     },
     "tags": []
@@ -598,9 +713,9 @@
    "source": [
     "## 3. Approche 2 : Min-Conflicts (recherche locale)\n",
     "\n",
-    "id\u00e9e radicalement diff\u00e9rente : on part d'une affectation **al\u00e9atoire** (une reine par colonne, ligne al\u00e9atoire), puis on **r\u00e9pare**. \u00c0 chaque it\u00e9ration, on choisit une colonne en conflit et on d\u00e9place sa reine vers la ligne qui **minimise** le nombre de conflits. Pas de retour arri\u00e8re : c'est une **marche** dans l'espace des configurations.\n",
+    "idée radicalement différente : on part d'une affectation **aléatoire** (une reine par colonne, ligne aléatoire), puis on **répare**. À chaque itération, on choisit une colonne en conflit et on déplace sa reine vers la ligne qui **minimise** le nombre de conflits. Pas de retour arrière : c'est une **marche** dans l'espace des configurations.\n",
     "\n",
-    "C'est l'anc\u00eatre des m\u00e9taheuristiques (proche du hill-climbing stochastique, cf [`Search-11`](../../Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb))."
+    "C'est l'ancêtre des métaheuristiques (proche du hill-climbing stochastique, cf [`Search-11`](../../Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb))."
    ]
   },
   {
@@ -609,16 +724,16 @@
    "id": "ad3526c7-24b4-44bd-b71a-932a8d9b6872",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:36:46.041764Z",
-     "iopub.status.busy": "2026-07-06T10:36:46.041548Z",
-     "iopub.status.idle": "2026-07-06T10:36:46.118887Z",
-     "shell.execute_reply": "2026-07-06T10:36:46.118586Z"
+     "iopub.execute_input": "2026-08-11T01:03:43.945139Z",
+     "iopub.status.busy": "2026-08-11T01:03:43.944824Z",
+     "iopub.status.idle": "2026-08-11T01:03:44.063592Z",
+     "shell.execute_reply": "2026-08-11T01:03:44.063396Z"
     },
     "papermill": {
-     "duration": 0.081839,
-     "end_time": "2026-07-06T10:36:46.119033",
+     "duration": 0.126311,
+     "end_time": "2026-08-11T01:03:44.063686",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.037194",
+     "start_time": "2026-08-11T01:03:43.937375",
      "status": "completed"
     },
     "tags": []
@@ -627,7 +742,7 @@
     {
      "data": {
       "text/plain": [
-       "Min-Conflicts, N = 8 -> solution en 17 it\u00e9rations (ok=True)."
+       "Min-Conflicts, N = 8 -> solution en 17 itérations (ok=True)."
       ]
      },
      "metadata": {},
@@ -651,9 +766,9 @@
     }
    ],
    "source": [
-    "// Conflits maintenus incr\u00e9mentalement via compteurs par ligne / diagonale (O(1) par requ\u00eate)\n",
+    "// Conflits maintenus incrémentalement via compteurs par ligne / diagonale (O(1) par requête)\n",
     "//  - rowConf[r]      = nombre de reines dans la ligne r\n",
-    "//  - diag1Conf[r-c+n]= nombre de reines sur la diagonale NO-SE (diff\u00e9rence r-c constante)\n",
+    "//  - diag1Conf[r-c+n]= nombre de reines sur la diagonale NO-SE (différence r-c constante)\n",
     "//  - diag2Conf[r+c]  = nombre de reines sur la diagonale SO-NE (somme r+c constante)\n",
     "// Conflits subis par la reine (col,row) = (rowConf[row]-1) + (diag1-1) + (diag2-1)\n",
     "(bool ok, int iters, int[] queens) MinConflicts(int n, int maxIters, int seed) {\n",
@@ -679,7 +794,7 @@
     "        int col = conflicted[rnd.Next(conflicted.Count)];\n",
     "        int curRow = queens[col];\n",
     "        // collecter TOUTES les lignes minimisant les conflits, puis tirage uniforme\n",
-    "        // (tie-break uniforme = \u00e9vite les cycles ; la reine d\u00e9plac\u00e9e EXCLUE de son propre compte)\n",
+    "        // (tie-break uniforme = évite les cycles ; la reine déplacée EXCLUE de son propre compte)\n",
     "        int bestConf = int.MaxValue;\n",
     "        var bestRows = new List<int>();\n",
     "        for (int row = 0; row < n; row++) {\n",
@@ -702,7 +817,7 @@
     "\n",
     "int n = 8;\n",
     "var (ok, iters, sol) = MinConflicts(n, 10000, 42);\n",
-    "Show(\"Min-Conflicts, N = \" + n + \" -> solution en \" + iters + \" it\u00e9rations (ok=\" + ok + \").\");\n",
+    "Show(\"Min-Conflicts, N = \" + n + \" -> solution en \" + iters + \" itérations (ok=\" + ok + \").\");\n",
     "if (ok) Show(BoardString(sol));\n"
    ]
   },
@@ -711,18 +826,18 @@
    "id": "decbd520-4352-4697-9311-76d4cc1cc440",
    "metadata": {
     "papermill": {
-     "duration": 0.00414,
-     "end_time": "2026-07-06T10:36:46.127768",
+     "duration": 0.005748,
+     "end_time": "2026-08-11T01:03:44.075601",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.123628",
+     "start_time": "2026-08-11T01:03:44.069853",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### 3.1 Le \u00ab miracle \u00bb de Min-Conflicts : passage \u00e0 l'\u00e9chelle\n",
+    "### 3.1 Le « miracle » de Min-Conflicts : passage à l'échelle\n",
     "\n",
-    "Le backtracking syst\u00e9matique explose (factoriel). Min-Conflicts, lui, r\u00e9sout des instances **\u00e9normes** en quelques centaines d'it\u00e9rations. C'est le r\u00e9sultat contre-intuitif de la recherche locale : sur les N-Reines (probl\u00e8me peu contraint \u00e0 grande \u00e9chelle), elle **surclasse** la recherche compl\u00e8te."
+    "Le backtracking systématique explose (factoriel). Min-Conflicts, lui, résout des instances **énormes** en quelques centaines d'itérations. C'est le résultat contre-intuitif de la recherche locale : sur les N-Reines (problème peu contraint à grande échelle), elle **surclasse** la recherche complète."
    ]
   },
   {
@@ -731,16 +846,16 @@
    "id": "d2389424-255b-48c4-8239-ab946f9da3d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:36:46.138026Z",
-     "iopub.status.busy": "2026-07-06T10:36:46.137686Z",
-     "iopub.status.idle": "2026-07-06T10:36:46.238732Z",
-     "shell.execute_reply": "2026-07-06T10:36:46.238594Z"
+     "iopub.execute_input": "2026-08-11T01:03:44.088454Z",
+     "iopub.status.busy": "2026-08-11T01:03:44.088123Z",
+     "iopub.status.idle": "2026-08-11T01:03:44.197323Z",
+     "shell.execute_reply": "2026-08-11T01:03:44.196872Z"
     },
     "papermill": {
-     "duration": 0.10692,
-     "end_time": "2026-07-06T10:36:46.238800",
+     "duration": 0.116262,
+     "end_time": "2026-08-11T01:03:44.197619",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.131880",
+     "start_time": "2026-08-11T01:03:44.081357",
      "status": "completed"
     },
     "tags": []
@@ -749,7 +864,7 @@
     {
      "data": {
       "text/plain": [
-       "     N | r\u00e9solu |  it\u00e9rations |  temps(ms)"
+       "     N | résolu |  itérations |  temps(ms)"
       ]
      },
      "metadata": {},
@@ -785,7 +900,7 @@
     {
      "data": {
       "text/plain": [
-       "   100 |    oui |         166 |        0.2"
+       "   100 |    oui |         166 |        0.3"
       ]
      },
      "metadata": {},
@@ -794,7 +909,7 @@
     {
      "data": {
       "text/plain": [
-       "   200 |    oui |         212 |        0.4"
+       "   200 |    oui |         212 |        0.7"
       ]
      },
      "metadata": {},
@@ -803,7 +918,7 @@
     {
      "data": {
       "text/plain": [
-       "   500 |    oui |         388 |        3.1"
+       "   500 |    oui |         388 |        2.8"
       ]
      },
      "metadata": {},
@@ -812,7 +927,7 @@
     {
      "data": {
       "text/plain": [
-       "  1000 |    oui |         735 |        6.3"
+       "  1000 |    oui |         735 |        9.1"
       ]
      },
      "metadata": {},
@@ -821,7 +936,7 @@
     {
      "data": {
       "text/plain": [
-       "Interpr\u00e9tation : N = 1000 r\u00e9solu en quelques centaines d'it\u00e9rations \u2014 inaccessible au backtracking."
+       "Interprétation : N = 1000 résolu en quelques centaines d'itérations — inaccessible au backtracking."
       ]
      },
      "metadata": {},
@@ -830,7 +945,7 @@
    ],
    "source": [
     "var sizes = new[] { 8, 50, 100, 200, 500, 1000 };\n",
-    "Show(\"N\".PadLeft(6) + \" | \" + \"r\u00e9solu\".PadLeft(6) + \" | \" + \"it\u00e9rations\".PadLeft(11) + \" | \" + \"temps(ms)\".PadLeft(10));\n",
+    "Show(\"N\".PadLeft(6) + \" | \" + \"résolu\".PadLeft(6) + \" | \" + \"itérations\".PadLeft(11) + \" | \" + \"temps(ms)\".PadLeft(10));\n",
     "Show(new string('-', 42));\n",
     "foreach (var n in sizes) {\n",
     "    var sw = Stopwatch.StartNew();\n",
@@ -838,7 +953,7 @@
     "    sw.Stop();\n",
     "    Show(n.ToString().PadLeft(6) + \" | \" + (ok ? \"oui\" : \"non\").PadLeft(6) + \" | \" + (ok ? it.ToString() : \">max\").PadLeft(11) + \" | \" + FI(sw.Elapsed.TotalMilliseconds, \"F1\").PadLeft(10));\n",
     "}\n",
-    "Show(\"Interpr\u00e9tation : N = 1000 r\u00e9solu en quelques centaines d'it\u00e9rations \u2014 inaccessible au backtracking.\");\n"
+    "Show(\"Interprétation : N = 1000 résolu en quelques centaines d'itérations — inaccessible au backtracking.\");\n"
    ]
   },
   {
@@ -846,18 +961,18 @@
    "id": "04ef871e-f6a5-41d3-818f-3405ab54f858",
    "metadata": {
     "papermill": {
-     "duration": 0.003872,
-     "end_time": "2026-07-06T10:36:46.246845",
+     "duration": 0.007763,
+     "end_time": "2026-08-11T01:03:44.213978",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.242973",
+     "start_time": "2026-08-11T01:03:44.206215",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 4. Approche 3 : \u00c9num\u00e9ration de toutes les solutions\n",
+    "## 4. Approche 3 : Énumération de toutes les solutions\n",
     "\n",
-    "Min-Conflicts donne **une** solution. Pour **compter** les solutions (N = 8 \u2192 92), il faut un parcours complet : on retire le `return true` du backtracking et on incr\u00e9mente un compteur \u00e0 chaque feuille."
+    "Min-Conflicts donne **une** solution. Pour **compter** les solutions (N = 8 → 92), il faut un parcours complet : on retire le `return true` du backtracking et on incrémente un compteur à chaque feuille."
    ]
   },
   {
@@ -866,16 +981,16 @@
    "id": "7e40765f-2668-4253-b72d-0060e1260ccc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:36:46.256717Z",
-     "iopub.status.busy": "2026-07-06T10:36:46.256489Z",
-     "iopub.status.idle": "2026-07-06T10:36:46.323757Z",
-     "shell.execute_reply": "2026-07-06T10:36:46.323472Z"
+     "iopub.execute_input": "2026-08-11T01:03:44.231864Z",
+     "iopub.status.busy": "2026-08-11T01:03:44.231578Z",
+     "iopub.status.idle": "2026-08-11T01:03:44.303177Z",
+     "shell.execute_reply": "2026-08-11T01:03:44.302959Z"
     },
     "papermill": {
-     "duration": 0.072756,
-     "end_time": "2026-07-06T10:36:46.323862",
+     "duration": 0.079993,
+     "end_time": "2026-08-11T01:03:44.303279",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.251106",
+     "start_time": "2026-08-11T01:03:44.223286",
      "status": "completed"
     },
     "tags": []
@@ -884,7 +999,7 @@
     {
      "data": {
       "text/plain": [
-       "N = 8 -> 92 solutions distinctes (r\u00e9sultat attendu : 92)."
+       "N = 8 -> 92 solutions distinctes (résultat attendu : 92)."
       ]
      },
      "metadata": {},
@@ -893,7 +1008,7 @@
     {
      "data": {
       "text/plain": [
-       "R\u00e9f\u00e9rence OEIS A000170 : N=1..8 = 1, 0, 0, 2, 10, 4, 40, 92."
+       "Référence OEIS A000170 : N=1..8 = 1, 0, 0, 2, 10, 4, 40, 92."
       ]
      },
      "metadata": {},
@@ -916,9 +1031,9 @@
     "int n = 8;\n",
     "var q = new int[n]; var p = new bool[n]; _solCount = 0;\n",
     "EnumerateAll(q, p, 0, n);\n",
-    "Show(\"N = \" + n + \" -> \" + _solCount + \" solutions distinctes (r\u00e9sultat attendu : 92).\");\n",
-    "// petites valeurs de r\u00e9f\u00e9rence\n",
-    "Show(\"R\u00e9f\u00e9rence OEIS A000170 : N=1..8 = 1, 0, 0, 2, 10, 4, 40, 92.\");\n"
+    "Show(\"N = \" + n + \" -> \" + _solCount + \" solutions distinctes (résultat attendu : 92).\");\n",
+    "// petites valeurs de référence\n",
+    "Show(\"Référence OEIS A000170 : N=1..8 = 1, 0, 0, 2, 10, 4, 40, 92.\");\n"
    ]
   },
   {
@@ -926,20 +1041,20 @@
    "id": "afcd8a39-2d5e-4c72-98bc-c81490e201c9",
    "metadata": {
     "papermill": {
-     "duration": 0.004138,
-     "end_time": "2026-07-06T10:36:46.332309",
+     "duration": 0.006609,
+     "end_time": "2026-08-11T01:03:44.316764",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.328171",
+     "start_time": "2026-08-11T01:03:44.310155",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### 4.1 Brisure de sym\u00e9trie : solutions fondamentales\n",
+    "### 4.1 Brisure de symétrie : solutions fondamentales\n",
     "\n",
-    "Beaucoup des 92 solutions sont **\u00e9quivalentes** par une sym\u00e9trie du carr\u00e9 (le groupe di\u00e9dral D4 : 4 rotations \u00d7 2 r\u00e9flexions = 8 transformations). Deux solutions \u00ab fondamentalement identiques \u00bb donnent la m\u00eame **forme canonique** = la plus petite (lexicalement) parmi leurs 8 transform\u00e9es.\n",
+    "Beaucoup des 92 solutions sont **équivalentes** par une symétrie du carré (le groupe diédral D4 : 4 rotations × 2 réflexions = 8 transformations). Deux solutions « fondamentalement identiques » donnent la même **forme canonique** = la plus petite (lexicalement) parmi leurs 8 transformées.\n",
     "\n",
-    "On obtient ainsi les **12 solutions fondamentales** de N = 8. C'est exactement la brisure de sym\u00e9trie qu'OR-Tools CP-SAT peut ajouter d\u00e9clarativement (contraintes `AddAllDifferent` + lex-ordering) \u2014 ici on la d\u00e9roule \u00e0 la main."
+    "On obtient ainsi les **12 solutions fondamentales** de N = 8. C'est exactement la brisure de symétrie qu'OR-Tools CP-SAT peut ajouter déclarativement (contraintes `AddAllDifferent` + lex-ordering) — ici on la déroule à la main."
    ]
   },
   {
@@ -948,16 +1063,16 @@
    "id": "d503a3b8-e6c9-4d2e-87a2-a29048614973",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:36:46.343811Z",
-     "iopub.status.busy": "2026-07-06T10:36:46.343184Z",
-     "iopub.status.idle": "2026-07-06T10:36:46.513986Z",
-     "shell.execute_reply": "2026-07-06T10:36:46.513863Z"
+     "iopub.execute_input": "2026-08-11T01:03:44.333394Z",
+     "iopub.status.busy": "2026-08-11T01:03:44.333100Z",
+     "iopub.status.idle": "2026-08-11T01:03:44.508072Z",
+     "shell.execute_reply": "2026-08-11T01:03:44.507844Z"
     },
     "papermill": {
-     "duration": 0.177105,
-     "end_time": "2026-07-06T10:36:46.514047",
+     "duration": 0.184765,
+     "end_time": "2026-08-11T01:03:44.508176",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.336942",
+     "start_time": "2026-08-11T01:03:44.323411",
      "status": "completed"
     },
     "tags": []
@@ -975,7 +1090,7 @@
     {
      "data": {
       "text/plain": [
-       "Les 80 autres s'obtiennent par sym\u00e9trie du carr\u00e9 (groupe D4, ordre 8)."
+       "Les 80 autres s'obtiennent par symétrie du carré (groupe D4, ordre 8)."
       ]
      },
      "metadata": {},
@@ -993,8 +1108,8 @@
     "            case \"r90\":  nx = n - 1 - y; ny = x; break;\n",
     "            case \"r180\": nx = n - 1 - x; ny = n - 1 - y; break;\n",
     "            case \"r270\": nx = y; ny = n - 1 - x; break;\n",
-    "            case \"fv\":   nx = n - 1 - x; ny = y; break;   // r\u00e9flexion verticale\n",
-    "            case \"fh\":   nx = x; ny = n - 1 - y; break;    // r\u00e9flexion horizontale\n",
+    "            case \"fv\":   nx = n - 1 - x; ny = y; break;   // réflexion verticale\n",
+    "            case \"fh\":   nx = x; ny = n - 1 - y; break;    // réflexion horizontale\n",
     "            case \"fd\":   nx = y; ny = x; break;            // diagonale principale\n",
     "            default:     nx = n - 1 - y; ny = n - 1 - x; break; // anti-diagonale\n",
     "        }\n",
@@ -1009,7 +1124,7 @@
     "    return forms.First();\n",
     "}\n",
     "\n",
-    "// collecter toutes les solutions puis d\u00e9nombrer les formes canoniques distinctes\n",
+    "// collecter toutes les solutions puis dénombrer les formes canoniques distinctes\n",
     "int n = 8;\n",
     "var all = new List<int[]>();\n",
     "void Collect(int[] queens, bool[] placed, int col) {\n",
@@ -1028,7 +1143,7 @@
     "var canonicals = new HashSet<string>();\n",
     "foreach (var sol in all) canonicals.Add(Canonical(sol));\n",
     "Show(\"N = \" + n + \" : \" + all.Count + \" solutions, \" + canonicals.Count + \" fondamentales (attendu : 12).\");\n",
-    "Show(\"Les \" + (all.Count - canonicals.Count) + \" autres s'obtiennent par sym\u00e9trie du carr\u00e9 (groupe D4, ordre 8).\");\n"
+    "Show(\"Les \" + (all.Count - canonicals.Count) + \" autres s'obtiennent par symétrie du carré (groupe D4, ordre 8).\");\n"
    ]
   },
   {
@@ -1036,27 +1151,27 @@
    "id": "536687e6-3a23-4e9a-a24c-c74e496eeee8",
    "metadata": {
     "papermill": {
-     "duration": 0.004754,
-     "end_time": "2026-07-06T10:36:46.522861",
+     "duration": 0.006336,
+     "end_time": "2026-08-11T01:03:44.521259",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.518107",
+     "start_time": "2026-08-11T01:03:44.514923",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## Synth\u00e8se compar\u00e9e\n",
+    "## Synthèse comparée\n",
     "\n",
-    "| Approche | Type | Garantit solution ? | Compte toutes les solutions ? | Passe \u00e0 l'\u00e9chelle ? |\n",
+    "| Approche | Type | Garantit solution ? | Compte toutes les solutions ? | Passe à l'échelle ? |\n",
     "|----------|------|---------------------|-------------------------------|---------------------|\n",
-    "| Backtracking simple | recherche compl\u00e8te | oui | non (1 solution) | non (factoriel) |\n",
-    "| + MRV | compl\u00e8te + heuristique | oui | non | un peu mieux |\n",
-    "| + Forward Checking | compl\u00e8te + propagation | oui | non | nettement mieux |\n",
+    "| Backtracking simple | recherche complète | oui | non (1 solution) | non (factoriel) |\n",
+    "| + MRV | complète + heuristique | oui | non | un peu mieux |\n",
+    "| + Forward Checking | complète + propagation | oui | non | nettement mieux |\n",
     "| Min-Conflicts | recherche locale | **non** (stochastique) | non | **oui (N = 1000+)** |\n",
-    "| \u00c9num\u00e9ration compl\u00e8te | parcours total | oui | **oui** | non (explosif) |\n",
-    "| + brisure de sym\u00e9trie | parcours + D4 | oui | **fondamentales** | non |\n",
+    "| Énumération complète | parcours total | oui | **oui** | non (explosif) |\n",
+    "| + brisure de symétrie | parcours + D4 | oui | **fondamentales** | non |\n",
     "\n",
-    "**Le\u00e7on** : aucun algorithme ne domine partout. La recherche compl\u00e8te garantit mais explose ; la recherche locale passe \u00e0 l'\u00e9chelle mais ne prouve rien. Les solveurs industriels (CP-SAT) combinent propagation + recherche + brisure de sym\u00e9trie d\u00e9clarative."
+    "**Leçon** : aucun algorithme ne domine partout. La recherche complète garantit mais explose ; la recherche locale passe à l'échelle mais ne prouve rien. Les solveurs industriels (CP-SAT) combinent propagation + recherche + brisure de symétrie déclarative."
    ]
   },
   {
@@ -1065,16 +1180,16 @@
    "id": "9b0fd2ac-03ef-4aa1-82bb-8cdba1c19428",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:36:46.535678Z",
-     "iopub.status.busy": "2026-07-06T10:36:46.535123Z",
-     "iopub.status.idle": "2026-07-06T10:36:46.580347Z",
-     "shell.execute_reply": "2026-07-06T10:36:46.580179Z"
+     "iopub.execute_input": "2026-08-11T01:03:44.536400Z",
+     "iopub.status.busy": "2026-08-11T01:03:44.536148Z",
+     "iopub.status.idle": "2026-08-11T01:03:44.576870Z",
+     "shell.execute_reply": "2026-08-11T01:03:44.576674Z"
     },
     "papermill": {
-     "duration": 0.052775,
-     "end_time": "2026-07-06T10:36:46.580426",
+     "duration": 0.048334,
+     "end_time": "2026-08-11T01:03:44.576964",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.527651",
+     "start_time": "2026-08-11T01:03:44.528630",
      "status": "completed"
     },
     "tags": []
@@ -1083,7 +1198,7 @@
     {
      "data": {
       "text/plain": [
-       "Synth\u00e8se affich\u00e9e ci-dessus (tableau markdown)."
+       "Synthèse affichée ci-dessus (tableau markdown)."
       ]
      },
      "metadata": {},
@@ -1091,7 +1206,299 @@
     }
    ],
    "source": [
-    "Show(\"Synth\u00e8se affich\u00e9e ci-dessus (tableau markdown).\");"
+    "Show(\"Synthèse affichée ci-dessus (tableau markdown).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "app1-tranche2-md-1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007444,
+     "end_time": "2026-08-11T01:03:44.591626",
+     "exception": false,
+     "start_time": "2026-08-11T01:03:44.584182",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Tranche 2 : parité lib-vs-lib via Google.OrTools (CP-SAT)\n",
+    "\n",
+    "La **Tranche 1** (sections 1–4 ci-dessus) réimplémente *from-scratch* et de façon lisible les trois grandes familles d'algorithmes pour les N-Reines : backtracking (simple, avec MRV et Forward Checking), recherche locale (Min-Conflicts), et énumération exhaustive avec brisure de symétrie. C'est la pédagogie — on **voit** le mécanisme de propagation et de retour-arrière.\n",
+    "\n",
+    "La **Tranche 2** franchit le même cap que le jumeau Python : invoquer un **moteur de production** de l'écosystème plutôt qu'une implémentation pédagogique. Le jumeau Python appelle `ortools.sat.python.cp_model` ; côté .NET, Google publie le **même solveur CP-SAT** sous forme du package NuGet `Google.OrTools`. La parité est donc **lib-vs-lib** : le même moteur (Lazy Clause Generation, propagation de bornes, recherche parallèle) des deux côtés.\n",
+    "\n",
+    "Le modèle CP-SAT des N-Reines tient en **trois contraintes d'égalité différentielle** (une par axe) — c'est la formulation canonique reconnue :\n",
+    "\n",
+    "| Axe | Contrainte | Sens |\n",
+    "|-----|-----------|------|\n",
+    "| Lignes | `AddAllDifferent(q[i])` | une reine au plus par ligne |\n",
+    "| Diagonales montantes ↗ | `AddAllDifferent(q[i] + i)` | une reine au plus par diagonale `i+j` constant |\n",
+    "| Diagonales descendantes ↘ | `AddAllDifferent(q[i] - i)` | une reine au plus par diagonale `i-j` constant |\n",
+    "\n",
+    "où `q[i]` = ligne de la reine placée en colonne `i` (variable entière `0 .. n-1`). C'est exactement le modèle de la cellule CP-SAT du jumeau Python (`App-1-NQueens.ipynb`), transposé tel quel en C#. Le solveur fait le reste : propagation, branchement, et — pour l'énumération — parcours de l'arbre complet.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "app1-tranche2-code-1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T01:03:44.607083Z",
+     "iopub.status.busy": "2026-08-11T01:03:44.606792Z",
+     "iopub.status.idle": "2026-08-11T01:04:52.383318Z",
+     "shell.execute_reply": "2026-08-11T01:04:52.382910Z"
+    },
+    "papermill": {
+     "duration": 67.784992,
+     "end_time": "2026-08-11T01:04:52.383508",
+     "exception": false,
+     "start_time": "2026-08-11T01:03:44.598516",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Google.OrTools, 9.15.6755</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CP-SAT N=8 : status=Optimal, temps=2589,1 ms\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution (ligne par colonne) : [4, 7, 3, 0, 6, 1, 5, 2]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Échiquier (X = reine) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . . . X . . . . \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . . . . . X . . \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . . . . . . . X \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . . X . . . . . \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X . . . . . . . \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . . . . . . X . \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . . . . X . . . \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . X . . . . . . \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Énumération CP-SAT N=8 : 92 solutions trouvées en 68,4 ms (status=Optimal)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "     N    Temps (ms)        Status\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     8          19,4        TROUVÉ\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    50         329,5        TROUVÉ\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   100        1690,8        TROUVÉ\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   500       60149,9       Unknown\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#r \"nuget: Google.OrTools\"\n",
+    "using Google.OrTools.Sat;\n",
+    "using System.Diagnostics;\n",
+    "\n",
+    "// --- Modèle canonique : q[i] = ligne de la reine en colonne i ; 3 x AddAllDifferent ---\n",
+    "IntVar[] BuildNQueensModel(CpModel model, int n)\n",
+    "{\n",
+    "    var q = new IntVar[n];\n",
+    "    for (int i = 0; i < n; i++)\n",
+    "        q[i] = model.NewIntVar(0, n - 1, $\"q_{i}\");\n",
+    "    // Une reine au plus par ligne, et par diagonale (montante + descendante).\n",
+    "    model.AddAllDifferent(q);\n",
+    "    model.AddAllDifferent(q.Select((v, i) => (LinearExpr)(v + i)).ToArray());\n",
+    "    model.AddAllDifferent(q.Select((v, i) => (LinearExpr)(v - i)).ToArray());\n",
+    "    return q;\n",
+    "}\n",
+    "\n",
+    "// --- Callback pour énumérer toutes les solutions (API C# : enumerate_all_solutions) ---\n",
+    "public sealed class SolutionCounter : CpSolverSolutionCallback\n",
+    "{\n",
+    "    public int Count { get; private set; }\n",
+    "    public override void OnSolutionCallback()\n",
+    "    {\n",
+    "        Count++;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// --- (1) Instance concrète N=8 : résolution + affichage (même instance que le Python) ---\n",
+    "{\n",
+    "    var model = new CpModel();\n",
+    "    var q = BuildNQueensModel(model, 8);\n",
+    "    var solver = new CpSolver();\n",
+    "    solver.StringParameters = \"max_time_in_seconds:30\";\n",
+    "    var sw = Stopwatch.StartNew();\n",
+    "    var st = solver.Solve(model);\n",
+    "    sw.Stop();\n",
+    "    var sol = Enumerable.Range(0, 8).Select(i => (int)solver.Value(q[i])).ToArray();\n",
+    "    Console.WriteLine($\"CP-SAT N=8 : status={st}, temps={sw.Elapsed.TotalMilliseconds:F1} ms\");\n",
+    "    Console.WriteLine($\"Solution (ligne par colonne) : [{string.Join(\", \", sol)}]\");\n",
+    "    Console.WriteLine(\"Échiquier (X = reine) :\");\n",
+    "    for (int r = 0; r < 8; r++)\n",
+    "    {\n",
+    "        var ligne = \"\";\n",
+    "        for (int c = 0; c < 8; c++) ligne += (sol[c] == r ? \"X \" : \". \");\n",
+    "        Console.WriteLine($\"  {ligne}\");\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// --- (2) Énumération de TOUTES les solutions N=8 (-> 92, valeur reconnue) ---\n",
+    "{\n",
+    "    var model = new CpModel();\n",
+    "    var q = BuildNQueensModel(model, 8);\n",
+    "    var solver = new CpSolver();\n",
+    "    solver.StringParameters = \"max_time_in_seconds:30 enumerate_all_solutions:true\";\n",
+    "    var counter = new SolutionCounter();\n",
+    "    var sw = Stopwatch.StartNew();\n",
+    "    var st = solver.Solve(model, counter);\n",
+    "    sw.Stop();\n",
+    "    Console.WriteLine($\"\\nÉnumération CP-SAT N=8 : {counter.Count} solutions trouvées en {sw.Elapsed.TotalMilliseconds:F1} ms (status={st})\");\n",
+    "}\n",
+    "\n",
+    "// --- (3) Benchmark CP-SAT (mêmes tailles que le jumeau Python : 8, 50, 100, 500) ---\n",
+    "Console.WriteLine($\"\\n{\"N\",6}  {\"Temps (ms)\",12}  {\"Status\",12}\");\n",
+    "Console.WriteLine(new string('-', 35));\n",
+    "foreach (var n in new[] { 8, 50, 100, 500 })\n",
+    "{\n",
+    "    var model = new CpModel();\n",
+    "    var q = BuildNQueensModel(model, n);\n",
+    "    var solver = new CpSolver();\n",
+    "    solver.StringParameters = \"max_time_in_seconds:60\";\n",
+    "    var sw = Stopwatch.StartNew();\n",
+    "    var st = solver.Solve(model);\n",
+    "    sw.Stop();\n",
+    "    var found = st is CpSolverStatus.Feasible or CpSolverStatus.Optimal;\n",
+    "    Console.WriteLine($\"{n,6}  {sw.Elapsed.TotalMilliseconds,12:F1}  {(found ? \"TROUVÉ\" : st.ToString()),12}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "app1-tranche2-md-2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008936,
+     "end_time": "2026-08-11T01:04:52.401365",
+     "exception": false,
+     "start_time": "2026-08-11T01:04:52.392429",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : lib-vs-lib et rôle du moteur\n",
+    "\n",
+    "- **Parité chiffre-à-chiffre avec le jumeau Python.** L'énumération CP-SAT des N-Reines pour N=8 retourne **92 solutions** — la valeur classique (12 fondamentales × 8 par symétries rotation/réflexion). C'est le même compte que la Tranche 1 from-scratch (section 4) et que le jumeau Python (`solve_nqueens_cpsat(8, enumerate_all=True)`).\n",
+    "- **Tranche 1 vs Tranche 2 = pédagogie vs production.** La Tranche 1 rend visible *pourquoi* ça marche : on suit le backtracking, on voit la Forward Checking tailler le domaine, on voit Min-Conflicts réparer. La Tranche 2 délègue tout cela au moteur CP-SAT, qui apporte la **Lazy Clause Generation**, la propagation de bornes et la recherche parallèle — le même rôle que `ortools.sat.python.cp_model` joue côté Python. Le benchmark [8, 50, 100, 500] montre la capacité du moteur à passer à l'échelle, en regard du benchmark Tranche 1 (section 2.3 / 3.1).\n",
+    "- **Pourquoi trois `AddAllDifferent` suffisent.** C'est la force déclarative de la programmation par contraintes : l'énoncé géométrique (une reine par ligne, par diagonale montante, par diagonale descendante) se traduit littéralement en trois contraintes globales, sans encoder le moindre mécanisme de parcours. Le solveur dérive lui-même la stratégie de branchement — là où la Tranche 1 a dû l'expliciter (MRV, Forward Checking).\n",
+    "\n",
+    "C'est exactement la parité demandée par l'EPIC #10382 : les deux jumeaux atteignent désormais un **moteur de production** de leur écosystème (`networkx`/`ortools` côté Python, `QuikGraph`/`Google.OrTools` côté .NET), la réimplémentation pédagogique étant conservée *en plus*, jamais *à la place*.\n"
    ]
   },
   {
@@ -1099,10 +1506,10 @@
    "id": "d0b73e33-8036-4d15-b358-6236b8b8e128",
    "metadata": {
     "papermill": {
-     "duration": 0.004894,
-     "end_time": "2026-07-06T10:36:46.590005",
+     "duration": 0.009012,
+     "end_time": "2026-08-11T01:04:52.420326",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.585111",
+     "start_time": "2026-08-11T01:04:52.411314",
      "status": "completed"
     },
     "tags": []
@@ -1110,29 +1517,29 @@
    "source": [
     "## 6. Exercices\n",
     "\n",
-    "### Exercice 1 : le probl\u00e8me des N-Tours\n",
+    "### Exercice 1 : le problème des N-Tours\n",
     "\n",
-    "Les tours ne conflituent que sur la **ligne et la colonne** (pas de diagonales). Avec une tour par colonne (contrainte d\u00e9j\u00e0 satisfaite), il ne reste qu'\u00e0 placer une tour par **ligne**. Compter les solutions pour N = 8 \u2014 c'est simplement le nombre de **permutations** de N lignes.\n",
+    "Les tours ne conflituent que sur la **ligne et la colonne** (pas de diagonales). Avec une tour par colonne (contrainte déjà satisfaite), il ne reste qu'à placer une tour par **ligne**. Compter les solutions pour N = 8 — c'est simplement le nombre de **permutations** de N lignes.\n",
     "\n",
     "> **Indice** : `IsSafe` devient `r == row` seulement (retirer la diagonale). Le compte attendu est `N!`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "f8ae9d65-70f6-4049-b536-cbeb49d8f2df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:36:46.600350Z",
-     "iopub.status.busy": "2026-07-06T10:36:46.600126Z",
-     "iopub.status.idle": "2026-07-06T10:36:46.636644Z",
-     "shell.execute_reply": "2026-07-06T10:36:46.636438Z"
+     "iopub.execute_input": "2026-08-11T01:04:52.442429Z",
+     "iopub.status.busy": "2026-08-11T01:04:52.442034Z",
+     "iopub.status.idle": "2026-08-11T01:04:52.534665Z",
+     "shell.execute_reply": "2026-08-11T01:04:52.534375Z"
     },
     "papermill": {
-     "duration": 0.04201,
-     "end_time": "2026-07-06T10:36:46.636733",
+     "duration": 0.105429,
+     "end_time": "2026-08-11T01:04:52.534775",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.594723",
+     "start_time": "2026-08-11T01:04:52.429346",
      "status": "completed"
     },
     "tags": []
@@ -1141,7 +1548,7 @@
     {
      "data": {
       "text/plain": [
-       "Exercice 1 \u00e0 compl\u00e9ter \u2014 attendu N=8 : 40320 (8!)."
+       "Exercice 1 à compléter — attendu N=8 : 40320 (8!)."
       ]
      },
      "metadata": {},
@@ -1149,12 +1556,12 @@
     }
    ],
    "source": [
-    "// Exercice 1 : N-Tours \u2014 une tour par colonne ET par ligne (pas de diagonale)\n",
+    "// Exercice 1 : N-Tours — une tour par colonne ET par ligne (pas de diagonale)\n",
     "// Etape 1 : adapter IsSafe (retirer la condition de diagonale).\n",
-    "// Etape 2 : \u00e9num\u00e9rer les solutions via EnumerateAll modifi\u00e9.\n",
-    "// Etape 3 : v\u00e9rifier que le compte vaut N! pour N = 8 (40320).\n",
+    "// Etape 2 : énumérer les solutions via EnumerateAll modifié.\n",
+    "// Etape 3 : vérifier que le compte vaut N! pour N = 8 (40320).\n",
     "static long Factorial(int k) { long f = 1; for (int i = 2; i <= k; i++) f *= i; return f; }\n",
-    "Show(\"Exercice 1 \u00e0 compl\u00e9ter \u2014 attendu N=8 : \" + Factorial(8) + \" (8!).\");\n"
+    "Show(\"Exercice 1 à compléter — attendu N=8 : \" + Factorial(8) + \" (8!).\");\n"
    ]
   },
   {
@@ -1162,10 +1569,10 @@
    "id": "10e00bb2-14b9-4a36-bf04-efa722583e9d",
    "metadata": {
     "papermill": {
-     "duration": 0.004366,
-     "end_time": "2026-07-06T10:36:46.645948",
+     "duration": 0.009446,
+     "end_time": "2026-08-11T01:04:52.556051",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.641582",
+     "start_time": "2026-08-11T01:04:52.546605",
      "status": "completed"
     },
     "tags": []
@@ -1173,27 +1580,27 @@
    "source": [
     "### Exercice 2 : seuil de bascule backtracking / min-conflicts\n",
     "\n",
-    "Pour petit N, le backtracking est instantan\u00e9 ; pour grand N, seul Min-Conflicts passe. O\u00f9 se situe le **seuil** au-del\u00e0 duquel Min-Conflicts devient plus rapide (en temps) que le backtracking avec Forward Checking ?\n",
+    "Pour petit N, le backtracking est instantané ; pour grand N, seul Min-Conflicts passe. Où se situe le **seuil** au-delà duquel Min-Conflicts devient plus rapide (en temps) que le backtracking avec Forward Checking ?\n",
     "\n",
-    "> **Indice** : boucler sur N de 8 \u00e0 30, mesurer `t_FC` et `t_MC`, trouver le plus petit N tel que `t_MC < t_FC`."
+    "> **Indice** : boucler sur N de 8 à 30, mesurer `t_FC` et `t_MC`, trouver le plus petit N tel que `t_MC < t_FC`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "9484275f-90a6-4611-8355-e82ca9d57ee7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:36:46.656719Z",
-     "iopub.status.busy": "2026-07-06T10:36:46.656497Z",
-     "iopub.status.idle": "2026-07-06T10:36:46.686685Z",
-     "shell.execute_reply": "2026-07-06T10:36:46.686476Z"
+     "iopub.execute_input": "2026-08-11T01:04:52.577719Z",
+     "iopub.status.busy": "2026-08-11T01:04:52.577251Z",
+     "iopub.status.idle": "2026-08-11T01:04:52.624205Z",
+     "shell.execute_reply": "2026-08-11T01:04:52.623710Z"
     },
     "papermill": {
-     "duration": 0.036161,
-     "end_time": "2026-07-06T10:36:46.686755",
+     "duration": 0.05839,
+     "end_time": "2026-08-11T01:04:52.624323",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.650594",
+     "start_time": "2026-08-11T01:04:52.565933",
      "status": "completed"
     },
     "tags": []
@@ -1202,7 +1609,7 @@
     {
      "data": {
       "text/plain": [
-       "Exercice 2 \u00e0 compl\u00e9ter \u2014 mesurer le crossover FC/MC."
+       "Exercice 2 à compléter — mesurer le crossover FC/MC."
       ]
      },
      "metadata": {},
@@ -1211,9 +1618,9 @@
    ],
    "source": [
     "// Exercice 2 : trouver le plus petit N tel que t_MinConflicts < t_ForwardChecking\n",
-    "// Etape 1 : pour N = 8..30, mesurer les deux temps (r\u00e9utiliser les fonctions ci-dessus).\n",
-    "// Etape 2 : retourner le premier N o\u00f9 MC bat FC.\n",
-    "Show(\"Exercice 2 \u00e0 compl\u00e9ter \u2014 mesurer le crossover FC/MC.\");\n"
+    "// Etape 1 : pour N = 8..30, mesurer les deux temps (réutiliser les fonctions ci-dessus).\n",
+    "// Etape 2 : retourner le premier N où MC bat FC.\n",
+    "Show(\"Exercice 2 à compléter — mesurer le crossover FC/MC.\");\n"
    ]
   },
   {
@@ -1221,38 +1628,38 @@
    "id": "588315d8-f45f-4d24-a191-5e34d4ad6cd5",
    "metadata": {
     "papermill": {
-     "duration": 0.004096,
-     "end_time": "2026-07-06T10:36:46.695086",
+     "duration": 0.010008,
+     "end_time": "2026-08-11T01:04:52.642950",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.690990",
+     "start_time": "2026-08-11T01:04:52.632942",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 3 : briser la sym\u00e9trie directement dans l'\u00e9num\u00e9ration\n",
+    "### Exercice 3 : briser la symétrie directement dans l'énumération\n",
     "\n",
-    "Plut\u00f4t que d'\u00e9num\u00e9rer les 92 solutions puis de filtrer par forme canonique (ce qui co\u00fbte 92 \u00d7 8 transforms), on peut **imposer** d\u00e8s la descente que la solution soit la forme canonique (ex. contrainte lexicographique `queens < Transform(queens, \"r90\")`). Impl\u00e9menter cette brisure **\u00e0 la vol\u00e9e**.\n",
+    "Plutôt que d'énumérer les 92 solutions puis de filtrer par forme canonique (ce qui coûte 92 × 8 transforms), on peut **imposer** dès la descente que la solution soit la forme canonique (ex. contrainte lexicographique `queens < Transform(queens, \"r90\")`). Implémenter cette brisure **à la volée**.\n",
     "\n",
-    "> **Indice** : \u00e0 la feuille (col == n), ne compter la solution que si son `Key` est \u00e9gal \u00e0 son `Canonical`. C'est une brisure *a posteriori* par feuille ; la brisure *a priori* (couper pendant la descente) est plus dure \u2014 c'est pr\u00e9cis\u00e9ment ce que fait CP-SAT."
+    "> **Indice** : à la feuille (col == n), ne compter la solution que si son `Key` est égal à son `Canonical`. C'est une brisure *a posteriori* par feuille ; la brisure *a priori* (couper pendant la descente) est plus dure — c'est précisément ce que fait CP-SAT."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "80e9b3f8-ff41-4095-b873-3d3cea65e70f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:36:46.704622Z",
-     "iopub.status.busy": "2026-07-06T10:36:46.704429Z",
-     "iopub.status.idle": "2026-07-06T10:36:46.731783Z",
-     "shell.execute_reply": "2026-07-06T10:36:46.731627Z"
+     "iopub.execute_input": "2026-08-11T01:04:52.667095Z",
+     "iopub.status.busy": "2026-08-11T01:04:52.666760Z",
+     "iopub.status.idle": "2026-08-11T01:04:52.720186Z",
+     "shell.execute_reply": "2026-08-11T01:04:52.719934Z"
     },
     "papermill": {
-     "duration": 0.032789,
-     "end_time": "2026-07-06T10:36:46.731859",
+     "duration": 0.066115,
+     "end_time": "2026-08-11T01:04:52.720305",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.699070",
+     "start_time": "2026-08-11T01:04:52.654190",
      "status": "completed"
     },
     "tags": []
@@ -1261,7 +1668,7 @@
     {
      "data": {
       "text/plain": [
-       "Exercice 3 \u00e0 compl\u00e9ter \u2014 briser la sym\u00e9trie \u00e0 l'\u00e9num\u00e9ration."
+       "Exercice 3 à compléter — briser la symétrie à l'énumération."
       ]
      },
      "metadata": {},
@@ -1269,10 +1676,10 @@
     }
    ],
    "source": [
-    "// Exercice 3 : \u00e9num\u00e9rer en ne gardant que les formes canoniques (a posteriori par feuille)\n",
-    "// Etape 1 : modifier EnumerateAll pour, \u00e0 la feuille, v\u00e9rifier Key(queens) == Canonical(queens).\n",
+    "// Exercice 3 : énumérer en ne gardant que les formes canoniques (a posteriori par feuille)\n",
+    "// Etape 1 : modifier EnumerateAll pour, à la feuille, vérifier Key(queens) == Canonical(queens).\n",
     "// Etape 2 : le compte doit donner directement 12 pour N = 8 (sans HashSet).\n",
-    "Show(\"Exercice 3 \u00e0 compl\u00e9ter \u2014 briser la sym\u00e9trie \u00e0 l'\u00e9num\u00e9ration.\");\n"
+    "Show(\"Exercice 3 à compléter — briser la symétrie à l'énumération.\");\n"
    ]
   },
   {
@@ -1280,10 +1687,10 @@
    "id": "5c7651cc-0be9-471c-b8e6-eda1558d9630",
    "metadata": {
     "papermill": {
-     "duration": 0.005078,
-     "end_time": "2026-07-06T10:36:46.741575",
+     "duration": 0.008713,
+     "end_time": "2026-08-11T01:04:52.738130",
      "exception": false,
-     "start_time": "2026-07-06T10:36:46.736497",
+     "start_time": "2026-08-11T01:04:52.729417",
      "status": "completed"
     },
     "tags": []
@@ -1291,21 +1698,21 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce twin C# a **d\u00e9roul\u00e9 \u00e0 la main** ce que le solveur industriel OR-Tools CP-SAT (twin Python) automatise :\n",
+    "Ce twin C# a **déroulé à la main** ce que le solveur industriel OR-Tools CP-SAT (twin Python) automatise :\n",
     "\n",
-    "- **Backtracking** (simple / MRV / Forward Checking) = le moteur de recherche compl\u00e8te avec propagation ;\n",
-    "- **Min-Conflicts** = la recherche locale qui passe \u00e0 l'\u00e9chelle (le \u00ab miracle \u00bb N = 1000) ;\n",
-    "- **\u00c9num\u00e9ration + brisure de sym\u00e9trie D4** = le comptage exact des solutions fondamentales (12 pour N = 8).\n",
+    "- **Backtracking** (simple / MRV / Forward Checking) = le moteur de recherche complète avec propagation ;\n",
+    "- **Min-Conflicts** = la recherche locale qui passe à l'échelle (le « miracle » N = 1000) ;\n",
+    "- **Énumération + brisure de symétrie D4** = le comptage exact des solutions fondamentales (12 pour N = 8).\n",
     "\n",
-    "**Lien avec les Foundations** : backtracking \u21c4 [`Search-1`](../../Part1-Foundations/Search-1-StateSpace-Csharp.ipynb) (DFS), CSP \u21c4 [`CSP-1`](../../Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb), Min-Conflicts \u21c4 [`Search-11`](../../Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb) (m\u00e9taheuristiques), CP-SAT \u21c4 [`App-1-NQueens`](App-1-NQueens.ipynb) (twin Python, solveur industriel).\n",
+    "**Lien avec les Foundations** : backtracking ⇄ [`Search-1`](../../Part1-Foundations/Search-1-StateSpace-Csharp.ipynb) (DFS), CSP ⇄ [`CSP-1`](../../Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb), Min-Conflicts ⇄ [`Search-11`](../../Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb) (métaheuristiques), CP-SAT ⇄ [`App-1-NQueens`](App-1-NQueens.ipynb) (twin Python, solveur industriel).\n",
     "\n",
     "### Pour aller plus loin\n",
     "- Ajouter la **propagation AC-3** (arc-consistency) avant le backtracking.\n",
-    "- Comparer au **recuit simul\u00e9** (cf Search-11 SA) sur les m\u00eames instances.\n",
-    "- Mesurer l'impact de la **brisure de sym\u00e9trie d\u00e9clarative** sur le temps d'\u00e9num\u00e9ration.\n",
+    "- Comparer au **recuit simulé** (cf Search-11 SA) sur les mêmes instances.\n",
+    "- Mesurer l'impact de la **brisure de symétrie déclarative** sur le temps d'énumération.\n",
     "\n",
     "---\n",
-    "*Marathon .NET \u21c4 Python #4956 \u2014 Search/Applications, tranche N-Reines. See #4956, #3801.*\n"
+    "*Marathon .NET ⇄ Python #4956 — Search/Applications, tranche N-Reines. See #4956, #3801.*\n"
    ]
   }
  ],
@@ -1323,12 +1730,12 @@
    "version": "13.0"
   },
   "papermill": {
-   "duration": 6.337636,
-   "end_time": "2026-07-06T10:36:46.981538",
+   "duration": 73.943582,
+   "end_time": "2026-08-11T01:04:52.979708",
    "exception": null,
    "input_path": "App-1b-NQueens-CSharp.ipynb",
-   "output_path": "App-1b-NQueens-CSharp.ipynb",
-   "start_time": "2026-07-06T10:36:40.643902"
+   "output_path": "app1_out2.ipynb",
+   "start_time": "2026-08-11T01:03:39.036126"
   }
  },
  "nbformat": 4,

--- a/scripts/notebook_tools/twin_pairs.d/app-1-nqueens.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-1-nqueens.yaml
@@ -15,6 +15,12 @@
       csharp_sha: 17128d989d96c86221f698d1586f00ddf5f6feb1
       content_python_sha: ad70343ffa9d6a0de5d499a7ff54663b1de01e30c1bb10220d632246318a2a86
       content_csharp_sha: 1c2eccf226436990afd5030959607150bc49647dae0df5845713a38825023f2a
+    - date: "2026-08-11"
+      by: myia-po-2025:CoursIA
+      python_sha: 09311f6bce8aa693233194a8ffbffa1c0bc37347
+      csharp_sha: ad89fd658bf2e427c50d29a24f66cae0d0fd84aa
+      content_python_sha: ad70343ffa9d6a0de5d499a7ff54663b1de01e30c1bb10220d632246318a2a86
+      content_csharp_sha: b00f93effc7751b76b5ba6f902fbcf4d66f2d2b0e43ea273574a89ad8e62d676
   known_differences:
     - "Bibliotheque vs from-scratch puis lib-vs-lib : Python invoque OR-Tools CP-SAT (CpModel, AddAllDifferent sur lignes + 2 diagonales) comme 3e approche au cote de backtracking/min-conflicts from-scratch. C# = deux tranches -- Tranche 1 (sections 1-4) reimplementation from-scratch pedagogique (backtracking simple + MRV + Forward Checking + Min-Conflicts + enumeration exhaustive avec brisure de symetrie, en System.* pur) PRESERVEE integralement ; Tranche 2 (PR #10382 cycle 12) ajoute Google.OrTools 9.15 (.NET natif, deja en service dans Sudoku-10/18, App-8, App-15b) avec le MEME modele canonique CP-SAT que le Python (3 x AddAllDifferent) sur N=8 -- parite verifiee chiffre a chiffre : l'enumeration CP-SAT retourne 92 solutions (valeur classique, = Tranche 1 section 4 = Python). parity_level=native-both (Python/ortools ET C#/Google.OrTools atteignent chacun le moteur de production CP-SAT de leur ecosysteme)."
     - "Asymetrie de couverture : Python (54 cellules) couvre la formulation CSP + 3 approches + section comparative + exemple guide ; C# (31 cellules) couvre les memes approches from-scratch (Tranche 1) + le pont CP-SAT (Tranche 2) + 3 exercices. Le benchmark CP-SAT [8,50,100,500] est reproduit des deux cotes ; N=500 = UNKNOWN au-dela de 60s des deux cotes (parite honnete : la recherche complete CP-SAT ne passe pas a l'echelle aussi bien que Min-Conflicts, demontre Tranche 1 section 3.1)."

--- a/scripts/notebook_tools/twin_pairs.d/app-1-nqueens.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-1-nqueens.yaml
@@ -2,7 +2,7 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-1b-NQueens-CSharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -16,6 +16,6 @@
       content_python_sha: ad70343ffa9d6a0de5d499a7ff54663b1de01e30c1bb10220d632246318a2a86
       content_csharp_sha: 1c2eccf226436990afd5030959607150bc49647dae0df5845713a38825023f2a
   known_differences:
-    - "Socle pedagogique commun : N-Reines comme CSP canonique — formulation (variables Reines, domaines 1..N, contraintes alldifferent lignes/colonnes/diagonales), resolution par plusieurs approches. Les deux twins couvrent Backtracking + Min-Conflicts (recherche locale) ; Python ajoute OR-Tools CP-SAT (3eme approche) + section comparative, C# ajoute l'enumeration exhaustive de toutes les solutions."
-    - "Idiomes framework : Python = OR-Tools CP-SAT (CpModel, AddAllDifferent) + backtracking/min-conflicts from-scratch, 54 cellules (formulation CSP, 3 approches, comparaison, exemple guide). C# = pur System.* (System / System.Collections.Generic / System.Linq), 0 NuGet, 5 using, 28 cellules (backtracking + min-conflicts + enumeration from-scratch, presentation compacte)."
-    - "Asymetrie pedagogique : Python met l'accent sur la comparaison empirique des 3 solveurs (backtracking vs min-conflicts vs CP-SAT) avec timings ; le C# demontre l'enumeration exhaustive complementaire en BCL pure sans dependance externe. Meme socle theorique (CSP N-Reines, propagation de contraintes), leviers de demonstration differents."
+    - "Bibliotheque vs from-scratch puis lib-vs-lib : Python invoque OR-Tools CP-SAT (CpModel, AddAllDifferent sur lignes + 2 diagonales) comme 3e approche au cote de backtracking/min-conflicts from-scratch. C# = deux tranches -- Tranche 1 (sections 1-4) reimplementation from-scratch pedagogique (backtracking simple + MRV + Forward Checking + Min-Conflicts + enumeration exhaustive avec brisure de symetrie, en System.* pur) PRESERVEE integralement ; Tranche 2 (PR #10382 cycle 12) ajoute Google.OrTools 9.15 (.NET natif, deja en service dans Sudoku-10/18, App-8, App-15b) avec le MEME modele canonique CP-SAT que le Python (3 x AddAllDifferent) sur N=8 -- parite verifiee chiffre a chiffre : l'enumeration CP-SAT retourne 92 solutions (valeur classique, = Tranche 1 section 4 = Python). parity_level=native-both (Python/ortools ET C#/Google.OrTools atteignent chacun le moteur de production CP-SAT de leur ecosysteme)."
+    - "Asymetrie de couverture : Python (54 cellules) couvre la formulation CSP + 3 approches + section comparative + exemple guide ; C# (31 cellules) couvre les memes approches from-scratch (Tranche 1) + le pont CP-SAT (Tranche 2) + 3 exercices. Le benchmark CP-SAT [8,50,100,500] est reproduit des deux cotes ; N=500 = UNKNOWN au-dela de 60s des deux cotes (parite honnete : la recherche complete CP-SAT ne passe pas a l'echelle aussi bien que Min-Conflicts, demontre Tranche 1 section 3.1)."
+    - "Idiomes framework : Python = OR-Tools CP-SAT (cp_model.CpModel, solver.parameters.max_time_in_seconds) + from-scratch ; C# = Google.OrTools.Sat (CpModel, solver.StringParameters='max_time_in_seconds:N') + from-scratch System.*. Meme socle theorique (CSP N-Reines, propagation de contraintes, 3 x AddAllDifferent). Le C# valorise la reimplementation pedagogique (Tranche 1) ET l'invocation du moteur SOTA (Tranche 2) -- la ou le Python valorise l'invocation de la lib."


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2025:CoursIA — prev: DEEP/notebook-dotnet #10387

See #10382, See #4956, See #3801

## Summary

EPIC #10382 (lib-vs-lib parity), family **Search/Applications**, dispatched to this lane by ai-01 (provisioning DM msg-20260811T002048, trio App-1/App-3/App-4). The C# twin `App-1b-NQueens-CSharp.ipynb` carried its cross-lang parity with the Python/OR-Tools twin **in prose only** — all 13 code cells were a from-scratch `System.*` implementation bridging no .NET engine. This PR adds the missing **Tranche 2** on the Tweety-5 / Search-15 gabarit: invoke the production .NET engine **Google.OrTools** (CP-SAT) on the SAME canonical N=8 instance, and verify lib-vs-lib parity **chiffre à chiffre**.

## The defect (firsthand, measured on origin/main)

`scripts/notebook_tools/twin_pairs.d/app-1-nqueens.yaml` registered `parity_level: semantic` with known_differences *"C# = pur System.*, 0 NuGet, 5 using"* while *"Python ajoute OR-Tools CP-SAT (3eme approche)"*. A grep on the C# twin's code cells for `#r`, `Google.OrTools`, any NuGet reference → **0 hits**. The C# side reached no engine; the Python side reaches `ortools.sat.python.cp_model`. That is exactly the #10382 finding (51 pairs where C# bridges no engine, Python does).

## Tranche 2 (3 new cells, from-scratch sections 1-4 untouched)

Inserted before §6 Exercises, on the validated Search-15 gabarit (Tranche 1 intact, Tranche 2 added after):

1. **`## Tranche 2 : parité lib-vs-lib via Google.OrTools (CP-SAT)`** (markdown) — the lib-vs-lib framing: Python/ortools ↔ C#/Google.OrTools, the canonical CP-SAT model (3× AddAllDifferent: lines + 2 diagonals), the table of the three constraint axes.
2. **Google.OrTools 9.15 CP-SAT** (code, ec=11) — `#r "nuget: Google.OrTools"` then the canonical model: `q[i]` = row in column i, `AddAllDifferent(q)`, `AddAllDifferent(q[i]+i)`, `AddAllDifferent(q[i]-i)`. Three sub-experiments mirroring the Python twin: (1) solve N=8 + board display, (2) enumerate all solutions N=8, (3) benchmark [8,50,100,500].
3. **Interpretation** (markdown) — Tranche 1 = readable pedagogy (backtracking, MRV, Forward Checking, Min-Conflicts visible); Tranche 2 = production CP-SAT engine (Lazy Clause Generation, bound propagation, the same role `ortools.sat` plays on the Python side).

## Firsthand output (committed, the parity proof)

```
CP-SAT N=8 : status=Optimal, temps=2589,1 ms
Solution (ligne par colonne) : [4, 7, 3, 0, 6, 1, 5, 2]
Échiquier (X = reine) :
  . . . X . . . .
  . . . . . X . .
  ...

Énumération CP-SAT N=8 : 92 solutions trouvées en 68,4 ms (status=Optimal)

     N    Temps (ms)        Status
-----------------------------------
     8          19,4        TROUVÉ
    50         329,5        TROUVÉ
   100        1690,8        TROUVÉ
   500       60149,9       Unknown
```

The engine reaches the **exact** enumeration count (92 = canonical value = Python twin `solve_nqueens_cpsat(8, enumerate_all=True)` = Tranche 1 §4). The benchmark is **exact parity** with the Python twin: both solve 8/50/100 OPTIMAL, both return **UNKNOWN for N=500** at the 60s limit (Python: 60287ms → UNKNOWN). Honest: complete CP-SAT search hits the same scaling wall that Min-Conflicts local search (Tranche 1 §3.1) overcomes. Parity is verified, not announced.

## C.1 / C.2 / execution / anti-regression

- **Anti-regression (acceptance criterion 1)**: the from-scratch tranche is preserved **byte-for-byte** — verified programmatically on the committed blob: all 21 original cells (0..20) source-identical to `origin/main`. The +676/-263 line delta is Papermill **output regeneration** (re-executed display_data for all 14 code cells) + the 3 new Tranche-2 cells, NOT source changes.
- **C.1**: no `raise NotImplementedError`/`assert False`/`1/0` (scan clean: 0/0/0).
- **C.2**: whole notebook re-executed via the `.net-csharp` kernel (Papermill, 14/14 code cells `execution_count` 1..14, 0 errors). Outputs are real.
- **API correction (rule F)**: the proven .NET OR-Tools API is `solver.StringParameters = "max_time_in_seconds:N"` (string property) + `solver.Solve(model, callback)` for enumeration — NOT the Python `solver.parameters.max_time_in_seconds` / `solver.SearchAllSolutions` style. First attempt used the Python API (compilation error CS1061); corrected from the proven pattern in App-15b (`Solver.StringParameters = $"max_time_in_seconds:..."`). Google.OrTools 9.15.6755 restored cleanly via NuGet — no workaround.
- **Path/secret hygiene**: `.NET Interactive` `probeAddresses` banner stripped post-re-exec (9 lines via `strip_probe_banner.py --apply`). Papermill `metadata.papermill.input/output_path` normalized to basenames. 0 machine-path leak in outputs.

## Registry update (acceptance criterion 2)

`scripts/notebook_tools/twin_pairs.d/app-1-nqueens.yaml`:
- `parity_level: semantic` → **`native-both`** (both twins now reach a production engine of their ecosystem).
- `known_differences` rewritten to describe the two-tranche structure + the chiffre-à-chiffre parity + the honest N=500 UNKNOWN on both sides.
- New audit entry via `check_twin_parity --update --pair "App-1 NQueens" --by "myia-po-2025:CoursIA"` (run LAST after all tooling strips, #8957; reads committed notebook blob `csharp_sha: ad89fd65...`).
- Registry health check: 157/157 OK, 0 DRIFT, 0 MISSING.

## Verdict SOTA (acceptance criterion 5)

**SOTA-OK** — Google.OrTools 9.15.6755 is properly restored (`#r "nuget: Google.OrTools"`) and invoked; the committed output is its real CP-SAT output (92 solutions, OPTIMAL status, benchmark). No workaround, no degraded substitution. This is the .NET production CP-SAT engine the owner asked each side to reach (#10382: "Chaque côté atteint un moteur de production de son écosystème").

## Variation note (G-VAR-3)

prev = DEEP/notebook-dotnet #10387 (Search-15 QuikGraph lib-vs-lib parity). This is DEEP/notebook-dotnet (App-1 Google.OrTools CP-SAT lib-vs-lib parity — domain reasoning: bridging the real .NET CP-SAT engine on the canonical N-queens instance + verifying chiffre-à-chiffre parity including the honest N=500 scaling wall). Same GENRE (notebook-dotnet) AND same TIER (DEEP) as prev — but **genuinely distinct substance** (different notebook, different engine, different problem: QuikGraph/Dijkstra/graph vs Google.OrTools/CP-SAT/N-queens), produced by domain reasoning, not scan-generated. Per G-VAR-3, a 2nd DEEP same-genre in a lane's domain-cœur is allowed when the substance is genuinely distinct (the litmus "could I generate the next by scanning the instance beside it?" → NO: designing the CP-SAT bridge + the canonical-model formulation + the parity reconstruction required domain reasoning). This is the second grain of the Search/Applications trio dispatched by ai-01 (App-1 done; App-3/App-4 queued).

## Why See, not Closes

This resolves ONE pair (App-1) of the 51-pair #10382 epic. The epic stays open. `See #10382`.

See #10382 (epic), See #4956 (.NET⇄Python parity marathon), See #3801 (SOTA registry).
