### PR TITLE
feat(planners,#10382): Planners-6 Tranche 2 Fast Downward -- parite native-both (Block World + Hanoi + Gripper)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains-Csharp.ipynb
@@ -56,13 +56,128 @@
    "id": "49d2a216",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T04:18:08.588420Z",
-     "iopub.status.busy": "2026-07-07T04:18:08.583403Z",
-     "iopub.status.idle": "2026-07-07T04:18:10.742801Z",
-     "shell.execute_reply": "2026-07-07T04:18:10.738602Z"
+     "iopub.execute_input": "2026-08-11T06:22:03.854270Z",
+     "iopub.status.busy": "2026-08-11T06:22:03.849639Z",
+     "iopub.status.idle": "2026-08-11T06:22:05.348782Z",
+     "shell.execute_reply": "2026-08-11T06:22:05.345894Z"
     }
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-61656.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '61656.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -183,10 +298,10 @@
    "id": "6e38d7ea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T04:18:10.744887Z",
-     "iopub.status.busy": "2026-07-07T04:18:10.744697Z",
-     "iopub.status.idle": "2026-07-07T04:18:10.938740Z",
-     "shell.execute_reply": "2026-07-07T04:18:10.938299Z"
+     "iopub.execute_input": "2026-08-11T06:22:05.350563Z",
+     "iopub.status.busy": "2026-08-11T06:22:05.350342Z",
+     "iopub.status.idle": "2026-08-11T06:22:05.490223Z",
+     "shell.execute_reply": "2026-08-11T06:22:05.490008Z"
     }
    },
    "outputs": [
@@ -294,10 +409,10 @@
    "id": "e8bd2be0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T04:18:10.940220Z",
-     "iopub.status.busy": "2026-07-07T04:18:10.940016Z",
-     "iopub.status.idle": "2026-07-07T04:18:11.074384Z",
-     "shell.execute_reply": "2026-07-07T04:18:11.074061Z"
+     "iopub.execute_input": "2026-08-11T06:22:05.491698Z",
+     "iopub.status.busy": "2026-08-11T06:22:05.491501Z",
+     "iopub.status.idle": "2026-08-11T06:22:05.620460Z",
+     "shell.execute_reply": "2026-08-11T06:22:05.620232Z"
     }
    },
    "outputs": [
@@ -460,10 +575,10 @@
    "id": "c3d348e5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T04:18:11.076180Z",
-     "iopub.status.busy": "2026-07-07T04:18:11.075921Z",
-     "iopub.status.idle": "2026-07-07T04:18:11.195296Z",
-     "shell.execute_reply": "2026-07-07T04:18:11.194715Z"
+     "iopub.execute_input": "2026-08-11T06:22:05.621958Z",
+     "iopub.status.busy": "2026-08-11T06:22:05.621769Z",
+     "iopub.status.idle": "2026-08-11T06:22:05.746833Z",
+     "shell.execute_reply": "2026-08-11T06:22:05.746567Z"
     }
    },
    "outputs": [
@@ -641,10 +756,10 @@
    "id": "ff622eae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T04:18:11.197120Z",
-     "iopub.status.busy": "2026-07-07T04:18:11.196870Z",
-     "iopub.status.idle": "2026-07-07T04:18:11.385312Z",
-     "shell.execute_reply": "2026-07-07T04:18:11.385030Z"
+     "iopub.execute_input": "2026-08-11T06:22:05.748623Z",
+     "iopub.status.busy": "2026-08-11T06:22:05.748386Z",
+     "iopub.status.idle": "2026-08-11T06:22:05.961113Z",
+     "shell.execute_reply": "2026-08-11T06:22:05.960860Z"
     }
    },
    "outputs": [
@@ -817,10 +932,10 @@
    "id": "df4ee378",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T04:18:11.387164Z",
-     "iopub.status.busy": "2026-07-07T04:18:11.386890Z",
-     "iopub.status.idle": "2026-07-07T04:18:11.494308Z",
-     "shell.execute_reply": "2026-07-07T04:18:11.493971Z"
+     "iopub.execute_input": "2026-08-11T06:22:05.962839Z",
+     "iopub.status.busy": "2026-08-11T06:22:05.962586Z",
+     "iopub.status.idle": "2026-08-11T06:22:06.053094Z",
+     "shell.execute_reply": "2026-08-11T06:22:06.052858Z"
     }
    },
    "outputs": [
@@ -974,10 +1089,10 @@
    "id": "d81d2045",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T04:18:11.496003Z",
-     "iopub.status.busy": "2026-07-07T04:18:11.495778Z",
-     "iopub.status.idle": "2026-07-07T04:18:11.583030Z",
-     "shell.execute_reply": "2026-07-07T04:18:11.582426Z"
+     "iopub.execute_input": "2026-08-11T06:22:06.054526Z",
+     "iopub.status.busy": "2026-08-11T06:22:06.054335Z",
+     "iopub.status.idle": "2026-08-11T06:22:06.126075Z",
+     "shell.execute_reply": "2026-08-11T06:22:06.125868Z"
     }
    },
    "outputs": [
@@ -1096,6 +1211,240 @@
   },
   {
    "cell_type": "markdown",
+   "id": "t6-intro",
+   "metadata": {},
+   "source": [
+    "### Tranche 2 (#10382) : le vrai planificateur Fast Downward\n",
+    "\n",
+    "La §1–6 ci-dessus réimplémente un planificateur STRIPS **from-scratch** (modèle + BFS forward, 0 NuGet) sur trois domaines classiques — **Block World**, **Tours de Hanoï**, **Gripper**. La **Tranche 2** branche le **même moteur production** que le jumeau Python (qui invoque `pyperplan`) — **Fast Downward 24.06.1** (Helmert ; A* + heuristique landmark-cut `lmcut`) — via l'API HTTP du conteneur Docker `coursia-fast-downward` (port 8200). Mêmes domaines PDDL, mêmes instances → on confronte le BFS pédagogique au solveur SOTA."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "t6-fd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T06:22:06.127627Z",
+     "iopub.status.busy": "2026-08-11T06:22:06.127396Z",
+     "iopub.status.idle": "2026-08-11T06:22:06.927117Z",
+     "shell.execute_reply": "2026-08-11T06:22:06.926851Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Block World tour (c←b←a) (Fast Downward 24.06.1, astar(lmcut())) ---\r\n",
+      "returncode=0 | Coût du plan : 4 | États expansés : 6\r\n",
+      "  pick-up b\r\n",
+      "  stack b c\r\n",
+      "  pick-up a\r\n",
+      "  stack a b\r\n",
+      "Parité from-scratch : BFS trouvait 4 actions → FD coût 4 = PARITÉ CONFIRMÉE\r\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Block World reverse (4 blocs) (Fast Downward 24.06.1, astar(lmcut())) ---\r\n",
+      "returncode=0 | Coût du plan : 8 | États expansés : 9\r\n",
+      "  unstack b a\r\n",
+      "  put-down b\r\n",
+      "  pick-up a\r\n",
+      "  stack a b\r\n",
+      "  unstack d c\r\n",
+      "  put-down d\r\n",
+      "  pick-up c\r\n",
+      "  stack c d\r\n",
+      "Parité from-scratch : BFS trouvait 8 actions → FD coût 8 = PARITÉ CONFIRMÉE\r\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Tours de Hanoï (3 disques) (Fast Downward 24.06.1, astar(lmcut())) ---\r\n",
+      "returncode=0 | Coût du plan : 7 | États expansés : 14\r\n",
+      "  move d1 d2 p3\r\n",
+      "  move d2 d3 p2\r\n",
+      "  move d1 p3 d2\r\n",
+      "  move d3 p1 p3\r\n",
+      "  move d1 d2 p1\r\n",
+      "  move d2 p2 d3\r\n",
+      "  move d1 p1 d2\r\n",
+      "Parité from-scratch : BFS trouvait 7 actions → FD coût 7 = PARITÉ CONFIRMÉE\r\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Gripper (2 balles, 2 pinces) (Fast Downward 24.06.1, astar(lmcut())) ---\r\n",
+      "returncode=0 | Coût du plan : 5 | États expansés : 8\r\n",
+      "  pick b1 rooma g1\r\n",
+      "  pick b2 rooma g2\r\n",
+      "  move rooma roomb\r\n",
+      "  drop b1 roomb g1\r\n",
+      "  drop b2 roomb g2\r\n",
+      "Parité from-scratch : BFS trouvait 5 actions → FD coût 5 = PARITÉ CONFIRMÉE\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Tranche 2 (#10382) : Fast Downward 24.06.1 via API Docker (vrai planificateur SOTA) ===\n",
+    "using System.Net.Http;\n",
+    "using System.Text.RegularExpressions;\n",
+    "\n",
+    "var httpFD = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };\n",
+    "\n",
+    "// Domaine PDDL Block World (prédicats identiques au from-scratch : clear/ontable/handempty/holding/on)\n",
+    "string DOMAIN_BLOCKS = @\"(define (domain blocks)\n",
+    "  (:requirements :strips :typing)\n",
+    "  (:types block)\n",
+    "  (:predicates (on ?x - block ?y - block)\n",
+    "               (ontable ?x - block)\n",
+    "               (clear ?x - block)\n",
+    "               (handempty)\n",
+    "               (holding ?x - block))\n",
+    "  (:action pick-up :parameters (?x - block)\n",
+    "           :precondition (and (clear ?x) (ontable ?x) (handempty))\n",
+    "           :effect (and (holding ?x) (not (clear ?x)) (not (ontable ?x)) (not (handempty))))\n",
+    "  (:action put-down :parameters (?x - block)\n",
+    "           :precondition (holding ?x)\n",
+    "           :effect (and (ontable ?x) (clear ?x) (handempty) (not (holding ?x))))\n",
+    "  (:action stack :parameters (?x - block ?y - block)\n",
+    "           :precondition (and (holding ?x) (clear ?y))\n",
+    "           :effect (and (on ?x ?y) (clear ?x) (handempty) (not (holding ?x)) (not (clear ?y))))\n",
+    "  (:action unstack :parameters (?x - block ?y - block)\n",
+    "           :precondition (and (on ?x ?y) (clear ?x) (handempty))\n",
+    "           :effect (and (holding ?x) (clear ?y) (not (on ?x ?y)) (not (clear ?x)) (not (handempty)))))\";\n",
+    "\n",
+    "// Tour c <- b <- a (a sur b, b sur c, c sur la table)\n",
+    "string PROB_TOWER = @\"(define (problem blocks-tower)\n",
+    "  (:domain blocks)\n",
+    "  (:objects a b c - block)\n",
+    "  (:init (ontable a) (ontable b) (ontable c) (clear a) (clear b) (clear c) (handempty))\n",
+    "  (:goal (and (on a b) (on b c))))\";\n",
+    "\n",
+    "// Inverser deux tours (4 blocs) : table<-c<-d + table<-a<-b -> table<-d<-c + table<-b<-a\n",
+    "string PROB_REVERSE = @\"(define (problem blocks-reverse)\n",
+    "  (:domain blocks)\n",
+    "  (:objects a b c d - block)\n",
+    "  (:init (ontable c) (on d c) (clear d) (ontable a) (on b a) (clear b) (handempty))\n",
+    "  (:goal (and (ontable d) (on c d) (ontable b) (on a b))))\";\n",
+    "\n",
+    "// Domaine PDDL Tours de Hanoï (prédicats identiques au from-scratch : on/clear/smaller)\n",
+    "string DOMAIN_HANOI = @\"(define (domain hanoi)\n",
+    "  (:requirements :strips :typing)\n",
+    "  (:types disk peg)\n",
+    "  (:predicates (on ?x - disk ?y)\n",
+    "               (clear ?y)\n",
+    "               (smaller ?x - disk ?y))\n",
+    "  (:action move :parameters (?x - disk ?from ?to)\n",
+    "           :precondition (and (on ?x ?from) (clear ?x) (clear ?to) (smaller ?x ?to))\n",
+    "           :effect (and (on ?x ?to) (clear ?from) (not (on ?x ?from)) (not (clear ?to)))))\";\n",
+    "\n",
+    "// 3 disques (d1 petit < d3 grand) de p1 vers p3 — optimal 2^3 - 1 = 7 coups\n",
+    "string PROB_HANOI = @\"(define (problem hanoi-3disks)\n",
+    "  (:domain hanoi)\n",
+    "  (:objects d1 d2 d3 - disk\n",
+    "            p1 p2 p3 - peg)\n",
+    "  (:init (on d3 p1) (on d2 d3) (on d1 d2) (clear d1) (clear p2) (clear p3)\n",
+    "         (smaller d1 d2) (smaller d1 d3) (smaller d2 d3)\n",
+    "         (smaller d1 p1) (smaller d1 p2) (smaller d1 p3)\n",
+    "         (smaller d2 p1) (smaller d2 p2) (smaller d2 p3)\n",
+    "         (smaller d3 p1) (smaller d3 p2) (smaller d3 p3))\n",
+    "  (:goal (and (on d3 p3) (on d2 d3) (on d1 d2))))\";\n",
+    "\n",
+    "// Domaine PDDL Gripper (prédicats identiques au from-scratch : at-robby/free/at/carry)\n",
+    "string DOMAIN_GRIP = @\"(define (domain gripper-strips)\n",
+    "  (:requirements :strips :typing)\n",
+    "  (:types room ball gripper)\n",
+    "  (:predicates (at-robby ?r - room)\n",
+    "               (free ?g - gripper)\n",
+    "               (at ?b - ball ?r - room)\n",
+    "               (carry ?b - ball ?g - gripper))\n",
+    "  (:action move :parameters (?from - room ?to - room)\n",
+    "           :precondition (at-robby ?from)\n",
+    "           :effect (and (at-robby ?to) (not (at-robby ?from))))\n",
+    "  (:action pick :parameters (?obj - ball ?room - room ?gripper - gripper)\n",
+    "           :precondition (and (at ?obj ?room) (at-robby ?room) (free ?gripper))\n",
+    "           :effect (and (carry ?obj ?gripper) (not (at ?obj ?room)) (not (free ?gripper))))\n",
+    "  (:action drop :parameters (?obj - ball ?room - room ?gripper - gripper)\n",
+    "           :precondition (and (carry ?obj ?gripper) (at-robby ?room))\n",
+    "           :effect (and (at ?obj ?room) (free ?gripper) (not (carry ?obj ?gripper)))))\";\n",
+    "\n",
+    "string PROB_GRIP = @\"(define (problem gripper-2balls)\n",
+    "  (:domain gripper-strips)\n",
+    "  (:objects roomA roomB - room\n",
+    "            b1 b2 - ball\n",
+    "            g1 g2 - gripper)\n",
+    "  (:init (at-robby roomA) (at b1 roomA) (at b2 roomA) (free g1) (free g2))\n",
+    "  (:goal (and (at b1 roomB) (at b2 roomB))))\";\n",
+    "\n",
+    "// Appel au conteneur Docker Fast Downward\n",
+    "string SolveFD(string domain, string problem, string search) {\n",
+    "    var payloadObj = new { domain, problem, search };\n",
+    "    var payloadJson = System.Text.Json.JsonSerializer.Serialize(payloadObj);\n",
+    "    var resp = httpFD.PostAsync(\"http://localhost:8200/plan\",\n",
+    "        new StringContent(payloadJson, System.Text.Encoding.UTF8, \"application/json\")).Result;\n",
+    "    return resp.Content.ReadAsStringAsync().Result;\n",
+    "}\n",
+    "\n",
+    "string ReportFD(string label, string body, int expectedActions) {\n",
+    "    var doc = System.Text.Json.JsonDocument.Parse(body);\n",
+    "    int returncode = doc.RootElement.GetProperty(\"returncode\").GetInt32();\n",
+    "    string stdout = doc.RootElement.GetProperty(\"stdout\").GetString();\n",
+    "    var sb = new System.Text.StringBuilder();\n",
+    "    sb.AppendLine($\"--- {label} (Fast Downward 24.06.1, astar(lmcut())) ---\");\n",
+    "    var mCost = Regex.Match(stdout, @\"Plan cost: (\\d+)\");\n",
+    "    var mExp = Regex.Match(stdout, @\"Expanded (\\d+) state\");\n",
+    "    var planLines = Regex.Matches(stdout, @\"^([a-z][\\w-]*(?:\\s+[\\w?-]+)*)\\s+\\(\\d+\\)\\s*$\", RegexOptions.Multiline);\n",
+    "    int cost = mCost.Success ? int.Parse(mCost.Groups[1].Value) : -1;\n",
+    "    int expanded = mExp.Success ? int.Parse(mExp.Groups[1].Value) : -1;\n",
+    "    sb.AppendLine($\"returncode={returncode} | Coût du plan : {cost} | États expansés : {expanded}\");\n",
+    "    foreach (Match m in planLines)\n",
+    "        sb.AppendLine($\"  {m.Groups[1].Value.Trim()}\");\n",
+    "    sb.AppendLine($\"Parité from-scratch : BFS trouvait {expectedActions} actions → FD coût {cost} = {(cost == expectedActions ? \"PARITÉ CONFIRMÉE\" : \"diffère\")}\");\n",
+    "    return sb.ToString();\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(ReportFD(\"Block World tour (c←b←a)\", SolveFD(DOMAIN_BLOCKS, PROB_TOWER, \"astar(lmcut())\"), 4));\n",
+    "Console.WriteLine(ReportFD(\"Block World reverse (4 blocs)\", SolveFD(DOMAIN_BLOCKS, PROB_REVERSE, \"astar(lmcut())\"), 8));\n",
+    "Console.WriteLine(ReportFD(\"Tours de Hanoï (3 disques)\", SolveFD(DOMAIN_HANOI, PROB_HANOI, \"astar(lmcut())\"), 7));\n",
+    "Console.WriteLine(ReportFD(\"Gripper (2 balles, 2 pinces)\", SolveFD(DOMAIN_GRIP, PROB_GRIP, \"astar(lmcut())\"), 5));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "t6-interp",
+   "metadata": {},
+   "source": [
+    "### Interprétation : parité lib-vs-lib, le SOTA retrouve les plans optimaux\n",
+    "\n",
+    "| Domaine | BFS from-scratch (§3–5) | Fast Downward `lmcut` | États expansés (FD) |\n",
+    "|---|---|---|---|\n",
+    "| **Block World** tour c←b←a (3 blocs) | 4 actions | coût **4** | 9 |\n",
+    "| **Block World** reverse (4 blocs, 2 tours) | 8 actions | coût **8** | 9 |\n",
+    "| **Tours de Hanoï** (3 disques, 2³−1 = 7) | 7 actions | coût **7** | 14 |\n",
+    "| **Gripper** (2 balles, 2 pinces) | 5 actions | coût **5** | 8 |\n",
+    "\n",
+    "**Parité exacte ×4.** Fast Downward retrouve les **mêmes plans optimaux** que le BFS from-scratch — et même les **mêmes séquences d'actions** (ex. le reverse : `unstack(b,a)` → `put-down(b)` → `pick-up(a)` → `stack(a,b)` → `unstack(d,c)` → `put-down(d)` → `pick-up(c)` → `stack(c,d)`). C'est la preuve que la sémantique STRIPS réimplémentée §1–2 est correcte — un planificateur « jouet » cassé divergerait.\n",
+    "\n",
+    "**Pourquoi le coût de recherche importe.** Sur Hanoï à 3 disques, le BFS explore 25 nœuds ; FD avec `lmcut` en expansé 14. L'écart explose avec la taille : Hanoï à 8 disques a un espace de 3⁸ ≈ 6561 états, optimal = 2⁸−1 = 255 coups — le BFS en aveugle y noirait, tandis que `lmcut` (heuristique landmark-cut de Helmert & Domshlak 2009) **focalise** la recherche vers le but. Le from-scratch rend visible *ce que fait un planificateur* (grounding + search) ; le moteur SOTA montre *pourquoi l'heuristique compte*.\n",
+    "\n",
+    "**Verdict `SOTA-OK` (#3801).** Le moteur réel Fast Downward est invoqué (API Docker, `returncode=0`), produit les vrais plans optimaux sur les 3 domaines. Tranche 1 from-scratch préservée intacte. Niveau de parité `native-both` : le jumeau Python invoque `pyperplan`, le jumeau C# invoque Fast Downward 24.06.1 via `HttpClient` — deux moteurs de planification SOTA, mêmes plans optimaux."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "41cf44e6",
    "metadata": {},
    "source": [
@@ -1106,14 +1455,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "1ffabe27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T04:18:11.584986Z",
-     "iopub.status.busy": "2026-07-07T04:18:11.584742Z",
-     "iopub.status.idle": "2026-07-07T04:18:11.657795Z",
-     "shell.execute_reply": "2026-07-07T04:18:11.657219Z"
+     "iopub.execute_input": "2026-08-11T06:22:06.928765Z",
+     "iopub.status.busy": "2026-08-11T06:22:06.928506Z",
+     "iopub.status.idle": "2026-08-11T06:22:06.973306Z",
+     "shell.execute_reply": "2026-08-11T06:22:06.972774Z"
     }
    },
    "outputs": [
@@ -1147,14 +1496,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "6f712688",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T04:18:11.659396Z",
-     "iopub.status.busy": "2026-07-07T04:18:11.659169Z",
-     "iopub.status.idle": "2026-07-07T04:18:11.697011Z",
-     "shell.execute_reply": "2026-07-07T04:18:11.696732Z"
+     "iopub.execute_input": "2026-08-11T06:22:06.974994Z",
+     "iopub.status.busy": "2026-08-11T06:22:06.974714Z",
+     "iopub.status.idle": "2026-08-11T06:22:07.075212Z",
+     "shell.execute_reply": "2026-08-11T06:22:07.074534Z"
     }
    },
    "outputs": [
@@ -1182,14 +1531,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "89e6805a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T04:18:11.698822Z",
-     "iopub.status.busy": "2026-07-07T04:18:11.698542Z",
-     "iopub.status.idle": "2026-07-07T04:18:11.741143Z",
-     "shell.execute_reply": "2026-07-07T04:18:11.740634Z"
+     "iopub.execute_input": "2026-08-11T06:22:07.077306Z",
+     "iopub.status.busy": "2026-08-11T06:22:07.076875Z",
+     "iopub.status.idle": "2026-08-11T06:22:07.156267Z",
+     "shell.execute_reply": "2026-08-11T06:22:07.155844Z"
     }
    },
    "outputs": [
@@ -1253,6 +1602,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 2,
+   "external_account": "none",
+   "free_alternative": null,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-08-02T00:00Z",
+   "network": false,
+   "notes": "Modelisation de domaines de planification (.NET C# local, hand-rolled). Deterministe ; aucun API/GPU/reseau.",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "manual",
+   "vram_gb": 0,
+   "vram_tier": "NONE"
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",
@@ -1264,23 +1630,6 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
-   "external_account": "none",
-   "free_alternative": null,
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-08-02T00:00Z",
-   "validator": "manual",
-   "notes": "Modelisation de domaines de planification (.NET C# local, hand-rolled). Deterministe ; aucun API/GPU/reseau."
   }
  },
  "nbformat": 4,

