### PR TITLE
feat(twin-parity,#10382): bridge_verdict + reason on 5 App pairs (App-10/17/18/19/20)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
@@ -3,6 +3,8 @@
     python: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb
     csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
     parity_level: semantic
+    bridge_verdict: SOTA-OK
+    bridge_verdict_reason: "Python = `cvxpy` (optimisation convexe exacte du portefeuille) + `pygad` (algorithme genetique) + stdlib. C# = `#r nuget: GeneticSharp` (moteur GA .NET reel : `PortfolioChromosome : ChromosomeBase`, `PortfolioFitness : IFitness`, generation reproductible seed 42) + BCL pure pour l'enumeration exacte K=2. Verdict SOTA-OK : le C# atteint un moteur de production de son ecosysteme (GeneticSharp, deja en service App-10b/App-9b/Sudoku-3) qui couvre le concept enseigne cote GA ; cote Python, `pygad` est son pendant GA (couvert par GeneticSharp) et `cvxpy` (convexe exact) n'a pas d'equivalent .NET en service dans le depot — la part convexe from-scratch/BCL est la contrepartie honnete. Rien a recuperer : le C# ne bride aucun moteur manquant. parity_level: semantic preserve."
     audits:
     -   date: '2026-08-04'
         by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/app-17-vrp-logistics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-17-vrp-logistics.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-17-VRP-Logistics.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-17b-VRP-Logistics-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: RECOVERABLE-LOCAL
+  bridge_verdict_reason: "Python = `ortools.constraint_solver` (pywrapcp, routing_enums_pb2 : moteur VRP SOTA Google OR-Tools routing) + dataclasses/math stdlib. C# = BCL pure (0 NuGet, 0 reference externe) : reimplementation from-scratch du VRP (construction de routes, contraintes de capacite). Verdict RECOVERABLE-LOCAL : `ortools` implemente le concept enseigne (routage/VRP) et Google.OrTools est deja en service dans le depot (CSP-4/6/8, Sudoku-10/18, Search-9, App-8, App-15b) — le C# pourrait brancher `Google.OrTools` (routing) pour atteindre la parite lib-vs-lib. Le from-scratch reste un choix pedagogique valide (fondamentaux), mais la tranche 2 Google.OrTools est recuperable localement. parity_level: semantic preserve."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/app-18-hyperparametertuning.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-18-hyperparametertuning.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb
   parity_level: semantic
+  bridge_verdict: RECOVERABLE-LOCAL
+  bridge_verdict_reason: "Python = `sklearn` (RandomForestClassifier, GradientBoostingClassifier, SVC, cross_val_score, Pipeline, StandardScaler) + `optuna` (optimisation d'hyperparametres SOTA) + `scipy.optimize`/`scipy.stats` + stdlib. C# = BCL pure (0 NuGet, 0 reference externe) : grid-search/random-search from-scratch. Verdict RECOVERABLE-LOCAL : `sklearn`/`optuna` implementent les concepts enseignes (classifieurs + tuning d'hyperparametres) et ML.NET est deja en service dans le depot (serie ML.NET, SL-3 RelevanceLearning — cf bucket-1 #10382) — le C# pourrait brancher ML.NET (AutoML / contexte de tuning) pour la parite lib-vs-lib. Le from-scratch (grid search manuel) reste pedagogique mais la tranche 2 ML.NET est recuperable localement. parity_level: semantic preserve."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/app-19-proceduralgeneration-wfc.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-19-proceduralgeneration-wfc.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: RECOVERABLE-LOCAL
+  bridge_verdict_reason: "Python = `wfc_cpsat` (module local `wfc_cpsat.py` qui wrappe `ortools` CP-SAT : solveur SOTA wave-function-collapse) + `ipywidgets` interactif + matplotlib viz. C# = BCL pure (0 NuGet) : WFC from-scratch (System.Text). Verdict RECOVERABLE-LOCAL : le coeur Python repose sur OR-Tools CP-SAT (moteur de production), et Google.OrTools est deja en service dans le depot (CSP-4/6/8, Sudoku-10/18, Search-9, App-8, App-15b) — le C# pourrait brancher Google.OrTools CP-SAT pour la parite lib-vs-lib sur la resolution WFC. Le from-scratch BCL (contraintes locales + backtracking) reste pedagogique mais la tranche 2 Google.OrTools est recuperable localement. parity_level: semantic preserve."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/app-20-sudokubenchmark.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-20-sudokubenchmark.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Python = stdlib pure (typing, copy, random, time) : solveurs Sudoku (backtracking, strategies) + benchmark from-scratch, aucun moteur de production externe (numpy/matplotlib = substrat generique viz uniquement). C# = BCL pure (0 NuGet) : meme benchmark from-scratch (backtracking, strategies). Verdict SOTA-OK : aucun des deux cotes n'importe un moteur de production — le benchmark compare des solveurs maison des deux cotes ; il n'y a rien a recuperer (pas de lib Python a bridger, pas d'equivalent .NET manquant). Le concept enseigne (benchmark de strategies Sudoku) est implemente from-scratch des deux cotes, parite sur les concepts cibles. parity_level: semantic preserve."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA


### PR DESCRIPTION
Grain: MED/twin — lane myia-po-2025:CoursIA — prev: MED/twin

# feat(twin-parity,#10382): bridge_verdict + reason on 5 App pairs (App-10/17/18/19/20)

See #10382

## What

Tranche of the twin-parity rollout #10382 (lib-vs-lib parity gap): annotate 5 Application-family pairs with a `bridge_verdict` + `reason` in the twin registry. The C# side of these pairs does not bridge a solver/engine that the Python twin imports — this tranche documents that gap explicitly rather than leaving it as an implicit `parity_level: semantic`.

## Pairs covered

- App-10, App-17, App-18, App-19, App-20 — each gets a `bridge_verdict` (INTRINSIC / RECOVERABLE-LOCAL / RECOVERABLE-MACHINE / SOTA-OK) and a one-line `reason` grounded firsthand in the pair's code.

## Validation

- `check_twin_parity.py` run post-edit: no new DRIFT introduced (verdict annotations are additive metadata).
- Each verdict grounded in a read of the C# vs Python source (not propagated from another lane's claim — G.1).

See #10382 (epic multi-lane, contribution partielle — pas Closes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
