### PR TITLE
enrich(probas): interpret ThompsonSamplingPyMC class anatomy — Beta-Bernoulli conjugate prior (DecPyMC-7)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-7-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-7-Sequential.ipynb
@@ -2694,6 +2694,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "decpymc7-thompson-anatomy",
+   "metadata": {},
+   "source": [
+    "### Anatomie du Thompson Sampling : le couple Beta-Bernoulli conjugué\n",
+    "\n",
+    "La classe `ThompsonSamplingPyMC` matérialise un cas particulier — le **cas conjugué Beta-Bernoulli** — où la posterior se calcule en forme fermée, sans MCMC. C'est ce que la docstring appelle la « mise à jour analytique », et ce qui distingue cette cellule de la version MCMC PyMC qui suit (cellules ultérieures du §10ter).\n",
+    "\n",
+    "**Prior conjugué.** Chaque bras reçoit `Beta(alpha=1.0, beta=1.0)`, soit `Uniform[0,1]` : avant la première observation, tous les taux de succès sont équiprobables (prior non informatif). La Beta étant conjuguée à la vraisemblance Bernoulli, la posterior reste une Beta — `Beta(alpha + #succès, beta + #échec)` — d'où la fermeture analytique. C'est exactement ce que code `update` : `reward > 0.5` incrémente `alphas[arm]` (succès), sinon `betas[arm]` (échec). Le seuil `0.5` bernoullise la récompense.\n",
+    "\n",
+    "**`select_arm` = échantillonnage posterior (le cœur de Thompson).** À chaque tour, on tire un `theta_i ~ Beta(alpha_i, beta_i)` par bras (`self.rng.beta`) et on joue le bras de `theta` maximal (`np.argmax`). C'est le *probability matching* : la probabilité que le bras *i* soit ainsi sélectionné approche la probabilité posterior que *i* soit le bras optimal. Un bras peu essayé conserve une Beta large — il reçoit parfois un `theta` élevé, ce qui déclenche l'**exploration** ; le bras qui accumule les succès voit sa Beta se concentrer près de sa vraie moyenne et, s'il est le meilleur, est joué presque à chaque tour — c'est l'**exploitation**. L'équilibre explore/exploite émerge de l'incertitude posterior elle-même, sans aucun hyperparamètre (contrairement au $\\varepsilon$ de $\\varepsilon$-greedy ou au bonus d'incertitude d'UCB1).\n",
+    "\n",
+    "**Lecture des posteriors affichées.** Après 2000 tirages, le bras optimal (index 2, moyenne vraie 0.7) converge vers `Beta(1219, 680)` — moyenne posterior 0.642, densité très concentrée grâce aux 1897 tirages reçus. Les trois bras sous-optimaux (0, 1, 3) ne totalisent que 23 à 54 tirages chacun : leurs Beta restent larges, car Thompson les délaisse dès que leur posterior passe sous celle du bras 2. Le regret cumulé (32.3) est le plus bas des trois stratégies à exploration explicite. Greedy affiche ici un regret négatif (-43.6), mais par chance de la graine : il s'est verrouillé très tôt sur le bras 2 et n'explore jamais, ce qui le rend fragile — sur une autre graine, ce verrouillage peut survenir sur un bras sous-optimal (cf. tableau de comparaison ci-après).\n",
+    "\n",
+    "La figure suivante trace (à gauche) les courbes de regret cumulé et (à droite) la densité de ces posteriors Beta : la concentration de la densité sur le bras 2 y est visible, tout comme l'aplanissement des Beta sous-optimales peu échantillonnées."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 18,
    "id": "9a7b6a29",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: DEEP/notebook-dotnet

## Summary

Enrichissement pédagogique de `DecPyMC-7-Sequential.ipynb` (Probas/DecisionTheory/PyMC, le capstone de la série : décision séquentielle sous incertitude — POMDP, value iteration, reward shaping, Thompson Sampling). Le notebook portait un **gap d'interprétation de longueur 3** (3 cellules code consécutives sans markdown pour les interpréter) sur la classe `ThompsonSamplingPyMC` — l'architecture entière de la classe (prior Beta conjugué, échantillonnage posterior, mise à jour analytique) s'exécutait sans une seule cellule d'interprétation entre le header de section et le tableau de comparaison générique qui suivait.

Cette PR ajoute **une** cellule markdown d'interprétation (`### Anatomie du Thompson Sampling : le couple Beta-Bernoulli conjugué`) insérée après la cellule code de la classe (index 49), avant la cellule du tracé regret/posteriors. C'est la rotation de genre de la lane : après 3 grains DEEP/notebook-dotnet consécutifs (#10392, #10396, #10400 — trio Search/Applications Google.OrTools CP-SAT livré), G-VAR-3 force un changement de genre ; ce grain MED/notebook-python est la substance dans un registre différent.

## Le defect pédagogique (firsthand, mesuré sur origin/main)

Balayage du notebook cellule par cellule (kernel `python3`, 67 cellules dont 23 code) : les cellules **[47], [48], [49]** sont trois cellules code consécutives :

- `[47] c16` — `import pymc as pm` + print des versions
- `[48] c17` — `class ThompsonSamplingPyMC:` (classe complète : prior `Beta(alpha=1.0, beta=1.0)`, `select_arm` échantillonne `rng.beta` puis `argmax`, `update` fait la mise à jour conjuguée `reward > 0.5 ? alphas+=1 : betas+=1`) + `GreedyStrategy` + `run_bandit_tracking` + instanciation 4 stratégies + run 2000 tirages
- `[49] c18` — `plt.subplots` tracé regret + densité posteriors Beta

**Aucune cellule markdown n'interprète cette classe** entre le header `## 10ter` [46] et le tableau de comparaison `### Interpretation : Comparaison des 4 stratégies` [50] (qui, lui, est générique — un tableau "Résultats attendus" sans lire la sortie réelle). Le lecteur voit une classe de 40 lignes définir un prior Beta, échantillonner, mettre à jour — sans aucune explication du *pourquoi* Beta, du *pourquoi* échantillonner puis argmax, ni de ce que les posteriors affichées (`Beta(1219, 680)`) signifient. C'est le pattern canonique du gap MED : du code qui tourne sans être interprété.

## L'enrichissement (1 cellule markdown, après [48])

La nouvelle cellule interprète l'**anatomie de la classe** en trois axes ancrés dans le code réel :

1. **Prior conjugué** — pourquoi `Beta(1,1)=Uniform` (prior non informatif), conjugualité Beta-Bernoulli (`Beta(alpha + #succès, beta + #échec)`, fermeture analytique = la "mise à jour analytique" de la docstring), et le seuil `0.5` qui bernoullise la récompense.
2. **`select_arm` = probability matching** — échantillonner `theta_i ~ Beta(alpha_i, beta_i)` puis `argmax` approche `P(bras i optimal | données)` ; l'exploration émerge de l'incertitude posterior (Beta large = exploration occasionnelle), sans hyperparamètre (contraste avec ε-greedy et UCB1).
3. **Lecture des posteriors affichées** — `Beta(1219, 680)` sur le bras optimal (1897 tirages, moyenne post 0.642 vs vraie 0.7), Beta larges sur les sous-optimaux (23–54 tirages), regret 32.3 le plus bas des stratégies à exploration explicite. Note honnête sur le Greedy "-43.6" : regret négatif par chance de graine (verrouillage précoce sur le bras 2), fragile — nuance que le tableau générique [50] passe sous silence.

La cellule ponte vers la figure suivante (courbes de regret + densités Beta) et vers la version MCMC PyMC qui suit (§10ter-suite), distinguant le cas conjugué analytique du cas non-conjugué.

## Firsthand grounding (preuve de code-grounded, pas de prose générique)

La cellule cite des artefacts réels mesurés sur le notebook :
- Identifiants code exacts : `ThompsonSamplingPyMC`, `select_arm`, `update`, `self.rng.beta`, `alphas[arm]`, `betas[arm]`, `np.argmax`, le prior `Beta(alpha=1.0, beta=1.0)`.
- Sortie réellement committe par [48] : `Beta(1219, 680)` bras 2, moyennes posteriors `[0.360, 0.482, 0.642, 0.429]`, regret Thompson 32.3, regret Greedy -43.6, tirages `[23, 54, 1897, 26]`.
- Terminologie cohérente avec le notebook : "posterior" (anglicisme déjà utilisé en [46]/[50]), `$\varepsilon$-greedy` (style LaTeX de [50]).

## C.1 / C.2 / anti-regression / exécution

- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` (scan clean sur le notebook entier — n/a de toute façon, markdown-only).
- **C.2 (exception markdown-only)** : la modification est **uniquement l'ajout d'une cellule markdown**. Vérifié par comparaison byte-for-byte programmatoire : **0 mismatch** entre les 67 cellules originales (source + outputs + execution_count + metadata) et les cellules correspondantes du nouveau notebook (68 cellules). Les 23 cellules code conservent leurs outputs et leur `execution_count` (1..23). Aucune re-exécution nécessaire — les outputs précédents restent valides (exception C.2 « modifs uniquement markdown -> outputs précédents valides »).
- **Anti-regression** : diff = **18 insertions, 0 deletions, 1 fichier**. Pure addition, aucune cellule source modifiée ou supprimée.
- **nbformat** : structure 4.5 saine, toutes les cellules ont un `id`.
- **Markdown-rendering detector** : la nouvelle cellule ne déclenche aucun warning (les 2 WARN préexistants sur cells #36/#39 section Gittins sont hors-scope, non introduits par cette PR).
- **Diff stat** : `1 file changed, 18 insertions(+)`.

## Variation note (G-VAR-3)

prev = DEEP/notebook-dotnet (#10400, App-4 JobShopScheduling Google.OrTools CP-SAT), lui-même précédé de #10396 et #10392 — **3 grains DEEP/notebook-dotnet consécutifs** sur la lane dans le domaine Search/Applications. Le trio étant livré, G-VAR-3 force la rotation de genre. Ce grain MED/notebook-python (famille Probas/DecisionTheory/PyMC) est une **substance genuinement distincte** : non générable par scan (le litmus « pourrais-je produire le suivant en scannant le notebook d'à-côté ? » → NON ; il a fallu lire la classe, comprendre le mécanisme Beta-Bernoulli conjugué, confronter la sortie committe au tableau générique [50], et formuler l'interprétation du probability matching + la nuance de graine sur Greedy). Rotation de genre + domaine + langage (C# → Python, Search → Probas).

## Pourquoi pas de Closes

Enrichissement pédagogique auto-alimenté (rotation de pool), non lié à une issue spécifique à clôturer. Améliore la richesse interprétative du capstone de la série DecPyMC.
