### PR TITLE
feat(Infer-12,#3801): add EP funnel-immunity section (Prong-B gap)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb
@@ -669,6 +669,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ep-funnel-immunity",
+   "metadata": {},
+   "source": [
+    "## Pourquoi EP ignore le funnel de Neal — l'avantage structural du message-passing\n",
+    "\n",
+    "Le modèle de la cellule précédente utilise la **paramétrisation centrée** `theta[c] ~ N(mu, tau)` : chaque effet de classe dépend directement de la précision de population `tau`. C'est exactement le terrain du **funnel de Neal** — une pathologie géométrique bien connue des modèles hiérarchiques gaussiens.\n",
+    "\n",
+    "**La géométrie du funnel.** Quand les classes sont très semblables, `tau` devient grand (faible dispersion) et la variance conditionnelle de `theta[c] | mu, tau` s'effondre vers zéro. L'espace joint `(tau, theta)` prend alors une forme très coudée, en entonnoir : étroit dans une direction, large dans l'autre. Un **échantillonneur Hamiltonien** (NUTS, utilisé par Stan et PyMC) suit la pente de ce postérieur en simulant une dynamique physique — et sur une géométrie coudée, sa trajectoire *diverge* (l'intégrateur devient instable). Le jumeau Python de ce notebook, **PyMC-12**, consacre une section entière à cette pathologie et compte les divergences.\n",
+    "\n",
+    "**Le remède MCMC : le non-centrage.** La reparamétrisation non centrée `theta = mu + tau^(-1/2) * z` avec `z ~ N(0, 1)` découple `theta` de `tau` et déplie l'entonnoir. C'est un changement de variable (même postérieur cible) qui rend la géométrie tractable pour l'échantillonnage. PyMC-12 le démontre empiriquement.\n",
+    "\n",
+    "**Pourquoi Infer.NET (EP) n'a pas besoin de ce remède.** L'inférence par **Expectation Propagation** ne s'attaque pas au même problème. EP ne *découvre pas* le postérieur en le parcourant — il **calcule** les marginales gaussiennes par **message-passing** sur le graphe de facteurs, en forme fermée pour la famille exponentielle. Il n'y a **pas de trajectoire** à diverger : la pathologie géométrique du funnel suppose un échantillonneur qui se déplace dans l'espace des paramètres, ce qu'EP ne fait jamais. Le modèle centré de la cellule 7 — qui serait pathogène pour NUTS — est inféré par EP **sans aucun diagnostic de divergence**, parce que le moteur n'en produit tout simplement pas. C'est l'avantage structural du calcul déterministe sur ce paradigme précis.\n",
+    "\n",
+    "> **La frontière de cet avantage.** EP paie son immunité au funnel par une **approximation gaussienne** : il projette forcément le postérieur sur une Gaussienne. Si le vrai postérieur est réellement multimodal ou fortement non-gaussien, EP le rabat sur une seule bosse et perd cette information (cf. Infer-2, qui confronte EP à VMP sur un mélange bimodal). Sur le modèle hiérarchique gaussien de ce notebook, où le postérieur est unimodal et quasi-gaussien, l'approximation est légitime — et l'absence de funnel est un vrai gain. Hors de ce régime, l'échantillonnage (PyMC) redevient l'outil adapté.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "096d8227",
    "metadata": {},
    "source": [

--- a/scripts/notebook_tools/twin_pairs.d/probas-12-modeles-hierarchiques.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-12-modeles-hierarchiques.yaml
@@ -8,6 +8,13 @@
       by: myia-po-2023:CoursIA
       python_sha: 91a08f3e69ac3eec7a3341d281a7b5386f018b5a
       csharp_sha: d9c7d20cdaa32ffa09e33a08a0646da228e08e84
+    - date: "2026-08-11"
+      by: myia-po-2025:CoursIA
+      python_sha: 91a08f3e69ac3eec7a3341d281a7b5386f018b5a
+      csharp_sha: 3606ff946d2c9622571442060c48a53d5cf14910
+      content_python_sha: 99a14bd3dbaf782912118a61e13f40a75e9adad8bca10368022d40edd6cbab2e
+      content_csharp_sha: bb2450a9abefd49a370c77b2ed6d6bd97402df3a101d7c4c0a76de72e1c40cd6
+      reason: "Enrichissement C#-only (#3801 Prong-B): ajout section markdown 'Pourquoi EP ignore le funnel de Neal' entre cellule 10 (Lecture du resultat) et cellule 11 (Exercices). La conclusion cellule 17 mentionnait EP 'analytique' sans JAMAIS expliquer pourquoi (funnel/Neal/divergence = 0 occurrences vs PyMC-12 funnel x11). La section demontre que le modele centree de la cellule 7 (pathogene pour NUTS) est infere sans diagnostic par EP (message-passing, pas d'echantillonnage). Python PyMC-12 inchange (deja couvre le cote MCMC du funnel). Asymetrie legitime = le sujet pedagogique meme de la paire (EP-vs-NUTS). 19 cells existantes byte-identiques, markdown-only (C.2 exception)."
   known_differences:
   - 'Socle pedagogique commun : modeles hierarchiques (effets aleatoires emboites) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA — prev: MED/notebook-python (#10456)

Comble un gap Prong-B (sota-not-workaround) sur Infer-12-Modeles-Hierarchiques : la compétence distinctive d'EP est nommée par allusion sans être jamais expliquée ni démontrée. See #3801.

## Le défaut pédagogique (mesuré firsthand, G.1)

Le notebook C# **Infer-12** mentionne dans sa conclusion (cell 17) que « L'inférence par EP est **analytique** (pas de MCMC) » — mais ne développe **JAMAIS** pourquoi cela importe. G.1 verify firsthand sur origin/main :

```
Infer-12 (C#):  funnel=0  Neal=0  non-centr=0  divergen=0
```

Son jumeau Python **PyMC-12** consacre une section entière à la même pathologie :
```
PyMC-12 (Python): funnel=11  Neal=7  non-centr=6  divergen=10
```

PyMC-12 cell[10] dit explicitement : « les divergences -- un diagnostic qu'EP, étant analytique, ne peut pas produire ». Le README de la série (lignes 122, 128, 286) cadre cette paire comme la démonstration de l'asymétrie structurelle EP (message-passing déterministe) vs NUTS (échantillonnage). Mais le côté C# de l'asymétrie n'est jamais expliqué.

## Le fix (markdown-only, 1 cell)

Insère une section markdown entre cell[10] (« Lecture du résultat ») et cell[11] (« Exercices ») :

**« Pourquoi EP ignore le funnel de Neal — l'avantage structural du message-passing »**

4 paragraphes pédagogiques :

1. **La géométrie du funnel** : quand `tau` est grand (classes très semblables), la variance conditionnelle de `theta[c] | mu, tau` s'effondre → géométrie coudée en entonnoir où l'échantillonneur Hamiltonien NUTS *diverge*.

2. **Le remède MCMC** : reparamétrisation non centrée `theta = mu + tau^(-1/2) * z` (que PyMC-12 démontre).

3. **Pourquoi EP n'a pas besoin de ce remède** : EP fait du **message-passing** sur le graphe de facteurs, calcule les marginales gaussiennes **analytiquement** en forme fermée. Pas de trajectoire → pas de divergence. **Le modèle centré de la cellule 7 — qui serait pathogène pour NUTS — est inféré par EP sans aucun diagnostic de divergence.**

4. **La frontière honnête** : EP paie son immunité par l'approximation gaussienne (cf. Infer-2 EP-vs-VMP sur mélange bimodal). Sur le modèle gaussien unimodal de ce notebook, l'approximation est légitime.

## Pourquoi c'est un vrai gap Prong-B (pas du remplissage)

Le modèle hiérarchique de la cellule 7 utilise la **paramétrisation centrée** `theta[c] = Variable.GaussianFromMeanAndPrecision(mu, tau)` — exactement le setup pathogène pour NUTS. La section explique pourquoi ce code précis, qui ferait diverger Stan/PyMC, est inféré sans diagnostic par Infer.NET. **La capacité distinctive du moteur est démontrée sur le vrai code du notebook, pas sur un exemple fabriqué.**

## Preuves (firsthand)

- **C.3 scope strict** : diff = **+18 insertions, 0 deletions**. 19 cellules existantes byte-identiques (0 source lines deleted, 0 outputs changed). Markdown-only → C.2 exception (pas de re-exec).
- **CRLF = 0** (LF-only, matche origin/main).
- **H.3 validate_pr_notebooks** : **PASS** (8 code cells, 0 erreur).
- **nbformat validate** : VALID, 20 cells (was 19).
- **Accents français préservés** (cohérent avec le reste du notebook FR).

## Twin parity (Probas/Infer.NET-PyMC)

Infer-12 est jumeau avec PyMC-12 (`parity_level: semantic`, EP-vs-NUTS). Mon enrichissement markdown-only C# fait DRIFT le `csharp_sha`. Rebaseline effectué (commit notebook → `--update` lit le blob committed → commit registry). Asymétrie justifiée : c'est précisément l'**asymétrie** qui est le sujet pédagogique de la paire (EP déterministe vs NUTS échantillonnage) — l'enrichissement explicite le côté C# d'une asymétrie que le README cadre déjà.

See #3801 (Prong-B : moteur dont la capacité distinctive n'est pas exercée), #2161.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
