### PR TITLE
feat(gt2-part2,#10459): Gambit enummixed bridge as SOTA oracle for C# support enumeration

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp-Part2.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp-Part2.ipynb
@@ -53,10 +53,10 @@
    "id": "gt2b02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T03:49:21.233157Z",
-     "iopub.status.busy": "2026-07-06T03:49:21.228820Z",
-     "iopub.status.idle": "2026-07-06T03:49:22.530914Z",
-     "shell.execute_reply": "2026-07-06T03:49:22.527185Z"
+     "iopub.execute_input": "2026-08-11T18:59:09.068207Z",
+     "iopub.status.busy": "2026-08-11T18:59:09.052045Z",
+     "iopub.status.idle": "2026-08-11T18:59:11.474394Z",
+     "shell.execute_reply": "2026-08-11T18:59:11.467987Z"
     },
     "papermill": {
      "duration": 1.308053,
@@ -77,7 +77,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -87,10 +86,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -105,7 +101,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -117,8 +112,6 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -167,13 +160,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -232,10 +223,10 @@
    "id": "gt2b04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T03:49:22.542737Z",
-     "iopub.status.busy": "2026-07-06T03:49:22.542502Z",
-     "iopub.status.idle": "2026-07-06T03:49:22.808085Z",
-     "shell.execute_reply": "2026-07-06T03:49:22.807968Z"
+     "iopub.execute_input": "2026-08-11T18:59:11.477317Z",
+     "iopub.status.busy": "2026-08-11T18:59:11.476786Z",
+     "iopub.status.idle": "2026-08-11T18:59:12.196546Z",
+     "shell.execute_reply": "2026-08-11T18:59:12.195875Z"
     },
     "papermill": {
      "duration": 0.268563,
@@ -320,10 +311,10 @@
    "id": "gt2b06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T03:49:22.817754Z",
-     "iopub.status.busy": "2026-07-06T03:49:22.817610Z",
-     "iopub.status.idle": "2026-07-06T03:49:22.937922Z",
-     "shell.execute_reply": "2026-07-06T03:49:22.937792Z"
+     "iopub.execute_input": "2026-08-11T18:59:12.199041Z",
+     "iopub.status.busy": "2026-08-11T18:59:12.198561Z",
+     "iopub.status.idle": "2026-08-11T18:59:12.507955Z",
+     "shell.execute_reply": "2026-08-11T18:59:12.507129Z"
     },
     "papermill": {
      "duration": 0.123859,
@@ -406,10 +397,10 @@
    "id": "gt2b08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T03:49:22.948386Z",
-     "iopub.status.busy": "2026-07-06T03:49:22.948215Z",
-     "iopub.status.idle": "2026-07-06T03:49:23.045088Z",
-     "shell.execute_reply": "2026-07-06T03:49:23.044962Z"
+     "iopub.execute_input": "2026-08-11T18:59:12.510697Z",
+     "iopub.status.busy": "2026-08-11T18:59:12.510216Z",
+     "iopub.status.idle": "2026-08-11T18:59:12.707839Z",
+     "shell.execute_reply": "2026-08-11T18:59:12.707020Z"
     },
     "papermill": {
      "duration": 0.100059,
@@ -505,10 +496,10 @@
    "id": "gt2b10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T03:49:23.055384Z",
-     "iopub.status.busy": "2026-07-06T03:49:23.055121Z",
-     "iopub.status.idle": "2026-07-06T03:49:23.238569Z",
-     "shell.execute_reply": "2026-07-06T03:49:23.238442Z"
+     "iopub.execute_input": "2026-08-11T18:59:12.710877Z",
+     "iopub.status.busy": "2026-08-11T18:59:12.710362Z",
+     "iopub.status.idle": "2026-08-11T18:59:13.039680Z",
+     "shell.execute_reply": "2026-08-11T18:59:13.038956Z"
     },
     "papermill": {
      "duration": 0.186565,
@@ -557,11 +548,11 @@
    "id": "gt2en01",
    "metadata": {},
    "source": [
-       "### De l'enumération combinatoire au test d'équilibre\n",
-       "\n",
-       "La fonction `SubsetsOfSize` ci-dessus est le **moteur combinatoire** : elle engendre tous les sous-ensembles de taille $k$ d'un ensemble de $n$ actions — il y en a $\\binom{n}{k}$. Sur Pierre-Feuille-Ciseaux ($n=3$), cela ne fait que $\\binom{3}{1}+\\binom{3}{2}+\\binom{3}{3} = 7$ supports à examiner par joueur.\n",
-       "\n",
-       "Le principe de **l'énumération des supports** (Mangasarian–Stone, 1964 ; Stengel 2002) est de transformer la recherche d'un équilibre de Nash en une **énumération finie** : pour chaque paire de supports candidats $(S_1, S_2)$ de même taille, on résout le **système d'indifférence** (la stratégie adverse rend le joueur indifférent entre les actions de son support) puis on **vérifie la positivité** et la condition de **best-response hors-support**. Chaque support donne au plus un équilibre candidat — c'est un algorithme complet qui trouve **tous** les équilibres, au prix d'une complexité combinatoire.\n"
+    "### De l'enumération combinatoire au test d'équilibre\n",
+    "\n",
+    "La fonction `SubsetsOfSize` ci-dessus est le **moteur combinatoire** : elle engendre tous les sous-ensembles de taille $k$ d'un ensemble de $n$ actions — il y en a $\\binom{n}{k}$. Sur Pierre-Feuille-Ciseaux ($n=3$), cela ne fait que $\\binom{3}{1}+\\binom{3}{2}+\\binom{3}{3} = 7$ supports à examiner par joueur.\n",
+    "\n",
+    "Le principe de **l'énumération des supports** (Mangasarian–Stone, 1964 ; Stengel 2002) est de transformer la recherche d'un équilibre de Nash en une **énumération finie** : pour chaque paire de supports candidats $(S_1, S_2)$ de même taille, on résout le **système d'indifférence** (la stratégie adverse rend le joueur indifférent entre les actions de son support) puis on **vérifie la positivité** et la condition de **best-response hors-support**. Chaque support donne au plus un équilibre candidat — c'est un algorithme complet qui trouve **tous** les équilibres, au prix d'une complexité combinatoire.\n"
    ]
   },
   {
@@ -570,10 +561,10 @@
    "id": "gt2b11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T03:49:23.244590Z",
-     "iopub.status.busy": "2026-07-06T03:49:23.244396Z",
-     "iopub.status.idle": "2026-07-06T03:49:23.335234Z",
-     "shell.execute_reply": "2026-07-06T03:49:23.335133Z"
+     "iopub.execute_input": "2026-08-11T18:59:13.042484Z",
+     "iopub.status.busy": "2026-08-11T18:59:13.041808Z",
+     "iopub.status.idle": "2026-08-11T18:59:13.269542Z",
+     "shell.execute_reply": "2026-08-11T18:59:13.268973Z"
     },
     "papermill": {
      "duration": 0.094029,
@@ -673,11 +664,11 @@
    "id": "gt2en02",
    "metadata": {},
    "source": [
-       "### Application : Pierre-Feuille-Ciseaux, l'équilibre uniforme attendu\n",
-       "\n",
-       "Appliquons l'algorithme au jeu symétrique $3 \\times 3$ Pierre-Feuille-Ciseaux. L'antisymétrie de la matrice de gain ($u_i = -u_j$) impose qu'aucun joueur n'ait d'avantage systématisque : la théorie prédit l'**équilibre uniforme** $\\sigma = (1/3, 1/3, 1/3)$ pour les deux joueurs, qui rend chaque action indifférente (espérance nulle) et est l'unique best-response à lui-même.\n",
-       "\n",
-       "C'est précisément ce que l'énumération des supports doit retrouver : le support complet $\\{R, P, S\\}$ produit, via le système d'indifférence $3 \\times 3$, la solution uniforme — et les supports de taille 1 et 2 sont rejetés (pas d'équilibre en stratégies pures, ni en support réduit). La cellule suivante exécute cette résolution et affiche le vecteur de probabilité trouvé.\n"
+    "### Application : Pierre-Feuille-Ciseaux, l'équilibre uniforme attendu\n",
+    "\n",
+    "Appliquons l'algorithme au jeu symétrique $3 \\times 3$ Pierre-Feuille-Ciseaux. L'antisymétrie de la matrice de gain ($u_i = -u_j$) impose qu'aucun joueur n'ait d'avantage systématisque : la théorie prédit l'**équilibre uniforme** $\\sigma = (1/3, 1/3, 1/3)$ pour les deux joueurs, qui rend chaque action indifférente (espérance nulle) et est l'unique best-response à lui-même.\n",
+    "\n",
+    "C'est précisément ce que l'énumération des supports doit retrouver : le support complet $\\{R, P, S\\}$ produit, via le système d'indifférence $3 \\times 3$, la solution uniforme — et les supports de taille 1 et 2 sont rejetés (pas d'équilibre en stratégies pures, ni en support réduit). La cellule suivante exécute cette résolution et affiche le vecteur de probabilité trouvé.\n"
    ]
   },
   {
@@ -686,10 +677,10 @@
    "id": "gt2b12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T03:49:23.340808Z",
-     "iopub.status.busy": "2026-07-06T03:49:23.340644Z",
-     "iopub.status.idle": "2026-07-06T03:49:23.415498Z",
-     "shell.execute_reply": "2026-07-06T03:49:23.415376Z"
+     "iopub.execute_input": "2026-08-11T18:59:13.271793Z",
+     "iopub.status.busy": "2026-08-11T18:59:13.271281Z",
+     "iopub.status.idle": "2026-08-11T18:59:13.460628Z",
+     "shell.execute_reply": "2026-08-11T18:59:13.460227Z"
     },
     "papermill": {
      "duration": 0.077944,
@@ -770,10 +761,10 @@
    "id": "gt2b14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T03:49:23.426717Z",
-     "iopub.status.busy": "2026-07-06T03:49:23.426510Z",
-     "iopub.status.idle": "2026-07-06T03:49:23.535570Z",
-     "shell.execute_reply": "2026-07-06T03:49:23.535300Z"
+     "iopub.execute_input": "2026-08-11T18:59:13.463315Z",
+     "iopub.status.busy": "2026-08-11T18:59:13.462855Z",
+     "iopub.status.idle": "2026-08-11T18:59:13.692969Z",
+     "shell.execute_reply": "2026-08-11T18:59:13.692090Z"
     },
     "papermill": {
      "duration": 0.112984,
@@ -867,10 +858,10 @@
    "id": "gt2b16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T03:49:23.547500Z",
-     "iopub.status.busy": "2026-07-06T03:49:23.547329Z",
-     "iopub.status.idle": "2026-07-06T03:49:23.616420Z",
-     "shell.execute_reply": "2026-07-06T03:49:23.616284Z"
+     "iopub.execute_input": "2026-08-11T18:59:13.695499Z",
+     "iopub.status.busy": "2026-08-11T18:59:13.694980Z",
+     "iopub.status.idle": "2026-08-11T18:59:13.852126Z",
+     "shell.execute_reply": "2026-08-11T18:59:13.851629Z"
     },
     "papermill": {
      "duration": 0.072909,
@@ -953,10 +944,10 @@
    "id": "gt2b18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T03:49:23.628877Z",
-     "iopub.status.busy": "2026-07-06T03:49:23.628549Z",
-     "iopub.status.idle": "2026-07-06T03:49:23.711382Z",
-     "shell.execute_reply": "2026-07-06T03:49:23.711156Z"
+     "iopub.execute_input": "2026-08-11T18:59:13.855405Z",
+     "iopub.status.busy": "2026-08-11T18:59:13.854922Z",
+     "iopub.status.idle": "2026-08-11T18:59:14.014752Z",
+     "shell.execute_reply": "2026-08-11T18:59:14.013977Z"
     },
     "papermill": {
      "duration": 0.086701,
@@ -1012,6 +1003,195 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "86226c8a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T18:59:14.017150Z",
+     "iopub.status.busy": "2026-08-11T18:59:14.016659Z",
+     "iopub.status.idle": "2026-08-11T18:59:14.553420Z",
+     "shell.execute_reply": "2026-08-11T18:59:14.552993Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== Pont Gambit : from-scratch (BCL .NET) vs gambit-enummixed (oracle SOTA) ===\r\n",
+       "Les deux calculent TOUS les equilibres de Nash mixtes par enumeration de supports.\r\n",
+       "\r\n",
+       "--- RPS (3x3) : from-scratch=1 | gambit=1 ---\r\n",
+       "  gambit [0.333,0.333,0.333] [0.333,0.333,0.333] -> dist_vs_scratch=0.000001, exploitabilite=0.000000\r\n",
+       "  >>> CORRESPOND : 1/1 appareilles (dist_max=0.000001, exploit=0 = equilibre de Nash verifie)\r\n",
+       "--- Biased (3x3) : from-scratch=1 | gambit=1 ---\r\n",
+       "  gambit [0.250,0.500,0.250] [0.250,0.500,0.250] -> dist_vs_scratch=0.000000, exploitabilite=0.000000\r\n",
+       "  >>> CORRESPOND : 1/1 appareilles (dist_max=0.000000, exploit=0 = equilibre de Nash verifie)\r\n",
+       "--- PD (2x2) : from-scratch=1 | gambit=1 ---\r\n",
+       "  gambit [0.000,1.000] [0.000,1.000] -> dist_vs_scratch=0.000000, exploitabilite=0.000000\r\n",
+       "  >>> CORRESPOND : 1/1 appareilles (dist_max=0.000000, exploit=0 = equilibre de Nash verifie)\r\n",
+       "--- MP (2x2) : from-scratch=1 | gambit=1 ---\r\n",
+       "  gambit [0.500,0.500] [0.500,0.500] -> dist_vs_scratch=0.000000, exploitabilite=0.000000\r\n",
+       "  >>> CORRESPOND : 1/1 appareilles (dist_max=0.000000, exploit=0 = equilibre de Nash verifie)\r\n",
+       "\r\n",
+       ">>> Bilan : 4/4 equilibres gambit apparaillent le from-scratch (dist < 1e-3). Exploitabilite ~ 0 partout -> ce sont bien des equilibres de Nash.\r\n",
+       "    Le from-scratch (BCL) et l'oracle SOTA Gambit donnent le MEME resultat :\r\n",
+       "    l'algorithme de la cellule precedente est correct, valide par l'outil de reference.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// === Pont Gambit CLI : gambit-enummixed comme oracle SOTA pour les equilibres de Nash mixtes ===\n",
+    "// Usings supplementaires (IO pour File/Path, Diagnostics pour Process) : non declares dans le setup.\n",
+    "using System.IO;\n",
+    "using System.Diagnostics;\n",
+    "// La cellule precedente (BCL .NET seule) implemente le SUPPORT ENUMERATION from-scratch :\n",
+    "//   enumeration de toutes les paires de supports (S1,S2) + Gauss + best-response check.\n",
+    "// Gambit (McKelvey-McLennan-Page, outil de reference GPL-2.0) resout le MEME probleme via CLI.\n",
+    "// On serialise le jeu au format .nfg (cf GameTheory-4-NashEquilibrium-Csharp), on invoque\n",
+    "// gambit-enummixed, puis on COMPARE numeriquement les deux sorties jeu par jeu.\n",
+    "// Axe binding (#10459) : CLI Process.Start pur — AUCUN binding .NET/NuGet, AUCUN P/Invoke,\n",
+    "// AUCUNE IKVM, AUCUN PythonNet. Gambit est un .exe autonome (verdict SOTA-OK une fois execute).\n",
+    "\n",
+    "static string ToNfg(NormalFormGame g, string title)\n",
+    "{\n",
+    "    var sb = new StringBuilder();\n",
+    "    sb.Append($\"NFG 1 R \\\"{title}\\\" {{ \\\"Player 1\\\" \\\"Player 2\\\" }} {{ {g.N1} {g.N2} }}\\n\");\n",
+    "    var nums = new List<string>();\n",
+    "    // Convention .nfg (GameTheory-4) : j2 (colonne) boucle EXTERNE, j1 (ligne) boucle INTERNE,\n",
+    "    // payoffs INTERLEVES [U1[i,j], U2[i,j]] — j1 varie le plus vite.\n",
+    "    for (int j = 0; j < g.N2; j++)\n",
+    "    for (int i = 0; i < g.N1; i++)\n",
+    "    {\n",
+    "        nums.Add(g.U1[i, j].ToString(\"G6\", CultureInfo.InvariantCulture));\n",
+    "        nums.Add(g.U2[i, j].ToString(\"G6\", CultureInfo.InvariantCulture));\n",
+    "    }\n",
+    "    sb.Append(string.Join(\" \", nums));\n",
+    "    return sb.ToString();\n",
+    "}\n",
+    "\n",
+    "static List<(double[] s1, double[] s2)> RunGambitEnumMixed(NormalFormGame g, string title, int decimals = 6)\n",
+    "{\n",
+    "    string exePath = @\"C:\\Program Files (x86)\\Gambit\\gambit-enummixed.exe\";\n",
+    "    if (!File.Exists(exePath))\n",
+    "        throw new FileNotFoundException(\"gambit-enummixed introuvable. Installer Gambit (gambit-project.sourceforge.net).\", exePath);\n",
+    "    string nfgPath = Path.Combine(Path.GetTempPath(), $\"{title}_enummixed.nfg\");\n",
+    "    File.WriteAllText(nfgPath, ToNfg(g, title));\n",
+    "    var psi = new ProcessStartInfo\n",
+    "    {\n",
+    "        FileName = exePath,\n",
+    "        Arguments = $\"-d {decimals} -q \\\"{nfgPath}\\\"\",\n",
+    "        RedirectStandardOutput = true, RedirectStandardError = true,\n",
+    "        UseShellExecute = false, CreateNoWindow = true,\n",
+    "    };\n",
+    "    var p = Process.Start(psi);\n",
+    "    string stdout = p.StandardOutput.ReadToEnd();\n",
+    "    p.WaitForExit(10000);\n",
+    "    var eqs = new List<(double[] s1, double[] s2)>();\n",
+    "    foreach (var line in stdout.Split('\\n', StringSplitOptions.RemoveEmptyEntries))\n",
+    "    {\n",
+    "        var tok = line.Trim().Split(',');\n",
+    "        if (tok.Length < 1 + g.N1 + g.N2 || tok[0] != \"NE\") continue;\n",
+    "        var s1 = new double[g.N1]; var s2 = new double[g.N2];\n",
+    "        for (int i = 0; i < g.N1; i++) s1[i] = double.Parse(tok[1 + i], CultureInfo.InvariantCulture);\n",
+    "        for (int j = 0; j < g.N2; j++) s2[j] = double.Parse(tok[1 + g.N1 + j], CultureInfo.InvariantCulture);\n",
+    "        eqs.Add((s1, s2));\n",
+    "    }\n",
+    "    return eqs;\n",
+    "}\n",
+    "\n",
+    "// Exploitabilite d'un profil (s1,s2) = somme des gains de deviation unilateraux.\n",
+    "//   = [max_a1 E1[a1,s2] - E1[s1,s2]] + [max_a2 E2[s1,a2] - E2[s1,s2]]\n",
+    "// A un equilibre de Nash, EXPLOITABILITE = 0 (aucune deviation profitable : 1er principe).\n",
+    "static double Exploitability(NormalFormGame g, double[] s1, double[] s2)\n",
+    "{\n",
+    "    double br1 = ExpectedVsMixed1(g, 0, s2);\n",
+    "    for (int a1 = 1; a1 < g.N1; a1++) { double e = ExpectedVsMixed1(g, a1, s2); if (e > br1) br1 = e; }\n",
+    "    double e1mix = 0; for (int a1 = 0; a1 < g.N1; a1++) e1mix += s1[a1] * ExpectedVsMixed1(g, a1, s2);\n",
+    "    double br2 = ExpectedVsMixed2(g, 0, s1);\n",
+    "    for (int a2 = 1; a2 < g.N2; a2++) { double e = ExpectedVsMixed2(g, a2, s1); if (e > br2) br2 = e; }\n",
+    "    double e2mix = 0; for (int a2 = 0; a2 < g.N2; a2++) e2mix += s2[a2] * ExpectedVsMixed2(g, a2, s1);\n",
+    "    return (br1 - e1mix) + (br2 - e2mix);\n",
+    "}\n",
+    "\n",
+    "// Distance-sup entre deux profils : max|s1-s1'| + max|s2-s2'|.\n",
+    "static double ProfileDistance(double[] s1, double[] s2, double[] t1, double[] t2)\n",
+    "{\n",
+    "    double d1 = 0, d2 = 0;\n",
+    "    for (int i = 0; i < s1.Length; i++) d1 = Math.Max(d1, Math.Abs(s1[i] - t1[i]));\n",
+    "    for (int j = 0; j < s2.Length; j++) d2 = Math.Max(d2, Math.Abs(s2[j] - t2[j]));\n",
+    "    return d1 + d2;\n",
+    "}\n",
+    "\n",
+    "// --- Comparaison from-scratch vs Gambit sur les 4 jeux canoniques ---\n",
+    "var games = new[] {\n",
+    "    (\"RPS\", RPS),\n",
+    "    (\"Biased\", Biased),\n",
+    "    (\"PD\", PD),\n",
+    "    (\"MP\", MP),\n",
+    "};\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine(\"=== Pont Gambit : from-scratch (BCL .NET) vs gambit-enummixed (oracle SOTA) ===\");\n",
+    "sb.AppendLine(\"Les deux calculent TOUS les equilibres de Nash mixtes par enumeration de supports.\");\n",
+    "sb.AppendLine();\n",
+    "int allMatch = 0, allTotal = 0;\n",
+    "foreach (var (name, game) in games)\n",
+    "{\n",
+    "    var scratch = SupportEnumeration(game);\n",
+    "    var gambit = RunGambitEnumMixed(game, name);\n",
+    "    sb.AppendLine($\"--- {name} ({game.N1}x{game.N2}) : from-scratch={scratch.Count} | gambit={gambit.Count} ---\");\n",
+    "    int matched = 0; double maxDist = 0;\n",
+    "    foreach (var (gs1, gs2) in gambit)\n",
+    "    {\n",
+    "        double best = double.MaxValue;\n",
+    "        foreach (var (sc1, sc2) in scratch)\n",
+    "        {\n",
+    "            double d = ProfileDistance(sc1, sc2, gs1, gs2);\n",
+    "            if (d < best) best = d;\n",
+    "        }\n",
+    "        if (best < 1e-3) matched++;\n",
+    "        maxDist = Math.Max(maxDist, best == double.MaxValue ? 0 : best);\n",
+    "        sb.AppendLine($\"  gambit [{string.Join(\",\", gs1.Select(x => FI(x, \"F3\")))}] \" +\n",
+    "                      $\"[{string.Join(\",\", gs2.Select(x => FI(x, \"F3\")))}] \" +\n",
+    "                      $\"-> dist_vs_scratch={FI(best == double.MaxValue ? -1 : best, \"F6\")}, \" +\n",
+    "                      $\"exploitabilite={FI(Exploitability(game, gs1, gs2), \"F6\")}\");\n",
+    "    }\n",
+    "    bool ok = matched == gambit.Count && matched == scratch.Count;\n",
+    "    sb.AppendLine($\"  >>> {(ok ? \"CORRESPOND\" : \"DIVERGENCE\")} : {matched}/{gambit.Count} appareilles \" +\n",
+    "                  $\"(dist_max={FI(maxDist, \"F6\")}, exploit=0 = equilibre de Nash verifie)\");\n",
+    "    allMatch += matched; allTotal += gambit.Count;\n",
+    "}\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine($\">>> Bilan : {allMatch}/{allTotal} equilibres gambit apparaillent le from-scratch \" +\n",
+    "              $\"(dist < 1e-3). Exploitabilite ~ 0 partout -> ce sont bien des equilibres de Nash.\");\n",
+    "sb.AppendLine(\"    Le from-scratch (BCL) et l'oracle SOTA Gambit donnent le MEME resultat :\");\n",
+    "sb.AppendLine(\"    l'algorithme de la cellule precedente est correct, valide par l'outil de reference.\");\n",
+    "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6233618e",
+   "metadata": {},
+   "source": [
+    "### Pont vers l'outil de reference : Gambit (oracle SOTA)\n",
+    "\n",
+    "La cellule precedente implemente **l'enumeration de supports** \"a la main\" (BCL .NET seule). Pour **valider** cet algorithme, on le confronte a **Gambit** ([gambit-project.sourceforge.net](http://gambit-project.sourceforge.net)), l'outil de reference du calcul d'equilibres de Nash (McKelvey, McLennan, Page), via son binaire `gambit-enummixed`.\n",
+    "\n",
+    "**Mecanique du pont.** Le jeu est serialise au format `.nfg` (deja utilise en tranche 4), puis passe au solveur Gambit qui enumere les supports et resout les memes systemes d'indifference. Le pont est un **pur appel CLI via `Process.Start`** : aucun binding .NET, aucun NuGet, aucune couche d'interoperabilite. Gambit etant un programme autonome sous licence GPL-2.0, le liaison par ligne de commande evite tout probleme de licence/compatibilite.\n",
+    "\n",
+    "**Deux metriques chiffrees guident la comparaison :**\n",
+    "\n",
+    "- **Distance** $\\max_i |\\sigma^{\\text{BCL}}_i - \\sigma^{\\text{Gambit}}_i|$ entre profils appareilles : $< 10^{-3}$ confirme que les deux methodes convergent vers le meme equilibre.\n",
+    "- **Exploitabilite** $\\max_{a_1} E_1[a_1,\\sigma_2] - E_1[\\sigma_1,\\sigma_2]$ (symetrisee pour le joueur 2) : **nulle a un equilibre de Nash** par construction (aucune deviation unilaterale profitable). C'est un test *independant* de Gambit : il ne fait que reformuler le **premier principe** (best-response).\n",
+    "\n",
+    "**Pourquoi ce pont n'est pas superflu (non-degenerescence).** Les 4 jeux canoniques couvrent les cas ou l'equilibre mixte est **reellement mixte** : RPS (uniformite par symetrie), RPS biaise (equilibre **asymetrique** $0{,}25/0{,}50/0{,}25$), Matching Pennies (melange $0{,}5/0{,}5$) et le Dilemme du Prisonnier (equilibre **pur** retrouve en support de taille 1). L'enumeration de supports est exactement l'outil qui discrimine ces structures — un simple `argmax` n'y suffirait pas."
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "gt2b19",
    "metadata": {
@@ -1032,14 +1212,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "gt2b20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T03:49:23.733387Z",
-     "iopub.status.busy": "2026-07-06T03:49:23.732832Z",
-     "iopub.status.idle": "2026-07-06T03:49:23.795814Z",
-     "shell.execute_reply": "2026-07-06T03:49:23.795687Z"
+     "iopub.execute_input": "2026-08-11T18:59:14.556151Z",
+     "iopub.status.busy": "2026-08-11T18:59:14.555610Z",
+     "iopub.status.idle": "2026-08-11T18:59:14.680003Z",
+     "shell.execute_reply": "2026-08-11T18:59:14.679145Z"
     },
     "papermill": {
      "duration": 0.069095,
@@ -1091,14 +1271,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "gt2b22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T03:49:23.810341Z",
-     "iopub.status.busy": "2026-07-06T03:49:23.810166Z",
-     "iopub.status.idle": "2026-07-06T03:49:23.856182Z",
-     "shell.execute_reply": "2026-07-06T03:49:23.856052Z"
+     "iopub.execute_input": "2026-08-11T18:59:14.682616Z",
+     "iopub.status.busy": "2026-08-11T18:59:14.682131Z",
+     "iopub.status.idle": "2026-08-11T18:59:14.747150Z",
+     "shell.execute_reply": "2026-08-11T18:59:14.746363Z"
     },
     "papermill": {
      "duration": 0.049912,
@@ -1149,14 +1329,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "gt2b24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T03:49:23.868182Z",
-     "iopub.status.busy": "2026-07-06T03:49:23.868014Z",
-     "iopub.status.idle": "2026-07-06T03:49:23.907733Z",
-     "shell.execute_reply": "2026-07-06T03:49:23.907612Z"
+     "iopub.execute_input": "2026-08-11T18:59:14.749776Z",
+     "iopub.status.busy": "2026-08-11T18:59:14.749172Z",
+     "iopub.status.idle": "2026-08-11T18:59:14.815233Z",
+     "shell.execute_reply": "2026-08-11T18:59:14.814831Z"
     },
     "papermill": {
      "duration": 0.043195,
@@ -1237,23 +1417,23 @@
   }
  ],
  "metadata": {
- "cost":{
-   "api_usd_est": 0.0,
+  "cost": {
    "api_provider": "none",
-   "qcc_tokens_est": 0,
+   "api_usd_est": 0.0,
    "cpu_min": 1,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
    "external_account": "none",
    "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-08-03",
+   "network": false,
+   "notes": "Forme normale C# — matrices de gains, strategies pures/mixtes. Algorithme deterministe (enumerate best responses), CPU pur.",
+   "qcc_tokens_est": 0,
    "reduced_pedagogical": false,
    "reproducibility": "HIGH",
-   "metadata_written": "2026-08-03",
    "validator": "manual",
-   "notes": "Forme normale C# — matrices de gains, strategies pures/mixtes. Algorithme deterministe (enumerate best responses), CPU pur."
+   "vram_gb": 0,
+   "vram_tier": "NONE"
   },
   "kernelspec": {
    "display_name": ".NET (C#)",

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform-part-2-support-enumeration.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform-part-2-support-enumeration.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Part2-Python.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp-Part2.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Pont SOTA rajoute cote C# (mandat #10382) : gambit-enummixed via CLI Process.Start sur les 4 jeux canoniques (RPS, RPS biaise, Prisonnier, Matching Pennies). Axes binding (#10459) : CLI pur (axe 3) -- AUCUN binding .NET/NuGet (axe 1), AUCUN P/Invoke (axe 2), AUCUNE IKVM (axe 4), AUCUN PythonNet (axe 5). nashpy (Python) et Gambit (McKelvey-McLennan-Page, CLI autonome GPL-2.0) sont deux libs differentes (axe 6) couvrant le meme role (support enumeration pour NE mixtes) -> pont desormais SYMETRIQUE. Comparaison numerique (cellule 24 du C#) : 4/4 equilibres gambit apparaillent le from-scratch BCL (dist < 1e-3) + exploitabilite = 0 partout (premier principe verifie). From-scratch BCL .NET conserve : le pont est EN PLUS jamais A LA PLACE."
   audits:
     - date: "2026-08-07"
       by: myia-po-2025:CoursIA
@@ -23,8 +25,16 @@
       csharp_sha: 0803644967201646eb00beb62327da4059e9bb29
       content_python_sha: b60792d2c1b041113ef870cf04c6eb17c1e31230115354571d25c7007a5cb2a9
       content_csharp_sha: f3431f222a16b4b4161785d0cf953b79f2670cb7bd27d8d821b56760ff760952
+    - date: "2026-08-11"
+      by: myia-po-2025:CoursIA
+      python_sha: 13c27d9afd12ca9f9f5dc96c00aa761d8d5bb87c
+      csharp_sha: 10b8e4e17ac1cc612830d0c1f188cb9b8531bdea
+      content_python_sha: b60792d2c1b041113ef870cf04c6eb17c1e31230115354571d25c7007a5cb2a9
+      content_csharp_sha: 01f83eddcb3821b0dae4899b90d4b7545c70d8387afb9c7414f88e1d9d5c8ea9
+      note: "Pont SOTA Gambit rajoute cote C# (cellule 24) : gambit-enummixed via CLI Process.Start, 4/4 jeux CORRESPOND (dist < 1e-3, exploitabilite = 0). bridge_verdict SOTA-OK, pont symetrique avec nashpy cote Python. From-scratch BCL conserve."
+      bridge_verdict: SOTA-OK
   known_differences:
     - "Socle pedagogique commun : support enumeration des equilibres de Nash mixtes NxN (indifference + Gauss pivot partiel + best-response), sur 4 jeux canoniques (RPS, RPS biaise, Prisonnier, Matching Pennies) + 3 exercices (BoS, RPSLS, complexite)."
-    - "Idiomes framework : Python = `numpy` pur pour le from-scratch (meme algorithme que le C#), PLUS `nashpy` comme verification independante (pont SOTA, cell 8). C# = pur BCL .NET (System.*, pas de lib tiers), nashpy n'existe pas en .NET."
-    - "Pont de verification asymetrique : le twin Python dispose de `nashpy` (lib de reference) comme juge de paix — le from-scratch est verifie contre le vrai outil SOTA (verdict SOTA-OK #3801). Le twin C# n'a pas d'equivalent .NET, sa verification est la parite algorithmique avec le Python."
+    - "Idiomes framework : Python = `numpy` pur pour le from-scratch (meme algorithme que le C#), PLUS `nashpy` comme verification independante (pont SOTA, cell 8). C# = pur BCL .NET (System.*, pas de lib tiers) pour le from-scratch, PLUS `gambit-enummixed` via CLI Process.Start comme pont SOTA (cell 24). nashpy n'existe pas en .NET, mais Gambit (McKelvey-McLennan-Page, GPL-2.0) est l'outil de reference canonique et couvre le meme role (support enumeration pour NE mixtes)."
+    - "Pont de verification SYMETRIQUE : le twin Python dispose de `nashpy`, le twin C# dispose de `gambit-enummixed` (CLI) -- les deux from-scratch sont verifies contre leur outil SOTA respectif (verdict SOTA-OK #3801 des deux cotes). Correspondance 4/4 sur les jeux canoniques confirmee firsthand dans les deux twins."
     - "Resultats numeriquement identiques : RPS uniforme (1/3,1/3,1/3), RPS biaise Paper=0.500, Prisonnier (Defect,Defect), Matching Pennies (0.5,0.5) — confirmes firsthand dans les deux twins."


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2025:CoursIA — prev: MED/lean (#10469)

Ajoute un pont SOTA `gambit-enummixed` au twin C# de GameTheory-2-NormalForm-Part2, qui était jusqu'ici **le seul twin GameTheory sans équivalent .NET** pour valider son support enumeration from-scratch. Steered by ai-01 (option b, msg-xtu2kj, pour éviter la collision avec #10464 po-2023 sur GT-17). See #10459, See #10382.

## Le défaut mesuré firsthand

Le twin yaml portait (lignes `known_differences`) **deux affirmations fausses** à deux paragraphes d'écart :

- **Idiomes framework** : « C# = pur BCL .NET (System.*, pas de lib tiers), **nashpy n'existe pas en .NET** » — muet sur tout équivalent SOTA côté C#.
- **Pont de vérification** : « Pont de vérification **asymétrique** : le twin Python dispose de `nashpy`... **Le twin C# n'a pas d'équivalent .NET**, sa verification est la parité algorithmique avec le Python. »

C'est le défaut que `gambit-enummixed` corrige : il **est** cet équivalent (énumération de supports pour NE mixtes — exactement l'algorithme du notebook). Le pont devient **symétrique**.

## La cellule ajoutée (additive, from-scratch préservé)

Cellule 24 (code) + 25 (markdown) insérées après les 4 jeux canoniques, avant les exercices. **0 ligne du from-scratch supprimée** (C.1/C.3) — le pont est EN PLUS, jamais A LA PLACE (mandat #10382).

1. `ToNfg(NormalFormGame, title)` — sérialise le jeu au format `.nfg` plat (convention GameTheory-4 : j2 boucle externe, j1 boucle interne, payoffs intercalés `[U1[i,j], U2[i,j]]`).
2. `RunGambitEnumMixed(g, title)` — invoque `gambit-enummixed.exe` via `Process.Start`, parse les lignes `NE,p1_1,...,p2_n`.
3. `Exploitability(g, s1, s2)` — métrique **indépendante de Gambit** : `[max_a1 E1[a1,s2] − E1[s1,s2]] + [max_a2 E2[s1,a2] − E2[s1,s2]]`. Nulle à un équilibre de Nash (premier principe).
4. `ProfileDistance` — `max|σ_BCL − σ_Gambit|` pour apparier les équilibres.

## Axes binding (#10459) — les 6 nommément

| Axe | Présent ? |
|-----|-----------|
| 1. Binding .NET/NuGet | **NON** — AUCUN NuGet |
| 2. P/Invoke | **NON** |
| 3. CLI Process.Start | **OUI** — axe utilisé |
| 4. IKVM | **NON** |
| 5. PythonNet | **NON** |
| 6. Lib différente | **OUI** — `gambit-enummixed` (McKelvey-McLennan-Page, GPL-2.0) ≠ `nashpy`, même rôle |

CLI pur = évite tout problème de licence GPL/compatibilité (Gambit est un `.exe` autonome).

## Résultat d'exécution (firsthand, re-exécuté .net-csharp)

```
=== Pont Gambit : from-scratch (BCL .NET) vs gambit-enummixed (oracle SOTA) ===
--- RPS (3x3) : from-scratch=1 | gambit=1 ---
  gambit [0.333,0.333,0.333] [0.333,0.333,0.333] -> dist=0.000001, exploitabilite=0.000000
  >>> CORRESPOND
--- Biased (3x3) : from-scratch=1 | gambit=1 ---
  gambit [0.250,0.500,0.250] [0.250,0.500,0.250] -> dist=0.000000, exploitabilite=0.000000
  >>> CORRESPOND
--- PD (2x2) : from-scratch=1 | gambit=1 ---
  gambit [0.000,1.000] [0.000,1.000] -> dist=0.000000, exploitabilite=0.000000   (Defect pur)
  >>> CORRESPOND
--- MP (2x2) : from-scratch=1 | gambit=1 ---
  gambit [0.500,0.500] [0.500,0.500] -> dist=0.000000, exploitabilite=0.000000
  >>> CORRESPOND

>>> Bilan : 4/4 equilibres gambit apparaillent le from-scratch (dist < 1e-3).
    Exploitabilite ~ 0 partout -> ce sont bien des equilibres de Nash.
```

**4/4 CORRESPOND**, symétrique avec le pont `nashpy` côté Python (cellule 8). La métrique d'exploitabilité (indépendante de Gambit) confirme qu'il s'agit bien d'équilibres de Nash — pas une simple correspondance numérique.

## Preuves (anti-régression)

- **Diff** : `+275/−85` sur 2 fichiers (notebook + yaml). **0 ligne de code from-scratch** (`SupportEnumeration`/`NormalFormGame`/`ExpectedVsMixed`) touchée — seulement 2 cellules ajoutées (code + markdown).
- **C.2 (re-exécution)** : notebook re-exécuté via `nbconvert --execute` kernel `.net-csharp`, `execution_count` non-null sur les 14 cellules code. `strip_probe_banner.py` appliqué (9 lignes banner retirées).
- **C.3 (scope)** : cellule[1] (setup, non touchée) restaurée à HEAD (port HTTP non-déterministe). Aucune cellule source modifiée hors mes 2 nouvelles.
- **Leak scan** : 0 chemin machine dans les outputs.
- **Twin yaml** : `bridge_verdict: SOTA-OK` + `bridge_verdict_reason` (6 axes), `known_differences` réécrit (lignes FALSE remplacées), SHA rebaselined via `check_twin_parity.py --update` (10b8e4e17).

## Pourquoi DEEP/notebook-dotnet (G-VAR-1)

Pont SOTA nouvellement branché (verdict SOTA-OK) + résultat falsifiable (4/4 CORRESPOND + exploitabilité=0) + re-exécution réelle. Litmus DEEP : `main` contient désormais une capacité (validation indépendante du support enumeration via oracle Gambit) qui n'existait pas. Rotation depuis MED/lean (#10469 Hashlife) — genre distinct.

See #10459 (paths-scoped : GT-2-NormalForm-Csharp-Part2.ipynb + le yaml), See #10382.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
