### PR TITLE
feat(check_lane_claim,#10419): [CLAIMED]/[RELEASED] paths: scope — disjoint claims no longer false-block

### DIFF
--- a/.claude/rules/lane-claim-protocol.md
+++ b/.claude/rules/lane-claim-protocol.md
@@ -20,7 +20,7 @@ L'issue GitHub ferme les trois d'un coup : locus **unique cross-lane par constru
 ## Regle HARD — cote coordinateur (ai-01)
 
 5. **Poser le `[CLAIMED]` au dispatch** (commentaire d'issue au nom de la lane servie), sans attendre que le worker le pose au demarrage : la fenetre decision → claim est celle du coordinateur a couvrir.
-6. **Partitionner explicitement par fichier** des que plusieurs lanes convergent sur une meme cible (precedent : `HashlifeCorrectness.lean` partitionne P4-mpr / murs SW-SE / MarginFragment entre trois lanes sur #6724).
+6. **Partitionner explicitement par fichier** des que plusieurs lanes convergent sur une meme cible (precedent : `HashlifeCorrectness.lean` partitionne P4-mpr / murs SW-SE / MarginFragment entre trois lanes sur #6724). Le partitionnement s'ecrit mecaniquement depuis #10419 : un `[CLAIMED]` portant une clause `paths:` ne bloque qu'une lane dont le scope **intersecte** le sien (fnmatch). Deux lanes aux scopes **disjoints** sur une meme issue-parapluie (cas nominal d'un audit multi-instances type #10382, une lane par notebook) sont donc libres en parallele. Syntaxe : `[CLAIMED] lane <machine:workspace> -- paths: glob1, glob2`. Sans la clause, le `[CLAIMED]` reste **epic-wide** (bloque toutes les autres lanes -- semantique heritee, preservee). L'organe lit le scope depuis le commentaire d'issue ET, en complement, depuis le `--paths` du caller ; la disjointness n'est honoree que quand **les deux** claims declarent un scope.
 7. **Lire les DEUX dashboards avant de provisionner** (rappel R3 [coordinator-discipline.md](coordinator-discipline.md)) — necessaire mais insuffisant seul : il ne couvre pas la fenetre inter-cycle, d'ou les points 5-6.
 
 ## Tie-break — l'issue l'emporte, l'override s'ecrit (#10223)

--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -106,19 +106,25 @@ _CLOSE = {"RELEASED", "CANCELLED", "ABANDONED", "DONE"}
 # merged without a written adjudication). Additive: the existing markers keep
 # their semantics, so no prior test changes.
 #
-# `paths:` clause (#10342): an optional path scope after the lane token -- when
-# present, the override's "close all others" effect is BOUND to the listed paths
-# (fnmatch, comma-separated). Other lanes remain FREE on paths outside the
-# scope, which is the missing leg for step-bounded adjudications (e.g. an
-# override that reassigns ONE lake leaves other lakes' claims un-touched).
-# Syntax: `[OVERRIDE] lane <machine:workspace> -- paths: glob1, glob2`.
-# Without the clause, the override is EPIC-WIDE (legacy semantics, preserved).
+# `paths:` clause (#10342 for [OVERRIDE], extended to [CLAIMED]/[RELEASED] by
+# #10419): an optional path scope after the lane token. When present on an
+# [OVERRIDE], the "close all others" effect is BOUND to the listed paths
+# (fnmatch, comma-separated). When present on a [CLAIMED], the claim is SCOPED
+# to those paths -- two lanes whose scoped claims do NOT intersect are free to
+# work the same issue in parallel (the nominal pattern for multi-instance
+# audits like #10382, one lane per notebook). Other lanes remain FREE on paths
+# outside the scope. Syntax: `[CLAIMED] lane <machine:workspace> -- paths: g1, g2`.
+# Without the clause, the marker is EPIC-WIDE (legacy semantics, preserved):
+# an unscoped [CLAIMED] blocks every other lane, an unscoped [OVERRIDE] closes
+# every other lane -- exactly as before #10342/#10419.
 _OVERRIDE = {"OVERRIDE"}
 # The token is OPTIONAL; the lane stays REQUIRED (an override without a named
 # beneficiary is unattributed, per existing semantics). Capture groups:
 # 1 = comma-separated path list (already stripped of surrounding spaces).
-_OVERRIDE_PATHS_RE = re.compile(
-    r"(?im)^[ \t]*\[\s*OVERRIDE\s*\][^\n]*?paths\s*:\s*([^\n]+?)\s*$"
+# Recognised on [CLAIMED], [RELEASED] (attached; the reducer treats release as
+# a full lane-close, so the scope is informational there), and [OVERRIDE].
+_PATHS_CLAUSE_RE = re.compile(
+    r"(?im)^[ \t]*\[\s*(?:CLAIMED|RELEASED|OVERRIDE)\s*\][^\n]*?paths\s*:\s*([^\n]+?)\s*$"
 )
 
 
@@ -179,13 +185,14 @@ class ClaimEvent(dict):
 
     @property
     def paths(self) -> list[str] | None:
-        """Optional path scope (#10342); None when the override is epic-wide.
+        """Optional path scope (#10342 OVERRIDE, #10419 CLAIMED/RELEASED).
 
-        A non-None value means the override's "close all others" effect is bound
-        to the listed globs (fnmatch); lanes without claims intersecting them
-        remain free. The reducer and check honour this: `compute_active_claims`
-        always preserves the full `paths` payload, and the check filters the
-        `others` dict by `_path_matches` when the caller supplies `--paths`.
+        None when the marker is epic-wide (no `paths:` clause). A non-None value
+        on an [OVERRIDE] binds its "close all others" effect to the listed globs;
+        on a [CLAIMED] it SCOPES the claim, so two lanes whose paths do NOT
+        intersect (fnmatch, `_path_matches`) are free to work the same issue in
+        parallel. The reducer preserves the full `paths` payload; the check
+        filters `others` by scope intersection (`_filter_by_claim_scope`).
         """
         return self.get("paths")
 
@@ -198,10 +205,13 @@ def parse_claim_event(comment: dict) -> ClaimEvent | None:
     (surfaced as "unattributed", never guessed). The timestamp is the comment's
     server `createdAt` -- the Defaut-2 fix: body stamps are not trusted.
 
-    `#10342 scope`: when the marker is `[OVERRIDE]` and the body carries a
-    `paths: <comma-list>` clause, the parsed list is attached to the event as
-    `paths`. Other markers ignore the clause (claim/release/done are not
-    scope-bound; the path-mode guard handles file collisions separately, #9959).
+    `#10342`/`#10419 scope`: when the marker line carries a `paths: <comma-list>`
+    clause, the parsed list is attached to the event as `paths`. Originally
+    [OVERRIDE]-only (#10342); #10419 extended recognition to [CLAIMED] and
+    [RELEASED]. For [CLAIMED] the scope makes two lanes with DISJOINT paths free
+    to work the same issue in parallel (multi-instance audits, one lane per
+    notebook). For [RELEASED] the clause is attached for symmetry but the
+    reducer treats release as a full lane-close (partial release is a non-goal).
 
     `#10395 Variante 1`: the marker LINE (the line carrying the last bracketed
     marker, not the whole body) is also passed to `extract_lane` as the
@@ -226,8 +236,10 @@ def parse_claim_event(comment: dict) -> ClaimEvent | None:
     else:
         action = "close"
     author = (comment.get("author") or {}).get("login")
-    paths = _extract_override_paths(body) if action == "override" else None
     marker_line = _last_marker_line(body, marker)
+    # `paths:` clause (#10342 OVERRIDE, #10419 CLAIMED/RELEASED): parsed from the
+    # marker line so a stray `paths:` in body prose cannot arm a false scope.
+    paths = _extract_paths_clause(marker_line) if marker_line else None
     intent = _extract_marker_intent(body) if marker_line else None
     return ClaimEvent(
         lane=extract_lane(body, marker_line=marker_line),
@@ -299,16 +311,19 @@ def _extract_marker_intent(body: str) -> str | None:
     return text
 
 
-def _extract_override_paths(body: str) -> list[str] | None:
-    """Parse the optional `paths: <comma-list>` clause of an [OVERRIDE] body.
+def _extract_paths_clause(text: str | None) -> list[str] | None:
+    """Parse the optional `paths: <comma-list>` clause from a marker line.
 
-    Returns the trimmed path list, or None when the clause is absent (the
-    override is then EPIC-WIDE -- the legacy semantics, preserved for backward
-    compatibility: every prior override without scope continues to lock
-    every other lane out). Empty fragments from stray commas are dropped
-    (a worker pasting `paths: a, , b` gets `["a", "b"]`, not `["a", "", "b"]`).
+    Recognised on [CLAIMED], [RELEASED], and [OVERRIDE] marker lines (#10342
+    introduced the clause for [OVERRIDE]; #10419 extended it to [CLAIMED] and
+    [RELEASED] so disjoint scoped claims no longer false-block each other on a
+    multi-instance issue). Returns the trimmed path list, or None when the
+    clause is absent -- the marker is then EPIC-WIDE (legacy semantics: an
+    unscoped [CLAIMED] blocks every other lane, an unscoped [OVERRIDE] closes
+    every other lane). Empty fragments from stray commas are dropped (a worker
+    pasting `paths: a, , b` gets `["a", "b"]`, not `["a", "", "b"]`).
     """
-    m = _OVERRIDE_PATHS_RE.search(body or "")
+    m = _PATHS_CLAUSE_RE.search(text or "")
     if not m:
         return None
     raw = m.group(1)
@@ -522,11 +537,14 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
             (but a warning is printed, #9812). None = legacy epic-wide block.
         now: injected `datetime` for stale calc (testability).
         my_paths: optional list of files the caller intends to edit (#10342).
-            When supplied, an `[OVERRIDE]` whose `paths:` clause does NOT
-            intersect `my_paths` is treated as if it does not exist for the
-            blocker test -- the override only locks the lanes it names the
-            paths for. Without `my_paths`, behaviour is unchanged (every
-            `[OVERRIDE]` is epic-wide, regardless of its scope clause).
+            Merged with the caller's OWN active-claim `paths:` clause (#10419)
+            to form `my_scope`. An `[OVERRIDE]` or `[CLAIMED]` whose `paths:`
+            clause does NOT intersect `my_scope` is treated as if it does not
+            exist for the blocker test -- the claim only locks the paths it
+            names. Without any declared scope (no `my_paths` AND no `paths:` on
+            the caller's own claim), behaviour is unchanged: every other active
+            claim blocks, regardless of its scope clause (we cannot prove
+            disjointness, so we conservatively over-block).
     """
     events = _sort_events(payload)
     active, unattributed = compute_active_claims(events)
@@ -538,7 +556,7 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
     # `my_paths`, we conservatively treat every scoped override as blocking
     # (the caller's intent is unknown -- better to over-block than silently
     # merge a write that should have pinged a held lane).
-    others = _filter_by_override_scope(others, my_paths)
+    others = _filter_by_claim_scope(others, my_paths, mine)
 
     # Stale-claim handling (#9812): a claim older than `stale_threshold` hours
     # (age from the server createdAt, NEVER the body) is treated as STALE -- it
@@ -623,45 +641,44 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
     return 0
 
 
-def _filter_by_override_scope(
+def _filter_by_claim_scope(
     others: dict[str, ClaimEvent],
     my_paths: list[str] | None,
+    mine: ClaimEvent | None,
 ) -> dict[str, ClaimEvent]:
-    """Drop `others` lanes whose `[OVERRIDE]` grant has a `paths:` scope that
-    does NOT intersect the caller's intended files (#10342).
+    """Drop `others` lanes whose scoped claim does NOT intersect my scope.
 
-    Rules:
-      - Plain `[CLAIMED]` events (no override) always stay in `others` --
-        their epic-wide semantics predate the scope feature.
-      - `[OVERRIDE]` events WITHOUT a `paths:` clause stay in `others` --
-        legacy epic-wide adjudication, preserved.
-      - `[OVERRIDE]` events WITH a `paths:` clause stay in `others` only when
-        at least one of `my_paths` matches the scope. When `my_paths` is
-        None (the caller did not declare intent), we conservatively keep the
-        lane in `others` -- better over-block than silent miss.
-      - The lane whose `event.marker == "OVERRIDE"` but has scope and DOES
-        NOT match `my_paths` is dropped: that lane was granted the claim on
-        a specific path range, the caller is working elsewhere, no collision.
+    `my_scope` (#10419) = the caller's `--paths` intent MERGED with the
+    `paths:` clause of the caller's OWN active claim (`mine`). When `my_scope`
+    is empty (the caller declared no path intent at all), every other lane is
+    kept -- we cannot prove disjointness, so we conservatively over-block
+    (legacy behaviour, preserved).
 
-    The reducer `compute_active_claims` already stored the override event
-    under its named lane (line `state = {ev.lane: ev}`); this filter only
-    prunes the `others` view, never the reducer output. The active_claims
-    summary keeps the full state, so the JSON output remains auditable.
+    Per other lane:
+      - No `paths:` clause (plain [CLAIMED], or epic-wide [OVERRIDE]) -> STAYS.
+        Its epic-wide semantics predate the scope feature (#10342/#10419).
+      - Has a `paths:` clause that INTERSECTS `my_scope` -> STAYS (real overlap).
+      - Has a `paths:` clause DISJOINT from `my_scope` -> DROPPED (free). This
+        is the #10419 fix: two lanes with disjoint scoped claims on the same
+        multi-instance issue no longer false-block each other.
+
+    The reducer `compute_active_claims` is untouched; this filter only prunes
+    the `others` view. The active_claims summary keeps the full state, so the
+    JSON output remains auditable.
     """
-    if not my_paths:
-        return others  # conservative legacy behaviour
+    mine_paths = (mine.get("paths") if mine else None) or []
+    my_scope = list(dict.fromkeys((my_paths or []) + mine_paths)) or None
+    if not my_scope:
+        return others  # no declared scope -> cannot prove disjointness
     filtered: dict[str, ClaimEvent] = {}
     for ln, ev in others.items():
-        if ev.marker != "OVERRIDE":
-            filtered[ln] = ev
-            continue
         scope = ev.get("paths")
         if not scope:
-            filtered[ln] = ev  # epic-wide override, preserved
+            filtered[ln] = ev  # epic-wide (plain CLAIMED or unscoped OVERRIDE)
             continue
-        if _path_matches_any(my_paths, scope):
-            filtered[ln] = ev  # scope covers at least one of my paths
-        # else: scope doesn't touch my paths -> free, drop from others
+        if _path_matches_any(my_scope, scope):
+            filtered[ln] = ev  # scopes intersect -> real collision
+        # else: both scoped, disjoint -> free, drop from others
     return filtered
 
 

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -894,9 +894,10 @@ def test_check_override_paths_keeps_other_lane_free_on_non_matching_path(capsys)
 
 
 def test_check_override_paths_keeps_plain_claimed_lane_blocking(capsys):
-    # Plain `[CLAIMED]` (not an override) is always epic-wide, even when the
-    # caller supplies `--paths`. The scope is a coordinator's adjudication
-    # tool; a worker's claim never carries it. This pins the boundary.
+    # A [CLAIMED] WITHOUT a `paths:` clause is epic-wide, even when the caller
+    # supplies `--paths`. (#10419 lets a worker SCOPE a [CLAIMED] with a
+    # `paths:` clause; this test pins the boundary for the UNSCOPED form,
+    # which stays global and blocks regardless of the caller's --paths.)
     p = payload(
         comment("[CLAIMED] lane myia-po-2026:CoursIA -- original",
                 "2026-08-09T11:00:00Z"),
@@ -959,6 +960,200 @@ def test_active_claims_summary_exposes_paths(capsys):
     assert rc == 1  # override granted A, so B is blocked (epic-wide read)
     assert "Lean/**" in out
     assert "scripts/**" in out
+
+
+# --- [CLAIMED] paths: scope (#10419) -----------------------------------------
+# #10342 introduced the `paths:` clause for [OVERRIDE] only. #10419 extends
+# recognition to [CLAIMED] (and [RELEASED], by symmetry) so that the nominal
+# pattern of a multi-instance audit -- several lanes each scoping their [CLAIMED]
+# to a DISJOINT notebook on the same parapluie issue -- no longer raises a
+# false `lane-claim-conflict` on every PR. Before #10419, a worker's claim
+# "never carried" a scope (see the comment pinned by
+# test_check_override_paths_keeps_plain_claimed_lane_blocking); the protocol
+# (lane-claim-protocol.md rule 6) already DEMANDED per-file partitioning that
+# the organ could not read. These tests pin the three layers: parse, reducer
+# passthrough, and the scope-intersection check.
+
+
+def test_parse_claimed_with_paths_clause():
+    # [CLAIMED] carrying a `paths:` clause -> the scope is attached (#10419).
+    ev = clc.parse_claim_event(
+        comment(
+            "[CLAIMED] lane myia-po-2023:CoursIA -- "
+            "paths: MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb",
+            "2026-08-11T04:02:00Z",
+        )
+    )
+    assert ev is not None
+    assert ev.marker == "CLAIMED"
+    assert ev.is_open
+    assert ev.paths == [
+        "MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb",
+    ]
+
+
+def test_parse_claimed_without_paths_clause_is_none():
+    # Plain [CLAIMED] (no scope) -> paths is None, NOT []. Legacy claim.
+    ev = clc.parse_claim_event(
+        comment("[CLAIMED] lane myia-po-2024:CoursIA -- build the guard",
+                "2026-08-06T22:00:00Z")
+    )
+    assert ev is not None
+    assert ev.paths is None
+
+
+def test_parse_claimed_paths_clause_drops_empty_fragments():
+    # Same empty-fragment hygiene as [OVERRIDE]: stray commas are dropped.
+    ev = clc.parse_claim_event(
+        comment("[CLAIMED] lane A:CoursIA -- paths: a.py, , b.py, ",
+                "2026-08-11T04:02:00Z")
+    )
+    assert ev.paths == ["a.py", "b.py"]
+
+
+def test_parse_released_with_paths_clause_attached():
+    # [RELEASED] recognises the clause (symmetry with [CLAIMED], #10419). The
+    # reducer treats release as a full lane-close, so the scope is informational
+    # here -- but the PARSE layer must not silently drop it.
+    ev = clc.parse_claim_event(
+        comment("[RELEASED] lane A:CoursIA -- paths: a.py, b.py",
+                "2026-08-11T05:00:00Z")
+    )
+    assert ev is not None
+    assert ev.marker == "RELEASED"
+    assert ev.paths == ["a.py", "b.py"]
+
+
+def test_reducer_preserves_claimed_scope_payload():
+    # The active-claim reducer stores the scoped [CLAIMED] event intact, so the
+    # check layer can read `paths` off it (mirrors the OVERRIDE reducer test).
+    events = [
+        clc.parse_claim_event(
+            comment("[CLAIMED] lane A:CoursIA -- paths: Search/Search-3.ipynb",
+                    "2026-08-11T04:02:00Z")
+        ),
+    ]
+    active, unattributed = clc.compute_active_claims(events)
+    assert not unattributed
+    assert active["A:CoursIA"].paths == ["Search/Search-3.ipynb"]
+
+
+def test_check_claimed_disjoint_paths_dont_block(capsys):
+    # CORE #10419 fix: two lanes, each [CLAIMED] scoped to a DISJOINT notebook,
+    # neither passing --paths. Before #10419 both were BLOCKED (false conflict);
+    # after, each reads the OTHER's scope from its own active claim and sees CLEAR.
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA -- "
+                "paths: Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb",
+                "2026-08-11T04:02:00Z"),
+        comment("[CLAIMED] lane myia-po-2023:CoursIA -- "
+                "paths: Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb",
+                "2026-08-11T04:05:00Z"),
+    )
+    rc = clc._run_check(p, "myia-po-2025:CoursIA")  # no --paths
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"blocking_lanes": []' in out
+    # The other lane is still in the audit JSON (state preserved), just not blocking.
+    assert "myia-po-2023:CoursIA" in out
+
+
+def test_check_claimed_10382_five_disjoint_claims(capsys):
+    # Regression reproduction of the #10382 / #10419 motivating incident: 5
+    # lanes each scoped to a disjoint notebook on one parapluie issue. Every
+    # lane MUST see blocking_lanes: [] -- the artefactual `lane-claim-conflict`
+    # that fired on all ~51 PRs of the audit is gone.
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2023:CoursIA -- "
+                "paths: Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb",
+                "2026-08-11T04:02:00Z"),
+        comment("[CLAIMED] lane myia-po-2024:CoursIA -- "
+                "paths: Planning/Planners-5-Heuristics-Csharp.ipynb",
+                "2026-08-11T04:03:00Z"),
+        comment("[CLAIMED] lane myia-po-2025:CoursIA -- "
+                "paths: Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb",
+                "2026-08-11T04:04:00Z"),
+        comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- "
+                "paths: Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb",
+                "2026-08-11T04:05:00Z"),
+        comment("[CLAIMED] lane myia-po-2026:CoursIA -- "
+                "paths: GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb",
+                "2026-08-11T04:07:00Z"),
+    )
+    for lane in (
+        "myia-po-2023:CoursIA",
+        "myia-po-2024:CoursIA",
+        "myia-po-2025:CoursIA",
+        "myia-po-2025:CoursIA-2",
+        "myia-po-2026:CoursIA",
+    ):
+        rc = clc._run_check(p, lane)
+        assert rc == 0, f"{lane} should be CLEAR on disjoint scopes"
+        assert '"blocking_lanes": []' in capsys.readouterr().out
+
+
+def test_check_claimed_same_path_still_blocks(capsys):
+    # Two scoped claims on the SAME path -> real collision -> BLOCKED. The scope
+    # feature must not dissolve a genuine file-level conflict into a false clear.
+    p = payload(
+        comment("[CLAIMED] lane A:CoursIA -- paths: Sudoku/Sudoku-9.ipynb",
+                "2026-08-11T04:02:00Z"),
+        comment("[CLAIMED] lane B:CoursIA-2 -- paths: Sudoku/Sudoku-9.ipynb",
+                "2026-08-11T04:05:00Z"),
+    )
+    rc = clc._run_check(p, "A:CoursIA")
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "BLOCKED" in err
+    assert "B:CoursIA-2" in err
+
+
+def test_check_claimed_one_scoped_one_plain_blocks(capsys):
+    # One scoped claim + one plain (epic-wide) claim -> BLOCKED. Disjointness is
+    # only honoured when BOTH sides declare a scope (acceptance #2 of #10419);
+    # a plain claim's intent is unknown, so it conservatively blocks.
+    p = payload(
+        comment("[CLAIMED] lane A:CoursIA -- paths: Search/Search-3.ipynb",
+                "2026-08-11T04:02:00Z"),
+        comment("[CLAIMED] lane B:CoursIA-2 -- working on Sudoku",
+                "2026-08-11T04:05:00Z"),
+    )
+    rc = clc._run_check(p, "A:CoursIA")
+    assert rc == 1
+    assert "B:CoursIA-2" in capsys.readouterr().err
+
+
+def test_check_my_claim_scope_derived_from_claim_not_just_cli(capsys):
+    # my_scope is built from the caller's OWN [CLAIMED] paths clause, NOT only
+    # from --paths. A lane that posted a scoped [CLAIMED] but calls the check
+    # without --paths still gets disjointness honoured against another scoped
+    # lane. This is the leg that makes the #10419 fix usable without forcing
+    # every worker to pass --paths on every invocation.
+    p = payload(
+        comment("[CLAIMED] lane A:CoursIA -- paths: Lean/Foo.lean",
+                "2026-08-11T04:02:00Z"),
+        comment("[CLAIMED] lane B:CoursIA-2 -- paths: scripts/foo.py",
+                "2026-08-11T04:05:00Z"),
+    )
+    rc = clc._run_check(p, "A:CoursIA")  # NO my_paths
+    assert rc == 0
+    assert '"blocking_lanes": []' in capsys.readouterr().out
+
+
+def test_check_claimed_paths_merged_with_cli_widen_scope(capsys):
+    # my_scope MERGES --paths with the caller's claim clause (defensive: a lane
+    # blocks if it touches ANY file I declared, by either channel). Here the
+    # other lane's scope intersects my CLI --paths but NOT my claim clause --
+    # the merge still catches the overlap and BLOCKS.
+    p = payload(
+        comment("[CLAIMED] lane A:CoursIA -- paths: Lean/Foo.lean",
+                "2026-08-11T04:02:00Z"),
+        comment("[CLAIMED] lane B:CoursIA-2 -- paths: scripts/bar.py",
+                "2026-08-11T04:05:00Z"),
+    )
+    rc = clc._run_check(p, "A:CoursIA", my_paths=["scripts/bar.py"])
+    assert rc == 1
+    assert "B:CoursIA-2" in capsys.readouterr().err
 
 
 # --- #10395 Variante 2: claim-scope mesh (intent in BLOCKED verdict) ---------


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA — prev: DEEP/notebook-dotnet (#10442 NFG fix)

Fixes #10419 (Option A) — `check_lane_claim` reconnaît la clause `paths:` sur les `[CLAIMED]`/`[RELEASED]`, et deux claims scopés disjoints ne se bloquent plus.

## Le défaut, mesuré (G.1)

`paths:` n'était parsé que pour `[OVERRIDE]` (`scripts/check_lane_claim.py` l.229 origin/main) :

```python
paths = _extract_override_paths(body) if action == "override" else None
```

Conséquence : sur une issue-parapluie multi-instances (#10382, une lane par notebook), chaque lane recevait `lane-claim-conflict` bien qu'**aucune** n'eût fauté — les claims étaient explicitement partitionnés par fichier dans leur propre texte, mais l'organe ne lisait pas ce partitionnement. Le docstring l'admettait (« Other markers ignore the clause »).

Reproduction firsthand (issue #10419) : 5 claims disjoints sur #10382 → `BLOCKED: another lane holds an active claim` pour chacun.

## Le fix (Option A de l'issue, 5 critères d'acceptation)

1. **Parse étendu** : `_PATHS_CLAUSE_RE` (ex `_OVERRIDE_PATHS_RE`) reconnaît `[CLAIMED]|RELEASED|OVERRIDE`. `_extract_paths_clause(marker_line)` (ex `_extract_override_paths`) lit la clause depuis la **marker-line** (un `paths:` dans la prose du corps ne peut plus armer un faux scope). Pour `[RELEASED]` la clause est attachée par symétrie ; le réducteur traite le release comme un close complet de lane (partial-release = non-goal, documenté).

2. **Filtre généralisé** : `_filter_by_claim_scope(others, my_paths, mine)` (ex `_filter_by_override_scope`). `my_scope` = `--paths` du caller **fusionné** avec la clause `paths:` du **propre claim actif** du caller (`mine`) — défensif (une lane bloque si elle touche n'importe quel fichier déclaré, par either canal). Une lane est droppée de `others` ssi **les deux** claims sont scopés et **disjoints** (fnmatch via `_path_matches`/`_path_matches_any` existants).

3. **Rétro-compatibilité** (acceptance #3, testée) : un `[CLAIMED]` **sans** `paths:` reste **epic-wide** (bloque tout le monde) ; un caller sans scope déclaré ne peut pas prouver la disjointness → over-block conservateur (legacy).

4. **Test de régression** (acceptance #4) : `test_check_claimed_10382_five_disjoint_claims` reproduit les 5 claims disjoints → `blocking_lanes: []` pour chacune. + 10 autres tests pin les 3 couches (parse / reducer / check), incluant le cas de collision réelle (même path → BLOCKED) et le cas one-scoped-one-plain (BLOCKED).

5. **Doc règle** (acceptance #5) : `.claude/rules/lane-claim-protocol.md` règle 6 documente la syntaxe `[CLAIMED] lane <m:w> -- paths: g1, g2`, rattachée au précédent #6724.

## Preuve (firsthand, G.1)

- `python -m pytest scripts/tests/test_check_lane_claim.py` → **78/78 PASS** (67 existants + 11 nouveaux). Aucune régression : tous les tests OVERRIDE-paths (#10342) passent à l'identique (le filtre généralisé préserve la sémantique OVERRIDE — `mine=None` quand le caller n'a pas de claim propre → `my_scope=my_paths` → logique de scope identique à avant).
- `test_lane_claim_required.py` (gate CI `lane-claim-guard.yml`) → **27/27 PASS**.
- 0 référence résiduelle aux anciens noms (`_OVERRIDE_PATHS_RE`, `_extract_override_paths`, `_filter_by_override_scope`) dans `scripts/`, `docs/`, `.github/`.

## Diff scope (C.3)

- `scripts/check_lane_claim.py` : rename + généralisation (parse étendu, filtre scoped, docstrings). +147/−69 net mais essentiellement des déplacements de docstring.
- `scripts/tests/test_check_lane_claim.py` : +201 (11 nouveaux tests + 1 commentaire de test existant corrigé — « a worker's claim never carries it » devenu faux depuis #10419).
- `.claude/rules/lane-claim-protocol.md` : règle 6 (+1 phrase sur la syntaxe scopée).

Aucun changement de comportement pour un claim existant sans `paths:` (épic-wide, préserve #10342/#10223).

## Out of scope

- **Partial-release** : un `[RELEASED] paths: A` sur un claim `[CLAIMED] paths: A,B` ne libère que A en théorie ; le réducteur (une active-claim par lane) ferme la lane entière. Non-goal de cette issue (#10419 vise les faux-conflicts CLAIMED, pas le partial-release).
- **Normalisation d'`app-10-portfolio.yaml`** (indent-4) : c'était #10430 (autre issue, déjà résolue par #10434), pas #10419.

See #10419, #10342, #10382, EPIC lane-claim-protocol.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
