### PR TITLE
feat(search,#10382): App-5 Timetabling Tranche 2 CP-SAT -- parite native-both

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb
@@ -67,10 +67,10 @@
    "id": "0b1c2d3e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T05:17:06.264769Z",
-     "iopub.status.busy": "2026-07-07T05:17:06.260646Z",
-     "iopub.status.idle": "2026-07-07T05:17:07.484351Z",
-     "shell.execute_reply": "2026-07-07T05:17:07.480701Z"
+     "iopub.execute_input": "2026-08-11T07:48:10.787320Z",
+     "iopub.status.busy": "2026-08-11T07:48:10.782870Z",
+     "iopub.status.idle": "2026-08-11T07:48:12.035822Z",
+     "shell.execute_reply": "2026-08-11T07:48:12.033802Z"
     },
     "papermill": {
      "duration": 1.230114,
@@ -83,6 +83,121 @@
    },
    "outputs": [
     {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-66480.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '66480.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -93,7 +208,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Runtime: .NET 10.0.9\r\n"
+      "Runtime: .NET 9.0.18\r\n"
      ]
     }
    ],
@@ -140,10 +255,10 @@
    "id": "1d2e3f4a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T05:17:07.496070Z",
-     "iopub.status.busy": "2026-07-07T05:17:07.495535Z",
-     "iopub.status.idle": "2026-07-07T05:17:07.633644Z",
-     "shell.execute_reply": "2026-07-07T05:17:07.633069Z"
+     "iopub.execute_input": "2026-08-11T07:48:12.037284Z",
+     "iopub.status.busy": "2026-08-11T07:48:12.037084Z",
+     "iopub.status.idle": "2026-08-11T07:48:12.180853Z",
+     "shell.execute_reply": "2026-08-11T07:48:12.180609Z"
     },
     "papermill": {
      "duration": 0.141625,
@@ -304,10 +419,10 @@
    "id": "3a4b5c6d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T05:17:07.650501Z",
-     "iopub.status.busy": "2026-07-07T05:17:07.650501Z",
-     "iopub.status.idle": "2026-07-07T05:17:07.909908Z",
-     "shell.execute_reply": "2026-07-07T05:17:07.909908Z"
+     "iopub.execute_input": "2026-08-11T07:48:12.182422Z",
+     "iopub.status.busy": "2026-08-11T07:48:12.182202Z",
+     "iopub.status.idle": "2026-08-11T07:48:12.436875Z",
+     "shell.execute_reply": "2026-08-11T07:48:12.436487Z"
     },
     "papermill": {
      "duration": 0.263405,
@@ -541,10 +656,10 @@
    "id": "5d6e7f8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T05:17:07.935729Z",
-     "iopub.status.busy": "2026-07-07T05:17:07.935729Z",
-     "iopub.status.idle": "2026-07-07T05:17:08.000092Z",
-     "shell.execute_reply": "2026-07-07T05:17:08.000092Z"
+     "iopub.execute_input": "2026-08-11T07:48:12.438405Z",
+     "iopub.status.busy": "2026-08-11T07:48:12.438203Z",
+     "iopub.status.idle": "2026-08-11T07:48:12.539353Z",
+     "shell.execute_reply": "2026-08-11T07:48:12.539081Z"
     },
     "papermill": {
      "duration": 0.068476,
@@ -588,7 +703,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Temps             : 1,66 ms\r\n"
+      "Temps             : 1,83 ms\r\n"
      ]
     },
     {
@@ -810,10 +925,10 @@
    "id": "7a8b9c0d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T05:17:08.031931Z",
-     "iopub.status.busy": "2026-07-07T05:17:08.031931Z",
-     "iopub.status.idle": "2026-07-07T05:17:08.151632Z",
-     "shell.execute_reply": "2026-07-07T05:17:08.151632Z"
+     "iopub.execute_input": "2026-08-11T07:48:12.540928Z",
+     "iopub.status.busy": "2026-08-11T07:48:12.540709Z",
+     "iopub.status.idle": "2026-08-11T07:48:12.653959Z",
+     "shell.execute_reply": "2026-08-11T07:48:12.653312Z"
     },
     "papermill": {
      "duration": 0.135667,
@@ -857,7 +972,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Temps              : 4,78 ms\r\n"
+      "Temps              : 5,68 ms\r\n"
      ]
     },
     {
@@ -1088,10 +1203,10 @@
    "id": "9d0e1f2a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T05:17:08.175342Z",
-     "iopub.status.busy": "2026-07-07T05:17:08.175342Z",
-     "iopub.status.idle": "2026-07-07T05:17:08.243043Z",
-     "shell.execute_reply": "2026-07-07T05:17:08.235530Z"
+     "iopub.execute_input": "2026-08-11T07:48:12.655753Z",
+     "iopub.status.busy": "2026-08-11T07:48:12.655538Z",
+     "iopub.status.idle": "2026-08-11T07:48:12.764607Z",
+     "shell.execute_reply": "2026-08-11T07:48:12.763583Z"
     },
     "papermill": {
      "duration": 0.072694,
@@ -1562,6 +1677,280 @@
   },
   {
    "cell_type": "markdown",
+   "id": "t2-intro",
+   "metadata": {},
+   "source": [
+    "### Tranche 2 (#10382) : le vrai solveur CP-SAT (Google.OrTools)\n",
+    "\n",
+    "Les §2–4 ci-dessus implantent l'emploi du temps **from-scratch** : heuristique gloutonne MRV (faisabilité rapide) + Branch-and-Bound (énumération avec élagage). La **Tranche 2** branche le **même moteur production** que le jumeau Python (`ortools.sat.python.cp_model`) — **Google.OrTools CP-SAT** (Perron & Furney) — le solveur SAT modulaire SOTA. Mêmes données (8 cours, 4 salles, 4 enseignants, 20 créneaux) → on confronte le solveur pédagogique au moteur SOTA sur le problème d'emploi du temps (minimiser les créneaux d'après-midi = préférence matinale)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "t2-cpsat",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T07:48:12.766338Z",
+     "iopub.status.busy": "2026-08-11T07:48:12.766101Z",
+     "iopub.status.idle": "2026-08-11T07:48:13.131551Z",
+     "shell.execute_reply": "2026-08-11T07:48:13.131119Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Google.OrTools, 9.11.4210</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Tranche 2 : CP-SAT (Google.OrTools 9.11) sur l'emploi du temps ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Statut                 : Optimal\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Temps                  : 47.0 ms\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Objectif (apres-midi)  : 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Affectations CP-SAT (objectif minimal) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Cours      Salle      Creneau\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Systemes   Salle_B    Lundi 8h-10h\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  IA         Amphi_A    Lundi 8h-10h\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Securite   Labo_C     Lundi 8h-10h\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Web        Labo_D     Lundi 8h-10h\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Reseaux    Labo_D     Lundi 10h-12h\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  BDD        Amphi_A    Lundi 10h-12h\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Probas     Amphi_A    Mardi 8h-10h\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Algo       Amphi_A    Mardi 10h-12h\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Prong-B : glouton MRV (faisabilite) vs CP-SAT (optimisation) ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Glouton MRV : 2 cours en apres-midi (compacte sur Lundi)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CP-SAT      : 0 cours en apres-midi (Optimal)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Gain        : CP-SAT elimine 2 cours d'apres-midi qu'un glouton ne cherche meme pas a eviter\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Tranche 2 (#10382) : emploi du temps optimal via Google.OrTools CP-SAT ===\n",
+    "#r \"nuget: Google.OrTools, 9.11.4210\"\n",
+    "using Google.OrTools.Sat;\n",
+    "using System.Globalization;\n",
+    "static string FI(double x, string fmt = \"F3\") => x.ToString(fmt, CultureInfo.InvariantCulture);\n",
+    "\n",
+    "// Modele CP-SAT : miroir de solve_timetable_cpsat cote Python.\n",
+    "// slot_var[c] in [0, NUM_SLOTS-1] ; room_var[c] dans les salles compatibles (id min..max).\n",
+    "// C1 conflit salle (reification meme-salle -> creneaux differents) ;\n",
+    "// C2 conflit enseignant ; S1 penalite apres-midi (slot % SLOTS_PER_DAY >= 2) ; minimize.\n",
+    "(string Status, double Ms, int Objective, Dictionary<string,(string,int)> Sched) SolveCpsat(int timeLimitS = 5) {\n",
+    "    var model = new CpModel();\n",
+    "    var slotVar = new Dictionary<string, IntVar>();\n",
+    "    var roomVar = new Dictionary<string, IntVar>();\n",
+    "    foreach (var c in courseNames) {\n",
+    "        slotVar[c] = model.NewIntVar(0, NUM_SLOTS - 1, $\"slot_{c}\");\n",
+    "        var compatIds = GetCompatibleRooms(c).Select(r => roomNames.IndexOf(r)).ToList();\n",
+    "        roomVar[c] = model.NewIntVar(compatIds.Min(), compatIds.Max(), $\"room_{c}\");\n",
+    "    }\n",
+    "    // C1 : pas de double reservation de salle (meme salle -> creneaux differents)\n",
+    "    for (int i = 0; i < courseNames.Count; i++)\n",
+    "        for (int j = i + 1; j < courseNames.Count; j++) {\n",
+    "            var c1 = courseNames[i]; var c2 = courseNames[j];\n",
+    "            var sameRoom = model.NewBoolVar($\"same_room_{c1}_{c2}\");\n",
+    "            model.Add(roomVar[c1] == roomVar[c2]).OnlyEnforceIf(sameRoom);\n",
+    "            model.Add(roomVar[c1] != roomVar[c2]).OnlyEnforceIf(sameRoom.Not());\n",
+    "            model.Add(slotVar[c1] != slotVar[c2]).OnlyEnforceIf(sameRoom);\n",
+    "        }\n",
+    "    // C2 : pas de double reservation d'enseignant\n",
+    "    foreach (var t in COURSES.Select(kv => kv.Value.Teacher).Distinct()) {\n",
+    "        var tc = GetTeacherCourses(t);\n",
+    "        for (int i = 0; i < tc.Count; i++)\n",
+    "            for (int j = i + 1; j < tc.Count; j++)\n",
+    "                model.Add(slotVar[tc[i]] != slotVar[tc[j]]);\n",
+    "    }\n",
+    "    // S1 : penalite creneaux d'apres-midi (slot % SLOTS_PER_DAY >= 2)\n",
+    "    var afternoon = new List<BoolVar>();\n",
+    "    foreach (var c in courseNames) {\n",
+    "        var hour = model.NewIntVar(0, SLOTS_PER_DAY - 1, $\"hour_{c}\");\n",
+    "        model.AddModuloEquality(hour, slotVar[c], SLOTS_PER_DAY);\n",
+    "        var isAf = model.NewBoolVar($\"afternoon_{c}\");\n",
+    "        model.Add(hour >= 2).OnlyEnforceIf(isAf);\n",
+    "        model.Add(hour < 2).OnlyEnforceIf(isAf.Not());\n",
+    "        afternoon.Add(isAf);\n",
+    "    }\n",
+    "    var penalty = model.NewIntVar(0, courseNames.Count, \"penalty\");\n",
+    "    model.Add(LinearExpr.Sum(afternoon) == penalty);\n",
+    "    model.Minimize(penalty);\n",
+    "\n",
+    "    var solver = new CpSolver();\n",
+    "    solver.StringParameters = $\"max_time_in_seconds:{timeLimitS}\";\n",
+    "    var sw = System.Diagnostics.Stopwatch.StartNew();\n",
+    "    var result = solver.Solve(model);\n",
+    "    sw.Stop();\n",
+    "    if (result == CpSolverStatus.Optimal || result == CpSolverStatus.Feasible) {\n",
+    "        var sched = new Dictionary<string,(string,int)>();\n",
+    "        foreach (var c in courseNames)\n",
+    "            sched[c] = (roomNames[(int)solver.Value(roomVar[c])], (int)solver.Value(slotVar[c]));\n",
+    "        return (result.ToString(), sw.Elapsed.TotalMilliseconds, (int)solver.Value(penalty), sched);\n",
+    "    }\n",
+    "    return (result.ToString(), sw.Elapsed.TotalMilliseconds, -1, null);\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"--- Tranche 2 : CP-SAT (Google.OrTools 9.11) sur l'emploi du temps ---\");\n",
+    "var (st, ms, obj, cpsatSched) = SolveCpsat(5);\n",
+    "Console.WriteLine($\"Statut                 : {st}\");\n",
+    "Console.WriteLine($\"Temps                  : {FI(ms,\"F1\")} ms\");\n",
+    "Console.WriteLine($\"Objectif (apres-midi)  : {obj}\");\n",
+    "if (cpsatSched != null) {\n",
+    "    Console.WriteLine(\"\");\n",
+    "    Console.WriteLine(\"Affectations CP-SAT (objectif minimal) :\");\n",
+    "    Console.WriteLine($\"  {\"Cours\",-10} {\"Salle\",-10} {\"Creneau\"}\");\n",
+    "    foreach (var c in courseNames.OrderBy(c => cpsatSched[c].Item2))\n",
+    "        Console.WriteLine($\"  {c,-10} {cpsatSched[c].Item1,-10} {SlotLabel(cpsatSched[c].Item2)}\");\n",
+    "}\n",
+    "\n",
+    "// --- Prong-B (#3801) : glouton (faisabilite) vs CP-SAT (optimisation) ---\n",
+    "// Re-derive le compte d'apres-midi du glouton MRV (cellule precedente) : honnete, pas de hardcode.\n",
+    "int greedyAfternoon = greedySchedule.Count(kv => (kv.Value.Slot % SLOTS_PER_DAY) >= 2);\n",
+    "Console.WriteLine(\"\");\n",
+    "Console.WriteLine(\"--- Prong-B : glouton MRV (faisabilite) vs CP-SAT (optimisation) ---\");\n",
+    "Console.WriteLine($\"Glouton MRV : {greedyAfternoon} cours en apres-midi (compacte sur Lundi)\");\n",
+    "Console.WriteLine($\"CP-SAT      : {obj} cours en apres-midi ({st})\");\n",
+    "Console.WriteLine($\"Gain        : CP-SAT elimine {greedyAfternoon - obj} cours d'apres-midi qu'un glouton ne cherche meme pas a eviter\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "t2-interp",
+   "metadata": {},
+   "source": [
+    "### Interprétation : parité lib-vs-lib, CP-SAT optimise là où le from-scratch satisfait\n",
+    "\n",
+    "**Validation.** CP-SAT retrouve une affectation réalisable **et** retourne le statut `Optimal` en ~50 ms. Toutes les contraintes dures sont respectées : les 4 cours exigeant l'Amphi_A (Algo, Probas, BDD, IA — capacité 100/90/80/75, seule salle ≥120) occupent 4 créneaux distincts ; aucun enseignant n'a deux cours au même créneau (Dupont : Algo/Systemes, Martin : Probas/IA, Bernard : Reseaux/Securite, Leroy : BDD/Web). C'est la preuve que le moteur SOTA confirme la sémantique « emploi du temps » du from-scratch.\n",
+    "\n",
+    "**Prong-B — la discrimination (pourquoi CP-SAT compte).** Le glouton MRV et le Branch-and-Bound §3 trouvent des affectations **réalisables** (contraintes dures), mais **n'optimisent aucun objectif souple** : le glouton compacte les 8 cours sur Lundi, plaçant **2 cours en après-midi** (BDD 14h, IA 16h). **CP-SAT, lui, minimise** la pénalité d'après-midi et prouve l'**optimal à 0** : il répartit les cours sur deux matinées pour qu'aucun ne soit en après-midi. C'est exactement la différence entre *satisfaire les contraintes* (from-scratch) et *optimiser une préférence* (solveur exact) — le cœur pédagogique du timetabling.\n",
+    "\n",
+    "**Verdict `SOTA-OK` (#3801).** Le moteur réel Google.OrTools CP-SAT est invoqué (`statut=Optimal`), produit le vrai minimum de l'objectif. Aucune sortie dégradée. La Tranche 1 from-scratch (MRV + B&B) est préservée intacte. Niveau de parité `native-both` : le jumeau Python invoque `ortools.sat.python.cp_model`, le jumeau C# invoque le même engine 9.11 via `#r \"nuget:\"`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1f2a3b4c",
    "metadata": {
     "papermill": {
@@ -1587,14 +1976,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "2a3b4c5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T05:17:08.274667Z",
-     "iopub.status.busy": "2026-07-07T05:17:08.274667Z",
-     "iopub.status.idle": "2026-07-07T05:17:08.297517Z",
-     "shell.execute_reply": "2026-07-07T05:17:08.297517Z"
+     "iopub.execute_input": "2026-08-11T07:48:13.133254Z",
+     "iopub.status.busy": "2026-08-11T07:48:13.133023Z",
+     "iopub.status.idle": "2026-08-11T07:48:13.209250Z",
+     "shell.execute_reply": "2026-08-11T07:48:13.208808Z"
     },
     "papermill": {
      "duration": 0.028854,
@@ -1707,14 +2096,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "515b0ebd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T05:17:08.320864Z",
-     "iopub.status.busy": "2026-07-07T05:17:08.320864Z",
-     "iopub.status.idle": "2026-07-07T05:17:08.357946Z",
-     "shell.execute_reply": "2026-07-07T05:17:08.356947Z"
+     "iopub.execute_input": "2026-08-11T07:48:13.210751Z",
+     "iopub.status.busy": "2026-08-11T07:48:13.210555Z",
+     "iopub.status.idle": "2026-08-11T07:48:13.252849Z",
+     "shell.execute_reply": "2026-08-11T07:48:13.252441Z"
     },
     "papermill": {
      "duration": 0.044095,
@@ -1779,14 +2168,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "0adb768a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T05:17:08.380185Z",
-     "iopub.status.busy": "2026-07-07T05:17:08.380185Z",
-     "iopub.status.idle": "2026-07-07T05:17:08.393552Z",
-     "shell.execute_reply": "2026-07-07T05:17:08.393552Z"
+     "iopub.execute_input": "2026-08-11T07:48:13.254762Z",
+     "iopub.status.busy": "2026-08-11T07:48:13.254553Z",
+     "iopub.status.idle": "2026-08-11T07:48:13.293699Z",
+     "shell.execute_reply": "2026-08-11T07:48:13.293469Z"
     },
     "papermill": {
      "duration": 0.020365,

--- a/scripts/notebook_tools/twin_pairs.d/app-5-timetabling.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-5-timetabling.yaml
@@ -2,7 +2,7 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -14,8 +14,15 @@
       csharp_sha: 1df664fbb228832fec6d05c12efe390465bd65c0
       content_python_sha: e3138b0bbcc57898cb78a3e3be17edefd3b13501a30f3bd6ef20ce9b943a1e6e
       content_csharp_sha: 1cdbcf8ff9091c8d28496ae42c40f6a6a9b2bc9afd0be44388f7ae9de3497191
+    - date: "2026-08-11"
+      by: myia-po-2024:CoursIA
+      python_sha: f86c512657965de508bfef73f94fd81adf13a3a8
+      csharp_sha: 64c768889121cb7d1f0413def68048cc76fbc1d5
+      content_python_sha: e3138b0bbcc57898cb78a3e3be17edefd3b13501a30f3bd6ef20ce9b943a1e6e
+      content_csharp_sha: 09619085c916f39b0d6958d90a6ae1692c8fe099b6a22d32ab5d29b71e944451
   known_differences:
+    - "Tranche 2 native-both (#10382, 2026-08-11 po-2024) : C# branche Google.OrTools CP-SAT 9.11 (meme engine que ortools.sat.python.cp_model cote Python). Miroir de solve_timetable_cpsat : slot/room vars, C1 conflit salle (reification), C2 conflit enseignant, S1 penalite apres-midi, model.Minimize(penalty). Validation firsthand : statut Optimal (47 ms), objectif apres-midi = 0 (toutes contraintes dures respectees). Prong-B (#3801) : glouton MRV = 2 cours en apres-midi (compacte sur Lundi), CP-SAT = 0 (Optimal) -- discrimination faisabilite-vs-optimisation mesuree. Verdict SOTA-OK : moteur reel invoque (statut Optimal). Tranche 1 from-scratch (MRV + B&B) preservee intacte (6 cellules code byte-identiques a main)."
     - "Edition 2026-08-08 (myia-po-2024:CoursIA, #9434 item 3) : drainage markdown-only d'une ligne de tableau dans la prose d'interpretation du twin Python (cell[22]) : les valeurs runtime absolues '< 1 ms' (Glouton) et '≈ 30 ms' (CP-SAT) remplacees par des descripteurs qualitatifs pointant vers les cellules de mesure live (cell[12] greedy 'Temps : 0.07 ms', cell[19] CP-SAT 'Temps de calcul : 32.5 ms'). Le twin C# (App-5-Timetabling-CSharp) n'est PAS touche (asymetrie pedagogique deja documentee ci-dessous : le C# demontre l'implementation from-scratch, ses propres valeurs de timing sont distinctes). Parite semantique preservee : socle theorique et concepts cibles inchanges ; seul le notebook Python a bouge, d'ou le re-baseline de son python_sha. Verifie firsthand : les cellules code de mesure au-dessus impriment toujours les runtimes live, la prose pointe desormais qualitativement vers elles (#9434)."
     - "Socle pedagogique commun : Emploi du temps / Timetabling (CSP : creneaux, salles, conflits) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
-    - "Idiomes framework : Python = OR-Tools CP-SAT + itertools combinations + search_helpers ; C# = BCL pure (System.*), 0 NuGet."
+    - "Idiomes framework : Python = OR-Tools CP-SAT + itertools combinations + search_helpers ; C# Tranche 1 = BCL pure (System.*, 0 NuGet) pour le from-scratch (MRV glouton + Branch-and-Bound) ; C# Tranche 2 = Google.OrTools CP-SAT 9.11 (meme engine que ortools.sat.python.cp_model, minimize penalite apres-midi)."
     - "Asymetrie pedagogique : Python met l'accent sur le solveur SOTA (OR-Tools CP-SAT / library specialisee) + visualisation matplotlib + experimentation comparative ; le C# demontre l'implementation from-scratch en BCL pure (ou binding NuGet du meme solver pour App-8/10/15), presentation compacte. Meme socle theorique, leviers de demonstration differents."


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2024:CoursIA — prev: DEEP/notebook-dotnet #10432 (App-2 GraphColoring Tranche 2)

## Summary

**Tranche 2 lib-vs-lib pour App-5-Timetabling-CSharp** (#10382) : branche le **même moteur production** que le jumeau Python (`ortools.sat.python.cp_model`) — **Google.OrTools CP-SAT 9.11** (Perron & Furney ; SAT + Lazy Clause Generation) — sur le problème d'emploi du temps universitaire. La Tranche 1 from-scratch (heuristique gloutonne MRV + Branch-and-Bound) est **préservée intacte** (6 cellules code byte-identiques à main, vérifié firsthand).

Promotion du niveau de parité `semantic` → `native-both`. Le `known_differences` du registre documentait la divergence (« Python = OR-Tools CP-SAT ; C# = BCL pure, 0 NuGet ») — cette Tranche 2 la résout.

## Détail technique

Trois cellules insérées après §4 (visualisation ASCII), avant l'Exemple résolu :

1. **Intro markdown** — pose la Tranche 2 comme confrontation du from-scratch pédagogique au solveur SOTA.
2. **Code C#** (`ec=7`) — `#r "nuget: Google.OrTools, 9.11.4210"`. Méthode `SolveCpsat()` miroir de `solve_timetable_cpsat` Python : `slot_var[c] ∈ [0,19]`, `room_var[c]` dans les salles compatibles, **C1** conflit salle (réification `same_room` booléen → créneaux différents), **C2** conflit enseignant, **S1** pénalité après-midi (`slot % 4 >= 2` via `AddModuloEquality`), `model.Minimize(penalty)`. Résolution via `CpSolver` + `StringParameters`.
3. **Interprétation markdown** — verdict SOTA-OK + la discrimination faisabilité-vs-optimisation.

## Verdict de parité (firsthand, re-exécuté)

**Validation (statut Optimal, 47 ms).** CP-SAT retourne `Optimal` et prouve l'**objectif après-midi = 0** : aucun cours en après-midi. Toutes les contraintes dures sont respectées — les 4 cours exigeant l'Amphi_A (Algo/Probas/BDD/IA, seule salle ≥120) occupent 4 créneaux distincts ; aucun enseignant n'a deux cours au même créneau (Dupont, Martin, Bernard, Leroy).

**Prong-B (#3801) — la discrimination mesurée firsthand :**

| Méthode | Cours en après-midi | Statut |
|---|---|---|
| Glouton MRV (from-scratch §3) | **2** (BDD 14h, IA 16h) | Faisabilité (compacte sur Lundi) |
| Branch-and-Bound (from-scratch §3) | — | Énumération de solutions réalisables (pas d'objectif) |
| **CP-SAT (Tranche 2)** | **0** | **Optimal** (minimise, certifie) |

Le from-scratch (glouton + B&B) trouve des affectations **réalisables** mais **n'optimise aucun objectif souple** : le glouton compacte les 8 cours sur Lundi. **CP-SAT minimise** la pénalité d'après-midi et prouve l'optimal à 0 en répartissant sur deux matinées. C'est exactement la différence entre *satisfaire les contraintes* et *optimiser une préférence* — le cœur pédagogique du timetabling, et le cas canonique où un solveur exact justifie son existence face aux heuristiques.

## Prong-B — problème non-trivial qui met le moteur en valeur

Le timetabling est **le** cas canonique (cf [sota-not-workaround.md](.claude/rules/sota-not-workaround.md)) de l'**optimisation sous contraintes** où un solveur exact se justifie : les heuristiques trouvent du faisable, mais seul CP-SAT **optimise** (minimiser les créneaux indésirables) **et certifie** l'optimalité (statut `Optimal` via SAT + Lazy Clause Generation). La discrimination a été **mesurée firsthand** avant d'être clamée (G.9) — glouton=2 après-midi vs CP-SAT=0 prouvé Optimal, vérifié sur les données réelles du notebook.

## Preuves d'exécution réelle (C.2 / H.1)

- Re-exécution complète `jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=.net-csharp` (cwd = dossier du notebook).
- **0 erreur**. `execution_count` 1..10 cohérent sur les 10 cellules code.
- Sorties commitées = vraies sorties CP-SAT (statut Optimal, objectif 0, table d'affectation, table Prong-B).
- `strip_probe_banner.py --apply` : 9 lignes `probeAddresses` stripées post-re-exec .NET (L532). Pas de hand-edit (Stop & Repair respecté).
- Cellule d'interprétation (markdown) ajustée pour **matcher exactement** les outputs commités (greedyAfternoon re-déduit live depuis `greedySchedule`, pas hardcodé).

## Twin registry

`app-5-timetabling.yaml` : `parity_level` semantic → **native-both**. Nouvelle entrée d'audit (csharp_sha `64c7688`), `known_differences` réécrit pour documenter la Tranche 2 CP-SAT + la Tranche 1 from-scratch préservée. SHA rebaseliné via `check_twin_parity.py --update` **après** le commit du notebook (leçon #8957).

`check_twin_parity.py` : **157/157 OK, DRIFT=0**.

## Scope

2 fichiers, 2 commits, 1 sujet (Tranche 2 App-5 Timetabling). Tranche 1 from-scratch **intacte** (vérifié : 6 cellules code byte-identiques à `origin/main`). Aucun changement hors-scope. Catalogue byte-identique à main.

See #10382, #3801.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
