### PR TITLE
fix(genai,#9434): complete partial wallclock drain in 03-2 cells[16]+[32]

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb
@@ -924,12 +924,12 @@
     "| STT (local) | 0.5-2s | GPU / taille audio |\n",
     "| STT (API) | 1-3s | Reseau |\n",
     "| LLM | 1-3s | Generation de tokens |\n",
-    "| TTS | ~5s (runtime *machine-dep* : 5.02s) | Reseau / synthese — goulot principal ce run |\n",
-    "| **Total** | **~8s (runtime *machine-dep* : 8.33s)** | **TTS le plus lent (runtime *machine-dep* : 5.02s vs LLM 1.72s vs STT 1.59s)** |\n",
+    "| TTS | ~5s (*runtime machine-dep* : 5.02s) | Reseau / synthese — goulot principal ce run |\n",
+    "| **Total** | **~8s (*runtime machine-dep* : 8.33s)** | **TTS le plus lent (*runtime machine-dep* : 5.02s vs LLM 1.72s vs STT 1.59s)** |\n",
     "\n",
     "**Points cles** :\n",
     "1. La latence totale du pipeline est la somme des latences individuelles\n",
-    "2. Sur ce run, le TTS est le goulot d'etranglement (runtime *machine-dep* : 5.02s vs 1.72s pour le LLM) ; la synthese vocale via API depend fortement de la latence reseau\n",
+    "2. Sur ce run, le TTS est le goulot d'etranglement (*runtime machine-dep* : 5.02s vs 1.72s pour le LLM) ; la synthese vocale via API depend fortement de la latence reseau\n",
     "3. Le retry exponentiel protege contre les erreurs transitoires\n",
     "4. Pour du temps reel, privilegier des modèles plus petits (gpt-4o-mini)"
    ]
@@ -1892,12 +1892,12 @@
     "\n",
     "| Pipeline | Étape la plus lente | Optimisation possible |\n",
     "|----------|--------------------|-----------------------|\n",
-    "| STT->LLM->TTS | TTS (synthese, runtime *machine-dep* : 5.02s) | Reduire la longueur du texte a synthetiser, voix plus rapides |\n",
+    "| STT->LLM->TTS | TTS (synthese, *runtime machine-dep* : 5.02s) | Reduire la longueur du texte a synthetiser, voix plus rapides |\n",
     "| Traduction | Comparable STT/LLM/TTS | Paralleliser STT et TTS si possible |\n",
     "| Podcast | TTS (N segments) | Paralleliser les appels TTS |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Le profilage revele que le TTS est le goulot d'etranglement (runtime *machine-dep* : 5.02s sur stt_llm_tts, 12.96s sur le podcast)\n",
+    "1. Le profilage revele que le TTS est le goulot d'etranglement (*runtime machine-dep* : 5.02s sur stt_llm_tts, 12.96s sur le podcast)\n",
     "2. La generation du podcast est dominee par les appels TTS séquentiels\n",
     "3. L'assemblage est negligeable par rapport aux appels API"
    ]


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2025:CoursIA-2 — prev: MED/lean #10572 (Lean-6 grain 5/5)

## Quoi

Complétion d'un drainage **partiel** de cellule markdown dans `03-2-Audio-Pipeline-Orchestration.ipynb` (sub-grain microscopique de l'EPIC **#9434** « quantitatif tenu par CI, pas par prose »).

