### PR TITLE
enrich(genai,#10488): fort-boyard-csharp density 343 -> WHAT+WHY + 2 interpretations

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/fort-boyard-csharp.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/fort-boyard-csharp.ipynb
@@ -87,6 +87,15 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Lecture de la sortie** — la cellule émet un `warning CS1701` : `Azure.Core` référence `System.ClientModel` en version `1.9.0.0` alors que la version `1.10.0.0` est chargée. C'est un **avertissement bénin**, pas une erreur : le runtime .NET a résolu l'assembly et continue.\n",
+    "\n",
+    "**Pourquoi distinguer ce warning d'une erreur** : dans un notebook .NET Interactive, un `warning CS` n'interrompt pas le flux (contrairement à une `error CS`). Ces conflits de version sont fréquents quand plusieurs packages NuGet dépendent de versions légèrement différentes d'une même librairie. Tant que l'exécution produit ses outputs attendus, ce warning est du bruit acceptable — ne pas le « corriger » comme un bug."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": "### Exercice : Verifier la configuration du Kernel\n\nAvant de lancer les agents, il est bon de verifier que le kernel est correctement configure.\n\n**Objectif** : Completez le code ci-dessous pour afficher le modèle utilise, le type de service (Azure ou OpenAI) et le statut de la connexion.\n\n**Indices** :\n- # Étape 1 : Utilisez les variables `model` et `useAzureOpenAI` définies dans la cellule précédente\n- # Étape 2 : Affichez un resume de la configuration avec `Console.WriteLine`\n- # Indice : Affichez aussi un avertissement si `apiKey` est vide ou si le modèle est inconnu",
    "metadata": {}
   },
