### PR TITLE
docs(qc,#1621): research/README — reclassify 4 QuantBook notebooks (c)->(b) [acceptance critère 2]

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/research/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/research/README.md
@@ -7,18 +7,18 @@ maturity:
 
 # Notebooks de recherche standalone
 
-Recherche indépendante utilisant des données locales (yfinance, pandas, sklearn). Aucun QuantConnect Cloud requis.
+Recherche indépendante utilisant des données locales (yfinance, pandas, sklearn). La majorité des notebooks s'exécutent en local sans QuantConnect Cloud ; **4 notebooks des familles M11/M12** (`research_btc_ml`, `research_m11ef_ensemble`, `research_m12_har_rv_j`, `research_m12_har_rv_j_minute`) chargent leurs données crypto via `QuantBook` QC Cloud (type (b), signalés dans le tableau ci-dessous).
 
 ## Notebooks
 
 | Notebook | Sujet | Type | Source de données |
 |----------|-------|------|-------------------|
-| `research_btc_ml.ipynb` | Caractéristiques de prédiction ML BTC | (c) Standalone | yfinance |
+| `research_btc_ml.ipynb` | Caractéristiques de prédiction ML BTC | (b) QuantBook QC Cloud | QC Cloud crypto (BTCUSDT Binance) |
 | `research_composite_ff_aw.ipynb` | Composite FamaFrench + AllWeather | (c) Standalone | yfinance |
 | `research_composite_mom_regime.ipynb` | Composite Momentum + Régime | (c) Standalone | yfinance |
-| `research_m11ef_ensemble.ipynb` | Méthodes d'ensemble | (c) Standalone | yfinance |
-| `research_m12_har_rv_j.ipynb` | Modèle de volatilité HAR-RV-J (horaire) | (c) Standalone | yfinance |
-| `research_m12_har_rv_j_minute.ipynb` | M12-HF : variante minute (QuantBook QC Cloud) | (c) Standalone | QC Cloud crypto |
+| `research_m11ef_ensemble.ipynb` | Méthodes d'ensemble | (b) QuantBook QC Cloud | QC Cloud crypto (Bitstamp/Coinbase) |
+| `research_m12_har_rv_j.ipynb` | Modèle de volatilité HAR-RV-J (horaire) | (b) QuantBook QC Cloud | QC Cloud crypto (Hour) |
+| `research_m12_har_rv_j_minute.ipynb` | M12-HF : variante minute (QuantBook QC Cloud) | (b) QuantBook QC Cloud | QC Cloud crypto (Minute, non exécuté) |
 | `research_m12_hf_btc_local.ipynb` | M12-HF : verdict BTC minute vs hourly (local) | (c) Standalone | BTC tick Bitstamp |
 | `research_m12_hf_dm_test.ipynb` | M12-HF : test de significativité Diebold-Mariano | (c) Standalone | BTC tick Bitstamp |
 | `research_quality_lowvol.ipynb` | Facteur Quality + Low Vol | (c) Standalone | yfinance |
@@ -31,7 +31,7 @@ Recherche indépendante utilisant des données locales (yfinance, pandas, sklear
 | `research_rl_tactical_overlay.ipynb` | Overlay tactique RL | (c) Standalone | yfinance |
 | `research_vrp_putwrite.ipynb` | Stratégie VRP put-write | (c) Standalone | yfinance |
 
-Les 17 notebooks sont de type **(c) standalone research**. La plupart s'exécutent localement avec `pip install yfinance pandas matplotlib scikit-learn` ; la famille M12-HF (3 notebooks) utilise des données tick BTC Bitstamp possédées (agrégées en minute localement), et la variante `_minute` est un QuantBook à exécuter sur QC Cloud.
+Sur les 17 notebooks, **13 sont de type (c) standalone research** (s'exécutent localement avec `pip install yfinance pandas matplotlib scikit-learn` ; la famille M12-HF, 3 notebooks, utilise des données tick BTC Bitstamp possédées agrégées en minute localement) et **4 sont de type (b) research lié au quantbook QC Cloud** (`research_btc_ml`, `research_m11ef_ensemble`, `research_m12_har_rv_j` exécutés, et la variante `_minute` qui instancie `QuantBook` sans outputs committés — à exécuter sur QC Cloud).
 
 ---
 
@@ -39,12 +39,12 @@ Les 17 notebooks sont de type **(c) standalone research**. La plupart s'exécute
 
 ### Ce que vous avez appris
 
-Ces **17 notebooks standalone** sont le **laboratoire local** de la série QuantConnect : ils ne nécessitent **pas** de compte QC Cloud ni de données payantes — `yfinance` (données gratuites) + `pandas` / `scikit-learn` suffisent (la famille M12-HF utilise des données tick BTC possédées). Ils illustrent deux familles de recherche :
+Ces **17 notebooks** sont le **laboratoire de recherche** de la série QuantConnect. La **majorité (13/17) sont standalone** et s'exécutent en local avec `yfinance` (données gratuites) + `pandas` / `scikit-learn` (la famille M12-HF utilise des données tick BTC possédées) ; les **4 notebooks des familles M11/M12** (btc_ml, m11ef_ensemble, m12_har_rv_j, m12_har_rv_j_minute) chargent leurs données crypto via `QuantBook` QC Cloud (type (b)). Ils illustrent deux familles de recherche :
 
 - **Recherche factorielle & allocation** (HAR-RV-J vol, FamaFrench + AllWeather composite, Momentum + Regime, Quality/LowVol, Risk Parity, VRP put-write) — on apprend que les modèles de volatilité et d'allocation robuste sont reproductibles en local sur données publiques, et que les composites (M12, M11ef) sont les briques des stratégies *Robuste* du catalogue. **Verdict honnête M12-HF** (`research_m12_hf_btc_local.ipynb` + `research_m12_hf_dm_test.ipynb`) : l'estimation de la realized variance en minute **bat** celle en hourly (delta médian +0.548, MSE minute ~moitié hourly), statistiquement validée par un test de Diebold-Mariano (HAC, p≈0.000) et un block-bootstrap dont l'IC95 est entièrement négatif. La cause du gain est cependant la **fréquence d'échantillonnage** (qualité de l'estimateur RV, Andersen-Bollerslev-Diebold 2003), **pas** la composante de jump — HAR-Classic sans jump montre le même gain. Leçon méthodologique : la résolution hourly (24 bars/jour) est trop bruitée pour le vol-targeting Kelly ; la minute (1440 bars/jour) l'est beaucoup moins.
 - **Recherche Reinforcement Learning** (intro, PPO, GRPO, reward shaping, multi-asset, tactical overlay) — on apprend que le RL trading se prototypé localement avant tout déploiement QC Cloud, et que le *reward shaping* est le levier le plus sensible (un reward mal spécifié fige la policy). **Leçon d'intégrité #3360** : diviser la reward portfolio-level par le nombre d'actifs (`reward / N_ASSETS`) détruit le signal du critic per-asset → la policy gèle près de l'uniforme → l'argmax collapse vers Buy (fingerprint buy-and-hold, Sharpe 0.657 identique au collapse PPO). Corrigé : la reward portfolio complète alimente chaque transition per-asset (cohérence #3359/#3360). Verdict ré-évalué honnête après fix : NO BEATS (A2C Sharpe 0.000, SAC −0.063 sur univers non-FAANG) — pour la bonne raison.
 
-Le fil rouge : **l'indépendance de la plateforme**. Ces notebooks prouvent que l'idéation et la validation ML peuvent se faire hors QC Cloud ; le cloud n'est requis que pour le backtest haute-fidélité sur données natives.
+Le fil rouge : **l'indépendance de la plateforme**. Ces notebooks prouvent que l'idéation et la validation ML peuvent se faire hors QC Cloud pour la majorité des sujets (13/17 standalone) ; QC Cloud devient nécessaire dès que la recherche porte sur des données crypto natives (4 notebooks M11/M12 qui instancient `QuantBook`), et reste la porte d'entrée du backtest haute-fidélité sur données natives.
 
 ### Prochaines étapes
 


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2024:CoursIA — prev: LIGHT/docs #10526

## Summary

Corrige une **inexactitude factuelle documentée** dans `QuantConnect/research/README.md` : le fichier claimait « 17 notebooks standalone, Aucun QuantConnect Cloud requis » et marquait les 17 comme `(c) Standalone / yfinance`. Un audit cell-par-cell firsthand sur `origin/main` révèle que **4 notebooks instancient réellement `qb = QuantBook()`** et chargent leurs données via QC Cloud — ils sont type **(b) research lié au quantbook**, pas (c) standalone. Cela satisfait le **critère d'acceptance 2** de l'EPIC #1621 (« distinction claire des 4 types de notebooks »).

See #1621. **Pas `Closes #1621`** : EPIC multi-volets (le sous-volet « dégénériciser ESGF » est FAIT depuis mai — ai-01 07-15 ; d'autres volets restent : consolidation projets/, checkpoints 444MB, papertrading).

## Ce que la PR change (1 fichier, markdown-only, 8±8 lignes)

`research/README.md` — 4 inexactitudes corrigées, contenu pédagogique préservé :

1. **Ligne 10 (intro)** : « Aucun QuantConnect Cloud requis » → nuancé : la majorité standalone, 4 notebooks M11/M12 via `QuantBook` QC Cloud.
2. **Tableau (4 lignes reclassées)** : `research_btc_ml`, `research_m11ef_ensemble`, `research_m12_har_rv_j`, `research_m12_har_rv_j_minute` : `(c) Standalone / yfinance` → `(b) QuantBook QC Cloud / QC Cloud crypto (source exacte)`.
3. **Ligne 34 (claim type)** : « Les 17 notebooks sont de type (c) » → « 13 sont (c) standalone, 4 sont (b) research lié QC Cloud ».
4. **Ligne 47 (fil rouge)** : « le cloud n'est requis que pour le backtest » → nuancé : QC Cloud nécessaire dès la recherche sur données crypto natives (4 notebooks M11/M12).

**Préservé intact** (audit §E fichier-entier, 47 lignes) : CATALOG-STATUS (byte-identique), verdict M12-HF (Diebold-Mariano p≈0.000, delta +0.548), leçon d'intégrité RL #3360 (reward/N_ASSETS), verdict NO BEATS (A2C 0.000, SAC −0.063), étapes pratiques, rappel honnête yfinance.

## Méthode — audit cell-par-cell firsthand (pas un verdict de recon au vol)

Pour chaque notebook de `research/`, extraction des cellules code + test `QuantBook`/`qb.AddCrypto`/`qb.History` + `execution_count`/`outputs` :

| Notebook | Verdict | Preuve |
|---|---|---|
| `research_btc_ml` | **QB QC Cloud, exécuté** | cell1 exec=1 outputs=1 : `qb = QuantBook(); qb.add_crypto('BTCUSDT', Binance)` |
| `research_m11ef_ensemble` | **QB QC Cloud, exécuté** | cell1-2 exec=1/2 : `qb = QuantBook(); qb.AddCrypto(Bitstamp/Coinbase)` |
| `research_m12_har_rv_j` | **QB QC Cloud, exécuté** | cell1-2 exec=1/2 : `qb = QuantBook(); qb.AddCrypto(Hour)` |
| `research_m12_har_rv_j_minute` | **QB, jamais exécuté** | cell1-3 exec=None outputs=0 : instancie QB sans outputs committés |
| `research_m12_hf_btc_local` | **FALSE POSITIVE** | mentionne Bitstamp + « 0 QCC » (0 QC Cloud) = explicitement standalone, 0 `QuantBook` |

## Acceptance (mesurée firsthand)

- **Tableau** : 4 lignes `(b) QuantBook QC Cloud` + 13 lignes `(c) Standalone` = 17 ✓.
- **Cohérence interne** : 0 ligne `(c) Standalone | QC Cloud crypto` (le seul cas ambigu `_minute` est désormais `(b)`).
- **CATALOG-STATUS byte-identique** (lignes 1-5 non touchées, [catalog-pr-hygiene](.claude/rules/catalog-pr-hygiene.md) HARD 1).
- **Contenu pédagogique préservé** : `grep -cE 'Diebold-Mariano|3360|NO BEATS'` = 3 (intact).
- **§E audit fichier-entier** (47 lignes) — pas un fix de ligne isolée laissant une inexactitude 30 lignes plus bas.

## Vérification

- **Markdown-only** : 0 notebook touché, 0 cellule code, 0 output modifié. Pas de re-exec.
- **Pas de nombre fabriqué** : 17, 13, 4, exec_count/outputs proviennent du scan firsthand des notebooks sur `origin/main`.
- **Convention type** : (a) quantbook QC Cloud canonique / (b) research lié quantbook / (c) standalone research / (d) placeholder — alignée sur l'acceptance EPIC.
- **FP documenté** : `research_m12_hf_btc_local` (mention Bitstamp = données locales, pas QB) laissé (c).
- Catalogue byte-identique à main. Grain tag ligne 1.

## Hors scope (G.4)

EPIC #1621 autres volets (consolidation projets/ 115 dirs, checkpoints ML 444MB Git LFS, papertrading status, tableau comparatif backtest) = tranches séparées. Le recon (sous-agent) a confirmé : Axe 1 (catalogue) déjà fait en substance, Axe 2 (papertrading) = mockups non déployés (verdict 1 ligne, grain séparé), Axe 4 (tableau backtest) stale depuis 2026-06-11.

## Modalité d'exécution

Markdown-only → pas de re-exécution (exception C.2). 0 cellule code touchée.
