### PR TITLE
Add(iit,#enrichment): IIT-2 interpretation cells for 4-node ring Big Phi (gap §6.2)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb
@@ -41,7 +41,7 @@
     "8. **Vers IIT 4.0** - Apercu des evolutions recentes de la théorie"
    ]
   },
-    {
+  {
    "cell_type": "markdown",
    "id": "ict-bridge-cadrage",
    "metadata": {
@@ -1120,6 +1120,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "iit2-md-ring-lecture",
+   "metadata": {},
+   "source": [
+    "### Lecture du reseau 4 noeuds : un anneau NON-LINEAIRE\n",
+    "\n",
+    "La matrice de connectivite decrit un **anneau a 4 noeuds** : chaque noeud a exactement deux voisins (A est relie a {B, C}, B a {A, D}, C a {A, D}, D a {B, C}). La subtilite est dans le choix des **portes logiques** :\n",
+    "\n",
+    "- A et C utilisent une porte **AND** (`a_next = B and C`, `c_next = A and D`)\n",
+    "- B et D utilisent une porte **OR** (`b_next = A or D`, `d_next = B or C`)\n",
+    "\n",
+    "Pourquoi pas du XOR pur ? Un anneau XOR est **lineaire sur GF(2)** : chaque sortie est une combinaison lineaire des entrees, le reseau est alors parfaitement decomposable et son Big $\\Phi$ vaut **0 a tous les etats**. Les portes AND/OR introduisent de la **non-linearite** : elles melangent l'information de facon irreductible, ce qui garantit un Big $\\Phi > 0$. C'est ce que nous allons mesurer maintenant, en deux temps : d'abord la **structure cause-effet** (CES = l'ensemble des concepts du systeme), puis le **Big $\\Phi$** (l'integration irreductible du systeme entier, via la partition MIP)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 14,
    "id": "6a77f701",
@@ -1306,6 +1321,31 @@
     "3. **Les reseaux recurrents peuvent avoir Phi > 0** : notre anneau non-lineaire exhibe une integration irreductible — CES non-vide, $\\Phi > 0$, et une vraie coupe MIP (pas un `NullCut`)\n",
     "4. **Decomposabilite topologique et effondrement de $\\Phi$** : a l'inverse du 3-noeuds ($\\Phi = 1{,}875$), l'anneau 4-noeuds de cette section a une connectivite **bipartite** ({A, D} d'un cote, {B, C} de l'autre). Muni de portes XOR pures, cette topologie serait **lineaire sur GF(2)** et donc **parfaitement decomposable** : son Big Phi s'effondrerait **theoriquement a 0**, sans information irreductible. C'est precisement pour eviter ce piege que cette section emploie des portes **AND/OR non-lineaires**, qui preservent l'irreductibilite (Big Phi empirique = **0,2569**, calcule ci-dessus). La lecon : ce n'est pas la linearite *en soi* qui detruit l'integration (le XOR 3-noeuds l'atteint a 1.875), c'est la **decomposabilite topologique** qu'elle autorise sur certaines structures — d'ou l'interet des portes non-lineaires AND/OR sur ce 4-noeuds.\n",
     "5. **La symetrie** de la connectivite influence la distribution des concepts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "iit2-md-interpretation-62",
+   "metadata": {},
+   "source": [
+    "### Lecture : non-lineaire OUI, mais faiblement integre\n",
+    "\n",
+    "Les trois cellules ci-dessus livrent un resultat **contre-intuitif**, qu'il faut decomposer en deux niveaux.\n",
+    "\n",
+    "**1. La non-linearite a bien fait son travail.** Le reseau 4 noeuds a un Big $\\Phi = 0.2569 > 0$ : contrairement a un anneau XOR pur (lineaire sur GF(2), $\\Phi = 0$), les portes AND/OR rendent le systeme irreductiblement integre. La prediction de la cellule de definition est confirmee — il y a bien de l'integration.\n",
+    "\n",
+    "**2. Mais cette integration est faible — environ 7× inferieure au reseau XOR 3 noeuds.** Le contraste est frappant :\n",
+    "\n",
+    "| Reseau | Topologie | Big $\\Phi$ | Coupe MIP |\n",
+    "|---|---|---|---|\n",
+    "| 3 noeuds (XOR, triangle complet) | chaque noeud liee aux 2 autres | **1.8750** | {B} ─ {A,C} |\n",
+    "| 4 noeuds (anneau AND/OR) | cycle a 4 | **0.2569** | {A,B} ─ {C,D} |\n",
+    "\n",
+    "Comment un reseau **non-lineaire** peut-il etre si peu integre face a un reseau **lineaire** (le XOR 3 noeuds) ? La reponse est dans la **coupe MIP**. Pour le 4-noeuds, la partition qui detruit le moins d'information separe proprement {A,B} de {C,D} : l'anneau a 4 admet une **bipartition naturelle** en deux moities symetriques qui interagissent peu entre elles. Le Big $\\Phi$ mesure le cout de la coupe la moins couteuse ; ici ce cout est faible, donc $\\Phi$ est faible. Le triangle 3-noeuds, lui, n'a pas de telle bipartition equitable — toute coupe isole un noeud unique du reste, ce qui detruit beaucoup d'information, d'ou un $\\Phi$ eleve.\n",
+    "\n",
+    "**3. La CES confirme cette symetrie.** Les 4 concepts se groupent en deux paires identiques : les concepts de A et D (mecanismes $(0,)$ et $(3,)$) ont tous deux $\\varphi = 0.25$ avec cause et effect portes sur {B, C} ; ceux de B et C ($(1,)$ et $(2,)$) ont $\\varphi = 0.1667$ avec cause et effect portes sur {A, D}. Cette symetrie {A, D} $\\leftrightarrow$ {B, C} est la ligne de faille geometrique que la MIP exploite pour couper le reseau a bas cout.\n",
+    "\n",
+    "**Lecon IIT** : **plus de noeuds n'implique pas plus d'integration.** Ce n'est ni la taille du reseau, ni meme la non-linearite de ses portes, qui determine $\\Phi$, mais la **robustesse de l'integration face au partitionnement**. Un petit reseau densement connecte peut etre bien plus integre qu'un grand reseau a topologie d'anneau, ou une bipartition naturelle existe. C'est pourquoi IIT definit $\\Phi$ comme le *minimum* sur toutes les partitions possibles : la MIP revele le maillon le plus faible, et c'est ce maillon qui borne l'integration du systeme entier."
    ]
   },
   {
@@ -1806,7 +1846,7 @@
     "- **Series connexes** : [Probas](../Probas/README.md), [GameTheory](../GameTheory/README.md)"
    ]
   },
-    {
+  {
    "cell_type": "markdown",
    "id": "ict-bridge-transition",
    "metadata": {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: DEEP/notebook-dotnet #10401

# IIT-2-AdvancedTopics : interprétation du résultat Big Phi du réseau 4-nœuds (gap §6.1-6.2)

Rotation de genre G-VAR-3 (3 notebook-dotnet consécutifs → notebook-python).

## Problème

`IIT-2-AdvancedTopics.ipynb` section 6 comportait un **défaut pédagogique** vérifié firsthand :

- **cells[26], [27], [28]** = 3 cellules code **consécutives** sans markdown entre elles : définition du réseau 4-nœuds (anneau AND/OR), analyse CES, calcul Big Phi.
- **section 6.2 « Interpreter les résultats »** (cell[29]) = un **header au corps vide** — suivi directement d'une ancre `sec7` puis d'une nouvelle section.
- Le résultat de cell[28] est **contre-intuitif et non interprété** : Big Phi du réseau 4-nœuds non-linéaire (AND/OR) = **0.2569**, soit ~7× **inférieur** au réseau XOR 3-nœuds (**1.8750**). Cell[26] prépare l'attente « non-linéarité → Big Phi > 0 » mais la magnitude faible et la comparaison nulle part expliquées.

Un étudiant lisant ce notebook reste sans explication du fait qu'un réseau *non-linéaire* soit moins intégré qu'un réseau *linéaire*.

## Solution

Ajout de **2 cellules markdown** (markdown-only, **0 cellule code modifiée** → C.2/C.3 ne requièrent pas de re-exécution) :

- **MD1 (cell 27)** — transition entre la définition de l'anneau et l'analyse CES : explique la topologie (anneau à 4, chaque nœud a 2 voisins), l'assignation des portes (A,C = AND ; B,D = OR), et pourquoi pas du XOR pur (anneau XOR = linéaire sur GF(2) → parfaitement décomposable → Big Φ = 0, d'où la nécessité des portes non-linéaires pour garantir Φ > 0).
- **MD2 (cell 31)** — corps de la section 6.2, interprétation en 3 niveaux + leçon :
  1. La non-linéarité confirme Φ > 0 (prédiction de la cellule de définition tenue).
  2. Mais Φ est faible : la **coupe MIP {A,B}|{C,D}** révèle la **bipartition naturelle** de l'anneau (deux moitiés symétriques faiblement couplées) → coupe peu coûteuse → Φ faible. Le triangle 3-nœuds n'a pas de bipartition équitable (toute coupe isole un nœud) → Φ élevé.
  3. La **CES confirme** : 4 concepts en 2 paires symétriques ({A,D} φ=0.25 ; {B,C} φ=0.1667), ligne de faille géométrique exploitée par la MIP.
  4. **Leçon IIT** : plus de nœuds ≠ plus d'intégration ; Φ est le *minimum* sur toutes les partitions — la MIP révèle le maillon faible.

Tableau comparatif (3-nœuds vs 4-nœuds : topologie, Big Φ, coupe MIP).

## Faits vérifiés firsthand (G.1)

Tous les chiffres de l'interprétation proviennent des **outputs des cellules existantes** lus directement, non d'une re-dérivation :

| Fait | Source output |
|---|---|
| Réseau 3-nœuds = `pyphi.examples.xor_network()`, triangle complet CM=[[0,1,1],...] | cell[4] output |
| Big Phi 3-nœuds = 1.874999, MIP {B}|{A,C} | cell[6] output |
| Réseau 4-nœuds = anneau AND/OR, Big Phi = 0.2569, MIP {A,B}|{C,D} | cell[28] output |
| CES 4 concepts : A,D φ=0.25 (purview {B,C}) ; B,C φ=0.1667 (purview {A,D}) | cell[27] output |
| 0.2569 × 7.3 ≈ 1.8750 → « ~7× inférieur » | calcul vérifié |

La note de cell[26] (« anneau XOR pur → Φ = 0 ») concerne un anneau XOR *hypothétique*, PAS le `xor_network()` 3-nœuds — **aucune contradiction** (vérifié).

## Exécution (règle F — honnête)

- **Aucune cellule code modifiée** (19 code cells = 19 sur origin/main, byte-identiques). Markdown-only.
- C.2/C.3 : la re-exécution n'est requise que pour les cellules code dont le **source** change. Ici, zéro.
- `pyphi 1.2.0` est **cassé sur Python 3.13** (`from collections import Iterable`, retiré Py3.10+) — les cellules code ne sont de toute façon pas ré-exécutables sur l'env courant. Les outputs existants (produits sur un env pyphi fonctionnel au commit initial) restent valides et cohérents avec mon interprétation.
- Pre-commit hooks : **tous PASS** (H.3, scrub paths, markdown-rendering defects).
- LaTeX vérifié : `\Phi` / `\varphi` à backslash simple (rendu Jupyter correct), 0 double-backslash.

## Anti-régression

Pure addition (+42/-2, les -2 = structure JSON autour des insertions, 0 contenu supprimé). Aucune cellule code touchée. Aucune interprétation existante remplacée (la section 6.2 était vide).

## Preuves vérifiables

| Check | Résultat |
|---|---|
| Markdown-only (0 code modifié) | 19 code cells = 19 origin/main, git diff = +42/-2 |
| Gap comblé | cell[27] + cell[31] = markdown, §6.2 a désormais un corps |
| Faits firsthand | tous les chiffres tirés des outputs existants (table ci-dessus) |
| H.3 | NONE (pre-commit PASS) |
| LaTeX | `\Phi`×11, `\varphi`×2, 0 double-backslash |
| Pas de hand-edit d'output | markdown-only, outputs existants intacts |

## Note variation

MED/notebook-python (CONTENU). Rotation genre depuis #10401 (DEEP/notebook-dotnet) — satisfait G-VAR-3 (pas de 4e notebook-dotnet consécutif). Le litmus LIGHT (« générable en scannant l'instance suivante ? ») → NON : l'interprétation du résultat contre-intuitif 0.2569 < 1.8750 exige la compréhension spécifique de la MIP/CES de cette instance, non dérivable d'un scan.
