### PR TITLE
feat(fallacy,#10355): 2 pedagogical exercises on Argumentum cards notebook (dette ai-01)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Argumentum_Cards.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Argumentum_Cards.ipynb
@@ -482,7 +482,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## 7.1. Exercice — compter les cartes par profondeur**Objectif** : la sélection « carte » n'est pas une couche unique de la taxonomie. Produisezun décompte des cartes par niveau de profondeur (`depth`) pour montrer la **granularitéhiérarchique** de la sélection — c'est exactement la structure que le PostTraining (Phase 2)doit exposer à un modèle de raisonnement pour qu'il sache qu'une carte profondeur 1 et unecarte profondeur 4 ne représentent pas le même niveau de généralité.**Indice** : la colonne `depth` du CSV est une chaîne de caractères ; pensez à la convertiren entier avant le décompte. `collections.Counter` est votre ami.# Indice : commencez par filtrer les cartes (carte=1), extrayez la colonne depth, comptez.# Etape 1 : créer une liste d'entiers depuis r['depth'] pour chaque carte.# Etape 2 : utiliser Counter() pour compter les occurrences par profondeur."
+    "## 7.1. Exercice — compter les cartes par profondeur\n",
+    "\n",
+    "**Objectif** : la sélection « carte » n'est pas une couche unique de la taxonomie. Produisez un décompte des cartes par niveau de profondeur (`depth`) pour montrer la **granularité hiérarchique** de la sélection — c'est exactement la structure que le PostTraining (Phase 2) doit exposer à un modèle de raisonnement pour qu'il sache qu'une carte profondeur 1 et une carte profondeur 4 ne représentent pas le même niveau de généralité.\n",
+    "\n",
+    "**Indice** : la colonne `depth` du CSV est une chaîne de caractères ; pensez à la convertir en entier avant le décompte. `collections.Counter` est votre ami.\n",
+    "\n",
+    "# Indice : commencez par filtrer les cartes (carte=1), extrayez la colonne depth, comptez.\n",
+    "# Etape 1 : créer une liste d'entiers depuis r['depth'] pour chaque carte.\n",
+    "# Etape 2 : utiliser Counter() pour compter les occurrences par profondeur.\n"
    ]
   },
   {
@@ -526,7 +534,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## 7.2. Exercice — remonter d'un sophisme feuille vers sa carte ancêtre**Objectif** : l'inverse de l'exercice 5 (cellule 4 — *la carte ouvre un sous-arbre*). Leworkflow descendant « carte → enfants → sophismes spécifiques » est ce que la cellule 9illustre déjà via `afficher_sous_arbre`. La **remontée** « sophisme feuille → carteancêtre » est l'opération symétrique dont la Phase 4 aura besoin pour transformer unedétection en *contexte* : étant donné un sophisme identifié en bout de chaîne, on remonteà la carte qui l'a *catégorisé*, et c'est la carte qui devient l'unité pédagogique.**Indice** : un path est une chaîne de segments séparés par des points (ex. `1.3.2.1`).Le parent d'un nœud est ce path privé de son dernier segment. La carte ancêtre est lepremier ancêtre dont le path figure dans la sélection `cards`.# Indice : remonter iterativement d'un cran (parent = path.rsplit('.', 1)[0]).# Etape 1 : definir path_parent(p) qui retourne le parent ou '' si plus de parent.# Etape 2 : remonter en boucle jusqu'à trouver un path dans cards (set des paths cartes).# Etape 3 : retourner la ligne de taxonomie correspondante, ou None si pas d'ancêtre carte."
+    "## 7.2. Exercice — remonter d'un sophisme feuille vers sa carte ancêtre\n",
+    "\n",
+    "**Objectif** : l'inverse de l'exercice 5 (cellule 4 — *la carte ouvre un sous-arbre*). Le workflow descendant « carte → enfants → sophismes spécifiques » est ce que la cellule 9 illustre déjà via `afficher_sous_arbre`. La **remontée** « sophisme feuille → carte ancêtre » est l'opération symétrique dont la Phase 4 aura besoin pour transformer une détection en *contexte* : étant donné un sophisme identifié en bout de chaîne, on remonte à la carte qui l'a *catégorisé*, et c'est la carte qui devient l'unité pédagogique.\n",
+    "\n",
+    "**Indice** : un path est une chaîne de segments séparés par des points (ex. `1.3.2.1`). Le parent d'un nœud est ce path privé de son dernier segment. La carte ancêtre est le premier ancêtre dont le path figure dans la sélection `cards`.\n",
+    "\n",
+    "# Indice : remonter iterativement d'un cran (parent = path.rsplit('.', 1)[0]).\n",
+    "# Etape 1 : definir path_parent(p) qui retourne le parent ou '' si plus de parent.\n",
+    "# Etape 2 : remonter en boucle jusqu'à trouver un path dans cards (set des paths cartes).\n",
+    "# Etape 3 : retourner la ligne de taxonomie correspondante, ou None si pas d'ancêtre carte.\n"
    ]
   },
   {
@@ -568,7 +585,19 @@
    "id": "4a929ad3",
    "metadata": {},
    "source": [
-    "## 8. Conclusion et ponts- **Une carte = une ligne de taxonomie** : le rendu est mécanique, reproductible, bilingue.  Aucune information n'est inventée — tout provient du CSV canonique.- **176 cartes sur 1408 nœuds** (12,5 %), réparties sur 7 familles, ~25 par famille.- **La carte est un nœud interne** : elle ouvre un sous-arbre de sophismes spécifiques.  C'est cette structure hiérarchique que le PostTraining (EPIC #10355) exploitera comme workflow.**Ponts avec la série** :- [`Argument_Analysis_Ontology_CrossLinks.ipynb`](Argument_Analysis_Ontology_CrossLinks.ipynb) —  la taxonomie entière (1408 nœuds), sa structure, ses liens transverses.- [`Argument_Analysis_ArgumentProfile.ipynb`](Argument_Analysis_ArgumentProfile.ipynb) —  le profil multidimensionnel d'un argument dans un débat (5 dimensions, dont les sophismes).- EPIC **#10355** — fallacy detection via Qwen3.5/3.6 FT+PT : ce notebook fournit le rendu  de référence de la *golden answer* pour le jeu de données de fine-tuning.*Données : Argumentum taxonomy (bilingue, 1408 nœuds). Notebook exécutable sans API ni clé.*"
+    "## 8. Conclusion et ponts\n",
+    "\n",
+    "- **Une carte = une ligne de taxonomie** : le rendu est mécanique, reproductible, bilingue. Aucune information n'est inventée — tout provient du CSV canonique.\n",
+    "- **176 cartes sur 1408 nœuds** (12,5 %), réparties sur 7 familles, ~25 par famille.\n",
+    "- **La carte est un nœud interne** : elle ouvre un sous-arbre de sophismes spécifiques. C'est cette structure hiérarchique que le PostTraining (EPIC #10355) exploitera comme workflow.\n",
+    "\n",
+    "**Ponts avec la série** :\n",
+    "\n",
+    "- [`Argument_Analysis_Ontology_CrossLinks.ipynb`](Argument_Analysis_Ontology_CrossLinks.ipynb) — la taxonomie entière (1408 nœuds), sa structure, ses liens transverses.\n",
+    "- [`Argument_Analysis_ArgumentProfile.ipynb`](Argument_Analysis_ArgumentProfile.ipynb) — le profil multidimensionnel d'un argument dans un débat (5 dimensions, dont les sophismes).\n",
+    "- EPIC **#10355** — fallacy detection via Qwen3.5/3.6 FT+PT : ce notebook fournit le rendu de référence de la *golden answer* pour le jeu de données de fine-tuning.\n",
+    "\n",
+    "*Données : Argumentum taxonomy (bilingue, 1408 nœuds). Notebook exécutable sans API ni clé.*\n"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Argumentum_Cards.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Argumentum_Cards.ipynb
@@ -507,7 +507,16 @@
    },
    "outputs": [],
    "source": [
-    "def compter_cartes_par_profondeur(cards: list) -> dict:    \"\"\"Retourne un dict {profondeur_int: nb_cartes} pour la sélection `cards`.    # Indice : iter sur cards, convertir r['depth'] en int (skip si non numerique).    # Etape 1 : initialiser un Counter vide.    # Etape 2 : pour chaque carte, incrementer le Counter à la profondeur normalisée.    # Etape 3 : retourner dict(sorted(counter.items())).    \"\"\"    # TODO etudiant    return None  # à compléter"
+    "def compter_cartes_par_profondeur(cards: list) -> dict:\n",
+    "    \"\"\"Retourne un dict {profondeur_int: nb_cartes} pour la sélection `cards`.\n",
+    "\n",
+    "    # Indice : iter sur cards, convertir r['depth'] en int (skip si non numerique).\n",
+    "    # Etape 1 : initialiser un Counter vide.\n",
+    "    # Etape 2 : pour chaque carte, incrementer le Counter à la profondeur normalisée.\n",
+    "    # Etape 3 : retourner dict(sorted(counter.items())).\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant\n",
+    "    return None  # à compléter"
    ]
   },
   {
@@ -524,7 +533,10 @@
    },
    "outputs": [],
    "source": [
-    "# Démonstration attendue (à décommenter après votre implémentation) :# distribution = compter_cartes_par_profondeur(CARDS)# for prof, nb in sorted(distribution.items()):#     print(f\"  profondeur {prof} : {nb} cartes\")"
+    "# Démonstration attendue (à décommenter après votre implémentation) :\n",
+    "# distribution = compter_cartes_par_profondeur(CARDS)\n",
+    "# for prof, nb in sorted(distribution.items()):\n",
+    "#     print(f\"  profondeur {prof} : {nb} cartes\")"
    ]
   },
   {
@@ -560,7 +572,19 @@
    },
    "outputs": [],
    "source": [
-    "def carte_ancetre_feuille(path_feuille: str, taxonomy: list, cards: list) -> dict | None:    \"\"\"Remonte d'un nœud feuille jusqu'à la première carte ancêtre.    Retourne la ligne de taxonomie de cette carte ancêtre, ou None si le chemin est    orphelin (aucun ancêtre n'est une carte).    # Indice : set(card['path'] for card in cards) => O(1) lookup à chaque remontée.    # Etape 1 : construire l'ensemble des paths de cartes (pour lookup rapide).    # Etape 2 : remonter en boucle : parent = path.rsplit('.', 1)[0].    # Etape 3 : si parent vide (racine sans carte), retourner None.    # Etape 4 : sinon retourner la ligne de taxonomy dont path == parent.    \"\"\"    # TODO etudiant    return None  # à compléter"
+    "def carte_ancetre_feuille(path_feuille: str, taxonomy: list, cards: list) -> dict | None:\n",
+    "    \"\"\"Remonte d'un nœud feuille jusqu'à la première carte ancêtre.\n",
+    "    Retourne la ligne de taxonomie de cette carte ancêtre, ou None si le chemin est\n",
+    "    orphelin (aucun ancêtre n'est une carte).\n",
+    "\n",
+    "    # Indice : set(card['path'] for card in cards) => O(1) lookup à chaque remontée.\n",
+    "    # Etape 1 : construire l'ensemble des paths de cartes (pour lookup rapide).\n",
+    "    # Etape 2 : remonter en boucle : parent = path.rsplit('.', 1)[0].\n",
+    "    # Etape 3 : si parent vide (racine sans carte), retourner None.\n",
+    "    # Etape 4 : sinon retourner la ligne de taxonomy dont path == parent.\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant\n",
+    "    return None  # à compléter"
    ]
   },
   {
@@ -577,7 +601,14 @@
    },
    "outputs": [],
    "source": [
-    "# Démonstration attendue (à décommenter après votre implémentation) :# # Trouve une feuille de profondeur >= 3 et remonte à sa carte ancêtre# for r in TAXONOMY:#     if str(r.get('carte','')).strip() in ('','0') and str(r.get('depth','')).isdigit() and int(r['depth']) >= 3:#         ancetre = carte_ancetre_feuille(r['path'], TAXONOMY, CARDS)#         if ancetre:#             print(f\"Feuille {r['path']}  ->  carte ancêtre {ancetre['path']}\")#             break"
+    "# Démonstration attendue (à décommenter après votre implémentation) :\n",
+    "# # Trouve une feuille de profondeur >= 3 et remonte à sa carte ancêtre\n",
+    "# for r in TAXONOMY:\n",
+    "#     if str(r.get('carte','')).strip() in ('','0') and str(r.get('depth','')).isdigit() and int(r['depth']) >= 3:\n",
+    "#         ancetre = carte_ancetre_feuille(r['path'], TAXONOMY, CARDS)\n",
+    "#         if ancetre:\n",
+    "#             print(f\"Feuille {r['path']}  ->  carte ancêtre {ancetre['path']}\")\n",
+    "#             break"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Argumentum_Cards.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Argumentum_Cards.ipynb
@@ -40,10 +40,10 @@
    "id": "65ef4273",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T01:59:53.935069Z",
-     "iopub.status.busy": "2026-08-11T01:59:53.934737Z",
-     "iopub.status.idle": "2026-08-11T01:59:53.988079Z",
-     "shell.execute_reply": "2026-08-11T01:59:53.987567Z"
+     "iopub.execute_input": "2026-08-11T11:22:31.145584Z",
+     "iopub.status.busy": "2026-08-11T11:22:31.145360Z",
+     "iopub.status.idle": "2026-08-11T11:22:31.210245Z",
+     "shell.execute_reply": "2026-08-11T11:22:31.209621Z"
     }
    },
    "outputs": [
@@ -101,10 +101,10 @@
    "id": "4a9b24f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T01:59:53.990085Z",
-     "iopub.status.busy": "2026-08-11T01:59:53.989867Z",
-     "iopub.status.idle": "2026-08-11T01:59:54.774616Z",
-     "shell.execute_reply": "2026-08-11T01:59:54.773756Z"
+     "iopub.execute_input": "2026-08-11T11:22:31.213016Z",
+     "iopub.status.busy": "2026-08-11T11:22:31.212781Z",
+     "iopub.status.idle": "2026-08-11T11:22:32.518145Z",
+     "shell.execute_reply": "2026-08-11T11:22:32.517103Z"
     }
    },
    "outputs": [
@@ -180,10 +180,10 @@
    "id": "a300fd33",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T01:59:54.777651Z",
-     "iopub.status.busy": "2026-08-11T01:59:54.777187Z",
-     "iopub.status.idle": "2026-08-11T01:59:54.786611Z",
-     "shell.execute_reply": "2026-08-11T01:59:54.785932Z"
+     "iopub.execute_input": "2026-08-11T11:22:32.521739Z",
+     "iopub.status.busy": "2026-08-11T11:22:32.521245Z",
+     "iopub.status.idle": "2026-08-11T11:22:32.528378Z",
+     "shell.execute_reply": "2026-08-11T11:22:32.527956Z"
     }
    },
    "outputs": [
@@ -309,10 +309,10 @@
    "id": "1012009f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T01:59:54.788969Z",
-     "iopub.status.busy": "2026-08-11T01:59:54.788652Z",
-     "iopub.status.idle": "2026-08-11T01:59:54.796990Z",
-     "shell.execute_reply": "2026-08-11T01:59:54.796444Z"
+     "iopub.execute_input": "2026-08-11T11:22:32.531672Z",
+     "iopub.status.busy": "2026-08-11T11:22:32.531358Z",
+     "iopub.status.idle": "2026-08-11T11:22:32.540255Z",
+     "shell.execute_reply": "2026-08-11T11:22:32.539436Z"
     }
    },
    "outputs": [
@@ -451,10 +451,10 @@
    "id": "9756babb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T01:59:54.800305Z",
-     "iopub.status.busy": "2026-08-11T01:59:54.799924Z",
-     "iopub.status.idle": "2026-08-11T01:59:54.803407Z",
-     "shell.execute_reply": "2026-08-11T01:59:54.802840Z"
+     "iopub.execute_input": "2026-08-11T11:22:32.543296Z",
+     "iopub.status.busy": "2026-08-11T11:22:32.542928Z",
+     "iopub.status.idle": "2026-08-11T11:22:32.547084Z",
+     "shell.execute_reply": "2026-08-11T11:22:32.546372Z"
     }
    },
    "outputs": [],
