### PR TITLE
fix(pr-gate,#10433): re-trigger rollup on guard completion (workflow_run)

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -22,13 +22,27 @@ name: PR gate
 #
 # Enabling it is a repository-settings change and therefore owner-only:
 #   Settings > Branches > main > Require status checks > add "PR gate"
-# Until that flip, this job is informative rather than blocking -- which is
-# precisely the half that does not need the owner, delivered so the flip is a
-# one-click action instead of a design problem.
+#
+# The owner has since flipped it to *required* on `main` (measured 2026-08-11,
+# issue #10433): #10423 sat BLOCKED with `PR gate` as its only non-SUCCESS
+# check and turned CLEAN the instant `PR gate` went green. So this job IS
+# blocking today; the branch-protection reasoning above (single requerrable
+# check, no `paths:` filter) is exactly why it is the safe one to require.
 
 on:
   pull_request:
     branches: [main]
+  # Issue #10433 -- the guard can re-qualify a tag by editing the PR body
+  # (variation-protocol §3), turning a previously-red "Require Grain tag" green
+  # AFTER this gate already aggregated. Because the gate fires on pull_request
+  # (no `edited` type), that stale FAILURE became permanent and the PR stayed
+  # BLOCKED until a manual `gh run rerun`. Adding `edited` alone does NOT fix it:
+  # the rollup re-fires in PARALLEL with the new guard run and can fail-fast on
+  # the stale conclusion before the green one surfaces. `workflow_run` fires only
+  # AFTER the guard completes, so the gate always aggregates a settled state.
+  workflow_run:
+    workflows: ["Variation Tag Guard"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       sha:
@@ -42,7 +56,12 @@ permissions:
   statuses: read
 
 concurrency:
-  group: pr-gate-${{ github.event.pull_request.number || github.ref }}
+  # SHA-keyed for workflow_run so two PRs' guard-completed re-triggers do not
+  # share a group (issue #10433); pull_request keeps the PR-number key (a re-push
+  # cancels the older run for the same PR). A same-SHA workflow_run fire cancels
+  # the stale run via cancel-in-progress -- exactly the desired behaviour: a
+  # fresh aggregation post-guard-completion supersedes the stale FAIL.
+  group: pr-gate-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -74,6 +93,11 @@ jobs:
       - name: Aggregate check verdicts
         env:
           GH_TOKEN: ${{ github.token }}
+          # The head SHA is event-specific: pull_request gives the PR head;
+          # workflow_run (the #10433 guard-completed re-trigger) gives the
+          # completed run's head_sha; workflow_dispatch honours the input.
+          # Fallback to the ref the run is on.
+          EVENT_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.event.inputs.sha || github.sha }}
           # Issue #10072 -- student PRs from forks must remain mergeable under
           # the benevolent-policy rule of .claude/rules/student-pr-reviews.md
           # ("Template vide + CI rouges = OK. Merge admin via gh auth switch -u
@@ -83,7 +107,12 @@ jobs:
           # variation-tag-guard.yml (L73-78) and translation-sync.yml (analog);
           # this script exposes --is-fork so the verdict is reported as PASS
           # without ever polling, keeping the "verdict on every PR" invariant.
-          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          # Fork detection is event-specific too: pull_request exposes
+          # head.repo.fork directly; workflow_run fires from the base repo, so a
+          # guard that ran against a fork head is detected by head_repository
+          # != repository (both are checked -- the guard re-triggers this gate
+          # for same-repo PRs as well).
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork || (github.event.workflow_run.head_repository != null && github.event.workflow_run.head_repository != github.repository) }}
         run: |
           # Pass --is-fork only when IS_FORK is the literal string "true".
           # GitHub serialises booleans as "true"/"false" (always set), so the
@@ -93,9 +122,10 @@ jobs:
           else
             IS_FORK_ARG=""
           fi
+          SHA="${EVENT_SHA:-$GITHUB_SHA}"
           python scripts/pr_gate.py \
             --repo "${{ github.repository }}" \
