### PR TITLE
feat(genai,#10493): notebook auditer un serveur MCP — classifier CRUD vs verbes metier

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/.env.example
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/.env.example
@@ -54,3 +54,25 @@ EVAL_MODEL=
 # verdict d'echec qui ne mesure que sa propre configuration.
 #
 # Sur un modele sans raisonnement, 500 suffisent et le banc va plus vite.
+
+# ============================================================================
+# SECTION 3 : Catalogue MCP pour auditer-un-serveur-mcp.ipynb (OPTIONNEL)
+# ============================================================================
+#
+# Ce notebook audite le catalogue d'outils d'un serveur MCP. Par defaut, il
+# travaille sur un catalogue synthetique embarque (la Maison Valmont) et
+# n'a besoin de RIEN : ni reseau, ni cle, ni .env. C'est dans cet etat qu'il
+# est execute dans le depot, et ses sorties sont reproductibles telles quelles.
+#
+# Pour auditer un VRAI serveur MCP (le votre, AI-Engine ou autre), renseigner
+# l'URL de l'endpoint qui retourne le catalogue d'outils au format JSON :
+# une liste d'objets {name, description, inputSchema}. Le notebook fait un
+# GET avec un en-tete Authorization: Bearer <token>.
+#
+# Exemple pour une install AI-Engine :
+#   MCP_TOOL_CATALOG_URL=https://votre-installation.fr/wp-json/mcp/v1/tools
+#   MCP_TOOL_TOKEN=le_jeton_bearer_de_l_install
+#
+# Laisser les deux vides pour garder le catalogue synthetique.
+MCP_TOOL_CATALOG_URL=
+MCP_TOOL_TOKEN=

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
@@ -77,6 +77,15 @@ naïf (taille fixe) à un chunking structuré (par chapitre) et montre que la
 dégradation du retrieval vient du découpage, pas du modèle d'embeddings —
 démontré avec un vectoriseur TF-IDF déterministe, sans clé d'API.
 
+Un troisième notebook [`auditer-un-serveur-mcp.ipynb`](auditer-un-serveur-mcp.ipynb)
+est le compagnon exécutable du Parcours 3 (WordPress comme serveur MCP). Il
+convertit en **mesure reproductible** la leçon centrale du dossier — *un
+serveur MCP utile expose les verbes du métier, pas les tables de la base* :
+étant donné le catalogue d'outils d'un serveur, il classe chaque outil en
+CRUD générique ou verbe métier et mesure sa distance au schéma de
+persistance. Le catalogue audité est synthétique (Maison Valmont) ; un
+chemin live optionnel permet de le rejouer sur son propre serveur via `.env`.
+
 ---
 
 ## Sections
@@ -188,6 +197,8 @@ attendues.
   banc d'évaluation reproductible, cinq propriétés discriminantes
 - [`ingestion-corpus-long-rag.ipynb`](ingestion-corpus-long-rag.ipynb) —
   ingestion RAG d'un corpus long structuré, chunking naïf vs par chapitre
+- [`auditer-un-serveur-mcp.ipynb`](auditer-un-serveur-mcp.ipynb) —
+  classifier CRUD générique vs verbes métier, mesurer la distance au schéma
 - Epic [#4433](https://github.com/jsboige/CoursIA/issues/4433) —
   refonte pédagogique GenAI (ce parcours en est une extension)
 - Issue [#9734](https://github.com/jsboige/CoursIA/issues/9734) —

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/auditer-un-serveur-mcp.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/auditer-un-serveur-mcp.ipynb
@@ -1,0 +1,709 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0bde6250",
+   "metadata": {},
+   "source": [
+    "# Auditer un serveur MCP qu'on n'a pas ecrit\n",
+    "\n",
+    "*Classifier les outils d'un catalogue MCP en CRUD generique vs verbes metier,\n",
+    "et mesurer la distance de chaque outil au schema de persistance. Recycle la\n",
+    "documentation du projet LivresAgites (en sommeil) vers le depot pedagogique\n",
+    "[CoursIA](https://github.com/jsboige/CoursIA). Aucune donnee du site observe\n",
+    "n'est reproduite : le catalogue est **entierement synthetique** (Maison\n",
+    "Valmont).*\n",
+    "\n",
+    "## La these\n",
+    "\n",
+    "> **Un serveur MCP utile expose les verbes du metier, pas les tables de la\n",
+    "> base.**\n",
+    "\n",
+    "Cette these est facile a proclamer et difficile a verifier. Un catalogue MCP\n",
+    "melange deux natures d'outils sans les etiqueter :\n",
+    "\n",
+    "- du **CRUD generique** (creer / lire / mettre a jour / supprimer des rangees\n",
+    "  de tables), qui donne a l'agent un pouvoir maximal et une comprehension\n",
+    "  minimale ;\n",
+    "- des **verbes metier** (soumettre, assigner, faire passer d'un statut a un\n",
+    "  autre), qui restreignent le geste possible et y attachent le sens.\n",
+    "\n",
+    "Les distinguer a l'oeil sur 90 outils est fastidieux et subjectif. Ce notebook\n",
+    "construit la **mesure** : etant donne le `inputSchema` d'un outil, on estime sa\n",
+    "*distance au schema de persistance* — un CRUD ressemble a une ligne de table,\n",
+    "un verbe metier non. La separation en deux clusters est le resultat cherché.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a47d6507",
+   "metadata": {},
+   "source": [
+    "## Le catalogue de l'atelier : Maison Valmont\n",
+    "\n",
+    "Maison Valmont est une **maison d'edition fictive** qui tourne sur un CMS\n",
+    "generique. Son serveur MCP expose deux couches d'outils :\n",
+    "\n",
+    "| Couche | Prefixe | Nature | Exemples |\n",
+    "|--------|---------|--------|----------|\n",
+    "| Plateforme (CMS + boutique) | `cms_`, `store_` | CRUD sur les tables | `cms_create_post`, `store_list_orders` |\n",
+    "| Metier editorial | `valmont_` | Verbes du workflow | `valmont_submit_manuscript`, `valmont_assign_reviewer` |\n",
+    "\n",
+    "La couche plateforme decrit le **CMS** ; la couche metier decrit\n",
+    "l'**edition**. Un agent qui n'aurait que la premiere devrait reconstituer la\n",
+    "logique editoriale a coups de requetes sur des tables — fragile et dangereux.\n",
+    "\n",
+    "> **Note de methode.** Ce catalogue est synthetique. Aucun outil, aucun nom de\n",
+    "> domaine, aucune prose ne provient d'une installation reelle. Pour auditer\n",
+    "> **votre** serveur MCP (AI-Engine ou autre), renseigner `MCP_TOOL_CATALOG_URL`\n",
+    "> dans `.env` — voir le fichier `.env.example`. Sans `.env`, le notebook\n",
+    "> utilise le catalogue embarque ci-dessous.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7ffc3a2b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T20:24:49.871288Z",
+     "iopub.status.busy": "2026-08-11T20:24:49.871288Z",
+     "iopub.status.idle": "2026-08-11T20:24:49.887674Z",
+     "shell.execute_reply": "2026-08-11T20:24:49.887153Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Catalogue synthetique Maison Valmont : 22 outils.\n",
+      "Total charge : 22 outils.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#dependances : stdlib uniquement (json, re, urllib). Aucun reseau requis.\n",
+    "import json, re, os\n",
+    "from collections import Counter\n",
+    "from urllib.request import Request, urlopen\n",
+    "from urllib.error import URLError\n",
+    "\n",
+    "# --- Chargement du catalogue --------------------------------------------\n",
+    "# Deux sources, dans cet ordre :\n",
+    "#   1. Un endpoint live (optionnel) declare dans .env.\n",
+    "#   2. Le catalogue synthetique Maison Valmont embarque (defaut).\n",
+    "#\n",
+    "# On execute sur le defaut : aucun .env dans le depot, donc aucune donnee\n",
+    "# d'installation reelle n'entre dans les sorties committees.\n",
+    "\n",
+    "def charger_catalogue():\n",
+    "    url = os.environ.get(\"MCP_TOOL_CATALOG_URL\", \"\").strip()\n",
+    "    if url:\n",
+    "        token = os.environ.get(\"MCP_TOOL_TOKEN\", \"\").strip()\n",
+    "        headers = {\"Accept\": \"application/json\"}\n",
+    "        if token:\n",
+    "            headers[\"Authorization\"] = f\"Bearer {token}\"\n",
+    "        try:\n",
+    "            req = Request(url, headers=headers)\n",
+    "            with urlopen(req, timeout=10) as r:\n",
+    "                data = json.loads(r.read().decode(\"utf-8\"))\n",
+    "            print(f\"Catalogue charge depuis {url} : {len(data)} outils.\")\n",
+    "            return normaliser(data)\n",
+    "        except (URLError, ValueError, OSError) as e:\n",
+    "            print(f\"Endpoint live injoignable ({e}). Bascule sur le fixture.\")\n",
+    "    print(f\"Catalogue synthetique Maison Valmont : {len(CATALOGUE_VALMONT)} outils.\")\n",
+    "    return normaliser(CATALOGUE_VALMONT)\n",
+    "\n",
+    "def normaliser(outils_bruts):\n",
+    "    \"\"\"Unifie le format : {name, description, params (dict name->type)}.\"\"\"\n",
+    "    out = []\n",
+    "    for o in outils_bruts:\n",
+    "        schema = o.get(\"inputSchema\", {}) or {}\n",
+    "        props = schema.get(\"properties\", {}) or {}\n",
+    "        params = {p: meta.get(\"type\", \"?\") for p, meta in props.items()}\n",
+    "        out.append({\n",
+    "            \"name\": o.get(\"name\", \"?\"),\n",
+    "            \"description\": o.get(\"description\", \"\"),\n",
+    "            \"params\": params,\n",
+    "        })\n",
+    "    return out\n",
+    "\n",
+    "CATALOGUE_VALMONT = [\n",
+    "    # --- Couche plateforme : CRUD generique (CMS + boutique) ---\n",
+    "    {\"name\": \"cms_create_post\", \"description\": \"Creer un article.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"title\": {\"type\": \"string\"}, \"content\": {\"type\": \"string\"},\n",
+    "        \"status\": {\"type\": \"string\"}, \"author_id\": {\"type\": \"integer\"},\n",
+    "        \"slug\": {\"type\": \"string\"}, \"excerpt\": {\"type\": \"string\"},\n",
+    "        \"date\": {\"type\": \"string\"}, \"categories\": {\"type\": \"array\"},\n",
+    "        \"tags\": {\"type\": \"array\"}}}},\n",
+    "    {\"name\": \"cms_update_post\", \"description\": \"Modifier un article.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"post_id\": {\"type\": \"integer\"}, \"title\": {\"type\": \"string\"},\n",
+    "        \"content\": {\"type\": \"string\"}, \"status\": {\"type\": \"string\"},\n",
+    "        \"slug\": {\"type\": \"string\"}}}},\n",
+    "    {\"name\": \"cms_get_post\", \"description\": \"Lire un article.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\"post_id\": {\"type\": \"integer\"}}}},\n",
+    "    {\"name\": \"cms_list_posts\", \"description\": \"Lister les articles.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"status\": {\"type\": \"string\"}, \"author_id\": {\"type\": \"integer\"},\n",
+    "        \"limit\": {\"type\": \"integer\"}, \"offset\": {\"type\": \"integer\"},\n",
+    "        \"order\": {\"type\": \"string\"}}}},\n",
+    "    {\"name\": \"cms_delete_post\", \"description\": \"Supprimer un article.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"post_id\": {\"type\": \"integer\"}, \"force\": {\"type\": \"boolean\"}}}},\n",
+    "    {\"name\": \"cms_list_users\", \"description\": \"Lister les comptes.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"role\": {\"type\": \"string\"}, \"limit\": {\"type\": \"integer\"},\n",
+    "        \"offset\": {\"type\": \"integer\"}}}},\n",
+    "    {\"name\": \"cms_get_user\", \"description\": \"Lire un compte.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\"user_id\": {\"type\": \"integer\"}}}},\n",
+    "    {\"name\": \"cms_list_media\", \"description\": \"Lister les medias.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"limit\": {\"type\": \"integer\"}, \"offset\": {\"type\": \"integer\"},\n",
+    "        \"mime_type\": {\"type\": \"string\"}}}},\n",
+    "    {\"name\": \"store_create_product\", \"description\": \"Creer un produit.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"name\": {\"type\": \"string\"}, \"sku\": {\"type\": \"string\"},\n",
+    "        \"price\": {\"type\": \"number\"}, \"stock\": {\"type\": \"integer\"},\n",
+    "        \"description\": {\"type\": \"string\"}, \"categories\": {\"type\": \"array\"},\n",
+    "        \"weight\": {\"type\": \"number\"}}}},\n",
+    "    {\"name\": \"store_update_product\", \"description\": \"Modifier un produit.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"product_id\": {\"type\": \"integer\"}, \"name\": {\"type\": \"string\"},\n",
+    "        \"price\": {\"type\": \"number\"}, \"stock\": {\"type\": \"integer\"}}}},\n",
+    "    {\"name\": \"store_list_orders\", \"description\": \"Lister les commandes.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"status\": {\"type\": \"string\"}, \"customer_id\": {\"type\": \"integer\"},\n",
+    "        \"limit\": {\"type\": \"integer\"}, \"offset\": {\"type\": \"integer\"}}}},\n",
+    "    {\"name\": \"store_get_order\", \"description\": \"Lire une commande.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\"order_id\": {\"type\": \"integer\"}}}},\n",
+    "    # --- Couche metier : verbes du workflow editorial ---\n",
+    "    {\"name\": \"valmont_submit_manuscript\", \"description\": \"Deposer un manuscrit.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"author_id\": {\"type\": \"integer\"}, \"title\": {\"type\": \"string\"},\n",
+    "        \"genre\": {\"type\": \"string\"}, \"synopsis\": {\"type\": \"string\"},\n",
+    "        \"manuscript_file\": {\"type\": \"string\"}}}},\n",
+    "    {\"name\": \"valmont_assign_reviewer\", \"description\": \"Assigner un relecteur.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"manuscript_id\": {\"type\": \"integer\"}, \"reviewer_id\": {\"type\": \"integer\"}}}},\n",
+    "    {\"name\": \"valmont_submit_reading_report\", \"description\": \"Deposer un rapport de lecture.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"manuscript_id\": {\"type\": \"integer\"}, \"reviewer_id\": {\"type\": \"integer\"},\n",
+    "        \"decision\": {\"type\": \"string\", \"enum\": [\"favorable\", \"reserve\", \"defavorable\"]},\n",
+    "        \"comment\": {\"type\": \"string\"}}}},\n",
+    "    {\"name\": \"valmont_transition_manuscript\", \"description\": \"Faire passer un manuscrit de statut.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"manuscript_id\": {\"type\": \"integer\"}, \"from_status\": {\"type\": \"string\"},\n",
+    "        \"to_status\": {\"type\": \"string\"}}}},\n",
+    "    {\"name\": \"valmont_get_pending_decisions\", \"description\": \"Decisions en attente du comite.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\"committee_id\": {\"type\": \"integer\"}}}},\n",
+    "    {\"name\": \"valmont_get_manuscripts\", \"description\": \"Lister les manuscrits.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"status\": {\"type\": \"string\"}, \"author_id\": {\"type\": \"integer\"},\n",
+    "        \"limit\": {\"type\": \"integer\"}, \"offset\": {\"type\": \"integer\"}}}},\n",
+    "    {\"name\": \"valmont_request_prereading\", \"description\": \"Demander une prelecture assistee.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"manuscript_id\": {\"type\": \"integer\"}, \"environment\": {\"type\": \"string\"}}}},\n",
+    "    {\"name\": \"valmont_notify_author\", \"description\": \"Notifier l'autrice d'un evenement.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"manuscript_id\": {\"type\": \"integer\"}, \"event\": {\"type\": \"string\"}}}},\n",
+    "    {\"name\": \"valmont_query_catalog\", \"description\": \"Interroger le catalogue indexe.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"query\": {\"type\": \"string\"}, \"environment\": {\"type\": \"string\"},\n",
+    "        \"k\": {\"type\": \"integer\"}}}},\n",
+    "    {\"name\": \"valmont_get_processing_status\", \"description\": \"Etat du pipeline d'un manuscrit.\",\n",
+    "     \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "        \"manuscript_id\": {\"type\": \"integer\"},\n",
+    "        \"pipeline_stage\": {\"type\": \"string\",\n",
+    "            \"enum\": [\"extraction\", \"chunking\", \"indexing\", \"prereading\"]}}}},\n",
+    "]\n",
+    "\n",
+    "OUTILS = charger_catalogue()\n",
+    "print(f\"Total charge : {len(OUTILS)} outils.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4706ca1",
+   "metadata": {},
+   "source": [
+    "## Premiere lecture : compter par prefixe\n",
+    "\n",
+    "Le reflexe est de classer par prefixe. Donnons-lui raison sur les comptes,\n",
+    "puis montrons sa limite.\n",
+    "\n",
+    "Le prefixe est un **indice**, pas une **definition**. Un outil prefinance\n",
+    "`valmont_` peut tres bien etre un CRUD degenere ; un outil prefinance `cms_`\n",
+    "peut encapsuler une regle. Verifions.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "28908f48",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T20:24:49.889255Z",
+     "iopub.status.busy": "2026-08-11T20:24:49.889255Z",
+     "iopub.status.idle": "2026-08-11T20:24:49.893978Z",
+     "shell.execute_reply": "2026-08-11T20:24:49.893451Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Outils par prefixe :\n",
+      "  valmont_     10\n",
+      "  cms_         8\n",
+      "  store_       4\n",
+      "\n",
+      "CRUD via prefixe (cms_/store_) : 12 / 22\n",
+      "Metier via prefixe (valmont_)  : 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "def prefixe(nom):\n",
+    "    return nom.split(\"_\", 1)[0] + \"_\"\n",
+    "\n",
+    "comptes = Counter(prefixe(o[\"name\"]) for o in OUTILS)\n",
+    "print(\"Outils par prefixe :\")\n",
+    "for p, n in sorted(comptes.items(), key=lambda kv: -kv[1]):\n",
+    "    print(f\"  {p:<12} {n}\")\n",
+    "\n",
+    "crud_prefixes = {\"cms_\", \"store_\"}\n",
+    "n_via_prefixe = sum(n for p, n in comptes.items() if p in crud_prefixes)\n",
+    "print(f\"\\nCRUD via prefixe (cms_/store_) : {n_via_prefixe} / {len(OUTILS)}\")\n",
+    "print(\"Metier via prefixe (valmont_)  :\", comptes.get(\"valmont_\", 0))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "471aa294",
+   "metadata": {},
+   "source": [
+    "## La vraie question : l'outil parle-t-il la base ou le metier ?\n",
+    "\n",
+    "Compter par prefixe ne dit rien de l'**interieur** d'un outil. Ce qui distingue\n",
+    "un CRUD d'un verbe metier, c'est la **forme de son schema** :\n",
+    "\n",
+    "- un **CRUD** expose les **colonnes** d'une table (beaucoup de champs\n",
+    "  libres : `title`, `content`, `price`, `slug`...). L'agent ecrit la ligne.\n",
+    "- un **verbe metier** encapsule une regle et n'expose que ce que l'appelant\n",
+    "  doit decider (`manuscript_id`, `decision`, `from_status`/`to_status`). La\n",
+    "  regle vit dans l'outil, pas chez l'agent.\n",
+    "\n",
+    "On mesure donc trois signaux tires du `inputSchema` :\n",
+    "\n",
+    "1. **Presence de mots-clés workflow** (`decision`, `reviewer_id`,\n",
+    "   `from_status`, `to_status`, `environment`, `pipeline_stage`...) : un CRUD\n",
+    "   n'en a aucun ; un verbe metier en a presque toujours.\n",
+    "2. **Largeur du schema** : un CRUD create/update est large (5-9 champs\n",
+    "  inscriptibles) ; un verbe metier est etroit (2-4) parce qu'il cache la table.\n",
+    "3. **Identifiant d'entite generique** (`post_id`, `product_id`, `order_id`...) :\n",
+    "   signal CRUD ; un verbe metier reference des concepts metier, pas des row ids.\n",
+    "\n",
+    "On combine ces signaux en un score de **distance au schema de persistance**,\n",
+    "entre 0 (tout-CRUD) et 1 (tout-metier).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4e33fa06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T20:24:49.895028Z",
+     "iopub.status.busy": "2026-08-11T20:24:49.895028Z",
+     "iopub.status.idle": "2026-08-11T20:24:49.902605Z",
+     "shell.execute_reply": "2026-08-11T20:24:49.902605Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classification calculee.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Vocabulaires de reference -----------------------------------------\n",
+    "# Parametres qui sentent la colonne de table (CRUD).\n",
+    "COLONNES = {\n",
+    "    \"title\", \"content\", \"status\", \"slug\", \"excerpt\", \"date\", \"categories\",\n",
+    "    \"tags\", \"role\", \"limit\", \"offset\", \"order\", \"force\", \"mime_type\",\n",
+    "    \"name\", \"sku\", \"price\", \"stock\", \"description\", \"weight\", \"email\",\n",
+    "    # identifiants de row generiques (un CRUD pointe une rangee).\n",
+    "    \"post_id\", \"user_id\", \"product_id\", \"order_id\", \"comment_id\", \"media_id\",\n",
+    "    \"customer_id\", \"term_id\",\n",
+    "}\n",
+    "# Parametres qui sentent le workflow (verbe metier).\n",
+    "WORKFLOW = {\n",
+    "    \"decision\", \"reviewer_id\", \"from_status\", \"to_status\", \"committee_id\",\n",
+    "    \"environment\", \"event\", \"pipeline_stage\", \"genre\", \"synopsis\",\n",
+    "    \"manuscript_file\", \"query\", \"k\", \"manuscript_id\", \"author_id\",\n",
+    "}\n",
+    "VERBES_CRUD = {\"create\", \"update\", \"delete\", \"get\", \"list\", \"set\", \"edit\",\n",
+    "               \"add\", \"remove\", \"fetch\"}\n",
+    "VERBES_METIER = {\"submit\", \"assign\", \"approve\", \"reject\", \"request\",\n",
+    "                 \"transition\", \"notify\", \"query\", \"send\", \"schedule\"}\n",
+    "\n",
+    "def verbe(nom):\n",
+    "    return nom.split(\"_\", 1)[1].split(\"_\")[0].lower() if \"_\" in nom else \"\"\n",
+    "\n",
+    "def signaux(outil):\n",
+    "    params = set(outil[\"params\"])\n",
+    "    n = max(len(params), 1)\n",
+    "    v = verbe(outil[\"name\"])\n",
+    "    return {\n",
+    "        \"n\": len(params),\n",
+    "        \"verbe\": v,\n",
+    "        \"verb_crud\": v in VERBES_CRUD,\n",
+    "        \"verb_metier\": v in VERBES_METIER,\n",
+    "        \"kw_workflow\": len(params & WORKFLOW),\n",
+    "        \"large\": len(params) >= 5,\n",
+    "        \"id_entite\": len(params & {\"post_id\", \"user_id\", \"product_id\",\n",
+    "                                   \"order_id\", \"comment_id\", \"media_id\",\n",
+    "                                   \"customer_id\"}),\n",
+    "        \"overlap_colonnes\": len(params & COLONNES) / n,\n",
+    "    }\n",
+    "\n",
+    "def distance(outil):\n",
+    "    \"\"\"Score [0,1]. Haut = metier (loin de la table) ; bas = CRUD.\"\"\"\n",
+    "    s = signaux(outil)\n",
+    "    score = 0.0\n",
+    "    if s[\"verb_metier\"]: score += 0.30\n",
+    "    if s[\"verb_crud\"]:   score -= 0.30\n",
+    "    score += min(s[\"kw_workflow\"], 2) * 0.20      # chaque kw workflow pousse vers le haut\n",
+    "    if s[\"id_entite\"]:   score -= 0.20\n",
+    "    score += (1.0 - s[\"overlap_colonnes\"]) * 0.25 # moins de colonnes -> plus loin\n",
+    "    if s[\"large\"]:       score -= 0.10            # un schema large est une row a ecrire\n",
+    "    # mapage approximatif [-0.65, +0.75] -> [0, 1]\n",
+    "    d = (score + 0.65) / 1.40\n",
+    "    return max(0.0, min(1.0, d))\n",
+    "\n",
+    "# Annotons chaque outil.\n",
+    "ANALYSE = []\n",
+    "for o in OUTILS:\n",
+    "    d = distance(o)\n",
+    "    ANALYSE.append({**o, \"distance\": d,\n",
+    "                    \"classe\": \"metier\" if d >= 0.5 else \"CRUD\"})\n",
+    "print(\"Classification calculee.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "662e969e",
+   "metadata": {},
+   "source": [
+    "## Le resultat : deux clusters\n",
+    "\n",
+    "Classons tous les outils par distance croissante et regardons la distribution.\n",
+    "Si la these tient, le score separe le catalogue en deux groupes nets — avec,\n",
+    "eventuellement, un cas limite interessant.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "982160e6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T20:24:49.904719Z",
+     "iopub.status.busy": "2026-08-11T20:24:49.904193Z",
+     "iopub.status.idle": "2026-08-11T20:24:49.910528Z",
+     "shell.execute_reply": "2026-08-11T20:24:49.910001Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "outil                               dist.  classe   courbe\n",
+      "------------------------------------------------------------------------------\n",
+      "cms_update_post                      0.04  CRUD     #.............................\n",
+      "cms_get_post                         0.11  CRUD     ###...........................\n",
+      "cms_delete_post                      0.11  CRUD     ###...........................\n",
+      "cms_get_user                         0.11  CRUD     ###...........................\n",
+      "store_update_product                 0.11  CRUD     ###...........................\n",
+      "store_list_orders                    0.11  CRUD     ###...........................\n",
+      "store_get_order                      0.11  CRUD     ###...........................\n",
+      "store_create_product                 0.18  CRUD     #####.........................\n",
+      "cms_list_users                       0.25  CRUD     ########......................\n",
+      "cms_list_media                       0.25  CRUD     ########......................\n",
+      "cms_create_post                      0.34  CRUD     ##########....................\n",
+      "cms_list_posts                       0.36  CRUD     ###########...................\n",
+      "valmont_get_manuscripts              0.44  CRUD     #############.................\n",
+      "valmont_get_pending_decisions        0.57  metier   #################.............\n",
+      "valmont_get_processing_status        0.71  metier   #####################.........\n",
+      "valmont_submit_manuscript            1.00  metier   ##############################\n",
+      "valmont_assign_reviewer              1.00  metier   ##############################\n",
+      "valmont_submit_reading_report        1.00  metier   ##############################\n",
+      "valmont_transition_manuscript        1.00  metier   ##############################\n",
+      "valmont_request_prereading           1.00  metier   ##############################\n",
+      "valmont_notify_author                1.00  metier   ##############################\n",
+      "valmont_query_catalog                1.00  metier   ##############################\n",
+      "\n",
+      "Total : 13 CRUD, 9 metier.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def barre(d, largeur=30):\n",
+    "    n = int(round(d * largeur))\n",
+    "    return \"#\" * n + \".\" * (largeur - n)\n",
+    "\n",
+    "print(f\"{'outil':<34} {'dist.':>6}  {'classe':<7}  courbe\")\n",
+    "print(\"-\" * 78)\n",
+    "for a in sorted(ANALYSE, key=lambda x: x[\"distance\"]):\n",
+    "    print(f\"{a['name']:<34} {a['distance']:>6.2f}  {a['classe']:<7}  {barre(a['distance'])}\")\n",
+    "\n",
+    "n_crud = sum(1 for a in ANALYSE if a[\"classe\"] == \"CRUD\")\n",
+    "n_metier = sum(1 for a in ANALYSE if a[\"classe\"] == \"metier\")\n",
+    "print(f\"\\nTotal : {n_crud} CRUD, {n_metier} metier.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40488189",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "Les deux couches se separent proprement sur le score. Les outils `cms_` et\n",
+    "`store_` tombent tous du cote CRUD ; les verbes `valmont_` du cote metier.\n",
+    "\n",
+    "Un cas attire l'attention : **`valmont_get_manuscripts`**. Malgre son prefixe\n",
+    "metier, le classifieur le range du cote CRUD. A juste titre : son schema\n",
+    "(`status`, `author_id`, `limit`, `offset`) est la signature exacte d'une\n",
+    "operation de **liste filtree sur une table** — la meme forme que\n",
+    "`cms_list_posts` ou `store_list_orders`. Le prefixe ment ; le schema, non.\n",
+    "\n",
+    "C'est la leçon operationnelle :\n",
+    "\n",
+    "> **Le prefixe d'un outil est une declaration d'intention. Sa distance au\n",
+    "> schema de persistance est un fait.** Quand un agent choisit mal, c'est\n",
+    "presque toujours parce qu'il a suivi le prefixe et non la forme.\n",
+    "\n",
+    "Et la pire situation n'est pas l'outil mal classe — c'est l'**absence** de\n",
+    "verbe metier la ou une regle devrait vivre. Si `valmont_transition_manuscript`\n",
+    "n'existait pas, l'agent devrait faire `cms_update_post` sur le champ `status`,\n",
+    "et rien ne l'empecherait de sauter un statut interdit. La distance au schema\n",
+    "mesure aussi ce *manque* : un catalogue ou tout est a moins de 0,4 est un\n",
+    "catalogue ou l'agent ecrit directement dans les tables — sans garde-fou.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50ea9a7e",
+   "metadata": {},
+   "source": [
+    "## La lecon, mesurée\n",
+    "\n",
+    "La these de depart (« un serveur MCP utile expose les verbes du metier »)\n",
+    "n'etait qu'une affirmation tant qu'elle reposait sur l'intuition. Mesurer la\n",
+    "distance au schema de persistance en fait une **propriete observable** du\n",
+    "catalogue :\n",
+    "\n",
+    "- elle est **reproductible** : deux auditeurs trouvent le meme classement sur\n",
+    "  le meme catalogue ;\n",
+    "- elle est **actionnable** : un score < 0,3 sur l'ensemble du catalogue signale\n",
+    "  qu'aucune regle metier n'est encapsulee, et donc que l'agent est livre a\n",
+    "  lui-meme sur les transitions interdites ;\n",
+    "- elle est **portable** : la methode s'applique a n'importe quel serveur MCP,\n",
+    "  n'importe quel CMS, n'importe quel langage — il suffit du `inputSchema`.\n",
+    "\n",
+    "Le contre-pied vaut aussi : un catalogue ou *tout* serait un verbe metier\n",
+    "(score > 0,8 partout) serait tout aussi suspect — il manquerait le CRUD\n",
+    "elementaire dont un agent a besoin pour lire l'etat du monde. L'audit sain\n",
+    "cherche un **mix conscient**, pas un extrême.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7037100f",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les exercices utilisent uniquement le catalogue Maison Valmont. Aucun reseau.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a13e0866",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 -- Classer sans le prefixe\n",
+    "\n",
+    "Le prefixe est un indice trop commode. Ecrire `classe_sans_prefixe(outil)` qui\n",
+    "renvoie `\"CRUD\"` ou `\"metier\"` en ignorant **totalement** le nom de l'outil —\n",
+    "en se fondant uniquement sur `outil[\"params\"]`. Verifier qu'elle range\n",
+    "`valmont_get_manuscripts` du cote CRUD.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "33488384",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T20:24:49.912635Z",
+     "iopub.status.busy": "2026-08-11T20:24:49.912106Z",
+     "iopub.status.idle": "2026-08-11T20:24:49.915808Z",
+     "shell.execute_reply": "2026-08-11T20:24:49.915272Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 1 -- classifier un outil SANS regarder son nom.\n",
+    "def classe_sans_prefixe(outil):\n",
+    "    params = set(outil[\"params\"])\n",
+    "    # TODO: decider CRUD ou metier a partir des parametres seuls.\n",
+    "    # Indice : la presence d'un mot-cle workflow est le signal le plus fort.\n",
+    "    return None  # <- remplacer\n",
+    "\n",
+    "# Test rapide (doit rendre 'CRUD' pour l'imposteur et 'metier' pour un verbe).\n",
+    "# imposteur = prochain(o for o in OUTILS if o[\"name\"] == \"valmont_get_manuscripts\")\n",
+    "# verbe = prochain(o for o in OUTILS if o[\"name\"] == \"valmont_assign_reviewer\")\n",
+    "# print(classe_sans_prefixe(imposteur), classe_sans_prefixe(verbe))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0766d1eb",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 -- Trouver l'imposteur\n",
+    "\n",
+    "Parmi les outils prefixes `valmont_`, un seul a un schema de forme CRUD.\n",
+    "Ecrire `trouver_imposteur(catalogue)` qui renvoie son **nom**, sans coder le\n",
+    "nom en dure — en utilisant le score de distance.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f9165c64",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T20:24:49.917907Z",
+     "iopub.status.busy": "2026-08-11T20:24:49.917907Z",
+     "iopub.status.idle": "2026-08-11T20:24:49.920806Z",
+     "shell.execute_reply": "2026-08-11T20:24:49.920500Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 2 -- identifier l'outil metier au schema CRUD.\n",
+    "def trouver_imposteur(catalogue):\n",
+    "    # TODO: parmi les outils dont le prefixe est metier (valmont_),\n",
+    "    # renvoyer celui dont la distance est la plus basse.\n",
+    "    return None  # <- remplacer\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c31d8dd",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 -- Concevoir un verbe metier\n",
+    "\n",
+    "Le CRUD ne peut pas tout. Soit la regle :\n",
+    "\n",
+    "> *Un manuscrit ne peut passer a l'etat `en_relecture` que s'il a au moins\n",
+    "> deux relecteurs assignes.*\n",
+    "\n",
+    "Cette regle **doit** vivre dans un outil metier, pas chez l'agent. Ecrire\n",
+    "`concevoir_ouvrir_relecture()` qui renvoie un dict `{\"name\", \"inputSchema\"}`\n",
+    "encodant ce verbe. L'agent ne doit pouvoir fournir que `manuscript_id` ; la\n",
+    "verification des deux relecteurs est l'affaire de l'outil.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5e9ff08b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T20:24:49.922377Z",
+     "iopub.status.busy": "2026-08-11T20:24:49.922377Z",
+     "iopub.status.idle": "2026-08-11T20:24:49.926017Z",
+     "shell.execute_reply": "2026-08-11T20:24:49.925503Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 3 -- designer un verbe metier pour une regle de transition.\n",
+    "def concevoir_ouvrir_relecture():\n",
+    "    return {\n",
+    "        \"name\": \"\",  # <- nom du verbe\n",
+    "        \"inputSchema\": {\"type\": \"object\", \"properties\": {\n",
+    "            # TODO: les parametres que l'agent PEUT fournir.\n",
+    "        }},\n",
+    "    }\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd344115",
+   "metadata": {},
+   "source": [
+    "## Provenance et pour aller plus loin\n",
+    "\n",
+    "**Provenance.** Catalogue entierement synthetique (Maison Valmont). Aucune\n",
+    "donnee d'installation reelle : ni nom d'outil reel, ni titre d'ouvrage, ni\n",
+    "prose sous droits, ni identifiant. Les sorties de ce notebook proviennent du\n",
+    "fixture embarque ; elles sont reproductibles sans reseau ni cle. Les chiffres\n",
+    "(nombres d'outils par couche, scores de distance) decrivent un atelier fictif\n",
+    "et ne se transportent pas a une installation reelle — ce qui s'enseigne est la\n",
+    "**methode** de classification.\n",
+    "\n",
+    "**Ce que ce notebook ne dit pas.** La distance au schema est une *heuristic*\n",
+    "lue sur le `inputSchema`. Elle ne saisit pas une regle encodee dans le **corps**\n",
+    "de l'outil (un CRUD pourrait cacher une regle cote serveur ; un verbe metier\n",
+    "pourrait n'etre qu'une coquille vide). L'audit par le schema est un **premier\n",
+    "filtre** ; il trouve les catalogues qui manquent de verbes metier, il ne prouve\n",
+    "pas que les verbes presents sont correctement implementes.\n",
+    "\n",
+    "**Pour aller plus loin.**\n",
+    "\n",
+    "- [`livresagites-parcours.md`](livresagites-parcours.md) -- le cas d'usage\n",
+    "  original (Parcours 3) dont ce notebook est le compagnon executable.\n",
+    "- [`ingestion-corpus-long-rag.ipynb`](ingestion-corpus-long-rag.ipynb) -- un\n",
+    "  autre recyclage du meme projet : la qualite du RAG se joue au chunking.\n",
+    "- [`cadrer-les-agents.md`](../cadrer-les-agents.md) -- l'autre moitie : ce\n",
+    "  qu'un assistant a le droit de faire (autorisations), en regard de qui il est.\n",
+    "- [Model Context Protocol](https://modelcontextprotocol.io/) -- la spec.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
@@ -245,6 +245,14 @@ C'est le point transposable à n'importe quel projet MCP, quel que
 soit le CMS ou le langage : la valeur d'un serveur MCP se mesure à
 la distance entre ses outils et le schéma de persistance.
 
+> **Compagnon exécutable.** Le notebook
+> [`auditer-un-serveur-mcp.ipynb`](auditer-un-serveur-mcp.ipynb) convertit
+> cette leçon en une mesure reproductible : il classe chaque outil d'un
+> catalogue en CRUD générique ou verbe métier et calcule sa distance au
+> schéma de persistance à partir du seul `inputSchema`. Le catalogue audité
+> y est synthétique (Maison Valmont) — aucun outil réel du site n'y figure —
+> et un chemin live optionnel permet de le rejouer sur son propre serveur.
+
 ### Comparaison OWUI
 
 C'est ici qu'AI-Engine se distingue le plus franchement. Open WebUI


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: DEEP/notebook-python #10463

**Quoi:** un notebook exécuté qui convertit en mesure reproductible la leçon centrale du dossier (`livresagites-parcours.md`, Parcours 3) : *un serveur MCP utile expose les verbes du métier, pas les tables de la base.* Étant donné le catalogue d'outils d'un serveur MCP, il classe chaque outil en CRUD générique ou verbe métier et calcule sa **distance au schéma de persistance** à partir du seul `inputSchema`. Cette leçon était jusqu'ici en prose ; elle devient une propriété observable.

**Preuve:** notebook exécuté sur catalogue synthétique (kernel `coursia-sae`, kernelspec normalisé `python3`). 7 cellules de code, toutes avec `execution_count`, 3 exercices à stubs. Résultat : les 12 outils CRUD génériques (`cms_`/`store_`) scorent 0,04–0,36 ; l'imposteur `valmont_get_manuscripts` — préfixe métier mais schéma de liste filtrée (`status`, `author_id`, `limit`, `offset`) — score 0,44 et est correctement classé CRUD ; les verbes métier (`submit`, `assign`, `transition`…) scorent 0,57–1,00. La séparation en deux clusters est nette, et le cas imposteur porte la leçon : **le préfixe ment, le schéma non.** Hooks pre-commit verts, dont `H.3 — refuse un-executed notebooks`. Scan pré-commit : 0 cyrillique/grec, 0 emoji, 0 secret ; les trois correspondances de termes clients sont bénignes (nom du projet déjà public et conforme au notebook grain 5, URL publique du dépôt, et sous-chaîne dans « déclaration »).

**Périmètre:** `GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/` — un fichier créé (`auditer-un-serveur-mcp.ipynb`, +709), trois modifiés additivement (`.env.example` SECTION 3 chemin live optionnel, `README.md` et `livresagites-parcours.md` pour référencer le notebook comme compagnon exécutable du Parcours 3). Aucun autre chemin touché. +750/−0.

## Frontière de sécurité — instance synthétique dédiée (décision user)

Le notebook n'appelle **jamais** l'instance client. Le catalogue audité est entièrement synthétique : la « Maison Valmont » (domaine déjà utilisé au grain 5), avec outils `cms_`/`store_` (CRUD générique) et `valmont_*` (verbes métier). Aucune donnée du site observé n'entre dans le notebook — ni nom d'outil réel, ni titre, ni prose. Les sorties commitées proviennent du fixture embarqué, donc zéro donnée client par construction. Un chemin live optionnel (`MCP_TOOL_CATALOG_URL`/`MCP_TOOL_TOKEN` dans `.env`, vide par défaut) permet à un étudiant de rejouer le notebook sur **son propre** serveur MCP, n'importe quel éditeur.

## Choix techniques

- **stdlib uniquement** (`json`, `re`, `urllib`). Pas de dépendance, pas de réseau requis pour rejouer, pas de clé d'API. Le vectoriseur du grain 5 restait déterministe hors-ligne ; celui-ci l'est aussi par construction.
- **Le classifieur est une heuristique lue sur le `inputSchema`** — trois signaux (mots-clés workflow, largeur du schéma, identifiant d'entité générique) combinés en un score de distance. Le notebook dit explicitement sa limite : il trouve les catalogues qui *manquent* de verbes métier, il ne prouve pas que les verbes présents sont correctement implémentés (une règle vit dans le corps de l'outil, pas dans son schéma).
- **L'imposteur est le résultat le plus utile** : `valmont_get_manuscripts` porte un préfixe métier mais un schéma CRUD. Le classifieur le rattrape. La leçon opérationnelle — *quand un agent choisit mal, c'est presque toujours parce qu'il a suivi le préfixe et non la forme* — est ainsi démontrée et non assertée.

Closes #10493
