### PR TITLE
enrich(qc,#10488): QC-Py-Dataset-Workflow density 200 -> 368 (WHAT+WHY + 3 interpretations)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Dataset-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Dataset-Workflow.ipynb
@@ -259,6 +259,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a1-interp-spy",
+   "metadata": {},
+   "source": [
+    "**Interprétation.** La sortie `SPY: 1257 jours, 2020-01-02 -> 2024-12-30` confirme que le cache yfinance fonctionne : le téléchargement a répercuté `Cache hit: SPY_9cf211eddf14.parquet` (aucun appel réseau), puis écrit `SPY_2020-01-01_2024-12-31.csv (1257 rows)`. Le hash dans le nom du parquet (`9cf211eddf14`) est dérivé des paramètres (symbole + plage + intervalle) : tant que ces paramètres ne changent pas, le cache sert la même archive.\n",
+    "\n",
+    "Les **1257 jours** couvrent environ 5 ans de cotations journalières (jours ouvrables ~252/an x 5 = 1260, proche). Ce format CSV plat est volontairement différent des objets `QuantBook`/`QCAlgorithm` utilisés plus loin dans le curriculum : ici on manipule un `DataFrame` Pandas classique, ce qui rend les données portables hors de l'API QuantConnect (backtests locaux, prototypage, comparaison avec d'autres sources)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 1 : Calculer les returns et statistiques de base\n\nChargez les données SPY et calculez les **returns journaliers**, la **moyenne**, l'**ecart-type** et le **Sharpe Ratio** annuelise.\n\n**Indices** :\n- `# Indice` : `returns = df['Close'].pct_change()`\n- `# Indice` : Sharpe annualise = `mean(returns) / std(returns) * sqrt(252)`\n- `# Étape 1` : Charger le CSV et calculer les returns\n- `# Étape 2` : Calculer mean et std des returns\n- `# Étape 3` : Calculer le Sharpe Ratio annualise"
@@ -509,6 +519,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a2-interp-btc",
+   "metadata": {},
+   "source": [
+    "**Interprétation.** L'archive BTC couvre **2191 jours (2019-01-01 -> 2024-12-30)**, soit ~6 ans -- davantage que SPY (1257 jours / 5 ans) parce que les marchés crypto négocient 24/7 (365 jours/an) alors que les actions suivent le calendrier ouvrable (~252 jours/an). C'est pourquoi un même nombre d'années donne plus de points de données en crypto.\n",
+    "\n",
+    "Le script `manage_crypto_archive.py` consolide la source en un seul fichier `BTC_USDT_archive.csv` : c'est une **archive** (historique persistant), pas un simple téléchargement. La distinction compte pour le trading : une archive se met à jour incrémentalement (cf. §4, cellule 18 ajoute `+561 new` rows) plutôt que de tout re-télécharger, ce qui évite de frapper l'API à chaque session."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 2 : Calculer la correlation BTC vs SPY\n\nCalculez la **correlation rolling 30 jours** entre les returns de BTC et SPY. Une correlation elevee reduit l'intérêt de la diversification.\n\n**Indices** :\n- `# Indice` : Mergez les deux DataFrames sur la date, puis calculez `returns.rolling(30).corr()`\n- `# Étape 1` : Calculer les returns pour SPY et BTC\n- `# Étape 2` : Merger les returns sur la colonne date\n- `# Étape 3` : Calculer la correlation rolling 30j"
@@ -674,6 +694,16 @@
     "    btc_klines[\"date\"] = pd.to_datetime(btc_klines[\"open_time\"], unit=\"ms\")\n",
     "    print(f\"Total: {len(btc_klines)} rangées\")\n",
     "    btc_klines.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3-interp-binance",
+   "metadata": {},
+   "source": [
+    "**Interprétation.** Les **91 rangées sur 3 fichiers** (31 + 29 + 31) illustrent le découpage mensuel des klines Binance : chaque fichier CSV couvre un mois calendaire. Ce format diffère de l'archive BTC consolidée (cellule 10, un seul fichier 2191 rows) parce que les klines Binance sont destinées à la **haute résolution** (1d ici, mais 1m/5m/15m en production) -- un seul fichier deviendrait rapidement ingérable.\n",
+    "\n",
+    "Le total de 91 rangées sur 3 mois reflète la granularité journalière (1d) : 31 + 29 + 31 = 91 jours. Pour du backtest intraday, ce même découpage mensuel contiendrait des millions de rangées (1 minute x 24h x 30j = 43200 points/mois) -- d'où l'importance de la convention `BTCUSDT_1d_2024-01.csv` qui encode la résolution dans le nom de fichier."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-python (#10587)

# enrich(qc,#10488): QC-Py-Dataset-Workflow density 200 -> 368 (WHAT+WHY + 3 interpretations)

See #10488

## What

`QC-Py-Dataset-Workflow.ipynb` (kernel `python3`, famille QuantConnect / data engineering) demonstrated the dataset workflow (yfinance cache parquet, crypto archive consolidation, monthly Binance klines) but had only section-header markdown BEFORE each code cell — no interpretation cell AFTER the output explaining WHY the observed values matter. This PR adds **3 markdown interpretation cells AFTER the demonstration cells**, each citing the real executed values.

## The 3 interpretation cells (each after a code-output cell)

1. **Cache yfinance (after SPY load)** — cites the real outputs: `Cache hit: SPY_9cf211eddf14.parquet`, `SPY: 1257 jours, 2020-01-02 -> 2024-12-30`. Explains WHY the parquet hash is a parameter fingerprint (symbole + plage + intervalle) and why 1257 days ≈ 5 trading years (~252/an), and why the flat CSV/DataFrame is deliberately different from `QuantBook`/`QCAlgorithm` objects used later in the curriculum.

2. **Archive crypto (after BTC load)** — cites `2191 jours (2019-01-01 -> 2024-12-30)`. Explains WHY crypto yields ~6 years of data vs 5 for SPY (24/7 markets, 365 days/an vs ~252 trading days), and WHY `manage_crypto_archive.py` consolidates into an *archive* (persistent, incremental `+561 new` rows) rather than a plain download.

3. **Klines Binance (after monthly files load)** — cites `91 rangées sur 3 fichiers (31 + 29 + 31)`. Explains WHY the monthly split (vs the single consolidated BTC archive) serves high-resolution data (1d…1m), and WHY the `BTCUSDT_1d_2024-01.csv` naming convention encodes the resolution.

## Validation

- **Code cells byte-identical to origin/main**: 14/14 code cells, sources + outputs + `execution_count` unchanged (verified programmatically: multiset equality on sources and outputs, `execution_count` nulls = 3 pre-existing exercise stubs at base indices 6/12/21).
- **Markdown-only edit** → C.2 exception (0 re-execution required; python3 outputs preserved as-is).
- `nbformat.validate`: OK (26 cells, 12 md + 14 code).
- `validate_pr_notebooks.py`: PASS (14 cells).
- C.1 scan: 0 forbidden patterns.
- `json.dumps(ensure_ascii=False, indent=1)` + trailing newline round-trips byte-identically — only the 3 inserted cells change the diff (**+30/-0, 1 file**).
- Catalogue byte-identical to main (not regenerated).
- Accents aligned with the file's existing style (accentuated French, matching the notebook's other markdown).
- Density: 200 → 368 chars/code-cell (+84%).

## G-VAR-3 note

Same genre as prev (`notebook-python` after #10587 ICT-28) but genuinely distinct substance: IIT collective-adoption threshold pedagogy vs QC data-engineering workflow — different family, different demonstrated content, not a scan-generated variant.

## Scope

Enriches QC-Py-Dataset-Workflow only, as part of #10488's mandate to raise the pedagogical density floor. Exercise stubs [6]/[12]/[21] left untouched (pre-existing `Exercice a completer` pattern, out of scope for a density PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>