### PR TITLE
feat(search,#10382): App-13b TSP Tranche 2 OR-Tools routing solver -- parite native-both

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13b-TSP-Metaheuristics-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13b-TSP-Metaheuristics-CSharp.ipynb
@@ -68,10 +68,10 @@
    "id": "c4295fbd-233b-48b4-a869-fb9514f084b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T11:51:56.422010Z",
-     "iopub.status.busy": "2026-07-06T11:51:56.416996Z",
-     "iopub.status.idle": "2026-07-06T11:51:58.153456Z",
-     "shell.execute_reply": "2026-07-06T11:51:58.150021Z"
+     "iopub.execute_input": "2026-08-11T10:46:44.674228Z",
+     "iopub.status.busy": "2026-08-11T10:46:44.668412Z",
+     "iopub.status.idle": "2026-08-11T10:46:46.549565Z",
+     "shell.execute_reply": "2026-08-11T10:46:46.546673Z"
     },
     "papermill": {
      "duration": 1.743975,
@@ -83,6 +83,121 @@
     "tags": []
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-69280.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '69280.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "data": {
       "text/plain": [
@@ -238,10 +353,10 @@
    "id": "91b4f7c3-f94c-44c6-b2c4-9ac3cf4d5a7a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T11:51:58.165900Z",
-     "iopub.status.busy": "2026-07-06T11:51:58.165625Z",
-     "iopub.status.idle": "2026-07-06T11:51:58.297789Z",
-     "shell.execute_reply": "2026-07-06T11:51:58.297592Z"
+     "iopub.execute_input": "2026-08-11T10:46:46.551239Z",
+     "iopub.status.busy": "2026-08-11T10:46:46.551030Z",
+     "iopub.status.idle": "2026-08-11T10:46:46.674937Z",
+     "shell.execute_reply": "2026-08-11T10:46:46.674730Z"
     },
     "papermill": {
      "duration": 0.136724,
@@ -256,7 +371,7 @@
     {
      "data": {
       "text/plain": [
-       "Force brute N=8 : optimum = 293.19 en 1.2 ms (5,040 = 7! permutations testees)."
+       "Force brute N=8 : optimum = 293.19 en 1.0 ms (5,040 = 7! permutations testees)."
       ]
      },
      "metadata": {},
@@ -339,10 +454,10 @@
    "id": "57a0573f-f033-43ff-ad7e-669b97cae264",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T11:51:58.308587Z",
-     "iopub.status.busy": "2026-07-06T11:51:58.308411Z",
-     "iopub.status.idle": "2026-07-06T11:51:58.349382Z",
-     "shell.execute_reply": "2026-07-06T11:51:58.349275Z"
+     "iopub.execute_input": "2026-08-11T10:46:46.676492Z",
+     "iopub.status.busy": "2026-08-11T10:46:46.676252Z",
+     "iopub.status.idle": "2026-08-11T10:46:46.733997Z",
+     "shell.execute_reply": "2026-08-11T10:46:46.733768Z"
     },
     "papermill": {
      "duration": 0.044362,
@@ -418,10 +533,10 @@
    "id": "28f18de6-1d18-4cbd-9483-2df2163d66bc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T11:51:58.359985Z",
-     "iopub.status.busy": "2026-07-06T11:51:58.359807Z",
-     "iopub.status.idle": "2026-07-06T11:51:58.406373Z",
-     "shell.execute_reply": "2026-07-06T11:51:58.406245Z"
+     "iopub.execute_input": "2026-08-11T10:46:46.735406Z",
+     "iopub.status.busy": "2026-08-11T10:46:46.735182Z",
+     "iopub.status.idle": "2026-08-11T10:46:46.788465Z",
+     "shell.execute_reply": "2026-08-11T10:46:46.788229Z"
     },
     "papermill": {
      "duration": 0.049903,
@@ -507,10 +622,10 @@
    "id": "0415d578-1b00-406c-af37-d8df4c81504e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T11:51:58.418535Z",
-     "iopub.status.busy": "2026-07-06T11:51:58.418346Z",
-     "iopub.status.idle": "2026-07-06T11:51:58.458378Z",
-     "shell.execute_reply": "2026-07-06T11:51:58.458218Z"
+     "iopub.execute_input": "2026-08-11T10:46:46.790196Z",
+     "iopub.status.busy": "2026-08-11T10:46:46.789916Z",
+     "iopub.status.idle": "2026-08-11T10:46:46.843213Z",
+     "shell.execute_reply": "2026-08-11T10:46:46.842973Z"
     },
     "papermill": {
      "duration": 0.044114,
@@ -587,10 +702,10 @@
    "id": "92ae3d30-47a7-4ca8-997d-ea8688fa6916",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T11:51:58.469276Z",
-     "iopub.status.busy": "2026-07-06T11:51:58.469109Z",
-     "iopub.status.idle": "2026-07-06T11:51:58.607627Z",
-     "shell.execute_reply": "2026-07-06T11:51:58.607507Z"
+     "iopub.execute_input": "2026-08-11T10:46:46.844731Z",
+     "iopub.status.busy": "2026-08-11T10:46:46.844515Z",
+     "iopub.status.idle": "2026-08-11T10:46:47.149118Z",
+     "shell.execute_reply": "2026-08-11T10:46:47.148629Z"
     },
     "papermill": {
      "duration": 0.141802,
@@ -603,121 +718,121 @@
    },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/plain": [
        "    N |   brut(opt) |          NN |       2-opt |   SA (3 seeds: mean) |   gap NN |  gap 2opt |   gap SA | SA vs 2-opt"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
       "text/plain": [
        "------------------------------------------------------------------------------------------------------"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
       "text/plain": [
        "    6 |      278.24 |      328.09 |      278.24 |    278.24 (3 seeds) |    17.9% |      0.0% |    -0.0% |        0.0%"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
       "text/plain": [
        "    8 |      293.19 |      344.77 |      293.19 |    293.19 (3 seeds) |    17.6% |      0.0% |    -0.0% |        0.0%"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
       "text/plain": [
        "   10 |      314.41 |      365.98 |      314.41 |    314.41 (3 seeds) |    16.4% |      0.0% |    -0.0% |        0.0%"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
       "text/plain": [
        "   30 |       (N/A) |      554.61 |      475.12 |    461.97 (3 seeds) |    (n/a) |     (n/a) |    (n/a) |        2.8%"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
       "text/plain": [
        "   60 |       (N/A) |      780.76 |      638.90 |    630.98 (3 seeds) |    (n/a) |     (n/a) |    (n/a) |        1.2%"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
       "text/plain": [
        "  100 |       (N/A) |      940.91 |      803.45 |    792.55 (3 seeds) |    (n/a) |     (n/a) |    (n/a) |        1.4%"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
       "text/plain": [
        "Interpretation : NN est rapide mais sous-optimal (gap ~16-22%). Pour N<=10, 2-opt et SA"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
       "text/plain": [
        "atteignent l'optimum exact (gap 0.0% - instance trop petite pour discriminer). Pour N>=30,"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
       "text/plain": [
        "2-opt reste bloque sur un optimum local ; SA (refroidissement lent, 3 seeds) l'ameliore de ~1-4%"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
       "text/plain": [
        "(colonne 'SA vs 2-opt' > 0) : c'est la valeur ajoutee de la metaheuristique. Au-dela de N=10,"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
       "text/plain": [
        "la force brute est infaisable (OR-Tools dans le twin Python donne la reference industrielle)."
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -750,7 +865,7 @@
     "Show(\"atteignent l'optimum exact (gap 0.0% - instance trop petite pour discriminer). Pour N>=30,\");\n",
     "Show(\"2-opt reste bloque sur un optimum local ; SA (refroidissement lent, 3 seeds) l'ameliore de ~1-4%\");\n",
     "Show(\"(colonne 'SA vs 2-opt' > 0) : c'est la valeur ajoutee de la metaheuristique. Au-dela de N=10,\");\n",
-    "Show(\"la force brute est infaisable (OR-Tools dans le twin Python donne la reference industrielle)."
+    "Show(\"la force brute est infaisable (OR-Tools dans le twin Python donne la reference industrielle).\");"
    ]
   },
   {
@@ -785,10 +900,10 @@
    "id": "2e6af927-59b4-4ad5-9aca-4a979e863656",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T11:51:58.620638Z",
-     "iopub.status.busy": "2026-07-06T11:51:58.620473Z",
-     "iopub.status.idle": "2026-07-06T11:51:58.645971Z",
-     "shell.execute_reply": "2026-07-06T11:51:58.646059Z"
+     "iopub.execute_input": "2026-08-11T10:46:47.150642Z",
+     "iopub.status.busy": "2026-08-11T10:46:47.150415Z",
+     "iopub.status.idle": "2026-08-11T10:46:47.196667Z",
+     "shell.execute_reply": "2026-08-11T10:46:47.196416Z"
     },
     "papermill": {
      "duration": 0.029726,
@@ -816,6 +931,314 @@
   },
   {
    "cell_type": "markdown",
+   "execution_count": null,
+   "id": "tr2-app13-intro",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Tranche 2 : moteur industriel OR-Tools (lib-vs-lib, #10382)\n",
+    "\n",
+    "Le twin Python `App-13-TSP-Metaheuristics.ipynb` appelle le **moteur industriel OR-Tools**\n",
+    "(`ortools.constraint_solver.routing`, `RoutingModel`) comme **r\u00e9f\u00e9rence** l\u00e0 o\u00f9 la force brute\n",
+    "devient infaisable (N>10). La Tranche 1 from-scratch ci-dessus (force brute, plus proche voisin,\n",
+    "2-opt, recuit simul\u00e9) est **pr\u00e9serv\u00e9e intacte** : on lui confronte maintenant le **m\u00eame moteur de\n",
+    "production** que le jumeau Python \u2014 **Google.OrTools 9.11** (Perron & Furney ; solveur de routage\n",
+    "avec recherche locale guid\u00e9e GLS).\n",
+    "\n",
+    "**Honn\u00eatet\u00e9 cruciale** : le solveur de routage est une **m\u00e9taheuristique** (recherche locale guid\u00e9e),\n",
+    "PAS un solveur exact \u2014 il ne d\u00e9livre **aucun certificat d'optimalit\u00e9**, contrairement \u00e0 CP-SAT.\n",
+    "C'est un **paradigme diff\u00e9rent** : l\u00e0 o\u00f9 CP-SAT (App-5, App-11) prouve l'optimum via SAT + Lazy\n",
+    "Clause Generation, le routing solver **explore** l'espace des tourn\u00e9es avec des op\u00e9rateurs de\n",
+    "recherche locale. Sa valeur est la **qualit\u00e9 industrielle sur grandes instances**, pas la garantie."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "tr2-app13-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T10:46:47.198358Z",
+     "iopub.status.busy": "2026-08-11T10:46:47.198102Z",
+     "iopub.status.idle": "2026-08-11T10:46:59.767555Z",
+     "shell.execute_reply": "2026-08-11T10:46:59.767088Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Google.OrTools, 9.11.4210</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "--- Tranche 2 : OR-Tools routing solver (Google.OrTools 9.11) ---"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Miroir C# de ortools_tsp (twin Python). RoutingModel = metaheuristique GLS,"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "PAS solveur exact : aucune garantie d'optimalite (contrairement a CP-SAT)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Parite (routing vs force brute, small N) :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    N |    brut(opt) |     routing | parite | routing ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   6 |       278.24 |      278.24 |     OK | 1013"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "   8 |       293.19 |      293.19 |     OK | 1001"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  10 |       314.41 |      314.41 |     OK | 1001"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Prong-B : reference industrielle (force brute infaisable pour N>10) :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    N |          NN |       2-opt |     SA (mean) |     routing | routing vs SA"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  30 |      554.61 |      475.12 |   461.97 (3s) |     461.87 |        0.0%"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  60 |      780.76 |      638.90 |   630.98 (3s) |     617.78 |        2.1%"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       " 100 |      940.91 |      803.45 |   792.55 (3s) |     750.22 |        5.3%"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "routing (GLS, moteur industriel) >= SA sur grandes instances : il combine recherche"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "locale guidee multi-operateur + premiere solution chemin-cout-min. Aucun code TSP"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "dedie cote utilisateur : toute la logique vit dans le moteur Google, comme en Python."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#r \"nuget: Google.OrTools, 9.11.4210\"\n",
+    "using Google.OrTools.ConstraintSolver;\n",
+    "using System.Diagnostics;\n",
+    "\n",
+    "// SolveRouting : miroir C# de ortools_tsp (Python pywrapcp.RoutingModel).\n",
+    "// RoutingModel = metaheuristique (recherche locale guidee GLS), PAS solveur exact.\n",
+    "(int[] tour, double cost, double ms) SolveRouting(TSPInstance tsp, int timeLimitS = 2) {\n",
+    "    var manager = new RoutingIndexManager(tsp.N, 1, 0);\n",
+    "    var routing = new RoutingModel(manager);\n",
+    "    long transitCallback(long fromIdx, long toIdx) {\n",
+    "        int f = manager.IndexToNode(fromIdx), too = manager.IndexToNode(toIdx);\n",
+    "        return (long)(tsp.D[f][too] * 1000);   // scale floats -> long (miroir Python *1000)\n",
+    "    }\n",
+    "    int transitIdx = routing.RegisterTransitCallback(transitCallback);\n",
+    "    routing.SetArcCostEvaluatorOfAllVehicles(transitIdx);\n",
+    "    var sp = operations_research_constraint_solver.DefaultRoutingSearchParameters();\n",
+    "    sp.FirstSolutionStrategy = FirstSolutionStrategy.Types.Value.PathCheapestArc;\n",
+    "    sp.LocalSearchMetaheuristic = LocalSearchMetaheuristic.Types.Value.GuidedLocalSearch;\n",
+    "    sp.TimeLimit = new Google.Protobuf.WellKnownTypes.Duration { Seconds = (long)timeLimitS };\n",
+    "    var sw = Stopwatch.StartNew();\n",
+    "    var sol = routing.SolveWithParameters(sp);\n",
+    "    sw.Stop();\n",
+    "    if (sol != null) {\n",
+    "        var tour = new List<int>();\n",
+    "        long idx = routing.Start(0);\n",
+    "        while (!routing.IsEnd(idx)) { tour.Add(manager.IndexToNode(idx)); idx = sol.Value(routing.NextVar(idx)); }\n",
+    "        var arr = tour.ToArray();\n",
+    "        return (arr, tsp.TourLength(arr), sw.Elapsed.TotalMilliseconds);\n",
+    "    }\n",
+    "    return (null, -1, sw.Elapsed.TotalMilliseconds);\n",
+    "}\n",
+    "\n",
+    "Show(\"--- Tranche 2 : OR-Tools routing solver (Google.OrTools 9.11) ---\");\n",
+    "Show(\"Miroir C# de ortools_tsp (twin Python). RoutingModel = metaheuristique GLS,\");\n",
+    "Show(\"PAS solveur exact : aucune garantie d'optimalite (contrairement a CP-SAT).\");\n",
+    "Show(\"\");\n",
+    "Show(\"Parite (routing vs force brute, small N) :\");\n",
+    "Show(\"    N |    brut(opt) |     routing | parite | routing ms\");\n",
+    "foreach (var n in new[]{6, 8, 10}) {\n",
+    "    var inst = RandomInstance(n, 7);\n",
+    "    var (bT, bL, bTr) = BruteForce(inst);\n",
+    "    var (rT, rC, rMs) = SolveRouting(inst, 1);\n",
+    "    bool ok = Math.Abs(rC - bL) < 0.5;\n",
+    "    Show(n.ToString().PadLeft(4) + \" | \" + FI(bL).PadLeft(12) + \" | \" + FI(rC).PadLeft(11) + \" | \" + (ok ? \"OK\" : \"DIFF\").PadLeft(6) + \" | \" + FI(rMs, \"F0\"));\n",
+    "}\n",
+    "\n",
+    "Show(\"\");\n",
+    "Show(\"Prong-B : reference industrielle (force brute infaisable pour N>10) :\");\n",
+    "Show(\"    N |          NN |       2-opt |     SA (mean) |     routing | routing vs SA\");\n",
+    "foreach (var n in new[]{30, 60, 100}) {\n",
+    "    var inst = RandomInstance(n, 7);\n",
+    "    var (nnT, nnL) = NearestNeighbor(inst);\n",
+    "    var (o2T, o2L, o2I) = TwoOpt(inst, nnT);\n",
+    "    double saSum = 0;\n",
+    "    foreach (var sd in new[]{1, 7, 42}) {\n",
+    "        var (saT, saL, saA) = SimulatedAnnealing(inst, nnT, T0: Math.Max(50.0, n*5.0), alpha: 0.99995, iters: Math.Min(300000, n*3000), seed: sd);\n",
+    "        saSum += saL;\n",
+    "    }\n",
+    "    double saMean = saSum / 3;\n",
+    "    var (rT, rC, rMs) = SolveRouting(inst, 3);\n",
+    "    string rVsSa = FI(100.0*(saMean - rC)/saMean, \"F1\") + \"%\";\n",
+    "    Show(n.ToString().PadLeft(4) + \" | \" + FI(nnL).PadLeft(11) + \" | \" + FI(o2L).PadLeft(11) + \" | \" + (FI(saMean)+\" (3s)\").PadLeft(13) + \" | \" + FI(rC).PadLeft(10) + \" | \" + rVsSa.PadLeft(11));\n",
+    "}\n",
+    "Show(\"\");\n",
+    "Show(\"routing (GLS, moteur industriel) >= SA sur grandes instances : il combine recherche\");\n",
+    "Show(\"locale guidee multi-operateur + premiere solution chemin-cout-min. Aucun code TSP\");\n",
+    "Show(\"dedie cote utilisateur : toute la logique vit dans le moteur Google, comme en Python.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "execution_count": null,
+   "id": "tr2-app13-interp",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "**Verdict SOTA-OK.** Le routing solver trouve l'optimum exact (= force brute) sur les petites\n",
+    "instances (N=6,8,10) et sert de **r\u00e9f\u00e9rence industrielle** sur les grandes (N=30,60,100) o\u00f9 la\n",
+    "force brute est infaisable (la cellule \u00a76 le mesurait d\u00e9j\u00e0 : N=15 \u2248 8,7\u00d710\u00b9\u2070 permutations).\n",
+    "\n",
+    "**Hi\u00e9rarchie honn\u00eate des quatre approches** (mesur\u00e9e sur N=100) :\n",
+    "\n",
+    "| M\u00e9thode | Nature | Qualit\u00e9 |\n",
+    "|---|---|---|\n",
+    "| **Plus proche voisin** (from-scratch \u00a73) | Heuristique greedy O(N\u00b2) | sous-optimale (~16% gap) |\n",
+    "| **2-opt** (from-scratch \u00a74) | Recherche locale, optimum **local** | bloque loin de l'optimum |\n",
+    "| **Recuit simul\u00e9** (from-scratch \u00a75) | M\u00e9taheuristique, acceptation de Metropolis | am\u00e9liore 2-opt de ~1-4% |\n",
+    "| **OR-Tools routing** (Tranche 2) | M\u00e9taheuristique industrielle **GLS** | meilleure qualit\u00e9, moteur de production |\n",
+    "\n",
+    "La force de `RoutingModel` n'est pas un certificat d'optimalit\u00e9 (c'est une m\u00e9taheuristique,\n",
+    "contrairement \u00e0 CP-SAT) mais sa **qualit\u00e9 robuste sur grandes instances** gr\u00e2ce \u00e0 la recherche\n",
+    "locale guid\u00e9e et ses op\u00e9rateurs multi-renversements. La Tranche 1 from-scratch reste **valable** :\n",
+    "elle rend tangible le *fonctionnement intime* de chaque m\u00e9thode. Ce sont deux leviers\n",
+    "compl\u00e9mentaires \u2014 la Tranche 2 donne au C# le m\u00eame outillage industriel que le jumeau Python."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cd83dcbc-6e62-4cc5-a6d3-30dcde065102",
    "metadata": {
     "papermill": {
@@ -839,14 +1262,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "2c0f9c30-1cb6-4f28-8abb-b7db21ef6042",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T11:51:58.658998Z",
-     "iopub.status.busy": "2026-07-06T11:51:58.658838Z",
-     "iopub.status.idle": "2026-07-06T11:51:58.702793Z",
-     "shell.execute_reply": "2026-07-06T11:51:58.702680Z"
+     "iopub.execute_input": "2026-08-11T10:46:59.770062Z",
+     "iopub.status.busy": "2026-08-11T10:46:59.769628Z",
+     "iopub.status.idle": "2026-08-11T10:46:59.840585Z",
+     "shell.execute_reply": "2026-08-11T10:46:59.840358Z"
     },
     "papermill": {
      "duration": 0.04793,
@@ -899,14 +1322,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "4905c22b-8226-4387-8258-247f639a7769",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T11:51:58.716248Z",
-     "iopub.status.busy": "2026-07-06T11:51:58.716098Z",
-     "iopub.status.idle": "2026-07-06T11:51:58.738258Z",
-     "shell.execute_reply": "2026-07-06T11:51:58.738151Z"
+     "iopub.execute_input": "2026-08-11T10:46:59.842199Z",
+     "iopub.status.busy": "2026-08-11T10:46:59.841971Z",
+     "iopub.status.idle": "2026-08-11T10:46:59.876093Z",
+     "shell.execute_reply": "2026-08-11T10:46:59.875912Z"
     },
     "papermill": {
      "duration": 0.026071,
@@ -959,14 +1382,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "dc10d571-044c-4d34-85ef-fc3b2a17a209",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T11:51:58.751293Z",
-     "iopub.status.busy": "2026-07-06T11:51:58.751135Z",
-     "iopub.status.idle": "2026-07-06T11:51:58.780070Z",
-     "shell.execute_reply": "2026-07-06T11:51:58.779895Z"
+     "iopub.execute_input": "2026-08-11T10:46:59.877232Z",
+     "iopub.status.busy": "2026-08-11T10:46:59.877047Z",
+     "iopub.status.idle": "2026-08-11T10:46:59.911046Z",
+     "shell.execute_reply": "2026-08-11T10:46:59.910821Z"
     },
     "papermill": {
      "duration": 0.032915,

--- a/scripts/notebook_tools/twin_pairs.d/app-13-tsp-metaheuristics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-13-tsp-metaheuristics.yaml
@@ -2,7 +2,7 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13b-TSP-Metaheuristics-CSharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -16,5 +16,5 @@
       content_csharp_sha: 1eaef55790de690842740d1c89cde1e542cca34bae710ea8b3b45bb80339c28b
   known_differences:
     - "Socle pedagogique commun : TSP / Voyageur de commerce (metaheuristiques + OR-Tools routing) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
-    - "Idiomes framework : Python = OR-Tools constraint_solver routing + permutations ; C# = BCL pure (System.*), 0 NuGet."
-    - "Asymetrie pedagogique : Python met l'accent sur le solveur SOTA (OR-Tools CP-SAT / library specialisee) + visualisation matplotlib + experimentation comparative ; le C# demontre l'implementation from-scratch en BCL pure (ou binding NuGet du meme solver pour App-8/10/15), presentation compacte. Meme socle theorique, leviers de demonstration differents."
+    - "Idiomes framework : Python = OR-Tools constraint_solver routing (pywrapcp/RoutingModel + GLS) + permutations ; C# = Tranche 1 from-scratch BCL pure (System.*, 0 NuGet) PRESERVEE + Tranche 2 Google.OrTools ConstraintSolver routing (RoutingModel + recherche locale guidee GLS), miroir du twin Python (#10382). Parite native-both."
+    - "Asymetrie pedagogique : Python met l'accent sur le solveur SOTA (OR-Tools CP-SAT / library specialisee) + visualisation matplotlib + experimentation comparative ; le C# demontre l'implementation from-scratch en BCL pure (Tranche 1 PRESERVEE) + Tranche 2 binding NuGet Google.OrTools routing (le meme moteur que le twin Python, #10382), presentation compacte. Meme socle theorique, leviers de demonstration differents."

--- a/scripts/notebook_tools/twin_pairs.d/app-13-tsp-metaheuristics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-13-tsp-metaheuristics.yaml
@@ -14,6 +14,12 @@
       csharp_sha: 941ceed1e298290c5e1fb3df4a29b34ec5066eeb
       content_python_sha: aae53d11e5d1de51e10fd7c4e699e9c844a44976628360a4472015e4a40b0b13
       content_csharp_sha: 1eaef55790de690842740d1c89cde1e542cca34bae710ea8b3b45bb80339c28b
+    - date: "2026-08-11"
+      by: myia-po-2024:CoursIA
+      python_sha: 9b312c4b7666b477baa6bdb620194ad1d862b37b
+      csharp_sha: b17271a454b54b83a47460384889200704d6bef7
+      content_python_sha: aae53d11e5d1de51e10fd7c4e699e9c844a44976628360a4472015e4a40b0b13
+      content_csharp_sha: de07350515378b0d9026e524bb069fe4a44fab21970329dd8b615a6e489232f6
   known_differences:
     - "Socle pedagogique commun : TSP / Voyageur de commerce (metaheuristiques + OR-Tools routing) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = OR-Tools constraint_solver routing (pywrapcp/RoutingModel + GLS) + permutations ; C# = Tranche 1 from-scratch BCL pure (System.*, 0 NuGet) PRESERVEE + Tranche 2 Google.OrTools ConstraintSolver routing (RoutingModel + recherche locale guidee GLS), miroir du twin Python (#10382). Parite native-both."


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2024:CoursIA — prev: DEEP/notebook-dotnet #10444 (App-11 Picross Tranche 2)

## Summary

**Tranche 2 lib-vs-lib pour App-13b-TSP-Metaheuristics-CSharp** (#10382) : branche le **même moteur production** que le jumeau Python (`ortools.constraint_solver.routing`, `pywrapcp.RoutingModel`) — **Google.OrTools ConstraintSolver 9.11** (Perron & Furney ; solveur de routage avec **recherche locale guidée GLS**) — sur le TSP (Voyageur de Commerce, NP-difficile). La Tranche 1 from-scratch (force brute, plus proche voisin, 2-opt, recuit simulé) est **préservée intacte**.

**Rotation de paradigme** : le routing solver est une **métaheuristique** (recherche locale guidée), **PAS** un solveur exact — il ne délivre **aucun certificat d'optimalité**, contrairement à CP-SAT (Tranches App-5/App-11, SAT + Lazy Clause Generation). C'est un paradigme genuinely distinct des 6 Tranches CP-SAT précédentes — la cellule d'interprétation documente cette honnêteté.

## Détail technique

Trois cellules insérées après §7 (Synthèse), avant §8 (Exercices) :

1. **Intro markdown** — pose la Tranche 2 comme confrontation du from-scratch au moteur industriel, et l'honnêteté clé : routing = métaheuristique (pas CP-SAT).
2. **Code C#** (`ec=8`) — `#r "nuget: Google.OrTools, 9.11.4210"`. Méthode `SolveRouting()` miroir de `ortools_tsp` Python : `RoutingIndexManager(N,1,0)` + `RoutingModel`, transit callback renvoyant `long` (échelle `*1000`, miroir Python), `SetArcCostEvaluatorOfAllVehicles`, `PATH_CHEAPEST_ARC` + `GUIDED_LOCAL_SEARCH` + `TimeLimit`.
3. **Interprétation markdown** — verdict SOTA-OK + hiérarchie honnête des 4 approches (NN greedy → 2-opt local → SA métaheuristique → routing GLS industriel).

## Verdict de parité (firsthand, re-exécuté)

**Validation (rc=0, 0 erreur, ec 1..11 contigus).**

**Parité routing vs force brute (N=6,8,10)** — routing trouve l'**optimum exact** :

| N | brut (opt) | routing | parité |
|---|---|---|---|
| 6 | 278.24 | 278.24 | OK |
| 8 | 293.19 | 293.19 | OK |
| 10 | 314.41 | 314.41 | OK |

**Prong-B (#3801) — référence industrielle (brute force infaisable pour N>10)** :

| N | NN | 2-opt | SA (mean) | routing | routing vs SA |
|---|---|---|---|---|---|
| 30 | 554.61 | 475.12 | 461.97 | 461.87 | 0.0% |
| 60 | 780.76 | 638.90 | 630.98 | 617.78 | **2.1% meilleur** |
| 100 | 940.91 | 803.45 | 792.55 | 750.22 | **5.3% meilleur** |

Le routing solver (GLS, moteur industriel) **égale puis dépasse** la meilleure métaheuristique from-scratch (SA) à mesure que N croît — c'est la **valeur ajoutée mesurée** du moteur de production, obtenue **sans aucune ligne de code TSP dédiée** côté utilisateur (toute la logique vit dans le moteur Google, comme en Python). La cellule §6 mesurait déjà que la force brute devient infaisable (N=15 ≈ 8,7×10¹⁰ permutations).

## Pre-existing C.2 defect repaired (cell[12])

La cellule §6 (benchmark) avait sur `origin/main` un **string literal non terminé** — `Show("la force brute est infaisable...industrielle).` sans fermeture `");` — rendant le notebook **non-exécutable** (CS1010 "saut de ligne dans la constante") alors qu'elle portait des outputs `ec=6` stale (source éditée sans re-exéc = violation C.2). Cet defect **bloquait** la re-exécution de bout en bout exigée par ma Tranche 2. Fix minimal (fermer le string), outputs régénérés **byte-identiques** (déterministes, vérifiés firsthand : le contenu committed correspondait déjà à la ligne fermée).

## Preuves d'exécution réelle (C.2 / H.1)

- Re-exécution complète `jupyter nbconvert --execute --inplace --ExecutePreprocessor.kernel_name=.net-csharp` (cwd = dossier du notebook).
- **0 erreur**. `execution_count` 1..11 contigus sur les 11 cellules code.
- Sorties commitées = vraies sorties du routing solver (table de parité + table Prong-B).
- `strip_probe_banner.py --apply` : 9 lignes `probeAddresses` stripées post-re-exec .NET (L532). Pas de hand-edit.
- Cellule d'interprétation (markdown) ajustée pour **matcher exactement** les outputs commités.

## Twin registry

`app-13-tsp-metaheuristics.yaml` : `parity_level` semantic → **native-both**. Nouvelle entrée d'audit (csharp_sha `b17271a4`), `known_differences` réécrit pour documenter la Tranche 2 routing + la Tranche 1 from-scratch préservée. SHA rebaseliné via `check_twin_parity.py --update` **après** le commit du notebook (leçon #8957).

`check_twin_parity.py` : **157/157 OK, DRIFT=0**.

## Scope

2 fichiers, 2 commits, 1 sujet (Tranche 2 App-13 TSP). Tranche 1 from-scratch **intacte**. Pre-existing C.2 defect (cell[12]) repaired comme prérequis à la re-exéc. Aucun changement hors-scope. Catalogue byte-identique à main.

See #10382, #3801.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
