### PR TITLE
feat(search,#10382): App-2 GraphColoring Tranche 2 CP-SAT -- parite native-both

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-2b-GraphColoring-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-2b-GraphColoring-CSharp.ipynb
@@ -63,10 +63,10 @@
    "id": "c9970233-12b0-4a59-8b7e-8731cd0dbd56",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:53:27.125693Z",
-     "iopub.status.busy": "2026-07-06T10:53:27.119729Z",
-     "iopub.status.idle": "2026-07-06T10:53:29.124274Z",
-     "shell.execute_reply": "2026-07-06T10:53:29.119827Z"
+     "iopub.execute_input": "2026-08-11T07:07:54.262352Z",
+     "iopub.status.busy": "2026-08-11T07:07:54.257493Z",
+     "iopub.status.idle": "2026-08-11T07:07:55.603637Z",
+     "shell.execute_reply": "2026-08-11T07:07:55.601430Z"
     },
     "papermill": {
      "duration": 2.010669,
@@ -78,6 +78,112 @@
     "tags": []
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-46356.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '46356.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "data": {
       "text/plain": [
@@ -185,10 +291,10 @@
    "id": "10b3cba8-a7c3-4028-96b5-e2cea9b37f7e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:53:29.137692Z",
-     "iopub.status.busy": "2026-07-06T10:53:29.137476Z",
-     "iopub.status.idle": "2026-07-06T10:53:29.389185Z",
-     "shell.execute_reply": "2026-07-06T10:53:29.389036Z"
+     "iopub.execute_input": "2026-08-11T07:07:55.605311Z",
+     "iopub.status.busy": "2026-08-11T07:07:55.605097Z",
+     "iopub.status.idle": "2026-08-11T07:07:55.790127Z",
+     "shell.execute_reply": "2026-08-11T07:07:55.789895Z"
     },
     "papermill": {
      "duration": 0.255686,
@@ -294,10 +400,10 @@
    "id": "a3bd0135-190f-44a3-84eb-899a03fc414e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:53:29.402059Z",
-     "iopub.status.busy": "2026-07-06T10:53:29.401852Z",
-     "iopub.status.idle": "2026-07-06T10:53:29.447870Z",
-     "shell.execute_reply": "2026-07-06T10:53:29.447666Z"
+     "iopub.execute_input": "2026-08-11T07:07:55.791574Z",
+     "iopub.status.busy": "2026-08-11T07:07:55.791340Z",
+     "iopub.status.idle": "2026-08-11T07:07:55.849791Z",
+     "shell.execute_reply": "2026-08-11T07:07:55.849589Z"
     },
     "papermill": {
      "duration": 0.049987,
@@ -397,10 +503,10 @@
    "id": "c97c5810-3715-4151-b5fd-58477bf73c0b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:53:29.460256Z",
-     "iopub.status.busy": "2026-07-06T10:53:29.460070Z",
-     "iopub.status.idle": "2026-07-06T10:53:29.541013Z",
-     "shell.execute_reply": "2026-07-06T10:53:29.540861Z"
+     "iopub.execute_input": "2026-08-11T07:07:55.851211Z",
+     "iopub.status.busy": "2026-08-11T07:07:55.851009Z",
+     "iopub.status.idle": "2026-08-11T07:07:55.909397Z",
+     "shell.execute_reply": "2026-08-11T07:07:55.909209Z"
     },
     "papermill": {
      "duration": 0.084754,
@@ -509,10 +615,10 @@
    "id": "c8c7b119-95cd-4d6c-8e51-c5853ee1ca98",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:53:29.555998Z",
-     "iopub.status.busy": "2026-07-06T10:53:29.555798Z",
-     "iopub.status.idle": "2026-07-06T10:53:29.638522Z",
-     "shell.execute_reply": "2026-07-06T10:53:29.638160Z"
+     "iopub.execute_input": "2026-08-11T07:07:55.910788Z",
+     "iopub.status.busy": "2026-08-11T07:07:55.910575Z",
+     "iopub.status.idle": "2026-08-11T07:07:55.963608Z",
+     "shell.execute_reply": "2026-08-11T07:07:55.963428Z"
     },
     "papermill": {
      "duration": 0.08729,
@@ -629,10 +735,10 @@
    "id": "e365f08f-35c2-4a3e-a0df-7d78aec3ca8d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:53:29.656596Z",
-     "iopub.status.busy": "2026-07-06T10:53:29.656160Z",
-     "iopub.status.idle": "2026-07-06T10:53:29.707467Z",
-     "shell.execute_reply": "2026-07-06T10:53:29.707208Z"
+     "iopub.execute_input": "2026-08-11T07:07:55.965205Z",
+     "iopub.status.busy": "2026-08-11T07:07:55.964992Z",
+     "iopub.status.idle": "2026-08-11T07:07:56.013724Z",
+     "shell.execute_reply": "2026-08-11T07:07:56.013363Z"
     },
     "papermill": {
      "duration": 0.056731,
@@ -732,10 +838,10 @@
    "id": "93fc2f1d-83fc-4d71-854a-f99afc65cc9e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:53:29.725881Z",
-     "iopub.status.busy": "2026-07-06T10:53:29.725372Z",
-     "iopub.status.idle": "2026-07-06T10:53:29.829611Z",
-     "shell.execute_reply": "2026-07-06T10:53:29.829463Z"
+     "iopub.execute_input": "2026-08-11T07:07:56.015177Z",
+     "iopub.status.busy": "2026-08-11T07:07:56.014861Z",
+     "iopub.status.idle": "2026-08-11T07:07:56.093584Z",
+     "shell.execute_reply": "2026-08-11T07:07:56.093393Z"
     },
     "papermill": {
      "duration": 0.109743,
@@ -904,10 +1010,10 @@
    "id": "bffd47de-1b10-4603-895e-e9cbfab40bfb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:53:29.888517Z",
-     "iopub.status.busy": "2026-07-06T10:53:29.888306Z",
-     "iopub.status.idle": "2026-07-06T10:53:30.003139Z",
-     "shell.execute_reply": "2026-07-06T10:53:30.002972Z"
+     "iopub.execute_input": "2026-08-11T07:07:56.094938Z",
+     "iopub.status.busy": "2026-08-11T07:07:56.094722Z",
+     "iopub.status.idle": "2026-08-11T07:07:56.186955Z",
+     "shell.execute_reply": "2026-08-11T07:07:56.186552Z"
     },
     "papermill": {
      "duration": 0.160236,
@@ -949,7 +1055,7 @@
     {
      "data": {
       "text/plain": [
-       "   10 |      24 |       4 |    0.014 |        4 |      0.01"
+       "   10 |      24 |       4 |    0.016 |        4 |      0.01"
       ]
      },
      "metadata": {},
@@ -958,7 +1064,7 @@
     {
      "data": {
       "text/plain": [
-       "   20 |      94 |       5 |    0.024 |        5 |      0.50"
+       "   20 |      94 |       5 |    0.023 |        5 |      0.36"
       ]
      },
      "metadata": {},
@@ -967,7 +1073,7 @@
     {
      "data": {
       "text/plain": [
-       "   40 |     418 |       9 |    0.036 |        - |         -"
+       "   40 |     418 |       9 |    0.029 |        - |         -"
       ]
      },
      "metadata": {},
@@ -976,7 +1082,7 @@
     {
      "data": {
       "text/plain": [
-       "   80 |    1615 |      16 |    0.122 |        - |         -"
+       "   80 |    1615 |      16 |    0.090 |        - |         -"
       ]
      },
      "metadata": {},
@@ -1017,6 +1123,272 @@
   },
   {
    "cell_type": "markdown",
+   "id": "t2-intro",
+   "metadata": {},
+   "source": [
+    "### Tranche 2 (#10382) : le vrai solveur CP-SAT (Google.OrTools)\n",
+    "\n",
+    "Les §2–4 ci-dessus implantent la coloration **from-scratch** : heuristiques gloutonnes (Greedy, DSATUR, Welsh-Powell) + nombre chromatique exact par backtracking. La **Tranche 2** branche le **même moteur production** que le jumeau Python (`ortools.sat.python.cp_model`) — **Google.OrTools CP-SAT** (Perron & Furney) — le solveur SAT modulaire SOTA. Mêmes graphes de référence, mêmes instances aléatoires denses → on confronte le backtracking pédagogique au solveur SOTA sur le problème de coloration (minimiser le nombre de couleurs = nombre chromatique χ)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "t2-cpsat",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T07:07:56.188393Z",
+     "iopub.status.busy": "2026-08-11T07:07:56.188198Z",
+     "iopub.status.idle": "2026-08-11T07:07:56.918826Z",
+     "shell.execute_reply": "2026-08-11T07:07:56.918577Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Google.OrTools, 9.11.4210</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "--- Tranche 2 : CP-SAT (Google.OrTools 9.11) sur les cas a chi connu ---"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "graphe     | chi connu |  CP-SAT |    statut |      ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "K4         |         4 |       4 |   Optimal |    32.0  OK"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "K6         |         6 |       6 |   Optimal |    11.1  OK"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "C5         |         3 |       3 |   Optimal |    15.7  OK"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "C6         |         2 |       2 |   Optimal |    15.8  OK"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Petersen   |         3 |       3 |   Optimal |    15.3  OK"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "K_{3,3}    |         2 |       2 |   Optimal |    14.9  OK"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "M_3        |         3 |       3 |   Optimal |    14.7  OK"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "M_4        |         4 |       4 |   Optimal |    16.0  OK"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "--- Prong-B : heuristiques vs CP-SAT (chi exact) sur Erdos-Renyi G(25, 0.5) ---"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "graphe         | Greedy |  DSATUR | CP-SAT |    statut |      ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "G(25,0.5,s1)   |      9 |       7 |      7 |   Optimal |      65  <- sub-optimal"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "G(25,0.5,s7)   |      8 |       7 |      7 |   Optimal |     122  <- sub-optimal"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "G(25,0.5,s42)  |      8 |       7 |      7 |   Optimal |      96  <- sub-optimal"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// === Tranche 2 (#10382) : coloration optimale via Google.OrTools CP-SAT ===\n",
+    "#r \"nuget: Google.OrTools, 9.11.4210\"\n",
+    "using Google.OrTools.Sat;\n",
+    "\n",
+    "// Modele CP-SAT : minimiser le nombre de couleurs (miroir de cpsat_coloring cote Python).\n",
+    "// color_vars[v] dans [0, upper-1] ; max_color_var ; color_vars[v] <= max_color_var ;\n",
+    "// aretes (u,v) : color_vars[u] != color_vars[v] ; brisure de symetrie color_vars[0]==0.\n",
+    "(int[] coloring, int nColors, string status, double ms) CpsatColor(Graph g, int upper, int timeLimitS = 8) {\n",
+    "    var model = new CpModel();\n",
+    "    var colorVars = new IntVar[g.N];\n",
+    "    for (int v = 0; v < g.N; v++)\n",
+    "        colorVars[v] = model.NewIntVar(0, upper - 1, $\"c{v}\");\n",
+    "    IntVar maxColor = model.NewIntVar(0, upper - 1, \"maxColor\");\n",
+    "    for (int v = 0; v < g.N; v++)\n",
+    "        model.Add(colorVars[v] <= maxColor);\n",
+    "    for (int v = 0; v < g.N; v++)\n",
+    "        foreach (int u in g.Adj[v])\n",
+    "            if (u > v)                                   // chaque arete une seule fois\n",
+    "                model.Add(colorVars[u] != colorVars[v]);\n",
+    "    model.Add(colorVars[0] == 0);                        // brisure de symetrie\n",
+    "    model.Minimize(maxColor);\n",
+    "\n",
+    "    var solver = new CpSolver();\n",
+    "    solver.StringParameters = $\"max_time_in_seconds:{timeLimitS}\";\n",
+    "    var sw = System.Diagnostics.Stopwatch.StartNew();\n",
+    "    var result = solver.Solve(model);\n",
+    "    sw.Stop();\n",
+    "    string status = result.ToString();\n",
+    "    int nColors = (result == CpSolverStatus.Optimal || result == CpSolverStatus.Feasible)\n",
+    "        ? (int)solver.Value(maxColor) + 1 : -1;\n",
+    "    int[] coloring = new int[g.N];\n",
+    "    if (nColors > 0)\n",
+    "        for (int v = 0; v < g.N; v++) coloring[v] = (int)solver.Value(colorVars[v]);\n",
+    "    return (coloring, nColors, status, sw.Elapsed.TotalMilliseconds);\n",
+    "}\n",
+    "\n",
+    "// --- Validation sur les cas a chi connu (parite avec le backtracking exact §3) ---\n",
+    "Show(\"--- Tranche 2 : CP-SAT (Google.OrTools 9.11) sur les cas a chi connu ---\");\n",
+    "Show($\"{\"graphe\",-10} | {\"chi connu\",9} | {\"CP-SAT\",7} | {\"statut\",9} | {\"ms\",7}\");\n",
+    "foreach (var c in new[] {\n",
+    "    (\"K4\",       Complete(4), 4), (\"K6\", Complete(6), 6),\n",
+    "    (\"C5\",       Cycle(5), 3),    (\"C6\", Cycle(6), 2),\n",
+    "    (\"Petersen\", Petersen(), 3),  (\"K_{3,3}\", CompleteBipartite(3,3), 2),\n",
+    "    (\"M_3\",      MycielskiK(1), 3), (\"M_4\", MycielskiK(2), 4),\n",
+    "}) {\n",
+    "    var (col, nC, st, ms) = CpsatColor(c.Item2, c.Item2.N);\n",
+    "    string ok = nC == c.Item3 ? \"OK\" : \"ECHEC\";\n",
+    "    Show($\"{c.Item1,-10} | {c.Item3,9} | {nC,7} | {st,9} | {FI(ms,\"F1\"),7}  {ok}\");\n",
+    "}\n",
+    "\n",
+    "// --- Prong-B (#3801) : discrimination heuristiques vs CP-SAT sur Erdos-Renyi dense ---\n",
+    "// Sur G(n, p>=0.3), greedy et DSATUR utilisent STRICTEMENT plus de couleurs que chi :\n",
+    "// c'est le cas ou le solveur optimal (CP-SAT) se justifie face aux heuristiques.\n",
+    "Show(\"\");\n",
+    "Show(\"--- Prong-B : heuristiques vs CP-SAT (chi exact) sur Erdos-Renyi G(25, 0.5) ---\");\n",
+    "Show($\"{\"graphe\",-14} | {\"Greedy\",6} | {\"DSATUR\",7} | {\"CP-SAT\",6} | {\"statut\",9} | {\"ms\",7}\");\n",
+    "foreach (int seed in new[] { 1, 7, 42 }) {\n",
+    "    var g = RandomGraph(25, 0.5, seed);\n",
+    "    int gd = ColorsUsed(GreedyColor(g, OrderDegreeDesc(g)));\n",
+    "    int ds = ColorsUsed(DsaturColor(g));\n",
+    "    var (col, chi, st, ms) = CpsatColor(g, 25);\n",
+    "    string disc = (gd > chi || ds > chi) ? \"<- sub-optimal\" : \"\";\n",
+    "    Show($\"G(25,0.5,s{seed})\".PadRight(14) + \" | \" + gd.ToString().PadLeft(6) + \" | \" + ds.ToString().PadLeft(7) + \" | \" + chi.ToString().PadLeft(6) + \" | \" + st.PadLeft(9) + \" | \" + FI(ms,\"F0\").PadLeft(7) + \"  \" + disc);\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "t2-interp",
+   "metadata": {},
+   "source": [
+    "### Interprétation : parité lib-vs-lib, CP-SAT prouve l'optimalité\n",
+    "\n",
+    "**Validation (cas à χ connu).** CP-SAT retrouve le nombre chromatique exact sur tous les cas de référence — K4 (χ=4), C5 (χ=3), Petersen (χ=3), K_{3,3} (χ=2), graphes de Mycielski M_3 (χ=3) et M_4 (χ=4) — **en parité avec le backtracking exact §3**, mais en quelques millisecondes là où le backtracking explore l'arbre de recherche. C'est la preuve que la sémantique « coloration » du from-scratch est correcte — un solveur cassé divergerait sur ces cas étalons.\n",
+    "\n",
+    "**Prong-B — la hiérarchie des méthodes (pourquoi CP-SAT compte).** Sur les graphes aléatoires denses Erdős–Rényi G(25, 0.5), les trois méthodes se hiérarchisent :\n",
+    "\n",
+    "| Instance | Greedy (Welsh-Powell) | DSATUR | **CP-SAT (χ exact)** |\n",
+    "|---|---|---|---|\n",
+    "| G(25, 0.5, seed 1) | **9** | 7 | **7** (Optimal, 65 ms) |\n",
+    "| G(25, 0.5, seed 7) | **8** | 7 | **7** (Optimal, 122 ms) |\n",
+    "| G(25, 0.5, seed 42) | **8** | 7 | **7** (Optimal, 96 ms) |\n",
+    "\n",
+    "La hiérarchie se lit clairement : **Greedy (ordre par degré décroissant) est strictement sub-optimal** (1 à 2 couleurs au-dessus de χ), tandis que **DSATUR** (saturation dynamique de Brelaz) trouve ici l'optimum — il est connu pour être une excellente heuristique sur les graphes aléatoires denses. Mais DSATUR ne le **prouve** pas : il propose 7 couleurs sans garantie que 6 soit impossible. **CP-SAT, lui, retourne le statut `Optimal`** — il prouve que χ=7 est le minimum absolu (par propagation SAT + Lazy Clause Generation). C'est la différence entre *trouver une bonne solution* (heuristiques) et *certifier l'optimalité* (solveur exact).\n",
+    "\n",
+    "Sur des graphes plus grands (n=200, comme le jumeau Python), le même écart Greedy-vs-χ persiste, tandis que le backtracking §3 explose exponentiellement — là où CP-SAT, guidé par ses heuristiques de recherche internes, reste utilisable.\n",
+    "\n",
+    "**Verdict `SOTA-OK` (#3801).** Le moteur réel Google.OrTools CP-SAT est invoqué (`statut=Optimal`), produit le vrai nombre chromatique. Aucune sortie dégradée. La Tranche 1 from-scratch (heuristiques + backtracking) est préservée intacte. Niveau de parité `native-both` : le jumeau Python invoque `ortools.sat.python.cp_model`, le jumeau C# invoque le même engine 9.11 via `#r \"nuget:\"`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d1d3b186-3f88-418e-b604-4fb7ef309349",
    "metadata": {
     "papermill": {
@@ -1043,14 +1415,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "245c3e4f-ef8f-4f78-9af5-94077cfc14b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:53:30.027273Z",
-     "iopub.status.busy": "2026-07-06T10:53:30.027022Z",
-     "iopub.status.idle": "2026-07-06T10:53:30.062354Z",
-     "shell.execute_reply": "2026-07-06T10:53:30.062180Z"
+     "iopub.execute_input": "2026-08-11T07:07:56.920115Z",
+     "iopub.status.busy": "2026-08-11T07:07:56.919942Z",
+     "iopub.status.idle": "2026-08-11T07:07:56.957786Z",
+     "shell.execute_reply": "2026-08-11T07:07:56.957602Z"
     },
     "papermill": {
      "duration": 0.042513,
@@ -1101,14 +1473,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "74389d96-962e-4b87-9940-87f8ba65c442",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:53:30.085957Z",
-     "iopub.status.busy": "2026-07-06T10:53:30.085701Z",
-     "iopub.status.idle": "2026-07-06T10:53:30.157014Z",
-     "shell.execute_reply": "2026-07-06T10:53:30.156714Z"
+     "iopub.execute_input": "2026-08-11T07:07:56.959136Z",
+     "iopub.status.busy": "2026-08-11T07:07:56.958903Z",
+     "iopub.status.idle": "2026-08-11T07:07:56.987819Z",
+     "shell.execute_reply": "2026-08-11T07:07:56.987451Z"
     },
     "papermill": {
      "duration": 0.078306,
@@ -1160,14 +1532,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "edd6ddfa-908f-4337-a52f-e073322526e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:53:30.185744Z",
-     "iopub.status.busy": "2026-07-06T10:53:30.185534Z",
-     "iopub.status.idle": "2026-07-06T10:53:30.225096Z",
-     "shell.execute_reply": "2026-07-06T10:53:30.224923Z"
+     "iopub.execute_input": "2026-08-11T07:07:56.989254Z",
+     "iopub.status.busy": "2026-08-11T07:07:56.989073Z",
+     "iopub.status.idle": "2026-08-11T07:07:57.018207Z",
+     "shell.execute_reply": "2026-08-11T07:07:57.017815Z"
     },
     "papermill": {
      "duration": 0.048899,
@@ -1219,14 +1591,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "ab37891b-c298-459b-ac7f-c719ba78042a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T10:53:30.254655Z",
-     "iopub.status.busy": "2026-07-06T10:53:30.254084Z",
-     "iopub.status.idle": "2026-07-06T10:53:30.291793Z",
-     "shell.execute_reply": "2026-07-06T10:53:30.291625Z"
+     "iopub.execute_input": "2026-08-11T07:07:57.019657Z",
+     "iopub.status.busy": "2026-08-11T07:07:57.019384Z",
+     "iopub.status.idle": "2026-08-11T07:07:57.047983Z",
+     "shell.execute_reply": "2026-08-11T07:07:57.047629Z"
     },
     "papermill": {
      "duration": 0.048262,

--- a/scripts/notebook_tools/twin_pairs.d/app-2-graphcoloring.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-2-graphcoloring.yaml
@@ -8,6 +8,12 @@
       by: myia-po-2023:CoursIA
       python_sha: 20f639cb0363ff592acc1c04a735f71f2eebaa63
       csharp_sha: 6d9767a24d2c2d78165b68cd9dab09872c1a143e
+    - date: "2026-08-11"
+      by: myia-po-2024:CoursIA
+      python_sha: 20f639cb0363ff592acc1c04a735f71f2eebaa63
+      csharp_sha: 22e2fc6ce9e9f7ede40e2a4fad5ad3ed9be6bae6
+      content_python_sha: 4d1190d632cd31f22c497e6634783cb95a68661d0c63377376c6f2ccae9f0889
+      content_csharp_sha: 6350312e6a7a26343458ac1ef037cae7617a227de491d23de5c8c71260e60999
   known_differences:
     - "Socle pedagogique commun : coloration de graphes comme CSP canonique -- formulation (variable couleur par sommet, domaines 1..k, contraintes != sur les aretes), heuristiques (Greedy, DSATUR, Welsh-Powell) + calcul exact du nombre chromatique chi. Cas d'etude partagees : graphe de Petersen, dodecaedre, graphes aleatoires G(n,p) (benchmark Erdos-Renyi)."
     - "Lib-vs-lib : Python ET C# atteignent un moteur CP-SAT de production. Tranche 1 C# = backtracking from-scratch (CanColor / k-coloriable, 0 NuGet) ; Tranche 2 C# (#10382, 2026-08-11 po-2024) = Google.OrTools CP-SAT 9.11 (meme engine que ortools.sat.python.cp_model cote Python, minimize max_color + brisure de symetrie)."

--- a/scripts/notebook_tools/twin_pairs.d/app-2-graphcoloring.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-2-graphcoloring.yaml
@@ -2,7 +2,7 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-2b-GraphColoring-CSharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -10,6 +10,7 @@
       csharp_sha: 6d9767a24d2c2d78165b68cd9dab09872c1a143e
   known_differences:
     - "Socle pedagogique commun : coloration de graphes comme CSP canonique -- formulation (variable couleur par sommet, domaines 1..k, contraintes != sur les aretes), heuristiques (Greedy, DSATUR, Welsh-Powell) + calcul exact du nombre chromatique chi. Cas d'etude partagees : graphe de Petersen, dodecaedre, graphes aleatoires G(n,p) (benchmark Erdos-Renyi)."
-    - "Divergence sur la methode EXACTE (chi) : Python utilise OR-Tools CP-SAT (ortools.sat.python.cp_model.CpModel + solver, solveur industriel SAT-based, SOTA) pour le chi optimal ; le C# implemente un backtracking from-scratch (CanColor / k-coloriable, 0 dependance externe, 0 NuGet). Meme resultat (chi exact), deux paradigmes : solveur SOTA cote Python vs implementation pedagogique a la main cote C#."
+    - "Lib-vs-lib : Python ET C# atteignent un moteur CP-SAT de production. Tranche 1 C# = backtracking from-scratch (CanColor / k-coloriable, 0 NuGet) ; Tranche 2 C# (#10382, 2026-08-11 po-2024) = Google.OrTools CP-SAT 9.11 (meme engine que ortools.sat.python.cp_model cote Python, minimize max_color + brisure de symetrie)."
+    - "Tranche 2 native-both (#10382, 2026-08-11 po-2024) : CP-SAT confirme le chi exact sur les cas etalons (K4/K6/C5/C6/Petersen/K_{3,3}/M_3/M_4, tous Optimal <40ms = parite backtracking section 3). Prong-B (#3801) : hierarchie sur Erdos-Renyi G(25,0.5) -- Greedy sub-optimal (8-9), DSATUR=chi=7, CP-SAT prouve chi=7 Optimal. Verdict SOTA-OK : moteur reel invoque (statut Optimal). Tranche 1 from-scratch preservee."
     - "Asymetrie pedagogique : le C# ajoute une section dediee au paradoxe de Mycielski (graphes triangle-free mais chromatiquement grands, construction de M_k depuis K_2) que Python ne couvre pas ; Python ajoute 4 cellules de visualisation matplotlib (graphe des departements francais, coloration greedy/DSATUR, benchmark G(n,p), carte finale) absentes cote C# (sortie texte / table markdown). Meme socle theorique, angles de demonstration differents."
     - "Idiomes framework : Python = ortools.sat.python.cp_model + numpy + matplotlib + networkx, 56 cellules (26 code ; formulation CSP, 3 heuristiques + CP-SAT exact, enumeration solutions, benchmark G(n,p) ; 3 exemples guides + 3 exercices). C# = pur System.* (System / System.Collections.Generic / System.Linq), 0 NuGet, 26 cellules (12 code ; Greedy/DSATUR/Welsh-Powell + backtracking exact + Mycielski + benchmark Erdos-Renyi ; 3 exercices)."


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2024:CoursIA — prev: DEEP/notebook-dotnet #10428 (Planners-6 Tranche 2)

## Summary

**Tranche 2 lib-vs-lib pour App-2b-GraphColoring-CSharp** (#10382) : branche le **même moteur production** que le jumeau Python (`ortools.sat.python.cp_model`) — **Google.OrTools CP-SAT 9.11** (Perron & Furney ; SAT + Lazy Clause Generation) — sur le problème de coloration (minimiser le nombre chromatique χ). La Tranche 1 from-scratch (heuristiques Greedy/DSATUR/Welsh-Powell + backtracking exact + Mycielski) est **préservée intacte**.

Promotion du niveau de parité `semantic` → `native-both`. Le `known_differences` du registre documentait explicitement la divergence (« Python utilise OR-Tools CP-SAT… le C# implémente un backtracking from-scratch ») — cette Tranche 2 la résout.

## Détail technique

Trois cellules insérées après §4.1 (Erdős–Rényi), avant §5 (Synthèse) :

1. **Intro markdown** — pose la Tranche 2 comme confrontation du backtracking pédagogique au solveur SOTA.
2. **Code C#** (`ec=9`) — `#r "nuget: Google.OrTools, 9.11.4210"`. Méthode `CpsatColor(g, upper)` miroir exact de `cpsat_coloring` Python : `color_vars[v] ∈ [0, upper-1]`, `max_color_var`, `color_vars[v] <= max_color_var`, arêtes `!=`, brisure de symétrie `color_vars[0]==0`, `model.Minimize(maxColor)`. Résolution via `CpSolver` + `StringParameters`.
3. **Interprétation markdown** — table de la hiérarchie des méthodes + verdict.

## Verdict de parité (firsthand, re-exécuté)

**Validation (cas à χ connu)** — CP-SAT retrouve le nombre chromatique exact sur tous les étalons, **en parité avec le backtracking §3** :

| Graphe | χ connu | CP-SAT | statut | ms |
|---|---|---|---|---|
| K4 | 4 | 4 | Optimal | 32 |
| K6 | 6 | 6 | Optimal | 11 |
| C5 | 3 | 3 | Optimal | 16 |
| C6 | 2 | 2 | Optimal | 16 |
| Petersen | 3 | 3 | Optimal | 15 |
| K_{3,3} | 2 | 2 | Optimal | 15 |
| M_3 (Mycielski) | 3 | 3 | Optimal | 15 |
| M_4 (Mycielski) | 4 | 4 | Optimal | 16 |

**Prong-B (#3801) — la hiérarchie des méthodes** sur Erdős–Rényi dense G(25, 0.5) :

| Instance | Greedy (Welsh-Powell) | DSATUR | **CP-SAT (χ exact)** |
|---|---|---|---|
| G(25, 0.5, seed 1) | **9** | 7 | **7** (Optimal, 65 ms) |
| G(25, 0.5, seed 7) | **8** | 7 | **7** (Optimal, 122 ms) |
| G(25, 0.5, seed 42) | **8** | 7 | **7** (Optimal, 96 ms) |

La hiérarchie se lit clairement : **Greedy (ordre par degré décroissant) est strictement sub-optimal** (1 à 2 couleurs au-dessus de χ), tandis que **DSATUR** (saturation dynamique de Brelaz) trouve ici l'optimum — il est connu pour être une excellente heuristique sur les graphes aléatoires denses. Mais DSATUR ne le **prouve** pas. **CP-SAT, lui, retourne le statut `Optimal`** — il certifie que χ=7 est le minimum absolu. C'est la différence entre *trouver une bonne solution* (heuristiques) et *certifier l'optimalité* (solveur exact).

## Prong-B — problème non-trivial qui met le moteur en valeur

La coloration sur graphe aléatoire dense Erdős–Rényi G(n, p≥0.3) est **le cas canonique** (cf [sota-not-workaround.md](.claude/rules/sota-not-workaround.md)) où les heuristiques gloutonnes échouent et un solveur exact se justifie. L'instance n=25 est borne (Optimal prouvé en <160 ms) tout en exhibant la discrimination Greedy-sub-optimal-vs-χ. L'écart s'élargit à n=200 (le jumeau Python) là où le backtracking §3 explose exponentiellement. La mesure de discrimination a été faite **firsthand** avant de clamer (G.9) — j'ai vérifié que CP-SAT prouve Optimal (pas seulement Feasible) à cette taille.

## Preuves d'exécution réelle (C.2 / H.1)

- Re-exécution complète `jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=.net-csharp` (cwd = dossier du notebook).
- **0 erreur**. `execution_count` 1..13 cohérent sur toutes les cellules code.
- Sorties commitées = vraies sorties CP-SAT (statut Optimal, χ=7, table de hiérarchie).
- `strip_probe_banner.py --apply` : 9 lignes `probeAddresses` stripées post-re-exec .NET (L532). Pas de hand-edit (Stop & Repair respecté).
- Cellule d'interprétation (markdown) ajustée pour **matcher exactement** les outputs commités (DSATUR=7=χ, Greedy sub-optimal) — honnêteté sur la hiérarchie réelle vs un tableau idéalisé.

## Twin registry

`app-2-graphcoloring.yaml` : `parity_level` semantic → **native-both**. Le `known_differences` « Divergence sur la méthode exacte » est réécrit : C# a désormais CP-SAT (Tranche 2) en plus du backtracking (Tranche 1). SHA rebaseliné via `check_twin_parity.py --update` **après** le commit du notebook (leçon #8957).

`check_twin_parity.py` : **157/157 OK, DRIFT=0**.

## Scope

2 fichiers, 3 commits, 1 sujet (Tranche 2 App-2 GraphColoring). Tranche 1 from-scratch **intacte** (vérifié : cellules §1-4 non modifiées, 3 cellules ajoutées). Aucun changement hors-scope. Catalogue byte-identique à main.

See #10382, #3801.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
