### PR TITLE
fix(variation,#10480): --check-pr consumes the GENRE cap as single source

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -284,10 +284,15 @@ jobs:
           gh pr view "$PR_NUMBER" --json labels > /tmp/pr_labels.json 2>/dev/null || \
             printf '[]' > /tmp/pr_labels.json
 
-          # ADVISORY : le script sort toujours en 0. Si le TIER EFFECTIF n'est
-          # pas LIGHT (declare LIGHT re-qualifie up, ou declare non-LIGHT sans
-          # down-qualif) ou la lane absente, il renvoie cap_reached=false et le
-          # label est retire (un label colle par un push anterieur ne survit pas).
+          # ADVISORY : le script sort toujours en 0. cap_reached consomme les
+          # DEUX axes du cap G-VAR-2 (#10480) : le TIER (LIGHT declare/effectif)
+          # ET le GENRE (light-genre -- readme/docs/guard/ledger/test -- quel
+          # que soit le tier declare). Un MED/readme peut donc faire cap_reached
+          # =true meme si 0 LIGHT declare (ferme le bypass ou --check-pr disait
+          # false et --genre-signals disait CAP-EXCEEDED-BY-GENRE sur la meme
+          # lane-day). Un non-LIGHT non-light-genre (DEEP/lean, MED/tooling) ou
+          # une lane absente renvoie cap_reached=false/None et le label est
+          # retire (un label colle par un push anterieur ne survit pas).
           python3 scripts/variation_light_cap.py \
             --replay /tmp/merged.json \
             --check-pr "$PR_NUMBER" \

--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -1029,3 +1029,174 @@ def test_truncation_flips_cap_verdict_on_the_10328_shape(tmp_path, capsys):
 
     assert cap_of(full)["cap"] == 3
     assert cap_of(lights)["cap"] == 1
+
+
+# --- #10480 : --check-pr consumes the GENRE cap as a single source -----------
+#
+# The defect (issue #10480, measured by ai-01 while merging #10468): on the
+# same lane-day, `--check-pr` returned `cap_reached: false` (the TIER axis was
+# empty -- 0 LIGHT declared) while `--genre-signals` returned
+# `CAP-EXCEEDED-BY-GENRE: true` (the GENRE axis was saturated by MED/readme
+# grains). The merge-gate reads `--check-pr`, so it let the bypass through: a
+# lane could declare MED on readme grains and never trip the cap. The fix makes
+# `--check-pr` consume BOTH axes (single source), discloses it via
+# `counts: "tier+genre"`, aligns the genre denominator on the tier CI window
+# (+1 open candidate), and #10341-guards the union so an innocent CONTENT
+# candidate is not held for a lane-day aggregate it does not carry.
+
+
+def test_check_pr_med_readme_on_saturated_lane_is_cap_reached(tmp_path, capsys):
+    # The #10480 defect, pinned. A lane with one MED/readme already merged;
+    # the OPEN candidate is also MED/readme. The TIER axis is empty (0 LIGHT
+    # declared) so the pre-fix --check-pr short-circuited `eff != "LIGHT"` to
+    # `cap_reached: false`. But the GENRE axis is saturated (light_genre=2 >
+    # cap=1) -- exactly what --genre-signals reported. The single-source fix
+    # makes --check-pr consume the genre axis: the MED/readme candidate IS a
+    # LIGHT-genre grain, so cap_reached must be True (the bypass is closed).
+    lane = "myia-ai-01:CoursIA"
+    merged = [
+        {"number": 1, "body": f"Grain: MED/readme -- lane {lane}",
+         "mergedAt": "2026-08-11T03:00:00Z"},
+    ]
+    body = f"Grain: MED/readme -- lane {lane}"
+    rc, res = _check_pr(tmp_path, merged, body, capsys=capsys)
+    assert rc == 0
+    assert res["cap_reached"] is True               # the bypass is closed
+    assert res["tier_cap_reached"] is False         # 0 LIGHT declared
+    assert res["cap_exceeded_by_genre"] is True     # light_genre=2 > cap=1
+    assert res["counts"] == "tier+genre"
+    assert res["light_genre"] == 2                  # 1 merged + the candidate
+    assert res["genre_cap"] == 1
+
+
+def test_check_pr_counts_field_discloses_both_axes(tmp_path, capsys):
+    # Acceptance #1: the verdict discloses which axes were tallied via
+    # `counts`, so the workflow never mistakes a single-source verdict for a
+    # declared-only one (the defect's blind spot).
+    lane = "myia-po-2023:CoursIA"
+    merged = [{"number": 1, "body": BODY_EMDASH, "mergedAt": "2026-08-11T03:00:00Z"}]
+    rc, res = _check_pr(tmp_path, merged, BODY_EMDASH, capsys=capsys)
+    assert rc == 0
+    assert res["counts"] == "tier+genre"
+
+
+def test_check_pr_lane_grains_window_aligned_tier_genre(tmp_path, capsys):
+    # Acceptance #2: the TIER and GENRE axes share the SAME CI window
+    # (lane_grains + 1 -- the open candidate). Pre-fix, --check-pr's tier
+    # denominator was `len(merged) + 1` while --genre-signals' genre
+    # denominator was `len(merged)` (merged-only) -- two different windows
+    # for the same lane-day. The fix aligns the genre denominator on the
+    # tier window INSIDE --check-pr (CI semantics); --genre-signals keeps
+    # the merged-only window by design (audit path, day over).
+    lane = "myia-po-2023:CoursIA"
+    # 3 merged DEEP grains + the open LIGHT/guard candidate.
+    merged = [
+        {"number": i, "body": f"Grain: DEEP/lean -- lane {lane}",
+         "mergedAt": f"2026-08-11T0{i}:00:00Z"}
+        for i in range(1, 4)
+    ]
+    body = f"Grain: LIGHT/guard -- lane {lane}"
+    rc, res = _check_pr(tmp_path, merged, body, capsys=capsys)
+    assert rc == 0
+    assert res["lane_grains"] == 4          # 3 merged + candidate (shared window)
+    # budget (tier) and genre_cap both derive from light_budget(lane_grains+1).
+    assert res["budget"] == 1
+    assert res["genre_cap"] == 1
+    assert res["budget"] == res["genre_cap"]
+
+
+def test_check_pr_med_tooling_innocent_on_saturated_lane_not_flipped(tmp_path, capsys):
+    # #10341 non-regression inside the #10480 fix. The lane's genre-cap is
+    # saturated (2 MED/readme merged), but the OPEN candidate is MED/tooling
+    # -- a CONTENT genre that does NOT carry the LIGHT-genre motif. The
+    # aggregate pattern is real (surfaced via lane_genre_saturated) but the
+    # candidate is innocent: cap_reached stays False. Holding it would block
+    # the grain that REMEDIES the monoculture instead of the META grains
+    # that caused it.
+    lane = "myia-po-2023:CoursIA"
+    merged = [
+        {"number": 1, "body": f"Grain: MED/readme -- lane {lane}",
+         "mergedAt": "2026-08-11T01:00:00Z"},
+        {"number": 2, "body": f"Grain: MED/readme -- lane {lane}",
+         "mergedAt": "2026-08-11T02:00:00Z"},
+    ]
+    body = f"Grain: MED/tooling -- lane {lane}"
+    rc, res = _check_pr(tmp_path, merged, body, capsys=capsys)
+    assert rc == 0
+    assert res["cap_reached"] is False                # innocent candidate
+    assert res["reason"].startswith("not LIGHT")      # historical verdict preserved
+    assert res.get("lane_genre_saturated") is True     # lane-day pattern surfaced
+
+
+def test_check_pr_light_non_light_genre_on_saturated_lane_not_genre_flipped(tmp_path, capsys):
+    # The #10341 guard in the OTHER direction: a LIGHT/tooling (tier LIGHT,
+    # genre NOT light-genre) on a readme-saturated lane. The tier axis
+    # assesses it normally (it IS a declared LIGHT); the genre axis reports
+    # the lane saturated (cap_exceeded_by_genre=True) but the UNION does not
+    # flip cap_reached -- the candidate does not carry the readme motif.
+    lane = "myia-po-2023:CoursIA"
+    merged = [
+        {"number": 1, "body": f"Grain: MED/readme -- lane {lane}",
+         "mergedAt": "2026-08-11T01:00:00Z"},
+        {"number": 2, "body": f"Grain: MED/readme -- lane {lane}",
+         "mergedAt": "2026-08-11T02:00:00Z"},
+    ]
+    body = f"Grain: LIGHT/tooling -- lane {lane}"
+    rc, res = _check_pr(tmp_path, merged, body, capsys=capsys)
+    assert rc == 0
+    assert res["tier_cap_reached"] is False           # 0 merged LIGHT, budget 1
+    assert res["cap_exceeded_by_genre"] is True       # the LANE is saturated
+    assert res["cap_reached"] is False                # but THIS candidate is innocent
+
+
+def test_check_pr_med_readme_first_of_lane_not_cap_reached(tmp_path, capsys):
+    # Falsification: a SINGLE MED/readme on an empty lane is within the floor
+    # budget (light_genre=1 == cap=1). The genre axis does not over-fire on
+    # the first grain -- the budget is permissive on purpose, only a
+    # SUSTAINED pattern is the defect.
+    lane = "myia-po-2023:CoursIA"
+    body = f"Grain: MED/readme -- lane {lane}"
+    rc, res = _check_pr(tmp_path, [], body, capsys=capsys)
+    assert rc == 0
+    assert res["cap_reached"] is False
+    assert res["cap_exceeded_by_genre"] is False      # light_genre=1 == cap=1
+    assert res["light_genre"] == 1
+    assert res["genre_cap"] == 1
+
+
+def test_check_pr_coherent_with_genre_signals_on_defect(tmp_path, capsys):
+    # Acceptance #3 (the pinning test): on a saturated lane-day, --check-pr
+    # and --genre-signals must NOT contradict each other. Pre-fix,
+    # --check-pr returned `cap_reached: false` while --genre-signals returned
+    # `CAP-EXCEEDED-BY-GENRE: true` -- the merge-gate let the bypass through.
+    # The single-source fix aligns them: when the candidate is a LIGHT-genre
+    # grain and the lane's genre count exceeds the cap, --check-pr's
+    # `cap_reached` agrees with the genre signal.
+    lane = "myia-ai-01:CoursIA"
+    merged = [
+        {"number": 1, "body": f"Grain: MED/readme -- lane {lane}",
+         "mergedAt": "2026-08-11T03:00:00Z"},
+        {"number": 2, "body": f"Grain: MED/readme -- lane {lane}",
+         "mergedAt": "2026-08-11T04:00:00Z"},
+    ]
+    mpath = tmp_path / "merged.json"
+    mpath.write_text(json.dumps(merged), encoding="utf-8")
+    bpath = tmp_path / "body.txt"
+    bpath.write_text(f"Grain: MED/readme -- lane {lane}", encoding="utf-8")
+    # --genre-signals: the audit verdict over the merged set (+candidate genre).
+    rc_g = vlc.main([
+        "--replay", str(mpath), "--genre-signals", "--lane", lane,
+        "--body-file", str(bpath),
+    ])
+    sig = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    # --check-pr: the CI verdict over the same lane-day.
+    rc_c = vlc.main([
+        "--replay", str(mpath), "--check-pr", "3", "--body-file", str(bpath),
+    ])
+    chk = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert rc_g == 0 and rc_c == 0
+    # Coherence: the genre axis is exceeded in BOTH verdicts, and because the
+    # candidate carries the motif (readme), --check-pr's union agrees.
+    assert sig["signals"]["CAP-EXCEEDED-BY-GENRE"] is True
+    assert chk["cap_exceeded_by_genre"] is True
+    assert chk["cap_reached"] is True

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -29,9 +29,17 @@ Modes
 
   --check-pr <N>       CI mode (the current PR): report whether PR <N> would be
                        cap-reached given the already-merged PRs in <file>.
-                       Emits machine-readable fields for the workflow to label
-                       and comment: `cap_reached`, `lane`, `consumed_by` (the
-                       earlier LIGHT that spent the budget, with its merge time).
+                       Consumes BOTH cap axes as a single source (#10480): the
+                       TIER cap (declared/effective LIGHT count) AND the GENRE
+                       cap (LIGHT-genre count, regardless of declared tier). A
+                       MED/readme can therefore be `cap_reached` even though its
+                       declared tier never spends the TIER budget -- closing the
+                       bypass where --check-pr returned `false` while
+                       --genre-signals returned `CAP-EXCEEDED-BY-GENRE` on the
+                       same lane-day. Emits `cap_reached` (the union, when the
+                       candidate carries the LIGHT-genre motif, #10341),
+                       `tier_cap_reached`, `cap_exceeded_by_genre`, `lane`,
+                       `consumed_by`, and a `counts: "tier+genre"` disclosure.
 
 Parsing
 -------
@@ -809,6 +817,20 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.check_pr is not None:
         # CI mode: the current PR is OPEN, so its body is NOT in the merged set.
+        #
+        # G-VAR-2 by GENRE (#10480): the verdict consumes BOTH cap axes -- the
+        # TIER cap (declared/effective LIGHT count, `light_cap_status`) AND the
+        # GENRE cap (LIGHT-genre count, `lane_genre_tally`). The defect this
+        # closes: a lane declared MED on readme grains saw `cap_reached: false`
+        # from --check-pr (the tier axis was empty) while --genre-signals
+        # screamed `CAP-EXCEEDED-BY-GENRE` (the genre axis was saturated) --
+        # same lane, same day, same script, contradictory verdicts, and the
+        # merge-gate (which reads --check-pr) let the bypass through. The
+        # single-source fix: --check-pr surfaces both axes, the `counts` field
+        # discloses which were tallied, and `cap_reached` is the UNION when the
+        # candidate itself carries the LIGHT-genre motif (#10341 preserves the
+        # innocent-CONTENT candidate from a lane-day aggregate it does not
+        # contribute to).
         body = None
         if args.body is not None:
             body = args.body
@@ -820,9 +842,15 @@ def main(argv: list[str] | None = None) -> int:
         if args.labels_file:
             cur_labels = load_labels_file(Path(args.labels_file))
         # Effective tier (#8970): a requalification label overrides the declared
-        # one. Only an EFFECTIVE LIGHT is assessed against the cap.
+        # one. Only an EFFECTIVE LIGHT spends the TIER budget. The GENRE budget
+        # is read off the declared genre (`effective_genre`), which a
+        # requalification label does NOT override -- the genre is the worker's
+        # substance claim, not a coordinator re-qualification field.
         eff = effective_tier(body, cur_labels)
         g = parse_grain(body)
+        cand_genre = effective_genre(body, cur_labels)
+        candidate_is_light_genre = cand_genre in LIGHT_GENRES
+
         # UNASSESSABLE vs ASSESSED (#9465). `cap_reached: false` must mean one
         # thing only: "assessed, and within budget". A body with no readable
         # tag, or a tag without a lane, is not an exemption -- it is a
@@ -836,26 +864,69 @@ def main(argv: list[str] | None = None) -> int:
                 "reason": "unassessable -- no Grain: tag in body",
             }))
             return 0
