### PR TITLE
feat(twin,#10382): bridge_verdict SOTA-OK for Z3-Python-02 Sudoku (pyz3/Microsoft.Z3 native)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/z3-python-02-sudoku.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-02-sudoku.yaml
@@ -3,11 +3,19 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Z3 EST le moteur SOTA SMT, branche NATIVEMENT des deux cotes : pyz3 (pip z3-solver, `from z3 import *`, API fonctionnelle Solver()/Int()/Distinct()) et Microsoft.Z3 (NuGet officiel, `#r \"nuget: Microsoft.Z3\"` + `using Microsoft.Z3;`, API Context ctx.MkSolver/MkIntConst/MkDistinct) sont les deux bindings de la meme lib C++ Z3 sous-jacente — pas un pont intermediaire type IKVM/PythonNet. Parite firsthand sur le concept central (resolution de Sudoku par encodage SMT) cellule 5 des deux notebooks : meme structure de contrainte (domaine 1-9 via `>=1,<=9`/`MkGe,MkLe`, indices figes `==`/`MkEq`, unicite `Distinct()`/`MkDistinct()` par ligne + colonne + bloc 3x3) -> meme verdict `s.check()==sat`/`s.Check()==Status.SATISFIABLE` -> 'Puzzle facile : resolu' + la meme grille 9x9 resolue. Aucune asymetrie de machinerie a corriger."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 31ede72cdc3c4895792d29b26e360cb2d31b66da
       csharp_sha: fedc5982513ac15be379f4b0ed0845032d2dc9a6
+    - date: "2026-08-11"
+      by: myia-po-2026:CoursIA
+      python_sha: 31ede72cdc3c4895792d29b26e360cb2d31b66da
+      csharp_sha: fedc5982513ac15be379f4b0ed0845032d2dc9a6
+      content_python_sha: 3607d23ded635bccfe9269d290d4830ae0608451d9ece9013354daea4ac523ff
+      content_csharp_sha: f322a51c165fe64d56a7dee6b3188baa1a99d203b86527196b0a3097e3a27820
   known_differences:
     - "Python : pyz3. C# : Microsoft.Z3 .NET (idiomes API comme NB-01)."
     - "Cote Python : modelisation Sudoku (81 cellules Int 1-9, alldifferent lignes/colonnes/blocs). Doc-honesty cures c.19 (PR #8045 : compte indices ~35 -> 30 pour puzzle_facile). SHA rebaseline c.802 apres DRIFT detecte par check_twin_parity.py : 4dcb5921 -> 1d3b1932 (commit e8a3be3ae merge le 2026-07-23)."


### PR DESCRIPTION
Quoi: Add `bridge_verdict: SOTA-OK` to the Z3-Python-02 Sudoku twin shard. Z3 is the SOTA SMT engine, branched NATIVELY on both sides (Microsoft.Z3 NuGet + pyz3 = the two bindings of the same C++ Z3 library), so there is no intermediate bridge to build (no IKVM/PythonNet).

Preuve: Firsthand parity on the central concept (Sudoku solving via SMT encoding), cell 5 of both notebooks — Python pyz3 `Int('c_r_c')` 9x9, domain `>=1,<=9`, givens `==`, `Distinct()` per row/col/3x3 box, `s.check()==sat` -> "Puzzle facile : resolu" + solved grid `[5,3,4,6,7,8,9,1,2]...` == C# Microsoft.Z3 `ctx.MkIntConst`, `MkGe/MkLe` 1-9, `MkEq` givens, `MkDistinct` row/col/box, `s.Check()==Status.SATISFIABLE` -> "Puzzle facile : resolu". Same constraints, same verdict from the same engine. `check_twin_parity.py --update` + `--check --ci-strict`: 157 pairs, drift_blob=0, drift_content=0.

Perimetre: 1 shard only (+8 lines, pure additive). No notebook source touched, catalogue byte-identical to main. Mirrors the ratified z3-01 (#10494) + z3-03 (#10477 MERGED) pattern. Advances EPIC #10382 native-both fleet.

Grain: MED/twin -- lane myia-po-2026:CoursIA

## Summary

Adds `bridge_verdict: SOTA-OK` + `bridge_verdict_reason` to `scripts/notebook_tools/twin_pairs.d/z3-python-02-sudoku.yaml`, plus a rebaselined audit entry (2026-08-11, myia-po-2026:CoursIA) with content SHAs.

**Why SOTA-OK by construction:** Z3 IS the SOTA SMT solver. The Python notebook uses pyz3 (`from z3 import *`, `Solver()`, `Int('c_r_c')`, `Distinct()`); the C# notebook uses Microsoft.Z3 (`#r "nuget: Microsoft.Z3"`, `using Microsoft.Z3;`, `ctx.MkSolver()`, `ctx.MkIntConst(...)`, `ctx.MkDistinct(...)`). Both are first-party bindings to the **same C++ Z3 library** — there is no intermediate bridge layer (unlike IKVM/PythonNet cases). Each language talks to the engine natively. The parity is therefore structural: same engine, same verdict.

**Firsthand parity evidence (cell 5, both notebooks — the Sudoku solver):**
- Python (pyz3): 81 `Int('c_r_c')`, domain `>=1,<=9`, givens fixed `==`, `Distinct()` per row + column + 3x3 box, `s.check() == sat` -> solved grid, `None` if unsat.
- C# (Microsoft.Z3): `ctx.MkIntConst(...)`, domain `MkGe(..,MkInt(1))/MkLe(..,MkInt(9))`, givens `MkEq`, `MkDistinct(...)` per row + column + box, `s.Check() == Status.SATISFIABLE` -> solved grid, `null` if unsat.
- Same output: `Puzzle facile : resolu` + the same 9x9 grid.

Same constraint structure, same verdict from the same Z3 engine. pyz3 `Distinct()` == Microsoft.Z3 `MkDistinct()`; `Int()` == `MkIntConst()`; `s.check()==sat` == `s.Check()==Status.SATISFIABLE`. No machinery asymmetry to correct.

## Verification

- `check_twin_parity.py --update --pair "Z3-Python-02 Sudoku" --by "myia-po-2026:CoursIA"` -> 1 pair rebaselined (new audit entry 2026-08-11 with content SHAs; python_sha/csharp_sha unchanged = parity holds).
- `check_twin_parity.py --check --ci-strict` -> 157 pairs, drift_blob=0, drift_content=0 (the single INFO line is a pre-existing metadata-only drift on Sudoku-14, unrelated, does not fail the gate).

See #10382