### PR TITLE
enrich(lean,#10479): Lean-16d Conway GoL interpretation cells (WHAT+WHY, citing real outputs)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16d-Conway-Game-of-Life-Lean-Native.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16d-Conway-Game-of-Life-Lean-Native.ipynb
@@ -579,6 +579,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a1-interp-moteur",
+   "metadata": {},
+   "source": [
+    "**Interprétation.** La sortie `#eval step blinker` renvoie `[(0, 1), (-1, 1), (1, 1)]` : les trois cellules vivantes, d'abord alignées *horizontalement* sur la ligne `r = 0`, forment maintenant une *verticale* sur la colonne `c = 1`. Le second `#eval step (step blinker)` redonne `[(0, 1), (0, 0), (0, 2)]` — la ligne horizontale initiale. Le clignoteur pivote donc de 90° à chaque génération.\n",
+    "\n",
+    "Pourquoi la cellule centrale `(0, 1)` survit-elle ? Elle a **2 voisins vivants** (les deux extrémités du clignoteur) → règle **S23** satisfaite. Les deux cellules `(−1, 1)` et `(1, 1)`, mortes au départ, ont chacune **3 voisins vivants** → règle **B3** : elles naissent. Le moteur `step` filtre les candidates par `aliveNext`, et l'oscillation émerge de la seule application locale de B3/S23 — aucun état global n'est stocké."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6877e38b",
    "metadata": {
     "papermill": {
@@ -702,6 +712,14 @@
     "\n",
     "#eval step block       -- inchangé (au tri près)\n",
     "#eval liveNeighborCount block (0, 0)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2-interp-stilllife",
+   "metadata": {},
+   "source": [
+    "**Interprétation.** `#eval step block` renvoie `[(0, 0), (0, 1), (1, 0), (1, 1)]` — strictement identique au bloc de départ. Et `#eval liveNeighborCount block (0, 0)` donne **3**. Chaque cellule du carré 2×2 compte les deux autres cellules de sa ligne/colonne (2) plus la diagonale opposée (1) = 3 voisins vivants. Comme elle est vivante et a 3 voisins, **S23** la maintient en vie ; aucune cellule morte adjacente n'atteint le seuil **B3** (leurs comptes restent à 2). Le bloc est donc un **still-life** : `step g = g` exactement, vérifié par l'exécution et non par une observation visuelle."
    ]
   },
   {
@@ -854,6 +872,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a3-interp-oscillateurs",
+   "metadata": {},
+   "source": [
+    "**Interprétation.** Les trois `#eval sameSet (evolve _ 2) _` renvoient tous `true` : clignoteur, crapaud et phare retrouvent leur configuration initiale après **2 générations**. C'est la définition même d'un oscillateur de période 2 — `evolve g 2 = g` (à l'ordre des cellules près, d'où le `sameSet` qui teste l'égalité ensembliste plutôt que l'ordre de liste).\n",
+    "\n",
+    "La nuance `sameSet` vs `=` est importante : `step` réordonne la grille (via `filter` + `eraseDups`), donc l'égalité structurelle `=` échouerait même sur un still-life parfait. `sameSet` neutralise cet artefact d'implémentation et capture la propriété sémantique attendue — la stabilité du *patron* de cellules, pas de leur ordre dans la liste."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0075f657",
    "metadata": {
     "papermill": {
@@ -968,6 +996,16 @@
     "  g.map (fun (r, c) => (r + dr, c + dc))\n",
     "\n",
     "#eval sameSet (evolve glider 4) (translate 1 1 glider)   -- le planeur avance\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4-interp-glider",
+   "metadata": {},
+   "source": [
+    "**Interprétation.** `#eval sameSet (evolve glider 4) (translate 1 1 glider)` renvoie `true` : après **4 générations**, le planeur coïncide (ensemblistement) avec sa propre translation de vecteur `(1, 1)`. Il s'est donc déplacé d'une case vers le sud-est. Contrairement aux oscillateurs — qui reviennent à leur point de départ — un **vaisseau** ne revient jamais à sa position initiale : il revient à sa *forme* translatée. C'est ce que capture la comparaison `evolve glider 4` contre `translate 1 1 glider` plutôt que contre `glider` lui-même.\n",
+    "\n",
+    "Cette translation diagonale est la signature du planeur : 4 pas pour avancer d'une case, soit une « vitesse » de *c/4* diagonale (le maximum pour un vaisseau de cette taille dans le Game of Life). C'est ce motif que les calculateurs à planeurs exploitent pour faire circuler de l'information."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-lean — lane myia-po-2025:CoursIA — prev: LIGHT/guard (#10574)

# enrich(lean,#10479): Lean-16d Conway GoL interpretation cells (WHAT+WHY, citing real outputs)

See #10479

## What

Lean-16d-Conway-Game-of-Life-Lean-Native.ipynb (kernel `lean4-wsl`) demonstrated the Game-of-Life engine on the native Lean kernel but interpreted the observed outputs only in thin section-header transitions. This PR adds **4 markdown interpretation cells AFTER the code outputs**, each citing the real executed values and explaining WHY the pattern behaves as it does under the B3/S23 rule. Directly addresses the user's note that applied Lean notebooks "mériteraient de renforcer significativement le niveau de pédagogie".

## The 4 interpretation cells (each after a code-output cell)

1. **Moteur (`step`/`evolve`)** — cites `step blinker` → `[(0, 1), (-1, 1), (1, 1)]` (horizontal→vertical pivot) and `step (step blinker)` → `[(0, 1), (0, 0), (0, 2)]` (back to horizontal). Explains WHY: center cell survives (2 neighbors → S23), the two dead cells at `(±1,1)` each have 3 neighbors → B3 birth. The oscillation emerges from local B3/S23 application alone, no global state.

2. **Still-lifes** — cites `step block` → `[(0, 0), (0, 1), (1, 0), (1, 1)]` (identical to input) and `liveNeighborCount block (0, 0)` → `3`. Explains WHY the 2×2 block is a fixed point: each cell has exactly 3 live neighbors → S23 maintains it; no dead neighbor reaches B3 threshold. `step g = g` verified by execution, not visual observation.

3. **Oscillateurs** — cites all three `sameSet (evolve _ 2) _` → `true` (blinker, toad, beacon). Explains the `sameSet` vs `=` nuance: `step` reorders the grid via `filter`+`eraseDups`, so structural equality fails on a perfectly stable pattern; `sameSet` captures the semantic property (pattern stability, not list order).

4. **Planeur (glider)** — cites `sameSet (evolve glider 4) (translate 1 1 glider)` → `true`. Explains WHY a spaceship differs from an oscillator: it returns to its *translated form*, not its initial position. The 4-step diagonal advance = the *c/4* glider speed exploited by glider-based logic circuits.

## Validation

- **Code cells byte-identical** to origin/main: 12/12 code cells, all `source`+`outputs`+`execution_count` unchanged (verified programmatically). Kernel `lean4-wsl` unchanged.
- **Markdown-only edit** → C.2 exception (0 re-execution required; the lean4-wsl outputs are preserved as-is).
- `nbformat.validate`: OK.
- `validate_pr_notebooks.py`: PASS (12 cells, lean4-wsl).
- `detect_markdown_rendering.py`: 0 violations.
- C.1 scan: 0 forbidden patterns (`raise NotImplementedError`/`assert False`/`1/0`). The `sorry` in Exercise 2 is a canonical Lean proof stub (Lean C.1 exception), pre-existing on origin/main, untouched.
- Catalogue byte-identical to main (not regenerated).
- `json.dumps(ensure_ascii=False, indent=1)` round-trips byte-identically to the original file format — only the 4 inserted cells change the diff (+38/-0, 1 file).

## Scope

Enriches Lean-16d only (the native-kernel GoL notebook), part of #10479's mandate to raise the pedagogical floor across the Lean series. Not in the contended intro series (Lean-2..6); this is an applied notebook where the engine demonstrates `decide`/`native_decide` certification — the interpretations connect the formal outputs to the Game-of-Life semantics.

prev: LIGHT/guard (#10574) → MED/notebook-lean here. Genre rotation honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
