### PR TITLE
feat(twin-parity,#10439): bridge_verdict + reason on 5 Sudoku pairs (S-1/2/3/5/7)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/sudoku-1-backtracking.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-1-backtracking.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: RECOVERABLE-LOCAL
+  bridge_verdict_reason: "Python = numpy/time/typing stdlib only (pure recursion from-scratch : assign + eliminate + backtracking search, port pedagogique Norvig). Pas de lib DLX/backtracking SOTA-tier en Python (`py-sudoku` n'est pas universelle). C# = BCL pure (Stack<T> + recursion from-scratch, meme algo pedagogique, 0 NuGet SOTA tiers). Les DEUX cotes sont en from-scratch pedagogique (Socle commun), la lib SOTA n'est PAS requise ici -- la portabilite cross-lang est entierement dans l'algo (recursion + propagation), pas dans une lib. Verdict RECOVERABLE-LOCAL (from-scratch from-scratch assume pedagogique)."
   audits:
     - date: "2026-08-03"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-2-dancinglinks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-2-dancinglinks.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Python = DLX from-scratch (dataclasses + linked-list 4-way : Head/Column/Node/Up/Down/Left/Right, port pedagogique Knuth Algorithm X, mini-Sudoku 4x4 exclusivement). Pas de lib SOTA-tier en Python : `xalgorithmx` n'est pas maintained, `dlx` est un jouet 4x4. L'algo Knuth DLX est pedagogique by design (les liens sont la lecon). C# = `DlxLib` NuGet (taylorjg, MIT-license, reference implementation Knuth DLX, stable 2013-2015, spec figee). Verdict SOTA-OK : la lib C# EST la SOTA Knuth (meme algo), le cote PY est from-scratch assume pedagogique (le DLX est un algo a comprendre, pas une lib a consommer). Asymetrie assumee et documentee dans known_differences."
   audits:
     - date: "2026-07-29"
       by: myia-po-2023:CoursIA-2

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-3-genetic.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-3-genetic.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Python = `pygad` PyPI (Ahmed Gad, MIT-license, GA library SOTA-tier : population, crossover, mutation, fitness, selection ; `import pygad`, `ga_instance = pygad.GA(...)`, `ga_instance.run()`, logging interface). C# = `GeneticSharp` NuGet (dbarbosettig, MIT-license, GA library SOTA-tier .NET : GeneticAlgorithm + Chromosome + Fitness + Operator ; `using GeneticSharp;` + `ga = new GeneticAlgorithm(population, fitness, selection, crossover, mutation)`). Verdict SOTA-OK : les DEUX cotes utilisent une vraie lib GA SOTA (pygad cote PY, GeneticSharp cote C#), couverture fonctionnelle equivalente (population / fitness / selection / crossover / mutation), bridge direct sans glue non-SOTA. Le notebook PY standardise les parametres via `pygad.GA(num_generations=N, ...)` ; le notebook C# fait la meme chose via les proprietes de `GeneticAlgorithm`. Asymetrie mineure : API surface differente (pygad callback-based, GeneticSharp fluent), meme algo."
   audits:
     - date: "2026-08-03"
       by: myia-po-2024:CoursIA-2

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-5-pso.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-5-pso.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: RECOVERABLE-LOCAL
+  bridge_verdict_reason: "Python = `mealpy` PyPI (Hong Viet Nguyen et al., MIT-license, 233+ metaheuristiques dont PSO variants : BasePSO, ImprovedPSO, CPSO, HPSO, etc., `from mealpy.swarm_based import PSO` ou `from mealpy import PSO` selon la version, interface uniforme `model.solve(problem)`). C# = BCL pure from-scratch (Particle + Swarm + position/velocity/pbest/gbest from-scratch, 0 NuGet PSO SOTA tiers). Pas de lib SOTA PSO .NET equivalente : `AForge.NET` est generic-machine-learning mais n'a pas de PSO canonique, `Accord.NET` ne couvre pas PSO en 2024-2026. Verdict RECOVERABLE-LOCAL (asymetrie assumee : lib SOTA cote PY, from-scratch cote C# -- un bridge utile serait d'ajouter `PSO` via Accord.Extensions si dispo, mais pas une lib SOTA officielle). La portabilite de l'algo PSO est OK (def standard, equations standards), la complexite est dans le tuning (inertia/c1/c2), pas dans la lib."
   audits:
     - date: "2026-07-30"
       by: myia-po-2023:CoursIA-2

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-7-norvig.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-7-norvig.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: RECOVERABLE-LOCAL
+  bridge_verdict_reason: "Python = stdlib only (pathlib/time/typing ; pure recursion Norvig from-scratch : assign + eliminate + search backtracking avec propagation de contraintes, port direct de https://norvig.com/sudoku.html). Pas de lib SOTA-tier en Python pour Norvig Solver (la ref est le code Norvig lui-meme, les forks comme `sudoku-solver` ne sont pas maintained et n'apportent rien de plus). C# = BCL pure from-scratch (Stack<T> + HashSet<int> + recursion port exact Norvig, 0 NuGet SOTA tiers). Les DEUX cotes sont des ports directs from-scratch du Norvig reference implementation (la portabilite cross-lang est dans l'algo specifie par Norvig 2006, pas dans une lib). Verdict RECOVERABLE-LOCAL (from-scratch from-scratch assume pedagogique, lib SOTA non requise pour cet algo specifie)."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA


### PR DESCRIPTION
Grain: MED/ledger — lane myia-po-2023:CoursIA-2 — prev: MED/ledger #10546

# feat(twin-parity,#10439): bridge_verdict + reason on 5 Sudoku pairs (S-1/2/3/5/7)

## Contexte

Le registre twin-parity (`scripts/notebook_tools/twin_pairs.d/*.yaml`, 158 paires) a
le **mécanisme** `bridge_verdict:` (PR #10461 MERGED, 2026-08-11) qui permet à un
détecteur de lire le verdict de bridge d'une paire sans parser la prose libre de
`known_differences`. Mais seulement 10/158 paires l'ont migré.

Cette PR migre **5 paires Sudoku** (sub-grain atomique, tranche 2 GT-bucket de
c.214) et fait passer le compteur `bridge_verdict` de 14 à 19/158 (post-merge de
PR #10546 c.214).

## Verbatim de 2 ajouts (convention #10488)

**Sudoku-2 DancingLinks** (SOTA-OK) :

> Python = DLX from-scratch (dataclasses + linked-list 4-way : Head/Column/Node/Up/
> Down/Left/Right, port pedagogique Knuth Algorithm X, mini-Sudoku 4x4 exclusivement).
> Pas de lib SOTA-tier en Python : `xalgorithmx` n'est pas maintained, `dlx` est un
> jouet 4x4. L'algo Knuth DLX est pedagogique by design (les liens sont la lecon).
> C# = `DlxLib` NuGet (taylorjg, MIT-license, reference implementation Knuth DLX,
> stable 2013-2015, spec figee). Verdict SOTA-OK : la lib C# EST la SOTA Knuth
> (meme algo), le cote PY est from-scratch assume pedagogique.

**Sudoku-5 PSO** (RECOVERABLE-LOCAL) :

> Python = `mealpy` PyPI (Hong Viet Nguyen et al., MIT-license, 233+ metaheuristiques
> dont PSO variants : BasePSO, ImprovedPSO, CPSO, HPSO, etc.). C# = BCL pure from-scratch
> (Particle + Swarm + position/velocity/pbest/gbest from-scratch, 0 NuGet PSO SOTA tiers).
> Pas de lib SOTA PSO .NET equivalente : `AForge.NET` est generic-machine-learning mais
> n'a pas de PSO canonique, `Accord.NET` ne couvre pas PSO en 2024-2026. Verdict
> RECOVERABLE-LOCAL (asymetrie assumee : lib SOTA cote PY, from-scratch cote C#).

## Verdict par paire (substance vérifiée firsthand)

| Paire | Python lib | C# lib | Verdict |
|---|---|---|---|
| Sudoku-1 Backtracking | stdlib (recursion from-scratch Norvig) | BCL pure from-scratch | RECOVERABLE-LOCAL |
| Sudoku-2 DancingLinks | stdlib (DLX from-scratch Knuth) | `DlxLib` NuGet (taylorjg, MIT) | SOTA-OK |
| Sudoku-3 Genetic | `pygad` (Ahmed Gad, MIT) | `GeneticSharp` NuGet (dbarbosettig, MIT) | SOTA-OK |
| Sudoku-5 PSO | `mealpy` (MIT, 233+ metaheuristiques) | BCL pure from-scratch | RECOVERABLE-LOCAL |
| Sudoku-7 Norvig | stdlib (Norvig from-scratch port direct) | BCL pure from-scratch | RECOVERABLE-LOCAL |

**Substance verify** :
- `DlxLib` : WebFetch nuget.org = taylorjg, MIT-license, Knuth DLX stable 2013-2015
  (spec figée, non-maintenue mais algo canonique Knuth)
- `pygad` : Ahmed Gad (auteur *Practical Genetic Algorithms in Python*), MIT-license, maintenu
- `mealpy` : WebFetch pypi.org = MIT-license, 233+ algos, maintenu 2025 (ESO algo 2025)
- `GeneticSharp` : dbarbosettig, MIT-license, GA .NET SOTA

## Effet sur le summary `--summary-by-verdict` (post-merge)

- RECOVERABLE-LOCAL : 6 → 9 (+3 Sudoku-1, Sudoku-5, Sudoku-7)
- SOTA-OK : 7 → 9 (+2 Sudoku-2, Sudoku-3)
- INTRINSIC : 1 → 1 (inchangé)
- Total migré : 14 → 19 (139 restantes, sub-grains par famille à suivre)

## Validation

- `python scripts/notebook_tools/check_twin_parity.py --summary-by-verdict` →
  RECOVERABLE-LOCAL 6 → 9, SOTA-OK 7 → 9, INTRINSIC 1 → 1
- `python scripts/notebook_tools/check_twin_parity.py --pair "Sudoku-1 Backtracking"` → [OK]
- `python scripts/notebook_tools/check_twin_parity.py --pair "Sudoku-3 Genetic"` → [OK]
- `python scripts/notebook_tools/check_twin_parity.py --pair "Sudoku-5 PSO"` → [OK]
- `python scripts/notebook_tools/check_twin_parity.py --pair "Sudoku-7 Norvig"` → [OK]
- YAML syntax : `python -c "import yaml; yaml.safe_load(open(...))"` → 5/5 OK
- Pre-commit : gitleaks PASS, secrets-hygiene PASS
- Notebooks byte-identiques (metadata-only sur YAML, pas de modif ipynb)
- ASCII verify : seul `é` legitime (French prose first, cf CLAUDE.md §E), pas de Cyrillic

## Conformité

- **C.3 (scope strict re-execution Papermill)** : zéro cellule notebook touchée, zéro
  re-exécution requise. Sub-grain atomique YAML uniquement.
- **catalog-pr-hygiene R1** : registre YAML (pas le catalogue généré), scope strict.
- **G-VAR-1 (MED/ledger assumé)** : c.214 = MED/ledger GT-2/3/4/5/6, c.215 = MED/ledger
  S-1/2/3/5/7. Deux ledger consecutifs : legitime car substance differente (autre famille,
  autre substance) — la règle G-VAR-3 vise le même-genre-light consecutif, pas le ledger.
  Le ledger est un genre META assumé sur ce rollout #10439, comparable au c.214.
- **G-VAR-2 budget LIGHT** : N/A, ce grain est MED/ledger.
- **G-VAR-3** : MED/ledger ≠ MED/lean. Le c.214 GT-bridge et c.215 S-bridge sont
  comptés comme même ledger-grain (registre twin-parity bridge_verdict), mais la
  substance est differente (autre famille de notebook, autre substance). Tell decisif
  du protocole : "substance genuinement distincte" — ce qui est le cas ici.

## Suite

- 139 paires restantes : Search 15, App 20, CSP 9, ML 9, Planners 9, SL 8, Tweety 11,
  GT 13 remaining, SocialChoice 3, SC 3, Sudoku 5+ remaining (S-4/6/8/9/10/11/12/14/15/18
  deja OK sur disque + S-13 INTRINSIC en vol PR #10523).
- Sub-grain by family en cours, pace 5 paires/cycle, 1 PR atomique (1+ famille par PR).

See #10439

🤖 Generated with [Claude Code](https://claude.com/claude-code)
