### PR TITLE
fix(harness,#10143): correct two measurement-falsified facts in .claude/rules (gitleaks pin, force-push verifiability)

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -36,7 +36,7 @@ L'ancienne rédaction interdisait `--force` **partout**, urgence-user comprise. 
 
 | Cible | Règle | Ce qui la porte |
 |---|---|---|
-| **`main`** | **INTERDIT**, sans exception d'urgence | `allow_force_pushes: false` dans la protection de branche — GitHub **refuse** le push. Ce n'est pas qu'une consigne (vérifiable : `gh api repos/jsboige/CoursIA/branches/main/protection -q .allow_force_pushes`) |
+| **`main`** | **INTERDIT**, sans exception d'urgence | `allow_force_pushes: false` dans la protection de branche — GitHub **refuse** le push. Ce n'est pas qu'une consigne, c'est le serveur qui tranche (voir la note de vérifiabilité ci-dessous) |
 | **Branche de PR (`feature/*`, `fix/*`, `docs/*`) à lane unique** | **AUTORISÉ**, `--force-with-lease` préféré | aucune protection côté plateforme : c'est la discipline de lane qui répond |
 | **Branche manipulée par plusieurs agents de front** | **INTERDIT** | un `[CLAIMED]` d'une autre lane sur l'issue vaut « plusieurs agents » → [lane-claim-protocol.md](lane-claim-protocol.md) |
 
@@ -44,6 +44,8 @@ L'ancienne rédaction interdisait `--force` **partout**, urgence-user comprise. 
 - **`--force-with-lease` plutôt que `--force`** : il échoue si le remote a bougé depuis ta dernière lecture — précisément le cas « une autre lane a poussé sans que je le sache ». C'est le garde-fou qui rend le périmètre ci-dessus sûr.
 - **Jamais de `reset --hard`** sur `main` ni sur une branche partagée.
 - **Un secret déjà commité ne se répare PAS par réécriture d'historique** : branche propre + cherry-pick, et **rotation de la clé** (cf [secrets-hygiene.md](secrets-hygiene.md) règle 5).
+
+**Note de vérifiabilité — `allow_force_pushes` n'est PAS lisible sans droit admin.** Une version antérieure de la ligne `main` ci-dessus donnait `gh api repos/jsboige/CoursIA/branches/main/protection -q .allow_force_pushes` comme preuve à portée de main. Cet endpoint renvoie **404 sans droit admin sur le dépôt** (constaté sous `myia-ai-01`, cf #9991) : le compte admin `jsboige` est requis pour **lire** la protection, alors qu'il ne l'est pas pour merger. Un 404 y est donc **une question, pas une absence mesurée** — et un agent qui l'interprète comme « pas de protection configurée » conclut l'inverse de la vérité. Ce que chaque lane peut vérifier sans droit admin, c'est le comportement : un `git push --force` sur `main` est **rejeté par le serveur**. La règle ne dépend pas de la lisibilité de la config.
 
 ---
 

--- a/.claude/rules/secrets-hygiene.md
+++ b/.claude/rules/secrets-hygiene.md
@@ -25,7 +25,14 @@ S'applique a **tous les agents** ecrivant du code dans le repo.
 
    **Seules normalisations manuelles tolerees** (PAS un scrub d'output) : `metadata.papermill.input/output_path` au `basename` (metadata, pas une sortie) ; quantbooks QC (non-executables via MCP, cf [[feedback-qc-cloud-exec-modalities]]) ; **`probeAddresses` banner strip** post-re-exec .NET Interactive (`scripts/notebook_tools/strip_probe_banner.py --apply <path>` — énumération `System.Net.NetworkInformation.NetworkInterface` qui leak les interfaces réseau du runner ; passer systématiquement après toute re-exec .NET avant commit, cf L532 MEMORY). **Bot-review** : toute PR qui hand-edite une sortie de cellule hors ces trois cas = `CHANGES_REQUESTED` ; `APPROVED` dessus = complaisance ([pr-review-discipline.md](pr-review-discipline.md) §H). Triage A/B/C complet + incidents fondateurs (#3903->#3913, #3952/53/55/56->#3958/59/60) : [docs §1.6](../../docs/reference/secrets-and-coord-detail.md#1-secrets-hygiene--content-based-pas-path-based).
 
-`.gitignore` seul est insuffisant : il protege les fichiers dedies, pas les literaux inline. Le scanner CI gitleaks est installe (`.pre-commit-config.yaml` v8.21.2 + `.github/workflows/secret-scan.yml`), mais ne couvre pas tous les patterns : la vigilance reste obligatoire (revue body/contenu PR, lecture `gh pr view --json files`, controle des `os.getenv("KEY", "...")` literal-default).
+`.gitignore` seul est insuffisant : il protege les fichiers dedies, pas les literaux inline. Le scanner CI gitleaks est installe (`.pre-commit-config.yaml` + `.github/workflows/secret-scan.yml`), mais ne couvre pas tous les patterns : la vigilance reste obligatoire (revue body/contenu PR, lecture `gh pr view --json files`, controle des `os.getenv("KEY", "...")` literal-default).
+
+**Le numero de version ne se recopie pas d'ici — il se lit aux deux pins.** Cette ligne a porte `v8.21.2` longtemps apres que les deux surfaces reelles soient passees a **8.24.3** (`.pre-commit-config.yaml` `rev:` et `GITLEAKS_VERSION:` dans le workflow, que le workflow compare lui-meme et fait echouer en cas de drift). Consequence mesuree le 2026-08-10 sur #10143 : un scan lance sous 8.21.2 en le croyant « la version epinglee » a renvoye **0 finding** la ou 8.24.3 en trouvait **37** deux jours plus tot — dont, a l'epoque, ~7 credentials reellement fuites. Un scan sous un binaire different n'est pas une mesure de ce que la CI applique : c'est une mesure d'autre chose, et elle **paraissait rassurante**. Verifier la version au moment de mesurer :
+
+```bash
+grep -A2 'gitleaks/gitleaks' .pre-commit-config.yaml | grep rev:   # pin pre-commit
+grep 'GITLEAKS_VERSION:' .github/workflows/secret-scan.yml          # pin CI (doit etre identique)
+```
 
 Detail (incident, fix structurel, regex de detection, postmortem template) : [docs/secrets-and-coord-detail.md](../../docs/reference/secrets-and-coord-detail.md#1-secrets-hygiene--content-based-pas-path-based).
 


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-ai-01:CoursIA — prev: LIGHT/ledger #10348

> **Tag requalifie par moi-meme, dans le body** (et non en commentaire, qui ne serait pas lu par le cap). J'avais declare `MED/docs` ; le guard a pose `variation-tier-inflation` + `variation-genre-cap-exceeded`, et il a raison sur les deux. Le litmus LIGHT s'applique a l'**artefact** — 2 fichiers, +11/-2, doc-only, et « pourrais-je en generer une douzaine en scannant la regle suivante ? » : oui, des numeros recopies, il y en a ailleurs. La *substance* de la trouvaille (quatre corpus, quatre nombres) est allee dans #10143, la ou elle appartient ; ce qui reste ici est la correction. En consequence, `LIGHT/docs` apres `LIGHT/ledger #10348` tombe sous le ban absolu G-VAR-3 des genres LIGHT consecutifs : **je tiens cette PR moi-meme** jusqu'a ce qu'un grain de contenu s'intercale. Un coordinateur qui s'exempterait de son propre gate le viderait de ses dents.

Deux faits du harnais que la mesure vient de refuter. Aucun des deux n'est une preference de redaction : chacun a **fait conclure faux**, et l'un des deux dans le registre securite.

## 1. `secrets-hygiene.md` epinglait une version de gitleaks que rien n'epingle

La ligne portait `v8.21.2`. Les deux surfaces reelles portent **8.24.3** :

```
.pre-commit-config.yaml:23        rev: v8.24.3
.github/workflows/secret-scan.yml:43   GITLEAKS_VERSION: 8.24.3
```

Le workflow compare lui-meme les deux et echoue en cas de drift (`Gitleaks version drift::CI pins ${GITLEAKS_VERSION} but .pre-commit-config.yaml pins v${expected}`) — donc les deux pins sont vrais et coherents, et c'est la **regle** qui etait seule a se tromper.

**Ce que ce chiffre recopie a produit, mesurable sur #10143 :**

| Date | Binaire utilise | Findings | Conclusion tiree |
|---|---|---|---|
| 2026-08-09 | **8.24.3** (le vrai pin) | **37** dont ~7 credentials reellement fuites | « ne pas allowlister en bloc » |
| 2026-08-10 | 8.21.2, cru « the pinned CI version » | **0** | « les 162 findings sont entierement drainees sur main » |

Les deux mesures sont sinceres et les deux ont ete faites firsthand. Elles divergent parce que l'une a lu la version dans le harnais au lieu des pins. Le detail qui rend l'erreur couteuse : le resultat faux etait le **rassurant**. Un scan sous un autre binaire n'est pas une mesure de ce que la CI applique — c'est une mesure d'autre chose, qui ressemble a une absence de defaut.

Le correctif ne remplace pas `8.21.2` par `8.24.3` : il **retire le numero** et met les deux commandes qui lisent les pins. Un numero recopie dans une regle re-derivera, la commande non.

## 2. `git-workflow.md` donnait comme preuve un endpoint qui 404 sans droit admin

La ligne `main` du tableau force-push offrait :

```
gh api repos/jsboige/CoursIA/branches/main/protection -q .allow_force_pushes
```

Cet endpoint renvoie **404 sans droit admin** (constate sous `myia-ai-01`, cf #9991) — le compte admin est requis pour **lire** la protection, alors qu'il ne l'est pas pour merger. Un agent qui suit la regle a la lettre obtient donc un 404 sur la commande censee prouver que la protection existe, et la lecture naturelle du 404 est **l'inverse de la verite**.

La regle elle-meme ne bouge pas d'un iota — force-push interdit sur `main`, autorise sur une branche de PR a lane unique. Ce qui change est la **preuve offerte** : ce que chaque lane peut verifier sans droit admin, c'est le comportement (le serveur rejette le push), pas la lisibilite de la config.

## Perimetre, et ce que cette PR n'est pas

- **2 fichiers, +11/-2.** Groupees plutot que deux PR de moins de 20 lignes, ce que §E de `pr-review-discipline` refuse systematiquement. Le sujet unique qui les reunit n'est pas « des docs » : c'est *un fait du harnais refute par la mesure*, meme classe de defaut, meme remede (remplacer la valeur recopiee par la commande qui la lit).
- **Ce n'est pas le plat principal de mon cycle** et je ne le presente pas comme tel : `docs` est un genre de classe META, que G-VAR-1 exclut du plancher. La substance du cycle est ailleurs (merges, arbitrages #6724 / #9568, review #10465, organe #10466).
- **#10143 n'est pas fermee par cette PR.** Sa mesure courante sous le bon binaire est en cours ; le `See #10143` est deliberement non-fermant.

## Ce qui reste sur #10143 apres cette PR

Les ~7 credentials de la mesure 8.24.3 **ont bien ete traites** — verifie a l'instant, et c'est la bonne nouvelle de l'affaire : le token Civitai a ete rotate (`9ac6d5821` / `00b6d8ddd`, « ROTATED 2026-08-10 »), les trois issues dediees ouvertes et fermees (#10202, #10205, #10265), et le litteral ne subsiste dans aucun des trois chemins nommes par la mesure forensique (0 occurrence). L'historique le porte encore, ce qui est attendu : la reecriture est interdite (~95 forks etudiants) et la rotation **est** le remede.

Ne reste donc que le comptage courant des faux positifs sous 8.24.3, pour savoir si les classes couvertes par #10201 et #10146 ont bien vide le corpus.

## Addendum mesure — et une nuance que je me dois de corriger

La mesure est faite (detail complet : [#10143](https://github.com/jsboige/CoursIA/issues/10143#issuecomment-5255089235)). Elle confirme le correctif de cette PR **et** en precise la portee sur un point ou la redaction ci-dessus va trop loin.

| Binaire | Corpus | Volume | Findings |
|---|---|---|---|
| 8.21.2 | racine du repo | — | 0 |
| 8.24.3 | racine du repo | **43.04 GB** | **240** |
| 8.24.3 | **contenu tracke de HEAD** | **467.69 MB** | **0** |

**Le scan a 0 finding du 10/08 avait raison — par accident.** Sa methode etait doublement invalide (mauvais binaire, et un corpus qui balaye 5 copies completes du repo sous `.claude/worktrees/`, soit 44x le contenu tracke, que la CI ne voit jamais), mais sa conclusion se trouve confirmee par la mesure correcte. Le tableau plus haut lui prete la conclusion « les 162 findings sont entierement drainees sur main » comme si elle etait fausse : elle est **vraie**, elle n'etait simplement pas etablie par ce qui la soutenait.

Ce que cette PR corrige n'en est pas affaibli, c'est meme le coeur du sujet : **un scan sous un binaire que rien n'epingle n'est pas une mesure de ce que la CI applique — que son chiffre tombe juste ou non.** Un pin recopie dans une regle rend cette invalidite indetectable ; les deux commandes qui lisent les pins la rendent triviale a ecarter.

Le residuel reel de #10143 s'est deplace ailleurs, et il est plus serieux que le comptage : le **controle positif** exige par son titre ne s'execute jamais (suite absente des testpaths, referencee par aucun workflow, et qui skippe a la main en deferant « CI is the authoritative gate » a une CI qui ne la lance pas). Detail et scope dans le commentaire lie.
