### PR TITLE
fix(ci,#10403): advisory guards 2-point git diff -> 3-point (scope to PR's own apport)

### DIFF
--- a/.github/workflows/cjk-residue-advisory.yml
+++ b/.github/workflows/cjk-residue-advisory.yml
@@ -58,6 +58,12 @@ jobs:
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
+        with:
+          # Need full history: the 3-point "$BASE...$HEAD" diff below resolves
+          # the merge-base of BASE and HEAD (#10403). fetch-depth 1 would miss
+          # the merge-base and the diff would fail instead of scoping to this
+          # PR's own apport.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -83,7 +89,10 @@ jobs:
           # files, which is learned-to-be-ignored even faster than #8822's
           # "label survives its cause". The fleet scan stays (informational
           # notice below); only the PR's own apport can trigger its label.
-          git diff --name-only --diff-filter=d "$BASE" "$HEAD" > changed.txt || true
+          # 3-point diff (#10403): "$BASE...$HEAD" diffs from the merge-base of
+          # BASE and HEAD, i.e. strictly what THIS branch introduced -- not the
+          # union of both directions that a 2-point "$BASE" "$HEAD" reports.
+          git diff --name-only --diff-filter=d "$BASE...$HEAD" > changed.txt || true
 
           python scripts/notebook_tools/detect_cjk_residue.py --json --check --stdin \
             < changed.txt > pr_payload.json 2> pr_scan.log || true

--- a/.github/workflows/dotnet-nuget-block-advisory.yml
+++ b/.github/workflows/dotnet-nuget-block-advisory.yml
@@ -80,7 +80,8 @@ jobs:
           set -uo pipefail
 
           # Added/modified *.ipynb in the PR (deletions excluded).
-          git diff --name-only --diff-filter=d "$BASE" "$HEAD" -- '*.ipynb' \
+          # 3-point diff (#10403): merge-base...HEAD -- strictly this PR's apport.
+          git diff --name-only --diff-filter=d "$BASE...$HEAD" -- '*.ipynb' \
             | grep -v $'\r$' > changed_ipynb.txt || true
           COUNT=$(wc -l < changed_ipynb.txt | tr -d ' ')
           echo "Modified *.ipynb in this PR: $COUNT"

--- a/.github/workflows/exercises-advisory.yml
+++ b/.github/workflows/exercises-advisory.yml
@@ -79,7 +79,8 @@ jobs:
 
           # Added/modified *.ipynb in the PR (deletions excluded -- a deleted
           # notebook has nothing to count).
-          git diff --name-only --diff-filter=d "$BASE" "$HEAD" -- '*.ipynb' \
+          # 3-point diff (#10403): merge-base...HEAD -- strictly this PR's apport.
+          git diff --name-only --diff-filter=d "$BASE...$HEAD" -- '*.ipynb' \
             | grep -v $'\r$' > changed_ipynb.txt || true
           COUNT=$(wc -l < changed_ipynb.txt | tr -d ' ')
           echo "Modified *.ipynb in this PR: $COUNT"

--- a/.github/workflows/markdown-table-guard.yml
+++ b/.github/workflows/markdown-table-guard.yml
@@ -77,7 +77,8 @@ jobs:
           # Added/modified *.ipynb + *.md + README* in the PR (deletions
           # excluded). Skip vendored / archived trees where we do not enforce
           # this (.lake/ Mathlib, docs/_archives/, node_modules).
-          git diff --name-only --diff-filter=d "$BASE" "$HEAD" \
+          # 3-point diff (#10403): merge-base...HEAD -- strictly this PR's apport.
+          git diff --name-only --diff-filter=d "$BASE...$HEAD" \
             -- '*.ipynb' '*.md' '*README*' \
             | grep -v -E '^(\.lake/|docs/_archives/|node_modules/)' \
             | grep -v $'\r$' > changed.txt || true

--- a/.github/workflows/repo-size-advisory.yml
+++ b/.github/workflows/repo-size-advisory.yml
@@ -50,7 +50,10 @@ jobs:
               echo "::warning file=${path}::Blob ajoute de ${mb} MiB (> seuil advisory 10 MiB). Policy docs/reference/repo-size-policy.md : LFS candidate ou justification pedagogique requise."
               found=1
             fi
-          done < <(git diff --raw --diff-filter=A "${BASE}" "${HEAD}" 2>/dev/null)
+          # 3-point diff (#10403): merge-base...HEAD -- strictly this PR's apport
+          # (a 2-point "${BASE}" "${HEAD}" would also flag blobs main gained
+          # since the branch point, which this PR never touched).
+          done < <(git diff --raw --diff-filter=A "${BASE}...${HEAD}" 2>/dev/null)
           if [ "$found" -eq 1 ]; then
             echo "ATTENTION : un ou plusieurs blobs depassent le seuil advisory. Voir policy docs/reference/repo-size-policy.md."
           else

--- a/.github/workflows/slides-build-advisory.yml
+++ b/.github/workflows/slides-build-advisory.yml
@@ -203,11 +203,12 @@ jobs:
           TOUCHED=()
           for t in "${TARGETS[@]}"; do
             dir="$(dirname "$t")"
-            if git diff --name-only --diff-filter=d "$BASE" "$HEAD" -- "$dir/" | grep -q .; then
+            if git diff --name-only --diff-filter=d "$BASE...$HEAD" -- "$dir/" | grep -q .; then
               TOUCHED+=("$t")
             fi
           done
-          SHARED=$(git diff --name-only --diff-filter=d "$BASE" "$HEAD" \
+          # 3-point diff (#10403): merge-base...HEAD -- strictly this PR's apport.
+          SHARED=$(git diff --name-only --diff-filter=d "$BASE...$HEAD" \
             -- 'slides/theme-ia101/' 'slides/package.json' 'slides/package-lock.json' \
             | head -1)
           if [ -n "$SHARED" ]; then


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python

See #10403

## Summary

Six advisory CI workflows computed « les fichiers modifiés par cette PR » with a **2-point** `git diff "$BASE" "$HEAD"`. On a diverged branch (a PR branched behind a main that kept merging), a 2-point diff reports the union of both directions — attributing to the PR every file main gained since the branch point. The cost: **false accusatory labels on clean PRs**. The trio #10392/#10396/#10400 carried the `dotnet-block-without-nuget` label sourced from a foreign `GameTheory-4-NashEquilibrium-Csharp.ipynb` they never touched (issue measured `Modified *.ipynb in this PR: 7` where the true count was 1).

This PR switches all six to the **3-point** `"$BASE...$HEAD"` form (diffs from the merge-base of BASE and HEAD — strictly what this branch introduced), and adds the missing `fetch-depth: 0` to the one workflow that lacked it.

## Firsthand scope (G.1 — found a 6th file the issue missed)

The issue's grep `git diff[^|]*"\$BASE" *"\$HEAD"` matches the `$BASE`/`$HEAD` form **without** braces. A full firsthand scan of `.github/workflows/*.yml` for every `git diff` involving BASE/HEAD found **6** buggy files (7 occurrences), not 5 — `repo-size-advisory.yml:53` uses the **brace-syntax** `"${BASE}" "${HEAD}"` and escaped the issue's grep:

| file | line(s) | form |
|------|---------|------|
| cjk-residue-advisory.yml | 95 | `"$BASE" "$HEAD"` |
| dotnet-nuget-block-advisory.yml | 84 | `"$BASE" "$HEAD"` |
| exercises-advisory.yml | 83 | `"$BASE" "$HEAD"` |
| markdown-table-guard.yml | 81 | `"$BASE" "$HEAD"` |
| **repo-size-advisory.yml** | 57 | `"${BASE}" "${HEAD}"` ← brace form, missed by issue grep |
| slides-build-advisory.yml | 206, 211 | `"$BASE" "$HEAD"` (×2) |

The already-correct gates (`bare-cross-dir-load-gate`, `cell-order-gate`, `degenerate-figure-gate`, `fabricated-output-gate`, `regression-guard`, `svg-*-gate`, `catalog-guard`, `translation-guard`) all use `"$BASE"...HEAD` — this PR aligns the six laggards to that canonical form.

## The fix

One-line change per occurrence: `"$BASE" "$HEAD"` → `"$BASE...$HEAD"` (3-point; uses the existing `$HEAD` env var = unambiguous PR head sha). For `repo-size-advisory.yml` the brace form `"${BASE}...${HEAD}"`. Each line carries a `# 3-point diff (#10403)` comment so the next copy-paste doesn't regress.

**`cjk-residue-advisory.yml` also gains `fetch-depth: 0`** (it was `actions/checkout@v4` with default `fetch-depth: 1`). Without the merge-base present, the 3-point diff would *fail* instead of over-reporting — a availability regression. The other five already had `fetch-depth: 0`.

## Acceptance criteria — all 3 verified firsthand

**1. No 2-point diff remains (both grep variants empty):**
```
$ grep -rnE 'git diff[^|]*"\$BASE" *"\$HEAD"' .github/workflows/*.yml   # issue's exact pattern
(exit 1 = empty)
$ grep -rnE 'git diff[^|]*"\$\{BASE\}" *"\$\{HEAD\}"' .github/workflows/*.yml   # brace form
(exit 1 = empty)
```
3-point form now present in all 6 files.

**2. fetch-depth verified for each (merge-base reachable):**
```
cjk-residue-advisory.yml     : fetch-depth:0 count=1  (ADDED by this PR)
dotnet-nuget-block-advisory  : fetch-depth:0 count=1
exercises-advisory.yml       : fetch-depth:0 count=1
markdown-table-guard.yml     : fetch-depth:0 count=1
repo-size-advisory.yml       : fetch-depth:0 count=1
slides-build-advisory.yml    : fetch-depth:0 count=1
```

**3. Proof on a diverged branch (the only case where the defect is visible):**

Built a synthetic divergence: `fakemain` branches from `A=17dc97b19` and **modifies** `GameTheory-4-NashEquilibrium-Csharp.ipynb` (simulating main gaining a change since the branch point); the PR head = `A` + this PR's workflow edits (touches 0 notebooks).

```
merge-base(fakemain, PR_head) = 17dc97b19 (= A, the branch point)

2-POINT (buggy): git diff --diff-filter=d fakemain PR_head -- '*.ipynb'
  MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
  >>> count = 1   <- foreign notebook the PR never touched APPEARS

3-POINT (fixed): git diff --diff-filter=d fakemain...PR_head -- '*.ipynb'
  >>> count = 0   <- foreign notebook correctly EXCLUDED
```

The 2-point form flags a file modified on main's side since the branch point — exactly the false-accusation path. The 3-point form scopes to what the branch introduced. (The synthetic `fakemain` branch + sentinel were discarded; the feature branch's own 3-point perimeter is the 6 workflow files only.)

## YAML + diff

- **YAML validity**: 0 parse errors across all `.github/workflows/*.yml` (python yaml).
- **Diff stat**: `6 files changed, 23 insertions(+), 7 deletions(-)`. The deletions are the old 2-point lines being replaced — coherent with intent.

## Why this matters now

The false-accusation rate is proportional to merge velocity: the parasite perimeter is exactly the set of files main gained since the branch point. The defect is most active when a coordinator has the least attention to spare — the night the trio shipped, ten PRs merged in three hours and three irreproachable PRs carried an accusatory label sourced from a fourth notebook. These five workflows were written with the *explicit* intent not to falsely accuse (e.g. `cjk-residue-advisory.yml` comment: « only the PR's own apport can trigger its label »); the 2-point diff silently defeated that intent. The guards are advisory (`exit 0`, the signal is the label) — the cost is human-reading time and trust erosion, not a hard block.

## Variation note (G-VAR-3)

prev = MED/notebook-python (DecPyMC-7 Thompson Sampling interpretation). This grain MED/guard (CI infra correctness) is a **different genre and domain** — rotation satisfied. Genuinely distinct substance (not scan-generable): required understanding 2-point vs 3-point `git diff` semantics, the merge-base/fetch-depth availability interaction, and a firsthand G.1 expansion that found a 6th instance the issue's grep missed (brace syntax). High leverage — fixes false accusatory labels across the saturated merge pool.

See #10403 (this resolves the issue — all 3 acceptance criteria met).
