### PR TITLE
docs(smt,#10488): Z3-Python-02-Sudoku-Csharp density 403->915 (+127%)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb
@@ -7,26 +7,30 @@
    "source": [
     "# Z3 (C# / .NET) — Sudoku par contraintes\n",
     "\n",
-    "**Twin C# de `Z3-Python-02-Sudoku.ipynb`** (parite .NET, marathon #4956, suite de `Z3-Python-01-Introduction-Csharp`).\n",
+    "**Twin C# de `Z3-Python-02-Sudoku.ipynb`** (parité .NET, marathon #4956, suite de `Z3-Python-01-Introduction-Csharp`).\n",
     "\n",
-    "Ce notebook resout le Sudoku de facon **declarative** avec le **moteur reel [Microsoft.Z3](https://github.com/Z3Prover/z3)** (NuGet, Z3 4.12.2.0), le même solveur que `z3-solver` (Python). Au lieu d'ecrire un algorithme de backtracking, on **exprime les règles du Sudoku comme des contraintes** et le solveur trouve une solution.\n",
+    "Ce notebook résout le Sudoku de façon **déclarative** avec le **moteur réel [Microsoft.Z3](https://github.com/Z3Prover/z3)** (NuGet, Z3 4.12.2.0) — le même solveur que `z3-solver` (Python). Au lieu d'écrire un algorithme de backtracking, on **exprime les règles du Sudoku comme des contraintes** et le solveur trouve la solution. C'est le **paradigme SMT** (Satisfiability Modulo Theories) : on spécifie le *quoi* (les contraintes), jamais le *comment* (la recherche).\n",
     "\n",
     "## Principe\n",
     "\n",
-    "Une grille de Sudoku 9x9 respecte trois contraintes d'unicite :\n",
+    "Une grille de Sudoku 9×9 respecte trois contraintes d'unicité :\n",
     "\n",
-    "1. **Lignes** : chaque ligne contient les chiffres 1-9 sans repetition.\n",
-    "2. **Colonnes** : chaque colonne contient 1-9 sans repetition.\n",
-    "3. **Blocs 3x3** : chaque sous-grille 3x3 contient 1-9 sans repetition.\n",
+    "1. **Lignes** : chaque ligne contient les chiffres 1-9 sans répétition.\n",
+    "2. **Colonnes** : chaque colonne contient 1-9 sans répétition.\n",
+    "3. **Blocs 3×3** : chaque sous-grille 3×3 contient 1-9 sans répétition.\n",
     "\n",
-    "La contrainte Z3 clee est `MkDistinct` : elle impose que tous les termes d'un ensemble soient deux a deux distincts.\n",
+    "La contrainte Z3 clé est `MkDistinct` : elle impose que tous les termes d'un ensemble soient deux à deux distincts — elle encode *exactement* la règle « tous différents » du Sudoku.\n",
+    "\n",
+    "## Pourquoi déclaratif ?\n",
+    "\n",
+    "Résoudre un Sudoku à la main = **backtracking** (essayer un chiffre, propager, revenir en arrière si contradiction). Z3 fait de même, mais avec un algorithme **SOTA** : CDCL (Conflict-Driven Clause Learning) + propagation d'intervalles, qui *apprend* de chaque conflit pour accélérer la recherche. Sur une instance 9×9, la résolution est quasi instantanée — et la vraie force du déclaratif est la **généralité** : le même `Solver` résout aussi l'Exercice 1 (anti-diagonale) en ajoutant *une seule* contrainte, sans réécrire d'algorithme.\n",
     "\n",
     "## Plan\n",
     "\n",
-    "1. Deux grilles de test (facile / intermediaire).\n",
-    "2. Resolution declarative avec `Solver` + `MkDistinct`.\n",
+    "1. Deux grilles de test (facile / intermédiaire).\n",
+    "2. Résolution déclarative avec `Solver` + `MkDistinct`.\n",
     "3. Visualisation ASCII de la grille.\n",
-    "4. Trois exercices.\n"
+    "4. Trois exercices (anti-diagonale, puzzle intermédiaire, énumération des solutions)."
    ]
   },
   {
@@ -67,6 +71,16 @@
     "using Microsoft.Z3;\n",
     "using System.Text;\n",
     "Console.WriteLine(\"Imports OK : Microsoft.Z3 version \" + Microsoft.Z3.Version.FullVersion);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-d3fef19a",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : le moteur Z3 chargé\n",
+    "\n",
+    "`Microsoft.Z3 version Z3 4.12.2.0` — c'est le **même solveur** que `z3-solver` côté Python (Z3Prover/z3, développé par Microsoft Research). Le binding .NET via NuGet expose l'API managée (`Context`, `Solver`, `IntExpr`, `MkDistinct`, `MkEq`). Aucun algorithme de résolution n'est écrit dans ce notebook : on **déclare** le problème, Z3 le résout — le **paradigme déclaratif** (SMT) opposé au backtracking impératif. Le moteur fait tout le travail de recherche ; nous, nous modélisons."
    ]
   },
   {
@@ -145,6 +159,16 @@
     "\n",
     "Console.WriteLine(\"Puzzle facile : \" + CompterIndices(puzzle_facile) + \" indices donnes\");\n",
     "Console.WriteLine(\"Puzzle intermediaire : \" + CompterIndices(puzzle_intermediaire) + \" indices donnes\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-47903cb9",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : 30 vs 36 chiffres donnés, deux difficultés\n",
+    "\n",
+    "Le puzzle **facile** (30 indices, grille canonique Wikipedia) laisse 51 cases vides ; l'**intermédiaire** (36 indices) n'en laisse que 45. Contre-intuitivement, **plus d'indices ≠ plus facile** : la difficulté d'un Sudoku dépend de la *profondeur de déduction* requise (chaînes de conséquences, techniques avancées comme X-Wing ou Swordfish), pas seulement du nombre de cases vides. Pour Z3, ces deux puzzles sont **triviaux** : un solveur SMT résout n'importe quel Sudoku légitime en millisecondes, quelle que soit sa difficulté humaine perçue — la complexité théorique (NP-complétude) n'opère qu'à l'échelle de la *classe* de problèmes, pas sur une instance 9×9 moderne."
    ]
   },
   {
@@ -239,6 +263,16 @@
     "var ctxS = new Context();\n",
     "var solution_facile = ResoudreSudoku(ctxS, puzzle_facile);\n",
     "Console.WriteLine(\"Puzzle facile : \" + (solution_facile != null ? \"resolu\" : \"insatisfiable\"));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-e54eebc6",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : « resolu » — la magie déclarative\n",
+    "\n",
+    "`Puzzle facile : resolu`. La fonction n'a écrit **aucune recherche** : 81 variables entières, 27 contraintes `MkDistinct` (9 lignes + 9 colonnes + 9 blocs 3×3), les pré-remplissages figés par `MkEq` — puis `s.Check()` retourne `SATISFIABLE`. Le moteur Z3 a fait tout le travail via **CDCL + propagation d'intervalles**, l'algorithme SOTA de la résolution SAT/SMT. C'est tout l'intérêt de l'approche déclarative : on *spécifie* le problème (ses contraintes), jamais sa méthode de résolution. `MkDistinct` est l'abstraction centrale : « tous différents » encode exactement la règle du Sudoku, et se généralise à tout CSP d'unicité (N-Reines, graph coloring, emploi du temps)."
    ]
   },
   {
@@ -465,6 +499,16 @@
     "AfficherSudoku(puzzle_facile, puzzle_facile, \"Puzzle facile (enonce, indices entre crochets)\");\n",
     "Console.WriteLine();\n",
     "if (solution_facile != null) AfficherSudoku(solution_facile, puzzle_facile, \"Solution (Z3)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-8055e181",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : la grille complétée, donné vs calculé\n",
+    "\n",
+    "La visualisation distingue les **indices donnés** `[n]` (cases de l'énoncé, figées par `MkEq`) des **cases calculées** ` n ` (remplies par Z3). On vérifie d'un coup d'œil les trois règles : chaque ligne, colonne et bloc 3×3 contient 1-9 sans répétition. La solution est **unique** pour un puzzle bien posé — l'Exercice 3 le confirmera en énumérant les solutions (UNSAT après blocage de la première = unicité). Le twin Python affiche cette même grille en couleur via `matplotlib` ; la version ASCII du twin C# est **iso-informative** (Prong B EPIC #3801) : mêmes données structurales (donné vs calculé, séparation des blocs), modalité de rendu différente, sans dépendance graphique."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-02-sudoku.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-02-sudoku.yaml
@@ -16,6 +16,12 @@
       csharp_sha: fedc5982513ac15be379f4b0ed0845032d2dc9a6
       content_python_sha: 3607d23ded635bccfe9269d290d4830ae0608451d9ece9013354daea4ac523ff
       content_csharp_sha: f322a51c165fe64d56a7dee6b3188baa1a99d203b86527196b0a3097e3a27820
+    - date: "2026-08-12"
+      by: myia-ai-01:CoursIA
+      python_sha: 31ede72cdc3c4895792d29b26e360cb2d31b66da
+      csharp_sha: 9922b667c446285537c687626cd76c6aa5cbcc9f
+      content_python_sha: 3607d23ded635bccfe9269d290d4830ae0608451d9ece9013354daea4ac523ff
+      content_csharp_sha: 8f1c53c018d1f3f96621997a3c88580846eff039607d7341fbf6a64e3c337ff6
   known_differences:
     - "Python : pyz3. C# : Microsoft.Z3 .NET (idiomes API comme NB-01)."
     - "Cote Python : modelisation Sudoku (81 cellules Int 1-9, alldifferent lignes/colonnes/blocs). Doc-honesty cures c.19 (PR #8045 : compte indices ~35 -> 30 pour puzzle_facile). SHA rebaseline c.802 apres DRIFT detecte par check_twin_parity.py : 4dcb5921 -> 1d3b1932 (commit e8a3be3ae merge le 2026-07-23)."


### PR DESCRIPTION
Grain: LIGHT/notebook-dotnet — lane myia-po-2023:CoursIA — prev: LIGHT/notebook-dotnet #10586

> Tag re-qualifie par ai-01 au merge-gate (absent du body d origine). Tier LIGHT par le litmus du protocole de variation : enrichissement markdown-only, sans re-execution, genere en balayant l instance suivante. Genre CONTENU. Voir le commentaire de cycle.

## Density enrichment — Z3-Python-02-Sudoku-Csharp.ipynb (twin C# .NET)

Markdown-only enrichment of the Z3 C# Sudoku twin (`Microsoft.Z3`, le meme solveur que `z3-solver`). Aucune cellule code modifiee.

### Livrable

| Metrique | Avant | Apres |
|----------|-------|-------|
| Densite (chars/code-cell) | 403 | **915 (+127%)** |
| Cellules code | 7 | 7 (byte-identiques) |
| Cellules markdown | 6 | 10 (+4 interpretation) |
| Total cellules | 13 | 17 |

### Ce qui a ete ajoute (markdown only)

- **4 cellules d'interpretation** apres les outputs cles :
  - Moteur Z3 charge (`4.12.2.0` = meme solveur que `z3-solver`, binding NuGet, paradigme declaratif SMT)
  - 30 vs 36 chiffres donnes (difficulte = profondeur de deduction, pas nombre de cases vides ; NP-complete mais trivial pour Z3 sur 9x9)
  - « resolu » = magie declarative (81 variables, 27 `MkDistinct`, CDCL + propagation d'intervalles, zero backtracking ecrit a la main)
  - Grille completee : donne `[n]` vs calcule ` n `, solution unique (Exercice 3 le verifiera), ASCII iso-informative vs matplotlib (Prong B #3801)
- **Setup/title cell developpe** : paradigme SMT (quoi vs comment), `MkDistinct` comme abstraction centrale (« tous differents »), pourquoi declaratif (CDCL apprend des conflits, generalite du Solver)

### Validation (preuves)

- **Code cells byte-identiques** : SHA-256 des 7 cellules code inchange (script de surgery verifie + re-verification `git diff` : sources identiques ordre preserve)
- **C.3 exception** : markdown-only, 0 re-execution requise (outputs existants valides)
- `validate_pr_notebooks.py` : **PASS** (7/7 cells)
- `detect_markdown_rendering.py` : **0 violations**
- C.1 scan code source : **0** pattern interdit (`raise NotImplementedError` / `assert False` / `1/0`)
- Catalogue byte-identique a `main` (aucun churn)

### SOTA (EPIC #3801)

Vrai moteur SOTA `Microsoft.Z3` invoque (deja present dans le notebook, non modifie). Verdict **SOTA-OK** : les outputs commites sont les vraies sorties du solveur. Aucun workaround degrade.

See #10488 (density paliers, contribution partielle — l'epic reste ouverte).

