### PR TITLE
fix(ci,#10391): twin-parity ::error annotation carries the rebaseline command (not a log pointer)

### DIFF
--- a/.github/workflows/twin-parity.yml
+++ b/.github/workflows/twin-parity.yml
@@ -119,13 +119,25 @@ jobs:
             echo ""
             echo "  Re-audite la paire firsthand, puis lance exactement :"
             echo ""
-            python -c "import json; d=json.load(open('twin_parity_report.json')); ns=[p['name'] for p in d.get('pairs',[]) if p.get('verdict')=='DRIFT_INTRODUCED'] or ['<nom exact de l entree>']; [print('    python scripts/notebook_tools/check_twin_parity.py --update --pair \"%s\" --by \"<machine:workspace>\"' % n) for n in ns]"
+            # Capture the rebaseline command(s) so we can put them INTO the
+            # ::error annotation (#10391). The annotation is the ONLY output a
+            # lane sees without opening the job log -- four lanes stalled a
+            # night on this gate because the annotation said "see the log above"
+            # instead of carrying the command. The python one-liner is unchanged
+            # (the log stays the authoritative copy + the artifact JSON stays
+            # the source); we capture + interpolate.
+            CMDS=$(python -c "import json; d=json.load(open('twin_parity_report.json')); ns=[p['name'] for p in d.get('pairs',[]) if p.get('verdict')=='DRIFT_INTRODUCED'] or ['<nom exact de l entree>']; [print('python scripts/notebook_tools/check_twin_parity.py --update --pair \"%s\" --by \"<machine:workspace>\"' % n) for n in ns]")
+            echo "$CMDS" | sed 's/^/    /'
             echo "  L'ecriture est chirurgicale (#8570) : seules les lignes"
             echo "  last_audit de cette paire changent. Ajoute une ligne en tete"
             echo "  de known_differences expliquant l'edition, puis commit."
             echo "--------------------------------------------------------------"
             echo ""
-            echo "::error title=Twin parity DRIFT INTRODUCED by this PR::La PR a introduit $INTRO paire(s) en DRIFT/MISSING qui etaient OK au base-ref origin/main. La commande de rebaseline exacte (avec le nom de la paire) est imprimee juste au-dessus dans ce log. Le selecteur --pair est obligatoire (#8508, lecons L963/L974) ; l'ecriture est chirurgicale et preserve les commentaires du registre (#8570). Alternative : splitter la PR pour que chaque cote evolue separement. Drift pre-existant ($PRE paire(s)) releve d'une PR dediee cf #8264. Voir twin_parity_report.json dans les artifacts."
+            # Workflow-command escaping for the annotation body: %0A = newline,
+            # %25 = literal %, %0D = CR. Without %0A the annotation truncates at
+            # the first newline and the multi-line command is lost.
+            CMDS_ANN=${CMDS//$'\n'/%0A}
+            echo "::error title=Twin parity DRIFT INTRODUCED by this PR::La PR a introduit $INTRO paire(s) en DRIFT/MISSING qui etaient OK au base-ref origin/main. Lance EXACTEMENT (le selecteur --pair est obligatoire #8508, lecons L963/L974) :%0A%0A$CMDS_ANN%0A%0A--update va en DERNIER : si le DRIFT vient d'une normalisation outillee (strip_probe_banner.py / strip_machine_paths.py / scrub_papermill_paths.py), these strips deplacent le blob SHA -- attester PUIS stripper invalide l'attestation (#8957). L'ecriture est chirurgicale et preserve les commentaires du registre (#8570). Alternative : splitter la PR pour que chaque cote evolue separement. Drift pre-existant ($PRE paire(s)) releve d'une PR dediee cf #8264. Voir twin_parity_report.json dans les artifacts."
             exit 1
           else
             echo "::error title=Twin parity tool error::Erreur d'execution du check (exit $EXIT). Voir les logs ci-dessus."


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: MED/guard

See #10391

## Summary

The `Twin parity audit` gate computes the exact rebaseline command (with the drifted pair name) in its job log, but its `::error` annotation — the only output a lane sees without opening the job log — pointed *to* that log ("la commande de rebaseline exacte est imprimée juste au-dessus dans ce log"). Four lanes stalled one night on this gate, none applied the command the workflow had already computed. The fix: capture the existing one-liner's output and **interpolate it into the annotation**, so the remedy travels with the signal.

## The defect (firsthand, from `origin/main`)

In `twin-parity.yml`, the `EXIT -eq 1` branch does two things:

- **line 122** — a python one-liner extracts `DRIFT_INTRODUCED` pair names from the report JSON and prints the exact `check_twin_parity.py --update --pair "<name>" --by "<machine:workspace>"` command per pair. Correct, in the log.
- **line 128** — the `::error` annotation that says: *« La commande de rebaseline exacte (avec le nom de la paire) est imprimée juste au-dessus dans ce log. »*

The annotation is what surfaces in the check summary, the Files tab, and the notification. The log body requires opening the run, finding the right job among ~20, and scrolling. The annotation literally said "the information is elsewhere" — and four lanes (#10353 GameTheory-7, #10370 SW-9, #10372 Tweety-11, #10385 Tweety-6) didn't make that step. Not a lane-discipline defect; a gate-ergonomics defect.

## The fix (14 insertions, 2 deletions, 1 file)

Capture the one-liner output into `$CMDS`, `%0A`-escape its newlines for the annotation body, and interpolate `$CMDS_ANN` directly into the `::error`:

```bash
CMDS=$(python -c "...the existing one-liner, unchanged...")
echo "$CMDS" | sed 's/^/    /'        # log stays the authoritative copy (indented as before)
CMDS_ANN=${CMDS//$'\n'/%0A}            # workflow-command escaping
echo "::error title=...::... Lance EXACTEMENT (le selecteur --pair est obligatoire #8508) :%0A%0A$CMDS_ANN%0A%0A--update va en DERNIER ..."
```

- **The python one-liner is byte-identical** (the log + artifact JSON stay the source). We duplicate the command INTO the annotation, we do not move it.
- **Annotation escaping** (`%0A` = newline, `%25` = literal `%`, `%0D` = CR): simulated firsthand — without `%0A` the multi-command annotation truncates at the first line; with it, all pair commands render on separate lines in the check UI.
- **`--update` va en DERNIER reminder preserved AND moved into the annotation** (#8957): if the DRIFT came from a tooled normalization (`strip_probe_banner.py`, `strip_machine_paths.py`, `scrub_papermill_paths.py`), attesting then stripping invalidates the attestation — the order pitfall that costs the second round-trip. This reminder was in the log only; now it is in the annotation too.

## Edge cases verified firsthand

| Case | `$CMDS` | `$CMDS_ANN` | annotation |
|------|---------|-------------|------------|
| 1+ DRIFT pairs | multi-line, one cmd/pair | `%0A`-joined | renders each command on its own line |
| 0 DRIFT (fallback `'<nom exact de l entree>'`) | single placeholder cmd | == `$CMDS` (no newline) | valid single-command annotation |

The python one-liner's `or ['<nom exact de l entree>']` fallback is unchanged; it now flows into the annotation instead of dying in the log.

## YAML + diff

- **YAML**: `yaml.safe_load` passes (the annotation body has internal `:` after the `title::message` separator — literal in the message, renders correctly; simulated).
- **Diff stat**: `1 file changed, 14 insertions(+), 2 deletions(-)`.

## Verification

The acceptance proof is the annotation *text containing the full command*, not a green check. Four PRs are/were in `DRIFT_INTRODUCED` state — after this fix merges, their next push shows the enriched annotation (the command interpolated with their drifted pair name). The escape logic is verified by local simulation (multi-line `$CMDS` → `%0A`-joined `$CMDS_ANN`); the live proof is the post-merge annotation on the next DRIFT'd PR.

## Variation note (G-VAR-3)

prev = MED/guard (#10405 advisory diff-perimeter, cycle 16). This is the **2nd MED/guard consecutive**. G-VAR-3 blocks same-genre consecutive only for **LIGHT** genres (`guard`→`guard` when LIGHT), or non-distinct DEEP/MED. This grain is **genuinely distinct substance**: cycle 16 was *workflow diff-perimeter semantics* (2-point vs 3-point `git diff`, merge-base, fetch-depth); this is *annotation ergonomics* (workflow-command `%0A` escaping, capture-and-interpolate, `--update`-last order pitfall). Different file (`twin-parity.yml` vs 6 advisory workflows), different CI subsystem (twin-parity gate vs advisory perimeter), different mechanism. The litmus « could I generate this by scanning the instance beside it? » → NO (required reading the twin-parity EXIT branch, understanding workflow-command escaping, and the #8957 attest-then-strip order trap). High leverage — unblocks the next DRIFT'd PR on first read.

Note on tier: the issue author filed this as `LIGHT/guard`. I'm classifying it MED — the fix adds real logic (capture + `%0A`-escape + interpolate + the `--update`-last reminder migration), not a `+1/-1` resync. If the coordinator reads it as LIGHT, it counts against the lane's LIGHT budget for the day (none spent yet this cycle), which is still within cap.

See #10391 (this resolves the issue — the annotation now carries the command, the two acceptance points met: command in the annotation + `--update`-last reminder in the annotation).
