### PR TITLE
fix(app-10b,#10022): seed GA (Random 42) + reconcile cell[11] on comparison (Closes #10022)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
@@ -588,35 +588,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Asset0    : 0,77 %\r\n"
+      "Asset0    : 0,11 %\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Asset1    : 2,96 %\r\n"
+      "Asset1    : 3,75 %\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Asset2    : 23,53 %\r\n"
+      "Asset2    : 23,49 %\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Asset3    : 30,82 %\r\n"
+      "Asset3    : 32,35 %\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Asset4    : 41,92 %\r\n"
+      "Asset4    : 40,30 %\r\n"
      ]
     },
     {
@@ -624,21 +624,21 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Rendement attendu : 20,51 %\r\n"
+      "Rendement attendu : 20,45 %\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Risque (écart-type): 12,91 %\r\n"
+      "Risque (écart-type): 12,81 %\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Fitness (return - alpha*risk): 0,0760\r\n"
+      "Fitness (return - alpha*risk): 0,0764\r\n"
      ]
     },
     {
@@ -675,12 +675,30 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Le GA bat l'equal-weight de 26,4% et atteint 99,5% de l'optimum de la grille.\r\n"
+      "Le GA bat l'equal-weight de 27,1% et atteint 100,0% de l'optimum de la grille.\r\n"
      ]
     }
    ],
    "source": [
     "using GeneticSharp;\n",
+    "\n",
+    "// === Reproductibilite : le GA est stochastique, on branche un generateur sempable (seed 42) ===\n",
+    "// GeneticSharp derive tout son alea (population initiale, selection, croisement, mutation) de\n",
+    "// RandomizationProvider.Current. Par defaut c'est un BasicRandomization non-deterministe -> les\n",
+    "// allocations varient d'une execution a l'autre. SeededRandomization implante les 7 methodes\n",
+    "// d'IRandomization (GeneticSharp 3.1.4) sur un System.Random(42), pour un resultat reproductible.\n",
+    "public class SeededRandomization : IRandomization\n",
+    "{\n",
+    "    private readonly Random _rng;\n",
+    "    public SeededRandomization(int seed) { _rng = new Random(seed); }\n",
+    "    public int GetInt(int min, int max) => _rng.Next(min, max);\n",
+    "    public int[] GetInts(int length, int min, int max) { var a = new int[length]; for (int i = 0; i < length; i++) a[i] = _rng.Next(min, max); return a; }\n",
+    "    public int[] GetUniqueInts(int length, int min, int max) { var pool = new List<int>(); for (int v = min; v < max; v++) pool.Add(v); var a = new int[length]; for (int i = 0; i < length && pool.Count > 0; i++) { int idx = _rng.Next(pool.Count); a[i] = pool[idx]; pool.RemoveAt(idx); } return a; }\n",
+    "    public float GetFloat() => (float)_rng.NextDouble();\n",
+    "    public float GetFloat(float min, float max) => min + (float)_rng.NextDouble() * (max - min);\n",
+    "    public double GetDouble() => _rng.NextDouble();\n",
+    "    public double GetDouble(double min, double max) => min + _rng.NextDouble() * (max - min);\n",
+    "}\n",
     "\n",
     "// Liste d'actifs\n",
     "var assets = new List<string> { \"Asset0\", \"Asset1\", \"Asset2\", \"Asset3\", \"Asset4\" };\n",
@@ -720,6 +738,11 @@
     "\n",
     "// Paramètre alpha = 1.0 (vous pouvez l'ajuster selon votre tolérance au risque)\n",
     "var fitness = new PortfolioFitness(portfolio, alpha: 1.0);\n",
+    "\n",
+    "// On branche le generateur sempable (seed 42) AVANT le chromosome : la population initiale\n",
+    "// (50 individus via PortfolioChromosome.CreateNew -> RandomizationProvider) et les operateurs\n",
+    "// (EliteSelection, UniformCrossover, UniformMutation) en derivent tous.\n",
+    "RandomizationProvider.Current = new SeededRandomization(42);\n",
     "\n",
     "// On crée un chromosome représentatif\n",
     "var chromosome = new PortfolioChromosome(assets);\n",
@@ -807,7 +830,10 @@
     "Console.WriteLine($\"Optimum grille (référence, pas 0.05)    : fitness {optFit:0.0000}\");\n",
     "\n",
     "// Verdict : le GA bat-il les baselines ? (bestReturn - bestRisk = fitness du GA)\n",
-    "Console.WriteLine($\"\\nLe GA bat l'equal-weight de {(bestReturn - bestRisk - ewFit) / ewFit * 100:0.0}% et atteint {(bestReturn - bestRisk) / optFit * 100:0.0}% de l'optimum de la grille.\");"
+    "Console.WriteLine($\"\\nLe GA bat l'equal-weight de {(bestReturn - bestRisk - ewFit) / ewFit * 100:0.0}% et atteint {(bestReturn - bestRisk) / optFit * 100:0.0}% de l'optimum de la grille.\");\n",
+    "\n",
+    "// Restore le generateur par defaut (non-sempable) pour ne pas affecter les GA suivants (cardinalite, etc.).\n",
+    "RandomizationProvider.Current = new BasicRandomization();"
    ]
   },
   {
@@ -824,40 +850,25 @@
     "tags": []
    },
    "source": [
-    "### Interprétation : Résultats de l'algorithme génétique\n",
+    "### Interpretation : le GA vs les baselines — la comparaison compte plus que l'allocation\n",
     "\n",
-    "**Sortie obtenue** : le GA a convergé vers une allocation avec un rendement attendu de 19,56% et un risque de 12,11% (fitness 0,0745).\n",
+    "**Verdict comparatif (reproductible, seed 42)** : le GA atteint une fitness de **0,0764** — soit **+27,1 %** au-dessus du portefeuille equal-weight (0,0602) et **+189 %** au-dessus du greedy (0,0264) — et rejoint **exactement l'optimum de la grille fine** (0,0764, 194 481 evaluations). C'est ce verdict qui porte la lecon, pas l'allocation exacte : sur ce paysage (rendements monotones, covariance diagonale-dominante), l'optimum est largement determine par le ratio rendement/risque marginal, et une infinite d'allocations proches donnent des fitness quasi-egales — d'ou la drift d'une execution a l'autre en l'absence de graine.\n",
     "\n",
-    "| Actif / métrique | Valeur GA | Signification |\n",
+    "| Strategie | Fitness | vs GA |\n",
     "|--------|--------|---------------|\n",
-    "| Asset0 | 4,31% | Allocation faible |\n",
-    "| Asset1 | 5,29% | Allocation faible |\n",
-    "| Asset2 | 22,32% | Allocation significative |\n",
-    "| Asset3 | 31,12% | Poids important |\n",
-    "| Asset4 | 36,96% | Allocation maximale |\n",
-    "| Rendement attendu | 19,56% | Rendement pondéré des 5 actifs |\n",
-    "| Risque (écart-type) | 12,11% | Volatilité du portefeuille |\n",
-    "| Fitness | 0,0745 | Rendement - alpha × risque (alpha=1.0) |\n",
+    "| **GA (GeneticSharp, seed 42)** | **0,0764** | — |\n",
+    "| Equal-weight (20% chacun) | 0,0602 | GA **+27,1 %** |\n",
+    "| Greedy (100% meilleur ratio rendement/risque) | 0,0264 | GA **+189 %** |\n",
+    "| Optimum grille (reference, pas 0.05) | 0,0764 | GA atteint **100 %** |\n",
     "\n",
-    "### Le GA apporte-t-il une valeur distinctive ? Comparaison aux baselines\n",
+    "**Lecons** :\n",
+    "1. **Le GA bat nettement l'equal-weight (+27,1 %)** : l'optimisation stochastique trouve un meilleur compromis rendement/risque qu'une diversification uniforme nave.\n",
+    "2. **Le GA ecrase le greedy (+189 %)** : concentrer 100 % sur l'actif au meilleur ratio individuel ignore la covariance — le portefeuille concentre subit un risque non diversifie qui detruit la fitness. Le GA, lui, exploite la matrice de covariance pour diversifier intelligemment.\n",
+    "3. **Le GA rejoint l'optimum de la grille (100 %)** : le GA stochastique rivalise avec une recherche exhaustive par grille fine (194 481 evaluations), pour une fraction du cout — c'est precisement la valeur d'une metaheuristique (bon compromis qualite/cout vs force brute).\n",
     "\n",
-    "La fitness seule (0,0745) ne dit pas si le GA **bat** des stratégies naïves. On confronte trois références (fitness = rendement - alpha × risque) :\n",
+    "> **Allocation trouvee (seed 42)** : Asset0 0,11 % · Asset1 3,75 % · Asset2 23,49 % · Asset3 32,35 % · Asset4 40,30 % (rendement 20,45 %, risque 12,81 %). Cette allocation precise n'est **pas** la lecon — le paysage admet beaucoup d'allocations quasi-optimales ; la lecon est le **verdict comparatif** ci-dessus, qui seul distingue le GA d'une baseline nave.\n",
     "\n",
-    "| Stratégie | Fitness | vs GA |\n",
-    "|--------|--------|---------------|\n",
-    "| **GA (GeneticSharp)** | **0,0745** | — |\n",
-    "| Equal-weight (20% chacun) | 0,0602 | GA **+23,8%** |\n",
-    "| Greedy (100% meilleur ratio rendement/risque) | 0,0264 | GA **+182%** |\n",
-    "| Optimum grille (référence, pas 0.05) | 0,0764 | GA atteint **97,5%** |\n",
-    "\n",
-    "**Leçons** :\n",
-    "1. **Le GA bat nettement l'equal-weight (+23,8%)** : l'optimisation stochastique trouve un meilleur compromis rendement/risque qu'une diversification uniforme naïve.\n",
-    "2. **Le GA écrase le greedy (+182%)** : concentrer 100% sur l'actif au meilleur ratio individuel ignore la covariance — le portefeuille concentré subit un risque non diversifié qui détruit la fitness. Le GA, lui, exploite la matrice de covariance pour diversifier intelligemment.\n",
-    "3. **Le GA atteint 97,5% de l'optimum de la grille** : le GA stochastique rivalise avec une recherche exhaustive par grille fine (194 481 évaluations), pour une fraction du coût — c'est précisément la valeur d'une métaheuristique (bon compromis qualité/coût vs force brute).\n",
-    "\n",
-    "> **Note technique** : la matrice de covariance joue un rôle crucial dans le risque. Les corrélations positives entre actifs signifient que la diversification réduit le risque, mais pas autant qu'avec des actifs parfaitement décorrélés. Le greedy ignore ce fait (il ne regarde que les variances individuelles) — d'où son effondrement. Le GA, via la fitness `rendement - alpha × risque`, *voit* la covariance et s'en sert pour diversifier.\n",
-    "\n",
-    "> **Reproductibilité** : le GA étant stochastique (population initiale aléatoire), les allocations varient légèrement d'une exécution à l'autre (fitness typiquement entre 0,074 et 0,077), mais le **verdict comparatif est robuste** : le GA bat toujours l'equal-weight de ~23-27% et atteint 97-99,9% de l'optimum de la grille. Les baselines (equal-weight, greedy, optimum grille) sont déterministes."
+    "> **Reproductibilite** : depuis cette cellule, le GA est **sempable** (seed 42 via `SeededRandomization` branchee sur `RandomizationProvider`) — chaque execution donne donc les memes allocations ET le meme verdict. Sans graine, les allocations varieraient (fitness typiquement 0,074–0,077) mais le verdict comparatif resterait robuste. Les baselines (equal-weight, greedy, optimum grille) sont deterministes."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
@@ -50,6 +50,12 @@
         csharp_sha: 8413a08b13a3f1d3350ca2fa61c5115200f11058
         content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
         content_csharp_sha: 2208eba59d6d7d0e5a7361811372e1627e7fbd6afe03524dfc1eb338d1374acd
+    -   date: '2026-08-11'
+        by: myia-po-2025:CoursIA-2
+        python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+        csharp_sha: 7023d3ba7fe5e0ce0624ee2806ea06851c4e382e
+        content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+        content_csharp_sha: 879e4a17d56b5bcc6aa292f8a1ec1ea2d29c0988615fe47dd5385ddc54a348c2
     known_differences:
     - 'Socle pedagogique commun : Optimisation de portefeuille (convex opt cvxpy + GeneticSharp C#) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles.'
     - 'Idiomes framework : Python = cvxpy convex optimization + math.comb ; C# = GeneticSharp NuGet (GA).'


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA-2 — prev: DEEP/notebook-dotnet #10420
(distinct substance : le précédent #10420 était un *bridge lib-vs-lib* GeneticSharp sur Search-11 ; celui-ci est un *fix de reproductibilité + réconciliation de prose* sur App-10b — problème, notebook et raisonnement différents, pas une variante scan-générée)

## App-10b : GA sempable (seed 42) + prose cell[11] réconciliée sur la comparaison

Closes #10022 (item 4 — le résiduel « 6 nombres gelés » flaggé par ai-01 au titre du « 5/6 mesuré »). Les items 1-3 (baselines, instance discriminante, re-exec) étaient livrés par les PR mergées de po-2024 (#10026, #10048, #10160, #10174, #10291) ; cette PR est la dernière pièce.

### Le défaut, mesuré firsthand (origin/main = 9d16e984a)

cell[10] lançait un GA GeneticSharp **non-sempable** : `PortfolioChromosome` dérive ses gènes de `RandomizationProvider.Current` (un `BasicRandomization` non-déterministe par défaut). Conséquence mesurée : la cellule[11] committée citait une allocation **gelée d'une exécution précédente** (Asset0 4,31 % … Asset4 36,96 %, fitness 0,0745, +23,8 %) qui ne **correspondait pas** à la sortie cell[10] committée (0,77 / 2,96 / 23,53 / 30,82 / 41,92 %, fitness 0,0760, +26,4 %). C'est exactement l'item 4 violé « sur six nombres » (ai-01).

### Le fix (cell[10] + cell[11], chirurgical)

**cell[10]** — on branche un générateur semable :
- `SeededRandomization : IRandomization` (les 7 méthodes de l'interface GeneticSharp 3.1.4, vérifiées par réflexion) sur un `System.Random(42)`.
- `RandomizationProvider.Current = new SeededRandomization(42)` **avant** la création du chromosome (la population initiale + les opérateurs en dérivent tous).
- **Restore** `new BasicRandomization()` en fin de cellule → le seed est **confiné à cell[10]** (cell[13] cardinalité et cell[16]/[19] N=12/N=6 ne sont pas affectées — vérifié C.3, voir bas).

**cell[11]** — réécrite **comparaison d'abord** :
- Le verdict comparatif (GA fitness 0,0764 = **+27,1 %** vs equal-weight, **+189 %** vs greedy, rejoint **100 % de l'optimum grille**) devient le headline.
- L'allocation exacte (6 nombres) est reléguée à une note secondaire (« Cette allocation précise n'est pas la leçon — le paysage admet beaucoup d'allocations quasi-optimales ; la leçon est le verdict comparatif »).
- Note de reproductibilité mise à jour : seed 42 → chaque exécution donne les **mêmes** allocations ET verdict (vérifié : 2 runs identiques).

### Sortie cell[10] (seed 42, reproductible)

```
Asset0 : 0,11 %   Asset1 : 3,75 %   Asset2 : 23,49 %   Asset3 : 32,35 %   Asset4 : 40,30 %
Rendement : 20,45 %   Risque : 12,81 %   Fitness : 0,0764
Equal-weight : 0,0602   Greedy : 0,0264   Optimum grille : 0,0764
Le GA bat l'equal-weight de 27,1% et atteint 100,0% de l'optimum de la grille.
```

### Verdict SOTA (Prong B, [.claude/rules/sota-not-workaround.md](.claude/rules/sota-not-workaround.md))

**SOTA-OK.** Le GA GeneticSharp (NuGet 3.1.4) est proprement invoqué et exécuté ; la sortie committée est sa vraie sortie (ec=5, 14 outputs, 0 erreur). L'instance est **discriminante** : le GA bat strictement l'equal-weight (+27,1 %) et le greedy (+189 %), et rejoint l'optimum de la grille fine — la valeur du GA est **visible dans la sortie** (item 2 de #10022, livré par #10160/#10174, confirmé ici).

### Conformité (C.1/C.2/C.3)

- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` dans cell[10] modifiée.
- **C.2** : cell[10] re-exécutée (nbconvert --execute, ec=5), outputs réels committés ; cell[11] markdown.
- **C.3** : exécution chirurgicale — **0 drift** sur les 26 autres cellules (source + outputs + execution_count byte-identiques à HEAD). Seules cell[10] (source + outputs) et cell[11] (source) diffèrent. Les cellules stochastiques 13/16/19 gardent leurs outputs committés (le seed est confiné à cell[10] via le restore). 0 probe banner.

### Twin registry

`scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml` : nouvelle entrée d'audit (2026-08-11). **Note outil** : `check_twin_parity.py --update` n'a pas pris la paire (`updated=0`) — le regex `surgical_rebaseline` attend une indentation 2-space (`^\s{2}(audits):`) alors que `app-10-portfolio.yaml` utilise l'indentation 4-space native du fichier. SHAs **calculés via la méthode canonique du tool** (`_content_sha` : strip top-level `metadata` + `json.dumps(sort_keys=True, ensure_ascii=False, separators=(",",":"))`, lus via `git show HEAD:<path>`) puis append manuel au format 4-space natif, **validés par `--check` : 157/157 OK, 0 DRIFT**. csharp_sha `7023d3ba` (blob HEAD), content_csharp_sha `879e4a17` (canonique), Python twin non touché (`483c2648` / `059e3dd5` inchangés). Le bug de regex (indent-4) sera tracké dans une issue séparée — ne concerne pas ce livrable.
