### PR TITLE
fix(twin-parity,#10430): recognize indent-4 audits header + loud-fail on missing header

### DIFF
--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -913,15 +913,33 @@ def surgical_rebaseline(raw: str, updates: dict[str, dict], force: bool = False)
             i += 1
             continue
 
-        m_hdr = re.match(r"^\s{2}(last_audit|audits):\s*$", line)
+        # Quantificateur \s{2,} (pas \s{2} exact) + coupure RELATIVE a
+        # l'indentation de la cle (#10430) : un fichier a indentation native 4
+        # (ex. app-10-portfolio.yaml, `audits:` a 4 espaces) voyait son en-tete
+        # reste invisible avec \s{2} exact -> surgical_rebaseline renvoyait
+        # touched=0 SANS erreur (header introuvable = no-op silencieux).
+        m_hdr = re.match(r"^(\s{2,})(last_audit|audits):\s*$", line)
         if m_hdr and current in updates:
-            form = m_hdr.group(1)
-            # Corps du bloc = lignes suivantes indentees a 4+ espaces.
+            hdr_indent = len(m_hdr.group(1))
+            form = m_hdr.group(2)
+            # Corps du bloc : coupure RELATIVE (pas le seuil absolu \s{4,}
+            # d'avant, qui etrangle la cle sibling `known_differences:` quand
+            # `audits:` est a indent 4). Continuation = strictement plus indent
+            # que la cle, OU un item de sequence `-` a indent >= cle (YAML
+            # autorise un block sequence a la meme indent que sa cle parent).
             block = [line]
             j = i + 1
-            while j < n and re.match(r"^\s{4,}\S", lines[j]):
-                block.append(lines[j])
-                j += 1
+            while j < n:
+                nxt = lines[j]
+                if not nxt.strip():
+                    break
+                lead = len(nxt) - len(nxt.lstrip(" "))
+                is_seq = nxt.lstrip(" ").startswith("-")
+                if lead > hdr_indent or (is_seq and lead >= hdr_indent):
+                    block.append(nxt)
+                    j += 1
+                else:
+                    break
             new_block, did = _transform_audit_block(form, block, updates[current], force=force)
             if did:
                 touched.add(current)
@@ -1265,6 +1283,7 @@ def main(argv=None) -> int:
         # commentaires + casserait le quoting `date: "..."` -> datetime.date.)
         if reg_path.is_dir():
             written = 0
+            missing_header = []
             for name, audit in updates.items():
                 pfile = _pair_file(reg_path, name)
                 if not pfile.exists():
@@ -1272,16 +1291,43 @@ def main(argv=None) -> int:
                           f"(attendu : {pfile.name}).", file=sys.stderr)
                     continue
                 raw = pfile.read_text(encoding="utf-8")
-                new_raw, _ = surgical_rebaseline(raw, {name: audit}, force=args.force)
+                # On capture `touched` (#10430) : avant, le compteur etait jete
+                # (`_`) et « header introuvable » (indent non reconnue, paire
+                # absente du fichier) produisait exactement la meme sortie qu'un
+                # no-op legit (« SHAs deja a jour ») -- un organe d'attestation
+                # qui echoue en silence. Les paires no-op legit sont deja
+                # filtree en amont (branche `no_op`/`forced_no_op`), donc
+                # touched==0 ici signifie reellement « header non reconnu ».
+                new_raw, touched = surgical_rebaseline(raw, {name: audit}, force=args.force)
+                if touched == 0:
+                    missing_header.append(name)
+                    continue
                 if new_raw != raw:
                     write_registry_text(pfile, new_raw)
                     written += 1
             updated = written
+            if missing_header:
+                print(
+                    f"AVERTISSEMENT : {len(missing_header)} paire(s) a rebaseliner "
+                    f"MAIS aucun bloc d'audit reconnu (audits:/last_audit: "
+                    f"introuvable ou indentation non reconnue) dans leur fichier "
+                    f"-- rebaseline IGNORE. Ce N'est PAS un no-op legit (les "
+                    f"SHAs different). Verifier l'indentation du fichier : "
+                    f"{', '.join(missing_header)}",
+                    file=sys.stderr,
+                )
         else:
             # mono-fichier legacy (--registry <file.yaml>)
             raw = reg_path.read_text(encoding="utf-8")
             new_raw, updated = surgical_rebaseline(raw, updates, force=args.force)
             write_registry_text(reg_path, new_raw)