@@ -499,10 +499,10 @@
    "id": "e4261ebe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T01:59:54.806720Z",
-     "iopub.status.busy": "2026-08-11T01:59:54.806484Z",
-     "iopub.status.idle": "2026-08-11T01:59:54.810292Z",
-     "shell.execute_reply": "2026-08-11T01:59:54.809679Z"
+     "iopub.execute_input": "2026-08-11T11:22:32.549970Z",
+     "iopub.status.busy": "2026-08-11T11:22:32.549688Z",
+     "iopub.status.idle": "2026-08-11T11:22:32.553919Z",
+     "shell.execute_reply": "2026-08-11T11:22:32.553167Z"
     }
    },
    "outputs": [],
@@ -525,10 +525,10 @@
    "id": "1715ebc3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T01:59:54.812862Z",
-     "iopub.status.busy": "2026-08-11T01:59:54.812505Z",
-     "iopub.status.idle": "2026-08-11T01:59:54.816329Z",
-     "shell.execute_reply": "2026-08-11T01:59:54.815667Z"
+     "iopub.execute_input": "2026-08-11T11:22:32.556470Z",
+     "iopub.status.busy": "2026-08-11T11:22:32.556223Z",
+     "iopub.status.idle": "2026-08-11T11:22:32.559198Z",
+     "shell.execute_reply": "2026-08-11T11:22:32.558607Z"
     }
    },
    "outputs": [],
