### PR TITLE
fix(timing,#10445): --json/--check no longer silently drop explicit paths

### DIFF
--- a/scripts/notebook_tools/check_machine_dep_timing.py
+++ b/scripts/notebook_tools/check_machine_dep_timing.py
@@ -451,13 +451,24 @@ def _repo_root() -> Path:
 
 
 def _collect_targets(args: argparse.Namespace) -> list[Path]:
-    """Resout la liste des notebooks a scanner depuis la CLI."""
+    """Resout la liste des notebooks a scanner depuis la CLI.
+
+    Precedence (fix #10445 partie b) : des ``paths`` explicites sont TOUJOURS
+    honors, meme quand ``--json``/``--check`` sont passes. Avant, ``--json``
+    impliquait ``--all`` en silence (``if args.all or args.json or args.check``
+    en premiere branche) : un appel ``--json chemin.ipynb`` scannait les 1015
+    notebooks du depot et jetait ``chemin.ipynb`` sans un mot -- produisant des
+    mesures fausses chez tous les appelants (incident merge-gate #10442 : 215
+    timings du repo attribues a 1 notebook GameTheory qui en contribuait 0).
+    Un outil qui jette un argument en silence est un bug de correctness, pas
+    un defaut d'ergonomie ; on ne l'ignore donc jamais sans prevenir.
+    ``--all`` explicite force l'inventaire complet (sa semantique) meme si des
+    paths sont aussi donnes -- cas contradictoire qui emet un avertissement
+    stderr pour ne pas jeter ``paths`` en silence.
+    """
     root = _repo_root()
-    if args.all or args.json or args.check:
-        # Cible canonique : notebooks pedagogiques. Les READMEs et `assets/`
-        # sont exclus -- le scope de #10158 est uniquement les ``.ipynb``.
-        candidates = sorted(root.glob("MyIA.AI.Notebooks/**/*.ipynb"))
-    elif args.paths:
+    if args.paths and not args.all:
+        # paths explicites = scan cible, quel que soit --json/--check.
         candidates = []
         for p in args.paths:
             pp = Path(p)
@@ -465,6 +476,18 @@ def _collect_targets(args: argparse.Namespace) -> list[Path]:
                 candidates.append(pp)
             elif pp.is_dir():
                 candidates.extend(sorted(pp.rglob("*.ipynb")))
+    elif args.all or args.json or args.check:
+        # Cible canonique : notebooks pedagogiques. Les READMEs et `assets/`
+        # sont exclus -- le scope de #10158 est uniquement les ``.ipynb``.
+        if args.all and args.paths:
+            # --all force l'inventaire mais des paths etaient donnes : on ne
+            # les jette pas en silence (regle : ne jamais ignorer un argument).
+            print(
+                "Avertissement : --all force le scan repo-entier ; "
+                "les paths fournis sont ignores.",
+                file=sys.stderr,
+            )
+        candidates = sorted(root.glob("MyIA.AI.Notebooks/**/*.ipynb"))
     else:
         return []
     # Filtre sortie : cibles _output.ipynb (artefacts transitoires) et

--- a/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
+++ b/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from check_machine_dep_timing import (  # noqa: E402
     _categorize,
+    _collect_targets,
     _scan_notebook,
     _is_range_bound,
     _is_detached_approximate,
@@ -1016,6 +1017,63 @@ def test_plan_cost_regex_does_not_overreach_real_wallclock() -> None:
     # Pas d'arithmetique de cout -> _categorize ne bascule pas en domain_quantity
     # via la branche plan-cost (WALLCLOCK_KEYWORDS 'execution' -> wallclock).
     assert _categorize(line, "2.4 s") == CATEGORY_WALLCLOCK
+
+
+# --------------------------------------------------------------------------- #
+#  CLI correctness #10445 (partie b) : --json/--check ne doivent pas jeter paths
+# --------------------------------------------------------------------------- #
+def _write_nb(path: Path, cells: list[dict] | None = None) -> Path:
+    """Ecrit un notebook JSON valide a un chemin precis (pour _collect_targets)."""
+    nb = {"cells": cells or [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(nb), encoding="utf-8")
+    return path
+
+
+def test_collect_targets_honors_paths_with_json(tmp_path: Path, monkeypatch) -> None:
+    """``--json chemin.ipynb`` doit scanner le chemin, pas le repo entier (#10445 b).
+
+    Avant le fix, ``args.json`` dans la premiere branche de ``_collect_targets``
+    impliquait ``--all`` : le chemin explicite etait jete, le glob repo-entier
+    s'executait. Incident merge-gate #10442 : 215 timings repo attribues a 1
+    notebook qui en contribuait 0. Ce test epingle qu'un ``paths`` explicite
+    prime sur ``--json``, ET qu'un leurre sous le glob ``MyIA.AI.Notebooks/``
+    n'est PAS scanne.
+    """
+    import argparse
+
+    import check_machine_dep_timing as m
+
+    # Cible explicite (hors MyIA.AI.Notebooks/ -- pas sous le glob) + leurre
+    # sous le glob : avant le fix, le glob retournait [decoy] et ignorait target.
+    target = _write_nb(tmp_path / "nb_target.ipynb")
+    _write_nb(tmp_path / "MyIA.AI.Notebooks" / "famille" / "decoy.ipynb")
+    monkeypatch.setattr(m, "_repo_root", lambda: tmp_path)
+
+    args = argparse.Namespace(paths=[target], all=False, json=True, check=False)
+    out = _collect_targets(args)
+    # Un seul cible (target), le leurre sous le glob est exclu.
+    assert out == [target]
+
+
+def test_collect_targets_all_with_paths_warns(tmp_path: Path, monkeypatch, capsys) -> None:
+    """``--all`` + paths force l'inventaire mais ne jette pas paths en silence (#10445 b).
+
+    ``--all`` est le seul cas ou paths est legitimement ignore (semantique :
+    forcer le scan complet). La regle « ne jamais jeter un argument en silence »
+    exige un avertissement stderr explicite.
+    """
+    import argparse
+
+    import check_machine_dep_timing as m
+
+    target = _write_nb(tmp_path / "nb_target.ipynb")
+    monkeypatch.setattr(m, "_repo_root", lambda: tmp_path)
+
+    args = argparse.Namespace(paths=[target], all=True, json=False, check=False)
+    _collect_targets(args)  # glob vide sous tmp_path -> [] mais le warn est emis
+    err = capsys.readouterr().err
+    assert "paths" in err.lower() and "ignore" in err.lower()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #10480

# fix(timing,#10445): --json/--check no longer silently drop explicit paths

## Quoi

`_collect_targets` (`check_machine_dep_timing.py`) mettait `args.all or args.json or args.check` dans sa première branche. Un appel `--json chemin.ipynb` scannait donc les 1015 notebooks du dépôt et jetait `chemin.ipynb` sans un mot. Un outil qui jette un argument en silence est un **bug de correctness**, pas un défaut d'ergonomie : le merge-gate de #10442 a attribué les 215 timings machine-dep du repo à un seul notebook GameTheory qui en contribuait 0, parce qu'un chemin a été passé, un nombre propre est revenu, et le nombre mesurait autre chose (issue #10445, diagnostiquée firsthand pendant ce gate).

## Comment (correctness, pas advisory noise)

Partie **(b)** de #10445 uniquement — les parties (a) [label = delta signé] et (c) [jauge d'inventaire hors PRs] sont des décisions de design advisory laissées au coordinateur ou à un grain ultérieur. Ce PR adresse le défaut de CLI qui a causé la mesure fausse.

- `paths` explicites priment **toujours**, même avec `--json`/`--check` (branche `if args.paths and not args.all`).
- `--all` explicite force l'inventaire complet (sa sémantique) inchangé.
- Le seul cas où `paths` est légitimement ignoré (`--all` + paths, cas contradictoire) émet un **avertissement stderr** — règle : ne jamais jeter un argument en silence.

## Preuve

48/48 tests passent (46 existants + 2 nouveaux). Les 2 tests sont **pinés** :

- `test_collect_targets_honors_paths_with_json` — crée `target.ipynb` (hors glob) + `decoy.ipynb` (sous `MyIA.AI.Notebooks/`), passe `paths=[target] --json`, vérifie `_collect_targets == [target]`. **Avant le fix** : l'ancienne branche `json→glob` retournait `[decoy]` (vérifié par simulation) → l'assertion aurait échoué. **Après** : retourne `[target]`.
- `test_collect_targets_all_with_paths_warns` — `--all` + paths force le glob MAIS émet le warning stderr (`paths` + `ignor` dans stderr).

Simulation de la régression (sanity du pin) :
```
AVANT fix (branche json->glob): [decoy.ipynb]  -> assert ==[target] aurait ECHOUE
APRES fix (_collect_targets):   [target.ipynb]  -> assert ==[target] PASSE
```

## Non-regression

Le mode inventaire par défaut (`--json`/`--check` seuls, sans paths) est **inchangé** — il scanne toujours le repo entier. Seul le cas `paths + --json/--check` change de comportement (scan ciblé au lieu d'inventaire silencieux). `--all` force l'inventaire comme avant.

See #10445 · See #10442 · See #9434 · See #10158

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Requalification de tier par le merge-gate (ai-01)

Tag d'origine : `LIGHT/tooling`. **Requalifie en `MED/tooling`**, dans le corps et non en commentaire (un tier requalifie ailleurs que dans le corps n'est pas lu par `variation_light_cap.py`, qui continuerait a le compter LIGHT).

Motif : le litmus LIGHT est *« pourrais-je en generer une douzaine en scannant l'instance suivante ? »*. Non — c'est **un** defaut de correctness nomme, avec sa cause racine mesuree (le merge-gate de #10442 a attribue 215 timings machine-dep a un notebook qui en contribuait 0) et **deux tests pines** dont l'un simule la regression avant fix. Le tier MED demande « etend de la substance existante avec verification, et change quelque chose » : les deux sont satisfaits. L'auteur s'est sous-tague ; l'honnetete du tag va dans les deux sens.

Consequence : `tooling` reste de classe **META**, donc cette PR ne tient pas le plancher G-VAR-1 de sa lane, quel que soit son tier. Ce n'est pas un reproche a la lane — c'est une dette de provisionnement a moi, honoree dans ce cycle.
