### PR TITLE
docs(pr-gate,#10435): correct stale header + document IN_PROGRESS handling + pin stale-rollup recovery

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -22,9 +22,20 @@ name: PR gate
 #
 # Enabling it is a repository-settings change and therefore owner-only:
 #   Settings > Branches > main > Require status checks > add "PR gate"
-# Until that flip, this job is informative rather than blocking -- which is
-# precisely the half that does not need the owner, delivered so the flip is a
-# one-click action instead of a design problem.
+#
+# Status (measured firsthand 2026-08-11, issue #10435): the flip has happened.
+# `PR gate` is now a **required** status check on `main` -- a PR with `PR gate`
+# as the only non-SUCCESS check reports `BLOCKED`, not `UNSTABLE`. This is why
+# the stale-rollup defect (#10435) hurts: a required check that never
+# re-aggregates after a guard it depends on flips green leaves the PR BLOCKED
+# until a manual rerun (~180 merges/day, not tenable). The structural fix
+# (re-aggregate on guard completion via `workflow_run`) is non-trivial -- a
+# `workflow_run`-triggered job posts its check-run on the workflow's default
+# branch commit, NOT on the PR head SHA, so it is invisible to `gh pr checks`
+# and to mergeState until the job also POSTS a check-run onto the PR head SHA
+# via the Checks API. That posting step is deliberately deferred to a follow-up
+# grain (it needs `actions: write` and a posting script); this file documents
+# the gap rather than papering over it.
 
 on:
   pull_request:

--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -323,6 +323,19 @@ def classify(
     what they actually reported -- and never reach `pending` or `bad`. They are
     kept separate rather than merged into `ok` so a caller can print "advisory
     X failed" instead of silently rewriting a failure into a pass.
+
+    Treatment of an IN_PROGRESS / QUEUED check (issue #10435, acceptance 2) --
+    a *required* check still in flight is treated exactly like an advisory in
+    flight: it lands in ``pending`` and the wait loop in ``wait_and_decide``
+    keeps polling until it reaches a terminal conclusion. The verdict returned
+    before the wait budget runs out is therefore "timed out waiting for
+    <name>", not "FAIL -- failing checks" (see ``verdict``). This choice --
+    bounded wait rather than re-queue or deferred verdict -- is what makes a
+    stale rollup recoverable by a plain ``gh run rerun``: the next run re-polls,
+    sees the now-terminal check, and settles. The defect #10435 documents is
+    NOT that classify mishandles in-flight checks (it waits on them correctly)
+    but that the *workflow trigger* never asks it to look again -- that trigger
+    fix lives in pr-gate.yml, not here.
     """
     pending: list[str] = []
     bad: list[str] = []

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -575,3 +575,45 @@ def test_fork_short_circuit_skips_the_canary(monkeypatch):
     monkeypatch.setattr(pr_gate, "derive_always_on_jobs", explode)
     code = pr_gate.main(["--repo", "o/r", "--sha", "deadbeef", "--is-fork"])
     assert code == 0
+
+
+# --- stale rollup recovery (issue #10435, acceptance 3) ----------------------
+#
+# The defect #10435 documents is structural at the *workflow trigger* level
+# (pr-gate.yml never re-aggregates after a guard it depends on flips green, so
+# a PR stays BLOCKED until a manual `gh run rerun`). But the recovery mechanism
+# a rerun exploits is a PROPERTY of classify/verdict that must not silently
+# change: a required check that was in flight (pending) on the first rollup
+# must, on the re-rollup, be seen as settled-green and flip the verdict from
+# FAIL (timed out) to PASS -- WITHOUT a new commit push. This pins exactly that
+# scenario, which is what makes the manual rerun (and any future workflow_run
+# trigger) sufficient to unblock the PR.
+
+
+def test_inflight_required_check_settles_to_pass_on_reroll():
+    """A required check pending on rollup 1 settles green on rollup 2 -> PASS.
+
+    Mirrors the #10435 scenario: `Require Grain tag` (a required, non-advisory
+    guard) was IN_PROGRESS when the first PR-gate run aggregated, so the run
+    either timed out on it or (more commonly, since the tag was genuinely
+    missing) saw it fail. After the tag is edited into the body, the guard
+    re-runs and completes `success`. A `gh run rerun` of PR gate re-aggregates
+    the CURRENT check set: the same guard name now reports conclusion=success,
+    and classify must route it to `ok`, yielding verdict PASS -- no commit push
+    intervening.
+    """
+    name = "Require Grain tag (block on absent, ..."
+    inflight = run(name, conclusion=None, status="in_progress", rid=10)
+    settled_green = run(name, conclusion="success", status="completed", rid=11)
+
+    # Rollup 1: guard still in flight -> pending -> verdict timed out (FAIL).
+    pending1, bad1, ok1, _adv = pr_gate.classify([inflight], pr_gate.DEFAULT_SELF_NAME)
+    assert pending1 == [name] and not bad1 and not ok1
+    code1, _msg1 = pr_gate.verdict(pending1, bad1, settled=False)
+    assert code1 == 1
+
+    # Rollup 2 (rerun, no new commit): same guard now completed+success -> ok.
+    pending2, bad2, ok2, _adv = pr_gate.classify([settled_green], pr_gate.DEFAULT_SELF_NAME)
+    assert not pending2 and not bad2 and ok2 == [name]
+    code2, _msg2 = pr_gate.verdict(pending2, bad2, settled=True)
+    assert code2 == 0


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2023:CoursIA — prev: LIGHT/tooling #10445

# docs(pr-gate,#10435): correct stale header + document IN_PROGRESS handling + pin stale-rollup recovery

## Quoi

Le défaut #10435 (mesuré 3× dans la nuit 2026-08-11, et vécu encore ce cycle sur #10481) : `PR gate` garde un `FAILURE` périmé quand un check requis passe au vert **après** son agrégation — et comme il est désormais *required*, la PR reste `BLOCKED` jusqu'à un `gh run rerun` manuel. J'ai subi exactement ça sur #10481 ce cycle (body edit Grain → guards `edited` re-PASS → `PR gate` stale FAIL → rerun manuel → CLEAN).

Cette PR livre **2 des 4 acceptance** de #10435 qui sont self-contained et testables, et documente honnêtement les 2 autres (gap structurel nécessitant un mécanisme plus large).

## Livré (acceptance 2, 3, 4)

- **Acceptance 4 (en-tête périmé)** : `pr-gate.yml` clamait « this job is informative rather than blocking » (vrai le 2026-08-07 à l'authoring). **Faux aujourd'hui** : le owner a flippé le check en *required* sur `main`. Un organe qui se documente comme non-bloquant alors qu'il bloque induit en erreur. En-tête corrigé avec le statut mesuré firsthand (2026-08-11) + pointeur vers le défaut structurel.

- **Acceptance 2 (IN_PROGRESS explicite)** : docstring de `classify()` documente désormais le traitement d'un check requis en vol → atterrit dans `pending`, le wait loop polle jusqu'à terminal, verdict pré-budget = « timed out waiting for <name> » (pas « FAIL -- failing checks »). Ce choix (bounded wait, pas re-queue ni verdict différé) est **ce qui rend un rollup stale récupérable par un simple `gh run rerun`**. Le défaut #10435 n'est PAS que `classify` gère mal les checks en vol (il les attend correctement) — c'est que le *trigger* workflow ne lui demande jamais de regarder à nouveau.

- **Acceptance 3 (test régression)** : `test_inflight_required_check_settles_to_pass_on_reroll` pinne le scénario exact — un guard requis `in_progress` sur le rollup 1 (verdict timed-out FAIL), puis le **même** guard `completed`+`success` sur le rerun (**sans push de commit**) → verdict PASS. C'est la propriété dont tout futur trigger `workflow_run` dépendra ; la pinner protège contre un refactor qui casserait silencieusement la récupération.

## Documenté comme gap (acceptance 1, non livrée — trop large pour ce grain)

- **Acceptance 1 (re-aggregate on guard completion)** : le trigger `workflow_run` sur "Variation Tag Guard" / "Grain tag conformity" completed est l'option prescrite par l'issue. **Mais** un job `workflow_run` poste son check-run sur le commit de la branche par défaut (main), **pas sur le PR head SHA** → invisible à `gh pr checks` et à `mergeState` tant que le job ne poste pas **aussi** un check-run sur le PR head SHA via la Checks API (nécessite `actions: write` + un script de posting). Cette subtilité n'est pas adressée par le body de l'issue. Plutôt que de pousser un trigger qui crée des checks fantômes sur `main`, le gap est documenté dans l'en-tête `pr-gate.yml` et laissé à un grain dédié (portée API + permissions).

## Preuve

- **40/40 tests passent** (39 existants + 1 nouveau).
- Le nouveau test pinne la transition pending→ok (pas le trigger, qui est un comportement CI). Avant ce test, aucune garde-fou n'empêchait un refactor de `classify` de casser la récupération stale-rollup.
- `pr-gate.yml` YAML valide (`yaml.safe_load` OK). Job `gate` inchangé (uniquement l'en-tête + commentaire de gap).

## Non-regression

Le job `gate` lui-même est **byte-identique** à main (seul l'en-tête de fichier change). Aucun comportement d'exécution modifié — cette PR est de la documentation + 1 test pin. Le trigger `workflow_run` a été prototypé puis **revert** (checks fantômes sur main) : le diff final ne contient que l'en-tête corrigé + le docstring + le test.

See #10435 · See #10433 (doublon, focus Grain seulement) · See #9819 (pourquoi PR gate est le seul check requerrable) · See #10072 (fork exemption préservée)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
