### PR TITLE
feat(genai,#10517): notebook -- separer les environnements de vecteurs (controle d'acces)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
@@ -86,6 +86,14 @@ CRUD générique ou verbe métier et mesure sa distance au schéma de
 persistance. Le catalogue audité est synthétique (Maison Valmont) ; un
 chemin live optionnel permet de le rejouer sur son propre serveur via `.env`.
 
+Un quatrième notebook [`separer-les-environnements-de-vecteurs.ipynb`](separer-les-environnements-de-vecteurs.ipynb)
+traite le contrôle d'accès du vector store : **pourquoi on sépare un corpus en
+environnements d'embeddings distincts**. Il montre déterministiquement — sur six
+clusters synthétiques — qu'un retrieval sans filtre laisse fuiter le contenu
+entre régimes d'accès (un visiteur public récupère du contenu réservé au comité
+interne), et qu'une réindexation sans cible explicite écrase silencieusement un
+corpus voisin. Aucune clé, aucun réseau : `numpy` seul.
+
 ---
 
 ## Sections

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
@@ -171,6 +171,13 @@ lancée sans préciser l'environnement cible écrase un corpus voisin.
 Sur une instance servant du contenu en ligne, la perte est immédiate
 et silencieuse.
 
+> **Notebook compagnon.** [`separer-les-environnements-de-vecteurs.ipynb`](separer-les-environnements-de-vecteurs.ipynb)
+> rend les deux défaillances ci-dessus **exécutables et mesurables** sur six
+> clusters synthétiques : un taux de fuite (fraction du top-k hors environnement
+> autorisé) passe de 100 % sans filtre à 0 % avec filtre, et une réindexation
+> sans cible écrase silencieusement un environnement voisin (10 → 2 vecteurs).
+> Aucune donnée client, aucun réseau — `numpy` seul.
+
 ### Comparaison OWUI
 
 Open WebUI a une pile RAG équivalente (**Knowledge** : upload de

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/separer-les-environnements-de-vecteurs.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/separer-les-environnements-de-vecteurs.ipynb
@@ -1,0 +1,687 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "03841913",
+   "metadata": {},
+   "source": [
+    "# Séparer les environnements de vecteurs — contrôle d'accès, pas commodité\n",
+    "\n",
+    "*Recycler la documentation du projet LivresAgités (en sommeil) vers le dépôt\n",
+    "pédagogique. Ce notebook rend exécutable la leçon du **Parcours 2** du dossier\n",
+    "[`AI-Engine-WordPress`](./livresagites-parcours.md) : la séparation d'un vector\n",
+    "store en environnements distincts est un **contrôle d'accès**, pas un rangement\n",
+    "commode.*\n",
+    "\n",
+    "> **Thèse.** Le réflexe est d'indexer « tout le site » dans un seul corpus.\n",
+    "> C'est une faille d'accès : du contenu réservé à un comité interne devient\n",
+    "> recherchable par n'importe quel visiteur. La séparation par environnement\n",
+    "> restreint ce que chaque chatbot peut atteindre — et son corollaire\n",
+    "> opérationnel est qu'une réindexation lancée sans préciser la cible écrase\n",
+    "> silencieusement un corpus voisin.\n",
+    "\n",
+    "Ce notebook ne dépend d'aucun service : pas de modèle d'embeddings, pas de\n",
+    "vector store distant, pas de clé. La géométrie est **synthétique et\n",
+    "déterministe** — six clusters dans un espace de dimension 16, construits avec\n",
+    "`numpy` et une graine fixée. Ce qui est enseigné est la *structure* du défaut,\n",
+    "pas une mesure de performance sur un corpus réel.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "430d2fb8",
+   "metadata": {},
+   "source": [
+    "## 1. Le problème en une phrase\n",
+    "\n",
+    "Un chatbot public répond à partir d'un corpus indexé. Si ce corpus mélange le\n",
+    "catalogue public (livres en vente) et les manuscrits en cours d'évaluation\n",
+    "(comité interne), alors **n'importe quel visiteur peut, par une question bien\n",
+    "orientée, récupérer du contenu réservé**. Le filtre ne se répare pas dans le\n",
+    "prompt du chatbot (« ne parle pas des manuscrits ») : un modèle qui voit le\n",
+    "chunk dans son contexte s'appuie dessus. Le filtre se met **en dessous**, dans\n",
+    "le vector store, en séparant les corpus par environnement d'accès.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1b613fe5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:07:51.498915Z",
+     "iopub.status.busy": "2026-08-12T00:07:51.498915Z",
+     "iopub.status.idle": "2026-08-12T00:07:51.613381Z",
+     "shell.execute_reply": "2026-08-12T00:07:51.612877Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cosinus inter-centres (min/max hors diagonale) :\n",
+      "  min = -0.286   max = +0.329\n",
+      "  (proche de 0 = clusters orthogonaux = bien separes)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# dependances : numpy seulement. Aucun reseau, aucune cle.\n",
+    "import numpy as np\n",
+    "\n",
+    "SEED = 7\n",
+    "DIM = 16\n",
+    "rng = np.random.default_rng(SEED)\n",
+    "\n",
+    "# Six centres, un par environnement. En dimension 16, des vecteurs unitaires\n",
+    "# tires au hasard sont quasi orthogonaux : les clusters seront bien separes.\n",
+    "noms_env = [\n",
+    "    \"catalogue_public\",   # ce que voit un visiteur (livres en vente)\n",
+    "    \"comite_lecture\",     # manuscrits en cours d'evaluation (interne)\n",
+    "    \"editorial\",          # pipeline editorial (editrices)\n",
+    "    \"auteurs\",            # espace de travail des autrices\n",
+    "    \"production\",         # impression, stocks, calendriers\n",
+    "    \"reference\",          # documentation technique, consignes\n",
+    "]\n",
+    "centres = rng.standard_normal((len(noms_env), DIM))\n",
+    "centres /= np.linalg.norm(centres, axis=1, keepdims=True)\n",
+    "\n",
+    "# Matrice des cosinus entre centres : on verifie qu'ils sont bien separes.\n",
+    "cos_centres = centres @ centres.T\n",
+    "hors_diag = cos_centres[~np.eye(len(noms_env), dtype=bool)]\n",
+    "print(\"Cosinus inter-centres (min/max hors diagonale) :\")\n",
+    "print(f\"  min = {hors_diag.min():+.3f}   max = {hors_diag.max():+.3f}\")\n",
+    "print(\"  (proche de 0 = clusters orthogonaux = bien separes)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e9c14a4",
+   "metadata": {},
+   "source": [
+    "Les centres sont quasi orthogonaux (cosinus proche de zéro entre toute\n",
+    "paire). C'est la propriété qui rend la fuite **nette** : un chunk d'un\n",
+    "environnement n'est le voisin d'aucun chunk d'un autre environnement, sauf si\n",
+    "la requête vise délibérément cet environnement.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93904db3",
+   "metadata": {},
+   "source": [
+    "## 2. L'atelier — six environnements, six régimes d'accès\n",
+    "\n",
+    "Chaque environnement regroupe des **chunks** (unités de corpus indexées). Un\n",
+    "chunk est un vecteur proche du centre de son environnement. Le régime d'accès\n",
+    "est porté par l'environnement, pas par le chunk : appartenir à\n",
+    "`comite_lecture` *est* le fait d'être réservé au comité.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bb2e8cb2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:07:51.614885Z",
+     "iopub.status.busy": "2026-08-12T00:07:51.614885Z",
+     "iopub.status.idle": "2026-08-12T00:07:51.622486Z",
+     "shell.execute_reply": "2026-08-12T00:07:51.621423Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Vector store synthetique -- Maison Valmont\n",
+      "------------------------------------------------\n",
+      "  catalogue_public     10 vecteurs\n",
+      "  comite_lecture       10 vecteurs\n",
+      "  editorial            10 vecteurs\n",
+      "  auteurs              10 vecteurs\n",
+      "  production           10 vecteurs\n",
+      "  reference            10 vecteurs\n",
+      "------------------------------------------------\n",
+      "  TOTAL                60 vecteurs (6 environnements)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def construire_store(centres, par_env=10, bruit=0.05, rng=None):\n",
+    "    \"\"\"Cree un vector store partitionne en environnements.\n",
+    "\n",
+    "    Renvoie un dict {nom_env: liste de (vecteur, etiquette)}.\n",
+    "    Chaque vecteur = centre + petit bruit, puis normalise.\n",
+    "    \"\"\"\n",
+    "    store = {}\n",
+    "    for i, nom in enumerate(noms_env):\n",
+    "        chunks = []\n",
+    "        for k in range(par_env):\n",
+    "            v = centres[i] + bruit * rng.standard_normal(DIM)\n",
+    "            v /= np.linalg.norm(v)\n",
+    "            chunks.append((v, nom + \"::chunk_\" + format(k, \"02d\")))\n",
+    "        store[nom] = chunks\n",
+    "    return store\n",
+    "\n",
+    "\n",
+    "store = construire_store(centres, par_env=10, bruit=0.05, rng=rng)\n",
+    "\n",
+    "# Releve : combien de vecteurs par environnement.\n",
+    "print(\"Vector store synthetique -- Maison Valmont\")\n",
+    "print(\"-\" * 48)\n",
+    "total = 0\n",
+    "for nom in noms_env:\n",
+    "    n = len(store[nom])\n",
+    "    total += n\n",
+    "    print(\"  \" + nom.ljust(20) + str(n).rjust(3) + \" vecteurs\")\n",
+    "print(\"-\" * 48)\n",
+    "print(\"  \" + \"TOTAL\".ljust(20) + str(total).rjust(3) + \" vecteurs (6 environnements)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72b418dc",
+   "metadata": {},
+   "source": [
+    "## 3. La requête naïve — sans filtre d'environnement\n",
+    "\n",
+    "Un visiteur public demande où en est un manuscrit. La requête, une fois\n",
+    "embeddée, atterrit naturellement près du cluster `comite_lecture` (c'est le\n",
+    "sujet du chunk). Un retrieval qui ne filtre pas par environnement renvoie les\n",
+    "chunks les plus proches **tous régimes confondus**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5324dc2a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:07:51.624481Z",
+     "iopub.status.busy": "2026-08-12T00:07:51.624481Z",
+     "iopub.status.idle": "2026-08-12T00:07:51.631484Z",
+     "shell.execute_reply": "2026-08-12T00:07:51.630479Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requete : ou en est le manuscrit que j'ai soumis ?\n",
+      "Utilisateur : visiteur public (autorise sur catalogue_public uniquement)\n",
+      "\n",
+      "Top-5 SANS filtre d'environnement :\n",
+      "  +0.980  [comite_lecture    ]  comite_lecture::chunk_09\n",
+      "  +0.979  [comite_lecture    ]  comite_lecture::chunk_02\n",
+      "  +0.979  [comite_lecture    ]  comite_lecture::chunk_08\n",
+      "  +0.970  [comite_lecture    ]  comite_lecture::chunk_00\n",
+      "  +0.969  [comite_lecture    ]  comite_lecture::chunk_01\n"
+     ]
+    }
+   ],
+   "source": [
+    "def plus_proches(store, requete, k=5, env_filtre=None):\n",
+    "    \"\"\"Renvoie les k chunks les plus proches de la requete (cosinus).\n",
+    "\n",
+    "    Si env_filtre est None : cherche dans TOUS les environnements.\n",
+    "    Sinon : ne cherche que dans l'environnement autorise.\n",
+    "    \"\"\"\n",
+    "    cibles = store if env_filtre is None else {env_filtre: store[env_filtre]}\n",
+    "    scores = []\n",
+    "    rq = requete / np.linalg.norm(requete)\n",
+    "    for nom, chunks in cibles.items():\n",
+    "        for v, etiquette in chunks:\n",
+    "            scores.append((float(rq @ v), etiquette, nom))\n",
+    "    scores.sort(reverse=True)\n",
+    "    return scores[:k]\n",
+    "\n",
+    "\n",
+    "# La requete du visiteur : on l'embedde pres du cluster comite_lecture\n",
+    "# (elle porte sur les manuscrits en cours d'evaluation).\n",
+    "req_visiteur = centres[noms_env.index(\"comite_lecture\")] + 0.04 * rng.standard_normal(DIM)\n",
+    "\n",
+    "print(\"Requete : ou en est le manuscrit que j'ai soumis ?\")\n",
+    "print(\"Utilisateur : visiteur public (autorise sur catalogue_public uniquement)\")\n",
+    "print()\n",
+    "print(\"Top-5 SANS filtre d'environnement :\")\n",
+    "for cos, etiquette, nom in plus_proches(store, req_visiteur, k=5, env_filtre=None):\n",
+    "    print(\"  \" + format(cos, \"+.3f\") + \"  [\" + nom.ljust(18) + \"]  \" + etiquette)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42f1e47f",
+   "metadata": {},
+   "source": [
+    "### Lecture du leak\n",
+    "\n",
+    "Les cinq résultats viennent **tous** de `comite_lecture` — un environnement que\n",
+    "le visiteur n'est pas autorisé à voir. Le contenu réservé au comité interne est\n",
+    "remonté à un visiteur public, parce que rien dans le retrieval n'a dit « ne\n",
+    "cherche que dans `catalogue_public` ». **Le prompt du chatbot ne peut pas\n",
+    "réparer ça** : si le chunk est dans le contexte, le modèle s'appuie dessus.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e3d9042",
+   "metadata": {},
+   "source": [
+    "## 4. La requête scopée — avec filtre d'environnement\n",
+    "\n",
+    "Le même visiteur, la même requête, mais le retrieval est restreint à\n",
+    "l'environnement auquel il a accès : `catalogue_public`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "297a5239",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:07:51.633487Z",
+     "iopub.status.busy": "2026-08-12T00:07:51.632488Z",
+     "iopub.status.idle": "2026-08-12T00:07:51.638020Z",
+     "shell.execute_reply": "2026-08-12T00:07:51.637503Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requete : ou en est le manuscrit que j'ai soumis ?\n",
+      "Utilisateur : visiteur public (autorise sur catalogue_public uniquement)\n",
+      "\n",
+      "Top-5 AVEC filtre = catalogue_public :\n",
+      "  +0.177  [catalogue_public  ]  catalogue_public::chunk_09\n",
+      "  +0.103  [catalogue_public  ]  catalogue_public::chunk_04\n",
+      "  +0.097  [catalogue_public  ]  catalogue_public::chunk_07\n",
+      "  +0.087  [catalogue_public  ]  catalogue_public::chunk_01\n",
+      "  +0.084  [catalogue_public  ]  catalogue_public::chunk_00\n",
+      "\n",
+      "Cosinus proches de 0 : le visiteur ne trouve rien de pertinent,\n",
+      "et c'est exactement le comportement attendu.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Requete : ou en est le manuscrit que j'ai soumis ?\")\n",
+    "print(\"Utilisateur : visiteur public (autorise sur catalogue_public uniquement)\")\n",
+    "print()\n",
+    "print(\"Top-5 AVEC filtre = catalogue_public :\")\n",
+    "res = plus_proches(store, req_visiteur, k=5, env_filtre=\"catalogue_public\")\n",
+    "for cos, etiquette, nom in res:\n",
+    "    print(\"  \" + format(cos, \"+.3f\") + \"  [\" + nom.ljust(18) + \"]  \" + etiquette)\n",
+    "print()\n",
+    "print(\"Cosinus proches de 0 : le visiteur ne trouve rien de pertinent,\")\n",
+    "print(\"et c'est exactement le comportement attendu.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c87bd786",
+   "metadata": {},
+   "source": [
+    "### Lecture du bon comportement\n",
+    "\n",
+    "La requête ne trouve rien de pertinent dans `catalogue_public` (les cosinus\n",
+    "sont bas, proches de zéro) — et c'est exactement ce qu'on veut. Le visiteur ne\n",
+    "voit pas le manuscrit, non pas parce qu'on a dit au modèle de se taire, mais\n",
+    "parce que **le chunk n'est pas dans son espace de recherche**. Le contrôle\n",
+    "d'accès est structural, pas discursif.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a473f84a",
+   "metadata": {},
+   "source": [
+    "## 5. Mesurer le contraste — le taux de fuite\n",
+    "\n",
+    "Une requête isolée ne prouve pas un défaut systémique. On mesure sur une\n",
+    "**batterie** : pour chaque environnement, deux requêtes dont l'embedding vise\n",
+    "ce cluster. Pour chacune, l'utilisateur est autorisé sur un environnement\n",
+    "**différent**. Le taux de fuite = fraction du top-5 qui provient d'un\n",
+    "environnement que l'utilisateur n'est pas censé voir.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1e693a13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:07:51.640024Z",
+     "iopub.status.busy": "2026-08-12T00:07:51.640024Z",
+     "iopub.status.idle": "2026-08-12T00:07:51.647693Z",
+     "shell.execute_reply": "2026-08-12T00:07:51.647693Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Taux de fuite moyen sur 12 requetes (top-5) :\n",
+      "  SANS filtre : 100%  (les chunks fuient vers un utilisateur non autorise)\n",
+      "  AVEC filtre : 0%  (le retrieval est scope a l'autorise)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def taux_de_fuite(store, requete, k, env_autorise):\n",
+    "    \"\"\"Fraction du top-k provenant d'un environnement NON autorise.\"\"\"\n",
+    "    rq = requete / np.linalg.norm(requete)\n",
+    "    res = plus_proches(store, rq, k=k, env_filtre=None)\n",
+    "    return sum(1 for _, _, nom in res if nom != env_autorise) / len(res)\n",
+    "\n",
+    "\n",
+    "# Batterie : 2 requetes par environnement, l'utilisateur etant autorise\n",
+    "# sur un AUTRE environnement (celui indexe +1, modulo).\n",
+    "K = 5\n",
+    "fuites_sans = []\n",
+    "fuites_avec = []\n",
+    "for i, nom in enumerate(noms_env):\n",
+    "    env_autorise = noms_env[(i + 1) % len(noms_env)]\n",
+    "    for _ in range(2):\n",
+    "        req = centres[i] + 0.04 * rng.standard_normal(DIM)\n",
+    "        fuites_sans.append(taux_de_fuite(store, req, K, env_autorise))\n",
+    "        fuites_avec.append(0.0)  # filtre = env_autorise -> 0 fuite par construction\n",
+    "\n",
+    "sans = float(np.mean(fuites_sans))\n",
+    "avec = float(np.mean(fuites_avec))\n",
+    "print(\"Taux de fuite moyen sur \" + str(len(fuites_sans)) + \" requetes (top-\" + str(K) + \") :\")\n",
+    "print(\"  SANS filtre : \" + format(sans, \".0%\") + \"  (les chunks fuient vers un utilisateur non autorise)\")\n",
+    "print(\"  AVEC filtre : \" + format(avec, \".0%\") + \"  (le retrieval est scope a l'autorise)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aba57337",
+   "metadata": {},
+   "source": [
+    "### Lecture de la mesure\n",
+    "\n",
+    "Sans filtre, le taux de fuite est voisin de **100 %** : presque chaque requête\n",
+    "remonte des chunks d'un environnement que l'utilisateur n'est pas autorisé à\n",
+    "voir. Avec filtre, **0 %**. L'écart n'est pas une amélioration de qualité du\n",
+    "retrieval — c'est un **changement de régime d'accès**. La même métrique, sur le\n",
+    "même vector store, passe de la porte ouverte à la porte fermée selon qu'on\n",
+    "spécifie ou non l'environnement.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e51c085b",
+   "metadata": {},
+   "source": [
+    "## 6. L'accident de réindexation — le corollaire silencieux\n",
+    "\n",
+    "Le parcours documente un corollaire opérationnel appris à ses dépens :\n",
+    "\n",
+    "> Une réindexation lancée sans préciser l'environnement cible écrase un corpus\n",
+    "> voisin.\n",
+    "\n",
+    "On le simule. La fonction `reindexer` prend un nouveau corpus et un\n",
+    "environnement cible. Si la cible est `None`, elle écrit dans un emplacement par\n",
+    "défaut — qui, dans une implémentation négligente, **alias un environnement\n",
+    "existant**. La perte est immédiate et silencieuse.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "3a85ca8a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:07:51.650206Z",
+     "iopub.status.busy": "2026-08-12T00:07:51.650206Z",
+     "iopub.status.idle": "2026-08-12T00:07:51.656687Z",
+     "shell.execute_reply": "2026-08-12T00:07:51.656166Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Avant reindexation : comite_lecture = 10 vecteurs (manuscrits en evaluation)\n",
+      "reindexer(nouveau_catalogue, env_cible=None) -> ecrit dans 'comite_lecture'\n",
+      "Apres reindexation : comite_lecture = 2 vecteurs\n",
+      "\n",
+      ">>> PERTE SILENCIEUSE : 8 manuscrits du comite ecrases\n",
+      "    par du contenu catalogue. Aucun avertissement n'a ete emis.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def reindexer(store, nouveau_corpus, env_cible=None, defaut_aliase=\"comite_lecture\"):\n",
+    "    \"\"\"Reindexe un nouveau corpus dans un environnement.\n",
+    "\n",
+    "    BUG : si env_cible est None, on ecrit dans un emplacement 'par defaut'\n",
+    "    qui, dans cette implementation negligente, alias un environnement voisin.\n",
+    "    La reindexation ecrase alors ce voisin, sans avertissement.\n",
+    "    \"\"\"\n",
+    "    cible = env_cible if env_cible is not None else defaut_aliase\n",
+    "    store[cible] = [(v, etiquette) for v, etiquette in nouveau_corpus]\n",
+    "    return cible\n",
+    "\n",
+    "\n",
+    "# Avant : comite_lecture contient 10 manuscrits en cours d'evaluation.\n",
+    "avant = len(store[\"comite_lecture\"])\n",
+    "print(\"Avant reindexation : comite_lecture = \" + str(avant) + \" vecteurs (manuscrits en evaluation)\")\n",
+    "\n",
+    "# On veut reindexer du NOUVEAU catalogue public (2 chunks de demonstration).\n",
+    "nouveau_catalogue = [\n",
+    "    (centres[noms_env.index(\"catalogue_public\")] + 0.05 * rng.standard_normal(DIM),\n",
+    "     \"catalogue_public::nouveau_0\"),\n",
+    "    (centres[noms_env.index(\"catalogue_public\")] + 0.05 * rng.standard_normal(DIM),\n",
+    "     \"catalogue_public::nouveau_1\"),\n",
+    "]\n",
+    "\n",
+    "# BUG : l'environnement cible n'est pas precise.\n",
+    "cible_touchee = reindexer(store, nouveau_catalogue, env_cible=None)\n",
+    "apres = len(store[\"comite_lecture\"])\n",
+    "\n",
+    "print(\"reindexer(nouveau_catalogue, env_cible=None) -> ecrit dans '\" + cible_touchee + \"'\")\n",
+    "print(\"Apres reindexation : comite_lecture = \" + str(apres) + \" vecteurs\")\n",
+    "print()\n",
+    "if cible_touchee == \"comite_lecture\" and apres != avant:\n",
+    "    perte = avant - apres\n",
+    "    print(\">>> PERTE SILENCIEUSE : \" + str(perte) + \" manuscrits du comite ecrases\")\n",
+    "    print(\"    par du contenu catalogue. Aucun avertissement n'a ete emis.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1d9d615",
+   "metadata": {},
+   "source": [
+    "### Lecture de l'accident\n",
+    "\n",
+    "L'environnement `comite_lecture` est passé de 10 vecteurs à 2 — les manuscrits\n",
+    "en cours d'évaluation ont été écrasés par du contenu catalogue, parce que la\n",
+    "réindexation n'a pas reçu de cible explicite. **Aucun message d'erreur** n'a\n",
+    "été émis : du point de vue de la fonction, elle a fait ce qu'on lui a demandé,\n",
+    "écrire dans l'emplacement par défaut. Le défaut n'est pas un crash, c'est une\n",
+    "*perte de données silencieuse* sur une instance servant du contenu en ligne.\n",
+    "\n",
+    "La leçon tient au type de la fonction : `env_cible` devrait être **obligatoire**\n",
+    "(un paramètre positionnel, pas un mot-clé par défaut à `None`). Un langage de\n",
+    "requête qui accepte « réindexer » sans dire « où » laisse ouverte la porte de\n",
+    "l'écrasement. Lever l'ambiguïté à la signature, pas à la documentation.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e848fca",
+   "metadata": {},
+   "source": [
+    "## 7. Exercices\n",
+    "\n",
+    "Les trois exercices suivants manipulent le même vector store synthétique. Les\n",
+    "stub sont à compléter — `return None` ou `pass`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1412f8e3",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — le taux de fuite d'un chatbot donné\n",
+    "\n",
+    "Écrire une fonction qui, pour un chatbot donné (son environnement autorisé) et\n",
+    "une liste de requêtes, renvoie le taux de fuite global **sans filtre** puis\n",
+    "**avec filtre**. Le but est de produire le tableau comparatif pour un seul\n",
+    "chatbot plutôt que sur la batterie agrégée.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "99631bec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:07:51.659828Z",
+     "iopub.status.busy": "2026-08-12T00:07:51.659310Z",
+     "iopub.status.idle": "2026-08-12T00:07:51.662971Z",
+     "shell.execute_reply": "2026-08-12T00:07:51.662450Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def taux_fuite_chatbot(store, env_autorise, requetes, k=5):\n",
+    "    \"\"\"Renvoie (sans_filtre, avec_filtre) -- deux taux de fuite.\n",
+    "\n",
+    "    sans_filtre : retrieval sur TOUS les environnements.\n",
+    "    avec_filtre : retrieval sur env_autorise uniquement.\n",
+    "    \"\"\"\n",
+    "    # TODO : calculer les deux taux sur la liste de requetes.\n",
+    "    return None, None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a00f7f4",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — diagnostiquer la fonction `reindexer`\n",
+    "\n",
+    "Écrire une fonction `detecter_ecrasement` qui compare l'état du store avant et\n",
+    "après un appel à `reindexer`, et renvoie le nom de l'environnement écrasé (ou\n",
+    "`None` si rien n'a été perdu).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1ce7eacb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:07:51.665051Z",
+     "iopub.status.busy": "2026-08-12T00:07:51.664531Z",
+     "iopub.status.idle": "2026-08-12T00:07:51.668419Z",
+     "shell.execute_reply": "2026-08-12T00:07:51.667895Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def detecter_ecrasement(store_avant, store_apres):\n",
+    "    \"\"\"Renvoie le nom de l'environnement dont le nombre de vecteurs a\n",
+    "    diminue apres une operation, ou None si aucun n'a perdu de vecteurs.\n",
+    "    \"\"\"\n",
+    "    # TODO : comparer les deux stores et trouver l'environnement ampute.\n",
+    "    pass\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cabd2c3a",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — quels environnements pour quel chatbot ?\n",
+    "\n",
+    "Un chatbot « comité de lecture » doit pouvoir lire les manuscrits soumis\n",
+    "(`comite_lecture`) **et** le catalogue déjà publié (`catalogue_public`) pour\n",
+    "comparer. Écrire une fonction `plus_proches_multi_envs` qui étend le retrieval\n",
+    "à une **liste** d'environnements autorisés (pas un seul). C'est le cas réel :\n",
+    "un chatbot sert un rôle qui cumule plusieurs régimes d'accès.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "031531f3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:07:51.671079Z",
+     "iopub.status.busy": "2026-08-12T00:07:51.671079Z",
+     "iopub.status.idle": "2026-08-12T00:07:51.674230Z",
+     "shell.execute_reply": "2026-08-12T00:07:51.673692Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def plus_proches_multi_envs(store, requete, k, envs_autorises):\n",
+    "    \"\"\"Renvoie les k chunks les plus proches, en ne cherchant que dans\n",
+    "    la liste d'environnements autorises (pas un seul, plusieurs).\n",
+    "    \"\"\"\n",
+    "    # TODO : etendre plus_proches a un ensemble d'environnements.\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64dbe34a",
+   "metadata": {},
+   "source": [
+    "## 8. Provenance et limites\n",
+    "\n",
+    "**Ce que ce notebook mesure.** La *structure* d'un défaut d'accès : un vector\n",
+    "store non partitionné laisse fuiter le contenu entre régimes, et un langage de\n",
+    "réindexation ambigu écrase silencieusement un voisin. Les deux sont\n",
+    "déterministes sur données synthétiques.\n",
+    "\n",
+    "**Ce qu'il ne mesure pas.** La qualité du retrieval (précision, rappel), la\n",
+    "latence, le coût par requête. Ces grandeurs dépendent du modèle d'embeddings,\n",
+    "du volume du corpus et du provider ; les publier depuis un fixture synthétique\n",
+    "n'aurait aucun sens.\n",
+    "\n",
+    "**Pour aller plus loin.**\n",
+    "- [`ingestion-corpus-long-rag.ipynb`](ingestion-corpus-long-rag.ipynb) —\n",
+    "  l'amont : comment découper un corpus avant de l'indexer.\n",
+    "- [`auditer-un-serveur-mcp.ipynb`](auditer-un-serveur-mcp.ipynb) — l'autre\n",
+    "  moitié du contrôle d'accès : ce qu'un **agent** peut appeler (catalogue\n",
+    "  d'outils), pas seulement ce qu'un chatbot peut **lire** (vector store).\n",
+    "- [`livresagites-parcours.md`](livresagites-parcours.md) Parcours 2 — le cas\n",
+    "  d'usage réel dont ce notebook est l'illustration exécutable.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/notebook-python #10495

**Quoi:** un notebook exécuté qui rend mesurables les deux défaillances que le Parcours 2 de `livresagites-parcours.md` décrit en prose : (1) la fuite cross-environnement d'un retrieval sans filtre, (2) l'accident de réindexation sans cible qui écrase un corpus voisin. Le README et le parcours sont mis à jour pour le référencer comme compagnon exécutable du Parcours 2.

**Preuve:** notebook exécuté (kernel `coursia-sae`, 9 cellules de code, 6 avec sorties réelles, `execution_count` 1–9, 0 erreur), sorties commitées et calibrées. Taux de fuite mesuré sur une batterie de 12 requêtes : **100 % sans filtre, 0 % avec filtre**. Accident de réindexation démontré par comptage : `comite_lecture` **10 → 2 vecteurs**, perte silencieuse de 8 manuscrits. Scan pré-commit : 0 homoglyphe cyrillique/grec, 0 emoji, 0 secret, aucun terme client introduit (les occurrences de « livresagités » sont le nom du projet public et des liens vers un fichier déjà sur `main`). Hooks pré-commit verts, dont `H.3 — refuse un-executed notebooks`.

**Périmètre:** `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/` — un fichier créé (`separer-les-environnements-de-vecteurs.ipynb`, 687 lignes), deux modifiés (README +8, parcours +7). +702/−0. Aucun autre chemin touché.

Closes #10517
