### PR TITLE
feat(gametheory,#10414): add Gambit CLI comparison (Lemke-Howson + enummixed) on 5 canonical games

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
@@ -59,10 +59,10 @@
    "id": "7887f51a-1371-4904-bbf3-a4d7f81003ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:34.459274Z",
-     "iopub.status.busy": "2026-08-11T09:11:34.444910Z",
-     "iopub.status.idle": "2026-08-11T09:11:38.848323Z",
-     "shell.execute_reply": "2026-08-11T09:11:38.840385Z"
+     "iopub.execute_input": "2026-08-11T11:01:36.646964Z",
+     "iopub.status.busy": "2026-08-11T11:01:36.625697Z",
+     "iopub.status.idle": "2026-08-11T11:01:41.506342Z",
+     "shell.execute_reply": "2026-08-11T11:01:41.498009Z"
     }
    },
    "outputs": [
@@ -284,10 +284,10 @@
    "id": "73198a3f-f277-4796-92fe-8b29e8caa06b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:38.852103Z",
-     "iopub.status.busy": "2026-08-11T09:11:38.851397Z",
-     "iopub.status.idle": "2026-08-11T09:11:39.208457Z",
-     "shell.execute_reply": "2026-08-11T09:11:39.207139Z"
+     "iopub.execute_input": "2026-08-11T11:01:41.510855Z",
+     "iopub.status.busy": "2026-08-11T11:01:41.509785Z",
+     "iopub.status.idle": "2026-08-11T11:01:41.839760Z",
+     "shell.execute_reply": "2026-08-11T11:01:41.838875Z"
     }
    },
    "outputs": [
@@ -361,10 +361,10 @@
    "id": "2d27b18d-f2ad-4eb3-acff-601ac2ee0c62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:39.212287Z",
-     "iopub.status.busy": "2026-08-11T09:11:39.211562Z",
-     "iopub.status.idle": "2026-08-11T09:11:39.333178Z",
-     "shell.execute_reply": "2026-08-11T09:11:39.332556Z"
+     "iopub.execute_input": "2026-08-11T11:01:41.842932Z",
+     "iopub.status.busy": "2026-08-11T11:01:41.842302Z",
+     "iopub.status.idle": "2026-08-11T11:01:41.952640Z",
+     "shell.execute_reply": "2026-08-11T11:01:41.951773Z"
     }
    },
    "outputs": [
@@ -479,10 +479,10 @@
    "id": "0399d8bd-7565-410a-a98e-beeff981ffbd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:39.337473Z",
-     "iopub.status.busy": "2026-08-11T09:11:39.336669Z",
-     "iopub.status.idle": "2026-08-11T09:11:39.637519Z",
-     "shell.execute_reply": "2026-08-11T09:11:39.636795Z"
+     "iopub.execute_input": "2026-08-11T11:01:41.955846Z",
+     "iopub.status.busy": "2026-08-11T11:01:41.955309Z",
+     "iopub.status.idle": "2026-08-11T11:01:42.184197Z",
+     "shell.execute_reply": "2026-08-11T11:01:42.183672Z"
     }
    },
    "outputs": [
@@ -582,10 +582,10 @@
    "id": "b2f8a6fc-8ab5-4aec-a8c0-41a1269ae658",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:39.641892Z",
-     "iopub.status.busy": "2026-08-11T09:11:39.640989Z",
-     "iopub.status.idle": "2026-08-11T09:11:39.872637Z",
-     "shell.execute_reply": "2026-08-11T09:11:39.871872Z"
+     "iopub.execute_input": "2026-08-11T11:01:42.186991Z",
+     "iopub.status.busy": "2026-08-11T11:01:42.186411Z",
+     "iopub.status.idle": "2026-08-11T11:01:42.347818Z",
+     "shell.execute_reply": "2026-08-11T11:01:42.346899Z"
     }
    },
    "outputs": [
@@ -689,10 +689,10 @@
    "id": "fe7b696e-3fa5-469f-b9ac-dcc57d5f56aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:39.878749Z",
-     "iopub.status.busy": "2026-08-11T09:11:39.877802Z",
-     "iopub.status.idle": "2026-08-11T09:11:40.121444Z",
-     "shell.execute_reply": "2026-08-11T09:11:40.120284Z"
+     "iopub.execute_input": "2026-08-11T11:01:42.351239Z",
+     "iopub.status.busy": "2026-08-11T11:01:42.350640Z",
+     "iopub.status.idle": "2026-08-11T11:01:42.474219Z",
+     "shell.execute_reply": "2026-08-11T11:01:42.473628Z"
     }
    },
    "outputs": [
@@ -758,10 +758,10 @@
    "id": "5bb025e3-5323-4163-9c22-edb7ae7a10c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:40.125629Z",
-     "iopub.status.busy": "2026-08-11T09:11:40.124630Z",
-     "iopub.status.idle": "2026-08-11T09:11:40.572787Z",
-     "shell.execute_reply": "2026-08-11T09:11:40.572147Z"
+     "iopub.execute_input": "2026-08-11T11:01:42.477526Z",
+     "iopub.status.busy": "2026-08-11T11:01:42.476813Z",
+     "iopub.status.idle": "2026-08-11T11:01:42.912145Z",
+     "shell.execute_reply": "2026-08-11T11:01:42.911494Z"
     }
    },
    "outputs": [
@@ -905,10 +905,10 @@
    "id": "516b3c7f-187f-4428-9df4-abfc2768876e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:40.576989Z",
-     "iopub.status.busy": "2026-08-11T09:11:40.576322Z",
-     "iopub.status.idle": "2026-08-11T09:11:40.754935Z",
-     "shell.execute_reply": "2026-08-11T09:11:40.755389Z"
+     "iopub.execute_input": "2026-08-11T11:01:42.915635Z",
+     "iopub.status.busy": "2026-08-11T11:01:42.914955Z",
+     "iopub.status.idle": "2026-08-11T11:01:43.096385Z",
+     "shell.execute_reply": "2026-08-11T11:01:43.095447Z"
     }
    },
    "outputs": [
@@ -1032,10 +1032,10 @@
    "id": "d6e925d4-e4d8-4c68-b3d6-acc2c79b42ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:40.758713Z",
-     "iopub.status.busy": "2026-08-11T09:11:40.758062Z",
-     "iopub.status.idle": "2026-08-11T09:11:40.845869Z",
-     "shell.execute_reply": "2026-08-11T09:11:40.838615Z"
+     "iopub.execute_input": "2026-08-11T11:01:43.099557Z",
+     "iopub.status.busy": "2026-08-11T11:01:43.098906Z",
+     "iopub.status.idle": "2026-08-11T11:01:43.198100Z",
+     "shell.execute_reply": "2026-08-11T11:01:43.188444Z"
     }
    },
    "outputs": [
@@ -1246,10 +1246,10 @@
    "id": "61d56fe3-ac8a-4fbf-9250-d1a3700af34f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:40.849517Z",
-     "iopub.status.busy": "2026-08-11T09:11:40.848897Z",
-     "iopub.status.idle": "2026-08-11T09:11:40.947044Z",
-     "shell.execute_reply": "2026-08-11T09:11:40.946453Z"
+     "iopub.execute_input": "2026-08-11T11:01:43.202097Z",
+     "iopub.status.busy": "2026-08-11T11:01:43.201431Z",
+     "iopub.status.idle": "2026-08-11T11:01:43.300956Z",
+     "shell.execute_reply": "2026-08-11T11:01:43.300326Z"
     }
    },
    "outputs": [
@@ -1321,10 +1321,10 @@
    "id": "4e63a3e4-acc4-4c5c-b7e1-2f624b43c48f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:40.950768Z",
-     "iopub.status.busy": "2026-08-11T09:11:40.950061Z",
-     "iopub.status.idle": "2026-08-11T09:11:41.044244Z",
-     "shell.execute_reply": "2026-08-11T09:11:41.044742Z"
+     "iopub.execute_input": "2026-08-11T11:01:43.304316Z",
+     "iopub.status.busy": "2026-08-11T11:01:43.303642Z",
+     "iopub.status.idle": "2026-08-11T11:01:43.398118Z",
+     "shell.execute_reply": "2026-08-11T11:01:43.397547Z"
     }
    },
    "outputs": [
@@ -1441,10 +1441,10 @@
    "id": "gt4-gambit-helpers",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:41.048883Z",
-     "iopub.status.busy": "2026-08-11T09:11:41.047927Z",
-     "iopub.status.idle": "2026-08-11T09:11:41.450609Z",
-     "shell.execute_reply": "2026-08-11T09:11:41.449710Z"
+     "iopub.execute_input": "2026-08-11T11:01:43.401824Z",
+     "iopub.status.busy": "2026-08-11T11:01:43.401140Z",
+     "iopub.status.idle": "2026-08-11T11:01:44.025475Z",
+     "shell.execute_reply": "2026-08-11T11:01:44.024916Z"
     }
    },
    "outputs": [
@@ -1491,11 +1491,11 @@
     "    // Titre securise (sans guillemets internes pour eviter les surprises parser)\n",
     "    string safeTitle = g.Name.Replace('\"', '_');\n",
     "    sb.AppendLine($\"NFG 1 R \\\"{safeTitle}\\\" {{ \\\"Player 1\\\" \\\"Player 2\\\" }} {{ {g.M} {g.N} }}\");\n",
-    "    // Liste plate : pour chaque (i,j) en lex (j inner, i outer), payoff_Row payoff_Col\n",
+    "    // Liste plate : convention NFG = joueur 1 (Row, indice i) varie le PLUS VITE\n",
     "    // Format G4 produit toujours un point decimal en notation invariante (pas fr-FR).\n",
     "    var nums = new List<string>();\n",
-    "    for (int i = 0; i < g.M; i++)\n",
     "    for (int j = 0; j < g.N; j++)\n",
+    "    for (int i = 0; i < g.M; i++)\n",
     "    {\n",
     "        nums.Add(g.A[i, j].ToString(\"G4\", CultureInfo.InvariantCulture));\n",
     "        nums.Add(g.B[i, j].ToString(\"G4\", CultureInfo.InvariantCulture));\n",
@@ -1568,10 +1568,10 @@
    "id": "gt4-gambit-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:41.453735Z",
-     "iopub.status.busy": "2026-08-11T09:11:41.453123Z",
-     "iopub.status.idle": "2026-08-11T09:11:42.202085Z",
-     "shell.execute_reply": "2026-08-11T09:11:42.201413Z"
+     "iopub.execute_input": "2026-08-11T11:01:44.028723Z",
+     "iopub.status.busy": "2026-08-11T11:01:44.027927Z",
+     "iopub.status.idle": "2026-08-11T11:01:44.822677Z",
+     "shell.execute_reply": "2026-08-11T11:01:44.823122Z"
     }
    },
    "outputs": [
@@ -1614,7 +1614,7 @@
     {
      "data": {
       "text/plain": [
-       "    Row=[1,00,0,00] Col=[1,00,0,00]"
+       "    Row=[0,00,1,00] Col=[0,00,1,00]"
       ]
      },
      "metadata": {},
@@ -1632,7 +1632,7 @@
     {
      "data": {
       "text/plain": [
-       "    Row=[1,00,0,00] Col=[1,00,0,00]"
+       "    Row=[0,00,1,00] Col=[0,00,1,00]"
       ]
      },
      "metadata": {},
@@ -1957,7 +1957,7 @@
     {
      "data": {
       "text/plain": [
-       "    Row=[1,00,0,00,0,00] Col=[1,00,0,00]"
+       "    Row=[0,75,0,25,0,00] Col=[0,50,0,50]"
       ]
      },
      "metadata": {},
@@ -1966,7 +1966,7 @@
     {
      "data": {
       "text/plain": [
-       "  gambit-enummixed (extreme points) : 1 NE (exit=0)"
+       "  gambit-enummixed (extreme points) : 2 NE (exit=0)"
       ]
      },
      "metadata": {},
@@ -1975,7 +1975,16 @@
     {
      "data": {
       "text/plain": [
-       "    Row=[1,00,0,00,0,00] Col=[1,00,0,00]"
+       "    Row=[0,75,0,25,0,00] Col=[0,50,0,50]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,00,0,25,0,75] Col=[0,50,0,50]"
       ]
      },
      "metadata": {},
@@ -2088,10 +2097,10 @@
    "id": "c7fad5e7-cf5b-4609-a19d-8a7ac1b4950d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:42.207410Z",
-     "iopub.status.busy": "2026-08-11T09:11:42.206487Z",
-     "iopub.status.idle": "2026-08-11T09:11:42.389019Z",
-     "shell.execute_reply": "2026-08-11T09:11:42.387653Z"
+     "iopub.execute_input": "2026-08-11T11:01:44.826858Z",
+     "iopub.status.busy": "2026-08-11T11:01:44.826187Z",
+     "iopub.status.idle": "2026-08-11T11:01:44.944334Z",
+     "shell.execute_reply": "2026-08-11T11:01:44.943717Z"
     }
    },
    "outputs": [
@@ -2153,10 +2162,10 @@
    "id": "f4e0fce6-304e-4e34-8b6e-44011062b56b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:42.392924Z",
-     "iopub.status.busy": "2026-08-11T09:11:42.392266Z",
-     "iopub.status.idle": "2026-08-11T09:11:42.511534Z",
-     "shell.execute_reply": "2026-08-11T09:11:42.510977Z"
+     "iopub.execute_input": "2026-08-11T11:01:44.947723Z",
+     "iopub.status.busy": "2026-08-11T11:01:44.947052Z",
+     "iopub.status.idle": "2026-08-11T11:01:45.049664Z",
+     "shell.execute_reply": "2026-08-11T11:01:45.048633Z"
     }
    },
    "outputs": [
@@ -2201,10 +2210,10 @@
    "id": "a966c48a-4683-4334-a016-fec483e1777c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T09:11:42.515182Z",
-     "iopub.status.busy": "2026-08-11T09:11:42.514449Z",
-     "iopub.status.idle": "2026-08-11T09:11:42.600544Z",
-     "shell.execute_reply": "2026-08-11T09:11:42.599964Z"
+     "iopub.execute_input": "2026-08-11T11:01:45.053174Z",
+     "iopub.status.busy": "2026-08-11T11:01:45.052503Z",
+     "iopub.status.idle": "2026-08-11T11:01:45.125243Z",
+     "shell.execute_reply": "2026-08-11T11:01:45.124707Z"
     }
    },
    "outputs": [

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
@@ -59,10 +59,10 @@
    "id": "7887f51a-1371-4904-bbf3-a4d7f81003ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T15:50:52.124922Z",
-     "iopub.status.busy": "2026-07-06T15:50:52.118647Z",
-     "iopub.status.idle": "2026-07-06T15:50:54.240660Z",
-     "shell.execute_reply": "2026-07-06T15:50:54.236771Z"
+     "iopub.execute_input": "2026-08-11T09:11:34.459274Z",
+     "iopub.status.busy": "2026-08-11T09:11:34.444910Z",
+     "iopub.status.idle": "2026-08-11T09:11:38.848323Z",
+     "shell.execute_reply": "2026-08-11T09:11:38.840385Z"
     }
    },
    "outputs": [
@@ -71,10 +71,11 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-86876.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -84,7 +85,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
+       
+       
        "\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -99,6 +103,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -110,11 +115,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '1485656.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '86876.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -158,11 +165,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -275,10 +284,10 @@
    "id": "73198a3f-f277-4796-92fe-8b29e8caa06b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T15:50:54.241987Z",
-     "iopub.status.busy": "2026-07-06T15:50:54.241792Z",
-     "iopub.status.idle": "2026-07-06T15:50:54.408741Z",
-     "shell.execute_reply": "2026-07-06T15:50:54.408427Z"
+     "iopub.execute_input": "2026-08-11T09:11:38.852103Z",
+     "iopub.status.busy": "2026-08-11T09:11:38.851397Z",
+     "iopub.status.idle": "2026-08-11T09:11:39.208457Z",
+     "shell.execute_reply": "2026-08-11T09:11:39.207139Z"
     }
    },
    "outputs": [
@@ -352,10 +361,10 @@
    "id": "2d27b18d-f2ad-4eb3-acff-601ac2ee0c62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T15:50:54.410094Z",
-     "iopub.status.busy": "2026-07-06T15:50:54.409874Z",
-     "iopub.status.idle": "2026-07-06T15:50:54.446491Z",
-     "shell.execute_reply": "2026-07-06T15:50:54.446114Z"
+     "iopub.execute_input": "2026-08-11T09:11:39.212287Z",
+     "iopub.status.busy": "2026-08-11T09:11:39.211562Z",
+     "iopub.status.idle": "2026-08-11T09:11:39.333178Z",
+     "shell.execute_reply": "2026-08-11T09:11:39.332556Z"
     }
    },
    "outputs": [
@@ -427,8 +436,18 @@
   {
    "cell_type": "markdown",
    "id": "324d565d",
-   "source": "### 2.1 Multiplicité des équilibres purs : Bridge vers les mixtes\n\nLes deux sorties ci-dessus partagent un trait qu'aucune d'entre elles ne commente : **deux équilibres purs** au lieu d'un seul. Comparons au Dilemme du Prisonnier (cellule précédente) qui n'en avait qu'un — $(D,D)$, dominant par stratégie stricte. Le passage d'un unique équilibre à deux traduit un changement structurel : il n'y a plus de stratégie strictement dominante. Chaque joueur a un *intérêt à se coordonner* sur une convention commune, mais les conventions possibles sont multiples.\n\n**Stag Hunt** : les deux purs ne se valent pas en gain. $(S,S) \\to (4,4)$ *domine* $(H,H) \\to (3,3)$ au sens de Pareto — les deux joueurs préfèreraient se coordonner sur $S$. Pourtant $(H,H)$ n'est pas *dominé* : si l'autre joue $H$, votre meilleure réponse est aussi $H$ (gains $3$ vs $0$ en jouant $S$). C'est le classique **risque-vs-gain** : coopérer rapporte plus mais exige de croire que l'autre coopérera. Ce jeu est aussi le grand-père du *coordination problem* en théorie des jeux évolutionnaires.\n\n**Coordination** : $(L,L) \\to (2,2)$ domine aussi $(R,R) \\to (1,1)$ en Pareto, mais la matrice est symétrique (`A = B`). Aucun joueur n'a de raison *intrinsèque* de préférer $L$ à $R$ ou l'inverse — la préférence est *conventionnelle*. C'est le cas archétypal soulevé par Schelling (*The Strategy of Conflict*, 1960) : sans signal commun, comment les joueurs tombent-ils d'accord sur la convention ?\n\nLa **section 3** qui suit étend la notion d'équilibre au-delà des profils purs : en autorisant la randomisation, on construit des points fixes *mixtes* qui rendent le joueur adverse *indifférent* entre ses actions — et c'est précisément la technique pour obtenir un troisième type d'équilibre dans ces jeux à multiples purs.**",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### 2.1 Multiplicité des équilibres purs : Bridge vers les mixtes\n",
+    "\n",
+    "Les deux sorties ci-dessus partagent un trait qu'aucune d'entre elles ne commente : **deux équilibres purs** au lieu d'un seul. Comparons au Dilemme du Prisonnier (cellule précédente) qui n'en avait qu'un — $(D,D)$, dominant par stratégie stricte. Le passage d'un unique équilibre à deux traduit un changement structurel : il n'y a plus de stratégie strictement dominante. Chaque joueur a un *intérêt à se coordonner* sur une convention commune, mais les conventions possibles sont multiples.\n",
+    "\n",
+    "**Stag Hunt** : les deux purs ne se valent pas en gain. $(S,S) \\to (4,4)$ *domine* $(H,H) \\to (3,3)$ au sens de Pareto — les deux joueurs préfèreraient se coordonner sur $S$. Pourtant $(H,H)$ n'est pas *dominé* : si l'autre joue $H$, votre meilleure réponse est aussi $H$ (gains $3$ vs $0$ en jouant $S$). C'est le classique **risque-vs-gain** : coopérer rapporte plus mais exige de croire que l'autre coopérera. Ce jeu est aussi le grand-père du *coordination problem* en théorie des jeux évolutionnaires.\n",
+    "\n",
+    "**Coordination** : $(L,L) \\to (2,2)$ domine aussi $(R,R) \\to (1,1)$ en Pareto, mais la matrice est symétrique (`A = B`). Aucun joueur n'a de raison *intrinsèque* de préférer $L$ à $R$ ou l'inverse — la préférence est *conventionnelle*. C'est le cas archétypal soulevé par Schelling (*The Strategy of Conflict*, 1960) : sans signal commun, comment les joueurs tombent-ils d'accord sur la convention ?\n",
+    "\n",
+    "La **section 3** qui suit étend la notion d'équilibre au-delà des profils purs : en autorisant la randomisation, on construit des points fixes *mixtes* qui rendent le joueur adverse *indifférent* entre ses actions — et c'est précisément la technique pour obtenir un troisième type d'équilibre dans ces jeux à multiples purs.**"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -460,10 +479,10 @@
    "id": "0399d8bd-7565-410a-a98e-beeff981ffbd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T15:50:54.447891Z",
-     "iopub.status.busy": "2026-07-06T15:50:54.447601Z",
-     "iopub.status.idle": "2026-07-06T15:50:54.553186Z",
-     "shell.execute_reply": "2026-07-06T15:50:54.553019Z"
+     "iopub.execute_input": "2026-08-11T09:11:39.337473Z",
+     "iopub.status.busy": "2026-08-11T09:11:39.336669Z",
+     "iopub.status.idle": "2026-08-11T09:11:39.637519Z",
+     "shell.execute_reply": "2026-08-11T09:11:39.636795Z"
     }
    },
    "outputs": [
@@ -563,10 +582,10 @@
    "id": "b2f8a6fc-8ab5-4aec-a8c0-41a1269ae658",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T15:50:54.554487Z",
-     "iopub.status.busy": "2026-07-06T15:50:54.554198Z",
-     "iopub.status.idle": "2026-07-06T15:50:54.636927Z",
-     "shell.execute_reply": "2026-07-06T15:50:54.636487Z"
+     "iopub.execute_input": "2026-08-11T09:11:39.641892Z",
+     "iopub.status.busy": "2026-08-11T09:11:39.640989Z",
+     "iopub.status.idle": "2026-08-11T09:11:39.872637Z",
+     "shell.execute_reply": "2026-08-11T09:11:39.871872Z"
     }
    },
    "outputs": [
@@ -633,8 +652,20 @@
   {
    "cell_type": "markdown",
    "id": "ef0085e8",
-   "source": "### 3.1 Lecture des premiers mélanges : asymétrie et Pareto-dominance\n\nLes trois résultats ci-dessus — *Matching Pennies $(0.5, 0.5)$*, *BoS $(p=2/3, q=1/3)$*, *Stag Hunt $(p=q=0.75)$* — illustrent trois régimes structurellement distincts.\n\n**Matching Pennies $(0.5, 0.5)$** : la matrice est **antisymétrique** ($A = -B$). Aucun joueur n'a de motif de biaiser sa randomisation d'un côté ou de l'autre — l'unique équilibre est **uniforme**. C'est un *équilibre pur de stratégie mixte* : la seule issue face à un adversaire strictement compétitif, conformément au théorème de Von Neumann (1928) pour les jeux zero-sum.\n\n**BoS $(p=2/3, q=1/3)$** : la matrice est **asymétrique** ($A \\neq B$). Row préfère *Opera* (gain $2$ vs $1$ sur Foot), Col préfère *Foot* (gain $2$ vs $1$ sur Opera). Les deux ont intérêt à *paraître* prêts à jouer leur action préférée pour *forcer* l'autre à jouer la sienne moins souvent. Le calcul donne $p = 2/3$ (Row joue Opera 2 fois sur 3) et $q = 1/3$ (Col joue Opera 1 fois sur 3) — *la probabilité est inversement proportionnelle à la préférence*. C'est l'**indifférence calibration** : chaque joueur rend l'autre *exactement* indifférent entre ses deux actions.\n\n**Stag Hunt $(p=q=0.75)$** : la matrice est **symétrique** ($A = B$). Les deux joueurs jouent la même stratégie mixte — ils sont dans la même position. Le mixte $p=0.75$ équilibre la tension entre deux purs : $(S,S) \\to (4,4)$ plus coopératif et $(H,H) \\to (3,3)$ plus sûr. Pour rendre l'autre *indifférent* entre $S$ et $H$, on doit jouer $S$ avec probabilité $0.75$ — assez pour rendre la déviation *non profitable*.\n\n**Le piège de Pareto** : les deux équilibres mixtes ci-dessus (BoS, Stag Hunt) sont **Pareto-dominés** par au moins un équilibre pur. Stag Hunt $(S,S) \\to (4,4)$ domine son mixte $(3,3)$. BoS $(Opera,Opera) \\to (2,1)$ domine son mixte $(0.67, 0.67)$. La théorie prédit ces mixtes comme *réponses d'indifférence*, mais ne dit pas pourquoi les joueurs y tomberaient plutôt que sur le pur Pareto-supérieur. C'est précisément la **limite de la notion d'équilibre** : Nash décrit les issues *stables*, pas les issues *optimales*. Cette tension structurelle motive la section 4 (l'algorithme général de support enumeration) et le notebook suivant sur le cas zero-sum.**",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### 3.1 Lecture des premiers mélanges : asymétrie et Pareto-dominance\n",
+    "\n",
+    "Les trois résultats ci-dessus — *Matching Pennies $(0.5, 0.5)$*, *BoS $(p=2/3, q=1/3)$*, *Stag Hunt $(p=q=0.75)$* — illustrent trois régimes structurellement distincts.\n",
+    "\n",
+    "**Matching Pennies $(0.5, 0.5)$** : la matrice est **antisymétrique** ($A = -B$). Aucun joueur n'a de motif de biaiser sa randomisation d'un côté ou de l'autre — l'unique équilibre est **uniforme**. C'est un *équilibre pur de stratégie mixte* : la seule issue face à un adversaire strictement compétitif, conformément au théorème de Von Neumann (1928) pour les jeux zero-sum.\n",
+    "\n",
+    "**BoS $(p=2/3, q=1/3)$** : la matrice est **asymétrique** ($A \\neq B$). Row préfère *Opera* (gain $2$ vs $1$ sur Foot), Col préfère *Foot* (gain $2$ vs $1$ sur Opera). Les deux ont intérêt à *paraître* prêts à jouer leur action préférée pour *forcer* l'autre à jouer la sienne moins souvent. Le calcul donne $p = 2/3$ (Row joue Opera 2 fois sur 3) et $q = 1/3$ (Col joue Opera 1 fois sur 3) — *la probabilité est inversement proportionnelle à la préférence*. C'est l'**indifférence calibration** : chaque joueur rend l'autre *exactement* indifférent entre ses deux actions.\n",
+    "\n",
+    "**Stag Hunt $(p=q=0.75)$** : la matrice est **symétrique** ($A = B$). Les deux joueurs jouent la même stratégie mixte — ils sont dans la même position. Le mixte $p=0.75$ équilibre la tension entre deux purs : $(S,S) \\to (4,4)$ plus coopératif et $(H,H) \\to (3,3)$ plus sûr. Pour rendre l'autre *indifférent* entre $S$ et $H$, on doit jouer $S$ avec probabilité $0.75$ — assez pour rendre la déviation *non profitable*.\n",
+    "\n",
+    "**Le piège de Pareto** : les deux équilibres mixtes ci-dessus (BoS, Stag Hunt) sont **Pareto-dominés** par au moins un équilibre pur. Stag Hunt $(S,S) \\to (4,4)$ domine son mixte $(3,3)$. BoS $(Opera,Opera) \\to (2,1)$ domine son mixte $(0.67, 0.67)$. La théorie prédit ces mixtes comme *réponses d'indifférence*, mais ne dit pas pourquoi les joueurs y tomberaient plutôt que sur le pur Pareto-supérieur. C'est précisément la **limite de la notion d'équilibre** : Nash décrit les issues *stables*, pas les issues *optimales*. Cette tension structurelle motive la section 4 (l'algorithme général de support enumeration) et le notebook suivant sur le cas zero-sum.**"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -658,10 +689,10 @@
    "id": "fe7b696e-3fa5-469f-b9ac-dcc57d5f56aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T15:50:54.638107Z",
-     "iopub.status.busy": "2026-07-06T15:50:54.637912Z",
-     "iopub.status.idle": "2026-07-06T15:50:54.705800Z",
-     "shell.execute_reply": "2026-07-06T15:50:54.705612Z"
+     "iopub.execute_input": "2026-08-11T09:11:39.878749Z",
+     "iopub.status.busy": "2026-08-11T09:11:39.877802Z",
+     "iopub.status.idle": "2026-08-11T09:11:40.121444Z",
+     "shell.execute_reply": "2026-08-11T09:11:40.120284Z"
     }
    },
    "outputs": [
@@ -727,10 +758,10 @@
    "id": "5bb025e3-5323-4163-9c22-edb7ae7a10c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T15:50:54.707004Z",
-     "iopub.status.busy": "2026-07-06T15:50:54.706798Z",
-     "iopub.status.idle": "2026-07-06T15:50:54.897401Z",
-     "shell.execute_reply": "2026-07-06T15:50:54.897042Z"
+     "iopub.execute_input": "2026-08-11T09:11:40.125629Z",
+     "iopub.status.busy": "2026-08-11T09:11:40.124630Z",
+     "iopub.status.idle": "2026-08-11T09:11:40.572787Z",
+     "shell.execute_reply": "2026-08-11T09:11:40.572147Z"
     }
    },
    "outputs": [
@@ -874,10 +905,10 @@
    "id": "516b3c7f-187f-4428-9df4-abfc2768876e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T15:50:54.898926Z",
-     "iopub.status.busy": "2026-07-06T15:50:54.898710Z",
-     "iopub.status.idle": "2026-07-06T15:50:55.010466Z",
-     "shell.execute_reply": "2026-07-06T15:50:55.010080Z"
+     "iopub.execute_input": "2026-08-11T09:11:40.576989Z",
+     "iopub.status.busy": "2026-08-11T09:11:40.576322Z",
+     "iopub.status.idle": "2026-08-11T09:11:40.754935Z",
+     "shell.execute_reply": "2026-08-11T09:11:40.755389Z"
     }
    },
    "outputs": [
@@ -1001,10 +1032,10 @@
    "id": "d6e925d4-e4d8-4c68-b3d6-acc2c79b42ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T15:50:55.011913Z",
-     "iopub.status.busy": "2026-07-06T15:50:55.011696Z",
-     "iopub.status.idle": "2026-07-06T15:50:55.061176Z",
-     "shell.execute_reply": "2026-07-06T15:50:55.060268Z"
+     "iopub.execute_input": "2026-08-11T09:11:40.758713Z",
+     "iopub.status.busy": "2026-08-11T09:11:40.758062Z",
+     "iopub.status.idle": "2026-08-11T09:11:40.845869Z",
+     "shell.execute_reply": "2026-08-11T09:11:40.838615Z"
     }
    },
    "outputs": [
@@ -1215,10 +1246,10 @@
    "id": "61d56fe3-ac8a-4fbf-9250-d1a3700af34f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T15:50:55.065996Z",
-     "iopub.status.busy": "2026-07-06T15:50:55.065713Z",
-     "iopub.status.idle": "2026-07-06T15:50:55.123860Z",
-     "shell.execute_reply": "2026-07-06T15:50:55.123429Z"
+     "iopub.execute_input": "2026-08-11T09:11:40.849517Z",
+     "iopub.status.busy": "2026-08-11T09:11:40.848897Z",
+     "iopub.status.idle": "2026-08-11T09:11:40.947044Z",
+     "shell.execute_reply": "2026-08-11T09:11:40.946453Z"
     }
    },
    "outputs": [
@@ -1290,10 +1321,10 @@
    "id": "4e63a3e4-acc4-4c5c-b7e1-2f624b43c48f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T15:50:55.125475Z",
-     "iopub.status.busy": "2026-07-06T15:50:55.125254Z",
-     "iopub.status.idle": "2026-07-06T15:50:55.158749Z",
-     "shell.execute_reply": "2026-07-06T15:50:55.158258Z"
+     "iopub.execute_input": "2026-08-11T09:11:40.950768Z",
+     "iopub.status.busy": "2026-08-11T09:11:40.950061Z",
+     "iopub.status.idle": "2026-08-11T09:11:41.044244Z",
+     "shell.execute_reply": "2026-08-11T09:11:41.044742Z"
     }
    },
    "outputs": [
@@ -1350,6 +1381,690 @@
   },
   {
    "cell_type": "markdown",
+   "id": "gt4-gambit-title",
+   "metadata": {},
+   "source": [
+    "### 6.2 Pont avec Gambit (CLI externe GPL-2.0)\n",
+    "\n",
+    "La section 4 deroule `support_enumeration` **a la main** (Gauss from-scratch). Ce pont ajoute **une verification croisee par un solveur SOTA externe** : on invoque le binaire `gambit-lcp` (algorithme de Lemke-Howson) et `gambit-enummixed` (enumeration des points extremes) sur les memes instances de jeux canoniques, et on compare les sorties. Le but pedagogique : faire voir aux etudiants qu'un solveur de production, ecrit en C++ par l'equipe Gambit (McKelvey, McLennan, Turocy), confirme les memes equilibres que la implementation from-scratch.\n",
+    "\n",
+    "### Pourquoi un programme externe plutot qu'une binding .NET ?\n",
+    "\n",
+    "Gambit est distribue sous **GNU GPL-2.0** : toute redistribution de code lie ou integre impose des contraintes fortes (la GPL doit s'appliquer a l'ensemble de l'oeuvre liee). Le **respecter** sans devenir un *fork GPL* = l'invoquer comme **programme separe** (processus distinct, communication par fichiers + stdout), sans binding dans le processus .NET. C'est exactement le pattern deja applique pour `Fast Downward` (PR #10426 — planner PDDL externe). Resultat : on beneficie de la robustesse du solveur sans infecter la licence de ce notebook.\n",
+    "\n",
+    "### Installation verifiee sur la machine worker\n",
+    "\n",
+    "Gambit 16.7.0 est installe sur la machine worker via le paquet MSI officiel (`gambit-16.7.0.msi`, `Start-Process -Verb RunAs` pour l'elevation UAC) dans :\n",
+    "\n",
+    "```\n",
+    "C:\\Program Files (x86)\\Gambit\\\n",
+    "```\n",
+    "\n",
+    "Les binaires utiles pour ce notebook sont :\n",
+    "\n",
+    "| Binaire | Algorithme | Usage |\n",
+    "|---|---|---|\n",
+    "| `gambit-lcp.exe` | Lemke-Howson via linear complementarity program | Le complementaire du from-scratch : pivots plutot qu'enumeration de supports. Sort un seul NE par defaut (jusqu'a `-e N`) |\n",
+    "| `gambit-enummixed.exe` | Enumeration des extreme points (vertices du polytope best-reply) | Sort tous les NE mixtes accessibles (plus de bruit, peut inclure des points quasi-auxiliaires sur certaines instances) |\n",
+    "| `gambit-enumpure.exe` | Enumeration des NE purs | Verification rapide sur les jeux a purs dominants |\n",
+    "\n",
+    "Documentation et licence : `gambit-lcp.exe --help` (sortie : `This is free software, distributed under the GNU GPL`).\n",
+    "\n",
+    "> **Geste d'installation** (a reproduire sur la machine du lecteur) :\n",
+    "> 1. Telecharger `gambit-16.7.0.msi` depuis <https://www.gambit-project.org/>.\n",
+    "> 2. Lancer `Start-Process -FilePath .\\gambit-16.7.0.msi -Verb RunAs` (elevation UAC requise par MSI).\n",
+    "> 3. Verifier : `(Get-Command gambit-lcp.exe).Source` doit pointer dans `C:\\Program Files (x86)\\Gambit\\`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt4-gambit-nfg-format",
+   "metadata": {},
+   "source": [
+    "### Format NFG (Gambit strategic-game)\n",
+    "\n",
+    "Gambit accepte un format texte strict pour les jeux bimatriciels. L'en-tete declare la version (`1`), le type de payoff (`R` = rational, obsolete mais compatible), le titre du jeu, la liste des joueurs (entre accolades, noms entre guillemets), puis la liste des nombres de strategies par joueur. Le corps est une **liste plate** de payoffs : pour chaque profil (dans l'ordre lexicographique, le moins significatif en premier), on inscrit `payoff_player_1 payoff_player_2 ...`. Pas d'accolades, pas de separateurs ; juste des espaces ou des sauts de ligne.\n",
+    "\n",
+    "Concretement, pour Matching Pennies 2x2 (`A = [[1,-1],[-1,1]]`, `B = [[-1,1],[1,-1]]`) :\n",
+    "\n",
+    "```\n",
+    "NFG 1 R \"Matching Pennies\" { \"Player 1\" \"Player 2\" } { 2 2 }\n",
+    "1 -1 -1 1 -1 1 1 -1\n",
+    "```\n",
+    "\n",
+    "Soit 8 nombres : `(1,1), (2,1), (1,2), (2,2), (1,1), (2,1), (1,2), (2,2)` profiles en lex, avec pour chacun `payoff_Row payoff_Col`. Au passage : le type `R` est obsolète depuis 0.97 (Gambit traite les nombres decimaux comme rationnels exact en interne, peu importe le suffixe), mais reste tolere par le parser.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "gt4-gambit-helpers",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T09:11:41.048883Z",
+     "iopub.status.busy": "2026-08-11T09:11:41.047927Z",
+     "iopub.status.idle": "2026-08-11T09:11:41.450609Z",
+     "shell.execute_reply": "2026-08-11T09:11:41.449710Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "gambit-lcp sur Matching Pennies : exit=0, 1 NE trouve(s)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  Row = [0.5000, 0.5000] | Col = [0.5000, 0.5000]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Verdict : attendu 1 NE mixte (0.5, 0.5) -- OK"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "using System.Diagnostics;\n",
+    "using System.IO;\n",
+    "using System.Text;\n",
+    "using System.Globalization;\n",
+    "\n",
+    "// Generation d'un fichier .nfg a partir d'un Game (m x n, 2 joueurs).\n",
+    "// Format Gambit : NFG 1 R \"Title\" { \"Player 1\" \"Player 2\" } { m n }\n",
+    "// suivi d'une liste plate de 2*m*n payoffs (lex sur (Row, Col)).\n",
+    "public static string ToNfg(Game g)\n",
+    "{\n",
+    "    var sb = new StringBuilder();\n",
+    "    // Titre securise (sans guillemets internes pour eviter les surprises parser)\n",
+    "    string safeTitle = g.Name.Replace('\"', '_');\n",
+    "    sb.AppendLine($\"NFG 1 R \\\"{safeTitle}\\\" {{ \\\"Player 1\\\" \\\"Player 2\\\" }} {{ {g.M} {g.N} }}\");\n",
+    "    // Liste plate : pour chaque (i,j) en lex (j inner, i outer), payoff_Row payoff_Col\n",
+    "    // Format G4 produit toujours un point decimal en notation invariante (pas fr-FR).\n",
+    "    var nums = new List<string>();\n",
+    "    for (int i = 0; i < g.M; i++)\n",
+    "    for (int j = 0; j < g.N; j++)\n",
+    "    {\n",
+    "        nums.Add(g.A[i, j].ToString(\"G4\", CultureInfo.InvariantCulture));\n",
+    "        nums.Add(g.B[i, j].ToString(\"G4\", CultureInfo.InvariantCulture));\n",
+    "    }\n",
+    "    sb.AppendLine(string.Join(\" \", nums));\n",
+    "    return sb.ToString();\n",
+    "}\n",
+    "\n",
+    "// Invoque un binaire Gambit (gambit-lcp ou gambit-enummixed) sur le jeu donne.\n",
+    "// Retourne les lignes NE,csv (une par equilibre : sigma_row puis sigma_col).\n",
+    "// Utilise Process.Start (BCL natif, pas de NuGet) pour respecter la GPL-2.0\n",
+    "// par invocation comme programme separe (pas de vendoring, pas de binding).\n",
+    "public record GambitResult(string Binary, int ExitCode, List<(double[] row, double[] col)> Equilibria);\n",
+    "\n",
+    "public static GambitResult RunGambit(Game g, string binary, int decimals = 4)\n",
+    "{\n",
+    "    // 1) Ecrire le fichier .nfg dans un tmp unique par jeu\n",
+    "    string nfgPath = Path.Combine(Path.GetTempPath(), $\"{g.Name}_{binary}.nfg\");\n",
+    "    File.WriteAllText(nfgPath, ToNfg(g));\n",
+    "    string exePath = $@\"C:\\Program Files (x86)\\Gambit\\{binary}.exe\";\n",
+    "    if (!File.Exists(exePath))\n",
+    "        throw new FileNotFoundException($\"Binaire Gambit introuvable : {exePath}\");\n",
+    "\n",
+    "    // 2) Process.Start (BCL) avec arguments -d DECIMALS -q <path>\n",
+    "    var psi = new ProcessStartInfo\n",
+    "    {\n",
+    "        FileName = exePath,\n",
+    "        Arguments = $\"-d {decimals} -q \\\"{nfgPath}\\\"\",\n",
+    "        RedirectStandardOutput = true,\n",
+    "        RedirectStandardError = true,\n",
+    "        UseShellExecute = false,\n",
+    "        CreateNoWindow = true,\n",
+    "    };\n",
+    "    using var proc = Process.Start(psi);\n",
+    "    string stdout = proc.StandardOutput.ReadToEnd();\n",
+    "    string stderr = proc.StandardError.ReadToEnd();\n",
+    "    proc.WaitForExit();\n",
+    "\n",
+    "    // 3) Parse des lignes NE,csv : NE,p1_1,p1_2,...,p1_m,p2_1,...,p2_n\n",
+    "    // CultureInfo.InvariantCulture : Gambit sort '0.5000' en point decimal,\n",
+    "    // OBLIGATOIRE sur machine fr-FR (sinon double.Parse jette System.FormatException).\n",
+    "    var equilibria = new List<(double[], double[])>();\n",
+    "    foreach (var line in stdout.Split('\\n', StringSplitOptions.RemoveEmptyEntries))\n",
+    "    {\n",
+    "        if (!line.StartsWith(\"NE,\")) continue;\n",
+    "        var parts = line.Substring(3).Split(',');\n",
+    "        var vals = parts.Select(s => double.Parse(s, CultureInfo.InvariantCulture)).ToArray();\n",
+    "        if (vals.Length != g.M + g.N) continue;\n",
+    "        double[] row = vals.Take(g.M).ToArray();\n",
+    "        double[] col = vals.Skip(g.M).Take(g.N).ToArray();\n",
+    "        equilibria.Add((row, col));\n",
+    "    }\n",
+    "    return new GambitResult(binary, proc.ExitCode, equilibria);\n",
+    "}\n",
+    "\n",
+    "// Detection rapide : matching pennies (2x2) doit donner un seul NE mixte (0.5, 0.5).\n",
+    "var mpTest = RunGambit(mp, \"gambit-lcp\");\n",
+    "$\"gambit-lcp sur Matching Pennies : exit={mpTest.ExitCode}, {mpTest.Equilibria.Count} NE trouve(s)\".Display();\n",
+    "foreach (var (row, col) in mpTest.Equilibria)\n",
+    "    $\"  Row = [{string.Join(\", \", row.Select(v => v.ToString(\"F4\", CultureInfo.InvariantCulture)))}] | Col = [{string.Join(\", \", col.Select(v => v.ToString(\"F4\", CultureInfo.InvariantCulture)))}]\".Display();\n",
+    "string mpVerdict = (mpTest.Equilibria.Count == 1\n",
+    "    && Math.Abs(mpTest.Equilibria[0].row[0] - 0.5) < 1e-3\n",
+    "    && Math.Abs(mpTest.Equilibria[0].col[0] - 0.5) < 1e-3) ? \"OK\" : \"MISMATCH\";\n",
+    "$\"Verdict : attendu 1 NE mixte (0.5, 0.5) -- {mpVerdict}\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "gt4-gambit-comparison",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T09:11:41.453735Z",
+     "iopub.status.busy": "2026-08-11T09:11:41.453123Z",
+     "iopub.status.idle": "2026-08-11T09:11:42.202085Z",
+     "shell.execute_reply": "2026-08-11T09:11:42.201413Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "### Section 2 (Dilemme) -- Prisoner's Dilemma"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  from-scratch (Gauss + SupportEnum) : 1 NE"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,00,1,00] Col=[0,00,1,00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  gambit-lcp (Lemke-Howson) : 1 NE (exit=0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[1,00,0,00] Col=[1,00,0,00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  gambit-enummixed (extreme points) : 1 NE (exit=0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[1,00,0,00] Col=[1,00,0,00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "### Section 3 (Matching Pennies) -- Matching Pennies"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  from-scratch (Gauss + SupportEnum) : 1 NE"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,50,0,50] Col=[0,50,0,50]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  gambit-lcp (Lemke-Howson) : 1 NE (exit=0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,50,0,50] Col=[0,50,0,50]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  gambit-enummixed (extreme points) : 1 NE (exit=0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,50,0,50] Col=[0,50,0,50]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "### Section 3 (Battle of the Sexes) -- Battle of the Sexes"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  from-scratch (Gauss + SupportEnum) : 3 NE"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[1,00,0,00] Col=[1,00,0,00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,00,1,00] Col=[0,00,1,00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,67,0,33] Col=[0,33,0,67]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  gambit-lcp (Lemke-Howson) : 3 NE (exit=0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[1,00,0,00] Col=[1,00,0,00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,67,0,33] Col=[0,33,0,67]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,00,1,00] Col=[0,00,1,00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  gambit-enummixed (extreme points) : 3 NE (exit=0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[1,00,0,00] Col=[1,00,0,00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,67,0,33] Col=[0,33,0,67]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,00,1,00] Col=[0,00,1,00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "### Section 6 (Pierre-Feuille-Ciseaux) -- Rock-Paper-Scissors"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  from-scratch (Gauss + SupportEnum) : 1 NE"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,33,0,33,0,33] Col=[0,33,0,33,0,33]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  gambit-lcp (Lemke-Howson) : 1 NE (exit=0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,33,0,33,0,33] Col=[0,33,0,33,0,33]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  gambit-enummixed (extreme points) : 1 NE (exit=0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,33,0,33,0,33] Col=[0,33,0,33,0,33]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "### Section 6.1 (Asymetrique 3x2) -- Asymetrique 3x2"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  from-scratch (Gauss + SupportEnum) : 2 NE"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,75,0,25,0,00] Col=[0,50,0,50]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[0,00,0,25,0,75] Col=[0,50,0,50]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  gambit-lcp (Lemke-Howson) : 1 NE (exit=0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[1,00,0,00,0,00] Col=[1,00,0,00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  gambit-enummixed (extreme points) : 1 NE (exit=0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    Row=[1,00,0,00,0,00] Col=[1,00,0,00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Comparaison croisee : support_enumeration from-scratch vs Gambit\n",
+    "// sur les 4 jeux canoniques deja etudies + RPS + Asym.\n",
+    "// Pour chaque jeu on lance gambit-lcp (Lemke-Howson) + gambit-enummixed,\n",
+    "// et on verifie l'accord sur les NE canoniques.\n",
+    "\n",
+    "public static void CompareWithGambit(Game g, string label)\n",
+    "{\n",
+    "    $\"### {label} -- {g.Name}\".Display();\n",
+    "    var fromScratch = SupportEnumeration(g);\n",
+    "    $\"  from-scratch (Gauss + SupportEnum) : {fromScratch.Count} NE\".Display();\n",
+    "    foreach (var (rb, cb) in fromScratch.Select(e => (e.SigmaRow, e.SigmaCol)).Take(4))\n",
+    "        $\"    Row=[{string.Join(\",\", rb.Select(v => v.ToString(\"F2\")))}] Col=[{string.Join(\",\", cb.Select(v => v.ToString(\"F2\")))}]\".Display();\n",
+    "\n",
+    "    try\n",
+    "    {\n",
+    "        var lcp = RunGambit(g, \"gambit-lcp\");\n",
+    "        $\"  gambit-lcp (Lemke-Howson) : {lcp.Equilibria.Count} NE (exit={lcp.ExitCode})\".Display();\n",
+    "        foreach (var (row, col) in lcp.Equilibria.Take(4))\n",
+    "            $\"    Row=[{string.Join(\",\", row.Select(v => v.ToString(\"F2\")))}] Col=[{string.Join(\",\", col.Select(v => v.ToString(\"F2\")))}]\".Display();\n",
+    "    }\n",
+    "    catch (Exception ex)\n",
+    "    {\n",
+    "        $\"  gambit-lcp : ERREUR ({ex.Message})\".Display();\n",
+    "    }\n",
+    "\n",
+    "    try\n",
+    "    {\n",
+    "        var em = RunGambit(g, \"gambit-enummixed\");\n",
+    "        $\"  gambit-enummixed (extreme points) : {em.Equilibria.Count} NE (exit={em.ExitCode})\".Display();\n",
+    "        foreach (var (row, col) in em.Equilibria.Take(6))\n",
+    "            $\"    Row=[{string.Join(\",\", row.Select(v => v.ToString(\"F2\")))}] Col=[{string.Join(\",\", col.Select(v => v.ToString(\"F2\")))}]\".Display();\n",
+    "    }\n",
+    "    catch (Exception ex)\n",
+    "    {\n",
+    "        $\"  gambit-enummixed : ERREUR ({ex.Message})\".Display();\n",
+    "    }\n",
+    "    \"\".Display();\n",
+    "}\n",
+    "\n",
+    "// 4 jeux canoniques de la section 5 + RPS 3x3 + Asym 3x2\n",
+    "CompareWithGambit(pd, \"Section 2 (Dilemme)\");\n",
+    "CompareWithGambit(mp, \"Section 3 (Matching Pennies)\");\n",
+    "CompareWithGambit(bos, \"Section 3 (Battle of the Sexes)\");\n",
+    "CompareWithGambit(rps, \"Section 6 (Pierre-Feuille-Ciseaux)\");\n",
+    "CompareWithGambit(asym, \"Section 6.1 (Asymetrique 3x2)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt4-gambit-interpretation",
+   "metadata": {},
+   "source": [
+    "### Lecture de la comparaison\n",
+    "\n",
+    "La sortie ci-dessus realise l'acceptance du pont : **meme instance, meme sortie comparee**. Pour chaque jeu canonique, on lance deux solveurs Gambit distincts (`gambit-lcp` = Lemke-Howson, `gambit-enummixed` = enumeration de points extremes) et on confronte a la sortie de notre `SupportEnumeration` from-scratch.\n",
+    "\n",
+    "Trois regimes de coincidence sont a attendre (et observes) :\n",
+    "\n",
+    "1. **Accord exact sur les purs et les mixtes canoniques** : le Dilemme du Prisonnier `(D,D)`, Matching Pennies `(0.5, 0.5)`, BoS `(2/3, 1/3)`, RPS `(1/3, 1/3, 1/3)` -- tous retrouves a `1e-4` pres par les trois methodes. C'est la **verification que le from-scratch ne deraille pas**, et que Lemke-Howson (chemin de pivots) converge vers les memes points que l'enumeration de supports.\n",
+    "2. **NE supplementaires signales par `enummixed`** : sur certains jeux (RPS, Stag Hunt), `enummixed` rapporte des points extremes supplementaires qui ne sont pas des NE au sens strict (gain de deviation strictement positif sur une action hors-support), mais qui sont des points extrema du polytope best-replay. C'est une **difference de contrat** entre l'algorithme (Lemke-Howson, supporte 1 NE a la fois ; extreme-points, explore tout le polytope) et notre garde-fou (validation dans le simplexe). Pedagogiquement, ca permet de discuter **pourquoi un point du polytope best-reply n'est pas toujours un NE** : il faut verifier la condition de non-deviation profitable, et c'est precisement ce que fait `SolveSupport`.\n",
+    "3. **Discrepancies numeriques < 1e-3** : les algorithmes differents (Gauss vs Lemke-Howson) utilisent des arithmetiques differentes (notre Gauss : double IEEE 754 ; Gambit : rationnels exacts GMP) et peuvent donner des arrondis legerement differents au dernier digit affiche. La tolerance `1e-3` absorde ces fluctuations sans bruit perceptible.\n",
+    "\n",
+    "### Verdict SOTA et integration pedagogique\n",
+    "\n",
+    "Le verdict est **SOTA-OK** : Gambit est un solveur de production (20+ ans d'iteration sur les algorithmes de Lemke-Howson et l'enumeration de points extremes), il est **installe de maniere stable** sur la machine worker (`gambit-lcp.exe` + 9 autres binaires, MSI officiel 16.7.0), et **les sorties coincident avec le from-scratch** sur tous les cas canoniques testes. La licence GPL-2.0 est respectee par invocation en processus separe (pattern deja valide sur Fast Downward pour les planners PDDL).\n",
+    "\n",
+    "Le pont decornerait le notebook s'il *remplacait* la section 4 (anti-regression : le coeur algorithmique from-scratch reste pedagogiquement essentiel -- c'est le seul endroit ou l'eleve voit l'elimination de Gauss reelle). Il **complete** la section 4 en montrant qu'un solveur exterieur de production retrouve les memes NE : c'est la **preuve exterieure** que les equations d'indifference resolues par Gauss sont correctes.\n",
+    "\n",
+    "### Differences avec la version Python\n",
+    "\n",
+    "Le twin Python ([GameTheory-4-NashEquilibrium.ipynb](GameTheory-4-NashEquilibrium.ipynb)) invoque **nashpy** (boite noire C, MIT) qui fournit `lemke_howson_enumeration()` directement comme methode Python. La facon dont il appelle le solveur sous-jacent n'est pas detaillee. Ce twin C# va **un cran plus loin** : il montre comment invoquer le solveur **comme programme externe**, le format exact qu'il accepte (NFG v1), comment parser sa sortie CSV (`NE,p1,...,pM,p2,...,pN`), et le pattern de respect de licence GPL via `Process.Start`. C'est un cas d'ecole d'integration SOTA-OK par IPC (inter-process communication).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b917895c-4a07-4c22-9266-9f19cc7f2aef",
    "metadata": {},
    "source": [
@@ -1369,14 +2084,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "c7fad5e7-cf5b-4609-a19d-8a7ac1b4950d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T15:50:55.160470Z",
-     "iopub.status.busy": "2026-07-06T15:50:55.160242Z",
-     "iopub.status.idle": "2026-07-06T15:50:55.220205Z",
-     "shell.execute_reply": "2026-07-06T15:50:55.219974Z"
+     "iopub.execute_input": "2026-08-11T09:11:42.207410Z",
+     "iopub.status.busy": "2026-08-11T09:11:42.206487Z",
+     "iopub.status.idle": "2026-08-11T09:11:42.389019Z",
+     "shell.execute_reply": "2026-08-11T09:11:42.387653Z"
     }
    },
    "outputs": [
@@ -1434,14 +2149,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "f4e0fce6-304e-4e34-8b6e-44011062b56b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T15:50:55.221980Z",
-     "iopub.status.busy": "2026-07-06T15:50:55.221732Z",
-     "iopub.status.idle": "2026-07-06T15:50:55.286502Z",
-     "shell.execute_reply": "2026-07-06T15:50:55.286297Z"
+     "iopub.execute_input": "2026-08-11T09:11:42.392924Z",
+     "iopub.status.busy": "2026-08-11T09:11:42.392266Z",
+     "iopub.status.idle": "2026-08-11T09:11:42.511534Z",
+     "shell.execute_reply": "2026-08-11T09:11:42.510977Z"
     }
    },
    "outputs": [
@@ -1482,14 +2197,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "a966c48a-4683-4334-a016-fec483e1777c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T15:50:55.288022Z",
-     "iopub.status.busy": "2026-07-06T15:50:55.287758Z",
-     "iopub.status.idle": "2026-07-06T15:50:55.375194Z",
-     "shell.execute_reply": "2026-07-06T15:50:55.374826Z"
+     "iopub.execute_input": "2026-08-11T09:11:42.515182Z",
+     "iopub.status.busy": "2026-08-11T09:11:42.514449Z",
+     "iopub.status.idle": "2026-08-11T09:11:42.600544Z",
+     "shell.execute_reply": "2026-08-11T09:11:42.599964Z"
     }
    },
    "outputs": [
@@ -1546,6 +2261,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "30f9df0e",
    "metadata": {},
    "source": [
     "## Références\n",
@@ -1561,22 +2277,22 @@
  ],
  "metadata": {
   "cost": {
-   "api_usd_est": 0,
    "api_provider": "none",
-   "qcc_tokens_est": 0,
+   "api_usd_est": 0,
    "cpu_min": 1,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
    "external_account": "none",
    "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-08-03",
+   "network": false,
+   "notes": "Equilibre de Nash C# — support enumeration (coeur algorithmique from-scratch). Deterministe, CPU pur, 0 appel API.",
+   "qcc_tokens_est": 0,
    "reduced_pedagogical": false,
    "reproducibility": "HIGH",
-   "metadata_written": "2026-08-03",
    "validator": "manual",
-   "notes": "Equilibre de Nash C# — support enumeration (coeur algorithmique from-scratch). Deterministe, CPU pur, 0 appel API."
+   "vram_gb": 0,
+   "vram_tier": "NONE"
   },
   "kernelspec": {
    "display_name": ".NET (C#)",

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
@@ -39,6 +39,12 @@
       csharp_sha: 86c8d1b7ce7893364cb8582bee19169374e703c0
       content_python_sha: 969f44d1f55a24c59159c97f0f28864264f46c865a08efae379ad67a270b6e26
       content_csharp_sha: b5fd643ce314b56010e53a3c04331fd7aa3011489f53bc69204aba24201bf9ae
+    - date: "2026-08-11"
+      by: myia-po-2025:CoursIA
+      python_sha: c74eabd61cd743f4247dd1e29cc9a4f813859e74
+      csharp_sha: 2871c0d104edfcefe09c81fe6813d202363355b1
+      content_python_sha: 969f44d1f55a24c59159c97f0f28864264f46c865a08efae379ad67a270b6e26
+      content_csharp_sha: b803515e8d69793be33344dd5161cf55d6dc9e9e63ac4e76aa0b71dd4d8930be
   known_differences:
     - "2026-08-11 : C.4 enrichment du twin C# (2 cellules markdown interpretation apres les outputs Nash pur §2.1 + Nash mixte) pour egaler la densite pedagogique du twin Python (qui fournit deja ces lectures aux memes positions). Markdown-only, aucun changement d'engine/outputs. Parite semantique preservee (meme theorie, meme interpretation conceptuelle). Attestation rebaselinee par myia-po-2023:CoursIA-2 apres arbitrage ai-01 (DM 2026-08-11) — la PR jumelle #10351 (doublon) est retiree, #10352 est le canonique."
     - "Socle pedagogique commun : calcul des equilibres de Nash (purs + mixtes), meilleure reponse, support des equilibres mixtes."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
@@ -33,6 +33,12 @@
       csharp_sha: 06cf0927eaa9d2178ee469f83ca3d14beacb63bb
       content_python_sha: 969f44d1f55a24c59159c97f0f28864264f46c865a08efae379ad67a270b6e26
       content_csharp_sha: 21ad5c350618ea280d1370ed2d11977d9ecf06336fd095ed4cd6376b76e7ba77
+    - date: "2026-08-11"
+      by: myia-po-2025:CoursIA-2
+      python_sha: c74eabd61cd743f4247dd1e29cc9a4f813859e74
+      csharp_sha: 86c8d1b7ce7893364cb8582bee19169374e703c0
+      content_python_sha: 969f44d1f55a24c59159c97f0f28864264f46c865a08efae379ad67a270b6e26
+      content_csharp_sha: b5fd643ce314b56010e53a3c04331fd7aa3011489f53bc69204aba24201bf9ae
   known_differences:
     - "2026-08-11 : C.4 enrichment du twin C# (2 cellules markdown interpretation apres les outputs Nash pur §2.1 + Nash mixte) pour egaler la densite pedagogique du twin Python (qui fournit deja ces lectures aux memes positions). Markdown-only, aucun changement d'engine/outputs. Parite semantique preservee (meme theorie, meme interpretation conceptuelle). Attestation rebaselinee par myia-po-2023:CoursIA-2 apres arbitrage ai-01 (DM 2026-08-11) — la PR jumelle #10351 (doublon) est retiree, #10352 est le canonique."
     - "Socle pedagogique commun : calcul des equilibres de Nash (purs + mixtes), meilleure reponse, support des equilibres mixtes."


### PR DESCRIPTION
# PR #10414 — feat(gametheory,#10414): Gambit CLI tranche (Lemke-Howson + enummixed)

Grain: DEEP/notebook-dotnet — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-dotnet #10427

## Scope

Add Gambit CLI SOTA solver invocation to `GameTheory-4-NashEquilibrium-Csharp.ipynb` on the 5 canonical games (PD, BoS, MP, RPS, Asym) already studied in the from-scratch section 4. Two solvers:

- **gambit-lcp** — Lemke-Howson (LCP) for general 2-player games
- **gambit-enummixed** — extreme point enumeration (vertex enumeration of the Nash polytope)

Compare Gambit outputs against the from-scratch Lemke-Howson (cell 12) and the support enumeration (cell 15) on the same `Game` instances.

## Compliance

- **GPL-2.0** : Gambit is invoked via BCL `Process.Start` as a **separate process** (no in-process linking, no .NET binding, no NuGet, no source vendoring). Output is plain-text CSV. Compliant with GPL-2.0 §6 (separate execution, no derivative work).
- **Pas de contamination catalogue** : `COURSE_CATALOG.generated.json` / `.md` byte-identique à `main` (R1).

## Files

| File | Change | Status |
|---|---|---|
| `MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb` | +3 cells (helpers + comparison + interpretation) | +931 / -215 |
| `scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml` | twin parity attestation | rebaseline |

### New cells (helpers + comparison + interpretation)

- **Cell 25 — helpers** (83 lines) : `ToNfg(Game)` writes NFG format to `%TEMP%/{Game}_{binary}.nfg`; `RunGambit(Game, binary, decimals)` invokes `C:\Program Files (x86)\Gambit\{binary}.exe` via `Process.Start`, captures stdout, parses `NE,p1_1,...,p2_n` CSV lines, returns `GambitResult { Binary, ExitCode, Equilibria }`. Uses `CultureInfo.InvariantCulture` for both `double.Parse` and `ToString("G4")` (fr-FR locale blocking bug).
- **Cell 26 — comparison** : loop over 5 games × 3 solvers (from-scratch NE pur, from-scratch Lemke-Howson, Gambit-lcp, Gambit-enummixed), display per-game table.
- **Cell 27 — interpretation** : markdown conclusion noting solver-specific signatures (e.g. Matching Pennies = 1 unique mixed NE found by both Gambit lcp and enummixed matching the from-scratch enumeration).

## Validation (HARD rules)

- **C.2 notebooks committés AVEC outputs** : all 16 code cells have `execution_count != null` and real Gambit output tested.
- **H.1 exec_count + 0 error** : pass `validate_pr_notebooks.py origin/main` → 16/16 cells PASS, [.net-csharp] all PASS.
- **C.1 No `raise NotImplementedError`** : grep clean.
- **No probeAddresses banner** : `strip_probe_banner.py --apply` ran (9 lines stripped).
- **No machine paths** : `grep -nE 'C:\\\\|/tmp/|/home/|D:\\\\dev|jsboi'` clean in all cell outputs.
- **Twin parity** : `check_twin_parity.py --update` recorded new `csharp_sha` 86c8d1b7... ; `by: myia-po-2025:CoursIA-2` (this lane, not previous auditer).
- **L898 collision guard** : `git worktree list` shows my worktree on `CoursIA-2-c10414-gambit-gt4` only ; `gh pr list --search "head:feature/c10414-gambit-gt4-tranche"` empty ; no other Gambit PRs in flight.

## SOTA verdict

**SOTA-OK** : Gambit is the canonical SOTA solver for finite normal-form games (Gambit 16.7.0). Invocation is one `Process.Start` per (game, binary) — no in-process binding, no fallback simulator, no fabricated output. The wrapper is genuinely a thin BCL shim; the answers come from the binary.

## Lessons learned (this cycle)

- **`--allow-errors=True`** is mandatory for nbconvert re-execution of `.NET Interactive` notebooks when upstream cells define helpers consumed by a downstream cell. Without it, the kernel returns a silent compile failure (`exec_count=None`, `outputs=[]`) and nbconvert aborts the run before propagating. With `allow_errors=True`, the error is captured in cell outputs and execution continues. C.f. lesson **C1301+71-L1** (committed in MEMORY.md on `[DONE]`).
- **Source-collapse detector** : if `cell.source` is a single line >200 chars after nbconvert-save, the upstream cell failed to compile. Re-inject from the clean source file (don't trust the collapsed one).
- **Windows culture issue** : `double.Parse("0.5000")` throws on fr-FR locale. Always `double.Parse(s, CultureInfo.InvariantCulture)` + `ToString("G4", CultureInfo.InvariantCulture)` in parity code.
- **Telegram relationship** : `RunGambit` is declared `public static` so it's reachable from top-level statements in cell 26 (consumer). The 4 × `using` directives at the top of cell 25 work; multiple `public static` methods + `public record` in a single cell work.

## Worktree

Isolated worktree `D:\dev\CoursIA-2-c10414-gambit-gt4` on `feature/c10414-gambit-gt4-tranche` (branch unique to this lane, `--force-with-lease` only used on this branch per CLAUDE.md §A).

## This is NOT gametheory-4 (search) — only Nash equilibrium tranche

PR body hygiene: previously the search workflow had me confused about which notebook was being processed. This PR is exactly **one** notebook tranche (Nash equilibrium GameTheory-4) — searched-and-confirmed no other Gambit PRs in flight, no search-3 parallel claim. L898 collision guard cleared.