-        if eff != "LIGHT":
-            # A KNOWN non-LIGHT tier is a genuine assessment, lane or not: a
-            # MED/DEEP grain never spends the LIGHT budget. Only the lane's
-            # denominator suffers, and that is `unattributed`'s business.
-            print(json.dumps({"cap_reached": False, "reason": f"not LIGHT (effective {eff})"}))
+        lane = g["lane"]
+        # A non-LIGHT tier never spends the TIER budget; a non-LIGHT-GENRE
+        # grain never spends the GENRE budget. A candidate that carries
+        # NEITHER axis (DEEP/lean, MED/tooling) gets the historical "not
+        # LIGHT" verdict -- the #10341 guard: a lane-day aggregate pattern
+        # must not be posed on a CONTENT candidate that does not carry it.
+        # Only a non-LIGHT tier that IS a LIGHT-genre (the MED/readme defect
+        # case) falls through to the structured assessment where the genre
+        # cap can flip `cap_reached`.
+        if eff != "LIGHT" and not candidate_is_light_genre:
+            out: dict = {"cap_reached": False, "reason": f"not LIGHT (effective {eff})"}
+            if lane:
+                # The lane's genre-cap may already be saturated by OTHER
+                # grains of the day. Surface it informationally (it does NOT
+                # flip `cap_reached` -- this candidate does not carry the
+                # motif) so the coordinator sees the lane-day pattern at
+                # merge time without the gate holding an innocent grain.
+                tally_info = lane_genre_tally(merged, lane)
+                if tally_info["light_genre"] > tally_info["cap"]:
+                    out["lane_genre_saturated"] = True
+            print(json.dumps(out))
             return 0
