### PR TITLE
fix(gametheory,#10382): GT-6 Axelrod verdict INTRINSIC (axelrod not bridgeable to .NET)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust-Csharp.ipynb
@@ -1445,11 +1445,12 @@
     "\n",
     "### Référence SOTA\n",
     "\n",
-    "Le twin Python [GameTheory-6-EvolutionTrust](GameTheory-6-EvolutionTrust.ipynb) utilise la librairie **`axelrod`** (200+ stratégies, tournoi, analyse) + **numpy/matplotlib** (animation de la dynamique). Cette lib est l'outil SOTA de recherche en IPD. Le twin C# rend **explicites** les briques qu'elle orchestre (moteur, stratégies, tournoi, ODE). En production : axelrod. En pédagogie : comprendre chaque brique, from-scratch.\n",
+    "Le twin Python [GameTheory-6-EvolutionTrust](GameTheory-6-EvolutionTrust.ipynb) utilise la librairie **`axelrod`** (200+ stratégies, tournoi, analyse) + **numpy/matplotlib** (animation de la dynamique). Cette lib est l'outil SOTA de recherche en IPD. **Verdict INTRINSIC (bucket-3, #10382)** : `axelrod` est une librairie **Python pure** (Knight, Glynatsi et al.) — aucun binding .NET n'existe (pas de NuGet « Axelrod.NET »), ce n'est **pas un binaire CLI** invocable par `Process.Start` (à la différence de clingo ou Fast Downward qui le sont ; on ne l'utilise que via `import axelrod as axl` / `axl.Tournament` / `axl.Match`), et ce n'est **pas du Java** (IKVM ponte Java, pas Python — à la différence de Tweety qui est bridgeable via IKVM). Le pont Python → .NET n'est donc pas viable. Le from-scratch C# EST la contrepartie légitime et **définitive** : là où Python délègue à `axelrod` (200+ stratégies, tournoi round-robin, analyse), le C# rend visibles les briques qu'elle orchestre (moteur IPD, stratégies, tournoi, ODE du réplicateur), au niveau de parité `semantic`. En production : axelrod. En pédagogie : comprendre chaque brique, from-scratch.\n",
     "\n",
     "---\n",
     "\n",
-    "**Marathon #4956** — twin C# .NET ⇄ Python. Suite de [GameTheory-3-Topology2x2-Csharp](GameTheory-3-Topology2x2-Csharp.ipynb). Voir #4956, #3801. Revue souhaitée : ai-01, po-2024 (GameTheory/.NET owner), po-2025.\n"
+    "**Marathon #4956** — twin C# .NET ⇄ Python. Suite de [GameTheory-3-Topology2x2-Csharp](GameTheory-3-Topology2x2-Csharp.ipynb). Voir #4956, #3801. Revue souhaitée : ai-01, po-2024 (GameTheory/.NET owner), po-2025.\n",
+    ""
    ]
   }
  ],

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-6-evolutiontrust.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-6-evolutiontrust.yaml
@@ -20,7 +20,14 @@
       csharp_sha: b1352e95a88555910b1b7bcfb90feb12891dc752
       content_python_sha: eccc57ad4442f22d1265df4a1350df0e8cbeba2414bb232daab4d3ec5085723b
       content_csharp_sha: a4375abf7c054c784da7754716810ee0a34dd1bd31d5a9e27034782e42ae6973
+    - date: "2026-08-11"
+      by: myia-po-2023:CoursIA
+      python_sha: db8f5ea35f0f891863bcf212bc112b031cafa494
+      csharp_sha: 86bb63cf6ba54b85b0d6ee67348f81db377f2f8d
+      content_python_sha: eccc57ad4442f22d1265df4a1350df0e8cbeba2414bb232daab4d3ec5085723b
+      content_csharp_sha: fd6487e762f7c7f4ca1d52d42c62819a1c3efad8af1930420733a1225c2e12bd
   known_differences:
     - "Socle pedagogique commun : Dilemme du Prisonnier Itere (IPD), tournoi d'Axelrod, strategies classiques (TitForTat, Pavlov, Generous TitForTat), dynamique evolutive (processus de Moran), emergence de la cooperation."
     - "Idiomes framework : Python = `numpy` + `matplotlib` + `matplotlib.animation` (viz dynamique du tournoi round-robin + courbes de Moran). C# = pur `System.*` (Collections.Generic, Linq) + moteur IPD from-scratch (T=5/R=3/P=1/S=0 convention Axelrod) ; 0 NuGet tiers."
     - "Asymetrie pedagogique : Python utilise matplotlib.animation pour la viz dynamique (gif-like) du tournoi + process de Moran ; le C# travaille en pur System.* sans viz dynamique (asci-art + tableaux). Meme socle theorique (Axelrod + Moran), leviers de demonstration differents (viz riche cote Python, code from-scratch minimaliste cote C#)."
