### PR TITLE
fix(variation,#10341): aggregate labels target the candidate, not the lane-day

### DIFF
--- a/.github/workflows/variation-light-genre.yml
+++ b/.github/workflows/variation-light-genre.yml
@@ -163,6 +163,17 @@ jobs:
           SIG_CAPEXC=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('CAP-EXCEEDED-BY-GENRE'))" 2>/dev/null || echo "False")
           SIG_MISMATCH=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('GENRE-MISMATCH'))" 2>/dev/null || echo "False")
           TALLY=$(python3 -c "import json; t=json.load(open('/tmp/signals.json')).get('tally',{}); print(f\"declared={t.get('light_declared',0)} genre={t.get('light_genre',0)} cap={t.get('cap',1)}\")" 2>/dev/null || echo "inconnu")
+          # #10341 -- the three aggregate signals (TIER-INFLATION, GENRE-RUN,
+          # CAP-EXCEEDED-BY-GENRE) measure the LANE-DAY, not the candidate.
+          # When the OPEN PR is CONTENT (not a LIGHT-genre grain -- genai,
+          # lean, qc, notebook-...), it does NOT contribute to the pattern
+          # they denounce. Posing the aggregate label on it would let the
+          # merge-gate (which reads the LABEL, not the check state) HOLD the
+          # grain that REMEDIES the motif, while the META grains that caused
+          # the cap/run/inflation go untouched. GENRE-MISMATCH is exempt: it
+          # carries on the candidate by construction (declared genre vs the
+          # candidate's OWN diff paths), so it may label regardless.
+          CAND_LIGHT=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('candidate_is_light_genre'))" 2>/dev/null || echo "False")
 
           # Labels distincts (lisibles dans gh pr list --json labels). Chaque
           # classe de defaut a son propre label -- un seul label fourre-tout
@@ -187,13 +198,14 @@ jobs:
             # sont fixes (cf scripts/variation_light_cap.py), une table
             # explicite reste la lecture la moins fragile.
             case "$SIGNAL" in
-              TIER-INFLATION)        SIGVAR="SIG_INFLATION" ;;
-              GENRE-RUN)             SIGVAR="SIG_RUN" ;;
-              CAP-EXCEEDED-BY-GENRE) SIGVAR="SIG_CAPEXC" ;;
-              GENRE-MISMATCH)        SIGVAR="SIG_MISMATCH" ;;
+              TIER-INFLATION)        SIGVAR="SIG_INFLATION"; MAY_LABEL_INNOCENT="no" ;;
+              GENRE-RUN)             SIGVAR="SIG_RUN"; MAY_LABEL_INNOCENT="no" ;;
+              CAP-EXCEEDED-BY-GENRE) SIGVAR="SIG_CAPEXC"; MAY_LABEL_INNOCENT="no" ;;
+              GENRE-MISMATCH)        SIGVAR="SIG_MISMATCH"; MAY_LABEL_INNOCENT="yes" ;;
               *)
                 echo "Signal non reconnnu : ${SIGNAL} (PR ${PR_NUMBER})"
                 SIGVAR="__UNDEFINED__"
+                MAY_LABEL_INNOCENT="yes"
                 ;;
             esac
             if [ "$SIGVAR" = "__UNDEFINED__" ]; then
@@ -206,7 +218,17 @@ jobs:
               SIGVAL="${!SIGVAR:-False}"
             fi
             gh label create "$LABEL" --description "$DESC" --color "$COLOR" --force 2>/dev/null || true
