### PR TITLE
fix(check_lane_claim,#10505): [OVERRIDE] paths: clause honored by reducer (scoped override no longer epic-wide)

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -354,9 +354,32 @@ def compute_active_claims(events: list[ClaimEvent]) -> tuple[dict, list[ClaimEve
             unattributed.append(ev)
             continue
         if ev.is_override:
-            # Coordinator adjudication (#10223): grant to this lane, close all
-            # others. Later events (open/close) still apply on top in walk order.
-            state = {ev.lane: ev}
+            # Coordinator adjudication (#10223): grant to this lane. The
+            # optional `paths:` clause (#10342, #10505) BOUNDS the "close
+            # others" effect to the override's scope instead of closing every
+            # other lane unconditionally. An unscoped override keeps the legacy
+            # epic-wide semantics (closes all). A scoped override closes only
+            # claims that INTERSECT it -- where intersection reuses the same
+            # convention as `_filter_by_claim_scope`: a claim with no `paths`
+            # clause is epic-wide (claims everything) so it intersects any
+            # scope and is closed; a scoped claim is closed iff its paths
+            # match the override's (fnmatch via `_path_matches_any`). The
+            # symmetry is deliberate: disjointness must require BOTH sides to
+            # declare a scope, at the reducer just as at the filter.
+            # Later events (open/close) still apply on top in walk order.
+            scope = ev.get("paths")
+            if not scope:
+                state = {ev.lane: ev}
+            else:
+                state = {
+                    ln: e for ln, e in state.items()
+                    if ln == ev.lane
+                    or (
+                        e.get("paths") is not None
+                        and not _path_matches_any(scope, e.get("paths") or [])
+                    )
+                }
+                state[ev.lane] = ev
         elif ev.is_open:
             state[ev.lane] = ev
         else:

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -826,6 +826,84 @@ def test_reducer_preserves_override_scope_payload():
     ]
 
 
+# --- reducer HONOURS the `paths:` clause on [OVERRIDE] (#10505) --------------
+#
+# Pre-#10505 the reducer did `state = {ev.lane: ev}` unconditionally -- a
+# scoped [OVERRIDE] read as epic-wide, silently closing every other lane's
+# claim (including scoped claims DISJOINT from the override). The four cases
+# below pin the corrected behaviour: a scoped override closes only claims
+# that intersect it. Intersection mirrors `_filter_by_claim_scope`: an
+# epic-wide claim (paths=None) intersects any scope (it claims everything);
+# a scoped claim is closed iff its paths match the override's (fnmatch).
+
+def _ev(action, lane, body, ts, paths_clause=None):
+    """Build a ClaimEvent straight from primitives (no comment parsing)."""
+    return clc.ClaimEvent(
+        lane=lane, action=action, marker={"open": "CLAIMED", "override": "OVERRIDE",
+                                          "close": "RELEASED"}[action],
+        created_at=ts, author="x", url=None,
+        paths=paths_clause, intent=None,
+    )
+
+
+def test_reducer_scoped_override_keeps_disjoint_scoped_claim():
+    # Override scoped to Lean/** ; a claim scoped to scripts/** is DISJOINT
+    # -> it MUST survive in the active state. Pre-#10505 it was closed (bug).
+    events = [
+        _ev("open", "A:CoursIA", "claim scripts", "2026-08-11T22:00:00Z",
+            paths_clause=["scripts/**"]),
+        _ev("override", "B:CoursIA", "reassign Lean only", "2026-08-11T22:30:00Z",
+            paths_clause=["MyIA.AI.Notebooks/SymbolicAI/Lean/**"]),
+    ]
+    active, _ = clc.compute_active_claims(events)
+    assert set(active) == {"A:CoursIA", "B:CoursIA"}  # both survive (disjoint)
+
+
+def test_reducer_scoped_override_closes_intersecting_scoped_claim():
+    # Override scoped to Lean/** ; a claim also scoped to Lean/** INTERSECTS
+    # -> it is closed. Same verdict as epic-wide, but via the scope rule.
+    events = [
+        _ev("open", "A:CoursIA", "claim Lean", "2026-08-11T22:00:00Z",
+            paths_clause=["MyIA.AI.Notebooks/SymbolicAI/Lean/**"]),
+        _ev("override", "B:CoursIA", "reassign Lean only", "2026-08-11T22:30:00Z",
+            paths_clause=["MyIA.AI.Notebooks/SymbolicAI/Lean/**"]),
+    ]
+    active, _ = clc.compute_active_claims(events)
+    assert set(active) == {"B:CoursIA"}  # A closed (intersecting scope)
+
+
+def test_reducer_scoped_override_closes_epic_wide_claim():
+    # Override scoped to Lean/** ; an EPIC-WIDE claim (paths=None) claims
+    # everything, so it intersects any scope -> closed. This is the rule the
+    # issue calls out explicitly (point 1): it keeps the #10289 behaviour
+    # identical (the epic-wide PT-11b claim was closed either way) but by an
+    # explicit, tested rule rather than an ignored scope.
+    events = [
+        _ev("open", "A:CoursIA", "claim all", "2026-08-11T22:00:00Z",
+            paths_clause=None),
+        _ev("override", "B:CoursIA", "reassign Lean only", "2026-08-11T22:30:00Z",
+            paths_clause=["MyIA.AI.Notebooks/SymbolicAI/Lean/**"]),
+    ]
+    active, _ = clc.compute_active_claims(events)
+    assert set(active) == {"B:CoursIA"}  # epic-wide A closed
+
+
+def test_reducer_epic_wide_override_closes_everything():
+    # Regression of #10223: an EPIC-WIDE override (no paths clause) closes
+    # every other lane, scoped or not. The scoped-override branch must not
+    # weaken the legacy behaviour.
+    events = [
+        _ev("open", "A:CoursIA", "claim Lean", "2026-08-11T22:00:00Z",
+            paths_clause=["MyIA.AI.Notebooks/SymbolicAI/Lean/**"]),
+        _ev("open", "C:CoursIA", "claim all", "2026-08-11T22:05:00Z",
+            paths_clause=None),
+        _ev("override", "B:CoursIA", "epic-wide reassign", "2026-08-11T22:30:00Z",
+            paths_clause=None),
+    ]
+    active, _ = clc.compute_active_claims(events)
+    assert set(active) == {"B:CoursIA"}  # every other lane closed
+
+
 # --- the actual SCOPE behaviour at the check layer ---------------------------
 
 def test_check_override_no_paths_preserves_legacy_epic_wide_behaviour(capsys):


### PR DESCRIPTION
Quoi: `compute_active_claims` honore enfin la clause `paths:` sur [OVERRIDE] -- un override scope ne ferme plus toutes les autres lanes (comportement epic-wide fantôme) mais seulement les claims dont le scope intersecte le sien.
Preuve: 4 tests de régression (scripts/tests/test_check_lane_claim.py) pins les 4 cas de #10505 -- disjoint survive / intersecting closed / epic-wide closed / epic-wide override closes all. Suite entière 109 passed (82 check_lane_claim + 27 lane_claim_required). Revert-check firsthand: OLD code {B} vs NEW {A,B} sur le cas disjoint -> le test echoue pre-fix, passe post-fix. `_path_matches_any` existant reutilise (pas de nouveau helper), symetrie avec `_filter_by_claim_scope` preservee (les deux cotes doivent declarer un scope pour la disjointness).
Perimetre: scripts/check_lane_claim.py reducer (compute_active_claims, ~25 lignes) + 4 tests. Aucun notebook, aucun Lean, aucune regle harnais. Check-layer (_filter_by_claim_scope) inchange -- il etait deja correct, c'est le reducer qui ignorait le scope.

Grain: LIGHT/guard-tooling -- lane myia-po-2026:CoursIA -- prev: Lean #10486 diagnosis

Closes #10505

## Contexte

`[OVERRIDE]` est une adjudication du coordinateur (#10223). Pre-#10342 il etait epic-wide (ferme toutes les autres lanes). #10342 a introduit une clause `paths:` optionnelle pour SCOPE l'override, et la doc + le check-layer (`_filter_by_claim_scope`) l'honorent -- mais le REDUCER `compute_active_claims` faisait `state = {ev.lane: ev}` inconditionnellement, ignorant `ev.get("paths")`. Un override scope se comportait donc exactement comme un override epic-wide: il fermait silencieusement les claims des lanes voisines meme quand leur scope etait disjoint.

La docstring de `_filter_by_claim_scope` le disait elle-meme: "The reducer `compute_active_claims` is untouched; this filter only prunes the `others` view." Le filtre corrigeait le verdict humain, mais l'ETAT (active_claims dans le JSON d'audit) restait faux -- et un coordinateur qui ecrit `[OVERRIDE] lane X -- paths: A/**` croyait borner son arbitrage au perimetre A alors que l'organe fermait quand meme les claims sur B.

## Le fix

`compute_active_claims` rend le remplacement conditionnel au scope, en reutilisant la mecanique d'intersection deja presente (`_path_matches_any`, le meme helper que `_filter_by_claim_scope`):

- Override SANS `paths:` (epic-wide) -> `state = {ev.lane: ev}` (legacy #10223, regression-pinned).
- Override AVEC `paths:` -> ferme seulement les claims dont le scope intersecte le sien. Une claim sans `paths:` (epic-wide, revendique tout) intersecte n'importe quel scope -> fermee. Une claim scope est fermee ssi ses paths matchent ceux de l'override (fnmatch).

Les deux points "a trancher" de l'issue sont decides et testes:
1. Claim epic-wide vs override scope -> fermee (la claim sans scope revendique tout).
2. Symetrie avec `_filter_by_claim_scope`: la disjointness exige que les deux cotes declarent un scope.

## Tests

4 tests de regression + les 78 existants toujours verts (109 total). Le test `test_reducer_scoped_override_keeps_disjoint_scoped_claim` est celui qui manquait -- il aurait attrape le defaut (A:CoursIA scope scripts/** survive un override B:CoursIA scope Lean/**).
