### PR TITLE
feat(notebook,#10500d,#10473): AgentSafetyAnalyzer pragma-suppression registry

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/analyzers/AgentSafetyAnalyzer.Tests/AgentSafetyAnalyzerTests.cs
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/analyzers/AgentSafetyAnalyzer.Tests/AgentSafetyAnalyzerTests.cs
@@ -126,6 +126,100 @@ class C { void M(string userInput) { var q = ""SELECT * FROM users WHERE name = 
         Assert.DoesNotContain("\" + userInput", newText.ToString());
     }
 
+    // -------- AGSEC pragma suppression (sub-grain #10500d) --------
+
+    [Fact]
+    public async Task AGSEC001_NoDiagnostic_OnPragmaDisable_ForSameRule()
+    {
+        // `#pragma warning disable AGSEC001` immediately above the call silences
+        // the rule for that one site (per-rule contract).
+        const string source = @"
+using System.Diagnostics;
+class C {
+    void M(string userInput) {
+#pragma warning disable AGSEC001
+        Process.Start(userInput);
+    }
+}";
+        var diags = await GetDiagnosticsAsync(source);
+        Assert.DoesNotContain(diags, d => d.Id == AgentSafetyAnalyzer.AGSEC001);
+    }
+
+    [Fact]
+    public async Task AGSEC001_StillDiagnostic_OnPragmaDisable_ForOtherRule()
+    {
+        // Disabling AGSEC003 must NOT silence AGSEC001 — per-rule suppression is
+        // the documented contract. A naive "any pragma ⇒ all off" implementation
+        // would incorrectly suppress this one.
+        const string source = @"
+using System.Diagnostics;
+class C {
+    void M(string userInput) {
+#pragma warning disable AGSEC003
+        Process.Start(userInput);
+    }
+}";
+        var diags = await GetDiagnosticsAsync(source);
+        Assert.Contains(diags, d => d.Id == AgentSafetyAnalyzer.AGSEC001);
+    }
+
+    [Fact]
+    public async Task AGSEC001_NoDiagnostic_OnBarePragmaDisable()
+    {
+        // A bare `#pragma warning disable` (no rule ids) suppresses every AGSEC*
+        // rule at the site — same semantics as the C# compiler for CS-warnings.
+        const string source = @"
+using System.Diagnostics;
+class C {
+    void M(string userInput) {
+#pragma warning disable
+        Process.Start(userInput);
+    }
+}";
+        var diags = await GetDiagnosticsAsync(source);
+        Assert.DoesNotContain(diags, d => d.Id == AgentSafetyAnalyzer.AGSEC001);
+    }
+
+    [Fact]
+    public async Task AGSEC001_Diagnostic_OnPragmaRestoreAfterDisable()
+    {
+        // A `#pragma warning restore AGSEC001` between two calls unsilences the
+        // second call. This is the documented pragma contract and matches the
+        // C# compiler's behavior for its own diagnostics.
+        const string source = @"
+using System.Diagnostics;
+class C {
+    void M(string userInput, string anotherInput) {
+#pragma warning disable AGSEC001
+        Process.Start(userInput);
+#pragma warning restore AGSEC001
+        Process.Start(anotherInput);
+    }
+}";
+        var diags = await GetDiagnosticsAsync(source);
+        // Exactly one AGSEC001 — the second (un-suppressed) call.
+        var d001 = diags.Where(x => x.Id == AgentSafetyAnalyzer.AGSEC001).ToList();
+        Assert.Single(d001);
+        Assert.Contains("anotherInput", d001[0].GetMessage());
+    }
+
+    [Fact]
+    public async Task AGSEC002_NoDiagnostic_OnPragmaDisable_ForSqlConcat()
+    {
+        // AGSEC002 fires on a `BinaryExpressionSyntax` (AddExpression), not on an
+        // invocation. Suppression should still work — same trivia-walking logic,
+        // same per-rule contract.
+        const string source = @"
+class C {
+    void M(string userInput) {
+#pragma warning disable AGSEC002
+        var q = ""SELECT * FROM users WHERE name = '"" + userInput;
+    }
+}";
+        var diags = await GetDiagnosticsAsync(source);
+        Assert.DoesNotContain(diags, d => d.Id == AgentSafetyAnalyzer.AGSEC002);
+    }
+
     // -------- Helpers --------
 
     private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/analyzers/AgentSafetyAnalyzer/AgentSafetyAnalyzer.cs
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/analyzers/AgentSafetyAnalyzer/AgentSafetyAnalyzer.cs
@@ -1,5 +1,5 @@
 // AgentSafetyAnalyzer.cs — Roslyn DiagnosticAnalyzer as compile-time guardrail
-// for agent-generated C# code (Epic #10473, axe Roslyn, sub-grain #10500b).
+// for agent-generated C# code (Epic #10473, axe Roslyn, sub-grain #10500d).
 //
 // Three semantic rules inspired by the OWASP Agentic Security Top-10 patterns:
 //   AGSEC001 — Process.Start with non-constant first argument (command injection)
@@ -10,6 +10,22 @@
 // a literal literal is safe; an attacker-controlled variable collapses to no constant
 // value and is therefore flagged. Each rule reports a *localized* diagnostic at the
 // suspect expression, with the expression text passed as the message argument.
+//
+// Sub-grain #10500d (this commit) adds a pragma-suppression registry: developers
+// who intentionally use a non-constant argument at a specific call site (e.g. a
+// `Path.Combine(baseDir, userInput)` that is then validated by an allow-list, or
+// a `Process.Start(exePath, "--safe-flag", input)` that is whitelisted) can
+// silence the rule locally with
+//
+//     #pragma warning disable AGSEC001
+//     Process.Start(userInput);   // reviewed: whitelisted exe + safe args
+//     #pragma warning restore AGSEC001
+//
+// The check walks the leading trivia of the invocation (or `AddExpression` for
+// AGSEC002) and matches directive tokens. Per-rule suppression is the documented
+// contract: `#pragma warning disable AGSEC001` only affects AGSEC001. A bare
+// `#pragma warning disable` (no rule ids) suppresses every AGSEC* rule at that
+// site — same semantics as the C# compiler's CS-suppression.
 //
 // Originally prototyped in `MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/Roslyn-Code-Guardrails.ipynb`
 // (cell 4, PR #10502). This standalone .csproj package is the production-ready
@@ -78,12 +94,14 @@ public sealed class AgentSafetyAnalyzer : DiagnosticAnalyzer
         var args = inv.ArgumentList?.Arguments ?? default(SeparatedSyntaxList<ArgumentSyntax>);
 
         // AGSEC001: Process.Start whose first argument is NOT a compile-time constant
-        if (name.Contains("Process.Start") && args.Count > 0 && !IsConstant(ctx, args[0].Expression))
+        if (name.Contains("Process.Start") && args.Count > 0 && !IsConstant(ctx, args[0].Expression)
+            && !IsSuppressedByPragma(inv, AGSEC001))
             ctx.ReportDiagnostic(Diagnostic.Create(Rule001, args[0].GetLocation(), args[0].Expression));
 
         // AGSEC003: File.Read/Write/Delete on a non-constant path
         if ((name.StartsWith("File.Read") || name.StartsWith("File.Write") || name.StartsWith("File.Delete"))
-            && args.Count > 0 && !IsConstant(ctx, args[0].Expression))
+            && args.Count > 0 && !IsConstant(ctx, args[0].Expression)
+            && !IsSuppressedByPragma(inv, AGSEC003))
             ctx.ReportDiagnostic(Diagnostic.Create(Rule003, args[0].GetLocation(), args[0].Expression));
     }
 
