### PR TITLE
fix(argument-analysis,#10399): restore newlines in Argumentum_Cards exercise markdown

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Argumentum_Cards.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Argumentum_Cards.ipynb
@@ -482,7 +482,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## 7.1. Exercice — compter les cartes par profondeur**Objectif** : la sélection « carte » n'est pas une couche unique de la taxonomie. Produisezun décompte des cartes par niveau de profondeur (`depth`) pour montrer la **granularitéhiérarchique** de la sélection — c'est exactement la structure que le PostTraining (Phase 2)doit exposer à un modèle de raisonnement pour qu'il sache qu'une carte profondeur 1 et unecarte profondeur 4 ne représentent pas le même niveau de généralité.**Indice** : la colonne `depth` du CSV est une chaîne de caractères ; pensez à la convertiren entier avant le décompte. `collections.Counter` est votre ami.# Indice : commencez par filtrer les cartes (carte=1), extrayez la colonne depth, comptez.# Etape 1 : créer une liste d'entiers depuis r['depth'] pour chaque carte.# Etape 2 : utiliser Counter() pour compter les occurrences par profondeur."
+    "## 7.1. Exercice — compter les cartes par profondeur\n",
+    "\n",
+    "**Objectif** : la sélection « carte » n'est pas une couche unique de la taxonomie. Produisez un décompte des cartes par niveau de profondeur (`depth`) pour montrer la **granularité hiérarchique** de la sélection — c'est exactement la structure que le PostTraining (Phase 2) doit exposer à un modèle de raisonnement pour qu'il sache qu'une carte profondeur 1 et une carte profondeur 4 ne représentent pas le même niveau de généralité.\n",
+    "\n",
+    "**Indice** : la colonne `depth` du CSV est une chaîne de caractères ; pensez à la convertir en entier avant le décompte. `collections.Counter` est votre ami.\n",
+    "\n",
+    "# Indice : commencez par filtrer les cartes (carte=1), extrayez la colonne depth, comptez.\n",
+    "# Etape 1 : créer une liste d'entiers depuis r['depth'] pour chaque carte.\n",
+    "# Etape 2 : utiliser Counter() pour compter les occurrences par profondeur.\n"
    ]
   },
   {
@@ -526,7 +534,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## 7.2. Exercice — remonter d'un sophisme feuille vers sa carte ancêtre**Objectif** : l'inverse de l'exercice 5 (cellule 4 — *la carte ouvre un sous-arbre*). Leworkflow descendant « carte → enfants → sophismes spécifiques » est ce que la cellule 9illustre déjà via `afficher_sous_arbre`. La **remontée** « sophisme feuille → carteancêtre » est l'opération symétrique dont la Phase 4 aura besoin pour transformer unedétection en *contexte* : étant donné un sophisme identifié en bout de chaîne, on remonteà la carte qui l'a *catégorisé*, et c'est la carte qui devient l'unité pédagogique.**Indice** : un path est une chaîne de segments séparés par des points (ex. `1.3.2.1`).Le parent d'un nœud est ce path privé de son dernier segment. La carte ancêtre est lepremier ancêtre dont le path figure dans la sélection `cards`.# Indice : remonter iterativement d'un cran (parent = path.rsplit('.', 1)[0]).# Etape 1 : definir path_parent(p) qui retourne le parent ou '' si plus de parent.# Etape 2 : remonter en boucle jusqu'à trouver un path dans cards (set des paths cartes).# Etape 3 : retourner la ligne de taxonomie correspondante, ou None si pas d'ancêtre carte."
+    "## 7.2. Exercice — remonter d'un sophisme feuille vers sa carte ancêtre\n",
+    "\n",
+    "**Objectif** : l'inverse de l'exercice 5 (cellule 4 — *la carte ouvre un sous-arbre*). Le workflow descendant « carte → enfants → sophismes spécifiques » est ce que la cellule 9 illustre déjà via `afficher_sous_arbre`. La **remontée** « sophisme feuille → carte ancêtre » est l'opération symétrique dont la Phase 4 aura besoin pour transformer une détection en *contexte* : étant donné un sophisme identifié en bout de chaîne, on remonte à la carte qui l'a *catégorisé*, et c'est la carte qui devient l'unité pédagogique.\n",
+    "\n",
+    "**Indice** : un path est une chaîne de segments séparés par des points (ex. `1.3.2.1`). Le parent d'un nœud est ce path privé de son dernier segment. La carte ancêtre est le premier ancêtre dont le path figure dans la sélection `cards`.\n",
+    "\n",
+    "# Indice : remonter iterativement d'un cran (parent = path.rsplit('.', 1)[0]).\n",
+    "# Etape 1 : definir path_parent(p) qui retourne le parent ou '' si plus de parent.\n",
+    "# Etape 2 : remonter en boucle jusqu'à trouver un path dans cards (set des paths cartes).\n",
+    "# Etape 3 : retourner la ligne de taxonomie correspondante, ou None si pas d'ancêtre carte.\n"
    ]
   },
   {
@@ -568,7 +585,19 @@
    "id": "4a929ad3",
    "metadata": {},
    "source": [
-    "## 8. Conclusion et ponts- **Une carte = une ligne de taxonomie** : le rendu est mécanique, reproductible, bilingue.  Aucune information n'est inventée — tout provient du CSV canonique.- **176 cartes sur 1408 nœuds** (12,5 %), réparties sur 7 familles, ~25 par famille.- **La carte est un nœud interne** : elle ouvre un sous-arbre de sophismes spécifiques.  C'est cette structure hiérarchique que le PostTraining (EPIC #10355) exploitera comme workflow.**Ponts avec la série** :- [`Argument_Analysis_Ontology_CrossLinks.ipynb`](Argument_Analysis_Ontology_CrossLinks.ipynb) —  la taxonomie entière (1408 nœuds), sa structure, ses liens transverses.- [`Argument_Analysis_ArgumentProfile.ipynb`](Argument_Analysis_ArgumentProfile.ipynb) —  le profil multidimensionnel d'un argument dans un débat (5 dimensions, dont les sophismes).- EPIC **#10355** — fallacy detection via Qwen3.5/3.6 FT+PT : ce notebook fournit le rendu  de référence de la *golden answer* pour le jeu de données de fine-tuning.*Données : Argumentum taxonomy (bilingue, 1408 nœuds). Notebook exécutable sans API ni clé.*"
+    "## 8. Conclusion et ponts\n",
+    "\n",
+    "- **Une carte = une ligne de taxonomie** : le rendu est mécanique, reproductible, bilingue. Aucune information n'est inventée — tout provient du CSV canonique.\n",
+    "- **176 cartes sur 1408 nœuds** (12,5 %), réparties sur 7 familles, ~25 par famille.\n",
+    "- **La carte est un nœud interne** : elle ouvre un sous-arbre de sophismes spécifiques. C'est cette structure hiérarchique que le PostTraining (EPIC #10355) exploitera comme workflow.\n",
+    "\n",
+    "**Ponts avec la série** :\n",
+    "\n",
+    "- [`Argument_Analysis_Ontology_CrossLinks.ipynb`](Argument_Analysis_Ontology_CrossLinks.ipynb) — la taxonomie entière (1408 nœuds), sa structure, ses liens transverses.\n",
+    "- [`Argument_Analysis_ArgumentProfile.ipynb`](Argument_Analysis_ArgumentProfile.ipynb) — le profil multidimensionnel d'un argument dans un débat (5 dimensions, dont les sophismes).\n",
+    "- EPIC **#10355** — fallacy detection via Qwen3.5/3.6 FT+PT : ce notebook fournit le rendu de référence de la *golden answer* pour le jeu de données de fine-tuning.\n",
+    "\n",
+    "*Données : Argumentum taxonomy (bilingue, 1408 nœuds). Notebook exécutable sans API ni clé.*\n"
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-correctness — lane myia-po-2025:CoursIA — prev: MED/guard

## Fix the collapsed-markdown rendering in Argumentum_Cards exercises (cells 12/15/18)

The 3 exercise cells added to `Argument_Analysis_Argumentum_Cards.ipynb` on this
branch (commit `f00386b61`) shipped with their markdown `source` collapsed into a
single-element list with 0 `\n` — a newline-stripping artifact. The whole cell
content (heading + `**Objectif**` + list items + `# Etape N` hints) rendered as
ONE giant H2 heading, with words glued where the stripped newlines carried no
trailing space.

This is the formatting defect the user flagged in Playwright on commit
`ac5855780`.

## Bug (firsthand, G.1)

| cell | len | elems | `\n` | rendered as |
|------|-----|-------|------|-------------|
| 12 | 876 | 1 | 0 | one H2 `7.1. Exercice — compter les cartes par profondeurObjectif : ...` |
| 15 | 1161 | 1 | 0 | one H2 `7.2. Exercice — remonter d'un sophisme feuille vers sa carte ancêtreObjectif : ...` |
| 18 | 1085 | 1 | 0 | one H2 `8. Conclusion et ponts- Une carte = une ligne de taxonomie : ...` |

Glued words (newlines lost mid-phrase): `profondeur**Objectif**`, `Produisezun`,
`granularitéhiérarchique`, `(Phase 2)doit`, `carteancêtre`, `remonteà`,
`## Références### Papiers fondateurs`.

## Fix (markdown-only, C.2 exception)

Reconstructed the proper multi-line `source` for each cell — split on the logical
line boundaries revealed by the glued words, restored the blank lines between
heading / **Objectif** / **Indice** / hint blocks, un-glued the words. Surgical
raw-text replacement (not `json.dump`): only the 3 `source` fields move, every
other byte stays identical (+32/-3, 1 file).

**No code change, no output change** → markdown-only (C.2 exception), **no
re-execution needed** (re-executing risks output drift).

## Proof (firsthand, G.1)

- Diff: **+32/-3**, 1 file, exactly the 3 source fields (no CRLF churn).
- `detect_markdown_rendering.py` (with PR #10446): `source_list_missing_newlines`
  **0** on the fixed notebook (was 3 ERROR). Only 2 pre-existing
  `oversized_hint` WARN remain (the `# Etape N` hint convention, author style,
  out of scope).
- HTML render (`jupyter nbconvert --to html`):
  - cell 12 → `<h2>7.1. Exercice — compter les cartes par profondeur</h2>` then
    `<p><strong>Objectif</strong> : ...</p>` (heading isolated from body).
  - cell 18 → `<h2>8. Conclusion et ponts</h2>` then `<ul><li>...` (list items
    render as a list, not glued into the heading).
  - All 4 glued-word markers **absent** from the rendered HTML.

## Out of scope (flagged, not fixed)

The notebook's markdown cells carry spurious `execution_count` + `outputs`
fields (a schema artifact from the tool that created the exercises —
`nbformat.validate` rejects them). This does NOT affect rendering and is NOT
touched here; a separate cleanup can strip them if desired.

## Related

- PR #10446 — the CI guard extension (`source_list_missing_newlines` single-element
  case) that now catches this defect class for every future PR.
- See #10399 (this branch's PR), #10397 (the guard blind-spot issue), EPIC #10355.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