+    - "Verdict INTRINSIC bucket-3 (#10382, 2026-08-11) : la librairie `axelrod` (Knight, Glynatsi et al.) est Python pure -- aucun binding .NET n'existe (pas de NuGet), ce n'est pas un binaire CLI invocable (a la difference de clingo/Fast Downward ; usage exclusif via `import axl`/`axl.Tournament`/`axl.Match`), et ce n'est pas du Java (IKVM ponte Java pas Python, a la difference de Tweety). Le pont Python->.NET n'est pas viable. Le from-scratch C# EST la contrepartie legitime et DEFINITIVE : niveau `semantic` (le from-scratch enseigne les memes concepts IPD/Axelrod/Moran), l'asymetrie axelrod fermee comme intrinseque. Verdict explicite ajoute dans la conclusion du notebook C# (markdown-only)."


### PR DESCRIPTION
## Quoi

Classify the **GameTheory-6-EvolutionTrust-Csharp** parity verdict definitively as **INTRINSIC (bucket-3)** — issue #10382 (dispatch partition GameTheory).

The conclusion previously *described* the axelrod asymmetry (Python delegates to the SOTA IPD library, C# is from-scratch) but did **NOT** state an explicit parity verdict. This PR adds the INTRINSIC classification with the bridgeability reasoning, closing the bucket-3 question for GT-6.

## Preuve (G.1 firsthand)

- **Python twin** ([GameTheory-6-EvolutionTrust.ipynb](MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust.ipynb)): `import axelrod as axl` → `axl.Tournament`, `axl.Match`, 200+ strategies. **Confirmed delegates to axelrod.**
- **C# twin**: 0 reference to any axelrod .NET lib — the 29 "axelrod" hits are prose explaining the comparison. Code = from-scratch pur `System.*` (0 NuGet, T=5/R=3/P=1/S=0 IPD engine). **Confirmed from-scratch.**

### Bridgeability analysis (why INTRINSIC)

`axelrod` (Knight, Glynatsi et al.) is a **pure-Python research library**:
- **No .NET binding** exists (no NuGet "Axelrod.NET").
- **Not a CLI binary** invocable via `Process.Start` — unlike clingo / Fast Downward (bucket-2 recoverable); usage is `import axl` / `axl.Tournament` / `axl.Match`.
- **Not Java** — IKVM bridges Java, not Python (unlike Tweety, which IS bridgeable via IKVM).
- Python→.NET bridge (pythonnet, IronPython) not viable for a research library of this scope.

→ The from-scratch C# IS the legitimate and **definitive** counterpart. `parity_level` stays `semantic` (both teach the same IPD/Axelrod/Moran concepts; the from-scratch renders visible what axelrod encapsulates).

### Reserve honnête

Searched for a credible .NET IPD-tournament library: none exists for axelrod-class iterated games (no NuGet, no IKVM path, axelrod is import-only not CLI). The INTRINSIC verdict holds.

## Perimetre

- **Notebook**: markdown-only change to conclusion cell[27] of [GameTheory-6-EvolutionTrust-Csharp.ipynb](MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust-Csharp.ipynb) (+728/-427 chars). **0 code cell touched** (C.2 exception markdown-only, no re-exec).
- **Twin registry**: `twin_pairs.d/gametheory-6-evolutiontrust.yaml` — added a `known_differences` entry carrying the INTRINSIC verdict. `parity_level` stays `semantic`. Re-attested via `check_twin_parity.py --update --force` after commit → `csharp_sha: 86bb63cf` matches the actual committed git blob; `content_csharp_sha` correctly rebaselined.

## Validation

- **C.1**: 0 (no stub/NotImplementedError touched — markdown only).
- **C.2**: markdown-only exception (no code cell, no re-exec needed).
- **H.3**: 0 cell with `execution_count=null` + no outputs.
- **Diff**: +10/-2 (2 files), markdown-only.

Grain: MED/notebook-dotnet CONTENT — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-dotnet #10394 (GT-13 CFR INTRINSIC). R6: bucket-3 verdict prose, family GameTheory (axelrod iterated-games subfamily, distinct from GT-13 CFR extensive-form).

See #10382 (bucket-3 partial — open_spiel GT-7/17 + nashpy GT-2/4/5 remain). See #4956 (epic parity .NET<=>Python).

🤖 Generated with [Claude Code](https://claude.com/claude-code)