### PR TITLE
feat(genai,#10517): notebook séparer les environnements de vecteurs (Parcours 2)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
@@ -86,6 +86,17 @@ CRUD générique ou verbe métier et mesure sa distance au schéma de
 persistance. Le catalogue audité est synthétique (Maison Valmont) ; un
 chemin live optionnel permet de le rejouer sur son propre serveur via `.env`.
 
+Un quatrième notebook [`separer-les-environnements-de-vecteurs.ipynb`](separer-les-environnements-de-vecteurs.ipynb)
+est le compagnon exécutable du Parcours 2 (RAG et piège du
+multi-environnement). Il convertit en **mesures reproductibles** les deux
+défaillances que la prose décrit : étant donné un vector store partitionné
+en six régimes d'accès, il démontre (1) la **fuite cross-environnement**
+— un retrieval émis sans filtre renvoie des chunks d'un régime réservé,
+mesurée par un taux de fuite — et (2) **l'accident de réindexation** —
+`reindexer(..., environnement=None)` écrase silencieusement un corpus
+voisin. Déterministe, numpy, sans clé ni réseau ; fixture synthétique à 100 %
+(Maison Valmont).
+
 ---
 
 ## Sections
@@ -199,6 +210,8 @@ attendues.
   ingestion RAG d'un corpus long structuré, chunking naïf vs par chapitre
 - [`auditer-un-serveur-mcp.ipynb`](auditer-un-serveur-mcp.ipynb) —
   classifier CRUD générique vs verbes métier, mesurer la distance au schéma
+- [`separer-les-environnements-de-vecteurs.ipynb`](separer-les-environnements-de-vecteurs.ipynb) —
+  fuite cross-environnement et accident de réindexation, mesurés sur un vector store partitionné
 - Epic [#4433](https://github.com/jsboige/CoursIA/issues/4433) —
   refonte pédagogique GenAI (ce parcours en est une extension)
 - Issue [#9734](https://github.com/jsboige/CoursIA/issues/9734) —

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
@@ -183,6 +183,13 @@ En revanche, la notion d'**environnements multiples** au sein d'une
 même instance est plus explicite côté AI-Engine, où elle est un
 champ de configuration de premier niveau.
 
+> [`separer-les-environnements-de-vecteurs.ipynb`](separer-les-environnements-de-vecteurs.ipynb)
+> convertit les deux défaillances ci-dessus en **mesures reproductibles** :
+> sur un vector store synthétique partitionné en six régimes d'accès, il
+> démontre la fuite cross-environnement (taux de chunks réservés renvoyés
+> à un visiteur public) et l'accident de réindexation silencieux
+> (comptage du corpus voisin écrasé). Déterministe, sans clé ni réseau.
+
 ---
 
 ## Parcours 3 — WordPress comme serveur MCP métier

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/separer-les-environnements-de-vecteurs.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/separer-les-environnements-de-vecteurs.ipynb
@@ -1,0 +1,599 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "64cabf83",
+   "metadata": {},
+   "source": [
+    "# Séparer les environnements de vecteurs\n",
+    "\n",
+    "> **La séparation par environnement est un contrôle d'accès, pas une commodité d'organisation.**\n",
+    "> Corollaire opérationnel : une réindexation lancée sans préciser l'environnement cible écrase un corpus voisin.\n",
+    "\n",
+    "Ces deux lignes viennent du *Parcours 2* de `livresagites-parcours.md`. Elles décrivent deux défaillances observées sur une installation réelle d'AI-Engine, où les vecteurs ne forment pas un corpus unique mais **six environnements d'embeddings distincts**, séparés par un identifiant en base.\n",
+    "\n",
+    "Ce notebook ne reparle pas de l'observation : il **rend les deux défaillances mesurables et reproductibles**. À partir d'un vector store synthétique partitionné en six régimes d'accès, on mesure deux choses :\n",
+    "\n",
+    "1. **le taux de fuite** — une requête de retrieval émise *sans* filtre d'environnement renvoie des chunks d'un régime d'accès différent ;\n",
+    "2. **l'accident de réindexation** — `reindexer(..., environnement=None)` écrit dans un emplacement par défaut qui écrase un corpus voisin, silencieusement.\n",
+    "\n",
+    "Les deux sont démontrés déterministiquement, sans réseau, sans clé, sur une fixture synthétique."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2ea73c9",
+   "metadata": {},
+   "source": [
+    "## La scène : Maison Valmont et ses six régimes d'accès\n",
+    "\n",
+    "Maison Valmont indexe ses contenus dans un vector store, mais tous les\n",
+    "contenus ne s'adressent pas au même public. Six environnements cohabitent,\n",
+    "chacun destiné à un régime d'accès distinct :\n",
+    "\n",
+    "| Environnement | Public visé | Régime |\n",
+    "|---|---|---|\n",
+    "| `catalogue_public` | visiteurs anonymes | ouvert |\n",
+    "| `vitrine` | page d'accueil, mis en avant | ouvert |\n",
+    "| `comite_lecture` | comité interne de relecture | réservé |\n",
+    "| `atelier_interne` | notes d'atelier, brouillons | réservé |\n",
+    "| `archive_privee` | archives dirigeants | confidentiel |\n",
+    "| `logistique` | fiches fournisseurs, stocks | interne |\n",
+    "\n",
+    "Deux environnements — `catalogue_public` et `comite_lecture` — traitent des\n",
+    "**œuvres comparables** (mêmes pièces, mêmes collections). Géométriquement,\n",
+    "leurs vecteurs sont donc proches : c'est précisément ce chevauchement qui\n",
+    "rendra la fuite possible, et qui montre pourquoi le contrôle d'accès ne\n",
+    "peut pas se déduire de la seule distance vectorielle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "410d2c00",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:12:31.914677Z",
+     "iopub.status.busy": "2026-08-12T00:12:31.914480Z",
+     "iopub.status.idle": "2026-08-12T00:12:31.995727Z",
+     "shell.execute_reply": "2026-08-12T00:12:31.995309Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Dépendances : numpy uniquement. Aucun réseau, aucune clé, aucun modèle.\n",
+    "import numpy as np\n",
+    "\n",
+    "RNG = np.random.default_rng(7)   # seed fixée : tout le notebook est reproductible\n",
+    "DIM = 16                         # dimension de l'espace d'embedding (synthétique)\n",
+    "ENVIRONNEMENTS = [\n",
+    "    \"catalogue_public\",\n",
+    "    \"comite_lecture\",\n",
+    "    \"atelier_interne\",\n",
+    "    \"logistique\",\n",
+    "    \"archive_privee\",\n",
+    "    \"vitrine\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24506c3a",
+   "metadata": {},
+   "source": [
+    "## Construire le vector store partitionné\n",
+    "\n",
+    "Chaque environnement est un **cluster** : un centroïde tiré aléatoirement,\n",
+    "autour duquel s'organisent `N=40` chunks. Le détail important : on\n",
+    "rapproche délibérément `catalogue_public` et `comite_lecture` (ils partagent\n",
+    "un thème, comme dans la vraie vie), de sorte que leurs clusters se\n",
+    "chevauchent partiellement. Les quatre autres environnements restent bien\n",
+    "séparés."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "51b50b68",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:12:31.998649Z",
+     "iopub.status.busy": "2026-08-12T00:12:31.998331Z",
+     "iopub.status.idle": "2026-08-12T00:12:32.005858Z",
+     "shell.execute_reply": "2026-08-12T00:12:32.005407Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Vector store Maison Valmont : 6 environnements, 240 chunks au total, dimension 16.\n",
+      "  catalogue_public   : 40 vecteurs\n",
+      "  comite_lecture     : 40 vecteurs\n",
+      "  atelier_interne    : 40 vecteurs\n",
+      "  logistique         : 40 vecteurs\n",
+      "  archive_privee     : 40 vecteurs\n",
+      "  vitrine            : 40 vecteurs\n"
+     ]
+    }
+   ],
+   "source": [
+    "N_PAR_ENV = 40\n",
+    "\n",
+    "# centroïdes de base, un par environnement\n",
+    "centroids = {env: RNG.normal(scale=3.0, size=DIM) for env in ENVIRONNEMENTS}\n",
+    "\n",
+    "# rapprochement catalogue_public <-> comite_lecture (mêmes œuvres => vecteurs proches)\n",
+    "centroids[\"comite_lecture\"] = centroids[\"catalogue_public\"] + RNG.normal(scale=0.6, size=DIM)\n",
+    "\n",
+    "# le vector store : dictionnaire environnement -> (N, DIM) chunks\n",
+    "store = {}\n",
+    "for env in ENVIRONNEMENTS:\n",
+    "    store[env] = centroids[env] + RNG.normal(scale=1.5, size=(N_PAR_ENV, DIM))\n",
+    "\n",
+    "print(f\"Vector store Maison Valmont : {len(store)} environnements, \"\n",
+    "      f\"{sum(len(v) for v in store.values())} chunks au total, dimension {DIM}.\")\n",
+    "for env in ENVIRONNEMENTS:\n",
+    "    print(f\"  {env:18s} : {len(store[env]):2d} vecteurs\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be8ab602",
+   "metadata": {},
+   "source": [
+    "## Le geste attendu : filtrer par environnement\n",
+    "\n",
+    "Un retrieval correct, émis depuis un chatbot pointant vers\n",
+    "`catalogue_public`, ne doit chercher **que** parmi les chunks de\n",
+    "`catalogue_public`. C'est ce que fait le paramètre `filtre` : il restreint\n",
+    "la recherche à un environnement avant le top-k. Sans lui, la recherche\n",
+    "se fait sur **l'union** de tous les environnements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6a43138e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:12:32.008570Z",
+     "iopub.status.busy": "2026-08-12T00:12:32.008232Z",
+     "iopub.status.idle": "2026-08-12T00:12:32.012916Z",
+     "shell.execute_reply": "2026-08-12T00:12:32.012392Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def retrieve(query, store, k=5, filtre=None):\n",
+    "    \"\"\"Renvoie les k chunks les plus proches de query (distance L2).\n",
+    "\n",
+    "    Si filtre=None : cherche dans TOUS les environnements (dangereux).\n",
+    "    Sinon : ne cherche que dans l'environnement 'filtre' (contrôle d'accès).\n",
+    "    \"\"\"\n",
+    "    envs_cherches = [filtre] if filtre is not None else list(store.keys())\n",
+    "    vecs, labels = [], []\n",
+    "    for env in envs_cherches:\n",
+    "        for v in store[env]:\n",
+    "            vecs.append(v); labels.append(env)\n",
+    "    vecs = np.array(vecs)\n",
+    "    dists = np.linalg.norm(vecs - query, axis=1)\n",
+    "    order = np.argsort(dists)[:k]\n",
+    "    return [labels[j] for j in order]\n",
+    "\n",
+    "def taux_de_fuite(resultats, environnement_attendu):\n",
+    "    \"\"\"Fraction des resultats hors de l'environnement attendu.\"\"\"\n",
+    "    if not resultats:\n",
+    "        return 0.0\n",
+    "    hors = sum(1 for r in resultats if r != environnement_attendu)\n",
+    "    return hors / len(resultats)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef855592",
+   "metadata": {},
+   "source": [
+    "## Première défaillance — la fuite cross-environnement\n",
+    "\n",
+    "Un visiteur **public** pose une question. Sa requête est embedée, puis on\n",
+    "cherche les 5 chunks les plus proches. Si l'environnement cible n'est pas\n",
+    "précisé, le retrieve balaie tout le store."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3d060322",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:12:32.015737Z",
+     "iopub.status.busy": "2026-08-12T00:12:32.015473Z",
+     "iopub.status.idle": "2026-08-12T00:12:32.019898Z",
+     "shell.execute_reply": "2026-08-12T00:12:32.019393Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top-5 sans filtre : ['catalogue_public', 'catalogue_public', 'catalogue_public', 'catalogue_public', 'comite_lecture']\n",
+      "Taux de fuite : 20% des chunks renvoyés viennent d'un autre régime.\n",
+      "  -> un visiteur public reçoit du contenu de : ['comite_lecture']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Une requête issue du regime catalogue_public (un visiteur cherche une œuvre)\n",
+    "requete = store[\"catalogue_public\"][0]\n",
+    "\n",
+    "# retrieve SANS filtre : la recherche balaie les six environnements\n",
+    "top5_sans_filtre = retrieve(requete, store, k=5, filtre=None)\n",
+    "fuite = taux_de_fuite(top5_sans_filtre, \"catalogue_public\")\n",
+    "\n",
+    "print(\"Top-5 sans filtre :\", top5_sans_filtre)\n",
+    "print(f\"Taux de fuite : {fuite:.0%} des chunks renvoyés viennent d'un autre régime.\")\n",
+    "if fuite > 0:\n",
+    "    intrus = [r for r in top5_sans_filtre if r != \"catalogue_public\"]\n",
+    "    print(f\"  -> un visiteur public reçoit du contenu de : {intrus}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d792f8d2",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "Le taux de fuite n'est pas un artefact de géométrie trop lâche : il vient\n",
+    "de ce que `catalogue_public` et `comite_lecture` parlent des **même œuvres**.\n",
+    "Leurs vecteurs sont légitimement proches, donc le plus proche voisin d'un\n",
+    "chunk public peut être un chunk du comité. La distance vectorielle, à elle\n",
+    "seule, **ne sait rien** du régime d'accès — elle ne mesure que la\n",
+    "proximité sémantique. C'est exactement le cas où un filtre explicite est\n",
+    "indispensable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0ce160c3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:12:32.022566Z",
+     "iopub.status.busy": "2026-08-12T00:12:32.022353Z",
+     "iopub.status.idle": "2026-08-12T00:12:32.027029Z",
+     "shell.execute_reply": "2026-08-12T00:12:32.026370Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top-5 avec filtre 'catalogue_public' : ['catalogue_public', 'catalogue_public', 'catalogue_public', 'catalogue_public', 'catalogue_public']\n",
+      "Taux de fuite : 0%\n",
+      "\n",
+      "--- Comparaison ---\n",
+      "  sans filtre : 20% de fuite (contenu réservé livré au public)\n",
+      "  avec filtre : 0% de fuite (recherche scopée au régime attendu)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Même requête, cette fois AVEC le filtre attendu\n",
+    "top5_avec_filtre = retrieve(requete, store, k=5, filtre=\"catalogue_public\")\n",
+    "fuite_f = taux_de_fuite(top5_avec_filtre, \"catalogue_public\")\n",
+    "\n",
+    "print(\"Top-5 avec filtre 'catalogue_public' :\", top5_avec_filtre)\n",
+    "print(f\"Taux de fuite : {fuite_f:.0%}\")\n",
+    "print()\n",
+    "print(\"--- Comparaison ---\")\n",
+    "print(f\"  sans filtre : {fuite:.0%} de fuite (contenu réservé livré au public)\")\n",
+    "print(f\"  avec filtre : {fuite_f:.0%} de fuite (recherche scopée au régime attendu)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0dbddbf4",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "Le filtre ramène le taux de fuite à **0%** — non pas en rapprochant les\n",
+    "vecteurs, mais en **restreignant l'espace de recherche avant** le top-k.\n",
+    "C'est bien un contrôle d'accès : la question n'est pas « ce chunk est-il\n",
+    "sémantiquement pertinent ? » mais « ce visiteur a-t-il le droit de le\n",
+    "voir ? ». La distance vectorielle répond à la première ; seule la\n",
+    "partition par environnement répond à la seconde."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2a86e85",
+   "metadata": {},
+   "source": [
+    "## Deuxième défaillance — l'accident de réindexation\n",
+    "\n",
+    "On veut réindexer un nouveau corpus. La fonction `reindexer` prend un\n",
+    "environnement cible. Si l'oubli de cet argument fait tomber sur un\n",
+    "emplacement par défaut, cet emplacement **écrase** un environnement\n",
+    "existant — sans avertissement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d1aead28",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:12:32.029994Z",
+     "iopub.status.busy": "2026-08-12T00:12:32.029803Z",
+     "iopub.status.idle": "2026-08-12T00:12:32.035025Z",
+     "shell.execute_reply": "2026-08-12T00:12:32.034599Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AVANT accident :\n",
+      "  catalogue_public : 40 vecteurs\n",
+      "  comite_lecture   : 40 vecteurs\n",
+      "\n",
+      "reindexer(..., environnement=None) a écrit dans : catalogue_public\n",
+      "\n",
+      "APRÈS accident :\n",
+      "  catalogue_public   : 12 vecteurs\n",
+      "  comite_lecture     : 40 vecteurs\n"
+     ]
+    }
+   ],
+   "source": [
+    "def reindexer(nouveau_corpus, store, environnement=None):\n",
+    "    \"\"\"Réindexe nouveau_corpus dans l'environnement cible.\n",
+    "\n",
+    "    DANGER : si environnement=None, écrit dans le premier environnement\n",
+    "    du store (emplacement par défaut) et écrase son contenu.\n",
+    "    \"\"\"\n",
+    "    cible = environnement if environnement is not None else next(iter(store))\n",
+    "    store[cible] = nouveau_corpus\n",
+    "    return cible\n",
+    "\n",
+    "# état avant : catalogue_public contient ses 40 chunks d'origine\n",
+    "print(\"AVANT accident :\")\n",
+    "print(f\"  catalogue_public : {len(store['catalogue_public'])} vecteurs\")\n",
+    "print(f\"  comite_lecture   : {len(store['comite_lecture'])} vecteurs\")\n",
+    "\n",
+    "# on voulait réindexer la vitrine, mais on a oublié l'environnement cible\n",
+    "nouveau_corpus_vitrine = RNG.normal(scale=3.0, size=(12, DIM))\n",
+    "cible_touchée = reindexer(nouveau_corpus_vitrine, store, environnement=None)\n",
+    "print(f\"\\nreindexer(..., environnement=None) a écrit dans : {cible_touchée}\")\n",
+    "\n",
+    "print(\"\\nAPRÈS accident :\")\n",
+    "for env in [\"catalogue_public\", \"comite_lecture\"]:\n",
+    "    print(f\"  {env:18s} : {len(store[env])} vecteurs\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d55778b",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "L'environnement par défaut était `catalogue_public`. En voulant réindexer\n",
+    "la vitrine, on a **silencieusement détruit** les 40 chunks d'origine du\n",
+    "catalogue public, remplacés par les 12 nouveaux vecteurs. Aucun message,\n",
+    "aucune erreur — la fonction a fait exactement ce qu'on lui a dit. La\n",
+    "perte est immédiate et invisible tant qu'on ne compte pas.\n",
+    "\n",
+    "C'est le corollaire opérationnel du parcours : « une réindexation lancée\n",
+    "sans préciser l'environnement cible écrase un corpus voisin ». Le comptage\n",
+    "avant/après est le seul instrument qui révèle l'accident."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4863ea1",
+   "metadata": {},
+   "source": [
+    "## La leçon, mesurée\n",
+    "\n",
+    "Les deux défaillances ont la même racine : **la partition par environnement\n",
+    "est porteuse d'un invariant de sécurité, pas d'une commodité de rangement**.\n",
+    "Retirer le filtre ou oublier la cible ne dégrade pas la qualité du\n",
+    "retrieval — il viole un contrôle d'accès.\n",
+    "\n",
+    "Deux métriques suffisent à le surveiller :\n",
+    "\n",
+    "- le **taux de fuite** d'un retrieval (fraction du top-k hors environnement\n",
+    "  attendu) — il doit être `0%` en production ;\n",
+    "- le **compte de chunks** par environnement avant/après une réindexation —\n",
+    "  toute chute inattendue signale un écrasement.\n",
+    "\n",
+    "Sur l'installation observée, ces deux métriques n'étaient instrumentées\n",
+    "nulle part : la fuite était invisible (le chatbot répondait, c'est tout),\n",
+    "et l'écrasement silencieux (le store acceptait l'écriture). Les rendre\n",
+    "explicites est le premier pas pour qu'elles cessent d'arriver."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ed4f465",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les trois exercices suivent le notebook : mesurer, protéger, surveiller.\n",
+    "Aucun n'est corrigé — à toi de compléter le geste à partir des fonctions\n",
+    "déjà définies (`retrieve`, `taux_de_fuite`, `reindexer`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd367e33",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — L'effet du top-k sur la fuite\n",
+    "\n",
+    "Le taux de fuite dépend de `k` : plus on demande de chunks, plus on a de\n",
+    "chances d'attraper un voisin hors-régime. Calcule le taux de fuite **moyen**\n",
+    "d'une requête `catalogue_public` sans filtre, pour `k = 5`, puis `k = 10`,\n",
+    "puis `k = 20`. Observe-t-on une dégradation ?\n",
+    "\n",
+    "*Indice :* boucle sur une dizaine de requêtes issues de\n",
+    "`store[\"catalogue_public\"]`, moyenne les taux de fuite pour chaque `k`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "47a7a7d1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:12:32.038134Z",
+     "iopub.status.busy": "2026-08-12T00:12:32.037952Z",
+     "iopub.status.idle": "2026-08-12T00:12:32.041208Z",
+     "shell.execute_reply": "2026-08-12T00:12:32.040370Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 1 -- mesurer l'effet du top-k sur le taux de fuite moyen.\n",
+    "# Étape 1 : choisis plusieurs requêtes issues de catalogue_public.\n",
+    "# Étape 2 : pour k dans [5, 10, 20], calcule le taux de fuite moyen (sans filtre).\n",
+    "# resultats = {}  # TODO étudiant\n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e94fa16",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Un reindexer qui refuse l'ambiguïté\n",
+    "\n",
+    "`reindexer(..., environnement=None)` est la porte ouverte à l'accident.\n",
+    "Écris une variante `reindexer_sur` qui **refuse** d'écrire quand\n",
+    "l'environnement est `None`, au lieu d'écrire silencieusement dans\n",
+    "l'emplacement par défaut. Elle doit signaler le refus sans lever d'erreur\n",
+    "qui casserait l'exécution du notebook.\n",
+    "\n",
+    "*Indice :* retourne une valeur sentinelle (par exemple la chaîne\n",
+    "`\"REFUS : environnement non précisé\"`) quand `environnement is None`,\n",
+    "au lieu de toucher au store."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "931a643d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:12:32.043645Z",
+     "iopub.status.busy": "2026-08-12T00:12:32.043377Z",
+     "iopub.status.idle": "2026-08-12T00:12:32.046059Z",
+     "shell.execute_reply": "2026-08-12T00:12:32.045616Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 2 -- écrire reindexer_sur(nouveau, store, env) qui refuse env=None.\n",
+    "# Contrat : si env is None, ne rien écrire et retourner un message explicite.\n",
+    "# def reindexer_sur(nouveau_corpus, store, environnement=None):\n",
+    "#     ...\n",
+    "# resultat = None  # TODO étudiant\n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "487a222c",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Un test de non-régression pour l'écrasement\n",
+    "\n",
+    "L'accident de réindexation est silencieux : rien ne l'annonce. Écris un\n",
+    "**test** (une assertion simple) qui détecte qu'un environnement a été\n",
+    "écrasé : il compare le compte de chunks d'un environnement avant et après\n",
+    "une opération, et signale toute chute. Le test doit **passer** quand\n",
+    "l'environnement est intact, et **échouer** (message clair) s'il a été\n",
+    "écrasé.\n",
+    "\n",
+    "*Indice :* `assert len(store[env]) == compte_avant, f\"{env} écrasé\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "9eaa2715",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T00:12:32.048688Z",
+     "iopub.status.busy": "2026-08-12T00:12:32.048352Z",
+     "iopub.status.idle": "2026-08-12T00:12:32.051169Z",
+     "shell.execute_reply": "2026-08-12T00:12:32.050727Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 3 -- un test qui détecte l'écrasement silencieux d'un environnement.\n",
+    "# Étape 1 : mémorise le compte de chunks de 'archive_privee' avant l'opération.\n",
+    "# Étape 2 : définis assert_pas_ecrase(env, compte_avant) qui lève une AssertionError\n",
+    "#           claire si len(store[env]) != compte_avant.\n",
+    "# test = None  # TODO étudiant\n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c83988f9",
+   "metadata": {},
+   "source": [
+    "## Provenance et pour aller plus loin\n",
+    "\n",
+    "Ce notebook matérialise le **Parcours 2** de `livresagites-parcours.md`\n",
+    "(RAG sur corpus et piège du multi-environnement). Il est le compagnon\n",
+    "exécutable de l'assertion « la séparation par environnement est un\n",
+    "contrôle d'accès ».\n",
+    "\n",
+    "- **Parcours 3** (audit d'un serveur MCP) a son propre compagnon :\n",
+    "  `auditer-un-serveur-mcp.ipynb`.\n",
+    "- La fixture est **synthétique à 100 %** (numpy, seed=7) : aucun appel\n",
+    "  réseau, aucune clé, aucune donnée client. Les noms d'environnements\n",
+    "  (`catalogue_public`, `comite_lecture`…) sont des rôles d'accès\n",
+    "  génériques, pas des noms réels ; les chunks sont des vecteurs, pas de\n",
+    "  la prose.\n",
+    "- Le scénario de chevauchement (`catalogue_public` ↔ `comite_lecture`)\n",
+    "  est volontaire : il modélise le cas réaliste où deux environnements\n",
+    "  traitent du contenu sémantiquement proche — précisément celui où un\n",
+    "  filtre d'environnement devient indispensable."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA

Compagnon exécutable du **Parcours 2** de `livresagites-parcours.md` (RAG sur corpus et piège du multi-environnement). Convertit les deux défaillances décrites en prose en **mesures reproductibles** sur un vector store synthétique partitionné en six régimes d'accès.

**Quoi:** un nouveau notebook `separer-les-environnements-de-vecteurs.ipynb` qui démontre déterministiquement (numpy, seed=7, R^16, fixture synthétique 100 % — aucun appel réseau, aucune clé, aucune donnée client) :
1. **Fuite cross-environnement** — un retrieval émis *sans* filtre renvoie des chunks d'un régime d'accès réservé. Mesure : taux de fuite top-k. Sur la géométrie calibrée (catalogue_public ↔ comite_lecture adjacents, car mêmes œuvres), le taux de fuite = **20 % sans filtre** (top-5 = 4 catalogue_public + 1 comite_lecture → « un visiteur public reçoit du contenu réservé au comité »), **0 % avec filtre**.
2. **Accident de réindexation** — `reindexer(..., environnement=None)` écrit dans l'emplacement par défaut et écrase silencieusement un corpus voisin (catalogue_public 40 → 12 vecteurs), révélé uniquement par comptage avant/après.

Le chevauchement catalogue_public↔comite_lecture est volontaire : il modélise le cas réaliste où deux environnements traitent du contenu sémantiquement proche — précisément celui où un filtre d'environnement devient indispensable (la distance vectorielle, à elle seule, ne sait rien du régime d'accès).

Patron = grain-9 `auditer-un-serveur-mcp.ipynb` (compagnon du Parcours 3) : intro → contexte Maison Valmont → dépendances → démo fuite → démo écrasement → leçon mesurée → 3 exercices stubbés → provenance. Trois exercices (`pass`, C.1 — aucune erreur volontaire) : effet du top-k sur la fuite, un reindexer qui refuse l'ambiguïté, un test de non-régression pour l'écrasement.

**Preuve:**
- Exécution réelle `jupyter nbconvert --execute --inplace`, kernel python3 : **9 cellules code, 0 `execution_count` null, 0 erreur**. Les 3 stubs `pass` s'exécutent sans erreur (C.1 conforme).
- Outputs mesurés et frappants : fuite 20 % vs 0 %, écrasement 40→12 (commit AVEC outputs, C.2).
- `nbformat 4.5` valide (python `nbformat.validate`).
- `detect_solution_leaks.py --scan` : **0 HIGH, 0 MEDIUM, 0 error**.
- 0 pattern C.1 interdit (`raise NotImplementedError`/`assert False`/`1/0`).
- `git diff origin/main -- COURSE_CATALOG.generated.{json,md}` : vide (catalogue byte-identique).
- README + parcours : référencent le notebook comme compagnon exécutable (FR primaire, règle readme-french-first).
- Diff atomique : 1 nouveau notebook + 2 màj doc (README +13, parcours +7), +619 lignes.

**Perimetre:** le notebook Parcours 2 uniquement. Pas de toucher au catalogue, aux autres notebooks (eval-choisir, ingestion-corpus, auditer-mcp), ni aux workflows CI. L'issue est entièrement couverte (notebook + màj README + parcours) → `Closes #10517`.

Closes #10517
