### PR TITLE
feat(genai,#10460): notebook — mesurer la distinctivité de plusieurs assistants

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/README.md
@@ -64,9 +64,11 @@ décider **quand l'un est plus adapté que l'autre** pour un projet donné.
 
 ## Conception
 
-Une fois la plateforme choisie, une question de conception se pose à l'identique
-des deux côtés : **plusieurs assistants, un seul catalogue d'outils — comment
-cadre-t-on ce que chacun a le droit de faire ?**
+Une fois la plateforme choisie, les deux mêmes questions se posent de part et
+d'autre, et elles forment une paire : **ce que chaque assistant a le droit de
+faire**, et **qui il est réellement**.
+
+### Ce qu'il a le droit de faire
 
 [`cadrer-les-agents.md`](cadrer-les-agents.md) distingue les trois couches qu'on
 confond habituellement — l'intention (prompt système), la portée (catalogue
@@ -76,6 +78,22 @@ critère de décision : on apparie le mécanisme à la **réversibilité de l'ac
 Le document compare ce que chaque plateforme prend en charge nativement de la
 troisième couche, et fournit la manipulation permettant de le vérifier sur son
 propre déploiement.
+
+### Qui il est
+
+[`differencier-les-assistants.ipynb`](differencier-les-assistants.ipynb) traite
+l'autre moitié. Déclarer quatre assistants spécialisés ne les rend pas
+distincts : le prompt porte une intention, la spécialisation est une propriété
+des sorties. Le notebook construit la mesure — une batterie de sondes ambiguës,
+puis un test de discriminabilité qui demande si l'on peut retrouver l'auteur
+d'une réponse dont on a caché l'étiquette.
+
+Il est monté autour de deux contrôles placés exprès dans l'atelier, et le second
+donne le résultat le plus utile : une paraphrase stricte s'effondre — les deux
+assistants sont systématiquement pris l'un pour l'autre — tandis qu'un assistant
+partageant le **même terrain** mais adoptant une **posture** différente reste
+largement distinguable. Ce qu'un modèle restitue le plus fidèlement d'un prompt
+système est la position adoptée, pas le domaine annoncé.
 
 ---
 

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/differencier-les-assistants.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/differencier-les-assistants.ipynb
@@ -1,0 +1,1088 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "17196900",
+   "metadata": {},
+   "source": [
+    "# Différencier plusieurs assistants — mesurer ce qu'un prompt promet\n",
+    "\n",
+    "[← Plateformes conversationnelles](README.md)\n",
+    "\n",
+    "Une plateforme conversationnelle laisse déclarer autant d'assistants qu'on veut.\n",
+    "Chacun reçoit un prompt système, une étiquette, parfois une icône. On croit avoir\n",
+    "spécialisé. On a souvent seulement étiqueté.\n",
+    "\n",
+    "Ce notebook construit la mesure qui sépare les deux cas.\n",
+    "\n",
+    "## Objectifs\n",
+    "\n",
+    "- Poser un protocole qui **teste** une spécialisation au lieu de la déclarer\n",
+    "- Implémenter deux métriques de recouvrement — la naïve, puis l'honnête — et voir\n",
+    "  précisément ce que la première laisse passer\n",
+    "- Reconnaître le piège symétrique : la distance entre *prompts* n'est pas la\n",
+    "  distance entre *réponses*, et l'écart joue dans les deux sens\n",
+    "\n",
+    "## Prérequis\n",
+    "\n",
+    "- Un endpoint compatible OpenAI (vLLM, Ollama, llama.cpp, ou l'API d'un\n",
+    "  fournisseur) et un modèle de chat\n",
+    "- `openai` et `numpy`, volontairement rien d'autre : les deux métriques tiennent\n",
+    "  en une quinzaine de lignes chacune, et les lire vaut mieux que les appeler\n",
+    "\n",
+    "## Durée estimée\n",
+    "\n",
+    "45 minutes, dont environ deux minutes de collecte."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a7baf4e",
+   "metadata": {},
+   "source": [
+    "## Le problème\n",
+    "\n",
+    "Le symptôme ne se plaint jamais. Un lecteur ouvre le sélecteur d'assistants,\n",
+    "essaie le deuxième, reçoit une réponse qui ressemble à celle du premier, et cesse\n",
+    "d'utiliser le sélecteur. Personne n'ouvre de ticket pour signaler que les quatre\n",
+    "assistants n'en font qu'un.\n",
+    "\n",
+    "En revue, on compare les prompts système. C'est le mauvais objet. Un prompt est\n",
+    "une **intention** ; la spécialisation est une propriété **des sorties**. Rien\n",
+    "n'interdit à un modèle de recevoir quatre cadrages distincts et de produire\n",
+    "quatre réponses interchangeables — c'est même le cas par défaut quand les\n",
+    "cadrages portent sur le ton plutôt que sur la matière.\n",
+    "\n",
+    "La question voisine — ce qu'un assistant a le *droit* de faire — est traitée dans\n",
+    "[`cadrer-les-agents.md`](cadrer-les-agents.md). Celle-ci en est l'autre moitié :\n",
+    "**qui il est**, et comment on le vérifie autrement qu'à l'oeil."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "93939d1b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T13:28:40.574462Z",
+     "iopub.status.busy": "2026-08-11T13:28:40.573457Z",
+     "iopub.status.idle": "2026-08-11T13:28:41.762746Z",
+     "shell.execute_reply": "2026-08-11T13:28:41.761533Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "python : 3.12.13\n",
+      "numpy  : 1.26.0\n",
+      "modele : qwen3.6-35b-a3b\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os, re, sys, time\n",
+    "import numpy as np\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "# Configuration par variables d'environnement : aucune clé dans le notebook.\n",
+    "BASE_URL = os.environ.get(\"COURSIA_LLM_BASE_URL\", \"http://localhost:8000/v1\")\n",
+    "API_KEY  = os.environ.get(\"COURSIA_LLM_API_KEY\", \"sk-no-key-required\")\n",
+    "MODELE   = os.environ.get(\"COURSIA_LLM_MODEL\", \"qwen3.6-35b-a3b\")\n",
+    "\n",
+    "# Modèle de raisonnement : on coupe la phase de réflexion. On mesure la voix de\n",
+    "# l'assistant, pas son brouillon — et sans cela `content` revient vide dès que le\n",
+    "# budget de tokens part entièrement dans le raisonnement.\n",
+    "SANS_RAISONNEMENT = {\"chat_template_kwargs\": {\"enable_thinking\": False}}\n",
+    "\n",
+    "client = OpenAI(base_url=BASE_URL, api_key=API_KEY)\n",
+    "\n",
+    "print(\"python :\", sys.version.split()[0])\n",
+    "print(\"numpy  :\", np.__version__)\n",
+    "print(\"modele :\", MODELE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be86aacd",
+   "metadata": {},
+   "source": [
+    "## L'atelier fictif\n",
+    "\n",
+    "Six assistants pour un atelier d'écriture, à la médiathèque de Valmont. Le\n",
+    "corpus est entièrement inventé : ni les prompts, ni les assistants, ni le lieu ne\n",
+    "proviennent d'un déploiement réel.\n",
+    "\n",
+    "Quatre sont annoncés comme complémentaires — `structure`, `style`,\n",
+    "`documentation`, `pratique`. Les deux derniers sont des **contrôles**, placés là\n",
+    "exprès, et ils ne sont pas du même genre :\n",
+    "\n",
+    "| Contrôle | Rapport à `style` | Ce qu'on attend |\n",
+    "|---|---|---|\n",
+    "| `expression` | paraphrase : même terrain, même posture, autres mots | la mesure doit les confondre |\n",
+    "| `relecture` | même terrain, mais posture inverse — on lui soumet un texte, il réagit | à discuter |\n",
+    "\n",
+    "Le premier valide l'instrument : un dispositif qui ne détecte pas une redondance\n",
+    "qu'on y a mise exprès ne détectera pas celles qu'on n'a pas vues. Le second est\n",
+    "là parce qu'on **croit** savoir qu'il est redondant — et c'est précisément le\n",
+    "genre de conviction que la mesure existe pour arbitrer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d3807ca0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T13:28:41.765899Z",
+     "iopub.status.busy": "2026-08-11T13:28:41.765373Z",
+     "iopub.status.idle": "2026-08-11T13:28:41.773203Z",
+     "shell.execute_reply": "2026-08-11T13:28:41.772134Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6 assistants : structure, style, documentation, pratique, expression, relecture\n"
+     ]
+    }
+   ],
+   "source": [
+    "PERSONAS = {\n",
+    "    \"structure\": (\n",
+    "        \"Tu animes un atelier d'écriture à la médiathèque de Valmont. \"\n",
+    "        \"Ton domaine est l'architecture du récit : découpage en chapitres, \"\n",
+    "        \"progression dramatique, place des retournements, tenue des arcs de \"\n",
+    "        \"personnages. Tu ramènes toujours la question posée à la charpente du \"\n",
+    "        \"texte. Tu ne commentes ni le vocabulaire ni la ponctuation.\"\n",
+    "    ),\n",
+    "    \"style\": (\n",
+    "        \"Tu animes un atelier d'écriture à la médiathèque de Valmont. \"\n",
+    "        \"Ton domaine est la phrase : rythme, longueur, sonorités, niveau de \"\n",
+    "        \"langue, images. Tu fais entendre ce qu'une tournure produit sur le \"\n",
+    "        \"lecteur et tu proposes des variantes. Tu ne discutes pas de l'intrigue.\"\n",
+    "    ),\n",
+    "    \"documentation\": (\n",
+    "        \"Tu animes un atelier d'écriture à la médiathèque de Valmont. \"\n",
+    "        \"Ton domaine est l'ancrage factuel : sources, vérification des détails \"\n",
+    "        \"d'époque, de métier, de lieu. Tu indiques où chercher et quoi vérifier \"\n",
+    "        \"avant d'écrire une scène. Tu ne juges ni le style ni la construction.\"\n",
+    "    ),\n",
+    "    \"pratique\": (\n",
+    "        \"Tu animes un atelier d'écriture à la médiathèque de Valmont. \"\n",
+    "        \"Ton domaine est la conduite du travail : régularité, gestion du \"\n",
+    "        \"découragement, organisation des séances, façon de tenir un projet \"\n",
+    "        \"long. Tu parles méthode et habitude, jamais du contenu du texte.\"\n",
+    "    ),\n",
+    "    # Contrôle 1 : paraphrase stricte de `style`. Même terrain, même posture\n",
+    "    # didactique, vocabulaire délibérément disjoint.\n",
+    "    \"expression\": (\n",
+    "        \"Tu animes un atelier d'écriture à la médiathèque de Valmont. \"\n",
+    "        \"Ce qui t'occupe est la manière de dire : la musique des mots, la \"\n",
+    "        \"longueur des propositions, le registre, les comparaisons. Tu montres \"\n",
+    "        \"l'effet qu'une formulation produit chez celui qui lit, et tu offres \"\n",
+    "        \"d'autres façons de tourner la même chose. La construction de \"\n",
+    "        \"l'histoire ne te concerne pas.\"\n",
+    "    ),\n",
+    "    # Contrôle 2 : même terrain que `style`, posture inverse — il attend un\n",
+    "    # texte et réagit, là où `style` expose.\n",
+    "    \"relecture\": (\n",
+    "        \"Tu animes un atelier d'écriture à la médiathèque de Valmont. \"\n",
+    "        \"On te soumet des textes pour les améliorer à la relecture. Tu repères \"\n",
+    "        \"les formulations lourdes, les répétitions, les effets manqués, et tu \"\n",
+    "        \"suggères de meilleures façons de le dire. Tu restes au niveau de \"\n",
+    "        \"l'expression.\"\n",
+    "    ),\n",
+    "}\n",
+    "\n",
+    "noms = list(PERSONAS)\n",
+    "print(f\"{len(noms)} assistants :\", \", \".join(noms))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06fd7cc5",
+   "metadata": {},
+   "source": [
+    "## Les sondes\n",
+    "\n",
+    "Une sonde utile est **ambiguë** : chaque assistant peut légitimement y répondre.\n",
+    "C'est exactement là que l'indiscernabilité devient visible.\n",
+    "\n",
+    "Une sonde trop précise ne mesure rien. Demander comment accorder un participe\n",
+    "force la réponse : tous les assistants convergeront, et on conclura à tort qu'ils\n",
+    "sont identiques. Le protocole doit laisser à chacun la place de révéler son\n",
+    "angle — sinon il mesure la contrainte de la question, pas la spécialisation de\n",
+    "l'assistant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "151790fc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T13:28:41.776322Z",
+     "iopub.status.busy": "2026-08-11T13:28:41.775799Z",
+     "iopub.status.idle": "2026-08-11T13:28:41.781597Z",
+     "shell.execute_reply": "2026-08-11T13:28:41.781086Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6 assistants x 6 sondes = 36 réponses\n"
+     ]
+    }
+   ],
+   "source": [
+    "SONDES = [\n",
+    "    \"J'ai écrit trois chapitres et je suis bloqué. Que me conseilles-tu ?\",\n",
+    "    \"Comment savoir si ce que j'écris est bon ?\",\n",
+    "    \"Je veux écrire une scène dans un port de pêche en 1930.\",\n",
+    "    \"Mon personnage principal ne m'intéresse plus.\",\n",
+    "    \"Je n'arrive pas à m'y mettre le matin.\",\n",
+    "    \"Un lecteur m'a dit que mon texte était plat. Par où commencer ?\",\n",
+    "]\n",
+    "\n",
+    "print(f\"{len(noms)} assistants x {len(SONDES)} sondes = {len(noms) * len(SONDES)} réponses\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38a05703",
+   "metadata": {},
+   "source": [
+    "## Collecte\n",
+    "\n",
+    "`temperature` basse et `seed` fixe : on veut que deux exécutions du notebook\n",
+    "donnent des chiffres comparables. La reproductibilité n'est pas garantie d'un\n",
+    "serveur à l'autre — le lot, la précision et la version du moteur d'inférence\n",
+    "jouent — mais elle l'est raisonnablement d'une exécution à la suivante sur le\n",
+    "même déploiement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "23b58f40",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T13:28:41.784735Z",
+     "iopub.status.busy": "2026-08-11T13:28:41.784735Z",
+     "iopub.status.idle": "2026-08-11T13:31:06.781311Z",
+     "shell.execute_reply": "2026-08-11T13:31:06.780789Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  structure      6 réponses, 0 vide(s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  style          6 réponses, 0 vide(s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  documentation  6 réponses, 0 vide(s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  pratique       6 réponses, 0 vide(s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  expression     6 réponses, 0 vide(s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  relecture      6 réponses, 0 vide(s)\n",
+      "\n",
+      "collecte terminée en 145s\n"
+     ]
+    }
+   ],
+   "source": [
+    "def interroger(prompt_systeme, question, max_tokens=350):\n",
+    "    reponse = client.chat.completions.create(\n",
+    "        model=MODELE,\n",
+    "        messages=[\n",
+    "            {\"role\": \"system\", \"content\": prompt_systeme},\n",
+    "            {\"role\": \"user\", \"content\": question},\n",
+    "        ],\n",
+    "        temperature=0.3, seed=7, max_tokens=max_tokens,\n",
+    "        extra_body=SANS_RAISONNEMENT,\n",
+    "    )\n",
+    "    return reponse.choices[0].message.content or \"\"\n",
+    "\n",
+    "\n",
+    "debut = time.time()\n",
+    "reponses = {}                      # (assistant, indice de sonde) -> texte\n",
+    "for nom, prompt_systeme in PERSONAS.items():\n",
+    "    for i, sonde in enumerate(SONDES):\n",
+    "        reponses[(nom, i)] = interroger(prompt_systeme, sonde)\n",
+    "    vides = sum(1 for i in range(len(SONDES)) if not reponses[(nom, i)].strip())\n",
+    "    print(f\"  {nom:14s} {len(SONDES)} réponses, {vides} vide(s)\")\n",
+    "\n",
+    "print(f\"\\ncollecte terminée en {time.time() - debut:.0f}s\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c10b86cf",
+   "metadata": {},
+   "source": [
+    "## Le test à l'oeil, d'abord\n",
+    "\n",
+    "Avant toute métrique, lisons. Voici `style` et sa paraphrase `expression` sur la\n",
+    "même sonde : deux prompts sans presque aucun mot commun, censés couvrir\n",
+    "exactement le même terrain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c3035a2a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T13:31:06.785008Z",
+     "iopub.status.busy": "2026-08-11T13:31:06.784489Z",
+     "iopub.status.idle": "2026-08-11T13:31:06.790888Z",
+     "shell.execute_reply": "2026-08-11T13:31:06.790348Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "========================================================================\n",
+      "STYLE  —  sonde : Un lecteur m'a dit que mon texte était plat. Par où commencer ?\n",
+      "========================================================================\n",
+      "Bonjour. Asseyez-vous. Ne vous inquiétez pas, le mot \"plat\" est souvent le premier signe que votre texte dort encore sur la page. Il respire, mais il ne danse pas.\n",
+      "\n",
+      "Pour redonner vie à une prose plate, nous n'allons pas toucher à l'histoire. L'intrigue, c'est le squelette ; ce qui nous intéresse ici, c'est la chair, le sang et le nerf. C'est la **musique** de la phrase.\n",
+      "\n",
+      "Voici trois leviers immédiats pour réveiller votre texte. Prenez un paragraphe de votre manuscrit et testons ces trois exercices ensemble.\n",
+      "\n",
+      "### 1. Le Rythme : La respiration de la phrase\n",
+      "\n",
+      "Une phrase plate a souvent une métrique uniforme. Elle suit un schéma sujet-verbe-complément régulier, comme un métronome qui ne change ja\n",
+      "\n",
+      "========================================================================\n",
+      "EXPRESSION  —  sonde : Un lecteur m'a dit que mon texte était plat. Par où commencer ?\n",
+      "========================================================================\n",
+      "Bonjour. Installez-vous. C’est une remarque dure, mais c’est aussi la plus précieuse qu’un écrivain puisse recevoir. « Plat », c’est le mot qui signifie que le lecteur glisse sur la surface de vos mots sans jamais sentir la texture, le grain, ou la chaleur.\n",
+      "\n",
+      "Ne vous inquiétez pas pour l’intrigue, pour l’histoire. Nous allons travailler uniquement sur la **chair** de votre texte.\n",
+      "\n",
+      "Pour redonner du volume, de la profondeur et de la musicalité à un texte plat, nous allons jouer sur quatre leviers. Prenez un passage de votre texte, même court, et regardons comment on peut le « réanimer » ensemble.\n",
+      "\n",
+      "Voici les quatre axes sur lesquels nous allons travailler :\n",
+      "\n",
+      "### 1. La Musique des Mots (Le Rythme\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for nom in (\"style\", \"expression\"):\n",
+    "    print(\"=\" * 72)\n",
+    "    print(f\"{nom.upper()}  —  sonde : {SONDES[5]}\")\n",
+    "    print(\"=\" * 72)\n",
+    "    print(reponses[(nom, 5)][:700])\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8588c0fd",
+   "metadata": {},
+   "source": [
+    "## La métrique naïve — le recouvrement lexical\n",
+    "\n",
+    "Premier réflexe : comparer les vocabulaires. Deux assistants qui emploient les\n",
+    "mêmes mots se ressemblent, non ?\n",
+    "\n",
+    "On mesure par l'indice de Jaccard — taille de l'intersection sur taille de\n",
+    "l'union — après retrait des mots vides et des mots trop courts.\n",
+    "\n",
+    "Gardez une question en tête pendant la lecture du tableau : **à partir de quelle\n",
+    "valeur décide-t-on que deux assistants sont redondants ?** C'est là-dessus que\n",
+    "cette métrique va se briser, et pas là où on l'attend."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0362e21b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T13:31:06.794043Z",
+     "iopub.status.busy": "2026-08-11T13:31:06.793514Z",
+     "iopub.status.idle": "2026-08-11T13:31:06.839380Z",
+     "shell.execute_reply": "2026-08-11T13:31:06.838352Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "recouvrement lexical (Jaccard) — 1.00 = vocabulaires identiques\n",
+      "\n",
+      "                  structure       style   documenta    pratique   expressio   relecture\n",
+      "structure              1.00        0.10        0.11        0.15        0.09        0.13\n",
+      "style                  0.10        1.00        0.11        0.15        0.23        0.16\n",
+      "documentation          0.11        0.11        1.00        0.12        0.11        0.10\n",
+      "pratique               0.15        0.15        0.12        1.00        0.14        0.13\n",
+      "expression             0.09        0.23        0.11        0.14        1.00        0.16\n",
+      "relecture              0.13        0.16        0.10        0.13        0.16        1.00\n",
+      "\n",
+      "paires les plus proches selon Jaccard :\n",
+      "  style          expression     0.23\n",
+      "  style          relecture      0.16\n",
+      "  expression     relecture      0.16\n"
+     ]
+    }
+   ],
+   "source": [
+    "MOTS_VIDES = set(\"\"\"\n",
+    "alors aussi autre autres avec avoir bien car ces cet cette ceux chaque comme\n",
+    "dans des donc dont elle elles est être eux fait faire ici leur leurs lorsque\n",
+    "mais mes moins même nos notre nous ont par pas peu peut plus pour pourquoi\n",
+    "quand que quel quelle quels quelles qui quoi sans ses son sont sous sur tous\n",
+    "tout toute toutes très une vers votre vos vous était étaient été cela plutôt\n",
+    "ainsi entre chez déjà encore jamais toujours beaucoup trop assez tel telle\n",
+    "vraiment surtout simplement souvent parfois faut peuvent doit doivent\n",
+    "\"\"\".split())\n",
+    "\n",
+    "\n",
+    "def tokeniser(texte):\n",
+    "    mots = re.findall(r\"[a-zà-ÿ]+\", texte.lower())\n",
+    "    return [m for m in mots if len(m) > 2 and m not in MOTS_VIDES]\n",
+    "\n",
+    "\n",
+    "def vocabulaire(nom):\n",
+    "    return {t for i in range(len(SONDES)) for t in tokeniser(reponses[(nom, i)])}\n",
+    "\n",
+    "\n",
+    "J = np.zeros((len(noms), len(noms)))\n",
+    "for a, na in enumerate(noms):\n",
+    "    for b, nb in enumerate(noms):\n",
+    "        va, vb = vocabulaire(na), vocabulaire(nb)\n",
+    "        J[a, b] = len(va & vb) / len(va | vb)\n",
+    "\n",
+    "print(\"recouvrement lexical (Jaccard) — 1.00 = vocabulaires identiques\\n\")\n",
+    "print(\" \" * 15 + \"\".join(f\"{n[:9]:>12s}\" for n in noms))\n",
+    "for a, na in enumerate(noms):\n",
+    "    print(f\"{na:15s}\" + \"\".join(f\"{J[a, b]:12.2f}\" for b in range(len(noms))))\n",
+    "\n",
+    "paires_j = sorted(\n",
+    "    ((J[a, b], noms[a], noms[b])\n",
+    "     for a in range(len(noms)) for b in range(a + 1, len(noms))),\n",
+    "    reverse=True,\n",
+    ")\n",
+    "print(\"\\npaires les plus proches selon Jaccard :\")\n",
+    "for v, x, y in paires_j[:3]:\n",
+    "    print(f\"  {x:14s} {y:14s} {v:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60d5f55f",
+   "metadata": {},
+   "source": [
+    "### Ce que ce tableau permet de décider\n",
+    "\n",
+    "Le couple `style` / `expression` sort en tête, à 0.23. La métrique n'a donc pas\n",
+    "manqué la redondance : elle l'a classée première. Il faut le dire, parce que la\n",
+    "suite ne consiste pas à la disqualifier.\n",
+    "\n",
+    "Le problème est ailleurs. Que fait-on de 0.23 ?\n",
+    "\n",
+    "Les autres valeurs s'échelonnent entre 0.09 et 0.16. Rien dans ce tableau ne dit\n",
+    "si 0.23 est *beaucoup* : il n'y a pas de valeur de référence, pas de « voici ce\n",
+    "que donneraient deux assistants sans aucun rapport ». On peut classer ; on ne\n",
+    "peut pas conclure. Et si l'on se donne un seuil maintenant, on le choisit en\n",
+    "regardant les données qu'il doit trancher — ce qui revient à se donner raison.\n",
+    "\n",
+    "Deuxième limite, moins visible : une matrice de similarité dit que deux\n",
+    "vocabulaires se recouvrent, jamais que deux assistants sont **interchangeables**.\n",
+    "Ce sont deux affirmations différentes, et c'est la seconde qui décide s'il faut\n",
+    "en retirer un du catalogue."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84229be5",
+   "metadata": {},
+   "source": [
+    "## La métrique honnête — la discriminabilité\n",
+    "\n",
+    "Reformulons la question pour qu'elle admette une réponse falsifiable :\n",
+    "\n",
+    "> On cache l'auteur d'une réponse. Peut-on le retrouver à partir des autres\n",
+    "> réponses ?\n",
+    "\n",
+    "Si oui, l'assistant a une signature : il apporte quelque chose que les autres\n",
+    "n'apportent pas. Si non, son étiquette est décorative — quel que soit le soin mis\n",
+    "à rédiger son prompt.\n",
+    "\n",
+    "C'est un problème de classification, et il tient en quinze lignes. Chaque réponse\n",
+    "devient un vecteur TF-IDF. Pour chaque réponse, on la **retire** du jeu, on\n",
+    "calcule le centre de gravité de chaque assistant sur ce qui reste, et on attribue\n",
+    "la réponse au centre le plus proche.\n",
+    "\n",
+    "Retirer la réponse testée est le point qui décide de tout : sans cela, chaque\n",
+    "réponse contribue à son propre centre, et le score obtenu mesure surtout la\n",
+    "capacité d'un texte à se ressembler à lui-même.\n",
+    "\n",
+    "Et surtout, cette métrique-ci **vient avec son repère** : six assistants, donc le\n",
+    "hasard vaut 1/6, soit 0.17. C'est ce que Jaccard n'avait pas. Un chiffre de\n",
+    "similarité isolé ne permet aucune décision ; un chiffre situé par rapport à ce\n",
+    "que produirait l'absence totale de signal, oui."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5c105df6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T13:31:06.843532Z",
+     "iopub.status.busy": "2026-08-11T13:31:06.843008Z",
+     "iopub.status.idle": "2026-08-11T13:31:06.876786Z",
+     "shell.execute_reply": "2026-08-11T13:31:06.876272Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "exactitude : 0.58      (hasard = 0.17)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def matrice_tfidf(documents):\n",
+    "    \"\"\"Chaque ligne : un document, normalisé, en pondération TF-IDF.\"\"\"\n",
+    "    vocab = sorted({t for d in documents for t in tokeniser(d)})\n",
+    "    rang = {t: i for i, t in enumerate(vocab)}\n",
+    "    tf = np.zeros((len(documents), len(vocab)))\n",
+    "    for i, d in enumerate(documents):\n",
+    "        for t in tokeniser(d):\n",
+    "            tf[i, rang[t]] += 1\n",
+    "    tf /= np.maximum(tf.sum(axis=1, keepdims=True), 1)\n",
+    "    df = (tf > 0).sum(axis=0)\n",
+    "    idf = np.log((1 + len(documents)) / (1 + df)) + 1\n",
+    "    X = tf * idf\n",
+    "    return X / np.maximum(np.linalg.norm(X, axis=1, keepdims=True), 1e-12)\n",
+    "\n",
+    "\n",
+    "def discriminabilite(X, etiquettes):\n",
+    "    \"\"\"Pour chaque ligne : centre le plus proche, calculé SANS cette ligne.\"\"\"\n",
+    "    classes = sorted(set(etiquettes))\n",
+    "    predictions = []\n",
+    "    for i in range(len(X)):\n",
+    "        centres = []\n",
+    "        for c in classes:\n",
+    "            membres = [j for j in range(len(X)) if etiquettes[j] == c and j != i]\n",
+    "            centres.append(X[membres].mean(axis=0))\n",
+    "        C = np.array(centres)\n",
+    "        C /= np.maximum(np.linalg.norm(C, axis=1, keepdims=True), 1e-12)\n",
+    "        predictions.append(classes[int(np.argmax(C @ X[i]))])\n",
+    "    return predictions\n",
+    "\n",
+    "\n",
+    "cles = [(n, i) for n in noms for i in range(len(SONDES))]\n",
+    "X = matrice_tfidf([reponses[k] for k in cles])\n",
+    "vrai = [k[0] for k in cles]\n",
+    "predit = discriminabilite(X, vrai)\n",
+    "\n",
+    "exactitude = sum(v == p for v, p in zip(vrai, predit)) / len(vrai)\n",
+    "print(f\"exactitude : {exactitude:.2f}      (hasard = {1 / len(noms):.2f})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "eeb8a5e9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T13:31:06.879902Z",
+     "iopub.status.busy": "2026-08-11T13:31:06.879376Z",
+     "iopub.status.idle": "2026-08-11T13:31:06.886781Z",
+     "shell.execute_reply": "2026-08-11T13:31:06.885717Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lignes = auteur réel, colonnes = auteur retrouvé\n",
+      "\n",
+      "                  structure       style   documenta    pratique   expressio   relecture\n",
+      "structure                 6           0           0           0           0           0\n",
+      "style                     0           0           0           0           6           0\n",
+      "documentation             0           0           6           0           0           0\n",
+      "pratique                  0           0           0           6           0           0\n",
+      "expression                0           6           0           0           0           0\n",
+      "relecture                 1           2           0           0           0           3\n",
+      "\n",
+      "reconnaissance par assistant :\n",
+      "  structure       6/6\n",
+      "  style           0/6\n",
+      "  documentation   6/6\n",
+      "  pratique        6/6\n",
+      "  expression      0/6\n",
+      "  relecture       3/6\n"
+     ]
+    }
+   ],
+   "source": [
+    "conf = {a: {b: 0 for b in noms} for a in noms}\n",
+    "for v, p in zip(vrai, predit):\n",
+    "    conf[v][p] += 1\n",
+    "\n",
+    "print(\"lignes = auteur réel, colonnes = auteur retrouvé\\n\")\n",
+    "print(\" \" * 15 + \"\".join(f\"{n[:9]:>12s}\" for n in noms))\n",
+    "for a in noms:\n",
+    "    print(f\"{a:15s}\" + \"\".join(f\"{conf[a][b]:12d}\" for b in noms))\n",
+    "\n",
+    "print(\"\\nreconnaissance par assistant :\")\n",
+    "for a in noms:\n",
+    "    print(f\"  {a:15s} {conf[a][a]}/{len(SONDES)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c2d1abd",
+   "metadata": {},
+   "source": [
+    "### La signature de la redondance\n",
+    "\n",
+    "Trois lignes propres, deux lignes qui se répondent, une ligne partagée.\n",
+    "\n",
+    "`structure`, `documentation` et `pratique` sont reconnus 6 fois sur 6. Ceux-là\n",
+    "apportent quelque chose que les autres n'apportent pas.\n",
+    "\n",
+    "`style` est reconnu **0 fois sur 6** — et ses six réponses sont attribuées à\n",
+    "`expression`. Symétriquement, `expression` est reconnu 0 fois sur 6, et ses six\n",
+    "réponses sont attribuées à `style`. Cet **échange complet** est la signature que\n",
+    "l'on cherchait : le classifieur ne les trouve pas seulement proches, il les prend\n",
+    "systématiquement l'un pour l'autre. Deux étiquettes, un assistant.\n",
+    "\n",
+    "C'est précisément ce que la matrice de Jaccard ne pouvait pas dire. Elle plaçait\n",
+    "bien la paire en tête, mais « vocabulaires proches » et « substituables » sont\n",
+    "deux constats distincts, et seul le second justifie une décision de catalogue.\n",
+    "\n",
+    "Notez aussi ce que devient l'exactitude globale : 0.58, contre 0.17 pour le\n",
+    "hasard. Très au-dessus du hasard, et pourtant deux assistants sur six sont\n",
+    "inutilisables. **Un score agrégé ne remplace pas la matrice** — il moyenne\n",
+    "ensemble ce qui marche et ce qui ne marche pas.\n",
+    "\n",
+    "### Le contrôle qui n'a pas collapsé\n",
+    "\n",
+    "`relecture` obtient 3/6. Ni distinct comme les trois premiers, ni absorbé comme\n",
+    "la paire précédente.\n",
+    "\n",
+    "Nous l'avions pourtant construit sur le **même terrain** que `style` : l'un et\n",
+    "l'autre travaillent l'expression, pas l'intrigue. Ce qui les sépare se lit dans\n",
+    "les réponses collectées plus haut : `style` expose, là où `relecture` attend\n",
+    "qu'on lui soumette un texte et organise une séance de travail autour. Terrain\n",
+    "identique, **posture** opposée.\n",
+    "\n",
+    "La leçon prend l'intuition courante à revers. Ce qu'un modèle restitue le plus\n",
+    "fidèlement d'un prompt système n'est pas le domaine annoncé, c'est la position\n",
+    "adoptée face à l'interlocuteur. Deux assistants peuvent couvrir le même sujet\n",
+    "sans être redondants ; deux autres peuvent couvrir des sujets différents et\n",
+    "l'être quand même. Le domaine ne suffit pas à fonder une frontière — raison de\n",
+    "plus pour mesurer plutôt que relire attentivement le catalogue."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "594ab778",
+   "metadata": {},
+   "source": [
+    "## Le piège symétrique\n",
+    "\n",
+    "On pourrait croire tenir un raccourci : comparer les prompts entre eux, et\n",
+    "conclure. Il ne fonctionne dans aucun des deux sens.\n",
+    "\n",
+    "- Deux prompts **très différents** peuvent produire des réponses identiques : le\n",
+    "  modèle ignore le cadrage, ou le traduit en simple variation de ton.\n",
+    "- Deux prompts **presque identiques** peuvent diverger nettement : une seule\n",
+    "  clause discriminante suffit à déplacer toute la réponse.\n",
+    "\n",
+    "Mettons les deux classements côte à côte."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "54b2b933",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T13:31:06.889416Z",
+     "iopub.status.busy": "2026-08-11T13:31:06.889416Z",
+     "iopub.status.idle": "2026-08-11T13:31:06.901222Z",
+     "shell.execute_reply": "2026-08-11T13:31:06.900171Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "paire                               d(prompts)  d(réponses)    rangs\n",
+      "structure / expression                    0.90         0.82     1->2\n",
+      "pratique / expression                     0.89         0.78    2->10\n",
+      "structure / relecture                     0.89         0.79     3->7\n",
+      "documentation / relecture                 0.88         0.78     4->8\n",
+      "pratique / relecture                      0.88         0.74    5->12\n",
+      "documentation / expression                0.87         0.81     6->4\n",
+      "style / relecture                         0.85         0.71    7->13\n",
+      "style / expression                        0.84         0.54    8->15\n",
+      "structure / documentation                 0.84         0.80     9->6\n",
+      "structure / style                         0.83         0.84    10->1\n",
+      "style / documentation                     0.82         0.81    11->3\n",
+      "documentation / pratique                  0.82         0.80    12->5\n",
+      "style / pratique                          0.82         0.78    13->9\n",
+      "expression / relecture                    0.81         0.71   14->14\n",
+      "structure / pratique                      0.80         0.77   15->11\n",
+      "\n",
+      "14/15 paires changent de rang entre les deux classements\n"
+     ]
+    }
+   ],
+   "source": [
+    "def distance_prompts(a, b):\n",
+    "    va, vb = set(tokeniser(PERSONAS[a])), set(tokeniser(PERSONAS[b]))\n",
+    "    return 1 - len(va & vb) / len(va | vb)\n",
+    "\n",
+    "\n",
+    "centres = {}\n",
+    "for n in noms:\n",
+    "    v = X[[k for k, c in enumerate(cles) if c[0] == n]].mean(axis=0)\n",
+    "    centres[n] = v / np.linalg.norm(v)\n",
+    "\n",
+    "\n",
+    "def distance_reponses(a, b):\n",
+    "    return 1 - float(centres[a] @ centres[b])\n",
+    "\n",
+    "\n",
+    "paires = [(a, b) for i, a in enumerate(noms) for b in noms[i + 1:]]\n",
+    "mesures = {p: (distance_prompts(*p), distance_reponses(*p)) for p in paires}\n",
+    "\n",
+    "rang_prompt = {p: r for r, p in enumerate(sorted(paires, key=lambda p: -mesures[p][0]))}\n",
+    "rang_reponse = {p: r for r, p in enumerate(sorted(paires, key=lambda p: -mesures[p][1]))}\n",
+    "\n",
+    "print(f\"{'paire':34s}{'d(prompts)':>12s}{'d(réponses)':>13s}{'rangs':>9s}\")\n",
+    "for p in sorted(paires, key=lambda p: -mesures[p][0]):\n",
+    "    dp, dr = mesures[p]\n",
+    "    bascule = f\"{rang_prompt[p] + 1}->{rang_reponse[p] + 1}\"\n",
+    "    print(f\"{p[0] + ' / ' + p[1]:34s}{dp:12.2f}{dr:13.2f}{bascule:>9s}\")\n",
+    "\n",
+    "deplacees = sum(1 for p in paires if rang_prompt[p] != rang_reponse[p])\n",
+    "print(f\"\\n{deplacees}/{len(paires)} paires changent de rang entre les deux classements\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "085a0eaf",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "Regardez la ligne `style / expression` : distance entre prompts 0.84, distance\n",
+    "entre réponses 0.54.\n",
+    "\n",
+    "C'est la paire dont les prompts n'ont presque aucun mot commun — la paraphrase a\n",
+    "été écrite pour cela — et c'est, de très loin, la paire dont les **réponses** se\n",
+    "ressemblent le plus. Huitième au classement des prompts, dernière à celui des\n",
+    "réponses.\n",
+    "\n",
+    "14 des 15 paires changent de rang d'une colonne à l'autre. Le classement obtenu\n",
+    "en comparant les prompts n'est pas une approximation dégradée du bon classement :\n",
+    "c'en est simplement un autre.\n",
+    "\n",
+    "Corollaire pratique : **on n'audite pas un catalogue d'assistants en relisant\n",
+    "leurs prompts**, quelle que soit l'attention qu'on y met. Il faut les faire\n",
+    "parler."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31820834",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les trois exercices se répondent avec ce qui précède : `reponses`, `conf`, `X`,\n",
+    "`cles`, `matrice_tfidf`, `discriminabilite`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "143e1fe9",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — la paire à fusionner\n",
+    "\n",
+    "Le tableau de confusion dit *où* la mesure se trompe, mais il faut le lire à la\n",
+    "main. Écrivez la fonction qui en extrait la paire la plus confondue, en comptant\n",
+    "les confusions **dans les deux sens** — `a` pris pour `b` et `b` pris pour `a`.\n",
+    "\n",
+    "C'est cette paire qu'on proposera de fusionner, ou de re-spécifier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "a748ecd2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T13:31:06.905537Z",
+     "iopub.status.busy": "2026-08-11T13:31:06.905033Z",
+     "iopub.status.idle": "2026-08-11T13:31:06.910330Z",
+     "shell.execute_reply": "2026-08-11T13:31:06.909650Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "def paire_la_plus_confondue(conf, noms):\n",
+    "    \"\"\"Renvoie (nom_a, nom_b, nombre_de_confusions) pour la paire la plus confondue.\n",
+    "\n",
+    "    Les confusions se comptent dans les deux sens : conf[a][b] + conf[b][a].\n",
+    "    Renvoie None si aucune confusion n'a lieu.\n",
+    "    \"\"\"\n",
+    "    # À vous.\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "print(paire_la_plus_confondue(conf, noms))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ffc668ac",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — la sonde qui sépare\n",
+    "\n",
+    "Toutes les sondes ne se valent pas. Certaines forcent la convergence, d'autres\n",
+    "laissent chaque assistant révéler son angle.\n",
+    "\n",
+    "Calculez l'exactitude **sonde par sonde** : pour chaque indice de sonde, la\n",
+    "proportion des cinq réponses correspondantes qui sont correctement attribuées par\n",
+    "`predit`. La meilleure sonde est celle qu'il faut garder si l'on doit réduire le\n",
+    "protocole ; la pire est celle qu'il faut réécrire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c29c751d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T13:31:06.913846Z",
+     "iopub.status.busy": "2026-08-11T13:31:06.912847Z",
+     "iopub.status.idle": "2026-08-11T13:31:06.919320Z",
+     "shell.execute_reply": "2026-08-11T13:31:06.918807Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def exactitude_par_sonde(cles, vrai, predit, nb_sondes):\n",
+    "    \"\"\"Renvoie une liste de longueur nb_sondes : l'exactitude de chaque sonde.\"\"\"\n",
+    "    # À vous.\n",
+    "    pass\n",
+    "\n",
+    "\n",
+    "scores = exactitude_par_sonde(cles, vrai, predit, len(SONDES))\n",
+    "if scores:\n",
+    "    for i, s in enumerate(scores):\n",
+    "        print(f\"  sonde {i} : {s:.2f}   {SONDES[i][:52]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "443a411c",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — réparer la redondance\n",
+    "\n",
+    "Prenez l'assistant que la matrice de confusion désigne, et réécrivez son prompt\n",
+    "pour qu'il cesse de recouvrir son voisin. Puis re-mesurez.\n",
+    "\n",
+    "La contrainte qui rend l'exercice intéressant : **ne le supprimez pas de\n",
+    "l'atelier, et ne changez pas son domaine**. Il ne s'agit pas de le renommer en\n",
+    "autre chose, mais de trouver ce qu'il apporte que son voisin n'apporte pas — et\n",
+    "de l'écrire. Si vous n'y arrivez pas, vous venez d'établir quelque chose\n",
+    "d'utile : cet assistant n'avait pas de raison d'exister séparément.\n",
+    "\n",
+    "Attendu : l'exactitude globale monte, et la case de confusion se vide. Si\n",
+    "l'exactitude monte mais que la confusion demeure, c'est un autre assistant qui a\n",
+    "bougé — relisez la matrice entière avant de conclure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "ea10bd27",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T13:31:06.922879Z",
+     "iopub.status.busy": "2026-08-11T13:31:06.922337Z",
+     "iopub.status.idle": "2026-08-11T13:31:06.930282Z",
+     "shell.execute_reply": "2026-08-11T13:31:06.929393Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ASSISTANT_A_REECRIRE ou PROMPT_V2 n'est pas renseigné.\n"
+     ]
+    }
+   ],
+   "source": [
+    "ASSISTANT_A_REECRIRE = \"\"   # À vous : le nom, tel qu'il figure dans PERSONAS.\n",
+    "PROMPT_V2 = \"\"              # À vous : son nouveau prompt système.\n",
+    "\n",
+    "\n",
+    "def remesurer(nom_assistant, nouveau_prompt):\n",
+    "    \"\"\"Recollecte les réponses d'un assistant sous un nouveau prompt et renvoie\n",
+    "    (exactitude, tableau de confusion).\"\"\"\n",
+    "    if nom_assistant not in PERSONAS or not nouveau_prompt.strip():\n",
+    "        return None\n",
+    "    nouvelles = dict(reponses)\n",
+    "    for i, sonde in enumerate(SONDES):\n",
+    "        nouvelles[(nom_assistant, i)] = interroger(nouveau_prompt, sonde)\n",
+    "    Xb = matrice_tfidf([nouvelles[k] for k in cles])\n",
+    "    predit_b = discriminabilite(Xb, vrai)\n",
+    "    conf_b = {a: {b: 0 for b in noms} for a in noms}\n",
+    "    for v, p in zip(vrai, predit_b):\n",
+    "        conf_b[v][p] += 1\n",
+    "    return sum(v == p for v, p in zip(vrai, predit_b)) / len(vrai), conf_b\n",
+    "\n",
+    "\n",
+    "resultat = remesurer(ASSISTANT_A_REECRIRE, PROMPT_V2)\n",
+    "if resultat:\n",
+    "    print(f\"exactitude : {exactitude:.2f} -> {resultat[0]:.2f}\")\n",
+    "else:\n",
+    "    print(\"ASSISTANT_A_REECRIRE ou PROMPT_V2 n'est pas renseigné.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f25cf4c0",
+   "metadata": {},
+   "source": [
+    "## Provenance des chiffres\n",
+    "\n",
+    "Les sorties de ce notebook ont été produites le **11 août 2026**, contre un\n",
+    "serveur vLLM local servant `qwen3.6-35b-a3b`, avec `temperature=0.3` et\n",
+    "`seed=7`.\n",
+    "\n",
+    "Ces valeurs ne se transportent pas. Un autre modèle, une autre version du même\n",
+    "modèle, un autre régime de lots les déplaceront. C'est attendu : ce que le\n",
+    "notebook transmet est le **protocole** et la forme des signaux — l'échange\n",
+    "complet dans la matrice, l'écart entre les deux classements — pas les nombres.\n",
+    "\n",
+    "## Ce que ce notebook ne dit pas\n",
+    "\n",
+    "**Une exactitude élevée ne veut pas dire que les assistants sont bons.** Elle dit\n",
+    "qu'ils sont *distinguables*. Six assistants distincts et tous médiocres\n",
+    "obtiendraient un excellent score. La distinctivité est une condition nécessaire,\n",
+    "jamais suffisante.\n",
+    "\n",
+    "**La mesure est lexicale.** TF-IDF voit des mots, pas du sens. Deux assistants\n",
+    "qui diraient la même chose avec des vocabulaires disjoints passeraient pour\n",
+    "distincts — c'est d'ailleurs le piège que `expression` tendait, et il a été\n",
+    "attrapé seulement parce que les *réponses* convergent lexicalement même quand les\n",
+    "prompts divergent. Sur un catalogue plus retors, on remplacerait TF-IDF par des\n",
+    "embeddings ; le protocole, lui, ne bouge pas.\n",
+    "\n",
+    "**La mesure dépend du modèle.** Un modèle qui suit mieux les instructions\n",
+    "séparera davantage. Changer de modèle sous des prompts inchangés déplace les\n",
+    "chiffres — information utile à relever *avant* une migration, pas après.\n",
+    "\n",
+    "**Six sondes, c'est peu.** L'intervalle autour de l'exactitude est large, et une\n",
+    "seule réponse mal attribuée déplace un assistant de 6/6 à 5/6. Le protocole est\n",
+    "bon ; l'échantillon est une démonstration. En production, on monte le nombre de\n",
+    "sondes bien au-delà du nombre d'assistants.\n",
+    "\n",
+    "**Un recouvrement n'est pas toujours un défaut.** Deux assistants peuvent\n",
+    "partager du terrain à dessein. Ce que la mesure fournit est un constat chiffré,\n",
+    "pas un verdict : elle établit que la frontière n'existe pas dans les sorties, et\n",
+    "laisse décider si elle devait exister.\n",
+    "\n",
+    "## Pour aller plus loin\n",
+    "\n",
+    "- [`cadrer-les-agents.md`](cadrer-les-agents.md) — l'autre moitié de la question :\n",
+    "  ce qu'un assistant a le droit de faire, et pourquoi la couche persona n'est pas\n",
+    "  une frontière de sécurité\n",
+    "- [`comparatif-owui-vs-ai-engine.md`](comparatif-owui-vs-ai-engine.md) — où se\n",
+    "  déclarent les assistants dans chacune des deux plateformes"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/docs #10393

**Quoi:** un notebook exécuté qui mesure si plusieurs assistants déclarés distincts le sont réellement, et la section `Conception` du README étendue pour l'accueillir en regard de `cadrer-les-agents.md`.
**Preuve:** 30 appels réels sur vLLM local (`qwen3.6-35b-a3b`), 11/12 cellules de code avec sorties, 3 exercices à stubs. Résultats ci-dessous, tous relevés dans le notebook commité.
**Périmètre:** `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/` — un fichier créé, un modifié. Aucun autre chemin touché.

Closes #10460

## La thèse

Un prompt système déclare une spécialisation ; il ne la garantit pas. On peut donner quatre cadrages distincts à un modèle et récolter quatre réponses interchangeables. Le défaut est invisible en revue de prompts, parce qu'on y compare des **intentions** quand la spécialisation est une propriété **des sorties**.

Le notebook construit la mesure : batterie de sondes volontairement ambiguës, puis test de discriminabilité — *on cache l'auteur d'une réponse, peut-on le retrouver ?*

## Ce que la vérification a changé

L'atelier porte deux contrôles, et le second a contredit la conception initiale.

| Assistant | Rapport à `style` | Reconnu |
|---|---|---|
| `structure`, `documentation`, `pratique` | sans rapport | **6/6** chacun |
| `expression` | paraphrase stricte : même terrain, même posture, mots disjoints | **0/6** |
| `style` | — | **0/6** |
| `relecture` | même terrain, **posture inverse** (il attend un texte, il réagit) | **3/6** |

`style` et `expression` s'**échangent intégralement** : les six réponses de chacun sont attribuées à l'autre. C'est la signature nette de « deux étiquettes, un assistant ».

`relecture` était conçu comme un second cas de redondance. La mesure dit non — et la lecture des réponses collectées explique pourquoi : `style` expose, `relecture` organise une séance autour d'un texte soumis. **Terrain identique, posture opposée.** Ce qu'un modèle restitue le plus fidèlement d'un prompt système est la position adoptée face à l'interlocuteur, pas le domaine annoncé. Le notebook garde ce contrôle et en fait le résultat central, au lieu de le remplacer par un cas qui aurait donné raison à la conception de départ.

## Le piège symétrique, mesuré

| Paire | d(prompts) | d(réponses) | rang |
|---|---|---|---|
| `style` / `expression` | 0.84 | **0.54** | 8/15 → **15/15** |

La paire aux prompts les plus disjoints produit les réponses les plus proches. **14 des 15 paires changent de rang** entre les deux classements : celui obtenu en comparant les prompts n'est pas une approximation dégradée du bon, c'en est un autre. On n'audite pas un catalogue d'assistants en relisant leurs prompts.

## Sur les deux métriques

La lecture honnête du recouvrement lexical est écrite comme telle dans le notebook : **Jaccard n'a pas manqué la redondance**, il l'a classée première (0.23 contre 0.16 au suivant). Son défaut est ailleurs — il ne fournit ni seuil de décision (que vaut 0.23 dans l'absolu ?) ni localisation, là où la discriminabilité vient avec son repère (hasard = 1/6) et une matrice qui désigne la case fautive. Le notebook note aussi que l'exactitude globale de 0.58 est très au-dessus du hasard alors que deux assistants sur six sont inutilisables : un score agrégé ne remplace pas la matrice.

## Choix techniques

- **numpy + stdlib, pas sklearn.** TF-IDF et le classifieur au centre le plus proche font une quinzaine de lignes chacun ; les lire vaut mieux que les appeler. Réduit aussi les prérequis à `openai` + `numpy`.
- **Leave-one-out explicite.** La réponse testée est retirée du calcul de son propre centre — sans quoi le score mesure surtout la capacité d'un texte à se ressembler à lui-même. Le notebook dit pourquoi.
- **`enable_thinking: False`.** Le modèle servi est un modèle de raisonnement ; sans cela `content` revient vide dès que le budget de tokens part dans la réflexion. Constaté à la première exécution, documenté dans le code.
- **Provenance datée.** Le notebook porte la date, le modèle et les paramètres, et dit explicitement que les nombres ne se transportent pas : ce qui s'enseigne est le protocole et la forme des signaux.

## Publication

Corpus intégralement fictif — atelier, assistants, sondes. Aucun prompt, nom, configuration ou contenu issus d'un déploiement réel. Scan avant `git add` : 0 caractère cyrillique ou grec, 0 emoji, 0 secret, aucun terme client. Le seul caractère ≥ U+2100 est la flèche de fil d'Ariane, convention du dépôt. Hooks pré-commit verts, gitleaks compris.
