### PR TITLE
feat(lean,#9568): drop 4 tautological native_decide + mark hashlife_correct_margin as 'inconditionnel-en-attente' (FR+EN siblings)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment.lean
@@ -74,6 +74,7 @@ kernel) sur le bestiaire ci-dessous. EPIC #3846 / #6724 / #9568.
 
 import Conway.Life.AdversarialBattery
 import Conway.Life.HashlifeCorrectness
+import Conway.Life.JumpCapture
 
 namespace Conway
 namespace Life
@@ -132,7 +133,18 @@ pas une preuve manquée. -/
     MacroCell-level) vers l'égalité de grille globale requiert l'assemblage borné P4/P5 —
     `p4_nw_overlap_wall` et sa chaîne helper 4-stage (PR #9745/#9760, ai-01 c.92–c.94,
     sorry 10→9). C'est le cœur de recherche ouvert ; cet énoncé en est le cadre honnête
-    (acceptance B : sorry documenté acceptable au premier commit). -/
+    (acceptance B : sorry documenté acceptable au premier commit).
+
+    **Note de cadrage (c.212, 2026-08-11) — *inconditionnel-en-attente*.** Le prédicat
+    `supportInMargin` est une **tautologie** (prouvé par `supportInMargin_trivial`,
+    JumpCapture.lean:120) : `gridFrameN n g` pad par `max 2 n ≥ n` et `cellMargin` côté
+    proche est non strict, donc `BoxAssezGrandN g n` est vraie pour **toute** grille et
+    **tout** `n`. L'hypothèse `h_margin : supportInMargin c k` ne restreint donc rien —
+    l'énoncé effectif est l'inconditionnel complet, sous un habillage géométrique qui ne
+    relativise pas. La vraie relativisation est ailleurs (prédicat `jumpCaptured`,
+    JumpCapture.lean §3, avec témoin `jumpCaptured_not_trivial`). Ce `sorry` reste donc
+    le **cœur de recherche ouvert**, indépendamment de la fragilité de son habillage —
+    verdict INTRINSIC préservé, contenu scientifique non-affaibli par ce constat. -/
 theorem hashlife_correct_margin (c : MacroCell) (k : Nat)
     (h_margin : supportInMargin c k) (h_central : centralCorrect c k) :
     evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) := by
@@ -144,37 +156,51 @@ theorem hashlife_correct_margin (c : MacroCell) (k : Nat)
   -- open P4/P5 heart — sorry documenté (acceptance B).
   sorry
 
-/-! ## Sanity-checks sur le bestiaire (kernel-`native_decide`)
+/-! ## Sanity-checks sur le bestiaire
 
 Le fragment `supportInMargin` est **décidable** (instance `Decidable (BoxAssezGrandN)`,
 HashlifeCorrectness L227) et **non vide** sur les témoins du bestiaire. Ces lemmes sont les
 sanity-checks réels (honnêtes) du fragment : le bloc 2×2 et le vide satisfont la marge à
 plusieurs horizons, et le sanity `k2` exhibe `2^2 = 4` — impossible avec la fixed-frame
-`BoxAssezGrand`, possible ici car `BoxAssezGrandN` pad par `max 2 4 = 4`. -/
+`BoxAssezGrand`, possible ici car `BoxAssezGrandN` pad par `max 2 4 = 4`.
+
+**Note (c.212, 2026-08-11)** : la classe d'axiome `native_decide` est interdite au sens de
+`pr-review-discipline` §B (forbidden). Or `supportInMargin` est machine-prouvé
+**tautologique** par `supportInMargin_trivial` (JumpCapture.lean:120) — vraie pour **toute**
+MacroCell et **tout** horizon. Les quatre témoins ci-dessous sont donc établis gratuitement
+par cette preuve générale, sans recours au noyau natif. Le `native_decide` historique
+témoignait d'une tautologie déjà démontrée — retrait net, zéro perte de contenu, axiome
+interdit ôté. -/
 
 /-- **Sanité** : le bloc 2×2 (`cexBlock1`) satisfait le fragment à l'horizon `2^0 = 1`
     (marge ≥ 1). Non-vacuité du fragment. -/
-theorem cexBlock1_supportInMargin_k0 : supportInMargin cexBlock1 0 := by native_decide
+theorem cexBlock1_supportInMargin_k0 : supportInMargin cexBlock1 0 :=
+  supportInMargin_trivial _ _
 
 /-- **Sanité** : le bloc 2×2 satisfait le fragment à l'horizon `2^1 = 2` (marge ≥ 2).
     C'est le plafond de la fixed-frame `BoxAssezGrand` (`boxAssezGrand_nonempty_le_two`). -/
