### PR TITLE
feat(posttraining,#10289): re-cible PT-05 RLVR sur Qwen3.5-0.8B + vraie eval (sort du toy-env)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_05_rlvr_verifiable_rewards.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_05_rlvr_verifiable_rewards.ipynb
@@ -97,11 +97,19 @@
    "id": "73d8136b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T02:51:47.001331Z",
-     "iopub.status.busy": "2026-05-29T02:51:47.001197Z",
-     "iopub.status.idle": "2026-05-29T02:51:47.005743Z",
-     "shell.execute_reply": "2026-05-29T02:51:47.004961Z"
-    }
+     "iopub.execute_input": "2026-08-11T19:28:37.653503Z",
+     "iopub.status.busy": "2026-08-11T19:28:37.653263Z",
+     "iopub.status.idle": "2026-08-11T19:28:40.320052Z",
+     "shell.execute_reply": "2026-08-11T19:28:40.319215Z"
+    },
+    "papermill": {
+     "duration": 2.672088,
+     "end_time": "2026-08-11T19:28:40.320996+00:00",
+     "exception": false,
+     "start_time": "2026-08-11T19:28:37.648908+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -109,9 +117,16 @@
      "output_type": "stream",
      "text": [
       "Python : 3.13.7 (tags/v3.13.7:bcee1c3, Aug 14 2025, 14:15:11) [MSC v.1944 64 bit (AMD64)]\n",
-      "Plateforme : Windows-11-10.0.26200-SP0\n",
+      "Plateforme : Windows-11-10.0.26200-SP0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CUDA disponible : False\n",
       "\n",
-      "LOAD_MODEL_AND_TRAIN = False\n",
+      "LOAD_MODEL_AND_TRAIN = False | SMOKE_TEST = False\n",
       "(Mode CPU-safe : generation + training seront skippees)\n"
      ]
     }
@@ -123,10 +138,23 @@
     "print(f\"Python : {sys.version}\")\n",
     "print(f\"Plateforme : {platform.platform()}\")\n",
     "\n",
+    "# Detection CUDA (correction : CUDA_AVAILABLE etait reference en cell 17 sans etre defini)\n",
+    "try:\n",
+    "    import torch\n",
+    "    CUDA_AVAILABLE = torch.cuda.is_available()\n",
+    "except ImportError:\n",
+    "    CUDA_AVAILABLE = False\n",
+    "print(f\"CUDA disponible : {CUDA_AVAILABLE}\")\n",
+    "\n",
+    "# Mode smoke : 2 steps pour valider la plomberie en < 2 min (ai-01 lance le run complet sur GPU 2)\n",
+    "SMOKE_TEST = False\n",
+    "# Par defaut on reste CPU-safe ; passer LOAD_MODEL_AND_TRAIN=True (et SMOKE_TEST=True pour un run rapide)\n",
     "LOAD_MODEL_AND_TRAIN = False\n",
-    "print(f\"\\nLOAD_MODEL_AND_TRAIN = {LOAD_MODEL_AND_TRAIN}\")\n",
+    "print(f\"\\nLOAD_MODEL_AND_TRAIN = {LOAD_MODEL_AND_TRAIN} | SMOKE_TEST = {SMOKE_TEST}\")\n",
     "if not LOAD_MODEL_AND_TRAIN:\n",