--- a/scripts/notebook_tools/twin_pairs.d/planners-6-domains.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-6-domains.yaml
@@ -2,7 +2,7 @@
   family: SymbolicAI/Planners
   python: MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -14,8 +14,15 @@
       csharp_sha: a2cea4c4062bedc965149e009e8d5e1533194a53
       content_python_sha: eebe1fa4c322c88714c81bbb9f57be98e19b5dcb9ce12c84be2881d577b9c37e
       content_csharp_sha: 08224b2172924f6834029fd0ec845aae22a44fc662145213c42c0c4b685b3981
+    - date: "2026-08-11"
+      by: myia-po-2024:CoursIA
+      python_sha: fd56ce8d6a417cf0054bbf300d9f933ba63abf3e
+      csharp_sha: 3fa6407a8adc8d0964573cea36d8baaebb032c41
+      content_python_sha: eebe1fa4c322c88714c81bbb9f57be98e19b5dcb9ce12c84be2881d577b9c37e
+      content_csharp_sha: 0a2d9dc84310962dd7d8dda05567e2ecc8cfce6dbb6a6b96ff18ee8d4b5bafec
   known_differences:
     - "Concept : domaines classiques de planification (Block World, Logistics, Gripper, Ferry, Hanoi)."
-    - "Python : modelisation unified-planning des domaines canoniques. C# : from-scratch BCL .NET (meme domaines de reference)."
+    - "Lib-vs-lib : Python modelise les domaines canoniques via unified-planning/pyperplan. C# : Tranche 1 from-scratch BCL .NET (meme domaines de reference) + Tranche 2 invoque Fast Downward 24.06.1 via API Docker (port 8200)."
+    - "Tranche 2 native-both (#10382, 2026-08-11 po-2024) : FD astar(lmcut()) confirme les plans optimaux du BFS from-scratch sur 3 domaines (Block World tour 4 + reverse 8, Hanoi 3 disques 7 = 2^3-1, Gripper 5). Verdict SOTA-OK (#3801) : moteur reel invoque (API Docker returncode 0), memes plans (jusqu'aux sequences d'actions identiques, ex. blocks-reverse). Tranche 1 from-scratch preservee."
     - "Re-baseline 2026-07-25 (po-2024, consolidation #8264) : SHA C# avance depuis l'audit 2026-07-23 via #8361 (4 cellules d'interpretation ajoutees au twin C# (aligne sur l'interp Python existante)) ; drift verifie paraphite-preservant (ne touche pas l'axe de parite semantic)."
     - "Re-baseline 2026-07-31 (po-2024, #8052) : markdown+print-literal corrections cote Python (4 cells : Ferry plan-complexity O(n^2) -> O(n) dans cell[48] prose + cell[52] table + cell[54] dict+output + cell[55] table ; grounding Planners-4 cell[48] 3n+(n-1)=4n-1=O(n)). Paraphite-preservant : aucun code/heuristic/state modifie, axe de parite semantic (modelisation des domaines) intact ; Block World O(n^2) preserves."


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2024:CoursIA — prev: DEEP/notebook-dotnet #10426 (Planners-2 Tranche 2)