-        if not g["lane"]:
-            # An effective LIGHT with no lane is the one case where the tier is
-            # known and the answer still cannot be computed: the budget is
-            # per-lane, so without a lane there is no denominator to compare to.
+        if not lane:
+            # An effective LIGHT (or a LIGHT-genre MED) with no lane is the one
+            # case where an axis is known and the answer still cannot be
+            # computed: both budgets are per-lane, so without a lane there is
+            # no denominator to compare to on either axis.
             print(json.dumps({
                 "cap_reached": None,
-                "reason": "unassessable -- effective LIGHT but no lane in tag",
+                "reason": "unassessable -- LIGHT (or LIGHT-genre) but no lane in tag",
             }))
             return 0
-        status = light_cap_status(merged, g["lane"])
+        # Structured assessment: effective LIGHT, OR a LIGHT-genre MED/DEEP.
+        # The two cap axes share the SAME CI window (lane_grains + 1 -- the
+        # open candidate is itself a grain of the day, counted in both
+        # denominators). The GENRE axis is aligned on the TIER window here;
+        # --genre-signals (the audit path) keeps the merged-only window
+        # because the day is over there and the denominator is KNOWN.
+        status = light_cap_status(merged, lane)
+        tally = lane_genre_tally(merged, lane)
+        light_genre_count = tally["light_genre"] + (1 if candidate_is_light_genre else 0)
+        genre_cap = light_budget(tally["lane_grains"] + 1)  # +1 candidate, aligned
+        cap_exceeded_by_genre = light_genre_count > genre_cap
+        tier_cap_reached = status["cap_reached"]
+        # UNION only when the candidate carries the genre motif (#10341): a
+        # LIGHT/tooling (tier LIGHT, genre not LIGHT) cannot trip the genre
+        # cap; a MED/readme (tier MED, genre LIGHT) can. Both directions of
+        # the defect are closed -- the declared-MED bypass AND the coherence
+        # with --genre-signals.
+        cap_reached = tier_cap_reached or (cap_exceeded_by_genre and candidate_is_light_genre)
         print(json.dumps({
             "pr": args.check_pr,
-            "lane": g["lane"],
-            **status,
+            "lane": lane,
+            "cap_reached": cap_reached,
+            "tier_cap_reached": tier_cap_reached,
+            "cap_exceeded_by_genre": cap_exceeded_by_genre,
+            "budget": status["budget"],
+            "spent": status["spent"],
+            "light_genre": light_genre_count,
+            "genre_cap": genre_cap,
+            "lane_grains": status["lane_grains"],
+            "consumed_by": status["consumed_by"],
+            "counts": "tier+genre",
         }))
         return 0
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: DEEP/tooling-secrets #10472

