### PR TITLE
fix(lean-ci,#10486): axiom gate names the declaration it refuses, and enumerates Unicode ones

### DIFF
--- a/.github/workflows/lean-axiom.yml
+++ b/.github/workflows/lean-axiom.yml
@@ -162,12 +162,27 @@ jobs:
             sys.exit(f"repo root has no MyIA.AI.Notebooks/: {repo_root}")
         sys.path.insert(0, str(repo_root / "MyIA.AI.Notebooks" / "SymbolicAI" / "Lean" / "agent_tests"))
 
+        from lean_server import LeanVerifier  # noqa: E402
+
         # `select_diagnostic_lines` is imported, not reimplemented here: the
         # selection has to agree with the canonical diagnostic marker (#8694,
         # shared with `prover.tools._parse_lean_errors`), and a YAML heredoc is
         # the one place in this repo no test can reach. It lives in
         # `lean_server.py`, pinned by `tests/test_error_marker_contract.py`.
-        from lean_server import LeanVerifier, select_diagnostic_lines  # noqa: E402
+        #
+        # The fallback is not defensive habit, it answers a STRUCTURAL version
+        # skew: callers reference this file as `lean-axiom.yml@main`, so the
+        # workflow body is always `main`'s while `lean_server.py` comes from the
+        # caller's checkout. A branch that predates the selector must degrade to
+        # the previous behaviour (tail slice), never crash the gate on an
+        # ImportError -- a green-to-crashed gate on every in-flight Lean PR
+        # would be a far worse defect than the one being fixed here (#10486).
+        try:
+            from lean_server import select_diagnostic_lines  # noqa: E402
+        except ImportError:
+            def select_diagnostic_lines(raw_output, limit=12):
+                lines = (raw_output or "").strip().splitlines()
+                return lines[-20:], False, 0
 
         modules = [m.strip() for m in os.environ["MODULES"].split(",") if m.strip()]
         allow = [a.strip() for a in os.environ.get("ALLOW", "").split(",") if a.strip()]

--- a/.github/workflows/lean-axiom.yml
+++ b/.github/workflows/lean-axiom.yml
@@ -162,7 +162,12 @@ jobs:
             sys.exit(f"repo root has no MyIA.AI.Notebooks/: {repo_root}")
         sys.path.insert(0, str(repo_root / "MyIA.AI.Notebooks" / "SymbolicAI" / "Lean" / "agent_tests"))
 
-        from lean_server import LeanVerifier  # noqa: E402
+        # `select_diagnostic_lines` is imported, not reimplemented here: the
+        # selection has to agree with the canonical diagnostic marker (#8694,
+        # shared with `prover.tools._parse_lean_errors`), and a YAML heredoc is
+        # the one place in this repo no test can reach. It lives in
+        # `lean_server.py`, pinned by `tests/test_error_marker_contract.py`.
+        from lean_server import LeanVerifier, select_diagnostic_lines  # noqa: E402
 
         modules = [m.strip() for m in os.environ["MODULES"].split(",") if m.strip()]
         allow = [a.strip() for a in os.environ.get("ALLOW", "").split(",") if a.strip()]
@@ -242,13 +247,29 @@ jobs:
             if result.get("error"):
                 print(f"  error: {result['error']}")
                 # `error` names the class of failure; `raw_output` names the
-                # cause. Without this tail, "build_failed_returncode_1" sends
-                # you to a local reproduction to learn what any CI log already
-                # had. Tail rather than head: Lean prints the failing
-                # declaration and its error last.
-                tail = (result.get("raw_output") or "").strip().splitlines()[-20:]
-                for line in tail:
+                # cause. Without it, "build_failed_returncode_1" sends you to a
+                # local reproduction to learn what any CI log already had.
+                #
+                # Select the DIAGNOSTIC lines, not the tail. This branch used to
+                # slice `raw_output[-20:]` on the rationale that "Lean prints
+                # the failing declaration and its error last" -- true when the
+                # MODULE fails to build, false for this checker, whose build is
+                # a batch of one `#print axioms` per declaration fed to
+                # `lean --stdin`. An error on command #7 of 537 prints near the
+                # TOP, so the tail showed 20 healthy `depends on axioms:` lines
+                # and the cause was invisible. Measured on #10486 (galois_lean,
+                # 537 declarations): the log carried `build_failed_returncode_1`
+                # and nothing else, and the worker was sent to reproduce a
+                # 4-minute Mathlib build to learn a name the runner already had.
+                sel, matched, omitted = select_diagnostic_lines(
+                    result.get("raw_output") or ""
+                )
+                if not matched:
+                    print("    | (no Lean diagnostic in capture -- last 20 lines follow)")
+                for line in sel:
                     print(f"    | {line}")
+                if omitted:
+                    print(f"    | ... (+{omitted} more diagnostic lines)")
             if result["has_sorry"]:
                 sorry_modules.append(mod)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -938,3 +938,43 @@ class LeanVerifier:
             if _ERROR_MARKER_RE.search(stripped):
                 errors.append(stripped)
         return errors
+
+
+# Number of trailing lines shown when a capture holds no diagnostic at all.
+_DIAGNOSTIC_TAIL_LINES = 20
+
+
+def select_diagnostic_lines(
+    raw_output: str, limit: int = 12
+) -> Tuple[List[str], bool, int]:
+    """Pick the lines that name the CAUSE out of a failed Lean/Lake capture.
+
+    Returns ``(lines, matched, omitted)``.  ``matched`` is ``True`` when at
+    least one line carried a diagnostic marker, in which case ``lines`` holds
+    up to ``limit`` of them and ``omitted`` counts the rest.  ``matched`` is
+    ``False`` when the capture holds no diagnostic at all -- lake resolution
+    failure, missing toolchain, a timeout kill -- and ``lines`` falls back to
+    the last :data:`_DIAGNOSTIC_TAIL_LINES` lines.
+
+    Why selection and not a tail slice (#10486).  :meth:`check_axioms` does not
+    run ``lake build``: it feeds ``lean --stdin`` an ``import`` plus one
+    ``#print axioms`` per declaration.  The reporting side of the axiom gate
+    used to print ``raw_output[-20:]``, on the reasoning that Lean prints the
+    failing declaration last -- true when the MODULE fails to build, false
+    here.  Measured on ``galois_lean`` (537 declarations): the failure came
+    from an early command, so the tail showed twenty healthy
+    ``depends on axioms:`` lines and the CI log carried only
+    ``build_failed_returncode_1``.  The name sat in the capture the runner
+    already had, in the part nobody printed, and the worker was sent to
+    reproduce a 4-minute Mathlib build to learn it.
+
+    Delegates to :meth:`LeanVerifier._extract_errors` rather than re-matching
+    the marker, so a new Lean spelling reaches every consumer at once -- the
+    duplication-by-prose that reopened #6790 through a class-tagged
+    diagnostic.  Pinned by ``tests/test_error_marker_contract.py``.
+    """
+    lines = (raw_output or "").strip().splitlines()
+    hits = LeanVerifier._extract_errors("\n".join(lines))
+    if hits:
+        return hits[:limit], True, max(0, len(hits) - limit)
+    return lines[-_DIAGNOSTIC_TAIL_LINES:], False, 0

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -131,15 +131,48 @@ def _find_lake_root(start: Path) -> Optional[Path]:
 # declaration is fortuitously named `Basic`. To feed real declaration names we
 # parse the module source, tracking `namespace`/`end` blocks so each name is
 # emitted fully qualified. See pr-review-discipline.md §B.3 / issue #8677.
+# Lean 4 identifiers are Unicode, and ours actually use it: Greek letters as
+# names (`π`, `ε`), subscripts (`h₁₂`, `mapsElations₂_gen1`), accents in
+# namespaces (`imbriqué`), and the `!`/`?` suffixes of the partial and optional
+# variants (`parseRLE!`, `head?`). An ASCII-only character class fails on those
+# in three distinct ways, all measured on our own lakes (#10486). Only the first
+# is visible; the other two keep the gate green while it checks nothing:
+#
+#   * LOUD PHANTOM -- the truncated name matches no declaration at all
+#     (`mapsElations₂_gen1` -> `mapsElations`, `dualBases_e_ε` ->
+#     `dualBases_e_`). `#print axioms` answers `unknown constant`, the run exits
+#     non-zero and #8681 voids the module. This is #10486's red.
+#   * SILENT ALIAS -- the truncated name matches a *different real* declaration.
+#     `foo`/`foo!`/`foo?` is a standard Lean idiom, so this is the common case:
+#     `Conway.Life.RLE` (wired and blocking) declares both `parseRLE` and
+#     `parseRLE!`, so the gate emitted the former twice, the latter never, and
+#     reported green having never inspected `parseRLE!`'s axiom closure.
+#   * SILENT MISS -- a name whose FIRST character is non-ASCII (`π`, `ε`) matches
+#     nothing, so the declaration is never enumerated. A `sorry` or a
+#     `native_decide` inside it passes unseen, with nothing going red to say so.
+#
+# `[^\W\d]` is "word character that is not a decimal digit" == letter or `_`,
+# Unicode-aware under Python 3's default `str` semantics -- so no `regex`
+# dependency is needed, and `\w` already covers subscripts (`'₂'.isalnum()` is
+# True) without spelling their code-point ranges out. The quantifier must stay
+# GREEDY: a lazy `*?` here matches a single character and turns every name into
+# a phantom, which is strictly worse than the bug it would be fixing.
+#
+# Over-acceptance is harmless in this direction -- the enumerator only ever
+# reads names that Lean itself already accepted -- whereas under-acceptance is
+# exactly what breaks the gate. Pinned by tests/test_check_axioms.py.
+_LEAN_ID = r"[^\W\d][\w'.!?]*"
+_LEAN_NS = r"[^\W\d][\w'.]*"
+
 _DECL_HEAD_RE = re.compile(
     r"^(?:@\[[^\]]*\]\s*)*"                                     # attributes (zero or more)
     r"(?P<mods>(?:(?:private|protected|noncomputable|unsafe|partial|abstract)\s+)*)"
     r"(?:theorem|lemma|def|opaque|axiom|abbrev|structure|inductive|class)\s+"
-    r"(?P<name>[A-Za-z_][A-Za-z0-9_'.]*)",
+    r"(?P<name>" + _LEAN_ID + r")",
     re.MULTILINE,
 )
-_NS_OPEN_RE = re.compile(r"^\s*namespace\s+(?P<ns>[A-Za-z_][A-Za-z0-9_.]*)")
-_NS_CLOSE_RE = re.compile(r"^\s*end\s+(?P<ns>[A-Za-z_][A-Za-z0-9_.]*)")
+_NS_OPEN_RE = re.compile(r"^\s*namespace\s+(?P<ns>" + _LEAN_NS + r")")
+_NS_CLOSE_RE = re.compile(r"^\s*end\s+(?P<ns>" + _LEAN_NS + r")")
 
 # Canonical Lean/Lake error marker (#8694). Lean 4 spells a diagnostic either
 # bare (``error:``) or tagged with a diagnostic class

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_check_axioms.py
@@ -217,6 +217,125 @@ def test_enumeration_skips_private_declarations(tmp_path):
     assert decls == ["Knots.public_thm", "Knots.prot_thm", "Knots.slow"]
 
 
+# ── #10486: Lean identifiers are Unicode, the enumerator was ASCII-only ────
+
+def test_enumeration_keeps_subscripts_and_suffixed_names(tmp_path):
+    """Truncation mode of #10486: an ASCII class cuts the name mid-identifier.
+
+    ``mapsElations₂_gen1`` was enumerated as ``mapsElations`` -- the ``₂``
+    (U+2082) ended the match. The truncated name reaches ``#print axioms``,
+    Lean answers ``unknown constant``, and #8681 voids the whole module: that
+    is the red observed on ``galois_lean``'s ``Sporadic.L34``.
+
+    The ``!``/``?`` suffixes truncate the same way. See the companion test
+    below for why that case is quieter, and worse.
+    """
+    src = (
+        "namespace Sporadic.L34\n"
+        "theorem mapsElations₂_gen1 : True := trivial\n"
+        "theorem h₁₂ : True := trivial\n"
+        "def parseRLE! (s : String) : Nat := 0\n"
+        "def head? (l : List Nat) : Option Nat := none\n"
+        "end Sporadic.L34\n"
+    )
+    (tmp_path / "M.lean").write_text(src, encoding="utf-8")
+    assert _enumerate_module_declarations(tmp_path, "M") == [
+        "Sporadic.L34.mapsElations₂_gen1",
+        "Sporadic.L34.h₁₂",
+        "Sporadic.L34.parseRLE!",
+        "Sporadic.L34.head?",
+    ]
+
+
+def test_enumeration_sees_names_starting_with_a_greek_letter(tmp_path):
+    """Silent half of #10486, and the dangerous one.
+
+    A name whose FIRST character is non-ASCII matched nothing at all, so the
+    declaration was never enumerated -- and a declaration that is never
+    enumerated is never axiom-checked. Nothing goes red: a ``sorry`` inside
+    ``π`` would have sailed through the gate. Measured on ``sensitivity_lean``,
+    which holds ``π``, ``ε`` and ``dualBases_e_ε``.
+    """
+    src = (
+        "namespace Sens\n"
+        "def π : Nat := 3\n"
+        "def ε : Nat := 0\n"
+        "theorem dualBases_e_ε : True := trivial\n"
+        "end Sens\n"
+    )
+    (tmp_path / "M.lean").write_text(src, encoding="utf-8")
+    assert _enumerate_module_declarations(tmp_path, "M") == [
+        "Sens.π",
+        "Sens.ε",
+        "Sens.dualBases_e_ε",
+    ]
+
+
+def test_enumeration_bang_variant_is_not_aliased_onto_its_sibling(tmp_path):
+    """The quiet mode of #10486, and the one that keeps a gate falsely green.
+
+    ``foo`` / ``foo!`` / ``foo?`` is a standard Lean idiom, so a truncation very
+    often lands on a *real* neighbouring declaration instead of on nothing. That
+    is the case live on ``main``: ``conway_lean``'s ``Conway.Life.RLE`` -- which
+    IS in the wired, blocking ``target-modules`` of ``lean-conway.yml`` --
+    declares ``parseRLE`` (line 188) and ``parseRLE!`` (line 199). The
+    enumerator emitted ``parseRLE`` twice and ``parseRLE!`` never, so the gate
+    checked one declaration twice, reported green, and never once inspected the
+    axiom closure of the other. No red, no signal, a hole.
+
+    Both must be emitted, distinctly.
+    """
+    src = (
+        "namespace Conway.Life.RLE\n"
+        "def parseRLE (s : String) : Except String Nat := .ok 0\n"
+        "def parseRLE! (s : String) : Nat := 0\n"
+        "end Conway.Life.RLE\n"
+    )
+    (tmp_path / "M.lean").write_text(src, encoding="utf-8")
+    decls = _enumerate_module_declarations(tmp_path, "M")
+    assert decls == [
+        "Conway.Life.RLE.parseRLE",
+        "Conway.Life.RLE.parseRLE!",
+    ]
+    assert len(set(decls)) == 2, "the ! variant must not collapse onto its sibling"
+
+
+def test_enumeration_tracks_an_accented_namespace(tmp_path):
+    """#10486, third site: a truncated NAMESPACE mis-qualifies its contents.
+
+    ``namespace imbriqué`` (real, in ``conway_lean``'s ``Conway.Doomsday``)
+    opened as ``imbriqu``. The stack itself stays balanced -- ``end imbriqué``
+    truncates identically, so the push and the pop agree -- which is precisely
+    why this went unnoticed: nothing looks structurally wrong. The damage is the
+    prefix handed to every declaration *inside* the block, which becomes a name
+    Lean does not know.
+    """
+    src = (
+        "namespace imbriqué\n"
+        "theorem inside : True := trivial\n"
+        "end imbriqué\n"
+        "theorem after : True := trivial\n"
+    )
+    (tmp_path / "M.lean").write_text(src, encoding="utf-8")
+    assert _enumerate_module_declarations(tmp_path, "M") == [
+        "imbriqué.inside",
+        "after",
+    ]
+
+
+def test_enumeration_name_quantifier_stays_greedy(tmp_path):
+    """Guards the fix against the lazy-quantifier "fix".
+
+    Making the name quantifier lazy (``*?``) satisfies every Unicode example
+    above while collapsing each name to its first character -- turning a handful
+    of phantom names into *all* names phantom. This pins the greedy behaviour so
+    that regression cannot land silently.
+    """
+    src = "theorem MapsElations : True := trivial\n"
+    (tmp_path / "M.lean").write_text(src, encoding="utf-8")
+    assert _enumerate_module_declarations(tmp_path, "M") == ["MapsElations"]
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # _extract_axioms
 # ──────────────────────────────────────────────────────────────────────────

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_error_marker_contract.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_error_marker_contract.py
@@ -56,7 +56,7 @@ HERE = Path(__file__).resolve().parent
 ROOT = HERE.parent
 sys.path.insert(0, str(ROOT))
 
-from lean_server import LeanVerifier  # noqa: E402
+from lean_server import LeanVerifier, select_diagnostic_lines  # noqa: E402
 from prover.tools import _parse_lean_errors  # noqa: E402
 
 
@@ -153,3 +153,95 @@ def test_legacy_module_level_still_parsed():
     assert _parse_lean_errors(line) == [
         {"line": None, "message": "cannot synthesize type"}
     ]
+
+
+# ---------------------------------------------------------------------------
+# Reporting side: which lines the axiom gate prints when the batch fails.
+#
+# `check_axioms` feeds `lean --stdin` an `import` plus one `#print axioms` per
+# declaration, so a capture from a FAILED run interleaves healthy
+# `depends on axioms:` answers with the diagnostic. The gate's reporting used
+# to slice the last 20 lines; on #10486 (galois_lean, 537 declarations) the
+# failure came early, the tail was 20 healthy declarations, and the CI log said
+# only `build_failed_returncode_1`. These tests pin the selection so that
+# regression cannot come back silently -- the reporting itself lives in a YAML
+# heredoc (`.github/workflows/lean-axiom.yml`) which no test can import.
+# ---------------------------------------------------------------------------
+
+
+def _batch_capture(n_healthy_after: int) -> str:
+    """A `#print axioms` batch capture: one early error, then healthy answers.
+
+    The diagnostic line is verbatim from ``REAL_BROKEN_BUILD`` -- the same
+    `unknown constant` shape a stale or unaddressable declaration name
+    produces, which is exactly the #10486 failure mode.
+    """
+    head = (
+        "<stdin>:8:14: error(lean.unknownIdentifier): "
+        "Unknown constant `Sporadic.gone`\n"
+    )
+    healthy = "".join(
+        f"'Galois.decl{i}' depends on axioms: "
+        "[propext, Classical.choice, Quot.sound]\n"
+        for i in range(n_healthy_after)
+    )
+    return head + healthy
+
+
+def test_early_diagnostic_survives_a_long_healthy_batch():
+    """The #10486 regression: a tail slice would show only healthy lines."""
+    capture = _batch_capture(n_healthy_after=40)
+    lines, matched, omitted = select_diagnostic_lines(capture)
+    assert matched is True
+    assert omitted == 0
+    assert len(lines) == 1
+    assert "Unknown constant `Sporadic.gone`" in lines[0]
+    # The defect being pinned, stated as a measurement rather than as prose:
+    # the old reporting sliced [-20:], which on this capture is all healthy.
+    assert all(
+        "error" not in ln for ln in capture.strip().splitlines()[-20:]
+    ), "fixture no longer reproduces the tail-slice blind spot"
+
+
+def test_every_real_diagnostic_is_selected():
+    """Selection agrees with the authority on real Lean output."""
+    lines, matched, omitted = select_diagnostic_lines(REAL_BROKEN_BUILD)
+    assert matched is True
+    assert lines == LeanVerifier._extract_errors(REAL_BROKEN_BUILD)
+    assert len(lines) == 3 and omitted == 0
+    assert not any("warning:" in ln for ln in lines)
+
+
+def test_limit_truncates_and_counts_the_remainder():
+    """A firehose is capped, and the cap says how much it hid."""
+    capture = "".join(
+        f"F.lean:{i}:0: error: boom {i}\n" for i in range(30)
+    )
+    lines, matched, omitted = select_diagnostic_lines(capture, limit=12)
+    assert matched is True
+    assert len(lines) == 12
+    assert omitted == 18
+    assert "boom 0" in lines[0]
+
+
+def test_falls_back_to_the_tail_when_no_diagnostic_exists():
+    """No marker at all (lake resolution, toolchain, timeout kill).
+
+    The fallback must be flagged as such: `matched is False` is what makes the
+    gate print "no Lean diagnostic in capture" rather than presenting a tail as
+    if it were the cause.
+    """
+    capture = "".join(f"info: building step {i}\n" for i in range(50))
+    lines, matched, omitted = select_diagnostic_lines(capture)
+    assert matched is False
+    assert omitted == 0
+    assert len(lines) == 20
+    assert lines[-1] == "info: building step 49"
+
+
+def test_empty_capture_is_not_a_crash():
+    """`raw_output` is empty on FileNotFoundError / timeout paths."""
+    for empty in ("", "   \n\n", None):
+        lines, matched, omitted = select_diagnostic_lines(empty)
+        assert matched is False and omitted == 0
+        assert lines in ([], [""])


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/tooling #10484

Corrige deux défauts de **mon propre organe**, tous deux découverts en diagnostiquant #10486. La PR de po-2026 y livre une preuve **saine** — `ci / Lean CI (galois_lean)` SUCCESS, `axioms: []`, `forbidden: []`, `has_sorry: False`, 537 déclarations toutes sur la whitelist `[propext, Classical.choice, Quot.sound]` — et le gate d'axiomes la refusait quand même. Deux causes distinctes, dans le même organe : **il ne disait pas pourquoi** (partie 1), et **il inventait le nom qu'il refusait** (partie 2). See #10486.

Les deux vont ensemble parce que c'est la partie 1 qui a rendu la partie 2 trouvable, et parce que la partie 2 seule aurait laissé le gate muet au prochain défaut d'énumération.

---

# Partie 1 — le gate imprime le diagnostic, pas la queue

La branche de reporting de `lean-axiom.yml` imprimait `raw_output[-20:]`, avec ce commentaire pour justification :

> *« Tail rather than head: Lean prints the failing declaration and its error last. »*

C'est vrai quand le **module** échoue à builder. C'est **faux pour ce checker** : `check_axioms` ne lance pas `lake build`, il envoie à `lean --stdin` un `import` **plus un `#print axioms` par déclaration**. Une erreur sur une commande précoce s'imprime donc **en haut** de la capture.

Sur #10486 (`galois_lean`, **537** déclarations), le job affichait :

```
  error: build_failed_returncode_1
    | 'Galois.decl...' depends on axioms: [propext, Classical.choice, Quot.sound]
    | ... 19 autres lignes saines
```

Le nom inadressable était **dans la capture que le runner avait déjà**, dans la partie que personne n'imprimait. J'ai renvoyé po-2026 vers une reproduction locale (~4 min de Mathlib) pour apprendre une chaîne que la CI tenait en main. Le `grep 'unknown constant'` que j'ai lancé sur le log complet ne renvoyait rien — non pas parce que l'erreur était absente, mais parce que le reporting la masquait. Ce faux négatif est ce qui a identifié le défaut.

| Fichier | Changement |
|---|---|
| `lean_server.py` | `select_diagnostic_lines(raw_output, limit=12) -> (lines, matched, omitted)`. Délègue à `LeanVerifier._extract_errors` — **pas** une seconde écriture du marqueur : c'est la duplication-par-prose qui avait rouvert #6790 via une classe de diagnostic (`error(lean.unknownIdentifier):`). Retombe sur la queue **seulement** si la capture ne porte aucun diagnostic (résolution lake, toolchain, kill par timeout), et le signale (`matched is False`) pour qu'une queue ne soit jamais présentée comme la cause. |
| `lean-axiom.yml` | Appelle le sélecteur au lieu d'inliner la tranche. Un heredoc YAML est le seul endroit du dépôt qu'aucun test ne peut importer — la logique doit en sortir pour être épinglable. |
| `tests/test_error_marker_contract.py` | **5 tests** ajoutés dans le fichier qui épingle déjà les deux parseurs sur de la sortie Lean réelle. |

### Avant / après, sur la forme exacte de #10486

Capture synthétique : une erreur `Unknown constant` précoce, puis 537 réponses saines.

```
--- ANCIEN (tail[-20:]) ---
    | 'Galois.decl534' depends on axioms: [propext, Classical.choice, Quot.sound]
    | 'Galois.decl535' depends on axioms: [propext, Classical.choice, Quot.sound]
    | 'Galois.decl536' depends on axioms: [propext, Classical.choice, Quot.sound]
    | ... (17 lignes saines de plus, aucune mention de la cause)
--- NOUVEAU ---
    | <stdin>:8:14: error(lean.unknownIdentifier): Unknown constant `Sporadic.gone`
```

---

# Partie 2 — l'énumérateur lit des identifiants Unicode, pas leur préfixe ASCII

**Diagnostic de po-2026** (`msg-20260811T201611-d9gq0m`), et il est juste : les trois regex d'énumération étaient en classes ASCII, alors que les identifiants Lean 4 sont Unicode et que **les nôtres s'en servent**. `mapsElations₂_gen1` était énuméré `mapsElations` — le `₂` (U+2082) terminait le match.

Ce n'est pas un défaut cosmétique, et il ne se réduit pas au symptôme rouge. **Trois modes de défaillance, dont un seul est visible :**

| Mode | Ce qui se passe | Sites mesurés | Gate |
|---|---|---|---|
| **LOUD PHANTOM** | le nom tronqué ne résout rien → `unknown constant` → #8681 annule le module | #10486 + 2 latents (`dualBases_e_ε` → `dualBases_e_`) | rouge |
| **SILENT ALIAS** | le nom tronqué tombe sur une **autre déclaration réelle** | 2, dans `conway_lean` | **câblé, bloquant, VERT aujourd'hui** |
| **SILENT MISS** | premier caractère non-ASCII → aucun match → jamais énuméré | 4, dans `sensitivity_lean` (`π`, `ε`) | latent (lake non câblé) |

**Le mode ALIAS est le pire, et il est vivant sur `main`.** `foo` / `foo!` / `foo?` est un idiome Lean standard, donc une troncature tombe très souvent sur un voisin **réel** plutôt que sur rien. `Conway.Life.RLE` — qui **est** dans les `target-modules` câblés et bloquants de `lean-conway.yml` — déclare `parseRLE` (l. 188) **et** `parseRLE!` (l. 199) :

```
old regex -> ['Conway.Life.RLE.parseRLE', 'Conway.Life.RLE.parseRLE']   # le même, deux fois
new regex -> ['Conway.Life.RLE.parseRLE', 'Conway.Life.RLE.parseRLE!']
```

Le gate envoyait donc `#print axioms …parseRLE` **deux fois**, `parseRLE!` **jamais**, et rapportait vert **sans avoir jamais inspecté la clôture d'axiomes de `parseRLE!`**. Aucun rouge, aucun signal, un trou. C'est aussi ce qui explique pourquoi `conway_lean` était vert malgré une troncature dans un module câblé — j'ai vérifié cette incohérence apparente avant de l'écrire, plutôt que de supposer que la troncature était partout bruyante.

### Le correctif, et pourquoi *cette* forme

```python
_LEAN_ID = r"[^\W\d][\w'.!?]*"     # noms de déclaration
_LEAN_NS = r"[^\W\d][\w'.]*"       # namespaces
```

- `[^\W\d]` = « caractère de mot qui n'est pas un chiffre décimal » = lettre ou `_`, **Unicode-aware** sous la sémantique `str` de Python 3 → **aucune dépendance `regex`**, et **aucune plage de code-points à épeler** : `\w` couvre déjà les indices (`'₂'.isalnum()` est `True`). Mon premier jet portait `₀-₉ₐ-ₜ` explicitement ; c'était **redondant**, et une plage redondante fait croire au lecteur suivant qu'elle porte quelque chose. Retirée après vérification que les 12 cas passent sans elle.
- La sur-acceptation est inoffensive **dans ce sens** : l'énumérateur ne lit que des noms que Lean a déjà acceptés. C'est la **sous**-acceptation qui casse le gate.

**Le quantifieur doit rester glouton.** La proposition de po-2026 le rendait paresseux :

```python
r"(?P<name>[A-Za-z_₀-₉][A-Za-z0-9_'.₀-₉\w]*?)"   # *? -> chaque nom se réduit à 1 caractère
```

Mesuré : `MapsElations` est capturé `M`. Ce patch satisfait tous les exemples Unicode **et** transforme 7 noms fantômes en **tous les noms fantômes** — strictement pire que le bug. Leur diagnostic est bon, leur remède non ; c'est pourquoi je livre le correctif ici plutôt que de le leur renvoyer. Ils avaient également manqué `_NS_OPEN_RE` / `_NS_CLOSE_RE`, qui portent le même défaut : `namespace imbriqué` (réel, dans `Conway.Doomsday`) ouvrait `imbriqu`. La pile reste **équilibrée** — `end imbriqué` tronque à l'identique, donc push et pop s'accordent, ce qui est exactement pourquoi c'est passé inaperçu — mais chaque déclaration **à l'intérieur** héritait d'un préfixe que Lean ne connaît pas.

### Rayon mesuré, commande reproductible

Scan des **409** fichiers `.lean` à nous (`git ls-files '*.lean'` moins `.lake/packages/`, `_peters/`, `reference_docs/`, `foundry-lib/lib/`), ancien motif contre nouveau :

```
== SILENT MISS  (jamais énuméré → jamais vérifié) : 4
   π                sensitivity_lean/Sensitivity/Hypercube.lean          (+ _en)
   ε                sensitivity_lean/Sensitivity/VectorSpace.lean        (+ _en)
== TRUNCATED : 4
   parseRLE     -> parseRLE!       conway_lean/Conway/Life/RLE.lean      (+ _en)   <- ALIAS, câblé
   dualBases_e_ -> dualBases_e_ε   sensitivity_lean/Sensitivity/VectorSpace.lean (+ _en)
== NAMESPACE mis-tracké : 1
   imbriqu -> imbriqué             conway_lean/Conway/Doomsday.lean
```

`sensitivity_lean` n'est **pas** câblé au gate (`grep -ln 'lean-axiom' .github/workflows/*.yml` → `lean-conway`, `lean-grothendieck`, `lean-knot` seulement), donc ses 6 sites sont **latents, pas des rouges actuels** — je le dis parce que la version courte « 9 sites cassés » serait plus impressionnante et fausse.

### Tests — 5 ajoutés, 4 falsifiés contre l'ancien code

```
$ cd MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests && python -m pytest tests/ -q
657 passed in 4.94s
```

Contre les **anciennes** regex, avec les nouveaux tests en place :

```
FAILED test_enumeration_keeps_subscripts_and_suffixed_names
  'Sporadic.L34.mapsElations' != 'Sporadic.L34.mapsElations₂_gen1'
FAILED test_enumeration_sees_names_starting_with_a_greek_letter
  ['Sens.dualBases_e_'] != ['Sens.π', 'Sens.ε', 'Sens.dualBases_e_ε']   # 2 des 3 disparaissent
FAILED test_enumeration_bang_variant_is_not_aliased_onto_its_sibling
  ['…parseRLE', '…parseRLE'] != ['…parseRLE', '…parseRLE!']
FAILED test_enumeration_tracks_an_accented_namespace
  ['imbriqu.inside', 'after'] != ['imbriqué.inside', 'after']
```

Le cinquième, `test_enumeration_name_quantifier_stays_greedy`, **passe déjà sur l'ancien code** : ce n'est pas une reproduction de bug mais un **garde anti-régression** contre le correctif paresseux ci-dessus. Je le signale parce qu'un test qui passe des deux côtés ne prouve rien du correctif, et le compter comme preuve serait de la complaisance.

## Ce que la PR ne change pas — vérifiable

**Partie 1 : aucun verdict ne bouge.** Le sélecteur n'est atteint que **dans** la branche d'impression existante `if result.get("error"):`, et `module_ok = result["success"]` est inchangé. Un gate qui rougissait rougit encore, à l'identique.

**Partie 2 : les verdicts bougent, et c'est le but.** Mesuré en diffant les **captures** de l'ancienne et de la nouvelle regex sur les quatre lakes (l'axe qui compte pour le mode ALIAS : la ligne *matche* des deux côtés, c'est le **nom capturé** qui diffère) :

| Lake | Câblé | Déclarations | Captures divergentes | Détail |
|---|---|---|---|---|
| `conway_lean` | **oui** | 609 | **2** | `parseRLE!` → `parseRLE` — `RLE.lean:199` + `RLE_en.lean:196` (paire FR/EN), **un seul nom distinct** |
| `grothendieck_lean` | oui | 169 | 0 | — |
| `knot_lean` | oui | 138 | 0 | — |
| `sensitivity_lean` | **non** | 32 | 6 | `ε` / `π` invisibles (SILENT MISS), `dualBases_e_ε` tronqué (LOUD PHANTOM) |

Sur les lakes câblés, la **seule** addition est donc `Conway.Life.RLE.parseRLE!` — un nom que l'ancienne classe `[A-Za-z0-9_'.]*` tronquait en `parseRLE`, c'est-à-dire attribuait silencieusement à **l'autre déclaration du même module**. Sa clôture est vérifiée pour la première fois : si elle portait un axiome interdit, ce merge **le révélerait**. `proof-integrity (conway_lean)` sur cette PR est donc la mesure qui compte, et c'est bien ce qu'on veut d'un gate.

Corollaire à ne pas se cacher : les 6 sites de `sensitivity_lean` restent **hors mesure**, ce lake n'étant pas appelant de `lean-axiom.yml`. Le vert de cette PR ne les couvre pas — c'est l'argument de câblage, suivi séparément.

**Aucun fichier `.lean` touché**, donc `grep -c sorry` inaffecté (§B.1 sans objet ici).

## Effet immédiat sur #10486 — le rebase devient porteur

`lean-galois.yml` appelle `uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main` : le heredoc de reporting vient donc de `main` dès ce merge, mais `lean_server.py` — où vivent **le sélecteur et les regex** — vient du **checkout de la branche appelante**.

| Geste de po-2026 | Ce que fait le job |
|---|---|
| **rebase sur `main`** puis re-run | les regex Unicode s'appliquent → `mapsElations₂_gen1` résout → **la cause disparaît**, le gate passe |
| re-run **sans rebase** | ancien énumérateur → mêmes 7 fantômes → **toujours rouge** |

C'est un **durcissement** de ce que je leur ai écrit deux fois. Dans `msg-20260811T195318-85uga5` j'avais dit qu'un simple re-run suffirait : faux. Puis, au commit précédent de cette PR, j'ai écrit que le rebase n'améliorait que le **log** : vrai à ce moment-là, dépassé maintenant. Avec la partie 2, **le rebase est ce qui rend leur PR verte** — il ne documente plus le problème, il le supprime.

Deuxième correction du même DM : le marqueur canonique s'appelle **`_ERROR_MARKER_RE`** et vit dans **`lean_server.py`**, pas `_ERROR_RE` dans le workflow. J'ai greppé le workflow pour `_ERROR_RE` avant de l'affirmer : zéro occurrence. Le nom que je leur ai donné n'existe pas.

## Discipline de variation — mon propre organe m'a signalé, je l'écris

`guard` est de classe **META** : aucun tier n'en fait un plat principal G-VAR-1 ([variation-protocol](.claude/rules/variation-protocol.md)). Cette PR **ne tient pas** le plancher de mon cycle, et #10484 (MED/`tooling`) ne le tenait pas non plus.

Et le signal advisory de cette PR est explicite, tally à l'appui : `declared=2 genre=4 cap=1` pour `myia-ai-01:CoursIA`. Ma lane est à **4× le cap** de genre LIGHT du jour. J'avais la partie 2 prête dans une **branche séparée**, prête à devenir une seconde PR `guard` : c'eût été 5. Je l'ai **repliée ici** — un grain au lieu de deux, sur une lane que mon propre organe déclare saturée. C'est la décision que j'imposerais à un worker, donc je me l'impose.

Ce que ce cas révèle, et qui manque au protocole : les caps gouvernent le **choix** d'un grain, pas la **levée d'un blocage qu'on a soi-même causé**. Tenir ce correctif pour respecter un quota de variété laisserait le grain DEEP/`lean` de po-2026 rouge à cause de mon bug — le compteur commanderait au dépôt. Je porte cet angle dans #10488 avec l'autre amendement de même nature (les caps gouvernent l'*ouverture* d'une poche, pas l'achèvement d'un lot déjà réclamé). Le plancher CONTENU de mon cycle est tenu ailleurs : PT-05 RLVR, exécuté pour de vrai sur GPU 2.

