### PR TITLE
feat(planners,#10382): Planners-2 Tranche 2 Fast Downward -- parite native-both

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics-Csharp.ipynb
@@ -91,13 +91,128 @@
    "id": "59fb7ef4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:26:46.142564Z",
-     "iopub.status.busy": "2026-07-06T12:26:46.136361Z",
-     "iopub.status.idle": "2026-07-06T12:26:47.992671Z",
-     "shell.execute_reply": "2026-07-06T12:26:47.988745Z"
+     "iopub.execute_input": "2026-08-11T05:58:12.761590Z",
+     "iopub.status.busy": "2026-08-11T05:58:12.756782Z",
+     "iopub.status.idle": "2026-08-11T05:58:14.059543Z",
+     "shell.execute_reply": "2026-08-11T05:58:14.057482Z"
     }
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-62240.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '62240.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "data": {
       "text/plain": [
@@ -121,17 +236,17 @@
      "output_type": "stream",
      "text": [
       "\r\n",
+      "(40,19): warning CS0649: Le champ 'Problem.Dom' n'est jamais assigné et aura toujours sa valeur par défaut null\r\n",
+      "\r\n",
       "(20,19): warning CS0649: Le champ 'Domain.Name' n'est jamais assigné et aura toujours sa valeur par défaut null\r\n",
-      "\r\n",
-      "(11,19): warning CS0649: Le champ 'ActionSchema.Name' n'est jamais assigné et aura toujours sa valeur par défaut null\r\n",
-      "\r\n",
-      "(39,19): warning CS0649: Le champ 'Problem.Name' n'est jamais assigné et aura toujours sa valeur par défaut null\r\n",
       "\r\n",
       "(7,38): warning CS0649: Le champ 'TypeDef.Name' n'est jamais assigné et aura toujours sa valeur par défaut null\r\n",
       "\r\n",
-      "(40,19): warning CS0649: Le champ 'Problem.Dom' n'est jamais assigné et aura toujours sa valeur par défaut null\r\n",
-      "\r\n",
       "(7,58): warning CS0649: Le champ 'TypeDef.Parent' n'est jamais assigné et aura toujours sa valeur par défaut null\r\n",
+      "\r\n",
+      "(39,19): warning CS0649: Le champ 'Problem.Name' n'est jamais assigné et aura toujours sa valeur par défaut null\r\n",
+      "\r\n",
+      "(11,19): warning CS0649: Le champ 'ActionSchema.Name' n'est jamais assigné et aura toujours sa valeur par défaut null\r\n",
       "\r\n"
      ]
     }
@@ -212,10 +327,10 @@
    "id": "fbdaf508",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:26:47.994499Z",
