### PR TITLE
feat(search,#10382): App-4 JobShopScheduling Tranche 2 via Google.OrTools CP-SAT (lib-vs-lib parity)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-4b-JobShopScheduling-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-4b-JobShopScheduling-CSharp.ipynb
@@ -5,28 +5,28 @@
    "id": "61b93069",
    "metadata": {
     "papermill": {
-     "duration": 0.003336,
-     "end_time": "2026-07-06T16:54:29.373255",
+     "duration": 0.003546,
+     "end_time": "2026-08-11T02:06:09.626130",
      "exception": false,
-     "start_time": "2026-07-06T16:54:29.369919",
+     "start_time": "2026-08-11T02:06:09.622584",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "# App-4b : Job-Shop Scheduling \u2014 Twin C# (ordonnancement d'atelier)\n",
+    "# App-4b : Job-Shop Scheduling — Twin C# (ordonnancement d'atelier)\n",
     "\n",
     "**Navigation** : [<< App-3b NurseScheduling-CSharp](App-3b-NurseScheduling-CSharp.ipynb) | [Index](../README.md) | [App-4 Python (OR-Tools) >>](App-4-JobShopScheduling.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
-    "\u00c0 la fin de ce notebook, vous saurez :\n",
-    "1. **Mod\u00e9liser** le *Job-Shop Scheduling Problem* (JSSP) : op\u00e9rations ordonn\u00e9es par job, une machine par op\u00e9ration, minimisation du makespan\n",
-    "2. **D\u00e9rouler des heuristiques de dispatching** from-scratch (SPT, LPT, MOR, MWKR, FIFO) et comprendre leurs biais\n",
-    "3. **Impl\u00e9menter un branch-and-bound** par \u00e9num\u00e9ration d'emplois du temps actifs avec \u00e9lagage par borne inf\u00e9rieure\n",
+    "À la fin de ce notebook, vous saurez :\n",
+    "1. **Modéliser** le *Job-Shop Scheduling Problem* (JSSP) : opérations ordonnées par job, une machine par opération, minimisation du makespan\n",
+    "2. **Dérouler des heuristiques de dispatching** from-scratch (SPT, LPT, MOR, MWKR, FIFO) et comprendre leurs biais\n",
+    "3. **Implémenter un branch-and-bound** par énumération d'emplois du temps actifs avec élagage par borne inférieure\n",
     "4. **Comparer** ces moteurs explicites au solveur industriel OR-Tools CP-SAT du twin Python\n",
     "\n",
-    "> **Twin C# du marathon #4956** (parit\u00e9 .NET \u21c4 Python). Le notebook Python [App-4-JobShopScheduling](App-4-JobShopScheduling.ipynb) invoque **OR-Tools CP-SAT** (`IntervalVar`, `AddNoOverlap`, minimisation du makespan). Ce twin d\u00e9roule les algorithmes **\u00e0 la main** (BCL .NET 9, **0 NuGet**) : ce que CP-SAT cache (propagation de pr\u00e9c\u00e9dences, gestion des ressources partag\u00e9es, recherche arborescente) devient explicite. Verdict axe-2 SOTA **#3801 Prong B**.\n"
+    "> **Twin C# du marathon #4956** (parité .NET ⇄ Python). Le notebook Python [App-4-JobShopScheduling](App-4-JobShopScheduling.ipynb) invoque **OR-Tools CP-SAT** (`IntervalVar`, `AddNoOverlap`, minimisation du makespan). Ce twin déroule les algorithmes **à la main** (BCL .NET 9, **0 NuGet**) : ce que CP-SAT cache (propagation de précédences, gestion des ressources partagées, recherche arborescente) devient explicite. Verdict axe-2 SOTA **#3801 Prong B**.\n"
    ]
   },
   {
@@ -34,29 +34,29 @@
    "id": "c3257ec8",
    "metadata": {
     "papermill": {
-     "duration": 0.001739,
-     "end_time": "2026-07-06T16:54:29.377373",
+     "duration": 0.002841,
+     "end_time": "2026-08-11T02:06:09.632149",
      "exception": false,
-     "start_time": "2026-07-06T16:54:29.375634",
+     "start_time": "2026-08-11T02:06:09.629308",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 1. Contexte \u2014 le Job-Shop Scheduling Problem\n",
+    "## 1. Contexte — le Job-Shop Scheduling Problem\n",
     "\n",
-    "Le JSSP est l'un des probl\u00e8mes combinatoires les plus \u00e9tudi\u00e9s en recherche op\u00e9rationnelle. On a `n` jobs, chacun compos\u00e9 d'une **s\u00e9quence ordonn\u00e9e** d'op\u00e9rations ; chaque op\u00e9ration doit \u00eatre ex\u00e9cut\u00e9e sur une machine donn\u00e9e pendant une dur\u00e9e donn\u00e9e. Une machine ne traite qu'une op\u00e9ration \u00e0 la fois (**no-overlap**), et les op\u00e9rations d'un m\u00eame job respectent leur ordre (**pr\u00e9c\u00e9dence**). L'objectif est de **minimiser le makespan** \u2014 la date de fin de la derni\u00e8re op\u00e9ration.\n",
+    "Le JSSP est l'un des problèmes combinatoires les plus étudiés en recherche opérationnelle. On a `n` jobs, chacun composé d'une **séquence ordonnée** d'opérations ; chaque opération doit être exécutée sur une machine donnée pendant une durée donnée. Une machine ne traite qu'une opération à la fois (**no-overlap**), et les opérations d'un même job respectent leur ordre (**précédence**). L'objectif est de **minimiser le makespan** — la date de fin de la dernière opération.\n",
     "\n",
-    "C'est un probl\u00e8me **NP-difficile** au sens fort : m\u00eame de petites instances (6\u00d76) sont non-triviales, et l'explosion combinatoire est brutale.\n",
+    "C'est un problème **NP-difficile** au sens fort : même de petites instances (6×6) sont non-triviales, et l'explosion combinatoire est brutale.\n",
     "\n",
     "### Deux familles d'algorithmes\n",
     "\n",
-    "| Famille | Id\u00e9e | Ce qu'on voit ici |\n",
+    "| Famille | Idée | Ce qu'on voit ici |\n",
     "|---------|------|-------------------|\n",
-    "| **Heuristiques de dispatching** | \u00c0 chaque pas, planifier l'op\u00e9ration \u00ab la plus prioritaire \u00bb (glouton) | SPT, LPT, MOR, MWKR, FIFO |\n",
-    "| **Branch-and-bound** | \u00c9num\u00e9rer les emplois du temps actifs en \u00e9laguant par borne inf\u00e9rieure | Optimum garanti sur petites instances |\n",
+    "| **Heuristiques de dispatching** | À chaque pas, planifier l'opération « la plus prioritaire » (glouton) | SPT, LPT, MOR, MWKR, FIFO |\n",
+    "| **Branch-and-bound** | Énumérer les emplois du temps actifs en élaguant par borne inférieure | Optimum garanti sur petites instances |\n",
     "\n",
-    "Le twin Python (CP-SAT) fusionne propagation + recherche + optimisation dans un solveur \u00ab bo\u00eete noire \u00bb. Ici on s\u00e9pare pour voir ce que chaque strat\u00e9gie capture \u2014 et ce qu'elle rate.\n"
+    "Le twin Python (CP-SAT) fusionne propagation + recherche + optimisation dans un solveur « boîte noire ». Ici on sépare pour voir ce que chaque stratégie capture — et ce qu'elle rate.\n"
    ]
   },
   {
@@ -65,21 +65,127 @@
    "id": "9ee18b7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:54:29.392726Z",
-     "iopub.status.busy": "2026-07-06T16:54:29.387378Z",
-     "iopub.status.idle": "2026-07-06T16:54:31.301167Z",
-     "shell.execute_reply": "2026-07-06T16:54:31.297352Z"
+     "iopub.execute_input": "2026-08-11T02:06:09.647066Z",
+     "iopub.status.busy": "2026-08-11T02:06:09.642245Z",
+     "iopub.status.idle": "2026-08-11T02:06:11.041111Z",
+     "shell.execute_reply": "2026-08-11T02:06:11.038978Z"
     },
     "papermill": {
-     "duration": 1.922058,
-     "end_time": "2026-07-06T16:54:31.301263",
+     "duration": 1.406124,
+     "end_time": "2026-08-11T02:06:11.041233",
      "exception": false,
-     "start_time": "2026-07-06T16:54:29.379205",
+     "start_time": "2026-08-11T02:06:09.635109",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-33584.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '33584.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "data": {
       "text/plain": [
@@ -121,7 +227,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "(13,37): info CS9236: La compilation n\u00e9cessite la liaison de l\u2019expression lambda au moins 100\u00a0fois. Envisagez de d\u00e9clarer l\u2019expression lambda avec des types de param\u00e8tre explicites ou, si l\u2019appel de m\u00e9thode conteneur est g\u00e9n\u00e9rique, utilisez des arguments de type explicite.\r\n",
+      "(13,37): info CS9236: La compilation nécessite la liaison de l’expression lambda au moins 100 fois. Envisagez de déclarer l’expression lambda avec des types de paramètre explicites ou, si l’appel de méthode conteneur est générique, utilisez des arguments de type explicite.\r\n",
       "\r\n"
      ]
     }
@@ -154,20 +260,20 @@
    "id": "a5e99e17",
    "metadata": {
     "papermill": {
-     "duration": 0.001965,
-     "end_time": "2026-07-06T16:54:31.305520",
+     "duration": 0.002768,
+     "end_time": "2026-08-11T02:06:11.047280",
      "exception": false,
-     "start_time": "2026-07-06T16:54:31.303555",
+     "start_time": "2026-08-11T02:06:11.044512",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 2. Mod\u00e8le \u2014 op\u00e9ration planifi\u00e9e et makespan\n",
+    "## 2. Modèle — opération planifiée et makespan\n",
     "\n",
-    "Une solution = une affectation `(d\u00e9but, fin)` \u00e0 chaque op\u00e9ration `(job, op_idx)`. Le **makespan** est le maximum des fins. Les contraintes \u00e0 respecter :\n",
-    "- **Pr\u00e9c\u00e9dence** : l'op\u00e9ration `k+1` du job `j` commence apr\u00e8s la fin de `k`.\n",
-    "- **No-overlap** : sur une machine, deux op\u00e9rations ne se chevauchent pas.\n"
+    "Une solution = une affectation `(début, fin)` à chaque opération `(job, op_idx)`. Le **makespan** est le maximum des fins. Les contraintes à respecter :\n",
+    "- **Précédence** : l'opération `k+1` du job `j` commence après la fin de `k`.\n",
+    "- **No-overlap** : sur une machine, deux opérations ne se chevauchent pas.\n"
    ]
   },
   {
@@ -176,16 +282,16 @@
    "id": "8f39b328",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:54:31.310967Z",
-     "iopub.status.busy": "2026-07-06T16:54:31.310783Z",
-     "iopub.status.idle": "2026-07-06T16:54:31.532893Z",
-     "shell.execute_reply": "2026-07-06T16:54:31.532735Z"
+     "iopub.execute_input": "2026-08-11T02:06:11.053754Z",
+     "iopub.status.busy": "2026-08-11T02:06:11.053564Z",
+     "iopub.status.idle": "2026-08-11T02:06:11.236151Z",
+     "shell.execute_reply": "2026-08-11T02:06:11.235966Z"
     },
     "papermill": {
-     "duration": 0.225416,
-     "end_time": "2026-07-06T16:54:31.532973",
+     "duration": 0.186248,
+     "end_time": "2026-08-11T02:06:11.236227",
      "exception": false,
-     "start_time": "2026-07-06T16:54:31.307557",
+     "start_time": "2026-08-11T02:06:11.049979",
      "status": "completed"
     },
     "tags": []
@@ -273,26 +379,26 @@
    "id": "271621d8",
    "metadata": {
     "papermill": {
-     "duration": 0.002597,
-     "end_time": "2026-07-06T16:54:31.538374",
+     "duration": 0.003145,
+     "end_time": "2026-08-11T02:06:11.242887",
      "exception": false,
-     "start_time": "2026-07-06T16:54:31.535777",
+     "start_time": "2026-08-11T02:06:11.239742",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 3. Heuristiques de dispatching \u2014 le glouton actif\n",
+    "## 3. Heuristiques de dispatching — le glouton actif\n",
     "\n",
-    "On simule l'atelier : \u00e0 chaque it\u00e9ration, on regarde les op\u00e9rations **pr\u00eates** (op\u00e9rateur suivant d'un job dont la pr\u00e9c\u00e9dence est satisfaite), on calcule leur **date de d\u00e9but au plus t\u00f4t** = `max(fin pr\u00e9c\u00e9dente du job, lib\u00e9ration de la machine)`, puis on planifie en priorit\u00e9 selon la r\u00e8gle. C'est l'algorithme explicite derri\u00e8re les r\u00e8gles de priorit\u00e9 industrielles.\n",
+    "On simule l'atelier : à chaque itération, on regarde les opérations **prêtes** (opérateur suivant d'un job dont la précédence est satisfaite), on calcule leur **date de début au plus tôt** = `max(fin précédente du job, libération de la machine)`, puis on planifie en priorité selon la règle. C'est l'algorithme explicite derrière les règles de priorité industrielles.\n",
     "\n",
-    "| R\u00e8gle | Priorit\u00e9 | Biais |\n",
+    "| Règle | Priorité | Biais |\n",
     "|-------|----------|------|\n",
-    "| **SPT** | dur\u00e9e la plus courte | favorise la fluidit\u00e9, risque sur les longues |\n",
-    "| **LPT** | dur\u00e9e la plus longue | s\u00e9curise les goulets |\n",
-    "| **MOR** | travail restant maximal dans le job | finit les jobs longs en priorit\u00e9 |\n",
+    "| **SPT** | durée la plus courte | favorise la fluidité, risque sur les longues |\n",
+    "| **LPT** | durée la plus longue | sécurise les goulets |\n",
+    "| **MOR** | travail restant maximal dans le job | finit les jobs longs en priorité |\n",
     "| **MWKR** | travail restant total (somme) | variante plus fine de MOR |\n",
-    "| **FIFO** | ordre d'arriv\u00e9e | baseline neutre |\n"
+    "| **FIFO** | ordre d'arrivée | baseline neutre |\n"
    ]
   },
   {
@@ -301,16 +407,16 @@
    "id": "d6ec525c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:54:31.544733Z",
-     "iopub.status.busy": "2026-07-06T16:54:31.544528Z",
-     "iopub.status.idle": "2026-07-06T16:54:31.711540Z",
-     "shell.execute_reply": "2026-07-06T16:54:31.711378Z"
+     "iopub.execute_input": "2026-08-11T02:06:11.251098Z",
+     "iopub.status.busy": "2026-08-11T02:06:11.250855Z",
+     "iopub.status.idle": "2026-08-11T02:06:11.407486Z",
+     "shell.execute_reply": "2026-08-11T02:06:11.407327Z"
     },
     "papermill": {
-     "duration": 0.170727,
-     "end_time": "2026-07-06T16:54:31.711628",
+     "duration": 0.161239,
+     "end_time": "2026-08-11T02:06:11.407555",
      "exception": false,
-     "start_time": "2026-07-06T16:54:31.540901",
+     "start_time": "2026-08-11T02:06:11.246316",
      "status": "completed"
     },
     "tags": []
@@ -410,16 +516,16 @@
    "id": "713ba838",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:54:31.718895Z",
-     "iopub.status.busy": "2026-07-06T16:54:31.718659Z",
-     "iopub.status.idle": "2026-07-06T16:54:31.823266Z",
-     "shell.execute_reply": "2026-07-06T16:54:31.823095Z"
+     "iopub.execute_input": "2026-08-11T02:06:11.415013Z",
+     "iopub.status.busy": "2026-08-11T02:06:11.414823Z",
+     "iopub.status.idle": "2026-08-11T02:06:11.472211Z",
+     "shell.execute_reply": "2026-08-11T02:06:11.472059Z"
     },
     "papermill": {
-     "duration": 0.108788,
-     "end_time": "2026-07-06T16:54:31.823348",
+     "duration": 0.061381,
+     "end_time": "2026-08-11T02:06:11.472273",
      "exception": false,
-     "start_time": "2026-07-06T16:54:31.714560",
+     "start_time": "2026-08-11T02:06:11.410892",
      "status": "completed"
     },
     "tags": []
@@ -476,20 +582,20 @@
    "id": "fabad2d2",
    "metadata": {
     "papermill": {
-     "duration": 0.003041,
-     "end_time": "2026-07-06T16:54:31.829541",
+     "duration": 0.003349,
+     "end_time": "2026-08-11T02:06:11.478876",
      "exception": false,
-     "start_time": "2026-07-06T16:54:31.826500",
+     "start_time": "2026-08-11T02:06:11.475527",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 4. Branch-and-bound \u2014 l'optimum garanti (petites instances)\n",
+    "## 4. Branch-and-bound — l'optimum garanti (petites instances)\n",
     "\n",
-    "Les heuristiques donnent une solution rapide mais sans garantie. Pour **prouver** l'optimum sur une petite instance, on \u00e9num\u00e8re les emplois du temps **actifs** : \u00e0 chaque conflit (plusieurs op\u00e9rations pr\u00eates au m\u00eame instant), on branche sur l'ordre, et on \u00e9lague toute branche dont la **borne inf\u00e9rieure** d\u00e9passe la meilleure solution connue.\n",
+    "Les heuristiques donnent une solution rapide mais sans garantie. Pour **prouver** l'optimum sur une petite instance, on énumère les emplois du temps **actifs** : à chaque conflit (plusieurs opérations prêtes au même instant), on branche sur l'ordre, et on élague toute branche dont la **borne inférieure** dépasse la meilleure solution connue.\n",
     "\n",
-    "La borne inf\u00e9rieure est simple : `max(fins actuelles)` augment\u00e9 du travail restant minimal. C'est l'\u00e9quivalent explicite de la propagation + recherche de CP-SAT, sans son ing\u00e9nierie.\n"
+    "La borne inférieure est simple : `max(fins actuelles)` augmenté du travail restant minimal. C'est l'équivalent explicite de la propagation + recherche de CP-SAT, sans son ingénierie.\n"
    ]
   },
   {
@@ -498,16 +604,16 @@
    "id": "2ca1c4b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:54:31.837451Z",
-     "iopub.status.busy": "2026-07-06T16:54:31.837039Z",
-     "iopub.status.idle": "2026-07-06T16:54:31.937418Z",
-     "shell.execute_reply": "2026-07-06T16:54:31.937249Z"
+     "iopub.execute_input": "2026-08-11T02:06:11.487254Z",
+     "iopub.status.busy": "2026-08-11T02:06:11.487068Z",
+     "iopub.status.idle": "2026-08-11T02:06:11.540723Z",
+     "shell.execute_reply": "2026-08-11T02:06:11.540572Z"
     },
     "papermill": {
-     "duration": 0.104894,
-     "end_time": "2026-07-06T16:54:31.937495",
+     "duration": 0.058448,
+     "end_time": "2026-08-11T02:06:11.540795",
      "exception": false,
-     "start_time": "2026-07-06T16:54:31.832601",
+     "start_time": "2026-08-11T02:06:11.482347",
      "status": "completed"
     },
     "tags": []
@@ -613,18 +719,18 @@
    "id": "a5182c97",
    "metadata": {
     "papermill": {
-     "duration": 0.00301,
-     "end_time": "2026-07-06T16:54:31.943859",
+     "duration": 0.003612,
+     "end_time": "2026-08-11T02:06:11.548387",
      "exception": false,
-     "start_time": "2026-07-06T16:54:31.940849",
+     "start_time": "2026-08-11T02:06:11.544775",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 5. Instance plus large \u2014 ft06 (6\u00d76)\n",
+    "## 5. Instance plus large — ft06 (6×6)\n",
     "\n",
-    "L'instance **ft06** de Fisher & Thompson (6 jobs \u00d7 6 machines, 36 op\u00e9rations) est un classique plus exigeant. Le branch-and-bound devient trop lent pour la prouver in-notebook, mais les heuristiques de dispatching restent instantan\u00e9es et donnent un encadrement. Le twin Python (CP-SAT) prouve ici son avantage : il trouve l'optimum (litt\u00e9rature : **makespan = 55**) en quelques secondes.\n"
+    "L'instance **ft06** de Fisher & Thompson (6 jobs × 6 machines, 36 opérations) est un classique plus exigeant. Le branch-and-bound devient trop lent pour la prouver in-notebook, mais les heuristiques de dispatching restent instantanées et donnent un encadrement. Le twin Python (CP-SAT) prouve ici son avantage : il trouve l'optimum (littérature : **makespan = 55**) en quelques secondes.\n"
    ]
   },
   {
@@ -633,16 +739,16 @@
    "id": "93d07395",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:54:31.951242Z",
-     "iopub.status.busy": "2026-07-06T16:54:31.951046Z",
-     "iopub.status.idle": "2026-07-06T16:54:32.023176Z",
-     "shell.execute_reply": "2026-07-06T16:54:32.023003Z"
+     "iopub.execute_input": "2026-08-11T02:06:11.556145Z",
+     "iopub.status.busy": "2026-08-11T02:06:11.555932Z",
+     "iopub.status.idle": "2026-08-11T02:06:11.599041Z",
+     "shell.execute_reply": "2026-08-11T02:06:11.598849Z"
     },
     "papermill": {
-     "duration": 0.076337,
-     "end_time": "2026-07-06T16:54:32.023259",
+     "duration": 0.047285,
+     "end_time": "2026-08-11T02:06:11.599114",
      "exception": false,
-     "start_time": "2026-07-06T16:54:31.946922",
+     "start_time": "2026-08-11T02:06:11.551829",
      "status": "completed"
     },
     "tags": []
@@ -714,25 +820,261 @@
    "id": "fa244c47",
    "metadata": {
     "papermill": {
-     "duration": 0.003422,
-     "end_time": "2026-07-06T16:54:32.030282",
+     "duration": 0.003393,
+     "end_time": "2026-08-11T02:06:11.606351",
      "exception": false,
-     "start_time": "2026-07-06T16:54:32.026860",
+     "start_time": "2026-08-11T02:06:11.602958",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 6. Compl\u00e9mentarit\u00e9 avec le twin Python (#3801 Prong B)\n",
+    "## 6. Complémentarité avec le twin Python (#3801 Prong B)\n",
     "\n",
     "| Aspect | Twin Python (App-4) | Twin C# (ici) |\n",
     "|--------|---------------------|----------------|\n",
-    "| Solveur optimal | **OR-Tools CP-SAT** (`IntervalVar` + `AddNoOverlap`) | **branch-and-bound from-scratch** (active-schedule + \u00e9lagage) |\n",
-    "| Heuristiques | dispatcher SPT/MOR | **5 r\u00e8gles** explicitement d\u00e9roul\u00e9es |\n",
+    "| Solveur optimal | **OR-Tools CP-SAT** (`IntervalVar` + `AddNoOverlap`) | **branch-and-bound from-scratch** (active-schedule + élagage) |\n",
+    "| Heuristiques | dispatcher SPT/MOR | **5 règles** explicitement déroulées |\n",
     "| Bornes | propagation CP | `LowerBound` = fin job + travail restant |\n",
-    "| D\u00e9pendances | `ortools` | **BCL seule, 0 NuGet** |\n",
+    "| Dépendances | `ortools` | **BCL seule, 0 NuGet** |\n",
     "\n",
-    "\u2605 Ce twin ne remplace pas CP-SAT (qui reste l'outil SOTA, capable de prouver ft06=55). Il rend **visibles** les briques que CP-SAT orchestre : la g\u00e9n\u00e9ration d'emploi du temps actif, le r\u00f4le des r\u00e8gles de priorit\u00e9, et la m\u00e9canique du branch-and-bound. C'est le c\u0153ur p\u00e9dagogique du Prong B \u2014 l'int\u00e9rieur de la bo\u00eete noire expos\u00e9.\n"
+    "★ Ce twin ne remplace pas CP-SAT (qui reste l'outil SOTA, capable de prouver ft06=55). Il rend **visibles** les briques que CP-SAT orchestre : la génération d'emploi du temps actif, le rôle des règles de priorité, et la mécanique du branch-and-bound. C'est le cœur pédagogique du Prong B — l'intérieur de la boîte noire exposé.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "app4-tranche2-md-1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003131,
+     "end_time": "2026-08-11T02:06:11.612638",
+     "exception": false,
+     "start_time": "2026-08-11T02:06:11.609507",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Tranche 2 : parité lib-vs-lib via Google.OrTools CP-SAT\n",
+    "\n",
+    "La **Tranche 1** ci-dessus (sections 3–4) réimplémente *from-scratch* deux moteurs — 5 règles de dispatching glouton (SPT, LPT, MOR, MWR, etc.) et un branch-and-bound — en BCL pure, 0 NuGet. C'est ce que la §6 « Complémentarité » décrit : rendre **visibles** la génération d'emploi du temps actif et l'élagage du B&B que CP-SAT orchestre en boîte noire. La §6 annonçait CP-SAT comme l'outil SOTA capable de « prouver ft06 = 55 ».\n",
+    "\n",
+    "La **Tranche 2** franchit le même cap que le jumeau Python : invoquer ce moteur de production plutôt que de le laisser de l'autre côté du miroir. Le jumeau Python appelle `ortools.sat.python.cp_model` ; côté .NET, Google publie le **même solveur CP-SAT** sous le package NuGet `Google.OrTools`. La parité est **lib-vs-lib** : le même moteur (intervalles, `NoOverlap`, propagation de bornes) des deux côtés.\n",
+    "\n",
+    "Le job-shop est la famille d'ordonnancement qui **exerce le plus distinctement** CP-SAT, car il mobilise une brique que les N-Reines et le Nurse-Rostering n'utilisaient pas : les **variables d'intervalle** (`IntervalVar`) et la contrainte globale **`AddNoOverlap`** (une machine ne traite qu'une opération à la fois). Le modèle tient en quatre éléments — c'est la formulation canonique reconnue, identique à celle du jumeau Python (`App-4-JobShopScheduling.ipynb`, fonction `solve_jssp_cpsat`) :\n",
+    "\n",
+    "| Élément | Construction CP-SAT | Sens |\n",
+    "|---------|---------------------|------|\n",
+    "| **Variables d'intervalle** | `NewIntervalVar(start, durée, end, …)` par opération | chaque opération occupe `[start, end]` sur sa machine |\n",
+    "| **Précédence (chaîne de job)** | `Add(end[j,k] <= start[j,k+1])` | opérations d'un même job en séquence |\n",
+    "| **Non-chevauchement machine** | `AddNoOverlap(intervalles d'une machine)` | une machine = une opération à la fois |\n",
+    "| **Objectif makespan** | `AddMaxEquality(makespan, toutes les fins)` + `Minimize(makespan)` | minimiser la date de fin totale |\n",
+    "\n",
+    "sur la **même instance ft03** que la Tranche 1 (3 jobs × 3 machines, déclarée en §1 et réutilisée telle quelle — la parité est sur le *même* problème).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "app4-tranche2-code-1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T02:06:11.620395Z",
+     "iopub.status.busy": "2026-08-11T02:06:11.620219Z",
+     "iopub.status.idle": "2026-08-11T02:06:13.734370Z",
+     "shell.execute_reply": "2026-08-11T02:06:13.734191Z"
+    },
+    "papermill": {
+     "duration": 2.118771,
+     "end_time": "2026-08-11T02:06:13.734447",
+     "exception": false,
+     "start_time": "2026-08-11T02:06:11.615676",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Google.OrTools, 9.15.6755</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Variables : 9 operations, horizon = 22\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Contraintes de precedence : 6\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Contraintes NoOverlap : 3 machines\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "CP-SAT JSSP ft03 : status=Optimal, makespan=11, temps=55,8 ms\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Emploi du temps CP-SAT (makespan optimal prouve) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Job 0 : [M0 @0-3] [M1 @4-6] [M2 @9-11] \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Job 1 : [M0 @3-5] [M2 @5-6] [M1 @6-10] \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Job 2 : [M1 @0-4] [M2 @6-9] [M0 @9-10] \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=> makespan = 11 (= jumeau Python OPTIMAL 11 ; LB = 10, le moteur prouve qu'aucun ordonnancement a 10 n'existe).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#r \"nuget: Google.OrTools\"\n",
+    "using Google.OrTools.Sat;\n",
+    "using System.Diagnostics;\n",
+    "using System.Collections.Generic;\n",
+    "\n",
+    "// Instance ft03 REUTILISEE de la cellule §1 (cellule code ec=1) : ft03, NJ, NM, horizon.\n",
+    "// Meme instance que le jumeau Python solve_jssp_cpsat(instance).\n",
+    "var model = new CpModel();\n",
+    "\n",
+    "// --- Etape 1 : variables d'intervalle par operation ---\n",
+    "var starts   = new IntVar[NJ][];\n",
+    "var ends     = new IntVar[NJ][];\n",
+    "var intervals= new IntervalVar[NJ][];\n",
+    "var machineIntervals = new List<IntervalVar>[NM];\n",
+    "for (int m = 0; m < NM; m++) machineIntervals[m] = new List<IntervalVar>();\n",
+    "\n",
+    "for (int j = 0; j < NJ; j++)\n",
+    "{\n",
+    "    int nOps = ft03[j].Length;\n",
+    "    starts[j]    = new IntVar[nOps];\n",
+    "    ends[j]      = new IntVar[nOps];\n",
+    "    intervals[j] = new IntervalVar[nOps];\n",
+    "    for (int k = 0; k < nOps; k++)\n",
+    "    {\n",
+    "        int mac = ft03[j][k].machine, dur = ft03[j][k].dur;\n",
+    "        var s = model.NewIntVar(0, horizon, $\"s_j{j}_o{k}\");\n",
+    "        var e = model.NewIntVar(0, horizon, $\"e_j{j}_o{k}\");\n",
+    "        var iv = model.NewIntervalVar(s, dur, e, $\"iv_j{j}_o{k}\");\n",
+    "        starts[j][k] = s; ends[j][k] = e; intervals[j][k] = iv;\n",
+    "        machineIntervals[mac].Add(iv);\n",
+    "    }\n",
+    "}\n",
+    "Console.WriteLine($\"Variables : {ft03.Sum(j => j.Length)} operations, horizon = {horizon}\");\n",
+    "\n",
+    "// --- Etape 2 : contraintes de precedence (operations d'un job en sequence) ---\n",
+    "int nPrec = 0;\n",
+    "for (int j = 0; j < NJ; j++)\n",
+    "    for (int k = 0; k < ft03[j].Length - 1; k++)\n",
+    "    { model.Add(ends[j][k] <= starts[j][k + 1]); nPrec++; }\n",
+    "Console.WriteLine($\"Contraintes de precedence : {nPrec}\");\n",
+    "\n",
+    "// --- Etape 3 : non-chevauchement par machine (AddNoOverlap) ---\n",
+    "for (int m = 0; m < NM; m++)\n",
+    "    model.AddNoOverlap(machineIntervals[m]);\n",
+    "Console.WriteLine($\"Contraintes NoOverlap : {NM} machines\");\n",
+    "\n",
+    "// --- Etape 4 : objectif = minimiser le makespan (max des fins) ---\n",
+    "var allEnds = new List<IntVar>();\n",
+    "for (int j = 0; j < NJ; j++)\n",
+    "    for (int k = 0; k < ft03[j].Length; k++) allEnds.Add(ends[j][k]);\n",
+    "var makespan = model.NewIntVar(0, horizon, \"makespan\");\n",
+    "model.AddMaxEquality(makespan, allEnds);\n",
+    "model.Minimize(makespan);\n",
+    "\n",
+    "// --- Resolution ---\n",
+    "var solver = new CpSolver();\n",
+    "solver.StringParameters = \"max_time_in_seconds:30\";\n",
+    "var sw = Stopwatch.StartNew();\n",
+    "var st = solver.Solve(model);\n",
+    "sw.Stop();\n",
+    "Console.WriteLine($\"\\nCP-SAT JSSP ft03 : status={st}, makespan={solver.Value(makespan)}, temps={sw.Elapsed.TotalMilliseconds:F1} ms\");\n",
+    "\n",
+    "// --- Emploi du temps solution (par job, par operation) ---\n",
+    "if (st is CpSolverStatus.Feasible or CpSolverStatus.Optimal)\n",
+    "{\n",
+    "    Console.WriteLine(\"\\nEmploi du temps CP-SAT (makespan optimal prouve) :\");\n",
+    "    for (int j = 0; j < NJ; j++)\n",
+    "    {\n",
+    "        var ligne = $\"  Job {j} : \";\n",
+    "        for (int k = 0; k < ft03[j].Length; k++)\n",
+    "        {\n",
+    "            int s = (int)solver.Value(starts[j][k]);\n",
+    "            int e = (int)solver.Value(ends[j][k]);\n",
+    "            int mac = ft03[j][k].machine;\n",
+    "            ligne += $\"[M{mac} @{s}-{e}] \";\n",
+    "        }\n",
+    "        Console.WriteLine(ligne);\n",
+    "    }\n",
+    "    Console.WriteLine($\"\\n=> makespan = {solver.Value(makespan)} (= jumeau Python OPTIMAL 11 ; LB = 10, le moteur prouve qu'aucun ordonnancement a 10 n'existe).\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "app4-tranche2-md-2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004561,
+     "end_time": "2026-08-11T02:06:13.743751",
+     "exception": false,
+     "start_time": "2026-08-11T02:06:13.739190",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : lib-vs-lib, non-chevauchement et preuve d'optimalité\n",
+    "\n",
+    "- **Parité de statut et de makespan avec le jumeau Python.** Le solveur CP-SAT .NET atteint `OPTIMAL` avec **makespan = 11** sur ft03 — exactement le résultat que produit le jumeau Python (`solve_jssp_cpsat` → OPTIMAL, makespan 11). La parité est **chiffre-à-chiffre sur l'optimum** : non seulement une solution faisable, mais la **même preuve d'optimalité**. La borne inférieure (10 = max du plus long job et de la machine la plus chargée) n'est pas atteignable ; le moteur démontre qu'aucun ordonnancement de makespan 10 n'existe, et que 11 est l'optimum global.\n",
+    "- **Tranche 1 vs Tranche 2 = pédagogie vs production.** La Tranche 1 (§3–4) rend *visible* la mécanique : les règles de dispatching ordonnancent gloutonnement, le branch-and-bound énumère les emplois du temps actifs en élaguant. La Tranche 2 délègre tout cela au moteur CP-SAT, qui apporte la contrainte globale `NoOverlap` (propagation énergique sur les intervalles) et la preuve d'optimalité — le même rôle que `ortools.sat.python.cp_model` joue côté Python. C'est le pont que la §6 « Complémentarité » réservait au twin Python : il est désormais matérialisé côté C#.\n",
+    "- **Pourquoi les intervalles changent tout.** Les N-Reines (App-1) et le Nurse-Rostering (App-3) se modélisent en booléens (`AddAllDifferent`, sommes linéaires). Le job-shop, lui, modélise le **temps** : chaque opération est un intervalle `[start, end]`, et la contrainte « une machine à la fois » devient la contrainte globale `AddNoOverlap`, qui propage bien plus efficacement qu'une paire de disjonctions `(a ≤ b) ∨ (b ≤ a)` explicites. C'est précisément la capacité de CP-SAT que ce notebook met en valeur (Prong B de #3801) : le moteur excelle là où la structure temporelle se prête aux intervalles.\n",
+    "- **Preuve vs heuristique.** La Tranche 1 §3 montrait que les meilleures règles de dispatching atteignent ft03 ≈ 12 ; CP-SAT prouve l'optimum 11. Sur ft06 (6×6, §5), le B&B from-scratch peinerait ; CP-SAT prouve 55 — c'est le saut de échelle que le moteur de production autorise, et que la §6 annonçait.\n",
+    "\n",
+    "C'est exactement la parité demandée par l'EPIC #10382 : les deux jumeaux atteignent désormais un **moteur de production** de leur écosystème (`ortools.sat` côté Python, `Google.OrTools` côté .NET), la réimplémentation pédagogique étant conservée *en plus*, jamais *à la place*.\n"
    ]
   },
   {
@@ -740,10 +1082,10 @@
    "id": "30d17597",
    "metadata": {
     "papermill": {
-     "duration": 0.003565,
-     "end_time": "2026-07-06T16:54:32.037342",
+     "duration": 0.006286,
+     "end_time": "2026-08-11T02:06:13.754559",
      "exception": false,
-     "start_time": "2026-07-06T16:54:32.033777",
+     "start_time": "2026-08-11T02:06:13.748273",
      "status": "completed"
     },
     "tags": []
@@ -757,36 +1099,36 @@
    "id": "af71eccd",
    "metadata": {
     "papermill": {
-     "duration": 0.003688,
-     "end_time": "2026-07-06T16:54:32.044810",
+     "duration": 0.004958,
+     "end_time": "2026-08-11T02:06:13.765292",
      "exception": false,
-     "start_time": "2026-07-06T16:54:32.041122",
+     "start_time": "2026-08-11T02:06:13.760334",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 1 \u2014 Impl\u00e9menter la r\u00e8gle MWKR sur ft06\n",
+    "### Exercice 1 — Implémenter la règle MWKR sur ft06\n",
     "\n",
-    "La r\u00e8gle MWKR (Most Work Remaining) priorise l'op\u00e9ration dont le **job a le plus de travail restant**. Elle est d\u00e9j\u00e0 dans le dispatcher ci-dessus \u2014 observez son makespan vs SPT sur ft06. **Votre t\u00e2che** : ajoutez une variante **AWKR** (Average Work Remaining = travail restant / nb d'op\u00e9rations restantes) et comparez.\n"
+    "La règle MWKR (Most Work Remaining) priorise l'opération dont le **job a le plus de travail restant**. Elle est déjà dans le dispatcher ci-dessus — observez son makespan vs SPT sur ft06. **Votre tâche** : ajoutez une variante **AWKR** (Average Work Remaining = travail restant / nb d'opérations restantes) et comparez.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "95e9a2ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:54:32.053649Z",
-     "iopub.status.busy": "2026-07-06T16:54:32.053419Z",
-     "iopub.status.idle": "2026-07-06T16:54:32.108025Z",
-     "shell.execute_reply": "2026-07-06T16:54:32.107894Z"
+     "iopub.execute_input": "2026-08-11T02:06:13.776805Z",
+     "iopub.status.busy": "2026-08-11T02:06:13.776572Z",
+     "iopub.status.idle": "2026-08-11T02:06:13.842838Z",
+     "shell.execute_reply": "2026-08-11T02:06:13.842693Z"
     },
     "papermill": {
-     "duration": 0.059587,
-     "end_time": "2026-07-06T16:54:32.108093",
+     "duration": 0.072519,
+     "end_time": "2026-08-11T02:06:13.842910",
      "exception": false,
-     "start_time": "2026-07-06T16:54:32.048506",
+     "start_time": "2026-08-11T02:06:13.770391",
      "status": "completed"
     },
     "tags": []
@@ -795,7 +1137,7 @@
     {
      "data": {
       "text/plain": [
-       "Exercice 1 a completer : impl\u00e9menter AWKR dans le dispatcher et comparer."
+       "Exercice 1 a completer : implémenter AWKR dans le dispatcher et comparer."
       ]
      },
      "metadata": {},
@@ -808,7 +1150,7 @@
     "// TODO etudiant : ajouter une regle \"AWKR\" au dispatcher (cle = -(somme restante / nb ops restantes))\n",
     "// Indice : modifier le 'switch' dans Dispatch(), ajouter \"AWKR\" => x => -(jobs[x.j].Skip(x.k).Sum(o => o.dur) / (double)(jobs[x.j].Length - x.k))\n",
     "// Puis comparer AWKR vs MWKR vs SPT sur ft06.\n",
-    "\"Exercice 1 a completer : impl\u00e9menter AWKR dans le dispatcher et comparer.\".Display();\n"
+    "\"Exercice 1 a completer : implémenter AWKR dans le dispatcher et comparer.\".Display();\n"
    ]
   },
   {
@@ -816,36 +1158,36 @@
    "id": "f354aead",
    "metadata": {
     "papermill": {
-     "duration": 0.002721,
-     "end_time": "2026-07-06T16:54:32.113891",
+     "duration": 0.004215,
+     "end_time": "2026-08-11T02:06:13.851810",
      "exception": false,
-     "start_time": "2026-07-06T16:54:32.111170",
+     "start_time": "2026-08-11T02:06:13.847595",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 2 \u2014 JSSP avec temps de setup\n",
+    "### Exercice 2 — JSSP avec temps de setup\n",
     "\n",
-    "Dans la r\u00e9alit\u00e9, changer de job sur une machine co\u00fbte un **temps de setup**. Ajoutez un co\u00fbt de setup `setup[m][jobA][jobB]` lorsqu'une machine encha\u00eene deux jobs diff\u00e9rents, et modifiez le dispatcher pour l'inclure dans `es`.\n"
+    "Dans la réalité, changer de job sur une machine coûte un **temps de setup**. Ajoutez un coût de setup `setup[m][jobA][jobB]` lorsqu'une machine enchaîne deux jobs différents, et modifiez le dispatcher pour l'inclure dans `es`.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "676e6162",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:54:32.120470Z",
-     "iopub.status.busy": "2026-07-06T16:54:32.120302Z",
-     "iopub.status.idle": "2026-07-06T16:54:32.214819Z",
-     "shell.execute_reply": "2026-07-06T16:54:32.214675Z"
+     "iopub.execute_input": "2026-08-11T02:06:13.861464Z",
+     "iopub.status.busy": "2026-08-11T02:06:13.861260Z",
+     "iopub.status.idle": "2026-08-11T02:06:13.892994Z",
+     "shell.execute_reply": "2026-08-11T02:06:13.892841Z"
     },
     "papermill": {
-     "duration": 0.098292,
-     "end_time": "2026-07-06T16:54:32.214888",
+     "duration": 0.036997,
+     "end_time": "2026-08-11T02:06:13.893068",
      "exception": false,
-     "start_time": "2026-07-06T16:54:32.116596",
+     "start_time": "2026-08-11T02:06:13.856071",
      "status": "completed"
     },
     "tags": []
@@ -874,36 +1216,36 @@
    "id": "f992042f",
    "metadata": {
     "papermill": {
-     "duration": 0.002901,
-     "end_time": "2026-07-06T16:54:32.220896",
+     "duration": 0.004431,
+     "end_time": "2026-08-11T02:06:13.902146",
      "exception": false,
-     "start_time": "2026-07-06T16:54:32.217995",
+     "start_time": "2026-08-11T02:06:13.897715",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 3 \u2014 Flexible Job-Shop\n",
+    "### Exercice 3 — Flexible Job-Shop\n",
     "\n",
-    "En *flexible* job-shop, chaque op\u00e9ration peut aller sur **un ensemble** de machines (pas une seule). C'est strictement plus dur. Proposez comment \u00e9tendre le dispatcher pour choisir la machine la moins charg\u00e9e parmi les candidates.\n"
+    "En *flexible* job-shop, chaque opération peut aller sur **un ensemble** de machines (pas une seule). C'est strictement plus dur. Proposez comment étendre le dispatcher pour choisir la machine la moins chargée parmi les candidates.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "2795805a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:54:32.227659Z",
-     "iopub.status.busy": "2026-07-06T16:54:32.227483Z",
-     "iopub.status.idle": "2026-07-06T16:54:32.267156Z",
-     "shell.execute_reply": "2026-07-06T16:54:32.267038Z"
+     "iopub.execute_input": "2026-08-11T02:06:13.912966Z",
+     "iopub.status.busy": "2026-08-11T02:06:13.912745Z",
+     "iopub.status.idle": "2026-08-11T02:06:13.946598Z",
+     "shell.execute_reply": "2026-08-11T02:06:13.946420Z"
     },
     "papermill": {
-     "duration": 0.043495,
-     "end_time": "2026-07-06T16:54:32.267219",
+     "duration": 0.039835,
+     "end_time": "2026-08-11T02:06:13.946682",
      "exception": false,
-     "start_time": "2026-07-06T16:54:32.223724",
+     "start_time": "2026-08-11T02:06:13.906847",
      "status": "completed"
     },
     "tags": []
@@ -932,10 +1274,10 @@
    "id": "d7258e32",
    "metadata": {
     "papermill": {
-     "duration": 0.002635,
-     "end_time": "2026-07-06T16:54:32.272654",
+     "duration": 0.004372,
+     "end_time": "2026-08-11T02:06:13.956133",
      "exception": false,
-     "start_time": "2026-07-06T16:54:32.270019",
+     "start_time": "2026-08-11T02:06:13.951761",
      "status": "completed"
     },
     "tags": []
@@ -943,12 +1285,12 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce twin C# a d\u00e9roul\u00e9 **deux familles d'algorithmes from-scratch** sur le Job-Shop Scheduling :\n",
+    "Ce twin C# a déroulé **deux familles d'algorithmes from-scratch** sur le Job-Shop Scheduling :\n",
     "\n",
     "- Les **heuristiques de dispatching** (SPT, LPT, MOR, MWKR, FIFO) donnent des solutions rapides mais sans garantie, et leurs biais se voient dans le makespan.\n",
-    "- Le **branch-and-bound** prouve l'optimum sur petites instances (ft03) en \u00e9num\u00e9rant les emplois du temps actifs avec \u00e9lagage \u2014 c'est l'\u00e9quivalent explicite de la propagation + recherche de CP-SAT.\n",
+    "- Le **branch-and-bound** prouve l'optimum sur petites instances (ft03) en énumérant les emplois du temps actifs avec élagage — c'est l'équivalent explicite de la propagation + recherche de CP-SAT.\n",
     "\n",
-    "La fronti\u00e8re est nette : au-del\u00e0 de quelques op\u00e9rations, seul un solveur industriel comme CP-SAT (twin Python) reste praticable. Ce twin rend lisible ce que CP-SAT encapsule \u2014 c'est tout l'enjeu du Prong B du marathon #4956.\n"
+    "La frontière est nette : au-delà de quelques opérations, seul un solveur industriel comme CP-SAT (twin Python) reste praticable. Ce twin rend lisible ce que CP-SAT encapsule — c'est tout l'enjeu du Prong B du marathon #4956.\n"
    ]
   },
   {
@@ -956,10 +1298,10 @@
    "id": "7ef995fd",
    "metadata": {
     "papermill": {
-     "duration": 0.002943,
-     "end_time": "2026-07-06T16:54:32.278282",
+     "duration": 0.004376,
+     "end_time": "2026-08-11T02:06:13.965165",
      "exception": false,
-     "start_time": "2026-07-06T16:54:32.275339",
+     "start_time": "2026-08-11T02:06:13.960789",
      "status": "completed"
     },
     "tags": []
@@ -969,7 +1311,7 @@
     "\n",
     "**Navigation** : [<< App-3b NurseScheduling-CSharp](App-3b-NurseScheduling-CSharp.ipynb) | [Index](../README.md) | [App-4 Python (OR-Tools) >>](App-4-JobShopScheduling.ipynb)\n",
     "\n",
-    "*Marathon #4956 \u2014 parit\u00e9 .NET \u21c4 Python. Voir EPIC #3801 (axe-2 SOTA).*\n"
+    "*Marathon #4956 — parité .NET ⇄ Python. Voir EPIC #3801 (axe-2 SOTA).*\n"
    ]
   }
  ],
@@ -988,14 +1330,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.485052,
-   "end_time": "2026-07-06T16:54:32.522621",
+   "duration": 6.467313,
+   "end_time": "2026-08-11T02:06:14.094351",
    "environment_variables": {},
    "exception": null,
    "input_path": "App-4b-JobShopScheduling-CSharp.ipynb",
-   "output_path": "app4b_exec.ipynb",
+   "output_path": "app4_out.ipynb",
    "parameters": {},
-   "start_time": "2026-07-06T16:54:27.037569",
+   "start_time": "2026-08-11T02:06:07.627038",
    "version": "2.6.0"
   }
  },

--- a/scripts/notebook_tools/twin_pairs.d/app-4-jobshopscheduling.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-4-jobshopscheduling.yaml
@@ -14,6 +14,12 @@
       csharp_sha: e16eeb2276ddc4c9edb0d8c4b7505691d88f7e35
       content_python_sha: 913f9921fd3c5220b8980601dd68df89430ead8a089f49c846501af6614dff1e
       content_csharp_sha: 4aacdd3215c8b9661fe4644e1b8ee9a0c11fb53aa4639771aff9ba2704d381bd
+    - date: "2026-08-11"
+      by: myia-po-2025:CoursIA
+      python_sha: 7c6fdea713ce9eff4a2fc782ae90c3f5e020304c
+      csharp_sha: 1632b5ea3a9b2bf7abb81950a25f0fea2c0d5310
+      content_python_sha: 913f9921fd3c5220b8980601dd68df89430ead8a089f49c846501af6614dff1e
+      content_csharp_sha: b2d1ad64f287b783e0f0cef85ca0686026dee181ae779a06ec696478e3a38455
   known_differences:
     - "Bibliotheque vs from-scratch puis lib-vs-lib : Python invoque OR-Tools CP-SAT (IntervalVar + AddNoOverlap + Minimize makespan) comme solveur SOTA. C# = deux tranches -- Tranche 1 (sections 3-4) reimplementation from-scratch pedagogique (5 regles de dispatching glouton + branch-and-bound, en BCL pure System.* 0 NuGet) PRESERVEE integralement ; Tranche 2 (PR #10382 cycle 14) ajoute Google.OrTools 9.15 (.NET natif, deja en service dans Sudoku-10/18, App-8, App-15b, App-1, App-3) avec le MEME modele canonique CP-SAT que le Python (IntervalVar par operation, precedence end<=start entre operations d'un job, AddNoOverlap par machine, AddMaxEquality+Minimize makespan) sur la MEME instance ft03 (3 jobs x 3 machines). parite verifiee : status=Optimal, makespan=11 (= Python OPTIMAL 11 ; LB=10, le moteur prouve l'optimum global). parity_level=native-both (Python/ortools ET C#/Google.OrTools atteignent chacun le moteur de production CP-SAT de leur ecosysteme)."
     - "Asymetrie de couverture : Python (visualisation matplotlib gantt + experimentation a grande echelle avec courbe de convergence CP-SAT + search_helpers) ; C# (25 cellules : heuristiques from-scratch Tranche 1 + pont CP-SAT Tranche 2 + 3 exercices + visualisation ASCII). La visualisation matplotlib et le benchmark a grande echelle restent propres au Python ; la parite porte sur le solveur SOTA (CP-SAT) et le socle theorique (IntervalVar + NoOverlap + makespan)."

--- a/scripts/notebook_tools/twin_pairs.d/app-4-jobshopscheduling.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-4-jobshopscheduling.yaml
@@ -2,7 +2,7 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-4b-JobShopScheduling-CSharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -15,6 +15,6 @@
       content_python_sha: 913f9921fd3c5220b8980601dd68df89430ead8a089f49c846501af6614dff1e
       content_csharp_sha: 4aacdd3215c8b9661fe4644e1b8ee9a0c11fb53aa4639771aff9ba2704d381bd
   known_differences:
-    - "Socle pedagogique commun : Job-shop scheduling (CSP : ordonnancement machines, makespan minimal) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
-    - "Idiomes framework : Python = OR-Tools CP-SAT + deepcopy/state + search_helpers ; C# = BCL pure (System.*), 0 NuGet."
-    - "Asymetrie pedagogique : Python met l'accent sur le solveur SOTA (OR-Tools CP-SAT / library specialisee) + visualisation matplotlib + experimentation comparative ; le C# demontre l'implementation from-scratch en BCL pure (ou binding NuGet du meme solver pour App-8/10/15), presentation compacte. Meme socle theorique, leviers de demonstration differents."
+    - "Bibliotheque vs from-scratch puis lib-vs-lib : Python invoque OR-Tools CP-SAT (IntervalVar + AddNoOverlap + Minimize makespan) comme solveur SOTA. C# = deux tranches -- Tranche 1 (sections 3-4) reimplementation from-scratch pedagogique (5 regles de dispatching glouton + branch-and-bound, en BCL pure System.* 0 NuGet) PRESERVEE integralement ; Tranche 2 (PR #10382 cycle 14) ajoute Google.OrTools 9.15 (.NET natif, deja en service dans Sudoku-10/18, App-8, App-15b, App-1, App-3) avec le MEME modele canonique CP-SAT que le Python (IntervalVar par operation, precedence end<=start entre operations d'un job, AddNoOverlap par machine, AddMaxEquality+Minimize makespan) sur la MEME instance ft03 (3 jobs x 3 machines). parite verifiee : status=Optimal, makespan=11 (= Python OPTIMAL 11 ; LB=10, le moteur prouve l'optimum global). parity_level=native-both (Python/ortools ET C#/Google.OrTools atteignent chacun le moteur de production CP-SAT de leur ecosysteme)."
+    - "Asymetrie de couverture : Python (visualisation matplotlib gantt + experimentation a grande echelle avec courbe de convergence CP-SAT + search_helpers) ; C# (25 cellules : heuristiques from-scratch Tranche 1 + pont CP-SAT Tranche 2 + 3 exercices + visualisation ASCII). La visualisation matplotlib et le benchmark a grande echelle restent propres au Python ; la parite porte sur le solveur SOTA (CP-SAT) et le socle theorique (IntervalVar + NoOverlap + makespan)."
+    - "Idiomes framework : Python = OR-Tools CP-SAT (cp_model.CpModel, model.NewIntervalVar, model.AddNoOverlap, model.Minimize) ; C# = Google.OrTools.Sat (CpModel, model.NewIntervalVar, model.AddNoOverlap, model.AddMaxEquality, model.Minimize) + from-scratch System.*. Meme socle theorique (Job-Shop Scheduling, intervalles, precedence, non-chevauchement machine, makespan). Le C# valorise la reimplementation pedagogique (Tranche 1) ET l'invocation du moteur SOTA (Tranche 2) -- les intervalles etant la brique CP-SAT que les N-Reines (App-1) et le Nurse-Rostering (App-3) en booléens n'exercent pas."


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2025:CoursIA — prev: DEEP/notebook-dotnet #10396

See #10382, See #4956, See #3801

## Summary

EPIC #10382 (lib-vs-lib parity), family **Search/Applications**, dispatched to this lane by ai-01 (provisioning DM msg-20260811T002048, trio App-1/App-3/App-4 — App-1 #10392, App-3 #10396, App-4 here **completes the trio**). The C# twin `App-4b-JobShopScheduling-CSharp.ipynb` carried its cross-lang parity with the Python/OR-Tools twin **in prose only** — all 9 code cells were 5 dispatching rules + a branch-and-bound from-scratch in pure `System.*` BCL, 0 NuGet. The §6 "Complémentarité" cell explicitly framed it as "Ce twin ne remplace pas CP-SAT (qui reste l'outil SOTA, capable de prouver ft06=55)". This PR adds the missing **Tranche 2** on the App-1/App-3 gabarit: invoke the production .NET engine **Google.OrTools** (CP-SAT) on the SAME job-shop instance, and verify lib-vs-lib parity.

## The defect (firsthand, measured on origin/main)

`scripts/notebook_tools/twin_pairs.d/app-4-jobshopscheduling.yaml` registered `parity_level: semantic` with known_differences *"C# = BCL pure (System.*), 0 NuGet"* while *"Python = OR-Tools CP-SAT"*. A grep on the C# twin's code cells for `#r`, `Google.OrTools`, `CpModel`, `IntervalVar`, `AddNoOverlap` → **0 hits**. The C# side reached no engine; the Python side reaches `ortools.sat.python.cp_model`. That is exactly the #10382 finding.

## Tranche 2 (3 new cells, from-scratch sections 1-6 untouched)

Inserted after §6 "Complémentarité", before §7 Exercises (§6 framing preserved as the Tranche-1 story; Tranche-2 intro notes §6's "0 NuGet" describes Tranche 1, now bridged):

1. **`## Tranche 2 : parité lib-vs-lib via Google.OrTools CP-SAT`** (markdown) — the lib-vs-lib framing + the table of the 4 model elements (IntervalVar / precedence / NoOverlap / makespan objective).
2. **Google.OrTools 9.15 CP-SAT JSSP** (code, ec=7) — `#r "nuget: Google.OrTools"` then the canonical model: `NewIntervalVar` per operation (reusing the `ft03` instance from §1 cell2), precedence `ends[j,k] <= starts[j,k+1]`, `AddNoOverlap` per machine, `AddMaxEquality(makespan, allEnds)` + `Minimize`. Solve + schedule display.
3. **Interprétation** (markdown) — Tranche 1 = readable pedagogy (dispatching + B&B visible); Tranche 2 = production CP-SAT engine (interval machinery, optimality proof); why intervals change everything vs App-1/App-3 booleans.

## Firsthand output (committed, the parity proof)

```
Variables : 9 operations, horizon = 22
Contraintes de precedence : 6
Contraintes NoOverlap : 3 machines

CP-SAT JSSP ft03 : status=Optimal, makespan=11, temps=55,8 ms

Emploi du temps CP-SAT (makespan optimal prouve) :
  Job 0 : [M0 @0-3] [M1 @4-6] [M2 @9-11]
  Job 1 : [M0 @3-5] [M2 @5-6] [M1 @6-10]
  Job 2 : [M1 @0-4] [M2 @6-9] [M0 @9-10]

=> makespan = 11 (= jumeau Python OPTIMAL 11 ; LB = 10, le moteur prouve qu'aucun ordonnancement a 10 n'existe).
```

The engine reaches the **exact** parity markers of the Python twin: `Optimal` status, **makespan = 11** (Python: OPTIMAL makespan 11). This is parity not just on a feasible solution but on the **proven optimum**: LB=10 (max of longest job 8 and most-loaded machine M1=10) is unreachable; CP-SAT proves 11 is the global optimum. Same engine, same instance, same model semantics.

## Why this grain is genuinely distinct (variation note)

This is the **3rd DEEP/notebook-dotnet consecutive** on this lane (App-1 → App-3 → App-4). Per G-VAR-3, the same-genre carve-out ceiling is 2; a 3rd is at the edge. However, this grain is **genuinely distinct substance** (the litmus "could I generate it by scanning the instance beside it?" → NO): job-shop exercises CP-SAT's **interval machinery** (`IntervalVar` + `AddNoOverlap`), a constraint class that App-1 (`AddAllDifferent`) and App-3 (boolean coverage/load) do **not** touch. The CP-SAT bridge here required designing interval construction + precedence chains + `AddMaxEquality` for makespan — a different domain model, not a scan-generated variant. Completing ai-01's dispatched trio is committed coordinator work. **Rotation forced next cycle** to a different genre/family.

## C.1 / C.2 / execution / anti-regression

- **Anti-regression**: from-scratch tranche preserved **byte-for-byte** — 13/13 cells (0..12) source-identical to `origin/main`. The +508/-160 delta is Papermill output regeneration + 3 new Tranche-2 cells, not source changes.
- **C.1**: 0 `raise NotImplementedError`/`assert False`/`1/0`.
- **C.2**: whole notebook re-executed via `.net-csharp` kernel (10/10 code cells `execution_count` 1..10, 0 errors).
- **API (rule F + lesson dotnet-ortools-api-stringparameters)**: used proven C# CP-SAT API — `model.NewIntervalVar`, `model.AddNoOverlap(...)`, `model.AddMaxEquality(target, exprs)`, `solver.StringParameters = "max_time_in_seconds:30"`. Google.OrTools 9.15.6755 restored cleanly.
- **Path/secret hygiene**: probeAddresses banner stripped (9 lines via `strip_probe_banner.py --apply`); papermill metadata normalized to basenames; 0 machine-path leak (verified).

## Registry update

`scripts/notebook_tools/twin_pairs.d/app-4-jobshopscheduling.yaml`: `parity_level: semantic` → **`native-both`**; known_differences rewritten (two-tranche structure + chiffre-à-chiffre makespan-11 parity); audit entry via `check_twin_parity --update --pair "App-4 JobShopScheduling" --by "myia-po-2025:CoursIA"` (run LAST, #8957). Registry health: 157/157 OK, 0 DRIFT.

## Verdict SOTA (acceptance criterion 5)

**SOTA-OK** — Google.OrTools 9.15.6755 properly restored and invoked; committed output is its real CP-SAT JSSP output (Optimal, makespan 11, valid schedule). No workaround.

## Trio Search/Applications complete

App-1 ✓ (#10392, NQueens), App-3 ✓ (#10396, NurseScheduling), App-4 ✓ (here, JobShopScheduling). The dispatched trio is done; next cycle rotates genre/family per G-VAR-3.

## Why See, not Closes

Resolves ONE pair (App-4) of the 51-pair #10382 epic. The epic stays open. `See #10382`.

See #10382 (epic), See #4956 (.NET⇄Python parity marathon), See #3801 (SOTA registry).
