### PR TITLE
fix(ci,#10421): catalog-guard bypasses the catalog vehicle by branch+content

### DIFF
--- a/.github/workflows/catalog-guard.yml
+++ b/.github/workflows/catalog-guard.yml
@@ -20,6 +20,10 @@ name: Catalog Guard
 # Exceptions:
 #   - github-actions[bot] (catalog-cron.yml, catalog-drift.yml auto-commits)
 #   - Manual workflow_dispatch (for emergency maintainer override)
+#   - Catalog vehicle chore/catalog-* whose diff is 100% catalog-owned (#10421):
+#     the long-lived catalog-refresh PR is human-authored when the bot hits a 403,
+#     so the author-based bypass cannot apply; the branch-name gate + content
+#     check recognize it without opening a #2632 poison vector on feature branches.
 
 on:
   pull_request:
@@ -60,6 +64,42 @@ jobs:
             echo "::notice title=Catalog guard::Manual dispatch — guard bypassed."
             echo "bypass=true" >> "$GITHUB_OUTPUT"
             exit 0
+          fi
+
+          # Catalog vehicle bypass (#10421). The long-lived catalog-refresh PR
+          # (chore/catalog-refresh-pending) is authored by a human (jsboige) when
+          # the bot cannot push (HTTP 403 on main), so the author-based bypass
+          # above does not apply and the guard FAILS on the very files the vehicle
+          # exists to update. Recognize the vehicle by its head branch AND a
+          # 100%-catalog-owned diff. The branch-name gate is load-bearing: an
+          # agent that regenerates the catalog on a feature branch (#2632 poison
+          # vector) is NOT on chore/catalog-* and is still caught below.
+          _catalog_owned() {
+            case "$1" in
+              COURSE_CATALOG.generated.json|COURSE_CATALOG.generated.md) return 0 ;;
+              README.md|*/README.md) return 0 ;;           # CATALOG-STATUS markers
+              docs/curriculum/*.md) return 0 ;;            # curriculum pages
+              docs/archive/reference/HEALTH_DASHBOARD.md) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+          HEAD_REF="${{ github.head_ref }}"
+          if [[ "$HEAD_REF" == chore/catalog-* ]]; then
+            ALL_CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" || true)
+            if [ -n "$ALL_CHANGED" ]; then
+              NON_CATALOG=""
+              while IFS= read -r f; do
+                [ -z "$f" ] && continue
+                if ! _catalog_owned "$f"; then NON_CATALOG="$NON_CATALOG $f"; fi
+              done <<< "$ALL_CHANGED"
+              if [ -z "$NON_CATALOG" ]; then
+                echo "::notice title=Catalog guard::Catalog vehicle ($HEAD_REF) — all changed files are catalog-owned, guard bypassed (#10421)."
+                echo "bypass=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              else
+                echo "::warning title=Catalog guard::Branch $HEAD_REF looks like the catalog vehicle but carries non-catalog files ($NON_CATALOG) — guard runs normally."
+              fi
+            fi
           fi
 
           # 3-dot diff: changes on the PR branch that are not on the base.


### PR DESCRIPTION
## Ce que la PR fait

Ajoute un **bypass par branche + contenu** à `catalog-guard.yml` pour reconnaître le véhicule catalog (`chore/catalog-refresh-pending`, #10348) indépendamment de son auteur.

## Cause 6 (#10421)

Le guard exemptait les changements catalog-owned par **auteur** (`github-actions[bot]`). Mais le véhicule catalog long-lived est authored **`jsboige`** — parce que le **403 de la cause 1** empêche le bot de pousser. Le bypass auteur ne s'applique donc pas, et le guard **FAIL** sur les fichiers générés (`COURSE_CATALOG.generated.{json,md}`) **qui sont le travail légitime du véhicule**. `mergeStateStatus: BLOCKED` permanent.

Mesure firsthand (commentaire issue) : après le nudge (`[skip ci]` retiré), `statusCheckRollup` est passé de 5 → 27 checks, `PR gate` 0 → 1, mais `PR gate: FAILURE` car `No catalog changes on feature branch: FAILURE`.

## Fix

Nouveau bypass, inséré entre le bypass `workflow_dispatch` et le check contenu existant :

```bash
if [[ "$HEAD_REF" == chore/catalog-* ]]; then
    ALL_CHANGED=$(git diff --name-only "origin/$BASE...HEAD")
    # si TOUS les fichiers changés sont catalog-owned -> bypass
fi
```

Fichier catalog-owned = `COURSE_CATALOG.generated.{json,md}` | `README.md`/`*/README.md` (marqueurs CATALOG-STATUS) | `docs/curriculum/*.md` | `docs/archive/reference/HEALTH_DASHBOARD.md`.

## Le gate branch-name est load-bearing (anti-retour #2632)

Un bypass **content-only** rouvrirait le vector d'empoisonnement fondateur #2632 : un agent régénère le catalog sur sa feature branch → change generated + son README marker → bypasserait le guard → silent-revert au merge. Le gate `chore/catalog-*` empêche ça : une feature branch (`feature/*`, `fix/*`) ne matche jamais, et tombe sur le check contenu existant qui FAIL sur les fichiers générés.

## Preuve (6 cas testés localement)

| Cas | head branch | contenu | verdict |
|-----|-------------|---------|---------|
| Véhicule legit (#10348, 18 fichiers) | `chore/catalog-refresh-pending` | all catalog-owned | **BYPASS** ✓ |
| Véhicule spoofé + notebook poison | `chore/catalog-refresh-pending` | generated + .ipynb | guard runs (FAIL) ✓ |
| Feature branch + regen catalog (#2632) | `feature/sudoku9-quikgraph` | generated only | existing path → FAIL ✓ |
| Feature branch sans catalog | `feature/fix` | code only | existing path → clean ✓ |
| Véhicule generated-only | `chore/catalog-refresh-pending` | generated only | **BYPASS** ✓ |
| Véhicule spoofé + docs/random | `chore/catalog-refresh-pending` | generated + docs/random/file.md | guard runs (FAIL) ✓ |

YAML valide, bash syntaxe OK (`bash -n`). Le bypass auteur `github-actions[bot]` existant est **conservé** (chemin nominal quand le 403 sera fixé).

See #10421 (cause 6). Ne `Closes` pas (issue multi-cause, d'autres causes restent : le `[skip ci]` ligne 161 de catalog-cron, le 403 bot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)