@@ -564,10 +564,10 @@
    "id": "09ea2b7a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T01:59:54.819287Z",
-     "iopub.status.busy": "2026-08-11T01:59:54.818943Z",
-     "iopub.status.idle": "2026-08-11T01:59:54.822153Z",
-     "shell.execute_reply": "2026-08-11T01:59:54.821606Z"
+     "iopub.execute_input": "2026-08-11T11:22:32.561914Z",
+     "iopub.status.busy": "2026-08-11T11:22:32.561659Z",
+     "iopub.status.idle": "2026-08-11T11:22:32.565385Z",
+     "shell.execute_reply": "2026-08-11T11:22:32.564718Z"
     }
    },
    "outputs": [],
@@ -593,10 +593,10 @@
    "id": "adb3ca75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T01:59:54.824161Z",
-     "iopub.status.busy": "2026-08-11T01:59:54.823946Z",
-     "iopub.status.idle": "2026-08-11T01:59:54.826924Z",
-     "shell.execute_reply": "2026-08-11T01:59:54.826335Z"
+     "iopub.execute_input": "2026-08-11T11:22:32.568529Z",
+     "iopub.status.busy": "2026-08-11T11:22:32.568050Z",
+     "iopub.status.idle": "2026-08-11T11:22:32.571260Z",
+     "shell.execute_reply": "2026-08-11T11:22:32.570576Z"
     }
    },
    "outputs": [],

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Argumentum_Cards.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Argumentum_Cards.ipynb
@@ -40,10 +40,10 @@
    "id": "65ef4273",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:45:29.628048Z",