@@ -113,7 +122,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Définissons maintenant les prompts pour nos agents Père Fouras et Laurent Jalabert, en veillant à ce que le mot à deviner soit inséré dans le prompt système du Père Fouras."
+    "## Définition des prompts système des agents\n",
+    "\n",
+    "**Pourquoi les prompts système sont des constantes séparées du code** : chaque agent reçoit un *rôle* fixe dans son prompt système. Séparer ces prompts du moteur suit la **séparation des responsabilités** : changer le ton du Père Fouras se fait en éditant une chaîne, sans toucher au code. Le marqueur `{{word}}` est un **template** Semantic Kernel : le kernel le remplace à l'exécution par le mot à deviner (`Anticonstitutionnellement`), ce qui rend le prompt *paramétré* et réutilisable pour n'importe quel mot plutôt que figé."
    ]
   },
   {
@@ -143,7 +154,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Nous allons maintenant enregistrer nos fonctions sémantiques pour les deux agents."
+    "## Création des agents `ChatCompletionAgent`\n",
+    "\n",
+    "**Pourquoi des objets `ChatCompletionAgent` et non de simples appels LLM** : un agent encapsule ses `Instructions` (prompt système), son `Name` (`Pere_Fouras` / `Laurent_Jalabert`) et son `Kernel` (accès au modèle). Sans cette abstraction, chaque tour devrait re-passer manuellement l'historique et l'identité à l'API. C'est aussi ce `Name` qui rend la trace lisible dans la cellule suivante (`# Assistant - Pere_Fouras: ...`) : on sait qui parle, indispensable pour diagnostiquer un agent erratique."
    ]
   },
   {
@@ -243,7 +256,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Initialisons maintenant les arguments pour suivre la conversation et le mot à deviner."
+    "## Boucle de conversation — le cœur de l'orchestration\n",
+    "\n",
+    "**Pourquoi `chat.InvokeAsync()` décide elle-même quel agent parle** : un `AgentGroupChat` applique une **stratégie de sélection** (quel agent parle au prochain tour) et une **stratégie de terminaison** (quand s'arrêter). Ici la stratégie alterne les agents et s'arrête quand Laurent devine le mot. Contrairement à une chaîne d'appels LLM linéaire, l'orchestrateur **réagit** à chaque réponse (`chat.IsComplete`) au lieu d'avancer aveuglément — observez dans la cellule suivante comment les rôles s'alternent automatiquement."
    ]
   },
   {
@@ -367,6 +382,15 @@
     "    Console.WriteLine($\"# {content.Role} - {content.AuthorName ?? \"*\"}: '{content.Content}'\");\n",
     "}\n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Lecture de la conversation** — l'orchestrateur a produit un échange de **charade** : le Père Fouras ouvre (« Mon premier est une préposition... Mon deuxième est une graine... Mon troisième évoque les règles d'un texte fondamental »), et Laurent Jalabert devine **tour par tour** (« 'à' ? » → non → « 'dans' ? » → non → « 'de' ? » → « Bravo ! Mon premier est effectivement 'de' ! »), puis « grain » et « loi » confirmés.\n",
+    "\n",
+    "**Ce que cet output démontre** : la trace alterne rigoureusement `Pere_Fouras` / `Laurent_Jalabert` sans qu'aucun code ne dicte l'ordre — c'est la **stratégie de sélection** du `AgentGroupChat`. Notez aussi que les agents **improvisent** : la charade générée ne décompose pas exactement `Anticonstitutionnellement` — le modèle crée sa propre énigme cohérente. C'est une propriété émergente des systèmes multi-agent : le comportement naît de l'interaction des prompts, pas d'un script."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: MED/notebook-python #10568

## Summary

Enrichissement markdown-only de `fort-boyard-csharp.ipynb` (EPIC #10488 densité). Densité **343 → 714** (cible EPIC ≥450-700). **Famille fraîche GenAI/SemanticKernel multi-agent** (.NET C#, kernel `.net-csharp`) vs Image/examples + Image/Orchestration + SMT + CaseStudies des PRs density précédentes = rotation R6 au niveau famille **et** genre (notebook-dotnet). Notebook multi-agent Semantic Kernel : Père Fouras vs Laurent Jalabert (jeu de devinette charade, `AgentGroupChat` sélection+terminaison).

See #10488.

## Ce que la PR change (1 fichier, markdown-only, +27/−3)

`fort-boyard-csharp.ipynb` — 15→17 cellules (+2 md). Kernel `.net-csharp`, 8 code cells.

| Cellule | Avant (WHAT 1-liner) | Après (WHAT+WHY) |
|---|---|---|
| `[5]` Prompts | "Définissons maintenant les prompts..." | + pourquoi const séparées du moteur (séparation responsabilités) + template `{{word}}` |
| `[7]` Agents | "Nous allons maintenant enregistrer nos fonctions..." | + pourquoi `ChatCompletionAgent` (Instructions/Name/Kernel, Name = trace lisible) |
| `[11]` Boucle | "Initialisons maintenant les arguments..." | + pourquoi `AgentGroupChat` stratégie sélection+terminaison (réactif vs linéaire) |

**2 interprétations insérées APRÈS outputs** :

- **Après config (cell 2 output, ec=2)** : warning **CS1701** `System.ClientModel` `1.9.0.0` vs `1.10.0.0` (vérifié dans output ec=2). Pourquoi warning bénin ≠ erreur (`warning CS` n'interrompt pas en .NET Interactive).
- **Après conversation jeu (cell 12 output, ec=5, 10 stream outputs)** : charade Père Fouras « Mon premier est une préposition » → Laurent devine `'à'`/`'dans'`/`'de'` → **« Mon premier est effectivement 'de' ! »** puis `grain`, `loi` (vérifié verbatim dans outputs ec=5). Pourquoi tour-à-tour = stratégie de sélection ; agents improvisent (charade ≠ décomposition littérale de `Anticonstitutionnellement`) = propriété émergente multi-agent.

## Preuves vérifiables (G.1 — claims vérifiés firsthand)

**Markdown-only = code cells byte-identiques à `origin/main`** :
- sources byte-identical: **True**
- outputs byte-identical: **True**
- exec_counts identical: **True**
- kernelspec identical: **True**

→ Exception C.2 markdown-only : **0 re-exécution requise** (code cells non touchées).

**Valeurs citées = vraies valeurs des outputs** (vérifié) :
- `warning CS1701` + `System.ClientModel` + `1.9.0.0` + `1.10.0.0` présents dans output ec=2
- `Mon premier est une préposition` + `Est-ce que mon premier est "de" ?` + `Mon premier est effectivement "de"` présents dans outputs ec=5 (cell 12, 10 streams)
- `Anticonstitutionnellement` (mot à deviner, cell 8) confirmé

**H.3 pre-commit passé** : gitleaks · probeAddresses · .NET username scrub · papermill paths · markdown-defect-guard · H.3 — tous Passed.

**C.1 respectée** : 0 pattern interdit (`raise NotImplementedError`/`assert False`/`1/0`). 3 cellules exercices préservées (cell 4/10/15, stubs `Exercice a completer` + `return 0` + `null` TODO).

## Transparence R6

7e PR density de ma lane. **Famille rotation** : Image/examples (3) → Image/Orchestration (1) → SMT-Csharp (1) → CaseStudies (1) → **SemanticKernel .NET multi-agent** (1, cette PR). **Genre rotation** : notebook-python ×4 → notebook-dotnet ×2 (SMT + cette PR). La **technique** (markdown density) se répète — c'est la contrainte de l'EPIC #10488 — mais la **substance de domaine** est entièrement multi-agent SK C# (prompts templated, abstraction ChatCompletionAgent, AgentGroupChat stratégie, charade émergente), sans chevauchement.

**Pourquoi cette PR n'est pas du content-gaming** : le notebook est *genuinely* sous-dense (343 < cible 450), SemanticKernel est une famille non touchée par mes PRs précédentes, 0 collision (toutes PRs fort-boyard précédentes = MERGED metadata.cost/secrets/diacritics, aucune OPEN), kernel .NET installé localement (regle F OK).

## Hors scope (G.4)

EPIC #10488 = 986 notebooks. Contribution partielle, `See #10488`.
