### PR TITLE
feat(harness,#10486): make proof-integrity gate legible on build_failed_returncode

### DIFF
--- a/.github/workflows/lean-axiom.yml
+++ b/.github/workflows/lean-axiom.yml
@@ -164,25 +164,21 @@ jobs:
 
         from lean_server import LeanVerifier  # noqa: E402
 
-        # `select_diagnostic_lines` is imported, not reimplemented here: the
-        # selection has to agree with the canonical diagnostic marker (#8694,
-        # shared with `prover.tools._parse_lean_errors`), and a YAML heredoc is
-        # the one place in this repo no test can reach. It lives in
-        # `lean_server.py`, pinned by `tests/test_error_marker_contract.py`.
-        #
-        # The fallback is not defensive habit, it answers a STRUCTURAL version
-        # skew: callers reference this file as `lean-axiom.yml@main`, so the
-        # workflow body is always `main`'s while `lean_server.py` comes from the
-        # caller's checkout. A branch that predates the selector must degrade to
-        # the previous behaviour (tail slice), never crash the gate on an
-        # ImportError -- a green-to-crashed gate on every in-flight Lean PR
-        # would be a far worse defect than the one being fixed here (#10486).
+        # `axiom_lookup_anomalies` is the complement filter for the
+        # build_failed_returncode_* path (#10486, ai-01 c.1044). It returns the
+        # lines of raw_output that are NOT healthy `#print axioms` verdicts --
+        # i.e. the actual error (unknown constant, type error) wherever it sits
+        # in the stream. select_diagnostic_lines misses `unknown constant`
+        # (no `error:` prefix) and falls back to a tail slice, which on a batch
+        # of 537 commands shows twenty healthy verdicts and hides the cause.
+        # Same version-skew fallback as above: degrade to the tail slice, never
+        # crash the gate on an ImportError from an older caller checkout.
         try:
-            from lean_server import select_diagnostic_lines  # noqa: E402
+            from lean_server import axiom_lookup_anomalies  # noqa: E402
         except ImportError:
-            def select_diagnostic_lines(raw_output, limit=12):
+            def axiom_lookup_anomalies(raw_output, limit=50):
                 lines = (raw_output or "").strip().splitlines()
-                return lines[-20:], False, 0
+                return lines[-20:]
 
         modules = [m.strip() for m in os.environ["MODULES"].split(",") if m.strip()]
         allow = [a.strip() for a in os.environ.get("ALLOW", "").split(",") if a.strip()]
@@ -251,9 +247,21 @@ jobs:
             else:
                 print(f"  enumerated decls: (none -- module is 'non applicable', "
                       f"a gate that inspected nothing)")
-            print(f"  axioms: {result['axioms']}")
-            print(f"  forbidden: {result['forbidden']}")
-            print(f"  has_sorry: {result['has_sorry']}")
+            # On the build_failed_returncode_* path, check_axioms reads the
+            # returncode BEFORE parsing (lean_server.py:760), so axioms are
+            # NEVER collected -- `axioms: []` / `forbidden: []` /
+            # `has_sorry: False` are the path's hardcoded defaults, not
+            # measurements. Printing them bare made a dead build read as
+            # "no forbidden axioms, no sorry" (ai-01 c.1044 on #10486: the gate
+            # said "couldn't measure", not "clean despite flake"). Say so.
+            if result.get("error"):
+                print(f"  axioms: (non mesuré -- échec de lookup, see error below)")
+                print(f"  forbidden: (non mesuré -- échec de lookup)")
+                print(f"  has_sorry: (non mesuré -- échec de lookup)")
+            else:
+                print(f"  axioms: {result['axioms']}")
+                print(f"  forbidden: {result['forbidden']}")
+                print(f"  has_sorry: {result['has_sorry']}")
             # `error` is the ONLY field that separates "the lake did not build /
             # was not found" from "a forbidden axiom was reached". Omitting it
             # made a dead build indistinguishable from a real violation in the
@@ -265,26 +273,25 @@ jobs:
                 # cause. Without it, "build_failed_returncode_1" sends you to a
                 # local reproduction to learn what any CI log already had.
                 #
-                # Select the DIAGNOSTIC lines, not the tail. This branch used to
-                # slice `raw_output[-20:]` on the rationale that "Lean prints
-                # the failing declaration and its error last" -- true when the
-                # MODULE fails to build, false for this checker, whose build is
-                # a batch of one `#print axioms` per declaration fed to
-                # `lean --stdin`. An error on command #7 of 537 prints near the
-                # TOP, so the tail showed 20 healthy `depends on axioms:` lines
-                # and the cause was invisible. Measured on #10486 (galois_lean,
-                # 537 declarations): the log carried `build_failed_returncode_1`
-                # and nothing else, and the worker was sent to reproduce a
-                # 4-minute Mathlib build to learn a name the runner already had.
-                sel, matched, omitted = select_diagnostic_lines(
-                    result.get("raw_output") or ""
-                )
-                if not matched:
-                    print("    | (no Lean diagnostic in capture -- last 20 lines follow)")
-                for line in sel:
-                    print(f"    | {line}")
-                if omitted:
-                    print(f"    | ... (+{omitted} more diagnostic lines)")
+                # Print the COMPLEMENT of the healthy form (ai-01 c.1044 on
+                # #10486): any non-blank line of raw_output that is NOT a
+                # `'decl' depends on axioms: [...]` / `does not depend on any
+                # axioms` verdict. On a healthy run this prints nothing. On a
+                # failed run it prints the cause (`unknown constant`, type
+                # error) wherever it sits in the stream -- bulletproof by
+                # position, unlike select_diagnostic_lines which matches the
+                # `error:` marker that an `unknown constant` lacks and then
+                # falls back to a tail slice. On #10486 (galois_lean, 537
+                # declarations) the tail was twenty healthy verdicts and the
+                # cause sat near the top, invisible.
+                anomalies = axiom_lookup_anomalies(result.get("raw_output") or "")
+                if anomalies:
+                    print(f"    | non-verdict lines in raw_output ({len(anomalies)} shown):")
+                    for line in anomalies:
+                        print(f"    | {line}")
+                else:
+                    print("    | (no non-verdict lines -- raw_output is all healthy"
+                          " axioms verdicts; failure left no trace in this capture)")
             if result["has_sorry"]:
                 sorry_modules.append(mod)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -1011,3 +1011,49 @@ def select_diagnostic_lines(
     if hits:
         return hits[:limit], True, max(0, len(hits) - limit)
     return lines[-_DIAGNOSTIC_TAIL_LINES:], False, 0
+
+
+# Healthy forms of a `#print axioms` response (one per declaration fed to
+# `lean --stdin`). Used by :func:`axiom_lookup_anomalies` as the complement
+# filter for the ``build_failed_returncode_*`` path (#10486, ai-01 c.1044).
+_AXIOM_VERDICT_RE = re.compile(
+    r"^'.*'\s+depends on axioms: \[.*\]$"
+    r"|^'.*'\s+does not depend on any axioms$"
+)
+
+
+def axiom_lookup_anomalies(raw_output: str, limit: int = 50) -> List[str]:
+    """Non-verdict lines in a ``#print axioms`` capture (complement filter).
+
+    :meth:`LeanVerifier.check_axioms` feeds ``lean --stdin`` an ``import``
+    plus one ``#print axioms <decl>`` per declaration. A healthy response is
+    exactly two shapes::
+
+        'Ns.decl' depends on axioms: [propext, Classical.choice, Quot.sound]
+        'Ns.decl' does not depend on any axioms
+
+    Anything else in the capture is the cause of the non-zero returncode -- an
+    ``unknown constant``, a type error, a stack trace. This returns those lines
+    (the COMPLEMENT of the healthy form), so a failed run prints the cause
+    wherever it sits in the stream. A tail slice misses it: the error of
+    command #7 of 537 sits near the top, the tail is twenty healthy verdicts.
+
+    Returns ``[]`` on a healthy capture (every non-blank line is a verdict) --
+    the signal that the failure left no trace in this capture (e.g. the process
+    was killed before printing). Bulletproof by position, unlike
+    marker-matching which an ``unknown constant`` (no ``error:`` prefix) slips
+    past -- that is the gap :func:`select_diagnostic_lines` leaves open on this
+    path. Bounded by ``limit`` so a catastrophically broken capture does not
+    flood the log.
+    """
+    out: List[str] = []
+    for line in (raw_output or "").splitlines():
+        if not line.strip():
+            continue
+        if _AXIOM_VERDICT_RE.match(line):
+            continue
+        out.append(line)
+        if len(out) >= limit:
+            out.append(f"... (+more, truncated at {limit} lines)")
+            break
+    return out

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_error_marker_contract.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_error_marker_contract.py
@@ -56,7 +56,7 @@ HERE = Path(__file__).resolve().parent
 ROOT = HERE.parent
 sys.path.insert(0, str(ROOT))
 
-from lean_server import LeanVerifier, select_diagnostic_lines  # noqa: E402
+from lean_server import LeanVerifier, axiom_lookup_anomalies, select_diagnostic_lines  # noqa: E402
 from prover.tools import _parse_lean_errors  # noqa: E402
 
 
@@ -245,3 +245,54 @@ def test_empty_capture_is_not_a_crash():
         lines, matched, omitted = select_diagnostic_lines(empty)
         assert matched is False and omitted == 0
         assert lines in ([], [""])
+
+
+# --- axiom_lookup_anomalies: complement filter for the axiom gate (#10486) ---
+#
+# The build_failed_returncode_* path of check_axioms feeds lean --stdin one
+# `#print axioms` per declaration. select_diagnostic_lines misses an `unknown
+# constant` (no `error:` marker) and falls back to a tail slice, which on a
+# 537-command batch shows healthy verdicts and hides the cause. The complement
+# filter returns whatever is NOT a healthy verdict -- the cause, wherever it
+# sits. Pinned here so the filter's contract (healthy -> [], broken -> cause)
+# does not silently drift.
+
+
+def test_axiom_anomalies_healthy_capture_returns_empty():
+    """A capture of all-healthy verdicts yields nothing to print."""
+    healthy = (
+        "'Sporadic.card_M23' depends on axioms: [propext, Classical.choice, Quot.sound]\n"
+        "'Sporadic.id' does not depend on any axioms\n"
+        "'Sporadic.simple_M23' depends on axioms: [propext, Classical.choice, Quot.sound]\n"
+    )
+    assert axiom_lookup_anomalies(healthy) == []
+
+
+def test_axiom_anomalies_unknown_constant_is_surfaced_wherever_it_sits():
+    """An `unknown constant` (no `error:` prefix) is the #10486 cause.
+
+    The whole point of the complement filter: select_diagnostic_lines misses
+    this line and falls back to a tail. The complement filter returns it by
+    position, not marker.
+    """
+    capture = (
+        "'Sporadic.card_M22' depends on axioms: [propext, Classical.choice, Quot.sound]\n"
+        "unknown constant 'Sporadic.L34.mapsElations'\n"
+        "'Sporadic.simple_M22' depends on axioms: [propext, Classical.choice, Quot.sound]\n"
+    )
+    assert axiom_lookup_anomalies(capture) == ["unknown constant 'Sporadic.L34.mapsElations'"]
+
+
+def test_axiom_anomalies_empty_capture_is_empty():
+    """Empty/None raw_output -> no anomalies (failure left no trace)."""
+    for empty in ("", "   \n\n", None):
+        assert axiom_lookup_anomalies(empty) == []
+
+
+def test_axiom_anomalies_respects_the_limit():
+    """A catastrophically broken capture is bounded, with a truncation marker."""
+    # 60 anomaly lines; limit default 50 -> 50 lines + truncation marker.
+    capture = "".join(f"bogus line {i}\n" for i in range(60))
+    out = axiom_lookup_anomalies(capture)
+    assert len(out) == 51  # 50 anomalies + 1 truncation marker
+    assert "truncated at 50" in out[-1]


### PR DESCRIPTION
## What

Makes the proof-integrity CI gate (`.github/workflows/lean-axiom.yml`) print the **actual** Lean error on the `build_failed_returncode_*` path instead of hiding it behind a tail slice. Unblocks **#10486** (galois_lean M23, 537 decls, stale CI FAIL with `build_failed_returncode_1`).

This is the instrumentation ai-01 greenlit (c.1044 DM, Option 2, better-than-full-dump spec). See the cycle MEMORY `proof-integrity-ci-hides-error-truncation.md`.

## Grain

Quoi: Add `axiom_lookup_anomalies` complement filter to `lean_server.py`; rewrite the `lean-axiom.yml` diagnostic block + error-path display to surface the real error.
Preuve: `17/17` tests pass (`python -m pytest tests/test_error_marker_contract.py -q`); `py_compile` OK on both modules; `lean-axiom.yml` is `workflow_call`-only (delivery canary `derive_always_on_jobs` ignores it, verified).
Perimetre: 3 files (`lean_server.py`, `lean-axiom.yml`, `test_error_marker_contract.py`). No Lean source touched.

Grain: MED/guard — lane myia-po-2026:CoursIA — prev: LIGHT/ci-infra #10512

## Why (the defect)

`select_diagnostic_lines` (current reporter) anchors on the `error:` marker. On the `#print axioms` batch path, an unresolvable declaration prints `unknown constant 'X'` — **no `error:` prefix**. The reporter misses it and falls back to a `last-20-lines` tail slice. On a batch of 537 commands the tail is twenty healthy verdicts and the real cause sits near the top, invisible. CI log said only `build_failed_returncode_1`. (Measured firsthand c.1043; ai-01 c.1044 rejected the "CI died early" inference — the process reached the LAST `#print axioms` then exited 1.)

Second defect: on `build_failed_returncode_*`, `check_axioms` reads returncode **before** parsing (lean_server.py:760), so the dict returns hardcoded defaults `axioms: [] / forbidden: [] / has_sorry: False`. Read bare, a dead build looks like "no forbidden axioms, no sorry" — that is a **default on the error path**, not a measurement.

## The fix (additive, two legs)

**Leg 1 — `axiom_lookup_anomalies` (lean_server.py).** Complement filter: returns every non-empty line that is **not** a healthy verdict (`'decl' depends on axioms: [...]` / `'decl' does not depend on any axioms`). On a healthy capture → `[]`. On a failed capture → the actual error, **wherever** it sits in the stream. Bulletproof by position, not by marker. Bounded by `limit` (default 50) + a truncation marker so a catastrophically broken capture does not flood the log.

**Leg 2 — `lean-axiom.yml` consumer.**
- On `build_failed_returncode_*`: `axioms`/`forbidden`/`has_sorry` now display `(non mesuré -- échec de lookup)` when `result.get("error")` — no more "clean" reading of an error path.
- Diagnostic block: replaced `select_diagnostic_lines` with `axiom_lookup_anomalies` (version-skew fallback to the old tail slice if the function is absent in an old checkout).

## Tests (+4, 17/17)

```
test_axiom_anomalies_healthy_capture_returns_empty
test_axiom_anomalies_unknown_constant_is_surfaced_wherever_it_sits   # the #10486 cause
test_axiom_anomalies_empty_capture_is_empty
test_axiom_anomalies_respects_the_limit
```

## Sequence to unblock #10486

1. This grain merges to `@main`.
2. **#10486 rebases** onto it (force-push — **coordinator decision** per git-workflow.md). Reason: `lean-axiom.yml` runs `lean_server.py` from the **caller's checkout**, so #10486 must carry `axiom_lookup_anomalies` in its own tree for CI to call it.
3. close + reopen #10486 → CI now prints the named error.
4. Either real Lean problem (fix it) or runner artifact (document with its name — never presume flake).

See #10486. Does not close it — instrumentation only; the named error is the next grain.

## Checklist
- [x] Tests added (4) and pass (17/17)
- [x] No Lean source / proof touched
- [x] `axiom_lookup_anomalies` is additive (existing `select_diagnostic_lines` kept for non-axiom paths)
- [x] `lean-axiom.yml` still `workflow_call`-only (canary unaffected)
- [ ] Needs ai-01 review + merge; **then** #10486 rebase (force-push, coordinator decision)

Co-Authored-By: Claude <noreply@anthropic.com>