### PR TITLE
feat(pr-gate,#10433): workflow_run re-aggregation posts verdict onto PR head (item-1)

### DIFF
--- a/.github/workflows/pr-gate-rerun.yml
+++ b/.github/workflows/pr-gate-rerun.yml
@@ -1,0 +1,116 @@
+name: PR gate (re-aggregate)
+
+# Re-aggregation path for the stale-rollup defect (#10433 item-1 / #10435).
+# Sister workflow to pr-gate.yml. Keep them in separate files on purpose: the
+# delivery canary in pr_gate.py (derive_always_on_jobs) scans every workflow in
+# this directory for jobs that run on EVERY pull_request and expects to find
+# them on each PR. A workflow_run-only job does not run on pull_request, so
+# folding it into pr-gate.yml (whose workflow-level trigger IS pull_request)
+# would make the canary wait for a check that never surfaces -- tripping the
+# #9858 partial-delivery alarm on ~180 merges/day. This file has NO pull_request
+# trigger, so the canary skips it entirely (derive_always_on_jobs returns None
+# from _pull_request_trigger and continues).
+#
+# What this fixes: pr-gate.yml aggregates once on pull_request with up to a
+# 90-min settle window. If a required guard (Variation Tag Guard) flips green
+# AFTER that aggregation, the PR stays BLOCKED on a stale FAIL until a manual
+# `gh run rerun`. This workflow re-aggregates the CURRENT check set when that
+# guard completes and POSTs the fresh verdict onto the PR head SHA.
+#
+# Why an explicit check-run POST (not the job's auto check-run): a workflow_run
+# job runs on the DEFAULT branch, so GITHUB_SHA is the default-branch commit and
+# the auto check-run lands there -- invisible to the PR head's mergeState (gh pr
+# checks, mergeStateStatus). pr_gate.py with --post-check-run POSTs a check-run
+# onto github.event.workflow_run.head_sha (the guard's SHA = the PR head), named
+# "PR gate" (--self-name) so it matches the required check on `main`.
+
+on:
+  workflow_run:
+    workflows: ["Variation Tag Guard"]
+    types: [completed]
+  # Manual dispatch for testing the re-aggregation path without waiting for a
+  # guard run. PR_NUMBER/HEAD_SHA default to empty; the job then no-ops unless
+  # both are supplied.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number whose head SHA to re-aggregate (testing only)'
+        required: false
+        default: ''
+      head_sha:
+        description: 'Head SHA to re-aggregate (defaults to the PR head)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  checks: write   # POST the check-run onto the PR head SHA (#10433 item-1)
+  statuses: read
+
+concurrency:
+  # One re-aggregation per PR at a time: a later guard-completion supersedes an
+  # in-flight one for the same PR.
+  group: pr-gate-rerun-${{ github.event.workflow_run.pull_requests[0].number || github.event.inputs.pr_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  reaggregate:
+    name: Re-aggregate after guard flip
+    runs-on: ubuntu-latest
+    # Above the script's own 90 min budget (mirrors pr-gate.yml): the script
+    # prints its verdict rather than the runner killing it mid-poll.
+    timeout-minutes: 100
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install canary dependency
+        # PyYAML drives derive_always_on_jobs (the rule-8 delivery canary). Same
+        # reason as pr-gate.yml: if the install fails, the script self-disables
+        # the canary (safe, no block) but the #9858 hole stays open.
+        run: pip install pyyaml
+
+      - name: Re-aggregate check verdicts onto the PR head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # The PR list travels in the workflow_run payload; index 0 is the PR
+          # the guard built for. Absent when the guard ran on a non-PR commit
+          # (e.g. a push to main) or when invoked via workflow_dispatch.
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number || github.event.inputs.pr_number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.event.inputs.head_sha }}
+        run: |
+          set -eu
+          # No PR associated with this guard run -> nothing to unblock.
+          # Fail-safe: skip rather than POST onto a bare commit (the
+          # pull_request path in pr-gate.yml already covers PR heads on open).
+          if [ -z "$PR_NUMBER" ] || [ -z "$HEAD_SHA" ]; then
+            echo "[pr-gate] workflow_run has no PR head to re-aggregate -- skip"
+            exit 0
+          fi
+          # workflow_run runs on the default branch, so it cannot read
+          # pull_request.head.repo.fork from the event. Resolve it via the PR
+          # number, then mirror pr-gate.yml's fork short-circuit (#10072): a
+          # fork PR must surface success on its head SHA, not a stale FAIL.
+          IS_FORK=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" \
+            --jq '.head.repo.fork' 2>/dev/null || echo false)
+          if [ "$IS_FORK" = "true" ]; then
+            IS_FORK_ARG="--is-fork"
+          else
+            IS_FORK_ARG=""
+          fi
+          # --post-check-run: POST the verdict onto HEAD_SHA (the PR head),
+          # because this job's auto check-run would land on the default branch.
+          # --self-name "PR gate": the POSTed check-run matches the required
+          # check name on `main` (same string as pr-gate.yml's gate job).
+          python scripts/pr_gate.py \
+            --repo "${{ github.repository }}" \
+            --sha "${HEAD_SHA}" \
+            --self-name "PR gate" \
+            --timeout-min 90 \
+            --poll-sec 30 \
+            --settle-polls 2 \
+            --post-check-run \
+            $IS_FORK_ARG

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -33,9 +33,12 @@ name: PR gate
 # `workflow_run`-triggered job posts its check-run on the workflow's default
 # branch commit, NOT on the PR head SHA, so it is invisible to `gh pr checks`
 # and to mergeState until the job also POSTS a check-run onto the PR head SHA
-# via the Checks API. That posting step is deliberately deferred to a follow-up
-# grain (it needs `actions: write` and a posting script); this file documents
-# the gap rather than papering over it.
+# via the Checks API. That posting step is implemented in the sister workflow
+# pr-gate-rerun.yml (#10433 item-1): a `workflow_run` trigger on Variation Tag
+# Guard completion + `--post-check-run` in pr_gate.py POSTs the re-aggregated
+# conclusion onto github.event.workflow_run.head_sha. Kept in a separate file
+# so this workflow's pull_request trigger does not make the delivery canary
+# (derive_always_on_jobs) wait for a workflow_run-only job on every PR.
 
 on:
   pull_request:

--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -425,6 +425,77 @@ def _gh_api(path: str) -> object:
         raise GateError(f"gh api {path} returned non-JSON: {exc}") from exc
 
 
+def _gh_api_post(path: str, fields: dict[str, str]) -> dict:
+    """Call `gh api -X POST <path>` with one `-f key=value` per field.
+
+    Mirror of :func:`_gh_api` for the Checks-API writes the re-aggregation path
+    needs (#10433 item-1). Any failure is fatal to the caller (rule 1); the
+    orchestrator wraps it so a POST failure never flips a verdict.
+    """
+    cmd = ["gh", "api", "-X", "POST", path]
+    for key, value in fields.items():
+        cmd += ["-f", f"{key}={value}"]
+    try:
+        completed = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - environment problem
+        raise GateError(f"gh CLI not available: {exc}") from exc
+
+    if completed.returncode != 0:
+        raise GateError(
+            f"gh api -X POST {path} failed (exit {completed.returncode}): "
+            f"{completed.stderr.strip()[:400]}"
+        )
+    body = completed.stdout.strip()
+    if not body:
+        return {}
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise GateError(f"gh api -X POST {path} returned non-JSON: {exc}") from exc
+
+
+def post_check_run(
+    repo: str,
+    sha: str,
+    name: str,
+    code: int,
+    message: str,
+    *,
+    poster=None,
+) -> dict:
+    """POST a completed check-run onto ``sha`` via the Checks API.
+
+    The ``workflow_run`` re-aggregation job (#10433 item-1) re-runs the verdict
+    but cannot rely on the job's auto check-run: for ``workflow_run``,
+    ``GITHUB_SHA`` is the *default-branch* commit, so the auto check-run lands
+    there and is invisible to the PR head's ``mergeState``. This POSTs a fresh
+    check-run onto the PR head SHA (``head_sha``) so the re-aggregated
+    conclusion surfaces on the PR.
+
+    ``code`` follows :func:`main`'s convention: 0 = success, 1 = failure.
+    ``poster`` is injectable so unit tests can assert the payload without the
+    network. Resolved at call time (not bound at definition) so monkeypatching
+    ``pr_gate._gh_api_post`` is seen by the default path.
+    """
+    if poster is None:
+        poster = _gh_api_post
+    title = message.splitlines()[0] if message else name
+    fields = {
+        "name": name,
+        "head_sha": sha,
+        "status": "completed",
+        "conclusion": "success" if code == 0 else "failure",
+        "output[title]": f"{name}: {title}"[:255],
+        "output[summary]": message or title,
+    }
+    return poster(f"repos/{repo}/check-runs", fields)
+
+
 def fetch_checks(repo: str, sha: str) -> list[dict]:
     """Union of check runs and legacy commit statuses for one SHA."""
     checks: list[dict] = []
@@ -560,6 +631,17 @@ def main(argv: Iterable[str] | None = None) -> int:
         action="store_true",
         help="Disable the rule-8 delivery canary (escape hatch only).",
     )