-            if [ "$SIGVAL" = "True" ]; then
+            # #10341 -- aggregate signals (MAY_LABEL_INNOCENT="no") must not
+            # label an innocent CONTENT candidate. The lane-day signal stays
+            # real (surfaced in the diagnostic comment below), but the LABEL
+            # -- which is what the merge-gate reads -- must not misattribute
+            # a META pattern (guard/docs/readme run or cap) to a CONTENT
+            # grain (genai/lean/qc/notebook-...) that does not carry it.
+            # GENRE-MISMATCH (MAY_LABEL_INNOCENT="yes") is exempt: its
+            # subject IS the candidate by construction. The else-branch also
+            # strips a label that a prior push had posed before the lane
+            # crossed the cap on META grains (idempotent re-eval).
+            if [ "$SIGVAL" = "True" ] && { [ "$MAY_LABEL_INNOCENT" = "yes" ] || [ "$CAND_LIGHT" = "True" ]; }; then
               gh pr edit "$PR_NUMBER" --add-label "$LABEL" 2>/dev/null || true
             else
               gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
@@ -227,6 +249,18 @@ jobs:
           - **CAP-EXCEEDED-BY-GENRE** : light_genre > cap partage G-VAR-2 (tally : ${TALLY})"
           [ "$SIG_MISMATCH" = "True" ] && ACTIVE_LINES="${ACTIVE_LINES}
           - **GENRE-MISMATCH** : declared genre != genre infere depuis les chemins du diff"