## Summary

The cross-PR LIGHT cap (G-VAR-2) had two counting axes that **contradicted each other on the same lane-day** (measured by ai-01 while merging #10468):

- `--check-pr` counted LIGHT by **declared tier** → short-circuited `eff != "LIGHT"` → `cap_reached: false` for any MED.
- `--genre-signals` counted LIGHT by **genre class** → `light_genre > cap` → `CAP-EXCEEDED-BY-GENRE: true`.

The merge-gate reads `--check-pr`, so a lane declaring **MED on readme grains** bypassed the cap entirely -- `--check-pr` said `false` while `--genre-signals` said `CAP-EXCEEDED-BY-GENRE: true` on the same lane, same day, same script.

## Fix (issue #10480, 3 acceptance points)

1. **Single source** -- `--check-pr` now consumes BOTH axes. The verdict adds `tier_cap_reached`, `cap_exceeded_by_genre`, `light_genre`, `genre_cap`, and a `counts: "tier+genre"` disclosure. A `MED/readme` (light-genre) can now flip `cap_reached` even with 0 LIGHT declared.

2. **Window aligned** -- the tier and genre denominators inside `--check-pr` share the SAME CI window (`lane_grains + 1` -- the open candidate). The genre denominator is now `light_budget(lane_grains + 1)`. `--genre-signals` keeps the merged-only window by design (audit, day over).

3. **Coherence pinned** -- new test `test_check_pr_coherent_with_genre_signals_on_defect`: on a saturated lane-day where the candidate carries the LIGHT-genre motif, `--check-pr.cap_reached` agrees with `--genre-signals.CAP-EXCEEDED-BY-GENRE`.

## #10341 preserved (both directions)

The union guard keeps an innocent CONTENT candidate out of a lane-day aggregate it does not carry:
- `MED/tooling` on a readme-saturated lane → `cap_reached: false` (lane pattern surfaced via `lane_genre_saturated` info field, not flipped).
- `LIGHT/tooling` (tier LIGHT, genre not light) → assessed on the tier axis only.

## Validation

- 73 tests pass (66 existing + 7 new): the defect pinned, `counts` disclosure, window alignment, two #10341 falsifications, the first-grain floor, and the end-to-end coherence pin.
- YAML syntax of the workflow re-validated.
- Smoke test on the defect scenario: `--check-pr` now returns `cap_reached: true` for a `MED/readme` on a saturated lane (was `false`).

Closes #10480

🤖 Generated with [Claude Code](https://claude.com/claude-code)
