### PR TITLE
docs(qc,#10488): enrich Sector-Momentum research_robustness prose FR+EN (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Sector-Momentum/research_robustness.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Sector-Momentum/research_robustness.ipynb
@@ -235,7 +235,9 @@
     "tags": []
    },
    "source": [
-    "Les régimes de volatilité (faible/élevée) sont identifiés pour adapter dynamiquement l'exposition de la stratégie Sector-Momentum."
+    "## Régimes de marché et momentum hebdomadaire\n",
+    "\n",
+    "Le momentum sectoriel ne vit pas dans un monde stationnaire : il **dépend du régime**. On agrège donc les données en fréquence hebdomadaire (réduit le bruit haute-fréquence sans perdre le signal de rotation) et on identifie les régimes *bull/bear/crash* (2015-2019 bull, 2020 COVID, 2021 recovery, 2022 bear, 2023-2025 AI bull) qui serviront à découper l'analyse de sensibilité. L'enjeu est de ne pas mesurer une performance « moyenne » qui lisse un régime favorable avec un crash — c'est précisément ce que le Sharpe 2.53 sur 7 mois de bull fait, et ce que la décomposition par régime va démasquer.\n"
    ]
   },
   {
@@ -337,6 +339,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "robustness-fr-interp-3",
+   "metadata": {},
+   "source": [
+    "**Lecture des régimes.** L'échantillon couvre 410 semaines hebdomadaires. Les premières valeurs de momentum hebdomadaire montrent la structure attendue : des rendements sectoriels divergents (XLK +2.3 %, XLV +3.1 % sur une même semaine de juillet 2018) — c'est cette divergence que la stratégie exploite en allouant aux secteurs les plus forts. LaNaN initiale correspond à la fenêtre de calcul du momentum (il faut quelques semaines pour établir le signal). Notons que la période 2018-2026 englobe **délibérément** le crash COVID (2020) et le bear market inflationniste (2022) : sans ces deux régimes hostiles, aucune conclusion de robustesse n'est possible.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "750ead53",
    "metadata": {
     "papermill": {
@@ -349,7 +359,9 @@
     "tags": []
    },
    "source": [
-    "Les ratios (Sharpe, drawdown) sont calculés sur plusieurs fenêtres de backtest pour évaluer la robustesse de la stratégie Sector-Momentum."
+    "## Backtest sur l'échantillon complet (le verdict du Sharpe réel)\n",
+    "\n",
+    "On applique la configuration courante (levier 2x) sur l'ensemble de l'échantillon 2018-2026 — pas seulement les 7 mois du backtest trompeur. C'est le moment où l'inflation du Sharpe se révèle : la cellule suivante produit le Sharpe **réel** sur ~8 ans, et la chute par rapport à 2.53 est la leçon centrale du notebook. Un backtest honnête inclut les bear markets ; un backtest qui les évite est une publicité, pas une validation.\n"
    ]
   },
   {
@@ -495,6 +507,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "robustness-fr-interp-5",
+   "metadata": {},
+   "source": [
+    "**Le verdict du Sharpe réel.** Sur ~8 ans (2018-2026), le Sharpe tombe à **0.697** — contre **2.53** affiché sur les 7 mois de bull market. C'est une chute de **72 %**, exactement l'ordre de grandeur annoncé en intro (0.5-0.8 attendu). Le drawdown maximal grimpe à **-45.8 %** avec le levier 2x. La conclusion est tranchée : le Sharpe 2.53 n'était pas une performance de stratégie, c'était l'artifact d'une fenêtre choisie dans le seul régime favorable. `avg_sectors_selected: 6.1` indique aussi que la stratégie sélectionne en moyenne 6 secteurs sur 9 — une diversification large, pas la concentration top-2 du notebook d'optimisation. C'est cohérent avec un signal momentum plus diffus en régime réel qu'en optimisation in-sample.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ed89bfec",
    "metadata": {
     "papermill": {
@@ -507,7 +527,9 @@
     "tags": []
    },
    "source": [
-    "La courbe de rendement cumulatif et les périodes de drawdown de la stratégie Sector-Momentum sont affichées pour l'analyse du risque."
+    "## Sensibilité au levier, par régime\n",
+    "\n",
+    "C'est l'analyse la plus révélatrice. On balaye trois niveaux de levier (1x, 1.5x, 2x) **dans chaque régime séparément**. Le présupposé naïf est « plus de levier = plus de Sharpe » : la cellule suivante montre que c'est **faux**. Le levier amplifie le rendement ET la volatilité dans les mêmes proportions, donc le Sharpe (rendement/volatilité) est invariant au levier dans chaque régime — mais le drawdown maximal, lui, explose. C'est la distinction cruciale : le levier n'améliore jamais le rendement ajusté du risque, il ne fait qu'aggraver la ruine quand le régime tourne.\n"
    ]
   },
   {
@@ -735,6 +757,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "robustness-fr-interp-7",
+   "metadata": {},
+   "source": [
+    "**Lecture de la sensibilité par régime.** Le tableau confirme trois faits décisifs :\n",
+    "\n",
+    "1. **Le Sharpe est invariant au levier dans chaque régime** — 0.35 partout en Bull 2015-2019, 2.45 partout en Recovery 2021, -0.08 partout en COVID et Bear 2022. Le levier ne crée **jamais** de valeur ajustée du risque : il scale rendement et volatilité de pair. C'est la propriété mathématique fondamentale du levier, et elle dit que tout « Sharpe optimal » trouvé en balayant le levier est une illusion d'optimiseur.\n",
+    "2. **Le drawdown, lui, n'est pas invariant** — il explose avec le levier : Bull -19.8 % → -36.4 %, Bear 2022 -25.4 % → **-45.8 %**. C'est le coût caché du levier : il ne change pas l'espérance, il change la **survivabilité**. Un drawdown de -45.8 % à levier 2x signifie qu'un investisseur à 100 $ est passé à 54 $ au creux — s'il a abandonné là (et la plupart le font), il a cristallisé la perte avant le rebond.\n",
+    "3. **Le Sharpe dépend du régime, pas du levier** — Recovery 2021 = 2.45 (excellent), COVID 2020 et Bear 2022 = -0.08 (négatif). La stratégie ne « marche pas » dans l'absolu : elle marche en tendance, et explose en reversal. C'est le profil de risque propre au momentum (crash factor), documenté depuis 2020.\n",
+    "\n",
+    "Le levier « optimal » n'est donc pas celui qui maximise le Sharpe (tous égaux) — c'est celui que le drawdown tolérable autorise. 1.0x survit à tout ; 2.0x ne survit pas à 2022.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7980c28a",
    "metadata": {
     "papermill": {
@@ -747,7 +783,9 @@
     "tags": []
    },
    "source": [
-    "Le Sharpe ratio glissant est tracé sur toute la période pour valider que la stratégie de rotation sectorielle reste performante dans le temps."
+    "## Validation walk-forward (le test ultime d'honnêteté)\n",
+    "\n",
+    "Le walk-forward est l'antidote au surajustement. On entraîne le choix de levier sur une fenêtre passée (2 ans), puis on teste sur une fenêtre future (6 mois) que le modèle n'a **jamais vue**. On répète sur toute la période, en glissant la fenêtre. Si la stratégie marche vraiment, le Sharpe hors-échantillon tiendra ; si elle était surajustée, il s'effondrera. Le verdict de la cellule suivante est sans appel : le walk-forward choisit systématiquement le levier **le plus bas** (1.0x) — l'optimiseur lui-même refuse le 2x qui avait produit le Sharpe 2.53 trompeur.\n"
    ]
   },
   {
@@ -984,6 +1022,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "robustness-fr-interp-9",
+   "metadata": {},
+   "source": [
+    "**Lecture du walk-forward.** Sur 11 fenêtres test hors-échantillon, le verdict est nuancé mais honnête :\n",
+    "\n",
+    "- **Sharpe moyen test : 1.20**, return moyen +7.2 % par période de 6 mois. La stratégie a une valeur prédictive réelle — ce n'est pas du bruit.\n",
+    "- **Le levier optimal choisi est TOUJOURS 1.0x** (le plus bas). L'optimiseur, confronté à des données qu'il n'a pas vues, refuse systématiquement le 2x du backtest trompeur. C'est la signature d'un modèle qui « sait » (via le walk-forward) que le levier élevé est dangereux hors-échantillon.\n",
+    "- **La variance est énorme** : le test 2024-06→2024-12 atteint **+3.41** (le meilleur, AI bull), mais le test 2021-12→2022-06 plonge à **-2.19** (le bear market kill). Un Sharpe moyen de 1.20 cache cette dispersion — c'est pourquoi le drawdown maximal moyen (-8.1 %) est un meilleur guide pour l'investisseur que le Sharpe moyen.\n",
+    "\n",
+    "**La contradiction apparente** : l'observation finale du code dit « 1.5x est un compromis robuste », mais les données montrent que le walk-forward choisit 1.0x à chaque fois. Le « 1.5x » est un choix humain (tolérance au drawdown intermédiaire), pas une conclusion de l'optimisation — l'optimisation, elle, dit 1.0x. Cette distinction méritait d'être nommée.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d40d7017",
    "metadata": {
     "papermill": {
@@ -1197,6 +1249,16 @@
     "    json.dump(recommendations, f, indent=2)\n",
     "\n",
     "print(f\"\\nRecommendations sauvegardees dans: {output_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "robustness-fr-interp-11",
+   "metadata": {},
+   "source": [
+    "**Lecture des recommandations.** Le JSON final codifie la leçon en changements concrets pour `main.py` : étendre la période (inclure 2020 et 2022), réduire le levier 2→1.5. C'est la traduction opérationnelle du verdict du walk-forward. Le `current_sharpe: 2.53` reste documenté comme le chiffre **à ne pas faire confiance** — il est conservé non comme une performance, mais comme la preuve du défaut que cette analyse démasque.\n",
+    "\n",
+    "**Ce que ce notebook enseigne, au-delà des chiffres.** Un backtest n'est valide que s'il inclut les régimes hostiles ; un Sharpe sans drawdown est une moitié de mesure ; un levier qui n'a pas été testé hors-échantillon est un pari. La robustesse n'est pas un Sharpe élevé — c'est un Sharpe qui **tient** quand le régime tourne, et un drawdown qu'un investisseur réel peut traverser sans abandonner.\n"
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #10510

## Summary

Enrichissement pédagogique (markdown-only) du **FR source** `research_robustness.ipynb` (Sector-Momentum), 2ᵉ unité de la poche P1 `partner-course-quant-trading` (#10488 dispatch ai-01). Le notebook porte le fil rouge honnête « 7 mois de bull market n'est PAS un backtest valide » : le Sharpe 2.53 affiché est un artifact, le Sharpe réel sur ~8 ans est **0.697**. L'enrichissement développe les 4 markdown one-liners [2,4,6,8] et insère 5 cellules d'interprétation APRÈS les outputs, citant les vraies valeurs.

**Le sibling EN n'est PAS touché** (réverti après amend) : `research_robustness_en.ipynb` est un fichier de traduction **dérivé** — la convention (#10308 translation-guard) interdit de le hand-éditer. Le pipeline `translation-sync.yml` le régénérera automatiquement depuis le FR après merge (T1 extrait cells changées → T3 re-traduit → T4 re-rend). La paire se re-synchronise via le pipeline, pas à la main.

See #10488. **Pas `Closes #10488`** : la poche P1 compte plusieurs unités, dispatchées en PR atomiques.

## Ce que la PR change (1 notebook FR, markdown-only, 0 cellule code touchée)

- **4 cellules markdown existantes** ([2,4,6,8]) développées : le WHAT (une ligne) devient WHAT + WHY (pourquoi régime, pourquoi échantillon complet, pourquoi sensibilité par régime, pourquoi walk-forward = test d'honnêteté).
- **5 nouvelles cellules d'interprétation** insérées APRÈS les outputs ([3,5,7,9,11]) — citent les valeurs réelles présentes dans les outputs.

## Interprétations ancrées dans les sorties réelles (extrait)

- **Cell [5] Sharpe réel** : sur ~8 ans (2018-2026), Sharpe **0.697** vs **2.53** sur 7 mois = chute de **72 %**, drawdown max **-45.8 %** à levier 2x. Le verdict central : le Sharpe 2.53 n'était pas une performance, c'était l'artifact d'une fenêtre cherry-pickée dans le seul régime favorable.
- **Cell [7] sensibilité par régime** : le Sharpe est **invariant au levier dans chaque régime** (0.35 partout en Bull 2015-2019, 2.45 partout en Recovery 2021, -0.08 partout en COVID/Bear 2022) → le levier ne crée jamais de valeur ajustée du risque. Mais le drawdown **explose** (Bull -19.8 %→-36.4 %, Bear 2022 -25.4 %→**-45.8 %**) → le coût caché du levier est la survivabilité, pas l'espérance.
- **Cell [9] walk-forward** : sur 11 fenêtres test hors-échantillon, le levier optimal choisi est **toujours 1.0x** (le plus bas) → l'optimiseur lui-même refuse le 2x trompeur. Sharpe moyen 1.20, mais variance énorme (test 2024-06→2024-12 = **+3.41** AI bull ; test 2021-12→2022-06 = **-2.19** bear-market kill).
- **Contradiction nommée honnêtement** : le code dit « 1.5x compromis robuste » mais les données walk-forward montrent 1.0x systématique → le 1.5x est un choix humain (tolérance drawdown), pas une conclusion de l'optimisation.

## Vérification (acceptance #10488 + C.2 exception markdown-only)

- **Code cells byte-identiques à `origin/main`** : vérifié mécaniquement pour le FR (6/6 : source + `execution_count` + `outputs` + `id` tous True). Aucune cellule code touchée → exception C.2 markdown-only, **pas de re-exec requise** (quantbook QC Cloud, mais markdown-only → non requis).
- **FR seul sur la PR** : le sibling EN est laissé à `origin/main` (fichier de traduction dérivé, régénéré par le pipeline `translation-sync.yml` post-merge). Conforme au translation-guard #10308.
- **Anti-churn C.3** : exactement 1 fichier FR diffère de `origin/main`.
- **nbformat 4.5 valide**, tous les `id` présents, `ensure_ascii=False` + indent=1 préservés.
- **Aucune transition générique** : chaque cellule dit ce que la suivante établit, en citant les valeurs de l'output précédent.
- **Pas de nombre fabriqué** : toutes les valeurs (0.697, 2.53, -45.8 %, 2.45, -0.08, 1.0x, 3.41, -2.19) proviennent des outputs committés.
- Catalogue byte-identique à main. Grain tag ligne 1.

## Synchronisation EN

`research_robustness_en.ipynb` sera régénéré par `translation-sync.yml` après merge du FR : T1 détecte les cellules markdown changées du FR, T3 les re-traduit, T4 re-rend le sibling EN. La paire se re-synchronise automatiquement — pas de hand-edit de l'EN (règle translation-guard #10308).

## Hors scope (G.4)

Les autres unités de la poche P1 (3 paires `kit-transitoire/01-ML-RandomForest`, `02-ML-XGBoost`, `03-Framework-Composite`) seront des PR séparées. Crypto-MultiCanal/research.ipynb est **hors scope** (issue #10318 séparée, claimée po-2024:CoursIA-2 + po-2023:CoursIA-2 — collision, non touché).

## Modalité d'exécution

Markdown-only → pas de re-exécution locale ni QC Cloud (exception C.2). Code cells byte-identiques → outputs préservés tels quels.
