### PR TITLE
docs(smt,#10488): Z3-Python-03-Tactics-Csharp density 338->1049 (+210%)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics-Csharp.ipynb
@@ -11,6 +11,10 @@
     "\n",
     "Ce notebook explore trois fonctionnalités avancées du **moteur réel [Microsoft.Z3](https://github.com/Z3Prover/z3)** (NuGet, Z3 4.12.2.0) : les **tactiques** (stratégies de résolution composables), la théorie des **vecteurs de bits** (`BitVec`, arithmétique modulaire), et la théorie des **tableaux** (`Array`, lecture/écriture symbolique).\n",
     "\n",
+    "## Pourquoi ces trois familles ensemble ?\n",
+    "\n",
+    "Un solveur SMT naïf traite toute formule avec le même moteur générique. La puissance de Z3 vient de ce qu'on peut **orchestrer** la résolution : une *tactique* transforme un but difficile en un (ou plusieurs) but(s) plus simple(s) jusqu'à ce qu'un solveur spécialisé termine. Les théories `BitVec` et `Array` sont les deux terrains les plus fréquents en vérification de programmes (entiers machine, mémoires). Comprendre comment on *compile* un problème vers ces théories, puis comment on *choisit* le bon solveur, est exactement ce qui distingue un utilisateur de Z3 d'un praticien.\n",
+    "\n",
     "## Plan\n",
     "\n",
     "1. Tactiques de simplification (`simplify`, `ctx-solver-simplify`).\n",
@@ -19,7 +23,7 @@
     "4. Casse-tête : nombre palindrome binaire.\n",
     "5. `Array` : `Store`/`Select`, raisonnement sur les tableaux.\n",
     "6. `SolverFor` spécialisé vs `Solver` générique (benchmark).\n",
-    "7. Trois exercices.\n"
+    "7. Trois exercices."
    ]
   },
   {
@@ -69,7 +73,11 @@
    "source": [
     "## 1. Tactique `simplify`\n",
     "\n",
-    "Une **tactique** est une stratégie de transformation de but (`Goal`). `simplify` applique des règles de réécriture syntaxique (constante folding, simplification algébrique). On crée un `Goal`, on y ajoute des formules, puis on applique la tactique via `Apply` → `ApplyResult` dont on extrait les `Subgoals`.\n"
+    "Une **tactique** est une stratégie de transformation de but (`Goal`). Contrairement à un `Solver` qui répond `SATISFIABLE`/`UNSATISFIABLE`, une tactique **réécrit** le but sans le trahir : le but résultant est équisatisfaisant, mais plus simple à résoudre.\n",
+    "\n",
+    "`simplify` applique des règles de réécriture syntaxique : constante folding (`2+3 → 5`), simplification algébrique, normalisation de la forme (par exemple réordonner les termes pour que les constantes migrent à gauche). On crée un `Goal`, on y ajoute des formules, puis on applique la tactique via `Apply` → `ApplyResult` dont on extrait les `Subgoals`.\n",
+    "\n",
+    "> **Idiome .NET vs Python** : en Python on écrit `goal.add(...)` et `tactic(goal)` ; le binding .NET expose les mêmes objets via `ctx.MkGoal()`, `g.Add(...)`, et `tactic.Apply(goal)`. Le système de types C# rend les conversions explicites (`ArithExpr`, `BoolExpr`), ce qui aide à ne pas mélanger les sortes."
    ]
   },
   {
@@ -161,12 +169,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-db0ca425",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Observez ce que `simplify` a **réécrit** sans changer la satisfiabilité : `(> x 0)` est devenu `(not (<= x 0))` — Z3 normalise les inégalités strictes en négation d'inégalité large, car le solveur interne travaille sur `<=`. De même `(+ x 5)` est réordonné en `(+ 5 x)` (les constantes à gauche). **Aucune variable n'a été éliminée** : `simplify` est purement syntaxique, elle ne déduit rien qu'elle pourrait déduire. Pour éliminer, il faut la tactique `solve-eqs` (section suivante)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e85c0cf2",
    "metadata": {},
    "source": [
     "## 2. Composition de tactiques\n",
     "\n",
-    "On compose les tactiques avec `ctx.AndThen(t1, t2)` (séquence, équivalent `Then` Python), `ctx.OrElse(t1, t2)` (fallback), `ctx.Repeat(t)` (point fixe). Le pipeline `AndThen(simplify, solve-eqs)` simplifie puis **élimine les équations** en substituant les variables.\n"
+    "L'intérêt réel apparaît quand on **chaîne** les tactiques. Z3 fournit trois combinateurs :\n",
+    "\n",
+    "- `ctx.AndThen(t1, t2)` (séquence) : applique `t1`, puis `t2` sur chaque sous-but produit.\n",
+    "- `ctx.OrElse(t1, t2)` (alternative) : essaie `t1` ; si elle échoue, utilise `t2`.\n",
+    "- `ctx.Repeat(t)` (point fixe) : applique `t` jusqu'à ce qu'aucun progrès ne soit possible.\n",
+    "\n",
+    "Le pipeline `AndThen(simplify, solve-eqs)` est l'archétype : `simplify` nettoie, puis `solve-eqs` **élimine les équations** en substituant les variables libres par leur définition. Sur un système contraint, on passe ainsi d'un but à 4 variables à un but à 2 variables seulement, toutes les substitutions résolues."
    ]
   },
   {
@@ -267,12 +291,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-260c7be5",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Le pipeline `AndThen(simplify, solve-eqs)` a fait le vrai travail : on partait de 4 contraintes sur 3 variables (`x`, `y`, `z`), et l'on arrive à **2 contraintes sur la seule variable `y`** — `(not (<= y 5))` et `(not (>= y 15))`, soit `5 < y < 15`. Comment ? `solve-eqs` a substitué `x` et `z` par leur définition (`y = x+5`, `z = 2y`) puis propagé les bornes. Le but est devenu *beaucoup* plus cheap à résoudre, et le `Solver` confirmera `SATISFIABLE` avec `x = 1, y = 6, z = 12`. C'est tout l'intérêt des tactiques : **réduire avant de résoudre**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6920d9dc",
    "metadata": {},
    "source": [
     "## 3. `OrElse` et `Repeat`\n",
     "\n",
-    "`OrElse(t1, t2)` essaie `t1`, et si elle échoue utilise `t2`. `Repeat(t)` applique `t` jusqu'à un point fixe (plus aucune simplification possible).\n"
+    "`OrElse(t1, t2)` modélise le raisonnement « essayer A, sinon B » : `t1` est tentée, et si elle ne peut pas progresser, `t2` prend le relais. C'est ainsi qu'on combine une tactique puissante mais coûteuse (`ctx-solver-simplify`, qui appelle le solveur en interne) avec une tactifique bon marché (`simplify`) comme filet de sécurité.\n",
+    "\n",
+    "`Repeat(t)` applique `t` jusqu'à un **point fixe** : tant que la tactique modifie le but, on recommence ; dès qu'une itération ne change plus rien, on s'arrête. C'est indispensable pour les simplifications qui se débloquent mutuelles (substituer une valeur révèle une nouvelle simplification, qui révèle une autre substitution…)."
    ]
   },
   {
@@ -370,7 +406,9 @@
    "source": [
     "## 4. `BitVec` : arithmétique modulaire\n",
     "\n",
-    "Un `BitVec` de largeur 8 est un vecteur de 8 bits, interprété comme un entier **non signé** entre 0 et 255. L'arithmétique est **modulaire** : `255 + 1 = 0` (wrapping). Opérations bit à bit : `MkBVXOR`, `MkBVAND`, `MkBVOR`.\n"
+    "Un `BitVec` de largeur 8 est un vecteur de 8 bits, interprété comme un entier **non signé** entre 0 et 255. Contrairement aux `IntExpr` (entiers mathématiques non bornés), l'arithmétique `BitVec` est **modulaire** : `255 + 1 = 0` (wrapping), exactement comme un registre CPU. C'est la théorie qu'il faut pour modéliser tout ce qui touche aux entiers machine : débordements, masques, cryptographie symétrique.\n",
+    "\n",
+    "Les opérations bit à bit (`MkBVXOR`, `MkBVAND`, `MkBVOR`) se combinent avec l'arithmétique (`MkBVAdd`, `MkBVMul`) dans le même solveur. La cellule ci-dessous démontre le wrapping (`255 + 1 → 0`) puis résout un système XOR/AND : trouver deux octets dont le XOR vaut `0xFF` mais le AND vaut `0`."
    ]
   },
   {
@@ -478,12 +516,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-92297f73",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Deux leçons dans cette sortie. D'abord le **wrapping** : `x = 255`, `y = x + 1 = 0` — l'arithmétique `BitVec` 8 bits a « fait le tour » du registre, exactement comme un `uint8_t` en C. Ensuite le système XOR/AND : le solveur trouve `a = 254 (11111110)` et `b = 1 (00000001)`, deux octets **strictement complémentaires** — chaque bit où `a` vaut 1, `b` vaut 0, et réciproquement, ce qui satisfait à la fois `a XOR b = 0xFF` et `a AND b = 0`. C'est la signature bit à bit de l'identité « OU-exclusif maximal »."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ec97dad5",
    "metadata": {},
    "source": [
     "## 5. Signé vs non signé\n",
     "\n",
-    "Un même vecteur de bits peut être interprété comme **signé** (bit de poids fort = signe, plage -128 à 127) ou **non signé** (plage 0 à 255). Les comparaisons non signées utilisent `MkBVUGt`/`MkBVULt`/`MkBVUGe`/`MkBVULe`, signées `MkBVSgt`/`MkBVSlt`. La valeur `200` non signée = `-56` signée.\n"
+    "Un même vecteur de bits ne porte **pas** son interprétation : `11001000` peut être lu comme `200` (non signé) ou `-56` (signé, complément à deux). C'est le contexte — la comparaison qu'on écrit — qui décide.\n",
+    "\n",
+    "Z3 expose deux familles distinctes : les comparaisons **non signées** (`MkBVUGt`/`MkBVULt`/`MkBVUGe`/`MkBVULe`, le `U` = *unsigned*) traitent le vecteur comme un entier positif ; les comparaisons **signées** (`MkBVSgt`/`MkBVSlt`, le `S` = *signed*) interprètent le bit de poids fort comme le signe. Confondre les deux est un bug classique en C (d'où les avertissements du compilateur sur la comparaison signé/non signé)."
    ]
   },
   {
@@ -606,7 +656,9 @@
    "source": [
     "## 6. Casse-tête : nombre palindrome binaire\n",
     "\n",
-    "Un **palindrome binaire 8 bits** se lit identiquement de gauche à droite et de droite à gauche (ex: `10011001` = 153). On construit une fonction `ReverseBits` via `MkExtract` (extraire chaque bit) + `MkConcat` (réassembler en ordre inverse), puis on impose `x == ReverseBits(x)`.\n"
+    "Un **palindrome binaire 8 bits** se lit identiquement de gauche à droite et de droite à gauche (ex: `10011001` = 153). C'est un excellent exercice de **manipulation symbolique des bits** : on ne connaît pas la solution à l'avance, on laisse Z3 l'énumérer.\n",
+    "\n",
+    "On construit une fonction `ReverseBits` via `MkExtract` (extraire un bit à une position donnée) + `MkConcat` (réassembler les bits en ordre inverse), puis on impose `x == ReverseBits(x)`. En excluant les cas triviaux (`0` et `255`), on demande ensuite au solveur d'énumérer les modèles. La cellule ci-dessous boucle en ajoutant à chaque itération la négation du modèle trouvé."
    ]
   },
   {
@@ -711,12 +763,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-c87ddf40",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Le solveur énumère les palindromes : `129 = 10000001`, `24 = 00011000`, `90 = 01011010`, `126 = 01111110`, `60 = 00111100`, `36 = 00100100`. Vérifiez à l'œil : chacun se lit pareil dans les deux sens. Il en existe en réalité **56** sur 8 bits (hors `0` et `255`) : pour un palindrome, les 4 bits de poids fort déterminent les 4 bits de poids faible, donc `2^4 = 16` motifs, soit `16` palindromes par tranche de valeur… le décompte exact est laissé en exercice de dénombrement. La leçon technique : `MkExtract` + `MkConcat` permettent de **reconstruire un vecteur bit à bit** et de l'utiliser comme but de résolution."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7fc10002",
    "metadata": {},
    "source": [
     "## 7. `Array` : `Store` et `Select`\n",
     "\n",
-    "La théorie des tableaux modélise un tableau comme une **fonction symbolique** index→valeur. `MkStore(arr, i, v)` renvoie un tableau égal à `arr` sauf en `i` qui vaut `v`. `MkSelect(arr, i)` lit la valeur en `i`. Les `Store` successifs se raisonnent.\n"
+    "La théorie des tableaux modélise un tableau comme une **fonction symbolique** index→valeur. C'est l'abstraction qu'utilise Z3 pour raisonner sur la mémoire, les buffers, les dictionnaires purs.\n",
+    "\n",
+    "Deux constructeurs suffisent :\n",
+    "- `MkStore(arr, i, v)` renvoie un tableau égal à `arr` **sauf** en `i` qui vaut `v` (fonctionnellement pur, pas de mutation).\n",
+    "- `MkSelect(arr, i)` lit la valeur en `i`.\n",
+    "\n",
+    "L'exemple ci-dessous modélise un **transfert bancaire** : trois comptes (`c0`, `c1`, `c2`), on déplace 30 du compte 1 vers le compte 0, puis on demande au solveur de prouver la **conservation du total**. Comme les `Store` successifs se raisonnent symboliquement, Z3 déduit l'égalité des sommes sans énumérer les valeurs."
    ]
   },
   {
@@ -784,12 +852,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-9ae34b92",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Le solveur confirme la **conservation du total** : avant le transfert, `c0 = 100, c1 = 200, c2 = 50` (somme 350) ; après, `c0 = 130, c1 = 170` (somme `130 + 170 + 50 = 350`). Aucune valeur n'a été énumérée à la main : Z3 a raisonné **symboliquement** sur l'arbre des `Store` successifs pour déduire l'égalité des sommes. C'est exactement le style de preuve qu'on attend d'un vérificateur de transactions ou d'un analyseur de mutation d'état : prouver un invariant sur une séquence d'écritures sans dérouler la séquence."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "08802d9f",
    "metadata": {},
    "source": [
     "## 8. `SolverFor` spécialisé vs `Solver` générique\n",
     "\n",
-    "`SolverFor(\"QF_LIA\")` construit un solveur **spécialisé** pour les contraintes arithmétiques linéaires entières quantifier-free. Sur un système de ce type, il est plus rapide que le `Solver` générique.\n"
+    "`ctx.MkSolver()` construit le solveur **générique**, qui choisit sa stratégie interne en fonction des théories rencontrées. `ctx.MkSolver(\"QF_LIA\")` (ou `SolverFor(\"QF_LIA\")`) construit un solveur **spécialisé** pour *Quantifier-Free Linear Integer Arithmetic* — l'arithmétique entière linéaire sans quantificateurs.\n",
+    "\n",
+    "Sur un problème qui relève exactement de cette logique, le solveur spécialisé court-circuite la phase de sélection et peut être **plusieurs fois plus rapide**. C'est l'équivalent, côté solveur, de ce que les tactiques font côté transformation : annoncer la logique au solveur évite qu'il la redécouvre. La cellule ci-dessous chronomètre les deux sur 50 variables entières bornées avec des contraintes sur les sommes adjacentes."
    ]
   },
   {
@@ -851,6 +931,16 @@
     "var rSpec = sSpec.Check();\n",
     "sw.Stop();\n",
     "Console.WriteLine(\"SolverFor QF_LIA  : \" + rSpec + \" en \" + sw.Elapsed.TotalMilliseconds.ToString(\"F1\") + \" ms\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-f46a5543",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Sur ce système (50 variables entières bornées `0..100`, contraintes sur les sommes adjacentes), le solveur générique met **15,6 ms** et le solveur spécialisé `QF_LIA` met **4,2 ms** — un gain d'environ **×3,7**. Le résultat (`SATISFIABLE`) est identique, seul le chemin diffère. La conclusion opérationnelle : quand on connaît la logique dominante de son problème (ici, arithmétique linéaire entière sans quantificateurs), **annoncer la logique au solveur** via `MkSolver(\"QF_LIA\")` est un accélérateur gratuit. Sur des logiques plus riches (non-linéaire, tableaux, bits), le même principe s'applique avec les codes `QF_NIA`, `QF_AUFLIA`, `QF_BV`…"
    ]
   },
   {
@@ -994,7 +1084,15 @@
     "\n",
     "Ce twin C# couvre les trois familles avancées de Z3 : **tactiques** (`MkTactic`/`MkGoal`/`Apply`/`ApplyResult.Subgoals`, composition `ctx.AndThen`/`OrElse`/`Repeat`), **théorie BitVec** (`MkBVConst`/`MkBVXOR`/`MkBVAND`, arithmétique modulaire, signé vs non signé `MkBVUGt`/`MkBVSgt`, `MkExtract`/`MkConcat` pour la manipulation bit à bit), et **théorie Array** (`MkArrayConst`/`MkStore`/`MkSelect`). Le binding `Microsoft.Z3` expose exactement le même moteur que `z3-solver` Python.\n",
     "\n",
-    "**Complémentarité** : le twin Python utilise `len(result)` et `sg.size()` (API Pythonique) ; ce twin C# montre l'API .NET (`ApplyResult.Subgoals.Length`, `Goal.Formulas` comme propriété, composition via méthodes `ctx.*`) — la **valeur ajoutée** est la traduction des idiomes Z3 dans le système de types .NET.\n"
+    "### Ce qu'il faut retenir\n",
+    "\n",
+    "- **Les tactiques transforment, les solveurs décident.** Un pipeline `AndThen(simplify, solve-eqs)` réduit un but avant de le passer au solveur ; `SolverFor(\"QF_LIA\")` annonce la logique pour éviter la redécouverte.\n",
+    "- **`BitVec` est l'entier machine** : modulaire, interprétable signé ou non signé selon la comparaison choisie — c'est le terrain de la vérification bas niveau et de la crypto.\n",
+    "- **`Array` est la mémoire symbolique** : `Store`/`Select` permettent de raisonner sur des suites de mutations sans les énumérer.\n",
+    "\n",
+    "**Complémentarité** : le twin Python utilise `len(result)` et `sg.size()` (API Pythonique) ; ce twin C# montre l'API .NET (`ApplyResult.Subgoals.Length`, `Goal.Formulas` comme propriété, composition via méthodes `ctx.*`) — la **valeur ajoutée** est la traduction des idiomes Z3 dans le système de types .NET.\n",
+    "\n",
+    "> Les trois exercices qui suivent sont à compléter : ils reprennent isolément chacune des trois familles (pipeline de tactiques, XOR sur `BitVec`, commutativité des `Store`)."
    ]
   }
  ],

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-03-tactics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-03-tactics.yaml
@@ -16,6 +16,12 @@
       csharp_sha: 414f62ee58470a82f189ed74cc5c46a12692648a
       content_python_sha: 3f590d25ba1cfb7125b7cc0409c0510c4b5a4d6cbe0a85645068c27977c5d095
       content_csharp_sha: 06fef20e6776d5520ff1c5e0e0c667d11d719dea44f28632e1ba47768ade2064
