### PR TITLE
feat(search,#10382): App-3 NurseScheduling Tranche 2 via Google.OrTools CP-SAT (lib-vs-lib parity)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-3b-NurseScheduling-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-3b-NurseScheduling-CSharp.ipynb
@@ -5,28 +5,28 @@
    "id": "0c428e5e",
    "metadata": {
     "papermill": {
-     "duration": 0.003463,
-     "end_time": "2026-07-06T16:01:29.045382",
+     "duration": 0.005185,
+     "end_time": "2026-08-11T01:37:28.539858",
      "exception": false,
-     "start_time": "2026-07-06T16:01:29.041919",
+     "start_time": "2026-08-11T01:37:28.534673",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "# App-3b : Nurse Scheduling \u2014 Twin C# (planification de gardes infirmi\u00e8res)\n",
+    "# App-3b : Nurse Scheduling — Twin C# (planification de gardes infirmières)\n",
     "\n",
     "**Navigation** : [<< App-2b GraphColoring-CSharp](App-2b-GraphColoring-CSharp.ipynb) | [Index](../README.md) | [App-3 Python (OR-Tools) >>](App-3-NurseScheduling.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
-    "\u00c0 la fin de ce notebook, vous saurez :\n",
-    "1. **Mod\u00e9liser** le *Nurse Rostering Problem* (NRP) comme un probl\u00e8me d'optimisation sous contraintes\n",
-    "2. **Distinguer** contraintes dures (obligatoires) et contraintes souples (pr\u00e9f\u00e9rences p\u00e9nalis\u00e9es)\n",
-    "3. **D\u00e9rouler trois solveurs from-scratch** : construction gloutonne, backtracking de faisabilit\u00e9, et **min-conflicts** (recherche locale \u00e0 minimisation de conflits)\n",
+    "À la fin de ce notebook, vous saurez :\n",
+    "1. **Modéliser** le *Nurse Rostering Problem* (NRP) comme un problème d'optimisation sous contraintes\n",
+    "2. **Distinguer** contraintes dures (obligatoires) et contraintes souples (préférences pénalisées)\n",
+    "3. **Dérouler trois solveurs from-scratch** : construction gloutonne, backtracking de faisabilité, et **min-conflicts** (recherche locale à minimisation de conflits)\n",
     "4. **Comparer** ces moteurs explicites au solveur industriel OR-Tools CP-SAT du twin Python\n",
     "\n",
-    "> **Twin C# du marathon #4956** (parit\u00e9 .NET \u21c4 Python). Le notebook Python [App-3-NurseScheduling](App-3-NurseScheduling.ipynb) invoque **OR-Tools CP-SAT** (`cp_model`), un solveur de programmation par contraintes industriel. Ce twin d\u00e9roule les algorithmes **\u00e0 la main** (BCL .NET 9, **0 NuGet, 0 OR-Tools**) : ce que CP-SAT cache dans sa bo\u00eete noire (propagation, recherche arborescente, optimisation d'objectif) devient explicite. Verdict axe-2 SOTA **#3801 Prong B** : compl\u00e9mentarit\u00e9 from-scratch.\n"
+    "> **Twin C# du marathon #4956** (parité .NET ⇄ Python). Le notebook Python [App-3-NurseScheduling](App-3-NurseScheduling.ipynb) invoque **OR-Tools CP-SAT** (`cp_model`), un solveur de programmation par contraintes industriel. Ce twin déroule les algorithmes **à la main** (BCL .NET 9, **0 NuGet, 0 OR-Tools**) : ce que CP-SAT cache dans sa boîte noire (propagation, recherche arborescente, optimisation d'objectif) devient explicite. Verdict axe-2 SOTA **#3801 Prong B** : complémentarité from-scratch.\n"
    ]
   },
   {
@@ -34,28 +34,28 @@
    "id": "1bb2a00a",
    "metadata": {
     "papermill": {
-     "duration": 0.002472,
-     "end_time": "2026-07-06T16:01:29.050748",
+     "duration": 0.005189,
+     "end_time": "2026-08-11T01:37:28.550434",
      "exception": false,
-     "start_time": "2026-07-06T16:01:29.048276",
+     "start_time": "2026-08-11T01:37:28.545245",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 1. Contexte \u2014 le Nurse Rostering Problem\n",
+    "## 1. Contexte — le Nurse Rostering Problem\n",
     "\n",
-    "Le NRP est un classique de l'optimisation combinatoire r\u00e9aliste : planifier les gardes d'un service hospitalier sur une semaine, en satisfaisant des **contraintes dures** (sinon le planning est inutilisable) tout en respectant au mieux des **contraintes souples** (pr\u00e9f\u00e9rences, \u00e9quit\u00e9). C'est un probl\u00e8me **NP-difficile** : l'espace de recherche est immense, et la fronti\u00e8re entre faisabilit\u00e9 et optimum est subtile.\n",
+    "Le NRP est un classique de l'optimisation combinatoire réaliste : planifier les gardes d'un service hospitalier sur une semaine, en satisfaisant des **contraintes dures** (sinon le planning est inutilisable) tout en respectant au mieux des **contraintes souples** (préférences, équité). C'est un problème **NP-difficile** : l'espace de recherche est immense, et la frontière entre faisabilité et optimum est subtile.\n",
     "\n",
     "### Pourquoi trois solveurs ?\n",
     "\n",
-    "| Solveur | R\u00f4le p\u00e9dagogique | Question \u00e0 laquelle il r\u00e9pond |\n",
+    "| Solveur | Rôle pédagogique | Question à laquelle il répond |\n",
     "|---------|------------------|-------------------------------|\n",
-    "| **Glouton** | Baseline na\u00efve | Que donne un choix purement local, sans retour arri\u00e8re ? |\n",
-    "| **Backtracking** | \u00c9num\u00e9ration exhaustive avec \u00e9lagage | Existe-t-il **un** planning faisable ? (pure satisfaction) |\n",
-    "| **Min-Conflicts** | Recherche locale stochastique | Quel planning **minimise** les pr\u00e9f\u00e9rences viol\u00e9es ? (optimisation) |\n",
+    "| **Glouton** | Baseline naïve | Que donne un choix purement local, sans retour arrière ? |\n",
+    "| **Backtracking** | Énumération exhaustive avec élagage | Existe-t-il **un** planning faisable ? (pure satisfaction) |\n",
+    "| **Min-Conflicts** | Recherche locale stochastique | Quel planning **minimise** les préférences violées ? (optimisation) |\n",
     "\n",
-    "Le twin Python (CP-SAT) fusionne ces trois r\u00f4les dans un seul solveur \u00ab bo\u00eete noire \u00bb. Ici, on les s\u00e9pare pour voir ce que chacun **voit** et **d\u00e9cide**.\n"
+    "Le twin Python (CP-SAT) fusionne ces trois rôles dans un seul solveur « boîte noire ». Ici, on les sépare pour voir ce que chacun **voit** et **décide**.\n"
    ]
   },
   {
@@ -64,21 +64,127 @@
    "id": "b65dc58e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:01:29.072673Z",
-     "iopub.status.busy": "2026-07-06T16:01:29.065872Z",
-     "iopub.status.idle": "2026-07-06T16:01:30.736472Z",
-     "shell.execute_reply": "2026-07-06T16:01:30.731798Z"
+     "iopub.execute_input": "2026-08-11T01:37:28.576476Z",
+     "iopub.status.busy": "2026-08-11T01:37:28.568316Z",
+     "iopub.status.idle": "2026-08-11T01:37:30.912520Z",
+     "shell.execute_reply": "2026-08-11T01:37:30.906656Z"
     },
     "papermill": {
-     "duration": 1.679818,
-     "end_time": "2026-07-06T16:01:30.736581",
+     "duration": 2.356392,
+     "end_time": "2026-08-11T01:37:30.912715",
      "exception": false,
-     "start_time": "2026-07-06T16:01:29.056763",
+     "start_time": "2026-08-11T01:37:28.556323",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-46144.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '46144.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "data": {
       "text/plain": [
@@ -141,27 +247,27 @@
    "id": "8c5509fe",
    "metadata": {
     "papermill": {
-     "duration": 0.002149,
-     "end_time": "2026-07-06T16:01:30.741247",
+     "duration": 0.005651,
+     "end_time": "2026-08-11T01:37:30.925026",
      "exception": false,
-     "start_time": "2026-07-06T16:01:30.739098",
+     "start_time": "2026-08-11T01:37:30.919375",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 2. Mod\u00e9lisation from-scratch \u2014 une variable par slot\n",
+    "## 2. Modélisation from-scratch — une variable par slot\n",
     "\n",
-    "Le twin Python utilise $x[n][d][s] \\in \\{0,1\\}$, soit $N \\times D \\times S = 105$ variables bool\u00e9ennes, puis contraint leur somme par slot \u00e0 1 (couverture). C'est la formulation \u00ab SAT \u00bb canonique que CP-SAT attend.\n",
+    "Le twin Python utilise $x[n][d][s] \\in \\{0,1\\}$, soit $N \\times D \\times S = 105$ variables booléennes, puis contraint leur somme par slot à 1 (couverture). C'est la formulation « SAT » canonique que CP-SAT attend.\n",
     "\n",
-    "La formulation **from-scratch** est plus compacte et plus naturelle pour une recherche locale : une seule variable enti\u00e8re par *slot* (jour, shift), dont la valeur est l'indice de l'infirmier assign\u00e9.\n",
+    "La formulation **from-scratch** est plus compacte et plus naturelle pour une recherche locale : une seule variable entière par *slot* (jour, shift), dont la valeur est l'indice de l'infirmier assigné.\n",
     "\n",
     "$$\\texttt{assign}[d][s] \\in \\{0, 1, \\dots, N-1\\}$$\n",
     "\n",
     "- **C1 (couverture)** est **automatiquement satisfaite** : chaque slot contient exactement un infirmier.\n",
-    "- Reste \u00e0 imposer **C2** (un infirmier fait au plus un shift par jour), **C3** (pas de Matin apr\u00e8s une Nuit) et **C4** (charge maximale).\n",
+    "- Reste à imposer **C2** (un infirmier fait au plus un shift par jour), **C3** (pas de Matin après une Nuit) et **C4** (charge maximale).\n",
     "\n",
-    "Ce changement de variables (105 bool\u00e9ens \u2192 21 entiers) est exactement le genre de d\u00e9cision de mod\u00e9lisation qu'OR-Tools masque et qu'un ing\u00e9nieur CSP doit ma\u00eetriser.\n"
+    "Ce changement de variables (105 booléens → 21 entiers) est exactement le genre de décision de modélisation qu'OR-Tools masque et qu'un ingénieur CSP doit maîtriser.\n"
    ]
   },
   {
@@ -170,16 +276,16 @@
    "id": "8b7c7071",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:01:30.746514Z",
-     "iopub.status.busy": "2026-07-06T16:01:30.746350Z",
-     "iopub.status.idle": "2026-07-06T16:01:31.006348Z",
-     "shell.execute_reply": "2026-07-06T16:01:31.006197Z"
+     "iopub.execute_input": "2026-08-11T01:37:30.937949Z",
+     "iopub.status.busy": "2026-08-11T01:37:30.937600Z",
+     "iopub.status.idle": "2026-08-11T01:37:31.377392Z",
+     "shell.execute_reply": "2026-08-11T01:37:31.376926Z"
     },
     "papermill": {
-     "duration": 0.26314,
-     "end_time": "2026-07-06T16:01:31.006421",
+     "duration": 0.446915,
+     "end_time": "2026-08-11T01:37:31.377547",
      "exception": false,
-     "start_time": "2026-07-06T16:01:30.743281",
+     "start_time": "2026-08-11T01:37:30.930632",
      "status": "completed"
     },
     "tags": []
@@ -261,16 +367,16 @@
    "id": "be00c8b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:01:31.013151Z",
-     "iopub.status.busy": "2026-07-06T16:01:31.012930Z",
-     "iopub.status.idle": "2026-07-06T16:01:31.242824Z",
-     "shell.execute_reply": "2026-07-06T16:01:31.242509Z"
+     "iopub.execute_input": "2026-08-11T01:37:31.395395Z",
+     "iopub.status.busy": "2026-08-11T01:37:31.394807Z",
+     "iopub.status.idle": "2026-08-11T01:37:31.685403Z",
+     "shell.execute_reply": "2026-08-11T01:37:31.683437Z"
     },
     "papermill": {
-     "duration": 0.233675,
-     "end_time": "2026-07-06T16:01:31.243002",
+     "duration": 0.301051,
+     "end_time": "2026-08-11T01:37:31.685619",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.009327",
+     "start_time": "2026-08-11T01:37:31.384568",
      "status": "completed"
     },
     "tags": []
@@ -327,18 +433,18 @@
    "id": "53eb14d2",
    "metadata": {
     "papermill": {
-     "duration": 0.00428,
-     "end_time": "2026-07-06T16:01:31.253158",
+     "duration": 0.006151,
+     "end_time": "2026-08-11T01:37:31.699775",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.248878",
+     "start_time": "2026-08-11T01:37:31.693624",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 3. Solveur 1 \u2014 construction gloutonne (baseline)\n",
+    "## 3. Solveur 1 — construction gloutonne (baseline)\n",
     "\n",
-    "On parcourt les slots dans l'ordre et, pour chacun, on choisit l'infirmier **le moins charg\u00e9** qui ne viole ni C2 (d\u00e9j\u00e0 un shift ce jour) ni C3 (Nuit la veille si on place un Matin). Aucun retour arri\u00e8re : c'est rapide mais myope.\n"
+    "On parcourt les slots dans l'ordre et, pour chacun, on choisit l'infirmier **le moins chargé** qui ne viole ni C2 (déjà un shift ce jour) ni C3 (Nuit la veille si on place un Matin). Aucun retour arrière : c'est rapide mais myope.\n"
    ]
   },
   {
@@ -347,16 +453,16 @@
    "id": "5c1e3a6d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:01:31.264297Z",
-     "iopub.status.busy": "2026-07-06T16:01:31.263813Z",
-     "iopub.status.idle": "2026-07-06T16:01:31.361460Z",
-     "shell.execute_reply": "2026-07-06T16:01:31.361283Z"
+     "iopub.execute_input": "2026-08-11T01:37:31.717755Z",
+     "iopub.status.busy": "2026-08-11T01:37:31.717084Z",
+     "iopub.status.idle": "2026-08-11T01:37:31.869723Z",
+     "shell.execute_reply": "2026-08-11T01:37:31.869215Z"
     },
     "papermill": {
-     "duration": 0.103041,
-     "end_time": "2026-07-06T16:01:31.361542",
+     "duration": 0.163013,
+     "end_time": "2026-08-11T01:37:31.869927",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.258501",
+     "start_time": "2026-08-11T01:37:31.706914",
      "status": "completed"
     },
     "tags": []
@@ -440,18 +546,18 @@
    "id": "8a020183",
    "metadata": {
     "papermill": {
-     "duration": 0.003563,
-     "end_time": "2026-07-06T16:01:31.369050",
+     "duration": 0.0093,
+     "end_time": "2026-08-11T01:37:31.888856",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.365487",
+     "start_time": "2026-08-11T01:37:31.879556",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 4. Solveur 2 \u2014 backtracking (faisabilit\u00e9 pure)\n",
+    "## 4. Solveur 2 — backtracking (faisabilité pure)\n",
     "\n",
-    "Question : existe-t-il **un** planning qui satisfait toutes les contraintes dures ? On \u00e9num\u00e8re les slots en profondeur, on essaie chaque infirmier, on \u00e9lague (backtrack) d\u00e8s qu'une contrainte dure est viol\u00e9e sur la partielle. Le premier planning complet trouv\u00e9 est retourn\u00e9. C'est l'\u00e9quivalent explicite de la phase de \u00ab feasible search \u00bb de CP-SAT.\n"
+    "Question : existe-t-il **un** planning qui satisfait toutes les contraintes dures ? On énumère les slots en profondeur, on essaie chaque infirmier, on élague (backtrack) dès qu'une contrainte dure est violée sur la partielle. Le premier planning complet trouvé est retourné. C'est l'équivalent explicite de la phase de « feasible search » de CP-SAT.\n"
    ]
   },
   {
@@ -460,16 +566,16 @@
    "id": "d6300f66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:01:31.378230Z",
-     "iopub.status.busy": "2026-07-06T16:01:31.377963Z",
-     "iopub.status.idle": "2026-07-06T16:01:31.566477Z",
-     "shell.execute_reply": "2026-07-06T16:01:31.566353Z"
+     "iopub.execute_input": "2026-08-11T01:37:31.911845Z",
+     "iopub.status.busy": "2026-08-11T01:37:31.911221Z",
+     "iopub.status.idle": "2026-08-11T01:37:32.083042Z",
+     "shell.execute_reply": "2026-08-11T01:37:32.082815Z"
     },
     "papermill": {
-     "duration": 0.19399,
-     "end_time": "2026-07-06T16:01:31.566536",
+     "duration": 0.184309,
+     "end_time": "2026-08-11T01:37:32.083147",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.372546",
+     "start_time": "2026-08-11T01:37:31.898838",
      "status": "completed"
     },
     "tags": []
@@ -580,25 +686,25 @@
    "id": "3950dfbc",
    "metadata": {
     "papermill": {
-     "duration": 0.002945,
-     "end_time": "2026-07-06T16:01:31.572136",
+     "duration": 0.00623,
+     "end_time": "2026-08-11T01:37:32.096763",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.569191",
+     "start_time": "2026-08-11T01:37:32.090533",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 5. Solveur 3 \u2014 Min-Conflicts (optimisation avec pr\u00e9f\u00e9rences)\n",
+    "## 5. Solveur 3 — Min-Conflicts (optimisation avec préférences)\n",
     "\n",
-    "Le backtracking trouve une solution faisable mais ignore les **pr\u00e9f\u00e9rences**. Pour l'optimisation, on passe \u00e0 la recherche locale. **Min-Conflicts** est l'algorithme classique des CSP :\n",
+    "Le backtracking trouve une solution faisable mais ignore les **préférences**. Pour l'optimisation, on passe à la recherche locale. **Min-Conflicts** est l'algorithme classique des CSP :\n",
     "\n",
-    "1. Partir d'un planning (ici, le r\u00e9sultat glouton).\n",
-    "2. Identifier les slots **en conflit** (impliqu\u00e9s dans une violation dure ou une pr\u00e9f\u00e9rence).\n",
-    "3. Choisir un slot conflit au hasard, et le r\u00e9affecter \u00e0 l'infirmier qui **minimise le co\u00fbt total**.\n",
-    "4. R\u00e9p\u00e9ter. Le co\u00fbt (`BIG \u00d7 dur + souple`) ne fait que guider la marche vers un planning faisable **et** respectueux des pr\u00e9f\u00e9rences.\n",
+    "1. Partir d'un planning (ici, le résultat glouton).\n",
+    "2. Identifier les slots **en conflit** (impliqués dans une violation dure ou une préférence).\n",
+    "3. Choisir un slot conflit au hasard, et le réaffecter à l'infirmier qui **minimise le coût total**.\n",
+    "4. Répéter. Le coût (`BIG × dur + souple`) ne fait que guider la marche vers un planning faisable **et** respectueux des préférences.\n",
     "\n",
-    "Une l\u00e9g\u00e8re stochasticit\u00e9 (choix al\u00e9atoire du slot) \u00e9vite les minima locaux \u2014 c'est l'esprit du *local search* que CP-SAT orchestre diff\u00e9remment (LNS, propagation).\n"
+    "Une légère stochasticité (choix aléatoire du slot) évite les minima locaux — c'est l'esprit du *local search* que CP-SAT orchestre différemment (LNS, propagation).\n"
    ]
   },
   {
@@ -607,16 +713,16 @@
    "id": "b07f66a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:01:31.582581Z",
-     "iopub.status.busy": "2026-07-06T16:01:31.582218Z",
-     "iopub.status.idle": "2026-07-06T16:01:31.699931Z",
-     "shell.execute_reply": "2026-07-06T16:01:31.699681Z"
+     "iopub.execute_input": "2026-08-11T01:37:32.111310Z",
+     "iopub.status.busy": "2026-08-11T01:37:32.110958Z",
+     "iopub.status.idle": "2026-08-11T01:37:32.226919Z",
+     "shell.execute_reply": "2026-08-11T01:37:32.226705Z"
     },
     "papermill": {
-     "duration": 0.122642,
-     "end_time": "2026-07-06T16:01:31.700016",
+     "duration": 0.123522,
+     "end_time": "2026-08-11T01:37:32.227018",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.577374",
+     "start_time": "2026-08-11T01:37:32.103496",
      "status": "completed"
     },
     "tags": []
@@ -717,18 +823,18 @@
    "id": "b2c630c9",
    "metadata": {
     "papermill": {
-     "duration": 0.004104,
-     "end_time": "2026-07-06T16:01:31.708090",
+     "duration": 0.005542,
+     "end_time": "2026-08-11T01:37:32.239104",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.703986",
+     "start_time": "2026-08-11T01:37:32.233562",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 6. Benchmark \u2014 faire valoir le moteur (Prong B #3801)\n",
+    "## 6. Benchmark — faire valoir le moteur (Prong B #3801)\n",
     "\n",
-    "Un notebook qui d\u00e9montre des solveurs doit les confronter \u00e0 un probl\u00e8me **assez riche** pour les distinguer. Ici, on compare les trois moteurs sur le co\u00fbt final (violations dures \u00d7 `BIG` + pr\u00e9f\u00e9rences) et le nombre d'it\u00e9rations. Le min-conflicts doit battre le glouton sur l'objectif souple tout en atteignant la faisabilit\u00e9 (co\u00fbt dur = 0).\n"
+    "Un notebook qui démontre des solveurs doit les confronter à un problème **assez riche** pour les distinguer. Ici, on compare les trois moteurs sur le coût final (violations dures × `BIG` + préférences) et le nombre d'itérations. Le min-conflicts doit battre le glouton sur l'objectif souple tout en atteignant la faisabilité (coût dur = 0).\n"
    ]
   },
   {
@@ -737,16 +843,16 @@
    "id": "a0c94a63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:01:31.717566Z",
-     "iopub.status.busy": "2026-07-06T16:01:31.717308Z",
-     "iopub.status.idle": "2026-07-06T16:01:31.819387Z",
-     "shell.execute_reply": "2026-07-06T16:01:31.819068Z"
+     "iopub.execute_input": "2026-08-11T01:37:32.252763Z",
+     "iopub.status.busy": "2026-08-11T01:37:32.252449Z",
+     "iopub.status.idle": "2026-08-11T01:37:32.361361Z",
+     "shell.execute_reply": "2026-08-11T01:37:32.361130Z"
     },
     "papermill": {
-     "duration": 0.107654,
-     "end_time": "2026-07-06T16:01:31.819546",
+     "duration": 0.116398,
+     "end_time": "2026-08-11T01:37:32.361463",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.711892",
+     "start_time": "2026-08-11T01:37:32.245065",
      "status": "completed"
     },
     "tags": []
@@ -805,27 +911,517 @@
    "id": "94a2068e",
    "metadata": {
     "papermill": {
-     "duration": 0.003437,
-     "end_time": "2026-07-06T16:01:31.826769",
+     "duration": 0.005284,
+     "end_time": "2026-08-11T01:37:32.372377",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.823332",
+     "start_time": "2026-08-11T01:37:32.367093",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 7. Compl\u00e9mentarit\u00e9 avec le twin Python (#3801 Prong B)\n",
+    "## 7. Complémentarité avec le twin Python (#3801 Prong B)\n",
     "\n",
     "| Aspect | Twin Python (App-3) | Twin C# (ici) |\n",
     "|--------|---------------------|----------------|\n",
-    "| Solveur | **OR-Tools CP-SAT** (`cp_model`) \u2014 solveur industriel | **3 moteurs from-scratch** (glouton, backtracking, min-conflicts) |\n",
-    "| Mod\u00e9lisation | 105 bool\u00e9ens $x[n][d][s]$ + contraintes `add(...)` | 21 entiers `assign[d][s]` (C1 auto-satisfaite) |\n",
-    "| Optimisation | `model.minimize(...)` (bo\u00eete noire) | **marche guid\u00e9e par le co\u00fbt** explicite (min-conflicts) |\n",
-    "| D\u00e9pendances | `ortools` (native) | **BCL seule, 0 NuGet** |\n",
+    "| Solveur | **OR-Tools CP-SAT** (`cp_model`) — solveur industriel | **3 moteurs from-scratch** (glouton, backtracking, min-conflicts) |\n",
+    "| Modélisation | 105 booléens $x[n][d][s]$ + contraintes `add(...)` | 21 entiers `assign[d][s]` (C1 auto-satisfaite) |\n",
+    "| Optimisation | `model.minimize(...)` (boîte noire) | **marche guidée par le coût** explicite (min-conflicts) |\n",
+    "| Dépendances | `ortools` (native) | **BCL seule, 0 NuGet** |\n",
     "\n",
-    "\u2605 Ce twin ne remplace pas CP-SAT (qui reste l'outil SOTA de production). Il rend **visible** ce que CP-SAT orchestre : la d\u00e9cision de mod\u00e9lisation (bool\u00e9ens vs entiers), la s\u00e9paration faisabilit\u00e9/optimisation, et la m\u00e9canique de la recherche locale. C'est le c\u0153ur p\u00e9dagogique du Prong B.\n",
+    "★ Ce twin ne remplace pas CP-SAT (qui reste l'outil SOTA de production). Il rend **visible** ce que CP-SAT orchestre : la décision de modélisation (booléens vs entiers), la séparation faisabilité/optimisation, et la mécanique de la recherche locale. C'est le cœur pédagogique du Prong B.\n",
     "\n",
-    "Le twin Python reste la r\u00e9f\u00e9rence pour le calcul industriel \u00e0 grande \u00e9chelle (son notebook pousse le probl\u00e8me \u00ab \u00e0 grande \u00e9chelle \u00bb avec courbe de convergence CP-SAT) ; ce twin C# se concentre sur la **lisibilit\u00e9 des algorithmes**.\n"
+    "Le twin Python reste la référence pour le calcul industriel à grande échelle (son notebook pousse le problème « à grande échelle » avec courbe de convergence CP-SAT) ; ce twin C# se concentre sur la **lisibilité des algorithmes**.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "app3-tranche2-md-1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005059,
+     "end_time": "2026-08-11T01:37:32.382648",
+     "exception": false,
+     "start_time": "2026-08-11T01:37:32.377589",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Tranche 2 : parité lib-vs-lib via Google.OrTools CP-SAT\n",
+    "\n",
+    "La **Tranche 1** ci-dessus (sections 2–5) réimplémente *from-scratch* trois moteurs — glouton, backtracking, Min-Conflicts — en BCL pure, 0 NuGet. C'est ce que la §7 « Complémentarité » décrit : rendre **visible** la décision de modélisation et la mécanique de la recherche locale que CP-SAT orchestre en boîte noire. La §7 annonçait CP-SAT comme l'outil SOTA que ce twin C# « ne remplace pas ».\n",
+    "\n",
+    "La **Tranche 2** franchit le même cap que le jumeau Python : invoquer ce moteur de production plutôt que de le laisser de l'autre côté du miroir. Le jumeau Python appelle `ortools.sat.python.cp_model` ; côté .NET, Google publie le **même solveur CP-SAT** sous le package NuGet `Google.OrTools`. La parité est **lib-vs-lib** : le même moteur (Lazy Clause Generation, propagation de bornes) des deux côtés.\n",
+    "\n",
+    "Le modèle CP-SAT du Nurse Rostering tient en **quatre familles de contraintes** (une par règle métier) — c'est la formulation canonique reconnue, identique à celle du jumeau Python (`App-3-NurseScheduling.ipynb` cellules C1–C4) :\n",
+    "\n",
+    "| Règle | Contrainte CP-SAT | Sens |\n",
+    "|-------|-------------------|------|\n",
+    "| **C1 Couverture** | `Add(Sum(x[n,d,s] pour tout n) == demand)` | exactement `demand` infirmier(s) par (jour, shift) |\n",
+    "| **C2 Unicité** | `Add(Sum(x[n,d,s] pour tout s) <= 1)` | au plus un shift par (infirmier, jour) |\n",
+    "| **C3 Repos** | `Add(x[n,d,NUIT] + x[n,d+1,MATIN] <= 1)` | pas de Matin après une Nuit |\n",
+    "| **C4 Charge max** | `Add(Sum(x[n,d,s] pour tout d,s) <= max_shifts)` | charge hebdo bornée |\n",
+    "\n",
+    "avec `x[n][d][s]` = variable booléenne (1 ssi l'infirmier `n` travaille le shift `s` le jour `d`), sur la **même instance** que la Tranche 1 : 5 infirmiers × 7 jours × 3 shifts, `demand = 1`, `max_shifts = 5`. Le solveur fait le reste — là où la Tranche 1 devait encoder la stratégie de parcours (glouton, retour-arrière, réparation Min-Conflicts).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "app3-tranche2-code-1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T01:37:32.394174Z",
+     "iopub.status.busy": "2026-08-11T01:37:32.393904Z",
+     "iopub.status.idle": "2026-08-11T01:37:36.392703Z",
+     "shell.execute_reply": "2026-08-11T01:37:36.392501Z"
+    },
+    "papermill": {
+     "duration": 4.005134,
+     "end_time": "2026-08-11T01:37:36.392796",
+     "exception": false,
+     "start_time": "2026-08-11T01:37:32.387662",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Google.OrTools, 9.15.6755</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CP-SAT NurseScheduling : status=Optimal, temps=78,8 ms\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Variables booleennes   : 105  (= jumeau Python x[n][d][s])\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Planning CP-SAT (lignes = jours, colonnes = equipes) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "jour      "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Matin         "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Apres-midi    "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nuit          "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lun       "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Emma          "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bob           "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Alice         "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mar       "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Emma          "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Alice         "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bob           "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mer       "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Emma          "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Claire        "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bob           "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jeu       "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Alice         "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Claire        "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Emma          "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ven       "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Claire        "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Alice         "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "David         "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sam       "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bob           "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "David         "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Alice         "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dim       "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Claire        "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bob           "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "David         "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Total shifts assignes : 21 / 21  (couverture C1 = 1/shift verifiee)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Charge par infirmier (C4 <= 5) : 5, 5, 4, 3, 4\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#r \"nuget: Google.OrTools\"\n",
+    "using Google.OrTools.Sat;\n",
+    "using System.Diagnostics;\n",
+    "\n",
+    "// --- Instance canonique (MEME que Tranche 1 cell2 + jumeau Python) ---\n",
+    "// N=5 infirmiers, D=7 jours, S=3 shifts, demand=1, max_shifts=5\n",
+    "int Nn = nurses.Length, Dd = days.Length, Ss = shifts.Length;\n",
+    "const int DEMAND = 1, MAX_SHIFTS = 5;\n",
+    "\n",
+    "// --- Variables : x[n,d,s] = infirmier n travaille shift s le jour d (booleen) ---\n",
+    "var model = new CpModel();\n",
+    "var x = new BoolVar[Nn, Dd, Ss];\n",
+    "for (int n = 0; n < Nn; n++)\n",
+    "    for (int d = 0; d < Dd; d++)\n",
+    "        for (int s = 0; s < Ss; s++)\n",
+    "            x[n, d, s] = model.NewBoolVar($\"x_{n}_{d}_{s}\");\n",
+    "\n",
+    "// --- C1 : Couverture - exactement DEMAND infirmier par (jour, shift) ---\n",
+    "for (int d = 0; d < Dd; d++)\n",
+    "    for (int s = 0; s < Ss; s++)\n",
+    "    {\n",
+    "        var cov = new BoolVar[Nn];\n",
+    "        for (int n = 0; n < Nn; n++) cov[n] = x[n, d, s];\n",
+    "        model.Add(LinearExpr.Sum(cov) == DEMAND);\n",
+    "    }\n",
+    "\n",
+    "// --- C2 : Unicite - au plus 1 shift par (infirmier, jour) ---\n",
+    "for (int n = 0; n < Nn; n++)\n",
+    "    for (int d = 0; d < Dd; d++)\n",
+    "    {\n",
+    "        var day = new BoolVar[Ss];\n",
+    "        for (int s = 0; s < Ss; s++) day[s] = x[n, d, s];\n",
+    "        model.Add(LinearExpr.Sum(day) <= 1);\n",
+    "    }\n",
+    "\n",
+    "// --- C3 : Repos - pas de Matin apres une Nuit ---\n",
+    "for (int n = 0; n < Nn; n++)\n",
+    "    for (int d = 0; d < Dd - 1; d++)\n",
+    "        model.Add((x[n, d, NUIT] + x[n, d + 1, MATIN]) <= 1);\n",
+    "\n",
+    "// --- C4 : Charge max - au plus MAX_SHIFTS par infirmier / semaine ---\n",
+    "for (int n = 0; n < Nn; n++)\n",
+    "{\n",
+    "    var load = new BoolVar[Dd * Ss];\n",
+    "    int kk = 0;\n",
+    "    for (int d = 0; d < Dd; d++)\n",
+    "        for (int s = 0; s < Ss; s++) load[kk++] = x[n, d, s];\n",
+    "    model.Add(LinearExpr.Sum(load) <= MAX_SHIFTS);\n",
+    "}\n",
+    "\n",
+    "// --- Resolution ---\n",
+    "var solver = new CpSolver();\n",
+    "solver.StringParameters = \"max_time_in_seconds:10\";\n",
+    "var sw = Stopwatch.StartNew();\n",
+    "var st = solver.Solve(model);\n",
+    "sw.Stop();\n",
+    "Console.WriteLine($\"CP-SAT NurseScheduling : status={st}, temps={sw.Elapsed.TotalMilliseconds:F1} ms\");\n",
+    "Console.WriteLine($\"Variables booleennes   : {Nn * Dd * Ss}  (= jumeau Python x[n][d][s])\");\n",
+    "\n",
+    "// --- Affichage du planning (jour x shift -> infirmier) ---\n",
+    "if (st is CpSolverStatus.Feasible or CpSolverStatus.Optimal)\n",
+    "{\n",
+    "    Console.WriteLine(\"\\nPlanning CP-SAT (lignes = jours, colonnes = equipes) :\");\n",
+    "    Console.Write($\"{\"jour\",-10}\");\n",
+    "    foreach (var sh in shifts) Console.Write($\"{sh,-14}\");\n",
+    "    Console.WriteLine();\n",
+    "    int assigned = 0;\n",
+    "    var perNurse = new int[Nn];\n",
+    "    for (int d = 0; d < Dd; d++)\n",
+    "    {\n",
+    "        Console.Write($\"{days[d],-10}\");\n",
+    "        for (int s = 0; s < Ss; s++)\n",
+    "        {\n",
+    "            string cell = \"-\";\n",
+    "            for (int n = 0; n < Nn; n++)\n",
+    "                if (solver.Value(x[n, d, s]) == 1) { cell = nurses[n]; assigned++; perNurse[n]++; break; }\n",
+    "            Console.Write($\"{cell,-14}\");\n",
+    "        }\n",
+    "        Console.WriteLine();\n",
+    "    }\n",
+    "    Console.WriteLine($\"\\nTotal shifts assignes : {assigned} / {Dd * Ss}  (couverture C1 = 1/shift verifiee)\");\n",
+    "    Console.WriteLine(\"Charge par infirmier (C4 <= 5) : \" + string.Join(\", \", perNurse));\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "app3-tranche2-md-2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007675,
+     "end_time": "2026-08-11T01:37:36.407965",
+     "exception": false,
+     "start_time": "2026-08-11T01:37:36.400290",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : lib-vs-lib et rôle du moteur\n",
+    "\n",
+    "- **Parité de statut avec le jumeau Python.** Le solveur CP-SAT .NET atteint `OPTIMAL` ou `FEASIBLE` sur la même instance que le jumeau Python (lui déclare `OPTIMAL` en ~30 ms). Les quatre familles de contraintes (C1–C4) sont les **mêmes sémantiquement** : couverture exacte, unicité par jour, repos Nuit→Matin, charge hebdo bornée. Un planning faisable est produit côté C# comme côté Python — la parité est **chiffre-à-chiffre sur le statut et la couverture** (21 shifts assignés = `D×S`, une infirmière par slot).\n",
+    "- **Tranche 1 vs Tranche 2 = pédagogie vs production.** La Tranche 1 (§2–5) rend *visible* la mécanique : le glouton ordonnance, le backtracking retourne-arrière, Min-Conflicts répare. La Tranche 2 délègue tout cela au moteur CP-SAT, qui apporte la propagation de bornes et la Lazy Clause Generation — le même rôle que `ortools.sat.python.cp_model` joue côté Python. C'est précisément le pont que la §7 « Complémentarité » annonçait comme l'atout du twin Python : il est désormais matérialisé côté C#.\n",
+    "- **Booléens vs entiers : la décision de modélisation.** La Tranche 1 cell2 a choisi `assign[d][s]` (entier = index d'infirmier), ce qui auto-satisfait C1 (un seul infirmier par slot). La Tranche 2, comme le jumeau Python, choisit `x[n][d][s]` booléen (105 variables) — formulation où C1 devient une contrainte explicite `Sum == demand`. Les deux modélisations sont légitimes ; la booléenne est celle du moteur industriel (elle se prête à l'optimisation pondérée via coefficients sur les variables, comme le jumeau Python le fait pour les préférences avec `Minimize`).\n",
+    "- **Pourquoi quatre contraintes suffisent.** C'est la force déclarative de la programmation par contraintes : l'énoncé métier (couverture, unicité, repos, charge) se traduit littéralement en quatre groupes de contraintes linéaires sur les booléens, sans encoder le moindre mécanisme de parcours. Le solveur dérive lui-même la stratégie — là où la Tranche 1 a dû l'expliciter (heuristique gloutonne, ordre de branchement, fonction de coût Min-Conflicts).\n",
+    "\n",
+    "C'est exactement la parité demandée par l'EPIC #10382 : les deux jumeaux atteignent désormais un **moteur de production** de leur écosystème (`ortools.sat` côté Python, `Google.OrTools` côté .NET), la réimplémentation pédagogique étant conservée *en plus*, jamais *à la place*.\n"
    ]
   },
   {
@@ -833,10 +1429,10 @@
    "id": "aecff2ac",
    "metadata": {
     "papermill": {
-     "duration": 0.003521,
-     "end_time": "2026-07-06T16:01:31.833978",
+     "duration": 0.008913,
+     "end_time": "2026-08-11T01:37:36.425166",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.830457",
+     "start_time": "2026-08-11T01:37:36.416253",
      "status": "completed"
     },
     "tags": []
@@ -844,7 +1440,7 @@
    "source": [
     "## 8. Exercices\n",
     "\n",
-    "Les trois exercices reprennent les extensions du twin Python. Chaque stub est \u00e0 compl\u00e9ter : l'objectif et le squelette sont donn\u00e9s, la logique m\u00e9tier est \u00e0 \u00e9crire.\n"
+    "Les trois exercices reprennent les extensions du twin Python. Chaque stub est à compléter : l'objectif et le squelette sont donnés, la logique métier est à écrire.\n"
    ]
   },
   {
@@ -852,38 +1448,38 @@
    "id": "ae942659",
    "metadata": {
     "papermill": {
-     "duration": 0.003428,
-     "end_time": "2026-07-06T16:01:31.841068",
+     "duration": 0.010497,
+     "end_time": "2026-08-11T01:37:36.444940",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.837640",
+     "start_time": "2026-08-11T01:37:36.434443",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 1 \u2014 Limite configurable de jours cons\u00e9cutifs\n",
+    "### Exercice 1 — Limite configurable de jours consécutifs\n",
     "\n",
-    "Le planning de base n'impose pas de limite de jours **consutifs** travaill\u00e9s. Un infirmier pourrait encha\u00eener 7 jours. Ajoutez une contrainte **C5** : au plus `maxConsec` jours cons\u00e9cutifs.\n",
+    "Le planning de base n'impose pas de limite de jours **consutifs** travaillés. Un infirmier pourrait enchaîner 7 jours. Ajoutez une contrainte **C5** : au plus `maxConsec` jours consécutifs.\n",
     "\n",
-    "**Indice** : pour chaque infirmier, comptez les runs de jours o\u00f9 il a au moins un shift ; un run d\u00e9passant `maxConsec` est une violation. Ajoutez ce compte \u00e0 `HardViolations` et testez avec `maxConsec = 3`.\n"
+    "**Indice** : pour chaque infirmier, comptez les runs de jours où il a au moins un shift ; un run dépassant `maxConsec` est une violation. Ajoutez ce compte à `HardViolations` et testez avec `maxConsec = 3`.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "ab6173b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:01:31.849235Z",
-     "iopub.status.busy": "2026-07-06T16:01:31.849025Z",
-     "iopub.status.idle": "2026-07-06T16:01:31.929600Z",
-     "shell.execute_reply": "2026-07-06T16:01:31.929443Z"
+     "iopub.execute_input": "2026-08-11T01:37:36.466005Z",
+     "iopub.status.busy": "2026-08-11T01:37:36.465543Z",
+     "iopub.status.idle": "2026-08-11T01:37:36.545975Z",
+     "shell.execute_reply": "2026-08-11T01:37:36.545592Z"
     },
     "papermill": {
-     "duration": 0.085219,
-     "end_time": "2026-07-06T16:01:31.929675",
+     "duration": 0.091343,
+     "end_time": "2026-08-11T01:37:36.546131",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.844456",
+     "start_time": "2026-08-11T01:37:36.454788",
      "status": "completed"
     },
     "tags": []
@@ -922,36 +1518,36 @@
    "id": "e3f2b40b",
    "metadata": {
     "papermill": {
-     "duration": 0.003283,
-     "end_time": "2026-07-06T16:01:31.936579",
+     "duration": 0.009203,
+     "end_time": "2026-08-11T01:37:36.563663",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.933296",
+     "start_time": "2026-08-11T01:37:36.554460",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 2 \u2014 Pr\u00e9f\u00e9rences pond\u00e9r\u00e9es par priorit\u00e9\n",
+    "### Exercice 2 — Préférences pondérées par priorité\n",
     "\n",
-    "Jusqu'ici chaque pr\u00e9f\u00e9rence viol\u00e9e co\u00fbte `PREF_PENALTY = 2`. En pratique, Alice d\u00e9teste plus le samedi matin que le dimanche apr\u00e8s-midi. Donnez \u00e0 chaque pr\u00e9f\u00e9rence un **poids propre**, et modifiez `SoftPenalty` pour sommer les poids.\n"
+    "Jusqu'ici chaque préférence violée coûte `PREF_PENALTY = 2`. En pratique, Alice déteste plus le samedi matin que le dimanche après-midi. Donnez à chaque préférence un **poids propre**, et modifiez `SoftPenalty` pour sommer les poids.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "931cafeb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:01:31.944352Z",
-     "iopub.status.busy": "2026-07-06T16:01:31.944147Z",
-     "iopub.status.idle": "2026-07-06T16:01:31.987208Z",
-     "shell.execute_reply": "2026-07-06T16:01:31.987083Z"
+     "iopub.execute_input": "2026-08-11T01:37:36.581456Z",
+     "iopub.status.busy": "2026-08-11T01:37:36.581159Z",
+     "iopub.status.idle": "2026-08-11T01:37:36.630908Z",
+     "shell.execute_reply": "2026-08-11T01:37:36.630675Z"
     },
     "papermill": {
-     "duration": 0.047409,
-     "end_time": "2026-07-06T16:01:31.987269",
+     "duration": 0.05961,
+     "end_time": "2026-08-11T01:37:36.631011",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.939860",
+     "start_time": "2026-08-11T01:37:36.571401",
      "status": "completed"
     },
     "tags": []
@@ -989,36 +1585,36 @@
    "id": "dbbb820e",
    "metadata": {
     "papermill": {
-     "duration": 0.002825,
-     "end_time": "2026-07-06T16:01:31.993037",
+     "duration": 0.008004,
+     "end_time": "2026-08-11T01:37:36.647024",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.990212",
+     "start_time": "2026-08-11T01:37:36.639020",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 3 \u2014 Contrats \u00e0 temps partiel (min/max par infirmier)\n",
+    "### Exercice 3 — Contrats à temps partiel (min/max par infirmier)\n",
     "\n",
-    "Certains infirmiers sont \u00e0 temps partiel : un **minimum** de shifts (garanti par contrat) et un **maximum** plus strict que `MAX_SHIFTS`. Ajoutez une contrainte par infirmier `(minShifts, maxShifts)` et int\u00e9grez-la au validateur.\n"
+    "Certains infirmiers sont à temps partiel : un **minimum** de shifts (garanti par contrat) et un **maximum** plus strict que `MAX_SHIFTS`. Ajoutez une contrainte par infirmier `(minShifts, maxShifts)` et intégrez-la au validateur.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "982b50ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:01:31.999667Z",
-     "iopub.status.busy": "2026-07-06T16:01:31.999504Z",
-     "iopub.status.idle": "2026-07-06T16:01:32.052022Z",
-     "shell.execute_reply": "2026-07-06T16:01:32.051885Z"
+     "iopub.execute_input": "2026-08-11T01:37:36.664919Z",
+     "iopub.status.busy": "2026-08-11T01:37:36.664377Z",
+     "iopub.status.idle": "2026-08-11T01:37:36.712875Z",
+     "shell.execute_reply": "2026-08-11T01:37:36.712659Z"
     },
     "papermill": {
-     "duration": 0.056286,
-     "end_time": "2026-07-06T16:01:32.052087",
+     "duration": 0.058187,
+     "end_time": "2026-08-11T01:37:36.712979",
      "exception": false,
-     "start_time": "2026-07-06T16:01:31.995801",
+     "start_time": "2026-08-11T01:37:36.654792",
      "status": "completed"
     },
     "tags": []
@@ -1055,10 +1651,10 @@
    "id": "d2ead9ed",
    "metadata": {
     "papermill": {
-     "duration": 0.002864,
-     "end_time": "2026-07-06T16:01:32.058092",
+     "duration": 0.007772,
+     "end_time": "2026-08-11T01:37:36.730956",
      "exception": false,
-     "start_time": "2026-07-06T16:01:32.055228",
+     "start_time": "2026-08-11T01:37:36.723184",
      "status": "completed"
     },
     "tags": []
@@ -1066,15 +1662,15 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce twin C# a d\u00e9roul\u00e9 **trois solveurs from-scratch** sur le Nurse Rostering Problem :\n",
+    "Ce twin C# a déroulé **trois solveurs from-scratch** sur le Nurse Rostering Problem :\n",
     "\n",
-    "- Le **glouton** est rapide mais myope : il atteint la faisabilit\u00e9 (co\u00fbt dur = 0), mais faute de retour arri\u00e8re il n'optimise pas les pr\u00e9f\u00e9rences \u2014 4 viol\u00e9es, le plus mauvais des trois solveurs.\n",
-    "- Le **backtracking** garantit la **faisabilit\u00e9** (un planning valide) mais ignore l'optimisation.\n",
-    "- Le **min-conflicts** atteint la faisabilit\u00e9 **et** minimise les pr\u00e9f\u00e9rences, en se laissant guider par le co\u00fbt.\n",
+    "- Le **glouton** est rapide mais myope : il atteint la faisabilité (coût dur = 0), mais faute de retour arrière il n'optimise pas les préférences — 4 violées, le plus mauvais des trois solveurs.\n",
+    "- Le **backtracking** garantit la **faisabilité** (un planning valide) mais ignore l'optimisation.\n",
+    "- Le **min-conflicts** atteint la faisabilité **et** minimise les préférences, en se laissant guider par le coût.\n",
     "\n",
-    "La d\u00e9cision de mod\u00e9lisation (une variable enti\u00e8re par slot plut\u00f4t que 105 bool\u00e9ens) est l'autre le\u00e7on cl\u00e9 : elle rend C1 triviale et ouvre la voie \u00e0 la recherche locale. Le twin Python (OR-Tools CP-SAT) reste l'outil de production ; ce twin rend explicite la m\u00e9canique que CP-SAT encapsule \u2014 c'est tout l'enjeu du Prong B du marathon #4956.\n",
+    "La décision de modélisation (une variable entière par slot plutôt que 105 booléens) est l'autre leçon clé : elle rend C1 triviale et ouvre la voie à la recherche locale. Le twin Python (OR-Tools CP-SAT) reste l'outil de production ; ce twin rend explicite la mécanique que CP-SAT encapsule — c'est tout l'enjeu du Prong B du marathon #4956.\n",
     "\n",
-    "**Pour aller plus loin** : comparez les temps de r\u00e9solution du min-conflicts (from-scratch) et de CP-SAT (twin Python) sur le probl\u00e8me \u00ab \u00e0 grande \u00e9chelle \u00bb \u2014 vous mesurerez alors concr\u00e8tement pourquoi un solveur industriel reste pertinent malgr\u00e9 la lisibilit\u00e9 des algorithmes faits maison.\n"
+    "**Pour aller plus loin** : comparez les temps de résolution du min-conflicts (from-scratch) et de CP-SAT (twin Python) sur le problème « à grande échelle » — vous mesurerez alors concrètement pourquoi un solveur industriel reste pertinent malgré la lisibilité des algorithmes faits maison.\n"
    ]
   },
   {
@@ -1082,10 +1678,10 @@
    "id": "c38c1334",
    "metadata": {
     "papermill": {
-     "duration": 0.002746,
-     "end_time": "2026-07-06T16:01:32.063574",
+     "duration": 0.009484,
+     "end_time": "2026-08-11T01:37:36.748491",
      "exception": false,
-     "start_time": "2026-07-06T16:01:32.060828",
+     "start_time": "2026-08-11T01:37:36.739007",
      "status": "completed"
     },
     "tags": []
@@ -1095,7 +1691,7 @@
     "\n",
     "**Navigation** : [<< App-2b GraphColoring-CSharp](App-2b-GraphColoring-CSharp.ipynb) | [Index](../README.md) | [App-3 Python (OR-Tools) >>](App-3-NurseScheduling.ipynb)\n",
     "\n",
-    "*Marathon #4956 \u2014 parit\u00e9 .NET \u21c4 Python. Voir EPIC #3801 (axe-2 SOTA).*\n"
+    "*Marathon #4956 — parité .NET ⇄ Python. Voir EPIC #3801 (axe-2 SOTA).*\n"
    ]
   }
  ],
@@ -1114,14 +1710,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.525827,
-   "end_time": "2026-07-06T16:01:32.198360",
+   "duration": 11.051163,
+   "end_time": "2026-08-11T01:37:37.002783",
    "environment_variables": {},
    "exception": null,
    "input_path": "App-3b-NurseScheduling-CSharp.ipynb",
-   "output_path": "app3b_exec.ipynb",
+   "output_path": "app3_out.ipynb",
    "parameters": {},
-   "start_time": "2026-07-06T16:01:26.672533",
+   "start_time": "2026-08-11T01:37:25.951620",
    "version": "2.6.0"
   }
  },

--- a/scripts/notebook_tools/twin_pairs.d/app-3-nursescheduling.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-3-nursescheduling.yaml
@@ -14,6 +14,12 @@
       csharp_sha: 52f7b50aa5d1f9553673ecce518df546dd4c1f93
       content_python_sha: b5cbd82694075843973d66e038023af6e204eb2c5ed5e46c8bdcaeec4f188ed6
       content_csharp_sha: c67f15539798cbcd5300e1b720a38a8b768191fb6ada5ba7ccf5f6936401a3d0
+    - date: "2026-08-11"
+      by: myia-po-2025:CoursIA
+      python_sha: 9dccc85f12b400cdef4b3186016abcda10dffd0b
+      csharp_sha: 7b105336ba11fb4be0ae1c52458f068c3a051189
+      content_python_sha: b5cbd82694075843973d66e038023af6e204eb2c5ed5e46c8bdcaeec4f188ed6
+      content_csharp_sha: 7e7fad00ffe3c2fef8fe1c69973fee44dc25ab73f4516a5e859dc7fe8b44ea14
   known_differences:
     - "Bibliotheque vs from-scratch puis lib-vs-lib : Python invoque OR-Tools CP-SAT (cp_model, 105 booleens x[n][d][s] + contraintes add(...), model.minimize pour les preferences) comme solveur SOTA. C# = deux tranches -- Tranche 1 (sections 2-5) reimplementation from-scratch pedagogique (3 solveurs : glouton, backtracking, Min-Conflicts, en BCL pure System.* 0 NuGet) PRESERVEE integralement ; Tranche 2 (PR #10382 cycle 13) ajoute Google.OrTools 9.15 (.NET natif, deja en service dans Sudoku-10/18, App-8, App-15b, App-1) avec le MEME modele canonique CP-SAT que le Python (4 contraintes C1-C4 : couverture Sum==demand, unicite Sum<=1, repos Nuit->Matin, charge max <= 5, sur 105 booleens x[n][d][s]) sur la MEME instance (5 infirmiers x 7 jours x 3 shifts). parite verifiee : status=Optimal (= Python OPTIMAL 30ms), 21/21 shifts assignes, charge [5,5,4,3,4] toutes <= 5. parity_level=native-both (Python/ortools ET C#/Google.OrTools atteignent chacun le moteur de production CP-SAT de leur ecosysteme)."
     - "Asymetrie de couverture : Python (matplotlib gantt + experimentation a grande echelle avec courbe de convergence CP-SAT + search_helpers) ; C# (27 cellules : 3 solveurs from-scratch Tranche 1 + pont CP-SAT Tranche 2 + 3 exercices + visualisation ASCII). La visualisation matplotlib et le benchmark a grande echelle restent propres au Python ; la parite porte sur le solveur SOTA (CP-SAT) et le socle theorique (C1-C4)."

--- a/scripts/notebook_tools/twin_pairs.d/app-3-nursescheduling.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-3-nursescheduling.yaml
@@ -2,7 +2,7 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-3b-NurseScheduling-CSharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -15,6 +15,6 @@
       content_python_sha: b5cbd82694075843973d66e038023af6e204eb2c5ed5e46c8bdcaeec4f188ed6
       content_csharp_sha: c67f15539798cbcd5300e1b720a38a8b768191fb6ada5ba7ccf5f6936401a3d0
   known_differences:
-    - "Socle pedagogique commun : Planning d'infirmieres (CSP : contraintes horaires, preferences, couverture) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
-    - "Idiomes framework : Python = OR-Tools CP-SAT + matplotlib gantt + search_helpers ; C# = BCL pure (System.*), 0 NuGet."
-    - "Asymetrie pedagogique : Python met l'accent sur le solveur SOTA (OR-Tools CP-SAT / library specialisee) + visualisation matplotlib + experimentation comparative ; le C# demontre l'implementation from-scratch en BCL pure (ou binding NuGet du meme solver pour App-8/10/15), presentation compacte. Meme socle theorique, leviers de demonstration differents."
+    - "Bibliotheque vs from-scratch puis lib-vs-lib : Python invoque OR-Tools CP-SAT (cp_model, 105 booleens x[n][d][s] + contraintes add(...), model.minimize pour les preferences) comme solveur SOTA. C# = deux tranches -- Tranche 1 (sections 2-5) reimplementation from-scratch pedagogique (3 solveurs : glouton, backtracking, Min-Conflicts, en BCL pure System.* 0 NuGet) PRESERVEE integralement ; Tranche 2 (PR #10382 cycle 13) ajoute Google.OrTools 9.15 (.NET natif, deja en service dans Sudoku-10/18, App-8, App-15b, App-1) avec le MEME modele canonique CP-SAT que le Python (4 contraintes C1-C4 : couverture Sum==demand, unicite Sum<=1, repos Nuit->Matin, charge max <= 5, sur 105 booleens x[n][d][s]) sur la MEME instance (5 infirmiers x 7 jours x 3 shifts). parite verifiee : status=Optimal (= Python OPTIMAL 30ms), 21/21 shifts assignes, charge [5,5,4,3,4] toutes <= 5. parity_level=native-both (Python/ortools ET C#/Google.OrTools atteignent chacun le moteur de production CP-SAT de leur ecosysteme)."
+    - "Asymetrie de couverture : Python (matplotlib gantt + experimentation a grande echelle avec courbe de convergence CP-SAT + search_helpers) ; C# (27 cellules : 3 solveurs from-scratch Tranche 1 + pont CP-SAT Tranche 2 + 3 exercices + visualisation ASCII). La visualisation matplotlib et le benchmark a grande echelle restent propres au Python ; la parite porte sur le solveur SOTA (CP-SAT) et le socle theorique (C1-C4)."
+    - "Idiomes framework : Python = OR-Tools CP-SAT (cp_model.CpModel, model.add, solver.parameters.max_time_in_seconds, model.minimize) ; C# = Google.OrTools.Sat (CpModel, model.Add(LinearExpr.Sum(...)), solver.StringParameters='max_time_in_seconds:N') + from-scratch System.*. Meme socle theorique (Nurse Rostering CSP, 4 familles de contraintes C1-C4, variables booleennes x[n][d][s]). Le C# valorise la reimplementation pedagogique (Tranche 1) ET l'invocation du moteur SOTA (Tranche 2)."


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2025:CoursIA — prev: DEEP/notebook-dotnet #10392

See #10382, See #4956, See #3801

## Summary

EPIC #10382 (lib-vs-lib parity), family **Search/Applications**, dispatched to this lane by ai-01 (provisioning DM msg-20260811T002048, trio App-1/App-3/App-4 — App-1 delivered #10392, App-3 here). The C# twin `App-3b-NurseScheduling-CSharp.ipynb` carried its cross-lang parity with the Python/OR-Tools twin **in prose only** — all 10 code cells were 3 from-scratch solvers (greedy, backtracking, min-conflicts) in pure `System.*` BCL, 0 NuGet. The §7 "Complémentarité" cell explicitly framed it as "Ce twin ne remplace pas CP-SAT (qui reste l'outil SOTA de production)". This PR adds the missing **Tranche 2** on the Search-15 / App-1 gabarit: invoke the production .NET engine **Google.OrTools** (CP-SAT) on the SAME nurse-rostering instance, and verify lib-vs-lib parity.

## The defect (firsthand, measured on origin/main)

`scripts/notebook_tools/twin_pairs.d/app-3-nursescheduling.yaml` registered `parity_level: semantic` with known_differences *"C# = BCL pure (System.*), 0 NuGet"* while *"Python = OR-Tools CP-SAT"*. A grep on the C# twin's code cells for `#r`, `Google.OrTools`, `CpModel`, `CpSolver` → **0 hits**. The C# side reached no engine; the Python side reaches `ortools.sat.python.cp_model`. That is exactly the #10382 finding (51 pairs where C# bridges no engine, Python does).

## Tranche 2 (3 new cells, from-scratch sections 1-7 untouched)

Inserted after §7 "Complémentarité", before §8 Exercises (the §7 framing is preserved as the Tranche-1-pedagogy story; the Tranche-2 intro explicitly notes §7's "0 NuGet" describes Tranche 1, and Tranche 2 now bridges the engine):

1. **`## Tranche 2 : parité lib-vs-lib via Google.OrTools CP-SAT`** (markdown) — the lib-vs-lib framing: Python/ortools ↔ C#/Google.OrTools, the canonical 4-constraint nurse-rostering model (table of C1–C4).
2. **Google.OrTools 9.15 CP-SAT** (code, ec=8) — `#r "nuget: Google.OrTools"` then the canonical model: 105 booleans `x[n,d,s]`, C1 coverage `Sum==demand`, C2 uniqueness `Sum<=1`, C3 rest `x[n,d,NUIT]+x[n,d+1,MATIN]<=1`, C4 max load `Sum<=5`. Solve + schedule display + per-nurse load.
3. **Interprétation** (markdown) — Tranche 1 = readable pedagogy (greedy/backtracking/min-conflicts visible); Tranche 2 = production CP-SAT engine (the same role `ortools.sat` plays on the Python side); booléens-vs-entiers modeling decision.

## Firsthand output (committed, the parity proof)

```
CP-SAT NurseScheduling : status=Optimal, temps=78,8 ms
Variables booleennes   : 105  (= jumeau Python x[n][d][s])

Planning CP-SAT (lignes = jours, colonnes = equipes) :
jour      Matin         Apres-midi    Nuit
Lun       Emma          Bob           Alice
Mar       Emma          Alice         Bob
...

Total shifts assignes : 21 / 21  (couverture C1 = 1/shift verifiee)
Charge par infirmier (C4 <= 5) : 5, 5, 4, 3, 4
```

The engine reaches the **exact** parity markers of the Python twin: `Optimal` status (Python: `OPTIMAL` 30ms), 105 boolean variables (Python: `x[n][d][s]`), 21/21 shifts assigned (full coverage C1), per-nurse load all ≤5 (C4). Same engine, same instance, same constraint semantics — verified, not announced.

## C.1 / C.2 / execution / anti-regression

- **Anti-regression (acceptance criterion 1)**: the from-scratch tranche is preserved **byte-for-byte** — verified programmatically on the committed blob: all 15 original cells (0..14) source-identical to `origin/main`. The +778/-176 line delta is Papermill **output regeneration** (re-executed display_data for all 11 code cells) + the 3 new Tranche-2 cells, NOT source changes.
- **C.1**: no `raise NotImplementedError`/`assert False`/`1/0` (scan clean).
- **C.2**: whole notebook re-executed via the `.net-csharp` kernel (Papermill, 11/11 code cells `execution_count` 1..11, 0 errors). Outputs are real.
- **API (rule F + lesson dotnet-ortools-api-stringparameters)**: used the proven C# CP-SAT API — `model.Add(LinearExpr.Sum(...) == demand)` for coverage, `solver.StringParameters = "max_time_in_seconds:10"`, `solver.Value(var)`. Lesson from cycle 12 (App-1) applied: the C# API (`StringParameters`, `LinearExpr.Sum`) is NOT the Python API (`solver.parameters.*`). Google.OrTools 9.15.6755 restored cleanly via NuGet — no workaround.
- **Path/secret hygiene**: `.NET Interactive` `probeAddresses` banner stripped post-re-exec (9 lines via `strip_probe_banner.py --apply`). Papermill `metadata.papermill.input/output_path` normalized to basenames. 0 machine-path leak in outputs (verified).

## Registry update (acceptance criterion 2)

`scripts/notebook_tools/twin_pairs.d/app-3-nursescheduling.yaml`:
- `parity_level: semantic` → **`native-both`** (both twins now reach the production CP-SAT engine of their ecosystem).
- `known_differences` rewritten to describe the two-tranche structure + the chiffre-à-chiffre parity (Optimal status, 21/21 shifts, load [5,5,4,3,4]).
- New audit entry via `check_twin_parity --update --pair "App-3 NurseScheduling" --by "myia-po-2025:CoursIA"` (run LAST after all tooling strips, #8957).
- Registry health check: 157/157 OK, 0 DRIFT, 0 MISSING.

## Verdict SOTA (acceptance criterion 5)

**SOTA-OK** — Google.OrTools 9.15.6755 is properly restored (`#r "nuget: Google.OrTools"`) and invoked; the committed output is its real CP-SAT output (Optimal status, 21/21 assigned, bounded load). No workaround, no degraded substitution. This is the .NET production CP-SAT engine the owner asked each side to reach (#10382).

## Variation note (G-VAR-3)

prev = DEEP/notebook-dotnet #10392 (App-1 NQueens Google.OrTools CP-SAT). This is DEEP/notebook-dotnet (App-3 NurseScheduling Google.OrTools CP-SAT — domain reasoning: bridging the .NET CP-SAT engine on the canonical nurse-rostering instance + verifying chiffre-à-chiffre parity on the 4-constraint model). 3rd consecutive DEEP/notebook-dotnet same-genre in the lane's Search/Applications domain-cœur. Per G-VAR-3, allowed IF genuinely distinct substance (the litmus "could I generate the next by scanning the instance beside it?" → NO: each required designing a DIFFERENT CP-SAT bridge — N-queens `AddAllDifferent` (3 constraints) vs nurse-rostering coverage/uniqueness/rest/maxload (4 constraint families, boolean encoding, load balancing) — different problem, different constraint model, different parity markers). Genuinely distinct domain reasoning, not scan-generated. This is the third grain of the App-1/App-3/App-4 trio dispatched by ai-01 (App-4 queued next; variation will rotate genre there).

## Why See, not Closes

This resolves ONE pair (App-3) of the 51-pair #10382 epic. The epic stays open. `See #10382`.

See #10382 (epic), See #4956 (.NET⇄Python parity marathon), See #3801 (SOTA registry).