+    parser.add_argument(
+        "--post-check-run",
+        action="store_true",
+        help=(
+            "POST the verdict as a completed check-run onto --sha via the "
+            "Checks API. Used by the workflow_run re-aggregation job (#10433 "
+            "item-1): that job's auto check-run lands on the default-branch "
+            "commit, not the PR head, so without this POST the re-aggregated "
+            "verdict is invisible to the PR's mergeState."
+        ),
+    )
     args = parser.parse_args(list(argv) if argv is not None else None)
 
     if args.is_fork:
@@ -570,6 +652,13 @@ def main(argv: Iterable[str] | None = None) -> int:
             "[pr-gate] fork PR -- out of scope (issue #10072); "
             "reporting PASS without polling.",
             flush=True,
+        )
+        # The workflow_run re-aggregation path runs on the default branch, so it
+        # cannot read the fork flag from the pull_request payload. It still POSTs
+        # here: a fork PR must surface `success` on its head SHA to match the
+        # --is-fork short-circuit (#10072), not a stale aggregated FAIL.
+        _maybe_post_check_run(
+            args, 0, "PASS -- fork PR short-circuit (issue #10072)"
         )
         return 0
 
@@ -598,10 +687,38 @@ def main(argv: Iterable[str] | None = None) -> int:
     except GateError as exc:
         # Rule 1: an unreadable state is a failure, never a pass.
         print(f"[pr-gate] FAIL -- cannot establish check state: {exc}", file=sys.stderr)
