### PR TITLE
enrich(iit,#10488): ICT-28 collective-adoption density 627 -> WHAT+WHY + interpretations

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-28-CollectiveAdoption.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-28-CollectiveAdoption.ipynb
@@ -149,6 +149,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a1-interp-seuil",
+   "metadata": {},
+   "source": [
+    "**Interprétation.** La courbe d'adoption en fonction de `rho` a la signature d'un **phénomène de masse critique** : quasi-nulle aux faibles fractions d'instigateurs (`0.000` à `rho=0,05`), quasi-totale aux fractions élevées (`1.000` à `rho=0,95`), avec un **saut maximal de `0,472`** entre deux valeurs consécutes de `rho`. Ce n'est pas une transition graduelle mais un basculement — exactement la courbe en S d'une percolation ou d'un seuil épidémique.\n",
+    "\n",
+    "Le verdict `threshold_exists = True` ne dit pas seulement « ça monte », il dit que la transition est **abrupte** : il existe une valeur `rho_c` en dessous de laquelle la convention novelle ne décolle pas, et au-dessus de laquelle elle devient inévitable. C'est ce seuil qui fait de l'adoption un acte *performatif* — la convention n'existe comme fait social qu'une fois franchi le point de bascule, pas avant."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "19be53f6",
    "metadata": {},
    "source": [
@@ -192,6 +202,16 @@
     "print(f\"  adoption @rho=0.1 = {verdict['adoption_at_low_rho']:.3f}\")\n",
     "print(f\"  niveau hasard 1/n = {verdict['chance_level']:.3f}\")\n",
     "print(\"  -> la convention novelle meurt : les naïfs convergent vers des conventions arbitraires.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2-interp-meurt",
+   "metadata": {},
+   "source": [
+    "**Interprétation.** Le résultat sous le seuil est **contre-intuitif** : à `rho=0,1`, l'adoption de la convention novelle atteint `0,011` — soit *trente fois moins* que le niveau du hasard `1/n = 0,333`. La convention ne fait pas que échouer à se propager, elle **meurt activement** : les agents naïfs convergent vers des conventions *arbitraires* (trois états possibles, tirés au sort), si bien que la cible finit sous-représentée par rapport au hasard. `dies = True` capture exactement cela.\n",
+    "\n",
+    "C'est la marque d'un effet de fragmentation : sans assez d'instigateurs pour ancrer la cible, le apprentissage social disperse le consensus plutôt qu'il ne le forme. Le seuil `rho_c` sépare donc deux régimes *qualitativement* distincts — fragmentation vs cascade — pas deux intensités d'un même phénomène."
    ]
   },
   {
@@ -282,6 +302,16 @@
     "print(\"Contrôle no_cascade_without_instigators : no_cascade =\", bool(verdict[\"no_cascade\"]))\n",
     "print(f\"  adoption @rho=0 = {verdict['adoption_at_rho_zero']:.3f}\")\n",
     "print(\"  -> sans instigateur, la cible n'est jamais introduite : pas de cascade spontanée.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3-interp-controle",
+   "metadata": {},
+   "source": [
+    "**Interprétation.** Le contrôle à `rho=0` est l'épreuve **falsifiante** de tout le dispositif. Sans aucun instigateur (`rho=0`), l'adoption de la cible reste à `0,000` : la convention novelle n'est jamais même introduite dans la population. `no_cascade = True` confirme qu'il n'y a pas d'émergence spontanée.\n",
+    "\n",
+    "Ce contrôle distingue deux hypothèses rivales que la seule observation d'une cascade ne pourrait départager : (a) la convention se propage par **apprentissage social** à partir des instigateurs, ou (b) elle apparaît par **dérive aléatoire** sans cause externe. En éliminant (b) — aucun instigateur, zéro adoption — on établit que la cascade observée au §3 provient bien de la performativité des instigateurs, pas d'un artefact statistique."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-lean (#10576)

# enrich(iit,#10488): ICT-28 collective-adoption density 627 -> WHAT+WHY + 3 interpretations

See #10488

## What

`ICT-28-CollectiveAdoption.ipynb` (kernel `python3`, strate 7 — adoption collective et seuil de performativité) demonstrated the 4 verdicts of the critical-mass threshold (critical_threshold / below_threshold_dies / above_threshold_cascades / negative control) but only had section-header markdown BEFORE each code cell — no interpretation cell AFTER the output explaining WHY the result confirms the performativity thesis. This PR adds **3 markdown interpretation cells AFTER the demonstration verdict cells**, each citing the real executed values.

## The 3 interpretation cells (each after a code-output cell)

1. **Seuil critique (`critical_threshold`)** — cites the real S-curve values: adoption `0.000` @rho=0.05 → `1.000` @rho=0.95, **saut maximal 0.472**. Explains WHY this is the signature of an abrupt critical-mass/percolation transition (not a gradual rise), and why `threshold_exists=True` means the convention only becomes a social fact once `rho_c` is crossed.

2. **Sous le seuil, la convention meurt (`below_threshold_dies`)** — cites the counterintuitive result: adoption `0.011` @rho=0.1 vs random `1/n = 0.333` (30× below chance). Explains WHY the convention doesn't just fail to spread — it dies *actively* via fragmentation (naive agents converge on arbitrary conventions). `dies=True` separates two qualitatively distinct regimes (fragmentation vs cascade).

3. **Contrôle falsifiant (`no_cascade_without_instigators`)** — cites `rho=0 → adoption 0.000`. Explains WHY this control is the falsifying test that distinguishes social-learning propagation (a) from random-drift emergence (b) — eliminating (b) establishes the cascade is performative, not statistical artifact.

## Validation

- **Code cells byte-identical** to origin/main: 8/8 code cells, all `source`+`outputs`+`execution_count` unchanged (verified programmatically). Kernel `python3` unchanged.
- **Markdown-only edit** → C.2 exception (0 re-execution required; python3 outputs preserved as-is).
- `nbformat.validate`: OK.
- `validate_pr_notebooks.py`: PASS (8 cells).
- C.1 scan: 0 forbidden patterns.
- `json.dumps(ensure_ascii=False, indent=1)` + trailing newline round-trips byte-identically to the original file format — only the 3 inserted cells change the diff (+30/-0, 1 file).
- Catalogue byte-identical to main (not regenerated).
- Density: 627 → 929 chars/code-cell (+48%).

## Scope

Enriches ICT-28 only (the collective-adoption threshold notebook). Part of #10488's mandate to raise the pedagogical density floor. The exercise cells [12/14/16] (labeled "Exercice" but containing full solutions) are left untouched — that pre-existing leak is a separate concern, out of scope for a density PR.

## Why this grain (honest, not idle)

prev: MED/notebook-lean (#10576) → MED/notebook-python here. Genre distinct (lean → python). IIT = family untouched by this lane this session. 0 OPEN PR on ICT-28 (L898 clean). The pool CPU-content space is genuinely drained (attested by 3 peer lanes: po-2023 c.8 SW-9, po-2024 c.803 Lab14 "dernier legit", po-2026 c.1059 GT-6 substance); IIT is the last un-touched density family (po-2023 flagged "scan density épuisé après IIT"). Density-in-genuinely-fresh-family = content (not META), satisfies G-VAR-1 floor. Forcing a DEEP pivot to GPU/QC-Cloud/Lean-cold would be gated (po-2025 = CPU-only, no vision, no warm Mathlib per env-inventory); twin-bridge space saturated by po-2023/po-2026 (7+ open PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
