### PR TITLE
feat(SW-2b,#2161): add 7 SPARQL section (Exemple guide 3 + Exercice 3)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
@@ -1253,6 +1253,135 @@
   },
   {
    "cell_type": "markdown",
+   "id": "sparql-intro",
+   "metadata": {},
+   "source": [
+    "<a id=\"sparql\"></a>\n",
+    "\n",
+    "## 7. Interroger un graphe avec SPARQL\n",
+    "\n",
+    "Jusqu'ici nous avons **construit** et **sérialisé** des graphes RDF. L'autre moitié du travail sémantique consiste à les **interroger**. **SPARQL** est le langage de requête standard du web sémantique — l'équivalent de SQL pour les triplets RDF.\n",
+    "\n",
+    "Une requête SPARQL **fait correspondre** un motif de triplet (le bloc `WHERE`) contre le graphe, puis **retourne** les variables liées (le `SELECT`). Le motif `?personne foaf:name ?nom` trouve toutes les personnes possédant un nom. `rdflib` intègre un moteur SPARQL : la méthode `g.query(\"SELECT ...\")` exécute la requête et renvoie un itérateur sur les lignes résultats.\n",
+    "\n",
+    "### Exemple guide 3 : Première requête SPARQL SELECT\n",
+    "\n",
+    "Construisons un petit graphe social et listons ses membres par nom trié. Notez les `PREFIX` qui déclarent les raccourcis d'namespace, exactement comme `g.bind()` côté Python.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "exemple-guide-sparql",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T12:05:19.599044Z",
+     "iopub.status.busy": "2026-08-11T12:05:19.598296Z",
+     "iopub.status.idle": "2026-08-11T12:05:21.054115Z",
+     "shell.execute_reply": "2026-08-11T12:05:21.051822Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Personnes dans le graphe (triées par nom) :\n",
+      "  http://example.org/Alice -> Alice\n",
+      "  http://example.org/Bob -> Bob\n",
+      "  http://example.org/Charlie -> Charlie\n"
+     ]
+    }
+   ],
+   "source": [
+    "if RDFLIB_AVAILABLE:\n",
+    "    # Exemple guide : requete SPARQL SELECT sur un graphe social\n",
+    "    g_demo = Graph()\n",
+    "    EX = Namespace(\"http://example.org/\")\n",
+    "    FOAF_NS = Namespace(\"http://xmlns.com/foaf/0.1/\")\n",
+    "    g_demo.bind(\"ex\", EX)\n",
+    "    g_demo.bind(\"foaf\", FOAF_NS)\n",
+    "\n",
+    "    # Trois personnes, une relation foaf:knows\n",
+    "    g_demo.add((EX.Alice, FOAF_NS.name, Literal(\"Alice\")))\n",
+    "    g_demo.add((EX.Bob, FOAF_NS.name, Literal(\"Bob\")))\n",
+    "    g_demo.add((EX.Charlie, FOAF_NS.name, Literal(\"Charlie\")))\n",
+    "    g_demo.add((EX.Alice, FOAF_NS.knows, EX.Bob))\n",
+    "\n",
+    "    # Requete SPARQL : toutes les personnes et leur nom, tries par nom\n",
+    "    requete_select = \"\"\"\n",
+    "    PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n",
+    "    SELECT ?personne ?nom WHERE {\n",
+    "        ?personne foaf:name ?nom .\n",
+    "    } ORDER BY ?nom\n",
+    "    \"\"\"\n",
+    "    resultats = g_demo.query(requete_select)\n",
+    "    print(\"Personnes dans le graphe (triées par nom) :\")\n",
+    "    for ligne in resultats:\n",
+    "        print(f\"  {ligne.personne} -> {ligne.nom}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exercice3-sparql",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Compter les amis d'Alice avec SPARQL\n",
+    "\n",
+    "Reprenez le graphe `g_demo` de l'exemple guide 3 (Alice connaît Bob). Écrivez une requête SPARQL qui **compte** combien de personnes `ex:Alice` connaît via `foaf:knows`. Utilisez la fonction d'agrégation `COUNT`.\n",
+    "\n",
+    "**Indice** : la syntaxe d'agrégation est `(COUNT(?ami) AS ?nombre)`. Le `SELECT` peut retourner un agrégat sans variable de ligne. Le sujet dans le `WHERE` est l'URI complète `<http://example.org/Alice>`.\n",
+    "\n",
+    "# Indice : PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n",
+    "# Etape 1 : ecrire le bloc WHERE { <http://example.org/Alice> foaf:knows ?ami . }\n",
+    "# Etape 2 : ajouter (COUNT(?ami) AS ?nombre) dans le SELECT\n",
+    "# Etape 3 : executer g_demo.query(...) et afficher le nombre\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "exercice3-sparql-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T12:05:21.059889Z",
+     "iopub.status.busy": "2026-08-11T12:05:21.059259Z",
+     "iopub.status.idle": "2026-08-11T12:05:21.071597Z",
+     "shell.execute_reply": "2026-08-11T12:05:21.068981Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : ecrivez le pattern SPARQL pour compter les amis d'Alice\n"
+     ]
+    }
+   ],
+   "source": [
+    "if RDFLIB_AVAILABLE:\n",
+    "    # TODO etudiant : compter les amis d'Alice avec une requete SPARQL\n",
+    "    # Le graphe g_demo est deja construit dans l'exemple guide 3 ci-dessus.\n",
+    "    # Indice : inspirez-vous de requete_select, avec COUNT dans le SELECT.\n",
+    "\n",
+    "    requete_ami = \"\"\"\n",
+    "    PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n",
+    "    SELECT (COUNT(?ami) AS ?nombre) WHERE {\n",
+    "        # TODO : pattern pour les foaf:knows d'Alice\n",
+    "    }\n",
+    "    \"\"\"\n",
+    "\n",
+    "    # Etape : executer la requete et afficher le nombre d'amis\n",
+    "    # resultat_ami = g_demo.query(requete_ami)\n",
+    "    # for ligne in resultat_ami:\n",
+    "    #     print(f\"Alice connait {ligne.nombre} personne(s)\")\n",
+    "\n",
+    "    print(\"Exercice a completer : ecrivez le pattern SPARQL pour compter les amis d'Alice\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "41f918c4",
    "metadata": {
     "papermill": {

--- a/scripts/notebook_tools/twin_pairs.d/sw-2-rdf-basics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-2-rdf-basics.yaml
@@ -9,6 +9,13 @@
       python_sha: 1ec640b95feee7021d0f7df93e598101b878dd13
       csharp_sha: fcea9bfbc914f113a7448e2511941ec09908d787
       reason: "Measure/value fix (C# cell 46 « Comparaison des tailles de serialisation » table): 2 rows contradicted the committed cell 45 measured output (17-triplet graphe social). c45 measures RDF/XML 1567 car = 95 % and JSON-LD 2069 car = 126 %, but c46 claimed RDF/XML « ~70-90 % » (95 % outside) and JSON-LD « ~60-80 % » (126 % wrong direction -- JSON-LD is MORE verbose than NTriples here, not more compact). Realigned both rows to the measured output (RDF/XML ~95 %, JSON-LD ~126 %, format le plus lourd), keeping the « valeurs exactes varient » caveat. Turtle 49 % (in 40-60 OK) and NTriples 100 % ref left unchanged. Markdown-only, 0 re-exec, no output change. Python twin SW-2b uses rdflib with different serializer sizes (separate analysis), python unchanged."
+    - date: "2026-08-11"
+      by: myia-po-2025:CoursIA
+      python_sha: 6d4e6bfdf2ca676926c76abda7da505698185020
+      csharp_sha: fcea9bfbc914f113a7448e2511941ec09908d787
+      content_python_sha: e4d4864ac6c5e54c934f445af44401718ecfb82dde43fa1c434ed0c706697440
+      content_csharp_sha: d2471f19c3459505386a13bb7974735deed73ae2b9c4684db8da68111c197c5d
+      reason: "Enrichissement Python-only (#2161): ajout section 7 SPARQL (Exemple guide 3 resolu SELECT + Exercice 3 stub COUNT) avant l'Exercice de synthese qui exigeait une requete SPARQL jamais introduite (pedagogical gap). SPARQL = standard W3C, independant de rdflib ; le jumeau C# SW-2 couvre le meme socle RDF via dotNetRDF et le SPARQL a sa paire dediee SW-4. 4 new cells (39 existing byte-identical), C# unchanged (csharp_sha preserved). Notebook now 4 exercices (was 2)."
   known_differences:
     - "Socle pedagogique commun : construction d'un premier graphe RDF (triplets sujet-predicat-objet), namespaces W3C (RDF/RDFS/XSD)."
     - "Lib-vs-lib : C# = `dotNetRDF 3.2.1` (`#r \"nuget: dotNetRDF, 3.2.1\"`, espaces `VDS.RDF` / `VDS.RDF.Parsing` / `VDS.RDF.Writing`). Python = `rdflib` (`from rdflib import Graph, URIRef, Literal, BNode, Namespace` + `rdflib.namespace` RDF/RDFS/XSD/FOAF/DC)."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/tooling (#10452)

Enrichit SW-2b-Python-RDFBasics avec une section SPARQL manquante. See #2161 (partial : un notebook enrichi, pas le rollout complet).

## Le défaut pedagogique

L'**Exercice de synthese** (cell 34, "reseau social") exigeait de l'etudiant une **requete SPARQL** -- mais SPARQL n'etait **jamais introduit** dans le notebook. Le notebook enseignait construire/serialiser un graphe RDF (rdflib), puis demandait brusquement d'interroger ce graphe avec un langage non enseigne. Lacune pedagogique verifiee firsthand : aucun `g.query(` n'apparaissait avant la synthese.

## Le fix

4 nouvelles cellules inserees a l'index 34 (entre Exercice 2 et l'Exercice de synthese, qui passe de 34 -> 38) :

1. **markdown §7 SPARQL** : intro (SPARQL = SQL pour RDF, motif WHERE / SELECT, `g.query()` integre un moteur SPARQL).
2. **code Exemple guide 3 (RESOLU)** : SPARQL `SELECT ?personne ?nom ... ORDER BY ?nom` sur un petit graphe social (Alice/Bob/Charlie). Output execute reel (ec=12) : "Personnes dans le graphe (triees par nom): Alice -> ... Bob -> ... Charlie -> ...". C'est un **Exemple** (solution complete fonctionnelle) -- ne JAMAIS stubber (cf exercise-example-labeling).
3. **markdown Exercice 3** : instructions (compter les amis d'Alice via `foaf:knows` avec `COUNT`) + indices (`# Indice PREFIX`, `# Etape N`).
4. **code Exercice 3 (STUB)** : `print("Exercice a completer...")`, aucune erreur (C.1 compliant, ec=13).

Le notebook passe de 2 a **4 exercices** (convention >=3, #2161).

## Preuves (firsthand)

- **C.3 scope strict** : diff = **+129 insertions, 0 deletions** sur le notebook. Les 39 cellules existantes sont **byte-identiques** (source-changed=0, outputs-changed=0). Methode : extract-4-cells-with-outputs -> `git checkout HEAD -- <nb>` (restore original intact) -> re-inject ONLY les 4 nouvelles cellules. Evite le churn de re-exec sur les cellules existantes (rdflib iteration non-deterministe).
- **C.2 outputs reels** : Exemple guide 3 ec=12 avec output SPARQL verifie ("Alice/Bob/Charlie" tries). Exercice 3 stub ec=13 (`print`, pas d'erreur).
- **H.3 validate_pr_notebooks** : **PASS** (14 code cells, 0 `execution_count: null` non-stub, 0 `raise NotImplementedError`).
- **count_exercises** : "Sub-threshold: 0" (tous les notebooks >=3 maintenant).
- **CRLF = 0** (LF-only, UTF-8 no-BOM, json indent=1 ensure_ascii=False).

## Twin parity (SemanticWeb/dotNetRDF-rdflib)

SW-2b est jumele avec SW-2-CSharp-RDFBasics (`parity_level: semantic`, rdflib vs dotNetRDF, meme socle W3C RDF 1.1). Mon enrichissement Python-only a fait **DRIFT** le `python_sha` du twin registry. Rebaseline effectue :

```
python scripts/notebook_tools/check_twin_parity.py --update --pair "SW-2 RDF-Basics" --by "myia-po-2025:CoursIA"
```

Nouvelle entree d'audit (2026-08-11) : `python_sha 6d4e6bfd`, `csharp_sha` preserve (C# non modifie). **Re-check : 11/11 OK, DRIFT=0.**

Justification de l'asymetrie Python/C# : SW-2b est explicitement un **sidetrack Python**. SPARQL est un **standard W3C** (independant de rdflib) ; le jumeau C# couvre le meme socle RDF via dotNetRDF, et le SPARQL a sa **paire dediee SW-4** (les deux cotes, Python+C#). Donc l'enrichissement reste dans le socle commun conceptuel -- pas de rupture de parite `semantic`.

## Diff scope

- `MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb` : +129 (4 new cells).
- `scripts/notebook_tools/twin_pairs.d/sw-2-rdf-basics.yaml` : +7 (1 new audit entry + reason).

See #2161, #6443 (cell injection methodology).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