+        _maybe_post_check_run(args, 1, f"FAIL -- cannot establish check state: {exc}")
         return 1
 
     print(f"[pr-gate] {message}", flush=True)
+    _maybe_post_check_run(args, code, message)
     return code
+
+
+def _maybe_post_check_run(args, code: int, message: str) -> None:
+    """POST the verdict as a check-run if ``--post-check-run`` was given.
+
+    The wrapper around :func:`post_check_run` that makes a POST failure
+    non-fatal: a failed POST leaves the stale check in place (the status quo
+    before #10433 item-1), never a false PASS. The exit code already reflects
+    the verdict; this only concerns whether the fresh verdict *surfaces* on the
+    PR head.
+    """
+    if not args.post_check_run:
+        return
+    try:
+        post_check_run(args.repo, args.sha, args.self_name, code, message)
+    except GateError as exc:
+        print(
+            f"[pr-gate] WARN -- check-run POST failed, stale check stays: {exc}",
+            file=sys.stderr,
+        )
+        return
+    conclusion = "success" if code == 0 else "failure"
+    print(
+        f"[pr-gate] posted check-run on {args.sha[:7]} (conclusion={conclusion})",
+        flush=True,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -617,3 +617,123 @@ def test_inflight_required_check_settles_to_pass_on_reroll():
     assert not pending2 and not bad2 and ok2 == [name]
     code2, _msg2 = pr_gate.verdict(pending2, bad2, settled=True)
     assert code2 == 0
+
+
+# --- workflow_run re-aggregation: post the verdict onto the PR head (#10433) -
+#
+# item-1 of #10433: the workflow_run trigger re-runs the verdict but its auto
+# check-run lands on the default-branch commit (GITHUB_SHA), invisible to the
+# PR head's mergeState. The fix is to POST a fresh check-run onto the PR head
+# SHA. These tests pin (a) the payload shape, (b) that --post-check-run fires
+# on every verdict path, and (c) that a POST failure never flips the exit code.
+
+
+def test_post_check_run_payload_on_pass():
+    """A success verdict POSTs conclusion=success onto the head SHA."""
+    captured = {}
+
+    def fake_poster(path, fields):
+        captured["path"] = path
+        captured["fields"] = fields
+        return {"id": 42}
+
+    out = pr_gate.post_check_run(
+        "o/r", "abc1234", "PR gate", 0, "PASS -- 3 checks green", poster=fake_poster
+    )
+    assert out == {"id": 42}
+    assert captured["path"] == "repos/o/r/check-runs"
+    f = captured["fields"]
+    assert f["name"] == "PR gate"
+    assert f["head_sha"] == "abc1234"
+    assert f["status"] == "completed"
+    assert f["conclusion"] == "success"
+    assert f["output[title]"].startswith("PR gate: PASS")
+    assert f["output[summary]"] == "PASS -- 3 checks green"
+
+
+def test_post_check_run_payload_on_fail():
+    """A failure verdict POSTs conclusion=failure, not silently success."""
+    captured = {}
+
+    def fake_poster(_path, fields):
+        captured["fields"] = fields
+        return {}
+
+    pr_gate.post_check_run("o/r", "abc1234", "PR gate", 1, "FAIL -- Lean CI", poster=fake_poster)
+    assert captured["fields"]["conclusion"] == "failure"
+
+
+def test_main_posts_on_pass_when_flag_set(monkeypatch):
+    """--post-check-run POSTs the success verdict onto the head SHA."""
+    monkeypatch.setattr(
+        pr_gate,
+        "wait_and_decide",
+        lambda *_a, **_kw: (0, "PASS -- no failing checks"),
+    )
+    posted = {}
+    monkeypatch.setattr(pr_gate, "_gh_api_post", lambda path, fields: posted.update({"path": path, "fields": fields}) or {})
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef", "--post-check-run"]
+    )
+    assert code == 0
+    assert posted["fields"]["head_sha"] == "deadbeef"
+    assert posted["fields"]["conclusion"] == "success"
+
+
+def test_main_posts_on_fail_when_flag_set(monkeypatch):
+    """--post-check-run POSTs the failure verdict too (not a silent skip)."""
+    monkeypatch.setattr(
+        pr_gate,
+        "wait_and_decide",
+        lambda *_a, **_kw: (1, "FAIL -- failing checks: Lean CI"),
+    )
+    posted = {}
+    monkeypatch.setattr(pr_gate, "_gh_api_post", lambda path, fields: posted.update({"conclusion": fields["conclusion"]}) or {})
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef", "--post-check-run"]
+    )
+    assert code == 1
+    assert posted["conclusion"] == "failure"
+
+
+def test_main_posts_success_on_fork_with_flag(monkeypatch):
+    """Fork + --post-check-run surfaces success on the head SHA (#10072).
+
+    The workflow_run job runs on the default branch and cannot read the fork
+    flag from the pull_request payload; it still POSTs, and the fork path must
+    POST success (matching the --is-fork short-circuit), not a stale FAIL.
+    """
+    monkeypatch.setattr(
+        pr_gate,
+        "wait_and_decide",
+        lambda *_a, **_kw: (_ for _ in ()).throw(AssertionError("fork must not poll")),
+    )
+    posted = {}
+    monkeypatch.setattr(pr_gate, "_gh_api_post", lambda path, fields: posted.update({"conclusion": fields["conclusion"]}) or {})
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef", "--is-fork", "--post-check-run"]
+    )
+    assert code == 0
+    assert posted["conclusion"] == "success"
+
+
+def test_post_failure_is_non_fatal(monkeypatch, capsys):
+    """A failed POST leaves the stale check (status quo), never flips the code."""
+    monkeypatch.setattr(
+        pr_gate,
+        "wait_and_decide",
+        lambda *_a, **_kw: (0, "PASS -- no failing checks"),
+    )
+
+    def failing_poster(_path, _fields):
+        raise pr_gate.GateError("403 forbidden")
+
+    monkeypatch.setattr(pr_gate, "_gh_api_post", failing_poster)
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef", "--post-check-run"]
+    )
+    # The verdict is still PASS (exit 0); only the POST failed.
+    assert code == 0
+    err = capsys.readouterr().err
+    assert "check-run POST failed" in err
+    assert "stale check stays" in err


