### PR TITLE
fix(ci): push-pattern pin tolerates options + runs on the workflows it pins (main red from #10416)

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -25,6 +25,13 @@ on:
       - 'tests/**'
       - 'pytest.ini'
       - '.github/workflows/scripts-tests.yml'
+      # test_workflow_branch_pattern.py (#10145) pins the SHELL TEXT of these
+      # two workflows, so editing them must run this suite. Without these two
+      # entries the pin is blind to its own subject: #10416 changed the push in
+      # catalog-cron.yml, no job ran, and the break only surfaced on the next
+      # unrelated PR that happened to touch scripts/**.
+      - '.github/workflows/catalog-cron.yml'
+      - '.github/workflows/translation-sync.yml'
       # #6790 prover tree-lock: the offline lock-lifecycle tests + the two
       # source files they guard (see the pytest step for why only this one
       # agent_tests file is included, not the whole dir).
@@ -43,6 +50,9 @@ on:
       - 'tests/**'
       - 'pytest.ini'
       - '.github/workflows/scripts-tests.yml'
+      # See the push: block above for why these two are pinned here.
+      - '.github/workflows/catalog-cron.yml'
+      - '.github/workflows/translation-sync.yml'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tree_lock.py'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py'

--- a/scripts/tests/test_workflow_branch_pattern.py
+++ b/scripts/tests/test_workflow_branch_pattern.py
@@ -71,6 +71,31 @@ def _extract_github_script_blocks(yaml_text: str) -> list[str]:
     return blocks
 
 
+# Any `git push ... origin ...`, options tolerated between the two words.
+#
+# Pinning the bare literal `git push origin` made this suite blind to a *more*
+# correct implementation: #10416 changed the push to
+# `git push --force-with-lease origin "HEAD:$BRANCH"` (mono-writer bot branch,
+# hard-fail on rejection) and the option slipped between `push` and `origin`,
+# so both pins below stopped finding any push block at all -- four red tests
+# for a change that satisfied what they assert. The forbidden-form pin at (1)
+# was already written option-tolerantly ("with any separator and any options");
+# this restores the same tolerance on the positive side. See #10416 (the change
+# that exposed the asymmetry) and #10145 (which introduced these pins).
+_PUSH_TO_ORIGIN = re.compile(r"git\s+push\b[^\n]*\borigin\b")
+
+
+def _find_push_block(blocks: list[str], *, exclude_main: bool = False) -> str | None:
+    """First run-block pushing to origin; optionally skip ones targeting main."""
+    for block in blocks:
+        if not _PUSH_TO_ORIGIN.search(block):
+            continue
+        if exclude_main and "HEAD:main" in block:
+            continue
+        return block
+    return None
+
+
 @pytest.fixture(scope="module")
 def catalog_cron_text() -> str:
     return _yaml_text(CATALOG_CRON)
@@ -132,11 +157,7 @@ def test_pushes_to_long_lived_branch(
     """
     text = _yaml_text(workflow_path)
     push_blocks = _extract_run_blocks(text)
-    push_block = None
-    for block in push_blocks:
-        if "git push origin" in block and "HEAD:main" not in block:
-            push_block = block
-            break
+    push_block = _find_push_block(push_blocks, exclude_main=True)
     assert push_block is not None, (
         f"{workflow_label}: no positive push block found (one that does not "
         f"target main)."
@@ -221,13 +242,9 @@ def test_push_hard_fails_on_rejection(
     """
     text = _yaml_text(workflow_path)
     blocks = _extract_run_blocks(text)
-    push_block = None
-    for block in blocks:
-        if "git push origin" in block:
-            push_block = block
-            break
+    push_block = _find_push_block(blocks)
     assert push_block is not None, (
-        f"{workflow_label}: no `git push origin` step found."
+        f"{workflow_label}: no `git push ... origin` step found."
     )
     # The push block must check the exit code (via `if !` or explicit $? test)
     # and exit 1 with an ::error annotation.


### PR DESCRIPTION
Grain: MED/test — lane myia-ai-01:CoursIA — prev: MED/guard #10416

## Ce que je répare, et c'est moi qui l'ai cassé

`main` est rouge sur `Scripts Tests (CPU)` — 4 tests, `7359 passed, 4 failed` — et la cause est **mon** #10416, mergé cette nuit à 04:58Z.

```
FAILED test_pushes_to_long_lived_branch[…catalog-cron.yml]     - no positive push block found
FAILED test_pushes_to_long_lived_branch[…translation-sync.yml] - no positive push block found
FAILED test_push_hard_fails_on_rejection[catalog-cron.yml]     - no `git push origin` step found
FAILED test_push_hard_fails_on_rejection[translation-sync.yml] - no `git push origin` step found
```

#10416 a corrigé le `! [rejected] (non-fast-forward)` du cron catalogue en passant le push à `git push --force-with-lease origin "HEAD:$BRANCH"`, dans un `if !` qui échoue dur avec une annotation `::error`. Les deux pins cherchent le **littéral** `"git push origin" in block` : l'option s'insère entre `push` et `origin`, la sous-chaîne disparaît, et les tests ne trouvent plus **aucun** bloc de push.

Le comble : `test_push_hard_fails_on_rejection` vérifie `::error` + `exit 1` — exactement ce que #10416 a implémenté. Le test rougit sur un changement qui **satisfait** ce qu'il affirme.

## Pourquoi ma CI ne l'a pas vu — la moitié structurelle

`Scripts Tests` porte des filtres `paths:` : `scripts/**`, `tests/**`, `pytest.ini`, `.github/workflows/scripts-tests.yml`, plus quelques fichiers prover. **Ni `catalog-cron.yml` ni `translation-sync.yml`.**

Or c'est le texte shell de ces deux fichiers que `test_workflow_branch_pattern.py` épingle. Un pin dont le sujet est absent des `paths:` de son déclencheur ne peut pas se déclencher quand ce sujet change : #10416 n'a touché que `catalog-cron.yml`, le job n'a **pas tourné**, et la casse n'a fait surface que sur la PR suivante à toucher `scripts/**` par hasard — **#10420** (Search-11, po-2025:CoursIA-2), qui n'y est pour rien.

Réparer le regex sans réparer les `paths:` laisserait la prochaine édition de workflow passer de la même façon. Les deux moitiés vont ensemble.

## Le correctif

**1. Tolérance aux options, symétrique de ce qui existait déjà.** L'assertion *négative* (« pas de `git push … HEAD:main` ») était déjà écrite « with any separator and any options » (l.101). Seul le côté *positif* était littéral. Un helper unique remplace les deux boucles :

```python
_PUSH_TO_ORIGIN = re.compile(r"git\s+push\b[^\n]*\borigin\b")

def _find_push_block(blocks, *, exclude_main: bool = False) -> str | None:
```

**2. Le job se déclenche sur les workflows qu'il épingle** — `catalog-cron.yml` et `translation-sync.yml` ajoutés aux `paths:` de `push:` **et** de `pull_request:`.

## Preuve — le pin garde ses dents

Local : `14 passed in 0.09s`. Et la propriété qui compte, falsifiée plutôt qu'affirmée :

```
MATCH   git push origin HEAD:chore/x-pending              (forme historique)
MATCH   git push --force-with-lease origin "HEAD:$BRANCH" (forme #10416)
MATCH   git push origin HEAD:main                         (INTERDIT — vu par le pin (1))
MATCH   git push --force origin HEAD:main                 (INTERDIT — vu par le pin (1))
no      git fetch origin main                             (pas un push)

exclude_main=True, uniquement des pushes vers main  -> None   → test (2) rouge
exclude_main=True, main + forme legitime            -> le bloc force-with-lease
```

Le regex **voit** les deux formes interdites (donc l'assertion (1) continue de les refuser) et `exclude_main` les écarte du bloc positif : un workflow qui ne pousserait que vers `main` fait toujours rougir (2). La tolérance porte sur les *options*, pas sur la *cible*.

## Une note sur ma propre lane, pour être exact

Ma lane n'a pas tenu de plancher de **contenu** cette nuit : `MED/guard` (#10416), `LIGHT/ledger` (#10348), et ce `MED/test`. Trois grains META d'affilée — c'est exactement le défaut de provisionnement que G-VAR-1 nomme, et il porte sur moi, pas sur une lane. Cette PR-ci n'est pas un choix de grain : c'est la réparation d'une casse que j'ai introduite, et laisser `main` rouge en invoquant un budget de variation serait absurde. Le déficit de contenu reste à mon débit.

See #10416 (la cause) · #10145 (qui a introduit les pins) · #10420 (le passant innocent) · #10421 (chaîne catalog-cron, causes 4 et 6) · #2871 (périmètre de ce job)