**Scope strict** : 5 lignes, 2 cellules markdown (cells[16] + [32]), **1 notebook**. Conversion uniforme `runtime *machine-dep* :` → `*runtime machine-dep* :` (re-formalisation du préfixe pour matcher le standard validé par PR #9715 cell[33] et PR #10550 cell[18]).

**Sub-grain de** : #9434 + #10158 (organe inventaire machine-dep timing). Le scanner `check_machine_dep_timing.py --all` (PR #10538 MERGED) avait listé 03-2 dans son scan mais le drainage **PR #9715 (MERGED 2026-08-04)** avait laissé 2 cellules avec un pattern **semi-drainé** (asterisques partiels) — fix microscopique légitime.

## VERBATIM (L10488 protocole — citations exactes, intégrales)

### Cellule [16] `### Interpretation : Pipeline STT -> LLM -> TTS`

**Avant** (verbatim 3 lignes, pattern `runtime *machine-dep*` partial):
```
| TTS | ~5s (runtime *machine-dep* : 5.02s) | Reseau / synthese — goulot principal ce run |
| **Total** | **~8s (runtime *machine-dep* : 8.33s)** | **TTS le plus lent (runtime *machine-dep* : 5.02s vs LLM 1.72s vs STT 1.59s)** |
2. Sur ce run, le TTS est le goulot d'etranglement (runtime *machine-dep* : 5.02s vs 1.72s pour le LLM) ; la synthese vocale via API depend fortement de la latence reseau
```

**Après** (verbatim 3 lignes, pattern canonique `*runtime machine-dep*`):
```
| TTS | ~5s (*runtime machine-dep* : 5.02s) | Reseau / synthese — goulot principal ce run |
| **Total** | **~8s (*runtime machine-dep* : 8.33s)** | **TTS le plus lent (*runtime machine-dep* : 5.02s vs LLM 1.72s vs STT 1.59s)** |
2. Sur ce run, le TTS est le goulot d'etranglement (*runtime machine-dep* : 5.02s vs 1.72s pour le LLM) ; la synthese vocale via API depend fortement de la latence reseau
```

### Cellule [32] `### Interpretation : Profilage`

**Avant** (verbatim 2 lignes):
```
| STT->LLM->TTS | TTS (synthese, runtime *machine-dep* : 5.02s) | Reduire la longueur du texte a synthetiser, voix plus rapides |
1. Le profilage revele que le TTS est le goulot d'etranglement (runtime *machine-dep* : 5.02s sur stt_llm_tts, 12.96s sur le podcast)
```

**Après**:
```
| STT->LLM->TTS | TTS (synthese, *runtime machine-dep* : 5.02s) | Reduire la longueur du texte a synthetiser, voix plus rapides |
1. Le profilage revele que le TTS est le goulot d'etranglement (*runtime machine-dep* : 5.02s sur stt_llm_tts, 12.96s sur le podcast)
```

**5 lignes au total**, **3 dans cell[16] + 2 dans cell[32]**, **1 notebook**, **0 code cell modifié**.

## Périmètre

- **Markdown-ONLY** (cf PR #9715 + #10550 pattern) : **5 lignes MD modifiées**. **16/16 cellules code byte-identiques** (vérifié par comparaison multi-set content+execution_count+outputs, conforme à CLAUDE.md §C.2 + §H.3).
- Headers neutres : cells[16] et [32] sont des cellules « Interpretation : », ni `Exercice N` ni `Exemple résolu`.
- Pas de re-exécution Papermill requise (modification markdown pure, scope C.3 respecté).
- JSON nbformat 4.5 valide, H.3 OK (0 cellule code avec ec=null).
- 0 HIGH solution-leak (delta guard #8053 : base=0, head=0 → PASS).
- 0 hand-édition de sortie de cellule (Stop & Repair respecté) — toutes les valeurs verbatim préservées (5.02s, 8.33s, 1.72s, 1.59s, 12.96s).

## Pattern formalisation

**Convention validée** (PR #9715 cell[33] + PR #10550 cell[18] + PR #10565 cell[21]) :

| Avant (LEAK) | Après (DRAINED) |
|---|---|
| `runtime *machine-dep* : X` | `*runtime machine-dep* : X` |
| `wallclock MS` | `*runtime machine-dep* : X` |
| `mesure : 8.2s` | `*runtime machine-dep* : ~8s` |

Le **pattern canonique** est `*runtime machine-dep*` (asterisques autour des DEUX mots) — c'est le tag visuel parsable par le scanner PR du gate CI. Le pattern partial `runtime *machine-dep*` (asterisques uniquement sur le second mot) **rougit au scanner** car la regex cherche `\*runtime` au début.

## Pourquoi cette sous-tâche est légitime

1. **Sub-grain de l'EPIC parent #9434 actif** — la règle upstream dit "MIDI sub-grains toujours accept" sous EPIC parent.
2. **Scope microscopique vérifié firsthand** (5 lignes, 1 notebook, 0 code cell) — pas d'écart possible.
3. **Convention cohérence** : 03-1, 03-3, 04-1, 04-3, 04-6, 04-7 sont TOUS déjà formalisés avec `*runtime machine-dep*`. 03-2 est l'**oublié** du drain #9715.
4. **0 hand-edit** : aucune sortie de cellule touchée, valeurs verbatim (5.02s, 8.33s, 1.72s, 1.59s, 12.96s, 17.23s) préservées pour traçabilité historique.

## Critères d'acceptation ai-01 (msg-20260812T001621-e1q8gz §3)

| # | Critère | Statut |
|---|---------|--------|
| 1 | Code cells byte-identiques (source, execution_count, outputs) | ✓ 16/16 |
| 2 | MD cells préexistantes non-touchées hors 5 lignes cibles | ✓ (diff scope = 5 lines) |
| 3 | Énoncés logiques vérifiés, pas plausibles | ✓ (cf VERBATIM) |

## Sub-grain suite

- 03-3 Realtime Voice API : 2 RUNTIME_MEASURED strict restants d'après scanner #10538 (mais déjà drainés visuellement) — no-op
- 04-3 Music Composition : 1 RUNTIME_MEASURED strict (mais déjà terminé visuellement) — no-op
- 02-Advanced + 04-10/11/12/13 : à scanner, candidats potentiels

## Suivi

- See #9434 (EPIC parent « GenAI/Audio machine-dep drainage »)
- See #10158 (organe inventaire)
- Précédent : PR #9715 (MERGED 2026-08-04, drain partiel 03-2 — 5 lignes oubliées détectées c.1301+96)
- C1301+91-L1 ★ pattern répété : drainage MD ≠ hand-edit output code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