+
+          # #10341 nuance : si la PR courante est CONTENU (non LIGHT-genre)
+          # et qu'un signal agrege est actif, le dire explicitement -- le
+          # motif lane-jour est reel (garde dans le commentaire pour le
+          # coordinateur), mais les labels agregees ne sont PAS poses sur
+          # cette PR, donc le merge-gate ne doit pas la HOLD pour ce motif.
+          if [ "$CAND_LIGHT" != "True" ]; then
+            if [ "$SIG_INFLATION" = "True" ] || [ "$SIG_RUN" = "True" ] || [ "$SIG_CAPEXC" = "True" ]; then
+              ACTIVE_LINES="${ACTIVE_LINES}
+          - **NOTE (#10341)** : la PR courante est de classe CONTENU (non LIGHT-genre) et ne contribue pas au motif ci-dessus -- les labels agregees ne sont PAS poses sur cette PR (le merge-gate ne doit pas la HOLD pour ce motif ; le coupable est parmi les grains META de la lane)."
+            fi
+          fi
 
           if [ -n "$ACTIVE_LINES" ]; then
             BODY="${MARK}

--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -620,6 +620,80 @@ def test_compute_signals_po2025_inflation_and_cap_exceeded():
     assert sig["inferred_genre_from_paths"] is None
 
 
+# --- #10341 : aggregate signals are lane-day, the label target is the candidate -
+#
+# The three aggregate signals (TIER-INFLATION, GENRE-RUN, CAP-EXCEEDED-BY-GENRE)
+# trip on the lane's MERGED set of the day. The label, however, is posed on the
+# OPEN candidate -- which may be CONTENT (genai/lean/qc/notebook-.../) and thus
+# NOT contribute to the pattern. compute_signals must keep the lane-day signals
+# TRUE (the comment surfaces the real pattern to the coordinator) AND expose
+# `candidate_is_light_genre` so the workflow can suppress the aggregate LABEL on
+# an innocent CONTENT candidate (#10341 -- the merge-gate reads the LABEL, not
+# the check state; posing it would HOLD the grain that REMEDIES the motif
+# instead of the META grains that caused it). GENRE-MISMATCH is the one signal
+# whose subject IS the candidate by construction, so it labels regardless.
+
+def test_compute_signals_candidate_is_light_genre_content_vs_meta():
+    # The OPEN candidate's contribution flag (#10341): CONTENT genres do not
+    # contribute to the LIGHT-genre pattern, META LIGHT genres do, and aliases
+    # canonicalise before the membership test. No candidate_genre -> False.
+    lane = _P_2025_C2
+    prs = [_tag_pr(1, "MED", "guard", lane=lane, at="2026-08-08T01:00:00Z")]
+    assert vlc.compute_signals(prs, lane, candidate_genre="genai")["candidate_is_light_genre"] is False
+    assert vlc.compute_signals(prs, lane, candidate_genre="qc")["candidate_is_light_genre"] is False
+    assert vlc.compute_signals(prs, lane, candidate_genre="readme")["candidate_is_light_genre"] is True
+    assert vlc.compute_signals(prs, lane, candidate_genre="docs")["candidate_is_light_genre"] is True
+    # Alias canonicalisation: lean-ci -> guard -> LIGHT-genre (#10020 alias table).
+    assert vlc.compute_signals(prs, lane, candidate_genre="lean-ci")["candidate_is_light_genre"] is True
+    # No candidate_genre at all (untagged open PR, or the lane-only call path):
+    # cannot contribute -> False.
+    assert vlc.compute_signals(prs, lane)["candidate_is_light_genre"] is False
+
+
+def test_aggregate_signals_real_but_candidate_innocent_10341():
+    # #10312 / #10341 founding case: the lane-day trips CAP-EXCEEDED-BY-GENRE,
+    # TIER-INFLATION and GENRE-RUN on META grains (6 guard + 3 docs), but the
+    # OPEN candidate is CONTENT (genai) -- it contributes to none of them.
+    lane = "myia-po-2023:CoursIA-2"
+    prs = [
+        _tag_pr(1, "MED", "guard", lane=lane, at="2026-08-10T01:00:00Z"),
+        _tag_pr(2, "MED", "guard", lane=lane, at="2026-08-10T02:00:00Z"),
+        _tag_pr(3, "MED", "guard", lane=lane, at="2026-08-10T03:00:00Z"),
+        _tag_pr(4, "MED", "guard", lane=lane, at="2026-08-10T04:00:00Z"),
+        _tag_pr(5, "MED", "guard", lane=lane, at="2026-08-10T05:00:00Z"),
+        _tag_pr(6, "MED", "guard", lane=lane, at="2026-08-10T06:00:00Z"),
+        _tag_pr(7, "MED", "docs", lane=lane, at="2026-08-10T07:00:00Z"),
+        _tag_pr(8, "MED", "docs", lane=lane, at="2026-08-10T08:00:00Z"),
+        _tag_pr(9, "MED", "docs", lane=lane, at="2026-08-10T09:00:00Z"),
+        # 10 grains total; light_genre = 9 (guard 6 + docs 3); the 10th is lean
+        # (CONTENT, META-silenced) so the cap arithmetic is explicit.
+        _tag_pr(10, "DEEP", "lean", lane=lane, at="2026-08-10T10:00:00Z"),
+    ]
+    # cap = max(1, 10 // 3) = 3; light_declared = 0 (all MED); light_genre = 9.
+    sig = vlc.compute_signals(prs, lane, candidate_genre="genai")
+    # Lane-day signals are REAL -- the lane truly exceeds, and the diagnostic
+    # comment must surface the pattern to the coordinator.
+    assert sig["signals"]["CAP-EXCEEDED-BY-GENRE"] is True    # 9 > 3
+    assert sig["signals"]["TIER-INFLATION"] is True           # 9 > 0 + 1
+    assert sig["signals"]["GENRE-RUN"] is True                # 6-guard run >= 2
+    # ...but the OPEN candidate is CONTENT and does not carry the motif.
+    assert sig["candidate_is_light_genre"] is False
+    # The workflow's suppression gate keys off this flag (see the
+    # MAY_LABEL_INNOCENT branch in variation-light-genre.yml, #10341): the
+    # aggregate LABEL is NOT posed on this PR even though the signal is True.
+
+
+def test_candidate_light_genre_true_for_guilty_meta_candidate():
+    # Non-regression: when the OPEN candidate IS itself a LIGHT-genre grain
+    # (e.g. MED/readme), candidate_is_light_genre=True -- the #10341
+    # suppression gate must NOT silence the label on a contributor. The
+    # aggregate signal is both real AND carried by this candidate.
+    lane = _P_2025_C2
+    prs = [_tag_pr(1, "MED", "guard", lane=lane, at="2026-08-10T01:00:00Z")]
+    sig = vlc.compute_signals(prs, lane, candidate_genre="readme")
+    assert sig["candidate_is_light_genre"] is True
+
+
 # --- FALSIFICATION TESTS (issue #10020 §Acceptance, #10016 model) ---------
 #
 # The detector must stay SILENT in non-monoculture cases. Two cases are

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -664,6 +664,17 @@ def compute_signals(
                                     `_genre_from_paths(candidate_files)` is
                                     not None AND the two disagree.
 
+    Three of the four signals (TIER-INFLATION, GENRE-RUN, CAP-EXCEEDED-BY-
+    GENRE) are LANE-DAY aggregates: they are True when the lane's merged
+    set of the day trips the rule, regardless of whether the OPEN
+    candidate contributes. GENRE-MISMATCH alone carries on the candidate
+    (declared genre vs its own diff paths). The return therefore also
+    exposes `candidate_is_light_genre` so the workflow can avoid posing
+    an aggregate label on a CONTENT candidate that does not contribute to
+    the pattern it denounces (#10341 -- otherwise the merge-gate, which
+    reads the LABEL, would HOLD the grain that REMEDIES the motif instead
+    of the META grains that caused it).
+
     The function returns the tally, the list of runs, and the four signals
     ON the tally/candidate -- the workflow decides what to label. The
     G-VAR-2 organ (the original `light_cap_status`) is unchanged: a PR
@@ -709,6 +720,15 @@ def compute_signals(
         "long_runs": long_runs,
         "inferred_genre_from_paths": inferred,
         "candidate_genre_canonical": can_canon,
+        # Whether the OPEN candidate is itself a LIGHT-genre grain, i.e. a
+        # CONTRIBUTOR to the pattern the three aggregate signals denounce.
+        # False when the candidate is CONTENT (genai/lean/qc/notebook-.../)
+        # or carries no readable genre -- in both cases it cannot contribute
+        # to light_genre / a genre-run / the cap numerator, so an aggregate
+        # label posed on it would misattribute a lane-day pattern to a grain
+        # that does not carry it (#10341). GENRE-MISMATCH is unaffected: it
+        # is the one signal whose subject IS the candidate by construction.
+        "candidate_is_light_genre": can_canon in LIGHT_GENRES,
     }
 
 


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/guard #10423

> Ligne `Grain:` écrite par ai-01 au merge-gate (variation-protocol §3, « re-qualifier le tag soi-même »).
> La PR était livrée sans tag, ce qui la rend **structurellement incomptable** et bloquait `Require Grain tag`.
> **Deuxième `guard` consécutif de la lane : j’autorise explicitement l’adjacence** (G-VAR-3, clause de
> substance genuinement distincte). Le litmus qui décide — « pourrais-je en générer une douzaine en
> scannant l’instance d’à-côté ? » — répond non : #10423 ajoute une règle de détection markdown, celle-ci
> corrige la **cible** d’un label agrégé ; deux défauts d’organe distincts, deux cas fondateurs distincts,
> deux tests de régression distincts. Et l’adjacence existe parce que **je** n’ai pas provisionné assez de
> CONTENU à cette lane cette nuit — le grain CSP-8 est parti en DM pour y répondre. Sanctionner ici
> porterait sur le mauvais objet.
> `tooling` serait aussi défendable que `guard` ; les deux sont de classe META et aucun organe ne
> change de verdict. Rien du corps ci-dessous n’a été modifié.

## Ce que la PR corrige (#10341)

Les trois signaux agrégés G-VAR-2/3-by-GENRE (`TIER-INFLATION`, `GENRE-RUN`, `CAP-EXCEEDED-BY-GENRE`) se déclenchent sur le **set mergé de la lane au jour UTC** — un agrégat. Mais le **label** est posé sur la **PR ouverte du moment** — qui peut être de classe **CONTENU** (`genai`/`lean`/`qc`/`notebook-...`) et donc **ne pas contribuer** au motif dénoncé.

Cas fondateur (#10312, `myia-po-2023:CoursIA-2`, 2026-08-10) : la lane porte `guard 6 + docs 3 = 9` LIGHT-genre (cap = 5), tous les signaux agrégés sont **vrais** — mais la PR étiquetée était `MED/genai`, le seul grain de la journée qui **corrigeait** le motif. Appliqué naïvement, le merge-gate (qui lit le **label**, pas l'état du check) aurait **HOLD le CONTENU** et laissé filer les neuf META coupables.

## Le correctif (piste 2 de l'issue — la plus économique)

- **`compute_signals`** retourne un nouveau champ `candidate_is_light_genre` (la PR ouverte EST elle-même un grain LIGHT-genre, i.e. une **contributrice** au motif). Les signaux lane-jour restent **TRUE** — le commentaire diagnostique continue de surfaçer le pattern réel au coordinateur ; seul le **label** est gated.
- **`variation-light-genre.yml`** supprime les trois labels agrégats sur une candidate CONTENU innocente (`MAY_LABEL_INNOCENT="no"` + `CAND_LIGHT!="True"` → `remove`, pas `add`). L'`else`-branche strippe aussi un label qu'un push antérieur aurait posé avant que la lane ne croise le cap sur des grains META (ré-éval idempotente).
- **`GENRE-MISMATCH` est exempt** (`MAY_LABEL_INNOCENT="yes"`) : son sujet EST la candidate par construction (genre déclaré vs les chemins du **propre** diff de la candidate).
- Une **ligne NOTE (#10341)** dans le commentaire diagnostique rend la suppression explicite, pour qu'un coordinateur qui lit la PR comprenne l'absence de label agrégat.

## Preuves

- **66/66 tests** passent (63 existants + 3 nouveaux) :
  - `test_compute_signals_candidate_is_light_genre_content_vs_meta` — CONTENT (`genai`/`qc`) → False, META (`readme`/`docs`) → True, alias (`lean-ci`→`guard`) → True, pas de `candidate_genre` → False.
  - `test_aggregate_signals_real_but_candidate_innocent_10341` — le scénario #10312 : lane 10 grains (6 guard + 3 docs + 1 lean), `light_genre=9`, `cap=3` → les 3 signaux agrégats True **ET** `candidate_is_light_genre=False` (precondition à la suppression workflow).
  - `test_candidate_light_genre_true_for_guilty_meta_candidate` — non-régression : une candidate `readme` (coupable) garde `candidate_is_light_genre=True` → le label **sera** posé.
- **YAML valide** (`yaml.safe_load`), **bash -n** clean sur le run block extrait (226 lignes).
- **Replay CLI** du scénario #10312 end-to-end : signaux lane-jour True + `candidate_is_light_genre=False` confirmé dans le JSON de sortie.

## Hors scope (acknowledged dans l'issue)

L'issue nomme explicitement trois pistes ; cette PR livre la **piste 2** (« ne pas poser le signal sur une PR de classe CONTENU »). Restent :
- **Pistes 1 & 3** : le cas où la PR courante est **elle-même META mais innocente** (ex. candidate `readme` alors que le run est sur `guard`). Piste 1 = nommer les grains fautifs dans le commentaire ; piste 3 = rendre le genre explicite dans le nom du label (`CAP-EXCEEDED-BY-guard+docs`). Suivi en PR-fille si le coordinateur le juge utile — le cas constaté (#10312) est fermé par celle-ci.

## Hygiène

- Single-subject (#10341), 3 fichiers, +133/-5.
- Catalogue **byte-identique** à `main` (catalog-pr-hygiene R1).
- Aucun notebook touché, aucun secret, advisory-only (exit 0 préservé).

See #10341, #10020 (organe provisionneur), #10312 (cas fondateur), #9768 (EPIC parent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

