### PR TITLE
feat(twin,#10382): annotate SemanticWeb bridge_verdict (10 pairs SOTA-OK)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/sw-10-rdf-star.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-10-rdf-star.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-CSharp-RDFStar.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/sw-11-knowledge-graphs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-11-knowledge-graphs.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-CSharp-KnowledgeGraphs.ipynb
   parity_level: surface
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/sw-13-reasoners.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-13-reasoners.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/sw-2-rdf-basics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-2-rdf-basics.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/sw-3-graph-operations.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-3-graph-operations.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/sw-4-sparql.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-4-sparql.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/sw-5-linked-data.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-5-linked-data.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/sw-6-rdfs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-6-rdfs.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/sw-8-shacl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-8-shacl.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/sw-9-json-ld.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-9-json-ld.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA


### PR DESCRIPTION
Quoti: Annoter les 10 paires SemanticWeb confirmées native-both firsthand avec `bridge_verdict: SOTA-OK`. La famille "SemanticWeb/dotNetRDF-rdflib" est le **modele nominal lib-vs-lib** (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF (native .NET), Python = rdflib (native Python) -- chaque cote atteint le moteur SOTA de son ecosysteme.

Preuve:
- Firsthand sur les 10 notebooks C# : `#r "nuget: dotNetRDF, 3.2.1"` + `VDS.RDF.*` refs (3-9 par notebook), `execution_count != null` (tous executes).
- Firsthand sur les 10 notebooks Python : `rdflib` imports (5-40 refs par notebook).
- Ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch = aucune asymetrie de machinerie a corriger.
- `check_twin_parity.py --check` = **157/157 OK, DRIFT=0, MISSING=0**.
- `check_twin_parity.py --summary-by-verdict` (cette branche) = **SOTA-OK 5 -> 15**.
- Paires : sw-2/3/4/5/6/8/9/10/11/13 (sw-7-owl EXCLU : Python rdflib=0, engine OWL different -- verdict separe requis, pas d'annotation en bloc).

Perimetre: 10 fichiers yaml (+20 lignes), annotation registre uniquement. 0 notebook touche, 0 re-exec (yaml metadata orthogonal aux blob SHA attestes). Atomique (1 sujet = SW family bridge_verdict, modele nominal). Complementaire de #10534 (Z3-API 04/05/06) -- les 2 PR ensemble font passer SOTA-OK 5 -> 18.

Grain: MED/twin -- lane myia-po-2026:CoursIA

See #10382