### PR TITLE
feat(twin,#10382): bridge_verdict SOTA-OK for Z3-Python-03 Tactics (pyz3/Microsoft.Z3 native)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/z3-python-03-tactics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-03-tactics.yaml
@@ -3,11 +3,19 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Z3 EST le moteur SOTA, branche NATIVEMENT des deux cotes : Microsoft.Z3 (NuGet officiel) et pyz3 sont les deux bindings de la meme lib C++ Z3 sous-jacente (pas un pont intermediaire type IKVM/PythonNet). Parite firsthand sur Tactic('simplify') cellule 1 des deux notebooks : meme output SMT-LIB canonique — C# '(not (<= x 0))' == Python 'Not(x <= 0)' et C# '(= y (+ 5 x))' == Python 'y == 1 + x'. Aucune asymetrie de machinerie a corriger."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 596992096613fb08367a5e41fae56b1b01254572
       csharp_sha: 414f62ee58470a82f189ed74cc5c46a12692648a
+    - date: "2026-08-11"
+      by: myia-po-2026:CoursIA
+      python_sha: 596992096613fb08367a5e41fae56b1b01254572
+      csharp_sha: 414f62ee58470a82f189ed74cc5c46a12692648a
+      content_python_sha: 3f590d25ba1cfb7125b7cc0409c0510c4b5a4d6cbe0a85645068c27977c5d095
+      content_csharp_sha: 06fef20e6776d5520ff1c5e0e0c667d11d719dea44f28632e1ba47768ade2064
   known_differences:
     - "Python : pyz3 (Tactic('simplify'), Then(), With()). C# : Microsoft.Z3 .NET (Tactic(ctx, ...))."
     - "Concept demontre (simplify elimine une redondance, ctx-solver-simplify la garde) verifie firsthand cote Python (NB-03 CLEAN)."


### PR DESCRIPTION
Grain: LIGHT/tooling -- lane myia-po-2026:CoursIA

Quoi: `bridge_verdict: SOTA-OK` + `bridge_verdict_reason` sur la paire twin `Z3-Python-03 Tactics` (SMT/Z3-API). Atteste formellement que le moteur SOTA Z3 est proprement branché des deux côtés (Python pyz3 + C# Microsoft.Z3), retirant la paire du bucket « actionnable sans intervention manuelle » (mandat ai-01 : 155 paires twin sans bridge_verdict, EPIC #10382 lib-vs-lib).
Preuve: parité firsthand sur `Tactic('simplify')` cellule 1 des deux notebooks (déjà exécutés 14/14 Python, 12/12 C#) — même output SMT-LIB canonique : C# `(not (<= x 0))` ≡ Python `Not(x <= 0)` ; C# `(= y (+ 5 x))` ≡ Python `y == 1 + x`. `check_twin_parity.py --ci-strict` : 157 paires, drift_blob=0, drift_content=0, exit 0. SHA notebooks inchangés (python_sha 59699209…, csharp_sha 414f62ee…) = preuve parité tient (aucun notebook modifié).
Perimetre: `z3-python-03-tactics.yaml` seul (+8 lignes : verdict + reason + entrée audit). Hors scope: notebooks Python/C# inchangés (pont déjà démontré dans le contenu existant) ; `parity_level: semantic` inchangé (le verdict est orthogonal à parity_level per le schema `_schema.yaml`).

## Contexte

Microsoft.Z3 (package NuGet officiel) et pyz3 sont les **deux bindings natifs officiels** de la même lib C++ Z3 sous-jacente — ce n'est pas un pont intermédiaire (type IKVM/PythonNet). Le verdict `SOTA-OK` du schema `bridge_verdict` (« le vrai outil SOTA est proprement branché ») est donc correct par construction, et confirmé firsthand par la parité des outputs simplify.

Le verdict est **orthogonal à `parity_level: semantic`** (déjà présent) : `parity_level` décrit la fidélité de traduction cellule-par-cellule ; `bridge_verdict` décrit si un moteur SOTA est branchable/branché côté .NET. Les deux coexistent.

See #10382