-     "iopub.status.busy": "2026-07-06T12:26:47.994305Z",
-     "iopub.status.idle": "2026-07-06T12:26:48.286983Z",
-     "shell.execute_reply": "2026-07-06T12:26:48.286723Z"
+     "iopub.execute_input": "2026-08-11T05:58:14.060953Z",
+     "iopub.status.busy": "2026-08-11T05:58:14.060720Z",
+     "iopub.status.idle": "2026-08-11T05:58:14.280708Z",
+     "shell.execute_reply": "2026-08-11T05:58:14.280451Z"
     }
    },
    "outputs": [
@@ -350,10 +465,10 @@
    "id": "331cb66f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:26:48.288558Z",
-     "iopub.status.busy": "2026-07-06T12:26:48.288355Z",
-     "iopub.status.idle": "2026-07-06T12:26:48.394832Z",
-     "shell.execute_reply": "2026-07-06T12:26:48.394463Z"
+     "iopub.execute_input": "2026-08-11T05:58:14.282255Z",
+     "iopub.status.busy": "2026-08-11T05:58:14.282018Z",
+     "iopub.status.idle": "2026-08-11T05:58:14.375141Z",
+     "shell.execute_reply": "2026-08-11T05:58:14.374878Z"
     }
    },
    "outputs": [
@@ -476,10 +591,10 @@
    "id": "1b715aa7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:26:48.396475Z",
-     "iopub.status.busy": "2026-07-06T12:26:48.396164Z",
-     "iopub.status.idle": "2026-07-06T12:26:48.632170Z",
-     "shell.execute_reply": "2026-07-06T12:26:48.631972Z"
+     "iopub.execute_input": "2026-08-11T05:58:14.376874Z",
+     "iopub.status.busy": "2026-08-11T05:58:14.376644Z",
+     "iopub.status.idle": "2026-08-11T05:58:14.570905Z",
+     "shell.execute_reply": "2026-08-11T05:58:14.570399Z"
     }
    },
    "outputs": [
@@ -607,10 +722,10 @@
    "id": "74af8ac2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:26:48.633982Z",
-     "iopub.status.busy": "2026-07-06T12:26:48.633772Z",
-     "iopub.status.idle": "2026-07-06T12:26:48.775386Z",
-     "shell.execute_reply": "2026-07-06T12:26:48.775108Z"
+     "iopub.execute_input": "2026-08-11T05:58:14.572546Z",
+     "iopub.status.busy": "2026-08-11T05:58:14.572236Z",
+     "iopub.status.idle": "2026-08-11T05:58:14.661426Z",
+     "shell.execute_reply": "2026-08-11T05:58:14.661200Z"
     }
    },
    "outputs": [
@@ -618,7 +733,7 @@
      "data": {
       "text/plain": [
        "Plan trouvé : 7 actions (BFS = longueur minimale)\r\n",
-       "Temps : 2,38 ms\r\n",
+       "Temps : 1,73 ms\r\n",
        "\r\n",
        "  1. load(box1,truck1,depot)\r\n",
        "  2. drive(truck1,depot,store)\r\n",
@@ -712,10 +827,10 @@
    "id": "d1adcb66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:26:48.777336Z",
-     "iopub.status.busy": "2026-07-06T12:26:48.777084Z",
-     "iopub.status.idle": "2026-07-06T12:26:48.971931Z",
-     "shell.execute_reply": "2026-07-06T12:26:48.971438Z"
+     "iopub.execute_input": "2026-08-11T05:58:14.663151Z",
+     "iopub.status.busy": "2026-08-11T05:58:14.662936Z",
+     "iopub.status.idle": "2026-08-11T05:58:14.780309Z",
+     "shell.execute_reply": "2026-08-11T05:58:14.779817Z"
     }
    },
    "outputs": [
@@ -826,6 +941,174 @@
   },
   {
    "cell_type": "markdown",
+   "id": "t2-intro",
+   "metadata": {},
+   "source": [
+    "### Tranche 2 (#10382) : le vrai planificateur Fast Downward\n",
+    "\n",
+    "La §1–8 ci-dessus réimplémente un planificateur STRIPS **from-scratch** (grounding + BFS forward, 0 NuGet) — la brique pédagogique qui rend visible ce que `unified-planning` (côté Python) cache. La **Tranche 2** branche le **même moteur production** que le jumeau Python — **Fast Downward 24.06.1** (Helmert ; A* + heuristique landmark-cut `lmcut`) — via l'API HTTP du conteneur Docker `coursia-fast-downward` (port 8200). Mêmes domaines PDDL (Logistics + Gripper), mêmes instances → on confronte le BFS pédagogique au solveur SOTA."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "t2-fd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T05:58:14.782100Z",
+     "iopub.status.busy": "2026-08-11T05:58:14.781867Z",
+     "iopub.status.idle": "2026-08-11T05:58:15.094504Z",
+     "shell.execute_reply": "2026-08-11T05:58:15.094313Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Logistics (Fast Downward 24.06.1, astar(lmcut())) ---\r\n",
+      "returncode=0 | Coût du plan : 7 | États expansés : 9\r\n",
+      "  load box1 truck1 depot\r\n",
+      "  drive truck1 depot store\r\n",
+      "  unload box1 truck1 store\r\n",
+      "  drive truck1 store depot\r\n",
+      "  load box2 truck1 depot\r\n",
+      "  drive truck1 depot warehouse\r\n",
+      "  unload box2 truck1 warehouse\r\n",
+      "Parité from-scratch : BFS trouvait 7 actions → FD coût 7 = PARITÉ CONFIRMÉE\r\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Gripper (Fast Downward 24.06.1, astar(lmcut())) ---\r\n",
+      "returncode=0 | Coût du plan : 5 | États expansés : 8\r\n",
+      "  pick ball1 rooma left\r\n",
+      "  pick ball2 rooma right\r\n",
+      "  move rooma roomb\r\n",
+      "  drop ball1 roomb left\r\n",
+      "  drop ball2 roomb right\r\n",
+      "Parité from-scratch : BFS trouvait 5 actions → FD coût 5 = PARITÉ CONFIRMÉE\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Tranche 2 (#10382) : Fast Downward 24.06.1 via API Docker (vrai planificateur SOTA) ===\n",
+    "using System.Net.Http;\n",
+    "using System.Text.RegularExpressions;\n",
+    "\n",
+    "var httpFD = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };\n",
+    "\n",
+    "// Domaine PDDL Logistics (prédicats identiques au from-scratch : at-loc/at-veh/empty/in)\n",
+    "string DOMAIN_LOG = @\"(define (domain logistics-simple)\n",
+    "  (:requirements :strips :typing)\n",
+    "  (:types location package vehicle - object\n",
+    "          truck - vehicle)\n",
+    "  (:predicates (at-loc ?p - package ?l - location)\n",
+    "               (at-veh ?v - vehicle ?l - location)\n",
+    "               (empty ?v - vehicle)\n",
+    "               (in ?p - package ?v - vehicle))\n",
+    "  (:action load :parameters (?p - package ?v - vehicle ?l - location)\n",
+    "           :precondition (and (at-loc ?p ?l) (at-veh ?v ?l) (empty ?v))\n",
+    "           :effect (and (in ?p ?v) (not (at-loc ?p ?l)) (not (empty ?v))))\n",
+    "  (:action unload :parameters (?p - package ?v - vehicle ?l - location)\n",
+    "           :precondition (and (in ?p ?v) (at-veh ?v ?l))\n",
+    "           :effect (and (at-loc ?p ?l) (empty ?v) (not (in ?p ?v))))\n",
+    "  (:action drive :parameters (?v - vehicle ?from - location ?to - location)\n",
+    "           :precondition (at-veh ?v ?from)\n",
+    "           :effect (and (at-veh ?v ?to) (not (at-veh ?v ?from)))))\";\n",
+    "\n",
+    "string PROB_LOG = @\"(define (problem logistics-simple-1)\n",
+    "  (:domain logistics-simple)\n",
+    "  (:objects depot warehouse store - location\n",
+    "            box1 box2 - package\n",
+    "            truck1 - truck)\n",
+    "  (:init (at-loc box1 depot) (at-loc box2 depot)\n",
+    "         (at-veh truck1 depot) (empty truck1))\n",
+    "  (:goal (and (at-loc box1 store) (at-loc box2 warehouse))))\";\n",
+    "\n",
+    "// Domaine PDDL Gripper (prédicats identiques au from-scratch : at-robby/free/at/carry)\n",
+    "string DOMAIN_GRIP = @\"(define (domain gripper-strips)\n",
+    "  (:requirements :strips :typing)\n",
+    "  (:types room ball gripper)\n",
+    "  (:predicates (at-robby ?r - room)\n",
+    "               (free ?g - gripper)\n",
+    "               (at ?b - ball ?r - room)\n",
+    "               (carry ?b - ball ?g - gripper))\n",
+    "  (:action move :parameters (?from - room ?to - room)\n",
+    "           :precondition (at-robby ?from)\n",
+    "           :effect (and (at-robby ?to) (not (at-robby ?from))))\n",
+    "  (:action pick :parameters (?obj - ball ?room - room ?gripper - gripper)\n",
+    "           :precondition (and (at ?obj ?room) (at-robby ?room) (free ?gripper))\n",
+    "           :effect (and (carry ?obj ?gripper) (not (at ?obj ?room)) (not (free ?gripper))))\n",
+    "  (:action drop :parameters (?obj - ball ?room - room ?gripper - gripper)\n",
+    "           :precondition (and (at-robby ?room) (carry ?obj ?gripper))\n",
+    "           :effect (and (at ?obj ?room) (free ?gripper) (not (carry ?obj ?gripper)))))\";\n",
+    "\n",
+    "string PROB_GRIP = @\"(define (problem gripper-2balls)\n",
+    "  (:domain gripper-strips)\n",
+    "  (:objects rooma roomb - room\n",
+    "            ball1 ball2 - ball\n",
+    "            left right - gripper)\n",
+    "  (:init (at-robby rooma) (free left) (free right)\n",
+    "         (at ball1 rooma) (at ball2 rooma))\n",
+    "  (:goal (and (at ball1 roomb) (at ball2 roomb))))\";\n",
+    "\n",
+    "// Appel au conteneur Docker Fast Downward\n",
+    "string SolveFD(string domain, string problem, string search) {\n",
+    "    var payloadObj = new { domain, problem, search };\n",
+    "    var payloadJson = System.Text.Json.JsonSerializer.Serialize(payloadObj);\n",
+    "    var resp = httpFD.PostAsync(\"http://localhost:8200/plan\",\n",
+    "        new StringContent(payloadJson, System.Text.Encoding.UTF8, \"application/json\")).Result;\n",
+    "    return resp.Content.ReadAsStringAsync().Result;\n",
+    "}\n",
+    "\n",
+    "string ReportFD(string label, string body, int expectedActions) {\n",
+    "    var doc = System.Text.Json.JsonDocument.Parse(body);\n",
+    "    int returncode = doc.RootElement.GetProperty(\"returncode\").GetInt32();\n",
+    "    string stdout = doc.RootElement.GetProperty(\"stdout\").GetString();\n",
+    "    var sb = new System.Text.StringBuilder();\n",
+    "    sb.AppendLine($\"--- {label} (Fast Downward 24.06.1, astar(lmcut())) ---\");\n",
+    "    var mCost = Regex.Match(stdout, @\"Plan cost: (\\d+)\");\n",
+    "    var mExp = Regex.Match(stdout, @\"Expanded (\\d+) state\");\n",
+    "    var planLines = Regex.Matches(stdout, @\"^([a-z][\\w-]*(?:\\s+[\\w?-]+)*)\\s+\\(\\d+\\)\\s*$\", RegexOptions.Multiline);\n",
+    "    int cost = mCost.Success ? int.Parse(mCost.Groups[1].Value) : -1;\n",
+    "    int expanded = mExp.Success ? int.Parse(mExp.Groups[1].Value) : -1;\n",
+    "    sb.AppendLine($\"returncode={returncode} | Coût du plan : {cost} | États expansés : {expanded}\");\n",
+    "    foreach (Match m in planLines)\n",
+    "        sb.AppendLine($\"  {m.Groups[1].Value.Trim()}\");\n",
+    "    sb.AppendLine($\"Parité from-scratch : BFS trouvait {expectedActions} actions → FD coût {cost} = {(cost == expectedActions ? \"PARITÉ CONFIRMÉE\" : \"diffère\")}\");\n",
+    "    return sb.ToString();\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(ReportFD(\"Logistics\", SolveFD(DOMAIN_LOG, PROB_LOG, \"astar(lmcut())\"), 7));\n",
+    "Console.WriteLine(ReportFD(\"Gripper\", SolveFD(DOMAIN_GRIP, PROB_GRIP, \"astar(lmcut())\"), 5));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "t2-interp",
+   "metadata": {},
+   "source": [
+    "### Interprétation : parité lib-vs-lib, scalabilité du SOTA\n",
+    "\n",
+    "| Domaine | BFS from-scratch (§4) | Fast Downward `lmcut` | États expansés (FD) |\n",
+    "|---|---|---|---|\n",
+    "| **Logistics** (1 camion, 2 colis, contrainte `empty`) | 7 actions | coût **7** | 9 |\n",
+    "| **Gripper** (2 pinces, 2 balles) | 5 actions | coût **5** | 8 |\n",
+    "\n",
+    "**Parité exacte.** Le moteur réel Fast Downward retrouve les **mêmes plans optimaux** que le BFS from-scratch. C'est la preuve que la sémantique STRIPS réimplémentée §1–8 est correcte — un planificateur \"jouet\" cassé divergerait.\n",
+    "\n",
+    "**La nuance n'est pas le résultat, c'est le coût de recherche.** Sur ces instances minuscules, BFS (forward, en aveugle) et A*+lmcut trouvent l'optimum ; mais le BFS explore aveuglément (coût uniforme, aucune heuristic), tandis que `lmcut` (heuristique landmark-cut de Helmert & Domshlak 2009) **focalise** la recherche vers le but. Sur une instance plus grande (Logistics à 10 colis), le BFS exploserait exponentiellement quand FD reste polynomial-grâce-à-l'heuristique. Le from-scratch rend visible *ce que fait un planificateur* (grounding + search) ; le moteur SOTA montre *pourquoi l'heuristique compte*.\n",
+    "\n",
+    "**Verdict `SOTA-OK` (#3801).** Le moteur réel Fast Downward est invoqué (API Docker, `returncode=0`), produit les vrais plans optimaux. Tranche 1 from-scratch préservée intacte. Niveau de parité `native-both` : le jumeau Python invoque `unified-planning` (qui wrap Fast Downward), le jumeau C# invoque le même engine 24.06.1 via HttpClient."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6c432c7c",
    "metadata": {},
    "source": [
@@ -865,14 +1148,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "11658aa1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:26:48.973528Z",
-     "iopub.status.busy": "2026-07-06T12:26:48.973318Z",
-     "iopub.status.idle": "2026-07-06T12:26:49.030634Z",
-     "shell.execute_reply": "2026-07-06T12:26:49.030477Z"
+     "iopub.execute_input": "2026-08-11T05:58:15.096133Z",
+     "iopub.status.busy": "2026-08-11T05:58:15.095929Z",
+     "iopub.status.idle": "2026-08-11T05:58:15.151120Z",
+     "shell.execute_reply": "2026-08-11T05:58:15.150873Z"
     }
    },
    "outputs": [
@@ -931,14 +1214,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "58bbfe7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:26:49.032147Z",
-     "iopub.status.busy": "2026-07-06T12:26:49.031935Z",
-     "iopub.status.idle": "2026-07-06T12:26:49.105153Z",
-     "shell.execute_reply": "2026-07-06T12:26:49.104945Z"
+     "iopub.execute_input": "2026-08-11T05:58:15.152881Z",
+     "iopub.status.busy": "2026-08-11T05:58:15.152674Z",
+     "iopub.status.idle": "2026-08-11T05:58:15.192409Z",
+     "shell.execute_reply": "2026-08-11T05:58:15.191943Z"
     }
    },
    "outputs": [
@@ -987,14 +1270,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "ee2d8671",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:26:49.106893Z",
-     "iopub.status.busy": "2026-07-06T12:26:49.106679Z",
-     "iopub.status.idle": "2026-07-06T12:26:49.159626Z",
-     "shell.execute_reply": "2026-07-06T12:26:49.159408Z"
+     "iopub.execute_input": "2026-08-11T05:58:15.194043Z",
+     "iopub.status.busy": "2026-08-11T05:58:15.193811Z",
+     "iopub.status.idle": "2026-08-11T05:58:15.228970Z",
+     "shell.execute_reply": "2026-08-11T05:58:15.228554Z"
     }
    },
    "outputs": [

--- a/scripts/notebook_tools/twin_pairs.d/planners-2-pddl-basics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-2-pddl-basics.yaml
@@ -2,7 +2,7 @@
   family: SymbolicAI/Planners
   python: MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   audits:
     - date: "2026-07-31"
       by: po-2024
@@ -10,5 +10,6 @@
       csharp_sha: 241758247433d536fb0f1f324962446cd6d12af5
   known_differences:
     - "Concept : syntaxe PDDL (domain.pddl + problem.pddl), predicats, actions, etat initial/but."
-    - "Python : generation PDDL via unified-planning PDDLWriter + parsing. C# : from-scratch PDDL text builder/parser BCL."
+    - "Lib-vs-lib : Python invoque unified-planning (qui wrap Fast Downward). C# : Tranche 1 from-scratch (grounding + BFS forward, BCL .NET) + Tranche 2 invoque Fast Downward 24.06.1 via API Docker (port 8200). Mêmes domaines PDDL (Logistics, Gripper)."
+    - "Tranche 2 native-both (#10382, 2026-08-11 po-2024) : FD astar(lmcut()) confirme les plans optimaux du BFS from-scratch — Logistics cout 7 (contrainte empty = 1 colis a la fois), Gripper cout 5 (2 pinces paralleles). Verdict SOTA-OK (#3801) : moteur reel invoque (API Docker returncode 0), memes plans. Tranche 1 from-scratch preservee."
     - "Re-baseline 2026-07-31 (po-2024, #8052) : markdown-only correction cote Python (cell[59] downstream next-notebook list : nb4/nb5 titres transposes -> Planners-4-Fast-Downward / Planners-5-Heuristics, conformes aux fichiers sur disque). Paraphite-preservant : aucun output/code modifie, axe de parite semantic intact."

--- a/scripts/notebook_tools/twin_pairs.d/planners-2-pddl-basics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-2-pddl-basics.yaml
@@ -8,6 +8,12 @@
       by: po-2024
       python_sha: c83be596acfef24a0d6b22bab6405f2e68074374
       csharp_sha: 241758247433d536fb0f1f324962446cd6d12af5
+    - date: "2026-08-11"
+      by: myia-po-2024:CoursIA
+      python_sha: c83be596acfef24a0d6b22bab6405f2e68074374
+      csharp_sha: 9e4f2381178788134c11a90ad6cf40aa8c8c473a
+      content_python_sha: 5d4135096b98c027a43c2e93f1efb883c1857fe80bfd2b47cbeebe20c3dafdd1
+      content_csharp_sha: 119bcb4b69575be84bc0bfa222091ee17e20d1db74be38463561c3bb7f7b3d8d
   known_differences:
     - "Concept : syntaxe PDDL (domain.pddl + problem.pddl), predicats, actions, etat initial/but."
     - "Lib-vs-lib : Python invoque unified-planning (qui wrap Fast Downward). C# : Tranche 1 from-scratch (grounding + BFS forward, BCL .NET) + Tranche 2 invoque Fast Downward 24.06.1 via API Docker (port 8200). Mêmes domaines PDDL (Logistics, Gripper)."


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2024:CoursIA — prev: DEEP/notebook-dotnet #10382 (Planners-4/5/7/8 Tranche 2)

## Summary

**Tranche 2 lib-vs-lib pour Planners-2-PDDL-Basics-Csharp** (#10382) : branche le **vrai moteur production Fast Downward 24.06.1** (Helmert ; A* + heuristique landmark-cut `lmcut`) via l'API HTTP du conteneur Docker `coursia-fast-downward` (port 8200) — le même engine que le jumeau Python invoque via `unified-planning`. La Tranche 1 from-scratch (grounding + BFS forward) est **préservée intacte**.

Promotion du niveau de parité `semantic` → `native-both`.

## Détail technique

Trois cellules insérées après la cellule Gripper-interp (§4), avant les exercices :

1. **Intro markdown** — pose la Tranche 2 comme confrontation du BFS pédagogique au solveur SOTA.
2. **Code C#** (`ec=7`) — `HttpClient` → `POST http://localhost:8200/plan` avec `{domain, problem, search:"astar(lmcut())"}`. Deux domaines PDDL aux prédicats **identiques au from-scratch** (Logistics : `at-loc`/`at-veh`/`empty`/`in` ; Gripper : `at-robby`/`free`/`at`/`carry`). `ReportFD()` désérialise l'enveloppe JSON `{"returncode","stdout",...}` via `System.Text.Json.JsonDocument`, puis regex le `stdout` : `Plan cost: (\d+)`, `Expanded (\d+) state`, lignes de plan.
3. **Interprétation markdown** — table comparative BFS vs FD + explication du coût de recherche (pourquoi l'heuristique compte à l'échelle).

## Verdict de parité (firsthand, re-exécuté)

| Domaine | BFS from-scratch (§4) | Fast Downward `lmcut` | États expansés (FD) |
|---|---|---|---|
| **Logistics** (1 camion, 2 colis, contrainte `empty` = 1 colis à la fois) | 7 actions | coût **7** | 9 |
| **Gripper** (2 pinces parallèles, 2 balles) | 5 actions | coût **5** | 8 |

**PARITÉ EXACTE ×2.** FD retrouve les mêmes plans optimaux que le BFS from-scratch :
- Logistics : load box1 → drive depot→store → unload box1 → drive store→depot → load box2 → drive depot→warehouse → unload box2 (7).
- Gripper : pick ball1 left → pick ball2 right → move rooma→roomb → drop ball1 left → drop ball2 right (5).

**Verdict `SOTA-OK` (#3801 Prong A).** Le moteur réel Fast Downward est invoqué (API Docker, `returncode=0`), produit les vrais plans optimaux. Aucune sortie dégradée/workaround — la sortie commitée EST la vraie sortie du SOTA.

## Prong B — problème non-trivial

L'instance Logistics exhibe la contrainte `empty` (le camion ne porte qu'un colis à la fois) qui force un plan non-linéaire (aller-retour dépôt). FD avec `lmcut` (heuristique landmark-cut de Helmert & Domshlak 2009) **focalise** la recherche vers le but — l'écart avec le BFS en aveugle deviendrait exponentiel sur une instance plus grande. Le from-scratch rend visible *ce que fait un planificateur* (grounding + search) ; le SOTA montre *pourquoi l'heuristique compte*.

## Preuves d'exécution réelle (C.2 / H.1)

- Re-exécution complète `jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=.net-csharp` (cwd = dossier du notebook).
- **0 erreur**. `execution_count` 1..10 cohérent sur toutes les cellules code.
- Sorties commitées = vraies sorties FD (coûts 7/5, plans détaillés). Pas de hand-edit (Stop & Repair respecté).
- `strip_probe_banner.py` : N/A (aucune énumération `NetworkInterface` dans cette cellule).

## Twin registry

`planners-2-pddl-basics.yaml` : `parity_level` semantic → **native-both**. `known_differences` réécrit : "C# : Tranche 1 from-scratch + Tranche 2 invoque Fast Downward 24.06.1 via API Docker". SHA rebaseliné via `check_twin_parity.py --update` **après** le commit du notebook (leçon #8957).

`check_twin_parity.py` : **157/157 OK, DRIFT=0**.

## Scope

2 fichiers, 2 commits, 1 sujet (Tranche 2 Planners-2). Tranche 1 from-scratch **intacte** (vérifié : cellules §1-8 non modifiées, seules 3 cellules ajoutées). Aucun changement hors-scope. Catalogue byte-identique à main.

See #10382, #3801.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