-    "    print(\"(Mode CPU-safe : generation + training seront skippees)\")"
+    "    print(\"(Mode CPU-safe : generation + training seront skippees)\")\n",
+    "elif SMOKE_TEST:\n",
+    "    print(\"(Mode SMOKE : 2 steps, validation plomberie uniquement)\")\n"
    ]
   },
   {
@@ -529,15 +557,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "8d06bb25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T02:51:48.645140Z",
-     "iopub.status.busy": "2026-05-29T02:51:48.645012Z",
-     "iopub.status.idle": "2026-05-29T02:51:48.649851Z",
-     "shell.execute_reply": "2026-05-29T02:51:48.649249Z"
-    }
+     "iopub.execute_input": "2026-08-11T19:28:45.469959Z",
+     "iopub.status.busy": "2026-08-11T19:28:45.469185Z",
+     "iopub.status.idle": "2026-08-11T19:28:45.483155Z",
+     "shell.execute_reply": "2026-08-11T19:28:45.482143Z"
+    },
+    "papermill": {
+     "duration": 0.019817,
+     "end_time": "2026-08-11T19:28:45.483818+00:00",
+     "exception": false,
+     "start_time": "2026-08-11T19:28:45.464001+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -548,25 +584,30 @@
       "\n",
       "Pour executer :\n",
       "  1. LOAD_MODEL_AND_TRAIN = True\n",
-      "  2. GPU avec >= 6 Go VRAM disponible\n",
+      "  2. GPU avec >= 6 Go VRAM disponible (pic mesure Qwen3.5-0.8B QLoRA 4-bit ~ 2,5 Go)\n",
       "  3. Temps estime : ~20-40 min (10 problems x G=4, 3 epochs)\n",
       "\n",
-      "Resultats attendus (RTX 3070, 10 problems, 3 epochs) :\n",
-      "  - Accuracy initiale : ~10-30% (modele 0.5B sans SFT math)\n",
-      "  - Accuracy finale : ~40-60% (amelioration GRPO)\n",
+      "Resultats attendus (Qwen3.5-0.8B, 10 problems, 3 epochs) :\n",
+      "  - Accuracy initiale : ~20-40% (modele 0.8B plus capable que le 0.5B supersede)\n",
+      "  - Accuracy finale : ~50-70% (amelioration GRPO, signal RLVR plus exploitable)\n",
       "  - Phenomene observable : emergence de chain-of-thought spontane\n",
-      "    (le modele commence a decomposer les calculs sans etre entraine pour ca)\n"
+      "    (le modele commence a decomposer les calculs sans etre entraine pour ca)\n",
+      "\n",
+      "NOTE : les valeurs ci-dessus sont des attentes raisonnables, pas des mesures.\n",
+      "       Les vraies mesures sont produites par la cell d'evaluation (generation + verifier SymPy).\n"
      ]
     }
    ],
    "source": [
     "if LOAD_MODEL_AND_TRAIN and CUDA_AVAILABLE:\n",
-    "    from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig\n",
+    "    from transformers import AutoModelForImageTextToText, AutoTokenizer, BitsAndBytesConfig\n",
     "    from trl import GRPOTrainer, GRPOConfig\n",
     "    from peft import LoraConfig, TaskType, get_peft_model\n",
     "    import torch\n",
     "\n",
-    "    MODEL_NAME = \"Qwen/Qwen2.5-0.5B-Instruct\"\n",
+    "    # Qwen3.5-0.8B : SOTA cible (remplace Qwen2.5-0.5B-Instruct, supersede).\n",
+    "    # Modele VL charge via AutoModelForImageTextToText (gabarit PT-03 valide), utilise ici en chemin text-only.\n",
+    "    MODEL_NAME = \"Qwen/Qwen3.5-0.8B\"\n",
     "\n",
     "    # Quantization 4-bit\n",
     "    bnb_config = BitsAndBytesConfig(\n",
@@ -589,8 +630,8 @@
     "        ],\n",
     "    )\n",
     "\n",
-    "    print(\"Chargement du modele (4-bit)...\")\n",
-    "    model = AutoModelForCausalLM.from_pretrained(\n",
+    "    print(\"Chargement du modele Qwen3.5-0.8B (4-bit)...\")\n",
+    "    model = AutoModelForImageTextToText.from_pretrained(\n",
     "        MODEL_NAME,\n",
     "        quantization_config=bnb_config,\n",
     "        device_map=\"auto\",\n",
@@ -601,8 +642,10 @@
     "    model = get_peft_model(model, lora_config)\n",
     "    model.print_trainable_parameters()\n",
     "\n",
+    "    # Mode smoke : on plafonne a 2 steps (validation plomberie), sans toucher au run complet\n",
+    "    smoke_overrides = {\"max_steps\": 2} if SMOKE_TEST else {}\n",
     "    print(\"Configuration GRPOConfig RLVR...\")\n",
-    "    rlvr_config = GRPOConfig(**RLVR_CONFIG_DICT)\n",
+    "    rlvr_config = GRPOConfig(**{**RLVR_CONFIG_DICT, **smoke_overrides})\n",
     "\n",
     "    print(\"Construction GRPOTrainer RLVR...\")\n",
     "    trainer = GRPOTrainer(\n",
@@ -624,14 +667,17 @@
     "    print()\n",
     "    print(\"Pour executer :\")\n",
     "    print(\"  1. LOAD_MODEL_AND_TRAIN = True\")\n",
-    "    print(\"  2. GPU avec >= 6 Go VRAM disponible\")\n",
+    "    print(\"  2. GPU avec >= 6 Go VRAM disponible (pic mesure Qwen3.5-0.8B QLoRA 4-bit ~ 2,5 Go)\")\n",
     "    print(\"  3. Temps estime : ~20-40 min (10 problems x G=4, 3 epochs)\")\n",
     "    print()\n",
-    "    print(\"Resultats attendus (RTX 3070, 10 problems, 3 epochs) :\")\n",
-    "    print(\"  - Accuracy initiale : ~10-30% (modele 0.5B sans SFT math)\")\n",
-    "    print(\"  - Accuracy finale : ~40-60% (amelioration GRPO)\")\n",
+    "    print(\"Resultats attendus (Qwen3.5-0.8B, 10 problems, 3 epochs) :\")\n",
+    "    print(\"  - Accuracy initiale : ~20-40% (modele 0.8B plus capable que le 0.5B supersede)\")\n",
+    "    print(\"  - Accuracy finale : ~50-70% (amelioration GRPO, signal RLVR plus exploitable)\")\n",
     "    print(\"  - Phenomene observable : emergence de chain-of-thought spontane\")\n",
-    "    print(\"    (le modele commence a decomposer les calculs sans etre entraine pour ca)\")"
+    "    print(\"    (le modele commence a decomposer les calculs sans etre entraine pour ca)\")\n",
+    "    print()\n",
+    "    print(\"NOTE : les valeurs ci-dessus sont des attentes raisonnables, pas des mesures.\")\n",
+    "    print(\"       Les vraies mesures sont produites par la cell d'evaluation (generation + verifier SymPy).\")\n"
    ]
   },
   {
@@ -669,78 +715,95 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "475196a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T02:51:48.651316Z",
-     "iopub.status.busy": "2026-05-29T02:51:48.651174Z",
-     "iopub.status.idle": "2026-05-29T02:51:48.655037Z",
-     "shell.execute_reply": "2026-05-29T02:51:48.654503Z"
-    }
+     "iopub.execute_input": "2026-08-11T19:28:45.501854Z",
+     "iopub.status.busy": "2026-08-11T19:28:45.501437Z",
+     "iopub.status.idle": "2026-08-11T19:28:45.511338Z",
+     "shell.execute_reply": "2026-08-11T19:28:45.510312Z"
+    },
+    "papermill": {
+     "duration": 0.016638,
+     "end_time": "2026-08-11T19:28:45.512243+00:00",
+     "exception": false,
+     "start_time": "2026-08-11T19:28:45.495605+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Emergence du raisonnement avec RLVR (resultats attendus)\n",
-      "============================================================\n",
-      "Probleme : A shirt costs $80. 25% discount, then 10% tax. Final price?\n",
-      "Ground truth : $66.00\n",
+      "Skip : evaluation reelle non executee.\n",
+      "Pour mesurer l'accuracy reelle (et non une simulation), executer avec :\n",
+      "  LOAD_MODEL_AND_TRAIN = True sur GPU (cell precedente), puis cette cell genere + verifie.\n",
       "\n",
-      "--- Avant RLVR (modele de base Qwen2.5-0.5B) ---\n",
-      "Completion 1 : $66\n",
-      "Completion 2 : $56\n",
-      "Completion 3 : The final price is $66.00.\n",
-      "Completion 4 : $70\n",
-      "Accuracy : 2/4 = 50% (correct par coincidence, pas de raisonnement)\n",
-      "\n",
-      "--- Apres RLVR (3 epochs, reward verifiable) ---\n",
-      "Completion 1 : The discount is 25% of $80 = $20. So the price becomes $60.\n",
-      "                Then 10% tax on $60 = $6. Final price = $60 + $6 = $66.00.\n",
-      "Completion 2 : Step 1: 80 * 0.75 = 60 (after 25% off).\n",
-      "                Step 2: 60 * 1.10 = 66. The answer is $66.00.\n",
-      "Completion 3 : $80 - 25% = $60. $60 + 10% = $66.00.\n",
-      "Completion 4 : Let me calculate: 80*(1-0.25)*(1+0.10) = 80*0.75*1.10 = $66.\n",
-      "Accuracy : 4/4 = 100% (tous avec raisonnement spontane)\n",
-      "\n",
-      "Observation cle : le modele a APPRIS a decomposer les calculs\n",
-      "sans JAMAIS avoir ete entraine avec des exemples de raisonnement.\n",
-      "C'est le phenomene d'emergence qui a rendu Deepseek-R1 celebre.\n"
+      "NOTE : cette cell n'invente PLUS de completions. Les resultats ne sont produits\n",
+      "       que par une vraie generation + verification SymPy sur le modele charge.\n"
      ]
     }
    ],
    "source": [
-    "# Simulation qualitative\n",
-    "print(\"Emergence du raisonnement avec RLVR (resultats attendus)\")\n",
-    "print(\"=\" * 60)\n",
+    "# Evaluation reelle : on genere avec le modele et on verifie via le verifier SymPy.\n",
+    "# (remplace l'ancienne \"simulation qualitative\" qui fabriquait des completions inventees)\n",
+    "import torch as _torch\n",
     "\n",
-    "test_problem = \"A shirt costs $80. 25% discount, then 10% tax. Final price?\"\n",
-    "print(f\"Probleme : {test_problem}\")\n",
-    "print(f\"Ground truth : $66.00\")\n",
-    "print()\n",
+    "def _evaluer_accuracy_rlvr(modele, tokenizer, problemes, num_completions=4, max_new_tokens=128):\n",
+    "    \"\"\"Genere num_completions par probleme, verifie chaque reponse via extract_answer + comparaison ground truth.\n",
     "\n",
-    "print(\"--- Avant RLVR (modele de base Qwen2.5-0.5B) ---\")\n",
-    "print(\"Completion 1 : $66\")\n",
-    "print(\"Completion 2 : $56\")\n",
-    "print(\"Completion 3 : The final price is $66.00.\")\n",
-    "print(\"Completion 4 : $70\")\n",
-    "print(\"Accuracy : 2/4 = 50% (correct par coincidence, pas de raisonnement)\")\n",
-    "print()\n",
+    "    Retourne (nb_correct, nb_total, details). Aucune valeur fabriquee : chaque ligne vient d'une generation reelle.\n",
+    "    \"\"\"\n",
+    "    modele.eval()\n",
+    "    nb_correct = 0\n",
+    "    nb_total = 0\n",
+    "    details = []\n",
+    "    for pb in problemes:\n",
+    "        prompt = pb[\"prompt\"]\n",
+    "        gt = pb[\"answer\"]\n",
+    "        messages = [{\"role\": \"user\", \"content\": prompt + \"\\n\\nReponds avec uniquement le nombre final apres 'Reponse : '.\"}]\n",
+    "        try:\n",
+    "            text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)\n",
+    "        except Exception:\n",
+    "            text = prompt\n",
+    "        ids = tokenizer(text, return_tensors=\"pt\").to(modele.device)\n",
+    "        corrects = 0\n",
+    "        for _ in range(num_completions):\n",
+    "            with _torch.no_grad():\n",
+    "                out = modele.generate(**ids, max_new_tokens=max_new_tokens, do_sample=True,\n",
+    "                                      temperature=0.7, pad_token_id=tokenizer.eos_token_id)\n",
+    "            comp = tokenizer.decode(out[0][ids[\"input_ids\"].shape[1]:], skip_special_tokens=True)\n",
+    "            pred = extract_answer(comp)\n",
+    "            ok = pred is not None and abs(pred - gt) < 1e-3\n",
+    "            corrects += int(ok)\n",
+    "            nb_total += 1\n",
+    "        nb_correct += corrects\n",
+    "        details.append((prompt[:50], gt, corrects, num_completions))\n",
+    "    return nb_correct, nb_total, details\n",
     "\n",
-    "print(\"--- Apres RLVR (3 epochs, reward verifiable) ---\")\n",
-    "print(\"Completion 1 : The discount is 25% of $80 = $20. So the price becomes $60.\")\n",
-    "print(\"                Then 10% tax on $60 = $6. Final price = $60 + $6 = $66.00.\")\n",
-    "print(\"Completion 2 : Step 1: 80 * 0.75 = 60 (after 25% off).\")\n",
-    "print(\"                Step 2: 60 * 1.10 = 66. The answer is $66.00.\")\n",
-    "print(\"Completion 3 : $80 - 25% = $60. $60 + 10% = $66.00.\")\n",
-    "print(\"Completion 4 : Let me calculate: 80*(1-0.25)*(1+0.10) = 80*0.75*1.10 = $66.\")\n",
-    "print(\"Accuracy : 4/4 = 100% (tous avec raisonnement spontane)\")\n",
-    "print()\n",
-    "print(\"Observation cle : le modele a APPRIS a decomposer les calculs\")\n",
-    "print(\"sans JAMAIS avoir ete entraine avec des exemples de raisonnement.\")\n",
-    "print(\"C'est le phenomene d'emergence qui a rendu Deepseek-R1 celebre.\")"
+    "if LOAD_MODEL_AND_TRAIN and CUDA_AVAILABLE and \"model\" in globals() and \"tokenizer\" in globals():\n",
+    "    print(\"Evaluation reelle post-RLVR (generation + verifier SymPy)\")\n",
+    "    print(\"=\" * 60)\n",
+    "    eval_sample = GSM8K_SAMPLE[:4]  # 4 problemes x 4 completions = 16 generations\n",
+    "    nb_correct, nb_total, details = _evaluer_accuracy_rlvr(model, tokenizer, eval_sample)\n",
+    "    print(f\"Accuracy post-RLVR : {nb_correct}/{nb_total} = {100*nb_correct/nb_total:.1f}%\")\n",
+    "    print()\n",
+    "    for prompt, gt, c, n in details:\n",
+    "        print(f\"  [{c}/{n}] gt={gt} | {prompt}...\")\n",
+    "    print()\n",
+    "    print(\"Chaque completion ci-dessus est issue d'une generation reelle du modele Qwen3.5-0.8B,\")\n",
+    "    print(\"verifiee par le verifier SymPy (extract_answer + comparaison ground truth).\")\n",
+    "    print(\"Aucune valeur n'est simulee ou inventee (correction du mandat #10289 : sortie du toy-env).\")\n",
+    "else:\n",
+    "    print(\"Skip : evaluation reelle non executee.\")\n",
+    "    print(\"Pour mesurer l'accuracy reelle (et non une simulation), executer avec :\")\n",
+    "    print(\"  LOAD_MODEL_AND_TRAIN = True sur GPU (cell precedente), puis cette cell genere + verifie.\")\n",
+    "    print()\n",
+    "    print(\"NOTE : cette cell n'invente PLUS de completions. Les resultats ne sont produits\")\n",
+    "    print(\"       que par une vraie generation + verification SymPy sur le modele charge.\")\n"
    ]
   },
   {
@@ -772,7 +835,16 @@
   {
    "cell_type": "markdown",
    "id": "c15d73e3",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003707,
+     "end_time": "2026-08-11T19:28:45.527742+00:00",
+     "exception": false,
+     "start_time": "2026-08-11T19:28:45.524035+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 10. 5 pieges spécifiques au RLVR\n",
     "\n",
@@ -793,7 +865,7 @@
     "**Solution** : ajouter des formats au parser, ou contraindre le format via system prompt.\n",
     "\n",
     "### Piege 5 : Confiance excessive dans l'emergence\n",
-    "L'emergence de CoT n'est pas garantie sur tous les modèles/tailles. Qwen2.5-0.5B peut ne pas montrer d'emergence nette.\n",
+    "L'emergence de CoT n'est pas garantie sur tous les modèles/tailles. Qwen3.5-0.8B peut ne pas montrer d'emergence nette.\n",
     "**Solution** : etre honnete sur les résultats. Pas de claim \"emergence observee\" si non verifiable."
    ]
   },


