### PR TITLE
feat(genai,#10500,#10473): Roslyn agent-safety guardrails analyzer notebook

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/Roslyn-Code-Guardrails.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/Roslyn-Code-Guardrails.ipynb
@@ -1,0 +1,756 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "roslyn-guard-c0",
+   "metadata": {},
+   "source": [
+    "# Garde-fous Roslyn pour le code genere par agent\n",
+    "\n",
+    "> Grain **DEEP/notebook-dotnet** -- lane `myia-po-2024:CoursIA` -- prev: DEEP/genai #10487. See #10473 (Epic *The Unexpected AI Stack: C#/.NET*, axe Roslyn).\n",
+    "\n",
+    "## La these en une phrase\n",
+    "\n",
+    "Quand un agent (Claude Code, Roo, un LLM) **genere du code C#**, le compilateur Roslyn peut servir de **garde-fou de securite** -- la verification se fait **dans la compilation elle-meme**, pas en post-traitement optionnel comme `mypy` ou `ruff` en Python.\n",
+    "\n",
+    "C'est un axe ou la pile .NET est structurellement en avance : un `DiagnosticAnalyzer` est execute par le compilateur a chaque build, avec acces au **modele semantique** (types, valeurs constantes, flux de donnees), pas seulement au texte. Un agent qui produit du code non-sur est donc rejete **avant** de tourner.\n",
+    "\n",
+    "## Ce que ce notebook demontre (execute, pas narre)\n",
+    "\n",
+    "1. Un **analyseur** `AgentSafetyAnalyzer` qui detecte 3 familles de code d'agent dangereux :\n",
+    "   - **AGSEC001** -- `Process.Start(variable)` : risque d'injection de commande (l'argument n'est pas une constante)\n",
+    "   - **AGSEC002** -- concatenation de chaine SQL (`\"SELECT ...\" + var`) : risque d'injection SQL\n",
+    "   - **AGSEC003** -- `File.Read/Write/Delete(variable)` : risque de path traversal\n",
+    "2. La **valeur ajoutee semantique** : l'analyseur distingue un **litteral sur** (`Process.Start(\"whoami\")`) d'une **variable attaquable** (`Process.Start(userCmd)`) -- un `grep` naif ne le peut pas.\n",
+    "3. Un **correcteur automatique** (`CodeFix`) qui transforme la concatenation SQL en chaine interpolation, premice d'une requete parametree.\n",
+    "\n",
+    "**Source** : *The Unexpected AI Stack: C#/.NET -- Part 1* (Charles Chen, 08/2026), section *Roslyn: analyseurs statiques comme garde-fous d'agent*.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "roslyn-guard-c1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T21:32:50.493332Z",
+     "iopub.status.busy": "2026-08-11T21:32:50.488641Z",
+     "iopub.status.idle": "2026-08-11T21:32:51.973914Z",
+     "shell.execute_reply": "2026-08-11T21:32:51.970748Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-28436.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '28436.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.CodeAnalysis.CSharp, 4.13.0</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Microsoft.CodeAnalysis (Roslyn) version: 4.13.0.0"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#r \"nuget: Microsoft.CodeAnalysis.CSharp, 4.13.0\"\n",
+    "\n",
+    "using Microsoft.CodeAnalysis;\n",
+    "using Microsoft.CodeAnalysis.CSharp;\n",
+    "using Microsoft.CodeAnalysis.CSharp.Syntax;\n",
+    "using Microsoft.CodeAnalysis.Diagnostics;\n",
+    "using System.Collections.Immutable;\n",
+    "using System.Text;\n",
+    "\n",
+    "// Preuve SOTA-OK : le VRAI Microsoft.CodeAnalysis est invoque, pas une reimplementation jouet.\n",
+    "$\"Microsoft.CodeAnalysis (Roslyn) version: {typeof(Compilation).Assembly.GetName().Version}\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "roslyn-guard-c2",
+   "metadata": {},
+   "source": [
+    "## Pourquoi un analyseur compile-time ? Parite C# / Python\n",
+    "\n",
+    "| Aspect | Python (apres generation d'agent) | C# / .NET (Roslyn) |\n",
+    "|---|---|---|\n",
+    "| Verificateur statique | `mypy` / `ruff` (linter **optionnel**, hors compilation) | `DiagnosticAnalyzer` execute **par le compilateur** a chaque build |\n",
+    "| Acces au modele semantique | partiel (`mypy` sur les types ; pas de valeurs constantes) | complet (types, **valeurs constantes**, flux de nullabilite, graphes d'appel) |\n",
+    "| Localisation des defauts | numero de ligne (regex) | **span precis** (`Location.Create`, colonne + longueur) |\n",
+    "| Correcteur auto | aucun standard | `CodeFixProvider` (ampoule IDE, `dotnet format`)\n",
+    "\n",
+    "La difference decisive est le **modele semantique**. Un `grep \"Process.Start\"` trouve l'appel, mais ne sait pas si l'argument est la chaine litterale `\"whoami\"` (sur) ou la variable `userCmd` (attaque). Roslyn, lui, peut demander au compilateur : *cette expression a-t-elle une valeur constante ?* via `SemanticModel.GetConstantValue`. C'est toute la difference entre regarder le **texte** et regarder le **sens** du code.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "roslyn-guard-c3",
+   "metadata": {},
+   "source": [
+    "## 1. L'analyseur `AgentSafetyAnalyzer`\n",
+    "\n",
+    "Un `DiagnosticAnalyzer` declare :\n",
+    "- des **regles** (`DiagnosticDescriptor` : identifiant, severite, message, categorie),\n",
+    "- des **abonnements syntaxiques** (`RegisterSyntaxNodeAction` : appelle un callback pour chaque noeud d'un type donne -- ici les `InvocationExpression` et les `BinaryExpression`).\n",
+    "\n",
+    "A chaque noeud visite, il decide de signaler (`ReportDiagnostic`) ou non. La classe ci-dessous en regroupe trois."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "roslyn-guard-c4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T21:32:51.976045Z",
+     "iopub.status.busy": "2026-08-11T21:32:51.975738Z",
+     "iopub.status.idle": "2026-08-11T21:32:52.312473Z",
+     "shell.execute_reply": "2026-08-11T21:32:52.312576Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AgentSafetyAnalyzer defini : 3 regles (AGSEC001/002/003), abonnees aux invocations et aux additions."
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "public sealed class AgentSafetyAnalyzer : DiagnosticAnalyzer\n",
+    "{\n",
+    "    public const string AGSEC001 = \"AGSEC001\"; // Process.Start non-constant\n",
+    "    public const string AGSEC002 = \"AGSEC002\"; // SQL concatenation\n",
+    "    public const string AGSEC003 = \"AGSEC003\"; // File.* path non-constant\n",
+    "\n",
+    "    internal static readonly DiagnosticDescriptor Rule001 = new(AGSEC001,\n",
+    "        \"Command injection: non-constant Process.Start argument\",\n",
+    "        \"Process.Start is called with a non-constant value '{0}': attacker-controlled input could inject a command\",\n",
+    "        \"Security\", DiagnosticSeverity.Warning, isEnabledByDefault: true);\n",
+    "\n",
+    "    internal static readonly DiagnosticDescriptor Rule002 = new(AGSEC002,\n",
+    "        \"SQL string concatenation\",\n",
+    "        \"SQL query built by concatenating '{0}': use a parameterized query (SqlParameter) instead\",\n",
+    "        \"Security\", DiagnosticSeverity.Warning, isEnabledByDefault: true);\n",
+    "\n",
+    "    internal static readonly DiagnosticDescriptor Rule003 = new(AGSEC003,\n",
+    "        \"Path traversal: non-constant file path\",\n",
+    "        \"File operation on a non-constant path '{0}': validate/contain the path before access\",\n",
+    "        \"Security\", DiagnosticSeverity.Warning, isEnabledByDefault: true);\n",
+    "\n",
+    "    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>\n",
+    "        ImmutableArray.Create(Rule001, Rule002, Rule003);\n",
+    "\n",
+    "    public override void Initialize(AnalysisContext context)\n",
+    "    {\n",
+    "        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);\n",
+    "        context.EnableConcurrentExecution();\n",
+    "        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);\n",
+    "        context.RegisterSyntaxNodeAction(AnalyzeAdd, SyntaxKind.AddExpression);\n",
+    "    }\n",
+    "\n",
+    "    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext ctx)\n",
+    "    {\n",
+    "        var inv = (InvocationExpressionSyntax)ctx.Node;\n",
+    "        var name = inv.Expression.ToString();\n",
+    "        var args = inv.ArgumentList?.Arguments ?? default(SeparatedSyntaxList<ArgumentSyntax>);\n",
+    "\n",
+    "        // AGSEC001 : Process.Start dont the first argument is NOT a compile-time constant\n",
+    "        if (name.Contains(\"Process.Start\") && args.Count > 0 && !IsConstant(ctx, args[0].Expression))\n",
+    "            ctx.ReportDiagnostic(Diagnostic.Create(Rule001, args[0].GetLocation(), args[0].Expression));\n",
+    "\n",
+    "        // AGSEC003 : File.Read/Write/Delete on a non-constant path\n",
+    "        if ((name.StartsWith(\"File.Read\") || name.StartsWith(\"File.Write\") || name.StartsWith(\"File.Delete\"))\n",
+    "            && args.Count > 0 && !IsConstant(ctx, args[0].Expression))\n",
+    "            ctx.ReportDiagnostic(Diagnostic.Create(Rule003, args[0].GetLocation(), args[0].Expression));\n",
+    "    }\n",
+    "\n",
+    "    private static void AnalyzeAdd(SyntaxNodeAnalysisContext ctx)\n",
+    "    {\n",
+    "        // AGSEC002 : \"SELECT ...\" + variable\n",
+    "        var add = (BinaryExpressionSyntax)ctx.Node;\n",
+    "        if (add.Left is not LiteralExpressionSyntax lit || !lit.IsKind(SyntaxKind.StringLiteralExpression)) return;\n",
+    "        if (!IsSqlLike(lit.Token.ValueText)) return;\n",
+    "        ctx.ReportDiagnostic(Diagnostic.Create(Rule002, add.GetLocation(), add.Right));\n",
+    "    }\n",
+    "\n",
+    "    // The semantique key: ask the compiler whether the expression folds to a constant.\n",
+    "    private static bool IsConstant(SyntaxNodeAnalysisContext ctx, ExpressionSyntax expr) =>\n",
+    "        ctx.SemanticModel.GetConstantValue(expr).HasValue;\n",
+    "\n",
+    "    private static bool IsSqlLike(string s)\n",
+    "    {\n",
+    "        var u = s.ToUpperInvariant();\n",
+    "        return u.Contains(\"SELECT \") || u.Contains(\"INSERT \") || u.Contains(\"UPDATE \") || u.Contains(\"DELETE \");\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "\"AgentSafetyAnalyzer defini : 3 regles (AGSEC001/002/003), abonnees aux invocations et aux additions.\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "roslyn-guard-c5",
+   "metadata": {},
+   "source": [
+    "## 2. Le code genere par l'agent\n",
+    "\n",
+    "Imaginons un agent qui produit un handler C#. Il a ecrit ce qui suit -- un melange realiste d'appels sur (litteraux) et dangereux (variables utilisateur) :\n",
+    "\n",
+    "```csharp\n",
+    "public void Run(string userCmd, string userId) {\n",
+    "    Process.Start(\"whoami\");                          // litteral : SUR\n",
+    "    Process.Start(userCmd);                           // variable : DANGEREUX\n",
+    "    var sql = \"SELECT * FROM Users WHERE id=\" + userId;  // concatenation : DANGEREUX\n",
+    "    File.ReadAllText(userId);                         // variable : DANGEREUX\n",
+    "    File.ReadAllText(\"config.json\");                  // litteral : SUR\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "On compile ce source avec l'analyseur branche, et on observe les diagnostics emis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "roslyn-guard-c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T21:32:52.314028Z",
+     "iopub.status.busy": "2026-08-11T21:32:52.313850Z",
+     "iopub.status.idle": "2026-08-11T21:32:53.013892Z",
+     "shell.execute_reply": "2026-08-11T21:32:53.014112Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 diagnostic(s) emis par l'analyseur :\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ligne  ID         Severite  Message\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "L7     AGSEC001   Warning   Process.Start is called with a non-constant value 'userCmd': attacker-controlled input could inject a command\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "L8     AGSEC002   Warning   SQL query built by concatenating 'userId': use a parameterized query (SqlParameter) instead\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "L9     AGSEC003   Warning   File operation on a non-constant path 'userId': validate/contain the path before access\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "Les 2 litteraux (whoami, config.json) sont silencieux : l'analyseur ne flag QUE les variables -> valeur semantique prouvee."
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "var agentCode = @\"\n",
+    "using System.Diagnostics;\n",
+    "using System.IO;\n",
+    "class AgentHandler {\n",
+    "    public void Run(string userCmd, string userId) {\n",
+    "        Process.Start(\"\"whoami\"\");\n",
+    "        Process.Start(userCmd);\n",
+    "        var sql = \"\"SELECT * FROM Users WHERE id=\"\" + userId;\n",
+    "        File.ReadAllText(userId);\n",
+    "        File.ReadAllText(\"\"config.json\"\");\n",
+    "    }\n",
+    "}\";\n",
+    "\n",
+    "var tree = CSharpSyntaxTree.ParseText(agentCode);\n",
+    "var compilation = CSharpCompilation.Create(\"AgentOutput\", new[] { tree });\n",
+    "var analyzer = new AgentSafetyAnalyzer();\n",
+    "var diags = await compilation\n",
+    "    .WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(analyzer))\n",
+    "    .GetAnalyzerDiagnosticsAsync();\n",
+    "\n",
+    "Console.WriteLine($\"{diags.Length} diagnostic(s) emis par l'analyseur :\\n\");\n",
+    "Console.WriteLine($\"{\"Ligne\",-6} {\"ID\",-10} {\"Severite\",-9} Message\");\n",
+    "Console.WriteLine(new string('-', 78));\n",
+    "foreach (var d in diags.OrderBy(d => d.Location.GetMappedLineSpan().StartLinePosition.Line))\n",
+    "{\n",
+    "    var ls = d.Location.GetMappedLineSpan();\n",
+    "    Console.WriteLine($\"L{ls.StartLinePosition.Line + 1,-5} {d.Id,-10} {d.Severity,-9} {d.GetMessage()}\");\n",
+    "}\n",
+    "\n",
+    "// Litteraux \"whoami\" et \"config.json\" : AUCUN diagnostic -> la distinction semantique marche.\n",
+    "string verdit = diags.Count() == 3\n",
+    "    ? \"\\nLes 2 litteraux (whoami, config.json) sont silencieux : l'analyseur ne flag QUE les variables -> valeur semantique prouvee.\"\n",
+    "    : $\"\\nAttention : {diags.Count()} diag(s), attendu 3.\";\n",
+    "verdit\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "roslyn-guard-c7",
+   "metadata": {},
+   "source": [
+    "## 3. Ce qu'un `grep` naif rate\n",
+    "\n",
+    "Comparons les deux approches sur le meme source. Un `grep \"Process.Start\"` compte **tous** les appels -- y compris le litteral sur. L'analyseur, lui, ne signale que l'appel dont l'argument **n'est pas une constante**.\n",
+    "\n",
+    "C'est la difference entre une analyse **textuelle** et une analyse **semantique**. Le grep ne peut pas demander au compilateur si une expression se reduit a une constante ; Roslyn le peut (`SemanticModel.GetConstantValue`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "roslyn-guard-c8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T21:32:53.015933Z",
+     "iopub.status.busy": "2026-08-11T21:32:53.015691Z",
+     "iopub.status.idle": "2026-08-11T21:32:53.067856Z",
+     "shell.execute_reply": "2026-08-11T21:32:53.067965Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "grep naif = 2 appel(s) Process.Start   |   analyseur AGSEC001 = 1 (les litteraux exclus)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "// Approche grep naif : compte toute occurrence de \"Process.Start\"\n",
+    "int grepMatches = System.Text.RegularExpressions.Regex.Count(agentCode, @\"Process\\.Start\\(\");\n",
+    "\n",
+    "// Approche analyseur : compte uniquement les AGSEC001 (argument non-constant)\n",
+    "int analyzerFlags = diags.Count(d => d.Id == AgentSafetyAnalyzer.AGSEC001);\n",
+    "\n",
+    "$\"grep naif = {grepMatches} appel(s) Process.Start   |   analyseur AGSEC001 = {analyzerFlags} (les litteraux exclus)\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "roslyn-guard-c9",
+   "metadata": {},
+   "source": [
+    "## 4. Le correcteur automatique (`CodeFix`)\n",
+    "\n",
+    "Un `DiagnosticAnalyzer` signale ; un `CodeFixProvider` **corrige**. Dans un IDE, il apparait sous l'ampoule ; en CI, il peut etre applique via `dotnet format`. Nous definissons ici la transformation elle-meme (extraite d'un `CodeFixProvider` pour la lisibilite) : elle reecrit la concatenation SQL en chaine interpolation, premiere etape vers une vraie requete parametree.\n",
+    "\n",
+    "La technique est idiomatique Roslyn : on construit le noeud de remplacement par **parsing** (`SyntaxFactory.ParseExpression`), puis on le substitue via `root.ReplaceNode`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "roslyn-guard-c10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T21:32:53.070121Z",
+     "iopub.status.busy": "2026-08-11T21:32:53.069872Z",
+     "iopub.status.idle": "2026-08-11T21:32:53.196497Z",
+     "shell.execute_reply": "2026-08-11T21:32:53.196303Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AVANT : \"SELECT * FROM Users WHERE id=\" + userId\n",
+       "APRES : $\"SELECT * FROM Users WHERE id={userId}\""
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "internal static class SqlConcatCodeFix\n",
+    "{\n",
+    "    // \"SELECT ... \" + var   ->   $\"SELECT ... {var}\"\n",
+    "    // Dans un vrai projet, cette transformation vit dans un CodeFixProvider.RegisterCodeFixesAsync\n",
+    "    // (CodeAction.Create + document.WithSyntaxRoot). On l'applique ici directement sur l'arbre.\n",
+    "    public static ExpressionSyntax ToInterpolated(BinaryExpressionSyntax add)\n",
+    "    {\n",
+    "        var leftText = ((LiteralExpressionSyntax)add.Left).Token.ValueText;\n",
+    "        var right = add.Right.ToString();\n",
+    "        var replacement = $\"$\\\"{leftText}{{{right}}}\\\"\";\n",
+    "        return SyntaxFactory.ParseExpression(replacement).WithTriviaFrom(add);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "var root = await tree.GetRootAsync();\n",
+    "var addExpr = root.DescendantNodes().OfType<BinaryExpressionSyntax>()\n",
+    "    .First(b => b.Kind() == SyntaxKind.AddExpression && b.Left is LiteralExpressionSyntax);\n",
+    "var fixedNode = SqlConcatCodeFix.ToInterpolated(addExpr);\n",
+    "var newRoot = root.ReplaceNode(addExpr, fixedNode);\n",
+    "\n",
+    "$\"AVANT : {addExpr}\\nAPRES : {fixedNode}\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "roslyn-guard-c11",
+   "metadata": {},
+   "source": [
+    "## 5. Brancher l'analyseur sur un vrai projet\n",
+    "\n",
+    "Jusqu'ici nous avons instancie l'analyseur programmatiquement (`WithAnalyzers`). Dans un vrai projet, on l'empaquette dans une **librairie d'analyseurs** (projet `netstandard2.0` reference par le projet consommateur via `<PackageReference>` ou `<ProjectReference>` avec `OutputItemType=Analyzer`), et il s'execute automatiquement a chaque `dotnet build`.\n",
+    "\n",
+    "Regle d'or .NET : activez aussi les analyseurs integrés via `.editorconfig` :\n",
+    "\n",
+    "```ini\n",
+    "[*.cs]\n",
+    "dotnet_analyzer_diagnostic.severity = warning\n",
+    "dotnet_code_quality.enable_platform_analyzer_on_ci = true\n",
+    "```\n",
+    "\n",
+    "Pour vos propres analyseurs (le contenu de ce notebook), l'etape de packaging est un grain separe (voir Exercice 3). Le notebook reste executable **sans** rien installer : tout se passe en memoire via `Microsoft.CodeAnalysis`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "roslyn-guard-c12",
+   "metadata": {},
+   "source": [
+    "## Exercice 1 : ajouter une regle (ReDoS sur regex)\n",
+    "\n",
+    "**Objectif** : ajouter une 4e regle **AGSEC004** qui signale `new Regex(variable)` -- une regex construite depuis une entree utilisateur est un vecteur de **ReDoS** (catastrophic backtracking).\n",
+    "\n",
+    "**Indices** :\n",
+    "- Abonnez-vous au kind `SyntaxKind.ObjectCreationExpression`.\n",
+    "- Verifiez que le type cree est `System.Text.RegularExpressions.Regex` via le modele semantique (`SymbolInfo`).\n",
+    "- Flaggez si le 1er argument n'est pas une constante."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "roslyn-guard-c13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T21:32:53.198042Z",
+     "iopub.status.busy": "2026-08-11T21:32:53.197830Z",
+     "iopub.status.idle": "2026-08-11T21:32:53.233520Z",
+     "shell.execute_reply": "2026-08-11T21:32:53.233275Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer -- implementez BuildReDoSRule() puis branchez-la dans Initialize().\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice a completer : implementer AGSEC004 (Regex non-constant -> ReDoS)\n",
+    "// Indice : ctx.SemanticModel.GetSymbolInfo(objectCreation).Symbol pour verifier le type Regex.\n",
+    "\n",
+    "public DiagnosticDescriptor BuildReDoSRule()\n",
+    "{\n",
+    "    // TODO etudiant : declarer le DiagnosticDescriptor pour AGSEC004\n",
+    "    // (id, titre, message, categorie Security, severity Warning, isEnabledByDefault true)\n",
+    "    return null; // TODO etudiant : remplacer par votre descriptor\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 1 a completer -- implementez BuildReDoSRule() puis branchez-la dans Initialize().\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "roslyn-guard-c14",
+   "metadata": {},
+   "source": [
+    "## Exercice 2 : etendre le codefix vers un vrai `SqlParameter`\n",
+    "\n",
+    "**Objectif** : le codefix actuel transforme la concatenation en interpolation (`$\"...\"`). Ameliorez-le pour produire une **vraie** requete parametree : remplacer la variable par un placeholder `@p0` et generer un commentaire indiquant la creation du `SqlParameter(\"@p0\", var)`.\n",
+    "\n",
+    "**Indice** : modifiez `ToInterpolated` pour construire la chaine `\"SELECT ... WHERE id=@p0\" /* + new SqlParameter(\"@p0\", userId) */`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "roslyn-guard-c15",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T21:32:53.234995Z",
+     "iopub.status.busy": "2026-08-11T21:32:53.234743Z",
+     "iopub.status.idle": "2026-08-11T21:32:53.271868Z",
+     "shell.execute_reply": "2026-08-11T21:32:53.271621Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer -- implementez ToParameterizedSql().\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice a completer : transformer la concatenation SQL en requete parametree.\n",
+    "\n",
+    "public static string ToParameterizedSql(BinaryExpressionSyntax add)\n",
+    "{\n",
+    "    // TODO etudiant : extraire leftText et right, produire la chaine parametree\n",
+    "    // avec un placeholder @p0 + un commentaire SqlParameter.\n",
+    "    return \"Exercice 2 a completer\";\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 2 a completer -- implementez ToParameterizedSql().\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "roslyn-guard-c16",
+   "metadata": {},
+   "source": [
+    "## Exercice 3 : packager l'analyseur pour un vrai `.csproj`\n",
+    "\n",
+    "**Objectif** : transformer la classe `AgentSafetyAnalyzer` en une **librairie d'analyseurs** referencee par un projet console, de maniere a ce qu'elle s'execute a chaque `dotnet build`.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Creer un projet `netstandard2.0` avec `<PackageReference Include=\"Microsoft.CodeAnalysis.CSharp\" Version=\"4.13.0\" />`.\n",
+    "2. Ajouter `[DiagnosticAnalyzer(LanguageNames.CSharp)]` sur la classe.\n",
+    "3. Dans le projet consommateur, referencer l'analyseur via :\n",
+    "   ```xml\n",
+    "   <ProjectReference Include=\"..\\AgentGuardrails\\AgentGuardrails.csproj\"\n",
+    "                     OutputItemType=\"Analyzer\" ReferenceOutputAssembly=\"false\" />\n",
+    "   ```\n",
+    "4. `dotnet build` doit alors faire echouer (ou avertir) sur le code d'agent dangereux."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "roslyn-guard-c17",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T21:32:53.273710Z",
+     "iopub.status.busy": "2026-08-11T21:32:53.273437Z",
+     "iopub.status.idle": "2026-08-11T21:32:53.317025Z",
+     "shell.execute_reply": "2026-08-11T21:32:53.316636Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer -- creer le projet netstandard2.0 + ProjectReference OutputItemType=Analyzer.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice a completer (hors notebook) : packaging en librairie d'analyseurs.\n",
+    "// Indice de validation : apres packaging, un `dotnet build` du projet consommateur\n",
+    "// doit emettre AGSEC001/002/003 sans code de test supplementaire.\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 3 a completer -- creer le projet netstandard2.0 + ProjectReference OutputItemType=Analyzer.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "roslyn-guard-c18",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Nous avons demontre, **avec du code execute** et non de la prose, pourquoi les analyseurs Roslyn sont un garde-fou naturel pour le **code genere par agent** :\n",
+    "\n",
+    "- la verification se fait **dans la compilation**, donc impossible a oublier (contrairement a un linter optionnel) ;\n",
+    "- le **modele semantique** distingue les litteraux surs des variables attaquables -- ce qu'aucun `grep` ne peut faire ;\n",
+    "- un `CodeFixProvider` corrige automatiquement, dans l'IDE comme en CI.\n",
+    "\n",
+    "C'est l'illustration concrete de la these de la serie *The Unexpected AI Stack* : pour **construire et operer** des systemes agentiques, la pile .NET offre des garde-fous que Python n'a pas nativement. Nos notebooks C# n'ont pas a se contenter d'egaler leur jumeau Python -- ils peuvent montrer ce que le Python ne sait pas faire.\n",
+    "\n",
+    "**Prochaines axes de l'Epic** (#10473) : Aspire (orchestration programmable, `#10474`), OpenTelemetry via le dashboard, CSharpRepl attache a un process vivant.\n",
+    "\n",
+    "---\n",
+    "*Sources* : [The Unexpected AI Stack: C#/.NET -- Part 1](https://chrlschn.dev/blog/2026/08/the-unexpected-ai-stack-csharp-dotnet-part-1/) (Charles Chen). [Roslyn analyzers docs](https://learn.microsoft.com/dotnet/csharp/roslyn-sdk/).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2024:CoursIA — prev: DEEP/genai #10487

## Summary

Nouveau notebook autonome démontrant les **analyseurs Roslyn comme garde-fous de code généré par agent** — axe Roslyn de l'Epic #10473 (*The Unexpected AI Stack: C#/.NET*). See #10500 (issue de ce grain) et #10473 (Epic, **jamais** `Closes` : la série publie).

La thèse : quand un agent génère du C#, le compilateur Roslyn peut valider **dans la compilation** avec accès au **modèle sémantique** (valeurs constantes, types) — pas seulement au texte comme `mypy`/`ruff`. C'est un axe où le .NET est structurellement en avance, et que nos notebooks C# peuvent montrer comme **ce que le Python ne sait pas faire**.

## Ce que la PR change (1 fichier nouveau, 0 modification d'existant)

Nouveau notebook : [`MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/Roslyn-Code-Guardrails.ipynb`](MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/Roslyn-Code-Guardrails.ipynb) (dossier existant, pas de nouvelle sous-série). 19 cellules (8 code, 11 markdown) :

1. **`AgentSafetyAnalyzer`** — 3 règles sémantiques (`DiagnosticAnalyzer`) :
   - **AGSEC001** `Process.Start(var)` — risque d'injection de commande
   - **AGSEC002** concatenation SQL (`"SELECT ..." + var`) — injection SQL
   - **AGSEC003** `File.Read/Write/Delete(var)` — path traversal
2. **Valeur ajoutée sémantique (Prong B)** : chaque règle demande au compilateur `SemanticModel.GetConstantValue(expr)` pour distinguer un **littéral sûr** (`Process.Start("whoami")`) d'une **variable attaquable** (`Process.Start(userCmd)`). Un `grep` naif ne le peut pas — démontré dans une cellule dédiée (grep=2 vs analyzer=1 sur `Process.Start`).
3. **Codefix** : transformation de la concatenation SQL en chaine interpolation (`$"SELECT ... {var}"`), via `SyntaxFactory.ParseExpression` + `root.ReplaceNode`.
4. **3 exercices** stub (conformes C.1 : `return null` / `return string` / `Console.WriteLine("à compléter")`, aucun `throw new NotImplementedException`) :
   - AGSEC004 ReDoS sur `new Regex(var)`
   - codefix étendu vers vrai `SqlParameter`
   - packaging en librairie d'analyseurs (`OutputItemType=Analyzer`)

## Preuve d'exécution (règle C.2 / H.1)

Exécuté via `jupyter nbconvert --execute` kernel `.net-csharp` (dotnet-interactive 1.0.617701, SDK 10.0.110). **8/8 cellules code exécutées, 0 erreur**, `execution_count` 1-8, outputs réels :

- Cell 0 : `Microsoft.CodeAnalysis (Roslyn) version: 4.13.0.0`
- Cell 2 : `3 diagnostic(s) emis` → L7 AGSEC001 / L8 AGSEC002 / L9 AGSEC003 + `Les 2 litteraux (whoami, config.json) sont silencieux -> valeur semantique prouvee.`
- Cell 4 : `AVANT: "SELECT * FROM Users WHERE id=" + userId` / `APRES: $"SELECT * FROM Users WHERE id={userId}"`

`strip_probe_banner.py` post-re-exec : **9 lignes probeAddresses strippées** (leak interfaces réseau du runner .NET Interactive, règle secrets-hygiene 6 / L532). `strip_machine_paths.py` : 0 leak.

## Verdict SOTA-OK (Prong A, [sota-not-workaround](.claude/rules/sota-not-workaround.md))

Le **vrai** `Microsoft.CodeAnalysis.CSharp` 4.13.0 est invoqué (`#r "nuget: ..."`), pas une réimplémentation jouet. `CompilationWithAnalyzers.GetAnalyzerDiagnosticsAsync` émet de vrais `Diagnostic` localisés. Validé firsthand dans un probe console avant transcription au notebook.

## Hors scope (G.4 — un sujet par PR)

- Aspire AppHost, CSharpRepl, OpenTelemetry spans : autres axes de l'Epic (#10474 claimé po-2023, filles à ouvrir).
- Analyseurs tiers existants (Roslynator, Meziantou) : cités, pas réinventés.
- Le packaging en librairie (`netstandard2.0` + `ProjectReference OutputItemType=Analyzer`) est l'Exercice 3, hors notebook.

## Vérification

- Anti-churn C.3 : exactement **1 fichier nouveau**, 0 modification d'existant (catalogue `COURSE_CATALOG.*` byte-identique à main).
- 3 exercices (three-exercises-per-notebook).
- Prose FR d'abord (readme-french-first).
- `Grain:` tag ligne 1 du body.