+            if updated < len(updates):
+                print(
+                    f"AVERTISSEMENT : {len(updates) - updated} paire(s) a "
+                    f"rebaseliner sans bloc d'audit reconnu dans {reg_path.name} "
+                    f"-- rebaseline IGNORE pour elles (header introuvable).",
+                    file=sys.stderr,
+                )
         if skipped:
             print(
                 f"Ignorees (notebook absent de git) : {', '.join(skipped)}",

--- a/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
@@ -454,3 +454,104 @@ def test_append_only_noop_does_not_grow_list():
     out, touched = ctp.surgical_rebaseline(raw, {"Paire-N": same})
     assert touched == 0
     assert out == raw, "un no-op sur la forme append-only doit etre byte-identique"
+
+
+# --- #10430 : indentation native 4 (audits: a indent 4) + coupure relative ---
+
+_INDENT4_RAW = (
+    "-   name: Indent4Pair\n"
+    "    family: Test\n"
+    "    python: a.ipynb\n"
+    "    csharp: b.ipynb\n"
+    "    parity_level: semantic\n"
+    "    audits:\n"
+    "    -   date: '2020-01-01'\n"
+    "        by: old-auditor\n"
+    "        python_sha: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+    "        csharp_sha: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+    "    known_differences:\n"
+    "    - 'note sibling qui ne doit pas etre avalee par le bloc audit'\n"
+)
+
+
+def test_indent4_audits_header_now_recognized_10430():
+    """Bug fondateur #10430 : `audits:` indent 4 etait invisible au regex \\s{2}.
+
+    Avant le fix, surgical_rebaseline renvoyait touched=0 (header non reconnu)
+    => no-op silencieux. Apres : le bloc est trouve, un SHA change declenche
+    l'append, touched=1.
+    """
+    new = {"date": "2026-08-11", "by": "test-lane",
+           "python_sha": "c" * 40,
+           "csharp_sha": "b" * 40}  # csharp inchange, python change -> drift
+    out, touched = ctp.surgical_rebaseline(_INDENT4_RAW, {"Indent4Pair": new})
+    assert touched == 1, "audits: a indent 4 doit desormais etre reconnu (#10430)"
+    # Append-only : le vieil enregistrement survive + un nouveau est ajoute.
+    assert out.count("-   date:") + out.count("- date:") >= 2
+
+
+def test_indent4_sibling_known_differences_not_consumed_10430():
+    """La coupure doit etre RELATIVE a l'indent de la cle, pas un seuil absolu.
+
+    Avec l'ancien `\\s{4,}\\S` pour les continuations, autoriser `audits:` a
+    indent 4 aurait etrangle la cle sibling `known_differences:` (aussi a
+    indent 4) dans le bloc audit -> faux drift + perte de la section. Le fix
+    coupe au premier non-item non-plus-indent-que-la-cle.
+    """
+    new = {"date": "2026-08-11", "by": "test-lane",
+           "python_sha": "c" * 40, "csharp_sha": "b" * 40}
+    out, touched = ctp.surgical_rebaseline(_INDENT4_RAW, {"Indent4Pair": new})
+    assert touched == 1
+    assert "known_differences:" in out, "la cle sibling doit survivre"
+    assert "note sibling qui ne doit pas etre avalee" in out, (
+        "le contenu de known_differences ne doit pas etre corrompu"
+    )
+
+
+def test_indent2_regression_normal_style_still_works():
+    """Regression : le style indent-2 (156 fichiers, la norme) reste reconnu.
+
+    Le passage a \\s{2,} + coupure relative ne doit pas casser la majorite des
+    registres. On verifie aussi qu'un sibling indent-2 (known_differences)
+    n'est pas consume dans ce format la non plus.
+    """
+    raw = (
+        "- name: Indent2Pair\n"
+        "  family: Test\n"
+        "  python: a.ipynb\n"
+        "  csharp: b.ipynb\n"
+        "  audits:\n"
+        "    - date: '2020-01-01'\n"
+        "      by: old-auditor\n"
+        "      python_sha: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        "      csharp_sha: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+        "  known_differences:\n"
+        "    - 'sibling indent-2'\n"
+    )
+    new = {"date": "2026-08-11", "by": "test-lane",
+           "python_sha": "c" * 40, "csharp_sha": "b" * 40}
+    out, touched = ctp.surgical_rebaseline(raw, {"Indent2Pair": new})
+    assert touched == 1
+    assert "known_differences:" in out
+    assert "sibling indent-2" in out
+
+
+def test_touched_zero_when_header_genuinely_absent():
+    """Contrat dont depend la garde loud-failure (#10430) du chemin multi-fichiers.
+
+    Quand une paire n'a AUCUN bloc audit (ni audits:, ni last_audit:),
+    surgical_rebaseline renvoie touched=0. Le chemin CLI multi-fichiers
+    distinguait avant ce cas d'un no-op legit uniquement par cette valeur ;
+    on verifie le contrat unitairement.
+    """
+    raw = (
+        "- name: NoAuditPair\n"
+        "  family: Test\n"
+        "  python: a.ipynb\n"
+        "  csharp: b.ipynb\n"
+    )
+    new = {"date": "2026-08-11", "by": "test-lane",
+           "python_sha": "c" * 40, "csharp_sha": "b" * 40}
+    out, touched = ctp.surgical_rebaseline(raw, {"NoAuditPair": new})
+    assert touched == 0
+    assert out == raw, "aucun header => byte-identique (la CLI le signale en AVERTISSEMENT)"


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/guard #10429

## Ce que la PR corrige (#10430)

Deux défauts dans le chemin de rebaseline chirurgical de `check_twin_parity.py`, rapportés par `myia-po-2025` pendant le rebaseline d'`app-10-portfolio.yaml` (PR #10427).

### Défaut 1 — no-op silencieux sur en-tête `audits:` à indentation 4

Le regex d'en-tête utilisait un quantificateur **exact** `\s{2}` :
```python
m_hdr = re.match(r"^\s{2}(last_audit|audits):\s*$", line)
```
Un fichier à indentation native 4 espaces (`app-10-portfolio.yaml`, `audits:` à indent 4) ne matchait pas → `surgical_rebaseline` renvoyait `touched=0` **sans erreur**. Le chemin CLI multi-fichiers affichait alors « 0 paire(s) mise(s) a jour » — un échec **indistinguable d'un no-op légitime** (« SHAs déjà à jour »). Un organe d'attestation qui échoue en silence.

Recensement sur `origin/main` : `audits:` indent-2 = 156 (norme) | indent-4 = 1 (app-10) | autre = 1.

### Défaut 2 — le chemin multi-fichiers jetait le compteur `touched`

```python
new_raw, _ = surgical_rebaseline(...)   # `_` = touched jeté
```
« Header introuvable » produisait exactement la même sortie qu'un no-op légitime. Les paires no-op légitimes sont **déjà filtrées** en amont (branches `no_op`/`forced_no_op`), donc `touched==0` dans la boucle signifiait réellement « header non reconnu » — mais rien ne le signalait.

## Les fixes

**Fix 1** — regex `\s{2}` → `\s{2,}`. **MAIS** `\s{2,}` seul sur-consomme : le regex de continuation `^\s{4,}\S` avalerait alors la clé sibling `known_differences:` (aussi à indent 4 dans app-10) dans le bloc audit → faux drift + perte de section.

  → La coupure de continuation est rendue **RELATIVE à l'indent de la clé** : strictement plus indentée que la clé, **OU** un item de séquence `-` à indent ≥ clé (YAML autorise un block sequence à la même indent que sa clé parent — le style `-   date:` d'app-10). Arrêt au premier sibling mapping key.

