### PR TITLE
docs(qc,#10488): enrich Sector-Momentum deep_research prose (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Sector-Momentum/deep_research_optimization.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Sector-Momentum/deep_research_optimization.ipynb
@@ -16,25 +16,25 @@
    "source": [
     "# Deep Research: Sector Momentum Optimization\n",
     "\n",
-    "## Objective\n",
-    "Maximize Sharpe ratio for the Sector Momentum strategy.\n",
+    "## Objectif\n",
+    "Maximiser le ratio de Sharpe de la stratégie *Sector Momentum* en balayant ses quatre leveurs (fenêtre de *lookback*, seuil VIX, levier, nombre de secteurs retenus). Le notebook ne se contente pas de trouver « les meilleurs paramètres » : il cherche aussi à comprendre **pourquoi** ils le sont, afin de distinguer un vrai signal d'un artefact d'optimisation sur une seule trajectoire historique.\n",
     "\n",
-    "## Strategy Overview\n",
-    "- **Assets**: 9 sector ETFs (XLK, XLF, XLV, XLY, XLP, XLE, XLB, XLU, XLRE)\n",
-    "- **Signal**: Dual momentum (relative strength + absolute momentum)\n",
-    "- **Rebalancing**: Monthly rotation to top-performing sectors\n",
-    "- **Risk Management**: VIX filter to skip rebalancing in high volatility\n",
+    "## Vue d'ensemble de la stratégie\n",
+    "- **Actifs** : 9 ETF sectoriels (XLK, XLF, XLV, XLY, XLP, XLE, XLB, XLU, XLRE) — une décomposition de l'économie US en rotateurs de cycle plutôt qu'en actions isolées.\n",
+    "- **Signal** : *dual momentum* (force relative entre secteurs + momentum absolu) — on achète ce qui monte, à condition que ce monte en valeur absolue.\n",
+    "- **Rééquilibrage** : rotation mensuelle vers les secteurs les mieux classés.\n",
+    "- **Gestion du risque** : filtre VIX qui suspend le rééquilibrage en régime de volatilité hostile.\n",
     "\n",
-    "## Current Parameters\n",
-    "- `lookback_period`: 126 days (6 months)\n",
-    "- `vix_threshold`: 25 (skip rebalancing if VIX > 25)\n",
-    "- `leverage`: 1.5x\n",
+    "## Paramètres courants (avant optimisation)\n",
+    "- `lookback_period` : 126 jours (~6 mois)\n",
+    "- `vix_threshold` : 25 (on saute le rééquilibrage si VIX > 25)\n",
+    "- `leverage` : 1.5x\n",
     "\n",
-    "## Research Questions\n",
-    "1. What is the optimal lookback period for momentum calculation?\n",
-    "2. Should the VIX threshold be dynamic (percentile-based)?\n",
-    "3. What leverage maximizes risk-adjusted returns?\n",
-    "4. How many sectors should we hold (diversification vs concentration)?"
+    "## Questions de recherche\n",
+    "1. Quelle fenêtre de *lookback* capte le mieux le signal momentum avant qu'il ne mean-reverse ?\n",
+    "2. Le seuil VIX doit-il être dynamique (basé sur les percentiles) plutôt qu'absolu ?\n",
+    "3. Quel levier maximise le rendement **ajusté du risque** (et non le rendement brut) ?\n",
+    "4. Combien de secteurs retenir — la diversification dilue-t-elle le signal, ou l'amplifie-t-elle en le concentrant ?\n"
    ]
   },
   {
@@ -104,7 +104,9 @@
     "tags": []
    },
    "source": [
-    "Téléchargement des données historiques des ETFs sectoriels (XLK, XLF, XLE, XLV, XLI, etc.) via yfinance depuis 2010 pour le backtest Sector-Momentum."
+    "## Téléchargement de l'univers sectoriel\n",
+    "\n",
+    "On charge l'historique des 9 ETF sectoriels et du VIX depuis 2010 (sortie de la crise financière : on évite ainsi le régime 2008-2009 dont la dynamique de volatilité écraserait tout signal momentum ultérieur). Le point important est la **reproductibilité** : un cache fige les données téléchargées via `yfinance`, de sorte que deux exécutions du notebook — aujourd'hui et dans six mois — travaillent sur la même trajectoire. Sans cette précaution, toute optimisation serait non-comparable d'une exécution à l'autre, et le « meilleur Sharpe » deviendrait une cible mouvante.\n"
    ]
   },
   {
@@ -168,6 +170,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "deepresearch-interp-data",
+   "metadata": {},
+   "source": [
+    "**Lecture des sorties.** L'univers charge 9 ETF sectoriels couvrant ~15 ans de cotation (3804 jours de VIX). Les `hit` du cache confirment que la trajectoire est figée : le notebook est reproductible. Notons que `XLI` (Industrials) apparaît dans la liste de téléchargement de la prose mais pas dans l'univers final des 9 — l'univers effectif est XLK/XLF/XLV/XLY/XLP/XLE/XLB/XLU/XLRE, soit la décomposition Sector SPDR canonique. C'est un point à garder en tête pour l'interprétation : le signal momentum porte sur ces 9 rotateurs, pas sur un panier plus large.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6b8b3c7e",
    "metadata": {
     "papermill": {
@@ -180,7 +190,9 @@
     "tags": []
    },
    "source": [
-    "Analyse statistique du VIX (moyenne, médiane, percentiles 75/90) pour calibrer le filtre de volatilité de la stratégie Sector-Momentum."
+    "## Calibration du filtre VIX\n",
+    "\n",
+    "Le filtre VIX défend la stratégie : il suspend le rééquilibrage quand la volatilité implicite du marché entre en régime hostile. Calibrer son seuil est un arbitrage coût/bénéfice — un seuil trop bas filtre trop souvent et laisse le stratège hors-marché pendant les rebonds ; un seuil trop haut ne filtre plus que les crises extrêmes et laisse passer la volatilité ordinaire. La cellule suivante mesure la **distribution empirique** du VIX (moyenne, médiane, percentiles) pour ancrer ce seuil dans la statistique réelle de l'échantillon plutôt que dans une règle arbitraire.\n"
    ]
   },
   {
@@ -238,6 +250,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "deepresearch-interp-vix",
+   "metadata": {},
+   "source": [
+    "**Lecture des statistiques VIX.** La distribution est **asymétrique à droite** : moyenne 18.36, médiane 16.59 — l'écart signale une longue queue de valeurs hautes (crises). Le percentile 90 à 27.02 et les jours au-dessus de 30 (6.4 % seulement) montrent que le régime extrême est rare mais marqué. Deux conséquences pour le calibrage du filtre : (1) un seuil absolu de 25 filtre ~29.2 % des jours (au-dessus de la moyenne), ce qui est **beaucoup** pour un filtre défensif ; (2) un seuil de 35 ne filtre que les ~6 % de jours de panique franche. Le grid search tranchera lequel des deux protège réellement le Sharpe — l'intuition « filtrer plus = plus sûr » n'est pas garantie, car chaque jour filtré est aussi un rebond manqué.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "afaaafbf",
    "metadata": {
     "papermill": {
@@ -250,7 +270,9 @@
     "tags": []
    },
    "source": [
-    "Le facteur momentum est calculé sur les rendements passés pour classer et sélectionner les actifs de la stratégie Sector-Momentum."
+    "## Calcul du facteur momentum\n",
+    "\n",
+    "Le momentum classe les secteurs par rendement passé sur la fenêtre de *lookback*. Le présupposé comportemental est l'**under-reaction** : les prix intègrent lentement l'information, si bien que les secteurs qui ont surperformé continuent statistically de le faire sur l'horizon court-moyen. La fenêtre de 126 jours (~6 mois) est le choix par défaut de la littérature (Jegadeesh-Titman), mais elle n'est pas nécessairement optimale pour des ETF sectoriels dont la rotation de cycle peut être plus rapide — c'est précisément ce que le grid search va trancher.\n"
    ]
   },
   {
@@ -341,6 +363,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "deepresearch-interp-momentum",
+   "metadata": {},
+   "source": [
+    "**Lecture des scores momentum.** À la date la plus récente, XLF (Financials) et XLY (Consumer Discretionary) dominent (1.55, 1.52), tandis que XLV (Healthcare) est négatif (-0.29) — une carte typique de régime *risk-on* où les valeurs cycliques mènent et les défensives décrochent. Le tableau de fréquence est plus instructif : Utilities arrive en tête (650 occurrences dans le top), devant Technology (640). C'est **contre-intuitif** pour une stratégie « momentum » (Utilities = défensif), et c'est précisément le signal que le momentum sectoriels capture mal seul : la persistance dépend du régime. C'est un argument pour le *dual momentum* (relatif + absolu) — le relatif seul raterait pourquoi Utilities, peu volatil, persiste si souvent.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5aaedb66",
    "metadata": {
     "papermill": {
@@ -353,7 +383,9 @@
     "tags": []
    },
    "source": [
-    "Les ratios (Sharpe, drawdown) sont calculés à partir des rendements du backtest pour évaluer la qualité de la stratégie Sector-Momentum."
+    "## Backtest de la configuration courante\n",
+    "\n",
+    "Le backtest calcule la trajectoire de richesse de la stratégie sur l'échantillon et en déduit deux métriques complémentaires : le **ratio de Sharpe** (rendement ajusté de la volatilité — pénalise un signal bruité) et le **drawdown maximal** (perte de pic à creux — pénalise un signal dont la volétile vient ruin). Les deux sont nécessaires : un Sharpe élevé obtenu au prix d'un drawdown profond n'est pas investissable, parce qu'un investisseur réel abandonnerait la stratégie avant le rebond. La cellule suivante apply les paramètres courants (126/25/1.5) pour établir la **baseline** que l'optimisation devra battre.\n"
    ]
   },
   {
@@ -476,6 +508,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "deepresearch-interp-backtest",
+   "metadata": {},
+   "source": [
+    "**Lecture de la baseline.** Sharpe 1.653 est un point de départ solide. Le signal d'alarme est le **drawdown de -120.7 %** : avec un levier de 1.5, la stratégie a perdu à un creux plus que la totalité du capital non levé. Concrètement, un investisseur ayant mis 100 $ aurait vu le levier le pousser en territoire de *margin call* avant le rebond. Un drawdown > 100 % n'est pas un détail de présentation — c'est la signature d'une stratégie **non-survivable** à ce levier. C'est la première chose que l'optimisation doit corriger (en réduisant le levier ou la concentration), avant même de chercher à monter le Sharpe. Un Sharpe de 1.65 qui tue son porteur en route n'est pas un résultat investissable.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "eb08467b",
    "metadata": {
     "papermill": {
@@ -488,7 +528,9 @@
     "tags": []
    },
    "source": [
-    "Les métriques de performance (Sharpe, CAGR, drawdown) sont agrégées sur les résultats de l'optimisation pour identifier les configurations Pareto-optimales."
+    "## Grid search sur les quatre leviers\n",
+    "\n",
+    "Le grid search balaye 320 combinaisons (5 *lookback* × 4 seuils VIX × 4 leviers × 4 *top_n*) et retient, pour chacune, le Sharpe réalisé. C'est un **balayage exhaustif en échantillon** : il trouve la configuration qui aurait été optimale sur cette trajectoire passée. La précaution est de ne pas confondre « optimal en échantillon » et « optimal à venir » — avec 320 combinaisons testées sur une seule trajectoire de 15 ans, le risque de surajustement est réel. La lecture des résultats doit donc privilégier les **tendances stables** (un paramètre qui gagne sur plusieurs configurations voisines) plutôt que le singleton absolu du top-1, et c'est ce que le tableau des 15 meilleures combinaisons permet de faire.\n"
    ]
   },
   {
@@ -634,6 +676,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "deepresearch-interp-gridsearch",
+   "metadata": {},
+   "source": [
+    "**Lecture du grid search.** Les 15 meilleures combinaisons dessinent un motif lisible :\n",
+    "\n",
+    "- **LevierSharpe-invariant** : les 4 premières lignes (levier 1.0 à 2.0) partagent le même Sharpe (2.016) et le même drawdown. Le levier ne crée pas de valeur ajustée du risque — il scale rendement et volatilité de pair. C'est la propriété fondamentale du levier en marché efficient, et elle dit que **le « bon » levier est un choix de tolérance, pas une variable à optimiser**.\n",
+    "- **Lookback 90 > 126** : le signal momentum sectoriel vit plus court que le canon 6-mois. Le paramètre par défaut de la baseline n'était pas optimal.\n",
+    "- **top_n = 2** partout : la concentration dans les 2 meilleurs secteurs bat la diversification. Le signal est assez fort pour être amplifié plutôt qu'amorti.\n",
+    "- **Seuil VIX = 35** : le filtre gagne à rester quasi-inactif. Sur cet échantillon, filtrer coûte plus qu'il ne protège.\n",
+    "\n",
+    "**Réserve** : le drawdown affiché (~-6 %) pour ~3720x de rendement cumulé est **mécaniquement suspect**. À reconcilier avec la baseline avant déploiement.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9ac7cfa8",
    "metadata": {
     "papermill": {
@@ -646,25 +703,32 @@
     "tags": []
    },
    "source": [
-    "## Research Findings & Recommendations\n",
+    "## Conclusions et recommandations\n",
     "\n",
-    "### Analysis Summary\n",
-    "Based on the grid search:\n",
+    "### Lecture des résultats du grid search\n",
     "\n",
-    "1. **Optimal Lookback**: The sweet spot for momentum calculation period\n",
-    "2. **VIX Threshold**: Balances risk reduction vs. opportunity cost\n",
-    "3. **Leverage**: Higher leverage increases returns but also drawdown\n",
-    "4. **Top N Sectors**: Diversification vs. concentration trade-off\n",
+    "Le balayage révèle quatre régularités plus robustes que le singleton du top-1 :\n",
     "\n",
-    "### Recommended Parameters\n",
+    "1. **Lookback court (90 jours > 126 jours)** — le momentum sectoriel décroît vite ; un signal sur ~3 mois bat le canon 6 mois de la littérature actions-individuelles. C'est cohérent avec une rotation de cycle plus rapide que le momentum *stock-picking*.\n",
+    "2. **Concentration (top_n = 2)** — retenir seulement les 2 meilleurs secteurs bat systématiquement la diversification (top_n = 3 ou 4). Le signal est assez fort pour que la concentration l'amplifie, plutôt que de l'amortir.\n",
+    "3. **Sharpe insensible au levier** — les 4 meilleures lignes ont des leviers de 1.0 à 2.0 et **le même Sharpe** (2.016). C'est attendu : le levier scale rendement et volatilité proportionnellement, donc le rendement ajusté du risque ne bouge pas. Optimiser le Sharpe sur le levier est une **illusion** — le levier est un choix de tolérance au risque, pas un paramètre de signal.\n",
+    "4. **Seuil VIX élevé (35 > 25)** — le filtre gagne à être peu actif. À 35, seuls ~6 % des jours sont filtrés ; à 25, ~29 %. Le filtre VIX coûte plus (opportunités manquées) qu'il ne protège, sur cet échantillon.\n",
+    "\n",
+    "### Configuration recommandée\n",
     "\n",
     "```python\n",
-    "# In main.py or Alpha model\n",
-    "LOOKBACK_PERIOD = <VALUE>  # From grid search\n",
-    "VIX_THRESHOLD = <VALUE>  # From grid search\n",
-    "LEVERAGE = <VALUE>  # From grid search\n",
-    "TOP_N_SECTORS = <VALUE>  # From grid search\n",
-    "```"
+    "# Dans main.py ou le modèle Alpha\n",
+    "LOOKBACK_PERIOD = 90    # momentum 3-mois > 6-mois (décroissance rapide du signal sectoriel)\n",
+    "VIX_THRESHOLD = 35      # filtre minimal — le VIX coûte plus qu'il ne protège ici\n",
+    "LEVERAGE = 1.0          # le Sharpe est insensible au levier ; 1.0 = pas de ruine possible\n",
+    "TOP_N_SECTORS = 2       # concentration — le signal est assez fort pour l'amplifier\n",
+    "```\n",
+    "\n",
+    "Sharpe attendu (en échantillon) : **~2.0**, contre **1.65** pour la baseline 126/25/1.5.\n",
+    "\n",
+    "### Réserve méthodologique\n",
+    "\n",
+    "Le drawdown maximal affiché pour la configuration optimisée (~-6 %) semble bas au regard du rendement cumulé (~3720x) et demande à être **vérifié** : sur un rendement de cet ordre, un drawdown de 6 % est mécaniquement suspect (soit la métrique est calculée sur une base différente de la baseline, soit le levier n'est pas appliqué uniformément dans le grid). Avant tout déploiement, il faut reconcilier l'échelle du drawdown entre la baseline (-120 % à levier 1.5) et le grid (-6 %), et confirmer que le levier est effectivement appliqué. C'est la différence entre un backtest présentable et un backtest investissable.\n"
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/tooling #10507

## Summary

Enrichissement pédagogique (markdown-only) de `deep_research_optimization.ipynb`, première unité de la poche P1 `partner-course-quant-trading` dispatchée par ai-01 (#10488, claim scopee `issuecomment-5259472171`). Le notebook passait de 2130 à ~11k chars de prose en interprétant les **vraies sorties** (Sharpe 1.653 → 2.016, VIX mean 18.36 / median 16.59, lookback 90 > 126, top_n=2, Sharpe insensible au levier) — l'objectif du mandat #10488 est la densité *bien ficelée* (interprétation après la cellule interprétée, citant les valeurs réelles, pas de transition générique).

See #10488. **Pas `Closes #10488`** : la poche P1 compte 5 unités (celle-ci + 2 paires FR/EN à synchroniser), dispatchées en PR atomiques.

## Ce que la PR change (1 notebook, markdown-only, 0 cellule code touchée)

- **6 cellules markdown existantes** ([0,2,4,6,8,10,12]) développées : le WHAT (une ligne) devient WHAT + WHY (pourquoi 2010, pourquoi le filtre VIX, pourquoi 126 jours, pourquoi Sharpe ET drawdown, pourquoi grid search = surajustement potentiel).
- **5 nouvelles cellules d'interprétation** insérées APRÈS les cellules code à sortie ([3,5,7,9,11]) — citent les valeurs réellement présentes dans les outputs.
- **Conclusion [12]** : les placeholders `<VALUE>` sont remplacés par les vrais meilleurs paramètres issus du grid search + une réserve méthodologique.

## Interprétations ancrées dans les sorties réelles (extrait)

- **Cell [9] baseline** : Sharpe 1.653, mais **drawdown -120.7 %** à levier 1.5 → « signature d'une stratégie non-survivable à ce levier », le signal d'alarme que l'optimisation doit corriger avant même de chercher à monter le Sharpe.
- **Cell [11] grid search** : les 4 meilleures lignes partagent le **même Sharpe (2.016) à leviers 1.0–2.0** → le levier scale rendement et volatilité de pair, optimiser le Sharpe sur le levier est une illusion (le « bon » levier est un choix de tolérance, pas un paramètre de signal).
- **Lookback 90 > 126** : le momentum sectoriel décroît plus vite que le canon 6-mois de la littérature *stock-picking*.
- **top_n = 2 partout** : la concentration bat la diversification (le signal est assez fort pour être amplifié).
- **VIX threshold 35 > 25** : le filtre gagne à rester quasi-inactif (6 % vs 29 % de jours filtrés).
- **Réserve honnête** : le drawdown ~-6 % affiché pour ~3720x de rendement cumulé est mécaniquement suspect — à reconcilier avec la baseline avant déploiement.

## Vérification (acceptance #10488 + C.2 exception markdown-only)

- **Code cells byte-identiques à `origin/main`** : vérifié mécaniquement (script Python, comparaison source + `execution_count` + `outputs` + `id` sur les 6 cellules code) — **6/6 True**. Aucune cellule code touchée → exception C.2 markdown-only, **pas de re-exécution requise** (quantbook QC Cloud, mais on n'en a pas besoin).
- **Anti-churn C.3** : exactement 1 fichier diffère de `origin/main`, les cellules code sont préservées byte-à-byte.
- **nbformat 4.5 valide**, 18 cells (6 code + 12 md), tous les `id` présents, `ensure_ascii=False` + indent=1 préservés (format du fichier source mesuré).
- **Aucune transition générique** (« Suite du traitement », « Passons à l'étape suivante ») : chaque cellule dit ce que la suivante établit et pourquoi c'est la suite logique, en citant les valeurs de l'output précédent.
- **Pas de nombre fabriqué** : toutes les valeurs citées (18.36, 16.59, 1.653, -120.7 %, 2.016, 90, 2, 35) proviennent des outputs committés.
- Catalogue byte-identique à main. Grain tag ligne 1.

## Hors scope (G.4)

Les 4 autres unités de la poche P1 (2 paires FR/EN `research.ipynb`/`research_en.ipynb` + `research_robustness`) seront des PR séparées — ne pas synchroniser une paire dans la même PR que celle-ci.

## Modalité d'exécution

Markdown-only → pas de re-exécution locale ni QC Cloud (exception C.2). Si une cellule code avait dû être touchée, j'aurais stoppé et signalé ai-01 (changement de modalité d'exécution).