### PR DESCRIPTION
Quoi: item-1 of #10433 — when a required guard (Variation Tag Guard) flips green AFTER the PR gate's pull_request job settled, the PR stayed BLOCKED on a stale FAIL until a manual `gh run rerun` (~180 merges/day). This adds the structural re-aggregation path #10492 documented but deferred ("needs actions:write + a posting script"): a workflow_run trigger + a `--post-check-run` flag that POSTs the fresh verdict onto the PR head SHA.

Preuve: 46/46 tests pass (40 existing + 6 new). The 6 new pin: (1) post_check_run payload on pass — `head_sha`/`conclusion=success`/`output[summary]` asserted; (2) payload on fail — `conclusion=failure`; (3) main posts on pass with flag; (4) main posts on fail with flag; (5) fork + flag posts success (#10072); (6) POST failure is non-fatal — exit code preserved, stale check stays. py_compile OK, both YAMLs parse. label-paths guard PASS. The canary self-exclusion test (test_derive_always_on_reads_real_workflows_and_excludes_self) guided the design: a single-file reaggregate job named "PR gate (...)" tripped it -> moved to a separate pr-gate-rerun.yml (no pull_request trigger -> canary skips it). Variation Tag Guard verified to run on pull_request (so workflow_run fires for PRs).

Perimetre: 4 files, +359/-3. (1) scripts/pr_gate.py — `_gh_api_post` + `post_check_run` (call-time poster resolution so monkeypatch is seen) + `--post-check-run` flag + `_maybe_post_check_run` wrapper (non-fatal); wired into all 3 return paths (fork/GateError/normal). (2) .github/workflows/pr-gate-rerun.yml (NEW) — workflow_run on "Variation Tag Guard" completion, resolves head_sha -> PR via workflow_run.pull_requests[0].number, re-runs pr_gate.py --post-check-run. (3) .github/workflows/pr-gate.yml — header comment only (deferred->implemented-in-sister-file). (4) scripts/tests/test_pr_gate.py — 6 new tests. Catalogue byte-identical. Items 2/3/4 already shipped in #10492 (not touched).

Grain: LIGHT/ci-infra — lane myia-po-2026:CoursIA — prev: MED/tooling #10509

---

# How it works

The pull_request job in pr-gate.yml is **byte-identical** to main — it keeps producing its auto check-run (correct: for pull_request, GITHUB_SHA = PR head). The re-aggregation is a separate, additive path:

1. Variation Tag Guard completes (success OR failure) on a PR.
2. pr-gate-rerun.yml's `workflow_run` trigger fires.
3. The `reaggregate` job resolves `github.event.workflow_run.head_sha` → PR number (`workflow_run.pull_requests[0].number`), skips if not a PR head (push-to-main guard runs).
4. Resolves the fork flag (workflow_run runs on default branch, can't read `pull_request.head.repo.fork`) via `gh api pulls/{n}`.
5. Re-runs `pr_gate.py --post-check-run --self-name "PR gate"` — aggregates the CURRENT check set (the guard is now green) and POSTs a check-run named "PR gate" onto the PR head SHA. That fresh check-run (conclusion=success) supersedes the stale FAIL in mergeState.

# Why separate file (the canary constraint)

`derive_always_on_jobs` scans every workflow in `.github/workflows/` for jobs that run on EVERY pull_request and expects them on each PR. A workflow_run-only job does not run on pull_request. Folding reaggregate into pr-gate.yml (whose workflow trigger IS pull_request) would make the canary wait for a check that never surfaces → #9858 partial-delivery alarm → ~180 merges/day blocked. `pr-gate-rerun.yml` has NO pull_request trigger, so `_pull_request_trigger` returns None and the canary skips it. The canary test caught this before push.

# Residual risk (honest, for review)

The `workflow_run` trigger and `pull_requests[0].number` resolution cannot be exercised locally — they fire only post-merge (workflow_run runs on the default branch). Mitigations:
- **Additive only**: the pull_request path is byte-identical; a bug in reaggregate leaves the status quo (PR stays blocked, as today), never a regression on the primary gate.
- **No false PASS possible**: the exit code still governs the verdict; --post-check-run only controls whether it *surfaces*. A POST failure is non-fatal (test 6).
- **Fork-safe**: --is-fork resolved via PR number, posts success on fork head (#10072).

Closes #10433 (item-1, the structural fix; items 2/3/4 shipped in #10492). See #10435 (twin — ai-01 may close as duplicate).
