### PR TITLE
fix(lean,#9568): drop 2 native_decide on BoxAssezGrandN witnesses (c.8205 + c.8206 + c.8207 sub-grain chain)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1132,14 +1132,20 @@ progress; a vacuous-worthless proof would not be. -/
     concrete substrate that makes `hashlife_correctN` non-vacuous at the
     large-`n` regime (vs the fixed-frame `BoxAssezGrand block 8`, unsatisfiable
     by the `n ≤ 2` cap). It is the propositional twin of the Bool-form
-    `box_assez_grandN_block 8 = true` (proven above), discharged by
-    `native_decide` directly on the `BoxAssezGrandN` proposition via the
-    `Decidable (BoxAssezGrandN)` instance. -/
-theorem boxAssezGrandN_block_8 : BoxAssezGrandN block 8 := by native_decide
+    `box_assez_grandN_block 8 = true` (proven above), discharged by the
+    **triviality lemma** `boxAssezGrandN_trivial` (proved in `Foundation.lean`
+    next to `BoxAssezGrandN`) — which says `BoxAssezGrandN g n` holds for
+    **every** `g` and `n` because `gridFrameN n g` pads by `max 2 n ≥ n` on
+    every side and `cellMargin` is non-strict. So both this witness and the
+    analogous `boxAssezGrandN_glider_8` are now `forbidden-axiom-free` — the
+    old `by native_decide` was a redundant machine-check on a tautological
+    proposition (c.8207 sub-grain of #9568 cleanup). -/
+theorem boxAssezGrandN_block_8 : BoxAssezGrandN block 8 := boxAssezGrandN_trivial _ _
 
 /-- Same non-vacuity witness on the `glider` spaceship at `n = 8`
-    (propositional form). -/
-theorem boxAssezGrandN_glider_8 : BoxAssezGrandN glider 8 := by native_decide
+    (propositional form). Discharged by the triviality lemma — see
+    `boxAssezGrandN_block_8` docstring. -/
+theorem boxAssezGrandN_glider_8 : BoxAssezGrandN glider 8 := boxAssezGrandN_trivial _ _
 
 /-- **Confinement authentique du jump** (re-signed, inlined from
     `Conway.Life.JumpCapture` to avoid the A↔B import cycle that exists because
@@ -1237,13 +1243,23 @@ theorem p5_large_n_jumpN (n : Nat) (g : Grid)
     required work *beyond* the jump. It does not.
 
     **Note (c.1035).** The non-vacuity witnesses
-    `boxAssezGrandN_block_8` / `boxAssezGrandN_glider_8` (L1138/L1142) are now
+    `boxAssezGrandN_block_8` / `boxAssezGrandN_glider_8` (around L1140) are now
     orphaned relative to this theorem, since the hypothesis they satisfied is
     gone. They still typecheck standalone and are kept for traceability of
     the c.95 / c.1035 evolution; their substantive role is superseded by
     `jumpCaptured_block` / `jumpCaptured_glider` in `JumpCapture.lean`. The
     `BoxAssezGrandN` predicate itself remains consumed by
-    `hashlife_correctN_le_two` (L1199), which keeps the witnesses honest. -/
+    `hashlife_correctN_le_two` (around L1270), which keeps the witnesses honest.
+
+    **Note (c.8207).** Both witnesses are now proved via `boxAssezGrandN_trivial`
+    (relocated c.8206 from `JumpCapture.lean` to `Foundation.lean` to break the
+    import cycle) instead of `by native_decide`. They were redundant machine
+    witnesses on a tautological proposition — `BoxAssezGrandN g n` holds for
+    every `g` and `n` by the construction of `gridFrameN` padding `max 2 n ≥ n`
+    and non-strict `cellMargin`. The forbidden-axiom class `native_decide.*`
+    (per pr-review-discipline §B) is now eliminated at these two sites
+    (c.8207 sub-grain of #9568 cleanup, follows the same pattern as the c.8205
+    drop on the 4 `supportInMargin_*_k*` sanity checks). -/
 theorem hashlife_correctN (n : Nat) (g : Grid)
     (hcap : jumpCaptured (gridToMacroCellWithOffset g).2 = true) :
     evolveHashlifeFast n g = evolve n g := by


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA-2 — prev: DEEP/lean #10467

## fix(lean,#9568): drop 2 redundant native_decide on BoxAssezGrandN witnesses via triviality lemma

Continues the #9568 forbidden-axiom cleanup begun in c.8205 (4 `native_decide` on
`supportInMargin_*_k*`) and c.8206 (Foundation relocation of
`box_assez_grandN_trivial`). This is the third and final sub-grain: the 2
`native_decide` on `boxAssezGrandN_block_8` and `boxAssezGrandN_glider_8` were
redundant machine witnesses on a tautological proposition.

### What's redundant

`BoxAssezGrandN g n` (= `box_assez_grandN g n = true`) holds for **every** grid
`g` and **every** `n`, because:
- `gridFrameN n g` pads by `max 2 n ≥ n` on every side,
- `cellMargin n` is non-strict on the near side (`r0 + n ≤ r`),
- and the padding-floor `max 2 n` is always at least `n` itself.

This was established in c.8206 as `box_assez_grandN_trivial` (in `Foundation.lean`,
relocated from `JumpCapture.lean` to break the import cycle that
`HashlifeMarginFragment` ↔ `JumpCapture` would otherwise create).

The 2 `by native_decide` at `HashlifeCorrectness.lean` L1138 / L1142 were
**redundant machine witnesses** on the same tautology — the kernel was
re-deriving `max 2 n ≥ n` per-call rather than citing the general proof.

### The change

| Theorem | Before | After |
|---|---|---|
| `boxAssezGrandN_block_8 : BoxAssezGrandN block 8` | `:= by native_decide` | `:= boxAssezGrandN_trivial _ _` |
| `boxAssezGrandN_glider_8 : BoxAssezGrandN glider 8` | `:= by native_decide` | `:= boxAssezGrandN_trivial _ _` |

Plus docstring expansion at L1129-1148 explaining the triviality lemma, and a
new `Note (c.8207)` block at L1255-1265 documenting the rationale + the
forbidden-axiom-elimination claim.

### File-level forbidden-axiom measure (HashlifeCorrectness.lean)

**Measured against `02a119b7a` rebased on `origin/main` (post-#10441 + post-#10467).**

| Mesure | `origin/main` | après c.8207 (`02a119b7a`) | Δ |
|---|---|---|---|
| `:= by native_decide` (theorem-level, sites où le kernel décide la conclusion) | 7 | **5** | **−2** |
| `grep -c native_decide` (naïf, lignes qui *mentionnent* le mot — incl. docstrings) | 25 | **25** | 0 |

**Pourquoi deux mesures :** la mesure naïf `grep -c native_decide` reste à 25
parce que les **nouvelles docstrings** ajoutées par c.8207 (Note bloc L1255-1265,
expansion L1129-1148) **mentionnent** le mot `native_decide` pour documenter
*qu'on l'a éliminé ici*. Cette mesure ne discrimine plus rien une fois qu'on
documente le rationale. La mesure theorem-level (`:= by native_decide` en
position de preuve) est celle qui porte la claim `#9568` : c'est elle qui
survit au rebase et que la review §B peut falsifier.

**Les 5 restants (post-c.8207) sont tous des `tactic-mode` `native_decide` arguments
dans `exact ⟨_, native_decide, _⟩` pour les witnesses P4 base-case `jumpCaptured_*`**
à L725/737/743/749/770/782/1306 — `Decidable` non-tautologique (la décidabilité
de `jumpCaptured` est un théorème, pas une tautologie), ils appartiennent à une
chaîne de décidabilité distincte et hors scope de cette sous-tâche.

### Vrai juge — `proof-integrity (conway_lean)`

**Le juge autoritatif n'est ni l'un ni l'autre `grep`** : c'est le job
`proof-integrity / Proof integrity (conway_lean)` qui tourne
`LeanVerifier.check_axioms(module, fail_on_sorry=True)` et compte les axiomes
`native_decide.*` réellement dans la clôture d'imports de
`HashlifeCorrectness.lean`. Run ID post-rebase : `31533595983` (job 93919262106,
démarré 2026-08-11T20:37Z). Le Δ mesuré par ce job est ce qu'il faut citer,
pas un proxy `grep` — un `grep -c` peut bouger (docstrings, commentaires)
sans qu'aucun axiome réel ait changé.

### Pattern (c.8205 → c.8206 → c.8207)

| Cycle | Pattern | Where |
|---|---|---|
| c.8205 | drop 4 `native_decide` on `supportInMargin_*_k*` sanity checks | `HashlifeMarginFragment.lean` (FR+EN siblings) |
| c.8206 | relocate `box_assez_grandN_trivial` to `Foundation.lean` (break import cycle) | `Foundation.lean` ← `JumpCapture.lean` |
| **c.8207** | **drop 2 `native_decide` on `BoxAssezGrandN` witnesses (this PR)** | **`HashlifeCorrectness.lean` L1143/L1148** |

After this PR lands, the `BoxAssezGrandN` family has **zero** `native_decide`
proofs left — every site uses `boxAssezGrandN_trivial` (general) or
`boxAssezGrandN` instance arguments (where the call-site is genuinely
tautology-relevant).

### Verdict — INTRINSIC conservation

The 2 forbidden axioms are eliminated; the **propositions they prove are
unchanged** (still `BoxAssezGrandN block 8` and `BoxAssezGrandN glider 8`). No
downstream theorem changes. `pr-review-discipline §B` constraint
(`native_decide.*` class) now strictly relaxed at these 2 sites, consistent
with the c.8205 finding (the `BoxAssezGrandN` family is **tautological** per
construction).

### Pre-push guards (mechanical, all passed)

| Guard | Status |
|---|---|
| L890 ★★ `git diff origin/main..HEAD -- PATHS` | diff shows 1 file (`HashlifeCorrectness.lean`, +18 −9) — single-file scope, post-rebase par ai-01 (`1308c275c → 02a119b7a`) |
| L898 ★★★ `gh pr list --state all --search head:<branch>` | 1 PR (this one) on `feature/c8207-9568-tautology-extend` ✓ |
| L899 ★★ `gh pr list --state merged --search "#9568"` | 4 prior merged PRs (`#9788`, `#9796`, `#9589`, `#9780`); none touch `boxAssezGrandN_block_8` / `_glider_8` ✓ |
| L903 ★★ `gh pr view N --comments` | ai-01 merge-gate comment `IC_kwDOH2Odns8AAAABOW8ekA` lu avant edit body (PR rebasée par ai-01 suite merge-order `#10467`) ✓ |
| L904 ★★ `git log HEAD..origin/main` | 0 commits ahead — c.8207 est rebased fresh on origin/main ✓ |
| L677-L4 ★★ PR body scratchpad | This file (not in worktree) ✓ |

### Anti-regression check

| Check | Status |
|---|---|
| Theorem-level scope (L1143 / L1148 only, NOT call-sites) | ✓ both are `def`-style tautological propositions |
| No consumer change | ✓ `grep -rn "boxAssezGrandN_block_8\|boxAssezGrandN_glider_8"` returns only docstring references (L990/991/1240) and the theorem defs themselves |
| Forbidden-axiom class NOT circumvented elsewhere | ✓ `BoxAssezGrandN` instance itself is a regular `Decidable`, not `native_decide` |
| `supportInMargin_trivial` (companion, c.8206) | ✓ unchanged — still uses `boxAssezGrandN_trivial _ _` as proof body |

### Issue / See

- See #9568 — c.8205 + c.8206 + c.8207 forbidden-axiom cleanup of `BoxAssezGrandN` family (3 sub-grains)
- See #6724 — parent EPIC for the wider tautology / capture / jump research
- See #10459 — concurrent lane work on `Search-7` (sibling-Stop-and-Repair cross-check)

### References

- `MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean` L1129-1148 (this PR's edit)
- `MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness/Foundation.lean` L161 (def `BoxAssezGrandN`) + c.8206-add L170 (thm `boxAssezGrandN_trivial`)
- PR #10467 (c.8206) — foundation relocation of `box_assez_grandN_trivial`
- Comment ai-01 `IC_kwDOH2Odns8AAAABOW8ekA` (PR rebasée suite merge-order `#10467` — context complet du Δ=−2 theorem-level)