-theorem cexBlock1_supportInMargin_k1 : supportInMargin cexBlock1 1 := by native_decide
+theorem cexBlock1_supportInMargin_k1 : supportInMargin cexBlock1 1 :=
+  supportInMargin_trivial _ _
 
 /-- **Sanité (n-aware)** : le bloc 2×2 satisfait le fragment à l'horizon `2^2 = 4`
     (marge ≥ 4) — IMPOSSIBLE avec la fixed-frame `BoxAssezGrand` (plafonnée à 2), possible
     ici car `BoxAssezGrandN` pad par `max 2 4 = 4`. C'est la raison du choix n-aware :
     sans lui, l'argument de suffisance « choisir `k` par horizon » s'effondrerait. -/
-theorem cexBlock1_supportInMargin_k2 : supportInMargin cexBlock1 2 := by native_decide
+theorem cexBlock1_supportInMargin_k2 : supportInMargin cexBlock1 2 :=
+  supportInMargin_trivial _ _
 
 /-- **Sanité** : le vide (`cexEmpty1`) satisfait le fragment à l'horizon `2^0 = 1` (pas de
     cellules vivantes à contraindre — `List.all` sur `[]` vacuously true). -/
-theorem cexEmpty1_supportInMargin_k0 : supportInMargin cexEmpty1 0 := by native_decide
+theorem cexEmpty1_supportInMargin_k0 : supportInMargin cexEmpty1 0 :=
+  supportInMargin_trivial _ _
 
 /-! ## Synthèse — le fragment est non vide et l'énoncé-cadre est honnête
 
 `supportInMargin` est décidable et témoigné sur le bestiaire (ci-dessus). L'énoncé-cadre
