### PR TITLE
feat(twin,#10382): annotate ML.NET/Python bridge_verdict (8 pairs SOTA-OK)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/ml-1-introduction.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-1-introduction.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib #10382 (moteurs distincts, chacun prod) : C# = Microsoft.ML (NuGet officiel Microsoft.ML, native .NET : Microsoft.ML.Transforms/Regression/Clustering/TimeSeries) et Python = scikit-learn (pip sklearn, native Python) -- chaque cote atteint le moteur SOTA ML de son ecosysteme, ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML refs + execution_count, Python sklearn imports."
   audits:
     - date: "2026-07-31"
       by: myia-po-2024:CoursIA-2

--- a/scripts/notebook_tools/twin_pairs.d/ml-2-data-features.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-2-data-features.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib #10382 (moteurs distincts, chacun prod) : C# = Microsoft.ML (NuGet officiel Microsoft.ML, native .NET : Microsoft.ML.Transforms/Regression/Clustering/TimeSeries) et Python = scikit-learn (pip sklearn, native Python) -- chaque cote atteint le moteur SOTA ML de son ecosysteme, ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML refs + execution_count, Python sklearn imports."
   audits:
     - date: "2026-08-02"
       by: myia-po-2024:CoursIA-2

--- a/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib #10382 (moteurs distincts, chacun prod) : C# = Microsoft.ML (NuGet officiel Microsoft.ML, native .NET : Microsoft.ML.Transforms/Regression/Clustering/TimeSeries) et Python = scikit-learn (pip sklearn, native Python) -- chaque cote atteint le moteur SOTA ML de son ecosysteme, ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML refs + execution_count, Python sklearn imports."
   audits:
     - date: "2026-07-31"
       by: myia-po-2024:CoursIA-2

--- a/scripts/notebook_tools/twin_pairs.d/ml-4-evaluation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-4-evaluation.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
   parity_level: surface
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib #10382 (moteurs distincts, chacun prod) : C# = Microsoft.ML (NuGet officiel Microsoft.ML, native .NET : Microsoft.ML.Transforms/Regression/Clustering/TimeSeries) et Python = scikit-learn (pip sklearn, native Python) -- chaque cote atteint le moteur SOTA ML de son ecosysteme, ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML refs + execution_count, Python sklearn imports."
   audits:
     - date: "2026-08-02"
       by: myia-po-2024:CoursIA-2

--- a/scripts/notebook_tools/twin_pairs.d/ml-5-timeseries.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-5-timeseries.yaml
@@ -3,6 +3,9 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
   parity_level: surface
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib #10382 (moteurs distincts, algorithmes differents) : C# = Microsoft.ML.Transforms.TimeSeries ForecastBySsa (Singular Spectrum Analysis, ML.NET-native) et Python = statsmodels (STL decomposition + SARIMAX, native Python) -- familles algorithmiques differentes (SSA vs SARIMAX) mais CHAQUE COTE atteint un moteur SOTA de forecast saisonnier de son ecosysteme. Aucun pont intermediaire, aucune reimplementation from-scratch. Verifie firsthand C# + exec, Python statsmodels imports."
+
   audits:
     - date: "2026-08-04"
       by: myia-po-2024:CoursIA-2

--- a/scripts/notebook_tools/twin_pairs.d/ml-7-recommendation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-7-recommendation.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib #10382 (moteurs distincts, chacun prod) : C# = Microsoft.ML (NuGet officiel Microsoft.ML, native .NET : Microsoft.ML.Transforms/Regression/Clustering/TimeSeries) et Python = scikit-learn (pip sklearn, native Python) -- chaque cote atteint le moteur SOTA ML de son ecosysteme, ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML refs + execution_count, Python sklearn imports."
   audits:
     - date: "2026-08-01"
       by: myia-po-2024:CoursIA-2

--- a/scripts/notebook_tools/twin_pairs.d/ml-8-clustering.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-8-clustering.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib #10382 (moteurs distincts, chacun prod) : C# = Microsoft.ML (NuGet officiel Microsoft.ML, native .NET : Microsoft.ML.Transforms/Regression/Clustering/TimeSeries) et Python = scikit-learn (pip sklearn, native Python) -- chaque cote atteint le moteur SOTA ML de son ecosysteme, ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML refs + execution_count, Python sklearn imports."
   audits:
     - date: "2026-07-31"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/ml-9-anomaly-detection.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-9-anomaly-detection.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Modele nominal lib-vs-lib #10382 (moteurs distincts, chacun prod) : C# = Microsoft.ML (NuGet officiel Microsoft.ML, native .NET : Microsoft.ML.Transforms/Regression/Clustering/TimeSeries) et Python = scikit-learn (pip sklearn, native Python) -- chaque cote atteint le moteur SOTA ML de son ecosysteme, ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML refs + execution_count, Python sklearn imports."
   audits:
     - date: "2026-08-04"
       by: myia-po-2024:CoursIA-2


### PR DESCRIPTION
Quoi: Annoter les 8 paires ML.NET/Python confirmées native-both firsthand avec `bridge_verdict: SOTA-OK`. Famille = modele nominal lib-vs-lib #10382 (table owner : « ML | scikit-learn | ML.NET | moteurs distincts »). C# = Microsoft.ML (native .NET), Python = scikit-learn (native Python) -- chaque cote atteint le moteur SOTA ML de son ecosysteme.

Preuve:
- Firsthand 8 notebooks C# : `Microsoft.ML` refs (4-21 par notebook), `execution_count != null` (tous executes).
- Firsthand 8 notebooks Python : `sklearn` imports (ml-5 = statsmodels STL/SARIMAX, nuance affinée).
- Ni pont intermediaire ni reimplementation = aucune asymetrie de machinerie.
- `check_twin_parity.py --check` = **157/157 OK, DRIFT=0, MISSING=0**.
- `check_twin_parity.py --summary-by-verdict` (cette branche) = **SOTA-OK 5 -> 13**.
- ml-6-onnx EXCLU (ONNX = format d'echange, pas lib-vs-lib engine, #4956 CLOSED -- les 2 cotes chargent le meme .onnx).
- ml-5-timeseries : reason affinée (C# SSA vs Python statsmodels SARIMAX = familles algorithmiques differentes, mais chaque cote SOTA).

Perimetre: 8 fichiers yaml (+17 lignes), annotation registre. 0 notebook, 0 re-exec. Atomique (1 sujet = ML.NET family). Complementaire de #10534/#10536/#10539 (Z3/SW/Probas).

Grain: MED/twin -- lane myia-po-2026:CoursIA

See #10382