### PR TITLE
feat(twin,#10382): complete Z3-API pilot bridge_verdict (04/05/06 SOTA-OK)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/z3-python-04-strings-regex.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-04-strings-regex.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Z3 string/regex theory (SeqSort) branchee NATIVEMENT des deux cotes : Microsoft.Z3 .NET (`#r \"nuget: Microsoft.Z3\"` + `using Microsoft.Z3;`, ctx.MkRange/MkConcat/MkRe/MkInRe sur Seq) et pyz3 (`from z3 import *`, Range/Concat/Plus/Re/InRe sur Seq) sont les deux bindings officiels du meme coeur C++ Z3 sous-jacent — pas un pont intermediaire type IKVM/PythonNet. Concept string-regex (date AAAA-MM-JJ sous-contrainte en groupes longueur-fixe) demontre des deux cotes. Aucune asymetrie de machinerie a corriger."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-05-quantifiers-proofs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-05-quantifiers-proofs.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Z3 quantifiers & proofs branche NATIVEMENT des deux cotes : Microsoft.Z3 .NET (`#r \"nuget: Microsoft.Z3\"` + `using Microsoft.Z3;`, ctx.MkForall/MkExists, Solver.Check() = Status.UNSATISFIABLE = preuve par refutation) et pyz3 (`from z3 import *`, ForAll/Exists, prove() par refutation, Fermat last theorem = unknown) sont les deux bindings officiels du meme coeur C++ Z3 — pas un pont intermediaire. Aucune asymetrie de machinerie a corriger."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-06-advanced-optimization.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-06-advanced-optimization.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Z3 optimization (MaxSAT / objectifs hierarchiques / front de Pareto) branchee NATIVEMENT des deux cotes : Microsoft.Z3 .NET (`#r \"nuget: Microsoft.Z3\"` + `using Microsoft.Z3;`, ctx.MkOptimize/MkMaximize/MkAssertSoft) et pyz3 (`from z3 import *`, Optimize/maximize/assert_soft) sont les deux bindings officiels du meme coeur C++ Z3 — pas un pont intermediaire. Concept porte au twin C# c.8052/#3801 (capstone budget 100->80, cas non-degenere, DRIFT resorbe). Aucune asymetrie de machinerie a corriger."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA


### PR DESCRIPTION
Quoi: Completer le pilote Z3-API declare dans `_schema.yaml` ("6 paires NB-01..06"). 01/02/03 portaient deja `bridge_verdict: SOTA-OK` (#10494/#10501/#10477) ; **04/05/06 manquaient** le verdict, laissant le pilote de ma lane incomplet. Ajout `bridge_verdict: SOTA-OK` + `bridge_verdict_reason` evidence-cited aux 3 paires.

Preuve:
- `git grep bridge_verdict origin/main -- twin_pairs.d/z3-python-*.yaml` = 01/02/03 only (avant cette PR).
- Firsthand sur les 3 notebooks C# : `#r "nuget: Microsoft.Z3"` + `using Microsoft.Z3` presents (04=12 refs, 05=12 refs, 06=4 refs), `execution_count != null` = executes.
- pyz3 ↔ Microsoft.Z3 = 2 bindings officiels du meme coeur C++ Z3 (pas un pont IKVM/PythonNet) = nativement branched des deux cotes.
- `check_twin_parity.py --check` = **157/157 OK, DRIFT=0, MISSING=0** (pas de regression).
- `check_twin_parity.py --summary-by-verdict` = **SOTA-OK 5 -> 8**, actionnables 151 -> 148.
- Feature Z3 distincte par paire (verifiee via known_differences existants) : 04 string/regex (MkRange/MkRe), 05 quantifiers/proofs (MkForall/MkExists, Fermat unknown), 06 optimization (MkOptimize/MkAssertSoft, MaxSAT/Pareto).

Perimetre: 3 fichiers yaml uniquement (annotation registre). 0 notebook touche, 0 re-exec (yaml metadata orthogonal a parity_level et aux blob SHA attestes). Audit 2026-08-04 existant reste valide (notebooks inchanges). Diff +6 lignes. Atomique, 1 sujet (Z3-API pilot completion).

Grain: MED/twin -- lane myia-po-2026:CoursIA

See #10382