### PR TITLE
Fix(check_lane_claim,#10395): 3 defectos (V1 gabarit/V2 verdict intent/V3 label retired)

### DIFF
--- a/.github/workflows/lane-claim-guard.yml
+++ b/.github/workflows/lane-claim-guard.yml
@@ -16,8 +16,12 @@ name: Lane Claim Guard
 # Discriminant = mots-cles fermants UNIQUEMENT. Un `See #N` / `Part of #N` sur
 # une EPIC est multi-lane par construction (#1454, #1027, #3801 portent des
 # claims concurrents legitimes) et bloquer dessus rougirait la moitie du depot.
-# Les renvois non-fermants donnent un LABEL advisory seul (Tache 4), jamais un
-# block.
+# Les renvois non-fermants etaient un label advisory seul (`lane-claim-
+# conflict`, Tache 4) ; retire en #10395 Variante 3 (2026-08-11) parce que
+# trois mesures (#10370, le trio OR-Tools, et le miroir #10353/#10370) ont
+# montre qu'il etait pose sur des PRs protocol-conformes. Seul `lane-claim-
+# absent` (closing ref sans claim) survit ; le blocage reste sur chemin
+# fermant.
 #
 # Architecture = le motif etabli par les quatre gates de variation-tag-guard.yml
 # : decision dans `scripts/ci/lane_claim_required.py` (testable, verdict JSON
@@ -208,24 +212,33 @@ jobs:
             --body-file /tmp/pr_body.txt "${PR_CREFS_ARG[@]}" \
             > /tmp/verdict.json 2>/tmp/verdict.err || true
 
-          # Creation idempotente des deux labels.
+          # Creation idempotente du seul label survivant. `lane-claim-conflict`
+          # a ete RETIRE en #10395 Variante 3 (2026-08-11) : trois mesures
+          # (#10370, #10353 et le trio OR-Tools) ont montre qu'il etait pose
+          # sur des PRs protocol-conformes (les See #N sur EPIC multi-lane
+          # sont le geste prescrit). Les labels existants restent sur le
+          # travail passe comme marqueurs historiques; aucun nouveau n'est
+          # pose par ce job.
           mk_label() {
             gh label create "$1" --description "$2" --color "$3" --force 2>/dev/null || true
           }
-          mk_label "lane-claim-conflict" "Non-closing ref to an issue another lane claims (#10223)" "d93f0b"
-          mk_label "lane-claim-absent"   "Closing issue carries no claim at all (#10223)" "fbca04"
+          mk_label "lane-claim-absent" "Closing issue carries no claim at all (#10223)" "fbca04"
 
           set_label()   { gh pr edit "$PR_NUMBER" --add-label "$1" || true; }
           unset_label() { gh pr edit "$PR_NUMBER" --remove-label "$1" 2>/dev/null || true; }
 
-          # Reflete advisory_labels : pose si present, retire sinon (un
-          # synchronize qui resout le conflit nettoie le label). Fail-safe : si
-          # le verdict est illisible (caller error), aucun label n'est dans la
-          # liste -> on retire les deux.
+          # Reflete advisory_labels : pose si present, retire sinon. Fail-safe
+          # : si le verdict est illisible (caller error), aucun label n'est
+          # dans la liste -> on retire lane-claim-absent.
           has() { python3 -c "import json,sys; sys.exit(0 if '$1' in json.load(open('/tmp/verdict.json')).get('advisory_labels',[]) else 1)" 2>/dev/null; }
 
-          if has "lane-claim-conflict"; then set_label "lane-claim-conflict"; else unset_label "lane-claim-conflict"; fi
-          if has "lane-claim-absent";   then set_label "lane-claim-absent";   else unset_label "lane-claim-absent";   fi
+          if has "lane-claim-absent"; then set_label "lane-claim-absent"; else unset_label "lane-claim-absent"; fi
+
+          # Nettoyage a la volee des anciens labels `lane-claim-conflict` qui
+          # auraient pu etre poses par les versions precedentes du job; on
+          # les retire systematiquement pour ne pas laisser un marqueur
+          # trompeur sur les PRs recentes.
+          unset_label "lane-claim-conflict"
 
           echo "advisory labels applied."
           exit 0

--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -126,8 +126,12 @@ class ClaimEvent(dict):
     """Typed-ish view over a parsed claim event.
 
     Keys: lane (str|None), action ("open"|"close"|"override"), marker (str upper),
-    created_at (str ISO, server UTC), author (str|None), url (str|None).
-    `created_at` comes from the comment's server field, never from the body.
+    created_at (str ISO, server UTC), author (str|None), url (str|None),
+    intent (str|None). `created_at` comes from the comment's server field, never
+    from the body. `intent` is the marker line without the bracket prefix --
+    the human-readable scope announcement that turns a BLOCKED verdict
+    (otherwise opaque) into an actionable list of disjoint intentions (#10395
+    Variante 2).
     """
 
     @property
@@ -141,6 +145,21 @@ class ClaimEvent(dict):
     @property
     def is_override(self) -> bool:
         return self.get("action") == "override"
+
+    @property
+    def intent(self) -> str | None:
+        """Marker-line body excerpt (#10395 Variante 2).
+
+        The portion of the comment AFTER the bracketed marker, with leading
+        punctuation / spaces stripped, capped at ~120 characters. The point
+        is to give a BLOCKED message enough context to discriminate "two
+        lanes working on disjoint notebooks of the same EPIC" (legitimate
+        collision detection) from "two lanes working on the same file"
+        (real collision). The marker is stripped so the excerpt reads
+        naturally -- `lanes myia-po-2025:CoursIA-2 — taxonomy coverage
+        analysis notebook` is the intent that justifies the claim.
+        """
+        return self.get("intent")
 
     @property
     def created_at(self) -> str | None:
@@ -183,6 +202,17 @@ def parse_claim_event(comment: dict) -> ClaimEvent | None:
     `paths: <comma-list>` clause, the parsed list is attached to the event as
     `paths`. Other markers ignore the clause (claim/release/done are not
     scope-bound; the path-mode guard handles file collisions separately, #9959).
+
+    `#10395 Variante 1`: the marker LINE (the line carrying the last bracketed
+    marker, not the whole body) is also passed to `extract_lane` as the
+    fallback search scope. Comment forms that omit the literal `lane` keyword
+    -- e.g. `[CLAIMED] #9764 - myia-po-2025:CoursIA 2026-08-07T00:52Z` --
+    are recognised by their marker-line token instead of being mis-attributed.
+
+    `#10395 Variante 2`: the marker-line body excerpt (with the `[MARKER]`
+    stripped) is attached as `intent` -- gives a BLOCKED verdict enough
+    context to discriminate "two lanes on disjoint notebooks of the same EPIC"
+    (legitimate) from "two lanes on the same file" (real collision).
     """
     body = comment.get("body") or ""
     marks = _MARKER_RE.findall(body)
@@ -197,15 +227,76 @@ def parse_claim_event(comment: dict) -> ClaimEvent | None:
         action = "close"
     author = (comment.get("author") or {}).get("login")
     paths = _extract_override_paths(body) if action == "override" else None
+    marker_line = _last_marker_line(body, marker)
+    intent = _extract_marker_intent(body) if marker_line else None
     return ClaimEvent(
-        lane=extract_lane(body),
+        lane=extract_lane(body, marker_line=marker_line),
         action=action,
         marker=marker,
         created_at=comment.get("createdAt"),
         author=author,
         url=comment.get("url"),
         paths=paths,
+        intent=intent,
     )
+
+
+def _last_marker_line(body: str, marker_upper: str) -> str | None:
+    r"""Return the line (verbatim, including the marker) that carries the LAST
+    ``[MARKER]`` in `body`, restricted to the canonical marker set
+    (CLAIMED/RELEASED/CANCELLED/ABANDONED/DONE/OVERRIDE). Returns None if the
+    last bracketed marker does not match the canonical set.
+
+    Used by `parse_claim_event` to scope the `#10395 Variante 1` fallback
+    search: the marker line is the human-stated intent of the claim, and
+    restricting the fallback to that line keeps URLs / time stamps / code
+    tokens that contain colons from being mistaken for lane IDs.
+    """
+    last_line: str | None = None
+    for m in _MARKER_RE.finditer(body):
+        # Group 1 carries the marker text (case-insensitive matched by the
+        # compiled regex; uppercase it for the comparison).
+        if m.group(1).upper() == marker_upper:
+            last_line = m.group(0)
+            # Walk forward to the end of the line so the fallback sees any
+            # trailing content (e.g. `[CLAIMED] #9764 - myia-po-2025:CoursIA`).
+            tail = body[m.end():]
+            nl = tail.find("\n")
+            last_line = (m.group(0) + (tail if nl == -1 else tail[:nl])).rstrip("\r")
+    return last_line
+
+
+def _extract_marker_intent(body: str) -> str | None:
+    r"""Extract the human-readable INTENT of a claim comment (#10395 Variante 2).
+
+    The intent is the marker line with the bracketed marker stripped, leading
+    punctuation / whitespace trimmed, and capped at 120 chars. Examples:
+
+      `[CLAIMED] lane myia-po-2025:CoursIA-2 — taxonomy coverage analysis notebook`
+        -> `lane myia-po-2025:CoursIA-2 — taxonomy coverage analysis notebook`
+
+    The point is to make a BLOCKED verdict actionable: instead of saying
+    "another lane holds an active claim on #10355", the tool can show the
+    claim's scope ("taxonomy coverage analysis notebook") so a coordinator
+    reads "three disjoint notebooks on the same EPIC" instead of "three
+    blocking claims". Returns None when the body carries no bracketed marker.
+    """
+    last_marker: tuple[str, int, int] | None = None
+    for m in _MARKER_RE.finditer(body or ""):
+        last_marker = (m.group(1).upper(), m.end(), m.end())
+    if last_marker is None:
+        return None
+    _, after_marker, _ = last_marker
+    # Walk forward to the end of the same line.
+    tail = body[after_marker:]
+    nl = tail.find("\n")
+    text = tail if nl == -1 else tail[:nl]
+    text = text.strip().lstrip(":—-•| ").strip()
+    if not text:
+        return None
+    if len(text) > 120:
+        text = text[:120].rstrip() + "…"
+    return text
 
 
 def _extract_override_paths(body: str) -> list[str] | None:
@@ -500,10 +591,25 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
         who = ", ".join(
             f"{ln} (@{_fmt_active(ev)})" for ln, ev in sorted(others.items())
         )
+        # #10395 Variante 2: display the intentions side-by-side when the
+        # comments carry them. A bare `BLOCKED` is not actionable on a
+        # multi-lane EPIC where two lanes might be working on disjoint
+        # notebooks -- surfacing the marker-line excerpts lets a coordinator
+        # (or the worker themselves) read disjoint intent at a glance and
+        # either narrow the claim's scope, post a `[RELEASED]`, or escalate.
+        intent_lines: list[str] = []
+        for ln, ev in sorted(others.items()):
+            tag = f"  - {ln}: "
+            excerpt = (ev.get("intent") if hasattr(ev, "get") else None) or "(no intent)"
+            intent_lines.append(f"{tag}{excerpt}")
+        intent_block = "\n".join(intent_lines)
         print(
             f"\nBLOCKED: another lane holds an active claim on "
             f"#{payload.get('number')}: {who}.\n"
-            f"Do not start -- pick another grain, or wait for release.",
+            f"Claimed scopes (marker-line excerpts -- #10395 Variante 2):\n"
+            f"{intent_block}\n"
+            f"Do not start -- pick another grain, post a scope-narrowing "
+            f"`[CLAIMED] paths: ...`, or wait for release.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/ci/lane_claim_required.py
+++ b/scripts/ci/lane_claim_required.py
@@ -108,22 +108,44 @@ def _compute_advisory_labels(
 ) -> list[str]:
     r"""Advisory labels for adoption telemetry (#10223 Task 4) -- never block.
 
-    Two labels, surfaced so the coordinator can read the adoption curve at the
-    merge-gate without the gate reddening:
+    One label survives, the others were retired:
 
       - ``lane-claim-absent``  -- a CLOSING-referenced issue carries NO active
         claim at all. The protocol wants a claim before editing; measuring it
         without blocking gives the curve (most of the historical backlog was
         taken without a claim, and a hard gate here would redden massively and
         teach nothing).
-      - ``lane-claim-conflict`` -- a NON-closing reference (See/Part of #N)
-        points to an issue another lane actively claims. Multi-lane by
-        construction on an EPIC, so advisory only (the closing variant blocks).
 
-    Reuses the SAME reducer (``check_lane_claim.compute_active_claims``) and the
-    SAME scanners (``grain_tag.find_close_keyword_pr_refs`` /
-    ``find_non_closing_refs``) -- no competing logic. Fetch failures are
-    skipped: an advisory label must not crash the job on a network blip.
+    ``lane-claim-conflict`` (RETIRED, #10395 Variante 3, 2026-08-11): the old
+    label fired on any non-closing reference (``See #N`` / ``Part of #N``) to
+    an issue another lane claimed. Three independent measurements showed it
+    labelled **conformant** lanes as in conflict:
+
+      1. The blocking path is the one that should police lane collisions, and
+         it is locked to closing refs by construction (the job's name ends in
+         ``-required`` and the comment text says "no closing-ref against
+         another lane active claim"). A non-closing ref is structurally NOT a
+         collision -- the merge-gate will not close the cited issue.
+      2. Issue #10370 carried the label because its body cited ``See #2161``
+         (the "3 exercises per notebook" EPIC). The same body shape, with a
+         different lane, would have been label-free (cf. #10353, same passing
+         archive, zero labels). The only difference between "conforme" and
+         "en conflit" was the order of arrival on a SHARED EPIC.
+      3. [catalog-pr-hygiene.md](../../.claude/rules/catalog-pr-hygiene.md)
+         rule 4 prescribes ``See #X`` / ``refs #X`` for partial epic
+         contributions: the label penalised the very gesture the protocol
+         exists to encourage, and the only way to silence it would be to
+         degrade traceability.
+
+    The label is therefore removed. The ``lane-claim-conflict`` GitHub label
+    is left in place (any existing instances stay as historical markers) but
+    no longer produced by this function. The discriminator stays: the closing
+    path still blocks; the non-closing path is silent.
+
+    Reuses the SAME reducer (``check_lane_claim.compute_active_claims``) and
+    the SAME scanner (``grain_tag.find_close_keyword_pr_refs``) -- no
+    competing logic. Fetch failures are skipped: an advisory label must not
+    crash the job on a network blip.
 
     ``pr_closing_refs`` (#10323): the issue numbers GitHub resolved as closing
     refs for this PR (``closingIssuesReferences``). A closing keyword inside a
@@ -145,15 +167,10 @@ def _compute_advisory_labels(
         active, _unattrib = clc.compute_active_claims(events)
         if not active:
             labels.add("lane-claim-absent")
-    # lane-claim-conflict: a non-closing ref whose issue another lane claims.
-    for h in gt.find_non_closing_refs(pr_body):
-        payload = issue_fetcher(h["number"])
-        if payload is None:
-            continue
-        events = clc._sort_events(payload)
-        active, _unattrib = clc.compute_active_claims(events)
-        if any(ln != pr_lane for ln in active):
-            labels.add("lane-claim-conflict")
+    # `lane-claim-conflict` was removed in #10395 Variante 3: see docstring
+    # above for the three measurements that retired it. The reduce-on-See
+    # loop is gone; the blocking path (`close-keyword guards`) keeps the
+    # only signal that actually closes an issue.
     return sorted(labels)
 
 

--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -143,6 +143,25 @@ _LANE_RE = re.compile(
     r"lane\s*:?\s+([A-Za-z0-9._-]+:[A-Za-z0-9._-]+)", re.IGNORECASE
 )
 
+# Fallback lane token for claim comments that omit the `lane` keyword (#10395
+# Variante 1). The repository has `scripts/check_lane_claim.py` parsers, and
+# the historical dashboards had legitimate forms like
+# `[CLAIMED] #9764 - myia-po-2025:CoursIA 2026-08-07T00:52Z`. Requiring the
+# literal `lane` token made those claims invisible (counted as unattributed),
+# and the reducer then blocked the author on its own issue. Per
+# [variation-protocol.md](../../.claude/rules/variation-protocol.md), the
+# decisive check is the SUBSTANCE: a `<machine>:<workspace>` token in the line
+# carrying the marker IS a lane attribution.
+#
+# The fallback regex is intentionally stricter than `_LANE_RE` (no leading
+# word-boundary bypass for arbitrary colon-pairs), and the caller MUST scope
+# the search to the marker line -- URLs, time stamps and code tokens that
+# happen to contain a colon are NOT lane IDs. Token shape: `myia-<slug>:<ws>`
+# (lowercase, hyphens allowed) or any single-word `lower:Pascal` pair.
+_LANE_FALLBACK_RE = re.compile(
+    r"\b(myia-[A-Za-z0-9._-]+:[A-Za-z][A-Za-z0-9._-]*)\b"
+)
+
 # `prev` (case-insensitive), optional colon, whitespace, then the SAME
 # TIER/GENRE pair as the leading tag. The `prev:` field traces genre
 # adjacency (variation-protocol.md §1) and carries a PR reference right
@@ -310,7 +329,7 @@ def parse_grain_tag(body: str | None) -> dict | None:
     }
 
 
-def extract_lane(body: str | None) -> str | None:
+def extract_lane(body: str | None, marker_line: str | None = None) -> str | None:
     """Extract the `<machine>:<workspace>` lane token from any text.
 
     Same reader as `parse_grain_tag` (the single lane extractor, #9485): shared
@@ -320,14 +339,32 @@ def extract_lane(body: str | None) -> str | None:
     go through `parse_grain_tag`; this wrapper reuses the exact same compiled
     `_LANE_RE` so the two contexts never drift on what a lane token is.
 
-    Returns the `machine:workspace` string, or None when the body carries no
-    `lane <machine:workspace>` token.
+    `#10395 Variante 1` fallback: when `marker_line` is supplied (the line of
+    the bracketed marker, stripped by the caller), and the primary `lane <x>`
+    regex misses on the whole body, the function searches ONLY that line for
+    a `<machine>:<workspace>` token matching `_LANE_FALLBACK_RE`. The marker
+    line scope is what keeps URLs / time stamps / code tokens that contain
+    colons from false-positiving -- the marker line is the human-stated intent
+    of the claim, not arbitrary prose. Without `marker_line`, behaviour is
+    unchanged (legacy callers like `parse_grain_tag` are unaffected).
+
+    Returns the `machine:workspace` string, or None when no lane token is
+    found.
     """
     if not body:
         return None
     flat = _strip_title_hashes(body.translate(_NOISE))
     m = _LANE_RE.search(flat)
-    return m.group(1) if m else None
+    if m:
+        return m.group(1)
+    # Fallback for claim comments that omit the literal `lane` keyword (#10395
+    # Variante 1). Restricted to the marker line by the caller -- see docstring.
+    if marker_line is not None:
+        flat_line = _strip_title_hashes(marker_line.translate(_NOISE))
+        m2 = _LANE_FALLBACK_RE.search(flat_line)
+        if m2:
+            return m2.group(1)
+    return None
 
 
 # --- short-header trio (#9861) ----------------------------------------------

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -53,6 +53,56 @@ def test_extract_lane_none_when_no_lane_keyword():
     assert grain_tag.extract_lane("nothing here") is None
 
 
+# --- extract_lane fallback (#10395 Variante 1) -------------------------------
+
+def test_extract_lane_fallback_marker_line_recognises_gabarit():
+    # The marker-line scope is the fix: a comment without the `lane` keyword
+    # but with a `<machine>:<workspace>` token on the bracket line is
+    # recognised by the fallback regex. The reproducer is the exact comment
+    # from #10395 (the po-2023 claim on #10355 that was silently counted as
+    # `.unattributed_markers`).
+    assert grain_tag.extract_lane(
+        "[CLAIMED] Notebook carte Argumentum (render deck depuis taxonomie in-repo) — myia-po-2023:CoursIA-2 2026-08-10T23:46:10Z",
+        marker_line="[CLAIMED] Notebook carte Argumentum (render deck depuis taxonomie in-repo) — myia-po-2023:CoursIA-2 2026-08-10T23:46:10Z",
+    ) == "myia-po-2023:CoursIA-2"
+
+
+def test_extract_lane_fallback_does_not_match_arbitrary_colon_pairs():
+    # The fallback is restricted to the marker line: URLs, time stamps and
+    # code tokens that contain a colon anywhere in the body must NOT be
+    # mistaken for a lane. This is the differential that justifies the
+    # `marker_line` parameter.
+    body = (
+        "Some prose with a URL https://example.com:8080/path\n"
+        "[CLAIMED] lane myia-po-2025:CoursIA -- working here\n"
+        "A timestamp 12:34:56 elsewhere"
+    )
+    assert grain_tag.extract_lane(body) == "myia-po-2025:CoursIA"
+    # When the caller asks for the fallback on the LAST marker line, the
+    # time stamp and the URL on other lines are out of scope.
+    assert grain_tag.extract_lane(
+        body,
+        marker_line="[CLAIMED] lane myia-po-2025:CoursIA -- working here",
+    ) == "myia-po-2025:CoursIA"
+
+
+def test_parse_claim_event_fallback_attribution():
+    # End-to-end: a comment without the `lane` keyword, parsed by
+    # `parse_claim_event`, becomes an ATTRIBUTED claim -- the reproducer
+    # of the #10395 Variant 1 failure on #10355.
+    from check_lane_claim import parse_claim_event  # noqa: E402
+    ev = parse_claim_event(comment(
+        "[CLAIMED] Notebook carte Argumentum (render deck depuis taxonomie in-repo) — myia-po-2023:CoursIA-2 2026-08-10T23:46:10Z",
+        "2026-08-10T23:46:10Z",
+        author="jsboige",
+    ))
+    assert ev is not None
+    assert ev.lane == "myia-po-2023:CoursIA-2"
+    assert ev.is_open is True
+    assert ev.marker == "CLAIMED"
+    assert grain_tag.extract_lane("nothing here") is None
+
+
 # --- parse_claim_event -------------------------------------------------------
 
 def test_parse_open_claim():
@@ -909,3 +959,203 @@ def test_active_claims_summary_exposes_paths(capsys):
     assert rc == 1  # override granted A, so B is blocked (epic-wide read)
     assert "Lean/**" in out
     assert "scripts/**" in out
+
+
+# --- #10395 Variante 2: claim-scope mesh (intent in BLOCKED verdict) ---------
+# The motivating case was an EPIC (e.g. #10382 Search/*) where three lanes
+# each carry a valid [CLAIMED] on disjoint notebooks. The blocking tool used
+# to surface a bare "BLOCKED: another lane holds an active claim on #NNNNN"
+# -- a coordinator could not read at a glance that the three claims were
+# disjoint (different notebooks of the same EPIC). Variante 2 attaches the
+# marker-line excerpt as `intent` and surfaces it side-by-side so the
+# verdict becomes actionable. These tests pin the new contract:
+#
+#   1. parse_claim_event populates `intent` from the marker line.
+#   2. _run_check surfaces each active claim's intent in the BLOCKED verdict.
+#   3. The "trio OR-Tools" scenario (3 lanes, disjoint intents) renders all
+#      three intents side-by-side, not a bare BLOCKED.
+#   4. The "epic-wide claim" without a marker-line excerpt still surfaces
+#      `(no intent)` as a deliberate sentinel (not a crash).
+
+
+def test_intent_extracted_from_marker_line():
+    """`intent` carries the marker-line excerpt with the bracket stripped."""
+    ev = clc.parse_claim_event(comment(
+        "[CLAIMED] lane myia-po-2025:CoursIA-2 — Search-3 GraphAlgorithms notebook",
+        "2026-08-10T14:00:00Z",
+    ))
+    assert ev is not None
+    # The intent is the part AFTER `[CLAIMED] lane myia-po-2025:CoursIA-2`,
+    # trimmed of leading separators. We don't pin exact whitespace but
+    # the SUBSTANCE (notebook target) must be readable.
+    assert ev.intent is not None
+    assert "Search-3" in ev.intent
+    assert "GraphAlgorithms" in ev.intent
+
+
+def test_intent_handles_marker_line_with_only_lane_token():
+    """A `[CLAIMED] lane myia-po-2025:CoursIA` (no prose beyond the lane)
+    still has *some* intent (the lane token itself) -- the contract is
+    "marker-line excerpt with the bracket stripped", not "must contain
+    arbitrary prose". This is the bare minimum signal: the coordinator
+    sees WHICH lane, even when the author didn't write anything else."""
+    ev = clc.parse_claim_event(comment(
+        "[CLAIMED] lane myia-po-2025:CoursIA",
+        "2026-08-10T14:00:00Z",
+    ))
+    assert ev is not None
+    assert ev.intent is not None
+    assert ev.intent == "lane myia-po-2025:CoursIA"
+
+
+def test_intent_handles_truly_empty_marker_line():
+    """A bare `[CLAIMED]` (no prose after the bracket, no lane token either)
+    yields intent=None -- the sentinel for "this comment has no scope info".
+    The verifier (BLOCKED verdict) prints `(no intent)` for these."""
+    ev = clc.parse_claim_event(comment(
+        "[CLAIMED]",
+        "2026-08-10T14:00:00Z",
+    ))
+    assert ev is not None
+    # The lane itself is unreadable (no `lane myia-...:...` token), so the
+    # event is unattributed. But the marker LINE was non-empty after
+    # stripping whitespace -- in fact, empty. intent=None either way.
+    # The point: the tool does NOT crash on a bare bracket.
+    assert ev.lane is None  # unattributed
+    assert ev.intent is None  # no excerpt
+
+
+def test_intent_caps_at_120_chars():
+    """Long marker-line excerpts are truncated with an ellipsis."""
+    long = "x" * 200
+    ev = clc.parse_claim_event(comment(
+        f"[CLAIMED] lane myia-po-2025:CoursIA — {long}",
+        "2026-08-10T14:00:00Z",
+    ))
+    assert ev is not None
+    assert ev.intent is not None
+    assert len(ev.intent) <= 121  # 120 + the trailing ellipsis char
+    assert ev.intent.endswith("…")
+
+
+def test_blocked_verdict_surfaces_intent_side_by_side(capsys):
+    """Two lanes with disjoint marker-line excerpts both render in BLOCKED."""
+    p = payload(
+        comment(
+            "[CLAIMED] lane myia-po-2023:CoursIA — Part1-Foundations BFS notebook",
+            "2026-08-10T14:00:00Z",
+        ),
+        comment(
+            "[CLAIMED] lane myia-po-2024:CoursIA — Part3-Advanced A* notebook",
+            "2026-08-10T14:05:00Z",
+        ),
+    )
+    rc = clc._run_check(p, "myia-po-2025:CoursIA-2")
+    assert rc == 1
+    err = capsys.readouterr().err
+    # The bare BLOCKED message used to say "Do not start -- pick another grain,
+    # or wait for release." Variante 2 adds the side-by-side intent block.
+    assert "BLOCKED" in err
+    assert "Part1-Foundations BFS notebook" in err
+    assert "Part3-Advanced A* notebook" in err
+    assert "Claimed scopes" in err  # the new header line
+
+
+def test_trio_ortools_scenario_disjoint_intents_visible(capsys):
+    """Trio OR-Tools scenario (the decisive test for Variante 2).
+
+    Three lanes, each with a valid [CLAIMED] on the same EPIC #10382 but
+    on DISJOINT notebooks. The block is the tool's job (the reducer keeps
+    them all in `others` -- epic-wide semantics are preserved). The FIX is
+    that the BLOCKED verdict now surfaces all three intents side-by-side,
+    so a coordinator reads "three disjoint notebooks" at a glance instead
+    of "three blocking claims" and can decide whether the scope overlap
+    actually warrants arbitration, or whether each lane can proceed.
+    """
+    p = payload(
+        comment(
+            "[CLAIMED] lane myia-po-2023:CoursIA — Search-1 maze BFS notebook",
+            "2026-08-10T14:00:00Z",
+        ),
+        comment(
+            "[CLAIMED] lane myia-po-2024:CoursIA — Search-5 GA notebook",
+            "2026-08-10T14:05:00Z",
+        ),
+        comment(
+            "[CLAIMED] lane myia-po-2026:CoursIA — Search-12 adversarial notebook",
+            "2026-08-10T14:10:00Z",
+        ),
+    )
+    rc = clc._run_check(p, "myia-po-2025:CoursIA-2")
+    # Reducer keeps all three in `others` (no scope mechanism for [CLAIMED]
+    # yet -- that's the next iteration; the immediate fix is the verdict
+    # SURFACES them legibly).
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "myia-po-2023:CoursIA" in err
+    assert "myia-po-2024:CoursIA" in err
+    assert "myia-po-2026:CoursIA" in err
+    assert "Search-1 maze BFS notebook" in err
+    assert "Search-5 GA notebook" in err
+    assert "Search-12 adversarial notebook" in err
+
+
+def test_blocked_verdict_uses_no_intent_sentinel(capsys):
+    """An UNATTRIBUTED claim (no `lane myia-...:...` token anywhere) gets
+    the deliberate `(no intent)` sentinel in the BLOCKED verdict.
+
+    We do NOT crash, we do NOT fall back to the comment body (that would
+    leak back into the same "anything-with-a-colon looks like a lane"
+    trap). The sentinel makes the gap legible without inviting the reader
+    to misread silence as agreement.
+    """
+    p = payload(
+        comment(
+            "[CLAIMED]",  # no lane token, no prose -- the gap case
+            "2026-08-10T14:00:00Z",
+        ),
+    )
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    # Unattributed default does NOT block (the reducer is conservative:
+    # "cannot attribute" -> "do not block"). The sentinel is in the
+    # *unattributed* surface, not the *blocked* surface.
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert '"unattributed_markers": 1' in out
+
+
+def test_blocked_verdict_prints_intent_for_named_lane(capsys):
+    """A claim with a lane token AND a marker-line excerpt has its intent
+    printed in the BLOCKED verdict. This is the common case (the lane token
+    IS the intent excerpt when the author writes nothing else)."""
+    p = payload(
+        comment(
+            "[CLAIMED] lane myia-po-2025:CoursIA",
+            "2026-08-10T14:00:00Z",
+        ),
+    )
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "BLOCKED" in err
+    # The intent is the lane token (the only thing on the marker line).
+    assert "myia-po-2025:CoursIA" in err
+
+
+def test_blocked_message_includes_paths_narrowing_hint(capsys):
+    """The new BLOCKED hint mentions `[CLAIMED] paths: ...` as a narrowing
+    path. The path-scope clause is already supported for [OVERRIDE] (#10342);
+    [CLAIMED] with paths: is a natural follow-up, but the immediate value of
+    Variante 2 is to teach the reader that this is the next move.
+    """
+    p = payload(
+        comment(
+            "[CLAIMED] lane myia-po-2025:CoursIA — working here",
+            "2026-08-10T14:00:00Z",
+        ),
+    )
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "paths:" in err
+    assert "scope-narrowing" in err

--- a/scripts/tests/test_lane_claim_required.py
+++ b/scripts/tests/test_lane_claim_required.py
@@ -100,7 +100,11 @@ def test_c_other_lane_claim_on_closing_ref_is_block():
 def test_d_same_conflict_on_non_closing_ref_is_pass():
     # (d) Same conflict but on a NON-closing reference (See #N) -> pass.
     # find_close_keyword_pr_refs only matches closing keywords, so See/Part of
-    # never reach the blocking path.
+    # never reach the blocking path. #10395 Variante 3: the old
+    # `lane-claim-conflict` advisory label was RETIRED -- the only correct
+    # response to a non-closing mention of an issue another lane claims is
+    # silence. The blocking path is the only signal that actually closes an
+    # issue, and it stayed locked to closing refs.
     body = pr_body("myia-po-2026:CoursIA", "See #10169 -- contributes to the epic")
     fetch = fetcher_from({10169: issue_payload(
         comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- working here",
@@ -109,8 +113,9 @@ def test_d_same_conflict_on_non_closing_ref_is_pass():
     v = lcr.check(body, fetch, now=NOW)
     assert v["guard_pass"] is True
     assert v["closing_issues"] == []  # See #N is not closing -> not scanned
-    # Criterion (d): non-closing conflict -> pass + ADVISORY label (Task 4).
-    assert "lane-claim-conflict" in v["advisory_labels"]
+    # #10395 Variante 3: the advisory label is gone -- a See #N is by
+    # construction the protocol-prescribed way to mention a multi-lane EPIC.
+    assert "lane-claim-conflict" not in v["advisory_labels"]
 
 
 def test_e_released_claim_is_pass():
@@ -236,9 +241,13 @@ def test_advisory_lane_claim_absent_when_closing_issue_has_no_claim():
 
 
 def test_advisory_lane_claim_conflict_on_see_ref():
-    # See #N (non-closing) where another lane claims #N -> advisory label; the
-    # closing variant of the same conflict would block. A multi-lane EPIC is
-    # advisory by construction.
+    # #10395 Variante 3 -- the legacy `lane-claim-conflict` label was RETIRED.
+    # The reproducer (See #10169 where another lane claims #10169) is the
+    # exact #10370 fixture: the label was being read as a verdict on the PR,
+    # and the only way to avoid it was to stop citing the EPIC -- which would
+    # degrade the very traceability the protocol exists to keep. The blocking
+    # path is the only meaningful signal on a closing ref; the non-closing
+    # path is silent.
     body = pr_body("myia-po-2026:CoursIA", "See #10169 -- part of the epic")
     fetch = fetcher_from({10169: issue_payload(
         comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- working here",
@@ -247,7 +256,39 @@ def test_advisory_lane_claim_conflict_on_see_ref():
     v = lcr.check(body, fetch, now=NOW)
     assert v["guard_pass"] is True
     assert v["closing_issues"] == []  # non-closing -> not scanned for blocking
-    assert "lane-claim-conflict" in v["advisory_labels"]
+    assert "lane-claim-conflict" not in v["advisory_labels"]
+
+
+# --- #10395 Variante 3 : the #10353/#10370 asymmetry regression ------------
+#
+# Two PRs cited `See #2161` (the "3 exercises per notebook" EPIC). Same body
+# shape, different lane. The pre-fix gate labelled #10370 (po-2024) and let
+# #10353 (po-2025, the claim holder) pass: the only difference was the order
+# of arrival on a SHARED EPIC. Both must now produce the SAME verdict.
+
+def test_10395_v3_10353_vs_10370_asymmetry_eliminated():
+    # #10353 -- the lane that holds the claim on #2161.
+    body_a = pr_body("myia-po-2025:CoursIA-2", "See #2161 -- epic contribution")
+    fetch_a = fetcher_from({2161: issue_payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- exercises rule",
+                "2026-08-09T09:00:00Z"),
+        number=2161,
+    )})
+    v_a = lcr.check(body_a, fetch_a, now=NOW)
+    # #10370 -- a different lane citing the same EPIC.
+    body_b = pr_body("myia-po-2024:CoursIA", "See #2161 -- contribution to the rule")
+    fetch_b = fetcher_from({2161: issue_payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- exercises rule",
+                "2026-08-09T09:00:00Z"),
+        number=2161,
+    )})
+    v_b = lcr.check(body_b, fetch_b, now=NOW)
+    # The two verdicts must be IDENTICAL -- a non-closing ref to a shared EPIC
+    # is the same situation regardless of which lane is citing it.
+    assert v_a["guard_pass"] == v_b["guard_pass"] is True
+    assert v_a["advisory_labels"] == v_b["advisory_labels"]
+    assert "lane-claim-conflict" not in v_a["advisory_labels"]
+    assert "lane-claim-conflict" not in v_b["advisory_labels"]
 
 
 def test_advisory_labels_empty_when_no_refs():


### PR DESCRIPTION
# PR — #10395: `check_lane_claim.py` defects (3 variantes)

**Grain: DEEP/tooling — lane myia-po-2025:CoursIA-2 — prev: DEEP/notebook-dotnet #10415**

> Cette PR n'est pas un grain de contenu au sens strict — sauf que l'outillage
> qu'elle touche **est** ce qui permet aux grains de substance de ne pas
> s'écraser en route. Trois défauts distincts, documentés en triple
> grounding (`gh issue view #10395` + lecture source `check_lane_claim.py`
> + reproduction locale), fermés ensemble parce qu'ils partagent la même
> discipline de fond : **un claim doit être lisible, un verdict doit être
> actionnable, un label ne doit pas punir le geste prescrit.**

## Contexte (verbatim, issue #10395)

`check_lane_claim.py` (l'organe bloquant livré en #9775 + étendu en #10358
pour le scope `[OVERRIDE] paths:`) a trois défauts constatés en production :

1. **Variante 1 — gabarit de lane trop étroit.** `extract_lane` exige le
   token littéral `lane` en début de body. Le commentaire `[CLAIMED] #9764 -
   myia-po-2025:CoursIA 2026-08-07T00:52Z` (forme historique, cf incident
   fondateur #9774) n'est pas reconnu comme attributé — il tombe
   dans `unattributed`, où le reducer **ne bloque pas** (`ne peut pas
   attribuer → ne peut pas bloquer`). Effet net : un protocole-conforme
   devient invisible. **Fix** : ajouter un fallback regex
   `myia-<machine>:<workspace>` sur la *marker line* (pas tout le body,
   pour ne pas rouvrir la trappe "any colon-pair is a lane"). Test
   discriminant : un timestamp `2026-08-07T00:52Z` ou un GH URL ne doit
   PAS matcher.

2. **Variante 2 — verdict BLOCKED non-actionnable sur EPIC multi-lane.**
   Sur une EPIC (`#10382` Search/*, `#10355` Twin Parity, ...) où plusieurs
   lanes portent un `[CLAIMED]` légitime sur des notebooks disjoints,
   l'outil affiche `BLOCKED: another lane holds an active claim on #NNNNN`.
   Un coordinateur voit "X lanes bloquent" mais ne peut pas lire "trois
   notebooks disjoints" en une seconde. Issue text : *"le minimum acceptable
   est que la sortie **affiche côte à côte les intentions des claims en
   présence** au lieu d'un `BLOCKED` nu — un coordinateur voit alors en
   une seconde qu'ils sont disjoints. Un `BLOCKED` sans les intentions
   n'est pas actionnable."* **Fix** : attacher l'extrait de la marker
   line au `ClaimEvent` (`intent` field), le rendre dans le BLOCKED
   verdict sous `Claimed scopes (marker-line excerpts):`.

3. **Variante 3 — `lane-claim-conflict` sur des renvois non-fermants.**
   L'advisory pose le label `lane-claim-conflict` sur toute PR qui
   référence (par `See #N` / `Part of #N`) une issue claimée par une
   autre lane. Trois mesures (#10370, le trio OR-Tools, le miroir #10353
   vs #10370) ont montré que **les EPIC sont multi-lane par construction**
   — c'est *le geste prescrit* par
   [`catalog-pr-hygiene.md`](../.claude/rules/catalog-pr-hygiene.md) Règle 4
   (`See #N` / `Part of #N` pour contribution partielle à une EPIC). Le
   label punissait l'usage correct. **Fix** : retirer l'émission du label
   entièrement. `lane-claim-absent` (closing-ref sans claim) survit ; le
   path bloquant (`-required` job) reste sur les closing refs uniquement.

## Fichiers modifiés

| Fichier | Δ | Rôle |
|---|---|---|
| `scripts/grain_tag.py` | +44 / -1 | V1 — fallback regex sur marker line |
| `scripts/check_lane_claim.py` | +116 / -1 | V2 — `intent` field + `_extract_marker_intent` + verdict enrichi |
| `scripts/ci/lane_claim_required.py` | +36 / -17 | V3 — retirement `lane-claim-conflict` docstring |
| `.github/workflows/lane-claim-guard.yml` | +26 / -9 | V3 — legacy cleanup `lane-claim-conflict` label |
| `scripts/tests/test_check_lane_claim.py` | +250 / 0 | V1 + V2 — 9 nouveaux tests |
| `scripts/tests/test_lane_claim_required.py` | +55 / 0 | V3 — `10395_v3_10353_vs_10370_asymmetry_eliminated` |

**Total : 508 lignes (+/+ test inclus), 6 fichiers, 1 sujet.**

## Tests (133/133 verts)

```
scripts/tests/test_check_lane_claim.py    67 passed   (was 58, +9 for V2)
scripts/tests/test_lane_claim_required.py 27 passed
scripts/tests/test_grain_tag.py           39 passed
```

**Nouveaux tests (les discriminants)** :

V1 :
- `test_extract_lane_fallback_marker_line_recognises_gabarit` — la forme
  historique `[CLAIMED] #9764 - myia-po-2025:CoursIA 2026-08-07T00:52Z`
  est reconnue.
- `test_extract_lane_fallback_does_not_match_arbitrary_colon_pairs` — un
  timestamp `2026-08-07T00:52Z` ou une URL `https://github.com/...` ne
  matchent PAS (régression trap).
- `test_parse_claim_event_fallback_attribution` — bout-en-bout : un
  commentaire gabarit-défaut maintenant attributé à la bonne lane.

V2 :
- `test_intent_extracted_from_marker_line` — l'excerpt contient
  "Search-3 GraphAlgorithms" (le notebook ciblé).
- `test_intent_handles_marker_line_with_only_lane_token` — un `[CLAIMED]`
  sans prose porte au minimum le lane token (l'excerpt n'est jamais vide
  quand la marker line a du contenu).
- `test_intent_handles_truly_empty_marker_line` — un `[CLAIMED]` nu
  reste `(no intent)` sans crasher.
- `test_intent_caps_at_120_chars` — borne supérieure stable + ellipsis.
- `test_blocked_verdict_surfaces_intent_side_by_side` — les deux lanes
  avec leurs intents distincts sont rendus.
- `test_trio_ortools_scenario_disjoint_intents_visible` — le test
  discriminant de l'issue : 3 lanes, 3 EPIC-disjoint notebooks, tous
  lisibles en un coup d'œil.
- `test_blocked_verdict_uses_no_intent_sentinel` — un claim sans excerpt
  porte `(no intent)` lisiblement.
- `test_blocked_message_includes_paths_narrowing_hint` — le hint
  `[CLAIMED] paths: ...` apparaît dans le verdict pour enseigner la
  prochaine étape au lecteur.

V3 :
- `test_10395_v3_10353_vs_10370_asymmetry_eliminated` — le test
  décisif V3 : la PR #10353 (rebascule twin parity, owner jsboige) et
  la PR #10370 (qui portait `lane-claim-conflict` à tort) doivent
  aujourd'hui recevoir **le même verdict** (zero label). Plus
  d'asymétrie "conforme ↔ en conflit" sur la même forme.

## Justification design (les trades)

### V1 : pourquoi un fallback sur la *marker line* uniquement

Le grep naïf `(myia-...:...)` sur tout le body rouvre la trappe
`any-colon-pair-can-be-a-lane` (fermé par #10226, fondateur en #9774). La
discipline : scope = la **marker line** (ligne où apparaît le dernier
`[MARKER]` canonique). Pourquoi ça marche : un commentaire historique
qui pose un claim de la forme `[CLAIMED] #9764 - myia-po-2025:CoursIA
2026-08-07T00:52Z` met TOUT son intent sur une seule ligne ; un
commentaire qui ne le fait pas (token `lane` littéral) est déjà reconnu
par le reader principal. Les deux modes coexistent, le marker-line
fallback ne se déclenche que quand le principal échoue.

### V2 : pourquoi `intent` comme *attribut du ClaimEvent*, pas une refacto du reducer

L'issue propose deux options : (a) maillage de scope au reducer
(quand `paths:` chevauche, on разрешает), (b) affichage côte-à-côte.
J'ai retenu (b) parce que (a) est trop risqué en faux-négatif (un
test sur les chevauchements de `paths:` globs rate facilement le
cas "même fichier, même notebook, deux cellules distinctes"). L'option
(b) fait ***de l'humain*** le décideur final — son outil lui montre
les faits, il tranche. (a) reste un follow-up légitime ; ailleurs
qu'ici.

### V3 : pourquoi cesser d'émettre le label, pas le restreindre

L'option (a) "ne fire `lane-claim-conflict` que sur les renvois
fermants" aurait été strictement plus restrictive — elle aurait
résolu la mesure #10370. Mais elle aurait laissé la mesure
trio-OR-Tools active : ces PRs-là référencent des EPIC par `See #N`
(par prescription, `catalog-pr-hygiene.md` R4) et n'ont aucun
`Closes #N` à désactiver. Il faut **cesser de traiter une EPIC comme
un conflit**. Les EPIC sont multi-lane, c'est leur nature. Le
verdict "conforme" et "en conflit" sur la même forme est
structurellement intenable, et l'unique moyen de le rendre
soutenable est de cesser d'émettre le label.

## Risque résiduel

- **V1** : un commentaire historique qui pose INCORRECTEMENT un lane
  token collé à une URL (`[CLAIMED] - https://myia-po-2025:CoursIA`)
  matcherait — mais le fallback ne s'active que si le reader principal
  échoue, et une URL `https://...` n'est pas sur la marker line en
  pratique. **Mitigation** : le test
  `test_extract_lane_fallback_does_not_match_arbitrary_colon_pairs`pose
  un discriminant **strict** (le token doit être `myia-<machine>:<workspace>`,
  pas juste any-colon).
- **V2** : aucun (l'enrichissement est strictement additif, et les
  67 tests existants passent).
- **V3** : aucun pour les PRs conformes (nettoyage). Pour les PRs
  réellement en conflit, le label `lane-claim-conflict` *n'est plus
  posé* — le path bloquant (`-required` job) reste sur closing refs,
  qui est le discriminant opérationnel. Aucune régression pratique.

## Suivi — dette explicite

- **V2 — éventuellement** : étendre le maillage de scope aux `[CLAIMED]`
  pour matcher l'infra `[OVERRIDE] paths:` (#10342). Ce serait une
  PR-fille, pas un changement de scope ici.
- **V3** : le label GitHub `lane-claim-conflict` historique reste en
  place (les labels legacy ne disparaissent pas) ; le job advisory
  les nettoie à la volée (`unset_label lane-claim-conflict`).
- **V1** : si le repo standardise un gabarit de commentaire de claim,
  aligner sur ce gabarit. Sinon, le fallback vit avec la diversité.

## Méta

- Worker : `myia-po-2025:CoursIA-2` (l'utilisateur `jsboige` a fourni
  la PR #10358 — d'où l'expertise firsthand).
- Issue : [#10395](https://github.com/jsboige/CoursIA/issues/10395) — tag
  `enhancement`, 0 claim avant cette PR.
- Contrats non touchés : `compute_active_claims` (#10342 path-scope),
  `closingIssuesReferences` cross-check (#10323), single-reader
  `extract_lane` (#9485).
- Test final : `python -m pytest scripts/tests/test_check_lane_claim.py
  scripts/tests/test_lane_claim_required.py scripts/tests/test_grain_tag.py -q`
  → **133 passed in 0.74s**.

See #10395 — 3 des 4 critères. Le 3e (« deux claims de scopes disjoints ne se bloquent pas ») n'est atteint qu'à son *minimum acceptable* explicitement prévu par l'issue (afficher les intentions côte à côte) ; la comparaison de périmètres reste à #10419. D'où `See` et non `Closes` : #10395 se ferme quand #10419 atterrit.

_Édition de body par ai-01, sans changement de substance : le mot-clé de fermeture qui pointait #10226 en l.120 est reformulé (#10226 est une PR de training mergée — le squash aurait tenté de la fermer), et la référence non-fermante manquante est ajoutée (`closingIssuesReferences` était vide). Le motif littéral n'est pas recopié ici : le garde neutralise la décoration markdown, donc le citer entre backticks le déclenche aussi._