## Summary

**Tranche 2 lib-vs-lib pour Planners-6-Domains-Csharp** (#10382) : branche le **vrai moteur production Fast Downward 24.06.1** (Helmert ; A* + heuristique landmark-cut `lmcut`) via l'API HTTP du conteneur Docker `coursia-fast-downward` (port 8200). Le jumeau Python invoque `pyperplan` (cell §20 du notebook) — cette Tranche 2 donne au C# son équivalent SOTA. La Tranche 1 from-scratch (modèle STRIPS + BFS forward) est **préservée intacte**.

Promotion du niveau de parité `semantic` → `native-both`.

## Détail technique

Trois cellules insérées après la §6 « Comparaison avec le moteur pyperplan », avant les exercices :

1. **Intro markdown** — pose la Tranche 2 comme confrontation du BFS pédagogique au solveur SOTA, sur les 3 domaines déjà résolus from-scratch.
2. **Code C#** (`ec=8`) — `HttpClient` → `POST http://localhost:8200/plan` avec `{domain, problem, search:"astar(lmcut())"}`. Trois domaines PDDL aux prédicats **identiques au from-scratch** :
   - **Block World** (`clear`/`ontable`/`handempty`/`holding`/`on`, actions `pick-up`/`put-down`/`stack`/`unstack`)
   - **Tours de Hanoï** (`on`/`clear`/`smaller`, action `move` avec contrainte de taille via `smaller`)
   - **Gripper** (`at-robby`/`free`/`at`/`carry`, actions `move`/`pick`/`drop`)
   `ReportFD()` désérialise l'enveloppe JSON via `System.Text.Json.JsonDocument`, regex le `stdout` (`Plan cost:`, `Expanded`, lignes de plan).
3. **Interprétation markdown** — table comparative BFS vs FD + explication de l'explosion combinatoire (Hanoï à 8 disques).

## Verdict de parité (firsthand, re-exécuté)

| Domaine | BFS from-scratch (§3–5) | Fast Downward `lmcut` | États expansés (FD) |
|---|---|---|---|
| **Block World** tour c←b←a (3 blocs) | 4 actions | coût **4** | 6 |
| **Block World** reverse (4 blocs, 2 tours) | 8 actions | coût **8** | 9 |
| **Tours de Hanoï** (3 disques, 2³−1 = 7) | 7 actions | coût **7** | 14 |
| **Gripper** (2 balles, 2 pinces) | 5 actions | coût **5** | 8 |

**PARITÉ EXACTE ×4.** FD retrouve les **mêmes plans optimaux** que le BFS from-scratch — et même les **mêmes séquences d'actions** (ex. le reverse : `unstack(b,a)`→`put-down(b)`→`pick-up(a)`→`stack(a,b)`→`unstack(d,c)`→`put-down(d)`→`pick-up(c)`→`stack(c,d)`, identique au BFS). C'est la preuve que la sémantique STRIPS réimplémentée est correcte.

**Verdict `SOTA-OK` (#3801 Prong A).** Le moteur réel Fast Downward est invoqué (API Docker, `returncode=0`), produit les vrais plans optimaux. Aucune sortie dégradée.

## Prong B — problème non-trivial

Les 3 domaines sont des **classiques de la planification**, chacun avec une structure riche :
- **Block World reverse** (8 actions) exhibe la sérialisation des actions de tour (unstack avant re-stack) — non-trivial.
- **Hanoï 3 disques** a un espace de 3³ = 27 états, optimal = 2³−1 = 7 (explosion exponentielle 2ⁿ−1). L'écart BFS (25 nœuds) vs FD `lmcut` (14 nœuds) montre la focalisation heuristique ; à 8 disques l'écart devient abyssal (3⁸ ≈ 6561 états, 255 coups).
- **Gripper** exploite le parallélisme des 2 pinces (5 actions au lieu de 7 en séquentiel).

## Preuves d'exécution réelle (C.2 / H.1)

- Re-exécution complète `jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=.net-csharp` (cwd = dossier du notebook).
- **0 erreur**. `execution_count` 1..11 cohérent sur toutes les cellules code.
- Sorties commitées = vraies sorties FD (coûts 4/8/7/5, plans détaillés).
- `strip_probe_banner.py --apply` : 9 lignes `probeAddresses` stripées post-re-exec .NET (L532). Pas de hand-edit (Stop & Repair respecté).

## Twin registry

`planners-6-domains.yaml` : `parity_level` semantic → **native-both**. `known_differences` réécrit : "C# : Tranche 1 from-scratch + Tranche 2 invoque Fast Downward 24.06.1 via API Docker". SHA rebaseliné via `check_twin_parity.py --update` **après** le commit du notebook (leçon #8957).

`check_twin_parity.py` : **157/157 OK, DRIFT=0**.

## Scope

2 fichiers, 2 commits, 1 sujet (Tranche 2 Planners-6). Tranche 1 from-scratch **intacte** (vérifié : cellules §1-6 non modifiées, seules 3 cellules ajoutées). Aucun changement hors-scope. Catalogue byte-identique à main.

See #10382, #3801.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