-     "iopub.status.busy": "2026-08-10T23:45:29.627856Z",
-     "iopub.status.idle": "2026-08-10T23:45:29.675689Z",
-     "shell.execute_reply": "2026-08-10T23:45:29.675259Z"
+     "iopub.execute_input": "2026-08-11T01:59:53.935069Z",
+     "iopub.status.busy": "2026-08-11T01:59:53.934737Z",
+     "iopub.status.idle": "2026-08-11T01:59:53.988079Z",
+     "shell.execute_reply": "2026-08-11T01:59:53.987567Z"
     }
    },
    "outputs": [
@@ -101,10 +101,10 @@
    "id": "4a9b24f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:45:29.677742Z",
-     "iopub.status.busy": "2026-08-10T23:45:29.677573Z",
-     "iopub.status.idle": "2026-08-10T23:45:30.329049Z",
-     "shell.execute_reply": "2026-08-10T23:45:30.328485Z"
+     "iopub.execute_input": "2026-08-11T01:59:53.990085Z",
+     "iopub.status.busy": "2026-08-11T01:59:53.989867Z",
+     "iopub.status.idle": "2026-08-11T01:59:54.774616Z",
+     "shell.execute_reply": "2026-08-11T01:59:54.773756Z"
     }
    },
    "outputs": [
@@ -180,10 +180,10 @@
    "id": "a300fd33",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:45:30.331820Z",
-     "iopub.status.busy": "2026-08-10T23:45:30.331370Z",
-     "iopub.status.idle": "2026-08-10T23:45:30.339405Z",
-     "shell.execute_reply": "2026-08-10T23:45:30.338806Z"
+     "iopub.execute_input": "2026-08-11T01:59:54.777651Z",
+     "iopub.status.busy": "2026-08-11T01:59:54.777187Z",
+     "iopub.status.idle": "2026-08-11T01:59:54.786611Z",
+     "shell.execute_reply": "2026-08-11T01:59:54.785932Z"
     }
    },
    "outputs": [
@@ -309,10 +309,10 @@
    "id": "1012009f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:45:30.342038Z",
-     "iopub.status.busy": "2026-08-10T23:45:30.341809Z",
-     "iopub.status.idle": "2026-08-10T23:45:30.349614Z",
-     "shell.execute_reply": "2026-08-10T23:45:30.349000Z"
+     "iopub.execute_input": "2026-08-11T01:59:54.788969Z",
+     "iopub.status.busy": "2026-08-11T01:59:54.788652Z",
+     "iopub.status.idle": "2026-08-11T01:59:54.796990Z",
+     "shell.execute_reply": "2026-08-11T01:59:54.796444Z"
     }
    },
    "outputs": [
@@ -451,10 +451,10 @@
    "id": "9756babb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T23:45:30.353322Z",
-     "iopub.status.busy": "2026-08-10T23:45:30.352847Z",
-     "iopub.status.idle": "2026-08-10T23:45:30.356893Z",
-     "shell.execute_reply": "2026-08-10T23:45:30.356216Z"
+     "iopub.execute_input": "2026-08-11T01:59:54.800305Z",
+     "iopub.status.busy": "2026-08-11T01:59:54.799924Z",
+     "iopub.status.idle": "2026-08-11T01:59:54.803407Z",
+     "shell.execute_reply": "2026-08-11T01:59:54.802840Z"
     }
    },
    "outputs": [],