**Fix 2** — la boucle multi-fichiers capture `touched` et, quand il vaut 0 pour une paire qui **était** dans `updates`, émet un `AVERTISSEMENT` loud (« ce n'est PAS un no-op légitime, les SHAs diffèrent »). Même garde ajoutée au chemin mono-fichier legacy quand `updated < len(updates)`.

## Preuves (empirique sur le VRAI fichier)

```python
raw = app-10-portfolio.yaml
out, touched = surgical_rebaseline(raw, {'App-10 Portfolio': {python_sha: changé, ...}})
# touched        = 1            (était 0 avant le fix)
# known_differences survived   = True   (sibling NON avalé)
# audit entries  = 10           (append-only, 9 -> 10)
# YAML valid after edit         = True
```

## Hors scope (signalé honnêtement)

`_render_new_audit_entry` hardcode l'indent 4/6 (style normal). Un app-10 rebaselined reçoit donc une entrée **fonctionnellement correcte mais de style mixte** (`- date:` vs `-   date:`) — YAML valide et parsable (vérifié). La normalisation cosmétique est différée (issue séparée si souhaité).

## Tests

4 nouveaux dans `test_check_twin_parity_surgical.py` :
1. en-tête `audits:` indent-4 désormais reconnu (touched 0→1).
2. sibling `known_differences:` non consommé (le contenu survive).
3. **régression indent-2** (156 fichiers normaux) toujours reconnue + sibling indent-2 non consommé.
4. contrat `touched==0` quand le header est réellement absent (précondition de la garde loud-failure).

Suite complète twin-parity : **48/48** (surgical + content_sha + update_guard + ci_sha + coverage).

See #10430, #8570 (surgical rebaseline origin), #9399 (append-only design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