-            --sha "${{ github.event.pull_request.head.sha || github.sha }}" \
+            --sha "$SHA" \
             --self-name "PR gate" \
             --timeout-min 90 \
             --poll-sec 30 \

--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -468,6 +468,21 @@ def wait_and_decide(
     single quiet poll is not enough, because a workflow queued milliseconds ago
     has not surfaced yet and would be invisible.
 
+    Required checks still IN_PROGRESS/QUEUED (status in STATUS_PENDING, or a
+    `completed` run with a null conclusion -- a transient GitHub state) are
+    `pending`: this loop keeps polling them and NEVER verdicts PASS while a
+    required check is in flight, bounded by `timeout_min` (default 90 min). A
+    required check that never settles times out and FAILs (rule 1, bias to
+    fail). This is distinct from ADVISORY checks (rule 6), whose queued or
+    in-progress state is reported but never blocks. The decision is deliberate:
+    the only safe way to observe a required check that turns green AFTER the
+    first aggregation is to re-run the rollup once that check has COMPLETED --
+    which is why pr-gate.yml re-triggers this gate via `workflow_run` on the
+    guard's completion (issue #10433) rather than verdicting on a transient
+    in-flight state. (Adding `edited` to the pull_request trigger instead would
+    race: the rollup re-fires in parallel with the new guard run and can
+    fail-fast on the stale conclusion before the green one surfaces.)
+
     `always_on_jobs` arms the delivery canary (rule 8). None or empty disables
     it (the gate then behaves exactly as before this rule). Only consulted at
     settle time, so a freshly-opened PR keeps the `settle_polls` grace period for

--- a/scripts/tests/test_pr_gate_stale_rollup.py
+++ b/scripts/tests/test_pr_gate_stale_rollup.py
@@ -1,0 +1,123 @@
+"""Regression tests for the stale-rollup bug (#10433).
+
+The PR gate (`scripts/pr_gate.py`) aggregates all check verdicts for a SHA.
+A stale FAILURE became permanent when a required check (the Variation Tag Guard)
+turned green AFTER the gate had already aggregated -- because the gate triggers
+on `pull_request` (no `edited`), and its fail-fast path returns on the first poll
+that sees a `bad` conclusion, before a newer run can supersede it.
+
+The fix re-triggers the rollup via `workflow_run` on the guard's completion, so
+the gate only ever aggregates a state where the guard has already settled. These
+tests pin the classify/wait_and_decide behaviour the fix relies on, so the
+trigger change cannot silently regress them:
+
+  1. wait_then_pass -- a check pending on poll 1, ok on poll 2 -> PASS. This is
+     the path the workflow_run re-trigger takes: by the time it fires, the guard
+     has completed, so the gate observes it settled-green and passes.
+  2. fail_fast_on_bad -- a genuinely-failed check -> FAIL on poll 1 (no wait).
+     Pins that the fail-fast is not weakened by the workflow_run change.
+  3. stale_bad_then_ok_currently_fails -- the `edited`-race limitation the
+     workflow_run approach exists to avoid: a `bad` conclusion on poll 1 fails
+     fast even when poll 2 would supersede it. Documents WHY the fix chose
+     `workflow_run` (post-completion) over `edited` (parallel, races the stale
+     conclusion). If this ever starts PASS-ing, revisit whether `edited` alone
+     would then suffice -- do not let it flip silently.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from pr_gate import wait_and_decide  # noqa: E402
+
+
+def _check(name, status, conclusion):
+    """Minimal check-run dict (the keys classify()/dedupe_latest() read)."""
+    return {
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "started_at": "2026-08-11T00:00:00Z",
+    }
+
+
+def _run(fetch_sequence, *, settle_polls=2, timeout_min=90):
+    """Drive wait_and_decide over a scripted sequence of fetch results.
+
+    fetch_sequence: list of check-lists, one per poll. The last entry repeats for
+    any extra polls the gate requests (a stable terminal state), so the test
+    terminates even when the gate needs settle_polls quiet polls to converge.
+    Returns (exit_code, message, polls_consumed).
+    """
+    calls = {"i": 0}
+
+    def fetch(_repo, _sha):
+        i = calls["i"]
+        calls["i"] = i + 1
+        return fetch_sequence[min(i, len(fetch_sequence) - 1)]
+
+    clock = {"t": 0.0}
+
+    def now():
+        # Advance 30 s per poll; stays well under the timeout_min*60 deadline so
+        # the timeout path (settled=False) never fires in these scenarios.
+        clock["t"] += 30.0
+        return clock["t"]
+
+    code, msg = wait_and_decide(
+        repo="jsboige/CoursIA",
+        sha="deadbeef",
+        self_name="PR gate",
+        timeout_min=timeout_min,
+        poll_sec=30.0,
+        settle_polls=settle_polls,
+        sleep=lambda _s: None,
+        fetch=fetch,
+        now=now,
+    )
+    return code, msg, calls["i"]
+
+
+def test_wait_then_pass():
+    """Required check pending on poll 1, ok on poll 2 -> PASS (workflow_run path)."""
+    guard = "Variation Tag Guard"
+    code, msg, polls = _run(
+        [
+            [_check(guard, "in_progress", None)],  # poll 1: guard still running
+            [_check(guard, "completed", "success")],  # poll 2: guard green
+        ]
+    )
+    assert code == 0, f"expected PASS, got {code}: {msg}"
+    assert polls >= 2  # did not fail-fast; waited for the guard to settle
+
+
+def test_fail_fast_on_bad():
+    """A genuinely-failed check -> FAIL on poll 1, no waiting (regression pin)."""
+    code, msg, polls = _run(
+        [
+            [_check("CI Build", "completed", "failure")],
+            [_check("CI Build", "completed", "success")],  # never reached
+        ]
+    )
+    assert code == 1
+    assert polls == 1  # fail-fast: did not wait for the would-be-green poll 2
+
+
+def test_stale_bad_then_ok_currently_fails():
+    """The edited-race limitation: bad on poll 1 fails fast even if poll 2 ok.
+
+    This is the documented reason the fix uses `workflow_run` (fires after the
+    guard completes, so it never observes a stale-then-superseded `bad`) rather
+    than `edited` (which triggers the rollup in parallel with the new guard run,
+    racing the stale conclusion). See #10433 acceptance item 1.
+    """
+    guard = "Variation Tag Guard"
+    code, msg, polls = _run(
+        [
+            [_check(guard, "completed", "failure")],  # stale failed guard
+            [_check(guard, "completed", "success")],  # new run supersedes (never reached)
+        ]
+    )
+    assert code == 1  # current behaviour: fail-fast on poll 1
+    assert polls == 1


### PR DESCRIPTION
Quoi: Re-déclencher le rollup du PR gate quand la Variation Tag Guard se termine, pour qu'un check requis qui passe au vert APRÈS l'agrégation initiale ne reste pas un FAILURE permanent. Bug mesuré deux fois le 2026-08-11 (#10423: 66 min, #10429: 35 min bloqués).

Preuve: `workflow_run` sur la fin du guard (fires post-completion) plutôt que `edited` (qui race : le rollup re-fire en parallèle du nouveau run du guard et peut fail-faster sur la conclusion périmée). Tests de régression firsthand : 3 tests pin les 3 comportements dont le fix dépend (`python -m pytest scripts/tests/test_pr_gate_stale_rollup.py` → 3 passed ; suite gate+variation complète → 137 passed). YAML validé (`yaml.safe_load`), `py_compile` OK. Fork detection vérifiée pour les 4 cas d'événement (pull_request same/fork, workflow_run same/fork, dispatch).

Perimetre: 3 fichiers (+174/-6). Aucun notebook touché, aucun catalogue régénéré (byte-identique à main). Pas de code métier — pure CI infra + docstring + tests.

Grain: MED/guard -- lane myia-po-2026:CoursIA

---

## Root cause

`pr-gate.yml` ne s'abonnait qu'à `pull_request` (types par défaut : opened/synchronize/reopened) et `workflow_dispatch`. Or la manœuvre de re-qualification d'un tag prescrite par variation-protocol §3 (éditer le corps de la PR) fait passer `Require Grain tag` au vert APRÈS que le gate a déjà agrégé — et le gate ne re-agrège jamais. Son FAILURE (dont l'unique cause était l'absence du tag) devient permanent, et comme le check est désormais **required** sur `main`, la PR reste `BLOCKED` jusqu'à un `gh run rerun` manuel. À ~180 merges/jour, ingérable.

Ajouter `edited` aux types `pull_request` **ne suffit pas** (et c'est dit dans l'issue) : l'édition déclenche le guard ET le rollup **en parallèle**, si bien que le rollup peut agréger pendant que le guard est encore `IN_PROGRESS` et échouer une seconde fois sur la conclusion périmée.

## Fix — `workflow_run` (post-completion, pas parallèle)

Le rollup se re-déclenche via `workflow_run` sur la **fin** du guard. À ce moment le guard a COMPLETED, donc le gate agrège toujours un état settled (success ou failure), jamais un transient IN_PROGRESS. Les 4 items d'acceptation de #10433 :

1. **Trigger** — `workflow_run: ["Variation Tag Guard"] types: [completed]` ajouté à `on:`. SHA + fork detection rendus event-specific dans le job gate :
   - `EVENT_SHA` = `pull_request.head.sha || workflow_run.head_sha || inputs.sha || github.sha`
   - `IS_FORK` = `pull_request.head.repo.fork || (workflow_run.head_repository != null && workflow_run.head_repository != repository)` — préserve l'exemption fork #10072 sous les deux événements (vérifié pour les 4 cas).
   - Concurrency group SHA-keyed pour workflow_run : deux PRs ne collisionnent pas, un même SHA cancel-in-progress le run périmé (le supersede voulu).
   - **Incidentalement** : l'input `sha` de `workflow_dispatch` était défini mais jamais lu dans le step (dead input) — `EVENT_SHA` le wire enfin (remplacement propre du `gh run rerun` manuel).

2. **Décision IN_PROGRESS/QUEUED** — docstring de `wait_and_decide()` : un check requis IN_PROGRESS/QUEUED (status in STATUS_PENDING, ou `completed`/conclusion null) est `pending` ; la boucle poll (bornée par `--timeout-min`, défaut 90 min) et **ne verdicte jamais PASS** en vol. Distinct des advisories (règle 6, jamais bloquants). C'est précisément pourquoi le re-trigger `workflow_run` est le bon fix plutôt que de veridicter sur un état transient.

3. **Test de régression** — `scripts/tests/test_pr_gate_stale_rollup.py`, 3 tests pin les comportements dont le fix dépend :
   - `test_wait_then_pass` : le chemin workflow_run (pending → green → PASS).
   - `test_fail_fast_on_bad` : le fail-fast sur échec réel est préservé (pas affaibli).
   - `test_stale_bad_then_ok_currently_fails` : la limitation du `edited`-race documentée — si ce test passe un jour à PASS, alors `edited` seul suffirait et le trigger `workflow_run` est à revisiter (il ne doit pas flipper silencieusement).

4. **En-tête corrigé** — le commentaire de tête disait « Until that flip, this job is informative rather than blocking ». C'est faux aujourd'hui : le check est required (#10423 était BLOCKED avec PR gate comme seul check non-SUCCESS, passé CLEAN au vert). Corrigé pour refléter l'état observé.

## Verification

```
python -m pytest scripts/tests/test_pr_gate_stale_rollup.py   # 3 passed
python -m pytest scripts/tests/test_pr_gate.py                # 39 passed
# suite gate + variation post-rebase : 137 passed
python -m py_compile scripts/pr_gate.py                       # OK
python -c "import yaml; yaml.safe_load(open('.github/workflows/pr-gate.yml'))"  # OK
```

Note déploiement : `workflow_run` runs sur la version du workflow présente sur `main` — le nouveau trigger ne fire avec la NOUVELLE définition qu'après merge. Le test prouve la logique ; le trigger s'active post-merge (comportement attendu pour tout changement CI).

See #10433 · #9819 · #10020