### PR TITLE
docs(conway,#6724): refactor self-refuting HashlifeJump docstring (FR+EN)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife.lean
@@ -299,14 +299,25 @@ L'idee clee : `hashlifeResult` sur une MacroCell de niveau `k` fait
 avancer la region centree de `2^(k-2)` generations. Pour garantir que le
 motif reste dans la region calculee, nous rembourrons la MacroCell de 2
 niveaux avec `centerInLevelPlus2`, qui place le motif au centre d'une
-cellule `(level + 2)`. Cela laisse `2^level` de marge de chaque cote, ce
-qui est largement suffisant pour `2^(level-2)` generations (vitesse de
-la lumiere = 1 cellule/gen).
+cellule `(level + 2)`, laissant `2^level` de marge de chaque cote.
 
-Avec ce rembourrage, `hashlifeResult` sur la cellule rembourree avance
-de `2^level` generations (et non `2^(level-2)`), et le decalage du
-resultat egale le decalage original (le resultat centre de la cellule
-rembourree s'aligne avec la region originale). -/
+Attention : ce rembourrage **augmente aussi la portee**. `hashlifeResult`
+sur la cellule rembourree avance de `2^level` generations (et non
+`2^(level-2)` comme la cellule non rembourree). La marge `2^level` se
+trouve donc comparee a une portee de `2^level` generations : le ratio est
+**tendu** (proche de 1), et non « largement suffisant » comme l'aurait
+laisse croire la portee naive `2^(level-2)`. Le theoreme
+`no_padding_depth_suffices` (cf. `JumpCapture.lean`) le formalise :
+`marginToResultWindow k p < jumpReach k p`, la marge restant strictement
+inferieure a la portee du cone de vitesse 1, l'ecart etant le clip de
+`2^(k-1)`.
+
+Le decalage du resultat egale le decalage original (le resultat centre de
+la cellule rembourree s'aligne avec la region originale). Desserrer ce
+ratio exigerait de decorreler la portee du niveau — le parametre `j` de
+Gosper (rembourrage plus profond que `+2`) ramene le ratio marge/portee
+a `2 - 2^(2-p)`, tendu a `p = 2` et surplus strict a `p >= 3` ; cette
+variante n'est pas implementee ici. -/
 
 /-- Fait sauter une MacroCell en avant de `2^level` generations en
     utilisant le Hashlife recursif avec rembourrage. Remboure l'entree de

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife_en.lean
@@ -299,13 +299,24 @@ The key insight: `hashlifeResult` on a level-`k` MacroCell advances the
 centered region by `2^(k-2)` generations. To ensure the pattern stays
 within the computed region, we pad the MacroCell by 2 levels using
 `centerInLevelPlus2`, which places the pattern at the center of a
-`(level + 2)` cell. This gives `2^level` margin on each side, which is
-more than enough for `2^(level-2)` generations (speed of light = 1 cell/gen).
+`(level + 2)` cell, leaving `2^level` margin on each side.
 
-With this padding, `hashlifeResult` on the padded cell advances by
-`2^level` generations (not `2^(level-2)`), and the result's offset equals
-the original offset (the centered result of the padded cell aligns with
-the original region). -/
+Note that this padding **also increases the reach**: `hashlifeResult` on
+the padded cell advances by `2^level` generations (not `2^(level-2)` as
+the unpadded cell would). The `2^level` margin is therefore measured
+against a reach of `2^level` generations: the ratio is **tight** (close
+to 1), not "more than enough" as the naive `2^(level-2)` reach would
+suggest. The theorem `no_padding_depth_suffices` (see `JumpCapture.lean`)
+formalizes this: `marginToResultWindow k p < jumpReach k p`, the margin
+remaining strictly below the speed-of-light cone's reach, the gap being
+the `2^(k-1)` clip.
+
+The result's offset equals the original offset (the centered result of
+the padded cell aligns with the original region). Loosening this ratio
+would require decoupling the reach from the level — Gosper's `j`
+parameter (padding deeper than `+2`) brings the margin/reach ratio to
+`2 - 2^(2-p)`, tight at `p = 2` and a strict surplus at `p >= 3`; this
+variant is not implemented here. -/
 
 /-- Jump a MacroCell forward by `2^level` generations using recursive
     Hashlife with padding. Pads the input by 2 levels, then calls


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2025:CoursIA — prev: DEEP/notebook-dotnet (#10462)

Refond la docstring du module `hashlifeJump` (`Hashlife.lean` + `Hashlife_en.lean`) qui contenait sa propre réfutation à deux paragraphes d'écart. Steered by ai-01 ([ARBITRAGE #6724] msg-20260811T143434-9ilwz9 : « La docstring `Hashlife.lean:298-309` contient les deux moitiés de sa propre réfutation »). See #6724.

## Le défaut (auto-contradiction mesurée firsthand)

La docstring du bloc `/-! ## API d'accélération exponentielle` disait, à deux paragraphes d'écart :

- **§1** : « Cela laisse `2^level` de marge de chaque côté, ce qui est **largement suffisant** pour `2^(level-2)` générations »
- **§2** : « Avec ce rembourrage, `hashlifeResult` sur la cellule rembourrée **avance de `2^level` générations** (et non `2^(level-2)`) »

Substituez §2 dans §1 : la marge `2^level` est comparée à une portée de `2^level` — ratio **tendu** (proche de 1), pas « largement suffisant ». La prémisse de §1 (portée = `2^(level-2)`) est exactement celle que §2 invalide. C'est cette prose incohérente qui a fait paraître la signature P5 prouvable pendant des mois.

## Le théorème qui tranche (déjà dans le lake)

`no_padding_depth_suffices` (`JumpCapture.lean:257`, mergé par #10441 `450de18a4`) :

```
theorem no_padding_depth_suffices (k p : Nat) (hk : 1 ≤ k) (hp : 1 ≤ p) :
    marginToResultWindow k p < jumpReach k p
```

avec `marginToResultWindow k p = 2^(k+p-2) − 2^(k-1)` (marge) et `jumpReach k p = 2^(k+p-2)` (portée du cône de vitesse 1). La marge est **strictement inférieure** à la portée, l'écart étant le clip de `2^(k-1)`. Le « largement suffisant » de §1 est donc faux dans les deux sens : la portée réelle est `2^level`, et même contre elle la marge reste strictement en dessous.

## Le fix (docstring-only, FR + EN sibling)

Refonte des §1-§2 en un raisonnement cohérent :

1. Le rembourrage `centerInLevelPlus2` laisse `2^level` de marge — mais **augmente aussi la portée** à `2^level` (et non `2^(level-2)`).
2. Le ratio marge/portée est **tendu** (proche de 1), pas « largement suffisant ». Citation de `no_padding_depth_suffices` par nom + son énoncé (`marginToResultWindow k p < jumpReach k p`, écart = clip `2^(k-1)`).
3. Le **levier réel** pour desserrer : décorréler la portée du niveau via le paramètre `j` de Gosper (rembourrage plus profond que `+2`). La docstring du lemme elle-même porte déjà le calcul `2 − 2^(2-p)` : tendu à `p = 2`, surplus strict à `p ≥ 3`. Cette variante n'est pas implémentée — nommée explicitement, pas masquée.

## Preuves (anti-régression, firsthand)

- **Diff docstring-only** : `+37/−15` sur 2 fichiers, **0 ligne de code** (`def`/`theorem`/`lemma`/proof) touchée. Seules les lignes 299-309 (à l'intérieur du bloc `/-! ... -/`) ont bougé, dans les deux fichiers.
- **i18n sibling checker** : `check_i18n_siblings.py Hashlife.lean Hashlife_en.lean` → **OK byte-identical** (0 drift, 0 orphan) — la paire FR/EN reste conforme (code byte-identical, docstrings diffèrent légitimement par langue).
- **Citation vérifiée firsthand** : `no_padding_depth_suffices` lu dans `JumpCapture.lean:257` (énoncé exact), `marginToResultWindow`/`jumpReach` lus lignes 208/215.

## Build verdict : RECOVERABLE-MACHINE (honnête)

`lake build Conway.Life.Hashlife` **n'a pas pu être validé sur po-2025** : la machine est **Mathlib-froide** (MEMORY `po2025-cold-mathlib-conway-recoverable-machine`). Le build de Mathlib depuis zéro (worktree frais, ~2955 cibles) a crashé (`Lean exited with code 1073807364` = `STATUS_ACCESS_VIOLATION`, segfault parallèle à 2258/2955) puis timeout (>10 min) à deux reprises. Aucun worktree sur po-2025 n'a de cache Mathlib réutilisable (`find .lake/.../Mathlib -name '*.olean'` = 0 sur tous les worktrees).

Ce défaut est **totalement indépendant de ma modif** : la modif est **docstring-only** (un commentaire dans un bloc `/-! ... -/`), qui ne produit **pas de bytecode** Lean. Le crash survient sur `Mathlib.Algebra.CharP.Invertible` (vendored, non touché). Les preuves de non-régression sont portées ailleurs :

1. **Diff docstring-only** : `+37/−15` sur 2 fichiers, **0 ligne de code** (`def`/`theorem`/`lemma`/proof) touchée — seulement les lignes 299-309 à l'intérieur du bloc `/-! ... -/`.
2. **i18n sibling checker OK byte-identical** (0 drift, 0 orphan) — le code (hors docstring) est byte-identique entre FR et EN.
3. **Citation correcte** : `no_padding_depth_suffices` énoncé lu firsthand (JumpCapture.lean:257), `marginToResultWindow`/`jumpReach` defs lues lignes 208/215.

**Action demandée** : re-review `lake build Conway.Life.Hashlife` sur une machine Lean-chaude (ai-01 a un Conway chaud — il a `no_padding_depth_suffices` mergé via #10441 po-2026 ; po-2026 a le lake Conway le plus récent). Si le build échoue sur cette modif, c'est que j'ai cassé le module — mais une modif de commentaire de module ne peut pas le faire.
- **Anti-régression** : la docstring du lemme `no_padding_depth_suffices` elle-même (lignes ~253-258) porte déjà le levier `j` de Gosper — ma refonte est cohérente avec elle, pas en conflit.

## Pourquoi MED/lean (G-VAR-3)

Rotation depuis `notebook-dotnet` (#10462 GT-10 .efg) — famille et genre distincts (Lean vs .NET notebook). Substantial MED : la refonte résout une auto-contradiction documentée (pas un relabel), cite un théorème voisin par nom, et nomme le levier réel. Le litmus LIGHT (« générable en série par scan ») = NON (a nécessité de croiser §1/§2 avec l'énoncé du lemme et la définition des fonctions de marge/portée).

See #6724 (étape 0 docstring, arbitrage ai-01). Le plat principal étape 1 (`p5_large_n_jumpN` sous capture itérée) reste sur cette issue — grain distinct.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