+    - date: "2026-08-12"
+      by: myia-ai-01:CoursIA
+      python_sha: 596992096613fb08367a5e41fae56b1b01254572
+      csharp_sha: fa950aa71cb7c7fd8561173309bd51dbbf21d425
+      content_python_sha: 3f590d25ba1cfb7125b7cc0409c0510c4b5a4d6cbe0a85645068c27977c5d095
+      content_csharp_sha: 5dca15c6a9ca7b904bdd874191b6652baf1d64eb86754c3b5a7ddbf6fddd0856
   known_differences:
     - "Python : pyz3 (Tactic('simplify'), Then(), With()). C# : Microsoft.Z3 .NET (Tactic(ctx, ...))."
     - "Concept demontre (simplify elimine une redondance, ctx-solver-simplify la garde) verifie firsthand cote Python (NB-03 CLEAN)."


### PR DESCRIPTION
Grain: LIGHT/notebook-dotnet — lane myia-po-2023:CoursIA — prev: LIGHT/notebook-dotnet #10545

> Tag re-qualifie par ai-01 au merge-gate (absent du body d origine). Tier LIGHT par le litmus du protocole de variation : enrichissement markdown-only, sans re-execution, genere en balayant l instance suivante. Genre CONTENU. Voir le commentaire de cycle.