-`hashlife_correct_margin` porte la correction relative au fragment ; son `sorry` documente
-ouvertement l'assemblage borné P4/P5 encore ouvert (`p4_nw_overlap_wall`, ai-01 c.94).
+`hashlife_correct_margin` porte la correction relative au fragment (en habillage — voir
+note *inconditionnel-en-attente* dans sa docstring : le prédicat est tautologique, le
+cœur de recherche reste l'assemblage borné P4/P5) ; son `sorry` documente ouvertement
+l'assemblage borné P4/P5 encore ouvert (`p4_nw_overlap_wall`, ai-01 c.94).
 Stratégie confirmée pour la suite de #6724 : fermer les murs NE/SW/SE bornés, puis câbler
 l'assemblage P4.4 qui déchargera le `sorry` de `hashlife_correct_margin`.
 -/

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMarginFragment_en.lean
@@ -73,6 +73,7 @@ bestiary below. EPIC #3846 / #6724 / #9568.
 
 import Conway.Life.AdversarialBattery_en
 import Conway.Life.HashlifeCorrectness
+import Conway.Life.JumpCapture
 
 namespace Conway_en
 open Conway
@@ -132,7 +133,18 @@ recursion, the margin containing the light-cone at every jump. Framework stateme
     to global grid equality requires the bounded P4/P5 assembly — `p4_nw_overlap_wall` and
     its 4-stage helper ladder (PR #9745/#9760, ai-01 c.92–c.94, sorry 10→9). This is the
     open research heart; this statement is its honest framework (acceptance B: documented
-    sorry acceptable at first commit). -/
+    sorry acceptable at first commit).
+
+    **Framing note (c.212, 2026-08-11) — *unconditional-in-waiting*.** The predicate
+    `supportInMargin` is a **tautology** (proven by `supportInMargin_trivial`,
+    JumpCapture.lean:120): `gridFrameN n g` pads by `max 2 n ≥ n` and the near-side
+    `cellMargin` is non-strict, so `BoxAssezGrandN g n` holds for **every** grid and **every**
+    `n`. The hypothesis `h_margin : supportInMargin c k` therefore constrains nothing — the
+    effective statement is the full unconditional, under geometric dressing that does not
+    relativize. The true relativization lives elsewhere (predicate `jumpCaptured`,
+    JumpCapture.lean §3, with witness `jumpCaptured_not_trivial`). This `sorry` therefore
+    remains the **open research heart**, regardless of the fragility of its dressing — the
+    INTRINSIC verdict is preserved, scientific content unweakened by this observation. -/
 theorem hashlife_correct_margin (c : MacroCell) (k : Nat)
     (h_margin : supportInMargin c k) (h_central : centralCorrect c k) :
     evolveHashlifeFast (2^k) (c.toGrid (0, 0)) = evolve (2^k) (c.toGrid (0, 0)) := by
@@ -144,37 +156,51 @@ theorem hashlife_correct_margin (c : MacroCell) (k : Nat)
   -- open P4/P5 heart — documented sorry (acceptance B).
   sorry
 
-/-! ## Sanity checks on the bestiary (kernel `native_decide`)
+/-! ## Sanity checks on the bestiary
 
 The fragment `supportInMargin` is **decidable** (instance `Decidable (BoxAssezGrandN)`,
 HashlifeCorrectness L227) and **non-empty** on the bestiary witnesses. These lemmas are the
 real (honest) sanity checks of the fragment: the 2×2 block and the empty cell satisfy the
 margin at several horizons, and the `k2` sanity exhibits `2^2 = 4` — impossible with the
-fixed-frame `BoxAssezGrand`, possible here because `BoxAssezGrandN` pads by `max 2 4 = 4`. -/
+fixed-frame `BoxAssezGrand`, possible here because `BoxAssezGrandN` pads by `max 2 4 = 4`.
+
+**Note (c.212, 2026-08-11)**: the `native_decide` axiom class is forbidden under
+`pr-review-discipline` §B. Yet `supportInMargin` is machine-proven **tautological** by
+`supportInMargin_trivial` (JumpCapture.lean:120) — true for **every** MacroCell and
+**every** horizon. The four witnesses below are therefore established for free by that
+general proof, without recourse to the native kernel. The historical `native_decide`
+attested to a tautology already demonstrated — clean removal, zero content loss,
+forbidden axiom excised. -/
 
 /-- **Sanity**: the 2×2 block (`cexBlock1`) satisfies the fragment at horizon `2^0 = 1`
     (margin ≥ 1). Non-vacuity of the fragment. -/
-theorem cexBlock1_supportInMargin_k0 : supportInMargin cexBlock1 0 := by native_decide
+theorem cexBlock1_supportInMargin_k0 : supportInMargin cexBlock1 0 :=
+  supportInMargin_trivial _ _
 
 /-- **Sanity**: the 2×2 block satisfies the fragment at horizon `2^1 = 2` (margin ≥ 2).
     This is the cap of the fixed-frame `BoxAssezGrand` (`boxAssezGrand_nonempty_le_two`). -/
-theorem cexBlock1_supportInMargin_k1 : supportInMargin cexBlock1 1 := by native_decide
+theorem cexBlock1_supportInMargin_k1 : supportInMargin cexBlock1 1 :=
+  supportInMargin_trivial _ _
 
 /-- **Sanity (n-aware)**: the 2×2 block satisfies the fragment at horizon `2^2 = 4`
     (margin ≥ 4) — IMPOSSIBLE with the fixed-frame `BoxAssezGrand` (capped at 2), possible
     here because `BoxAssezGrandN` pads by `max 2 4 = 4`. This is the reason for the n-aware
     choice: without it, the "choose `k` by horizon" sufficiency argument would collapse. -/
-theorem cexBlock1_supportInMargin_k2 : supportInMargin cexBlock1 2 := by native_decide
+theorem cexBlock1_supportInMargin_k2 : supportInMargin cexBlock1 2 :=
+  supportInMargin_trivial _ _
 
 /-- **Sanity**: the empty cell (`cexEmpty1`) satisfies the fragment at horizon `2^0 = 1`
     (no live cells to constrain — `List.all` over `[]` is vacuously true). -/
-theorem cexEmpty1_supportInMargin_k0 : supportInMargin cexEmpty1 0 := by native_decide
+theorem cexEmpty1_supportInMargin_k0 : supportInMargin cexEmpty1 0 :=
+  supportInMargin_trivial _ _
 
 /-! ## Synthesis — the fragment is non-empty and the framework statement is honest
 
 `supportInMargin` is decidable and witnessed on the bestiary (above). The framework
-statement `hashlife_correct_margin` carries the fragment-relative correctness; its `sorry`
-openly documents the still-open bounded P4/P5 assembly (`p4_nw_overlap_wall`, ai-01 c.94).
+statement `hashlife_correct_margin` carries the fragment-relative correctness (in dressing
+— see *unconditional-in-waiting* note in its docstring: the predicate is tautological, the
+research heart remains the bounded P4/P5 assembly); its `sorry` openly documents the
+still-open bounded P4/P5 assembly (`p4_nw_overlap_wall`, ai-01 c.94).
 Strategy confirmed for the rest of #6724: close the bounded NE/SW/SE walls, then wire the
 P4.4 assembly that will discharge the `sorry` of `hashlife_correct_margin`.
 -/


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA-2 — prev: LIGHT/guard c.8202

## Sub-grain (a)+(b) du découpage c.212 — issue #9568

### Sub-grain (a) — retrait des 4 `native_decide` redondants

Les 4 témoins du bestiaire (`cexBlock1_supportInMargin_k0/k1/k2` et
`cexEmpty1_supportInMargin_k0`) prouvaient `supportInMargin c k` par
`by native_decide`. Or `supportInMargin` est machine-prouvé **tautologique**
par `supportInMargin_trivial` ([JumpCapture.lean:120](MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/JumpCapture.lean#L120)),
lui-même conséquence directe de `boxAssezGrandN_trivial` : `gridFrameN n g`
pad par `max 2 n ≥ n` et le `cellMargin` côté proche est non strict, donc
`BoxAssezGrandN g n` est vraie pour **toute** grille et **tout** `n`.

Les 4 témoins sont donc établis gratuitement par cette preuve générale, sans
recours au noyau natif. Le `native_decide` historique témoignait d'une
tautologie déjà démontrée — **retrait net, zéro perte de contenu, axiome
interdit ôté** (classe `forbidden` au sens de `pr-review-discipline` §B).

### Sub-grain (b) — marquage `hashlife_correct_margin` *inconditionnel-en-attente*

Co-livré avec (a) : la docstring de `hashlife_correct_margin` porte désormais
une « note de cadrage » explicite — le prédicat `supportInMargin` est
tautologique (prouvé par `supportInMargin_trivial`), donc l'hypothèse
`h_margin : supportInMargin c k` ne restreint rien. L'énoncé effectif est
l'inconditionnel complet, sous un habillage géométrique qui ne relativise pas.

La vraie relativisation est ailleurs : prédicat `jumpCaptured` (JumpCapture.lean §3)
avec témoin `jumpCaptured_not_trivial`. Le `sorry` de `hashlife_correct_margin`
reste donc le **cœur de recherche ouvert** (assemblage borné P4/P5,
`p4_nw_overlap_wall` PR #9745/#9760, ai-01 c.92–c.94), **indépendamment** de
la fragilité de son habillage — **verdict INTRINSIC préservé, contenu
scientifique non-affaibli** par ce constat.

### EPIC #4980 lockstep (L882 ★★)

Les fichiers FR-canonical + `_en` sibling diffèrent **uniquement** dans les
docstrings/bloc d'en-tête (énoncés, tactiques, noms de lemmes, refs Mathlib
identiques). Les deux fichiers reçoivent **simultanément** :

- L'import `import Conway.Life.JumpCapture`
- Les 4 remplacements `by native_decide` → `supportInMargin_trivial _ _`
- Le paragraphe *inconditionnel-en-attente* dans la docstring de
  `hashlife_correct_margin`

### Validation pre-push (L890/L898/L899/L903/L904 ★★)

| Garde | Résultat |
|---|---|
| **L890 ★★** `git diff origin/main..HEAD -- <paths>` | OK — 2 fichiers exactement, +70/-18 |
| **L898 ★★★** collision open PR | OK — `gh pr list --state open` : 0 PR touchant `HashlifeMarginFragment` ou `supportInMargin` |
| **L899 ★★** collision merged PR | OK — dernier PR touchant le fichier = #9780 MERGED 07/08 |
| **L903 ★★** commentaires pre-push sur issue | OK — issue #9568 lue firsthand ; seul `[CLAIMED]` po-2026 c.8205 du 14:10Z |
| **L904 ★★** base rebase frais | OK — branche rebasée sur `origin/main` (e5f4d52ca) avant commit ; `git log HEAD~0..origin/main` vide post-commit |

### Non-application de H.3/H.4 (CI autoritatif, L897 ★★)

Pas de `lake build` local : `conway_lean` a 3 modes d'échec WSL documentés
(L897 ★★), CI GitHub est autoritatif. Le scope est minime (+70/-18 sur 2
fichiers) — la chaîne d'imports affectée est triviale
(`JumpCapture`→`BoxAssezGrandN_trivial`). CI déclenchée post-push.

### Liens

- See #9568 (sub-grain a+b du découpage c.212)
- Part of #6724 (Hashlife correction EPIC, sorry budget inchangé — le `sorry`
  de `hashlife_correct_margin` reste l'assemblage borné P4/P5 ouvert)
- PR #9780 (premier merge du fragment, Livrable B initial 07/08)
- PR #9806 (JumpCapture, source de `supportInMargin_trivial`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)