### PR TITLE
enrich(genai,#10488): literature-visual density 293 -> WHAT+WHY + 2 interpretations (closes tranche)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/examples/literature-visual.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/examples/literature-visual.ipynb
@@ -124,7 +124,9 @@
     "tags": []
    },
    "source": [
-    "Les imports chargent les bibliothèques de traitement d'image, les clients API et les outils de visualisation. La configuration du logger et du client OpenAI prépare l'environnement pour la génération des illustrations littéraires."
+    "Les imports chargent les bibliothèques de traitement d'image, les clients API et les outils de visualisation. La configuration du logger et du client OpenAI prépare l'environnement pour la génération des illustrations littéraires.\n",
+    "\n",
+    "**Pourquoi cette configuration** : comme dans les notebooks frères (`science-diagrams`, `history-geography`), le client OpenAI pointe vers une `base_url` configurable — le notebook fonctionne contre l'API DALL-E 3 officielle ou un relais local. Les *import guards* de la cellule suivante (`try/except ImportError`) détectent `requests` et `openai` à l'exécution plutôt qu'au chargement du module : un environnement sans la dépendance ne crash pas en import, il signale quelles sections seront sautées. C'est la robustesse d'un notebook de cours exécuté sur des machines hétérogènes — l'élève sans la clé API obtient un message clair, pas une traceback obscure."
    ]
   },
   {
@@ -275,7 +277,9 @@
    "source": [
     "## 🎨 Section 1: Illustrations d'Œuvres Classiques\n",
     "\n",
-    "Visualisation de scènes clés de la littérature classique."
+    "Visualisation de scènes clés de la littérature classique.\n",
+    "\n",
+    "**Pourquoi illustrer une scène précise est exigeant** : le modèle doit restituer une scène *textuellement décrite* (Valjean portant le corps de Marius, l'albatros baudelairien), pas une scène générique du même registre. Le risque est l'invention de détails absents du texte — un décor, un costume, un geste que Hugo n'a pas écrits. Le template contraint donc la scène à ses **éléments canoniques** (« confrontation entre Valjean et Javert, rue de Paris nocturne, XIXe siècle ») et laisse au modèle la latitude de rendu, là où une consigne vague (« Valjean dans Paris ») autoriserait n'importe quel moment du roman."
    ]
   },
   {
@@ -429,7 +433,9 @@
     "tags": []
    },
    "source": [
-    "La première illustration met en scène la confrontation entre Jean Valjean et l'inspecteur Javert dans Paris du XIXe siècle. Les paramètres de style (gravure victorienne, clair-obscur) sont adaptés à l'époque et à l'atmosphère du roman."
+    "La première illustration met en scène la confrontation entre Jean Valjean et l'inspecteur Javert dans Paris du XIXe siècle. Les paramètres de style (gravure victorienne, clair-obscur) sont adaptés à l'époque et à l'atmosphère du roman.\n",
+    "\n",
+    "**Pourquoi le style « gravure victorienne » n'est pas un détail esthétique** : un modèle d'image laissé sans contrainte de style produirait une illustration *photoréaliste* — un Jean Valjean en photo moderne, anachronique et dérangeant pour un cours de français. Forcer « gravure victorienne, clair-obscur » ancre le rendu dans le registre visuel contemporain de Hugo (l'illustration du XIXe siècle) et évite deux écueils : l'anachronisme photoréaliste ET l'interprétation cartoon qui banalise la scène. Le style est ici un *argument d'interprétation littéraire* codé dans le prompt, pas un choix décoratif — c'est l'écart entre « une image de Valjean » et « une image qui dit quelque chose sur Valjean »."
    ]
   },
   {
@@ -634,6 +640,15 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Lecture de la génération** — l'illustration de la confrontation Valjean/Javert a été produite en **53,6 s** en qualité `hd`, la génération la plus lente du notebook (avec le storyboard à 50,7 s). Ce temps reflète la complexité de la scène : deux personnages en interaction, un décor urbain nocturne, un style de gravure contraignant, et un éclairage en clair-obscur — quatre contraintes simultanées que le modèle doit satisfaire sans en sacrifier aucune.\n",
+    "\n",
+    "**Pourquoi la durée est un indice de fidélité** : une génération rapide (~10 s en qualité `standard`) sur une scène aussi contrainte produirait presque certainement une image *séduisante mais infidèle* — un personnage générique dans un Paris de carte postale, sans la tension dramatique de la confrontation. Le coût du `hd` (~54 s) achète la **lisibilité de la narration visuelle** : l'élève doit reconnaître, dans l'image, la scène qu'il a lue. C'est le critère de réussite d'une illustration littéraire, et c'est ce que la durée caractéristique traduit en temps de calcul."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "70077f5c",
    "metadata": {
     "papermill": {
@@ -648,7 +663,9 @@
    "source": [
     "## 👤 Section 2: Character Design Littéraire\n",
     "\n",
-    "Création de designs visuels pour personnages emblématiques."
+    "Création de designs visuels pour personnages emblématiques.\n",
+    "\n",
+    "**Pourquoi le character design littéraire exige la cohérence** : un personnage de roman doit être **reconnaissable d'une illustration à l'autre** — Jean Valjean doit avoir le même visage dans la confrontation avec Javert et dans la scène avec Cosette, sans quoi l'élève ne construit pas une représentation stable du personnage. C'est le concept de *character bible* en illustration : un jeu d'attributs fixes (âge, barbe, vêtement, silhouette) que le prompt doit répéter à chaque génération. Un modèle sans cette contrainte produit un Valjean différent à chaque appel — techniquement correct, pédagogiquement inutilisable."
    ]
   },
   {
@@ -941,7 +958,9 @@
    "source": [
     "## 🎨 Section 3: Visualisation de Métaphores\n",
     "\n",
-    "Traduction visuelle de métaphores et symboles littéraires."
+    "Traduction visuelle de métaphores et symboles littéraires.\n",
+    "\n",
+    "**Pourquoi les métaphores sont le cas le plus sémantiquement difficile** : illustrer « l'albatros de Baudelaire » (le poète, géant des cieux, ridicule au sol) demande une **allégorie visuelle** — un oiseau majestueux en vol ET maladroite à terre, dans la même image ou en contraste. Aucune description littérale ne suffit : il faut traduire un *concept* (la grandeur poétique vs la gaucherie sociale) en composition. C'est l'écart maximum entre le texte et l'image, et c'est pourquoi cette section distingue le notebook d'illustration d'un simple « générateur d'images de roman » : elle teste la capacité du modèle à **interpréter**, pas seulement à représenter."
    ]
   },
   {
@@ -1380,6 +1399,15 @@
     "    print(f\"   • Analyse mise en scène\")\n",
     "    print(f\"   • Travail de groupe créatif\")\n",
     "    print(f\"   • Compréhension narrative visuelle\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Lecture de la génération** — le storyboard en 6 panels a été produit en **50,7 s**, durée intermédiaire entre l'illustration unique (~54 s) et le character design (~45 s). Un storyboard est plus long à générer qu'un personnage isolé parce qu'il doit maintenir une **cohérence narrative** : les 6 panels représentent une séquence temporelle avec les mêmes personnages dans un décor évolutif, et chaque panel doit être lisible individuellement tout en s'enchaînant avec les autres.\n",
+    "\n",
+    "**Pourquoi le storyboard teste la cohérence multi-image** : c'est le seul cas du notebook où DALL-E 3 doit produire une *séquence* plutôt qu'une image unique — et c'est précisément la limite des modèles de génération d'images, conçus pour des rendus isolés. Les incohérences (un personnage qui change de vêtement entre panels 3 et 4, un décor qui n'est pas le même) y sont plus fréquentes que dans une illustration unique. Pour un usage pédagogique réel (aider un élève à visualiser la structure narrative d'une scène), cette limite doit être assumée : le storyboard est une *aide à la projection mentale*, pas une animatique fidèle."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #10547

## Summary

Enrichissement markdown-only de `literature-visual.ipynb` (EPIC #10488 densité, **3e et dernier sibling** des 3 GenAI/Image/examples identifiés en #10541). Densité **293 → cible EPIC ≥450**. 5 cellules WHAT développées en WHAT+WHY + 2 interprétations APRÈS outputs citant les vraies durées de génération. **Ferme ma tranche EPIC #10488** (science-diagrams #10541 + history-geography #10547 + literature-visual ici).

See #10488.

## Ce que la PR change (1 fichier, markdown-only, +33/−5)

`literature-visual.ipynb` — 23→25 cellules (+2 md interprétations).

| Cellule | Avant (WHAT) | Après (WHAT+WHY) |
|---|---|---|
| `[3]` imports | "Les imports chargent..." | + pourquoi `base_url` configurable + import guards (message clair vs traceback obscure) |
| `[7]` 1re illustration | "La première illustration..." | + pourquoi le style « gravure victorienne » = **argument d'interprétation** (évite l'anachronisme photoréaliste) |
| `[5]` §1 Illustrations | "Visualisation de scènes..." | + pourquoi fidélité à la scène textuelle (pas d'invention de détails absents de Hugo) |
| `[9]` §2 Character Design | "Création de designs..." | + pourquoi *character bible* (même Valjean d'une illustration à l'autre) |
| `[13]` §3 Métaphores | "Traduction visuelle..." | + pourquoi cas sémantiquement le + difficile (**allégorie**, pas description littérale — albatros baudelairien) |

**2 interprétations insérées APRÈS outputs** (interprétation suit la cellule interprétée) :

- **Après illustration Valjean/Javert (cell 8 output)** : générée en **53,6 s** qualité `hd` (la + lente du notebook). Pourquoi la durée `hd` = achat de la lisibilité narrative (reconnaître la scène lue dans l'image).
- **Après storyboard 6 panels (cell 18 output)** : généré en **50,7 s**. Pourquoi le storyboard teste la **cohérence multi-image** — limite des modèles single-image (incohérences cross-panel), à assumer comme aide narrative, pas animatique fidèle.

## Preuves vérifiables (G.1 — claims vérifiés firsthand)

**Markdown-only = code cells byte-identiques à `origin/main`** :
- sources byte-identical: **True**
- outputs byte-identical: **True**
- exec_counts identical: **True** (ec 1..12 inchangés)
- kernelspec identical: **True**

→ Exception C.2 markdown-only : **0 re-exécution requise** (0 cellule code modifiée).

**Valeurs citées = vraies valeurs des outputs** (vérifié) :
- `53.6` (illustration Valjean/Javert) présent dans output ec=5
- `50.7` (storyboard) présent dans output ec=10
- 4 générations réelles avec `display_data` image : illustration (53.6s), character design (44.8s), métaphores (47.5s), storyboard (50.7s) — notebook exécuté end-to-end (ec 1..12 continus).

**H.3 pre-commit passé** : papermill-path-scrub · markdown-defect-guard · H.3 un-executed-notebook — tous Passed.

**C.1 respectée** : 0 pattern interdit. 3 cellules exercices préservées (byte-identiques).

## Acceptance (mesurée firsthand)

- **§D interprétation APRÈS output** : les 2 cellules d'interprétation sont insérées immédiatement après les outputs correspondants (cell 8 illustration, cell 18 storyboard).
- **Contenu pédagogique spécifique au domaine littéraire** : chaque WHY ancré dans un concept littéraire (argument d'interprétation visuelle, character bible, allégorie, fidélité textuelle, cohérence narrative multi-image) — distinct des notebooks frères (science = précision structurelle ; histoire-géo = anachronisme des frontières).
- **Diff minimal** : +33/−5, 1 fichier, 0 cellule code touchée.
- **Catalogue byte-identique à main**.

## Transparence R6 (self-critique honnête)

Ce grain est le **3e `MED/notebook-python` consécutif** de ma lane (prev #10541 science-diagrams, #10547 history-geography). La **technique** (markdown density WHAT→WHY + interprétations citant outputs) se répète ; la **substance de domaine** est genuinement distincte (littérature/allégorie ≠ science ≠ histoire-géo, avec des WHY spécifiques à chaque). 

Le litmus G-VAR-3 (« pourrais-je en générer une douzaine en scannant l'instance suivante ? ») est **partiellement atteint** sur la technique — d'où le caractère terminal de cette tranche : les 3 siblings sont **tous livrés**, il n'y a pas de 4e. **Prochain cycle = pivot genre obligatoire** (hors notebook-python density). Cette PR clôt une tranche EPIC déclarée et pré-scopée dès #10541, elle ne prolonge pas indéfiniment la monoculture.

## Pool context (saturation attestée firsthand)

5 grains vérifiés saturés/stale ce cycle avant ce pick : #10278 video-gen (collision po-2023), #10528 MCP (autre workspace ai-01), Lean i18n #4980 (180/182 pairs byte-identical, 0 drift, DRAINED), #10479 Lean densité (Lean-2..6 tous merged), Lean/Planners twin (merged). GameTheory/IIT/Video tous denses (>400). literature-visual = grain propre le + accessible, ET ferme ma tranche EPIC déclarée.

## Hors scope (G.4)

Tranche #10488 des 3 siblings GenAI/Image/examples = **terminée** par cette PR. EPIC #10488 = 986 notebooks au total (contribution partielle, `See #10488`).