### PR DESCRIPTION
Grain: DEEP/genai — lane myia-po-2024:CoursIA — prev: DEEP/lean #9762 (pullback_imap #2159)

## Summary

Re-cible **PT-05 RLVR** (Reinforcement Learning with Verifiable Rewards) du toy-env `Qwen2.5-0.5B-Instruct` (superseded) vers **`Qwen3.5-0.8B`** (SOTA cible) — mandat user direct #10289 du 2026-08-10 (« utiliser un vrai LLM [...] faire du vrai RL »), dispatch ai-01 firsthand `msg-20260811T114555-4xll0v`.

See #10289 (issue non entièrement résolue : le run RLVR réel sur GPU 2 reste à lancer pour mesurer l'accuracy post-entraînement).

## Ce que la PR change (4 cells, chirurgical)

- **Cell 3 (setup)** : corrige un `NameError` latent (`CUDA_AVAILABLE` était référencé en cell 17 sans être défini) via détection `torch.cuda`. Ajoute un flag `SMOKE_TEST` (mode 2-steps < 2 min, validation plomberie).
- **Cell 17 (training)** : `MODEL_NAME = "Qwen/Qwen3.5-0.8B"` (was `Qwen2.5-0.5B-Instruct`), `AutoModelForImageTextToText` (gabarit PT-03 #10361 validé — Qwen3.5-0.8B est VL, chargé ici en chemin text-only). LoRA 4-bit QLoRA inchangé (r=8). `max_steps=2` injecté en mode smoke.
- **Cell 19 (evaluation)** : remplace la **simulation fabriquée** (« Completion 1 : $66 ... Accuracy : 2/4 = 50% » — résultats inventés) par une **vraie fonction `_evaluer_accuracy_rlvr`** qui génère avec le modèle + vérifie chaque réponse via `extract_answer` + le verifier SymPy. En l'absence de GPU, la cell skip proprement avec un message honnête (« cette cell n'invente PLUS de completions ») au lieu de fabriquer. C'est le cœur du mandat : un RLVR sur un modèle trop faible ne fait pas valoir le vérifieur, il fait valoir le hasard (Prong-B #3801).
- **Cell 21 (markdown)** : prose `Qwen2.5-0.5B` → `Qwen3.5-0.8B`.

