### PR TITLE
feat(twin,#10382): annotate Probas/Infer.NET-PyMC bridge_verdict (19 pairs SOTA-OK)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/probas-1-setup.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-1-setup.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-07-29"
       by: myia-po-2023:CoursIA-2

--- a/scripts/notebook_tools/twin_pairs.d/probas-10-model-selection.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-10-model-selection.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Model-Selection.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/probas-11-topic-models.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-11-topic-models.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Topic-Models.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/probas-12-modeles-hierarchiques.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-12-modeles-hierarchiques.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Modeles-Hierarchiques.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/probas-13-crowdsourcing.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-13-crowdsourcing.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Crowdsourcing.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/probas-14-sequences.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-14-sequences.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Sequences.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/probas-15-recommenders.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-15-recommenders.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/probas-16-sparse-gaussian-process.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-16-sparse-gaussian-process.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-16-Sparse-Gaussian-Process.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/probas-17-kalman-filter.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-17-kalman-filter.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Kalman-Filter.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-08-01"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/probas-18-change-point.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-18-change-point.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Change-Point.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/probas-19-survival-analysis.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-19-survival-analysis.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Survival-Analysis.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/probas-2-gaussian-mixtures.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-2-gaussian-mixtures.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-2-Gaussian-Mixtures.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-08-03"
       by: myia-po-2024:CoursIA-2

--- a/scripts/notebook_tools/twin_pairs.d/probas-3-factor-graphs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-3-factor-graphs.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-3-Factor-Graphs.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-07-29"
       by: myia-po-2023:CoursIA-2

--- a/scripts/notebook_tools/twin_pairs.d/probas-4-bayesian-networks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-4-bayesian-networks.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-4-Bayesian-Networks.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-07-30"
       by: myia-po-2024:CoursIA-2

--- a/scripts/notebook_tools/twin_pairs.d/probas-5-causal-inference.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-5-causal-inference.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Causal-Inference.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-07-29"
       by: myia-po-2023:CoursIA-2

--- a/scripts/notebook_tools/twin_pairs.d/probas-6-debugging.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-6-debugging.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-Debugging.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/probas-7-skills-irt.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-7-skills-irt.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-7-Skills-IRT.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-07-29"
       by: myia-po-2023:CoursIA-2

--- a/scripts/notebook_tools/twin_pairs.d/probas-8-trueskill.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-8-trueskill.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-TrueSkill.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-08-01"
       by: myia-po-2026:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/probas-9-classification.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-9-classification.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-9-Classification.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
     - date: "2026-07-29"
       by: myia-po-2023:CoursIA-2


### PR DESCRIPTION
Quoi: Annoter les 19 paires Probas/Infer.NET-PyMC avec `bridge_verdict: SOTA-OK`. Cette famille est le **modele nominal lib-vs-lib cite textuellement par owner** dans #10382 : « *PyMC vs Infer, 2 moteurs qui brillent chacun de leur cote, se completent et passent aisement en prod chacun si necessaire.* » C# = Microsoft Infer.NET (native .NET), Python = PyMC (native Python) -- chaque cote atteint le moteur SOTA de son ecosysteme probabiliste.

Preuve:
- Firsthand sur les 19 notebooks C# : `Microsoft.ML.Probabilistic` refs (5-13 par notebook), `execution_count != null` (tous executes).
- Firsthand sur les 19 notebooks Python : `pymc` imports (1-4 par notebook).
- Ni pont intermediaire ni reimplementation from-scratch = aucune asymetrie de machinerie a corriger.
- `check_twin_parity.py --check` = **157/157 OK, DRIFT=0, MISSING=0**.
- `check_twin_parity.py --summary-by-verdict` (cette branche) = **SOTA-OK 5 -> 24**.
- 19/19 native-both, uniforme, AUCUNE exclusion (contrairement SW-7-owl dans #10536).

Perimetre: 19 fichiers yaml (+38 lignes), annotation registre uniquement. 0 notebook touche, 0 re-exec (yaml metadata orthogonal aux blob SHA attestes). Atomique (1 sujet = Probas family bridge_verdict, le modele nominal exemplaire). Complementaire de #10534 (Z3 3 paires) et #10536 (SW 10 paires) -- les 3 PRs ensemble font passer SOTA-OK 5 -> 37 sur main.

Grain: MED/twin -- lane myia-po-2026:CoursIA

See #10382