@@ -477,26 +477,98 @@
   },
   {
    "cell_type": "markdown",
+   "execution_count": null,
+   "id": "c71e5d10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## 7.1. Exercice — compter les cartes par profondeur**Objectif** : la sélection « carte » n'est pas une couche unique de la taxonomie. Produisezun décompte des cartes par niveau de profondeur (`depth`) pour montrer la **granularitéhiérarchique** de la sélection — c'est exactement la structure que le PostTraining (Phase 2)doit exposer à un modèle de raisonnement pour qu'il sache qu'une carte profondeur 1 et unecarte profondeur 4 ne représentent pas le même niveau de généralité.**Indice** : la colonne `depth` du CSV est une chaîne de caractères ; pensez à la convertiren entier avant le décompte. `collections.Counter` est votre ami.# Indice : commencez par filtrer les cartes (carte=1), extrayez la colonne depth, comptez.# Etape 1 : créer une liste d'entiers depuis r['depth'] pour chaque carte.# Etape 2 : utiliser Counter() pour compter les occurrences par profondeur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e4261ebe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T01:59:54.806720Z",
+     "iopub.status.busy": "2026-08-11T01:59:54.806484Z",
+     "iopub.status.idle": "2026-08-11T01:59:54.810292Z",
+     "shell.execute_reply": "2026-08-11T01:59:54.809679Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def compter_cartes_par_profondeur(cards: list) -> dict:    \"\"\"Retourne un dict {profondeur_int: nb_cartes} pour la sélection `cards`.    # Indice : iter sur cards, convertir r['depth'] en int (skip si non numerique).    # Etape 1 : initialiser un Counter vide.    # Etape 2 : pour chaque carte, incrementer le Counter à la profondeur normalisée.    # Etape 3 : retourner dict(sorted(counter.items())).    \"\"\"    # TODO etudiant    return None  # à compléter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1715ebc3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T01:59:54.812862Z",
+     "iopub.status.busy": "2026-08-11T01:59:54.812505Z",
+     "iopub.status.idle": "2026-08-11T01:59:54.816329Z",
+     "shell.execute_reply": "2026-08-11T01:59:54.815667Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Démonstration attendue (à décommenter après votre implémentation) :# distribution = compter_cartes_par_profondeur(CARDS)# for prof, nb in sorted(distribution.items()):#     print(f\"  profondeur {prof} : {nb} cartes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "execution_count": null,
+   "id": "e6394521",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## 7.2. Exercice — remonter d'un sophisme feuille vers sa carte ancêtre**Objectif** : l'inverse de l'exercice 5 (cellule 4 — *la carte ouvre un sous-arbre*). Leworkflow descendant « carte → enfants → sophismes spécifiques » est ce que la cellule 9illustre déjà via `afficher_sous_arbre`. La **remontée** « sophisme feuille → carteancêtre » est l'opération symétrique dont la Phase 4 aura besoin pour transformer unedétection en *contexte* : étant donné un sophisme identifié en bout de chaîne, on remonteà la carte qui l'a *catégorisé*, et c'est la carte qui devient l'unité pédagogique.**Indice** : un path est une chaîne de segments séparés par des points (ex. `1.3.2.1`).Le parent d'un nœud est ce path privé de son dernier segment. La carte ancêtre est lepremier ancêtre dont le path figure dans la sélection `cards`.# Indice : remonter iterativement d'un cran (parent = path.rsplit('.', 1)[0]).# Etape 1 : definir path_parent(p) qui retourne le parent ou '' si plus de parent.# Etape 2 : remonter en boucle jusqu'à trouver un path dans cards (set des paths cartes).# Etape 3 : retourner la ligne de taxonomie correspondante, ou None si pas d'ancêtre carte."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "09ea2b7a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T01:59:54.819287Z",
+     "iopub.status.busy": "2026-08-11T01:59:54.818943Z",
+     "iopub.status.idle": "2026-08-11T01:59:54.822153Z",
+     "shell.execute_reply": "2026-08-11T01:59:54.821606Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def carte_ancetre_feuille(path_feuille: str, taxonomy: list, cards: list) -> dict | None:    \"\"\"Remonte d'un nœud feuille jusqu'à la première carte ancêtre.    Retourne la ligne de taxonomie de cette carte ancêtre, ou None si le chemin est    orphelin (aucun ancêtre n'est une carte).    # Indice : set(card['path'] for card in cards) => O(1) lookup à chaque remontée.    # Etape 1 : construire l'ensemble des paths de cartes (pour lookup rapide).    # Etape 2 : remonter en boucle : parent = path.rsplit('.', 1)[0].    # Etape 3 : si parent vide (racine sans carte), retourner None.    # Etape 4 : sinon retourner la ligne de taxonomy dont path == parent.    \"\"\"    # TODO etudiant    return None  # à compléter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "adb3ca75",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T01:59:54.824161Z",
+     "iopub.status.busy": "2026-08-11T01:59:54.823946Z",
+     "iopub.status.idle": "2026-08-11T01:59:54.826924Z",
+     "shell.execute_reply": "2026-08-11T01:59:54.826335Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Démonstration attendue (à décommenter après votre implémentation) :# # Trouve une feuille de profondeur >= 3 et remonte à sa carte ancêtre# for r in TAXONOMY:#     if str(r.get('carte','')).strip() in ('','0') and str(r.get('depth','')).isdigit() and int(r['depth']) >= 3:#         ancetre = carte_ancetre_feuille(r['path'], TAXONOMY, CARDS)#         if ancetre:#             print(f\"Feuille {r['path']}  ->  carte ancêtre {ancetre['path']}\")#             break"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4a929ad3",
    "metadata": {},
    "source": [
-    "## 6. Conclusion et ponts\n",
-    "\n",
-    "- **Une carte = une ligne de taxonomie** : le rendu est mécanique, reproductible, bilingue.\n",
-    "  Aucune information n'est inventée — tout provient du CSV canonique.\n",
-    "- **176 cartes sur 1408 nœuds** (12,5 %), réparties sur 7 familles, ~25 par famille.\n",
-    "- **La carte est un nœud interne** : elle ouvre un sous-arbre de sophismes spécifiques.\n",
-    "  C'est cette structure hiérarchique que le PostTraining (EPIC #10355) exploitera comme workflow.\n",
-    "\n",
-    "**Ponts avec la série** :\n",
-    "- [`Argument_Analysis_Ontology_CrossLinks.ipynb`](Argument_Analysis_Ontology_CrossLinks.ipynb) —\n",
-    "  la taxonomie entière (1408 nœuds), sa structure, ses liens transverses.\n",
-    "- [`Argument_Analysis_ArgumentProfile.ipynb`](Argument_Analysis_ArgumentProfile.ipynb) —\n",
-    "  le profil multidimensionnel d'un argument dans un débat (5 dimensions, dont les sophismes).\n",
-    "- EPIC **#10355** — fallacy detection via Qwen3.5/3.6 FT+PT : ce notebook fournit le rendu\n",
-    "  de référence de la *golden answer* pour le jeu de données de fine-tuning.\n",
-    "\n",
-    "*Données : Argumentum taxonomy (bilingue, 1408 nœuds). Notebook exécutable sans API ni clé.*"
+    "## 8. Conclusion et ponts- **Une carte = une ligne de taxonomie** : le rendu est mécanique, reproductible, bilingue.  Aucune information n'est inventée — tout provient du CSV canonique.- **176 cartes sur 1408 nœuds** (12,5 %), réparties sur 7 familles, ~25 par famille.- **La carte est un nœud interne** : elle ouvre un sous-arbre de sophismes spécifiques.  C'est cette structure hiérarchique que le PostTraining (EPIC #10355) exploitera comme workflow.**Ponts avec la série** :- [`Argument_Analysis_Ontology_CrossLinks.ipynb`](Argument_Analysis_Ontology_CrossLinks.ipynb) —  la taxonomie entière (1408 nœuds), sa structure, ses liens transverses.- [`Argument_Analysis_ArgumentProfile.ipynb`](Argument_Analysis_ArgumentProfile.ipynb) —  le profil multidimensionnel d'un argument dans un débat (5 dimensions, dont les sophismes).- EPIC **#10355** — fallacy detection via Qwen3.5/3.6 FT+PT : ce notebook fournit le rendu  de référence de la *golden answer* pour le jeu de données de fine-tuning.*Données : Argumentum taxonomy (bilingue, 1408 nœuds). Notebook exécutable sans API ni clé.*"
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: LIGHT/guard #10391

# PR c.206 — #10355 exercices 7.1 + 7.2 (dette exercises-below-threshold)

## Contexte — grain nommé par ai-01 (DM msg-20260811T013522-49cefz)

Le merge de #10379 a posé **1 seul label fondé** sur le notebook Argumentum carte livré : `exercises-below-threshold`. Un notebook neuf doit porter **≥3 exercices** dès la création (règle `three-exercises-per-notebook`), et le notebook livré n'en portait qu'**un seul** (cellule [11] `chercher_cartes`). ai-01 a explicitement nommé les **deux exercices à ajouter** :

> (a) **compter les cartes par profondeur** dans l'arbre — l'apprenant découvre que la granularité carte n'est pas une couche unique, ce qui est exactement le point que ta cellule 5 soulève pour le dataset FT ; (b) **remonter d'un sophisme feuille vers sa carte ancêtre** — l'inverse de `afficher_sous_arbre`, et l'opération dont la Phase 4 aura besoin pour descendre du général au particulier.

## Livrable — 2 exercices ajoutés + conclusion renumérotée

**13 → 19 cells** (5 code + 8 markdown → 9 code + 10 markdown). Conclusion renumérotée `## 6` → `## 8` pour cohérence de la nouvelle section `## 7`.

### Exercice 7.1 — `compter_cartes_par_profondeur(cards) -> dict[int, int]`

Distribution empirique mesurée firsthand (depuis le CSV canonique `argumentum_fallacies_taxonomy.csv`) :

| Profondeur | Nb cartes | % |
|---:|---:|---:|
| 1 | 7 | 4,0 % |
| 2 | 21 | 11,9 % |
| 3 | 63 | 35,8 % |
| 4 | 45 | 25,6 % |
| 5 | 31 | 17,6 % |
| 6 | 8 | 4,5 % |
| 7 | 1 | 0,6 % |
| **total** | **176** | **100 %** |

La sélection « carte » n'est **pas** une couche unique — c'est exactement la granularité hiérarchique que la Phase 2 du PostTraining (EPIC #10355) doit exposer au modèle de raisonnement pour qu'il sache qu'une carte profondeur 1 (famille racine) et une carte profondeur 4 (sous-sophisme spécialisé) ne représentent **pas le même niveau de généralité**. Pattern stub conforme (`return None  # à compléter`, indices `# Etape 1`, `# Etape 2`).

### Exercice 7.2 — `carte_ancetre_feuille(path_feuille, taxonomy, cards) -> dict | None`

L'inverse de `afficher_sous_arbre` (cellule [9]). Le workflow descendant « carte → enfants → sophismes spécifiques » est ce que la cellule 9 illustre déjà. La **remontée** « sophisme feuille → carte ancêtre » est l'opération symétrique dont la Phase 4 aura besoin pour transformer une détection en *contexte* : étant donné un sophisme identifié en bout de chaîne (ex. path `1.1.2.1`), on remonte à la carte qui l'a *catégorisé* (ex. ancêtre carte `1.1.2`).

Test de la solution (verifié sur données réelles, premier exemple) :

| Feuille path | Carte ancêtre path | Profondeur carte |
|---|---|---|
| `1.1.1.1` | `1.1.1` | 3 |
| `1.1.1.1.1` | `1.1.1` | 3 |
| `1.1.1.1.1.1` | `1.1.1` | 3 |

Sur les 148 cartes de profondeur ≥ 3, **148 remontent à un ancêtre carte** (100 %). Aucune orpheline dans le CSV canonique.

## Mesure d'impact

| Métrique | Avant | Après | Delta |
|---|---:|---:|---:|
| **Cellules notebook** | 13 | 19 | +6 (+46 %) |
| **Cellules code (exécutées)** | 5 (ec=1..5) | 9 (ec=1..9) | +4 |
| **Cellules markdown** | 8 | 10 | +2 |
| **Exercices étudiants (stub)** | 1 | 3 | **+2 (cible ≥3 atteinte)** |
| **Sections `## N.`** | 6 (1-6) | 8 (1-5 + 7.1/7.2 + 8) | renumérotation cohérente |

## Validation

- **H.3 pré-commit** : ✅ tous hooks verts (gitleaks, strip probe-banners, scrub papermill paths, oversized markdown-rendering defects, **H.3 execution_count != null**).
- **Exécution kernel** : notebook re-exécuté via `nbconvert.ExecutePreprocessor` (kernel `python3`, timeout 60s) — toutes les 9 cellules code ont execution_count = 1..9, aucune erreur.
- **C.1 (stubs sans erreur volontaire)** : ✅ `return None  # à compléter` uniquement, jamais `raise NotImplementedError`.
- **C.2 (notebooks committés AVEC outputs)** : ✅ execution_count != null + outputs cohérents (les stubs retournent `None`, c'est l'exécution réelle).
- **Pattern stub conforme** à `three-exercises-per-notebook.md` (exercice stub `pass`/`return None` + markdown objectif + indices `# Indice`/`# Etape N`).
- **Aucune cellule `# Solution` / `# Exemple résolu` supprimée** (anti-régression notebook-conventions respectée).

## Scope & hygiene

- **1 fichier modifié** : `MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Argumentum_Cards.ipynb` (+109 / -37 lignes).
- **Pas de regen catalogue** : `COURSE_CATALOG.generated.{json,md}` byte-identique à main.
- **Pas de twin_parity** : notebook absent du registre `twin_pairs.d/` (vérifié firsthand) → pas concerné par le gate `twin-parity.yml`.
- **L898 collision guard cleared** :
  - `gh pr list --search "Argument_Analysis_Argumentum_Cards"` → 0 PRs ouvertes sur ce path.
  - `gh pr list --search "Argumentum"` → PRs #10379 MERGED, #10368 MERGED, #10376 MERGED — toutes distinctes du livrable.
  - Pas de claim concurrent sur l'EPIC #10355 (`[CLAIMED] lane myia-po-2023:CoursIA-2` posé en premier, voir commentaire d'issue #5248129511).
- **Branch** : `feature/c206-argumentum-exercises` (rebase frais sur `origin/main` HEAD `3eda94028`).
- **Pre-push hook secret scan** : ✅ gitleaks PASS (pas de literal secret dans le notebook).

## Liens

- **Closes partial #10355** (1/3 critères EPIC : exercices notebook ≥3) — pas un `Closes` complet, l'EPIC reste ouverte pour les Phases 2/3/4.
- See **#10379** (PR MERGED parente, exercices-below-threshold dette nommée — cette PR l'éteint).
- See **ai-01 DM msg-20260811T013522-49cefz** (grain nommé explicitement).
- See **#10355** (EPIC fallacy detection via Qwen3.5/3.6 FT+PT — Phases 2-4).
- See **#10391** (twin-parity annotation fix — gate improvement parallèle, à-côté G-VAR-2).
- See **#10395** (lane-claim-reducteur défauts — gate improvement parallèle, à-côté G-VAR-2).
- See **#10368** (#10379 MERGED parent — `academic->Argumentum label alignment module`).
- See **#10376** (#10379 MERGED predecessor — exploration taxonomy_argumentum_explorer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