## Outputs — honnêtement CPU-safe (le run RLVR réel est pour GPU 2)

CUDA n'est **pas disponible** sur le runner po-2024 (torch 2.11.0+cpu). Les outputs committés sont ceux du **mode CPU-safe** (`LOAD_MODEL_AND_TRAIN=False`, par défaut) : cell 3 documente « CUDA disponible : False », cell 17/19 print « Skip ... Pour mesurer l'accuracy réelle ... LOAD_MODEL_AND_TRAIN=True ». Aucune valeur fabriquée — ce sont les outputs réels d'une exécution papermill (kernel python3, exit 0).

**Le run RLVR réel** (mesure de l'accuracy post-entraînement, vraie génération + vérification SymPy) est à lancer sur **GPU 2** par ai-01 (modalité trancheée `msg-llnoab` : je livre script+config, ai-01 lance). Ré-injection des outputs GPU dans une PR follow-up.

VRAM attendue (déclarée) : pic ~2,5 Go (QLoRA 4-bit Qwen3.5-0.8B, mesuré sur PT-03 #10361 / 21_LoRA #10361). Wall-clock attendu : ~20-40 min (10 problems × G=4, 3 epochs).

## Vérification

- Papermill CPU-safe : **exit 0**, 26/26 cells exécutées, cell 23 affiche « Exercice a completer » (C.1 conforme — stub sans `raise NotImplementedError`).
- Anti-churn C.3 : exactement cells `[3, 17, 19, 21]` diffèrent de `origin/main` (byte-identity préservé sur les 22 autres, raw-JSON dump pas nbformat).
- Syntaxe AST validée sur cells 3/17/19.
- `metadata.papermill.*_path` strippés au basename (secrets-hygiene règle 6).
- Catalogue byte-identique à main (notebook-only).

## Hors scope (G.4 — un sujet par PR)

Le détecteur de reward hacking d'ICT (PT-07 rewardspy) est cité par le mandat comme un actif à réutiliser, mais le brancher est un grain à part entière — signalé en commentaire d'issue, pas implémenté ici.
