### PR TITLE
fix(fallacy,#10355): correct language framing — Argumentum is multilingual (8 langues), not French-only

### DIFF
--- a/MyIA.AI.Notebooks/FallacyDetection/02_fallacy_datasets_landscape.ipynb
+++ b/MyIA.AI.Notebooks/FallacyDetection/02_fallacy_datasets_landscape.ipynb
@@ -18,16 +18,7 @@
    "cell_type": "markdown",
    "id": "f9a72029",
    "metadata": {},
-   "source": [
-    "## Methodologie\n",
-    "\n",
-    "Pour chaque dataset, on tente :\n",
-    "1. **Resolution de l'endpoint canonique** (API REST HF / GitHub / URL directe) — capture du code HTTP.\n",
-    "2. **Metadata + cardinalite** (taille, nombre de lignes / classes, licence) depuis l'endpoint ou le manifeste.\n",
-    "3. **Pertinence pour la taxonomie Argumentum** (1408 sophismes / 8 familles, FR) — le dataset est-il etiquete en fallacies, et dans quelle grille ?\n",
-    "\n",
-    "Date d'acces : `2026-08-10`. Chaque chiffre est sourcé par l'URL de l'endpoint interrogé. Les échecs sont explicites (critère 2 : \"succès ou échec documenté\")."
-   ]
+   "source": "## Methodologie\n\nPour chaque dataset, on tente :\n1. **Resolution de l'endpoint canonique** (API REST HF / GitHub / URL directe) — capture du code HTTP.\n2. **Metadata + cardinalite** (taille, nombre de lignes / classes, licence) depuis l'endpoint ou le manifeste.\n3. **Pertinence pour la taxonomie Argumentum** (1408 sophismes / 8 familles, multilingue 8 langues) — le dataset est-il etiquete en fallacies, et dans quelle grille ?\n\nDate d'acces : `2026-08-10`. Chaque chiffre est sourcé par l'URL de l'endpoint interrogé. Les échecs sont explicites (critère 2 : \"succès ou échec documenté\")."
   },
   {
    "cell_type": "code",
@@ -477,12 +468,7 @@
    "cell_type": "markdown",
    "id": "62237251",
    "metadata": {},
-   "source": [
-    "---\n",
-    "### Dataset 7 — Corpus rhetorique francais (si disponible)\n",
-    "\n",
-    "La taxonomie Argumentum est **francaise** ; un corpus rhetorique FR etiquete serait ideal. Recherche sur HF + GitHub."
-   ]
+   "source": "---\n### Dataset 7 — Corpus rhetorique francais (si disponible)\n\nLa taxonomie Argumentum est **multilingue** (parallele sur 8 langues, avec libelles anglais natifs `text_en` / `desc_en` / `example_en`) ; le francais est la langue initiale, non exclusive. Un corpus rhetorique FR etiquete reste utile comme jeu d'evaluation FR complementaire. Recherche sur HF + GitHub."
   },
   {
    "cell_type": "code",
@@ -597,18 +583,7 @@
    "cell_type": "markdown",
    "id": "63290dc5",
    "metadata": {},
-   "source": [
-    "## Conclusion — vers la Phase 2 (dataset builder)\n",
-    "\n",
-    "**Paysage verifies** (acces reel, date d'acces ci-dessus) :\n",
-    "- **Cibles etiquetees fallacy** : Logic/LogicClimate (13 classes) + MAFALDA (23 L2) = base directe pour la Phase 3 (fine-tuning). Tous deux accessibles via GitHub.\n",
-    "- **Sources adjacentes** (non etiquetees fallacy) : IBM debate_speeches, IBM-Rank-30k, AraucariaDB, Reddit ChangeMyView = corpus argumentatifs qu'une Phase 2 (dataset builder) devra etiqueter / projeter dans la grille Argumentum.\n",
-    "- **Corpus FR** : aucun corpus FR etiquete fallace publiquement accessible. La source FR principale reste le **deck-2 Argumentum** (1408 entrees) — a solliciter via les agents Argumentum (Phase 2).\n",
-    "\n",
-    "**Decalage de langue confirme** (cf. survey, extraction Jessynoo) : tous les datasets academiques accessibles sont en **anglais** ; la taxonomie Argumentum est en **francais**. La Phase 2 devra traiter ce gap (traduction d'etiquettes, corpus multilingue, ou restriction initiale au sous-ensemble Argumentum couvert academiquement).\n",
-    "\n",
-    "Voir : [survey SOTA](../../docs/research/fallacy-detection-survey.md) (livrable 1), [extraction Jessynoo](data/jessynoo_rfallacy_anonymized.csv) (livrable 3), [inventaire SAE Qwen](../../MyIA.AI.Notebooks/GenAI/_research/qwen_sae_inventory.md) (livrable 4). EPIC [#10355](https://github.com/jsboige/CoursIA/issues/10355), Phase 1 [#10356](https://github.com/jsboige/CoursIA/issues/10356)."
-   ]
+   "source": "## Conclusion — vers la Phase 2 (dataset builder)\n\n**Paysage verifies** (acces reel, date d'acces ci-dessus) :\n- **Cibles etiquetees fallacy** : Logic/LogicClimate (13 classes) + MAFALDA (23 L2) = base directe pour la Phase 3 (fine-tuning). Tous deux accessibles via GitHub.\n- **Sources adjacentes** (non etiquetees fallacy) : IBM debate_speeches, IBM-Rank-30k, AraucariaDB, Reddit ChangeMyView = corpus argumentatifs qu'une Phase 2 (dataset builder) devra etiqueter / projeter dans la grille Argumentum.\n- **Corpus FR** : aucun corpus FR etiquete fallacy publiquement accessible (recherche HF + GitHub ci-dessus). La source FR principale reste le **deck-2 Argumentum** (1408 entrees) — a solliciter via les agents Argumentum (Phase 2). Notons que la taxonomie Argumentum elle-meme est **multilingue** (8 langues, anglais natif inclus), donc ce n'est pas un corpus strictement FR.\n\n**Langue** : les datasets academiques accessibles sont en **anglais**, mais la taxonomie Argumentum est **multilingue** (8 langues, anglais natif inclus via les champs `text_en` / `desc_en` / `example_en`) — non uniquement francaise. **Pas de pont de langue a construire** entre le corpus d'entrainement EN et la taxonomie cible. Le levier reel est une evaluation **cross-lingue** (entrainer sur une langue, tester sur une autre, sur un meme noeud de taxonomie) qu'Argumentum rend possible ligne a ligne.\n\nVoir : [survey SOTA](../../docs/research/fallacy-detection-survey.md) (livrable 1), [extraction Jessynoo](data/jessynoo_rfallacy_anonymized.csv) (livrable 3), [inventaire SAE Qwen](../../MyIA.AI.Notebooks/GenAI/_research/qwen_sae_inventory.md) (livrable 4). EPIC [#10355](https://github.com/jsboige/CoursIA/issues/10355), Phase 1 [#10356](https://github.com/jsboige/CoursIA/issues/10356)."
   }
  ],
  "metadata": {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: DEEP/notebook-dotnet (#10483)

Corrige le « décalage de langue confirmé EN/FR » du notebook landscape Phase 1 (PR #10367, merged), qui se fondait sur l'affirmation inexacte « La taxonomie Argumentum est française ». Sur demande owner (jsboige) en session directe 2026-08-11 — voir [issuecomment-5258701578](https://github.com/jsboige/CoursIA/issues/10355#issuecomment-5258701578) sur l'Epic #10355.

## Le défaut (mesuré firsthand sur origin/main)

Le notebook `02_fallacy_datasets_landscape.ipynb` posait le constat erroné **deux fois** :

- **cell[15]** (dataset 7 intro) : « La taxonomie Argumentum est **française** ; un corpus rhétorique FR étiqueté serait idéal. »
- **cell[19]** (conclusion) : « **Décalage de langue confirmé** […] tous les datasets académiques accessibles sont en **anglais** ; la taxonomie Argumentum est en **français**. La Phase 2 devra traiter ce gap (traduction d'étiquettes, corpus multilingue…). »
- **cell[2]** (méthodologie) : « (1408 sophismes / 8 familles, **FR**) »

**Inexact** : la taxonomie Argumentum est **parallèle sur 8 langues** avec libellés anglais natifs (`text_en` / `desc_en` / `example_en`) ; le français est la langue initiale, non exclusive. Ce point est **déjà établi dans le fil #10355** (comment `myia-ai-01` 2026-08-10 : « Il n'y a pas de pont de langue à construire, et le chantier de traduction que la Phase 2 s'apprêtait à budgéter tombe »), mais n'avait **pas été répercuté** dans le notebook landscape livré, qui continuait d'afficher le « décalage de langue » comme un fait. Le fil et le livrable se contredisaient.

## La correction (markdown-only, 3 cellules)

| Cellule | Avant | Après |
|---|---|---|
| `f9a72029` (méthodo) | `(1408 sophismes / 8 familles, FR)` | `(1408 sophismes / 8 familles, multilingue 8 langues)` |
| `62237251` (dataset 7) | « La taxonomie Argumentum est **française** » | encadrement multilingue (8 langues, anglais natif) |
| `63290dc5` (conclusion) | « **Décalage de langue confirmé** […] Argumentum est en **français** » | reformulation : pas de pont de langue à construire ; le vrai levier est l'évaluation **cross-lingue** (entraîner sur une langue, tester sur une autre) |

La bullet « Corpus FR » de la conclusion précise aussi qu'aucun corpus FR étiqueté fallacy n'est publiquement accessible (recherche HF+GitHub ci-dessus), et que la taxonomie Argumentum elle-même étant multilingue, ce n'est pas un corpus strictement FR.

## Preuves (anti-régression)

- **Markdown-only** : 3 cellules markdown éditées, **0 cellule code sur 11** touchée. Outputs et `execution_count` préservés cellule-par-cellule (vérifié : `0 cellule avec autre changement`). Diff `+4/−29`.
- **Exception règle C** : aucune cellule code source modifiée → outputs précédents valides, pas de re-exécution requise (les résultats de recherche HF/GH restent vrais et honnêtes).
- **nbformat.validate OK** (20 cells, structure intacte).
- **0 leak** dans les 3 cellules éditées.
- **L898 collision** : aucune PR OPEN sur ce notebook (uniquement #10367 merged = le landscape original).

## Pourquoi MED/notebook-python (G-VAR-1)

Correction d'un finding qui **change une décision** : la Phase 2 ne budgète plus le chantier de traduction FR/EN (le livrable paysage l'orientait à tort). Litmus MED « change quelque chose de réel » = OUI ; litmus LIGHT « générable en série par scan » = NON (a nécessité de croiser le fil #10355, les comments ai-01 et le contenu exact du livrable).

See #10355 (Epic), See #10356 (Phase 1). Correction du livrable 2 (landscape, PR #10367).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