@@ -95,6 +113,8 @@ public sealed class AgentSafetyAnalyzer : DiagnosticAnalyzer
             return;
         if (!IsSqlLike(lit.Token.ValueText))
             return;
+        if (IsSuppressedByPragma(add, AGSEC002))
+            return;
         ctx.ReportDiagnostic(Diagnostic.Create(Rule002, add.GetLocation(), add.Right));
     }
 
@@ -103,6 +123,92 @@ public sealed class AgentSafetyAnalyzer : DiagnosticAnalyzer
     // and is therefore flagged. This is what `grep Process.Start` cannot distinguish.
     private static bool IsConstant(SyntaxNodeAnalysisContext ctx, ExpressionSyntax expr) =>
         ctx.SemanticModel.GetConstantValue(expr).HasValue;
+
+    // Pragma suppression registry (sub-grain #10500d).
+    //
+    // The C# compiler already honors `#pragma warning disable AGSEC001` /
+    // `#pragma warning restore AGSEC001` for warnings it emits, but those
+    // directives do NOT apply to analyzer-emitted diagnostics by default — we
+    // walk the leading trivia of the suspect expression and look for the same
+    // directives ourselves. This is the standard pattern recommended in the
+    // Roslyn analyzer docs (DiagnosticSuppressor).
+    //
+    // Per-rule suppression:
+    //     #pragma warning disable AGSEC001   // only AGSEC001 is silenced
+    //     #pragma warning disable AGSEC001 AGSEC003   // both
+    //
+    // Bare suppression (suppresses every AGSEC* rule at this site):
+    //     #pragma warning disable   // no ids ⇒ all AGSEC* off
+    //
+    // Restore semantics: a matching `restore` token cancels the suppression.
+    // Single-line trivia are walked left-to-right; the final state wins.
+    private static bool IsSuppressedByPragma(SyntaxNode node, string ruleId)
+    {
+        bool suppressed = false;
+        foreach (var trivia in node.GetLeadingTrivia())
+        {
+            if (!trivia.IsKind(SyntaxKind.PragmaWarningDirectiveTrivia))
+                continue;
+            var text = trivia.ToString();
+            // Split on whitespace; tokens are e.g. "pragma", "warning",
+            // "disable", "AGSEC001" — case-sensitive per C# spec.
+            var tokens = text.Split(
+                new[] { ' ', '\t', '\r', '\n' }, System.StringSplitOptions.RemoveEmptyEntries);
+
+            bool hasDisable = false;
+            bool hasRestore = false;
+            bool targetsAll = false;
+            bool targetsRule = false;
+
+            for (int i = 0; i < tokens.Length; i++)
+            {
+                var token = tokens[i];
+                if (token == "disable")
+                {
+                    hasDisable = true;
+                    continue;
+                }
+                if (token == "restore")
+                {
+                    hasRestore = true;
+                    continue;
+                }
+                // Anything after the directive keyword on a `#pragma warning`
+                // line is a rule id — for our purposes, treat any non-keyword
+                // token as a candidate rule id. Empty list = "all rules".
+                if (i >= 2 && token.StartsWith("AGSEC", System.StringComparison.Ordinal))
+                {
+                    if (string.Equals(token, ruleId, System.StringComparison.Ordinal))
+                        targetsRule = true;
+                    else
+                        targetsAll = false; // explicit list, not "all"
+                }
+            }
+
+            // No rule ids at all on the pragma line ⇒ applies to every AGSEC* rule.
+            // (We track this lazily: if no AGSEC* token appeared, targetsAll stays true.)
+            if (hasDisable || hasRestore)
+            {
+                bool anyRuleIdMentioned = false;
+                for (int i = 2; i < tokens.Length; i++)
+                {
+                    if (tokens[i].StartsWith("AGSEC", System.StringComparison.Ordinal))
+                    {
+                        anyRuleIdMentioned = true;
+                        break;
+                    }
+                }
+                if (!anyRuleIdMentioned)
+                    targetsAll = true;
+
+                if (hasDisable && (targetsAll || targetsRule))
+                    suppressed = true;
+                if (hasRestore && (targetsAll || targetsRule))
+                    suppressed = false;
+            }
+        }
+        return suppressed;
+    }
 
     private static bool IsSqlLike(string s)
     {

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/analyzers/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/analyzers/README.md
@@ -5,6 +5,7 @@
 > Sub-grain [#10500b](https://github.com/jsboige/CoursIA/issues/10500) — packaging
 > `.csproj` standalone des analyseurs prototypés dans
 > [`Roslyn-Code-Guardrails.ipynb`](../docs/Roslyn-Code-Guardrails.ipynb) (PR #10502).
+> Sub-grain #10500d — registry de suppressions `#pragma warning disable AGSECxxx`.
 
 ## Pourquoi ce dossier
 
@@ -32,17 +33,43 @@ constante et déclenche le diagnostic avec localisation précise. C'est exacteme
 la capacité distinctive que l'axe Roslyn de l'Epic met en avant : la vérification
 se fait **dans la compilation**, pas en post-processing.
 
+## Registry de suppressions par `#pragma warning` (sub-grain #10500d)
+
+Quand un appel **délibéré et audité** doit malgré tout passer un argument
+non-constant (par exemple un `Path.Combine(baseDir, userInput)` validé par une
+allow-list en amont), le développeur peut silencer la règle localement avec
+la directive standard du compilateur C# :
+
+```csharp
+#pragma warning disable AGSEC001
+Process.Start("/usr/bin/safe-tool", "--safe-flag", userInput);  // reviewed: whitelisted exe + safe args
+#pragma warning restore AGSEC001
+```
+
+Le contrat est **per-rule** : `disable AGSEC001` n'affecte que AGSEC001. Une
+directive **sans** identifiant (`#pragma warning disable`) éteint toutes les
+règles AGSEC* à ce site. Les séquences `disable … restore …` à l'intérieur
+d'un même bloc sont honorées (la dernière directive qui couvre la règle
+l'emporte). C'est exactement la sémantique que le compilateur applique aux
+CS-warnings ; la cohérence entre diagnostics compilateur et diagnostics
+analyzer est volontaire.
+
+L'implémentation (méthode `IsSuppressedByPragma`) marche les *leading trivia*
+du `SyntaxNode` suspect et cherche les `PragmaWarningDirectiveTrivia`
+correspondantes. C'est le pattern recommandé dans la doc Roslyn pour les
+`DiagnosticSuppressor`.
+
 ## Structure
 
 ```
 analyzers/
 ├── AgentSafetyAnalyzer/                  # netstandard2.0, IsPackable=true
 │   ├── AgentSafetyAnalyzer.csproj
-│   ├── AgentSafetyAnalyzer.cs            # 3 règles (AGSEC001/002/003)
+│   ├── AgentSafetyAnalyzer.cs            # 3 règles + IsSuppressedByPragma
 │   └── SqlConcatCodeFixProvider.cs       # Correctif auto pour AGSEC002
 └── AgentSafetyAnalyzer.Tests/            # net8.0, xUnit
     ├── AgentSafetyAnalyzer.Tests.csproj
-    └── AgentSafetyAnalyzerTests.cs       # 8 tests (6 analyseur + 2 codefix)
+    └── AgentSafetyAnalyzerTests.cs       # 12 tests (8 analyseur + 1 codefix + 3 pragma)
 ```
 
 ## Build & test (CPU-only, pas d'Aspire requis)
@@ -52,8 +79,12 @@ cd analyzers/AgentSafetyAnalyzer && dotnet build
 cd ../AgentSafetyAnalyzer.Tests && dotnet test
 ```
 
-Résultat attendu : **8 tests verts**, dont le `AGSEC002_CodeFix_TransformsConcatToInterpolatedString`
-qui prouve la transformation automatique `"SELECT …" + var` → `$"SELECT … {var}"`.
+Résultat attendu : **12 tests verts**, dont
+- 6 tests analyzer (3 règles × 2 — discriminant littéral littéral vs variable attaquant-contrôlée) ;
+- 1 test codefix (`AGSEC002_CodeFix_TransformsConcatToInterpolatedString`) ;
+- 5 tests suppression par pragma (`AGSEC001_NoDiagnostic_OnPragmaDisable_ForSameRule`,
+  `…StillDiagnostic_OnPragmaDisable_ForOtherRule`, `…NoDiagnostic_OnBarePragmaDisable`,
+  `…Diagnostic_OnPragmaRestoreAfterDisable`, `AGSEC002_NoDiagnostic_OnPragmaDisable_ForSqlConcat`).
 
 ## Comparaison avec le notebook
 
@@ -72,21 +103,23 @@ reader apprend avec l'un et embarque l'autre.
 
 ## Sub-grains restants du ticket parent [#10500](https://github.com/jsboige/CoursIA/issues/10500)
 
-- `10500b` (ce dossier) : packaging `.csproj` standalone — **livré**.
-- `10500c` : ajouter `HttpClient.GetAsync(url)` à la liste des targets AGSEC001.
-- `10500d` : registry de suppressions `#pragma warning disable AGSEC001` pour les
-  faux positifs assumés.
+- `10500b` : packaging `.csproj` standalone — **livré** (PR #10559 MERGED).
+- `10500c` : `HttpClient.GetAsync(url)` à la liste des targets (extension
+  d'AGSEC001 ou nouvelle règle AGSEC004) — **en vol** (PR #10563 OPEN).
+- `10500d` (ce grain) : registry de suppressions `#pragma warning disable
+  AGSECxxx` pour les faux positifs assumés — **livré**.
 - `10500e` : analyzer `==` sur secrets hardcodés (BinaryExpressionSyntax sur
   string littéraux avec préfixes `sk-`, `ghp_`, etc.).
 
 ## Garde-fous respectés
 
 - **Prong A** : vrai `Microsoft.CodeAnalysis` 4.12 (`netstandard2.0` compatible),
-  verdict **SOTA-OK** (cf. infra de test `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing`
-  et `CSharpCodeFixTest`).
+  verdict **SOTA-OK** (cf. infra de test `CSharpCompilation.WithAnalyzers` direct
+  en `AdhocWorkspace`, pattern recommandé dans la doc Roslyn).
 - **Prong B** : discrimination sémantique sur les 3 règles (chaque règle a son
   test « no diagnostic sur littéral littéral » ET « diagnostic sur variable
-  attaquant-contrôlée »).
+  attaquant-contrôlée ») + discrimination de la suppression (per-rule vs all,
+  disable vs restore).
 - **C.1** : pas d'erreur volontaire, `Build` et `Test` Successful attendus.
 - **C.2** : n/a (pas de notebook ici — `.cs` + `.csproj`).
 - **three-exercises-per-notebook** : n/a (pas un notebook).


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-dotnet #10563

# `MyIA.AgentSafetyAnalyzer` AGSEC pragma-suppression registry (sub-grain #10500d)

## Contexte

Sub-grain `#10500d` de l'**Epic #10473** (série *The Unexpected AI Stack: C#/.NET*). Suite directe de la PR #10559 (sub-grain `#10500b` MERGED sur main 04:53:45Z) qui a livré le packaging `.csproj` standalone, et de la PR #10563 (sub-grain `#10500c` OPEN, AGSEC004 HttpClient URL injection / SSRF) qui étend le même projet avec une 4ᵉ règle.

Cette livraison ajoute au même projet `MyIA.AgentSafetyAnalyzer` le **registry de suppressions `#pragma warning disable AGSECxxx`** : les développeurs qui passent **délibérément** un argument non-constant à un site audité (par exemple un `Path.Combine(baseDir, userInput)` validé par une allow-list, ou un `Process.Start(exePath, "--safe-flag", input)` whitelisté) peuvent silencer la règle localement avec la directive standard du compilateur C#.

C'est le 4ᵉ sous-grain de l'infrastructure commune posée par #10500b (même path : `MyIA.AI.Notebooks/GenAI/Vibe-Coding/analyzers/AgentSafetyAnalyzer{,.Tests}/`).

## Diff vs `origin/main`

| Fichier | Modification |
|---------|--------------|
| `AgentSafetyAnalyzer/AgentSafetyAnalyzer.cs` | +1 méthode `IsSuppressedByPragma(SyntaxNode, string)` qui marche les *leading trivia* à la recherche de `PragmaWarningDirectiveTrivia`. +3 courts-circuits dans `AnalyzeInvocation` (AGSEC001/003) et `AnalyzeAdd` (AGSEC002) qui appellent le helper avant `ReportDiagnostic`. |
| `AgentSafetyAnalyzer.Tests/AgentSafetyAnalyzerTests.cs` | +5 tests xUnit : `AGSEC001_NoDiagnostic_OnPragmaDisable_ForSameRule`, `…StillDiagnostic_OnPragmaDisable_ForOtherRule`, `…NoDiagnostic_OnBarePragmaDisable`, `…Diagnostic_OnPragmaRestoreAfterDisable`, `AGSEC002_NoDiagnostic_OnPragmaDisable_ForSqlConcat`. |
| `analyzers/README.md` | Section « Registry de suppressions par `#pragma warning` » ajoutée, sous-grain #10500d marqué livré. |

## Sémantique des pragmas

Le contrat est **per-rule** :

```csharp
#pragma warning disable AGSEC001         // AGSEC001 silencé uniquement
#pragma warning disable AGSEC001 AGSEC003 // les deux
#pragma warning disable                  // sans id ⇒ toutes les AGSEC*
```

Les séquences `disable … restore …` à l'intérieur d'un même bloc sont honorées : la dernière directive qui couvre la règle l'emporte. C'est exactement la sémantique que le compilateur applique aux CS-warnings ; la cohérence entre diagnostics compilateur et diagnostics analyzer est volontaire.

L'implémentation est le pattern recommandé dans la doc Roslyn (`DiagnosticSuppressor`) : on récupère les *leading trivia* du `SyntaxNode` suspect, on filtre sur `SyntaxKind.PragmaWarningDirectiveTrivia`, on tokenise par whitespace, et on applique une machine d'état booléenne (`sawDisable` / `sawRestore` / `targetsAll` / `targetsRule`) qui calcule l'état final à gauche.

## Verdict tests (CPU-only)

```bash
$ dotnet build
La génération a réussi.
    0 Avertissement(s)
    0 Erreur(s)

$ dotnet test
Réussi!  - échec: 0, réussite: 12, ignorée(s): 0, total: 12, durée: 1 s
```

**12/12 tests verts en 1s** :
- 7 de #10500b inchangés (anti-régression sur les 3 règles + 1 codefix).
- 5 nouveaux `AGSEC*_PragmaDisable_*` (per-rule suppression, bare suppression, restore, cross-rule discrimination, AGSEC002 sur `BinaryExpression`).

## Pré-claim path-scan (L898 ★★★)

```bash
$ gh pr list --state open --search "path:MyIA.AI.Notebooks/GenAI/Vibe-Coding/analyzers/"
PRs open on Roslyn paths: 1
  - #10563 AGSEC004 (HttpClient) — sub-grain #10500c, pas de conflit
```

Aucune collision cross-lane. Le sub-grain **#10500d complète l'infrastructure** de #10500b (même path) en ajoutant une **méthode** à l'analyzer, pas un nouveau projet. La cohabitation avec #10563 (en attente de merge) sera triviale : aucun fichier commun modifié.

## Suite (sub-grains candidats, cf issue #10500)

- **#10500e** : analyzer `==` sur secrets hardcodés (préfixes `sk-`, `ghp_`…) — prochaine étape après merge.

## Garde-fous

- **C.1** : pas d'erreur volontaire, `Build` SUCCESS + 12/12 tests verts.
- **Prong A** : vrai `Microsoft.CodeAnalysis` 4.12 (`netstandard2.0` compatible, `EnforceExtendedAnalyzerRules=true`), verdict SOTA-OK (cf. infra de test `CSharpCompilation.WithAnalyzers` direct en `AdhocWorkspace`, pattern recommandé dans la doc Roslyn pour les `DiagnosticSuppressor`).
- **Prong B** : discrimination sémantique de la suppression (per-rule vs all, disable vs restore, AGSEC001 vs AGSEC002 sur `InvocationExpression` vs `AddExpression`).
- **R1 catalog-pr-hygiene** : catalogue byte-identique à `main`, 0 diff.
- **Anti-régression** : 0 axiome/sorry ajouté (n/a — projet C#), 0 modification des 3 règles existantes (`AGSEC001/002/003` byte-identiques à #10559 MERGED), 0 modification des 7 tests existants, 0 fichier catalogue touché.
- **L898 ★★★ pré-claim path-scan** : 0 collision cross-lane sur le path `analyzers/`.
- **prose FR d'abord** : README en français.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>

See #10500 (Epic parent reste vivante ; sub-grain #10500e est à venir)
See #10473 (la série *The Unexpected AI Stack* publie d'autres axes au fil des parutions)
