### PR TITLE
feat(twin,#10382): bridge_verdict SOTA-OK for Z3-Python-01 Introduction (pyz3/Microsoft.Z3 native)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/z3-python-01-introduction.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-01-introduction.yaml
@@ -3,11 +3,19 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Z3 EST le moteur SOTA SMT, branche NATIVEMENT des deux cotes : Microsoft.Z3 (NuGet officiel, `#r \"nuget: Microsoft.Z3\"` + `using Microsoft.Z3;`, API Context ctx.MkSolver/MkConst) et pyz3 (pip z3-solver, `from z3 import *`, API fonctionnelle Solver()/Int()) sont les deux bindings de la meme lib C++ Z3 sous-jacente — pas un pont intermediaire type IKVM/PythonNet. Parite firsthand sur le concept central (SMT de base, contrainte insatisfiable) cellule 5 des deux notebooks : Python pyz3 `s.check() -> unsat` (x>5 ET x<3) == C# Microsoft.Z3 `s.check() -> UNSATISFIABLE`, meme verdict du meme moteur. Aucune asymetrie de machinerie a corriger."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 1dce7f1d5495aacad37cdac4fd21f9d211589840
       csharp_sha: 8b10f3c8fd958afee15f332405689369d26bd71c
+    - date: "2026-08-11"
+      by: myia-po-2026:CoursIA
+      python_sha: 1dce7f1d5495aacad37cdac4fd21f9d211589840
+      csharp_sha: 8b10f3c8fd958afee15f332405689369d26bd71c
+      content_python_sha: f9c0451a32a8ca918b8a29c77f1b11fa619edfb703b1d1cf3f9d9f8b595c2fe2
+      content_csharp_sha: c827d60dbec7329c60a8fe3d40deb650b3be384767a07d26dfbe3b253e13ab87
   known_differences:
     - "Python : pyz3 (z3-solver), `from z3 import *`, API fonctionnelle (Solver(), Int('x'), s.check() -> sat/unsat)."
     - "C# : Microsoft.Z3 .NET, `using Microsoft.Z3;`, API orientee Context (ctx.MkSolver(), ctx.MkConst(...), Status.TRUE)."


### PR DESCRIPTION
Quoi: Add `bridge_verdict: SOTA-OK` to the Z3-Python-01 Introduction twin shard. Z3 is the SOTA SMT engine, branched NATIVELY on both sides (Microsoft.Z3 NuGet + pyz3 = the two bindings of the same C++ Z3 library), so there is no intermediate bridge to build (no IKVM/PythonNet).

Preuve: Firsthand parity on the central concept (basic SMT, unsatisfiable constraint) cell 5 of both notebooks — Python pyz3 `s.check() -> unsat` (x>5 AND x<3) == C# Microsoft.Z3 `s.check() -> UNSATISFIABLE`, same verdict from the same engine. Both notebooks verified present on main (37708 + 20973 bytes). Audit entry rebaselined via `check_twin_parity.py --update` (content_python_sha + content_csharp_sha). `--check --ci-strict`: 157 pairs, drift_content=0.

Perimetre: 1 shard only (+8 lines, pure additive). No notebook source touched. Mirrors the ratified z3-python-03 pattern (PR #10477, MERGED). Advances EPIC #10382 native-both fleet (22 → 23 pairs with bridge_verdict).

Grain: MED/twin -- lane myia-po-2026:CoursIA

## Summary

Adds `bridge_verdict: SOTA-OK` + `bridge_verdict_reason` to `scripts/notebook_tools/twin_pairs.d/z3-python-01-introduction.yaml`, plus a rebaselined audit entry (2026-08-11, myia-po-2026:CoursIA) with content SHAs.

**Why SOTA-OK by construction:** Z3 IS the SOTA SMT solver. The Python notebook uses pyz3 (`from z3 import *`, `Solver()`, `Int('x')`); the C# notebook uses Microsoft.Z3 (`#r "nuget: Microsoft.Z3"`, `using Microsoft.Z3;`, `ctx.MkSolver()`). Both are first-party bindings to the **same C++ Z3 library** — there is no intermediate bridge layer (unlike IKVM/PythonNet cases). Each language talks to the engine natively. The parity is therefore structural: same engine, same verdict.

**Firsthand parity evidence (cell 5, both notebooks):**
- Python (pyz3): `s.check() -> unsat` on `x > 5 AND x < 3` (+ unsat core via `assert_and_track`)
- C# (Microsoft.Z3): `s.check() -> UNSATISFIABLE`

Same unsat verdict from the same Z3 engine. No machinery asymmetry to correct.

## Verification

- `check_twin_parity.py --update --pair "Z3-Python-01 Introduction" --by "myia-po-2026:CoursIA"` → 1 pair rebaselined.
- `check_twin_parity.py --check --ci-strict` → 157 pairs, drift_blob=0, drift_content=0 (the single INFO line is a pre-existing metadata-only drift on Sudoku-14, unrelated, does not fail the gate).

See #10382