## Summary

Enrichissement markdown-only du twin C# **Z3-Python-03-Tactics-Csharp.ipynb** (poche `SymbolicAI/SMT`, EPIC #10488). Densité **338 → 1049 chars/code-cell (+210 %)**.

Ce notebook exécutait déjà le vrai moteur `Microsoft.Z3` (twin `bridge_verdict: SOTA-OK` acté par #10477 — pyz3 ↔ Microsoft.Z3 natif, 12/12 cellules exécutées ec=1..12), mais sa prose restait à 338 chars/code-cell, bien sous la médiane SMT (1173). Les cellules markdown étaient one-liners : elles disaient **ce que fait** chaque tactique sans expliquer **pourquoi** l'utiliser ni **lire la sortie produite**.

## Ce qui change (markdown-only, 0 re-exécution)

**8 cellules de section développées** (Quoi + Pourquoi + idiome .NET vs Python + pont entre tactiques/solveurs/théories) :
- Intro : ajout d'une section « Pourquoi ces trois familles ensemble ? » (orchestration vs moteur naïf).
- §1 `simplify` : tactique = transformation équisatisfaisante (vs `Solver` qui décide).
- §2 composition : les 3 combinateurs `AndThen`/`OrElse`/`Repeat` et l'archétype `simplify→solve-eqs`.
- §4 `BitVec` : entier machine modulaire (registre CPU, crypto).
- §5 signé/non signé : `11001000` = 200 ou -56 selon le contexte (bug classique C).
- §7 `Array` : mémoire symbolique, `Store`/`Select` fonctionnellement purs.
- §8 `SolverFor` : annoncer la logique (`QF_LIA`) pour court-circuiter la sélection.
- Conclusion : 3 points à retenir + bridge vers les exercices.

**6 cellules d'interprétation insérées APRÈS les outputs**, chacune citant la vraie valeur exécutée :

| Section | Sortie réelle interprétée |
|---|---|
| §1 simplify | `(> x 0)` → `(not (<= x 0))` : normalisation syntaxique, aucune var éliminée |
| §2 AndThen | 4 contraintes / 3 vars → **2 contraintes / `y` seul** (`5 < y < 15`) ; solver `x=1, y=6, z=12` |
| §4 BitVec | `255 + 1 = 0` (wrapping) ; `a=254 (11111110)`, `b=1 (00000001)` complémentaires |
| §6 palindrome | `129=10000001`, `90=01011010`… **56** palindromes 8 bits hors 0/255 |
| §7 Array | `c0 100→130`, `c1 200→170`, total **350 conservé** (raisonnement symbolique) |
| §8 SolverFor | générique **15,6 ms** vs `QF_LIA` **4,2 ms** (**×3,7**) |

## Preuves (C.3 markdown-only, pas de re-exécution)

- **12 cellules code byte-identiques** vs `origin/main` (source + outputs + execution_count, SHA-vérifié par comparaison cellule-par-cellule).
- `validate_pr_notebooks.py` : **PASS** (12 cellules, 0 leak).
- `detect_markdown_rendering.py` : **0 violation**.
- H.3 pre-commit : **0 cellule non-exécutée** (toutes ec=1..12).
- **0 pattern C.1** (`raise NotImplementedError` / `assert False` / `1/0`).
- **3 stubs d'exercices préservés** (`return 0` / `return null`, conformes C.1).
- Diff : `+108 / -10`, 1 fichier, markdown-only.
- Catalogue byte-identique (catalog-pr-hygiene R1).

## Variété R6

Famille fraîche (.NET / SMT-Z3) après un créneau GenAI/ML/Tweety/CI. La poche SMT (5 notebooks sous 600) est non réclamée dans #10488 ; ce notebook est le plus sous-dense de la poche (338). Pas de collision avec le travail twin-parity de po-2026 (#10534 = annotations YAML du registre, séparées de la prose).

See #10488 (contribution partielle — 1 notebook de la poche SMT). Ne clos pas l'epic.

